### PR TITLE
op-acceptance-tests: Edge cases with engine APIs

### DIFF
--- a/op-acceptance-tests/tests/sync/elsync/gap_clp2p/sync_test.go
+++ b/op-acceptance-tests/tests/sync/elsync/gap_clp2p/sync_test.go
@@ -1,6 +1,7 @@
 package gap_clp2p
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
@@ -67,4 +68,86 @@ func TestReachUnsafeTipByAppendingUnsafePayload(gt *testing.T) {
 	// Try once more to check that filling in the gap works again
 	logger.Info("Second trial for appending payload until tip")
 	sys.L2CLB.AppendUnsafePayloadUntilTip(sys.L2ELB, sys.L2EL, 400)
+}
+
+// TestCLUnsafeNotRewoundOnInvalidDuringELSync verifies that the CL's unsafe head
+// is not rewound when the EL returns INVALID for a payload during EL sync.
+//
+// When the EL is still syncing and cannot append new blocks, ForkchoiceUpdate
+// returns SYNCING. In this state, the CL may continue to advance its unsafe head
+// as it processes new targets, creating temporary divergence from the EL.
+//
+// The test then crafts a payload that the EL can still validate—even though it is
+// not appendable to the EL's current head—by introducing a detectable fault in the
+// payload itself (e.g., malformed ExtraData). The CL relays this payload through
+// engine_newPayload, and the EL immediately responds INVALID based on intrinsic
+// payload validation. The EL does not advance or trigger sync for this payload,
+// and the CL's unsafe head remains unchanged, without rewinding.
+//
+// This confirms that an INVALID response during EL sync halts advancement but does
+// not cause the CL's unsafe head to regress, preserving the last known valid head
+// while maintaining correct Engine API semantics.
+func TestCLUnsafeNotRewoundOnInvalidDuringELSync(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewSingleChainMultiNodeWithoutCheck(t)
+	logger := t.Logger()
+	require := t.Require()
+
+	// Advance few blocks to make sure reference node advanced
+	sys.L2CL.Advanced(types.LocalUnsafe, 7, 30)
+
+	// Restart L2CLB to always trigger an EL Sync
+	sys.L2CLB.Stop()
+	// Wipe out L2ELB state to start from genesis
+	sys.L2ELB.Stop()
+	sys.L2ELB.Start()
+	sys.L2CLB.Start()
+
+	// At this point, L2ELB has no ELP2P and no safe advancement because batcher is stopped
+	startNum := sys.L2ELB.BlockRefByLabel(eth.Unsafe).Number
+	sys.L2CLB.UnsafeHead().NumEqualTo(startNum)
+
+	attempts := 3
+	// Check CL and EL divergence when there is a unsafe gap
+	for _, gap := range []uint64{3, 5} {
+		targetNum := startNum + gap
+		sys.L2CLB.SignalTarget(sys.L2EL, targetNum)
+		sys.L2ELB.NotAdvanced(eth.Unsafe)
+		sys.L2ELB.UnsafeHead().NumEqualTo(startNum)
+		// Check FCU returns SYNCING
+		sys.L2ELB.ForkchoiceUpdate(sys.L2EL, targetNum, startNum, startNum, nil).Retry(attempts).ResultAllSyncing()
+		// Even though EL did not advance, CL advanced
+		sys.L2CLB.UnsafeHead().NumEqualTo(targetNum)
+		logger.Info("CL and EL diverged", "CL", targetNum, "EL", startNum)
+	}
+
+	// Inject invalid payload that can be only checked by the EL
+	// Must choose payload number after than CL unsafe to make the payload sent to EL
+	targetNum := sys.L2CLB.UnsafeHead().BlockRef.Number + 1
+	payload := sys.L2EL.PayloadByNumber(targetNum)
+	// inject fault to the payload
+	// Altering extradata makes EL return INVALID even if the EL does not have state to validate
+	// EL will not trigger EL Sync because EL already knows that the payload is INVALID
+	payload.ExecutionPayload.ExtraData = bytes.Repeat([]byte{0xFF}, 32)
+	newHash, ok := payload.CheckBlockHash()
+	require.False(ok)
+	logger.Info("Injected fault to payload", "newHash", newHash, "prevHash", payload.ExecutionPayload.BlockHash)
+	payload.ExecutionPayload.BlockHash = newHash
+	_, ok = payload.CheckBlockHash()
+	require.True(ok)
+	sys.L2CLB.PostUnsafePayload(payload)
+	sys.L2CLB.NotAdvanced(types.LocalUnsafe, attempts)
+	sys.L2ELB.NotAdvanced(eth.Unsafe)
+	// EL did not advance
+	sys.L2ELB.UnsafeHead().NumEqualTo(startNum)
+	// CL did not advance
+	sys.L2CLB.UnsafeHead().NumEqualTo(startNum + 5)
+	// Check newPayload returns INVALID
+	// ex) op-geth error msg: "ignoring bad block: holocene extraData should be 9 bytes, got 32"
+	sys.L2ELB.NewPayloadRaw(payload).IsInvalid()
+
+	t.Cleanup(func() {
+		sys.L2ELB.Start()
+		sys.L2CLB.Start()
+	})
 }

--- a/op-acceptance-tests/tests/sync/elsync/gap_elp2p/sync_test.go
+++ b/op-acceptance-tests/tests/sync/elsync/gap_elp2p/sync_test.go
@@ -276,3 +276,69 @@ func TestELP2PFCUInvalidHash(gt *testing.T) {
 		sys.L2ELB.DisconnectPeerWith(sys.L2EL)
 	})
 }
+
+func TestSafeDoesNotAdvanceWhenUnsafeIsSyncing_NoELP2P(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewSingleChainMultiNodeWithoutCheck(t)
+	logger := t.Logger()
+
+	// Advance few blocks to make sure reference node advanced
+	sys.L2CL.Advanced(types.LocalUnsafe, 10, 30)
+
+	sys.L2CLB.Stop()
+
+	// At this point, L2ELB has no ELP2P, and L2CL connection
+	startNum := sys.L2ELB.BlockRefByLabel(eth.Unsafe).Number
+
+	// Try to advance non canonical chain
+	targetNum := startNum + 1
+	logger.Info("NewPayload", "target", targetNum)
+	sys.L2ELB.NewPayload(sys.L2EL, targetNum).IsValid()
+
+	// FCU to advance unsafe and safe normally, promoting non canonical chain to canonical
+	logger.Info("ForkchoiceUpdate", "target", targetNum)
+	sys.L2ELB.ForkchoiceUpdate(sys.L2EL, targetNum, targetNum, 0, nil).IsValid()
+	sys.L2ELB.UnsafeHead().NumEqualTo(targetNum)
+	sys.L2ELB.SafeHead().NumEqualTo(targetNum)
+	logger.Info("Canonical chain advanced for unsafe and safe", "number", targetNum)
+
+	// Try to advance non canonical chain
+	safeTargetNum := startNum + 2
+	logger.Info("NewPayload", "target", safeTargetNum)
+	sys.L2ELB.NewPayload(sys.L2EL, safeTargetNum).IsValid()
+
+	// FCU safe normally, but target unsafe which cannot be synced because of the gap
+	unsafeTargetNum := safeTargetNum + 5
+	attempts := 5
+	logger.Info("ForkchoiceUpdate", "safeTarget", safeTargetNum, "unsafeTarget", unsafeTargetNum)
+	sys.L2ELB.ForkchoiceUpdate(sys.L2EL, unsafeTargetNum, safeTargetNum, 0, nil).Retry(attempts).ResultAllSyncing()
+	sys.L2ELB.UnsafeHead().NumEqualTo(targetNum)
+	sys.L2ELB.SafeHead().NumEqualTo(targetNum)
+	logger.Info("Canonical chain not advanced for unsafe and safe", "number", targetNum)
+
+	// Try to advance non canonical chain
+	safeTargetNum = startNum + 3
+	logger.Info("NewPayload", "target", safeTargetNum)
+	sys.L2ELB.NewPayload(sys.L2EL, safeTargetNum).IsValid()
+
+	// FCU safe normally, but target unsafe which cannot be synced because of the gap
+	unsafeTargetNum = safeTargetNum + 6
+	logger.Info("ForkchoiceUpdate", "safeTarget", safeTargetNum, "unsafeTarget", unsafeTargetNum)
+	sys.L2ELB.ForkchoiceUpdate(sys.L2EL, unsafeTargetNum, safeTargetNum, 0, nil).Retry(attempts).ResultAllSyncing()
+	sys.L2ELB.UnsafeHead().NumEqualTo(targetNum)
+	sys.L2ELB.SafeHead().NumEqualTo(targetNum)
+	logger.Info("Canonical chain not advanced for unsafe and safe", "number", targetNum)
+
+	// Enable EL P2P to update both unsafe and safe at once using EL Sync
+	sys.L2ELB.PeerWith(sys.L2EL)
+	logger.Info("ForkchoiceUpdate", "safeTarget", safeTargetNum, "unsafeTarget", unsafeTargetNum)
+	sys.L2ELB.ForkchoiceUpdate(sys.L2EL, unsafeTargetNum, safeTargetNum, 0, nil).WaitUntilValid(attempts)
+	sys.L2ELB.UnsafeHead().NumEqualTo(unsafeTargetNum)
+	sys.L2ELB.SafeHead().NumEqualTo(safeTargetNum)
+	logger.Info("Canonical chain advanced for unsafe and safe", "safeTarget", safeTargetNum, "unsafeTarget", unsafeTargetNum)
+
+	t.Cleanup(func() {
+		sys.L2CLB.Start()
+		sys.L2ELB.DisconnectPeerWith(sys.L2EL)
+	})
+}

--- a/op-acceptance-tests/tests/sync/elsync/gap_elp2p/sync_test.go
+++ b/op-acceptance-tests/tests/sync/elsync/gap_elp2p/sync_test.go
@@ -234,6 +234,21 @@ func TestL2ELP2PCanonicalChainAdvancedByFCU(gt *testing.T) {
 	})
 }
 
+// TestELP2PFCUInvalidHash verifies that when an Execution Layer (EL) client
+// receives a Forkchoice Update (FCU) with an unknown head hash (invalid or
+// non-existent) during EL syncing, it remains in the "SYNCING" state and does
+// not advance its canonical chain.
+//
+// In this scenario, the node is EL syncing, and the target forkchoice head hash
+// does not exist in any connected EL peers. When the EL processes an FCU with
+// such an unknown hash, it attempts to fetch the corresponding block from peers
+// once. If the block cannot be retrieved, the EL reports SYNCING. The EL will not
+// retry automatically, but each subsequent FCU with the same unknown hash will
+// trigger another one-time fetch attempt, again resulting in SYNCING.
+//
+// This behavior ensures that the EL client safely handles invalid or unknown
+// forkchoice targets by consistently reporting SYNCING for each FCU attempt
+// and by avoiding advancement of the chain on invalid data.
 func TestELP2PFCUInvalidHash(gt *testing.T) {
 	t := devtest.SerialT(gt)
 	sys := presets.NewSingleChainMultiNodeWithoutCheck(t)
@@ -277,6 +292,19 @@ func TestELP2PFCUInvalidHash(gt *testing.T) {
 	})
 }
 
+// TestSafeDoesNotAdvanceWhenUnsafeIsSyncing_NoELP2P verifies Engine API semantics
+// where ForkchoiceUpdate (FCU) validates the unsafe target first and, if the unsafe
+// head is not directly appendable (e.g., there is a gap), FCU returns SYNCING and
+// exits early without updating the safe head—even when the provided safe hash is
+// independently appendable.
+//
+// The presence or absence of EL P2P is not the core factor here. Disabling EL P2P
+// in this test simply makes the gap persist so the condition is observable. The
+// key behavior is that FCU's unsafe-first check causes an early return, so the safe
+// head is not bumped when the unsafe target cannot be immediately synced.
+//
+// This validates that safe head updates are contingent on the unsafe target passing
+// appendability/sync checks first, per Engine API behavior.
 func TestSafeDoesNotAdvanceWhenUnsafeIsSyncing_NoELP2P(gt *testing.T) {
 	t := devtest.SerialT(gt)
 	sys := presets.NewSingleChainMultiNodeWithoutCheck(t)
@@ -343,6 +371,27 @@ func TestSafeDoesNotAdvanceWhenUnsafeIsSyncing_NoELP2P(gt *testing.T) {
 	})
 }
 
+// TestInvalidPayloadThroughCLP2P verifies that invalid L2 payloads propagated via
+// CL P2P (simulated with admin_postUnsafePayload) do not advance either the CL or EL.
+//
+// The test first confirms normal progress on a valid target, then exercises three
+// invalid cases and asserts no advancement on both sides (unsafe head remains at
+// startNum+1):
+//
+//  1. CL-detectable invalidity (bad block hash):
+//     The payload is mutated (e.g., StateRoot) without updating BlockHash.
+//     The CL rejects it immediately (hash mismatch) and does not relay it to the EL.
+//
+//  2. EL-only invalidity (bad state root):
+//     The payload's BlockHash is recomputed so the CL relays it via engine_newPayload,
+//     but the EL rejects it during execution due to an invalid state root.
+//
+//  3. EL-only invalidity via invalid parent:
+//     A new payload builds on a previously rejected block (an invalid parent),
+//     causing the EL to reject it as referencing an invalid ancestor.
+//
+// In all scenarios, both CL and EL remain at the same head height, confirming that
+// invalid payloads—whether rejected at the CL or EL—do not advance the chain.
 func TestInvalidPayloadThroughCLP2P(gt *testing.T) {
 	t := devtest.SerialT(gt)
 	sys := presets.NewSingleChainMultiNodeWithoutCheck(t)

--- a/op-acceptance-tests/tests/sync/elsync/gap_elp2p/sync_test.go
+++ b/op-acceptance-tests/tests/sync/elsync/gap_elp2p/sync_test.go
@@ -7,7 +7,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
-	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
 )
 
 // TestL2ELP2PCanonicalChainAdvancedByFCU verifies the interaction between NewPayload,
@@ -226,6 +227,49 @@ func TestL2ELP2PCanonicalChainAdvancedByFCU(gt *testing.T) {
 	_, err = sys.L2ELB.Escape().L2EthClient().BlockRefByNumber(t.Ctx(), targetNum)
 	require.ErrorIs(err, ethereum.NotFound)
 	sys.L2ELB.ForkchoiceUpdate(sys.L2EL, targetNum, 0, 0, nil).IsSyncing()
+
+	t.Cleanup(func() {
+		sys.L2CLB.Start()
+		sys.L2ELB.DisconnectPeerWith(sys.L2EL)
+	})
+}
+
+func TestELP2PFCUInvalidHash(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewSingleChainMultiNodeWithoutCheck(t)
+	logger := t.Logger()
+	genesis := sys.L2ELB.BlockRefByNumber(0)
+
+	// Advance few blocks to make sure reference node advanced
+	sys.L2CL.Advanced(types.LocalUnsafe, 10, 30)
+
+	sys.L2CLB.Stop()
+
+	// At this point, L2ELB has no ELP2P, and L2CL connection
+	startNum := sys.L2ELB.BlockRefByLabel(eth.Unsafe).Number
+
+	// Peer to confirm EL Syncing is working
+	sys.L2ELB.PeerWith(sys.L2EL)
+
+	// Trigger EL Sync to valid hash
+	targetNum := startNum + 3
+	attempts := 5
+	sys.L2ELB.ForkchoiceUpdate(sys.L2EL, targetNum, 0, 0, nil).WaitUntilValid(attempts)
+	// head advanced
+	sys.L2ELB.UnsafeHead().NumEqualTo(targetNum)
+	logger.Info("Canonical chain advanced", "number", targetNum)
+
+	unsafeHashInvalid := common.MaxHash // must be non-existent invalid hash
+	// We retry FCU using the invalid hash
+	// The ELP2P enabled L2EL will ask other peers but fail to fetch the block with the invalid hash
+	// Example logs from L2EL(geth)
+	//  "Fetching the unknown forkchoice head from network"  hash=0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+	//  "Fetching batch of headers"
+	//  "Could not retrieve unknown head from peers"
+	sys.L2ELB.ForkchoiceUpdateRaw(unsafeHashInvalid, genesis.Hash, genesis.Hash, nil).Retry(attempts).ResultAllSyncing()
+
+	sys.L2ELB.UnsafeHead().NumEqualTo(targetNum)
+	logger.Info("Canonical chain not advanced", "number", targetNum)
 
 	t.Cleanup(func() {
 		sys.L2CLB.Start()

--- a/op-acceptance-tests/tests/sync/elsync/gap_elp2p/sync_test.go
+++ b/op-acceptance-tests/tests/sync/elsync/gap_elp2p/sync_test.go
@@ -348,6 +348,7 @@ func TestInvalidPayloadThroughCLP2P(gt *testing.T) {
 	sys := presets.NewSingleChainMultiNodeWithoutCheck(t)
 	logger := t.Logger()
 	require := t.Require()
+	ctx := t.Ctx()
 
 	// Advance few blocks to make sure reference node advanced
 	sys.L2CL.Advanced(types.LocalUnsafe, 4, 30)
@@ -364,10 +365,23 @@ func TestInvalidPayloadThroughCLP2P(gt *testing.T) {
 
 	// Assume sequencer crafted invalid payload and broadcasted via P2P
 	// Simulate the situation using the admin_postUnsafePayload API
+
+	// Scenario 1: Invalid Payload can be checked at the CL side
 	targetNum = startNum + 2
 	payload := sys.L2EL.PayloadByNumber(targetNum)
-	// inject fault to the payload and provide to the L2CLB
+	// inject fault to the payload
 	payload.ExecutionPayload.StateRoot = eth.Bytes32{}
+	logger.Info("Injected fault to payload but not updated hash")
+	// Post invalid payload with the fault that can be checked at the CL side
+	require.Error(sys.L2CLB.Escape().RollupAPI().PostUnsafePayload(ctx, payload))
+	// ex) op-node error msg: "payload has bad block hash"
+	// CL will not send the payload but drop immediately due to hash mismatch
+	// EL did not advance
+	sys.L2ELB.UnsafeHead().NumEqualTo(startNum + 1)
+	// CL did not advance
+	sys.L2CLB.UnsafeHead().NumEqualTo(startNum + 1)
+
+	// Scenario 2: Invalid Payload can be only checked at the EL side
 	// Make sure to update the block hash included at payload to CL relay the payload to the EL
 	newHash, ok := payload.CheckBlockHash()
 	require.False(ok)
@@ -378,9 +392,30 @@ func TestInvalidPayloadThroughCLP2P(gt *testing.T) {
 	// L2CLB will relay the payload to the L2ELB using the engine_newPayload
 	// L2ELB will return INVALID because payload is invalid, due to wrong stateRoot
 	// ex) op-geth will call InsertBlockWithoutSetHead() to execute the payload while engine_newPayload
-
 	// Post invalid payload with the fault that can be only checked at the EL side
 	sys.L2CLB.PostUnsafePayload(payload)
+	// ex) op-geth error msg: "ignoring bad block: invalid merkle root"
+	sys.L2CLB.NotAdvanced(types.LocalUnsafe, attempts)
+	sys.L2ELB.NotAdvanced(eth.Unsafe)
+	// EL did not advance
+	sys.L2ELB.UnsafeHead().NumEqualTo(startNum + 1)
+	// CL did not advance
+	sys.L2CLB.UnsafeHead().NumEqualTo(startNum + 1)
+
+	// Scenario 3: Invalid Payload can be only checked at the EL side, invalid because invalid parent
+	// Try to build on top of previously rejected block with block number startNum + 2
+	targetNum = startNum + 3
+	payload2 := sys.L2EL.PayloadByNumber(targetNum)
+	payload2.ExecutionPayload.ParentHash = payload.ExecutionPayload.BlockHash
+	newHash, ok = payload2.CheckBlockHash()
+	require.False(ok)
+	logger.Info("Updated payload parent to invalid payload", "newHash", newHash)
+	payload2.ExecutionPayload.BlockHash = newHash
+	_, ok = payload.CheckBlockHash()
+	require.True(ok)
+	// Post invalid payload with the fault that can be only checked at the EL side
+	sys.L2CLB.PostUnsafePayload(payload)
+	// ex) op-geth error msg: "ignoring bad block: links to previously rejected block"
 	sys.L2CLB.NotAdvanced(types.LocalUnsafe, attempts)
 	sys.L2ELB.NotAdvanced(eth.Unsafe)
 	// EL did not advance

--- a/op-acceptance-tests/tests/sync/elsync/gap_elp2p/sync_test.go
+++ b/op-acceptance-tests/tests/sync/elsync/gap_elp2p/sync_test.go
@@ -234,7 +234,7 @@ func TestL2ELP2PCanonicalChainAdvancedByFCU(gt *testing.T) {
 	})
 }
 
-// TestELP2PFCUInvalidHash verifies that when an Execution Layer (EL) client
+// TestELP2PFCUUnavailableHash verifies that when an Execution Layer (EL) client
 // receives a Forkchoice Update (FCU) with an unknown head hash (invalid or
 // non-existent) during EL syncing, it remains in the "SYNCING" state and does
 // not advance its canonical chain.
@@ -249,7 +249,7 @@ func TestL2ELP2PCanonicalChainAdvancedByFCU(gt *testing.T) {
 // This behavior ensures that the EL client safely handles invalid or unknown
 // forkchoice targets by consistently reporting SYNCING for each FCU attempt
 // and by avoiding advancement of the chain on invalid data.
-func TestELP2PFCUInvalidHash(gt *testing.T) {
+func TestELP2PFCUUnavailableHash(gt *testing.T) {
 	t := devtest.SerialT(gt)
 	sys := presets.NewSingleChainMultiNodeWithoutCheck(t)
 	logger := t.Logger()

--- a/op-acceptance-tests/tests/sync/elsync/gap_elp2p/sync_test.go
+++ b/op-acceptance-tests/tests/sync/elsync/gap_elp2p/sync_test.go
@@ -342,3 +342,49 @@ func TestSafeDoesNotAdvanceWhenUnsafeIsSyncing_NoELP2P(gt *testing.T) {
 		sys.L2ELB.DisconnectPeerWith(sys.L2EL)
 	})
 }
+
+func TestInvalidPayloadThroughCLP2P(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewSingleChainMultiNodeWithoutCheck(t)
+	logger := t.Logger()
+	require := t.Require()
+
+	// Advance few blocks to make sure reference node advanced
+	sys.L2CL.Advanced(types.LocalUnsafe, 4, 30)
+
+	// At this point, L2ELB has no ELP2P, and L2CL connection
+	startNum := sys.L2ELB.BlockRefByLabel(eth.Unsafe).Number
+
+	// We check L2ELB can be advanced using the valid payload first
+	attempts := 3
+	targetNum := startNum + 1
+	sys.L2CLB.SignalTarget(sys.L2EL, targetNum)
+	sys.L2ELB.Reached(eth.Unsafe, targetNum, attempts)
+	logger.Info("Canonical chain advanced", "number", targetNum)
+
+	// Assume sequencer crafted invalid payload and broadcasted via P2P
+	// Simulate the situation using the admin_postUnsafePayload API
+	targetNum = startNum + 2
+	payload := sys.L2EL.PayloadByNumber(targetNum)
+	// inject fault to the payload and provide to the L2CLB
+	payload.ExecutionPayload.StateRoot = eth.Bytes32{}
+	// Make sure to update the block hash included at payload to CL relay the payload to the EL
+	newHash, ok := payload.CheckBlockHash()
+	require.False(ok)
+	logger.Info("Injected fault to payload", "newHash", newHash, "prevHash", payload.ExecutionPayload.BlockHash)
+	payload.ExecutionPayload.BlockHash = newHash
+	_, ok = payload.CheckBlockHash()
+	require.True(ok)
+	// L2CLB will relay the payload to the L2ELB using the engine_newPayload
+	// L2ELB will return INVALID because payload is invalid, due to wrong stateRoot
+	// ex) op-geth will call InsertBlockWithoutSetHead() to execute the payload while engine_newPayload
+
+	// Post invalid payload with the fault that can be only checked at the EL side
+	sys.L2CLB.PostUnsafePayload(payload)
+	sys.L2CLB.NotAdvanced(types.LocalUnsafe, attempts)
+	sys.L2ELB.NotAdvanced(eth.Unsafe)
+	// EL did not advance
+	sys.L2ELB.UnsafeHead().NumEqualTo(startNum + 1)
+	// CL did not advance
+	sys.L2CLB.UnsafeHead().NumEqualTo(startNum + 1)
+}

--- a/op-devstack/dsl/engine.go
+++ b/op-devstack/dsl/engine.go
@@ -35,10 +35,14 @@ func (r *NewPayloadResult) IsValid() *NewPayloadResult {
 }
 
 type ForkchoiceUpdateResult struct {
-	T       devtest.T
-	Refresh func()
-	Result  *eth.ForkchoiceUpdatedResult
-	Err     error
+	T          devtest.T
+	Refresh    func()
+	Result     *eth.ForkchoiceUpdatedResult
+	ValidCnt   int // count for VALID response
+	SyncingCnt int // count for SYNCING response
+	InvalidCnt int // count for INVALID response
+	RefreshCnt int
+	Err        error
 }
 
 func (r *ForkchoiceUpdateResult) IsForkchoiceUpdatedStatus(status eth.ExecutePayloadStatus) *ForkchoiceUpdateResult {
@@ -72,11 +76,34 @@ func (r *ForkchoiceUpdateResult) WaitUntilValid(attempts int) *ForkchoiceUpdateR
 				return errors.New("forkchoice has empty result")
 			}
 			if r.Result.PayloadStatus.Status != eth.ExecutionValid {
-				r.T.Log("Wait for FCU to return valid", "status", r.Result.PayloadStatus.Status, "try_count", tryCnt)
+				r.T.Logger().Info("Wait for FCU to return valid", "status", r.Result.PayloadStatus.Status, "try_count", tryCnt)
 				return errors.New("still syncing")
 			}
 			return nil
 		})
 	r.T.Require().NoError(err)
 	return r
+}
+
+func (r *ForkchoiceUpdateResult) Retry(attempts int) *ForkchoiceUpdateResult {
+	tryCnt := 0
+	err := retry.Do0(r.T.Ctx(), attempts, &retry.FixedStrategy{Dur: 500 * time.Millisecond},
+		func() error {
+			r.Refresh()
+			tryCnt += 1
+			if r.Err != nil {
+				return fmt.Errorf("forkchoice returned error: %w", r.Err)
+			}
+			if r.Result == nil {
+				return errors.New("forkchoice has empty result")
+			}
+			r.T.Logger().Info("Retrying FCU", "status", r.Result.PayloadStatus.Status, "try_count", tryCnt)
+			return errors.New("retry")
+		})
+	r.T.Require().Error(err) // always return error for retrying
+	return r
+}
+
+func (r *ForkchoiceUpdateResult) ResultAllSyncing() {
+	r.T.Require().True(r.RefreshCnt == r.SyncingCnt)
 }

--- a/op-devstack/dsl/engine.go
+++ b/op-devstack/dsl/engine.go
@@ -105,5 +105,5 @@ func (r *ForkchoiceUpdateResult) Retry(attempts int) *ForkchoiceUpdateResult {
 }
 
 func (r *ForkchoiceUpdateResult) ResultAllSyncing() {
-	r.T.Require().True(r.RefreshCnt == r.SyncingCnt)
+	r.T.Require().Equal(r.RefreshCnt, r.SyncingCnt)
 }

--- a/op-devstack/dsl/engine.go
+++ b/op-devstack/dsl/engine.go
@@ -34,6 +34,12 @@ func (r *NewPayloadResult) IsValid() *NewPayloadResult {
 	return r
 }
 
+func (r *NewPayloadResult) IsInvalid() *NewPayloadResult {
+	r.IsPayloadStatus(eth.ExecutionInvalid)
+	r.T.Require().NoError(r.Err)
+	return r
+}
+
 type ForkchoiceUpdateResult struct {
 	T          devtest.T
 	Refresh    func()

--- a/op-devstack/dsl/l2_cl.go
+++ b/op-devstack/dsl/l2_cl.go
@@ -367,13 +367,18 @@ func (cl *L2CLNode) WaitForNonZeroUnsafeTime(ctx context.Context) *eth.SyncStatu
 	return ss
 }
 
-func (cl *L2CLNode) SignalTarget(el *L2ELNode, targetNum uint64) {
-	cl.log.Info("Signaling L2CL", "target", targetNum)
-	payload := el.PayloadByNumber(targetNum)
+func (cl *L2CLNode) SignalTarget(refNode *L2ELNode, targetNum uint64) {
+	cl.log.Info("Signaling L2CL", "target", targetNum, "refNode", refNode)
+	payload := refNode.PayloadByNumber(targetNum)
+	cl.PostUnsafePayload(payload)
+}
+
+func (cl *L2CLNode) PostUnsafePayload(payload *eth.ExecutionPayloadEnvelope) {
+	cl.log.Info("PostUnsafePayload", "target", payload.ExecutionPayload.BlockNumber)
 	err := retry.Do0(cl.ctx, 3, retry.Fixed(2*time.Second), func() error {
 		return cl.inner.RollupAPI().PostUnsafePayload(cl.ctx, payload)
 	})
-	cl.require.NoErrorf(err, "failed to post unsafe payload via admin API: target %d", targetNum)
+	cl.require.NoErrorf(err, "failed to post unsafe payload via admin API: target %d", payload.ExecutionPayload.BlockNumber)
 }
 
 func (cl *L2CLNode) Reset(lvl types.SafetyLevel, target eth.L2BlockRef) {
@@ -403,4 +408,8 @@ func (cl *L2CLNode) AppendUnsafePayloadUntilTip(verEL, seqEL *L2ELNode, maxAttem
 			cl.SignalTarget(seqEL, verUnsafe.Number+1)
 			return fmt.Errorf("unsafe gap with size %d still exists", gap)
 		}))
+}
+
+func (cl *L2CLNode) UnsafeHead() *BlockRefResult {
+	return &BlockRefResult{T: cl.t, BlockRef: cl.HeadBlockRef(types.LocalUnsafe)}
 }

--- a/op-devstack/dsl/l2_el.go
+++ b/op-devstack/dsl/l2_el.go
@@ -258,6 +258,11 @@ func (el *L2ELNode) PayloadByNumber(number uint64) *eth.ExecutionPayloadEnvelope
 func (el *L2ELNode) NewPayload(refNode *L2ELNode, number uint64) *NewPayloadResult {
 	el.log.Info("NewPayload", "number", number, "node", el, "refNode", refNode)
 	payload := refNode.PayloadByNumber(number)
+	return el.NewPayloadRaw(payload)
+}
+
+func (el *L2ELNode) NewPayloadRaw(payload *eth.ExecutionPayloadEnvelope) *NewPayloadResult {
+	el.log.Info("NewPayloadRaw", "number", payload.ExecutionPayload.BlockNumber)
 	status, err := el.inner.L2EngineClient().NewPayload(el.ctx, payload.ExecutionPayload, payload.ParentBeaconBlockRoot)
 	return &NewPayloadResult{T: el.t, Status: status, Err: err}
 }

--- a/op-devstack/dsl/l2_el.go
+++ b/op-devstack/dsl/l2_el.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -263,17 +264,39 @@ func (el *L2ELNode) NewPayload(refNode *L2ELNode, number uint64) *NewPayloadResu
 
 // ForkchoiceUpdate fetches FCU target hashes from the reference EL node, and FCU update with attributes
 func (el *L2ELNode) ForkchoiceUpdate(refNode *L2ELNode, unsafe, safe, finalized uint64, attr *eth.PayloadAttributes) *ForkchoiceUpdateResult {
+	unsafeHash := refNode.BlockRefByNumber(unsafe).Hash
+	safeHash := refNode.BlockRefByNumber(safe).Hash
+	finalizedHash := refNode.BlockRefByNumber(finalized).Hash
+	el.log.Info("ForkchoiceUpdate with reference node", "unsafe", unsafe, "safe", safe, "finalized", finalized, "node", el, "refNode", refNode)
+	return el.ForkchoiceUpdateRaw(unsafeHash, safeHash, finalizedHash, attr)
+}
+
+// ForkchoiceUpdateRaw calls FCU with block hashes with attributes
+func (el *L2ELNode) ForkchoiceUpdateRaw(unsafe, safe, finalized common.Hash, attr *eth.PayloadAttributes) *ForkchoiceUpdateResult {
 	result := &ForkchoiceUpdateResult{T: el.t}
 	refresh := func() {
-		el.log.Info("ForkchoiceUpdate", "unsafe", unsafe, "safe", safe, "finalized", finalized, "attr", attr, "node", el, "refNode", refNode)
+		result.RefreshCnt += 1
+		el.log.Info("ForkchoiceUpdateRaw", "unsafe", unsafe, "safe", safe, "finalized", finalized, "attr", attr, "node", el)
 		state := &eth.ForkchoiceState{
-			HeadBlockHash:      refNode.BlockRefByNumber(unsafe).Hash,
-			SafeBlockHash:      refNode.BlockRefByNumber(safe).Hash,
-			FinalizedBlockHash: refNode.BlockRefByNumber(finalized).Hash,
+			HeadBlockHash:      unsafe,
+			SafeBlockHash:      safe,
+			FinalizedBlockHash: finalized,
 		}
 		res, err := el.inner.L2EngineClient().ForkchoiceUpdate(el.ctx, state, attr)
 		result.Result = res
 		result.Err = err
+		if result.Result != nil {
+			switch result.Result.PayloadStatus.Status {
+			case eth.ExecutionValid:
+				result.ValidCnt += 1
+			case eth.ExecutionSyncing:
+				result.SyncingCnt += 1
+			case eth.ExecutionInvalid:
+				result.InvalidCnt += 1
+			default:
+				el.require.NoError(fmt.Errorf("invalid fcu payload status: %s", result.Result.PayloadStatus.Status))
+			}
+		}
 	}
 	result.Refresh = refresh
 	result.Refresh()
@@ -320,4 +343,22 @@ func (el *L2ELNode) MatchedFn(refNode SyncStatusProvider, lvl types.SafetyLevel,
 
 func (el *L2ELNode) Matched(refNode SyncStatusProvider, lvl types.SafetyLevel, attempts int) {
 	el.require.NoError(el.MatchedFn(refNode, lvl, attempts)())
+}
+
+func (el *L2ELNode) UnsafeHead() *BlockRefResult {
+	return &BlockRefResult{T: el.t, BlockRef: el.BlockRefByLabel(eth.Unsafe)}
+}
+
+func (el *L2ELNode) SafeHead() *BlockRefResult {
+	return &BlockRefResult{T: el.t, BlockRef: el.BlockRefByLabel(eth.Safe)}
+}
+
+type BlockRefResult struct {
+	T        devtest.T
+	BlockRef eth.L2BlockRef
+}
+
+func (r *BlockRefResult) NumEqualTo(num uint64) *BlockRefResult {
+	r.T.Require().Equal(num, r.BlockRef.Number)
+	return r
 }


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Adds acceptance tests to lock down the edge cases with engine API interactions, between CL and the EL. All are related with the removal of RR Sync.

**Tests**

1. `TestELP2PFCUUnavailableHash`
```
// TestELP2PFCUUnavailableHash verifies that when an Execution Layer (EL) client
// receives a Forkchoice Update (FCU) with an unknown head hash (invalid or
// non-existent) during EL syncing, it remains in the "SYNCING" state and does
// not advance its canonical chain.
```
No action items.

2. `TestSafeDoesNotAdvanceWhenUnsafeIsSyncing_NoELP2P`
```
// TestSafeDoesNotAdvanceWhenUnsafeIsSyncing_NoELP2P verifies Engine API semantics
// where ForkchoiceUpdate (FCU) validates the unsafe target first and, if the unsafe
// head is not directly appendable (e.g., there is a gap), FCU returns SYNCING and
// exits early without updating the safe head—even when the provided safe hash is
// independently appendable.
```
Action item: We may still want to advance the safe head while we are EL Syncing, and this test shows op-node might not advance unsafe heads due to `FCU` behavior. Check op-node behavior.

3. `TestInvalidPayloadThroughCLP2P`
```
// TestInvalidPayloadThroughCLP2P verifies that invalid L2 payloads propagated via
// CL P2P (simulated with admin_postUnsafePayload) do not advance either the CL or EL.
//
// The test first confirms normal progress on a valid target, then exercises three
// invalid cases and asserts no advancement on both sides (unsafe head remains at
// startNum+1):
//
//  1. CL-detectable invalidity (bad block hash):
//     The payload is mutated (e.g., StateRoot) without updating BlockHash.
//     The CL rejects it immediately (hash mismatch) and does not relay it to the EL.
//
//  2. EL-only invalidity (bad state root):
//     The payload's BlockHash is recomputed so the CL relays it via engine_newPayload,
//     but the EL rejects it during execution due to an invalid state root.
//
//  3. EL-only invalidity via invalid parent:
//     A new payload builds on a previously rejected block (an invalid parent),
//     causing the EL to reject it as referencing an invalid ancestor.
```
The CL and the EL will not advance its unsafe heads if the payload is INVALID. More precisely, if the `engine_newPayload` returned INVALID, there will be no further `engine_forkchoiceUpdate` call, as well as NOT bumping the unsafe head. So we never update the CL's unsafe head if the result is INVALID. In other words, unsafe head which can be queried from CL's engine API responses were not INVALID, but rather VALID or SYNCING.

Related: https://github.com/ethereum-optimism/optimism/issues/17627#issuecomment-3369432912

4. `TestCLUnsafeNotRewoundOnInvalidDuringELSync`
```
// TestCLUnsafeNotRewoundOnInvalidDuringELSync verifies that the CL's unsafe head
// is not rewound when the EL returns INVALID for a payload during EL sync.
//
// When the EL is still syncing and cannot append new blocks, ForkchoiceUpdate
// returns SYNCING. In this state, the CL may continue to advance its unsafe head
// as it processes new targets, creating temporary divergence from the EL.
//
// The test then crafts a payload that the EL can still validate—even though it is
// not appendable to the EL's current head—by introducing a detectable fault in the
// payload itself (e.g., malformed ExtraData). The CL relays this payload through
// engine_newPayload, and the EL immediately responds INVALID based on intrinsic
// payload validation. The EL does not advance or trigger sync for this payload,
// and the CL's unsafe head remains unchanged, without rewinding.
//
// This confirms that an INVALID response during EL sync halts advancement but does
// not cause the CL's unsafe head to regress, preserving the last known valid head
// while maintaining correct Engine API semantics.
```
op-node does not rewind unsafe head which was advanced while EL Syncing when `engine_newPayload` response is INVALID. For example consider the following scenario:
1. op-node / op-geth synced to block N
    - op-node unsafe: N, op-geth unsafe: N
2. op-node receives unsafe payload N + 2 and injects to EL. op-node EL syncs. op-geth returns SYNCING. 
    - op-node unsafe: N + 2, op-geth unsafe: N
3. op-node receives unsafe payload N + 4 and injects to EL. op-node EL syncs. op-geth returns SYNCING. 
    - op-node unsafe: N + 4, op-geth unsafe: N
4. op-node receives unsafe payload N + 5, and injects to EL.
    - The payload was INVALID, EL was able to determine the payload state
    - op-node unsafe is still N + 4, op-geth unsafe: N
So when INVALID is observed to the op-node while EL Syncing(VALID -> SYNCING -> ... -> SYNCING -> INVALID), we may need to rewind the op-node's unsafe label to N, not staying at N + 4.

Action item: We may patch op-node to rewind the unsafe head when INVALID encountered while EL Syncing

Related: https://github.com/ethereum-optimism/optimism/issues/17627#issuecomment-3369432912

We may choose one of 
1. Reset unsafe head to the last unsafe head we got a VALID response for (not SYNCING!)
    - If we do nothing, the unsafe head will stay at SYNCING
2. Reset unsafe head back to the current unsafe head according to the EL
3. Reset unsafe head back to the safe head we're sending
4. Do a full reset of the derivation pipeline

**Additional context**

These tests were added to lock in the behavior while discussing the edge cases of EL Syncing. Tracked at https://github.com/ethereum-optimism/optimism/issues/17694


