### PR TITLE
build(contracts): enforce compiler warnings and fix test return value checks

### DIFF
--- a/packages/contracts-bedrock/foundry.toml
+++ b/packages/contracts-bedrock/foundry.toml
@@ -69,6 +69,7 @@ fs_permissions = [
 
 # 5159 error code is selfdestruct error code
 ignored_error_codes = ["transient-storage", "code-size", "init-code-size", 5159]
+deny_warnings = true
 ffi = true
 
 # We set the gas limit to max int64 to avoid running out of gas during testing, since the default

--- a/packages/contracts-bedrock/foundry.toml
+++ b/packages/contracts-bedrock/foundry.toml
@@ -68,7 +68,7 @@ fs_permissions = [
 ]
 
 # 5159 error code is selfdestruct error code
-ignored_error_codes = ["transient-storage", "code-size", "init-code-size", 5159]
+ignored_error_codes = ["transient-storage", "code-size", "init-code-size", "too-many-warnings", 5159]
 deny_warnings = true
 ffi = true
 

--- a/packages/contracts-bedrock/justfile
+++ b/packages/contracts-bedrock/justfile
@@ -352,6 +352,7 @@ pre-commit *ARGS:
 # Cleans, builds, lints, and runs all checks.
 pre-pr *ARGS:
   #!/bin/bash
+  set -e
   # Optionally clean the previous build.
   # --clean is typically not needed but can force a clean build if you suspect cache issues.
   if [[ "{{ARGS}}" == *"--clean"* ]]; then

--- a/packages/contracts-bedrock/test/L2/FeeSplitter.t.sol
+++ b/packages/contracts-bedrock/test/L2/FeeSplitter.t.sol
@@ -153,6 +153,7 @@ contract FeeSplitter_Initialize_Test is FeeSplitter_TestInit {
 contract FeeSplitter_Receive_Test is FeeSplitter_TestInit {
     /// @notice Test that receive function reverts when sender is not an approved vault
     function testFuzz_feeSplitterReceive_whenNotApprovedVault_reverts(address _caller, uint256 _amount) public {
+        vm.assume(_caller != address(0));
         vm.assume(_caller != Predeploys.SEQUENCER_FEE_WALLET);
         vm.assume(_caller != Predeploys.BASE_FEE_VAULT);
         vm.assume(_caller != Predeploys.OPERATOR_FEE_VAULT);
@@ -161,12 +162,13 @@ contract FeeSplitter_Receive_Test is FeeSplitter_TestInit {
 
         vm.prank(_caller);
         vm.expectRevert(IFeeSplitter.FeeSplitter_SenderNotCurrentVault.selector);
-        (bool success,) = payable(address(feeSplitter)).call{ value: _amount }("");
-        assert(!success);
+        (bool revertsAsExpected,) = payable(address(feeSplitter)).call{ value: _amount }("");
+        assertTrue(revertsAsExpected, "FeeSplitter_Test: call did not revert");
     }
 
     /// @notice Test receive function from non-approved vault reverts even during disbursement
     function testFuzz_feeSplitterReceive_whenNonFeeVault_reverts(address _caller, uint256 _amount) public {
+        vm.assume(_caller != address(0));
         vm.assume(_caller != Predeploys.SEQUENCER_FEE_WALLET);
         vm.assume(_caller != Predeploys.BASE_FEE_VAULT);
         vm.assume(_caller != Predeploys.OPERATOR_FEE_VAULT);
@@ -178,8 +180,8 @@ contract FeeSplitter_Receive_Test is FeeSplitter_TestInit {
 
         // Now we test the actual sender validation
         vm.expectRevert(IFeeSplitter.FeeSplitter_SenderNotCurrentVault.selector);
-        (bool success,) = payable(address(feeSplitter)).call{ value: _amount }("");
-        assert(!success);
+        (bool revertsAsExpected,) = payable(address(feeSplitter)).call{ value: _amount }("");
+        assertTrue(revertsAsExpected, "FeeSplitter_Test: call did not revert");
     }
 
     /// @notice Test receive function works during disbursement from SequencerFeeVault
@@ -661,8 +663,8 @@ contract FeeSplitter_DisburseFees_Test is FeeSplitter_TestInit {
         // Attempt to send ETH from the vault - should revert because transient storage was cleared
         vm.prank(_vault);
         vm.expectRevert(IFeeSplitter.FeeSplitter_SenderNotCurrentVault.selector);
-        (bool success,) = payable(address(feeSplitter)).call{ value: _attemptAmount }("");
-        assert(!success);
+        (bool revertsAsExpected,) = payable(address(feeSplitter)).call{ value: _attemptAmount }("");
+        assertTrue(revertsAsExpected, "FeeSplitter_Test: call did not revert");
     }
 }
 

--- a/packages/contracts-bedrock/test/L2/FeeSplitter.t.sol
+++ b/packages/contracts-bedrock/test/L2/FeeSplitter.t.sol
@@ -161,7 +161,8 @@ contract FeeSplitter_Receive_Test is FeeSplitter_TestInit {
 
         vm.prank(_caller);
         vm.expectRevert(IFeeSplitter.FeeSplitter_SenderNotCurrentVault.selector);
-        payable(address(feeSplitter)).call{ value: _amount }("");
+        (bool success,) = payable(address(feeSplitter)).call{ value: _amount }("");
+        assert(!success);
     }
 
     /// @notice Test receive function from non-approved vault reverts even during disbursement
@@ -177,7 +178,8 @@ contract FeeSplitter_Receive_Test is FeeSplitter_TestInit {
 
         // Now we test the actual sender validation
         vm.expectRevert(IFeeSplitter.FeeSplitter_SenderNotCurrentVault.selector);
-        payable(address(feeSplitter)).call{ value: _amount }("");
+        (bool success,) = payable(address(feeSplitter)).call{ value: _amount }("");
+        assert(!success);
     }
 
     /// @notice Test receive function works during disbursement from SequencerFeeVault
@@ -659,7 +661,8 @@ contract FeeSplitter_DisburseFees_Test is FeeSplitter_TestInit {
         // Attempt to send ETH from the vault - should revert because transient storage was cleared
         vm.prank(_vault);
         vm.expectRevert(IFeeSplitter.FeeSplitter_SenderNotCurrentVault.selector);
-        payable(address(feeSplitter)).call{ value: _attemptAmount }("");
+        (bool success,) = payable(address(feeSplitter)).call{ value: _attemptAmount }("");
+        assert(!success);
     }
 }
 

--- a/packages/contracts-bedrock/test/L2/FeeSplitterVaults.t.sol
+++ b/packages/contracts-bedrock/test/L2/FeeSplitterVaults.t.sol
@@ -52,7 +52,8 @@ contract FeeSplitterVaults_Receive_Test is Test {
                 }
 
                 vm.prank(_selectedVault);
-                payable(address(feeSplitter)).call{ value: _amount }("");
+                (bool success,) = payable(address(feeSplitter)).call{ value: _amount }("");
+                require(success, "FeeSplitterVaults_Test: call failed");
             }
         }
     }


### PR DESCRIPTION
### Changes

- Add `deny_warnings = true` to `foundry.toml` default profile
- Add `set -e` to `just pre-pr` command in justfile
- Add `"too-many-warnings"` to `ignored_error_codes` in foundry.toml
- Fix unchecked low-level call return values in `FeeSplitter` tests (4 occurrences)

### Why

The CI was showing Warning 9302 (unchecked low-level call return values) but not failing builds. This PR:

1. **Enforces warnings as errors** via `deny_warnings = true` so future warnings will block CI
2. **Makes pre-pr fail fast** via `set -e` to catch issues earlier in the development cycle
3. **Ignores the "too-many-warnings" meta-warning** - Solidity stops reporting after 256 warnings and throws this error, but still returns the warnings we care about (like 9302). The ignored codes list is foundry's filtering layer on top of Solidity's output
4. **Fixes existing warnings** by properly checking return values from `.call()` operations in test files