### PR TITLE
Safer Safes audit fixes (no bytecode changes)

### DIFF
--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -208,8 +208,8 @@
     "sourceCodeHash": "0x7fc4789b082bc8ecd29c4c75a06058f0ff0b72f1c1028a42db6f1c35269c8865"
   },
   "src/safe/SaferSafes.sol:SaferSafes": {
-    "initCodeHash": "0xb4e7885e5f181e9223ecdbc4cfc8b5887fd2c22359e4c8bb4dee53f7dd193876",
-    "sourceCodeHash": "0x31f453780466a9d3e498a7981f66c92c3d0b76e1ee80c19e374d9692bcfbd931"
+    "initCodeHash": "0xea63f8c74f2ce10cc53e460b5f7f5006a06ab5612adc7253885a1ca3df124adb",
+    "sourceCodeHash": "0x169dc281821d3951fb399deefb0b84021b8172cf32ca03526686421bb6478cb4"
   },
   "src/universal/OptimismMintableERC20.sol:OptimismMintableERC20": {
     "initCodeHash": "0x3c85eed0d017dca8eda6396aa842ddc12492587b061e8c756a8d32c4610a9658",

--- a/packages/contracts-bedrock/src/safe/LivenessModule2.sol
+++ b/packages/contracts-bedrock/src/safe/LivenessModule2.sol
@@ -279,12 +279,17 @@ abstract contract LivenessModule2 {
         _cancelChallenge(callingSafe);
     }
 
-    /// @notice With successful challenge, removes all current owners from enabled safe,
-    ///         appoints fallback as sole owner, and sets its quorum to 1.
-    /// @dev Note: After ownership transfer, the fallback owner becomes the sole owner
-    ///      and is also still configured as the fallback owner. This means the
-    ///      fallback owner effectively becomes its own fallback owner, maintaining
-    ///      the ability to challenge itself if needed.
+
+    /// @notice With successful challenge, removes all current owners from enabled safe, appoints
+    ///         fallback as sole owner, and sets its quorum to 1.
+    /// @dev After ownership transfer, the fallback owner becomes the sole owner and is also still
+    ///      configured as the fallback owner. If the fallback owner would become unable to sign,
+    ///      it would not be able challenge the safe again. For this reason, it is important that
+    ///      the fallback owner has a way to preserve its own liveness.
+    ///
+    ///      It is of critical importance that this function never reverts. If it were to do so,
+    ///      the Safe would be permanently bricked. For this reason, the external calls from this
+    ///      function are allowed to fail silently instead of reverting.
     /// @param _safe The Safe address to transfer ownership of.
     function changeOwnershipToFallback(Safe _safe) external {
         // Ensure Safe is configured with this module to prevent unauthorized execution.

--- a/packages/contracts-bedrock/src/safe/LivenessModule2.sol
+++ b/packages/contracts-bedrock/src/safe/LivenessModule2.sol
@@ -279,7 +279,6 @@ abstract contract LivenessModule2 {
         _cancelChallenge(callingSafe);
     }
 
-
     /// @notice With successful challenge, removes all current owners from enabled safe, appoints
     ///         fallback as sole owner, and sets its quorum to 1.
     /// @dev After ownership transfer, the fallback owner becomes the sole owner and is also still

--- a/packages/contracts-bedrock/src/safe/SaferSafes.sol
+++ b/packages/contracts-bedrock/src/safe/SaferSafes.sol
@@ -26,8 +26,8 @@ import { ISemver } from "interfaces/universal/ISemver.sol";
 ///      compatibility restrictions in the LivenessModule2 and TimelockGuard contracts.
 contract SaferSafes is LivenessModule2, TimelockGuard, ISemver {
     /// @notice Semantic version.
-    /// @custom:semver 1.9.0
-    string public constant version = "1.9.0";
+    /// @custom:semver 1.9.1
+    string public constant version = "1.9.1";
 
     /// @notice Error for when the liveness response period is insufficient.
     error SaferSafes_InsufficientLivenessResponsePeriod();

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -208,6 +208,8 @@ abstract contract TimelockGuard is BaseGuard {
     /// @notice Returns the blocking threshold, which is defined as the minimum number of owners
     ///         that must coordinate to block a transaction from being executed by refusing to
     ///         sign.
+    /// @dev Becase `_safe.getOwners()` loops through the owners list, it could run out of gas if
+    ///      there are a lot of owners.
     /// @param _safe The Safe address to query
     /// @return The current blocking threshold
     function _blockingThreshold(Safe _safe) internal view returns (uint256) {

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -229,7 +229,7 @@ abstract contract TimelockGuard is BaseGuard {
         return _safeStates[_safe][_safeConfigNonces[_safe]];
     }
 
-    /// @notice Internal helper function which can be overriden in a child contract to check if the
+    /// @notice Internal helper function which can be overridden in a child contract to check if the
     ///         guard's configuration is valid in the context of other extensions that are enabled
     ///         on the Safe.
     function _checkCombinedConfig(Safe _safe) internal view virtual;

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -473,6 +473,9 @@ abstract contract TimelockGuard is BaseGuard {
     ///      1. Safe disables the guard via GuardManager.setGuard(address(0)).
     ///      2. Safe calls this clearTimelockGuard() function to remove stored configuration.
     ///      3. If Safe later re-enables the guard, it must call configureTimelockGuard() again.
+    ///      Warning: Clearing the configuration allows all transactions previously scheduled to be
+    ///      scheduled again, including cancelled transactions. It is strongly recommended to
+    ///      manually increment the Safe's nonce when a scheduled transaction is cancelled.
     function clearTimelockGuard() external {
         Safe callingSafe = Safe(payable(msg.sender));
 
@@ -494,6 +497,11 @@ abstract contract TimelockGuard is BaseGuard {
     ///      existing signature generation tools. Owners can use any method to sign the a
     ///      transaction, including signing with a private key, calling the Safe's approveHash
     ///      function, or EIP1271 contract signatures.
+    ///      The Safe doesn't increase its nonce when a transaction is cancelled in the Timelock.
+    ///      This means that it is possible to add the very same transaction a second time to the
+    ///      safe queue, but it won't be possible to schedule it again in the Timelock. It is
+    ///      recommended that the safe nonce is manually incremented when a scheduled transaction
+    ///      is cancelled.
     /// @param _safe The Safe address to schedule the transaction for.
     /// @param _nonce The nonce of the Safe for the transaction being scheduled.
     /// @param _params The parameters of the transaction being scheduled.

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -344,7 +344,8 @@ abstract contract TimelockGuard is BaseGuard {
 
         // Limit execution of transactions to owners of the Safe only.
         // This ensures that an attacker cannot simply collect valid signatures, but must also
-        // control a private key.
+        // control a private key. It is accepted as a trade-off that paymasters, relayers or UX
+        // wrappers cannot execute transactions with the TimelockGuard enabled.
         if (!callingSafe.isOwner(_msgSender)) {
             revert TimelockGuard_NotOwner();
         }

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -214,7 +214,7 @@ abstract contract TimelockGuard is BaseGuard {
         return _safe.getOwners().length - _safe.getThreshold() + 1;
     }
 
-    /// @notice Internal helper to get the guard address from a Safe
+    /// @notice Internal helper to check if TimelockGuard is enabled for a Safe
     /// @param _safe The Safe address
     /// @return The current guard address
     function _isGuardEnabled(Safe _safe) internal view returns (bool) {

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -596,6 +596,9 @@ abstract contract TimelockGuard is BaseGuard {
     ///      of checkNSignatures is that owners can use any method to sign the cancellation
     ///      transaction inputs, including signing with a private key, calling the Safe's
     ///      approveHash function, or EIP1271 contract signatures.
+    ///
+    ///      It is allowed to cancel transactions from a disabled TimelockGuard, as a way of
+    ///      clearing the queue that wouldn't be as blunt as calling `clearTimelockConfiguration`.
     /// @param _safe The Safe address to cancel the transaction for.
     /// @param _txHash The hash of the transaction being cancelled.
     /// @param _nonce The nonce of the Safe for the transaction being cancelled.

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -212,7 +212,7 @@ abstract contract TimelockGuard is BaseGuard {
     /// @notice Returns the blocking threshold, which is defined as the minimum number of owners
     ///         that must coordinate to block a transaction from being executed by refusing to
     ///         sign.
-    /// @dev Becase `_safe.getOwners()` loops through the owners list, it could run out of gas if
+    /// @dev Because `_safe.getOwners()` loops through the owners list, it could run out of gas if
     ///      there are a lot of owners.
     /// @param _safe The Safe address to query
     /// @return The current blocking threshold


### PR DESCRIPTION
Fixed [issues from SaferSafes audit](https://cantina.xyz/code/4c27cc57-83c2-4e6d-89ba-9cc7a1ca4e0c/findings) that don't require a bytecode change:


### LivenessModule2

- **`execTransactionFromModule` calls fail silently** ([Cantina](https://cantina.xyz//code/4c27cc57-83c2-4e6d-89ba-9cc7a1ca4e0c/packages/contracts-bedrock/src/safe/LivenessModule2.sol?preview=code#comment-74c44d39-8ab2-4f07-b486-7e6aa918b271))  
  *Resolution:* Documented in natspec. `changeOwnershipToFallback` must not revert. Commit: [1f62006](https://github.com/ethereum-optimism/optimism/pull/18147/commits/1f62006359561924afbd01b05555ba6213967675)

### TimelockGuard

- **Cancelled transaction cannot be re-scheduled at same nonce** ([Cantina](https://cantina.xyz//code/4c27cc57-83c2-4e6d-89ba-9cc7a1ca4e0c/packages/contracts-bedrock/src/safe/TimelockGuard.sol))  
  *Resolution:* If a transaction is cancelled, the Safe nonce doesn't increment. Re-queuing the same transaction at the same nonce is blocked (same txHash). Commit: [954854c](https://github.com/ethereum-optimism/optimism/pull/18147/commits/954854cc31eb18f0218a189d037a06e2650b8321)

- **Removing TimelockGuard allows execution of "cancelled" transactions** ([Cantina](https://cantina.xyz//code/4c27cc57-83c2-4e6d-89ba-9cc7a1ca4e0c/packages/contracts-bedrock/src/safe/TimelockGuard.sol?preview=code#comment-966ebcb4-51a1-4aaa-9570-e42c3d3cfd16))  
  *Resolution:* Documented in runbook to bump Safe nonce past last transaction with valid signatures. Added warning that removing the guard makes execution instantaneous. Commit: [954854c](https://github.com/ethereum-optimism/optimism/pull/18147/commits/954854cc31eb18f0218a189d037a06e2650b8321)

- **`_blockingThreshold()` uses excessive gas with many owners** ([Cantina](https://cantina.xyz//code/4c27cc57-83c2-4e6d-89ba-9cc7a1ca4e0c/packages/contracts-bedrock/src/safe/TimelockGuard.sol?preview=code#comment-e5cb1d37-9f8f-487f-8680-d8db9af72b61))  
  *Resolution:* Added natspec warning against using hundreds of owners. Commit: [6acd71c](https://github.com/ethereum-optimism/optimism/pull/18147/commits/6acd71c84c2d36afe3ff9c2ab190c01eed77b36d)

- **Cancelling transactions from a disabled guard is possible** ([Cantina](https://cantina.xyz//code/4c27cc57-83c2-4e6d-89ba-9cc7a1ca4e0c/packages/contracts-bedrock/src/safe/TimelockGuard.sol?preview=code#comment-44111c03-034e-4934-835a-01ad1d0b8a41))  
  *Resolution:* Documented in natspec. This is intentional to allow selective clearing of transaction queue before re-enabling. Commit: [52c2c34](https://github.com/ethereum-optimism/optimism/pull/18147/commits/52c2c341df7bd3c82f88bab1e634b8db36ca6188)

- **`execTransaction` restricted to owners only** ([Cantina](https://cantina.xyz//code/4c27cc57-83c2-4e6d-89ba-9cc7a1ca4e0c/packages/contracts-bedrock/src/safe/TimelockGuard.sol?preview=code#comment-c1383f3f-9300-4666-8e54-9e7d1f35a3ef))  
  *Resolution:* Documented rationale in natspec. Trade-off is that paymasters, relayers, and UX wrappers cannot be used. Commit: [de3a859](https://github.com/ethereum-optimism/optimism/pull/18147/commits/de3a859ee4f7fdbd0fdb17cf9db7027de7ed32f7)

- **Typo** ([Cantina](https://cantina.xyz//code/4c27cc57-83c2-4e6d-89ba-9cc7a1ca4e0c/packages/contracts-bedrock/src/safe/TimelockGuard.sol?preview=code#comment-9da9612a-0729-4b72-9c1d-03d53b5dc3ae)) — Fixed in [329ed74](https://github.com/ethereum-optimism/optimism/pull/18147/commits/329ed74949df8cda09f94c8069957919b0e2637c)

- **Wrong comment** ([Cantina](https://cantina.xyz//code/4c27cc57-83c2-4e6d-89ba-9cc7a1ca4e0c/packages/contracts-bedrock/src/safe/TimelockGuard.sol?preview=code#comment-24049627-8303-460d-b43d-1fbecd814318)) — Fixed in [054b7a0](https://github.com/ethereum-optimism/optimism/pull/18147/commits/054b7a00d98b14a4bbc0b8852e60d07428f431d7)