### PR TITLE
fix(ci): add branch restriction and label override for artifact fallback

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -354,8 +354,14 @@ commands:
 
               # Check if PR has force-use-fresh-artifacts label (override fallback)
               if [ -n "${CIRCLE_PULL_REQUEST}" ]; then
-                export GH_TOKEN=${MISE_GITHUB_TOKEN}
-                if gh pr view ${CIRCLE_PULL_REQUEST} --json labels | grep -q "force-use-fresh-artifacts"; then
+                # Extract PR number from URL
+                PR_NUMBER=$(echo "${CIRCLE_PULL_REQUEST}" | grep -o '[0-9]*$')
+
+                # Query GitHub API for PR details
+                PR_DATA=$(curl -s -H "Authorization: token ${MISE_GITHUB_TOKEN}" \
+                  "https://api.github.com/repos/ethereum-optimism/optimism/pulls/${PR_NUMBER}")
+
+                if echo "$PR_DATA" | grep -q '"name"[[:space:]]*:[[:space:]]*"force-use-fresh-artifacts"'; then
                   echo "Force use fresh artifacts label detected, skipping fallback"
                   USE_FALLBACK=false
                 fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -345,34 +345,7 @@ commands:
     steps:
       - run:
           name: Pull artifacts
-          command: |
-            USE_FALLBACK=false
-
-            # Check if we're on a PR (not develop branch)
-            if [ "${CIRCLE_BRANCH}" != "develop" ]; then
-              USE_FALLBACK=true
-
-              # Check if PR has force-use-fresh-artifacts label (override fallback)
-              if [ -n "${CIRCLE_PULL_REQUEST}" ]; then
-                # Extract PR number from URL
-                PR_NUMBER=$(echo "${CIRCLE_PULL_REQUEST}" | grep -o '[0-9]*$')
-
-                # Query GitHub API for PR details
-                PR_DATA=$(curl -s -H "Authorization: token ${MISE_GITHUB_TOKEN}" \
-                  "https://api.github.com/repos/ethereum-optimism/optimism/pulls/${PR_NUMBER}")
-
-                if echo "$PR_DATA" | grep -q '"name"[[:space:]]*:[[:space:]]*"force-use-fresh-artifacts"'; then
-                  echo "Force use fresh artifacts label detected, skipping fallback"
-                  USE_FALLBACK=false
-                fi
-              fi
-            fi
-
-            if [ "$USE_FALLBACK" = "true" ]; then
-              bash scripts/ops/pull-artifacts.sh --fallback-to-latest
-            else
-              bash scripts/ops/pull-artifacts.sh
-            fi
+          command: bash scripts/ops/use-latest-fallback.sh
           working_directory: packages/contracts-bedrock
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -341,12 +341,28 @@ commands:
           key: go-<<parameters.namespace>>-<<parameters.version>>-<<parameters.module>>-{{ checksum "<<parameters.module>>/go.mod" }}-{{ checksum "<<parameters.module>>/go.sum" }}
 
   pull-artifacts-conditional:
-    description: "Pull artifacts with conditional fallback based on branch"
+    description: "Pull artifacts with conditional fallback based on branch and PR labels"
     steps:
       - run:
           name: Pull artifacts
           command: |
+            USE_FALLBACK=false
+
+            # Check if we're on a PR (not develop branch)
             if [ "${CIRCLE_BRANCH}" != "develop" ]; then
+              USE_FALLBACK=true
+
+              # Check if PR has force-use-fresh-artifacts label (override fallback)
+              if [ -n "${CIRCLE_PULL_REQUEST}" ]; then
+                export GH_TOKEN=${MISE_GITHUB_TOKEN}
+                if gh pr view ${CIRCLE_PULL_REQUEST} --json labels | grep -q "force-use-fresh-artifacts"; then
+                  echo "Force use fresh artifacts label detected, skipping fallback"
+                  USE_FALLBACK=false
+                fi
+              fi
+            fi
+
+            if [ "$USE_FALLBACK" = "true" ]; then
               bash scripts/ops/pull-artifacts.sh --fallback-to-latest
             else
               bash scripts/ops/pull-artifacts.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -340,6 +340,19 @@ commands:
             - ~/go/pkg/mod
           key: go-<<parameters.namespace>>-<<parameters.version>>-<<parameters.module>>-{{ checksum "<<parameters.module>>/go.mod" }}-{{ checksum "<<parameters.module>>/go.sum" }}
 
+  pull-artifacts-conditional:
+    description: "Pull artifacts with conditional fallback based on branch"
+    steps:
+      - run:
+          name: Pull artifacts
+          command: |
+            if [ "${CIRCLE_BRANCH}" != "develop" ]; then
+              bash scripts/ops/pull-artifacts.sh --fallback-to-latest
+            else
+              bash scripts/ops/pull-artifacts.sh
+            fi
+          working_directory: packages/contracts-bedrock
+
 jobs:
   # Kurtosis-based acceptance tests
   op-acceptance-tests-kurtosis:
@@ -932,10 +945,7 @@ jobs:
           name: Print forge version
           command: forge --version
           working_directory: packages/contracts-bedrock
-      - run:
-          name: Pull artifacts with latest fallback
-          command: bash scripts/ops/pull-artifacts.sh --fallback-to-latest
-          working_directory: packages/contracts-bedrock
+      - pull-artifacts-conditional
       - go-restore-cache:
           namespace: packages/contracts-bedrock/scripts/go-ffi
       - run:
@@ -1102,10 +1112,7 @@ jobs:
           name: Print forge version
           command: forge --version
           working_directory: packages/contracts-bedrock
-      - run:
-          name: Pull artifacts with latest fallback
-          command: bash scripts/ops/pull-artifacts.sh --fallback-to-latest
-          working_directory: packages/contracts-bedrock
+      - pull-artifacts-conditional
       - run:
           name: Install lcov
           command: |
@@ -1199,10 +1206,7 @@ jobs:
           name: Print forge version
           command: forge --version
           working_directory: packages/contracts-bedrock
-      - run:
-          name: Pull artifacts with latest fallback
-          command: bash scripts/ops/pull-artifacts.sh --fallback-to-latest
-          working_directory: packages/contracts-bedrock
+      - pull-artifacts-conditional
       - run:
           name: Write pinned block number for cache key
           command: |

--- a/packages/contracts-bedrock/scripts/ops/use-latest-fallback.sh
+++ b/packages/contracts-bedrock/scripts/ops/use-latest-fallback.sh
@@ -21,7 +21,7 @@ if [ "${CIRCLE_BRANCH:-}" != "develop" ]; then
     PR_DATA=$(curl -sS --fail --connect-timeout 10 --max-time 30 -H "Authorization: token ${MISE_GITHUB_TOKEN}" \
       "https://api.github.com/repos/ethereum-optimism/optimism/pulls/${PR_NUMBER}")
 
-    if echo "$PR_DATA" | grep -q '"name"[[:space:]]*:[[:space:]]*"force-use-fresh-artifacts"'; then
+    if echo "$PR_DATA" | jq -e 'any(.labels[]; .name == "force-use-fresh-artifacts")' >/dev/null; then
       echo "Force use fresh artifacts label detected, skipping fallback"
       USE_FALLBACK=false
     fi

--- a/packages/contracts-bedrock/scripts/ops/use-latest-fallback.sh
+++ b/packages/contracts-bedrock/scripts/ops/use-latest-fallback.sh
@@ -17,13 +17,16 @@ if [ "${CIRCLE_BRANCH:-}" != "develop" ]; then
     # Extract PR number from URL
     PR_NUMBER=$(echo "${CIRCLE_PULL_REQUEST}" | grep -o '[0-9]*$')
 
-    # Query GitHub API for PR details
-    PR_DATA=$(curl -sS --fail --connect-timeout 10 --max-time 30 -H "Authorization: token ${MISE_GITHUB_TOKEN}" \
-      "https://api.github.com/repos/ethereum-optimism/optimism/pulls/${PR_NUMBER}")
+    # Query GitHub API for PR details (fail safe: proceed with fallback on error)
+    if PR_DATA=$(curl -sS --fail --connect-timeout 10 --max-time 30 -H "Authorization: token ${MISE_GITHUB_TOKEN}" \
+      "https://api.github.com/repos/ethereum-optimism/optimism/pulls/${PR_NUMBER}" 2>/dev/null); then
 
-    if echo "$PR_DATA" | jq -e 'any(.labels[]; .name == "force-use-fresh-artifacts")' >/dev/null; then
-      echo "Force use fresh artifacts label detected, skipping fallback"
-      USE_FALLBACK=false
+      if echo "$PR_DATA" | jq -e 'any(.labels[]; .name == "force-use-fresh-artifacts")' >/dev/null 2>&1; then
+        echo "Force use fresh artifacts label detected, skipping fallback"
+        USE_FALLBACK=false
+      fi
+    else
+      echo "Warning: Failed to fetch PR labels from GitHub API, proceeding with fallback"
     fi
   fi
 fi

--- a/packages/contracts-bedrock/scripts/ops/use-latest-fallback.sh
+++ b/packages/contracts-bedrock/scripts/ops/use-latest-fallback.sh
@@ -18,7 +18,7 @@ if [ "${CIRCLE_BRANCH:-}" != "develop" ]; then
     PR_NUMBER=$(echo "${CIRCLE_PULL_REQUEST}" | grep -o '[0-9]*$')
 
     # Query GitHub API for PR details
-    PR_DATA=$(curl -s -H "Authorization: token ${MISE_GITHUB_TOKEN}" \
+    PR_DATA=$(curl -sS --fail --connect-timeout 10 --max-time 30 -H "Authorization: token ${MISE_GITHUB_TOKEN}" \
       "https://api.github.com/repos/ethereum-optimism/optimism/pulls/${PR_NUMBER}")
 
     if echo "$PR_DATA" | grep -q '"name"[[:space:]]*:[[:space:]]*"force-use-fresh-artifacts"'; then

--- a/packages/contracts-bedrock/scripts/ops/use-latest-fallback.sh
+++ b/packages/contracts-bedrock/scripts/ops/use-latest-fallback.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Pulls artifacts with conditional fallback based on branch and PR labels
+# - PR branches: Use fallback by default (faster builds)
+# - develop branch: Always build fresh (accuracy)
+# - force-use-fresh-artifacts label: Override fallback (emergency escape hatch)
+
+USE_FALLBACK=false
+
+# Check if we're on a PR (not develop branch)
+if [ "${CIRCLE_BRANCH:-}" != "develop" ]; then
+  USE_FALLBACK=true
+
+  # Check if PR has force-use-fresh-artifacts label (override fallback)
+  if [ -n "${CIRCLE_PULL_REQUEST:-}" ]; then
+    # Extract PR number from URL
+    PR_NUMBER=$(echo "${CIRCLE_PULL_REQUEST}" | grep -o '[0-9]*$')
+
+    # Query GitHub API for PR details
+    PR_DATA=$(curl -s -H "Authorization: token ${MISE_GITHUB_TOKEN}" \
+      "https://api.github.com/repos/ethereum-optimism/optimism/pulls/${PR_NUMBER}")
+
+    if echo "$PR_DATA" | grep -q '"name"[[:space:]]*:[[:space:]]*"force-use-fresh-artifacts"'; then
+      echo "Force use fresh artifacts label detected, skipping fallback"
+      USE_FALLBACK=false
+    fi
+  fi
+fi
+
+# Pull artifacts with or without fallback
+if [ "$USE_FALLBACK" = "true" ]; then
+  bash scripts/ops/pull-artifacts.sh --fallback-to-latest
+else
+  bash scripts/ops/pull-artifacts.sh
+fi


### PR DESCRIPTION
This PR adds branch-based conditional logic to restrict artifact fallback to PR builds only, and implements a label-based override mechanism for emergency cases.

### Reason

The fallback mechanism (which uses latest develop artifacts for speed) needs two safety controls:

1. **Branch restriction**: Develop merges must always build with fresh artifacts to avoid issues with snapshots/checks jobs that are sensitive to stale artifacts
2. **Label override**: PRs need an escape hatch to disable fallback when stale artifacts cause test failures or unexpected behavior

These controls maintain CI health on develop while preserving PR optimization benefits, with a safety valve for edge cases.

### Changes

- Add branch-based conditional logic to check `CIRCLE_BRANCH != develop` before enabling `--fallback-to-latest`
- Add `force-use-fresh-artifacts` PR label check to allow manual override of fallback (requires manual CI rerun after adding label)
- Extract `pull-artifacts-conditional` reusable CircleCI command to avoid code duplication
- Create `use-latest-fallback.sh` bash script with branch and label checking logic
- Update `contracts-bedrock-tests`, `contracts-bedrock-coverage`, and `contracts-bedrock-tests-upgrade` jobs to use new command