### PR TITLE
feat(ctb): Add the nonce and txHash into the ScheduledTransactions struct

### DIFF
--- a/packages/contracts-bedrock/interfaces/safe/ITimelockGuard.sol
+++ b/packages/contracts-bedrock/interfaces/safe/ITimelockGuard.sol
@@ -12,11 +12,12 @@ interface ITimelockGuard {
         Cancelled,
         Executed
     }
+
     struct ScheduledTransaction {
+        bytes32 txHash;
         uint256 executionTime;
         TransactionState state;
         ExecTransactionParams params;
-        bytes32 txHash;
         uint256 nonce;
     }
 

--- a/packages/contracts-bedrock/interfaces/safe/ITimelockGuard.sol
+++ b/packages/contracts-bedrock/interfaces/safe/ITimelockGuard.sol
@@ -16,6 +16,8 @@ interface ITimelockGuard {
         uint256 executionTime;
         TransactionState state;
         ExecTransactionParams params;
+        bytes32 txHash;
+        uint256 nonce;
     }
 
     struct ExecTransactionParams {

--- a/packages/contracts-bedrock/snapshots/abi/SaferSafes.json
+++ b/packages/contracts-bedrock/snapshots/abi/SaferSafes.json
@@ -366,6 +366,16 @@
             "internalType": "struct TimelockGuard.ExecTransactionParams",
             "name": "params",
             "type": "tuple"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "txHash",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint256",
+            "name": "nonce",
+            "type": "uint256"
           }
         ],
         "internalType": "struct TimelockGuard.ScheduledTransaction[]",
@@ -536,6 +546,16 @@
             "internalType": "struct TimelockGuard.ExecTransactionParams",
             "name": "params",
             "type": "tuple"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "txHash",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint256",
+            "name": "nonce",
+            "type": "uint256"
           }
         ],
         "internalType": "struct TimelockGuard.ScheduledTransaction",

--- a/packages/contracts-bedrock/snapshots/abi/SaferSafes.json
+++ b/packages/contracts-bedrock/snapshots/abi/SaferSafes.json
@@ -306,6 +306,11 @@
       {
         "components": [
           {
+            "internalType": "bytes32",
+            "name": "txHash",
+            "type": "bytes32"
+          },
+          {
             "internalType": "uint256",
             "name": "executionTime",
             "type": "uint256"
@@ -366,11 +371,6 @@
             "internalType": "struct TimelockGuard.ExecTransactionParams",
             "name": "params",
             "type": "tuple"
-          },
-          {
-            "internalType": "bytes32",
-            "name": "txHash",
-            "type": "bytes32"
           },
           {
             "internalType": "uint256",
@@ -486,6 +486,11 @@
       {
         "components": [
           {
+            "internalType": "bytes32",
+            "name": "txHash",
+            "type": "bytes32"
+          },
+          {
             "internalType": "uint256",
             "name": "executionTime",
             "type": "uint256"
@@ -546,11 +551,6 @@
             "internalType": "struct TimelockGuard.ExecTransactionParams",
             "name": "params",
             "type": "tuple"
-          },
-          {
-            "internalType": "bytes32",
-            "name": "txHash",
-            "type": "bytes32"
           },
           {
             "internalType": "uint256",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -208,7 +208,7 @@
     "sourceCodeHash": "0x7fc4789b082bc8ecd29c4c75a06058f0ff0b72f1c1028a42db6f1c35269c8865"
   },
   "src/safe/SaferSafes.sol:SaferSafes": {
-    "initCodeHash": "0x2bee3bc687583bae2cb88edcf25ebe277b8d34b30bf9faac55ae6ec80080b8b9",
+    "initCodeHash": "0xff09e8a0e0398546e8edc25862d587844a089ddae759b4b4190b291b119a73b9",
     "sourceCodeHash": "0xed36bffcde1bf806a9bd9b599296f4818a6c123f5277d2f3e68635cb3f22973d"
   },
   "src/universal/OptimismMintableERC20.sol:OptimismMintableERC20": {

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -208,7 +208,7 @@
     "sourceCodeHash": "0x7fc4789b082bc8ecd29c4c75a06058f0ff0b72f1c1028a42db6f1c35269c8865"
   },
   "src/safe/SaferSafes.sol:SaferSafes": {
-    "initCodeHash": "0xd9dd8f02b50eb996c4c24482d7f7dd34d4b75e0b435e532df0080af037b2cde2",
+    "initCodeHash": "0xb4e7885e5f181e9223ecdbc4cfc8b5887fd2c22359e4c8bb4dee53f7dd193876",
     "sourceCodeHash": "0x31f453780466a9d3e498a7981f66c92c3d0b76e1ee80c19e374d9692bcfbd931"
   },
   "src/universal/OptimismMintableERC20.sol:OptimismMintableERC20": {

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -208,8 +208,8 @@
     "sourceCodeHash": "0x7fc4789b082bc8ecd29c4c75a06058f0ff0b72f1c1028a42db6f1c35269c8865"
   },
   "src/safe/SaferSafes.sol:SaferSafes": {
-    "initCodeHash": "0xff09e8a0e0398546e8edc25862d587844a089ddae759b4b4190b291b119a73b9",
-    "sourceCodeHash": "0xed36bffcde1bf806a9bd9b599296f4818a6c123f5277d2f3e68635cb3f22973d"
+    "initCodeHash": "0xd9dd8f02b50eb996c4c24482d7f7dd34d4b75e0b435e532df0080af037b2cde2",
+    "sourceCodeHash": "0x31f453780466a9d3e498a7981f66c92c3d0b76e1ee80c19e374d9692bcfbd931"
   },
   "src/universal/OptimismMintableERC20.sol:OptimismMintableERC20": {
     "initCodeHash": "0x3c85eed0d017dca8eda6396aa842ddc12492587b061e8c756a8d32c4610a9658",

--- a/packages/contracts-bedrock/src/safe/SaferSafes.sol
+++ b/packages/contracts-bedrock/src/safe/SaferSafes.sol
@@ -26,8 +26,8 @@ import { ISemver } from "interfaces/universal/ISemver.sol";
 ///      compatibility restrictions in the LivenessModule2 and TimelockGuard contracts.
 contract SaferSafes is LivenessModule2, TimelockGuard, ISemver {
     /// @notice Semantic version.
-    /// @custom:semver 1.8.0
-    string public constant version = "1.8.0";
+    /// @custom:semver 1.9.0
+    string public constant version = "1.9.0";
 
     /// @notice Error for when the liveness response period is insufficient.
     error SaferSafes_InsufficientLivenessResponsePeriod();

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -91,10 +91,14 @@ abstract contract TimelockGuard is BaseGuard {
     /// @custom:field executionTime The timestamp when execution becomes valid.
     /// @custom:field state The state of the transaction.
     /// @custom:field params The parameters of the transaction.
+    /// @custom:field txHash The hash of the transaction.
+    /// @custom:field nonce The nonce of the transaction.
     struct ScheduledTransaction {
         uint256 executionTime;
         TransactionState state;
         ExecTransactionParams params;
+        bytes32 txHash;
+        uint256 nonce;
     }
 
     /// @notice Parameters for the Safe's execTransaction function
@@ -564,8 +568,13 @@ abstract contract TimelockGuard is BaseGuard {
         uint256 executionTime = block.timestamp + _currentSafeState(_safe).timelockDelay;
 
         // Schedule the transaction and add it to the pending transactions set
-        _currentSafeState(_safe).scheduledTransactions[txHash] =
-            ScheduledTransaction({ executionTime: executionTime, state: TransactionState.Pending, params: _params });
+        _currentSafeState(_safe).scheduledTransactions[txHash] = ScheduledTransaction({
+            executionTime: executionTime,
+            state: TransactionState.Pending,
+            params: _params,
+            txHash: txHash,
+            nonce: _nonce
+        });
         _currentSafeState(_safe).pendingTxHashes.add(txHash);
 
         emit TransactionScheduled(_safe, txHash, executionTime);

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -88,16 +88,16 @@ abstract contract TimelockGuard is BaseGuard {
     }
 
     /// @notice Scheduled transaction
+    /// @custom:field txHash The hash of the transaction.
     /// @custom:field executionTime The timestamp when execution becomes valid.
     /// @custom:field state The state of the transaction.
     /// @custom:field params The parameters of the transaction.
-    /// @custom:field txHash The hash of the transaction.
     /// @custom:field nonce The nonce of the transaction.
     struct ScheduledTransaction {
+        bytes32 txHash;
         uint256 executionTime;
         TransactionState state;
         ExecTransactionParams params;
-        bytes32 txHash;
         uint256 nonce;
     }
 
@@ -569,10 +569,10 @@ abstract contract TimelockGuard is BaseGuard {
 
         // Schedule the transaction and add it to the pending transactions set
         _currentSafeState(_safe).scheduledTransactions[txHash] = ScheduledTransaction({
+            txHash: txHash,
             executionTime: executionTime,
             state: TransactionState.Pending,
             params: _params,
-            txHash: txHash,
             nonce: _nonce
         });
         _currentSafeState(_safe).pendingTxHashes.add(txHash);

--- a/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
+++ b/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
@@ -505,10 +505,10 @@ contract TimelockGuard_ScheduledTransaction_Test is TimelockGuard_TestInit {
 
         TimelockGuard.ScheduledTransaction memory scheduledTransaction =
             timelockGuard.scheduledTransaction(safe, dummyTx.hash);
+        assertEq(scheduledTransaction.txHash, dummyTx.hash);
         assertEq(scheduledTransaction.executionTime, INIT_TIME + TIMELOCK_DELAY);
         assert(scheduledTransaction.state == TimelockGuard.TransactionState.Pending);
         assertEq(keccak256(abi.encode(scheduledTransaction.params)), keccak256(abi.encode(dummyTx.params)));
-        assertEq(scheduledTransaction.txHash, dummyTx.hash);
         assertEq(scheduledTransaction.nonce, dummyTx.nonce);
     }
 }
@@ -527,13 +527,14 @@ contract TimelockGuard_PendingTransactions_Test is TimelockGuard_TestInit {
         dummyTx.scheduleTransaction(timelockGuard);
 
         TimelockGuard.ScheduledTransaction[] memory pendingTransactions = timelockGuard.pendingTransactions(safe);
+        // verify the pending transaction is the one we scheduled
         assertEq(pendingTransactions.length, 1);
-        // ensure the hash of the transaction params are the same
-        assertEq(pendingTransactions[0].params.to, dummyTx.params.to);
-        assertEq(keccak256(abi.encode(pendingTransactions[0].params)), keccak256(abi.encode(dummyTx.params)));
-        // verify that txHash and nonce are correctly populated
         assertEq(pendingTransactions[0].txHash, dummyTx.hash);
+        assertEq(pendingTransactions[0].executionTime, INIT_TIME + TIMELOCK_DELAY);
+        assert(pendingTransactions[0].state == TimelockGuard.TransactionState.Pending);
+        assertEq(pendingTransactions[0].params.to, dummyTx.params.to);
         assertEq(pendingTransactions[0].nonce, dummyTx.nonce);
+        assertEq(keccak256(abi.encode(pendingTransactions[0].params)), keccak256(abi.encode(dummyTx.params)));
     }
 
     function test_pendingTransactions_removeTransactionAfterCancellation_succeeds() external {

--- a/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
+++ b/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
@@ -508,6 +508,8 @@ contract TimelockGuard_ScheduledTransaction_Test is TimelockGuard_TestInit {
         assertEq(scheduledTransaction.executionTime, INIT_TIME + TIMELOCK_DELAY);
         assert(scheduledTransaction.state == TimelockGuard.TransactionState.Pending);
         assertEq(keccak256(abi.encode(scheduledTransaction.params)), keccak256(abi.encode(dummyTx.params)));
+        assertEq(scheduledTransaction.txHash, dummyTx.hash);
+        assertEq(scheduledTransaction.nonce, dummyTx.nonce);
     }
 }
 
@@ -529,6 +531,9 @@ contract TimelockGuard_PendingTransactions_Test is TimelockGuard_TestInit {
         // ensure the hash of the transaction params are the same
         assertEq(pendingTransactions[0].params.to, dummyTx.params.to);
         assertEq(keccak256(abi.encode(pendingTransactions[0].params)), keccak256(abi.encode(dummyTx.params)));
+        // verify that txHash and nonce are correctly populated
+        assertEq(pendingTransactions[0].txHash, dummyTx.hash);
+        assertEq(pendingTransactions[0].nonce, dummyTx.nonce);
     }
 
     function test_pendingTransactions_removeTransactionAfterCancellation_succeeds() external {


### PR DESCRIPTION
Add nonce and txHash to ScheduledTransaction struct


**Summary**

Extends the ScheduledTransaction struct in TimelockGuard to include txHash and nonce, storing them when transactions are scheduled for easier access.

