### PR TITLE
opcm: Restrict devFeatures on public testnets

### DIFF
--- a/packages/contracts-bedrock/scripts/deploy/VerifyOPCM.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/VerifyOPCM.s.sol
@@ -972,9 +972,29 @@ contract VerifyOPCM is Script {
         bool isTestingEnvironment = address(0xbeefcafe).code.length > 0;
 
         // Check if any dev features are enabled.
-        if (block.chainid == 1 && !isTestingEnvironment && devFeatureBitmap != bytes32(0)) {
+        if (_isProductionChain(block.chainid) && !isTestingEnvironment && devFeatureBitmap != bytes32(0)) {
             revert VerifyOPCM_DevFeatureBitmapNotEmpty();
         }
+    }
+
+    function _isProductionChain(uint256 _chainId) internal pure returns (bool) {
+        if (_chainId == 1) {
+            // Mainnet
+            return true;
+        }
+        if (_chainId == 11155111) {
+            // Sepolia
+            return true;
+        }
+        if (_chainId == 17000) {
+            // Holesky
+            return true;
+        }
+        if (_chainId == 560048) {
+            // Hoodi
+            return true;
+        }
+        return false;
     }
 
     /// @notice Validates that all getter functions in the OPContractsManager ABI are accounted for

--- a/packages/contracts-bedrock/test/scripts/VerifyOPCM.t.sol
+++ b/packages/contracts-bedrock/test/scripts/VerifyOPCM.t.sol
@@ -109,7 +109,7 @@ contract VerifyOPCM_Run_Test is VerifyOPCM_TestInit {
         }
     }
 
-    function test_run_bitmapNotEmptyOnMainnet_reverts(bytes32 _devFeatureBitmap) public {
+    function testFuzz_run_bitmapNotEmptyOnMainnet_reverts(bytes32 _devFeatureBitmap, uint256 chainIdIdx) public {
         // Coverage changes bytecode and causes failures, skip.
         skipIfCoverage();
 
@@ -121,8 +121,11 @@ contract VerifyOPCM_Run_Test is VerifyOPCM_TestInit {
             address(opcm), abi.encodeCall(IOPContractsManager.devFeatureBitmap, ()), abi.encode(_devFeatureBitmap)
         );
 
-        // Set the chain ID to 1.
-        vm.chainId(1);
+        // Set to production chain id
+        uint256[4] memory productionChainIds = [uint256(1), uint256(11155111), uint256(17000), uint256(560048)];
+        chainIdIdx = chainIdIdx % productionChainIds.length;
+        uint256 chainId = productionChainIds[chainIdIdx];
+        vm.chainId(chainId);
 
         // Disable testing environment.
         vm.etch(address(0xbeefcafe), bytes(""));


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Restrict devFeatures on public testnets as well as mainnet.

**Tests**

Existing test updated.

