### PR TITLE
fix(op-acceptance-tests): reduce per-package timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3225,7 +3225,7 @@ workflows:
       - op-acceptance-tests:
           name: memory-all
           gate: "" # Empty gate = gateless mode
-          no_output_timeout: 90m
+          no_output_timeout: 80m  # Keep this less than 90m to avoid CircleCI timeout
           context:
             - circleci-repo-readonly-authenticated-github-token
             - slack

--- a/op-acceptance-tests/justfile
+++ b/op-acceptance-tests/justfile
@@ -98,8 +98,7 @@ acceptance-test devnet="" gate="base":
             "--validators" "./acceptance-tests.yaml"
             "--exclude-gates" "flake-shake"
             "--allow-skips"
-            "--timeout" "90m"
-            "--default-timeout" "30m"
+            "--timeout" "60m"
             "--orchestrator" "$ORCHESTRATOR"
             "--show-progress"
         )


### PR DESCRIPTION
Reduce op-acceptor's timeouts so that they're less than, and different to, CircleCI's.
