### PR TITLE
op-node: Light CL: Disabling Derivation

### DIFF
--- a/op-acceptance-tests/tests/sync/unsafe_only/init_test.go
+++ b/op-acceptance-tests/tests/sync/unsafe_only/init_test.go
@@ -1,0 +1,18 @@
+package unsafe_only
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/compat"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+)
+
+func TestMain(m *testing.M) {
+	presets.DoMain(m, presets.WithSingleChainTwoVerifiers(),
+		presets.WithExecutionLayerSyncOnVerifiers(),
+		presets.WithReqRespSyncDisabled(),
+		presets.WithNoDiscovery(),
+		presets.WithCompatibleTypes(compat.SysGo),
+		presets.WithUnsafeOnly(),
+	)
+}

--- a/op-acceptance-tests/tests/sync/unsafe_only/sync_test.go
+++ b/op-acceptance-tests/tests/sync/unsafe_only/sync_test.go
@@ -81,6 +81,18 @@ func TestUnsafeOnly_SequencerRestart(gt *testing.T) {
 	// Derivation did not happen at sequencer
 	sys.L2CL.SafeHead().IsGenesis()
 
+	// Stop the sequencer with API
+	sys.L2CL.StopSequencer()
+	sys.L2ELB.NotAdvancedUnsafe(3)
+
+	// Restart the sequencer with API
+	sys.L2CL.StartSequencer()
+	// Sequencer produces blocks again
+	sys.L2CL.AdvancedUnsafe(3, attempts)
+
+	// Derivation did not happen at sequencer
+	sys.L2CL.SafeHead().IsGenesis()
+
 	// Derivation happened at the second verifier
 	safeHeadNum := sys.L2CLC.SafeHead().BlockRef.Number
 	require.Greater(safeHeadNum, uint64(0))

--- a/op-acceptance-tests/tests/sync/unsafe_only/sync_test.go
+++ b/op-acceptance-tests/tests/sync/unsafe_only/sync_test.go
@@ -1,0 +1,93 @@
+package unsafe_only
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+)
+
+func TestUnsafeOnly_VerifierUnsafeGapClosed(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewSingleChainTwoVerifiersWithoutCheck(t)
+	require := t.Require()
+	attempts := 10
+
+	sys.L2CL.AdvancedUnsafe(3, attempts)
+	sys.L2EL.MatchedUnsafe(sys.L2ELB, attempts)
+	sys.L2CL.MatchedUnsafe(sys.L2CLB, attempts)
+
+	// Case 1: Closing the gap starting from genesis
+	sys.L2CLB.Stop()
+	sys.L2ELB.DisconnectPeerWith(sys.L2EL)
+	// Wipe EL to genesis
+	sys.L2ELB.Stop()
+	sys.L2ELB.Start()
+	// Check EL rewinded to genesis. Unsafe gap introduced
+	sys.L2ELB.UnsafeHead().IsGenesis()
+	// Verifier CL triggers EL Sync to close the gap including genesis
+	sys.L2CLB.Start()
+	sys.L2CLB.ConnectPeer(sys.L2CL)
+	sys.L2ELB.PeerWith(sys.L2EL)
+	// Gap is closed
+	sys.L2CLB.MatchedUnsafe(sys.L2CL, attempts)
+	sys.L2ELB.MatchedUnsafe(sys.L2EL, attempts)
+
+	// Case 2: Closing the gap not starting from genesis
+	sys.L2CLB.DisconnectPeer(sys.L2CL)
+	sys.L2CL.AdvancedUnsafe(3, attempts)
+	sys.L2CLB.NotAdvanced(types.LocalUnsafe, 3)
+	// Turn back the CLP2P
+	sys.L2CLB.ConnectPeer(sys.L2CL)
+	// gap is closed again
+	sys.L2CLB.MatchedUnsafe(sys.L2CL, attempts)
+	sys.L2ELB.MatchedUnsafe(sys.L2EL, attempts)
+
+	// Derivation did not happen at sequencer and the first verifier
+	sys.L2CL.SafeHead().IsGenesis()
+	sys.L2CLB.SafeHead().IsGenesis()
+	// Derivation happened at the second verifier
+	require.Greater(sys.L2CLC.SafeHead().BlockRef.Number, uint64(0))
+
+	t.Cleanup(func() {
+		sys.L2ELB.Start()
+		sys.L2ELB.PeerWith(sys.L2EL)
+		sys.L2CLB.Start()
+		sys.L2CLB.ConnectPeer(sys.L2CL)
+	})
+}
+
+func TestUnsafeOnly_SequencerRestart(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewSingleChainTwoVerifiersWithoutCheck(t)
+	require := t.Require()
+
+	sys.L2Batcher.Stop() // temp
+
+	attempts := 10
+
+	sys.L2CL.AdvancedUnsafe(3, attempts)
+	sys.L2EL.MatchedUnsafe(sys.L2ELB, attempts)
+	sys.L2CL.MatchedUnsafe(sys.L2CLB, attempts)
+
+	// Stop the sequencer
+	sys.L2CL.Stop()
+	sys.L2ELB.NotAdvancedUnsafe(3)
+
+	// Restart the sequencer
+	sys.L2CL.Start()
+	// Sequencer produces blocks again
+	sys.L2CL.AdvancedUnsafe(3, attempts)
+
+	// Derivation did not happen at sequencer and the first verifier
+	sys.L2CL.SafeHead().IsGenesis()
+	// sys.L2CLB.SafeHead().IsGenesis()
+	// Derivation happened at the second verifier
+	safeHeadNum := sys.L2CLC.SafeHead().BlockRef.Number
+	require.Greater(safeHeadNum, uint64(0))
+
+	t.Cleanup(func() {
+		sys.L2CL.Start()
+	})
+}

--- a/op-acceptance-tests/tests/sync/unsafe_only/sync_test.go
+++ b/op-acceptance-tests/tests/sync/unsafe_only/sync_test.go
@@ -44,9 +44,9 @@ func TestUnsafeOnly_VerifierUnsafeGapClosed(gt *testing.T) {
 	sys.L2CLB.MatchedUnsafe(sys.L2CL, attempts)
 	sys.L2ELB.MatchedUnsafe(sys.L2EL, attempts)
 
-	// Derivation did not happen at sequencer and the first verifier
+	// Derivation did not happen
 	sys.L2CL.SafeHead().IsGenesis()
-	sys.L2CLB.SafeHead().IsGenesis()
+
 	// Derivation happened at the second verifier
 	require.Greater(sys.L2CLC.SafeHead().BlockRef.Number, uint64(0))
 
@@ -80,9 +80,9 @@ func TestUnsafeOnly_SequencerRestart(gt *testing.T) {
 	// Sequencer produces blocks again
 	sys.L2CL.AdvancedUnsafe(3, attempts)
 
-	// Derivation did not happen at sequencer and the first verifier
+	// Derivation did not happen at sequencer
 	sys.L2CL.SafeHead().IsGenesis()
-	// sys.L2CLB.SafeHead().IsGenesis()
+
 	// Derivation happened at the second verifier
 	safeHeadNum := sys.L2CLC.SafeHead().BlockRef.Number
 	require.Greater(safeHeadNum, uint64(0))

--- a/op-acceptance-tests/tests/sync/unsafe_only/sync_test.go
+++ b/op-acceptance-tests/tests/sync/unsafe_only/sync_test.go
@@ -63,8 +63,6 @@ func TestUnsafeOnly_SequencerRestart(gt *testing.T) {
 	sys := presets.NewSingleChainTwoVerifiersWithoutCheck(t)
 	require := t.Require()
 
-	sys.L2Batcher.Stop() // temp
-
 	attempts := 10
 
 	sys.L2CL.AdvancedUnsafe(3, attempts)

--- a/op-acceptance-tests/tests/sync_tester/sync_tester_ext_el/ext_config.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_tester_ext_el/ext_config.go
@@ -1,0 +1,88 @@
+package sync_tester_ext_el
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+// Configuration defaults for op-sepolia
+const (
+	DefaultNetworkPreset = "op-sepolia"
+
+	// Tailscale networking endpoints
+	DefaultL2ELEndpointTailscale       = "https://proxyd-l2-sepolia.primary.client.dev.oplabs.cloud"
+	DefaultL1CLBeaconEndpointTailscale = "https://beacon-api-proxy-sepolia.primary.client.dev.oplabs.cloud"
+	DefaultL1ELEndpointTailscale       = "https://proxyd-l1-sepolia.primary.client.dev.oplabs.cloud"
+)
+
+var (
+	// Network presets for different networks against which we test op-node syncing
+	networkPresets = map[string]stack.ExtNetworkConfig{
+		"op-sepolia": {
+			L2NetworkName:      "op-sepolia",
+			L1ChainID:          eth.ChainIDFromUInt64(11155111),
+			L2ELEndpoint:       "https://ci-sepolia-l2.optimism.io",
+			L1CLBeaconEndpoint: "https://ci-sepolia-beacon.optimism.io",
+			L1ELEndpoint:       "https://ci-sepolia-l1.optimism.io",
+		},
+		"base-sepolia": {
+			L2NetworkName:      "base-sepolia",
+			L1ChainID:          eth.ChainIDFromUInt64(11155111),
+			L2ELEndpoint:       "https://base-sepolia-rpc.optimism.io",
+			L1CLBeaconEndpoint: "https://ci-sepolia-beacon.optimism.io",
+			L1ELEndpoint:       "https://ci-sepolia-l1.optimism.io",
+		},
+		"unichain-sepolia": {
+			L2NetworkName:      "unichain-sepolia",
+			L1ChainID:          eth.ChainIDFromUInt64(11155111),
+			L2ELEndpoint:       "https://unichain-sepolia-rpc.optimism.io",
+			L1CLBeaconEndpoint: "https://ci-sepolia-beacon.optimism.io",
+			L1ELEndpoint:       "https://ci-sepolia-l1.optimism.io",
+		},
+		"op-mainnet": {
+			L2NetworkName:      "op-mainnet",
+			L1ChainID:          eth.ChainIDFromUInt64(1),
+			L2ELEndpoint:       "https://op-mainnet-rpc.optimism.io",
+			L1CLBeaconEndpoint: "https://ci-mainnet-beacon.optimism.io",
+			L1ELEndpoint:       "https://ci-mainnet-l1.optimism.io",
+		},
+		"base-mainnet": {
+			L2NetworkName:      "base-mainnet",
+			L1ChainID:          eth.ChainIDFromUInt64(1),
+			L2ELEndpoint:       "https://base-mainnet-rpc.optimism.io",
+			L1CLBeaconEndpoint: "https://ci-mainnet-beacon.optimism.io",
+			L1ELEndpoint:       "https://ci-mainnet-l1.optimism.io",
+		},
+	}
+)
+
+func GetNetworkPreset(name string) (stack.ExtNetworkConfig, error) {
+	var config stack.ExtNetworkConfig
+	if name == "" {
+		config = networkPresets[DefaultNetworkPreset]
+	} else {
+		var ok bool
+		config, ok = networkPresets[name]
+		if !ok {
+			return stack.ExtNetworkConfig{}, fmt.Errorf("NETWORK_PRESET %s not found", name)
+		}
+	}
+	// Override configuration with Tailscale endpoints if Tailscale networking is enabled
+	if os.Getenv("TAILSCALE_NETWORKING") == "true" {
+		config.L2ELEndpoint = getEnvOrDefault("L2_EL_ENDPOINT_TAILSCALE", DefaultL2ELEndpointTailscale)
+		config.L1CLBeaconEndpoint = getEnvOrDefault("L1_CL_BEACON_ENDPOINT_TAILSCALE", DefaultL1CLBeaconEndpointTailscale)
+		config.L1ELEndpoint = getEnvOrDefault("L1_EL_ENDPOINT_TAILSCALE", DefaultL1ELEndpointTailscale)
+	}
+	return config, nil
+}
+
+// getEnvOrDefault returns the environment variable value or the default if not set
+func getEnvOrDefault(envVar, defaultValue string) string {
+	if value := os.Getenv(envVar); value != "" {
+		return value
+	}
+	return defaultValue
+}

--- a/op-acceptance-tests/tests/sync_tester/sync_tester_ext_el/sync_tester_ext_el_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_tester_ext_el/sync_tester_ext_el_test.go
@@ -22,64 +22,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
-// Configuration defaults for op-sepolia
-const (
-	DefaultNetworkPreset = "op-sepolia"
-
-	// Tailscale networking endpoints
-	DefaultL2ELEndpointTailscale       = "https://proxyd-l2-sepolia.primary.client.dev.oplabs.cloud"
-	DefaultL1CLBeaconEndpointTailscale = "https://beacon-api-proxy-sepolia.primary.client.dev.oplabs.cloud"
-	DefaultL1ELEndpointTailscale       = "https://proxyd-l1-sepolia.primary.client.dev.oplabs.cloud"
-)
-
-var (
-	// Network presets for different networks against which we test op-node syncing
-	networkPresets = map[string]stack.ExtNetworkConfig{
-		"op-sepolia": {
-			L2NetworkName:      "op-sepolia",
-			L1ChainID:          eth.ChainIDFromUInt64(11155111),
-			L2ELEndpoint:       "https://ci-sepolia-l2.optimism.io",
-			L1CLBeaconEndpoint: "https://ci-sepolia-beacon.optimism.io",
-			L1ELEndpoint:       "https://ci-sepolia-l1.optimism.io",
-		},
-		"base-sepolia": {
-			L2NetworkName:      "base-sepolia",
-			L1ChainID:          eth.ChainIDFromUInt64(11155111),
-			L2ELEndpoint:       "https://base-sepolia-rpc.optimism.io",
-			L1CLBeaconEndpoint: "https://ci-sepolia-beacon.optimism.io",
-			L1ELEndpoint:       "https://ci-sepolia-l1.optimism.io",
-		},
-		"unichain-sepolia": {
-			L2NetworkName:      "unichain-sepolia",
-			L1ChainID:          eth.ChainIDFromUInt64(11155111),
-			L2ELEndpoint:       "https://unichain-sepolia-rpc.optimism.io",
-			L1CLBeaconEndpoint: "https://ci-sepolia-beacon.optimism.io",
-			L1ELEndpoint:       "https://ci-sepolia-l1.optimism.io",
-		},
-		"op-mainnet": {
-			L2NetworkName:      "op-mainnet",
-			L1ChainID:          eth.ChainIDFromUInt64(1),
-			L2ELEndpoint:       "https://op-mainnet-rpc.optimism.io",
-			L1CLBeaconEndpoint: "https://ci-mainnet-beacon.optimism.io",
-			L1ELEndpoint:       "https://ci-mainnet-l1.optimism.io",
-		},
-		"base-mainnet": {
-			L2NetworkName:      "base-mainnet",
-			L1ChainID:          eth.ChainIDFromUInt64(1),
-			L2ELEndpoint:       "https://base-mainnet-rpc.optimism.io",
-			L1CLBeaconEndpoint: "https://ci-mainnet-beacon.optimism.io",
-			L1ELEndpoint:       "https://ci-mainnet-l1.optimism.io",
-		},
-	}
-	L2CLSyncMode = getSyncMode("L2_CL_SYNCMODE")
-)
-
-func getSyncMode(envVar string) sync.Mode {
-	if value := os.Getenv(envVar); value == sync.ELSyncString {
-		return sync.ELSync
-	}
-	return sync.CLSync
-}
+var L2CLSyncMode = getSyncMode("L2_CL_SYNCMODE")
 
 func TestSyncTesterExtEL(gt *testing.T) {
 	t := devtest.SerialT(gt)
@@ -161,22 +104,8 @@ func setupOrchestrator(gt *testing.T, t devtest.T, blocksToSync uint64) (*sysgo.
 	ctx := t.Ctx()
 	require := t.Require()
 
-	config := networkPresets[DefaultNetworkPreset]
-
-	// Override configuration with Tailscale endpoints if Tailscale networking is enabled
-	if os.Getenv("TAILSCALE_NETWORKING") == "true" {
-		config.L2ELEndpoint = getEnvOrDefault("L2_EL_ENDPOINT_TAILSCALE", DefaultL2ELEndpointTailscale)
-		config.L1CLBeaconEndpoint = getEnvOrDefault("L1_CL_BEACON_ENDPOINT_TAILSCALE", DefaultL1CLBeaconEndpointTailscale)
-		config.L1ELEndpoint = getEnvOrDefault("L1_EL_ENDPOINT_TAILSCALE", DefaultL1ELEndpointTailscale)
-	}
-
-	if os.Getenv("NETWORK_PRESET") != "" {
-		var ok bool
-		config, ok = networkPresets[os.Getenv("NETWORK_PRESET")]
-		if !ok {
-			gt.Errorf("NETWORK_PRESET %s not found", os.Getenv("NETWORK_PRESET"))
-		}
-	}
+	config, err := GetNetworkPreset(os.Getenv("NETWORK_PRESET"))
+	require.NoError(err, "failed to initialize network preset")
 
 	// Runtime configuration values
 	l.Info("Runtime configuration values for TestSyncTesterExtEL")
@@ -246,10 +175,9 @@ func setupOrchestrator(gt *testing.T, t devtest.T, blocksToSync uint64) (*sysgo.
 	return orch.(*sysgo.Orchestrator), target
 }
 
-// getEnvOrDefault returns the environment variable value or the default if not set
-func getEnvOrDefault(envVar, defaultValue string) string {
-	if value := os.Getenv(envVar); value != "" {
-		return value
+func getSyncMode(envVar string) sync.Mode {
+	if value := os.Getenv(envVar); value == sync.ELSyncString {
+		return sync.ELSync
 	}
-	return defaultValue
+	return sync.CLSync
 }

--- a/op-acceptance-tests/tests/sync_tester/sync_tester_unsafe_only_ext/init_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_tester_unsafe_only_ext/init_test.go
@@ -1,0 +1,43 @@
+package sync_tester_unsafe_only_ext
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/sync_tester/sync_tester_ext_el"
+	bss "github.com/ethereum-optimism/optimism/op-batcher/batcher"
+	"github.com/ethereum-optimism/optimism/op-devstack/compat"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+	"github.com/ethereum-optimism/optimism/op-node/chaincfg"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+func TestMain(m *testing.M) {
+	// Target op-sepolia
+	networkName := "op-sepolia"
+	config, _ := sync_tester_ext_el.GetNetworkPreset(networkName)
+	chainCfg := chaincfg.ChainByName(networkName)
+	presets.DoMain(m,
+		presets.WithExternalELWithSuperchainRegistry(config),
+		// CL connected to sync tester EL is verifier
+		presets.WithExecutionLayerSyncOnVerifiers(),
+		// Make sync tester EL mock EL Sync
+		presets.WithELSyncActive(),
+		// Only rely on EL sync for unsafe gap filling
+		presets.WithReqRespSyncDisabled(),
+		presets.WithNoDiscovery(),
+		presets.WithCompatibleTypes(compat.SysGo),
+		presets.WithUnsafeOnly(),
+		stack.MakeCommon(sysgo.WithBatcherOption(func(id stack.L2BatcherID, cfg *bss.CLIConfig) {
+			// For stopping derivation, not to advance safe heads
+			cfg.Stopped = true
+		})),
+		// Sync tester EL at genesis
+		presets.WithSyncTesterELInitialState(eth.FCUState{
+			Latest:    chainCfg.Genesis.L2.Number,
+			Safe:      chainCfg.Genesis.L2.Number,
+			Finalized: chainCfg.Genesis.L2.Number,
+		}),
+	)
+}

--- a/op-acceptance-tests/tests/sync_tester/sync_tester_unsafe_only_ext/sync_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_tester_unsafe_only_ext/sync_test.go
@@ -36,7 +36,15 @@ func TestSyncTesterUnsafeOnlyReachUnsafeTip(gt *testing.T) {
 	for i := unsafeTipNum + 1; i <= target; i++ {
 		sys.L2CL.SignalTarget(sys.L2ELReadOnly, i)
 	}
+	sys.L2EL.Reached(eth.Unsafe, target, 5)
+	sys.L2CL.Reached(types.LocalUnsafe, target, 5)
 
+	// Check unsafe gap is closed
+	target = unsafeTipNum + 9
+	sys.L2ELReadOnly.Reached(eth.Unsafe, target, 6)
+	for i := unsafeTipNum + 6; i <= target; i++ {
+		sys.L2CL.SignalTarget(sys.L2ELReadOnly, i)
+	}
 	sys.L2EL.Reached(eth.Unsafe, target, 5)
 	sys.L2CL.Reached(types.LocalUnsafe, target, 5)
 }

--- a/op-acceptance-tests/tests/sync_tester/sync_tester_unsafe_only_ext/sync_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_tester_unsafe_only_ext/sync_test.go
@@ -1,0 +1,31 @@
+package sync_tester_unsafe_only_ext
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+func TestSyncTesterUnsafeOnlyReachUnsafeTip(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	require := t.Require()
+
+	sys := presets.NewMinimalExternalEL(t)
+	sys.L2EL.UnsafeHead().IsGenesis()
+
+	// Check external read only EL is advancing
+	sys.L2ELReadOnly.Advanced(eth.Unsafe, 3)
+
+	unsafeTip := sys.L2ELReadOnly.UnsafeHead()
+	unsafeTipNum := unsafeTip.BlockRef.Number
+	startNum := unsafeTipNum - 3
+	// Trigger and finish EL Sync
+	for i := startNum; i <= unsafeTipNum; i++ {
+		sys.L2CL.SignalTarget(sys.L2ELReadOnly, i)
+	}
+
+	sys.L2EL.Reached(eth.Unsafe, unsafeTipNum, 5)
+	require.Equal(unsafeTip.BlockRef, sys.L2EL.UnsafeHead().BlockRef)
+}

--- a/op-acceptance-tests/tests/sync_tester/sync_tester_unsafe_only_ext/sync_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_tester_unsafe_only_ext/sync_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
 func TestSyncTesterUnsafeOnlyReachUnsafeTip(gt *testing.T) {
@@ -28,4 +29,14 @@ func TestSyncTesterUnsafeOnlyReachUnsafeTip(gt *testing.T) {
 
 	sys.L2EL.Reached(eth.Unsafe, unsafeTipNum, 5)
 	require.Equal(unsafeTip.BlockRef, sys.L2EL.UnsafeHead().BlockRef)
+
+	// Make sure the unsafe only CL can still advance unsafe
+	target := unsafeTipNum + 3
+	sys.L2ELReadOnly.Reached(eth.Unsafe, target, 3)
+	for i := unsafeTipNum + 1; i <= target; i++ {
+		sys.L2CL.SignalTarget(sys.L2ELReadOnly, i)
+	}
+
+	sys.L2EL.Reached(eth.Unsafe, target, 5)
+	sys.L2CL.Reached(types.LocalUnsafe, target, 5)
 }

--- a/op-devstack/dsl/l2_cl.go
+++ b/op-devstack/dsl/l2_cl.go
@@ -230,12 +230,24 @@ func (cl *L2CLNode) Advanced(lvl types.SafetyLevel, delta uint64, attempts int) 
 	cl.require.NoError(cl.AdvancedFn(lvl, delta, attempts)())
 }
 
+func (cl *L2CLNode) AdvancedUnsafe(delta uint64, attempts int) {
+	cl.Advanced(types.LocalUnsafe, delta, attempts)
+}
+
 func (cl *L2CLNode) NotAdvanced(lvl types.SafetyLevel, attempts int) {
 	cl.require.NoError(cl.NotAdvancedFn(lvl, attempts)())
 }
 
+func (cl *L2CLNode) NotAdvancedUnsafe(attempts int) {
+	cl.NotAdvanced(types.LocalUnsafe, attempts)
+}
+
 func (cl *L2CLNode) Reached(lvl types.SafetyLevel, target uint64, attempts int) {
 	cl.require.NoError(cl.ReachedFn(lvl, target, attempts)())
+}
+
+func (cl *L2CLNode) ReachedUnsafe(target uint64, attempts int) {
+	cl.Reached(types.LocalUnsafe, target, attempts)
 }
 
 func (cl *L2CLNode) ReachedRef(lvl types.SafetyLevel, target eth.BlockID, attempts int) {
@@ -279,6 +291,10 @@ func (cl *L2CLNode) Lagged(refNode SyncStatusProvider, lvl types.SafetyLevel, at
 
 func (cl *L2CLNode) Matched(refNode SyncStatusProvider, lvl types.SafetyLevel, attempts int) {
 	cl.require.NoError(cl.MatchedFn(refNode, lvl, attempts)())
+}
+
+func (cl *L2CLNode) MatchedUnsafe(refNode SyncStatusProvider, attempts int) {
+	cl.Matched(refNode, types.LocalUnsafe, attempts)
 }
 
 func (cl *L2CLNode) PeerInfo() *apis.PeerInfo {
@@ -412,4 +428,8 @@ func (cl *L2CLNode) AppendUnsafePayloadUntilTip(verEL, seqEL *L2ELNode, maxAttem
 
 func (cl *L2CLNode) UnsafeHead() *BlockRefResult {
 	return &BlockRefResult{T: cl.t, BlockRef: cl.HeadBlockRef(types.LocalUnsafe)}
+}
+
+func (cl *L2CLNode) SafeHead() *BlockRefResult {
+	return &BlockRefResult{T: cl.t, BlockRef: cl.HeadBlockRef(types.CrossSafe)}
 }

--- a/op-devstack/dsl/l2_el.go
+++ b/op-devstack/dsl/l2_el.go
@@ -170,6 +170,10 @@ func (el *L2ELNode) NotAdvanced(label eth.BlockLabel, attempts int) {
 	el.require.NoError(el.NotAdvancedFn(label, attempts)())
 }
 
+func (el *L2ELNode) NotAdvancedUnsafe(attempts int) {
+	el.NotAdvanced(eth.Unsafe, attempts)
+}
+
 func (el *L2ELNode) ReorgTriggered(target eth.L2BlockRef, attempts int) {
 	el.require.NoError(el.ReorgTriggeredFn(target, attempts)())
 }
@@ -349,6 +353,10 @@ func (el *L2ELNode) Matched(refNode SyncStatusProvider, lvl types.SafetyLevel, a
 	el.require.NoError(el.MatchedFn(refNode, lvl, attempts)())
 }
 
+func (el *L2ELNode) MatchedUnsafe(refNode SyncStatusProvider, attempts int) {
+	el.Matched(refNode, types.LocalUnsafe, attempts)
+}
+
 func (el *L2ELNode) UnsafeHead() *BlockRefResult {
 	return &BlockRefResult{T: el.t, BlockRef: el.BlockRefByLabel(eth.Unsafe)}
 }
@@ -365,4 +373,8 @@ type BlockRefResult struct {
 func (r *BlockRefResult) NumEqualTo(num uint64) *BlockRefResult {
 	r.T.Require().Equal(num, r.BlockRef.Number)
 	return r
+}
+
+func (r *BlockRefResult) IsGenesis() *BlockRefResult {
+	return r.NumEqualTo(0)
 }

--- a/op-devstack/presets/cl_config.go
+++ b/op-devstack/presets/cl_config.go
@@ -56,3 +56,12 @@ func WithNoDiscovery() stack.CommonOption {
 				cfg.NoDiscovery = true
 			})))
 }
+
+func WithUnsafeOnly() stack.CommonOption {
+	return stack.MakeCommon(
+		sysgo.WithGlobalL2CLOption(sysgo.L2CLOptionFn(
+			func(_ devtest.P, id stack.L2CLNodeID, cfg *sysgo.L2CLConfig) {
+				cfg.SequencerUnsafeOnly = true
+				cfg.VerifierUnsafeOnly = true
+			})))
+}

--- a/op-devstack/presets/minimal_external_el.go
+++ b/op-devstack/presets/minimal_external_el.go
@@ -5,7 +5,9 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/shim"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack/match"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
 )
 
@@ -33,4 +35,28 @@ func (m *MinimalExternalEL) L2Networks() []*dsl.L2Network {
 
 func WithExternalELWithSuperchainRegistry(networkPreset stack.ExtNetworkConfig) stack.CommonOption {
 	return stack.MakeCommon(sysgo.ExternalELSystemWithEndpointAndSuperchainRegistry(&sysgo.DefaultMinimalExternalELSystemIDs{}, networkPreset))
+}
+
+func NewMinimalExternalEL(t devtest.T) *MinimalExternalEL {
+	orch := Orchestrator()
+	system := shim.NewSystem(t)
+	orch.Hydrate(system)
+
+	l2 := system.L2Network(match.L2ChainA)
+	verifierCL := l2.L2CLNode(match.FirstL2CL)
+	syncTester := l2.SyncTester(match.FirstSyncTester)
+
+	sys := &MinimalExternalEL{
+		Log:          t.Logger(),
+		T:            t,
+		ControlPlane: orch.ControlPlane(),
+		L1Network:    dsl.NewL1Network(system.L1Network(match.FirstL1Network)),
+		L1EL:         dsl.NewL1ELNode(system.L1Network(match.FirstL1Network).L1ELNode(match.FirstL1EL)),
+		L2Chain:      dsl.NewL2Network(l2, orch.ControlPlane()),
+		L2CL:         dsl.NewL2CLNode(verifierCL, orch.ControlPlane()),
+		L2ELReadOnly: dsl.NewL2ELNode(l2.L2ELNode(match.FirstL2EL), orch.ControlPlane()),
+		L2EL:         dsl.NewL2ELNode(l2.L2ELNode(match.SecondL2EL), orch.ControlPlane()),
+		SyncTester:   dsl.NewSyncTester(syncTester),
+	}
+	return sys
 }

--- a/op-devstack/presets/singlechain_twoverifiers.go
+++ b/op-devstack/presets/singlechain_twoverifiers.go
@@ -1,0 +1,46 @@
+package presets
+
+import (
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/shim"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack/match"
+	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+)
+
+type SingleChainTwoVerifiers struct {
+	SingleChainMultiNode
+
+	L2ELC *dsl.L2ELNode
+	L2CLC *dsl.L2CLNode
+}
+
+func WithSingleChainTwoVerifiers() stack.CommonOption {
+	return stack.MakeCommon(sysgo.DefaultSingleChainTwoVerifiersSystem(&sysgo.DefaultSingleChainTwoVerifiersSystemIDs{}))
+}
+
+func NewSingleChainTwoVerifiersWithoutCheck(t devtest.T) *SingleChainTwoVerifiers {
+	system := shim.NewSystem(t)
+	orch := Orchestrator()
+	orch.Hydrate(system)
+	singleChainMultiNode := NewSingleChainMultiNodeWithoutCheck(t)
+	l2 := system.L2Network(match.Assume(t, match.L2ChainA))
+	verifierCL := l2.L2CLNode(match.Assume(t,
+		match.And(
+			match.Not(match.WithSequencerActive(t.Ctx())),
+			match.Not[stack.L2CLNodeID, stack.L2CLNode](singleChainMultiNode.L2CL.ID()),
+			match.Not[stack.L2CLNodeID, stack.L2CLNode](singleChainMultiNode.L2CLB.ID()),
+		)))
+	verifierEL := l2.L2ELNode(match.Assume(t,
+		match.And(
+			match.Not[stack.L2ELNodeID, stack.L2ELNode](singleChainMultiNode.L2EL.ID()),
+			match.Not[stack.L2ELNodeID, stack.L2ELNode](singleChainMultiNode.L2ELB.ID()),
+		)))
+	preset := &SingleChainTwoVerifiers{
+		SingleChainMultiNode: *singleChainMultiNode,
+		L2ELC:                dsl.NewL2ELNode(verifierEL, orch.ControlPlane()),
+		L2CLC:                dsl.NewL2CLNode(verifierCL, orch.ControlPlane()),
+	}
+	return preset
+}

--- a/op-devstack/sysgo/l2_cl.go
+++ b/op-devstack/sysgo/l2_cl.go
@@ -36,6 +36,10 @@ type L2CLConfig struct {
 
 	// NoDiscovery is the flag to enable/disable discovery
 	NoDiscovery bool
+
+	// UnsafeOnly is the flag to disable derivation
+	SequencerUnsafeOnly bool
+	VerifierUnsafeOnly  bool
 }
 
 func L2CLSequencer() L2CLOption {
@@ -50,16 +54,24 @@ func L2CLIndexing() L2CLOption {
 	})
 }
 
+func L2CLVerifierDisableUnsafeOnly() L2CLOption {
+	return L2CLOptionFn(func(p devtest.P, id stack.L2CLNodeID, cfg *L2CLConfig) {
+		cfg.VerifierUnsafeOnly = false
+	})
+}
+
 func DefaultL2CLConfig() *L2CLConfig {
 	return &L2CLConfig{
-		SequencerSyncMode: nodeSync.CLSync,
-		VerifierSyncMode:  nodeSync.CLSync,
-		SafeDBPath:        "",
-		IsSequencer:       false,
-		IndexingMode:      false,
-		EnableReqRespSync: true,
-		UseReqRespSync:    true,
-		NoDiscovery:       false,
+		SequencerSyncMode:   nodeSync.CLSync,
+		VerifierSyncMode:    nodeSync.CLSync,
+		SafeDBPath:          "",
+		IsSequencer:         false,
+		IndexingMode:        false,
+		EnableReqRespSync:   true,
+		UseReqRespSync:      true,
+		NoDiscovery:         false,
+		SequencerUnsafeOnly: false,
+		VerifierUnsafeOnly:  false,
 	}
 }
 

--- a/op-devstack/sysgo/l2_cl_opnode.go
+++ b/op-devstack/sysgo/l2_cl_opnode.go
@@ -297,6 +297,7 @@ func WithOpNode(l2CLID stack.L2CLNodeID, l1CLID stack.L1CLNodeID, l1ELID stack.L
 				SupportsPostFinalizationELSync: false,
 				UnsafeOnly:                     unsafeOnly,
 				L2FollowSourceEndpoint:         "",
+				NeedInitialResetEngine:         cfg.IsSequencer && unsafeOnly,
 			},
 			ConfigPersistence:               config.DisabledConfigPersistence{},
 			Metrics:                         opmetrics.CLIConfig{},

--- a/op-devstack/sysgo/l2_cl_opnode.go
+++ b/op-devstack/sysgo/l2_cl_opnode.go
@@ -174,12 +174,16 @@ func WithOpNode(l2CLID stack.L2CLNodeID, l1CLID stack.L1CLNodeID, l1ELID stack.L
 		L2CLOptionBundle(opts).Apply(p, l2CLID, cfg) // apply specific options
 
 		syncMode := cfg.VerifierSyncMode
+		unsafeOnly := false
 		if cfg.IsSequencer {
 			syncMode = cfg.SequencerSyncMode
 			// Sanity check, to navigate legacy sync-mode test assumptions.
 			// Can't enable ELSync on the sequencer or it will never start sequencing because
 			// ELSync needs to receive gossip from the sequencer to drive the sync
 			p.Require().NotEqual(nodeSync.ELSync, syncMode, "sequencer cannot use EL sync")
+			unsafeOnly = cfg.SequencerUnsafeOnly
+		} else {
+			unsafeOnly = cfg.VerifierUnsafeOnly
 		}
 
 		jwtPath, jwtSecret := orch.writeDefaultJWT()
@@ -291,6 +295,8 @@ func WithOpNode(l2CLID stack.L2CLNodeID, l1CLID stack.L1CLNodeID, l1ELID stack.L
 				SyncModeReqResp:                cfg.UseReqRespSync,
 				SkipSyncStartCheck:             false,
 				SupportsPostFinalizationELSync: false,
+				UnsafeOnly:                     unsafeOnly,
+				L2FollowSourceEndpoint:         "",
 			},
 			ConfigPersistence:               config.DisabledConfigPersistence{},
 			Metrics:                         opmetrics.CLIConfig{},

--- a/op-devstack/sysgo/system_singlechain_twoverifiers.go
+++ b/op-devstack/sysgo/system_singlechain_twoverifiers.go
@@ -1,0 +1,43 @@
+package sysgo
+
+import (
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+type DefaultSingleChainTwoVerifiersSystemIDs struct {
+	DefaultSingleChainMultiNodeSystemIDs
+
+	L2CLC stack.L2CLNodeID
+	L2ELC stack.L2ELNodeID
+}
+
+func NewDefaultSingleChainTwoVerifiersSystemIDs(l1ID, l2ID eth.ChainID) DefaultSingleChainTwoVerifiersSystemIDs {
+	return DefaultSingleChainTwoVerifiersSystemIDs{
+		DefaultSingleChainMultiNodeSystemIDs: NewDefaultSingleChainMultiNodeSystemIDs(l1ID, l2ID),
+		L2CLC:                                stack.NewL2CLNodeID("c", l2ID),
+		L2ELC:                                stack.NewL2ELNodeID("c", l2ID),
+	}
+}
+
+func DefaultSingleChainTwoVerifiersSystem(dest *DefaultSingleChainTwoVerifiersSystemIDs) stack.Option[*Orchestrator] {
+	ids := NewDefaultSingleChainTwoVerifiersSystemIDs(DefaultL1ID, DefaultL2AID)
+
+	opt := stack.Combine[*Orchestrator]()
+	opt.Add(DefaultSingleChainMultiNodeSystem(&dest.DefaultSingleChainMultiNodeSystemIDs))
+
+	opt.Add(WithL2ELNode(ids.L2ELC))
+	// Specific options are applied after global options
+	// this means unsafeOnly is always disabled for the second verifier
+	opt.Add(WithL2CLNode(ids.L2CLC, ids.L1CL, ids.L1EL, ids.L2ELC, L2CLVerifierDisableUnsafeOnly()))
+
+	opt.Add(WithL2CLP2PConnection(ids.L2CL, ids.L2CLC))
+	opt.Add(WithL2ELP2PConnection(ids.L2EL, ids.L2ELC))
+	opt.Add(WithL2CLP2PConnection(ids.L2CLB, ids.L2CLC))
+	opt.Add(WithL2ELP2PConnection(ids.L2ELB, ids.L2ELC))
+
+	opt.Add(stack.Finally(func(orch *Orchestrator) {
+		*dest = ids
+	}))
+	return opt
+}

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -269,7 +269,22 @@ func (s *Driver) eventLoop() {
 	syncCheckInterval := time.Duration(s.SyncDeriver.Config.BlockTime) * time.Second * 2
 	altSyncTicker := time.NewTicker(syncCheckInterval)
 	defer altSyncTicker.Stop()
+
 	lastUnsafeL2 := s.SyncDeriver.Engine.UnsafeL2Head()
+
+	unsafeOnly := s.SyncDeriver.SyncCfg.UnsafeOnly
+
+	resetAltSync := func(newHead eth.L2BlockRef, derivationReady bool) {
+		s.log.Debug(
+			"altSyncTicker reset",
+			"head", newHead,
+			"lastUnsafeL2", lastUnsafeL2,
+			"derivationReady", derivationReady,
+			"unsafeOnly", unsafeOnly,
+		)
+		lastUnsafeL2 = newHead
+		altSyncTicker.Reset(syncCheckInterval)
+	}
 
 	for {
 		if s.driverCtx.Err() != nil { // don't try to schedule/handle more work when we are closing.
@@ -278,18 +293,15 @@ func (s *Driver) eventLoop() {
 
 		planSequencerAction()
 
-		// Reset the alt-sync ticker when either:
-		//   - The unsafe L2 head has changed, or
-		//   - Derivation is not yet ready (unless derivation is intentionally disabled via UnsafeOnly).
-		// This prevents requesting L2 blocks unnecessarily while we are already syncing.
-		//
-		// When UnsafeOnly is enabled, derivation will never become ready. Without the
-		// !UnsafeOnly guard, the alt-sync ticker would reset indefinitely, preventing
-		// normal alt-sync progress.
-		if head := s.SyncDeriver.Engine.UnsafeL2Head(); head != lastUnsafeL2 || (!s.SyncDeriver.Derivation.DerivationReady() && !s.SyncDeriver.SyncCfg.UnsafeOnly) {
-			s.log.Debug("altSyncTicker reset", "head", head, "lastUnsafeL2", lastUnsafeL2, "derivationReady", s.SyncDeriver.Derivation.DerivationReady(), "unsafeOnly", s.SyncDeriver.SyncCfg.UnsafeOnly)
-			lastUnsafeL2 = head
-			altSyncTicker.Reset(syncCheckInterval)
+		head := s.SyncDeriver.Engine.UnsafeL2Head()
+		derivationReady := s.SyncDeriver.Derivation.DerivationReady()
+
+		if lastUnsafeL2 != head {
+			// Unsafe head changed: reset alt-sync to avoid redundant L2 requests while syncing.
+			resetAltSync(head, derivationReady)
+		} else if !unsafeOnly && !derivationReady {
+			// Derivation enabled but not yet ready: reset alt-sync while it catches up.
+			resetAltSync(head, derivationReady)
 		}
 
 		select {

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -278,10 +278,16 @@ func (s *Driver) eventLoop() {
 
 		planSequencerAction()
 
-		// If the engine is not ready, or if the L2 head is actively changing, then reset the alt-sync:
-		// there is no need to request L2 blocks when we are syncing already.
-		if head := s.SyncDeriver.Engine.UnsafeL2Head(); head != lastUnsafeL2 || !s.SyncDeriver.Derivation.DerivationReady() {
-			s.log.Debug("altSyncTicker reset", "head", head, "lastUnsafeL2", lastUnsafeL2, "derivationReady", s.SyncDeriver.Derivation.DerivationReady())
+		// Reset the alt-sync ticker when either:
+		//   - The unsafe L2 head has changed, or
+		//   - Derivation is not yet ready (unless derivation is intentionally disabled via UnsafeOnly).
+		// This prevents requesting L2 blocks unnecessarily while we are already syncing.
+		//
+		// When UnsafeOnly is enabled, derivation will never become ready. Without the
+		// !UnsafeOnly guard, the alt-sync ticker would reset indefinitely, preventing
+		// normal alt-sync progress.
+		if head := s.SyncDeriver.Engine.UnsafeL2Head(); head != lastUnsafeL2 || (!s.SyncDeriver.Derivation.DerivationReady() && !s.SyncDeriver.SyncCfg.UnsafeOnly) {
+			s.log.Debug("altSyncTicker reset", "head", head, "lastUnsafeL2", lastUnsafeL2, "derivationReady", s.SyncDeriver.Derivation.DerivationReady(), "unsafeOnly", s.SyncDeriver.SyncCfg.UnsafeOnly)
 			lastUnsafeL2 = head
 			altSyncTicker.Reset(syncCheckInterval)
 		}

--- a/op-node/rollup/driver/sync_deriver.go
+++ b/op-node/rollup/driver/sync_deriver.go
@@ -236,7 +236,7 @@ func (s *SyncDeriver) SyncStep() {
 
 	if s.Engine.IsEngineInitialELSyncing() {
 		// The pipeline cannot move forwards if doing initial EL sync.
-		s.Log.Debug("Rollup driver is backing off because execution engine is initial EL syncing.",
+		s.Log.Debug("Rollup driver is backing off because execution engine is performing initial EL sync.",
 			"unsafe_head", s.Engine.UnsafeL2Head())
 		s.StepDeriver.ResetStepBackoff(s.Ctx)
 		return

--- a/op-node/rollup/driver/sync_deriver.go
+++ b/op-node/rollup/driver/sync_deriver.go
@@ -227,11 +227,13 @@ func (s *SyncDeriver) SyncStep() {
 
 	s.tryBackupUnsafeReorg()
 
-	// Guard: Do not send an FCU until UsafeHead is initialized.
-	// In other words, avoid sending an FCU that sets the unsafe head to genesis.
-	// This prevents side effects such as snap sync being terminated prematurely with an empty EL.
 	if s.Engine.UnsafeL2HeadInitialized() {
+		// Only send an FCU once UnsafeHead has been initialized.
+		// This prevents side effects such as snap sync being terminated
+		// prematurely with an empty EL.
 		s.Engine.TryUpdateEngine(s.Ctx)
+	} else {
+		s.Log.Warn("Skipping TryUpdateEngine because unsafe-head is not initialized yet")
 	}
 
 	if s.Engine.IsEngineInitialELSyncing() {

--- a/op-node/rollup/driver/sync_deriver.go
+++ b/op-node/rollup/driver/sync_deriver.go
@@ -227,7 +227,12 @@ func (s *SyncDeriver) SyncStep() {
 
 	s.tryBackupUnsafeReorg()
 
-	s.Engine.TryUpdateEngine(s.Ctx)
+	// Guard: Do not send an FCU until UsafeHead is initialized.
+	// In other words, avoid sending an FCU that sets the unsafe head to genesis.
+	// This prevents side effects such as snap sync being terminated prematurely with an empty EL.
+	if s.Engine.UnsafeL2HeadInitialized() {
+		s.Engine.TryUpdateEngine(s.Ctx)
+	}
 
 	if s.Engine.IsEngineInitialELSyncing() {
 		// The pipeline cannot move forwards if doing initial EL sync.

--- a/op-node/rollup/driver/sync_deriver.go
+++ b/op-node/rollup/driver/sync_deriver.go
@@ -230,10 +230,18 @@ func (s *SyncDeriver) SyncStep() {
 	s.Engine.TryUpdateEngine(s.Ctx)
 
 	if s.Engine.IsEngineInitialELSyncing() {
-		// The pipeline cannot move forwards if doing EL sync.
-		s.Log.Debug("Rollup driver is backing off because execution engine is syncing.",
+		// The pipeline cannot move forwards if doing initial EL sync.
+		s.Log.Debug("Rollup driver is backing off because execution engine is initial EL syncing.",
 			"unsafe_head", s.Engine.UnsafeL2Head())
 		s.StepDeriver.ResetStepBackoff(s.Ctx)
+		return
+	}
+
+	if s.SyncCfg.UnsafeOnly {
+		if !s.Engine.UnsafeL2HeadInitialized() {
+			// Need a single reset to tripper sequencer block building
+			s.Engine.ResetEngine(s.Ctx)
+		}
 		return
 	}
 

--- a/op-node/rollup/driver/sync_deriver.go
+++ b/op-node/rollup/driver/sync_deriver.go
@@ -238,10 +238,8 @@ func (s *SyncDeriver) SyncStep() {
 	}
 
 	if s.SyncCfg.UnsafeOnly {
-		if !s.Engine.UnsafeL2HeadInitialized() {
-			// Need a single reset to tripper sequencer block building
-			s.Engine.ResetEngine(s.Ctx)
-		}
+		// May need a single reset to trigger sequencer block building
+		s.Engine.TryInitialResetEngineForSequencer(s.Ctx)
 		return
 	}
 

--- a/op-node/rollup/driver/sync_deriver.go
+++ b/op-node/rollup/driver/sync_deriver.go
@@ -227,14 +227,7 @@ func (s *SyncDeriver) SyncStep() {
 
 	s.tryBackupUnsafeReorg()
 
-	if s.Engine.UnsafeL2HeadInitialized() {
-		// Only send an FCU once UnsafeHead has been initialized.
-		// This prevents side effects such as snap sync being terminated
-		// prematurely with an empty EL.
-		s.Engine.TryUpdateEngine(s.Ctx)
-	} else {
-		s.Log.Warn("Skipping TryUpdateEngine because unsafe-head is not initialized yet")
-	}
+	s.Engine.TryUpdateEngine(s.Ctx)
 
 	if s.Engine.IsEngineInitialELSyncing() {
 		// The pipeline cannot move forwards if doing initial EL sync.

--- a/op-node/rollup/driver/sync_deriver.go
+++ b/op-node/rollup/driver/sync_deriver.go
@@ -245,8 +245,10 @@ func (s *SyncDeriver) SyncStep() {
 	}
 
 	if s.SyncCfg.UnsafeOnly {
-		// May need a single reset to trigger sequencer block building
-		s.Engine.TryInitialResetEngineForSequencer(s.Ctx)
+		if s.SyncCfg.NeedInitialResetEngine {
+			// May need a single reset to trigger sequencer block building
+			s.Engine.TryInitialResetEngineForSequencer(s.Ctx)
+		}
 		return
 	}
 

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -189,12 +189,6 @@ func (e *EngineController) UnsafeL2Head() eth.L2BlockRef {
 	return e.unsafeHead
 }
 
-func (e *EngineController) UnsafeL2HeadInitialized() bool {
-	e.mu.Lock()
-	defer e.mu.Unlock()
-	return e.unsafeHead != eth.L2BlockRef{}
-}
-
 func (e *EngineController) PendingSafeL2Head() eth.L2BlockRef {
 	return e.pendingSafeHead
 }
@@ -873,16 +867,11 @@ func (e *EngineController) SetOriginSelectorResetter(resetter OriginSelectorForc
 func (e *EngineController) ForceReset(ctx context.Context, localUnsafe, crossUnsafe, localSafe, crossSafe, finalized eth.L2BlockRef) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	e.forceReset(ctx, localUnsafe, crossUnsafe, localSafe, crossSafe, finalized)
+	e.forceReset(ctx, localUnsafe, crossUnsafe, localSafe, crossSafe, finalized, false)
 }
 
 // forceReset performs a forced reset to the specified block references
-func (e *EngineController) forceReset(ctx context.Context, localUnsafe, crossUnsafe, localSafe, crossSafe, finalized eth.L2BlockRef) {
-	unsafeL2NotInitialized := e.unsafeHead == eth.L2BlockRef{}
-	if unsafeL2NotInitialized {
-		e.log.Info("EngineController Unsafe head was not initialized at the start of the reset")
-	}
-
+func (e *EngineController) forceReset(ctx context.Context, localUnsafe, crossUnsafe, localSafe, crossSafe, finalized eth.L2BlockRef, signalOnlySeq bool) {
 	// Reset other components before resetting the engine
 	if e.attributesResetter != nil {
 		e.attributesResetter.ForceReset(ctx, localUnsafe, crossUnsafe, localSafe, crossSafe, finalized)
@@ -901,8 +890,10 @@ func (e *EngineController) forceReset(ctx context.Context, localUnsafe, crossUns
 		e.emitter.Emit(ctx, derive.ConfirmPipelineResetEvent{})
 	}
 
-	if unsafeL2NotInitialized {
-		// Do not FCU but propagate the initial reset info to the sequencer when sequencing enabled
+	if signalOnlySeq {
+		// Intentionally not propagating ForkchoiceUpdateEvent to other event Deriver avoiding side effects.
+		// If we do tryUpdateEngine instead, it will eventually emit ForkchoiceUpdateEvent, causing block building
+		// to never begin. Use fine grained ForkchoiceUpdateInitEvent to only propagate info to the sequencer component.
 		e.emitter.Emit(ctx, ForkchoiceUpdateInitEvent{
 			UnsafeL2Head:    e.unsafeHead,
 			SafeL2Head:      e.safeHead,
@@ -1055,13 +1046,28 @@ func (e *EngineController) onResetEngineRequest(ctx context.Context) {
 		})
 		return
 	}
-	e.forceReset(ctx, result.Unsafe, result.Unsafe, result.Safe, result.Safe, result.Finalized)
+	e.forceReset(ctx, result.Unsafe, result.Unsafe, result.Safe, result.Safe, result.Finalized, false)
 }
 
-func (e *EngineController) ResetEngine(ctx context.Context) {
+// InitialResetEngineForSequencer resets engine controller with the info from FindL2Heads and only propagates
+// ForkchoiceUpdateEvent info to the sequencer to trigger sequencer block building, but not propagating
+// ForkchoiceUpdateEvent to other event Deriver avoiding side effects
+func (e *EngineController) TryInitialResetEngineForSequencer(ctx context.Context) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	e.onResetEngineRequest(ctx)
+	if e.unsafeHead != (eth.L2BlockRef{}) {
+		// Engine already initialized unsafe head. Early return
+		return
+	}
+	e.log.Info("EngineController Unsafe head was not initialized at the start of the reset")
+	result, err := sync.FindL2Heads(e.ctx, e.rollupCfg, e.l1, e.engine, e.log, e.syncCfg)
+	if err != nil {
+		e.log.Warn("Failed to find L2 Heads to start from while initial reset: %w", err)
+		// Do not emit ResetEvent because it will end propagating ForkchoiceUpdateEvent
+		// Because the engine controller failed to initialize, the next SyncStep will retry this method
+		return
+	}
+	e.forceReset(ctx, result.Unsafe, result.Unsafe, result.Safe, result.Safe, result.Finalized, true)
 }
 
 var ErrEngineSyncing = errors.New("engine is syncing")

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -1049,7 +1049,7 @@ func (e *EngineController) onResetEngineRequest(ctx context.Context) {
 	e.forceReset(ctx, result.Unsafe, result.Unsafe, result.Safe, result.Safe, result.Finalized, false)
 }
 
-// InitialResetEngineForSequencer resets engine controller with the info from FindL2Heads and only propagates
+// TryInitialResetEngineForSequencer resets engine controller with the info from FindL2Heads and only propagates
 // ForkchoiceUpdateEvent info to the sequencer to trigger sequencer block building, but not propagating
 // ForkchoiceUpdateEvent to other event Deriver avoiding side effects
 func (e *EngineController) TryInitialResetEngineForSequencer(ctx context.Context) {

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -188,12 +188,6 @@ func (e *EngineController) UnsafeL2Head() eth.L2BlockRef {
 	return e.unsafeHead
 }
 
-func (e *EngineController) UnsafeL2HeadInitialized() bool {
-	e.mu.Lock()
-	defer e.mu.Unlock()
-	return e.unsafeHead != eth.L2BlockRef{}
-}
-
 func (e *EngineController) PendingSafeL2Head() eth.L2BlockRef {
 	return e.pendingSafeHead
 }

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -184,9 +184,14 @@ func NewEngineController(ctx context.Context, engine ExecEngine, log log.Logger,
 		unsafePayloads: NewPayloadsQueue(log, maxUnsafePayloadsMemory, payloadMemSize),
 	}
 }
-
 func (e *EngineController) UnsafeL2Head() eth.L2BlockRef {
 	return e.unsafeHead
+}
+
+func (e *EngineController) UnsafeL2HeadInitialized() bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.unsafeHead != eth.L2BlockRef{}
 }
 
 func (e *EngineController) PendingSafeL2Head() eth.L2BlockRef {

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -189,6 +189,12 @@ func (e *EngineController) UnsafeL2Head() eth.L2BlockRef {
 	return e.unsafeHead
 }
 
+func (e *EngineController) UnsafeL2HeadInitialized() bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.unsafeHead != eth.L2BlockRef{}
+}
+
 func (e *EngineController) PendingSafeL2Head() eth.L2BlockRef {
 	return e.pendingSafeHead
 }
@@ -872,6 +878,11 @@ func (e *EngineController) ForceReset(ctx context.Context, localUnsafe, crossUns
 
 // forceReset performs a forced reset to the specified block references
 func (e *EngineController) forceReset(ctx context.Context, localUnsafe, crossUnsafe, localSafe, crossSafe, finalized eth.L2BlockRef) {
+	unsafeL2NotInitialized := e.unsafeHead == eth.L2BlockRef{}
+	if unsafeL2NotInitialized {
+		e.log.Info("EngineController Unsafe head was not initialized at the start of the reset")
+	}
+
 	// Reset other components before resetting the engine
 	if e.attributesResetter != nil {
 		e.attributesResetter.ForceReset(ctx, localUnsafe, crossUnsafe, localSafe, crossSafe, finalized)
@@ -890,8 +901,17 @@ func (e *EngineController) forceReset(ctx context.Context, localUnsafe, crossUns
 		e.emitter.Emit(ctx, derive.ConfirmPipelineResetEvent{})
 	}
 
-	// Time to apply the changes to the underlying engine
-	e.tryUpdateEngine(ctx)
+	if unsafeL2NotInitialized {
+		// Do not FCU but propagate the initial reset info to the sequencer when sequencing enabled
+		e.emitter.Emit(ctx, ForkchoiceUpdateInitEvent{
+			UnsafeL2Head:    e.unsafeHead,
+			SafeL2Head:      e.safeHead,
+			FinalizedL2Head: e.finalizedHead,
+		})
+	} else {
+		// Time to apply the changes to the underlying engine
+		e.tryUpdateEngine(ctx)
+	}
 
 	v := EngineResetConfirmedEvent{
 		LocalUnsafe: e.unsafeHead,
@@ -1036,6 +1056,12 @@ func (e *EngineController) onResetEngineRequest(ctx context.Context) {
 		return
 	}
 	e.forceReset(ctx, result.Unsafe, result.Unsafe, result.Safe, result.Safe, result.Finalized)
+}
+
+func (e *EngineController) ResetEngine(ctx context.Context) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.onResetEngineRequest(ctx)
 }
 
 var ErrEngineSyncing = errors.New("engine is syncing")

--- a/op-node/rollup/engine/events.go
+++ b/op-node/rollup/engine/events.go
@@ -27,6 +27,15 @@ func (ev ForkchoiceUpdateEvent) String() string {
 	return "forkchoice-update"
 }
 
+// ForkchoiceUpdateInitEvent is only for the sequencer to be signaled during initialization
+type ForkchoiceUpdateInitEvent struct {
+	UnsafeL2Head, SafeL2Head, FinalizedL2Head eth.L2BlockRef
+}
+
+func (ev ForkchoiceUpdateInitEvent) String() string {
+	return "forkchoice-update-init"
+}
+
 // UnsafeUpdateEvent signals that the given block is now considered safe.
 // This is pre-forkchoice update; the change may not be reflected yet in the EL.
 type UnsafeUpdateEvent struct {

--- a/op-node/rollup/engine/payload_success.go
+++ b/op-node/rollup/engine/payload_success.go
@@ -29,7 +29,7 @@ func (e *EngineController) onPayloadSuccess(ctx context.Context, ev PayloadSucce
 		e.log.Warn("Successfully built replacement block, resetting chain to continue now", "replacement", ev.Ref)
 		// Change the engine state to make the replacement block the cross-safe head of the chain,
 		// And continue syncing from there.
-		e.forceReset(ctx, ev.Ref, ev.Ref, ev.Ref, ev.Ref, e.Finalized())
+		e.forceReset(ctx, ev.Ref, ev.Ref, ev.Ref, ev.Ref, e.Finalized(), false)
 		e.emitter.Emit(ctx, InteropReplacedBlockEvent{
 			Envelope: ev.Envelope,
 			Ref:      ev.Ref.BlockRef(),

--- a/op-node/rollup/sequencing/sequencer.go
+++ b/op-node/rollup/sequencing/sequencer.go
@@ -198,6 +198,8 @@ func (d *Sequencer) OnEvent(ctx context.Context, ev event.Event) bool {
 		d.onEngineResetConfirmedEvent(x)
 	case engine.ForkchoiceUpdateEvent:
 		d.onForkchoiceUpdate(x)
+	case engine.ForkchoiceUpdateInitEvent:
+		d.onForkchoiceUpdate(engine.ForkchoiceUpdateEvent(x))
 	default:
 		return false
 	}

--- a/op-node/rollup/sync/config.go
+++ b/op-node/rollup/sync/config.go
@@ -77,8 +77,5 @@ type Config struct {
 
 	UnsafeOnly             bool   `json:"unsafe_only"`
 	L2FollowSourceEndpoint string `json:"l2_follow_source_endpoint"`
-}
-
-func (c *Config) L2FollowSourceEnabled() bool {
-	return c.L2FollowSourceEndpoint != ""
+	NeedInitialResetEngine bool   `json:"need_initial_reset_engine"`
 }

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -380,6 +380,7 @@ func NewSyncConfig(ctx cliiface.Context, log log.Logger) (*sync.Config, error) {
 		SupportsPostFinalizationELSync: engineKind.SupportsPostFinalizationELSync(),
 		UnsafeOnly:                     unsafeOnly,
 		L2FollowSourceEndpoint:         l2FollowSourceEndpoint,
+		NeedInitialResetEngine:         isSequencer && unsafeOnly,
 	}
 	if ctx.Bool(flags.L2EngineSyncEnabled.Name) {
 		cfg.SyncMode = sync.ELSync


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Implements logic for disabling derivation or in other words, unsafe only. This tweak must be work both for verifier and sequencer. 

Idea: Use the prior method to disable derivation. While initial EL Syncing, the derivation was disabled, altering the sync step:

```go
func (s *SyncDeriver) SyncStep() {
     ... 
    if s.Engine.IsEngineInitialELSyncing() {
    	s.StepDeriver.ResetStepBackoff(s.Ctx)
    	return
    }
    s.Engine.RequestPendingSafeUpdate(s.Ctx)
}
```
Not calling `s.Engine.RequestPendingSafeUpdate(s.Ctx)` was to key to not triggering the attributes handler, resulting in no derivation. Therefore after the initial EL Sync is done, we now check unsafe only is enabled. If enabled, we early return again.

```go
func (s *SyncDeriver) SyncStep() {
     ... 
    if s.Engine.IsEngineInitialELSyncing() {
    	s.StepDeriver.ResetStepBackoff(s.Ctx)
    	return
    }
    if s.SyncCfg.UnsafeOnly {
    	// May need a single reset to trigger sequencer block building
    	s.Engine.TryInitialResetEngineForSequencer(s.Ctx)
    	return
    }
    s.Engine.RequestPendingSafeUpdate(s.Ctx)
}
```

For the verifier, it will be only signaled via the CLP2P, and will start spinning the engine controller. Easy!

For the sequencer, it does not get signaled to the external data source at all, because we disabled derivation and sequencer never listens to its own gossip. Therefore the block building is never initially triggered. More precisely, block building is never triggered because the engine controller's unsafe head is not initialized. 

https://github.com/ethereum-optimism/optimism/blob/31ecd4a1bdb83629938df8e04950c637544adb3e/op-node/rollup/sequencing/sequencer.go#L486-L494

To signal the sequencer component inside the op-node, we may trigger a initial reset. While resetting, we query the EL and fetch its unsafe, safe, finalized (if available) (`FindL2Heads`), and sync it with Engine Controller using `forceReset`. 

https://github.com/ethereum-optimism/optimism/blob/d19b0f5962dcb312685027012dcdfa2fa25e3ba6/op-node/rollup/engine/engine_controller.go#L1060-L1076

While `forceReset`ing, we do not want to call FCU to the EL nor broadcasting the FCU result to other components using the event system. Rather, we only want to sync the inital engine state (unsafe, safe, finalized) to the Engine Controller and the sequencer component. To do this, I added a special event `ForkchoiceUpdateInitEvent` to only propagate the initial engine state to the sequencer component. After that, we call `EngineResetConfirmedEvent` to continue(start) sequencing. 

~Also handle the special case; after we do a initial reset targeting the fresh EL which is at genesis and never synced, `SyncStep()` may be called, resulting in `s.Engine.TryUpdateEngine`. This means we will FCU the EL to the genesis, and this may immediately finish snap syncing. Add a guard to disable this useless FCUing.~ This problem may happen because of the follow up PR: implementing `l2.follow.source`. 

https://github.com/ethereum-optimism/optimism/blob/d19b0f5962dcb312685027012dcdfa2fa25e3ba6/op-node/rollup/driver/sync_deriver.go#L230-L235

Alt Sync ticker will be always reset when unsafeOnly is true. Handle this case to enable alt sync to allow unsafe gap filling even when unsafeOnly is enabled.

https://github.com/ethereum-optimism/optimism/blob/c3cd8e5060551cb5c2f0d9d1d6672a2e62f792a3/op-node/rollup/driver/driver.go#L281-L290

**Tests**

Multiple acceptance tests are added with the new preset `NewSingleChainTwoVerifiersWithoutCheck`. This adds a single sequencer and two verifier network, with the second verifier always do derivation.

- `TestUnsafeOnly_VerifierUnsafeGapClosed`: Tests that the unsafe gap can be closed for the unsafe only verifier. 
- `TestUnsafeOnly_SequencerRestart`: Tests that unsafe only sequencer can build blocks, even after restart.
- `TestSyncTesterUnsafeOnlyReachUnsafeTip`: Uses op-sepolia with sync tester to check the CL can sync to the chain tip using unsafe only.

Manual tests are also done.

For sync tester + unsafe only verifier op-node, checked that the unsafe head reaches the unsafe tip of op-sepolia. cmds: 
```sh
/op-sync-tester --config config.yaml --rpc.port=8551 --log.level TRACE
```
```sh
/op-node 
     --l1="https://proxyd-l1-sepolia.primary.client.dev.oplabs.cloud/" \
     --l2="http://localhost:8551"  \
     --l2.jwt-secret="/tmp/jwt.txt"   \
     --network op-sepolia   \
     --rpc.addr=0.0.0.0   \
     --rpc.port=8547   \
     --l1.beacon=https://beacon-api-proxy-sepolia.primary.client.dev.oplabs.cloud/   \
     --sequencer.enabled=false   \
     --syncmode.req-resp=false   \
     --syncmode=execution-layer   \
     --log.level=DEBUG   \
     --l2.unsafe-only
```

Used real op-geth + unsafe only to validate that the snap sync does not immediately terminates because the FCU is called to the genesis. cmds:
```sh
/geth \
  --syncmode=snap \
  --datadir=/tmp/op-geth-sepolia \
  --networkid=11155420 \
  --http \
  --http.addr=0.0.0.0 \
  --http.port=8545 \
  --http.api=eth,net,web3,admin,debug \
  --ws \
  --ws.addr=0.0.0.0 \
  --ws.port=8546 \
  --ws.api=eth,net,web3,admin,debug \
  --authrpc.addr=0.0.0.0 \
  --authrpc.port=8551 \
  --authrpc.vhosts="*" \
  --authrpc.jwtsecret=/tmp/jwt.txt \
  --rollup.sequencerhttp=https://sepolia-sequencer.optimism.io \
  --rollup.disabletxpoolgossip=true \
  --op-network=op-sepolia
```

Deployed https://github.com/ethereum-optimism/optimism/pull/18290/commits/c3cd8e5060551cb5c2f0d9d1d6672a2e62f792a3 to the devnet cluster, to validate the code in real infra. Bootstrapping done, and unsafe gap is also filled using 
```
    OP_NODE_SYNCMODE_REQ_RESP: "false"
    OP_NODE_L2_UNSAFE_ONLY: "true"
```

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Metadata**

- Fixes https://github.com/ethereum-optimism/optimism/issues/18316
