### PR TITLE
op-acceptance-tests: add test to base gate for unsafe gossip / head progression

### DIFF
--- a/op-acceptance-tests/tests/base/chain/init_test.go
+++ b/op-acceptance-tests/tests/base/chain/init_test.go
@@ -8,6 +8,6 @@ import (
 
 func TestMain(m *testing.M) {
 	presets.DoMain(m,
-		presets.WithMinimal(),
+		presets.WithSingleChainMultiNode(),
 	)
 }

--- a/op-acceptance-tests/tests/base/chain/unsafe_sync_test.go
+++ b/op-acceptance-tests/tests/base/chain/unsafe_sync_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+	"github.com/stretchr/testify/require"
 )
 
 // TestUnsafeSync tests that the verifier nodes are able to sync the unsafe head of the chain.
@@ -16,14 +17,13 @@ import (
 func TestUnsafeSync(gt *testing.T) {
 	t := devtest.SerialT(gt)
 	sys := presets.NewSingleChainMultiNode(t)
-
 	l2chainID := sys.L2Chain.Escape().ChainID()
+	const NUM_UNSAFE_BLOCKS = 10
 
-	const NUM_UNSAFE_BLOCKS = 20
-	const MAX_LAG = 10
-
+	// In order for this test to be valid, we need at least 2 L2 EL nodes.
 	t.Require().Greater(len(sys.L2Chain.L2ELNodes()), 1, "expected at least 2 L2 EL nodes")
 
+	// Find the index of the sequencer node.
 	indexOfSequencer := 0
 	for i, el := range sys.L2Chain.L2ELNodes() {
 		if strings.Contains(el.ID().String(), "sequencer") {
@@ -32,28 +32,45 @@ func TestUnsafeSync(gt *testing.T) {
 		}
 	}
 
-	initialUnsafeHead := sys.L2Chain.L2ELNodes()[0].ChainSyncStatus(sys.L2Chain.Escape().ChainID(), types.LocalUnsafe).Number
-
-	ticker := time.NewTicker(time.Duration(sys.L2Chain.Escape().RollupConfig().BlockTime) * time.Second / 10)
+	// Wait for the sequencer to produce at least NUM_UNSAFE_BLOCKS unsafe blocks.
+	initialUnsafeHeadNumber := sys.L2Chain.L2ELNodes()[0].ChainSyncStatus(sys.L2Chain.Escape().ChainID(), types.LocalUnsafe).Number
+	finalUnsafeHeadNumber := initialUnsafeHeadNumber + NUM_UNSAFE_BLOCKS
+	ticker := time.NewTicker(time.Duration(sys.L2Chain.Escape().RollupConfig().BlockTime) * time.Second)
 	for range ticker.C {
 		sequencerUnsafeHead := sys.L2Chain.L2ELNodes()[indexOfSequencer].ChainSyncStatus(sys.L2Chain.Escape().ChainID(), types.LocalUnsafe)
+		t.Logf("Sequencer unsafe head (number %d) is %d/%d blocks ahead of initial unsafe head (number %d)",
+			sequencerUnsafeHead.Number, sequencerUnsafeHead.Number-initialUnsafeHeadNumber, NUM_UNSAFE_BLOCKS, initialUnsafeHeadNumber)
+		if sequencerUnsafeHead.Number >= finalUnsafeHeadNumber {
+			break
+		}
+	}
+
+	// Check verifier nodes progess to the final unsafe head number.
+	allVerifierNodesInSync := func() bool {
 		for i, el := range sys.L2Chain.L2ELNodes() {
 			if i == indexOfSequencer {
 				continue
 			}
 			verifierUnsafeHead := el.ChainSyncStatus(l2chainID, types.LocalUnsafe)
-			lag := uint64(verifierUnsafeHead.Number) - uint64(sequencerUnsafeHead.Number)
-			if lag > 0 {
-				t.Require().Fail("verifier unsafe head is ahead of sequencer unsafe head", "verifier", el.ID(), "verifier unsafe head", verifierUnsafeHead.Number, "sequencer unsafe head", sequencerUnsafeHead.Number)
+			if verifierUnsafeHead.Number < initialUnsafeHeadNumber+NUM_UNSAFE_BLOCKS {
+				return false
 			}
-			if lag < 0 {
-				t.Require().Greater(lag, uint64(MAX_LAG), "verifier (%s) unsafe head (number %d) is too far behind sequencer unsafe head (number %d) with max lag %d", el.ID(), verifierUnsafeHead.Number, sequencerUnsafeHead.Number, MAX_LAG)
-			}
-			t.Logf("verifier (%s) unsafe head (number %d) is %d blocks behind sequencer unsafe head (number %d)", el.ID(), verifierUnsafeHead.Number, lag, sequencerUnsafeHead.Number)
 		}
-		if sequencerUnsafeHead.Number >= initialUnsafeHead+NUM_UNSAFE_BLOCKS {
-			break
+		return true
+	}
+	require.Eventually(t, allVerifierNodesInSync, 30*time.Second, time.Duration(sys.L2Chain.Escape().RollupConfig().BlockTime)*time.Second)
+	t.Log("All verifier nodes progressed to the final unsafe head number", finalUnsafeHeadNumber)
+
+	// Final sanity check on the block hashes being consistent.
+	finalUnsafeBlockHash := sys.L2Chain.L2ELNodes()[indexOfSequencer].BlockRefByNumber(finalUnsafeHeadNumber).Hash
+	for i, el := range sys.L2Chain.L2ELNodes() {
+		if i == indexOfSequencer {
+			continue
+		}
+		verifierUnsafeBlockHash := el.BlockRefByNumber(finalUnsafeHeadNumber).Hash
+		if verifierUnsafeBlockHash != finalUnsafeBlockHash {
+			t.Require().Fail("verifier (%s) unsafe block hash (%s) does not match final unsafe block hash (%s)", el.ID(), verifierUnsafeBlockHash, finalUnsafeBlockHash)
 		}
 	}
-	t.Logf("Sequencer unsafe head advanced %d blocks and %d verifier nodes stayed within 10 blocks of the unsafe head", initialUnsafeHead+NUM_UNSAFE_BLOCKS, len(sys.L2Chain.L2ELNodes()))
+	t.Log("All verifier nodes have the final unsafe block hash", finalUnsafeBlockHash)
 }

--- a/op-acceptance-tests/tests/base/chain/unsafe_sync_test.go
+++ b/op-acceptance-tests/tests/base/chain/unsafe_sync_test.go
@@ -12,8 +12,8 @@ import (
 )
 
 // TestUnsafeSync tests that the verifier nodes are able to sync the unsafe head of the chain.
-// It does this by waiting for the sequencer to produce 10 unsafe blocks and requiring the verifier nodes to
-// be no more than 10 blocks behind the unsafe head.
+// It does this by waiting for the sequencer to produce NUM_UNSAFE_BLOCKS unsafe blocks and requiring the verifier nodes to
+// be progress to the final unsafe head number.
 func TestUnsafeSync(gt *testing.T) {
 	t := devtest.SerialT(gt)
 	sys := presets.NewSingleChainMultiNode(t)
@@ -23,7 +23,7 @@ func TestUnsafeSync(gt *testing.T) {
 	sys.L2Batcher.Stop()
 
 	l2chainID := sys.L2Chain.Escape().ChainID()
-	const NUM_UNSAFE_BLOCKS = 3
+	const NUM_UNSAFE_BLOCKS = 10
 	const TIMEOUT = 5 * time.Second // time to wait for all verifier nodes to catch up to the sequencer
 
 	// In order for this test to be valid, we need at least 2 L2 EL nodes.

--- a/op-acceptance-tests/tests/base/chain/unsafe_sync_test.go
+++ b/op-acceptance-tests/tests/base/chain/unsafe_sync_test.go
@@ -17,8 +17,14 @@ import (
 func TestUnsafeSync(gt *testing.T) {
 	t := devtest.SerialT(gt)
 	sys := presets.NewSingleChainMultiNode(t)
+
+	// Stop batcher so there is no sync from deriving from L1
+	// This won't work on external networks.
+	sys.L2Batcher.Stop()
+
 	l2chainID := sys.L2Chain.Escape().ChainID()
-	const NUM_UNSAFE_BLOCKS = 10
+	const NUM_UNSAFE_BLOCKS = 3
+	const TIMEOUT = 5 * time.Second // time to wait for all verifier nodes to catch up to the sequencer
 
 	// In order for this test to be valid, we need at least 2 L2 EL nodes.
 	t.Require().Greater(len(sys.L2Chain.L2ELNodes()), 1, "expected at least 2 L2 EL nodes")
@@ -58,7 +64,11 @@ func TestUnsafeSync(gt *testing.T) {
 		}
 		return true
 	}
-	require.Eventually(t, allVerifierNodesInSync, 30*time.Second, time.Duration(sys.L2Chain.Escape().RollupConfig().BlockTime)*time.Second)
+
+	require.Eventually(t, allVerifierNodesInSync, TIMEOUT, time.Duration(sys.L2Chain.Escape().RollupConfig().BlockTime)*time.Second,
+		"all verifier nodes did not progress to the final unsafe head number within %s",
+		TIMEOUT,
+	)
 	t.Log("All verifier nodes progressed to the final unsafe head number", finalUnsafeHeadNumber)
 
 	// Final sanity check on the block hashes being consistent.

--- a/op-acceptance-tests/tests/base/chain/unsafe_sync_test.go
+++ b/op-acceptance-tests/tests/base/chain/unsafe_sync_test.go
@@ -1,0 +1,59 @@
+package chain
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+)
+
+// TestUnsafeSync tests that the verifier nodes are able to sync the unsafe head of the chain.
+// It does this by waiting for the sequencer to produce 10 unsafe blocks and requiring the verifier nodes to
+// be no more than 10 blocks behind the unsafe head.
+func TestUnsafeSync(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewSingleChainMultiNode(t)
+
+	l2chainID := sys.L2Chain.Escape().ChainID()
+
+	const NUM_UNSAFE_BLOCKS = 20
+	const MAX_LAG = 10
+
+	t.Require().Greater(len(sys.L2Chain.L2ELNodes()), 1, "expected at least 2 L2 EL nodes")
+
+	indexOfSequencer := 0
+	for i, el := range sys.L2Chain.L2ELNodes() {
+		if strings.Contains(el.ID().String(), "sequencer") {
+			indexOfSequencer = i
+			break
+		}
+	}
+
+	initialUnsafeHead := sys.L2Chain.L2ELNodes()[0].ChainSyncStatus(sys.L2Chain.Escape().ChainID(), types.LocalUnsafe).Number
+
+	ticker := time.NewTicker(time.Duration(sys.L2Chain.Escape().RollupConfig().BlockTime) * time.Second / 10)
+	for range ticker.C {
+		sequencerUnsafeHead := sys.L2Chain.L2ELNodes()[indexOfSequencer].ChainSyncStatus(sys.L2Chain.Escape().ChainID(), types.LocalUnsafe)
+		for i, el := range sys.L2Chain.L2ELNodes() {
+			if i == indexOfSequencer {
+				continue
+			}
+			verifierUnsafeHead := el.ChainSyncStatus(l2chainID, types.LocalUnsafe)
+			lag := int64(verifierUnsafeHead.Number) - int64(sequencerUnsafeHead.Number)
+			if lag > 0 {
+				t.Require().Fail("verifier unsafe head is ahead of sequencer unsafe head")
+			}
+			if lag < 0 {
+				t.Require().Greater(lag, -MAX_LAG, "verifier (%s) unsafe head (number %d) is too far behind sequencer unsafe head (number %d)", el.ID(), verifierUnsafeHead.Number, sequencerUnsafeHead.Number)
+			}
+			t.Logf("verifier (%s) unsafe head (number %d) is %d blocks behind sequencer unsafe head (number %d)", el.ID(), verifierUnsafeHead.Number, lag, sequencerUnsafeHead.Number)
+		}
+		if sequencerUnsafeHead.Number >= initialUnsafeHead+NUM_UNSAFE_BLOCKS {
+			break
+		}
+	}
+	t.Logf("Sequencer unsafe head advanced %d blocks and %d verifier nodes stayed within 10 blocks of the unsafe head", initialUnsafeHead+NUM_UNSAFE_BLOCKS, len(sys.L2Chain.L2ELNodes()))
+}

--- a/op-acceptance-tests/tests/base/chain/unsafe_sync_test.go
+++ b/op-acceptance-tests/tests/base/chain/unsafe_sync_test.go
@@ -42,12 +42,12 @@ func TestUnsafeSync(gt *testing.T) {
 				continue
 			}
 			verifierUnsafeHead := el.ChainSyncStatus(l2chainID, types.LocalUnsafe)
-			lag := int64(verifierUnsafeHead.Number) - int64(sequencerUnsafeHead.Number)
+			lag := uint64(verifierUnsafeHead.Number) - uint64(sequencerUnsafeHead.Number)
 			if lag > 0 {
-				t.Require().Fail("verifier unsafe head is ahead of sequencer unsafe head")
+				t.Require().Fail("verifier unsafe head is ahead of sequencer unsafe head", "verifier", el.ID(), "verifier unsafe head", verifierUnsafeHead.Number, "sequencer unsafe head", sequencerUnsafeHead.Number)
 			}
 			if lag < 0 {
-				t.Require().Greater(lag, -MAX_LAG, "verifier (%s) unsafe head (number %d) is too far behind sequencer unsafe head (number %d)", el.ID(), verifierUnsafeHead.Number, sequencerUnsafeHead.Number)
+				t.Require().Greater(lag, uint64(MAX_LAG), "verifier (%s) unsafe head (number %d) is too far behind sequencer unsafe head (number %d) with max lag %d", el.ID(), verifierUnsafeHead.Number, sequencerUnsafeHead.Number, MAX_LAG)
 			}
 			t.Logf("verifier (%s) unsafe head (number %d) is %d blocks behind sequencer unsafe head (number %d)", el.ID(), verifierUnsafeHead.Number, lag, sequencerUnsafeHead.Number)
 		}


### PR DESCRIPTION
We recently realised that acceptance tests do not give us good coverage for unsafe head progression via p2p gossip. See, for example, https://github.com/ethereum-optimism/optimism/pull/17940 (a bug which wasn't caught by ATs) as well as a recent op-reth bug we only caught on devnet. 

This test adds that coverage, and simply asserts that a) there are some non-sequencer verifier nodes and b) they catch up to the sequencer within a timeout period. 

The test disables the sysgo batcher, because otherwise safe chain derivation would allow the test to pass even if gossip was broken. Therefore this test should not run against external networks. 

I confirmed manually that introducing a bug, where op-node just rejects gossip payloads unconditionally, does indeed cause this test to fail. 