### PR TITLE
ctb: Skip blueprint DG impl verification

### DIFF
--- a/packages/contracts-bedrock/scripts/deploy/VerifyOPCM.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/VerifyOPCM.s.sol
@@ -413,6 +413,13 @@ contract VerifyOPCM is Script {
         string memory artifactPath = _buildArtifactPath(_target.name);
         console.log(string.concat("  Expected Runtime Artifact: ", artifactPath));
 
+        // Check if this is a V1 dispute game that should be skipped
+        if (_isV1DisputeGameImplementation(_target.name) && _target.blueprint) {
+            if (_isV2DisputeGamesEnabled(_opcm)) {
+                console.log("[SKIP] Dispute game blueprint not deployed (dispute game v2 feature enabled)");
+                return true; // Consider this "verified" when feature is on
+            }
+        }
         // Check if this is a V2 dispute game that should be skipped
         if (_isV2DisputeGameImplementation(_target.name)) {
             if (!_isV2DisputeGamesEnabled(_opcm)) {
@@ -550,6 +557,13 @@ contract VerifyOPCM is Script {
     function _isSuperDisputeGamesEnabled(IOPContractsManager _opcm) internal view returns (bool) {
         bytes32 bitmap = _opcm.devFeatureBitmap();
         return DevFeatures.isDevFeatureEnabled(bitmap, DevFeatures.OPTIMISM_PORTAL_INTEROP);
+    }
+
+    /// @notice Checks if a contract is a V1 dispute game implementation.
+    /// @param _contractName The name to check.
+    /// @return True if this is a V1 dispute game.
+    function _isV1DisputeGameImplementation(string memory _contractName) internal pure returns (bool) {
+        return LibString.eq(_contractName, "FaultDisputeGame") || LibString.eq(_contractName, "PermissionedDisputeGame");
     }
 
     /// @notice Checks if a contract is a V2 dispute game implementation.

--- a/packages/contracts-bedrock/scripts/deploy/VerifyOPCM.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/VerifyOPCM.s.sol
@@ -418,8 +418,8 @@ contract VerifyOPCM is Script {
             if (_isV2DisputeGamesEnabled(_opcm)) {
                 console.log("[SKIP] Dispute game blueprint not deployed (dispute game v2 feature enabled)");
                 return true; // Consider this "verified" when feature is on
-            } else if (_target.addr != address(0)) {
-                console.log("[FAIL] Dispute game blueprint was deployed (dispute game v2 feature enabled)");
+            } else if (_target.addr == address(0)) {
+                console.log("[FAIL] Dispute game blueprint not deployed (dispute game v2 feature disabled)");
                 success = false;
             }
         }

--- a/packages/contracts-bedrock/scripts/deploy/VerifyOPCM.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/VerifyOPCM.s.sol
@@ -418,6 +418,9 @@ contract VerifyOPCM is Script {
             if (_isV2DisputeGamesEnabled(_opcm)) {
                 console.log("[SKIP] Dispute game blueprint not deployed (dispute game v2 feature enabled)");
                 return true; // Consider this "verified" when feature is on
+            } else if (_target.addr != address(0)) {
+                console.log("[FAIL] Dispute game blueprint was deployed (dispute game v2 feature enabled)");
+                success = false;
             }
         }
         // Check if this is a V2 dispute game that should be skipped


### PR DESCRIPTION
When the `DEPLOY_V2_DISPUTE_GAMES` feature flag is enabled, we should skip verification of the old v1 implementation blueprint since they're not used.