### PR TITLE
op-devstack: Remove unused preset syncmode.RRSync

### DIFF
--- a/op-acceptance-tests/tests/depreqres/syncmodereqressync/clsync/init_test.go
+++ b/op-acceptance-tests/tests/depreqres/syncmodereqressync/clsync/init_test.go
@@ -14,7 +14,6 @@ func TestMain(m *testing.M) {
 	presets.DoMain(m, presets.WithSingleChainMultiNode(),
 		presets.WithConsensusLayerSync(),
 		presets.WithCompatibleTypes(compat.SysGo),
-		presets.WithSyncModeReqRespSync(),
 		presets.WithNoDiscovery(),
 		stack.MakeCommon(sysgo.WithBatcherOption(func(id stack.L2BatcherID, cfg *bss.CLIConfig) {
 			cfg.Stopped = true

--- a/op-acceptance-tests/tests/depreqres/syncmodereqressync/elsync/init_test.go
+++ b/op-acceptance-tests/tests/depreqres/syncmodereqressync/elsync/init_test.go
@@ -14,7 +14,6 @@ func TestMain(m *testing.M) {
 	presets.DoMain(m, presets.WithSingleChainMultiNode(),
 		presets.WithExecutionLayerSyncOnVerifiers(),
 		presets.WithCompatibleTypes(compat.SysGo),
-		presets.WithSyncModeReqRespSync(),
 		presets.WithNoDiscovery(),
 		stack.MakeCommon(sysgo.WithBatcherOption(func(id stack.L2BatcherID, cfg *bss.CLIConfig) {
 			cfg.Stopped = true

--- a/op-devstack/presets/cl_config.go
+++ b/op-devstack/presets/cl_config.go
@@ -41,14 +41,6 @@ func WithReqRespSyncDisabled() stack.CommonOption {
 			})))
 }
 
-func WithSyncModeReqRespSync() stack.CommonOption {
-	return stack.MakeCommon(
-		sysgo.WithGlobalL2CLOption(sysgo.L2CLOptionFn(
-			func(_ devtest.P, id stack.L2CLNodeID, cfg *sysgo.L2CLConfig) {
-				cfg.UseReqRespSync = true
-			})))
-}
-
 func WithNoDiscovery() stack.CommonOption {
 	return stack.MakeCommon(
 		sysgo.WithGlobalL2CLOption(sysgo.L2CLOptionFn(


### PR DESCRIPTION
`UseReqRespSync` is default true, so we do not need the `WithSyncModeReqRespSync` preset.