### PR TITLE
ci: add experimental GHA to build & attest images

### DIFF
--- a/.github/workflows/bake.yaml
+++ b/.github/workflows/bake.yaml
@@ -1,0 +1,88 @@
+name: bake
+
+on:
+  pull_request:
+    paths:
+      - 'ops/docker/**'
+      - 'packages/contracts-bedrock/**'
+      - 'docker-bake.hcl'
+      - '.github/workflows/bake.yaml'
+      - 'ops/scripts/compute-git-versions.sh'
+  push:
+    tags:
+      - '*'
+
+jobs:
+  prep:
+    runs-on: ubuntu-24.04
+    outputs:
+      sanitised_ref_name: ${{ steps.sanitize.outputs.ref_name }}
+      versions: ${{ steps.compute_versions.outputs.versions }}
+      kona_version: ${{ steps.kona.outputs.version }}
+    steps:
+      - name: harden-runner
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2
+        with:
+          egress-policy: audit
+      - name: Checkout
+        uses: actions/checkout@71cf2267d89c5cb81562390fa70a37fa40b1305e # v4
+        with:
+          fetch-depth: 0  # Need full history for git tag operations
+      - name: Sanitize ref_name
+        id: sanitize
+        run: echo "ref_name=$(echo ${{ github.ref_name }} | sed 's/[^a-zA-Z0-9.]/-/g')" >> $GITHUB_OUTPUT
+      - name: Read KONA_VERSION from kona/version.json
+        id: kona
+        run: |
+          KONA_VERSION=$(jq -r .version kona/version.json)
+          echo "version=$KONA_VERSION" >> $GITHUB_OUTPUT
+          echo "KONA_VERSION: $KONA_VERSION"
+      - name: Compute GIT_VERSION for all images
+        id: compute_versions
+        run: |
+          VERSIONS=$(GIT_COMMIT="${{ github.sha }}" make compute-git-versions)
+          echo "versions=$VERSIONS" >> $GITHUB_OUTPUT
+          echo "Computed versions: $VERSIONS"
+
+  build:
+    needs: prep
+    strategy:
+      fail-fast: false
+      matrix:
+        image_name:
+          - op-node
+          - op-batcher
+          - op-deployer
+          - op-faucet
+          - op-program
+          - op-proposer
+          - op-challenger
+          - op-dispute-mon
+          - op-conductor
+          - da-server
+          - op-supervisor
+          - op-supernode
+          - op-test-sequencer
+          - cannon
+          - op-dripper
+          - op-interop-mon
+    uses: ethereum-optimism/factory/.github/workflows/docker-bake.yaml@35765f06fe9e78ffc4b00aff0adb3fca948959f3
+    with:
+      image_name: ${{ matrix.image_name }}
+      bake_file: docker-bake.hcl
+      target: ${{ matrix.image_name }}
+      tag: ${{ needs.prep.outputs.sanitised_ref_name }}
+      gcp_project_id: ${{ vars.GCP_PROJECT_ID_OPLABS_TOOLS_ARTIFACTS }}
+      gcp_registry: us-docker.pkg.dev/oplabs-tools-artifacts/oss
+      env: |
+        GIT_VERSION=${{ fromJson(needs.prep.outputs.versions)[matrix.image_name] }}
+        KONA_VERSION=${{ needs.prep.outputs.kona_version }}
+      set: |
+        *.args.GIT_COMMIT=${{ github.sha }}
+        *.args.GIT_DATE=${{ github.event.head_commit.timestamp }}
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+
+

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,6 @@ include ./justfiles/flags.mk
 
 BEDROCK_TAGS_REMOTE?=origin
 OP_STACK_GO_BUILDER?=us-docker.pkg.dev/oplabs-tools-artifacts/images/op-stack-go:latest
-KONA_VERSION = 1.2.2
-DOCKER_TARGETS = op-node op-batcher op-proposer op-challenger op-dispute-mon op-supervisor
 
 # Requires at least Python v3.9; specify a minor version below if needed
 PYTHON?=python3
@@ -36,12 +34,11 @@ golang-docker: ## Builds Docker images for Go components using buildx
 	GIT_COMMIT=$$(git rev-parse HEAD) \
 	GIT_DATE=$$(git show -s --format='%ct') \
 	IMAGE_TAGS=$$(git rev-parse HEAD),latest \
-	KONA_VERSION=$$(jq -r .version kona/version.json) \
 	docker buildx bake \
 			--progress plain \
 			--load \
 			-f docker-bake.hcl \
-			$(DOCKER_TARGETS)
+			op-node op-batcher op-proposer op-challenger op-dispute-mon op-supervisor
 .PHONY: golang-docker
 
 docker-builder-clean: ## Removes the Docker buildx builder
@@ -52,6 +49,10 @@ docker-builder: ## Creates a Docker buildx builder
 	docker buildx create \
 		--driver=docker-container --name=buildx-build --bootstrap --use
 .PHONY: docker-builder
+
+compute-git-versions: ## Computes GIT_VERSION for all images and outputs JSON
+	@GIT_COMMIT=$$(git rev-parse HEAD) ./ops/scripts/compute-git-versions.sh
+.PHONY: compute-git-versions
 
 # add --print to dry-run
 cross-op-node: ## Builds cross-platform Docker image for op-node

--- a/ops/scripts/compute-git-versions.sh
+++ b/ops/scripts/compute-git-versions.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Computes GIT_VERSION for all OP Stack images based on git tags pointing at a commit.
+# Replicates CircleCI logic exactly - each image can have different GIT_VERSION values.
+# Outputs JSON mapping image names to their GIT_VERSION values.
+#
+# Usage:
+#   GIT_COMMIT=$(git rev-parse HEAD) ./ops/scripts/compute-git-versions.sh
+#
+# Output format:
+#   {"op-node":"v1.2.3","op-batcher":"v1.1.0",...}
+
+GIT_COMMIT="${GIT_COMMIT:-$(git rev-parse HEAD)}"
+
+IMAGES=(
+  "op-node"
+  "op-batcher"
+  "op-deployer"
+  "op-faucet"
+  "op-program"
+  "op-proposer"
+  "op-challenger"
+  "op-dispute-mon"
+  "op-conductor"
+  "da-server"
+  "op-supervisor"
+  "op-supernode"
+  "op-test-sequencer"
+  "cannon"
+  "op-dripper"
+  "op-interop-mon"
+)
+
+echo "Checking git tags pointing at $GIT_COMMIT:" >&2
+tags_at_commit=$(git tag --points-at "$GIT_COMMIT" || true)
+echo "Tags at commit: $tags_at_commit" >&2
+
+declare -A VERSIONS
+
+for IMAGE_NAME in "${IMAGES[@]}"; do
+  # Replicate CircleCI logic exactly: filter tags by image name prefix
+  filtered_tags=$(echo "$tags_at_commit" | grep "^${IMAGE_NAME}/" || true)
+  echo "Filtered tags for ${IMAGE_NAME}: $filtered_tags" >&2
+
+  if [ -z "$filtered_tags" ]; then
+    VERSIONS["$IMAGE_NAME"]="untagged"
+  else
+    sorted_tags=$(echo "$filtered_tags" | sed "s|${IMAGE_NAME}/||" | sort -V)
+    echo "Sorted tags for ${IMAGE_NAME}: $sorted_tags" >&2
+
+    # prefer full release tag over "-rc" release candidate tag if both exist
+    full_release_tag=$(echo "$sorted_tags" | grep -v -- "-rc" || true)
+    if [ -z "$full_release_tag" ]; then
+      VERSIONS["$IMAGE_NAME"]=$(echo "$sorted_tags" | tail -n 1)
+    else
+      VERSIONS["$IMAGE_NAME"]=$(echo "$full_release_tag" | tail -n 1)
+    fi
+  fi
+
+  echo "GIT_VERSION for ${IMAGE_NAME}: ${VERSIONS[$IMAGE_NAME]}" >&2
+done
+
+# Output as JSON
+JSON="{"
+FIRST=true
+for IMAGE_NAME in "${IMAGES[@]}"; do
+  if [ "$FIRST" = true ]; then
+    FIRST=false
+  else
+    JSON="${JSON},"
+  fi
+  VERSION="${VERSIONS[$IMAGE_NAME]}"
+  JSON="${JSON}\"${IMAGE_NAME}\":\"${VERSION}\""
+done
+JSON="${JSON}}"
+
+echo "$JSON"
+


### PR DESCRIPTION
This pull request adds a Github Action workflow to
- build the 16 images from the `docker-bake.hcl` with a secure reusable [workflow](https://github.com/ethereum-optimism/factory/blob/main/.github/workflows/docker-build.yaml) from the factory repository. Images are built for arm64 and amd64 linux architectures and are assembled under one multiarch manifest
- attach to it a SLSA Build Level 3 in-toto provenance attestation
- sign the attestation (providing the same benefit of an image signature) with Sigstore

Users will be able to verify that the images they pull were
- built from this repository
- built from protected tags
- not tampered

Users can verify attestations with the `gh` cli. A valid attestation also guarantees the image it refers to has not been tampered.

<img width="1224" height="597" alt="Screenshot 2025-11-27 at 14 14 57" src="https://github.com/user-attachments/assets/d56d266c-aeab-411b-9ca1-bbde7062272e" />

Attestations will show up in https://github.com/ethereum-optimism/op-geth/attestations

<img width="1132" height="1060" alt="Screenshot 2025-11-27 at 14 19 07" src="https://github.com/user-attachments/assets/031e3f0d-bf2d-4656-9a8d-56677dc160a9" />

<img width="1132" height="1060" alt="Screenshot 2025-11-27 at 14 19 26" src="https://github.com/user-attachments/assets/6f17304d-ec03-47a9-bb14-b5ead929d7fd" />
