### PR TITLE
fix(op-node): fix safe head debounce

### DIFF
--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -255,7 +255,6 @@ func (e *EngineController) SetLocalSafeHead(r eth.L2BlockRef) {
 func (e *EngineController) SetSafeHead(r eth.L2BlockRef) {
 	e.metrics.RecordL2Ref("l2_safe", r)
 	e.safeHead = r
-	e.needFCUCall = true
 	// Instead of immediately calling FCU, buffer this update
 	e.needSafeHeadUpdate = true
 }


### PR DESCRIPTION
**Description**
I applied the debouce FCU PR https://github.com/ethereum-optimism/optimism/pull/18234 to our fork, enabled debug logs on op-node and ran a devnet. I noticed that I was still getting FCU calls for every block in a batch, so no debouncing whatsoever. After looking at the code and the original PR https://github.com/ethereum-optimism/optimism/pull/17901, I noticed there was likely a mistake with applying the changes and the line that should replace `e.needFCUCall` was added without replacing it.

So the current version still performs an FCU on every safe head update instead of buffering them.
