### PR TITLE
SaferSafes: Fix version checks

### DIFF
--- a/op-acceptance-tests/scripts/ci_flake_shake_prepare_slack.sh
+++ b/op-acceptance-tests/scripts/ci_flake_shake_prepare_slack.sh
@@ -49,18 +49,10 @@ if [ -f "$PROMO_JSON" ]; then
     fi
   fi
 
-  # Ensure URL points to the artifacts page of the report job
-  REPORT_ARTIFACTS_URL="$REPORT_JOB_URL"
-  if [ -n "$REPORT_ARTIFACTS_URL" ]; then
-    if ! printf '%s' "$REPORT_ARTIFACTS_URL" | grep -q '/artifacts\($\|[?#]\)'; then
-      REPORT_ARTIFACTS_URL="${REPORT_ARTIFACTS_URL%/}/artifacts"
-    fi
-  fi
-
   # Build Block Kit blocks (header + link + divider + per-candidate sections)
   # See: https://docs.slack.dev/block-kit
   SLACK_BLOCKS=$(jq -c \
-    --arg url "${REPORT_ARTIFACTS_URL}" \
+    --arg url "${REPORT_JOB_URL}" \
     --arg job "${REPORT_JOB_URL}" \
     --slurpfile meta "${PROMO_JSON%/*}/metadata.json" '
     def name_or_pkg(t): (if ((t.test_name|tostring)|length) == 0 then "(package)" else t.test_name end);
@@ -103,7 +95,7 @@ if [ -f "$PROMO_JSON" ]; then
         (
           [
             {"type":"header","text":{"type":"plain_text","text":":partywizard: Acceptance Tests: Flake-Shake Promotion Candidates (\($root.candidates|length)) — \(if $date != "" then $date else (now|strftime("%Y-%m-%d")) end)"}},
-            {"type":"section","text":{"type":"mrkdwn","text": (if $pr_url != "" then "PR: <\($pr_url)|Open PR>  •  Artifacts: <\($url)|CircleCI Job>" else "Artifacts: <\($url)|CircleCI Job>" end) }},
+            {"type":"section","text":{"type":"mrkdwn","text": (if $pr_url != "" then "<\($pr_url)|Pull Request>  •  <\($url)|CircleCI Job>" else "Artifacts: <\($url)|CircleCI Job>" end) }},
             {"type":"divider"}
           ]
         )

--- a/op-acceptance-tests/tests/sync_tester/sync_tester_hfs_ext/sync_tester_hfs_ext_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_tester_hfs_ext/sync_tester_hfs_ext_test.go
@@ -249,7 +249,7 @@ func hfsExt(gt *testing.T, upgradeName rollup.ForkName, l2CLSyncMode sync.Mode) 
 	}
 	require := t.Require()
 
-	ft := sys.L2.Escape().RollupConfig().ActivationTimeFor(upgradeName)
+	ft := sys.L2.Escape().RollupConfig().ActivationTime(upgradeName)
 	var l2CLSyncStatus *eth.SyncStatus
 	attempts := 1000
 	if l2CLSyncMode == sync.ELSync {

--- a/op-devstack/dsl/l2_network.go
+++ b/op-devstack/dsl/l2_network.go
@@ -231,7 +231,7 @@ func (n *L2Network) AwaitActivation(t devtest.T, forkName rollup.ForkName) eth.B
 	el := n.Escape().L2ELNode(match.FirstL2EL)
 
 	rollupCfg := n.Escape().RollupConfig()
-	maybeActivationTime := rollupCfg.ActivationTimeFor(forkName)
+	maybeActivationTime := rollupCfg.ActivationTime(forkName)
 	require.NotNil(maybeActivationTime, "Required fork is not scheduled for activation")
 	activationTime := *maybeActivationTime
 	if activationTime == 0 {

--- a/op-e2e/actions/helpers/user.go
+++ b/op-e2e/actions/helpers/user.go
@@ -285,7 +285,7 @@ func (s *BasicUser[B]) MakeTransaction(t Testing) *types.Transaction {
 
 // ActMakeTx makes a tx with the predetermined contents (see randomization and other actions)
 // and sends it to the tx pool
-func (s *BasicUser[B]) ActMakeTx(t Testing) {
+func (s *BasicUser[B]) ActMakeTx(t Testing) *types.Transaction {
 	t.Helper()
 	tx := s.MakeTransaction(t)
 	err := s.env.EthCl.SendTransaction(t.Ctx(), tx)
@@ -293,6 +293,7 @@ func (s *BasicUser[B]) ActMakeTx(t Testing) {
 	s.lastTxHash = tx.Hash()
 	// reset the calldata
 	s.txCallData = []byte{}
+	return tx
 }
 
 func (s *BasicUser[B]) ActCheckReceiptStatusOfLastTx(success bool) func(t Testing) {

--- a/op-e2e/actions/proofs/activation_block_test.go
+++ b/op-e2e/actions/proofs/activation_block_test.go
@@ -1,0 +1,102 @@
+package proofs
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
+	actionsHelpers "github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
+	"github.com/ethereum-optimism/optimism/op-e2e/actions/proofs/helpers"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+type activationBlockTestCfg struct {
+	fork          rollup.ForkName
+	numUpgradeTxs int
+}
+
+// TestUpgradeBlockTxOmission tests that the sequencer omits user transactions in activation blocks
+// and that batches that contain user transactions in an activation block are dropped.
+func TestActivationBlockTxOmission(gt *testing.T) {
+	matrix := helpers.NewMatrix[activationBlockTestCfg]()
+
+	matrix.AddDefaultTestCasesWithName(
+		string(rollup.Jovian),
+		activationBlockTestCfg{fork: rollup.Jovian, numUpgradeTxs: 5},
+		helpers.NewForkMatrix(helpers.Isthmus),
+		testActivationBlockTxOmission,
+	)
+	// New forks should be added here in the future.
+
+	matrix.Run(gt)
+}
+
+func testActivationBlockTxOmission(gt *testing.T, testCfg *helpers.TestCfg[activationBlockTestCfg]) {
+	tcfg := testCfg.Custom
+	t := actionsHelpers.NewDefaultTesting(gt)
+	offset := uint64(4)
+	testSetup := func(dc *genesis.DeployConfig) {
+		dc.L1PragueTimeOffset = ptr(hexutil.Uint64(0))
+		// activate fork after a few blocks
+		dc.SetForkTimeOffset(tcfg.fork, &offset)
+	}
+	env := helpers.NewL2FaultProofEnv(t, testCfg, helpers.NewTestParams(), helpers.NewBatcherCfg(), testSetup)
+
+	engine := env.Engine
+	sequencer := env.Sequencer
+	miner := env.Miner
+	rollupCfg := env.Sd.RollupCfg
+	blockTime := rollupCfg.BlockTime
+
+	miner.ActEmptyBlock(t)
+
+	sequencer.ActL1HeadSignal(t)
+	for i := 0; i < int(offset)-1; i++ {
+		sequencer.ActL2EmptyBlock(t)
+	}
+	tx := env.Alice.L2.ActMakeTx(t)
+	sequencer.ActL2StartBlock(t)
+	// we assert later that the sequencer actually omits this tx in the activation block
+	engine.ActL2IncludeTx(env.Alice.Address())
+	sequencer.ActL2EndBlock(t)
+
+	actHeader := engine.L2Chain().CurrentHeader()
+	require.Equal(t, tcfg.fork,
+		rollupCfg.IsActivationBlock(actHeader.Time-blockTime, actHeader.Time),
+		"this block should be the activation block")
+	actBlock := engine.L2Chain().GetBlockByHash(actHeader.Hash())
+	require.Len(t, actBlock.Transactions(), tcfg.numUpgradeTxs+1, "activation block contains unexpected txs")
+
+	batcher := env.Batcher
+	for i := 0; i < int(offset)-1; i++ {
+		batcher.ActL2BatchBuffer(t)
+	}
+	batcher.ActL2BatchBuffer(t,
+		actionsHelpers.WithBlockModifier(func(block *types.Block) *types.Block {
+			// inject user tx into activation batch
+			return block.WithBody(types.Body{Transactions: append(block.Transactions(), tx)})
+		}))
+
+	batcher.ActL2ChannelClose(t)
+	batcher.ActL2BatchSubmit(t)
+	env.Miner.ActL1StartBlock(12)(t)
+	env.Miner.ActL1IncludeTxByHash(env.Batcher.LastSubmitted.Hash())(t)
+	env.Miner.ActL1EndBlock(t)
+
+	env.Sequencer.ActL1HeadSignal(t)
+	env.Sequencer.ActL2PipelineFull(t)
+
+	recs := env.Logs.FindLogs(testlog.NewMessageFilter("dropping batch with user transactions in fork activation block"))
+	require.Len(t, recs, 1)
+
+	l2SafeHead := engine.L2Chain().CurrentSafeBlock()
+	preActHeader := engine.L2Chain().GetHeaderByHash(actHeader.ParentHash)
+	require.Equal(t, eth.HeaderBlockID(preActHeader), eth.HeaderBlockID(l2SafeHead), "derivation only reaches pre-upgrade block")
+
+	env.RunFaultProofProgramFromGenesis(t, l2SafeHead.Number.Uint64(), testCfg.CheckResult, testCfg.InputParams...)
+}

--- a/op-node/rollup/chain_spec.go
+++ b/op-node/rollup/chain_spec.go
@@ -63,6 +63,8 @@ var AllForks = []ForkName{
 	// ADD NEW FORKS HERE!
 }
 
+var LatestFork = AllForks[len(AllForks)-1]
+
 func ForksFrom(fork ForkName) []ForkName {
 	for i, f := range AllForks {
 		if f == fork {

--- a/op-node/rollup/derive/batches.go
+++ b/op-node/rollup/derive/batches.go
@@ -134,7 +134,9 @@ func checkSingularBatch(cfg *rollup.Config, log log.Logger, l1Blocks []eth.L1Blo
 	}
 
 	// Future forks that contain upgrade transactions must be added here.
-	if (cfg.IsInteropActivationBlock(batch.Timestamp)) && len(batch.Transactions) > 0 {
+	if (cfg.IsJovianActivationBlock(batch.Timestamp) ||
+		cfg.IsInteropActivationBlock(batch.Timestamp)) &&
+		len(batch.Transactions) > 0 {
 		log.Warn("dropping batch with user transactions in fork activation block")
 		return BatchDrop
 	}

--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -432,7 +432,7 @@ func (c *Config) L1Signer() types.Signer {
 }
 
 func (c *Config) IsForkActive(fork ForkName, timestamp uint64) bool {
-	activationTime := c.ActivationTimeFor(fork)
+	activationTime := c.ActivationTime(fork)
 	return activationTime != nil && timestamp >= *activationTime
 }
 
@@ -558,7 +558,8 @@ func (c *Config) IsInteropActivationBlock(l2BlockTime uint64) bool {
 		!c.IsInterop(l2BlockTime-c.BlockTime)
 }
 
-func (c *Config) ActivationTimeFor(fork ForkName) *uint64 {
+func (c *Config) ActivationTime(fork ForkName) *uint64 {
+	// NEW FORKS MUST BE ADDED HERE
 	switch fork {
 	case Interop:
 		return c.InteropTime
@@ -585,81 +586,78 @@ func (c *Config) ActivationTimeFor(fork ForkName) *uint64 {
 	}
 }
 
+func (c *Config) SetActivationTime(fork ForkName, timestamp *uint64) {
+	// NEW FORKS MUST BE ADDED HERE
+	switch fork {
+	case Interop:
+		c.InteropTime = timestamp
+	case Jovian:
+		c.JovianTime = timestamp
+	case Isthmus:
+		c.IsthmusTime = timestamp
+	case Holocene:
+		c.HoloceneTime = timestamp
+	case Granite:
+		c.GraniteTime = timestamp
+	case Fjord:
+		c.FjordTime = timestamp
+	case Ecotone:
+		c.EcotoneTime = timestamp
+	case Delta:
+		c.DeltaTime = timestamp
+	case Canyon:
+		c.CanyonTime = timestamp
+	case Regolith:
+		c.RegolithTime = timestamp
+	default:
+		panic(fmt.Sprintf("unknown fork: %v", fork))
+	}
+}
+
 // IsActivationBlock returns the fork which activates at the block with time newTime if the previous
-// block's time is oldTime. It return an empty ForkName if no fork activation takes place between
+// block's time is oldTime. It returns an empty ForkName if no fork activation takes place between
 // those timestamps. It can be used for both, L1 and L2 blocks.
 func (c *Config) IsActivationBlock(oldTime, newTime uint64) ForkName {
-	if c.IsInterop(newTime) && !c.IsInterop(oldTime) {
-		return Interop
-	}
-	if c.IsJovian(newTime) && !c.IsJovian(oldTime) {
-		return Jovian
-	}
-	if c.IsIsthmus(newTime) && !c.IsIsthmus(oldTime) {
-		return Isthmus
-	}
-	if c.IsHolocene(newTime) && !c.IsHolocene(oldTime) {
-		return Holocene
-	}
-	if c.IsGranite(newTime) && !c.IsGranite(oldTime) {
-		return Granite
-	}
-	if c.IsFjord(newTime) && !c.IsFjord(oldTime) {
-		return Fjord
-	}
-	if c.IsEcotone(newTime) && !c.IsEcotone(oldTime) {
-		return Ecotone
-	}
-	if c.IsDelta(newTime) && !c.IsDelta(oldTime) {
-		return Delta
-	}
-	if c.IsCanyon(newTime) && !c.IsCanyon(oldTime) {
-		return Canyon
+	for _, fork := range scheduleableForks {
+		if c.IsForkActive(fork, newTime) && !c.IsForkActive(fork, oldTime) {
+			return fork
+		}
 	}
 	return None
 }
 
-func (c *Config) IsActivationBlockForFork(l2BlockTime uint64, forkName ForkName) bool {
-	return c.IsActivationBlock(l2BlockTime-c.BlockTime, l2BlockTime) == forkName
+func (c *Config) IsActivationBlockForFork(l2BlockTime uint64, fork ForkName) bool {
+	return l2BlockTime >= c.BlockTime &&
+		!c.IsForkActive(fork, l2BlockTime-c.BlockTime) &&
+		c.IsForkActive(fork, l2BlockTime)
 }
 
+// ActivateAtGenesis updates the config to activate the given fork and all previous forks at genesis
+// and all later forks are disabled.
 func (c *Config) ActivateAtGenesis(hardfork ForkName) {
-	// IMPORTANT! ordered from newest to oldest
-	switch hardfork {
-	case Interop:
-		c.InteropTime = new(uint64)
-		fallthrough
-	case Jovian:
-		c.JovianTime = new(uint64)
-		fallthrough
-	case Isthmus:
-		c.IsthmusTime = new(uint64)
-		fallthrough
-	case Holocene:
-		c.HoloceneTime = new(uint64)
-		fallthrough
-	case Granite:
-		c.GraniteTime = new(uint64)
-		fallthrough
-	case Fjord:
-		c.FjordTime = new(uint64)
-		fallthrough
-	case Ecotone:
-		c.EcotoneTime = new(uint64)
-		fallthrough
-	case Delta:
-		c.DeltaTime = new(uint64)
-		fallthrough
-	case Canyon:
-		c.CanyonTime = new(uint64)
-		fallthrough
-	case Regolith:
-		c.RegolithTime = new(uint64)
-		fallthrough
-	case Bedrock:
-		// default
-	case None:
-		break
+	c.ActivateAt(hardfork, 0)
+}
+
+var scheduleableForks = ForksFrom(Regolith)
+
+// ActivateAt updates the config to activate the given fork at the given timestamp, all previous
+// forks at genesis, and all later forks are disabled.
+func (c *Config) ActivateAt(fork ForkName, timestamp uint64) {
+	if !IsValidFork(fork) {
+		panic(fmt.Sprintf("invalid fork: %s", fork))
+	}
+	ts := new(uint64)
+	// Special case: if only activating Bedrock, all scheduleable forks are disabled.
+	if fork == Bedrock {
+		ts = nil
+	}
+	for i, f := range scheduleableForks {
+		if f == fork {
+			c.SetActivationTime(fork, &timestamp)
+			ts = nil
+		} else {
+			c.SetActivationTime(scheduleableForks[i], ts)
+		}
 	}
 }
 

--- a/op-service/ptr/ptr.go
+++ b/op-service/ptr/ptr.go
@@ -3,6 +3,12 @@ package ptr
 
 import "fmt"
 
+var (
+	Zero16 = New[uint16](0)
+	Zero32 = New[uint32](0)
+	Zero64 = New[uint64](0)
+)
+
 func New[T any](v T) *T {
 	return &v
 }

--- a/packages/contracts-bedrock/snapshots/abi/SaferSafes.json
+++ b/packages/contracts-bedrock/snapshots/abi/SaferSafes.json
@@ -169,7 +169,7 @@
     ],
     "name": "checkTransaction",
     "outputs": [],
-    "stateMutability": "view",
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {

--- a/packages/contracts-bedrock/snapshots/abi/SaferSafes.json
+++ b/packages/contracts-bedrock/snapshots/abi/SaferSafes.json
@@ -860,6 +860,11 @@
   },
   {
     "inputs": [],
+    "name": "LivenessModule2_InvalidVersion",
+    "type": "error"
+  },
+  {
+    "inputs": [],
     "name": "LivenessModule2_ModuleNotConfigured",
     "type": "error"
   },

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -208,8 +208,8 @@
     "sourceCodeHash": "0x7fc4789b082bc8ecd29c4c75a06058f0ff0b72f1c1028a42db6f1c35269c8865"
   },
   "src/safe/SaferSafes.sol:SaferSafes": {
-    "initCodeHash": "0xe8ff14ba3d023064046251967c3f4d0eb7bc3c2eee6519523f1175b37c0f9ac9",
-    "sourceCodeHash": "0x046424a35624e13badd3d3f91993c27d4d6058b4696cba8bdda27b09bc972785"
+    "initCodeHash": "0x6e47950b34cc45b226ee9b9e07bfd7e311d174896836ec32da7d465216df4df8",
+    "sourceCodeHash": "0x4fbf7d6805b1c59e6b04a1de922992920dd906658f07a36988ede147811f83f2"
   },
   "src/universal/OptimismMintableERC20.sol:OptimismMintableERC20": {
     "initCodeHash": "0x3c85eed0d017dca8eda6396aa842ddc12492587b061e8c756a8d32c4610a9658",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -208,8 +208,8 @@
     "sourceCodeHash": "0x7fc4789b082bc8ecd29c4c75a06058f0ff0b72f1c1028a42db6f1c35269c8865"
   },
   "src/safe/SaferSafes.sol:SaferSafes": {
-    "initCodeHash": "0x80fd43f977ab997ad18467b6bc618aefa1994b09a4990c75757ace01ab57da3b",
-    "sourceCodeHash": "0xf03bdf0eeb55f88424c4d3d4f738ecd25d41aa3164b22674b667b8f3e478f948"
+    "initCodeHash": "0x6ac4f1e3a5fe0d9d920f8b8568af41994b4f6c5cf371fd86c3c75f162203a6e6",
+    "sourceCodeHash": "0x0f27f450363c2eeafacd2741c613a14dcf7633b3e99e83ddea1ac152710dd868"
   },
   "src/universal/OptimismMintableERC20.sol:OptimismMintableERC20": {
     "initCodeHash": "0x3c85eed0d017dca8eda6396aa842ddc12492587b061e8c756a8d32c4610a9658",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -208,8 +208,8 @@
     "sourceCodeHash": "0x7fc4789b082bc8ecd29c4c75a06058f0ff0b72f1c1028a42db6f1c35269c8865"
   },
   "src/safe/SaferSafes.sol:SaferSafes": {
-    "initCodeHash": "0xe8ff14ba3d023064046251967c3f4d0eb7bc3c2eee6519523f1175b37c0f9ac9",
-    "sourceCodeHash": "0x046424a35624e13badd3d3f91993c27d4d6058b4696cba8bdda27b09bc972785"
+    "initCodeHash": "0x53d91ad9ac46955c7d76787e6597066d251c2ebec50b02b7d6c8ed81423f5e9c",
+    "sourceCodeHash": "0x0f27f450363c2eeafacd2741c613a14dcf7633b3e99e83ddea1ac152710dd868"
   },
   "src/universal/OptimismMintableERC20.sol:OptimismMintableERC20": {
     "initCodeHash": "0x3c85eed0d017dca8eda6396aa842ddc12492587b061e8c756a8d32c4610a9658",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -208,8 +208,8 @@
     "sourceCodeHash": "0x7fc4789b082bc8ecd29c4c75a06058f0ff0b72f1c1028a42db6f1c35269c8865"
   },
   "src/safe/SaferSafes.sol:SaferSafes": {
-    "initCodeHash": "0x6e47950b34cc45b226ee9b9e07bfd7e311d174896836ec32da7d465216df4df8",
-    "sourceCodeHash": "0x4fbf7d6805b1c59e6b04a1de922992920dd906658f07a36988ede147811f83f2"
+    "initCodeHash": "0x64970a074a2e0938db8da88e920b3eba28a559513ebcf48e0622678f51d37acc",
+    "sourceCodeHash": "0x304de7d65a89f3aede42d39194dc4bf8cf60218b21d6977c65abe7585b530d27"
   },
   "src/universal/OptimismMintableERC20.sol:OptimismMintableERC20": {
     "initCodeHash": "0x3c85eed0d017dca8eda6396aa842ddc12492587b061e8c756a8d32c4610a9658",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -208,8 +208,8 @@
     "sourceCodeHash": "0x7fc4789b082bc8ecd29c4c75a06058f0ff0b72f1c1028a42db6f1c35269c8865"
   },
   "src/safe/SaferSafes.sol:SaferSafes": {
-    "initCodeHash": "0x53d91ad9ac46955c7d76787e6597066d251c2ebec50b02b7d6c8ed81423f5e9c",
-    "sourceCodeHash": "0x0f27f450363c2eeafacd2741c613a14dcf7633b3e99e83ddea1ac152710dd868"
+    "initCodeHash": "0x80fd43f977ab997ad18467b6bc618aefa1994b09a4990c75757ace01ab57da3b",
+    "sourceCodeHash": "0xf03bdf0eeb55f88424c4d3d4f738ecd25d41aa3164b22674b667b8f3e478f948"
   },
   "src/universal/OptimismMintableERC20.sol:OptimismMintableERC20": {
     "initCodeHash": "0x3c85eed0d017dca8eda6396aa842ddc12492587b061e8c756a8d32c4610a9658",

--- a/packages/contracts-bedrock/src/safe/LivenessModule2.sol
+++ b/packages/contracts-bedrock/src/safe/LivenessModule2.sol
@@ -15,13 +15,11 @@ import { SemverComp } from "src/libraries/SemverComp.sol";
 ///         when the Safe becomes unresponsive. The fallback owner can initiate a challenge,
 ///         and if the Safe doesn't respond within the challenge period, ownership transfers
 ///         to the fallback owner.
-///         This contract is compatible only with the Safe contract version 1.4.1.
 /// @dev This is a singleton contract. To use it:
 ///      1. The Safe must first enable this module using ModuleManager.enableModule()
 ///      2. The Safe must then configure the module by calling configure() with params
 ///
-///     This guard is compatible only with Safe versions 1.3.x and 1.4.x. Enabling it for a Safe
-///     from any other version will brick the Safe.
+///     This guard is compatible only with Safe version 1.4.1.
 ///
 ///      Follows a state machine diagram for the lifecycle of this contract:
 ///      +----------------------+
@@ -79,7 +77,7 @@ abstract contract LivenessModule2 {
     /// @notice Error for when Safe is not configured for this module.
     error LivenessModule2_ModuleNotConfigured();
 
-    /// @notice Error for when the contract is not between 1.3.x and 1.5.x
+    /// @notice Error for when the contract is not 1.4.1.
     error LivenessModule2_InvalidVersion();
 
     /// @notice Error for when a challenge already exists.
@@ -180,11 +178,9 @@ abstract contract LivenessModule2 {
             revert LivenessModule2_InvalidFallbackOwner();
         }
 
-        // Check that the safe contract version is between 1.3.x and 1.5.x
-        // Prior to version 1.3.0, GuardManager.setGuard didn't exist. If the module were to be
-        // enabled for an unsupported version the module would fail to transfer ownership when
-        // required.
-        if (SemverComp.lt(callingSafe.VERSION(), "1.3.0") || SemverComp.gte(callingSafe.VERSION(), "1.6.0")) {
+        // Check that the safe contract version is 1.4.1. There have been breaking changes at every
+        // minor version, and we can only support one version.
+        if (!SemverComp.eq(callingSafe.VERSION(), "1.4.1")) {
             revert LivenessModule2_InvalidVersion();
         }
 

--- a/packages/contracts-bedrock/src/safe/LivenessModule2.sol
+++ b/packages/contracts-bedrock/src/safe/LivenessModule2.sol
@@ -7,6 +7,9 @@ import { Enum } from "safe-contracts/common/Enum.sol";
 import { OwnerManager } from "safe-contracts/base/OwnerManager.sol";
 import { GuardManager } from "safe-contracts/base/GuardManager.sol";
 
+// Libraries
+import { SemverComp } from "src/libraries/SemverComp.sol";
+
 /// @title LivenessModule2
 /// @notice This module allows challenge-based ownership transfer to a fallback owner
 ///         when the Safe becomes unresponsive. The fallback owner can initiate a challenge,
@@ -16,6 +19,9 @@ import { GuardManager } from "safe-contracts/base/GuardManager.sol";
 /// @dev This is a singleton contract. To use it:
 ///      1. The Safe must first enable this module using ModuleManager.enableModule()
 ///      2. The Safe must then configure the module by calling configure() with params
+///
+///     This guard is compatible only with Safe versions 1.3.x and 1.4.x. Enabling it for a Safe
+///     from any other version will brick the Safe.
 ///
 ///      Follows a state machine diagram for the lifecycle of this contract:
 ///      +----------------------+
@@ -72,6 +78,9 @@ abstract contract LivenessModule2 {
 
     /// @notice Error for when Safe is not configured for this module.
     error LivenessModule2_ModuleNotConfigured();
+
+    /// @notice Error for when the contract is not between 1.3.x and 1.5.x
+    error LivenessModule2_InvalidVersion();
 
     /// @notice Error for when a challenge already exists.
     error LivenessModule2_ChallengeAlreadyExists();
@@ -169,6 +178,14 @@ abstract contract LivenessModule2 {
         // fallbackOwner must not be zero address to have a valid ownership recipient.
         if (_config.fallbackOwner == address(0)) {
             revert LivenessModule2_InvalidFallbackOwner();
+        }
+
+        // Check that the safe contract version is between 1.3.x and 1.5.x
+        // Prior to version 1.3.0, GuardManager.setGuard didn't exist. If the module were to be
+        // enabled for an unsupported version the module would fail to transfer ownership when
+        // required.
+        if (SemverComp.lt(callingSafe.VERSION(), "1.3.0") || SemverComp.gte(callingSafe.VERSION(), "1.6.0")) {
+            revert LivenessModule2_InvalidVersion();
         }
 
         // Check that this module is enabled on the calling Safe.

--- a/packages/contracts-bedrock/src/safe/SaferSafes.sol
+++ b/packages/contracts-bedrock/src/safe/SaferSafes.sol
@@ -25,8 +25,8 @@ import { ISemver } from "interfaces/universal/ISemver.sol";
 ///      desired, then there is no need to enable or configure it.
 contract SaferSafes is LivenessModule2, TimelockGuard, ISemver {
     /// @notice Semantic version.
-    /// @custom:semver 1.5.2
-    string public constant version = "1.5.2";
+    /// @custom:semver 1.6.0
+    string public constant version = "1.6.0";
 
     /// @notice Error for when the liveness response period is insufficient.
     error SaferSafes_InsufficientLivenessResponsePeriod();

--- a/packages/contracts-bedrock/src/safe/SaferSafes.sol
+++ b/packages/contracts-bedrock/src/safe/SaferSafes.sol
@@ -26,8 +26,8 @@ import { ISemver } from "interfaces/universal/ISemver.sol";
 ///      compatibility restrictions in the LivenessModule2 and TimelockGuard contracts.
 contract SaferSafes is LivenessModule2, TimelockGuard, ISemver {
     /// @notice Semantic version.
-    /// @custom:semver 1.6.0
-    string public constant version = "1.6.0";
+    /// @custom:semver 1.6.1
+    string public constant version = "1.6.1";
 
     /// @notice Error for when the liveness response period is insufficient.
     error SaferSafes_InsufficientLivenessResponsePeriod();

--- a/packages/contracts-bedrock/src/safe/SaferSafes.sol
+++ b/packages/contracts-bedrock/src/safe/SaferSafes.sol
@@ -11,8 +11,7 @@ import { ISemver } from "interfaces/universal/ISemver.sol";
 
 /// @title SaferSafes
 /// @notice Combined Safe extensions providing both liveness module and timelock guard
-///         functionality
-///         This contract is compatible only with the Safe contract version 1.4.1.
+///         functionality.
 /// @dev This contract can be enabled simultaneously as both a module and a guard on a Safe:
 ///      - As a module: provides liveness challenge functionality to prevent multisig deadlock
 ///      - As a guard: provides timelock functionality for transaction delays and cancellation
@@ -23,10 +22,12 @@ import { ISemver } from "interfaces/universal/ISemver.sol";
 ///      enabled or disabled independently of the other. When installing either component, it
 ///      should first be enabled, and then configured. If a component's functionality is not
 ///      desired, then there is no need to enable or configure it.
+///      This contract is compatible only with the Safe contract version 1.3.x and 1.4.x due to the
+///      compatibility restrictions in the LivenessModule2 and TimelockGuard contracts.
 contract SaferSafes is LivenessModule2, TimelockGuard, ISemver {
     /// @notice Semantic version.
-    /// @custom:semver 1.5.2
-    string public constant version = "1.5.2";
+    /// @custom:semver 1.6.0
+    string public constant version = "1.6.0";
 
     /// @notice Error for when the liveness response period is insufficient.
     error SaferSafes_InsufficientLivenessResponsePeriod();

--- a/packages/contracts-bedrock/src/safe/SaferSafes.sol
+++ b/packages/contracts-bedrock/src/safe/SaferSafes.sol
@@ -26,8 +26,8 @@ import { ISemver } from "interfaces/universal/ISemver.sol";
 ///      compatibility restrictions in the LivenessModule2 and TimelockGuard contracts.
 contract SaferSafes is LivenessModule2, TimelockGuard, ISemver {
     /// @notice Semantic version.
-    /// @custom:semver 1.6.1
-    string public constant version = "1.6.1";
+    /// @custom:semver 1.6.0
+    string public constant version = "1.6.0";
 
     /// @notice Error for when the liveness response period is insufficient.
     error SaferSafes_InsufficientLivenessResponsePeriod();

--- a/packages/contracts-bedrock/src/safe/SaferSafes.sol
+++ b/packages/contracts-bedrock/src/safe/SaferSafes.sol
@@ -26,8 +26,8 @@ import { ISemver } from "interfaces/universal/ISemver.sol";
 ///      compatibility restrictions in the LivenessModule2 and TimelockGuard contracts.
 contract SaferSafes is LivenessModule2, TimelockGuard, ISemver {
     /// @notice Semantic version.
-    /// @custom:semver 1.6.0
-    string public constant version = "1.6.0";
+    /// @custom:semver 1.7.0
+    string public constant version = "1.7.0";
 
     /// @notice Error for when the liveness response period is insufficient.
     error SaferSafes_InsufficientLivenessResponsePeriod();

--- a/packages/contracts-bedrock/src/safe/SaferSafes.sol
+++ b/packages/contracts-bedrock/src/safe/SaferSafes.sol
@@ -11,8 +11,7 @@ import { ISemver } from "interfaces/universal/ISemver.sol";
 
 /// @title SaferSafes
 /// @notice Combined Safe extensions providing both liveness module and timelock guard
-///         functionality
-///         This contract is compatible only with the Safe contract version 1.4.1.
+///         functionality.
 /// @dev This contract can be enabled simultaneously as both a module and a guard on a Safe:
 ///      - As a module: provides liveness challenge functionality to prevent multisig deadlock
 ///      - As a guard: provides timelock functionality for transaction delays and cancellation
@@ -23,6 +22,8 @@ import { ISemver } from "interfaces/universal/ISemver.sol";
 ///      enabled or disabled independently of the other. When installing either component, it
 ///      should first be enabled, and then configured. If a component's functionality is not
 ///      desired, then there is no need to enable or configure it.
+///      This contract is compatible only with the Safe contract version 1.3.x and 1.4.x due to the
+///      compatibility restrictions in the LivenessModule2 and TimelockGuard contracts.
 contract SaferSafes is LivenessModule2, TimelockGuard, ISemver {
     /// @notice Semantic version.
     /// @custom:semver 1.6.0

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -39,7 +39,8 @@ import { Constants } from "src/libraries/Constants.sol";
 ///     each cancellation.
 ///     The cancellation threshold is reset to 1 after any transaction is executed successfully.
 /// Safe Version Compatibility:
-///     This guard is compatible only with Safe versions 1.4.1.
+///     This guard is compatible only with Safe versions 1.3.x and 1.4.x. Enabling it for a Safe
+///     from any other version will brick the Safe.
 /// Threats Mitigated and Integration With LivenessModule:
 ///     This Guard is designed to protect against a number of well-defined scenarios, defined on
 ///     the two axes of amount of keys compromised, and type of compromise.
@@ -152,7 +153,7 @@ abstract contract TimelockGuard is BaseGuard {
     /// @notice Error for when a transaction has already been executed
     error TimelockGuard_TransactionAlreadyExecuted();
 
-    /// @notice Error for when the contract is not 1.4.1
+    /// @notice Error for when the contract is not 1.3.x or 1.4.x
     error TimelockGuard_InvalidVersion();
 
     /// @notice Error for when trying to clear guard while it is still enabled
@@ -451,10 +452,12 @@ abstract contract TimelockGuard is BaseGuard {
         // Record the calling Safe
         Safe callingSafe = Safe(payable(msg.sender));
 
-        // Check that the contract is at least version 1.3.0
-        // Prior to version 1.3.0, checkSignatures() was not exposed as a public function, so we need to check the
-        // version otherwise the safe will be bricked.
-        if (SemverComp.lt(callingSafe.VERSION(), "1.3.0")) {
+        // Check that the safe contract is version 1.3.x or 1.4.x
+        // Prior to version 1.3.0, checkSignatures() was not exposed as a public function, on 1.5.0
+        // `encodeTransactionData` was removed from the safe, and the `isValidSignature` function
+        // signature changed. If the guard were to be enabled for an unsupported version the safe
+        // would be rendered permanently unusable.
+        if (SemverComp.lt(callingSafe.VERSION(), "1.4.0") || SemverComp.gte(callingSafe.VERSION(), "1.5.0")) {
             revert TimelockGuard_InvalidVersion();
         }
 

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -442,7 +442,7 @@ abstract contract TimelockGuard is BaseGuard {
         // `encodeTransactionData` was removed from the safe, and the `isValidSignature` function
         // signature changed. If the guard were to be enabled for an unsupported version the safe
         // would be rendered permanently unusable.
-        if (SemverComp.lt(callingSafe.VERSION(), "1.4.0") || SemverComp.gte(callingSafe.VERSION(), "1.5.0")) {
+        if (SemverComp.lt(callingSafe.VERSION(), "1.3.0") || SemverComp.gte(callingSafe.VERSION(), "1.5.0")) {
             revert TimelockGuard_InvalidVersion();
         }
 

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -457,7 +457,7 @@ abstract contract TimelockGuard is BaseGuard {
         // `encodeTransactionData` was removed from the safe, and the `isValidSignature` function
         // signature changed. If the guard were to be enabled for an unsupported version the safe
         // would be rendered permanently unusable.
-        if (SemverComp.lt(callingSafe.VERSION(), "1.4.0") || SemverComp.gte(callingSafe.VERSION(), "1.5.0")) {
+        if (SemverComp.lt(callingSafe.VERSION(), "1.3.0") || SemverComp.gte(callingSafe.VERSION(), "1.5.0")) {
             revert TimelockGuard_InvalidVersion();
         }
 

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -45,8 +45,7 @@ import { Constants } from "src/libraries/Constants.sol";
 ///     removing them from the pending transactions queue, and resetting the cancellation
 ///     threshold.
 /// Safe Version Compatibility:
-///     This guard is compatible only with Safe versions 1.3.x and 1.4.x. Enabling it for a Safe
-///     from any other version will brick the Safe.
+///     This guard is compatible only with Safe version 1.4.1.
 /// Threats Mitigated and Integration With LivenessModule:
 ///     This Guard is designed to protect against a number of well-defined scenarios, defined on
 ///     the two axes of amount of keys compromised, and type of compromise.
@@ -159,7 +158,7 @@ abstract contract TimelockGuard is BaseGuard {
     /// @notice Error for when a transaction has already been executed
     error TimelockGuard_TransactionAlreadyExecuted();
 
-    /// @notice Error for when the contract is not 1.3.x or 1.4.x
+    /// @notice Error for when the contract is not 1.4.1
     error TimelockGuard_InvalidVersion();
 
     /// @notice Error for when trying to clear guard while it is still enabled
@@ -437,12 +436,10 @@ abstract contract TimelockGuard is BaseGuard {
         // Record the calling Safe
         Safe callingSafe = Safe(payable(msg.sender));
 
-        // Check that the safe contract is version 1.3.x or 1.4.x
-        // Prior to version 1.3.0, checkSignatures() was not exposed as a public function, on 1.5.0
-        // `encodeTransactionData` was removed from the safe, and the `isValidSignature` function
-        // signature changed. If the guard were to be enabled for an unsupported version the safe
-        // would be rendered permanently unusable.
-        if (SemverComp.lt(callingSafe.VERSION(), "1.3.0") || SemverComp.gte(callingSafe.VERSION(), "1.5.0")) {
+        // Check that the safe contract is version 1.4.1
+        // There have been breaking changes at every minor version, and we can only support one
+        // version.
+        if (!SemverComp.eq(callingSafe.VERSION(), "1.4.1")) {
             revert TimelockGuard_InvalidVersion();
         }
 

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -45,7 +45,8 @@ import { Constants } from "src/libraries/Constants.sol";
 ///     removing them from the pending transactions queue, and resetting the cancellation
 ///     threshold.
 /// Safe Version Compatibility:
-///     This guard is compatible only with Safe versions 1.4.1.
+///     This guard is compatible only with Safe versions 1.3.x and 1.4.x. Enabling it for a Safe
+///     from any other version will brick the Safe.
 /// Threats Mitigated and Integration With LivenessModule:
 ///     This Guard is designed to protect against a number of well-defined scenarios, defined on
 ///     the two axes of amount of keys compromised, and type of compromise.
@@ -158,7 +159,7 @@ abstract contract TimelockGuard is BaseGuard {
     /// @notice Error for when a transaction has already been executed
     error TimelockGuard_TransactionAlreadyExecuted();
 
-    /// @notice Error for when the contract is not 1.4.1
+    /// @notice Error for when the contract is not 1.3.x or 1.4.x
     error TimelockGuard_InvalidVersion();
 
     /// @notice Error for when trying to clear guard while it is still enabled
@@ -436,10 +437,12 @@ abstract contract TimelockGuard is BaseGuard {
         // Record the calling Safe
         Safe callingSafe = Safe(payable(msg.sender));
 
-        // Check that the contract is at least version 1.3.0
-        // Prior to version 1.3.0, checkSignatures() was not exposed as a public function, so we need to check the
-        // version otherwise the safe will be bricked.
-        if (SemverComp.lt(callingSafe.VERSION(), "1.3.0")) {
+        // Check that the safe contract is version 1.3.x or 1.4.x
+        // Prior to version 1.3.0, checkSignatures() was not exposed as a public function, on 1.5.0
+        // `encodeTransactionData` was removed from the safe, and the `isValidSignature` function
+        // signature changed. If the guard were to be enabled for an unsupported version the safe
+        // would be rendered permanently unusable.
+        if (SemverComp.lt(callingSafe.VERSION(), "1.4.0") || SemverComp.gte(callingSafe.VERSION(), "1.5.0")) {
             revert TimelockGuard_InvalidVersion();
         }
 

--- a/packages/contracts-bedrock/test/L2/L1FeeVault.t.sol
+++ b/packages/contracts-bedrock/test/L2/L1FeeVault.t.sol
@@ -6,6 +6,16 @@ import { CommonTest } from "test/setup/CommonTest.sol";
 
 // Libraries
 import { Types } from "src/libraries/Types.sol";
+import { SemverComp } from "src/libraries/SemverComp.sol";
+
+/// @title L1FeeVault_Version_Test
+/// @notice Tests the `version` function of the `L1FeeVault` contract.
+contract L1FeeVault_Version_Test is CommonTest {
+    /// @notice Tests that the version returns a valid semver string.
+    function test_version_succeeds() external view {
+        SemverComp.parse(l1FeeVault.version());
+    }
+}
 
 /// @title L1FeeVault_Constructor_Test
 /// @notice Tests the `constructor` of the `L1FeeVault` contract.

--- a/packages/contracts-bedrock/test/safe/LivenessModule2.t.sol
+++ b/packages/contracts-bedrock/test/safe/LivenessModule2.t.sol
@@ -194,7 +194,6 @@ contract LivenessModule2_ConfigureLivenessModule_Test is LivenessModule2_TestIni
         );
     }
 
-
     /// @notice Checks configuration reverts when the contract is too old.
     function test_configureLivenessModule_revertsIfVersionTooOld_reverts() external {
         // nosemgrep: sol-style-use-abi-encodecall

--- a/packages/contracts-bedrock/test/safe/LivenessModule2.t.sol
+++ b/packages/contracts-bedrock/test/safe/LivenessModule2.t.sol
@@ -195,7 +195,7 @@ contract LivenessModule2_ConfigureLivenessModule_Test is LivenessModule2_TestIni
     }
 
     /// @notice Checks configuration reverts when the contract is too old.
-    function test_configureLivenessModule_revertsIfVersionTooOld_reverts() external {
+    function test_configureLivenessModule_withVersionTooOld_reverts() external {
         // nosemgrep: sol-style-use-abi-encodecall
         vm.mockCall(address(safeInstance.safe), abi.encodeWithSignature("VERSION()"), abi.encode("1.2.0"));
         vm.expectRevert(LivenessModule2.LivenessModule2_InvalidVersion.selector, address(livenessModule2));
@@ -206,7 +206,7 @@ contract LivenessModule2_ConfigureLivenessModule_Test is LivenessModule2_TestIni
     }
 
     /// @notice Checks configuration reverts when the contract is too old.
-    function test_configureLivenessModule_revertsIfVersionTooNew_reverts() external {
+    function test_configureLivenessModule_withVersionTooNew_reverts() external {
         // nosemgrep: sol-style-use-abi-encodecall
         vm.mockCall(address(safeInstance.safe), abi.encodeWithSignature("VERSION()"), abi.encode("1.6.0"));
         vm.expectRevert(LivenessModule2.LivenessModule2_InvalidVersion.selector, address(livenessModule2));

--- a/packages/contracts-bedrock/test/safe/LivenessModule2.t.sol
+++ b/packages/contracts-bedrock/test/safe/LivenessModule2.t.sol
@@ -216,6 +216,16 @@ contract LivenessModule2_ConfigureLivenessModule_Test is LivenessModule2_TestIni
         );
     }
 
+    /// @notice Checks configuration succeeds even with pre-release versions of the Safe contract.
+    function test_configureLivenessModule_withPreReleaseVersion_succeeds() external {
+        // nosemgrep: sol-style-use-abi-encodecall
+        vm.mockCall(address(safeInstance.safe), abi.encodeWithSignature("VERSION()"), abi.encode("1.3.0-rc.1"));
+        vm.prank(address(safeInstance.safe));
+        livenessModule2.configureLivenessModule(
+            LivenessModule2.ModuleConfig({ livenessResponsePeriod: CHALLENGE_PERIOD, fallbackOwner: fallbackOwner })
+        );
+    }
+
     function test_configureLivenessModule_cancelsExistingChallenge_succeeds() external {
         // First configure the module
         _enableModule(safeInstance, CHALLENGE_PERIOD, fallbackOwner);

--- a/packages/contracts-bedrock/test/safe/LivenessModule2.t.sol
+++ b/packages/contracts-bedrock/test/safe/LivenessModule2.t.sol
@@ -195,20 +195,9 @@ contract LivenessModule2_ConfigureLivenessModule_Test is LivenessModule2_TestIni
     }
 
     /// @notice Checks configuration reverts when the contract is too old.
-    function test_configureLivenessModule_withVersionTooOld_reverts() external {
+    function test_configureLivenessModule_withWrongVersion_reverts() external {
         // nosemgrep: sol-style-use-abi-encodecall
-        vm.mockCall(address(safeInstance.safe), abi.encodeWithSignature("VERSION()"), abi.encode("1.2.0"));
-        vm.expectRevert(LivenessModule2.LivenessModule2_InvalidVersion.selector, address(livenessModule2));
-        vm.prank(address(safeInstance.safe));
-        livenessModule2.configureLivenessModule(
-            LivenessModule2.ModuleConfig({ livenessResponsePeriod: CHALLENGE_PERIOD, fallbackOwner: fallbackOwner })
-        );
-    }
-
-    /// @notice Checks configuration reverts when the contract is too old.
-    function test_configureLivenessModule_withVersionTooNew_reverts() external {
-        // nosemgrep: sol-style-use-abi-encodecall
-        vm.mockCall(address(safeInstance.safe), abi.encodeWithSignature("VERSION()"), abi.encode("1.6.0"));
+        vm.mockCall(address(safeInstance.safe), abi.encodeWithSignature("VERSION()"), abi.encode("1.4.0"));
         vm.expectRevert(LivenessModule2.LivenessModule2_InvalidVersion.selector, address(livenessModule2));
         vm.prank(address(safeInstance.safe));
         livenessModule2.configureLivenessModule(
@@ -219,7 +208,7 @@ contract LivenessModule2_ConfigureLivenessModule_Test is LivenessModule2_TestIni
     /// @notice Checks configuration succeeds even with pre-release versions of the Safe contract.
     function test_configureLivenessModule_withPreReleaseVersion_succeeds() external {
         // nosemgrep: sol-style-use-abi-encodecall
-        vm.mockCall(address(safeInstance.safe), abi.encodeWithSignature("VERSION()"), abi.encode("1.3.0-rc.1"));
+        vm.mockCall(address(safeInstance.safe), abi.encodeWithSignature("VERSION()"), abi.encode("1.4.1-rc.1"));
         vm.prank(address(safeInstance.safe));
         livenessModule2.configureLivenessModule(
             LivenessModule2.ModuleConfig({ livenessResponsePeriod: CHALLENGE_PERIOD, fallbackOwner: fallbackOwner })

--- a/packages/contracts-bedrock/test/safe/LivenessModule2.t.sol
+++ b/packages/contracts-bedrock/test/safe/LivenessModule2.t.sol
@@ -194,6 +194,29 @@ contract LivenessModule2_ConfigureLivenessModule_Test is LivenessModule2_TestIni
         );
     }
 
+
+    /// @notice Checks configuration reverts when the contract is too old.
+    function test_configureLivenessModule_revertsIfVersionTooOld_reverts() external {
+        // nosemgrep: sol-style-use-abi-encodecall
+        vm.mockCall(address(safeInstance.safe), abi.encodeWithSignature("VERSION()"), abi.encode("1.2.0"));
+        vm.expectRevert(LivenessModule2.LivenessModule2_InvalidVersion.selector, address(livenessModule2));
+        vm.prank(address(safeInstance.safe));
+        livenessModule2.configureLivenessModule(
+            LivenessModule2.ModuleConfig({ livenessResponsePeriod: CHALLENGE_PERIOD, fallbackOwner: fallbackOwner })
+        );
+    }
+
+    /// @notice Checks configuration reverts when the contract is too old.
+    function test_configureLivenessModule_revertsIfVersionTooNew_reverts() external {
+        // nosemgrep: sol-style-use-abi-encodecall
+        vm.mockCall(address(safeInstance.safe), abi.encodeWithSignature("VERSION()"), abi.encode("1.6.0"));
+        vm.expectRevert(LivenessModule2.LivenessModule2_InvalidVersion.selector, address(livenessModule2));
+        vm.prank(address(safeInstance.safe));
+        livenessModule2.configureLivenessModule(
+            LivenessModule2.ModuleConfig({ livenessResponsePeriod: CHALLENGE_PERIOD, fallbackOwner: fallbackOwner })
+        );
+    }
+
     function test_configureLivenessModule_cancelsExistingChallenge_succeeds() external {
         // First configure the module
         _enableModule(safeInstance, CHALLENGE_PERIOD, fallbackOwner);

--- a/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
+++ b/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
@@ -305,7 +305,7 @@ contract TimelockGuard_ConfigureTimelockGuard_Test is TimelockGuard_TestInit {
     }
 
     /// @notice Checks configuration reverts when the contract is too old.
-    function test_configureTimelockGuard_revertsIfVersionTooOld_reverts() external {
+    function test_configureTimelockGuard_withVersionTooOld_reverts() external {
         // nosemgrep: sol-style-use-abi-encodecall
         vm.mockCall(address(safeInstance.safe), abi.encodeWithSignature("VERSION()"), abi.encode("1.2.0"));
         vm.expectRevert(TimelockGuard.TimelockGuard_InvalidVersion.selector, address(timelockGuard));
@@ -314,10 +314,19 @@ contract TimelockGuard_ConfigureTimelockGuard_Test is TimelockGuard_TestInit {
     }
 
     /// @notice Checks configuration reverts when the contract is too old.
-    function test_configureTimelockGuard_revertsIfVersionTooNew_reverts() external {
+    function test_configureTimelockGuard_withVersionTooNew_reverts() external {
         // nosemgrep: sol-style-use-abi-encodecall
         vm.mockCall(address(safeInstance.safe), abi.encodeWithSignature("VERSION()"), abi.encode("1.5.0"));
         vm.expectRevert(TimelockGuard.TimelockGuard_InvalidVersion.selector, address(timelockGuard));
+        vm.prank(address(safeInstance.safe));
+        timelockGuard.configureTimelockGuard(TIMELOCK_DELAY);
+    }
+
+    /// @notice Checks configuration does not revert if using patch releases of supported versions.
+    ///         Safe Versions: https://github.com/safe-global/safe-smart-account/tags
+    function test_configureTimelockGuard_withPatchReleases_succeeds() external {
+        // nosemgrep: sol-style-use-abi-encodecall
+        vm.mockCall(address(safeInstance.safe), abi.encodeWithSignature("VERSION()"), abi.encode("1.3.0-rc.1"));
         vm.prank(address(safeInstance.safe));
         timelockGuard.configureTimelockGuard(TIMELOCK_DELAY);
     }

--- a/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
+++ b/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
@@ -317,29 +317,19 @@ contract TimelockGuard_ConfigureTimelockGuard_Test is TimelockGuard_TestInit {
         timelockGuard.configureTimelockGuard(_delay);
     }
 
-    /// @notice Checks configuration reverts when the contract is too old.
-    function test_configureTimelockGuard_withVersionTooOld_reverts() external {
+    /// @notice Checks configuration reverts when the contract is not 1.4.1.
+    function test_configureTimelockGuard_withWrongVersion_reverts() external {
         // nosemgrep: sol-style-use-abi-encodecall
-        vm.mockCall(address(safeInstance.safe), abi.encodeWithSignature("VERSION()"), abi.encode("1.2.0"));
+        vm.mockCall(address(safeInstance.safe), abi.encodeWithSignature("VERSION()"), abi.encode("1.4.0"));
         vm.expectRevert(TimelockGuard.TimelockGuard_InvalidVersion.selector, address(timelockGuard));
         vm.prank(address(safeInstance.safe));
         timelockGuard.configureTimelockGuard(TIMELOCK_DELAY);
     }
 
-    /// @notice Checks configuration reverts when the contract is too old.
-    function test_configureTimelockGuard_withVersionTooNew_reverts() external {
-        // nosemgrep: sol-style-use-abi-encodecall
-        vm.mockCall(address(safeInstance.safe), abi.encodeWithSignature("VERSION()"), abi.encode("1.5.0"));
-        vm.expectRevert(TimelockGuard.TimelockGuard_InvalidVersion.selector, address(timelockGuard));
-        vm.prank(address(safeInstance.safe));
-        timelockGuard.configureTimelockGuard(TIMELOCK_DELAY);
-    }
-
-    /// @notice Checks configuration does not revert if using patch releases of supported versions.
-    ///         Safe Versions: https://github.com/safe-global/safe-smart-account/tags
+    /// @notice Checks configuration succeeds even with pre-release versions of the Safe contract.
     function test_configureTimelockGuard_withPatchReleases_succeeds() external {
         // nosemgrep: sol-style-use-abi-encodecall
-        vm.mockCall(address(safeInstance.safe), abi.encodeWithSignature("VERSION()"), abi.encode("1.3.0-rc.1"));
+        vm.mockCall(address(safeInstance.safe), abi.encodeWithSignature("VERSION()"), abi.encode("1.4.1-rc.1"));
         vm.prank(address(safeInstance.safe));
         timelockGuard.configureTimelockGuard(TIMELOCK_DELAY);
     }

--- a/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
+++ b/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
@@ -326,6 +326,15 @@ contract TimelockGuard_ConfigureTimelockGuard_Test is TimelockGuard_TestInit {
         timelockGuard.configureTimelockGuard(TIMELOCK_DELAY);
     }
 
+    /// @notice Checks configuration reverts when the contract is too old.
+    function test_configureTimelockGuard_revertsIfVersionTooNew_reverts() external {
+        // nosemgrep: sol-style-use-abi-encodecall
+        vm.mockCall(address(safeInstance.safe), abi.encodeWithSignature("VERSION()"), abi.encode("1.5.0"));
+        vm.expectRevert(TimelockGuard.TimelockGuard_InvalidVersion.selector, address(timelockGuard));
+        vm.prank(address(safeInstance.safe));
+        timelockGuard.configureTimelockGuard(TIMELOCK_DELAY);
+    }
+
     /// @notice Asserts the maximum valid delay configures successfully.
     function test_configureTimelockGuard_acceptsMaxValidDelay_succeeds() external {
         vm.expectEmit(true, true, true, true);

--- a/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
+++ b/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
@@ -318,7 +318,7 @@ contract TimelockGuard_ConfigureTimelockGuard_Test is TimelockGuard_TestInit {
     }
 
     /// @notice Checks configuration reverts when the contract is too old.
-    function test_configureTimelockGuard_revertsIfVersionTooOld_reverts() external {
+    function test_configureTimelockGuard_withVersionTooOld_reverts() external {
         // nosemgrep: sol-style-use-abi-encodecall
         vm.mockCall(address(safeInstance.safe), abi.encodeWithSignature("VERSION()"), abi.encode("1.2.0"));
         vm.expectRevert(TimelockGuard.TimelockGuard_InvalidVersion.selector, address(timelockGuard));
@@ -327,10 +327,19 @@ contract TimelockGuard_ConfigureTimelockGuard_Test is TimelockGuard_TestInit {
     }
 
     /// @notice Checks configuration reverts when the contract is too old.
-    function test_configureTimelockGuard_revertsIfVersionTooNew_reverts() external {
+    function test_configureTimelockGuard_withVersionTooNew_reverts() external {
         // nosemgrep: sol-style-use-abi-encodecall
         vm.mockCall(address(safeInstance.safe), abi.encodeWithSignature("VERSION()"), abi.encode("1.5.0"));
         vm.expectRevert(TimelockGuard.TimelockGuard_InvalidVersion.selector, address(timelockGuard));
+        vm.prank(address(safeInstance.safe));
+        timelockGuard.configureTimelockGuard(TIMELOCK_DELAY);
+    }
+
+    /// @notice Checks configuration does not revert if using patch releases of supported versions.
+    ///         Safe Versions: https://github.com/safe-global/safe-smart-account/tags
+    function test_configureTimelockGuard_withPatchReleases_succeeds() external {
+        // nosemgrep: sol-style-use-abi-encodecall
+        vm.mockCall(address(safeInstance.safe), abi.encodeWithSignature("VERSION()"), abi.encode("1.3.0-rc.1"));
         vm.prank(address(safeInstance.safe));
         timelockGuard.configureTimelockGuard(TIMELOCK_DELAY);
     }

--- a/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
+++ b/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
@@ -313,6 +313,15 @@ contract TimelockGuard_ConfigureTimelockGuard_Test is TimelockGuard_TestInit {
         timelockGuard.configureTimelockGuard(TIMELOCK_DELAY);
     }
 
+    /// @notice Checks configuration reverts when the contract is too old.
+    function test_configureTimelockGuard_revertsIfVersionTooNew_reverts() external {
+        // nosemgrep: sol-style-use-abi-encodecall
+        vm.mockCall(address(safeInstance.safe), abi.encodeWithSignature("VERSION()"), abi.encode("1.5.0"));
+        vm.expectRevert(TimelockGuard.TimelockGuard_InvalidVersion.selector, address(timelockGuard));
+        vm.prank(address(safeInstance.safe));
+        timelockGuard.configureTimelockGuard(TIMELOCK_DELAY);
+    }
+
     /// @notice Asserts the maximum valid delay configures successfully.
     function test_configureTimelockGuard_acceptsMaxValidDelay_succeeds() external {
         vm.expectEmit(true, true, true, true);


### PR DESCRIPTION
Fixed the version check in TimelockGuard to be >=1.3.0 && <1.5.0, with reasons in the comments.

Added a version check for LivenessModule2 to be >=1.3.0 && <1.6.0, with reasons in the comments.