### PR TITLE
op-acceptance-tests: Replace fast games with regular FDGs

### DIFF
--- a/op-acceptance-tests/tests/base/withdrawal/init_test.go
+++ b/op-acceptance-tests/tests/base/withdrawal/init_test.go
@@ -3,7 +3,6 @@ package withdrawal
 import (
 	"testing"
 
-	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	"github.com/ethereum-optimism/optimism/op-devstack/compat"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 )
@@ -13,14 +12,7 @@ func TestMain(m *testing.M) {
 		// TODO(infra#401): Re-enable the test when the sysext missing toolset is implemented
 		presets.WithCompatibleTypes(compat.SysGo),
 		presets.WithMinimal(),
-		presets.WithProposerGameType(faultTypes.FastGameType),
-		// Fast game for test
-		presets.WithFastGame(),
-		// Deployer must be L1PAO to make op-deployer happy
-		presets.WithDeployerMatchL1PAO(),
-		// Guardian must be L1PAO to make AnchorStateRegistry's setRespectedGameType method work
-		presets.WithGuardianMatchL1PAO(),
-		// Fast finalization for fast withdrawal
+		presets.WithTimeTravel(),
 		presets.WithFinalizationPeriodSeconds(1),
 		// Satisfy OptimismPortal2 PROOF_MATURITY_DELAY_SECONDS check, avoid OptimismPortal_ProofNotOldEnough() revert
 		presets.WithProofMaturityDelaySeconds(2),

--- a/op-acceptance-tests/tests/base/withdrawal/withdrawal_test.go
+++ b/op-acceptance-tests/tests/base/withdrawal/withdrawal_test.go
@@ -15,7 +15,7 @@ func TestWithdrawal(gt *testing.T) {
 	require := sys.T.Require()
 
 	bridge := sys.StandardBridge()
-	require.EqualValues(faultTypes.FastGameType, bridge.RespectedGameType(), "Respected game type must be FastGame")
+	require.EqualValues(faultTypes.PermissionedGameType, bridge.RespectedGameType(), "Respected game type must be PermissionedGameType")
 
 	initialL1Balance := eth.OneThirdEther
 
@@ -44,6 +44,13 @@ func TestWithdrawal(gt *testing.T) {
 	withdrawal.Prove(l1User)
 	expectedL1UserBalance = expectedL1UserBalance.Sub(withdrawal.ProveGasCost())
 	l1User.VerifyBalanceExact(expectedL1UserBalance)
+
+	// Advance time until game is resolvable
+	sys.AdvanceTime(bridge.GameResolutionDelay())
+	withdrawal.WaitForDisputeGameResolved()
+
+	// Advance time to when game finalization and proof finalization delay has expired
+	sys.AdvanceTime(max(bridge.WithdrawalDelay()-bridge.GameResolutionDelay(), bridge.DisputeGameFinalityDelay()))
 
 	t.Logger().Info("Attempting to finalize", "proofMaturity", bridge.WithdrawalDelay(), "gameResolutionDelay", bridge.GameResolutionDelay(), "gameFinalityDelay", bridge.DisputeGameFinalityDelay())
 	withdrawal.Finalize(l1User)

--- a/op-devstack/presets/minimal.go
+++ b/op-devstack/presets/minimal.go
@@ -1,9 +1,11 @@
 package presets
 
 import (
-	challengerConfig "github.com/ethereum-optimism/optimism/op-challenger/config"
+	"time"
+
 	"github.com/ethereum/go-ethereum/log"
 
+	challengerConfig "github.com/ethereum-optimism/optimism/op-challenger/config"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl/proofs"
@@ -17,6 +19,7 @@ type Minimal struct {
 	Log          log.Logger
 	T            devtest.T
 	ControlPlane stack.ControlPlane
+	system       stack.ExtensibleSystem
 
 	L1Network *dsl.L1Network
 	L1EL      *dsl.L1ELNode
@@ -51,6 +54,12 @@ func (m *Minimal) DisputeGameFactory() *proofs.DisputeGameFactory {
 	return proofs.NewDisputeGameFactory(m.T, m.L1Network, m.L1EL.EthClient(), m.L2Chain.DisputeGameFactoryProxyAddr(), m.L2CL, m.L2EL, nil, m.challengerConfig)
 }
 
+func (m *Minimal) AdvanceTime(amount time.Duration) {
+	ttSys, ok := m.system.(stack.TimeTravelSystem)
+	m.T.Require().True(ok, "attempting to advance time on incompatible system")
+	ttSys.AdvanceTime(amount)
+}
+
 func WithMinimal() stack.CommonOption {
 	return stack.MakeCommon(sysgo.DefaultMinimalSystem(&sysgo.DefaultMinimalSystemIDs{}))
 }
@@ -77,6 +86,7 @@ func minimalFromSystem(t devtest.T, system stack.ExtensibleSystem, orch stack.Or
 		Log:              t.Logger(),
 		T:                t,
 		ControlPlane:     orch.ControlPlane(),
+		system:           system,
 		L1Network:        dsl.NewL1Network(system.L1Network(match.FirstL1Network)),
 		L1EL:             dsl.NewL1ELNode(l1Net.L1ELNode(match.Assume(t, match.FirstL1EL))),
 		L2Chain:          dsl.NewL2Network(l2, orch.ControlPlane()),

--- a/op-devstack/presets/proof.go
+++ b/op-devstack/presets/proof.go
@@ -2,11 +2,9 @@ package presets
 
 import (
 	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
-	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/state"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
 	ps "github.com/ethereum-optimism/optimism/op-proposer/proposer"
-	"github.com/ethereum/go-ethereum/common"
 )
 
 func WithProposerGameType(gameType faultTypes.GameType) stack.CommonOption {
@@ -15,34 +13,6 @@ func WithProposerGameType(gameType faultTypes.GameType) stack.CommonOption {
 			sysgo.WithProposerOption(func(id stack.L2ProposerID, cfg *ps.CLIConfig) {
 				cfg.DisputeGameType = uint32(gameType)
 			})))
-}
-
-// TODO(infra#401): Implement support in the sysext toolset
-func WithFastGame() stack.CommonOption {
-	return stack.MakeCommon(
-		sysgo.WithDeployerOptions(
-			sysgo.WithAdditionalDisputeGames(
-				[]state.AdditionalDisputeGame{
-					{
-						ChainProofParams: state.ChainProofParams{
-							DisputeGameType: uint32(faultTypes.FastGameType),
-							// Use Alphabet VM prestate which is a pre-determined fixed hash
-							DisputeAbsolutePrestate: common.HexToHash("0x03c7ae758795765c6664a5d39bf63841c71ff191e9189522bad8ebff5d4eca98"),
-							DisputeMaxGameDepth:     14 + 3 + 1,
-							DisputeSplitDepth:       14,
-							DisputeClockExtension:   0,
-							DisputeMaxClockDuration: 0,
-						},
-						VMType:                       state.VMTypeAlphabet,
-						UseCustomOracle:              true,
-						OracleMinProposalSize:        10000,
-						OracleChallengePeriodSeconds: 0,
-						MakeRespected:                true,
-					},
-				},
-			),
-		),
-	)
 }
 
 // TODO(infra#401): Implement support in the sysext toolset


### PR DESCRIPTION
This change replaces the fast game used in withdrawal tests with the FaultDisputeGame.
Removing support for fast games will help simplify op-deployer and OPCM. This is one of a series of patches to completely get rid of fast games for integration testing.