### PR TITLE
chore: add some TODOs for later into OPCMv2

### DIFF
--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
@@ -283,7 +283,7 @@ contract OPContractsManagerV2 is ISemver {
                     && LibString.eq(string(_extraInstructions[i].data), "DelayedWETH")
             ) {
                 // Unified DelayedWETH is being deployed for the first time.
-                // TODO:(#?????): Remove this allowance after unified DelayedWETH is deployed.
+                // TODO:(#18382): Remove this allowance after unified DelayedWETH is deployed.
             } else {
                 revert OPContractsManagerV2_InvalidUpgradeInstruction();
             }
@@ -580,6 +580,7 @@ contract OPContractsManagerV2 is ISemver {
                 ),
                 (IResourceMetering.ResourceConfig)
             ),
+            // TODO:(#18381): Use getStartingAnchorRoot once U18 is deployed.
             startingAnchorRoot: abi.decode(
                 _loadBytes(
                     address(_chainContracts.anchorStateRegistry),


### PR DESCRIPTION
Adds a few small TODOs into OPCMv2, to be cleaned up when we execute future upgrades. Adding the TODOs into the code makes them easier to track.
