### PR TITLE
op-challenger: Reclaim bonds for optimistic zk games

### DIFF
--- a/op-challenger/game/fault/contracts/optimisticzkdisputegame.go
+++ b/op-challenger/game/fault/contracts/optimisticzkdisputegame.go
@@ -3,6 +3,7 @@ package contracts
 import (
 	"context"
 	"fmt"
+	"math/big"
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts/metrics"
@@ -44,6 +45,8 @@ type OptimisticZKDisputeGameContract interface {
 	ChallengeTx(ctx context.Context) (txmgr.TxCandidate, error)
 	GetProposal(ctx context.Context) (common.Hash, uint64, error)
 	GetChallengerMetadata(ctx context.Context, block rpcblock.Block) (ChallengerMetadata, error)
+	GetCredit(ctx context.Context, recipient common.Address) (*big.Int, gameTypes.GameStatus, error)
+	ClaimCreditTx(ctx context.Context, recipient common.Address) (txmgr.TxCandidate, error)
 }
 
 type OptimisticZKDisputeGameContractLatest struct {
@@ -51,6 +54,37 @@ type OptimisticZKDisputeGameContractLatest struct {
 	multiCaller *batching.MultiCaller
 	contract    *batching.BoundContract
 }
+
+func (g *OptimisticZKDisputeGameContractLatest) GetCredit(ctx context.Context, recipient common.Address) (*big.Int, gameTypes.GameStatus, error) {
+	defer g.metrics.StartContractRequest("GetCredit")()
+	results, err := g.multiCaller.Call(ctx, rpcblock.Latest,
+		g.contract.Call(methodCredit, recipient),
+		g.contract.Call(methodStatus))
+	if err != nil {
+		return nil, gameTypes.GameStatusInProgress, err
+	}
+	if len(results) != 2 {
+		return nil, gameTypes.GameStatusInProgress, fmt.Errorf("expected 2 results but got %v", len(results))
+	}
+	credit := results[0].GetBigInt(0)
+	status, err := gameTypes.GameStatusFromUint8(results[1].GetUint8(0))
+	if err != nil {
+		return nil, gameTypes.GameStatusInProgress, fmt.Errorf("invalid game status %v: %w", status, err)
+	}
+	return credit, status, nil
+}
+
+func (g *OptimisticZKDisputeGameContractLatest) ClaimCreditTx(ctx context.Context, recipient common.Address) (txmgr.TxCandidate, error) {
+	defer g.metrics.StartContractRequest("ClaimCredit")()
+	call := g.contract.Call(methodClaimCredit, recipient)
+	_, err := g.multiCaller.SingleCall(ctx, rpcblock.Latest, call)
+	if err != nil {
+		return txmgr.TxCandidate{}, fmt.Errorf("%w: %w", ErrSimulationFailed, err)
+	}
+	return call.ToTxCandidate()
+}
+
+var _ OptimisticZKDisputeGameContract = (*OptimisticZKDisputeGameContractLatest)(nil)
 
 func NewOptimisticZKDisputeGameContract(
 	m metrics.ContractMetricer,

--- a/op-challenger/game/fault/contracts/optimisticzkdisputegame_test.go
+++ b/op-challenger/game/fault/contracts/optimisticzkdisputegame_test.go
@@ -2,6 +2,7 @@ package contracts
 
 import (
 	"context"
+	"errors"
 	"math/big"
 	"testing"
 	"time"
@@ -11,6 +12,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
 	batchingTest "github.com/ethereum-optimism/optimism/op-service/sources/batching/test"
+	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 	"github.com/ethereum-optimism/optimism/packages/contracts-bedrock/snapshots"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
@@ -219,6 +221,52 @@ func TestZKGetProposal(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, rootClaim, actualClaim)
 			require.Equal(t, l2SequenceNumber.Uint64(), actualSeqNum)
+		})
+	}
+}
+
+func TestZKGame_GetCredit(t *testing.T) {
+	for _, version := range zkVersions {
+		version := version
+		t.Run(version.String(), func(t *testing.T) {
+			stubRpc, game := setupZKDisputeGameTest(t, version)
+			addr := common.Address{0x01}
+			expectedCredit := big.NewInt(4284)
+			expectedStatus := gameTypes.GameStatusChallengerWon
+			stubRpc.SetResponse(zkGameAddr, methodCredit, rpcblock.Latest, []interface{}{addr}, []interface{}{expectedCredit})
+			stubRpc.SetResponse(zkGameAddr, methodStatus, rpcblock.Latest, nil, []interface{}{expectedStatus})
+
+			actualCredit, actualStatus, err := game.GetCredit(context.Background(), addr)
+			require.NoError(t, err)
+			require.Equal(t, expectedCredit, actualCredit)
+			require.Equal(t, expectedStatus, actualStatus)
+		})
+	}
+}
+
+func TestZKGame_ClaimCreditTx(t *testing.T) {
+	for _, version := range zkVersions {
+		version := version
+		t.Run(version.String(), func(t *testing.T) {
+			t.Run("Success", func(t *testing.T) {
+				stubRpc, game := setupZKDisputeGameTest(t, version)
+				addr := common.Address{0xaa}
+
+				stubRpc.SetResponse(zkGameAddr, methodClaimCredit, rpcblock.Latest, []interface{}{addr}, nil)
+				tx, err := game.ClaimCreditTx(context.Background(), addr)
+				require.NoError(t, err)
+				stubRpc.VerifyTxCandidate(tx)
+			})
+
+			t.Run("SimulationFails", func(t *testing.T) {
+				stubRpc, game := setupZKDisputeGameTest(t, version)
+				addr := common.Address{0xaa}
+
+				stubRpc.SetError(zkGameAddr, methodClaimCredit, rpcblock.Latest, []interface{}{addr}, errors.New("still locked"))
+				tx, err := game.ClaimCreditTx(context.Background(), addr)
+				require.ErrorIs(t, err, ErrSimulationFailed)
+				require.Equal(t, txmgr.TxCandidate{}, tx)
+			})
 		})
 	}
 }

--- a/op-challenger/game/zk/register.go
+++ b/op-challenger/game/zk/register.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-challenger/config"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/client"
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/claims"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/generic"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/scheduler"
@@ -22,6 +23,7 @@ type ClockReader interface {
 
 type Registry interface {
 	RegisterGameType(gameType gameTypes.GameType, creator scheduler.PlayerCreator)
+	RegisterBondContract(gameType gameTypes.GameType, creator claims.BondContractCreator)
 }
 
 type TxSender interface {
@@ -59,6 +61,9 @@ func RegisterGameTypes(
 				clients.L1Client(),
 				ActorCreator(l1Clock, rollupClient, gameStatusProvider, contract, txSender),
 			)
+		})
+		registry.RegisterBondContract(gameTypes.OptimisticZKGameType, func(game gameTypes.GameMetadata) (claims.BondContract, error) {
+			return contracts.NewOptimisticZKDisputeGameContract(m, game.Proxy, clients.MultiCaller())
 		})
 	}
 	return nil


### PR DESCRIPTION
**Description**

Support reclaiming bonds for optimistic zk games.  The claimer code was already very generic so just implement the required contract binding methods and register the game type.

**Tests**

Added unit tests.

**Additional context**

Builds on #18464 

**Metadata**

#18321 