### PR TITLE
op-batcher: fix oldestL1Origin update in ChannelBuilder.AddBlock

### DIFF
--- a/op-batcher/batcher/channel_builder.go
+++ b/op-batcher/batcher/channel_builder.go
@@ -186,7 +186,7 @@ func (c *ChannelBuilder) AddBlock(block SizedBlock) (*derive.L1BlockInfo, error)
 			Number: l1info.Number,
 		}
 	}
-	if c.oldestL1Origin.Number == 0 || l1info.Number < c.latestL1Origin.Number {
+	if c.oldestL1Origin.Number == 0 || l1info.Number < c.oldestL1Origin.Number {
 		c.oldestL1Origin = eth.BlockID{
 			Hash:   l1info.BlockHash,
 			Number: l1info.Number,

--- a/op-batcher/batcher/channel_builder_test.go
+++ b/op-batcher/batcher/channel_builder_test.go
@@ -29,6 +29,26 @@ var defaultTestRollupConfig = &rollup.Config{
 	L2ChainID: big.NewInt(1234),
 }
 
+func TestChannelBuilder_OldestL1Origin_MixedSequence(t *testing.T) {
+	cb, err := newChannelBuilder(defaultTestChannelConfig(), defaultTestRollupConfig, latestL1BlockOrigin)
+	require.NoError(t, err)
+	require.Equal(t, eth.BlockID{}, cb.OldestL1Origin())
+
+	_, err = cb.AddBlock(SizedBlock{Block: newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(1), common.Hash{}, 5, 100)})
+	require.NoError(t, err)
+	_, err = cb.AddBlock(SizedBlock{Block: newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(2), common.Hash{}, 6, 100)})
+	require.NoError(t, err)
+	_, err = cb.AddBlock(SizedBlock{Block: newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(3), common.Hash{}, 10, 100)})
+	require.NoError(t, err)
+	require.Equal(t, uint64(5), cb.OldestL1Origin().Number)
+	require.Equal(t, uint64(10), cb.LatestL1Origin().Number)
+
+	_, err = cb.AddBlock(SizedBlock{Block: newMiniL2BlockWithNumberParentAndL1Information(0, big.NewInt(4), common.Hash{}, 8, 100)})
+	require.NoError(t, err)
+	require.Equal(t, uint64(5), cb.OldestL1Origin().Number)
+	require.Equal(t, uint64(10), cb.LatestL1Origin().Number)
+}
+
 // newChannelBuilder creates a new channel builder or returns an error if the
 // channel out could not be created.
 // it acts as a factory for either a span or singular channel out


### PR DESCRIPTION
The ChannelBuilder was updating oldestL1Origin by comparing incoming L1 origins against latestL1Origin instead of the current oldest value, which could incorrectly raise the tracked minimum when adding blocks with L1 origins that are less than latest but greater than the true minimum. This change corrects the comparison to use oldestL1Origin, aligning with the documented semantics and the analogous correct logic used for oldestL2. A regression test adds a mixed L1-origin sequence to ensure the oldest origin remains the minimum across out-of-order updates. While timeout behavior is unaffected due to separate min/max inclusion tracking and unified timeout management, accurate oldestL1Origin is important for correct logging and observability.