### PR TITLE
cannon: Ensure cannon temp files are removed before exiting.

### DIFF
--- a/cannon/multicannon/exec.go
+++ b/cannon/multicannon/exec.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/versions"
+	"github.com/urfave/cli/v2"
 )
 
 // use the all directive to ensure the .gitkeep file is retained and avoid compiler errors
@@ -31,14 +32,12 @@ func ExecuteCannon(ctx context.Context, args []string, ver versions.StateVersion
 	}
 	cannonProgramPath, err := extractTempFile(filepath.Base(cannonProgramName), cannonProgramBin)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error extracting %s: %v\n", cannonProgramName, err)
-		os.Exit(1)
+		return cli.Exit(fmt.Sprintf("Error extracting %s: %v\n", cannonProgramName, err), 1)
 	}
 	defer os.Remove(cannonProgramPath)
 
 	if err := os.Chmod(cannonProgramPath, 0755); err != nil {
-		fmt.Fprintf(os.Stderr, "Error setting execute permission for %s: %v\n", cannonProgramName, err)
-		os.Exit(1)
+		return cli.Exit(fmt.Sprintf("Error setting execute permission for %s: %v\n", cannonProgramName, err), 1)
 	}
 
 	// nosemgrep: go.lang.security.audit.dangerous-exec-command.dangerous-exec-command
@@ -52,8 +51,7 @@ func ExecuteCannon(ctx context.Context, args []string, ver versions.StateVersion
 	if err := cmd.Wait(); err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
-			// relay exit code to the parent process
-			os.Exit(exitErr.ExitCode())
+			return cli.Exit("", exitErr.ExitCode())
 		} else {
 			return fmt.Errorf("failed to wait for cannon-impl program: %w", err)
 		}


### PR DESCRIPTION
os.Exit doesn't run defer statements before exiting. So return cli.Exit error instead - still lets us set the error code and triggers an exit, but handled by urfave after the function has returned and defer statements have run.
