### PR TITLE
op-dispute-mon: Update list of output root game types

### DIFF
--- a/op-dispute-mon/mon/extract/output_agreement_enricher_test.go
+++ b/op-dispute-mon/mon/extract/output_agreement_enricher_test.go
@@ -40,7 +40,7 @@ func TestOutputAgreementEnricher(t *testing.T) {
 	})
 
 	t.Run("SkipNonOutputRootGameTypes", func(t *testing.T) {
-		gameTypes := []uint32{4, 5, 7, 8, 10, 49812}
+		gameTypes := []uint32{4, 5, 7, 9, 11, 49812}
 		for _, gameType := range gameTypes {
 			gameType := gameType
 			t.Run(fmt.Sprintf("GameType_%d", gameType), func(t *testing.T) {

--- a/op-dispute-mon/mon/extract/super_agreement_enricher_test.go
+++ b/op-dispute-mon/mon/extract/super_agreement_enricher_test.go
@@ -61,7 +61,7 @@ func TestDetector_CheckSuperRootAgreement(t *testing.T) {
 	})
 
 	t.Run("FetchAllNonOutputRootGameTypes", func(t *testing.T) {
-		gameTypes := []uint32{4, 5, 7, 8, 10, 49812} // Treat unknown game types as using super roots
+		gameTypes := []uint32{4, 5, 7, 9, 11, 49812} // Treat unknown game types as using super roots
 		for _, gameType := range gameTypes {
 			gameType := gameType
 			t.Run(fmt.Sprintf("GameType_%d", gameType), func(t *testing.T) {

--- a/op-dispute-mon/mon/types/types.go
+++ b/op-dispute-mon/mon/types/types.go
@@ -13,7 +13,25 @@ import (
 
 // outputRootGameTypes lists the set of legacy game types that use output roots
 // It is assumed that all other game types use super roots
-var outputRootGameTypes = []uint32{0, 1, 2, 3, 6, 254, 255, 1337}
+var outputRootGameTypes = []types.GameType{
+	types.CannonGameType,
+	types.PermissionedGameType,
+	types.AsteriscGameType,
+	types.AsteriscKonaGameType,
+	types.OPSuccinctGameType,
+	types.CannonKonaGameType,
+	types.OptimisticZKGameType,
+	types.FastGameType,
+	types.AlphabetGameType,
+	types.KailuaGameType,
+}
+
+var superRootGameTypes = []types.GameType{
+	types.SuperCannonGameType,
+	types.SuperPermissionedGameType,
+	types.SuperAsteriscKonaGameType,
+	types.SuperCannonKonaGameType,
+}
 
 // EnrichedClaim extends the faultTypes.Claim with additional context.
 type EnrichedClaim struct {
@@ -87,7 +105,7 @@ type EnrichedGameData struct {
 
 // UsesOutputRoots returns true if the game type is one of the known types that use output roots as proposals.
 func (g EnrichedGameData) UsesOutputRoots() bool {
-	return slices.Contains(outputRootGameTypes, g.GameType)
+	return slices.Contains(outputRootGameTypes, types.GameType(g.GameType))
 }
 
 // HasMixedAvailability returns true if some rollup endpoints returned "not found" while others succeeded

--- a/op-dispute-mon/mon/types/types_test.go
+++ b/op-dispute-mon/mon/types/types_test.go
@@ -13,7 +13,7 @@ func TestEnrichedGameData_UsesOutputRoots(t *testing.T) {
 		gameType := gameType
 		t.Run(fmt.Sprintf("GameType-%v", gameType), func(t *testing.T) {
 			data := EnrichedGameData{
-				GameMetadata: types.GameMetadata{GameType: gameType},
+				GameMetadata: types.GameMetadata{GameType: uint32(gameType)},
 			}
 			require.True(t, data.UsesOutputRoots())
 		})
@@ -174,6 +174,25 @@ func TestEnrichedGameData_HasMixedSafety(t *testing.T) {
 			}
 			result := data.HasMixedSafety()
 			require.Equal(t, test.expected, result)
+		})
+	}
+}
+
+func TestAllSupportedGameTypesAreOutputOrSuperRootType(t *testing.T) {
+	for _, gameType := range types.SupportedGameTypes {
+		t.Run(gameType.String(), func(t *testing.T) {
+			data := EnrichedGameData{
+				GameMetadata: types.GameMetadata{
+					GameType: uint32(gameType),
+				},
+			}
+			if data.UsesOutputRoots() {
+				require.Contains(t, outputRootGameTypes, gameType)
+				require.NotContains(t, superRootGameTypes, gameType)
+			} else {
+				require.Contains(t, superRootGameTypes, gameType)
+				require.NotContains(t, outputRootGameTypes, gameType)
+			}
 		})
 	}
 }


### PR DESCRIPTION
**Description**

Once upon a time all new game types were going to use super roots. Life did not turn out that way...

Update the list of game types using output roots - in particular, include cannon-kona and optimistic-zk. Also add a list of super root games and a test to ensure that all supported game types are categorised into one or the other so we can't miss this for new games.
