### PR TITLE
op-node/rollup: Introduce MaxSequencerDrift Fjord const override

### DIFF
--- a/op-node/rollup/chain_spec.go
+++ b/op-node/rollup/chain_spec.go
@@ -156,17 +156,14 @@ func (s *ChainSpec) MaxRLPBytesPerChannel(t uint64) uint64 {
 	return maxRLPBytesPerChannelBedrock
 }
 
-// IsFeatMaxSequencerDriftConstant specifies in which fork the max sequencer drift change to a
-// constant will be performed.
-func (s *ChainSpec) IsFeatMaxSequencerDriftConstant(t uint64) bool {
-	return s.config.IsFjord(t)
-}
-
 // MaxSequencerDrift returns the maximum sequencer drift for the given block timestamp. Until Fjord,
 // this was a rollup configuration parameter. Since Fjord, it is a constant, so its effective value
 // should always be queried via the ChainSpec.
 func (s *ChainSpec) MaxSequencerDrift(t uint64) uint64 {
-	if s.IsFeatMaxSequencerDriftConstant(t) {
+	if s.config.IsFjord(t) {
+		if msdOverride := s.config.MaxSequencerDriftFjord; msdOverride != nil {
+			return *msdOverride
+		}
 		return maxSequencerDriftFjord
 	}
 	return s.config.MaxSequencerDrift

--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -163,6 +163,10 @@ type Config struct {
 	// This feature (de)activates by L1 origin timestamp, to keep a consistent L1 block info per L2
 	// epoch.
 	PectraBlobScheduleTime *uint64 `json:"pectra_blob_schedule_time,omitempty"`
+
+	// Optional override of the default constant (1800) max sequencer drift that Fjord introduces.
+	// Standard chains must leave this field unset. If nil, the default constant is used.
+	MaxSequencerDriftFjord *uint64 `json:"max_sequencer_drift_fjord,omitempty"`
 }
 
 // ValidateL1Config checks L1 config variables for errors.


### PR DESCRIPTION
**Description**

There are OP Stack chains that want to use a different max sequencer drift constant than the one introduced with Fjord.

This PR is a sketch for how this could be done in an optional way using a new optional field in the rollup config.

It should be noted that standard chains must not set this.

The PR also removes the feature flag, since the Fjord spec is sealed.

