### PR TITLE
chore: Drop code persistence from the CI workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -471,6 +471,8 @@ jobs:
     steps:
       - utils/checkout-with-mise:
          checkout-method: blobless
+      - attach_workspace:
+          at: .
       - check-changed:
           patterns: cannon,packages/contracts-bedrock/src/cannon,op-preimage,go.mod
       - run:
@@ -571,6 +573,7 @@ jobs:
     steps:
       - utils/checkout-with-mise:
          checkout-method: blobless
+      - install-contracts-dependencies
       - run:
           name: Print forge version
           command: forge --version
@@ -1066,6 +1069,9 @@ jobs:
     steps:
       - utils/checkout-with-mise:
          checkout-method: blobless
+      - install-contracts-dependencies
+      - attach_workspace:
+          at: .
       - check-changed:
           patterns: contracts-bedrock
       - install-solc-compilers
@@ -1159,6 +1165,9 @@ jobs:
     resource_class: xlarge
     steps:
       - utils/checkout-with-mise
+      - install-contracts-dependencies
+      - attach_workspace:
+          at: .
       - check-changed:
           patterns: contracts-bedrock
       - install-solc-compilers
@@ -1234,6 +1243,9 @@ jobs:
     resource_class: xlarge
     steps:
       - utils/checkout-with-mise
+      - install-contracts-dependencies
+      - attach_workspace:
+          at: .
       - check-changed:
           patterns: contracts-bedrock
       - get-target-branch
@@ -1386,6 +1398,8 @@ jobs:
     steps:
       - utils/checkout-with-mise:
          checkout-method: blobless
+      - attach_workspace:
+          at: .
       - restore_cache:
           key: go-tests-v2-{{ checksum "go.mod" }}
       - run:
@@ -1459,6 +1473,8 @@ jobs:
     steps:
       - utils/checkout-with-mise:
          checkout-method: blobless
+      - attach_workspace:
+          at: .
       - run:
           name: build op-program-client
           command: make op-program-client
@@ -2306,6 +2322,7 @@ jobs:
     steps:
       - utils/checkout-with-mise:
          checkout-method: blobless
+      - install-contracts-dependencies
       - run:
           name: Build contracts
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1635,6 +1635,8 @@ jobs:
     steps:
       - utils/checkout-with-mise:
          checkout-method: blobless
+      - attach_workspace:
+          at: .
       # Restore cached Go modules
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -290,12 +290,6 @@ commands:
           environment:
             FOUNDRY_PROFILE: ci
 
-  checkout-from-workspace:
-    steps:
-      - attach_workspace:
-          at: "."
-      - utils/install-mise
-
   go-restore-cache:
     parameters:
       # The go module to cache for. If the go module does not come with its own go.mod and go.sum,
@@ -361,7 +355,8 @@ jobs:
       - image: <<pipeline.parameters.default_docker_image>>
     resource_class: xlarge
     steps:
-      - checkout-from-workspace
+      - utils/checkout-with-mise:
+          checkout-method: blobless
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
@@ -456,18 +451,6 @@ jobs:
           steps:
             - store_artifacts:
                 path: ./op-acceptance-tests/logs
-  initialize:
-    docker:
-      - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: large
-    steps:
-      - utils/checkout-with-mise:
-          checkout-method: blobless
-      - install-contracts-dependencies
-      - persist_to_workspace:
-          root: "."
-          paths:
-            - "."
 
   cannon-go-lint-and-test:
     docker:
@@ -486,7 +469,8 @@ jobs:
         type: boolean
         default: false
     steps:
-      - checkout-from-workspace
+      - utils/checkout-with-mise:
+         checkout-method: blobless
       - check-changed:
           patterns: cannon,packages/contracts-bedrock/src/cannon,op-preimage,go.mod
       - run:
@@ -535,7 +519,8 @@ jobs:
       - image: <<pipeline.parameters.default_docker_image>>
     resource_class: xlarge
     steps:
-      - checkout-from-workspace
+      - utils/checkout-with-mise:
+         checkout-method: blobless
       - run:
           name: Check `RISCV.sol` bytecode
           working_directory: packages/contracts-bedrock
@@ -584,7 +569,8 @@ jobs:
         type: string
         default: ci
     steps:
-      - checkout-from-workspace
+      - utils/checkout-with-mise:
+         checkout-method: blobless
       - run:
           name: Print forge version
           command: forge --version
@@ -618,7 +604,8 @@ jobs:
     resource_class: xlarge
     steps:
       - utils/checkout-with-mise
-      - attach_workspace: { at: "." }
+      - attach_workspace:
+          at: .
       - install-contracts-dependencies
       - check-changed:
           patterns: contracts-bedrock
@@ -678,7 +665,8 @@ jobs:
       resource_class: "<<parameters.resource_class>>"
       docker_layer_caching: true # we rely on this for faster builds, and actively warm it up for builds with common stages
     steps:
-      - checkout-from-workspace
+      - utils/checkout-with-mise:
+         checkout-method: blobless
       - run:
           command: mkdir -p /tmp/docker_images
       - when:
@@ -903,7 +891,8 @@ jobs:
         type: string
         default: ""
     steps:
-      - checkout-from-workspace
+      - utils/checkout-with-mise:
+         checkout-method: blobless
       - run:
           name: Check if test list is empty
           command: |
@@ -968,7 +957,8 @@ jobs:
       - image: <<pipeline.parameters.default_docker_image>>
     resource_class: xlarge
     steps:
-      - checkout-from-workspace
+      - utils/checkout-with-mise:
+         checkout-method: blobless
       - run:
           name: Print dependencies
           command: just dep-status
@@ -1014,7 +1004,8 @@ jobs:
       - image: <<pipeline.parameters.default_docker_image>>
     resource_class: medium
     steps:
-      - checkout-from-workspace
+      - utils/checkout-with-mise:
+         checkout-method: blobless
       - run:
           name: Check Python version
           command: python3 --version
@@ -1073,7 +1064,8 @@ jobs:
         type: string
         default: ""
     steps:
-      - checkout-from-workspace
+      - utils/checkout-with-mise:
+         checkout-method: blobless
       - check-changed:
           patterns: contracts-bedrock
       - install-solc-compilers
@@ -1166,7 +1158,7 @@ jobs:
       - image: <<pipeline.parameters.default_docker_image>>
     resource_class: xlarge
     steps:
-      - checkout-from-workspace
+      - utils/checkout-with-mise
       - check-changed:
           patterns: contracts-bedrock
       - install-solc-compilers
@@ -1241,7 +1233,7 @@ jobs:
       - image: <<pipeline.parameters.default_docker_image>>
     resource_class: xlarge
     steps:
-      - checkout-from-workspace
+      - utils/checkout-with-mise
       - check-changed:
           patterns: contracts-bedrock
       - get-target-branch
@@ -1311,7 +1303,8 @@ jobs:
       - image: <<pipeline.parameters.default_docker_image>>
     resource_class: xlarge
     steps:
-      - checkout-from-workspace
+      - utils/checkout-with-mise:
+         checkout-method: blobless
       - check-changed:
           patterns: "<<parameters.package_name>>"
       - attach_workspace:
@@ -1342,7 +1335,8 @@ jobs:
       - image: <<pipeline.parameters.default_docker_image>>
     resource_class: large
     steps:
-      - checkout-from-workspace
+      - utils/checkout-with-mise:
+         checkout-method: blobless
       - restore_cache:
           key: golangci-v1-{{ checksum ".golangci.yaml" }}
       - run:
@@ -1390,7 +1384,8 @@ jobs:
     circleci_ip_ranges: true
     parallelism: <<parameters.parallelism>>
     steps:
-      - checkout-from-workspace
+      - utils/checkout-with-mise:
+         checkout-method: blobless
       - restore_cache:
           key: go-tests-v2-{{ checksum "go.mod" }}
       - run:
@@ -1462,7 +1457,8 @@ jobs:
     machine: true
     resource_class: <<parameters.resource_class>>
     steps:
-      - checkout-from-workspace
+      - utils/checkout-with-mise:
+         checkout-method: blobless
       - run:
           name: build op-program-client
           command: make op-program-client
@@ -1523,7 +1519,8 @@ jobs:
       - image: <<pipeline.parameters.default_docker_image>>
     circleci_ip_ranges: true
     steps:
-      - checkout-from-workspace
+      - utils/checkout-with-mise:
+         checkout-method: blobless
       # Restore cached Go modules
       - restore_cache:
           keys:
@@ -1620,7 +1617,8 @@ jobs:
     circleci_ip_ranges: true
     resource_class: 2xlarge
     steps:
-      - checkout-from-workspace
+      - utils/checkout-with-mise:
+         checkout-method: blobless
       # Restore cached Go modules
       - restore_cache:
           keys:
@@ -1711,7 +1709,8 @@ jobs:
     resource_class: xlarge
     parallelism: << pipeline.parameters.flake-shake-workers >>
     steps:
-      - checkout-from-workspace
+      - utils/checkout-with-mise:
+         checkout-method: blobless
       - restore_cache:
           keys:
             - go-mod-v1-{{ checksum "go.sum" }}
@@ -1757,7 +1756,8 @@ jobs:
       image: ubuntu-2404:current
     resource_class: large
     steps:
-      - checkout-from-workspace
+      - utils/checkout-with-mise:
+         checkout-method: blobless
       - attach_workspace:
           at: .
       - run:
@@ -1807,7 +1807,8 @@ jobs:
       image: ubuntu-2404:current
     resource_class: large
     steps:
-      - checkout-from-workspace
+      - utils/checkout-with-mise:
+         checkout-method: blobless
       - run:
           name: Lint/Vet/Build op-acceptance-tests/cmd
           working_directory: op-acceptance-tests
@@ -1885,7 +1886,8 @@ jobs:
       - image: <<pipeline.parameters.default_docker_image>>
     resource_class: large
     steps:
-      - checkout-from-workspace
+      - utils/checkout-with-mise:
+         checkout-method: blobless
       - run:
           name: Install tools
           command: |
@@ -1907,7 +1909,8 @@ jobs:
       - image: <<pipeline.parameters.default_docker_image>>
     resource_class: xlarge
     steps:
-      - checkout-from-workspace
+      - utils/checkout-with-mise:
+         checkout-method: blobless
       - restore_cache:
           name: Restore cannon prestate cache
           key: cannon-prestate-{{ checksum "./cannon/bin/cannon" }}-{{ checksum "op-program/bin/op-program-client.elf" }}
@@ -1934,7 +1937,8 @@ jobs:
     docker:
       - image: <<pipeline.parameters.default_docker_image>>
     steps:
-      - checkout-from-workspace
+      - utils/checkout-with-mise:
+         checkout-method: blobless
       - setup_remote_docker
       - run:
           name: Build prestates
@@ -1949,7 +1953,8 @@ jobs:
     machine:
       docker_layer_caching: true # we rely on this for faster builds, and actively warm it up for builds with common stages
     steps:
-      - checkout-from-workspace
+      - utils/checkout-with-mise:
+         checkout-method: blobless
       - restore_cache:
           name: Restore kona cache
           key: kona-prestate-{{ checksum "./kona/justfile" }}
@@ -1971,7 +1976,8 @@ jobs:
     docker:
       - image: <<pipeline.parameters.default_docker_image>>
     steps:
-      - checkout-from-workspace
+      - utils/checkout-with-mise:
+         checkout-method: blobless
       - restore_cache:
           name: Restore kona host cache
           key: kona-host-{{ checksum "./kona/justfile" }}
@@ -2143,7 +2149,8 @@ jobs:
       - image: <<pipeline.parameters.default_docker_image>>
     resource_class: xlarge
     steps:
-      - checkout-from-workspace
+      - utils/checkout-with-mise:
+         checkout-method: blobless
       - setup_remote_docker
       - run:
           name: Run Analyzer
@@ -2156,7 +2163,8 @@ jobs:
       - image: <<pipeline.parameters.default_docker_image>>
     resource_class: large
     steps:
-      - checkout-from-workspace
+      - utils/checkout-with-mise:
+         checkout-method: blobless
       - run:
           name: Verify Compatibility
           command: |
@@ -2168,7 +2176,8 @@ jobs:
       - image: <<pipeline.parameters.default_docker_image>>
     resource_class: large
     steps:
-      - checkout-from-workspace
+      - utils/checkout-with-mise:
+         checkout-method: blobless
       - check-changed:
           patterns: op-node
       - run:
@@ -2180,7 +2189,8 @@ jobs:
       - image: <<pipeline.parameters.default_docker_image>>
     resource_class: large
     steps:
-      - checkout-from-workspace
+      - utils/checkout-with-mise:
+         checkout-method: blobless
       - check-changed:
           patterns: op-service
       - run:
@@ -2191,7 +2201,8 @@ jobs:
     docker:
       - image: <<pipeline.parameters.default_docker_image>>
     steps:
-      - checkout-from-workspace
+      - utils/checkout-with-mise:
+         checkout-method: blobless
       - run:
           command: just check-forge-version
           working_directory: op-deployer
@@ -2293,7 +2304,8 @@ jobs:
       - image: <<pipeline.parameters.default_docker_image>>
     resource_class: medium
     steps:
-      - checkout-from-workspace
+      - utils/checkout-with-mise:
+         checkout-method: blobless
       - run:
           name: Build contracts
           command: |
@@ -2414,20 +2426,13 @@ workflows:
             - equal: [true, << pipeline.parameters.kurtosis_acceptance_tests_dispatch >>]
             - equal: ["api", << pipeline.trigger_source >>]
     jobs:
-      - initialize:
-          context:
-            - circleci-repo-readonly-authenticated-github-token
       - contracts-bedrock-build: # needed for in-process tests that some suites may use
           build_args: --skip test
           context:
             - circleci-repo-readonly-authenticated-github-token
-          requires:
-            - initialize
       - cannon-prestate-quick: # needed for sysgo tests (if any package is in-memory)
           context:
             - circleci-repo-readonly-authenticated-github-token
-          requires:
-            - initialize
       - op-acceptance-tests-kurtosis:
           name: kurtosis-simple-nightly
           devnet: simple
@@ -2473,17 +2478,12 @@ workflows:
                   "__not_set__",
                 ] #this is to prevent triggering this workflow as the default value is always set for main_dispatch
     jobs:
-      - initialize:
-          context:
-            - circleci-repo-readonly-authenticated-github-token
       - contracts-bedrock-build:
           name: contracts-bedrock-build
           # Build with just core + script contracts.
           build_args: --deny-warnings --skip test
           context:
             - circleci-repo-readonly-authenticated-github-token
-          requires:
-            - initialize
       - check-kontrol-build:
           requires:
             - contracts-bedrock-build
@@ -2497,8 +2497,6 @@ workflows:
           test_profile: ciheavy
           context:
             - circleci-repo-readonly-authenticated-github-token
-          requires:
-            - initialize
       - contracts-bedrock-tests:
           name: contracts-bedrock-tests <<matrix.dev_features>>
           test_list: find test -name "*.t.sol"
@@ -2511,8 +2509,6 @@ workflows:
                 - CANNON_KONA,DEPLOY_V2_DISPUTE_GAMES
           context:
             - circleci-repo-readonly-authenticated-github-token
-          requires:
-            - initialize
           check_changed_patterns: contracts-bedrock,op-node
       - contracts-bedrock-coverage:
           # Generate coverage reports.
@@ -2525,8 +2521,6 @@ workflows:
               dev_features: *dev_features_matrix
           context:
             - circleci-repo-readonly-authenticated-github-token
-          requires:
-            - initialize
       - contracts-bedrock-tests-upgrade:
           name: contracts-bedrock-tests-upgrade op-mainnet <<matrix.dev_features>>
           fork_op_chain: op
@@ -2538,8 +2532,6 @@ workflows:
               dev_features: *dev_features_matrix
           context:
             - circleci-repo-readonly-authenticated-github-token
-          requires:
-            - initialize
       - contracts-bedrock-tests-upgrade:
           name: contracts-bedrock-tests-upgrade <<matrix.fork_op_chain>>-mainnet
           fork_op_chain: <<matrix.fork_op_chain>>
@@ -2550,8 +2542,6 @@ workflows:
               fork_op_chain: ["base", "ink", "unichain"]
           context:
             - circleci-repo-readonly-authenticated-github-token
-          requires:
-            - initialize
       - contracts-bedrock-checks:
           requires:
             - contracts-bedrock-build
@@ -2565,13 +2555,9 @@ workflows:
       - op-deployer-forge-version:
           context:
             - circleci-repo-readonly-authenticated-github-token
-          requires:
-            - initialize
       - diff-asterisc-bytecode:
           context:
             - circleci-repo-readonly-authenticated-github-token
-          requires:
-            - initialize
       - semgrep-scan:
           name: semgrep-scan-local
           scan_command: semgrep scan --timeout=100 --config .semgrep/rules/ --error .
@@ -2587,8 +2573,6 @@ workflows:
       - go-lint:
           context:
             - circleci-repo-readonly-authenticated-github-token
-          requires:
-            - initialize
       - fuzz-golang:
           name: fuzz-golang-<<matrix.package_name>>
           on_changes: <<matrix.package_name>>
@@ -2601,8 +2585,6 @@ workflows:
                 - op-chain-ops
           context:
             - circleci-repo-readonly-authenticated-github-token
-          requires:
-            - initialize
       - fuzz-golang:
           name: cannon-fuzz
           package_name: cannon
@@ -2654,13 +2636,9 @@ workflows:
       - analyze-op-program-client:
           context:
             - circleci-repo-readonly-authenticated-github-token
-          requires:
-            - initialize
       - op-program-compat:
           context:
             - circleci-repo-readonly-authenticated-github-token
-          requires:
-            - initialize
       - bedrock-go-tests:
           requires:
             - go-lint
@@ -2704,13 +2682,10 @@ workflows:
           context:
             - circleci-repo-readonly-authenticated-github-token
           requires:
-            - initialize
             - contracts-bedrock-build
       - cannon-prestate-quick:
           context:
             - circleci-repo-readonly-authenticated-github-token
-          requires:
-            - initialize
       - sanitize-op-program:
           requires:
             - cannon-prestate-quick
@@ -2719,13 +2694,9 @@ workflows:
       - check-generated-mocks-op-node:
           context:
             - circleci-repo-readonly-authenticated-github-token
-          requires:
-            - initialize
       - check-generated-mocks-op-service:
           context:
             - circleci-repo-readonly-authenticated-github-token
-          requires:
-            - initialize
       - cannon-go-lint-and-test:
           requires:
             - contracts-bedrock-build
@@ -2748,14 +2719,6 @@ workflows:
 
   go-release-op-deployer:
     jobs:
-      - initialize:
-          filters:
-            tags:
-              only: /^op-deployer.*/
-            branches:
-              ignore: /.*/
-          context:
-            - circleci-repo-readonly-authenticated-github-token
       - contracts-bedrock-build:
           name: build-contracts-go-release-op-deployer
           filters:
@@ -2766,8 +2729,6 @@ workflows:
           build_args: --skip test
           context:
             - circleci-repo-readonly-authenticated-github-token
-          requires:
-            - initialize
       - go-release:
           filters:
             tags:
@@ -2783,14 +2744,6 @@ workflows:
 
   go-release-op-up:
     jobs:
-      - initialize:
-          filters:
-            tags:
-              only: /^op-up.*/
-            branches:
-              ignore: /.*/
-          context:
-            - circleci-repo-readonly-authenticated-github-token
       - contracts-bedrock-build:
           name: build-contracts-go-release-op-up
           filters:
@@ -2801,8 +2754,6 @@ workflows:
           build_args: --skip test
           context:
             - circleci-repo-readonly-authenticated-github-token
-          requires:
-            - initialize
       - go-release:
           filters:
             tags:
@@ -2821,19 +2772,9 @@ workflows:
       not:
         equal: [scheduled_pipeline, << pipeline.trigger_source >>]
     jobs:
-      - initialize:
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-          filters:
-            tags:
-              only: /^(da-server|cannon|ufm-[a-z0-9\-]*|op-[a-z0-9\-]*)\/v.*/
-            branches:
-              ignore: /.*/
       - contracts-bedrock-build:
           context:
             - circleci-repo-readonly-authenticated-github-token
-          requires:
-            - initialize
           filters:
             tags:
               only: /^op-deployer.*/ # ensure contract artifacts are embedded in op-deployer binary
@@ -2873,7 +2814,6 @@ workflows:
           context:
             - oplabs-gcr-release
           requires:
-            - initialize
             - contracts-bedrock-build
       # Checks for cross-platform images go here
       - check-cross-platform:
@@ -2925,8 +2865,6 @@ workflows:
               ignore: /.*/
           context:
             - circleci-repo-readonly-authenticated-github-token
-          requires:
-            - initialize
       - publish-cannon-prestates:
           context:
             - circleci-repo-readonly-authenticated-github-token
@@ -2978,14 +2916,9 @@ workflows:
             - equal: [true, <<pipeline.parameters.fault_proofs_dispatch>>]
             - equal: ["api", << pipeline.trigger_source >>]
     jobs:
-      - initialize:
-          context:
-            - circleci-repo-readonly-authenticated-github-token
       - cannon-prestate:
           context:
             - circleci-repo-readonly-authenticated-github-token
-          requires:
-            - initialize
       - cannon-stf-verify:
           context:
             - slack
@@ -2995,8 +2928,6 @@ workflows:
           context:
             - slack
             - circleci-repo-readonly-authenticated-github-token
-          requires:
-            - initialize
       - go-tests-with-fault-proof-deps:
           name: op-e2e-cannon-tests
           notify: true
@@ -3041,15 +2972,10 @@ workflows:
         - equal: [build_four_hours, <<pipeline.schedule.name>>]
         - equal: [true, << pipeline.parameters.cannon_full_test_dispatch >>]
     jobs:
-      - initialize:
-          context:
-            - circleci-repo-readonly-authenticated-github-token
       - contracts-bedrock-build:
           build_args: --deny-warnings --skip test
           context:
             - circleci-repo-readonly-authenticated-github-token
-          requires:
-            - initialize
       - cannon-go-lint-and-test:
           requires:
             - contracts-bedrock-build
@@ -3067,14 +2993,9 @@ workflows:
         # Trigger on manual triggers if explicitly requested
         - equal: [true, << pipeline.parameters.docker_publish_dispatch >>]
     jobs:
-      - initialize:
-          context:
-            - circleci-repo-readonly-authenticated-github-token
       - contracts-bedrock-build:
           context:
             - circleci-repo-readonly-authenticated-github-token
-          requires:
-            - initialize
       - docker-build:
           matrix:
             parameters:
@@ -3103,7 +3024,6 @@ workflows:
             - slack
             - circleci-repo-readonly-authenticated-github-token
           requires:
-            - initialize
             - contracts-bedrock-build
       - check-cross-platform:
           matrix:
@@ -3138,20 +3058,13 @@ workflows:
             - equal: [true, << pipeline.parameters.flake-shake-dispatch >>]
             - equal: ["api", << pipeline.trigger_source >>]
     jobs:
-      - initialize:
-          context:
-            - circleci-repo-readonly-authenticated-github-token
       - contracts-bedrock-build:
           build_args: --skip test
           context:
             - circleci-repo-readonly-authenticated-github-token
-          requires:
-            - initialize
       - cannon-prestate-quick:
           context:
             - circleci-repo-readonly-authenticated-github-token
-          requires:
-            - initialize
       - op-acceptance-tests-flake-shake:
           context:
             - circleci-repo-readonly-authenticated-github-token
@@ -3200,20 +3113,13 @@ workflows:
         # Trigger on manual triggers if explicitly requested
         - equal: [true, << pipeline.parameters.sync_test_op_node_dispatch >>]
     jobs:
-      - initialize:
-          context:
-            - circleci-repo-readonly-authenticated-github-token
       - contracts-bedrock-build: # needed for sysgo tests
           build_args: --skip test
           context:
             - circleci-repo-readonly-authenticated-github-token
-          requires:
-            - initialize
       - cannon-prestate-quick: # needed for sysgo tests
           context:
             - circleci-repo-readonly-authenticated-github-token
-          requires:
-            - initialize
       - op-acceptance-sync-tests-docker:
           name: "sync-test-<<matrix.network_preset>>-daily-<<matrix.l2_cl_syncmode>>"
           gate: sync-test-op-node
@@ -3235,15 +3141,10 @@ workflows:
         - equal: [build_daily, <<pipeline.schedule.name>>]
         - equal: [true, << pipeline.parameters.heavy_fuzz_dispatch >>]
     jobs:
-      - initialize:
-          context:
-            - circleci-repo-readonly-authenticated-github-token
       - contracts-bedrock-heavy-fuzz-nightly:
           context:
             - slack
             - circleci-repo-readonly-authenticated-github-token
-          requires:
-            - initialize
 
   # Acceptance tests
   acceptance-tests:
@@ -3255,30 +3156,19 @@ workflows:
             - equal: [true, <<pipeline.parameters.acceptance_tests_dispatch>>]
             - equal: ["api", << pipeline.trigger_source >>]
     jobs:
-      - initialize:
-          context:
-            - circleci-repo-readonly-authenticated-github-token
       - contracts-bedrock-build: # needed for sysgo tests
           build_args: --skip test
           context:
             - circleci-repo-readonly-authenticated-github-token
-          requires:
-            - initialize
       - cannon-prestate-quick: # needed for sysgo tests
           context:
             - circleci-repo-readonly-authenticated-github-token
-          requires:
-            - initialize
       - cannon-kona-prestate: # needed for sysgo tests (if any package is in-memory)
           context:
             - circleci-repo-readonly-authenticated-github-token
-          requires:
-            - initialize
       - cannon-kona-host: # needed for sysgo tests (if any package is in-memory)
           context:
             - circleci-repo-readonly-authenticated-github-token
-          requires:
-            - initialize
       # IN-MEMORY (all)
       - op-acceptance-tests:
           name: memory-all
@@ -3335,14 +3225,9 @@ workflows:
         - equal: [build_mon_thu, <<pipeline.schedule.name>>]
         - equal: [true, << pipeline.parameters.ai_contracts_test_dispatch >>]
     jobs:
-      - initialize:
-          context:
-            - circleci-repo-readonly-authenticated-github-token
       - ai-contracts-test:
           context:
             - circleci-repo-readonly-authenticated-github-token
             - circleci-api-token
             - devin-api
             - slack
-          requires:
-            - initialize

--- a/ops/ai-eng/contracts-test-maintenance/docs/runbook.md
+++ b/ops/ai-eng/contracts-test-maintenance/docs/runbook.md
@@ -67,7 +67,7 @@ ai-contracts-test:
   docker:
     - image: cimg/base:2024.01
   steps:
-    - checkout-from-workspace
+    - utils/checkout-with-mise
     - run: just ai-contracts-test
     - store_artifacts: log.json
 ```


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Since we are moving away from latitude boxes, we can now remove the checkout optimization that was put in place in #17063.

The checkout method was kept as `full` for any jobs that use `git diff`, for the rest `blobless` was specified.

Fixes https://github.com/ethereum-optimism/optimism/issues/18258