### PR TITLE
ci: add requires --initialize to subsequent jobs in release workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2822,6 +2822,8 @@ workflows:
       - contracts-bedrock-build:
           context:
             - circleci-repo-readonly-authenticated-github-token
+          requires:
+            - initialize
           filters:
             tags:
               only: /^op-deployer.*/ # ensure contract artifacts are embedded in op-deployer binary
@@ -2861,6 +2863,7 @@ workflows:
           context:
             - oplabs-gcr-release
           requires:
+            - initialize
             - contracts-bedrock-build
       # Checks for cross-platform images go here
       - check-cross-platform:
@@ -2912,6 +2915,8 @@ workflows:
               ignore: /.*/
           context:
             - circleci-repo-readonly-authenticated-github-token
+          requires:
+            - initialize
       - publish-cannon-prestates:
           context:
             - circleci-repo-readonly-authenticated-github-token


### PR DESCRIPTION
Without this wiring, the rest of the workflow doesn't run. 