### PR TITLE
op-challenger: Challenge proposals that are still unsafe.

### DIFF
--- a/op-challenger/game/fault/contracts/optimisticzkdisputegame.go
+++ b/op-challenger/game/fault/contracts/optimisticzkdisputegame.go
@@ -25,6 +25,23 @@ const (
 	ProposalStatusResolved
 )
 
+func (p ProposalStatus) String() string {
+	switch p {
+	case ProposalStatusUnchallenged:
+		return "Unchallenged"
+	case ProposalStatusChallenged:
+		return "Challenged"
+	case ProposalStatusUnchallengedAndValidProofProvided:
+		return "UnchallengedAndValidProofProvided"
+	case ProposalStatusChallengedAndValidProofProvided:
+		return "ChallengedAndValidProofProvided"
+	case ProposalStatusResolved:
+		return "Resolved"
+	default:
+		return fmt.Sprintf("ProposalStatus(%d)", uint8(p))
+	}
+}
+
 var (
 	methodChallenge      = "challenge"
 	methodChallengerBond = "challengerBond"

--- a/op-challenger/game/fault/contracts/optimisticzkdisputegame.go
+++ b/op-challenger/game/fault/contracts/optimisticzkdisputegame.go
@@ -3,6 +3,7 @@ package contracts
 import (
 	"context"
 	"fmt"
+	"math/big"
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts/metrics"
@@ -44,6 +45,8 @@ type OptimisticZKDisputeGameContract interface {
 	ChallengeTx(ctx context.Context) (txmgr.TxCandidate, error)
 	GetProposal(ctx context.Context) (common.Hash, uint64, error)
 	GetChallengerMetadata(ctx context.Context, block rpcblock.Block) (ChallengerMetadata, error)
+	GetCredit(ctx context.Context, recipient common.Address) (*big.Int, gameTypes.GameStatus, error)
+	ClaimCreditTx(ctx context.Context, recipient common.Address) (txmgr.TxCandidate, error)
 }
 
 type OptimisticZKDisputeGameContractLatest struct {
@@ -51,6 +54,37 @@ type OptimisticZKDisputeGameContractLatest struct {
 	multiCaller *batching.MultiCaller
 	contract    *batching.BoundContract
 }
+
+func (g *OptimisticZKDisputeGameContractLatest) GetCredit(ctx context.Context, recipient common.Address) (*big.Int, gameTypes.GameStatus, error) {
+	defer g.metrics.StartContractRequest("GetCredit")()
+	results, err := g.multiCaller.Call(ctx, rpcblock.Latest,
+		g.contract.Call(methodCredit, recipient),
+		g.contract.Call(methodStatus))
+	if err != nil {
+		return nil, gameTypes.GameStatusInProgress, err
+	}
+	if len(results) != 2 {
+		return nil, gameTypes.GameStatusInProgress, fmt.Errorf("expected 2 results but got %v", len(results))
+	}
+	credit := results[0].GetBigInt(0)
+	status, err := gameTypes.GameStatusFromUint8(results[1].GetUint8(0))
+	if err != nil {
+		return nil, gameTypes.GameStatusInProgress, fmt.Errorf("invalid game status %v: %w", status, err)
+	}
+	return credit, status, nil
+}
+
+func (g *OptimisticZKDisputeGameContractLatest) ClaimCreditTx(ctx context.Context, recipient common.Address) (txmgr.TxCandidate, error) {
+	defer g.metrics.StartContractRequest("ClaimCredit")()
+	call := g.contract.Call(methodClaimCredit, recipient)
+	_, err := g.multiCaller.SingleCall(ctx, rpcblock.Latest, call)
+	if err != nil {
+		return txmgr.TxCandidate{}, fmt.Errorf("%w: %w", ErrSimulationFailed, err)
+	}
+	return call.ToTxCandidate()
+}
+
+var _ OptimisticZKDisputeGameContract = (*OptimisticZKDisputeGameContractLatest)(nil)
 
 func NewOptimisticZKDisputeGameContract(
 	m metrics.ContractMetricer,

--- a/op-challenger/game/fault/contracts/optimisticzkdisputegame_test.go
+++ b/op-challenger/game/fault/contracts/optimisticzkdisputegame_test.go
@@ -2,6 +2,7 @@ package contracts
 
 import (
 	"context"
+	"errors"
 	"math/big"
 	"testing"
 	"time"
@@ -11,6 +12,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
 	batchingTest "github.com/ethereum-optimism/optimism/op-service/sources/batching/test"
+	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 	"github.com/ethereum-optimism/optimism/packages/contracts-bedrock/snapshots"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
@@ -219,6 +221,52 @@ func TestZKGetProposal(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, rootClaim, actualClaim)
 			require.Equal(t, l2SequenceNumber.Uint64(), actualSeqNum)
+		})
+	}
+}
+
+func TestZKGame_GetCredit(t *testing.T) {
+	for _, version := range zkVersions {
+		version := version
+		t.Run(version.String(), func(t *testing.T) {
+			stubRpc, game := setupZKDisputeGameTest(t, version)
+			addr := common.Address{0x01}
+			expectedCredit := big.NewInt(4284)
+			expectedStatus := gameTypes.GameStatusChallengerWon
+			stubRpc.SetResponse(zkGameAddr, methodCredit, rpcblock.Latest, []interface{}{addr}, []interface{}{expectedCredit})
+			stubRpc.SetResponse(zkGameAddr, methodStatus, rpcblock.Latest, nil, []interface{}{expectedStatus})
+
+			actualCredit, actualStatus, err := game.GetCredit(context.Background(), addr)
+			require.NoError(t, err)
+			require.Equal(t, expectedCredit, actualCredit)
+			require.Equal(t, expectedStatus, actualStatus)
+		})
+	}
+}
+
+func TestZKGame_ClaimCreditTx(t *testing.T) {
+	for _, version := range zkVersions {
+		version := version
+		t.Run(version.String(), func(t *testing.T) {
+			t.Run("Success", func(t *testing.T) {
+				stubRpc, game := setupZKDisputeGameTest(t, version)
+				addr := common.Address{0xaa}
+
+				stubRpc.SetResponse(zkGameAddr, methodClaimCredit, rpcblock.Latest, []interface{}{addr}, nil)
+				tx, err := game.ClaimCreditTx(context.Background(), addr)
+				require.NoError(t, err)
+				stubRpc.VerifyTxCandidate(tx)
+			})
+
+			t.Run("SimulationFails", func(t *testing.T) {
+				stubRpc, game := setupZKDisputeGameTest(t, version)
+				addr := common.Address{0xaa}
+
+				stubRpc.SetError(zkGameAddr, methodClaimCredit, rpcblock.Latest, []interface{}{addr}, errors.New("still locked"))
+				tx, err := game.ClaimCreditTx(context.Background(), addr)
+				require.ErrorIs(t, err, ErrSimulationFailed)
+				require.Equal(t, txmgr.TxCandidate{}, tx)
+			})
 		})
 	}
 }

--- a/op-challenger/game/zk/actor.go
+++ b/op-challenger/game/zk/actor.go
@@ -175,6 +175,10 @@ func (a *Actor) createResolveTx(ctx context.Context, gameState contracts.Challen
 	return txmgr.TxCandidate{}, errNoResolutionRequired
 }
 
-func (a *Actor) AdditionalStatus(_ context.Context) ([]any, error) {
-	return nil, nil
+func (a *Actor) AdditionalStatus(ctx context.Context) ([]any, error) {
+	metadata, err := a.contract.GetChallengerMetadata(ctx, rpcblock.Latest)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get challenger metadata: %w", err)
+	}
+	return []any{"proposalStatus", metadata.ProposalStatus}, nil
 }

--- a/op-challenger/game/zk/actor.go
+++ b/op-challenger/game/zk/actor.go
@@ -130,6 +130,14 @@ func (a *Actor) isValidProposal(ctx context.Context) (bool, error) {
 		// Output root doesn't match so can't be valid
 		return false, nil
 	}
+	if canonicalOutput.Status.SafeL2.Number < proposalSeqNum {
+		// Note this deliberately uses the simpler check of if the proposed block is currently unsafe
+		// The proposal is not necessarily supported by data on L1 up to the game's L1 head
+		// but we don't need to challenge it as long as supporting data has since become available
+		// and the output matches the canonical chain.
+		a.logger.Debug("Proposed block is not yet safe, treating as invalid", "safe", canonicalOutput.Status.SafeL2.Number, "proposed", proposalSeqNum)
+		return false, nil
+	}
 	return true, nil
 }
 

--- a/op-challenger/game/zk/actor_test.go
+++ b/op-challenger/game/zk/actor_test.go
@@ -76,6 +76,15 @@ func TestActor(t *testing.T) {
 			challenge: true,
 		},
 		{
+			name: "ChallengeCurrentlyUnsafeProposal",
+			setup: func(t *testing.T, stubs *zkTestStubs) {
+				stubs.contract.proposalHash = stubs.rootProvider.root
+				stubs.contract.l2SequenceNumber = stubs.rootProvider.rootBlockNum
+				stubs.rootProvider.safeBlockNum = stubs.rootProvider.rootBlockNum - 1
+			},
+			challenge: true,
+		},
+		{
 			name: "ChallengeUnresolvableGameWithNoParent",
 			setup: func(t *testing.T, stubs *zkTestStubs) {
 				stubs.contract.proposalHash = common.Hash{0xba, 0xd0}
@@ -203,6 +212,7 @@ func setupActorTest(t *testing.T) (*Actor, *zkTestStubs) {
 	rootProvider := &stubRootProvider{
 		root:         common.Hash{0x11},
 		rootBlockNum: rootBlockNum,
+		safeBlockNum: rootBlockNum + 10,
 	}
 	// Default to a valid proposal
 	contract := &stubContract{
@@ -231,6 +241,7 @@ type stubRootProvider struct {
 	outputErr    error
 	rootBlockNum uint64
 	root         common.Hash
+	safeBlockNum uint64
 }
 
 func (s *stubRootProvider) OutputAtBlock(_ context.Context, blockNum uint64) (*eth.OutputResponse, error) {
@@ -242,6 +253,11 @@ func (s *stubRootProvider) OutputAtBlock(_ context.Context, blockNum uint64) (*e
 	}
 	return &eth.OutputResponse{
 		OutputRoot: eth.Bytes32(s.root),
+		Status: &eth.SyncStatus{
+			SafeL2: eth.L2BlockRef{
+				Number: s.safeBlockNum,
+			},
+		},
 	}, nil
 }
 

--- a/op-challenger/game/zk/register.go
+++ b/op-challenger/game/zk/register.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-challenger/config"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/client"
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/claims"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/generic"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/scheduler"
@@ -22,6 +23,7 @@ type ClockReader interface {
 
 type Registry interface {
 	RegisterGameType(gameType gameTypes.GameType, creator scheduler.PlayerCreator)
+	RegisterBondContract(gameType gameTypes.GameType, creator claims.BondContractCreator)
 }
 
 type TxSender interface {
@@ -59,6 +61,9 @@ func RegisterGameTypes(
 				clients.L1Client(),
 				ActorCreator(l1Clock, rollupClient, gameStatusProvider, contract, txSender),
 			)
+		})
+		registry.RegisterBondContract(gameTypes.OptimisticZKGameType, func(game gameTypes.GameMetadata) (claims.BondContract, error) {
+			return contracts.NewOptimisticZKDisputeGameContract(m, game.Proxy, clients.MultiCaller())
 		})
 	}
 	return nil


### PR DESCRIPTION
**Description**

Challenge optimistic zk proposals if they are still unsafe. This ensures the game can't resolve as valid and then later have the unsafe chain re-orged out. While the data still may not have been submitted before the game's L1 head, if the safe head has since advanced we know that the data is on L1 and that is the output root that will be derived so there's we don't waste capital by placing a challenge.  This also avoids the need to use the safe head db.

Also adds the proposal status to the in progress game info log.

**Tests**

Added unit test.

**Additional context**

Builds on #18465 

**Metadata**

#18321 