### PR TITLE
op-acceptance-tests: Deflake: EL Syncing happens Async

### DIFF
--- a/op-devstack/dsl/l2_el.go
+++ b/op-devstack/dsl/l2_el.go
@@ -281,10 +281,10 @@ func (el *L2ELNode) ForkchoiceUpdate(refNode *L2ELNode, unsafe, safe, finalized 
 }
 
 func (el *L2ELNode) FinishedELSync(refNode *L2ELNode, unsafe, safe, finalized uint64) {
-	el.log.Info("Start EL Sync", "unsafe", unsafe, "safe", safe, "finalized", finalized)
+	el.log.Info("Trigger EL Sync", "unsafe", unsafe, "safe", safe, "finalized", finalized)
 	trial := 1
 	el.require.NoError(retry.Do0(el.ctx, 5, &retry.FixedStrategy{Dur: 2 * time.Second}, func() error {
-		el.log.Info("FCU to activate EL Sync", "trial", trial)
+		el.log.Info("FCU to trigger EL Sync", "trial", trial)
 		res := el.ForkchoiceUpdate(refNode, unsafe, safe, finalized, nil)
 		// If EL Sync triggered, Example logs from L2EL(geth)
 		//  New skeleton head announced
@@ -294,7 +294,7 @@ func (el *L2ELNode) FinishedELSync(refNode *L2ELNode, unsafe, safe, finalized ui
 			return nil
 		}
 		trial += 1
-		return errors.New("EL Sync not yet triggered")
+		return errors.New("EL Sync not finished")
 	}))
 }
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Fixing `TestL2ELP2PCanonicalChainAdvancedByFCU` for de-flaking. Flake shake report: https://output.circle-artifacts.com/output/job/fca74efc-c5b1-4750-9841-b64745bbcecf/artifacts/0/flake-shake-report/flake-shake-report.html

<img width="1091" height="50" alt="image" src="https://github.com/user-attachments/assets/2d2815ae-f961-4b60-9497-dc093576c250" />

EL sync is happening async in the background after the FCU trigger. If peers are attached, EL will actively reach out to the peers, and finish EL Sync before the next FCU call for the same target.

That said, we may allow the FCU return VALID immediately for using the same target, after peers are connected. Previously we assumed that EL sync must be triggered explicitly after the peer connection, but in reality async EL Sync job was ongoing and can be completed before the second FCU call.
