### PR TITLE
op-deployer: allow to set customized inbox contract consistently

### DIFF
--- a/op-deployer/pkg/deployer/opcm/opchain.go
+++ b/op-deployer/pkg/deployer/opcm/opchain.go
@@ -25,6 +25,7 @@ type DeployOPChainInput struct {
 	UnsafeBlockSigner      common.Address
 	Proposer               common.Address
 	Challenger             common.Address
+	BatchInbox             common.Address
 
 	BasefeeScalar     uint32
 	BlobBaseFeeScalar uint32

--- a/op-deployer/pkg/deployer/pipeline/opchain.go
+++ b/op-deployer/pkg/deployer/pipeline/opchain.go
@@ -81,6 +81,10 @@ func DeployOPChain(env *Env, intent *state.Intent, st *state.State, chainID comm
 	return nil
 }
 
+type BatchInboxConfig struct {
+	BatchInboxAddress common.Address `json:"batchInboxAddress" toml:"batchInboxAddress"`
+}
+
 func makeDCI(intent *state.Intent, thisIntent *state.ChainIntent, chainID common.Hash, st *state.State) (opcm.DeployOPChainInput, error) {
 	proofParams, err := jsonutil.MergeJSON(
 		state.ChainProofParams{
@@ -96,6 +100,14 @@ func makeDCI(intent *state.Intent, thisIntent *state.ChainIntent, chainID common
 	)
 	if err != nil {
 		return opcm.DeployOPChainInput{}, fmt.Errorf("error merging proof params from overrides: %w", err)
+	}
+	batchInboxConfig, err := jsonutil.MergeJSON(
+		BatchInboxConfig{},
+		intent.GlobalDeployOverrides,
+		thisIntent.DeployOverrides,
+	)
+	if err != nil {
+		return opcm.DeployOPChainInput{}, fmt.Errorf("error merging batchInbox params from overrides: %w", err)
 	}
 
 	return opcm.DeployOPChainInput{
@@ -120,6 +132,7 @@ func makeDCI(intent *state.Intent, thisIntent *state.ChainIntent, chainID common
 		AllowCustomDisputeParameters: proofParams.DangerouslyAllowCustomDisputeParameters,
 		OperatorFeeScalar:            thisIntent.OperatorFeeScalar,
 		OperatorFeeConstant:          thisIntent.OperatorFeeConstant,
+		BatchInbox:                   batchInboxConfig.BatchInboxAddress,
 	}, nil
 }
 

--- a/packages/contracts-bedrock/interfaces/L1/IOPContractsManager.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IOPContractsManager.sol
@@ -157,6 +157,7 @@ interface IOPContractsManager {
         uint256 disputeSplitDepth;
         Duration disputeClockExtension;
         Duration disputeMaxClockDuration;
+        address batchInbox;
     }
 
     /// @notice The full set of outputs from deploying a new OP Stack chain.

--- a/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
+++ b/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
@@ -111,7 +111,7 @@ library ChainAssertions {
         // Depends on start block being set to 0 in `initialize`
         require(config.startBlock() == block.number, "CHECK-SCFG-140");
         require(
-            config.batchInbox() == IOPContractsManager(_doi.opcm).chainIdToBatchInboxAddress(_doi.l2ChainId),
+            config.batchInbox() == (_doi.batchInbox == address(0) ? IOPContractsManager(_doi.opcm).chainIdToBatchInboxAddress(_doi.l2ChainId) : _doi.batchInbox),
             "CHECK-SCFG-150"
         );
         // Check _addresses

--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -441,7 +441,8 @@ contract Deploy is Deployer {
             disputeMaxGameDepth: cfg.faultGameMaxDepth(),
             disputeSplitDepth: cfg.faultGameSplitDepth(),
             disputeClockExtension: Duration.wrap(uint64(cfg.faultGameClockExtension())),
-            disputeMaxClockDuration: Duration.wrap(uint64(cfg.faultGameMaxClockDuration()))
+            disputeMaxClockDuration: Duration.wrap(uint64(cfg.faultGameMaxClockDuration())),
+            batchInbox: cfg.batchInboxAddress()
         });
     }
 }

--- a/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
@@ -78,7 +78,8 @@ contract DeployOPChain is Script {
             disputeMaxGameDepth: _input.disputeMaxGameDepth,
             disputeSplitDepth: _input.disputeSplitDepth,
             disputeClockExtension: _input.disputeClockExtension,
-            disputeMaxClockDuration: _input.disputeMaxClockDuration
+            disputeMaxClockDuration: _input.disputeMaxClockDuration,
+            batchInbox: _input.batchInbox
         });
 
         vm.broadcast(msg.sender);

--- a/packages/contracts-bedrock/scripts/libraries/Types.sol
+++ b/packages/contracts-bedrock/scripts/libraries/Types.sol
@@ -49,5 +49,6 @@ library Types {
         // Fee params
         uint32 operatorFeeScalar;
         uint64 operatorFeeConstant;
+        address batchInbox;
     }
 }

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -1686,7 +1686,7 @@ contract OPContractsManagerDeployer is OPContractsManagerBase {
                 _input.gasLimit,
                 _input.roles.unsafeBlockSigner,
                 referenceResourceConfig,
-                chainIdToBatchInboxAddress(_input.l2ChainId),
+                _input.batchInbox == address(0) ? chainIdToBatchInboxAddress(_input.l2ChainId) : _input.batchInbox,
                 opChainAddrs,
                 _input.l2ChainId,
                 _superchainConfig
@@ -2111,6 +2111,7 @@ contract OPContractsManager is ISemver {
         uint256 disputeSplitDepth;
         Duration disputeClockExtension;
         Duration disputeMaxClockDuration;
+        address batchInbox;
     }
 
     /// @notice The full set of outputs from deploying a new OP Stack chain.

--- a/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
@@ -513,7 +513,8 @@ abstract contract OPContractsManager_TestInit is CommonTest, DisputeGames {
                 disputeMaxGameDepth: 73,
                 disputeSplitDepth: 30,
                 disputeClockExtension: Duration.wrap(10800),
-                disputeMaxClockDuration: Duration.wrap(302400)
+                disputeMaxClockDuration: Duration.wrap(302400),
+                batchInbox: address(0)
             })
         );
     }
@@ -2357,7 +2358,8 @@ contract OPContractsManager_Deploy_Test is DeployOPChain_TestBase, DisputeGames 
             disputeMaxGameDepth: _doi.disputeMaxGameDepth,
             disputeSplitDepth: _doi.disputeSplitDepth,
             disputeClockExtension: _doi.disputeClockExtension,
-            disputeMaxClockDuration: _doi.disputeMaxClockDuration
+            disputeMaxClockDuration: _doi.disputeMaxClockDuration,
+            batchInbox: _doi.batchInbox
         });
     }
 


### PR DESCRIPTION
Currently if `batchInboxAddress` is set in the `globalDeployOverrides` section of `intent.toml`, it will only be applied to the rollup config [here](https://github.com/ethereum-optimism/optimism/blob/78daacda28646a39315f7bdf70e5fe9c0cc7b5f1/op-chain-ops/genesis/config.go#L1109).

It doesn't apply to the SystemConfig contract, which uses a chain-id-derived value [here](https://github.com/ethereum-optimism/optimism/blob/78daacda28646a39315f7bdf70e5fe9c0cc7b5f1/packages/contracts-bedrock/src/L1/OPContractsManager.sol#L1689).

This PR makes this configuration also apply to the SystemConfig contract.