### PR TITLE
ci: Put go tests on regular runners

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1279,10 +1279,6 @@ jobs:
         description: Slack user or group to mention when notifying of failures
         type: string
         default: ""
-      resource_class:
-        description: Machine resource class
-        type: string
-        default: ethereum-optimism/latitude-1-go-e2e
       no_output_timeout:
         description: Timeout for when CircleCI kills the job if there's no output
         type: string

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1303,19 +1303,30 @@ jobs:
         description: Number machines to distribute the tests across
         type: integer
         default: 1
-    machine: true
-    resource_class: <<parameters.resource_class>>
+    docker:
+      - image: <<pipeline.parameters.default_docker_image>>
+    resource_class: 2xlarge
     circleci_ip_ranges: true
     parallelism: <<parameters.parallelism>>
     steps:
       - checkout-from-workspace
+      - restore_cache:
+          key: go-tests-v2-{{ checksum "go.mod" }}
       - run:
           name: Run Go tests via Makefile
           no_output_timeout: <<parameters.no_output_timeout>>
           command: |
             <<parameters.environment_overrides>>
             export TEST_TIMEOUT=<<parameters.test_timeout>>
+            # set to less than number CPUs (xlarge Docker is 16 CPU) so there's some buffer for things
+            # like Geth
+            export PARALLEL=12
             make <<parameters.rule>>
+      - save_cache:
+          key: go-tests-v2-{{ checksum "go.mod" }}
+          paths:
+            - "~/.cache/go-build"
+            - "~/go"
       - store_test_results:
           path: ./tmp/test-results
       - run:
@@ -2460,7 +2471,7 @@ workflows:
             - contracts-bedrock-build
       - go-tests:
           name: go-tests-short
-          parallelism: 2
+          parallelism: 12
           no_output_timeout: 19m
           test_timeout: 20m
           requires:
@@ -2474,7 +2485,7 @@ workflows:
       - go-tests:
           name: go-tests-full
           rule: "go-tests-ci" # Run full test suite instead of short
-          parallelism: 2
+          parallelism: 16
           no_output_timeout: 89m # Longer timeout for full tests
           test_timeout: 90m
           notify: true

--- a/Makefile
+++ b/Makefile
@@ -206,7 +206,17 @@ TEST_PKGS := \
 	./op-e2e/e2eutils/... \
 	./op-e2e/opgeth/... \
 	./op-e2e/interop/... \
-	./op-e2e/actions/... \
+	./op-e2e/actions/altda \
+	./op-e2e/actions/batcher \
+	./op-e2e/actions/derivation \
+	./op-e2e/actions/helpers \
+	./op-e2e/actions/interop \
+	./op-e2e/actions/proofs \
+	./op-e2e/actions/proposer \
+	./op-e2e/actions/safedb \
+	./op-e2e/actions/sequencer \
+	./op-e2e/actions/sync \
+	./op-e2e/actions/upgrades \
 	./packages/contracts-bedrock/scripts/checks/... \
 	./op-dripper/... \
 	./devnet-sdk/... \
@@ -215,7 +225,8 @@ TEST_PKGS := \
 	./op-deployer/pkg/deployer/artifacts/... \
 	./op-deployer/pkg/deployer/broadcaster/... \
 	./op-deployer/pkg/deployer/clean/... \
-	./op-deployer/pkg/deployer/integration_test/... \
+	./op-deployer/pkg/deployer/integration_test/ \
+	./op-deployer/pkg/deployer/integration_test/cli/... \
 	./op-deployer/pkg/deployer/standard/... \
 	./op-deployer/pkg/deployer/state/... \
 	./op-deployer/pkg/deployer/verify/... \
@@ -276,13 +287,32 @@ _go-tests-ci-internal:
 	@echo "Running Go tests with gotestsum..."
 	$(DEFAULT_TEST_ENV_VARS) && \
 	$(CI_ENV_VARS) && \
-	gotestsum --format=testname \
-		--junitfile=./tmp/test-results/results.xml \
-		--jsonfile=./tmp/testlogs/log.json \
-		--rerun-fails=3 \
-		--rerun-fails-max-failures=50 \
-		--packages="$(ALL_TEST_PACKAGES)" \
-		-- -parallel=$$PARALLEL -coverprofile=coverage.out $(GO_TEST_FLAGS) -timeout=$(TEST_TIMEOUT) -tags="ci";
+	if [ -n "$$CIRCLE_NODE_TOTAL" ] && [ "$$CIRCLE_NODE_TOTAL" -gt 1 ]; then \
+		export NODE_INDEX=$${CIRCLE_NODE_INDEX:-0} && \
+		export NODE_TOTAL=$${CIRCLE_NODE_TOTAL:-1} && \
+		export PARALLEL_PACKAGES=$$(echo "$(ALL_TEST_PACKAGES)" | tr ' ' '\n' | awk -v idx=$$NODE_INDEX -v total=$$NODE_TOTAL 'NR % total == idx' | tr '\n' ' ') && \
+		if [ -n "$$PARALLEL_PACKAGES" ]; then \
+			echo "Node $$NODE_INDEX/$$NODE_TOTAL running packages: $$PARALLEL_PACKAGES"; \
+			gotestsum --format=testname \
+				--junitfile=./tmp/test-results/results-$$NODE_INDEX.xml \
+				--jsonfile=./tmp/testlogs/log-$$NODE_INDEX.json \
+				--rerun-fails=3 \
+				--rerun-fails-max-failures=50 \
+				--packages="$$PARALLEL_PACKAGES" \
+				-- -parallel=$$PARALLEL -coverprofile=coverage-$$NODE_INDEX.out $(GO_TEST_FLAGS) -timeout=$(TEST_TIMEOUT) -tags="ci"; \
+		else \
+			echo "ERROR: Node $$NODE_INDEX/$$NODE_TOTAL has no packages to run! Perhaps parallelism is set too high? (ALL_TEST_PACKAGES has $$(echo '$(ALL_TEST_PACKAGES)' | wc -w) packages)"; \
+			exit 1; \
+		fi; \
+	else \
+		gotestsum --format=testname \
+			--junitfile=./tmp/test-results/results.xml \
+			--jsonfile=./tmp/testlogs/log.json \
+			--rerun-fails=3 \
+			--rerun-fails-max-failures=50 \
+			--packages="$(ALL_TEST_PACKAGES)" \
+			-- -parallel=$$PARALLEL -coverprofile=coverage.out $(GO_TEST_FLAGS) -timeout=$(TEST_TIMEOUT) -tags="ci"; \
+	fi
 .PHONY: _go-tests-ci-internal
 
 go-tests-short-ci: ## Runs short Go tests with gotestsum for CI (assumes deps built by CI)

--- a/op-e2e/e2e.go
+++ b/op-e2e/e2e.go
@@ -1,10 +1,7 @@
 package op_e2e
 
 import (
-	"crypto/md5"
 	"os"
-	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
@@ -24,78 +21,10 @@ func InitParallel(t e2eutils.TestingBase, args ...func(t e2eutils.TestingBase)) 
 	for _, arg := range args {
 		arg(t)
 	}
-	autoAllocateExecutor(t)
-}
-
-// isSubTest determines if the test is a sub-test or top level test.
-// It does this by checking if the test name contains /
-// This is not a particularly great way check, but appears to be the only option currently.
-func isSubTest(t e2eutils.TestingBase) bool {
-	return strings.Contains(t.Name(), "/")
-}
-
-func autoAllocateExecutor(t e2eutils.TestingBase) {
-	if isSubTest(t) {
-		// Always run subtests, they only start on the same executor as their parent.
-		return
-	}
-	info := getExecutorInfo(t)
-	tName := t.Name()
-	tHash := md5.Sum([]byte(tName))
-	executor := uint64(tHash[0]) % info.total
-	checkExecutor(t, info, executor)
 }
 
 func UsesCannon(t e2eutils.TestingBase) {
 	if os.Getenv("OP_E2E_CANNON_ENABLED") == "false" {
 		t.Skip("Skipping cannon test")
 	}
-}
-
-type executorInfo struct {
-	total      uint64
-	idx        uint64
-	splitInUse bool
-}
-
-func getExecutorInfo(t e2eutils.TestingBase) executorInfo {
-	var info executorInfo
-	envTotal := os.Getenv("CIRCLE_NODE_TOTAL")
-	envIdx := os.Getenv("CIRCLE_NODE_INDEX")
-	if envTotal == "" || envIdx == "" {
-		// Not using test splitting, so ignore assigned executor
-		t.Logf("Test splitting not in use.")
-		info.total = 1
-		return info
-	}
-	total, err := strconv.ParseUint(envTotal, 10, 0)
-	if err != nil {
-		t.Fatalf("Could not parse CIRCLE_NODE_TOTAL env var %v: %v", envTotal, err)
-	}
-	idx, err := strconv.ParseUint(envIdx, 10, 0)
-	if err != nil {
-		t.Fatalf("Could not parse CIRCLE_NODE_INDEX env var %v: %v", envIdx, err)
-	}
-
-	info.total = total
-	info.idx = idx
-	info.splitInUse = true
-	return info
-}
-
-func checkExecutor(t e2eutils.TestingBase, info executorInfo, assignedIdx uint64) {
-	if !info.splitInUse {
-		t.Logf("Test splitting not in use.")
-		return
-	}
-
-	if assignedIdx >= info.total && info.idx == info.total-1 {
-		t.Logf("Running test. Current executor (%v) is the last executor and assigned executor (%v) >= total executors (%v).", info.idx, assignedIdx, info.total)
-		return
-	}
-	if info.idx == assignedIdx {
-		t.Logf("Running test. Assigned executor (%v) matches current executor (%v) of total (%v)", assignedIdx, info.idx, info.total)
-		return
-	}
-	t.Skipf("Skipping test. Assigned executor %v, current executor %v of total %v", assignedIdx, info.idx, info.total)
 }


### PR DESCRIPTION
We originally made self-hosted runners for our Go tests to improve performance. Building the Go tests and downloading the caches and dependencies added up to a significant amount of test runtime. Since then, CircleCI has made a bunch of performance improvements (like zstd compression) that reduce the performance impact of those steps and make using the built-in CircleCI runners viable again.

Additionally, last week we experienced very slow builds as a result of a large build backlog. Builds were queuing due to limited self-hosted runner capacity. It would be very expensive for us to increase that capacity to where we need it.

This PR moves the Go tests back to CircleCI runners. This allows us to infinitely scale runner capacity, and obviates the need to continue maintaining the large Go test runners on Latitude. As part of this PR, I increased parallelism on the go-test-* jobs to take advantage of CircleCI's built-in sharding mechanism, and removed the code that manually distributed tests over executors in op-e2e. I used Stefano's previous attempt at test sharding to do this.

`go-tests-short` takes about 5 minutes now; with a few optimizations this could be reduced even further.

Co-Authored-By: @scharissis