### PR TITLE
chore: Last two latitude boxes gone

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1446,7 +1446,7 @@ jobs:
       resource_class:
         description: Machine resource class
         type: string
-        default: ethereum-optimism/latitude-1-go-e2e
+        default: 2xlarge
       no_output_timeout:
         description: Timeout for when CircleCI kills the job if there's no output
         type: string
@@ -3003,7 +3003,7 @@ workflows:
           mentions: "@proofs-team"
           no_output_timeout: 90m
           test_timeout: 480m
-          resource_class: ethereum-optimism/latitude-fps-1
+          resource_class: large
           context:
             - slack
             - circleci-repo-readonly-authenticated-github-token

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1618,7 +1618,7 @@ jobs:
     docker:
       - image: <<pipeline.parameters.default_docker_image>>
     circleci_ip_ranges: true
-    resource_class: 2xlarge
+    resource_class: 2xlarge+
     steps:
       - checkout-from-workspace
       # Restore cached Go modules


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

The last two occurrences of the self-hosted runners are now gone

Fixes https://github.com/ethereum-optimism/platforms-team/issues/1270