### PR TITLE
fix(op-faucet): explicitly define timeouts

### DIFF
--- a/op-faucet/faucet/backend/config/static.go
+++ b/op-faucet/faucet/backend/config/static.go
@@ -22,8 +22,8 @@ var DefaultFaucetTxManagerValues = txmgr.DefaultFlagValues{
 	MinBaseFeeGwei:            1.0,
 	ResubmissionTimeout:       24 * time.Second,
 	NetworkTimeout:            10 * time.Second,
-	TxSendTimeout:             2 * time.Minute,
-	TxNotInMempoolTimeout:     1 * time.Minute,
+	TxSendTimeout:             5 * time.Minute,
+	TxNotInMempoolTimeout:     2 * time.Minute,
 	ReceiptQueryInterval:      200 * time.Millisecond,
 }
 

--- a/op-faucet/faucet/backend/config/static.go
+++ b/op-faucet/faucet/backend/config/static.go
@@ -22,8 +22,8 @@ var DefaultFaucetTxManagerValues = txmgr.DefaultFlagValues{
 	MinBaseFeeGwei:            1.0,
 	ResubmissionTimeout:       24 * time.Second,
 	NetworkTimeout:            10 * time.Second,
-	TxSendTimeout:             5 * time.Minute,
-	TxNotInMempoolTimeout:     2 * time.Minute,
+	TxSendTimeout:             2 * time.Minute,
+	TxNotInMempoolTimeout:     90 * time.Second,
 	ReceiptQueryInterval:      200 * time.Millisecond,
 }
 

--- a/op-faucet/faucet/service.go
+++ b/op-faucet/faucet/service.go
@@ -162,10 +162,10 @@ func (s *Service) initHTTPServer(cfg *config.Config) error {
 	// This causes tests to fail if the faucet can't fund in the aforementioned time, even if the
 	// test timeout is longer
 	faucetTimeouts := httputil.HTTPTimeouts{
-		ReadTimeout:       6 * time.Minute,
+		ReadTimeout:       2 * time.Minute,
 		ReadHeaderTimeout: 30 * time.Second,
-		WriteTimeout:      6 * time.Minute,
-		IdleTimeout:       3 * time.Minute,
+		WriteTimeout:      2 * time.Minute,
+		IdleTimeout:       1 * time.Minute,
 	}
 
 	s.httpServer = httputil.NewHTTPServer(endpoint, s.rpcHandler,

--- a/op-faucet/faucet/service.go
+++ b/op-faucet/faucet/service.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"strconv"
 	"sync/atomic"
+	"time"
 
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -156,7 +157,19 @@ func (s *Service) initRPCHandler(cfg *config.Config) error {
 
 func (s *Service) initHTTPServer(cfg *config.Config) error {
 	endpoint := net.JoinHostPort(cfg.RPC.ListenAddr, strconv.Itoa(cfg.RPC.ListenPort))
-	s.httpServer = httputil.NewHTTPServer(endpoint, s.rpcHandler)
+
+	// Define new timeouts instead of the default of 30 seconds
+	// This causes tests to fail if the faucet can't fund in the aforementioned time, even if the
+	// test timeout is longer
+	faucetTimeouts := httputil.HTTPTimeouts{
+		ReadTimeout:       6 * time.Minute,
+		ReadHeaderTimeout: 30 * time.Second,
+		WriteTimeout:      6 * time.Minute,
+		IdleTimeout:       3 * time.Minute,
+	}
+
+	s.httpServer = httputil.NewHTTPServer(endpoint, s.rpcHandler,
+		httputil.WithHTTPOptions(httputil.WithTimeouts(faucetTimeouts)))
 	return nil
 }
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
When testing against sepolia l1 and devnets, sometimes the tests may fail due to a hidden timeout in op-faucet. This timeout is caused by the HTTP Server connection being dropped, in this PR we're explicitly defining these timeouts.

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
