### PR TITLE
op-node: Light CL: Frontend Flags

### DIFF
--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -222,7 +222,6 @@ var (
 		Usage:    "Disable derivation",
 		EnvVars:  prefixEnvVars("L2_UNSAFE_ONLY"),
 		Category: RollupCategory,
-		Value:    false,
 		Required: false,
 	}
 	L2FollowSource = &cli.StringFlag{
@@ -230,7 +229,6 @@ var (
 		Usage:    "Address of L2 EL RPC HTTP endpoint to fetch safe/finalized blocks",
 		EnvVars:  prefixEnvVars("L2_FOLLOW_SOURCE"),
 		Category: RollupCategory,
-		Value:    "",
 		Required: false,
 	}
 	VerifierL1Confs = &cli.Uint64Flag{

--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -217,6 +217,22 @@ var (
 		Value:    time.Second * 10,
 		Category: RollupCategory,
 	}
+	L2UnsafeOnly = &cli.BoolFlag{
+		Name:     "l2.unsafe-only",
+		Usage:    "Disable derivation",
+		EnvVars:  prefixEnvVars("L2_UNSAFE_ONLY"),
+		Category: RollupCategory,
+		Value:    false,
+		Required: false,
+	}
+	L2FollowSource = &cli.StringFlag{
+		Name:     "l2.follow.source",
+		Usage:    "Address of L2 EL RPC HTTP endpoint to fetch safe/finalized blocks",
+		EnvVars:  prefixEnvVars("L2_FOLLOW_SOURCE"),
+		Category: RollupCategory,
+		Value:    "",
+		Required: false,
+	}
 	VerifierL1Confs = &cli.Uint64Flag{
 		Name:     "verifier.l1-confs",
 		Usage:    "Number of L1 blocks to keep distance from the L1 head before deriving L2 data from. Reorgs are supported, but may be slow to perform.",
@@ -486,6 +502,8 @@ var optionalFlags = []cli.Flag{
 	L1ChainConfig,
 	L2EngineKind,
 	L2EngineRpcTimeout,
+	L2UnsafeOnly,
+	L2FollowSource,
 	InteropRPCAddr,
 	InteropRPCPort,
 	InteropJWTSecret,

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -201,8 +201,10 @@ type InitializationOverrides struct {
 // some later initialization steps depend on the node being partially initialized with other components,
 // so order is important to ensure that all resources are available when needed.
 func (n *OpNode) init(ctx context.Context, cfg *config.Config, overrides InitializationOverrides) error {
-
 	n.log.Info("Initializing rollup node", "version", n.appVersion)
+	if cfg.Sync.UnsafeOnly {
+		n.log.Info("Disabled derivation", "followSourceEnabled", cfg.Sync.L2FollowSourceEndpoint != "")
+	}
 
 	var err error
 

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -202,9 +202,14 @@ type InitializationOverrides struct {
 // so order is important to ensure that all resources are available when needed.
 func (n *OpNode) init(ctx context.Context, cfg *config.Config, overrides InitializationOverrides) error {
 	n.log.Info("Initializing rollup node", "version", n.appVersion)
+	safe := "enabled"
 	if cfg.Sync.UnsafeOnly {
-		n.log.Info("Disabled derivation", "followSourceEnabled", cfg.Sync.L2FollowSourceEndpoint != "")
+		safe = cfg.Sync.L2FollowSourceEndpoint
+		if safe == "" {
+			safe = "disabled"
+		}
 	}
+	n.log.Info("Safety levels", "unsafe", "enabled", "safe", safe)
 
 	var err error
 

--- a/op-node/rollup/sync/config.go
+++ b/op-node/rollup/sync/config.go
@@ -74,4 +74,11 @@ type Config struct {
 	SkipSyncStartCheck bool `json:"skip_sync_start_check"`
 
 	SupportsPostFinalizationELSync bool `json:"supports_post_finalization_elsync"`
+
+	UnsafeOnly             bool   `json:"unsafe_only"`
+	L2FollowSourceEndpoint string `json:"l2_follow_source_endpoint"`
+}
+
+func (c *Config) L2FollowSourceEnabled() bool {
+	return c.L2FollowSourceEndpoint != ""
 }

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -350,8 +350,8 @@ func NewSyncConfig(ctx cliiface.Context, log log.Logger) (*sync.Config, error) {
 		return nil, err
 	}
 	unsafeOnly := ctx.Bool(flags.L2UnsafeOnly.Name)
-	isVerifier := !ctx.Bool(flags.SequencerEnabledFlag.Name)
-	if unsafeOnly && isVerifier {
+	isSequencer := ctx.Bool(flags.SequencerEnabledFlag.Name)
+	if unsafeOnly && !isSequencer {
 		// The verifier node initially gains payloads from the sequencer via CLP2P.
 		// To sync to the chain tip, the verifier must close the gap between its current
 		// unsafe view and the sequencer's latest unsafe payloads.

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -340,6 +340,12 @@ func NewSyncConfig(ctx cliiface.Context, log log.Logger) (*sync.Config, error) {
 	} else if ctx.IsSet(flags.L2EngineSyncEnabled.Name) {
 		log.Error("l2.engine-sync is deprecated and will be removed in a future release. Use --syncmode=execution-layer instead.")
 	}
+	unsafeOnly := ctx.Bool(flags.L2UnsafeOnly.Name)
+	l2FollowSourceEndpoint := ctx.String(flags.L2FollowSource.Name)
+	if !unsafeOnly && l2FollowSourceEndpoint != "" {
+		return nil, errors.New("cannot follow external safe/finalized with derivation enabled (--l2.unsafe-only=false): " +
+			"Either remove --l2.follow.source or set --l2.unsafe-only=true to disable derivation")
+	}
 	rrSyncEnabled := ctx.Bool(flags.SyncModeReqRespFlag.Name)
 	// p2p.sync.req-resp=false && syncmode.req-resp=true is not allowed
 	if !ctx.Bool(flags.SyncReqRespName) && rrSyncEnabled {
@@ -349,7 +355,6 @@ func NewSyncConfig(ctx cliiface.Context, log log.Logger) (*sync.Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	unsafeOnly := ctx.Bool(flags.L2UnsafeOnly.Name)
 	isSequencer := ctx.Bool(flags.SequencerEnabledFlag.Name)
 	if unsafeOnly && !isSequencer {
 		// The verifier node initially gains payloads from the sequencer via CLP2P.
@@ -366,11 +371,6 @@ func NewSyncConfig(ctx cliiface.Context, log log.Logger) (*sync.Config, error) {
 		}
 		// If RR Sync is not used, EL Sync will fill in the unsafe gap.
 		// This path is much faster and more practical for closing the gap.
-	}
-	l2FollowSourceEndpoint := ctx.String(flags.L2FollowSource.Name)
-	if !unsafeOnly && l2FollowSourceEndpoint != "" {
-		return nil, errors.New("cannot follow external safe/finalized with derivation enabled (--l2.unsafe-only=false): " +
-			"Either remove --l2.follow.source or set --l2.unsafe-only=true to disable derivation")
 	}
 	engineKind := engine.Kind(ctx.String(flags.L2EngineKind.Name))
 	cfg := &sync.Config{

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -372,9 +372,6 @@ func NewSyncConfig(ctx cliiface.Context, log log.Logger) (*sync.Config, error) {
 		return nil, errors.New("cannot follow external safe/finalized with derivation enabled (--l2.unsafe-only=false): " +
 			"Either remove --l2.follow.source or set --l2.unsafe-only=true to disable derivation")
 	}
-	if unsafeOnly {
-		log.Info("Disabled derivation", "followSourceEnabled", l2FollowSourceEndpoint != "")
-	}
 	engineKind := engine.Kind(ctx.String(flags.L2EngineKind.Name))
 	cfg := &sync.Config{
 		SyncMode:                       mode,

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -340,25 +340,52 @@ func NewSyncConfig(ctx cliiface.Context, log log.Logger) (*sync.Config, error) {
 	} else if ctx.IsSet(flags.L2EngineSyncEnabled.Name) {
 		log.Error("l2.engine-sync is deprecated and will be removed in a future release. Use --syncmode=execution-layer instead.")
 	}
+	rrSyncEnabled := ctx.Bool(flags.SyncModeReqRespFlag.Name)
 	// p2p.sync.req-resp=false && syncmode.req-resp=true is not allowed
-	if !ctx.Bool(flags.SyncReqRespName) && ctx.Bool(flags.SyncModeReqRespFlag.Name) {
+	if !ctx.Bool(flags.SyncReqRespName) && rrSyncEnabled {
 		return nil, errors.New("cannot set --p2p.sync.req-resp=false and --syncmode.req-resp=true at the same time")
 	}
 	mode, err := sync.StringToMode(ctx.String(flags.SyncModeFlag.Name))
 	if err != nil {
 		return nil, err
 	}
-
+	unsafeOnly := ctx.Bool(flags.L2UnsafeOnly.Name)
+	isVerifier := !ctx.Bool(flags.SequencerEnabledFlag.Name)
+	if unsafeOnly && isVerifier {
+		// The verifier node initially gains payloads from the sequencer via CLP2P.
+		// To sync to the chain tip, the verifier must close the gap between its current
+		// unsafe view and the sequencer's latest unsafe payloads.
+		// With derivation disabled, the node can only rely on RR Sync or EL Sync to close this gap.
+		if rrSyncEnabled {
+			// Allowing RR Sync technically works, but it is impractical for a verifier to
+			// rely solely on RR Syncing - bootstrapping would take too long.
+			// Since RR Sync is also being deprecated, fail early for clarity.
+			return nil, errors.New("derivation disabled (--l2.unsafe-only=true) and RR sync enabled (--syncmode.req-resp=true): " +
+				"reaching the unsafe tip would rely solely on RR sync, " +
+				"which is infeasible for bootstrap. Disable RR sync or enable derivation")
+		}
+		// If RR Sync is not used, EL Sync will fill in the unsafe gap.
+		// This path is much faster and more practical for closing the gap.
+	}
+	l2FollowSourceEndpoint := ctx.String(flags.L2FollowSource.Name)
+	if !unsafeOnly && l2FollowSourceEndpoint != "" {
+		return nil, errors.New("cannot follow external safe/finalized with derivation enabled (--l2.unsafe-only=false): " +
+			"Either remove --l2.follow.source or set --l2.unsafe-only=true to disable derivation")
+	}
+	if unsafeOnly {
+		log.Info("Disabled derivation", "followSourceEnabled", l2FollowSourceEndpoint != "")
+	}
 	engineKind := engine.Kind(ctx.String(flags.L2EngineKind.Name))
 	cfg := &sync.Config{
 		SyncMode:                       mode,
 		SyncModeReqResp:                ctx.Bool(flags.SyncModeReqRespFlag.Name),
 		SkipSyncStartCheck:             ctx.Bool(flags.SkipSyncStartCheck.Name),
 		SupportsPostFinalizationELSync: engineKind.SupportsPostFinalizationELSync(),
+		UnsafeOnly:                     unsafeOnly,
+		L2FollowSourceEndpoint:         l2FollowSourceEndpoint,
 	}
 	if ctx.Bool(flags.L2EngineSyncEnabled.Name) {
 		cfg.SyncMode = sync.ELSync
 	}
-
 	return cfg, nil
 }

--- a/op-node/service_test.go
+++ b/op-node/service_test.go
@@ -62,8 +62,7 @@ func TestNewSyncConfig_FollowSourceWithDerivationEnabled(t *testing.T) {
 		// unsafe-only defaults in false
 		fmt.Sprintf("--%s=http://example", flags.L2FollowSource.Name),
 	})
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "cannot follow external safe/finalized with derivation enabled")
+	require.ErrorContains(t, err, "cannot follow external safe/finalized with derivation enabled")
 }
 
 func TestNewSyncConfig_VerifierUnsafeOnlyWithRRSyncEnabled(t *testing.T) {
@@ -72,6 +71,5 @@ func TestNewSyncConfig_VerifierUnsafeOnlyWithRRSyncEnabled(t *testing.T) {
 		fmt.Sprintf("--%s=true", flags.L2UnsafeOnly.Name),
 		fmt.Sprintf("--%s=true", flags.SyncModeReqRespFlag.Name),
 	})
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "reaching the unsafe tip would rely solely on RR sync")
+	require.ErrorContains(t, err, "reaching the unsafe tip would rely solely on RR sync")
 }

--- a/op-node/service_test.go
+++ b/op-node/service_test.go
@@ -1,0 +1,77 @@
+package opnode
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-node/flags"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
+)
+
+func syncConfigCliApp() *cli.App {
+	syncConfigFlags := append([]cli.Flag{
+		flags.L2UnsafeOnly,
+		flags.SequencerEnabledFlag,
+		flags.L2EngineSyncEnabled,
+		flags.SyncModeFlag,
+		flags.SyncModeReqRespFlag,
+		flags.L2FollowSource,
+		flags.L2EngineKind,
+		flags.SkipSyncStartCheck,
+	}, flags.P2PFlags("")..., // For p2p.sync.req-resp
+	)
+	return &cli.App{
+		Flags: syncConfigFlags,
+		Action: func(c *cli.Context) error {
+			_, err := NewSyncConfig(c, log.New())
+			return err
+		},
+	}
+}
+
+func run(args []string) error {
+	return syncConfigCliApp().Run(append([]string{"test"}, args...))
+}
+
+func TestNewSyncConfigDefault(t *testing.T) {
+	require.NoError(t, run(nil))
+}
+
+func TestNewSyncConfig_DerivationDisabled_NoRRSync(t *testing.T) {
+	err := run([]string{
+		fmt.Sprintf("--%s=true", flags.L2UnsafeOnly.Name),
+		// No follow source with no derivation allowed
+		fmt.Sprintf("--%s=false", flags.SyncModeReqRespFlag.Name),
+	})
+	require.NoError(t, err)
+}
+
+func TestNewSyncConfig_FollowSourceWithDerivationDisabled(t *testing.T) {
+	err := run([]string{
+		fmt.Sprintf("--%s=true", flags.L2UnsafeOnly.Name),
+		fmt.Sprintf("--%s=http://example", flags.L2FollowSource.Name),
+		fmt.Sprintf("--%s=false", flags.SyncModeReqRespFlag.Name),
+	})
+	require.NoError(t, err)
+}
+
+func TestNewSyncConfig_FollowSourceWithDerivationEnabled(t *testing.T) {
+	err := run([]string{
+		// unsafe-only defaults in false
+		fmt.Sprintf("--%s=http://example", flags.L2FollowSource.Name),
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cannot follow external safe/finalized with derivation enabled")
+}
+
+func TestNewSyncConfig_VerifierUnsafeOnlyWithRRSyncEnabled(t *testing.T) {
+	err := run([]string{
+		// verifier mode is default
+		fmt.Sprintf("--%s=true", flags.L2UnsafeOnly.Name),
+		fmt.Sprintf("--%s=true", flags.SyncModeReqRespFlag.Name),
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "reaching the unsafe tip would rely solely on RR sync")
+}


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Add a flag: `l2.unsafe-only=[bool]` and `l2.follow.source=[RPC_STR]` which both are optional.

Adds fields to the `syncConfig` struct and also sanity check flag combinations.

No actual backend logic added yet.

**Tests**

Unit tests added, covering error case combinations, and the default one succeeds.
