### PR TITLE
opcm: Set cannon_kona init bond during upgrade

### DIFF
--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -20,8 +20,8 @@
     "sourceCodeHash": "0xfca613b5d055ffc4c3cbccb0773ddb9030abedc1aa6508c9e2e7727cc0cd617b"
   },
   "src/L1/OPContractsManager.sol:OPContractsManager": {
-    "initCodeHash": "0x659729d1df8a1d04fa09f8aacbd83d63511af4b41ca92f334b324dc97833839b",
-    "sourceCodeHash": "0x47d94eda9ea1a238d770f9a51ea3648ccd279f5b567d50844d62dddb1b910a1c"
+    "initCodeHash": "0xaf9f3fe706ae2a15108451d7e665208254be8b6d398c3e738c8887a0f8cd7903",
+    "sourceCodeHash": "0xba3c7ef4834fda6df516249a77ef2ff6d7c512cf694f4322e696e57377086eec"
   },
   "src/L1/OPContractsManagerStandardValidator.sol:OPContractsManagerStandardValidator": {
     "initCodeHash": "0x0c8b15453d0f0bc5d9af07f104505e0bbb2b358f0df418289822fb73a8652b30",

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -1077,6 +1077,8 @@ contract OPContractsManagerUpgrader is OPContractsManagerBase {
                         _gameType: GameTypes.CANNON_KONA,
                         _disputeGameFactory: disputeGameFactory
                     });
+                    uint256 initialCannonGameBond = disputeGameFactory.initBonds(GameTypes.CANNON);
+                    disputeGameFactory.setInitBond(GameTypes.CANNON_KONA, initialCannonGameBond);
                 }
             }
         }
@@ -2165,9 +2167,9 @@ contract OPContractsManager is ISemver {
 
     // -------- Constants and Variables --------
 
-    /// @custom:semver 5.4.0
+    /// @custom:semver 5.5.0
     function version() public pure virtual returns (string memory) {
-        return "5.4.0";
+        return "5.5.0";
     }
 
     OPContractsManagerGameTypeAdder public immutable opcmGameTypeAdder;

--- a/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
@@ -347,10 +347,6 @@ contract OPContractsManager_Upgrade_Harness is CommonTest, DisputeGames {
     )
         internal
     {
-        bytes32 expectedAbsolutePrestate = _opChainConfig.cannonPrestate.raw();
-        if (expectedAbsolutePrestate == bytes32(0)) {
-            expectedAbsolutePrestate = preUpgradeState.permissionedAbsolutePrestate.raw();
-        }
         address expectedVm = address(_opcm.implementations().mipsImpl);
 
         Claim claim = Claim.wrap(bytes32(uint256(1)));
@@ -359,12 +355,27 @@ contract OPContractsManager_Upgrade_Harness is CommonTest, DisputeGames {
         (, uint256 rootBlockNumber) = optimismPortal2.anchorStateRegistry().getAnchorRoot();
         uint256 l2BlockNumber = rootBlockNumber + 1;
 
+        bool expectCannonKonaGameSet =
+            isDevFeatureEnabled(DevFeatures.CANNON_KONA) && _opChainConfig.cannonKonaPrestate.raw() != bytes32(0);
+
         // Deploy live games and ensure they're configured correctly
-        GameType[] memory gameTypes = new GameType[](2);
+        GameType[] memory gameTypes = new GameType[](expectCannonKonaGameSet ? 3 : 2);
         gameTypes[0] = GameTypes.PERMISSIONED_CANNON;
         gameTypes[1] = GameTypes.CANNON;
+        if (expectCannonKonaGameSet) {
+            gameTypes[2] = GameTypes.CANNON_KONA;
+        }
         for (uint256 i = 0; i < gameTypes.length; i++) {
             GameType gt = gameTypes[i];
+
+            bytes32 expectedAbsolutePrestate = _opChainConfig.cannonPrestate.raw();
+            if (expectedAbsolutePrestate == bytes32(0)) {
+                expectedAbsolutePrestate = preUpgradeState.permissionedAbsolutePrestate.raw();
+            }
+            if (expectCannonKonaGameSet && gt.raw() == GameTypes.CANNON_KONA.raw()) {
+                expectedAbsolutePrestate = _opChainConfig.cannonKonaPrestate.raw();
+            }
+
             vm.prank(_proposer, _proposer);
             IPermissionedDisputeGame game = IPermissionedDisputeGame(
                 address(disputeGameFactory.create{ value: bondAmount }(gt, claim, abi.encode(l2BlockNumber)))
@@ -392,6 +403,11 @@ contract OPContractsManager_Upgrade_Harness is CommonTest, DisputeGames {
             } else {
                 vm.assertEq(address(preUpgradeState.permissionlessWethProxy), address(game.weth()));
             }
+        }
+
+        if (!expectCannonKonaGameSet) {
+            assertEq(address(0), address(disputeGameFactory.gameImpls(GameTypes.CANNON_KONA)));
+            assertEq(0, disputeGameFactory.initBonds(GameTypes.CANNON_KONA));
         }
     }
 

--- a/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
@@ -375,6 +375,7 @@ contract OPContractsManager_Upgrade_Harness is CommonTest, DisputeGames {
             if (expectCannonKonaGameSet && gt.raw() == GameTypes.CANNON_KONA.raw()) {
                 expectedAbsolutePrestate = _opChainConfig.cannonKonaPrestate.raw();
             }
+            assertEq(bondAmount, disputeGameFactory.initBonds(gt));
 
             vm.prank(_proposer, _proposer);
             IPermissionedDisputeGame game = IPermissionedDisputeGame(
@@ -408,6 +409,7 @@ contract OPContractsManager_Upgrade_Harness is CommonTest, DisputeGames {
         if (!expectCannonKonaGameSet) {
             assertEq(address(0), address(disputeGameFactory.gameImpls(GameTypes.CANNON_KONA)));
             assertEq(0, disputeGameFactory.initBonds(GameTypes.CANNON_KONA));
+            assertEq(0, disputeGameFactory.gameArgs(GameTypes.CANNON_KONA).length);
         }
     }
 


### PR DESCRIPTION
Fixes a bug in opcm.upgrade where the CANNON_KONA initial bond was not set.