### PR TITLE
test: use a custom Test contract for makeAddr

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2778,10 +2778,9 @@ workflows:
             parameters:
               features: &features_matrix
                 - main
-                - OPTIMISM_PORTAL_INTEROP
-                - CANNON_KONA,DEPLOY_V2_DISPUTE_GAMES
-                - OPCM_V2
                 - CUSTOM_GAS_TOKEN
+                - OPTIMISM_PORTAL_INTEROP
+                - OPCM_V2
                 - OPCM_V2,CUSTOM_GAS_TOKEN
                 - OPCM_V2,OPTIMISM_PORTAL_INTEROP
           context:

--- a/.semgrep/rules/sol-rules.yaml
+++ b/.semgrep/rules/sol-rules.yaml
@@ -398,3 +398,14 @@ rules:
     paths:
       include:
         - packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
+
+  - id: sol-style-ban-forge-std-test-import
+    languages: [solidity]
+    severity: ERROR
+    message: Import Test from test/setup/Test.sol, not forge-std/Test.sol. Import other forge-std components (stdStorage, StdStorage, stdError, StdUtils, Vm, console2, etc.) from their specific files (forge-std/StdStorage.sol, forge-std/StdError.sol, forge-std/StdUtils.sol, forge-std/Vm.sol, forge-std/console2.sol, etc.)
+    pattern-regex: import\s+(\{[^}]*\}\s+from\s+)?"forge-std/Test\.sol"\s*;
+    paths:
+      include:
+        - packages/contracts-bedrock/test
+      exclude:
+        - packages/contracts-bedrock/test/setup/Test.sol

--- a/.semgrep/tests/sol-rules.sol-style-ban-forge-std-test-import.t.sol
+++ b/.semgrep/tests/sol-rules.sol-style-ban-forge-std-test-import.t.sol
@@ -1,0 +1,20 @@
+// ruleid: sol-style-ban-forge-std-test-import
+import { Test } from "forge-std/Test.sol";
+
+// ruleid: sol-style-ban-forge-std-test-import
+import { Test as ForgeTest } from "forge-std/Test.sol";
+
+// ruleid: sol-style-ban-forge-std-test-import
+import { Test, Vm } from "forge-std/Test.sol";
+
+// ok: sol-style-ban-forge-std-test-import
+import { Test } from "test/setup/Test.sol";
+
+// ok: sol-style-ban-forge-std-test-import
+import { Test as BaseTest } from "test/setup/Test.sol";
+
+// ok: sol-style-ban-forge-std-test-import
+import { Vm } from "forge-std/Vm.sol";
+
+// ok: sol-style-ban-forge-std-test-import
+import { StdUtils } from "forge-std/StdUtils.sol";

--- a/packages/contracts-bedrock/justfile
+++ b/packages/contracts-bedrock/justfile
@@ -81,8 +81,8 @@ test-dev *ARGS: build-go-ffi
 
 # Default block number for the forked upgrade path.
 
-export sepoliaBlockNumber := "9366100"
-export mainnetBlockNumber := "23530400"
+export sepoliaBlockNumber := "9770063"
+export mainnetBlockNumber := "23942395"
 
 export pinnedBlockNumber := if env_var_or_default("FORK_BASE_CHAIN", "") == "mainnet" {
     mainnetBlockNumber

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -36,8 +36,8 @@
     "sourceCodeHash": "0x16fb96f4d29a10d03b3b9c70edf56df51e97c2a1a3f0ba36aae79469b446ad5c"
   },
   "src/L1/OptimismPortalInterop.sol:OptimismPortalInterop": {
-    "initCodeHash": "0x087281cd2a48e882648c09fa90bfcca7487d222e16300f9372deba6b2b8ccfad",
-    "sourceCodeHash": "0x1cc641a4272aea85e13cbf42d9032d1b91ef858eafe3be6b5649cc8504c9cf69"
+    "initCodeHash": "0xd361ed3b8d56dcc1f3c068ef3af9c83f3da1165bcdab097250ad4772f350c52e",
+    "sourceCodeHash": "0xd7d2166d29a22f3a051bc832cbce05f9ca06f1ac1bfb0790f29579f12bb95b8f"
   },
   "src/L1/ProtocolVersions.sol:ProtocolVersions": {
     "initCodeHash": "0xcb59ad9a5ec2a0831b7f4daa74bdacba82ffa03035dafb499a732c641e017f4e",

--- a/packages/contracts-bedrock/src/L1/OptimismPortalInterop.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortalInterop.sol
@@ -229,9 +229,9 @@ contract OptimismPortalInterop is Initializable, ResourceMetering, Reinitializab
     error OptimismPortal_MigratingToSameRegistry();
 
     /// @notice Semantic version.
-    /// @custom:semver 5.1.0+interop
+    /// @custom:semver 5.2.0+interop
     function version() public pure virtual returns (string memory) {
-        return "5.1.0+interop";
+        return "5.2.0+interop";
     }
 
     /// @param _proofMaturityDelaySeconds The proof maturity delay in seconds.

--- a/packages/contracts-bedrock/test/L1/L1StandardBridge.t.sol
+++ b/packages/contracts-bedrock/test/L1/L1StandardBridge.t.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.15;
 
 // Testing
-import { stdStorage, StdStorage } from "forge-std/Test.sol";
+import { stdStorage, StdStorage } from "forge-std/StdStorage.sol";
 import { CommonTest } from "test/setup/CommonTest.sol";
 import { ForgeArtifacts, StorageSlot } from "scripts/libraries/ForgeArtifacts.sol";
 

--- a/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
@@ -2,7 +2,8 @@
 pragma solidity 0.8.15;
 
 // Testing
-import { Test, stdStorage, StdStorage } from "forge-std/Test.sol";
+import { Test } from "test/setup/Test.sol";
+import { stdStorage, StdStorage } from "forge-std/StdStorage.sol";
 import { VmSafe } from "forge-std/Vm.sol";
 import { CommonTest } from "test/setup/CommonTest.sol";
 import { FeatureFlags } from "test/setup/FeatureFlags.sol";

--- a/packages/contracts-bedrock/test/L1/ResourceMetering.t.sol
+++ b/packages/contracts-bedrock/test/L1/ResourceMetering.t.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.15;
 
 // Testing
-import { Test } from "forge-std/Test.sol";
+import { Test } from "test/setup/Test.sol";
 
 // Contracts
 import { ResourceMetering } from "src/L1/ResourceMetering.sol";

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerContainer.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerContainer.t.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.15;
 
 // Testing
-import { Test } from "forge-std/Test.sol";
+import { Test } from "test/setup/Test.sol";
 
 // Contracts
 import { OPContractsManagerContainer } from "src/L1/opcm/OPContractsManagerContainer.sol";

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerUtils.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerUtils.t.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.15;
 
 // Testing
-import { Test } from "forge-std/Test.sol";
+import { Test } from "test/setup/Test.sol";
 
 // Contracts
 import { OPContractsManagerUtils } from "src/L1/opcm/OPContractsManagerUtils.sol";

--- a/packages/contracts-bedrock/test/L2/CrossDomainOwnable.t.sol
+++ b/packages/contracts-bedrock/test/L2/CrossDomainOwnable.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-// Testing utilities
+// Testing
+import { Test } from "test/setup/Test.sol";
 import { VmSafe } from "forge-std/Vm.sol";
-import { Test } from "forge-std/Test.sol";
 import { CommonTest } from "test/setup/CommonTest.sol";
 
 // Libraries

--- a/packages/contracts-bedrock/test/L2/CrossL2Inbox.t.sol
+++ b/packages/contracts-bedrock/test/L2/CrossL2Inbox.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-// Testing utilities
-import { Test } from "forge-std/Test.sol";
+// Testing
+import { Test } from "test/setup/Test.sol";
 import { CommonTest } from "test/setup/CommonTest.sol";
 import { VmSafe } from "forge-std/Vm.sol";
 

--- a/packages/contracts-bedrock/test/L2/FeeSplitterVaults.t.sol
+++ b/packages/contracts-bedrock/test/L2/FeeSplitterVaults.t.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.25;
 
+// Testing
+import { Test } from "test/setup/Test.sol";
+import { FeeSplitterForTest } from "test/mocks/FeeSplitterForTest.sol";
+
 // Libraries
 import { Predeploys } from "src/libraries/Predeploys.sol";
-
-// Testing
-import { Test } from "forge-std/Test.sol";
-import { FeeSplitterForTest } from "test/mocks/FeeSplitterForTest.sol";
 
 // Interfaces
 import { IFeeSplitter } from "interfaces/L2/IFeeSplitter.sol";

--- a/packages/contracts-bedrock/test/L2/GasPriceOracle.t.sol
+++ b/packages/contracts-bedrock/test/L2/GasPriceOracle.t.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-// Testing utilities
+// Testing
 import { CommonTest } from "test/setup/CommonTest.sol";
 import { Fork } from "scripts/libraries/Config.sol";
+import { stdError } from "forge-std/StdError.sol";
 
 // Libraries
 import { Encoding } from "src/libraries/Encoding.sol";
-import { stdError } from "forge-std/Test.sol";
 
 contract GasPriceOracle_Test is CommonTest {
     address depositor;

--- a/packages/contracts-bedrock/test/L2/L1Block.t.sol
+++ b/packages/contracts-bedrock/test/L2/L1Block.t.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.15;
 
 // Testing
 import { CommonTest } from "test/setup/CommonTest.sol";
-import { stdStorage, StdStorage } from "forge-std/Test.sol";
+import { stdStorage, StdStorage } from "forge-std/StdStorage.sol";
 
 // Libraries
 import { Encoding } from "src/libraries/Encoding.sol";

--- a/packages/contracts-bedrock/test/L2/L2StandardBridge.t.sol
+++ b/packages/contracts-bedrock/test/L2/L2StandardBridge.t.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.15;
 
 // Testing
-import { stdStorage, StdStorage } from "forge-std/Test.sol";
+import { stdStorage, StdStorage } from "forge-std/StdStorage.sol";
 import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 import { CommonTest } from "test/setup/CommonTest.sol";
 

--- a/packages/contracts-bedrock/test/L2/L2ToL2CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/L2/L2ToL2CrossDomainMessenger.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.25;
 
-// Testing utilities
-import { Test } from "forge-std/Test.sol";
+// Testing
+import { Test } from "test/setup/Test.sol";
 import { Vm } from "forge-std/Vm.sol";
 
 // Libraries

--- a/packages/contracts-bedrock/test/L2/LiquidityController.t.sol
+++ b/packages/contracts-bedrock/test/L2/LiquidityController.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-// Testing utilities
+// Testing
 import { CommonTest } from "test/setup/CommonTest.sol";
-import { stdStorage, StdStorage } from "forge-std/Test.sol";
+import { stdStorage, StdStorage } from "forge-std/StdStorage.sol";
 
 // Libraries
 import { Features } from "src/libraries/Features.sol";

--- a/packages/contracts-bedrock/test/L2/OptimismSuperchainERC20.t.sol
+++ b/packages/contracts-bedrock/test/L2/OptimismSuperchainERC20.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.25;
 
-// Testing utilities
-import { Test } from "forge-std/Test.sol";
+// Testing
+import { Test } from "test/setup/Test.sol";
 import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 
 // Libraries

--- a/packages/contracts-bedrock/test/L2/SuperchainERC20.t.sol
+++ b/packages/contracts-bedrock/test/L2/SuperchainERC20.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.25;
 
-// Testing utilities
-import { Test } from "forge-std/Test.sol";
+// Testing
+import { Test } from "test/setup/Test.sol";
 
 // Libraries
 import { Predeploys } from "src/libraries/Predeploys.sol";

--- a/packages/contracts-bedrock/test/L2/SuperchainTokenBridge.t.sol
+++ b/packages/contracts-bedrock/test/L2/SuperchainTokenBridge.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.25;
 
-// Testing utilities
-import { Test } from "forge-std/Test.sol";
+// Testing
+import { Test } from "test/setup/Test.sol";
 
 // Libraries
 import { Predeploys } from "src/libraries/Predeploys.sol";

--- a/packages/contracts-bedrock/test/cannon/MIPS64.t.sol
+++ b/packages/contracts-bedrock/test/cannon/MIPS64.t.sol
@@ -1,10 +1,16 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { Test } from "forge-std/Test.sol";
+// Testing
+import { Test } from "test/setup/Test.sol";
 
+// Scripts
 import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
+
+// Libraries
 import { UnsupportedStateVersion } from "src/cannon/libraries/CannonErrors.sol";
+
+// Interfaces
 import { IPreimageOracle } from "interfaces/cannon/IPreimageOracle.sol";
 import { IMIPS64 } from "interfaces/cannon/IMIPS64.sol";
 

--- a/packages/contracts-bedrock/test/cannon/PreimageOracle.t.sol
+++ b/packages/contracts-bedrock/test/cannon/PreimageOracle.t.sol
@@ -2,7 +2,9 @@
 pragma solidity 0.8.15;
 
 // Testing
-import { Test, Vm, console2 as console } from "forge-std/Test.sol";
+import { Test } from "test/setup/Test.sol";
+import { Vm } from "forge-std/Vm.sol";
+import { console2 as console } from "forge-std/console2.sol";
 
 // Scripts
 import { DeployUtils } from "scripts/libraries/DeployUtils.sol";

--- a/packages/contracts-bedrock/test/dispute/lib/LibClock.t.sol
+++ b/packages/contracts-bedrock/test/dispute/lib/LibClock.t.sol
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.15;
 
-import { Test } from "forge-std/Test.sol";
+// Testing
+import { Test } from "test/setup/Test.sol";
+
+// Libraries
 import { LibClock } from "src/dispute/lib/LibUDT.sol";
 import "src/dispute/lib/Types.sol";
 

--- a/packages/contracts-bedrock/test/dispute/lib/LibGameArgs.t.sol
+++ b/packages/contracts-bedrock/test/dispute/lib/LibGameArgs.t.sol
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.15;
 
-import { Test } from "forge-std/Test.sol";
+// Testing
+import { Test } from "test/setup/Test.sol";
+
+// Libraries
 import { LibGameArgs } from "src/dispute/lib/LibGameArgs.sol";
 import { InvalidGameArgsLength } from "src/dispute/lib/Errors.sol";
 

--- a/packages/contracts-bedrock/test/dispute/lib/LibGameId.t.sol
+++ b/packages/contracts-bedrock/test/dispute/lib/LibGameId.t.sol
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.15;
 
-import { Test } from "forge-std/Test.sol";
+// Testing
+import { Test } from "test/setup/Test.sol";
 
+// Libraries
 import "src/dispute/lib/Types.sol";
 
 /// @title LibGameId_Pack_Test

--- a/packages/contracts-bedrock/test/dispute/lib/LibPosition.t.sol
+++ b/packages/contracts-bedrock/test/dispute/lib/LibPosition.t.sol
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.15;
 
-import { Test } from "forge-std/Test.sol";
+// Testing
+import { Test } from "test/setup/Test.sol";
+
+// Libraries
 import { LibPosition } from "src/dispute/lib/LibPosition.sol";
 import "src/dispute/lib/Types.sol";
 

--- a/packages/contracts-bedrock/test/integration/EventLogger.t.sol
+++ b/packages/contracts-bedrock/test/integration/EventLogger.t.sol
@@ -1,17 +1,20 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import { Test } from "forge-std/Test.sol";
+// Testing
+import { Test } from "test/setup/Test.sol";
+import { VmSafe } from "forge-std/Vm.sol";
 
-import { Identifier as IfaceIdentifier } from "interfaces/L2/ICrossL2Inbox.sol";
-
+// Contracts
 import { EventLogger } from "../../src/integration/EventLogger.sol";
+import { CrossL2Inbox } from "src/L2/CrossL2Inbox.sol";
 
+// Libraries
 import { Predeploys } from "src/libraries/Predeploys.sol";
 
+// Interfaces
+import { Identifier as IfaceIdentifier } from "interfaces/L2/ICrossL2Inbox.sol";
 import { ICrossL2Inbox, Identifier as ImplIdentifier } from "interfaces/L2/ICrossL2Inbox.sol";
-import { VmSafe } from "forge-std/Vm.sol";
-import { CrossL2Inbox } from "src/L2/CrossL2Inbox.sol";
 
 /// @title EventLogger_TestInit
 /// @notice Reusable test initialization for `EventLogger` tests.

--- a/packages/contracts-bedrock/test/invariants/CustomGasToken.t.sol
+++ b/packages/contracts-bedrock/test/invariants/CustomGasToken.t.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.15;
 
 // Testing
-import { StdUtils } from "forge-std/Test.sol";
+import { StdUtils } from "forge-std/StdUtils.sol";
 import { Vm } from "forge-std/Vm.sol";
 import { CommonTest } from "test/setup/CommonTest.sol";
 

--- a/packages/contracts-bedrock/test/invariants/ETHLiquidity.t.sol
+++ b/packages/contracts-bedrock/test/invariants/ETHLiquidity.t.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.15;
 
 // Testing
-import { StdUtils } from "forge-std/Test.sol";
+import { StdUtils } from "forge-std/StdUtils.sol";
 import { Vm } from "forge-std/Vm.sol";
 import { CommonTest } from "test/setup/CommonTest.sol";
 

--- a/packages/contracts-bedrock/test/invariants/InvariantTest.sol
+++ b/packages/contracts-bedrock/test/invariants/InvariantTest.sol
@@ -1,9 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Testing
+import { Test } from "test/setup/Test.sol";
 import { FFIInterface } from "test/setup/FFIInterface.sol";
+
+// Scripts
 import { Deploy } from "scripts/deploy/Deploy.s.sol";
-import { Test } from "forge-std/Test.sol";
 
 /// @title InvariantTest
 /// @dev An extension to `Test` that sets up excluded contracts for invariant testing.

--- a/packages/contracts-bedrock/test/invariants/OptimismPortal2.t.sol
+++ b/packages/contracts-bedrock/test/invariants/OptimismPortal2.t.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.15;
 
 // Testing
-import { StdUtils } from "forge-std/Test.sol";
+import { StdUtils } from "forge-std/StdUtils.sol";
 import { Vm } from "forge-std/Vm.sol";
 import { CommonTest } from "test/setup/CommonTest.sol";
 import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";

--- a/packages/contracts-bedrock/test/invariants/OptimismSuperchainERC20/OptimismSuperchainERC20.t.sol
+++ b/packages/contracts-bedrock/test/invariants/OptimismSuperchainERC20/OptimismSuperchainERC20.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.25;
 
-// Testing utilities
-import { Test } from "forge-std/Test.sol";
+// Testing
+import { Test } from "test/setup/Test.sol";
 
 // Libraries
 import { Predeploys } from "src/libraries/Predeploys.sol";

--- a/packages/contracts-bedrock/test/invariants/SystemConfig.t.sol
+++ b/packages/contracts-bedrock/test/invariants/SystemConfig.t.sol
@@ -1,11 +1,18 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { Test } from "forge-std/Test.sol";
+// Testing
+import { Test } from "test/setup/Test.sol";
+
+// Scripts
+import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
+
+// Libraries
+import { Constants } from "src/libraries/Constants.sol";
+
+// Interfaces
 import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
 import { IProxy } from "interfaces/universal/IProxy.sol";
-import { Constants } from "src/libraries/Constants.sol";
-import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 
 contract SystemConfig_GasLimitBoundaries_Invariant is Test {

--- a/packages/contracts-bedrock/test/legacy/DeployerWhitelist.t.sol
+++ b/packages/contracts-bedrock/test/legacy/DeployerWhitelist.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-// Testing utilities
-import { Test } from "forge-std/Test.sol";
+// Testing
+import { Test } from "test/setup/Test.sol";
 
 // Target contract
 import { IDeployerWhitelist } from "interfaces/legacy/IDeployerWhitelist.sol";

--- a/packages/contracts-bedrock/test/legacy/L1BlockNumber.t.sol
+++ b/packages/contracts-bedrock/test/legacy/L1BlockNumber.t.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.15;
 
 // Testing
-import { Test } from "forge-std/Test.sol";
+import { Test } from "test/setup/Test.sol";
 
 // Libraries
 import { Predeploys } from "src/libraries/Predeploys.sol";

--- a/packages/contracts-bedrock/test/legacy/L1ChugSplashProxy.t.sol
+++ b/packages/contracts-bedrock/test/legacy/L1ChugSplashProxy.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.15;
 
-// Forge
-import { Test } from "forge-std/Test.sol";
+// Testing
+import { Test } from "test/setup/Test.sol";
 import { VmSafe } from "forge-std/Vm.sol";
 
 // Scripts

--- a/packages/contracts-bedrock/test/legacy/ResolvedDelegateProxy.t.sol
+++ b/packages/contracts-bedrock/test/legacy/ResolvedDelegateProxy.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-// Testing utilities
-import { Test } from "forge-std/Test.sol";
+// Testing
+import { Test } from "test/setup/Test.sol";
 
 // Target contract dependencies
 import { IAddressManager } from "interfaces/legacy/IAddressManager.sol";

--- a/packages/contracts-bedrock/test/libraries/Blueprint.t.sol
+++ b/packages/contracts-bedrock/test/libraries/Blueprint.t.sol
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { Test } from "forge-std/Test.sol";
+// Testing
+import { Test } from "test/setup/Test.sol";
+
+// Libraries
 import { Blueprint } from "src/libraries/Blueprint.sol";
 
 /// @dev Used to test that constructor args are appended properly when deploying from a blueprint.

--- a/packages/contracts-bedrock/test/libraries/Bytes.t.sol
+++ b/packages/contracts-bedrock/test/libraries/Bytes.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-// Testing utilities
-import { Test } from "forge-std/Test.sol";
+// Testing
+import { Test } from "test/setup/Test.sol";
 
-// Target contract
+// Libraries
 import { Bytes } from "src/libraries/Bytes.sol";
 
 contract Bytes_Harness {

--- a/packages/contracts-bedrock/test/libraries/Constants.t.sol
+++ b/packages/contracts-bedrock/test/libraries/Constants.t.sol
@@ -1,8 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { Test } from "forge-std/Test.sol";
+// Testing
+import { Test } from "test/setup/Test.sol";
+
+// Libraries
 import { Constants } from "src/libraries/Constants.sol";
+
+// Interfaces
 import { IResourceMetering } from "interfaces/L1/IResourceMetering.sol";
 
 /// @title Constants_Test

--- a/packages/contracts-bedrock/test/libraries/DeployUtils.t.sol
+++ b/packages/contracts-bedrock/test/libraries/DeployUtils.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-// Forge
-import { Test } from "forge-std/Test.sol";
+// Testing
+import { Test } from "test/setup/Test.sol";
 
 // Libraries
 import { DeployUtils } from "scripts/libraries/DeployUtils.sol";

--- a/packages/contracts-bedrock/test/libraries/DevFeatures.t.sol
+++ b/packages/contracts-bedrock/test/libraries/DevFeatures.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-// Testing utilities
-import { Test } from "forge-std/Test.sol";
+// Testing
+import { Test } from "test/setup/Test.sol";
 
-// Target contract
+// Libraries
 import { DevFeatures } from "src/libraries/DevFeatures.sol";
 
 contract DevFeatures_isDevFeatureEnabled_Test is Test {

--- a/packages/contracts-bedrock/test/libraries/EOA.t.sol
+++ b/packages/contracts-bedrock/test/libraries/EOA.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-// Forge
-import { Test } from "forge-std/Test.sol";
+// Testing
+import { Test } from "test/setup/Test.sol";
 
 // Libraries
 import { EOA } from "src/libraries/EOA.sol";

--- a/packages/contracts-bedrock/test/libraries/GasPayingToken.t.sol
+++ b/packages/contracts-bedrock/test/libraries/GasPayingToken.t.sol
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-// Target contract
+// Testing
+import { Test } from "test/setup/Test.sol";
+
+// Libraries
 import { GasPayingToken } from "src/libraries/GasPayingToken.sol";
 import { Constants } from "src/libraries/Constants.sol";
-import { Test } from "forge-std/Test.sol";
 import { LibString } from "@solady/utils/LibString.sol";
 
 contract GasPayingToken_Harness {

--- a/packages/contracts-bedrock/test/libraries/SafeCall.t.sol
+++ b/packages/contracts-bedrock/test/libraries/SafeCall.t.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-// Scripts
-import { Config } from "scripts/libraries/Config.sol";
-
-// Forge
-import { Test } from "forge-std/Test.sol";
+// Testing
+import { Test } from "test/setup/Test.sol";
 import { VmSafe } from "forge-std/Vm.sol";
 import { StdCheatsSafe } from "forge-std/StdCheats.sol";
+
+// Scripts
+import { Config } from "scripts/libraries/Config.sol";
 
 // Libraries
 import { LibString } from "@solady/utils/LibString.sol";

--- a/packages/contracts-bedrock/test/libraries/SemverComp.t.sol
+++ b/packages/contracts-bedrock/test/libraries/SemverComp.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-// Forge
-import { Test } from "forge-std/Test.sol";
+// Testing
+import { Test } from "test/setup/Test.sol";
 
 // Libraries
 import { JSONParserLib } from "solady/src/utils/JSONParserLib.sol";

--- a/packages/contracts-bedrock/test/libraries/StaticConfig.t.sol
+++ b/packages/contracts-bedrock/test/libraries/StaticConfig.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-// Testing utilities
-import { Test } from "forge-std/Test.sol";
+// Testing
+import { Test } from "test/setup/Test.sol";
 import { FFIInterface } from "test/setup/FFIInterface.sol";
 
-// Target contract
+// Libraries
 import { StaticConfig } from "src/libraries/StaticConfig.sol";
 
 /// @title StaticConfig_TestInit

--- a/packages/contracts-bedrock/test/libraries/Storage.t.sol
+++ b/packages/contracts-bedrock/test/libraries/Storage.t.sol
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-// Target contract
+// Testing
+import { Test } from "test/setup/Test.sol";
+
+// Contracts
 import { StorageSetter } from "src/universal/StorageSetter.sol";
-import { Test } from "forge-std/Test.sol";
 
 /// @title Storage_TestInit
 /// @notice Reusable test initialization for `Storage` tests.

--- a/packages/contracts-bedrock/test/libraries/TransientContext.t.sol
+++ b/packages/contracts-bedrock/test/libraries/TransientContext.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
-// Testing utilities
-import { Test } from "forge-std/Test.sol";
+// Testing
+import { Test } from "test/setup/Test.sol";
 
-// Target contractS
+// Target contracts
 import { TransientContext } from "src/libraries/TransientContext.sol";
 import { TransientReentrancyAware } from "src/libraries/TransientContext.sol";
 

--- a/packages/contracts-bedrock/test/libraries/rlp/RLPReader.t.sol
+++ b/packages/contracts-bedrock/test/libraries/rlp/RLPReader.t.sol
@@ -1,8 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { stdError } from "forge-std/Test.sol";
-import { Test } from "forge-std/Test.sol";
+// Testing
+import { Test } from "test/setup/Test.sol";
+import { stdError } from "forge-std/StdError.sol";
+
+// Libraries
 import { RLPReader } from "src/libraries/rlp/RLPReader.sol";
 import "src/libraries/rlp/RLPErrors.sol";
 

--- a/packages/contracts-bedrock/test/libraries/rlp/RLPWriter.t.sol
+++ b/packages/contracts-bedrock/test/libraries/rlp/RLPWriter.t.sol
@@ -1,8 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Testing
+import { Test } from "test/setup/Test.sol";
+
+// Libraries
 import { RLPWriter } from "src/libraries/rlp/RLPWriter.sol";
-import { Test } from "forge-std/Test.sol";
 
 /// @title RLPWriter_writeString_Test
 /// @notice Tests the `writeString` function of the `RLPWriter` library.

--- a/packages/contracts-bedrock/test/libraries/trie/MerkleTrie.t.sol
+++ b/packages/contracts-bedrock/test/libraries/trie/MerkleTrie.t.sol
@@ -1,10 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { Test } from "forge-std/Test.sol";
+// Testing
+import { Test } from "test/setup/Test.sol";
+import { FFIInterface } from "test/setup/FFIInterface.sol";
+
+// Libraries
 import { MerkleTrie } from "src/libraries/trie/MerkleTrie.sol";
 import { RLPReader } from "src/libraries/rlp/RLPReader.sol";
-import { FFIInterface } from "test/setup/FFIInterface.sol";
 import "src/libraries/rlp/RLPErrors.sol";
 
 contract MerkleTrie_Harness {

--- a/packages/contracts-bedrock/test/opcm/DeployAlphabetVM.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployAlphabetVM.t.sol
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import { Test } from "forge-std/Test.sol";
+// Testing
+import { Test } from "test/setup/Test.sol";
+
+// Scripts
+import { DeployAlphabetVM } from "scripts/deploy/DeployAlphabetVM.s.sol";
 
 // Interfaces
 import { IPreimageOracle } from "interfaces/cannon/IPreimageOracle.sol";
-
-import { DeployAlphabetVM } from "scripts/deploy/DeployAlphabetVM.s.sol";
 
 contract DeployAlphabetVM2_Test is Test {
     DeployAlphabetVM deployAlphanetVM;

--- a/packages/contracts-bedrock/test/opcm/DeployAltDA.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployAltDA.t.sol
@@ -1,13 +1,17 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { Test } from "forge-std/Test.sol";
+// Testing
+import { Test } from "test/setup/Test.sol";
 
+// Scripts
 import { DeployAltDA } from "scripts/deploy/DeployAltDA.s.sol";
+import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
+
+// Interfaces
 import { IDataAvailabilityChallenge } from "interfaces/L1/IDataAvailabilityChallenge.sol";
 import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
 import { IProxy } from "interfaces/universal/IProxy.sol";
-import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 
 contract DeployAltDA_Test is Test {
     DeployAltDA deployAltDA;

--- a/packages/contracts-bedrock/test/opcm/DeployAsterisc.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployAsterisc.t.sol
@@ -1,14 +1,15 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { Test } from "forge-std/Test.sol";
+// Testing
+import { Test } from "test/setup/Test.sol";
 
+// Scripts
 import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
+import { DeployAsterisc } from "scripts/deploy/DeployAsterisc.s.sol";
 
 // Interfaces
 import { IPreimageOracle } from "interfaces/cannon/IPreimageOracle.sol";
-
-import { DeployAsterisc } from "scripts/deploy/DeployAsterisc.s.sol";
 
 contract DeployAsterisc_Test is Test {
     DeployAsterisc deployAsterisc;

--- a/packages/contracts-bedrock/test/opcm/DeployDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployDisputeGame.t.sol
@@ -1,7 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { Test } from "forge-std/Test.sol";
+// Testing
+import { Test } from "test/setup/Test.sol";
+
+// Libraries
+import { LibPosition } from "src/dispute/lib/LibPosition.sol";
+import { GameType } from "src/dispute/lib/Types.sol";
+import { LibString } from "@solady/utils/LibString.sol";
 
 // Interfaces
 import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.sol";
@@ -13,7 +19,9 @@ import { IPreimageOracle } from "interfaces/cannon/IPreimageOracle.sol";
 import { LibPosition } from "src/dispute/lib/LibPosition.sol";
 import { GameType } from "src/dispute/lib/Types.sol";
 import { LibString } from "@solady/utils/LibString.sol";
+import { Config } from "scripts/libraries/Config.sol";
 
+// Contracts
 import { PreimageOracle } from "src/cannon/PreimageOracle.sol";
 import { DeployDisputeGame } from "scripts/deploy/DeployDisputeGame.s.sol";
 

--- a/packages/contracts-bedrock/test/opcm/DeployDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployDisputeGame.t.sol
@@ -19,7 +19,6 @@ import { IPreimageOracle } from "interfaces/cannon/IPreimageOracle.sol";
 import { LibPosition } from "src/dispute/lib/LibPosition.sol";
 import { GameType } from "src/dispute/lib/Types.sol";
 import { LibString } from "@solady/utils/LibString.sol";
-import { Config } from "scripts/libraries/Config.sol";
 
 // Contracts
 import { PreimageOracle } from "src/cannon/PreimageOracle.sol";

--- a/packages/contracts-bedrock/test/opcm/DeployFeesDepositor.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployFeesDepositor.t.sol
@@ -1,17 +1,21 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { Test } from "forge-std/Test.sol";
+// Testing
+import { Test } from "test/setup/Test.sol";
+import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
+
+// Scripts
+import { DeployFeesDepositor } from "scripts/deploy/DeployFeesDepositor.s.sol";
+
+// Contracts
+import { FeesDepositor } from "src/L1/FeesDepositor.sol";
+import { Proxy } from "src/universal/Proxy.sol";
 
 // Interfaces
 import { IFeesDepositor } from "interfaces/L1/IFeesDepositor.sol";
 import { IL1CrossDomainMessenger } from "interfaces/L1/IL1CrossDomainMessenger.sol";
 import { IProxy } from "interfaces/universal/IProxy.sol";
-
-import { DeployFeesDepositor } from "scripts/deploy/DeployFeesDepositor.s.sol";
-import { FeesDepositor } from "src/L1/FeesDepositor.sol";
-import { Proxy } from "src/universal/Proxy.sol";
-import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 
 /// @title DeployFeesDepositor_Test
 /// @notice This test is used to test the DeployFeesDepositor script.

--- a/packages/contracts-bedrock/test/opcm/DeployImplementations.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployImplementations.t.sol
@@ -2,7 +2,8 @@
 pragma solidity 0.8.15;
 
 // Testing
-import { Test, stdStorage, StdStorage } from "forge-std/Test.sol";
+import { Test } from "test/setup/Test.sol";
+import { stdStorage, StdStorage } from "forge-std/StdStorage.sol";
 import "../setup/FeatureFlags.sol";
 
 // Libraries

--- a/packages/contracts-bedrock/test/opcm/DeployMIPS2.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployMIPS2.t.sol
@@ -1,14 +1,18 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { Test } from "forge-std/Test.sol";
+// Testing
+import { Test } from "test/setup/Test.sol";
+
+// Scripts
+import { DeployMIPS2 } from "scripts/deploy/DeployMIPS2.s.sol";
+import { StandardConstants } from "scripts/deploy/StandardConstants.sol";
+
+// Contracts
+import { MIPS64 } from "src/cannon/MIPS64.sol";
 
 // Interfaces
 import { IPreimageOracle } from "interfaces/cannon/IPreimageOracle.sol";
-
-import { DeployMIPS2 } from "scripts/deploy/DeployMIPS2.s.sol";
-import { MIPS64 } from "src/cannon/MIPS64.sol";
-import { StandardConstants } from "scripts/deploy/StandardConstants.sol";
 
 contract DeployMIPS2_Test is Test {
     DeployMIPS2 deployMIPS;

--- a/packages/contracts-bedrock/test/opcm/DeployOPChain.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployOPChain.t.sol
@@ -1,16 +1,22 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { Test } from "forge-std/Test.sol";
+// Testing
+import { Test } from "test/setup/Test.sol";
 import { FeatureFlags } from "test/setup/FeatureFlags.sol";
-import { Features } from "src/libraries/Features.sol";
 
+// Scripts
 import { DeploySuperchain } from "scripts/deploy/DeploySuperchain.s.sol";
 import { DeployImplementations } from "scripts/deploy/DeployImplementations.s.sol";
 import { DeployOPChain } from "scripts/deploy/DeployOPChain.s.sol";
 import { StandardConstants } from "scripts/deploy/StandardConstants.sol";
 import { Types } from "scripts/libraries/Types.sol";
 
+// Libraries
+import { DevFeatures } from "src/libraries/DevFeatures.sol";
+import { Features } from "src/libraries/Features.sol";
+
+// Interfaces
 import { IOPContractsManager } from "interfaces/L1/IOPContractsManager.sol";
 import { Claim, Duration, GameType, GameTypes } from "src/dispute/lib/Types.sol";
 import { IPermissionedDisputeGame } from "interfaces/dispute/IPermissionedDisputeGame.sol";

--- a/packages/contracts-bedrock/test/opcm/DeployOPChain.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployOPChain.t.sol
@@ -13,7 +13,6 @@ import { StandardConstants } from "scripts/deploy/StandardConstants.sol";
 import { Types } from "scripts/libraries/Types.sol";
 
 // Libraries
-import { DevFeatures } from "src/libraries/DevFeatures.sol";
 import { Features } from "src/libraries/Features.sol";
 
 // Interfaces

--- a/packages/contracts-bedrock/test/opcm/DeploySuperchain.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeploySuperchain.t.sol
@@ -1,11 +1,17 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { Test } from "forge-std/Test.sol";
+// Testing
+import { Test } from "test/setup/Test.sol";
 
-import { Proxy } from "src/universal/Proxy.sol";
-import { ProtocolVersion } from "interfaces/L1/IProtocolVersions.sol";
+// Scripts
 import { DeploySuperchain } from "scripts/deploy/DeploySuperchain.s.sol";
+
+// Contracts
+import { Proxy } from "src/universal/Proxy.sol";
+
+// Interfaces
+import { ProtocolVersion } from "interfaces/L1/IProtocolVersions.sol";
 
 contract DeploySuperchain_Test is Test {
     DeploySuperchain deploySuperchain;

--- a/packages/contracts-bedrock/test/opcm/InteropMigration.t.sol
+++ b/packages/contracts-bedrock/test/opcm/InteropMigration.t.sol
@@ -1,13 +1,19 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { Test } from "forge-std/Test.sol";
+// Testing
+import { Test } from "test/setup/Test.sol";
 
+// Scripts
 import { InteropMigrationInput, InteropMigration, InteropMigrationOutput } from "scripts/deploy/InteropMigration.s.sol";
+
+// Libraries
+import { Claim } from "src/dispute/lib/Types.sol";
+
+// Interfaces
 import { IOPContractsManagerInteropMigrator, IOPContractsManager } from "interfaces/L1/IOPContractsManager.sol";
 import { IOptimismPortal2 as IOptimismPortal } from "interfaces/L1/IOptimismPortal2.sol";
 import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
-import { Claim } from "src/dispute/lib/Types.sol";
 
 contract InteropMigrationInput_Test is Test {
     InteropMigrationInput input;

--- a/packages/contracts-bedrock/test/opcm/SetDisputeGameImpl.t.sol
+++ b/packages/contracts-bedrock/test/opcm/SetDisputeGameImpl.t.sol
@@ -1,16 +1,25 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import { Test } from "forge-std/Test.sol";
-import { IDisputeGame } from "interfaces/dispute/IDisputeGame.sol";
-import { IDisputeGameFactory } from "interfaces/dispute/IDisputeGameFactory.sol";
-import { GameType, Proposal, Hash } from "src/dispute/lib/Types.sol";
+// Testing
+import { Test } from "test/setup/Test.sol";
+
+// Scripts
 import { SetDisputeGameImpl, SetDisputeGameImplInput } from "scripts/deploy/SetDisputeGameImpl.s.sol";
+
+// Contracts
 import { DisputeGameFactory } from "src/dispute/DisputeGameFactory.sol";
 import { Proxy } from "src/universal/Proxy.sol";
 import { SuperchainConfig } from "src/L1/SuperchainConfig.sol";
 import { AnchorStateRegistry } from "src/dispute/AnchorStateRegistry.sol";
 import { SystemConfig } from "src/L1/SystemConfig.sol";
+
+// Libraries
+import { GameType, Proposal, Hash } from "src/dispute/lib/Types.sol";
+
+// Interfaces
+import { IDisputeGame } from "interfaces/dispute/IDisputeGame.sol";
+import { IDisputeGameFactory } from "interfaces/dispute/IDisputeGameFactory.sol";
 import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
 import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.sol";
 import { IResourceMetering } from "interfaces/L1/IResourceMetering.sol";

--- a/packages/contracts-bedrock/test/opcm/UpgradeOPChain.t.sol
+++ b/packages/contracts-bedrock/test/opcm/UpgradeOPChain.t.sol
@@ -1,13 +1,20 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { Test } from "forge-std/Test.sol";
+// Testing
+import { Test } from "test/setup/Test.sol";
+
+// Scripts
+import { UpgradeOPChain, UpgradeOPChainInput } from "scripts/deploy/UpgradeOPChain.s.sol";
+
+// Contracts
+import { OPContractsManager } from "src/L1/OPContractsManager.sol";
+
+// Libraries
 import { Claim } from "src/dispute/lib/Types.sol";
 
+// Interfaces
 import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
-
-import { OPContractsManager } from "src/L1/OPContractsManager.sol";
-import { UpgradeOPChain, UpgradeOPChainInput } from "scripts/deploy/UpgradeOPChain.s.sol";
 
 contract UpgradeOPChainInput_Test is Test {
     UpgradeOPChainInput input;

--- a/packages/contracts-bedrock/test/opcm/UpgradeSuperchainConfig.t.sol
+++ b/packages/contracts-bedrock/test/opcm/UpgradeSuperchainConfig.t.sol
@@ -1,11 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { Test } from "forge-std/Test.sol";
+// Testing
+import { Test } from "test/setup/Test.sol";
 
-import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
-
+// Scripts
 import { UpgradeSuperchainConfig } from "scripts/deploy/UpgradeSuperchainConfig.s.sol";
+
+// Interfaces
+import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 import { IOPContractsManager } from "interfaces/L1/IOPContractsManager.sol";
 
 /// @title MockOPCM

--- a/packages/contracts-bedrock/test/periphery/AssetReceiver.t.sol
+++ b/packages/contracts-bedrock/test/periphery/AssetReceiver.t.sol
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-// Testing utilities
-import { Test } from "forge-std/Test.sol";
+// Testing
+import { Test } from "test/setup/Test.sol";
 import { TestERC20 } from "test/mocks/TestERC20.sol";
 import { TestERC721 } from "test/mocks/TestERC721.sol";
+
+// Contracts
 import { AssetReceiver } from "src/periphery/AssetReceiver.sol";
 
 /// @title AssetReceiver_TestInit

--- a/packages/contracts-bedrock/test/periphery/Transactor.t.sol
+++ b/packages/contracts-bedrock/test/periphery/Transactor.t.sol
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-// Testing utilities
-import { Test } from "forge-std/Test.sol";
+// Testing
+import { Test } from "test/setup/Test.sol";
+
+// Contracts
 import { Transactor } from "src/periphery/Transactor.sol";
 
 /// @title Transactor_TestInit

--- a/packages/contracts-bedrock/test/periphery/TransferOnion.t.sol
+++ b/packages/contracts-bedrock/test/periphery/TransferOnion.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-// Testing utilities
-import { Test } from "forge-std/Test.sol";
-import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+// Testing
+import { Test } from "test/setup/Test.sol";
 
-// Target contract
+// Contracts
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { TransferOnion } from "src/periphery/TransferOnion.sol";
 
 /// @title TransferOnion_TestInit

--- a/packages/contracts-bedrock/test/periphery/drippie/Drippie.t.sol
+++ b/packages/contracts-bedrock/test/periphery/drippie/Drippie.t.sol
@@ -1,11 +1,16 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { Test } from "forge-std/Test.sol";
-import { Drippie } from "src/periphery/drippie/Drippie.sol";
-import { IDripCheck } from "src/periphery/drippie/IDripCheck.sol";
-import { CheckTrue } from "src/periphery/drippie/dripchecks/CheckTrue.sol";
+// Testing
+import { Test } from "test/setup/Test.sol";
 import { SimpleStorage } from "test/mocks/SimpleStorage.sol";
+
+// Contracts
+import { Drippie } from "src/periphery/drippie/Drippie.sol";
+import { CheckTrue } from "src/periphery/drippie/dripchecks/CheckTrue.sol";
+
+// Interfaces
+import { IDripCheck } from "src/periphery/drippie/IDripCheck.sol";
 
 /// @title  TestDrippie
 /// @notice This is a wrapper contract around Drippie used for testing. Returning an entire

--- a/packages/contracts-bedrock/test/periphery/drippie/dripchecks/CheckBalanceLow.t.sol
+++ b/packages/contracts-bedrock/test/periphery/drippie/dripchecks/CheckBalanceLow.t.sol
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { Test } from "forge-std/Test.sol";
+// Testing
+import { Test } from "test/setup/Test.sol";
+
+// Contracts
 import { CheckBalanceLow } from "src/periphery/drippie/dripchecks/CheckBalanceLow.sol";
 
 /// @title CheckBalanceLow_TestInit

--- a/packages/contracts-bedrock/test/periphery/drippie/dripchecks/CheckSecrets.t.sol
+++ b/packages/contracts-bedrock/test/periphery/drippie/dripchecks/CheckSecrets.t.sol
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { Test } from "forge-std/Test.sol";
+// Testing
+import { Test } from "test/setup/Test.sol";
+
+// Contracts
 import { CheckSecrets } from "src/periphery/drippie/dripchecks/CheckSecrets.sol";
 
 /// @title CheckSecrets_TestInit

--- a/packages/contracts-bedrock/test/periphery/drippie/dripchecks/CheckTrue.t.sol
+++ b/packages/contracts-bedrock/test/periphery/drippie/dripchecks/CheckTrue.t.sol
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { Test } from "forge-std/Test.sol";
+// Testing
+import { Test } from "test/setup/Test.sol";
+
+// Contracts
 import { CheckTrue } from "src/periphery/drippie/dripchecks/CheckTrue.sol";
 
 /// @title CheckTrue_TestInit

--- a/packages/contracts-bedrock/test/periphery/faucet/Faucet.t.sol
+++ b/packages/contracts-bedrock/test/periphery/faucet/Faucet.t.sol
@@ -1,10 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { Test } from "forge-std/Test.sol";
+// Testing
+import { Test } from "test/setup/Test.sol";
+import { FaucetHelper } from "test/mocks/FaucetHelper.sol";
+
+// Contracts
 import { Faucet } from "src/periphery/faucet/Faucet.sol";
 import { AdminFaucetAuthModule } from "src/periphery/faucet/authmodules/AdminFaucetAuthModule.sol";
-import { FaucetHelper } from "test/mocks/FaucetHelper.sol";
 
 /// @title Faucet_TestInit
 /// @notice Reusable test initialization for `Faucet` tests.

--- a/packages/contracts-bedrock/test/periphery/faucet/authmodules/AdminFaucetAuthModule.t.sol
+++ b/packages/contracts-bedrock/test/periphery/faucet/authmodules/AdminFaucetAuthModule.t.sol
@@ -1,10 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { Test } from "forge-std/Test.sol";
+// Testing
+import { Test } from "test/setup/Test.sol";
+import { FaucetHelper } from "test/mocks/FaucetHelper.sol";
+
+// Contracts
 import { AdminFaucetAuthModule } from "src/periphery/faucet/authmodules/AdminFaucetAuthModule.sol";
 import { Faucet } from "src/periphery/faucet/Faucet.sol";
-import { FaucetHelper } from "test/mocks/FaucetHelper.sol";
 
 /// @title AdminFaucetAuthModule_TestInit
 /// @notice Reusable test initialization for `AdminFaucetAuthModule` tests.

--- a/packages/contracts-bedrock/test/safe-tools/SafeTestTools.sol
+++ b/packages/contracts-bedrock/test/safe-tools/SafeTestTools.sol
@@ -1,8 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.7.0 <0.9.0;
 
+// Forge
+import { console2 as console } from "forge-std/console2.sol";
+import { Vm } from "forge-std/Vm.sol";
+
 // Testing
-import { Test } from "test/setup/Test.sol";
 import "./CompatibilityFallbackHandler_1_3_0.sol";
 
 // Contracts

--- a/packages/contracts-bedrock/test/safe-tools/SafeTestTools.sol
+++ b/packages/contracts-bedrock/test/safe-tools/SafeTestTools.sol
@@ -1,16 +1,21 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.7.0 <0.9.0;
 
-import "forge-std/Test.sol";
-import { LibSort } from "@solady/utils/LibSort.sol";
+// Testing
+import { Test } from "test/setup/Test.sol";
+import "./CompatibilityFallbackHandler_1_3_0.sol";
+
+// Contracts
 import { Safe as GnosisSafe } from "safe-contracts/Safe.sol";
+import { SafeProxyFactory as GnosisSafeProxyFactory } from "safe-contracts/proxies/SafeProxyFactory.sol";
+import { SignMessageLib } from "safe-contracts/libraries/SignMessageLib.sol";
+
+// Libraries
+import { LibSort } from "@solady/utils/LibSort.sol";
 import { OwnerManager } from "safe-contracts/base/OwnerManager.sol";
 import { ModuleManager } from "safe-contracts/base/ModuleManager.sol";
 import { GuardManager } from "safe-contracts/base/GuardManager.sol";
-import { SafeProxyFactory as GnosisSafeProxyFactory } from "safe-contracts/proxies/SafeProxyFactory.sol";
 import { Enum } from "safe-contracts/common/Enum.sol";
-import { SignMessageLib } from "safe-contracts/libraries/SignMessageLib.sol";
-import "./CompatibilityFallbackHandler_1_3_0.sol";
 
 // Tools to simplify testing Safe contracts
 // Author: Colin Nielsen (https://github.com/colinnielsen/safe-tools)

--- a/packages/contracts-bedrock/test/safe/LivenessGuard.t.sol
+++ b/packages/contracts-bedrock/test/safe/LivenessGuard.t.sol
@@ -3,8 +3,6 @@ pragma solidity 0.8.15;
 
 // Testing
 import { Test } from "test/setup/Test.sol";
-import { StdUtils } from "forge-std/StdUtils.sol";
-import { StdCheats } from "forge-std/StdCheats.sol";
 import "test/safe-tools/SafeTestTools.sol";
 
 // Contracts
@@ -169,7 +167,7 @@ contract LivenessGuard_ShowLiveness_Test is LivenessGuard_TestInit {
 /// @title LivenessGuard_Uncategorized_Test
 /// @notice General tests that are not testing any function directly of the `LivenessGuard`
 ///         contract or are testing multiple functions at once.
-contract LivenessGuard_Uncategorized_Test is StdCheats, StdUtils, LivenessGuard_TestInit {
+contract LivenessGuard_Uncategorized_Test is LivenessGuard_TestInit {
     using SafeTestLib for SafeInstance;
 
     /// @notice Enumerates the possible owner management operations

--- a/packages/contracts-bedrock/test/safe/LivenessGuard.t.sol
+++ b/packages/contracts-bedrock/test/safe/LivenessGuard.t.sol
@@ -1,16 +1,20 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { Test } from "forge-std/Test.sol";
+// Testing
+import { Test } from "test/setup/Test.sol";
 import { StdUtils } from "forge-std/StdUtils.sol";
 import { StdCheats } from "forge-std/StdCheats.sol";
+import "test/safe-tools/SafeTestTools.sol";
+
+// Contracts
 import { Safe } from "safe-contracts/Safe.sol";
+import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+import { LivenessGuard } from "src/safe/LivenessGuard.sol";
+
+// Libraries
 import { OwnerManager } from "safe-contracts/base/OwnerManager.sol";
 import { Enum } from "safe-contracts/common/Enum.sol";
-import "test/safe-tools/SafeTestTools.sol";
-import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
-
-import { LivenessGuard } from "src/safe/LivenessGuard.sol";
 
 /// @notice A wrapper contract exposing the length of the ownersBefore set in the LivenessGuard.
 contract LivenessGuard_WrappedGuard_Harness is LivenessGuard {

--- a/packages/contracts-bedrock/test/safe/LivenessModule.t.sol
+++ b/packages/contracts-bedrock/test/safe/LivenessModule.t.sol
@@ -1,13 +1,17 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { Test } from "forge-std/Test.sol";
-import { Safe } from "safe-contracts/Safe.sol";
-import { OwnerManager } from "safe-contracts/base/OwnerManager.sol";
+// Testing
+import { Test } from "test/setup/Test.sol";
 import "test/safe-tools/SafeTestTools.sol";
 
+// Contracts
+import { Safe } from "safe-contracts/Safe.sol";
 import { LivenessModule } from "src/safe/LivenessModule.sol";
 import { LivenessGuard } from "src/safe/LivenessGuard.sol";
+
+// Libraries
+import { OwnerManager } from "safe-contracts/base/OwnerManager.sol";
 
 /// @title LivenessModule_TestInit
 /// @notice Reusable test initialization for `LivenessModule` tests.

--- a/packages/contracts-bedrock/test/safe/LivenessModule2.t.sol
+++ b/packages/contracts-bedrock/test/safe/LivenessModule2.t.sol
@@ -1,17 +1,21 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { Test } from "forge-std/Test.sol";
-import { Enum } from "safe-contracts/common/Enum.sol";
-import { Safe } from "safe-contracts/Safe.sol";
+// Testing
+import { Test } from "test/setup/Test.sol";
 import "test/safe-tools/SafeTestTools.sol";
-import { Constants } from "src/libraries/Constants.sol";
+import { DummyGuard } from "test/mocks/DummyGuard.sol";
 
+// Contracts
+import { Safe } from "safe-contracts/Safe.sol";
 import { LivenessModule2 } from "src/safe/LivenessModule2.sol";
 import { SaferSafes } from "src/safe/SaferSafes.sol";
+
+// Libraries
+import { Enum } from "safe-contracts/common/Enum.sol";
+import { Constants } from "src/libraries/Constants.sol";
 import { ModuleManager } from "safe-contracts/base/ModuleManager.sol";
 import { GuardManager } from "safe-contracts/base/GuardManager.sol";
-import { DummyGuard } from "test/mocks/DummyGuard.sol";
 
 /// @title LivenessModule2_TestUtils
 /// @notice Reusable helper methods for LivenessModule2 tests.

--- a/packages/contracts-bedrock/test/safe/SafeSigners.t.sol
+++ b/packages/contracts-bedrock/test/safe/SafeSigners.t.sol
@@ -1,9 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { Test } from "forge-std/Test.sol";
-import { SafeSigners } from "src/safe/SafeSigners.sol";
+// Testing
+import { Test } from "test/setup/Test.sol";
 import "test/safe-tools/SafeTestTools.sol";
+
+// Contracts
+import { SafeSigners } from "src/safe/SafeSigners.sol";
 
 /// @title SafeSigners_TestInit
 /// @notice Reusable test initialization for `SafeSigners` tests.

--- a/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
+++ b/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
@@ -2,8 +2,9 @@
 pragma solidity 0.8.15;
 
 // Testing
-import { Test } from "test/setup/Test.sol";
 import "test/safe-tools/SafeTestTools.sol";
+import { Test } from "test/setup/Test.sol";
+import { stdStorage, StdStorage } from "forge-std/StdStorage.sol";
 
 // Contracts
 import { Safe } from "safe-contracts/Safe.sol";

--- a/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
+++ b/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
@@ -1,14 +1,20 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { Test } from "forge-std/Test.sol";
-import { Safe } from "safe-contracts/Safe.sol";
-import { GuardManager } from "safe-contracts/base/GuardManager.sol";
-import { ITransactionGuard } from "interfaces/safe/ITransactionGuard.sol";
+// Testing
+import { Test } from "test/setup/Test.sol";
 import "test/safe-tools/SafeTestTools.sol";
 
+// Contracts
+import { Safe } from "safe-contracts/Safe.sol";
 import { TimelockGuard } from "src/safe/TimelockGuard.sol";
 import { SaferSafes } from "src/safe/SaferSafes.sol";
+
+// Libraries
+import { GuardManager } from "safe-contracts/base/GuardManager.sol";
+
+// Interfaces
+import { ITransactionGuard } from "interfaces/safe/ITransactionGuard.sol";
 
 using TransactionBuilder for TransactionBuilder.Transaction;
 

--- a/packages/contracts-bedrock/test/scripts/DeployOwnership.t.sol
+++ b/packages/contracts-bedrock/test/scripts/DeployOwnership.t.sol
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Forge
+import { StdCheatsSafe } from "forge-std/StdCheats.sol";
+
 // Testing
 import { Test } from "test/setup/Test.sol";
 
@@ -25,6 +28,10 @@ contract DeployOwnershipTest is Test, DeployOwnership {
     function setUp() public override {
         super.setUp();
         run();
+    }
+
+    function makeAddr(string memory _name) internal override(Test, StdCheatsSafe) returns (address) {
+        return Test.makeAddr(_name);
     }
 
     /// @dev Helper function to make assertions on basic Safe config properties.

--- a/packages/contracts-bedrock/test/scripts/DeployOwnership.t.sol
+++ b/packages/contracts-bedrock/test/scripts/DeployOwnership.t.sol
@@ -1,18 +1,23 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
+// Testing
+import { Test } from "test/setup/Test.sol";
+
+// Scripts
 import {
     DeployOwnership,
     SafeConfig,
     SecurityCouncilConfig,
     LivenessModuleConfig
 } from "scripts/deploy/DeployOwnership.s.sol";
-import { Test } from "forge-std/Test.sol";
 
+// Contracts
 import { Safe } from "safe-contracts/Safe.sol";
-import { ModuleManager } from "safe-contracts/base/ModuleManager.sol";
-
 import { LivenessModule2 } from "src/safe/LivenessModule2.sol";
+
+// Libraries
+import { ModuleManager } from "safe-contracts/base/ModuleManager.sol";
 
 contract DeployOwnershipTest is Test, DeployOwnership {
     address internal constant SENTINEL_MODULES = address(0x1);

--- a/packages/contracts-bedrock/test/scripts/FetchChainInfo.t.sol
+++ b/packages/contracts-bedrock/test/scripts/FetchChainInfo.t.sol
@@ -1,8 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import { Test } from "forge-std/Test.sol";
+// Testing
+import { Test } from "test/setup/Test.sol";
+
+// Scripts
 import { FetchChainInfo, FetchChainInfoInput, FetchChainInfoOutput } from "scripts/FetchChainInfo.s.sol";
+
+// Libraries
 import { GameTypes, GameType } from "src/dispute/lib/Types.sol";
 import { LibGameType } from "src/dispute/lib/LibUDT.sol";
 

--- a/packages/contracts-bedrock/test/scripts/L2Genesis.t.sol
+++ b/packages/contracts-bedrock/test/scripts/L2Genesis.t.sol
@@ -1,11 +1,18 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { Test } from "forge-std/Test.sol";
+// Testing
+import { Test } from "test/setup/Test.sol";
 import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
+
+// Scripts
 import { L2Genesis } from "scripts/L2Genesis.s.sol";
-import { Predeploys } from "src/libraries/Predeploys.sol";
 import { LATEST_FORK } from "scripts/libraries/Config.sol";
+
+// Libraries
+import { Predeploys } from "src/libraries/Predeploys.sol";
+
+// Interfaces
 import { ISuperchainRevSharesCalculator } from "interfaces/L2/ISuperchainRevSharesCalculator.sol";
 import { ISequencerFeeVault } from "interfaces/L2/ISequencerFeeVault.sol";
 import { IBaseFeeVault } from "interfaces/L2/IBaseFeeVault.sol";

--- a/packages/contracts-bedrock/test/setup/CommonTest.sol
+++ b/packages/contracts-bedrock/test/setup/CommonTest.sol
@@ -1,10 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-// Forge
-import { Test } from "forge-std/Test.sol";
-
 // Testing
+import { Test } from "test/setup/Test.sol";
 import { Setup } from "test/setup/Setup.sol";
 import { Events } from "test/setup/Events.sol";
 import { FFIInterface } from "test/setup/FFIInterface.sol";

--- a/packages/contracts-bedrock/test/setup/Test.sol
+++ b/packages/contracts-bedrock/test/setup/Test.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+// Forge
+import { Test as ForgeTest } from "forge-std/Test.sol";
+
+/// @title Test
+/// @notice Test is a minimal extension of the Test contract with op-specific tweaks.
+abstract contract Test is ForgeTest {
+    /// @notice Makes an address without a private key, labels it, and cleans it.
+    /// @param _name The name of the address.
+    /// @return The address.
+    function makeAddr(string memory _name) public override returns (address) {
+        address addr = address(uint160(uint256(keccak256(abi.encode(_name)))));
+        destroyAccount(addr, address(0));
+        vm.label(addr, _name);
+        return addr;
+    }
+}

--- a/packages/contracts-bedrock/test/setup/Test.sol
+++ b/packages/contracts-bedrock/test/setup/Test.sol
@@ -10,7 +10,7 @@ abstract contract Test is ForgeTest {
     /// @notice Makes an address without a private key, labels it, and cleans it.
     /// @param _name The name of the address.
     /// @return The address.
-    function makeAddr(string memory _name) public override returns (address) {
+    function makeAddr(string memory _name) internal virtual override returns (address) {
         address addr = address(uint160(uint256(keccak256(abi.encode(_name)))));
         destroyAccount(addr, address(0));
         vm.label(addr, _name);

--- a/packages/contracts-bedrock/test/universal/CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/universal/CrossDomainMessenger.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-// Testing utilities
-import { Test } from "forge-std/Test.sol";
+// Testing
+import { Test } from "test/setup/Test.sol";
 import { CommonTest } from "test/setup/CommonTest.sol";
 
 // Libraries

--- a/packages/contracts-bedrock/test/universal/Proxy.t.sol
+++ b/packages/contracts-bedrock/test/universal/Proxy.t.sol
@@ -1,10 +1,17 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { Test } from "forge-std/Test.sol";
-import { Bytes32AddressLib } from "@rari-capital/solmate/src/utils/Bytes32AddressLib.sol";
-import { IProxy } from "interfaces/universal/IProxy.sol";
+// Testing
+import { Test } from "test/setup/Test.sol";
+
+// Scripts
 import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
+
+// Libraries
+import { Bytes32AddressLib } from "@rari-capital/solmate/src/utils/Bytes32AddressLib.sol";
+
+// Interfaces
+import { IProxy } from "interfaces/universal/IProxy.sol";
 
 contract Proxy_SimpleStorage_Harness {
     mapping(uint256 => uint256) internal store;

--- a/packages/contracts-bedrock/test/universal/ProxyAdmin.t.sol
+++ b/packages/contracts-bedrock/test/universal/ProxyAdmin.t.sol
@@ -2,8 +2,11 @@
 pragma solidity 0.8.15;
 
 // Testing
-import { Test } from "forge-std/Test.sol";
+import { Test } from "test/setup/Test.sol";
 import { Proxy_SimpleStorage_Harness } from "test/universal/Proxy.t.sol";
+
+// Scripts
+import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 
 // Interfaces
 import { IAddressManager } from "interfaces/legacy/IAddressManager.sol";
@@ -11,8 +14,6 @@ import { IL1ChugSplashProxy } from "interfaces/legacy/IL1ChugSplashProxy.sol";
 import { IResolvedDelegateProxy } from "interfaces/legacy/IResolvedDelegateProxy.sol";
 import { IProxy } from "interfaces/universal/IProxy.sol";
 import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
-
-import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 
 /// @title ProxyAdmin_TestInit
 /// @notice Reusable test initialization for `ProxyAdmin` tests.

--- a/packages/contracts-bedrock/test/universal/ReinitializableBase.t.sol
+++ b/packages/contracts-bedrock/test/universal/ReinitializableBase.t.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.15;
 
 // Testing
-import { Test } from "forge-std/Test.sol";
+import { Test } from "test/setup/Test.sol";
 
 // Contracts
 import { ReinitializableBase } from "src/universal/ReinitializableBase.sol";

--- a/packages/contracts-bedrock/test/universal/WETH98.t.sol
+++ b/packages/contracts-bedrock/test/universal/WETH98.t.sol
@@ -2,11 +2,13 @@
 pragma solidity 0.8.15;
 
 // Testing
-import { Test } from "forge-std/Test.sol";
+import { Test } from "test/setup/Test.sol";
 
-// Contracts
-import { IWETH98 } from "interfaces/universal/IWETH98.sol";
+// Scripts
 import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
+
+// Interfaces
+import { IWETH98 } from "interfaces/universal/IWETH98.sol";
 
 /// @title WETH98_TestInit
 /// @notice Reusable test initialization for `WETH98` tests.

--- a/packages/contracts-bedrock/test/vendor/AddressAliasHelper.t.sol
+++ b/packages/contracts-bedrock/test/vendor/AddressAliasHelper.t.sol
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { Test } from "forge-std/Test.sol";
+// Testing
+import { Test } from "test/setup/Test.sol";
+
+// Libraries
 import { AddressAliasHelper } from "src/vendor/AddressAliasHelper.sol";
 
 /// @title AddressAliasHelper_ApplyL1ToL2Alias_Test

--- a/packages/contracts-bedrock/test/vendor/InitializableOZv5.t.sol
+++ b/packages/contracts-bedrock/test/vendor/InitializableOZv5.t.sol
@@ -1,12 +1,21 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.25;
 
-import { Test } from "forge-std/Test.sol";
-import { IOptimismSuperchainERC20 } from "interfaces/L2/IOptimismSuperchainERC20.sol";
-import { Initializable } from "@openzeppelin/contracts-v5/proxy/utils/Initializable.sol";
+// Testing
+import { Test } from "test/setup/Test.sol";
+
+// Scripts
 import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
-import { IFeeVault } from "interfaces/L2/IFeeVault.sol";
+
+// Contracts
+import { Initializable } from "@openzeppelin/contracts-v5/proxy/utils/Initializable.sol";
+
+// Libraries
 import { Types } from "src/libraries/Types.sol";
+
+// Interfaces
+import { IOptimismSuperchainERC20 } from "interfaces/L2/IOptimismSuperchainERC20.sol";
+import { IFeeVault } from "interfaces/L2/IFeeVault.sol";
 
 /// @title InitializerOZv5_Test
 /// @dev Ensures that the `initialize()` function on contracts cannot be called more than


### PR DESCRIPTION
This PR introduces a light wrapper around the forge Test contract specifically for the purpose of making sure people are using a version of makeAddr that will always be reproducible. Without this makeAddr uses a private key which means that fork tests can be unreliable if people mess with these addresses on mainnet.
