### PR TITLE
flake: Flush Pipeline Prior to Tx Planning

### DIFF
--- a/op-e2e/actions/interop/interop_msg_test.go
+++ b/op-e2e/actions/interop/interop_msg_test.go
@@ -488,6 +488,8 @@ func TestBreakTimestampInvariant(gt *testing.T) {
 	// chain A progressed single unsafe block
 	eventLoggerAddress := DeployEventLogger(t, optsA)
 
+	actors.ChainA.Sequencer.ActL2PipelineFull(t)
+
 	// Intent to initiate message(or emit event) on chain A
 	txA := txintent.NewIntent[*txintent.InitTrigger, *txintent.InteropOutput](optsA)
 	randomInitTrigger := interop.RandomInitTrigger(rng, eventLoggerAddress, 3, 10)


### PR DESCRIPTION
Fixes: https://github.com/ethereum-optimism/optimism/issues/18137

Based on the line number in the failure provided, looks like things fail early on, and since it's a nonce issue, I'm pretty sure it's just a matter of ensuring the first transaction is flushed before planning happens on the second one.

I couldn't repro the failure locally but I'll upload this PR and see if we see anything.