### PR TITLE
op-deployer: Add flags for new v2 dispute game implementations options

### DIFF
--- a/op-deployer/pkg/deployer/bootstrap/flags.go
+++ b/op-deployer/pkg/deployer/bootstrap/flags.go
@@ -63,6 +63,30 @@ var (
 		EnvVars: deployer.PrefixEnvVar("DISPUTE_GAME_FINALITY_DELAY_SECONDS"),
 		Value:   standard.DisputeGameFinalityDelaySeconds,
 	}
+	DisputeMaxGameDepthFlag = &cli.Uint64Flag{
+		Name:    "dispute-max-game-depth",
+		Usage:   "Maximum depth of the dispute game tree (value as string). Defaults to the standard value.",
+		EnvVars: deployer.PrefixEnvVar("DISPUTE_MAX_GAME_DEPTH"),
+		Value:   standard.DisputeMaxGameDepth,
+	}
+	DisputeSplitDepthFlag = &cli.Uint64Flag{
+		Name:    "dispute-split-depth",
+		Usage:   "Depth at which the dispute game tree splits (value as string). Defaults to the standard value.",
+		EnvVars: deployer.PrefixEnvVar("DISPUTE_SPLIT_DEPTH"),
+		Value:   standard.DisputeSplitDepth,
+	}
+	DisputeClockExtensionFlag = &cli.Uint64Flag{
+		Name:    "dispute-clock-extension",
+		Usage:   "Clock extension in seconds for dispute game timing. Defaults to the standard value.",
+		EnvVars: deployer.PrefixEnvVar("DISPUTE_CLOCK_EXTENSION"),
+		Value:   standard.DisputeClockExtension,
+	}
+	DisputeMaxClockDurationFlag = &cli.Uint64Flag{
+		Name:    "dispute-max-clock-duration",
+		Usage:   "Maximum clock duration in seconds for dispute game timing. Defaults to the standard value.",
+		EnvVars: deployer.PrefixEnvVar("DISPUTE_MAX_CLOCK_DURATION"),
+		Value:   standard.DisputeMaxClockDuration,
+	}
 	MIPSVersionFlag = &cli.Uint64Flag{
 		Name:    MIPSVersionFlagName,
 		Usage:   "MIPS version.",
@@ -159,6 +183,10 @@ var ImplementationsFlags = []cli.Flag{
 	ChallengePeriodSecondsFlag,
 	ProofMaturityDelaySecondsFlag,
 	DisputeGameFinalityDelaySecondsFlag,
+	DisputeMaxGameDepthFlag,
+	DisputeSplitDepthFlag,
+	DisputeClockExtensionFlag,
+	DisputeMaxClockDurationFlag,
 	SuperchainConfigProxyFlag,
 	ProtocolVersionsProxyFlag,
 	L1ProxyAdminOwnerFlag,

--- a/op-deployer/pkg/deployer/bootstrap/implementations.go
+++ b/op-deployer/pkg/deployer/bootstrap/implementations.go
@@ -39,10 +39,10 @@ type ImplementationsConfig struct {
 	ProofMaturityDelaySeconds       uint64             `cli:"proof-maturity-delay-seconds"`
 	DisputeGameFinalityDelaySeconds uint64             `cli:"dispute-game-finality-delay-seconds"`
 	DevFeatureBitmap                common.Hash        `cli:"dev-feature-bitmap"`
-	FaultGameMaxGameDepth           uint64             `cli:"fault-game-max-game-depth"`
-	FaultGameSplitDepth             uint64             `cli:"fault-game-split-depth"`
-	FaultGameClockExtension         uint64             `cli:"fault-game-clock-extension"`
-	FaultGameMaxClockDuration       uint64             `cli:"fault-game-max-clock-duration"`
+	FaultGameMaxGameDepth           uint64             `cli:"dispute-max-game-depth"`
+	FaultGameSplitDepth             uint64             `cli:"dispute-split-depth"`
+	FaultGameClockExtension         uint64             `cli:"dispute-clock-extension"`
+	FaultGameMaxClockDuration       uint64             `cli:"dispute-max-clock-duration"`
 	SuperchainConfigProxy           common.Address     `cli:"superchain-config-proxy"`
 	ProtocolVersionsProxy           common.Address     `cli:"protocol-versions-proxy"`
 	L1ProxyAdminOwner               common.Address     `cli:"l1-proxy-admin-owner"`

--- a/op-deployer/pkg/deployer/manage/add_game_type.go
+++ b/op-deployer/pkg/deployer/manage/add_game_type.go
@@ -152,10 +152,9 @@ func AddGameTypeCLI(cliCtx *cli.Context) error {
 
 	initialBond, err := cliutil.BigIntFlag(cliCtx, InitialBondFlag.Name)
 	if err != nil {
-		cfg.InitialBond = initialBond
-	} else {
 		return fmt.Errorf("failed to parse initial bond: %w", err)
 	}
+	cfg.InitialBond = initialBond
 
 	if err := cfg.Check(); err != nil {
 		return fmt.Errorf("invalid config: %w", err)


### PR DESCRIPTION

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Add flags for new implementation options required to bootstrap with V2 games enabled.

Also provides standard values as defaults.

