### PR TITLE
ci: Clean up op-deployer caches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1321,6 +1321,11 @@ jobs:
               tar -czf testlogs.tar.gz -C ./tmp testlogs
             fi
           when: always
+      - run:
+          name: Clean up op-deployer artifacts
+          command: |
+            rm -rf ~/.op-deployer/*
+          when: always
       - store_artifacts:
           path: testlogs*.tar.gz
           when: always


### PR DESCRIPTION
We keep running into issues where OPD caches are not properly cleaned up in tests. This adds a stopgap that cleans them up after every test to prevent disk usage exploding on our self-hosted runners.
