### PR TITLE
Use vm.prank(address,bool) for delegateCall, remove DelegateCaller contract

### DIFF
--- a/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
@@ -3,11 +3,10 @@ pragma solidity 0.8.15;
 
 // Testing
 import { Test, stdStorage, StdStorage } from "forge-std/Test.sol";
-import { VmSafe } from "forge-std/Vm.sol";
+import { Vm, VmSafe } from "forge-std/Vm.sol";
 import { CommonTest } from "test/setup/CommonTest.sol";
 import { FeatureFlags } from "test/setup/FeatureFlags.sol";
 import { DeployOPChain_TestBase } from "test/opcm/DeployOPChain.t.sol";
-import { DelegateCaller } from "test/mocks/Callers.sol";
 
 // Scripts
 import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
@@ -149,9 +148,6 @@ contract OPContractsManager_Upgrade_Harness is CommonTest, DisputeGames {
         upgrader = proxyAdmin.owner();
         vm.label(upgrader, "ProxyAdmin Owner");
 
-        // Set the upgrader to be a DelegateCaller so we can test the upgrade
-        vm.etch(upgrader, vm.getDeployedCode("test/mocks/Callers.sol:DelegateCaller"));
-
         opChainConfigs.push(
             IOPContractsManager.OpChainConfig({
                 systemConfigProxy: systemConfig,
@@ -213,18 +209,13 @@ contract OPContractsManager_Upgrade_Harness is CommonTest, DisputeGames {
         address initialProposer = permissionedGameProposer(disputeGameFactory);
 
         // Always start by upgrading the SuperchainConfig contract.
-        // Temporarily replace the superchainPAO with a DelegateCaller.
         address superchainPAO = IProxyAdmin(EIP1967Helper.getAdmin(address(superchainConfig))).owner();
-        bytes memory superchainPAOCode = address(superchainPAO).code;
-        vm.etch(superchainPAO, vm.getDeployedCode("test/mocks/Callers.sol:DelegateCaller"));
 
         // Execute the SuperchainConfig upgrade.
-        // nosemgrep: sol-safety-trycatch-eip150
-        try DelegateCaller(superchainPAO).dcForward(
-            address(_opcm), abi.encodeCall(IOPContractsManager.upgradeSuperchainConfig, (superchainConfig))
-        ) {
-            // Great, the upgrade succeeded.
-        } catch (bytes memory reason) {
+        prankDelegateCall(superchainPAO);
+        (bool success, bytes memory reason) =
+            address(_opcm).delegatecall(abi.encodeCall(IOPContractsManager.upgradeSuperchainConfig, (superchainConfig)));
+        if (success == false) {
             // Only acceptable revert reason is the SuperchainConfig already being up to date. This
             // try/catch is better than checking the version via the implementations struct because
             // the implementations struct interface can change between OPCM versions which would
@@ -236,22 +227,16 @@ contract OPContractsManager_Upgrade_Harness is CommonTest, DisputeGames {
             );
         }
 
-        // Reset the superchainPAO to the original code.
-        vm.etch(superchainPAO, superchainPAOCode);
-
-        // Temporarily replace the upgrader with a DelegateCaller.
-        bytes memory delegateCallerCode = address(_delegateCaller).code;
-        vm.etch(_delegateCaller, vm.getDeployedCode("test/mocks/Callers.sol:DelegateCaller"));
-
         // Expect the revert if one is specified.
         if (_revertBytes.length > 0) {
             vm.expectRevert(_revertBytes);
         }
 
         // Execute the chain upgrade.
-        DelegateCaller(_delegateCaller).dcForward(
-            address(_opcm), abi.encodeCall(IOPContractsManager.upgrade, (opChainConfigs))
-        );
+        prankDelegateCall(_delegateCaller);
+        (bool upgradeSuccess,) =
+            address(_opcm).delegatecall(abi.encodeCall(IOPContractsManager.upgrade, (opChainConfigs)));
+        assertTrue(upgradeSuccess, "upgrade failed");
 
         // Return early if a revert was expected. Otherwise we'll get errors below.
         if (_revertBytes.length > 0) {
@@ -263,9 +248,6 @@ contract OPContractsManager_Upgrade_Harness is CommonTest, DisputeGames {
         uint256 fusakaLimit = 2 ** 24;
         VmSafe.Gas memory gas = vm.lastCallGas();
         assertLt(gas.gasTotalUsed, fusakaLimit * 9 / 10, "Upgrade exceeds gas target of 90% of 2**24 (EIP-7825)");
-
-        // Reset the upgrader to the original code.
-        vm.etch(_delegateCaller, delegateCallerCode);
 
         // We expect there to only be one chain config for these tests, you will have to rework
         // this test if you add more.
@@ -1079,21 +1061,21 @@ contract OPContractsManager_UpdatePrestate_Test is OPContractsManager_TestInit {
             cannonKonaArgsBefore = _getParsedGameArgs(dgf, GameTypes.CANNON_KONA);
         }
 
-        // Turn the ProxyAdmin owner into a DelegateCaller.
-        address proxyAdminOwner = chainDeployOutput1.opChainProxyAdmin.owner();
-        vm.etch(address(proxyAdminOwner), vm.getDeployedCode("test/mocks/Callers.sol:DelegateCaller"));
-
         IOPContractsManager.UpdatePrestateInput[] memory inputs = new IOPContractsManager.UpdatePrestateInput[](1);
         inputs[0] = _input;
 
+        // make the call to cache the proxy admin owner before setting expectRevert
+        address proxyAdminOwner = chainDeployOutput1.opChainProxyAdmin.owner();
         if (_revertBytes.length > 0) {
             vm.expectRevert(_revertBytes);
         }
 
+        // Foundry fails with "cannot `prank` delegate call from an EOA" if empty
         // Trigger the updatePrestate function.
-        DelegateCaller(proxyAdminOwner).dcForward(
-            address(prestateUpdater), abi.encodeCall(IOPContractsManager.updatePrestate, (inputs))
-        );
+        prankDelegateCall(proxyAdminOwner);
+        (bool success,) =
+            address(prestateUpdater).delegatecall(abi.encodeCall(IOPContractsManager.updatePrestate, (inputs)));
+        assertTrue(success, "updatePrestate failed");
 
         // Return early if a revert was expected. Otherwise we'll get errors below.
         if (_revertBytes.length > 0) {
@@ -1215,14 +1197,12 @@ contract OPContractsManager_UpdatePrestate_Test is OPContractsManager_TestInit {
             chainDeployOutput1.systemConfigProxy, prestate, Claim.wrap(bytes32(0))
         );
 
-        // Turn the ProxyAdmin owner into a DelegateCaller.
-        address proxyAdminOwner = chainDeployOutput1.opChainProxyAdmin.owner();
-        vm.etch(address(proxyAdminOwner), vm.getDeployedCode("test/mocks/Callers.sol:DelegateCaller"));
-
         // Trigger the updatePrestate function.
-        DelegateCaller(proxyAdminOwner).dcForward(
-            address(prestateUpdater), abi.encodeCall(IOPContractsManager.updatePrestate, (inputs))
-        );
+        address proxyAdminOwner = chainDeployOutput1.opChainProxyAdmin.owner();
+        prankDelegateCall(proxyAdminOwner);
+        (bool success,) =
+            address(prestateUpdater).delegatecall(abi.encodeCall(IOPContractsManager.updatePrestate, (inputs)));
+        assertTrue(success, "updatePrestate failed");
 
         LibGameArgs.GameArgs memory permissionedGameArgs = LibGameArgs.decode(
             IDisputeGameFactory(chainDeployOutput1.systemConfigProxy.disputeGameFactory()).gameArgs(
@@ -1345,14 +1325,12 @@ contract OPContractsManager_UpdatePrestate_Test is OPContractsManager_TestInit {
             cannonKonaPrestate: cannonKonaPrestate
         });
 
-        // Turn the ProxyAdmin owner into a DelegateCaller.
-        address proxyAdminOwner = chainDeployOutput1.opChainProxyAdmin.owner();
-        vm.etch(address(proxyAdminOwner), vm.getDeployedCode("test/mocks/Callers.sol:DelegateCaller"));
-
         // Trigger the updatePrestate function.
-        DelegateCaller(proxyAdminOwner).dcForward(
-            address(prestateUpdater), abi.encodeCall(IOPContractsManager.updatePrestate, (inputs))
-        );
+        address proxyAdminOwner = chainDeployOutput1.opChainProxyAdmin.owner();
+        prankDelegateCall(proxyAdminOwner);
+        (bool success,) =
+            address(prestateUpdater).delegatecall(abi.encodeCall(IOPContractsManager.updatePrestate, (inputs)));
+        assertTrue(success, "updatePrestate failed");
 
         LibGameArgs.GameArgs memory permissionedGameArgs =
             LibGameArgs.decode(chainDeployOutput1.disputeGameFactoryProxy.gameArgs(GameTypes.SUPER_PERMISSIONED_CANNON));
@@ -1693,7 +1671,6 @@ contract OPContractsManager_Upgrade_Test is OPContractsManager_Upgrade_Harness {
 
     function test_upgrade_notProxyAdminOwner_reverts() public {
         address delegateCaller = makeAddr("delegateCaller");
-        vm.etch(delegateCaller, vm.getDeployedCode("test/mocks/Callers.sol:DelegateCaller"));
 
         assertNotEq(superchainProxyAdmin.owner(), delegateCaller);
         assertNotEq(proxyAdmin.owner(), delegateCaller);
@@ -1756,13 +1733,13 @@ contract OPContractsManager_UpgradeSuperchainConfig_Test is OPContractsManager_U
         ISuperchainConfig superchainConfig = ISuperchainConfig(artifacts.mustGetAddress("SuperchainConfigProxy"));
 
         address superchainPAO = IProxyAdmin(EIP1967Helper.getAdmin(address(superchainConfig))).owner();
-        vm.etch(superchainPAO, vm.getDeployedCode("test/mocks/Callers.sol:DelegateCaller"));
 
         vm.expectEmit(address(superchainConfig));
         emit Upgraded(impls.superchainConfigImpl);
-        DelegateCaller(superchainPAO).dcForward(
-            address(opcm), abi.encodeCall(IOPContractsManager.upgradeSuperchainConfig, (superchainConfig))
-        );
+        prankDelegateCall(superchainPAO);
+        (bool success,) =
+            address(opcm).delegatecall(abi.encodeCall(IOPContractsManager.upgradeSuperchainConfig, (superchainConfig)));
+        assertTrue(success, "upgradeSuperchainConfig failed");
     }
 
     /// @notice Tests that the upgradeSuperchainConfig function reverts when it is not called via delegatecall.
@@ -1779,15 +1756,16 @@ contract OPContractsManager_UpgradeSuperchainConfig_Test is OPContractsManager_U
         ISuperchainConfig superchainConfig = ISuperchainConfig(artifacts.mustGetAddress("SuperchainConfigProxy"));
 
         address delegateCaller = makeAddr("delegateCaller");
-        vm.etch(delegateCaller, vm.getDeployedCode("test/mocks/Callers.sol:DelegateCaller"));
+        vm.etch(delegateCaller, hex"00"); // Foundry fails with "cannot `prank` delegate call from an EOA" if empty
 
         assertNotEq(superchainProxyAdmin.owner(), delegateCaller);
         assertNotEq(proxyAdmin.owner(), delegateCaller);
 
         vm.expectRevert("Ownable: caller is not the owner");
-        DelegateCaller(delegateCaller).dcForward(
-            address(opcm), abi.encodeCall(IOPContractsManager.upgradeSuperchainConfig, (superchainConfig))
-        );
+        prankDelegateCall(delegateCaller);
+        (bool success,) =
+            address(opcm).delegatecall(abi.encodeCall(IOPContractsManager.upgradeSuperchainConfig, (superchainConfig)));
+        assertTrue(success, "upgradeSuperchainConfig failed");
     }
 
     /// @notice Tests that the upgradeSuperchainConfig function reverts when the superchainConfig version is the same or
@@ -1803,9 +1781,10 @@ contract OPContractsManager_UpgradeSuperchainConfig_Test is OPContractsManager_U
 
         // Try to upgrade the SuperchainConfig contract again, should fail.
         vm.expectRevert(IOPContractsManagerUpgrader.OPContractsManagerUpgrader_SuperchainConfigAlreadyUpToDate.selector);
-        DelegateCaller(upgrader).dcForward(
-            address(opcm), abi.encodeCall(IOPContractsManager.upgradeSuperchainConfig, (superchainConfig))
-        );
+        prankDelegateCall(upgrader);
+        (bool success,) =
+            address(opcm).delegatecall(abi.encodeCall(IOPContractsManager.upgradeSuperchainConfig, (superchainConfig)));
+        assertTrue(success, "upgradeSuperchainConfig failed");
     }
 }
 
@@ -1870,7 +1849,6 @@ contract OPContractsManager_Migrate_Test is OPContractsManager_TestInit {
     {
         // Set the proxy admin owner to be a delegate caller.
         address proxyAdminOwner = chainDeployOutput1.opChainProxyAdmin.owner();
-        vm.etch(address(proxyAdminOwner), vm.getDeployedCode("test/mocks/Callers.sol:DelegateCaller"));
 
         // Execute a delegatecall to the OPCM migration function.
         // Check gas usage of the migration function.
@@ -1878,7 +1856,9 @@ contract OPContractsManager_Migrate_Test is OPContractsManager_TestInit {
         if (_revertSelector != bytes4(0)) {
             vm.expectRevert(_revertSelector);
         }
-        DelegateCaller(proxyAdminOwner).dcForward(address(opcm), abi.encodeCall(IOPContractsManager.migrate, (_input)));
+        prankDelegateCall(proxyAdminOwner);
+        (bool success,) = address(opcm).delegatecall(abi.encodeCall(IOPContractsManager.migrate, (_input)));
+        assertTrue(success, "migrate failed");
         uint256 gasAfter = gasleft();
 
         // Make sure the gas usage is less than 20 million so we can definitely fit in a block.

--- a/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.15;
 
 // Testing
 import { Test, stdStorage, StdStorage } from "forge-std/Test.sol";
-import { Vm, VmSafe } from "forge-std/Vm.sol";
+import { VmSafe } from "forge-std/Vm.sol";
 import { CommonTest } from "test/setup/CommonTest.sol";
 import { FeatureFlags } from "test/setup/FeatureFlags.sol";
 import { DeployOPChain_TestBase } from "test/opcm/DeployOPChain.t.sol";

--- a/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
@@ -1070,7 +1070,6 @@ contract OPContractsManager_UpdatePrestate_Test is OPContractsManager_TestInit {
             vm.expectRevert(_revertBytes);
         }
 
-        // Foundry fails with "cannot `prank` delegate call from an EOA" if empty
         // Trigger the updatePrestate function.
         prankDelegateCall(proxyAdminOwner);
         (bool success,) =
@@ -1756,7 +1755,6 @@ contract OPContractsManager_UpgradeSuperchainConfig_Test is OPContractsManager_U
         ISuperchainConfig superchainConfig = ISuperchainConfig(artifacts.mustGetAddress("SuperchainConfigProxy"));
 
         address delegateCaller = makeAddr("delegateCaller");
-        vm.etch(delegateCaller, hex"00"); // Foundry fails with "cannot `prank` delegate call from an EOA" if empty
 
         assertNotEq(superchainProxyAdmin.owner(), delegateCaller);
         assertNotEq(proxyAdmin.owner(), delegateCaller);

--- a/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
@@ -5,7 +5,6 @@ pragma solidity 0.8.15;
 import { CommonTest } from "test/setup/CommonTest.sol";
 import { StandardConstants } from "scripts/deploy/StandardConstants.sol";
 import { DisputeGames } from "../setup/DisputeGames.sol";
-import { DelegateCaller } from "test/mocks/Callers.sol";
 
 // Libraries
 import { GameType, Hash } from "src/dispute/lib/LibUDT.sol";
@@ -207,9 +206,8 @@ abstract contract OPContractsManagerStandardValidator_TestInit is CommonTest, Di
                     addGameType(GameTypes.CANNON_KONA, cannonKonaPrestate);
                 }
             } else {
-                // Set the ProxyAdmin owner to be a delegatecaller.
+                // Get the ProxyAdmin owner.
                 address owner = proxyAdmin.owner();
-                vm.etch(owner, vm.getDeployedCode("test/mocks/Callers.sol:DelegateCaller"));
 
                 // Prepare the upgrade input.
                 IOPContractsManagerV2.DisputeGameConfig[] memory disputeGameConfigs =
@@ -242,8 +240,8 @@ abstract contract OPContractsManagerStandardValidator_TestInit is CommonTest, Di
                 });
 
                 // Call upgrade to all games to be enabled.
-                DelegateCaller(owner).dcForward(
-                    address(opcmV2),
+                prankDelegateCall(owner);
+                (bool success,) = address(opcmV2).delegatecall(
                     abi.encodeCall(
                         IOPContractsManagerV2.upgrade,
                         (
@@ -255,6 +253,7 @@ abstract contract OPContractsManagerStandardValidator_TestInit is CommonTest, Di
                         )
                     )
                 );
+                assertTrue(success, "upgrade failed");
 
                 // Grab the FaultDisputeGame implementation.
                 fdgImpl = IFaultDisputeGame(address(disputeGameFactory.gameImpls(GameTypes.CANNON)));

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
@@ -4,7 +4,6 @@ pragma solidity 0.8.15;
 // Testing
 import { VmSafe } from "forge-std/Vm.sol";
 import { CommonTest } from "test/setup/CommonTest.sol";
-import { DelegateCaller } from "test/mocks/Callers.sol";
 import { DisputeGames } from "test/setup/DisputeGames.sol";
 
 // Libraries
@@ -63,15 +62,13 @@ contract OPContractsManagerV2_Upgrade_TestInit is CommonTest, DisputeGames {
         skipIfNotForkTest("OPContractsManagerV2_Upgrade_TestInit: only runs in forked tests");
         skipIfOpsRepoTest("OPContractsManagerV2_Upgrade_TestInit: skipped in superchain-ops");
 
-        // Turn the chain PAO into a DelegateCaller.
+        // Set the chain PAO.
         chainPAO = proxyAdmin.owner();
         vm.label(chainPAO, "ProxyAdmin Owner");
-        vm.etch(chainPAO, vm.getDeployedCode("test/mocks/Callers.sol:DelegateCaller"));
 
-        // Turn the SuperchainConfig PAO into a DelegateCaller.
+        // Set the SuperchainConfig PAO.
         superchainPAO = IProxyAdmin(EIP1967Helper.getAdmin(address(superchainConfig))).owner();
         vm.label(superchainPAO, "SuperchainConfig ProxyAdmin Owner");
-        vm.etch(superchainPAO, vm.getDeployedCode("test/mocks/Callers.sol:DelegateCaller"));
 
         // Grab and set the L2 chain ID.
         l2ChainId = uint256(uint160(address(artifacts.mustGetAddress("L2ChainId"))));
@@ -135,8 +132,8 @@ contract OPContractsManagerV2_Upgrade_TestInit is CommonTest, DisputeGames {
 
         // Execute the SuperchainConfig upgrade.
         // nosemgrep: sol-safety-trycatch-eip150
-        try DelegateCaller(superchainPAO).dcForward(
-            address(opcmV2),
+        prankDelegateCall(superchainPAO);
+        (bool success, bytes memory reason) = address(opcmV2).delegatecall(
             abi.encodeCall(
                 IOPContractsManagerV2.upgradeSuperchain,
                 (
@@ -146,9 +143,8 @@ contract OPContractsManagerV2_Upgrade_TestInit is CommonTest, DisputeGames {
                     })
                 )
             )
-        ) {
-            // Great, the upgrade succeeded.
-        } catch (bytes memory reason) {
+        );
+        if (success == false) {
             // Only acceptable revert reason is the SuperchainConfig already being up to date. This
             // try/catch is better than checking the version via the implementations struct because
             // the implementations struct interface can change between OPCM versions which would
@@ -158,10 +154,6 @@ contract OPContractsManagerV2_Upgrade_TestInit is CommonTest, DisputeGames {
                 "Revert reason other than DowngradeNotAllowed"
             );
         }
-
-        // Temporarily replace the chainPAO with a DelegateCaller.
-        bytes memory delegateCallerCode = address(_delegateCaller).code;
-        vm.etch(_delegateCaller, vm.getDeployedCode("test/mocks/Callers.sol:DelegateCaller"));
 
         // Expect the revert if one is specified.
         if (_revertBytes.length > 0) {
@@ -174,25 +166,20 @@ contract OPContractsManagerV2_Upgrade_TestInit is CommonTest, DisputeGames {
         }
 
         // Execute the V2 chain upgrade via delegate caller.
-        DelegateCaller(_delegateCaller).dcForward(
-            address(opcmV2), abi.encodeCall(IOPContractsManagerV2.upgrade, (v2UpgradeInput))
-        );
+        prankDelegateCall(_delegateCaller);
+        (bool upgradeSuccess,) =
+            address(opcmV2).delegatecall(abi.encodeCall(IOPContractsManagerV2.upgrade, (v2UpgradeInput)));
+        assertTrue(upgradeSuccess, "upgrade failed");
 
         // Return early if a revert was expected. Otherwise we'll get errors below.
         if (_revertBytes.length > 0) {
             return;
         }
 
-        // Reset the chainPAO to the original code.
-        vm.etch(_delegateCaller, delegateCallerCode);
-
         // Less than 90% of the gas target of 2**24 (EIP-7825) to account for the gas used by using Safe.
         uint256 fusakaLimit = 2 ** 24;
         VmSafe.Gas memory gas = vm.lastCallGas();
         assertLt(gas.gasTotalUsed, fusakaLimit * 9 / 10, "Upgrade exceeds gas target of 90% of 2**24 (EIP-7825)");
-
-        // Reset the chainPAO to the original code.
-        vm.etch(_delegateCaller, delegateCallerCode);
 
         // Coverage changes bytecode, so we get various errors. We can safely ignore the result of
         // the standard validator in the coverage case, if the validator is failing in coverage
@@ -295,7 +282,6 @@ contract OPContractsManagerV2_Upgrade_Test is OPContractsManagerV2_Upgrade_TestI
     ///         owner address.
     function test_upgrade_notProxyAdminOwner_reverts() public {
         address delegateCaller = makeAddr("delegateCaller");
-        vm.etch(delegateCaller, vm.getDeployedCode("test/mocks/Callers.sol:DelegateCaller"));
 
         assertNotEq(superchainProxyAdmin.owner(), delegateCaller);
         assertNotEq(proxyAdmin.owner(), delegateCaller);
@@ -474,9 +460,11 @@ contract OPContractsManagerV2_UpgradeSuperchain_Test is OPContractsManagerV2_Upg
         emit Upgraded(superchainConfigImpl);
 
         // Do the upgrade.
-        DelegateCaller(superchainPAO).dcForward(
-            address(opcmV2), abi.encodeCall(IOPContractsManagerV2.upgradeSuperchain, (superchainUpgradeInput))
+        prankDelegateCall(superchainPAO);
+        (bool success,) = address(opcmV2).delegatecall(
+            abi.encodeCall(IOPContractsManagerV2.upgradeSuperchain, (superchainUpgradeInput))
         );
+        assertTrue(success, "upgradeSuperchain failed");
     }
 
     /// @notice Tests that the upgradeSuperchain function reverts when not delegatecalled.
@@ -488,9 +476,8 @@ contract OPContractsManagerV2_UpgradeSuperchain_Test is OPContractsManagerV2_Upg
     /// @notice Tests that the upgradeSuperchain function reverts when the delegate caller is not
     ///         the superchainProxyAdmin owner.
     function test_upgradeSuperchain_notProxyAdminOwner_reverts() public {
-        // Make a new address and turn it into a DelegateCaller.
+        // Make a new address for testing.
         address delegateCaller = makeAddr("delegateCaller");
-        vm.etch(delegateCaller, vm.getDeployedCode("test/mocks/Callers.sol:DelegateCaller"));
 
         // Sanity check that the address we generated isn't the superchainPAO or chainPAO.
         assertNotEq(superchainPAO, delegateCaller);
@@ -498,9 +485,11 @@ contract OPContractsManagerV2_UpgradeSuperchain_Test is OPContractsManagerV2_Upg
 
         // Should revert.
         vm.expectRevert("Ownable: caller is not the owner");
-        DelegateCaller(delegateCaller).dcForward(
-            address(opcmV2), abi.encodeCall(IOPContractsManagerV2.upgradeSuperchain, (superchainUpgradeInput))
+        prankDelegateCall(delegateCaller);
+        (bool success,) = address(opcmV2).delegatecall(
+            abi.encodeCall(IOPContractsManagerV2.upgradeSuperchain, (superchainUpgradeInput))
         );
+        assertTrue(success, "upgradeSuperchain failed");
     }
 
     /// @notice Tests that the upgradeSuperchain function reverts when the superchainConfig version
@@ -521,8 +510,10 @@ contract OPContractsManagerV2_UpgradeSuperchain_Test is OPContractsManagerV2_Upg
                 IOPContractsManagerV2.OPContractsManagerV2_DowngradeNotAllowed.selector, address(superchainConfig)
             )
         );
-        DelegateCaller(superchainPAO).dcForward(
-            address(opcmV2), abi.encodeCall(IOPContractsManagerV2.upgradeSuperchain, (superchainUpgradeInput))
+        prankDelegateCall(superchainPAO);
+        (bool success,) = address(opcmV2).delegatecall(
+            abi.encodeCall(IOPContractsManagerV2.upgradeSuperchain, (superchainUpgradeInput))
         );
+        assertTrue(success, "upgradeSuperchain failed");
     }
 }

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
@@ -131,7 +131,6 @@ contract OPContractsManagerV2_Upgrade_TestInit is CommonTest, DisputeGames {
         address initialProposer = permissionedGameProposer(disputeGameFactory);
 
         // Execute the SuperchainConfig upgrade.
-        // nosemgrep: sol-safety-trycatch-eip150
         prankDelegateCall(superchainPAO);
         (bool success, bytes memory reason) = address(opcmV2).delegatecall(
             abi.encodeCall(

--- a/packages/contracts-bedrock/test/mocks/Callers.sol
+++ b/packages/contracts-bedrock/test/mocks/Callers.sol
@@ -33,27 +33,6 @@ contract Reverter {
     }
 }
 
-/// @dev Can be etched in to any address to test making a delegatecall from that address.
-contract DelegateCaller {
-    function dcForward(address _target, bytes memory _data) external {
-        assembly {
-            // Perform the delegatecall, make sure to pass all available gas.
-            let success := delegatecall(gas(), _target, add(_data, 0x20), mload(_data), 0x0, 0x0)
-
-            // Copy returndata into memory at 0x0....returndatasize. Note that this *will*
-            // overwrite the calldata that we just copied into memory but that doesn't really
-            // matter because we'll be returning in a second anyway.
-            returndatacopy(0x0, 0x0, returndatasize())
-
-            // Success == 0 means a revert. We'll revert too and pass the data up.
-            if iszero(success) { revert(0x0, returndatasize()) }
-
-            // Otherwise we'll just return and pass the data up.
-            return(0x0, returndatasize())
-        }
-    }
-}
-
 /// @title GasBurner
 /// @notice Contract that burns a specified amount of gas on receive or fallback.
 contract GasBurner {

--- a/packages/contracts-bedrock/test/setup/CommonTest.sol
+++ b/packages/contracts-bedrock/test/setup/CommonTest.sol
@@ -237,4 +237,14 @@ abstract contract CommonTest is Test, Setup, Events {
 
         useUpgradedFork = false;
     }
+
+    /// @dev Helper function to setup a prank for delegatecall.
+    /// @param _caller The address to prank as the caller.
+    function prankDelegateCall(address _caller) internal {
+        // Foundry fails with "cannot `prank` delegate call from an EOA" if empty
+        if (_caller.code.length == 0) {
+            vm.etch(_caller, hex"00");
+        }
+        vm.prank(_caller, true);
+    }
 }

--- a/packages/contracts-bedrock/test/setup/ForkLive.s.sol
+++ b/packages/contracts-bedrock/test/setup/ForkLive.s.sol
@@ -246,8 +246,17 @@ contract ForkLive is Deployer, StdAssertions, DisputeGames {
         // Always try to upgrade the SuperchainConfig. Not always necessary but easier to do it
         // every time rather than adding or removing this code for each upgrade.
         vm.prank(superchainPAO, true);
-        (bool success, bytes memory reason) =
-            address(_opcm).delegatecall(abi.encodeCall(IOPContractsManager.upgradeSuperchainConfig, (superchainConfig)));
+        (bool success, bytes memory reason) = address(_opcm).delegatecall(
+            abi.encodeCall(
+                IOPContractsManagerV2.upgradeSuperchain,
+                (
+                    IOPContractsManagerV2.SuperchainUpgradeInput({
+                        superchainConfig: superchainConfig,
+                        extraInstructions: new IOPContractsManagerV2.ExtraInstruction[](0)
+                    })
+                )
+            )
+        );
         if (success == false) {
             // Only acceptable revert reason is downgrade not allowed.
             assertTrue(

--- a/packages/contracts-bedrock/test/setup/ForkLive.s.sol
+++ b/packages/contracts-bedrock/test/setup/ForkLive.s.sol
@@ -211,7 +211,6 @@ contract ForkLive is Deployer, StdAssertions, DisputeGames {
         });
 
         // Execute the SuperchainConfig upgrade.
-        // nosemgrep: sol-safety-trycatch-eip150
         // Always try to upgrade the SuperchainConfig. Not always necessary but easier to do it
         // every time rather than adding or removing this code for each upgrade.
         ISuperchainConfig superchainConfig = ISuperchainConfig(artifacts.mustGetAddress("SuperchainConfigProxy"));

--- a/packages/contracts-bedrock/test/setup/ForkLive.s.sol
+++ b/packages/contracts-bedrock/test/setup/ForkLive.s.sol
@@ -7,7 +7,6 @@ import { StdAssertions } from "forge-std/StdAssertions.sol";
 // Testing
 import { stdToml } from "forge-std/StdToml.sol";
 import { DisputeGames } from "test/setup/DisputeGames.sol";
-import { FeatureFlags } from "test/setup/FeatureFlags.sol";
 
 // Scripts
 import { Deployer } from "scripts/deploy/Deployer.sol";

--- a/packages/contracts-bedrock/test/setup/ForkLive.s.sol
+++ b/packages/contracts-bedrock/test/setup/ForkLive.s.sol
@@ -6,8 +6,8 @@ import { StdAssertions } from "forge-std/StdAssertions.sol";
 
 // Testing
 import { stdToml } from "forge-std/StdToml.sol";
-import { DelegateCaller } from "test/mocks/Callers.sol";
 import { DisputeGames } from "test/setup/DisputeGames.sol";
+import { FeatureFlags } from "test/setup/FeatureFlags.sol";
 
 // Scripts
 import { Deployer } from "scripts/deploy/Deployer.sol";
@@ -210,22 +210,17 @@ contract ForkLive is Deployer, StdAssertions, DisputeGames {
             cannonKonaPrestate: Claim.wrap(bytes32(keccak256("cannonKonaPrestate")))
         });
 
-        // Turn the SuperchainPAO into a DelegateCaller so we can try to upgrade the
-        // SuperchainConfig contract.
+        // Execute the SuperchainConfig upgrade.
+        // nosemgrep: sol-safety-trycatch-eip150
+        // Always try to upgrade the SuperchainConfig. Not always necessary but easier to do it
+        // every time rather than adding or removing this code for each upgrade.
         ISuperchainConfig superchainConfig = ISuperchainConfig(artifacts.mustGetAddress("SuperchainConfigProxy"));
         IProxyAdmin superchainProxyAdmin = IProxyAdmin(EIP1967Helper.getAdmin(address(superchainConfig)));
         address superchainPAO = superchainProxyAdmin.owner();
-        bytes memory superchainPAOCode = address(superchainPAO).code;
-        vm.etch(superchainPAO, vm.getDeployedCode("test/mocks/Callers.sol:DelegateCaller"));
-
-        // Always try to upgrade the SuperchainConfig. Not always necessary but easier to do it
-        // every time rather than adding or removing this code for each upgrade.
-        try DelegateCaller(superchainPAO).dcForward(
-            address(_opcm), abi.encodeCall(IOPContractsManager.upgradeSuperchainConfig, (superchainConfig))
-        ) {
-            // Great, the upgrade succeeded.
-        } catch (bytes memory reason) {
-            // Only acceptable revert reason is the SuperchainConfig already being up to date.
+        vm.prank(superchainPAO, true);
+        (bool success, bytes memory reason) =
+            address(_opcm).delegatecall(abi.encodeCall(IOPContractsManager.upgradeSuperchainConfig, (superchainConfig)));
+        if (success == false) {
             assertTrue(
                 bytes4(reason)
                     == IOPContractsManagerUpgrader.OPContractsManagerUpgrader_SuperchainConfigAlreadyUpToDate.selector,
@@ -233,21 +228,10 @@ contract ForkLive is Deployer, StdAssertions, DisputeGames {
             );
         }
 
-        // Reset the superchainPAO to the original code.
-        vm.etch(superchainPAO, superchainPAOCode);
-
-        // Temporarily replace the upgrader with a DelegateCaller so we can test the upgrade,
-        // then reset its code to the original code.
-        bytes memory upgraderCode = address(_delegateCaller).code;
-        vm.etch(_delegateCaller, vm.getDeployedCode("test/mocks/Callers.sol:DelegateCaller"));
-
         // Upgrade the chain.
-        DelegateCaller(_delegateCaller).dcForward(
-            address(_opcm), abi.encodeCall(IOPContractsManager.upgrade, (opChains))
-        );
-
-        // Reset the upgrader to the original code.
-        vm.etch(_delegateCaller, upgraderCode);
+        vm.prank(_delegateCaller, true);
+        (bool upgradeSuccess,) = address(_opcm).delegatecall(abi.encodeCall(IOPContractsManager.upgrade, (opChains)));
+        assertTrue(upgradeSuccess, "upgrade failed");
     }
 
     /// @notice Performs a single OPCM V2 upgrade.
@@ -256,44 +240,23 @@ contract ForkLive is Deployer, StdAssertions, DisputeGames {
     function _doUpgradeV2(IOPContractsManagerV2 _opcm, address _delegateCaller) internal {
         ISystemConfig systemConfig = ISystemConfig(artifacts.mustGetAddress("SystemConfigProxy"));
 
-        // Turn the SuperchainPAO into a DelegateCaller so we can try to upgrade the
-        // SuperchainConfig contract.
+        // Get the SuperchainPAO address.
         ISuperchainConfig superchainConfig = ISuperchainConfig(artifacts.mustGetAddress("SuperchainConfigProxy"));
         IProxyAdmin superchainProxyAdmin = IProxyAdmin(EIP1967Helper.getAdmin(address(superchainConfig)));
         address superchainPAO = superchainProxyAdmin.owner();
-        bytes memory superchainPAOCode = address(superchainPAO).code;
-        vm.etch(superchainPAO, vm.getDeployedCode("test/mocks/Callers.sol:DelegateCaller"));
 
         // Always try to upgrade the SuperchainConfig. Not always necessary but easier to do it
         // every time rather than adding or removing this code for each upgrade.
-        try DelegateCaller(superchainPAO).dcForward(
-            address(_opcm),
-            abi.encodeCall(
-                IOPContractsManagerV2.upgradeSuperchain,
-                (
-                    IOPContractsManagerV2.SuperchainUpgradeInput({
-                        superchainConfig: superchainConfig,
-                        extraInstructions: new IOPContractsManagerV2.ExtraInstruction[](0)
-                    })
-                )
-            )
-        ) {
-            // Great, the upgrade succeeded.
-        } catch (bytes memory reason) {
-            // Only acceptable revert reason is the SuperchainConfig already being up to date.
+        vm.prank(superchainPAO, true);
+        (bool success, bytes memory reason) =
+            address(_opcm).delegatecall(abi.encodeCall(IOPContractsManager.upgradeSuperchainConfig, (superchainConfig)));
+        if (success == false) {
+            // Only acceptable revert reason is downgrade not allowed.
             assertTrue(
                 bytes4(reason) == IOPContractsManagerV2.OPContractsManagerV2_DowngradeNotAllowed.selector,
                 "Revert reason other than DowngradeNotAllowed"
             );
         }
-
-        // Reset the superchainPAO to the original code.
-        vm.etch(superchainPAO, superchainPAOCode);
-
-        // Temporarily replace the upgrader with a DelegateCaller so we can test the upgrade,
-        // then reset its code to the original code.
-        bytes memory upgraderCode = address(_delegateCaller).code;
-        vm.etch(_delegateCaller, vm.getDeployedCode("test/mocks/Callers.sol:DelegateCaller"));
 
         // Grab the existing PermissionedDisputeGame parameters.
         IDisputeGameFactory disputeGameFactory =
@@ -343,9 +306,8 @@ contract ForkLive is Deployer, StdAssertions, DisputeGames {
         extraInstructions[0] =
             IOPContractsManagerV2.ExtraInstruction({ key: "PermittedProxyDeployment", data: bytes("DelayedWETH") });
 
-        // Upgrade the chain.
-        DelegateCaller(_delegateCaller).dcForward(
-            address(_opcm),
+        vm.prank(_delegateCaller, true);
+        (bool upgradeSuccess,) = address(_opcm).delegatecall(
             abi.encodeCall(
                 IOPContractsManagerV2.upgrade,
                 (
@@ -357,9 +319,7 @@ contract ForkLive is Deployer, StdAssertions, DisputeGames {
                 )
             )
         );
-
-        // Reset the upgrader to the original code.
-        vm.etch(_delegateCaller, upgraderCode);
+        assertTrue(upgradeSuccess, "upgrade failed");
     }
 
     /// @notice Upgrades the contracts using the OPCM.


### PR DESCRIPTION
Removes the usage of DelegateCaller. The pattern established is much nicer.

