### PR TITLE
op-service: Add logfmtms to Log Format Usage

### DIFF
--- a/op-service/log/cli.go
+++ b/op-service/log/cli.go
@@ -53,7 +53,7 @@ func CLIFlagsWithCategory(envPrefix string, category string) []cli.Flag {
 		},
 		&cli.GenericFlag{
 			Name:     FormatFlagName,
-			Usage:    "Format the log output. Supported formats: 'text', 'terminal', 'logfmt', 'json', 'json-pretty',",
+			Usage:    fmt.Sprintf("Format the log output. Supported formats: %s", SupportedFormatsString()),
 			Value:    NewFormatFlagValue(FormatText),
 			EnvVars:  opservice.PrefixEnvVar(envPrefix, "LOG_FORMAT"),
 			Category: category,
@@ -143,6 +143,25 @@ const (
 	FormatJSON     FormatType = "json"
 	FormatJSONMs   FormatType = "jsonms"
 )
+
+// All supported format types in a slice for iteration
+var formatTypes = []FormatType{
+	FormatText,
+	FormatTerminal,
+	FormatLogFmt,
+	FormatLogFmtMs,
+	FormatJSON,
+	FormatJSONMs,
+}
+
+// SupportedFormatsString returns a comma-delimited string of supported formats,
+func SupportedFormatsString() string {
+	names := make([]string, 0, len(formatTypes))
+	for _, f := range formatTypes {
+		names = append(names, f.String())
+	}
+	return strings.Join(names, ", ")
+}
 
 // FormatHandler returns the correct slog handler factory for the provided format.
 func FormatHandler(ft FormatType, color bool) func(io.Writer) slog.Handler {


### PR DESCRIPTION
Adds a list of supported text formats and uses it in a helper function for Usage, instead of being manually populated.