### PR TITLE
op-node/p2p: prevent single peer failure from cancelling range sync

### DIFF
--- a/op-node/p2p/sync.go
+++ b/op-node/p2p/sync.go
@@ -566,6 +566,9 @@ func (s *SyncClient) peerLoop(ctx context.Context, id peer.ID) {
 	// so we don't be too aggressive to the server.
 	rl := rate.NewLimiter(peerServerBlocksRateLimit, peerServerBlocksBurst)
 
+	// Track ranges that this peer already failed to serve (by rangeReqId).
+	failedRanges := make(map[uint64]struct{})
+
 	// if onlyReqToStatic is on, ensure that only static peers are dealing with the request
 	peerRequests := s.peerRequests
 	if s.syncOnlyReqToStatic && !s.extra.IsStatic(id) {
@@ -594,6 +597,13 @@ func (s *SyncClient) peerLoop(ctx context.Context, id peer.ID) {
 				continue
 			}
 
+			// If this peer already failed on this range, don't request further blocks for it.
+			if _, failed := failedRanges[pr.rangeReqId]; failed {
+				log.Debug("skipping peer for previously failed range", "num", pr.num, "rangeReqId", pr.rangeReqId)
+				s.inFlight.delete(pr.num)
+				continue
+			}
+
 			// We already established the peer is available w.r.t. rate-limiting,
 			// and this is the only loop over this peer, so we can request now.
 			start := time.Now()
@@ -609,8 +619,9 @@ func (s *SyncClient) peerLoop(ctx context.Context, id peer.ID) {
 				if re, ok := err.(requestResultErr); ok {
 					resultCode = re.ResultCode()
 					if resultCode == ResultCodeNotFoundErr {
-						log.Warn("cancelling p2p sync range request", "rangeReqId", pr.rangeReqId)
-						s.activeRangeRequests.delete(pr.rangeReqId)
+						// Mark this range as failed for this peer only; do not affect other peers.
+						failedRanges[pr.rangeReqId] = struct{}{}
+						log.Debug("peer marked failed for range", "rangeReqId", pr.rangeReqId)
 						sendResponseError = false // don't penalize peer for this error
 					}
 				}

--- a/op-node/p2p/sync.go
+++ b/op-node/p2p/sync.go
@@ -254,10 +254,9 @@ type SyncClient struct {
 	inFlight       *requestIdMap
 	inFlightChecks chan inFlightCheck
 
-	rangeRequests       chan rangeRequest
-	activeRangeRequests *requestIdMap
-	rangeReqId          uint64
-	peerRequests        chan peerRequest
+	rangeRequests chan rangeRequest
+	rangeReqId    uint64
+	peerRequests  chan peerRequest
 
 	results chan syncResult
 
@@ -285,24 +284,23 @@ func NewSyncClient(log log.Logger, cfg *rollup.Config, host HostNewStream, rcv r
 	ctx, cancel := context.WithCancel(context.Background())
 
 	c := &SyncClient{
-		log:                 log,
-		cfg:                 cfg,
-		metrics:             metrics,
-		appScorer:           appScorer,
-		newStreamFn:         host.NewStream,
-		payloadByNumber:     PayloadByNumberProtocolID(cfg.L2ChainID),
-		peers:               make(map[peer.ID]context.CancelFunc),
-		quarantineByNum:     make(map[uint64]common.Hash),
-		rangeRequests:       make(chan rangeRequest), // blocking
-		activeRangeRequests: newRequestIdMap(),
-		peerRequests:        make(chan peerRequest, 128),
-		results:             make(chan syncResult, 128),
-		inFlight:            newRequestIdMap(),
-		inFlightChecks:      make(chan inFlightCheck, 128),
-		globalRL:            rate.NewLimiter(globalServerBlocksRateLimit, globalServerBlocksBurst),
-		resCtx:              ctx,
-		resCancel:           cancel,
-		receivePayload:      rcv,
+		log:             log,
+		cfg:             cfg,
+		metrics:         metrics,
+		appScorer:       appScorer,
+		newStreamFn:     host.NewStream,
+		payloadByNumber: PayloadByNumberProtocolID(cfg.L2ChainID),
+		peers:           make(map[peer.ID]context.CancelFunc),
+		quarantineByNum: make(map[uint64]common.Hash),
+		rangeRequests:   make(chan rangeRequest), // blocking
+		peerRequests:    make(chan peerRequest, 128),
+		results:         make(chan syncResult, 128),
+		inFlight:        newRequestIdMap(),
+		inFlightChecks:  make(chan inFlightCheck, 128),
+		globalRL:        rate.NewLimiter(globalServerBlocksRateLimit, globalServerBlocksBurst),
+		resCtx:          ctx,
+		resCancel:       cancel,
+		receivePayload:  rcv,
 	}
 	if extra, ok := host.(ExtraHostFeatures); ok && extra.SyncOnlyReqToStatic() {
 		c.extra = extra
@@ -374,17 +372,14 @@ func (s *SyncClient) RequestL2Range(ctx context.Context, start, end eth.L2BlockR
 		s.log.Debug("P2P sync client received range signal, but cannot sync open-ended chain: need sync target to verify blocks through parent-hashes", "start", start)
 		return 0, nil
 	}
-	// Create shared rangeReqId so associated peerRequests can all be cancelled by setting a single flag
+	// Create shared rangeReqId for tracking this range request
 	rangeReqId := atomic.AddUint64(&s.rangeReqId, 1)
-	// need to flag request as active before adding request to s.rangeRequests to avoid race
-	s.activeRangeRequests.set(rangeReqId, true)
 
 	// synchronize requests with the main loop for state access
 	select {
 	case s.rangeRequests <- rangeRequest{start: start.Number, end: end, id: rangeReqId}:
 		return rangeReqId, nil
 	case <-ctx.Done():
-		s.activeRangeRequests.delete(rangeReqId)
 		return rangeReqId, fmt.Errorf("too busy with P2P results/requests: %w", ctx.Err())
 	}
 }
@@ -591,12 +586,6 @@ func (s *SyncClient) peerLoop(ctx context.Context, id peer.ID) {
 		// once the peer is available, wait for a sync request.
 		select {
 		case pr := <-peerRequests:
-			if !s.activeRangeRequests.get(pr.rangeReqId) {
-				log.Debug("dropping cancelled p2p sync request", "num", pr.num)
-				s.inFlight.delete(pr.num)
-				continue
-			}
-
 			// If this peer already failed on this range, don't request further blocks for it.
 			if _, failed := failedRanges[pr.rangeReqId]; failed {
 				log.Debug("skipping peer for previously failed range", "num", pr.num, "rangeReqId", pr.rangeReqId)

--- a/op-node/p2p/sync_test.go
+++ b/op-node/p2p/sync_test.go
@@ -283,7 +283,6 @@ func TestMultiPeerSync(t *testing.T) {
 	_, err = clB.RequestL2Range(ctx, payloads.getBlockRef(20), payloads.getBlockRef(30))
 
 	require.NoError(t, err)
-	// Range request is now tracked internally, no global activeRangeRequests map
 
 	for i := uint64(29); i > 25; i-- {
 		select {

--- a/op-node/p2p/sync_test.go
+++ b/op-node/p2p/sync_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math/big"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -549,4 +550,106 @@ func TestMutexUnlocks(t *testing.T) {
 			t.Fatal("Mutex deadlock detected - bug exists")
 		}
 	})
+}
+
+// TestRangeNotCancelledOnMissingBlock verifies that when a block is missing from all peers,
+// the range request is not cancelled: blocks after the missing block are promoted, while blocks
+// before it are fetched but remain in quarantine.
+func TestRangeNotCancelledOnMissingBlock(t *testing.T) {
+	t.Parallel()
+
+	log := testlog.Logger(t, log.LevelError)
+	cfg, payloads := setupSyncTestData(50)
+
+	mnet, err := mocknet.FullMeshConnected(3)
+	require.NoError(t, err)
+	defer mnet.Close()
+	hosts := mnet.Hosts()
+	clientHost, peerAHost, peerBHost := hosts[0], hosts[1], hosts[2]
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	// Both peers are missing block 35
+	servePayload := func(n uint64) (*eth.ExecutionPayloadEnvelope, error) {
+		if n == 35 {
+			return nil, ethereum.NotFound
+		}
+		p, ok := payloads.getPayload(n)
+		if !ok {
+			return nil, ethereum.NotFound
+		}
+		return p, nil
+	}
+
+	peerASrv := NewReqRespServer(cfg, mockPayloadFn(servePayload), metrics.NoopMetrics)
+	peerAPayloadByNumber := MakeStreamHandler(ctx, log.New("serve", "peerA"), peerASrv.HandleSyncRequest)
+	peerAHost.SetStreamHandler(PayloadByNumberProtocolID(cfg.L2ChainID), peerAPayloadByNumber)
+
+	peerBSrv := NewReqRespServer(cfg, mockPayloadFn(servePayload), metrics.NoopMetrics)
+	peerBPayloadByNumber := MakeStreamHandler(ctx, log.New("serve", "peerB"), peerBSrv.HandleSyncRequest)
+	peerBHost.SetStreamHandler(PayloadByNumberProtocolID(cfg.L2ChainID), peerBPayloadByNumber)
+
+	received := make(chan *eth.ExecutionPayloadEnvelope, 100)
+	receivePayload := receivePayloadFn(func(ctx context.Context, from peer.ID, payload *eth.ExecutionPayloadEnvelope) error {
+		received <- payload
+		return nil
+	})
+
+	client := NewSyncClient(log.New("role", "client"), cfg, clientHost, receivePayload, metrics.NoopMetrics, &NoopApplicationScorer{})
+	client.AddPeer(peerAHost.ID())
+	client.AddPeer(peerBHost.ID())
+	client.Start()
+	defer client.Close()
+
+	_, err = client.RequestL2Range(ctx, payloads.getBlockRef(30), payloads.getBlockRef(40))
+	require.NoError(t, err)
+
+	receivedNums := make(map[uint64]struct{})
+	deadline := time.After(10 * time.Second)
+
+	for len(receivedNums) < 4 {
+		select {
+		case p := <-received:
+			receivedNums[uint64(p.ExecutionPayload.BlockNumber)] = struct{}{}
+		case <-deadline:
+			goto verify
+		}
+	}
+
+	time.Sleep(2 * time.Second)
+	for {
+		select {
+		case p := <-received:
+			receivedNums[uint64(p.ExecutionPayload.BlockNumber)] = struct{}{}
+		default:
+			goto verify
+		}
+	}
+
+verify:
+	// Verify blocks 36-39 were promoted
+	require.Equal(t, 4, len(receivedNums))
+	for i := uint64(36); i <= 39; i++ {
+		require.Contains(t, receivedNums, i)
+	}
+
+	// Verify block 35 and blocks 31-34 were NOT promoted
+	for i := uint64(31); i <= 35; i++ {
+		require.NotContains(t, receivedNums, i)
+	}
+
+	// Verify blocks 31-34 are in quarantine
+	clientValue := reflect.ValueOf(client).Elem()
+	quarantineByNumField := clientValue.FieldByName("quarantineByNum")
+	quarantineByNumField = reflect.NewAt(
+		quarantineByNumField.Type(),
+		quarantineByNumField.Addr().UnsafePointer(),
+	).Elem()
+	quarantineByNum := quarantineByNumField.Interface().(map[uint64]common.Hash)
+
+	require.Equal(t, 4, len(quarantineByNum))
+	for i := uint64(31); i <= 34; i++ {
+		require.Contains(t, quarantineByNum, i)
+	}
 }

--- a/op-node/p2p/sync_test.go
+++ b/op-node/p2p/sync_test.go
@@ -280,10 +280,10 @@ func TestMultiPeerSync(t *testing.T) {
 	// now see if B can sync a range, and fill the gap with a re-request
 	bl25, _ := payloads.getPayload(25) // temporarily remove it from the available payloads. This will create a gap
 	payloads.deletePayload(25)
-	rangeReqId, err := clB.RequestL2Range(ctx, payloads.getBlockRef(20), payloads.getBlockRef(30))
+	_, err = clB.RequestL2Range(ctx, payloads.getBlockRef(20), payloads.getBlockRef(30))
 
 	require.NoError(t, err)
-	require.True(t, clB.activeRangeRequests.get(rangeReqId), "expecting range request to be active")
+	// Range request is now tracked internally, no global activeRangeRequests map
 
 	for i := uint64(29); i > 25; i-- {
 		select {
@@ -330,7 +330,6 @@ func TestMultiPeerSync(t *testing.T) {
 			break
 		}
 	}
-	require.True(t, clB.activeRangeRequests.get(rangeReqId), "range should remain active after NotFound")
 
 	// Add back the block
 	payloads.addPayload(bl25)

--- a/op-node/p2p/sync_test.go
+++ b/op-node/p2p/sync_test.go
@@ -330,7 +330,7 @@ func TestMultiPeerSync(t *testing.T) {
 			break
 		}
 	}
-	require.False(t, clB.activeRangeRequests.get(rangeReqId), "expecting range request to be cancelled")
+	require.True(t, clB.activeRangeRequests.get(rangeReqId), "range should remain active after NotFound")
 
 	// Add back the block
 	payloads.addPayload(bl25)


### PR DESCRIPTION
## Description
#10063  cancels the entire rangeRequest when any peer returns ResultCodeNotFoundErr. This forces all peers to stop working on that range and wait for the next alt-sync tick, increasing time-to-sync. In static peer setups where some peers may not yet have the requested blocks (e.g., backup sequencers or RPC nodes), a single NotFound from one peer cancels the range and unnecessarily stalls others.

## Fix
Make NotFound handling peer-local instead of global:

1. **Remove global `activeRangeRequests` tracking**: The original implementation used a global `activeRangeRequests` map to track active ranges and would delete the entire range when any peer returned NotFound, causing all peers to stop processing that range.

2. **Add peer-local `failedRanges` tracking**: Each `peerLoop` now maintains its own goroutine-local `failedRanges` map keyed by `rangeReqId`. When a peer returns NotFound for a range, we mark only that peer as failed for that range and skip subsequent blocks in that range to that specific peer.

3. **Preserve parallel syncing**: Other peers continue syncing the same range immediately without waiting for the next alt-sync tick, maximizing throughput in multi-peer setups.

This approach eliminates unnecessary global coordination, reduces memory overhead (no shared mutex-protected map), and allows healthy peers to continue syncing even when some peers don't have the requested blocks yet.