### PR TITLE
kona: Update to 1.2.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2018,7 +2018,7 @@ jobs:
          checkout-method: blobless
       - restore_cache:
           name: Restore kona host cache
-          key: kona-host-{{ checksum "./kona/justfile" }}
+          key: kona-host-{{ checksum "./kona/justfile" }}-{{ checksum "./kona/version.json" }}
       - run: # The mise plugin for clang is broken so install via apt-get
           name: Install clang
           command: |
@@ -2029,7 +2029,7 @@ jobs:
           command: just build-kona-host
           working_directory: kona
       - save_cache:
-          key: kona-host-{{ checksum "./kona/justfile" }}
+          key: kona-host-{{ checksum "./kona/justfile" }}-{{ checksum "./kona/version.json" }}
           name: Save Kona host to cache
           paths:
             - "kona/bin/kona-host"

--- a/kona/justfile
+++ b/kona/justfile
@@ -85,4 +85,4 @@ checkout-kona:
 clean:
   #!/usr/bin/env bash
   set -euo pipefail
-  rm -rf "{{KONA_DIR}}/build" "{{KONA_DIR}}/prestates"
+  rm -rf "{{KONA_DIR}}/build" "{{KONA_DIR}}/prestates" "{{KONA_DIR}}/bin"

--- a/kona/version.json
+++ b/kona/version.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.2.2",
-    "prestateHash": "0x03e183aa55db11aba6c1f2f7adccad15411d44fb54285e104cb73468927de0e7",
-    "interopPrestateHash": "0x033f554908ed264b81963ad6bf8a856c7c114af950df5a6fff67c5db85886083"
+    "version": "1.2.4",
+    "prestateHash": "0x036d1def0a2815e1cb8370c17b4f6346cf83551d853f3bfe7b3ab4bfed935671",
+    "interopPrestateHash": "0x03bb838f039a019830e1b73b7fcddd28aa212ff78104a574bc5833e677bdb331"
 }

--- a/op-acceptance-tests/tests/proofs/cannon/step_test.go
+++ b/op-acceptance-tests/tests/proofs/cannon/step_test.go
@@ -29,7 +29,6 @@ func TestExecuteStep_Cannon(gt *testing.T) {
 
 func TestExecuteStep_CannonKona(gt *testing.T) {
 	t := devtest.ParallelT(gt)
-	t.Skip("kona doesn't yet support ws URLs")
 	sys := presets.NewMinimal(t)
 
 	l1User := sys.FunderL1.NewFundedEOA(eth.ThousandEther)


### PR DESCRIPTION
**Description**

Updates kona to 1.2.4. Enable cannon-kona acceptance test now that kona supports web sockets.


**Metadata**

fixes https://github.com/ethereum-optimism/optimism/issues/17764
