### PR TITLE
fix(op-node): correct deposit count in sequencer metrics

### DIFF
--- a/op-node/rollup/engine/build_seal.go
+++ b/op-node/rollup/engine/build_seal.go
@@ -111,7 +111,9 @@ func (e *EngineController) onBuildSeal(ctx context.Context, ev BuildSealEvent) {
 	e.metrics.RecordSequencerBuildingDiffTime(buildTime - time.Duration(e.rollupCfg.BlockTime)*time.Second)
 
 	txnCount := len(envelope.ExecutionPayload.Transactions)
-	depositCount, _ := lastDeposit(envelope.ExecutionPayload.Transactions)
+	lastDepositIdx, _ := lastDeposit(envelope.ExecutionPayload.Transactions)
+	// lastDeposit returns the index (0-based), so add 1 to get the count
+	depositCount := lastDepositIdx + 1
 	e.metrics.CountSequencedTxsInBlock(txnCount, depositCount)
 
 	e.log.Debug("Built new L2 block", "l2_unsafe", ref, "l1_origin", ref.L1Origin,


### PR DESCRIPTION
The `lastDeposit` function returns a 0-based index of the last deposit transaction, but the result was used directly as the deposit count in metrics.

This caused the deposit count to always be off by one:
- 3 deposits at indices 0,1,2 → function returns 2 → metrics recorded 2 instead of 3

Fixed by adding +1 to convert the index to an actual count. This is safe because `sanityCheckPayload` guarantees at least one deposit exists before we reach this code.