### PR TITLE
dispute-mon: new metric to track out-of-sync node endpoints

### DIFF
--- a/op-dispute-mon/metrics/metrics.go
+++ b/op-dispute-mon/metrics/metrics.go
@@ -183,6 +183,8 @@ type Metricer interface {
 
 	RecordNodeEndpointErrorCount(count int)
 
+	RecordNodeEndpointOutOfSyncCount(count int)
+
 	RecordMixedAvailabilityGames(count int)
 
 	RecordMixedSafetyGames(count int)
@@ -239,13 +241,14 @@ type Metrics struct {
 	failedGames                prometheus.Gauge
 	l2Challenges               prometheus.GaugeVec
 
-	requiredCollateral       prometheus.GaugeVec
-	availableCollateral      prometheus.GaugeVec
-	nodeEndpointErrors       prometheus.Gauge
-	nodeEndpointErrorCount   prometheus.Gauge
-	mixedAvailabilityGames   prometheus.Gauge
-	mixedSafetyGames         prometheus.Gauge
-	differentOutputRootGames prometheus.Gauge
+	requiredCollateral         prometheus.GaugeVec
+	availableCollateral        prometheus.GaugeVec
+	nodeEndpointErrors         prometheus.Gauge
+	nodeEndpointErrorCount     prometheus.Gauge
+	nodeEndpointOutOfSyncCount prometheus.Gauge
+	mixedAvailabilityGames     prometheus.Gauge
+	mixedSafetyGames           prometheus.Gauge
+	differentOutputRootGames   prometheus.Gauge
 }
 
 func (m *Metrics) Registry() *prometheus.Registry {
@@ -423,6 +426,11 @@ func NewMetrics() *Metrics {
 			Name:      "node_endpoint_error_count",
 			Help:      "Total number of individual endpoint error occurrences (other than \"not found\") across all rollup node endpoints in the last update cycle",
 		}),
+		nodeEndpointOutOfSyncCount: factory.NewGauge(prometheus.GaugeOpts{
+			Namespace: Namespace,
+			Name:      "node_endpoint_out_of_sync_count",
+			Help:      "Total number of out-of-sync responses (where node's CurrentL1 <= game's L1HeadNum) across all rollup node endpoints in the last update cycle",
+		}),
 		mixedAvailabilityGames: factory.NewGauge(prometheus.GaugeOpts{
 			Namespace: Namespace,
 			Name:      "mixed_availability_games",
@@ -581,6 +589,10 @@ func (m *Metrics) RecordNodeEndpointErrors(count int) {
 
 func (m *Metrics) RecordNodeEndpointErrorCount(count int) {
 	m.nodeEndpointErrorCount.Set(float64(count))
+}
+
+func (m *Metrics) RecordNodeEndpointOutOfSyncCount(count int) {
+	m.nodeEndpointOutOfSyncCount.Set(float64(count))
 }
 
 func (m *Metrics) RecordMixedAvailabilityGames(count int) {

--- a/op-dispute-mon/metrics/noop.go
+++ b/op-dispute-mon/metrics/noop.go
@@ -58,6 +58,8 @@ func (*NoopMetricsImpl) RecordNodeEndpointErrors(_ int) {}
 
 func (*NoopMetricsImpl) RecordNodeEndpointErrorCount(_ int) {}
 
+func (*NoopMetricsImpl) RecordNodeEndpointOutOfSyncCount(_ int) {}
+
 func (*NoopMetricsImpl) RecordMixedAvailabilityGames(_ int) {}
 
 func (*NoopMetricsImpl) RecordMixedSafetyGames(_ int) {}

--- a/op-dispute-mon/mon/extract/extractor.go
+++ b/op-dispute-mon/mon/extract/extractor.go
@@ -149,20 +149,21 @@ func (e *Extractor) enrichGame(ctx context.Context, blockHash common.Hash, game 
 		enrichedClaims[i] = monTypes.EnrichedClaim{Claim: claim}
 	}
 	enrichedGame := &monTypes.EnrichedGameData{
-		LastUpdateTime:              e.clock.Now(),
-		GameMetadata:                game,
-		L1Head:                      meta.L1Head,
-		L2BlockNumber:               meta.L2SequenceNum,
-		RootClaim:                   meta.RootClaim,
-		Status:                      meta.Status,
-		MaxClockDuration:            meta.MaxClockDuration,
-		BlockNumberChallenged:       meta.L2BlockNumberChallenged,
-		BlockNumberChallenger:       meta.L2BlockNumberChallenger,
-		Claims:                      enrichedClaims,
-		RollupEndpointErrors:        make(map[string]bool),
-		RollupEndpointErrorCount:    0,
-		RollupEndpointNotFoundCount: 0,
-		RollupEndpointTotalCount:    0,
+		LastUpdateTime:               e.clock.Now(),
+		GameMetadata:                 game,
+		L1Head:                       meta.L1Head,
+		L2BlockNumber:                meta.L2SequenceNum,
+		RootClaim:                    meta.RootClaim,
+		Status:                       meta.Status,
+		MaxClockDuration:             meta.MaxClockDuration,
+		BlockNumberChallenged:        meta.L2BlockNumberChallenged,
+		BlockNumberChallenger:        meta.L2BlockNumberChallenger,
+		Claims:                       enrichedClaims,
+		RollupEndpointErrors:         make(map[string]bool),
+		RollupEndpointErrorCount:     0,
+		RollupEndpointNotFoundCount:  0,
+		RollupEndpointOutOfSyncCount: 0,
+		RollupEndpointTotalCount:     0,
 	}
 	if err := e.applyEnrichers(ctx, blockHash, caller, enrichedGame); err != nil {
 		return nil, fmt.Errorf("failed to enrich game: %w", err)

--- a/op-dispute-mon/mon/extract/extractor_test.go
+++ b/op-dispute-mon/mon/extract/extractor_test.go
@@ -384,6 +384,17 @@ func TestExtractor_EnrichGameInitializesRollupEndpointErrorCount(t *testing.T) {
 	require.Equal(t, 0, enriched[0].RollupEndpointErrorCount, "RollupEndpointErrorCount should be initialized to 0")
 }
 
+func TestExtractor_EnrichGameInitializesRollupEndpointOutOfSyncCount(t *testing.T) {
+	extractor, _, games, _, _ := setupExtractorTest(t)
+	games.games = []gameTypes.GameMetadata{{}}
+	enriched, ignored, failed, err := extractor.Extract(context.Background(), common.Hash{}, 0)
+	require.NoError(t, err)
+	require.Zero(t, ignored)
+	require.Zero(t, failed)
+	require.Len(t, enriched, 1)
+	require.Equal(t, 0, enriched[0].RollupEndpointOutOfSyncCount, "RollupEndpointOutOfSyncCount should be initialized to 0")
+}
+
 type mockEnricher struct {
 	err    error
 	calls  int

--- a/op-dispute-mon/mon/extract/output_agreement_enricher.go
+++ b/op-dispute-mon/mon/extract/output_agreement_enricher.go
@@ -137,6 +137,7 @@ func (o *OutputAgreementEnricher) Enrich(ctx context.Context, block rpcblock.Blo
 			continue
 		}
 		if result.gameL1HeadUnprocessed {
+			game.RollupEndpointOutOfSyncCount++
 			continue
 		}
 

--- a/op-dispute-mon/mon/extract/output_agreement_enricher_test.go
+++ b/op-dispute-mon/mon/extract/output_agreement_enricher_test.go
@@ -410,7 +410,7 @@ func TestOutputAgreementEnricher(t *testing.T) {
 
 	})
 
-	t.Run("RecordEndpointErrorCounts", func(t *testing.T) {
+	t.Run("RecordEndpointErrorCount", func(t *testing.T) {
 		t.Run("SingleNodeErrorCount", func(t *testing.T) {
 			validator, client, _ := setupOutputValidatorTest(t)
 			client.outputErr = errors.New("connection failed")
@@ -492,6 +492,119 @@ func TestOutputAgreementEnricher(t *testing.T) {
 			err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
 			require.NoError(t, err)
 			require.Equal(t, 2, game.RollupEndpointErrorCount)
+		})
+	})
+
+	t.Run("RecordEndpointOutOfSyncCount", func(t *testing.T) {
+		t.Run("NoOutOfSyncNodes", func(t *testing.T) {
+			validator, clients, _ := setupMultiNodeTest(t, 3)
+			// All clients are in sync (currentL1 > game.L1HeadNum)
+			clients[0].currentL1 = 300
+			clients[1].currentL1 = 400
+			clients[2].currentL1 = 500
+
+			game := &types.EnrichedGameData{
+				GameMetadata: challengerTypes.GameMetadata{
+					GameType: 0,
+				},
+				L1HeadNum:                    200,
+				L2BlockNumber:                100,
+				RootClaim:                    mockRootClaim,
+				RollupEndpointErrors:         make(map[string]bool),
+				RollupEndpointOutOfSyncCount: 0,
+			}
+			err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
+			require.NoError(t, err)
+			require.Equal(t, 0, game.RollupEndpointOutOfSyncCount)
+		})
+
+		t.Run("SingleNodeOutOfSync", func(t *testing.T) {
+			validator, clients, _ := setupMultiNodeTest(t, 3)
+			clients[0].currentL1 = 99 // Out of sync
+			clients[1].currentL1 = 300
+			clients[2].currentL1 = 400
+
+			game := &types.EnrichedGameData{
+				GameMetadata: challengerTypes.GameMetadata{
+					GameType: 0,
+				},
+				L1HeadNum:                    200,
+				L2BlockNumber:                100,
+				RootClaim:                    mockRootClaim,
+				RollupEndpointErrors:         make(map[string]bool),
+				RollupEndpointOutOfSyncCount: 0,
+			}
+			err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
+			require.NoError(t, err)
+			require.Equal(t, 1, game.RollupEndpointOutOfSyncCount)
+		})
+
+		t.Run("MultipleNodesOutOfSync", func(t *testing.T) {
+			validator, clients, _ := setupMultiNodeTest(t, 4)
+			clients[0].currentL1 = 99  // Out of sync
+			clients[1].currentL1 = 100 // Out of sync
+			clients[2].currentL1 = 50  // Out of sync
+			clients[3].currentL1 = 300 // In sync
+
+			game := &types.EnrichedGameData{
+				GameMetadata: challengerTypes.GameMetadata{
+					GameType: 0,
+				},
+				L1HeadNum:                    200,
+				L2BlockNumber:                100,
+				RootClaim:                    mockRootClaim,
+				RollupEndpointErrors:         make(map[string]bool),
+				RollupEndpointOutOfSyncCount: 0,
+			}
+			err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
+			require.NoError(t, err)
+			require.Equal(t, 3, game.RollupEndpointOutOfSyncCount)
+		})
+
+		t.Run("AllNodesOutOfSync", func(t *testing.T) {
+			validator, clients, _ := setupMultiNodeTest(t, 3)
+			clients[0].currentL1 = 99
+			clients[1].currentL1 = 100 // Equal to game L1 head, considered out of sync
+			clients[2].currentL1 = 0
+
+			game := &types.EnrichedGameData{
+				GameMetadata: challengerTypes.GameMetadata{
+					GameType: 0,
+				},
+				L1HeadNum:                    200,
+				L2BlockNumber:                100,
+				RootClaim:                    mockRootClaim,
+				RollupEndpointErrors:         make(map[string]bool),
+				RollupEndpointOutOfSyncCount: 0,
+			}
+			err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
+			require.ErrorIs(t, err, ErrAllNodesUnavailable)
+			require.Equal(t, 3, game.RollupEndpointOutOfSyncCount)
+		})
+
+		t.Run("MixedOutOfSyncAndErrors", func(t *testing.T) {
+			validator, clients, _ := setupMultiNodeTest(t, 5)
+			clients[0].currentL1 = 99                     // Out of sync
+			clients[1].outputErr = errors.New("boom")     // Error
+			clients[2].currentL1 = 100                    // Out of sync (equal to game L1 head)
+			clients[3].outputErr = mockNotFoundRPCError() // Not found (not counted as error)
+			clients[4].currentL1 = 300                    // In sync and succeeds
+
+			game := &types.EnrichedGameData{
+				GameMetadata: challengerTypes.GameMetadata{
+					GameType: 0,
+				},
+				L1HeadNum:                    200,
+				L2BlockNumber:                100,
+				RootClaim:                    mockRootClaim,
+				RollupEndpointErrors:         make(map[string]bool),
+				RollupEndpointErrorCount:     0,
+				RollupEndpointOutOfSyncCount: 0,
+			}
+			err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
+			require.NoError(t, err)
+			require.Equal(t, 2, game.RollupEndpointOutOfSyncCount, "should count 2 out-of-sync nodes")
+			require.Equal(t, 1, game.RollupEndpointErrorCount, "should count 1 error (not found is not an error)")
 		})
 	})
 }

--- a/op-dispute-mon/mon/node_endpoint_out_of_sync.go
+++ b/op-dispute-mon/mon/node_endpoint_out_of_sync.go
@@ -1,0 +1,32 @@
+package mon
+
+import (
+	"github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+type NodeEndpointOutOfSyncMetrics interface {
+	RecordNodeEndpointOutOfSyncCount(count int)
+}
+
+type NodeEndpointOutOfSyncMonitor struct {
+	logger  log.Logger
+	metrics NodeEndpointOutOfSyncMetrics
+}
+
+func NewNodeEndpointOutOfSyncMonitor(logger log.Logger, metrics NodeEndpointOutOfSyncMetrics) *NodeEndpointOutOfSyncMonitor {
+	return &NodeEndpointOutOfSyncMonitor{
+		logger:  logger,
+		metrics: metrics,
+	}
+}
+
+func (m *NodeEndpointOutOfSyncMonitor) CheckNodeEndpointOutOfSync(games []*types.EnrichedGameData) {
+	totalOutOfSync := 0
+
+	for _, game := range games {
+		totalOutOfSync += game.RollupEndpointOutOfSyncCount
+	}
+
+	m.metrics.RecordNodeEndpointOutOfSyncCount(totalOutOfSync)
+}

--- a/op-dispute-mon/mon/node_endpoint_out_of_sync_test.go
+++ b/op-dispute-mon/mon/node_endpoint_out_of_sync_test.go
@@ -1,0 +1,125 @@
+package mon
+
+import (
+	"testing"
+
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckNodeEndpointOutOfSync_NoOutOfSync(t *testing.T) {
+	games := []*types.EnrichedGameData{
+		{GameMetadata: gameTypes.GameMetadata{Proxy: common.Address{0x11}}, RollupEndpointOutOfSyncCount: 0},
+		{GameMetadata: gameTypes.GameMetadata{Proxy: common.Address{0x22}}, RollupEndpointOutOfSyncCount: 0},
+		{GameMetadata: gameTypes.GameMetadata{Proxy: common.Address{0x33}}, RollupEndpointOutOfSyncCount: 0},
+	}
+
+	metrics := &stubNodeEndpointOutOfSyncMetrics{}
+	logger := testlog.Logger(t, log.LvlDebug)
+	monitor := NewNodeEndpointOutOfSyncMonitor(logger, metrics)
+
+	monitor.CheckNodeEndpointOutOfSync(games)
+
+	require.Equal(t, 0, metrics.recordedCount)
+}
+
+func TestCheckNodeEndpointOutOfSync_SingleGameOutOfSync(t *testing.T) {
+	games := []*types.EnrichedGameData{
+		{
+			GameMetadata:                 gameTypes.GameMetadata{Proxy: common.Address{0x11}},
+			RollupEndpointOutOfSyncCount: 5,
+		},
+		{
+			GameMetadata:                 gameTypes.GameMetadata{Proxy: common.Address{0x22}},
+			RollupEndpointOutOfSyncCount: 0,
+		},
+	}
+
+	metrics := &stubNodeEndpointOutOfSyncMetrics{}
+	logger := testlog.Logger(t, log.LvlDebug)
+	monitor := NewNodeEndpointOutOfSyncMonitor(logger, metrics)
+
+	monitor.CheckNodeEndpointOutOfSync(games)
+
+	require.Equal(t, 5, metrics.recordedCount)
+}
+
+func TestCheckNodeEndpointOutOfSync_MultipleGamesOutOfSync(t *testing.T) {
+	games := []*types.EnrichedGameData{
+		{
+			GameMetadata:                 gameTypes.GameMetadata{Proxy: common.Address{0x11}},
+			RollupEndpointOutOfSyncCount: 3,
+		},
+		{
+			GameMetadata:                 gameTypes.GameMetadata{Proxy: common.Address{0x22}},
+			RollupEndpointOutOfSyncCount: 7,
+		},
+		{
+			GameMetadata:                 gameTypes.GameMetadata{Proxy: common.Address{0x33}},
+			RollupEndpointOutOfSyncCount: 2,
+		},
+	}
+
+	metrics := &stubNodeEndpointOutOfSyncMetrics{}
+	logger := testlog.Logger(t, log.LvlDebug)
+	monitor := NewNodeEndpointOutOfSyncMonitor(logger, metrics)
+
+	monitor.CheckNodeEndpointOutOfSync(games)
+
+	// Should sum all out-of-sync counts (3 + 7 + 2 = 12)
+	require.Equal(t, 12, metrics.recordedCount)
+}
+
+func TestCheckNodeEndpointOutOfSync_MixedGamesWithAndWithoutOutOfSync(t *testing.T) {
+	games := []*types.EnrichedGameData{
+		{
+			GameMetadata:                 gameTypes.GameMetadata{Proxy: common.Address{0x11}},
+			RollupEndpointOutOfSyncCount: 0,
+		},
+		{
+			GameMetadata:                 gameTypes.GameMetadata{Proxy: common.Address{0x22}},
+			RollupEndpointOutOfSyncCount: 4,
+		},
+		{
+			GameMetadata:                 gameTypes.GameMetadata{Proxy: common.Address{0x33}},
+			RollupEndpointOutOfSyncCount: 0,
+		},
+		{
+			GameMetadata:                 gameTypes.GameMetadata{Proxy: common.Address{0x44}},
+			RollupEndpointOutOfSyncCount: 6,
+		},
+	}
+
+	metrics := &stubNodeEndpointOutOfSyncMetrics{}
+	logger := testlog.Logger(t, log.LvlDebug)
+	monitor := NewNodeEndpointOutOfSyncMonitor(logger, metrics)
+
+	monitor.CheckNodeEndpointOutOfSync(games)
+
+	// Should sum only non-zero out-of-sync counts (4 + 6 = 10)
+	require.Equal(t, 10, metrics.recordedCount)
+}
+
+func TestCheckNodeEndpointOutOfSync_EmptyGamesList(t *testing.T) {
+	games := []*types.EnrichedGameData{}
+
+	metrics := &stubNodeEndpointOutOfSyncMetrics{}
+	logger := testlog.Logger(t, log.LvlDebug)
+	monitor := NewNodeEndpointOutOfSyncMonitor(logger, metrics)
+
+	monitor.CheckNodeEndpointOutOfSync(games)
+
+	require.Equal(t, 0, metrics.recordedCount)
+}
+
+type stubNodeEndpointOutOfSyncMetrics struct {
+	recordedCount int
+}
+
+func (s *stubNodeEndpointOutOfSyncMetrics) RecordNodeEndpointOutOfSyncCount(count int) {
+	s.recordedCount = count
+}

--- a/op-dispute-mon/mon/service.go
+++ b/op-dispute-mon/mon/service.go
@@ -238,6 +238,7 @@ func (s *Service) initMonitor(ctx context.Context, cfg *config.Config) {
 	updateTimeMonitor := NewUpdateTimeMonitor(s.cl, s.metrics)
 	nodeEndpointErrorsMonitor := NewNodeEndpointErrorsMonitor(s.logger, s.metrics)
 	nodeEndpointErrorCountMonitor := NewNodeEndpointErrorCountMonitor(s.logger, s.metrics)
+	nodeEndpointOutOfSyncMonitor := NewNodeEndpointOutOfSyncMonitor(s.logger, s.metrics)
 	mixedAvailabilityMonitor := NewMixedAvailability(s.logger, s.metrics)
 	mixedSafetyMonitor := NewMixedSafetyMonitor(s.logger, s.metrics)
 	differentOutputRootMonitor := NewDifferentOutputRootMonitor(s.logger, s.metrics)
@@ -252,6 +253,7 @@ func (s *Service) initMonitor(ctx context.Context, cfg *config.Config) {
 		updateTimeMonitor.CheckUpdateTimes,
 		nodeEndpointErrorsMonitor.CheckNodeEndpointErrors,
 		nodeEndpointErrorCountMonitor.CheckNodeEndpointErrorCount,
+		nodeEndpointOutOfSyncMonitor.CheckNodeEndpointOutOfSync,
 		mixedAvailabilityMonitor.CheckMixedAvailability,
 		mixedSafetyMonitor.CheckMixedSafety,
 		differentOutputRootMonitor.CheckDifferentOutputRoots)

--- a/op-dispute-mon/mon/types/types.go
+++ b/op-dispute-mon/mon/types/types.go
@@ -69,6 +69,9 @@ type EnrichedGameData struct {
 	// RollupEndpointNotFoundCount tracks the number of endpoints that returned "not found" for this game.
 	RollupEndpointNotFoundCount int
 
+	// RollupEndpointOutOfSyncCount tracks the number of endpoints that were out of sync for this game.
+	RollupEndpointOutOfSyncCount int
+
 	// RollupEndpointTotalCount tracks the total number of rollup endpoints attempted for this game.
 	RollupEndpointTotalCount int
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Add a new metric to track out-of-sync node endpoints.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

Part of https://github.com/ethereum-optimism/optimism/issues/11020

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
