### PR TITLE
Cherry-pick Safe directory changes from develop to op-safe-contracts/v1.0.0

### DIFF
--- a/packages/contracts-bedrock/interfaces/safe/ITimelockGuard.sol
+++ b/packages/contracts-bedrock/interfaces/safe/ITimelockGuard.sol
@@ -12,10 +12,13 @@ interface ITimelockGuard {
         Cancelled,
         Executed
     }
+
     struct ScheduledTransaction {
+        bytes32 txHash;
         uint256 executionTime;
         TransactionState state;
         ExecTransactionParams params;
+        uint256 nonce;
     }
 
     struct ExecTransactionParams {

--- a/packages/contracts-bedrock/interfaces/safe/ITimelockGuard.sol
+++ b/packages/contracts-bedrock/interfaces/safe/ITimelockGuard.sol
@@ -48,7 +48,7 @@ interface ITimelockGuard {
     event GuardConfigured(address indexed safe, uint256 timelockDelay);
     event TransactionCancelled(address indexed safe, bytes32 indexed txHash);
     event TransactionScheduled(address indexed safe, bytes32 indexed txHash, uint256 executionTime);
-    event TransactionExecuted(address indexed safe, bytes32 txHash);
+    event TransactionExecuted(address indexed safe, bytes32 indexed txHash);
     event Message(string message);
     event TransactionsNotCancelled(address indexed safe, uint256 uncancelledCount);
 

--- a/packages/contracts-bedrock/snapshots/abi/SaferSafes.json
+++ b/packages/contracts-bedrock/snapshots/abi/SaferSafes.json
@@ -805,7 +805,7 @@
         "type": "address"
       },
       {
-        "indexed": false,
+        "indexed": true,
         "internalType": "bytes32",
         "name": "txHash",
         "type": "bytes32"

--- a/packages/contracts-bedrock/snapshots/abi/SaferSafes.json
+++ b/packages/contracts-bedrock/snapshots/abi/SaferSafes.json
@@ -306,6 +306,11 @@
       {
         "components": [
           {
+            "internalType": "bytes32",
+            "name": "txHash",
+            "type": "bytes32"
+          },
+          {
             "internalType": "uint256",
             "name": "executionTime",
             "type": "uint256"
@@ -366,6 +371,11 @@
             "internalType": "struct TimelockGuard.ExecTransactionParams",
             "name": "params",
             "type": "tuple"
+          },
+          {
+            "internalType": "uint256",
+            "name": "nonce",
+            "type": "uint256"
           }
         ],
         "internalType": "struct TimelockGuard.ScheduledTransaction[]",
@@ -476,6 +486,11 @@
       {
         "components": [
           {
+            "internalType": "bytes32",
+            "name": "txHash",
+            "type": "bytes32"
+          },
+          {
             "internalType": "uint256",
             "name": "executionTime",
             "type": "uint256"
@@ -536,6 +551,11 @@
             "internalType": "struct TimelockGuard.ExecTransactionParams",
             "name": "params",
             "type": "tuple"
+          },
+          {
+            "internalType": "uint256",
+            "name": "nonce",
+            "type": "uint256"
           }
         ],
         "internalType": "struct TimelockGuard.ScheduledTransaction",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -208,8 +208,8 @@
     "sourceCodeHash": "0x7fc4789b082bc8ecd29c4c75a06058f0ff0b72f1c1028a42db6f1c35269c8865"
   },
   "src/safe/SaferSafes.sol:SaferSafes": {
-    "initCodeHash": "0x2bee3bc687583bae2cb88edcf25ebe277b8d34b30bf9faac55ae6ec80080b8b9",
-    "sourceCodeHash": "0xed36bffcde1bf806a9bd9b599296f4818a6c123f5277d2f3e68635cb3f22973d"
+    "initCodeHash": "0xb4e7885e5f181e9223ecdbc4cfc8b5887fd2c22359e4c8bb4dee53f7dd193876",
+    "sourceCodeHash": "0x31f453780466a9d3e498a7981f66c92c3d0b76e1ee80c19e374d9692bcfbd931"
   },
   "src/universal/OptimismMintableERC20.sol:OptimismMintableERC20": {
     "initCodeHash": "0x3c85eed0d017dca8eda6396aa842ddc12492587b061e8c756a8d32c4610a9658",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -208,8 +208,8 @@
     "sourceCodeHash": "0x7fc4789b082bc8ecd29c4c75a06058f0ff0b72f1c1028a42db6f1c35269c8865"
   },
   "src/safe/SaferSafes.sol:SaferSafes": {
-    "initCodeHash": "0xb4e7885e5f181e9223ecdbc4cfc8b5887fd2c22359e4c8bb4dee53f7dd193876",
-    "sourceCodeHash": "0x31f453780466a9d3e498a7981f66c92c3d0b76e1ee80c19e374d9692bcfbd931"
+    "initCodeHash": "0xea63f8c74f2ce10cc53e460b5f7f5006a06ab5612adc7253885a1ca3df124adb",
+    "sourceCodeHash": "0x169dc281821d3951fb399deefb0b84021b8172cf32ca03526686421bb6478cb4"
   },
   "src/universal/OptimismMintableERC20.sol:OptimismMintableERC20": {
     "initCodeHash": "0x3c85eed0d017dca8eda6396aa842ddc12492587b061e8c756a8d32c4610a9658",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -208,8 +208,8 @@
     "sourceCodeHash": "0x7fc4789b082bc8ecd29c4c75a06058f0ff0b72f1c1028a42db6f1c35269c8865"
   },
   "src/safe/SaferSafes.sol:SaferSafes": {
-    "initCodeHash": "0xea63f8c74f2ce10cc53e460b5f7f5006a06ab5612adc7253885a1ca3df124adb",
-    "sourceCodeHash": "0x169dc281821d3951fb399deefb0b84021b8172cf32ca03526686421bb6478cb4"
+    "initCodeHash": "0x80f67f25659b54347cea5f8c250cdf66a32a647375b6703e790b05965fe9cf88",
+    "sourceCodeHash": "0x9edb7350f8c664964dc106a89e1a117ba9e9b2d2c52d57b3c1c976170a34aa3b"
   },
   "src/universal/OptimismMintableERC20.sol:OptimismMintableERC20": {
     "initCodeHash": "0x3c85eed0d017dca8eda6396aa842ddc12492587b061e8c756a8d32c4610a9658",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -208,8 +208,8 @@
     "sourceCodeHash": "0x7fc4789b082bc8ecd29c4c75a06058f0ff0b72f1c1028a42db6f1c35269c8865"
   },
   "src/safe/SaferSafes.sol:SaferSafes": {
-    "initCodeHash": "0x80f67f25659b54347cea5f8c250cdf66a32a647375b6703e790b05965fe9cf88",
-    "sourceCodeHash": "0x9edb7350f8c664964dc106a89e1a117ba9e9b2d2c52d57b3c1c976170a34aa3b"
+    "initCodeHash": "0x0ad1f0f33517132b06a225b51e6eac48904d4ad691e0045eb70244d811d0d99d",
+    "sourceCodeHash": "0xd6683fe9be4019d34249ada5a4de3e597f1bd9cd473a89f6eff8f749a0b0e978"
   },
   "src/universal/OptimismMintableERC20.sol:OptimismMintableERC20": {
     "initCodeHash": "0x3c85eed0d017dca8eda6396aa842ddc12492587b061e8c756a8d32c4610a9658",

--- a/packages/contracts-bedrock/src/safe/LivenessModule2.sol
+++ b/packages/contracts-bedrock/src/safe/LivenessModule2.sol
@@ -173,8 +173,8 @@ abstract contract LivenessModule2 {
         if (_config.livenessResponsePeriod == 0) {
             revert LivenessModule2_InvalidResponsePeriod();
         }
-        // fallbackOwner must not be zero address to have a valid ownership recipient.
-        if (_config.fallbackOwner == address(0)) {
+        // fallbackOwner must not be zero address or the safe itself to be able to become an owner.
+        if (_config.fallbackOwner == address(0) || _config.fallbackOwner == address(callingSafe)) {
             revert LivenessModule2_InvalidFallbackOwner();
         }
 
@@ -334,6 +334,9 @@ abstract contract LivenessModule2 {
         }
 
         // Now swap the remaining single owner with the fallback owner
+        // Note: If the fallback owner would be the only or the last owner in the owners list,
+        // swapOwner would internally revert in OwnerManager, but we ignore it because the final
+        // owners list would still be what we want.
         _safe.execTransactionFromModule({
             to: address(_safe),
             value: 0,

--- a/packages/contracts-bedrock/src/safe/LivenessModule2.sol
+++ b/packages/contracts-bedrock/src/safe/LivenessModule2.sol
@@ -279,12 +279,16 @@ abstract contract LivenessModule2 {
         _cancelChallenge(callingSafe);
     }
 
-    /// @notice With successful challenge, removes all current owners from enabled safe,
-    ///         appoints fallback as sole owner, and sets its quorum to 1.
-    /// @dev Note: After ownership transfer, the fallback owner becomes the sole owner
-    ///      and is also still configured as the fallback owner. This means the
-    ///      fallback owner effectively becomes its own fallback owner, maintaining
-    ///      the ability to challenge itself if needed.
+    /// @notice With successful challenge, removes all current owners from enabled safe, appoints
+    ///         fallback as sole owner, and sets its quorum to 1.
+    /// @dev After ownership transfer, the fallback owner becomes the sole owner and is also still
+    ///      configured as the fallback owner. If the fallback owner would become unable to sign,
+    ///      it would not be able challenge the safe again. For this reason, it is important that
+    ///      the fallback owner has a way to preserve its own liveness.
+    ///
+    ///      It is of critical importance that this function never reverts. If it were to do so,
+    ///      the Safe would be permanently bricked. For this reason, the external calls from this
+    ///      function are allowed to fail silently instead of reverting.
     /// @param _safe The Safe address to transfer ownership of.
     function changeOwnershipToFallback(Safe _safe) external {
         // Ensure Safe is configured with this module to prevent unauthorized execution.

--- a/packages/contracts-bedrock/src/safe/SaferSafes.sol
+++ b/packages/contracts-bedrock/src/safe/SaferSafes.sol
@@ -26,8 +26,8 @@ import { ISemver } from "interfaces/universal/ISemver.sol";
 ///      compatibility restrictions in the LivenessModule2 and TimelockGuard contracts.
 contract SaferSafes is LivenessModule2, TimelockGuard, ISemver {
     /// @notice Semantic version.
-    /// @custom:semver 1.9.1
-    string public constant version = "1.9.1";
+    /// @custom:semver 1.10.0
+    string public constant version = "1.10.0";
 
     /// @notice Error for when the liveness response period is insufficient.
     error SaferSafes_InsufficientLivenessResponsePeriod();

--- a/packages/contracts-bedrock/src/safe/SaferSafes.sol
+++ b/packages/contracts-bedrock/src/safe/SaferSafes.sol
@@ -26,8 +26,8 @@ import { ISemver } from "interfaces/universal/ISemver.sol";
 ///      compatibility restrictions in the LivenessModule2 and TimelockGuard contracts.
 contract SaferSafes is LivenessModule2, TimelockGuard, ISemver {
     /// @notice Semantic version.
-    /// @custom:semver 1.9.0
-    string public constant version = "1.9.0";
+    /// @custom:semver 1.9.1
+    string public constant version = "1.9.1";
 
     /// @notice Error for when the liveness response period is insufficient.
     error SaferSafes_InsufficientLivenessResponsePeriod();

--- a/packages/contracts-bedrock/src/safe/SaferSafes.sol
+++ b/packages/contracts-bedrock/src/safe/SaferSafes.sol
@@ -26,8 +26,8 @@ import { ISemver } from "interfaces/universal/ISemver.sol";
 ///      compatibility restrictions in the LivenessModule2 and TimelockGuard contracts.
 contract SaferSafes is LivenessModule2, TimelockGuard, ISemver {
     /// @notice Semantic version.
-    /// @custom:semver 1.8.0
-    string public constant version = "1.8.0";
+    /// @custom:semver 1.9.0
+    string public constant version = "1.9.0";
 
     /// @notice Error for when the liveness response period is insufficient.
     error SaferSafes_InsufficientLivenessResponsePeriod();

--- a/packages/contracts-bedrock/src/safe/SaferSafes.sol
+++ b/packages/contracts-bedrock/src/safe/SaferSafes.sol
@@ -26,8 +26,8 @@ import { ISemver } from "interfaces/universal/ISemver.sol";
 ///      compatibility restrictions in the LivenessModule2 and TimelockGuard contracts.
 contract SaferSafes is LivenessModule2, TimelockGuard, ISemver {
     /// @notice Semantic version.
-    /// @custom:semver 1.10.0
-    string public constant version = "1.10.0";
+    /// @custom:semver 1.10.1
+    string public constant version = "1.10.1";
 
     /// @notice Error for when the liveness response period is insufficient.
     error SaferSafes_InsufficientLivenessResponsePeriod();

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -190,16 +190,16 @@ abstract contract TimelockGuard is BaseGuard {
     /// @param txHash The identifier of the cancelled transaction.
     event TransactionCancelled(Safe indexed safe, bytes32 indexed txHash);
 
+    /// @notice Emitted when a transaction is executed for a Safe.
+    /// @param safe The Safe whose transaction is executed.
+    /// @param txHash The identifier of the executed transaction.
+    event TransactionExecuted(Safe indexed safe, bytes32 indexed txHash);
+
     /// @notice Emitted when the cancellation threshold is updated
     /// @param safe The Safe whose cancellation threshold is updated.
     /// @param oldThreshold The old cancellation threshold.
     /// @param newThreshold The new cancellation threshold.
     event CancellationThresholdUpdated(Safe indexed safe, uint256 oldThreshold, uint256 newThreshold);
-
-    /// @notice Emitted when a transaction is executed for a Safe.
-    /// @param safe The Safe whose transaction is executed.
-    /// @param txHash The identifier of the executed transaction.
-    event TransactionExecuted(Safe indexed safe, bytes32 txHash);
 
     /// @notice Used to emit a message, primarily to ensure that the cancelTransaction function is
     ///         is not labelled as view so that it is treated as a state-changing function.
@@ -455,8 +455,13 @@ abstract contract TimelockGuard is BaseGuard {
             revert TimelockGuard_InvalidVersion();
         }
 
-        // Validate timelock delay - must not be longer than 1 year
-        if (_timelockDelay > 365 days) {
+        // Check that this guard is enabled on the calling Safe
+        if (!_isGuardEnabled(callingSafe)) {
+            revert TimelockGuard_GuardNotEnabled();
+        }
+
+        // Validate timelock delay - must not be zero or longer than 1 year
+        if (_timelockDelay == 0 || _timelockDelay > 365 days) {
             revert TimelockGuard_InvalidTimelockDelay();
         }
 

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -88,13 +88,17 @@ abstract contract TimelockGuard is BaseGuard {
     }
 
     /// @notice Scheduled transaction
+    /// @custom:field txHash The hash of the transaction.
     /// @custom:field executionTime The timestamp when execution becomes valid.
     /// @custom:field state The state of the transaction.
     /// @custom:field params The parameters of the transaction.
+    /// @custom:field nonce The nonce of the transaction.
     struct ScheduledTransaction {
+        bytes32 txHash;
         uint256 executionTime;
         TransactionState state;
         ExecTransactionParams params;
+        uint256 nonce;
     }
 
     /// @notice Parameters for the Safe's execTransaction function
@@ -564,8 +568,13 @@ abstract contract TimelockGuard is BaseGuard {
         uint256 executionTime = block.timestamp + _currentSafeState(_safe).timelockDelay;
 
         // Schedule the transaction and add it to the pending transactions set
-        _currentSafeState(_safe).scheduledTransactions[txHash] =
-            ScheduledTransaction({ executionTime: executionTime, state: TransactionState.Pending, params: _params });
+        _currentSafeState(_safe).scheduledTransactions[txHash] = ScheduledTransaction({
+            txHash: txHash,
+            executionTime: executionTime,
+            state: TransactionState.Pending,
+            params: _params,
+            nonce: _nonce
+        });
         _currentSafeState(_safe).pendingTxHashes.add(txHash);
 
         emit TransactionScheduled(_safe, txHash, executionTime);

--- a/packages/contracts-bedrock/test/safe/LivenessModule2.t.sol
+++ b/packages/contracts-bedrock/test/safe/LivenessModule2.t.sol
@@ -185,12 +185,24 @@ contract LivenessModule2_ConfigureLivenessModule_Test is LivenessModule2_TestIni
         );
     }
 
-    function test_configureLivenessModule_invalidFallbackOwner_reverts() external {
+    function test_configureLivenessModule_zeroAddressFallbackOwner_reverts() external {
         // Test with zero address
         vm.expectRevert(LivenessModule2.LivenessModule2_InvalidFallbackOwner.selector);
         vm.prank(address(safeInstance.safe));
         livenessModule2.configureLivenessModule(
             LivenessModule2.ModuleConfig({ livenessResponsePeriod: CHALLENGE_PERIOD, fallbackOwner: address(0) })
+        );
+    }
+
+    function test_configureLivenessModule_safeAddressFallbackOwner_reverts() external {
+        // Test with safe address as fallbackOwner
+        vm.expectRevert(LivenessModule2.LivenessModule2_InvalidFallbackOwner.selector);
+        vm.prank(address(safeInstance.safe));
+        livenessModule2.configureLivenessModule(
+            LivenessModule2.ModuleConfig({
+                livenessResponsePeriod: CHALLENGE_PERIOD,
+                fallbackOwner: address(safeInstance.safe)
+            })
         );
     }
 

--- a/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
+++ b/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
@@ -505,9 +505,11 @@ contract TimelockGuard_ScheduledTransaction_Test is TimelockGuard_TestInit {
 
         TimelockGuard.ScheduledTransaction memory scheduledTransaction =
             timelockGuard.scheduledTransaction(safe, dummyTx.hash);
+        assertEq(scheduledTransaction.txHash, dummyTx.hash);
         assertEq(scheduledTransaction.executionTime, INIT_TIME + TIMELOCK_DELAY);
         assert(scheduledTransaction.state == TimelockGuard.TransactionState.Pending);
         assertEq(keccak256(abi.encode(scheduledTransaction.params)), keccak256(abi.encode(dummyTx.params)));
+        assertEq(scheduledTransaction.nonce, dummyTx.nonce);
     }
 }
 
@@ -525,9 +527,13 @@ contract TimelockGuard_PendingTransactions_Test is TimelockGuard_TestInit {
         dummyTx.scheduleTransaction(timelockGuard);
 
         TimelockGuard.ScheduledTransaction[] memory pendingTransactions = timelockGuard.pendingTransactions(safe);
+        // verify the pending transaction is the one we scheduled
         assertEq(pendingTransactions.length, 1);
-        // ensure the hash of the transaction params are the same
+        assertEq(pendingTransactions[0].txHash, dummyTx.hash);
+        assertEq(pendingTransactions[0].executionTime, INIT_TIME + TIMELOCK_DELAY);
+        assert(pendingTransactions[0].state == TimelockGuard.TransactionState.Pending);
         assertEq(pendingTransactions[0].params.to, dummyTx.params.to);
+        assertEq(pendingTransactions[0].nonce, dummyTx.nonce);
         assertEq(keccak256(abi.encode(pendingTransactions[0].params)), keccak256(abi.encode(dummyTx.params)));
     }
 


### PR DESCRIPTION
## Summary

This PR cherry-picks all Safe directory changes from develop that occurred after the `op-safe-contracts/v1.0.0` tag was created. This ensures the Safe contracts on the v1.0.0 branch match the latest improvements on develop.

## Changes

Cherry-picked the following commits:

1. **feat(ctb): Add the nonce and txHash into the ScheduledTransactions struct** (#18097)
   - Adds nonce and txHash fields to the ScheduledTransactions struct in TimelockGuard
   - Updates ITimelockGuard interface and tests

2. **Safer Safes audit fixes (no bytecode changes)** (#18147)
   - Improves natspec documentation
   - Bumps safe nonce when cancelling transactions
   - Clarifies trade-offs and design decisions

3. **SaferSafes audit fixes 2** (#18172)
   - Adds missing `indexed` to events
   - Prevents configuring non-enabled safes
   - Disallows safe address as fallback owner
   - Disallows zero timelock delay

4. **Recommended a Safe fallback owner** (#18239)
   - Adds recommendation for Safe fallback owner in natspec

## Files Changed

- `src/safe/LivenessModule2.sol`
- `src/safe/SaferSafes.sol`
- `src/safe/TimelockGuard.sol`
- `test/safe/LivenessModule2.t.sol`
- `test/safe/TimelockGuard.t.sol`
- `interfaces/safe/ITimelockGuard.sol`
- Updated snapshots and semver-lock

## Verification

All cherry-picks were successful with no conflicts. The Safe directory now matches develop.