### PR TITLE
ci: update factory workflow to use attest parameter

### DIFF
--- a/.github/workflows/protected.yaml
+++ b/.github/workflows/protected.yaml
@@ -61,7 +61,7 @@ jobs:
           - cannon
           - op-dripper
           - op-interop-mon
-    uses: ethereum-optimism/factory/.github/workflows/docker-bake.yaml@2ff3f9bba03d59a6ad10fdf660ed253f53956188
+    uses: ethereum-optimism/factory/.github/workflows/docker-bake.yaml@753bcd4284a6d36eac6e31df2492015ab8650331
     with:
       image_name: ${{ matrix.image_name }}
       bake_file: docker-bake.hcl
@@ -69,6 +69,7 @@ jobs:
       tag: ${{ needs.prep.outputs.sanitised_ref_name }}
       gcp_project_id: ${{ vars.GCP_PROJECT_ID_OPLABS_TOOLS_ARTIFACTS }}
       registry: us-docker.pkg.dev/oplabs-tools-artifacts/oss
+      attest: true
       env: |
         GIT_VERSION=${{ fromJson(needs.prep.outputs.versions)[matrix.image_name] }}
         KONA_VERSION=${{ needs.prep.outputs.kona_version }}

--- a/.github/workflows/unprotected.yaml
+++ b/.github/workflows/unprotected.yaml
@@ -67,14 +67,14 @@ jobs:
           - cannon
           - op-dripper
           - op-interop-mon
-    uses: ethereum-optimism/factory/.github/workflows/docker-bake.yaml@2ff3f9bba03d59a6ad10fdf660ed253f53956188
+    uses: ethereum-optimism/factory/.github/workflows/docker-bake.yaml@753bcd4284a6d36eac6e31df2492015ab8650331
     with:
       image_name: ${{ matrix.image_name }}
       bake_file: docker-bake.hcl
       target: ${{ matrix.image_name }}
       tag: 24h
       registry: ttl.sh/${{ github.sha }}
-      push_provenance: false
+      attest: false
       env: |
         GIT_VERSION=${{ fromJson(needs.prep.outputs.versions)[matrix.image_name] }}
         KONA_VERSION=${{ needs.prep.outputs.kona_version }}


### PR DESCRIPTION
## Changes

- Update factory workflow SHA to 753bcd4284a6d36eac6e31df2492015ab8650331
- Change `push_provenance: false` to `attest: false` in unprotected.yaml
- Add `attest: true` in protected.yaml

Fixes attestation failures on fork PRs while maintaining attestation on protected branches.