### PR TITLE
fix(scripts): validate interfaces and libraries in test artifact checking

### DIFF
--- a/packages/contracts-bedrock/scripts/checks/test-validation/main.go
+++ b/packages/contracts-bedrock/scripts/checks/test-validation/main.go
@@ -124,7 +124,10 @@ func testContractExistsInFile(testFilePath, contractName string) bool {
 		return false
 	}
 
-	return strings.Contains(string(content), "contract "+contractName)
+	contentStr := string(content)
+	return strings.Contains(contentStr, "contract "+contractName) ||
+		strings.Contains(contentStr, "interface "+contractName) ||
+		strings.Contains(contentStr, "library "+contractName)
 }
 
 // Test name validation

--- a/packages/contracts-bedrock/scripts/checks/test-validation/main_test.go
+++ b/packages/contracts-bedrock/scripts/checks/test-validation/main_test.go
@@ -82,7 +82,7 @@ func TestTestContractExistsInFile(t *testing.T) {
 	defer cleanup()
 
 	_ = os.MkdirAll("test", 0755)
-	_ = os.WriteFile("test/Contract.t.sol", []byte("contract MyContract_Test {}\ncontract OtherContract {}"), 0644)
+	_ = os.WriteFile("test/Contract.t.sol", []byte("contract MyContract_Test {}\ninterface IHelper {}\nlibrary LibHelper {}"), 0644)
 
 	if testContractExistsInFile("", "MyContract_Test") {
 		t.Error("empty path should return false")
@@ -92,6 +92,12 @@ func TestTestContractExistsInFile(t *testing.T) {
 	}
 	if !testContractExistsInFile("test/Contract.t.sol", "MyContract_Test") {
 		t.Error("should find existing contract")
+	}
+	if !testContractExistsInFile("test/Contract.t.sol", "IHelper") {
+		t.Error("should find existing interface")
+	}
+	if !testContractExistsInFile("test/Contract.t.sol", "LibHelper") {
+		t.Error("should find existing library")
 	}
 	if testContractExistsInFile("test/Contract.t.sol", "NonExistent_Test") {
 		t.Error("should return false for non-existent contract")


### PR DESCRIPTION
This PR updates the test validation script to check for interfaces and libraries in addition to contracts when validating test artifacts.

### Reason
The validation script was skipping artifacts for interfaces and libraries because it only checked for the `contract` keyword. This caused unnecessary skip messages for valid helper types that should be validated. The script now properly validates all solidity type declarations that forge creates artifacts for.

### Changes
- Update `testContractExistsInFile()` to match `interface` and `library` keywords in addition to `contract`
- Add test cases for interface and library validation in `TestTestContractExistsInFile`