### PR TITLE
feat: expose starting root in ASR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1181,7 +1181,7 @@ jobs:
         default: ""
     docker:
       - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: xlarge
+    resource_class: 2xlarge
     steps:
       - utils/checkout-with-mise
       - install-contracts-dependencies

--- a/packages/contracts-bedrock/interfaces/dispute/IAnchorStateRegistry.sol
+++ b/packages/contracts-bedrock/interfaces/dispute/IAnchorStateRegistry.sol
@@ -26,6 +26,7 @@ interface IAnchorStateRegistry is IProxyAdminOwnedBase {
     function blacklistDisputeGame(IDisputeGame _disputeGame) external;
     function disputeGameBlacklist(IDisputeGame) external view returns (bool);
     function getAnchorRoot() external view returns (Hash, uint256);
+    function startingAnchorRoot() external view returns (Hash root, uint256 l2SequenceNumber);
     function disputeGameFinalityDelaySeconds() external view returns (uint256);
     function disputeGameFactory() external view returns (IDisputeGameFactory);
     function initialize(

--- a/packages/contracts-bedrock/interfaces/dispute/IAnchorStateRegistry.sol
+++ b/packages/contracts-bedrock/interfaces/dispute/IAnchorStateRegistry.sol
@@ -26,7 +26,7 @@ interface IAnchorStateRegistry is IProxyAdminOwnedBase {
     function blacklistDisputeGame(IDisputeGame _disputeGame) external;
     function disputeGameBlacklist(IDisputeGame) external view returns (bool);
     function getAnchorRoot() external view returns (Hash, uint256);
-    function startingAnchorRoot() external view returns (Hash root, uint256 l2SequenceNumber);
+    function getStartingAnchorRoot() external view returns (Proposal memory);
     function disputeGameFinalityDelaySeconds() external view returns (uint256);
     function disputeGameFactory() external view returns (IDisputeGameFactory);
     function initialize(

--- a/packages/contracts-bedrock/snapshots/abi/AnchorStateRegistry.json
+++ b/packages/contracts-bedrock/snapshots/abi/AnchorStateRegistry.json
@@ -125,6 +125,31 @@
   },
   {
     "inputs": [],
+    "name": "getStartingAnchorRoot",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "Hash",
+            "name": "root",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint256",
+            "name": "l2SequenceNumber",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct Proposal",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
     "name": "initVersion",
     "outputs": [
       {
@@ -417,24 +442,6 @@
     "name": "setRespectedGameType",
     "outputs": [],
     "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "startingAnchorRoot",
-    "outputs": [
-      {
-        "internalType": "Hash",
-        "name": "root",
-        "type": "bytes32"
-      },
-      {
-        "internalType": "uint256",
-        "name": "l2SequenceNumber",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
     "type": "function"
   },
   {

--- a/packages/contracts-bedrock/snapshots/abi/AnchorStateRegistry.json
+++ b/packages/contracts-bedrock/snapshots/abi/AnchorStateRegistry.json
@@ -421,6 +421,24 @@
   },
   {
     "inputs": [],
+    "name": "startingAnchorRoot",
+    "outputs": [
+      {
+        "internalType": "Hash",
+        "name": "root",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "l2SequenceNumber",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
     "name": "superchainConfig",
     "outputs": [
       {

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -164,8 +164,8 @@
     "sourceCodeHash": "0x03c160168986ffc8d26a90c37366e7ad6da03f49d83449e1f8b3de0f4b590f6f"
   },
   "src/dispute/AnchorStateRegistry.sol:AnchorStateRegistry": {
-    "initCodeHash": "0x9a4206f5952acde111cd6ae909e587c91b0f6f0dc118ac2db208b9f716e062ca",
-    "sourceCodeHash": "0xefe8de8c70fed698ccba922732f6601d27a87ee2e1d88eaac67a00d8cb3dfd4b"
+    "initCodeHash": "0xc00fdb1a4ae0ec8d7a96ebaad38ffaee9d96b942ab2a56e0ce2f76639f79ae7c",
+    "sourceCodeHash": "0xd2837ddf6992926ced31ef1916f95ebb8cc2006e94b82c2287997e5397edfeaf"
   },
   "src/dispute/DelayedWETH.sol:DelayedWETH": {
     "initCodeHash": "0xa8f60e142108b33675a8f6b6979c73b96eea247884842d796f9f878904c0a906",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -164,8 +164,8 @@
     "sourceCodeHash": "0x03c160168986ffc8d26a90c37366e7ad6da03f49d83449e1f8b3de0f4b590f6f"
   },
   "src/dispute/AnchorStateRegistry.sol:AnchorStateRegistry": {
-    "initCodeHash": "0xb761ca2d38cb744cd3cb8a571ea543a74a6e79ffa16316609d6ca78e949b87fb",
-    "sourceCodeHash": "0x7e1810270aaa863f782b830920ebc2f914d6d12b535f7cdf8b58d2c46aaf01d0"
+    "initCodeHash": "0x9a4206f5952acde111cd6ae909e587c91b0f6f0dc118ac2db208b9f716e062ca",
+    "sourceCodeHash": "0xefe8de8c70fed698ccba922732f6601d27a87ee2e1d88eaac67a00d8cb3dfd4b"
   },
   "src/dispute/DelayedWETH.sol:DelayedWETH": {
     "initCodeHash": "0xa8f60e142108b33675a8f6b6979c73b96eea247884842d796f9f878904c0a906",

--- a/packages/contracts-bedrock/src/dispute/AnchorStateRegistry.sol
+++ b/packages/contracts-bedrock/src/dispute/AnchorStateRegistry.sol
@@ -41,7 +41,7 @@ contract AnchorStateRegistry is ProxyAdminOwnedBase, Initializable, Reinitializa
     IFaultDisputeGame public anchorGame;
 
     /// @notice The starting anchor root.
-    Proposal public startingAnchorRoot;
+    Proposal internal startingAnchorRoot;
 
     /// @notice Mapping of blacklisted dispute games.
     mapping(IDisputeGame => bool) public disputeGameBlacklist;
@@ -129,6 +129,11 @@ contract AnchorStateRegistry is ProxyAdminOwnedBase, Initializable, Reinitializa
     /// @notice Returns the dispute game finality delay in seconds.
     function disputeGameFinalityDelaySeconds() external view returns (uint256) {
         return DISPUTE_GAME_FINALITY_DELAY_SECONDS;
+    }
+
+    /// @notice Returns the starting anchor root.
+    function getStartingAnchorRoot() external view returns (Proposal memory) {
+        return startingAnchorRoot;
     }
 
     /// @notice Allows the Guardian to set the respected game type.

--- a/packages/contracts-bedrock/src/dispute/AnchorStateRegistry.sol
+++ b/packages/contracts-bedrock/src/dispute/AnchorStateRegistry.sol
@@ -25,8 +25,8 @@ import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 ///         be initialized with a more recent starting state which reduces the amount of required offchain computation.
 contract AnchorStateRegistry is ProxyAdminOwnedBase, Initializable, ReinitializableBase, ISemver {
     /// @notice Semantic version.
-    /// @custom:semver 3.6.0
-    string public constant version = "3.6.0";
+    /// @custom:semver 3.7.0
+    string public constant version = "3.7.0";
 
     /// @notice The dispute game finality delay in seconds.
     uint256 internal immutable DISPUTE_GAME_FINALITY_DELAY_SECONDS;
@@ -41,7 +41,7 @@ contract AnchorStateRegistry is ProxyAdminOwnedBase, Initializable, Reinitializa
     IFaultDisputeGame public anchorGame;
 
     /// @notice The starting anchor root.
-    Proposal internal startingAnchorRoot;
+    Proposal public startingAnchorRoot;
 
     /// @notice Mapping of blacklisted dispute games.
     mapping(IDisputeGame => bool) public disputeGameBlacklist;

--- a/packages/contracts-bedrock/test/dispute/AnchorStateRegistry.t.sol
+++ b/packages/contracts-bedrock/test/dispute/AnchorStateRegistry.t.sol
@@ -449,14 +449,6 @@ contract AnchorStateRegistry_GetAnchorRoot_Test is AnchorStateRegistry_TestInit 
 /// @title AnchorStateRegistry_GetStartingAnchorRoot_Test
 /// @notice Tests the `getStartingAnchorRoot` function of the `AnchorStateRegistry` contract.
 contract AnchorStateRegistry_GetStartingAnchorRoot_Test is AnchorStateRegistry_TestInit {
-    /// @notice Tests that getStartingAnchorRoot returns the value initialized in the initialize
-    ///         function.
-    function test_getStartingAnchorRoot_initialValue_succeeds() public view {
-        Proposal memory startingAnchorRoot = anchorStateRegistry.getStartingAnchorRoot();
-        assertEq(startingAnchorRoot.root.raw(), 0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF);
-        assertEq(startingAnchorRoot.l2SequenceNumber, 0);
-    }
-
     /// @notice Tests that getStartingAnchorRoot remains unchanged even if the current anchor root
     ///         changes.
     function test_getStartingAnchorRoot_afterUpdate_succeeds() public {
@@ -482,19 +474,22 @@ contract AnchorStateRegistry_GetStartingAnchorRoot_Test is AnchorStateRegistry_T
         // Set the anchor game to the game proxy.
         anchorStateRegistry.setAnchorState(gameProxy);
 
+        // Grab the value of the starting anchor root before the update.
+        Proposal memory startingAnchorRootBeforeUpdate = anchorStateRegistry.getStartingAnchorRoot();
+
         // Verify the CURRENT anchor root has changed.
         (Hash currentRoot, uint256 currentL2BlockNumber) = anchorStateRegistry.getAnchorRoot();
         assertEq(currentRoot.raw(), gameProxy.rootClaim().raw());
         assertEq(currentL2BlockNumber, gameProxy.l2SequenceNumber());
 
         // Verify the STARTING anchor root has NOT changed.
-        Proposal memory startingAnchorRoot = anchorStateRegistry.getStartingAnchorRoot();
-        assertEq(startingAnchorRoot.root.raw(), 0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF);
-        assertEq(startingAnchorRoot.l2SequenceNumber, 0);
+        Proposal memory startingAnchorRootAfterUpdate = anchorStateRegistry.getStartingAnchorRoot();
+        assertEq(startingAnchorRootAfterUpdate.root.raw(), startingAnchorRootBeforeUpdate.root.raw());
+        assertEq(startingAnchorRootAfterUpdate.l2SequenceNumber, startingAnchorRootBeforeUpdate.l2SequenceNumber);
 
         // Explicitly assert they are different (assuming the new game has different values).
-        assertFalse(currentRoot.raw() == startingAnchorRoot.root.raw());
-        assertFalse(currentL2BlockNumber == startingAnchorRoot.l2SequenceNumber);
+        assertFalse(currentRoot.raw() == startingAnchorRootAfterUpdate.root.raw());
+        assertFalse(currentL2BlockNumber == startingAnchorRootAfterUpdate.l2SequenceNumber);
     }
 }
 

--- a/packages/contracts-bedrock/test/dispute/AnchorStateRegistry.t.sol
+++ b/packages/contracts-bedrock/test/dispute/AnchorStateRegistry.t.sol
@@ -446,6 +446,58 @@ contract AnchorStateRegistry_GetAnchorRoot_Test is AnchorStateRegistry_TestInit 
     }
 }
 
+/// @title AnchorStateRegistry_StartingAnchorRoot_Test
+/// @notice Tests the `startingAnchorRoot` public variable of the `AnchorStateRegistry` contract.
+contract AnchorStateRegistry_StartingAnchorRoot_Test is AnchorStateRegistry_TestInit {
+    /// @notice Tests that startingAnchorRoot returns the value initialized in the initialize
+    ///         function.
+    function test_startingAnchorRoot_initialValue_succeeds() public view {
+        (Hash root, uint256 l2BlockNumber) = anchorStateRegistry.startingAnchorRoot();
+        assertEq(root.raw(), 0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF);
+        assertEq(l2BlockNumber, 0);
+    }
+
+    /// @notice Tests that startingAnchorRoot remains unchanged even if the current anchor root
+    ///         changes.
+    function test_startingAnchorRoot_afterUpdate_succeeds() public {
+        // Mock the game to be resolved.
+        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.resolvedAt, ()), abi.encode(block.timestamp));
+        vm.warp(block.timestamp + optimismPortal2.disputeGameFinalityDelaySeconds() + 1);
+
+        // Mock the game to be the defender wins.
+        vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.status, ()), abi.encode(GameStatus.DEFENDER_WINS));
+
+        // Mock the game's L2 block number to be greater than the starting anchor root block number.
+        vm.mockCall(
+            address(gameProxy), abi.encodeCall(gameProxy.l2SequenceNumber, ()), abi.encode(validL2BlockNumber + 1)
+        );
+
+        // Mock the game's anchor root to be different from the starting anchor root.
+        vm.mockCall(
+            address(gameProxy),
+            abi.encodeCall(gameProxy.rootClaim, ()),
+            abi.encode(Claim.wrap(keccak256(abi.encode(123))))
+        );
+
+        // Set the anchor game to the game proxy.
+        anchorStateRegistry.setAnchorState(gameProxy);
+
+        // Verify the CURRENT anchor root has changed.
+        (Hash currentRoot, uint256 currentL2BlockNumber) = anchorStateRegistry.getAnchorRoot();
+        assertEq(currentRoot.raw(), gameProxy.rootClaim().raw());
+        assertEq(currentL2BlockNumber, gameProxy.l2SequenceNumber());
+
+        // Verify the STARTING anchor root has NOT changed.
+        (Hash startingRoot, uint256 startingL2BlockNumber) = anchorStateRegistry.startingAnchorRoot();
+        assertEq(startingRoot.raw(), 0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF);
+        assertEq(startingL2BlockNumber, 0);
+
+        // Explicitly assert they are different (assuming the new game has different values).
+        assertFalse(currentRoot.raw() == startingRoot.raw());
+        assertFalse(currentL2BlockNumber == startingL2BlockNumber);
+    }
+}
+
 /// @title AnchorStateRegistry_IsGameRegistered_Test
 /// @notice Tests the `isGameRegistered` function of the `AnchorStateRegistry` contract.
 contract AnchorStateRegistry_IsGameRegistered_Test is AnchorStateRegistry_TestInit {

--- a/packages/contracts-bedrock/test/dispute/AnchorStateRegistry.t.sol
+++ b/packages/contracts-bedrock/test/dispute/AnchorStateRegistry.t.sol
@@ -446,20 +446,20 @@ contract AnchorStateRegistry_GetAnchorRoot_Test is AnchorStateRegistry_TestInit 
     }
 }
 
-/// @title AnchorStateRegistry_StartingAnchorRoot_Test
-/// @notice Tests the `startingAnchorRoot` public variable of the `AnchorStateRegistry` contract.
-contract AnchorStateRegistry_StartingAnchorRoot_Test is AnchorStateRegistry_TestInit {
-    /// @notice Tests that startingAnchorRoot returns the value initialized in the initialize
+/// @title AnchorStateRegistry_GetStartingAnchorRoot_Test
+/// @notice Tests the `getStartingAnchorRoot` function of the `AnchorStateRegistry` contract.
+contract AnchorStateRegistry_GetStartingAnchorRoot_Test is AnchorStateRegistry_TestInit {
+    /// @notice Tests that getStartingAnchorRoot returns the value initialized in the initialize
     ///         function.
-    function test_startingAnchorRoot_initialValue_succeeds() public view {
-        (Hash root, uint256 l2BlockNumber) = anchorStateRegistry.startingAnchorRoot();
-        assertEq(root.raw(), 0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF);
-        assertEq(l2BlockNumber, 0);
+    function test_getStartingAnchorRoot_initialValue_succeeds() public view {
+        Proposal memory startingAnchorRoot = anchorStateRegistry.getStartingAnchorRoot();
+        assertEq(startingAnchorRoot.root.raw(), 0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF);
+        assertEq(startingAnchorRoot.l2SequenceNumber, 0);
     }
 
-    /// @notice Tests that startingAnchorRoot remains unchanged even if the current anchor root
+    /// @notice Tests that getStartingAnchorRoot remains unchanged even if the current anchor root
     ///         changes.
-    function test_startingAnchorRoot_afterUpdate_succeeds() public {
+    function test_getStartingAnchorRoot_afterUpdate_succeeds() public {
         // Mock the game to be resolved.
         vm.mockCall(address(gameProxy), abi.encodeCall(gameProxy.resolvedAt, ()), abi.encode(block.timestamp));
         vm.warp(block.timestamp + optimismPortal2.disputeGameFinalityDelaySeconds() + 1);
@@ -488,13 +488,13 @@ contract AnchorStateRegistry_StartingAnchorRoot_Test is AnchorStateRegistry_Test
         assertEq(currentL2BlockNumber, gameProxy.l2SequenceNumber());
 
         // Verify the STARTING anchor root has NOT changed.
-        (Hash startingRoot, uint256 startingL2BlockNumber) = anchorStateRegistry.startingAnchorRoot();
-        assertEq(startingRoot.raw(), 0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF);
-        assertEq(startingL2BlockNumber, 0);
+        Proposal memory startingAnchorRoot = anchorStateRegistry.getStartingAnchorRoot();
+        assertEq(startingAnchorRoot.root.raw(), 0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF);
+        assertEq(startingAnchorRoot.l2SequenceNumber, 0);
 
         // Explicitly assert they are different (assuming the new game has different values).
-        assertFalse(currentRoot.raw() == startingRoot.raw());
-        assertFalse(currentL2BlockNumber == startingL2BlockNumber);
+        assertFalse(currentRoot.raw() == startingAnchorRoot.root.raw());
+        assertFalse(currentL2BlockNumber == startingAnchorRoot.l2SequenceNumber);
     }
 }
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
This PR updates the AnchorStateRegistry to expose the `startingAnchorRoot` property. Exposing this property means that we can avoid creating state diffs in the ASR every time it gets re-initialized as part of OPCMv2.