### PR TITLE
op-deployer: Fix error handling in add_game_type CLI parsing. (#18026)

### DIFF
--- a/op-deployer/pkg/deployer/manage/add_game_type.go
+++ b/op-deployer/pkg/deployer/manage/add_game_type.go
@@ -150,10 +150,9 @@ func AddGameTypeCLI(cliCtx *cli.Context) error {
 
 	initialBond, err := cliutil.BigIntFlag(cliCtx, InitialBondFlag.Name)
 	if err != nil {
-		cfg.InitialBond = initialBond
-	} else {
 		return fmt.Errorf("failed to parse initial bond: %w", err)
 	}
+	cfg.InitialBond = initialBond
 
 	if err := cfg.Check(); err != nil {
 		return fmt.Errorf("invalid config: %w", err)


### PR DESCRIPTION
Previously it exited with an error message when there was no error.

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Backport of `add-game-type` CLI validaton fix #18026 to `op-deployer` v0.4.x

Related to https://github.com/ethereum-optimism/platforms-team/issues/1119