### PR TITLE
batch_decoder: Fix & allow config loading via L2 chain ID

### DIFF
--- a/op-node/cmd/batch_decoder/main.go
+++ b/op-node/cmd/batch_decoder/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
 	"math/big"
@@ -38,15 +39,17 @@ func main() {
 					Required: true,
 					Usage:    "Last block (exclusive) to fetch",
 				},
-				&cli.StringFlag{
-					Name:     "inbox",
-					Required: true,
-					Usage:    "Batch Inbox Address",
+				&cli.Uint64Flag{
+					Name:  "l2-chain-id",
+					Usage: "L2 chain ID to load inbox & sender from superchain-registry",
 				},
 				&cli.StringFlag{
-					Name:     "sender",
-					Required: true,
-					Usage:    "Batch Sender Address",
+					Name:  "inbox",
+					Usage: "Batch Inbox Address",
+				},
+				&cli.StringFlag{
+					Name:  "sender",
+					Usage: "Batch Sender Address",
 				},
 				&cli.StringFlag{
 					Name:  "out",
@@ -82,6 +85,7 @@ func main() {
 				if err != nil {
 					log.Fatal(err)
 				}
+
 				beaconAddr := cliCtx.String("l1.beacon")
 				var beacon *sources.L1BeaconClient
 				if beaconAddr != "" {
@@ -95,24 +99,41 @@ func main() {
 				} else {
 					fmt.Println("L1 Beacon endpoint not set. Unable to fetch post-ecotone channel frames")
 				}
+
+				var inbox, sender common.Address
+				if cliCtx.IsSet("l2-chain-id") {
+					l2ChainID := cliCtx.Uint64("l2-chain-id")
+					rcfg, err := rollup.LoadOPStackRollupConfig(l2ChainID)
+					if err != nil {
+						return err
+					}
+					inbox = rcfg.BatchInboxAddress
+					sender = rcfg.Genesis.SystemConfig.BatcherAddr
+				} else if cliCtx.IsSet("inbox") && cliCtx.IsSet("sender") {
+					inbox = common.HexToAddress(cliCtx.String("inbox"))
+					sender = common.HexToAddress(cliCtx.String("sender"))
+				} else {
+					return fmt.Errorf("either --l2-chain-id or both --inbox and --sender must be set")
+				}
+
 				config := fetch.Config{
-					Start:   uint64(cliCtx.Int("start")),
-					End:     uint64(cliCtx.Int("end")),
-					ChainID: chainID,
-					BatchSenders: map[common.Address]struct{}{
-						common.HexToAddress(cliCtx.String("sender")): {},
-					},
-					BatchInbox:         common.HexToAddress(cliCtx.String("inbox")),
+					Start:              uint64(cliCtx.Int("start")),
+					End:                uint64(cliCtx.Int("end")),
+					ChainID:            chainID,
+					BatchSenders:       map[common.Address]struct{}{sender: {}},
+					BatchInbox:         inbox,
 					OutDirectory:       cliCtx.String("out"),
 					ConcurrentRequests: uint64(cliCtx.Int("concurrent-requests")),
 				}
+				fmt.Printf("Fetch Config: L1 Chain ID: %v. Inbox Address: %v. Valid Senders: %v.\n", config.ChainID, config.BatchInbox, config.BatchSenders)
+
 				totalValid, totalInvalid := fetch.Batches(l1Client, beacon, config)
 				fmt.Printf("Fetched batches in range [%v,%v). Found %v valid & %v invalid batches\n", config.Start, config.End, totalValid, totalInvalid)
-				fmt.Printf("Fetch Config: Chain ID: %v. Inbox Address: %v. Valid Senders: %v.\n", config.ChainID, config.BatchInbox, config.BatchSenders)
 				fmt.Printf("Wrote transactions with batches to %v\n", config.OutDirectory)
 				return nil
 			},
 		},
+
 		{
 			Name:  "reassemble",
 			Usage: "Reassembles channels from fetched batch transactions and decode batches",
@@ -129,63 +150,49 @@ func main() {
 				},
 				&cli.Uint64Flag{
 					Name:  "l2-chain-id",
-					Value: 10,
-					Usage: "L2 chain id for span batch derivation. Default value from op-mainnet.",
+					Usage: "L2 chain ID to load rollup config from superchain-registry",
 				},
-				&cli.Uint64Flag{
-					Name:  "l2-genesis-timestamp",
-					Value: 1686068903,
-					Usage: "L2 genesis time for span batch derivation. Default value from op-mainnet. " +
-						"Superchain-registry prioritized when given value is inconsistent.",
-				},
-				&cli.Uint64Flag{
-					Name:  "l2-block-time",
-					Value: 2,
-					Usage: "L2 block time for span batch derivation. Default value from op-mainnet. " +
-						"Superchain-registry prioritized when given value is inconsistent.",
-				},
-				&cli.StringFlag{
-					Name:  "inbox",
-					Value: "0xFF00000000000000000000000000000000000010",
-					Usage: "Batch Inbox Address. Default value from op-mainnet. " +
-						"Superchain-registry prioritized when given value is inconsistent.",
+				&cli.PathFlag{
+					Name:  "rollup-config",
+					Value: "rollup.json",
+					Usage: "Path to rollup config JSON file. Must only be set if not using l2-chain-id flag.",
 				},
 			},
 			Action: func(cliCtx *cli.Context) error {
-				var (
-					L2GenesisTime     uint64         = cliCtx.Uint64("l2-genesis-timestamp")
-					L2BlockTime       uint64         = cliCtx.Uint64("l2-block-time")
-					BatchInboxAddress common.Address = common.HexToAddress(cliCtx.String("inbox"))
-				)
-				L2ChainID := new(big.Int).SetUint64(cliCtx.Uint64("l2-chain-id"))
-				rollupCfg, err := rollup.LoadOPStackRollupConfig(L2ChainID.Uint64())
-				if err == nil {
-					// prioritize superchain config
-					if L2GenesisTime != rollupCfg.Genesis.L2Time {
-						L2GenesisTime = rollupCfg.Genesis.L2Time
-						fmt.Printf("L2GenesisTime overridden: %v\n", L2GenesisTime)
+				var rollupCfg *rollup.Config
+				if cliCtx.IsSet("l2-chain-id") {
+					l2ChainID := new(big.Int).SetUint64(cliCtx.Uint64("l2-chain-id"))
+					cfg, err := rollup.LoadOPStackRollupConfig(l2ChainID.Uint64())
+					if err != nil {
+						return err
 					}
-					if L2BlockTime != rollupCfg.BlockTime {
-						L2BlockTime = rollupCfg.BlockTime
-						fmt.Printf("L2BlockTime overridden: %v\n", L2BlockTime)
+					rollupCfg = cfg
+				} else if cliCtx.IsSet("rollup-config") {
+					f, err := os.Open(cliCtx.String("rollup-config"))
+					if err != nil {
+						return err
 					}
-					if BatchInboxAddress != rollupCfg.BatchInboxAddress {
-						BatchInboxAddress = rollupCfg.BatchInboxAddress
-						fmt.Printf("BatchInboxAddress overridden: %v\n", BatchInboxAddress)
+					defer f.Close()
+					if err := json.NewDecoder(f).Decode(&rollupCfg); err != nil {
+						return err
 					}
+				} else {
+					return fmt.Errorf("either --l2-chain-id or --rollup-config must be set")
 				}
+
 				config := reassemble.Config{
-					BatchInbox:    BatchInboxAddress,
+					BatchInbox:    rollupCfg.BatchInboxAddress,
 					InDirectory:   cliCtx.String("in"),
 					OutDirectory:  cliCtx.String("out"),
-					L2ChainID:     L2ChainID,
-					L2GenesisTime: L2GenesisTime,
-					L2BlockTime:   L2BlockTime,
+					L2ChainID:     rollupCfg.L2ChainID,
+					L2GenesisTime: rollupCfg.Genesis.L2Time,
+					L2BlockTime:   rollupCfg.BlockTime,
 				}
 				reassemble.Channels(config, rollupCfg)
 				return nil
 			},
 		},
+
 		{
 			Name:  "force-close",
 			Usage: "Create the tx data which will force close a channel",

--- a/op-node/cmd/batch_decoder/reassemble/reassemble.go
+++ b/op-node/cmd/batch_decoder/reassemble/reassemble.go
@@ -8,6 +8,7 @@ import (
 	"math/big"
 	"os"
 	"path"
+	"slices"
 	"sort"
 
 	"github.com/ethereum-optimism/optimism/op-node/cmd/batch_decoder/fetch"
@@ -63,7 +64,7 @@ func LoadFrames(directory string, inbox common.Address) []FrameWithMetadata {
 // specified batch inbox and then re-assembles all channels & writes the re-assembled channels
 // to the out directory.
 func Channels(config Config, rollupCfg *rollup.Config) {
-	if err := os.MkdirAll(config.OutDirectory, 0750); err != nil {
+	if err := os.MkdirAll(config.OutDirectory, 0o750); err != nil {
 		log.Fatal(err)
 	}
 	frames := LoadFrames(config.InDirectory, config.BatchInbox)
@@ -72,6 +73,9 @@ func Channels(config Config, rollupCfg *rollup.Config) {
 		framesByChannel[frame.Frame.ID] = append(framesByChannel[frame.Frame.ID], frame)
 	}
 	for id, frames := range framesByChannel {
+		slices.SortFunc(frames, func(a FrameWithMetadata, b FrameWithMetadata) int {
+			return int(a.Frame.FrameNumber) - int(b.Frame.FrameNumber)
+		})
 		ch := ProcessFrames(config, rollupCfg, id, frames)
 		filename := path.Join(config.OutDirectory, fmt.Sprintf("%s.json", id.String()))
 		if err := writeChannel(ch, filename); err != nil {


### PR DESCRIPTION

**Description**

Fixes the batch decoder to have a full rollup config for `reassemble` and allow loading of it via the `l2-chain-id` flag. Also improves the `fetch` command to also allow only setting the L2 chain id.

**Tests**

Tested locally.

