### PR TITLE
feat: have OPCMv2 revert if user tries to provide address(0) as SystemConfig for upgrade

### DIFF
--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -53,7 +53,7 @@
   },
   "src/L1/opcm/OPContractsManagerV2.sol:OPContractsManagerV2": {
     "initCodeHash": "0x0db0819c7dcefafc5a0780b3a85c0b2dded2413cb5ee12306eecd6c81d91a404",
-    "sourceCodeHash": "0xbfd27bd3b397274049e68c6db9bae6135747cb5b5dfc9fa2cb16e2781ab5aca7"
+    "sourceCodeHash": "0x41a838105c41756eccab3a2ef2e89ebd1ec4e04aabde1597ca847878cb87fe4f"
   },
   "src/L2/BaseFeeVault.sol:BaseFeeVault": {
     "initCodeHash": "0x838bbd7f381e84e21887f72bd1da605bfc4588b3c39aed96cbce67c09335b3ee",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -51,6 +51,10 @@
     "initCodeHash": "0x5ff0f79914999b54daeb3e3f38a1e2275f286e005a9e52055d169282605fec81",
     "sourceCodeHash": "0xc2b530bf529ac23d1ba1adf67eedcc5d95e25c2919e1d97f4f2bba4823303b17"
   },
+  "src/L1/opcm/OPContractsManagerV2.sol:OPContractsManagerV2": {
+    "initCodeHash": "0xdfa852bc51fc52a1221426f44375d9292f33df36fc9294eaab2c1cd676f563f3",
+    "sourceCodeHash": "0xbfd27bd3b397274049e68c6db9bae6135747cb5b5dfc9fa2cb16e2781ab5aca7"
+  },
   "src/L2/BaseFeeVault.sol:BaseFeeVault": {
     "initCodeHash": "0x838bbd7f381e84e21887f72bd1da605bfc4588b3c39aed96cbce67c09335b3ee",
     "sourceCodeHash": "0xcb329746df0baddd3dc03c6c88da5d6bdc0f0a96d30e6dc78d0891bb1e935032"

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -52,7 +52,7 @@
     "sourceCodeHash": "0xc2b530bf529ac23d1ba1adf67eedcc5d95e25c2919e1d97f4f2bba4823303b17"
   },
   "src/L1/opcm/OPContractsManagerV2.sol:OPContractsManagerV2": {
-    "initCodeHash": "0xdfa852bc51fc52a1221426f44375d9292f33df36fc9294eaab2c1cd676f563f3",
+    "initCodeHash": "0x0db0819c7dcefafc5a0780b3a85c0b2dded2413cb5ee12306eecd6c81d91a404",
     "sourceCodeHash": "0xbfd27bd3b397274049e68c6db9bae6135747cb5b5dfc9fa2cb16e2781ab5aca7"
   },
   "src/L2/BaseFeeVault.sol:BaseFeeVault": {

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.15;
 
 // Libraries
 import { LibString } from "@solady/utils/LibString.sol";

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
@@ -180,7 +180,8 @@ contract OPContractsManagerV2 is ISemver {
     IOPContractsManagerStandardValidator public immutable standardValidator;
 
     /// @notice The version of the OPCM contract.
-    string public constant version = "6.0.0";
+    /// @custom:semver 6.1.0
+    string public constant version = "6.1.0";
 
     /// @notice Special constant key for the PermittedProxyDeployment instruction.
     string internal constant PERMITTED_PROXY_DEPLOYMENT_KEY = "PermittedProxyDeployment";
@@ -246,6 +247,13 @@ contract OPContractsManagerV2 is ISemver {
     /// @param _inp The chain upgrade input.
     /// @return The upgraded chain contracts.
     function upgrade(UpgradeInput memory _inp) external returns (ChainContracts memory) {
+        // Sanity check that the SystemConfig isn't address(0). We use address(0) as a special
+        // value to indicate that this is an initial deployment, so we definitely don't want to
+        // allow it here.
+        if (address(_inp.systemConfig) == address(0)) {
+            revert OPContractsManagerV2_InvalidUpgradeInput();
+        }
+
         // Assert that the upgrade instructions are valid.
         // NOTE for developers: We use the concept of upgrade instructions to help maintain the
         // principle that OPCM should be updated at the time that the feature is being developed

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
@@ -317,6 +317,16 @@ contract OPContractsManagerV2_Upgrade_Test is OPContractsManagerV2_Upgrade_TestI
         );
     }
 
+    /// @notice Tests that the V2 upgrade function reverts when the SystemConfig address is zero.
+    function test_upgrade_zeroSystemConfig_reverts() public {
+        v2UpgradeInput.systemConfig = ISystemConfig(address(0));
+
+        // nosemgrep: sol-style-use-abi-encodecall
+        runCurrentUpgradeV2(
+            chainPAO, abi.encodeWithSelector(IOPContractsManagerV2.OPContractsManagerV2_InvalidUpgradeInput.selector)
+        );
+    }
+
     /// @notice Tests that the V2 upgrade function reverts when the user does not provide a game
     ///         config for each valid game type.
     function test_upgrade_missingGameConfigs_reverts() public {


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Updates OPCMv2 to revert if the user tries to provide `address(0)` as the systemconfig address