### PR TITLE
op-acceptance-tests: Improve DA footprint test stability

### DIFF
--- a/op-acceptance-tests/tests/jovian/da_footprint_test.go
+++ b/op-acceptance-tests/tests/jovian/da_footprint_test.go
@@ -103,6 +103,12 @@ func (env *daFootprintEnv) setDAFootprintGasScalarViaSystemConfig(t devtest.T, s
 	return rec
 }
 
+func (env *daFootprintEnv) getDAFootprintGasScalarOfSystemConfig(t devtest.T) uint16 {
+	scalar, err := contractio.Read(env.systemConfig.DAFootprintGasScalar(), t.Ctx())
+	t.Require().NoError(err)
+	return scalar
+}
+
 // expectL1BlockDAFootprintGasScalar expects the given DA footprint gas scalar to be set in the L1Block contract.
 func (env *daFootprintEnv) expectL1BlockDAFootprintGasScalar(t devtest.T, expected uint16) {
 	current, err := contractio.Read(env.l1Block.DAFootprintGasScalar(), t.Ctx())
@@ -150,6 +156,10 @@ func TestDAFootprint(gt *testing.T) {
 				// https://github.com/ethereum-optimism/optimism/issues/18061
 				env.l2EL.WaitL1OriginReached(eth.Unsafe, rec.BlockNumber.Uint64(), 100)
 			} else {
+				scalar := env.getDAFootprintGasScalarOfSystemConfig(t)
+				if scalar != 0 {
+					t.Skipf("Skipping default scalar test because SystemConfig DA footprint gas scalar is set to %d != 0", scalar)
+				}
 				sys.L2EL.WaitForBlockNumber(1) // make sure we don't assert on genesis
 			}
 			env.expectL1BlockDAFootprintGasScalar(t, tc.expected)

--- a/op-devstack/dsl/el.go
+++ b/op-devstack/dsl/el.go
@@ -69,9 +69,16 @@ func (el *elNode) WaitForUnsafeRef(predicate func(eth.BlockInfo) (bool, error)) 
 }
 
 func (el *elNode) WaitForBlockNumber(targetBlock uint64) eth.BlockInfo {
-	return el.WaitForUnsafe(func(info eth.BlockInfo) (bool, error) {
+	info := el.WaitForUnsafe(func(info eth.BlockInfo) (bool, error) {
 		return info.NumberU64() >= targetBlock, nil
 	})
+	if info.NumberU64() == targetBlock {
+		return info
+	}
+	// we've gone too far
+	info, err := el.inner.EthClient().InfoByNumber(el.ctx, targetBlock)
+	el.require.NoError(err, "Expected to get info by number after waiting")
+	return info
 }
 
 func (el *elNode) WaitForOnline() {


### PR DESCRIPTION
**Description**

Improves DA footprint acceptance tests, making them more stable when running on real networks.
- Skipping first initial scalar tests if a non-zero scalar is already set
- Fixing WaitForBlockNum helper to return info at exact block number, not any at or higher.


