### PR TITLE
docs: add note about L2 gas price oracle updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+> Note: The L2 gas price oracle values are updated periodically by governance and should not be assumed constant.
 Commit directly to the main branch
 <div align="center">
   <br />

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+Commit directly to the main branch
 <div align="center">
   <br />
   <br />

--- a/base-builder-insight-on-opstack.md
+++ b/base-builder-insight-on-opstack.md
@@ -1,0 +1,30 @@
+# Base Builder Insight on the OP Stack
+
+As a builder exploring both Base and Optimism, I’ve realized how powerful the OP Stack is as a shared foundation.  
+It manages to balance decentralization, scalability, and developer freedom — all while staying transparent.
+
+---
+
+### 1. Shared Infrastructure, Independent Growth
+The most impressive part of the OP Stack is how it lets multiple L2s evolve independently while staying compatible.  
+That openness encourages real innovation without fragmentation.
+
+---
+
+### 2. Developer Perspective
+The documentation and code clarity make it approachable even for first-time contributors.  
+A few more comments in the bridge and fault-proof modules could help newcomers understand execution paths faster.
+
+---
+
+### 3. Cross-L2 Collaboration
+Seeing Base and Optimism both build on the same framework shows what healthy open-source cooperation looks like.  
+This model could inspire more L2s to join the Superchain movement.
+
+---
+
+### Closing Thought
+Base is proof that the OP Stack isn’t just technology — it’s an idea of collective progress.  
+I’m leaving this note as appreciation for everyone contributing to that shared vision.
+
+> Strong foundations make room for stronger builders.


### PR DESCRIPTION
The Optimism network includes an on-chain gas price oracle used to estimate L1 data costs. 
This PR adds a clarification to the documentation stating that the oracle is periodically updated by the protocol's governance process 
and that developers integrating L2 transactions should not rely on fixed gas prices.

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
