### PR TITLE
ci: Use cached solidity compilers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,8 +160,9 @@ commands:
             pip3 install -r requirements.txt
             python3 main.py "<<parameters.patterns>>"
 
-  install-contracts-dependencies:
-    description: "Install the dependencies for the smart contracts"
+
+  install-solc-compilers:
+    description: "Install the solc compilers"
     parameters:
       solc_versions:
         description: "The versions of solc to install"
@@ -182,6 +183,16 @@ commands:
           key: svm-cache-{{ checksum "mise.toml" }}-<<parameters.solc_versions>>
           paths:
             - ~/.svm
+
+  install-contracts-dependencies:
+    description: "Install the dependencies for the smart contracts"
+    parameters:
+      solc_versions:
+        description: "The versions of solc to install"
+        type: string
+        default: "0.8.15,0.8.19,0.8.25,0.8.28"
+    steps:
+      - install-solc-compilers
       - run:
           name: Install dependencies
           command: |
@@ -1065,6 +1076,7 @@ jobs:
       - checkout-from-workspace
       - check-changed:
           patterns: contracts-bedrock
+      - install-solc-compilers
       - run:
           name: Print dependencies
           command: just dep-status
@@ -1153,6 +1165,7 @@ jobs:
       - checkout-from-workspace
       - check-changed:
           patterns: contracts-bedrock
+      - install-solc-compilers
       - run:
           name: Print dependencies
           command: just dep-status


### PR DESCRIPTION
Should reduce the likelihood of text file busy errors.

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
