### PR TITLE
test: skip some acceptance tests if CGT enabled

### DIFF
--- a/op-acceptance-tests/tests/base/deposit/deposit_test.go
+++ b/op-acceptance-tests/tests/base/deposit/deposit_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/custom_gas_token"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl/contract"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
@@ -18,6 +19,9 @@ func TestL1ToL2Deposit(gt *testing.T) {
 	// Create a test environment using op-devstack
 	t := devtest.SerialT(gt)
 	sys := presets.NewMinimal(t)
+
+	// Skip this test if CGT is enabled
+	custom_gas_token.SkipIfCGT(t, sys)
 
 	// Wait for L1 node to be responsive
 	sys.L1Network.WaitForOnline()

--- a/op-acceptance-tests/tests/custom_gas_token/helpers.go
+++ b/op-acceptance-tests/tests/custom_gas_token/helpers.go
@@ -23,48 +23,83 @@ var (
 	l2BridgeAddr = common.HexToAddress("0x4200000000000000000000000000000000000010")
 )
 
-// ensureCGTOrSkip probes L2 L1Block for CGT mode. If not enabled, the test is skipped.
-// Returns (name, symbol).
-func ensureCGTOrSkip(t devtest.T, sys *presets.Minimal) (string, string) {
+// isCGTEnabled checks if CGT mode is enabled without skipping the test.
+// Returns true if CGT is enabled, false if native ETH mode, and false if the check fails.
+func isCGTEnabled(t devtest.T, sys *presets.Minimal) bool {
 	l2 := sys.L2EL.Escape().L2EthClient()
-
 	isCustomGasTokenFunc := w3.MustNewFunc("isCustomGasToken()", "bool")
+
+	ctx, cancel := context.WithTimeout(t.Ctx(), 20*time.Second)
+	defer cancel()
+
+	data, _ := isCustomGasTokenFunc.EncodeArgs()
+	out, err := l2.Call(ctx, ethereum.CallMsg{To: &l1BlockAddr, Data: data}, rpc.LatestBlockNumber)
+	if err != nil {
+		return false
+	}
+
+	var isCustom bool
+	if err := isCustomGasTokenFunc.DecodeReturns(out, &isCustom); err != nil {
+		return false
+	}
+
+	return isCustom
+}
+
+// getCGTMetadata retrieves the name and symbol of the custom gas token.
+// Returns empty strings if CGT is not enabled or if the call fails.
+func getCGTMetadata(t devtest.T, sys *presets.Minimal) (string, string) {
+	l2 := sys.L2EL.Escape().L2EthClient()
 	gasPayingTokenNameFunc := w3.MustNewFunc("gasPayingTokenName()", "string")
 	gasPayingTokenSymbolFunc := w3.MustNewFunc("gasPayingTokenSymbol()", "string")
 
 	ctx, cancel := context.WithTimeout(t.Ctx(), 20*time.Second)
 	defer cancel()
 
-	// isCustomGasToken()
-	data, _ := isCustomGasTokenFunc.EncodeArgs()
+	// Read name
+	data, _ := gasPayingTokenNameFunc.EncodeArgs()
 	out, err := l2.Call(ctx, ethereum.CallMsg{To: &l1BlockAddr, Data: data}, rpc.LatestBlockNumber)
 	if err != nil {
-		t.Skipf("CGT not enabled (isCustomGasToken() call failed): %v", err)
+		return "", ""
 	}
-	var isCustom bool
-	if err := isCustomGasTokenFunc.DecodeReturns(out, &isCustom); err != nil {
-		t.Require().NoError(err)
-	}
-	if !isCustom {
-		t.Skip("CGT disabled on this devnet (native ETH mode detected)")
-	}
-
-	// Read metadata (name/symbol)
-	data, _ = gasPayingTokenNameFunc.EncodeArgs()
-	out, err = l2.Call(ctx, ethereum.CallMsg{To: &l1BlockAddr, Data: data}, rpc.LatestBlockNumber)
-	t.Require().NoError(err)
 	var name string
 	if err := gasPayingTokenNameFunc.DecodeReturns(out, &name); err != nil {
-		t.Require().NoError(err)
+		return "", ""
 	}
 
+	// Read symbol
 	data, _ = gasPayingTokenSymbolFunc.EncodeArgs()
 	out, err = l2.Call(ctx, ethereum.CallMsg{To: &l1BlockAddr, Data: data}, rpc.LatestBlockNumber)
-	t.Require().NoError(err)
+	if err != nil {
+		return "", ""
+	}
 	var symbol string
 	if err := gasPayingTokenSymbolFunc.DecodeReturns(out, &symbol); err != nil {
-		t.Require().NoError(err)
+		return "", ""
 	}
 
 	return name, symbol
+}
+
+// ensureCGTOrSkip probes L2 L1Block for CGT mode. If not enabled, the test is skipped.
+// Returns (name, symbol).
+func ensureCGTOrSkip(t devtest.T, sys *presets.Minimal) (string, string) {
+	if !isCGTEnabled(t, sys) {
+		t.Skip("CGT disabled on this devnet (native ETH mode detected)")
+	}
+
+	name, symbol := getCGTMetadata(t, sys)
+	if name == "" || symbol == "" {
+		t.Skip("Failed to retrieve CGT metadata")
+	}
+
+	return name, symbol
+}
+
+// SkipIfCGT probes L2 L1Block for CGT mode. If CGT is enabled, the test is skipped.
+// This is useful for tests that should only run with native ETH.
+func SkipIfCGT(t devtest.T, sys *presets.Minimal) {
+	if isCGTEnabled(t, sys) {
+		t.Skip("Test skipped: CGT is enabled (test requires native ETH)")
+	}
 }

--- a/op-acceptance-tests/tests/isthmus/withdrawal_root/withdrawals_root_test.go
+++ b/op-acceptance-tests/tests/isthmus/withdrawal_root/withdrawals_root_test.go
@@ -3,6 +3,7 @@ package withdrawal
 import (
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/custom_gas_token"
 	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
@@ -13,6 +14,10 @@ import (
 func TestWithdrawalRoot(gt *testing.T) {
 	t := devtest.SerialT(gt)
 	sys := presets.NewMinimal(t)
+
+	// Skip this test if CGT is enabled
+	custom_gas_token.SkipIfCGT(t, sys)
+
 	require := sys.T.Require()
 
 	require.True(sys.L2Chain.IsForkActive(forks.Isthmus), "Isthmus fork must be active for this test")


### PR DESCRIPTION
**Description**

Adds the `SkipIfCGT` function to avoid false positives in tests that are currently failing.
