### PR TITLE
etherscan: V2 Migration

### DIFF
--- a/op-deployer/pkg/deployer/verify/etherscan.go
+++ b/op-deployer/pkg/deployer/verify/etherscan.go
@@ -30,6 +30,7 @@ type EtherscanContractCreationResp struct {
 
 type EtherscanClient struct {
 	apiKey      string
+	chainID     uint64
 	url         string
 	rateLimiter *rate.Limiter
 }
@@ -37,19 +38,20 @@ type EtherscanClient struct {
 func getAPIEndpoint(l1ChainID uint64) (string, error) {
 	switch l1ChainID {
 	case 1:
-		return "https://api.etherscan.io/api", nil // eth-mainnet
+		return "https://api.etherscan.io/v2/api", nil // eth-mainnet
 	case 11155111:
-		return "https://api-sepolia.etherscan.io/api", nil // eth-sepolia
+		return "https://api-sepolia.etherscan.io/v2/api", nil // eth-sepolia
 	case 84532:
-		return "https://api-sepolia.basescan.org/api", nil // base-sepolia
+		return "https://api-sepolia.basescan.org/v2/api", nil // base-sepolia
 	default:
 		return "", fmt.Errorf("unsupported L1 chain ID: %d", l1ChainID)
 	}
 }
 
-func NewEtherscanClient(apiKey string, url string, rateLimiter *rate.Limiter) *EtherscanClient {
+func NewEtherscanClient(apiKey string, chainID uint64, url string, rateLimiter *rate.Limiter) *EtherscanClient {
 	return &EtherscanClient{
 		apiKey:      apiKey,
+		chainID:     chainID,
 		url:         url,
 		rateLimiter: rateLimiter,
 	}
@@ -67,8 +69,8 @@ func (c *EtherscanClient) sendRateLimitedRequest(req *http.Request) (*http.Respo
 // getContractCreation returns the txHash of the contract creation tx
 // (useful for extracting constructor args)
 func (c *EtherscanClient) getContractCreation(address common.Address) (common.Hash, error) {
-	req, err := http.NewRequest("GET", fmt.Sprintf("%s?module=contract&action=getcontractcreation&contractaddresses=%s&apikey=%s",
-		c.url, address.Hex(), c.apiKey), nil)
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s?chainid=%d&module=contract&action=getcontractcreation&contractaddresses=%s&apikey=%s",
+		c.url, c.chainID, address.Hex(), c.apiKey), nil)
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("failed to create contract creation request: %w", err)
 	}
@@ -143,8 +145,8 @@ func (c *EtherscanClient) verifySourceCode(address common.Address, artifact *con
 }
 
 func (c *EtherscanClient) isVerified(address common.Address) (bool, error) {
-	req, err := http.NewRequest("GET", fmt.Sprintf("%s?module=contract&action=getabi&address=%s&apikey=%s",
-		c.url, address.Hex(), c.apiKey), nil)
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s?chainid=%d&module=contract&action=getabi&address=%s&apikey=%s",
+		c.url, c.chainID, address.Hex(), c.apiKey), nil)
 	if err != nil {
 		return false, err
 	}
@@ -164,8 +166,8 @@ func (c *EtherscanClient) isVerified(address common.Address) (bool, error) {
 }
 
 func (c *EtherscanClient) pollVerificationStatus(reqId string) error {
-	req, err := http.NewRequest("GET", fmt.Sprintf("%s?apikey=%s&module=contract&action=checkverifystatus&guid=%s",
-		c.url, c.apiKey, reqId), nil)
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s?chainid=%d&apikey=%s&module=contract&action=checkverifystatus&guid=%s",
+		c.url, c.chainID, c.apiKey, reqId), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create checkverifystatus request: %w", err)
 	}

--- a/op-deployer/pkg/deployer/verify/etherscan.go
+++ b/op-deployer/pkg/deployer/verify/etherscan.go
@@ -40,9 +40,9 @@ func getAPIEndpoint(l1ChainID uint64) (string, error) {
 	case 1:
 		return "https://api.etherscan.io/v2/api", nil // eth-mainnet
 	case 11155111:
-		return "https://api-sepolia.etherscan.io/v2/api", nil // eth-sepolia
+		return "https://api.etherscan.io/v2/api", nil // eth-sepolia
 	case 84532:
-		return "https://api-sepolia.basescan.org/v2/api", nil // base-sepolia
+		return "https://api.basescan.org/v2/api", nil // base-sepolia
 	default:
 		return "", fmt.Errorf("unsupported L1 chain ID: %d", l1ChainID)
 	}
@@ -120,7 +120,7 @@ func (c *EtherscanClient) verifySourceCode(address common.Address, artifact *con
 		"constructorArguements": {constructorArgs},
 	}
 
-	req, err := http.NewRequest("POST", c.url, strings.NewReader(data.Encode()))
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s?chainid=%d", c.url, c.chainID), strings.NewReader(data.Encode()))
 	if err != nil {
 		return "", fmt.Errorf("failed to create verification request: %w", err)
 	}

--- a/op-deployer/pkg/deployer/verify/etherscan_test.go
+++ b/op-deployer/pkg/deployer/verify/etherscan_test.go
@@ -20,13 +20,13 @@ const (
 )
 
 // createTestClient creates a new EtherscanClient with a mock server for testing
-func createTestClient(t *testing.T, handler http.HandlerFunc) (*EtherscanClient, *httptest.Server) {
+func createTestClient(t *testing.T, chainid uint64, handler http.HandlerFunc) (*EtherscanClient, *httptest.Server) {
 	server := httptest.NewServer(handler)
 	t.Cleanup(func() { server.Close() })
 
 	// Use a fast rate limiter for testing
 	limiter := rate.NewLimiter(rate.Every(time.Millisecond), 10)
-	return NewEtherscanClient(testAPIKey, server.URL, limiter), server
+	return NewEtherscanClient(testAPIKey, chainid, server.URL, limiter), server
 }
 
 // createTestArtifact creates a contract artifact for testing
@@ -52,8 +52,8 @@ func TestGetAPIEndpoint(t *testing.T) {
 		expected      string
 		expectedError bool
 	}{
-		{"Mainnet", 1, "https://api.etherscan.io/api", false},
-		{"Sepolia", 11155111, "https://api-sepolia.etherscan.io/api", false},
+		{"Mainnet", 1, "https://api.etherscan.io/v2/api", false},
+		{"Sepolia", 11155111, "https://api-sepolia.etherscan.io/v2/api", false},
 		{"Unknown", 999, "", true},
 	}
 
@@ -71,7 +71,7 @@ func TestGetAPIEndpoint(t *testing.T) {
 }
 
 func TestGetContractCreation(t *testing.T) {
-	client, _ := createTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+	client, _ := createTestClient(t, 1, func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, "GET", r.Method)
 		require.Contains(t, r.URL.String(), "module=contract")
 		require.Contains(t, r.URL.String(), "action=getcontractcreation")
@@ -106,7 +106,7 @@ func TestGetContractCreation(t *testing.T) {
 }
 
 func TestGetContractCreationError(t *testing.T) {
-	client, _ := createTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+	client, _ := createTestClient(t, 1, func(w http.ResponseWriter, r *http.Request) {
 		resp := EtherscanContractCreationResp{
 			Status:  "0",
 			Message: "Error",
@@ -126,7 +126,7 @@ func TestGetContractCreationError(t *testing.T) {
 }
 
 func TestVerifySourceCode(t *testing.T) {
-	client, _ := createTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+	client, _ := createTestClient(t, 1, func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, "POST", r.Method)
 		require.Equal(t, "application/x-www-form-urlencoded", r.Header.Get("Content-Type"))
 
@@ -170,7 +170,7 @@ func TestIsVerified(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client, _ := createTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			client, _ := createTestClient(t, 1, func(w http.ResponseWriter, r *http.Request) {
 				require.Equal(t, "GET", r.Method)
 				require.Contains(t, r.URL.String(), "module=contract")
 				require.Contains(t, r.URL.String(), "action=getabi")
@@ -231,7 +231,7 @@ func TestPollVerificationStatus(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			responseIndex := 0
 
-			client, _ := createTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			client, _ := createTestClient(t, 1, func(w http.ResponseWriter, r *http.Request) {
 				require.Equal(t, "GET", r.Method)
 				require.Contains(t, r.URL.String(), "module=contract")
 				require.Contains(t, r.URL.String(), "action=checkverifystatus")

--- a/op-deployer/pkg/deployer/verify/verifier.go
+++ b/op-deployer/pkg/deployer/verify/verifier.go
@@ -37,7 +37,7 @@ func NewVerifier(apiKey string, l1ChainID uint64, artifactsFS foundry.StatDirFs,
 	}
 	l.Info("found etherscan url", "url", etherscanUrl)
 
-	etherscan := NewEtherscanClient(apiKey, etherscanUrl, rate.NewLimiter(rate.Limit(1), 1))
+	etherscan := NewEtherscanClient(apiKey, l1ChainID, etherscanUrl, rate.NewLimiter(rate.Limit(1), 1))
 
 	return &Verifier{
 		l1ChainID:   l1ChainID,

--- a/op-deployer/pkg/deployer/verify/verifier_test.go
+++ b/op-deployer/pkg/deployer/verify/verifier_test.go
@@ -51,7 +51,8 @@ func TestVerifierWithEmbeddedArtifacts(t *testing.T) {
 	artifactsFS, err := artifacts.ExtractEmbedded(testCacheDir)
 	require.NoError(t, err, "embedded artifacts should be extracted successfully")
 
-	verifier, err := NewVerifier(testAPIKey, 1, artifactsFS, log.New(log.JSONHandler(io.Discard)), nil)
+	l1ChainID := uint64(1)
+	verifier, err := NewVerifier(testAPIKey, l1ChainID, artifactsFS, log.New(log.JSONHandler(io.Discard)), nil)
 	require.NoError(t, err, "verifier should be created successfully with embedded artifacts")
 	require.NotNil(t, verifier, "verifier should not be nil")
 
@@ -74,7 +75,7 @@ func TestVerifierWithEmbeddedArtifacts(t *testing.T) {
 	}))
 	defer fakeServer.Close()
 
-	verifier.etherscan = NewEtherscanClient(testAPIKey, fakeServer.URL, rate.NewLimiter(rate.Inf, 1))
+	verifier.etherscan = NewEtherscanClient(testAPIKey, l1ChainID, fakeServer.URL, rate.NewLimiter(rate.Inf, 1))
 
 	bundle := bootstrapContractAddresses()
 


### PR DESCRIPTION
When using op-deployer to verify l1 contracts, we met such failures :

<img width="1692" height="183" alt="image" src="https://github.com/user-attachments/assets/d82a9e17-85f3-4194-a3e6-accb78dee373" />


And by trying this url directly(replacing parameters accordingly):

```
https://api-sepolia.etherscan.io/api?module=contract&action=getcontractcreation&contractaddresses=%s&apikey=%s 
```

we got a more direct reason:

<img width="1263" height="95" alt="image" src="https://github.com/user-attachments/assets/47a71a44-bb68-4519-8517-78b0b2b276df" />


This PR migrates op-deployer to [v2 api](https://docs.etherscan.io/v2-migration) when calling etherscan APIs, and all existing related tests are passing.


**UPDATE**

I've verified this patch, and it's working as expected:

<img width="2242" height="1510" alt="image" src="https://github.com/user-attachments/assets/16cb5b01-3927-4b15-a1cc-dbcbdabd63aa" />
