### PR TITLE
chore(ci): go-tests parallelism.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2460,7 +2460,7 @@ workflows:
             - contracts-bedrock-build
       - go-tests:
           name: go-tests-short
-          parallelism: 4
+          parallelism: 3
           no_output_timeout: 19m
           test_timeout: 20m
           requires:
@@ -2474,7 +2474,7 @@ workflows:
       - go-tests:
           name: go-tests-full
           rule: "go-tests-ci" # Run full test suite instead of short
-          parallelism: 4
+          parallelism: 3
           no_output_timeout: 89m # Longer timeout for full tests
           test_timeout: 90m
           notify: true


### PR DESCRIPTION
Lowering to not use all runners.
