### PR TITLE
contracts: Load CANNON game implementation from DisputeGameFactory instead of via artifacts

### DIFF
--- a/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
@@ -166,17 +166,7 @@ contract OPContractsManager_Upgrade_Harness is CommonTest, DisputeGames {
         permissionedDisputeGame = IPermissionedDisputeGame(address(artifacts.mustGetAddress("PermissionedDisputeGame")));
         IDisputeGameFactory dgf = IDisputeGameFactory(address(artifacts.mustGetAddress("DisputeGameFactoryProxy")));
         faultDisputeGame = IFaultDisputeGame(address(dgf.gameImpls(GameTypes.CANNON)));
-        if (isDevFeatureEnabled(DevFeatures.DEPLOY_V2_DISPUTE_GAMES)) {
-            bytes memory args = dgf.gameArgs(GameTypes.CANNON);
-            if (args.length == 0) {
-                // Not yet using game args so load directly from the game implementation contract
-                delayedWeth = faultDisputeGame.weth();
-            } else {
-                delayedWeth = IDelayedWETH(payable(LibGameArgs.decode(args).weth));
-            }
-        } else {
-            delayedWeth = faultDisputeGame.weth();
-        }
+        delayedWeth = faultDisputeGame.weth();
 
         // grab the pre-upgrade state
         preUpgradeState = PreUpgradeState({

--- a/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
@@ -163,10 +163,20 @@ contract OPContractsManager_Upgrade_Harness is CommonTest, DisputeGames {
 
         delayedWETHPermissionedGameProxy =
             IDelayedWETH(payable(artifacts.mustGetAddress("PermissionedDelayedWETHProxy")));
-        delayedWeth = IDelayedWETH(payable(artifacts.mustGetAddress("PermissionlessDelayedWETHProxy")));
         permissionedDisputeGame = IPermissionedDisputeGame(address(artifacts.mustGetAddress("PermissionedDisputeGame")));
         IDisputeGameFactory dgf = IDisputeGameFactory(address(artifacts.mustGetAddress("DisputeGameFactoryProxy")));
         faultDisputeGame = IFaultDisputeGame(address(dgf.gameImpls(GameTypes.CANNON)));
+        if (isDevFeatureEnabled(DevFeatures.DEPLOY_V2_DISPUTE_GAMES)) {
+            bytes memory args = dgf.gameArgs(GameTypes.CANNON);
+            if (args.length == 0) {
+                // Not yet using game args so load directly from the game implementation contract
+                delayedWeth = faultDisputeGame.weth();
+            } else {
+                delayedWeth = IDelayedWETH(payable(LibGameArgs.decode(args).weth));
+            }
+        } else {
+            delayedWeth = faultDisputeGame.weth();
+        }
 
         // grab the pre-upgrade state
         preUpgradeState = PreUpgradeState({

--- a/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
@@ -165,7 +165,8 @@ contract OPContractsManager_Upgrade_Harness is CommonTest, DisputeGames {
             IDelayedWETH(payable(artifacts.mustGetAddress("PermissionedDelayedWETHProxy")));
         delayedWeth = IDelayedWETH(payable(artifacts.mustGetAddress("PermissionlessDelayedWETHProxy")));
         permissionedDisputeGame = IPermissionedDisputeGame(address(artifacts.mustGetAddress("PermissionedDisputeGame")));
-        faultDisputeGame = IFaultDisputeGame(address(artifacts.mustGetAddress("FaultDisputeGame")));
+        IDisputeGameFactory dgf = IDisputeGameFactory(address(artifacts.mustGetAddress("DisputeGameFactoryProxy")));
+        faultDisputeGame = IFaultDisputeGame(address(dgf.gameImpls(GameTypes.CANNON)));
 
         // grab the pre-upgrade state
         preUpgradeState = PreUpgradeState({
@@ -1970,6 +1971,7 @@ contract OPContractsManager_Migrate_Test is OPContractsManager_TestInit {
 
     function _getPostMigrateExpectedGameTypes(IOPContractsManagerInteropMigrator.MigrateInput memory _input)
         internal
+        view
         returns (GameType[] memory gameTypes_)
     {
         uint256 gameCount = 1;

--- a/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
@@ -179,11 +179,7 @@ abstract contract OPContractsManagerStandardValidator_TestInit is CommonTest, Di
 
         if (isForkTest()) {
             // Load the FaultDisputeGame once, we'll need it later.
-            fdgImpl = IFaultDisputeGame(artifacts.mustGetAddress("FaultDisputeGame"));
-
-            // Add the FaultDisputeGame to the DisputeGameFactory.
-            vm.prank(disputeGameFactory.owner());
-            disputeGameFactory.setImplementation(GameTypes.CANNON, IDisputeGame(address(fdgImpl)));
+            fdgImpl = IFaultDisputeGame(disputeGameFactory.gameImpls(GameTypes.CANNON));
         } else {
             // Deploy a permissionless FaultDisputeGame.
             IOPContractsManager.AddGameOutput memory output = addGameType(GameTypes.CANNON, cannonPrestate);

--- a/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
@@ -179,7 +179,7 @@ abstract contract OPContractsManagerStandardValidator_TestInit is CommonTest, Di
 
         if (isForkTest()) {
             // Load the FaultDisputeGame once, we'll need it later.
-            fdgImpl = IFaultDisputeGame(disputeGameFactory.gameImpls(GameTypes.CANNON));
+            fdgImpl = IFaultDisputeGame(address(disputeGameFactory.gameImpls(GameTypes.CANNON)));
         } else {
             // Deploy a permissionless FaultDisputeGame.
             IOPContractsManager.AddGameOutput memory output = addGameType(GameTypes.CANNON, cannonPrestate);

--- a/packages/contracts-bedrock/test/setup/ForkLive.s.sol
+++ b/packages/contracts-bedrock/test/setup/ForkLive.s.sol
@@ -177,9 +177,6 @@ contract ForkLive is Deployer, StdAssertions, FeatureFlags {
         artifacts.save("MipsSingleton", vm.parseTomlAddress(opToml, ".addresses.MIPS"));
         IDisputeGameFactory disputeGameFactory =
             IDisputeGameFactory(artifacts.mustGetAddress("DisputeGameFactoryProxy"));
-        IFaultDisputeGame faultDisputeGame = IFaultDisputeGame(address(disputeGameFactory.gameImpls(GameTypes.CANNON)));
-        artifacts.save("FaultDisputeGame", address(faultDisputeGame));
-        artifacts.save("PermissionlessDelayedWETHProxy", address(faultDisputeGame.weth()));
 
         // The PermissionedDisputeGame and PermissionedDelayedWETHProxy are not listed in the registry for OP, so we
         // look it up onchain
@@ -281,13 +278,6 @@ contract ForkLive is Deployer, StdAssertions, FeatureFlags {
             IDisputeGameFactory(artifacts.mustGetAddress("DisputeGameFactoryProxy"));
         address permissionedDisputeGame = address(disputeGameFactory.gameImpls(GameTypes.PERMISSIONED_CANNON));
         artifacts.save("PermissionedDisputeGame", permissionedDisputeGame);
-
-        address permissionlessDisputeGame = address(disputeGameFactory.gameImpls(GameTypes.CANNON));
-        if (permissionlessDisputeGame != address(0)) {
-            // Both names are used in different places, so we save both.
-            artifacts.save("PermissionlessDisputeGame", address(permissionlessDisputeGame));
-            artifacts.save("FaultDisputeGame", address(permissionlessDisputeGame));
-        }
 
         IAnchorStateRegistry newAnchorStateRegistry;
         if (isDevFeatureEnabled(DevFeatures.DEPLOY_V2_DISPUTE_GAMES)) {


### PR DESCRIPTION
**Description**

Stop storing `FaultDisputeGame` and `PermissionlessDelayedWETH` in artifacts and load them from the dispute game factory when required.

**Tests**

Existing tests should continue to pass.


**Metadata**

fixes https://github.com/ethereum-optimism/optimism/issues/17741 because then permissionless games aren't stored by ForkLive at all so no need to update for cannon-kona.