### PR TITLE
op-challenger: Move GameType to the game/type package instead of game/fault/type

### DIFF
--- a/op-acceptance-tests/tests/base/disputegame_v2/smoke_test.go
+++ b/op-acceptance-tests/tests/base/disputegame_v2/smoke_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts/gameargs"
-	challengerTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 )
@@ -15,18 +15,18 @@ func TestSmoke(gt *testing.T) {
 	require := t.Require()
 	dgf := sys.DisputeGameFactory()
 
-	gameArgs := dgf.GameArgs(challengerTypes.PermissionedGameType)
+	gameArgs := dgf.GameArgs(gameTypes.PermissionedGameType)
 	require.NotEmpty(gameArgs, "game args is must be set for permissioned v2 dispute games")
 	_, err := gameargs.Parse(gameArgs)
 	require.NoError(err, "Permissioned game args invalid")
 
-	gameArgs = dgf.GameArgs(challengerTypes.CannonGameType)
+	gameArgs = dgf.GameArgs(gameTypes.CannonGameType)
 	require.NotEmpty(gameArgs, "game args is must be set for cannon v2 dispute games")
 	_, err = gameargs.Parse(gameArgs)
 	require.NoError(err, "Permissionless game args invalid")
 
-	permissionedGame := dgf.GameImpl(challengerTypes.PermissionedGameType)
+	permissionedGame := dgf.GameImpl(gameTypes.PermissionedGameType)
 	require.NotEmpty(permissionedGame.Address, "permissioned game impl must be set")
-	cannonGame := dgf.GameImpl(challengerTypes.CannonGameType)
+	cannonGame := dgf.GameImpl(gameTypes.CannonGameType)
 	require.NotEmpty(cannonGame.Address, "cannon game impl must be set")
 }

--- a/op-acceptance-tests/tests/base/withdrawal/cannon/init_test.go
+++ b/op-acceptance-tests/tests/base/withdrawal/cannon/init_test.go
@@ -4,9 +4,9 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/base/withdrawal"
-	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 )
 
 func TestMain(m *testing.M) {
-	withdrawal.InitWithGameType(m, types.CannonGameType)
+	withdrawal.InitWithGameType(m, gameTypes.CannonGameType)
 }

--- a/op-acceptance-tests/tests/base/withdrawal/cannon/withdrawal_test.go
+++ b/op-acceptance-tests/tests/base/withdrawal/cannon/withdrawal_test.go
@@ -4,9 +4,9 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/base/withdrawal"
-	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 )
 
 func TestWithdrawal_Cannon(gt *testing.T) {
-	withdrawal.TestWithdrawal(gt, faultTypes.CannonGameType)
+	withdrawal.TestWithdrawal(gt, gameTypes.CannonGameType)
 }

--- a/op-acceptance-tests/tests/base/withdrawal/cannon_kona/init_test.go
+++ b/op-acceptance-tests/tests/base/withdrawal/cannon_kona/init_test.go
@@ -4,9 +4,9 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/base/withdrawal"
-	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 )
 
 func TestMain(m *testing.M) {
-	withdrawal.InitWithGameType(m, types.CannonKonaGameType)
+	withdrawal.InitWithGameType(m, gameTypes.CannonKonaGameType)
 }

--- a/op-acceptance-tests/tests/base/withdrawal/cannon_kona/withdrawal_test.go
+++ b/op-acceptance-tests/tests/base/withdrawal/cannon_kona/withdrawal_test.go
@@ -4,9 +4,9 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/base/withdrawal"
-	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 )
 
 func TestWithdrawal_CannonKona(gt *testing.T) {
-	withdrawal.TestWithdrawal(gt, faultTypes.CannonKonaGameType)
+	withdrawal.TestWithdrawal(gt, gameTypes.CannonKonaGameType)
 }

--- a/op-acceptance-tests/tests/base/withdrawal/permissioned/init_test.go
+++ b/op-acceptance-tests/tests/base/withdrawal/permissioned/init_test.go
@@ -4,9 +4,9 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/base/withdrawal"
-	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 )
 
 func TestMain(m *testing.M) {
-	withdrawal.InitWithGameType(m, types.PermissionedGameType)
+	withdrawal.InitWithGameType(m, gameTypes.PermissionedGameType)
 }

--- a/op-acceptance-tests/tests/base/withdrawal/permissioned/withdrawal_test.go
+++ b/op-acceptance-tests/tests/base/withdrawal/permissioned/withdrawal_test.go
@@ -4,9 +4,9 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/base/withdrawal"
-	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 )
 
 func TestWithdrawal_Permissioned(gt *testing.T) {
-	withdrawal.TestWithdrawal(gt, faultTypes.PermissionedGameType)
+	withdrawal.TestWithdrawal(gt, gameTypes.PermissionedGameType)
 }

--- a/op-acceptance-tests/tests/base/withdrawal/withdrawal_test_helper.go
+++ b/op-acceptance-tests/tests/base/withdrawal/withdrawal_test_helper.go
@@ -3,14 +3,14 @@ package withdrawal
 import (
 	"testing"
 
-	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-devstack/compat"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
-func InitWithGameType(m *testing.M, gameType faultTypes.GameType) {
+func InitWithGameType(m *testing.M, gameType gameTypes.GameType) {
 	presets.DoMain(m,
 		presets.WithCompatibleTypes(compat.SysGo),
 		presets.WithMinimal(),
@@ -25,7 +25,7 @@ func InitWithGameType(m *testing.M, gameType faultTypes.GameType) {
 	)
 }
 
-func TestWithdrawal(gt *testing.T, gameType faultTypes.GameType) {
+func TestWithdrawal(gt *testing.T, gameType gameTypes.GameType) {
 	t := devtest.SerialT(gt)
 	sys := presets.NewMinimal(t)
 	require := sys.T.Require()

--- a/op-challenger/cmd/create_game.go
+++ b/op-challenger/cmd/create_game.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-challenger/flags"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts"
 	contractMetrics "github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts/metrics"
-	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-challenger/tools"
 	opservice "github.com/ethereum-optimism/optimism/op-service"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
@@ -22,7 +22,7 @@ var (
 		Name:    "game-type",
 		Usage:   "Game type to create (numeric values).",
 		EnvVars: opservice.PrefixEnvVar(flags.EnvVarPrefix, "TRACE_TYPE"),
-		Value:   types.CannonGameType.String(),
+		Value:   gameTypes.CannonGameType.String(),
 	}
 	OutputRootFlag = &cli.StringFlag{
 		Name:    "output-root",

--- a/op-challenger/game/fault/contracts/detect.go
+++ b/op-challenger/game/fault/contracts/detect.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
 	"github.com/ethereum/go-ethereum/common"
@@ -22,26 +22,26 @@ var (
 	}]`))
 )
 
-func DetectGameType(ctx context.Context, addr common.Address, caller *batching.MultiCaller) (faultTypes.GameType, error) {
+func DetectGameType(ctx context.Context, addr common.Address, caller *batching.MultiCaller) (gameTypes.GameType, error) {
 	result, err := caller.SingleCall(ctx, rpcblock.Latest, batching.NewContractCall(gameTypeABI, addr, methodGameType))
 	if err != nil {
-		return faultTypes.UnknownGameType, fmt.Errorf("failed to detect game type: %w", err)
+		return gameTypes.UnknownGameType, fmt.Errorf("failed to detect game type: %w", err)
 	}
-	gameType := faultTypes.GameType(result.GetUint32(0))
+	gameType := gameTypes.GameType(result.GetUint32(0))
 	switch gameType {
-	case faultTypes.CannonGameType,
-		faultTypes.PermissionedGameType,
-		faultTypes.CannonKonaGameType,
-		faultTypes.AsteriscGameType,
-		faultTypes.AlphabetGameType,
-		faultTypes.FastGameType,
-		faultTypes.AsteriscKonaGameType,
-		faultTypes.SuperCannonGameType,
-		faultTypes.SuperPermissionedGameType,
-		faultTypes.SuperCannonKonaGameType,
-		faultTypes.SuperAsteriscKonaGameType:
+	case gameTypes.CannonGameType,
+		gameTypes.PermissionedGameType,
+		gameTypes.CannonKonaGameType,
+		gameTypes.AsteriscGameType,
+		gameTypes.AlphabetGameType,
+		gameTypes.FastGameType,
+		gameTypes.AsteriscKonaGameType,
+		gameTypes.SuperCannonGameType,
+		gameTypes.SuperPermissionedGameType,
+		gameTypes.SuperCannonKonaGameType,
+		gameTypes.SuperAsteriscKonaGameType:
 		return gameType, nil
 	default:
-		return faultTypes.UnknownGameType, fmt.Errorf("unsupported game type: %d", gameType)
+		return gameTypes.UnknownGameType, fmt.Errorf("unsupported game type: %d", gameType)
 	}
 }

--- a/op-challenger/game/fault/contracts/disputegame.go
+++ b/op-challenger/game/fault/contracts/disputegame.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts/metrics"
-	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
@@ -35,23 +34,23 @@ type DisputeGameContract interface {
 }
 
 func NewDisputeGameContractForGame(ctx context.Context, metrics metrics.ContractMetricer, caller *batching.MultiCaller, game gameTypes.GameMetadata) (DisputeGameContract, error) {
-	return NewDisputeGameContract(ctx, metrics, caller, types.GameType(game.GameType), game.Proxy)
+	return NewDisputeGameContract(ctx, metrics, caller, gameTypes.GameType(game.GameType), game.Proxy)
 }
 
-func NewDisputeGameContract(ctx context.Context, metrics metrics.ContractMetricer, caller *batching.MultiCaller, gameType types.GameType, addr common.Address) (DisputeGameContract, error) {
+func NewDisputeGameContract(ctx context.Context, metrics metrics.ContractMetricer, caller *batching.MultiCaller, gameType gameTypes.GameType, addr common.Address) (DisputeGameContract, error) {
 	switch gameType {
-	case types.SuperCannonGameType, types.SuperCannonKonaGameType, types.SuperPermissionedGameType, types.SuperAsteriscKonaGameType:
+	case gameTypes.SuperCannonGameType, gameTypes.SuperCannonKonaGameType, gameTypes.SuperPermissionedGameType, gameTypes.SuperAsteriscKonaGameType:
 		return NewSuperFaultDisputeGameContract(ctx, metrics, addr, caller)
 
-	case types.CannonGameType,
-		types.PermissionedGameType,
-		types.CannonKonaGameType,
-		types.AsteriscGameType,
-		types.AlphabetGameType,
-		types.FastGameType,
-		types.AsteriscKonaGameType:
+	case gameTypes.CannonGameType,
+		gameTypes.PermissionedGameType,
+		gameTypes.CannonKonaGameType,
+		gameTypes.AsteriscGameType,
+		gameTypes.AlphabetGameType,
+		gameTypes.FastGameType,
+		gameTypes.AsteriscKonaGameType:
 		return NewPreInteropFaultDisputeGameContract(ctx, metrics, addr, caller)
-	case types.OptimisticZKGameType:
+	case gameTypes.OptimisticZKGameType:
 		return NewOptimisticZKDisputeGameContract(metrics, addr, caller)
 	default:
 		return nil, ErrUnsupportedGameType

--- a/op-challenger/game/fault/contracts/faultdisputegame.go
+++ b/op-challenger/game/fault/contracts/faultdisputegame.go
@@ -81,7 +81,7 @@ func NewFaultDisputeGameContract(ctx context.Context, metrics metrics.ContractMe
 		return nil, fmt.Errorf("failed to detect game type: %w", err)
 	}
 	switch gameType {
-	case types.SuperCannonGameType, types.SuperCannonKonaGameType, types.SuperPermissionedGameType, types.SuperAsteriscKonaGameType:
+	case gameTypes.SuperCannonGameType, gameTypes.SuperCannonKonaGameType, gameTypes.SuperPermissionedGameType, gameTypes.SuperAsteriscKonaGameType:
 		return NewSuperFaultDisputeGameContract(ctx, metrics, addr, caller)
 	default:
 		return NewPreInteropFaultDisputeGameContract(ctx, metrics, addr, caller)

--- a/op-challenger/game/fault/contracts/faultdisputegame_test.go
+++ b/op-challenger/game/fault/contracts/faultdisputegame_test.go
@@ -14,7 +14,7 @@ import (
 
 	contractMetrics "github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts/metrics"
 	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
-	"github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
@@ -39,7 +39,7 @@ var (
 
 type contractVersion struct {
 	version  string
-	gameType faultTypes.GameType
+	gameType gameTypes.GameType
 	loadAbi  func() *abi.ABI
 }
 
@@ -52,7 +52,7 @@ func (c contractVersion) String() string {
 }
 
 func (c contractVersion) IsSuperGame() bool {
-	return c.gameType == faultTypes.SuperCannonGameType || c.gameType == faultTypes.SuperPermissionedGameType || c.gameType == faultTypes.SuperAsteriscKonaGameType
+	return c.gameType == gameTypes.SuperCannonGameType || c.gameType == gameTypes.SuperPermissionedGameType || c.gameType == gameTypes.SuperAsteriscKonaGameType
 }
 
 const (
@@ -68,47 +68,47 @@ const (
 var versions = []contractVersion{
 	{
 		version:  vers080,
-		gameType: faultTypes.CannonGameType,
+		gameType: gameTypes.CannonGameType,
 		loadAbi: func() *abi.ABI {
 			return mustParseAbi(faultDisputeGameAbi020)
 		},
 	},
 	{
 		version:  vers0180,
-		gameType: faultTypes.CannonGameType,
+		gameType: gameTypes.CannonGameType,
 		loadAbi: func() *abi.ABI {
 			return mustParseAbi(faultDisputeGameAbi0180)
 		},
 	},
 	{
 		version:  vers111,
-		gameType: faultTypes.CannonGameType,
+		gameType: gameTypes.CannonGameType,
 		loadAbi: func() *abi.ABI {
 			return mustParseAbi(faultDisputeGameAbi111)
 		},
 	},
 	{
 		version:  vers120,
-		gameType: faultTypes.CannonGameType,
+		gameType: gameTypes.CannonGameType,
 		loadAbi: func() *abi.ABI {
 			return mustParseAbi(faultDisputeGameAbi120)
 		},
 	},
 	{
 		version:  vers131,
-		gameType: faultTypes.CannonGameType,
+		gameType: gameTypes.CannonGameType,
 		loadAbi: func() *abi.ABI {
 			return mustParseAbi(faultDisputeGameAbi131)
 		},
 	},
 	{
 		version:  versLatest,
-		gameType: faultTypes.CannonGameType,
+		gameType: gameTypes.CannonGameType,
 		loadAbi:  snapshots.LoadFaultDisputeGameABI,
 	},
 	{
 		version:  verSuperCannon,
-		gameType: faultTypes.SuperCannonGameType,
+		gameType: gameTypes.SuperCannonGameType,
 		loadAbi:  snapshots.LoadSuperFaultDisputeGameABI,
 	},
 }
@@ -126,7 +126,7 @@ func TestSimpleGetters(t *testing.T) {
 		{
 			methodAlias: "status",
 			method:      methodStatus,
-			result:      types.GameStatusChallengerWon,
+			result:      gameTypes.GameStatusChallengerWon,
 			call: func(game FaultDisputeGameContract) (any, error) {
 				return game.GetStatus(context.Background())
 			},
@@ -192,7 +192,7 @@ func TestSimpleGetters(t *testing.T) {
 		{
 			methodAlias: "resolve",
 			method:      methodResolve,
-			result:      types.GameStatusInProgress,
+			result:      gameTypes.GameStatusInProgress,
 			call: func(game FaultDisputeGameContract) (any, error) {
 				return game.CallResolve(context.Background())
 			},
@@ -581,7 +581,7 @@ func TestGetGameMetadata(t *testing.T) {
 			expectedL2BlockNumber := uint64(123)
 			expectedMaxClockDuration := uint64(456)
 			expectedRootClaim := common.Hash{0x01, 0x02}
-			expectedStatus := types.GameStatusChallengerWon
+			expectedStatus := gameTypes.GameStatusChallengerWon
 			expectedL2BlockNumberChallenged := true
 			expectedL2BlockNumberChallenger := common.Address{0xee}
 			block := rpcblock.ByNumber(889)
@@ -625,7 +625,7 @@ func TestGetMetadata(t *testing.T) {
 			expectedL1Head := common.Hash{0x0a, 0x0b}
 			expectedL2BlockNumber := uint64(123)
 			expectedRootClaim := common.Hash{0x01, 0x02}
-			expectedStatus := types.GameStatusChallengerWon
+			expectedStatus := gameTypes.GameStatusChallengerWon
 			block := rpcblock.ByNumber(889)
 			stubRpc.SetResponse(fdgAddr, methodL1Head, block, nil, []interface{}{expectedL1Head})
 			if version.IsSuperGame() {
@@ -705,7 +705,7 @@ func TestFaultDisputeGame_GetCredit(t *testing.T) {
 			stubRpc, game := setupFaultDisputeGameTest(t, version)
 			addr := common.Address{0x01}
 			expectedCredit := big.NewInt(4284)
-			expectedStatus := types.GameStatusChallengerWon
+			expectedStatus := gameTypes.GameStatusChallengerWon
 			stubRpc.SetResponse(fdgAddr, methodCredit, rpcblock.Latest, []interface{}{addr}, []interface{}{expectedCredit})
 			stubRpc.SetResponse(fdgAddr, methodStatus, rpcblock.Latest, nil, []interface{}{expectedStatus})
 

--- a/op-challenger/game/fault/contracts/gamefactory.go
+++ b/op-challenger/game/fault/contracts/gamefactory.go
@@ -9,8 +9,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts/gameargs"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts/metrics"
-	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
-	"github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
@@ -39,9 +38,9 @@ var (
 //go:embed abis/DisputeGameFactory-1.2.0.json
 var disputeGameFactoryAbi120 []byte
 
-type gameArgsFunc func(ctx context.Context, caller *batching.MultiCaller, block rpcblock.Block, contract *batching.BoundContract, gameType faultTypes.GameType) ([]byte, error)
+type gameArgsFunc func(ctx context.Context, caller *batching.MultiCaller, block rpcblock.Block, contract *batching.BoundContract, gameType gameTypes.GameType) ([]byte, error)
 
-func getGameArgsLatest(ctx context.Context, caller *batching.MultiCaller, block rpcblock.Block, contract *batching.BoundContract, gameType faultTypes.GameType) ([]byte, error) {
+func getGameArgsLatest(ctx context.Context, caller *batching.MultiCaller, block rpcblock.Block, contract *batching.BoundContract, gameType gameTypes.GameType) ([]byte, error) {
 	result, err := caller.SingleCall(ctx, block, contract.Call(methodGameArgs, gameType))
 	if err != nil {
 		return nil, fmt.Errorf("failed to get game args: %w", err)
@@ -49,7 +48,7 @@ func getGameArgsLatest(ctx context.Context, caller *batching.MultiCaller, block 
 	return result.GetBytes(0), nil
 }
 
-func getGameArgsNoOp(_ context.Context, _ *batching.MultiCaller, _ rpcblock.Block, _ *batching.BoundContract, _ faultTypes.GameType) ([]byte, error) {
+func getGameArgsNoOp(_ context.Context, _ *batching.MultiCaller, _ rpcblock.Block, _ *batching.BoundContract, _ gameTypes.GameType) ([]byte, error) {
 	return nil, nil
 }
 
@@ -107,16 +106,16 @@ func (f *DisputeGameFactoryContract) GetGameCount(ctx context.Context, blockHash
 	return result.GetBigInt(0).Uint64(), nil
 }
 
-func (f *DisputeGameFactoryContract) GetGame(ctx context.Context, idx uint64, blockHash common.Hash) (types.GameMetadata, error) {
+func (f *DisputeGameFactoryContract) GetGame(ctx context.Context, idx uint64, blockHash common.Hash) (gameTypes.GameMetadata, error) {
 	defer f.metrics.StartContractRequest("GetGame")()
 	result, err := f.multiCaller.SingleCall(ctx, rpcblock.ByHash(blockHash), f.contract.Call(methodGameAtIndex, new(big.Int).SetUint64(idx)))
 	if err != nil {
-		return types.GameMetadata{}, fmt.Errorf("failed to load game %v: %w", idx, err)
+		return gameTypes.GameMetadata{}, fmt.Errorf("failed to load game %v: %w", idx, err)
 	}
 	return f.decodeGame(idx, result), nil
 }
 
-func (f *DisputeGameFactoryContract) getGameImpl(ctx context.Context, gameType faultTypes.GameType) (common.Address, error) {
+func (f *DisputeGameFactoryContract) getGameImpl(ctx context.Context, gameType gameTypes.GameType) (common.Address, error) {
 	defer f.metrics.StartContractRequest("GetGameImpl")()
 	result, err := f.multiCaller.SingleCall(ctx, rpcblock.Latest, f.contract.Call(methodGameImpls, gameType))
 	if err != nil {
@@ -125,7 +124,7 @@ func (f *DisputeGameFactoryContract) getGameImpl(ctx context.Context, gameType f
 	return result.GetAddress(0), nil
 }
 
-func (f *DisputeGameFactoryContract) HasGameImpl(ctx context.Context, gameType faultTypes.GameType) (bool, error) {
+func (f *DisputeGameFactoryContract) HasGameImpl(ctx context.Context, gameType gameTypes.GameType) (bool, error) {
 	impl, err := f.getGameImpl(ctx, gameType)
 	if err != nil {
 		return false, err
@@ -133,7 +132,7 @@ func (f *DisputeGameFactoryContract) HasGameImpl(ctx context.Context, gameType f
 	return impl != (common.Address{}), nil
 }
 
-func (f *DisputeGameFactoryContract) GetGameVm(ctx context.Context, gameType faultTypes.GameType) (*VMContract, error) {
+func (f *DisputeGameFactoryContract) GetGameVm(ctx context.Context, gameType gameTypes.GameType) (*VMContract, error) {
 	defer f.metrics.StartContractRequest("GetGameVm")()
 	gameArgs, err := f.getGameArgs(ctx, f.multiCaller, rpcblock.Latest, f.contract, gameType)
 	if err != nil {
@@ -155,7 +154,7 @@ func (f *DisputeGameFactoryContract) GetGameVm(ctx context.Context, gameType fau
 	return NewVMContract(args.Vm, f.multiCaller), nil
 }
 
-func (f *DisputeGameFactoryContract) GetGamePrestate(ctx context.Context, gameType faultTypes.GameType) (common.Hash, error) {
+func (f *DisputeGameFactoryContract) GetGamePrestate(ctx context.Context, gameType gameTypes.GameType) (common.Hash, error) {
 	defer f.metrics.StartContractRequest("GetGamePrestate")()
 	gameArgs, err := f.getGameArgs(ctx, f.multiCaller, rpcblock.Latest, f.contract, gameType)
 	if err != nil {
@@ -177,7 +176,7 @@ func (f *DisputeGameFactoryContract) GetGamePrestate(ctx context.Context, gameTy
 	return args.AbsolutePrestate, nil
 }
 
-func (f *DisputeGameFactoryContract) faultDisputeGameForType(ctx context.Context, gameType faultTypes.GameType) (FaultDisputeGameContract, error) {
+func (f *DisputeGameFactoryContract) faultDisputeGameForType(ctx context.Context, gameType gameTypes.GameType) (FaultDisputeGameContract, error) {
 	addr, err := f.getGameImpl(ctx, gameType)
 	if err != nil {
 		return nil, err
@@ -185,7 +184,7 @@ func (f *DisputeGameFactoryContract) faultDisputeGameForType(ctx context.Context
 	return NewFaultDisputeGameContract(ctx, f.metrics, addr, f.multiCaller)
 }
 
-func (f *DisputeGameFactoryContract) GetGamesAtOrAfter(ctx context.Context, blockHash common.Hash, earliestTimestamp uint64) ([]types.GameMetadata, error) {
+func (f *DisputeGameFactoryContract) GetGamesAtOrAfter(ctx context.Context, blockHash common.Hash, earliestTimestamp uint64) ([]gameTypes.GameMetadata, error) {
 	defer f.metrics.StartContractRequest("GetGamesAtOrAfter")()
 	count, err := f.GetGameCount(ctx, blockHash)
 	if err != nil {
@@ -194,7 +193,7 @@ func (f *DisputeGameFactoryContract) GetGamesAtOrAfter(ctx context.Context, bloc
 	batchSize := uint64(f.multiCaller.BatchSize())
 	rangeEnd := count
 
-	var games []types.GameMetadata
+	var games []gameTypes.GameMetadata
 	for {
 		if rangeEnd == uint64(0) {
 			// rangeEnd is exclusive so if its 0 we've reached the end.
@@ -230,7 +229,7 @@ func (f *DisputeGameFactoryContract) GetGamesAtOrAfter(ctx context.Context, bloc
 	}
 }
 
-func (f *DisputeGameFactoryContract) GetAllGames(ctx context.Context, blockHash common.Hash) ([]types.GameMetadata, error) {
+func (f *DisputeGameFactoryContract) GetAllGames(ctx context.Context, blockHash common.Hash) ([]gameTypes.GameMetadata, error) {
 	defer f.metrics.StartContractRequest("GetAllGames")()
 	count, err := f.GetGameCount(ctx, blockHash)
 	if err != nil {
@@ -247,7 +246,7 @@ func (f *DisputeGameFactoryContract) GetAllGames(ctx context.Context, blockHash 
 		return nil, fmt.Errorf("failed to fetch games: %w", err)
 	}
 
-	var games []types.GameMetadata
+	var games []gameTypes.GameMetadata
 	for i, result := range results {
 		games = append(games, f.decodeGame(uint64(i), result))
 	}
@@ -290,11 +289,11 @@ func (f *DisputeGameFactoryContract) DecodeDisputeGameCreatedLog(rcpt *ethTypes.
 	return common.Address{}, 0, common.Hash{}, fmt.Errorf("%w: %v", ErrEventNotFound, eventDisputeGameCreated)
 }
 
-func (f *DisputeGameFactoryContract) decodeGame(idx uint64, result *batching.CallResult) types.GameMetadata {
+func (f *DisputeGameFactoryContract) decodeGame(idx uint64, result *batching.CallResult) gameTypes.GameMetadata {
 	gameType := result.GetUint32(0)
 	timestamp := result.GetUint64(1)
 	proxy := result.GetAddress(2)
-	return types.GameMetadata{
+	return gameTypes.GameMetadata{
 		Index:     idx,
 		GameType:  gameType,
 		Timestamp: timestamp,

--- a/op-challenger/game/fault/contracts/gamefactory_test.go
+++ b/op-challenger/game/fault/contracts/gamefactory_test.go
@@ -9,8 +9,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts/gameargs"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts/metrics"
-	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
-	"github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
 	batchingTest "github.com/ethereum-optimism/optimism/op-service/sources/batching/test"
@@ -104,25 +103,25 @@ func TestLoadGame(t *testing.T) {
 		t.Run(version.String(), func(t *testing.T) {
 			blockHash := common.Hash{0xbb, 0xce}
 			stubRpc, factory := setupDisputeGameFactoryTest(t, version)
-			game0 := types.GameMetadata{
+			game0 := gameTypes.GameMetadata{
 				Index:     0,
 				GameType:  0,
 				Timestamp: 1234,
 				Proxy:     common.Address{0xaa},
 			}
-			game1 := types.GameMetadata{
+			game1 := gameTypes.GameMetadata{
 				Index:     1,
 				GameType:  1,
 				Timestamp: 5678,
 				Proxy:     common.Address{0xbb},
 			}
-			game2 := types.GameMetadata{
+			game2 := gameTypes.GameMetadata{
 				Index:     2,
 				GameType:  99,
 				Timestamp: 9988,
 				Proxy:     common.Address{0xcc},
 			}
-			expectedGames := []types.GameMetadata{game0, game1, game2}
+			expectedGames := []gameTypes.GameMetadata{game0, game1, game2}
 			for idx, expected := range expectedGames {
 				expectGetGame(stubRpc, idx, blockHash, expected)
 				actual, err := factory.GetGame(context.Background(), uint64(idx), blockHash)
@@ -138,26 +137,26 @@ func TestGetAllGames(t *testing.T) {
 		t.Run(version.String(), func(t *testing.T) {
 			blockHash := common.Hash{0xbb, 0xce}
 			stubRpc, factory := setupDisputeGameFactoryTest(t, version)
-			game0 := types.GameMetadata{
+			game0 := gameTypes.GameMetadata{
 				Index:     0,
 				GameType:  0,
 				Timestamp: 1234,
 				Proxy:     common.Address{0xaa},
 			}
-			game1 := types.GameMetadata{
+			game1 := gameTypes.GameMetadata{
 				Index:     1,
 				GameType:  1,
 				Timestamp: 5678,
 				Proxy:     common.Address{0xbb},
 			}
-			game2 := types.GameMetadata{
+			game2 := gameTypes.GameMetadata{
 				Index:     2,
 				GameType:  99,
 				Timestamp: 9988,
 				Proxy:     common.Address{0xcc},
 			}
 
-			expectedGames := []types.GameMetadata{game0, game1, game2}
+			expectedGames := []gameTypes.GameMetadata{game0, game1, game2}
 			stubRpc.SetResponse(factoryAddr, methodGameCount, rpcblock.ByHash(blockHash), nil, []interface{}{big.NewInt(int64(len(expectedGames)))})
 			for idx, expected := range expectedGames {
 				expectGetGame(stubRpc, idx, blockHash, expected)
@@ -190,9 +189,9 @@ func TestGetAllGamesAtOrAfter(t *testing.T) {
 				t.Run(fmt.Sprintf("Count_%v_Start_%v", test.gameCount, test.earliestGameIdx), func(t *testing.T) {
 					blockHash := common.Hash{0xbb, 0xce}
 					stubRpc, factory := setupDisputeGameFactoryTest(t, version)
-					var allGames []types.GameMetadata
+					var allGames []gameTypes.GameMetadata
 					for i := 0; i < test.gameCount; i++ {
-						allGames = append(allGames, types.GameMetadata{
+						allGames = append(allGames, gameTypes.GameMetadata{
 							Index:     uint64(i),
 							GameType:  uint32(i),
 							Timestamp: uint64(i),
@@ -209,7 +208,7 @@ func TestGetAllGamesAtOrAfter(t *testing.T) {
 					actualGames, err := factory.GetGamesAtOrAfter(context.Background(), blockHash, earliestTimestamp)
 					require.NoError(t, err)
 					// Games come back in descending timestamp order
-					var expectedGames []types.GameMetadata
+					var expectedGames []gameTypes.GameMetadata
 					if test.earliestGameIdx < len(allGames) {
 						expectedGames = slices.Clone(allGames[test.earliestGameIdx:])
 					}
@@ -250,7 +249,7 @@ func TestHasGameImpl(t *testing.T) {
 	for _, version := range factoryVersions {
 		t.Run(version.String()+"-set", func(t *testing.T) {
 			stubRpc, factory := setupDisputeGameFactoryTest(t, version)
-			gameType := faultTypes.CannonGameType
+			gameType := gameTypes.CannonGameType
 			gameImplAddr := common.Address{0xaa}
 			stubRpc.SetResponse(
 				factoryAddr,
@@ -258,20 +257,20 @@ func TestHasGameImpl(t *testing.T) {
 				rpcblock.Latest,
 				[]interface{}{gameType},
 				[]interface{}{gameImplAddr})
-			actual, err := factory.HasGameImpl(context.Background(), faultTypes.CannonGameType)
+			actual, err := factory.HasGameImpl(context.Background(), gameTypes.CannonGameType)
 			require.NoError(t, err)
 			require.True(t, actual)
 		})
 		t.Run(version.String()+"-unset", func(t *testing.T) {
 			stubRpc, factory := setupDisputeGameFactoryTest(t, version)
-			gameType := faultTypes.CannonGameType
+			gameType := gameTypes.CannonGameType
 			stubRpc.SetResponse(
 				factoryAddr,
 				methodGameImpls,
 				rpcblock.Latest,
 				[]interface{}{gameType},
 				[]interface{}{common.Address{}})
-			actual, err := factory.HasGameImpl(context.Background(), faultTypes.CannonGameType)
+			actual, err := factory.HasGameImpl(context.Background(), gameTypes.CannonGameType)
 			require.NoError(t, err)
 			require.False(t, actual)
 		})
@@ -283,7 +282,7 @@ func TestGetGameVM(t *testing.T) {
 		t.Run(fmt.Sprintf("GameArgs-%v", usesGameArgs), func(t *testing.T) {
 			for _, version := range factoryVersions {
 				t.Run(version.String(), func(t *testing.T) {
-					gameType := faultTypes.CannonGameType
+					gameType := gameTypes.CannonGameType
 					rpc, factory := setupDisputeGameFactoryTest(t, version)
 
 					if usesGameArgs {
@@ -322,7 +321,7 @@ func TestGetGamePrestate(t *testing.T) {
 		t.Run(fmt.Sprintf("GameArgs-%v", usesGameArgs), func(t *testing.T) {
 			for _, version := range factoryVersions {
 				t.Run(version.String(), func(t *testing.T) {
-					gameType := faultTypes.CannonGameType
+					gameType := gameTypes.CannonGameType
 					prestate := common.Hash{92, 4, 6, 12, 4}
 					rpc, factory := setupDisputeGameFactoryTest(t, version)
 
@@ -428,7 +427,7 @@ func TestDecodeDisputeGameCreatedLog(t *testing.T) {
 	}
 }
 
-func expectGetGame(stubRpc *batchingTest.AbiBasedRpc, idx int, blockHash common.Hash, game types.GameMetadata) {
+func expectGetGame(stubRpc *batchingTest.AbiBasedRpc, idx int, blockHash common.Hash, game gameTypes.GameMetadata) {
 	stubRpc.SetResponse(
 		factoryAddr,
 		methodGameAtIndex,
@@ -469,7 +468,7 @@ func setupDisputeGameFactoryTest(t *testing.T, version factoryContractVersion) (
 	return stubRpc, factory
 }
 
-func setupDisputeGame(rpc *batchingTest.AbiBasedRpc, gameAddr common.Address, gameType faultTypes.GameType) {
+func setupDisputeGame(rpc *batchingTest.AbiBasedRpc, gameAddr common.Address, gameType gameTypes.GameType) {
 	rpc.AddContract(gameAddr, snapshots.LoadFaultDisputeGameABI())
 	rpc.SetResponse(gameAddr, methodVersion, rpcblock.Latest, nil, []interface{}{versLatest})
 	rpc.SetResponse(gameAddr, methodGameType, rpcblock.Latest, nil, []interface{}{gameType})

--- a/op-challenger/game/fault/contracts/optimisticzkdisputegame_test.go
+++ b/op-challenger/game/fault/contracts/optimisticzkdisputegame_test.go
@@ -7,8 +7,7 @@ import (
 	"time"
 
 	contractMetrics "github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts/metrics"
-	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
-	"github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
 	batchingTest "github.com/ethereum-optimism/optimism/op-service/sources/batching/test"
@@ -24,7 +23,7 @@ const (
 var zkVersions = []contractVersion{
 	{
 		version:  versZKLatest,
-		gameType: faultTypes.OptimisticZKGameType,
+		gameType: gameTypes.OptimisticZKGameType,
 		loadAbi:  snapshots.LoadZKDisputeGameABI,
 	},
 }
@@ -42,7 +41,7 @@ func TestZKSimpleGetters(t *testing.T) {
 		{
 			methodAlias: "status",
 			method:      methodStatus,
-			result:      types.GameStatusChallengerWon,
+			result:      gameTypes.GameStatusChallengerWon,
 			call: func(game OptimisticZKDisputeGameContract) (any, error) {
 				return game.GetStatus(context.Background())
 			},
@@ -58,7 +57,7 @@ func TestZKSimpleGetters(t *testing.T) {
 		{
 			methodAlias: "resolve",
 			method:      methodResolve,
-			result:      types.GameStatusInProgress,
+			result:      gameTypes.GameStatusInProgress,
 			call: func(game OptimisticZKDisputeGameContract) (any, error) {
 				return game.CallResolve(context.Background())
 			},
@@ -105,7 +104,7 @@ func TestZKGetMetadata(t *testing.T) {
 			expectedL1Head := common.Hash{0x0a, 0x0b}
 			expectedL2BlockNumber := uint64(123)
 			expectedRootClaim := common.Hash{0x01, 0x02}
-			expectedStatus := types.GameStatusChallengerWon
+			expectedStatus := gameTypes.GameStatusChallengerWon
 			block := rpcblock.ByNumber(889)
 			stubRpc.SetResponse(fdgAddr, methodL1Head, block, nil, []interface{}{expectedL1Head})
 			stubRpc.SetResponse(fdgAddr, methodL2SequenceNumber, block, nil, []interface{}{new(big.Int).SetUint64(expectedL2BlockNumber)})

--- a/op-challenger/game/fault/register.go
+++ b/op-challenger/game/fault/register.go
@@ -12,6 +12,7 @@ import (
 	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	keccakTypes "github.com/ethereum-optimism/optimism/op-challenger/game/keccak/types"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/scheduler"
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-challenger/metrics"
 	"github.com/ethereum-optimism/optimism/op-service/clock"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
@@ -22,8 +23,8 @@ import (
 type CloseFunc func()
 
 type Registry interface {
-	RegisterGameType(gameType faultTypes.GameType, creator scheduler.PlayerCreator)
-	RegisterBondContract(gameType faultTypes.GameType, creator claims.BondContractCreator)
+	RegisterGameType(gameType gameTypes.GameType, creator scheduler.PlayerCreator)
+	RegisterBondContract(gameType gameTypes.GameType, creator claims.BondContractCreator)
 }
 
 type OracleRegistry interface {
@@ -65,77 +66,77 @@ func RegisterGameTypes(
 		if err != nil {
 			return nil, err
 		}
-		registerTasks = append(registerTasks, NewCannonRegisterTask(faultTypes.CannonGameType, cfg, m, vm.NewOpProgramServerExecutor(logger), l2HeaderSource, rollupClient, syncValidator))
+		registerTasks = append(registerTasks, NewCannonRegisterTask(gameTypes.CannonGameType, cfg, m, vm.NewOpProgramServerExecutor(logger), l2HeaderSource, rollupClient, syncValidator))
 	}
 	if cfg.TraceTypeEnabled(faultTypes.TraceTypeCannonKona) {
 		l2HeaderSource, rollupClient, syncValidator, err := clients.SingleChainClients()
 		if err != nil {
 			return nil, err
 		}
-		registerTasks = append(registerTasks, NewCannonKonaRegisterTask(faultTypes.CannonKonaGameType, cfg, m, vm.NewKonaExecutor(), l2HeaderSource, rollupClient, syncValidator))
+		registerTasks = append(registerTasks, NewCannonKonaRegisterTask(gameTypes.CannonKonaGameType, cfg, m, vm.NewKonaExecutor(), l2HeaderSource, rollupClient, syncValidator))
 	}
 	if cfg.TraceTypeEnabled(faultTypes.TraceTypeSuperCannon) {
 		rootProvider, syncValidator, err := clients.SuperchainClients()
 		if err != nil {
 			return nil, err
 		}
-		registerTasks = append(registerTasks, NewSuperCannonRegisterTask(faultTypes.SuperCannonGameType, cfg, m, vm.NewOpProgramServerExecutor(logger), rootProvider, syncValidator))
+		registerTasks = append(registerTasks, NewSuperCannonRegisterTask(gameTypes.SuperCannonGameType, cfg, m, vm.NewOpProgramServerExecutor(logger), rootProvider, syncValidator))
 	}
 	if cfg.TraceTypeEnabled(faultTypes.TraceTypeSuperCannonKona) {
 		rootProvider, syncValidator, err := clients.SuperchainClients()
 		if err != nil {
 			return nil, err
 		}
-		registerTasks = append(registerTasks, NewSuperCannonKonaRegisterTask(faultTypes.SuperCannonKonaGameType, cfg, m, vm.NewKonaSuperExecutor(), rootProvider, syncValidator))
+		registerTasks = append(registerTasks, NewSuperCannonKonaRegisterTask(gameTypes.SuperCannonKonaGameType, cfg, m, vm.NewKonaSuperExecutor(), rootProvider, syncValidator))
 	}
 	if cfg.TraceTypeEnabled(faultTypes.TraceTypePermissioned) {
 		l2HeaderSource, rollupClient, syncValidator, err := clients.SingleChainClients()
 		if err != nil {
 			return nil, err
 		}
-		registerTasks = append(registerTasks, NewCannonRegisterTask(faultTypes.PermissionedGameType, cfg, m, vm.NewOpProgramServerExecutor(logger), l2HeaderSource, rollupClient, syncValidator))
+		registerTasks = append(registerTasks, NewCannonRegisterTask(gameTypes.PermissionedGameType, cfg, m, vm.NewOpProgramServerExecutor(logger), l2HeaderSource, rollupClient, syncValidator))
 	}
 	if cfg.TraceTypeEnabled(faultTypes.TraceTypeSuperPermissioned) {
 		rootProvider, syncValidator, err := clients.SuperchainClients()
 		if err != nil {
 			return nil, err
 		}
-		registerTasks = append(registerTasks, NewSuperCannonRegisterTask(faultTypes.SuperPermissionedGameType, cfg, m, vm.NewOpProgramServerExecutor(logger), rootProvider, syncValidator))
+		registerTasks = append(registerTasks, NewSuperCannonRegisterTask(gameTypes.SuperPermissionedGameType, cfg, m, vm.NewOpProgramServerExecutor(logger), rootProvider, syncValidator))
 	}
 	if cfg.TraceTypeEnabled(faultTypes.TraceTypeAsterisc) {
 		l2HeaderSource, rollupClient, syncValidator, err := clients.SingleChainClients()
 		if err != nil {
 			return nil, err
 		}
-		registerTasks = append(registerTasks, NewAsteriscRegisterTask(faultTypes.AsteriscGameType, cfg, m, vm.NewOpProgramServerExecutor(logger), l2HeaderSource, rollupClient, syncValidator))
+		registerTasks = append(registerTasks, NewAsteriscRegisterTask(gameTypes.AsteriscGameType, cfg, m, vm.NewOpProgramServerExecutor(logger), l2HeaderSource, rollupClient, syncValidator))
 	}
 	if cfg.TraceTypeEnabled(faultTypes.TraceTypeAsteriscKona) {
 		l2HeaderSource, rollupClient, syncValidator, err := clients.SingleChainClients()
 		if err != nil {
 			return nil, err
 		}
-		registerTasks = append(registerTasks, NewAsteriscKonaRegisterTask(faultTypes.AsteriscKonaGameType, cfg, m, vm.NewKonaExecutor(), l2HeaderSource, rollupClient, syncValidator))
+		registerTasks = append(registerTasks, NewAsteriscKonaRegisterTask(gameTypes.AsteriscKonaGameType, cfg, m, vm.NewKonaExecutor(), l2HeaderSource, rollupClient, syncValidator))
 	}
 	if cfg.TraceTypeEnabled(faultTypes.TraceTypeSuperAsteriscKona) {
 		rootProvider, syncValidator, err := clients.SuperchainClients()
 		if err != nil {
 			return nil, err
 		}
-		registerTasks = append(registerTasks, NewSuperAsteriscKonaRegisterTask(faultTypes.SuperAsteriscKonaGameType, cfg, m, vm.NewKonaSuperExecutor(), rootProvider, syncValidator))
+		registerTasks = append(registerTasks, NewSuperAsteriscKonaRegisterTask(gameTypes.SuperAsteriscKonaGameType, cfg, m, vm.NewKonaSuperExecutor(), rootProvider, syncValidator))
 	}
 	if cfg.TraceTypeEnabled(faultTypes.TraceTypeFast) {
 		l2HeaderSource, rollupClient, syncValidator, err := clients.SingleChainClients()
 		if err != nil {
 			return nil, err
 		}
-		registerTasks = append(registerTasks, NewAlphabetRegisterTask(faultTypes.FastGameType, l2HeaderSource, rollupClient, syncValidator))
+		registerTasks = append(registerTasks, NewAlphabetRegisterTask(gameTypes.FastGameType, l2HeaderSource, rollupClient, syncValidator))
 	}
 	if cfg.TraceTypeEnabled(faultTypes.TraceTypeAlphabet) {
 		l2HeaderSource, rollupClient, syncValidator, err := clients.SingleChainClients()
 		if err != nil {
 			return nil, err
 		}
-		registerTasks = append(registerTasks, NewAlphabetRegisterTask(faultTypes.AlphabetGameType, l2HeaderSource, rollupClient, syncValidator))
+		registerTasks = append(registerTasks, NewAlphabetRegisterTask(gameTypes.AlphabetGameType, l2HeaderSource, rollupClient, syncValidator))
 	}
 	for _, task := range registerTasks {
 		if err := task.Register(ctx, registry, oracles, systemClock, l1Clock, logger, m, txSender, gameFactory, caller, l1HeaderSource, selective, claimants, cfg.ResponseDelay, cfg.ResponseDelayAfter); err != nil {

--- a/op-challenger/game/fault/register_task.go
+++ b/op-challenger/game/fault/register_task.go
@@ -21,7 +21,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/vm"
 	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/scheduler"
-	"github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-challenger/metrics"
 	"github.com/ethereum-optimism/optimism/op-service/clock"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -32,7 +32,7 @@ import (
 )
 
 type RegisterTask struct {
-	gameType               faultTypes.GameType
+	gameType               gameTypes.GameType
 	skipPrestateValidation bool
 
 	syncValidator SyncValidator
@@ -51,16 +51,16 @@ type RegisterTask struct {
 		poststateBlock uint64) (*trace.Accessor, error)
 }
 
-func NewSuperCannonRegisterTask(gameType faultTypes.GameType, cfg *config.Config, m caching.Metrics, serverExecutor vm.OracleServerExecutor, rootProvider super.RootProvider, syncValidator *super.SyncValidator) *RegisterTask {
+func NewSuperCannonRegisterTask(gameType gameTypes.GameType, cfg *config.Config, m caching.Metrics, serverExecutor vm.OracleServerExecutor, rootProvider super.RootProvider, syncValidator *super.SyncValidator) *RegisterTask {
 	return newSuperCannonVMRegisterTaskWithConfig(gameType, cfg, m, serverExecutor, rootProvider, syncValidator, cfg.Cannon, cfg.CannonAbsolutePreStateBaseURL, cfg.CannonAbsolutePreState)
 }
 
-func NewSuperCannonKonaRegisterTask(gameType faultTypes.GameType, cfg *config.Config, m caching.Metrics, serverExecutor vm.OracleServerExecutor, rootProvider super.RootProvider, syncValidator *super.SyncValidator) *RegisterTask {
+func NewSuperCannonKonaRegisterTask(gameType gameTypes.GameType, cfg *config.Config, m caching.Metrics, serverExecutor vm.OracleServerExecutor, rootProvider super.RootProvider, syncValidator *super.SyncValidator) *RegisterTask {
 	return newSuperCannonVMRegisterTaskWithConfig(gameType, cfg, m, serverExecutor, rootProvider, syncValidator, cfg.CannonKona, cfg.CannonKonaAbsolutePreStateBaseURL, cfg.CannonKonaAbsolutePreState)
 }
 
 func newSuperCannonVMRegisterTaskWithConfig(
-	gameType faultTypes.GameType,
+	gameType gameTypes.GameType,
 	cfg *config.Config,
 	m caching.Metrics,
 	serverExecutor vm.OracleServerExecutor,
@@ -74,7 +74,7 @@ func newSuperCannonVMRegisterTaskWithConfig(
 	return &RegisterTask{
 		gameType:               gameType,
 		syncValidator:          syncValidator,
-		skipPrestateValidation: gameType == faultTypes.SuperPermissionedGameType,
+		skipPrestateValidation: gameType == gameTypes.SuperPermissionedGameType,
 		getTopPrestateProvider: func(ctx context.Context, prestateTimestamp uint64) (faultTypes.PrestateProvider, error) {
 			return super.NewSuperRootPrestateProvider(rootProvider, prestateTimestamp), nil
 		},
@@ -105,16 +105,16 @@ func newSuperCannonVMRegisterTaskWithConfig(
 	}
 }
 
-func NewCannonRegisterTask(gameType faultTypes.GameType, cfg *config.Config, m caching.Metrics, serverExecutor vm.OracleServerExecutor, l2Client utils.L2HeaderSource, rollupClient outputs.OutputRollupClient, syncValidator SyncValidator) *RegisterTask {
+func NewCannonRegisterTask(gameType gameTypes.GameType, cfg *config.Config, m caching.Metrics, serverExecutor vm.OracleServerExecutor, l2Client utils.L2HeaderSource, rollupClient outputs.OutputRollupClient, syncValidator SyncValidator) *RegisterTask {
 	return newCannonVMRegisterTaskWithConfig(gameType, cfg, m, serverExecutor, l2Client, rollupClient, syncValidator, cfg.Cannon, cfg.CannonAbsolutePreStateBaseURL, cfg.CannonAbsolutePreState)
 }
 
-func NewCannonKonaRegisterTask(gameType faultTypes.GameType, cfg *config.Config, m caching.Metrics, serverExecutor vm.OracleServerExecutor, l2Client utils.L2HeaderSource, rollupClient outputs.OutputRollupClient, syncValidator SyncValidator) *RegisterTask {
+func NewCannonKonaRegisterTask(gameType gameTypes.GameType, cfg *config.Config, m caching.Metrics, serverExecutor vm.OracleServerExecutor, l2Client utils.L2HeaderSource, rollupClient outputs.OutputRollupClient, syncValidator SyncValidator) *RegisterTask {
 	return newCannonVMRegisterTaskWithConfig(gameType, cfg, m, serverExecutor, l2Client, rollupClient, syncValidator, cfg.CannonKona, cfg.CannonKonaAbsolutePreStateBaseURL, cfg.CannonKonaAbsolutePreState)
 }
 
 func newCannonVMRegisterTaskWithConfig(
-	gameType faultTypes.GameType,
+	gameType gameTypes.GameType,
 	cfg *config.Config,
 	m caching.Metrics,
 	serverExecutor vm.OracleServerExecutor,
@@ -132,7 +132,7 @@ func newCannonVMRegisterTaskWithConfig(
 		// Don't validate the absolute prestate or genesis output root for permissioned games
 		// Only trusted actors participate in these games so they aren't expected to reach the step() call and
 		// are often configured without valid prestates but the challenger should still resolve the games.
-		skipPrestateValidation: gameType == faultTypes.PermissionedGameType,
+		skipPrestateValidation: gameType == gameTypes.PermissionedGameType,
 		getTopPrestateProvider: func(ctx context.Context, prestateBlock uint64) (faultTypes.PrestateProvider, error) {
 			return outputs.NewPrestateProvider(rollupClient, prestateBlock), nil
 		},
@@ -162,7 +162,7 @@ func newCannonVMRegisterTaskWithConfig(
 	}
 }
 
-func NewAsteriscRegisterTask(gameType faultTypes.GameType, cfg *config.Config, m caching.Metrics, serverExecutor vm.OracleServerExecutor, l2Client utils.L2HeaderSource, rollupClient outputs.OutputRollupClient, syncValidator SyncValidator) *RegisterTask {
+func NewAsteriscRegisterTask(gameType gameTypes.GameType, cfg *config.Config, m caching.Metrics, serverExecutor vm.OracleServerExecutor, l2Client utils.L2HeaderSource, rollupClient outputs.OutputRollupClient, syncValidator SyncValidator) *RegisterTask {
 	stateConverter := asterisc.NewStateConverter(cfg.Asterisc)
 	return &RegisterTask{
 		gameType:      gameType,
@@ -196,7 +196,7 @@ func NewAsteriscRegisterTask(gameType faultTypes.GameType, cfg *config.Config, m
 	}
 }
 
-func NewAsteriscKonaRegisterTask(gameType faultTypes.GameType, cfg *config.Config, m caching.Metrics, serverExecutor vm.OracleServerExecutor, l2Client utils.L2HeaderSource, rollupClient outputs.OutputRollupClient, syncValidator SyncValidator) *RegisterTask {
+func NewAsteriscKonaRegisterTask(gameType gameTypes.GameType, cfg *config.Config, m caching.Metrics, serverExecutor vm.OracleServerExecutor, l2Client utils.L2HeaderSource, rollupClient outputs.OutputRollupClient, syncValidator SyncValidator) *RegisterTask {
 	stateConverter := asterisc.NewStateConverter(cfg.Asterisc)
 	return &RegisterTask{
 		gameType:      gameType,
@@ -230,12 +230,12 @@ func NewAsteriscKonaRegisterTask(gameType faultTypes.GameType, cfg *config.Confi
 	}
 }
 
-func NewSuperAsteriscKonaRegisterTask(gameType faultTypes.GameType, cfg *config.Config, m caching.Metrics, serverExecutor vm.OracleServerExecutor, rootProvider super.RootProvider, syncValidator *super.SyncValidator) *RegisterTask {
+func NewSuperAsteriscKonaRegisterTask(gameType gameTypes.GameType, cfg *config.Config, m caching.Metrics, serverExecutor vm.OracleServerExecutor, rootProvider super.RootProvider, syncValidator *super.SyncValidator) *RegisterTask {
 	stateConverter := asterisc.NewStateConverter(cfg.AsteriscKona)
 	return &RegisterTask{
 		gameType:               gameType,
 		syncValidator:          syncValidator,
-		skipPrestateValidation: gameType == faultTypes.SuperPermissionedGameType,
+		skipPrestateValidation: gameType == gameTypes.SuperPermissionedGameType,
 		getTopPrestateProvider: func(ctx context.Context, prestateTimestamp uint64) (faultTypes.PrestateProvider, error) {
 			return super.NewSuperRootPrestateProvider(rootProvider, prestateTimestamp), nil
 		},
@@ -266,7 +266,7 @@ func NewSuperAsteriscKonaRegisterTask(gameType faultTypes.GameType, cfg *config.
 	}
 }
 
-func NewAlphabetRegisterTask(gameType faultTypes.GameType, l2Client utils.L2HeaderSource, rollupClient outputs.OutputRollupClient, syncValidator SyncValidator) *RegisterTask {
+func NewAlphabetRegisterTask(gameType gameTypes.GameType, l2Client utils.L2HeaderSource, rollupClient outputs.OutputRollupClient, syncValidator SyncValidator) *RegisterTask {
 	return &RegisterTask{
 		gameType:      gameType,
 		syncValidator: syncValidator,
@@ -292,7 +292,7 @@ func NewAlphabetRegisterTask(gameType faultTypes.GameType, l2Client utils.L2Head
 }
 
 func cachePrestates(
-	gameType faultTypes.GameType,
+	gameType gameTypes.GameType,
 	stateConverter vm.StateConverter,
 	m caching.Metrics,
 	prestateBaseURL *url.URL,
@@ -329,7 +329,7 @@ func (e *RegisterTask) Register(
 	responseDelay time.Duration,
 	responseDelayAfter uint64) error {
 
-	playerCreator := func(game types.GameMetadata, dir string) (scheduler.GamePlayer, error) {
+	playerCreator := func(game gameTypes.GameMetadata, dir string) (scheduler.GamePlayer, error) {
 		contract, err := contracts.NewFaultDisputeGameContract(ctx, m, game.Proxy, caller)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create fault dispute game contracts: %w", err)
@@ -385,14 +385,14 @@ func (e *RegisterTask) Register(
 	}
 	registry.RegisterGameType(e.gameType, playerCreator)
 
-	contractCreator := func(game types.GameMetadata) (claims.BondContract, error) {
+	contractCreator := func(game gameTypes.GameMetadata) (claims.BondContract, error) {
 		return contracts.NewFaultDisputeGameContract(ctx, m, game.Proxy, caller)
 	}
 	registry.RegisterBondContract(e.gameType, contractCreator)
 	return nil
 }
 
-func registerOracle(ctx context.Context, logger log.Logger, oracles OracleRegistry, gameFactory *contracts.DisputeGameFactoryContract, gameType faultTypes.GameType) error {
+func registerOracle(ctx context.Context, logger log.Logger, oracles OracleRegistry, gameFactory *contracts.DisputeGameFactoryContract, gameType gameTypes.GameType) error {
 	// Check that there is an implementation set for this game type and skip if not.
 	hasImpl, err := gameFactory.HasGameImpl(ctx, gameType)
 	if err != nil {

--- a/op-challenger/game/fault/register_task_test.go
+++ b/op-challenger/game/fault/register_task_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts/gameargs"
-	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/registry"
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-challenger/metrics"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
@@ -35,7 +35,7 @@ func TestRegisterOracle_MissingGameImpl(t *testing.T) {
 
 			logger, logs := testlog.CaptureLogger(t, log.LvlInfo)
 			oracles := registry.NewOracleRegistry()
-			gameType := faultTypes.CannonGameType
+			gameType := gameTypes.CannonGameType
 
 			rpc.SetResponse(gameFactoryAddr, "gameImpls", rpcblock.Latest, []interface{}{gameType}, []interface{}{common.Address{}})
 
@@ -76,7 +76,7 @@ func TestRegisterOracle_AddsOracle(t *testing.T) {
 	}
 	for _, testCase := range tests {
 		t.Run(testCase.name, func(t *testing.T) {
-			for _, gameType := range []faultTypes.GameType{faultTypes.CannonGameType, faultTypes.SuperCannonGameType, faultTypes.SuperAsteriscKonaGameType} {
+			for _, gameType := range []gameTypes.GameType{gameTypes.CannonGameType, gameTypes.SuperCannonGameType, gameTypes.SuperAsteriscKonaGameType} {
 				t.Run(fmt.Sprintf("%v", gameType), func(t *testing.T) {
 					gameFactoryAddr := common.Address{0xaa}
 					gameImplAddr := common.Address{0xbb}
@@ -84,9 +84,9 @@ func TestRegisterOracle_AddsOracle(t *testing.T) {
 					oracleAddr := common.Address{0xdd}
 					rpc := test.NewAbiBasedRpc(t, gameFactoryAddr, snapshots.LoadDisputeGameFactoryABI())
 					rpc.SetResponse(gameFactoryAddr, "version", rpcblock.Latest, nil, []interface{}{testCase.version})
-					if gameType == faultTypes.CannonGameType {
+					if gameType == gameTypes.CannonGameType {
 						rpc.AddContract(gameImplAddr, snapshots.LoadFaultDisputeGameABI())
-					} else if gameType == faultTypes.SuperCannonGameType || gameType == faultTypes.SuperAsteriscKonaGameType {
+					} else if gameType == gameTypes.SuperCannonGameType || gameType == gameTypes.SuperAsteriscKonaGameType {
 						rpc.AddContract(gameImplAddr, snapshots.LoadSuperFaultDisputeGameABI())
 					} else {
 						t.Fatalf("game type %v not supported", gameType)

--- a/op-challenger/game/fault/types/types.go
+++ b/op-challenger/game/fault/types/types.go
@@ -11,6 +11,7 @@ import (
 
 	"slices"
 
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	preimage "github.com/ethereum-optimism/optimism/op-preimage"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
@@ -23,65 +24,6 @@ var (
 	ErrL2BlockNumberValid = errors.New("l2 block number is valid")
 	ErrNotInSync          = errors.New("local node too far behind")
 )
-
-type GameType uint32
-
-const (
-	CannonGameType            GameType = 0
-	PermissionedGameType      GameType = 1
-	AsteriscGameType          GameType = 2
-	AsteriscKonaGameType      GameType = 3
-	SuperCannonGameType       GameType = 4
-	SuperPermissionedGameType GameType = 5
-	OPSuccinctGameType        GameType = 6
-	SuperAsteriscKonaGameType GameType = 7
-	CannonKonaGameType        GameType = 8
-	SuperCannonKonaGameType   GameType = 9
-	OptimisticZKGameType      GameType = 10
-	FastGameType              GameType = 254
-	AlphabetGameType          GameType = 255
-	KailuaGameType            GameType = 1337
-	UnknownGameType           GameType = math.MaxUint32
-)
-
-func (t GameType) MarshalText() ([]byte, error) {
-	return []byte(t.String()), nil
-}
-
-func (t GameType) String() string {
-	switch t {
-	case CannonGameType:
-		return "cannon"
-	case PermissionedGameType:
-		return "permissioned"
-	case AsteriscGameType:
-		return "asterisc"
-	case AsteriscKonaGameType:
-		return "asterisc-kona"
-	case SuperCannonGameType:
-		return "super-cannon"
-	case SuperPermissionedGameType:
-		return "super-permissioned"
-	case OPSuccinctGameType:
-		return "op-succinct"
-	case SuperAsteriscKonaGameType:
-		return "super-asterisc-kona"
-	case CannonKonaGameType:
-		return "cannon-kona"
-	case SuperCannonKonaGameType:
-		return "super-cannon-kona"
-	case OptimisticZKGameType:
-		return "optimistic-zk"
-	case FastGameType:
-		return "fast"
-	case AlphabetGameType:
-		return "alphabet"
-	case KailuaGameType:
-		return "kailua"
-	default:
-		return fmt.Sprintf("<invalid: %d>", t)
-	}
-}
 
 type TraceType string
 
@@ -135,32 +77,32 @@ func ValidTraceType(value TraceType) bool {
 	return slices.Contains(TraceTypes, value)
 }
 
-func (t TraceType) GameType() GameType {
+func (t TraceType) GameType() gameTypes.GameType {
 	switch t {
 	case TraceTypeCannon:
-		return CannonGameType
+		return gameTypes.CannonGameType
 	case TraceTypeCannonKona:
-		return CannonKonaGameType
+		return gameTypes.CannonKonaGameType
 	case TraceTypePermissioned:
-		return PermissionedGameType
+		return gameTypes.PermissionedGameType
 	case TraceTypeAsterisc:
-		return AsteriscGameType
+		return gameTypes.AsteriscGameType
 	case TraceTypeAsteriscKona:
-		return AsteriscKonaGameType
+		return gameTypes.AsteriscKonaGameType
 	case TraceTypeFast:
-		return FastGameType
+		return gameTypes.FastGameType
 	case TraceTypeAlphabet:
-		return AlphabetGameType
+		return gameTypes.AlphabetGameType
 	case TraceTypeSuperCannon:
-		return SuperCannonGameType
+		return gameTypes.SuperCannonGameType
 	case TraceTypeSuperCannonKona:
-		return SuperCannonKonaGameType
+		return gameTypes.SuperCannonKonaGameType
 	case TraceTypeSuperPermissioned:
-		return SuperPermissionedGameType
+		return gameTypes.SuperPermissionedGameType
 	case TraceTypeSuperAsteriscKona:
-		return SuperAsteriscKonaGameType
+		return gameTypes.SuperAsteriscKonaGameType
 	default:
-		return UnknownGameType
+		return gameTypes.UnknownGameType
 	}
 }
 

--- a/op-challenger/game/fault/types/types_test.go
+++ b/op-challenger/game/fault/types/types_test.go
@@ -4,6 +4,7 @@ import (
 	"math/big"
 	"testing"
 
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -65,7 +66,7 @@ func TestKnownGameTypeForEveryTraceType(t *testing.T) {
 	for _, traceType := range TraceTypes {
 		traceType := traceType
 		t.Run(traceType.String(), func(t *testing.T) {
-			require.NotEqual(t, UnknownGameType, traceType.GameType())
+			require.NotEqual(t, gameTypes.UnknownGameType, traceType.GameType())
 		})
 	}
 }

--- a/op-challenger/game/registry/registry.go
+++ b/op-challenger/game/registry/registry.go
@@ -5,35 +5,34 @@ import (
 	"fmt"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/claims"
-	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/scheduler"
-	"github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 )
 
 var ErrUnsupportedGameType = errors.New("unsupported game type")
 
 type GameTypeRegistry struct {
-	types        map[faultTypes.GameType]scheduler.PlayerCreator
-	bondCreators map[faultTypes.GameType]claims.BondContractCreator
+	types        map[gameTypes.GameType]scheduler.PlayerCreator
+	bondCreators map[gameTypes.GameType]claims.BondContractCreator
 }
 
 func NewGameTypeRegistry() *GameTypeRegistry {
 	return &GameTypeRegistry{
-		types:        make(map[faultTypes.GameType]scheduler.PlayerCreator),
-		bondCreators: make(map[faultTypes.GameType]claims.BondContractCreator),
+		types:        make(map[gameTypes.GameType]scheduler.PlayerCreator),
+		bondCreators: make(map[gameTypes.GameType]claims.BondContractCreator),
 	}
 }
 
 // RegisterGameType registers a scheduler.PlayerCreator to use for a specific game type.
 // Panics if the same game type is registered multiple times, since this indicates a significant programmer error.
-func (r *GameTypeRegistry) RegisterGameType(gameType faultTypes.GameType, creator scheduler.PlayerCreator) {
+func (r *GameTypeRegistry) RegisterGameType(gameType gameTypes.GameType, creator scheduler.PlayerCreator) {
 	if _, ok := r.types[gameType]; ok {
 		panic(fmt.Errorf("duplicate creator registered for game type: %v", gameType))
 	}
 	r.types[gameType] = creator
 }
 
-func (r *GameTypeRegistry) RegisterBondContract(gameType faultTypes.GameType, creator claims.BondContractCreator) {
+func (r *GameTypeRegistry) RegisterBondContract(gameType gameTypes.GameType, creator claims.BondContractCreator) {
 	if _, ok := r.bondCreators[gameType]; ok {
 		panic(fmt.Errorf("duplicate bond contract registered for game type: %v", gameType))
 	}
@@ -41,16 +40,16 @@ func (r *GameTypeRegistry) RegisterBondContract(gameType faultTypes.GameType, cr
 }
 
 // CreatePlayer creates a new game player for the given game, using the specified directory for persisting data.
-func (r *GameTypeRegistry) CreatePlayer(game types.GameMetadata, dir string) (scheduler.GamePlayer, error) {
-	creator, ok := r.types[faultTypes.GameType(game.GameType)]
+func (r *GameTypeRegistry) CreatePlayer(game gameTypes.GameMetadata, dir string) (scheduler.GamePlayer, error) {
+	creator, ok := r.types[gameTypes.GameType(game.GameType)]
 	if !ok {
 		return nil, fmt.Errorf("%w: %v", ErrUnsupportedGameType, game.GameType)
 	}
 	return creator(game, dir)
 }
 
-func (r *GameTypeRegistry) CreateBondContract(game types.GameMetadata) (claims.BondContract, error) {
-	creator, ok := r.bondCreators[faultTypes.GameType(game.GameType)]
+func (r *GameTypeRegistry) CreateBondContract(game gameTypes.GameMetadata) (claims.BondContract, error) {
+	creator, ok := r.bondCreators[gameTypes.GameType(game.GameType)]
 	if !ok {
 		return nil, fmt.Errorf("%w: %v", ErrUnsupportedGameType, game.GameType)
 	}

--- a/op-challenger/game/types/game_type.go
+++ b/op-challenger/game/types/game_type.go
@@ -1,0 +1,65 @@
+package types
+
+import (
+	"fmt"
+	"math"
+)
+
+type GameType uint32
+
+const (
+	CannonGameType            GameType = 0
+	PermissionedGameType      GameType = 1
+	AsteriscGameType          GameType = 2
+	AsteriscKonaGameType      GameType = 3
+	SuperCannonGameType       GameType = 4
+	SuperPermissionedGameType GameType = 5
+	OPSuccinctGameType        GameType = 6
+	SuperAsteriscKonaGameType GameType = 7
+	CannonKonaGameType        GameType = 8
+	SuperCannonKonaGameType   GameType = 9
+	OptimisticZKGameType      GameType = 10
+	FastGameType              GameType = 254
+	AlphabetGameType          GameType = 255
+	KailuaGameType            GameType = 1337
+	UnknownGameType           GameType = math.MaxUint32
+)
+
+func (t GameType) MarshalText() ([]byte, error) {
+	return []byte(t.String()), nil
+}
+
+func (t GameType) String() string {
+	switch t {
+	case CannonGameType:
+		return "cannon"
+	case PermissionedGameType:
+		return "permissioned"
+	case AsteriscGameType:
+		return "asterisc"
+	case AsteriscKonaGameType:
+		return "asterisc-kona"
+	case SuperCannonGameType:
+		return "super-cannon"
+	case SuperPermissionedGameType:
+		return "super-permissioned"
+	case OPSuccinctGameType:
+		return "op-succinct"
+	case SuperAsteriscKonaGameType:
+		return "super-asterisc-kona"
+	case CannonKonaGameType:
+		return "cannon-kona"
+	case SuperCannonKonaGameType:
+		return "super-cannon-kona"
+	case OptimisticZKGameType:
+		return "optimistic-zk"
+	case FastGameType:
+		return "fast"
+	case AlphabetGameType:
+		return "alphabet"
+	case KailuaGameType:
+		return "kailua"
+	default:
+		return fmt.Sprintf("<invalid: %d>", t)
+	}
+}

--- a/op-challenger/runner/prestates.go
+++ b/op-challenger/runner/prestates.go
@@ -14,7 +14,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts/metrics"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/prestates"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/vm"
-	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
@@ -23,7 +23,7 @@ import (
 type OnChainPrestateFetcher struct {
 	m                  metrics.ContractMetricer
 	gameFactoryAddress common.Address
-	gameType           types.GameType
+	gameType           gameTypes.GameType
 	caller             *batching.MultiCaller
 }
 

--- a/op-deployer/pkg/deployer/pipeline/dispute_games.go
+++ b/op-deployer/pkg/deployer/pipeline/dispute_games.go
@@ -5,7 +5,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts/gameargs"
-	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/opcm"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/state"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -101,7 +101,7 @@ func deployDisputeGame(
 			Proposer:            thisIntent.Roles.Proposer,
 			Challenger:          thisIntent.Roles.Challenger,
 		}
-		if game.DisputeGameType == uint32(types.PermissionedGameType) {
+		if game.DisputeGameType == uint32(gameTypes.PermissionedGameType) {
 			gameArgs = args.PackPermissioned()
 		} else {
 			gameArgs = args.PackPermissionless()

--- a/op-devstack/dsl/proofs/dispute_game_factory.go
+++ b/op-devstack/dsl/proofs/dispute_game_factory.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/outputs"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/prestates"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/vm"
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-challenger/metrics"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	safetyTypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
@@ -150,13 +151,13 @@ func (f *DisputeGameFactory) GameAtIndex(idx int64) *FaultDisputeGame {
 	return NewFaultDisputeGame(f.t, f.require, gameInfo.Proxy, f.getGameHelper, f.honestTraceForGame, game)
 }
 
-func (f *DisputeGameFactory) GameImpl(gameType challengerTypes.GameType) *FaultDisputeGame {
+func (f *DisputeGameFactory) GameImpl(gameType gameTypes.GameType) *FaultDisputeGame {
 	implAddr := contract.Read(f.dgf.GameImpls(uint32(gameType)))
 	game := bindings.NewFaultDisputeGame(bindings.WithClient(f.ethClient), bindings.WithTo(implAddr), bindings.WithTest(f.t))
 	return NewFaultDisputeGame(f.t, f.require, implAddr, f.getGameHelper, f.honestTraceForGame, game)
 }
 
-func (f *DisputeGameFactory) GameArgs(gameType challengerTypes.GameType) []byte {
+func (f *DisputeGameFactory) GameArgs(gameType gameTypes.GameType) []byte {
 	return contract.Read(f.dgf.GameArgs(uint32(gameType)))
 }
 
@@ -175,10 +176,10 @@ func (f *DisputeGameFactory) WaitForGame() *FaultDisputeGame {
 func (f *DisputeGameFactory) StartSuperCannonGame(eoa *dsl.EOA, opts ...GameOpt) *SuperFaultDisputeGame {
 	f.require.NotNil(f.supervisor, "supervisor is required to start super games")
 
-	return f.startSuperCannonGameOfType(eoa, challengerTypes.SuperCannonGameType, opts...)
+	return f.startSuperCannonGameOfType(eoa, gameTypes.SuperCannonGameType, opts...)
 }
 
-func (f *DisputeGameFactory) startSuperCannonGameOfType(eoa *dsl.EOA, gameType challengerTypes.GameType, opts ...GameOpt) *SuperFaultDisputeGame {
+func (f *DisputeGameFactory) startSuperCannonGameOfType(eoa *dsl.EOA, gameType gameTypes.GameType, opts ...GameOpt) *SuperFaultDisputeGame {
 	cfg := NewGameCfg(opts...)
 	timestamp := cfg.l2SequenceNumber
 	if !cfg.l2SequenceNumberSet {
@@ -207,11 +208,11 @@ func (f *DisputeGameFactory) createSuperGameExtraData(timestamp uint64, cfg *Gam
 }
 
 func (f *DisputeGameFactory) StartCannonGame(eoa *dsl.EOA, opts ...GameOpt) *FaultDisputeGame {
-	return f.startOutputRootGameOfType(eoa, challengerTypes.CannonGameType, f.honestTraceForGame, opts...)
+	return f.startOutputRootGameOfType(eoa, gameTypes.CannonGameType, f.honestTraceForGame, opts...)
 }
 
 func (f *DisputeGameFactory) StartCannonKonaGame(eoa *dsl.EOA, opts ...GameOpt) *FaultDisputeGame {
-	return f.startOutputRootGameOfType(eoa, challengerTypes.CannonKonaGameType, f.honestTraceForGame, opts...)
+	return f.startOutputRootGameOfType(eoa, gameTypes.CannonKonaGameType, f.honestTraceForGame, opts...)
 }
 
 func (f *DisputeGameFactory) honestTraceForGame(game *FaultDisputeGame) challengerTypes.TraceAccessor {
@@ -220,7 +221,7 @@ func (f *DisputeGameFactory) honestTraceForGame(game *FaultDisputeGame) challeng
 	}
 	f.require.NotNil(f.challengerCfg, "Challenger config is required to create honest trace")
 	switch game.GameType() {
-	case challengerTypes.CannonGameType:
+	case gameTypes.CannonGameType:
 		return f.honestOutputCannonTrace(
 			game,
 			f.challengerCfg.CannonAbsolutePreStateBaseURL,
@@ -228,7 +229,7 @@ func (f *DisputeGameFactory) honestTraceForGame(game *FaultDisputeGame) challeng
 			f.challengerCfg.Cannon,
 			vm.NewOpProgramServerExecutor(f.log),
 		)
-	case challengerTypes.CannonKonaGameType:
+	case gameTypes.CannonKonaGameType:
 		return f.honestOutputCannonTrace(
 			game,
 			f.challengerCfg.CannonKonaAbsolutePreStateBaseURL,
@@ -288,7 +289,7 @@ func (f *DisputeGameFactory) honestOutputCannonTrace(
 
 func (f *DisputeGameFactory) startOutputRootGameOfType(
 	eoa *dsl.EOA,
-	gameType challengerTypes.GameType,
+	gameType gameTypes.GameType,
 	honestTraceProvider func(game *FaultDisputeGame) challengerTypes.TraceAccessor,
 	opts ...GameOpt) *FaultDisputeGame {
 	cfg := NewGameCfg(opts...)
@@ -318,7 +319,7 @@ func (f *DisputeGameFactory) createOutputGameExtraData(blockNum uint64, cfg *Gam
 	return extraData
 }
 
-func (f *DisputeGameFactory) createNewGame(eoa *dsl.EOA, gameType challengerTypes.GameType, claim common.Hash, extraData []byte) (*bindings.FaultDisputeGame, common.Address) {
+func (f *DisputeGameFactory) createNewGame(eoa *dsl.EOA, gameType gameTypes.GameType, claim common.Hash, extraData []byte) (*bindings.FaultDisputeGame, common.Address) {
 	f.log.Info("Creating dispute game", "gameType", gameType, "claim", claim.Hex(), "extradata", common.Bytes2Hex(extraData))
 
 	// Pull some metadata we need to construct a new game
@@ -337,7 +338,7 @@ func (f *DisputeGameFactory) createNewGame(eoa *dsl.EOA, gameType challengerType
 	return bindings.NewFaultDisputeGame(bindings.WithClient(f.ethClient), bindings.WithTo(gameAddr), bindings.WithTest(f.t)), gameAddr
 }
 
-func (f *DisputeGameFactory) initBond(gameType challengerTypes.GameType) eth.ETH {
+func (f *DisputeGameFactory) initBond(gameType gameTypes.GameType) eth.ETH {
 	return eth.WeiBig(contract.Read(f.dgf.InitBonds(uint32(gameType))))
 }
 

--- a/op-devstack/dsl/proofs/fault_dispute_game.go
+++ b/op-devstack/dsl/proofs/fault_dispute_game.go
@@ -53,8 +53,8 @@ func NewFaultDisputeGame(
 	return fdg
 }
 
-func (g *FaultDisputeGame) GameType() challengerTypes.GameType {
-	return challengerTypes.GameType(contract.Read(g.game.GameType()))
+func (g *FaultDisputeGame) GameType() gameTypes.GameType {
+	return gameTypes.GameType(contract.Read(g.game.GameType()))
 }
 
 func (g *FaultDisputeGame) MaxDepth() challengerTypes.Depth {

--- a/op-devstack/dsl/proofs/game_helper.go
+++ b/op-devstack/dsl/proofs/game_helper.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 
 	challengerTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
@@ -138,7 +139,7 @@ func (gs *GameHelper) AuthEOA(eoa *dsl.EOA) *GameHelper {
 func (gs *GameHelper) CreateGameWithClaims(
 	eoa *dsl.EOA,
 	factory *DisputeGameFactory,
-	gameType challengerTypes.GameType,
+	gameType gameTypes.GameType,
 	rootClaim common.Hash,
 	extraData []byte,
 	moves []GameHelperMove,

--- a/op-devstack/presets/proof.go
+++ b/op-devstack/presets/proof.go
@@ -1,7 +1,7 @@
 package presets
 
 import (
-	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl/contract"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack/match"
@@ -11,7 +11,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/txintent/contractio"
 )
 
-func WithRespectedGameType(gameType faultTypes.GameType) stack.CommonOption {
+func WithRespectedGameType(gameType gameTypes.GameType) stack.CommonOption {
 	opts := WithProposerGameType(gameType)
 	opts = stack.Combine(opts,
 		stack.MakeCommon(sysgo.WithRespectedGameType(gameType)), // Set if sysgo is in use
@@ -20,13 +20,13 @@ func WithRespectedGameType(gameType faultTypes.GameType) stack.CommonOption {
 	return opts
 }
 
-func WithAddedGameType(gameType faultTypes.GameType) stack.CommonOption {
+func WithAddedGameType(gameType gameTypes.GameType) stack.CommonOption {
 	opts := stack.Combine(
 		stack.MakeCommon(sysgo.WithGameTypeAdded(gameType)), // Add if sysgo is in use
 		RequireGameTypePresent(gameType),                    // Verify present for other chains
 	)
 
-	if gameType == faultTypes.CannonKonaGameType {
+	if gameType == gameTypes.CannonKonaGameType {
 		opts = stack.Combine(
 			opts,
 			WithCannonKonaFeatureEnabled(),
@@ -36,7 +36,7 @@ func WithAddedGameType(gameType faultTypes.GameType) stack.CommonOption {
 	return opts
 }
 
-func RequireGameTypePresent(gameType faultTypes.GameType) stack.CommonOption {
+func RequireGameTypePresent(gameType gameTypes.GameType) stack.CommonOption {
 	return stack.FnOption[stack.Orchestrator]{
 		PostHydrateFn: func(sys stack.System) {
 			elNode := sys.L1Network(match.FirstL1Network).L1ELNode(match.FirstL1EL)
@@ -53,7 +53,7 @@ func RequireGameTypePresent(gameType faultTypes.GameType) stack.CommonOption {
 	}
 }
 
-func RequireRespectedGameType(gameType faultTypes.GameType) stack.CommonOption {
+func RequireRespectedGameType(gameType gameTypes.GameType) stack.CommonOption {
 	return stack.FnOption[stack.Orchestrator]{
 		PostHydrateFn: func(sys stack.System) {
 
@@ -73,7 +73,7 @@ func RequireRespectedGameType(gameType faultTypes.GameType) stack.CommonOption {
 	}
 }
 
-func WithProposerGameType(gameType faultTypes.GameType) stack.CommonOption {
+func WithProposerGameType(gameType gameTypes.GameType) stack.CommonOption {
 	return stack.Combine(
 		stack.MakeCommon(
 			sysgo.WithProposerOption(func(id stack.L2ProposerID, cfg *ps.CLIConfig) {

--- a/op-devstack/sysgo/add_game_type.go
+++ b/op-devstack/sysgo/add_game_type.go
@@ -8,7 +8,7 @@ import (
 	"runtime"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
-	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/artifacts"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/manage"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
@@ -28,8 +28,8 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
-func WithGameTypeAdded(gameType types.GameType) stack.Option[*Orchestrator] {
-	if gameType == types.PermissionedGameType {
+func WithGameTypeAdded(gameType gameTypes.GameType) stack.Option[*Orchestrator] {
+	if gameType == gameTypes.PermissionedGameType {
 		// Permissioned games are added as part of the initial deployment
 		// so no action required.
 		return stack.Combine[*Orchestrator]()
@@ -45,7 +45,7 @@ func WithGameTypeAdded(gameType types.GameType) stack.Option[*Orchestrator] {
 	return opts
 }
 
-func WithRespectedGameType(gameType types.GameType) stack.Option[*Orchestrator] {
+func WithRespectedGameType(gameType gameTypes.GameType) stack.Option[*Orchestrator] {
 	return stack.FnOption[*Orchestrator]{
 		FinallyFn: func(o *Orchestrator) {
 			for _, l2ChainID := range o.l2Nets.Keys() {
@@ -60,7 +60,7 @@ func WithCannonGameTypeAdded(l1ELID stack.L1ELNodeID, l2ChainID eth.ChainID) sta
 		FinallyFn: func(o *Orchestrator) {
 			// TODO(#17867): Rebuild the op-program prestate using the newly minted L2 chain configs before using it.
 			absolutePrestate := getAbsolutePrestate(o.P(), "op-program/bin/prestate-proof-mt64.json")
-			addGameType(o, absolutePrestate, types.CannonGameType, l1ELID, l2ChainID)
+			addGameType(o, absolutePrestate, gameTypes.CannonGameType, l1ELID, l2ChainID)
 		},
 	}
 }
@@ -73,7 +73,7 @@ func WithCannonKonaGameTypeAdded() stack.Option[*Orchestrator] {
 		FinallyFn: func(o *Orchestrator) {
 			absolutePrestate := getCannonKonaAbsolutePrestate(o.P())
 			for _, l2ChainID := range o.l2Nets.Keys() {
-				addGameType(o, absolutePrestate, types.CannonKonaGameType, o.l1ELs.Keys()[0], l2ChainID)
+				addGameType(o, absolutePrestate, gameTypes.CannonKonaGameType, o.l1ELs.Keys()[0], l2ChainID)
 			}
 		},
 	}
@@ -87,7 +87,7 @@ func WithChallengerCannonKonaEnabled() stack.Option[*Orchestrator] {
 	}
 }
 
-func setRespectedGameType(o *Orchestrator, gameType types.GameType, l1ELID stack.L1ELNodeID, l2ChainID eth.ChainID) {
+func setRespectedGameType(o *Orchestrator, gameType gameTypes.GameType, l1ELID stack.L1ELNodeID, l2ChainID eth.ChainID) {
 	t := o.P()
 	require := t.Require()
 	require.NotNil(o.wb, "must have a world builder")
@@ -139,7 +139,7 @@ func setRespectedGameType(o *Orchestrator, gameType types.GameType, l1ELID stack
 	require.Equal(rcpt.Status, gethTypes.ReceiptStatusSuccessful, "set respected game type tx did not execute correctly")
 }
 
-func addGameType(o *Orchestrator, absolutePrestate common.Hash, gameType types.GameType, l1ELID stack.L1ELNodeID, l2ChainID eth.ChainID) {
+func addGameType(o *Orchestrator, absolutePrestate common.Hash, gameType gameTypes.GameType, l1ELID stack.L1ELNodeID, l2ChainID eth.ChainID) {
 	t := o.P()
 	require := t.Require()
 	require.NotNil(o.wb, "must have a world builder")
@@ -210,11 +210,11 @@ func addGameType(o *Orchestrator, absolutePrestate common.Hash, gameType types.G
 	transferOwnershipForDelegateCallProxy(t, l1ChainID.ToBig(), l1PAOKey, client, delegateCallProxy, dgf, l1PAO)
 }
 
-func PrestateForGameType(t devtest.CommonT, gameType types.GameType) common.Hash {
+func PrestateForGameType(t devtest.CommonT, gameType gameTypes.GameType) common.Hash {
 	switch gameType {
-	case types.CannonGameType:
+	case gameTypes.CannonGameType:
 		return getAbsolutePrestate(t, "op-program/bin/prestate-proof-mt64.json")
-	case types.CannonKonaGameType:
+	case gameTypes.CannonKonaGameType:
 		return getCannonKonaAbsolutePrestate(t)
 	default:
 		t.Require().Fail("no prestate available for game type", gameType)

--- a/op-dispute-mon/mon/extract/caller.go
+++ b/op-dispute-mon/mon/extract/caller.go
@@ -50,18 +50,18 @@ func (g *GameCallerCreator) CreateContract(ctx context.Context, game gameTypes.G
 	if fdg, ok := g.cache.Get(game.Proxy); ok {
 		return fdg, nil
 	}
-	switch faultTypes.GameType(game.GameType) {
-	case faultTypes.CannonGameType,
-		faultTypes.PermissionedGameType,
-		faultTypes.CannonKonaGameType,
-		faultTypes.AsteriscGameType,
-		faultTypes.AlphabetGameType,
-		faultTypes.FastGameType,
-		faultTypes.AsteriscKonaGameType,
-		faultTypes.SuperCannonGameType,
-		faultTypes.SuperPermissionedGameType,
-		faultTypes.SuperCannonKonaGameType,
-		faultTypes.SuperAsteriscKonaGameType:
+	switch gameTypes.GameType(game.GameType) {
+	case gameTypes.CannonGameType,
+		gameTypes.PermissionedGameType,
+		gameTypes.CannonKonaGameType,
+		gameTypes.AsteriscGameType,
+		gameTypes.AlphabetGameType,
+		gameTypes.FastGameType,
+		gameTypes.AsteriscKonaGameType,
+		gameTypes.SuperCannonGameType,
+		gameTypes.SuperPermissionedGameType,
+		gameTypes.SuperCannonKonaGameType,
+		gameTypes.SuperAsteriscKonaGameType:
 		fdg, err := contracts.NewFaultDisputeGameContract(ctx, g.m, game.Proxy, g.caller)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create fault dispute game contract: %w", err)

--- a/op-dispute-mon/mon/extract/caller_test.go
+++ b/op-dispute-mon/mon/extract/caller_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/ethereum-optimism/optimism/packages/contracts-bedrock/snapshots"
 	"github.com/ethereum/go-ethereum/common"
 
-	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 	batchingTest "github.com/ethereum-optimism/optimism/op-service/sources/batching/test"
@@ -29,47 +28,47 @@ func TestMetadataCreator_CreateContract(t *testing.T) {
 	}{
 		{
 			name: "validCannonGameType",
-			game: types.GameMetadata{GameType: uint32(faultTypes.CannonGameType), Proxy: fdgAddr},
+			game: types.GameMetadata{GameType: uint32(types.CannonGameType), Proxy: fdgAddr},
 		},
 		{
 			name: "validPermissionedGameType",
-			game: types.GameMetadata{GameType: uint32(faultTypes.PermissionedGameType), Proxy: fdgAddr},
+			game: types.GameMetadata{GameType: uint32(types.PermissionedGameType), Proxy: fdgAddr},
 		},
 		{
 			name: "validCannonKonaGameType",
-			game: types.GameMetadata{GameType: uint32(faultTypes.CannonKonaGameType), Proxy: fdgAddr},
+			game: types.GameMetadata{GameType: uint32(types.CannonKonaGameType), Proxy: fdgAddr},
 		},
 		{
 			name: "validAsteriscGameType",
-			game: types.GameMetadata{GameType: uint32(faultTypes.AsteriscGameType), Proxy: fdgAddr},
+			game: types.GameMetadata{GameType: uint32(types.AsteriscGameType), Proxy: fdgAddr},
 		},
 		{
 			name: "validAlphabetGameType",
-			game: types.GameMetadata{GameType: uint32(faultTypes.AlphabetGameType), Proxy: fdgAddr},
+			game: types.GameMetadata{GameType: uint32(types.AlphabetGameType), Proxy: fdgAddr},
 		},
 		{
 			name: "validFastGameType",
-			game: types.GameMetadata{GameType: uint32(faultTypes.FastGameType), Proxy: fdgAddr},
+			game: types.GameMetadata{GameType: uint32(types.FastGameType), Proxy: fdgAddr},
 		},
 		{
 			name: "validAsteriscKonaGameType",
-			game: types.GameMetadata{GameType: uint32(faultTypes.AsteriscKonaGameType), Proxy: fdgAddr},
+			game: types.GameMetadata{GameType: uint32(types.AsteriscKonaGameType), Proxy: fdgAddr},
 		},
 		{
 			name: "validSuperCannonGameType",
-			game: types.GameMetadata{GameType: uint32(faultTypes.SuperCannonGameType), Proxy: fdgAddr},
+			game: types.GameMetadata{GameType: uint32(types.SuperCannonGameType), Proxy: fdgAddr},
 		},
 		{
 			name: "validSuperPermissionedGameType",
-			game: types.GameMetadata{GameType: uint32(faultTypes.SuperPermissionedGameType), Proxy: fdgAddr},
+			game: types.GameMetadata{GameType: uint32(types.SuperPermissionedGameType), Proxy: fdgAddr},
 		},
 		{
 			name: "validSuperCannonKonaGameType",
-			game: types.GameMetadata{GameType: uint32(faultTypes.SuperCannonKonaGameType), Proxy: fdgAddr},
+			game: types.GameMetadata{GameType: uint32(types.SuperCannonKonaGameType), Proxy: fdgAddr},
 		},
 		{
 			name: "validSuperAsteriscKonaGameType",
-			game: types.GameMetadata{GameType: uint32(faultTypes.SuperAsteriscKonaGameType), Proxy: fdgAddr},
+			game: types.GameMetadata{GameType: uint32(types.SuperAsteriscKonaGameType), Proxy: fdgAddr},
 		},
 		{
 			name:        "InvalidGameType",
@@ -101,10 +100,10 @@ func TestMetadataCreator_CreateContract(t *testing.T) {
 
 func setupMetadataLoaderTest(t *testing.T, gameType uint32) (*batching.MultiCaller, *mockCacheMetrics) {
 	fdgAbi := snapshots.LoadFaultDisputeGameABI()
-	if gameType == uint32(faultTypes.SuperPermissionedGameType) ||
-		gameType == uint32(faultTypes.SuperCannonGameType) ||
-		gameType == uint32(faultTypes.SuperCannonKonaGameType) ||
-		gameType == uint32(faultTypes.SuperAsteriscKonaGameType) {
+	if gameType == uint32(types.SuperPermissionedGameType) ||
+		gameType == uint32(types.SuperCannonGameType) ||
+		gameType == uint32(types.SuperCannonKonaGameType) ||
+		gameType == uint32(types.SuperAsteriscKonaGameType) {
 		fdgAbi = snapshots.LoadSuperFaultDisputeGameABI()
 	}
 	stubRpc := batchingTest.NewAbiBasedRpc(t, fdgAddr, fdgAbi)

--- a/op-e2e/e2eutils/disputegame/helper.go
+++ b/op-e2e/e2eutils/disputegame/helper.go
@@ -12,7 +12,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts/metrics"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/outputs"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/super"
-	challengerTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	shared "github.com/ethereum-optimism/optimism/op-devstack/shared/challenger"
 	"github.com/ethereum-optimism/optimism/op-e2e/bindings"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/challenger"
@@ -153,7 +153,7 @@ func (h *FactoryHelper) PreimageHelper(ctx context.Context) *preimage.Helper {
 	caller := batching.NewMultiCaller(h.Client.Client(), batching.DefaultBatchSize)
 	dgf, err := contracts.NewDisputeGameFactoryContract(ctx, metrics.NoopContractMetrics, h.FactoryAddr, caller)
 	h.Require.NoError(err)
-	vm, err := dgf.GetGameVm(ctx, challengerTypes.GameType(cannonGameType))
+	vm, err := dgf.GetGameVm(ctx, gameTypes.GameType(cannonGameType))
 	h.Require.NoError(err)
 	oracle, err := vm.Oracle(ctx)
 	h.Require.NoError(err)

--- a/op-e2e/system/e2esys/setup.go
+++ b/op-e2e/system/e2esys/setup.go
@@ -16,7 +16,7 @@ import (
 	"testing"
 	"time"
 
-	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/maps"
 
@@ -926,9 +926,9 @@ func (cfg SystemConfig) Start(t *testing.T, startOpts ...StartOption) (*System, 
 	}
 
 	// L2Output Submitter
-	respectedGameType := faultTypes.PermissionedGameType
+	respectedGameType := gameTypes.PermissionedGameType
 	if cfg.AllocType == config.AllocTypeFastGame {
-		respectedGameType = faultTypes.FastGameType
+		respectedGameType = gameTypes.FastGameType
 	}
 	proposerCLIConfig := &l2os.CLIConfig{
 		L1EthRpc:          sys.EthInstances[RoleL1].UserRPC().RPC(),


### PR DESCRIPTION
**Description**

Game types are not specific to fault dispute games. As we introduce ZK games we want to maintain good separation between the fault dispute game handling code and the zk game handling code.



**Metadata**

#18321 