### PR TITLE
Enable monitoring in sysgo

### DIFF
--- a/op-devstack/README.md
+++ b/op-devstack/README.md
@@ -147,27 +147,45 @@ and returns a typed output that the test then may use.
 
 ## Environment Variables
 
-The following environment variables can be used to configure devstack:
+### The following environment variables can be used to configure devstack:
 
 - `DEVSTACK_ORCHESTRATOR`: Configures the preferred orchestrator kind (see Orchestrator interface section above).
 - `DEVSTACK_KEYS_SALT`: Seeds the keys generated with `NewHDWallet`. This is useful for "isolating" test runs, and might be needed to reproduce CI and/or acceptance test runs. It can be any string, including the empty one to use the "usual" devkeys.
 - `DEVNET_ENV_URL`: Used when `DEVSTACK_ORCHESTRATOR=sysext` to specify the network descriptor URL.
 - `DEVNET_EXPECT_PRECONDITIONS_MET`: This can be set of force test failures when their pre-conditions are not met, which would otherwise result in them being skipped. This is helpful in particular for runs that do intend to run specific tests (as opposed to whatever is available). `op-acceptor` does set that variable, for example.
 
-Rust stack env vars:
+### Rust stack env vars:
 - `DEVSTACK_L2CL_KIND=kona` to select kona as default L2 CL node
 - `DEVSTACK_L2EL_KIND=op-reth` to select op-reth as default L2 EL node
 - `KONA_NODE_EXEC_PATH=/home/USERHERE/projects/kona/target/debug/kona-node` to select the kona-node executable to run
 - `OP_RETH_EXEC_PATH=/home/USERHERE/projects/reth/target/release/op-reth` to select the op-reth executable to run
 
-Go stack env vars:
+### Go stack env vars:
 - `DEVSTACK_L1EL_KIND=geth` to select geth as default L1 EL node
 - `SYSGO_GETH_EXEC_PATH=/path/to/geth` to select the geth executable to run
 
-L2 Observability env vars (note: only applicable if any L2 component calls `Orchestrator.RegisterL2MetricsEndpoints`):
-- `SYSGO_DOCKER_EXEC_PATH` to set local path to docker executable (defaults to `/usr/local/bin/docker`)
+### Metrics env vars (note: only applicable if any L2 component calls `Orchestrator.RegisterL2MetricsEndpoints`):
+- `SYSGO_DOCKER_EXEC_PATH` path to docker executable (defaults to `docker` assuming it is in your `PATH`)
 - `SYSGO_GRAFANA_PROVISIONING_DIR` to provide a local grafana provisioning dir to use (otherwise a temp dir will be created and removed at the end of tests)
 - `SYSGO_GRAFANA_DATA_DIR` to provide a local grafana data dir to use (otherwise a temp dir will be created and removed at the end of tests)
+- `KONA_METRICS_ENABLED` set to `true` to enable `kona-node` instances to report metrics.
+- `OP_RETH_METRICS_ENABLED` set to `true` to enable `op-reth` instances to report metrics.
 
-Other useful env vars:
+### Other useful env vars:
 - `DISABLE_OP_E2E_LEGACY=true` to disable the op-e2e package from loading build-artifacts that are not used by devstack.
+
+## Metrics
+If any component is configured to expose metrics, prometheus and grafana instances will be created via docker to serve them to the user.
+
+If metrics are enabled, the grafana instance will be served at `http://localhost:3000`. If that port is in use, the dev stack may fail to deploy.
+
+### Requirements
+The [Docker](https://docs.docker.com) binary must be installed and either be available in your `PATH` as `docker` or configured via `SYSGO_DOCKER_EXEC_PATH` See [Environment Variables](#environment-variables).
+
+### Enabling Metrics
+Metrics for each applicable component may be enabled/disabled via env vars. See [this](#metrics-env-vars-note-only-applicable-if-any-l2-component-calls-orchestratorregisterl2metricsendpoints) for more info.
+
+### Configuring dashboards
+When configuring dashboards, note that there is a single prometheus datasource available at `http://host.docker.internal:9999`.
+
+Note: It is recommended to set a `SYSGO_GRAFANA_PROVISIONING_DIR` and `SYSGO_GRAFANA_DATA_DIR`. This allows any configured datasources, dashboards, and visualizations to persist across restarts. If these variables are not set, temporary directories will be used and any configuration will be lost on restart.

--- a/op-devstack/README.md
+++ b/op-devstack/README.md
@@ -61,6 +61,7 @@ Available components:
   - `L2Batcher`: op-batcher, or equivalent
   - `L2Proposer`: op-proposer, or equivalent
   - `L2Challenger`: op-challenger, or equivalent
+  - `L2MetricsDashboard`: runs prometheus and grafana instances if any component registers metrics endpoints with the `Orchestrator`
 - `Supervisor`: op-supervisor service, or equivalent
 - `Faucet`: util to fund eth to test accounts
 
@@ -163,7 +164,7 @@ Go stack env vars:
 - `DEVSTACK_L1EL_KIND=geth` to select geth as default L1 EL node
 - `SYSGO_GETH_EXEC_PATH=/path/to/geth` to select the geth executable to run
 
-Observability env vars:
+L2 Observability env vars (note: only applicable if any L2 component calls `Orchestrator.RegisterL2MetricsEndpoints`):
 - `SYSGO_DOCKER_EXEC_PATH` to set local path to docker executable (defaults to `/usr/local/bin/docker`)
 - `SYSGO_GRAFANA_PROVISIONING_DIR` to provide a local grafana provisioning dir to use (otherwise a temp dir will be created and removed at the end of tests)
 - `SYSGO_GRAFANA_DATA_DIR` to provide a local grafana data dir to use (otherwise a temp dir will be created and removed at the end of tests)

--- a/op-devstack/README.md
+++ b/op-devstack/README.md
@@ -169,6 +169,8 @@ and returns a typed output that the test then may use.
 - `SYSGO_DOCKER_EXEC_PATH` path to docker executable (defaults to `docker` assuming it is in your `PATH`)
 - `SYSGO_GRAFANA_PROVISIONING_DIR` to provide a local grafana provisioning dir to use (otherwise a temp dir will be created and removed at the end of tests)
 - `SYSGO_GRAFANA_DATA_DIR` to provide a local grafana data dir to use (otherwise a temp dir will be created and removed at the end of tests)
+- `SYSGO_GRAFANA_DOCKER_IMAGE_TAG` indicates which grafana docker image tag should be used (default is `12.2`).
+- `SYSGO_PROMETHEUS_DOCKER_IMAGE_TAG` indicates which prometheus docker image tag should be used (default is `v3.7.2`).
 
 ### Other useful env vars:
 - `DISABLE_OP_E2E_LEGACY=true` to disable the op-e2e package from loading build-artifacts that are not used by devstack.

--- a/op-devstack/README.md
+++ b/op-devstack/README.md
@@ -163,5 +163,10 @@ Go stack env vars:
 - `DEVSTACK_L1EL_KIND=geth` to select geth as default L1 EL node
 - `SYSGO_GETH_EXEC_PATH=/path/to/geth` to select the geth executable to run
 
+Observability env vars:
+- `SYSGO_DOCKER_EXEC_PATH` to set local path to docker executable (defaults to `/usr/local/bin/docker`)
+- `SYSGO_GRAFANA_PROVISIONING_DIR` to provide a local grafana provisioning dir to use (otherwise a temp dir will be created and removed at the end of tests)
+- `SYSGO_GRAFANA_DATA_DIR` to provide a local grafana data dir to use (otherwise a temp dir will be created and removed at the end of tests)
+
 Other useful env vars:
 - `DISABLE_OP_E2E_LEGACY=true` to disable the op-e2e package from loading build-artifacts that are not used by devstack.

--- a/op-devstack/README.md
+++ b/op-devstack/README.md
@@ -164,28 +164,25 @@ and returns a typed output that the test then may use.
 - `DEVSTACK_L1EL_KIND=geth` to select geth as default L1 EL node
 - `SYSGO_GETH_EXEC_PATH=/path/to/geth` to select the geth executable to run
 
-### Metrics env vars (note: only applicable if any L2 component calls `Orchestrator.RegisterL2MetricsEndpoints`):
+### Metrics env vars:
+- `SYSGO_METRICS_ENABLED` set to `true` to enable metrics to be exposed via prometheus and grafana for all running components that expose metrics (default: `false`)
 - `SYSGO_DOCKER_EXEC_PATH` path to docker executable (defaults to `docker` assuming it is in your `PATH`)
 - `SYSGO_GRAFANA_PROVISIONING_DIR` to provide a local grafana provisioning dir to use (otherwise a temp dir will be created and removed at the end of tests)
 - `SYSGO_GRAFANA_DATA_DIR` to provide a local grafana data dir to use (otherwise a temp dir will be created and removed at the end of tests)
-- `KONA_METRICS_ENABLED` set to `true` to enable `kona-node` instances to report metrics.
-- `OP_RETH_METRICS_ENABLED` set to `true` to enable `op-reth` instances to report metrics.
 
 ### Other useful env vars:
 - `DISABLE_OP_E2E_LEGACY=true` to disable the op-e2e package from loading build-artifacts that are not used by devstack.
 
 ## Metrics
-If any component is configured to expose metrics, prometheus and grafana instances will be created via docker to serve them to the user.
+If [metrics are enabled](#metrics-env-vars) and any component is configured to expose metrics, prometheus and grafana instances will be created via docker to serve them to the user.
 
 If metrics are enabled, the grafana instance will be served at `http://localhost:3000`. If that port is in use, the dev stack may fail to deploy.
 
 ### Requirements
-The [Docker](https://docs.docker.com) binary must be installed and either be available in your `PATH` as `docker` or configured via `SYSGO_DOCKER_EXEC_PATH` See [Environment Variables](#environment-variables).
-
-### Enabling Metrics
-Metrics for each applicable component may be enabled/disabled via env vars. See [this](#metrics-env-vars-note-only-applicable-if-any-l2-component-calls-orchestratorregisterl2metricsendpoints) for more info.
+The [Docker](https://docs.docker.com) binary must be installed and either be available in your `PATH` as `docker` or configured via `SYSGO_DOCKER_EXEC_PATH` See [Environment Variables](#metrics-env-vars).
 
 ### Configuring dashboards
 When configuring dashboards, note that there is a single prometheus datasource available at `http://host.docker.internal:9999`.
 
-Note: It is recommended to set a `SYSGO_GRAFANA_PROVISIONING_DIR` and `SYSGO_GRAFANA_DATA_DIR`. This allows any configured datasources, dashboards, and visualizations to persist across restarts. If these variables are not set, temporary directories will be used and any configuration will be lost on restart.
+> [!TIP]
+> It is recommended to set a `SYSGO_GRAFANA_PROVISIONING_DIR` and `SYSGO_GRAFANA_DATA_DIR`. This allows any configured datasources, dashboards, and visualizations to persist across restarts. If these variables are not set, temporary directories will be used and any configuration will be lost on restart.

--- a/op-devstack/sysgo/config.go
+++ b/op-devstack/sysgo/config.go
@@ -5,7 +5,7 @@ import "strconv"
 const sysgoMetricsEnabledEnvVar = "SYSGO_METRICS_ENABLED"
 
 func areMetricsEnabled() bool {
-	enabledStr := GetEnvVarOrDefault(sysgoMetricsEnabledEnvVar, "false")
+	enabledStr := getEnvVarOrDefault(sysgoMetricsEnabledEnvVar, "false")
 	enabled, err := strconv.ParseBool(enabledStr)
 	// NB: default to false on error parsing enabled setting
 	return err == nil && enabled

--- a/op-devstack/sysgo/config.go
+++ b/op-devstack/sysgo/config.go
@@ -2,10 +2,10 @@ package sysgo
 
 import "strconv"
 
-const SysgoMetricsEnabledEnvVar = "SYSGO_METRICS_ENABLED"
+const sysgoMetricsEnabledEnvVar = "SYSGO_METRICS_ENABLED"
 
-func AreMetricsEnabled() bool {
-	enabledStr := GetEnvVarOrDefault(SysgoMetricsEnabledEnvVar, "false")
+func areMetricsEnabled() bool {
+	enabledStr := GetEnvVarOrDefault(sysgoMetricsEnabledEnvVar, "false")
 	enabled, err := strconv.ParseBool(enabledStr)
 	// NB: default to false on error parsing enabled setting
 	return err == nil && enabled

--- a/op-devstack/sysgo/config.go
+++ b/op-devstack/sysgo/config.go
@@ -1,0 +1,12 @@
+package sysgo
+
+import "strconv"
+
+const SysgoMetricsEnabledEnvVar = "SYSGO_METRICS_ENABLED"
+
+func AreMetricsEnabled() bool {
+	enabledStr := GetEnvVarOrDefault(SysgoMetricsEnabledEnvVar, "false")
+	enabled, err := strconv.ParseBool(enabledStr)
+	// NB: default to false on error parsing enabled setting
+	return err == nil && enabled
+}

--- a/op-devstack/sysgo/l2_cl_kona.go
+++ b/op-devstack/sysgo/l2_cl_kona.go
@@ -4,7 +4,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	url2 "net/url"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -46,8 +46,8 @@ type KonaNode struct {
 
 	sub *SubProcess
 
-	areMetricsEnabled  bool
-	addMetricsCallback func(serviceName string, endpoint ...PrometheusMetricsEndpoint)
+	areMetricsEnabled        bool
+	registerMetricsEndpoints func(serviceName string, endpoint ...PrometheusMetricsEndpoint)
 }
 
 func (k *KonaNode) hydrate(system stack.ExtensibleSystem) {
@@ -129,7 +129,7 @@ func (k *KonaNode) Start() {
 	if k.areMetricsEnabled {
 		var metricsEndpoint PrometheusMetricsEndpoint
 		k.p.Require().NoError(tasks.Await(k.p.Ctx(), metricsEndpointChan, &metricsEndpoint), "need user RPC")
-		k.addMetricsCallback("kona-node", metricsEndpoint)
+		k.registerMetricsEndpoints("kona-node", metricsEndpoint)
 	}
 
 	k.userProxy.SetUpstream(ProxyAddr(k.p.Require(), userRPCAddr))
@@ -169,12 +169,12 @@ func (k *KonaNode) tryParseKonaMetricsFromLog(msg string) *PrometheusMetricsEndp
 		return nil
 	}
 
-	url, err := url2.Parse(strings.Split(msg, metricsPrefix)[1])
+	parsedUrl, err := url.Parse(strings.Split(msg, metricsPrefix)[1])
 	k.p.Require().NoError(err, fmt.Sprintf("invalid kona metrics url output to logs: %s", msg))
-	port := url.Port()
+	port := parsedUrl.Port()
 	k.p.Require().NotEmpty(port, fmt.Sprintf("empty port url in kona metrics url; log line: %s", msg))
 	return &PrometheusMetricsEndpoint{
-		host:              url.Host,
+		host:              parsedUrl.Host,
 		port:              port,
 		isLocal:           true,
 		isRunningInDocker: false,
@@ -243,9 +243,9 @@ func WithKonaNode(l2CLID stack.L2CLNodeID, l1CLID stack.L1CLNodeID, l1ELID stack
 			PropagateEnvVarOrDefault("KONA_NODE_RPC_PORT", "0"),
 			PropagateEnvVarOrDefault("KONA_NODE_RPC_WS_ENABLED", "true"),
 			PropagateEnvVarOrDefault("KONA_METRICS_ADDR", ""),
-			// NB: Instead of GetAvailableLocalPort, we should pass "0" so the OS to pick its own port, but
-			// prometheus doesn't expose that port, so we can't log it and parse it here.
-			// If/when that gets changed, update this default to "0".
+			// NB: Instead of GetAvailableLocalPort, we should pass "0" so the OS picks its
+			// own port, but prometheus doesn't expose that port, so we can't log it and
+			// parse it here. If/when that gets changed, update this default to "0".
 			PropagateEnvVarOrDefault("KONA_METRICS_PORT", GetAvailableLocalPort()),
 			PropagateEnvVarOrDefault("KONA_LOG_LEVEL", "3"), // default to info level
 			PropagateEnvVarOrDefault("KONA_LOG_STDOUT_FORMAT", "json"),
@@ -278,17 +278,17 @@ func WithKonaNode(l2CLID stack.L2CLNodeID, l1CLID stack.L1CLNodeID, l1ELID stack
 		p.Require().NotErrorIs(err, os.ErrNotExist, "executable must exist")
 
 		k := &KonaNode{
-			id:                 l2CLID,
-			userRPC:            "", // retrieved from logs
-			interopEndpoint:    "", // retrieved from logs
-			interopJwtSecret:   eth.Bytes32{},
-			el:                 l2ELID,
-			execPath:           execPath,
-			args:               []string{"node"},
-			env:                envVars,
-			p:                  p,
-			areMetricsEnabled:  areMetricsEnabled,
-			addMetricsCallback: orch.RegisterMetricsEndpoints,
+			id:                       l2CLID,
+			userRPC:                  "", // retrieved from logs
+			interopEndpoint:          "", // retrieved from logs
+			interopJwtSecret:         eth.Bytes32{},
+			el:                       l2ELID,
+			execPath:                 execPath,
+			args:                     []string{"node"},
+			env:                      envVars,
+			p:                        p,
+			areMetricsEnabled:        areMetricsEnabled,
+			registerMetricsEndpoints: orch.RegisterL2MetricsEndpoints,
 		}
 		p.Logger().Info("Starting kona-node")
 		k.Start()

--- a/op-devstack/sysgo/l2_cl_kona.go
+++ b/op-devstack/sysgo/l2_cl_kona.go
@@ -3,7 +3,6 @@ package sysgo
 import (
 	"encoding/hex"
 	"encoding/json"
-	"fmt"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -98,12 +97,18 @@ func (k *KonaNode) Start() {
 
 	onLogEntry := func(e logpipe.LogEntry) {
 		msg := e.LogMessage()
-		switch msg {
-		case "RPC server bound to address":
+		if msg == "RPC server bound to address" {
 			userRPCChan <- "http://" + e.FieldValue("addr").(string)
-		default:
-			if endpoint := k.tryParseMetricsFromLog(msg); endpoint != nil {
-				metricsEndpointChan <- *endpoint
+		} else if metricsUrl, found := strings.CutPrefix(msg, "Serving metrics at: "); found {
+			// Matching messages like "Serving metrics at: http://0.0.0.0:9091"
+			parsedUrl, err := url.Parse(metricsUrl)
+			k.p.Require().NoError(err, "invalid metrics url output to logs", "log", msg)
+			k.p.Require().NotEmpty(parsedUrl.Port(), "empty port in logged metrics url", "log", msg)
+			metricsEndpointChan <- PrometheusMetricsEndpoint{
+				host:              parsedUrl.Hostname(),
+				port:              parsedUrl.Port(),
+				isLocal:           true,
+				isRunningInDocker: false,
 			}
 		}
 	}
@@ -153,30 +158,6 @@ func (k *KonaNode) UserRPC() string {
 
 func (k *KonaNode) InteropRPC() (endpoint string, jwtSecret eth.Bytes32) {
 	return k.interopEndpoint, k.interopJwtSecret
-}
-
-// Matching messages like "Serving metrics at: http://0.0.0.0:9091"
-const konaMetricsPrefix = "Serving metrics at: "
-
-// tryParseMetricsFromLog attempts to parse a running kona metrics server endpoint from
-// the provided log message.
-//
-// If the log message doesn't appear to be metrics-related, nil will be returned. See: `konaMetricsPrefix`.
-func (k *KonaNode) tryParseMetricsFromLog(msg string) *PrometheusMetricsEndpoint {
-	if !strings.HasPrefix(msg, konaMetricsPrefix) {
-		return nil
-	}
-
-	parsedUrl, err := url.Parse(strings.Split(msg, konaMetricsPrefix)[1])
-	k.p.Require().NoError(err, fmt.Sprintf("invalid kona metrics url output to logs: %s", msg))
-	port := parsedUrl.Port()
-	k.p.Require().NotEmpty(port, fmt.Sprintf("empty port url in kona metrics url; log line: %s", msg))
-	return &PrometheusMetricsEndpoint{
-		host:              parsedUrl.Host,
-		port:              port,
-		isLocal:           true,
-		isRunningInDocker: false,
-	}
 }
 
 var _ L2CLNode = (*KonaNode)(nil)

--- a/op-devstack/sysgo/l2_cl_kona.go
+++ b/op-devstack/sysgo/l2_cl_kona.go
@@ -3,8 +3,11 @@ package sysgo
 import (
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
+	url2 "net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -42,6 +45,9 @@ type KonaNode struct {
 	p devtest.P
 
 	sub *SubProcess
+
+	areMetricsEnabled  bool
+	addMetricsCallback func(serviceName string, endpoint ...PrometheusMetricsEndpoint)
 }
 
 func (k *KonaNode) hydrate(system stack.ExtensibleSystem) {
@@ -86,11 +92,21 @@ func (k *KonaNode) Start() {
 	// And inspect them along the way, to get the RPC server address.
 	logOut := logpipe.ToLogger(k.p.Logger().New("src", "stdout"))
 	logErr := logpipe.ToLogger(k.p.Logger().New("src", "stderr"))
-	userRPC := make(chan string, 1)
+	userRPCChan := make(chan string, 1)
+	defer close(userRPCChan)
+
+	metricsEndpointChan := make(chan PrometheusMetricsEndpoint, 1)
+	defer close(metricsEndpointChan)
+
 	onLogEntry := func(e logpipe.LogEntry) {
-		switch e.LogMessage() {
+		msg := e.LogMessage()
+		switch msg {
 		case "RPC server bound to address":
-			userRPC <- "http://" + e.FieldValue("addr").(string)
+			userRPCChan <- "http://" + e.FieldValue("addr").(string)
+		default:
+			if endpoint := k.tryParseKonaMetricsFromLog(msg); endpoint != nil {
+				metricsEndpointChan <- *endpoint
+			}
 		}
 	}
 	stdOutLogs := logpipe.LogProcessor(func(line []byte) {
@@ -108,7 +124,13 @@ func (k *KonaNode) Start() {
 	k.p.Require().NoError(err, "Must start")
 
 	var userRPCAddr string
-	k.p.Require().NoError(tasks.Await(k.p.Ctx(), userRPC, &userRPCAddr), "need user RPC")
+	k.p.Require().NoError(tasks.Await(k.p.Ctx(), userRPCChan, &userRPCAddr), "need user RPC")
+
+	if k.areMetricsEnabled {
+		var metricsEndpoint PrometheusMetricsEndpoint
+		k.p.Require().NoError(tasks.Await(k.p.Ctx(), metricsEndpointChan, &metricsEndpoint), "need user RPC")
+		k.addMetricsCallback("kona-node", metricsEndpoint)
+	}
 
 	k.userProxy.SetUpstream(ProxyAddr(k.p.Require(), userRPCAddr))
 }
@@ -133,6 +155,30 @@ func (k *KonaNode) UserRPC() string {
 
 func (k *KonaNode) InteropRPC() (endpoint string, jwtSecret eth.Bytes32) {
 	return k.interopEndpoint, k.interopJwtSecret
+}
+
+// Matching messages like "Serving metrics at: http://0.0.0.0:9091"
+const metricsPrefix = "Serving metrics at: "
+
+// tryParseKonaMetricsFromLog attempts to parse a running kona metrics server endpoint from
+// the provided log message.
+//
+// If the log message doesn't appear to be metrics-related, nil will be returned. See: `metricsPrefix`.
+func (k *KonaNode) tryParseKonaMetricsFromLog(msg string) *PrometheusMetricsEndpoint {
+	if !strings.HasPrefix(msg, metricsPrefix) {
+		return nil
+	}
+
+	url, err := url2.Parse(strings.Split(msg, metricsPrefix)[1])
+	k.p.Require().NoError(err, fmt.Sprintf("invalid kona metrics url output to logs: %s", msg))
+	port := url.Port()
+	k.p.Require().NotEmpty(port, fmt.Sprintf("empty port url in kona metrics url; log line: %s", msg))
+	return &PrometheusMetricsEndpoint{
+		host:              url.Host,
+		port:              port,
+		isLocal:           true,
+		isRunningInDocker: false,
+	}
 }
 
 var _ L2CLNode = (*KonaNode)(nil)
@@ -178,6 +224,9 @@ func WithKonaNode(l2CLID stack.L2CLNodeID, l1CLID stack.L1CLNodeID, l1ELID stack
 		p.Require().NoError(err, "must write l1 chain config")
 		p.Require().NoError(err, os.WriteFile(tempL1CfgPath, l1CfgData, 0o644))
 
+		//NB: Defaults to false on parsing err
+		areMetricsEnabled, _ := strconv.ParseBool(GetEnvVarOrDefault("KONA_METRICS_ENABLED", "false"))
+
 		envVars := []string{
 			"KONA_NODE_L1_ETH_RPC=" + l1EL.UserRPC(),
 			"KONA_NODE_L1_BEACON=" + l1CL.beaconHTTPAddr,
@@ -187,18 +236,23 @@ func WithKonaNode(l2CLID stack.L2CLNodeID, l1CLID stack.L1CLNodeID, l1ELID stack
 			"KONA_NODE_L2_ENGINE_AUTH=" + l2EL.JWTPath(),
 			"KONA_NODE_ROLLUP_CONFIG=" + tempRollupCfgPath,
 			"KONA_NODE_L1_CHAIN_CONFIG=" + tempL1CfgPath,
-			"KONA_NODE_P2P_NO_DISCOVERY=true",
 			"KONA_NODE_P2P_PRIV_PATH=" + tempP2PPath,
-			"KONA_NODE_RPC_ADDR=127.0.0.1",
-			"KONA_NODE_RPC_PORT=0",
-			"KONA_NODE_RPC_WS_ENABLED=true",
-			"KONA_METRICS_ENABLED=false",
-			"KONA_LOG_LEVEL=3", // info level
-			"KONA_LOG_STDOUT_FORMAT=json",
+			"KONA_METRICS_ENABLED=" + fmt.Sprintf("%t", areMetricsEnabled),
+			PropagateEnvVarOrDefault("KONA_NODE_P2P_NO_DISCOVERY", "true"),
+			PropagateEnvVarOrDefault("KONA_NODE_RPC_ADDR", "127.0.0.1"),
+			PropagateEnvVarOrDefault("KONA_NODE_RPC_PORT", "0"),
+			PropagateEnvVarOrDefault("KONA_NODE_RPC_WS_ENABLED", "true"),
+			PropagateEnvVarOrDefault("KONA_METRICS_ADDR", ""),
+			// NB: Instead of GetAvailableLocalPort, we should pass "0" so the OS to pick its own port, but
+			// prometheus doesn't expose that port, so we can't log it and parse it here.
+			// If/when that gets changed, update this default to "0".
+			PropagateEnvVarOrDefault("KONA_METRICS_PORT", GetAvailableLocalPort()),
+			PropagateEnvVarOrDefault("KONA_LOG_LEVEL", "3"), // default to info level
+			PropagateEnvVarOrDefault("KONA_LOG_STDOUT_FORMAT", "json"),
 			// p2p ports
-			"KONA_NODE_P2P_LISTEN_IP=127.0.0.1",
-			"KONA_NODE_P2P_LISTEN_TCP_PORT=0",
-			"KONA_NODE_P2P_LISTEN_UDP_PORT=0",
+			PropagateEnvVarOrDefault("KONA_NODE_P2P_LISTEN_IP", "127.0.0.1"),
+			PropagateEnvVarOrDefault("KONA_NODE_P2P_LISTEN_TCP_PORT", "0"),
+			PropagateEnvVarOrDefault("KONA_NODE_P2P_LISTEN_UDP_PORT", "0"),
 		}
 		if cfg.IsSequencer {
 			p2pKey, err := orch.keys.Secret(devkeys.SequencerP2PRole.Key(l2CLID.ChainID().ToBig()))
@@ -224,15 +278,17 @@ func WithKonaNode(l2CLID stack.L2CLNodeID, l1CLID stack.L1CLNodeID, l1ELID stack
 		p.Require().NotErrorIs(err, os.ErrNotExist, "executable must exist")
 
 		k := &KonaNode{
-			id:               l2CLID,
-			userRPC:          "", // retrieved from logs
-			interopEndpoint:  "", // retrieved from logs
-			interopJwtSecret: eth.Bytes32{},
-			el:               l2ELID,
-			execPath:         execPath,
-			args:             []string{"node"},
-			env:              envVars,
-			p:                p,
+			id:                 l2CLID,
+			userRPC:            "", // retrieved from logs
+			interopEndpoint:    "", // retrieved from logs
+			interopJwtSecret:   eth.Bytes32{},
+			el:                 l2ELID,
+			execPath:           execPath,
+			args:               []string{"node"},
+			env:                envVars,
+			p:                  p,
+			areMetricsEnabled:  areMetricsEnabled,
+			addMetricsCallback: orch.RegisterMetricsEndpoints,
 		}
 		p.Logger().Info("Starting kona-node")
 		k.Start()

--- a/op-devstack/sysgo/l2_cl_kona.go
+++ b/op-devstack/sysgo/l2_cl_kona.go
@@ -92,8 +92,8 @@ func (k *KonaNode) Start() {
 	userRPCChan := make(chan string, 1)
 	defer close(userRPCChan)
 
-	metricsEndpointChan := make(chan PrometheusMetricsEndpoint, 1)
-	defer close(metricsEndpointChan)
+	metricsTargetChan := make(chan PrometheusMetricsTarget, 1)
+	defer close(metricsTargetChan)
 
 	onLogEntry := func(e logpipe.LogEntry) {
 		msg := e.LogMessage()
@@ -104,12 +104,7 @@ func (k *KonaNode) Start() {
 			parsedUrl, err := url.Parse(metricsUrl)
 			k.p.Require().NoError(err, "invalid metrics url output to logs", "log", msg)
 			k.p.Require().NotEmpty(parsedUrl.Port(), "empty port in logged metrics url", "log", msg)
-			metricsEndpointChan <- PrometheusMetricsEndpoint{
-				host:              parsedUrl.Hostname(),
-				port:              parsedUrl.Port(),
-				isLocal:           true,
-				isRunningInDocker: false,
-			}
+			metricsTargetChan <- NewPrometheusMetricsTarget(parsedUrl.Hostname(), parsedUrl.Port(), false)
 		}
 	}
 	stdOutLogs := logpipe.LogProcessor(func(line []byte) {
@@ -130,9 +125,9 @@ func (k *KonaNode) Start() {
 	k.p.Require().NoError(tasks.Await(k.p.Ctx(), userRPCChan, &userRPCAddr), "need user RPC")
 
 	if areMetricsEnabled() {
-		var metricsEndpoint PrometheusMetricsEndpoint
-		k.p.Require().NoError(tasks.Await(k.p.Ctx(), metricsEndpointChan, &metricsEndpoint), "need metrics endpoint")
-		k.l2MetricsRegistrar.RegisterL2MetricsEndpoints(k.id, metricsEndpoint)
+		var metricsTarget PrometheusMetricsTarget
+		k.p.Require().NoError(tasks.Await(k.p.Ctx(), metricsTargetChan, &metricsTarget), "need metrics endpoint")
+		k.l2MetricsRegistrar.RegisterL2MetricsTargets(k.id, metricsTarget)
 	}
 
 	k.userProxy.SetUpstream(ProxyAddr(k.p.Require(), userRPCAddr))

--- a/op-devstack/sysgo/l2_cl_kona.go
+++ b/op-devstack/sysgo/l2_cl_kona.go
@@ -7,7 +7,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"sync"
 
@@ -46,7 +45,6 @@ type KonaNode struct {
 
 	sub *SubProcess
 
-	areMetricsEnabled        bool
 	registerMetricsEndpoints func(serviceName string, endpoint ...PrometheusMetricsEndpoint)
 }
 
@@ -126,7 +124,7 @@ func (k *KonaNode) Start() {
 	var userRPCAddr string
 	k.p.Require().NoError(tasks.Await(k.p.Ctx(), userRPCChan, &userRPCAddr), "need user RPC")
 
-	if k.areMetricsEnabled {
+	if AreMetricsEnabled() {
 		var metricsEndpoint PrometheusMetricsEndpoint
 		k.p.Require().NoError(tasks.Await(k.p.Ctx(), metricsEndpointChan, &metricsEndpoint), "need metrics endpoint")
 		k.registerMetricsEndpoints("kona-node", metricsEndpoint)
@@ -224,9 +222,6 @@ func WithKonaNode(l2CLID stack.L2CLNodeID, l1CLID stack.L1CLNodeID, l1ELID stack
 		p.Require().NoError(err, "must write l1 chain config")
 		p.Require().NoError(err, os.WriteFile(tempL1CfgPath, l1CfgData, 0o644))
 
-		//NB: Defaults to false on parsing err
-		areMetricsEnabled, _ := strconv.ParseBool(GetEnvVarOrDefault("KONA_METRICS_ENABLED", "false"))
-
 		envVars := []string{
 			"KONA_NODE_L1_ETH_RPC=" + l1EL.UserRPC(),
 			"KONA_NODE_L1_BEACON=" + l1CL.beaconHTTPAddr,
@@ -237,7 +232,6 @@ func WithKonaNode(l2CLID stack.L2CLNodeID, l1CLID stack.L1CLNodeID, l1ELID stack
 			"KONA_NODE_ROLLUP_CONFIG=" + tempRollupCfgPath,
 			"KONA_NODE_L1_CHAIN_CONFIG=" + tempL1CfgPath,
 			"KONA_NODE_P2P_PRIV_PATH=" + tempP2PPath,
-			"KONA_METRICS_ENABLED=" + fmt.Sprintf("%t", areMetricsEnabled),
 			PropagateEnvVarOrDefault("KONA_NODE_P2P_NO_DISCOVERY", "true"),
 			PropagateEnvVarOrDefault("KONA_NODE_RPC_ADDR", "127.0.0.1"),
 			PropagateEnvVarOrDefault("KONA_NODE_RPC_PORT", "0"),
@@ -251,7 +245,7 @@ func WithKonaNode(l2CLID stack.L2CLNodeID, l1CLID stack.L1CLNodeID, l1ELID stack
 			PropagateEnvVarOrDefault("KONA_NODE_P2P_LISTEN_UDP_PORT", "0"),
 		}
 
-		if areMetricsEnabled {
+		if AreMetricsEnabled() {
 			metricsPort, err := GetAvailableLocalPort()
 			p.Require().NoError(err, "WithKonaNode: getting metrics port")
 
@@ -259,6 +253,7 @@ func WithKonaNode(l2CLID stack.L2CLNodeID, l1CLID stack.L1CLNodeID, l1ELID stack
 			// own port, but prometheus doesn't expose that port, so we can't log it and
 			// parse it here. If/when that gets changed, update this default to "0".
 			envVars = append(envVars, PropagateEnvVarOrDefault("KONA_METRICS_PORT", metricsPort))
+			envVars = append(envVars, "KONA_METRICS_ENABLED=true")
 		}
 
 		if cfg.IsSequencer {
@@ -294,7 +289,6 @@ func WithKonaNode(l2CLID stack.L2CLNodeID, l1CLID stack.L1CLNodeID, l1ELID stack
 			args:                     []string{"node"},
 			env:                      envVars,
 			p:                        p,
-			areMetricsEnabled:        areMetricsEnabled,
 			registerMetricsEndpoints: orch.RegisterL2MetricsEndpoints,
 		}
 		p.Logger().Info("Starting kona-node")

--- a/op-devstack/sysgo/l2_cl_kona.go
+++ b/op-devstack/sysgo/l2_cl_kona.go
@@ -232,7 +232,7 @@ func WithKonaNode(l2CLID stack.L2CLNodeID, l1CLID stack.L1CLNodeID, l1ELID stack
 			// See: https://github.com/op-rs/kona/issues/2987
 			metricsPort, err := GetAvailableLocalPort()
 			p.Require().NoError(err, "WithKonaNode: getting metrics port")
-			
+
 			envVars = append(envVars, PropagateEnvVarOrDefault("KONA_METRICS_PORT", metricsPort))
 			envVars = append(envVars, "KONA_METRICS_ENABLED=true")
 		}

--- a/op-devstack/sysgo/l2_cl_kona.go
+++ b/op-devstack/sysgo/l2_cl_kona.go
@@ -44,7 +44,7 @@ type KonaNode struct {
 
 	sub *SubProcess
 
-	registerMetricsEndpoints func(serviceName string, endpoint ...PrometheusMetricsEndpoint)
+	l2MetricsRegistrar L2MetricsRegistrar
 }
 
 func (k *KonaNode) hydrate(system stack.ExtensibleSystem) {
@@ -132,7 +132,7 @@ func (k *KonaNode) Start() {
 	if areMetricsEnabled() {
 		var metricsEndpoint PrometheusMetricsEndpoint
 		k.p.Require().NoError(tasks.Await(k.p.Ctx(), metricsEndpointChan, &metricsEndpoint), "need metrics endpoint")
-		k.registerMetricsEndpoints("kona-node", metricsEndpoint)
+		k.l2MetricsRegistrar.RegisterL2MetricsEndpoints(k.id, metricsEndpoint)
 	}
 
 	k.userProxy.SetUpstream(ProxyAddr(k.p.Require(), userRPCAddr))
@@ -261,16 +261,16 @@ func WithKonaNode(l2CLID stack.L2CLNodeID, l1CLID stack.L1CLNodeID, l1ELID stack
 		p.Require().NotErrorIs(err, os.ErrNotExist, "executable must exist")
 
 		k := &KonaNode{
-			id:                       l2CLID,
-			userRPC:                  "", // retrieved from logs
-			interopEndpoint:          "", // retrieved from logs
-			interopJwtSecret:         eth.Bytes32{},
-			el:                       l2ELID,
-			execPath:                 execPath,
-			args:                     []string{"node"},
-			env:                      envVars,
-			p:                        p,
-			registerMetricsEndpoints: orch.RegisterL2MetricsEndpoints,
+			id:                 l2CLID,
+			userRPC:            "", // retrieved from logs
+			interopEndpoint:    "", // retrieved from logs
+			interopJwtSecret:   eth.Bytes32{},
+			el:                 l2ELID,
+			execPath:           execPath,
+			args:               []string{"node"},
+			env:                envVars,
+			p:                  p,
+			l2MetricsRegistrar: orch,
 		}
 		p.Logger().Info("Starting kona-node")
 		k.Start()

--- a/op-devstack/sysgo/l2_cl_kona.go
+++ b/op-devstack/sysgo/l2_cl_kona.go
@@ -124,7 +124,7 @@ func (k *KonaNode) Start() {
 	var userRPCAddr string
 	k.p.Require().NoError(tasks.Await(k.p.Ctx(), userRPCChan, &userRPCAddr), "need user RPC")
 
-	if AreMetricsEnabled() {
+	if areMetricsEnabled() {
 		var metricsEndpoint PrometheusMetricsEndpoint
 		k.p.Require().NoError(tasks.Await(k.p.Ctx(), metricsEndpointChan, &metricsEndpoint), "need metrics endpoint")
 		k.registerMetricsEndpoints("kona-node", metricsEndpoint)
@@ -245,7 +245,7 @@ func WithKonaNode(l2CLID stack.L2CLNodeID, l1CLID stack.L1CLNodeID, l1ELID stack
 			PropagateEnvVarOrDefault("KONA_NODE_P2P_LISTEN_UDP_PORT", "0"),
 		}
 
-		if AreMetricsEnabled() {
+		if areMetricsEnabled() {
 			metricsPort, err := GetAvailableLocalPort()
 			p.Require().NoError(err, "WithKonaNode: getting metrics port")
 

--- a/op-devstack/sysgo/l2_cl_kona.go
+++ b/op-devstack/sysgo/l2_cl_kona.go
@@ -212,27 +212,27 @@ func WithKonaNode(l2CLID stack.L2CLNodeID, l1CLID stack.L1CLNodeID, l1ELID stack
 			"KONA_NODE_ROLLUP_CONFIG=" + tempRollupCfgPath,
 			"KONA_NODE_L1_CHAIN_CONFIG=" + tempL1CfgPath,
 			"KONA_NODE_P2P_PRIV_PATH=" + tempP2PPath,
-			PropagateEnvVarOrDefault("KONA_NODE_P2P_NO_DISCOVERY", "true"),
-			PropagateEnvVarOrDefault("KONA_NODE_RPC_ADDR", "127.0.0.1"),
-			PropagateEnvVarOrDefault("KONA_NODE_RPC_PORT", "0"),
-			PropagateEnvVarOrDefault("KONA_NODE_RPC_WS_ENABLED", "true"),
-			PropagateEnvVarOrDefault("KONA_METRICS_ADDR", ""),
-			PropagateEnvVarOrDefault("KONA_LOG_LEVEL", "3"), // default to info level
-			PropagateEnvVarOrDefault("KONA_LOG_STDOUT_FORMAT", "json"),
+			propagateEnvVarOrDefault("KONA_NODE_P2P_NO_DISCOVERY", "true"),
+			propagateEnvVarOrDefault("KONA_NODE_RPC_ADDR", "127.0.0.1"),
+			propagateEnvVarOrDefault("KONA_NODE_RPC_PORT", "0"),
+			propagateEnvVarOrDefault("KONA_NODE_RPC_WS_ENABLED", "true"),
+			propagateEnvVarOrDefault("KONA_METRICS_ADDR", ""),
+			propagateEnvVarOrDefault("KONA_LOG_LEVEL", "3"), // default to info level
+			propagateEnvVarOrDefault("KONA_LOG_STDOUT_FORMAT", "json"),
 			// p2p ports
-			PropagateEnvVarOrDefault("KONA_NODE_P2P_LISTEN_IP", "127.0.0.1"),
-			PropagateEnvVarOrDefault("KONA_NODE_P2P_LISTEN_TCP_PORT", "0"),
-			PropagateEnvVarOrDefault("KONA_NODE_P2P_LISTEN_UDP_PORT", "0"),
+			propagateEnvVarOrDefault("KONA_NODE_P2P_LISTEN_IP", "127.0.0.1"),
+			propagateEnvVarOrDefault("KONA_NODE_P2P_LISTEN_TCP_PORT", "0"),
+			propagateEnvVarOrDefault("KONA_NODE_P2P_LISTEN_UDP_PORT", "0"),
 		}
 
 		if areMetricsEnabled() {
-			// NB: Instead of GetAvailableLocalPort, we should pass "0" so the OS picks its
+			// NB: Instead of getAvailableLocalPort, we should pass "0" so the OS picks its
 			// own port, but that is not currently logged properly so we cannot parse it.
 			// See: https://github.com/op-rs/kona/issues/2987
-			metricsPort, err := GetAvailableLocalPort()
+			metricsPort, err := getAvailableLocalPort()
 			p.Require().NoError(err, "WithKonaNode: getting metrics port")
 
-			envVars = append(envVars, PropagateEnvVarOrDefault("KONA_METRICS_PORT", metricsPort))
+			envVars = append(envVars, propagateEnvVarOrDefault("KONA_METRICS_PORT", metricsPort))
 			envVars = append(envVars, "KONA_METRICS_ENABLED=true")
 		}
 

--- a/op-devstack/sysgo/l2_cl_kona.go
+++ b/op-devstack/sysgo/l2_cl_kona.go
@@ -90,8 +90,8 @@ func (k *KonaNode) Start() {
 	// Create the sub-process.
 	// We pipe sub-process logs to the test-logger.
 	// And inspect them along the way, to get the RPC server address.
-	logOut := logpipe.ToLogger(k.p.Logger().New("src", "stdout"))
-	logErr := logpipe.ToLogger(k.p.Logger().New("src", "stderr"))
+	logOut := logpipe.ToLogger(k.p.Logger().New("component", "kona-node", "src", "stdout"))
+	logErr := logpipe.ToLogger(k.p.Logger().New("component", "kona-node", "src", "stderr"))
 	userRPCChan := make(chan string, 1)
 	defer close(userRPCChan)
 

--- a/op-devstack/sysgo/l2_cl_kona.go
+++ b/op-devstack/sysgo/l2_cl_kona.go
@@ -227,12 +227,12 @@ func WithKonaNode(l2CLID stack.L2CLNodeID, l1CLID stack.L1CLNodeID, l1ELID stack
 		}
 
 		if areMetricsEnabled() {
+			// NB: Instead of GetAvailableLocalPort, we should pass "0" so the OS picks its
+			// own port, but that is not currently logged properly so we cannot parse it.
+			// See: https://github.com/op-rs/kona/issues/2987
 			metricsPort, err := GetAvailableLocalPort()
 			p.Require().NoError(err, "WithKonaNode: getting metrics port")
-
-			// NB: Instead of GetAvailableLocalPort, we should pass "0" so the OS picks its
-			// own port, but prometheus doesn't expose that port, so we can't log it and
-			// parse it here. If/when that gets changed, update this default to "0".
+			
 			envVars = append(envVars, PropagateEnvVarOrDefault("KONA_METRICS_PORT", metricsPort))
 			envVars = append(envVars, "KONA_METRICS_ENABLED=true")
 		}

--- a/op-devstack/sysgo/l2_cl_kona.go
+++ b/op-devstack/sysgo/l2_cl_kona.go
@@ -243,10 +243,6 @@ func WithKonaNode(l2CLID stack.L2CLNodeID, l1CLID stack.L1CLNodeID, l1ELID stack
 			PropagateEnvVarOrDefault("KONA_NODE_RPC_PORT", "0"),
 			PropagateEnvVarOrDefault("KONA_NODE_RPC_WS_ENABLED", "true"),
 			PropagateEnvVarOrDefault("KONA_METRICS_ADDR", ""),
-			// NB: Instead of GetAvailableLocalPort, we should pass "0" so the OS picks its
-			// own port, but prometheus doesn't expose that port, so we can't log it and
-			// parse it here. If/when that gets changed, update this default to "0".
-			PropagateEnvVarOrDefault("KONA_METRICS_PORT", GetAvailableLocalPort()),
 			PropagateEnvVarOrDefault("KONA_LOG_LEVEL", "3"), // default to info level
 			PropagateEnvVarOrDefault("KONA_LOG_STDOUT_FORMAT", "json"),
 			// p2p ports
@@ -254,6 +250,17 @@ func WithKonaNode(l2CLID stack.L2CLNodeID, l1CLID stack.L1CLNodeID, l1ELID stack
 			PropagateEnvVarOrDefault("KONA_NODE_P2P_LISTEN_TCP_PORT", "0"),
 			PropagateEnvVarOrDefault("KONA_NODE_P2P_LISTEN_UDP_PORT", "0"),
 		}
+
+		if areMetricsEnabled {
+			metricsPort, err := GetAvailableLocalPort()
+			p.Require().NoError(err, "WithKonaNode: getting metrics port")
+
+			// NB: Instead of GetAvailableLocalPort, we should pass "0" so the OS picks its
+			// own port, but prometheus doesn't expose that port, so we can't log it and
+			// parse it here. If/when that gets changed, update this default to "0".
+			envVars = append(envVars, PropagateEnvVarOrDefault("KONA_METRICS_PORT", metricsPort))
+		}
+
 		if cfg.IsSequencer {
 			p2pKey, err := orch.keys.Secret(devkeys.SequencerP2PRole.Key(l2CLID.ChainID().ToBig()))
 			require.NoError(err, "need p2p key for sequencer")

--- a/op-devstack/sysgo/l2_cl_kona.go
+++ b/op-devstack/sysgo/l2_cl_kona.go
@@ -3,6 +3,7 @@ package sysgo
 import (
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -101,6 +102,9 @@ func (k *KonaNode) Start() {
 			userRPCChan <- "http://" + e.FieldValue("addr").(string)
 		} else if metricsUrl, found := strings.CutPrefix(msg, "Serving metrics at: "); found {
 			// Matching messages like "Serving metrics at: http://0.0.0.0:9091"
+			if !strings.HasPrefix(metricsUrl, "http") {
+				metricsUrl = fmt.Sprintf("http://%s", metricsUrl)
+			}
 			parsedUrl, err := url.Parse(metricsUrl)
 			k.p.Require().NoError(err, "invalid metrics url output to logs", "log", msg)
 			k.p.Require().NotEmpty(parsedUrl.Port(), "empty port in logged metrics url", "log", msg)

--- a/op-devstack/sysgo/l2_cl_kona.go
+++ b/op-devstack/sysgo/l2_cl_kona.go
@@ -104,7 +104,7 @@ func (k *KonaNode) Start() {
 		case "RPC server bound to address":
 			userRPCChan <- "http://" + e.FieldValue("addr").(string)
 		default:
-			if endpoint := k.tryParseKonaMetricsFromLog(msg); endpoint != nil {
+			if endpoint := k.tryParseMetricsFromLog(msg); endpoint != nil {
 				metricsEndpointChan <- *endpoint
 			}
 		}
@@ -128,7 +128,7 @@ func (k *KonaNode) Start() {
 
 	if k.areMetricsEnabled {
 		var metricsEndpoint PrometheusMetricsEndpoint
-		k.p.Require().NoError(tasks.Await(k.p.Ctx(), metricsEndpointChan, &metricsEndpoint), "need user RPC")
+		k.p.Require().NoError(tasks.Await(k.p.Ctx(), metricsEndpointChan, &metricsEndpoint), "need metrics endpoint")
 		k.registerMetricsEndpoints("kona-node", metricsEndpoint)
 	}
 
@@ -158,18 +158,18 @@ func (k *KonaNode) InteropRPC() (endpoint string, jwtSecret eth.Bytes32) {
 }
 
 // Matching messages like "Serving metrics at: http://0.0.0.0:9091"
-const metricsPrefix = "Serving metrics at: "
+const konaMetricsPrefix = "Serving metrics at: "
 
-// tryParseKonaMetricsFromLog attempts to parse a running kona metrics server endpoint from
+// tryParseMetricsFromLog attempts to parse a running kona metrics server endpoint from
 // the provided log message.
 //
-// If the log message doesn't appear to be metrics-related, nil will be returned. See: `metricsPrefix`.
-func (k *KonaNode) tryParseKonaMetricsFromLog(msg string) *PrometheusMetricsEndpoint {
-	if !strings.HasPrefix(msg, metricsPrefix) {
+// If the log message doesn't appear to be metrics-related, nil will be returned. See: `konaMetricsPrefix`.
+func (k *KonaNode) tryParseMetricsFromLog(msg string) *PrometheusMetricsEndpoint {
+	if !strings.HasPrefix(msg, konaMetricsPrefix) {
 		return nil
 	}
 
-	parsedUrl, err := url.Parse(strings.Split(msg, metricsPrefix)[1])
+	parsedUrl, err := url.Parse(strings.Split(msg, konaMetricsPrefix)[1])
 	k.p.Require().NoError(err, fmt.Sprintf("invalid kona metrics url output to logs: %s", msg))
 	port := parsedUrl.Port()
 	k.p.Require().NotEmpty(port, fmt.Sprintf("empty port url in kona metrics url; log line: %s", msg))

--- a/op-devstack/sysgo/l2_el_opreth.go
+++ b/op-devstack/sysgo/l2_el_opreth.go
@@ -41,7 +41,7 @@ type OpReth struct {
 
 	sub *SubProcess
 
-	registerMetricsEndpoints func(serviceName string, endpoint ...PrometheusMetricsEndpoint)
+	l2MetricsRegistrar L2MetricsRegistrar
 }
 
 var _ L2ELNode = (*OpReth)(nil)
@@ -154,7 +154,7 @@ func (n *OpReth) Start() {
 	if areMetricsEnabled() {
 		var metricsEndpoint PrometheusMetricsEndpoint
 		n.p.Require().NoError(tasks.Await(n.p.Ctx(), metricsEndpointChan, &metricsEndpoint), "need metrics endpoint")
-		n.registerMetricsEndpoints("op-reth", metricsEndpoint)
+		n.l2MetricsRegistrar.RegisterL2MetricsEndpoints(n.id, metricsEndpoint)
 	}
 
 	n.userProxy.SetUpstream(ProxyAddr(n.p.Require(), userRPCAddr))
@@ -278,17 +278,17 @@ func WithOpReth(id stack.L2ELNodeID, opts ...L2ELOption) stack.Option[*Orchestra
 		}
 
 		l2EL := &OpReth{
-			id:                       id,
-			l2Net:                    l2Net,
-			jwtPath:                  jwtPath,
-			jwtSecret:                jwtSecret,
-			authRPC:                  "",
-			userRPC:                  "",
-			execPath:                 execPath,
-			args:                     args,
-			env:                      []string{},
-			p:                        p,
-			registerMetricsEndpoints: orch.RegisterL2MetricsEndpoints,
+			id:                 id,
+			l2Net:              l2Net,
+			jwtPath:            jwtPath,
+			jwtSecret:          jwtSecret,
+			authRPC:            "",
+			userRPC:            "",
+			execPath:           execPath,
+			args:               args,
+			env:                []string{},
+			p:                  orch.p,
+			l2MetricsRegistrar: orch,
 		}
 
 		p.Logger().Info("Starting op-reth")

--- a/op-devstack/sysgo/l2_el_opreth.go
+++ b/op-devstack/sysgo/l2_el_opreth.go
@@ -6,7 +6,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"sync"
 
@@ -44,7 +43,6 @@ type OpReth struct {
 
 	sub *SubProcess
 
-	areMetricsEnabled        bool
 	registerMetricsEndpoints func(serviceName string, endpoint ...PrometheusMetricsEndpoint)
 }
 
@@ -150,7 +148,7 @@ func (n *OpReth) Start() {
 	n.p.Require().NoError(tasks.Await(n.p.Ctx(), userRPCChan, &userRPCAddr), "need user RPC")
 	n.p.Require().NoError(tasks.Await(n.p.Ctx(), authRPCChan, &authRPCAddr), "need auth RPC")
 
-	if n.areMetricsEnabled {
+	if AreMetricsEnabled() {
 		var metricsEndpoint PrometheusMetricsEndpoint
 		n.p.Require().NoError(tasks.Await(n.p.Ctx(), metricsEndpointChan, &metricsEndpoint), "need metrics endpoint")
 		n.registerMetricsEndpoints("op-reth", metricsEndpoint)
@@ -292,9 +290,7 @@ func WithOpReth(id stack.L2ELNodeID, opts ...L2ELOption) stack.Option[*Orchestra
 			"-vvvv",
 		}
 
-		//NB: Defaults to false on parsing err
-		areMetricsEnabled, _ := strconv.ParseBool(GetEnvVarOrDefault("OP_RETH_METRICS_ENABLED", "false"))
-		if areMetricsEnabled {
+		if AreMetricsEnabled() {
 			metricsPort, err := GetAvailableLocalPort()
 			p.Require().NoError(err, "WithOpReth: getting metrics port")
 			args = append(args, "--metrics="+metricsPort)
@@ -315,7 +311,6 @@ func WithOpReth(id stack.L2ELNodeID, opts ...L2ELOption) stack.Option[*Orchestra
 			args:                     args,
 			env:                      []string{},
 			p:                        p,
-			areMetricsEnabled:        areMetricsEnabled,
 			registerMetricsEndpoints: orch.RegisterL2MetricsEndpoints,
 		}
 

--- a/op-devstack/sysgo/l2_el_opreth.go
+++ b/op-devstack/sysgo/l2_el_opreth.go
@@ -2,8 +2,12 @@ package sysgo
 
 import (
 	"encoding/json"
+	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
@@ -39,6 +43,9 @@ type OpReth struct {
 	p devtest.P
 
 	sub *SubProcess
+
+	areMetricsEnabled        bool
+	registerMetricsEndpoints func(serviceName string, endpoint ...PrometheusMetricsEndpoint)
 }
 
 var _ L2ELNode = (*OpReth)(nil)
@@ -97,19 +104,31 @@ func (n *OpReth) Start() {
 	}
 	logOut := logpipe.ToLogger(n.p.Logger().New("src", "stdout"))
 	logErr := logpipe.ToLogger(n.p.Logger().New("src", "stderr"))
-	userRPC := make(chan string, 1)
-	authRPC := make(chan string, 1)
+
+	authRPCChan := make(chan string, 1)
+	defer close(authRPCChan)
+
+	metricsEndpointChan := make(chan PrometheusMetricsEndpoint, 1)
+	defer close(metricsEndpointChan)
+
+	userRPCChan := make(chan string, 1)
+	defer close(userRPCChan)
 	onLogEntry := func(e logpipe.LogEntry) {
-		switch e.LogMessage() {
+		msg := e.LogMessage()
+		switch msg {
 		case "RPC WS server started":
 			select {
-			case userRPC <- "ws://" + e.FieldValue("url").(string):
+			case userRPCChan <- "ws://" + e.FieldValue("url").(string):
 			default:
 			}
 		case "RPC auth server started":
 			select {
-			case authRPC <- "ws://" + e.FieldValue("url").(string):
+			case authRPCChan <- "ws://" + e.FieldValue("url").(string):
 			default:
+			}
+		default:
+			if endpoint := n.tryParseMetricsFromLog(msg); endpoint != nil {
+				metricsEndpointChan <- *endpoint
 			}
 		}
 	}
@@ -128,8 +147,14 @@ func (n *OpReth) Start() {
 	n.p.Require().NoError(err, "Must start")
 
 	var userRPCAddr, authRPCAddr string
-	n.p.Require().NoError(tasks.Await(n.p.Ctx(), userRPC, &userRPCAddr), "need user RPC")
-	n.p.Require().NoError(tasks.Await(n.p.Ctx(), authRPC, &authRPCAddr), "need auth RPC")
+	n.p.Require().NoError(tasks.Await(n.p.Ctx(), userRPCChan, &userRPCAddr), "need user RPC")
+	n.p.Require().NoError(tasks.Await(n.p.Ctx(), authRPCChan, &authRPCAddr), "need auth RPC")
+
+	if n.areMetricsEnabled {
+		var metricsEndpoint PrometheusMetricsEndpoint
+		n.p.Require().NoError(tasks.Await(n.p.Ctx(), metricsEndpointChan, &metricsEndpoint), "need metrics endpoint")
+		n.registerMetricsEndpoints("op-reth", metricsEndpoint)
+	}
 
 	n.userProxy.SetUpstream(ProxyAddr(n.p.Require(), userRPCAddr))
 	n.authProxy.SetUpstream(ProxyAddr(n.p.Require(), authRPCAddr))
@@ -155,6 +180,35 @@ func (n *OpReth) EngineRPC() string {
 
 func (n *OpReth) JWTPath() string {
 	return n.jwtPath
+}
+
+// Matching messages like "Starting metrics endpoint at 127.0.0.1:9091"
+const opRethMetricsPrefix = "Starting metrics endpoint at "
+
+// tryParseMetricsFromLog attempts to parse a running kona metrics server endpoint from
+// the provided log message.
+//
+// If the log message doesn't appear to be metrics-related, nil will be returned. See: `opRethMetricsPrefix`.
+func (n *OpReth) tryParseMetricsFromLog(msg string) *PrometheusMetricsEndpoint {
+	if !strings.HasPrefix(msg, opRethMetricsPrefix) {
+		return nil
+	}
+
+	loggedUrl := strings.Split(msg, opRethMetricsPrefix)[1]
+	if !strings.HasPrefix(loggedUrl, "http://") {
+		loggedUrl = fmt.Sprintf("http://%s", loggedUrl)
+	}
+
+	parsedUrl, err := url.Parse(loggedUrl)
+	n.p.Require().NoError(err, fmt.Sprintf("invalid op-reth metrics url output to logs: %s", msg))
+	port := parsedUrl.Port()
+	n.p.Require().NotEmpty(port, fmt.Sprintf("empty port url in op-reth metrics url; log line: %s", msg))
+	return &PrometheusMetricsEndpoint{
+		host:              parsedUrl.Host,
+		port:              port,
+		isLocal:           true,
+		isRunningInDocker: false,
+	}
 }
 
 func WithOpReth(id stack.L2ELNodeID, opts ...L2ELOption) stack.Option[*Orchestrator] {
@@ -207,53 +261,60 @@ func WithOpReth(id stack.L2ELNodeID, opts ...L2ELOption) stack.Option[*Orchestra
 		// so we use the CLI flags instead.
 		args := []string{
 			"node",
-			"--chain=" + chainConfigPath,
-			"--with-unused-ports",
-			"--datadir=" + dataDirPath,
-			"--log.file.directory=" + logDirPath,
-			"--disable-nat",
-			"--disable-dns-discovery",
-			"--disable-discv4-discovery",
-			"--p2p-secret-key=" + tempP2PPath,
-			"--nat=none",
 			"--addr=127.0.0.1",
-			"--port=0",
+			"--authrpc.addr=127.0.0.1",
+			"--authrpc.jwtsecret=" + jwtPath,
+			"--authrpc.port=0",
+			"--builder.deadline=2",
+			"--builder.interval=100ms",
+			"--chain=" + chainConfigPath,
+			"--color=never",
+			"--datadir=" + dataDirPath,
+			"--disable-discovery",
 			"--http",
+			"--http.api=admin,debug,eth,net,trace,txpool,web3,rpc,reth,miner",
 			"--http.addr=127.0.0.1",
 			"--http.port=0",
-			"--http.api=admin,debug,eth,net,trace,txpool,web3,rpc,reth,miner",
-			"--ws",
-			"--ws.addr=127.0.0.1",
-			"--ws.port=0",
-			"--ws.api=admin,debug,eth,net,trace,txpool,web3,rpc,reth,miner",
 			"--ipcdisable",
-			"--authrpc.addr=127.0.0.1",
-			"--authrpc.port=0",
+			"--log.file.directory=" + logDirPath,
+			"--log.stdout.format=json",
+			"--nat=none",
+			"--p2p-secret-key=" + tempP2PPath,
+			"--port=0",
 			"--rpc.eth-proof-window=30",
-			"--authrpc.jwtsecret=" + jwtPath,
 			"--txpool.minimum-priority-fee=1",
 			"--txpool.nolocals",
-			"--builder.interval=100ms",
-			"--builder.deadline=2",
-			"--log.stdout.format=json",
-			"--color=never",
+			"--with-unused-ports",
+			"--ws",
+			"--ws.api=admin,debug,eth,net,trace,txpool,web3,rpc,reth,miner",
+			"--ws.addr=127.0.0.1",
+			"--ws.port=0",
 			"-vvvv",
 		}
+
+		//NB: Defaults to false on parsing err
+		areMetricsEnabled, _ := strconv.ParseBool(GetEnvVarOrDefault("OP_RETH_METRICS_ENABLED", "false"))
+		if areMetricsEnabled {
+			args = append(args, "--metrics="+GetAvailableLocalPort())
+		}
+
 		if supervisorRPC != "" {
 			args = append(args, "--rollup.supervisor-http="+supervisorRPC)
 		}
 
 		l2EL := &OpReth{
-			id:        id,
-			l2Net:     l2Net,
-			jwtPath:   jwtPath,
-			jwtSecret: jwtSecret,
-			authRPC:   "",
-			userRPC:   "",
-			execPath:  execPath,
-			args:      args,
-			env:       []string{},
-			p:         p,
+			id:                       id,
+			l2Net:                    l2Net,
+			jwtPath:                  jwtPath,
+			jwtSecret:                jwtSecret,
+			authRPC:                  "",
+			userRPC:                  "",
+			execPath:                 execPath,
+			args:                     args,
+			env:                      []string{},
+			p:                        p,
+			areMetricsEnabled:        areMetricsEnabled,
+			registerMetricsEndpoints: orch.RegisterL2MetricsEndpoints,
 		}
 
 		p.Logger().Info("Starting op-reth")

--- a/op-devstack/sysgo/l2_el_opreth.go
+++ b/op-devstack/sysgo/l2_el_opreth.go
@@ -102,8 +102,8 @@ func (n *OpReth) Start() {
 		})
 		n.userRPC = "ws://" + n.userProxy.Addr()
 	}
-	logOut := logpipe.ToLogger(n.p.Logger().New("src", "stdout"))
-	logErr := logpipe.ToLogger(n.p.Logger().New("src", "stderr"))
+	logOut := logpipe.ToLogger(n.p.Logger().New("component", "op-reth", "src", "stdout"))
+	logErr := logpipe.ToLogger(n.p.Logger().New("component", "op-reth", "src", "stderr"))
 
 	authRPCChan := make(chan string, 1)
 	defer close(authRPCChan)

--- a/op-devstack/sysgo/l2_el_opreth.go
+++ b/op-devstack/sysgo/l2_el_opreth.go
@@ -265,6 +265,9 @@ func WithOpReth(id stack.L2ELNodeID, opts ...L2ELOption) stack.Option[*Orchestra
 		}
 
 		if areMetricsEnabled() {
+			// NB: Instead of GetAvailableLocalPort, we should pass "0" so the OS picks its
+			// own port, but that is not currently logged properly so we cannot parse it.
+			// See: https://github.com/op-rs/op-reth/issues/333
 			metricsPort, err := GetAvailableLocalPort()
 			p.Require().NoError(err, "WithOpReth: getting metrics port")
 			args = append(args, "--metrics="+metricsPort)

--- a/op-devstack/sysgo/l2_el_opreth.go
+++ b/op-devstack/sysgo/l2_el_opreth.go
@@ -104,8 +104,8 @@ func (n *OpReth) Start() {
 	authRPCChan := make(chan string, 1)
 	defer close(authRPCChan)
 
-	metricsEndpointChan := make(chan PrometheusMetricsEndpoint, 1)
-	defer close(metricsEndpointChan)
+	metricsTargetChan := make(chan PrometheusMetricsTarget, 1)
+	defer close(metricsTargetChan)
 
 	userRPCChan := make(chan string, 1)
 	defer close(userRPCChan)
@@ -125,12 +125,7 @@ func (n *OpReth) Start() {
 			// expected format: "Starting metrics endpoint at 127.0.0.1:9091"
 			hostAndPortArray := strings.Split(strings.TrimSpace(hostAndPortString), ":")
 			n.p.Require().Len(hostAndPortArray, 2, "invalid host and port string parsed from log message", "msg", msg, "hostAndPortArray", hostAndPortArray)
-			metricsEndpointChan <- PrometheusMetricsEndpoint{
-				host:              hostAndPortArray[0],
-				port:              hostAndPortArray[1],
-				isLocal:           true,
-				isRunningInDocker: false,
-			}
+			metricsTargetChan <- NewPrometheusMetricsTarget(hostAndPortArray[0], hostAndPortArray[1], false)
 		}
 	}
 	stdOutLogs := logpipe.LogProcessor(func(line []byte) {
@@ -152,9 +147,9 @@ func (n *OpReth) Start() {
 	n.p.Require().NoError(tasks.Await(n.p.Ctx(), authRPCChan, &authRPCAddr), "need auth RPC")
 
 	if areMetricsEnabled() {
-		var metricsEndpoint PrometheusMetricsEndpoint
-		n.p.Require().NoError(tasks.Await(n.p.Ctx(), metricsEndpointChan, &metricsEndpoint), "need metrics endpoint")
-		n.l2MetricsRegistrar.RegisterL2MetricsEndpoints(n.id, metricsEndpoint)
+		var metricsTarget PrometheusMetricsTarget
+		n.p.Require().NoError(tasks.Await(n.p.Ctx(), metricsTargetChan, &metricsTarget), "need metrics endpoint")
+		n.l2MetricsRegistrar.RegisterL2MetricsTargets(n.id, metricsTarget)
 	}
 
 	n.userProxy.SetUpstream(ProxyAddr(n.p.Require(), userRPCAddr))

--- a/op-devstack/sysgo/l2_el_opreth.go
+++ b/op-devstack/sysgo/l2_el_opreth.go
@@ -2,6 +2,8 @@ package sysgo
 
 import (
 	"encoding/json"
+	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -121,11 +123,15 @@ func (n *OpReth) Start() {
 			case authRPCChan <- "ws://" + e.FieldValue("url").(string):
 			default:
 			}
-		} else if hostAndPortString, found := strings.CutPrefix(msg, "Starting metrics endpoint at "); found {
+		} else if metricsUrl, found := strings.CutPrefix(msg, "Starting metrics endpoint at "); found {
 			// expected format: "Starting metrics endpoint at 127.0.0.1:9091"
-			hostAndPortArray := strings.Split(strings.TrimSpace(hostAndPortString), ":")
-			n.p.Require().Len(hostAndPortArray, 2, "invalid host and port string parsed from log message", "msg", msg, "hostAndPortArray", hostAndPortArray)
-			metricsTargetChan <- NewPrometheusMetricsTarget(hostAndPortArray[0], hostAndPortArray[1], false)
+			if !strings.HasPrefix(metricsUrl, "http") {
+				metricsUrl = fmt.Sprintf("http://%s", metricsUrl)
+			}
+			parsedUrl, err := url.Parse(metricsUrl)
+			n.p.Require().NoError(err, "invalid metrics url output to logs", "log", msg)
+			n.p.Require().NotEmpty(parsedUrl.Port(), "empty port in logged metrics url", "log", msg)
+			metricsTargetChan <- NewPrometheusMetricsTarget(parsedUrl.Hostname(), parsedUrl.Port(), false)
 		}
 	}
 	stdOutLogs := logpipe.LogProcessor(func(line []byte) {

--- a/op-devstack/sysgo/l2_el_opreth.go
+++ b/op-devstack/sysgo/l2_el_opreth.go
@@ -185,7 +185,7 @@ func (n *OpReth) JWTPath() string {
 // Matching messages like "Starting metrics endpoint at 127.0.0.1:9091"
 const opRethMetricsPrefix = "Starting metrics endpoint at "
 
-// tryParseMetricsFromLog attempts to parse a running kona metrics server endpoint from
+// tryParseMetricsFromLog attempts to parse a running op-reth metrics server endpoint from
 // the provided log message.
 //
 // If the log message doesn't appear to be metrics-related, nil will be returned. See: `opRethMetricsPrefix`.
@@ -295,7 +295,9 @@ func WithOpReth(id stack.L2ELNodeID, opts ...L2ELOption) stack.Option[*Orchestra
 		//NB: Defaults to false on parsing err
 		areMetricsEnabled, _ := strconv.ParseBool(GetEnvVarOrDefault("OP_RETH_METRICS_ENABLED", "false"))
 		if areMetricsEnabled {
-			args = append(args, "--metrics="+GetAvailableLocalPort())
+			metricsPort, err := GetAvailableLocalPort()
+			p.Require().NoError(err, "WithOpReth: getting metrics port")
+			args = append(args, "--metrics="+metricsPort)
 		}
 
 		if supervisorRPC != "" {

--- a/op-devstack/sysgo/l2_el_opreth.go
+++ b/op-devstack/sysgo/l2_el_opreth.go
@@ -266,10 +266,10 @@ func WithOpReth(id stack.L2ELNodeID, opts ...L2ELOption) stack.Option[*Orchestra
 		}
 
 		if areMetricsEnabled() {
-			// NB: Instead of GetAvailableLocalPort, we should pass "0" so the OS picks its
+			// NB: Instead of getAvailableLocalPort, we should pass "0" so the OS picks its
 			// own port, but that is not currently logged properly so we cannot parse it.
 			// See: https://github.com/op-rs/op-reth/issues/333
-			metricsPort, err := GetAvailableLocalPort()
+			metricsPort, err := getAvailableLocalPort()
 			p.Require().NoError(err, "WithOpReth: getting metrics port")
 			args = append(args, "--metrics="+metricsPort)
 		}

--- a/op-devstack/sysgo/l2_el_opreth.go
+++ b/op-devstack/sysgo/l2_el_opreth.go
@@ -148,7 +148,7 @@ func (n *OpReth) Start() {
 	n.p.Require().NoError(tasks.Await(n.p.Ctx(), userRPCChan, &userRPCAddr), "need user RPC")
 	n.p.Require().NoError(tasks.Await(n.p.Ctx(), authRPCChan, &authRPCAddr), "need auth RPC")
 
-	if AreMetricsEnabled() {
+	if areMetricsEnabled() {
 		var metricsEndpoint PrometheusMetricsEndpoint
 		n.p.Require().NoError(tasks.Await(n.p.Ctx(), metricsEndpointChan, &metricsEndpoint), "need metrics endpoint")
 		n.registerMetricsEndpoints("op-reth", metricsEndpoint)
@@ -290,7 +290,7 @@ func WithOpReth(id stack.L2ELNodeID, opts ...L2ELOption) stack.Option[*Orchestra
 			"-vvvv",
 		}
 
-		if AreMetricsEnabled() {
+		if areMetricsEnabled() {
 			metricsPort, err := GetAvailableLocalPort()
 			p.Require().NoError(err, "WithOpReth: getting metrics port")
 			args = append(args, "--metrics="+metricsPort)

--- a/op-devstack/sysgo/l2_el_opreth.go
+++ b/op-devstack/sysgo/l2_el_opreth.go
@@ -2,8 +2,6 @@ package sysgo
 
 import (
 	"encoding/json"
-	"fmt"
-	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -113,20 +111,25 @@ func (n *OpReth) Start() {
 	defer close(userRPCChan)
 	onLogEntry := func(e logpipe.LogEntry) {
 		msg := e.LogMessage()
-		switch msg {
-		case "RPC WS server started":
+		if msg == "RPC WS server started" {
 			select {
 			case userRPCChan <- "ws://" + e.FieldValue("url").(string):
 			default:
 			}
-		case "RPC auth server started":
+		} else if msg == "RPC auth server started" {
 			select {
 			case authRPCChan <- "ws://" + e.FieldValue("url").(string):
 			default:
 			}
-		default:
-			if endpoint := n.tryParseMetricsFromLog(msg); endpoint != nil {
-				metricsEndpointChan <- *endpoint
+		} else if hostAndPortString, found := strings.CutPrefix(msg, "Starting metrics endpoint at "); found {
+			// expected format: "Starting metrics endpoint at 127.0.0.1:9091"
+			hostAndPortArray := strings.Split(strings.TrimSpace(hostAndPortString), ":")
+			n.p.Require().Len(hostAndPortArray, 2, "invalid host and port string parsed from log message", "msg", msg, "hostAndPortArray", hostAndPortArray)
+			metricsEndpointChan <- PrometheusMetricsEndpoint{
+				host:              hostAndPortArray[0],
+				port:              hostAndPortArray[1],
+				isLocal:           true,
+				isRunningInDocker: false,
 			}
 		}
 	}
@@ -178,35 +181,6 @@ func (n *OpReth) EngineRPC() string {
 
 func (n *OpReth) JWTPath() string {
 	return n.jwtPath
-}
-
-// Matching messages like "Starting metrics endpoint at 127.0.0.1:9091"
-const opRethMetricsPrefix = "Starting metrics endpoint at "
-
-// tryParseMetricsFromLog attempts to parse a running op-reth metrics server endpoint from
-// the provided log message.
-//
-// If the log message doesn't appear to be metrics-related, nil will be returned. See: `opRethMetricsPrefix`.
-func (n *OpReth) tryParseMetricsFromLog(msg string) *PrometheusMetricsEndpoint {
-	if !strings.HasPrefix(msg, opRethMetricsPrefix) {
-		return nil
-	}
-
-	loggedUrl := strings.Split(msg, opRethMetricsPrefix)[1]
-	if !strings.HasPrefix(loggedUrl, "http://") {
-		loggedUrl = fmt.Sprintf("http://%s", loggedUrl)
-	}
-
-	parsedUrl, err := url.Parse(loggedUrl)
-	n.p.Require().NoError(err, fmt.Sprintf("invalid op-reth metrics url output to logs: %s", msg))
-	port := parsedUrl.Port()
-	n.p.Require().NotEmpty(port, fmt.Sprintf("empty port url in op-reth metrics url; log line: %s", msg))
-	return &PrometheusMetricsEndpoint{
-		host:              parsedUrl.Host,
-		port:              port,
-		isLocal:           true,
-		isRunningInDocker: false,
-	}
 }
 
 func WithOpReth(id stack.L2ELNodeID, opts ...L2ELOption) stack.Option[*Orchestrator] {

--- a/op-devstack/sysgo/l2_metrics_dashboard.go
+++ b/op-devstack/sysgo/l2_metrics_dashboard.go
@@ -28,16 +28,18 @@ const grafanaServerPort = "3000"
 const grafanaDockerPort = "3000"
 
 type L2MetricsRegistrar interface {
-	// RegisterL2MetricsEndpoints is called by components when they are started (or earlier) to register
+	// RegisterL2MetricsTargets is called by components when they are started (or earlier) to register
 	// their metrics endpoints so that a prometheus instance may be spun up to scrape metrics.
-	RegisterL2MetricsEndpoints(serviceName stack.IDWithChain, endpoints ...PrometheusMetricsEndpoint)
+	RegisterL2MetricsTargets(serviceName stack.IDWithChain, endpoints ...PrometheusMetricsTarget)
 }
 
-type PrometheusMetricsEndpoint struct {
-	host              string
-	port              string
-	isLocal           bool
-	isRunningInDocker bool
+type PrometheusMetricsTarget string
+
+func NewPrometheusMetricsTarget(host string, port string, isRunningInDocker bool) PrometheusMetricsTarget {
+	if !isRunningInDocker {
+		host = dockerToLocalHost
+	}
+	return PrometheusMetricsTarget(fmt.Sprintf("%s:%s", host, port))
 }
 
 type L2MetricsDashboard struct {
@@ -205,18 +207,17 @@ func WithL2MetricsDashboard() stack.Option[*Orchestrator] {
 			PropagateEnvVarOrDefault("GF_USERS_ALLOW_SIGN_UP", "false"),
 			PropagateEnvVarOrDefault("GF_INSTALL_PLUGINS", "grafana-piechart-panel"),
 		}
-
 		dashboard := &L2MetricsDashboard{
 			p: p,
 
 			prometheusExecPath: GetEnvVarOrDefault(dockerExecutablePathEnvVar, "docker"),
 			prometheusArgs:     prometheusArgs,
-			prometheusEnv:      []string{},
+			prometheusEnv:      os.Environ(),
 			prometheusEndpoint: prometheusEndpoint,
 
 			grafanaExecPath: GetEnvVarOrDefault(dockerExecutablePathEnvVar, "docker"),
 			grafanaArgs:     grafanaArgs,
-			grafanaEnv:      grafanaEnv,
+			grafanaEnv:      append(grafanaEnv, os.Environ()...),
 		}
 
 		p.Logger().Info(fmt.Sprintf("Starting metrics dashboard: %+v", dashboard))
@@ -248,25 +249,15 @@ type prometheusStaticConfig struct {
 	Targets []string `yaml:"targets"`
 }
 
-// endpointHostPortString resolves the host:port string, accounting for the fact that the requester
-// will be in a docker container.
-func endpointHostPortString(p PrometheusMetricsEndpoint) string {
-	host := p.host
-	if p.isLocal && !p.isRunningInDocker {
-		host = dockerToLocalHost
-	}
-	return fmt.Sprintf("%s:%s", host, p.port)
-}
-
 // Returns the path to the dynamically-generated prometheus.yml file for metrics scraping.
-func getPrometheusConfigFilePath(p devtest.P, metricsEndpoints *locks.RWMap[string, []PrometheusMetricsEndpoint]) string {
+func getPrometheusConfigFilePath(p devtest.P, metricsEndpoints *locks.RWMap[string, []PrometheusMetricsTarget]) string {
 
 	var scrapeConfigs []prometheusScrapeConfigEntry
 
-	metricsEndpoints.Range(func(name string, endpoints []PrometheusMetricsEndpoint) bool {
+	metricsEndpoints.Range(func(name string, endpoints []PrometheusMetricsTarget) bool {
 		var targets []string
 		for _, endpoint := range endpoints {
-			targets = append(targets, endpointHostPortString(endpoint))
+			targets = append(targets, string(endpoint))
 		}
 		scrapeConfigs = append(scrapeConfigs, prometheusScrapeConfigEntry{
 			Name:          name,

--- a/op-devstack/sysgo/l2_metrics_dashboard.go
+++ b/op-devstack/sysgo/l2_metrics_dashboard.go
@@ -1,0 +1,330 @@
+package sysgo
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-service/locks"
+	"github.com/ethereum-optimism/optimism/op-service/logpipe"
+	"gopkg.in/yaml.v3"
+)
+
+const DockerExecutablePathEnvVar = "SYSGO_DOCKER_EXEC_PATH"
+const GrafanaProvisioningDirEnvVar = "SYSGO_GRAFANA_PROVISIONING_DIR"
+const GrafanaDataDirEnvVar = "SYSGO_GRAFANA_DATA_DIR"
+
+const DockerToLocalHost = "host.docker.internal"
+
+const PrometheusHost = "0.0.0.0"
+const PrometheusServerPort = "9999"
+const PrometheusDockerPort = "9090"
+
+const GrafanaHost = "0.0.0.0"
+const GrafanaServerPort = "3000"
+const GrafanaDockerPort = "3000"
+
+type L2MetricsDashboard interface {
+	stack.Lifecycle
+	hydrate(system stack.ExtensibleSystem)
+	Endpoint() string
+}
+
+type L2GrafanaDashboard struct {
+	p devtest.P
+
+	grafanaExecPath   string
+	grafanaArgs       []string
+	grafanaEnv        []string
+	grafanaSubprocess *SubProcess
+
+	prometheusExecPath   string
+	prometheusArgs       []string
+	prometheusEnv        []string
+	prometheusSubprocess *SubProcess
+
+	prometheusEndpoint string
+}
+
+func (g *L2GrafanaDashboard) hydrate(system stack.ExtensibleSystem) {
+	// TODO:
+	//  if other components are running, store prometheus metrics scraping endpoints
+	//  if not, store an array of components to query at start-time
+	//		If going this route, create a generic interface for components to implement
+}
+
+func (g *L2GrafanaDashboard) Start() {
+	g.startPrometheus()
+	g.startGrafana()
+}
+
+func (g *L2GrafanaDashboard) startPrometheus() {
+	// Create the sub-process.
+	// We pipe sub-process logs to the test-logger.
+	logOut := logpipe.ToLogger(g.p.Logger().New("src", "stdout"))
+	logErr := logpipe.ToLogger(g.p.Logger().New("src", "stderr"))
+
+	stdOutLogs := logpipe.LogProcessor(func(line []byte) {
+		e := logpipe.ParseRustStructuredLogs(line)
+		logOut(e)
+	})
+	stdErrLogs := logpipe.LogProcessor(func(line []byte) {
+		e := logpipe.ParseRustStructuredLogs(line)
+		logErr(e)
+	})
+
+	g.prometheusSubprocess = NewSubProcess(g.p, stdOutLogs, stdErrLogs)
+
+	if err := g.prometheusSubprocess.Start(g.prometheusExecPath, g.prometheusArgs, g.prometheusEnv); err != nil {
+		g.p.Logger().Error(fmt.Sprintf("Error starting prometheus: %+v", err))
+		g.p.Require().NoError(err, "Must start")
+	}
+
+	// Wait until prometheus is ready
+	url := fmt.Sprintf("%s/-/ready", g.prometheusEndpoint)
+	interval := 2 * time.Second
+
+	for {
+		resp, err := http.Get(url)
+		if err == nil && resp.StatusCode == http.StatusOK {
+			resp.Body.Close()
+			break
+		}
+
+		g.p.Logger().Info(fmt.Sprintf("Waiting for prometheus to start at %s...", g.prometheusEndpoint))
+
+		time.Sleep(interval)
+	}
+
+	g.p.Logger().Info(fmt.Sprintf("Prometheus started at %s...", g.prometheusEndpoint))
+}
+
+func (g *L2GrafanaDashboard) startGrafana() {
+	// Create the sub-process.
+	// We pipe sub-process logs to the test-logger.
+	logOut := logpipe.ToLogger(g.p.Logger().New("src", "stdout"))
+	logErr := logpipe.ToLogger(g.p.Logger().New("src", "stderr"))
+
+	stdOutLogs := logpipe.LogProcessor(func(line []byte) {
+		e := logpipe.ParseRustStructuredLogs(line)
+		logOut(e)
+	})
+	stdErrLogs := logpipe.LogProcessor(func(line []byte) {
+		e := logpipe.ParseRustStructuredLogs(line)
+		logErr(e)
+	})
+
+	g.grafanaSubprocess = NewSubProcess(g.p, stdOutLogs, stdErrLogs)
+
+	if err := g.grafanaSubprocess.Start(g.grafanaExecPath, g.grafanaArgs, g.grafanaEnv); err != nil {
+		g.p.Logger().Error(fmt.Sprintf("Error starting grafana: %+v", err))
+		g.p.Require().NoError(err, "Must start")
+	}
+}
+
+func (g *L2GrafanaDashboard) Stop() {
+	err := g.grafanaSubprocess.Stop()
+	g.p.Require().NoError(err, "Grafana must stop")
+
+	err = g.prometheusSubprocess.Stop()
+	g.p.Require().NoError(err, "Prometheus must stop")
+
+	g.grafanaSubprocess = nil
+	g.prometheusSubprocess = nil
+}
+
+func WithL2MetricsDashboard() stack.Option[*Orchestrator] {
+	return stack.Finally(func(orch *Orchestrator) {
+		p := orch.P()
+
+		// don't start prometheus or grafana if there is nothing exporting metrics.
+		if orch.metricsEndpoints.Len() == 0 {
+			return
+		}
+
+		prometheusEndpoint := fmt.Sprintf("http://%s:%s", PrometheusHost, PrometheusServerPort)
+		promConfig := getPrometheusConfigFilePath(p, &orch.metricsEndpoints)
+		prometheusArgs := []string{
+			"run",
+			"-p", fmt.Sprintf("%s:%s", PrometheusServerPort, PrometheusDockerPort),
+			"-v", fmt.Sprintf("%s:/etc/prometheus/prometheus.yml:ro", promConfig),
+			"prom/prometheus",
+			"--config.file=/etc/prometheus/prometheus.yml",
+		}
+		p.TempDir()
+
+		grafanaProvDir := getGrafanaProvisioningDirPath(p)
+		grafanaDataDir := getGrafanaDataDir(p)
+		grafanaArgs := []string{
+			"run",
+			"-p", fmt.Sprintf("%s:%s", GrafanaServerPort, GrafanaDockerPort),
+			"-v", fmt.Sprintf("%s:/etc/grafana/provisioning:ro", grafanaProvDir),
+			"-v", fmt.Sprintf("%s:/var/lib/grafana", grafanaDataDir),
+			"grafana/grafana",
+		}
+		grafanaEnv := []string{
+			PropagateEnvVarOrDefault("GF_SECURITY_ADMIN_USER", "admin"),
+			PropagateEnvVarOrDefault("GF_SECURITY_ADMIN_PASSWORD", "admin"),
+			PropagateEnvVarOrDefault("GF_USERS_ALLOW_SIGN_UP", "false"),
+			PropagateEnvVarOrDefault("GF_INSTALL_PLUGINS", "grafana-piechart-panel"),
+		}
+
+		dashboard := &L2GrafanaDashboard{
+			p: p,
+
+			prometheusExecPath: GetEnvVarOrDefault(DockerExecutablePathEnvVar, "/usr/local/bin/docker"),
+			prometheusArgs:     prometheusArgs,
+			prometheusEnv:      []string{},
+			prometheusEndpoint: prometheusEndpoint,
+
+			grafanaExecPath: GetEnvVarOrDefault(DockerExecutablePathEnvVar, "/usr/local/bin/docker"),
+			grafanaArgs:     grafanaArgs,
+			grafanaEnv:      grafanaEnv,
+		}
+
+		p.Logger().Info(fmt.Sprintf("Starting metrics dashboard: %+v", dashboard))
+
+		dashboard.Start()
+		p.Cleanup(dashboard.Stop)
+		p.Logger().Info("Metrics dashboard is up", "url", fmt.Sprintf("http://%s:%s", GrafanaHost, GrafanaServerPort))
+	})
+}
+
+type prometheusConfig struct {
+	Global        prometheusGlobalConfig        `yaml:"global"`
+	ScrapeConfigs []prometheusScrapeConfigEntry `yaml:"scrape_configs"`
+}
+
+type prometheusGlobalConfig struct {
+	ScrapeInterval     string `yaml:"scrape_interval"`
+	EvaluationInterval string `yaml:"evaluation_interval"`
+}
+
+type prometheusScrapeConfigEntry struct {
+	Name          string                   `yaml:"job_name"`
+	Scheme        string                   `yaml:"scheme"`
+	StaticConfigs []prometheusStaticConfig `yaml:"static_configs"`
+}
+
+type prometheusStaticConfig struct {
+	Targets []string `yaml:"targets"`
+}
+
+// endpointHostPortString resolves the host:port string, accounting for the fact that the requester
+// will be in a docker container.
+func endpointHostPortString(p PrometheusMetricsEndpoint) string {
+	host := p.host
+	if p.isLocal && !p.isRunningInDocker {
+		host = DockerToLocalHost
+	}
+	return fmt.Sprintf("%s:%s", host, p.port)
+}
+
+// Returns the path to dynamically-generated the prometheus.yml file for metrics.
+func getPrometheusConfigFilePath(p devtest.P, metricsEndpoints *locks.RWMap[string, []PrometheusMetricsEndpoint]) string {
+
+	var scrapeConfigs []prometheusScrapeConfigEntry
+
+	metricsEndpoints.Range(func(name string, endpoints []PrometheusMetricsEndpoint) bool {
+		var targets []string
+		for _, endpoint := range endpoints {
+			targets = append(targets, endpointHostPortString(endpoint))
+		}
+		scrapeConfigs = append(scrapeConfigs, prometheusScrapeConfigEntry{
+			Name:          name,
+			Scheme:        "http",
+			StaticConfigs: []prometheusStaticConfig{{Targets: targets}},
+		})
+		return true
+	})
+
+	yamlConfig := prometheusConfig{
+		Global: prometheusGlobalConfig{
+			ScrapeInterval:     "5s",
+			EvaluationInterval: "5s",
+		},
+		ScrapeConfigs: scrapeConfigs,
+	}
+
+	b, err := yaml.Marshal(&yamlConfig)
+	p.Require().NoError(err, fmt.Sprintf("getPrometheusConfigFilePath: error creating yaml from scrape configs %+v", scrapeConfigs))
+
+	p.Logger().Info(fmt.Sprintf(`getPrometheusConfigFilePath: generated prometheus.yml: %s`, string(b)))
+
+	filePath := filepath.Join(p.TempDir(), "prometheus.yml")
+	file, err := os.Create(filePath)
+	p.Require().NoError(err, fmt.Sprintf("getPrometheusConfigFilePath:error creating prometheus file at %s", filePath))
+	defer file.Close()
+
+	_, err = file.Write(b)
+	p.Require().NoError(err, fmt.Sprintf("getPrometheusConfigFilePath:error writing string to prom file at %s, string: %s", filePath, string(b)))
+
+	return filePath
+}
+
+// getGrafanaProvisioningDirPath returns the path to the grafana provisioning dir for metrics.
+// If the provisioning dir env var is set, this function will use it. If not, a temp dir
+// will be created and removed when this process terminates.
+func getGrafanaProvisioningDirPath(p devtest.P) string {
+	// If the caller provides a Grafana provisioning directory, use that, otherwise use a temp dir
+	baseDir := os.Getenv(GrafanaProvisioningDirEnvVar)
+	if baseDir == "" {
+		baseDir = filepath.Join(p.TempDir(), "grafana")
+	}
+
+	dirPath := filepath.Join(baseDir, "provisioning/datasources")
+	err := os.MkdirAll(dirPath, 0777)
+	p.Require().NoError(err, fmt.Sprintf("getGrafanaProvisioningDirPath: error writing dir path %s", dirPath))
+
+	p.Logger().Info(fmt.Sprintf("Created grafana/provisioning/datasources dir at %s", dirPath))
+
+	filePath := filepath.Join(dirPath, "prometheus.yml")
+	file, err := os.Create(filePath)
+	p.Require().NoError(err, fmt.Sprintf("getGrafanaProvisioningDirPath: error creating prometheus file at %s", filePath))
+	defer file.Close()
+
+	contents := fmt.Sprintf(
+		`
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://%s:%s
+    isDefault: true
+`, DockerToLocalHost, PrometheusServerPort)
+
+	if _, err = file.WriteString(contents); err != nil {
+		p.Require().NoError(err, fmt.Sprintf("getGrafanaProvisioningDirPath: error prom file at %s, string: %s", filePath, contents))
+	}
+
+	p.Logger().Info(fmt.Sprintf("getGrafanaProvisioningDirPath: wrote prom config to file %s; config: %s", filePath, contents))
+
+	return baseDir
+}
+
+// getGrafanaDataDir returns the path to the grafana provisioning dir for metrics.
+// If the data dir env var is set, this function will use it. If not, a temp dir
+// will be created and removed when this process terminates.
+func getGrafanaDataDir(p devtest.P) string {
+	// If the caller provides a Grafana data directory, use that, otherwise use a temp dir
+	baseDir := os.Getenv(GrafanaDataDirEnvVar)
+	if baseDir == "" {
+		baseDir = filepath.Join(p.TempDir(), "grafana-data")
+	}
+
+	if _, err := os.Stat(baseDir); err != nil && os.IsNotExist(err) {
+		if err := os.Mkdir(baseDir, 0777); err != nil {
+			p.Require().NoError(err, fmt.Sprintf("getGrafanaDataDir: creating grafana data directory at %s", baseDir))
+		}
+	} else {
+		p.Require().NoError(err, fmt.Sprintf("getGrafanaDataDir: checking if grafana data directory exists at %s", baseDir))
+	}
+
+	return baseDir
+}

--- a/op-devstack/sysgo/l2_metrics_dashboard.go
+++ b/op-devstack/sysgo/l2_metrics_dashboard.go
@@ -71,7 +71,7 @@ func (g *L2MetricsDashboard) Stop() {
 	stopWaitGroup.Add(1)
 	go func() {
 		defer stopWaitGroup.Done()
-		err := g.grafanaSubprocess.Stop()
+		err := g.grafanaSubprocess.Stop(true)
 		g.p.Require().NoError(err, "Grafana must stop")
 		g.grafanaSubprocess = nil
 	}()
@@ -79,7 +79,7 @@ func (g *L2MetricsDashboard) Stop() {
 	stopWaitGroup.Add(1)
 	go func() {
 		defer stopWaitGroup.Done()
-		err := g.prometheusSubprocess.Stop()
+		err := g.prometheusSubprocess.Stop(true)
 		g.p.Require().NoError(err, "Prometheus must stop")
 		g.prometheusSubprocess = nil
 	}()

--- a/op-devstack/sysgo/l2_metrics_dashboard.go
+++ b/op-devstack/sysgo/l2_metrics_dashboard.go
@@ -163,20 +163,20 @@ func WithL2MetricsDashboard() stack.Option[*Orchestrator] {
 			"grafana/grafana",
 		}
 		grafanaEnv := []string{
-			PropagateEnvVarOrDefault("GF_SECURITY_ADMIN_USER", "admin"),
-			PropagateEnvVarOrDefault("GF_SECURITY_ADMIN_PASSWORD", "admin"),
-			PropagateEnvVarOrDefault("GF_USERS_ALLOW_SIGN_UP", "false"),
-			PropagateEnvVarOrDefault("GF_INSTALL_PLUGINS", "grafana-piechart-panel"),
+			propagateEnvVarOrDefault("GF_SECURITY_ADMIN_USER", "admin"),
+			propagateEnvVarOrDefault("GF_SECURITY_ADMIN_PASSWORD", "admin"),
+			propagateEnvVarOrDefault("GF_USERS_ALLOW_SIGN_UP", "false"),
+			propagateEnvVarOrDefault("GF_INSTALL_PLUGINS", "grafana-piechart-panel"),
 		}
 		dashboard := &L2MetricsDashboard{
 			p: p,
 
-			prometheusExecPath: GetEnvVarOrDefault(dockerExecutablePathEnvVar, "docker"),
+			prometheusExecPath: getEnvVarOrDefault(dockerExecutablePathEnvVar, "docker"),
 			prometheusArgs:     prometheusArgs,
 			prometheusEnv:      os.Environ(),
 			prometheusEndpoint: prometheusEndpoint,
 
-			grafanaExecPath: GetEnvVarOrDefault(dockerExecutablePathEnvVar, "docker"),
+			grafanaExecPath: getEnvVarOrDefault(dockerExecutablePathEnvVar, "docker"),
 			grafanaArgs:     grafanaArgs,
 			grafanaEnv:      append(grafanaEnv, os.Environ()...),
 		}

--- a/op-devstack/sysgo/l2_metrics_dashboard.go
+++ b/op-devstack/sysgo/l2_metrics_dashboard.go
@@ -102,9 +102,8 @@ func (g *L2MetricsDashboard) startPrometheus() {
 
 	g.prometheusSubprocess = NewSubProcess(g.p, stdOutLogs, stdErrLogs)
 
-	if err := g.prometheusSubprocess.Start(g.prometheusExecPath, g.prometheusArgs, g.prometheusEnv); err != nil {
-		g.p.Require().NoError(err, "prometheus must start")
-	}
+	err := g.prometheusSubprocess.Start(g.prometheusExecPath, g.prometheusArgs, g.prometheusEnv)
+	g.p.Require().NoError(err, "prometheus must start")
 
 	g.p.Logger().Info("Prometheus started", "endpoint", g.prometheusEndpoint)
 }
@@ -126,9 +125,8 @@ func (g *L2MetricsDashboard) startGrafana() {
 
 	g.grafanaSubprocess = NewSubProcess(g.p, stdOutLogs, stdErrLogs)
 
-	if err := g.grafanaSubprocess.Start(g.grafanaExecPath, g.grafanaArgs, g.grafanaEnv); err != nil {
-		g.p.Require().NoError(err, "Grafana must start")
-	}
+	err := g.grafanaSubprocess.Start(g.grafanaExecPath, g.grafanaArgs, g.grafanaEnv)
+	g.p.Require().NoError(err, "Grafana must start")
 
 	g.p.Logger().Info("Grafana started")
 }

--- a/op-devstack/sysgo/l2_metrics_dashboard.go
+++ b/op-devstack/sysgo/l2_metrics_dashboard.go
@@ -167,12 +167,12 @@ func WithL2MetricsDashboard() stack.Option[*Orchestrator] {
 		dashboard := &L2MetricsDashboard{
 			p: p,
 
-			prometheusExecPath: GetEnvVarOrDefault(DockerExecutablePathEnvVar, "/usr/local/bin/docker"),
+			prometheusExecPath: GetEnvVarOrDefault(DockerExecutablePathEnvVar, "docker"),
 			prometheusArgs:     prometheusArgs,
 			prometheusEnv:      []string{},
 			prometheusEndpoint: prometheusEndpoint,
 
-			grafanaExecPath: GetEnvVarOrDefault(DockerExecutablePathEnvVar, "/usr/local/bin/docker"),
+			grafanaExecPath: GetEnvVarOrDefault(DockerExecutablePathEnvVar, "docker"),
 			grafanaArgs:     grafanaArgs,
 			grafanaEnv:      grafanaEnv,
 		}

--- a/op-devstack/sysgo/l2_metrics_dashboard.go
+++ b/op-devstack/sysgo/l2_metrics_dashboard.go
@@ -138,11 +138,10 @@ func (g *L2MetricsDashboard) startPrometheus() {
 	g.prometheusSubprocess = NewSubProcess(g.p, stdOutLogs, stdErrLogs)
 
 	if err := g.prometheusSubprocess.Start(g.prometheusExecPath, g.prometheusArgs, g.prometheusEnv); err != nil {
-		g.p.Logger().Error(fmt.Sprintf("Error starting prometheus: %+v", err))
-		g.p.Require().NoError(err, "Must start")
+		g.p.Require().NoError(err, "prometheus must start")
 	}
 
-	g.p.Logger().Info(fmt.Sprintf("Prometheus started at %s", g.prometheusEndpoint))
+	g.p.Logger().Info("Prometheus started", "endpoint", g.prometheusEndpoint)
 }
 
 func (g *L2MetricsDashboard) startGrafana() {
@@ -163,8 +162,7 @@ func (g *L2MetricsDashboard) startGrafana() {
 	g.grafanaSubprocess = NewSubProcess(g.p, stdOutLogs, stdErrLogs)
 
 	if err := g.grafanaSubprocess.Start(g.grafanaExecPath, g.grafanaArgs, g.grafanaEnv); err != nil {
-		g.p.Logger().Error(fmt.Sprintf("Error starting grafana: %+v", err))
-		g.p.Require().NoError(err, "Must start")
+		g.p.Require().NoError(err, "Grafana must start")
 	}
 
 	g.p.Logger().Info("Grafana started")
@@ -220,7 +218,7 @@ func WithL2MetricsDashboard() stack.Option[*Orchestrator] {
 			grafanaEnv:      append(grafanaEnv, os.Environ()...),
 		}
 
-		p.Logger().Info(fmt.Sprintf("Starting metrics dashboard: %+v", dashboard))
+		p.Logger().Info("Starting metrics dashboard", "dashboard", dashboard)
 
 		dashboard.Start()
 		p.Cleanup(dashboard.Stop)
@@ -276,17 +274,17 @@ func getPrometheusConfigFilePath(p devtest.P, metricsEndpoints *locks.RWMap[stri
 	}
 
 	b, err := yaml.Marshal(&yamlConfig)
-	p.Require().NoError(err, fmt.Sprintf("getPrometheusConfigFilePath: error creating yaml from scrape configs %+v", scrapeConfigs))
+	p.Require().NoError(err, "getPrometheusConfigFilePath: error creating yaml from scrape configs", "scrapeConfigs", scrapeConfigs)
 
-	p.Logger().Info(fmt.Sprintf(`getPrometheusConfigFilePath: generated prometheus.yml: %s`, string(b)))
+	p.Logger().Info(`getPrometheusConfigFilePath: generated prometheus.yml`, "prometheus.yaml", string(b))
 
 	filePath := filepath.Join(p.TempDir(), "prometheus.yml")
 	file, err := os.Create(filePath)
-	p.Require().NoError(err, fmt.Sprintf("getPrometheusConfigFilePath:error creating prometheus file at %s", filePath))
+	p.Require().NoError(err, "getPrometheusConfigFilePath:error creating prometheus file", "filePath", filePath)
 	defer file.Close()
 
 	_, err = file.Write(b)
-	p.Require().NoError(err, fmt.Sprintf("getPrometheusConfigFilePath:error writing string to prom file at %s, string: %s", filePath, string(b)))
+	p.Require().NoError(err, "getPrometheusConfigFilePath:error writing string to prom file", "filePath", filePath, "contents", string(b))
 
 	return filePath
 }
@@ -306,13 +304,13 @@ func getGrafanaProvisioningDirPath(p devtest.P) string {
 
 	dirPath := filepath.Join(baseDir, "provisioning/datasources")
 	err := os.MkdirAll(dirPath, 0777)
-	p.Require().NoError(err, fmt.Sprintf("getGrafanaProvisioningDirPath: error writing dir path %s", dirPath))
+	p.Require().NoError(err, "getGrafanaProvisioningDirPath: error writing dir path", "dirPath", dirPath)
 
-	p.Logger().Info(fmt.Sprintf("Created grafana/provisioning/datasources dir at %s", dirPath))
+	p.Logger().Info("Created grafana/provisioning/datasources dir", "dirPath", dirPath)
 
 	filePath := filepath.Join(dirPath, "prometheus.yml")
 	file, err := os.Create(filePath)
-	p.Require().NoError(err, fmt.Sprintf("getGrafanaProvisioningDirPath: error creating prometheus file at %s", filePath))
+	p.Require().NoError(err, "getGrafanaProvisioningDirPath: error creating prometheus file", "filePath", filePath)
 	defer file.Close()
 
 	contents := fmt.Sprintf(
@@ -328,10 +326,10 @@ datasources:
 `, dockerToLocalHost, prometheusServerPort)
 
 	if _, err = file.WriteString(contents); err != nil {
-		p.Require().NoError(err, fmt.Sprintf("getGrafanaProvisioningDirPath: error prom file at %s, string: %s", filePath, contents))
+		p.Require().NoError(err, "getGrafanaProvisioningDirPath: error writing prom file", "filePath", filePath, "contents", contents)
 	}
 
-	p.Logger().Info(fmt.Sprintf("getGrafanaProvisioningDirPath: wrote prom config to file %s; config: %s", filePath, contents))
+	p.Logger().Info("getGrafanaProvisioningDirPath: wrote prom config to file", "filePath", filePath, "contents", contents)
 
 	return baseDir
 }
@@ -348,10 +346,10 @@ func getGrafanaDataDir(p devtest.P) string {
 
 	if _, err := os.Stat(baseDir); err != nil && os.IsNotExist(err) {
 		if err := os.Mkdir(baseDir, 0777); err != nil {
-			p.Require().NoError(err, fmt.Sprintf("getGrafanaDataDir: creating grafana data directory at %s", baseDir))
+			p.Require().NoError(err, "getGrafanaDataDir: error creating grafana data directory", "baseDir", baseDir)
 		}
 	} else {
-		p.Require().NoError(err, fmt.Sprintf("getGrafanaDataDir: checking if grafana data directory exists at %s", baseDir))
+		p.Require().NoError(err, "getGrafanaDataDir: checking if grafana data directory exists", "baseDir", baseDir)
 	}
 
 	return baseDir

--- a/op-devstack/sysgo/l2_metrics_dashboard.go
+++ b/op-devstack/sysgo/l2_metrics_dashboard.go
@@ -27,6 +27,12 @@ const grafanaHost = "0.0.0.0"
 const grafanaServerPort = "3000"
 const grafanaDockerPort = "3000"
 
+type L2MetricsRegistrar interface {
+	// RegisterL2MetricsEndpoints is called by components when they are started (or earlier) to register
+	// their metrics endpoints so that a prometheus instance may be spun up to scrape metrics.
+	RegisterL2MetricsEndpoints(serviceName stack.IDWithChain, endpoints ...PrometheusMetricsEndpoint)
+}
+
 type PrometheusMetricsEndpoint struct {
 	host              string
 	port              string

--- a/op-devstack/sysgo/l2_metrics_dashboard.go
+++ b/op-devstack/sysgo/l2_metrics_dashboard.go
@@ -63,8 +63,8 @@ func (g *L2MetricsDashboard) Stop() {
 func (g *L2MetricsDashboard) startPrometheus() {
 	// Create the sub-process.
 	// We pipe sub-process logs to the test-logger.
-	logOut := logpipe.ToLogger(g.p.Logger().New("src", "stdout"))
-	logErr := logpipe.ToLogger(g.p.Logger().New("src", "stderr"))
+	logOut := logpipe.ToLogger(g.p.Logger().New("component", "prometheus", "src", "stdout"))
+	logErr := logpipe.ToLogger(g.p.Logger().New("component", "prometheus", "src", "stderr"))
 
 	stdOutLogs := logpipe.LogProcessor(func(line []byte) {
 		e := logpipe.ParseRustStructuredLogs(line)
@@ -104,8 +104,8 @@ func (g *L2MetricsDashboard) startPrometheus() {
 func (g *L2MetricsDashboard) startGrafana() {
 	// Create the sub-process.
 	// We pipe sub-process logs to the test-logger.
-	logOut := logpipe.ToLogger(g.p.Logger().New("src", "stdout"))
-	logErr := logpipe.ToLogger(g.p.Logger().New("src", "stderr"))
+	logOut := logpipe.ToLogger(g.p.Logger().New("component", "grafana", "src", "stdout"))
+	logErr := logpipe.ToLogger(g.p.Logger().New("component", "grafana", "src", "stderr"))
 
 	stdOutLogs := logpipe.LogProcessor(func(line []byte) {
 		e := logpipe.ParseRustStructuredLogs(line)

--- a/op-devstack/sysgo/l2_metrics_dashboard.go
+++ b/op-devstack/sysgo/l2_metrics_dashboard.go
@@ -281,7 +281,9 @@ func getPrometheusConfigFilePath(p devtest.P, metricsEndpoints *locks.RWMap[stri
 	filePath := filepath.Join(p.TempDir(), "prometheus.yml")
 	file, err := os.Create(filePath)
 	p.Require().NoError(err, "getPrometheusConfigFilePath:error creating prometheus file", "filePath", filePath)
-	defer file.Close()
+	defer func() {
+		p.Require().NoError(file.Close())
+	}()
 
 	_, err = file.Write(b)
 	p.Require().NoError(err, "getPrometheusConfigFilePath:error writing string to prom file", "filePath", filePath, "contents", string(b))
@@ -311,7 +313,9 @@ func getGrafanaProvisioningDirPath(p devtest.P) string {
 	filePath := filepath.Join(dirPath, "prometheus.yml")
 	file, err := os.Create(filePath)
 	p.Require().NoError(err, "getGrafanaProvisioningDirPath: error creating prometheus file", "filePath", filePath)
-	defer file.Close()
+	defer func() {
+		p.Require().NoError(file.Close())
+	}()
 
 	contents := fmt.Sprintf(
 		`

--- a/op-devstack/sysgo/l2_metrics_dashboard.go
+++ b/op-devstack/sysgo/l2_metrics_dashboard.go
@@ -16,6 +16,8 @@ import (
 const dockerExecutablePathEnvVar = "SYSGO_DOCKER_EXEC_PATH"
 const grafanaProvisioningDirEnvVar = "SYSGO_GRAFANA_PROVISIONING_DIR"
 const grafanaDataDirEnvVar = "SYSGO_GRAFANA_DATA_DIR"
+const grafanaDockerImageTagEnvVar = "SYSGO_GRAFANA_DOCKER_IMAGE_TAG"
+const prometheusDockerImageTagEnvVar = "SYSGO_PROMETHEUS_DOCKER_IMAGE_TAG"
 
 const dockerToLocalHost = "host.docker.internal"
 
@@ -140,6 +142,7 @@ func WithL2MetricsDashboard() stack.Option[*Orchestrator] {
 
 		p := orch.P()
 
+		prometheusImageTag := getEnvVarOrDefault(prometheusDockerImageTagEnvVar, "v3.7.2")
 		prometheusEndpoint := fmt.Sprintf("http://%s:%s", prometheusHost, prometheusServerPort)
 		promConfig := getPrometheusConfigFilePath(p, &orch.l2MetricsEndpoints)
 		// these are args to run via docker; see dashboard definition below
@@ -147,10 +150,11 @@ func WithL2MetricsDashboard() stack.Option[*Orchestrator] {
 			"run",
 			"-p", fmt.Sprintf("%s:%s", prometheusServerPort, prometheusDockerPort),
 			"-v", fmt.Sprintf("%s:/etc/prometheus/prometheus.yml:ro", promConfig),
-			"prom/prometheus",
+			fmt.Sprintf("prom/prometheus:%s", prometheusImageTag),
 			"--config.file=/etc/prometheus/prometheus.yml",
 		}
 
+		grafanaImageTag := getEnvVarOrDefault(grafanaDockerImageTagEnvVar, "12.2")
 		grafanaEndpoint := fmt.Sprintf("http://%s:%s", grafanaHost, grafanaServerPort)
 		grafanaProvDir := getGrafanaProvisioningDirPath(p)
 		grafanaDataDir := getGrafanaDataDir(p)
@@ -160,7 +164,7 @@ func WithL2MetricsDashboard() stack.Option[*Orchestrator] {
 			"-p", fmt.Sprintf("%s:%s", grafanaServerPort, grafanaDockerPort),
 			"-v", fmt.Sprintf("%s:/etc/grafana/provisioning:ro", grafanaProvDir),
 			"-v", fmt.Sprintf("%s:/var/lib/grafana", grafanaDataDir),
-			"grafana/grafana",
+			fmt.Sprintf("grafana/grafana:%s", grafanaImageTag),
 		}
 		grafanaEnv := []string{
 			propagateEnvVarOrDefault("GF_SECURITY_ADMIN_USER", "admin"),

--- a/op-devstack/sysgo/l2_metrics_dashboard.go
+++ b/op-devstack/sysgo/l2_metrics_dashboard.go
@@ -28,13 +28,7 @@ const GrafanaHost = "0.0.0.0"
 const GrafanaServerPort = "3000"
 const GrafanaDockerPort = "3000"
 
-type L2MetricsDashboard interface {
-	stack.Lifecycle
-	hydrate(system stack.ExtensibleSystem)
-	Endpoint() string
-}
-
-type L2GrafanaDashboard struct {
+type L2MetricsDashboard struct {
 	p devtest.P
 
 	grafanaExecPath   string
@@ -50,19 +44,23 @@ type L2GrafanaDashboard struct {
 	prometheusEndpoint string
 }
 
-func (g *L2GrafanaDashboard) hydrate(system stack.ExtensibleSystem) {
-	// TODO:
-	//  if other components are running, store prometheus metrics scraping endpoints
-	//  if not, store an array of components to query at start-time
-	//		If going this route, create a generic interface for components to implement
-}
-
-func (g *L2GrafanaDashboard) Start() {
+func (g *L2MetricsDashboard) Start() {
 	g.startPrometheus()
 	g.startGrafana()
 }
 
-func (g *L2GrafanaDashboard) startPrometheus() {
+func (g *L2MetricsDashboard) Stop() {
+	err := g.grafanaSubprocess.Stop()
+	g.p.Require().NoError(err, "Grafana must stop")
+
+	err = g.prometheusSubprocess.Stop()
+	g.p.Require().NoError(err, "Prometheus must stop")
+
+	g.grafanaSubprocess = nil
+	g.prometheusSubprocess = nil
+}
+
+func (g *L2MetricsDashboard) startPrometheus() {
 	// Create the sub-process.
 	// We pipe sub-process logs to the test-logger.
 	logOut := logpipe.ToLogger(g.p.Logger().New("src", "stdout"))
@@ -100,10 +98,10 @@ func (g *L2GrafanaDashboard) startPrometheus() {
 		time.Sleep(interval)
 	}
 
-	g.p.Logger().Info(fmt.Sprintf("Prometheus started at %s...", g.prometheusEndpoint))
+	g.p.Logger().Info(fmt.Sprintf("Prometheus started at %s", g.prometheusEndpoint))
 }
 
-func (g *L2GrafanaDashboard) startGrafana() {
+func (g *L2MetricsDashboard) startGrafana() {
 	// Create the sub-process.
 	// We pipe sub-process logs to the test-logger.
 	logOut := logpipe.ToLogger(g.p.Logger().New("src", "stdout"))
@@ -124,30 +122,22 @@ func (g *L2GrafanaDashboard) startGrafana() {
 		g.p.Logger().Error(fmt.Sprintf("Error starting grafana: %+v", err))
 		g.p.Require().NoError(err, "Must start")
 	}
-}
 
-func (g *L2GrafanaDashboard) Stop() {
-	err := g.grafanaSubprocess.Stop()
-	g.p.Require().NoError(err, "Grafana must stop")
-
-	err = g.prometheusSubprocess.Stop()
-	g.p.Require().NoError(err, "Prometheus must stop")
-
-	g.grafanaSubprocess = nil
-	g.prometheusSubprocess = nil
+	g.p.Logger().Info("Grafana started")
 }
 
 func WithL2MetricsDashboard() stack.Option[*Orchestrator] {
 	return stack.Finally(func(orch *Orchestrator) {
-		p := orch.P()
-
 		// don't start prometheus or grafana if there is nothing exporting metrics.
-		if orch.metricsEndpoints.Len() == 0 {
+		if orch.l2MetricsEndpoints.Len() == 0 {
 			return
 		}
 
+		p := orch.P()
+
 		prometheusEndpoint := fmt.Sprintf("http://%s:%s", PrometheusHost, PrometheusServerPort)
-		promConfig := getPrometheusConfigFilePath(p, &orch.metricsEndpoints)
+		promConfig := getPrometheusConfigFilePath(p, &orch.l2MetricsEndpoints)
+		// these are args to run via docker; see dashboard definition below
 		prometheusArgs := []string{
 			"run",
 			"-p", fmt.Sprintf("%s:%s", PrometheusServerPort, PrometheusDockerPort),
@@ -155,10 +145,11 @@ func WithL2MetricsDashboard() stack.Option[*Orchestrator] {
 			"prom/prometheus",
 			"--config.file=/etc/prometheus/prometheus.yml",
 		}
-		p.TempDir()
 
+		grafanaEndpoint := fmt.Sprintf("http://%s:%s", GrafanaHost, GrafanaServerPort)
 		grafanaProvDir := getGrafanaProvisioningDirPath(p)
 		grafanaDataDir := getGrafanaDataDir(p)
+		// these are args to run via docker; see dashboard definition below
 		grafanaArgs := []string{
 			"run",
 			"-p", fmt.Sprintf("%s:%s", GrafanaServerPort, GrafanaDockerPort),
@@ -173,7 +164,7 @@ func WithL2MetricsDashboard() stack.Option[*Orchestrator] {
 			PropagateEnvVarOrDefault("GF_INSTALL_PLUGINS", "grafana-piechart-panel"),
 		}
 
-		dashboard := &L2GrafanaDashboard{
+		dashboard := &L2MetricsDashboard{
 			p: p,
 
 			prometheusExecPath: GetEnvVarOrDefault(DockerExecutablePathEnvVar, "/usr/local/bin/docker"),
@@ -190,10 +181,11 @@ func WithL2MetricsDashboard() stack.Option[*Orchestrator] {
 
 		dashboard.Start()
 		p.Cleanup(dashboard.Stop)
-		p.Logger().Info("Metrics dashboard is up", "url", fmt.Sprintf("http://%s:%s", GrafanaHost, GrafanaServerPort))
+		p.Logger().Info("Metrics dashboard is up", "url", grafanaEndpoint)
 	})
 }
 
+// TODO: If our needs get more complex, use https://pkg.go.dev/github.com/prometheus/prometheus/config instead.
 type prometheusConfig struct {
 	Global        prometheusGlobalConfig        `yaml:"global"`
 	ScrapeConfigs []prometheusScrapeConfigEntry `yaml:"scrape_configs"`
@@ -224,7 +216,7 @@ func endpointHostPortString(p PrometheusMetricsEndpoint) string {
 	return fmt.Sprintf("%s:%s", host, p.port)
 }
 
-// Returns the path to dynamically-generated the prometheus.yml file for metrics.
+// Returns the path to the dynamically-generated prometheus.yml file for metrics scraping.
 func getPrometheusConfigFilePath(p devtest.P, metricsEndpoints *locks.RWMap[string, []PrometheusMetricsEndpoint]) string {
 
 	var scrapeConfigs []prometheusScrapeConfigEntry
@@ -267,8 +259,11 @@ func getPrometheusConfigFilePath(p devtest.P, metricsEndpoints *locks.RWMap[stri
 }
 
 // getGrafanaProvisioningDirPath returns the path to the grafana provisioning dir for metrics.
-// If the provisioning dir env var is set, this function will use it. If not, a temp dir
+// If the provisioning dir env var is set, this function will use that path. If not, a temp dir
 // will be created and removed when this process terminates.
+// Note: from the returned directory, the generated prometheus.yml will be at:
+//
+//	returned_dir_path/provisioning/datasources/prometheus.yml
 func getGrafanaProvisioningDirPath(p devtest.P) string {
 	// If the caller provides a Grafana provisioning directory, use that, otherwise use a temp dir
 	baseDir := os.Getenv(GrafanaProvisioningDirEnvVar)
@@ -309,7 +304,7 @@ datasources:
 }
 
 // getGrafanaDataDir returns the path to the grafana provisioning dir for metrics.
-// If the data dir env var is set, this function will use it. If not, a temp dir
+// If the data dir env var is set, this function will use that path. If not, a temp dir
 // will be created and removed when this process terminates.
 func getGrafanaDataDir(p devtest.P) string {
 	// If the caller provides a Grafana data directory, use that, otherwise use a temp dir

--- a/op-devstack/sysgo/l2_metrics_dashboard.go
+++ b/op-devstack/sysgo/l2_metrics_dashboard.go
@@ -27,6 +27,13 @@ const grafanaHost = "0.0.0.0"
 const grafanaServerPort = "3000"
 const grafanaDockerPort = "3000"
 
+type PrometheusMetricsEndpoint struct {
+	host              string
+	port              string
+	isLocal           bool
+	isRunningInDocker bool
+}
+
 type L2MetricsDashboard struct {
 	p devtest.P
 

--- a/op-devstack/sysgo/l2_metrics_dashboard.go
+++ b/op-devstack/sysgo/l2_metrics_dashboard.go
@@ -128,8 +128,8 @@ func (g *L2MetricsDashboard) startGrafana() {
 
 func WithL2MetricsDashboard() stack.Option[*Orchestrator] {
 	return stack.Finally(func(orch *Orchestrator) {
-		// don't start prometheus or grafana if there is nothing exporting metrics.
-		if orch.l2MetricsEndpoints.Len() == 0 {
+		// don't start prometheus or grafana if metrics are disabled or there is nothing exporting metrics.
+		if !AreMetricsEnabled() || orch.l2MetricsEndpoints.Len() == 0 {
 			return
 		}
 

--- a/op-devstack/sysgo/l2_metrics_dashboard.go
+++ b/op-devstack/sysgo/l2_metrics_dashboard.go
@@ -2,10 +2,9 @@ package sysgo
 
 import (
 	"fmt"
-	"net/http"
 	"os"
 	"path/filepath"
-	"time"
+	"sync"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
@@ -45,19 +44,65 @@ type L2MetricsDashboard struct {
 }
 
 func (g *L2MetricsDashboard) Start() {
-	g.startPrometheus()
-	g.startGrafana()
+	var startWaitGroup sync.WaitGroup
+
+	startWaitGroup.Add(1)
+	go func() {
+		defer startWaitGroup.Done()
+		g.startPrometheus()
+	}()
+
+	startWaitGroup.Add(1)
+	go func() {
+		defer startWaitGroup.Done()
+		g.startGrafana()
+	}()
+
+	startedCh := make(chan struct{})
+	go func() {
+		startWaitGroup.Wait()
+		close(startedCh)
+	}()
+
+	select {
+	case <-g.p.Ctx().Done():
+		g.p.Logger().Info("context done before prometheus and grafana started")
+	case <-startedCh:
+		g.p.Logger().Info("prometheus and grafana started successfully")
+	}
 }
 
 func (g *L2MetricsDashboard) Stop() {
-	err := g.grafanaSubprocess.Stop()
-	g.p.Require().NoError(err, "Grafana must stop")
+	var stopWaitGroup sync.WaitGroup
 
-	err = g.prometheusSubprocess.Stop()
-	g.p.Require().NoError(err, "Prometheus must stop")
+	stopWaitGroup.Add(1)
+	go func() {
+		defer stopWaitGroup.Done()
+		err := g.grafanaSubprocess.Stop()
+		g.p.Require().NoError(err, "Grafana must stop")
+		g.grafanaSubprocess = nil
+	}()
 
-	g.grafanaSubprocess = nil
-	g.prometheusSubprocess = nil
+	stopWaitGroup.Add(1)
+	go func() {
+		defer stopWaitGroup.Done()
+		err := g.prometheusSubprocess.Stop()
+		g.p.Require().NoError(err, "Prometheus must stop")
+		g.prometheusSubprocess = nil
+	}()
+
+	stoppedCh := make(chan struct{})
+	go func() {
+		stopWaitGroup.Wait()
+		close(stoppedCh)
+	}()
+
+	select {
+	case <-g.p.Ctx().Done():
+		g.p.Logger().Info("context done before prometheus and grafana exited")
+	case <-stoppedCh:
+		g.p.Logger().Info("prometheus and grafana stopped successfully")
+	}
 }
 
 func (g *L2MetricsDashboard) startPrometheus() {
@@ -80,22 +125,6 @@ func (g *L2MetricsDashboard) startPrometheus() {
 	if err := g.prometheusSubprocess.Start(g.prometheusExecPath, g.prometheusArgs, g.prometheusEnv); err != nil {
 		g.p.Logger().Error(fmt.Sprintf("Error starting prometheus: %+v", err))
 		g.p.Require().NoError(err, "Must start")
-	}
-
-	// Wait until prometheus is ready
-	url := fmt.Sprintf("%s/-/ready", g.prometheusEndpoint)
-	interval := 2 * time.Second
-
-	for {
-		resp, err := http.Get(url)
-		if err == nil && resp.StatusCode == http.StatusOK {
-			resp.Body.Close()
-			break
-		}
-
-		g.p.Logger().Info(fmt.Sprintf("Waiting for prometheus to start at %s...", g.prometheusEndpoint))
-
-		time.Sleep(interval)
 	}
 
 	g.p.Logger().Info(fmt.Sprintf("Prometheus started at %s", g.prometheusEndpoint))

--- a/op-devstack/sysgo/l2_metrics_dashboard.go
+++ b/op-devstack/sysgo/l2_metrics_dashboard.go
@@ -14,19 +14,19 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const DockerExecutablePathEnvVar = "SYSGO_DOCKER_EXEC_PATH"
-const GrafanaProvisioningDirEnvVar = "SYSGO_GRAFANA_PROVISIONING_DIR"
-const GrafanaDataDirEnvVar = "SYSGO_GRAFANA_DATA_DIR"
+const dockerExecutablePathEnvVar = "SYSGO_DOCKER_EXEC_PATH"
+const grafanaProvisioningDirEnvVar = "SYSGO_GRAFANA_PROVISIONING_DIR"
+const grafanaDataDirEnvVar = "SYSGO_GRAFANA_DATA_DIR"
 
-const DockerToLocalHost = "host.docker.internal"
+const dockerToLocalHost = "host.docker.internal"
 
-const PrometheusHost = "0.0.0.0"
-const PrometheusServerPort = "9999"
-const PrometheusDockerPort = "9090"
+const prometheusHost = "0.0.0.0"
+const prometheusServerPort = "9999"
+const prometheusDockerPort = "9090"
 
-const GrafanaHost = "0.0.0.0"
-const GrafanaServerPort = "3000"
-const GrafanaDockerPort = "3000"
+const grafanaHost = "0.0.0.0"
+const grafanaServerPort = "3000"
+const grafanaDockerPort = "3000"
 
 type L2MetricsDashboard struct {
 	p devtest.P
@@ -129,30 +129,30 @@ func (g *L2MetricsDashboard) startGrafana() {
 func WithL2MetricsDashboard() stack.Option[*Orchestrator] {
 	return stack.Finally(func(orch *Orchestrator) {
 		// don't start prometheus or grafana if metrics are disabled or there is nothing exporting metrics.
-		if !AreMetricsEnabled() || orch.l2MetricsEndpoints.Len() == 0 {
+		if !areMetricsEnabled() || orch.l2MetricsEndpoints.Len() == 0 {
 			return
 		}
 
 		p := orch.P()
 
-		prometheusEndpoint := fmt.Sprintf("http://%s:%s", PrometheusHost, PrometheusServerPort)
+		prometheusEndpoint := fmt.Sprintf("http://%s:%s", prometheusHost, prometheusServerPort)
 		promConfig := getPrometheusConfigFilePath(p, &orch.l2MetricsEndpoints)
 		// these are args to run via docker; see dashboard definition below
 		prometheusArgs := []string{
 			"run",
-			"-p", fmt.Sprintf("%s:%s", PrometheusServerPort, PrometheusDockerPort),
+			"-p", fmt.Sprintf("%s:%s", prometheusServerPort, prometheusDockerPort),
 			"-v", fmt.Sprintf("%s:/etc/prometheus/prometheus.yml:ro", promConfig),
 			"prom/prometheus",
 			"--config.file=/etc/prometheus/prometheus.yml",
 		}
 
-		grafanaEndpoint := fmt.Sprintf("http://%s:%s", GrafanaHost, GrafanaServerPort)
+		grafanaEndpoint := fmt.Sprintf("http://%s:%s", grafanaHost, grafanaServerPort)
 		grafanaProvDir := getGrafanaProvisioningDirPath(p)
 		grafanaDataDir := getGrafanaDataDir(p)
 		// these are args to run via docker; see dashboard definition below
 		grafanaArgs := []string{
 			"run",
-			"-p", fmt.Sprintf("%s:%s", GrafanaServerPort, GrafanaDockerPort),
+			"-p", fmt.Sprintf("%s:%s", grafanaServerPort, grafanaDockerPort),
 			"-v", fmt.Sprintf("%s:/etc/grafana/provisioning:ro", grafanaProvDir),
 			"-v", fmt.Sprintf("%s:/var/lib/grafana", grafanaDataDir),
 			"grafana/grafana",
@@ -167,12 +167,12 @@ func WithL2MetricsDashboard() stack.Option[*Orchestrator] {
 		dashboard := &L2MetricsDashboard{
 			p: p,
 
-			prometheusExecPath: GetEnvVarOrDefault(DockerExecutablePathEnvVar, "docker"),
+			prometheusExecPath: GetEnvVarOrDefault(dockerExecutablePathEnvVar, "docker"),
 			prometheusArgs:     prometheusArgs,
 			prometheusEnv:      []string{},
 			prometheusEndpoint: prometheusEndpoint,
 
-			grafanaExecPath: GetEnvVarOrDefault(DockerExecutablePathEnvVar, "docker"),
+			grafanaExecPath: GetEnvVarOrDefault(dockerExecutablePathEnvVar, "docker"),
 			grafanaArgs:     grafanaArgs,
 			grafanaEnv:      grafanaEnv,
 		}
@@ -211,7 +211,7 @@ type prometheusStaticConfig struct {
 func endpointHostPortString(p PrometheusMetricsEndpoint) string {
 	host := p.host
 	if p.isLocal && !p.isRunningInDocker {
-		host = DockerToLocalHost
+		host = dockerToLocalHost
 	}
 	return fmt.Sprintf("%s:%s", host, p.port)
 }
@@ -266,7 +266,7 @@ func getPrometheusConfigFilePath(p devtest.P, metricsEndpoints *locks.RWMap[stri
 //	returned_dir_path/provisioning/datasources/prometheus.yml
 func getGrafanaProvisioningDirPath(p devtest.P) string {
 	// If the caller provides a Grafana provisioning directory, use that, otherwise use a temp dir
-	baseDir := os.Getenv(GrafanaProvisioningDirEnvVar)
+	baseDir := os.Getenv(grafanaProvisioningDirEnvVar)
 	if baseDir == "" {
 		baseDir = filepath.Join(p.TempDir(), "grafana")
 	}
@@ -292,7 +292,7 @@ datasources:
     access: proxy
     url: http://%s:%s
     isDefault: true
-`, DockerToLocalHost, PrometheusServerPort)
+`, dockerToLocalHost, prometheusServerPort)
 
 	if _, err = file.WriteString(contents); err != nil {
 		p.Require().NoError(err, fmt.Sprintf("getGrafanaProvisioningDirPath: error prom file at %s, string: %s", filePath, contents))
@@ -308,7 +308,7 @@ datasources:
 // will be created and removed when this process terminates.
 func getGrafanaDataDir(p devtest.P) string {
 	// If the caller provides a Grafana data directory, use that, otherwise use a temp dir
-	baseDir := os.Getenv(GrafanaDataDirEnvVar)
+	baseDir := os.Getenv(grafanaDataDirEnvVar)
 	if baseDir == "" {
 		baseDir = filepath.Join(p.TempDir(), "grafana-data")
 	}

--- a/op-devstack/sysgo/l2_metrics_dashboard.go
+++ b/op-devstack/sysgo/l2_metrics_dashboard.go
@@ -59,32 +59,8 @@ type L2MetricsDashboard struct {
 }
 
 func (g *L2MetricsDashboard) Start() {
-	var startWaitGroup sync.WaitGroup
-
-	startWaitGroup.Add(1)
-	go func() {
-		defer startWaitGroup.Done()
-		g.startPrometheus()
-	}()
-
-	startWaitGroup.Add(1)
-	go func() {
-		defer startWaitGroup.Done()
-		g.startGrafana()
-	}()
-
-	startedCh := make(chan struct{})
-	go func() {
-		startWaitGroup.Wait()
-		close(startedCh)
-	}()
-
-	select {
-	case <-g.p.Ctx().Done():
-		g.p.Logger().Info("context done before prometheus and grafana started")
-	case <-startedCh:
-		g.p.Logger().Info("prometheus and grafana started successfully")
-	}
+	g.startPrometheus()
+	g.startGrafana()
 }
 
 func (g *L2MetricsDashboard) Stop() {
@@ -106,18 +82,7 @@ func (g *L2MetricsDashboard) Stop() {
 		g.prometheusSubprocess = nil
 	}()
 
-	stoppedCh := make(chan struct{})
-	go func() {
-		stopWaitGroup.Wait()
-		close(stoppedCh)
-	}()
-
-	select {
-	case <-g.p.Ctx().Done():
-		g.p.Logger().Info("context done before prometheus and grafana exited")
-	case <-stoppedCh:
-		g.p.Logger().Info("prometheus and grafana stopped successfully")
-	}
+	stopWaitGroup.Wait()
 }
 
 func (g *L2MetricsDashboard) startPrometheus() {

--- a/op-devstack/sysgo/l2_metrics_dashboard_test.go
+++ b/op-devstack/sysgo/l2_metrics_dashboard_test.go
@@ -30,7 +30,7 @@ func TestWithL2MetricsDashboard_DisabledIfEndpointsRegisteredButNotExplicitlyEna
 func TestWithL2MetricsDashboard_DisabledIfNoEndpointsRegisteredButExplicitlyEnabled(t *testing.T) {
 
 	o := &Orchestrator{}
-	err := os.Setenv(SysgoMetricsEnabledEnvVar, "true")
+	err := os.Setenv(sysgoMetricsEnabledEnvVar, "true")
 	require.NoError(t, err, "error setting metrics enabled")
 
 	// This should run without error if disabled

--- a/op-devstack/sysgo/l2_metrics_dashboard_test.go
+++ b/op-devstack/sysgo/l2_metrics_dashboard_test.go
@@ -1,0 +1,12 @@
+package sysgo
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+)
+
+func TestWithL2MetricsDashboard_DefaultDisabled(t *testing.T) {
+	// This should run without error if orch.l2MetricsEndpoints is unset
+	stack.ApplyOptionLifecycle(WithL2MetricsDashboard(), &Orchestrator{})
+}

--- a/op-devstack/sysgo/l2_metrics_dashboard_test.go
+++ b/op-devstack/sysgo/l2_metrics_dashboard_test.go
@@ -16,7 +16,7 @@ func TestWithL2MetricsDashboard_DefaultDisabled(t *testing.T) {
 func TestWithL2MetricsDashboard_DisabledIfEndpointsRegisteredButNotExplicitlyEnabled(t *testing.T) {
 
 	o := &Orchestrator{}
-	o.RegisterL2MetricsEndpoints("test", PrometheusMetricsEndpoint{
+	o.RegisterL2MetricsTargets("test", PrometheusMetricsTarget{
 		host:              "localhost",
 		port:              "9090",
 		isLocal:           true,

--- a/op-devstack/sysgo/l2_metrics_dashboard_test.go
+++ b/op-devstack/sysgo/l2_metrics_dashboard_test.go
@@ -1,12 +1,38 @@
 package sysgo
 
 import (
+	"os"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/stretchr/testify/require"
 )
 
 func TestWithL2MetricsDashboard_DefaultDisabled(t *testing.T) {
 	// This should run without error if orch.l2MetricsEndpoints is unset
 	stack.ApplyOptionLifecycle(WithL2MetricsDashboard(), &Orchestrator{})
+}
+
+func TestWithL2MetricsDashboard_DisabledIfEndpointsRegisteredButNotExplicitlyEnabled(t *testing.T) {
+
+	o := &Orchestrator{}
+	o.RegisterL2MetricsEndpoints("test", PrometheusMetricsEndpoint{
+		host:              "localhost",
+		port:              "9090",
+		isLocal:           true,
+		isRunningInDocker: false,
+	})
+
+	// This should run without error if disabled
+	stack.ApplyOptionLifecycle(WithL2MetricsDashboard(), o)
+}
+
+func TestWithL2MetricsDashboard_DisabledIfNoEndpointsRegisteredButExplicitlyEnabled(t *testing.T) {
+
+	o := &Orchestrator{}
+	err := os.Setenv(SysgoMetricsEnabledEnvVar, "true")
+	require.NoError(t, err, "error setting metrics enabled")
+
+	// This should run without error if disabled
+	stack.ApplyOptionLifecycle(WithL2MetricsDashboard(), o)
 }

--- a/op-devstack/sysgo/l2_metrics_dashboard_test.go
+++ b/op-devstack/sysgo/l2_metrics_dashboard_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/stretchr/testify/require"
 )
 
@@ -14,14 +15,11 @@ func TestWithL2MetricsDashboard_DefaultDisabled(t *testing.T) {
 }
 
 func TestWithL2MetricsDashboard_DisabledIfEndpointsRegisteredButNotExplicitlyEnabled(t *testing.T) {
+	id := stack.NewL2ELNodeID("test", eth.ChainIDFromUInt64(11111111111))
+	metricsTarget := NewPrometheusMetricsTarget("localhost", "9090", false)
 
 	o := &Orchestrator{}
-	o.RegisterL2MetricsTargets("test", PrometheusMetricsTarget{
-		host:              "localhost",
-		port:              "9090",
-		isLocal:           true,
-		isRunningInDocker: false,
-	})
+	o.RegisterL2MetricsTargets(id, metricsTarget)
 
 	// This should run without error if disabled
 	stack.ApplyOptionLifecycle(WithL2MetricsDashboard(), o)

--- a/op-devstack/sysgo/orchestrator.go
+++ b/op-devstack/sysgo/orchestrator.go
@@ -20,7 +20,6 @@ import (
 )
 
 type PrometheusMetricsEndpoint struct {
-	name              string
 	host              string
 	port              string
 	isLocal           bool
@@ -59,8 +58,8 @@ type Orchestrator struct {
 	challengers    locks.RWMap[stack.L2ChallengerID, *L2Challenger]
 	proposers      locks.RWMap[stack.L2ProposerID, *L2Proposer]
 
-	// Prometheus endpoints to scrape
-	metricsEndpoints locks.RWMap[string, []PrometheusMetricsEndpoint]
+	// service name => prometheus endpoints to scrape
+	l2MetricsEndpoints locks.RWMap[string, []PrometheusMetricsEndpoint]
 
 	syncTester *SyncTesterService
 	faucet     *FaucetService
@@ -150,11 +149,11 @@ func (o *Orchestrator) Hydrate(sys stack.ExtensibleSystem) {
 	o.sysHook.PostHydrate(sys)
 }
 
-// RegisterMetricsEndpoints is called by components when they are started (or earlier) to register
+// RegisterL2MetricsEndpoints is called by components when they are started (or earlier) to register
 // their metrics endpoints so that a prometheus instance may be spun up to scrape metrics.
-func (o *Orchestrator) RegisterMetricsEndpoints(serviceName string, endpoints ...PrometheusMetricsEndpoint) {
+func (o *Orchestrator) RegisterL2MetricsEndpoints(serviceName string, endpoints ...PrometheusMetricsEndpoint) {
 	// NB: there may be multiple services with the same name, but we'll register them as separate metrics endpoints
-	for i := 1; !o.metricsEndpoints.SetIfMissing(fmt.Sprintf("%s_%d", serviceName, i), endpoints); i++ {
+	for i := 1; !o.l2MetricsEndpoints.SetIfMissing(fmt.Sprintf("%s_%d", serviceName, i), endpoints); i++ {
 	}
 }
 

--- a/op-devstack/sysgo/orchestrator.go
+++ b/op-devstack/sysgo/orchestrator.go
@@ -51,7 +51,7 @@ type Orchestrator struct {
 	proposers      locks.RWMap[stack.L2ProposerID, *L2Proposer]
 
 	// service name => prometheus endpoints to scrape
-	l2MetricsEndpoints locks.RWMap[string, []PrometheusMetricsEndpoint]
+	l2MetricsEndpoints locks.RWMap[string, []PrometheusMetricsTarget]
 
 	syncTester *SyncTesterService
 	faucet     *FaucetService
@@ -141,7 +141,7 @@ func (o *Orchestrator) Hydrate(sys stack.ExtensibleSystem) {
 	o.sysHook.PostHydrate(sys)
 }
 
-func (o *Orchestrator) RegisterL2MetricsEndpoints(id stack.IDWithChain, endpoints ...PrometheusMetricsEndpoint) {
+func (o *Orchestrator) RegisterL2MetricsTargets(id stack.IDWithChain, endpoints ...PrometheusMetricsTarget) {
 	wasSet := o.l2MetricsEndpoints.SetIfMissing(id.Key(), endpoints)
 	if !wasSet {
 		existing, found := o.l2MetricsEndpoints.Get(id.Key())

--- a/op-devstack/sysgo/orchestrator.go
+++ b/op-devstack/sysgo/orchestrator.go
@@ -144,8 +144,8 @@ func (o *Orchestrator) Hydrate(sys stack.ExtensibleSystem) {
 func (o *Orchestrator) RegisterL2MetricsTargets(id stack.IDWithChain, endpoints ...PrometheusMetricsTarget) {
 	wasSet := o.l2MetricsEndpoints.SetIfMissing(id.Key(), endpoints)
 	if !wasSet {
-		existing, found := o.l2MetricsEndpoints.Get(id.Key())
-		o.p.Require().True(wasSet, "l2MetricsEndpoints endpoints not set", "key", id.Key(), "endpoints", endpoints, "conflicted", found, "conflicts", existing)
+		existing, _ := o.l2MetricsEndpoints.Get(id.Key())
+		o.p.Logger().Warn("multiple endpoints registered with the same key", "key", id.Key(), "existing", existing, "new", endpoints)
 	}
 }
 

--- a/op-devstack/sysgo/orchestrator.go
+++ b/op-devstack/sysgo/orchestrator.go
@@ -19,13 +19,6 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 
-type PrometheusMetricsEndpoint struct {
-	host              string
-	port              string
-	isLocal           bool
-	isRunningInDocker bool
-}
-
 type Orchestrator struct {
 	p devtest.P
 

--- a/op-devstack/sysgo/orchestrator.go
+++ b/op-devstack/sysgo/orchestrator.go
@@ -1,7 +1,6 @@
 package sysgo
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
@@ -142,11 +141,11 @@ func (o *Orchestrator) Hydrate(sys stack.ExtensibleSystem) {
 	o.sysHook.PostHydrate(sys)
 }
 
-// RegisterL2MetricsEndpoints is called by components when they are started (or earlier) to register
-// their metrics endpoints so that a prometheus instance may be spun up to scrape metrics.
-func (o *Orchestrator) RegisterL2MetricsEndpoints(serviceName string, endpoints ...PrometheusMetricsEndpoint) {
-	// NB: there may be multiple services with the same name, but we'll register them as separate metrics endpoints
-	for i := 1; !o.l2MetricsEndpoints.SetIfMissing(fmt.Sprintf("%s_%d", serviceName, i), endpoints); i++ {
+func (o *Orchestrator) RegisterL2MetricsEndpoints(id stack.IDWithChain, endpoints ...PrometheusMetricsEndpoint) {
+	wasSet := o.l2MetricsEndpoints.SetIfMissing(id.Key(), endpoints)
+	if !wasSet {
+		existing, found := o.l2MetricsEndpoints.Get(id.Key())
+		o.p.Require().True(wasSet, "l2MetricsEndpoints endpoints not set", "key", id.Key(), "endpoints", endpoints, "conflicted", found, "conflicts", existing)
 	}
 }
 

--- a/op-devstack/sysgo/orchestrator.go
+++ b/op-devstack/sysgo/orchestrator.go
@@ -1,6 +1,7 @@
 package sysgo
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
@@ -17,6 +18,14 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/locks"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 )
+
+type PrometheusMetricsEndpoint struct {
+	name              string
+	host              string
+	port              string
+	isLocal           bool
+	isRunningInDocker bool
+}
 
 type Orchestrator struct {
 	p devtest.P
@@ -49,6 +58,9 @@ type Orchestrator struct {
 	batchers       locks.RWMap[stack.L2BatcherID, *L2Batcher]
 	challengers    locks.RWMap[stack.L2ChallengerID, *L2Challenger]
 	proposers      locks.RWMap[stack.L2ProposerID, *L2Proposer]
+
+	// Prometheus endpoints to scrape
+	metricsEndpoints locks.RWMap[string, []PrometheusMetricsEndpoint]
 
 	syncTester *SyncTesterService
 	faucet     *FaucetService
@@ -136,6 +148,14 @@ func (o *Orchestrator) Hydrate(sys stack.ExtensibleSystem) {
 	}
 	o.faucet.hydrate(sys)
 	o.sysHook.PostHydrate(sys)
+}
+
+// RegisterMetricsEndpoints is called by components when they are started (or earlier) to register
+// their metrics endpoints so that a prometheus instance may be spun up to scrape metrics.
+func (o *Orchestrator) RegisterMetricsEndpoints(serviceName string, endpoints ...PrometheusMetricsEndpoint) {
+	// NB: there may be multiple services with the same name, but we'll register them as separate metrics endpoints
+	for i := 1; !o.metricsEndpoints.SetIfMissing(fmt.Sprintf("%s_%d", serviceName, i), endpoints); i++ {
+	}
 }
 
 type hydrator interface {

--- a/op-devstack/sysgo/system.go
+++ b/op-devstack/sysgo/system.go
@@ -82,6 +82,8 @@ func defaultMinimalSystemOpts(ids *DefaultMinimalSystemIDs, dest *DefaultMinimal
 		ids.L2EL,
 	}))
 
+	opt.Add(WithL2MetricsDashboard())
+
 	opt.Add(stack.Finally(func(orch *Orchestrator) {
 		*dest = *ids
 	}))
@@ -162,6 +164,8 @@ func DefaultTwoL2System(dest *DefaultTwoL2SystemIDs) stack.Option[*Orchestrator]
 	opt.Add(WithProposer(ids.L2BProposer, ids.L1EL, &ids.L2BCL, nil))
 
 	opt.Add(WithFaucets([]stack.L1ELNodeID{ids.L1EL}, []stack.L2ELNodeID{ids.L2AEL, ids.L2BEL}))
+
+	opt.Add(WithL2MetricsDashboard())
 
 	opt.Add(stack.Finally(func(orch *Orchestrator) {
 		*dest = ids
@@ -265,6 +269,8 @@ func DefaultMinimalSystemWithSyncTester(dest *DefaultMinimalSystemWithSyncTester
 
 	opt.Add(WithSyncTester(ids.SyncTester, []stack.L2ELNodeID{ids.L2EL}))
 
+	opt.Add(WithL2MetricsDashboard())
+
 	opt.Add(stack.Finally(func(orch *Orchestrator) {
 		*dest = ids
 	}))
@@ -365,6 +371,9 @@ func baseInteropSystem(ids *DefaultSingleChainInteropSystemIDs) stack.Option[*Or
 	// Note: we provide L2 CL nodes still, even though they are not used post-interop.
 	// Since we may create an interop infra-setup, before interop is even scheduled to run.
 	opt.Add(WithProposer(ids.L2AProposer, ids.L1EL, &ids.L2ACL, &ids.Supervisor))
+
+	opt.Add(WithL2MetricsDashboard())
+
 	return opt
 }
 
@@ -425,6 +434,8 @@ func DefaultInteropSystem(dest *DefaultInteropSystemIDs) stack.Option[*Orchestra
 	}))
 
 	opt.Add(WithFaucets([]stack.L1ELNodeID{ids.L1EL}, []stack.L2ELNodeID{ids.L2AEL, ids.L2BEL}))
+
+	opt.Add(WithL2MetricsDashboard())
 
 	// Upon evaluation of the option, export the contents we created.
 	// Ids here are static, but other things may be exported too.
@@ -490,6 +501,8 @@ func defaultSuperProofsSystem(dest *DefaultInteropSystemIDs, deployerOpts ...Dep
 		ids.L2BEL, ids.L2AEL,
 	}))
 
+	opt.Add(WithL2MetricsDashboard())
+
 	// Upon evaluation of the option, export the contents we created.
 	// Ids here are static, but other things may be exported too.
 	opt.Add(stack.Finally(func(orch *Orchestrator) {
@@ -543,6 +556,8 @@ func MultiSupervisorInteropSystem(dest *MultiSupervisorInteropSystemIDs) stack.O
 	// P2P connect L2CL nodes
 	opt.Add(WithL2CLP2PConnection(ids.L2ACL, ids.L2A2CL))
 	opt.Add(WithL2CLP2PConnection(ids.L2BCL, ids.L2B2CL))
+
+	opt.Add(WithL2MetricsDashboard())
 
 	// Upon evaluation of the option, export the contents we created.
 	// Ids here are static, but other things may be exported too.

--- a/op-devstack/sysgo/system_singlechain_multinode.go
+++ b/op-devstack/sysgo/system_singlechain_multinode.go
@@ -74,6 +74,7 @@ func DefaultSingleChainMultiNodeSystemWithoutP2P(dest *DefaultSingleChainMultiNo
 
 	opt.Add(WithL2ELNode(ids.L2ELB))
 	opt.Add(WithL2CLNode(ids.L2CLB, ids.L1CL, ids.L1EL, ids.L2ELB))
+	opt.Add(WithL2MetricsDashboard())
 
 	opt.Add(stack.Finally(func(orch *Orchestrator) {
 		*dest = ids

--- a/op-devstack/sysgo/system_synctester.go
+++ b/op-devstack/sysgo/system_synctester.go
@@ -69,6 +69,8 @@ func DefaultSimpleSystemWithSyncTester(dest *DefaultSimpleSystemWithSyncTesterID
 	// P2P Connect CLs to signal unsafe heads
 	opt.Add(WithL2CLP2PConnection(ids.L2CL, ids.L2CL2))
 
+	opt.Add(WithL2MetricsDashboard())
+
 	opt.Add(stack.Finally(func(orch *Orchestrator) {
 		*dest = ids
 	}))

--- a/op-devstack/sysgo/system_synctester_ext.go
+++ b/op-devstack/sysgo/system_synctester_ext.go
@@ -92,6 +92,8 @@ func ExternalELSystemWithEndpointAndSuperchainRegistry(dest *DefaultMinimalExter
 
 	opt.Add(WithExtL2Node(ids.L2ELReadOnly, networkPreset.L2ELEndpoint))
 
+	opt.Add(WithL2MetricsDashboard())
+
 	opt.Add(stack.Finally(func(orch *Orchestrator) {
 		*dest = ids
 	}))

--- a/op-devstack/sysgo/util.go
+++ b/op-devstack/sysgo/util.go
@@ -1,0 +1,40 @@
+package sysgo
+
+import (
+	"fmt"
+	"net"
+	"os"
+)
+
+func GetEnvVarOrDefault(envVarName string, defaultValue string) string {
+	val := os.Getenv(envVarName)
+	if val == "" {
+		val = defaultValue
+	}
+	return val
+}
+
+func PropagateEnvVarOrDefault(envVarName string, defaultValue string) string {
+	if val := GetEnvVarOrDefault(envVarName, defaultValue); val == "" {
+		return ""
+	} else {
+		return fmt.Sprintf("%s=%s", envVarName, val)
+	}
+}
+
+// NB: arbitrary start port with a low probability of conflict
+var availableLocalPortStart = 20_000
+
+func GetAvailableLocalPort() string {
+	port := availableLocalPortStart
+	for {
+		ln, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+		if err != nil {
+			port++
+		}
+		_ = ln.Close()
+		availableLocalPortStart = port + 1
+		return fmt.Sprintf("%d", port)
+	}
+
+}

--- a/op-devstack/sysgo/util.go
+++ b/op-devstack/sysgo/util.go
@@ -8,10 +8,10 @@ import (
 	"sync"
 )
 
-// GetEnvVarOrDefault returns the value of the provided env var or the provided default value if unset or empty.
+// GetEnvVarOrDefault returns the value of the provided env var or the provided default value if unset.
 func GetEnvVarOrDefault(envVarName string, defaultValue string) string {
-	val := os.Getenv(envVarName)
-	if val == "" {
+	val, found := os.LookupEnv(envVarName)
+	if !found {
 		val = defaultValue
 	}
 	return val
@@ -19,7 +19,7 @@ func GetEnvVarOrDefault(envVarName string, defaultValue string) string {
 
 // PropagateEnvVarOrDefault returns a string in the format "ENV_VAR_NAME=VALUE", with the ENV_VAR_NAME being
 // the provided env var name and the value being the value of that env var, or the provided default
-// value if that env var is unset or empty
+// value if that env var is unset.
 func PropagateEnvVarOrDefault(envVarName string, defaultValue string) string {
 	if val := GetEnvVarOrDefault(envVarName, defaultValue); val == "" {
 		return ""

--- a/op-devstack/sysgo/util.go
+++ b/op-devstack/sysgo/util.go
@@ -6,6 +6,7 @@ import (
 	"os"
 )
 
+// GetEnvVarOrDefault returns the value of the provided env var or the provided default value if unset or empty.
 func GetEnvVarOrDefault(envVarName string, defaultValue string) string {
 	val := os.Getenv(envVarName)
 	if val == "" {
@@ -14,6 +15,9 @@ func GetEnvVarOrDefault(envVarName string, defaultValue string) string {
 	return val
 }
 
+// PropagateEnvVarOrDefault returns a string in the format "ENV_VAR_NAME=VALUE", with the ENV_VAR_NAME being
+// the provided env var name and the value being the value of that env var, or the provided default
+// value if that env var is unset or empty
 func PropagateEnvVarOrDefault(envVarName string, defaultValue string) string {
 	if val := GetEnvVarOrDefault(envVarName, defaultValue); val == "" {
 		return ""
@@ -25,16 +29,18 @@ func PropagateEnvVarOrDefault(envVarName string, defaultValue string) string {
 // NB: arbitrary start port with a low probability of conflict
 var availableLocalPortStart = 20_000
 
+// GetAvailableLocalPort searches for and returns a currently unused local port.
 func GetAvailableLocalPort() string {
-	port := availableLocalPortStart
-	for {
+	for port := availableLocalPortStart; port < 65_535; port++ {
 		ln, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
 		if err != nil {
-			port++
+			continue
 		}
 		_ = ln.Close()
 		availableLocalPortStart = port + 1
 		return fmt.Sprintf("%d", port)
 	}
 
+	// NB: this is a hack, but it should never happen, so don't return & check for error on every call.
+	return "[should never happen] no available port found... this will err when you try to use it"
 }

--- a/op-devstack/sysgo/util.go
+++ b/op-devstack/sysgo/util.go
@@ -1,6 +1,7 @@
 package sysgo
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -33,7 +34,7 @@ var availableLocalPortMutex sync.Mutex
 
 // GetAvailableLocalPort searches for and returns a currently unused local port.
 // Note: this function is threadsafe.
-func GetAvailableLocalPort() string {
+func GetAvailableLocalPort() (string, error) {
 	availableLocalPortMutex.Lock()
 	defer availableLocalPortMutex.Unlock()
 
@@ -44,9 +45,8 @@ func GetAvailableLocalPort() string {
 		}
 		_ = ln.Close()
 		availableLocalPortStart = port + 1
-		return fmt.Sprintf("%d", port)
+		return fmt.Sprintf("%d", port), nil
 	}
 
-	// NB: this is a hack, but it should never happen, so don't return & check for error on every call.
-	return "[should never happen] no available port found... this will err when you try to use it"
+	return "", errors.New("could not find open port")
 }

--- a/op-devstack/sysgo/util.go
+++ b/op-devstack/sysgo/util.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"sync"
 )
 
 // GetEnvVarOrDefault returns the value of the provided env var or the provided default value if unset or empty.
@@ -28,9 +29,14 @@ func PropagateEnvVarOrDefault(envVarName string, defaultValue string) string {
 
 // NB: arbitrary start port with a low probability of conflict
 var availableLocalPortStart = 20_000
+var availableLocalPortMutex sync.Mutex
 
 // GetAvailableLocalPort searches for and returns a currently unused local port.
+// Note: this function is threadsafe.
 func GetAvailableLocalPort() string {
+	availableLocalPortMutex.Lock()
+	defer availableLocalPortMutex.Unlock()
+
 	for port := availableLocalPortStart; port < 65_535; port++ {
 		ln, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
 		if err != nil {

--- a/op-devstack/sysgo/util.go
+++ b/op-devstack/sysgo/util.go
@@ -8,8 +8,8 @@ import (
 	"sync"
 )
 
-// GetEnvVarOrDefault returns the value of the provided env var or the provided default value if unset.
-func GetEnvVarOrDefault(envVarName string, defaultValue string) string {
+// getEnvVarOrDefault returns the value of the provided env var or the provided default value if unset.
+func getEnvVarOrDefault(envVarName string, defaultValue string) string {
 	val, found := os.LookupEnv(envVarName)
 	if !found {
 		val = defaultValue
@@ -17,11 +17,11 @@ func GetEnvVarOrDefault(envVarName string, defaultValue string) string {
 	return val
 }
 
-// PropagateEnvVarOrDefault returns a string in the format "ENV_VAR_NAME=VALUE", with the ENV_VAR_NAME being
+// propagateEnvVarOrDefault returns a string in the format "ENV_VAR_NAME=VALUE", with the ENV_VAR_NAME being
 // the provided env var name and the value being the value of that env var, or the provided default
 // value if that env var is unset.
-func PropagateEnvVarOrDefault(envVarName string, defaultValue string) string {
-	if val := GetEnvVarOrDefault(envVarName, defaultValue); val == "" {
+func propagateEnvVarOrDefault(envVarName string, defaultValue string) string {
+	if val := getEnvVarOrDefault(envVarName, defaultValue); val == "" {
 		return ""
 	} else {
 		return fmt.Sprintf("%s=%s", envVarName, val)
@@ -32,9 +32,9 @@ func PropagateEnvVarOrDefault(envVarName string, defaultValue string) string {
 var availableLocalPortStart = 20_000
 var availableLocalPortMutex sync.Mutex
 
-// GetAvailableLocalPort searches for and returns a currently unused local port.
+// getAvailableLocalPort searches for and returns a currently unused local port.
 // Note: this function is threadsafe.
-func GetAvailableLocalPort() (string, error) {
+func getAvailableLocalPort() (string, error) {
 	availableLocalPortMutex.Lock()
 	defer availableLocalPortMutex.Unlock()
 

--- a/op-devstack/sysgo/util_test.go
+++ b/op-devstack/sysgo/util_test.go
@@ -1,0 +1,86 @@
+package sysgo
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const unsetVar = "unset"
+
+func strPtr(s string) *string {
+	if s == unsetVar {
+		return nil
+	}
+	return &s
+}
+
+func TestGetEnvVarOrDefault(t *testing.T) {
+	const envVarName = "TestGetEnvVarOrDefaultEnvVarName"
+	tests := []struct {
+		name         string
+		osValue      *string
+		defaultValue string
+		expected     string
+	}{
+		{osValue: strPtr("a"), defaultValue: "b", expected: "a"},
+		{osValue: strPtr("a"), defaultValue: "", expected: "a"},
+		{osValue: strPtr(""), defaultValue: "b", expected: "b"},
+		{osValue: strPtr(""), defaultValue: "b", expected: "b"},
+		{osValue: strPtr(unsetVar), defaultValue: "b", expected: "b"},
+		{osValue: strPtr(unsetVar), defaultValue: "", expected: ""},
+	}
+
+	for i, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			varName := fmt.Sprintf("%s_%d", envVarName, i)
+
+			if test.osValue != nil {
+				err := os.Setenv(varName, *test.osValue)
+				require.NoErrorf(t, err, "Error setting env var %s", err)
+			}
+
+			require.Equal(t, GetEnvVarOrDefault(varName, test.defaultValue), test.expected)
+		})
+	}
+
+}
+
+func TestPropagateEnvVarOrDefault(t *testing.T) {
+	const envVarName = "TestPropagateEnvVarOrDefaultEnvVarName"
+	tests := []struct {
+		name         string
+		osValue      *string
+		defaultValue string
+		expected     string
+	}{
+		{osValue: strPtr("a"), defaultValue: "b", expected: "a"},
+		{osValue: strPtr("a"), defaultValue: "", expected: "a"},
+		{osValue: strPtr(""), defaultValue: "b", expected: "b"},
+		{osValue: strPtr(""), defaultValue: "b", expected: "b"},
+		{osValue: strPtr(unsetVar), defaultValue: "b", expected: "b"},
+		{osValue: strPtr(unsetVar), defaultValue: "", expected: ""},
+	}
+
+	for i, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			varName := fmt.Sprintf("%s_%d", envVarName, i)
+
+			if test.osValue != nil {
+				err := os.Setenv(varName, *test.osValue)
+				require.NoErrorf(t, err, "Error setting env var %s", err)
+			}
+
+			res := PropagateEnvVarOrDefault(varName, test.defaultValue)
+			if (test.osValue == nil || *test.osValue == "") && test.defaultValue == "" {
+				require.Equal(t, res, "")
+			} else {
+				require.Equal(t, res, fmt.Sprintf("%s=%s", varName, test.expected))
+			}
+		})
+	}
+}

--- a/op-devstack/sysgo/util_test.go
+++ b/op-devstack/sysgo/util_test.go
@@ -25,12 +25,12 @@ func TestGetEnvVarOrDefault(t *testing.T) {
 		defaultValue string
 		expected     string
 	}{
-		{osValue: strPtr("a"), defaultValue: "b", expected: "a"},
-		{osValue: strPtr("a"), defaultValue: "", expected: "a"},
-		{osValue: strPtr(""), defaultValue: "b", expected: "b"},
-		{osValue: strPtr(""), defaultValue: "b", expected: "b"},
-		{osValue: strPtr(unsetVar), defaultValue: "b", expected: "b"},
-		{osValue: strPtr(unsetVar), defaultValue: "", expected: ""},
+		{name: "Use OS value, no default", osValue: strPtr("a"), defaultValue: "", expected: "a"},
+		{name: "Use OS value with default", osValue: strPtr("a"), defaultValue: "b", expected: "a"},
+		{name: "Use empty OS Value with default", osValue: strPtr(""), defaultValue: "b", expected: ""},
+		{name: "Use empty OS Value, no default", osValue: strPtr(""), defaultValue: "", expected: ""},
+		{name: "Use default", osValue: strPtr(unsetVar), defaultValue: "b", expected: "b"},
+		{name: "Use empty default", osValue: strPtr(unsetVar), defaultValue: "", expected: ""},
 	}
 
 	for i, test := range tests {
@@ -57,12 +57,12 @@ func TestPropagateEnvVarOrDefault(t *testing.T) {
 		defaultValue string
 		expected     string
 	}{
-		{osValue: strPtr("a"), defaultValue: "b", expected: "a"},
-		{osValue: strPtr("a"), defaultValue: "", expected: "a"},
-		{osValue: strPtr(""), defaultValue: "b", expected: "b"},
-		{osValue: strPtr(""), defaultValue: "b", expected: "b"},
-		{osValue: strPtr(unsetVar), defaultValue: "b", expected: "b"},
-		{osValue: strPtr(unsetVar), defaultValue: "", expected: ""},
+		{name: "Use OS value, no default", osValue: strPtr("a"), defaultValue: "", expected: "a"},
+		{name: "Use OS value with default", osValue: strPtr("a"), defaultValue: "b", expected: "a"},
+		{name: "Use empty OS Value with default", osValue: strPtr(""), defaultValue: "b", expected: ""},
+		{name: "Use empty OS Value with empty default", osValue: strPtr(""), defaultValue: "", expected: ""},
+		{name: "Use default", osValue: strPtr(unsetVar), defaultValue: "b", expected: "b"},
+		{name: "Use empty default", osValue: strPtr(unsetVar), defaultValue: "", expected: ""},
 	}
 
 	for i, test := range tests {
@@ -76,7 +76,7 @@ func TestPropagateEnvVarOrDefault(t *testing.T) {
 			}
 
 			res := PropagateEnvVarOrDefault(varName, test.defaultValue)
-			if (test.osValue == nil || *test.osValue == "") && test.defaultValue == "" {
+			if (test.osValue != nil && *test.osValue == "") || (test.osValue == nil && test.defaultValue == "") {
 				require.Equal(t, res, "")
 			} else {
 				require.Equal(t, res, fmt.Sprintf("%s=%s", varName, test.expected))

--- a/op-devstack/sysgo/util_test.go
+++ b/op-devstack/sysgo/util_test.go
@@ -43,7 +43,7 @@ func TestGetEnvVarOrDefault(t *testing.T) {
 				require.NoErrorf(t, err, "Error setting env var %s", err)
 			}
 
-			require.Equal(t, GetEnvVarOrDefault(varName, test.defaultValue), test.expected)
+			require.Equal(t, getEnvVarOrDefault(varName, test.defaultValue), test.expected)
 		})
 	}
 
@@ -75,7 +75,7 @@ func TestPropagateEnvVarOrDefault(t *testing.T) {
 				require.NoErrorf(t, err, "Error setting env var %s", err)
 			}
 
-			res := PropagateEnvVarOrDefault(varName, test.defaultValue)
+			res := propagateEnvVarOrDefault(varName, test.defaultValue)
 			if (test.osValue != nil && *test.osValue == "") || (test.osValue == nil && test.defaultValue == "") {
 				require.Equal(t, res, "")
 			} else {

--- a/op-up/main.go
+++ b/op-up/main.go
@@ -131,6 +131,7 @@ func runOpUp(ctx context.Context, stderr io.Writer, opUpDir string) error {
 
 		sysgo.WithL2ELNode(ids.L2EL),
 		sysgo.WithL2CLNode(ids.L2CL, ids.L1CL, ids.L1EL, ids.L2EL, sysgo.L2CLSequencer()),
+		sysgo.WithL2MetricsDashboard(),
 
 		sysgo.WithBatcher(ids.L2Batcher, ids.L1EL, ids.L2CL, ids.L2EL),
 		sysgo.WithProposer(ids.L2Proposer, ids.L1EL, &ids.L2CL, nil),


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Adds L2 observability to sysgo, wiring it up for `kona-node` and `op-reth`.

Note: observability still needs to be configured for other L2 components that expose metrics, but this PR provides a pattern to do so.

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**
Added tests for utils that were added in this PR as well as a test that confirms that the option returned from `WithL2MetricsDashboard` works in the default case (does not fail when being applied).

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**
The new `WithL2MetricsDashboard` option factory function configures and starts dockerized prometheus and grafana instances to expose metrics if any component has registered metrics endpoints with the `Orchestrator`.

Note: This functionality is disabled by default. If enabled, docker is required to be installed, and the `SYSGO_DOCKER_EXEC_PATH` should be set to the docker binary if it is not already in your `PATH`.

<!--
Add any other context about the problem you're solving.
-->

**Metadata**
- Closes #17941 
<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
