### PR TITLE
Add DeployFeesDepositor script

### DIFF
--- a/packages/contracts-bedrock/scripts/deploy/DeployFeesDepositor.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployFeesDepositor.s.sol
@@ -4,7 +4,6 @@ pragma solidity 0.8.15;
 import { Script } from "forge-std/Script.sol";
 import { console2 as console } from "forge-std/console2.sol";
 
-import { FeesDepositor } from "src/L1/FeesDepositor.sol";
 import { IFeesDepositor } from "interfaces/L1/IFeesDepositor.sol";
 import { Proxy } from "src/universal/Proxy.sol";
 import { IL1CrossDomainMessenger } from "interfaces/L1/IL1CrossDomainMessenger.sol";

--- a/packages/contracts-bedrock/scripts/deploy/DeployFeesDepositor.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployFeesDepositor.s.sol
@@ -79,6 +79,8 @@ contract DeployFeesDepositor is Script {
     }
 
     /// @notice Initializes the FeesDepositor proxy contract.
+    /// @param _feesDepositorProxy The address of the FeesDepositor proxy.
+    /// @param _feesDepositorImpl The address of the FeesDepositor implementation.
     /// @param _minDepositAmount The threshold at which fees are deposited.
     /// @param _l2Recipient The L2 recipient of the fees.
     /// @param _messenger The L1CrossDomainMessenger contract address.

--- a/packages/contracts-bedrock/scripts/deploy/DeployFeesDepositor.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployFeesDepositor.s.sol
@@ -99,8 +99,7 @@ contract DeployFeesDepositor is Script {
         );
 
         vm.broadcast(deployer);
-        IProxy(_feesDepositorProxy)
-            .upgradeToAndCall({ _implementation: address(_feesDepositorImpl), _data: initData });
+        IProxy(_feesDepositorProxy).upgradeToAndCall({ _implementation: address(_feesDepositorImpl), _data: initData });
     }
 
     /// @notice Transfers the ownership of the proxy to the final proxy.
@@ -143,4 +142,3 @@ contract DeployFeesDepositor is Script {
         console.log("================================");
     }
 }
-

--- a/packages/contracts-bedrock/scripts/deploy/DeployFeesDepositor.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployFeesDepositor.s.sol
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { Script } from "forge-std/Script.sol";
+import { console2 as console } from "forge-std/console2.sol";
+
+import { FeesDepositor } from "src/L1/FeesDepositor.sol";
+import { IFeesDepositor } from "interfaces/L1/IFeesDepositor.sol";
+import { Proxy } from "src/universal/Proxy.sol";
+import { IL1CrossDomainMessenger } from "interfaces/L1/IL1CrossDomainMessenger.sol";
+import { IProxy } from "interfaces/universal/IProxy.sol";
+
+import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
+
+/// @title DeployFeesDepositor
+/// @notice Script used to deploy and initialize the FeesDepositor contract.
+contract DeployFeesDepositor is Script {
+    /// @notice Output addresses from deployment.
+    struct Output {
+        /// @notice The deployed FeesDepositor implementation address.
+        address feesDepositorImpl;
+        /// @notice The deployed FeesDepositor proxy address.
+        address feesDepositorProxy;
+    }
+
+    bytes32 internal _salt = DeployUtils.DEFAULT_SALT;
+
+    address deployer;
+
+    /// @notice Deploys and initializes the FeesDepositor contract.
+    /// @param _proxyAdmin The address that will be the admin of the proxy.
+    /// @param _minDepositAmount The threshold at which fees are deposited.
+    /// @param _l2Recipient The L2 recipient of the fees.
+    /// @param _messenger The L1CrossDomainMessenger contract address.
+    /// @param _gasLimit The gas limit for the deposit transaction.
+    /// @return output_ The deployment output addresses.
+    function run(
+        address _proxyAdmin,
+        uint96 _minDepositAmount,
+        address _l2Recipient,
+        address _messenger,
+        uint32 _gasLimit
+    )
+        public
+        returns (Output memory output_)
+    {
+        deployer = msg.sender;
+
+        assertValidInput(_proxyAdmin, _l2Recipient, _messenger, _minDepositAmount, _gasLimit);
+
+        // Deploy the implementation.
+        deployImplementation(output_);
+
+        // Deploy the proxy.
+        deployProxy(_proxyAdmin, output_);
+
+        // Initialize the proxy.
+        initializeProxy(_minDepositAmount, _l2Recipient, _messenger, _gasLimit, output_);
+
+        // Transfer the ownership of the proxy to the final proxy.
+        transferToFinalProxyAdmin(_proxyAdmin, output_);
+
+        // Log the results.
+        logResults(output_);
+    }
+
+    /// @notice Deploys the FeesDepositor implementation contract.
+    /// @param _output The output struct to populate.
+    function deployImplementation(Output memory _output) internal {
+        FeesDepositor impl = FeesDepositor(
+            DeployUtils.createDeterministic({
+                _name: "FeesDepositor",
+                _args: DeployUtils.encodeConstructor(abi.encodeCall(IFeesDepositor.__constructor__, ())),
+                _salt: _salt
+            })
+        );
+
+        vm.label(address(impl), "FeesDepositorImpl");
+        _output.feesDepositorImpl = address(impl);
+    }
+
+    /// @notice Deploys the Proxy contract for FeesDepositor.
+    /// @param _proxyAdmin The address that will be the admin of the proxy.
+    /// @param _output The output struct to populate.
+    function deployProxy(address _proxyAdmin, Output memory _output) internal {
+        IProxy proxy = IProxy(
+            DeployUtils.createDeterministic({
+                _name: "Proxy",
+                _args: DeployUtils.encodeConstructor(abi.encodeCall(IProxy.__constructor__, (deployer))),
+                _salt: _salt
+            })
+        );
+
+        vm.label(address(proxy), "FeesDepositorProxy");
+        _output.feesDepositorProxy = address(proxy);
+    }
+
+    /// @notice Initializes the FeesDepositor proxy contract.
+    /// @param _minDepositAmount The threshold at which fees are deposited.
+    /// @param _l2Recipient The L2 recipient of the fees.
+    /// @param _messenger The L1CrossDomainMessenger contract address.
+    /// @param _gasLimit The gas limit for the deposit transaction.
+    /// @param _output The deployment output addresses.
+    function initializeProxy(
+        uint96 _minDepositAmount,
+        address _l2Recipient,
+        address _messenger,
+        uint32 _gasLimit,
+        Output memory _output
+    )
+        internal
+    {
+        bytes memory initData = abi.encodeCall(
+            FeesDepositor.initialize, (_minDepositAmount, _l2Recipient, IL1CrossDomainMessenger(_messenger), _gasLimit)
+        );
+
+        console.log("Proxy admin:", deployer);
+        console.logBytes32(
+            vm.load(address(_output.feesDepositorProxy), bytes32(uint256(keccak256("eip1967.proxy.admin")) - 1))
+        );
+        vm.broadcast(deployer);
+        IProxy(payable(_output.feesDepositorProxy))
+            .upgradeToAndCall({ _implementation: _output.feesDepositorImpl, _data: initData });
+    }
+
+    /// @notice Transfers the ownership of the proxy to the final proxy.
+    /// @param _proxyAdmin The address that will be the admin of the proxy.
+    function transferToFinalProxyAdmin(address _proxyAdmin, Output memory _output) internal {
+        vm.broadcast(deployer);
+        IProxy(payable(_output.feesDepositorProxy)).changeAdmin(_proxyAdmin);
+    }
+
+    /// @notice Validates the input parameters.
+    /// @param _proxyAdmin The address that will be the admin of the proxy.
+    /// @param _l2Recipient The L2 recipient of the fees.
+    /// @param _messenger The L1CrossDomainMessenger contract address.
+    /// @param _minDepositAmount The threshold at which fees are deposited.
+    /// @param _gasLimit The gas limit for the deposit transaction.
+    function assertValidInput(
+        address _proxyAdmin,
+        address _l2Recipient,
+        address _messenger,
+        uint96 _minDepositAmount,
+        uint32 _gasLimit
+    )
+        internal
+        pure
+    {
+        require(_proxyAdmin != address(0), "DeployFeesDepositor: proxyAdmin cannot be zero address");
+        require(_l2Recipient != address(0), "DeployFeesDepositor: l2Recipient cannot be zero address");
+        require(_messenger != address(0), "DeployFeesDepositor: messenger cannot be zero address");
+        require(_minDepositAmount > 0, "DeployFeesDepositor: minDepositAmount must be greater than zero");
+        require(_gasLimit > 0, "DeployFeesDepositor: gasLimit must be greater than zero");
+    }
+
+    /// @notice Logs the deployment results.
+    /// @param _output The deployment output addresses.
+    function logResults(Output memory _output) internal view {
+        console.log("=== FeesDepositor Deployment ===");
+        console.log("Implementation:", _output.feesDepositorImpl);
+        console.log("Proxy:", _output.feesDepositorProxy);
+        console.log("================================");
+    }
+}
+

--- a/packages/contracts-bedrock/scripts/deploy/DeployFeesDepositor.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployFeesDepositor.s.sol
@@ -47,7 +47,7 @@ contract DeployFeesDepositor is Script {
         // Initialize the proxy.
         initializeProxy(proxy, impl, _minDepositAmount, _l2Recipient, _messenger, _gasLimit);
 
-        // Transfer the ownership of the proxy to the final proxy.
+        // Transfer the ownership of the proxy to the final proxy admin.
         transferToFinalProxyAdmin(_proxyAdmin, proxy);
 
         // Log the results.
@@ -101,7 +101,7 @@ contract DeployFeesDepositor is Script {
         IProxy(_feesDepositorProxy).upgradeToAndCall({ _implementation: address(_feesDepositorImpl), _data: initData });
     }
 
-    /// @notice Transfers the ownership of the proxy to the final proxy.
+    /// @notice Transfers the ownership of the proxy to the final proxy admin.
     /// @param _proxyAdmin The address that will be the admin of the proxy.
     function transferToFinalProxyAdmin(address _proxyAdmin, IProxy _feesDepositorProxy) internal {
         vm.broadcast(deployer);

--- a/packages/contracts-bedrock/scripts/deploy/DeployFeesDepositor.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployFeesDepositor.s.sol
@@ -135,7 +135,7 @@ contract DeployFeesDepositor is Script {
     /// @notice Logs the deployment results.
     /// @param _feesDepositorImpl The deployed FeesDepositor implementation address.
     /// @param _feesDepositorProxy The deployed FeesDepositor proxy address.
-    function logResults(IFeesDepositor _feesDepositorImpl, IProxy _feesDepositorProxy) internal view {
+    function logResults(IFeesDepositor _feesDepositorImpl, IProxy _feesDepositorProxy) internal pure {
         console.log("=== FeesDepositor Deployment ===");
         console.log("Implementation:", address(_feesDepositorImpl));
         console.log("Proxy:", address(_feesDepositorProxy));

--- a/packages/contracts-bedrock/scripts/deploy/DeployFeesDepositor.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployFeesDepositor.s.sol
@@ -33,7 +33,7 @@ contract DeployFeesDepositor is Script {
         uint32 _gasLimit
     )
         public
-        returns (IFeesDepositor feesDepositorImpl, IProxy feesDepositorProxy)
+        returns (IFeesDepositor, IProxy)
     {
         deployer = msg.sender;
 

--- a/packages/contracts-bedrock/scripts/deploy/DeployFeesDepositor.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployFeesDepositor.s.sol
@@ -15,14 +15,6 @@ import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 /// @title DeployFeesDepositor
 /// @notice Script used to deploy and initialize the FeesDepositor contract.
 contract DeployFeesDepositor is Script {
-    /// @notice Output addresses from deployment.
-    struct Output {
-        /// @notice The deployed FeesDepositor implementation address.
-        address feesDepositorImpl;
-        /// @notice The deployed FeesDepositor proxy address.
-        address feesDepositorProxy;
-    }
-
     bytes32 internal _salt = DeployUtils.DEFAULT_SALT;
 
     address deployer;
@@ -33,7 +25,6 @@ contract DeployFeesDepositor is Script {
     /// @param _l2Recipient The L2 recipient of the fees.
     /// @param _messenger The L1CrossDomainMessenger contract address.
     /// @param _gasLimit The gas limit for the deposit transaction.
-    /// @return output_ The deployment output addresses.
     function run(
         address _proxyAdmin,
         uint96 _minDepositAmount,
@@ -42,57 +33,50 @@ contract DeployFeesDepositor is Script {
         uint32 _gasLimit
     )
         public
-        returns (Output memory output_)
+        returns (IFeesDepositor feesDepositorImpl, IProxy feesDepositorProxy)
     {
         deployer = msg.sender;
 
         assertValidInput(_proxyAdmin, _l2Recipient, _messenger, _minDepositAmount, _gasLimit);
 
         // Deploy the implementation.
-        deployImplementation(output_);
+        IFeesDepositor impl = deployImplementation();
 
         // Deploy the proxy.
-        deployProxy(_proxyAdmin, output_);
+        IProxy proxy = deployProxy();
 
         // Initialize the proxy.
-        initializeProxy(_minDepositAmount, _l2Recipient, _messenger, _gasLimit, output_);
+        initializeProxy(proxy, impl, _minDepositAmount, _l2Recipient, _messenger, _gasLimit);
 
         // Transfer the ownership of the proxy to the final proxy.
-        transferToFinalProxyAdmin(_proxyAdmin, output_);
+        transferToFinalProxyAdmin(_proxyAdmin, proxy);
 
         // Log the results.
-        logResults(output_);
+        logResults(impl, proxy);
+
+        return (impl, proxy);
     }
 
     /// @notice Deploys the FeesDepositor implementation contract.
-    /// @param _output The output struct to populate.
-    function deployImplementation(Output memory _output) internal {
-        FeesDepositor impl = FeesDepositor(
+    function deployImplementation() internal returns (IFeesDepositor) {
+        return IFeesDepositor(
             DeployUtils.createDeterministic({
                 _name: "FeesDepositor",
                 _args: DeployUtils.encodeConstructor(abi.encodeCall(IFeesDepositor.__constructor__, ())),
                 _salt: _salt
             })
         );
-
-        vm.label(address(impl), "FeesDepositorImpl");
-        _output.feesDepositorImpl = address(impl);
     }
 
     /// @notice Deploys the Proxy contract for FeesDepositor.
-    /// @param _proxyAdmin The address that will be the admin of the proxy.
-    /// @param _output The output struct to populate.
-    function deployProxy(address _proxyAdmin, Output memory _output) internal {
-        IProxy proxy = IProxy(
+    function deployProxy() internal returns (IProxy) {
+        return IProxy(
             DeployUtils.createDeterministic({
                 _name: "Proxy",
                 _args: DeployUtils.encodeConstructor(abi.encodeCall(IProxy.__constructor__, (deployer))),
                 _salt: _salt
             })
         );
-
-        vm.label(address(proxy), "FeesDepositorProxy");
-        _output.feesDepositorProxy = address(proxy);
     }
 
     /// @notice Initializes the FeesDepositor proxy contract.
@@ -100,34 +84,30 @@ contract DeployFeesDepositor is Script {
     /// @param _l2Recipient The L2 recipient of the fees.
     /// @param _messenger The L1CrossDomainMessenger contract address.
     /// @param _gasLimit The gas limit for the deposit transaction.
-    /// @param _output The deployment output addresses.
     function initializeProxy(
+        IProxy _feesDepositorProxy,
+        IFeesDepositor _feesDepositorImpl,
         uint96 _minDepositAmount,
         address _l2Recipient,
         address _messenger,
-        uint32 _gasLimit,
-        Output memory _output
+        uint32 _gasLimit
     )
         internal
     {
         bytes memory initData = abi.encodeCall(
-            FeesDepositor.initialize, (_minDepositAmount, _l2Recipient, IL1CrossDomainMessenger(_messenger), _gasLimit)
+            IFeesDepositor.initialize, (_minDepositAmount, _l2Recipient, IL1CrossDomainMessenger(_messenger), _gasLimit)
         );
 
-        console.log("Proxy admin:", deployer);
-        console.logBytes32(
-            vm.load(address(_output.feesDepositorProxy), bytes32(uint256(keccak256("eip1967.proxy.admin")) - 1))
-        );
         vm.broadcast(deployer);
-        IProxy(payable(_output.feesDepositorProxy))
-            .upgradeToAndCall({ _implementation: _output.feesDepositorImpl, _data: initData });
+        IProxy(_feesDepositorProxy)
+            .upgradeToAndCall({ _implementation: address(_feesDepositorImpl), _data: initData });
     }
 
     /// @notice Transfers the ownership of the proxy to the final proxy.
     /// @param _proxyAdmin The address that will be the admin of the proxy.
-    function transferToFinalProxyAdmin(address _proxyAdmin, Output memory _output) internal {
+    function transferToFinalProxyAdmin(address _proxyAdmin, IProxy _feesDepositorProxy) internal {
         vm.broadcast(deployer);
-        IProxy(payable(_output.feesDepositorProxy)).changeAdmin(_proxyAdmin);
+        _feesDepositorProxy.changeAdmin(_proxyAdmin);
     }
 
     /// @notice Validates the input parameters.
@@ -154,11 +134,12 @@ contract DeployFeesDepositor is Script {
     }
 
     /// @notice Logs the deployment results.
-    /// @param _output The deployment output addresses.
-    function logResults(Output memory _output) internal view {
+    /// @param _feesDepositorImpl The deployed FeesDepositor implementation address.
+    /// @param _feesDepositorProxy The deployed FeesDepositor proxy address.
+    function logResults(IFeesDepositor _feesDepositorImpl, IProxy _feesDepositorProxy) internal view {
         console.log("=== FeesDepositor Deployment ===");
-        console.log("Implementation:", _output.feesDepositorImpl);
-        console.log("Proxy:", _output.feesDepositorProxy);
+        console.log("Implementation:", address(_feesDepositorImpl));
+        console.log("Proxy:", address(_feesDepositorProxy));
         console.log("================================");
     }
 }

--- a/packages/contracts-bedrock/test/opcm/DeployFeesDepositor.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployFeesDepositor.t.sol
@@ -123,4 +123,3 @@ contract DeployFeesDepositor_Test is Test {
         assertEq(feesDepositor.gasLimit(), defaultGasLimit, "GasLimit mismatch");
     }
 }
-

--- a/packages/contracts-bedrock/test/opcm/DeployFeesDepositor.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployFeesDepositor.t.sol
@@ -43,29 +43,29 @@ contract DeployFeesDepositor_Test is Test {
         vm.assume(_gasLimit > 0);
 
         // Run the deployment script.
-        DeployFeesDepositor.Output memory output1 =
+        (IFeesDepositor feesDepositorImpl, IProxy feesDepositorProxy) =
             deployFeesDepositor.run(_proxyAdmin, _minDepositAmount, _l2Recipient, _messenger, _gasLimit);
 
         // Verify the implementation is deployed correctly.
         FeesDepositor impl = new FeesDepositor();
-        assertEq(output1.feesDepositorImpl.code, address(impl).code, "Implementation code mismatch");
+        assertEq(address(feesDepositorImpl).code, address(impl).code, "Implementation code mismatch");
 
         // Verify the proxy is deployed correctly.
         Proxy proxy = new Proxy(_proxyAdmin);
-        assertEq(output1.feesDepositorProxy.code, address(proxy).code, "Proxy code mismatch");
+        assertEq(address(feesDepositorProxy).code, address(proxy).code, "Proxy code mismatch");
 
         // Verify the proxy admin is set correctly.
-        assertEq(EIP1967Helper.getAdmin(output1.feesDepositorProxy), _proxyAdmin, "Proxy admin mismatch");
+        assertEq(EIP1967Helper.getAdmin(address(feesDepositorProxy)), _proxyAdmin, "Proxy admin mismatch");
 
         // Verify the proxy implementation is set correctly.
         assertEq(
-            EIP1967Helper.getImplementation(output1.feesDepositorProxy),
-            output1.feesDepositorImpl,
+            EIP1967Helper.getImplementation(address(feesDepositorProxy)),
+            address(feesDepositorImpl),
             "Proxy implementation mismatch"
         );
 
         // Verify the FeesDepositor is initialized correctly.
-        FeesDepositor feesDepositor = FeesDepositor(payable(output1.feesDepositorProxy));
+        FeesDepositor feesDepositor = FeesDepositor(payable(address(feesDepositorProxy)));
         assertEq(feesDepositor.minDepositAmount(), _minDepositAmount, "MinDepositAmount mismatch");
         assertEq(feesDepositor.l2Recipient(), _l2Recipient, "L2Recipient mismatch");
         assertEq(address(feesDepositor.messenger()), _messenger, "Messenger mismatch");
@@ -103,20 +103,20 @@ contract DeployFeesDepositor_Test is Test {
     }
 
     function test_run_defaultInput_succeeds() public {
-        DeployFeesDepositor.Output memory output = deployFeesDepositor.run(
+        (IFeesDepositor feesDepositorImpl, IProxy feesDepositorProxy) = deployFeesDepositor.run(
             defaultProxyAdmin, defaultMinDepositAmount, defaultL2Recipient, address(defaultMessenger), defaultGasLimit
         );
 
         // Verify addresses are non-zero.
-        assertNotEq(output.feesDepositorImpl, address(0), "Implementation address is zero");
-        assertNotEq(output.feesDepositorProxy, address(0), "Proxy address is zero");
+        assertNotEq(address(feesDepositorImpl), address(0), "Implementation address is zero");
+        assertNotEq(address(feesDepositorProxy), address(0), "Proxy address is zero");
 
         // Verify contracts have code.
-        assertGt(output.feesDepositorImpl.code.length, 0, "Implementation has no code");
-        assertGt(output.feesDepositorProxy.code.length, 0, "Proxy has no code");
+        assertGt(address(feesDepositorImpl).code.length, 0, "Implementation has no code");
+        assertGt(address(feesDepositorProxy).code.length, 0, "Proxy has no code");
 
         // Verify the FeesDepositor is initialized correctly.
-        FeesDepositor feesDepositor = FeesDepositor(payable(output.feesDepositorProxy));
+        IFeesDepositor feesDepositor = IFeesDepositor(payable(address(feesDepositorProxy)));
         assertEq(feesDepositor.minDepositAmount(), defaultMinDepositAmount, "MinDepositAmount mismatch");
         assertEq(feesDepositor.l2Recipient(), defaultL2Recipient, "L2Recipient mismatch");
         assertEq(address(feesDepositor.messenger()), address(defaultMessenger), "Messenger mismatch");

--- a/packages/contracts-bedrock/test/opcm/DeployFeesDepositor.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployFeesDepositor.t.sol
@@ -13,6 +13,8 @@ import { FeesDepositor } from "src/L1/FeesDepositor.sol";
 import { Proxy } from "src/universal/Proxy.sol";
 import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 
+/// @title DeployFeesDepositor_Test
+/// @notice This test is used to test the DeployFeesDepositor script.
 contract DeployFeesDepositor_Test is Test {
     DeployFeesDepositor deployFeesDepositor;
 
@@ -23,10 +25,12 @@ contract DeployFeesDepositor_Test is Test {
     uint96 defaultMinDepositAmount = 1 ether;
     uint32 defaultGasLimit = 200_000;
 
+    /// @notice Sets up the test suite.
     function setUp() public {
         deployFeesDepositor = new DeployFeesDepositor();
     }
 
+    /// @notice Tests that the DeployFeesDepositor script succeeds with valid fuzzed input values.
     function testFuzz_run_succeeds(
         address _proxyAdmin,
         uint96 _minDepositAmount,
@@ -72,6 +76,7 @@ contract DeployFeesDepositor_Test is Test {
         assertEq(feesDepositor.gasLimit(), _gasLimit, "GasLimit mismatch");
     }
 
+    /// @notice Tests that the DeployFeesDepositor script reverts when called with zero input values.
     function test_run_nullInput_reverts() public {
         // Test zero proxyAdmin
         vm.expectRevert("DeployFeesDepositor: proxyAdmin cannot be zero address");
@@ -102,6 +107,7 @@ contract DeployFeesDepositor_Test is Test {
         );
     }
 
+    /// @notice Tests that the DeployFeesDepositor script succeeds when called with default input values.
     function test_run_defaultInput_succeeds() public {
         (IFeesDepositor feesDepositorImpl, IProxy feesDepositorProxy) = deployFeesDepositor.run(
             defaultProxyAdmin, defaultMinDepositAmount, defaultL2Recipient, address(defaultMessenger), defaultGasLimit

--- a/packages/contracts-bedrock/test/opcm/DeployFeesDepositor.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployFeesDepositor.t.sol
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { Test } from "forge-std/Test.sol";
+
+// Interfaces
+import { IFeesDepositor } from "interfaces/L1/IFeesDepositor.sol";
+import { IL1CrossDomainMessenger } from "interfaces/L1/IL1CrossDomainMessenger.sol";
+import { IProxy } from "interfaces/universal/IProxy.sol";
+
+import { DeployFeesDepositor } from "scripts/deploy/DeployFeesDepositor.s.sol";
+import { FeesDepositor } from "src/L1/FeesDepositor.sol";
+import { Proxy } from "src/universal/Proxy.sol";
+import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
+
+contract DeployFeesDepositor_Test is Test {
+    DeployFeesDepositor deployFeesDepositor;
+
+    // Define default input variables for testing.
+    address defaultProxyAdmin = makeAddr("defaultProxyAdmin");
+    address defaultL2Recipient = makeAddr("defaultL2Recipient");
+    IL1CrossDomainMessenger defaultMessenger = IL1CrossDomainMessenger(makeAddr("defaultMessenger"));
+    uint96 defaultMinDepositAmount = 1 ether;
+    uint32 defaultGasLimit = 200_000;
+
+    function setUp() public {
+        deployFeesDepositor = new DeployFeesDepositor();
+    }
+
+    function testFuzz_run_succeeds(
+        address _proxyAdmin,
+        uint96 _minDepositAmount,
+        address _l2Recipient,
+        address _messenger,
+        uint32 _gasLimit
+    )
+        public
+    {
+        vm.assume(_proxyAdmin != address(0));
+        vm.assume(_l2Recipient != address(0));
+        vm.assume(_messenger != address(0));
+        vm.assume(_minDepositAmount > 0);
+        vm.assume(_gasLimit > 0);
+
+        // Run the deployment script.
+        DeployFeesDepositor.Output memory output1 =
+            deployFeesDepositor.run(_proxyAdmin, _minDepositAmount, _l2Recipient, _messenger, _gasLimit);
+
+        // Verify the implementation is deployed correctly.
+        FeesDepositor impl = new FeesDepositor();
+        assertEq(output1.feesDepositorImpl.code, address(impl).code, "Implementation code mismatch");
+
+        // Verify the proxy is deployed correctly.
+        Proxy proxy = new Proxy(_proxyAdmin);
+        assertEq(output1.feesDepositorProxy.code, address(proxy).code, "Proxy code mismatch");
+
+        // Verify the proxy admin is set correctly.
+        assertEq(EIP1967Helper.getAdmin(output1.feesDepositorProxy), _proxyAdmin, "Proxy admin mismatch");
+
+        // Verify the proxy implementation is set correctly.
+        assertEq(
+            EIP1967Helper.getImplementation(output1.feesDepositorProxy),
+            output1.feesDepositorImpl,
+            "Proxy implementation mismatch"
+        );
+
+        // Verify the FeesDepositor is initialized correctly.
+        FeesDepositor feesDepositor = FeesDepositor(payable(output1.feesDepositorProxy));
+        assertEq(feesDepositor.minDepositAmount(), _minDepositAmount, "MinDepositAmount mismatch");
+        assertEq(feesDepositor.l2Recipient(), _l2Recipient, "L2Recipient mismatch");
+        assertEq(address(feesDepositor.messenger()), _messenger, "Messenger mismatch");
+        assertEq(feesDepositor.gasLimit(), _gasLimit, "GasLimit mismatch");
+    }
+
+    function test_run_nullInput_reverts() public {
+        // Test zero proxyAdmin
+        vm.expectRevert("DeployFeesDepositor: proxyAdmin cannot be zero address");
+        deployFeesDepositor.run(
+            address(0), defaultMinDepositAmount, defaultL2Recipient, address(defaultMessenger), defaultGasLimit
+        );
+
+        // Test zero l2Recipient
+        vm.expectRevert("DeployFeesDepositor: l2Recipient cannot be zero address");
+        deployFeesDepositor.run(
+            defaultProxyAdmin, defaultMinDepositAmount, address(0), address(defaultMessenger), defaultGasLimit
+        );
+
+        // Test zero messenger
+        vm.expectRevert("DeployFeesDepositor: messenger cannot be zero address");
+        deployFeesDepositor.run(
+            defaultProxyAdmin, defaultMinDepositAmount, defaultL2Recipient, address(0), defaultGasLimit
+        );
+
+        // Test zero minDepositAmount
+        vm.expectRevert("DeployFeesDepositor: minDepositAmount must be greater than zero");
+        deployFeesDepositor.run(defaultProxyAdmin, 0, defaultL2Recipient, address(defaultMessenger), defaultGasLimit);
+
+        // Test zero gasLimit
+        vm.expectRevert("DeployFeesDepositor: gasLimit must be greater than zero");
+        deployFeesDepositor.run(
+            defaultProxyAdmin, defaultMinDepositAmount, defaultL2Recipient, address(defaultMessenger), 0
+        );
+    }
+
+    function test_run_defaultInput_succeeds() public {
+        DeployFeesDepositor.Output memory output = deployFeesDepositor.run(
+            defaultProxyAdmin, defaultMinDepositAmount, defaultL2Recipient, address(defaultMessenger), defaultGasLimit
+        );
+
+        // Verify addresses are non-zero.
+        assertNotEq(output.feesDepositorImpl, address(0), "Implementation address is zero");
+        assertNotEq(output.feesDepositorProxy, address(0), "Proxy address is zero");
+
+        // Verify contracts have code.
+        assertGt(output.feesDepositorImpl.code.length, 0, "Implementation has no code");
+        assertGt(output.feesDepositorProxy.code.length, 0, "Proxy has no code");
+
+        // Verify the FeesDepositor is initialized correctly.
+        FeesDepositor feesDepositor = FeesDepositor(payable(output.feesDepositorProxy));
+        assertEq(feesDepositor.minDepositAmount(), defaultMinDepositAmount, "MinDepositAmount mismatch");
+        assertEq(feesDepositor.l2Recipient(), defaultL2Recipient, "L2Recipient mismatch");
+        assertEq(address(feesDepositor.messenger()), address(defaultMessenger), "Messenger mismatch");
+        assertEq(feesDepositor.gasLimit(), defaultGasLimit, "GasLimit mismatch");
+    }
+}
+


### PR DESCRIPTION
**Description**

Adds a script for deploying the `FeesDepositor`. This script follows the pattern of other existing 'one off' deployment scripts (ie. `DeployMips2.s.sol`) as well as the tests of those scripts. 

