### PR TITLE
fix(op-dispute-mon): prevent ignored games from retaining cached data

### DIFF
--- a/op-dispute-mon/mon/extract/extractor.go
+++ b/op-dispute-mon/mon/extract/extractor.go
@@ -109,9 +109,12 @@ func (e *Extractor) enrichGames(ctx context.Context, blockHash common.Hash, game
 	updatedGameData := make(map[common.Address]*monTypes.EnrichedGameData)
 	// Push each game into the channel and store the latest cached game data as a default if fetching fails
 	for _, game := range games {
-		previousData := e.latestGameData[game.Proxy]
-		if previousData != nil {
-			updatedGameData[game.Proxy] = previousData
+		// Only cache data for non-ignored games to ensure ignored games are completely excluded
+		if !e.ignoredGames[game.Proxy] {
+			previousData := e.latestGameData[game.Proxy]
+			if previousData != nil {
+				updatedGameData[game.Proxy] = previousData
+			}
 		}
 		gameCh <- game
 	}

--- a/op-dispute-mon/mon/extract/extractor_test.go
+++ b/op-dispute-mon/mon/extract/extractor_test.go
@@ -208,6 +208,36 @@ func TestExtractor_Extract(t *testing.T) {
 		require.Equal(t, firstUpdateTime, actual[gameA].LastUpdateTime)
 		require.Equal(t, secondUpdateTime, actual[gameB].LastUpdateTime)
 	})
+
+	t.Run("IgnorePreviouslyCachedGame", func(t *testing.T) {
+		enricher := &mockEnricher{}
+		extractor, _, games, _, _ := setupExtractorTest(t, enricher)
+		gameA := common.Address{0xaa}
+		gameB := common.Address{0xbb}
+		games.games = []gameTypes.GameMetadata{{Proxy: gameA}, {Proxy: gameB}}
+
+		// First fetch succeeds and the results should be cached
+		enriched, ignored, failed, err := extractor.Extract(context.Background(), common.Hash{}, 0)
+		require.NoError(t, err)
+		require.Zero(t, ignored)
+		require.Zero(t, failed)
+		require.Len(t, enriched, 2)
+
+		// Now add gameA to the ignored games list
+		extractor.ignoredGames[gameA] = true
+
+		// Second fetch should ignore gameA even though it has cached data
+		enriched, ignored, failed, err = extractor.Extract(context.Background(), common.Hash{}, 0)
+		require.NoError(t, err)
+		require.Equal(t, 1, ignored) // gameA is now ignored
+		require.Zero(t, failed)
+		require.Len(t, enriched, 1) // Only gameB should be returned
+		require.Equal(t, gameB, enriched[0].Proxy)
+
+		for _, data := range enriched {
+			require.NotEqual(t, gameA, data.Proxy)
+		}
+	})
 }
 
 func verifyLogs(t *testing.T, logs *testlog.CapturingHandler, createErr, metadataErr, claimsErr, durationErr int) {


### PR DESCRIPTION
## Problem

**Description**

When a dispute game is added to the `ignoredGames` configuration, the monitor correctly increments the `ignored` counter and logs a warning, but **the game's previously cached data remains in the returned `enrichedGames` list**. This causes ignored games to still be processed by forecast and monitoring logic, creating a semantic inconsistency.

**Evidence**

1. **Test expectations**: The `IgnoreGames` test expects `len(enriched) == 1` when 2 games exist with 1 ignored
2. **Metric semantics**: `ignored_games` is documented as "games present in the game window but ignored via config"
3. **Actual behavior**: Ignored games with cached data still appear in results and are processed

## Tests

Added test case `IgnorePreviouslyCachedGame` that verifies:
1. A game is successfully enriched and cached
2. The game is added to ignoredGames
3. On next extraction, the game is not in results despite having cached data
4. The ignored counter is incremented correctly

