### PR TITLE
op-deployer: activate jovian at genesis by default

### DIFF
--- a/op-acceptance-tests/tests/sync_tester/sync_tester_hfs/init_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_tester_hfs/init_test.go
@@ -15,7 +15,7 @@ import (
 func TestMain(m *testing.M) {
 	presets.DoMain(m, presets.WithSimpleWithSyncTester(),
 		presets.WithCompatibleTypes(compat.SysGo),
-		presets.WithHardforkSequentialActivation(rollup.Bedrock, rollup.Jovian, 15),
+		presets.WithHardforkSequentialActivation(rollup.Bedrock, rollup.Interop, 15),
 		stack.MakeCommon(sysgo.WithBatcherOption(func(id stack.L2BatcherID, cfg *bss.CLIConfig) {
 			// For supporting pre-delta batches
 			cfg.BatchType = derive.SingularBatchType

--- a/op-deployer/pkg/deployer/pipeline/l2genesis.go
+++ b/op-deployer/pkg/deployer/pipeline/l2genesis.go
@@ -113,7 +113,7 @@ func GenerateL2Genesis(pEnv *Env, intent *state.Intent, bundle ArtifactsBundle, 
 }
 
 func calculateL2GenesisOverrides(intent *state.Intent, thisIntent *state.ChainIntent) (l2GenesisOverrides, *genesis.UpgradeScheduleDeployConfig, error) {
-	schedule := standard.DefaultHardforkScheduleForTag(standard.CurrentTag)
+	schedule := standard.DefaultHardforkSchedule()
 
 	overrides := defaultOverrides()
 	// Special case for FundDevAccounts since it's both an intent value and an override.

--- a/op-deployer/pkg/deployer/pipeline/l2genesis_test.go
+++ b/op-deployer/pkg/deployer/pipeline/l2genesis_test.go
@@ -32,7 +32,7 @@ func TestCalculateL2GenesisOverrides(t *testing.T) {
 			expectError:       false,
 			expectedOverrides: defaultOverrides(),
 			expectedSchedule: func() *genesis.UpgradeScheduleDeployConfig {
-				return standard.DefaultHardforkScheduleForTag("")
+				return standard.DefaultHardforkSchedule()
 			},
 		},
 		{
@@ -55,7 +55,7 @@ func TestCalculateL2GenesisOverrides(t *testing.T) {
 				GovernanceTokenOwner:                     standard.GovernanceTokenOwner,
 			},
 			expectedSchedule: func() *genesis.UpgradeScheduleDeployConfig {
-				return standard.DefaultHardforkScheduleForTag("")
+				return standard.DefaultHardforkSchedule()
 			},
 		},
 		{
@@ -89,7 +89,7 @@ func TestCalculateL2GenesisOverrides(t *testing.T) {
 				GovernanceTokenOwner:                     common.HexToAddress("0x1111111111111111111111111111111111111111"),
 			},
 			expectedSchedule: func() *genesis.UpgradeScheduleDeployConfig {
-				sched := standard.DefaultHardforkScheduleForTag("")
+				sched := standard.DefaultHardforkSchedule()
 				sched.L2GenesisInteropTimeOffset = op_service.U64UtilPtr(0x1234)
 				return sched
 			},
@@ -129,7 +129,7 @@ func TestCalculateL2GenesisOverrides(t *testing.T) {
 				GovernanceTokenOwner:                     common.HexToAddress("0x1111111111111111111111111111111111111111"),
 			},
 			expectedSchedule: func() *genesis.UpgradeScheduleDeployConfig {
-				sched := standard.DefaultHardforkScheduleForTag("")
+				sched := standard.DefaultHardforkSchedule()
 				sched.L2GenesisInteropTimeOffset = op_service.U64UtilPtr(0x1234)
 				return sched
 			},
@@ -146,7 +146,7 @@ func TestCalculateL2GenesisOverrides(t *testing.T) {
 			expectError:       false,
 			expectedOverrides: defaultOverrides(),
 			expectedSchedule: func() *genesis.UpgradeScheduleDeployConfig {
-				schedule := standard.DefaultHardforkScheduleForTag("")
+				schedule := standard.DefaultHardforkSchedule()
 				schedule.L2GenesisInteropTimeOffset = op_service.U64UtilPtr(0)
 				return schedule
 			},

--- a/op-deployer/pkg/deployer/standard/standard.go
+++ b/op-deployer/pkg/deployer/standard/standard.go
@@ -10,7 +10,6 @@ import (
 	"github.com/ethereum/go-ethereum/superchain"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	op_service "github.com/ethereum-optimism/optimism/op-service"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -163,11 +162,8 @@ func ProtocolVersionsOwner(chainID uint64) (common.Address, error) {
 	}
 }
 
-// DefaultHardforkScheduleForTag is used to determine which hardforks should be activated by default given a
-// contract tag. For example, passing in v1.6.0 will return all hardforks up to and including Granite. This allows
-// OP Deployer to set sane defaults for hardforks. This is not an ideal solution, but it will have to work until we get
-// to MCP L2.
-func DefaultHardforkScheduleForTag(tag string) *genesis.UpgradeScheduleDeployConfig {
+// DefaultHardforkSchedule is used to determine which hardforks should be activated by default.
+func DefaultHardforkSchedule() *genesis.UpgradeScheduleDeployConfig {
 	sched := &genesis.UpgradeScheduleDeployConfig{
 		L2GenesisRegolithTimeOffset: op_service.U64UtilPtr(0),
 		L2GenesisCanyonTimeOffset:   op_service.U64UtilPtr(0),
@@ -175,19 +171,9 @@ func DefaultHardforkScheduleForTag(tag string) *genesis.UpgradeScheduleDeployCon
 		L2GenesisEcotoneTimeOffset:  op_service.U64UtilPtr(0),
 		L2GenesisFjordTimeOffset:    op_service.U64UtilPtr(0),
 		L2GenesisGraniteTimeOffset:  op_service.U64UtilPtr(0),
-	}
-
-	switch tag {
-	case ContractsV160Tag, ContractsV170Beta1L2Tag:
-		return sched
-	case ContractsV180Tag, ContractsV200Tag, ContractsV300Tag:
-		sched.ActivateForkAtGenesis(rollup.Holocene)
-	case ContractsV400Tag, ContractsV410Tag:
-		sched.ActivateForkAtGenesis(rollup.Holocene)
-		sched.ActivateForkAtGenesis(rollup.Isthmus)
-	default:
-		sched.ActivateForkAtGenesis(rollup.Holocene)
-		sched.ActivateForkAtGenesis(rollup.Isthmus)
+		L2GenesisHoloceneTimeOffset: op_service.U64UtilPtr(0),
+		L2GenesisIsthmusTimeOffset:  op_service.U64UtilPtr(0),
+		L2GenesisJovianTimeOffset:   op_service.U64UtilPtr(0),
 	}
 
 	return sched

--- a/op-deployer/pkg/deployer/standard/standard.go
+++ b/op-deployer/pkg/deployer/standard/standard.go
@@ -10,7 +10,7 @@ import (
 	"github.com/ethereum/go-ethereum/superchain"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
-	op_service "github.com/ethereum-optimism/optimism/op-service"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
 
 	"github.com/ethereum/go-ethereum/common"
 )
@@ -164,17 +164,8 @@ func ProtocolVersionsOwner(chainID uint64) (common.Address, error) {
 
 // DefaultHardforkSchedule is used to determine which hardforks should be activated by default.
 func DefaultHardforkSchedule() *genesis.UpgradeScheduleDeployConfig {
-	sched := &genesis.UpgradeScheduleDeployConfig{
-		L2GenesisRegolithTimeOffset: op_service.U64UtilPtr(0),
-		L2GenesisCanyonTimeOffset:   op_service.U64UtilPtr(0),
-		L2GenesisDeltaTimeOffset:    op_service.U64UtilPtr(0),
-		L2GenesisEcotoneTimeOffset:  op_service.U64UtilPtr(0),
-		L2GenesisFjordTimeOffset:    op_service.U64UtilPtr(0),
-		L2GenesisGraniteTimeOffset:  op_service.U64UtilPtr(0),
-		L2GenesisHoloceneTimeOffset: op_service.U64UtilPtr(0),
-		L2GenesisIsthmusTimeOffset:  op_service.U64UtilPtr(0),
-		L2GenesisJovianTimeOffset:   op_service.U64UtilPtr(0),
-	}
+	sched := &genesis.UpgradeScheduleDeployConfig{}
+	sched.ActivateForkAtGenesis(rollup.Jovian)
 
 	return sched
 }

--- a/op-deployer/pkg/deployer/standard/standard_test.go
+++ b/op-deployer/pkg/deployer/standard/standard_test.go
@@ -13,8 +13,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDefaultHardforkScheduleForTag(t *testing.T) {
+func TestDefaultHardforkSchedule(t *testing.T) {
 	sched := DefaultHardforkSchedule()
+	require.NotNil(t, sched.RegolithTime(0))
+	require.NotNil(t, sched.CanyonTime(0))
+	require.NotNil(t, sched.DeltaTime(0))
+	require.NotNil(t, sched.EcotoneTime(0))
+	require.NotNil(t, sched.FjordTime(0))
+	require.NotNil(t, sched.GraniteTime(0))
 	require.NotNil(t, sched.HoloceneTime(0))
 	require.NotNil(t, sched.IsthmusTime(0))
 	require.NotNil(t, sched.JovianTime(0))

--- a/op-deployer/pkg/deployer/standard/standard_test.go
+++ b/op-deployer/pkg/deployer/standard/standard_test.go
@@ -14,25 +14,10 @@ import (
 )
 
 func TestDefaultHardforkScheduleForTag(t *testing.T) {
-	sched := DefaultHardforkScheduleForTag(ContractsV160Tag)
-	require.Nil(t, sched.HoloceneTime(0))
-	require.Nil(t, sched.IsthmusTime(0))
-
-	sched = DefaultHardforkScheduleForTag(ContractsV180Tag)
-	require.NotNil(t, sched.HoloceneTime(0))
-	require.Nil(t, sched.IsthmusTime(0))
-
-	sched = DefaultHardforkScheduleForTag(ContractsV200Tag)
-	require.NotNil(t, sched.HoloceneTime(0))
-	require.Nil(t, sched.IsthmusTime(0))
-
-	sched = DefaultHardforkScheduleForTag(ContractsV300Tag)
-	require.NotNil(t, sched.HoloceneTime(0))
-	require.Nil(t, sched.IsthmusTime(0))
-
-	sched = DefaultHardforkScheduleForTag("")
+	sched := DefaultHardforkSchedule()
 	require.NotNil(t, sched.HoloceneTime(0))
 	require.NotNil(t, sched.IsthmusTime(0))
+	require.NotNil(t, sched.JovianTime(0))
 }
 
 func TestStandardAddresses(t *testing.T) {

--- a/op-deployer/pkg/deployer/state/deploy_config.go
+++ b/op-deployer/pkg/deployer/state/deploy_config.go
@@ -18,12 +18,10 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 
-var (
-	l2GenesisBlockBaseFeePerGas = hexutil.Big(*(big.NewInt(1000000000)))
-)
+var l2GenesisBlockBaseFeePerGas = hexutil.Big(*(big.NewInt(1000000000)))
 
 func CombineDeployConfig(intent *Intent, chainIntent *ChainIntent, state *State, chainState *ChainState) (genesis.DeployConfig, error) {
-	upgradeSchedule := standard.DefaultHardforkScheduleForTag(standard.CurrentTag)
+	upgradeSchedule := standard.DefaultHardforkSchedule()
 
 	cfg := genesis.DeployConfig{
 		L1DependenciesConfig: genesis.L1DependenciesConfig{
@@ -149,7 +147,6 @@ func CombineDeployConfig(intent *Intent, chainIntent *ChainIntent, state *State,
 		cfg, err = jsonutil.MergeJSON(cfg, intent.GlobalDeployOverrides)
 		if err != nil {
 			return genesis.DeployConfig{}, fmt.Errorf("error merging global L2 overrides: %w", err)
-
 		}
 	}
 


### PR DESCRIPTION
By default, activate jovian hardfork at genesis for new chains.

Also, removes the contract tag input from the `DefaultHardforkSchedule` function since any given version of op-deployer is only meant to deploy contracts and create genesis for the `CurrentTag` (aka latest op-contracts tag).