### PR TITLE
contracts: Don't require two code owners for changing the go abi loader

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -33,8 +33,9 @@
 # Contracts
 # We require a minimum of 2 reviewers for all changes to the contracts-bedrock
 # directory unless only markdown files are being changed.
-/packages/contracts-bedrock/**           @ethereum-optimism/contract-reviewers #[min:2]
-/packages/contracts-bedrock/**/*.md      @ethereum-optimism/contract-reviewers
+/packages/contracts-bedrock/**                            @ethereum-optimism/contract-reviewers #[min:2]
+/packages/contracts-bedrock/**/*.md                       @ethereum-optimism/contract-reviewers
+/packages/contracts-bedrock/snapshots/abi_loader*.go      @ethereum-optimism/go-reviewers
 
 # Security docs
 /docs @ethereum-optimism/evm-safety


### PR DESCRIPTION
**Description**

We shouldn't need two reviews to change the abi loading code (which has to be in packages/contracts-bedrock due to Go's rules around embedding content). And it should be approved by go reviewers, not contract reviewers.