### PR TITLE
ci(contracts): increase heavy-fuzz job resources to 2xlarge

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -967,7 +967,7 @@ jobs:
     circleci_ip_ranges: true
     docker:
       - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: xlarge
+    resource_class: 2xlarge
     steps:
       - utils/checkout-with-mise:
          checkout-method: blobless


### PR DESCRIPTION
### Changes
- Upgraded `contracts-bedrock-heavy-fuzz-nightly` CircleCI job's resources from `xlarge` to `2xlarge`

### Reason
The heavy-fuzz job has been failing consistently with `solc` being killed by the OOM killer during compilation (signal 9). The compilation step requires more memory than the xlarge instance provides, causing the build to fail before tests can even run.