### PR TITLE
derive: Drop span batch with singular batch extraction error

### DIFF
--- a/op-node/rollup/derive/batch_stage.go
+++ b/op-node/rollup/derive/batch_stage.go
@@ -158,7 +158,9 @@ func (bs *BatchStage) nextSingularBatchCandidate(ctx context.Context, parent eth
 		// If next batch is SpanBatch, convert it to SingularBatches.
 		singularBatches, err := spanBatch.GetSingularBatches(bs.l1Blocks, parent)
 		if err != nil {
-			return nil, NewCriticalError(err)
+			spanBatch.LogContext(bs.Log()).Warn("Dropping invalid span batch, flushing channel", "error", err)
+			bs.FlushChannel()
+			return nil, NotEnoughData
 		}
 		bs.nextSpan = singularBatches
 		// span-batches are non-empty, so the below pop is safe.

--- a/op-node/rollup/derive/span_batch.go
+++ b/op-node/rollup/derive/span_batch.go
@@ -582,7 +582,9 @@ func (b *SpanBatch) ToRawSpanBatch() (*RawSpanBatch, error) {
 
 // GetSingularBatches converts SpanBatchElements after L2 safe head to SingularBatches.
 // Since SpanBatchElement does not contain EpochHash, set EpochHash from the given L1 blocks.
-// The result SingularBatches do not contain ParentHash yet. It must be set by BatchQueue.
+// The result SingularBatches do not contain the ParentHash yet. It must be set by the
+// BatchQueue/BatchStage. If this function returns an error, derivation must treat this as an
+// invalid batch and not as a critical derivation error.
 func (b *SpanBatch) GetSingularBatches(l1Origins []eth.L1BlockRef, l2SafeHead eth.L2BlockRef) ([]*SingularBatch, error) {
 	var singularBatches []*SingularBatch
 	originIdx := 0


### PR DESCRIPTION
**Description**

Instead of critically crashing derivation. This may happen during L2 reorg scenarios that were caused by L1 origin reorgs.

Still WIP and testing, we may want to add proper L1 origin checks to the span batch prefix check function instead.

**Tests**

TODO

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
