### PR TITLE
op-challenger: Support retrieving the oracle and prestate via game args.

### DIFF
--- a/op-acceptance-tests/tests/base/disputegame_v2/init_test.go
+++ b/op-acceptance-tests/tests/base/disputegame_v2/init_test.go
@@ -7,7 +7,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	// TODO(#17810): Use the new v2 dispute game flag via presets.WithDisputeGameV2()
-	//presets.DoMain(m, presets.WithProofs(), presets.WithDisputeGameV2())
-	presets.DoMain(m, presets.WithProofs())
+	presets.DoMain(m, presets.WithProofs(), presets.WithDisputeGameV2())
 }

--- a/op-acceptance-tests/tests/base/disputegame_v2/smoke_test.go
+++ b/op-acceptance-tests/tests/base/disputegame_v2/smoke_test.go
@@ -3,13 +3,13 @@ package disputegame_v2
 import (
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts/gameargs"
 	challengerTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 )
 
 func TestSmoke(gt *testing.T) {
-	gt.Skip("TODO(#17810): Re-enable once opcm.deploy supports v2 dispute games")
 	t := devtest.SerialT(gt)
 	sys := presets.NewMinimal(t)
 	require := t.Require()
@@ -17,8 +17,13 @@ func TestSmoke(gt *testing.T) {
 
 	gameArgs := dgf.GameArgs(challengerTypes.PermissionedGameType)
 	require.NotEmpty(gameArgs, "game args is must be set for permissioned v2 dispute games")
+	_, err := gameargs.Parse(gameArgs)
+	require.NoError(err, "Permissioned game args invalid")
+
 	gameArgs = dgf.GameArgs(challengerTypes.CannonGameType)
 	require.NotEmpty(gameArgs, "game args is must be set for cannon v2 dispute games")
+	_, err = gameargs.Parse(gameArgs)
+	require.NoError(err, "Permissionless game args invalid")
 
 	permissionedGame := dgf.GameImpl(challengerTypes.PermissionedGameType)
 	require.NotEmpty(permissionedGame.Address, "permissioned game impl must be set")

--- a/op-chain-ops/cmd/unclaimed-credits/main.go
+++ b/op-chain-ops/cmd/unclaimed-credits/main.go
@@ -72,7 +72,10 @@ func unclaimedCreditsApp(ctx *cli.Context) error {
 	defer l1Client.Close()
 
 	caller := batching.NewMultiCaller(l1Client.Client(), batching.DefaultBatchSize)
-	contract := contracts.NewDisputeGameFactoryContract(metrics.NoopContractMetrics, factoryAddr, caller)
+	contract, err := contracts.NewDisputeGameFactoryContract(ctx.Context, metrics.NoopContractMetrics, factoryAddr, caller)
+	if err != nil {
+		return fmt.Errorf("failed to create dispute game factory contract: %w", err)
+	}
 	head, err := l1Client.HeaderByNumber(ctx.Context, nil)
 	if err != nil {
 		return fmt.Errorf("failed to retrieve current head block: %w", err)

--- a/op-challenger/cmd/create_game.go
+++ b/op-challenger/cmd/create_game.go
@@ -43,7 +43,7 @@ func CreateGame(ctx *cli.Context) error {
 
 	contract, txMgr, err := NewContractWithTxMgr[*contracts.DisputeGameFactoryContract](ctx, flags.FactoryAddress,
 		func(ctx context.Context, metricer contractMetrics.ContractMetricer, address common.Address, caller *batching.MultiCaller) (*contracts.DisputeGameFactoryContract, error) {
-			return contracts.NewDisputeGameFactoryContract(metricer, address, caller), nil
+			return contracts.NewDisputeGameFactoryContract(ctx, metricer, address, caller)
 		})
 	if err != nil {
 		return fmt.Errorf("failed to create dispute game factory bindings: %w", err)

--- a/op-challenger/cmd/list_games.go
+++ b/op-challenger/cmd/list_games.go
@@ -71,7 +71,10 @@ func ListGames(ctx *cli.Context) error {
 	defer l1Client.Close()
 
 	caller := batching.NewMultiCaller(l1Client.Client(), batching.DefaultBatchSize)
-	contract := contracts.NewDisputeGameFactoryContract(metrics.NoopContractMetrics, factoryAddr, caller)
+	contract, err := contracts.NewDisputeGameFactoryContract(ctx.Context, metrics.NoopContractMetrics, factoryAddr, caller)
+	if err != nil {
+		return fmt.Errorf("failed to create dispute game factory contract: %w", err)
+	}
 	head, err := l1Client.HeaderByNumber(ctx.Context, nil)
 	if err != nil {
 		return fmt.Errorf("failed to retrieve current head block: %w", err)

--- a/op-challenger/game/fault/contracts/abis/DisputeGameFactory-1.2.0.json
+++ b/op-challenger/game/fault/contracts/abis/DisputeGameFactory-1.2.0.json
@@ -1,0 +1,526 @@
+[
+  {
+    "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "GameType",
+        "name": "_gameType",
+        "type": "uint32"
+      },
+      {
+        "internalType": "Claim",
+        "name": "_rootClaim",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_extraData",
+        "type": "bytes"
+      }
+    ],
+    "name": "create",
+    "outputs": [
+      {
+        "internalType": "contract IDisputeGame",
+        "name": "proxy_",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "GameType",
+        "name": "_gameType",
+        "type": "uint32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_start",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_n",
+        "type": "uint256"
+      }
+    ],
+    "name": "findLatestGames",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "index",
+            "type": "uint256"
+          },
+          {
+            "internalType": "GameId",
+            "name": "metadata",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "Timestamp",
+            "name": "timestamp",
+            "type": "uint64"
+          },
+          {
+            "internalType": "Claim",
+            "name": "rootClaim",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes",
+            "name": "extraData",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct DisputeGameFactory.GameSearchResult[]",
+        "name": "games_",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_index",
+        "type": "uint256"
+      }
+    ],
+    "name": "gameAtIndex",
+    "outputs": [
+      {
+        "internalType": "GameType",
+        "name": "gameType_",
+        "type": "uint32"
+      },
+      {
+        "internalType": "Timestamp",
+        "name": "timestamp_",
+        "type": "uint64"
+      },
+      {
+        "internalType": "contract IDisputeGame",
+        "name": "proxy_",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "gameCount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "gameCount_",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "GameType",
+        "name": "",
+        "type": "uint32"
+      }
+    ],
+    "name": "gameImpls",
+    "outputs": [
+      {
+        "internalType": "contract IDisputeGame",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "GameType",
+        "name": "_gameType",
+        "type": "uint32"
+      },
+      {
+        "internalType": "Claim",
+        "name": "_rootClaim",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_extraData",
+        "type": "bytes"
+      }
+    ],
+    "name": "games",
+    "outputs": [
+      {
+        "internalType": "contract IDisputeGame",
+        "name": "proxy_",
+        "type": "address"
+      },
+      {
+        "internalType": "Timestamp",
+        "name": "timestamp_",
+        "type": "uint64"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "GameType",
+        "name": "_gameType",
+        "type": "uint32"
+      },
+      {
+        "internalType": "Claim",
+        "name": "_rootClaim",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_extraData",
+        "type": "bytes"
+      }
+    ],
+    "name": "getGameUUID",
+    "outputs": [
+      {
+        "internalType": "Hash",
+        "name": "uuid_",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "GameType",
+        "name": "",
+        "type": "uint32"
+      }
+    ],
+    "name": "initBonds",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "initVersion",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_owner",
+        "type": "address"
+      }
+    ],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "proxyAdmin",
+    "outputs": [
+      {
+        "internalType": "contract IProxyAdmin",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "proxyAdminOwner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "GameType",
+        "name": "_gameType",
+        "type": "uint32"
+      },
+      {
+        "internalType": "contract IDisputeGame",
+        "name": "_impl",
+        "type": "address"
+      }
+    ],
+    "name": "setImplementation",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "GameType",
+        "name": "_gameType",
+        "type": "uint32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_initBond",
+        "type": "uint256"
+      }
+    ],
+    "name": "setInitBond",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "version",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "disputeProxy",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "GameType",
+        "name": "gameType",
+        "type": "uint32"
+      },
+      {
+        "indexed": true,
+        "internalType": "Claim",
+        "name": "rootClaim",
+        "type": "bytes32"
+      }
+    ],
+    "name": "DisputeGameCreated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "impl",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "GameType",
+        "name": "gameType",
+        "type": "uint32"
+      }
+    ],
+    "name": "ImplementationSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "GameType",
+        "name": "gameType",
+        "type": "uint32"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "newBond",
+        "type": "uint256"
+      }
+    ],
+    "name": "InitBondUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint8",
+        "name": "version",
+        "type": "uint8"
+      }
+    ],
+    "name": "Initialized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "Hash",
+        "name": "uuid",
+        "type": "bytes32"
+      }
+    ],
+    "name": "GameAlreadyExists",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "IncorrectBondAmount",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "GameType",
+        "name": "gameType",
+        "type": "uint32"
+      }
+    ],
+    "name": "NoImplementation",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ProxyAdminOwnedBase_NotProxyAdmin",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ProxyAdminOwnedBase_NotProxyAdminOrProxyAdminOwner",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ProxyAdminOwnedBase_NotProxyAdminOwner",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ProxyAdminOwnedBase_NotResolvedDelegateProxy",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ProxyAdminOwnedBase_NotSharedProxyAdminOwner",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ProxyAdminOwnedBase_ProxyAdminNotFound",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ReinitializableBase_ZeroInitVersion",
+    "type": "error"
+  }
+]

--- a/op-challenger/game/fault/contracts/gameargs/gameargs.go
+++ b/op-challenger/game/fault/contracts/gameargs/gameargs.go
@@ -1,0 +1,68 @@
+package gameargs
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+const (
+	PermissionlessArgsLength = 124
+	PermissionedArgsLength   = 164
+)
+
+var (
+	ErrInvalidGameArgs = errors.New("invalid game args")
+)
+
+type GameArgs struct {
+	AbsolutePrestate    common.Hash
+	Vm                  common.Address
+	AnchorStateRegistry common.Address
+	Weth                common.Address
+	L2ChainID           eth.ChainID
+	Proposer            common.Address
+	Challenger          common.Address
+}
+
+func (g GameArgs) PackPermissionless() []byte {
+	chainID := g.L2ChainID.Bytes32()
+	return slices.Concat(
+		g.AbsolutePrestate[:],
+		g.Vm[:],
+		g.AnchorStateRegistry[:],
+		g.Weth[:],
+		chainID[:],
+	)
+}
+
+func (g GameArgs) PackPermissioned() []byte {
+	return slices.Concat(
+		g.PackPermissionless(),
+		g.Proposer[:],
+		g.Challenger[:],
+	)
+}
+
+func Parse(args []byte) (GameArgs, error) {
+	if len(args) != PermissionlessArgsLength && len(args) != PermissionedArgsLength {
+		return GameArgs{}, fmt.Errorf("%w: invalid length (%v)", ErrInvalidGameArgs, len(args))
+	}
+	var output GameArgs
+	output.AbsolutePrestate = common.BytesToHash(args[0:32])
+	output.Vm = common.BytesToAddress(args[32:52])
+	output.AnchorStateRegistry = common.BytesToAddress(args[52:72])
+	output.Weth = common.BytesToAddress(args[72:92])
+	var chainID [32]byte
+	copy(chainID[:], args[92:124])
+	output.L2ChainID = eth.ChainIDFromBytes32(chainID)
+
+	if len(args) == PermissionedArgsLength {
+		output.Proposer = common.BytesToAddress(args[124:144])
+		output.Challenger = common.BytesToAddress(args[144:164])
+	}
+	return output, nil
+}

--- a/op-challenger/game/fault/contracts/gameargs/gameargs_test.go
+++ b/op-challenger/game/fault/contracts/gameargs/gameargs_test.go
@@ -1,0 +1,67 @@
+package gameargs
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParse(t *testing.T) {
+	t.Run("Invalid-ZeroLength", func(t *testing.T) {
+		_, err := Parse([]byte{})
+		require.ErrorIs(t, err, ErrInvalidGameArgs)
+	})
+
+	t.Run("Invalid-TooLong", func(t *testing.T) {
+		input := make([]byte, PermissionedArgsLength+1)
+		_, err := Parse(input)
+		require.ErrorIs(t, err, ErrInvalidGameArgs)
+	})
+
+	t.Run("Invalid-TooShort", func(t *testing.T) {
+		input := make([]byte, PermissionlessArgsLength-1)
+		_, err := Parse(input)
+		require.ErrorIs(t, err, ErrInvalidGameArgs)
+	})
+
+	t.Run("Invalid-BetweenValidLengths", func(t *testing.T) {
+		input := make([]byte, PermissionlessArgsLength+1)
+		_, err := Parse(input)
+		require.ErrorIs(t, err, ErrInvalidGameArgs)
+	})
+
+	t.Run("Valid-Permissionless", func(t *testing.T) {
+		expected := fullGameArgs()
+		expected.Proposer = common.Address{}
+		expected.Challenger = common.Address{}
+		input := expected.PackPermissionless()
+		actual, err := Parse(input)
+		require.NoError(t, err)
+		require.Equal(t, expected, actual)
+	})
+
+	t.Run("Valid-Permissioned", func(t *testing.T) {
+		expected := fullGameArgs()
+		input := expected.PackPermissioned()
+		actual, err := Parse(input)
+		require.NoError(t, err)
+		require.Equal(t, expected, actual)
+	})
+}
+
+func fullGameArgs() GameArgs {
+	rng := rand.New(rand.NewSource(0))
+	return GameArgs{
+		AbsolutePrestate:    testutils.RandomHash(rng),
+		Vm:                  testutils.RandomAddress(rng),
+		AnchorStateRegistry: testutils.RandomAddress(rng),
+		Weth:                testutils.RandomAddress(rng),
+		L2ChainID:           eth.ChainIDFromBytes32(testutils.RandomHash(rng)),
+		Proposer:            testutils.RandomAddress(rng),
+		Challenger:          testutils.RandomAddress(rng),
+	}
+}

--- a/op-challenger/game/fault/contracts/gamefactory_test.go
+++ b/op-challenger/game/fault/contracts/gamefactory_test.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts/gameargs"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts/metrics"
 	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/types"
@@ -14,14 +15,50 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
 	batchingTest "github.com/ethereum-optimism/optimism/op-service/sources/batching/test"
 	"github.com/ethereum-optimism/optimism/packages/contracts-bedrock/snapshots"
+	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	ethTypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	versFactory120    = "1.2.0"
+	versFactoryLatest = "1.4.0"
+)
+
+type factoryContractVersion struct {
+	version           string
+	loadAbi           func() *abi.ABI
+	noGameArgsSupport bool
+}
+
+func (c factoryContractVersion) Is(versions ...string) bool {
+	return slices.Contains(versions, c.version)
+}
+
+func (c factoryContractVersion) String() string {
+	return c.version
+}
+
 var (
 	factoryAddr = common.HexToAddress("0x24112842371dFC380576ebb09Ae16Cb6B6caD7CB")
 	batchSize   = 5
+
+	factoryVersions = []factoryContractVersion{
+		{
+			version: versFactory120,
+			loadAbi: func() *abi.ABI {
+				return mustParseAbi(disputeGameFactoryAbi120)
+			},
+			noGameArgsSupport: true,
+		},
+		{
+			version: versFactoryLatest,
+			loadAbi: func() *abi.ABI {
+				return snapshots.LoadDisputeGameFactoryABI()
+			},
+		},
+	}
 )
 
 func TestDisputeGameFactorySimpleGetters(t *testing.T) {
@@ -42,82 +79,94 @@ func TestDisputeGameFactorySimpleGetters(t *testing.T) {
 			},
 		},
 	}
-	for _, test := range tests {
-		test := test
-		t.Run(test.method, func(t *testing.T) {
-			stubRpc, factory := setupDisputeGameFactoryTest(t)
-			stubRpc.SetResponse(factoryAddr, test.method, rpcblock.ByHash(blockHash), nil, []interface{}{test.result})
-			status, err := test.call(factory)
-			require.NoError(t, err)
-			expected := test.expected
-			if expected == nil {
-				expected = test.result
+	for _, version := range factoryVersions {
+		t.Run(version.String(), func(t *testing.T) {
+			for _, test := range tests {
+				test := test
+				t.Run(test.method, func(t *testing.T) {
+					stubRpc, factory := setupDisputeGameFactoryTest(t, version)
+					stubRpc.SetResponse(factoryAddr, test.method, rpcblock.ByHash(blockHash), nil, []interface{}{test.result})
+					status, err := test.call(factory)
+					require.NoError(t, err)
+					expected := test.expected
+					if expected == nil {
+						expected = test.result
+					}
+					require.Equal(t, expected, status)
+				})
 			}
-			require.Equal(t, expected, status)
 		})
 	}
 }
 
 func TestLoadGame(t *testing.T) {
-	blockHash := common.Hash{0xbb, 0xce}
-	stubRpc, factory := setupDisputeGameFactoryTest(t)
-	game0 := types.GameMetadata{
-		Index:     0,
-		GameType:  0,
-		Timestamp: 1234,
-		Proxy:     common.Address{0xaa},
-	}
-	game1 := types.GameMetadata{
-		Index:     1,
-		GameType:  1,
-		Timestamp: 5678,
-		Proxy:     common.Address{0xbb},
-	}
-	game2 := types.GameMetadata{
-		Index:     2,
-		GameType:  99,
-		Timestamp: 9988,
-		Proxy:     common.Address{0xcc},
-	}
-	expectedGames := []types.GameMetadata{game0, game1, game2}
-	for idx, expected := range expectedGames {
-		expectGetGame(stubRpc, idx, blockHash, expected)
-		actual, err := factory.GetGame(context.Background(), uint64(idx), blockHash)
-		require.NoError(t, err)
-		require.Equal(t, expected, actual)
+	for _, version := range factoryVersions {
+		t.Run(version.String(), func(t *testing.T) {
+			blockHash := common.Hash{0xbb, 0xce}
+			stubRpc, factory := setupDisputeGameFactoryTest(t, version)
+			game0 := types.GameMetadata{
+				Index:     0,
+				GameType:  0,
+				Timestamp: 1234,
+				Proxy:     common.Address{0xaa},
+			}
+			game1 := types.GameMetadata{
+				Index:     1,
+				GameType:  1,
+				Timestamp: 5678,
+				Proxy:     common.Address{0xbb},
+			}
+			game2 := types.GameMetadata{
+				Index:     2,
+				GameType:  99,
+				Timestamp: 9988,
+				Proxy:     common.Address{0xcc},
+			}
+			expectedGames := []types.GameMetadata{game0, game1, game2}
+			for idx, expected := range expectedGames {
+				expectGetGame(stubRpc, idx, blockHash, expected)
+				actual, err := factory.GetGame(context.Background(), uint64(idx), blockHash)
+				require.NoError(t, err)
+				require.Equal(t, expected, actual)
+			}
+		})
 	}
 }
 
 func TestGetAllGames(t *testing.T) {
-	blockHash := common.Hash{0xbb, 0xce}
-	stubRpc, factory := setupDisputeGameFactoryTest(t)
-	game0 := types.GameMetadata{
-		Index:     0,
-		GameType:  0,
-		Timestamp: 1234,
-		Proxy:     common.Address{0xaa},
-	}
-	game1 := types.GameMetadata{
-		Index:     1,
-		GameType:  1,
-		Timestamp: 5678,
-		Proxy:     common.Address{0xbb},
-	}
-	game2 := types.GameMetadata{
-		Index:     2,
-		GameType:  99,
-		Timestamp: 9988,
-		Proxy:     common.Address{0xcc},
-	}
+	for _, version := range factoryVersions {
+		t.Run(version.String(), func(t *testing.T) {
+			blockHash := common.Hash{0xbb, 0xce}
+			stubRpc, factory := setupDisputeGameFactoryTest(t, version)
+			game0 := types.GameMetadata{
+				Index:     0,
+				GameType:  0,
+				Timestamp: 1234,
+				Proxy:     common.Address{0xaa},
+			}
+			game1 := types.GameMetadata{
+				Index:     1,
+				GameType:  1,
+				Timestamp: 5678,
+				Proxy:     common.Address{0xbb},
+			}
+			game2 := types.GameMetadata{
+				Index:     2,
+				GameType:  99,
+				Timestamp: 9988,
+				Proxy:     common.Address{0xcc},
+			}
 
-	expectedGames := []types.GameMetadata{game0, game1, game2}
-	stubRpc.SetResponse(factoryAddr, methodGameCount, rpcblock.ByHash(blockHash), nil, []interface{}{big.NewInt(int64(len(expectedGames)))})
-	for idx, expected := range expectedGames {
-		expectGetGame(stubRpc, idx, blockHash, expected)
+			expectedGames := []types.GameMetadata{game0, game1, game2}
+			stubRpc.SetResponse(factoryAddr, methodGameCount, rpcblock.ByHash(blockHash), nil, []interface{}{big.NewInt(int64(len(expectedGames)))})
+			for idx, expected := range expectedGames {
+				expectGetGame(stubRpc, idx, blockHash, expected)
+			}
+			actualGames, err := factory.GetAllGames(context.Background(), blockHash)
+			require.NoError(t, err)
+			require.Equal(t, expectedGames, actualGames)
+		})
 	}
-	actualGames, err := factory.GetAllGames(context.Background(), blockHash)
-	require.NoError(t, err)
-	require.Equal(t, expectedGames, actualGames)
 }
 
 func TestGetAllGamesAtOrAfter(t *testing.T) {
@@ -134,141 +183,249 @@ func TestGetAllGamesAtOrAfter(t *testing.T) {
 		{gameCount: batchSize * 2, earliestGameIdx: batchSize*2 + 1},
 		{gameCount: batchSize - 2, earliestGameIdx: batchSize - 3},
 	}
-	for _, test := range tests {
-		test := test
-		t.Run(fmt.Sprintf("Count_%v_Start_%v", test.gameCount, test.earliestGameIdx), func(t *testing.T) {
-			blockHash := common.Hash{0xbb, 0xce}
-			stubRpc, factory := setupDisputeGameFactoryTest(t)
-			var allGames []types.GameMetadata
-			for i := 0; i < test.gameCount; i++ {
-				allGames = append(allGames, types.GameMetadata{
-					Index:     uint64(i),
-					GameType:  uint32(i),
-					Timestamp: uint64(i),
-					Proxy:     common.Address{byte(i)},
-				})
-			}
+	for _, version := range factoryVersions {
+		t.Run(version.String(), func(t *testing.T) {
+			for _, test := range tests {
+				test := test
+				t.Run(fmt.Sprintf("Count_%v_Start_%v", test.gameCount, test.earliestGameIdx), func(t *testing.T) {
+					blockHash := common.Hash{0xbb, 0xce}
+					stubRpc, factory := setupDisputeGameFactoryTest(t, version)
+					var allGames []types.GameMetadata
+					for i := 0; i < test.gameCount; i++ {
+						allGames = append(allGames, types.GameMetadata{
+							Index:     uint64(i),
+							GameType:  uint32(i),
+							Timestamp: uint64(i),
+							Proxy:     common.Address{byte(i)},
+						})
+					}
 
-			stubRpc.SetResponse(factoryAddr, methodGameCount, rpcblock.ByHash(blockHash), nil, []interface{}{big.NewInt(int64(len(allGames)))})
-			for idx, expected := range allGames {
-				expectGetGame(stubRpc, idx, blockHash, expected)
-			}
-			// Set an earliest timestamp that's in the middle of a batch
-			earliestTimestamp := uint64(test.earliestGameIdx)
-			actualGames, err := factory.GetGamesAtOrAfter(context.Background(), blockHash, earliestTimestamp)
-			require.NoError(t, err)
-			// Games come back in descending timestamp order
-			var expectedGames []types.GameMetadata
-			if test.earliestGameIdx < len(allGames) {
-				expectedGames = slices.Clone(allGames[test.earliestGameIdx:])
-			}
-			slices.Reverse(expectedGames)
-			require.Equal(t, len(expectedGames), len(actualGames))
-			if len(expectedGames) != 0 {
-				// Don't assert equal for empty arrays, we accept nil or empty array
-				require.Equal(t, expectedGames, actualGames)
+					stubRpc.SetResponse(factoryAddr, methodGameCount, rpcblock.ByHash(blockHash), nil, []interface{}{big.NewInt(int64(len(allGames)))})
+					for idx, expected := range allGames {
+						expectGetGame(stubRpc, idx, blockHash, expected)
+					}
+					// Set an earliest timestamp that's in the middle of a batch
+					earliestTimestamp := uint64(test.earliestGameIdx)
+					actualGames, err := factory.GetGamesAtOrAfter(context.Background(), blockHash, earliestTimestamp)
+					require.NoError(t, err)
+					// Games come back in descending timestamp order
+					var expectedGames []types.GameMetadata
+					if test.earliestGameIdx < len(allGames) {
+						expectedGames = slices.Clone(allGames[test.earliestGameIdx:])
+					}
+					slices.Reverse(expectedGames)
+					require.Equal(t, len(expectedGames), len(actualGames))
+					if len(expectedGames) != 0 {
+						// Don't assert equal for empty arrays, we accept nil or empty array
+						require.Equal(t, expectedGames, actualGames)
+					}
+				})
 			}
 		})
 	}
 }
 
 func TestGetGameFromParameters(t *testing.T) {
-	stubRpc, factory := setupDisputeGameFactoryTest(t)
-	traceType := uint32(123)
-	outputRoot := common.Hash{0x01}
-	l2BlockNum := common.BigToHash(big.NewInt(456)).Bytes()
-	stubRpc.SetResponse(
-		factoryAddr,
-		methodGames,
-		rpcblock.Latest,
-		[]interface{}{traceType, outputRoot, l2BlockNum},
-		[]interface{}{common.Address{0xaa}, uint64(1)},
-	)
-	addr, err := factory.GetGameFromParameters(context.Background(), traceType, outputRoot, uint64(456))
-	require.NoError(t, err)
-	require.Equal(t, common.Address{0xaa}, addr)
+	for _, version := range factoryVersions {
+		t.Run(version.String(), func(t *testing.T) {
+			stubRpc, factory := setupDisputeGameFactoryTest(t, version)
+			traceType := uint32(123)
+			outputRoot := common.Hash{0x01}
+			l2BlockNum := common.BigToHash(big.NewInt(456)).Bytes()
+			stubRpc.SetResponse(
+				factoryAddr,
+				methodGames,
+				rpcblock.Latest,
+				[]interface{}{traceType, outputRoot, l2BlockNum},
+				[]interface{}{common.Address{0xaa}, uint64(1)},
+			)
+			addr, err := factory.GetGameFromParameters(context.Background(), traceType, outputRoot, uint64(456))
+			require.NoError(t, err)
+			require.Equal(t, common.Address{0xaa}, addr)
+		})
+	}
 }
 
-func TestGetGameImpl(t *testing.T) {
-	stubRpc, factory := setupDisputeGameFactoryTest(t)
-	gameType := faultTypes.CannonGameType
-	gameImplAddr := common.Address{0xaa}
-	stubRpc.SetResponse(
-		factoryAddr,
-		methodGameImpls,
-		rpcblock.Latest,
-		[]interface{}{gameType},
-		[]interface{}{gameImplAddr})
-	actual, err := factory.GetGameImpl(context.Background(), faultTypes.CannonGameType)
-	require.NoError(t, err)
-	require.Equal(t, gameImplAddr, actual)
+func TestHasGameImpl(t *testing.T) {
+	for _, version := range factoryVersions {
+		t.Run(version.String()+"-set", func(t *testing.T) {
+			stubRpc, factory := setupDisputeGameFactoryTest(t, version)
+			gameType := faultTypes.CannonGameType
+			gameImplAddr := common.Address{0xaa}
+			stubRpc.SetResponse(
+				factoryAddr,
+				methodGameImpls,
+				rpcblock.Latest,
+				[]interface{}{gameType},
+				[]interface{}{gameImplAddr})
+			actual, err := factory.HasGameImpl(context.Background(), faultTypes.CannonGameType)
+			require.NoError(t, err)
+			require.True(t, actual)
+		})
+		t.Run(version.String()+"-unset", func(t *testing.T) {
+			stubRpc, factory := setupDisputeGameFactoryTest(t, version)
+			gameType := faultTypes.CannonGameType
+			stubRpc.SetResponse(
+				factoryAddr,
+				methodGameImpls,
+				rpcblock.Latest,
+				[]interface{}{gameType},
+				[]interface{}{common.Address{}})
+			actual, err := factory.HasGameImpl(context.Background(), faultTypes.CannonGameType)
+			require.NoError(t, err)
+			require.False(t, actual)
+		})
+	}
+}
+
+func TestGetGameVM(t *testing.T) {
+	for _, usesGameArgs := range []bool{true, false} {
+		t.Run(fmt.Sprintf("GameArgs-%v", usesGameArgs), func(t *testing.T) {
+			for _, version := range factoryVersions {
+				t.Run(version.String(), func(t *testing.T) {
+					gameType := faultTypes.CannonGameType
+					rpc, factory := setupDisputeGameFactoryTest(t, version)
+
+					if usesGameArgs {
+						if version.noGameArgsSupport {
+							t.Skip("Game args not supported on this contract version")
+						}
+						gameArgs := gameargs.GameArgs{Vm: vmAddr}.PackPermissionless()
+						rpc.SetResponse(factoryAddr, methodGameArgs, rpcblock.Latest, []interface{}{gameType}, []interface{}{gameArgs})
+					} else {
+						if !version.noGameArgsSupport {
+							// No game args set
+							rpc.SetResponse(factoryAddr, methodGameArgs, rpcblock.Latest, []interface{}{gameType}, []interface{}{[]byte{}})
+						}
+
+						gameAddr := common.Address{1, 2, 5, 6}
+						rpc.SetResponse(factoryAddr, methodGameImpls, rpcblock.Latest, []interface{}{gameType}, []interface{}{gameAddr})
+
+						setupDisputeGame(rpc, gameAddr, gameType)
+
+						// Get VM from game implementation
+						rpc.SetResponse(gameAddr, methodVM, rpcblock.Latest, nil, []interface{}{vmAddr})
+					}
+
+					vm, err := factory.GetGameVm(context.Background(), gameType)
+					require.NoError(t, err)
+					require.NotNil(t, vm)
+					require.Equal(t, vmAddr, vm.Addr())
+				})
+			}
+		})
+	}
+}
+
+func TestGetGamePrestate(t *testing.T) {
+	for _, usesGameArgs := range []bool{true, false} {
+		t.Run(fmt.Sprintf("GameArgs-%v", usesGameArgs), func(t *testing.T) {
+			for _, version := range factoryVersions {
+				t.Run(version.String(), func(t *testing.T) {
+					gameType := faultTypes.CannonGameType
+					prestate := common.Hash{92, 4, 6, 12, 4}
+					rpc, factory := setupDisputeGameFactoryTest(t, version)
+
+					if usesGameArgs {
+						if version.noGameArgsSupport {
+							t.Skip("Game args not supported on this contract version")
+						}
+						gameArgs := gameargs.GameArgs{AbsolutePrestate: prestate}.PackPermissionless()
+						rpc.SetResponse(factoryAddr, methodGameArgs, rpcblock.Latest, []interface{}{gameType}, []interface{}{gameArgs})
+					} else {
+						if !version.noGameArgsSupport {
+							// No game args set
+							rpc.SetResponse(factoryAddr, methodGameArgs, rpcblock.Latest, []interface{}{gameType}, []interface{}{[]byte{}})
+						}
+
+						gameAddr := common.Address{1, 2, 5, 6}
+						rpc.SetResponse(factoryAddr, methodGameImpls, rpcblock.Latest, []interface{}{gameType}, []interface{}{gameAddr})
+
+						setupDisputeGame(rpc, gameAddr, gameType)
+
+						// Get VM from game implementation
+						rpc.SetResponse(gameAddr, methodAbsolutePrestate, rpcblock.Latest, nil, []interface{}{prestate})
+					}
+
+					actualPrestate, err := factory.GetGamePrestate(context.Background(), gameType)
+					require.NoError(t, err)
+					require.NotNil(t, actualPrestate)
+					require.Equal(t, prestate, actualPrestate)
+				})
+			}
+		})
+	}
 }
 
 func TestDecodeDisputeGameCreatedLog(t *testing.T) {
-	_, factory := setupDisputeGameFactoryTest(t)
-	fdgAbi := snapshots.LoadDisputeGameFactoryABI()
-	eventAbi := fdgAbi.Events[eventDisputeGameCreated]
-	gameAddr := common.Address{0x11}
-	gameType := uint32(4)
-	rootClaim := common.Hash{0xaa, 0xbb, 0xcc}
+	for _, version := range factoryVersions {
+		t.Run(version.String(), func(t *testing.T) {
+			_, factory := setupDisputeGameFactoryTest(t, version)
+			fdgAbi := factory.abi
+			eventAbi := fdgAbi.Events[eventDisputeGameCreated]
+			gameAddr := common.Address{0x11}
+			gameType := uint32(4)
+			rootClaim := common.Hash{0xaa, 0xbb, 0xcc}
 
-	createValidReceipt := func() *ethTypes.Receipt {
-		return &ethTypes.Receipt{
-			Status:          ethTypes.ReceiptStatusSuccessful,
-			ContractAddress: fdgAddr,
-			Logs: []*ethTypes.Log{
-				{
-					Address: fdgAddr,
-					Topics: []common.Hash{
-						eventAbi.ID,
-						common.BytesToHash(gameAddr.Bytes()),
-						common.BytesToHash(big.NewInt(int64(gameType)).Bytes()),
-						rootClaim,
+			createValidReceipt := func() *ethTypes.Receipt {
+				return &ethTypes.Receipt{
+					Status:          ethTypes.ReceiptStatusSuccessful,
+					ContractAddress: fdgAddr,
+					Logs: []*ethTypes.Log{
+						{
+							Address: fdgAddr,
+							Topics: []common.Hash{
+								eventAbi.ID,
+								common.BytesToHash(gameAddr.Bytes()),
+								common.BytesToHash(big.NewInt(int64(gameType)).Bytes()),
+								rootClaim,
+							},
+						},
 					},
-				},
-			},
-		}
+				}
+			}
+
+			t.Run("IgnoreIncorrectContract", func(t *testing.T) {
+				rcpt := createValidReceipt()
+				rcpt.Logs[0].Address = common.Address{0xff}
+				_, _, _, err := factory.DecodeDisputeGameCreatedLog(rcpt)
+				require.ErrorIs(t, err, ErrEventNotFound)
+			})
+
+			t.Run("IgnoreInvalidEvent", func(t *testing.T) {
+				rcpt := createValidReceipt()
+				rcpt.Logs[0].Topics = rcpt.Logs[0].Topics[0:2]
+				_, _, _, err := factory.DecodeDisputeGameCreatedLog(rcpt)
+				require.ErrorIs(t, err, ErrEventNotFound)
+			})
+
+			t.Run("IgnoreWrongEvent", func(t *testing.T) {
+				rcpt := createValidReceipt()
+				rcpt.Logs[0].Topics = []common.Hash{
+					fdgAbi.Events["ImplementationSet"].ID,
+					common.BytesToHash(common.Address{0x11}.Bytes()), // Implementation addr
+					common.BytesToHash(big.NewInt(4).Bytes()),        // Game type
+
+				}
+				// Check the log is a valid ImplementationSet
+				name, _, err := factory.contract.DecodeEvent(rcpt.Logs[0])
+				require.NoError(t, err)
+				require.Equal(t, "ImplementationSet", name)
+
+				_, _, _, err = factory.DecodeDisputeGameCreatedLog(rcpt)
+				require.ErrorIs(t, err, ErrEventNotFound)
+			})
+
+			t.Run("ValidEvent", func(t *testing.T) {
+				rcpt := createValidReceipt()
+				actualGameAddr, actualGameType, actualRootClaim, err := factory.DecodeDisputeGameCreatedLog(rcpt)
+				require.NoError(t, err)
+				require.Equal(t, gameAddr, actualGameAddr)
+				require.Equal(t, gameType, actualGameType)
+				require.Equal(t, rootClaim, actualRootClaim)
+			})
+		})
 	}
-
-	t.Run("IgnoreIncorrectContract", func(t *testing.T) {
-		rcpt := createValidReceipt()
-		rcpt.Logs[0].Address = common.Address{0xff}
-		_, _, _, err := factory.DecodeDisputeGameCreatedLog(rcpt)
-		require.ErrorIs(t, err, ErrEventNotFound)
-	})
-
-	t.Run("IgnoreInvalidEvent", func(t *testing.T) {
-		rcpt := createValidReceipt()
-		rcpt.Logs[0].Topics = rcpt.Logs[0].Topics[0:2]
-		_, _, _, err := factory.DecodeDisputeGameCreatedLog(rcpt)
-		require.ErrorIs(t, err, ErrEventNotFound)
-	})
-
-	t.Run("IgnoreWrongEvent", func(t *testing.T) {
-		rcpt := createValidReceipt()
-		rcpt.Logs[0].Topics = []common.Hash{
-			fdgAbi.Events["ImplementationSet"].ID,
-			common.BytesToHash(common.Address{0x11}.Bytes()), // Implementation addr
-			common.BytesToHash(big.NewInt(4).Bytes()),        // Game type
-
-		}
-		// Check the log is a valid ImplementationSet
-		name, _, err := factory.contract.DecodeEvent(rcpt.Logs[0])
-		require.NoError(t, err)
-		require.Equal(t, "ImplementationSet", name)
-
-		_, _, _, err = factory.DecodeDisputeGameCreatedLog(rcpt)
-		require.ErrorIs(t, err, ErrEventNotFound)
-	})
-
-	t.Run("ValidEvent", func(t *testing.T) {
-		rcpt := createValidReceipt()
-		actualGameAddr, actualGameType, actualRootClaim, err := factory.DecodeDisputeGameCreatedLog(rcpt)
-		require.NoError(t, err)
-		require.Equal(t, gameAddr, actualGameAddr)
-		require.Equal(t, gameType, actualGameType)
-		require.Equal(t, rootClaim, actualRootClaim)
-	})
 }
 
 func expectGetGame(stubRpc *batchingTest.AbiBasedRpc, idx int, blockHash common.Hash, game types.GameMetadata) {
@@ -285,25 +442,35 @@ func expectGetGame(stubRpc *batchingTest.AbiBasedRpc, idx int, blockHash common.
 }
 
 func TestCreateTx(t *testing.T) {
-	stubRpc, factory := setupDisputeGameFactoryTest(t)
-	traceType := uint32(123)
-	outputRoot := common.Hash{0x01}
-	l2BlockNum := common.BigToHash(big.NewInt(456)).Bytes()
-	bond := big.NewInt(49284294829)
-	stubRpc.SetResponse(factoryAddr, methodInitBonds, rpcblock.Latest, []interface{}{traceType}, []interface{}{bond})
-	stubRpc.SetResponse(factoryAddr, methodCreateGame, rpcblock.Latest, []interface{}{traceType, outputRoot, l2BlockNum}, nil)
-	tx, err := factory.CreateTx(context.Background(), traceType, outputRoot, uint64(456))
-	require.NoError(t, err)
-	stubRpc.VerifyTxCandidate(tx)
-	require.NotNil(t, tx.Value)
-	require.Truef(t, bond.Cmp(tx.Value) == 0, "Expected bond %v but was %v", bond, tx.Value)
+	for _, version := range factoryVersions {
+		t.Run(version.String(), func(t *testing.T) {
+			stubRpc, factory := setupDisputeGameFactoryTest(t, version)
+			traceType := uint32(123)
+			outputRoot := common.Hash{0x01}
+			l2BlockNum := common.BigToHash(big.NewInt(456)).Bytes()
+			bond := big.NewInt(49284294829)
+			stubRpc.SetResponse(factoryAddr, methodInitBonds, rpcblock.Latest, []interface{}{traceType}, []interface{}{bond})
+			stubRpc.SetResponse(factoryAddr, methodCreateGame, rpcblock.Latest, []interface{}{traceType, outputRoot, l2BlockNum}, nil)
+			tx, err := factory.CreateTx(context.Background(), traceType, outputRoot, uint64(456))
+			require.NoError(t, err)
+			stubRpc.VerifyTxCandidate(tx)
+			require.NotNil(t, tx.Value)
+			require.Truef(t, bond.Cmp(tx.Value) == 0, "Expected bond %v but was %v", bond, tx.Value)
+		})
+	}
 }
 
-func setupDisputeGameFactoryTest(t *testing.T) (*batchingTest.AbiBasedRpc, *DisputeGameFactoryContract) {
-	fdgAbi := snapshots.LoadDisputeGameFactoryABI()
-
-	stubRpc := batchingTest.NewAbiBasedRpc(t, factoryAddr, fdgAbi)
+func setupDisputeGameFactoryTest(t *testing.T, version factoryContractVersion) (*batchingTest.AbiBasedRpc, *DisputeGameFactoryContract) {
+	stubRpc := batchingTest.NewAbiBasedRpc(t, factoryAddr, version.loadAbi())
 	caller := batching.NewMultiCaller(stubRpc, batchSize)
-	factory := NewDisputeGameFactoryContract(metrics.NoopContractMetrics, factoryAddr, caller)
+	stubRpc.SetResponse(factoryAddr, methodVersion, rpcblock.Latest, []interface{}{}, []interface{}{version.version})
+	factory, err := NewDisputeGameFactoryContract(context.Background(), metrics.NoopContractMetrics, factoryAddr, caller)
+	require.NoError(t, err)
 	return stubRpc, factory
+}
+
+func setupDisputeGame(rpc *batchingTest.AbiBasedRpc, gameAddr common.Address, gameType faultTypes.GameType) {
+	rpc.AddContract(gameAddr, snapshots.LoadFaultDisputeGameABI())
+	rpc.SetResponse(gameAddr, methodVersion, rpcblock.Latest, nil, []interface{}{versLatest})
+	rpc.SetResponse(gameAddr, methodGameType, rpcblock.Latest, nil, []interface{}{gameType})
 }

--- a/op-challenger/game/fault/register_task_test.go
+++ b/op-challenger/game/fault/register_task_test.go
@@ -6,9 +6,11 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts"
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts/gameargs"
 	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/registry"
 	"github.com/ethereum-optimism/optimism/op-challenger/metrics"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching/test"
@@ -20,64 +22,120 @@ import (
 )
 
 func TestRegisterOracle_MissingGameImpl(t *testing.T) {
-	gameFactoryAddr := common.Address{0xaa}
-	rpc := test.NewAbiBasedRpc(t, gameFactoryAddr, snapshots.LoadDisputeGameFactoryABI())
-	m := metrics.NoopMetrics
-	caller := batching.NewMultiCaller(rpc, batching.DefaultBatchSize)
-	gameFactory := contracts.NewDisputeGameFactoryContract(m, gameFactoryAddr, caller)
+	// Test versions with and without game args support
+	for _, factoryVersion := range []string{"1.2.0", "1.3.0"} {
+		t.Run(factoryVersion, func(t *testing.T) {
+			gameFactoryAddr := common.Address{0xaa}
+			rpc := test.NewAbiBasedRpc(t, gameFactoryAddr, snapshots.LoadDisputeGameFactoryABI())
+			rpc.SetResponse(gameFactoryAddr, "version", rpcblock.Latest, nil, []interface{}{factoryVersion})
+			m := metrics.NoopMetrics
+			caller := batching.NewMultiCaller(rpc, batching.DefaultBatchSize)
+			gameFactory, err := contracts.NewDisputeGameFactoryContract(context.Background(), m, gameFactoryAddr, caller)
+			require.NoError(t, err)
 
-	logger, logs := testlog.CaptureLogger(t, log.LvlInfo)
-	oracles := registry.NewOracleRegistry()
-	gameType := faultTypes.CannonGameType
+			logger, logs := testlog.CaptureLogger(t, log.LvlInfo)
+			oracles := registry.NewOracleRegistry()
+			gameType := faultTypes.CannonGameType
 
-	rpc.SetResponse(gameFactoryAddr, "gameImpls", rpcblock.Latest, []interface{}{gameType}, []interface{}{common.Address{}})
+			rpc.SetResponse(gameFactoryAddr, "gameImpls", rpcblock.Latest, []interface{}{gameType}, []interface{}{common.Address{}})
 
-	err := registerOracle(context.Background(), logger, m, oracles, gameFactory, caller, gameType)
-	require.NoError(t, err)
-	require.NotNil(t, logs.FindLog(
-		testlog.NewMessageFilter("No game implementation set for game type"),
-		testlog.NewAttributesFilter("gameType", gameType.String())))
+			err = registerOracle(context.Background(), logger, oracles, gameFactory, gameType)
+			require.NoError(t, err)
+			require.NotNil(t, logs.FindLog(
+				testlog.NewMessageFilter("No game implementation set for game type"),
+				testlog.NewAttributesFilter("gameType", gameType.String())))
+		})
+	}
 }
 
 func TestRegisterOracle_AddsOracle(t *testing.T) {
-	for _, gameType := range []faultTypes.GameType{faultTypes.CannonGameType, faultTypes.SuperCannonGameType, faultTypes.SuperAsteriscKonaGameType} {
-		t.Run(fmt.Sprintf("%v", gameType), func(t *testing.T) {
-			gameFactoryAddr := common.Address{0xaa}
-			gameImplAddr := common.Address{0xbb}
-			vmAddr := common.Address{0xcc}
-			oracleAddr := common.Address{0xdd}
-			rpc := test.NewAbiBasedRpc(t, gameFactoryAddr, snapshots.LoadDisputeGameFactoryABI())
-			if gameType == faultTypes.CannonGameType {
-				rpc.AddContract(gameImplAddr, snapshots.LoadFaultDisputeGameABI())
-			} else if gameType == faultTypes.SuperCannonGameType || gameType == faultTypes.SuperAsteriscKonaGameType {
-				rpc.AddContract(gameImplAddr, snapshots.LoadSuperFaultDisputeGameABI())
-			} else {
-				t.Fatalf("game type %v not supported", gameType)
+	tests := []struct {
+		name            string
+		version         string
+		supportGameArgs bool
+		useGameArgs     bool
+	}{
+		{
+			name:            "pre-game args support",
+			version:         "1.2.0",
+			supportGameArgs: false,
+			useGameArgs:     false,
+		},
+		{
+			name:            "game args supported but not used",
+			version:         "1.3.0",
+			supportGameArgs: true,
+			useGameArgs:     false,
+		},
+		{
+			name:            "game args supported and used",
+			version:         "1.3.0",
+			supportGameArgs: true,
+			useGameArgs:     true,
+		},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			for _, gameType := range []faultTypes.GameType{faultTypes.CannonGameType, faultTypes.SuperCannonGameType, faultTypes.SuperAsteriscKonaGameType} {
+				t.Run(fmt.Sprintf("%v", gameType), func(t *testing.T) {
+					gameFactoryAddr := common.Address{0xaa}
+					gameImplAddr := common.Address{0xbb}
+					vmAddr := common.Address{0xcc}
+					oracleAddr := common.Address{0xdd}
+					rpc := test.NewAbiBasedRpc(t, gameFactoryAddr, snapshots.LoadDisputeGameFactoryABI())
+					rpc.SetResponse(gameFactoryAddr, "version", rpcblock.Latest, nil, []interface{}{testCase.version})
+					if gameType == faultTypes.CannonGameType {
+						rpc.AddContract(gameImplAddr, snapshots.LoadFaultDisputeGameABI())
+					} else if gameType == faultTypes.SuperCannonGameType || gameType == faultTypes.SuperAsteriscKonaGameType {
+						rpc.AddContract(gameImplAddr, snapshots.LoadSuperFaultDisputeGameABI())
+					} else {
+						t.Fatalf("game type %v not supported", gameType)
+					}
+					rpc.AddContract(vmAddr, snapshots.LoadMIPSABI())
+					rpc.AddContract(oracleAddr, snapshots.LoadPreimageOracleABI())
+					m := metrics.NoopMetrics
+					caller := batching.NewMultiCaller(rpc, batching.DefaultBatchSize)
+					gameFactory, err := contracts.NewDisputeGameFactoryContract(context.Background(), m, gameFactoryAddr, caller)
+					require.NoError(t, err)
+
+					if testCase.useGameArgs {
+						gameArgs := gameargs.GameArgs{
+							AbsolutePrestate:    common.Hash{1},
+							Vm:                  vmAddr,
+							AnchorStateRegistry: common.Address{3},
+							Weth:                common.Address{4},
+							L2ChainID:           eth.ChainID{5},
+							Proposer:            common.Address{6},
+							Challenger:          common.Address{7},
+						}.PackPermissionless()
+						rpc.SetResponse(gameFactoryAddr, "gameArgs", rpcblock.Latest, []interface{}{gameType}, []interface{}{gameArgs})
+					} else if testCase.supportGameArgs {
+						rpc.SetResponse(gameFactoryAddr, "gameArgs", rpcblock.Latest, []interface{}{gameType}, []interface{}{[]byte{}})
+					}
+
+					logger := testlog.Logger(t, log.LvlInfo)
+					oracles := registry.NewOracleRegistry()
+
+					// Use the latest v1 of these contracts. Doesn't have to be an exact match for the version.
+					rpc.SetResponse(gameImplAddr, "version", rpcblock.Latest, []interface{}{}, []interface{}{"1.100.0"})
+					rpc.SetResponse(oracleAddr, "version", rpcblock.Latest, []interface{}{}, []interface{}{"1.100.0"})
+
+					rpc.SetResponse(gameFactoryAddr, "gameImpls", rpcblock.Latest, []interface{}{gameType}, []interface{}{gameImplAddr})
+					if !testCase.useGameArgs {
+						// Can only get the vm address from the implementation contract if game args aren't being used
+						rpc.SetResponse(gameImplAddr, "vm", rpcblock.Latest, []interface{}{}, []interface{}{vmAddr})
+					}
+					rpc.SetResponse(vmAddr, "oracle", rpcblock.Latest, []interface{}{}, []interface{}{oracleAddr})
+
+					rpc.SetResponse(gameImplAddr, "gameType", rpcblock.Latest, []interface{}{}, []interface{}{uint32(gameType)})
+
+					err = registerOracle(context.Background(), logger, oracles, gameFactory, gameType)
+					require.NoError(t, err)
+					registered := oracles.Oracles()
+					require.Len(t, registered, 1)
+					require.Equal(t, oracleAddr, registered[0].Addr())
+				})
 			}
-			rpc.AddContract(vmAddr, snapshots.LoadMIPSABI())
-			rpc.AddContract(oracleAddr, snapshots.LoadPreimageOracleABI())
-			m := metrics.NoopMetrics
-			caller := batching.NewMultiCaller(rpc, batching.DefaultBatchSize)
-			gameFactory := contracts.NewDisputeGameFactoryContract(m, gameFactoryAddr, caller)
-
-			logger := testlog.Logger(t, log.LvlInfo)
-			oracles := registry.NewOracleRegistry()
-
-			// Use the latest v1 of these contracts. Doesn't have to be an exact match for the version.
-			rpc.SetResponse(gameImplAddr, "version", rpcblock.Latest, []interface{}{}, []interface{}{"1.100.0"})
-			rpc.SetResponse(oracleAddr, "version", rpcblock.Latest, []interface{}{}, []interface{}{"1.100.0"})
-
-			rpc.SetResponse(gameFactoryAddr, "gameImpls", rpcblock.Latest, []interface{}{gameType}, []interface{}{gameImplAddr})
-			rpc.SetResponse(gameImplAddr, "vm", rpcblock.Latest, []interface{}{}, []interface{}{vmAddr})
-			rpc.SetResponse(vmAddr, "oracle", rpcblock.Latest, []interface{}{}, []interface{}{oracleAddr})
-
-			rpc.SetResponse(gameImplAddr, "gameType", rpcblock.Latest, []interface{}{}, []interface{}{uint32(gameType)})
-
-			err := registerOracle(context.Background(), logger, m, oracles, gameFactory, caller, gameType)
-			require.NoError(t, err)
-			registered := oracles.Oracles()
-			require.Len(t, registered, 1)
-			require.Equal(t, oracleAddr, registered[0].Addr())
 		})
 	}
 }

--- a/op-challenger/game/service.go
+++ b/op-challenger/game/service.go
@@ -100,7 +100,7 @@ func (s *Service) initFromConfig(ctx context.Context, cfg *config.Config) error 
 	if err := s.initMetricsServer(&cfg.MetricsConfig); err != nil {
 		return fmt.Errorf("failed to init metrics server: %w", err)
 	}
-	if err := s.initFactoryContract(cfg); err != nil {
+	if err := s.initFactoryContract(ctx, cfg); err != nil {
 		return fmt.Errorf("failed to create factory contract bindings: %w", err)
 	}
 	if err := s.registerGameTypes(ctx, cfg); err != nil {
@@ -192,9 +192,12 @@ func (s *Service) initMetricsServer(cfg *opmetrics.CLIConfig) error {
 	return nil
 }
 
-func (s *Service) initFactoryContract(cfg *config.Config) error {
-	factoryContract := contracts.NewDisputeGameFactoryContract(s.metrics, cfg.GameFactoryAddress,
+func (s *Service) initFactoryContract(ctx context.Context, cfg *config.Config) error {
+	factoryContract, err := contracts.NewDisputeGameFactoryContract(ctx, s.metrics, cfg.GameFactoryAddress,
 		batching.NewMultiCaller(s.l1Client.Client(), batching.DefaultBatchSize))
+	if err != nil {
+		return fmt.Errorf("failed to create factory contract: %w", err)
+	}
 	s.factoryContract = factoryContract
 	return nil
 }

--- a/op-dispute-mon/mon/service.go
+++ b/op-dispute-mon/mon/service.go
@@ -84,7 +84,7 @@ func (s *Service) initFromConfig(ctx context.Context, cfg *config.Config) error 
 	if err := s.initMetricsServer(&cfg.MetricsConfig); err != nil {
 		return fmt.Errorf("failed to init metrics server: %w", err)
 	}
-	if err := s.initFactoryContract(cfg); err != nil {
+	if err := s.initFactoryContract(ctx, cfg); err != nil {
 		return fmt.Errorf("failed to create factory contract bindings: %w", err)
 	}
 	if err := s.initOutputRollupClient(ctx, cfg); err != nil {
@@ -254,8 +254,11 @@ func (s *Service) initMetricsServer(cfg *opmetrics.CLIConfig) error {
 	return nil
 }
 
-func (s *Service) initFactoryContract(cfg *config.Config) error {
-	factoryContract := contracts.NewDisputeGameFactoryContract(s.metrics, cfg.GameFactoryAddress, s.l1Caller)
+func (s *Service) initFactoryContract(ctx context.Context, cfg *config.Config) error {
+	factoryContract, err := contracts.NewDisputeGameFactoryContract(ctx, s.metrics, cfg.GameFactoryAddress, s.l1Caller)
+	if err != nil {
+		return fmt.Errorf("failed to create dispute game factory contract: %w", err)
+	}
 	s.factoryContract = factoryContract
 	return nil
 }

--- a/op-e2e/interop/interop_test.go
+++ b/op-e2e/interop/interop_test.go
@@ -428,7 +428,8 @@ func TestProposals(t *testing.T) {
 		rpcClient, err := dial.DialRPCClientWithTimeout(context.Background(), logger, s2.L1().UserRPC().RPC())
 		require.NoError(t, err)
 		caller := batching.NewMultiCaller(rpcClient, batching.DefaultBatchSize)
-		factory := contracts.NewDisputeGameFactoryContract(metrics.NoopContractMetrics, gameFactoryAddr, caller)
+		factory, err := contracts.NewDisputeGameFactoryContract(context.Background(), metrics.NoopContractMetrics, gameFactoryAddr, caller)
+		require.NoError(t, err)
 		ethClient := ethclient.NewClient(rpcClient)
 		require.Eventually(t, func() bool {
 			head, err := ethClient.BlockByNumber(context.Background(), nil)


### PR DESCRIPTION
**Description**

The implementation contract doesn't always have the values embedded. It automatically switches between game args and reading from the implementation, as well as detecting versions that don't yet support game args for backwards compatibility.

The `GetGameImpl` method is now internal to `DisputeGameFactory` to ensure that nothing is grabbing the game implementation and depending on its behaviour. `DisputeGameFactory` exposes methods to get the VM or Prestate in a way that's compatible with game args.

**Tests**

Updated tests. Smoke test that detected this is now enabled.


**Metadata**

fixes https://github.com/ethereum-optimism/optimism/issues/17810