### PR TITLE
fix(ci): publish-contract-artifacts disable parallel composite upload

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2220,8 +2220,9 @@ jobs:
       - notify-failures-on-develop
 
   publish-contract-artifacts:
-    machine: true
-    resource_class: ethereum-optimism/latitude-1
+    docker:
+      - image: <<pipeline.parameters.default_docker_image>>
+    resource_class: xlarge
     steps:
       - gcp-cli/install
       - gcp-oidc-authenticate:

--- a/packages/contracts-bedrock/scripts/ops/publish-artifacts.sh
+++ b/packages/contracts-bedrock/scripts/ops/publish-artifacts.sh
@@ -53,6 +53,7 @@ du -sh "$archive_name" | awk '{$1=$1};1' # trim leading whitespace
 echoerr "> Done."
 
 echoerr "> Uploading artifacts to GCS..."
+gcloud config set storage/parallel_composite_upload_enabled False
 gcloud --verbosity="info" storage cp "$archive_name" "gs://$DEPLOY_BUCKET/$archive_name"
 echoerr "> Done."
 

--- a/packages/contracts-bedrock/scripts/ops/publish-artifacts.sh
+++ b/packages/contracts-bedrock/scripts/ops/publish-artifacts.sh
@@ -53,6 +53,7 @@ du -sh "$archive_name" | awk '{$1=$1};1' # trim leading whitespace
 echoerr "> Done."
 
 echoerr "> Uploading artifacts to GCS..."
+# Force single-stream upload to improve reliability
 gcloud config set storage/parallel_composite_upload_enabled False
 gcloud --verbosity="info" storage cp "$archive_name" "gs://$DEPLOY_BUCKET/$archive_name"
 echoerr "> Done."


### PR DESCRIPTION
The `publish-contract-artifacts` job often hangs indefinitely and then times out after 20min ([example failure](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/106872/workflows/576bba2e-abd8-4492-8c0e-c225dd4113ce/jobs/4072200)). This pr attempts to improve reliability by disabling parallel composite uploads, and opting for the slower but simpler single-stream approach. The trade-off is uploads may take 2-3x longer, but thats only ~6min compared to current 2min. The improved reliability seems like a worthy trade.