### PR TITLE
Add deny warnings to default test_command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -872,7 +872,7 @@ jobs:
       test_command:
         description: Test command to execute (test or coverage)
         type: string
-        default: test
+        default: test --deny-warnings
       test_flags:
         description: Additional flags to pass to the test command
         type: string

--- a/packages/contracts-bedrock/test/L2/FeeSplitter.t.sol
+++ b/packages/contracts-bedrock/test/L2/FeeSplitter.t.sol
@@ -161,7 +161,8 @@ contract FeeSplitter_Receive_Test is FeeSplitter_TestInit {
 
         vm.prank(_caller);
         vm.expectRevert(IFeeSplitter.FeeSplitter_SenderNotCurrentVault.selector);
-        payable(address(feeSplitter)).call{ value: _amount }("");
+        (bool revertsAsExpected,) = payable(address(feeSplitter)).call{ value: _amount }("");
+        assertTrue(revertsAsExpected);
     }
 
     /// @notice Test receive function from non-approved vault reverts even during disbursement
@@ -177,7 +178,8 @@ contract FeeSplitter_Receive_Test is FeeSplitter_TestInit {
 
         // Now we test the actual sender validation
         vm.expectRevert(IFeeSplitter.FeeSplitter_SenderNotCurrentVault.selector);
-        payable(address(feeSplitter)).call{ value: _amount }("");
+        (bool revertsAsExpected,) = payable(address(feeSplitter)).call{ value: _amount }("");
+        assertTrue(revertsAsExpected);
     }
 
     /// @notice Test receive function works during disbursement from SequencerFeeVault
@@ -659,7 +661,8 @@ contract FeeSplitter_DisburseFees_Test is FeeSplitter_TestInit {
         // Attempt to send ETH from the vault - should revert because transient storage was cleared
         vm.prank(_vault);
         vm.expectRevert(IFeeSplitter.FeeSplitter_SenderNotCurrentVault.selector);
-        payable(address(feeSplitter)).call{ value: _attemptAmount }("");
+        (bool revertsAsExpected,) = payable(address(feeSplitter)).call{ value: _attemptAmount }("");
+        assertTrue(revertsAsExpected);
     }
 }
 

--- a/packages/contracts-bedrock/test/L2/FeeSplitterVaults.t.sol
+++ b/packages/contracts-bedrock/test/L2/FeeSplitterVaults.t.sol
@@ -52,7 +52,8 @@ contract FeeSplitterVaults_Receive_Test is Test {
                 }
 
                 vm.prank(_selectedVault);
-                payable(address(feeSplitter)).call{ value: _amount }("");
+                (bool revertsAsExpected,) = payable(address(feeSplitter)).call{ value: _amount }("");
+                assertTrue(revertsAsExpected);
             }
         }
     }


### PR DESCRIPTION
Warnings are currently being allowed through CI, because the contracts-bedrock-build job [skips tests](https://github.com/ethereum-optimism/optimism/blob/b7c0afd57d1d14dea3b9f9bb1dabb2b7cfe88a59/.circleci/config.yml#L2516). 

Tests are therefore not built until they are actually run, so this PR ensures the `--deny-warnings` flag is applied on the test command.

You will see that the first commit in this PR [fails](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/107448/workflows/2b3fb267-19c1-452e-9df0-5adba7f54400/jobs/4092639) because of the compiler warnings. The second commit addresses the warnings.