### PR TITLE
test: use ARM64-enabled asterisc test image from ttl.sh

### DIFF
--- a/ops/docker/op-stack-go/Dockerfile
+++ b/ops/docker/op-stack-go/Dockerfile
@@ -223,7 +223,7 @@ CMD ["op-node"]
 # Make the kona docker image published by upstream available as a source to copy kona from.
 FROM ghcr.io/op-rs/kona/kona-host:$KONA_VERSION AS kona
 # Make the asterisc docker image published by upstream available as a source to copy asterisc from.
-FROM us-docker.pkg.dev/oplabs-tools-artifacts/images/asterisc:$ASTERISC_VERSION AS asterisc
+FROM ttl.sh/a0562c85de6b9dc0ea69b374389359d763716632/asterisc:160-merge AS asterisc
 
 # Also produce an op-challenger loaded with kona and asterisc using ubuntu
 FROM $UBUNTU_TARGET_BASE_IMAGE AS op-challenger-target


### PR DESCRIPTION
This PR tests the ARM64-enabled asterisc image built from ethereum-optimism/asterisc#160 using the factory docker-build workflow.

## Testing
- Uses test image: `ttl.sh/a0562c85de6b9dc0ea69b374389359d763716632/asterisc:160-merge`
- Verifies that the ARM64 build warning is resolved
- Validates multi-arch asterisc image works correctly in op-challenger builds

## Related
- ethereum-optimism/asterisc#160 - Adds factory GHA workflow for multi-arch builds

**Note:** This is a test PR and should not be merged. Once validated, we'll update to use the official registry image.