### PR TITLE
ci: split bake workflow in protected/unprotected flows

### DIFF
--- a/.github/workflows/protected.yaml
+++ b/.github/workflows/protected.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   prep:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     outputs:
       sanitised_ref_name: ${{ steps.sanitize.outputs.ref_name }}
       versions: ${{ steps.compute_versions.outputs.versions }}
@@ -20,7 +20,7 @@ jobs:
         with:
           egress-policy: audit
       - name: Checkout
-        uses: actions/checkout@71cf2267d89c5cb81562390fa70a37fa40b1305e # v4
+        uses: actions/checkout@71cf2267d89c5cb81562390fa70a37fa40b1305e # v6
         with:
           fetch-depth: 0  # Need full history for git tag operations
       - name: Sanitize ref_name

--- a/.github/workflows/protected.yaml
+++ b/.github/workflows/protected.yaml
@@ -1,0 +1,81 @@
+name: bake
+
+on:
+  push:
+    tags:
+      - '*'
+    branches:
+      - 'develop'
+
+jobs:
+  prep:
+    runs-on: ubuntu-24.04
+    outputs:
+      sanitised_ref_name: ${{ steps.sanitize.outputs.ref_name }}
+      versions: ${{ steps.compute_versions.outputs.versions }}
+      kona_version: ${{ steps.kona.outputs.version }}
+    steps:
+      - name: harden-runner
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2
+        with:
+          egress-policy: audit
+      - name: Checkout
+        uses: actions/checkout@71cf2267d89c5cb81562390fa70a37fa40b1305e # v4
+        with:
+          fetch-depth: 0  # Need full history for git tag operations
+      - name: Sanitize ref_name
+        id: sanitize
+        run: echo "ref_name=$(echo ${{ github.ref_name }} | sed 's/[^a-zA-Z0-9.]/-/g')" >> $GITHUB_OUTPUT
+      - name: Read KONA_VERSION from kona/version.json
+        id: kona
+        run: |
+          KONA_VERSION=$(jq -r .version kona/version.json)
+          echo "version=$KONA_VERSION" >> $GITHUB_OUTPUT
+          echo "KONA_VERSION: $KONA_VERSION"
+      - name: Compute GIT_VERSION for all images
+        id: compute_versions
+        run: |
+          VERSIONS=$(GIT_COMMIT="${{ github.sha }}" make compute-git-versions)
+          echo "versions=$VERSIONS" >> $GITHUB_OUTPUT
+          echo "Computed versions: $VERSIONS"
+
+  build:
+    needs: prep
+    strategy:
+      fail-fast: false
+      matrix:
+        image_name:
+          - op-node
+          - op-batcher
+          - op-deployer
+          - op-faucet
+          - op-program
+          - op-proposer
+          - op-challenger
+          - op-dispute-mon
+          - op-conductor
+          - da-server
+          - op-supervisor
+          - op-supernode
+          - op-test-sequencer
+          - cannon
+          - op-dripper
+          - op-interop-mon
+    uses: ethereum-optimism/factory/.github/workflows/docker-bake.yaml@2ff3f9bba03d59a6ad10fdf660ed253f53956188
+    with:
+      image_name: ${{ matrix.image_name }}
+      bake_file: docker-bake.hcl
+      target: ${{ matrix.image_name }}
+      tag: ${{ needs.prep.outputs.sanitised_ref_name }}
+      gcp_project_id: ${{ vars.GCP_PROJECT_ID_OPLABS_TOOLS_ARTIFACTS }}
+      registry: us-docker.pkg.dev/oplabs-tools-artifacts/oss
+      env: |
+        GIT_VERSION=${{ fromJson(needs.prep.outputs.versions)[matrix.image_name] }}
+        KONA_VERSION=${{ needs.prep.outputs.kona_version }}
+      set: |
+        *.args.GIT_COMMIT=${{ github.sha }}
+        *.args.GIT_DATE=${{ github.event.head_commit.timestamp }}
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write

--- a/.github/workflows/unprotected.yaml
+++ b/.github/workflows/unprotected.yaml
@@ -1,25 +1,29 @@
-name: bake
+name: bake (PR)
 
 on:
   pull_request:
+    branches:
+      - 'develop'
     paths:
       - 'ops/docker/**'
       - 'packages/contracts-bedrock/**'
       - 'docker-bake.hcl'
-      - '.github/workflows/bake.yaml'
+      - '.github/workflows/unprotected.yaml'
       - 'ops/scripts/compute-git-versions.sh'
-  push:
-    tags:
-      - '*'
 
 jobs:
   prep:
     runs-on: ubuntu-24.04
     outputs:
-      sanitised_ref_name: ${{ steps.sanitize.outputs.ref_name }}
       versions: ${{ steps.compute_versions.outputs.versions }}
       kona_version: ${{ steps.kona.outputs.version }}
+      date: ${{ steps.date.outputs.date }}
     steps:
+      - name: Get date
+        id: date
+        run: |
+          DATE=$(date +%Y%m%d)
+          echo "date=$DATE" >> $GITHUB_OUTPUT
       - name: harden-runner
         uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2
         with:
@@ -28,9 +32,6 @@ jobs:
         uses: actions/checkout@71cf2267d89c5cb81562390fa70a37fa40b1305e # v4
         with:
           fetch-depth: 0  # Need full history for git tag operations
-      - name: Sanitize ref_name
-        id: sanitize
-        run: echo "ref_name=$(echo ${{ github.ref_name }} | sed 's/[^a-zA-Z0-9.]/-/g')" >> $GITHUB_OUTPUT
       - name: Read KONA_VERSION from kona/version.json
         id: kona
         run: |
@@ -66,23 +67,21 @@ jobs:
           - cannon
           - op-dripper
           - op-interop-mon
-    uses: ethereum-optimism/factory/.github/workflows/docker-bake.yaml@35765f06fe9e78ffc4b00aff0adb3fca948959f3
+    uses: ethereum-optimism/factory/.github/workflows/docker-bake.yaml@2ff3f9bba03d59a6ad10fdf660ed253f53956188
     with:
       image_name: ${{ matrix.image_name }}
       bake_file: docker-bake.hcl
       target: ${{ matrix.image_name }}
-      tag: ${{ needs.prep.outputs.sanitised_ref_name }}
-      gcp_project_id: ${{ vars.GCP_PROJECT_ID_OPLABS_TOOLS_ARTIFACTS }}
-      gcp_registry: us-docker.pkg.dev/oplabs-tools-artifacts/oss
+      tag: 24h
+      registry: ttl.sh/${{ github.sha }}
+      push_provenance: false
       env: |
         GIT_VERSION=${{ fromJson(needs.prep.outputs.versions)[matrix.image_name] }}
         KONA_VERSION=${{ needs.prep.outputs.kona_version }}
       set: |
         *.args.GIT_COMMIT=${{ github.sha }}
-        *.args.GIT_DATE=${{ github.event.head_commit.timestamp }}
+        *.args.GIT_DATE=${{ needs.prep.outputs.date }}
     permissions:
       contents: read
       id-token: write
       attestations: write
-
-

--- a/.github/workflows/unprotected.yaml
+++ b/.github/workflows/unprotected.yaml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   prep:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     outputs:
       versions: ${{ steps.compute_versions.outputs.versions }}
       kona_version: ${{ steps.kona.outputs.version }}
@@ -29,7 +29,7 @@ jobs:
         with:
           egress-policy: audit
       - name: Checkout
-        uses: actions/checkout@71cf2267d89c5cb81562390fa70a37fa40b1305e # v4
+        uses: actions/checkout@71cf2267d89c5cb81562390fa70a37fa40b1305e # v6
         with:
           fetch-depth: 0  # Need full history for git tag operations
       - name: Read KONA_VERSION from kona/version.json


### PR DESCRIPTION
This change improves security and it will also greatly reduce usage of our container registry. It splits the execution of the docker bake GHA workflow in 2:
- protected branches/tags: continues as is now to push images to GCP
- PRs: skip authentication to GCP & push images to [ttl.sh](https://ttl.sh) where they are automatically deleted after 24h