### PR TITLE
op-dispute-mon: Rename L2BlockNumber to L2SequenceNumber

### DIFF
--- a/op-dispute-mon/mon/different_output_roots.go
+++ b/op-dispute-mon/mon/different_output_roots.go
@@ -28,7 +28,7 @@ func (m *DifferentOutputRootMonitor) CheckDifferentOutputRoots(games []*types.En
 			count++
 			m.logger.Debug("Different output roots detected",
 				"game", game.Proxy,
-				"l2BlockNumber", game.L2BlockNumber,
+				"l2SequenceNumber", game.L2SequenceNumber,
 				"rootClaim", game.RootClaim)
 		}
 	}

--- a/op-dispute-mon/mon/different_output_roots_test.go
+++ b/op-dispute-mon/mon/different_output_roots_test.go
@@ -16,25 +16,25 @@ func TestCheckDifferentOutputRoots(t *testing.T) {
 		{
 			GameMetadata:                       gameTypes.GameMetadata{Proxy: common.Address{0x11}},
 			RollupEndpointDifferentOutputRoots: true,
-			L2BlockNumber:                      100,
+			L2SequenceNumber:                   100,
 			RootClaim:                          common.HexToHash("0xaaa"),
 		},
 		{
 			GameMetadata:                       gameTypes.GameMetadata{Proxy: common.Address{0x22}},
 			RollupEndpointDifferentOutputRoots: false, // No disagreement
-			L2BlockNumber:                      200,
+			L2SequenceNumber:                   200,
 			RootClaim:                          common.HexToHash("0xbbb"),
 		},
 		{
 			GameMetadata:                       gameTypes.GameMetadata{Proxy: common.Address{0x33}},
 			RollupEndpointDifferentOutputRoots: true,
-			L2BlockNumber:                      300,
+			L2SequenceNumber:                   300,
 			RootClaim:                          common.HexToHash("0xccc"),
 		},
 		{
 			GameMetadata:                       gameTypes.GameMetadata{Proxy: common.Address{0x44}},
 			RollupEndpointDifferentOutputRoots: false, // No disagreement
-			L2BlockNumber:                      400,
+			L2SequenceNumber:                   400,
 			RootClaim:                          common.HexToHash("0xddd"),
 		},
 	}
@@ -52,7 +52,7 @@ func TestCheckDifferentOutputRoots(t *testing.T) {
 
 	l := logs[0]
 	require.Equal(t, common.Address{0x11}, l.AttrValue("game"))
-	require.Equal(t, uint64(100), l.AttrValue("l2BlockNumber"))
+	require.Equal(t, uint64(100), l.AttrValue("l2SequenceNumber"))
 	require.Equal(t, common.HexToHash("0xaaa"), l.AttrValue("rootClaim"))
 
 	// Info log for summary
@@ -108,17 +108,17 @@ func TestCheckDifferentOutputRoots_AllGamesHaveDisagreements(t *testing.T) {
 		{
 			GameMetadata:                       gameTypes.GameMetadata{Proxy: common.Address{0x11}},
 			RollupEndpointDifferentOutputRoots: true,
-			L2BlockNumber:                      100,
+			L2SequenceNumber:                   100,
 		},
 		{
 			GameMetadata:                       gameTypes.GameMetadata{Proxy: common.Address{0x22}},
 			RollupEndpointDifferentOutputRoots: true,
-			L2BlockNumber:                      200,
+			L2SequenceNumber:                   200,
 		},
 		{
 			GameMetadata:                       gameTypes.GameMetadata{Proxy: common.Address{0x33}},
 			RollupEndpointDifferentOutputRoots: true,
-			L2BlockNumber:                      300,
+			L2SequenceNumber:                   300,
 		},
 	}
 	metrics := &stubDifferentOutputRootMetrics{}

--- a/op-dispute-mon/mon/extract/extractor.go
+++ b/op-dispute-mon/mon/extract/extractor.go
@@ -152,7 +152,7 @@ func (e *Extractor) enrichGame(ctx context.Context, blockHash common.Hash, game 
 		LastUpdateTime:               e.clock.Now(),
 		GameMetadata:                 game,
 		L1Head:                       meta.L1Head,
-		L2BlockNumber:                meta.L2SequenceNum,
+		L2SequenceNumber:             meta.L2SequenceNum,
 		RootClaim:                    meta.RootClaim,
 		Status:                       meta.Status,
 		MaxClockDuration:             meta.MaxClockDuration,

--- a/op-dispute-mon/mon/extract/output_agreement_enricher.go
+++ b/op-dispute-mon/mon/extract/output_agreement_enricher.go
@@ -64,7 +64,7 @@ func (o *OutputAgreementEnricher) Enrich(ctx context.Context, block rpcblock.Blo
 	if len(o.clients) == 0 {
 		return fmt.Errorf("%w but required for game type %v", ErrRollupRpcRequired, game.GameType)
 	}
-	if game.L2BlockNumber > math.MaxInt64 {
+	if game.L2SequenceNumber > math.MaxInt64 {
 		// The claimed block number is bigger than an int64. The BlockNumber type used by RPCs is an int64 so anything
 		// bigger than that can't be a valid block. So we can determine that this proposal invalid just because it
 		// has a ridiculously big block number which must be far in the future.
@@ -92,7 +92,7 @@ func (o *OutputAgreementEnricher) Enrich(ctx context.Context, block rpcblock.Blo
 				return
 			}
 
-			output, err := client.OutputAtBlock(ctx, game.L2BlockNumber)
+			output, err := client.OutputAtBlock(ctx, game.L2SequenceNumber)
 			if err != nil {
 				// Only treat JSON-RPC application-level "not found" as notFound.
 				// Transport/HTTP errors or other failures should be treated as errors.
@@ -114,13 +114,13 @@ func (o *OutputAgreementEnricher) Enrich(ctx context.Context, block rpcblock.Blo
 			if outputRoot == game.RootClaim {
 				safeHead, err := client.SafeHeadAtL1Block(ctx, game.L1HeadNum)
 				if err != nil {
-					o.log.Warn("Unable to verify proposed block was safe", "l1HeadNum", game.L1HeadNum, "l2BlockNum", game.L2BlockNumber, "err", err)
+					o.log.Warn("Unable to verify proposed block was safe", "l1HeadNum", game.L1HeadNum, "l2SequenceNumber", game.L2SequenceNumber, "err", err)
 					// If safe head data isn't available, assume the output root was safe
 					// Avoids making the dispute mon dependent on safe head db being available
 					results[i].isSafe = true
 					return
 				}
-				results[i].isSafe = safeHead.SafeHead.Number >= game.L2BlockNumber
+				results[i].isSafe = safeHead.SafeHead.Number >= game.L2SequenceNumber
 			}
 		}(i, client)
 	}
@@ -130,7 +130,7 @@ func (o *OutputAgreementEnricher) Enrich(ctx context.Context, block rpcblock.Blo
 	foundResults := make([]outputResult, 0, len(results))
 	for idx, result := range results {
 		if result.err != nil {
-			o.log.Error("Failed to fetch output root", "clientIndex", idx, "l2BlockNum", game.L2BlockNumber, "err", result.err)
+			o.log.Error("Failed to fetch output root", "clientIndex", idx, "l2SequenceNumber", game.L2SequenceNumber, "err", result.err)
 			endpointID := fmt.Sprintf("client-%d", idx)
 			game.RollupEndpointErrors[endpointID] = true
 			game.RollupEndpointErrorCount++
@@ -191,7 +191,7 @@ func (o *OutputAgreementEnricher) Enrich(ctx context.Context, block rpcblock.Blo
 
 	if diverged {
 		o.log.Warn("Nodes disagree on output root",
-			"l2BlockNum", game.L2BlockNumber,
+			"l2SequenceNumber", game.L2SequenceNumber,
 			"firstOutput", firstResult.outputRoot,
 			"found", len(foundResults),
 			"valid", len(validResults))

--- a/op-dispute-mon/mon/extract/output_agreement_enricher_test.go
+++ b/op-dispute-mon/mon/extract/output_agreement_enricher_test.go
@@ -31,7 +31,7 @@ func TestOutputAgreementEnricher(t *testing.T) {
 				GameType: 0,
 			},
 			L1HeadNum:            200,
-			L2BlockNumber:        0,
+			L2SequenceNumber:     0,
 			RootClaim:            mockRootClaim,
 			RollupEndpointErrors: make(map[string]bool),
 		}
@@ -50,9 +50,9 @@ func TestOutputAgreementEnricher(t *testing.T) {
 					GameMetadata: challengerTypes.GameMetadata{
 						GameType: gameType,
 					},
-					L1HeadNum:     200,
-					L2BlockNumber: 0,
-					RootClaim:     mockRootClaim,
+					L1HeadNum:        200,
+					L2SequenceNumber: 0,
+					RootClaim:        mockRootClaim,
 				}
 				err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
 				require.NoError(t, err)
@@ -71,9 +71,9 @@ func TestOutputAgreementEnricher(t *testing.T) {
 					GameMetadata: challengerTypes.GameMetadata{
 						GameType: gameType,
 					},
-					L1HeadNum:     200,
-					L2BlockNumber: 0,
-					RootClaim:     mockRootClaim,
+					L1HeadNum:        200,
+					L2SequenceNumber: 0,
+					RootClaim:        mockRootClaim,
 				}
 				err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
 				require.NoError(t, err)
@@ -89,7 +89,7 @@ func TestOutputAgreementEnricher(t *testing.T) {
 		}
 		game := &types.EnrichedGameData{
 			L1HeadNum:            100,
-			L2BlockNumber:        0,
+			L2SequenceNumber:     0,
 			RootClaim:            mockRootClaim,
 			RollupEndpointErrors: make(map[string]bool),
 		}
@@ -108,7 +108,7 @@ func TestOutputAgreementEnricher(t *testing.T) {
 		}
 		game := &types.EnrichedGameData{
 			L1HeadNum:            100,
-			L2BlockNumber:        0,
+			L2SequenceNumber:     0,
 			RootClaim:            mockRootClaim,
 			RollupEndpointErrors: make(map[string]bool),
 		}
@@ -125,9 +125,9 @@ func TestOutputAgreementEnricher(t *testing.T) {
 		clients[1].currentL1 = 100 // Out of sync because it is only equal to the game L1 head
 		clients[2].currentL1 = 0
 		game := &types.EnrichedGameData{
-			L1HeadNum:     100,
-			L2BlockNumber: 0,
-			RootClaim:     mockRootClaim,
+			L1HeadNum:        100,
+			L2SequenceNumber: 0,
+			RootClaim:        mockRootClaim,
 		}
 		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
 		require.ErrorIs(t, err, ErrAllNodesUnavailable)
@@ -142,9 +142,9 @@ func TestOutputAgreementEnricher(t *testing.T) {
 		// Would disagree but will be ignored because node is not in sync
 		clients[0].outputRoot = common.Hash{0xaa, 0xbb, 0xcc, 0xdd}
 		game := &types.EnrichedGameData{
-			L1HeadNum:     100,
-			L2BlockNumber: 0,
-			RootClaim:     mockRootClaim,
+			L1HeadNum:        100,
+			L2SequenceNumber: 0,
+			RootClaim:        mockRootClaim,
 		}
 		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
 		require.NoError(t, err)
@@ -160,7 +160,7 @@ func TestOutputAgreementEnricher(t *testing.T) {
 		clients[2].outputErr = nil
 		game := &types.EnrichedGameData{
 			L1HeadNum:            100,
-			L2BlockNumber:        0,
+			L2SequenceNumber:     0,
 			RootClaim:            mockRootClaim,
 			RollupEndpointErrors: make(map[string]bool),
 		}
@@ -181,7 +181,7 @@ func TestOutputAgreementEnricher(t *testing.T) {
 		clients[3].safeHeadNum = 100
 		game := &types.EnrichedGameData{
 			L1HeadNum:            100,
-			L2BlockNumber:        50,
+			L2SequenceNumber:     50,
 			RootClaim:            mockRootClaim,
 			RollupEndpointErrors: make(map[string]bool),
 		}
@@ -200,7 +200,7 @@ func TestOutputAgreementEnricher(t *testing.T) {
 		clients[2].outputRoot = differentRoot
 		game := &types.EnrichedGameData{
 			L1HeadNum:            100,
-			L2BlockNumber:        50,
+			L2SequenceNumber:     50,
 			RootClaim:            mockRootClaim,
 			RollupEndpointErrors: make(map[string]bool),
 		}
@@ -219,7 +219,7 @@ func TestOutputAgreementEnricher(t *testing.T) {
 		clients[2].outputRoot = divergedRoot
 		game := &types.EnrichedGameData{
 			L1HeadNum:            100,
-			L2BlockNumber:        0,
+			L2SequenceNumber:     0,
 			RootClaim:            mockRootClaim,
 			RollupEndpointErrors: make(map[string]bool),
 		}
@@ -237,7 +237,7 @@ func TestOutputAgreementEnricher(t *testing.T) {
 		clients[2].safeHeadNum = 101
 		game := &types.EnrichedGameData{
 			L1HeadNum:            100,
-			L2BlockNumber:        0,
+			L2SequenceNumber:     0,
 			RootClaim:            mockRootClaim,
 			RollupEndpointErrors: make(map[string]bool),
 		}
@@ -255,7 +255,7 @@ func TestOutputAgreementEnricher(t *testing.T) {
 		clients[2].safeHeadErr = nil
 		game := &types.EnrichedGameData{
 			L1HeadNum:            100,
-			L2BlockNumber:        0,
+			L2SequenceNumber:     0,
 			RootClaim:            mockRootClaim,
 			RollupEndpointErrors: make(map[string]bool),
 		}
@@ -273,7 +273,7 @@ func TestOutputAgreementEnricher(t *testing.T) {
 		clients[2].safeHeadNum = 70
 		game := &types.EnrichedGameData{
 			L1HeadNum:            100,
-			L2BlockNumber:        80,
+			L2SequenceNumber:     80,
 			RootClaim:            mockRootClaim,
 			RollupEndpointErrors: make(map[string]bool),
 		}
@@ -294,7 +294,7 @@ func TestOutputAgreementEnricher(t *testing.T) {
 
 		game := &types.EnrichedGameData{
 			L1HeadNum:            100,
-			L2BlockNumber:        50, // Higher than all safe heads
+			L2SequenceNumber:     50, // Higher than all safe heads
 			RootClaim:            mockRootClaim,
 			RollupEndpointErrors: make(map[string]bool),
 		}
@@ -317,7 +317,7 @@ func TestOutputAgreementEnricher(t *testing.T) {
 
 		game := &types.EnrichedGameData{
 			L1HeadNum:            100,
-			L2BlockNumber:        50,
+			L2SequenceNumber:     50,
 			RootClaim:            mockRootClaim,
 			RollupEndpointErrors: make(map[string]bool),
 		}
@@ -336,7 +336,7 @@ func TestOutputAgreementEnricher(t *testing.T) {
 		rollup.outputErr = errors.New("should not have even requested the output root")
 		game := &types.EnrichedGameData{
 			L1HeadNum:            100,
-			L2BlockNumber:        uint64(math.MaxInt64) + 1,
+			L2SequenceNumber:     uint64(math.MaxInt64) + 1,
 			RootClaim:            mockRootClaim,
 			RollupEndpointErrors: make(map[string]bool),
 		}
@@ -356,7 +356,7 @@ func TestOutputAgreementEnricher(t *testing.T) {
 					GameType: 0,
 				},
 				L1HeadNum:            200,
-				L2BlockNumber:        100,
+				L2SequenceNumber:     100,
 				RootClaim:            mockRootClaim,
 				RollupEndpointErrors: make(map[string]bool),
 			}
@@ -377,7 +377,7 @@ func TestOutputAgreementEnricher(t *testing.T) {
 					GameType: 0,
 				},
 				L1HeadNum:            200,
-				L2BlockNumber:        100,
+				L2SequenceNumber:     100,
 				RootClaim:            mockRootClaim,
 				RollupEndpointErrors: make(map[string]bool),
 			}
@@ -398,7 +398,7 @@ func TestOutputAgreementEnricher(t *testing.T) {
 					GameType: 0,
 				},
 				L1HeadNum:            200,
-				L2BlockNumber:        100,
+				L2SequenceNumber:     100,
 				RootClaim:            mockRootClaim,
 				RollupEndpointErrors: make(map[string]bool),
 			}
@@ -419,7 +419,7 @@ func TestOutputAgreementEnricher(t *testing.T) {
 					GameType: 0,
 				},
 				L1HeadNum:                200,
-				L2BlockNumber:            100,
+				L2SequenceNumber:         100,
 				RootClaim:                mockRootClaim,
 				RollupEndpointErrors:     make(map[string]bool),
 				RollupEndpointErrorCount: 0,
@@ -441,7 +441,7 @@ func TestOutputAgreementEnricher(t *testing.T) {
 					GameType: 0,
 				},
 				L1HeadNum:                200,
-				L2BlockNumber:            100,
+				L2SequenceNumber:         100,
 				RootClaim:                mockRootClaim,
 				RollupEndpointErrors:     make(map[string]bool),
 				RollupEndpointErrorCount: 0,
@@ -462,7 +462,7 @@ func TestOutputAgreementEnricher(t *testing.T) {
 					GameType: 0,
 				},
 				L1HeadNum:                200,
-				L2BlockNumber:            100,
+				L2SequenceNumber:         100,
 				RootClaim:                mockRootClaim,
 				RollupEndpointErrors:     make(map[string]bool),
 				RollupEndpointErrorCount: 0,
@@ -484,7 +484,7 @@ func TestOutputAgreementEnricher(t *testing.T) {
 					GameType: 0,
 				},
 				L1HeadNum:                200,
-				L2BlockNumber:            100,
+				L2SequenceNumber:         100,
 				RootClaim:                mockRootClaim,
 				RollupEndpointErrors:     make(map[string]bool),
 				RollupEndpointErrorCount: 0,
@@ -508,7 +508,7 @@ func TestOutputAgreementEnricher(t *testing.T) {
 					GameType: 0,
 				},
 				L1HeadNum:                    200,
-				L2BlockNumber:                100,
+				L2SequenceNumber:             100,
 				RootClaim:                    mockRootClaim,
 				RollupEndpointErrors:         make(map[string]bool),
 				RollupEndpointOutOfSyncCount: 0,
@@ -529,7 +529,7 @@ func TestOutputAgreementEnricher(t *testing.T) {
 					GameType: 0,
 				},
 				L1HeadNum:                    200,
-				L2BlockNumber:                100,
+				L2SequenceNumber:             100,
 				RootClaim:                    mockRootClaim,
 				RollupEndpointErrors:         make(map[string]bool),
 				RollupEndpointOutOfSyncCount: 0,
@@ -551,7 +551,7 @@ func TestOutputAgreementEnricher(t *testing.T) {
 					GameType: 0,
 				},
 				L1HeadNum:                    200,
-				L2BlockNumber:                100,
+				L2SequenceNumber:             100,
 				RootClaim:                    mockRootClaim,
 				RollupEndpointErrors:         make(map[string]bool),
 				RollupEndpointOutOfSyncCount: 0,
@@ -572,7 +572,7 @@ func TestOutputAgreementEnricher(t *testing.T) {
 					GameType: 0,
 				},
 				L1HeadNum:                    200,
-				L2BlockNumber:                100,
+				L2SequenceNumber:             100,
 				RootClaim:                    mockRootClaim,
 				RollupEndpointErrors:         make(map[string]bool),
 				RollupEndpointOutOfSyncCount: 0,
@@ -595,7 +595,7 @@ func TestOutputAgreementEnricher(t *testing.T) {
 					GameType: 0,
 				},
 				L1HeadNum:                    200,
-				L2BlockNumber:                100,
+				L2SequenceNumber:             100,
 				RootClaim:                    mockRootClaim,
 				RollupEndpointErrors:         make(map[string]bool),
 				RollupEndpointErrorCount:     0,
@@ -717,7 +717,7 @@ func TestOutputAgreementEnricher_SafetyCounting(t *testing.T) {
 				GameType: 0,
 			},
 			L1HeadNum:                 200,
-			L2BlockNumber:             75,
+			L2SequenceNumber:          75,
 			RootClaim:                 rootClaim,
 			RollupEndpointErrors:      make(map[string]bool),
 			RollupEndpointSafeCount:   0,
@@ -748,7 +748,7 @@ func TestOutputAgreementEnricher_SafetyCounting(t *testing.T) {
 				GameType: 0,
 			},
 			L1HeadNum:                 200,
-			L2BlockNumber:             75,
+			L2SequenceNumber:          75,
 			RootClaim:                 rootClaim,
 			RollupEndpointErrors:      make(map[string]bool),
 			RollupEndpointSafeCount:   0,
@@ -783,7 +783,7 @@ func TestOutputAgreementEnricher_SafetyCounting(t *testing.T) {
 				GameType: 0,
 			},
 			L1HeadNum:                 200,
-			L2BlockNumber:             75,
+			L2SequenceNumber:          75,
 			RootClaim:                 rootClaim,
 			RollupEndpointErrors:      make(map[string]bool),
 			RollupEndpointSafeCount:   0,
@@ -813,7 +813,7 @@ func TestOutputAgreementEnricher_SafetyCounting(t *testing.T) {
 				GameType: 0,
 			},
 			L1HeadNum:                 200,
-			L2BlockNumber:             75,
+			L2SequenceNumber:          75,
 			RootClaim:                 rootClaim,
 			RollupEndpointErrors:      make(map[string]bool),
 			RollupEndpointSafeCount:   0,
@@ -842,7 +842,7 @@ func TestOutputAgreementEnricher_SafetyCounting(t *testing.T) {
 				GameType: 0,
 			},
 			L1HeadNum:                          100,
-			L2BlockNumber:                      0,
+			L2SequenceNumber:                   0,
 			RootClaim:                          mockRootClaim,
 			RollupEndpointErrors:               make(map[string]bool),
 			RollupEndpointDifferentOutputRoots: false,
@@ -866,7 +866,7 @@ func TestOutputAgreementEnricher_SafetyCounting(t *testing.T) {
 				GameType: 0,
 			},
 			L1HeadNum:                          100,
-			L2BlockNumber:                      0,
+			L2SequenceNumber:                   0,
 			RootClaim:                          mockRootClaim,
 			RollupEndpointErrors:               make(map[string]bool),
 			RollupEndpointDifferentOutputRoots: false,
@@ -890,7 +890,7 @@ func TestOutputAgreementEnricher_SafetyCounting(t *testing.T) {
 				GameType: 0,
 			},
 			L1HeadNum:                          100,
-			L2BlockNumber:                      0,
+			L2SequenceNumber:                   0,
 			RootClaim:                          mockRootClaim,
 			RollupEndpointErrors:               make(map[string]bool),
 			RollupEndpointDifferentOutputRoots: false,
@@ -916,7 +916,7 @@ func TestOutputAgreementEnricher_SafetyCounting(t *testing.T) {
 				GameType: 0,
 			},
 			L1HeadNum:                          100,
-			L2BlockNumber:                      0,
+			L2SequenceNumber:                   0,
 			RootClaim:                          mockRootClaim,
 			RollupEndpointErrors:               make(map[string]bool),
 			RollupEndpointDifferentOutputRoots: false,
@@ -940,7 +940,7 @@ func TestOutputAgreementEnricher_SafetyCounting(t *testing.T) {
 				GameType: 0,
 			},
 			L1HeadNum:                          100,
-			L2BlockNumber:                      0,
+			L2SequenceNumber:                   0,
 			RootClaim:                          mockRootClaim,
 			RollupEndpointErrors:               make(map[string]bool),
 			RollupEndpointDifferentOutputRoots: false,

--- a/op-dispute-mon/mon/extract/super_agreement_enricher.go
+++ b/op-dispute-mon/mon/extract/super_agreement_enricher.go
@@ -63,7 +63,7 @@ func (e *SuperAgreementEnricher) Enrich(ctx context.Context, block rpcblock.Bloc
 		wg.Add(1)
 		go func(i int, client SuperRootProvider) {
 			defer wg.Done()
-			response, err := client.SuperRootAtTimestamp(ctx, hexutil.Uint64(game.L2BlockNumber))
+			response, err := client.SuperRootAtTimestamp(ctx, hexutil.Uint64(game.L2SequenceNumber))
 			if errors.Is(err, ethereum.NotFound) {
 				results[i] = superRootResult{notFound: true}
 				return
@@ -87,7 +87,7 @@ func (e *SuperAgreementEnricher) Enrich(ctx context.Context, block rpcblock.Bloc
 	foundResults := make([]superRootResult, 0, len(results))
 	for idx, result := range results {
 		if result.err != nil {
-			e.log.Error("Failed to fetch super root", "clientIndex", idx, "l2BlockNum", game.L2BlockNumber, "err", result.err)
+			e.log.Error("Failed to fetch super root", "clientIndex", idx, "l2SequenceNumber", game.L2SequenceNumber, "err", result.err)
 			continue
 		}
 
@@ -130,7 +130,7 @@ func (e *SuperAgreementEnricher) Enrich(ctx context.Context, block rpcblock.Bloc
 
 	if diverged {
 		e.log.Warn("Supervisor nodes disagree on super root",
-			"l2BlockNum", game.L2BlockNumber,
+			"l2SequenceNumber", game.L2SequenceNumber,
 			"firstSuperRoot", firstResult.superRoot,
 			"found", len(foundResults),
 			"valid", len(validResults))

--- a/op-dispute-mon/mon/extract/super_agreement_enricher_test.go
+++ b/op-dispute-mon/mon/extract/super_agreement_enricher_test.go
@@ -30,9 +30,9 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 			GameMetadata: challengerTypes.GameMetadata{
 				GameType: 999,
 			},
-			L1HeadNum:     200,
-			L2BlockNumber: 0,
-			RootClaim:     mockRootClaim,
+			L1HeadNum:        200,
+			L2SequenceNumber: 0,
+			RootClaim:        mockRootClaim,
 		}
 		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
 		require.ErrorIs(t, err, ErrSupervisorRpcRequired)
@@ -49,9 +49,9 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 					GameMetadata: challengerTypes.GameMetadata{
 						GameType: gameType,
 					},
-					L1HeadNum:     200,
-					L2BlockNumber: 0,
-					RootClaim:     mockRootClaim,
+					L1HeadNum:        200,
+					L2SequenceNumber: 0,
+					RootClaim:        mockRootClaim,
 				}
 				err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
 				require.NoError(t, err)
@@ -70,9 +70,9 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 					GameMetadata: challengerTypes.GameMetadata{
 						GameType: gameType,
 					},
-					L1HeadNum:     200,
-					L2BlockNumber: 0,
-					RootClaim:     mockRootClaim,
+					L1HeadNum:        200,
+					L2SequenceNumber: 0,
+					RootClaim:        mockRootClaim,
 				}
 				err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
 				require.NoError(t, err)
@@ -88,9 +88,9 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 			GameMetadata: challengerTypes.GameMetadata{
 				GameType: 999,
 			},
-			L1HeadNum:     100,
-			L2BlockNumber: 0,
-			RootClaim:     mockRootClaim,
+			L1HeadNum:        100,
+			L2SequenceNumber: 0,
+			RootClaim:        mockRootClaim,
 		}
 		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
 		require.ErrorIs(t, err, ErrAllSupervisorNodesUnavailable)
@@ -105,9 +105,9 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 			GameMetadata: challengerTypes.GameMetadata{
 				GameType: 999,
 			},
-			L1HeadNum:     100,
-			L2BlockNumber: 0,
-			RootClaim:     common.Hash{},
+			L1HeadNum:        100,
+			L2SequenceNumber: 0,
+			RootClaim:        common.Hash{},
 		}
 		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
 		require.NoError(t, err)
@@ -123,9 +123,9 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 			GameMetadata: challengerTypes.GameMetadata{
 				GameType: 999,
 			},
-			L1HeadNum:     200,
-			L2BlockNumber: 0,
-			RootClaim:     mockRootClaim,
+			L1HeadNum:        200,
+			L2SequenceNumber: 0,
+			RootClaim:        mockRootClaim,
 		}
 		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
 		require.NoError(t, err)
@@ -141,9 +141,9 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 			GameMetadata: challengerTypes.GameMetadata{
 				GameType: 999,
 			},
-			L1HeadNum:     200,
-			L2BlockNumber: 0,
-			RootClaim:     mockRootClaim,
+			L1HeadNum:        200,
+			L2SequenceNumber: 0,
+			RootClaim:        mockRootClaim,
 		}
 		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
 		require.NoError(t, err)
@@ -159,9 +159,9 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 			GameMetadata: challengerTypes.GameMetadata{
 				GameType: 999,
 			},
-			L1HeadNum:     100,
-			L2BlockNumber: 0,
-			RootClaim:     common.Hash{},
+			L1HeadNum:        100,
+			L2SequenceNumber: 0,
+			RootClaim:        common.Hash{},
 		}
 		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
 		require.NoError(t, err)
@@ -177,9 +177,9 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 			GameMetadata: challengerTypes.GameMetadata{
 				GameType: 999,
 			},
-			L1HeadNum:     200,
-			L2BlockNumber: 100,
-			RootClaim:     mockRootClaim,
+			L1HeadNum:        200,
+			L2SequenceNumber: 100,
+			RootClaim:        mockRootClaim,
 		}
 		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
 		require.NoError(t, err)
@@ -196,9 +196,9 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 			GameMetadata: challengerTypes.GameMetadata{
 				GameType: 999,
 			},
-			L1HeadNum:     100,
-			L2BlockNumber: 42984924,
-			RootClaim:     mockRootClaim,
+			L1HeadNum:        100,
+			L2SequenceNumber: 42984924,
+			RootClaim:        mockRootClaim,
 		}
 		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
 		require.NoError(t, err)
@@ -216,9 +216,9 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 			GameMetadata: challengerTypes.GameMetadata{
 				GameType: 999,
 			},
-			L1HeadNum:     100,
-			L2BlockNumber: 0,
-			RootClaim:     mockRootClaim,
+			L1HeadNum:        100,
+			L2SequenceNumber: 0,
+			RootClaim:        mockRootClaim,
 		}
 		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
 		require.Error(t, err)
@@ -237,9 +237,9 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 			GameMetadata: challengerTypes.GameMetadata{
 				GameType: 999,
 			},
-			L1HeadNum:     100,
-			L2BlockNumber: 0,
-			RootClaim:     mockRootClaim,
+			L1HeadNum:        100,
+			L2SequenceNumber: 0,
+			RootClaim:        mockRootClaim,
 		}
 		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
 		require.NoError(t, err)
@@ -257,9 +257,9 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 			GameMetadata: challengerTypes.GameMetadata{
 				GameType: 999,
 			},
-			L1HeadNum:     200,
-			L2BlockNumber: 0,
-			RootClaim:     mockRootClaim,
+			L1HeadNum:        200,
+			L2SequenceNumber: 0,
+			RootClaim:        mockRootClaim,
 		}
 		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
 		require.NoError(t, err)
@@ -278,9 +278,9 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 			GameMetadata: challengerTypes.GameMetadata{
 				GameType: 999,
 			},
-			L1HeadNum:     200,
-			L2BlockNumber: 0,
-			RootClaim:     mockRootClaim,
+			L1HeadNum:        200,
+			L2SequenceNumber: 0,
+			RootClaim:        mockRootClaim,
 		}
 		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
 		require.NoError(t, err)
@@ -298,9 +298,9 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 			GameMetadata: challengerTypes.GameMetadata{
 				GameType: 999,
 			},
-			L1HeadNum:     200,
-			L2BlockNumber: 0,
-			RootClaim:     mockRootClaim,
+			L1HeadNum:        200,
+			L2SequenceNumber: 0,
+			RootClaim:        mockRootClaim,
 		}
 		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
 		require.NoError(t, err)
@@ -321,9 +321,9 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 			GameMetadata: challengerTypes.GameMetadata{
 				GameType: 999,
 			},
-			L1HeadNum:     200,
-			L2BlockNumber: 50,
-			RootClaim:     mockRootClaim,
+			L1HeadNum:        200,
+			L2SequenceNumber: 50,
+			RootClaim:        mockRootClaim,
 		}
 		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
 		require.NoError(t, err)
@@ -344,9 +344,9 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 			GameMetadata: challengerTypes.GameMetadata{
 				GameType: 999,
 			},
-			L1HeadNum:     200,
-			L2BlockNumber: 50,
-			RootClaim:     mockRootClaim,
+			L1HeadNum:        200,
+			L2SequenceNumber: 50,
+			RootClaim:        mockRootClaim,
 		}
 		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
 		require.NoError(t, err)
@@ -367,9 +367,9 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 			GameMetadata: challengerTypes.GameMetadata{
 				GameType: 999,
 			},
-			L1HeadNum:     200,
-			L2BlockNumber: 50,
-			RootClaim:     mockRootClaim,
+			L1HeadNum:        200,
+			L2SequenceNumber: 50,
+			RootClaim:        mockRootClaim,
 		}
 		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
 		require.NoError(t, err)
@@ -391,9 +391,9 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 			GameMetadata: challengerTypes.GameMetadata{
 				GameType: 999,
 			},
-			L1HeadNum:     200,
-			L2BlockNumber: 50,
-			RootClaim:     mockRootClaim,
+			L1HeadNum:        200,
+			L2SequenceNumber: 50,
+			RootClaim:        mockRootClaim,
 		}
 		err := validator.Enrich(context.Background(), rpcblock.Latest, nil, game)
 		require.NoError(t, err)

--- a/op-dispute-mon/mon/forecast.go
+++ b/op-dispute-mon/mon/forecast.go
@@ -93,15 +93,15 @@ func (f *Forecast) forecastGame(game *monTypes.EnrichedGameData, metrics *foreca
 		if metrics.LatestValidProposal < game.Timestamp {
 			metrics.LatestValidProposal = game.Timestamp
 		}
-		if metrics.LatestValidProposalL2Block < game.L2BlockNumber {
-			metrics.LatestValidProposalL2Block = game.L2BlockNumber
+		if metrics.LatestValidProposalL2Block < game.L2SequenceNumber {
+			metrics.LatestValidProposalL2Block = game.L2SequenceNumber
 		}
 	}
 
 	if game.Status != types.GameStatusInProgress {
 		if game.Status != expectedResult {
 			f.logger.Error("Unexpected game result",
-				"game", game.Proxy, "blockNum", game.L2BlockNumber,
+				"game", game.Proxy, "l2SequenceNumber", game.L2SequenceNumber,
 				"expectedResult", expectedResult, "actualResult", game.Status,
 				"rootClaim", game.RootClaim, "correctClaim", expected)
 		}
@@ -127,7 +127,7 @@ func (f *Forecast) forecastGame(game *monTypes.EnrichedGameData, metrics *foreca
 	// by the challenger since the counter is proven on-chain.
 	if game.BlockNumberChallenged {
 		f.logger.Debug("Found game with challenged block number",
-			"game", game.Proxy, "blockNum", game.L2BlockNumber, "agreement", agreement)
+			"game", game.Proxy, "l2SequenceNumber", game.L2SequenceNumber, "agreement", agreement)
 		// If the block number is challenged the challenger will always win
 		forecastStatus = types.GameStatusChallengerWon
 	} else {
@@ -141,12 +141,12 @@ func (f *Forecast) forecastGame(game *monTypes.EnrichedGameData, metrics *foreca
 		if forecastStatus == types.GameStatusChallengerWon {
 			metrics.AgreeChallengerAhead++
 			f.logger.Warn("Forecasting unexpected game result", "status", forecastStatus,
-				"game", game.Proxy, "blockNum", game.L2BlockNumber,
+				"game", game.Proxy, "l2SequenceNumber", game.L2SequenceNumber,
 				"rootClaim", game.RootClaim, "expected", expected)
 		} else {
 			metrics.AgreeDefenderAhead++
 			f.logger.Debug("Forecasting expected game result", "status", forecastStatus,
-				"game", game.Proxy, "blockNum", game.L2BlockNumber,
+				"game", game.Proxy, "l2SequenceNumber", game.L2SequenceNumber,
 				"rootClaim", game.RootClaim, "expected", expected)
 		}
 	} else {
@@ -154,12 +154,12 @@ func (f *Forecast) forecastGame(game *monTypes.EnrichedGameData, metrics *foreca
 		if forecastStatus == types.GameStatusDefenderWon {
 			metrics.DisagreeDefenderAhead++
 			f.logger.Warn("Forecasting unexpected game result", "status", forecastStatus,
-				"game", game.Proxy, "blockNum", game.L2BlockNumber,
+				"game", game.Proxy, "l2SequenceNumber", game.L2SequenceNumber,
 				"rootClaim", game.RootClaim, "expected", expected)
 		} else {
 			metrics.DisagreeChallengerAhead++
 			f.logger.Debug("Forecasting expected game result", "status", forecastStatus,
-				"game", game.Proxy, "blockNum", game.L2BlockNumber,
+				"game", game.Proxy, "l2SequenceNumber", game.L2SequenceNumber,
 				"rootClaim", game.RootClaim, "expected", expected)
 		}
 	}

--- a/op-dispute-mon/mon/forecast_test.go
+++ b/op-dispute-mon/mon/forecast_test.go
@@ -109,14 +109,14 @@ func TestForecast_Forecast_EndLogs(t *testing.T) {
 		expectedGame := monTypes.EnrichedGameData{
 			Status:                types.GameStatusInProgress,
 			BlockNumberChallenged: true,
-			L2BlockNumber:         6,
+			L2SequenceNumber:      6,
 			AgreeWithClaim:        false,
 		}
 		forecast.Forecast([]*monTypes.EnrichedGameData{&expectedGame}, 0, 0)
 		l := logs.FindLog(testlog.NewLevelFilter(log.LevelDebug), testlog.NewMessageFilter("Found game with challenged block number"))
 		require.NotNil(t, l)
 		require.Equal(t, expectedGame.Proxy, l.AttrValue("game"))
-		require.Equal(t, expectedGame.L2BlockNumber, l.AttrValue("blockNum"))
+		require.Equal(t, expectedGame.L2SequenceNumber, l.AttrValue("l2SequenceNumber"))
 		require.Equal(t, false, l.AttrValue("agreement"))
 
 		expectedMetrics := zeroGameAgreement()
@@ -130,14 +130,14 @@ func TestForecast_Forecast_EndLogs(t *testing.T) {
 		expectedGame := monTypes.EnrichedGameData{
 			Status:                types.GameStatusInProgress,
 			BlockNumberChallenged: true,
-			L2BlockNumber:         6,
+			L2SequenceNumber:      6,
 			AgreeWithClaim:        true,
 		}
 		forecast.Forecast([]*monTypes.EnrichedGameData{&expectedGame}, 0, 0)
 		l := logs.FindLog(testlog.NewLevelFilter(log.LevelDebug), testlog.NewMessageFilter("Found game with challenged block number"))
 		require.NotNil(t, l)
 		require.Equal(t, expectedGame.Proxy, l.AttrValue("game"))
-		require.Equal(t, expectedGame.L2BlockNumber, l.AttrValue("blockNum"))
+		require.Equal(t, expectedGame.L2SequenceNumber, l.AttrValue("l2SequenceNumber"))
 		require.Equal(t, true, l.AttrValue("agreement"))
 
 		expectedMetrics := zeroGameAgreement()
@@ -269,10 +269,10 @@ func TestForecast_Forecast_MultipleGames(t *testing.T) {
 	games := make([]*monTypes.EnrichedGameData, 9)
 	for i := range games {
 		games[i] = &monTypes.EnrichedGameData{
-			Status:        gameStatus[i],
-			Claims:        claims[i],
-			RootClaim:     rootClaims[i],
-			L2BlockNumber: uint64(i),
+			Status:           gameStatus[i],
+			Claims:           claims[i],
+			RootClaim:        rootClaims[i],
+			L2SequenceNumber: uint64(i),
 			GameMetadata: types.GameMetadata{
 				Timestamp: uint64(i),
 			},

--- a/op-dispute-mon/mon/l2_challenges.go
+++ b/op-dispute-mon/mon/l2_challenges.go
@@ -28,11 +28,11 @@ func (m *L2ChallengesMonitor) CheckL2Challenges(games []*types.EnrichedGameData)
 		if game.BlockNumberChallenged {
 			if game.AgreeWithClaim {
 				m.logger.Warn("Found game with valid block number challenged",
-					"game", game.Proxy, "blockNum", game.L2BlockNumber, "agreement", game.AgreeWithClaim, "challenger", game.BlockNumberChallenger)
+					"game", game.Proxy, "l2SequenceNumber", game.L2SequenceNumber, "agreement", game.AgreeWithClaim, "challenger", game.BlockNumberChallenger)
 				agreeChallengeCount++
 			} else {
 				m.logger.Debug("Found game with invalid block number challenged",
-					"game", game.Proxy, "blockNum", game.L2BlockNumber, "agreement", game.AgreeWithClaim, "challenger", game.BlockNumberChallenger)
+					"game", game.Proxy, "l2SequenceNumber", game.L2SequenceNumber, "agreement", game.AgreeWithClaim, "challenger", game.BlockNumberChallenger)
 				disagreeChallengeCount++
 			}
 		}

--- a/op-dispute-mon/mon/l2_challenges_test.go
+++ b/op-dispute-mon/mon/l2_challenges_test.go
@@ -13,9 +13,9 @@ import (
 
 func TestMonitorL2Challenges(t *testing.T) {
 	games := []*types.EnrichedGameData{
-		{GameMetadata: gameTypes.GameMetadata{Proxy: common.Address{0x44}}, BlockNumberChallenged: true, AgreeWithClaim: true, L2BlockNumber: 44, BlockNumberChallenger: common.Address{0x55}},
+		{GameMetadata: gameTypes.GameMetadata{Proxy: common.Address{0x44}}, BlockNumberChallenged: true, AgreeWithClaim: true, L2SequenceNumber: 44, BlockNumberChallenger: common.Address{0x55}},
 		{BlockNumberChallenged: false, AgreeWithClaim: true},
-		{GameMetadata: gameTypes.GameMetadata{Proxy: common.Address{0x22}}, BlockNumberChallenged: true, AgreeWithClaim: false, L2BlockNumber: 22, BlockNumberChallenger: common.Address{0x33}},
+		{GameMetadata: gameTypes.GameMetadata{Proxy: common.Address{0x22}}, BlockNumberChallenged: true, AgreeWithClaim: false, L2SequenceNumber: 22, BlockNumberChallenger: common.Address{0x33}},
 		{BlockNumberChallenged: false, AgreeWithClaim: false},
 		{BlockNumberChallenged: false, AgreeWithClaim: false},
 		{BlockNumberChallenged: false, AgreeWithClaim: true},
@@ -33,7 +33,7 @@ func TestMonitorL2Challenges(t *testing.T) {
 	l := capturedLogs.FindLog(levelFilter, messageFilter)
 	require.NotNil(t, l)
 	require.Equal(t, common.Address{0x44}, l.AttrValue("game"))
-	require.Equal(t, uint64(44), l.AttrValue("blockNum"))
+	require.Equal(t, uint64(44), l.AttrValue("l2SequenceNumber"))
 	require.Equal(t, true, l.AttrValue("agreement"))
 	require.Equal(t, common.Address{0x55}, l.AttrValue("challenger"))
 
@@ -43,7 +43,7 @@ func TestMonitorL2Challenges(t *testing.T) {
 	l = capturedLogs.FindLog(levelFilter, messageFilter)
 	require.NotNil(t, l)
 	require.Equal(t, common.Address{0x22}, l.AttrValue("game"))
-	require.Equal(t, uint64(22), l.AttrValue("blockNum"))
+	require.Equal(t, uint64(22), l.AttrValue("l2SequenceNumber"))
 	require.Equal(t, false, l.AttrValue("agreement"))
 	require.Equal(t, common.Address{0x33}, l.AttrValue("challenger"))
 }

--- a/op-dispute-mon/mon/types/types.go
+++ b/op-dispute-mon/mon/types/types.go
@@ -26,7 +26,7 @@ type EnrichedGameData struct {
 	LastUpdateTime        time.Time
 	L1Head                common.Hash
 	L1HeadNum             uint64
-	L2BlockNumber         uint64
+	L2SequenceNumber      uint64
 	RootClaim             common.Hash
 	Status                types.GameStatus
 	MaxClockDuration      uint64


### PR DESCRIPTION
The field is used for both block numbers with output root games and timestamp for super root games. Calling it L2BlockNumber caused confusion with super root games.