### PR TITLE
all: Move fork names into new op-core/forks package

### DIFF
--- a/devnet-sdk/testing/testlib/validators/forks.go
+++ b/devnet-sdk/testing/testlib/validators/forks.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/devnet-sdk/system"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/testing/systest"
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum/go-ethereum/params"
 )
 
@@ -39,32 +39,32 @@ func getChainConfig(t systest.T, sys system.System, chainIdx uint64) (*params.Ch
 
 // IsForkActivated checks if a specific fork is activated at the given timestamp
 // based on the chain configuration.
-func IsForkActivated(c *params.ChainConfig, forkName rollup.ForkName, timestamp uint64) (bool, error) {
+func IsForkActivated(c *params.ChainConfig, forkName forks.Name, timestamp uint64) (bool, error) {
 	if c == nil {
 		return false, fmt.Errorf("provided chain config is nil")
 	}
 
 	switch forkName {
-	case rollup.Bedrock:
+	case forks.Bedrock:
 		// Bedrock is activated based on block number, not timestamp
 		return true, nil // Assuming bedrock is always active in the context of this validator
-	case rollup.Regolith:
+	case forks.Regolith:
 		return c.IsOptimismRegolith(timestamp), nil
-	case rollup.Canyon:
+	case forks.Canyon:
 		return c.IsOptimismCanyon(timestamp), nil
-	case rollup.Ecotone:
+	case forks.Ecotone:
 		return c.IsOptimismEcotone(timestamp), nil
-	case rollup.Fjord:
+	case forks.Fjord:
 		return c.IsOptimismFjord(timestamp), nil
-	case rollup.Granite:
+	case forks.Granite:
 		return c.IsOptimismGranite(timestamp), nil
-	case rollup.Holocene:
+	case forks.Holocene:
 		return c.IsOptimismHolocene(timestamp), nil
-	case rollup.Isthmus:
+	case forks.Isthmus:
 		return c.IsOptimismIsthmus(timestamp), nil
-	case rollup.Jovian:
+	case forks.Jovian:
 		return c.IsOptimismJovian(timestamp), nil
-	case rollup.Interop:
+	case forks.Interop:
 		return c.IsInterop(timestamp), nil
 	default:
 		return false, fmt.Errorf("unknown fork name: %s", forkName)
@@ -72,7 +72,7 @@ func IsForkActivated(c *params.ChainConfig, forkName rollup.ForkName, timestamp 
 }
 
 // forkConfigValidator is a helper function that checks if a specific L2 chain meets a fork condition.
-func forkConfigValidator(chainIdx uint64, forkName rollup.ForkName, shouldBeActive bool, forkConfigMarker interface{}) systest.PreconditionValidator {
+func forkConfigValidator(chainIdx uint64, forkName forks.Name, shouldBeActive bool, forkConfigMarker interface{}) systest.PreconditionValidator {
 	return func(t systest.T, sys system.System) (context.Context, error) {
 		chainConfig, timestamp, err := getChainConfig(t, sys, chainIdx)
 		if err != nil {
@@ -105,7 +105,7 @@ type ChainConfigGetter = func(context.Context) *params.ChainConfig
 // AcquireForkConfig returns a ForkConfigGetter and a PreconditionValidator
 // that ensures a ForkConfig is available for the specified L2 chain.
 // The ForkConfig can be used to check if various forks are activated.
-func acquireForkConfig(chainIdx uint64, forkName rollup.ForkName, shouldBeActive bool) (ChainConfigGetter, systest.PreconditionValidator) {
+func acquireForkConfig(chainIdx uint64, forkName forks.Name, shouldBeActive bool) (ChainConfigGetter, systest.PreconditionValidator) {
 	chainConfigMarker := new(byte)
 	validator := forkConfigValidator(chainIdx, forkName, shouldBeActive, chainConfigMarker)
 	return func(ctx context.Context) *params.ChainConfig {
@@ -114,13 +114,13 @@ func acquireForkConfig(chainIdx uint64, forkName rollup.ForkName, shouldBeActive
 }
 
 // RequiresFork returns a validator that ensures a specific L2 chain has a specific fork activated.
-func AcquireL2WithFork(chainIdx uint64, forkName rollup.ForkName) (ChainConfigGetter, systest.PreconditionValidator) {
+func AcquireL2WithFork(chainIdx uint64, forkName forks.Name) (ChainConfigGetter, systest.PreconditionValidator) {
 	return acquireForkConfig(chainIdx, forkName, true)
 }
 
 // RequiresNotFork returns a validator that ensures a specific L2 chain does not
 // have a specific fork activated. Will not work with the interop fork
 // specifically since interop is not an ordered release fork.
-func AcquireL2WithoutFork(chainIdx uint64, forkName rollup.ForkName) (ChainConfigGetter, systest.PreconditionValidator) {
+func AcquireL2WithoutFork(chainIdx uint64, forkName forks.Name) (ChainConfigGetter, systest.PreconditionValidator) {
 	return acquireForkConfig(chainIdx, forkName, false)
 }

--- a/devnet-sdk/testing/testlib/validators/validators_test.go
+++ b/devnet-sdk/testing/testlib/validators/validators_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ethereum-optimism/optimism/devnet-sdk/system"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/testing/systest"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/types"
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -33,7 +33,7 @@ func TestValidators(t *testing.T) {
 	t.Run("multiple validators", func(t *testing.T) {
 		walletGetter1, validator1 := AcquireL2WalletWithFunds(0, types.NewBalance(big.NewInt(1)))
 		walletGetter2, validator2 := AcquireL2WalletWithFunds(0, types.NewBalance(big.NewInt(10)))
-		chainConfigGetter, l2ForkValidator := AcquireL2WithFork(0, rollup.Isthmus)
+		chainConfigGetter, l2ForkValidator := AcquireL2WithFork(0, forks.Isthmus)
 
 		// We create a system that has a low-level L1 chain and at least one wallet
 		systestSystem := &mockSystem{
@@ -109,7 +109,7 @@ func TestValidators(t *testing.T) {
 		}
 
 		// Get the validator for requiring Isthmus fork to be active
-		chainConfigGetter, validator := AcquireL2WithFork(0, rollup.Isthmus)
+		chainConfigGetter, validator := AcquireL2WithFork(0, forks.Isthmus)
 		systestT := systest.NewT(t)
 
 		// Apply the validator
@@ -119,7 +119,7 @@ func TestValidators(t *testing.T) {
 		// Verify the chain config getter works
 		chainConfig := chainConfigGetter(ctx)
 		require.NotNil(t, chainConfig)
-		isActive, err := IsForkActivated(chainConfig, rollup.Isthmus, 100)
+		isActive, err := IsForkActivated(chainConfig, forks.Isthmus, 100)
 		require.NoError(t, err)
 		require.True(t, isActive)
 	})
@@ -143,7 +143,7 @@ func TestValidators(t *testing.T) {
 		}
 
 		// Get the validator for requiring Isthmus fork to be active
-		_, validator := AcquireL2WithFork(0, rollup.Isthmus)
+		_, validator := AcquireL2WithFork(0, forks.Isthmus)
 		systestT := systest.NewT(t)
 
 		// Apply the validator - should fail since fork is not active
@@ -171,7 +171,7 @@ func TestValidators(t *testing.T) {
 		}
 
 		// Get the validator for requiring Isthmus fork to not be active
-		chainConfigGetter, validator := AcquireL2WithoutFork(0, rollup.Isthmus)
+		chainConfigGetter, validator := AcquireL2WithoutFork(0, forks.Isthmus)
 		systestT := systest.NewT(t)
 
 		// Apply the validator
@@ -181,7 +181,7 @@ func TestValidators(t *testing.T) {
 		// Verify the chain config getter works
 		chainConfig := chainConfigGetter(ctx)
 		require.NotNil(t, chainConfig)
-		isActive, err := IsForkActivated(chainConfig, rollup.Isthmus, 100)
+		isActive, err := IsForkActivated(chainConfig, forks.Isthmus, 100)
 		require.NoError(t, err)
 		require.False(t, isActive)
 	})
@@ -205,7 +205,7 @@ func TestValidators(t *testing.T) {
 		}
 
 		// Get the validator for requiring Isthmus fork to not be active
-		_, validator := AcquireL2WithoutFork(0, rollup.Isthmus)
+		_, validator := AcquireL2WithoutFork(0, forks.Isthmus)
 		systestT := systest.NewT(t)
 
 		// Apply the validator - should fail since fork is active
@@ -221,7 +221,7 @@ func TestValidators(t *testing.T) {
 		}
 
 		// Try to get chain config for an invalid chain index
-		_, validator := AcquireL2WithFork(0, rollup.Isthmus)
+		_, validator := AcquireL2WithFork(0, forks.Isthmus)
 		systestT := systest.NewT(t)
 
 		// Apply the validator - should fail since chain index is out of range

--- a/op-acceptance-tests/tests/ecotone/fees_test.go
+++ b/op-acceptance-tests/tests/ecotone/fees_test.go
@@ -4,10 +4,10 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
@@ -16,7 +16,7 @@ func TestFees(gt *testing.T) {
 	sys := presets.NewMinimal(t)
 	require := t.Require()
 
-	err := dsl.RequiresL2Fork(t.Ctx(), sys, 0, rollup.Ecotone)
+	err := dsl.RequiresL2Fork(t.Ctx(), sys, 0, forks.Ecotone)
 	require.NoError(err, "Ecotone fork must be active for this test")
 
 	alice := sys.FunderL2.NewFundedEOA(eth.OneTenthEther)

--- a/op-acceptance-tests/tests/fjord/check_scripts_test.go
+++ b/op-acceptance-tests/tests/fjord/check_scripts_test.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/ethereum/go-ethereum/rpc"
 
+	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/predeploys"
 	txib "github.com/ethereum-optimism/optimism/op-service/txintent/bindings"
@@ -34,7 +34,7 @@ func TestCheckFjordScript(gt *testing.T) {
 	require := t.Require()
 	ctx := t.Ctx()
 
-	err := dsl.RequiresL2Fork(ctx, sys, 0, rollup.Fjord)
+	err := dsl.RequiresL2Fork(ctx, sys, 0, forks.Fjord)
 	require.NoError(err)
 
 	wallet := sys.FunderL2.NewFundedEOA(eth.OneThirdEther)

--- a/op-acceptance-tests/tests/fjord/fees_test.go
+++ b/op-acceptance-tests/tests/fjord/fees_test.go
@@ -7,7 +7,7 @@ import (
 	dsl "github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/predeploys"
 	txib "github.com/ethereum-optimism/optimism/op-service/txintent/bindings"
@@ -19,7 +19,7 @@ func TestFees(gt *testing.T) {
 	require := t.Require()
 	ctx := t.Ctx()
 
-	err := dsl.RequiresL2Fork(ctx, sys, 0, rollup.Fjord)
+	err := dsl.RequiresL2Fork(ctx, sys, 0, forks.Fjord)
 	require.NoError(err)
 	operatorFee := dsl.NewOperatorFee(t, sys.L2Chain, sys.L1EL)
 	operatorFee.SetOperatorFee(100000000, 500)

--- a/op-acceptance-tests/tests/interop/upgrade-singlechain/crossl2inbox_test.go
+++ b/op-acceptance-tests/tests/interop/upgrade-singlechain/crossl2inbox_test.go
@@ -4,11 +4,11 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
+	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack/match"
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/predeploys"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -22,7 +22,7 @@ func TestPostInbox(gt *testing.T) {
 		require := t.Require()
 		el := net.Escape().L2ELNode(match.FirstL2EL)
 
-		activationBlock := net.AwaitActivation(t, rollup.Interop)
+		activationBlock := net.AwaitActivation(t, forks.Interop)
 		require.NotZero(activationBlock, "must not activate interop at genesis")
 
 		pre := activationBlock.Number - 1

--- a/op-acceptance-tests/tests/interop/upgrade/post_test.go
+++ b/op-acceptance-tests/tests/interop/upgrade/post_test.go
@@ -7,19 +7,19 @@ import (
 	"testing"
 	"time"
 
-	stypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
-
 	"github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/interop"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
+	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack/match"
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/predeploys"
+	stypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 )
 
 func TestPostInbox(gt *testing.T) {
@@ -28,7 +28,7 @@ func TestPostInbox(gt *testing.T) {
 	sys := presets.NewSimpleInterop(t)
 	devtest.RunParallel(t, sys.L2Networks(), func(t devtest.T, net *dsl.L2Network) {
 		require := t.Require()
-		activationBlock := net.AwaitActivation(t, rollup.Interop)
+		activationBlock := net.AwaitActivation(t, forks.Interop)
 
 		el := net.Escape().L2ELNode(match.FirstL2EL)
 		implAddrBytes, err := el.EthClient().GetStorageAt(t.Ctx(), predeploys.CrossL2InboxAddr,
@@ -96,7 +96,7 @@ func testSupervisorAnchorBlock(t devtest.T, sys *presets.SimpleInterop) {
 			t.Gate().True(upgradeTime.Before(deadline), "test must not time out before upgrade happens")
 		}
 
-		activationBlock := net.AwaitActivation(t, rollup.Interop)
+		activationBlock := net.AwaitActivation(t, forks.Interop)
 		sys.Supervisor.WaitForL2HeadToAdvanceTo(net.ChainID(), stypes.CrossSafe, activationBlock)
 
 		logger.Info("Validating anchor block timing",

--- a/op-acceptance-tests/tests/isthmus/erc20_bridge/erc20_bridge_test.go
+++ b/op-acceptance-tests/tests/isthmus/erc20_bridge/erc20_bridge_test.go
@@ -3,11 +3,11 @@ package erc20bridge
 import (
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl/contract"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/txintent/bindings"
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
@@ -18,7 +18,7 @@ func TestERC20Bridge(gt *testing.T) {
 	sys := presets.NewMinimal(t)
 	require := t.Require()
 
-	err := dsl.RequiresL2Fork(t.Ctx(), sys, 0, rollup.Isthmus)
+	err := dsl.RequiresL2Fork(t.Ctx(), sys, 0, forks.Isthmus)
 	require.NoError(err, "Isthmus fork must be active for this test")
 
 	// Create users with same identity on both chains

--- a/op-acceptance-tests/tests/isthmus/operator_fee/operator_fee_test.go
+++ b/op-acceptance-tests/tests/isthmus/operator_fee/operator_fee_test.go
@@ -3,16 +3,16 @@ package operatorfee
 import (
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
 )
 
 func TestOperatorFee(gt *testing.T) {
 	t := devtest.SerialT(gt)
 	sys := presets.NewMinimal(t)
-	err := dsl.RequiresL2Fork(t.Ctx(), sys, 0, rollup.Isthmus)
+	err := dsl.RequiresL2Fork(t.Ctx(), sys, 0, forks.Isthmus)
 	t.Require().NoError(err, "Isthmus fork must be active for this test")
 	dsl.RunOperatorFeeTest(t, sys.L2Chain, sys.L1EL, sys.FunderL1, sys.FunderL2)
 }

--- a/op-acceptance-tests/tests/isthmus/pectra/pectra_features_test.go
+++ b/op-acceptance-tests/tests/isthmus/pectra/pectra_features_test.go
@@ -6,10 +6,10 @@ import (
 	"encoding/binary"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
 	"github.com/ethereum/go-ethereum/common"
@@ -31,7 +31,7 @@ func TestPectra(gt *testing.T) {
 	sys := presets.NewMinimal(t)
 	require := t.Require()
 
-	err := dsl.RequiresL2Fork(t.Ctx(), sys, 0, rollup.Isthmus)
+	err := dsl.RequiresL2Fork(t.Ctx(), sys, 0, forks.Isthmus)
 	require.NoError(err, "Isthmus fork must be active for Pectra features")
 
 	alice := sys.FunderL2.NewFundedEOA(eth.OneTenthEther)

--- a/op-acceptance-tests/tests/isthmus/withdrawal_root/withdrawals_root_test.go
+++ b/op-acceptance-tests/tests/isthmus/withdrawal_root/withdrawals_root_test.go
@@ -3,10 +3,10 @@ package withdrawal
 import (
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
@@ -15,7 +15,7 @@ func TestWithdrawalRoot(gt *testing.T) {
 	sys := presets.NewMinimal(t)
 	require := sys.T.Require()
 
-	err := dsl.RequiresL2Fork(t.Ctx(), sys, 0, rollup.Isthmus)
+	err := dsl.RequiresL2Fork(t.Ctx(), sys, 0, forks.Isthmus)
 	require.NoError(err, "Isthmus fork must be active for this test")
 
 	secondCheck, err := dsl.CheckForChainFork(t.Ctx(), sys.L2Networks(), t.Logger())

--- a/op-acceptance-tests/tests/jovian/da_footprint_test.go
+++ b/op-acceptance-tests/tests/jovian/da_footprint_test.go
@@ -10,10 +10,10 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/interop/loadtest"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
+	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/txinclude"
@@ -121,7 +121,7 @@ func TestDAFootprint(gt *testing.T) {
 	sys := presets.NewMinimal(t)
 	require := t.Require()
 
-	err := dsl.RequiresL2Fork(t.Ctx(), sys, 0, rollup.Jovian)
+	err := dsl.RequiresL2Fork(t.Ctx(), sys, 0, forks.Jovian)
 	require.NoError(err, "Jovian fork must be active for this test")
 
 	env := newDAFootprintEnv(t, sys.L2Chain, sys.L1EL, sys.L2EL)

--- a/op-acceptance-tests/tests/jovian/min_base_fee_test.go
+++ b/op-acceptance-tests/tests/jovian/min_base_fee_test.go
@@ -4,10 +4,10 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 
 	"encoding/binary"
@@ -122,7 +122,7 @@ func TestMinBaseFee(gt *testing.T) {
 	sys := presets.NewMinimal(t)
 	require := t.Require()
 
-	err := dsl.RequiresL2Fork(t.Ctx(), sys, 0, rollup.Jovian)
+	err := dsl.RequiresL2Fork(t.Ctx(), sys, 0, forks.Jovian)
 	require.NoError(err, "Jovian fork must be active for this test")
 
 	minBaseFee := newMinBaseFee(t, sys.L2Chain, sys.L1EL, sys.L2EL)

--- a/op-acceptance-tests/tests/jovian/operator_fee_test.go
+++ b/op-acceptance-tests/tests/jovian/operator_fee_test.go
@@ -3,16 +3,16 @@ package jovian
 import (
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
 )
 
 func TestOperatorFee(gt *testing.T) {
 	t := devtest.SerialT(gt)
 	sys := presets.NewMinimal(t)
-	err := dsl.RequiresL2Fork(t.Ctx(), sys, 0, rollup.Jovian)
+	err := dsl.RequiresL2Fork(t.Ctx(), sys, 0, forks.Jovian)
 	t.Require().NoError(err, "Jovian fork must be active for this test")
 	dsl.RunOperatorFeeTest(t, sys.L2Chain, sys.L1EL, sys.FunderL1, sys.FunderL2)
 }

--- a/op-acceptance-tests/tests/sync_tester/sync_tester_hfs/init_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_tester_hfs/init_test.go
@@ -4,18 +4,18 @@ import (
 	"testing"
 
 	bss "github.com/ethereum-optimism/optimism/op-batcher/batcher"
+	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum-optimism/optimism/op-devstack/compat"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 )
 
 func TestMain(m *testing.M) {
 	presets.DoMain(m, presets.WithSimpleWithSyncTester(),
 		presets.WithCompatibleTypes(compat.SysGo),
-		presets.WithHardforkSequentialActivation(rollup.Bedrock, rollup.Jovian, 15),
+		presets.WithHardforkSequentialActivation(forks.Bedrock, forks.Jovian, 15),
 		stack.MakeCommon(sysgo.WithBatcherOption(func(id stack.L2BatcherID, cfg *bss.CLIConfig) {
 			// For supporting pre-delta batches
 			cfg.BatchType = derive.SingularBatchType

--- a/op-acceptance-tests/tests/sync_tester/sync_tester_hfs_ext/sync_tester_hfs_ext_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_tester_hfs_ext/sync_tester_hfs_ext_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/log"
 
+	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
@@ -17,7 +18,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/stack/match"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
 	"github.com/ethereum-optimism/optimism/op-node/chaincfg"
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
@@ -40,14 +40,14 @@ const (
 
 var (
 	// Network upgrade block numbers for op-sepolia
-	networkUpgradeBlocks = map[rollup.ForkName]uint64{
-		rollup.Canyon:   4089330,
-		rollup.Delta:    5700330,
-		rollup.Ecotone:  8366130,
-		rollup.Fjord:    12597930,
-		rollup.Granite:  15837930,
-		rollup.Holocene: 20415330,
-		rollup.Isthmus:  26551530,
+	networkUpgradeBlocks = map[forks.Name]uint64{
+		forks.Canyon:   4089330,
+		forks.Delta:    5700330,
+		forks.Ecotone:  8366130,
+		forks.Fjord:    12597930,
+		forks.Granite:  15837930,
+		forks.Holocene: 20415330,
+		forks.Isthmus:  26551530,
 	}
 
 	// Load configuration from environment variables with defaults
@@ -61,59 +61,59 @@ var (
 )
 
 func TestSyncTesterHFS_Canyon_CLSync(gt *testing.T) {
-	hfsExt(gt, rollup.Canyon, sync.CLSync)
+	hfsExt(gt, forks.Canyon, sync.CLSync)
 }
 
 func TestSyncTesterHFS_Canyon_ELSync(gt *testing.T) {
-	hfsExt(gt, rollup.Canyon, sync.ELSync)
+	hfsExt(gt, forks.Canyon, sync.ELSync)
 }
 
 func TestSyncTesterHFS_Delta_CLSync(gt *testing.T) {
-	hfsExt(gt, rollup.Delta, sync.CLSync)
+	hfsExt(gt, forks.Delta, sync.CLSync)
 }
 
 func TestSyncTesterHFS_Delta_ELSync(gt *testing.T) {
-	hfsExt(gt, rollup.Delta, sync.ELSync)
+	hfsExt(gt, forks.Delta, sync.ELSync)
 }
 
 func TestSyncTesterHFS_Ecotone_CLSync(gt *testing.T) {
-	hfsExt(gt, rollup.Ecotone, sync.CLSync)
+	hfsExt(gt, forks.Ecotone, sync.CLSync)
 }
 
 func TestSyncTesterHFS_Ecotone_ELSync(gt *testing.T) {
-	hfsExt(gt, rollup.Ecotone, sync.ELSync)
+	hfsExt(gt, forks.Ecotone, sync.ELSync)
 }
 
 func TestSyncTesterHFS_Fjord_CLSync(gt *testing.T) {
-	hfsExt(gt, rollup.Fjord, sync.CLSync)
+	hfsExt(gt, forks.Fjord, sync.CLSync)
 }
 
 func TestSyncTesterHFS_Fjord_ELSync(gt *testing.T) {
-	hfsExt(gt, rollup.Fjord, sync.ELSync)
+	hfsExt(gt, forks.Fjord, sync.ELSync)
 }
 
 func TestSyncTesterHFS_Granite_CLSync(gt *testing.T) {
-	hfsExt(gt, rollup.Granite, sync.CLSync)
+	hfsExt(gt, forks.Granite, sync.CLSync)
 }
 
 func TestSyncTesterHFS_Granite_ELSync(gt *testing.T) {
-	hfsExt(gt, rollup.Granite, sync.ELSync)
+	hfsExt(gt, forks.Granite, sync.ELSync)
 }
 
 func TestSyncTesterHFS_Holocene_CLSync(gt *testing.T) {
-	hfsExt(gt, rollup.Holocene, sync.CLSync)
+	hfsExt(gt, forks.Holocene, sync.CLSync)
 }
 
 func TestSyncTesterHFS_Holocene_ELSync(gt *testing.T) {
-	hfsExt(gt, rollup.Holocene, sync.ELSync)
+	hfsExt(gt, forks.Holocene, sync.ELSync)
 }
 
 func TestSyncTesterHFS_Isthmus_CLSync(gt *testing.T) {
-	hfsExt(gt, rollup.Isthmus, sync.CLSync)
+	hfsExt(gt, forks.Isthmus, sync.CLSync)
 }
 
 func TestSyncTesterHFS_Isthmus_ELSync(gt *testing.T) {
-	hfsExt(gt, rollup.Isthmus, sync.ELSync)
+	hfsExt(gt, forks.Isthmus, sync.ELSync)
 }
 
 // getEnvOrDefault returns the environment variable value or the default if not set
@@ -215,7 +215,7 @@ func setupOrchestrator(gt *testing.T, t devtest.T, blk, targetBlock uint64, l2CL
 	return orch.(*sysgo.Orchestrator)
 }
 
-func hfsExt(gt *testing.T, upgradeName rollup.ForkName, l2CLSyncMode sync.Mode) {
+func hfsExt(gt *testing.T, upgradeName forks.Name, l2CLSyncMode sync.Mode) {
 	t := devtest.ParallelT(gt)
 	l := t.Logger()
 

--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -18,6 +18,7 @@ import (
 
 	altda "github.com/ethereum-optimism/optimism/op-alt-da"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/addresses"
+	"github.com/ethereum-optimism/optimism/op-core/forks"
 	opparams "github.com/ethereum-optimism/optimism/op-node/params"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -406,25 +407,25 @@ func offsetToUpgradeTime(offset *hexutil.Uint64, genesisTime uint64) *uint64 {
 
 func (d *UpgradeScheduleDeployConfig) ForkTimeOffset(fork rollup.ForkName) *uint64 {
 	switch fork {
-	case rollup.Regolith:
+	case forks.Regolith:
 		return (*uint64)(d.L2GenesisRegolithTimeOffset)
-	case rollup.Canyon:
+	case forks.Canyon:
 		return (*uint64)(d.L2GenesisCanyonTimeOffset)
-	case rollup.Delta:
+	case forks.Delta:
 		return (*uint64)(d.L2GenesisDeltaTimeOffset)
-	case rollup.Ecotone:
+	case forks.Ecotone:
 		return (*uint64)(d.L2GenesisEcotoneTimeOffset)
-	case rollup.Fjord:
+	case forks.Fjord:
 		return (*uint64)(d.L2GenesisFjordTimeOffset)
-	case rollup.Granite:
+	case forks.Granite:
 		return (*uint64)(d.L2GenesisGraniteTimeOffset)
-	case rollup.Holocene:
+	case forks.Holocene:
 		return (*uint64)(d.L2GenesisHoloceneTimeOffset)
-	case rollup.Isthmus:
+	case forks.Isthmus:
 		return (*uint64)(d.L2GenesisIsthmusTimeOffset)
-	case rollup.Jovian:
+	case forks.Jovian:
 		return (*uint64)(d.L2GenesisJovianTimeOffset)
-	case rollup.Interop:
+	case forks.Interop:
 		return (*uint64)(d.L2GenesisInteropTimeOffset)
 	default:
 		panic(fmt.Sprintf("unknown fork: %s", fork))
@@ -433,32 +434,32 @@ func (d *UpgradeScheduleDeployConfig) ForkTimeOffset(fork rollup.ForkName) *uint
 
 func (d *UpgradeScheduleDeployConfig) SetForkTimeOffset(fork rollup.ForkName, offset *uint64) {
 	switch fork {
-	case rollup.Regolith:
+	case forks.Regolith:
 		d.L2GenesisRegolithTimeOffset = (*hexutil.Uint64)(offset)
-	case rollup.Canyon:
+	case forks.Canyon:
 		d.L2GenesisCanyonTimeOffset = (*hexutil.Uint64)(offset)
-	case rollup.Delta:
+	case forks.Delta:
 		d.L2GenesisDeltaTimeOffset = (*hexutil.Uint64)(offset)
-	case rollup.Ecotone:
+	case forks.Ecotone:
 		d.L2GenesisEcotoneTimeOffset = (*hexutil.Uint64)(offset)
-	case rollup.Fjord:
+	case forks.Fjord:
 		d.L2GenesisFjordTimeOffset = (*hexutil.Uint64)(offset)
-	case rollup.Granite:
+	case forks.Granite:
 		d.L2GenesisGraniteTimeOffset = (*hexutil.Uint64)(offset)
-	case rollup.Holocene:
+	case forks.Holocene:
 		d.L2GenesisHoloceneTimeOffset = (*hexutil.Uint64)(offset)
-	case rollup.Isthmus:
+	case forks.Isthmus:
 		d.L2GenesisIsthmusTimeOffset = (*hexutil.Uint64)(offset)
-	case rollup.Jovian:
+	case forks.Jovian:
 		d.L2GenesisJovianTimeOffset = (*hexutil.Uint64)(offset)
-	case rollup.Interop:
+	case forks.Interop:
 		d.L2GenesisInteropTimeOffset = (*hexutil.Uint64)(offset)
 	default:
 		panic(fmt.Sprintf("unknown fork: %s", fork))
 	}
 }
 
-var scheduleableForks = rollup.ForksFrom(rollup.Regolith)
+var scheduleableForks = forks.From(forks.Regolith)
 
 // ActivateForkAtOffset activates the given fork at the given offset. Previous forks are activated
 // at genesis and later forks are deactivated.
@@ -466,7 +467,7 @@ var scheduleableForks = rollup.ForksFrom(rollup.Regolith)
 // ActivateForkAtOffset with the earliest fork and then SetForkTimeOffset to individually set later
 // forks.
 func (d *UpgradeScheduleDeployConfig) ActivateForkAtOffset(fork rollup.ForkName, offset uint64) {
-	if !rollup.IsValidFork(fork) || fork == rollup.Bedrock {
+	if !forks.IsValid(fork) || fork == forks.Bedrock {
 		panic(fmt.Sprintf("invalid fork: %s", fork))
 	}
 	ts := new(uint64)

--- a/op-chain-ops/genesis/config_test.go
+++ b/op-chain-ops/genesis/config_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 )
@@ -94,7 +95,7 @@ func TestForksCantActivateAtSamePostGenesisBlock(t *testing.T) {
 	postGenesisOffset := uint64(1500)
 	config := &UpgradeScheduleDeployConfig{}
 	for _, fork := range config.forks() {
-		config.SetForkTimeOffset(rollup.ForkName(fork.Name), &postGenesisOffset)
+		config.SetForkTimeOffset(forks.Name(fork.Name), &postGenesisOffset)
 	}
 	err := config.Check(testlog.Logger(t, log.LevelDebug))
 	require.Error(t, err)
@@ -153,7 +154,7 @@ func TestL1Deployments(t *testing.T) {
 // This test guarantees that getters and setters for all forks are present.
 func TestUpgradeScheduleDeployConfig_ForkGettersAndSetters(t *testing.T) {
 	var d UpgradeScheduleDeployConfig
-	for i, fork := range rollup.ForksFrom(rollup.Regolith) {
+	for i, fork := range forks.From(forks.Regolith) {
 		require.Nil(t, d.ForkTimeOffset(fork))
 		offset := uint64(i * 42)
 		d.SetForkTimeOffset(fork, &offset)
@@ -165,11 +166,11 @@ func TestUpgradeScheduleDeployConfig_ActivateForkAtOffset(t *testing.T) {
 	var d UpgradeScheduleDeployConfig
 	ts := uint64(42)
 	t.Run("invalid", func(t *testing.T) {
-		require.Panics(t, func() { d.ActivateForkAtOffset(rollup.Bedrock, ts) })
+		require.Panics(t, func() { d.ActivateForkAtOffset(forks.Bedrock, ts) })
 	})
 
 	t.Run("regolith", func(t *testing.T) {
-		d.ActivateForkAtOffset(rollup.Regolith, ts)
+		d.ActivateForkAtOffset(forks.Regolith, ts)
 		require.EqualValues(t, &ts, d.L2GenesisRegolithTimeOffset)
 		for _, fork := range scheduleableForks[1:] {
 			require.Nil(t, d.ForkTimeOffset(fork))
@@ -177,7 +178,7 @@ func TestUpgradeScheduleDeployConfig_ActivateForkAtOffset(t *testing.T) {
 	})
 
 	t.Run("ecotone", func(t *testing.T) {
-		d.ActivateForkAtOffset(rollup.Ecotone, ts)
+		d.ActivateForkAtOffset(forks.Ecotone, ts)
 		require.EqualValues(t, &ts, d.L2GenesisEcotoneTimeOffset)
 		for _, fork := range scheduleableForks[:3] {
 			require.Zero(t, *d.ForkTimeOffset(fork))
@@ -201,14 +202,14 @@ func TestUpgradeScheduleDeployConfig_SolidityForkNumber(t *testing.T) {
 		fork     rollup.ForkName
 		expected int64
 	}{
-		{rollup.Delta, 1},
-		{rollup.Ecotone, 2},
-		{rollup.Fjord, 3},
-		{rollup.Granite, 4},
-		{rollup.Holocene, 5},
-		{rollup.Isthmus, 6},
-		{rollup.Jovian, 7},
-		{rollup.Interop, 8},
+		{forks.Delta, 1},
+		{forks.Ecotone, 2},
+		{forks.Fjord, 3},
+		{forks.Granite, 4},
+		{forks.Holocene, 5},
+		{forks.Isthmus, 6},
+		{forks.Jovian, 7},
+		{forks.Interop, 8},
 	}
 	for _, tt := range tests {
 		var d UpgradeScheduleDeployConfig

--- a/op-core/forks/forks.go
+++ b/op-core/forks/forks.go
@@ -1,0 +1,72 @@
+package forks
+
+import "fmt"
+
+// Name identifies a hardfork by name.
+type Name string
+
+const (
+	Bedrock  Name = "bedrock"
+	Regolith Name = "regolith"
+	Canyon   Name = "canyon"
+	Delta    Name = "delta"
+	Ecotone  Name = "ecotone"
+	Fjord    Name = "fjord"
+	Granite  Name = "granite"
+	Holocene Name = "holocene"
+	Isthmus  Name = "isthmus"
+	Jovian   Name = "jovian"
+	Interop  Name = "interop"
+	// ADD NEW FORKS TO All BELOW!
+	None Name = ""
+)
+
+// All lists all known forks in chronological order.
+var All = []Name{
+	Bedrock,
+	Regolith,
+	Canyon,
+	Delta,
+	Ecotone,
+	Fjord,
+	Granite,
+	Holocene,
+	Isthmus,
+	Jovian,
+	Interop,
+	// ADD NEW FORKS HERE!
+}
+
+// Latest returns the most recent fork in All.
+var Latest = All[len(All)-1]
+
+// From returns the list of forks starting from the provided fork, inclusive.
+func From(start Name) []Name {
+	for i, f := range All {
+		if f == start {
+			return All[i:]
+		}
+	}
+	panic(fmt.Sprintf("invalid fork: %s", start))
+}
+
+var next = func() map[Name]Name {
+	m := make(map[Name]Name, len(All))
+	for i, f := range All {
+		if i == len(All)-1 {
+			m[f] = None
+			break
+		}
+		m[f] = All[i+1]
+	}
+	return m
+}()
+
+// IsValid returns true if the provided fork is a known fork.
+func IsValid(f Name) bool {
+	_, ok := next[f]
+	return ok
+}
+
+// Next returns the fork that follows the provided fork, or None if it is the last.
+func Next(f Name) Name { return next[f] }

--- a/op-deployer/pkg/deployer/standard/standard.go
+++ b/op-deployer/pkg/deployer/standard/standard.go
@@ -3,17 +3,15 @@ package standard
 import (
 	"fmt"
 
-	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
+	"github.com/ethereum-optimism/optimism/op-core/forks"
+	op_service "github.com/ethereum-optimism/optimism/op-service"
 
 	"github.com/ethereum-optimism/superchain-registry/validation"
 
-	"github.com/ethereum/go-ethereum/superchain"
-
-	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
-	op_service "github.com/ethereum-optimism/optimism/op-service"
-
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/superchain"
 )
 
 const (
@@ -180,13 +178,13 @@ func DefaultHardforkScheduleForTag(tag string) *genesis.UpgradeScheduleDeployCon
 	case ContractsV160Tag, ContractsV170Beta1L2Tag:
 		return sched
 	case ContractsV180Tag, ContractsV200Tag, ContractsV300Tag:
-		sched.ActivateForkAtGenesis(rollup.Holocene)
+		sched.ActivateForkAtGenesis(forks.Holocene)
 	case ContractsV400Tag, ContractsV410Tag:
-		sched.ActivateForkAtGenesis(rollup.Holocene)
-		sched.ActivateForkAtGenesis(rollup.Isthmus)
+		sched.ActivateForkAtGenesis(forks.Holocene)
+		sched.ActivateForkAtGenesis(forks.Isthmus)
 	default:
-		sched.ActivateForkAtGenesis(rollup.Holocene)
-		sched.ActivateForkAtGenesis(rollup.Isthmus)
+		sched.ActivateForkAtGenesis(forks.Holocene)
+		sched.ActivateForkAtGenesis(forks.Isthmus)
 	}
 
 	return sched

--- a/op-devstack/dsl/operator_fee.go
+++ b/op-devstack/dsl/operator_fee.go
@@ -5,9 +5,9 @@ import (
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
+	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack/match"
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/predeploys"
 	"github.com/ethereum-optimism/optimism/op-service/txintent/bindings"
@@ -142,7 +142,7 @@ func (of *OperatorFee) ValidateTransactionFees(from *EOA, to *EOA, amount *big.I
 	of.require.NoError(err)
 
 	// Infer active fork from block info
-	isJovian := of.l2Network.IsForkActive(rollup.Jovian, info.Time())
+	isJovian := of.l2Network.IsForkActive(forks.Jovian, info.Time())
 
 	// Verify GPO upgraded when jovian is active
 	// We have nothing to assert when jovian is inactive because an isthmus L2 can

--- a/op-devstack/dsl/validators.go
+++ b/op-devstack/dsl/validators.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/params"
@@ -22,26 +23,26 @@ func IsForkActivated(c *params.ChainConfig, forkName rollup.ForkName, timestamp 
 	}
 
 	switch forkName {
-	case rollup.Bedrock:
+	case forks.Bedrock:
 		// Bedrock is activated based on block number, not timestamp
 		return true, nil // Assuming bedrock is always active in the context of this validator
-	case rollup.Regolith:
+	case forks.Regolith:
 		return c.IsOptimismRegolith(timestamp), nil
-	case rollup.Canyon:
+	case forks.Canyon:
 		return c.IsOptimismCanyon(timestamp), nil
-	case rollup.Ecotone:
+	case forks.Ecotone:
 		return c.IsOptimismEcotone(timestamp), nil
-	case rollup.Fjord:
+	case forks.Fjord:
 		return c.IsOptimismFjord(timestamp), nil
-	case rollup.Granite:
+	case forks.Granite:
 		return c.IsOptimismGranite(timestamp), nil
-	case rollup.Holocene:
+	case forks.Holocene:
 		return c.IsOptimismHolocene(timestamp), nil
-	case rollup.Isthmus:
+	case forks.Isthmus:
 		return c.IsOptimismIsthmus(timestamp), nil
-	case rollup.Jovian:
+	case forks.Jovian:
 		return c.IsOptimismJovian(timestamp), nil
-	case rollup.Interop:
+	case forks.Interop:
 		return c.IsInterop(timestamp), nil
 	default:
 		return false, fmt.Errorf("unknown fork name: %s", forkName)

--- a/op-devstack/presets/interop.go
+++ b/op-devstack/presets/interop.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
+	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl/proofs"
@@ -14,7 +15,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/stack/match"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/intentbuilder"
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
 )
 
 type SingleChainInterop struct {
@@ -141,7 +141,7 @@ func WithUnscheduledInterop() stack.CommonOption {
 	return stack.Combine(
 		stack.MakeCommon(sysgo.WithDeployerOptions(func(p devtest.P, keys devkeys.Keys, builder intentbuilder.Builder) {
 			for _, l2 := range builder.L2s() {
-				l2.WithForkAtOffset(rollup.Interop, nil)
+				l2.WithForkAtOffset(forks.Interop, nil)
 			}
 		})),
 		stack.PostHydrate[stack.Orchestrator](func(sys stack.System) {
@@ -175,7 +175,7 @@ func WithSuggestedInteropActivationOffset(offset uint64) stack.CommonOption {
 	return stack.MakeCommon(sysgo.WithDeployerOptions(
 		func(p devtest.P, keys devkeys.Keys, builder intentbuilder.Builder) {
 			for _, l2Cfg := range builder.L2s() {
-				l2Cfg.WithForkAtOffset(rollup.Interop, &offset)
+				l2Cfg.WithForkAtOffset(forks.Interop, &offset)
 			}
 		},
 	))

--- a/op-devstack/presets/jovian.go
+++ b/op-devstack/presets/jovian.go
@@ -2,11 +2,11 @@ package presets
 
 import (
 	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
+	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/intentbuilder"
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
 )
 
 // WithJovianAtGenesis configures all L2s to activate the Jovian fork at genesis in sysgo mode.
@@ -14,7 +14,7 @@ func WithJovianAtGenesis() stack.CommonOption {
 	return stack.MakeCommon(sysgo.WithDeployerOptions(
 		func(p devtest.P, _ devkeys.Keys, builder intentbuilder.Builder) {
 			for _, l2Cfg := range builder.L2s() {
-				l2Cfg.WithForkAtGenesis(rollup.Jovian)
+				l2Cfg.WithForkAtGenesis(forks.Jovian)
 			}
 		},
 	))

--- a/op-devstack/presets/simple_with_synctester.go
+++ b/op-devstack/presets/simple_with_synctester.go
@@ -1,13 +1,13 @@
 package presets
 
 import (
+	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/shim"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack/match"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
 )
 
 type SimpleWithSyncTester struct {
@@ -43,6 +43,6 @@ func NewSimpleWithSyncTester(t devtest.T) *SimpleWithSyncTester {
 	}
 }
 
-func WithHardforkSequentialActivation(startFork, endFork rollup.ForkName, delta uint64) stack.CommonOption {
+func WithHardforkSequentialActivation(startFork, endFork forks.Name, delta uint64) stack.CommonOption {
 	return stack.MakeCommon(sysgo.WithDeployerOptions(sysgo.WithHardforkSequentialActivation(startFork, endFork, &delta)))
 }

--- a/op-devstack/sysgo/deployer.go
+++ b/op-devstack/sysgo/deployer.go
@@ -13,6 +13,7 @@ import (
 	"github.com/holiman/uint256"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
+	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/artifacts"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/inspect"
@@ -291,7 +292,7 @@ func WithDevFeatureEnabled(flag common.Hash) DeployerOption {
 func WithInteropAtGenesis() DeployerOption {
 	return func(p devtest.P, keys devkeys.Keys, builder intentbuilder.Builder) {
 		for _, l2Cfg := range builder.L2s() {
-			l2Cfg.WithForkAtGenesis(rollup.Interop)
+			l2Cfg.WithForkAtGenesis(forks.Interop)
 		}
 	}
 }
@@ -300,13 +301,13 @@ func WithInteropAtGenesis() DeployerOption {
 // activate hardforks sequentially, starting from startFork and continuing
 // until (but not including) endFork. Each successive fork is scheduled at
 // an increasing offset.
-func WithHardforkSequentialActivation(startFork, endFork rollup.ForkName, delta *uint64) DeployerOption {
+func WithHardforkSequentialActivation(startFork, endFork forks.Name, delta *uint64) DeployerOption {
 	return func(p devtest.P, keys devkeys.Keys, builder intentbuilder.Builder) {
 		for _, l2Cfg := range builder.L2s() {
 			l2Cfg.WithForkAtGenesis(startFork)
 			activateWithOffset := false
 			deactivate := false
-			for idx, refFork := range rollup.AllForks {
+			for idx, refFork := range forks.All {
 				if deactivate || refFork == endFork {
 					l2Cfg.WithForkAtOffset(refFork, nil)
 					deactivate = true

--- a/op-e2e/actions/derivation/blocktime_test.go
+++ b/op-e2e/actions/derivation/blocktime_test.go
@@ -4,10 +4,10 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-core/forks"
 	actionsHelpers "github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
 	upgradesHelpers "github.com/ethereum-optimism/optimism/op-e2e/actions/upgrades/helpers"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -165,9 +165,9 @@ func LargeL1Gaps(gt *testing.T, deltaTimeOffset *hexutil.Uint64) {
 	dp.DeployConfig.SequencerWindowSize = 4
 	dp.DeployConfig.MaxSequencerDrift = 32
 	if deltaTimeOffset != nil {
-		dp.DeployConfig.ActivateForkAtOffset(rollup.Delta, uint64(*deltaTimeOffset))
+		dp.DeployConfig.ActivateForkAtOffset(forks.Delta, uint64(*deltaTimeOffset))
 	} else {
-		dp.DeployConfig.ActivateForkAtGenesis(rollup.Canyon)
+		dp.DeployConfig.ActivateForkAtGenesis(forks.Canyon)
 	}
 	// TODO(client-pod#831): The Ecotone (and Fjord) activation blocks don't include user txs,
 	// so disabling these forks for now.

--- a/op-e2e/actions/helpers/env.go
+++ b/op-e2e/actions/helpers/env.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
+	"github.com/ethereum-optimism/optimism/op-core/forks"
 	e2ecfg "github.com/ethereum-optimism/optimism/op-e2e/config"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
@@ -52,7 +53,7 @@ func WithActiveGenesisFork(fork rollup.ForkName) EnvOpt {
 // DefaultFork specifies the default fork to use when setting up the action test environment.
 // Currently manually set to Holocene.
 // Replace with `var DefaultFork = func() rollup.ForkName { return rollup.AllForks[len(rollup.AllForks)-1] }()` after Interop launch.
-const DefaultFork = rollup.Holocene
+const DefaultFork = forks.Holocene
 
 // SetupEnv sets up a default action test environment. If no fork is specified, the default fork as
 // specified by the package variable [defaultFork] is used.

--- a/op-e2e/actions/helpers/l2_sequencer.go
+++ b/op-e2e/actions/helpers/l2_sequencer.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 
+	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum-optimism/optimism/op-node/config"
 	"github.com/ethereum-optimism/optimism/op-node/metrics"
 	"github.com/ethereum-optimism/optimism/op-node/node/safedb"
@@ -212,7 +213,7 @@ func (s *L2Sequencer) ActBuildL2ToTime(t Testing, target uint64) {
 	}
 }
 
-func (s *L2Sequencer) ActBuildL2ToFork(t Testing, fork rollup.ForkName) eth.L2BlockRef {
+func (s *L2Sequencer) ActBuildL2ToFork(t Testing, fork forks.Name) eth.L2BlockRef {
 	require.NotNil(t, s.RollupCfg.ActivationTime(fork), "cannot activate %s when it is not scheduled", fork)
 	for !s.RollupCfg.IsForkActive(fork, s.L2Unsafe().Time) {
 		s.ActL2EmptyBlock(t)

--- a/op-e2e/actions/proofs/activation_block_test.go
+++ b/op-e2e/actions/proofs/activation_block_test.go
@@ -4,9 +4,9 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
+	"github.com/ethereum-optimism/optimism/op-core/forks"
 	actionsHelpers "github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/proofs/helpers"
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/stretchr/testify/require"
@@ -16,7 +16,7 @@ import (
 )
 
 type activationBlockTestCfg struct {
-	fork          rollup.ForkName
+	fork          forks.Name
 	numUpgradeTxs int
 }
 
@@ -26,8 +26,8 @@ func TestActivationBlockTxOmission(gt *testing.T) {
 	matrix := helpers.NewMatrix[activationBlockTestCfg]()
 
 	matrix.AddDefaultTestCasesWithName(
-		string(rollup.Jovian),
-		activationBlockTestCfg{fork: rollup.Jovian, numUpgradeTxs: 5},
+		string(forks.Jovian),
+		activationBlockTestCfg{fork: forks.Jovian, numUpgradeTxs: 5},
 		helpers.NewForkMatrix(helpers.Isthmus),
 		testActivationBlockTxOmission,
 	)

--- a/op-e2e/actions/proofs/helpers/env.go
+++ b/op-e2e/actions/proofs/helpers/env.go
@@ -4,6 +4,7 @@ import (
 	"math/rand"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
+	"github.com/ethereum-optimism/optimism/op-core/forks"
 	e2ecfg "github.com/ethereum-optimism/optimism/op-e2e/config"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-program/client/boot"
@@ -48,7 +49,7 @@ func NewL2FaultProofEnv[c any](t helpers.Testing, testCfg *TestCfg[c], tp *e2eut
 		if testCfg.Hardfork == nil {
 			t.Fatalf("HF not set")
 		}
-		dp.DeployConfig.ActivateForkAtGenesis(rollup.ForkName(testCfg.Hardfork.Name))
+		dp.DeployConfig.ActivateForkAtGenesis(forks.Name(testCfg.Hardfork.Name))
 
 		for _, override := range deployConfigOverrides {
 			override(dp.DeployConfig)

--- a/op-e2e/actions/proofs/helpers/matrix.go
+++ b/op-e2e/actions/proofs/helpers/matrix.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-program/client/claim"
 	"github.com/ethereum/go-ethereum/common"
 )
@@ -117,15 +117,15 @@ type ForkMatrix = []*Hardfork
 
 // Hardfork definitions
 var (
-	Regolith = &Hardfork{Name: string(rollup.Regolith), Precedence: 1}
-	Canyon   = &Hardfork{Name: string(rollup.Canyon), Precedence: 2}
-	Delta    = &Hardfork{Name: string(rollup.Delta), Precedence: 3}
-	Ecotone  = &Hardfork{Name: string(rollup.Ecotone), Precedence: 4}
-	Fjord    = &Hardfork{Name: string(rollup.Fjord), Precedence: 5}
-	Granite  = &Hardfork{Name: string(rollup.Granite), Precedence: 6}
-	Holocene = &Hardfork{Name: string(rollup.Holocene), Precedence: 7}
-	Isthmus  = &Hardfork{Name: string(rollup.Isthmus), Precedence: 8}
-	Jovian   = &Hardfork{Name: string(rollup.Jovian), Precedence: 9}
+	Regolith = &Hardfork{Name: string(forks.Regolith), Precedence: 1}
+	Canyon   = &Hardfork{Name: string(forks.Canyon), Precedence: 2}
+	Delta    = &Hardfork{Name: string(forks.Delta), Precedence: 3}
+	Ecotone  = &Hardfork{Name: string(forks.Ecotone), Precedence: 4}
+	Fjord    = &Hardfork{Name: string(forks.Fjord), Precedence: 5}
+	Granite  = &Hardfork{Name: string(forks.Granite), Precedence: 6}
+	Holocene = &Hardfork{Name: string(forks.Holocene), Precedence: 7}
+	Isthmus  = &Hardfork{Name: string(forks.Isthmus), Precedence: 8}
+	Jovian   = &Hardfork{Name: string(forks.Jovian), Precedence: 9}
 )
 
 var (

--- a/op-e2e/actions/proofs/jovian_dafootprint_test.go
+++ b/op-e2e/actions/proofs/jovian_dafootprint_test.go
@@ -6,10 +6,10 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
+	"github.com/ethereum-optimism/optimism/op-core/forks"
 	actionsHelpers "github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/proofs/helpers"
 	"github.com/ethereum-optimism/optimism/op-e2e/bindings"
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-service/predeploys"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -190,7 +190,7 @@ func Test_ProgramAction_JovianDAFootprint(gt *testing.T) {
 
 		jovianAtGenesis := env.Sequencer.RollupCfg.IsJovian(env.Sequencer.RollupCfg.Genesis.L2Time)
 		if !jovianAtGenesis {
-			env.Sequencer.ActBuildL2ToFork(t, rollup.Jovian)
+			env.Sequencer.ActBuildL2ToFork(t, forks.Jovian)
 		}
 
 		// We run three sub-steps. First, we test the default behavior. Then we update the scalar to
@@ -213,10 +213,10 @@ func Test_ProgramAction_JovianDAFootprint(gt *testing.T) {
 		genesisConfigFn helpers.DeployConfigOverride
 	}{
 		"JovianAtGenesis": {
-			genesisConfigFn: func(dc *genesis.DeployConfig) { dc.ActivateForkAtGenesis(rollup.Jovian) },
+			genesisConfigFn: func(dc *genesis.DeployConfig) { dc.ActivateForkAtGenesis(forks.Jovian) },
 		},
 		"JovianAfterGenesis": {
-			genesisConfigFn: func(dc *genesis.DeployConfig) { dc.ActivateForkAtOffset(rollup.Jovian, 4) },
+			genesisConfigFn: func(dc *genesis.DeployConfig) { dc.ActivateForkAtOffset(forks.Jovian, 4) },
 		},
 	}
 

--- a/op-e2e/actions/proofs/jovian_minbasefee_test.go
+++ b/op-e2e/actions/proofs/jovian_minbasefee_test.go
@@ -5,10 +5,10 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
+	"github.com/ethereum-optimism/optimism/op-core/forks"
 	actionsHelpers "github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/proofs/helpers"
 	"github.com/ethereum-optimism/optimism/op-e2e/bindings"
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/predeploys"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -118,25 +118,25 @@ func Test_ProgramAction_JovianMinBaseFee(gt *testing.T) {
 	}{
 		"JovianActivationAfterGenesis": {
 			genesisConfigFn: func(dc *genesis.DeployConfig) {
-				dc.ActivateForkAtOffset(rollup.Jovian, 10)
+				dc.ActivateForkAtOffset(forks.Jovian, 10)
 			},
 			minBaseFee: 0,
 		},
 		"JovianActivationAtGenesisZeroMinBaseFee": {
 			genesisConfigFn: func(dc *genesis.DeployConfig) {
-				dc.ActivateForkAtGenesis(rollup.Jovian)
+				dc.ActivateForkAtGenesis(forks.Jovian)
 			},
 			minBaseFee: 0,
 		},
 		"JovianActivationAtGenesisMinBaseFeeMedium": {
 			genesisConfigFn: func(dc *genesis.DeployConfig) {
-				dc.ActivateForkAtGenesis(rollup.Jovian)
+				dc.ActivateForkAtGenesis(forks.Jovian)
 			},
 			minBaseFee: 1_000_000_000, // 1 gwei
 		},
 		"JovianActivationAtGenesisMinBaseFeeHigh": {
 			genesisConfigFn: func(dc *genesis.DeployConfig) {
-				dc.ActivateForkAtGenesis(rollup.Jovian)
+				dc.ActivateForkAtGenesis(forks.Jovian)
 			},
 			minBaseFee: 2_000_000_000, // 2 gwei
 		},

--- a/op-e2e/actions/proofs/operator_fee_fix_transition_test.go
+++ b/op-e2e/actions/proofs/operator_fee_fix_transition_test.go
@@ -5,10 +5,10 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
+	"github.com/ethereum-optimism/optimism/op-core/forks"
 	actionsHelpers "github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/proofs/helpers"
 	"github.com/ethereum-optimism/optimism/op-e2e/bindings"
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/predeploys"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -28,7 +28,7 @@ func Test_ProgramAction_OperatorFeeFixTransition(gt *testing.T) {
 		t := actionsHelpers.NewDefaultTesting(gt)
 
 		deployConfigOverrides := func(dp *genesis.DeployConfig) {
-			dp.ActivateForkAtOffset(rollup.Jovian, 15)
+			dp.ActivateForkAtOffset(forks.Jovian, 15)
 		}
 
 		testOperatorFeeScalar := uint32(345e6)
@@ -140,7 +140,7 @@ func Test_ProgramAction_OperatorFeeFixTransition(gt *testing.T) {
 		require.True(t, aliceFinalBalance.Cmp(aliceInitialBalance) < 0, "Alice's balance should decrease")
 
 		// Now wind forward to jovian
-		unsafeL2Head = env.Sequencer.ActBuildL2ToFork(t, rollup.Jovian)
+		unsafeL2Head = env.Sequencer.ActBuildL2ToFork(t, forks.Jovian)
 
 		// reset accounting
 		aliceInitialBalance, _, _, _, operatorFeeVaultInitialBalance = getCurrentBalances(unsafeL2Head.Number)

--- a/op-e2e/actions/proofs/system_config_test.go
+++ b/op-e2e/actions/proofs/system_config_test.go
@@ -8,10 +8,10 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
+	"github.com/ethereum-optimism/optimism/op-core/forks"
 	actionsHelpers "github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/proofs/helpers"
 	"github.com/ethereum-optimism/optimism/op-e2e/bindings"
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
@@ -36,7 +36,7 @@ func testSystemConfigEarlyIsthmusUpgrade(gt *testing.T, testCfg *helpers.TestCfg
 
 	t := actionsHelpers.NewDefaultTesting(gt)
 	testSetup := func(dp *genesis.DeployConfig) {
-		dp.ActivateForkAtOffset(rollup.Isthmus, isthmusOffset)
+		dp.ActivateForkAtOffset(forks.Isthmus, isthmusOffset)
 	}
 	env := helpers.NewL2FaultProofEnv(t, testCfg, helpers.NewTestParams(), helpers.NewBatcherCfg(), testSetup)
 	sequencer := env.Sequencer

--- a/op-e2e/actions/upgrades/dencun_fork_test.go
+++ b/op-e2e/actions/upgrades/dencun_fork_test.go
@@ -4,18 +4,17 @@ import (
 	"context"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
+	transactions "github.com/ethereum-optimism/optimism/op-e2e/e2eutils/transactions"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/log"
-
-	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
-	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/transactions"
-	"github.com/ethereum-optimism/optimism/op-service/testlog"
 )
 
 func TestDencunL1ForkAfterGenesis(gt *testing.T) {
@@ -125,7 +124,7 @@ func TestDencunL2ForkAfterGenesis(gt *testing.T) {
 	dp := e2eutils.MakeDeployParams(t, helpers.DefaultRollupTestParams())
 	require.Zero(t, *dp.DeployConfig.L1CancunTimeOffset)
 	// This test will fork on the second block
-	dp.DeployConfig.ActivateForkAtOffset(rollup.Ecotone, dp.DeployConfig.L2BlockTime*2)
+	dp.DeployConfig.ActivateForkAtOffset(forks.Ecotone, dp.DeployConfig.L2BlockTime*2)
 
 	sd := e2eutils.Setup(t, dp, helpers.DefaultAlloc)
 	log := testlog.Logger(t, log.LevelDebug)

--- a/op-e2e/actions/upgrades/ecotone_fork_test.go
+++ b/op-e2e/actions/upgrades/ecotone_fork_test.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
 	"github.com/stretchr/testify/require"
 
@@ -18,7 +19,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
 	"github.com/ethereum-optimism/optimism/op-e2e/bindings"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-service/predeploys"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
@@ -50,7 +50,7 @@ func TestEcotoneNetworkUpgradeTransactions(gt *testing.T) {
 
 	require.Zero(t, *dp.DeployConfig.L1CancunTimeOffset)
 	// Activate all forks at genesis, and schedule Ecotone the block after
-	dp.DeployConfig.ActivateForkAtOffset(rollup.Ecotone, uint64(ecotoneOffset))
+	dp.DeployConfig.ActivateForkAtOffset(forks.Ecotone, uint64(ecotoneOffset))
 	require.NoError(t, dp.DeployConfig.Check(log), "must have valid config")
 
 	sd := e2eutils.Setup(t, dp, helpers.DefaultAlloc)

--- a/op-e2e/actions/upgrades/fjord_fork_test.go
+++ b/op-e2e/actions/upgrades/fjord_fork_test.go
@@ -16,9 +16,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
+	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum-optimism/optimism/op-e2e/bindings"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 )
@@ -37,7 +37,7 @@ func TestFjordNetworkUpgradeTransactions(gt *testing.T) {
 
 	// Activate all forks at genesis, and schedule Fjord the block after
 	fjordOffset := uint64(2)
-	dp.DeployConfig.ActivateForkAtOffset(rollup.Fjord, fjordOffset)
+	dp.DeployConfig.ActivateForkAtOffset(forks.Fjord, fjordOffset)
 
 	require.NoError(t, dp.DeployConfig.Check(log), "must have valid config")
 

--- a/op-e2e/actions/upgrades/holocene_fork_test.go
+++ b/op-e2e/actions/upgrades/holocene_fork_test.go
@@ -9,15 +9,15 @@ import (
 
 	"github.com/ethereum/go-ethereum/core/types"
 
+	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
 	"github.com/ethereum-optimism/optimism/op-e2e/system/e2esys"
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 )
 
 func TestHoloceneActivationAtGenesis(gt *testing.T) {
 	t := helpers.NewDefaultTesting(gt)
-	env := helpers.SetupEnv(t, helpers.WithActiveGenesisFork(rollup.Holocene))
+	env := helpers.SetupEnv(t, helpers.WithActiveGenesisFork(forks.Holocene))
 
 	// Start op-nodes
 	env.Seq.ActL2PipelineFull(t)
@@ -53,7 +53,7 @@ func TestHoloceneActivationAtGenesis(gt *testing.T) {
 func TestHoloceneLateActivationAndReset(gt *testing.T) {
 	t := helpers.NewDefaultTesting(gt)
 	holoceneOffset := uint64(24)
-	env := helpers.SetupEnv(t, helpers.WithActiveFork(rollup.Holocene, holoceneOffset))
+	env := helpers.SetupEnv(t, helpers.WithActiveFork(forks.Holocene, holoceneOffset))
 
 	requireHoloceneTransformationLogs := func(role string, expNumLogs int) {
 		recs := env.Logs.FindLogs(testlog.NewMessageContainsFilter("transforming to Holocene"), testlog.NewAttributesFilter("role", role))
@@ -135,7 +135,7 @@ func TestHoloceneLateActivationAndReset(gt *testing.T) {
 
 func TestHoloceneInvalidPayload(gt *testing.T) {
 	t := helpers.NewDefaultTesting(gt)
-	env := helpers.SetupEnv(t, helpers.WithActiveGenesisFork(rollup.Holocene))
+	env := helpers.SetupEnv(t, helpers.WithActiveGenesisFork(forks.Holocene))
 	ctx := context.Background()
 
 	requireDepositOnlyLogs := func(role string, expNumLogs int) {

--- a/op-e2e/config/init.go
+++ b/op-e2e/config/init.go
@@ -13,13 +13,13 @@ import (
 	"time"
 
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/versions"
+	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/artifacts"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/inspect"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/pipeline"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/standard"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/state"
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"golang.org/x/exp/maps"
@@ -257,7 +257,7 @@ func initAllocType(root string, allocType AllocType) {
 			}
 
 			upgradeSchedule := new(genesis.UpgradeScheduleDeployConfig)
-			upgradeSchedule.ActivateForkAtGenesis(rollup.ForkName(mode))
+			upgradeSchedule.ActivateForkAtGenesis(forks.Name(mode))
 			upgradeOverridesJSON, err := json.Marshal(upgradeSchedule)
 			if err != nil {
 				panic(fmt.Errorf("failed to marshal upgrade schedule: %w", err))

--- a/op-e2e/e2eutils/intentbuilder/builder.go
+++ b/op-e2e/e2eutils/intentbuilder/builder.go
@@ -14,10 +14,10 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/addresses"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
+	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/artifacts"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/standard"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/state"
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
@@ -91,8 +91,8 @@ type L2FeesConfigurator interface {
 }
 
 type L2HardforkConfigurator interface {
-	WithForkAtGenesis(fork rollup.ForkName)
-	WithForkAtOffset(fork rollup.ForkName, offset *uint64)
+	WithForkAtGenesis(fork forks.Name)
+	WithForkAtOffset(fork forks.Name, offset *uint64)
 }
 
 type Builder interface {
@@ -431,10 +431,10 @@ func (c *l2Configurator) WithOperatorFeeConstant(value uint64) {
 	c.builder.intent.Chains[c.chainIndex].OperatorFeeConstant = value
 }
 
-func (c *l2Configurator) WithForkAtGenesis(fork rollup.ForkName) {
+func (c *l2Configurator) WithForkAtGenesis(fork forks.Name) {
 	var future bool
-	for _, refFork := range rollup.AllForks {
-		if refFork == rollup.Bedrock {
+	for _, refFork := range forks.All {
+		if refFork == forks.Bedrock {
 			continue
 		}
 
@@ -450,8 +450,8 @@ func (c *l2Configurator) WithForkAtGenesis(fork rollup.ForkName) {
 	}
 }
 
-func (c *l2Configurator) WithForkAtOffset(fork rollup.ForkName, offset *uint64) {
-	require.True(c.t, rollup.IsValidFork(fork))
+func (c *l2Configurator) WithForkAtOffset(fork forks.Name, offset *uint64) {
+	require.True(c.t, forks.IsValid(fork))
 	key := fmt.Sprintf("l2Genesis%sTimeOffset", cases.Title(language.English).String(string(fork)))
 
 	if offset == nil {

--- a/op-e2e/e2eutils/intentbuilder/builder_test.go
+++ b/op-e2e/e2eutils/intentbuilder/builder_test.go
@@ -12,10 +12,10 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/addresses"
+	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/artifacts"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/standard"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/state"
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
@@ -114,8 +114,8 @@ func TestBuilder(t *testing.T) {
 
 	// Test L2HardforkConfigurator methods
 	isthmusOffset := uint64(8000)
-	l2Config.WithForkAtGenesis(rollup.Holocene)
-	l2Config.WithForkAtOffset(rollup.Isthmus, &isthmusOffset)
+	l2Config.WithForkAtGenesis(forks.Holocene)
+	l2Config.WithForkAtOffset(forks.Isthmus, &isthmusOffset)
 
 	// Build the intent
 	intent, err := builder.Build()

--- a/op-e2e/system/bridge/deposit_test.go
+++ b/op-e2e/system/bridge/deposit_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	op_e2e "github.com/ethereum-optimism/optimism/op-e2e"
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/holiman/uint256"
 
 	"github.com/ethereum-optimism/optimism/op-e2e/system/e2esys"
@@ -16,6 +15,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
 
+	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -129,7 +129,7 @@ func TestMintCallToDelegatedAccount(t *testing.T) {
 	op_e2e.InitParallel(t)
 	cfg := e2esys.DefaultSystemConfig(t)
 	cfg.DeployConfig = cfg.DeployConfig.Copy()
-	cfg.DeployConfig.ActivateForkAtGenesis(rollup.Isthmus)
+	cfg.DeployConfig.ActivateForkAtGenesis(forks.Isthmus)
 	delete(cfg.Nodes, "verifier")
 	sys, err := cfg.Start(t)
 	require.NoError(t, err, "Error starting up system")

--- a/op-node/rollup/attributes/engine_consolidate_test.go
+++ b/op-node/rollup/attributes/engine_consolidate_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 
+	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/predeploys"
@@ -232,126 +233,126 @@ func TestAttributesMatch(t *testing.T) {
 	}{
 		{
 			args:      bedrockArgs(),
-			rollupCfg: cfg(rollup.Bedrock),
+			rollupCfg: cfg(forks.Bedrock),
 			desc:      "validBedrockArgs",
 		},
 		{
 			args:      bedrockArgs(),
-			rollupCfg: cfg(rollup.Canyon),
+			rollupCfg: cfg(forks.Canyon),
 			err:       ErrCanyonMustHaveWithdrawals.Error() + ": block",
 			desc:      "bedrockArgsPostCanyon",
 		},
 		{
 			args:      canyonArgs(),
-			rollupCfg: cfg(rollup.Canyon),
+			rollupCfg: cfg(forks.Canyon),
 			desc:      "validCanyonArgs",
 		},
 		{
 			args:      ecotoneArgs(),
-			rollupCfg: cfg(rollup.Ecotone),
+			rollupCfg: cfg(forks.Ecotone),
 			desc:      "validEcotoneArgs",
 		},
 		{
 			args:      holoceneArgs(),
-			rollupCfg: cfg(rollup.Holocene),
+			rollupCfg: cfg(forks.Holocene),
 			desc:      "validholoceneArgs",
 		},
 		{
 			args:      jovianArgs(),
-			rollupCfg: cfg(rollup.Jovian),
+			rollupCfg: cfg(forks.Jovian),
 			desc:      "validJovianArgs",
 		},
 		{
 			args:      mismatchedParentHashArgs(),
-			rollupCfg: cfg(rollup.Holocene),
+			rollupCfg: cfg(forks.Holocene),
 			err:       "parent hash field does not match",
 			desc:      "mismatchedParentHashArgs",
 		},
 		{
 			args:      createMismatchedTimestamp(),
-			rollupCfg: cfg(rollup.Holocene),
+			rollupCfg: cfg(forks.Holocene),
 			err:       "timestamp field does not match",
 			desc:      "createMismatchedTimestamp",
 		},
 		{
 			args:      createMismatchedPrevRandao(),
-			rollupCfg: cfg(rollup.Holocene),
+			rollupCfg: cfg(forks.Holocene),
 			err:       "random field does not match",
 			desc:      "createMismatchedPrevRandao",
 		},
 		{
 			args:      createMismatchedTransactions(),
-			rollupCfg: cfg(rollup.Holocene),
+			rollupCfg: cfg(forks.Holocene),
 			err:       "transaction count does not match",
 			desc:      "createMismatchedTransactions",
 		},
 		{
 			args:      ecotoneNoParentBeaconBlockRoot(),
-			rollupCfg: cfg(rollup.Holocene),
+			rollupCfg: cfg(forks.Holocene),
 			err:       "expected non-nil parent beacon block root",
 			desc:      "ecotoneNoParentBeaconBlockRoot",
 		},
 		{
 			args:      ecotoneUnexpectedParentBeaconBlockRoot(),
-			rollupCfg: cfg(rollup.Holocene),
+			rollupCfg: cfg(forks.Holocene),
 			err:       "expected nil parent beacon block root but got non-nil",
 			desc:      "ecotoneUnexpectedParentBeaconBlockRoot",
 		},
 		{
 			args:      ecotoneMismatchParentBeaconBlockRoot(),
-			rollupCfg: cfg(rollup.Ecotone),
+			rollupCfg: cfg(forks.Ecotone),
 			err:       "parent beacon block root does not match",
 			desc:      "ecotoneMismatchParentBeaconBlockRoot",
 		},
 		{
 			args:      ecotoneMismatchParentBeaconBlockRootPtr(),
-			rollupCfg: cfg(rollup.Ecotone),
+			rollupCfg: cfg(forks.Ecotone),
 			desc:      "ecotoneMismatchParentBeaconBlockRootPtr",
 		},
 		{
 			args:      ecotoneNilParentBeaconBlockRoots(),
-			rollupCfg: cfg(rollup.Ecotone),
+			rollupCfg: cfg(forks.Ecotone),
 			desc:      "ecotoneNilParentBeaconBlockRoots",
 		},
 		{
 			args:      createMismatchedGasLimit(),
-			rollupCfg: cfg(rollup.Holocene),
+			rollupCfg: cfg(forks.Holocene),
 			err:       "gas limit does not match",
 			desc:      "createMismatchedGasLimit",
 		},
 		{
 			args:      createNilGasLimit(),
-			rollupCfg: cfg(rollup.Holocene),
+			rollupCfg: cfg(forks.Holocene),
 			err:       "expected gaslimit in attributes to not be nil",
 			desc:      "createNilGasLimit",
 		},
 		{
 			args:      createMismatchedFeeRecipient(),
-			rollupCfg: cfg(rollup.Holocene),
+			rollupCfg: cfg(forks.Holocene),
 			err:       "fee recipient data does not match",
 			desc:      "createMismatchedFeeRecipient",
 		},
 		{
 			args:      createMismatchedEIP1559Params(),
-			rollupCfg: cfg(rollup.Holocene),
+			rollupCfg: cfg(forks.Holocene),
 			err:       "eip1559 parameters do not match",
 			desc:      "createMismatchedEIP1559Params",
 		},
 		{
 			args:      jovianArgsMinBaseFeeMissingFromAttributes(),
-			rollupCfg: cfg(rollup.Jovian),
+			rollupCfg: cfg(forks.Jovian),
 			err:       "minBaseFee does not match",
 			desc:      "missingMinBaseFee",
 		},
 		{
 			args:      jovianArgsMinBaseFeeMissingFromBlock(),
-			rollupCfg: cfg(rollup.Jovian),
+			rollupCfg: cfg(forks.Jovian),
 			err:       "invalid block extraData: MinBaseFee extraData should be 17 bytes, got 9",
 			desc:      "missingMinBaseFee",
 		},
 		{
 			args:      jovianArgsInconsistentMinBaseFee(),
-			rollupCfg: cfg(rollup.Jovian),
+			rollupCfg: cfg(forks.Jovian),
 			err:       "minBaseFee does not match",
 			desc:      "inconsistentMinBaseFee",
 		},

--- a/op-node/rollup/chain_spec.go
+++ b/op-node/rollup/chain_spec.go
@@ -1,9 +1,9 @@
 package rollup
 
 import (
-	"fmt"
 	"math/big"
 
+	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum-optimism/optimism/op-node/params"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/log"
@@ -30,66 +30,8 @@ const (
 // ChainSpec instead of reading the rollup configuration field directly.
 const maxSequencerDriftFjord = 1800
 
-type ForkName string
-
-const (
-	Bedrock  ForkName = "bedrock"
-	Regolith ForkName = "regolith"
-	Canyon   ForkName = "canyon"
-	Delta    ForkName = "delta"
-	Ecotone  ForkName = "ecotone"
-	Fjord    ForkName = "fjord"
-	Granite  ForkName = "granite"
-	Holocene ForkName = "holocene"
-	Isthmus  ForkName = "isthmus"
-	Jovian   ForkName = "jovian"
-	Interop  ForkName = "interop"
-	// ADD NEW FORKS TO AllForks BELOW!
-	None ForkName = ""
-)
-
-var AllForks = []ForkName{
-	Bedrock,
-	Regolith,
-	Canyon,
-	Delta,
-	Ecotone,
-	Fjord,
-	Granite,
-	Holocene,
-	Isthmus,
-	Jovian,
-	Interop,
-	// ADD NEW FORKS HERE!
-}
-
-var LatestFork = AllForks[len(AllForks)-1]
-
-func ForksFrom(fork ForkName) []ForkName {
-	for i, f := range AllForks {
-		if f == fork {
-			return AllForks[i:]
-		}
-	}
-	panic(fmt.Sprintf("invalid fork: %s", fork))
-}
-
-var nextFork = func() map[ForkName]ForkName {
-	m := make(map[ForkName]ForkName, len(AllForks))
-	for i, f := range AllForks {
-		if i == len(AllForks)-1 {
-			m[f] = None
-			break
-		}
-		m[f] = AllForks[i+1]
-	}
-	return m
-}()
-
-func IsValidFork(fork ForkName) bool {
-	_, ok := nextFork[fork]
-	return ok
-}
+// Legacy type alias kept temporarily for rollup internals; external code should use forks.Name directly.
+type ForkName = forks.Name
 
 type ChainSpec struct {
 	config      *Config
@@ -175,36 +117,36 @@ func (s *ChainSpec) MaxSequencerDrift(t uint64) uint64 {
 func (s *ChainSpec) CheckForkActivation(log log.Logger, block eth.L2BlockRef) {
 	if s.currentFork == "" {
 		// Initialize currentFork if it is not set yet
-		s.currentFork = Bedrock
+		s.currentFork = forks.Bedrock
 		if s.config.IsRegolith(block.Time) {
-			s.currentFork = Regolith
+			s.currentFork = forks.Regolith
 		}
 		if s.config.IsCanyon(block.Time) {
-			s.currentFork = Canyon
+			s.currentFork = forks.Canyon
 		}
 		if s.config.IsDelta(block.Time) {
-			s.currentFork = Delta
+			s.currentFork = forks.Delta
 		}
 		if s.config.IsEcotone(block.Time) {
-			s.currentFork = Ecotone
+			s.currentFork = forks.Ecotone
 		}
 		if s.config.IsFjord(block.Time) {
-			s.currentFork = Fjord
+			s.currentFork = forks.Fjord
 		}
 		if s.config.IsGranite(block.Time) {
-			s.currentFork = Granite
+			s.currentFork = forks.Granite
 		}
 		if s.config.IsHolocene(block.Time) {
-			s.currentFork = Holocene
+			s.currentFork = forks.Holocene
 		}
 		if s.config.IsIsthmus(block.Time) {
-			s.currentFork = Isthmus
+			s.currentFork = forks.Isthmus
 		}
 		if s.config.IsJovian(block.Time) {
-			s.currentFork = Jovian
+			s.currentFork = forks.Jovian
 		}
 		if s.config.IsInterop(block.Time) {
-			s.currentFork = Interop
+			s.currentFork = forks.Interop
 		}
 		log.Info("Current hardfork version detected", "forkName", s.currentFork)
 		return
@@ -212,31 +154,31 @@ func (s *ChainSpec) CheckForkActivation(log log.Logger, block eth.L2BlockRef) {
 
 	foundActivationBlock := false
 
-	switch nextFork[s.currentFork] {
-	case Regolith:
+	switch forks.Next(s.currentFork) {
+	case forks.Regolith:
 		foundActivationBlock = s.config.IsRegolithActivationBlock(block.Time)
-	case Canyon:
+	case forks.Canyon:
 		foundActivationBlock = s.config.IsCanyonActivationBlock(block.Time)
-	case Delta:
+	case forks.Delta:
 		foundActivationBlock = s.config.IsDeltaActivationBlock(block.Time)
-	case Ecotone:
+	case forks.Ecotone:
 		foundActivationBlock = s.config.IsEcotoneActivationBlock(block.Time)
-	case Fjord:
+	case forks.Fjord:
 		foundActivationBlock = s.config.IsFjordActivationBlock(block.Time)
-	case Granite:
+	case forks.Granite:
 		foundActivationBlock = s.config.IsGraniteActivationBlock(block.Time)
-	case Holocene:
+	case forks.Holocene:
 		foundActivationBlock = s.config.IsHoloceneActivationBlock(block.Time)
-	case Isthmus:
+	case forks.Isthmus:
 		foundActivationBlock = s.config.IsIsthmusActivationBlock(block.Time)
-	case Jovian:
+	case forks.Jovian:
 		foundActivationBlock = s.config.IsJovianActivationBlock(block.Time)
-	case Interop:
+	case forks.Interop:
 		foundActivationBlock = s.config.IsInteropActivationBlock(block.Time)
 	}
 
 	if foundActivationBlock {
-		s.currentFork = nextFork[s.currentFork]
+		s.currentFork = forks.Next(s.currentFork)
 		log.Info("Detected hardfork activation block", "forkName", s.currentFork, "timestamp", block.Time, "blockNum", block.Number, "hash", block.Hash)
 	}
 }

--- a/op-node/rollup/chain_spec_test.go
+++ b/op-node/rollup/chain_spec_test.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum/go-ethereum/common"
@@ -159,55 +160,55 @@ func TestCheckForkActivation(t *testing.T) {
 		{
 			name:                "Regolith activation",
 			block:               eth.L2BlockRef{Time: 10, Number: 5, Hash: common.Hash{0x5}},
-			expectedCurrentFork: Regolith,
+			expectedCurrentFork: forks.Regolith,
 			expectedLog:         "Detected hardfork activation block",
 		},
 		{
 			name:                "Still Regolith",
 			block:               eth.L2BlockRef{Time: 11, Number: 6, Hash: common.Hash{0x6}},
-			expectedCurrentFork: Regolith,
+			expectedCurrentFork: forks.Regolith,
 			expectedLog:         "",
 		},
 		{
 			name:                "Canyon activation",
 			block:               eth.L2BlockRef{Time: 20, Number: 7, Hash: common.Hash{0x7}},
-			expectedCurrentFork: Canyon,
+			expectedCurrentFork: forks.Canyon,
 			expectedLog:         "Detected hardfork activation block",
 		},
 		{
 			name:                "Granite activation",
 			block:               eth.L2BlockRef{Time: 60, Number: 8, Hash: common.Hash{0x8}},
-			expectedCurrentFork: Granite,
+			expectedCurrentFork: forks.Granite,
 			expectedLog:         "Detected hardfork activation block",
 		},
 		{
 			name:                "Holocene activation",
 			block:               eth.L2BlockRef{Time: 70, Number: 9, Hash: common.Hash{0x9}},
-			expectedCurrentFork: Holocene,
+			expectedCurrentFork: forks.Holocene,
 			expectedLog:         "Detected hardfork activation block",
 		},
 		{
 			name:                "Isthmus activation",
 			block:               eth.L2BlockRef{Time: 80, Number: 10, Hash: common.Hash{0xa}},
-			expectedCurrentFork: Isthmus,
+			expectedCurrentFork: forks.Isthmus,
 			expectedLog:         "Detected hardfork activation block",
 		},
 		{
 			name:                "Jovian activation",
 			block:               eth.L2BlockRef{Time: 90, Number: 11, Hash: common.Hash{0xb}},
-			expectedCurrentFork: Jovian,
+			expectedCurrentFork: forks.Jovian,
 			expectedLog:         "Detected hardfork activation block",
 		},
 		{
 			name:                "Interop activation",
 			block:               eth.L2BlockRef{Time: 100, Number: 11, Hash: common.Hash{0xb}},
-			expectedCurrentFork: Interop,
+			expectedCurrentFork: forks.Interop,
 			expectedLog:         "Detected hardfork activation block",
 		},
 		{
 			name:                "No more hardforks",
 			block:               eth.L2BlockRef{Time: 700, Number: 12, Hash: common.Hash{0xc}},
-			expectedCurrentFork: Interop,
+			expectedCurrentFork: forks.Interop,
 			expectedLog:         "",
 		},
 	}

--- a/op-node/rollup/derive/attributes_test.go
+++ b/op-node/rollup/derive/attributes_test.go
@@ -8,6 +8,7 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/predeploys"
@@ -230,7 +231,7 @@ func TestPreparePayloadAttributes(t *testing.T) {
 		require.NoError(t, err)
 
 		// sets config to post-interop
-		cfg.ActivateAtGenesis(rollup.Interop)
+		cfg.ActivateAtGenesis(forks.Interop)
 
 		seqNumber := uint64(0)
 		epoch := l1Info.ID()
@@ -271,7 +272,7 @@ func TestPreparePayloadAttributes(t *testing.T) {
 		l1Info.InfoNum = l2Parent.L1Origin.Number // same origin again, so the sequence number is not reset
 
 		// sets config to post-interop
-		cfg.ActivateAtGenesis(rollup.Interop)
+		cfg.ActivateAtGenesis(forks.Interop)
 
 		seqNumber := l2Parent.SequenceNumber + 1
 		epoch := l1Info.ID()
@@ -297,7 +298,7 @@ func TestPreparePayloadAttributes(t *testing.T) {
 
 	t.Run("holocene 1559 params", func(t *testing.T) {
 		cfg := mkCfg()
-		cfg.ActivateAtGenesis(rollup.Holocene)
+		cfg.ActivateAtGenesis(forks.Holocene)
 		rng := rand.New(rand.NewSource(1234))
 		l1Fetcher := &testutils.MockL1Source{}
 		defer l1Fetcher.AssertExpectations(t)
@@ -382,7 +383,7 @@ func TestPreparePayloadAttributes(t *testing.T) {
 	t.Run("interop", func(t *testing.T) {
 		prepareActivationAttributes := func(t *testing.T, depSet depset.DependencySet) *eth.PayloadAttributes {
 			cfg := mkCfg()
-			cfg.ActivateAtGenesis(rollup.Isthmus)
+			cfg.ActivateAtGenesis(forks.Isthmus)
 			interopTime := uint64(1000)
 			cfg.InteropTime = &interopTime
 			rng := rand.New(rand.NewSource(1234))
@@ -444,7 +445,7 @@ func TestPreparePayloadAttributes(t *testing.T) {
 
 		t.Run("minimum base fee param", func(t *testing.T) {
 			cfg := mkCfg()
-			cfg.ActivateAtGenesis(rollup.Jovian)
+			cfg.ActivateAtGenesis(forks.Jovian)
 			rng := rand.New(rand.NewSource(1234))
 			l1Fetcher := &testutils.MockL1Source{}
 			defer l1Fetcher.AssertExpectations(t)

--- a/op-node/rollup/derive/batch_mux.go
+++ b/op-node/rollup/derive/batch_mux.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/log"
@@ -48,9 +49,9 @@ func (b *BatchMux) Reset(ctx context.Context, base eth.L1BlockRef, sysCfg eth.Sy
 	return b.SingularBatchProvider.Reset(ctx, base, sysCfg)
 }
 
-func (b *BatchMux) Transform(f rollup.ForkName) {
+func (b *BatchMux) Transform(f forks.Name) {
 	switch f {
-	case rollup.Holocene:
+	case forks.Holocene:
 		b.TransformHolocene()
 	}
 }

--- a/op-node/rollup/derive/batch_mux_test.go
+++ b/op-node/rollup/derive/batch_mux_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 
+	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
@@ -31,7 +32,7 @@ func TestBatchMux_LaterHolocene(t *testing.T) {
 	require.IsType(t, new(BatchQueue), b.SingularBatchProvider)
 	require.Equal(t, l1A, b.SingularBatchProvider.(*BatchQueue).origin)
 
-	b.Transform(rollup.Holocene)
+	b.Transform(forks.Holocene)
 	require.IsType(t, new(BatchStage), b.SingularBatchProvider)
 	require.Equal(t, l1A, b.SingularBatchProvider.(*BatchStage).origin)
 
@@ -64,5 +65,5 @@ func TestBatchMux_ActiveHolocene(t *testing.T) {
 	require.IsType(t, new(BatchStage), b.SingularBatchProvider)
 	require.Equal(t, l1A, b.SingularBatchProvider.(*BatchStage).origin)
 
-	require.Panics(t, func() { b.Transform(rollup.Holocene) })
+	require.Panics(t, func() { b.Transform(forks.Holocene) })
 }

--- a/op-node/rollup/derive/batches_test.go
+++ b/op-node/rollup/derive/batches_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
@@ -655,7 +656,7 @@ func TestValidBatch(t *testing.T) {
 	// Add test cases for all forks from Jovian to assert that upgrade block must not contain user
 	// txs. If a future fork should allow user txs in its upgrade block, it must be removed from
 	// this list explicitly.
-	for _, fork := range rollup.ForksFrom(rollup.Jovian) {
+	for _, fork := range forks.From(forks.Jovian) {
 		singularBatchTestCases = append(singularBatchTestCases, ValidBatchTestCase{
 			Name:       fmt.Sprintf("user txs in %s upgrade block", fork),
 			L1Blocks:   []eth.L1BlockRef{l1A, l1B, l1C},

--- a/op-node/rollup/derive/channel_mux.go
+++ b/op-node/rollup/derive/channel_mux.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/log"
@@ -52,9 +53,9 @@ func (c *ChannelMux) Reset(ctx context.Context, base eth.L1BlockRef, sysCfg eth.
 	return c.RawChannelProvider.Reset(ctx, base, sysCfg)
 }
 
-func (c *ChannelMux) Transform(f rollup.ForkName) {
+func (c *ChannelMux) Transform(f forks.Name) {
 	switch f {
-	case rollup.Holocene:
+	case forks.Holocene:
 		c.TransformHolocene()
 	}
 }

--- a/op-node/rollup/derive/channel_mux_test.go
+++ b/op-node/rollup/derive/channel_mux_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 
+	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum-optimism/optimism/op-node/metrics"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -34,7 +35,7 @@ func TestChannelMux_LaterHolocene(t *testing.T) {
 	require.Equal(t, io.EOF, err)
 	require.IsType(t, new(ChannelBank), c.RawChannelProvider)
 
-	c.Transform(rollup.Holocene)
+	c.Transform(forks.Holocene)
 	require.IsType(t, new(ChannelAssembler), c.RawChannelProvider)
 
 	err = c.Reset(ctx, l1B, eth.SystemConfig{})
@@ -65,5 +66,5 @@ func TestChannelMux_ActiveHolocene(t *testing.T) {
 	require.Equal(t, io.EOF, err)
 	require.IsType(t, new(ChannelAssembler), c.RawChannelProvider)
 
-	require.Panics(t, func() { c.Transform(rollup.Holocene) })
+	require.Panics(t, func() { c.Transform(forks.Holocene) })
 }

--- a/op-node/rollup/derive/frame_queue.go
+++ b/op-node/rollup/derive/frame_queue.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/log"
 
+	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
@@ -36,9 +37,9 @@ func NewFrameQueue(log log.Logger, cfg *rollup.Config, prev NextDataProvider) *F
 	}
 }
 
-func (fq *FrameQueue) Transform(f rollup.ForkName) {
+func (fq *FrameQueue) Transform(f forks.Name) {
 	switch f {
-	case rollup.Holocene:
+	case forks.Holocene:
 		fq.log.Info("FrameQueue: resetting with Holocene activation")
 		// With Holocene activation, the frame queue is simply reset
 		fq.reset()

--- a/op-node/rollup/derive/l1_block_info_test.go
+++ b/op-node/rollup/derive/l1_block_info_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
 
+	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
@@ -112,7 +113,7 @@ func TestParseL1InfoDepositTxData(t *testing.T) {
 		rng := rand.New(rand.NewSource(1234))
 		info := testutils.MakeBlockInfo(nil)(rng)
 		rollupCfg := rollup.Config{}
-		rollupCfg.ActivateAtGenesis(rollup.Regolith)
+		rollupCfg.ActivateAtGenesis(forks.Regolith)
 		depTx, err := L1InfoDeposit(&rollupCfg, params.MergedTestChainConfig, randomL1Cfg(rng, info), randomSeqNr(rng), info, 0)
 		require.NoError(t, err)
 		require.False(t, depTx.IsSystemTransaction)
@@ -122,7 +123,7 @@ func TestParseL1InfoDepositTxData(t *testing.T) {
 		rng := rand.New(rand.NewSource(1234))
 		info := testutils.MakeBlockInfo(nil)(rng)
 		rollupCfg := rollup.Config{BlockTime: 2, Genesis: rollup.Genesis{L2Time: 1000}}
-		rollupCfg.ActivateAtGenesis(rollup.Ecotone)
+		rollupCfg.ActivateAtGenesis(forks.Ecotone)
 		// run 1 block after ecotone transition
 		timestamp := rollupCfg.Genesis.L2Time + rollupCfg.BlockTime
 		depTx, err := L1InfoDeposit(&rollupCfg, params.MergedTestChainConfig, randomL1Cfg(rng, info), randomSeqNr(rng), info, timestamp)
@@ -135,7 +136,7 @@ func TestParseL1InfoDepositTxData(t *testing.T) {
 		rng := rand.New(rand.NewSource(1234))
 		info := testutils.MakeBlockInfo(nil)(rng)
 		rollupCfg := rollup.Config{BlockTime: 2, Genesis: rollup.Genesis{L2Time: 1000}}
-		rollupCfg.ActivateAtGenesis(rollup.Delta)
+		rollupCfg.ActivateAtGenesis(forks.Delta)
 		ecotoneTime := rollupCfg.Genesis.L2Time + rollupCfg.BlockTime // activate ecotone just after genesis
 		rollupCfg.EcotoneTime = &ecotoneTime
 		depTx, err := L1InfoDeposit(&rollupCfg, params.MergedTestChainConfig, randomL1Cfg(rng, info), randomSeqNr(rng), info, ecotoneTime)
@@ -148,7 +149,7 @@ func TestParseL1InfoDepositTxData(t *testing.T) {
 		rng := rand.New(rand.NewSource(1234))
 		info := testutils.MakeBlockInfo(nil)(rng)
 		rollupCfg := rollup.Config{BlockTime: 2, Genesis: rollup.Genesis{L2Time: 1000}}
-		rollupCfg.ActivateAtGenesis(rollup.Ecotone)
+		rollupCfg.ActivateAtGenesis(forks.Ecotone)
 		depTx, err := L1InfoDeposit(&rollupCfg, params.MergedTestChainConfig, randomL1Cfg(rng, info), randomSeqNr(rng), info, rollupCfg.Genesis.L2Time)
 		require.NoError(t, err)
 		require.False(t, depTx.IsSystemTransaction)
@@ -159,7 +160,7 @@ func TestParseL1InfoDepositTxData(t *testing.T) {
 		rng := rand.New(rand.NewSource(1234))
 		info := testutils.MakeBlockInfo(nil)(rng)
 		rollupCfg := rollup.Config{BlockTime: 2, Genesis: rollup.Genesis{L2Time: 1000}}
-		rollupCfg.ActivateAtGenesis(rollup.Isthmus)
+		rollupCfg.ActivateAtGenesis(forks.Isthmus)
 		// run 1 block after isthmus transition
 		timestamp := rollupCfg.Genesis.L2Time + rollupCfg.BlockTime
 		depTx, err := L1InfoDeposit(&rollupCfg, params.MergedTestChainConfig, randomL1Cfg(rng, info), randomSeqNr(rng), info, timestamp)
@@ -172,7 +173,7 @@ func TestParseL1InfoDepositTxData(t *testing.T) {
 		rng := rand.New(rand.NewSource(1234))
 		info := testutils.MakeBlockInfo(nil)(rng)
 		rollupCfg := rollup.Config{BlockTime: 2, Genesis: rollup.Genesis{L2Time: 1000}}
-		rollupCfg.ActivateAtGenesis(rollup.Holocene)
+		rollupCfg.ActivateAtGenesis(forks.Holocene)
 		isthmusTime := rollupCfg.Genesis.L2Time + rollupCfg.BlockTime // activate isthmus just after genesis
 		rollupCfg.IsthmusTime = &isthmusTime
 		depTx, err := L1InfoDeposit(&rollupCfg, params.MergedTestChainConfig, randomL1Cfg(rng, info), randomSeqNr(rng), info, isthmusTime)
@@ -187,7 +188,7 @@ func TestParseL1InfoDepositTxData(t *testing.T) {
 		rng := rand.New(rand.NewSource(1234))
 		info := testutils.MakeBlockInfo(nil)(rng)
 		rollupCfg := rollup.Config{BlockTime: 2, Genesis: rollup.Genesis{L2Time: 1000}}
-		rollupCfg.ActivateAtGenesis(rollup.Isthmus)
+		rollupCfg.ActivateAtGenesis(forks.Isthmus)
 		depTx, err := L1InfoDeposit(&rollupCfg, params.MergedTestChainConfig, randomL1Cfg(rng, info), randomSeqNr(rng), info, rollupCfg.Genesis.L2Time)
 		require.NoError(t, err)
 		require.False(t, depTx.IsSystemTransaction)
@@ -198,7 +199,7 @@ func TestParseL1InfoDepositTxData(t *testing.T) {
 		rng := rand.New(rand.NewSource(1234))
 		info := testutils.MakeBlockInfo(nil)(rng)
 		rollupCfg := rollup.Config{BlockTime: 2, Genesis: rollup.Genesis{L2Time: 1000}}
-		rollupCfg.ActivateAtGenesis(rollup.Jovian)
+		rollupCfg.ActivateAtGenesis(forks.Jovian)
 		// run 1 block after Jovian transition
 		timestamp := rollupCfg.Genesis.L2Time + rollupCfg.BlockTime
 		depTx, err := L1InfoDeposit(&rollupCfg, params.MergedTestChainConfig, randomL1Cfg(rng, info), randomSeqNr(rng), info, timestamp)
@@ -215,7 +216,7 @@ func TestParseL1InfoDepositTxData(t *testing.T) {
 		rng := rand.New(rand.NewSource(1234))
 		info := testutils.MakeBlockInfo(nil)(rng)
 		rollupCfg := rollup.Config{BlockTime: 2, Genesis: rollup.Genesis{L2Time: 1000}}
-		rollupCfg.ActivateAtGenesis(rollup.Isthmus)
+		rollupCfg.ActivateAtGenesis(forks.Isthmus)
 		jovianTime := rollupCfg.Genesis.L2Time + rollupCfg.BlockTime // activate jovian just after genesis
 		rollupCfg.InteropTime = &jovianTime
 		depTx, err := L1InfoDeposit(&rollupCfg, params.MergedTestChainConfig, randomL1Cfg(rng, info), randomSeqNr(rng), info, jovianTime)
@@ -230,7 +231,7 @@ func TestParseL1InfoDepositTxData(t *testing.T) {
 		rng := rand.New(rand.NewSource(1234))
 		info := testutils.MakeBlockInfo(nil)(rng)
 		rollupCfg := rollup.Config{BlockTime: 2, Genesis: rollup.Genesis{L2Time: 1000}}
-		rollupCfg.ActivateAtGenesis(rollup.Jovian)
+		rollupCfg.ActivateAtGenesis(forks.Jovian)
 		depTx, err := L1InfoDeposit(&rollupCfg, params.MergedTestChainConfig, randomL1Cfg(rng, info), randomSeqNr(rng), info, rollupCfg.Genesis.L2Time)
 		require.NoError(t, err)
 		require.False(t, depTx.IsSystemTransaction)
@@ -241,7 +242,7 @@ func TestParseL1InfoDepositTxData(t *testing.T) {
 		rng := rand.New(rand.NewSource(1234))
 		info := testutils.MakeBlockInfo(nil)(rng)
 		rollupCfg := rollup.Config{BlockTime: 2, Genesis: rollup.Genesis{L2Time: 1000}}
-		rollupCfg.ActivateAtGenesis(rollup.Interop)
+		rollupCfg.ActivateAtGenesis(forks.Interop)
 		// run 1 block after interop transition
 		timestamp := rollupCfg.Genesis.L2Time + rollupCfg.BlockTime
 		depTx, err := L1InfoDeposit(&rollupCfg, params.MergedTestChainConfig, randomL1Cfg(rng, info), randomSeqNr(rng), info, timestamp)
@@ -254,7 +255,7 @@ func TestParseL1InfoDepositTxData(t *testing.T) {
 		rng := rand.New(rand.NewSource(1234))
 		info := testutils.MakeBlockInfo(nil)(rng)
 		rollupCfg := rollup.Config{BlockTime: 2, Genesis: rollup.Genesis{L2Time: 1000}}
-		rollupCfg.ActivateAtGenesis(rollup.Jovian)
+		rollupCfg.ActivateAtGenesis(forks.Jovian)
 		interopTime := rollupCfg.Genesis.L2Time + rollupCfg.BlockTime // activate interop just after genesis
 		rollupCfg.InteropTime = &interopTime
 		depTx, err := L1InfoDeposit(&rollupCfg, params.MergedTestChainConfig, randomL1Cfg(rng, info), randomSeqNr(rng), info, interopTime)
@@ -268,7 +269,7 @@ func TestParseL1InfoDepositTxData(t *testing.T) {
 		rng := rand.New(rand.NewSource(1234))
 		info := testutils.MakeBlockInfo(nil)(rng)
 		rollupCfg := rollup.Config{BlockTime: 2, Genesis: rollup.Genesis{L2Time: 1000}}
-		rollupCfg.ActivateAtGenesis(rollup.Interop)
+		rollupCfg.ActivateAtGenesis(forks.Interop)
 		depTx, err := L1InfoDeposit(&rollupCfg, params.MergedTestChainConfig, randomL1Cfg(rng, info), randomSeqNr(rng), info, rollupCfg.Genesis.L2Time)
 		require.NoError(t, err)
 		require.False(t, depTx.IsSystemTransaction)

--- a/op-node/rollup/derive/pipeline.go
+++ b/op-node/rollup/derive/pipeline.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 
+	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
@@ -49,7 +50,7 @@ type ChannelFlusher interface {
 }
 
 type ForkTransformer interface {
-	Transform(rollup.ForkName)
+	Transform(forks.Name)
 }
 
 type L2Source interface {
@@ -273,7 +274,7 @@ func (dp *DerivationPipeline) initialReset(ctx context.Context, resetL2Safe eth.
 
 func (db *DerivationPipeline) transformStages(oldOrigin, newOrigin eth.L1BlockRef) {
 	fork := db.rollupCfg.IsActivationBlock(oldOrigin.Time, newOrigin.Time)
-	if fork == rollup.None {
+	if fork == forks.None {
 		return
 	}
 

--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	altda "github.com/ethereum-optimism/optimism/op-alt-da"
+	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
@@ -339,25 +340,25 @@ func (cfg *Config) Check() error {
 		return err
 	}
 
-	if err := checkFork(cfg.RegolithTime, cfg.CanyonTime, Regolith, Canyon); err != nil {
+	if err := checkFork(cfg.RegolithTime, cfg.CanyonTime, forks.Regolith, forks.Canyon); err != nil {
 		return err
 	}
-	if err := checkFork(cfg.CanyonTime, cfg.DeltaTime, Canyon, Delta); err != nil {
+	if err := checkFork(cfg.CanyonTime, cfg.DeltaTime, forks.Canyon, forks.Delta); err != nil {
 		return err
 	}
-	if err := checkFork(cfg.DeltaTime, cfg.EcotoneTime, Delta, Ecotone); err != nil {
+	if err := checkFork(cfg.DeltaTime, cfg.EcotoneTime, forks.Delta, forks.Ecotone); err != nil {
 		return err
 	}
-	if err := checkFork(cfg.EcotoneTime, cfg.FjordTime, Ecotone, Fjord); err != nil {
+	if err := checkFork(cfg.EcotoneTime, cfg.FjordTime, forks.Ecotone, forks.Fjord); err != nil {
 		return err
 	}
-	if err := checkFork(cfg.FjordTime, cfg.GraniteTime, Fjord, Granite); err != nil {
+	if err := checkFork(cfg.FjordTime, cfg.GraniteTime, forks.Fjord, forks.Granite); err != nil {
 		return err
 	}
-	if err := checkFork(cfg.GraniteTime, cfg.HoloceneTime, Granite, Holocene); err != nil {
+	if err := checkFork(cfg.GraniteTime, cfg.HoloceneTime, forks.Granite, forks.Holocene); err != nil {
 		return err
 	}
-	if err := checkFork(cfg.HoloceneTime, cfg.IsthmusTime, Holocene, Isthmus); err != nil {
+	if err := checkFork(cfg.HoloceneTime, cfg.IsthmusTime, forks.Holocene, forks.Isthmus); err != nil {
 		return err
 	}
 
@@ -438,52 +439,52 @@ func (c *Config) IsForkActive(fork ForkName, timestamp uint64) bool {
 
 // IsRegolith returns true if the Regolith hardfork is active at or past the given timestamp.
 func (c *Config) IsRegolith(timestamp uint64) bool {
-	return c.IsForkActive(Regolith, timestamp)
+	return c.IsForkActive(forks.Regolith, timestamp)
 }
 
 // IsCanyon returns true if the Canyon hardfork is active at or past the given timestamp.
 func (c *Config) IsCanyon(timestamp uint64) bool {
-	return c.IsForkActive(Canyon, timestamp)
+	return c.IsForkActive(forks.Canyon, timestamp)
 }
 
 // IsDelta returns true if the Delta hardfork is active at or past the given timestamp.
 func (c *Config) IsDelta(timestamp uint64) bool {
-	return c.IsForkActive(Delta, timestamp)
+	return c.IsForkActive(forks.Delta, timestamp)
 }
 
 // IsEcotone returns true if the Ecotone hardfork is active at or past the given timestamp.
 func (c *Config) IsEcotone(timestamp uint64) bool {
-	return c.IsForkActive(Ecotone, timestamp)
+	return c.IsForkActive(forks.Ecotone, timestamp)
 }
 
 // IsFjord returns true if the Fjord hardfork is active at or past the given timestamp.
 func (c *Config) IsFjord(timestamp uint64) bool {
-	return c.IsForkActive(Fjord, timestamp)
+	return c.IsForkActive(forks.Fjord, timestamp)
 }
 
 // IsGranite returns true if the Granite hardfork is active at or past the given timestamp.
 func (c *Config) IsGranite(timestamp uint64) bool {
-	return c.IsForkActive(Granite, timestamp)
+	return c.IsForkActive(forks.Granite, timestamp)
 }
 
 // IsHolocene returns true if the Holocene hardfork is active at or past the given timestamp.
 func (c *Config) IsHolocene(timestamp uint64) bool {
-	return c.IsForkActive(Holocene, timestamp)
+	return c.IsForkActive(forks.Holocene, timestamp)
 }
 
 // IsIsthmus returns true if the Isthmus hardfork is active at or past the given timestamp.
 func (c *Config) IsIsthmus(timestamp uint64) bool {
-	return c.IsForkActive(Isthmus, timestamp)
+	return c.IsForkActive(forks.Isthmus, timestamp)
 }
 
 // IsJovian returns true if the Jovian hardfork is active at or past the given timestamp.
 func (c *Config) IsJovian(timestamp uint64) bool {
-	return c.IsForkActive(Jovian, timestamp)
+	return c.IsForkActive(forks.Jovian, timestamp)
 }
 
 // IsInterop returns true if the Interop hardfork is active at or past the given timestamp.
 func (c *Config) IsInterop(timestamp uint64) bool {
-	return c.IsForkActive(Interop, timestamp)
+	return c.IsForkActive(forks.Interop, timestamp)
 }
 
 func (c *Config) IsRegolithActivationBlock(l2BlockTime uint64) bool {
@@ -561,25 +562,25 @@ func (c *Config) IsInteropActivationBlock(l2BlockTime uint64) bool {
 func (c *Config) ActivationTime(fork ForkName) *uint64 {
 	// NEW FORKS MUST BE ADDED HERE
 	switch fork {
-	case Interop:
+	case forks.Interop:
 		return c.InteropTime
-	case Jovian:
+	case forks.Jovian:
 		return c.JovianTime
-	case Isthmus:
+	case forks.Isthmus:
 		return c.IsthmusTime
-	case Holocene:
+	case forks.Holocene:
 		return c.HoloceneTime
-	case Granite:
+	case forks.Granite:
 		return c.GraniteTime
-	case Fjord:
+	case forks.Fjord:
 		return c.FjordTime
-	case Ecotone:
+	case forks.Ecotone:
 		return c.EcotoneTime
-	case Delta:
+	case forks.Delta:
 		return c.DeltaTime
-	case Canyon:
+	case forks.Canyon:
 		return c.CanyonTime
-	case Regolith:
+	case forks.Regolith:
 		return c.RegolithTime
 	default:
 		panic(fmt.Sprintf("unknown fork: %v", fork))
@@ -589,25 +590,25 @@ func (c *Config) ActivationTime(fork ForkName) *uint64 {
 func (c *Config) SetActivationTime(fork ForkName, timestamp *uint64) {
 	// NEW FORKS MUST BE ADDED HERE
 	switch fork {
-	case Interop:
+	case forks.Interop:
 		c.InteropTime = timestamp
-	case Jovian:
+	case forks.Jovian:
 		c.JovianTime = timestamp
-	case Isthmus:
+	case forks.Isthmus:
 		c.IsthmusTime = timestamp
-	case Holocene:
+	case forks.Holocene:
 		c.HoloceneTime = timestamp
-	case Granite:
+	case forks.Granite:
 		c.GraniteTime = timestamp
-	case Fjord:
+	case forks.Fjord:
 		c.FjordTime = timestamp
-	case Ecotone:
+	case forks.Ecotone:
 		c.EcotoneTime = timestamp
-	case Delta:
+	case forks.Delta:
 		c.DeltaTime = timestamp
-	case Canyon:
+	case forks.Canyon:
 		c.CanyonTime = timestamp
-	case Regolith:
+	case forks.Regolith:
 		c.RegolithTime = timestamp
 	default:
 		panic(fmt.Sprintf("unknown fork: %v", fork))
@@ -623,7 +624,7 @@ func (c *Config) IsActivationBlock(oldTime, newTime uint64) ForkName {
 			return fork
 		}
 	}
-	return None
+	return forks.None
 }
 
 func (c *Config) IsActivationBlockForFork(l2BlockTime uint64, fork ForkName) bool {
@@ -638,17 +639,17 @@ func (c *Config) ActivateAtGenesis(hardfork ForkName) {
 	c.ActivateAt(hardfork, 0)
 }
 
-var scheduleableForks = ForksFrom(Regolith)
+var scheduleableForks = forks.From(forks.Regolith)
 
 // ActivateAt updates the config to activate the given fork at the given timestamp, all previous
 // forks at genesis, and all later forks are disabled.
 func (c *Config) ActivateAt(fork ForkName, timestamp uint64) {
-	if !IsValidFork(fork) {
+	if !forks.IsValid(fork) {
 		panic(fmt.Sprintf("invalid fork: %s", fork))
 	}
 	ts := new(uint64)
 	// Special case: if only activating Bedrock, all scheduleable forks are disabled.
-	if fork == Bedrock {
+	if fork == forks.Bedrock {
 		ts = nil
 	}
 	for i, f := range scheduleableForks {

--- a/op-program/Dockerfile.repro.dockerignore
+++ b/op-program/Dockerfile.repro.dockerignore
@@ -4,6 +4,7 @@
 !go.*
 # internal dependencies
 !cannon/
+!op-core/
 !op-alt-da/
 !op-node/
 !op-preimage/

--- a/op-program/Dockerfile.vmcompat.dockerignore
+++ b/op-program/Dockerfile.vmcompat.dockerignore
@@ -4,6 +4,7 @@
 !go.*
 # internal dependencies
 !cannon/
+!op-core/
 !op-alt-da/
 !op-node/
 !op-preimage/

--- a/op-program/client/l2/engineapi/l2_engine_api_test.go
+++ b/op-program/client/l2/engineapi/l2_engine_api_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum/go-ethereum/beacon/engine"
@@ -179,7 +179,7 @@ func createGenesisWithIsthmusTimeOffset(forkTimeOffset uint64) *core.Genesis {
 		},
 	}
 
-	deployConfig.ActivateForkAtOffset(rollup.Isthmus, forkTimeOffset)
+	deployConfig.ActivateForkAtOffset(forks.Isthmus, forkTimeOffset)
 
 	l1Genesis, err := genesis.NewL1Genesis(deployConfig)
 	if err != nil {

--- a/ops/docker/op-stack-go/Dockerfile.dockerignore
+++ b/ops/docker/op-stack-go/Dockerfile.dockerignore
@@ -4,6 +4,7 @@
 
 !/cannon
 !/devnet-sdk
+!/op-core
 !/op-batcher
 !/op-chain-ops
 !/op-deployer


### PR DESCRIPTION

**Description**

This PR introduces a new package `op-core` to host core protocol code and migrates fork definitions into it, at `op-core/forks`.

**Tests**

Refactor, all tests must keep passing.

**Additional context**

This is 1/n of a larger effort to improve our package dependency tree, in particular moving core dependencies on which other components like tests, batcher, op-program, op-supernode, etc depend (like a lot inside `op-node/rollup/derive`) into a neutral core package so that we avoid importing anything below `op-node/...` in packages outside op-node. 
