### PR TITLE
fix(op-up): cancel RPC calls when HTTP client disconnects

### DIFF
--- a/op-up/main.go
+++ b/op-up/main.go
@@ -296,7 +296,7 @@ func proxyEL(stderr io.Writer, client client.RPC) error {
 		var rpcResult json.RawMessage
 
 		// Create a context with a timeout for the RPC call to the backend.
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second) // 30-second timeout
+		ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second) // 30-second timeout
 		defer cancel()                                                           // Ensure the context is cancelled to release resources
 
 		fmt.Fprintf(stderr, "%s\n", method)

--- a/op-up/main.go
+++ b/op-up/main.go
@@ -297,7 +297,7 @@ func proxyEL(stderr io.Writer, client client.RPC) error {
 
 		// Create a context with a timeout for the RPC call to the backend.
 		ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second) // 30-second timeout
-		defer cancel()                                                           // Ensure the context is cancelled to release resources
+		defer cancel() // Ensure the context is cancelled to release resources
 
 		fmt.Fprintf(stderr, "%s\n", method)
 


### PR DESCRIPTION


The `proxyEL` function creates RPC call contexts using `context.Background()`, which means backend RPC calls continue executing even when the HTTP client disconnects. This leads to resource leaks and unnecessary backend load.

