### PR TITLE
chore: Backport #18543 to `op-deployer` v4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -712,6 +712,8 @@ jobs:
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
+      - attach_workspace:
+          at: .
       - run:
           command: mkdir -p /tmp/docker_images
       - when:


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Backports #18543 to `op-deployer` v4