### PR TITLE
cannon: Fix shutdown process to ensure preimage server channels are closed

### DIFF
--- a/cannon/cmd/run.go
+++ b/cannon/cmd/run.go
@@ -262,16 +262,7 @@ func (p *ProcessPreimageOracle) Close() error {
 		return err
 	}
 
-	// Demand the process exit
-	p.log.Warn("Preimage server process did not exit on interrupt signal, sending kill signal")
-	if err := p.cmd.Process.Signal(os.Kill); err != nil {
-		p.log.Warn("Failed to send kill signal to preimage server process", "err", err)
-	}
-	if exited, err := tryWait(30 * time.Second); exited {
-		return err
-	}
-
-	// No more Mr Nice Guy, just terminate the process
+	// Just terminate the process
 	p.log.Warn("Preimage server process would not exit cleanly, terminating")
 	if err := p.cmd.Process.Kill(); err != nil {
 		p.log.Warn("Failed to kill preimage server process", "err", err)

--- a/cannon/cmd/run.go
+++ b/cannon/cmd/run.go
@@ -147,16 +147,18 @@ func (rk rawKey) PreimageKey() [32]byte {
 }
 
 type ProcessPreimageOracle struct {
-	pCl      *preimage.OracleClient
-	hCl      *preimage.HintWriter
-	cmd      *exec.Cmd
-	waitErr  chan error
-	cancelIO context.CancelCauseFunc
+	log       log.Logger
+	pCl       *preimage.OracleClient
+	hCl       *preimage.HintWriter
+	cmd       *exec.Cmd
+	waitErr   chan error
+	cancelIO  context.CancelCauseFunc
+	ioClosers ioutil.MultiCloser
 }
 
 const clientPollTimeout = time.Second * 15
 
-func NewProcessPreimageOracle(name string, args []string, stdout log.Logger, stderr log.Logger) (*ProcessPreimageOracle, error) {
+func NewProcessPreimageOracle(logger log.Logger, name string, args []string, stdout log.Logger, stderr log.Logger) (*ProcessPreimageOracle, error) {
 	if name == "" {
 		return &ProcessPreimageOracle{}, nil
 	}
@@ -188,11 +190,14 @@ func NewProcessPreimageOracle(name string, args []string, stdout log.Logger, std
 	preimageClientIO := preimage.NewFilePoller(ctx, pClientRW, clientPollTimeout)
 	hostClientIO := preimage.NewFilePoller(ctx, hClientRW, clientPollTimeout)
 	out := &ProcessPreimageOracle{
+		log:      logger,
 		pCl:      preimage.NewOracleClient(preimageClientIO),
 		hCl:      preimage.NewHintWriter(hostClientIO),
 		cmd:      cmd,
 		waitErr:  make(chan error),
 		cancelIO: cancelIO,
+		// We only close our side of the channels, the client program owns the side we pass through as extra files
+		ioClosers: ioutil.MultiCloser{preimageClientIO, hostClientIO},
 	}
 	return out, nil
 }
@@ -239,14 +244,38 @@ func (p *ProcessPreimageOracle) Close() error {
 	if exited, err := tryWait(1 * time.Second); exited {
 		return err
 	}
-	// Politely ask the process to exit and give it some more time
-	_ = p.cmd.Process.Signal(os.Interrupt)
+
+	// Close the IO streams to the preimage server to encourage it to exit
+	if err := p.ioClosers.Close(); err != nil {
+		p.log.Warn("Failed to close preimage oracle IO streams", "err", err)
+	}
 	if exited, err := tryWait(30 * time.Second); exited {
 		return err
 	}
 
-	// Force the process to exit
-	_ = p.cmd.Process.Signal(os.Kill)
+	// Politely ask the process to exit
+	p.log.Info("Preimage server process did not exit when streams closed, sending interrupt signal")
+	if err := p.cmd.Process.Signal(os.Interrupt); err != nil {
+		p.log.Warn("Failed to send interrupt signal to preimage server process", "err", err)
+	}
+	if exited, err := tryWait(30 * time.Second); exited {
+		return err
+	}
+
+	// Demand the process exit
+	p.log.Warn("Preimage server process did not exit on interrupt signal, sending kill signal")
+	if err := p.cmd.Process.Signal(os.Kill); err != nil {
+		p.log.Warn("Failed to send kill signal to preimage server process", "err", err)
+	}
+	if exited, err := tryWait(30 * time.Second); exited {
+		return err
+	}
+
+	// No more Mr Nice Guy, just terminate the process
+	p.log.Warn("Preimage server process would not exit cleanly, terminating")
+	if err := p.cmd.Process.Kill(); err != nil {
+		p.log.Warn("Failed to kill preimage server process", "err", err)
+	}
 	return <-p.waitErr
 }
 
@@ -367,7 +396,7 @@ func Run(ctx *cli.Context) error {
 
 	poOut := Logger(os.Stdout, log.LevelInfo).With("module", "host")
 	poErr := Logger(os.Stderr, log.LevelInfo).With("module", "host")
-	po, err := NewProcessPreimageOracle(args[0], args[1:], poOut, poErr)
+	po, err := NewProcessPreimageOracle(l, args[0], args[1:], poOut, poErr)
 	if err != nil {
 		return fmt.Errorf("failed to create pre-image oracle process: %w", err)
 	}

--- a/op-service/ioutil/multi_closer.go
+++ b/op-service/ioutil/multi_closer.go
@@ -1,0 +1,19 @@
+package ioutil
+
+import (
+	"errors"
+	"io"
+)
+
+// MultiCloser is a simple type that supports combining multiple io.Closer instances into a single io.Closer
+type MultiCloser []io.Closer
+
+func (m MultiCloser) Close() error {
+	var err error
+	for _, c := range m {
+		if e := c.Close(); e != nil {
+			err = errors.Join(err, e)
+		}
+	}
+	return err
+}

--- a/op-service/ioutil/multi_closer_test.go
+++ b/op-service/ioutil/multi_closer_test.go
@@ -1,0 +1,65 @@
+package ioutil
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMultiCloser(t *testing.T) {
+	t.Run("Empty", func(t *testing.T) {
+		closer := &MultiCloser{}
+		require.NoError(t, closer.Close())
+	})
+
+	t.Run("Single", func(t *testing.T) {
+		closee1 := &testCloser{}
+		closer := &MultiCloser{closee1}
+		require.NoError(t, closer.Close())
+		require.True(t, closee1.closed)
+	})
+
+	t.Run("Multiple", func(t *testing.T) {
+		closee1 := &testCloser{}
+		closee2 := &testCloser{}
+		closee3 := &testCloser{}
+		closer := &MultiCloser{closee1, closee2, closee3}
+		require.NoError(t, closer.Close())
+		require.True(t, closee1.closed)
+		require.True(t, closee2.closed)
+		require.True(t, closee3.closed)
+	})
+
+	t.Run("ErrorOnFirst", func(t *testing.T) {
+		closee1 := &testCloser{err: errors.New("first error")}
+		closee2 := &testCloser{}
+		closer := &MultiCloser{closee1, closee2}
+		require.ErrorIs(t, closer.Close(), closee1.err)
+		require.True(t, closee1.closed)
+		require.True(t, closee2.closed, "Should still close closee2")
+	})
+
+	t.Run("ErrorOnMultiple", func(t *testing.T) {
+		closee1 := &testCloser{err: errors.New("first error")}
+		closee2 := &testCloser{err: errors.New("second error")}
+		closee3 := &testCloser{}
+		closer := &MultiCloser{closee1, closee2, closee3}
+		// Returned error should combine all returned errors
+		require.ErrorIs(t, closer.Close(), closee1.err)
+		require.ErrorIs(t, closer.Close(), closee2.err)
+		require.True(t, closee1.closed)
+		require.True(t, closee2.closed, "Should still close closee2")
+		require.True(t, closee3.closed, "Should still close closee3")
+	})
+}
+
+type testCloser struct {
+	closed bool
+	err    error
+}
+
+func (t *testCloser) Close() error {
+	t.closed = true
+	return t.err
+}


### PR DESCRIPTION
**Description**

kona-host wasn't exiting when the client program completed leaving cannon hung forever. Closing the file channels sends a signal it actually listens to so it exits. Also strengthen the fallbacks to ultimately terminate the subprocess forcefully if it ignores even the KILL signal.

The cannon-kona AT is still failing because it doesn't support ws URLs (needs https://github.com/op-rs/kona/pull/3022 and then pull in a new kona version in kona/justfile).

**Metadata**

https://github.com/ethereum-optimism/optimism/issues/17764
