### PR TITLE
chore(ci): op-e2e-cannon-tests; xlarge machine

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2987,7 +2987,7 @@ workflows:
           mentions: "@proofs-team"
           no_output_timeout: 90m
           test_timeout: 480m
-          resource_class: large
+          resource_class: xlarge
           context:
             - slack
             - circleci-repo-readonly-authenticated-github-token


### PR DESCRIPTION
Job kept being killed, probably due to hitting resource limits.

<img width="1625" height="705" alt="Screenshot 2025-11-24 at 12 50 43" src="https://github.com/user-attachments/assets/21e9c24c-ea50-43bb-90fa-d6c2d94cd049" />

([source](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/108323/workflows/a62981ce-3abb-42fa-8ccf-107c2f2ed90a/jobs/4121312/resources))