### PR TITLE
op-deployer: Add upgrade integration test for DEPLOY_V2_DISPUTE_GAME

### DIFF
--- a/packages/contracts-bedrock/scripts/deploy/UpgradeSuperchainConfig.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/UpgradeSuperchainConfig.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.15;
 
 import { Script } from "forge-std/Script.sol";
 import { IOPContractsManager } from "interfaces/L1/IOPContractsManager.sol";


### PR DESCRIPTION
Add tests that cover the op-deployer upgrade flow for the `DEPLOY_V2_DISPUTE_GAME` feature.

fixes https://github.com/ethereum-optimism/optimism/issues/17773