### PR TITLE
cannon: Rework cannon "next" vm handling in e2e tests

### DIFF
--- a/op-e2e/config/init.go
+++ b/op-e2e/config/init.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/cannon/mipsevm/versions"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/artifacts"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/inspect"
@@ -488,7 +489,11 @@ func cannonPrestate(monorepoRoot string, allocType AllocType) common.Hash {
 		once = &cannonPrestateMTOnce
 		cacheVar = &cannonPrestateMT
 	} else if cannonVmType == state.VMTypeCannonNext {
-		filename = "prestate-proof-mt64Next.json"
+		if versions.GetCurrentVersion() != versions.GetExperimentalVersion() {
+			filename = "prestate-proof-mt64Next.json"
+		} else {
+			filename = "prestate-proof-mt64.json"
+		}
 		once = &cannonPrestateMTNextOnce
 		cacheVar = &cannonPrestateMTNext
 	} else {

--- a/op-program/builder/main.go
+++ b/op-program/builder/main.go
@@ -88,6 +88,7 @@ func runBuildPrestates(cliCtx *cli.Context) error {
 	logger := setupLogger()
 	ctx := cliCtx.Context
 	releasesOnly := cliCtx.Bool("releases-only")
+	buildNext := versions.GetCurrentVersion() != versions.GetExperimentalVersion()
 
 	root, err := opservice.FindMonorepoRoot(".")
 	if err != nil {
@@ -106,7 +107,7 @@ func runBuildPrestates(cliCtx *cli.Context) error {
 		{programELF, versions.GetCurrentVersion(), "-mt64"},
 		{interopProgramELF, versions.GetCurrentVersion(), "-interop"},
 	}
-	if !releasesOnly {
+	if !releasesOnly && buildNext {
 		prestates = append(prestates, prestateInfo{programELF, versions.GetExperimentalVersion(), "-mt64Next"})
 		prestates = append(prestates, prestateInfo{interopProgramELF, versions.GetExperimentalVersion(), "-interopNext"})
 	}
@@ -117,7 +118,7 @@ func runBuildPrestates(cliCtx *cli.Context) error {
 		}
 	}
 
-	if !releasesOnly {
+	if !releasesOnly && !buildNext {
 		// some tests expect a "next" prestate to exist. So let's fake them if they weren't built.
 		copies := []struct {
 			src, dst string


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Clean-up quick fix from https://github.com/ethereum-optimism/optimism/pull/18062.  Re-enable skipping "next" cannon prestate building, and rework e2e init script to account for these skips.

**Metadata**

Related to: https://github.com/ethereum-optimism/optimism/issues/17177
