### PR TITLE
chore: Bump circleci-utils orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ orbs:
   slack: circleci/slack@6.0.0
   shellcheck: circleci/shellcheck@3.2.0
   codecov: codecov/codecov@5.0.3
-  utils: ethereum-optimism/circleci-utils@dev:first
+  utils: ethereum-optimism/circleci-utils@1.0.22
   docker: circleci/docker@2.8.2
   github-cli: circleci/github-cli@2.7.0
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ orbs:
   slack: circleci/slack@6.0.0
   shellcheck: circleci/shellcheck@3.2.0
   codecov: codecov/codecov@5.0.3
-  utils: ethereum-optimism/circleci-utils@1.0.20
+  utils: ethereum-optimism/circleci-utils@dev:first
   docker: circleci/docker@2.8.2
   github-cli: circleci/github-cli@2.7.0
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

CircleCI will [switch all checkouts to blobless on November 3rd](https://circleci.com/changelog/default-method-used-to-checkout-code-from-your-repository-is-changing-on-nov/). Since this repo is too complex to try and `blobless`, this PR goes down the safe pathway by bumping the `circleci-utils` orb to a version that defaults the checkout method to `full`. `blobless` can then be rolled out without any time pressure.