### PR TITLE
chore: update fees depositor address and min withdrawal amount on genesis

### DIFF
--- a/op-deployer/pkg/deployer/standard/standard.go
+++ b/op-deployer/pkg/deployer/standard/standard.go
@@ -46,8 +46,7 @@ const (
 	CurrentTag              = ContractsV410Tag
 )
 
-// TODO(#17505): This address should be updated to the actual address once deployed
-var L1FeesDepositor = common.HexToAddress("0x81c01427DFA9A2512b4EBf1462868856BA4aA91a")
+var L1FeesDepositor = common.HexToAddress("0xed9B99a703BaD32AC96FDdc313c0652e379251Fd")
 
 var DisputeAbsolutePrestate = common.HexToHash("0x038512e02c4c3f7bdaec27d00edf55b7155e0905301e1a88083e4e0a6764d54c")
 

--- a/packages/contracts-bedrock/scripts/L2Genesis.s.sol
+++ b/packages/contracts-bedrock/scripts/L2Genesis.s.sol
@@ -89,8 +89,8 @@ contract L2Genesis is Script {
     uint256 internal constant PRECOMPILE_COUNT = 256;
 
     uint80 internal constant DEV_ACCOUNT_FUND_AMT = 10_000 ether;
-    uint32 internal constant WITHDRAWAL_MIN_GAS_LIMIT = 1_000_000;
-    uint256 internal constant MIN_WITHDRAWAL_AMOUNT_THRESHOLD = 10 ether;
+    uint32 internal constant WITHDRAWAL_MIN_GAS_LIMIT = 800_000;
+    uint256 internal constant MIN_WITHDRAWAL_AMOUNT_THRESHOLD = 2 ether;
 
     /// @notice Default Anvil dev accounts. Only funded if `cfg.fundDevAccounts == true`.
     /// Also known as "test test test test test test test test test test test junk" mnemonic accounts,

--- a/packages/contracts-bedrock/test/L2/L1Withdrawer.t.sol
+++ b/packages/contracts-bedrock/test/L2/L1Withdrawer.t.sol
@@ -18,8 +18,8 @@ contract L1Withdrawer_TestInit is CommonTest {
     event WithdrawalGasLimitUpdated(uint32 oldWithdrawalGasLimit, uint32 newWithdrawalGasLimit);
 
     // Test state
-    uint256 minWithdrawalAmount = 10 ether;
-    uint32 withdrawalGasLimit = 1_000_000;
+    uint256 minWithdrawalAmount = 2 ether;
+    uint32 withdrawalGasLimit = 800_000;
 
     uint32 internal constant MIN_WITHDRAWAL_GAS_LIMIT = 800_000;
 

--- a/packages/contracts-bedrock/test/L2/RevenueSharingIntegration.t.sol
+++ b/packages/contracts-bedrock/test/L2/RevenueSharingIntegration.t.sol
@@ -32,31 +32,6 @@ contract RevenueSharingIntegration_Test is CommonTest {
         disbursementInterval = feeSplitter.feeDisbursementInterval();
     }
 
-    /// @notice Configure all vaults to withdraw to FeeSplitter on L2
-    function _configureVaultsForFeeSplitter() private {
-        // Get the ProxyAdmin owner to configure vaults
-        address proxyAdminOwner = proxyAdmin.owner();
-
-        // Configure all vaults to withdraw to FeeSplitter on L2
-        vm.startPrank(proxyAdminOwner);
-        IFeeVault(payable(address(sequencerFeeVault))).setRecipient(address(feeSplitter));
-        IFeeVault(payable(address(sequencerFeeVault))).setWithdrawalNetwork(Types.WithdrawalNetwork.L2);
-        IFeeVault(payable(address(sequencerFeeVault))).setMinWithdrawalAmount(0);
-
-        IFeeVault(payable(address(baseFeeVault))).setRecipient(address(feeSplitter));
-        IFeeVault(payable(address(baseFeeVault))).setWithdrawalNetwork(Types.WithdrawalNetwork.L2);
-        IFeeVault(payable(address(baseFeeVault))).setMinWithdrawalAmount(0);
-
-        IFeeVault(payable(address(l1FeeVault))).setRecipient(address(feeSplitter));
-        IFeeVault(payable(address(l1FeeVault))).setWithdrawalNetwork(Types.WithdrawalNetwork.L2);
-        IFeeVault(payable(address(l1FeeVault))).setMinWithdrawalAmount(0);
-
-        IFeeVault(payable(address(operatorFeeVault))).setRecipient(address(feeSplitter));
-        IFeeVault(payable(address(operatorFeeVault))).setWithdrawalNetwork(Types.WithdrawalNetwork.L2);
-        IFeeVault(payable(address(operatorFeeVault))).setMinWithdrawalAmount(0);
-        vm.stopPrank();
-    }
-
     /// @notice Helper to fund vaults
     function _fundVaults(uint256 _sequencerFees, uint256 _baseFees, uint256 _l1Fees, uint256 _operatorFees) private {
         vm.deal(address(sequencerFeeVault), _sequencerFees);
@@ -134,8 +109,9 @@ contract RevenueSharingIntegration_Test is CommonTest {
     // | 0/0/0/0          | 2.5          | 205.55       | Accumulating                   |
     // |__________________|______________|______________|________________________________|
     function test_revenueSharing_fullFlow_succeeds() public {
-        // Configure vaults to withdraw to FeeSplitter
-        _configureVaultsForFeeSplitter();
+        // Use 10 ETH as the minimum withdrawal amount for this test's hardcoded math
+        vm.prank(proxyAdminOwner);
+        l1Withdrawer.setMinWithdrawalAmount(10 ether);
 
         // Get recipient addresses
         address shareRecipient = superchainRevSharesCalculator.shareRecipient();
@@ -271,9 +247,6 @@ contract RevenueSharingIntegration_Test is CommonTest {
             superchainRevSharesCalculator.getRecipientsAndAmounts(_sequencerFees, _baseFees, _operatorFees, _l1Fees);
             return;
         }
-
-        // Configure vaults for disbursement
-        _configureVaultsForFeeSplitter();
 
         {
             // Get share info from calculator first

--- a/packages/contracts-bedrock/test/L2/RevenueSharingIntegration.t.sol
+++ b/packages/contracts-bedrock/test/L2/RevenueSharingIntegration.t.sol
@@ -4,9 +4,7 @@ pragma solidity 0.8.15;
 import { CommonTest } from "test/setup/CommonTest.sol";
 import { ISharesCalculator } from "interfaces/L2/ISharesCalculator.sol";
 import { ISuperchainRevSharesCalculator } from "interfaces/L2/ISuperchainRevSharesCalculator.sol";
-import { IFeeVault } from "interfaces/L2/IFeeVault.sol";
 import { Predeploys } from "src/libraries/Predeploys.sol";
-import { Types } from "src/libraries/Types.sol";
 import { ICrossDomainMessenger } from "interfaces/universal/ICrossDomainMessenger.sol";
 
 /// @title RevenueSharingIntegration_Test

--- a/packages/contracts-bedrock/test/scripts/L2Genesis.t.sol
+++ b/packages/contracts-bedrock/test/scripts/L2Genesis.t.sol
@@ -194,9 +194,9 @@ abstract contract L2Genesis_TestInit is Test {
 
         // Check the L1Withdrawer is properly set
         IL1Withdrawer l1Withdrawer = IL1Withdrawer(superchainRevSharesCalculator.shareRecipient());
-        assertEq(l1Withdrawer.minWithdrawalAmount(), 10 ether);
+        assertEq(l1Withdrawer.minWithdrawalAmount(), 2 ether);
         assertEq(l1Withdrawer.recipient(), input.l1FeesDepositor);
-        assertEq(l1Withdrawer.withdrawalGasLimit(), 1_000_000);
+        assertEq(l1Withdrawer.withdrawalGasLimit(), 800_000);
     }
 
     function testCGT() internal view {


### PR DESCRIPTION
**Description**

Updates `FeesDepositor` address with the recently deployed address.
Updates the `minWithdrawalAmount` threshold on genesis from 10 eth to 2 eth for consistency after the value was decided, and updates the gas limit required for a withdrawal from 1m to 800k since that value is more than enough based on our tests.

**Tests**

Set the threshold again to 10 eth for the `test_revenueSharing_fullFlow_succeeds` test given the threshold amount is not the relevant part of the test, math is hardcoded, and to make it more future proof in case this value changes again later. We still have a fuzzed integration test with 2 eth as threshold.

**Metadata**

- Fixes https://github.com/ethereum-optimism/optimism/issues/17505 (partially, the other fix needs to take place on the superchain-ops repo)
- https://sepolia.etherscan.io/address/0xed9B99a703BaD32AC96FDdc313c0652e379251Fd
- https://etherscan.io/address/0xed9B99a703BaD32AC96FDdc313c0652e379251Fd
