### PR TITLE
Unify on a single transport websocket client and update devstack and conductor to use it

### DIFF
--- a/op-acceptance-tests/tests/flashblocks/flashblocks_stream_test.go
+++ b/op-acceptance-tests/tests/flashblocks/flashblocks_stream_test.go
@@ -82,7 +82,7 @@ func TestFlashblocksStream(gt *testing.T) {
 	defer close(builderOutput)
 	builderDone := make(chan struct{})
 	go func() {
-		err := oprbuilderNode.FlashblocksClient().ListenFor(ctx, logger.With("stream_source", "op-rbuilder"), testDuration, builderOutput, builderDone)
+		err := oprbuilderNode.FlashblocksClient().ReadAll(ctx, logger.With("stream_source", "op-rbuilder"), testDuration, builderOutput, builderDone)
 		require.NoError(t, err)
 	}()
 	builderMessages := make([]string, 0)
@@ -92,7 +92,7 @@ func TestFlashblocksStream(gt *testing.T) {
 	doneListening := make(chan struct{})
 	streamedMessages := make([]string, 0)
 	go func() {
-		err := rollupBoostNode.FlashblocksClient().ListenFor(ctx, logger.With("stream_source", "rollup-boost"), testDuration, output, doneListening)
+		err := rollupBoostNode.FlashblocksClient().ReadAll(ctx, logger.With("stream_source", "rollup-boost"), testDuration, output, doneListening)
 		require.NoError(t, err)
 	}()
 

--- a/op-acceptance-tests/tests/flashblocks/flashblocks_transfer_test.go
+++ b/op-acceptance-tests/tests/flashblocks/flashblocks_transfer_test.go
@@ -45,9 +45,6 @@ func TestFlashblocksTransfer(gt *testing.T) {
 	_, span = tracer.Start(ctx, fmt.Sprintf("test chain %s", sys.L2Chain.String()))
 	defer span.End()
 
-	doneListening := make(chan struct{})
-	output := make(chan []byte, 100)
-
 	// Drive a couple blocks on the test sequencer so the faucet L2 funding tx has a chance to land before we rely on it.
 	driveViaTestSequencer(t, sys, 2)
 
@@ -55,11 +52,15 @@ func TestFlashblocksTransfer(gt *testing.T) {
 	bob := sys.Wallet.NewEOA(sys.L2EL)
 	bobAddress := bob.Address().Hex()
 
-	// flashblocks listener
+	// flashblocks listener - start goroutine and wait for it to be running
 	flashblocksClient := sys.L2RollupBoost.FlashblocksClient()
+	output := make(chan []byte, 100)
+	doneListening := make(chan struct{})
 	go func() {
-		err := flashblocksClient.ListenFor(ctx, logger, 20*time.Second, output, doneListening)
-		t.Require().NoError(err, "failed to listen for flashblocks")
+		err := flashblocksClient.ReadAll(ctx, logger.With("stream_source", "rollup-boost"), 20*time.Second, output, doneListening)
+		if err != nil {
+			t.Require().NoError(err, "failed to listen for flashblocks")
+		}
 	}()
 
 	var executedTransaction *txplan.PlannedTx

--- a/op-conductor/rpc/ws/flashblocks_handler.go
+++ b/op-conductor/rpc/ws/flashblocks_handler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/coder/websocket"
 
 	"github.com/ethereum-optimism/optimism/op-conductor/metrics"
+	opclient "github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/httputil"
 	"github.com/ethereum-optimism/optimism/op-service/retry"
 	"github.com/ethereum/go-ethereum/log"
@@ -54,7 +55,7 @@ type Handler struct {
 	log                 log.Logger
 	isLeaderFn          func(context.Context) bool
 	metrics             metrics.Metricer
-	rollupBoostConn     *websocket.Conn
+	rollupBoostConn     *opclient.WSClient
 	rollupBoostCtx      context.Context
 	rollupBoostWsCancel context.CancelFunc
 	httpServer          *httputil.HTTPServer
@@ -83,18 +84,14 @@ func NewHandler(cfg Config, log log.Logger, isLeaderFn func(context.Context) boo
 
 	// Try to establish initial connection to rollup boost WebSocket
 	maxConnectionAttempts := 5
-	var err error
-	handler.rollupBoostConn, err = retry.Do(context.Background(), maxConnectionAttempts, retry.Fixed(reconnectDelay), func() (*websocket.Conn, error) {
-		log.Info("attempting to connect to rollup boost WebSocket", "url", cfg.RollupBoostWsURL)
-		dialCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		conn, resp, err := websocket.Dial(dialCtx, cfg.RollupBoostWsURL, nil)
-		if resp != nil && resp.Body != nil {
-			resp.Body.Close()
-		}
-		return conn, err
+	conn, err := opclient.DialWS(context.Background(), opclient.WSConfig{
+		URL:         cfg.RollupBoostWsURL,
+		DialTimeout: 5 * time.Second,
+		MaxAttempts: maxConnectionAttempts,
+		Backoff:     retry.Fixed(reconnectDelay),
+		Log:         log,
 	})
-
+	handler.rollupBoostConn = conn
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to rollup boost WebSocket: %w", err)
 	}
@@ -204,13 +201,12 @@ func (h *Handler) listenToRollupBoost(ctx context.Context) {
 				h.log.Info("reconnecting to rollup boost WebSocket", "url", h.cfg.RollupBoostWsURL)
 
 				// Connect with timeout
-				dialCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-				defer cancel()
-				conn, resp, err := websocket.Dial(dialCtx, h.cfg.RollupBoostWsURL, nil)
-				if resp != nil && resp.Body != nil {
-					resp.Body.Close()
-				}
-
+				conn, err := opclient.DialWS(ctx, opclient.WSConfig{
+					URL:         h.cfg.RollupBoostWsURL,
+					DialTimeout: 5 * time.Second,
+					MaxAttempts: 1,
+					Log:         h.log,
+				})
 				if err != nil {
 					h.log.Warn("failed to connect to rollup boost WebSocket, will retry",
 						"err", err, "retryIn", reconnectDelay)
@@ -227,8 +223,8 @@ func (h *Handler) listenToRollupBoost(ctx context.Context) {
 
 			// Read with timeout
 			readCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-			defer cancel()
 			_, message, err := h.rollupBoostConn.Read(readCtx)
+			cancel()
 
 			if err != nil {
 				h.log.Warn("error reading from rollup boost WebSocket", "err", err)

--- a/op-devstack/dsl/l2_op_rbuilder.go
+++ b/op-devstack/dsl/l2_op_rbuilder.go
@@ -1,11 +1,9 @@
 package dsl
 
 import (
-	"context"
-	"time"
+	opclient "github.com/ethereum-optimism/optimism/op-service/client"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
-	"github.com/ethereum/go-ethereum/log"
 )
 
 type OPRBuilderNodeSet []*OPRBuilderNode
@@ -21,7 +19,7 @@ func NewOPRBuilderNodeSet(inner []stack.OPRBuilderNode, control stack.ControlPla
 type OPRBuilderNode struct {
 	commonImpl
 	inner    stack.OPRBuilderNode
-	wsClient *FlashblocksWSClient
+	wsClient *opclient.WSClient
 	control  stack.ControlPlane
 }
 
@@ -29,7 +27,7 @@ func NewOPRBuilderNode(inner stack.OPRBuilderNode, control stack.ControlPlane) *
 	return &OPRBuilderNode{
 		commonImpl: commonFromT(inner.T()),
 		inner:      inner,
-		wsClient:   NewFlashblocksWSClient(inner.FlashblocksClient()),
+		wsClient:   inner.FlashblocksClient(),
 		control:    control,
 	}
 }
@@ -42,8 +40,8 @@ func (c *OPRBuilderNode) Escape() stack.OPRBuilderNode {
 	return c.inner
 }
 
-func (c *OPRBuilderNode) ListenFor(ctx context.Context, logger log.Logger, duration time.Duration, output chan<- []byte, done chan<- struct{}) error {
-	return c.wsClient.ListenFor(ctx, logger, duration, output, done)
+func (c *OPRBuilderNode) FlashblocksClient() *opclient.WSClient {
+	return c.wsClient
 }
 
 func (el *OPRBuilderNode) Stop() {
@@ -53,8 +51,4 @@ func (el *OPRBuilderNode) Stop() {
 
 func (el *OPRBuilderNode) Start() {
 	el.control.OPRBuilderNodeState(el.inner.ID(), stack.Start)
-}
-
-func (el *OPRBuilderNode) FlashblocksClient() *FlashblocksWSClient {
-	return NewFlashblocksWSClient(el.inner.FlashblocksClient())
 }

--- a/op-devstack/dsl/rollup_boost.go
+++ b/op-devstack/dsl/rollup_boost.go
@@ -1,6 +1,10 @@
 package dsl
 
-import "github.com/ethereum-optimism/optimism/op-devstack/stack"
+import (
+	opclient "github.com/ethereum-optimism/optimism/op-service/client"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+)
 
 type RollupBoostNodesSet []*RollupBoostNode
 
@@ -30,6 +34,6 @@ func NewRollupBoostNode(inner stack.RollupBoostNode, control stack.ControlPlane)
 	}
 }
 
-func (r *RollupBoostNode) FlashblocksClient() *FlashblocksWSClient {
-	return NewFlashblocksWSClient(r.inner.FlashblocksClient())
+func (r *RollupBoostNode) FlashblocksClient() *opclient.WSClient {
+	return r.inner.FlashblocksClient()
 }

--- a/op-devstack/shim/op_rbuilder.go
+++ b/op-devstack/shim/op_rbuilder.go
@@ -6,21 +6,22 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/apis"
+	opclient "github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
 )
 
 type OPRBuilderNodeConfig struct {
 	ELNodeConfig
-	RollupCfg           *rollup.Config
-	ID                  stack.OPRBuilderNodeID
-	FlashblocksWsClient stack.FlashblocksWSClient
+	RollupCfg         *rollup.Config
+	ID                stack.OPRBuilderNodeID
+	FlashblocksClient *opclient.WSClient
 }
 
 type OPRBuilderNode struct {
 	rpcELNode
-	id                  stack.OPRBuilderNodeID
-	engineClient        *sources.EngineClient
-	flashblocksWsClient stack.FlashblocksWSClient
+	id                stack.OPRBuilderNodeID
+	engineClient      *sources.EngineClient
+	flashblocksClient *opclient.WSClient
 }
 
 var _ stack.OPRBuilderNode = (*OPRBuilderNode)(nil)
@@ -33,10 +34,10 @@ func NewOPRBuilderNode(cfg OPRBuilderNodeConfig) *OPRBuilderNode {
 	require.NoError(cfg.T, err)
 
 	return &OPRBuilderNode{
-		rpcELNode:           newRpcELNode(cfg.ELNodeConfig),
-		engineClient:        l2EngineClient,
-		id:                  cfg.ID,
-		flashblocksWsClient: cfg.FlashblocksWsClient,
+		rpcELNode:         newRpcELNode(cfg.ELNodeConfig),
+		engineClient:      l2EngineClient,
+		id:                cfg.ID,
+		flashblocksClient: cfg.FlashblocksClient,
 	}
 }
 
@@ -48,8 +49,8 @@ func (r *OPRBuilderNode) L2EthClient() apis.L2EthClient {
 	return r.engineClient.L2Client
 }
 
-func (r *OPRBuilderNode) FlashblocksClient() stack.FlashblocksWSClient {
-	return r.flashblocksWsClient
+func (r *OPRBuilderNode) FlashblocksClient() *opclient.WSClient {
+	return r.flashblocksClient
 }
 
 func (r *OPRBuilderNode) L2EngineClient() apis.EngineClient {

--- a/op-devstack/shim/rollup_boost.go
+++ b/op-devstack/shim/rollup_boost.go
@@ -1,18 +1,20 @@
 package shim
 
 import (
+	"github.com/stretchr/testify/require"
+
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/apis"
+	opclient "github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
-	"github.com/stretchr/testify/require"
 )
 
 type RollupBoostNodeConfig struct {
 	ELNodeConfig
-	RollupCfg           *rollup.Config
-	ID                  stack.RollupBoostNodeID
-	FlashblocksWsClient stack.FlashblocksWSClient
+	RollupCfg         *rollup.Config
+	ID                stack.RollupBoostNodeID
+	FlashblocksClient *opclient.WSClient
 }
 
 type RollupBoostNode struct {
@@ -21,7 +23,7 @@ type RollupBoostNode struct {
 
 	id stack.RollupBoostNodeID
 
-	flashblocksWsClient stack.FlashblocksWSClient
+	flashblocksClient *opclient.WSClient
 }
 
 var _ stack.RollupBoostNode = (*RollupBoostNode)(nil)
@@ -34,10 +36,10 @@ func NewRollupBoostNode(cfg RollupBoostNodeConfig) *RollupBoostNode {
 	require.NoError(cfg.T, err)
 
 	return &RollupBoostNode{
-		rpcELNode:           newRpcELNode(cfg.ELNodeConfig),
-		engineClient:        l2EngineClient,
-		id:                  cfg.ID,
-		flashblocksWsClient: cfg.FlashblocksWsClient,
+		rpcELNode:         newRpcELNode(cfg.ELNodeConfig),
+		engineClient:      l2EngineClient,
+		id:                cfg.ID,
+		flashblocksClient: cfg.FlashblocksClient,
 	}
 }
 
@@ -49,8 +51,8 @@ func (r *RollupBoostNode) L2EthClient() apis.L2EthClient {
 	return r.engineClient.L2Client
 }
 
-func (r *RollupBoostNode) FlashblocksClient() stack.FlashblocksWSClient {
-	return r.flashblocksWsClient
+func (r *RollupBoostNode) FlashblocksClient() *opclient.WSClient {
+	return r.flashblocksClient
 }
 
 func (r *RollupBoostNode) L2EngineClient() apis.EngineClient {

--- a/op-devstack/stack/op_rbuilder.go
+++ b/op-devstack/stack/op_rbuilder.go
@@ -4,6 +4,7 @@ import (
 	"log/slog"
 
 	"github.com/ethereum-optimism/optimism/op-service/apis"
+	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
@@ -72,7 +73,7 @@ type OPRBuilderNode interface {
 	ID() OPRBuilderNodeID
 	L2EthClient() apis.L2EthClient
 	L2EngineClient() apis.EngineClient
-	FlashblocksClient() FlashblocksWSClient
+	FlashblocksClient() *client.WSClient
 
 	ELNode
 }

--- a/op-devstack/stack/rollup_boost.go
+++ b/op-devstack/stack/rollup_boost.go
@@ -4,6 +4,7 @@ import (
 	"log/slog"
 
 	"github.com/ethereum-optimism/optimism/op-service/apis"
+	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
@@ -72,7 +73,7 @@ type RollupBoostNode interface {
 	ID() RollupBoostNodeID
 	L2EthClient() apis.L2EthClient
 	L2EngineClient() apis.EngineClient
-	FlashblocksClient() FlashblocksWSClient
+	FlashblocksClient() *client.WSClient
 
 	ELNode
 }

--- a/op-devstack/sysext/l2.go
+++ b/op-devstack/sysext/l2.go
@@ -206,6 +206,13 @@ func (o *Orchestrator) hydrateRollupBoostNodeMaybe(node *descriptors.Node, l2Net
 	flashblocksWsUrl, flashblocksWsHeaders, err := o.findProtocolService(rollupBoostService, WebsocketFlashblocksProtocol)
 	require.NoError(err, "failed to find websocket service for rollup-boost")
 
+	wsClient, err := client.DialWS(l2Net.T().Ctx(), client.WSConfig{
+		URL:     flashblocksWsUrl,
+		Headers: flashblocksWsHeaders,
+		Log:     l2Net.Logger(),
+	})
+	require.NoError(err, "failed to create rollup-boost websocket client")
+
 	rollupBoost := shim.NewRollupBoostNode(shim.RollupBoostNodeConfig{
 		ID: stack.NewRollupBoostNodeID(rollupBoostService.Name, l2ID.ChainID()),
 		ELNodeConfig: shim.ELNodeConfig{
@@ -213,13 +220,8 @@ func (o *Orchestrator) hydrateRollupBoostNodeMaybe(node *descriptors.Node, l2Net
 			Client:       o.rpcClient(l2Net.T(), rollupBoostService, RPCProtocol, "/", opts...),
 			ChainID:      l2ID.ChainID(),
 		},
-		RollupCfg: l2Net.RollupConfig(),
-		FlashblocksWsClient: shim.NewFlashblocksWSClient(shim.FlashblocksWSClientConfig{
-			CommonConfig: shim.NewCommonConfig(l2Net.T()),
-			ID:           stack.NewFlashblocksWSClientID(rollupBoostService.Name, l2ID.ChainID()),
-			WsUrl:        flashblocksWsUrl,
-			WsHeaders:    flashblocksWsHeaders,
-		}),
+		RollupCfg:         l2Net.RollupConfig(),
+		FlashblocksClient: wsClient,
 	})
 
 	l2Net.AddRollupBoostNode(rollupBoost)
@@ -264,6 +266,13 @@ func (o *Orchestrator) hydrateOPRBuilderMaybe(node *descriptors.Node, l2Net stac
 	flashblocksWsUrl, flashblocksWsHeaders, err := o.findProtocolService(rbuilderService, WebsocketFlashblocksProtocol)
 	require.NoError(err, "failed to find websocket service for rbuilder")
 
+	wsClient, err := client.DialWS(l2Net.T().Ctx(), client.WSConfig{
+		URL:     flashblocksWsUrl,
+		Headers: flashblocksWsHeaders,
+		Log:     l2Net.Logger(),
+	})
+	require.NoError(err, "failed to create rbuilder websocket client")
+
 	flashblocksBuilder := shim.NewOPRBuilderNode(shim.OPRBuilderNodeConfig{
 		ID: stack.NewOPRBuilderNodeID(rbuilderService.Name, l2ID.ChainID()),
 		ELNodeConfig: shim.ELNodeConfig{
@@ -271,12 +280,7 @@ func (o *Orchestrator) hydrateOPRBuilderMaybe(node *descriptors.Node, l2Net stac
 			Client:       o.rpcClient(l2Net.T(), rbuilderService, RPCProtocol, "/", opts...),
 			ChainID:      l2ID.ChainID(),
 		},
-		FlashblocksWsClient: shim.NewFlashblocksWSClient(shim.FlashblocksWSClientConfig{
-			CommonConfig: shim.NewCommonConfig(l2Net.T()),
-			ID:           stack.NewFlashblocksWSClientID(rbuilderService.Name, l2ID.ChainID()),
-			WsUrl:        flashblocksWsUrl,
-			WsHeaders:    flashblocksWsHeaders,
-		}),
+		FlashblocksClient: wsClient,
 	})
 
 	l2Net.AddOPRBuilderNode(flashblocksBuilder)

--- a/op-devstack/sysgo/op_rbuilder.go
+++ b/op-devstack/sysgo/op_rbuilder.go
@@ -312,6 +312,13 @@ func (b *OPRBuilderNode) hydrate(system stack.ExtensibleSystem) {
 	system.T().Require().NoError(err)
 	system.T().Cleanup(elRPC.Close)
 
+	// Create a shared websocket client for flashblocks traffic over the proxy.
+	wsClient, err := client.DialWS(system.T().Ctx(), client.WSConfig{
+		URL: b.wsProxyURL,
+		Log: system.Logger(),
+	})
+	system.T().Require().NoError(err)
+
 	node := shim.NewOPRBuilderNode(shim.OPRBuilderNodeConfig{
 		ID: b.id,
 		ELNodeConfig: shim.ELNodeConfig{
@@ -319,13 +326,8 @@ func (b *OPRBuilderNode) hydrate(system stack.ExtensibleSystem) {
 			Client:       elRPC,
 			ChainID:      b.id.ChainID(),
 		},
-		RollupCfg: b.rollupCfg,
-		FlashblocksWsClient: shim.NewFlashblocksWSClient(shim.FlashblocksWSClientConfig{
-			CommonConfig: shim.NewCommonConfig(system.T()),
-			ID:           stack.NewFlashblocksWSClientID(b.id.Key(), b.id.ChainID()),
-			WsUrl:        b.wsProxyURL,
-			WsHeaders:    nil,
-		}),
+		RollupCfg:         b.rollupCfg,
+		FlashblocksClient: wsClient,
 	})
 	system.L2Network(stack.L2NetworkID(b.id.ChainID())).(stack.ExtensibleL2Network).AddOPRBuilderNode(node)
 }

--- a/op-devstack/sysgo/rollup_boost.go
+++ b/op-devstack/sysgo/rollup_boost.go
@@ -21,7 +21,7 @@ import (
 
 // RollupBoostNode is a lightweight sysgo-managed process wrapper around a rollup-boost
 // WebSocket stream source. It exposes a stable proxied ws URL and hydrates the L2
-// network with a FlashblocksWSClient shim that points at it.
+// network with a shared WSClient that points at it.
 type RollupBoostNode struct {
 	mu sync.Mutex
 
@@ -51,6 +51,14 @@ func (r *RollupBoostNode) hydrate(system stack.ExtensibleSystem) {
 	system.T().Require().NoError(err)
 	system.T().Cleanup(elRPC.Close)
 
+	// Create a shared websocket client for flashblocks traffic over the proxy.
+	wsClient, err := client.DialWS(system.T().Ctx(), client.WSConfig{
+		URL:     r.wsProxyURL,
+		Headers: r.header,
+		Log:     system.Logger(),
+	})
+	system.T().Require().NoError(err)
+
 	node := shim.NewRollupBoostNode(shim.RollupBoostNodeConfig{
 		ID: r.id,
 		ELNodeConfig: shim.ELNodeConfig{
@@ -58,13 +66,8 @@ func (r *RollupBoostNode) hydrate(system stack.ExtensibleSystem) {
 			Client:       elRPC,
 			ChainID:      r.id.ChainID(),
 		},
-		RollupCfg: system.L2Network(stack.L2NetworkID(r.id.ChainID())).RollupConfig(),
-		FlashblocksWsClient: shim.NewFlashblocksWSClient(shim.FlashblocksWSClientConfig{
-			CommonConfig: shim.NewCommonConfig(system.T()),
-			ID:           stack.NewFlashblocksWSClientID(r.id.Key(), r.id.ChainID()),
-			WsUrl:        r.wsProxyURL,
-			WsHeaders:    r.header,
-		}),
+		RollupCfg:         system.L2Network(stack.L2NetworkID(r.id.ChainID())).RollupConfig(),
+		FlashblocksClient: wsClient,
 	})
 	system.L2Network(stack.L2NetworkID(r.id.ChainID())).(stack.ExtensibleL2Network).AddRollupBoostNode(node)
 }
@@ -149,7 +152,7 @@ func (r *RollupBoostNode) Stop() {
 }
 
 // WithRollupBoost starts a rollup-boost process using the provided options
-// and registers a FlashblocksWSClient on the target L2 chain.
+// and registers a WSClient on the target L2 chain.
 // l2ELID is required to link the proxy to the L2 EL it serves.
 func WithRollupBoost(id stack.RollupBoostNodeID, l2ELID stack.L2ELNodeID, opts ...RollupBoostOption) stack.Option[*Orchestrator] {
 	return stack.AfterDeploy(func(orch *Orchestrator) {

--- a/op-devstack/sysgo/system.go
+++ b/op-devstack/sysgo/system.go
@@ -623,7 +623,7 @@ func singleChainSystemWithFlashblocksOpts(ids *SingleChainSystemWithFlashblocksI
 	opt := stack.Combine[*Orchestrator]()
 	// Precompute deterministic P2P identity and peering between sequencer EL and op-rbuilder EL.
 	seqID := NewELNodeIdentity("127.0.0.1", 0)
-	builderID := NewELNodeIdentity("127.0.0.1", 30303) // use default reth p2p port
+	builderID := NewELNodeIdentity("127.0.0.1", 0) // allocate dynamic port for builder
 
 	var missingEnv []string
 	if os.Getenv("OP_RBUILDER_EXEC_PATH") == "" {

--- a/op-devstack/sysgo/util.go
+++ b/op-devstack/sysgo/util.go
@@ -11,8 +11,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/coder/websocket"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	opclient "github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -79,14 +79,8 @@ func waitWSReady(p devtest.P, rawURL string, timeout time.Duration) {
 	waitWSMsg := fmt.Sprintf("WebSocket endpoint %s not ready within %v", rawURL, timeout)
 	p.Require().EventuallyWithT(func(c *assert.CollectT) {
 		ctx, cancel := context.WithTimeout(context.Background(), 750*time.Millisecond)
-		conn, resp, err := websocket.Dial(ctx, rawURL, nil)
+		err := opclient.ProbeWS(ctx, rawURL)
 		cancel()
-		if resp != nil && resp.Body != nil {
-			_ = resp.Body.Close()
-		}
-		if conn != nil {
-			_ = conn.Close(websocket.StatusNormalClosure, "")
-		}
 		assert.NoError(c, err, "WebSocket handshake to %s should succeed", rawURL)
 	}, timeout, 100*time.Millisecond, waitWSMsg)
 }

--- a/op-service/client/ws.go
+++ b/op-service/client/ws.go
@@ -1,0 +1,200 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-service/retry"
+)
+
+// WSConfig configures a websocket connection.
+// This is the shared configuration type for all outbound websocket clients in the codebase.
+// Higher level users can build additional behavior on top, but should prefer DialWS / WSClient
+// instead of constructing websocket.Dial calls directly.
+type WSConfig struct {
+	// URL is the websocket endpoint, e.g. wss://example:8546/ws.
+	URL string
+	// Headers are optional HTTP headers included in the websocket handshake.
+	Headers http.Header
+
+	// DialTimeout bounds the initial websocket dial.
+	DialTimeout time.Duration
+	// ReadTimeout bounds individual Read calls when a context without deadline is used.
+	ReadTimeout time.Duration
+	// WriteTimeout bounds individual Write calls when a context without deadline is used.
+	WriteTimeout time.Duration
+
+	// MaxAttempts configures how many dial attempts are made with backoff.
+	// Defaults to 1 if zero.
+	MaxAttempts int
+	// Backoff is the backoff strategy used between dial attempts.
+	// Defaults to retry.Exponential() if nil.
+	Backoff retry.Strategy
+
+	// Log is used for connection level logging.
+	// If nil, logging is disabled.
+	Log log.Logger
+}
+
+// applyDefaults fills empty WSConfig fields with conservative defaults.
+func (c *WSConfig) applyDefaults() {
+	if c.DialTimeout == 0 {
+		c.DialTimeout = 10 * time.Second
+	}
+	if c.ReadTimeout == 0 {
+		c.ReadTimeout = 30 * time.Second
+	}
+	if c.WriteTimeout == 0 {
+		c.WriteTimeout = 30 * time.Second
+	}
+	if c.MaxAttempts < 1 {
+		c.MaxAttempts = 1
+	}
+	if c.Backoff == nil {
+		c.Backoff = retry.Exponential()
+	}
+}
+
+// WSClient is the canonical outbound websocket client for the monorepo.
+// It wraps a coder/websocket connection, handles dialing with backoff, and exposes
+// context-aware read/write helpers. New outbound websocket integrations should go
+// through this type (or helpers built on top of it) rather than using websocket.Dial
+// directly.
+type WSClient struct {
+	conn   *websocket.Conn
+	config WSConfig
+}
+
+// DialWS establishes a websocket connection using the given configuration.
+// It performs MaxAttempts connection attempts with the configured backoff.
+func DialWS(ctx context.Context, cfg WSConfig) (*WSClient, error) {
+	cfg.applyDefaults()
+
+	if cfg.Log != nil {
+		cfg.Log.Info("Dialing websocket", "url", cfg.URL)
+	}
+
+	conn, err := retry.Do(ctx, cfg.MaxAttempts, cfg.Backoff, func() (*websocket.Conn, error) {
+		dialCtx, cancel := context.WithTimeout(ctx, cfg.DialTimeout)
+		defer cancel()
+		conn, resp, err := websocket.Dial(dialCtx, cfg.URL, &websocket.DialOptions{
+			HTTPHeader: cfg.Headers,
+		})
+		if resp != nil && resp.Body != nil {
+			_ = resp.Body.Close()
+		}
+		return conn, err
+	})
+	if err != nil {
+		if cfg.Log != nil {
+			cfg.Log.Warn("Failed to dial websocket", "url", cfg.URL, "err", err)
+		}
+		return nil, err
+	}
+
+	if cfg.Log != nil {
+		cfg.Log.Info("Websocket connection established", "url", cfg.URL)
+	}
+
+	return &WSClient{
+		conn:   conn,
+		config: cfg,
+	}, nil
+}
+
+// Close closes the websocket connection with the given status and reason.
+func (c *WSClient) Close(status websocket.StatusCode, reason string) error {
+	if c == nil || c.conn == nil {
+		return nil
+	}
+	return c.conn.Close(status, reason)
+}
+
+// Read reads the next message from the websocket connection.
+// If the context has no deadline, a default read timeout from the config is applied.
+func (c *WSClient) Read(ctx context.Context) (websocket.MessageType, []byte, error) {
+	if deadline, ok := ctx.Deadline(); !ok || time.Until(deadline) <= 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, c.config.ReadTimeout)
+		defer cancel()
+	}
+	return c.conn.Read(ctx)
+}
+
+// Write writes a message to the websocket connection.
+// If the context has no deadline, a default write timeout from the config is applied.
+func (c *WSClient) Write(ctx context.Context, msgType websocket.MessageType, data []byte) error {
+	if deadline, ok := ctx.Deadline(); !ok || time.Until(deadline) <= 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, c.config.WriteTimeout)
+		defer cancel()
+	}
+	return c.conn.Write(ctx, msgType, data)
+}
+
+// ReadAll streams all websocket messages for the given duration into the provided output channel.
+// It closes the done channel (when provided) after finishing the read loop.
+func (c *WSClient) ReadAll(ctx context.Context, logger log.Logger, duration time.Duration, output chan<- []byte, done chan<- struct{}) error {
+	if c == nil {
+		return errors.New("ws client is nil")
+	}
+	if logger == nil {
+		return errors.New("logger is nil")
+	}
+	if done != nil {
+		defer close(done)
+	}
+
+	logger.Info("Listening on WebSocket client", "duration", duration)
+
+	ctx, cancel := context.WithTimeout(ctx, duration)
+	defer cancel()
+
+	for {
+		_, message, err := c.Read(ctx)
+		if err != nil {
+			if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+				logger.Info("WebSocket read finished")
+				return nil
+			}
+			logger.Error("Error reading WebSocket message", "error", err)
+			return err
+		}
+		logger.Debug("Received WebSocket message", "message_length", len(message))
+
+		select {
+		case output <- message:
+		case <-ctx.Done():
+			logger.Info("Context done while sending message")
+			return nil
+		}
+	}
+}
+
+// ProbeWS performs a lightweight websocket handshake against the given URL and closes immediately.
+// It can be used in readiness checks to verify that the endpoint accepts websocket connections.
+func ProbeWS(ctx context.Context, url string) error {
+	cfg := WSConfig{
+		URL:         url,
+		DialTimeout: 5 * time.Second,
+		MaxAttempts: 1,
+	}
+	cfg.applyDefaults()
+
+	conn, err := DialWS(ctx, cfg)
+	if err != nil {
+		return err
+	}
+	// Close without waiting for the peer's close frame. Some flashblocks endpoints
+	// immediately drop the connection after a successful handshake which makes the
+	// full close handshake fail spuriously even though the endpoint is healthy.
+	if conn.conn == nil {
+		return nil
+	}
+	return conn.conn.CloseNow()
+}

--- a/op-service/client/ws_test.go
+++ b/op-service/client/ws_test.go
@@ -1,0 +1,99 @@
+package client
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+// newTestLogger returns a no-op logger suitable for tests.
+func newTestLogger(t *testing.T) log.Logger {
+	t.Helper()
+	// Root logger with no handlers is effectively silent.
+	return log.New()
+}
+
+// wsEchoServer starts a simple websocket echo server for tests.
+func wsEchoServer(t *testing.T) (*httptest.Server, string) {
+	t.Helper()
+	ctx := t.Context()
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
+			CompressionMode: websocket.CompressionDisabled,
+		})
+		if err != nil {
+			return
+		}
+		defer conn.Close(websocket.StatusNormalClosure, "test complete")
+
+		for {
+			msgType, data, err := conn.Read(ctx)
+			if err != nil {
+				return
+			}
+			if err := conn.Write(ctx, msgType, data); err != nil {
+				return
+			}
+		}
+	})
+
+	srv := httptest.NewServer(handler)
+
+	// Convert http://127.0.0.1:port to ws://127.0.0.1:port.
+	wsURL := "ws" + srv.URL[len("http"):]
+	return srv, wsURL
+}
+
+func TestDialWSAndEcho(t *testing.T) {
+	ctx := t.Context()
+	srv, wsURL := wsEchoServer(t)
+	defer srv.Close()
+
+	opCtx, cancelOp := context.WithTimeout(ctx, 5*time.Second)
+	defer cancelOp()
+
+	client, err := DialWS(opCtx, WSConfig{
+		URL: wsURL,
+		Log: newTestLogger(t),
+	})
+	if err != nil {
+		t.Fatalf("DialWS failed: %v", err)
+	}
+	defer client.Close(websocket.StatusNormalClosure, "test complete")
+
+	const payload = "hello over websocket"
+
+	if err := client.Write(opCtx, websocket.MessageText, []byte(payload)); err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+
+	msgType, data, err := client.Read(opCtx)
+	if err != nil {
+		t.Fatalf("Read failed: %v", err)
+	}
+	if msgType != websocket.MessageText {
+		t.Fatalf("unexpected message type: %v", msgType)
+	}
+	if string(data) != payload {
+		t.Fatalf("unexpected payload: got %q, want %q", string(data), payload)
+	}
+}
+
+func TestProbeWS(t *testing.T) {
+	ctx := t.Context()
+	srv, wsURL := wsEchoServer(t)
+	defer srv.Close()
+
+	opCtx, cancelOp := context.WithTimeout(ctx, 5*time.Second)
+	defer cancelOp()
+
+	if err := ProbeWS(opCtx, wsURL); err != nil {
+		t.Fatalf("ProbeWS failed: %v", err)
+	}
+}


### PR DESCRIPTION
Introduced a shared websocket client and plumbed it through flashblocks/rollup-boost flows, replacing bespoke wrappers.

  - Added canonical WSConfig/WSClient with retries, default timeouts, and ProbeWS readiness helper, plus echo/handshake tests (op-service/client/ws.go:14, op-service/client/ws_test.go:53).
  - Swapped conductor flashblocks handler over to the shared client for initial dial and reconnect backoff, removing inlined websocket.Dial logic (op-conductor/rpc/ws/flashblocks_handler.go:66).
  - Eliminated the flashblocks-specific stack/shim DSL clients in favor of passing the shared *opclient.WSClient through orchestrator, shim, and DSL layers (op-devstack/shim/rollup_boost.go:12, op-devstack/shim/op_rbuilder.go:12, op-devstack/dsl/l2_op_rbuilder.go:33), and wired sysgo/sysext setup to create and
    reuse that client while probing endpoints with ProbeWS.

  Tests: go test ./op-service/client.