### PR TITLE
challenger: Stop kona-host using color in logs

### DIFF
--- a/cannon/cmd/run.go
+++ b/cannon/cmd/run.go
@@ -179,6 +179,8 @@ func NewProcessPreimageOracle(name string, args []string, stdout log.Logger, std
 		pOracleRW.Reader(),
 		pOracleRW.Writer(),
 	}
+	// Discourage rust programs from using color in logs.
+	cmd.Env = append([]string{"NO_COLOR=1"}, os.Environ()...)
 
 	// Note that the client file descriptors are not closed when the pre-image server exits.
 	// So we use the FilePoller to ensure that we don't get stuck in a blocking read/write.


### PR DESCRIPTION
**Description**

Somewhere along the line Kona-host started outputting colour codes in logs which caused cannon to think they were binary and log them as hex blobs.  Set NO_COLOR=1 to tell it to stop that.
