### PR TITLE
op-program: Set decoratemappings=0 directly in the main file.

### DIFF
--- a/op-program/client/cmd/godebug.go
+++ b/op-program/client/cmd/godebug.go
@@ -1,8 +1,0 @@
-// Disable annotating anonymous memory mappings. Cannon doesn't support this syscall
-// The directive (and functionality) only exists on go1.25 and above so this file is conditionally included.
-
-//go:build go1.25
-
-//go:debug decoratemappings=0
-
-package main

--- a/op-program/client/cmd/main.go
+++ b/op-program/client/cmd/main.go
@@ -1,3 +1,4 @@
+//go:debug decoratemappings=0
 package main
 
 import (

--- a/op-program/client/interopcmd/main.go
+++ b/op-program/client/interopcmd/main.go
@@ -1,3 +1,4 @@
+//go:debug decoratemappings=0
 package main
 
 import (


### PR DESCRIPTION
Latest go1.25 doesn't apply it if build conditionals are used (even if the file is included in compilation).
