### PR TITLE
devstack: Enable individual dev features instead of replacing the whole bitmap

### DIFF
--- a/op-deployer/pkg/deployer/devfeatures.go
+++ b/op-deployer/pkg/deployer/devfeatures.go
@@ -30,3 +30,11 @@ func IsDevFeatureEnabled(bitmap, flag common.Hash) bool {
 	bitmapContainsFeatures := new(big.Int).And(b, f).Cmp(f) == 0
 	return featuresIsNonZero && bitmapContainsFeatures
 }
+
+func EnableDevFeature(bitmap, flag common.Hash) common.Hash {
+	var result common.Hash
+	for i := 0; i < 32; i++ {
+		result[i] = bitmap[i] | flag[i]
+	}
+	return result
+}

--- a/op-devstack/presets/disputegame_v2.go
+++ b/op-devstack/presets/disputegame_v2.go
@@ -7,5 +7,5 @@ import (
 )
 
 func WithDisputeGameV2() stack.CommonOption {
-	return stack.MakeCommon(sysgo.WithDeployerOptions(sysgo.WithDevFeatureBitmap(deployer.DeployV2DisputeGamesDevFlag)))
+	return stack.MakeCommon(sysgo.WithDeployerOptions(sysgo.WithDevFeatureEnabled(deployer.DeployV2DisputeGamesDevFlag)))
 }

--- a/op-devstack/sysgo/deployer.go
+++ b/op-devstack/sysgo/deployer.go
@@ -28,6 +28,7 @@ import (
 
 // funderMnemonicIndex the funding account is not one of the 30 standard account, but still derived from a user-key.
 const funderMnemonicIndex = 10_000
+const devFeatureBitmapKey = "devFeatureBitmap"
 
 type DeployerOption func(p devtest.P, keys devkeys.Keys, builder intentbuilder.Builder)
 
@@ -274,10 +275,15 @@ func WithPrefundedL2(l1ChainID, l2ChainID eth.ChainID) DeployerOption {
 	}
 }
 
-// WithDevFeatureBitmap sets the dev feature bitmap.
-func WithDevFeatureBitmap(devFlags common.Hash) DeployerOption {
+// WithDevFeatureEnabled adds a feature as enabled in the dev feature bitmap
+func WithDevFeatureEnabled(flag common.Hash) DeployerOption {
 	return func(p devtest.P, keys devkeys.Keys, builder intentbuilder.Builder) {
-		builder.WithGlobalOverride("devFeatureBitmap", devFlags)
+		currentValue := builder.GlobalOverride(devFeatureBitmapKey)
+		var bitmap common.Hash
+		if currentValue != nil {
+			bitmap = currentValue.(common.Hash)
+		}
+		builder.WithGlobalOverride(devFeatureBitmapKey, deployer.EnableDevFeature(bitmap, flag))
 	}
 }
 

--- a/op-devstack/sysgo/system.go
+++ b/op-devstack/sysgo/system.go
@@ -459,7 +459,7 @@ func defaultSuperProofsSystem(dest *DefaultInteropSystemIDs, deployerOpts ...Dep
 			WithCommons(ids.L1.ChainID()),
 			WithPrefundedL2(ids.L1.ChainID(), ids.L2A.ChainID()),
 			WithPrefundedL2(ids.L1.ChainID(), ids.L2B.ChainID()),
-			WithDevFeatureBitmap(deployer.OptimismPortalInteropDevFlag),
+			WithDevFeatureEnabled(deployer.OptimismPortalInteropDevFlag),
 		}, deployerOpts...)...))
 
 	opt.Add(WithL1Nodes(ids.L1EL, ids.L1CL))

--- a/op-e2e/e2eutils/intentbuilder/builder.go
+++ b/op-e2e/e2eutils/intentbuilder/builder.go
@@ -106,6 +106,7 @@ type Builder interface {
 	Build() (*state.Intent, error)
 
 	WithGlobalOverride(key string, value any) Builder
+	GlobalOverride(key string) any
 }
 
 func WithDevkeyVaults(t require.TestingT, dk devkeys.Keys, configurator L2Configurator) {
@@ -221,6 +222,10 @@ func (b *intentBuilder) WithGlobalOverride(key string, value any) Builder {
 	}
 	b.intent.GlobalDeployOverrides[key] = value
 	return b
+}
+
+func (b *intentBuilder) GlobalOverride(key string) any {
+	return b.intent.GlobalDeployOverrides[key]
 }
 
 func (b *intentBuilder) Build() (*state.Intent, error) {


### PR DESCRIPTION
**Description**


Allows things to be combined easily and avoids the risk of features being left disabled because they were later overwritten.
