### PR TITLE
chore(op-acceptance-tests): ci; kurtosis defaults to cci runner

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -349,7 +349,7 @@ jobs:
       use_circleci_runner:
         description: Whether to use CircleCI runners (with Docker) instead of self-hosted runners
         type: boolean
-        default: false
+        default: true
     machine:
       image: <<# parameters.use_circleci_runner >>ubuntu-2404:current<</ parameters.use_circleci_runner >><<^ parameters.use_circleci_runner >>true<</ parameters.use_circleci_runner >>
       docker_layer_caching: <<parameters.use_circleci_runner>>


### PR DESCRIPTION
Makes the default value of 'use_circleci_runner' be 'true' for the job 'op-acceptance-tests-kurtosis'.
This should have no effect as all current uses of it explicitly pass in a value of 'true', but provides protection for the future.

Resolves: https://github.com/ethereum-optimism/platforms-team/issues/1271
