### PR TITLE
op-dispute-mon: log RPC URLs on startup

### DIFF
--- a/op-dispute-mon/cmd/main.go
+++ b/op-dispute-mon/cmd/main.go
@@ -56,6 +56,11 @@ func run(ctx context.Context, args []string, action ConfiguredLifecycle) error {
 		if err != nil {
 			return nil, err
 		}
+		logger.Info("RPC endpoints",
+			"l1", cfg.L1EthRpc,
+			"rollup", cfg.RollupRpcs,
+			"supervisor", cfg.SupervisorRpcs,
+		)
 		return action(ctx.Context, logger, cfg)
 	})
 	return app.RunContext(ctx, args)


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Log the URLs on startup to be sure that the multi-line yaml format in k8s config is resulting in correctly setting the `ROLLUP_RPC` env var.

**Tests**

No tests, just adding log statement.

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
