### PR TITLE
op-e2e: Deflake TestMissingBatchE2E: Retry inclusion check when indexing

### DIFF
--- a/op-e2e/e2eutils/geth/wait.go
+++ b/op-e2e/e2eutils/geth/wait.go
@@ -86,6 +86,31 @@ func WaitForTransaction(hash common.Hash, client *ethclient.Client, timeout time
 	}
 }
 
+// WaitUntilTransactionNotFound polls TransactionByHash until the client
+// returns ethereum.NotFound, indicating the EL has finished indexing and
+// the transaction is definitively absent.
+func WaitUntilTransactionNotFound(client *ethclient.Client, hash common.Hash, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	for {
+		_, err := client.TransactionReceipt(ctx, hash)
+		switch {
+		case err == nil:
+			return fmt.Errorf("tx %s unexpectedly found", hash.Hex())
+		case errors.Is(err, ethereum.NotFound):
+			return nil
+		case strings.Contains(err.Error(), errStrTxIdxingInProgress):
+			select {
+			case <-ctx.Done():
+				return fmt.Errorf("timeout waiting for tx indexer to settle: %w", ctx.Err())
+			case <-time.After(100 * time.Millisecond):
+			}
+		default:
+			return fmt.Errorf("unexpected RPC error while waiting for tx not found: %w", err)
+		}
+	}
+}
+
 type waitForBlockOptions struct {
 	noChangeTimeout time.Duration
 	absoluteTimeout time.Duration

--- a/op-e2e/e2eutils/geth/wait.go
+++ b/op-e2e/e2eutils/geth/wait.go
@@ -108,7 +108,7 @@ func WaitUntilTransactionNotFound(client *ethclient.Client, hash common.Hash, ti
 			case <-ticker.C:
 			}
 		default:
-			return fmt.Errorf("unexpected RPC error while waiting for tx not found: %w", err)
+			return fmt.Errorf("unexpected error while waiting for tx not found: %w", err)
 		}
 	}
 }

--- a/op-e2e/e2eutils/geth/wait.go
+++ b/op-e2e/e2eutils/geth/wait.go
@@ -90,20 +90,22 @@ func WaitForTransaction(hash common.Hash, client *ethclient.Client, timeout time
 // returns ethereum.NotFound, indicating the EL has finished indexing and
 // the transaction is definitively absent.
 func WaitUntilTransactionNotFound(client *ethclient.Client, hash common.Hash, timeout time.Duration) error {
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	for {
 		_, err := client.TransactionReceipt(ctx, hash)
 		switch {
 		case err == nil:
-			return fmt.Errorf("tx %s unexpectedly found", hash.Hex())
+			return fmt.Errorf("tx %s unexpectedly found", hash)
 		case errors.Is(err, ethereum.NotFound):
 			return nil
 		case strings.Contains(err.Error(), errStrTxIdxingInProgress):
 			select {
 			case <-ctx.Done():
 				return fmt.Errorf("timeout waiting for tx indexer to settle: %w", ctx.Err())
-			case <-time.After(100 * time.Millisecond):
+			case <-ticker.C:
 			}
 		default:
 			return fmt.Errorf("unexpected RPC error while waiting for tx not found: %w", err)

--- a/op-e2e/system/verifier/sequencer_window_test.go
+++ b/op-e2e/system/verifier/sequencer_window_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
 	"github.com/ethereum-optimism/optimism/op-e2e/system/e2esys"
 	"github.com/ethereum-optimism/optimism/op-e2e/system/helpers"
-	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
@@ -52,12 +51,11 @@ func TestMissingBatchE2E(t *testing.T) {
 	require.Nil(t, err, "Waiting for block on verifier")
 
 	// Assert that the transaction is not found on the verifier
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-	_, err = l2Verif.TransactionReceipt(ctx, receipt.TxHash)
-	require.Equal(t, ethereum.NotFound, err, "Found transaction in verifier when it should not have been included")
+	require.NoError(t, geth.WaitUntilTransactionNotFound(l2Verif, receipt.TxHash, 30*time.Second))
 
 	// Wait a short time for the L2 reorg to occur on the sequencer as well.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
 	err = wait.ForSafeBlock(ctx, seqRollupClient, receipt.BlockNumber.Uint64())
 	require.Nil(t, err, "timeout waiting for L2 reorg on sequencer safe head")
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

`TestMissingBatchE2E` flaked because it checked the tx inclusion while EL is indexing. Wait until EL finishes indexing and check tx inclusion to ensure tx not found.

Flake logs:

```
Failed
=== RUN   TestMissingBatchE2E
=== PAUSE TestMissingBatchE2E
=== CONT  TestMissingBatchE2E
    testlog.go:151: writing test log to /home/circleci/project/tmp/testlogs/TestMissingBatchE2E-8956.log
    testlog.go:152: some tests may have written to the root logger
    testlog.go:153: logs from the root logger have been written to 
    setup.go:654: Generating L2 genesis l2_allocs_mode granite
    sequencer_window_test.go:58: 
        	Error Trace:	/home/circleci/project/op-e2e/system/verifier/sequencer_window_test.go:58
        	Error:      	Not equal: 
        	            	expected: *errors.errorString(&errors.errorString{s:"not found"})
        	            	actual  : *rpc.jsonError(&rpc.jsonError{Code:-32000, Message:"transaction indexing is in progress", Data:"transaction indexing is in progress"})
        	Test:       	TestMissingBatchE2E
        	Messages:   	Found transaction in verifier when it should not have been included
    setup.go:499: CLOSING
--- FAIL: TestMissingBatchE2E (11.24s)
```

Ran locally consecutive 30 times and never flaked.

**Metadata**
- Fixes https://github.com/ethereum-optimism/optimism/issues/18138