### PR TITLE
fix(scripts): skip validation for missing test artifacts

### DIFF
--- a/packages/contracts-bedrock/scripts/checks/test-validation/main.go
+++ b/packages/contracts-bedrock/scripts/checks/test-validation/main.go
@@ -58,6 +58,13 @@ func processFile(path string) (*common.Void, []error) {
 		return nil, []error{err}
 	}
 
+	// Skip validation for artifacts where the contract doesn't exist in the source file
+	testFilePath, contractName, _ := getCompilationTarget(artifact)
+	if !testContractExistsInFile(testFilePath, contractName) {
+		fmt.Printf("Skipping validation for %s (contract %s not found in source file)\n", testFileName, contractName)
+		return nil, nil
+	}
+
 	var errors []error
 
 	// Validate test function naming conventions
@@ -92,7 +99,7 @@ func testFileExists(testFileName string) bool {
 
 	// Search recursively in test directory for the file
 	found := false
-	filepath.Walk("test", func(path string, info os.FileInfo, err error) error {
+	_ = filepath.Walk("test", func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return nil
 		}
@@ -103,6 +110,21 @@ func testFileExists(testFileName string) bool {
 		return nil
 	})
 	return found
+}
+
+// Checks if test contract exists in the specified test source file
+func testContractExistsInFile(testFilePath, contractName string) bool {
+	if testFilePath == "" || contractName == "" {
+		return false
+	}
+
+	// Read file and check if contract name exists
+	content, err := os.ReadFile(testFilePath)
+	if err != nil {
+		return false
+	}
+
+	return strings.Contains(string(content), "contract "+contractName)
 }
 
 // Test name validation

--- a/packages/contracts-bedrock/scripts/checks/test-validation/main.go
+++ b/packages/contracts-bedrock/scripts/checks/test-validation/main.go
@@ -41,8 +41,17 @@ func main() {
 	fmt.Println("✅ All contract test validations passed")
 }
 
-// Processes a single test artifact file and runs all validations
+// File processing
+
+// Processes a single test artifact file and runs all validations.
 func processFile(path string) (*common.Void, []error) {
+	// Skip validation for artifacts without corresponding source files
+	testFileName := extractTestFileName(path)
+	if !testFileExists(testFileName) {
+		fmt.Printf("Skipping validation for %s (test file not found in branch)\n", testFileName)
+		return nil, nil
+	}
+
 	// Read and parse the Forge artifact file
 	artifact, err := common.ReadForgeArtifact(path)
 	if err != nil {
@@ -60,6 +69,40 @@ func processFile(path string) (*common.Void, []error) {
 	errors = append(errors, structureErrors...)
 
 	return nil, errors
+}
+
+// Test file validation
+
+// Extracts test filename from artifact path
+func extractTestFileName(path string) string {
+	pathParts := strings.Split(path, string(filepath.Separator))
+	for _, part := range pathParts {
+		if strings.HasSuffix(part, ".t.sol") {
+			return part
+		}
+	}
+	return ""
+}
+
+// Checks if test source file exists in the test directory
+func testFileExists(testFileName string) bool {
+	if testFileName == "" {
+		return false
+	}
+
+	// Search recursively in test directory for the file
+	found := false
+	filepath.Walk("test", func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		if !info.IsDir() && filepath.Base(path) == testFileName {
+			found = true
+			return filepath.SkipAll
+		}
+		return nil
+	})
+	return found
 }
 
 // Test name validation

--- a/packages/contracts-bedrock/scripts/checks/test-validation/main_test.go
+++ b/packages/contracts-bedrock/scripts/checks/test-validation/main_test.go
@@ -11,14 +11,69 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi"
 )
 
+// setupTestDir creates a temporary directory and changes to it for testing.
+// Returns a cleanup function that should be deferred.
+func setupTestDir(t *testing.T) (tmpDir string, cleanup func()) {
+	t.Helper()
+	tmpDir = t.TempDir()
+	oldWd, _ := os.Getwd()
+	os.Chdir(tmpDir)
+	return tmpDir, func() { os.Chdir(oldWd) }
+}
+
+// createTestArtifact creates a ForgeArtifact with the given compilation target.
+func createTestArtifact(srcPath, contractName string) *solc.ForgeArtifact {
+	return &solc.ForgeArtifact{
+		Metadata: solc.ForgeCompilerMetadata{
+			Settings: solc.CompilerSettings{
+				CompilationTarget: map[string]string{srcPath: contractName},
+			},
+		},
+	}
+}
+
 func TestProcessFile(t *testing.T) {
-	tmpFile := filepath.Join(t.TempDir(), "test.json")
-	if err := os.WriteFile(tmpFile, []byte(`{"abi":[{"name":"IS_TEST"}],"metadata":{"settings":{"compilationTarget":{"test.sol":"Test"}}}}`), 0644); err != nil {
+	tmpDir, cleanup := setupTestDir(t)
+	defer cleanup()
+
+	os.MkdirAll(filepath.Join(tmpDir, "test"), 0755)
+	os.WriteFile(filepath.Join(tmpDir, "test", "Test.t.sol"), []byte(""), 0644)
+
+	tmpFile := filepath.Join(tmpDir, "forge-artifacts", "Test.t.sol", "Test.json")
+	os.MkdirAll(filepath.Dir(tmpFile), 0755)
+	if err := os.WriteFile(tmpFile, []byte(`{"abi":[{"name":"IS_TEST"}],"metadata":{"settings":{"compilationTarget":{"Test.t.sol":"Test"}}}}`), 0644); err != nil {
 		t.Fatal(err)
 	}
 	_, errors := processFile(tmpFile)
 	if len(errors) == 0 {
 		t.Error("expected error for invalid test name")
+	}
+}
+
+func TestExtractTestFileName(t *testing.T) {
+	if got := extractTestFileName("forge-artifacts/Contract.t.sol/Contract_Test.json"); got != "Contract.t.sol" {
+		t.Errorf("extractTestFileName() = %q, want %q", got, "Contract.t.sol")
+	}
+	if got := extractTestFileName("forge-artifacts/Contract.sol/Contract.json"); got != "" {
+		t.Errorf("extractTestFileName() = %q, want empty", got)
+	}
+}
+
+func TestTestFileExists(t *testing.T) {
+	_, cleanup := setupTestDir(t)
+	defer cleanup()
+
+	os.MkdirAll(filepath.Join("test", "safe"), 0755)
+	os.WriteFile(filepath.Join("test", "safe", "Existing.t.sol"), []byte(""), 0644)
+
+	if testFileExists("") {
+		t.Error("empty filename should return false")
+	}
+	if !testFileExists("Existing.t.sol") {
+		t.Error("should find existing file in subdirectory")
+	}
+	if testFileExists("NonExistent.t.sol") {
+		t.Error("should return false for non-existent file")
 	}
 }
 
@@ -210,15 +265,15 @@ func TestCheckTestName(t *testing.T) {
 func TestValidateTestStructure(t *testing.T) {
 	excludedPaths = []string{"test/excluded/"}
 	defer func() { excludedPaths = nil }()
-	artifact := &solc.ForgeArtifact{Metadata: solc.ForgeCompilerMetadata{Settings: solc.CompilerSettings{CompilationTarget: map[string]string{"test/excluded/Contract.t.sol": "Contract_Test"}}}}
+	artifact := createTestArtifact("test/excluded/Contract.t.sol", "Contract_Test")
 	if errors := validateTestStructure(artifact); len(errors) != 0 {
 		t.Errorf("expected no errors for excluded path, got %d", len(errors))
 	}
 }
 
 func TestCheckTestStructure(t *testing.T) {
-	valid := &solc.ForgeArtifact{Metadata: solc.ForgeCompilerMetadata{Settings: solc.CompilerSettings{CompilationTarget: map[string]string{"test.sol": "Contract_TestInit"}}}}
-	invalid := &solc.ForgeArtifact{Metadata: solc.ForgeCompilerMetadata{Settings: solc.CompilerSettings{CompilationTarget: map[string]string{"test.sol": "Invalid_Pattern"}}}}
+	valid := createTestArtifact("test.sol", "Contract_TestInit")
+	invalid := createTestArtifact("test.sol", "Invalid_Pattern")
 	if len(checkTestStructure(valid)) > 0 {
 		t.Error("valid pattern should not error")
 	}
@@ -276,25 +331,18 @@ func TestGetCompilationTarget(t *testing.T) {
 }
 
 func TestCheckSrcPath(t *testing.T) {
-	tmpDir := t.TempDir()
+	tmpDir, cleanup := setupTestDir(t)
+	defer cleanup()
+
 	if err := os.MkdirAll(filepath.Join(tmpDir, "src"), 0755); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(tmpDir, "src", "Contract.sol"), []byte(""), 0644); err != nil {
 		t.Fatal(err)
 	}
-	oldWd, _ := os.Getwd()
-	defer func() {
-		if err := os.Chdir(oldWd); err != nil {
-			t.Error(err)
-		}
-	}()
-	if err := os.Chdir(tmpDir); err != nil {
-		t.Fatal(err)
-	}
 
-	valid := &solc.ForgeArtifact{Metadata: solc.ForgeCompilerMetadata{Settings: solc.CompilerSettings{CompilationTarget: map[string]string{"test/Contract.t.sol": "Contract_Test"}}}}
-	invalid := &solc.ForgeArtifact{Metadata: solc.ForgeCompilerMetadata{Settings: solc.CompilerSettings{CompilationTarget: map[string]string{"test/Missing.t.sol": "Missing_Test"}}}}
+	valid := createTestArtifact("test/Contract.t.sol", "Contract_Test")
+	invalid := createTestArtifact("test/Missing.t.sol", "Missing_Test")
 
 	if !checkSrcPath(valid) {
 		t.Error("valid src path should return true")
@@ -344,20 +392,13 @@ func TestCheckContractNameFilePath(t *testing.T) {
 }
 
 func TestFindArtifactPath(t *testing.T) {
-	tmpDir := t.TempDir()
+	tmpDir, cleanup := setupTestDir(t)
+	defer cleanup()
+
 	if err := os.MkdirAll(filepath.Join(tmpDir, "forge-artifacts", "Contract.sol"), 0755); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(tmpDir, "forge-artifacts", "Contract.sol", "Contract.json"), []byte("{}"), 0644); err != nil {
-		t.Fatal(err)
-	}
-	oldWd, _ := os.Getwd()
-	defer func() {
-		if err := os.Chdir(oldWd); err != nil {
-			t.Error(err)
-		}
-	}()
-	if err := os.Chdir(tmpDir); err != nil {
 		t.Fatal(err)
 	}
 
@@ -417,7 +458,7 @@ func TestExtractFunctionsFromAST(t *testing.T) {
 }
 
 func TestCheckFunctionExists(t *testing.T) {
-	artifact := &solc.ForgeArtifact{Metadata: solc.ForgeCompilerMetadata{Settings: solc.CompilerSettings{CompilationTarget: map[string]string{"test/Contract.t.sol": "Contract_Test"}}}}
+	artifact := createTestArtifact("test/Contract.t.sol", "Contract_Test")
 	if !checkFunctionExists(artifact, "constructor") {
 		t.Error("constructor should always exist")
 	}

--- a/packages/contracts-bedrock/scripts/checks/test-validation/main_test.go
+++ b/packages/contracts-bedrock/scripts/checks/test-validation/main_test.go
@@ -17,8 +17,8 @@ func setupTestDir(t *testing.T) (tmpDir string, cleanup func()) {
 	t.Helper()
 	tmpDir = t.TempDir()
 	oldWd, _ := os.Getwd()
-	os.Chdir(tmpDir)
-	return tmpDir, func() { os.Chdir(oldWd) }
+	_ = os.Chdir(tmpDir)
+	return tmpDir, func() { _ = os.Chdir(oldWd) }
 }
 
 // createTestArtifact creates a ForgeArtifact with the given compilation target.
@@ -36,11 +36,11 @@ func TestProcessFile(t *testing.T) {
 	tmpDir, cleanup := setupTestDir(t)
 	defer cleanup()
 
-	os.MkdirAll(filepath.Join(tmpDir, "test"), 0755)
-	os.WriteFile(filepath.Join(tmpDir, "test", "Test.t.sol"), []byte(""), 0644)
+	_ = os.MkdirAll(filepath.Join(tmpDir, "test"), 0755)
+	_ = os.WriteFile(filepath.Join(tmpDir, "test", "Test.t.sol"), []byte(""), 0644)
 
 	tmpFile := filepath.Join(tmpDir, "forge-artifacts", "Test.t.sol", "Test.json")
-	os.MkdirAll(filepath.Dir(tmpFile), 0755)
+	_ = os.MkdirAll(filepath.Dir(tmpFile), 0755)
 	if err := os.WriteFile(tmpFile, []byte(`{"abi":[{"name":"IS_TEST"}],"metadata":{"settings":{"compilationTarget":{"Test.t.sol":"Test"}}}}`), 0644); err != nil {
 		t.Fatal(err)
 	}
@@ -63,8 +63,8 @@ func TestTestFileExists(t *testing.T) {
 	_, cleanup := setupTestDir(t)
 	defer cleanup()
 
-	os.MkdirAll(filepath.Join("test", "safe"), 0755)
-	os.WriteFile(filepath.Join("test", "safe", "Existing.t.sol"), []byte(""), 0644)
+	_ = os.MkdirAll(filepath.Join("test", "safe"), 0755)
+	_ = os.WriteFile(filepath.Join("test", "safe", "Existing.t.sol"), []byte(""), 0644)
 
 	if testFileExists("") {
 		t.Error("empty filename should return false")
@@ -73,6 +73,30 @@ func TestTestFileExists(t *testing.T) {
 		t.Error("should find existing file in subdirectory")
 	}
 	if testFileExists("NonExistent.t.sol") {
+		t.Error("should return false for non-existent file")
+	}
+}
+
+func TestTestContractExistsInFile(t *testing.T) {
+	_, cleanup := setupTestDir(t)
+	defer cleanup()
+
+	_ = os.MkdirAll("test", 0755)
+	_ = os.WriteFile("test/Contract.t.sol", []byte("contract MyContract_Test {}\ncontract OtherContract {}"), 0644)
+
+	if testContractExistsInFile("", "MyContract_Test") {
+		t.Error("empty path should return false")
+	}
+	if testContractExistsInFile("test/Contract.t.sol", "") {
+		t.Error("empty contract name should return false")
+	}
+	if !testContractExistsInFile("test/Contract.t.sol", "MyContract_Test") {
+		t.Error("should find existing contract")
+	}
+	if testContractExistsInFile("test/Contract.t.sol", "NonExistent_Test") {
+		t.Error("should return false for non-existent contract")
+	}
+	if testContractExistsInFile("test/NonExistent.t.sol", "MyContract_Test") {
 		t.Error("should return false for non-existent file")
 	}
 }


### PR DESCRIPTION
This PR adds a workaround to skip validation for test artifacts whose test files or contracts don't exist in the current branch.

## Reason
When using CircleCI's artifact fallback with `--fallback-to-latest`, the `lint-forge-tests-check-no-build` job downloads artifacts from the `develop` branch. If `develop` contains tests that don't exist in the PR branch (because the PR hasn't rebased yet), validation fails. This change allows the validation script to skip artifacts for missing test files and contracts, fixing the CI failure.

## Changes
- Add `extractTestFileName()` to extract test filename from artifact path
- Add `testFileExists()` to check if test source file exists recursively in test directory
- Add `testContractExistsInFile()` to check if specific test contract exists in the source file
- Skip validation in `processFile()` when test source file or test contract does not exist
- Add `TestExtractTestFileName`, `TestTestFileExists`, and `TestTestContractExistsInFile` tests
- Add `setupTestDir()` and `createTestArtifact()` test helper functions
- Update `TestProcessFile` to validate the filtering logic
- Refactor test setup to use helper functions in multiple tests