### PR TITLE
circleci: Slack context for scheduled-sync-test-op-node

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3179,7 +3179,7 @@ workflows:
           no_output_timeout: 30m
           context:
             - circleci-repo-readonly-authenticated-github-token
-            - discord
+            - slack
           requires:
             - contracts-bedrock-build
             - cannon-prestate-quick


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Even if `scheduled-sync-test-op-node` failed, no slack notif triggered because no auth. 
```
Posting Status
BASH_ENV file: /tmp/.bash_env-eb6ecf79-09be-4ba4-ad21-bf6729a227cc-0-build
Exists. Sourcing into ENV
In order to use the Slack Orb (v4 +), an OAuth token must be present via the SLACK_ACCESS_TOKEN environment variable.
Follow the setup guide available in the wiki: https://github.com/CircleCI-Public/slack-orb/wiki/Setup

Exited with code exit status 1
```

Example failure at https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/107614/workflows/892f5134-e4ab-4e36-9a87-b03e74373a94/jobs/4098262

Fix by adding proper circleci slack context.