### PR TITLE
fix(op-batcher): exempt generic da from max input size

### DIFF
--- a/op-batcher/batcher/service.go
+++ b/op-batcher/batcher/service.go
@@ -40,6 +40,8 @@ type BatcherConfig struct {
 	// UseAltDA is true if the rollup config has a DA challenge address so the batcher
 	// will post inputs to the DA server and post commitments to blobs or calldata.
 	UseAltDA bool
+	// GenericDA is true if the DA server generates commitments for the input
+	GenericDA bool
 	// maximum number of concurrent blob put requests to the DA server
 	MaxConcurrentDARequests uint64
 
@@ -284,7 +286,7 @@ func (bs *BatcherService) initChannelConfig(cfg *CLIConfig) error {
 		return fmt.Errorf("cannot use data availability type blobs or auto with Alt-DA")
 	}
 
-	if bs.UseAltDA && cc.MaxFrameSize > altda.MaxInputSize {
+	if bs.UseAltDA && !bs.GenericDA &&  cc.MaxFrameSize > altda.MaxInputSize {
 		return fmt.Errorf("max frame size %d exceeds altDA max input size %d", cc.MaxFrameSize, altda.MaxInputSize)
 	}
 
@@ -428,6 +430,7 @@ func (bs *BatcherService) initAltDA(cfg *CLIConfig) error {
 	}
 	bs.AltDA = config.NewDAClient()
 	bs.UseAltDA = config.Enabled
+	bs.GenericDA = config.GenericDA
 	return nil
 }
 

--- a/op-batcher/batcher/service.go
+++ b/op-batcher/batcher/service.go
@@ -286,7 +286,7 @@ func (bs *BatcherService) initChannelConfig(cfg *CLIConfig) error {
 		return fmt.Errorf("cannot use data availability type blobs or auto with Alt-DA")
 	}
 
-	if bs.UseAltDA && !bs.GenericDA &&  cc.MaxFrameSize > altda.MaxInputSize {
+	if bs.UseAltDA && !bs.GenericDA && cc.MaxFrameSize > altda.MaxInputSize {
 		return fmt.Errorf("max frame size %d exceeds altDA max input size %d", cc.MaxFrameSize, altda.MaxInputSize)
 	}
 


### PR DESCRIPTION
Cherry-pick Celestia's fixes to alt-DA the remove max frame size limits for generic DA types. Credit to @tuxcanfly from the Celestia team.

Closes https://github.com/ethereum-optimism/optimism/issues/17872.
