### PR TITLE
op-deployer: support op-contracts/v5.0.0-rc.2 upgrade

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/docker/docker v27.5.1+incompatible
 	github.com/docker/go-connections v0.5.0
 	github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.4-0.20251001155152-4eb15ccedf7e
-	github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20251009180028-9b4658b9b7af
+	github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20251104194255-7380dcd87c00
 	github.com/ethereum/go-ethereum v1.16.3
 	github.com/fatih/color v1.18.0
 	github.com/fsnotify/fsnotify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -240,8 +240,8 @@ github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.4-0.20251001155152-4eb15c
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.4-0.20251001155152-4eb15ccedf7e/go.mod h1:DYj7+vYJ4cIB7zera9mv4LcAynCL5u4YVfoeUu6Wa+w=
 github.com/ethereum-optimism/op-geth v1.101603.2-0.20251016091451-5c6d276814f2 h1:fvYTR+KOcvSDd/gJuh+ALG/Fx7Y0xU3ZaDkgT/kqVi0=
 github.com/ethereum-optimism/op-geth v1.101603.2-0.20251016091451-5c6d276814f2/go.mod h1:Ct2QjqZ2UKgvvgKLLYzoh/DBicJZB8DXsv45DgEjcco=
-github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20251009180028-9b4658b9b7af h1:WWz0gJM/boaUImtJnROecPirAerKCLpAU4m6Tx0ArOg=
-github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20251009180028-9b4658b9b7af/go.mod h1:NZ816PzLU1TLv1RdAvYAb6KWOj4Zm5aInT0YpDVml2Y=
+github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20251104194255-7380dcd87c00 h1:eLxykgilVpGE1NTJSpUkpk/cXam6+ZkbbnCfCBShEiU=
+github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20251104194255-7380dcd87c00/go.mod h1:NZ816PzLU1TLv1RdAvYAb6KWOj4Zm5aInT0YpDVml2Y=
 github.com/ethereum/c-kzg-4844/v2 v2.1.0 h1:gQropX9YFBhl3g4HYhwE70zq3IHFRgbbNPw0Shwzf5w=
 github.com/ethereum/c-kzg-4844/v2 v2.1.0/go.mod h1:TC48kOKjJKPbN7C++qIgt0TJzZ70QznYR7Ob+WXl57E=
 github.com/ethereum/go-verkle v0.2.2 h1:I2W0WjnrFUIzzVPwm8ykY+7pL2d4VhlsePn4j7cnFk8=

--- a/op-deployer/pkg/deployer/integration_test/cli/upgrade_test.go
+++ b/op-deployer/pkg/deployer/integration_test/cli/upgrade_test.go
@@ -37,23 +37,28 @@ func TestCLIUpgrade(t *testing.T) {
 		{
 			contractTag: standard.ContractsV200Tag,
 			version:     "v2.0.0",
-			forkBlock:   7792843,
+			forkBlock:   7792843, // one block past the opcm deployment block
 		},
-		//{
-		//contractTag: standard.ContractsV300Tag,
-		//version:     "v3.0.0",
-		//forkBlock:   7853303,
-		//},
+		{
+			contractTag: standard.ContractsV300Tag,
+			version:     "v3.0.0",
+			forkBlock:   8092886, // one block before op-sepolia was upgraded
+		},
 		{
 			contractTag: standard.ContractsV400Tag,
 			version:     "v4.0.0",
-			forkBlock:   8577263,
+			forkBlock:   8577263, // one block past the opcm deployment block
 		},
 		{
 			contractTag: standard.ContractsV410Tag,
 			version:     "v4.1.0",
-			forkBlock:   9165154,
+			forkBlock:   9165154, // one block past the opcm deployment block
 		},
+		//{
+		//contractTag: standard.ContractsV500Tag,
+		//version:     "v5.0.0-rc.2",
+		//forkBlock:   9554797, // one block past the opcm deployment block
+		//},
 	}
 
 	for _, tc := range testCases {
@@ -87,7 +92,7 @@ func TestCLIUpgrade(t *testing.T) {
 
 			configData, err := json.MarshalIndent(testConfig, "", "  ")
 			require.NoError(t, err)
-			require.NoError(t, os.WriteFile(configFile, configData, 0644))
+			require.NoError(t, os.WriteFile(configFile, configData, 0o644))
 
 			// Run full cli command to write calldata to outfile
 			output := runner.ExpectSuccess(t, []string{
@@ -115,7 +120,6 @@ func TestCLIUpgrade(t *testing.T) {
 			dataHex := hex.EncodeToString(dump[0].Data)
 			require.True(t, strings.HasPrefix(dataHex, "ff2dd5a1"),
 				"calldata should have opcm.upgrade fcn selector ff2dd5a1, got: %s", dataHex[:8])
-
 		})
 	}
 }

--- a/op-deployer/pkg/deployer/standard/standard.go
+++ b/op-deployer/pkg/deployer/standard/standard.go
@@ -42,7 +42,8 @@ const (
 	ContractsV300Tag        = "op-contracts/v3.0.0"
 	ContractsV400Tag        = "op-contracts/v4.0.0-rc.7"
 	ContractsV410Tag        = "op-contracts/v4.1.0"
-	CurrentTag              = ContractsV410Tag
+	ContractsV500Tag        = "op-contracts/v5.0.0-rc.2"
+	CurrentTag              = ContractsV500Tag
 )
 
 var DisputeAbsolutePrestate = common.HexToHash("0x038512e02c4c3f7bdaec27d00edf55b7155e0905301e1a88083e4e0a6764d54c")

--- a/op-deployer/pkg/deployer/upgrade/flags.go
+++ b/op-deployer/pkg/deployer/upgrade/flags.go
@@ -7,6 +7,7 @@ import (
 	v300 "github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/upgrade/v3_0_0"
 	v400 "github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/upgrade/v4_0_0"
 	v410 "github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/upgrade/v4_1_0"
+	v500 "github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/upgrade/v5_0_0"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	"github.com/urfave/cli/v2"
 )
@@ -71,6 +72,17 @@ var Commands = cli.Commands{
 			OutfileFlag,
 		}, oplog.CLIFlags(deployer.EnvVarPrefix)...),
 		Action: UpgradeCLI(v410.DefaultUpgrader),
+	},
+	&cli.Command{
+		Name:  "v5.0.0-rc.2",
+		Usage: "upgrades a chain to version v5.0.0-rc.2 (U17 release candidate)",
+		Flags: append([]cli.Flag{
+			deployer.L1RPCURLFlag,
+			ConfigFlag,
+			OverrideArtifactsURLFlag,
+			OutfileFlag,
+		}, oplog.CLIFlags(deployer.EnvVarPrefix)...),
+		Action: UpgradeCLI(v500.DefaultUpgrader),
 	},
 	&cli.Command{
 		Name:  "embedded",

--- a/op-deployer/pkg/deployer/upgrade/v5_0_0/upgrade.go
+++ b/op-deployer/pkg/deployer/upgrade/v5_0_0/upgrade.go
@@ -1,0 +1,24 @@
+// Package v5_0_0 implements the upgrade to v5.0.0 (U17). The interface for the upgrade is identical
+// to the upgrade for v2.0.0 (U13), so all this package does is implement the Upgrader interface and
+// call into the v2.0.0 upgrade.
+package v5_0_0
+
+import (
+	"encoding/json"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/script"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/artifacts"
+	v200 "github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/upgrade/v2_0_0"
+)
+
+type Upgrader struct{}
+
+func (u *Upgrader) Upgrade(host *script.Host, input json.RawMessage) error {
+	return v200.DefaultUpgrader.Upgrade(host, input)
+}
+
+func (u *Upgrader) ArtifactsURL() string {
+	return artifacts.CreateHttpLocator("b112b16f8939fbb732c0693de3d3bd1e8e3e2f0771f91d5ab300a6c9b7b1af73")
+}
+
+var DefaultUpgrader = new(Upgrader)


### PR DESCRIPTION
Updates superchain-registry import and op-deployer to support the following new upgrade command:
```
op-deployer upgrade v5.0.0-rc.2
```