### PR TITLE
fix: Full checkout for FFI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -931,7 +931,7 @@ jobs:
         default: ""
     steps:
       - utils/checkout-with-mise:
-          checkout-method: blobless
+          checkout-method: full
       - install-zstd
       - run:
           name: Check if test list is empty
@@ -995,7 +995,7 @@ jobs:
     resource_class: 2xlarge
     steps:
       - utils/checkout-with-mise:
-          checkout-method: blobless
+          checkout-method: full
       - install-contracts-dependencies
       - install-zstd
       - run:
@@ -1091,7 +1091,7 @@ jobs:
         default: ""
     steps:
       - utils/checkout-with-mise:
-          checkout-method: blobless
+          checkout-method: full
       - install-contracts-dependencies
       - install-zstd
       - attach_workspace:


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

the FFI build fails with blobless checkouts, this reintroduces `full` checkout for affected builds