### PR TITLE
Move state changes to checkTransaction

### DIFF
--- a/packages/contracts-bedrock/snapshots/abi/SaferSafes.json
+++ b/packages/contracts-bedrock/snapshots/abi/SaferSafes.json
@@ -169,7 +169,7 @@
     ],
     "name": "checkTransaction",
     "outputs": [],
-    "stateMutability": "view",
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -208,8 +208,8 @@
     "sourceCodeHash": "0x7fc4789b082bc8ecd29c4c75a06058f0ff0b72f1c1028a42db6f1c35269c8865"
   },
   "src/safe/SaferSafes.sol:SaferSafes": {
-    "initCodeHash": "0xe8ff14ba3d023064046251967c3f4d0eb7bc3c2eee6519523f1175b37c0f9ac9",
-    "sourceCodeHash": "0x046424a35624e13badd3d3f91993c27d4d6058b4696cba8bdda27b09bc972785"
+    "initCodeHash": "0x6e47950b34cc45b226ee9b9e07bfd7e311d174896836ec32da7d465216df4df8",
+    "sourceCodeHash": "0x4fbf7d6805b1c59e6b04a1de922992920dd906658f07a36988ede147811f83f2"
   },
   "src/universal/OptimismMintableERC20.sol:OptimismMintableERC20": {
     "initCodeHash": "0x3c85eed0d017dca8eda6396aa842ddc12492587b061e8c756a8d32c4610a9658",

--- a/packages/contracts-bedrock/src/safe/SaferSafes.sol
+++ b/packages/contracts-bedrock/src/safe/SaferSafes.sol
@@ -25,8 +25,8 @@ import { ISemver } from "interfaces/universal/ISemver.sol";
 ///      desired, then there is no need to enable or configure it.
 contract SaferSafes is LivenessModule2, TimelockGuard, ISemver {
     /// @notice Semantic version.
-    /// @custom:semver 1.5.2
-    string public constant version = "1.5.2";
+    /// @custom:semver 1.6.0
+    string public constant version = "1.6.0";
 
     /// @notice Error for when the liveness response period is insufficient.
     error SaferSafes_InsufficientLivenessResponsePeriod();

--- a/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
+++ b/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
@@ -699,12 +699,12 @@ contract TimelockGuard_CheckTransaction_Test is TimelockGuard_TestInit {
     /// @notice Test that checkTransaction treats failed transactions the same as successful ones
     function test_checkTransaction_failedTransaction_succeeds() external {
         // Build a transaction that will revert (call a contract that always reverts)
-        TransactionBuilder.Transaction memory failingTx = _createEmptyTransaction(safeInstance);
+        TransactionBuilder.Transaction memory dummyTx = _createEmptyTransaction(safeInstance);
         Reverter reverter = new Reverter();
-        failingTx.params.to = address(reverter);
+        dummyTx.params.to = address(reverter);
         // empty data triggers fallback, which reverts
-        failingTx.updateTransaction();
-        failingTx.scheduleTransaction(timelockGuard);
+        dummyTx.updateTransaction();
+        dummyTx.scheduleTransaction(timelockGuard);
 
         // Advance time past timelock delay
         uint256 expectedExecutionTime = block.timestamp + TIMELOCK_DELAY;
@@ -719,27 +719,27 @@ contract TimelockGuard_CheckTransaction_Test is TimelockGuard_TestInit {
 
         // Expect TransactionExecuted event when the guard confirms execution in checkTransaction
         vm.expectEmit(true, true, true, true);
-        emit TransactionExecuted(safeInstance.safe, failingTx.hash);
+        emit TransactionExecuted(safeInstance.safe, dummyTx.hash);
 
         // Call checkTransaction as if from the Safe, with an owner as msgSender
         vm.prank(address(safeInstance.safe));
         timelockGuard.checkTransaction(
-            failingTx.params.to,
-            failingTx.params.value,
-            failingTx.params.data,
-            failingTx.params.operation,
-            failingTx.params.safeTxGas,
-            failingTx.params.baseGas,
-            failingTx.params.gasPrice,
-            failingTx.params.gasToken,
-            failingTx.params.refundReceiver,
+            dummyTx.params.to,
+            dummyTx.params.value,
+            dummyTx.params.data,
+            dummyTx.params.operation,
+            dummyTx.params.safeTxGas,
+            dummyTx.params.baseGas,
+            dummyTx.params.gasPrice,
+            dummyTx.params.gasToken,
+            dummyTx.params.refundReceiver,
             "",
             safeInstance.owners[0]
         );
 
         // State should reflect execution, even if the transaction failed
         TimelockGuard.ScheduledTransaction memory scheduledTx =
-            timelockGuard.scheduledTransaction(safeInstance.safe, failingTx.hash);
+            timelockGuard.scheduledTransaction(safeInstance.safe, dummyTx.hash);
         assertEq(uint256(scheduledTx.state), uint256(TimelockGuard.TransactionState.Executed));
         TimelockGuard.ScheduledTransaction[] memory pending = timelockGuard.pendingTransactions(safe);
         assertEq(pending.length, 0);
@@ -755,20 +755,20 @@ contract TimelockGuard_CheckTransaction_Test is TimelockGuard_TestInit {
         assertEq(timelockGuard.timelockDelay(unguardedSafe.safe), 0);
 
         // Build a dummy tx for the unconfigured Safe
-        TransactionBuilder.Transaction memory txUnconfigured = _createDummyTransaction(unguardedSafe);
+        TransactionBuilder.Transaction memory dummyTx = _createDummyTransaction(unguardedSafe);
 
         // Should not revert: guard returns early when timelock delay is zero
         vm.prank(address(unguardedSafe.safe));
         timelockGuard.checkTransaction(
-            txUnconfigured.params.to,
-            txUnconfigured.params.value,
-            txUnconfigured.params.data,
-            txUnconfigured.params.operation,
-            txUnconfigured.params.safeTxGas,
-            txUnconfigured.params.baseGas,
-            txUnconfigured.params.gasPrice,
-            txUnconfigured.params.gasToken,
-            txUnconfigured.params.refundReceiver,
+            dummyTx.params.to,
+            dummyTx.params.value,
+            dummyTx.params.data,
+            dummyTx.params.operation,
+            dummyTx.params.safeTxGas,
+            dummyTx.params.baseGas,
+            dummyTx.params.gasPrice,
+            dummyTx.params.gasToken,
+            dummyTx.params.refundReceiver,
             "",
             unguardedSafe.owners[0]
         );
@@ -867,75 +867,6 @@ contract TimelockGuard_CheckTransaction_Test is TimelockGuard_TestInit {
         dummyTx.executeTransaction(nonOwner);
     }
 }
-
-/// @title TimelockGuard_CheckAfterExecution_Test
-/// @notice Tests for checkAfterExecution function
-// contract TimelockGuard_CheckAfterExecution_Test is TimelockGuard_TestInit {
-//     function setUp() public override {
-//         super.setUp();
-//         _configureGuard(safeInstance, TIMELOCK_DELAY);
-//     }
-//
-//     /// @notice Verifies successful execution updates state and resets threshold.
-//     function test_checkAfterExecution_successfulExecution_succeeds() external {
-//         TransactionBuilder.Transaction memory dummyTx = _createDummyTransaction(safeInstance);
-//         dummyTx.scheduleTransaction(timelockGuard);
-//
-//         uint256 expectedExecutionTime = block.timestamp + TIMELOCK_DELAY;
-//         vm.warp(expectedExecutionTime);
-//
-//         // Verify initial cancellation threshold
-//         uint256 initialThreshold = timelockGuard.cancellationThreshold(safeInstance.safe);
-//         assertEq(initialThreshold, 1);
-//
-//         // Call checkAfterExecution with successful execution
-//         vm.expectEmit(true, true, true, true);
-//         emit TransactionExecuted(safeInstance.safe, dummyTx.hash);
-//         vm.prank(address(safeInstance.safe));
-//         timelockGuard.checkAfterExecution(dummyTx.hash, true);
-//
-//         // Verify transaction state changed to Executed
-//         TimelockGuard.ScheduledTransaction memory scheduledTx =
-//             timelockGuard.scheduledTransaction(safeInstance.safe, dummyTx.hash);
-//         assertEq(uint256(scheduledTx.state), uint256(TimelockGuard.TransactionState.Executed));
-//
-//         // Verify transaction removed from pending list
-//         TimelockGuard.ScheduledTransaction[] memory pending = timelockGuard.pendingTransactions(safeInstance.safe);
-//         assertEq(pending.length, 0);
-//
-//         // Verify cancellation threshold was reset to 1
-//         assertEq(timelockGuard.cancellationThreshold(safeInstance.safe), 1);
-//
-//         // Verify transaction cannot be executed again
-//         vm.expectRevert(TimelockGuard.TimelockGuard_TransactionAlreadyExecuted.selector);
-//         dummyTx.executeTransaction(safeInstance.owners[0]);
-//     }
-//
-//     /// @notice Verifies transaction state remains unchanged on execution failure.
-//     function test_checkAfterExecution_failedExecution_succeeds() external {
-//         TransactionBuilder.Transaction memory dummyTx = _createDummyTransaction(safeInstance);
-//         dummyTx.scheduleTransaction(timelockGuard);
-//
-//         uint256 expectedExecutionTime = block.timestamp + TIMELOCK_DELAY;
-//         vm.warp(expectedExecutionTime);
-//
-//         // Call checkAfterExecution with failed execution
-//         vm.prank(address(safeInstance.safe));
-//         timelockGuard.checkAfterExecution(dummyTx.hash, false);
-//
-//         // Verify transaction state remains unchanged
-//         TimelockGuard.ScheduledTransaction memory scheduledTx =
-//             timelockGuard.scheduledTransaction(safeInstance.safe, dummyTx.hash);
-//         assertEq(uint256(scheduledTx.state), uint256(TimelockGuard.TransactionState.Pending));
-//         assertEq(uint256(scheduledTx.executionTime), expectedExecutionTime);
-//     }
-//
-//     /// @notice Fuzz test: Verifies unconfigured guard allows checkAfterExecution for any _hash.
-//     function testFuzz_checkAfterExecution_unconfiguredGuard_succeeds(bytes32 _hash) external {
-//         vm.prank(address(unguardedSafe.safe));
-//         timelockGuard.checkAfterExecution(_hash, true);
-//     }
-// }
 
 /// @title TimelockGuard_MaxCancellationThreshold_Test
 /// @notice Tests for the maxCancellationThreshold function in TimelockGuard

--- a/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
+++ b/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
@@ -6,6 +6,7 @@ import { Safe } from "safe-contracts/Safe.sol";
 import { GuardManager } from "safe-contracts/base/GuardManager.sol";
 import { ITransactionGuard } from "interfaces/safe/ITransactionGuard.sol";
 import "test/safe-tools/SafeTestTools.sol";
+import { Reverter } from "test/mocks/Callers.sol";
 
 import { TimelockGuard } from "src/safe/TimelockGuard.sol";
 import { SaferSafes } from "src/safe/SaferSafes.sol";
@@ -145,7 +146,9 @@ library TransactionBuilder {
 /// @title TimelockGuard_TestInit
 /// @notice Reusable test initialization for `TimelockGuard` tests.
 abstract contract TimelockGuard_TestInit is Test, SafeTestTools {
+    using stdStorage for StdStorage;
     // Events
+
     event GuardConfigured(Safe indexed safe, uint256 timelockDelay);
     event TransactionScheduled(Safe indexed safe, bytes32 indexed txId, uint256 when);
     event TransactionCancelled(Safe indexed safe, bytes32 indexed txId);
@@ -186,6 +189,16 @@ abstract contract TimelockGuard_TestInit is Test, SafeTestTools {
 
         // Enable the guard on the Safe
         _enableGuard(safeInstance);
+    }
+
+    /// @notice Set the cancellation threshold storage for a given Safe on the TimelockGuard.
+    /// @param _safe The Safe for which to override the threshold.
+    /// @param _value The threshold value to set.
+    function _setCancellationThreshold(Safe _safe, uint256 _value) internal {
+        uint256 slot = stdstore.target(address(timelockGuard)).sig("cancellationThreshold(address)").with_key(
+            address(_safe)
+        ).find();
+        vm.store(address(timelockGuard), bytes32(slot), bytes32(uint256(_value)));
     }
 
     /// @notice Deploys a Safe with the given owners and threshold
@@ -635,6 +648,132 @@ contract TimelockGuard_CheckTransaction_Test is TimelockGuard_TestInit {
         _configureGuard(safeInstance, TIMELOCK_DELAY);
     }
 
+    /// @notice Test that checkTransaction updates state for successful transactions
+    function test_checkTransaction_successfulTransaction_succeeds() external {
+        // Schedule a transaction
+        TransactionBuilder.Transaction memory dummyTx = _createDummyTransaction(safeInstance);
+        dummyTx.scheduleTransaction(timelockGuard);
+
+        // Advance time past timelock delay
+        uint256 expectedExecutionTime = block.timestamp + TIMELOCK_DELAY;
+        vm.warp(expectedExecutionTime);
+
+        // Increment the Safe nonce to mimic pre-exec state (Safe increments before calling guard)
+        vm.store(address(safeInstance.safe), bytes32(uint256(5)), bytes32(uint256(safeInstance.safe.nonce() + 1)));
+
+        // Bump initial cancellation threshold to 2 to validate reset behavior
+        _setCancellationThreshold(safeInstance.safe, 2);
+        assertEq(timelockGuard.cancellationThreshold(safeInstance.safe), 2);
+
+        // Expect TransactionExecuted event when the guard confirms execution in checkTransaction
+        vm.expectEmit(true, true, true, true);
+        emit TransactionExecuted(safeInstance.safe, dummyTx.hash);
+
+        // Call checkTransaction as if from the Safe, with an owner as msgSender
+        vm.prank(address(safeInstance.safe));
+        timelockGuard.checkTransaction(
+            dummyTx.params.to,
+            dummyTx.params.value,
+            dummyTx.params.data,
+            dummyTx.params.operation,
+            dummyTx.params.safeTxGas,
+            dummyTx.params.baseGas,
+            dummyTx.params.gasPrice,
+            dummyTx.params.gasToken,
+            dummyTx.params.refundReceiver,
+            "",
+            safeInstance.owners[0]
+        );
+
+        // State should reflect execution
+        TimelockGuard.ScheduledTransaction memory scheduledTx =
+            timelockGuard.scheduledTransaction(safeInstance.safe, dummyTx.hash);
+        assertEq(uint256(scheduledTx.state), uint256(TimelockGuard.TransactionState.Executed));
+        TimelockGuard.ScheduledTransaction[] memory pending = timelockGuard.pendingTransactions(safe);
+        assertEq(pending.length, 0);
+
+        // Cancellation threshold should be reset to 1
+        assertEq(timelockGuard.cancellationThreshold(safeInstance.safe), 1);
+    }
+
+    /// @notice Test that checkTransaction treats failed transactions the same as successful ones
+    function test_checkTransaction_failedTransaction_succeeds() external {
+        // Build a transaction that will revert (call a contract that always reverts)
+        TransactionBuilder.Transaction memory failingTx = _createEmptyTransaction(safeInstance);
+        Reverter reverter = new Reverter();
+        failingTx.params.to = address(reverter);
+        // empty data triggers fallback, which reverts
+        failingTx.updateTransaction();
+        failingTx.scheduleTransaction(timelockGuard);
+
+        // Advance time past timelock delay
+        uint256 expectedExecutionTime = block.timestamp + TIMELOCK_DELAY;
+        vm.warp(expectedExecutionTime);
+
+        // Increment the Safe nonce to mimic pre-exec state (Safe increments before calling guard)
+        vm.store(address(safeInstance.safe), bytes32(uint256(5)), bytes32(uint256(safeInstance.safe.nonce() + 1)));
+
+        // Bump initial cancellation threshold to 2 to validate reset behavior
+        _setCancellationThreshold(safeInstance.safe, 2);
+        assertEq(timelockGuard.cancellationThreshold(safeInstance.safe), 2);
+
+        // Expect TransactionExecuted event when the guard confirms execution in checkTransaction
+        vm.expectEmit(true, true, true, true);
+        emit TransactionExecuted(safeInstance.safe, failingTx.hash);
+
+        // Call checkTransaction as if from the Safe, with an owner as msgSender
+        vm.prank(address(safeInstance.safe));
+        timelockGuard.checkTransaction(
+            failingTx.params.to,
+            failingTx.params.value,
+            failingTx.params.data,
+            failingTx.params.operation,
+            failingTx.params.safeTxGas,
+            failingTx.params.baseGas,
+            failingTx.params.gasPrice,
+            failingTx.params.gasToken,
+            failingTx.params.refundReceiver,
+            "",
+            safeInstance.owners[0]
+        );
+
+        // State should reflect execution, even if the transaction failed
+        TimelockGuard.ScheduledTransaction memory scheduledTx =
+            timelockGuard.scheduledTransaction(safeInstance.safe, failingTx.hash);
+        assertEq(uint256(scheduledTx.state), uint256(TimelockGuard.TransactionState.Executed));
+        TimelockGuard.ScheduledTransaction[] memory pending = timelockGuard.pendingTransactions(safe);
+        assertEq(pending.length, 0);
+
+        // Cancellation threshold should be reset to 1
+        assertEq(timelockGuard.cancellationThreshold(safeInstance.safe), 1);
+    }
+
+    /// @notice Ensures checkTransaction returns early and does not revert when guard is enabled but unconfigured
+    function test_checkTransaction_unconfiguredGuard_succeeds() external {
+        // Enable guard on an otherwise unconfigured Safe
+        _enableGuard(unguardedSafe);
+        assertEq(timelockGuard.timelockDelay(unguardedSafe.safe), 0);
+
+        // Build a dummy tx for the unconfigured Safe
+        TransactionBuilder.Transaction memory txUnconfigured = _createDummyTransaction(unguardedSafe);
+
+        // Should not revert: guard returns early when timelock delay is zero
+        vm.prank(address(unguardedSafe.safe));
+        timelockGuard.checkTransaction(
+            txUnconfigured.params.to,
+            txUnconfigured.params.value,
+            txUnconfigured.params.data,
+            txUnconfigured.params.operation,
+            txUnconfigured.params.safeTxGas,
+            txUnconfigured.params.baseGas,
+            txUnconfigured.params.gasPrice,
+            txUnconfigured.params.gasToken,
+            txUnconfigured.params.refundReceiver,
+            "",
+            unguardedSafe.owners[0]
+        );
+    }
+
     /// @notice Test that checkTransaction reverts when scheduled transaction delay hasn't passed
     function test_checkTransaction_scheduledTransactionNotReady_reverts() external {
         TransactionBuilder.Transaction memory dummyTx = _createDummyTransaction(safeInstance);
@@ -731,72 +870,72 @@ contract TimelockGuard_CheckTransaction_Test is TimelockGuard_TestInit {
 
 /// @title TimelockGuard_CheckAfterExecution_Test
 /// @notice Tests for checkAfterExecution function
-contract TimelockGuard_CheckAfterExecution_Test is TimelockGuard_TestInit {
-    function setUp() public override {
-        super.setUp();
-        _configureGuard(safeInstance, TIMELOCK_DELAY);
-    }
-
-    /// @notice Verifies successful execution updates state and resets threshold.
-    function test_checkAfterExecution_successfulExecution_succeeds() external {
-        TransactionBuilder.Transaction memory dummyTx = _createDummyTransaction(safeInstance);
-        dummyTx.scheduleTransaction(timelockGuard);
-
-        uint256 expectedExecutionTime = block.timestamp + TIMELOCK_DELAY;
-        vm.warp(expectedExecutionTime);
-
-        // Verify initial cancellation threshold
-        uint256 initialThreshold = timelockGuard.cancellationThreshold(safeInstance.safe);
-        assertEq(initialThreshold, 1);
-
-        // Call checkAfterExecution with successful execution
-        vm.expectEmit(true, true, true, true);
-        emit TransactionExecuted(safeInstance.safe, dummyTx.hash);
-        vm.prank(address(safeInstance.safe));
-        timelockGuard.checkAfterExecution(dummyTx.hash, true);
-
-        // Verify transaction state changed to Executed
-        TimelockGuard.ScheduledTransaction memory scheduledTx =
-            timelockGuard.scheduledTransaction(safeInstance.safe, dummyTx.hash);
-        assertEq(uint256(scheduledTx.state), uint256(TimelockGuard.TransactionState.Executed));
-
-        // Verify transaction removed from pending list
-        TimelockGuard.ScheduledTransaction[] memory pending = timelockGuard.pendingTransactions(safeInstance.safe);
-        assertEq(pending.length, 0);
-
-        // Verify cancellation threshold was reset to 1
-        assertEq(timelockGuard.cancellationThreshold(safeInstance.safe), 1);
-
-        // Verify transaction cannot be executed again
-        vm.expectRevert(TimelockGuard.TimelockGuard_TransactionAlreadyExecuted.selector);
-        dummyTx.executeTransaction(safeInstance.owners[0]);
-    }
-
-    /// @notice Verifies transaction state remains unchanged on execution failure.
-    function test_checkAfterExecution_failedExecution_succeeds() external {
-        TransactionBuilder.Transaction memory dummyTx = _createDummyTransaction(safeInstance);
-        dummyTx.scheduleTransaction(timelockGuard);
-
-        uint256 expectedExecutionTime = block.timestamp + TIMELOCK_DELAY;
-        vm.warp(expectedExecutionTime);
-
-        // Call checkAfterExecution with failed execution
-        vm.prank(address(safeInstance.safe));
-        timelockGuard.checkAfterExecution(dummyTx.hash, false);
-
-        // Verify transaction state remains unchanged
-        TimelockGuard.ScheduledTransaction memory scheduledTx =
-            timelockGuard.scheduledTransaction(safeInstance.safe, dummyTx.hash);
-        assertEq(uint256(scheduledTx.state), uint256(TimelockGuard.TransactionState.Pending));
-        assertEq(uint256(scheduledTx.executionTime), expectedExecutionTime);
-    }
-
-    /// @notice Fuzz test: Verifies unconfigured guard allows checkAfterExecution for any _hash.
-    function testFuzz_checkAfterExecution_unconfiguredGuard_succeeds(bytes32 _hash) external {
-        vm.prank(address(unguardedSafe.safe));
-        timelockGuard.checkAfterExecution(_hash, true);
-    }
-}
+// contract TimelockGuard_CheckAfterExecution_Test is TimelockGuard_TestInit {
+//     function setUp() public override {
+//         super.setUp();
+//         _configureGuard(safeInstance, TIMELOCK_DELAY);
+//     }
+//
+//     /// @notice Verifies successful execution updates state and resets threshold.
+//     function test_checkAfterExecution_successfulExecution_succeeds() external {
+//         TransactionBuilder.Transaction memory dummyTx = _createDummyTransaction(safeInstance);
+//         dummyTx.scheduleTransaction(timelockGuard);
+//
+//         uint256 expectedExecutionTime = block.timestamp + TIMELOCK_DELAY;
+//         vm.warp(expectedExecutionTime);
+//
+//         // Verify initial cancellation threshold
+//         uint256 initialThreshold = timelockGuard.cancellationThreshold(safeInstance.safe);
+//         assertEq(initialThreshold, 1);
+//
+//         // Call checkAfterExecution with successful execution
+//         vm.expectEmit(true, true, true, true);
+//         emit TransactionExecuted(safeInstance.safe, dummyTx.hash);
+//         vm.prank(address(safeInstance.safe));
+//         timelockGuard.checkAfterExecution(dummyTx.hash, true);
+//
+//         // Verify transaction state changed to Executed
+//         TimelockGuard.ScheduledTransaction memory scheduledTx =
+//             timelockGuard.scheduledTransaction(safeInstance.safe, dummyTx.hash);
+//         assertEq(uint256(scheduledTx.state), uint256(TimelockGuard.TransactionState.Executed));
+//
+//         // Verify transaction removed from pending list
+//         TimelockGuard.ScheduledTransaction[] memory pending = timelockGuard.pendingTransactions(safeInstance.safe);
+//         assertEq(pending.length, 0);
+//
+//         // Verify cancellation threshold was reset to 1
+//         assertEq(timelockGuard.cancellationThreshold(safeInstance.safe), 1);
+//
+//         // Verify transaction cannot be executed again
+//         vm.expectRevert(TimelockGuard.TimelockGuard_TransactionAlreadyExecuted.selector);
+//         dummyTx.executeTransaction(safeInstance.owners[0]);
+//     }
+//
+//     /// @notice Verifies transaction state remains unchanged on execution failure.
+//     function test_checkAfterExecution_failedExecution_succeeds() external {
+//         TransactionBuilder.Transaction memory dummyTx = _createDummyTransaction(safeInstance);
+//         dummyTx.scheduleTransaction(timelockGuard);
+//
+//         uint256 expectedExecutionTime = block.timestamp + TIMELOCK_DELAY;
+//         vm.warp(expectedExecutionTime);
+//
+//         // Call checkAfterExecution with failed execution
+//         vm.prank(address(safeInstance.safe));
+//         timelockGuard.checkAfterExecution(dummyTx.hash, false);
+//
+//         // Verify transaction state remains unchanged
+//         TimelockGuard.ScheduledTransaction memory scheduledTx =
+//             timelockGuard.scheduledTransaction(safeInstance.safe, dummyTx.hash);
+//         assertEq(uint256(scheduledTx.state), uint256(TimelockGuard.TransactionState.Pending));
+//         assertEq(uint256(scheduledTx.executionTime), expectedExecutionTime);
+//     }
+//
+//     /// @notice Fuzz test: Verifies unconfigured guard allows checkAfterExecution for any _hash.
+//     function testFuzz_checkAfterExecution_unconfiguredGuard_succeeds(bytes32 _hash) external {
+//         vm.prank(address(unguardedSafe.safe));
+//         timelockGuard.checkAfterExecution(_hash, true);
+//     }
+// }
 
 /// @title TimelockGuard_MaxCancellationThreshold_Test
 /// @notice Tests for the maxCancellationThreshold function in TimelockGuard


### PR DESCRIPTION
The state changes in `checkAfterExecution` break the CEI pattern and introduces unneeded complexity. Moving them to `checkTransaction` achieves the same end.
