### PR TITLE
docs(op-batcher): Add runtime batcher flushing instructions

### DIFF
--- a/op-batcher/readme.md
+++ b/op-batcher/readme.md
@@ -166,6 +166,16 @@ curl -X POST -H "Content-Type: application/json" \
 
 The batcher tries to ensure that batches are posted at a minimum frequency specified by `MAX_CHANNEL_DURATION`. To achieve this, it caches the l1 origin of the last submitted channel, and will force close a channel if the timestamp of the l1 head moves beyond the timestamp of that l1 origin plus `MAX_CHANNEL_DURATION`. When clearing its state, e.g. following the detection of a reorg, the batcher will not clear the cached l1 origin: this way, the regular posting of batches will not be disturbed by events like reorgs.
 
+### Runtime batcher flushing
+It is possible to manually trigger the batcher to post data to the DA layer without restarting it, like so:
+```bash
+# Runtime controller switching
+curl -X POST -H "Content-Type: application/json" \
+  --data '{"jsonrpc":"2.0","method":"admin_flushBatcher","params":[],"id":1}' \
+  http://localhost:8545
+```
+The command can either be run on the batcher host machine itself, or remotely by replacing `localhost` with the appropriate remote hostname.
+
 ## Known issues and future work
 
 Link to [open issues with the `op-batcher` tag](https://github.com/ethereum-optimism/optimism/issues?q=is%3Aopen+is%3Aissue+label%3AA-op-batcher).

--- a/op-batcher/readme.md
+++ b/op-batcher/readme.md
@@ -181,6 +181,9 @@ cast rpc admin_flushBatcher -r http://localhost:8545
 ```
 The command can either be run on the batcher host machine itself, or remotely by replacing `localhost` with the appropriate remote hostname.
 
+### Enabling the `admin` API
+This is disabled by default but can be set with `OP_BATCHER_RPC_ENABLE_ADMIN=true` or `--rpc.enable-admin=true`. It is necessary to allow the commands above to work.
+
 ## Known issues and future work
 
 Link to [open issues with the `op-batcher` tag](https://github.com/ethereum-optimism/optimism/issues?q=is%3Aopen+is%3Aissue+label%3AA-op-batcher).

--- a/op-batcher/readme.md
+++ b/op-batcher/readme.md
@@ -154,7 +154,7 @@ The batcher includes sophisticated throttling mechanisms to manage data availabi
 --throttle-threshold=1000000
 --throttle-controller-type=quadratic
 
-# Runtime controller switching
+# Runtime controller inspection
 curl -X POST -H "Content-Type: application/json" \
   --data '{"jsonrpc":"2.0","method":"admin_getThrottleController","params":[],"id":1}' \
   http://localhost:8545

--- a/op-batcher/readme.md
+++ b/op-batcher/readme.md
@@ -169,7 +169,6 @@ The batcher tries to ensure that batches are posted at a minimum frequency speci
 ### Runtime batcher flushing
 It is possible to manually trigger the batcher to post data to the DA layer without restarting it, like so:
 ```bash
-# Runtime controller switching
 curl -X POST -H "Content-Type: application/json" \
   --data '{"jsonrpc":"2.0","method":"admin_flushBatcher","params":[],"id":1}' \
   http://localhost:8545

--- a/op-batcher/readme.md
+++ b/op-batcher/readme.md
@@ -158,6 +158,9 @@ The batcher includes sophisticated throttling mechanisms to manage data availabi
 curl -X POST -H "Content-Type: application/json" \
   --data '{"jsonrpc":"2.0","method":"admin_getThrottleController","params":[],"id":1}' \
   http://localhost:8545
+
+# or
+cast rpc admin_getThrottleController -r http://localhost:8545
 ```
 
 **📖 For complete documentation, configuration guides, and troubleshooting, see [Enhanced DA Throttling Mechanisms](./throttling.md)**
@@ -172,6 +175,9 @@ It is possible to manually trigger the batcher to post data to the DA layer with
 curl -X POST -H "Content-Type: application/json" \
   --data '{"jsonrpc":"2.0","method":"admin_flushBatcher","params":[],"id":1}' \
   http://localhost:8545
+
+# or
+cast rpc admin_flushBatcher -r http://localhost:8545
 ```
 The command can either be run on the batcher host machine itself, or remotely by replacing `localhost` with the appropriate remote hostname.
 

--- a/op-batcher/readme.md
+++ b/op-batcher/readme.md
@@ -169,6 +169,9 @@ cast rpc admin_getThrottleController -r http://localhost:8545
 
 The batcher tries to ensure that batches are posted at a minimum frequency specified by `MAX_CHANNEL_DURATION`. To achieve this, it caches the l1 origin of the last submitted channel, and will force close a channel if the timestamp of the l1 head moves beyond the timestamp of that l1 origin plus `MAX_CHANNEL_DURATION`. When clearing its state, e.g. following the detection of a reorg, the batcher will not clear the cached l1 origin: this way, the regular posting of batches will not be disturbed by events like reorgs.
 
+### Enabling the `admin` API
+In the following sections, we make use of the batcher's admin API. This is disabled by default but can be set with `OP_BATCHER_RPC_ENABLE_ADMIN=true` or `--rpc.enable-admin=true`.
+
 ### Runtime batcher flushing
 It is possible to manually trigger the batcher to post data to the DA layer without restarting it, like so:
 ```bash
@@ -180,9 +183,6 @@ curl -X POST -H "Content-Type: application/json" \
 cast rpc admin_flushBatcher -r http://localhost:8545
 ```
 The command can either be run on the batcher host machine itself, or remotely by replacing `localhost` with the appropriate remote hostname.
-
-### Enabling the `admin` API
-This is disabled by default but can be set with `OP_BATCHER_RPC_ENABLE_ADMIN=true` or `--rpc.enable-admin=true`. It is necessary to allow the commands above to work.
 
 ## Known issues and future work
 


### PR DESCRIPTION
Added instructions for manually triggering the batcher to post data to the DA layer.

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
