### PR TITLE
feat(ci): run upgrade tests with dev flags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1146,6 +1146,10 @@ jobs:
       fork_base_rpc:
         description: Fork Base RPC
         type: string
+      dev_features:
+        description: Comma-separated list of dev features to enable (e.g., "OPTIMISM_PORTAL_INTEROP,ANOTHER_FEATURE")
+        type: string
+        default: ""
     docker:
       - image: <<pipeline.parameters.default_docker_image>>
     resource_class: xlarge
@@ -1176,6 +1180,8 @@ jobs:
       - restore_cache:
           name: Restore forked state
           key: forked-state-contracts-bedrock-tests-upgrade-<<parameters.fork_op_chain>>-<<parameters.fork_base_chain>>-{{ checksum "packages/contracts-bedrock/pinnedBlockNumber.txt" }}
+      - setup-dev-features:
+          dev_features: <<parameters.dev_features>>
       - run:
           name: Run tests
           command: just test-upgrade
@@ -2454,13 +2460,26 @@ workflows:
           requires:
             - initialize
       - contracts-bedrock-tests-upgrade:
+          name: contracts-bedrock-tests-upgrade op-mainnet <<matrix.dev_features>>
+          fork_op_chain: op
+          fork_base_chain: mainnet
+          fork_base_rpc: https://ci-mainnet-l1-archive.optimism.io
+          dev_features: <<matrix.dev_features>>
+          matrix:
+            parameters:
+              dev_features: *dev_features_matrix
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+          requires:
+            - initialize
+      - contracts-bedrock-tests-upgrade:
           name: contracts-bedrock-tests-upgrade <<matrix.fork_op_chain>>-mainnet
           fork_op_chain: <<matrix.fork_op_chain>>
           fork_base_chain: mainnet
           fork_base_rpc: https://ci-mainnet-l1-archive.optimism.io
           matrix:
             parameters:
-              fork_op_chain: ["op", "base", "ink", "unichain"]
+              fork_op_chain: ["base", "ink", "unichain"]
           context:
             - circleci-repo-readonly-authenticated-github-token
           requires:

--- a/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
@@ -95,7 +95,7 @@ abstract contract OPContractsManagerStandardValidator_TestInit is CommonTest, Di
     Claim cannonPrestate;
 
     /// @notice The CannonKona absolute prestate.
-    Claim cannonKonaPrestate = Claim.wrap(bytes32(keccak256("cannonKona")));
+    Claim cannonKonaPrestate = Claim.wrap(bytes32(keccak256("cannonKonaPrestate")));
 
     /// @notice The proposer role set on the PermissionedDisputeGame instance.
     address proposer;


### PR DESCRIPTION
Updates CI to run upgrade tests with dev flags enabled. Only OP will run with dev flags enabled for now, this should be sufficient and will avoid dramatically increasing CI impact.