### PR TITLE
op-batcher: fix MaxChannelDuration tracking for large block backlogs

### DIFF
--- a/op-acceptance-tests/tests/batcher/batcher_test.go
+++ b/op-acceptance-tests/tests/batcher/batcher_test.go
@@ -1,0 +1,132 @@
+package batcher
+
+import (
+	"testing"
+	"time"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack/match"
+	"github.com/ethereum-optimism/optimism/op-service/apis"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/txplan"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBatcherFullChannelsAfterDowntime(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewSingleChainMultiNodeWithTestSeq(t)
+	l := t.Logger()
+	ts_L2 := sys.TestSequencer.Escape().ControlAPI(sys.L2EL.ChainID())
+	ts_L1 := sys.TestSequencer.Escape().ControlAPI(sys.L1Network.ChainID())
+
+	alice := sys.FunderL2.NewFundedEOA(eth.OneWei)
+	cathrine := sys.FunderL2.NewFundedEOA(eth.OneTenthEther)
+
+	cl := sys.L1Network.Escape().L1CLNode(match.FirstL1CL)
+
+	sys.ControlPlane.FakePoSState(cl.ID(), stack.Stop)
+
+	latestUnsafe_A := sys.L2CL.StopSequencer()
+	l.Info("Latest unsafe block after stopping the L2 sequencer", "latestUnsafe", latestUnsafe_A)
+
+	parent := latestUnsafe_A
+	nonce := uint64(0)
+	for j := 0; j < 200; j++ {
+		l1Origin := sys.L1EL.BlockRefByLabel(eth.Unsafe).Hash
+
+		for i := 0; i < 5; i++ {
+			l.Debug("Sequencing L2 block", "iteration", i, "parent", parent)
+			sequenceBlockWithL1Origin(t, ts_L2, parent, l1Origin, alice, cathrine, nonce)
+			nonce++
+
+			parent = sys.L2CL.HeadBlockRef(types.LocalUnsafe).Hash
+
+			sys.AdvanceTime(time.Second * 2)
+		}
+
+		l.Debug("Sequencing L1 block", "iteration_j", j)
+		sequenceBlock(t, ts_L1, common.Hash{})
+	}
+
+	sys.L2CL.StartSequencer()
+
+	l.Info("Current L1 unsafe block", "currentL1Unsafe", sys.L1EL.BlockRefByLabel(eth.Unsafe))
+	sys.ControlPlane.FakePoSState(cl.ID(), stack.Start)
+
+	sys.L2Batcher.Start()
+
+	channels, channelFrames, l2Txs := sys.L2Chain.DeriveData(4) // over the next 4 blocks, collect batches/channels/frames submitted by the batcher on the L1 network, and parse them
+	{
+		for _, c := range channels {
+			l.Info("Channel details", "channelID", c.String(), "frameCount", len(channelFrames[c]), "dataLength_frame0", len(channelFrames[c][0].Data))
+		}
+
+		require.Equal(t, 10, len(channels)) // we expect a total of 10 channels, due to existing MaxChannelDuration bug filed at: https://github.com/ethereum-optimism/optimism/issues/18092
+
+		// values are dependent on:
+		// - MaxPendingTransactions
+		// - number of blocks and transactions sent in the test - 1000 L2 blocks with 1 transaction from cathrine to alice
+		// - MaxL1TxSize (this is set to 40_000 bytes for test purposes)
+		sizeRanges := []struct {
+			min  int
+			max  int
+			note string
+		}{
+			{min: 7_000, max: 10_000, note: "channel 0 - the first 100 blocks"},
+			{min: 100, max: 1000, note: "channel 1 - only a few blocks due to racy behavior, nowhere near the channel capacity"},
+			{min: 100, max: 1000, note: "channel 2 - only a few blocks due to racy behavior, nowhere near the channel capacity"},
+			{min: 100, max: 1000, note: "channel 3 - only a few blocks due to racy behavior, nowhere near the channel capacity"},
+			{min: 100, max: 1000, note: "channel 4 - only a few blocks due to racy behavior, nowhere near the channel capacity"},
+			{min: 100, max: 1000, note: "channel 5 - only a few blocks due to racy behavior, nowhere near the channel capacity"},
+			{min: 100, max: 1000, note: "channel 6 - only a few blocks due to racy behavior, nowhere near the channel capacity"},
+			{min: 100, max: 1000, note: "channel 7 - only a few blocks due to racy behavior, nowhere near the channel capacity"},
+			{min: 20_000, max: 40_000, note: "channel 8 - filled to the max capacity, due to blocking behavior because of MaxPendingTransactions limit reached"},
+			{min: 20_000, max: 40_000, note: "channel 9 - filled to the max capacity, due to blocking behavior because of MaxPendingTransactions limit reached"},
+		}
+
+		for i, entry := range sizeRanges {
+			require.LessOrEqual(t, len(channelFrames[channels[i]][0].Data), entry.max, entry.note)
+			require.GreaterOrEqual(t, len(channelFrames[channels[i]][0].Data), entry.min, entry.note)
+		}
+
+		require.Equal(t, len(l2Txs[cathrine.Address()]), 1000) // we expect 1000 transactions total sent from cathrine to alice
+	}
+
+	//sys.L2Chain.PrintChain()
+	//sys.L1Network.PrintChain()
+
+	status := sys.L2CL.SyncStatus()
+	spew.Dump(status)
+}
+
+func sequenceBlock(t devtest.T, ts apis.TestSequencerControlAPI, parent common.Hash) {
+	require.NoError(t, ts.New(t.Ctx(), seqtypes.BuildOpts{Parent: parent}))
+	require.NoError(t, ts.Next(t.Ctx()))
+}
+
+func sequenceBlockWithL1Origin(t devtest.T, ts apis.TestSequencerControlAPI, parent common.Hash, l1Origin common.Hash, alice *dsl.EOA, cathrine *dsl.EOA, nonce uint64) {
+	require.NoError(t, ts.New(t.Ctx(), seqtypes.BuildOpts{Parent: parent, L1Origin: &l1Origin}))
+
+	// include simple transfer tx in opened block
+	{
+		to := cathrine.PlanTransfer(alice.Address(), eth.OneWei)
+		opt := txplan.Combine(to, txplan.WithStaticNonce(nonce))
+		ptx := txplan.NewPlannedTx(opt)
+		signed_tx, err := ptx.Signed.Eval(t.Ctx())
+		require.NoError(t, err, "Expected to be able to evaluate a planned transaction on op-test-sequencer, but got error")
+		txdata, err := signed_tx.MarshalBinary()
+		require.NoError(t, err, "Expected to be able to marshal a signed transaction on op-test-sequencer, but got error")
+
+		err = ts.IncludeTx(t.Ctx(), txdata)
+		require.NoError(t, err, "Expected to be able to include a signed transaction on op-test-sequencer, but got error")
+	}
+
+	require.NoError(t, ts.Next(t.Ctx()))
+}

--- a/op-acceptance-tests/tests/batcher/batcher_test.go
+++ b/op-acceptance-tests/tests/batcher/batcher_test.go
@@ -24,7 +24,6 @@ func TestBatcherFullChannelsAfterDowntime(gt *testing.T) {
 	sys := presets.NewSingleChainMultiNodeWithTestSeq(t)
 	l := t.Logger()
 	ts_L2 := sys.TestSequencer.Escape().ControlAPI(sys.L2EL.ChainID())
-	ts_L1 := sys.TestSequencer.Escape().ControlAPI(sys.L1Network.ChainID())
 
 	alice := sys.FunderL2.NewFundedEOA(eth.OneWei)
 	cathrine := sys.FunderL2.NewFundedEOA(eth.OneTenthEther)
@@ -53,7 +52,7 @@ func TestBatcherFullChannelsAfterDowntime(gt *testing.T) {
 		}
 
 		l.Debug("Sequencing L1 block", "iteration_j", j)
-		sequenceBlock(t, ts_L1, common.Hash{})
+		sys.TestSequencer.SequenceBlock(t, sys.L1Network.ChainID(), common.Hash{})
 	}
 
 	sys.L2CL.StartSequencer()
@@ -94,11 +93,6 @@ func TestBatcherFullChannelsAfterDowntime(gt *testing.T) {
 
 	status := sys.L2CL.SyncStatus()
 	spew.Dump(status)
-}
-
-func sequenceBlock(t devtest.T, ts apis.TestSequencerControlAPI, parent common.Hash) {
-	require.NoError(t, ts.New(t.Ctx(), seqtypes.BuildOpts{Parent: parent}))
-	require.NoError(t, ts.Next(t.Ctx()))
 }
 
 func sequenceBlockWithL1Origin(t devtest.T, ts apis.TestSequencerControlAPI, parent common.Hash, l1Origin common.Hash, alice *dsl.EOA, cathrine *dsl.EOA, nonce uint64) {

--- a/op-acceptance-tests/tests/batcher/batcher_test.go
+++ b/op-acceptance-tests/tests/batcher/batcher_test.go
@@ -49,6 +49,7 @@ func TestBatcherFullChannelsAfterDowntime(gt *testing.T) {
 			parent = sys.L2CL.HeadBlockRef(types.LocalUnsafe).Hash
 
 			sys.AdvanceTime(time.Second * 2)
+			time.Sleep(20 * time.Millisecond) // failed to force-include tx: type: 2 sender; err: nonce too high
 		}
 
 		l.Debug("Sequencing L1 block", "iteration_j", j)
@@ -68,7 +69,7 @@ func TestBatcherFullChannelsAfterDowntime(gt *testing.T) {
 			l.Info("Channel details", "channelID", c.String(), "frameCount", len(channelFrames[c]), "dataLength_frame0", len(channelFrames[c][0].Data))
 		}
 
-		require.Equal(t, 10, len(channels)) // we expect a total of 10 channels, due to existing MaxChannelDuration bug filed at: https://github.com/ethereum-optimism/optimism/issues/18092
+		require.Equal(t, 2, len(channels)) // we expect a total of 2 channels
 
 		// values are dependent on:
 		// - MaxPendingTransactions
@@ -79,16 +80,8 @@ func TestBatcherFullChannelsAfterDowntime(gt *testing.T) {
 			max  int
 			note string
 		}{
-			{min: 7_000, max: 10_000, note: "channel 0 - the first 100 blocks"},
-			{min: 100, max: 1000, note: "channel 1 - only a few blocks due to racy behavior, nowhere near the channel capacity"},
-			{min: 100, max: 1000, note: "channel 2 - only a few blocks due to racy behavior, nowhere near the channel capacity"},
-			{min: 100, max: 1000, note: "channel 3 - only a few blocks due to racy behavior, nowhere near the channel capacity"},
-			{min: 100, max: 1000, note: "channel 4 - only a few blocks due to racy behavior, nowhere near the channel capacity"},
-			{min: 100, max: 1000, note: "channel 5 - only a few blocks due to racy behavior, nowhere near the channel capacity"},
-			{min: 100, max: 1000, note: "channel 6 - only a few blocks due to racy behavior, nowhere near the channel capacity"},
-			{min: 100, max: 1000, note: "channel 7 - only a few blocks due to racy behavior, nowhere near the channel capacity"},
-			{min: 20_000, max: 40_000, note: "channel 8 - filled to the max capacity, due to blocking behavior because of MaxPendingTransactions limit reached"},
-			{min: 20_000, max: 40_000, note: "channel 9 - filled to the max capacity, due to blocking behavior because of MaxPendingTransactions limit reached"},
+			{min: 30_000, max: 40_000, note: "channel 0 - filled to the max capacity"},
+			{min: 30_000, max: 40_000, note: "channel 1 - remaining data, filling channel close to max capacity"},
 		}
 
 		for i, entry := range sizeRanges {

--- a/op-acceptance-tests/tests/batcher/batcher_test.go
+++ b/op-acceptance-tests/tests/batcher/batcher_test.go
@@ -99,9 +99,6 @@ func TestBatcherFullChannelsAfterDowntime(gt *testing.T) {
 		require.Equal(t, len(l2Txs[cathrine.Address()]), 1000) // we expect 1000 transactions total sent from cathrine to alice
 	}
 
-	//sys.L2Chain.PrintChain()
-	//sys.L1Network.PrintChain()
-
 	status := sys.L2CL.SyncStatus()
 	spew.Dump(status)
 }

--- a/op-acceptance-tests/tests/batcher/init_test.go
+++ b/op-acceptance-tests/tests/batcher/init_test.go
@@ -1,0 +1,33 @@
+package batcher
+
+import (
+	"testing"
+	"time"
+
+	bss "github.com/ethereum-optimism/optimism/op-batcher/batcher"
+	"github.com/ethereum-optimism/optimism/op-devstack/compat"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+)
+
+func TestMain(m *testing.M) {
+	presets.DoMain(m, presets.WithSingleChainMultiNode(),
+		presets.WithExecutionLayerSyncOnVerifiers(),
+		presets.WithCompatibleTypes(compat.SysGo),
+		presets.WithNoDiscovery(),
+		presets.WithTimeTravel(),
+		stack.MakeCommon(sysgo.WithBatcherOption(func(id stack.L2BatcherID, cfg *bss.CLIConfig) {
+			cfg.Stopped = true
+
+			// set the blob max size to 40_000 bytes for test purposes
+			cfg.MaxL1TxSize = 40_000
+			cfg.TestUseMaxTxSizeForBlobs = true
+
+			cfg.PollInterval = 1000 * time.Millisecond
+
+			cfg.MaxChannelDuration = 50 // not sure if this is reasonable, or should be larger?
+			cfg.MaxPendingTransactions = 7
+		})),
+	)
+}

--- a/op-acceptance-tests/tests/batcher/init_test.go
+++ b/op-acceptance-tests/tests/batcher/init_test.go
@@ -26,7 +26,7 @@ func TestMain(m *testing.M) {
 
 			cfg.PollInterval = 1000 * time.Millisecond
 
-			cfg.MaxChannelDuration = 50 // not sure if this is reasonable, or should be larger?
+			cfg.MaxChannelDuration = 50
 			cfg.MaxPendingTransactions = 7
 		})),
 	)

--- a/op-acceptance-tests/tests/interop/reorgs/l2_reorgs_after_l1_reorg_test.go
+++ b/op-acceptance-tests/tests/interop/reorgs/l2_reorgs_after_l1_reorg_test.go
@@ -8,10 +8,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack/match"
-	"github.com/ethereum-optimism/optimism/op-service/apis"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
-	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
@@ -66,7 +64,6 @@ func testL2ReorgAfterL1Reorg(gt *testing.T, n int, preChecks, postChecks checksF
 	ctx := t.Ctx()
 
 	sys := presets.NewSimpleInterop(t)
-	ts := sys.TestSequencer.Escape().ControlAPI(sys.L1Network.ChainID())
 
 	cl := sys.L1Network.Escape().L1CLNode(match.FirstL1CL)
 
@@ -76,7 +73,7 @@ func testL2ReorgAfterL1Reorg(gt *testing.T, n int, preChecks, postChecks checksF
 
 	// sequence a few L1 and L2 blocks
 	for range n + 1 {
-		sequenceL1Block(t, ts, common.Hash{})
+		sys.TestSequencer.SequenceBlock(t, sys.L1Network.ChainID(), common.Hash{})
 
 		sys.L2ChainA.WaitForBlock()
 		sys.L2ChainA.WaitForBlock()
@@ -101,7 +98,7 @@ func testL2ReorgAfterL1Reorg(gt *testing.T, n int, preChecks, postChecks checksF
 	tipL2_preReorg := sys.L2ELA.BlockRefByLabel(eth.Unsafe)
 
 	// reorg the L1 chain -- sequence an alternative L1 block from divergence block parent
-	sequenceL1Block(t, ts, divergence.ParentHash)
+	sys.TestSequencer.SequenceBlock(t, sys.L1Network.ChainID(), divergence.ParentHash)
 
 	// continue building on the alternative L1 chain
 	sys.ControlPlane.FakePoSState(cl.ID(), stack.Start)
@@ -159,9 +156,4 @@ func testL2ReorgAfterL1Reorg(gt *testing.T, n int, preChecks, postChecks checksF
 
 	// post reorg test validations and checks
 	postChecks(t, sys)
-}
-
-func sequenceL1Block(t devtest.T, ts apis.TestSequencerControlAPI, parent common.Hash) {
-	require.NoError(t, ts.New(t.Ctx(), seqtypes.BuildOpts{Parent: parent}))
-	require.NoError(t, ts.Next(t.Ctx()))
 }

--- a/op-batcher/batcher/channel.go
+++ b/op-batcher/batcher/channel.go
@@ -27,7 +27,7 @@ type channel struct {
 }
 
 func newChannel(log log.Logger, metr metrics.Metricer, cfg ChannelConfig, rollupCfg *rollup.Config, latestL1OriginBlockNum uint64, channelOut derive.ChannelOut) *channel {
-	cb := NewChannelBuilderWithChannelOut(cfg, rollupCfg, latestL1OriginBlockNum, channelOut)
+	cb := NewChannelBuilderWithChannelOut(log, cfg, rollupCfg, latestL1OriginBlockNum, channelOut)
 	return &channel{
 		ChannelBuilder:        cb,
 		log:                   log,

--- a/op-batcher/batcher/channel_builder.go
+++ b/op-batcher/batcher/channel_builder.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/queue"
+	"github.com/ethereum/go-ethereum/log"
 )
 
 var (
@@ -47,6 +48,7 @@ type frameData struct {
 // ChannelBuilder uses a ChannelOut to create a channel with output frame
 // size approximation.
 type ChannelBuilder struct {
+	log       log.Logger
 	cfg       ChannelConfig
 	rollupCfg *rollup.Config
 
@@ -87,8 +89,9 @@ type ChannelBuilder struct {
 	outputBytes int
 }
 
-func NewChannelBuilderWithChannelOut(cfg ChannelConfig, rollupCfg *rollup.Config, latestL1OriginBlockNum uint64, channelOut derive.ChannelOut) *ChannelBuilder {
+func NewChannelBuilderWithChannelOut(log log.Logger, cfg ChannelConfig, rollupCfg *rollup.Config, latestL1OriginBlockNum uint64, channelOut derive.ChannelOut) *ChannelBuilder {
 	cb := &ChannelBuilder{
+		log:       log.With("channel_id", channelOut.ID()),
 		cfg:       cfg,
 		rollupCfg: rollupCfg,
 		co:        channelOut,
@@ -224,8 +227,7 @@ func (c *ChannelBuilder) updateDurationTimeout(l1BlockNum uint64) {
 	if c.cfg.MaxChannelDuration == 0 {
 		return
 	}
-	timeout := l1BlockNum + c.cfg.MaxChannelDuration
-	c.updateTimeout(timeout, ErrMaxDurationReached)
+	c.updateTimeout(l1BlockNum+c.cfg.MaxChannelDuration, ErrMaxDurationReached)
 }
 
 // updateSwTimeout updates the block timeout with the sequencer window timeout
@@ -244,6 +246,7 @@ func (c *ChannelBuilder) updateSwTimeout(l1InfoNumber uint64) {
 // full error reason in case the timeout is hit in the future.
 func (c *ChannelBuilder) updateTimeout(timeoutBlockNum uint64, reason error) {
 	if c.timeout == 0 || c.timeout > timeoutBlockNum {
+		c.log.Debug("setting timeout", "number", timeoutBlockNum, "timeout", c.timeout)
 		c.timeout = timeoutBlockNum
 		c.timeoutReason = reason
 	}
@@ -252,15 +255,10 @@ func (c *ChannelBuilder) updateTimeout(timeoutBlockNum uint64, reason error) {
 // CheckTimeout checks if the channel is timed out at the given block number and
 // in this case marks the channel as full, if it wasn't full already.
 func (c *ChannelBuilder) CheckTimeout(l1BlockNum uint64) {
-	if !c.IsFull() && c.TimedOut(l1BlockNum) {
+	if c.timeout != 0 && !c.IsFull() && l1BlockNum >= c.timeout {
+		c.log.Debug("checking timeout", "l1blockNum", l1BlockNum, "timeout", c.timeout)
 		c.setFullErr(c.timeoutReason)
 	}
-}
-
-// TimedOut returns whether the passed block number is after the timeout block
-// number. If no block timeout is set yet, it returns false.
-func (c *ChannelBuilder) TimedOut(blockNum uint64) bool {
-	return c.timeout != 0 && blockNum >= c.timeout
 }
 
 // IsFull returns whether the channel is full.

--- a/op-batcher/batcher/channel_builder_test.go
+++ b/op-batcher/batcher/channel_builder_test.go
@@ -14,8 +14,10 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	dtest "github.com/ethereum-optimism/optimism/op-node/rollup/derive/test"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/trie"
 
@@ -32,13 +34,13 @@ var defaultTestRollupConfig = &rollup.Config{
 // newChannelBuilder creates a new channel builder or returns an error if the
 // channel out could not be created.
 // it acts as a factory for either a span or singular channel out
-func newChannelBuilder(cfg ChannelConfig, rollupCfg *rollup.Config, latestL1OriginBlockNum uint64) (*ChannelBuilder, error) {
+func newChannelBuilder(log log.Logger, cfg ChannelConfig, rollupCfg *rollup.Config, latestL1OriginBlockNum uint64) (*ChannelBuilder, error) {
 	co, err := NewChannelOut(cfg, rollupCfg)
 	if err != nil {
 		return nil, fmt.Errorf("creating channel out: %w", err)
 	}
 
-	return NewChannelBuilderWithChannelOut(cfg, rollupCfg, latestL1OriginBlockNum, co), nil
+	return NewChannelBuilderWithChannelOut(log, cfg, rollupCfg, latestL1OriginBlockNum, co), nil
 }
 
 // addMiniBlock adds a minimal valid L2 block to the channel builder using the
@@ -166,23 +168,6 @@ func addTooManyBlocks(cb *ChannelBuilder, blockCount int) (int, error) {
 	return blockCount, nil
 }
 
-// FuzzDurationTimeoutZeroMaxChannelDuration ensures that when whenever the MaxChannelDuration
-// is set to 0, the channel builder cannot have a duration timeout.
-func FuzzDurationTimeoutZeroMaxChannelDuration(f *testing.F) {
-	for i := range [10]int{} {
-		f.Add(uint64(i))
-	}
-	f.Fuzz(func(t *testing.T, l1BlockNum uint64) {
-		channelConfig := defaultTestChannelConfig()
-		channelConfig.MaxChannelDuration = 0
-		cb, err := newChannelBuilder(channelConfig, defaultTestRollupConfig, latestL1BlockOrigin)
-		require.NoError(t, err)
-		cb.timeout = 0
-		cb.updateDurationTimeout(l1BlockNum)
-		require.False(t, cb.TimedOut(l1BlockNum))
-	})
-}
-
 // FuzzChannelBuilder_DurationZero ensures that when whenever the MaxChannelDuration
 // is not set to 0, the channel builder will always have a duration timeout
 // as long as the channel builder's timeout is set to 0.
@@ -195,10 +180,11 @@ func FuzzChannelBuilder_DurationZero(f *testing.F) {
 			t.Skip("Max channel duration cannot be 0")
 		}
 
+		log := testlog.Logger(t, log.LvlInfo)
 		// Create the channel builder
 		channelConfig := defaultTestChannelConfig()
 		channelConfig.MaxChannelDuration = maxChannelDuration
-		cb, err := newChannelBuilder(channelConfig, defaultTestRollupConfig, latestL1BlockOrigin)
+		cb, err := newChannelBuilder(log, channelConfig, defaultTestRollupConfig, latestL1BlockOrigin)
 		require.NoError(t, err)
 
 		// Whenever the timeout is set to 0, the channel builder should have a duration timeout
@@ -222,10 +208,11 @@ func FuzzDurationTimeoutMaxChannelDuration(f *testing.F) {
 			t.Skip("Max channel duration cannot be 0")
 		}
 
+		log := testlog.Logger(t, log.LvlInfo)
 		// Create the channel builder
 		channelConfig := defaultTestChannelConfig()
 		channelConfig.MaxChannelDuration = maxChannelDuration
-		cb, err := newChannelBuilder(channelConfig, defaultTestRollupConfig, latestL1BlockOrigin)
+		cb, err := newChannelBuilder(log, channelConfig, defaultTestRollupConfig, latestL1BlockOrigin)
 		require.NoError(t, err)
 
 		// Whenever the timeout is greater than the l1BlockNum,
@@ -255,11 +242,12 @@ func FuzzChannelCloseTimeout(f *testing.F) {
 		f.Add(uint64(i), uint64(i), uint64(i), uint64(i*5))
 	}
 	f.Fuzz(func(t *testing.T, l1BlockNum uint64, channelTimeout uint64, subSafetyMargin uint64, timeout uint64) {
+		log := testlog.Logger(t, log.LvlInfo)
 		// Create the channel builder
 		channelConfig := defaultTestChannelConfig()
 		channelConfig.ChannelTimeout = channelTimeout
 		channelConfig.SubSafetyMargin = subSafetyMargin
-		cb, err := newChannelBuilder(channelConfig, defaultTestRollupConfig, latestL1BlockOrigin)
+		cb, err := newChannelBuilder(log, channelConfig, defaultTestRollupConfig, latestL1BlockOrigin)
 		require.NoError(t, err)
 
 		// Check the timeout
@@ -283,11 +271,12 @@ func FuzzChannelZeroCloseTimeout(f *testing.F) {
 		f.Add(uint64(i), uint64(i), uint64(i))
 	}
 	f.Fuzz(func(t *testing.T, l1BlockNum uint64, channelTimeout uint64, subSafetyMargin uint64) {
+		log := testlog.Logger(t, log.LvlInfo)
 		// Create the channel builder
 		channelConfig := defaultTestChannelConfig()
 		channelConfig.ChannelTimeout = channelTimeout
 		channelConfig.SubSafetyMargin = subSafetyMargin
-		cb, err := newChannelBuilder(channelConfig, defaultTestRollupConfig, latestL1BlockOrigin)
+		cb, err := newChannelBuilder(log, channelConfig, defaultTestRollupConfig, latestL1BlockOrigin)
 		require.NoError(t, err)
 
 		// Check the timeout
@@ -310,11 +299,12 @@ func FuzzSeqWindowClose(f *testing.F) {
 		f.Add(uint64(i), uint64(i), uint64(i), uint64(i*5))
 	}
 	f.Fuzz(func(t *testing.T, epochNum uint64, seqWindowSize uint64, subSafetyMargin uint64, timeout uint64) {
+		log := testlog.Logger(t, log.LvlInfo)
 		// Create the channel builder
 		channelConfig := defaultTestChannelConfig()
 		channelConfig.SeqWindowSize = seqWindowSize
 		channelConfig.SubSafetyMargin = subSafetyMargin
-		cb, err := newChannelBuilder(channelConfig, defaultTestRollupConfig, latestL1BlockOrigin)
+		cb, err := newChannelBuilder(log, channelConfig, defaultTestRollupConfig, latestL1BlockOrigin)
 		require.NoError(t, err)
 
 		// Check the timeout
@@ -338,11 +328,12 @@ func FuzzSeqWindowZeroTimeoutClose(f *testing.F) {
 		f.Add(uint64(i), uint64(i), uint64(i))
 	}
 	f.Fuzz(func(t *testing.T, epochNum uint64, seqWindowSize uint64, subSafetyMargin uint64) {
+		log := testlog.Logger(t, log.LvlInfo)
 		// Create the channel builder
 		channelConfig := defaultTestChannelConfig()
 		channelConfig.SeqWindowSize = seqWindowSize
 		channelConfig.SubSafetyMargin = subSafetyMargin
-		cb, err := newChannelBuilder(channelConfig, defaultTestRollupConfig, latestL1BlockOrigin)
+		cb, err := newChannelBuilder(log, channelConfig, defaultTestRollupConfig, latestL1BlockOrigin)
 		require.NoError(t, err)
 
 		// Check the timeout
@@ -387,10 +378,11 @@ func TestChannelBuilderBatchType(t *testing.T) {
 
 // TestChannelBuilder_NextFrame tests calling NextFrame on a ChannelBuilder with only one frame
 func TestChannelBuilder_NextFrame(t *testing.T) {
+	log := testlog.Logger(t, log.LvlInfo)
 	channelConfig := defaultTestChannelConfig()
 
 	// Create a new channel builder
-	cb, err := newChannelBuilder(channelConfig, defaultTestRollupConfig, latestL1BlockOrigin)
+	cb, err := newChannelBuilder(log, channelConfig, defaultTestRollupConfig, latestL1BlockOrigin)
 	require.NoError(t, err)
 
 	// Mock the internals of `ChannelBuilder.outputFrame`
@@ -427,11 +419,12 @@ func TestChannelBuilder_NextFrame(t *testing.T) {
 
 // TestChannelBuilder_OutputWrongFramePanic tests that a panic is thrown when we try to rewind the cursor with an invalid frame id
 func ChannelBuilder_OutputWrongFramePanic(t *testing.T, batchType uint) {
+	log := testlog.Logger(t, log.LvlInfo)
 	channelConfig := defaultTestChannelConfig()
 	channelConfig.BatchType = batchType
 
 	// Construct a channel builder
-	cb, err := newChannelBuilder(channelConfig, defaultTestRollupConfig, latestL1BlockOrigin)
+	cb, err := newChannelBuilder(log, channelConfig, defaultTestRollupConfig, latestL1BlockOrigin)
 	require.NoError(t, err)
 
 	// Mock the internals of `ChannelBuilder.outputFrame`
@@ -461,13 +454,14 @@ func ChannelBuilder_OutputWrongFramePanic(t *testing.T, batchType uint) {
 
 // TestChannelBuilder_OutputFrames tests [ChannelBuilder.OutputFrames] for singular batches.
 func TestChannelBuilder_OutputFrames(t *testing.T) {
+	log := testlog.Logger(t, log.LvlInfo)
 	channelConfig := defaultTestChannelConfig()
 	channelConfig.MaxFrameSize = derive.FrameV0OverHeadSize + 1
 	channelConfig.TargetNumFrames = 1000
 	channelConfig.InitNoneCompressor()
 
 	// Construct the channel builder
-	cb, err := newChannelBuilder(channelConfig, defaultTestRollupConfig, latestL1BlockOrigin)
+	cb, err := newChannelBuilder(log, channelConfig, defaultTestRollupConfig, latestL1BlockOrigin)
 	require.NoError(t, err)
 	require.False(t, cb.IsFull())
 	require.Equal(t, 0, cb.PendingFrames())
@@ -510,6 +504,7 @@ func TestChannelBuilder_OutputFrames_SpanBatch(t *testing.T) {
 }
 
 func ChannelBuilder_OutputFrames_SpanBatch(t *testing.T, algo derive.CompressionAlgo) {
+	log := testlog.Logger(t, log.LvlInfo)
 	channelConfig := defaultTestChannelConfig()
 	channelConfig.MaxFrameSize = 20 + derive.FrameV0OverHeadSize
 	if algo.IsBrotli() {
@@ -521,7 +516,7 @@ func ChannelBuilder_OutputFrames_SpanBatch(t *testing.T, algo derive.Compression
 	channelConfig.InitRatioCompressor(1, algo)
 
 	// Construct the channel builder
-	cb, err := newChannelBuilder(channelConfig, defaultTestRollupConfig, latestL1BlockOrigin)
+	cb, err := newChannelBuilder(log, channelConfig, defaultTestRollupConfig, latestL1BlockOrigin)
 	require.NoError(t, err)
 	require.False(t, cb.IsFull())
 	require.Equal(t, 0, cb.PendingFrames())
@@ -572,6 +567,7 @@ func ChannelBuilder_OutputFrames_SpanBatch(t *testing.T, algo derive.Compression
 // function errors when the max RLP bytes per channel is reached.
 func ChannelBuilder_MaxRLPBytesPerChannel(t *testing.T, batchType uint) {
 	t.Parallel()
+	log := testlog.Logger(t, log.LvlInfo)
 	channelConfig := defaultTestChannelConfig()
 	chainSpec := rollup.NewChainSpec(defaultTestRollupConfig)
 	channelConfig.MaxFrameSize = chainSpec.MaxRLPBytesPerChannel(latestL1BlockOrigin) * 2
@@ -579,7 +575,7 @@ func ChannelBuilder_MaxRLPBytesPerChannel(t *testing.T, batchType uint) {
 	channelConfig.BatchType = batchType
 
 	// Construct the channel builder
-	cb, err := newChannelBuilder(channelConfig, defaultTestRollupConfig, latestL1BlockOrigin)
+	cb, err := newChannelBuilder(log, channelConfig, defaultTestRollupConfig, latestL1BlockOrigin)
 	require.NoError(t, err)
 
 	// Add a block that overflows the [ChannelOut]
@@ -594,6 +590,7 @@ func ChannelBuilder_MaxRLPBytesPerChannel(t *testing.T, batchType uint) {
 // then check postFjord w/ double the amount of blocks
 func ChannelBuilder_MaxRLPBytesPerChannelFjord(t *testing.T, batchType uint) {
 	t.Parallel()
+	log := testlog.Logger(t, log.LvlInfo)
 	channelConfig := defaultTestChannelConfig()
 	chainSpec := rollup.NewChainSpec(defaultTestRollupConfig)
 	channelConfig.MaxFrameSize = chainSpec.MaxRLPBytesPerChannel(latestL1BlockOrigin) * 2
@@ -601,7 +598,7 @@ func ChannelBuilder_MaxRLPBytesPerChannelFjord(t *testing.T, batchType uint) {
 	channelConfig.BatchType = batchType
 
 	// Construct the channel builder
-	cb, err := newChannelBuilder(channelConfig, defaultTestRollupConfig, latestL1BlockOrigin)
+	cb, err := newChannelBuilder(log, channelConfig, defaultTestRollupConfig, latestL1BlockOrigin)
 	require.NoError(t, err)
 
 	// Count how many a block that overflows the [ChannelOut]
@@ -622,7 +619,7 @@ func ChannelBuilder_MaxRLPBytesPerChannelFjord(t *testing.T, batchType uint) {
 	channelConfig.InitNoneCompressor()
 	channelConfig.BatchType = batchType
 
-	cb, err = newChannelBuilder(channelConfig, rollupConfig, latestL1BlockOrigin)
+	cb, err = newChannelBuilder(log, channelConfig, rollupConfig, latestL1BlockOrigin)
 	require.NoError(t, err)
 
 	// try add double the amount of block, it should not error
@@ -634,6 +631,7 @@ func ChannelBuilder_MaxRLPBytesPerChannelFjord(t *testing.T, batchType uint) {
 // ChannelBuilder_OutputFramesMaxFrameIndex tests the [ChannelBuilder.OutputFrames]
 // function errors when the max frame index is reached.
 func ChannelBuilder_OutputFramesMaxFrameIndex(t *testing.T, batchType uint) {
+	log := testlog.Logger(t, log.LvlInfo)
 	channelConfig := defaultTestChannelConfig()
 	channelConfig.MaxFrameSize = derive.FrameV0OverHeadSize + 1
 	channelConfig.TargetNumFrames = math.MaxUint16 + 1
@@ -645,7 +643,7 @@ func ChannelBuilder_OutputFramesMaxFrameIndex(t *testing.T, batchType uint) {
 	// Continuously add blocks until the max frame index is reached
 	// This should cause the [ChannelBuilder.OutputFrames] function
 	// to error
-	cb, err := newChannelBuilder(channelConfig, defaultTestRollupConfig, latestL1BlockOrigin)
+	cb, err := newChannelBuilder(log, channelConfig, defaultTestRollupConfig, latestL1BlockOrigin)
 	require.NoError(t, err)
 	require.False(t, cb.IsFull())
 	require.Equal(t, 0, cb.PendingFrames())
@@ -673,6 +671,7 @@ func ChannelBuilder_OutputFramesMaxFrameIndex(t *testing.T, batchType uint) {
 // [derive.FrameV0OverHeadSize] in [MaxDataSize] is omitted, which has been the
 // case before it got fixed it #9887.
 func TestChannelBuilder_FullShadowCompressor(t *testing.T) {
+	log := testlog.Logger(t, log.LvlInfo)
 	require := require.New(t)
 	cfg := ChannelConfig{
 		MaxFrameSize:    752,
@@ -681,7 +680,7 @@ func TestChannelBuilder_FullShadowCompressor(t *testing.T) {
 	}
 
 	cfg.InitShadowCompressor(derive.Zlib)
-	cb, err := newChannelBuilder(cfg, defaultTestRollupConfig, latestL1BlockOrigin)
+	cb, err := newChannelBuilder(log, cfg, defaultTestRollupConfig, latestL1BlockOrigin)
 	require.NoError(err)
 
 	rng := rand.New(rand.NewSource(420))
@@ -703,6 +702,7 @@ func TestChannelBuilder_FullShadowCompressor(t *testing.T) {
 }
 
 func ChannelBuilder_AddBlock(t *testing.T, batchType uint) {
+	log := testlog.Logger(t, log.LvlInfo)
 	channelConfig := defaultTestChannelConfig()
 	channelConfig.BatchType = batchType
 
@@ -713,7 +713,7 @@ func ChannelBuilder_AddBlock(t *testing.T, batchType uint) {
 	channelConfig.InitRatioCompressor(1, derive.Zlib)
 
 	// Construct the channel builder
-	cb, err := newChannelBuilder(channelConfig, defaultTestRollupConfig, latestL1BlockOrigin)
+	cb, err := newChannelBuilder(log, channelConfig, defaultTestRollupConfig, latestL1BlockOrigin)
 	require.NoError(t, err)
 
 	// Add a nonsense block to the channel builder
@@ -736,10 +736,11 @@ func ChannelBuilder_AddBlock(t *testing.T, batchType uint) {
 }
 
 func TestChannelBuilder_CheckTimeout(t *testing.T) {
+	log := testlog.Logger(t, log.LvlInfo)
 	channelConfig := defaultTestChannelConfig()
 
 	// Construct the channel builder
-	cb, err := newChannelBuilder(channelConfig, defaultTestRollupConfig, latestL1BlockOrigin)
+	cb, err := newChannelBuilder(log, channelConfig, defaultTestRollupConfig, latestL1BlockOrigin)
 	require.NoError(t, err)
 
 	// Assert timeout is setup correctly
@@ -758,13 +759,14 @@ func TestChannelBuilder_CheckTimeout(t *testing.T) {
 }
 
 func TestChannelBuilder_CheckTimeoutZeroMaxChannelDuration(t *testing.T) {
+	log := testlog.Logger(t, log.LvlInfo)
 	channelConfig := defaultTestChannelConfig()
 
 	// Set the max channel duration to 0
 	channelConfig.MaxChannelDuration = 0
 
 	// Construct the channel builder
-	cb, err := newChannelBuilder(channelConfig, defaultTestRollupConfig, latestL1BlockOrigin)
+	cb, err := newChannelBuilder(log, channelConfig, defaultTestRollupConfig, latestL1BlockOrigin)
 	require.NoError(t, err)
 
 	// Without a max channel duration, timeout should not be set
@@ -781,13 +783,14 @@ func TestChannelBuilder_CheckTimeoutZeroMaxChannelDuration(t *testing.T) {
 }
 
 func TestChannelBuilder_FramePublished(t *testing.T) {
+	log := testlog.Logger(t, log.LvlInfo)
 	cfg := defaultTestChannelConfig()
 	cfg.MaxChannelDuration = 10_000
 	cfg.ChannelTimeout = 1000
 	cfg.SubSafetyMargin = 100
 
 	// Construct the channel builder
-	cb, err := newChannelBuilder(cfg, defaultTestRollupConfig, latestL1BlockOrigin)
+	cb, err := newChannelBuilder(log, cfg, defaultTestRollupConfig, latestL1BlockOrigin)
 	require.NoError(t, err)
 	require.Equal(t, latestL1BlockOrigin+cfg.MaxChannelDuration, cb.timeout)
 
@@ -804,9 +807,10 @@ func TestChannelBuilder_FramePublished(t *testing.T) {
 }
 
 func TestChannelBuilder_LatestL1Origin(t *testing.T) {
-	cb, err := newChannelBuilder(defaultTestChannelConfig(), defaultTestRollupConfig, latestL1BlockOrigin)
+	log := testlog.Logger(t, log.LvlInfo)
+	cb, err := newChannelBuilder(log, defaultTestChannelConfig(), defaultTestRollupConfig, latestL1BlockOrigin)
 	require.NoError(t, err)
-	require.Equal(t, eth.BlockID{}, cb.LatestL1Origin())
+	require.Equal(t, eth.BlockID{}, cb.LatestL1Origin(), "LatestL1Origin should be empty")
 
 	_, err = cb.AddBlock(SizedBlock{Block: newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(1), common.Hash{}, 1, 100)})
 	require.NoError(t, err)
@@ -826,7 +830,8 @@ func TestChannelBuilder_LatestL1Origin(t *testing.T) {
 }
 
 func TestChannelBuilder_OldestL1Origin(t *testing.T) {
-	cb, err := newChannelBuilder(defaultTestChannelConfig(), defaultTestRollupConfig, latestL1BlockOrigin)
+	log := testlog.Logger(t, log.LvlInfo)
+	cb, err := newChannelBuilder(log, defaultTestChannelConfig(), defaultTestRollupConfig, latestL1BlockOrigin)
 	require.NoError(t, err)
 	require.Equal(t, eth.BlockID{}, cb.OldestL1Origin())
 
@@ -848,7 +853,8 @@ func TestChannelBuilder_OldestL1Origin(t *testing.T) {
 }
 
 func TestChannelBuilder_LatestL2(t *testing.T) {
-	cb, err := newChannelBuilder(defaultTestChannelConfig(), defaultTestRollupConfig, latestL1BlockOrigin)
+	log := testlog.Logger(t, log.LvlInfo)
+	cb, err := newChannelBuilder(log, defaultTestChannelConfig(), defaultTestRollupConfig, latestL1BlockOrigin)
 	require.NoError(t, err)
 	require.Equal(t, eth.BlockID{}, cb.LatestL2())
 
@@ -870,7 +876,8 @@ func TestChannelBuilder_LatestL2(t *testing.T) {
 }
 
 func TestChannelBuilder_OldestL2(t *testing.T) {
-	cb, err := newChannelBuilder(defaultTestChannelConfig(), defaultTestRollupConfig, latestL1BlockOrigin)
+	log := testlog.Logger(t, log.LvlInfo)
+	cb, err := newChannelBuilder(log, defaultTestChannelConfig(), defaultTestRollupConfig, latestL1BlockOrigin)
 	require.NoError(t, err)
 	require.Equal(t, eth.BlockID{}, cb.OldestL2())
 
@@ -892,6 +899,7 @@ func TestChannelBuilder_OldestL2(t *testing.T) {
 }
 
 func ChannelBuilder_PendingFrames_TotalFrames(t *testing.T, batchType uint) {
+	log := testlog.Logger(t, log.LvlInfo)
 	const tnf = 9
 	rng := rand.New(rand.NewSource(94572314))
 	require := require.New(t)
@@ -900,7 +908,7 @@ func ChannelBuilder_PendingFrames_TotalFrames(t *testing.T, batchType uint) {
 	cfg.TargetNumFrames = tnf
 	cfg.BatchType = batchType
 	cfg.InitShadowCompressor(derive.Zlib)
-	cb, err := newChannelBuilder(cfg, defaultTestRollupConfig, latestL1BlockOrigin)
+	cb, err := newChannelBuilder(log, cfg, defaultTestRollupConfig, latestL1BlockOrigin)
 	require.NoError(err)
 
 	// initial builder should be empty
@@ -936,6 +944,7 @@ func ChannelBuilder_PendingFrames_TotalFrames(t *testing.T, batchType uint) {
 }
 
 func ChannelBuilder_InputBytes(t *testing.T, batchType uint) {
+	log := testlog.Logger(t, log.LvlInfo)
 	require := require.New(t)
 	rng := rand.New(rand.NewSource(4982432))
 	cfg := defaultTestChannelConfig()
@@ -945,7 +954,7 @@ func ChannelBuilder_InputBytes(t *testing.T, batchType uint) {
 		chainId := big.NewInt(1234)
 		spanBatch = derive.NewSpanBatch(uint64(0), chainId)
 	}
-	cb, err := newChannelBuilder(cfg, defaultTestRollupConfig, latestL1BlockOrigin)
+	cb, err := newChannelBuilder(log, cfg, defaultTestRollupConfig, latestL1BlockOrigin)
 	require.NoError(err)
 
 	require.Zero(cb.InputBytes())
@@ -975,6 +984,7 @@ func ChannelBuilder_InputBytes(t *testing.T, batchType uint) {
 }
 
 func ChannelBuilder_OutputBytes(t *testing.T, batchType uint) {
+	log := testlog.Logger(t, log.LvlInfo)
 	require := require.New(t)
 	rng := rand.New(rand.NewSource(9860372))
 	cfg := defaultTestChannelConfig()
@@ -982,7 +992,7 @@ func ChannelBuilder_OutputBytes(t *testing.T, batchType uint) {
 	cfg.TargetNumFrames = 16
 	cfg.BatchType = batchType
 	cfg.InitRatioCompressor(1.0, derive.Zlib)
-	cb, err := newChannelBuilder(cfg, defaultTestRollupConfig, latestL1BlockOrigin)
+	cb, err := newChannelBuilder(log, cfg, defaultTestRollupConfig, latestL1BlockOrigin)
 	require.NoError(err, "NewChannelBuilder")
 
 	require.Zero(cb.OutputBytes())

--- a/op-batcher/batcher/channel_builder_test.go
+++ b/op-batcher/batcher/channel_builder_test.go
@@ -758,6 +758,25 @@ func TestChannelBuilder_CheckTimeout(t *testing.T) {
 	require.ErrorIs(t, cb.FullErr(), ErrMaxDurationReached)
 }
 
+func TestChannelBuilder_MaxChannelDurationZero(t *testing.T) {
+	log := testlog.Logger(t, log.LvlInfo)
+	channelConfig := defaultTestChannelConfig()
+	channelConfig.MaxChannelDuration = 0
+
+	// Construct the channel builder
+	cb, err := newChannelBuilder(log, channelConfig, defaultTestRollupConfig, latestL1BlockOrigin)
+	require.NoError(t, err)
+
+	// Assert timeout is setup correctly
+	require.Equal(t, uint64(0), channelConfig.MaxChannelDuration)
+
+	// Check a new L1 block which should not update the timeout, due to config setting MaxChannelDuration to 0
+	cb.CheckTimeout(uint64(12345))
+
+	require.Equal(t, uint64(0), cb.timeout)
+	require.NoError(t, cb.FullErr())
+}
+
 func TestChannelBuilder_CheckTimeoutZeroMaxChannelDuration(t *testing.T) {
 	log := testlog.Logger(t, log.LvlInfo)
 	channelConfig := defaultTestChannelConfig()

--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -224,8 +224,8 @@ func (s *channelManager) nextTxData(channel *channel) (txData, error) {
 // It will decide whether to switch DA type automatically.
 // When switching DA type, the channelManager state will be rebuilt
 // with a new ChannelConfig.
-func (s *channelManager) TxData(l1Head eth.BlockID, isPectra bool, isThrottling bool, forcePublish pubInfo) (txData, error) {
-	channel, err := s.getReadyChannel(l1Head, forcePublish)
+func (s *channelManager) TxData(l1Head eth.BlockID, isPectra bool, isThrottling bool, pi pubInfo) (txData, error) {
+	channel, err := s.getReadyChannel(l1Head, pi)
 	if err != nil {
 		return emptyTxData, err
 	}
@@ -259,7 +259,7 @@ func (s *channelManager) TxData(l1Head eth.BlockID, isPectra bool, isThrottling 
 	s.defaultCfg = newCfg
 
 	// Try again to get data to send on chain.
-	channel, err = s.getReadyChannel(l1Head, forcePublish)
+	channel, err = s.getReadyChannel(l1Head, pi)
 	if err != nil {
 		return emptyTxData, err
 	}
@@ -318,7 +318,12 @@ func (s *channelManager) getReadyChannel(l1Head eth.BlockID, pi pubInfo) (*chann
 		return nil, err
 	}
 
-	s.registerL1Block(l1Head)
+	if !pi.moreComing {
+		// Register current L1 head only after all pending blocks have been
+		// processed. Even if a timeout will be triggered now, it is better to have
+		// all pending blocks be included in this channel for submission.
+		s.registerL1Block(l1Head)
+	}
 
 	if err := s.outputFrames(); err != nil {
 		return nil, err

--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -266,9 +266,10 @@ func (s *channelManager) TxData(l1Head eth.BlockID, isPectra bool, isThrottling 
 	return s.nextTxData(channel)
 }
 
+// pubInfo is a struct that contains signal information sent on the publishSignal channel
 type pubInfo struct {
 	forcePublish bool
-	moreComing   bool
+	moreComing   bool // moreComing is set to true if there are more blocks to be processed while loading blocks into state
 }
 
 // getReadyChannel returns the next channel ready to submit data, or an error.

--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -268,8 +268,12 @@ func (s *channelManager) TxData(l1Head eth.BlockID, isPectra bool, isThrottling 
 
 // pubInfo is a struct that contains signal information sent on the publishSignal channel
 type pubInfo struct {
-	forcePublish      bool
-	publishingBacklog bool // publishingBacklog is set to true if there are more blocks to be processed while loading blocks into state
+	// forcePublish is set to true if the current channel should be force-closed and submitted now.
+	forcePublish bool
+
+	// ignoreMaxChannelDuration is set to true if we should keep the current channel open even if it's duration is exceeded.
+	// For example, if we know there are more blocks to load and we want to pack those into the current channel before sending it.
+	ignoreMaxChannelDuration bool
 }
 
 // getReadyChannel returns the next channel ready to submit data, or an error.
@@ -319,10 +323,12 @@ func (s *channelManager) getReadyChannel(l1Head eth.BlockID, pi pubInfo) (*chann
 		return nil, err
 	}
 
-	if !pi.publishingBacklog {
-		// Register current L1 head only after all pending blocks have been
-		// processed. Even if a timeout will be triggered now, it is better to have
-		// all pending blocks be included in this channel for submission.
+	if !pi.ignoreMaxChannelDuration {
+		// Register current L1 head (which checks for the max duration timeout)
+		// only after all blocks in the manager's state have been
+		// processed, and only if we weren't told to ignore the max channel duration.
+		// The aim is to prefer to optimally pack blocks into channels when
+		// instead of timing out the channel when more blocks soon to be processed.
 		s.registerL1Block(l1Head)
 	}
 

--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -268,8 +268,8 @@ func (s *channelManager) TxData(l1Head eth.BlockID, isPectra bool, isThrottling 
 
 // pubInfo is a struct that contains signal information sent on the publishSignal channel
 type pubInfo struct {
-	forcePublish bool
-	moreComing   bool // moreComing is set to true if there are more blocks to be processed while loading blocks into state
+	forcePublish      bool
+	publishingBacklog bool // publishingBacklog is set to true if there are more blocks to be processed while loading blocks into state
 }
 
 // getReadyChannel returns the next channel ready to submit data, or an error.
@@ -319,7 +319,7 @@ func (s *channelManager) getReadyChannel(l1Head eth.BlockID, pi pubInfo) (*chann
 		return nil, err
 	}
 
-	if !pi.moreComing {
+	if !pi.publishingBacklog {
 		// Register current L1 head only after all pending blocks have been
 		// processed. Even if a timeout will be triggered now, it is better to have
 		// all pending blocks be included in this channel for submission.

--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -109,7 +109,6 @@ func (s *channelManager) TxFailed(_id txID) {
 // TxConfirmed marks a transaction as confirmed on L1. Only if the channel timed out
 // the channelManager's state is modified.
 func (s *channelManager) TxConfirmed(_id txID, inclusionBlock eth.BlockID) {
-
 	id := _id.String()
 	if channel, ok := s.txChannels[id]; ok {
 		delete(s.txChannels, id)
@@ -225,7 +224,7 @@ func (s *channelManager) nextTxData(channel *channel) (txData, error) {
 // It will decide whether to switch DA type automatically.
 // When switching DA type, the channelManager state will be rebuilt
 // with a new ChannelConfig.
-func (s *channelManager) TxData(l1Head eth.BlockID, isPectra, isThrottling, forcePublish bool) (txData, error) {
+func (s *channelManager) TxData(l1Head eth.BlockID, isPectra bool, isThrottling bool, forcePublish pubInfo) (txData, error) {
 	channel, err := s.getReadyChannel(l1Head, forcePublish)
 	if err != nil {
 		return emptyTxData, err
@@ -267,6 +266,11 @@ func (s *channelManager) TxData(l1Head eth.BlockID, isPectra, isThrottling, forc
 	return s.nextTxData(channel)
 }
 
+type pubInfo struct {
+	forcePublish bool
+	moreComing   bool
+}
+
 // getReadyChannel returns the next channel ready to submit data, or an error.
 // It will create a new channel if necessary.
 // If there is no data ready to send, it adds blocks from the block queue
@@ -275,9 +279,8 @@ func (s *channelManager) TxData(l1Head eth.BlockID, isPectra, isThrottling, forc
 // there is no channel with txData
 // If forcePublish is true, it will force close channels and
 // generate frames for them.
-func (s *channelManager) getReadyChannel(l1Head eth.BlockID, forcePublish bool) (*channel, error) {
-
-	if forcePublish && s.currentChannel.TotalFrames() == 0 {
+func (s *channelManager) getReadyChannel(l1Head eth.BlockID, pi pubInfo) (*channel, error) {
+	if pi.forcePublish && s.currentChannel.TotalFrames() == 0 {
 		s.log.Info("Force-closing channel and creating frames", "channel_id", s.currentChannel.ID())
 		s.currentChannel.Close()
 		if err := s.currentChannel.OutputFrames(); err != nil {
@@ -315,9 +318,6 @@ func (s *channelManager) getReadyChannel(l1Head eth.BlockID, forcePublish bool) 
 		return nil, err
 	}
 
-	// Register current L1 head only after all pending blocks have been
-	// processed. Even if a timeout will be triggered now, it is better to have
-	// all pending blocks be included in this channel for submission.
 	s.registerL1Block(l1Head)
 
 	if err := s.outputFrames(); err != nil {
@@ -461,6 +461,8 @@ func (s *channelManager) outputFrames() error {
 	s.log.Info("Channel closed",
 		"id", s.currentChannel.ID(),
 		"blocks_pending", s.pendingBlocks(),
+		"block_cursor", s.blockCursor,
+		"blocks_len", s.blocks.Len(),
 		"num_frames", s.currentChannel.TotalFrames(),
 		"input_bytes", inBytes,
 		"output_bytes", outBytes,
@@ -540,7 +542,6 @@ func (s *channelManager) PruneChannels(num int) {
 	if clearCurrentChannel {
 		s.currentChannel = nil
 	}
-
 }
 
 // PendingDABytes returns the current number of bytes pending to be written to the DA layer (from blocks fetched from L2

--- a/op-batcher/batcher/channel_manager_memory_test.go
+++ b/op-batcher/batcher/channel_manager_memory_test.go
@@ -124,7 +124,7 @@ func runMemoryTest(t *testing.T, batchType uint, compressorType string, compress
 			require.NoError(t, m.processBlocks())
 
 			// Try to get transaction data to fill channels
-			_, err := m.TxData(eth.BlockID{}, false, false, pubInfo{forcePublish: false, publishingBacklog: false})
+			_, err := m.TxData(eth.BlockID{}, false, false, pubInfo{})
 			// It's okay if there's no data ready (io.EOF)
 			if err != nil && err.Error() != "EOF" {
 				require.NoError(t, err)

--- a/op-batcher/batcher/channel_manager_memory_test.go
+++ b/op-batcher/batcher/channel_manager_memory_test.go
@@ -124,7 +124,7 @@ func runMemoryTest(t *testing.T, batchType uint, compressorType string, compress
 			require.NoError(t, m.processBlocks())
 
 			// Try to get transaction data to fill channels
-			_, err := m.TxData(eth.BlockID{}, false, false, pubInfo{forcePublish: false, moreComing: false})
+			_, err := m.TxData(eth.BlockID{}, false, false, pubInfo{forcePublish: false, publishingBacklog: false})
 			// It's okay if there's no data ready (io.EOF)
 			if err != nil && err.Error() != "EOF" {
 				require.NoError(t, err)

--- a/op-batcher/batcher/channel_manager_memory_test.go
+++ b/op-batcher/batcher/channel_manager_memory_test.go
@@ -124,7 +124,7 @@ func runMemoryTest(t *testing.T, batchType uint, compressorType string, compress
 			require.NoError(t, m.processBlocks())
 
 			// Try to get transaction data to fill channels
-			_, err := m.TxData(eth.BlockID{}, false, false, false)
+			_, err := m.TxData(eth.BlockID{}, false, false, pubInfo{forcePublish: false, moreComing: false})
 			// It's okay if there's no data ready (io.EOF)
 			if err != nil && err.Error() != "EOF" {
 				require.NoError(t, err)

--- a/op-batcher/batcher/channel_manager_test.go
+++ b/op-batcher/batcher/channel_manager_test.go
@@ -345,8 +345,6 @@ func TestChannelManager_MoreComing(t *testing.T) {
 		m.blocks.Enqueue(SizedBlock{Block: block})
 	}
 
-	// The test requires us to have something in the channel queue
-	// at this point, but not yet ready to send and not full
 	require.NotEmpty(t, m.channelQueue)
 	require.False(t, m.channelQueue[0].IsFull())
 
@@ -354,6 +352,8 @@ func TestChannelManager_MoreComing(t *testing.T) {
 	_, err = m.TxData(eth.BlockID{Number: 22}, false, false, pubInfo{forcePublish: false, moreComing: false})
 	require.NoError(t, err)
 	require.NotEmpty(t, m.channelQueue)
+
+	// Given that `moreComing` is set to false, the channel should be timed out
 	require.True(t, m.channelQueue[0].IsFull())
 	require.ErrorIs(t, m.channelQueue[0].FullErr(), ErrMaxDurationReached)
 }

--- a/op-batcher/batcher/channel_manager_test.go
+++ b/op-batcher/batcher/channel_manager_test.go
@@ -103,9 +103,9 @@ func ChannelManagerReturnsErrReorgWhenDrained(t *testing.T, batchType uint) {
 
 	require.NoError(t, m.AddL2Block(a))
 
-	_, err := m.TxData(eth.BlockID{}, false, false, pubInfo{forcePublish: false, publishingBacklog: false})
+	_, err := m.TxData(eth.BlockID{}, false, false, pubInfo{})
 	require.NoError(t, err)
-	_, err = m.TxData(eth.BlockID{}, false, false, pubInfo{forcePublish: false, publishingBacklog: false})
+	_, err = m.TxData(eth.BlockID{}, false, false, pubInfo{})
 	require.ErrorIs(t, err, io.EOF)
 
 	require.ErrorIs(t, m.AddL2Block(x), ErrReorg)
@@ -207,7 +207,7 @@ func ChannelManager_TxResend(t *testing.T, batchType uint) {
 
 	require.NoError(m.AddL2Block(a))
 
-	txdata0, err := m.TxData(eth.BlockID{}, false, false, pubInfo{forcePublish: false, publishingBacklog: false})
+	txdata0, err := m.TxData(eth.BlockID{}, false, false, pubInfo{})
 	require.NoError(err)
 	txdata0bytes := txdata0.CallData()
 	data0 := make([]byte, len(txdata0bytes))
@@ -215,13 +215,13 @@ func ChannelManager_TxResend(t *testing.T, batchType uint) {
 	copy(data0, txdata0bytes)
 
 	// ensure channel is drained
-	_, err = m.TxData(eth.BlockID{}, false, false, pubInfo{forcePublish: false, publishingBacklog: false})
+	_, err = m.TxData(eth.BlockID{}, false, false, pubInfo{})
 	require.ErrorIs(err, io.EOF)
 
 	// requeue frame
 	m.TxFailed(txdata0.ID())
 
-	txdata1, err := m.TxData(eth.BlockID{}, false, false, pubInfo{forcePublish: false, publishingBacklog: false})
+	txdata1, err := m.TxData(eth.BlockID{}, false, false, pubInfo{})
 	require.NoError(err)
 
 	data1 := txdata1.CallData()
@@ -318,9 +318,9 @@ func newFakeDynamicEthChannelConfig(lgr log.Logger,
 	}
 }
 
-// TestChannelManager_PublishingBacklog tests that the channel manager will not time out
-// when publishingBacklog is set to true in the signal struct.
-func TestChannelManager_PublishingBacklog(t *testing.T) {
+// TestChannelManager_IgnoreMaxChannelDuration tests that the channel manager will not time out
+// when ignoreMaxChannelDuration is set to true in the signal struct.
+func TestChannelManager_IgnoreMaxChannelDuration(t *testing.T) {
 	l := testlog.Logger(t, log.LevelCrit)
 
 	cfg := channelManagerTestConfig(10000, derive.SingularBatchType)
@@ -336,10 +336,9 @@ func TestChannelManager_PublishingBacklog(t *testing.T) {
 		m.blocks.Enqueue(SizedBlock{Block: block})
 	}
 
-	// Call TxData a first time - if `publishingBacklog` is `false`, channel would be timed out, but since `publishingBacklog`
-	// is set to true here, we essentially ignore the registering of L1 block, so channel doesn't time out, and
-	// io.EOF is expected here.
-	_, err := m.TxData(eth.BlockID{Number: 21}, false, false, pubInfo{forcePublish: false, publishingBacklog: true})
+	// Call TxData a first time - if `ignoreMaxChannelDuration` is `false`, channel would be timed out,
+	// but since `ignoreMaxChannelDuration` is `true`, we expect it to be not timed out.
+	_, err := m.TxData(eth.BlockID{Number: 21}, false, false, pubInfo{ignoreMaxChannelDuration: true})
 	require.ErrorIs(t, err, io.EOF)
 
 	// Add more blocks to the channel manager
@@ -351,12 +350,12 @@ func TestChannelManager_PublishingBacklog(t *testing.T) {
 	require.NotEmpty(t, m.channelQueue)
 	require.False(t, m.channelQueue[0].IsFull())
 
-	// Call TxData again, with publishingBacklog set to false
-	_, err = m.TxData(eth.BlockID{Number: 22}, false, false, pubInfo{forcePublish: false, publishingBacklog: false})
+	// Call TxData again, with ignoreMaxChannelDuration unset.
+	_, err = m.TxData(eth.BlockID{Number: 22}, false, false, pubInfo{})
 	require.NoError(t, err)
 	require.NotEmpty(t, m.channelQueue)
 
-	// Given that `publishingBacklog` is set to false, the channel should be timed out
+	// Given that ignoreMaxChannelDuration was unset, the channel should be timed out
 	require.True(t, m.channelQueue[0].IsFull())
 	require.ErrorIs(t, m.channelQueue[0].FullErr(), ErrMaxDurationReached)
 }
@@ -407,7 +406,7 @@ func TestChannelManager_TxData(t *testing.T) {
 			m.blocks = queue.Queue[SizedBlock]{SizedBlock{Block: blockA}}
 
 			// Call TxData a first time to trigger blocks->channels pipeline
-			_, err := m.TxData(eth.BlockID{}, false, false, pubInfo{forcePublish: false, publishingBacklog: false})
+			_, err := m.TxData(eth.BlockID{}, false, false, pubInfo{})
 			require.ErrorIs(t, err, io.EOF)
 
 			// The test requires us to have something in the channel queue
@@ -426,7 +425,7 @@ func TestChannelManager_TxData(t *testing.T) {
 			var data txData
 			for {
 				m.blocks.Enqueue(SizedBlock{Block: blockA})
-				data, err = m.TxData(eth.BlockID{}, false, false, pubInfo{forcePublish: false, publishingBacklog: false})
+				data, err = m.TxData(eth.BlockID{}, false, false, pubInfo{})
 				if err == nil && data.Len() > 0 {
 					break
 				}
@@ -754,7 +753,7 @@ func TestChannelManager_TxData_ForcePublish(t *testing.T) {
 	m.blocks = queue.Queue[SizedBlock]{SizedBlock{Block: blockA}}
 
 	// Call TxData a first time to trigger blocks->channels pipeline
-	txData, err := m.TxData(eth.BlockID{}, false, false, pubInfo{forcePublish: false, publishingBacklog: false})
+	txData, err := m.TxData(eth.BlockID{}, false, false, pubInfo{})
 	require.ErrorIs(t, err, io.EOF)
 	require.Zero(t, txData.Len(), 0)
 
@@ -764,7 +763,7 @@ func TestChannelManager_TxData_ForcePublish(t *testing.T) {
 	require.False(t, m.channelQueue[0].IsFull())
 
 	// Call TxData with force publish enabled
-	txData, err = m.TxData(eth.BlockID{}, false, false, pubInfo{forcePublish: true, publishingBacklog: false})
+	txData, err = m.TxData(eth.BlockID{}, false, false, pubInfo{forcePublish: true})
 
 	// Despite no additional blocks being added, we should have tx data:
 	require.NoError(t, err)
@@ -871,7 +870,7 @@ func TestChannelManagerUnsafeBytes(t *testing.T) {
 			_, err = manager.TxData(eth.BlockID{
 				Hash:   common.Hash{},
 				Number: 0,
-			}, true, false, pubInfo{forcePublish: false, publishingBacklog: false})
+			}, true, false, pubInfo{})
 		}
 
 		assert.Equal(t, tc.afterAddingToChannel, manager.UnsafeDABytes())

--- a/op-batcher/batcher/channel_manager_test.go
+++ b/op-batcher/batcher/channel_manager_test.go
@@ -103,9 +103,9 @@ func ChannelManagerReturnsErrReorgWhenDrained(t *testing.T, batchType uint) {
 
 	require.NoError(t, m.AddL2Block(a))
 
-	_, err := m.TxData(eth.BlockID{}, false, false, pubInfo{forcePublish: false, moreComing: false})
+	_, err := m.TxData(eth.BlockID{}, false, false, pubInfo{forcePublish: false, publishingBacklog: false})
 	require.NoError(t, err)
-	_, err = m.TxData(eth.BlockID{}, false, false, pubInfo{forcePublish: false, moreComing: false})
+	_, err = m.TxData(eth.BlockID{}, false, false, pubInfo{forcePublish: false, publishingBacklog: false})
 	require.ErrorIs(t, err, io.EOF)
 
 	require.ErrorIs(t, m.AddL2Block(x), ErrReorg)
@@ -207,7 +207,7 @@ func ChannelManager_TxResend(t *testing.T, batchType uint) {
 
 	require.NoError(m.AddL2Block(a))
 
-	txdata0, err := m.TxData(eth.BlockID{}, false, false, pubInfo{forcePublish: false, moreComing: false})
+	txdata0, err := m.TxData(eth.BlockID{}, false, false, pubInfo{forcePublish: false, publishingBacklog: false})
 	require.NoError(err)
 	txdata0bytes := txdata0.CallData()
 	data0 := make([]byte, len(txdata0bytes))
@@ -215,13 +215,13 @@ func ChannelManager_TxResend(t *testing.T, batchType uint) {
 	copy(data0, txdata0bytes)
 
 	// ensure channel is drained
-	_, err = m.TxData(eth.BlockID{}, false, false, pubInfo{forcePublish: false, moreComing: false})
+	_, err = m.TxData(eth.BlockID{}, false, false, pubInfo{forcePublish: false, publishingBacklog: false})
 	require.ErrorIs(err, io.EOF)
 
 	// requeue frame
 	m.TxFailed(txdata0.ID())
 
-	txdata1, err := m.TxData(eth.BlockID{}, false, false, pubInfo{forcePublish: false, moreComing: false})
+	txdata1, err := m.TxData(eth.BlockID{}, false, false, pubInfo{forcePublish: false, publishingBacklog: false})
 	require.NoError(err)
 
 	data1 := txdata1.CallData()
@@ -318,8 +318,9 @@ func newFakeDynamicEthChannelConfig(lgr log.Logger,
 	}
 }
 
-// TestChannelManager_MoreComing
-func TestChannelManager_MoreComing(t *testing.T) {
+// TestChannelManager_PublishingBacklog tests that the channel manager will not time out
+// when publishingBacklog is set to true in the signal struct.
+func TestChannelManager_PublishingBacklog(t *testing.T) {
 	l := testlog.Logger(t, log.LevelCrit)
 
 	cfg := channelManagerTestConfig(10000, derive.SingularBatchType)
@@ -335,8 +336,8 @@ func TestChannelManager_MoreComing(t *testing.T) {
 		m.blocks.Enqueue(SizedBlock{Block: block})
 	}
 
-	// Call TxData a first time - if `moreComing` is `false`, channel would be timed out.
-	_, err := m.TxData(eth.BlockID{Number: 21}, false, false, pubInfo{forcePublish: false, moreComing: true})
+	// Call TxData a first time - if `publishingBacklog` is `false`, channel would be timed out.
+	_, err := m.TxData(eth.BlockID{Number: 21}, false, false, pubInfo{forcePublish: false, publishingBacklog: true})
 	require.ErrorIs(t, err, io.EOF)
 
 	// Add more blocks to the channel manager
@@ -348,12 +349,12 @@ func TestChannelManager_MoreComing(t *testing.T) {
 	require.NotEmpty(t, m.channelQueue)
 	require.False(t, m.channelQueue[0].IsFull())
 
-	// Call TxData again, with moreComing set to false
-	_, err = m.TxData(eth.BlockID{Number: 22}, false, false, pubInfo{forcePublish: false, moreComing: false})
+	// Call TxData again, with publishingBacklog set to false
+	_, err = m.TxData(eth.BlockID{Number: 22}, false, false, pubInfo{forcePublish: false, publishingBacklog: false})
 	require.NoError(t, err)
 	require.NotEmpty(t, m.channelQueue)
 
-	// Given that `moreComing` is set to false, the channel should be timed out
+	// Given that `publishingBacklog` is set to false, the channel should be timed out
 	require.True(t, m.channelQueue[0].IsFull())
 	require.ErrorIs(t, m.channelQueue[0].FullErr(), ErrMaxDurationReached)
 }
@@ -404,7 +405,7 @@ func TestChannelManager_TxData(t *testing.T) {
 			m.blocks = queue.Queue[SizedBlock]{SizedBlock{Block: blockA}}
 
 			// Call TxData a first time to trigger blocks->channels pipeline
-			_, err := m.TxData(eth.BlockID{}, false, false, pubInfo{forcePublish: false, moreComing: false})
+			_, err := m.TxData(eth.BlockID{}, false, false, pubInfo{forcePublish: false, publishingBacklog: false})
 			require.ErrorIs(t, err, io.EOF)
 
 			// The test requires us to have something in the channel queue
@@ -423,7 +424,7 @@ func TestChannelManager_TxData(t *testing.T) {
 			var data txData
 			for {
 				m.blocks.Enqueue(SizedBlock{Block: blockA})
-				data, err = m.TxData(eth.BlockID{}, false, false, pubInfo{forcePublish: false, moreComing: false})
+				data, err = m.TxData(eth.BlockID{}, false, false, pubInfo{forcePublish: false, publishingBacklog: false})
 				if err == nil && data.Len() > 0 {
 					break
 				}
@@ -751,7 +752,7 @@ func TestChannelManager_TxData_ForcePublish(t *testing.T) {
 	m.blocks = queue.Queue[SizedBlock]{SizedBlock{Block: blockA}}
 
 	// Call TxData a first time to trigger blocks->channels pipeline
-	txData, err := m.TxData(eth.BlockID{}, false, false, pubInfo{forcePublish: false, moreComing: false})
+	txData, err := m.TxData(eth.BlockID{}, false, false, pubInfo{forcePublish: false, publishingBacklog: false})
 	require.ErrorIs(t, err, io.EOF)
 	require.Zero(t, txData.Len(), 0)
 
@@ -761,7 +762,7 @@ func TestChannelManager_TxData_ForcePublish(t *testing.T) {
 	require.False(t, m.channelQueue[0].IsFull())
 
 	// Call TxData with force publish enabled
-	txData, err = m.TxData(eth.BlockID{}, false, false, pubInfo{forcePublish: true, moreComing: false})
+	txData, err = m.TxData(eth.BlockID{}, false, false, pubInfo{forcePublish: true, publishingBacklog: false})
 
 	// Despite no additional blocks being added, we should have tx data:
 	require.NoError(t, err)
@@ -868,7 +869,7 @@ func TestChannelManagerUnsafeBytes(t *testing.T) {
 			_, err = manager.TxData(eth.BlockID{
 				Hash:   common.Hash{},
 				Number: 0,
-			}, true, false, pubInfo{forcePublish: false, moreComing: false})
+			}, true, false, pubInfo{forcePublish: false, publishingBacklog: false})
 		}
 
 		assert.Equal(t, tc.afterAddingToChannel, manager.UnsafeDABytes())

--- a/op-batcher/batcher/channel_manager_test.go
+++ b/op-batcher/batcher/channel_manager_test.go
@@ -336,7 +336,9 @@ func TestChannelManager_PublishingBacklog(t *testing.T) {
 		m.blocks.Enqueue(SizedBlock{Block: block})
 	}
 
-	// Call TxData a first time - if `publishingBacklog` is `false`, channel would be timed out.
+	// Call TxData a first time - if `publishingBacklog` is `false`, channel would be timed out, but since `publishingBacklog`
+	// is set to true here, we essentially ignore the registering of L1 block, so channel doesn't time out, and
+	// io.EOF is expected here.
 	_, err := m.TxData(eth.BlockID{Number: 21}, false, false, pubInfo{forcePublish: false, publishingBacklog: true})
 	require.ErrorIs(t, err, io.EOF)
 

--- a/op-batcher/batcher/channel_manager_test.go
+++ b/op-batcher/batcher/channel_manager_test.go
@@ -103,9 +103,9 @@ func ChannelManagerReturnsErrReorgWhenDrained(t *testing.T, batchType uint) {
 
 	require.NoError(t, m.AddL2Block(a))
 
-	_, err := m.TxData(eth.BlockID{}, false, false, false)
+	_, err := m.TxData(eth.BlockID{}, false, false, pubInfo{forcePublish: false, moreComing: false})
 	require.NoError(t, err)
-	_, err = m.TxData(eth.BlockID{}, false, false, false)
+	_, err = m.TxData(eth.BlockID{}, false, false, pubInfo{forcePublish: false, moreComing: false})
 	require.ErrorIs(t, err, io.EOF)
 
 	require.ErrorIs(t, m.AddL2Block(x), ErrReorg)
@@ -207,7 +207,7 @@ func ChannelManager_TxResend(t *testing.T, batchType uint) {
 
 	require.NoError(m.AddL2Block(a))
 
-	txdata0, err := m.TxData(eth.BlockID{}, false, false, false)
+	txdata0, err := m.TxData(eth.BlockID{}, false, false, pubInfo{forcePublish: false, moreComing: false})
 	require.NoError(err)
 	txdata0bytes := txdata0.CallData()
 	data0 := make([]byte, len(txdata0bytes))
@@ -215,13 +215,13 @@ func ChannelManager_TxResend(t *testing.T, batchType uint) {
 	copy(data0, txdata0bytes)
 
 	// ensure channel is drained
-	_, err = m.TxData(eth.BlockID{}, false, false, false)
+	_, err = m.TxData(eth.BlockID{}, false, false, pubInfo{forcePublish: false, moreComing: false})
 	require.ErrorIs(err, io.EOF)
 
 	// requeue frame
 	m.TxFailed(txdata0.ID())
 
-	txdata1, err := m.TxData(eth.BlockID{}, false, false, false)
+	txdata1, err := m.TxData(eth.BlockID{}, false, false, pubInfo{forcePublish: false, moreComing: false})
 	require.NoError(err)
 
 	data1 := txdata1.CallData()
@@ -364,7 +364,7 @@ func TestChannelManager_TxData(t *testing.T) {
 			m.blocks = queue.Queue[SizedBlock]{SizedBlock{Block: blockA}}
 
 			// Call TxData a first time to trigger blocks->channels pipeline
-			_, err := m.TxData(eth.BlockID{}, false, false, false)
+			_, err := m.TxData(eth.BlockID{}, false, false, pubInfo{forcePublish: false, moreComing: false})
 			require.ErrorIs(t, err, io.EOF)
 
 			// The test requires us to have something in the channel queue
@@ -383,7 +383,7 @@ func TestChannelManager_TxData(t *testing.T) {
 			var data txData
 			for {
 				m.blocks.Enqueue(SizedBlock{Block: blockA})
-				data, err = m.TxData(eth.BlockID{}, false, false, false)
+				data, err = m.TxData(eth.BlockID{}, false, false, pubInfo{forcePublish: false, moreComing: false})
 				if err == nil && data.Len() > 0 {
 					break
 				}
@@ -607,11 +607,12 @@ func TestChannelManager_PruneBlocks(t *testing.T) {
 
 func TestChannelManager_PruneChannels(t *testing.T) {
 	cfg := channelManagerTestConfig(100, derive.SingularBatchType)
-	A, err := newChannelWithChannelOut(nil, metrics.NoopMetrics, cfg, defaultTestRollupConfig, 0)
+	l := testlog.Logger(t, log.LevelCrit)
+	A, err := newChannelWithChannelOut(l, metrics.NoopMetrics, cfg, defaultTestRollupConfig, 0)
 	require.NoError(t, err)
-	B, err := newChannelWithChannelOut(nil, metrics.NoopMetrics, cfg, defaultTestRollupConfig, 0)
+	B, err := newChannelWithChannelOut(l, metrics.NoopMetrics, cfg, defaultTestRollupConfig, 0)
 	require.NoError(t, err)
-	C, err := newChannelWithChannelOut(nil, metrics.NoopMetrics, cfg, defaultTestRollupConfig, 0)
+	C, err := newChannelWithChannelOut(l, metrics.NoopMetrics, cfg, defaultTestRollupConfig, 0)
 	require.NoError(t, err)
 
 	type testCase struct {
@@ -710,7 +711,7 @@ func TestChannelManager_TxData_ForcePublish(t *testing.T) {
 	m.blocks = queue.Queue[SizedBlock]{SizedBlock{Block: blockA}}
 
 	// Call TxData a first time to trigger blocks->channels pipeline
-	txData, err := m.TxData(eth.BlockID{}, false, false, false)
+	txData, err := m.TxData(eth.BlockID{}, false, false, pubInfo{forcePublish: false, moreComing: false})
 	require.ErrorIs(t, err, io.EOF)
 	require.Zero(t, txData.Len(), 0)
 
@@ -720,7 +721,7 @@ func TestChannelManager_TxData_ForcePublish(t *testing.T) {
 	require.False(t, m.channelQueue[0].IsFull())
 
 	// Call TxData with force publish enabled
-	txData, err = m.TxData(eth.BlockID{}, false, false, true)
+	txData, err = m.TxData(eth.BlockID{}, false, false, pubInfo{forcePublish: true, moreComing: false})
 
 	// Despite no additional blocks being added, we should have tx data:
 	require.NoError(t, err)
@@ -827,7 +828,7 @@ func TestChannelManagerUnsafeBytes(t *testing.T) {
 			_, err = manager.TxData(eth.BlockID{
 				Hash:   common.Hash{},
 				Number: 0,
-			}, true, false, false)
+			}, true, false, pubInfo{forcePublish: false, moreComing: false})
 		}
 
 		assert.Equal(t, tc.afterAddingToChannel, manager.UnsafeDABytes())

--- a/op-batcher/batcher/channel_manager_test.go
+++ b/op-batcher/batcher/channel_manager_test.go
@@ -318,6 +318,46 @@ func newFakeDynamicEthChannelConfig(lgr log.Logger,
 	}
 }
 
+// TestChannelManager_MoreComing
+func TestChannelManager_MoreComing(t *testing.T) {
+	l := testlog.Logger(t, log.LevelCrit)
+
+	cfg := channelManagerTestConfig(10000, derive.SingularBatchType)
+	cfg.MaxChannelDuration = 20
+	cfg.InitNoneCompressor()
+
+	m := NewChannelManager(l, metrics.NoopMetrics, cfg, defaultTestRollupConfig)
+
+	// Seed channel manager with blocks
+	rng := rand.New(rand.NewSource(99))
+	for range 2 {
+		block := derivetest.RandomL2BlockWithChainId(rng, 2, defaultTestRollupConfig.L2ChainID)
+		m.blocks.Enqueue(SizedBlock{Block: block})
+	}
+
+	// Call TxData a first time - if `moreComing` is `false`, channel would be timed out.
+	_, err := m.TxData(eth.BlockID{Number: 21}, false, false, pubInfo{forcePublish: false, moreComing: true})
+	require.ErrorIs(t, err, io.EOF)
+
+	// Add more blocks to the channel manager
+	for range 2 {
+		block := derivetest.RandomL2BlockWithChainId(rng, 2, defaultTestRollupConfig.L2ChainID)
+		m.blocks.Enqueue(SizedBlock{Block: block})
+	}
+
+	// The test requires us to have something in the channel queue
+	// at this point, but not yet ready to send and not full
+	require.NotEmpty(t, m.channelQueue)
+	require.False(t, m.channelQueue[0].IsFull())
+
+	// Call TxData again, with moreComing set to false
+	_, err = m.TxData(eth.BlockID{Number: 22}, false, false, pubInfo{forcePublish: false, moreComing: false})
+	require.NoError(t, err)
+	require.NotEmpty(t, m.channelQueue)
+	require.True(t, m.channelQueue[0].IsFull())
+	require.ErrorIs(t, m.channelQueue[0].FullErr(), ErrMaxDurationReached)
+}
+
 // TestChannelManager_TxData seeds the channel manager with blocks and triggers the
 // blocks->channels pipeline multiple times. Values are chosen such that a channel
 // is created under one set of market conditions, and then submitted under a different

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -268,7 +268,7 @@ func (l *BatchSubmitter) Flush(ctx context.Context) error {
 	}
 
 	l.Log.Info("Flushing Batch Submitter")
-	l.tryPublishSignal(l.publishSignal, pubInfo{forcePublish: true, moreComing: false})
+	l.tryPublishSignal(l.publishSignal, pubInfo{forcePublish: true, publishingBacklog: false})
 	return nil
 }
 
@@ -302,7 +302,7 @@ func (l *BatchSubmitter) loadBlocksIntoState(ctx context.Context, start, end uin
 			// This allows the batcher to start publishing sooner in the
 			// case of a large backlog of blocks to load.
 			l.sendToThrottlingLoop(unsafeBytesUpdated)
-			l.tryPublishSignal(publishSignal, pubInfo{moreComing: i < end, forcePublish: false})
+			l.tryPublishSignal(publishSignal, pubInfo{publishingBacklog: i < end, forcePublish: false})
 		}
 
 	}
@@ -556,7 +556,7 @@ func (l *BatchSubmitter) blockLoadingLoop(ctx context.Context, wg *sync.WaitGrou
 					l.sendToThrottlingLoop(unsafeBytesUpdated) // we have increased the unsafe data. Signal the throttling loop to check if it should throttle.
 				}
 			}
-			l.tryPublishSignal(publishSignal, pubInfo{forcePublish: false, moreComing: false}) // always signal the write loop to ensure we periodically publish even if we aren't loading blocks
+			l.tryPublishSignal(publishSignal, pubInfo{forcePublish: false, publishingBacklog: false}) // always signal the write loop to ensure we periodically publish even if we aren't loading blocks
 		case <-ctx.Done():
 			l.Log.Info("blockLoadingLoop returning")
 			return

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -117,7 +117,7 @@ type BatchSubmitter struct {
 
 	throttleController *throttler.ThrottleController
 
-	publishSignal chan pubInfo // true if we should force a tx to be published now, false if we should check the usual conditions (timeouts)
+	publishSignal chan pubInfo
 }
 
 // NewBatchSubmitter initializes the BatchSubmitter driver from a preconfigured DriverSetup

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -501,7 +501,7 @@ func (l *BatchSubmitter) publishingLoop(ctx context.Context, wg *sync.WaitGroup,
 
 	for pi := range l.publishSignal {
 		l.Log.Debug("publishing loop received signal", "force_publish", pi.forcePublish)
-		l.publishStateToL1(ctx, txQueue, receiptsCh, daGroup, pi.forcePublish)
+		l.publishStateToL1(ctx, txQueue, receiptsCh, daGroup, pi)
 	}
 
 	// First wait for all DA requests to finish to prevent new transactions being queued
@@ -771,7 +771,7 @@ func (l *BatchSubmitter) waitNodeSync() error {
 
 // publishStateToL1 queues up all pending TxData to be published to the L1, returning when there is no more data to
 // queue for publishing or if there was an error queuing the data.
-func (l *BatchSubmitter) publishStateToL1(ctx context.Context, queue *txmgr.Queue[txRef], receiptsCh chan txmgr.TxReceipt[txRef], daGroup *errgroup.Group, forcePublish bool) {
+func (l *BatchSubmitter) publishStateToL1(ctx context.Context, queue *txmgr.Queue[txRef], receiptsCh chan txmgr.TxReceipt[txRef], daGroup *errgroup.Group, pi pubInfo) {
 	for {
 		select {
 		case <-ctx.Done():
@@ -788,7 +788,7 @@ func (l *BatchSubmitter) publishStateToL1(ctx context.Context, queue *txmgr.Queu
 			return
 		}
 
-		err := l.publishTxToL1(ctx, queue, receiptsCh, daGroup, forcePublish)
+		err := l.publishTxToL1(ctx, queue, receiptsCh, daGroup, pi)
 		if err != nil {
 			if err != io.EOF {
 				l.Log.Error("Error publishing tx to l1", "err", err)
@@ -842,7 +842,7 @@ func (l *BatchSubmitter) clearState(ctx context.Context) {
 }
 
 // publishTxToL1 submits a single state tx to the L1
-func (l *BatchSubmitter) publishTxToL1(ctx context.Context, queue *txmgr.Queue[txRef], receiptsCh chan txmgr.TxReceipt[txRef], daGroup *errgroup.Group, forcePublish bool) error {
+func (l *BatchSubmitter) publishTxToL1(ctx context.Context, queue *txmgr.Queue[txRef], receiptsCh chan txmgr.TxReceipt[txRef], daGroup *errgroup.Group, pi pubInfo) error {
 	// send all available transactions
 	l1tip, isPectra, err := l.l1Tip(ctx)
 	if err != nil {
@@ -855,7 +855,7 @@ func (l *BatchSubmitter) publishTxToL1(ctx context.Context, queue *txmgr.Queue[t
 	// Collect next transaction data. This pulls data out of the channel, so we need to make sure
 	// to put it back if ever da or txmgr requests fail, by calling l.recordFailedDARequest/recordFailedTx.
 	l.channelMgrMutex.Lock()
-	txdata, err := l.channelMgr.TxData(l1tip.ID(), isPectra, params.IsThrottling(), pubInfo{forcePublish: forcePublish})
+	txdata, err := l.channelMgr.TxData(l1tip.ID(), isPectra, params.IsThrottling(), pi)
 	l.channelMgrMutex.Unlock()
 
 	if err == io.EOF {

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -268,7 +268,7 @@ func (l *BatchSubmitter) Flush(ctx context.Context) error {
 	}
 
 	l.Log.Info("Flushing Batch Submitter")
-	l.tryPublishSignal(l.publishSignal, pubInfo{forcePublish: true, publishingBacklog: false})
+	l.tryPublishSignal(l.publishSignal, pubInfo{forcePublish: true})
 	return nil
 }
 
@@ -302,7 +302,7 @@ func (l *BatchSubmitter) loadBlocksIntoState(ctx context.Context, start, end uin
 			// This allows the batcher to start publishing sooner in the
 			// case of a large backlog of blocks to load.
 			l.sendToThrottlingLoop(unsafeBytesUpdated)
-			l.tryPublishSignal(publishSignal, pubInfo{publishingBacklog: i < end, forcePublish: false})
+			l.tryPublishSignal(publishSignal, pubInfo{ignoreMaxChannelDuration: i < end})
 		}
 
 	}
@@ -436,7 +436,7 @@ func (l *BatchSubmitter) sendToThrottlingLoop(unsafeBytesUpdated chan int64) {
 	}
 }
 
-// trySignal tries to send an empty struct on the provided channel.
+// trySignal tries to send the provided value on the provided channel.
 // It is not blocking, no signal will be sent if the channel is full.
 func (l *BatchSubmitter) tryPublishSignal(c chan pubInfo, value pubInfo) {
 	select {
@@ -556,7 +556,7 @@ func (l *BatchSubmitter) blockLoadingLoop(ctx context.Context, wg *sync.WaitGrou
 					l.sendToThrottlingLoop(unsafeBytesUpdated) // we have increased the unsafe data. Signal the throttling loop to check if it should throttle.
 				}
 			}
-			l.tryPublishSignal(publishSignal, pubInfo{forcePublish: false, publishingBacklog: false}) // always signal the write loop to ensure we periodically publish even if we aren't loading blocks
+			l.tryPublishSignal(publishSignal, pubInfo{}) // always signal the publishing loop to ensure we periodically publish even if we aren't loading blocks
 		case <-ctx.Done():
 			l.Log.Info("blockLoadingLoop returning")
 			return

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -117,7 +117,7 @@ type BatchSubmitter struct {
 
 	throttleController *throttler.ThrottleController
 
-	publishSignal chan bool // true if we should force a tx to be published now, false if we should check the usual conditions (timeouts)
+	publishSignal chan pubInfo // true if we should force a tx to be published now, false if we should check the usual conditions (timeouts)
 }
 
 // NewBatchSubmitter initializes the BatchSubmitter driver from a preconfigured DriverSetup
@@ -173,7 +173,7 @@ func (l *BatchSubmitter) StartBatchSubmitting() error {
 
 	// Channels used to signal between the loops
 	unsafeBytesUpdated := make(chan int64, 1)
-	publishSignal := make(chan bool, 1)
+	publishSignal := make(chan pubInfo, 1)
 	l.publishSignal = publishSignal
 
 	// DA throttling loop should always be started except for testing (indicated by ThrottleThreshold == 0)
@@ -268,13 +268,13 @@ func (l *BatchSubmitter) Flush(ctx context.Context) error {
 	}
 
 	l.Log.Info("Flushing Batch Submitter")
-	trySignal(l.publishSignal, true)
+	l.tryPublishSignal(l.publishSignal, pubInfo{forcePublish: true, moreComing: false})
 	return nil
 }
 
 // loadBlocksIntoState loads the blocks between start and end (inclusive).
 // If there is a reorg, it will return an error.
-func (l *BatchSubmitter) loadBlocksIntoState(ctx context.Context, start, end uint64, publishSignal chan bool, unsafeBytesUpdated chan int64) error {
+func (l *BatchSubmitter) loadBlocksIntoState(ctx context.Context, start, end uint64, publishSignal chan pubInfo, unsafeBytesUpdated chan int64) error {
 	if end < start {
 		return fmt.Errorf("start number is > end number %d,%d", start, end)
 	}
@@ -302,7 +302,7 @@ func (l *BatchSubmitter) loadBlocksIntoState(ctx context.Context, start, end uin
 			// This allows the batcher to start publishing sooner in the
 			// case of a large backlog of blocks to load.
 			l.sendToThrottlingLoop(unsafeBytesUpdated)
-			trySignal(publishSignal, false)
+			l.tryPublishSignal(publishSignal, pubInfo{moreComing: i < end, forcePublish: false})
 		}
 
 	}
@@ -328,7 +328,6 @@ func (l *BatchSubmitter) loadBlockIntoState(ctx context.Context, blockNumber uin
 	defer cancel()
 
 	block, err := l2Client.BlockByNumber(cCtx, new(big.Int).SetUint64(blockNumber))
-
 	if err != nil {
 		return nil, fmt.Errorf("getting L2 block: %w", err)
 	}
@@ -439,10 +438,11 @@ func (l *BatchSubmitter) sendToThrottlingLoop(unsafeBytesUpdated chan int64) {
 
 // trySignal tries to send an empty struct on the provided channel.
 // It is not blocking, no signal will be sent if the channel is full.
-func trySignal(c chan bool, value bool) {
+func (l *BatchSubmitter) tryPublishSignal(c chan pubInfo, value pubInfo) {
 	select {
 	case c <- value:
 	default:
+		l.Log.Warn("publishSignal channel is full, skipping signal")
 	}
 }
 
@@ -487,7 +487,7 @@ func (l *BatchSubmitter) syncAndPrune(syncStatus *eth.SyncStatus) *inclusiveBloc
 // -  waits for a signal that blocks have been loaded
 // -  drives the creation of channels and frames
 // -  sends transactions to the DA layer
-func (l *BatchSubmitter) publishingLoop(ctx context.Context, wg *sync.WaitGroup, receiptsCh chan txmgr.TxReceipt[txRef], publishSignal chan bool) {
+func (l *BatchSubmitter) publishingLoop(ctx context.Context, wg *sync.WaitGroup, receiptsCh chan txmgr.TxReceipt[txRef], publishSignal chan pubInfo) {
 	defer close(receiptsCh)
 	defer wg.Done()
 
@@ -499,9 +499,9 @@ func (l *BatchSubmitter) publishingLoop(ctx context.Context, wg *sync.WaitGroup,
 	}
 	txQueue := txmgr.NewQueue[txRef](ctx, l.Txmgr, l.Config.MaxPendingTransactions)
 
-	for forcePublish := range publishSignal {
-		l.Log.Debug("publishing loop received signal", "force_publish", forcePublish)
-		l.publishStateToL1(ctx, txQueue, receiptsCh, daGroup, forcePublish)
+	for pi := range l.publishSignal {
+		l.Log.Debug("publishing loop received signal", "force_publish", pi.forcePublish)
+		l.publishStateToL1(ctx, txQueue, receiptsCh, daGroup, pi.forcePublish)
 	}
 
 	// First wait for all DA requests to finish to prevent new transactions being queued
@@ -524,7 +524,7 @@ func (l *BatchSubmitter) publishingLoop(ctx context.Context, wg *sync.WaitGroup,
 // -  polls the sequencer,
 // -  prunes the channel manager state (i.e. safe blocks)
 // -  loads unsafe blocks from the sequencer
-func (l *BatchSubmitter) blockLoadingLoop(ctx context.Context, wg *sync.WaitGroup, unsafeBytesUpdated chan int64, publishSignal chan bool) {
+func (l *BatchSubmitter) blockLoadingLoop(ctx context.Context, wg *sync.WaitGroup, unsafeBytesUpdated chan int64, publishSignal chan pubInfo) {
 	ticker := time.NewTicker(l.Config.PollInterval)
 	defer ticker.Stop()
 	defer close(unsafeBytesUpdated)
@@ -556,7 +556,7 @@ func (l *BatchSubmitter) blockLoadingLoop(ctx context.Context, wg *sync.WaitGrou
 					l.sendToThrottlingLoop(unsafeBytesUpdated) // we have increased the unsafe data. Signal the throttling loop to check if it should throttle.
 				}
 			}
-			trySignal(publishSignal, false) // always signal the write loop to ensure we periodically publish even if we aren't loading blocks
+			l.tryPublishSignal(publishSignal, pubInfo{forcePublish: false, moreComing: false}) // always signal the write loop to ensure we periodically publish even if we aren't loading blocks
 		case <-ctx.Done():
 			l.Log.Info("blockLoadingLoop returning")
 			return
@@ -855,7 +855,7 @@ func (l *BatchSubmitter) publishTxToL1(ctx context.Context, queue *txmgr.Queue[t
 	// Collect next transaction data. This pulls data out of the channel, so we need to make sure
 	// to put it back if ever da or txmgr requests fail, by calling l.recordFailedDARequest/recordFailedTx.
 	l.channelMgrMutex.Lock()
-	txdata, err := l.channelMgr.TxData(l1tip.ID(), isPectra, params.IsThrottling(), forcePublish)
+	txdata, err := l.channelMgr.TxData(l1tip.ID(), isPectra, params.IsThrottling(), pubInfo{forcePublish: forcePublish})
 	l.channelMgrMutex.Unlock()
 
 	if err == io.EOF {

--- a/op-devstack/dsl/el.go
+++ b/op-devstack/dsl/el.go
@@ -38,7 +38,7 @@ func (el *elNode) WaitForBlock() eth.BlockRef {
 
 func (el *elNode) WaitForLabel(label eth.BlockLabel, predicate func(eth.BlockInfo) (bool, error)) eth.BlockInfo {
 	var block eth.BlockInfo
-	err := wait.For(el.ctx, 500*time.Millisecond, func() (bool, error) {
+	err := wait.For(el.ctx, 200*time.Millisecond, func() (bool, error) {
 		var err error
 		block, err = el.inner.EthClient().InfoByLabel(el.ctx, label)
 		if err != nil {

--- a/op-devstack/dsl/l2_network.go
+++ b/op-devstack/dsl/l2_network.go
@@ -1,7 +1,9 @@
 package dsl
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"math"
 	"time"
 
@@ -12,9 +14,11 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/stack/match"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/retry"
 	"github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
 )
 
 // L2Network wraps a stack.L2Network interface for DSL operations
@@ -260,4 +264,263 @@ func (n *L2Network) DisputeGameFactoryProxyAddr() common.Address {
 
 func (n *L2Network) DepositContractAddr() common.Address {
 	return n.inner.RollupConfig().DepositContractAddress
+}
+
+func (n *L2Network) DeriveData(blocks int) (channels []derive.ChannelID, channelFrames map[derive.ChannelID][]derive.Frame, l2Txs map[common.Address][]*ethtypes.Transaction) {
+	l := n.log
+	ctx := n.ctx
+
+	channelFrames = make(map[derive.ChannelID][]derive.Frame)
+	channels = make([]derive.ChannelID, 0)
+	l2Txs = make(map[common.Address][]*ethtypes.Transaction)
+
+	rollupCfg := n.inner.RollupConfig()
+	batchInboxAddr := rollupCfg.BatchInboxAddress
+
+	l1EC := n.inner.L1().L1ELNode(match.FirstL1EL).EthClient()
+
+	// Get current L1 block number before starting to monitor
+	startBlockRef, err := l1EC.BlockRefByLabel(ctx, eth.Unsafe)
+	n.require.NoError(err, "Failed to get start block number")
+
+	seenChannels := make(map[derive.ChannelID]bool)
+	lastBlockRef := startBlockRef
+
+	// Monitor L1 blocks for batch transactions
+	for range blocks {
+		NewL1ELNode(n.inner.L1().L1ELNode(match.FirstL1EL)).WaitForBlock()
+
+		// Get current block number
+		currentBlockRef, err := l1EC.BlockRefByLabel(ctx, eth.Unsafe)
+		n.require.NoError(err, "Failed to get current block number")
+		blockNum := currentBlockRef.Number
+		lastBlockRef = currentBlockRef
+
+		_, txs, err := l1EC.InfoAndTxsByNumber(ctx, blockNum)
+		n.require.NoError(err, "Failed to get block %d", blockNum)
+
+		// Process transactions in this block
+		for _, tx := range txs {
+			// Check if transaction is targeted to BatchInbox
+			if tx.To() != nil && *tx.To() == batchInboxAddr {
+				// Get transaction sender
+				chainID := n.inner.L1().ChainID()
+				chainIDBig := chainID.ToBig()
+				signer := ethtypes.LatestSignerForChainID(chainIDBig)
+				sender, err := signer.Sender(tx)
+				n.require.NoError(err, "Failed to get transaction sender")
+
+				l.Debug("Found batch transaction",
+					"txHash", tx.Hash(),
+					"block", blockNum,
+					"sender", sender)
+
+				var datas [][]byte
+				if tx.Type() != ethtypes.BlobTxType {
+					// Regular transaction - data is in tx.Data()
+					datas = append(datas, tx.Data())
+				} else {
+					// Blob transaction - need to fetch blobs from beacon
+					// For now, log that we found a blob tx but skip detailed parsing
+					// as it requires beacon API access
+					l.Error("Found blob transaction (skipping blob fetch for now)",
+						"txHash", tx.Hash(),
+						"blobHashes", tx.BlobHashes())
+					continue
+				}
+
+				// Parse frames from transaction data
+				for _, data := range datas {
+					frames, err := derive.ParseFrames(data)
+					if err != nil {
+						l.Warn("Failed to parse frames from transaction",
+							"txHash", tx.Hash(),
+							"error", err)
+						n.require.NoError(err)
+					}
+
+					l.Debug("Parsed frames from transaction",
+						"txHash", tx.Hash(),
+						"frameCount", len(frames))
+
+					// Process each frame
+					for _, frame := range frames {
+						channelID := frame.ID
+						if !seenChannels[channelID] {
+							seenChannels[channelID] = true
+							l.Debug("Found new channel",
+								"channelID", channelID.String(),
+								"txHash", tx.Hash(),
+								"block", blockNum)
+							channels = append(channels, channelID)
+						}
+						channelFrames[channelID] = append(channelFrames[channelID], frame)
+						l.Debug("Frame added to channel",
+							"channelID", channelID.String(),
+							"frameNumber", frame.FrameNumber,
+							"dataLength", len(frame.Data),
+							"isLast", frame.IsLast,
+							"txHash", tx.Hash())
+					}
+				}
+			}
+		}
+	}
+
+	// Reassemble channels and extract batches
+	for channelID, frames := range channelFrames {
+		l.Debug("Processing channel",
+			"channelID", channelID.String(),
+			"frameCount", len(frames))
+
+		// Sort frames by frame number
+		sortedFrames := make([]derive.Frame, len(frames))
+		copy(sortedFrames, frames)
+		for i := 0; i < len(sortedFrames); i++ {
+			for j := i + 1; j < len(sortedFrames); j++ {
+				if sortedFrames[i].FrameNumber > sortedFrames[j].FrameNumber {
+					sortedFrames[i], sortedFrames[j] = sortedFrames[j], sortedFrames[i]
+				}
+			}
+		}
+
+		// Create a channel and add frames to it
+		// We need an L1 block ref for the channel - use the last processed block as the origin
+		originBlock := lastBlockRef
+		ch := derive.NewChannel(channelID, originBlock, false)
+
+		for _, frame := range sortedFrames {
+			err := ch.AddFrame(frame, originBlock)
+			if err != nil {
+				l.Warn("Failed to add frame to channel",
+					"channelID", channelID.String(),
+					"frameNumber", frame.FrameNumber,
+					"error", err)
+				continue
+			}
+		}
+
+		l.Debug("Channel is ready, extracting batches",
+			"channelID", channelID.String(),
+			"size", ch.Size())
+
+		channelReader := ch.Reader()
+		channelData, err := io.ReadAll(channelReader)
+		if err != nil {
+			l.Warn("Failed to read channel data",
+				"channelID", channelID.String(),
+				"error", err)
+			continue
+		}
+
+		l.Debug("Read channel data",
+			"channelID", channelID.String(),
+			"dataLength", len(channelData))
+
+		spec := rollup.NewChainSpec(rollupCfg)
+		maxRLPBytes := spec.MaxRLPBytesPerChannel(originBlock.Time)
+		isFjord := rollupCfg.IsFjord(originBlock.Time)
+		batchReader, err := derive.BatchReader(bytes.NewReader(channelData), maxRLPBytes, isFjord)
+		if err != nil {
+			l.Warn("Failed to create batch reader",
+				"channelID", channelID.String(),
+				"error", err)
+			continue
+		}
+
+		// Read all batches from the channel
+		batchCount := 0
+		for {
+			batchData, err := batchReader()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				l.Warn("Failed to read batch from channel",
+					"channelID", channelID.String(),
+					"batchCount", batchCount,
+					"error", err)
+				break
+			}
+
+			batchCount++
+			batchType := batchData.GetBatchType()
+
+			l.Debug("Found batch in channel",
+				"channelID", channelID.String(),
+				"batchNumber", batchCount,
+				"batchType", batchType,
+				"compressionAlgo", batchData.ComprAlgo)
+
+			// Decode the batch based on type
+			if batchType == derive.SingularBatchType {
+				singularBatch, err := derive.GetSingularBatch(batchData)
+				if err != nil {
+					l.Warn("Failed to decode singular batch",
+						"channelID", channelID.String(),
+						"batchNumber", batchCount,
+						"error", err)
+					n.require.NoError(err)
+				}
+
+				for _, txData := range singularBatch.Transactions {
+					var tx ethtypes.Transaction
+					n.require.NoError(tx.UnmarshalBinary(txData))
+
+					signer := ethtypes.LatestSignerForChainID(rollupCfg.L2ChainID)
+					fromAddr, err := signer.Sender(&tx)
+					n.require.NoError(err)
+
+					l2Txs[fromAddr] = append(l2Txs[fromAddr], &tx)
+				}
+
+			} else if batchType == derive.SpanBatchType {
+				spanBatch, err := derive.DeriveSpanBatch(
+					batchData,
+					rollupCfg.BlockTime,
+					rollupCfg.Genesis.L2Time,
+					rollupCfg.L2ChainID,
+				)
+				if err != nil {
+					l.Warn("Failed to decode span batch",
+						"channelID", channelID.String(),
+						"batchNumber", batchCount,
+						"error", err)
+					continue
+				}
+
+				for blockIdx, batchElement := range spanBatch.Batches {
+					l.Debug("L2 block in span batch",
+						"channelID", channelID.String(),
+						"batchNumber", batchCount,
+						"blockIndex", blockIdx,
+						"epochNum", batchElement.EpochNum,
+						"timestamp", batchElement.Timestamp,
+						"txCount", len(batchElement.Transactions))
+
+					for _, txData := range batchElement.Transactions {
+						var tx ethtypes.Transaction
+						n.require.NoError(tx.UnmarshalBinary(txData))
+
+						signer := ethtypes.LatestSignerForChainID(rollupCfg.L2ChainID)
+						fromAddr, err := signer.Sender(&tx)
+						n.require.NoError(err)
+
+						l2Txs[fromAddr] = append(l2Txs[fromAddr], &tx)
+					}
+				}
+			} else {
+				l.Warn("Unknown batch type",
+					"channelID", channelID.String(),
+					"batchNumber", batchCount,
+					"batchType", batchType)
+			}
+		}
+
+		l.Debug("Finished processing channel",
+			"channelID", channelID.String(),
+			"totalBatches", batchCount)
+	}
+
+	return channels, channelFrames, l2Txs
 }

--- a/op-devstack/dsl/sequencer.go
+++ b/op-devstack/dsl/sequencer.go
@@ -1,7 +1,12 @@
 package dsl
 
 import (
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
 )
 
 type TestSequencer struct {
@@ -23,4 +28,11 @@ func (s *TestSequencer) String() string {
 
 func (s *TestSequencer) Escape() stack.TestSequencer {
 	return s.inner
+}
+
+func (s *TestSequencer) SequenceBlock(t devtest.T, chainID eth.ChainID, parent common.Hash) {
+	ca := s.Escape().ControlAPI(chainID)
+
+	require.NoError(t, ca.New(t.Ctx(), seqtypes.BuildOpts{Parent: parent}))
+	require.NoError(t, ca.Next(t.Ctx()))
 }

--- a/op-devstack/sysgo/l2_batcher.go
+++ b/op-devstack/sysgo/l2_batcher.go
@@ -89,7 +89,7 @@ func WithBatcher(batcherID stack.L2BatcherID, l1ELID stack.L1ELNodeID, l2CLID st
 			L1EthRpc:                 l1EL.UserRPC(),
 			L2EthRpc:                 []string{l2EL.UserRPC()},
 			RollupRpc:                []string{l2CL.UserRPC()},
-			MaxPendingTransactions:   1,
+			MaxPendingTransactions:   7,
 			MaxChannelDuration:       1,
 			MaxL1TxSize:              120_000,
 			TestUseMaxTxSizeForBlobs: false,

--- a/op-devstack/sysgo/l2_cl_opnode.go
+++ b/op-devstack/sysgo/l2_cl_opnode.go
@@ -28,6 +28,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup/interop"
 	nodeSync "github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/clock"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
 	"github.com/ethereum-optimism/optimism/op-service/oppprof"
@@ -51,6 +52,7 @@ type OpNode struct {
 	el               *stack.L2ELNodeID // Optional: nil when using SyncTester
 	userProxy        *tcpproxy.Proxy
 	interopProxy     *tcpproxy.Proxy
+	clock            clock.Clock
 }
 
 var _ L2CLNode = (*OpNode)(nil)
@@ -111,7 +113,7 @@ func (n *OpNode) Start() {
 		n.interopEndpoint = "ws://" + n.interopProxy.Addr()
 	}
 	n.logger.Info("Starting op-node")
-	opNode, err := opnode.NewOpnode(n.logger, n.cfg, func(err error) {
+	opNode, err := opnode.NewOpnode(n.logger, n.cfg, n.clock, func(err error) {
 		n.p.Require().NoError(err, "op-node critical error")
 	})
 	n.p.Require().NoError(err, "op-node failed to start")
@@ -314,6 +316,10 @@ func WithOpNode(l2CLID stack.L2CLNodeID, l1CLID stack.L1CLNodeID, l1ELID stack.L
 			cfg:    nodeCfg,
 			logger: logger,
 			p:      p,
+		}
+
+		if orch.timeTravelClock != nil {
+			l2CLNode.clock = orch.timeTravelClock
 		}
 
 		// Set the EL field to link to the L2EL node

--- a/op-e2e/e2eutils/opnode/opnode.go
+++ b/op-e2e/e2eutils/opnode/opnode.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/node/runcfg"
 	"github.com/ethereum-optimism/optimism/op-node/p2p"
 	"github.com/ethereum-optimism/optimism/op-service/cliapp"
+	"github.com/ethereum-optimism/optimism/op-service/clock"
 	"github.com/ethereum-optimism/optimism/op-service/endpoint"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
@@ -54,7 +55,7 @@ func (o *Opnode) P2P() p2p.Node {
 
 var _ services.RollupNode = (*Opnode)(nil)
 
-func NewOpnode(l log.Logger, c *config.Config, errFn func(error)) (*Opnode, error) {
+func NewOpnode(l log.Logger, c *config.Config, clk clock.Clock, errFn func(error)) (*Opnode, error) {
 	if err := c.Check(); err != nil {
 		return nil, err
 	}
@@ -70,7 +71,7 @@ func NewOpnode(l log.Logger, c *config.Config, errFn func(error)) (*Opnode, erro
 			l.Warn("closed op-node!")
 		}()
 	}
-	node, err := rollupNode.New(context.Background(), c, l, "", metrics.NewMetrics(""))
+	node, err := rollupNode.New(context.Background(), c, l, "", metrics.NewMetrics(""), clk)
 	if err != nil {
 		return nil, err
 	}

--- a/op-e2e/interop/supersystem_l2.go
+++ b/op-e2e/interop/supersystem_l2.go
@@ -22,6 +22,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 	l2os "github.com/ethereum-optimism/optimism/op-proposer/proposer"
 	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/clock"
 	"github.com/ethereum-optimism/optimism/op-service/dial"
 	"github.com/ethereum-optimism/optimism/op-service/endpoint"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
@@ -198,7 +199,7 @@ func (s *interopE2ESystem) newNodeForL2(
 		ConfigPersistence: config.DisabledConfigPersistence{},
 	}
 	opNode, err := opnode.NewOpnode(logger.New("service", "op-node"),
-		nodeCfg, func(err error) {
+		nodeCfg, clock.SystemClock, func(err error) {
 			s.t.Error(err)
 		})
 	require.NoError(s.t, err)

--- a/op-e2e/system/e2esys/setup.go
+++ b/op-e2e/system/e2esys/setup.go
@@ -612,10 +612,10 @@ func (cfg SystemConfig) Start(t *testing.T, startOpts ...StartOption) (*System, 
 	// Automatically stop the system at the end of the test
 	t.Cleanup(sys.Close)
 
-	c := clock.SystemClock
+	clk := clock.SystemClock
 	if cfg.SupportL1TimeTravel {
 		sys.TimeTravelClock = clock.NewAdvancingClock(100 * time.Millisecond)
-		c = sys.TimeTravelClock
+		clk = sys.TimeTravelClock
 	}
 
 	if err := cfg.DeployConfig.Check(testlog.Logger(t, log.LevelInfo)); err != nil {
@@ -747,7 +747,7 @@ func (cfg SystemConfig) Start(t *testing.T, startOpts ...StartOption) (*System, 
 
 	// Initialize nodes
 	l1Geth, _, err := geth.InitL1(
-		cfg.DeployConfig.L1BlockTime, cfg.L1FinalizedDistance, l1Genesis, c,
+		cfg.DeployConfig.L1BlockTime, cfg.L1FinalizedDistance, l1Genesis, clk,
 		path.Join(cfg.BlobsPath, "l1_el"), bcn, cfg.GethOptions[RoleL1]...)
 	if err != nil {
 		return nil, err
@@ -887,7 +887,7 @@ func (cfg SystemConfig) Start(t *testing.T, startOpts ...StartOption) (*System, 
 		c.Rollup.LogDescription(cfg.Loggers[name], chaincfg.L2ChainIDToNetworkDisplayName)
 		l := cfg.Loggers[name]
 
-		n, err := opnode.NewOpnode(l, &c, func(err error) {
+		n, err := opnode.NewOpnode(l, &c, clk, func(err error) {
 			t.Error(err)
 		})
 		require.NoError(t, err)

--- a/op-e2e/system/p2p/reqresp_test.go
+++ b/op-e2e/system/p2p/reqresp_test.go
@@ -157,7 +157,7 @@ func TestSystemP2PAltSync(t *testing.T) {
 	// Ensure L1 chain configuration is provided for the sync node
 	syncNodeCfg.L1ChainConfig = sys.L1GenesisCfg.Config
 
-	syncerNode, err := rollupNode.New(ctx, syncNodeCfg, cfg.Loggers["syncer"], "", metrics.NewMetrics(""))
+	syncerNode, err := rollupNode.New(ctx, syncNodeCfg, cfg.Loggers["syncer"], "", metrics.NewMetrics(""), nil)
 	require.NoError(t, err)
 	err = syncerNode.Start(ctx)
 	require.NoError(t, err)

--- a/op-node/cmd/main.go
+++ b/op-node/cmd/main.go
@@ -94,7 +94,7 @@ func RollupNodeMain(ctx *cli.Context, closeApp context.CancelCauseFunc) (cliapp.
 		cfg.Rollup.LogDescription(log, chaincfg.L2ChainIDToNetworkDisplayName)
 	}
 
-	n, err := node.New(ctx.Context, cfg, log, VersionWithMeta, m)
+	n, err := node.New(ctx.Context, cfg, log, VersionWithMeta, m, nil)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create the rollup node: %w", err)
 	}

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -34,6 +34,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup/sequencing"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/clock"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/event"
 	"github.com/ethereum-optimism/optimism/op-service/httputil"
@@ -103,6 +104,7 @@ type OpNode struct {
 	// Retain the config to test for active features rather than test for runtime state.
 	cfg        *config.Config
 	log        log.Logger
+	clock      clock.Clock
 	appVersion string
 	metrics    *metrics.Metrics
 
@@ -153,15 +155,15 @@ type OpNode struct {
 // New creates a new OpNode instance.
 // The provided ctx argument is for the span of initialization only;
 // the node will immediately Stop(ctx) before finishing initialization if the context is canceled during initialization.
-func New(ctx context.Context, cfg *config.Config, log log.Logger, appVersion string, m *metrics.Metrics) (*OpNode, error) {
-	return NewWithOverride(ctx, cfg, log, appVersion, m, InitializationOverrides{})
+func New(ctx context.Context, cfg *config.Config, log log.Logger, appVersion string, m *metrics.Metrics, clk clock.Clock) (*OpNode, error) {
+	return NewWithOverride(ctx, cfg, log, appVersion, m, clk, InitializationOverrides{})
 }
 
 // NewWithOverride creates a new OpNode instance with optional initialization overrides.
 // This allows callers to override specific initialization steps, enabling resource sharing
 // (e.g., shared L1Client across multiple nodes) without duplicating connections or caches.
 // If override is nil or any of its fields are nil, the default initialization is used for those steps.
-func NewWithOverride(ctx context.Context, cfg *config.Config, log log.Logger, appVersion string, m *metrics.Metrics, override InitializationOverrides) (*OpNode, error) {
+func NewWithOverride(ctx context.Context, cfg *config.Config, log log.Logger, appVersion string, m *metrics.Metrics, clk clock.Clock, override InitializationOverrides) (*OpNode, error) {
 	if err := cfg.Check(); err != nil {
 		return nil, err
 	}
@@ -169,6 +171,7 @@ func NewWithOverride(ctx context.Context, cfg *config.Config, log log.Logger, ap
 	n := &OpNode{
 		cfg:        cfg,
 		log:        log,
+		clock:      clk,
 		appVersion: appVersion,
 		metrics:    m,
 		rollupHalt: cfg.RollupHalt,
@@ -712,7 +715,7 @@ func initP2P(cfg *config.Config, node *OpNode) (*p2p.NodeP2P, error) {
 		}
 		// embed syncDeriver and tracer(optional) to the blockReceiver to handle unsafe payloads via p2p
 		rec := p2p.NewBlockReceiver(node.log, node.metrics, node.l2Driver.SyncDeriver, node.cfg.Tracer)
-		p2pNode, err := p2p.NewNodeP2P(node.resourcesCtx, &cfg.Rollup, node.log, cfg.P2P, rec, node.l2Source, node.runCfg, node.metrics)
+		p2pNode, err := p2p.NewNodeP2P(node.resourcesCtx, &cfg.Rollup, node.log, cfg.P2P, rec, node.l2Source, node.runCfg, node.metrics, node.clock)
 		if err != nil {
 			return nil, err
 		}

--- a/op-node/p2p/gossip.go
+++ b/op-node/p2p/gossip.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/clock"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/ptr"
 	opsigner "github.com/ethereum-optimism/optimism/op-service/signer"
@@ -264,7 +265,7 @@ func (sb *seenBlocks) markSeen(h common.Hash) {
 	sb.blockHashes = append(sb.blockHashes, h)
 }
 
-func BuildBlocksValidator(log log.Logger, cfg *rollup.Config, runCfg GossipRuntimeConfig, blockVersion eth.BlockVersion, gossipConf GossipSetupConfigurables) pubsub.ValidatorEx {
+func BuildBlocksValidator(log log.Logger, cfg *rollup.Config, runCfg GossipRuntimeConfig, blockVersion eth.BlockVersion, gossipConf GossipSetupConfigurables, clk clock.Clock) pubsub.ValidatorEx {
 	// Seen block hashes per block height
 	// uint64 -> *seenBlocks
 	blockHeightLRU, err := lru.New[uint64, *seenBlocks](1000)
@@ -331,6 +332,9 @@ func BuildBlocksValidator(log log.Logger, cfg *rollup.Config, runCfg GossipRunti
 
 		// rounding down to seconds is fine here.
 		now := uint64(time.Now().Unix())
+		if clk != nil {
+			now = uint64(clk.Now().Unix())
+		}
 
 		// [REJECT] if the `payload.timestamp` is older than the configured threshold
 		threshold := uint64(gossipConf.GetGossipTimestampThreshold().Seconds())
@@ -630,11 +634,11 @@ func (p *publisher) Close() error {
 	return errors.Join(e1, e2)
 }
 
-func JoinGossip(self peer.ID, ps *pubsub.PubSub, log log.Logger, cfg *rollup.Config, runCfg GossipRuntimeConfig, gossipIn GossipIn, gossipConf GossipSetupConfigurables) (GossipOut, error) {
+func JoinGossip(self peer.ID, ps *pubsub.PubSub, log log.Logger, cfg *rollup.Config, runCfg GossipRuntimeConfig, gossipIn GossipIn, gossipConf GossipSetupConfigurables, clk clock.Clock) (GossipOut, error) {
 	p2pCtx, p2pCancel := context.WithCancel(context.Background())
 
 	v1Logger := log.New("topic", "blocksV1")
-	blocksV1Validator := guardGossipValidator(log, logValidationResult(self, "validated blockv1", v1Logger, BuildBlocksValidator(v1Logger, cfg, runCfg, eth.BlockV1, gossipConf)))
+	blocksV1Validator := guardGossipValidator(log, logValidationResult(self, "validated blockv1", v1Logger, BuildBlocksValidator(v1Logger, cfg, runCfg, eth.BlockV1, gossipConf, clk)))
 	blocksV1, err := newBlockTopic(p2pCtx, blocksTopicV1(cfg), ps, v1Logger, gossipIn, blocksV1Validator)
 	if err != nil {
 		p2pCancel()
@@ -642,7 +646,7 @@ func JoinGossip(self peer.ID, ps *pubsub.PubSub, log log.Logger, cfg *rollup.Con
 	}
 
 	v2Logger := log.New("topic", "blocksV2")
-	blocksV2Validator := guardGossipValidator(log, logValidationResult(self, "validated blockv2", v2Logger, BuildBlocksValidator(v2Logger, cfg, runCfg, eth.BlockV2, gossipConf)))
+	blocksV2Validator := guardGossipValidator(log, logValidationResult(self, "validated blockv2", v2Logger, BuildBlocksValidator(v2Logger, cfg, runCfg, eth.BlockV2, gossipConf, clk)))
 	blocksV2, err := newBlockTopic(p2pCtx, blocksTopicV2(cfg), ps, v2Logger, gossipIn, blocksV2Validator)
 	if err != nil {
 		p2pCancel()
@@ -650,7 +654,7 @@ func JoinGossip(self peer.ID, ps *pubsub.PubSub, log log.Logger, cfg *rollup.Con
 	}
 
 	v3Logger := log.New("topic", "blocksV3")
-	blocksV3Validator := guardGossipValidator(log, logValidationResult(self, "validated blockv3", v3Logger, BuildBlocksValidator(v3Logger, cfg, runCfg, eth.BlockV3, gossipConf)))
+	blocksV3Validator := guardGossipValidator(log, logValidationResult(self, "validated blockv3", v3Logger, BuildBlocksValidator(v3Logger, cfg, runCfg, eth.BlockV3, gossipConf, clk)))
 	blocksV3, err := newBlockTopic(p2pCtx, blocksTopicV3(cfg), ps, v3Logger, gossipIn, blocksV3Validator)
 	if err != nil {
 		p2pCancel()
@@ -658,7 +662,7 @@ func JoinGossip(self peer.ID, ps *pubsub.PubSub, log log.Logger, cfg *rollup.Con
 	}
 
 	v4Logger := log.New("topic", "blocksV4")
-	blocksV4Validator := guardGossipValidator(log, logValidationResult(self, "validated blockv4", v4Logger, BuildBlocksValidator(v4Logger, cfg, runCfg, eth.BlockV4, gossipConf)))
+	blocksV4Validator := guardGossipValidator(log, logValidationResult(self, "validated blockv4", v4Logger, BuildBlocksValidator(v4Logger, cfg, runCfg, eth.BlockV4, gossipConf, clk)))
 	blocksV4, err := newBlockTopic(p2pCtx, blocksTopicV4(cfg), ps, v4Logger, gossipIn, blocksV4Validator)
 	if err != nil {
 		p2pCancel()

--- a/op-node/p2p/gossip_test.go
+++ b/op-node/p2p/gossip_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/golang/snappy"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/clock"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/ptr"
 	opsigner "github.com/ethereum-optimism/optimism/op-service/signer"
@@ -156,14 +157,14 @@ func TestBlockValidator(t *testing.T) {
 
 	// Create a mock gossip configuration for testing
 	mockGossipConf := &mockGossipSetupConfigurablesWithThreshold{threshold: 60 * time.Second}
-	v2Validator := BuildBlocksValidator(testlog.Logger(t, log.LevelCrit), cfg, runCfg, eth.BlockV2, mockGossipConf)
-	v3Validator := BuildBlocksValidator(testlog.Logger(t, log.LevelCrit), cfg, runCfg, eth.BlockV3, mockGossipConf)
-	v4Validator := BuildBlocksValidator(testlog.Logger(t, log.LevelDebug), cfg, runCfg, eth.BlockV4, mockGossipConf)
+	v2Validator := BuildBlocksValidator(testlog.Logger(t, log.LevelCrit), cfg, runCfg, eth.BlockV2, mockGossipConf, clock.SystemClock)
+	v3Validator := BuildBlocksValidator(testlog.Logger(t, log.LevelCrit), cfg, runCfg, eth.BlockV3, mockGossipConf, clock.SystemClock)
+	v4Validator := BuildBlocksValidator(testlog.Logger(t, log.LevelDebug), cfg, runCfg, eth.BlockV4, mockGossipConf, clock.SystemClock)
 	jovianCfg := &rollup.Config{
 		L2ChainID:  big.NewInt(100),
 		JovianTime: ptr.New(uint64(0)),
 	}
-	v4JovianValidator := BuildBlocksValidator(testlog.Logger(t, log.LevelCrit), jovianCfg, runCfg, eth.BlockV4, mockGossipConf)
+	v4JovianValidator := BuildBlocksValidator(testlog.Logger(t, log.LevelCrit), jovianCfg, runCfg, eth.BlockV4, mockGossipConf, clock.SystemClock)
 
 	zero, one := uint64(0), uint64(1)
 	beaconHash, withdrawalsRoot := common.HexToHash("0x1234"), common.HexToHash("0x9876")
@@ -263,7 +264,7 @@ func TestGossipTimestampThreshold(t *testing.T) {
 			mockConfig := &mockGossipSetupConfigurablesWithThreshold{threshold: tc.threshold}
 
 			// Create validator with the mock config
-			validator := BuildBlocksValidator(testlog.Logger(t, log.LevelCrit), cfg, runCfg, eth.BlockV2, mockConfig)
+			validator := BuildBlocksValidator(testlog.Logger(t, log.LevelCrit), cfg, runCfg, eth.BlockV2, mockConfig, clock.SystemClock)
 
 			// Create payload with the specific timestamp
 			payload := createExecutionPayload(types.Withdrawals{}, nil, nil, nil)

--- a/op-node/p2p/host_test.go
+++ b/op-node/p2p/host_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/metrics"
 	"github.com/ethereum-optimism/optimism/op-node/p2p/store"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/clock"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
@@ -120,7 +121,7 @@ func TestP2PFull(t *testing.T) {
 	runCfgB := &testutils.MockRuntimeConfig{P2PSeqAddress: common.Address{0x42}}
 
 	logA := testlog.Logger(t, log.LevelError).New("host", "A")
-	nodeA, err := NewNodeP2P(context.Background(), &rollup.Config{}, logA, &confA, &mockGossipIn{}, nil, runCfgA, metrics.NoopMetrics)
+	nodeA, err := NewNodeP2P(context.Background(), &rollup.Config{}, logA, &confA, &mockGossipIn{}, nil, runCfgA, metrics.NoopMetrics, clock.SystemClock)
 	require.NoError(t, err)
 	defer nodeA.Close()
 
@@ -149,7 +150,7 @@ func TestP2PFull(t *testing.T) {
 
 	logB := testlog.Logger(t, log.LevelError).New("host", "B")
 
-	nodeB, err := NewNodeP2P(context.Background(), &rollup.Config{}, logB, &confB, &mockGossipIn{}, nil, runCfgB, metrics.NoopMetrics)
+	nodeB, err := NewNodeP2P(context.Background(), &rollup.Config{}, logB, &confB, &mockGossipIn{}, nil, runCfgB, metrics.NoopMetrics, clock.SystemClock)
 	require.NoError(t, err)
 	defer nodeB.Close()
 	hostB := nodeB.Host()
@@ -321,7 +322,7 @@ func TestDiscovery(t *testing.T) {
 	resourcesCtx, resourcesCancel := context.WithCancel(context.Background())
 	defer resourcesCancel()
 
-	nodeA, err := NewNodeP2P(context.Background(), rollupCfg, logA, &confA, &mockGossipIn{}, nil, runCfgA, metrics.NoopMetrics)
+	nodeA, err := NewNodeP2P(context.Background(), rollupCfg, logA, &confA, &mockGossipIn{}, nil, runCfgA, metrics.NoopMetrics, clock.SystemClock)
 	require.NoError(t, err)
 	defer nodeA.Close()
 	hostA := nodeA.Host()
@@ -336,7 +337,7 @@ func TestDiscovery(t *testing.T) {
 	confB.DiscoveryDB = discDBC
 
 	// Start B
-	nodeB, err := NewNodeP2P(context.Background(), rollupCfg, logB, &confB, &mockGossipIn{}, nil, runCfgB, metrics.NoopMetrics)
+	nodeB, err := NewNodeP2P(context.Background(), rollupCfg, logB, &confB, &mockGossipIn{}, nil, runCfgB, metrics.NoopMetrics, clock.SystemClock)
 	require.NoError(t, err)
 	defer nodeB.Close()
 	hostB := nodeB.Host()
@@ -351,7 +352,7 @@ func TestDiscovery(t *testing.T) {
 		}})
 
 	// Start C
-	nodeC, err := NewNodeP2P(context.Background(), rollupCfg, logC, &confC, &mockGossipIn{}, nil, runCfgC, metrics.NoopMetrics)
+	nodeC, err := NewNodeP2P(context.Background(), rollupCfg, logC, &confC, &mockGossipIn{}, nil, runCfgC, metrics.NoopMetrics, clock.SystemClock)
 	require.NoError(t, err)
 	defer nodeC.Close()
 	hostC := nodeC.Host()

--- a/op-node/p2p/node.go
+++ b/op-node/p2p/node.go
@@ -61,6 +61,7 @@ func NewNodeP2P(
 	l2Chain L2Chain,
 	runCfg GossipRuntimeConfig,
 	metrics metrics.Metricer,
+	clock clock.Clock,
 ) (*NodeP2P, error) {
 	if setup == nil {
 		return nil, errors.New("p2p node cannot be created without setup")
@@ -69,7 +70,7 @@ func NewNodeP2P(
 		return nil, errors.New("SetupP2P.Disabled is true")
 	}
 	var n NodeP2P
-	if err := n.init(resourcesCtx, rollupCfg, log, setup, gossipIn, l2Chain, runCfg, metrics); err != nil {
+	if err := n.init(resourcesCtx, rollupCfg, log, setup, gossipIn, l2Chain, runCfg, metrics, clock); err != nil {
 		closeErr := n.Close()
 		if closeErr != nil {
 			log.Error("failed to close p2p after starting with err", "closeErr", closeErr, "err", err)
@@ -93,6 +94,7 @@ func (n *NodeP2P) init(
 	l2Chain L2Chain,
 	runCfg GossipRuntimeConfig,
 	metrics metrics.Metricer,
+	clk clock.Clock,
 ) error {
 	bwc := p2pmetrics.NewBandwidthCounter()
 
@@ -162,7 +164,7 @@ func (n *NodeP2P) init(
 	if err != nil {
 		return fmt.Errorf("failed to start gossipsub router: %w", err)
 	}
-	n.gsOut, err = JoinGossip(n.host.ID(), n.gs, log, rollupCfg, runCfg, gossipIn, setup)
+	n.gsOut, err = JoinGossip(n.host.ID(), n.gs, log, rollupCfg, runCfg, gossipIn, setup, clk)
 	if err != nil {
 		return fmt.Errorf("failed to join blocks gossip topic: %w", err)
 	}

--- a/op-supernode/supernode/chain_container/virtual_node/virtual_node.go
+++ b/op-supernode/supernode/chain_container/virtual_node/virtual_node.go
@@ -18,7 +18,7 @@ func defaultInnerNodeFactory(ctx context.Context, cfg *opnodecfg.Config, log get
 	if initOverload != nil {
 		overrides = *initOverload
 	}
-	return rollupNode.NewWithOverride(ctx, cfg, log, appVersion, m, overrides)
+	return rollupNode.NewWithOverride(ctx, cfg, log, appVersion, m, nil, overrides)
 }
 
 var (


### PR DESCRIPTION
Fixes: https://github.com/ethereum-optimism/optimism/issues/18092

---

This PR is:
1. Adding `time travel` support for the L2 chains in `op-devstack`.
2. Adding `TestBatcherFullChannelsAfterDowntime` integration test, which creates a backlog of ~1h worth of blocks, in order to test the `op-batcher` handling of a backlog after some downtime.
3. Locks the current behavior of the `op-batcher` with respect to processing backlogs and the number of channels it submits in such a scenario.
4. Modifying the `publishSignal` channel in the `op-batcher` to include information about the backlog of blocks (namely `pubInfo`), which should be taken into account when deciding if a channel has timed out, currently done in `registerL1Block`.
5. Derives back L2 data from L1 in `TestBatcherFullChannelsAfterDowntime` and confirm the number of `channels` and `frames` submitted as well as their `data length`, to determine if the batcher is working as expected.