### PR TITLE
fix: TxBuilder blob fallback to update txType to DynamicFee

### DIFF
--- a/devnet-sdk/system/txbuilder.go
+++ b/devnet-sdk/system/txbuilder.go
@@ -122,6 +122,7 @@ func (b *TxBuilder) BuildTx(options ...TxOption) (Transaction, error) {
 			tx, err = b.buildBlobTx(opts)
 		} else {
 			// If blob tx type is forced but no blobs provided, fall back to dynamic fee tx
+			txType = types.DynamicFeeTxType
 			tx, err = b.buildDynamicFeeTx(opts)
 		}
 	case types.AccessListTxType:


### PR DESCRIPTION
When a blob transaction type is forced but no blob data is provided, BuildTx fell back to constructing a dynamic-fee transaction but left the reported txType as Blob. Downstream signers select the signer based on Transaction.Type(), so this mismatch could result in selecting an incompatible signer (e.g., EIP-155 signer) and failing to sign. This change updates txType to types.DynamicFeeTxType in the fallback branch so EthTx.Type() matches the actual raw transaction type, ensuring consistent behavior throughout signing and sending paths.