### PR TITLE
fix(ci): add dependency installation to heavy fuzz nightly job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -984,6 +984,7 @@ jobs:
     steps:
       - utils/checkout-with-mise:
          checkout-method: blobless
+      - install-contracts-dependencies
       - install-zstd
       - run:
           name: Print dependencies


### PR DESCRIPTION
This PR fixes the "Text file busy" race condition in the `contracts-bedrock-heavy-fuzz-nightly` CI job.

### Reason
The nightly heavy fuzz job was failing with a "Text file busy (os error 26)" error because forge test would run before git submodules and solc compilers were properly initialized. This fix aligns the job with other contract test jobs that already use proper dependency installation.

### Changes
- Add `install-contracts-dependencies` step to `contracts-bedrock-heavy-fuzz-nightly` job to pre-install git submodules and solc compilers before running tests