### PR TITLE
contracts: Update ForkLive to support cannon kona

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1192,8 +1192,6 @@ jobs:
             ETH_RPC_URL: <<parameters.fork_base_rpc>>
             FORK_OP_CHAIN: <<parameters.fork_op_chain>>
             FORK_BASE_CHAIN: <<parameters.fork_base_chain>>
-            DEV_FEATURE__CANNON_KONA: true
-            DEV_FEATURE__DEPLOY_V2_DISPUTE_GAMES: true
           working_directory: packages/contracts-bedrock
           no_output_timeout: 15m
       - run:
@@ -1207,8 +1205,6 @@ jobs:
             ETH_RPC_URL: <<parameters.fork_base_rpc>>
             FORK_OP_CHAIN: <<parameters.fork_op_chain>>
             FORK_BASE_CHAIN: <<parameters.fork_base_chain>>
-            DEV_FEATURE__CANNON_KONA: true
-            DEV_FEATURE__DEPLOY_V2_DISPUTE_GAMES: true
           working_directory: packages/contracts-bedrock
           when: on_fail
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1192,6 +1192,8 @@ jobs:
             ETH_RPC_URL: <<parameters.fork_base_rpc>>
             FORK_OP_CHAIN: <<parameters.fork_op_chain>>
             FORK_BASE_CHAIN: <<parameters.fork_base_chain>>
+            DEV_FEATURE__CANNON_KONA: true
+            DEV_FEATURE__DEPLOY_V2_DISPUTE_GAMES: true
           working_directory: packages/contracts-bedrock
           no_output_timeout: 15m
       - run:
@@ -1205,6 +1207,8 @@ jobs:
             ETH_RPC_URL: <<parameters.fork_base_rpc>>
             FORK_OP_CHAIN: <<parameters.fork_op_chain>>
             FORK_BASE_CHAIN: <<parameters.fork_base_chain>>
+            DEV_FEATURE__CANNON_KONA: true
+            DEV_FEATURE__DEPLOY_V2_DISPUTE_GAMES: true
           working_directory: packages/contracts-bedrock
           when: on_fail
       - save_cache:

--- a/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
@@ -165,7 +165,7 @@ contract OPContractsManager_Upgrade_Harness is CommonTest, DisputeGames {
             IDelayedWETH(payable(artifacts.mustGetAddress("PermissionedDelayedWETHProxy")));
         delayedWeth = IDelayedWETH(payable(artifacts.mustGetAddress("PermissionlessDelayedWETHProxy")));
         permissionedDisputeGame = IPermissionedDisputeGame(address(artifacts.mustGetAddress("PermissionedDisputeGame")));
-        faultDisputeGame = IFaultDisputeGame(address(artifacts.mustGetAddress("FaultDisputeGame")));
+        faultDisputeGame = IFaultDisputeGame(address(artifacts.mustGetAddress("FaultDisputeGameCannon")));
 
         // grab the pre-upgrade state
         preUpgradeState = PreUpgradeState({

--- a/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
@@ -179,7 +179,7 @@ abstract contract OPContractsManagerStandardValidator_TestInit is CommonTest, Di
 
         if (isForkTest()) {
             // Load the FaultDisputeGame once, we'll need it later.
-            fdgImpl = IFaultDisputeGame(artifacts.mustGetAddress("FaultDisputeGame"));
+            fdgImpl = IFaultDisputeGame(artifacts.mustGetAddress("FaultDisputeGameCannon"));
 
             // Add the FaultDisputeGame to the DisputeGameFactory.
             vm.prank(disputeGameFactory.owner());

--- a/packages/contracts-bedrock/test/setup/ForkLive.s.sol
+++ b/packages/contracts-bedrock/test/setup/ForkLive.s.sol
@@ -289,8 +289,6 @@ contract ForkLive is Deployer, StdAssertions, FeatureFlags {
 
         address cannonDisputeGame = address(disputeGameFactory.gameImpls(GameTypes.CANNON));
         if (cannonDisputeGame != address(0)) {
-            // Store under FaultDisputeGame for backwards compatibility with superchain-registry
-            artifacts.save("FaultDisputeGame", address(cannonDisputeGame));
             artifacts.save("FaultDisputeGameCannon", address(cannonDisputeGame));
         }
 

--- a/packages/contracts-bedrock/test/setup/ForkLive.s.sol
+++ b/packages/contracts-bedrock/test/setup/ForkLive.s.sol
@@ -282,11 +282,16 @@ contract ForkLive is Deployer, StdAssertions, FeatureFlags {
         address permissionedDisputeGame = address(disputeGameFactory.gameImpls(GameTypes.PERMISSIONED_CANNON));
         artifacts.save("PermissionedDisputeGame", permissionedDisputeGame);
 
-        address permissionlessDisputeGame = address(disputeGameFactory.gameImpls(GameTypes.CANNON));
-        if (permissionlessDisputeGame != address(0)) {
+        address cannonDisputeGame = address(disputeGameFactory.gameImpls(GameTypes.CANNON));
+        if (cannonDisputeGame != address(0)) {
             // Both names are used in different places, so we save both.
-            artifacts.save("PermissionlessDisputeGame", address(permissionlessDisputeGame));
-            artifacts.save("FaultDisputeGame", address(permissionlessDisputeGame));
+            artifacts.save("PermissionlessDisputeGame", address(cannonDisputeGame));
+            artifacts.save("FaultDisputeGame", address(cannonDisputeGame));
+        }
+
+        address cannonKonaDisputeGame = address(disputeGameFactory.gameImpls(GameTypes.CANNON_KONA));
+        if (cannonKonaDisputeGame != address(0)) {
+            artifacts.save("FaultDisputeGameCannonKona", address(cannonKonaDisputeGame));
         }
 
         IAnchorStateRegistry newAnchorStateRegistry;

--- a/packages/contracts-bedrock/test/setup/ForkLive.s.sol
+++ b/packages/contracts-bedrock/test/setup/ForkLive.s.sol
@@ -285,8 +285,8 @@ contract ForkLive is Deployer, StdAssertions, FeatureFlags {
         address cannonDisputeGame = address(disputeGameFactory.gameImpls(GameTypes.CANNON));
         if (cannonDisputeGame != address(0)) {
             // Both names are used in different places, so we save both.
-//            artifacts.save("PermissionlessDisputeGame", address(cannonDisputeGame));
-//            artifacts.save("FaultDisputeGame", address(cannonDisputeGame));
+            artifacts.save("PermissionlessDisputeGame", address(cannonDisputeGame));
+            artifacts.save("FaultDisputeGame", address(cannonDisputeGame));
             artifacts.save("FaultDisputeGameCannon", address(cannonDisputeGame));
         }
 

--- a/packages/contracts-bedrock/test/setup/ForkLive.s.sol
+++ b/packages/contracts-bedrock/test/setup/ForkLive.s.sol
@@ -289,6 +289,8 @@ contract ForkLive is Deployer, StdAssertions, FeatureFlags {
 
         address cannonDisputeGame = address(disputeGameFactory.gameImpls(GameTypes.CANNON));
         if (cannonDisputeGame != address(0)) {
+            // Store under FaultDisputeGame for backwards compatibility with superchain-registry
+            artifacts.save("FaultDisputeGame", address(cannonDisputeGame));
             artifacts.save("FaultDisputeGameCannon", address(cannonDisputeGame));
         }
 

--- a/packages/contracts-bedrock/test/setup/ForkLive.s.sol
+++ b/packages/contracts-bedrock/test/setup/ForkLive.s.sol
@@ -177,9 +177,14 @@ contract ForkLive is Deployer, StdAssertions, FeatureFlags {
         artifacts.save("MipsSingleton", vm.parseTomlAddress(opToml, ".addresses.MIPS"));
         IDisputeGameFactory disputeGameFactory =
             IDisputeGameFactory(artifacts.mustGetAddress("DisputeGameFactoryProxy"));
-        IFaultDisputeGame faultDisputeGame = IFaultDisputeGame(address(disputeGameFactory.gameImpls(GameTypes.CANNON)));
-        artifacts.save("FaultDisputeGame", address(faultDisputeGame));
-        artifacts.save("PermissionlessDelayedWETHProxy", address(faultDisputeGame.weth()));
+        IFaultDisputeGame cannonDisputeGame = IFaultDisputeGame(address(disputeGameFactory.gameImpls(GameTypes.CANNON)));
+        artifacts.save("FaultDisputeGameCannon", address(cannonDisputeGame));
+        artifacts.save("PermissionlessDelayedWETHProxy", address(cannonDisputeGame.weth()));
+        IFaultDisputeGame cannonKonaDisputeGame =
+            IFaultDisputeGame(address(disputeGameFactory.gameImpls(GameTypes.CANNON_KONA)));
+        if (address(cannonKonaDisputeGame) != address(0)) {
+            artifacts.save("FaultDisputeGameCannonKona", address(cannonKonaDisputeGame));
+        }
 
         // The PermissionedDisputeGame and PermissionedDelayedWETHProxy are not listed in the registry for OP, so we
         // look it up onchain
@@ -284,9 +289,6 @@ contract ForkLive is Deployer, StdAssertions, FeatureFlags {
 
         address cannonDisputeGame = address(disputeGameFactory.gameImpls(GameTypes.CANNON));
         if (cannonDisputeGame != address(0)) {
-            // Both names are used in different places, so we save both.
-            artifacts.save("PermissionlessDisputeGame", address(cannonDisputeGame));
-            artifacts.save("FaultDisputeGame", address(cannonDisputeGame));
             artifacts.save("FaultDisputeGameCannon", address(cannonDisputeGame));
         }
 

--- a/packages/contracts-bedrock/test/setup/ForkLive.s.sol
+++ b/packages/contracts-bedrock/test/setup/ForkLive.s.sol
@@ -285,8 +285,9 @@ contract ForkLive is Deployer, StdAssertions, FeatureFlags {
         address cannonDisputeGame = address(disputeGameFactory.gameImpls(GameTypes.CANNON));
         if (cannonDisputeGame != address(0)) {
             // Both names are used in different places, so we save both.
-            artifacts.save("PermissionlessDisputeGame", address(cannonDisputeGame));
-            artifacts.save("FaultDisputeGame", address(cannonDisputeGame));
+//            artifacts.save("PermissionlessDisputeGame", address(cannonDisputeGame));
+//            artifacts.save("FaultDisputeGame", address(cannonDisputeGame));
+            artifacts.save("FaultDisputeGameCannon", address(cannonDisputeGame));
         }
 
         address cannonKonaDisputeGame = address(disputeGameFactory.gameImpls(GameTypes.CANNON_KONA));


### PR DESCRIPTION
**Description**

Updates ForkLive.s.sol to identify cannon kona.  Fork tests pass both with no dev features enabled and with CANNON_KONA and DEPLOY_V2_DISPUTE_GAMES features enabled.

Ran the fork tests by explicitly setting the env vars in circleci config temporarily. We probably can't run fork tests with different feature combinations all the time or we'll exceed API rate limits on the nodes they use.

**Metadata**

Fixes https://github.com/ethereum-optimism/optimism/issues/17741