### PR TITLE
op-deployer: activate jovian at genesis by default (#18342)

### DIFF
--- a/op-acceptance-tests/tests/sync_tester/sync_tester_hfs/init_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_tester_hfs/init_test.go
@@ -15,7 +15,7 @@ import (
 func TestMain(m *testing.M) {
 	presets.DoMain(m, presets.WithSimpleWithSyncTester(),
 		presets.WithCompatibleTypes(compat.SysGo),
-		presets.WithHardforkSequentialActivation(forks.Bedrock, forks.Interop, 6),
+		presets.WithHardforkSequentialActivation(forks.Bedrock, forks.Jovian, 6),
 		presets.WithNoDiscovery(),
 		stack.MakeCommon(sysgo.WithBatcherOption(func(id stack.L2BatcherID, cfg *bss.CLIConfig) {
 			// For supporting pre-delta batches

--- a/op-acceptance-tests/tests/sync_tester/sync_tester_hfs/init_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_tester_hfs/init_test.go
@@ -15,7 +15,7 @@ import (
 func TestMain(m *testing.M) {
 	presets.DoMain(m, presets.WithSimpleWithSyncTester(),
 		presets.WithCompatibleTypes(compat.SysGo),
-		presets.WithHardforkSequentialActivation(forks.Bedrock, forks.Jovian, 6),
+		presets.WithHardforkSequentialActivation(forks.Bedrock, forks.Interop, 6),
 		presets.WithNoDiscovery(),
 		stack.MakeCommon(sysgo.WithBatcherOption(func(id stack.L2BatcherID, cfg *bss.CLIConfig) {
 			// For supporting pre-delta batches

--- a/op-deployer/pkg/deployer/pipeline/l2genesis.go
+++ b/op-deployer/pkg/deployer/pipeline/l2genesis.go
@@ -137,7 +137,7 @@ func GenerateL2Genesis(pEnv *Env, intent *state.Intent, bundle ArtifactsBundle, 
 }
 
 func calculateL2GenesisOverrides(intent *state.Intent, thisIntent *state.ChainIntent) (l2GenesisOverrides, *genesis.UpgradeScheduleDeployConfig, error) {
-	schedule := standard.DefaultHardforkScheduleForTag(standard.CurrentTag)
+	schedule := standard.DefaultHardforkSchedule()
 
 	overrides := defaultOverrides()
 	// Special case for FundDevAccounts since it's both an intent value and an override.

--- a/op-deployer/pkg/deployer/pipeline/l2genesis_test.go
+++ b/op-deployer/pkg/deployer/pipeline/l2genesis_test.go
@@ -32,7 +32,7 @@ func TestCalculateL2GenesisOverrides(t *testing.T) {
 			expectError:       false,
 			expectedOverrides: defaultOverrides(),
 			expectedSchedule: func() *genesis.UpgradeScheduleDeployConfig {
-				return standard.DefaultHardforkScheduleForTag("")
+				return standard.DefaultHardforkSchedule()
 			},
 		},
 		{
@@ -49,7 +49,7 @@ func TestCalculateL2GenesisOverrides(t *testing.T) {
 				return defaults
 			}(),
 			expectedSchedule: func() *genesis.UpgradeScheduleDeployConfig {
-				return standard.DefaultHardforkScheduleForTag("")
+				return standard.DefaultHardforkSchedule()
 			},
 		},
 		{
@@ -88,7 +88,7 @@ func TestCalculateL2GenesisOverrides(t *testing.T) {
 				GovernanceTokenOwner:                     common.HexToAddress("0x1111111111111111111111111111111111111111"),
 			},
 			expectedSchedule: func() *genesis.UpgradeScheduleDeployConfig {
-				sched := standard.DefaultHardforkScheduleForTag("")
+				sched := standard.DefaultHardforkSchedule()
 				sched.L2GenesisInteropTimeOffset = op_service.U64UtilPtr(0x1234)
 				return sched
 			},
@@ -131,7 +131,7 @@ func TestCalculateL2GenesisOverrides(t *testing.T) {
 				GovernanceTokenOwner:                     common.HexToAddress("0x1111111111111111111111111111111111111111"),
 			},
 			expectedSchedule: func() *genesis.UpgradeScheduleDeployConfig {
-				sched := standard.DefaultHardforkScheduleForTag("")
+				sched := standard.DefaultHardforkSchedule()
 				sched.L2GenesisInteropTimeOffset = op_service.U64UtilPtr(0x1234)
 				return sched
 			},
@@ -148,7 +148,7 @@ func TestCalculateL2GenesisOverrides(t *testing.T) {
 			expectError:       false,
 			expectedOverrides: defaultOverrides(),
 			expectedSchedule: func() *genesis.UpgradeScheduleDeployConfig {
-				schedule := standard.DefaultHardforkScheduleForTag("")
+				schedule := standard.DefaultHardforkSchedule()
 				schedule.L2GenesisInteropTimeOffset = op_service.U64UtilPtr(0)
 				return schedule
 			},

--- a/op-deployer/pkg/deployer/standard/standard.go
+++ b/op-deployer/pkg/deployer/standard/standard.go
@@ -5,13 +5,13 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
 	"github.com/ethereum-optimism/optimism/op-core/forks"
-	op_service "github.com/ethereum-optimism/optimism/op-service"
 
 	"github.com/ethereum-optimism/superchain-registry/validation"
 
+	"github.com/ethereum/go-ethereum/superchain"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/superchain"
 )
 
 const (
@@ -166,32 +166,10 @@ func ProtocolVersionsOwner(chainID uint64) (common.Address, error) {
 	}
 }
 
-// DefaultHardforkScheduleForTag is used to determine which hardforks should be activated by default given a
-// contract tag. For example, passing in v1.6.0 will return all hardforks up to and including Granite. This allows
-// OP Deployer to set sane defaults for hardforks. This is not an ideal solution, but it will have to work until we get
-// to MCP L2.
-func DefaultHardforkScheduleForTag(tag string) *genesis.UpgradeScheduleDeployConfig {
-	sched := &genesis.UpgradeScheduleDeployConfig{
-		L2GenesisRegolithTimeOffset: op_service.U64UtilPtr(0),
-		L2GenesisCanyonTimeOffset:   op_service.U64UtilPtr(0),
-		L2GenesisDeltaTimeOffset:    op_service.U64UtilPtr(0),
-		L2GenesisEcotoneTimeOffset:  op_service.U64UtilPtr(0),
-		L2GenesisFjordTimeOffset:    op_service.U64UtilPtr(0),
-		L2GenesisGraniteTimeOffset:  op_service.U64UtilPtr(0),
-	}
-
-	switch tag {
-	case ContractsV160Tag, ContractsV170Beta1L2Tag:
-		return sched
-	case ContractsV180Tag, ContractsV200Tag, ContractsV300Tag:
-		sched.ActivateForkAtGenesis(forks.Holocene)
-	case ContractsV400Tag, ContractsV410Tag, ContractsV500Tag:
-		sched.ActivateForkAtGenesis(forks.Holocene)
-		sched.ActivateForkAtGenesis(forks.Isthmus)
-	default:
-		sched.ActivateForkAtGenesis(forks.Holocene)
-		sched.ActivateForkAtGenesis(forks.Isthmus)
-	}
+// DefaultHardforkSchedule is used to determine which hardforks should be activated by default.
+func DefaultHardforkSchedule() *genesis.UpgradeScheduleDeployConfig {
+	sched := &genesis.UpgradeScheduleDeployConfig{}
+	sched.ActivateForkAtGenesis(forks.Jovian)
 
 	return sched
 }

--- a/op-deployer/pkg/deployer/standard/standard_test.go
+++ b/op-deployer/pkg/deployer/standard/standard_test.go
@@ -13,26 +13,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDefaultHardforkScheduleForTag(t *testing.T) {
-	sched := DefaultHardforkScheduleForTag(ContractsV160Tag)
-	require.Nil(t, sched.HoloceneTime(0))
-	require.Nil(t, sched.IsthmusTime(0))
-
-	sched = DefaultHardforkScheduleForTag(ContractsV180Tag)
-	require.NotNil(t, sched.HoloceneTime(0))
-	require.Nil(t, sched.IsthmusTime(0))
-
-	sched = DefaultHardforkScheduleForTag(ContractsV200Tag)
-	require.NotNil(t, sched.HoloceneTime(0))
-	require.Nil(t, sched.IsthmusTime(0))
-
-	sched = DefaultHardforkScheduleForTag(ContractsV300Tag)
-	require.NotNil(t, sched.HoloceneTime(0))
-	require.Nil(t, sched.IsthmusTime(0))
-
-	sched = DefaultHardforkScheduleForTag("")
+func TestDefaultHardforkSchedule(t *testing.T) {
+	sched := DefaultHardforkSchedule()
+	require.NotNil(t, sched.RegolithTime(0))
+	require.NotNil(t, sched.CanyonTime(0))
+	require.NotNil(t, sched.DeltaTime(0))
+	require.NotNil(t, sched.EcotoneTime(0))
+	require.NotNil(t, sched.FjordTime(0))
+	require.NotNil(t, sched.GraniteTime(0))
 	require.NotNil(t, sched.HoloceneTime(0))
 	require.NotNil(t, sched.IsthmusTime(0))
+	require.NotNil(t, sched.JovianTime(0))
 }
 
 func TestStandardAddresses(t *testing.T) {

--- a/op-deployer/pkg/deployer/state/deploy_config.go
+++ b/op-deployer/pkg/deployer/state/deploy_config.go
@@ -18,12 +18,10 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 
-var (
-	l2GenesisBlockBaseFeePerGas = hexutil.Big(*(big.NewInt(1000000000)))
-)
+var l2GenesisBlockBaseFeePerGas = hexutil.Big(*(big.NewInt(1000000000)))
 
 func CombineDeployConfig(intent *Intent, chainIntent *ChainIntent, state *State, chainState *ChainState) (genesis.DeployConfig, error) {
-	upgradeSchedule := standard.DefaultHardforkScheduleForTag(standard.CurrentTag)
+	upgradeSchedule := standard.DefaultHardforkSchedule()
 
 	cfg := genesis.DeployConfig{
 		L1DependenciesConfig: genesis.L1DependenciesConfig{
@@ -163,7 +161,6 @@ func CombineDeployConfig(intent *Intent, chainIntent *ChainIntent, state *State,
 		cfg, err = jsonutil.MergeJSON(cfg, intent.GlobalDeployOverrides)
 		if err != nil {
 			return genesis.DeployConfig{}, fmt.Errorf("error merging global L2 overrides: %w", err)
-
 		}
 	}
 


### PR DESCRIPTION
Porting changes from https://github.com/ethereum-optimism/optimism/pull/18342 back to `develop`

Closes #18314 