### PR TITLE
ci(workflows): update factory workflow to fix bash history expansion flaky bug

### DIFF
--- a/.github/workflows/protected.yaml
+++ b/.github/workflows/protected.yaml
@@ -61,7 +61,7 @@ jobs:
           - cannon
           - op-dripper
           - op-interop-mon
-    uses: ethereum-optimism/factory/.github/workflows/docker-bake.yaml@753bcd4284a6d36eac6e31df2492015ab8650331
+    uses: ethereum-optimism/factory/.github/workflows/docker-bake.yaml@f08b1f0c47f15b3c95dc9811fb09c1d8ed3436bd
     with:
       image_name: ${{ matrix.image_name }}
       bake_file: docker-bake.hcl

--- a/.github/workflows/unprotected.yaml
+++ b/.github/workflows/unprotected.yaml
@@ -67,7 +67,7 @@ jobs:
           - cannon
           - op-dripper
           - op-interop-mon
-    uses: ethereum-optimism/factory/.github/workflows/docker-bake.yaml@753bcd4284a6d36eac6e31df2492015ab8650331
+    uses: ethereum-optimism/factory/.github/workflows/docker-bake.yaml@f08b1f0c47f15b3c95dc9811fb09c1d8ed3436bd
     with:
       image_name: ${{ matrix.image_name }}
       bake_file: docker-bake.hcl


### PR DESCRIPTION
## Description

Updates the `docker-bake.yaml` workflow reference to include a fix that prevents bash history expansion issues when build metadata contains special characters like `!`.

## Changes

- Updated `protected.yaml` and `unprotected.yaml` to use factory workflow at `f08b1f0c47f15b3c95dc9811fb09c1d8ed3436bd`

## Related

- Fix PR: ethereum-optimism/factory#8
- Issue observed in: #18488, #18452 