### PR TITLE
chore: Go cache for several uncached builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1272,12 +1272,14 @@ jobs:
       - attach_workspace:
           at: "."
           if: ${{ uses_artifacts }}
+      - go-restore-cache
       - run:
           name: Fuzz
           no_output_timeout: 15m
           command: |
             make fuzz
           working_directory: "<<parameters.package_name>>"
+      - go-save-cache
       - run:
           name: Copy fuzz artifacts
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -291,6 +291,7 @@ commands:
       # "." can be used to point to the root go.mod and go.sum
       module:
         type: string
+        default: .
       # Version can be used as a cache buster when making breaking changes to caching strategy
       version:
         type: string
@@ -307,6 +308,7 @@ commands:
     parameters:
       module:
         type: string
+        default: .
       version:
         type: string
         default: <<pipeline.parameters.go-cache-version>>
@@ -902,14 +904,12 @@ jobs:
           name: Pull artifacts
           command: bash scripts/ops/pull-artifacts.sh
           working_directory: packages/contracts-bedrock
-      - go-restore-cache:
-          module: .
+      - go-restore-cache
       - run:
           name: Build go-ffi
           command: just build-go-ffi
           working_directory: packages/contracts-bedrock
-      - go-save-cache:
-          module: .
+      - go-save-cache
       - run:
           name: Run tests
           command: |
@@ -933,11 +933,6 @@ jobs:
           name: Lint forge test names
           command: just lint-forge-tests-check-no-build
           working_directory: packages/contracts-bedrock
-      - save_cache:
-          name: Save Go build cache
-          key: golang-build-cache-contracts-bedrock-tests-{{ checksum "go.sum" }}
-          paths:
-            - "~/.cache/go-build"
       - notify-failures-on-develop
 
   contracts-bedrock-heavy-fuzz-nightly:
@@ -1277,16 +1272,14 @@ jobs:
       - attach_workspace:
           at: "."
           if: ${{ uses_artifacts }}
-      - go-restore-cache:
-          module: <<parameters.package_name>>
+      - go-restore-cache
       - run:
           name: Fuzz
           no_output_timeout: 15m
           command: |
             make fuzz
           working_directory: "<<parameters.package_name>>"
-      - go-save-cache:
-          module: <<parameters.package_name>>
+      - go-save-cache
       - run:
           name: Copy fuzz artifacts
           command: |
@@ -1729,17 +1722,14 @@ jobs:
           working_directory: op-acceptance-tests
           command: |
             just cmd-check
-      - go-restore-cache:
-          module: .
-          namespace: mod
+      - go-restore-cache
       - run:
           name: Build flake-shake aggregator
           working_directory: op-acceptance-tests
           command: |
             go mod download
             go build -o ../flake-shake-aggregator ./cmd/flake-shake-aggregator/main.go
-      - go-save-cache:
-          module: .
+      - go-save-cache
       - run:
           name: Aggregate results
           command: |
@@ -1778,16 +1768,14 @@ jobs:
           working_directory: op-acceptance-tests
           command: |
             just cmd-check
-      - go-restore-cache:
-          module: .
+      - go-restore-cache
       - run:
           name: Build flake-shake promoter
           working_directory: op-acceptance-tests
           command: |
             go mod download
             go build -o ../flake-shake-promoter ./cmd/flake-shake-promoter/main.go
-      - go-save-cache:
-          module: .
+      - go-save-cache
       - run:
           name: Set GH_TOKEN
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -322,7 +322,7 @@ commands:
         default: <<pipeline.parameters.go-cache-version>>
     steps:
       - save_cache:
-          name: Restore go cache for <<parameters.namespace>> (<<parameters.module>>/go.mod)
+          name: Save go cache for <<parameters.namespace>> (<<parameters.module>>/go.mod)
           paths:
             - ~/.cache/go-build
             - ~/go/pkg/mod

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -287,7 +287,8 @@ commands:
 
   go-restore-cache:
     parameters:
-      # The go module to cache for (e.g. go-ffi, op-node, etc.)
+      # The go module to cache for. If the go module does not come with its own go.mod and go.sum,
+      # "." can be used to point to the root go.mod and go.sum
       module:
         type: string
       # Version can be used as a cache buster when making breaking changes to caching strategy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -292,33 +292,41 @@ commands:
       module:
         type: string
         default: .
+      # Since many builds can run off the same go.mod/go.sum, we'll namespace the caches
+      namespace:
+        type: string
       # Version can be used as a cache buster when making breaking changes to caching strategy
       version:
         type: string
         default: <<pipeline.parameters.go-cache-version>>
     steps:
       - restore_cache:
-          name: Restore mod cache for <<parameters.module>>
+          name: Restore go cache for <<parameters.namespace>> (<<parameters.module>>/go.mod)
           keys:
-            - go-mod-<<parameters.version>>-<<parameters.module>>-{{ checksum "<<parameters.module>>/go.mod" }}-{{ checksum "<<parameters.module>>/go.sum" }}
-            - go-mod-<<parameters.version>>-<<parameters.module>>-{{ checksum "<<parameters.module>>/go.mod" }}-
-            - go-mod-<<parameters.version>>-<<parameters.module>>-
+            - go-<<parameters.namespace>>-<<parameters.version>>-<<parameters.module>>-{{ checksum "<<parameters.module>>/go.mod" }}-{{ checksum "<<parameters.module>>/go.sum" }}
+            - go-<<parameters.namespace>>-<<parameters.version>>-<<parameters.module>>-{{ checksum "<<parameters.module>>/go.mod" }}-
+            - go-<<parameters.namespace>>-<<parameters.version>>-<<parameters.module>>-
 
   go-save-cache:
     parameters:
+      # The go module to cache for. If the go module does not come with its own go.mod and go.sum,
+      # "." can be used to point to the root go.mod and go.sum
       module:
         type: string
         default: .
+      # Since many builds can run off the same go.mod/go.sum, we'll namespace the caches
+      namespace:
+        type: string
       version:
         type: string
         default: <<pipeline.parameters.go-cache-version>>
     steps:
       - save_cache:
-          name: Restore mod & build cache for <<parameters.module>>
+          name: Restore go cache for <<parameters.namespace>> (<<parameters.module>>/go.mod)
           paths:
             - ~/.cache/go-build
             - ~/go/pkg/mod
-          key: go-mod-<<parameters.version>>-<<parameters.module>>-{{ checksum "<<parameters.module>>/go.mod" }}-{{ checksum "<<parameters.module>>/go.sum" }}
+          key: go-<<parameters.namespace>>-<<parameters.version>>-<<parameters.module>>-{{ checksum "<<parameters.module>>/go.mod" }}-{{ checksum "<<parameters.module>>/go.sum" }}
 
 jobs:
   # Kurtosis-based acceptance tests
@@ -904,12 +912,14 @@ jobs:
           name: Pull artifacts
           command: bash scripts/ops/pull-artifacts.sh
           working_directory: packages/contracts-bedrock
-      - go-restore-cache
+      - go-restore-cache:
+          namespace: packages/contracts-bedrock/scripts/go-ffi
       - run:
           name: Build go-ffi
           command: just build-go-ffi
           working_directory: packages/contracts-bedrock
-      - go-save-cache
+      - go-save-cache:
+          namespace: packages/contracts-bedrock/scripts/go-ffi
       - run:
           name: Run tests
           command: |
@@ -1272,14 +1282,16 @@ jobs:
       - attach_workspace:
           at: "."
           if: ${{ uses_artifacts }}
-      - go-restore-cache
+      - go-restore-cache:
+          namespace: fuzz-<<parameters.package_name>>
       - run:
           name: Fuzz
           no_output_timeout: 15m
           command: |
             make fuzz
           working_directory: "<<parameters.package_name>>"
-      - go-save-cache
+      - go-save-cache:
+          namespace: fuzz-<<parameters.package_name>>
       - run:
           name: Copy fuzz artifacts
           command: |
@@ -1722,14 +1734,16 @@ jobs:
           working_directory: op-acceptance-tests
           command: |
             just cmd-check
-      - go-restore-cache
+      - go-restore-cache:
+          namespace: op-acceptance-tests-flake-shake-aggregator
       - run:
           name: Build flake-shake aggregator
           working_directory: op-acceptance-tests
           command: |
             go mod download
             go build -o ../flake-shake-aggregator ./cmd/flake-shake-aggregator/main.go
-      - go-save-cache
+      - go-save-cache:
+          namespace: op-acceptance-tests-flake-shake-aggregator
       - run:
           name: Aggregate results
           command: |
@@ -1768,14 +1782,16 @@ jobs:
           working_directory: op-acceptance-tests
           command: |
             just cmd-check
-      - go-restore-cache
+      - go-restore-cache:
+          namespace: op-acceptance-tests-flake-shake-promoter
       - run:
           name: Build flake-shake promoter
           working_directory: op-acceptance-tests
           command: |
             go mod download
             go build -o ../flake-shake-promoter ./cmd/flake-shake-promoter/main.go
-      - go-save-cache
+      - go-save-cache:
+          namespace: op-acceptance-tests-flake-shake-promoter
       - run:
           name: Set GH_TOKEN
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1272,14 +1272,12 @@ jobs:
       - attach_workspace:
           at: "."
           if: ${{ uses_artifacts }}
-      - go-restore-cache
       - run:
           name: Fuzz
           no_output_timeout: 15m
           command: |
             make fuzz
           working_directory: "<<parameters.package_name>>"
-      - go-save-cache
       - run:
           name: Copy fuzz artifacts
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,6 +83,10 @@ parameters:
   flake-shake-workers:
     type: integer
     default: 50
+  # go-cache-version can be used as a cache buster when making breaking changes to caching strategy
+  go-cache-version:
+    type: string
+    default: "v0.0"
 
 orbs:
   go: circleci/go@1.8.0
@@ -280,6 +284,38 @@ commands:
       - attach_workspace:
           at: "."
       - utils/install-mise
+
+  go-restore-cache:
+    parameters:
+      # The go module to cache for (e.g. go-ffi, op-node, etc.)
+      module:
+        type: string
+      # Version can be used as a cache buster when making breaking changes to caching strategy
+      version:
+        type: string
+        default: <<pipeline.parameters.go-cache-version>>
+    steps:
+      - restore_cache:
+          name: Restore mod cache for <<parameters.module>>
+          keys:
+            - go-mod-<<parameters.version>>-<<parameters.module>>-{{ checksum "<<parameters.module>>/go.mod" }}-{{ checksum "<<parameters.module>>/go.sum" }}
+            - go-mod-<<parameters.version>>-<<parameters.module>>-{{ checksum "<<parameters.module>>/go.mod" }}-
+            - go-mod-<<parameters.version>>-<<parameters.module>>-
+
+  go-save-cache:
+    parameters:
+      module:
+        type: string
+      version:
+        type: string
+        default: <<pipeline.parameters.go-cache-version>>
+    steps:
+      - save_cache:
+          name: Restore mod & build cache for <<parameters.module>>
+          paths:
+            - ~/.cache/go-build
+            - ~/go/pkg/mod
+          key: go-mod-<<parameters.version>>-<<parameters.module>>-{{ checksum "<<parameters.module>>/go.mod" }}-{{ checksum "<<parameters.module>>/go.sum" }}
 
 jobs:
   # Kurtosis-based acceptance tests
@@ -865,10 +901,14 @@ jobs:
           name: Pull artifacts
           command: bash scripts/ops/pull-artifacts.sh
           working_directory: packages/contracts-bedrock
+      - go-restore-cache:
+          module: .
       - run:
           name: Build go-ffi
           command: just build-go-ffi
           working_directory: packages/contracts-bedrock
+      - go-save-cache:
+          module: .
       - run:
           name: Run tests
           command: |
@@ -1236,12 +1276,16 @@ jobs:
       - attach_workspace:
           at: "."
           if: ${{ uses_artifacts }}
+      - go-restore-cache:
+          module: <<parameters.package_name>>
       - run:
           name: Fuzz
           no_output_timeout: 15m
           command: |
             make fuzz
           working_directory: "<<parameters.package_name>>"
+      - go-save-cache:
+          module: <<parameters.package_name>>
       - run:
           name: Copy fuzz artifacts
           command: |
@@ -1684,12 +1728,17 @@ jobs:
           working_directory: op-acceptance-tests
           command: |
             just cmd-check
+      - go-restore-cache:
+          module: .
+          namespace: mod
       - run:
           name: Build flake-shake aggregator
           working_directory: op-acceptance-tests
           command: |
             go mod download
             go build -o ../flake-shake-aggregator ./cmd/flake-shake-aggregator/main.go
+      - go-save-cache:
+          module: .
       - run:
           name: Aggregate results
           command: |
@@ -1728,12 +1777,16 @@ jobs:
           working_directory: op-acceptance-tests
           command: |
             just cmd-check
+      - go-restore-cache:
+          module: .
       - run:
           name: Build flake-shake promoter
           working_directory: op-acceptance-tests
           command: |
             go mod download
             go build -o ../flake-shake-promoter ./cmd/flake-shake-promoter/main.go
+      - go-save-cache:
+          module: .
       - run:
           name: Set GH_TOKEN
           command: |

--- a/op-batcher/justfile
+++ b/op-batcher/justfile
@@ -33,4 +33,4 @@ fuzz:
         "FuzzChannelZeroCloseTimeout" \
         "FuzzSeqWindowClose" \
         "FuzzSeqWindowZeroTimeoutClose" \
-    | parallel -j {{PARALLEL_JOBS}} {{just_executable()}} batcher_fuzz_task {}
+    | parallel --tag -j {{PARALLEL_JOBS}} {{just_executable()}} batcher_fuzz_task {}

--- a/op-chain-ops/justfile
+++ b/op-chain-ops/justfile
@@ -12,7 +12,7 @@ _LDFLAGSSTRING := "'" + trim(
 # Build ecotone-scalar binary
 ecotone-scalar: (go_build "./bin/ecotone-scalar" "./cmd/ecotone-scalar" "-ldflags" _LDFLAGSSTRING)
 
-# Build receipt-reference-builder binary  
+# Build receipt-reference-builder binary
 receipt-reference-builder: (go_build "./bin/receipt-reference-builder" "./cmd/receipt-reference-builder" "-ldflags" _LDFLAGSSTRING)
 
 # Run tests
@@ -33,4 +33,4 @@ fuzz:
         "FuzzEncodeDecodeLegacyWithdrawal" \
         "FuzzAliasing" \
         "FuzzVersionedNonce" \
-    | parallel -j {{PARALLEL_JOBS}} {{just_executable()}} fuzz_task {}
+    | parallel --tag -j {{PARALLEL_JOBS}} {{just_executable()}} fuzz_task {}

--- a/op-e2e/Makefile
+++ b/op-e2e/Makefile
@@ -60,11 +60,7 @@ clean:
 .PHONY: clean
 
 fuzz:
-	printf "%s\n" \
-		"go test -run NOTAREALTEST -tags cgo_test -v -fuzztime 10s -fuzz FuzzFjordCostFunction ./opgeth" \
-		"go test -run NOTAREALTEST -tags cgo_test -v -fuzztime 10s -fuzz FuzzFastLzGethSolidity ./opgeth" \
-		"go test -run NOTAREALTEST -tags cgo_test -v -fuzztime 10s -fuzz FuzzFastLzCgo ./opgeth" \
-	| parallel -j 8 {}
+	parallel --tag -N1 "go test -run NOTAREALTEST -tags cgo_test -v -fuzztime 10s -fuzz {} ./opgeth" ::: FuzzFjordCostFunction FuzzFastLzGethSolidity FuzzFastLzCgo
 
 ifndef CONTRACT
 gen-binding:

--- a/op-node/justfile
+++ b/op-node/justfile
@@ -46,4 +46,4 @@ fuzz:
 		"FuzzParseL1InfoDepositTxDataBadLength" \
 		"FuzzRejectCreateBlockBadTimestamp" \
 		"FuzzDecodeDepositTxDataToL1Info" \
-	| parallel -j {{PARALLEL_JOBS}} {{just_executable()}} node_fuzz_task {}
+	| parallel --tag -j {{PARALLEL_JOBS}} {{just_executable()}} node_fuzz_task {}

--- a/op-service/justfile
+++ b/op-service/justfile
@@ -13,4 +13,4 @@ service_fuzz_task FUZZ TIME='60s': (go_fuzz FUZZ TIME "./eth")
 fuzz:
     go test ./eth/... -list=Fuzz -vet=off \
     | grep 'Fuzz' \
-    | parallel -j {{PARALLEL_JOBS}} {{just_executable()}} service_fuzz_task {}
+    | parallel --tag -j {{PARALLEL_JOBS}} {{just_executable()}} service_fuzz_task {}


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

We have several uncached go builds in our pipeline - some of them are making some already long running tests even longer.

This PR adds two generic commands `go-save-cache` and `go-restore-cache` and uses them in `contracts-bedrock-tests`, `fuzz-golang` and `op-acceptance-tests-*` jobs.

A small quality of life improvement has been added as well - the fuzz jobs run with `parallel` now [prefix their output with the fuzzed parameters](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/105953/workflows/efa3460e-7cf9-47ec-aa69-c8840cba3ad4/jobs/4041121).