### PR TITLE
cannon: Default to cannon VM version 8

### DIFF
--- a/cannon/Dockerfile.diff
+++ b/cannon/Dockerfile.diff
@@ -23,14 +23,14 @@ ARG GIT_DATE
 
 ARG TARGETOS TARGETARCH
 
-FROM --platform=$BUILDPLATFORM us-docker.pkg.dev/oplabs-tools-artifacts/images/cannon:v1.5.0-alpha.1 AS cannon-multithreaded64-4
+FROM --platform=$BUILDPLATFORM us-docker.pkg.dev/oplabs-tools-artifacts/images/cannon:v1.6.0 AS cannon-multithreaded64-5
 
 FROM --platform=$BUILDPLATFORM builder AS cannon-verify
-COPY --from=cannon-multithreaded64-4 /usr/local/bin/cannon /usr/local/bin/cannon-multithreaded64-4
+COPY --from=cannon-multithreaded64-5 /usr/local/bin/cannon /usr/local/bin/cannon-multithreaded64-5
 
-# Check cannon-multithreaded64-4
-# verify the latest multithreaded VM behavior against multithreaded64-4
-RUN cd cannon && make diff-multithreaded64-4-cannon -e OTHER_CANNON=/usr/local/bin/cannon-multithreaded64-4
+# Check cannon-multithreaded64-5
+# verify the latest multithreaded VM behavior against multithreaded64-5
+RUN cd cannon && make diff-multithreaded64-5-cannon -e OTHER_CANNON=/usr/local/bin/cannon-multithreaded64-5
 RUN --mount=type=cache,target=/root/.cache/go-build cd cannon && \
- make diff-multithreaded64-4-cannon -e OTHER_CANNON=/usr/local/bin/cannon-multithreaded64-4 \
+ make diff-multithreaded64-5-cannon -e OTHER_CANNON=/usr/local/bin/cannon-multithreaded64-5 \
  GOOS=$TARGETOS GOARCH=$TARGETARCH GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE

--- a/cannon/mipsevm/versions/version.go
+++ b/cannon/mipsevm/versions/version.go
@@ -105,7 +105,7 @@ func GetStateVersionStrings() []string {
 
 // GetCurrentVersion returns the current default version.
 func GetCurrentVersion() StateVersion {
-	return VersionMultiThreaded64_v4
+	return VersionMultiThreaded64_v5
 }
 
 // GetExperimentalVersion returns the newest in-development version of Cannon if it exists, otherwise returns the same

--- a/op-program/Makefile
+++ b/op-program/Makefile
@@ -48,7 +48,7 @@ check-custom-chains: op-program-host
 
 reproducible-prestate: check-custom-chains
 	@docker build --build-arg GO_VERSION=1.24.2-alpine3.21 --build-arg EXPORT_TARGET=next  --output ./bin/ --progress plain -f Dockerfile.repro ../
-	@docker build --build-arg GO_VERSION=1.23.8-alpine3.21 --build-arg EXPORT_TARGET=current --output ./bin/ --progress plain -f Dockerfile.repro ../
+	@docker build --build-arg GO_VERSION=1.24.2-alpine3.21 --build-arg EXPORT_TARGET=current --output ./bin/ --progress plain -f Dockerfile.repro ../
 	@echo "-------------------- Production Prestates --------------------"
 	@echo "\nCannon64 Absolute prestate hash: "
 	@cat ./bin/prestate-proof-mt64.json | jq -r .pre

--- a/op-program/builder/main.go
+++ b/op-program/builder/main.go
@@ -88,7 +88,6 @@ func runBuildPrestates(cliCtx *cli.Context) error {
 	logger := setupLogger()
 	ctx := cliCtx.Context
 	releasesOnly := cliCtx.Bool("releases-only")
-	buildNext := versions.GetCurrentVersion() != versions.GetExperimentalVersion()
 
 	root, err := opservice.FindMonorepoRoot(".")
 	if err != nil {
@@ -107,7 +106,7 @@ func runBuildPrestates(cliCtx *cli.Context) error {
 		{programELF, versions.GetCurrentVersion(), "-mt64"},
 		{interopProgramELF, versions.GetCurrentVersion(), "-interop"},
 	}
-	if !releasesOnly && buildNext {
+	if !releasesOnly {
 		prestates = append(prestates, prestateInfo{programELF, versions.GetExperimentalVersion(), "-mt64Next"})
 		prestates = append(prestates, prestateInfo{interopProgramELF, versions.GetExperimentalVersion(), "-interopNext"})
 	}
@@ -118,7 +117,7 @@ func runBuildPrestates(cliCtx *cli.Context) error {
 		}
 	}
 
-	if !releasesOnly && !buildNext {
+	if !releasesOnly {
 		// some tests expect a "next" prestate to exist. So let's fake them if they weren't built.
 		copies := []struct {
 			src, dst string

--- a/op-program/repro.justfile
+++ b/op-program/repro.justfile
@@ -40,9 +40,9 @@ prestate TYPE CLIENT_SUFFIX PRESTATE_SUFFIX: cannon op-program-client-mips
         --version {{TYPE}}\
         --suffix {{PRESTATE_SUFFIX}}
 
-build-mt64: (prestate "multithreaded64-4" "64" "-mt64")
+build-mt64: (prestate "multithreaded64-5" "64" "-mt64")
 build-mt64Next: (prestate "multithreaded64-5" "64" "-mt64Next")
-build-interop: (prestate "multithreaded64-4" "-interop" "-interop")
+build-interop: (prestate "multithreaded64-5" "-interop" "-interop")
 build-interopNext: (prestate "multithreaded64-5" "-interop" "-interopNext")
 
 build-current: build-mt64 build-interop


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Set Cannon version 8 targeting Go 1.24 as the default vm. 

**Metadata**

Fixes https://github.com/ethereum-optimism/optimism/issues/17177
