### PR TITLE
op-node/rollup/derive: Fix too old batch epoch handling

### DIFF
--- a/op-node/rollup/derive/batch_queue.go
+++ b/op-node/rollup/derive/batch_queue.go
@@ -96,6 +96,8 @@ func (bq *BatchQueue) NextBatch(ctx context.Context, parent eth.L2BlockRef) (*Si
 		}
 		// If next batch is SpanBatch, convert it to SingularBatches.
 		singularBatches, err := spanBatch.GetSingularBatches(bq.l1Blocks, parent)
+		// bq.deriveNextBatch above will already have performed full span batch validation
+		// so an error performing singular batch extraction here is treated as a critical logic error.
 		if err != nil {
 			return nil, false, NewCriticalError(err)
 		}

--- a/op-node/rollup/derive/batch_queue_test.go
+++ b/op-node/rollup/derive/batch_queue_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 
+	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
@@ -46,6 +47,41 @@ func (f *fakeBatchQueueInput) NextBatch(ctx context.Context) (Batch, error) {
 	e := f.errors[f.i]
 	f.i += 1
 	return b, e
+}
+
+type fakeSafeBlockFetcher struct {
+	blocks   map[uint64]eth.L2BlockRef
+	payloads map[uint64]*eth.ExecutionPayloadEnvelope
+}
+
+func newFakeSafeBlockFetcher() *fakeSafeBlockFetcher {
+	return &fakeSafeBlockFetcher{
+		blocks:   make(map[uint64]eth.L2BlockRef),
+		payloads: make(map[uint64]*eth.ExecutionPayloadEnvelope),
+	}
+}
+
+func (f *fakeSafeBlockFetcher) addBlock(ref eth.L2BlockRef, payload *eth.ExecutionPayloadEnvelope) {
+	f.blocks[ref.Number] = ref
+	if payload != nil {
+		f.payloads[ref.Number] = payload
+	}
+}
+
+func (f *fakeSafeBlockFetcher) L2BlockRefByNumber(_ context.Context, number uint64) (eth.L2BlockRef, error) {
+	ref, ok := f.blocks[number]
+	if !ok {
+		return eth.L2BlockRef{}, errors.New("unknown L2 block")
+	}
+	return ref, nil
+}
+
+func (f *fakeSafeBlockFetcher) PayloadByNumber(_ context.Context, number uint64) (*eth.ExecutionPayloadEnvelope, error) {
+	payload, ok := f.payloads[number]
+	if !ok || payload == nil {
+		return nil, errors.New("unknown execution payload")
+	}
+	return payload, nil
 }
 
 func mockHash(time uint64, layer uint8) common.Hash {
@@ -151,7 +187,6 @@ func TestBatchQueue(t *testing.T) {
 		{"Shuffle", testBatchQueue_Shuffle},
 	}
 	for _, test := range tests {
-		test := test
 		t.Run(test.name+"_SingularBatch", func(t *testing.T) {
 			test.f(t, SingularBatchType)
 		})
@@ -185,19 +220,19 @@ func TestBatchStages(t *testing.T) {
 		{"InvalidInternalAdvance", testBatchStage_InvalidInternalAdvance},
 		{"AdvancedEpoch", testBatchStage_AdvancedEpoch},
 		{"ResetOneBlockBeforeOrigin", testBatchStage_ResetOneBlockBeforeOrigin},
+		{"OverlappingSpanBatch", testBatchStage_OverlappingSpanBatch},
 	}
 	for _, test := range tests {
-		test := test
-		t.Run("BatchQueue_"+test.name+"_SingularBatch", func(t *testing.T) {
+		t.Run("BatchQueue/SingularBatch/"+test.name, func(t *testing.T) {
 			test.f(t, SingularBatchType, newBatchQueue)
 		})
-		t.Run("BatchQueue_"+test.name+"_SpanBatch", func(t *testing.T) {
+		t.Run("BatchQueue/SpanBatch/"+test.name, func(t *testing.T) {
 			test.f(t, SpanBatchType, newBatchQueue)
 		})
-		t.Run("BatchStage_"+test.name+"_SingularBatch", func(t *testing.T) {
+		t.Run("BatchStage/SingularBatch/"+test.name, func(t *testing.T) {
 			test.f(t, SingularBatchType, newBatchStage)
 		})
-		t.Run("BatchStage_"+test.name+"_SpanBatch", func(t *testing.T) {
+		t.Run("BatchStage/SpanBatch/"+test.name, func(t *testing.T) {
 			test.f(t, SpanBatchType, newBatchStage)
 		})
 	}
@@ -408,7 +443,7 @@ func testBatchStage_Eager(t *testing.T, batchType int, newBatchStage testableBat
 // testBatchStage_InvalidInternalAdvance asserts that we do not miss an epoch when generating batches.
 // This is a regression test for CLI-3378.
 func testBatchStage_InvalidInternalAdvance(t *testing.T, batchType int, newBatchStage testableBatchStageFactory) {
-	log := testlog.Logger(t, log.LevelTrace)
+	log := testlog.Logger(t, log.LevelError)
 	l1 := L1Chain([]uint64{5, 10, 15, 20, 25, 30})
 	chainId := big.NewInt(1234)
 	safeHead := eth.L2BlockRef{
@@ -525,6 +560,88 @@ func testBatchStage_InvalidInternalAdvance(t *testing.T, batchType int, newBatch
 	b, _, e = bq.NextBatch(context.Background(), safeHead)
 	require.ErrorIs(t, e, io.EOF)
 	require.Nil(t, b)
+}
+
+// testBatchStage_OverlappingSpanBatch verifies that overlapping span batches
+// with outdated L1 origins are dropped for both the BatchQueue and BatchStage implementations.
+func testBatchStage_OverlappingSpanBatch(t *testing.T, batchType int, newBatchStage testableBatchStageFactory) {
+	if batchType != SpanBatchType {
+		t.Skip("only applicable to span batches")
+	}
+
+	log, logs := testlog.CaptureLogger(t, log.LevelWarn)
+	l1 := L1Chain([]uint64{10, 16, 22, 28})
+	chainId := big.NewInt(1234)
+	cfg := &rollup.Config{
+		Genesis: rollup.Genesis{
+			L2Time: 20,
+		},
+		BlockTime:         2,
+		MaxSequencerDrift: 600,
+		SeqWindowSize:     1000,
+		L2ChainID:         chainId,
+	}
+	// we skip singular batches above, so can always activate Delta
+	cfg.ActivateAtGenesis(forks.Delta)
+
+	parentBatch := b(cfg.L2ChainID, 20, l1[0])
+	parentRef := singularBatchToBlockRef(t, parentBatch, 0)
+	parentPayload := singularBatchToPayload(t, parentBatch, 0)
+	safeBatch := b(cfg.L2ChainID, 22, l1[1])
+	safeHead := singularBatchToBlockRef(t, safeBatch, 1)
+	safePayload := singularBatchToPayload(t, safeBatch, 1)
+
+	fetcher := newFakeSafeBlockFetcher()
+	fetcher.addBlock(parentRef, &parentPayload)
+	fetcher.addBlock(safeHead, &safePayload)
+
+	t.Run("outdated origin", func(t *testing.T) {
+		invalidSpanSingulars := []*SingularBatch{
+			b(cfg.L2ChainID, 22, l1[0]), // same block number as safe head, will be skipped
+			b(cfg.L2ChainID, 24, l1[0]), // first batch after safe head uses outdated origin 0
+			b(cfg.L2ChainID, 26, l1[1]),
+		}
+		invalidSpan := initializedSpanBatch(invalidSpanSingulars, cfg.Genesis.L2Time, chainId)
+		input := &fakeBatchQueueInput{
+			batches: []Batch{invalidSpan},
+			errors:  []error{nil},
+			origin:  l1[2],
+		}
+
+		stage := newBatchStage(log, cfg, input, fetcher)
+		_ = stage.Reset(context.Background(), l1[1], eth.SystemConfig{})
+
+		// The invalid overlapping span batch should be dropped and reported as lacking data.
+		batch, _, err := stage.NextBatch(context.Background(), safeHead)
+		require.ErrorIs(t, err, NotEnoughData)
+		require.Nil(t, batch)
+		switch stage.(type) {
+		case *BatchQueue:
+			logs.RequireMessageContainedOnce(t, "block epoch is too old")
+		case *BatchStage:
+			logs.RequireMessageContainedOnce(t, "Dropping invalid span batch, flushing channel (singular batch extraction)")
+		}
+	})
+
+	t.Run("valid", func(t *testing.T) {
+		validSpanSingulars := []*SingularBatch{
+			safeBatch,
+			b(cfg.L2ChainID, 24, l1[1]),
+		}
+		validSpan := initializedSpanBatch(validSpanSingulars, cfg.Genesis.L2Time, chainId)
+		input := &fakeBatchQueueInput{
+			batches: []Batch{validSpan},
+			errors:  []error{nil},
+			origin:  l1[2],
+		}
+
+		stage := newBatchStage(log, cfg, input, fetcher)
+		_ = stage.Reset(context.Background(), l1[1], eth.SystemConfig{})
+
+		batch, _, err := stage.NextBatch(context.Background(), safeHead)
+		require.NoError(t, err)
+		require.Equal(t, validSpanSingulars[1], batch)
+	})
 }
 
 func testBatchQueue_Missing(t *testing.T, batchType int) {

--- a/op-node/rollup/derive/batch_stage.go
+++ b/op-node/rollup/derive/batch_stage.go
@@ -145,7 +145,7 @@ func (bs *BatchStage) nextSingularBatchCandidate(ctx context.Context, parent eth
 			// NotEnoughData to read in next batch until we're through all past batches
 			return nil, NotEnoughData
 		case BatchDrop: // drop, try next
-			spanBatch.LogContext(bs.Log()).Warn("Dropping invalid span batch, flushing channel")
+			spanBatch.LogContext(bs.Log()).Warn("Dropping invalid span batch, flushing channel (span batch prefix checks)")
 			bs.FlushChannel()
 			return nil, NotEnoughData
 		case BatchUndecided: // l2 fetcher error, try again
@@ -157,8 +157,12 @@ func (bs *BatchStage) nextSingularBatchCandidate(ctx context.Context, parent eth
 
 		// If next batch is SpanBatch, convert it to SingularBatches.
 		singularBatches, err := spanBatch.GetSingularBatches(bs.l1Blocks, parent)
+		// Errors can happen here because the span batch prefix checks are not exhaustive (unlike the full span batch
+		// checks) so an error must be handled like an invalid span batch (DROP).
 		if err != nil {
-			return nil, NewCriticalError(err)
+			spanBatch.LogContext(bs.Log()).Warn("Dropping invalid span batch, flushing channel (singular batch extraction)", "error", err)
+			bs.FlushChannel()
+			return nil, NotEnoughData
 		}
 		bs.nextSpan = singularBatches
 		// span-batches are non-empty, so the below pop is safe.

--- a/op-node/rollup/derive/batches.go
+++ b/op-node/rollup/derive/batches.go
@@ -230,7 +230,7 @@ func checkSpanBatchPrefix(ctx context.Context, cfg *rollup.Config, log log.Logge
 		log.Trace("received out-of-order batch for future processing after next batch", "next_timestamp", nextTimestamp)
 		return BatchFuture, eth.L2BlockRef{}
 	}
-	if batch.GetBlockTimestamp(batch.GetBlockCount()-1) < nextTimestamp {
+	if batch.GetLastTimestamp() < nextTimestamp {
 		log.Warn("span batch has no new blocks after safe head")
 		if cfg.IsHolocene(l1InclusionBlock.Time) {
 			return BatchPast, eth.L2BlockRef{}
@@ -277,9 +277,9 @@ func checkSpanBatchPrefix(ctx context.Context, cfg *rollup.Config, log log.Logge
 		return BatchDrop, parentBlock
 	}
 
-	endEpochNum := batch.GetBlockEpochNum(batch.GetBlockCount() - 1)
+	endEpochNum := uint64(batch.GetLastEpochNum())
 	originChecked := false
-	// l1Blocks is supplied from batch queue and its length is limited to SequencerWindowSize.
+	// l1Blocks is supplied from the batch queue/stage and its length is limited to SequencerWindowSize.
 	for _, l1Block := range l1Blocks {
 		if l1Block.Number == endEpochNum {
 			if !batch.CheckOriginHash(l1Block.Hash) {
@@ -317,24 +317,36 @@ func checkSpanBatch(ctx context.Context, cfg *rollup.Config, log log.Logger, l1B
 	originAdvanced := startEpochNum == parentBlock.L1Origin.Number+1
 
 	for i := 0; i < batch.GetBlockCount(); i++ {
-		if batch.GetBlockTimestamp(i) <= l2SafeHead.Time {
+		blockTimestamp := batch.GetBlockTimestamp(i)
+		blockEpoch := batch.GetBlockEpochNum(i)
+
+		if blockTimestamp <= l2SafeHead.Time {
 			continue
 		}
+		if blockEpoch < l2SafeHead.L1Origin.Number {
+			log.Warn("block epoch is too old", "minimum", l2SafeHead.ID(), "have", blockEpoch)
+			return BatchDrop
+		}
 		var l1Origin eth.L1BlockRef
+		var originFound bool
 		for j := originIdx; j < len(l1Blocks); j++ {
-			if batch.GetBlockEpochNum(i) == l1Blocks[j].Number {
+			if blockEpoch == l1Blocks[j].Number {
 				l1Origin = l1Blocks[j]
 				originIdx = j
+				originFound = true
 				break
 			}
 		}
+		if !originFound {
+			log.Info("unable to find L1 origin for batch", "epoch", blockEpoch, "timestamp", blockTimestamp)
+			return BatchDrop
+		}
 		if i > 0 {
 			originAdvanced = false
-			if batch.GetBlockEpochNum(i) > batch.GetBlockEpochNum(i-1) {
+			if blockEpoch > batch.GetBlockEpochNum(i-1) {
 				originAdvanced = true
 			}
 		}
-		blockTimestamp := batch.GetBlockTimestamp(i)
 		if blockTimestamp < l1Origin.Time {
 			log.Warn("block timestamp is less than L1 origin timestamp", "l2_timestamp", blockTimestamp, "l1_timestamp", l1Origin.Time, "origin", l1Origin.ID())
 			return BatchDrop
@@ -387,7 +399,7 @@ func checkSpanBatch(ctx context.Context, cfg *rollup.Config, log log.Logger, l1B
 			safeBlockNum := parentNum + i + 1
 			safeBlockPayload, err := l2Fetcher.PayloadByNumber(ctx, safeBlockNum)
 			if err != nil {
-				log.Warn("failed to fetch L2 block payload", "number", parentNum, "err", err)
+				log.Warn("failed to fetch L2 block payload", "number", safeBlockNum, "err", err)
 				// unable to validate the batch for now. retry later.
 				return BatchUndecided
 			}

--- a/op-node/rollup/derive/span_batch.go
+++ b/op-node/rollup/derive/span_batch.go
@@ -446,9 +446,14 @@ func (b *SpanBatch) GetBatchType() int {
 	return SpanBatchType
 }
 
-// GetTimestamp returns timestamp of the first block in the span
+// GetTimestamp returns the timestamp of the first block in the span
 func (b *SpanBatch) GetTimestamp() uint64 {
 	return b.Batches[0].Timestamp
+}
+
+// GetLastTimestamp returns the timestamp of the last block in the span
+func (b *SpanBatch) GetLastTimestamp() uint64 {
+	return b.peek(0).Timestamp
 }
 
 // TxCount returns the tx count for the batch
@@ -476,9 +481,14 @@ func (b *SpanBatch) LogContext(log log.Logger) log.Logger {
 	)
 }
 
-// GetStartEpochNum returns epoch number(L1 origin block number) of the first block in the span
+// GetStartEpochNum returns epoch number (L1 origin block number) of the first block in the span
 func (b *SpanBatch) GetStartEpochNum() rollup.Epoch {
 	return b.Batches[0].EpochNum
+}
+
+// GetLastEpochNum returns epoch number (L1 origin block number) of the last block in the span
+func (b *SpanBatch) GetLastEpochNum() rollup.Epoch {
+	return b.peek(0).EpochNum
 }
 
 // CheckOriginHash checks if the l1OriginCheck matches the first 20 bytes of given hash, probably L1 block hash from the current canonical L1 chain.
@@ -582,13 +592,21 @@ func (b *SpanBatch) ToRawSpanBatch() (*RawSpanBatch, error) {
 
 // GetSingularBatches converts SpanBatchElements after L2 safe head to SingularBatches.
 // Since SpanBatchElement does not contain EpochHash, set EpochHash from the given L1 blocks.
-// The result SingularBatches do not contain ParentHash yet. It must be set by BatchQueue.
+// The result SingularBatches do not contain ParentHash yet. It must be set by the BatchQueue/Stage.
+//
+// If the span batch is overlapping the safe head, it may happen that the batch is found to be invalid
+// only at this point and that the span batch passed the previous span batch prefix checks.
+// In this case, an error is returned and the whole span batch must be dropped.
 func (b *SpanBatch) GetSingularBatches(l1Origins []eth.L1BlockRef, l2SafeHead eth.L2BlockRef) ([]*SingularBatch, error) {
 	var singularBatches []*SingularBatch
 	originIdx := 0
 	for _, batch := range b.Batches {
 		if batch.Timestamp <= l2SafeHead.Time {
 			continue
+		}
+		if uint64(batch.EpochNum) < l2SafeHead.L1Origin.Number {
+			return nil, fmt.Errorf("future batch (ts: %d) L1 origin %d behind safe head (ts: %d) origin %d",
+				batch.Timestamp, batch.EpochNum, l2SafeHead.Time, l2SafeHead.L1Origin.Number)
 		}
 		singularBatch := SingularBatch{
 			EpochNum:     batch.EpochNum,
@@ -605,7 +623,7 @@ func (b *SpanBatch) GetSingularBatches(l1Origins []eth.L1BlockRef, l2SafeHead et
 			}
 		}
 		if !originFound {
-			return nil, fmt.Errorf("unable to find L1 origin for the epoch number: %d", batch.EpochNum)
+			return nil, fmt.Errorf("unable to find L1 origin for batch (ts: %d) with epoch number: %d", batch.Timestamp, batch.EpochNum)
 		}
 		singularBatches = append(singularBatches, &singularBatch)
 	}

--- a/op-service/testlog/capturing.go
+++ b/op-service/testlog/capturing.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum-optimism/optimism/op-service/logmods"
 )
@@ -212,8 +213,23 @@ func (c *CapturingHandler) FindLogs(filters ...LogFilter) []*CapturedRecord {
 	return logs
 }
 
-func (h *CapturedRecord) AttrValue(name string) (v any) {
-	h.Attrs(func(a slog.Attr) bool {
+func (c *CapturingHandler) RequireMessageContained(t require.TestingT, message string, filters ...LogFilter) {
+	filters = append(filters, NewMessageContainsFilter(message))
+	require.NotNil(t, c.FindLog(filters...), "expected message %s in logs", message)
+}
+
+func (c *CapturingHandler) RequireMessageContainedOnce(t require.TestingT, message string, filters ...LogFilter) {
+	filters = append(filters, NewMessageContainsFilter(message))
+	require.Len(t, c.FindLogs(filters...), 1, "expected message %s exactly once in logs", message)
+}
+
+func (c *CapturingHandler) RequireMessageContainedNTimes(t require.TestingT, message string, n int, filters ...LogFilter) {
+	filters = append(filters, NewMessageContainsFilter(message))
+	require.Len(t, c.FindLogs(filters...), n, "expected message %s %d times in logs", message, n)
+}
+
+func (r *CapturedRecord) AttrValue(name string) (v any) {
+	r.Attrs(func(a slog.Attr) bool {
 		if a.Key == name {
 			v = a.Value.Any()
 			return false


### PR DESCRIPTION
**Description**

When a span batch overlaps the safe chain, it can happen that it passes the Holocene span batch prefix checks but that the segment of the span batch after the current safe head has outdated L1 origins. This should be treated as an invalid batch and the span batch should be dropped. However, it currently is treated as a critical derivation error.

**Tests**

Added regression tests for BatchStage and BatchQueue implementations.

**Additional context**

Such a scenario can happen if a chain has a long L2 reorg caused by a long L1 reorg (e.g. forgetting to update L1 node before an L1 fork and then deviating from the canonical chain for a couple hours before the L1 nodes are fixed) and then auto-derivation kicking in, causing overlapping span batches with outdated L1 origins.

The derivation rule was technically in the specs already, but they get clarified with https://github.com/ethereum-optimism/specs/pull/863.
