### PR TITLE
ci(contracts): enable latest artifact fallback logic

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -933,8 +933,8 @@ jobs:
           command: forge --version
           working_directory: packages/contracts-bedrock
       - run:
-          name: Pull artifacts
-          command: bash scripts/ops/pull-artifacts.sh
+          name: Pull artifacts with latest fallback
+          command: bash scripts/ops/pull-artifacts.sh --fallback-to-latest
           working_directory: packages/contracts-bedrock
       - go-restore-cache:
           namespace: packages/contracts-bedrock/scripts/go-ffi
@@ -1103,8 +1103,8 @@ jobs:
           command: forge --version
           working_directory: packages/contracts-bedrock
       - run:
-          name: Pull artifacts
-          command: bash scripts/ops/pull-artifacts.sh
+          name: Pull artifacts with latest fallback
+          command: bash scripts/ops/pull-artifacts.sh --fallback-to-latest
           working_directory: packages/contracts-bedrock
       - run:
           name: Install lcov
@@ -1200,8 +1200,8 @@ jobs:
           command: forge --version
           working_directory: packages/contracts-bedrock
       - run:
-          name: Pull artifacts
-          command: bash scripts/ops/pull-artifacts.sh
+          name: Pull artifacts with latest fallback
+          command: bash scripts/ops/pull-artifacts.sh --fallback-to-latest
           working_directory: packages/contracts-bedrock
       - run:
           name: Write pinned block number for cache key

--- a/packages/contracts-bedrock/scripts/ops/pull-artifacts.sh
+++ b/packages/contracts-bedrock/scripts/ops/pull-artifacts.sh
@@ -16,9 +16,43 @@ echoerr() {
   echo "$@" 1>&2
 }
 
+download_and_extract() {
+  local archive_name=$1
+
+  echoerr "> Downloading..."
+  curl -o "$archive_name" "https://storage.googleapis.com/oplabs-contract-artifacts/$archive_name"
+  echoerr "> Done."
+
+  echoerr "> Cleaning up existing artifacts..."
+  rm -rf artifacts
+  rm -rf forge-artifacts
+  rm -rf cache
+  echoerr "> Done."
+
+  echoerr "> Extracting artifacts..."
+  if [[ "$archive_name" == *.tar.zst ]]; then
+    zstd -dc "$archive_name" | tar -xf - --exclude='*../*'
+  else
+    tar -xzvf "$archive_name" --exclude='*../*'
+  fi
+  echoerr "> Done."
+
+  echoerr "> Cleaning up."
+  rm "$archive_name"
+  echoerr "> Done."
+  exit 0
+}
+
 # Check for help flag
 if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
   usage
+fi
+
+# Check for fallback-to-latest flag
+USE_LATEST_FALLBACK=false
+if [ "${1:-}" = "--fallback-to-latest" ]; then
+  USE_LATEST_FALLBACK=true
+  echoerr "> Fallback to latest enabled"
 fi
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
@@ -41,26 +75,20 @@ echoerr "> Checking for existing artifacts..."
 if [ "$HAS_ZSTD" = true ]; then
   archive_name_zst="artifacts-v1-$checksum.tar.zst"
   exists_zst=$(curl -s -o /dev/null --fail -LI "https://storage.googleapis.com/oplabs-contract-artifacts/$archive_name_zst" || echo "fail")
-  
+
   if [ "$exists_zst" != "fail" ]; then
-    echoerr "> Found .tar.zst artifacts. Downloading..."
-    curl -o "$archive_name_zst" "https://storage.googleapis.com/oplabs-contract-artifacts/$archive_name_zst"
-    echoerr "> Done."
-    
-    echoerr "> Cleaning up existing artifacts..."
-    rm -rf artifacts
-    rm -rf forge-artifacts
-    rm -rf cache
-    echoerr "> Done."
-    
-    echoerr "> Extracting existing artifacts..."
-    zstd -dc "$archive_name_zst" | tar -xf -
-    echoerr "> Done."
-    
-    echoerr "> Cleaning up."
-    rm "$archive_name_zst"
-    echoerr "> Done."
-    exit 0
+    download_and_extract "$archive_name_zst"
+  fi
+
+  # Try latest fallback if enabled
+  if [ "$USE_LATEST_FALLBACK" = true ]; then
+    echoerr "> Exact checksum not found, trying latest artifacts..."
+    archive_name_zst="artifacts-v1-latest.tar.zst"
+    exists_latest_zst=$(curl -s -o /dev/null --fail -LI "https://storage.googleapis.com/oplabs-contract-artifacts/$archive_name_zst" || echo "fail")
+
+    if [ "$exists_latest_zst" != "fail" ]; then
+      download_and_extract "$archive_name_zst"
+    fi
   fi
 fi
 
@@ -68,30 +96,22 @@ archive_name_gz="artifacts-v1-$checksum.tar.gz"
 exists_gz=$(curl -s -o /dev/null --fail -LI "https://storage.googleapis.com/oplabs-contract-artifacts/$archive_name_gz" || echo "fail")
 
 if [ "$exists_gz" == "fail" ]; then
-  echoerr "> No existing artifacts found, exiting."
-  exit 0
+  # Try latest fallback if enabled
+  if [ "$USE_LATEST_FALLBACK" = true ]; then
+    echoerr "> Exact checksum not found, trying latest artifacts..."
+    archive_name_gz="artifacts-v1-latest.tar.gz"
+    exists_latest_gz=$(curl -s -o /dev/null --fail -LI "https://storage.googleapis.com/oplabs-contract-artifacts/$archive_name_gz" || echo "fail")
+
+    if [ "$exists_latest_gz" == "fail" ]; then
+      echoerr "> No existing artifacts found (including latest), exiting."
+      exit 0
+    fi
+
+    echoerr "> Found latest .tar.gz artifacts."
+  else
+    echoerr "> No existing artifacts found, exiting."
+    exit 0
+  fi
 fi
 
-if [ "$HAS_ZSTD" = true ]; then
-  echoerr "> Only .tar.gz artifacts available (zstd format not found)."
-else
-  echoerr "> Found .tar.gz artifacts (zstd not available)."
-fi
-
-echoerr "> Cleaning up existing artifacts..."
-rm -rf artifacts
-rm -rf forge-artifacts
-rm -rf cache
-echoerr "> Done."
-
-echoerr "> Downloading artifacts..."
-curl -o "$archive_name_gz" "https://storage.googleapis.com/oplabs-contract-artifacts/$archive_name_gz"
-echoerr "> Done."
-
-echoerr "> Extracting existing artifacts..."
-tar -xzvf "$archive_name_gz"
-echoerr "> Done."
-
-echoerr "> Cleaning up."
-rm "$archive_name_gz"
-echoerr "> Done."
+download_and_extract "$archive_name_gz"

--- a/packages/contracts-bedrock/scripts/ops/pull-artifacts.sh
+++ b/packages/contracts-bedrock/scripts/ops/pull-artifacts.sh
@@ -20,7 +20,7 @@ download_and_extract() {
   local archive_name=$1
 
   echoerr "> Downloading..."
-  curl -o "$archive_name" "https://storage.googleapis.com/oplabs-contract-artifacts/$archive_name"
+  curl --fail --location --connect-timeout 30 --max-time 300 --tlsv1.2 -o "$archive_name" "https://storage.googleapis.com/oplabs-contract-artifacts/$archive_name"
   echoerr "> Done."
 
   echoerr "> Cleaning up existing artifacts..."
@@ -31,9 +31,9 @@ download_and_extract() {
 
   echoerr "> Extracting artifacts..."
   if [[ "$archive_name" == *.tar.zst ]]; then
-    zstd -dc "$archive_name" | tar -xf - --exclude='*../*'
+    zstd -dc "$archive_name" | tar -xf - --exclude='*..*'
   else
-    tar -xzvf "$archive_name" --exclude='*../*'
+    tar -xzvf "$archive_name" --exclude='*..*'
   fi
   echoerr "> Done."
 

--- a/packages/contracts-bedrock/test/L2/OperatorFeeVault.t.sol
+++ b/packages/contracts-bedrock/test/L2/OperatorFeeVault.t.sol
@@ -33,3 +33,5 @@ contract OperatorFeeVault_Version_Test is CommonTest {
         SemverComp.parse(operatorFeeVault.version());
     }
 }
+
+// Test artifact fallback logic

--- a/packages/contracts-bedrock/test/L2/OperatorFeeVault.t.sol
+++ b/packages/contracts-bedrock/test/L2/OperatorFeeVault.t.sol
@@ -33,5 +33,3 @@ contract OperatorFeeVault_Version_Test is CommonTest {
         SemverComp.parse(operatorFeeVault.version());
     }
 }
-
-// Test artifact fallback logic


### PR DESCRIPTION
### Changes

Enables the artifact fallback mechanism introduced in [#18291](
https://github.com/ethereum-optimism/optimism/pull/18291) to optimize PR contract test builds:

- `pull-artifacts.sh`: Added `--fallback-to-latest` flag that tries exact checksum first, then falls back to `artifacts-v1-latest.tar.{gz,zst}` uploaded by develop
- `.circleci/config.yml`: Enabled fallback for `contracts-bedrock-tests`, `contracts-bedrock-coverage`, and `contracts-bedrock-tests-upgrade` jobs
- Extracted `download_and_extract()` helper function to eliminate duplication
- Added `--exclude='*../*'` to tar commands to prevent path traversal attacks

### Reason

This completes the two-phase rollout started in [#18291](https://github.com/ethereum-optimism/optimism/pull/18291). PR builds currently compile all contracts from scratch because exact checksum-based artifacts don't exist for new code. With this fallback now enabled, PRs download the most recent develop artifacts (uploaded by #18291) and only recompile changed contracts, reducing CI build time through incremental compilation instead of full rebuilds.