### PR TITLE
op-node: change default value and turn off Req/Resp p2p sync by default

### DIFF
--- a/op-devstack/sysgo/l2_cl.go
+++ b/op-devstack/sysgo/l2_cl.go
@@ -63,7 +63,7 @@ func DefaultL2CLConfig() *L2CLConfig {
 		IsSequencer:       false,
 		IndexingMode:      false,
 		EnableReqRespSync: true,
-		UseReqRespSync:    true,
+		UseReqRespSync:    false,
 		NoDiscovery:       false,
 		FollowSource:      "",
 	}

--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -119,7 +119,7 @@ var (
 	SyncModeReqRespFlag = &cli.BoolFlag{
 		Name:     "syncmode.req-resp",
 		Required: false,
-		Value:    true,
+		Value:    false,
 		EnvVars:  prefixEnvVars("SYNCMODE_REQ_RESP"),
 		Category: RollupCategory,
 	}


### PR DESCRIPTION
This PR is changing the default value for `--syncmode.req-resp` to `false`.

~This PR is to be merged in a future release after some grace period.~

---

Related: https://github.com/ethereum-optimism/optimism/pull/17751

Project doc: https://www.notion.so/oplabs/Deprecating-Req-Res-CL-P2P-Sync-protocol-292f153ee162808a8f30edd24367d6d7