### PR TITLE
ci: rename contracts-bedrock-tests job to match required check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2327,7 +2327,7 @@ workflows:
             - circleci-repo-readonly-authenticated-github-token
       - contracts-bedrock-tests:
           # Test everything except PreimageOracle.t.sol since it's slow.
-          name: contracts-bedrock-tests
+          name: contracts-bedrock-tests main
           test_list: find test -name "*.t.sol" -not -name "PreimageOracle.t.sol"
           context:
             - circleci-repo-readonly-authenticated-github-token


### PR DESCRIPTION
The required status check is looking for "contracts-bedrock-tests main" (job name and workflow name). This change renames the job to include "main" in the name so it matches the required check for proposal branches. Once merged, we'll rebase https://github.com/ethereum-optimism/optimism/pull/18132 on top of this to unblock it
