### PR TITLE
chore(ai-eng): add ReinitializableBase test to exclusion list

### DIFF
--- a/ops/ai-eng/contracts-test-maintenance/exclusion.toml
+++ b/ops/ai-eng/contracts-test-maintenance/exclusion.toml
@@ -22,5 +22,6 @@ files = [
     "test/universal/BenchmarkTest.t.sol",
     "test/universal/ExtendedPause.t.sol",
     "test/vendor/Initializable.t.sol",
-    "test/vendor/InitializableOZv5.t.sol"
+    "test/vendor/InitializableOZv5.t.sol",
+    "test/universal/ReinitializableBase.t.sol"
 ]


### PR DESCRIPTION
This PR adds `ReinitializableBase.t.sol` to the static exclusions list to prevent it from blocking the AI test maintenance system while a permanent solution is developed.

### Reason

The AI test maintenance system has consistently selected `ReinitializableBase.t.sol` as the highest-priority test during Monday/Thursday runs, even though it already has comprehensive coverage and requires no improvements. This causes the system to fail each run when it determines no changes are needed, blocking progress on other tests that could benefit from automated maintenance. This is a temporary fix while we develop the `no_changes_needed` exclusion group with automatic re-evaluation logic.

### Changes

- Add `test/universal/ReinitializableBase.t.sol` to the static files exclusion list in exclusion.toml