### PR TITLE
op-batcher [altda]: configurable multiple frames per tx

### DIFF
--- a/op-batcher/batcher/channel.go
+++ b/op-batcher/batcher/channel.go
@@ -133,7 +133,7 @@ func (c *channel) NextTxData() txData {
 
 func (c *channel) HasTxData() bool {
 	if c.IsFull() || // If the channel is full, we should start to submit it
-		!c.cfg.UseBlobs { // If using calldata, we only send one frame per tx
+		!c.cfg.UseBlobs && !c.cfg.MultiFrame { // If not using blobs or multiframe, we only send one frame per tx
 		return c.HasPendingFrame()
 	}
 	// Collect enough frames if channel is not full yet

--- a/op-batcher/batcher/channel_config.go
+++ b/op-batcher/batcher/channel_config.go
@@ -49,6 +49,10 @@ type ChannelConfig struct {
 	// UseBlobs indicates that this channel should be sent as a multi-blob
 	// transaction with one blob per frame.
 	UseBlobs bool
+
+	// MultiFrame indicates that this channel should be sent as a multi-frame
+	// transaction with one frame per blob.
+	MultiFrame bool
 }
 
 // ChannelConfig returns a copy of the receiver.
@@ -93,7 +97,7 @@ func (cc *ChannelConfig) ReinitCompressorConfig() {
 }
 
 func (cc *ChannelConfig) MaxFramesPerTx() int {
-	if !cc.UseBlobs {
+	if !cc.UseBlobs || !cc.MultiFrame {
 		return 1
 	}
 	return cc.TargetNumFrames

--- a/op-batcher/batcher/config.go
+++ b/op-batcher/batcher/config.go
@@ -104,6 +104,9 @@ type CLIConfig struct {
 	// Maximum number of blocks to add to a span batch. Default is 0 - no maximum.
 	MaxBlocksPerSpanBatch int
 
+	// MultiFrame controls whether to put all frames of a channel inside a single tx.
+	MultiFrame bool
+
 	// The target number of frames to create per channel. Controls number of blobs
 	// per blob tx, if using Blob DA.
 	TargetNumFrames int
@@ -232,6 +235,7 @@ func NewConfig(ctx *cli.Context) *CLIConfig {
 		MaxChannelDuration:           ctx.Uint64(flags.MaxChannelDurationFlag.Name),
 		MaxL1TxSize:                  ctx.Uint64(flags.MaxL1TxSizeBytesFlag.Name),
 		MaxBlocksPerSpanBatch:        ctx.Int(flags.MaxBlocksPerSpanBatch.Name),
+		MultiFrame:                   ctx.Bool(flags.MultiFrameTxsFlag.Name),
 		TargetNumFrames:              ctx.Int(flags.TargetNumFramesFlag.Name),
 		ApproxComprRatio:             ctx.Float64(flags.ApproxComprRatioFlag.Name),
 		Compressor:                   ctx.String(flags.CompressorFlag.Name),

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -914,7 +914,13 @@ func (l *BatchSubmitter) cancelBlockingTx(queue *txmgr.Queue[txRef], receiptsCh 
 // publishToAltDAAndL1 posts the txdata to the DA Provider and then sends the commitment to L1.
 func (l *BatchSubmitter) publishToAltDAAndL1(txdata txData, queue *txmgr.Queue[txRef], receiptsCh chan txmgr.TxReceipt[txRef], daGroup *errgroup.Group) {
 	// sanity checks
-	if nf := len(txdata.frames); nf != 1 {
+	_, isPectra, err := l.l1Tip(context.Background())
+	if err != nil {
+		l.Log.Error("Failed to query L1 tip", "err", err)
+		return
+	}
+	_, params := l.throttleController.Load()
+	if nf := len(txdata.frames); nf > l.ChannelConfig.ChannelConfig(isPectra, params.IsThrottling()).TargetNumFrames {
 		l.Log.Crit("Unexpected number of frames in calldata tx", "num_frames", nf)
 	}
 	if txdata.asBlob {

--- a/op-batcher/batcher/service.go
+++ b/op-batcher/batcher/service.go
@@ -270,6 +270,10 @@ func (bs *BatcherService) initChannelConfig(cfg *CLIConfig) error {
 		BatchType:             cfg.BatchType,
 	}
 
+	if cfg.MultiFrame {
+		cc.MultiFrame = true
+	}
+
 	switch cfg.DataAvailabilityType {
 	case flags.BlobsType, flags.AutoType:
 		if !cfg.TestUseMaxTxSizeForBlobs {

--- a/op-batcher/flags/flags.go
+++ b/op-batcher/flags/flags.go
@@ -83,6 +83,12 @@ var (
 		Usage:   "Maximum number of blocks to add to a span batch. Default is 0 - no maximum.",
 		EnvVars: prefixEnvVars("MAX_BLOCKS_PER_SPAN_BATCH"),
 	}
+	MultiFrameTxsFlag = &cli.BoolFlag{
+		Name:    "multi-frame-txs",
+		Usage:   "Whether to put all frames of a channel inside a single tx. Ignored for blobs, where true will be used.",
+		Value:   false,
+		EnvVars: prefixEnvVars("MULTI_FRAME_TXS"),
+	}
 	TargetNumFramesFlag = &cli.IntFlag{
 		Name:    "target-num-frames",
 		Usage:   "The target number of frames to create per channel. Controls number of blobs per blob tx, if using Blob DA.",
@@ -178,6 +184,7 @@ var optionalFlags = []cli.Flag{
 	MaxChannelDurationFlag,
 	MaxL1TxSizeBytesFlag,
 	MaxBlocksPerSpanBatch,
+	MultiFrameTxsFlag,
 	TargetNumFramesFlag,
 	ApproxComprRatioFlag,
 	CompressorFlag,


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

This PR allows the number of frames per op-batcher altda transaction to be configurable via the CLI flag `--multi-frame-txs`.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->

Fixes #18508 
