### PR TITLE
fix(ci): bump machine size for publish-contract-artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2232,7 +2232,7 @@ jobs:
   publish-contract-artifacts:
     docker:
       - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: xlarge
+    resource_class: 2xlarge
     steps:
       - gcp-cli/install
       - gcp-oidc-authenticate:


### PR DESCRIPTION
Bumps the ci machine size from xlarge to 2xlarge for `publish-contract-artifacts` to match other jobs that build contracts. Without this fix, the machine seems to run out of memory when trying to build/compile contracts ([ref](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/107392/workflows/bc60ad10-0697-4dfd-857a-c5df3456b924/jobs/4090062)). 