### PR TITLE
tests: Non-zero prestate when running DeployDisputeGame

### DIFF
--- a/op-e2e/config/init.go
+++ b/op-e2e/config/init.go
@@ -498,7 +498,7 @@ func cannonPrestate(monorepoRoot string, allocType AllocType) common.Hash {
 	once.Do(func() {
 		f, err := os.Open(path.Join(monorepoRoot, "op-program", "bin", filename))
 		if err != nil {
-			log.Error("error opening prestate file", "err", err)
+			log.Warn("error opening prestate file. If you're running a test that requires prestates, make sure you've run `make cannon-prestates`", "err", err)
 			return
 		}
 		defer f.Close()
@@ -506,12 +506,16 @@ func cannonPrestate(monorepoRoot string, allocType AllocType) common.Hash {
 		var prestate prestateFile
 		dec := json.NewDecoder(f)
 		if err := dec.Decode(&prestate); err != nil {
-			log.Error("error decoding prestate file", "err", err)
+			log.Error("error decoding prestate file. If you're running a test that requires prestates, make sure you've run `make cannon-prestates`", "err", err)
 			return
 		}
 
 		*cacheVar = common.HexToHash(prestate.Pre)
 	})
 
+	// Provide a dummy value so that the DeployDisputeGame script succeeds. Many tests do not require a dispute game. So this allieviates the need to build prestates during local development.
+	if *cacheVar == (common.Hash{}) {
+		*cacheVar = common.HexToHash("0xc02b59f772cb23a75b6ffb9f7602ba25fdd5d8e75ad88efcc013fec2c63b0895") // keccak("dummy")
+	}
 	return *cacheVar
 }

--- a/packages/contracts-bedrock/test/opcm/DeployDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployDisputeGame.t.sol
@@ -50,6 +50,7 @@ contract DeployDisputeGame_Test is Test {
     )
         public
     {
+        vm.assume(_input.absolutePrestate != bytes32(0));
         vm.assume(_input.l2ChainId != 0);
         vm.assume(_gameType != 0);
         vm.assume(_clockExtension != 0);
@@ -87,6 +88,7 @@ contract DeployDisputeGame_Test is Test {
     )
         public
     {
+        vm.assume(_input.absolutePrestate != bytes32(0));
         vm.assume(_input.l2ChainId != 0);
         vm.assume(_gameType != 0);
         vm.assume(_clockExtension != 0);


### PR DESCRIPTION
Also supply a dummy absolute prestate during op-e2e init so that local dev does not require a prestate build.