### PR TITLE
op-sync-tester: Verifier Engine APIs for Jovian

### DIFF
--- a/op-acceptance-tests/tests/sync_tester/sync_tester_hfs/init_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_tester_hfs/init_test.go
@@ -15,7 +15,7 @@ import (
 func TestMain(m *testing.M) {
 	presets.DoMain(m, presets.WithSimpleWithSyncTester(),
 		presets.WithCompatibleTypes(compat.SysGo),
-		presets.WithHardforkSequentialActivation(forks.Bedrock, forks.Jovian, 15),
+		presets.WithHardforkSequentialActivation(forks.Bedrock, forks.Jovian, 6),
 		stack.MakeCommon(sysgo.WithBatcherOption(func(id stack.L2BatcherID, cfg *bss.CLIConfig) {
 			// For supporting pre-delta batches
 			cfg.BatchType = derive.SingularBatchType

--- a/op-acceptance-tests/tests/sync_tester/sync_tester_hfs/init_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_tester_hfs/init_test.go
@@ -16,6 +16,7 @@ func TestMain(m *testing.M) {
 	presets.DoMain(m, presets.WithSimpleWithSyncTester(),
 		presets.WithCompatibleTypes(compat.SysGo),
 		presets.WithHardforkSequentialActivation(forks.Bedrock, forks.Jovian, 6),
+		presets.WithNoDiscovery(),
 		stack.MakeCommon(sysgo.WithBatcherOption(func(id stack.L2BatcherID, cfg *bss.CLIConfig) {
 			// For supporting pre-delta batches
 			cfg.BatchType = derive.SingularBatchType

--- a/op-acceptance-tests/tests/sync_tester/sync_tester_hfs/sync_tester_hfs_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_tester_hfs/sync_tester_hfs_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
@@ -14,21 +15,54 @@ func TestSyncTesterHardforks(gt *testing.T) {
 
 	sys := presets.NewSimpleWithSyncTester(t)
 	require := t.Require()
+	logger := t.Logger()
+	ctx := t.Ctx()
+
+	// Check the L2CL passed configured hardforks
+	jovianTime := sys.L2Chain.Escape().ChainConfig().JovianTime
+	require.NotNil(jovianTime, "jovian must be activated")
 
 	// Hardforks will be activated from Bedrock to Jovian, 10 hardforks with 6 second time delta between.
-	// 6 * 10 = 60s , so we need at least 30 (60 / 2 + 1) L2 blocks with block time 2 to make the CL experience scheduled hardforks.
+	// 6 * 10 = 60s, so we need at least 30 (60 / 2 + 1) L2 blocks with block time 2 to make the CL experience scheduled hardforks.
 	targetNum := 32
+
+	// Unsafe advancement: NewPayload -> ForkchoiceUpdated(no attr)
 	dsl.CheckAll(t,
 		sys.L2CL.AdvancedFn(types.LocalUnsafe, uint64(targetNum), targetNum+10),
 		sys.L2CL2.AdvancedFn(types.LocalUnsafe, uint64(targetNum), targetNum+10),
 	)
 
 	current := sys.L2CL2.HeadBlockRef(types.LocalUnsafe)
-
-	// Check the L2CL passed configured hardforks
-	jovianTime := sys.L2Chain.Escape().ChainConfig().JovianTime
-	require.NotNil(jovianTime, "jovian must be activated")
 	require.Greater(current.Time, *jovianTime, "must pass jovian block")
 	// Check block hash state from L2CL2 which was synced using the sync tester
 	require.Equal(sys.L2EL.BlockRefByNumber(current.Number).Hash, current.Hash, "hash mismatch")
+	logger.Info("Advancement using CLP2P done", "head", sys.L2EL.UnsafeHead())
+
+	// Disconnect CLP2P to solely rely on derivation
+	sys.L2CL2.DisconnectPeer(sys.L2CL)
+	sys.L2CL.DisconnectPeer(sys.L2CL2)
+	sys.L2CL2.Stop()
+	sessionIDs := sys.SyncTester.ListSessions()
+	require.GreaterOrEqual(len(sessionIDs), 1, "at least one session")
+	sessionID := sessionIDs[0]
+	logger.Info("SyncTester EL", "sessionID", sessionID)
+	syncTesterClient := sys.SyncTester.Escape().APIWithSession(sessionID)
+	// Resync starting from genesis
+	require.NoError(syncTesterClient.ResetSession(ctx))
+	sys.SyncTesterL2EL.UnsafeHead().NumEqualTo(0)
+
+	// Wait until safe head reached Jovian
+	sys.L2CL.Reached(types.LocalSafe, current.Number, 20)
+
+	// Check safe head advancement can solely rely on derivation reaching Jovian
+	// Safe advancement: ForkchoiceUpdated(with attr) -> GetPayload -> NewPayload -> ForkchoiceUpdated(no attr)
+	sys.L2CL2.Start()
+	sys.L2CL2.Reached(types.LocalSafe, current.Number, 20)
+	sys.SyncTesterL2EL.Reached(eth.Safe, current.Number, 10)
+
+	current = sys.L2CL2.HeadBlockRef(types.LocalSafe)
+	require.Greater(current.Time, *jovianTime, "must pass jovian block")
+	// Check block hash state from L2CL2 which was synced using the sync tester
+	require.Equal(sys.L2EL.BlockRefByNumber(current.Number).Hash, current.Hash, "hash mismatch")
+	logger.Info("Advancement using derivation done", "head", sys.L2EL.UnsafeHead())
 }

--- a/op-acceptance-tests/tests/sync_tester/sync_tester_hfs/sync_tester_hfs_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_tester_hfs/sync_tester_hfs_test.go
@@ -15,20 +15,20 @@ func TestSyncTesterHardforks(gt *testing.T) {
 	sys := presets.NewSimpleWithSyncTester(t)
 	require := t.Require()
 
-	// Hardforks will be activated from Bedrock to Isthmus, 9 hardforks with 15 second time delta between.
-	// 15 * 9 = 135s, so we need at least 69 (135 / 2 + 1) L2 blocks with block time 2 to make the CL experience scheduled hardforks.
-	targetNum := 70
+	// Hardforks will be activated from Bedrock to Jovian, 10 hardforks with 6 second time delta between.
+	// 6 * 10 = 60s , so we need at least 30 (60 / 2 + 1) L2 blocks with block time 2 to make the CL experience scheduled hardforks.
+	targetNum := 32
 	dsl.CheckAll(t,
-		sys.L2CL.AdvancedFn(types.LocalUnsafe, uint64(targetNum), targetNum*2+10),
-		sys.L2CL2.AdvancedFn(types.LocalUnsafe, uint64(targetNum), targetNum*2+10),
+		sys.L2CL.AdvancedFn(types.LocalUnsafe, uint64(targetNum), targetNum+10),
+		sys.L2CL2.AdvancedFn(types.LocalUnsafe, uint64(targetNum), targetNum+10),
 	)
 
 	current := sys.L2CL2.HeadBlockRef(types.LocalUnsafe)
 
 	// Check the L2CL passed configured hardforks
-	isthmusTime := sys.L2Chain.Escape().ChainConfig().IsthmusTime
-	require.NotNil(isthmusTime, "isthmus must be activated")
-	require.Greater(current.Time, *isthmusTime, "must pass isthmus block")
+	jovianTime := sys.L2Chain.Escape().ChainConfig().JovianTime
+	require.NotNil(jovianTime, "jovian must be activated")
+	require.Greater(current.Time, *jovianTime, "must pass jovian block")
 	// Check block hash state from L2CL2 which was synced using the sync tester
 	require.Equal(sys.L2EL.BlockRefByNumber(current.Number).Hash, current.Hash, "hash mismatch")
 }

--- a/op-devstack/sysgo/deployer.go
+++ b/op-devstack/sysgo/deployer.go
@@ -332,7 +332,7 @@ func WithInteropAtGenesis() DeployerOption {
 
 // WithHardforkSequentialActivation configures a deployment such that L2 chains
 // activate hardforks sequentially, starting from startFork and continuing
-// until (but not including) endFork. Each successive fork is scheduled at
+// until (including) endFork. Each successive fork is scheduled at
 // an increasing offset.
 func WithHardforkSequentialActivation(startFork, endFork opforks.Name, delta *uint64) DeployerOption {
 	return func(p devtest.P, keys devkeys.Keys, builder intentbuilder.Builder) {
@@ -341,7 +341,7 @@ func WithHardforkSequentialActivation(startFork, endFork opforks.Name, delta *ui
 			activateWithOffset := false
 			deactivate := false
 			for idx, refFork := range opforks.All {
-				if deactivate || refFork == endFork {
+				if deactivate {
 					l2Cfg.WithForkAtOffset(refFork, nil)
 					deactivate = true
 					continue
@@ -352,6 +352,9 @@ func WithHardforkSequentialActivation(startFork, endFork opforks.Name, delta *ui
 				}
 				if startFork == refFork {
 					activateWithOffset = true
+				}
+				if endFork == refFork {
+					deactivate = true
 				}
 			}
 		}

--- a/op-sync-tester/synctester/backend/sync_tester.go
+++ b/op-sync-tester/synctester/backend/sync_tester.go
@@ -3,6 +3,7 @@ package backend
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -426,11 +427,17 @@ func (s *SyncTester) forkchoiceUpdated(ctx context.Context, session *eth.SyncTes
 			// Consider as sync error if read only EL interaction fails because we cannot validate
 			return &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionSyncing}, PayloadID: nil}, nil
 		}
+		// https://github.com/ethereum-optimism/specs/blob/510377c586d0cbede2d40402d2371fcadd5656a0/specs/protocol/jovian/exec-engine.md#minimum-base-fee-in-block-header
+		// Implicitly determine whether jovian is enabled by inspecting extraData from read only EL data
+		isJovian := eip1559.ValidateMinBaseFeeExtraData(newBlock.Header().Extra) == nil
 		// https://github.com/ethereum-optimism/specs/blob/972dec7c7c967800513c354b2f8e5b79340de1c3/specs/protocol/holocene/exec-engine.md#eip-1559-parameters-in-block-header
 		// Implicitly determine whether holocene is enabled by inspecting extraData from read only EL data
-		isHolocene := eip1559.ValidateHoloceneExtraData(newBlock.Header().Extra) == nil
+		isHolocene := true // holocene is always activated when jovian is activated
+		if !isJovian {
+			isHolocene = eip1559.ValidateHoloceneExtraData(newBlock.Header().Extra) == nil
+		}
 		// Sanity check attr comparing with newBlock
-		if err := s.validateAttributesForBlock(attr, newBlock, isHolocene); err != nil {
+		if err := s.validateAttributesForBlock(attr, newBlock, isHolocene, isJovian); err != nil {
 			// https://github.com/ethereum/execution-apis/blob/584905270d8ad665718058060267061ecfd79ca5/src/engine/paris.md#specification-1
 			// Client software MUST respond to this method call in the following way: {error: {code: -38003, message: "Invalid payload attributes"}} if the payload is deemed VALID and forkchoiceState has been applied successfully, but no build process has been started due to invalid payloadAttributes.
 			return &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionInvalid}, PayloadID: nil}, engine.InvalidPayloadAttributes.With(err)
@@ -488,9 +495,11 @@ func (s *SyncTester) forkchoiceUpdated(ctx context.Context, session *eth.SyncTes
 //   - Gas limit must match.
 //   - If Holocene is active: Extra data must be exactly 9 bytes, the version byte must equal to 0,
 //     the remaining 8 bytes must match the EIP-1559 parameters.
+//   - If Jovian is active: Extra data must be exactly 17 bytes, the version byte must equal to 1,
+//     the remaining 8 bytes must match the MinBaseFee parameter.
 //
 // Returns an error if any mismatch or invalid condition is found, otherwise nil.
-func (s *SyncTester) validateAttributesForBlock(attr *eth.PayloadAttributes, block *types.Block, isHolocene bool) error {
+func (s *SyncTester) validateAttributesForBlock(attr *eth.PayloadAttributes, block *types.Block, isHolocene, isJovian bool) error {
 	h := block.Header()
 	if h.Time != uint64(attr.Timestamp) {
 		return fmt.Errorf("timestamp mismatch: header=%d, attr=%d", h.Time, attr.Timestamp)
@@ -555,6 +564,23 @@ func (s *SyncTester) validateAttributesForBlock(attr *eth.PayloadAttributes, blo
 		// Spec: Prior to Holocene activation, eip1559Parameters in PayloadAttributesV3 must be null and is otherwise considered invalid.
 		if attr.EIP1559Params != nil {
 			return fmt.Errorf("holocene disabled but EIP1559Params not nil. eip1559Params: %s", attr.EIP1559Params)
+		}
+	}
+	if isJovian {
+		// https://github.com/ethereum-optimism/specs/blob/510377c586d0cbede2d40402d2371fcadd5656a0/specs/protocol/jovian/exec-engine.md#minimum-base-fee-in-payloadattributesv3
+		// Spec: The Engine API PayloadAttributesV3 is extended with a new field minBaseFee
+		if attr.MinBaseFee == nil {
+			return errors.New("jovian enabled but MinBaseFee nil")
+		}
+		minBaseFee := binary.BigEndian.Uint64(block.Extra()[9:])
+		if minBaseFee != *attr.MinBaseFee {
+			return fmt.Errorf("MinBaseFee mismatch: %d != %d", *attr.MinBaseFee, minBaseFee)
+		}
+	} else {
+		// https://github.com/ethereum-optimism/specs/blob/510377c586d0cbede2d40402d2371fcadd5656a0/specs/protocol/jovian/exec-engine.md#minimum-base-fee-in-payloadattributesv3
+		// Spec: The minBaseFee MUST be null prior to the Jovian fork, and MUST be non-null after the Jovian fork.
+		if attr.MinBaseFee != nil {
+			return fmt.Errorf("jovian disabled but MinBaseFee not nil. MinBaseFee: %s", attr.MinBaseFee)
 		}
 	}
 	return nil

--- a/op-sync-tester/synctester/backend/sync_tester.go
+++ b/op-sync-tester/synctester/backend/sync_tester.go
@@ -556,7 +556,7 @@ func (s *SyncTester) validateAttributesForBlock(attr *eth.PayloadAttributes, blo
 			// Cannot validate since EL will fall back to prior eip1559 constants
 			return nil
 		}
-		if !bytes.Equal(block.Extra()[1:], (*attr.EIP1559Params)[:]) {
+		if !bytes.Equal(block.Extra()[1:1+8], (*attr.EIP1559Params)[:]) {
 			return fmt.Errorf("eip1559Params mismatch: %s != 0x%s", *attr.EIP1559Params, hex.EncodeToString(block.Extra()[1:]))
 		}
 	} else {
@@ -572,7 +572,7 @@ func (s *SyncTester) validateAttributesForBlock(attr *eth.PayloadAttributes, blo
 		if attr.MinBaseFee == nil {
 			return errors.New("jovian enabled but MinBaseFee nil")
 		}
-		minBaseFee := binary.BigEndian.Uint64(block.Extra()[9:])
+		minBaseFee := binary.BigEndian.Uint64(block.Extra()[1+8 : 1+8+8])
 		if minBaseFee != *attr.MinBaseFee {
 			return fmt.Errorf("MinBaseFee mismatch: %d != %d", *attr.MinBaseFee, minBaseFee)
 		}
@@ -580,7 +580,7 @@ func (s *SyncTester) validateAttributesForBlock(attr *eth.PayloadAttributes, blo
 		// https://github.com/ethereum-optimism/specs/blob/510377c586d0cbede2d40402d2371fcadd5656a0/specs/protocol/jovian/exec-engine.md#minimum-base-fee-in-payloadattributesv3
 		// Spec: The minBaseFee MUST be null prior to the Jovian fork, and MUST be non-null after the Jovian fork.
 		if attr.MinBaseFee != nil {
-			return fmt.Errorf("jovian disabled but MinBaseFee not nil. MinBaseFee: %s", attr.MinBaseFee)
+			return fmt.Errorf("jovian disabled but MinBaseFee not nil. MinBaseFee: %d", attr.MinBaseFee)
 		}
 	}
 	return nil

--- a/op-sync-tester/synctester/backend/sync_tester.go
+++ b/op-sync-tester/synctester/backend/sync_tester.go
@@ -496,6 +496,7 @@ func (s *SyncTester) forkchoiceUpdated(ctx context.Context, session *eth.SyncTes
 //   - If Holocene is active: Extra data must be exactly 9 bytes, the version byte must equal to 0,
 //     the remaining 8 bytes must match the EIP-1559 parameters.
 //   - If Jovian is active: Extra data must be exactly 17 bytes, the version byte must equal to 1,
+//     the first 8 bytes must match the EIP-1559 parameters,
 //     the remaining 8 bytes must match the MinBaseFee parameter.
 //
 // Returns an error if any mismatch or invalid condition is found, otherwise nil.


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Support Jovian Syncing for sync tester. Sync Tester can query the read only EL backend and inspect block header's extra data. If the extra data length is 17([ref](https://github.com/ethereum-optimism/specs/blob/510377c586d0cbede2d40402d2371fcadd5656a0/specs/protocol/jovian/exec-engine.md#minimum-base-fee-in-block-header)), sync tester considers the block is from Jovian and performs appropriate validation.

The validation is only done at checking attributes, not payloads because payload format was not altered at jovian. This means even if we do not update sync tester for jovian, the sync tester would just work using the unsafe sync, only calling `engine_newPayload` and `engine_fcu` without attrs. However, when syncing with derivation, the CL will derive the attrs and perform `engine_fcu` with attr -> `engine_getPayload` -> `engine_newPayload` -> `engine_fcu` without attr. Therefore the derivation syncing will not work without this PR.

**Tests**

Updated existing `TestSyncTesterHardforks` acceptance tests to cover Jovian blocks, and also cover syncing only with derivation. The original test only covered unsafe payload syncing, which did not cover the full engine api (not including `engine_fcu` with attr + `engine_getPayload`).

Also tested with `jovian-beta-0` devnet with chain id `420110019` and validated that the safe head advancement is working. Used commands:

Jovian activation check:
```sh
cast block 249245 --rpc-url https://jovian-beta-0.optimism.io/ # (pre jovian)
cast block 249246 --rpc-url https://jovian-beta-0.optimism.io/ # (jovian)
```
sync-tester:
```sh
/op-sync-tester/bin/op-sync-tester --config config.yaml --rpc.port=8551 --log.level TRACE
```

sync-tester config:
```yaml
synctesters:
  jovian:
    chain_id: 420110019
    el_rpc: https://jovian-beta-0.optimism.io
```

rollup config from https://github.com/ethereum-optimism/devnets/blob/70bde7688f52eeca44769ccb7efe078b788b8f9c/betanets/jovian-beta/jovian-beta-0/rollup.json

op-node(sync tester start state targeted to `249230`, which is 15 blocks behind jovian):
```sh
/op-node/bin/op-node \
     --l1="https://proxyd-l1-sepolia.primary.client.dev.oplabs.cloud/" \
     --l2="http://localhost:8551/chain/420110019/synctest/7b39fb24-4acf-4d45-8920-ab27b6a31ee4?latest=249230&safe=249230&finalized=249230" \
     --l2.jwt-secret="/tmp/jwt.txt" \
     --rollup.config /tmp/rollup_config.json \
     --rpc.addr=0.0.0.0 \
     --rpc.port=8547 \
     --l1.beacon=https://beacon-api-proxy-sepolia.primary.client.dev.oplabs.cloud/ \
     --p2p.disable=true \
     --log.level=DEBUG  > op-node-sepolia-jovian.log
```

**Additional Context**

Without this change, it will break our daily sync test job at `scheduled-sync-test-op-node`. op-sepolia will activate Jovian at this wed, and the derivation only sync node will not work without this fix.

Also interop testing relies on the sync tester, giving faster feedback loop. We have needs to use the op-sepolia & op-mainnet to do various sync tests for interop. Those network will eventually Jovian activated and sync tester will need this fix.

**Metadata**

- Fixes https://github.com/ethereum-optimism/optimism/issues/18126
