### PR TITLE
op-supernode: Enable P2P for Virtual Nodes

### DIFF
--- a/op-supernode/README.md
+++ b/op-supernode/README.md
@@ -1,126 +1,83 @@
-## OP Supernode
+# OP Supernode
 
 Run multiple OP Stack chains in a single process. OP Supernode virtualizes OP Node so each chain runs as an isolated in-memory worker with per-chain config, data, and logs.
 
-### Highlights
-- Multi-chain in one binary; lightweight per-chain workers
-- Per-chain config via `-vn.*` flag prefixing
-- Isolated data directories per chain
-- Structured logs with `chain_id` and `vn_id`
-- Shared L1 RPC and Beacon clients with non-closeable wrappers
+## Major Features
+### Chain Containers
+Chain Containers represent the concerns of one specific Chain being managed by the `op-supernode`
 
-### How it works
+#### Chain Isolation / Interfacing
+Chain Containers abstract away the local Consensus Layer / Derivation Pipeline, as well as the Execution Engine.
+Chain containers manage the runtime of the CL as a local process called a "Virtual Node", which presently is implemented
+only by `op-node` itself.
+Chain Containers provide a stable interface to get data from the chain or affect the chain without needing to operate on the internals of
+that chain.
+Chain Containers also allow for multiple chains to be derived inside of the same `op-supernode`. Because theya re isolated,
+running many chains worth of derivation is trivial.
+
+
+#### Shared Chain Resources
+Chain Containers also benefit from running in a shared environment through the use of shared resources.
+Shared resources are Dependencies which have been injected into the Virtual Node such that the original behavior is in-tact,
+but redundant access is eliminated.
+
+- Shared L1 and Beacon Client mean shared caching and only a single pipe to the L1 across all chains.
+- Shared RPCs through a namespaced RPC registration system. Call `11155420/` for OP Sepolia's RPC capabilities, or `84532/` for Base Sepolia.
+- Metrics are shared through similar namespacing, but will likely be joined via prometheus dimensions in the future.
+- Data Directories are namespaced to protect SafeDB and P2P resources
+- Flag configuration can be shared amongst chains for common setup.
+
+
+#### Flag Configuration Tips
+
+Because `op-node` is the only implementation of Virtual Nodes presently, it gets special treatment when the application starts up.
+In specific, all those flags which are found in `op-node` are upstreamed with namespacing into the `op-supernode` flags.
+This allows for *roughly* 1:1 setup and behavior between Node and Supernode, with cavets listed below.
+- To set a value for one chain, use `--vn.<chainID>.<flag>`
+- To set a value for *all* chains, use `--vn.all.<flag>`
+- Some behaviors are expected to be configured at the `op-supernode` level and are not respected per usual when the application starts:
+  - `l1` and `l1.beacon` are used to create the shared L1 client. Any L1 configuration will not be respected by a Virtual Node.
+  - Log and Metric settings are passed down to the Virtual node from the top level Log/Metric flags, and individual chain settings may not be respected.
+  - `p2p` is enabled/disabled at the top level and sets all listen ports to `0` to prevent collisions. Per-chain P2P functionality will added
+  via a shared resource in the future.
+
+Example launch of Supernode:
 ```
-Supernode: Runs Containers
-  ├── ChainContainer (901) Manages:
-      ├── VirtualNode ── In Memory OP Node (901)
-      └── (FUTURE) Engine Controller (901)
-  ├── ChainContainer (902) Manages:
-      ├── VirtualNode ── In Memory OP Node (902)
-      └── (FUTURE) Engine Controller (902)
-  └── ChainContainer (903) Manages:
-      ├── VirtualNode ── In Memory OP Node (903)
-      └── (FUTURE) Engine Controller (903)
-```
-- Supernode orchestrates chain containers (start/stop/restart, pause/resume, shutdown)
-- ChainContainer applies per-chain config and passes shared resources
-- VirtualNode runs OP Node with isolated resources and context-rich logging
+./bin/op-supernode \
+  --l1='...' \
+  --l1.beacon='...' \
+  --disable-p2p=true \
+  --log.level=DEBUG \
+  --metrics.enabled=true \
+  --metrics.port=7300 \
+  --chains=11155420,84532 \
+  --vn.11155420.network=op-sepolia \
+  --vn.11155420.l2='...' \
+  --vn.84532.network=base-sepolia \
+  --vn.84532.l2='...'
+  --vn.84532.l1.beacon-archiver='...' \
+  --vn.all.l2.jwt-secret=../../jwt-secret.txt \
+  ```
+
+Note: consult the `help` printout of the application as currently there is a mistake in the naming of Environment Variables for flags.
+Env Vars may be used, but at present their names include inappropriate `op-node` markers.
+
+### Activities
+Activities represent the concerns of `op-supernode` which fall outside of any one chain, and are modular plugins to the capabilities of the software.
+
+#### RPC Activities
+Components which expose RPC functionality and register as an Activity will have their RPC namespaces registered against the `op-supernode` root.
+
+#### Runnable Activities
+Components which expose Start/Stop are given a goroutine to work during `op-supernode` runtime
+
+#### Current Activities:
+- `Heartbeat`
+  - RPC: `heartbeat_check` produces a random-hex sign of life when called.
+  - Runtime: emits a simple heartbeat message to the logs to show liveness.
 
 ### Quickstart
 Build:
 ```bash
 just op-supernode
 ```
-
-Run multiple chains:
-```bash
-./bin/op-supernode \
-  --chains 901,902 \
-  --data-dir ./supernode-data \
-  --l1 http://localhost:8545 \
-  --l1.beacon http://localhost:5052 \
-  -vn.901.l2=http://localhost:9001 \
-  -vn.901.rollup.config=./rollup-901.json \
-  -vn.902.l2=http://localhost:9002 \
-  -vn.902.rollup.config=./rollup-902.json \
-  -vn.all.l2.jwt-secret=./jwt-902.txt
-```
-
-Environment variables:
-```bash
-export OP_SUPERNODE_CHAINS=901,902,903
-export OP_SUPERNODE_DATA_DIR=/var/lib/supernode
-export OP_SUPERNODE_L1_ETH_RPC=$L1_RPC
-export OP_SUPERNODE_L1_BEACON=$L1_BEACON
-
-./bin/op-supernode \
-  -vn.901.l2=$CHAIN_901_RPC \
-  -vn.902.l2=$CHAIN_902_RPC \
-  -vn.903.l2=$CHAIN_903_RPC
-```
-
-### Configuration
-- Required: `--chains`, `--l1`
-- Optional: `--l1.beacon`, `--data-dir` (default `./datadir`), standard op-service flags (logging, metrics, pprof, RPC)
-
-Per-chain flags are prefixed:
-- `-vn.all.<flag>` applies to all chains
-- `-vn.<chainID>.<flag>` applies to one chain
-
-All virtual node configuration flags can also be set by environment variable, prefixed with `VN_ALL_` or `VN_<CHAINID>_`.
-
-Common examples:
-```bash
-# Supernode-level L1
---l1 http://l1:8545
---l1.beacon http://l1:5052
-
-# Per-chain L2 execution engines
--vn.901.l2=http://op-geth-901:8551
--vn.902.l2=http://op-geth-902:8551
-
-# Per-chain rollup configs
--vn.901.rollup.config=./rollup-901.json
--vn.902.rollup.config=./rollup-902.json
-
-# Apply to all chains
--vn.all.syncmode=execution-layer
-```
-
-### Data and logs
-Data layout:
-```
-<data-dir>/
-  ├── 901/
-  │   └── safe_db/
-  ├── 902/
-  │   └── safe_db/
-  └── 903/
-      └── safe_db/
-```
-
-Logs include `chain_id` and a short-lived `vn_id` for filtering and debugging.
-
-### RPC Routing
-RPC Clients are created in namespaced paths, so the supernode has a single RPC URL which acts as an RPC router to the virtual nodes
-```
-/
-  ├── 901/
-  ├── 902/
-  └── 903/
-```
-calling RPC methods on `/901` will route the method to the Virtual Node for that chain.
-
-### Metrics Routing
-Prometheus Metrics are exposed in namespaced paths, so the supernode has a single RPC URL which acts as an RPC router to the virtual nodes
-```
-/
-  ├── 901/metrics
-  ├── 902/metrics
-  └── 903/metrics
-```
-All metrics are available at the supernode-configured metrics port.
-
-### Limitations
-- P2P disabled for Virtual Nodes (unsafe head sync possible later)
-- Pause/resume exists but not yet exposed via API

--- a/op-supernode/cmd/main.go
+++ b/op-supernode/cmd/main.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
+	"strconv"
 
 	"github.com/ethereum-optimism/optimism/op-service/ctxinterrupt"
 
@@ -55,7 +57,7 @@ func main() {
 			return nil, err
 		}
 
-		// Create supernode the config from the CLI context
+		// Create supernode config from the CLI context
 		cfg := config.NewConfig(cliCtx)
 		if err := cfg.Check(); err != nil {
 			return nil, fmt.Errorf("invalid CLI flags: %w", err)
@@ -65,28 +67,13 @@ func main() {
 		l := oplog.NewLogger(oplog.AppOut(cliCtx), cfg.LogConfig)
 		oplog.SetGlobalLogHandler(l.Handler())
 
-		// Validate the environment variables for the app (requres logs so has to be later)
+		// Validate the environment variables for the app
 		opservice.ValidateEnvVars(flags.EnvVarPrefix, dynamicFlags, l)
 
 		// Build virtual Configs from the CLI Context for each chain
-		vnCfgs := make(map[eth.ChainID]*opnodecfg.Config)
-		for _, chainID := range cfg.Chains {
-			// Create a new VirtualCLI for the chain which will serve as an opnode config
-			vcli := flags.NewVirtualCLI(cliCtx, chainID)
-			// Override the L1 and Beacon addresses for the virtual node
-			// Based on the top level L1 and Beacon addresses
-			vcli.WithStringOverride(opnodeflags.L1NodeAddr.Name, cfg.L1NodeAddr)
-			vcli.WithStringOverride(opnodeflags.BeaconAddr.Name, cfg.L1BeaconAddr)
-			// Disable P2P for virtual nodes and set the peerstore and discovery paths to memory
-			// this is disabled at the CLI level to allow config construction
-			vcli.WithBoolOverride(opnodeflags.DisableP2PName, true)
-			vcli.WithStringOverride(opnodeflags.PeerstorePathName, "memory")
-			vcli.WithStringOverride(opnodeflags.DiscoveryPathName, "memory")
-			cfg, err := opnode.NewConfig(vcli, l)
-			if err != nil {
-				return nil, fmt.Errorf("failed to create virtual node config: %w", err)
-			}
-			vnCfgs[eth.ChainIDFromUInt64(chainID)] = cfg
+		vnCfgs, err := createVirtualNodeConfigs(cliCtx, cfg, l)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create virtual node configs: %w", err)
 		}
 
 		// Create the supernode, supplying the logger, version, and close function
@@ -108,4 +95,58 @@ func main() {
 	if err := app.RunContext(ctx, os.Args); err != nil {
 		log.Crit("Application failed", "message", err)
 	}
+}
+
+func createVirtualNodeConfigs(cliCtx *cli.Context, cfg *config.CLIConfig, l log.Logger) (map[eth.ChainID]*opnodecfg.Config, error) {
+	vnCfgs := make(map[eth.ChainID]*opnodecfg.Config)
+	for _, chainID := range cfg.Chains {
+		// Create a new VirtualCLI for the chain which will serve as an opnode config
+		vcli := flags.NewVirtualCLI(cliCtx, chainID)
+		// force P2P settings to match top level DisableP2P flag
+		if cliCtx.Bool(flags.DisableP2P.Name) {
+			if err := withNoP2P(vcli); err != nil {
+				return nil, fmt.Errorf("failed to disable P2P for chain %d: %w", chainID, err)
+			}
+		} else {
+			if err := withNamespacedP2P(vcli, cfg.DataDir, strconv.FormatUint(chainID, 10)); err != nil {
+				return nil, fmt.Errorf("failed to configure P2P for chain %d: %w", chainID, err)
+			}
+		}
+		// Override the L1 and Beacon addresses for the virtual node
+		// Based on the top level L1 and Beacon addresses
+		vcli.WithStringOverride(opnodeflags.L1NodeAddr.Name, cfg.L1NodeAddr)
+		vcli.WithStringOverride(opnodeflags.BeaconAddr.Name, cfg.L1BeaconAddr)
+		cfg, err := opnode.NewConfig(vcli, l)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create virtual node config: %w", err)
+		}
+		vnCfgs[eth.ChainIDFromUInt64(chainID)] = cfg
+	}
+	return vnCfgs, nil
+}
+
+func withNoP2P(vcli *flags.VirtualCLI) error {
+	vcli.WithBoolOverride(opnodeflags.DisableP2PName, true)
+	vcli.WithStringOverride(opnodeflags.P2PPrivPathName, "")
+	vcli.WithStringOverride(opnodeflags.PeerstorePathName, "")
+	vcli.WithStringOverride(opnodeflags.DiscoveryPathName, "")
+	vcli.WithUintOverride(opnodeflags.ListenTCPPortName, 0)
+	vcli.WithUintOverride(opnodeflags.ListenUDPPortName, 0)
+	return nil
+}
+
+func withNamespacedP2P(vcli *flags.VirtualCLI, datadir string, namespace string) error {
+	// Configure per-VN P2P using namespaced DataDir and dynamic ports
+	p2pDir := filepath.Join(datadir, namespace, "p2p")
+	// Ensure per-VN p2p directory exists for key and databases
+	if err := os.MkdirAll(p2pDir, 0o700); err != nil {
+		return fmt.Errorf("failed creating p2p dir for chain %s: %w", namespace, err)
+	}
+	vcli.WithStringOverride(opnodeflags.P2PPrivPathName, filepath.Join(p2pDir, "opnode_p2p_priv.txt"))
+	vcli.WithStringOverride(opnodeflags.PeerstorePathName, filepath.Join(p2pDir, "peerstore_db"))
+	vcli.WithStringOverride(opnodeflags.DiscoveryPathName, filepath.Join(p2pDir, "discovery_db"))
+	// Force dynamic TCP/UDP listen ports to avoid collisions
+	vcli.WithUintOverride(opnodeflags.ListenTCPPortName, 0)
+	vcli.WithUintOverride(opnodeflags.ListenUDPPortName, 0)
+	return nil
 }

--- a/op-supernode/cmd/main.go
+++ b/op-supernode/cmd/main.go
@@ -25,7 +25,7 @@ import (
 )
 
 var (
-	Version   = "v0.1.0"
+	Version   = "v0.1.1"
 	GitCommit = ""
 	GitDate   = ""
 )

--- a/op-supernode/flags/flags.go
+++ b/op-supernode/flags/flags.go
@@ -45,6 +45,13 @@ var (
 		EnvVars:  prefixEnvVars("L1_BEACON"),
 		Required: false,
 	}
+	DisableP2P = &cli.BoolFlag{
+		Name:     "disable-p2p",
+		Usage:    "Disable P2P for all chains. Affects configuration handed to virtual nodes.",
+		EnvVars:  prefixEnvVars("DISABLE_P2P"),
+		Value:    false,
+		Required: false,
+	}
 )
 
 var requiredFlags = []cli.Flag{
@@ -52,7 +59,9 @@ var requiredFlags = []cli.Flag{
 	L1NodeAddr,
 }
 
-var optionalFlags []cli.Flag
+var optionalFlags = []cli.Flag{
+	DisableP2P,
+}
 
 func init() {
 	optionalFlags = append(optionalFlags, L1BeaconAddr)

--- a/op-supernode/flags/virtual_cli.go
+++ b/op-supernode/flags/virtual_cli.go
@@ -16,10 +16,11 @@ type VirtualCLI struct {
 	// this is useful for enforcing defaults or disabling features which aren't supported by the virtual node
 	stringOverrides map[string]string
 	boolOverrides   map[string]bool
+	uintOverrides   map[string]uint
 }
 
 func NewVirtualCLI(base *cli.Context, chainID uint64) *VirtualCLI {
-	return &VirtualCLI{inner: base, chainID: chainID, stringOverrides: make(map[string]string), boolOverrides: make(map[string]bool)}
+	return &VirtualCLI{inner: base, chainID: chainID, stringOverrides: make(map[string]string), boolOverrides: make(map[string]bool), uintOverrides: make(map[string]uint)}
 }
 
 func (v *VirtualCLI) chainName(name string) string {
@@ -38,6 +39,9 @@ func (v *VirtualCLI) IsSet(name string) bool {
 		return true
 	}
 	if _, ok := v.boolOverrides[name]; ok {
+		return true
+	}
+	if _, ok := v.uintOverrides[name]; ok {
 		return true
 	}
 	if v.inner.IsSet(v.chainName(name)) {
@@ -87,6 +91,9 @@ func (v *VirtualCLI) Int(name string) int {
 }
 
 func (v *VirtualCLI) Uint(name string) uint {
+	if val, ok := v.uintOverrides[name]; ok {
+		return val
+	}
 	cName := v.chainName(name)
 	if v.inner.IsSet(cName) {
 		return v.inner.Uint(cName)
@@ -158,5 +165,11 @@ func (v *VirtualCLI) WithStringOverride(name, value string) *VirtualCLI {
 // WithBoolOverride sets a bool override for the given base flag name
 func (v *VirtualCLI) WithBoolOverride(name string, value bool) *VirtualCLI {
 	v.boolOverrides[name] = value
+	return v
+}
+
+// WithUintOverride sets a uint override for the given base flag name
+func (v *VirtualCLI) WithUintOverride(name string, value uint) *VirtualCLI {
+	v.uintOverrides[name] = value
 	return v
 }

--- a/op-supernode/supernode/chain_container/chain_container.go
+++ b/op-supernode/supernode/chain_container/chain_container.go
@@ -9,7 +9,6 @@ import (
 
 	opnodecfg "github.com/ethereum-optimism/optimism/op-node/config"
 	rollupNode "github.com/ethereum-optimism/optimism/op-node/node"
-	p2p "github.com/ethereum-optimism/optimism/op-node/p2p"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	oprpc "github.com/ethereum-optimism/optimism/op-service/rpc"
 	"github.com/ethereum-optimism/optimism/op-supernode/config"
@@ -70,8 +69,6 @@ func NewChainContainer(
 		appVersion:         virtualNodeVersion,
 		virtualNodeFactory: defaultVirtualNodeFactory,
 	}
-	// Disable P2P and inherit paths from supernode base config
-	vncfg.P2P = &p2p.Config{DisableP2P: true}
 	vncfg.SafeDBPath = c.subPath("safe_db")
 	vncfg.RPC = cfg.RPCConfig
 	return c
@@ -90,7 +87,6 @@ func (c *simpleChainContainer) Start(ctx context.Context) error {
 	defer func() { c.stopped <- struct{}{} }()
 	for {
 		// Refresh per-start derived fields
-		c.vncfg.P2P = &p2p.Config{DisableP2P: true}
 		c.vncfg.SafeDBPath = c.subPath("safe_db")
 		c.vncfg.RPC = c.cfg.RPCConfig
 		// create a fresh handler per (re)start, swap it into the router, and inject into overload

--- a/op-supernode/supernode/chain_container/chain_container_test.go
+++ b/op-supernode/supernode/chain_container/chain_container_test.go
@@ -122,17 +122,6 @@ func TestChainContainer_Constructor(t *testing.T) {
 		require.Equal(t, 1, cap(impl.stopped))
 	})
 
-	t.Run("P2P disabled for virtual nodes", func(t *testing.T) {
-		vncfgCopy := createTestVNConfig()
-		container := NewChainContainer(chainID, vncfgCopy, log, cfg, initOverload, nil, nil, nil)
-
-		impl, ok := container.(*simpleChainContainer)
-		require.True(t, ok)
-
-		require.NotNil(t, impl.vncfg.P2P)
-		require.True(t, impl.vncfg.P2P.Disabled())
-	})
-
 	t.Run("SafeDBPath uses subPath", func(t *testing.T) {
 		cfg := config.CLIConfig{
 			DataDir: "/tmp/datadir",


### PR DESCRIPTION
# What

Enables P2P for Virtual Nodes by taking a top level `op-supervisor` flag `--disable-p2p` and using it to decide how to load the Virtual CLI Contexts for the Nodes.

## What?

In Supernode's `Main`, I take the top level `urface CLI Context` which contains all the runtime flags, and I wrap it with a virtual accessor which can reroute queries. For example, when a Virtual Node asks for some flag value `--x`, we proxy that check to `--chainID.x`. This allows for all Virtual Nodes to share one set of flags including global values, while also allowing per-chain settings.

When `op-supervisor` starts with `--disable-p2p=true`, all P2P configurations are set to zero-values or disabled for all chains.

When `op-supervisor` starts with `--disable-p2p=false`, all P2P configurations are set to use namespaced Data Directories, and use `0` for all port values for dynamic assignment.

## Why?

For a `op-supernode` to sync, it can *either* do a Full Sync, meaning it derives manually from genesis, or it can use some Execution Syncing mechanism to push the engine to the tip-state. This requires that you *know* what the tip is in order to target it, and currently the only way to get a signal to sync towards is over the CL P2P network.

*Personally* I am not a huge fan of `op-supernode` supporting P2P, but given the vital role it serves in first time startup, I've decided to give it some basic enablement.

In the future, if we want a more sophisticated P2P, I recommend we build a shared resource which can deduplicate the number of listening ports. That task is more involved than I'd like to take on to enable P2P for the moment.

## Tests
Locally tested to confirm on/off both set P2P correctly.

Also running this in our actual infrastructure, which confirms this change is what's required to enable the `op-supernode` to correctly sync and start up.

I've heard that writing P2P tests that are meaningful and not flaky is very difficult so I've avoided it for this endeavor, but would accept pushback if there's a specific type of testing this PR deserves.

# Also

Rewrote the README.md at the same time since this change caused me to open it up and realize it's a little stale.
