### PR TITLE
op-node: remove Jovian feature toggles

### DIFF
--- a/op-chain-ops/genesis/genesis.go
+++ b/op-chain-ops/genesis/genesis.go
@@ -123,7 +123,7 @@ func NewL2Genesis(config *DeployConfig, l1StartHeader *eth.BlockRef) (*core.Gene
 	if optimismChainConfig.IsIsthmus(genesis.Timestamp) {
 		genesis.Alloc[params.HistoryStorageAddress] = types.Account{Nonce: 1, Code: params.HistoryStorageCode, Balance: common.Big0}
 	}
-	if optimismChainConfig.IsMinBaseFee(genesis.Timestamp) {
+	if optimismChainConfig.IsJovian(genesis.Timestamp) {
 		genesis.ExtraData = MinBaseFeeExtraData
 	}
 

--- a/op-devstack/dsl/bridge.go
+++ b/op-devstack/dsl/bridge.go
@@ -604,7 +604,7 @@ func gasCost(rcpt *types.Receipt, rollupCfg *rollup.Config, blockTimestamp *uint
 		}
 		operatorCost := new(big.Int).SetUint64(rcpt.GasUsed)
 		operatorCost.Mul(operatorCost, new(big.Int).SetUint64(*rcpt.OperatorFeeScalar))
-		if rollupCfg.IsOperatorFeeFix(*blockTimestamp) {
+		if rollupCfg.IsJovian(*blockTimestamp) {
 			operatorCost.Mul(operatorCost, big.NewInt(100))
 		} else {
 			operatorCost.Div(operatorCost, big.NewInt(1_000_000))

--- a/op-node/p2p/gossip.go
+++ b/op-node/p2p/gossip.go
@@ -387,7 +387,7 @@ func BuildBlocksValidator(log log.Logger, cfg *rollup.Config, runCfg GossipRunti
 				log.Warn("payload is on v3 topic, but has nil blob gas used", "bad_hash", payload.BlockHash.String())
 				return pubsub.ValidationReject
 				// [REJECT] if the block is on a topic >= V3 and has a non-zero blob gas used field pre-Jovian
-			} else if !cfg.IsDAFootprintBlockLimit(uint64(payload.Timestamp)) && *payload.BlobGasUsed != 0 {
+			} else if !cfg.IsJovian(uint64(payload.Timestamp)) && *payload.BlobGasUsed != 0 {
 				log.Warn("payload is on v3 topic, but has non-zero blob gas used",
 					"bad_hash", payload.BlockHash.String(), "blob_gas_used", *payload.BlobGasUsed)
 				return pubsub.ValidationReject

--- a/op-node/rollup/derive/attributes.go
+++ b/op-node/rollup/derive/attributes.go
@@ -146,7 +146,7 @@ func (ba *FetchingAttributesBuilder) PreparePayloadAttributes(ctx context.Contex
 	}
 
 	if ba.rollupCfg.IsJovianActivationBlock(nextL2Time) {
-		jovian, err := JovianNetworkUpgradeTransactions(ba.rollupCfg.IsDAFootprintBlockLimit(nextL2Time), ba.rollupCfg.IsOperatorFeeFix(nextL2Time))
+		jovian, err := JovianNetworkUpgradeTransactions(ba.rollupCfg.IsJovian(nextL2Time), ba.rollupCfg.IsJovian(nextL2Time))
 		if err != nil {
 			return nil, NewCriticalError(fmt.Errorf("failed to build jovian network upgrade txs: %w", err))
 		}
@@ -209,7 +209,7 @@ func (ba *FetchingAttributesBuilder) PreparePayloadAttributes(ctx context.Contex
 		r.EIP1559Params = new(eth.Bytes8)
 		*r.EIP1559Params = sysConfig.EIP1559Params
 	}
-	if ba.rollupCfg.IsMinBaseFee(nextL2Time) {
+	if ba.rollupCfg.IsJovian(nextL2Time) {
 		r.MinBaseFee = &sysConfig.MinBaseFee
 	}
 	return r, nil

--- a/op-node/rollup/derive/payload_util.go
+++ b/op-node/rollup/derive/payload_util.go
@@ -104,11 +104,11 @@ func PayloadToSystemConfig(rollupCfg *rollup.Config, payload *eth.ExecutionPaylo
 		})
 	}
 
-	if rollupCfg.IsMinBaseFee(uint64(payload.Timestamp)) {
+	if rollupCfg.IsJovian(uint64(payload.Timestamp)) {
 		// ValidateOptimismExtraData returning a nil error guarantees that m is not nil
 		r.MinBaseFee = *m
 	}
-	if rollupCfg.IsDAFootprintBlockLimit(uint64(payload.Timestamp)) {
+	if rollupCfg.IsJovian(uint64(payload.Timestamp)) {
 		r.DAFootprintGasScalar = info.DAFootprintGasScalar
 	}
 	return r, nil

--- a/op-node/rollup/toggles.go
+++ b/op-node/rollup/toggles.go
@@ -1,16 +1,7 @@
 package rollup
 
-// This file contains ephemeral feature toggles which should be removed
-// after the fork scope is locked.
-
+// IsMinBaseFee implements eip1559.ForkChecker interface.
+// MinBaseFee feature is part of the Jovian hardfork.
 func (c *Config) IsMinBaseFee(time uint64) bool {
-	return c.IsJovian(time) // Replace with return false to disable
-}
-
-func (c *Config) IsDAFootprintBlockLimit(time uint64) bool {
-	return c.IsJovian(time) // Replace with return false to disable
-}
-
-func (c *Config) IsOperatorFeeFix(time uint64) bool {
-	return c.IsJovian(time) // Replace with return false to disable
+	return c.IsJovian(time)
 }

--- a/op-program/client/l2/test/miner.go
+++ b/op-program/client/l2/test/miner.go
@@ -122,7 +122,7 @@ func (m *Miner) Fork(t *testing.T, blockNumber uint64, attrs *eth.PayloadAttribu
 			GasLimit:              &gasLimit,
 			EIP1559Params:         &eip1559Params,
 		}
-		if m.backend.Config().IsMinBaseFee(head.Time) {
+		if m.backend.Config().IsJovian(head.Time) {
 			stub := uint64(1e9)
 			attrs.MinBaseFee = &stub
 		}
@@ -146,7 +146,7 @@ func (m *Miner) MineAt(t *testing.T, head *types.Header, attrs *eth.PayloadAttri
 			GasLimit:              &gasLimit,
 			EIP1559Params:         &eip1559Params,
 		}
-		if m.backend.Config().IsMinBaseFee(head.Time) {
+		if m.backend.Config().IsJovian(head.Time) {
 			stub := uint64(1e9)
 			attrs.MinBaseFee = &stub
 		}


### PR DESCRIPTION
**Description**

This PR removes ephemeral Jovian feature toggles now that the hardfork scope has been finalized, as requested in #17960.

**Changes:**
- Removed `IsDAFootprintBlockLimit()` and `IsOperatorFeeFix()` toggle wrapper methods
- Retained `IsMinBaseFee()` as it implements the `eip1559.ForkChecker` interface (required by op-geth)
- Replaced all toggle usage with direct `IsJovian()` calls across the codebase
- Updated comments to reflect that `IsMinBaseFee` is now an interface implementation rather than an ephemeral toggle

The toggles were temporary wrappers around `IsJovian()` used during development to allow individual feature testing. With the Jovian hardfork scope now locked, these wrappers are no longer needed.

**Tests**

-  Full project build passes: `go build ./...`
- All existing tests continue to work (no test changes needed as behavior is unchanged)
- Verified `IsMinBaseFee` correctly implements `eip1559.ForkChecker` interface

No new tests added as this is a refactoring that maintains existing behavior - the toggles already returned `IsJovian()`, so replacing them with direct calls has no functional change.

**Additional context**

The `IsMinBaseFee` method could not be removed entirely because it's part of the `eip1559.ForkChecker` interface defined in op-geth:
```go
type ForkChecker interface {
    IsHolocene(time uint64) bool
    IsMinBaseFee(time uint64) bool
}
```

This interface is used by `eip1559.ValidateOptimismExtraData()` and `eip1559.DecodeOptimismExtraData()` functions.

**Metadata**

- Fixes #17960