### PR TITLE
opcm: Do not deploy the V1 dispute game blueprints when V2 is enabled

### DIFF
--- a/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
@@ -230,8 +230,10 @@ contract DeployImplementations is Script {
         require(checkAddress == address(0), "OPCM-50");
         // The max initcode/runtimecode size is 48KB/24KB.
         // But for Blueprint, the initcode is stored as runtime code, that's why it's necessary to split into 2 parts.
-        (blueprints.permissionedDisputeGame1, blueprints.permissionedDisputeGame2) = DeployUtils.createDeterministicBlueprint(vm.getCode("PermissionedDisputeGame"), _salt);
-        (blueprints.permissionlessDisputeGame1, blueprints.permissionlessDisputeGame2) = DeployUtils.createDeterministicBlueprint(vm.getCode("FaultDisputeGame"), _salt);
+        if (!DevFeatures.isDevFeatureEnabled(_input.devFeatureBitmap, DevFeatures.DEPLOY_V2_DISPUTE_GAMES)) {
+            (blueprints.permissionedDisputeGame1, blueprints.permissionedDisputeGame2) = DeployUtils.createDeterministicBlueprint(vm.getCode("PermissionedDisputeGame"), _salt);
+            (blueprints.permissionlessDisputeGame1, blueprints.permissionlessDisputeGame2) = DeployUtils.createDeterministicBlueprint(vm.getCode("FaultDisputeGame"), _salt);
+        }
         (blueprints.superPermissionedDisputeGame1, blueprints.superPermissionedDisputeGame2) = DeployUtils.createDeterministicBlueprint(vm.getCode("SuperPermissionedDisputeGame"), _salt);
         (blueprints.superPermissionlessDisputeGame1, blueprints.superPermissionlessDisputeGame2) = DeployUtils.createDeterministicBlueprint(vm.getCode("SuperFaultDisputeGame"), _salt);
         // forgefmt: disable-end

--- a/packages/contracts-bedrock/test/opcm/DeployImplementations.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployImplementations.t.sol
@@ -362,6 +362,27 @@ contract DeployImplementations_Test is Test {
             302400,
             "PermissionedDisputeGameV2 maxClockDuration incorrect"
         );
+
+        assertEq(
+            output.opcm.blueprints().permissionedDisputeGame1,
+            address(0),
+            "PermissionedDisputeGame1 blueprint should not be deployed"
+        );
+        assertEq(
+            output.opcm.blueprints().permissionedDisputeGame2,
+            address(0),
+            "PermissionedDisputeGame2 blueprint should not be deployed"
+        );
+        assertEq(
+            output.opcm.blueprints().permissionlessDisputeGame1,
+            address(0),
+            "PermissionlessDisputeGame1 blueprint should not be deployed"
+        );
+        assertEq(
+            output.opcm.blueprints().permissionlessDisputeGame1,
+            address(0),
+            "PermissionlessDisputeGame2 blueprint should not be deployed"
+        );
     }
 
     function test_v2ParamsValidation_withFlagDisabled_succeeds() public {


### PR DESCRIPTION
**Description**

Do not deploy the V1 dispute game blueprints when V2 is enabled.
Guarantees we aren't depending on these blueprints in any way and they will be safe to delete.


**Metadata**

Fixes https://github.com/ethereum-optimism/optimism/issues/17599