### PR TITLE
op-challenger: Update version of kona-host in docker image to 1.2.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -769,6 +769,7 @@ jobs:
             fi
 
             # Let them cook!
+            KONA_VERSION=$(jq -r .version kona/version.json) \
             docker buildx bake \
               --progress plain \
               --builder=buildx-build \
@@ -1994,13 +1995,13 @@ jobs:
          checkout-method: blobless
       - restore_cache:
           name: Restore kona cache
-          key: kona-prestate-{{ checksum "./kona/justfile" }}
+          key: kona-prestate-{{ checksum "./kona/justfile" }}-{{ checksum "./kona/version.json" }}
       - run:
           name: Build kona prestates
           command: just build-prestates
           working_directory: kona
       - save_cache:
-          key: kona-prestate-{{ checksum "./kona/justfile" }}
+          key: kona-prestate-{{ checksum "./kona/justfile" }}-{{ checksum "./kona/version.json" }}
           name: Save Kona to cache
           paths:
             - "kona/prestates/"

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ include ./justfiles/flags.mk
 
 BEDROCK_TAGS_REMOTE?=origin
 OP_STACK_GO_BUILDER?=us-docker.pkg.dev/oplabs-tools-artifacts/images/op-stack-go:latest
+KONA_VERSION = 1.2.2
+DOCKER_TARGETS = op-node op-batcher op-proposer op-challenger op-dispute-mon op-supervisor
 
 # Requires at least Python v3.9; specify a minor version below if needed
 PYTHON?=python3
@@ -34,11 +36,12 @@ golang-docker: ## Builds Docker images for Go components using buildx
 	GIT_COMMIT=$$(git rev-parse HEAD) \
 	GIT_DATE=$$(git show -s --format='%ct') \
 	IMAGE_TAGS=$$(git rev-parse HEAD),latest \
+	KONA_VERSION=$$(jq -r .version kona/version.json) \
 	docker buildx bake \
 			--progress plain \
 			--load \
 			-f docker-bake.hcl \
-			op-node op-batcher op-proposer op-challenger op-dispute-mon op-supervisor
+			$(DOCKER_TARGETS)
 .PHONY: golang-docker
 
 docker-builder-clean: ## Removes the Docker buildx builder

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -7,7 +7,7 @@ variable "REPOSITORY" {
 }
 
 variable "KONA_VERSION" {
-  default = "1.2.0"
+  default = "1.2.2"
 }
 
 variable "ASTERISC_VERSION" {

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -7,7 +7,7 @@ variable "REPOSITORY" {
 }
 
 variable "KONA_VERSION" {
-  default = "1.2.2"
+  default = "none"
 }
 
 variable "ASTERISC_VERSION" {

--- a/kona/justfile
+++ b/kona/justfile
@@ -1,7 +1,7 @@
 KONA_DIR := `realpath .`
-KONA_VERSION := "kona-client/v1.2.2"
-KONA_PRESTATE_HASH := "0x03e183aa55db11aba6c1f2f7adccad15411d44fb54285e104cb73468927de0e7"
-KONA_INTEROP_PRESTATE_HASH := "0x033f554908ed264b81963ad6bf8a856c7c114af950df5a6fff67c5db85886083"
+KONA_VERSION := `jq -r .version ./version.json`
+KONA_PRESTATE_HASH := `jq -r .prestateHash ./version.json`
+KONA_INTEROP_PRESTATE_HASH := `jq -r .interopPrestateHash ./version.json`
 
 default: build-all
 
@@ -31,8 +31,15 @@ build-prestate VARIANT HASH:
     cd docker/fpvm-prestates
     # Delete any existing artifacts (they're in .gitignore so reset --hard won't delete them)
     rm -rf ../../prestate-artifacts-cannon
-    echo just cannon {{VARIANT}} "{{KONA_VERSION}}" $(cat ../../.config/cannon_tag)
-    just cannon {{VARIANT}} "{{KONA_VERSION}}" $(cat ../../.config/cannon_tag)
+    echo just cannon {{VARIANT}} "kona-client/v{{KONA_VERSION}}" $(cat ../../.config/cannon_tag)
+    just cannon {{VARIANT}} "kona-client/v{{KONA_VERSION}}" $(cat ../../.config/cannon_tag)
+
+    # Check the prestate hash matches what we expect
+    ACTUAL_HASH=$(jq -r .pre ../../prestate-artifacts-cannon/prestate-proof.json)
+    if [[ "${ACTUAL_HASH}" != "{{HASH}}" ]]; then
+      echo "Incorrect prestate hash, expected {{HASH}} but was ${ACTUAL_HASH}"
+      exit 1
+    fi
 
     mkdir -p "{{KONA_DIR}}/prestates"
     cp ../../prestate-artifacts-cannon/prestate.bin.gz "{{KONA_DIR}}/prestates/{{HASH}}.bin.gz"
@@ -46,7 +53,7 @@ build-kona-host:
     # which contains the kona version we're checking out. Locally you may need to run
     # just clean to force a rebuild if the kona version has changed.
     if [[ -f "bin/kona-host" ]]; then
-        echo "kona-host already built. Assuming it is built from {{KONA_VERSION}}"
+        echo "kona-host already built. Assuming it is built from kona-client/v{{KONA_VERSION}}"
         exit
     fi
 
@@ -68,10 +75,10 @@ checkout-kona:
     if [[ -d kona ]]; then
       cd kona
       git fetch origin
-      git checkout -f "{{KONA_VERSION}}"
+      git checkout -f "kona-client/v{{KONA_VERSION}}"
       git reset --hard HEAD
     else
-      git clone -b "{{KONA_VERSION}}" https://github.com/op-rs/kona kona
+      git clone -b "kona-client/v{{KONA_VERSION}}" https://github.com/op-rs/kona kona
       cd kona
     fi
 

--- a/kona/version.json
+++ b/kona/version.json
@@ -1,0 +1,5 @@
+{
+    "version": "1.2.2",
+    "prestateHash": "0x03e183aa55db11aba6c1f2f7adccad15411d44fb54285e104cb73468927de0e7",
+    "interopPrestateHash": "0x033f554908ed264b81963ad6bf8a856c7c114af950df5a6fff67c5db85886083"
+}

--- a/op-devstack/sysgo/superroot.go
+++ b/op-devstack/sysgo/superroot.go
@@ -7,7 +7,6 @@ import (
 	"math/big"
 	"os"
 	"path"
-	"regexp"
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
@@ -31,6 +30,7 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/lmittmann/w3"
 	w3eth "github.com/lmittmann/w3/module/eth"
+	"github.com/stretchr/testify/require"
 )
 
 func WithSuperRoots(l1ChainID eth.ChainID, l1ELID stack.L1ELNodeID, l2CLID stack.L2CLNodeID, supervisorID stack.SupervisorID, primaryL2 eth.ChainID) stack.Option[*Orchestrator] {
@@ -233,31 +233,30 @@ func getInteropCannonAbsolutePrestate(t devtest.CommonT) common.Hash {
 }
 
 func getInteropCannonKonaAbsolutePrestate(t devtest.CommonT) common.Hash {
-	return common.HexToHash(findKonaVariable(t, "KONA_INTEROP_PRESTATE_HASH"))
+	return loadKonaVersions(t, "KONA_INTEROP_PRESTATE_HASH").InteropPrestateHash
 }
 
 func getCannonKonaAbsolutePrestate(t devtest.CommonT) common.Hash {
-	return common.HexToHash(findKonaVariable(t, "KONA_PRESTATE_HASH"))
+	return loadKonaVersions(t, "KONA_PRESTATE_HASH").PrestateHash
 }
 
-func findKonaVariable(t devtest.CommonT, name string) string {
-	konaJustfilePath := "kona/justfile"
-	root, err := findMonorepoRoot(konaJustfilePath)
+func loadKonaVersions(t devtest.CommonT, name string) konaVersions {
+	konaVersionPath := "kona/version.json"
+	root, err := findMonorepoRoot(konaVersionPath)
 	t.Require().NoError(err)
-	p := path.Join(root, konaJustfilePath)
+	p := path.Join(root, konaVersionPath)
 	data, err := os.ReadFile(p)
-	t.Require().NoError(err, "Failed to read kona justfile")
-	justfileVariableMatcher := regexp.MustCompile("([_A-Z]+) := \"([^\"]*)\"")
-	variables := justfileVariableMatcher.FindAllStringSubmatch(string(data), -1)
-	for _, matches := range variables {
-		key := matches[1]
-		value := matches[2]
-		if key == name {
-			return value
-		}
-	}
-	t.Require().True(false, "Did not find required kona variable")
-	return ""
+	t.Require().NoError(err, "Failed to read kona versions")
+	var versions konaVersions
+	err = json.Unmarshal(data, &versions)
+	require.NoError(t, err, "Failed to parse kona versions")
+	return versions
+}
+
+type konaVersions struct {
+	Version             string      `json:"version"`
+	PrestateHash        common.Hash `json:"prestateHash"`
+	InteropPrestateHash common.Hash `json:"interPrestateHash"`
 }
 
 func getAbsolutePrestate(t devtest.CommonT, prestatePath string) common.Hash {

--- a/op-devstack/sysgo/superroot.go
+++ b/op-devstack/sysgo/superroot.go
@@ -233,14 +233,14 @@ func getInteropCannonAbsolutePrestate(t devtest.CommonT) common.Hash {
 }
 
 func getInteropCannonKonaAbsolutePrestate(t devtest.CommonT) common.Hash {
-	return loadKonaVersions(t, "KONA_INTEROP_PRESTATE_HASH").InteropPrestateHash
+	return loadKonaVersions(t).InteropPrestateHash
 }
 
 func getCannonKonaAbsolutePrestate(t devtest.CommonT) common.Hash {
-	return loadKonaVersions(t, "KONA_PRESTATE_HASH").PrestateHash
+	return loadKonaVersions(t).PrestateHash
 }
 
-func loadKonaVersions(t devtest.CommonT, name string) konaVersions {
+func loadKonaVersions(t devtest.CommonT) konaVersions {
 	konaVersionPath := "kona/version.json"
 	root, err := findMonorepoRoot(konaVersionPath)
 	t.Require().NoError(err)
@@ -256,7 +256,7 @@ func loadKonaVersions(t devtest.CommonT, name string) konaVersions {
 type konaVersions struct {
 	Version             string      `json:"version"`
 	PrestateHash        common.Hash `json:"prestateHash"`
-	InteropPrestateHash common.Hash `json:"interPrestateHash"`
+	InteropPrestateHash common.Hash `json:"interopPrestateHash"`
 }
 
 func getAbsolutePrestate(t devtest.CommonT, prestatePath string) common.Hash {


### PR DESCRIPTION
**Description**

Update version of Kona-host included in op-challenger docker image to 1.2.2.

Extracts the kona version from the `kona/justfile` to a separate JSON file so that we have a single source of truth for the kona version to use but is still very simple to parse in the Makefile etc.
