### PR TITLE
op-service/flags: Modularize fork override flags

### DIFF
--- a/op-core/forks/forks.go
+++ b/op-core/forks/forks.go
@@ -17,11 +17,15 @@ const (
 	Isthmus  Name = "isthmus"
 	Jovian   Name = "jovian"
 	Interop  Name = "interop"
-	// ADD NEW FORKS TO All BELOW!
+	// ADD NEW MAINLINE FORKS TO [All] BELOW!
+
+	// Optional Forks - not part of mainline
+	PectraBlobSchedule Name = "pectrablobschedule"
+
 	None Name = ""
 )
 
-// All lists all known forks in chronological order.
+// All lists all known mainline forks in chronological order.
 var All = []Name{
 	Bedrock,
 	Regolith,
@@ -34,10 +38,16 @@ var All = []Name{
 	Isthmus,
 	Jovian,
 	Interop,
-	// ADD NEW FORKS HERE!
+	// ADD NEW MAINLINE FORKS HERE!
 }
 
-// Latest returns the most recent fork in All.
+// AllOpt lists all optional forks in chronological order.
+var AllOpt = []Name{
+	PectraBlobSchedule,
+	// ADD NEW OPTIONAL FORKS HERE!
+}
+
+// Latest returns the most recent fork in [All].
 var Latest = All[len(All)-1]
 
 // From returns the list of forks starting from the provided fork, inclusive.

--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -582,6 +582,11 @@ func (c *Config) ActivationTime(fork ForkName) *uint64 {
 		return c.CanyonTime
 	case forks.Regolith:
 		return c.RegolithTime
+
+	// Optional forks
+	case forks.PectraBlobSchedule:
+		return c.PectraBlobScheduleTime
+
 	default:
 		panic(fmt.Sprintf("unknown fork: %v", fork))
 	}
@@ -610,6 +615,11 @@ func (c *Config) SetActivationTime(fork ForkName, timestamp *uint64) {
 		c.CanyonTime = timestamp
 	case forks.Regolith:
 		c.RegolithTime = timestamp
+
+	// Optional forks
+	case forks.PectraBlobSchedule:
+		c.PectraBlobScheduleTime = timestamp
+
 	default:
 		panic(fmt.Sprintf("unknown fork: %v", fork))
 	}

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -257,45 +257,12 @@ Conflicting configuration is deprecated, and will stop the op-node from starting
 }
 
 func applyOverrides(ctx cliiface.Context, rollupConfig *rollup.Config) {
-	if ctx.IsSet(opflags.CanyonOverrideFlagName) {
-		canyon := ctx.Uint64(opflags.CanyonOverrideFlagName)
-		rollupConfig.CanyonTime = &canyon
-	}
-	if ctx.IsSet(opflags.DeltaOverrideFlagName) {
-		delta := ctx.Uint64(opflags.DeltaOverrideFlagName)
-		rollupConfig.DeltaTime = &delta
-	}
-	if ctx.IsSet(opflags.EcotoneOverrideFlagName) {
-		ecotone := ctx.Uint64(opflags.EcotoneOverrideFlagName)
-		rollupConfig.EcotoneTime = &ecotone
-	}
-	if ctx.IsSet(opflags.FjordOverrideFlagName) {
-		fjord := ctx.Uint64(opflags.FjordOverrideFlagName)
-		rollupConfig.FjordTime = &fjord
-	}
-	if ctx.IsSet(opflags.GraniteOverrideFlagName) {
-		granite := ctx.Uint64(opflags.GraniteOverrideFlagName)
-		rollupConfig.GraniteTime = &granite
-	}
-	if ctx.IsSet(opflags.HoloceneOverrideFlagName) {
-		holocene := ctx.Uint64(opflags.HoloceneOverrideFlagName)
-		rollupConfig.HoloceneTime = &holocene
-	}
-	if ctx.IsSet(opflags.PectraBlobScheduleOverrideFlagName) {
-		pectrablobschedule := ctx.Uint64(opflags.PectraBlobScheduleOverrideFlagName)
-		rollupConfig.PectraBlobScheduleTime = &pectrablobschedule
-	}
-	if ctx.IsSet(opflags.IsthmusOverrideFlagName) {
-		isthmus := ctx.Uint64(opflags.IsthmusOverrideFlagName)
-		rollupConfig.IsthmusTime = &isthmus
-	}
-	if ctx.IsSet(opflags.JovianOverrideFlagName) {
-		jovian := ctx.Uint64(opflags.JovianOverrideFlagName)
-		rollupConfig.JovianTime = &jovian
-	}
-	if ctx.IsSet(opflags.InteropOverrideFlagName) {
-		interop := ctx.Uint64(opflags.InteropOverrideFlagName)
-		rollupConfig.InteropTime = &interop
+	for _, fork := range opflags.OverridableForks {
+		flagName := opflags.OverrideName(fork)
+		if ctx.IsSet(flagName) {
+			timestamp := ctx.Uint64(flagName)
+			rollupConfig.SetActivationTime(fork, &timestamp)
+		}
 	}
 }
 

--- a/op-service/flags/flags.go
+++ b/op-service/flags/flags.go
@@ -6,101 +6,46 @@ import (
 
 	"github.com/urfave/cli/v2"
 
+	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum-optimism/optimism/op-node/chaincfg"
 	opservice "github.com/ethereum-optimism/optimism/op-service"
 	"github.com/ethereum-optimism/optimism/op-service/cliiface"
 )
 
 const (
-	RollupConfigFlagName               = "rollup.config"
-	NetworkFlagName                    = "network"
-	CanyonOverrideFlagName             = "override.canyon"
-	DeltaOverrideFlagName              = "override.delta"
-	EcotoneOverrideFlagName            = "override.ecotone"
-	FjordOverrideFlagName              = "override.fjord"
-	GraniteOverrideFlagName            = "override.granite"
-	HoloceneOverrideFlagName           = "override.holocene"
-	PectraBlobScheduleOverrideFlagName = "override.pectrablobschedule"
-	IsthmusOverrideFlagName            = "override.isthmus"
-	InteropOverrideFlagName            = "override.interop"
-	JovianOverrideFlagName             = "override.jovian"
+	RollupConfigFlagName = "rollup.config"
+	NetworkFlagName      = "network"
 )
 
+// OverridableForks lists all forks that can be overridden via CLI flags or env vars.
+// It's all mainline forks from Canyon onwards, plus all optional forks.
+var OverridableForks = append(forks.From(forks.Canyon), forks.AllOpt...)
+
+func OverrideName(f forks.Name) string { return "override." + string(f) }
+
+func OverrideEnvVar(envPrefix string, fork forks.Name) []string {
+	return opservice.PrefixEnvVar(envPrefix, "OVERRIDE_"+strings.ToUpper(string(fork)))
+}
+
 func CLIFlags(envPrefix string, category string) []cli.Flag {
-	return []cli.Flag{
-		&cli.Uint64Flag{
-			Name:     CanyonOverrideFlagName,
-			Usage:    "Manually specify the Canyon fork timestamp, overriding the bundled setting",
-			EnvVars:  opservice.PrefixEnvVar(envPrefix, "OVERRIDE_CANYON"),
-			Hidden:   false,
-			Category: category,
-		},
-		&cli.Uint64Flag{
-			Name:     DeltaOverrideFlagName,
-			Usage:    "Manually specify the Delta fork timestamp, overriding the bundled setting",
-			EnvVars:  opservice.PrefixEnvVar(envPrefix, "OVERRIDE_DELTA"),
-			Hidden:   false,
-			Category: category,
-		},
-		&cli.Uint64Flag{
-			Name:     EcotoneOverrideFlagName,
-			Usage:    "Manually specify the Ecotone fork timestamp, overriding the bundled setting",
-			EnvVars:  opservice.PrefixEnvVar(envPrefix, "OVERRIDE_ECOTONE"),
-			Hidden:   false,
-			Category: category,
-		},
-		&cli.Uint64Flag{
-			Name:     FjordOverrideFlagName,
-			Usage:    "Manually specify the Fjord fork timestamp, overriding the bundled setting",
-			EnvVars:  opservice.PrefixEnvVar(envPrefix, "OVERRIDE_FJORD"),
-			Hidden:   false,
-			Category: category,
-		},
-		&cli.Uint64Flag{
-			Name:     GraniteOverrideFlagName,
-			Usage:    "Manually specify the Granite fork timestamp, overriding the bundled setting",
-			EnvVars:  opservice.PrefixEnvVar(envPrefix, "OVERRIDE_GRANITE"),
-			Hidden:   false,
-			Category: category,
-		},
-		&cli.Uint64Flag{
-			Name:     HoloceneOverrideFlagName,
-			Usage:    "Manually specify the Holocene fork timestamp, overriding the bundled setting",
-			EnvVars:  opservice.PrefixEnvVar(envPrefix, "OVERRIDE_HOLOCENE"),
-			Hidden:   false,
-			Category: category,
-		},
-		&cli.Uint64Flag{
-			Name:     PectraBlobScheduleOverrideFlagName,
-			Usage:    "Manually specify the PectraBlobSchedule fork timestamp, overriding the bundled setting",
-			EnvVars:  opservice.PrefixEnvVar(envPrefix, "OVERRIDE_PECTRABLOBSCHEDULE"),
-			Hidden:   false,
-			Category: category,
-		},
-		&cli.Uint64Flag{
-			Name:     IsthmusOverrideFlagName,
-			Usage:    "Manually specify the Isthmus fork timestamp, overriding the bundled setting",
-			EnvVars:  opservice.PrefixEnvVar(envPrefix, "OVERRIDE_ISTHMUS"),
-			Hidden:   false,
-			Category: category,
-		},
-		&cli.Uint64Flag{
-			Name:     JovianOverrideFlagName,
-			Usage:    "Manually specify the Jovian fork timestamp, overriding the bundled setting",
-			EnvVars:  opservice.PrefixEnvVar(envPrefix, "OVERRIDE_JOVIAN"),
-			Hidden:   false,
-			Category: category,
-		},
-		&cli.Uint64Flag{
-			Name:     InteropOverrideFlagName,
-			Usage:    "Manually specify the Interop fork timestamp, overriding the bundled setting",
-			EnvVars:  opservice.PrefixEnvVar(envPrefix, "OVERRIDE_INTEROP"),
-			Hidden:   false,
-			Category: category,
-		},
+	return append(CLIOverrideFlags(envPrefix, category),
 		CLINetworkFlag(envPrefix, category),
 		CLIRollupConfigFlag(envPrefix, category),
+	)
+}
+
+func CLIOverrideFlags(envPrefix string, category string) []cli.Flag {
+	var flags []cli.Flag
+	for _, fork := range OverridableForks {
+		flags = append(flags,
+			&cli.Uint64Flag{
+				Name:     OverrideName(fork),
+				Usage:    fmt.Sprintf("Manually specify the %s fork timestamp, overriding the bundled setting", fork),
+				EnvVars:  OverrideEnvVar(envPrefix, fork),
+				Category: category,
+			})
 	}
+	return flags
 }
 
 func CLINetworkFlag(envPrefix string, category string) cli.Flag {


### PR DESCRIPTION
**Description**

Replaces manual specification of fork override flags with modular forwards-compatible method.

**Tests**
I ran `go run ./op-node/cmd --help | less` and checked the expected output for the overrides section:
```
    --override.canyon value             (default: 0)                       ($OP_NODE_OVERRIDE_CANYON)
          Manually specify the canyon fork timestamp, overriding the bundled setting

    --override.delta value              (default: 0)                       ($OP_NODE_OVERRIDE_DELTA)
          Manually specify the delta fork timestamp, overriding the bundled setting

    --override.ecotone value            (default: 0)                       ($OP_NODE_OVERRIDE_ECOTONE)
          Manually specify the ecotone fork timestamp, overriding the bundled setting

    --override.fjord value              (default: 0)                       ($OP_NODE_OVERRIDE_FJORD)
          Manually specify the fjord fork timestamp, overriding the bundled setting

    --override.granite value            (default: 0)                       ($OP_NODE_OVERRIDE_GRANITE)
          Manually specify the granite fork timestamp, overriding the bundled setting

    --override.holocene value           (default: 0)                       ($OP_NODE_OVERRIDE_HOLOCENE)
          Manually specify the holocene fork timestamp, overriding the bundled setting

    --override.interop value            (default: 0)                       ($OP_NODE_OVERRIDE_INTEROP)
          Manually specify the interop fork timestamp, overriding the bundled setting

    --override.isthmus value            (default: 0)                       ($OP_NODE_OVERRIDE_ISTHMUS)
          Manually specify the isthmus fork timestamp, overriding the bundled setting

    --override.jovian value             (default: 0)                       ($OP_NODE_OVERRIDE_JOVIAN)
          Manually specify the jovian fork timestamp, overriding the bundled setting

    --override.pectrablobschedule value (default: 0)                       ($OP_NODE_OVERRIDE_PECTRABLOBSCHEDULE)
          Manually specify the pectrablobschedule fork timestamp, overriding the bundled
```

**Additional context**

Follow up to #18121 to showcase what's possible with more modular fork handling.
