### PR TITLE
feat: contracts changes required for OPCMv2

### DIFF
--- a/packages/contracts-bedrock/interfaces/L1/ISystemConfig.sol
+++ b/packages/contracts-bedrock/interfaces/L1/ISystemConfig.sol
@@ -23,6 +23,7 @@ interface ISystemConfig is IProxyAdminOwnedBase {
         address l1StandardBridge;
         address optimismPortal;
         address optimismMintableERC20Factory;
+        address delayedWETH;
     }
 
     error ReinitializableBase_ZeroInitVersion();
@@ -39,6 +40,7 @@ interface ISystemConfig is IProxyAdminOwnedBase {
     function L1_STANDARD_BRIDGE_SLOT() external view returns (bytes32);
     function OPTIMISM_MINTABLE_ERC20_FACTORY_SLOT() external view returns (bytes32);
     function OPTIMISM_PORTAL_SLOT() external view returns (bytes32);
+    function DELAYED_WETH_SLOT() external view returns (bytes32);
     function START_BLOCK_SLOT() external view returns (bytes32);
     function UNSAFE_BLOCK_SIGNER_SLOT() external view returns (bytes32);
     function VERSION() external view returns (uint256);
@@ -78,6 +80,7 @@ interface ISystemConfig is IProxyAdminOwnedBase {
     function daFootprintGasScalar() external view returns (uint16);
     function optimismMintableERC20Factory() external view returns (address addr_);
     function optimismPortal() external view returns (address addr_);
+    function delayedWETH() external view returns (address addr_);
     function overhead() external view returns (uint256);
     function owner() external view returns (address);
     function renounceOwnership() external;

--- a/packages/contracts-bedrock/snapshots/abi/SystemConfig.json
+++ b/packages/contracts-bedrock/snapshots/abi/SystemConfig.json
@@ -19,6 +19,19 @@
   },
   {
     "inputs": [],
+    "name": "DELAYED_WETH_SLOT",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
     "name": "L1_CROSS_DOMAIN_MESSENGER_SLOT",
     "outputs": [
       {
@@ -188,6 +201,19 @@
   },
   {
     "inputs": [],
+    "name": "delayedWETH",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "addr_",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
     "name": "disputeGameFactory",
     "outputs": [
       {
@@ -267,6 +293,11 @@
           {
             "internalType": "address",
             "name": "optimismMintableERC20Factory",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "delayedWETH",
             "type": "address"
           }
         ],
@@ -403,6 +434,11 @@
           {
             "internalType": "address",
             "name": "optimismMintableERC20Factory",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "delayedWETH",
             "type": "address"
           }
         ],

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -24,8 +24,8 @@
     "sourceCodeHash": "0xfca613b5d055ffc4c3cbccb0773ddb9030abedc1aa6508c9e2e7727cc0cd617b"
   },
   "src/L1/OPContractsManager.sol:OPContractsManager": {
-    "initCodeHash": "0x6bf74671476f7a6c5d35cad90e16c7d0c1b1e7c4d33fb5f8e0966e1e3ca9cfe8",
-    "sourceCodeHash": "0x1e5421e93901d3a2b1c6021acf71b443bf66af4a9710ddbb331b1f8419e90dde"
+    "initCodeHash": "0x7d38768f50c33e2029508c887b5bcf80119ac7d7b77b25cfb70a1b96e99f3bf9",
+    "sourceCodeHash": "0x642ca11e3e067d05643e2cc871c906ca70d1f9154d8c8a1efccf9a754bca78eb"
   },
   "src/L1/OPContractsManagerStandardValidator.sol:OPContractsManagerStandardValidator": {
     "initCodeHash": "0x0c8b15453d0f0bc5d9af07f104505e0bbb2b358f0df418289822fb73a8652b30",
@@ -48,8 +48,8 @@
     "sourceCodeHash": "0xbf344c4369b8cb00ec7a3108f72795747f3bc59ab5b37ac18cf21e72e2979dbf"
   },
   "src/L1/SystemConfig.sol:SystemConfig": {
-    "initCodeHash": "0xe36ea91f876df8ee99f700cc691919e74a2f06b68c2774de58d5027f74ecb930",
-    "sourceCodeHash": "0x18ebe840a448ad52ca6f0864c90c475c8622958900f2296e8a7cdfb8cc5cc512"
+    "initCodeHash": "0x4a4d7e60fc65777a2faaf34c31d1fa310299b5e3384ac1c77ef42d9051a9b14d",
+    "sourceCodeHash": "0xba941a73e213fdfbdf4ac0f8717e8f60036ca0bb421f9b08adcc1447f25cb477"
   },
   "src/L2/BaseFeeVault.sol:BaseFeeVault": {
     "initCodeHash": "0x838bbd7f381e84e21887f72bd1da605bfc4588b3c39aed96cbce67c09335b3ee",
@@ -164,8 +164,8 @@
     "sourceCodeHash": "0x03c160168986ffc8d26a90c37366e7ad6da03f49d83449e1f8b3de0f4b590f6f"
   },
   "src/dispute/AnchorStateRegistry.sol:AnchorStateRegistry": {
-    "initCodeHash": "0x9bb9cd78ac1d15844fbff2e7c759f2c949f3aa1a8d950d54ddb4b1ed88863239",
-    "sourceCodeHash": "0xf2715ff5393244742428454e1661aae7a56433867ee7bc563f44ad572c492d82"
+    "initCodeHash": "0xb761ca2d38cb744cd3cb8a571ea543a74a6e79ffa16316609d6ca78e949b87fb",
+    "sourceCodeHash": "0x7e1810270aaa863f782b830920ebc2f914d6d12b535f7cdf8b58d2c46aaf01d0"
   },
   "src/dispute/DelayedWETH.sol:DelayedWETH": {
     "initCodeHash": "0xa8f60e142108b33675a8f6b6979c73b96eea247884842d796f9f878904c0a906",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -25,7 +25,7 @@
   },
   "src/L1/OPContractsManager.sol:OPContractsManager": {
     "initCodeHash": "0x7d38768f50c33e2029508c887b5bcf80119ac7d7b77b25cfb70a1b96e99f3bf9",
-    "sourceCodeHash": "0x642ca11e3e067d05643e2cc871c906ca70d1f9154d8c8a1efccf9a754bca78eb"
+    "sourceCodeHash": "0xfa88a187cf10da53170190b77edd2b366501302e9cf1cce06a03a1c7f1eaa1e5"
   },
   "src/L1/OPContractsManagerStandardValidator.sol:OPContractsManagerStandardValidator": {
     "initCodeHash": "0x0c8b15453d0f0bc5d9af07f104505e0bbb2b358f0df418289822fb73a8652b30",

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -960,6 +960,10 @@ contract OPContractsManagerUpgrader is OPContractsManagerBase {
             upgradeTo(proxyAdmin, address(optimismPortal), _impls.optimismPortalImpl);
         }
 
+        // Upgrade the AnchorStateRegistry contract. No upgrade/initializer needed, just updating
+        // the implementation to latest.
+        upgradeTo(proxyAdmin, address(optimismPortal.anchorStateRegistry()), _impls.anchorStateRegistryImpl);
+
         // Upgrade the OptimismMintableERC20Factory contract.
         upgradeTo(
             proxyAdmin,

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -1573,8 +1573,9 @@ contract OPContractsManagerDeployer is OPContractsManagerBase {
             l1ERC721Bridge: address(_output.l1ERC721BridgeProxy),
             l1StandardBridge: address(_output.l1StandardBridgeProxy),
             optimismPortal: address(_output.optimismPortalProxy),
-            optimismMintableERC20Factory: address(_output.optimismMintableERC20FactoryProxy)
-        });
+            optimismMintableERC20Factory: address(_output.optimismMintableERC20FactoryProxy),
+            delayedWETH: address(0) // Will be used in OPCMv2.
+         });
 
         assertValidContractAddress(opChainAddrs_.l1CrossDomainMessenger);
         assertValidContractAddress(opChainAddrs_.l1ERC721Bridge);
@@ -2208,9 +2209,9 @@ contract OPContractsManager is ISemver {
 
     // -------- Constants and Variables --------
 
-    /// @custom:semver 5.6.0
+    /// @custom:semver 5.7.0
     function version() public pure virtual returns (string memory) {
-        return "5.6.0";
+        return "5.7.0";
     }
 
     OPContractsManagerGameTypeAdder public immutable opcmGameTypeAdder;

--- a/packages/contracts-bedrock/src/L1/SystemConfig.sol
+++ b/packages/contracts-bedrock/src/L1/SystemConfig.sol
@@ -52,6 +52,7 @@ contract SystemConfig is ProxyAdminOwnedBase, OwnableUpgradeable, Reinitializabl
         address l1StandardBridge;
         address optimismPortal;
         address optimismMintableERC20Factory;
+        address delayedWETH;
     }
 
     /// @notice Version identifier, used for upgrades.
@@ -83,6 +84,9 @@ contract SystemConfig is ProxyAdminOwnedBase, OwnableUpgradeable, Reinitializabl
     /// @notice Storage slot that the OptimismMintableERC20Factory address is stored at.
     bytes32 public constant OPTIMISM_MINTABLE_ERC20_FACTORY_SLOT =
         bytes32(uint256(keccak256("systemconfig.optimismmintableerc20factory")) - 1);
+
+    /// @notice Storage slot that the DelayedWETH address is stored at.
+    bytes32 public constant DELAYED_WETH_SLOT = bytes32(uint256(keccak256("systemconfig.delayedweth")) - 1);
 
     /// @notice Storage slot that the batch inbox address is stored at.
     bytes32 public constant BATCH_INBOX_SLOT = bytes32(uint256(keccak256("systemconfig.batchinbox")) - 1);
@@ -166,9 +170,9 @@ contract SystemConfig is ProxyAdminOwnedBase, OwnableUpgradeable, Reinitializabl
     error SystemConfig_InvalidFeatureState();
 
     /// @notice Semantic version.
-    /// @custom:semver 3.11.0
+    /// @custom:semver 3.12.0
     function version() public pure virtual returns (string memory) {
-        return "3.11.0";
+        return "3.12.0";
     }
 
     /// @notice Constructs the SystemConfig contract.
@@ -228,7 +232,7 @@ contract SystemConfig is ProxyAdminOwnedBase, OwnableUpgradeable, Reinitializabl
         Storage.setAddress(L1_STANDARD_BRIDGE_SLOT, _addresses.l1StandardBridge);
         Storage.setAddress(OPTIMISM_PORTAL_SLOT, _addresses.optimismPortal);
         Storage.setAddress(OPTIMISM_MINTABLE_ERC20_FACTORY_SLOT, _addresses.optimismMintableERC20Factory);
-
+        Storage.setAddress(DELAYED_WETH_SLOT, _addresses.delayedWETH);
         _setStartBlock();
 
         _setResourceConfig(_config);
@@ -294,6 +298,11 @@ contract SystemConfig is ProxyAdminOwnedBase, OwnableUpgradeable, Reinitializabl
         addr_ = Storage.getAddress(OPTIMISM_MINTABLE_ERC20_FACTORY_SLOT);
     }
 
+    /// @notice Getter for the DelayedWETH address.
+    function delayedWETH() public view returns (address addr_) {
+        addr_ = Storage.getAddress(DELAYED_WETH_SLOT);
+    }
+
     /// @notice Consolidated getter for the Addresses struct.
     function getAddresses() external view returns (Addresses memory) {
         return Addresses({
@@ -301,7 +310,8 @@ contract SystemConfig is ProxyAdminOwnedBase, OwnableUpgradeable, Reinitializabl
             l1ERC721Bridge: l1ERC721Bridge(),
             l1StandardBridge: l1StandardBridge(),
             optimismPortal: optimismPortal(),
-            optimismMintableERC20Factory: optimismMintableERC20Factory()
+            optimismMintableERC20Factory: optimismMintableERC20Factory(),
+            delayedWETH: delayedWETH()
         });
     }
 

--- a/packages/contracts-bedrock/src/dispute/AnchorStateRegistry.sol
+++ b/packages/contracts-bedrock/src/dispute/AnchorStateRegistry.sol
@@ -25,8 +25,8 @@ import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 ///         be initialized with a more recent starting state which reduces the amount of required offchain computation.
 contract AnchorStateRegistry is ProxyAdminOwnedBase, Initializable, ReinitializableBase, ISemver {
     /// @notice Semantic version.
-    /// @custom:semver 3.5.0
-    string public constant version = "3.5.0";
+    /// @custom:semver 3.6.0
+    string public constant version = "3.6.0";
 
     /// @notice The dispute game finality delay in seconds.
     uint256 internal immutable DISPUTE_GAME_FINALITY_DELAY_SECONDS;
@@ -103,7 +103,16 @@ contract AnchorStateRegistry is ProxyAdminOwnedBase, Initializable, Reinitializa
         disputeGameFactory = _disputeGameFactory;
         startingAnchorRoot = _startingAnchorRoot;
         respectedGameType = _startingRespectedGameType;
-        retirementTimestamp = uint64(block.timestamp);
+
+        // Set the retirement timestamp to the current timestamp the first time the contract is
+        // initialized. This was originally done in U16a to guarantee that all games created before
+        // the initialization of the new AnchorStateRegistry would be retired. This is no longer
+        // required behavior but it's useful to maintain common behavior across all new and old
+        // AnchorStateRegistry instances. We don't set the retirement timestamp if already set to
+        // avoid retiring games when re-initializing the contract during an upgrade.
+        if (retirementTimestamp == 0) {
+            retirementTimestamp = uint64(block.timestamp);
+        }
     }
 
     /// @notice Returns whether the contract is paused.

--- a/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
+++ b/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
@@ -164,7 +164,8 @@ contract SystemConfig_Initialize_Test is SystemConfig_TestInit {
                 l1ERC721Bridge: address(0),
                 l1StandardBridge: address(0),
                 optimismPortal: address(0),
-                optimismMintableERC20Factory: address(0)
+                optimismMintableERC20Factory: address(0),
+                delayedWETH: address(0)
             }),
             _l2ChainId: 1234,
             _superchainConfig: ISuperchainConfig(address(0))
@@ -220,7 +221,8 @@ contract SystemConfig_Initialize_Test is SystemConfig_TestInit {
                 l1ERC721Bridge: address(0),
                 l1StandardBridge: address(0),
                 optimismPortal: address(0),
-                optimismMintableERC20Factory: address(0)
+                optimismMintableERC20Factory: address(0),
+                delayedWETH: address(0)
             }),
             _l2ChainId: 1234,
             _superchainConfig: ISuperchainConfig(address(0))
@@ -254,7 +256,8 @@ contract SystemConfig_StartBlock_Test is SystemConfig_TestInit {
                 l1ERC721Bridge: address(0),
                 l1StandardBridge: address(0),
                 optimismPortal: address(0),
-                optimismMintableERC20Factory: address(0)
+                optimismMintableERC20Factory: address(0),
+                delayedWETH: address(0)
             }),
             _l2ChainId: 1234,
             _superchainConfig: ISuperchainConfig(address(0))
@@ -285,7 +288,8 @@ contract SystemConfig_StartBlock_Test is SystemConfig_TestInit {
                 l1ERC721Bridge: address(0),
                 l1StandardBridge: address(0),
                 optimismPortal: address(0),
-                optimismMintableERC20Factory: address(0)
+                optimismMintableERC20Factory: address(0),
+                delayedWETH: address(0)
             }),
             _l2ChainId: 1234,
             _superchainConfig: ISuperchainConfig(address(0))
@@ -582,7 +586,8 @@ contract SystemConfig_SetResourceConfig_Test is SystemConfig_TestInit {
                 l1ERC721Bridge: address(0),
                 l1StandardBridge: address(0),
                 optimismPortal: address(0),
-                optimismMintableERC20Factory: address(0)
+                optimismMintableERC20Factory: address(0),
+                delayedWETH: address(0)
             }),
             _l2ChainId: 1234,
             _superchainConfig: ISuperchainConfig(address(0))

--- a/packages/contracts-bedrock/test/dispute/AnchorStateRegistry.t.sol
+++ b/packages/contracts-bedrock/test/dispute/AnchorStateRegistry.t.sol
@@ -81,6 +81,68 @@ contract AnchorStateRegistry_Initialize_Test is AnchorStateRegistry_TestInit {
         assertEq(val, anchorStateRegistry.initVersion());
     }
 
+    /// @notice Tests that the retirement timestamp is set on the first initialization.
+    function test_initialize_firstInitialization_setsRetirementTimestamp_succeeds() public {
+        skipIfForkTest("State has changed since initialization on a forked network.");
+
+        (Hash root, uint256 l2SequenceNumber) = anchorStateRegistry.getAnchorRoot();
+        GameType startingGameType = anchorStateRegistry.respectedGameType();
+
+        StorageSlot memory initSlot = ForgeArtifacts.getSlot("AnchorStateRegistry", "_initialized");
+        StorageSlot memory retirementSlot = ForgeArtifacts.getSlot("AnchorStateRegistry", "retirementTimestamp");
+        address proxyAdminOwner = anchorStateRegistry.proxyAdminOwner();
+
+        // Reset initialization and retirement timestamp state.
+        vm.store(address(anchorStateRegistry), bytes32(initSlot.slot), bytes32(0));
+        vm.store(address(anchorStateRegistry), bytes32(retirementSlot.slot), bytes32(0));
+
+        uint256 newTimestamp = block.timestamp + 100;
+        vm.warp(newTimestamp);
+        uint64 expectedTimestamp = uint64(newTimestamp);
+
+        vm.prank(proxyAdminOwner);
+        anchorStateRegistry.initialize(
+            systemConfig,
+            disputeGameFactory,
+            Proposal({ root: root, l2SequenceNumber: l2SequenceNumber }),
+            startingGameType
+        );
+
+        assertEq(anchorStateRegistry.retirementTimestamp(), expectedTimestamp);
+    }
+
+    /// @notice Tests that the retirement timestamp is unchanged during re-initialization.
+    function test_initialize_reinitialization_doesNotChangeRetirementTimestamp_succeeds() public {
+        skipIfForkTest("State has changed since initialization on a forked network.");
+
+        (Hash root, uint256 l2SequenceNumber) = anchorStateRegistry.getAnchorRoot();
+        GameType startingGameType = anchorStateRegistry.respectedGameType();
+
+        StorageSlot memory initSlot = ForgeArtifacts.getSlot("AnchorStateRegistry", "_initialized");
+        address proxyAdminOwner = anchorStateRegistry.proxyAdminOwner();
+
+        uint256 initialTimestamp = block.timestamp + 200;
+        vm.warp(initialTimestamp);
+        vm.prank(superchainConfig.guardian());
+        anchorStateRegistry.updateRetirementTimestamp();
+        uint64 originalTimestamp = anchorStateRegistry.retirementTimestamp();
+
+        uint256 reinitTimestamp = block.timestamp + 200;
+        vm.warp(reinitTimestamp);
+
+        vm.store(address(anchorStateRegistry), bytes32(initSlot.slot), bytes32(0));
+
+        vm.prank(proxyAdminOwner);
+        anchorStateRegistry.initialize(
+            systemConfig,
+            disputeGameFactory,
+            Proposal({ root: root, l2SequenceNumber: l2SequenceNumber }),
+            startingGameType
+        );
+
+        assertEq(anchorStateRegistry.retirementTimestamp(), originalTimestamp);
+    }
+
     /// @notice Tests that initialization cannot be done twice
     function test_initialize_twice_reverts() public {
         vm.expectRevert("Initializable: contract is already initialized");

--- a/packages/contracts-bedrock/test/dispute/AnchorStateRegistry.t.sol
+++ b/packages/contracts-bedrock/test/dispute/AnchorStateRegistry.t.sol
@@ -82,7 +82,7 @@ contract AnchorStateRegistry_Initialize_Test is AnchorStateRegistry_TestInit {
     }
 
     /// @notice Tests that the retirement timestamp is set on the first initialization.
-    function test_initialize_firstInitialization_setsRetirementTimestamp_succeeds() public {
+    function test_initialize_setsRetirementTimestamp_succeeds() public {
         skipIfForkTest("State has changed since initialization on a forked network.");
 
         (Hash root, uint256 l2SequenceNumber) = anchorStateRegistry.getAnchorRoot();
@@ -112,7 +112,7 @@ contract AnchorStateRegistry_Initialize_Test is AnchorStateRegistry_TestInit {
     }
 
     /// @notice Tests that the retirement timestamp is unchanged during re-initialization.
-    function test_initialize_reinitialization_doesNotChangeRetirementTimestamp_succeeds() public {
+    function test_initialize_reinitializationDoesNotChangeRetirementTimestamp_succeeds() public {
         skipIfForkTest("State has changed since initialization on a forked network.");
 
         (Hash root, uint256 l2SequenceNumber) = anchorStateRegistry.getAnchorRoot();

--- a/packages/contracts-bedrock/test/invariants/SystemConfig.t.sol
+++ b/packages/contracts-bedrock/test/invariants/SystemConfig.t.sol
@@ -44,7 +44,8 @@ contract SystemConfig_GasLimitBoundaries_Invariant is Test {
                         l1ERC721Bridge: address(0),
                         l1StandardBridge: address(0),
                         optimismPortal: address(0),
-                        optimismMintableERC20Factory: address(0)
+                        optimismMintableERC20Factory: address(0),
+                        delayedWETH: address(0)
                     }),
                     1234, // _l2ChainId
                     ISuperchainConfig(address(0)) // _superchainConfig

--- a/packages/contracts-bedrock/test/opcm/SetDisputeGameImpl.t.sol
+++ b/packages/contracts-bedrock/test/opcm/SetDisputeGameImpl.t.sol
@@ -192,7 +192,8 @@ contract SetDisputeGameImpl_Test is Test {
                     l1ERC721Bridge: address(4),
                     l1StandardBridge: address(5),
                     optimismPortal: address(6),
-                    optimismMintableERC20Factory: address(7)
+                    optimismMintableERC20Factory: address(7),
+                    delayedWETH: address(8)
                 }),
                 10,
                 ISuperchainConfig(address(supConfigProxy))

--- a/packages/contracts-bedrock/test/vendor/Initializable.t.sol
+++ b/packages/contracts-bedrock/test/vendor/Initializable.t.sol
@@ -191,7 +191,8 @@ contract Initializer_Test is CommonTest {
                             l1ERC721Bridge: address(0),
                             l1StandardBridge: address(0),
                             optimismPortal: address(0),
-                            optimismMintableERC20Factory: address(0)
+                            optimismMintableERC20Factory: address(0),
+                            delayedWETH: address(0)
                         }),
                         0,
                         ISuperchainConfig(address(0))
@@ -227,7 +228,8 @@ contract Initializer_Test is CommonTest {
                             l1ERC721Bridge: address(0),
                             l1StandardBridge: address(0),
                             optimismPortal: address(0),
-                            optimismMintableERC20Factory: address(0)
+                            optimismMintableERC20Factory: address(0),
+                            delayedWETH: address(0)
                         }),
                         0,
                         ISuperchainConfig(address(0))


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
This PR makes two changes to the core OP Stack contracts:

- AnchorStateRegistry `initialize` function only sets the retirement timestamp on first initialization. Makes it possible to call `initialize` again safely.
- SystemConfig `initialize` function gets a new DelayedWETH parameters. We are NOT actually using this parameter yet for U18 and the value is set to use `address(0)` at deploy time. OPCMv2 will utilize this parameter so that all dispute games share the same DelayedWETH contract.