### PR TITLE
chore(op-acceptance-tests): ci; default to cci runner

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1600,14 +1600,10 @@ jobs:
         description: Timeout for when CircleCI kills the job if there's no output
         type: string
         default: 30m
-      use_circleci_runner:
-        description: Whether to use CircleCI runners (with Docker) instead of self-hosted runners
-        type: boolean
-        default: false
-    machine:
-      image: <<# parameters.use_circleci_runner >>ubuntu-2404:current<</ parameters.use_circleci_runner >><<^ parameters.use_circleci_runner >>true<</ parameters.use_circleci_runner >>
-      docker_layer_caching: <<parameters.use_circleci_runner>>
-    resource_class: <<# parameters.use_circleci_runner >>xlarge<</ parameters.use_circleci_runner >><<^ parameters.use_circleci_runner >>ethereum-optimism/latitude-1<</ parameters.use_circleci_runner >>
+    docker:
+      - image: <<pipeline.parameters.default_docker_image>>
+    circleci_ip_ranges: true
+    resource_class: 2xlarge
     steps:
       - checkout-from-workspace
       # Restore cached Go modules


### PR DESCRIPTION
Makes our acceptance tests run on CircleCI runners (using a docker executor) by default.

Resolves: https://github.com/ethereum-optimism/platforms-team/issues/1276
