### PR TITLE
fix(op-node): fix channel size calculation bug when pruning frames

### DIFF
--- a/op-node/rollup/derive/channel.go
+++ b/op-node/rollup/derive/channel.go
@@ -91,8 +91,8 @@ func (ch *Channel) AddFrame(frame Frame, l1InclusionBlock eth.L1BlockRef) error 
 		for idx, prunedFrame := range ch.inputs {
 			if idx >= uint64(ch.endFrameNumber) {
 				delete(ch.inputs, idx)
+				ch.size -= frameSize(prunedFrame)
 			}
-			ch.size -= frameSize(prunedFrame)
 		}
 		ch.highestFrameNumber = ch.endFrameNumber
 	}

--- a/op-node/rollup/derive/channel_test.go
+++ b/op-node/rollup/derive/channel_test.go
@@ -98,6 +98,17 @@ func TestFrameValidity(t *testing.T) {
 			sizes:     []uint64{207, 204},
 		},
 		{
+			name: "prune multiple frames after close",
+			frames: []Frame{
+				{ID: id, FrameNumber: 0, IsLast: false, Data: []byte("zero")},
+				{ID: id, FrameNumber: 5, IsLast: false, Data: []byte("five_")},
+				{ID: id, FrameNumber: 10, IsLast: false, Data: []byte("seven__")},
+				{ID: id, FrameNumber: 2, IsLast: true, Data: []byte("four")},
+			},
+			shouldErr: []bool{false, false, false, false},
+			sizes:     []uint64{204, 409, 616, 408}, // After pruning: frame0(204) + frame2(204) = 408
+		},
+		{
 			name: "multiple valid frames",
 			frames: []Frame{
 				{ID: id, FrameNumber: 10, Data: []byte("seven__")},


### PR DESCRIPTION
**Description**

Fixes a bug in `Channel.AddFrame()` where the channel size was incorrectly decremented for all frames during pruning, instead of only for the frames that were actually deleted.

When a closing frame is received with a frame number lower than previously seen frames (which can happen in non-strict ordering mode), the code prunes frames with numbers >= `endFrameNumber`. However, the size calculation was subtracting the size of **all** frames in the channel, not just the ones being deleted.

**Tests**

- All existing tests pass
- New test case verifies correct behavior when pruning multiple frames
**Additional context**

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
