### PR TITLE
op-daployer: guard L1() against nil state to prevent panic

### DIFF
--- a/op-deployer/pkg/deployer/inspect/l1.go
+++ b/op-deployer/pkg/deployer/inspect/l1.go
@@ -42,7 +42,15 @@ func L1(globalState *state.State, chainID common.Hash) (*addresses.L1Contracts, 
 	if err != nil {
 		return nil, fmt.Errorf("failed to get chain state for ID %s: %w", chainID.String(), err)
 	}
-
+	if globalState.AppliedIntent == nil {
+		return nil, fmt.Errorf("can only run this command following a full apply")
+	}
+	if globalState.SuperchainDeployment == nil {
+		return nil, fmt.Errorf("superchain contracts not available - run op-deployer apply")
+	}
+	if globalState.ImplementationsDeployment == nil {
+		return nil, fmt.Errorf("implementations contracts not available - run op-deployer apply")
+	}
 	l1Contracts := addresses.L1Contracts{
 		SuperchainContracts:      *globalState.SuperchainDeployment,
 		ImplementationsContracts: *globalState.ImplementationsDeployment,


### PR DESCRIPTION
This change prevents a potential panic in inspect.L1() by adding explicit precondition checks before dereferencing SuperchainDeployment and ImplementationsDeployment. These fields are pointer members of state.State that are set during the superchain and implementations deployment stages and can legitimately be nil until a full apply is completed. Unlike other inspect commands which already validate that AppliedIntent is present or otherwise enforce state completeness, L1() was assuming these pointers were initialized and would panic in partially applied or stale states. The new checks ensure that L1() is only executed after a full apply and that the necessary superchain and implementation contracts are available, returning clear, actionable errors instead of crashing. This makes the behavior consistent with inspect deploy-config and inspect genesis and improves the CLI’s resilience and diagnostics.