### PR TITLE
fix(op-acceptance-tests): ci; slack token

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3204,6 +3204,7 @@ workflows:
           no_output_timeout: 90m
           context:
             - circleci-repo-readonly-authenticated-github-token
+            - slack
             - discord
           requires:
             - contracts-bedrock-build


### PR DESCRIPTION
Adds the missing token context.

Fixes the issue seen [here](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/106678/workflows/7b1f1d32-1fac-4730-827e-94c391d13da8/jobs/4066037).