### PR TITLE
Remove redundant path join in update-op-geth helper

### DIFF
--- a/ops/scripts/update-op-geth.py
+++ b/ops/scripts/update-op-geth.py
@@ -2,7 +2,6 @@
 
 
 import subprocess
-import os
 
 
 GETH_VERSION='v1.12.0'
@@ -22,13 +21,13 @@ def update_mod(project):
 		'edit',
 		'-replace',
 		f'github.com/ethereum/go-ethereum@{GETH_VERSION}=github.com/ethereum-optimism/op-geth@optimism'
-	], cwd=os.path.join(project), check=True)
+	], cwd=project, check=True)
 	print('Tidying...')
 	subprocess.run([
 		'go',
 		'mod',
 		'tidy'
-	], cwd=os.path.join(project), check=True)
+	], cwd=project, check=True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Drop the unused os import from update-op-geth.py pass the already-correct project value directly to subprocess.run, eliminating the redundant os.path.join call