### PR TITLE
op-acceptance: Add acceptance test for playing out dispute games

### DIFF
--- a/op-acceptance-tests/tests/interop/proofs/proposer_test.go
+++ b/op-acceptance-tests/tests/interop/proofs/proposer_test.go
@@ -17,6 +17,6 @@ func TestProposer(gt *testing.T) {
 	rootClaim := newGame.RootClaim().Value()
 	l2SequenceNumber := newGame.L2SequenceNumber()
 
-	superRoot := sys.Supervisor.FetchSuperRootAtTimestamp(l2SequenceNumber.Uint64())
+	superRoot := sys.Supervisor.FetchSuperRootAtTimestamp(l2SequenceNumber)
 	t.Require().Equal(superRoot.SuperRoot[:], rootClaim[:])
 }

--- a/op-acceptance-tests/tests/isthmus/preinterop/proposer_test.go
+++ b/op-acceptance-tests/tests/isthmus/preinterop/proposer_test.go
@@ -18,6 +18,6 @@ func TestProposer(gt *testing.T) {
 	rootClaim := newGame.RootClaim().Value()
 	l2SequenceNumber := newGame.L2SequenceNumber()
 
-	superRoot := sys.Supervisor.FetchSuperRootAtTimestamp(l2SequenceNumber.Uint64())
+	superRoot := sys.Supervisor.FetchSuperRootAtTimestamp(l2SequenceNumber)
 	t.Require().Equal(superRoot.SuperRoot[:], rootClaim[:])
 }

--- a/op-acceptance-tests/tests/proofs/cannon/init_test.go
+++ b/op-acceptance-tests/tests/proofs/cannon/init_test.go
@@ -1,0 +1,18 @@
+package cannon
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/compat"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+)
+
+func TestMain(m *testing.M) {
+	presets.DoMain(m,
+		presets.WithProofs(),
+		presets.WithJovianAtGenesis(),
+		presets.WithSafeDBEnabled(),
+		// Requires access to a challenger config which only sysgo provides
+		// These tests would also be exceptionally slow on real L1s
+		presets.WithCompatibleTypes(compat.SysGo))
+}

--- a/op-acceptance-tests/tests/proofs/cannon/init_test.go
+++ b/op-acceptance-tests/tests/proofs/cannon/init_test.go
@@ -3,7 +3,6 @@ package cannon
 import (
 	"testing"
 
-	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	"github.com/ethereum-optimism/optimism/op-devstack/compat"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 )
@@ -13,8 +12,6 @@ func TestMain(m *testing.M) {
 		presets.WithProofs(),
 		presets.WithJovianAtGenesis(),
 		presets.WithSafeDBEnabled(),
-		// Use a slow game type to be sure the anchor state doesn't update
-		presets.WithProposerGameType(faultTypes.PermissionedGameType),
 		// Requires access to a challenger config which only sysgo provides
 		// These tests would also be exceptionally slow on real L1s
 		presets.WithCompatibleTypes(compat.SysGo))

--- a/op-acceptance-tests/tests/proofs/cannon/init_test.go
+++ b/op-acceptance-tests/tests/proofs/cannon/init_test.go
@@ -3,6 +3,7 @@ package cannon
 import (
 	"testing"
 
+	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	"github.com/ethereum-optimism/optimism/op-devstack/compat"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 )
@@ -12,6 +13,8 @@ func TestMain(m *testing.M) {
 		presets.WithProofs(),
 		presets.WithJovianAtGenesis(),
 		presets.WithSafeDBEnabled(),
+		// Use a slow game type to be sure the anchor state doesn't update
+		presets.WithProposerGameType(faultTypes.PermissionedGameType),
 		// Requires access to a challenger config which only sysgo provides
 		// These tests would also be exceptionally slow on real L1s
 		presets.WithCompatibleTypes(compat.SysGo))

--- a/op-acceptance-tests/tests/proofs/cannon/step_test.go
+++ b/op-acceptance-tests/tests/proofs/cannon/step_test.go
@@ -4,10 +4,10 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl/proofs"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
-	"github.com/ethereum/go-ethereum/common"
 )
 
 func TestExecuteStep(gt *testing.T) {
@@ -18,10 +18,9 @@ func TestExecuteStep(gt *testing.T) {
 	blockNum := uint64(3)
 	sys.L2CL.Reached(types.LocalSafe, blockNum, 30)
 
-	game := sys.DisputeGameFactory().StartCannonGame(l1User)
-	claim := game.DisputeToL2SequenceNumber(l1User, game.RootClaim(), blockNum)
+	game := sys.DisputeGameFactory().StartCannonGame(l1User, proofs.WithL2SequenceNumber(blockNum))
+	claim := game.DisputeL2SequenceNumber(l1User, game.RootClaim(), blockNum)
 	game.LogGameData()
-	claim = claim.Attack(l1User, common.Hash{0x01, 0xba, 0xd0})
 	claim = claim.WaitForCounterClaim()             // Wait for the honest challenger to counter
 	claim = game.DisputeToStep(l1User, claim, 1000) // Skip down to max depth
 	game.LogGameData()

--- a/op-acceptance-tests/tests/proofs/cannon/step_test.go
+++ b/op-acceptance-tests/tests/proofs/cannon/step_test.go
@@ -1,0 +1,28 @@
+package cannon
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+func TestExecuteStep(gt *testing.T) {
+	t := devtest.ParallelT(gt)
+	sys := presets.NewMinimal(t)
+
+	l1User := sys.FunderL1.NewFundedEOA(eth.ThousandEther)
+	blockNum := uint64(3)
+	sys.L2CL.Reached(types.LocalSafe, blockNum, 30)
+
+	game := sys.DisputeGameFactory().StartCannonGame(l1User)
+	claim := game.DisputeToL2SequenceNumber(l1User, game.RootClaim(), blockNum)
+	game.LogGameData()
+	claim = claim.Attack(l1User, common.Hash{0x01, 0xba, 0xd0})
+	claim = claim.WaitForCounterClaim()             // Wait for the honest challenger to counter
+	claim = game.DisputeToStep(l1User, claim, 1000) // Skip down to max depth
+	game.LogGameData()
+}

--- a/op-acceptance-tests/tests/proofs/cannon/step_test.go
+++ b/op-acceptance-tests/tests/proofs/cannon/step_test.go
@@ -25,4 +25,5 @@ func TestExecuteStep(gt *testing.T) {
 	claim = claim.WaitForCounterClaim()             // Wait for the honest challenger to counter
 	claim = game.DisputeToStep(l1User, claim, 1000) // Skip down to max depth
 	game.LogGameData()
+	claim.WaitForCountered()
 }

--- a/op-devstack/dsl/proofs/claim.go
+++ b/op-devstack/dsl/proofs/claim.go
@@ -1,12 +1,14 @@
 package proofs
 
 import (
+	"context"
 	"fmt"
 	"math/big"
 	"slices"
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 
@@ -83,6 +85,19 @@ func (c *Claim) WaitForCounterClaim(ignoreClaims ...*Claim) *Claim {
 		return uint64(claim.ParentContractIndex) == c.Index && !containsClaim(claimIdx, ignoreClaims)
 	})
 	return newClaim(c.t, c.require, counterIdx, counterClaim, c.game)
+}
+
+// WaitForCountered waits until the claim is countered either by a child claim or by a step call.
+func (c *Claim) WaitForCountered() {
+	timedCtx, cancel := context.WithTimeout(c.t.Ctx(), defaultTimeout)
+	defer cancel()
+	err := wait.For(timedCtx, time.Second, func() (bool, error) {
+		claim := c.game.claimAtIndex(c.Index)
+		return claim.CounteredBy != common.Address{}, nil
+	})
+	if err != nil { // Avoid waiting time capturing game data when there's no error
+		c.require.NoErrorf(err, "Claim %v was not countered\n%v", c.Index, c.game.GameData())
+	}
 }
 
 func (c *Claim) VerifyNoCounterClaim() {

--- a/op-devstack/dsl/proofs/claim.go
+++ b/op-devstack/dsl/proofs/claim.go
@@ -2,9 +2,11 @@ package proofs
 
 import (
 	"fmt"
+	"math/big"
 	"slices"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 
@@ -43,12 +45,35 @@ func (c *Claim) Value() common.Hash {
 	return c.claim.Value
 }
 
+func (c *Claim) Bond() *big.Int {
+	return c.claim.Bond
+}
+
+func (c *Claim) Position() types.Position {
+	return c.claim.Position
+}
+
 func (c *Claim) Claimant() common.Address {
 	return c.claim.Claimant
 }
 
-func (c *Claim) Depth() uint64 {
-	return uint64(c.claim.Depth())
+func (c *Claim) Depth() types.Depth {
+	return c.claim.Depth()
+}
+
+func (c *Claim) AsChallengerClaim() types.Claim {
+	return types.Claim{
+		ClaimData: types.ClaimData{
+			Value:    c.claim.Value,
+			Bond:     c.claim.Bond,
+			Position: c.claim.Position,
+		},
+		CounteredBy:         c.claim.CounteredBy,
+		Claimant:            c.claim.Claimant,
+		Clock:               c.claim.Clock,
+		ContractIndex:       int(c.Index),
+		ParentContractIndex: int(c.claim.ParentContractIndex),
+	}
 }
 
 // WaitForCounterClaim waits for the claim to be countered by another claim being posted.

--- a/op-devstack/dsl/proofs/claim.go
+++ b/op-devstack/dsl/proofs/claim.go
@@ -111,6 +111,11 @@ func (c *Claim) Attack(eoa *dsl.EOA, newClaim common.Hash) *Claim {
 	return c.WaitForCounterClaim()
 }
 
+func (c *Claim) Defend(eoa *dsl.EOA, newClaim common.Hash) *Claim {
+	c.game.Defend(eoa, c.Index, newClaim)
+	return c.WaitForCounterClaim()
+}
+
 func containsClaim(claimIdx uint64, haystack []*Claim) bool {
 	return slices.ContainsFunc(haystack, func(candidate *Claim) bool {
 		return candidate.Index == claimIdx

--- a/op-devstack/dsl/proofs/claim.go
+++ b/op-devstack/dsl/proofs/claim.go
@@ -63,7 +63,7 @@ func (c *Claim) Depth() types.Depth {
 	return c.claim.Depth()
 }
 
-func (c *Claim) AsChallengerClaim() types.Claim {
+func (c *Claim) asChallengerClaim() types.Claim {
 	return types.Claim{
 		ClaimData: types.ClaimData{
 			Value:    c.claim.Value,

--- a/op-devstack/dsl/proofs/dispute_game_factory.go
+++ b/op-devstack/dsl/proofs/dispute_game_factory.go
@@ -40,6 +40,8 @@ type DisputeGameFactory struct {
 	supervisor    *dsl.Supervisor
 	gameHelper    *GameHelper
 	challengerCfg *challengerConfig.Config
+
+	honestTraces map[common.Address]challengerTypes.TraceAccessor
 }
 
 func NewDisputeGameFactory(
@@ -66,6 +68,8 @@ func NewDisputeGameFactory(
 		supervisor:    supervisor,
 		ethClient:     ethClient,
 		challengerCfg: challengerCfg,
+
+		honestTraces: make(map[common.Address]challengerTypes.TraceAccessor),
 	}
 }
 
@@ -204,6 +208,9 @@ func (f *DisputeGameFactory) StartCannonGame(eoa *dsl.EOA, opts ...GameOpt) *Fau
 }
 
 func (f *DisputeGameFactory) honestTraceForGame(game *FaultDisputeGame) challengerTypes.TraceAccessor {
+	if existing, ok := f.honestTraces[game.Address]; ok {
+		return existing
+	}
 	f.require.Equal(challengerTypes.CannonGameType, game.GameType(), "Honest trace only supported for cannon game types")
 	f.require.NotNil(f.challengerCfg, "Challenger config is required to create honest trace")
 	logger := f.t.Logger().New("role", "honestTrace")
@@ -231,6 +238,7 @@ func (f *DisputeGameFactory) honestTraceForGame(game *FaultDisputeGame) challeng
 		game.L2SequenceNumber(),
 	)
 	f.require.NoError(err, "Failed to create cannon trace accessor")
+	f.honestTraces[game.Address] = accessor
 	return accessor
 }
 

--- a/op-devstack/dsl/proofs/dispute_game_factory.go
+++ b/op-devstack/dsl/proofs/dispute_game_factory.go
@@ -70,10 +70,12 @@ func NewDisputeGameFactory(
 }
 
 type GameCfg struct {
-	allowFuture  bool
-	allowUnsafe  bool
-	rootClaimSet bool
-	rootClaim    common.Hash
+	allowFuture         bool
+	allowUnsafe         bool
+	l2SequenceNumber    uint64
+	l2SequenceNumberSet bool
+	rootClaimSet        bool
+	rootClaim           common.Hash
 }
 type GameOpt interface {
 	Apply(cfg *GameCfg)
@@ -100,6 +102,13 @@ func WithRootClaim(claim common.Hash) GameOpt {
 	return gameOptFn(func(c *GameCfg) {
 		c.rootClaim = claim
 		c.rootClaimSet = true
+	})
+}
+
+func WithL2SequenceNumber(seqNum uint64) GameOpt {
+	return gameOptFn(func(c *GameCfg) {
+		c.l2SequenceNumber = seqNum
+		c.l2SequenceNumberSet = true
 	})
 }
 
@@ -158,13 +167,16 @@ func (f *DisputeGameFactory) WaitForGame() *FaultDisputeGame {
 
 func (f *DisputeGameFactory) StartSuperCannonGame(eoa *dsl.EOA, opts ...GameOpt) *SuperFaultDisputeGame {
 	f.require.NotNil(f.supervisor, "supervisor is required to start super games")
-	proposalTimestamp := f.supervisor.FetchSyncStatus().SafeTimestamp
 
-	return f.startSuperCannonGameOfType(eoa, proposalTimestamp, challengerTypes.SuperCannonGameType, opts...)
+	return f.startSuperCannonGameOfType(eoa, challengerTypes.SuperCannonGameType, opts...)
 }
 
-func (f *DisputeGameFactory) startSuperCannonGameOfType(eoa *dsl.EOA, timestamp uint64, gameType challengerTypes.GameType, opts ...GameOpt) *SuperFaultDisputeGame {
+func (f *DisputeGameFactory) startSuperCannonGameOfType(eoa *dsl.EOA, gameType challengerTypes.GameType, opts ...GameOpt) *SuperFaultDisputeGame {
 	cfg := NewGameCfg(opts...)
+	timestamp := cfg.l2SequenceNumber
+	if !cfg.l2SequenceNumberSet {
+		timestamp = f.supervisor.FetchSyncStatus().SafeTimestamp
+	}
 	extraData := f.createSuperGameExtraData(timestamp, cfg)
 	rootClaim := cfg.rootClaim
 	if !cfg.rootClaimSet {
@@ -228,7 +240,10 @@ func (f *DisputeGameFactory) startOutputRootGameOfType(
 	honestTraceProvider func(game *FaultDisputeGame) challengerTypes.TraceAccessor,
 	opts ...GameOpt) *FaultDisputeGame {
 	cfg := NewGameCfg(opts...)
-	blockNum := f.l2CL.SafeL2BlockRef().Number
+	blockNum := cfg.l2SequenceNumber
+	if !cfg.l2SequenceNumberSet {
+		blockNum = f.l2CL.SafeL2BlockRef().Number
+	}
 	extraData := f.createOutputGameExtraData(blockNum, cfg)
 	rootClaim := cfg.rootClaim
 	if !cfg.rootClaimSet {

--- a/op-devstack/dsl/proofs/dispute_game_factory.go
+++ b/op-devstack/dsl/proofs/dispute_game_factory.go
@@ -10,7 +10,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/outputs"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/vm"
 	"github.com/ethereum-optimism/optimism/op-challenger/metrics"
-	"github.com/ethereum-optimism/optimism/op-devstack/stack/match"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	safetyTypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 	"github.com/ethereum/go-ethereum/common"
@@ -218,7 +217,7 @@ func (f *DisputeGameFactory) honestTraceForGame(game *FaultDisputeGame) challeng
 	rollupClient := f.l2CL.Escape().RollupAPI()
 	prestateProvider := outputs.NewPrestateProvider(rollupClient, prestateBlock)
 	l1HeadHash := game.L1Head()
-	l1Head, err := f.l1Network.Escape().L1ELNode(match.FirstL1EL).EthClient().BlockRefByHash(f.t.Ctx(), l1HeadHash)
+	l1Head, err := f.ethClient.BlockRefByHash(f.t.Ctx(), l1HeadHash)
 	f.require.NoError(err, "Failed to fetch L1 Head")
 
 	l2ElClient := f.l2EL.Escape().L2EthClient()

--- a/op-devstack/dsl/proofs/dispute_game_factory.go
+++ b/op-devstack/dsl/proofs/dispute_game_factory.go
@@ -1,11 +1,18 @@
 package proofs
 
 import (
+	"context"
 	"encoding/binary"
 	"math/big"
 	"time"
 
+	challengerConfig "github.com/ethereum-optimism/optimism/op-challenger/config"
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/outputs"
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/vm"
+	"github.com/ethereum-optimism/optimism/op-challenger/metrics"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack/match"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	safetyTypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
@@ -21,29 +28,44 @@ import (
 )
 
 type DisputeGameFactory struct {
-	t          devtest.T
-	require    *require.Assertions
-	log        log.Logger
-	l1Network  *dsl.L1Network
-	ethClient  apis.EthClient
-	dgf        *bindings.DisputeGameFactory
-	addr       common.Address
-	supervisor *dsl.Supervisor
-	gameHelper *GameHelper
+	t             devtest.T
+	require       *require.Assertions
+	log           log.Logger
+	l1Network     *dsl.L1Network
+	ethClient     apis.EthClient
+	dgf           *bindings.DisputeGameFactory
+	addr          common.Address
+	l2CL          *dsl.L2CLNode
+	l2EL          *dsl.L2ELNode
+	supervisor    *dsl.Supervisor
+	gameHelper    *GameHelper
+	challengerCfg *challengerConfig.Config
 }
 
-func NewDisputeGameFactory(t devtest.T, l1Network *dsl.L1Network, ethClient apis.EthClient, dgfAddr common.Address, supervisor *dsl.Supervisor) *DisputeGameFactory {
+func NewDisputeGameFactory(
+	t devtest.T,
+	l1Network *dsl.L1Network,
+	ethClient apis.EthClient,
+	dgfAddr common.Address,
+	l2CL *dsl.L2CLNode,
+	l2EL *dsl.L2ELNode,
+	supervisor *dsl.Supervisor,
+	challengerCfg *challengerConfig.Config,
+) *DisputeGameFactory {
 	dgf := bindings.NewDisputeGameFactory(bindings.WithClient(ethClient), bindings.WithTo(dgfAddr), bindings.WithTest(t))
 
 	return &DisputeGameFactory{
-		t:          t,
-		require:    require.New(t),
-		log:        t.Logger(),
-		l1Network:  l1Network,
-		dgf:        dgf,
-		addr:       dgfAddr,
-		supervisor: supervisor,
-		ethClient:  ethClient,
+		t:             t,
+		require:       require.New(t),
+		log:           t.Logger(),
+		l1Network:     l1Network,
+		dgf:           dgf,
+		addr:          dgfAddr,
+		l2CL:          l2CL,
+		l2EL:          l2EL,
+		supervisor:    supervisor,
+		ethClient:     ethClient,
+		challengerCfg: challengerCfg,
 	}
 }
 
@@ -97,7 +119,7 @@ func (f *DisputeGameFactory) getGameHelper(eoa *dsl.EOA) *GameHelper {
 	if f.gameHelper != nil {
 		return f.gameHelper
 	}
-	gs := DeployGameHelper(f.t, eoa)
+	gs := DeployGameHelper(f.t, eoa, f.honestTraceForGame)
 	f.gameHelper = gs
 	return gs
 }
@@ -109,13 +131,13 @@ func (f *DisputeGameFactory) GameCount() int64 {
 func (f *DisputeGameFactory) GameAtIndex(idx int64) *FaultDisputeGame {
 	gameInfo := contract.Read(f.dgf.GameAtIndex(big.NewInt(idx)))
 	game := bindings.NewFaultDisputeGame(bindings.WithClient(f.ethClient), bindings.WithTo(gameInfo.Proxy), bindings.WithTest(f.t))
-	return NewFaultDisputeGame(f.t, f.require, gameInfo.Proxy, f.getGameHelper, game)
+	return NewFaultDisputeGame(f.t, f.require, gameInfo.Proxy, f.getGameHelper, f.honestTraceForGame, game)
 }
 
 func (f *DisputeGameFactory) GameImpl(gameType challengerTypes.GameType) *FaultDisputeGame {
 	implAddr := contract.Read(f.dgf.GameImpls(uint32(gameType)))
 	game := bindings.NewFaultDisputeGame(bindings.WithClient(f.ethClient), bindings.WithTo(implAddr), bindings.WithTest(f.t))
-	return NewFaultDisputeGame(f.t, f.require, implAddr, f.getGameHelper, game)
+	return NewFaultDisputeGame(f.t, f.require, implAddr, f.getGameHelper, f.honestTraceForGame, game)
 }
 
 func (f *DisputeGameFactory) GameArgs(gameType challengerTypes.GameType) []byte {
@@ -165,6 +187,70 @@ func (f *DisputeGameFactory) createSuperGameExtraData(timestamp uint64, cfg *Gam
 	return extraData
 }
 
+func (f *DisputeGameFactory) StartCannonGame(eoa *dsl.EOA, opts ...GameOpt) *FaultDisputeGame {
+	return f.startOutputRootGameOfType(eoa, challengerTypes.CannonGameType, f.honestTraceForGame, opts...)
+}
+
+func (f *DisputeGameFactory) honestTraceForGame(game *FaultDisputeGame) challengerTypes.TraceAccessor {
+	f.require.Equal(challengerTypes.CannonGameType, game.GameType(), "Honest trace only supported for cannon game types")
+	f.require.NotNil(f.challengerCfg, "Challenger config is required to create honest trace")
+	logger := f.t.Logger().New("role", "honestTrace")
+	prestateBlock := game.StartingL2SequenceNumber()
+	rollupClient := f.l2CL.Escape().RollupAPI()
+	prestateProvider := outputs.NewPrestateProvider(rollupClient, prestateBlock)
+	l1HeadHash := game.L1Head()
+	l1Head, err := f.l1Network.Escape().L1ELNode(match.FirstL1EL).EthClient().BlockRefByHash(f.t.Ctx(), l1HeadHash)
+	f.require.NoError(err, "Failed to fetch L1 Head")
+
+	l2ElClient := f.l2EL.Escape().L2EthClient()
+	accessor, err := outputs.NewOutputCannonTraceAccessor(
+		logger,
+		metrics.NoopMetrics,
+		f.challengerCfg.Cannon,
+		vm.NewOpProgramServerExecutor(logger),
+		&ethClientHeaderProvider{client: l2ElClient},
+		prestateProvider,
+		f.challengerCfg.CannonAbsolutePreState,
+		rollupClient,
+		f.t.TempDir(),
+		l1Head.ID(),
+		game.SplitDepth(),
+		prestateBlock,
+		game.L2SequenceNumber(),
+	)
+	f.require.NoError(err, "Failed to create cannon trace accessor")
+	return accessor
+}
+
+func (f *DisputeGameFactory) startOutputRootGameOfType(
+	eoa *dsl.EOA,
+	gameType challengerTypes.GameType,
+	honestTraceProvider func(game *FaultDisputeGame) challengerTypes.TraceAccessor,
+	opts ...GameOpt) *FaultDisputeGame {
+	cfg := NewGameCfg(opts...)
+	blockNum := f.l2CL.SafeL2BlockRef().Number
+	extraData := f.createOutputGameExtraData(blockNum, cfg)
+	rootClaim := cfg.rootClaim
+	if !cfg.rootClaimSet {
+		// Default to correct root claim
+		response, err := f.l2CL.Escape().RollupAPI().OutputAtBlock(f.t.Ctx(), blockNum)
+		f.require.NoErrorf(err, "Failed to get output root at block %v", blockNum)
+		rootClaim = common.Hash(response.OutputRoot)
+	}
+	game, addr := f.createNewGame(eoa, gameType, rootClaim, extraData)
+	return NewFaultDisputeGame(f.t, f.require, addr, f.getGameHelper, honestTraceProvider, game)
+}
+
+func (f *DisputeGameFactory) createOutputGameExtraData(blockNum uint64, cfg *GameCfg) []byte {
+	f.require.NotNil(f.l2CL, "L2 CL is required create output games")
+	if !cfg.allowFuture {
+		f.l2CL.Reached(safetyTypes.LocalSafe, blockNum, 30)
+	}
+	extraData := make([]byte, 32)
+	binary.BigEndian.PutUint64(extraData[24:], blockNum)
+	return extraData
+}
+
 func (f *DisputeGameFactory) createNewGame(eoa *dsl.EOA, gameType challengerTypes.GameType, claim common.Hash, extraData []byte) (*bindings.FaultDisputeGame, common.Address) {
 	f.log.Info("Creating dispute game", "gameType", gameType, "claim", claim.Hex(), "extradata", common.Bytes2Hex(extraData))
 
@@ -208,4 +294,18 @@ func (a *GameHelperEOA) PerformMoves(game *FaultDisputeGame, moves ...GameHelper
 
 func (a *GameHelperEOA) Address() common.Address {
 	return a.EOA.Address()
+}
+
+// ethClientHeaderProvider is an adapter for the L1Client interface used in op-node and devstack to
+// the HeaderProvider interface used in challenger
+type ethClientHeaderProvider struct {
+	client apis.EthClient
+}
+
+func (p *ethClientHeaderProvider) HeaderByNumber(ctx context.Context, blockNum *big.Int) (*types.Header, error) {
+	info, err := p.client.InfoByNumber(ctx, blockNum.Uint64())
+	if err != nil {
+		return nil, err
+	}
+	return info.Header(), nil
 }

--- a/op-devstack/dsl/proofs/fault_dispute_game.go
+++ b/op-devstack/dsl/proofs/fault_dispute_game.go
@@ -101,6 +101,7 @@ func (g *FaultDisputeGame) Attack(eoa *dsl.EOA, claimIdx uint64, newClaim common
 func (g *FaultDisputeGame) Defend(eoa *dsl.EOA, claimIdx uint64, newClaim common.Hash) {
 	claim := g.claimAtIndex(claimIdx)
 	g.t.Logf("Defending claim %v (depth: %d) with counter-claim %v", claimIdx, claim.Position.Depth(), newClaim)
+	g.require.False(claim.IsRootPosition(), "Cannot defend the root claim")
 
 	requiredBond := g.requiredBond(claim.Position.Defend())
 

--- a/op-devstack/dsl/proofs/fault_dispute_game.go
+++ b/op-devstack/dsl/proofs/fault_dispute_game.go
@@ -163,7 +163,6 @@ func (g *FaultDisputeGame) waitForClaim(timeout time.Duration, errorMsg string, 
 		}
 		return false, nil
 	})
-	g.require.NoError(err, errorMsg)
 	if err != nil { // Avoid waiting time capturing game data when there's no error
 		g.require.NoErrorf(err, "%v\n%v", errorMsg, g.GameData())
 	}

--- a/op-devstack/dsl/proofs/fault_dispute_game.go
+++ b/op-devstack/dsl/proofs/fault_dispute_game.go
@@ -24,42 +24,66 @@ import (
 type gameHelperProvider func(deployer *dsl.EOA) *GameHelper
 
 type FaultDisputeGame struct {
-	t              devtest.T
-	require        *require.Assertions
-	game           *bindings.FaultDisputeGame
-	Address        common.Address
-	helperProvider gameHelperProvider
+	t                   devtest.T
+	require             *require.Assertions
+	game                *bindings.FaultDisputeGame
+	Address             common.Address
+	helperProvider      gameHelperProvider
+	honestTraceProvider func() challengerTypes.TraceAccessor
 }
 
-func NewFaultDisputeGame(t devtest.T, require *require.Assertions, addr common.Address, helperProvider gameHelperProvider, game *bindings.FaultDisputeGame) *FaultDisputeGame {
-	return &FaultDisputeGame{
+func NewFaultDisputeGame(
+	t devtest.T,
+	require *require.Assertions,
+	addr common.Address,
+	helperProvider gameHelperProvider,
+	honestTrace func(game *FaultDisputeGame) challengerTypes.TraceAccessor,
+	game *bindings.FaultDisputeGame,
+) *FaultDisputeGame {
+	fdg := &FaultDisputeGame{
 		t:              t,
 		require:        require,
 		game:           game,
 		Address:        addr,
 		helperProvider: helperProvider,
 	}
+	fdg.honestTraceProvider = func() challengerTypes.TraceAccessor {
+		return honestTrace(fdg)
+	}
+	return fdg
+}
+
+func (g *FaultDisputeGame) GameType() challengerTypes.GameType {
+	return challengerTypes.GameType(contract.Read(g.game.GameType()))
 }
 
 func (g *FaultDisputeGame) MaxDepth() challengerTypes.Depth {
 	return challengerTypes.Depth(contract.Read(g.game.MaxGameDepth()).Uint64())
 }
 
-func (g *FaultDisputeGame) SplitDepth() uint64 {
-	return contract.Read(g.game.SplitDepth()).Uint64()
+func (g *FaultDisputeGame) SplitDepth() challengerTypes.Depth {
+	return challengerTypes.Depth(contract.Read(g.game.SplitDepth()).Uint64())
 }
 
 func (g *FaultDisputeGame) RootClaim() *Claim {
 	return g.ClaimAtIndex(0)
 }
 
-func (g *FaultDisputeGame) L2SequenceNumber() *big.Int {
-	return contract.Read(g.game.L2SequenceNumber())
+func (g *FaultDisputeGame) L2SequenceNumber() uint64 {
+	return contract.Read(g.game.L2SequenceNumber()).Uint64()
+}
+
+func (g *FaultDisputeGame) StartingL2SequenceNumber() uint64 {
+	return contract.Read(g.game.StartingBlockNumber())
 }
 
 func (g *FaultDisputeGame) ClaimAtIndex(claimIndex uint64) *Claim {
 	claim := g.claimAtIndex(claimIndex)
 	return g.newClaim(claimIndex, claim)
+}
+
+func (g *FaultDisputeGame) L1Head() common.Hash {
+	return contract.Read(g.game.L1Head())
 }
 
 func (g *FaultDisputeGame) Attack(eoa *dsl.EOA, claimIdx uint64, newClaim common.Hash) {
@@ -76,6 +100,14 @@ func (g *FaultDisputeGame) Attack(eoa *dsl.EOA, claimIdx uint64, newClaim common
 
 func (g *FaultDisputeGame) PerformMoves(eoa *dsl.EOA, moves ...GameHelperMove) []*Claim {
 	return g.helperProvider(eoa).PerformMoves(eoa, g, moves)
+}
+
+func (g *FaultDisputeGame) DisputeToL2SequenceNumber(eoa *dsl.EOA, startClaim *Claim, l2SequenceNumber uint64) *Claim {
+	return g.helperProvider(eoa).DisputeToL2SequenceNumber(eoa, g, startClaim, l2SequenceNumber)
+}
+
+func (g *FaultDisputeGame) DisputeToStep(eoa *dsl.EOA, startClaim *Claim, traceIndex uint64) *Claim {
+	return g.helperProvider(eoa).DisputeToStep(eoa, g, startClaim, traceIndex)
 }
 
 func (g *FaultDisputeGame) requiredBond(pos challengerTypes.Position) eth.ETH {

--- a/op-devstack/dsl/proofs/fault_dispute_game.go
+++ b/op-devstack/dsl/proofs/fault_dispute_game.go
@@ -98,12 +98,24 @@ func (g *FaultDisputeGame) Attack(eoa *dsl.EOA, claimIdx uint64, newClaim common
 	g.t.Require().Equal(receipt.Status, types.ReceiptStatusSuccessful)
 }
 
+func (g *FaultDisputeGame) Defend(eoa *dsl.EOA, claimIdx uint64, newClaim common.Hash) {
+	claim := g.claimAtIndex(claimIdx)
+	g.t.Logf("Defending claim %v (depth: %d) with counter-claim %v", claimIdx, claim.Position.Depth(), newClaim)
+
+	requiredBond := g.requiredBond(claim.Position.Defend())
+
+	defendCall := g.game.Defend(claim.Value, new(big.Int).SetUint64(claimIdx), newClaim)
+
+	receipt := contract.Write(eoa, defendCall, txplan.WithValue(requiredBond), txplan.WithGasRatio(2))
+	g.t.Require().Equal(receipt.Status, types.ReceiptStatusSuccessful)
+}
+
 func (g *FaultDisputeGame) PerformMoves(eoa *dsl.EOA, moves ...GameHelperMove) []*Claim {
 	return g.helperProvider(eoa).PerformMoves(eoa, g, moves)
 }
 
-func (g *FaultDisputeGame) DisputeToL2SequenceNumber(eoa *dsl.EOA, startClaim *Claim, l2SequenceNumber uint64) *Claim {
-	return g.helperProvider(eoa).DisputeToL2SequenceNumber(eoa, g, startClaim, l2SequenceNumber)
+func (g *FaultDisputeGame) DisputeL2SequenceNumber(eoa *dsl.EOA, startClaim *Claim, l2SequenceNumber uint64) *Claim {
+	return g.helperProvider(eoa).DisputeL2SequenceNumber(eoa, g, startClaim, l2SequenceNumber)
 }
 
 func (g *FaultDisputeGame) DisputeToStep(eoa *dsl.EOA, startClaim *Claim, traceIndex uint64) *Claim {

--- a/op-devstack/dsl/proofs/game_helper.go
+++ b/op-devstack/dsl/proofs/game_helper.go
@@ -165,26 +165,41 @@ func (gs *GameHelper) CreateGameWithClaims(
 	return receipt.ContractAddress
 }
 
-func (gs *GameHelper) DisputeToL2SequenceNumber(eoa *dsl.EOA, game *FaultDisputeGame, startClaim *Claim, l2SequenceNumber uint64) *Claim {
+func (gs *GameHelper) DisputeL2SequenceNumber(eoa *dsl.EOA, game *FaultDisputeGame, startClaim *Claim, l2SequenceNumber uint64) *Claim {
 	splitDepth := game.SplitDepth()
 	startingSeqNumber := game.StartingL2SequenceNumber()
 	gs.require.Greater(l2SequenceNumber, startingSeqNumber, "Cannot dispute things at or prior to the starting block")
+	seqNumAtPosition := func(pos challengerTypes.Position) uint64 {
+		return pos.TraceIndex(splitDepth).Uint64() + startingSeqNumber + 1
+	}
 	shouldMoveLeftFrom := func(pos challengerTypes.Position) bool {
 		// Move left when equal to the sequence number so that we disagree with it
-		return pos.TraceIndex(splitDepth).Uint64()+startingSeqNumber+1 >= l2SequenceNumber
+		return seqNumAtPosition(pos) >= l2SequenceNumber
 	}
-	finalClaim := gs.disputeTo(eoa, game, startClaim, splitDepth, shouldMoveLeftFrom)
+	finalClaim, gameState := gs.disputeTo(eoa, game, startClaim, splitDepth, shouldMoveLeftFrom)
 
 	// Check that we landed in the right place
 	// We can only land on every second sequence number, starting from startingSeqNumber+1
 	// And we want to land on the sequence number that's either equal to or one before l2SequenceNumber
 	// If it's equal to we would attack, if it's the one before we would defend to ensure the bottom
 	// half of the game is executing l2SequenceNumber.
-	traceIndex := finalClaim.Position().TraceIndex(splitDepth)
+	finalPosition := seqNumAtPosition(finalClaim.Position())
 	if l2SequenceNumber%2 == startingSeqNumber%2 {
-		gs.require.Equal(l2SequenceNumber-1, traceIndex.Uint64()+startingSeqNumber+1)
+		gs.require.Equal(l2SequenceNumber-1, finalPosition)
+		// When defending the required status code depends on whether we provided the next trace or not.
+		disputedClaim, found := gameState.AncestorWithTraceIndex(finalClaim.asChallengerClaim(), finalClaim.Position().MoveRight().TraceIndex(game.MaxDepth()))
+		gs.require.True(found, "Did not find ancestor at target trace index")
+		statusCode := byte(0x00)
+		if disputedClaim.Position.Depth()%2 == splitDepth%2 {
+			statusCode = byte(0x01)
+		}
+		gs.t.Logf("Defend at split depth with status code %v", statusCode)
+		finalClaim = finalClaim.Defend(eoa, common.Hash{statusCode, 0xba, 0xd0})
 	} else {
-		gs.require.Equal(l2SequenceNumber, traceIndex.Uint64()+startingSeqNumber+1)
+		gs.t.Log("Attack at split depth")
+		gs.require.Equal(l2SequenceNumber, finalPosition)
+		// When attacking, the final block must be invalid so always use 0x01 as status code
+		finalClaim = finalClaim.Attack(eoa, common.Hash{0x01, 0xba, 0xd0})
 	}
 	return finalClaim
 }
@@ -204,7 +219,7 @@ func (gs *GameHelper) DisputeToStep(eoa *dsl.EOA, game *FaultDisputeGame, startC
 		// Move left when equal to the trace index so that we disagree with it
 		return traceIndexAtPosition(pos) >= traceIndex
 	}
-	finalClaim := gs.disputeTo(eoa, game, startClaim, maxDepth, shouldMoveLeftFrom)
+	finalClaim, _ := gs.disputeTo(eoa, game, startClaim, maxDepth, shouldMoveLeftFrom)
 	// Check that we landed in the right place
 	// We can only land on every second sequence number, starting from startingSeqNumber+1
 	// And we want to land on the sequence number that's either equal to or one before l2SequenceNumber
@@ -219,9 +234,8 @@ func (gs *GameHelper) DisputeToStep(eoa *dsl.EOA, game *FaultDisputeGame, startC
 	return finalClaim
 }
 
-func (gs *GameHelper) disputeTo(eoa *dsl.EOA, game *FaultDisputeGame, startClaim *Claim, targetDepth challengerTypes.Depth, shouldMoveLeftFrom func(pos challengerTypes.Position) bool) *Claim {
+func (gs *GameHelper) disputeTo(eoa *dsl.EOA, game *FaultDisputeGame, startClaim *Claim, targetDepth challengerTypes.Depth, shouldMoveLeftFrom func(pos challengerTypes.Position) bool) (*Claim, challengerTypes.Game) {
 	honestTrace := gs.honestTraceProvider(game)
-	splitDepth := game.SplitDepth()
 	maxDepth := game.MaxDepth()
 	parentIdx := int64(startClaim.Index)
 	moves := make([]GameHelperMove, 0, targetDepth)
@@ -245,10 +259,6 @@ func (gs *GameHelper) disputeTo(eoa *dsl.EOA, game *FaultDisputeGame, startClaim
 			value, err := honestTrace.Get(gs.t.Ctx(), gameState, startClaim.asChallengerClaim(), nextPos)
 			gs.require.NoError(err, "Failed to get trace value at position %v", nextPos)
 			claimValue = value
-		} else if nextPos.Depth() == splitDepth+1 {
-			// Invalid claims countering the split depth must still start with the expected status code
-			// Note: this is not a complete implementation, if we are defending our own claim we need to use 0x0
-			claimValue[0] = 0x01
 		}
 		nextMove := Move(parentIdx, claimValue, shouldAttack)
 
@@ -269,7 +279,7 @@ func (gs *GameHelper) disputeTo(eoa *dsl.EOA, game *FaultDisputeGame, startClaim
 		parentIdx++
 	}
 	addedClaims := gs.PerformMoves(eoa, game, moves)
-	return addedClaims[len(addedClaims)-1]
+	return addedClaims[len(addedClaims)-1], gameState
 }
 
 func allChallengerClaims(game *FaultDisputeGame) []challengerTypes.Claim {

--- a/op-devstack/dsl/proofs/game_helper.go
+++ b/op-devstack/dsl/proofs/game_helper.go
@@ -3,6 +3,7 @@ package proofs
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"math/big"
 	"os"
 	"path/filepath"
@@ -32,13 +33,14 @@ type contractArtifactData struct {
 }
 
 type GameHelper struct {
-	t            devtest.T
-	require      *require.Assertions
-	contractAddr common.Address
-	abi          abi.ABI
+	t                   devtest.T
+	require             *require.Assertions
+	contractAddr        common.Address
+	abi                 abi.ABI
+	honestTraceProvider func(game *FaultDisputeGame) challengerTypes.TraceAccessor
 }
 
-func DeployGameHelper(t devtest.T, deployer *dsl.EOA) *GameHelper {
+func DeployGameHelper(t devtest.T, deployer *dsl.EOA, honestTraceProvider func(game *FaultDisputeGame) challengerTypes.TraceAccessor) *GameHelper {
 	req := require.New(t)
 
 	artifactData := getGameHelperArtifactData(t)
@@ -66,10 +68,11 @@ func DeployGameHelper(t devtest.T, deployer *dsl.EOA) *GameHelper {
 	t.Logf("GameHelper contract deployed at: %s", contractAddr.Hex())
 
 	return &GameHelper{
-		t:            t,
-		require:      require.New(t),
-		contractAddr: contractAddr,
-		abi:          artifactData.ABI,
+		t:                   t,
+		require:             require.New(t),
+		contractAddr:        contractAddr,
+		abi:                 artifactData.ABI,
+		honestTraceProvider: honestTraceProvider,
 	}
 }
 
@@ -124,10 +127,11 @@ func (gs *GameHelper) AuthEOA(eoa *dsl.EOA) *GameHelper {
 	gs.require.NoError(err)
 	gs.require.Equal(types.ReceiptStatusSuccessful, receipt.Status)
 	return &GameHelper{
-		t:            gs.t,
-		require:      require.New(gs.t),
-		contractAddr: eoa.Address(),
-		abi:          gs.abi,
+		t:                   gs.t,
+		require:             require.New(gs.t),
+		contractAddr:        eoa.Address(),
+		abi:                 gs.abi,
+		honestTraceProvider: gs.honestTraceProvider,
 	}
 }
 
@@ -161,7 +165,124 @@ func (gs *GameHelper) CreateGameWithClaims(
 	return receipt.ContractAddress
 }
 
+func (gs *GameHelper) DisputeToL2SequenceNumber(eoa *dsl.EOA, game *FaultDisputeGame, startClaim *Claim, l2SequenceNumber uint64) *Claim {
+	splitDepth := game.SplitDepth()
+	startingSeqNumber := game.StartingL2SequenceNumber()
+	gs.require.Greater(l2SequenceNumber, startingSeqNumber, "Cannot dispute things at or prior to the starting block")
+	shouldMoveLeftFrom := func(pos challengerTypes.Position) bool {
+		// Move left when equal to the sequence number so that we disagree with it
+		return pos.TraceIndex(splitDepth).Uint64()+startingSeqNumber+1 >= l2SequenceNumber
+	}
+	finalClaim := gs.disputeTo(eoa, game, startClaim, splitDepth, shouldMoveLeftFrom)
+
+	// Check that we landed in the right place
+	// We can only land on every second sequence number, starting from startingSeqNumber+1
+	// And we want to land on the sequence number that's either equal to or one before l2SequenceNumber
+	// If it's equal to we would attack, if it's the one before we would defend to ensure the bottom
+	// half of the game is executing l2SequenceNumber.
+	traceIndex := finalClaim.Position().TraceIndex(splitDepth)
+	if l2SequenceNumber%2 == startingSeqNumber%2 {
+		gs.require.Equal(l2SequenceNumber-1, traceIndex.Uint64()+startingSeqNumber+1)
+	} else {
+		gs.require.Equal(l2SequenceNumber, traceIndex.Uint64()+startingSeqNumber+1)
+	}
+	return finalClaim
+}
+
+func (gs *GameHelper) DisputeToStep(eoa *dsl.EOA, game *FaultDisputeGame, startClaim *Claim, traceIndex uint64) *Claim {
+	splitDepth := game.SplitDepth()
+	maxDepth := game.MaxDepth()
+	if startClaim.Depth() < splitDepth {
+		gs.require.Greater(startClaim.Depth(), splitDepth, "Start claim must be past the game split depth")
+	}
+	traceIndexAtPosition := func(pos challengerTypes.Position) uint64 {
+		relativeFinalPosition, err := pos.RelativeToAncestorAtDepth(splitDepth + 1)
+		gs.require.NoError(err, "Failed to calculate relative position")
+		return relativeFinalPosition.TraceIndex(maxDepth - splitDepth - 1).Uint64()
+	}
+	shouldMoveLeftFrom := func(pos challengerTypes.Position) bool {
+		// Move left when equal to the trace index so that we disagree with it
+		return traceIndexAtPosition(pos) >= traceIndex
+	}
+	finalClaim := gs.disputeTo(eoa, game, startClaim, maxDepth, shouldMoveLeftFrom)
+	// Check that we landed in the right place
+	// We can only land on every second sequence number, starting from startingSeqNumber+1
+	// And we want to land on the sequence number that's either equal to or one before l2SequenceNumber
+	// If it's equal to we would attack, if it's the one before we would defend to ensure the bottom
+	// half of the game is executing l2SequenceNumber.
+	finalTraceIndex := traceIndexAtPosition(finalClaim.Position())
+	if traceIndex%2 == 1 {
+		gs.require.Equal(traceIndex-1, finalTraceIndex)
+	} else {
+		gs.require.Equal(traceIndex, finalTraceIndex)
+	}
+	return finalClaim
+}
+
+func (gs *GameHelper) disputeTo(eoa *dsl.EOA, game *FaultDisputeGame, startClaim *Claim, targetDepth challengerTypes.Depth, shouldMoveLeftFrom func(pos challengerTypes.Position) bool) *Claim {
+	honestTrace := gs.honestTraceProvider(game)
+	splitDepth := game.SplitDepth()
+	maxDepth := game.MaxDepth()
+	parentIdx := int64(startClaim.Index)
+	moves := make([]GameHelperMove, 0, targetDepth)
+	currentPos := startClaim.Position()
+	claims := allChallengerClaims(game)
+	gameState := challengerTypes.NewGameState(claims, maxDepth)
+	honestRootClaim, err := honestTrace.Get(gs.t.Ctx(), gameState, claims[0], challengerTypes.RootPosition)
+	gs.require.NoError(err, "Failed to get honest root claim")
+	agreeWithRoot := claims[0].Value == honestRootClaim
+	for currentPos.Depth() < targetDepth {
+		shouldAttack := shouldMoveLeftFrom(currentPos)
+		nextPos := currentPos.Defend()
+		if shouldAttack {
+			nextPos = currentPos.Attack()
+		}
+		claimValue := common.Hash{0xba, 0xd0}
+		gs.t.Logf("Disputing claim %v at depth %v with claim at depth %v", parentIdx, currentPos.Depth(), nextPos.Depth())
+		if !shouldMoveLeftFrom(nextPos) || !gameState.AgreeWithClaimLevel(claims[len(claims)-1], agreeWithRoot) {
+			// Either we needed the honest actor to move right (defend) after this move or we are the honest actor
+			// so make sure we use an honest claim value.
+			value, err := honestTrace.Get(gs.t.Ctx(), gameState, startClaim.AsChallengerClaim(), nextPos)
+			gs.require.NoError(err, "Failed to get trace value at position %v", nextPos)
+			claimValue = value
+		} else if nextPos.Depth() == splitDepth+1 {
+			// Invalid claims countering the split depth must still start with the expected status code
+			// Note: this is not a complete implementation, if we are defending our own claim we need to use 0x0
+			claimValue[0] = 0x01
+		}
+		nextMove := Move(parentIdx, claimValue, shouldAttack)
+
+		moves = append(moves, nextMove)
+		claims = append(claims, challengerTypes.Claim{
+			ClaimData: challengerTypes.ClaimData{
+				Value:    nextMove.Claim,
+				Bond:     big.NewInt(0),
+				Position: nextPos,
+			},
+			Claimant:            eoa.Address(),
+			Clock:               challengerTypes.Clock{},
+			ContractIndex:       int(parentIdx + 1),
+			ParentContractIndex: int(parentIdx),
+		})
+		gameState = challengerTypes.NewGameState(claims, maxDepth)
+		currentPos = nextPos
+		parentIdx++
+	}
+	addedClaims := gs.PerformMoves(eoa, game, moves)
+	return addedClaims[len(addedClaims)-1]
+}
+
+func allChallengerClaims(game *FaultDisputeGame) []challengerTypes.Claim {
+	claims := game.allClaims()
+	challengerClaims := make([]challengerTypes.Claim, len(claims))
+	for i, claim := range claims {
+		challengerClaims[i] = game.newClaim(uint64(i), claim).AsChallengerClaim()
+	}
+	return challengerClaims
+}
+
 func (gs *GameHelper) PerformMoves(eoa *dsl.EOA, game *FaultDisputeGame, moves []GameHelperMove) []*Claim {
+	gs.t.Log("Performing moves: \n" + describeMoves(moves))
 	data, err := gs.abi.Pack("performMoves", game.Address, moves)
 	gs.require.NoError(err)
 
@@ -196,19 +317,39 @@ func (gs *GameHelper) PerformMoves(eoa *dsl.EOA, game *FaultDisputeGame, moves [
 	return claims
 }
 
+func describeMoves(moves []GameHelperMove) string {
+	description := ""
+	for _, move := range moves {
+		moveType := "Defend"
+		if move.Attack {
+			moveType = "Attack"
+		}
+		description += fmt.Sprintf("%s claim %s, value %s\n", moveType, move.ParentIdx, move.Claim)
+	}
+	return description
+}
+
 func (gs *GameHelper) totalMoveBonds(game *FaultDisputeGame, moves []GameHelperMove) eth.ETH {
 	claimPositions := map[uint64]challengerTypes.Position{
-		0: challengerTypes.RootPosition,
+		0: challengerTypes.RootPosition, // The claim at index 0 is always in the root position
 	}
+	preExistingClaimCount := game.claimCount()
 	totalBond := eth.Ether(0)
 	for i, move := range moves {
 		parentPos := claimPositions[move.ParentIdx.Uint64()]
-		gs.require.NotEmpty(parentPos, "Move references non-existent parent - may be out of order")
+		if parentPos == (challengerTypes.Position{}) {
+			gs.require.LessOrEqual(move.ParentIdx.Uint64(), preExistingClaimCount, "No parent position found - moves may be out of order")
+			// Handle cases were there are existing claims and we're adding moves that reference them
+			gs.t.Logf("Loading parent position for existing claim at index %v", move.ParentIdx)
+			parentClaim := game.ClaimAtIndex(move.ParentIdx.Uint64())
+			parentPos = parentClaim.Position()
+			claimPositions[move.ParentIdx.Uint64()] = parentPos
+		}
 		childPos := parentPos.Defend()
 		if move.Attack {
 			childPos = parentPos.Attack()
 		}
-		claimPositions[uint64(i)+1] = childPos
+		claimPositions[uint64(i)+preExistingClaimCount] = childPos
 		bond := game.requiredBond(childPos)
 		totalBond = totalBond.Add(bond)
 	}

--- a/op-devstack/dsl/proofs/game_helper.go
+++ b/op-devstack/dsl/proofs/game_helper.go
@@ -242,7 +242,7 @@ func (gs *GameHelper) disputeTo(eoa *dsl.EOA, game *FaultDisputeGame, startClaim
 		if !shouldMoveLeftFrom(nextPos) || !gameState.AgreeWithClaimLevel(claims[len(claims)-1], agreeWithRoot) {
 			// Either we needed the honest actor to move right (defend) after this move or we are the honest actor
 			// so make sure we use an honest claim value.
-			value, err := honestTrace.Get(gs.t.Ctx(), gameState, startClaim.AsChallengerClaim(), nextPos)
+			value, err := honestTrace.Get(gs.t.Ctx(), gameState, startClaim.asChallengerClaim(), nextPos)
 			gs.require.NoError(err, "Failed to get trace value at position %v", nextPos)
 			claimValue = value
 		} else if nextPos.Depth() == splitDepth+1 {
@@ -276,7 +276,7 @@ func allChallengerClaims(game *FaultDisputeGame) []challengerTypes.Claim {
 	claims := game.allClaims()
 	challengerClaims := make([]challengerTypes.Claim, len(claims))
 	for i, claim := range claims {
-		challengerClaims[i] = game.newClaim(uint64(i), claim).AsChallengerClaim()
+		challengerClaims[i] = game.newClaim(uint64(i), claim).asChallengerClaim()
 	}
 	return challengerClaims
 }

--- a/op-devstack/dsl/proofs/super_fault_dispute_game.go
+++ b/op-devstack/dsl/proofs/super_fault_dispute_game.go
@@ -1,6 +1,8 @@
 package proofs
 
 import (
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl/contract"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 
@@ -13,8 +15,16 @@ type SuperFaultDisputeGame struct {
 }
 
 func NewSuperFaultDisputeGame(t devtest.T, require *require.Assertions, addr common.Address, helperProvider gameHelperProvider, game *bindings.FaultDisputeGame) *SuperFaultDisputeGame {
-	fdg := NewFaultDisputeGame(t, require, addr, helperProvider, game)
+	honestTraceProvider := func(_ *FaultDisputeGame) types.TraceAccessor {
+		require.Fail("Honest trace not supported for super games")
+		return nil
+	}
+	fdg := NewFaultDisputeGame(t, require, addr, helperProvider, honestTraceProvider, game)
 	return &SuperFaultDisputeGame{
 		FaultDisputeGame: fdg,
 	}
+}
+
+func (g *SuperFaultDisputeGame) StartingL2SequenceNumber() uint64 {
+	return contract.Read(g.game.StartingSequenceNumber())
 }

--- a/op-devstack/presets/interop.go
+++ b/op-devstack/presets/interop.go
@@ -114,7 +114,7 @@ func (s *SimpleInterop) L2Networks() []*dsl.L2Network {
 }
 
 func (s *SimpleInterop) DisputeGameFactory() *proofs.DisputeGameFactory {
-	return proofs.NewDisputeGameFactory(s.T, s.L1Network, s.L1EL.EthClient(), s.L2ChainA.DisputeGameFactoryProxyAddr(), s.Supervisor)
+	return proofs.NewDisputeGameFactory(s.T, s.L1Network, s.L1EL.EthClient(), s.L2ChainA.DisputeGameFactoryProxyAddr(), nil, nil, s.Supervisor, nil)
 }
 
 func (s *SingleChainInterop) StandardBridge(l2Chain *dsl.L2Network) *dsl.StandardBridge {

--- a/op-devstack/presets/minimal.go
+++ b/op-devstack/presets/minimal.go
@@ -1,6 +1,7 @@
 package presets
 
 import (
+	challengerConfig "github.com/ethereum-optimism/optimism/op-challenger/config"
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
@@ -31,6 +32,9 @@ type Minimal struct {
 	FaucetL2 *dsl.Faucet
 	FunderL1 *dsl.Funder
 	FunderL2 *dsl.Funder
+
+	// May be nil if not using sysgo
+	challengerConfig *challengerConfig.Config
 }
 
 func (m *Minimal) L2Networks() []*dsl.L2Network {
@@ -44,7 +48,7 @@ func (m *Minimal) StandardBridge() *dsl.StandardBridge {
 }
 
 func (m *Minimal) DisputeGameFactory() *proofs.DisputeGameFactory {
-	return proofs.NewDisputeGameFactory(m.T, m.L1Network, m.L1EL.EthClient(), m.L2Chain.DisputeGameFactoryProxyAddr(), nil)
+	return proofs.NewDisputeGameFactory(m.T, m.L1Network, m.L1EL.EthClient(), m.L2Chain.DisputeGameFactoryProxyAddr(), m.L2CL, m.L2EL, nil, m.challengerConfig)
 }
 
 func WithMinimal() stack.CommonOption {
@@ -64,18 +68,24 @@ func minimalFromSystem(t devtest.T, system stack.ExtensibleSystem, orch stack.Or
 	l2 := system.L2Network(match.Assume(t, match.L2ChainA))
 	sequencerCL := l2.L2CLNode(match.Assume(t, match.WithSequencerActive(t.Ctx())))
 	sequencerEL := l2.L2ELNode(match.Assume(t, match.EngineFor(sequencerCL)))
+	var challengerCfg *challengerConfig.Config
+	if len(l2.L2Challengers()) > 0 {
+		challengerCfg = l2.L2Challengers()[0].Config()
+	}
+
 	out := &Minimal{
-		Log:          t.Logger(),
-		T:            t,
-		ControlPlane: orch.ControlPlane(),
-		L1Network:    dsl.NewL1Network(system.L1Network(match.FirstL1Network)),
-		L1EL:         dsl.NewL1ELNode(l1Net.L1ELNode(match.Assume(t, match.FirstL1EL))),
-		L2Chain:      dsl.NewL2Network(l2, orch.ControlPlane()),
-		L2Batcher:    dsl.NewL2Batcher(l2.L2Batcher(match.Assume(t, match.FirstL2Batcher))),
-		L2EL:         dsl.NewL2ELNode(sequencerEL, orch.ControlPlane()),
-		L2CL:         dsl.NewL2CLNode(sequencerCL, orch.ControlPlane()),
-		Wallet:       dsl.NewRandomHDWallet(t, 30), // Random for test isolation
-		FaucetL2:     dsl.NewFaucet(l2.Faucet(match.Assume(t, match.FirstFaucet))),
+		Log:              t.Logger(),
+		T:                t,
+		ControlPlane:     orch.ControlPlane(),
+		L1Network:        dsl.NewL1Network(system.L1Network(match.FirstL1Network)),
+		L1EL:             dsl.NewL1ELNode(l1Net.L1ELNode(match.Assume(t, match.FirstL1EL))),
+		L2Chain:          dsl.NewL2Network(l2, orch.ControlPlane()),
+		L2Batcher:        dsl.NewL2Batcher(l2.L2Batcher(match.Assume(t, match.FirstL2Batcher))),
+		L2EL:             dsl.NewL2ELNode(sequencerEL, orch.ControlPlane()),
+		L2CL:             dsl.NewL2CLNode(sequencerCL, orch.ControlPlane()),
+		Wallet:           dsl.NewRandomHDWallet(t, 30), // Random for test isolation
+		FaucetL2:         dsl.NewFaucet(l2.Faucet(match.Assume(t, match.FirstFaucet))),
+		challengerConfig: challengerCfg,
 	}
 	out.FaucetL1 = dsl.NewFaucet(out.L1Network.Escape().Faucet(match.Assume(t, match.FirstFaucet)))
 	out.FunderL1 = dsl.NewFunder(out.Wallet, out.FaucetL1, out.L1EL)

--- a/op-devstack/shim/l2_challenger.go
+++ b/op-devstack/shim/l2_challenger.go
@@ -1,15 +1,24 @@
 package shim
 
-import "github.com/ethereum-optimism/optimism/op-devstack/stack"
+import (
+	"github.com/ethereum-optimism/optimism/op-challenger/config"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+)
 
 type L2ChallengerConfig struct {
 	CommonConfig
-	ID stack.L2ChallengerID
+	ID     stack.L2ChallengerID
+	Config *config.Config
 }
 
 type rpcL2Challenger struct {
 	commonImpl
-	id stack.L2ChallengerID
+	id     stack.L2ChallengerID
+	config *config.Config
+}
+
+func (r *rpcL2Challenger) Config() *config.Config {
+	return r.config
 }
 
 var _ stack.L2Challenger = (*rpcL2Challenger)(nil)
@@ -19,6 +28,7 @@ func NewL2Challenger(cfg L2ChallengerConfig) stack.L2Challenger {
 	return &rpcL2Challenger{
 		commonImpl: newCommon(cfg.CommonConfig),
 		id:         cfg.ID,
+		config:     cfg.Config,
 	}
 }
 

--- a/op-devstack/stack/l2_challenger.go
+++ b/op-devstack/stack/l2_challenger.go
@@ -3,6 +3,7 @@ package stack
 import (
 	"log/slog"
 
+	"github.com/ethereum-optimism/optimism/op-challenger/config"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
@@ -69,4 +70,5 @@ func (id L2ChallengerID) Match(elems []L2Challenger) []L2Challenger {
 type L2Challenger interface {
 	Common
 	ID() L2ChallengerID
+	Config() *config.Config
 }

--- a/op-devstack/sysgo/l2_challenger.go
+++ b/op-devstack/sysgo/l2_challenger.go
@@ -21,12 +21,14 @@ type L2Challenger struct {
 	id       stack.L2ChallengerID
 	service  cliapp.Lifecycle
 	l2NetIDs []stack.L2NetworkID
+	config   *config.Config
 }
 
 func (p *L2Challenger) hydrate(system stack.ExtensibleSystem) {
 	bFrontend := shim.NewL2Challenger(shim.L2ChallengerConfig{
 		CommonConfig: shim.NewCommonConfig(system.T()),
 		ID:           p.id,
+		Config:       p.config,
 	})
 
 	for _, netID := range p.l2NetIDs {
@@ -176,6 +178,7 @@ func WithL2ChallengerPostDeploy(orch *Orchestrator, challengerID stack.L2Challen
 		id:       challengerID,
 		service:  svc,
 		l2NetIDs: l2NetIDs,
+		config:   cfg,
 	}
 	orch.challengers.Set(challengerID, c)
 }

--- a/op-service/eth/block_info.go
+++ b/op-service/eth/block_info.go
@@ -34,6 +34,7 @@ type BlockInfo interface {
 	// HeaderRLP returns the RLP of the block header as per consensus rules
 	// Returns an error if the header RLP could not be written
 	HeaderRLP() ([]byte, error)
+	Header() *types.Header
 }
 
 func InfoToL1BlockRef(info BlockInfo) L1BlockRef {
@@ -162,7 +163,11 @@ func (h *headerBlockInfo) HeaderRLP() ([]byte, error) {
 	return rlp.EncodeToBytes(h.header) // usage is rare and mostly 1-time-use, no need to cache
 }
 
-func (h headerBlockInfo) WithdrawalsRoot() *common.Hash {
+func (h *headerBlockInfo) Header() *types.Header {
+	return h.header
+}
+
+func (h *headerBlockInfo) WithdrawalsRoot() *common.Hash {
 	return h.header.WithdrawalsHash
 }
 

--- a/op-service/testutils/l1info.go
+++ b/op-service/testutils/l1info.go
@@ -36,6 +36,10 @@ type MockBlockInfo struct {
 	InfoWithdrawalsRoot  *common.Hash
 }
 
+func (l *MockBlockInfo) Header() *types.Header {
+	panic("not implemented")
+}
+
 func (l *MockBlockInfo) Hash() common.Hash {
 	return l.InfoHash
 }

--- a/op-service/txintent/bindings/FaultDisputeGame.go
+++ b/op-service/txintent/bindings/FaultDisputeGame.go
@@ -45,15 +45,18 @@ type FaultDisputeGame struct {
 	L1Head           func() TypedCall[common.Hash] `sol:"l1Head"`
 	L2SequenceNumber func() TypedCall[*big.Int]    `sol:"l2SequenceNumber"`
 	Status           func() TypedCall[uint8]       `sol:"status"`
+	GameType         func() TypedCall[uint32]      `sol:"gameType"`
 
 	// IFaultDisputeGame.sol read methods
-	ClaimDataLen     func() TypedCall[*big.Int]                                                 `sol:"claimDataLen"`
-	ClaimData        func(*big.Int) TypedCall[ClaimData]                                        `sol:"claimData"`
-	GetRequiredBond  func(position *Uint128) TypedCall[*big.Int]                                `sol:"getRequiredBond"`
-	MaxGameDepth     func() TypedCall[*big.Int]                                                 `sol:"maxGameDepth"`
-	SplitDepth       func() TypedCall[*big.Int]                                                 `sol:"splitDepth"`
-	SubGame          func(parentClaimIndex *big.Int, subGameIndex *big.Int) TypedCall[*big.Int] `sol:"subgame"`
-	MaxClockDuration func() TypedCall[uint64]                                                   `sol:"maxClockDuration"`
+	ClaimDataLen           func() TypedCall[*big.Int]                                                 `sol:"claimDataLen"`
+	ClaimData              func(*big.Int) TypedCall[ClaimData]                                        `sol:"claimData"`
+	GetRequiredBond        func(position *Uint128) TypedCall[*big.Int]                                `sol:"getRequiredBond"`
+	MaxGameDepth           func() TypedCall[*big.Int]                                                 `sol:"maxGameDepth"`
+	SplitDepth             func() TypedCall[*big.Int]                                                 `sol:"splitDepth"`
+	SubGame                func(parentClaimIndex *big.Int, subGameIndex *big.Int) TypedCall[*big.Int] `sol:"subgame"`
+	MaxClockDuration       func() TypedCall[uint64]                                                   `sol:"maxClockDuration"`
+	StartingBlockNumber    func() TypedCall[uint64]                                                   `sol:"startingBlockNumber"`
+	StartingSequenceNumber func() TypedCall[uint64]                                                   `sol:"startingSequenceNumber"`
 
 	// IFaultDisputeGame.sol write methods
 	Move   func(targetClaim common.Hash, targetClaimIndex *big.Int, newClaim common.Hash, isAttack bool) TypedCall[any] `sol:"move"`


### PR DESCRIPTION
**Description**

Starts migrating acceptance tests for proofs from op-e2e to op-acceptance.  This requires fleshing out quite a bit of the DSL and infrastructure.  The new test just confirms that the challenger can successfully call step on an arbitrary point in the cannon execution. This sets up the infrastructure for tests having access to an honest trace and using game helper to dispute specific blocks or trace indices.

To get an honest trace we need to create a challenger config. That requires access to things like the genesis config and actual URLs (not just prebuilt clients since challenger executes cannon as a sub-process). Since that's not available via the dev stack abstractions, a prebuilt challenger config is made available by SysGo that is passed through. We don't currently have a way to create that config with SysExt, but there's little to no value to running these dispute game tests on real networks as they would be exceedingly slow and not actually test anything new.

