### PR TITLE
op-node/rollup: Drop non-empty batches for Jovian activation block

### DIFF
--- a/op-acceptance-tests/tests/sync_tester/sync_tester_hfs_ext/sync_tester_hfs_ext_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_tester_hfs_ext/sync_tester_hfs_ext_test.go
@@ -249,7 +249,7 @@ func hfsExt(gt *testing.T, upgradeName rollup.ForkName, l2CLSyncMode sync.Mode) 
 	}
 	require := t.Require()
 
-	ft := sys.L2.Escape().RollupConfig().ActivationTimeFor(upgradeName)
+	ft := sys.L2.Escape().RollupConfig().ActivationTime(upgradeName)
 	var l2CLSyncStatus *eth.SyncStatus
 	attempts := 1000
 	if l2CLSyncMode == sync.ELSync {

--- a/op-devstack/dsl/l2_network.go
+++ b/op-devstack/dsl/l2_network.go
@@ -231,7 +231,7 @@ func (n *L2Network) AwaitActivation(t devtest.T, forkName rollup.ForkName) eth.B
 	el := n.Escape().L2ELNode(match.FirstL2EL)
 
 	rollupCfg := n.Escape().RollupConfig()
-	maybeActivationTime := rollupCfg.ActivationTimeFor(forkName)
+	maybeActivationTime := rollupCfg.ActivationTime(forkName)
 	require.NotNil(maybeActivationTime, "Required fork is not scheduled for activation")
 	activationTime := *maybeActivationTime
 	if activationTime == 0 {

--- a/op-e2e/actions/helpers/user.go
+++ b/op-e2e/actions/helpers/user.go
@@ -285,7 +285,7 @@ func (s *BasicUser[B]) MakeTransaction(t Testing) *types.Transaction {
 
 // ActMakeTx makes a tx with the predetermined contents (see randomization and other actions)
 // and sends it to the tx pool
-func (s *BasicUser[B]) ActMakeTx(t Testing) {
+func (s *BasicUser[B]) ActMakeTx(t Testing) *types.Transaction {
 	t.Helper()
 	tx := s.MakeTransaction(t)
 	err := s.env.EthCl.SendTransaction(t.Ctx(), tx)
@@ -293,6 +293,7 @@ func (s *BasicUser[B]) ActMakeTx(t Testing) {
 	s.lastTxHash = tx.Hash()
 	// reset the calldata
 	s.txCallData = []byte{}
+	return tx
 }
 
 func (s *BasicUser[B]) ActCheckReceiptStatusOfLastTx(success bool) func(t Testing) {

--- a/op-e2e/actions/proofs/activation_block_test.go
+++ b/op-e2e/actions/proofs/activation_block_test.go
@@ -1,0 +1,102 @@
+package proofs
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
+	actionsHelpers "github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
+	"github.com/ethereum-optimism/optimism/op-e2e/actions/proofs/helpers"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+type activationBlockTestCfg struct {
+	fork          rollup.ForkName
+	numUpgradeTxs int
+}
+
+// TestUpgradeBlockTxOmission tests that the sequencer omits user transactions in activation blocks
+// and that batches that contain user transactions in an activation block are dropped.
+func TestActivationBlockTxOmission(gt *testing.T) {
+	matrix := helpers.NewMatrix[activationBlockTestCfg]()
+
+	matrix.AddDefaultTestCasesWithName(
+		string(rollup.Jovian),
+		activationBlockTestCfg{fork: rollup.Jovian, numUpgradeTxs: 5},
+		helpers.NewForkMatrix(helpers.Isthmus),
+		testActivationBlockTxOmission,
+	)
+	// New forks should be added here in the future.
+
+	matrix.Run(gt)
+}
+
+func testActivationBlockTxOmission(gt *testing.T, testCfg *helpers.TestCfg[activationBlockTestCfg]) {
+	tcfg := testCfg.Custom
+	t := actionsHelpers.NewDefaultTesting(gt)
+	offset := uint64(4)
+	testSetup := func(dc *genesis.DeployConfig) {
+		dc.L1PragueTimeOffset = ptr(hexutil.Uint64(0))
+		// activate fork after a few blocks
+		dc.SetForkTimeOffset(tcfg.fork, &offset)
+	}
+	env := helpers.NewL2FaultProofEnv(t, testCfg, helpers.NewTestParams(), helpers.NewBatcherCfg(), testSetup)
+
+	engine := env.Engine
+	sequencer := env.Sequencer
+	miner := env.Miner
+	rollupCfg := env.Sd.RollupCfg
+	blockTime := rollupCfg.BlockTime
+
+	miner.ActEmptyBlock(t)
+
+	sequencer.ActL1HeadSignal(t)
+	for i := 0; i < int(offset)-1; i++ {
+		sequencer.ActL2EmptyBlock(t)
+	}
+	tx := env.Alice.L2.ActMakeTx(t)
+	sequencer.ActL2StartBlock(t)
+	// we assert later that the sequencer actually omits this tx in the activation block
+	engine.ActL2IncludeTx(env.Alice.Address())
+	sequencer.ActL2EndBlock(t)
+
+	actHeader := engine.L2Chain().CurrentHeader()
+	require.Equal(t, tcfg.fork,
+		rollupCfg.IsActivationBlock(actHeader.Time-blockTime, actHeader.Time),
+		"this block should be the activation block")
+	actBlock := engine.L2Chain().GetBlockByHash(actHeader.Hash())
+	require.Len(t, actBlock.Transactions(), tcfg.numUpgradeTxs+1, "activation block contains unexpected txs")
+
+	batcher := env.Batcher
+	for i := 0; i < int(offset)-1; i++ {
+		batcher.ActL2BatchBuffer(t)
+	}
+	batcher.ActL2BatchBuffer(t,
+		actionsHelpers.WithBlockModifier(func(block *types.Block) *types.Block {
+			// inject user tx into activation batch
+			return block.WithBody(types.Body{Transactions: append(block.Transactions(), tx)})
+		}))
+
+	batcher.ActL2ChannelClose(t)
+	batcher.ActL2BatchSubmit(t)
+	env.Miner.ActL1StartBlock(12)(t)
+	env.Miner.ActL1IncludeTxByHash(env.Batcher.LastSubmitted.Hash())(t)
+	env.Miner.ActL1EndBlock(t)
+
+	env.Sequencer.ActL1HeadSignal(t)
+	env.Sequencer.ActL2PipelineFull(t)
+
+	recs := env.Logs.FindLogs(testlog.NewMessageFilter("dropping batch with user transactions in fork activation block"))
+	require.Len(t, recs, 1)
+
+	l2SafeHead := engine.L2Chain().CurrentSafeBlock()
+	preActHeader := engine.L2Chain().GetHeaderByHash(actHeader.ParentHash)
+	require.Equal(t, eth.HeaderBlockID(preActHeader), eth.HeaderBlockID(l2SafeHead), "derivation only reaches pre-upgrade block")
+
+	env.RunFaultProofProgramFromGenesis(t, l2SafeHead.Number.Uint64(), testCfg.CheckResult, testCfg.InputParams...)
+}

--- a/op-node/rollup/chain_spec.go
+++ b/op-node/rollup/chain_spec.go
@@ -63,6 +63,8 @@ var AllForks = []ForkName{
 	// ADD NEW FORKS HERE!
 }
 
+var LatestFork = AllForks[len(AllForks)-1]
+
 func ForksFrom(fork ForkName) []ForkName {
 	for i, f := range AllForks {
 		if f == fork {

--- a/op-node/rollup/derive/batches.go
+++ b/op-node/rollup/derive/batches.go
@@ -134,7 +134,9 @@ func checkSingularBatch(cfg *rollup.Config, log log.Logger, l1Blocks []eth.L1Blo
 	}
 
 	// Future forks that contain upgrade transactions must be added here.
-	if (cfg.IsInteropActivationBlock(batch.Timestamp)) && len(batch.Transactions) > 0 {
+	if (cfg.IsJovianActivationBlock(batch.Timestamp) ||
+		cfg.IsInteropActivationBlock(batch.Timestamp)) &&
+		len(batch.Transactions) > 0 {
 		log.Warn("dropping batch with user transactions in fork activation block")
 		return BatchDrop
 	}

--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -432,7 +432,7 @@ func (c *Config) L1Signer() types.Signer {
 }
 
 func (c *Config) IsForkActive(fork ForkName, timestamp uint64) bool {
-	activationTime := c.ActivationTimeFor(fork)
+	activationTime := c.ActivationTime(fork)
 	return activationTime != nil && timestamp >= *activationTime
 }
 
@@ -558,7 +558,8 @@ func (c *Config) IsInteropActivationBlock(l2BlockTime uint64) bool {
 		!c.IsInterop(l2BlockTime-c.BlockTime)
 }
 
-func (c *Config) ActivationTimeFor(fork ForkName) *uint64 {
+func (c *Config) ActivationTime(fork ForkName) *uint64 {
+	// NEW FORKS MUST BE ADDED HERE
 	switch fork {
 	case Interop:
 		return c.InteropTime
@@ -585,81 +586,78 @@ func (c *Config) ActivationTimeFor(fork ForkName) *uint64 {
 	}
 }
 
+func (c *Config) SetActivationTime(fork ForkName, timestamp *uint64) {
+	// NEW FORKS MUST BE ADDED HERE
+	switch fork {
+	case Interop:
+		c.InteropTime = timestamp
+	case Jovian:
+		c.JovianTime = timestamp
+	case Isthmus:
+		c.IsthmusTime = timestamp
+	case Holocene:
+		c.HoloceneTime = timestamp
+	case Granite:
+		c.GraniteTime = timestamp
+	case Fjord:
+		c.FjordTime = timestamp
+	case Ecotone:
+		c.EcotoneTime = timestamp
+	case Delta:
+		c.DeltaTime = timestamp
+	case Canyon:
+		c.CanyonTime = timestamp
+	case Regolith:
+		c.RegolithTime = timestamp
+	default:
+		panic(fmt.Sprintf("unknown fork: %v", fork))
+	}
+}
+
 // IsActivationBlock returns the fork which activates at the block with time newTime if the previous
-// block's time is oldTime. It return an empty ForkName if no fork activation takes place between
+// block's time is oldTime. It returns an empty ForkName if no fork activation takes place between
 // those timestamps. It can be used for both, L1 and L2 blocks.
 func (c *Config) IsActivationBlock(oldTime, newTime uint64) ForkName {
-	if c.IsInterop(newTime) && !c.IsInterop(oldTime) {
-		return Interop
-	}
-	if c.IsJovian(newTime) && !c.IsJovian(oldTime) {
-		return Jovian
-	}
-	if c.IsIsthmus(newTime) && !c.IsIsthmus(oldTime) {
-		return Isthmus
-	}
-	if c.IsHolocene(newTime) && !c.IsHolocene(oldTime) {
-		return Holocene
-	}
-	if c.IsGranite(newTime) && !c.IsGranite(oldTime) {
-		return Granite
-	}
-	if c.IsFjord(newTime) && !c.IsFjord(oldTime) {
-		return Fjord
-	}
-	if c.IsEcotone(newTime) && !c.IsEcotone(oldTime) {
-		return Ecotone
-	}
-	if c.IsDelta(newTime) && !c.IsDelta(oldTime) {
-		return Delta
-	}
-	if c.IsCanyon(newTime) && !c.IsCanyon(oldTime) {
-		return Canyon
+	for _, fork := range scheduleableForks {
+		if c.IsForkActive(fork, newTime) && !c.IsForkActive(fork, oldTime) {
+			return fork
+		}
 	}
 	return None
 }
 
-func (c *Config) IsActivationBlockForFork(l2BlockTime uint64, forkName ForkName) bool {
-	return c.IsActivationBlock(l2BlockTime-c.BlockTime, l2BlockTime) == forkName
+func (c *Config) IsActivationBlockForFork(l2BlockTime uint64, fork ForkName) bool {
+	return l2BlockTime >= c.BlockTime &&
+		!c.IsForkActive(fork, l2BlockTime-c.BlockTime) &&
+		c.IsForkActive(fork, l2BlockTime)
 }
 
+// ActivateAtGenesis updates the config to activate the given fork and all previous forks at genesis
+// and all later forks are disabled.
 func (c *Config) ActivateAtGenesis(hardfork ForkName) {
-	// IMPORTANT! ordered from newest to oldest
-	switch hardfork {
-	case Interop:
-		c.InteropTime = new(uint64)
-		fallthrough
-	case Jovian:
-		c.JovianTime = new(uint64)
-		fallthrough
-	case Isthmus:
-		c.IsthmusTime = new(uint64)
-		fallthrough
-	case Holocene:
-		c.HoloceneTime = new(uint64)
-		fallthrough
-	case Granite:
-		c.GraniteTime = new(uint64)
-		fallthrough
-	case Fjord:
-		c.FjordTime = new(uint64)
-		fallthrough
-	case Ecotone:
-		c.EcotoneTime = new(uint64)
-		fallthrough
-	case Delta:
-		c.DeltaTime = new(uint64)
-		fallthrough
-	case Canyon:
-		c.CanyonTime = new(uint64)
-		fallthrough
-	case Regolith:
-		c.RegolithTime = new(uint64)
-		fallthrough
-	case Bedrock:
-		// default
-	case None:
-		break
+	c.ActivateAt(hardfork, 0)
+}
+
+var scheduleableForks = ForksFrom(Regolith)
+
+// ActivateAt updates the config to activate the given fork at the given timestamp, all previous
+// forks at genesis, and all later forks are disabled.
+func (c *Config) ActivateAt(fork ForkName, timestamp uint64) {
+	if !IsValidFork(fork) {
+		panic(fmt.Sprintf("invalid fork: %s", fork))
+	}
+	ts := new(uint64)
+	// Special case: if only activating Bedrock, all scheduleable forks are disabled.
+	if fork == Bedrock {
+		ts = nil
+	}
+	for i, f := range scheduleableForks {
+		if f == fork {
+			c.SetActivationTime(fork, &timestamp)
+			ts = nil
+		} else {
+			c.SetActivationTime(scheduleableForks[i], ts)
+		}
 	}
 }
 

--- a/op-service/ptr/ptr.go
+++ b/op-service/ptr/ptr.go
@@ -3,6 +3,12 @@ package ptr
 
 import "fmt"
 
+var (
+	Zero16 = New[uint16](0)
+	Zero32 = New[uint32](0)
+	Zero64 = New[uint64](0)
+)
+
 func New[T any](v T) *T {
 	return &v
 }


### PR DESCRIPTION
**Description**

Adds Jovian to the list of forks (before, only Interop) that forbids non-empty batches at the activation block. If the Jovian activation batch contains transactions, it is now dropped.

Also add and improve modular fork handling for the rollup config, which simplified writing the test and adds helpers to more easily write modular tests that work for all forks in the future.

**Tests**

Unit tests added for batch validity checks.

Action/proofs test added to assert that activation batcher with transactions are dropped.

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

Fixes https://github.com/ethereum-optimism/optimism/issues/17704

Interesting historical context, this has already been implemented once at https://github.com/ethereum-optimism/optimism/pull/14797
