### PR TITLE
op-deployer: record opDeployerVersion in intent and state

### DIFF
--- a/op-deployer/.goreleaser.yaml
+++ b/op-deployer/.goreleaser.yaml
@@ -27,8 +27,8 @@ builds:
         goarch: arm64
     mod_timestamp: "{{ .CommitTimestamp }}"
     ldflags:
-      - -X main.GitCommit={{ .FullCommit }}
-      - -X main.GitDate={{ .CommitDate }}
+      - -X github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/version.GitCommit={{ .FullCommit }}
+      - -X github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/version.GitDate={{ .CommitDate }}
       - -X github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/version.Version={{ .Version }}
       - -X github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/version.Meta=
 

--- a/op-deployer/cmd/op-deployer/main.go
+++ b/op-deployer/cmd/op-deployer/main.go
@@ -6,20 +6,10 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/cli"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/version"
-
-	opservice "github.com/ethereum-optimism/optimism/op-service"
 )
-
-var (
-	GitCommit = ""
-	GitDate   = ""
-)
-
-// VersionWithMeta holds the textual version string including the metadata.
-var VersionWithMeta = opservice.FormatVersion(version.Version, GitCommit, GitDate, version.Meta)
 
 func main() {
-	app := cli.NewApp(VersionWithMeta)
+	app := cli.NewApp(version.VersionWithMeta)
 	app.Writer = os.Stdout
 	app.ErrWriter = os.Stderr
 	err := app.Run(os.Args)

--- a/op-deployer/justfile
+++ b/op-deployer/justfile
@@ -19,10 +19,10 @@ copy-contract-artifacts:
         --exclude="*.t.sol"
 
 _LDFLAGSSTRING := "'" + trim(
-    "-X main.GitCommit=" + GITCOMMIT + " " + \
-    "-X main.GitDate=" + GITDATE + " " + \
-    "-X main.Version=" + VERSION + " " + \
-    "-X main.Meta=" + VERSION_META + " " + \
+    "-X github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/version.GitCommit=" + GITCOMMIT + " " + \
+    "-X github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/version.GitDate=" + GITDATE + " " + \
+    "-X github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/version.Version=" + VERSION + " " + \
+    "-X github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/version.Meta=" + VERSION_META + " " + \
     "") + "'"
 
 build-go: (go_build "./bin/op-deployer" "./cmd/op-deployer" "-ldflags" _LDFLAGSSTRING)
@@ -30,6 +30,9 @@ build-go: (go_build "./bin/op-deployer" "./cmd/op-deployer" "-ldflags" _LDFLAGSS
 docker-build: build-contracts copy-contract-artifacts
     #!/bin/bash
     cd ..
+    export GIT_VERSION="untagged"
+    export GIT_COMMIT=$(git rev-parse HEAD)
+    export GIT_DATE=$(git show -s --format=%ct HEAD)
     docker buildx bake op-deployer --load --set op-deployer.tags=op-deployer:local
 
 # Updates pkg/deployer/forge/version.json with version and checksum of tarball for each supported OS/arch

--- a/op-deployer/pkg/deployer/init.go
+++ b/op-deployer/pkg/deployer/init.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/state"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/version"
 
 	op_service "github.com/ethereum-optimism/optimism/op-service"
 
@@ -85,12 +86,13 @@ func Init(cfg InitConfig) error {
 	}
 
 	st := &state.State{
-		Version: 1,
+		Version:           1,
+		OpDeployerVersion: version.VersionWithMeta,
 	}
 
 	stat, err := os.Stat(cfg.Outdir)
 	if errors.Is(err, os.ErrNotExist) {
-		if err := os.MkdirAll(cfg.Outdir, 0755); err != nil {
+		if err := os.MkdirAll(cfg.Outdir, 0o755); err != nil {
 			return fmt.Errorf("failed to create outdir: %w", err)
 		}
 	} else if err != nil {

--- a/op-deployer/pkg/deployer/state/intent.go
+++ b/op-deployer/pkg/deployer/state/intent.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-chain-ops/addresses"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/artifacts"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/standard"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/version"
 	"github.com/ethereum-optimism/optimism/op-service/ioutil"
 	"github.com/ethereum-optimism/optimism/op-service/jsonutil"
 	"github.com/ethereum-optimism/superchain-registry/validation"
@@ -26,8 +27,10 @@ const (
 	IntentTypeStandardOverrides IntentType = "standard-overrides"
 )
 
-var emptyAddress common.Address
-var emptyHash common.Hash
+var (
+	emptyAddress common.Address
+	emptyHash    common.Hash
+)
 
 type SuperchainProofParams struct {
 	WithdrawalDelaySeconds          uint64      `json:"faultGameWithdrawalDelay" toml:"faultGameWithdrawalDelay"`
@@ -81,6 +84,7 @@ type L1DevGenesisParams struct {
 
 type Intent struct {
 	ConfigType            IntentType                 `json:"configType" toml:"configType"`
+	OpDeployerVersion     string                     `json:"opDeployerVersion" toml:"opDeployerVersion"`
 	L1ChainID             uint64                     `json:"l1ChainID" toml:"l1ChainID"`
 	OPCMAddress           *common.Address            `json:"opcmAddress" toml:"opcmAddress"`
 	SuperchainConfigProxy *common.Address            `json:"superchainConfigProxy" toml:"superchainConfigProxy"`
@@ -96,8 +100,10 @@ type Intent struct {
 	L1DevGenesisParams *L1DevGenesisParams `json:"l1DevGenesisParams"`
 }
 
-var ErrL1ContractsLocatorUndefined = errors.New("L1ContractsLocator undefined")
-var ErrL2ContractsLocatorUndefined = errors.New("L2ContractsLocator undefined")
+var (
+	ErrL1ContractsLocatorUndefined = errors.New("L1ContractsLocator undefined")
+	ErrL2ContractsLocatorUndefined = errors.New("L2ContractsLocator undefined")
+)
 
 func (c *Intent) L1ChainIDBig() *big.Int {
 	return big.NewInt(int64(c.L1ChainID))
@@ -305,6 +311,7 @@ func NewIntent(configType IntentType, l1ChainId uint64, l2ChainIds []common.Hash
 		return
 	}
 	intent.ConfigType = configType
+	intent.OpDeployerVersion = version.VersionWithMeta
 	return
 }
 
@@ -313,6 +320,7 @@ func NewIntent(configType IntentType, l1ChainId uint64, l2ChainIds []common.Hash
 func NewIntentCustom(l1ChainId uint64, l2ChainIds []common.Hash) (Intent, error) {
 	intent := Intent{
 		ConfigType:         IntentTypeCustom,
+		OpDeployerVersion:  version.VersionWithMeta,
 		L1ChainID:          l1ChainId,
 		L1ContractsLocator: &artifacts.Locator{URL: &url.URL{}},
 		L2ContractsLocator: &artifacts.Locator{URL: &url.URL{}},
@@ -336,6 +344,7 @@ func NewIntentStandard(l1ChainId uint64, l2ChainIds []common.Hash) (Intent, erro
 
 	intent := Intent{
 		ConfigType:         IntentTypeStandard,
+		OpDeployerVersion:  version.VersionWithMeta,
 		L1ChainID:          l1ChainId,
 		L1ContractsLocator: artifacts.DefaultL1ContractsLocator,
 		L2ContractsLocator: artifacts.DefaultL2ContractsLocator,

--- a/op-deployer/pkg/deployer/state/state.go
+++ b/op-deployer/pkg/deployer/state/state.go
@@ -25,6 +25,9 @@ type State struct {
 	// Version versions the state so we can update it later.
 	Version int `json:"version"`
 
+	// OpDeployerVersion is the version of op-deployer that was used to create the state
+	OpDeployerVersion string `json:"opDeployerVersion"`
+
 	// Create2Salt is the salt used for CREATE2 deployments.
 	Create2Salt common.Hash `json:"create2Salt"`
 

--- a/op-deployer/pkg/deployer/version/version.go
+++ b/op-deployer/pkg/deployer/version/version.go
@@ -1,6 +1,13 @@
 package version
 
+import opservice "github.com/ethereum-optimism/optimism/op-service"
+
 var (
-	Version = "v0.0.0"
-	Meta    = "dev"
+	GitCommit = ""
+	GitDate   = ""
+	Version   = "v0.0.0"
+	Meta      = "dev"
 )
+
+// VersionWithMeta holds the textual version string including the metadata.
+var VersionWithMeta = opservice.FormatVersion(Version, GitCommit, GitDate, Meta)

--- a/ops/docker/op-stack-go/Dockerfile
+++ b/ops/docker/op-stack-go/Dockerfile
@@ -181,10 +181,7 @@ RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache
 
 FROM --platform=$BUILDPLATFORM builder AS op-deployer-builder
 ARG OP_DEPLOYER_VERSION=v0.0.0
-
-# Add forge
 COPY --from=builder_foundry /usr/local/bin/forge /usr/local/bin/forge
-
 RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build just \
   GOOS=$TARGETOS GOARCH=$TARGETARCH GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE VERSION="$OP_DEPLOYER_VERSION" \
   op-deployer/build-go


### PR DESCRIPTION
# Problem

Since the state/intent contracts locators were modified to remove "tagged" locators and default to "embedded", we lost some information about which contracts are deployed if we're looking at the intent/state files. This makes it difficult for debugging and downstream tools to know which version of op-deployer/op-contracts was used to generate the state.json.

# Solution

1. Move version related vars from `cmd/op-deployer/main.go` to `pkg/deployer/version` (to make them importable by other parts of the code)
2. Update goreleaser and `just build-go` recipes to set the var values in the correct place based on [1] updates
3. Update op-deployer code to read the values set in [2] and write those values when intent/state structs are created