### PR TITLE
ci: Prepare for kona prestate verification

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1991,11 +1991,10 @@ jobs:
           mentions: "@proofs-team"
 
   preimage-reproducibility:
-    docker:
-      - image: <<pipeline.parameters.default_docker_image>>
+    machine: true
+    resource_class: large
     steps:
       - utils/checkout-with-mise
-      - setup_remote_docker
       - run:
           name: Verify reproducibility
           command: make -C op-program verify-reproducibility

--- a/op-program/scripts/build-prestates.sh
+++ b/op-program/scripts/build-prestates.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 SCRIPTS_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 KONA_REPO_URL=https://github.com/op-rs/kona
@@ -46,17 +46,8 @@ function build_kona_prestate() {
         git clone -b "${version}" "$KONA_REPO_URL" kona > "${log_file}" 2>&1
         cd kona
     fi
-    mise trust --yes ./mise.toml
-
-    # HACK: The docker buildx version in cci is too old to parse variable blocks in docker-bake that contain
-    # descriptions. So patch them out
-    awk '
-  /^[[:space:]]*variable[[:space:]]*"[^"]+"[[:space:]]*{/ {invar=1}
-  invar && /^[[:space:]]*description[[:space:]]*=/ {next}
-  {print}
-  invar && /^[[:space:]]*}/ {invar=0}
-    ' docker/docker-bake.hcl > docker/docker-bake.patched.hcl
-    cp docker/docker-bake.patched.hcl docker/docker-bake.hcl
+    # kona doesn't define a mise dependency. luckily the monorepo does and it should be preinstalled by now. So let's setup just shim.
+    MISE_DEFAULT_CONFIG_FILENAME="${REPO_DIR}"/mise.toml mise use just
 
     cd docker/fpvm-prestates
     rm -rf ../../prestate-artifacts-cannon

--- a/op-program/scripts/build-prestates.sh
+++ b/op-program/scripts/build-prestates.sh
@@ -48,6 +48,16 @@ function build_kona_prestate() {
     fi
     mise trust --yes ./mise.toml
 
+    # HACK: The docker buildx version in cci is too old to parse variable blocks in docker-bake that contain
+    # descriptions. So patch them out
+    awk '
+  /^[[:space:]]*variable[[:space:]]*"[^"]+"[[:space:]]*{/ {invar=1}
+  invar && /^[[:space:]]*description[[:space:]]*=/ {next}
+  {print}
+  invar && /^[[:space:]]*}/ {invar=0}
+    ' docker/docker-bake.hcl > docker/docker-bake.patched.hcl
+    cp docker/docker-bake.patched.hcl docker/docker-bake.hcl
+
     cd docker/fpvm-prestates
     rm -rf ../../prestate-artifacts-cannon
     just cannon kona-client "${version}" "$(cat ../../.config/cannon_tag)" >> "${log_file}" 2>&1

--- a/op-program/scripts/build-prestates.sh
+++ b/op-program/scripts/build-prestates.sh
@@ -46,8 +46,9 @@ function build_kona_prestate() {
         git clone -b "${version}" "$KONA_REPO_URL" kona > "${log_file}" 2>&1
         cd kona
     fi
-    # kona doesn't define a mise dependency. luckily the monorepo does and it should be preinstalled by now. So let's setup just shim.
-    MISE_DEFAULT_CONFIG_FILENAME="${REPO_DIR}"/mise.toml mise use just
+    # kona doesn't define a just dependency in its mise config.
+    # but the monorepo does and it should be preinstalled by now. So let's setup the just shim.
+    MISE_DEFAULT_CONFIG_FILENAME="${REPO_DIR}"/mise.toml mise use just > "${log_file}" 2>&1
 
     cd docker/fpvm-prestates
     rm -rf ../../prestate-artifacts-cannon

--- a/op-program/scripts/build-prestates.sh
+++ b/op-program/scripts/build-prestates.sh
@@ -32,8 +32,8 @@ function build_kona_prestate() {
         exit 1
     fi
     local short_version
-    short_version=$(echo "${VERSION}" | cut -c 14-)
-    local log_file="${LOGS_DIR}/build-${short_version}.txt"
+    short_version=$(echo "${version}" | cut -c 14-)
+    local log_file="${LOGS_DIR}/build-kona-${short_version}.txt"
     echo "Building Version: ${version} Logs: ${log_file}"
 
     mkdir -p kona-prestate-build
@@ -46,6 +46,8 @@ function build_kona_prestate() {
         git clone -b "${version}" "$KONA_REPO_URL" kona > "${log_file}" 2>&1
         cd kona
     fi
+    mise trust --yes ./mise.toml
+
     cd docker/fpvm-prestates
     rm -rf ../../prestate-artifacts-cannon
     just cannon kona-client "${version}" "$(cat ../../.config/cannon_tag)" >> "${log_file}" 2>&1

--- a/op-program/scripts/build-prestates.sh
+++ b/op-program/scripts/build-prestates.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 SCRIPTS_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+KONA_REPO_URL=https://github.com/op-rs/kona
 
 TMP_DIR=$(mktemp -d)
 function cleanup() {
@@ -24,13 +25,53 @@ mkdir -p "${STATES_DIR}" "${LOGS_DIR}"
 
 cd "${REPO_DIR}"
 
-VERSIONS_JSON="[]"
-readarray -t VERSIONS < <(git tag --list 'op-program/v*' --sort taggerdate)
+function build_kona_prestate() {
+    local version=$1
+    if [[ -z "${version}" ]]; then
+        echo "Error: version is required"
+        exit 1
+    fi
+    local short_version
+    short_version=$(echo "${VERSION}" | cut -c 14-)
+    local log_file="${LOGS_DIR}/build-${short_version}.txt"
+    echo "Building Version: ${version} Logs: ${log_file}"
 
-for VERSION in "${VERSIONS[@]}"
-do
+    mkdir -p kona-prestate-build
+    cd kona-prestate-build
+
+    if [[ -d kona ]]; then
+        cd kona
+        git checkout --force "${version}" > "${log_file}" 2>&1
+    else
+        git clone -b "${version}" "$KONA_REPO_URL" kona > "${log_file}" 2>&1
+        cd kona
+    fi
+    cd docker/fpvm-prestates
+    rm -rf ../../prestate-artifacts-cannon
+    just cannon kona-client "${version}" "$(cat ../../.config/cannon_tag)" >> "${log_file}" 2>&1
+    local prestate_hash
+    prestate_hash=$(cat ../../prestate-artifacts-cannon/prestate-proof.json | jq -r .pre)
+    cp ../../prestate-artifacts-cannon/prestate.bin.gz "${STATES_DIR}/${prestate_hash}.bin.gz"
+    VERSIONS_JSON=$(echo "${VERSIONS_JSON}" | jq ". += [{\"version\": \"${short_version}\", \"hash\": \"${prestate_hash}\", \"type\": \"cannon64-kona\"}]")
+    echo "Built kona ${version}: ${prestate_hash}"
+
+    rm ../../prestate-artifacts-cannon/prestate-proof.json
+    just cannon kona-client-int "${version}" "$(cat ../../.config/cannon_tag)" >> "${log_file}" 2>&1
+    prestate_hash=$(cat ../../prestate-artifacts-cannon/prestate-proof.json | jq -r .pre)
+    cp ../../prestate-artifacts-cannon/prestate.bin.gz "${STATES_DIR}/${prestate_hash}.bin.gz"
+    VERSIONS_JSON=$(echo "${VERSIONS_JSON}" | jq ". += [{\"version\": \"${short_version}\", \"hash\": \"${prestate_hash}\", \"type\": \"cannon64-kona-interop\"}]")
+    echo "Built kona-interop ${version}: ${prestate_hash}"
+}
+
+function build_op_program_prestate() {
+    local VERSION=$1
+    if [[ -z "${VERSION}" ]]; then
+        echo "Error: VERSION is required"
+        exit 1
+    fi
+    local SHORT_VERSION # declared separately from assignment to avoid masking failures
     SHORT_VERSION=$(echo "${VERSION}" | cut -c 13-)
-    LOG_FILE="${LOGS_DIR}/build-${SHORT_VERSION}.txt"
+    local LOG_FILE="${LOGS_DIR}/build-${SHORT_VERSION}.txt"
     echo "Building Version: ${VERSION} Logs: ${LOG_FILE}"
     # use --force to overwrite any mise.toml changes
     git checkout --force "${VERSION}" > "${LOG_FILE}" 2>&1
@@ -53,6 +94,7 @@ EOF
     make reproducible-prestate >> "${LOG_FILE}" 2>&1
 
     if [ -f "${BIN_DIR}/prestate-proof.json" ]; then
+      local HASH
       HASH=$(cat "${BIN_DIR}/prestate-proof.json" | jq -r .pre)
       if [ -f "${BIN_DIR}/prestate.bin.gz" ]
       then
@@ -65,6 +107,7 @@ EOF
     fi
 
     if [ -f "${BIN_DIR}/prestate-proof-mt64.json" ]; then
+      local HASH
       HASH=$(cat "${BIN_DIR}/prestate-proof-mt64.json" | jq -r .pre)
       cp "${BIN_DIR}/prestate-mt64.bin.gz" "${STATES_DIR}/${HASH}.mt64.bin.gz"
       VERSIONS_JSON=$(echo "${VERSIONS_JSON}" | jq ". += [{\"version\": \"${SHORT_VERSION}\", \"hash\": \"${HASH}\", \"type\": \"cannon64\"}]")
@@ -72,11 +115,46 @@ EOF
     fi
 
     if [ -f "${BIN_DIR}/prestate-proof-interop.json" ]; then
+      local HASH
       HASH=$(cat "${BIN_DIR}/prestate-proof-interop.json" | jq -r .pre)
       cp "${BIN_DIR}/prestate-interop.bin.gz" "${STATES_DIR}/${HASH}.interop.bin.gz"
       VERSIONS_JSON=$(echo "${VERSIONS_JSON}" | jq ". += [{\"version\": \"${SHORT_VERSION}\", \"hash\": \"${HASH}\", \"type\": \"interop\"}]")
       echo "Built cannon-interop ${VERSION}: ${HASH}"
     fi
+}
+
+# this global is written to by build_op_program_prestate and build_kona_prestate
+VERSIONS_JSON="[]"
+readarray -t VERSIONS < <(git tag --list 'op-program/v*' --sort taggerdate)
+
+for VERSION in "${VERSIONS[@]}"
+do
+    pushd .
+    build_op_program_prestate "${VERSION}"
+    popd
+done
+echo "${VERSIONS_JSON}" > "${VERSIONS_FILE}"
+
+# ignore alpha, beta, and older kona-client releases. The cannon prestate builds are not well supported on these versions
+EXCLUDED=(
+  "kona-client/v1.0.0"
+  "kona-client/v1.0.1"
+  "kona-client/v1.0.2"
+  "kona-client/v1.1.0-rc.1"
+  "kona-client/v1.1.0-rc.3"
+  "kona-client/v1.1.3"
+)
+printf "%s\n" "${EXCLUDED[@]}" > excluded.txt
+
+readarray -t KONA_VERSIONS < <(git ls-remote --tags "$KONA_REPO_URL" | grep kona-client/ \
+  | sed 's|.*refs/tags/||' | sed 's/\^{}//' | sort -u \
+  | grep -v beta | grep -v alpha | grep -v -F -f excluded.txt)
+
+for VERSION in "${KONA_VERSIONS[@]}"
+do
+    pushd .
+    build_kona_prestate "${VERSION}"
+    popd
 done
 echo "${VERSIONS_JSON}" > "${VERSIONS_FILE}"
 


### PR DESCRIPTION
Add support for cannon-kona prestate build in the monorepo. Depends on updates to the standard prestates in the superchain-registry - https://github.com/ethereum-optimism/superchain-registry/pull/1144

### Testing
```bash
cd op-program
scripts/build-prestates.sh
go run ./prestates/verify/verify.go \
  --input temp/states/versions.json  \
  --expected ../../superchain-registry/validation/standard/standard-prestates.toml # get this from the above pr
```

fixes https://github.com/ethereum-optimism/optimism/issues/17283