### PR TITLE
fix: use default mips version and use local op-deployer

### DIFF
--- a/op-deployer/justfile
+++ b/op-deployer/justfile
@@ -94,7 +94,7 @@ deploy-opcm release="dev" locator="$DEFAULT_LOCATOR": _validate_rpc
   ./bin/op-deployer bootstrap implementations \
     --l1-rpc-url $ETH_RPC_URL \
     --private-key $PRIVATE_KEY \
-    --mips-version 7 \
+    --mips-version 8 \
     --protocol-versions-proxy $PROTOCOL_VERSIONS_PROXY \
     --superchain-config-proxy $SUPERCHAIN_CONFIG_PROXY \
     --l1-proxy-admin-owner $L1_PROXY_ADMIN_OWNER \

--- a/op-deployer/justfile
+++ b/op-deployer/justfile
@@ -91,7 +91,7 @@ pre-deploy: build build-contracts
 deploy-opcm release="dev" locator="$DEFAULT_LOCATOR": _validate_rpc
   #!/bin/bash
   echo "Using artifacts locator: {{locator}}"
-  ./bin/op-deployer bootstrap implementations \
+  go run ./cmd/op-deployer bootstrap implementations \
     --l1-rpc-url $ETH_RPC_URL \
     --private-key $PRIVATE_KEY \
     --mips-version 8 \
@@ -107,7 +107,7 @@ deploy-opcm release="dev" locator="$DEFAULT_LOCATOR": _validate_rpc
 verify-opcm locator="$DEFAULT_LOCATOR": _validate_rpc
   #!/bin/bash
   echo "Using artifacts locator: {{locator}}"
-  ./bin/op-deployer verify \
+  go run ./cmd/op-deployer verify \
     --artifacts-locator {{locator}} \
     --l1-rpc-url $ETH_RPC_URL \
     --etherscan-api-key $ETHERSCAN_API_KEY \

--- a/op-deployer/justfile
+++ b/op-deployer/justfile
@@ -94,7 +94,6 @@ deploy-opcm release="dev" locator="$DEFAULT_LOCATOR": _validate_rpc
   go run ./cmd/op-deployer bootstrap implementations \
     --l1-rpc-url $ETH_RPC_URL \
     --private-key $PRIVATE_KEY \
-    --mips-version 8 \
     --protocol-versions-proxy $PROTOCOL_VERSIONS_PROXY \
     --superchain-config-proxy $SUPERCHAIN_CONFIG_PROXY \
     --l1-proxy-admin-owner $L1_PROXY_ADMIN_OWNER \


### PR DESCRIPTION
This PR makes two changes to the op-deployer justfile:
1. It bumps the hardcoded MIPS version from 7 to 8 to ensure Go 1.24 support is included by default
2. It changes to using `go run` to invoke op-deployer instead of requiring that the binary be built beforehand