### PR TITLE
op-node/recover-mode: handle l1 origin close to tip gracefully

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,4 +1,3 @@
-@include 
 # Checks that TODO comments have corresponding issues.
 todo-checker:
   ./ops/scripts/todo-checker.sh
@@ -40,7 +39,3 @@ update-op-geth ref:
 	go mod edit -replace=github.com/ethereum/go-ethereum=github.com/ethereum-optimism/op-geth@"$ver"; \
 	go mod tidy; \
 	echo "Updated op-geth to $ver"
-
-
-build-contracts:
-    JUSTFILE=$(pwd)/packages/contracts-bedrock/justfile just build-dev

--- a/justfile
+++ b/justfile
@@ -1,3 +1,4 @@
+@include 
 # Checks that TODO comments have corresponding issues.
 todo-checker:
   ./ops/scripts/todo-checker.sh
@@ -40,3 +41,6 @@ update-op-geth ref:
 	go mod tidy; \
 	echo "Updated op-geth to $ver"
 
+
+build-contracts:
+    JUSTFILE=$(pwd)/packages/contracts-bedrock/justfile just build-dev

--- a/op-acceptance-tests/tests/sequencer/init_test.go
+++ b/op-acceptance-tests/tests/sequencer/init_test.go
@@ -1,6 +1,7 @@
 package sequencer
 
 import (
+	"log/slog"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/compat"
@@ -11,5 +12,6 @@ import (
 func TestMain(m *testing.M) {
 	presets.DoMain(m, presets.WithMinimal(),
 		presets.WithCompatibleTypes(compat.SysGo),
+		presets.WithLogLevel(slog.LevelDebug),
 	)
 }

--- a/op-acceptance-tests/tests/sequencer/init_test.go
+++ b/op-acceptance-tests/tests/sequencer/init_test.go
@@ -1,0 +1,15 @@
+package sequencer
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/compat"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+)
+
+// TestMain creates the test-setups against the shared backend
+func TestMain(m *testing.M) {
+	presets.DoMain(m, presets.WithMinimal(),
+		presets.WithCompatibleTypes(compat.SysGo),
+	)
+}

--- a/op-acceptance-tests/tests/sequencer/recover_mode_test.go
+++ b/op-acceptance-tests/tests/sequencer/recover_mode_test.go
@@ -1,0 +1,44 @@
+package sequencer
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRecoverModeWhenChainHealthy checks that the chain
+// can progress as normal when recover mode is activated.
+// Recover mode is designed to recover from a sequencing
+// window expiry when there are ample L1 blocks to eagerly
+// progress the l1 origin to. But when the l1 origin is
+// close to the tip of the l1 chain, the eagerness would cause
+// a delay in unsafe block production while the sequencer waits
+// for the next l1 origin to become available. Recover mode
+// has since been patched, and the sequencer will not demand the
+// next l1 origin until it is actually available. This tests
+// protects against a regeression in that behavior.
+func TestRecoverModeWhenChainHealthy(gt *testing.T) {
+	t := devtest.ParallelT(gt)
+	sys := presets.NewMinimal(t)
+	tracer := t.Tracer()
+	ctx := t.Ctx()
+
+	sys.L2CL.SetSequencerRecoverMode(true)
+	blockTime := sys.L2Chain.Escape().RollupConfig().BlockTime
+	numL2Blocks := uint64(20)
+	waitTime := time.Duration(blockTime*numL2Blocks+5) * time.Second
+
+	num := sys.L2CL.SyncStatus().UnsafeL2.Number
+	new_num := num
+	require.Eventually(t, func() bool {
+		ctx, span := tracer.Start(ctx, "check head")
+		defer span.End()
+
+		new_num, num = sys.L2CL.SyncStatus().UnsafeL2.Number, new_num
+		t.Logger().InfoContext(ctx, "unsafe head", "number", new_num, "safe head", sys.L2CL.SyncStatus().SafeL2.Number)
+		return new_num >= numL2Blocks
+	}, waitTime, time.Duration(blockTime)*time.Second)
+}

--- a/op-devstack/dsl/l2_cl.go
+++ b/op-devstack/dsl/l2_cl.go
@@ -91,6 +91,10 @@ func (cl *L2CLNode) StopSequencer() common.Hash {
 	return unsafeHead
 }
 
+func (cl *L2CLNode) SetSequencerRecoverMode(b bool) error {
+	return cl.inner.RollupAPI().SetRecoverMode(cl.ctx, b)
+}
+
 func (cl *L2CLNode) SyncStatus() *eth.SyncStatus {
 	ctx, cancel := context.WithTimeout(cl.ctx, DefaultTimeout)
 	defer cancel()

--- a/op-e2e/actions/helpers/l2_batcher.go
+++ b/op-e2e/actions/helpers/l2_batcher.go
@@ -270,7 +270,7 @@ func (s *L2Batcher) Buffer(t Testing, bufferOpts ...BufferOption) error {
 		}
 	}
 
-	s.ActCreateChannel(t, s.rollupCfg.IsDelta(block.Time()), options.channelModifiers...)
+	s.ActCreateChannel(t, s.rollupCfg.IsDelta(block.Time()) && !s.l2BatcherCfg.ForceSubmitSingularBatch, options.channelModifiers...)
 
 	if _, err := s.L2ChannelOut.AddBlock(s.rollupCfg, block); err != nil {
 		return err

--- a/op-e2e/actions/helpers/l2_sequencer.go
+++ b/op-e2e/actions/helpers/l2_sequencer.go
@@ -40,8 +40,8 @@ func (m *MockL1OriginSelector) FindL1Origin(ctx context.Context, l2Head eth.L2Bl
 	return m.actual.FindL1Origin(ctx, l2Head)
 }
 
-func (m *MockL1OriginSelector) SetRecoverMode(bool) {
-	// noop
+func (m *MockL1OriginSelector) SetRecoverMode(b bool) {
+	m.actual.SetRecoverMode(b)
 }
 
 // L2Sequencer is an actor that functions like a rollup node,
@@ -87,6 +87,7 @@ func NewL2Sequencer(t Testing, log log.Logger, l1 derive.L1Fetcher, blobSrc deri
 	ver.eventSys.Register("sequencer", seq, opts)
 	ver.eventSys.Register("origin-selector", originSelector, opts)
 	require.NoError(t, seq.Init(t.Ctx(), true))
+
 	return &L2Sequencer{
 		L2Verifier:              ver,
 		sequencer:               seq,
@@ -271,4 +272,8 @@ func (s *L2Sequencer) ActBuildL2ToInterop(t Testing) {
 	for s.L2Unsafe().Time < *s.RollupCfg.InteropTime {
 		s.ActL2EmptyBlock(t)
 	}
+}
+
+func (s *L2Sequencer) ActSetRecoverMode(t Testing, b bool) {
+	s.sequencer.SetRecoverMode(b)
 }

--- a/op-e2e/actions/helpers/l2_sequencer.go
+++ b/op-e2e/actions/helpers/l2_sequencer.go
@@ -98,20 +98,28 @@ func NewL2Sequencer(t Testing, log log.Logger, l1 derive.L1Fetcher, blobSrc deri
 
 // ActL2StartBlock starts building of a new L2 block on top of the head
 func (s *L2Sequencer) ActL2StartBlock(t Testing) {
+	err := s.ActMaybeL2StartBlock(t)
+	require.NoError(t, err, "failed to start block building")
+}
+
+// ActMaybeL2StartBlock tries to start building a new L2 block on top of the head
+func (s *L2Sequencer) ActMaybeL2StartBlock(t Testing) error {
 	require.NoError(t, s.drainer.Drain()) // can't build when other work is still blocking
 	if !s.L2PipelineIdle {
 		t.InvalidAction("cannot start L2 build when derivation is not idle")
-		return
+		return nil
 	}
 	if s.l2Building {
 		t.InvalidAction("already started building L2 block")
-		return
+		return nil
 	}
 	s.synchronousEvents.Emit(t.Ctx(), sequencing.SequencerActionEvent{})
-	require.NoError(t, s.drainer.DrainUntil(event.Is[engine.BuildStartedEvent], false),
-		"failed to start block building")
-
+	err := s.drainer.DrainUntil(event.Is[engine.BuildStartedEvent], false)
+	if err != nil {
+		return err
+	}
 	s.l2Building = true
+	return nil
 }
 
 // ActL2EndBlock completes a new L2 block and applies it to the L2 chain as new canonical unsafe head

--- a/op-e2e/actions/helpers/l2_sequencer.go
+++ b/op-e2e/actions/helpers/l2_sequencer.go
@@ -87,7 +87,6 @@ func NewL2Sequencer(t Testing, log log.Logger, l1 derive.L1Fetcher, blobSrc deri
 	ver.eventSys.Register("sequencer", seq, opts)
 	ver.eventSys.Register("origin-selector", originSelector, opts)
 	require.NoError(t, seq.Init(t.Ctx(), true))
-
 	return &L2Sequencer{
 		L2Verifier:              ver,
 		sequencer:               seq,

--- a/op-e2e/actions/helpers/utils.go
+++ b/op-e2e/actions/helpers/utils.go
@@ -15,7 +15,7 @@ func DefaultRollupTestParams() *e2eutils.TestParams {
 		MaxSequencerDrift:   40,
 		SequencerWindowSize: 120,
 		ChannelTimeout:      120,
-		L1BlockTime:         15,
+		L1BlockTime:         12, // Many of the action helpers assume a 12s L1 block time
 		AllocType:           config.DefaultAllocType,
 	}
 }

--- a/op-e2e/actions/helpers/utils.go
+++ b/op-e2e/actions/helpers/utils.go
@@ -13,7 +13,7 @@ import (
 func DefaultRollupTestParams() *e2eutils.TestParams {
 	return &e2eutils.TestParams{
 		MaxSequencerDrift:   40,
-		SequencerWindowSize: 10,
+		SequencerWindowSize: 120,
 		ChannelTimeout:      120,
 		L1BlockTime:         15,
 		AllocType:           config.DefaultAllocType,

--- a/op-e2e/actions/helpers/utils.go
+++ b/op-e2e/actions/helpers/utils.go
@@ -13,7 +13,7 @@ import (
 func DefaultRollupTestParams() *e2eutils.TestParams {
 	return &e2eutils.TestParams{
 		MaxSequencerDrift:   40,
-		SequencerWindowSize: 120,
+		SequencerWindowSize: 10,
 		ChannelTimeout:      120,
 		L1BlockTime:         15,
 		AllocType:           config.DefaultAllocType,

--- a/op-e2e/actions/proofs/helpers/env.go
+++ b/op-e2e/actions/proofs/helpers/env.go
@@ -243,15 +243,12 @@ func (env *L2FaultProofEnv) BatchAndMine(t helpers.Testing) {
 // Returns the L2 Safe Block Reference
 func (env *L2FaultProofEnv) BatchMineAndSync(t helpers.Testing) eth.L2BlockRef {
 	t.Helper()
-	// id := env.Miner.UnsafeID()
 	env.BatchAndMine(t)
 	env.Sequencer.ActL1HeadSignal(t)
 	env.Sequencer.ActL2PipelineFull(t)
 
 	// Assertions
-
 	syncStatus := env.Sequencer.SyncStatus()
-	// require.Equal(t, syncStatus.UnsafeL2.L1Origin, id, "UnsafeL2.L1Origin should equal L1 Unsafe ID before batch submitted")
 	require.Equal(t, syncStatus.UnsafeL2, syncStatus.SafeL2, "UnsafeL2 should equal SafeL2")
 
 	return syncStatus.SafeL2

--- a/op-e2e/actions/proofs/helpers/env.go
+++ b/op-e2e/actions/proofs/helpers/env.go
@@ -243,7 +243,7 @@ func (env *L2FaultProofEnv) BatchAndMine(t helpers.Testing) {
 // Returns the L2 Safe Block Reference
 func (env *L2FaultProofEnv) BatchMineAndSync(t helpers.Testing) eth.L2BlockRef {
 	t.Helper()
-	id := env.Miner.UnsafeID()
+	// id := env.Miner.UnsafeID()
 	env.BatchAndMine(t)
 	env.Sequencer.ActL1HeadSignal(t)
 	env.Sequencer.ActL2PipelineFull(t)
@@ -251,7 +251,7 @@ func (env *L2FaultProofEnv) BatchMineAndSync(t helpers.Testing) eth.L2BlockRef {
 	// Assertions
 
 	syncStatus := env.Sequencer.SyncStatus()
-	require.Equal(t, syncStatus.UnsafeL2.L1Origin, id, "UnsafeL2.L1Origin should equal L1 Unsafe ID before batch submitted")
+	// require.Equal(t, syncStatus.UnsafeL2.L1Origin, id, "UnsafeL2.L1Origin should equal L1 Unsafe ID before batch submitted")
 	require.Equal(t, syncStatus.UnsafeL2, syncStatus.SafeL2, "UnsafeL2 should equal SafeL2")
 
 	return syncStatus.SafeL2

--- a/op-e2e/actions/proofs/sequence_window_expiry_test.go
+++ b/op-e2e/actions/proofs/sequence_window_expiry_test.go
@@ -13,7 +13,7 @@ import (
 // and then recovers the chain using sequencer recover mode.
 func runSequenceWindowExpireTest(gt *testing.T, testCfg *helpers.TestCfg[any]) {
 	t := actionsHelpers.NewDefaultTesting(gt)
-	const SEQUENCER_WINDOW_SIZE = 10 // (short, to keep test fast)
+	const SEQUENCER_WINDOW_SIZE = 50 // (short, to keep test fast)
 	tp := helpers.NewTestParams(func(p *e2eutils.TestParams) {
 		p.SequencerWindowSize = SEQUENCER_WINDOW_SIZE
 	})
@@ -78,11 +78,12 @@ func runSequenceWindowExpireTest(gt *testing.T, testCfg *helpers.TestCfg[any]) {
 		return int(ss.CurrentL1.Number - ss.SafeL2.L1Origin.Number)
 	}
 
+	// Define "drift" as the difference between the current L2 block's timestamp and the unsafe L2 block's L1 origin's timestamp.
 	computeDrift := func() int {
 		ss := env.Sequencer.SyncStatus()
-		l2header, err := env.Engine.EthClient().HeaderByHash(t.Ctx(), ss.SafeL2.Hash)
+		l2header, err := env.Engine.EthClient().HeaderByHash(t.Ctx(), ss.UnsafeL2.Hash)
 		require.NoError(t, err)
-		l1header, err := env.Miner.EthClient().HeaderByHash(t.Ctx(), ss.SafeL2.L1Origin.Hash)
+		l1header, err := env.Miner.EthClient().HeaderByHash(t.Ctx(), ss.UnsafeL2.L1Origin.Hash)
 		require.NoError(t, err)
 		t.Log("l2header.Time", l2header.Time)
 		t.Log("l1header.Time", l1header.Time)
@@ -110,19 +111,12 @@ func runSequenceWindowExpireTest(gt *testing.T, testCfg *helpers.TestCfg[any]) {
 			// is critical for recover mode to work.
 			env.Sequencer.ActL2EndBlock(t)
 		}
-		if numL1Blocks%2 == 0 {
-			// Simulate batching every 2 L1 blocks
-			env.BatchMineAndSync(t)
-		} else {
-			// Keep the L1 chain moving forward
-			env.Miner.ActEmptyBlock(t)
-		}
+		env.BatchMineAndSync(t) // Mines 1 block on L1
 		numL1Blocks++
 		lag = computeLag()
 		t.Log("lag", lag)
-		drift := computeDrift()
-		t.Log("drift", drift)
-		if lag == 1 && numL1Blocks > 10 { // A lag of 1 is the minimum possible.
+		t.Log("drift", computeDrift())
+		if lag == 1 { // A lag of 1 is the minimum possible.
 			break
 		}
 	}

--- a/op-e2e/actions/proofs/sequence_window_expiry_test.go
+++ b/op-e2e/actions/proofs/sequence_window_expiry_test.go
@@ -1,36 +1,38 @@
 package proofs
 
 import (
-	"strconv"
 	"testing"
 
 	actionsHelpers "github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/proofs/helpers"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
+	"github.com/ethereum-optimism/optimism/op-program/client/claim"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
 
-type testCase struct {
-	recoverMode bool
-	spanBatches bool
-}
-
-// Run a test that proves a deposit-only block generated due to sequence window expiry.
-func runSequenceWindowExpireTest(gt *testing.T, testCfg *helpers.TestCfg[testCase]) {
+// Run a test that proves a deposit-only block generated due to sequence window expiry,
+// and then recovers the chain using sequencer recover mode.
+func runSequenceWindowExpireTest(gt *testing.T, testCfg *helpers.TestCfg[any]) {
 	t := actionsHelpers.NewDefaultTesting(gt)
-	tp := helpers.NewTestParams()
-	bc := helpers.NewBatcherCfg()
+	const SEQUENCER_WINDOW_SIZE = 10 // (short, to keep test fast)
+	tp := helpers.NewTestParams(func(p *e2eutils.TestParams) {
+		p.SequencerWindowSize = SEQUENCER_WINDOW_SIZE
+	})
 
-	if testCfg.Custom.spanBatches {
-		// It seems more difficult to recover with span batches, since the singular batches within are invalidated atomically.
-		// That is to say, if the oldest batch in the span batch fails the sequencing window check (l1 origin + seq window < l1 inclusion)
-		// All following batches are invalidated / dropped as well.
-		// Although, if the same blocks were batched with singular batches, wouldn't the older blocks being rejected invalidate that later batches anyway?
-		// Perhaps not in the case of recover mode since the noTxPool mode means autoderviation actually fills the gap with identical blocks anyway.
-		// It seems like this is actually just a problem with derivation, it would be possible to consider modifying the rules to allow for recovery from span batches too.
-		bc.ForceSubmitSpanBatch = true
-	} else {
-		bc.ForceSubmitSingularBatch = true
-	}
+	// It seems more difficult (almost impossible)to recover from sequencing window expiry with span batches,
+	// since the singular batches within are invalidated _atomically_.
+	// That is to say, if the oldest batch in the span batch fails the sequencing window chec
+	// (l1 origin + seq window < l1 inclusion)
+	// All following batches are invalidated / dropped as well.
+	// https://github.com/ethereum-optimism/optimism/blob/73339162d78a1ebf2daadab01736382eed6f4527/op-node/rollup/derive/batches.go#L96-L100
+	//
+	// If the same blocks were batched with singular batches, the validation rules are different
+	// https://github.com/ethereum-optimism/optimism/blob/73339162d78a1ebf2daadab01736382eed6f4527/op-node/rollup/derive/batches.go#L83-L86
+	// In the case of recover mode, the noTxPool=true condition means autoderviation actually fills
+	// the gap with identical blocks anyway, meaning the following batches are actually still valid.
+	bc := helpers.NewBatcherCfg()
+	bc.ForceSubmitSingularBatch = true
 
 	env := helpers.NewL2FaultProofEnv(t, testCfg, tp, bc)
 
@@ -39,8 +41,6 @@ func runSequenceWindowExpireTest(gt *testing.T, testCfg *helpers.TestCfg[testCas
 
 	// Expire the sequence window by building `SequenceWindow + 1` empty blocks on L1.
 	// note that tp.SequencerWindowSize is 10.
-	// If we were sequencing properly, we would expect the unsafe head to be up to 15*10 = 150
-	// because l2 block time is 1s, l1 block time is 15s, and sequence window is 10 blocks.
 	for i := 0; i < int(tp.SequencerWindowSize)+1; i++ {
 		env.Alice.L1.ActResetTxOpts(t)
 		env.Alice.ActDeposit(t)
@@ -65,57 +65,75 @@ func runSequenceWindowExpireTest(gt *testing.T, testCfg *helpers.TestCfg[testCas
 	l2SafeHead = env.Engine.L2Chain().CurrentSafeBlock()
 	require.Greater(t, l2SafeHead.Number.Uint64(), uint64(0))
 
-	// Run the FPP on one of the auto-derived blocks.
-	env.RunFaultProofProgram(t, l2SafeHead.Number.Uint64()/2, testCfg.CheckResult, testCfg.InputParams...)
-
 	// Set recover mode on the sequencer:
-	// I am not actually convinced we need this...
-	// and I think it does more harm than good when
-	// the lag approaches zero
-	env.Sequencer.ActSetRecoverMode(t, testCfg.Custom.recoverMode)
+	env.Sequencer.ActSetRecoverMode(t, true)
+	// Since recover mode only affects the L2 CL (op-node),
+	// it won't stop the test environment injecting transactions
+	// directly into the engine. So we will force the engine
+	// to ignore such injections if recover mode is enabled.
+	env.Engine.EngineApi.SetForceEmpty(true)
 
-	// Build both chains and assert the l1 origin catches back up with the tip of the L1 chain.
+	// Define "lag" as the difference between the current L1 block number and the safe L2 block's L1 origin number.
+	computeLag := func() int {
+		ss := env.Sequencer.SyncStatus()
+		return int(ss.CurrentL1.Number - ss.SafeL2.L1Origin.Number)
+	}
+
+	// Build both chains and assert the L1 origin catches back up with the tip of the L1 chain.
+	lag := computeLag()
+	require.GreaterOrEqual(t, uint64(lag), tp.SequencerWindowSize, "Lag is less than sequencing window size")
 	numL1Blocks := 0
 	timeout := tp.SequencerWindowSize * 5
-	ss := env.Sequencer.SyncStatus()
-	lag := ss.CurrentL1.Number - ss.SafeL2.L1Origin.Number
-	require.GreaterOrEqual(t, lag, tp.SequencerWindowSize, "Lag is less than sequencing window size")
 	for numL1Blocks < int(timeout) {
 		for range tp.L1BlockTime / env.Sd.RollupCfg.BlockTime {
 			env.Sequencer.ActL2StartBlock(t)
-			env.Alice.L2.ActMakeTx(t)
-			env.Engine.ActL2IncludeTx(env.Alice.Address())
-			// RecoverMode will ensure no user transactions, so don't mess with that here.
+			env.Bob.L2.ActResetTxOpts(t)
+			env.Bob.L2.ActMakeTx(t)
+			env.Engine.ActL2IncludeTx(env.Bob.Address())(t)
+			// RecoverMode (above, if enabled) should prevent this
+			// transaction from being included in the block, which
+			// is critical for recover mode to work.
 			env.Sequencer.ActL2EndBlock(t)
 		}
 		if numL1Blocks%2 == 0 {
+			// Simulate batching every 2 L1 blocks
 			env.BatchMineAndSync(t)
 		} else {
+			// Keep the L1 chain moving forward
 			env.Miner.ActEmptyBlock(t)
 		}
 		numL1Blocks++
-		l1Head := env.Miner.UnsafeNum()
-		ss = env.Sequencer.SyncStatus()
-		t.Log(
-			"unsafeL2.Number", ss.UnsafeL2.Number,
-			"safeL2.Number", ss.SafeL2.Number,
-			"currentL1", ss.CurrentL1.Number,
-			"l1_origin_unsafe", ss.UnsafeL2.L1Origin.Number,
-			"l1_origin_safe", ss.SafeL2.L1Origin.Number,
-			"l1_head", l1Head)
-		lag = ss.CurrentL1.Number - ss.SafeL2.L1Origin.Number
-		t.Log("lag", lag) // This lag starts out equal to the sequencing window, and eventually decreases to a lower value
-		if lag <= 1 {     // We can't expect to get a lag of 0, so a lag of 1 is the best we can hope for.
+		lag = computeLag()
+		t.Log("lag", lag) // This lag starts out equal to the sequencing window, and eventually decreases to 1.
+		if lag <= 1 {     // A lag of 1 is the minimum possible.
 			break
 		}
 	}
 
-	if uint64(numL1Blocks) > timeout {
-		t.Fatal("L1 Origin did not catch up to tip within % L1 blocks", numL1Blocks)
+	if uint64(numL1Blocks) >= timeout {
+		t.Fatal("L1 Origin did not catch up to tip within %d L1 blocks (lag is %d)", numL1Blocks, lag)
 	} else {
 		t.Logf("L1 Origin caught up to within %d blocks of the tip within %d L1 blocks (sequencing window size %d)", lag, numL1Blocks, tp.SequencerWindowSize)
 	}
 
+	// Disable recover mode so we can get some user transactions in again.
+	env.Sequencer.ActSetRecoverMode(t, false)
+	env.Engine.EngineApi.SetForceEmpty(false)
+	l2SafeBefore := env.Sequencer.L2Safe()
+	env.Sequencer.ActL2StartBlock(t)
+	env.Bob.L2.ActResetTxOpts(t)
+	env.Bob.L2.ActMakeTx(t)
+	env.Engine.ActL2IncludeTx(env.Bob.Address())(t)
+	env.Sequencer.ActL2EndBlock(t)
+	env.BatchMineAndSync(t)
+	l2Safe := env.Sequencer.L2Safe()
+	require.Equal(t, l2Safe.Number, l2SafeBefore.Number+1, "safe chain did not progress with user transactions")
+	l2SafeBlock, err := env.Engine.EthClient().BlockByHash(t.Ctx(), l2Safe.Hash)
+	require.NoError(t, err)
+	// Assert safe block has at least two transactions
+	require.GreaterOrEqual(t, len(l2SafeBlock.Transactions()), 2, "safe block did not have at least two transactions")
+
+	// env.RunFaultProofProgramFromGenesis(t, l2Safe.Number, testCfg.CheckResult, testCfg.InputParams...)
 }
 
 // Runs a that proves a block in a chain where the batcher opens a channel, the sequence window expires, and then the
@@ -199,45 +217,40 @@ func runSequenceWindowExpire_ChannelCloseAfterWindowExpiry_Test(gt *testing.T, t
 }
 
 func Test_ProgramAction_SequenceWindowExpired(gt *testing.T) {
-	matrix := helpers.NewMatrix[testCase]()
+	matrix := helpers.NewMatrix[any]()
 	defer matrix.Run(gt)
 
 	forks := helpers.ForkMatrix{helpers.LatestFork}
-	// TODO add recoverMode=true test case
-	for _, testCase := range []testCase{
-		{recoverMode: false, spanBatches: false},
-		{recoverMode: false, spanBatches: true},
-	} {
+	{
 		matrix.AddTestCase(
-			"HonestClaim-recoverMode-"+strconv.FormatBool(testCase.recoverMode)+"-spanBatches-"+strconv.FormatBool(testCase.spanBatches),
-			testCase,
+			"HonestClaim",
+			nil,
 			forks,
 			runSequenceWindowExpireTest,
 			helpers.ExpectNoError(),
 		)
 	}
-
-	// matrix.AddTestCase(
-	// 	"JunkClaim",
-	// 	nil,
-	// 	forks,
-	// 	runSequenceWindowExpireTest,
-	// 	helpers.ExpectError(claim.ErrClaimNotValid),
-	// 	helpers.WithL2Claim(common.HexToHash("0xdeadbeef")),
-	// )
-	// matrix.AddTestCase(
-	// 	"ChannelCloseAfterWindowExpiry-HonestClaim",
-	// 	nil,
-	// 	forks,
-	// 	runSequenceWindowExpire_ChannelCloseAfterWindowExpiry_Test,
-	// 	helpers.ExpectNoError(),
-	// )
-	// matrix.AddTestCase(
-	// 	"ChannelCloseAfterWindowExpiry-JunkClaim",
-	// 	nil,
-	// 	forks,
-	// 	runSequenceWindowExpire_ChannelCloseAfterWindowExpiry_Test,
-	// 	helpers.ExpectError(claim.ErrClaimNotValid),
-	// 	helpers.WithL2Claim(common.HexToHash("0xdeadbeef")),
-	// )
+	matrix.AddTestCase(
+		"JunkClaim",
+		nil,
+		forks,
+		runSequenceWindowExpireTest,
+		helpers.ExpectError(claim.ErrClaimNotValid),
+		helpers.WithL2Claim(common.HexToHash("0xdeadbeef")),
+	)
+	matrix.AddTestCase(
+		"ChannelCloseAfterWindowExpiry-HonestClaim",
+		nil,
+		forks,
+		runSequenceWindowExpire_ChannelCloseAfterWindowExpiry_Test,
+		helpers.ExpectNoError(),
+	)
+	matrix.AddTestCase(
+		"ChannelCloseAfterWindowExpiry-JunkClaim",
+		nil,
+		forks,
+		runSequenceWindowExpire_ChannelCloseAfterWindowExpiry_Test,
+		helpers.ExpectError(claim.ErrClaimNotValid),
+		helpers.WithL2Claim(common.HexToHash("0xdeadbeef")),
+	)
 }

--- a/op-e2e/actions/proofs/sequence_window_expiry_test.go
+++ b/op-e2e/actions/proofs/sequence_window_expiry_test.go
@@ -20,9 +20,9 @@ func runSequenceWindowExpireTest(gt *testing.T, testCfg *helpers.TestCfg[any]) {
 		p.SequencerWindowSize = SEQUENCER_WINDOW_SIZE
 	})
 
-	// It seems more difficult (almost impossible)to recover from sequencing window expiry with span batches,
+	// It seems more difficult (almost impossible) to recover from sequencing window expiry with span batches,
 	// since the singular batches within are invalidated _atomically_.
-	// That is to say, if the oldest batch in the span batch fails the sequencing window chec
+	// That is to say, if the oldest batch in the span batch fails the sequencing window check
 	// (l1 origin + seq window < l1 inclusion)
 	// All following batches are invalidated / dropped as well.
 	// https://github.com/ethereum-optimism/optimism/blob/73339162d78a1ebf2daadab01736382eed6f4527/op-node/rollup/derive/batches.go#L96-L100
@@ -65,6 +65,8 @@ func runSequenceWindowExpireTest(gt *testing.T, testCfg *helpers.TestCfg[any]) {
 	l2SafeHead = env.Engine.L2Chain().CurrentSafeBlock()
 	require.Greater(t, l2SafeHead.Number.Uint64(), uint64(0))
 
+	env.RunFaultProofProgram(t, l2SafeHead.Number.Uint64()/2, testCfg.CheckResult, testCfg.InputParams...)
+
 	// Set recover mode on the sequencer:
 	env.Sequencer.ActSetRecoverMode(t, true)
 	// Since recover mode only affects the L2 CL (op-node),
@@ -90,7 +92,7 @@ func runSequenceWindowExpireTest(gt *testing.T, testCfg *helpers.TestCfg[any]) {
 			env.Bob.L2.ActResetTxOpts(t)
 			env.Bob.L2.ActMakeTx(t)
 			env.Engine.ActL2IncludeTx(env.Bob.Address())(t)
-			// RecoverMode (above, if enabled) should prevent this
+			// RecoverMode (enabled above) should prevent this
 			// transaction from being included in the block, which
 			// is critical for recover mode to work.
 			env.Sequencer.ActL2EndBlock(t)
@@ -113,7 +115,8 @@ func runSequenceWindowExpireTest(gt *testing.T, testCfg *helpers.TestCfg[any]) {
 	if uint64(numL1Blocks) >= timeout {
 		t.Fatal("L1 Origin did not catch up to tip within %d L1 blocks (lag is %d)", numL1Blocks, lag)
 	} else {
-		t.Logf("L1 Origin caught up to within %d blocks of the tip within %d L1 blocks (sequencing window size %d)", lag, numL1Blocks, tp.SequencerWindowSize)
+		t.Logf("L1 Origin caught up to within %d blocks of the tip within %d L1 blocks (sequencing window size %d)",
+			lag, numL1Blocks, tp.SequencerWindowSize)
 	}
 
 	// Disable recover mode so we can get some user transactions in again.
@@ -133,7 +136,7 @@ func runSequenceWindowExpireTest(gt *testing.T, testCfg *helpers.TestCfg[any]) {
 	// Assert safe block has at least two transactions
 	require.GreaterOrEqual(t, len(l2SafeBlock.Transactions()), 2, "safe block did not have at least two transactions")
 
-	// env.RunFaultProofProgramFromGenesis(t, l2Safe.Number, testCfg.CheckResult, testCfg.InputParams...)
+	env.RunFaultProofProgram(t, l2Safe.Number, testCfg.CheckResult, testCfg.InputParams...)
 }
 
 // Runs a that proves a block in a chain where the batcher opens a channel, the sequence window expires, and then the

--- a/op-e2e/actions/proofs/sequence_window_expiry_test.go
+++ b/op-e2e/actions/proofs/sequence_window_expiry_test.go
@@ -40,12 +40,11 @@ func runSequenceWindowExpireTest(gt *testing.T, testCfg *helpers.TestCfg[any]) {
 	env.Miner.ActEmptyBlock(t)
 
 	// Expire the sequence window by building `SequenceWindow + 1` empty blocks on L1.
-	// note that tp.SequencerWindowSize is 10.
 	for i := 0; i < int(tp.SequencerWindowSize)+1; i++ {
 		env.Alice.L1.ActResetTxOpts(t)
 		env.Alice.ActDeposit(t)
 
-		env.Miner.ActL1StartBlock(15)(t)
+		env.Miner.ActL1StartBlock(tp.L1BlockTime)(t)
 		env.Miner.ActL1IncludeTx(env.Alice.Address())(t)
 		env.Miner.ActL1EndBlock(t)
 
@@ -107,7 +106,7 @@ func runSequenceWindowExpireTest(gt *testing.T, testCfg *helpers.TestCfg[any]) {
 		numL1Blocks++
 		lag = computeLag()
 		t.Log("lag", lag) // This lag starts out equal to the sequencing window, and eventually decreases to 1.
-		if lag <= 1 {     // A lag of 1 is the minimum possible.
+		if lag == 1 {     // A lag of 1 is the minimum possible.
 			break
 		}
 	}
@@ -223,16 +222,14 @@ func Test_ProgramAction_SequenceWindowExpired(gt *testing.T) {
 	matrix := helpers.NewMatrix[any]()
 	defer matrix.Run(gt)
 
-	forks := helpers.ForkMatrix{helpers.LatestFork}
-	{
-		matrix.AddTestCase(
-			"HonestClaim",
-			nil,
-			forks,
-			runSequenceWindowExpireTest,
-			helpers.ExpectNoError(),
-		)
-	}
+	forks := helpers.ForkMatrix{helpers.Granite, helpers.LatestFork}
+	matrix.AddTestCase(
+		"HonestClaim",
+		nil,
+		forks,
+		runSequenceWindowExpireTest,
+		helpers.ExpectNoError(),
+	)
 	matrix.AddTestCase(
 		"JunkClaim",
 		nil,

--- a/op-e2e/actions/proofs/sequence_window_expiry_test.go
+++ b/op-e2e/actions/proofs/sequence_window_expiry_test.go
@@ -6,8 +6,6 @@ import (
 	actionsHelpers "github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/proofs/helpers"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
-	"github.com/ethereum-optimism/optimism/op-program/client/claim"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
 
@@ -80,14 +78,30 @@ func runSequenceWindowExpireTest(gt *testing.T, testCfg *helpers.TestCfg[any]) {
 		return int(ss.CurrentL1.Number - ss.SafeL2.L1Origin.Number)
 	}
 
+	computeDrift := func() int {
+		ss := env.Sequencer.SyncStatus()
+		l2header, err := env.Engine.EthClient().HeaderByHash(t.Ctx(), ss.SafeL2.Hash)
+		require.NoError(t, err)
+		l1header, err := env.Miner.EthClient().HeaderByHash(t.Ctx(), ss.SafeL2.L1Origin.Hash)
+		require.NoError(t, err)
+		t.Log("l2header.Time", l2header.Time)
+		t.Log("l1header.Time", l1header.Time)
+		return int(l2header.Time) - int(l1header.Time)
+	}
+
 	// Build both chains and assert the L1 origin catches back up with the tip of the L1 chain.
 	lag := computeLag()
+	t.Log("lag", lag)
 	require.GreaterOrEqual(t, uint64(lag), tp.SequencerWindowSize, "Lag is less than sequencing window size")
 	numL1Blocks := 0
-	timeout := tp.SequencerWindowSize * 5
+	timeout := tp.SequencerWindowSize * 50
+
 	for numL1Blocks < int(timeout) {
-		for range tp.L1BlockTime / env.Sd.RollupCfg.BlockTime {
-			env.Sequencer.ActL2StartBlock(t)
+		for range 100 * tp.L1BlockTime / env.Sd.RollupCfg.BlockTime { // go at 100x real time
+			err := env.Sequencer.ActMaybeL2StartBlock(t)
+			if err != nil {
+				break
+			}
 			env.Bob.L2.ActResetTxOpts(t)
 			env.Bob.L2.ActMakeTx(t)
 			env.Engine.ActL2IncludeTx(env.Bob.Address())(t)
@@ -105,8 +119,10 @@ func runSequenceWindowExpireTest(gt *testing.T, testCfg *helpers.TestCfg[any]) {
 		}
 		numL1Blocks++
 		lag = computeLag()
-		t.Log("lag", lag) // This lag starts out equal to the sequencing window, and eventually decreases to 1.
-		if lag == 1 {     // A lag of 1 is the minimum possible.
+		t.Log("lag", lag)
+		drift := computeDrift()
+		t.Log("drift", drift)
+		if lag == 1 && numL1Blocks > 10 { // A lag of 1 is the minimum possible.
 			break
 		}
 	}
@@ -222,7 +238,8 @@ func Test_ProgramAction_SequenceWindowExpired(gt *testing.T) {
 	matrix := helpers.NewMatrix[any]()
 	defer matrix.Run(gt)
 
-	forks := helpers.ForkMatrix{helpers.Granite, helpers.LatestFork}
+	// forks := helpers.ForkMatrix{helpers.Granite, helpers.LatestFork}
+	forks := helpers.ForkMatrix{helpers.LatestFork}
 	matrix.AddTestCase(
 		"HonestClaim",
 		nil,
@@ -230,27 +247,27 @@ func Test_ProgramAction_SequenceWindowExpired(gt *testing.T) {
 		runSequenceWindowExpireTest,
 		helpers.ExpectNoError(),
 	)
-	matrix.AddTestCase(
-		"JunkClaim",
-		nil,
-		forks,
-		runSequenceWindowExpireTest,
-		helpers.ExpectError(claim.ErrClaimNotValid),
-		helpers.WithL2Claim(common.HexToHash("0xdeadbeef")),
-	)
-	matrix.AddTestCase(
-		"ChannelCloseAfterWindowExpiry-HonestClaim",
-		nil,
-		forks,
-		runSequenceWindowExpire_ChannelCloseAfterWindowExpiry_Test,
-		helpers.ExpectNoError(),
-	)
-	matrix.AddTestCase(
-		"ChannelCloseAfterWindowExpiry-JunkClaim",
-		nil,
-		forks,
-		runSequenceWindowExpire_ChannelCloseAfterWindowExpiry_Test,
-		helpers.ExpectError(claim.ErrClaimNotValid),
-		helpers.WithL2Claim(common.HexToHash("0xdeadbeef")),
-	)
+	// matrix.AddTestCase(
+	// 	"JunkClaim",
+	// 	nil,
+	// 	forks,
+	// 	runSequenceWindowExpireTest,
+	// 	helpers.ExpectError(claim.ErrClaimNotValid),
+	// 	helpers.WithL2Claim(common.HexToHash("0xdeadbeef")),
+	// )
+	// matrix.AddTestCase(
+	// 	"ChannelCloseAfterWindowExpiry-HonestClaim",
+	// 	nil,
+	// 	forks,
+	// 	runSequenceWindowExpire_ChannelCloseAfterWindowExpiry_Test,
+	// 	helpers.ExpectNoError(),
+	// )
+	// matrix.AddTestCase(
+	// 	"ChannelCloseAfterWindowExpiry-JunkClaim",
+	// 	nil,
+	// 	forks,
+	// 	runSequenceWindowExpire_ChannelCloseAfterWindowExpiry_Test,
+	// 	helpers.ExpectError(claim.ErrClaimNotValid),
+	// 	helpers.WithL2Claim(common.HexToHash("0xdeadbeef")),
+	// )
 }

--- a/op-e2e/actions/proofs/sequence_window_expiry_test.go
+++ b/op-e2e/actions/proofs/sequence_window_expiry_test.go
@@ -6,6 +6,8 @@ import (
 	actionsHelpers "github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/proofs/helpers"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
+	"github.com/ethereum-optimism/optimism/op-program/client/claim"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
 
@@ -93,6 +95,8 @@ func runSequenceWindowExpireTest(gt *testing.T, testCfg *helpers.TestCfg[any]) {
 	// Build both chains and assert the L1 origin catches back up with the tip of the L1 chain.
 	lag := computeLag()
 	t.Log("lag", lag)
+	drift := computeDrift()
+	t.Log("drift", drift)
 	require.GreaterOrEqual(t, uint64(lag), tp.SequencerWindowSize, "Lag is less than sequencing window size")
 	numL1Blocks := 0
 	timeout := tp.SequencerWindowSize * 50
@@ -110,12 +114,15 @@ func runSequenceWindowExpireTest(gt *testing.T, testCfg *helpers.TestCfg[any]) {
 			// transaction from being included in the block, which
 			// is critical for recover mode to work.
 			env.Sequencer.ActL2EndBlock(t)
+			drift = computeDrift()
+			t.Log("drift", drift)
 		}
 		env.BatchMineAndSync(t) // Mines 1 block on L1
 		numL1Blocks++
 		lag = computeLag()
 		t.Log("lag", lag)
-		t.Log("drift", computeDrift())
+		drift = computeDrift()
+		t.Log("drift", drift)
 		if lag == 1 { // A lag of 1 is the minimum possible.
 			break
 		}
@@ -126,6 +133,15 @@ func runSequenceWindowExpireTest(gt *testing.T, testCfg *helpers.TestCfg[any]) {
 	} else {
 		t.Logf("L1 Origin caught up to within %d blocks of the tip within %d L1 blocks (sequencing window size %d)",
 			lag, numL1Blocks, tp.SequencerWindowSize)
+	}
+
+	switch {
+	case drift == 0:
+		t.Fatal("drift is zero, this implies the unsafe l2 head is pinned to the l1 head")
+	case drift > int(tp.MaxSequencerDrift):
+		t.Fatal("drift is too high")
+	default:
+		t.Log("drift", drift)
 	}
 
 	// Disable recover mode so we can get some user transactions in again.
@@ -232,8 +248,7 @@ func Test_ProgramAction_SequenceWindowExpired(gt *testing.T) {
 	matrix := helpers.NewMatrix[any]()
 	defer matrix.Run(gt)
 
-	// forks := helpers.ForkMatrix{helpers.Granite, helpers.LatestFork}
-	forks := helpers.ForkMatrix{helpers.LatestFork}
+	forks := helpers.ForkMatrix{helpers.Granite, helpers.LatestFork}
 	matrix.AddTestCase(
 		"HonestClaim",
 		nil,
@@ -241,27 +256,27 @@ func Test_ProgramAction_SequenceWindowExpired(gt *testing.T) {
 		runSequenceWindowExpireTest,
 		helpers.ExpectNoError(),
 	)
-	// matrix.AddTestCase(
-	// 	"JunkClaim",
-	// 	nil,
-	// 	forks,
-	// 	runSequenceWindowExpireTest,
-	// 	helpers.ExpectError(claim.ErrClaimNotValid),
-	// 	helpers.WithL2Claim(common.HexToHash("0xdeadbeef")),
-	// )
-	// matrix.AddTestCase(
-	// 	"ChannelCloseAfterWindowExpiry-HonestClaim",
-	// 	nil,
-	// 	forks,
-	// 	runSequenceWindowExpire_ChannelCloseAfterWindowExpiry_Test,
-	// 	helpers.ExpectNoError(),
-	// )
-	// matrix.AddTestCase(
-	// 	"ChannelCloseAfterWindowExpiry-JunkClaim",
-	// 	nil,
-	// 	forks,
-	// 	runSequenceWindowExpire_ChannelCloseAfterWindowExpiry_Test,
-	// 	helpers.ExpectError(claim.ErrClaimNotValid),
-	// 	helpers.WithL2Claim(common.HexToHash("0xdeadbeef")),
-	// )
+	matrix.AddTestCase(
+		"JunkClaim",
+		nil,
+		forks,
+		runSequenceWindowExpireTest,
+		helpers.ExpectError(claim.ErrClaimNotValid),
+		helpers.WithL2Claim(common.HexToHash("0xdeadbeef")),
+	)
+	matrix.AddTestCase(
+		"ChannelCloseAfterWindowExpiry-HonestClaim",
+		nil,
+		forks,
+		runSequenceWindowExpire_ChannelCloseAfterWindowExpiry_Test,
+		helpers.ExpectNoError(),
+	)
+	matrix.AddTestCase(
+		"ChannelCloseAfterWindowExpiry-JunkClaim",
+		nil,
+		forks,
+		runSequenceWindowExpire_ChannelCloseAfterWindowExpiry_Test,
+		helpers.ExpectError(claim.ErrClaimNotValid),
+		helpers.WithL2Claim(common.HexToHash("0xdeadbeef")),
+	)
 }

--- a/op-e2e/actions/proofs/sequence_window_expiry_test.go
+++ b/op-e2e/actions/proofs/sequence_window_expiry_test.go
@@ -1,6 +1,7 @@
 package proofs
 
 import (
+	"strconv"
 	"testing"
 
 	actionsHelpers "github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
@@ -8,19 +9,29 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type testCase struct {
+	recoverMode bool
+	spanBatches bool
+}
+
 // Run a test that proves a deposit-only block generated due to sequence window expiry.
-func runSequenceWindowExpireTest(gt *testing.T, testCfg *helpers.TestCfg[any]) {
+func runSequenceWindowExpireTest(gt *testing.T, testCfg *helpers.TestCfg[testCase]) {
 	t := actionsHelpers.NewDefaultTesting(gt)
 	tp := helpers.NewTestParams()
 	bc := helpers.NewBatcherCfg()
 
-	// It seems more difficult to recover with span batches, since the singular batches within are invalidated atomically.
-	// That is to say, if the oldest batch in the span batch fails the sequencing window check (l1 origin + seq window < l1 inclusion)
-	// All following batches are invalidated / dropped as well.
-	// Although, if the same blocks were batched with singular batches, wouldn't the older blocks being rejected invalidate that later batches anyway?
-	// Perhaps not in the case of recover mode since the noTxPool mode means autoderviation actually fills the gap with identical blocks anyway.
-	// It seems like this is actually just a problem with derivation, it would be possible to consider modifying the rules to allow for recovery from span batches too.
-	bc.ForceSubmitSingularBatch = true
+	if testCfg.Custom.spanBatches {
+		// It seems more difficult to recover with span batches, since the singular batches within are invalidated atomically.
+		// That is to say, if the oldest batch in the span batch fails the sequencing window check (l1 origin + seq window < l1 inclusion)
+		// All following batches are invalidated / dropped as well.
+		// Although, if the same blocks were batched with singular batches, wouldn't the older blocks being rejected invalidate that later batches anyway?
+		// Perhaps not in the case of recover mode since the noTxPool mode means autoderviation actually fills the gap with identical blocks anyway.
+		// It seems like this is actually just a problem with derivation, it would be possible to consider modifying the rules to allow for recovery from span batches too.
+		bc.ForceSubmitSpanBatch = true
+	} else {
+		bc.ForceSubmitSingularBatch = true
+	}
+
 	env := helpers.NewL2FaultProofEnv(t, testCfg, tp, bc)
 
 	// Mine an empty L1 block for gas estimation purposes.
@@ -55,24 +66,36 @@ func runSequenceWindowExpireTest(gt *testing.T, testCfg *helpers.TestCfg[any]) {
 	require.Greater(t, l2SafeHead.Number.Uint64(), uint64(0))
 
 	// Run the FPP on one of the auto-derived blocks.
-	// env.RunFaultProofProgram(t, l2SafeHead.Number.Uint64()/2, testCfg.CheckResult, testCfg.InputParams...)
+	env.RunFaultProofProgram(t, l2SafeHead.Number.Uint64()/2, testCfg.CheckResult, testCfg.InputParams...)
 
 	// Set recover mode on the sequencer:
 	// I am not actually convinced we need this...
-	env.Sequencer.ActSetRecoverMode(t, true)
+	// and I think it does more harm than good when
+	// the lag approaches zero
+	env.Sequencer.ActSetRecoverMode(t, testCfg.Custom.recoverMode)
 
-	// Allow the l1 origin to catch up to the l1 head
-	lag := tp.SequencerWindowSize
-	for i := 0; i < int(tp.SequencerWindowSize)*100; i++ {
-		env.Sequencer.ActL2StartBlock(t)
-		env.Sequencer.ActL2EndBlock(t)
-		if i%30 == 0 {
+	// Build both chains and assert the l1 origin catches back up with the tip of the L1 chain.
+	numL1Blocks := 0
+	timeout := tp.SequencerWindowSize * 5
+	ss := env.Sequencer.SyncStatus()
+	lag := ss.CurrentL1.Number - ss.SafeL2.L1Origin.Number
+	require.GreaterOrEqual(t, lag, tp.SequencerWindowSize, "Lag is less than sequencing window size")
+	for numL1Blocks < int(timeout) {
+		for range tp.L1BlockTime / env.Sd.RollupCfg.BlockTime {
+			env.Sequencer.ActL2StartBlock(t)
+			env.Alice.L2.ActMakeTx(t)
+			env.Engine.ActL2IncludeTx(env.Alice.Address())
+			// RecoverMode will ensure no user transactions, so don't mess with that here.
+			env.Sequencer.ActL2EndBlock(t)
+		}
+		if numL1Blocks%2 == 0 {
 			env.BatchMineAndSync(t)
-		} else if i%15 == 0 {
+		} else {
 			env.Miner.ActEmptyBlock(t)
 		}
+		numL1Blocks++
 		l1Head := env.Miner.UnsafeNum()
-		ss := env.Sequencer.SyncStatus()
+		ss = env.Sequencer.SyncStatus()
 		t.Log(
 			"unsafeL2.Number", ss.UnsafeL2.Number,
 			"safeL2.Number", ss.SafeL2.Number,
@@ -81,17 +104,18 @@ func runSequenceWindowExpireTest(gt *testing.T, testCfg *helpers.TestCfg[any]) {
 			"l1_origin_safe", ss.SafeL2.L1Origin.Number,
 			"l1_head", l1Head)
 		lag = ss.CurrentL1.Number - ss.SafeL2.L1Origin.Number
-		t.Log("lag", lag) // TODO this lag starts out equal to the sequencing window, and eventually decreases to a lower value
-		if lag < 5 {      // What is a reasonable exit condition here? Let's say half the sequencing window
+		t.Log("lag", lag) // This lag starts out equal to the sequencing window, and eventually decreases to a lower value
+		if lag <= 1 {     // We can't expect to get a lag of 0, so a lag of 1 is the best we can hope for.
 			break
 		}
 	}
 
-	// env.Sequencer.ActWaitForUserTransactions(t)
+	if uint64(numL1Blocks) > timeout {
+		t.Fatal("L1 Origin did not catch up to tip within % L1 blocks", numL1Blocks)
+	} else {
+		t.Logf("L1 Origin caught up to within %d blocks of the tip within %d L1 blocks (sequencing window size %d)", lag, numL1Blocks, tp.SequencerWindowSize)
+	}
 
-	// Run the test until the l1 origin is close to tip, to cover any residual issues with recover mode
-	//
-	// Asser that the unsafe chain keeps progressing (and we don't e.g. violate sequencer drift.)
 }
 
 // Runs a that proves a block in a chain where the batcher opens a channel, the sequence window expires, and then the
@@ -175,17 +199,24 @@ func runSequenceWindowExpire_ChannelCloseAfterWindowExpiry_Test(gt *testing.T, t
 }
 
 func Test_ProgramAction_SequenceWindowExpired(gt *testing.T) {
-	matrix := helpers.NewMatrix[any]()
+	matrix := helpers.NewMatrix[testCase]()
 	defer matrix.Run(gt)
 
 	forks := helpers.ForkMatrix{helpers.LatestFork}
-	matrix.AddTestCase(
-		"HonestClaim",
-		nil,
-		forks,
-		runSequenceWindowExpireTest,
-		helpers.ExpectNoError(),
-	)
+	// TODO add recoverMode=true test case
+	for _, testCase := range []testCase{
+		{recoverMode: false, spanBatches: false},
+		{recoverMode: false, spanBatches: true},
+	} {
+		matrix.AddTestCase(
+			"HonestClaim-recoverMode-"+strconv.FormatBool(testCase.recoverMode)+"-spanBatches-"+strconv.FormatBool(testCase.spanBatches),
+			testCase,
+			forks,
+			runSequenceWindowExpireTest,
+			helpers.ExpectNoError(),
+		)
+	}
+
 	// matrix.AddTestCase(
 	// 	"JunkClaim",
 	// 	nil,

--- a/op-e2e/actions/proofs/sequence_window_expiry_test.go
+++ b/op-e2e/actions/proofs/sequence_window_expiry_test.go
@@ -5,8 +5,6 @@ import (
 
 	actionsHelpers "github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/proofs/helpers"
-	"github.com/ethereum-optimism/optimism/op-program/client/claim"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
 
@@ -14,17 +12,29 @@ import (
 func runSequenceWindowExpireTest(gt *testing.T, testCfg *helpers.TestCfg[any]) {
 	t := actionsHelpers.NewDefaultTesting(gt)
 	tp := helpers.NewTestParams()
-	env := helpers.NewL2FaultProofEnv(t, testCfg, tp, helpers.NewBatcherCfg())
+	bc := helpers.NewBatcherCfg()
 
-	// Mine an empty block for gas estimation purposes.
+	// It seems more difficult to recover with span batches, since the singular batches within are invalidated atomically.
+	// That is to say, if the oldest batch in the span batch fails the sequencing window check (l1 origin + seq window < l1 inclusion)
+	// All following batches are invalidated / dropped as well.
+	// Although, if the same blocks were batched with singular batches, wouldn't the older blocks being rejected invalidate that later batches anyway?
+	// Perhaps not in the case of recover mode since the noTxPool mode means autoderviation actually fills the gap with identical blocks anyway.
+	// It seems like this is actually just a problem with derivation, it would be possible to consider modifying the rules to allow for recovery from span batches too.
+	bc.ForceSubmitSingularBatch = true
+	env := helpers.NewL2FaultProofEnv(t, testCfg, tp, bc)
+
+	// Mine an empty L1 block for gas estimation purposes.
 	env.Miner.ActEmptyBlock(t)
 
 	// Expire the sequence window by building `SequenceWindow + 1` empty blocks on L1.
+	// note that tp.SequencerWindowSize is 10.
+	// If we were sequencing properly, we would expect the unsafe head to be up to 15*10 = 150
+	// because l2 block time is 1s, l1 block time is 15s, and sequence window is 10 blocks.
 	for i := 0; i < int(tp.SequencerWindowSize)+1; i++ {
 		env.Alice.L1.ActResetTxOpts(t)
 		env.Alice.ActDeposit(t)
 
-		env.Miner.ActL1StartBlock(12)(t)
+		env.Miner.ActL1StartBlock(15)(t)
 		env.Miner.ActL1IncludeTx(env.Alice.Address())(t)
 		env.Miner.ActL1EndBlock(t)
 
@@ -45,7 +55,43 @@ func runSequenceWindowExpireTest(gt *testing.T, testCfg *helpers.TestCfg[any]) {
 	require.Greater(t, l2SafeHead.Number.Uint64(), uint64(0))
 
 	// Run the FPP on one of the auto-derived blocks.
-	env.RunFaultProofProgram(t, l2SafeHead.Number.Uint64()/2, testCfg.CheckResult, testCfg.InputParams...)
+	// env.RunFaultProofProgram(t, l2SafeHead.Number.Uint64()/2, testCfg.CheckResult, testCfg.InputParams...)
+
+	// Set recover mode on the sequencer:
+	// I am not actually convinced we need this...
+	env.Sequencer.ActSetRecoverMode(t, true)
+
+	// Allow the l1 origin to catch up to the l1 head
+	lag := tp.SequencerWindowSize
+	for i := 0; i < int(tp.SequencerWindowSize)*100; i++ {
+		env.Sequencer.ActL2StartBlock(t)
+		env.Sequencer.ActL2EndBlock(t)
+		if i%30 == 0 {
+			env.BatchMineAndSync(t)
+		} else if i%15 == 0 {
+			env.Miner.ActEmptyBlock(t)
+		}
+		l1Head := env.Miner.UnsafeNum()
+		ss := env.Sequencer.SyncStatus()
+		t.Log(
+			"unsafeL2.Number", ss.UnsafeL2.Number,
+			"safeL2.Number", ss.SafeL2.Number,
+			"currentL1", ss.CurrentL1.Number,
+			"l1_origin_unsafe", ss.UnsafeL2.L1Origin.Number,
+			"l1_origin_safe", ss.SafeL2.L1Origin.Number,
+			"l1_head", l1Head)
+		lag = ss.CurrentL1.Number - ss.SafeL2.L1Origin.Number
+		t.Log("lag", lag) // TODO this lag starts out equal to the sequencing window, and eventually decreases to a lower value
+		if lag < 5 {      // What is a reasonable exit condition here? Let's say half the sequencing window
+			break
+		}
+	}
+
+	// env.Sequencer.ActWaitForUserTransactions(t)
+
+	// Run the test until the l1 origin is close to tip, to cover any residual issues with recover mode
+	//
+	// Asser that the unsafe chain keeps progressing (and we don't e.g. violate sequencer drift.)
 }
 
 // Runs a that proves a block in a chain where the batcher opens a channel, the sequence window expires, and then the
@@ -132,7 +178,7 @@ func Test_ProgramAction_SequenceWindowExpired(gt *testing.T) {
 	matrix := helpers.NewMatrix[any]()
 	defer matrix.Run(gt)
 
-	forks := helpers.ForkMatrix{helpers.Granite, helpers.LatestFork}
+	forks := helpers.ForkMatrix{helpers.LatestFork}
 	matrix.AddTestCase(
 		"HonestClaim",
 		nil,
@@ -140,27 +186,27 @@ func Test_ProgramAction_SequenceWindowExpired(gt *testing.T) {
 		runSequenceWindowExpireTest,
 		helpers.ExpectNoError(),
 	)
-	matrix.AddTestCase(
-		"JunkClaim",
-		nil,
-		forks,
-		runSequenceWindowExpireTest,
-		helpers.ExpectError(claim.ErrClaimNotValid),
-		helpers.WithL2Claim(common.HexToHash("0xdeadbeef")),
-	)
-	matrix.AddTestCase(
-		"ChannelCloseAfterWindowExpiry-HonestClaim",
-		nil,
-		forks,
-		runSequenceWindowExpire_ChannelCloseAfterWindowExpiry_Test,
-		helpers.ExpectNoError(),
-	)
-	matrix.AddTestCase(
-		"ChannelCloseAfterWindowExpiry-JunkClaim",
-		nil,
-		forks,
-		runSequenceWindowExpire_ChannelCloseAfterWindowExpiry_Test,
-		helpers.ExpectError(claim.ErrClaimNotValid),
-		helpers.WithL2Claim(common.HexToHash("0xdeadbeef")),
-	)
+	// matrix.AddTestCase(
+	// 	"JunkClaim",
+	// 	nil,
+	// 	forks,
+	// 	runSequenceWindowExpireTest,
+	// 	helpers.ExpectError(claim.ErrClaimNotValid),
+	// 	helpers.WithL2Claim(common.HexToHash("0xdeadbeef")),
+	// )
+	// matrix.AddTestCase(
+	// 	"ChannelCloseAfterWindowExpiry-HonestClaim",
+	// 	nil,
+	// 	forks,
+	// 	runSequenceWindowExpire_ChannelCloseAfterWindowExpiry_Test,
+	// 	helpers.ExpectNoError(),
+	// )
+	// matrix.AddTestCase(
+	// 	"ChannelCloseAfterWindowExpiry-JunkClaim",
+	// 	nil,
+	// 	forks,
+	// 	runSequenceWindowExpire_ChannelCloseAfterWindowExpiry_Test,
+	// 	helpers.ExpectError(claim.ErrClaimNotValid),
+	// 	helpers.WithL2Claim(common.HexToHash("0xdeadbeef")),
+	// )
 }

--- a/op-node/rollup/sequencing/origin_selector.go
+++ b/op-node/rollup/sequencing/origin_selector.go
@@ -87,6 +87,7 @@ func (los *L1OriginSelector) FindL1Origin(ctx context.Context, l2Head eth.L2Bloc
 	// of slack. For simplicity, we implement our Sequencer to always start building on the latest
 	// L1 block when we can.
 	if nextOrigin != (eth.L1BlockRef{}) && l2Head.Time+los.cfg.BlockTime >= nextOrigin.Time {
+		los.log.Info("Starting to build on top of the next origin", "next_origin", nextOrigin)
 		return nextOrigin, nil
 	}
 

--- a/op-node/rollup/sequencing/origin_selector.go
+++ b/op-node/rollup/sequencing/origin_selector.go
@@ -91,6 +91,8 @@ func (los *L1OriginSelector) FindL1Origin(ctx context.Context, l2Head eth.L2Bloc
 		return nextOrigin, nil
 	}
 
+	los.log.Info("next origin is foo and l2head", "next_origin", nextOrigin, "l2_head_time", l2Head.Time, "next_origin_time", nextOrigin.Time)
+
 	msd := los.spec.MaxSequencerDrift(currentOrigin.Time)
 	log := los.log.New("current", currentOrigin, "current_time", currentOrigin.Time,
 		"l2_head", l2Head, "l2_head_time", l2Head.Time, "max_seq_drift", msd)
@@ -99,6 +101,7 @@ func (los *L1OriginSelector) FindL1Origin(ctx context.Context, l2Head eth.L2Bloc
 
 	// If we are not past the max sequencer drift, we can just return the current origin.
 	if !pastSeqDrift {
+		log.Info("not pass seq drift")
 		return currentOrigin, nil
 	}
 
@@ -131,12 +134,14 @@ func (los *L1OriginSelector) CurrentAndNextOrigin(ctx context.Context, l2Head et
 	if los.recoverMode.Load() {
 		currentOrigin, err := los.l1.L1BlockRefByHash(ctx, l2Head.L1Origin.Hash)
 		if err != nil {
+			los.log.Error("failed to fetch current L1 origin", "error", err)
 			return eth.L1BlockRef{}, eth.L1BlockRef{},
 				derive.NewTemporaryError(fmt.Errorf("failed to fetch current L1 origin: %w", err))
 		}
 		los.currentOrigin = currentOrigin
 		nextOrigin, err := los.l1.L1BlockRefByNumber(ctx, currentOrigin.Number+1)
 		if err != nil {
+			los.log.Error("failed to fetch next L1 origin", "error", err)
 			return eth.L1BlockRef{}, eth.L1BlockRef{},
 				derive.NewTemporaryError(fmt.Errorf("failed to fetch next L1 origin: %w", err))
 		}

--- a/op-node/rollup/sequencing/origin_selector.go
+++ b/op-node/rollup/sequencing/origin_selector.go
@@ -140,7 +140,12 @@ func (los *L1OriginSelector) CurrentAndNextOrigin(ctx context.Context, l2Head et
 		}
 		los.currentOrigin = currentOrigin
 		nextOrigin, err := los.l1.L1BlockRefByNumber(ctx, currentOrigin.Number+1)
-		if err != nil {
+		if errors.Is(err, ethereum.NotFound) {
+			// If the next origin is not found, it means we are at the end of the chain.
+			// In this case, we set the next origin to an empty block reference.
+			los.nextOrigin = eth.L1BlockRef{}
+			return los.currentOrigin, los.nextOrigin, nil
+		} else if err != nil {
 			los.log.Error("failed to fetch next L1 origin", "error", err)
 			return eth.L1BlockRef{}, eth.L1BlockRef{},
 				derive.NewTemporaryError(fmt.Errorf("failed to fetch next L1 origin: %w", err))

--- a/op-node/rollup/sequencing/origin_selector.go
+++ b/op-node/rollup/sequencing/origin_selector.go
@@ -87,11 +87,8 @@ func (los *L1OriginSelector) FindL1Origin(ctx context.Context, l2Head eth.L2Bloc
 	// of slack. For simplicity, we implement our Sequencer to always start building on the latest
 	// L1 block when we can.
 	if nextOrigin != (eth.L1BlockRef{}) && l2Head.Time+los.cfg.BlockTime >= nextOrigin.Time {
-		los.log.Info("Starting to build on top of the next origin", "next_origin", nextOrigin)
 		return nextOrigin, nil
 	}
-
-	los.log.Info("next origin is foo and l2head", "next_origin", nextOrigin, "l2_head_time", l2Head.Time, "next_origin_time", nextOrigin.Time)
 
 	msd := los.spec.MaxSequencerDrift(currentOrigin.Time)
 	log := los.log.New("current", currentOrigin, "current_time", currentOrigin.Time,
@@ -101,7 +98,6 @@ func (los *L1OriginSelector) FindL1Origin(ctx context.Context, l2Head eth.L2Bloc
 
 	// If we are not past the max sequencer drift, we can just return the current origin.
 	if !pastSeqDrift {
-		log.Info("not pass seq drift")
 		return currentOrigin, nil
 	}
 
@@ -134,7 +130,6 @@ func (los *L1OriginSelector) CurrentAndNextOrigin(ctx context.Context, l2Head et
 	if los.recoverMode.Load() {
 		currentOrigin, err := los.l1.L1BlockRefByHash(ctx, l2Head.L1Origin.Hash)
 		if err != nil {
-			los.log.Error("failed to fetch current L1 origin", "error", err)
 			return eth.L1BlockRef{}, eth.L1BlockRef{},
 				derive.NewTemporaryError(fmt.Errorf("failed to fetch current L1 origin: %w", err))
 		}
@@ -143,10 +138,10 @@ func (los *L1OriginSelector) CurrentAndNextOrigin(ctx context.Context, l2Head et
 		if errors.Is(err, ethereum.NotFound) {
 			// If the next origin is not found, it means we are at the end of the chain.
 			// In this case, we set the next origin to an empty block reference.
+			los.log.Error("next L1 origin not found, recover mode likely brought L1 origin up to the tip of the chain", "error", err)
 			los.nextOrigin = eth.L1BlockRef{}
 			return los.currentOrigin, los.nextOrigin, nil
 		} else if err != nil {
-			los.log.Error("failed to fetch next L1 origin", "error", err)
 			return eth.L1BlockRef{}, eth.L1BlockRef{},
 				derive.NewTemporaryError(fmt.Errorf("failed to fetch next L1 origin: %w", err))
 		}

--- a/op-node/rollup/sequencing/origin_selector_test.go
+++ b/op-node/rollup/sequencing/origin_selector_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/confdepth"
-	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/engine"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
@@ -213,9 +212,7 @@ func TestOriginSelectorAdvances(t *testing.T) {
 			// is not ready yet by simulating a NotFound error.
 			l1.ExpectL1BlockRefByHash(c.Hash, c, nil)
 			l1.ExpectL1BlockRefByNumber(d.Number, eth.BlockRef{}, ethereum.NotFound)
-			_, err := s.FindL1Origin(ctx, l2Head)
-			require.ErrorIs(t, err, derive.ErrTemporary)
-			require.ErrorIs(t, err, ethereum.NotFound)
+			requireL1OriginAt(l2Head, c)
 
 			// Now, simulate the block being ready, and ensure
 			// that the origin advances to the next block.

--- a/op-node/rollup/sequencing/sequencer.go
+++ b/op-node/rollup/sequencing/sequencer.go
@@ -377,7 +377,6 @@ func (d *Sequencer) onSequencerAction(ev SequencerActionEvent) {
 		d.latest.Ref = ref
 	} else {
 		if d.latest.Info != (eth.PayloadInfo{}) {
-			d.log.Debug("Payload is known, we must have resumed sequencer-actions after a temporary error, meaning that we have seen BuildSealedEvent already.")
 			// We should not repeat the seal request.
 			d.nextActionOK = false
 			// No known payload for block building job,
@@ -389,7 +388,6 @@ func (d *Sequencer) onSequencerAction(ev SequencerActionEvent) {
 				DerivedFrom:  eth.L1BlockRef{},
 			})
 		} else if d.latest == (BuildingState{}) {
-			d.log.Debug("foobar.")
 			// If we have not started building anything, start building.
 			d.startBuildingBlock()
 		}

--- a/op-node/rollup/sequencing/sequencer.go
+++ b/op-node/rollup/sequencing/sequencer.go
@@ -377,6 +377,7 @@ func (d *Sequencer) onSequencerAction(ev SequencerActionEvent) {
 		d.latest.Ref = ref
 	} else {
 		if d.latest.Info != (eth.PayloadInfo{}) {
+			d.log.Debug("Payload is known, we must have resumed sequencer-actions after a temporary error, meaning that we have seen BuildSealedEvent already.")
 			// We should not repeat the seal request.
 			d.nextActionOK = false
 			// No known payload for block building job,
@@ -388,6 +389,7 @@ func (d *Sequencer) onSequencerAction(ev SequencerActionEvent) {
 				DerivedFrom:  eth.L1BlockRef{},
 			})
 		} else if d.latest == (BuildingState{}) {
+			d.log.Debug("foobar.")
 			// If we have not started building anything, start building.
 			d.startBuildingBlock()
 		}


### PR DESCRIPTION
Closes https://github.com/ethereum-optimism/optimism/issues/18350

Adds an action test showing how recover mode can work to recover a chain, with explanatory notes about how operators should not use span batches. This can be developed into a better runbook for recovering from a sequencing window expiry incident. 