### PR TITLE
op-acceptance-tests: fix two papercuts

### DIFF
--- a/op-acceptance-tests/tests/jovian/da_footprint_test.go
+++ b/op-acceptance-tests/tests/jovian/da_footprint_test.go
@@ -145,7 +145,10 @@ func TestDAFootprint(gt *testing.T) {
 			if tc.setScalar != nil {
 				rec := env.setDAFootprintGasScalarViaSystemConfig(t, *tc.setScalar)
 				// Wait for change to propagate to L2
-				env.l2EL.WaitL1OriginReached(eth.Unsafe, rec.BlockNumber.Uint64(), 20)
+				// Retrying up to 100 times is overkill, but lower values may not work on
+				// persistent networks. See the following issue for more details.
+				// https://github.com/ethereum-optimism/optimism/issues/18061
+				env.l2EL.WaitL1OriginReached(eth.Unsafe, rec.BlockNumber.Uint64(), 100)
 			} else {
 				sys.L2EL.WaitForBlockNumber(1) // make sure we don't assert on genesis
 			}


### PR DESCRIPTION
- spammer schedules emit warning logs too often.
- DA footprint test does not retry while looking for an L1 origin often enough. The root problem (arbitrary timeouts everywhere) can be addressed later.