### PR TITLE
op-e2e: Only deploy the fast game in AllocTypeFastGame

### DIFF
--- a/op-e2e/config/init.go
+++ b/op-e2e/config/init.go
@@ -237,6 +237,23 @@ func initAllocType(root string, allocType AllocType) {
 			}
 			if allocType == AllocTypeFastGame {
 				intent.GlobalDeployOverrides["preimageOracleChallengePeriod"] = 1
+				for _, chain := range intent.Chains {
+					chain.AdditionalDisputeGames = append(chain.AdditionalDisputeGames,
+						state.AdditionalDisputeGame{
+							ChainProofParams: state.ChainProofParams{
+								// Fast game
+								DisputeGameType: 254,
+								// Prestate doesn't matter as there's no time to play the game anyway.
+								DisputeAbsolutePrestate: common.HexToHash("0x03c7ae758795765c6664a5d39bf63841c71ff191e9189522bad8ebff5d4eca98"),
+								DisputeMaxGameDepth:     14 + 3 + 1,
+								DisputeSplitDepth:       14,
+								DisputeClockExtension:   0,
+								DisputeMaxClockDuration: 1,
+							},
+							VMType:        state.VMTypeAlphabet,
+							MakeRespected: true,
+						})
+				}
 			}
 
 			baseUpgradeSchedule := map[string]any{
@@ -402,19 +419,6 @@ func defaultIntent(root string, loc *artifacts.Locator, deployer common.Address,
 				UseRevenueShare:    true,
 				ChainFeesRecipient: common.HexToAddress("0xBcd4042DE499D14e55001CcbB24a551F3b954096"),
 				AdditionalDisputeGames: []state.AdditionalDisputeGame{
-					{
-						ChainProofParams: state.ChainProofParams{
-							// Fast game
-							DisputeGameType:         254,
-							DisputeAbsolutePrestate: defaultPrestate,
-							DisputeMaxGameDepth:     14 + 3 + 1,
-							DisputeSplitDepth:       14,
-							DisputeClockExtension:   0,
-							DisputeMaxClockDuration: 120,
-						},
-						VMType:        state.VMTypeAlphabet,
-						MakeRespected: true,
-					},
 					{
 						ChainProofParams: state.ChainProofParams{
 							// Alphabet game

--- a/op-e2e/faultproofs/output_alphabet_test.go
+++ b/op-e2e/faultproofs/output_alphabet_test.go
@@ -9,7 +9,6 @@ import (
 	op_e2e "github.com/ethereum-optimism/optimism/op-e2e"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/types"
-	"github.com/ethereum-optimism/optimism/op-e2e/config"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/challenger"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/disputegame"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
@@ -21,7 +20,7 @@ import (
 func TestOutputAlphabetGame_ChallengerWins(t *testing.T) {
 	op_e2e.InitParallel(t)
 	ctx := context.Background()
-	sys, l1Client := StartFaultDisputeSystem(t, WithAllocType(config.AllocTypeFastGame))
+	sys, l1Client := StartFaultDisputeSystem(t)
 	t.Cleanup(sys.Close)
 
 	disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
@@ -78,7 +77,7 @@ func TestOutputAlphabetGame_ChallengerWins(t *testing.T) {
 func TestOutputAlphabetGame_ReclaimBond(t *testing.T) {
 	op_e2e.InitParallel(t)
 	ctx := context.Background()
-	sys, l1Client := StartFaultDisputeSystem(t, WithAllocType(config.AllocTypeFastGame))
+	sys, l1Client := StartFaultDisputeSystem(t)
 	t.Cleanup(sys.Close)
 
 	disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
@@ -148,7 +147,7 @@ func TestOutputAlphabetGame_ReclaimBond(t *testing.T) {
 func TestOutputAlphabetGame_ValidOutputRoot(t *testing.T) {
 	op_e2e.InitParallel(t)
 	ctx := context.Background()
-	sys, l1Client := StartFaultDisputeSystem(t, WithAllocType(config.AllocTypeFastGame))
+	sys, l1Client := StartFaultDisputeSystem(t)
 	t.Cleanup(sys.Close)
 
 	disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
@@ -185,7 +184,7 @@ func TestChallengerCompleteExhaustiveDisputeGame(t *testing.T) {
 
 	testCase := func(t *testing.T, isRootCorrect bool) {
 		ctx := context.Background()
-		sys, l1Client := StartFaultDisputeSystem(t, WithAllocType(config.AllocTypeFastGame))
+		sys, l1Client := StartFaultDisputeSystem(t)
 		t.Cleanup(sys.Close)
 
 		disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
@@ -250,7 +249,7 @@ func TestChallengerCompleteExhaustiveDisputeGame(t *testing.T) {
 func TestOutputAlphabetGame_FreeloaderEarnsNothing(t *testing.T) {
 	op_e2e.InitParallel(t)
 	ctx := context.Background()
-	sys, l1Client := StartFaultDisputeSystem(t, WithAllocType(config.AllocTypeFastGame))
+	sys, l1Client := StartFaultDisputeSystem(t)
 	t.Cleanup(sys.Close)
 
 	freeloaderOpts, err := bind.NewKeyedTransactorWithChainID(sys.Cfg.Secrets.Mallory, sys.Cfg.L1ChainIDBig())
@@ -314,7 +313,7 @@ func TestOutputAlphabetGame_FreeloaderEarnsNothing(t *testing.T) {
 func TestHighestActedL1BlockMetric(t *testing.T) {
 	op_e2e.InitParallel(t)
 	ctx := context.Background()
-	sys, l1Client := StartFaultDisputeSystem(t, WithAllocType(config.AllocTypeFastGame))
+	sys, l1Client := StartFaultDisputeSystem(t)
 	t.Cleanup(sys.Close)
 
 	disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)

--- a/op-e2e/system/bridge/validity_test.go
+++ b/op-e2e/system/bridge/validity_test.go
@@ -267,7 +267,7 @@ func TestMixedDepositValidity(t *testing.T) {
 }
 
 func TestMixedWithdrawalValidity_Default(t *testing.T) {
-	testMixedWithdrawalValidity(t, config.DefaultAllocType)
+	testMixedWithdrawalValidity(t, config.AllocTypeFastGame)
 }
 
 // TestMixedWithdrawalValidity makes a number of withdrawal transactions and ensures ones with modified parameters are

--- a/op-e2e/system/bridge/withdrawal_test.go
+++ b/op-e2e/system/bridge/withdrawal_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestWithdrawals_Default(t *testing.T) {
-	testWithdrawals(t, config.DefaultAllocType)
+	testWithdrawals(t, config.AllocTypeFastGame)
 }
 
 // testWithdrawals checks that a deposit and then withdrawal execution succeeds. It verifies the

--- a/op-e2e/system/e2esys/setup.go
+++ b/op-e2e/system/e2esys/setup.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/maps"
 
@@ -925,12 +926,16 @@ func (cfg SystemConfig) Start(t *testing.T, startOpts ...StartOption) (*System, 
 	}
 
 	// L2Output Submitter
+	respectedGameType := faultTypes.PermissionedGameType
+	if cfg.AllocType == config.AllocTypeFastGame {
+		respectedGameType = faultTypes.FastGameType
+	}
 	proposerCLIConfig := &l2os.CLIConfig{
 		L1EthRpc:          sys.EthInstances[RoleL1].UserRPC().RPC(),
 		RollupRpc:         sys.RollupNodes[RoleSeq].UserRPC().RPC(),
 		DGFAddress:        config.L1Deployments(cfg.AllocType).DisputeGameFactoryProxy.Hex(),
 		ProposalInterval:  6 * time.Second,
-		DisputeGameType:   254, // Fast game type
+		DisputeGameType:   uint32(respectedGameType),
 		PollInterval:      500 * time.Millisecond,
 		TxMgrConfig:       setuputils.NewTxMgrConfig(sys.EthInstances[RoleL1].UserRPC(), cfg.Secrets.Proposer),
 		AllowNonFinalized: cfg.NonFinalizedProposals,


### PR DESCRIPTION
Only deploy the fast game in AllocTypeFastGame
Use the fast game alloc in withdrawal tests and not in alphabet tests.
Actually make the fast game fast.