### PR TITLE
op-e2e: Enable Osaka on L1 by default

### DIFF
--- a/op-chain-ops/interopgen/recipe.go
+++ b/op-chain-ops/interopgen/recipe.go
@@ -274,6 +274,7 @@ func (r *InteropDevL2Recipe) build(l1ChainID uint64, addrs devkeys.Addresses) (*
 				L2GenesisInteropTimeOffset:  (*hexutil.Uint64)(&r.InteropOffset),
 				L1CancunTimeOffset:          new(hexutil.Uint64),
 				L1PragueTimeOffset:          new(hexutil.Uint64),
+				L1OsakaTimeOffset:           new(hexutil.Uint64),
 			},
 			L2CoreDeployConfig: genesis.L2CoreDeployConfig{
 				L1ChainID:                 l1ChainID,

--- a/op-e2e/e2eutils/setup.go
+++ b/op-e2e/e2eutils/setup.go
@@ -282,4 +282,6 @@ func ApplyDeployConfigForks(deployConfig *genesis.DeployConfig) {
 	deployConfig.L2GenesisRegolithTimeOffset = new(hexutil.Uint64)
 	// Activated by default, contracts depend on it
 	deployConfig.L1CancunTimeOffset = new(hexutil.Uint64)
+	deployConfig.L1PragueTimeOffset = new(hexutil.Uint64)
+	deployConfig.L1OsakaTimeOffset = new(hexutil.Uint64)
 }

--- a/op-e2e/faultproofs/util.go
+++ b/op-e2e/faultproofs/util.go
@@ -57,6 +57,7 @@ func WithLatestFork() faultDisputeConfigOpts {
 			genesisActivation := hexutil.Uint64(0)
 			cfg.DeployConfig.L1CancunTimeOffset = &genesisActivation
 			cfg.DeployConfig.L1PragueTimeOffset = &genesisActivation
+			cfg.DeployConfig.L1OsakaTimeOffset = &genesisActivation
 			cfg.DeployConfig.L2GenesisDeltaTimeOffset = &genesisActivation
 			cfg.DeployConfig.L2GenesisEcotoneTimeOffset = &genesisActivation
 			cfg.DeployConfig.L2GenesisFjordTimeOffset = &genesisActivation


### PR DESCRIPTION
**Description**

Try enabling Osaka on L1 by default for op-e2e tests. WCPGW?