### PR TITLE
feat: have OPCM upgrade allowances be upgrade specific

### DIFF
--- a/ops/ai-eng/graphite/rules.md
+++ b/ops/ai-eng/graphite/rules.md
@@ -6,6 +6,21 @@ This file explains the rules that you should use when reviewing a PR.
 
 You are ONLY to review changes to Solidity files (*.sol). Do NOT leave comments on any other file types.
 
+## OPCM Version Bump Warnings
+
+If the PR modifies `OPContractsManagerV2.sol` and changes the `version` constant with a major or minor version bump, you MUST leave a prominent comment on the PR with the following message:
+
+> ⚠️ **OPCM Version Bump Detected**
+>
+> This PR includes a major or minor version bump to `OPContractsManagerV2.sol`.
+>
+> **Reminder of OPCM versioning rules:**
+> - **Major bump**: Only for a new required sequential upgrade (e.g., U16 → U17)
+> - **Minor bump**: Only for replacing an existing OPCM for the same upgrade (e.g., bug fixes, U16a)
+> - **Patch bump**: Expected for normal development work
+>
+> Please confirm this version bump is intentional and follows the versioning policy.
+
 ## Rules for Reviewing Solidity Files
 
 This section applies to Solidity files ONLY.

--- a/packages/contracts-bedrock/book/src/policies/release-process.md
+++ b/packages/contracts-bedrock/book/src/policies/release-process.md
@@ -4,6 +4,16 @@ This release process applies to all contract release namespaces:
 - `op-contracts/vX.Y.Z`: Core protocol contracts
 - `op-safe-contracts/vX.Y.Z`: Safe multisig extensions
 
+## OPCM Versioning
+
+The OPCM contract uses a specific versioning scheme:
+
+- **Major version bump**: New required sequential upgrade (e.g., U16 → U17 → U18).
+- **Minor version bump**: Replacement OPCM for the same upgrade (e.g., bug fixes, U16a).
+- **Patch version bump**: Development changes on `develop` branch.
+
+See [OPCM Semver Rules](./versioning.md#opcm-semver-rules) for more details.
+
 ## Creating a tagged release
 
 First select a tag string based on the guidance in [Monorepo Contracts Release Versioning](./versioning.md#monorepo-contracts-release-versioning)

--- a/packages/contracts-bedrock/book/src/policies/versioning.md
+++ b/packages/contracts-bedrock/book/src/policies/versioning.md
@@ -82,3 +82,13 @@ Versioning for monorepo releases works as follows:
 The [OPCM](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/L1/OPContractsManager.sol) is the contract that manages the deployment of all contracts on L1.
 
 The `OPCM` is the source of truth for the contracts that belong in a release, available as on-chain addresses by querying [the `getImplementations` function](https://github.com/ethereum-optimism/optimism/blob/4c8764f0453e141555846d8c9dd2af9edbc1d014/packages/contracts-bedrock/src/L1/OPContractsManager.sol#L1061).
+
+### OPCM Semver Rules
+
+OPCM follows a specific versioning scheme that differs from individual contract versioning:
+
+- **Major version bump**: Used when there is a new required sequential upgrade. Each new upgrade in the upgrade sequence (e.g., U16, U17, U18) requires a major version bump to the OPCM.
+- **Minor version bump**: Used when an OPCM is replacing an existing OPCM for the same upgrade. This applies when:
+  - Fixing bugs in an OPCM for a given upgrade (e.g., fixes for the Superchain Config bug)
+  - Releasing an updated OPCM variant for the same upgrade (e.g., U16a replacing U16)
+- **Patch version bump**: Used during active development on the `develop` branch. This is the expected behavior for day-to-day development work.

--- a/packages/contracts-bedrock/interfaces/L1/opcm/IOPContractsManagerUtils.sol
+++ b/packages/contracts-bedrock/interfaces/L1/opcm/IOPContractsManagerUtils.sol
@@ -45,6 +45,16 @@ interface IOPContractsManagerUtils {
         external
         pure
         returns (bytes32);
+
+    function isMatchingInstruction(
+        ExtraInstruction memory _instruction,
+        string memory _key,
+        bytes memory _data
+    )
+        external
+        pure
+        returns (bool);
+
     function hasInstruction(
         ExtraInstruction[] memory _instructions,
         string memory _key,

--- a/packages/contracts-bedrock/interfaces/L1/opcm/IOPContractsManagerV2.sol
+++ b/packages/contracts-bedrock/interfaces/L1/opcm/IOPContractsManagerV2.sol
@@ -98,7 +98,7 @@ interface IOPContractsManagerV2 {
     error OPContractsManagerV2_InvalidUpgradeInput();
     error OPContractsManagerV2_SuperchainConfigNeedsUpgrade();
     error OPContractsManagerV2_UnsupportedGameType();
-    error OPContractsManagerV2_InvalidUpgradeInstruction();
+    error OPContractsManagerV2_InvalidUpgradeInstruction(string _key);
     error IdentityPrecompileCallFailed();
     error ReservedBitsSet();
     error BytesArrayTooLong();

--- a/packages/contracts-bedrock/snapshots/abi/OPContractsManagerUtils.json
+++ b/packages/contracts-bedrock/snapshots/abi/OPContractsManagerUtils.json
@@ -333,6 +333,47 @@
   {
     "inputs": [
       {
+        "components": [
+          {
+            "internalType": "string",
+            "name": "key",
+            "type": "string"
+          },
+          {
+            "internalType": "bytes",
+            "name": "data",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct OPContractsManagerUtils.ExtraInstruction",
+        "name": "_instruction",
+        "type": "tuple"
+      },
+      {
+        "internalType": "string",
+        "name": "_key",
+        "type": "string"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_data",
+        "type": "bytes"
+      }
+    ],
+    "name": "isMatchingInstruction",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "address",
         "name": "_source",
         "type": "address"

--- a/packages/contracts-bedrock/snapshots/abi/OPContractsManagerV2.json
+++ b/packages/contracts-bedrock/snapshots/abi/OPContractsManagerV2.json
@@ -698,7 +698,13 @@
     "type": "error"
   },
   {
-    "inputs": [],
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "_key",
+        "type": "string"
+      }
+    ],
     "name": "OPContractsManagerV2_InvalidUpgradeInstruction",
     "type": "error"
   },

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -52,8 +52,8 @@
     "sourceCodeHash": "0xc2b530bf529ac23d1ba1adf67eedcc5d95e25c2919e1d97f4f2bba4823303b17"
   },
   "src/L1/opcm/OPContractsManagerV2.sol:OPContractsManagerV2": {
-    "initCodeHash": "0xdc680150107040b836f25238278502308c777469f546099950982e746a523214",
-    "sourceCodeHash": "0xdd0f9d924f3b636af28bfd35b02bb61c288038db28a8f724a7093da56c107f4a"
+    "initCodeHash": "0x0c63eca33b25e7015b6961011607adc04a264ba92ec9a3513048f0fa90122b2f",
+    "sourceCodeHash": "0xd8a29f9d62835492be62d271bdabb0b6da897fedffee67a3b88bcd28581354b1"
   },
   "src/L2/BaseFeeVault.sol:BaseFeeVault": {
     "initCodeHash": "0x838bbd7f381e84e21887f72bd1da605bfc4588b3c39aed96cbce67c09335b3ee",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -52,8 +52,8 @@
     "sourceCodeHash": "0xc2b530bf529ac23d1ba1adf67eedcc5d95e25c2919e1d97f4f2bba4823303b17"
   },
   "src/L1/opcm/OPContractsManagerV2.sol:OPContractsManagerV2": {
-    "initCodeHash": "0x56f7a0a6caf5231b61000b71ef5747de03eeb932be61ac836082afcbd19df29c",
-    "sourceCodeHash": "0xe4965a225c1c608a39507727ca18a274a91c7d0db84e3014df3c8183595b24a4"
+    "initCodeHash": "0xdc680150107040b836f25238278502308c777469f546099950982e746a523214",
+    "sourceCodeHash": "0xdd0f9d924f3b636af28bfd35b02bb61c288038db28a8f724a7093da56c107f4a"
   },
   "src/L2/BaseFeeVault.sol:BaseFeeVault": {
     "initCodeHash": "0x838bbd7f381e84e21887f72bd1da605bfc4588b3c39aed96cbce67c09335b3ee",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -52,8 +52,8 @@
     "sourceCodeHash": "0xc2b530bf529ac23d1ba1adf67eedcc5d95e25c2919e1d97f4f2bba4823303b17"
   },
   "src/L1/opcm/OPContractsManagerV2.sol:OPContractsManagerV2": {
-    "initCodeHash": "0xac3d87fe46b00ba4f61969accbdee2737f9a8663f6fa5b31b15e718acf9d3357",
-    "sourceCodeHash": "0xdb5734dcfb8704537dac3db2960c00198d4d46e74887afc2de2d3b4e71967757"
+    "initCodeHash": "0x56f7a0a6caf5231b61000b71ef5747de03eeb932be61ac836082afcbd19df29c",
+    "sourceCodeHash": "0xe4965a225c1c608a39507727ca18a274a91c7d0db84e3014df3c8183595b24a4"
   },
   "src/L2/BaseFeeVault.sol:BaseFeeVault": {
     "initCodeHash": "0x838bbd7f381e84e21887f72bd1da605bfc4588b3c39aed96cbce67c09335b3ee",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -52,8 +52,8 @@
     "sourceCodeHash": "0xc2b530bf529ac23d1ba1adf67eedcc5d95e25c2919e1d97f4f2bba4823303b17"
   },
   "src/L1/opcm/OPContractsManagerV2.sol:OPContractsManagerV2": {
-    "initCodeHash": "0x0c63eca33b25e7015b6961011607adc04a264ba92ec9a3513048f0fa90122b2f",
-    "sourceCodeHash": "0x91a4ab913b8ff25c9f69647e7db5af75281e182f69166489b3b05160a1a4b282"
+    "initCodeHash": "0xa288a8ea1931f665b15d2156c7d6758eae2099817195139d6f76acd5fc7fdbab",
+    "sourceCodeHash": "0x04afece9acbb0b2600aceff910f9d5897e52eb0830a7238cf9ddd219954a8cfe"
   },
   "src/L2/BaseFeeVault.sol:BaseFeeVault": {
     "initCodeHash": "0x838bbd7f381e84e21887f72bd1da605bfc4588b3c39aed96cbce67c09335b3ee",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -53,7 +53,7 @@
   },
   "src/L1/opcm/OPContractsManagerV2.sol:OPContractsManagerV2": {
     "initCodeHash": "0x0c63eca33b25e7015b6961011607adc04a264ba92ec9a3513048f0fa90122b2f",
-    "sourceCodeHash": "0xd8a29f9d62835492be62d271bdabb0b6da897fedffee67a3b88bcd28581354b1"
+    "sourceCodeHash": "0x91a4ab913b8ff25c9f69647e7db5af75281e182f69166489b3b05160a1a4b282"
   },
   "src/L2/BaseFeeVault.sol:BaseFeeVault": {
     "initCodeHash": "0x838bbd7f381e84e21887f72bd1da605bfc4588b3c39aed96cbce67c09335b3ee",

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerUtils.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerUtils.sol
@@ -89,6 +89,23 @@ contract OPContractsManagerUtils {
         return keccak256(abi.encode(_l2ChainId, _saltMixer, _contractName));
     }
 
+    /// @notice Helper function to check if an instruction matches a given key and data.
+    /// @param _instruction The instruction to check.
+    /// @param _key The key of the instruction to check for.
+    /// @param _data The data of the instruction to check for.
+    /// @return True if the instruction matches, false otherwise.
+    function isMatchingInstruction(
+        ExtraInstruction memory _instruction,
+        string memory _key,
+        bytes memory _data
+    )
+        public
+        pure
+        returns (bool)
+    {
+        return LibString.eq(_instruction.key, _key) && LibString.eq(string(_instruction.data), string(_data));
+    }
+
     /// @notice Helper function to check if a given instruction is present in a list of extra
     ///         upgrade instructions.
     /// @param _instructions The list of extra upgrade instructions.
@@ -105,8 +122,7 @@ contract OPContractsManagerUtils {
         returns (bool)
     {
         for (uint256 i = 0; i < _instructions.length; i++) {
-            if (LibString.eq(_instructions[i].key, _key) && LibString.eq(string(_instructions[i].data), string(_data)))
-            {
+            if (isMatchingInstruction(_instructions[i], _key, _data)) {
                 return true;
             }
         }

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerUtilsCaller.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerUtilsCaller.sol
@@ -55,6 +55,26 @@ abstract contract OPContractsManagerUtilsCaller {
         );
     }
 
+    /// @notice Helper function to check if an instruction matches a given key and data.
+    /// @param _instruction The instruction to check.
+    /// @param _key The key of the instruction to check for.
+    /// @param _data The data of the instruction to check for.
+    /// @return True if the instruction matches, false otherwise.
+    function _isMatchingInstruction(
+        IOPContractsManagerUtils.ExtraInstruction memory _instruction,
+        string memory _key,
+        bytes memory _data
+    )
+        internal
+        view
+        returns (bool)
+    {
+        return abi.decode(
+            _staticcall(abi.encodeCall(IOPContractsManagerUtils.isMatchingInstruction, (_instruction, _key, _data))),
+            (bool)
+        );
+    }
+
     /// @notice Helper function to load data from a source contract as bytes.
     /// @param _source The source contract to load the data from.
     /// @param _selector The selector of the function to call on the source contract.

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
@@ -257,22 +257,46 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
     ///////////////////////////////////////////////////////////////////////////
 
     /// @notice Asserts that the upgrade instructions array is valid.
+    /// @dev Developers don't need to touch this function, modify _isPermittedInstruction instead.
     /// @param _extraInstructions The extra upgrade instructions for the chain.
     function _assertValidUpgradeInstructions(IOPContractsManagerUtils.ExtraInstruction[] memory _extraInstructions)
         internal
         pure
     {
         for (uint256 i = 0; i < _extraInstructions.length; i++) {
-            if (
-                LibString.eq(_extraInstructions[i].key, Constants.PERMITTED_PROXY_DEPLOYMENT_KEY)
-                    && LibString.eq(string(_extraInstructions[i].data), "DelayedWETH")
-            ) {
-                // Unified DelayedWETH is being deployed for the first time.
-                // TODO:(#?????): Remove this allowance after unified DelayedWETH is deployed.
-            } else {
+            if (!_isPermittedInstruction(_extraInstructions[i])) {
                 revert OPContractsManagerV2_InvalidUpgradeInstruction();
             }
         }
+    }
+
+    /// @notice Checks if an upgrade instruction is permitted.
+    /// @param _instruction The upgrade instruction to check.
+    /// @return True if the instruction is permitted, false otherwise.
+    function _isPermittedInstruction(IOPContractsManagerUtils.ExtraInstruction memory _instruction) internal pure returns (bool) {
+        // NOTE (IMPORTANT FOR DEVELOPERS): You MAY need to allow permitted instructions here for
+        // your specific upgrade. For example, if you are adding a new contract that needs to be
+        // deployed you will need to add an allowance so that the proxy can be deployed.
+        // Allowances MUST always be restricted to one specific upgrade. Here we maintain this
+        // restriction by checking that the version is less than the NEXT release version. Once
+        // developers start working on the next release this will automatically become false so
+        // even if the code is somehow forgotten it will not actually apply to the deployment. Make
+        // sure to REMOVE the allowance once the upgrade is complete.
+        if (SemverComp.lt(version, "7.0.0")) {
+            if (
+                LibString.eq(_instruction.key, Constants.PERMITTED_PROXY_DEPLOYMENT_KEY)
+                    && LibString.eq(string(_instruction.data), "DelayedWETH")
+            ) {
+                // Unified DelayedWETH is being deployed for the first time.
+                // TODO:(#18382): Remove this allowance after unified DelayedWETH is deployed.
+                return true;
+            } else {
+                return false;
+            }
+        }
+
+        // Always return false by default.
+        return false;
     }
 
     /// @notice Loads (or builds) the chain contracts from whatever exists.

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
@@ -145,7 +145,7 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
     error OPContractsManagerV2_InvalidUpgradeInput();
 
     /// @notice Thrown when an invalid upgrade instruction is provided.
-    error OPContractsManagerV2_InvalidUpgradeInstruction();
+    error OPContractsManagerV2_InvalidUpgradeInstruction(string _key);
 
     /// @notice Container of blueprint and implementation contract addresses.
     IOPContractsManagerContainer public immutable contractsContainer;
@@ -265,7 +265,7 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
     {
         for (uint256 i = 0; i < _extraInstructions.length; i++) {
             if (!_isPermittedInstruction(_extraInstructions[i])) {
-                revert OPContractsManagerV2_InvalidUpgradeInstruction();
+                revert OPContractsManagerV2_InvalidUpgradeInstruction(_extraInstructions[i].key);
             }
         }
     }

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
@@ -153,12 +153,12 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
     IOPContractsManagerStandardValidator public immutable standardValidator;
 
     /// @notice The version of the OPCM contract.
-    ///         OPCM versioning rules:
+    ///         WARNING: OPCM versioning rules differ from other contracts:
     ///         - Major bump: New required sequential upgrade
     ///         - Minor bump: Replacement OPCM for same upgrade
     ///         - Patch bump: Development changes (expected for normal dev work)
-    /// @custom:semver 6.3.0
-    string public constant version = "6.3.0";
+    /// @custom:semver 6.0.3
+    string public constant version = "6.0.3";
 
     /// @param _contractsContainer The container of blueprint and implementation contract addresses.
     /// @param _standardValidator The standard validator for this OPCM release.

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
@@ -153,6 +153,10 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
     IOPContractsManagerStandardValidator public immutable standardValidator;
 
     /// @notice The version of the OPCM contract.
+    ///         OPCM versioning rules:
+    ///         - Major bump: New required sequential upgrade
+    ///         - Minor bump: Replacement OPCM for same upgrade
+    ///         - Patch bump: Development changes (expected for normal dev work)
     /// @custom:semver 6.3.0
     string public constant version = "6.3.0";
 

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
@@ -5,7 +5,6 @@ pragma solidity 0.8.15;
 import { OPContractsManagerUtilsCaller } from "src/L1/opcm/OPContractsManagerUtilsCaller.sol";
 
 // Libraries
-import { LibString } from "@solady/utils/LibString.sol";
 import { Blueprint } from "src/libraries/Blueprint.sol";
 import { Claim, GameType, GameTypes, Proposal } from "src/dispute/lib/Types.sol";
 import { SemverComp } from "src/libraries/SemverComp.sol";
@@ -154,8 +153,8 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
     IOPContractsManagerStandardValidator public immutable standardValidator;
 
     /// @notice The version of the OPCM contract.
-    /// @custom:semver 6.2.0
-    string public constant version = "6.2.0";
+    /// @custom:semver 6.3.0
+    string public constant version = "6.3.0";
 
     /// @param _contractsContainer The container of blueprint and implementation contract addresses.
     /// @param _standardValidator The standard validator for this OPCM release.
@@ -261,7 +260,7 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
     /// @param _extraInstructions The extra upgrade instructions for the chain.
     function _assertValidUpgradeInstructions(IOPContractsManagerUtils.ExtraInstruction[] memory _extraInstructions)
         internal
-        pure
+        view
     {
         for (uint256 i = 0; i < _extraInstructions.length; i++) {
             if (!_isPermittedInstruction(_extraInstructions[i])) {
@@ -273,7 +272,11 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
     /// @notice Checks if an upgrade instruction is permitted.
     /// @param _instruction The upgrade instruction to check.
     /// @return True if the instruction is permitted, false otherwise.
-    function _isPermittedInstruction(IOPContractsManagerUtils.ExtraInstruction memory _instruction) internal pure returns (bool) {
+    function _isPermittedInstruction(IOPContractsManagerUtils.ExtraInstruction memory _instruction)
+        internal
+        view
+        returns (bool)
+    {
         // NOTE (IMPORTANT FOR DEVELOPERS): You MAY need to allow permitted instructions here for
         // your specific upgrade. For example, if you are adding a new contract that needs to be
         // deployed you will need to add an allowance so that the proxy can be deployed.
@@ -283,16 +286,9 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
         // even if the code is somehow forgotten it will not actually apply to the deployment. Make
         // sure to REMOVE the allowance once the upgrade is complete.
         if (SemverComp.lt(version, "7.0.0")) {
-            if (
-                LibString.eq(_instruction.key, Constants.PERMITTED_PROXY_DEPLOYMENT_KEY)
-                    && LibString.eq(string(_instruction.data), "DelayedWETH")
-            ) {
-                // Unified DelayedWETH is being deployed for the first time.
-                // TODO:(#18382): Remove this allowance after unified DelayedWETH is deployed.
-                return true;
-            } else {
-                return false;
-            }
+            // Unified DelayedWETH is being deployed for the first time.
+            // TODO:(#18382): Remove this allowance after unified DelayedWETH is deployed.
+            return _isMatchingInstruction(_instruction, Constants.PERMITTED_PROXY_DEPLOYMENT_KEY, "DelayedWETH");
         }
 
         // Always return false by default.

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
@@ -575,7 +575,9 @@ contract OPContractsManagerV2_Upgrade_Test is OPContractsManagerV2_Upgrade_TestI
         // nosemgrep: sol-style-use-abi-encodecall
         runCurrentUpgradeV2(
             chainPAO,
-            abi.encodeWithSelector(IOPContractsManagerV2.OPContractsManagerV2_InvalidUpgradeInstruction.selector)
+            abi.encodeWithSelector(
+                IOPContractsManagerV2.OPContractsManagerV2_InvalidUpgradeInstruction.selector, "PermitProxyDeployment"
+            )
         );
     }
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Updates the OPCMv2 check for allowed extra instructions to be
specific to releases. When release versions are bumped, the
allowances become automatically invalid and would reveal
anywhere in the codebase where the allowance is being used.