### PR TITLE
op-deployer: include AnchorStateRegistry + Opcm components in state.json

### DIFF
--- a/op-deployer/pkg/deployer/opcm/opchain.go
+++ b/op-deployer/pkg/deployer/opcm/opchain.go
@@ -99,6 +99,7 @@ type ReadImplementationAddressesOutput struct {
 	OptimismPortalInterop        common.Address
 	EthLockbox                   common.Address `evm:"ethLockbox"`
 	SystemConfig                 common.Address
+	AnchorStateRegistry          common.Address
 	L1CrossDomainMessenger       common.Address
 	L1ERC721Bridge               common.Address
 	L1StandardBridge             common.Address
@@ -110,6 +111,11 @@ type ReadImplementationAddressesOutput struct {
 	PermissionedDisputeGameV2    common.Address
 	SuperFaultDisputeGame        common.Address
 	SuperPermissionedDisputeGame common.Address
+	OpcmDeployer                 common.Address
+	OpcmUpgrader                 common.Address
+	OpcmGameTypeAdder            common.Address
+	OpcmStandardValidator        common.Address
+	OpcmInteropMigrator          common.Address
 }
 
 type ReadImplementationAddressesScript script.DeployScriptWithOutput[ReadImplementationAddressesInput, ReadImplementationAddressesOutput]

--- a/op-deployer/pkg/deployer/pipeline/opchain.go
+++ b/op-deployer/pkg/deployer/pipeline/opchain.go
@@ -68,6 +68,7 @@ func DeployOPChain(env *Env, intent *state.Intent, st *state.State, chainID comm
 	st.ImplementationsDeployment.OptimismPortalInteropImpl = impls.OptimismPortalInterop
 	st.ImplementationsDeployment.EthLockboxImpl = impls.EthLockbox
 	st.ImplementationsDeployment.SystemConfigImpl = impls.SystemConfig
+	st.ImplementationsDeployment.AnchorStateRegistryImpl = impls.AnchorStateRegistry
 	st.ImplementationsDeployment.L1CrossDomainMessengerImpl = impls.L1CrossDomainMessenger
 	st.ImplementationsDeployment.L1Erc721BridgeImpl = impls.L1ERC721Bridge
 	st.ImplementationsDeployment.L1StandardBridgeImpl = impls.L1StandardBridge
@@ -77,6 +78,11 @@ func DeployOPChain(env *Env, intent *state.Intent, st *state.State, chainID comm
 	st.ImplementationsDeployment.PreimageOracleImpl = impls.PreimageOracleSingleton
 	st.ImplementationsDeployment.FaultDisputeGameV2Impl = impls.FaultDisputeGameV2
 	st.ImplementationsDeployment.PermissionedDisputeGameV2Impl = impls.PermissionedDisputeGameV2
+	st.ImplementationsDeployment.OpcmDeployerImpl = impls.OpcmDeployer
+	st.ImplementationsDeployment.OpcmGameTypeAdderImpl = impls.OpcmGameTypeAdder
+	st.ImplementationsDeployment.OpcmUpgraderImpl = impls.OpcmUpgrader
+	st.ImplementationsDeployment.OpcmInteropMigratorImpl = impls.OpcmInteropMigrator
+	st.ImplementationsDeployment.OpcmStandardValidatorImpl = impls.OpcmStandardValidator
 
 	return nil
 }

--- a/packages/contracts-bedrock/scripts/deploy/ReadImplementationAddresses.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/ReadImplementationAddresses.s.sol
@@ -27,6 +27,7 @@ contract ReadImplementationAddresses is Script {
         address optimismPortalInterop;
         address ethLockbox;
         address systemConfig;
+        address anchorStateRegistry;
         address l1CrossDomainMessenger;
         address l1ERC721Bridge;
         address l1StandardBridge;
@@ -38,6 +39,11 @@ contract ReadImplementationAddresses is Script {
         address permissionedDisputeGameV2;
         address superFaultDisputeGame;
         address superPermissionedDisputeGame;
+        address opcmDeployer;
+        address opcmUpgrader;
+        address opcmGameTypeAdder;
+        address opcmStandardValidator;
+        address opcmInteropMigrator;
     }
 
     function run(Input memory _input) public returns (Output memory output_) {
@@ -55,14 +61,22 @@ contract ReadImplementationAddresses is Script {
 
         // Get implementations from OPCM
         IOPContractsManager opcm = IOPContractsManager(_input.opcm);
-        output_.mipsSingleton = opcm.implementations().mipsImpl;
-        output_.delayedWETH = opcm.implementations().delayedWETHImpl;
-        output_.ethLockbox = opcm.implementations().ethLockboxImpl;
-        output_.optimismPortalInterop = opcm.implementations().optimismPortalInteropImpl;
-        output_.faultDisputeGameV2 = opcm.implementations().faultDisputeGameV2Impl;
-        output_.permissionedDisputeGameV2 = opcm.implementations().permissionedDisputeGameV2Impl;
-        output_.superFaultDisputeGame = opcm.implementations().superFaultDisputeGameImpl;
-        output_.superPermissionedDisputeGame = opcm.implementations().superPermissionedDisputeGameImpl;
+        output_.opcmGameTypeAdder = address(opcm.opcmGameTypeAdder());
+        output_.opcmDeployer = address(opcm.opcmDeployer());
+        output_.opcmUpgrader = address(opcm.opcmUpgrader());
+        output_.opcmInteropMigrator = address(opcm.opcmInteropMigrator());
+        output_.opcmStandardValidator = address(opcm.opcmStandardValidator());
+
+        IOPContractsManager.Implementations memory impls = opcm.implementations();
+        output_.mipsSingleton = impls.mipsImpl;
+        output_.delayedWETH = impls.delayedWETHImpl;
+        output_.ethLockbox = impls.ethLockboxImpl;
+        output_.anchorStateRegistry = impls.anchorStateRegistryImpl;
+        output_.optimismPortalInterop = impls.optimismPortalInteropImpl;
+        output_.faultDisputeGameV2 = impls.faultDisputeGameV2Impl;
+        output_.permissionedDisputeGameV2 = impls.permissionedDisputeGameV2Impl;
+        output_.superFaultDisputeGame = impls.superFaultDisputeGameImpl;
+        output_.superPermissionedDisputeGame = impls.superPermissionedDisputeGameImpl;
 
         // Get L1CrossDomainMessenger from AddressManager
         IAddressManager am = IAddressManager(_input.addressManager);


### PR DESCRIPTION
Previously the following addresses were always set to 0x000...000 in the op-deployer state.json output file even though they get deployed as part of the implementations contract bundle:
* AnchorStateRegistryImpl
* OpcmGameTypeAdderImpl
* OpcmDeployerImpl
* OpcmUpgraderImpl
* OpcmInteropMigratorImpl
* OpcmStandardValidatorImpl

To fix this, the ReadImplementations.s.sol script's output was updated to include those addresses, and the op-deployer code that invokes that script was updated to read the addresses and write them to the state.json.