### PR TITLE
chore: Parallelism for solidity tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -920,14 +920,14 @@ jobs:
           command: bash scripts/ops/pull-artifacts.sh
           working_directory: packages/contracts-bedrock
       - go-restore-cache:
-          module: scripts/go-ffi
+          module: contracts-bedrock/scripts/go-ffi
           namespace: mod
       - run:
           name: Build go-ffi
           command: just build-go-ffi
           working_directory: packages/contracts-bedrock
       - go-save-cache-mod:
-          module: scripts/go-ffi
+          module: contracts-bedrock/scripts/go-ffi
       - run:
           name: Run tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -900,6 +900,9 @@ jobs:
           name: Check if test list is empty
           command: |
             TEST_FILES=$(<<parameters.test_list>>)
+
+            echo "Test files: $TEST_FILES"
+
             if [ -z "$TEST_FILES" ]; then
               echo "No test files to run. Exiting early."
               circleci-agent step halt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,6 +83,10 @@ parameters:
   flake-shake-workers:
     type: integer
     default: 50
+  # go-cache-version can be used as a cache buster when making breaking changes to caching strategy
+  go-cache-version:
+    type: string
+    default: "v0.0"
 
 orbs:
   go: circleci/go@1.8.0
@@ -280,6 +284,55 @@ commands:
       - attach_workspace:
           at: "."
       - utils/install-mise
+
+  go-restore-cache:
+    parameters:
+      # The go module to cache for (e.g. go-ffi, op-node, etc.)
+      module:
+        type: string
+      # Since this is a generic command, we'll use a namespace to differentiate cache types
+      namespace:
+        type: string
+      # Version can be used as a cache buster when making breaking changes to caching strategy
+      version:
+        type: string
+        default: <<pipeline.parameters.go-cache-version>>
+    steps:
+      - restore_cache:
+          name: Restore <<parameters.namespace>> cache for <<parameters.module>>
+          keys:
+            - go-<<parameters.version>>-<<parameters.namespace>>-<<parameters.module>>-{{ checksum "<<parameters.module>>/go.mod" }}-{{ checksum "<<parameters.module>>/go.sum" }}
+            - go-<<parameters.version>>-<<parameters.namespace>>-<<parameters.module>>-{{ checksum "<<parameters.module>>/go.mod" }}-
+            - go-<<parameters.version>>-<<parameters.namespace>>-<<parameters.module>>-
+
+  go-save-cache-mod:
+    parameters:
+      module:
+        type: string
+      version:
+        type: string
+        default: <<pipeline.parameters.go-cache-version>>
+    steps:
+      - save_cache:
+          name: Restore mod & build cache for <<parameters.module>>
+          paths:
+            - ~/.cache/go-build
+            - ~/go/pkg/mod
+          key: go-<<parameters.version>>-mod-<<parameters.module>>-{{ checksum "<<parameters.module>>/go.mod" }}-{{ checksum "<<parameters.module>>/go.sum" }}
+
+  go-save-cache-lint:
+    parameters:
+      module:
+        type: string
+      version:
+        type: string
+        default: <<pipeline.parameters.go-cache-version>>
+    steps:
+      - save_cache:
+          name: Restore lint cache for <<parameters.module>>
+          paths:
+            - ~/.cache/golangci-lint
+          key: go-<<parameters.version>>-lint-<<parameters.module>>-{{ checksum "<<parameters.module>>/go.mod" }}-{{ checksum "<<parameters.module>>/go.sum" }}
 
 jobs:
   # Kurtosis-based acceptance tests
@@ -866,10 +919,15 @@ jobs:
           name: Pull artifacts
           command: bash scripts/ops/pull-artifacts.sh
           working_directory: packages/contracts-bedrock
+      - go-restore-cache:
+          module: scripts/go-ffi
+          namespace: mod
       - run:
           name: Build go-ffi
           command: just build-go-ffi
           working_directory: packages/contracts-bedrock
+      - go-save-cache-mod:
+          module: scripts/go-ffi
       - run:
           name: Run tests
           command: |
@@ -1678,12 +1736,17 @@ jobs:
           working_directory: op-acceptance-tests
           command: |
             just cmd-check
+      - go-restore-cache:
+          module: op-acceptance-tests
+          namespace: mod
       - run:
           name: Build flake-shake aggregator
           working_directory: op-acceptance-tests
           command: |
             go mod download
             go build -o ../flake-shake-aggregator ./cmd/flake-shake-aggregator/main.go
+      - go-save-cache-mod:
+          module: op-acceptance-tests
       - run:
           name: Aggregate results
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -920,14 +920,14 @@ jobs:
           command: bash scripts/ops/pull-artifacts.sh
           working_directory: packages/contracts-bedrock
       - go-restore-cache:
-          module: contracts-bedrock/scripts/go-ffi
+          module: .
           namespace: mod
       - run:
           name: Build go-ffi
           command: just build-go-ffi
           working_directory: packages/contracts-bedrock
       - go-save-cache-mod:
-          module: contracts-bedrock/scripts/go-ffi
+          module: .
       - run:
           name: Run tests
           command: |
@@ -1737,7 +1737,7 @@ jobs:
           command: |
             just cmd-check
       - go-restore-cache:
-          module: op-acceptance-tests
+          module: .
           namespace: mod
       - run:
           name: Build flake-shake aggregator
@@ -1746,7 +1746,7 @@ jobs:
             go mod download
             go build -o ../flake-shake-aggregator ./cmd/flake-shake-aggregator/main.go
       - go-save-cache-mod:
-          module: op-acceptance-tests
+          module: .
       - run:
           name: Aggregate results
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ orbs:
   slack: circleci/slack@6.0.0
   shellcheck: circleci/shellcheck@3.2.0
   codecov: codecov/codecov@5.0.3
-  utils: ethereum-optimism/circleci-utils@1.0.20
+  utils: ethereum-optimism/circleci-utils@1.0.22
   docker: circleci/docker@2.8.2
   github-cli: circleci/github-cli@2.7.0
 
@@ -840,6 +840,7 @@ jobs:
         description: List of changed files to run tests on
         type: string
         default: contracts-bedrock
+    parallelism: 4
     steps:
       - checkout-from-workspace
       - run:


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

We are currently splitting the solidity tests by timings but only run one executor - this is not ideal as it has no effect.

[See the warning here](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/105749/workflows/90687315-91ca-4975-a217-80c216abbe0b/jobs/4038374/timing)