### PR TITLE
op-challenger: Stop bundling asterisc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ golang-docker: ## Builds Docker images for Go components using buildx
 	GIT_COMMIT=$$(git rev-parse HEAD) \
 	GIT_DATE=$$(git show -s --format='%ct') \
 	IMAGE_TAGS=$$(git rev-parse HEAD),latest \
+	KONA_VERSION=$$(jq -r .version kona/version.json) \
 	docker buildx bake \
 			--progress plain \
 			--load \

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -10,10 +10,6 @@ variable "KONA_VERSION" {
   default = "none"
 }
 
-variable "ASTERISC_VERSION" {
-  default = "v1.3.0"
-}
-
 variable "GIT_COMMIT" {
   default = "dev"
 }
@@ -149,7 +145,6 @@ target "op-challenger" {
     GIT_DATE = "${GIT_DATE}"
     OP_CHALLENGER_VERSION = "${OP_CHALLENGER_VERSION}"
     KONA_VERSION="${KONA_VERSION}"
-    ASTERISC_VERSION="${ASTERISC_VERSION}"
   }
   target = "op-challenger-target"
   platforms = split(",", PLATFORMS)

--- a/op-challenger/cmd/main_test.go
+++ b/op-challenger/cmd/main_test.go
@@ -150,7 +150,7 @@ func TestOpSupervisor(t *testing.T) {
 
 func TestGameTypes(t *testing.T) {
 	t.Run("Default", func(t *testing.T) {
-		expectedDefault := []gameTypes.GameType{gameTypes.CannonGameType, gameTypes.AsteriscKonaGameType, gameTypes.CannonKonaGameType}
+		expectedDefault := []gameTypes.GameType{gameTypes.CannonGameType, gameTypes.CannonKonaGameType}
 		cfg := configForArgs(t, addRequiredArgsForMultipleGameTypesExcept(expectedDefault, "--game-types"))
 		require.Equal(t, expectedDefault, cfg.GameTypes)
 	})

--- a/op-challenger/flags/flags.go
+++ b/op-challenger/flags/flags.go
@@ -88,7 +88,7 @@ var (
 		Aliases: []string{"trace-type"}, // For backwards compatibility
 		Usage:   "The game types to support. Valid options: " + openum.EnumStringer(gameTypes.SupportedGameTypes),
 		EnvVars: prefixEnvVars("GAME_TYPES", "TRACE_TYPE"),
-		Value:   cli.NewStringSlice(gameTypes.CannonGameType.String(), gameTypes.AsteriscKonaGameType.String(), gameTypes.CannonKonaGameType.String()),
+		Value:   cli.NewStringSlice(gameTypes.CannonGameType.String(), gameTypes.CannonKonaGameType.String()),
 	}
 	DatadirFlag = &cli.StringFlag{
 		Name:    "datadir",

--- a/ops/docker/op-stack-go/Dockerfile
+++ b/ops/docker/op-stack-go/Dockerfile
@@ -16,10 +16,6 @@ ARG UBUNTU_TARGET_BASE_IMAGE=ubuntu:22.04
 # The only build that uses this is `op-challenger-target`.
 ARG KONA_VERSION=none
 
-# The version of asterisc to use.
-# The only build that uses this is `op-challenger-target`.
-ARG ASTERISC_VERSION=none
-
 # builder_foundry does not need to be built on $BUILDPLATFORM, as foundry produces static binaries.
 FROM alpine:3.21 AS builder_foundry
 
@@ -222,25 +218,20 @@ CMD ["op-node"]
 
 # Make the kona docker image published by upstream available as a source to copy kona from.
 FROM ghcr.io/op-rs/kona/kona-host:$KONA_VERSION AS kona
-# Make the asterisc docker image published by upstream available as a source to copy asterisc from.
-FROM us-docker.pkg.dev/oplabs-tools-artifacts/images/asterisc:$ASTERISC_VERSION AS asterisc
 
-# Also produce an op-challenger loaded with kona and asterisc using ubuntu
+# Also produce an op-challenger loaded with kona using ubuntu
 FROM $UBUNTU_TARGET_BASE_IMAGE AS op-challenger-target
 RUN apt-get update && apt-get install -y --no-install-recommends musl openssl ca-certificates
 COPY --from=op-challenger-builder /app/op-challenger/bin/op-challenger /usr/local/bin/
 # Copy in op-program and cannon
 COPY --from=op-program-builder /app/op-program/bin/op-program /usr/local/bin/
-ENV OP_CHALLENGER_ASTERISC_SERVER=/usr/local/bin/op-program
 ENV OP_CHALLENGER_CANNON_SERVER=/usr/local/bin/op-program
 COPY --from=cannon-builder /app/cannon/bin/cannon /usr/local/bin/
 ENV OP_CHALLENGER_CANNON_BIN=/usr/local/bin/cannon
-# Copy in kona and asterisc
+# Copy in kona
 COPY --from=kona /usr/local/bin/kona-host /usr/local/bin/
 ENV OP_CHALLENGER_ASTERISC_KONA_SERVER=/usr/local/bin/kona-host
 ENV OP_CHALLENGER_CANNON_KONA_SERVER=/usr/local/bin/kona-host
-COPY --from=asterisc /usr/local/bin/asterisc /usr/local/bin/
-ENV OP_CHALLENGER_ASTERISC_BIN=/usr/local/bin/asterisc
 CMD ["op-challenger"]
 
 FROM $TARGET_BASE_IMAGE AS op-dispute-mon-target


### PR DESCRIPTION
**Description**

Stop bundling asterisc with the op-challenger docker image. Remove asterisc-kona from default game types.

**Tests**

Updated unit tests. Manually confirmed the asterisc CLI options are not required.

