### PR TITLE
op-acceptance-tests: batcher: add pending nonce busy wait

### DIFF
--- a/op-acceptance-tests/tests/batcher/batcher_test.go
+++ b/op-acceptance-tests/tests/batcher/batcher_test.go
@@ -42,13 +42,16 @@ func TestBatcherFullChannelsAfterDowntime(gt *testing.T) {
 
 		for i := 0; i < 5; i++ {
 			l.Debug("Sequencing L2 block", "iteration", i, "parent", parent)
-			sequenceBlockWithL1Origin(t, ts_L2, parent, l1Origin, alice, cathrine, nonce)
+			sequenceBlockWithL1Origin(t, ts_L2, parent, l1Origin, cathrine, alice, nonce)
 			nonce++
 
 			parent = sys.L2CL.HeadBlockRef(types.LocalUnsafe).Hash
 
+			// we need to wait for the nonce for the address on the L2 EL client to be updated
+			// so that we can sequence the next block
+			sys.L2EL.PendingNonceMatched(cathrine.Address(), nonce, 10, 1*time.Second)
+
 			sys.AdvanceTime(time.Second * 2)
-			time.Sleep(20 * time.Millisecond) // failed to force-include tx: type: 2 sender; err: nonce too high
 		}
 
 		l.Debug("Sequencing L1 block", "iteration_j", j)
@@ -95,12 +98,12 @@ func TestBatcherFullChannelsAfterDowntime(gt *testing.T) {
 	spew.Dump(status)
 }
 
-func sequenceBlockWithL1Origin(t devtest.T, ts apis.TestSequencerControlAPI, parent common.Hash, l1Origin common.Hash, alice *dsl.EOA, cathrine *dsl.EOA, nonce uint64) {
+func sequenceBlockWithL1Origin(t devtest.T, ts apis.TestSequencerControlAPI, parent common.Hash, l1Origin common.Hash, from *dsl.EOA, to *dsl.EOA, nonce uint64) {
 	require.NoError(t, ts.New(t.Ctx(), seqtypes.BuildOpts{Parent: parent, L1Origin: &l1Origin}))
 
 	// include simple transfer tx in opened block
 	{
-		to := cathrine.PlanTransfer(alice.Address(), eth.OneWei)
+		to := from.PlanTransfer(to.Address(), eth.OneWei)
 		opt := txplan.Combine(to, txplan.WithStaticNonce(nonce))
 		ptx := txplan.NewPlannedTx(opt)
 		signed_tx, err := ptx.Signed.Eval(t.Ctx())

--- a/op-acceptance-tests/tests/batcher/batcher_test.go
+++ b/op-acceptance-tests/tests/batcher/batcher_test.go
@@ -47,9 +47,7 @@ func TestBatcherFullChannelsAfterDowntime(gt *testing.T) {
 
 			parent = sys.L2CL.HeadBlockRef(types.LocalUnsafe).Hash
 
-			// we need to wait for the nonce for the address on the L2 EL client to be updated
-			// so that we can sequence the next block
-			sys.L2EL.PendingNonceMatched(cathrine.Address(), nonce, 10, 1*time.Second)
+			sys.L2EL.WaitForPendingNonceMatch(cathrine.Address(), nonce, 10, 1*time.Second)
 
 			sys.AdvanceTime(time.Second * 2)
 		}

--- a/op-devstack/dsl/l2_el.go
+++ b/op-devstack/dsl/l2_el.go
@@ -357,8 +357,8 @@ func (el *L2ELNode) MatchedUnsafe(refNode SyncStatusProvider, attempts int) {
 	el.Matched(refNode, types.LocalUnsafe, attempts)
 }
 
-// PendingNonceMatchedFn returns a lambda that checks that the pending nonce of an account matches the provided reference nonce
-func (el *L2ELNode) PendingNonceMatchedFn(account common.Address, nonce uint64, attempts int, duration time.Duration) CheckFunc {
+// WaitForPendingNonceMatchFn returns a lambda that waits for the pending nonce of an account to match the provided reference nonce
+func (el *L2ELNode) WaitForPendingNonceMatchFn(account common.Address, nonce uint64, attempts int, duration time.Duration) CheckFunc {
 	return func() error {
 		logger := el.log.With("id", el.inner.ID(), "account", account)
 		logger.Debug("Expecting pending nonce to match with reference nonce", "nonce", nonce)
@@ -380,9 +380,9 @@ func (el *L2ELNode) PendingNonceMatchedFn(account common.Address, nonce uint64, 
 	}
 }
 
-// PendingNonceMatched checks that the pending nonce of an account matches the reference nonce
-func (el *L2ELNode) PendingNonceMatched(account common.Address, nonce uint64, attempts int, duration time.Duration) {
-	el.require.NoError(el.PendingNonceMatchedFn(account, nonce, attempts, duration)())
+// WaitForPendingNonceMatch waits for the pending nonce of an account to match the reference nonce
+func (el *L2ELNode) WaitForPendingNonceMatch(account common.Address, nonce uint64, attempts int, duration time.Duration) {
+	el.require.NoError(el.WaitForPendingNonceMatchFn(account, nonce, attempts, duration)())
 }
 
 func (el *L2ELNode) UnsafeHead() *BlockRefResult {

--- a/op-devstack/dsl/l2_el.go
+++ b/op-devstack/dsl/l2_el.go
@@ -357,6 +357,35 @@ func (el *L2ELNode) MatchedUnsafe(refNode SyncStatusProvider, attempts int) {
 	el.Matched(refNode, types.LocalUnsafe, attempts)
 }
 
+// PendingNonceMatchedFn returns a lambda that checks that the pending nonce of an account matches between two L2EL nodes
+// Composable with other lambdas to wait in parallel
+func (el *L2ELNode) PendingNonceMatchedFn(account common.Address, nonce uint64, attempts int, duration time.Duration) CheckFunc {
+	return func() error {
+		logger := el.log.With("id", el.inner.ID(), "account", account)
+		logger.Debug("Expecting pending nonce to match with reference nonce", "nonce", nonce)
+		return retry.Do0(el.ctx, attempts, &retry.FixedStrategy{Dur: duration},
+			func() error {
+				baseNonce, err := el.inner.EthClient().PendingNonceAt(el.ctx, account)
+				if err != nil {
+					return fmt.Errorf("failed to get pending nonce from base node: %w", err)
+				}
+
+				if baseNonce == nonce {
+					logger.Debug("Pending nonce matched", "nonce", baseNonce)
+					return nil
+				}
+
+				logger.Debug("Pending nonce mismatch", "base", baseNonce, "nonce", nonce)
+				return fmt.Errorf("expected pending nonce to match: base=%d, nonce=%d", baseNonce, nonce)
+			})
+	}
+}
+
+// PendingNonceMatched checks that the pending nonce of an account matches between two L2EL nodes
+func (el *L2ELNode) PendingNonceMatched(account common.Address, nonce uint64, attempts int, duration time.Duration) {
+	el.require.NoError(el.PendingNonceMatchedFn(account, nonce, attempts, duration)())
+}
+
 func (el *L2ELNode) UnsafeHead() *BlockRefResult {
 	return &BlockRefResult{T: el.t, BlockRef: el.BlockRefByLabel(eth.Unsafe)}
 }

--- a/op-devstack/dsl/l2_el.go
+++ b/op-devstack/dsl/l2_el.go
@@ -357,8 +357,7 @@ func (el *L2ELNode) MatchedUnsafe(refNode SyncStatusProvider, attempts int) {
 	el.Matched(refNode, types.LocalUnsafe, attempts)
 }
 
-// PendingNonceMatchedFn returns a lambda that checks that the pending nonce of an account matches between two L2EL nodes
-// Composable with other lambdas to wait in parallel
+// PendingNonceMatchedFn returns a lambda that checks that the pending nonce of an account matches the provided reference nonce
 func (el *L2ELNode) PendingNonceMatchedFn(account common.Address, nonce uint64, attempts int, duration time.Duration) CheckFunc {
 	return func() error {
 		logger := el.log.With("id", el.inner.ID(), "account", account)
@@ -367,7 +366,7 @@ func (el *L2ELNode) PendingNonceMatchedFn(account common.Address, nonce uint64, 
 			func() error {
 				baseNonce, err := el.inner.EthClient().PendingNonceAt(el.ctx, account)
 				if err != nil {
-					return fmt.Errorf("failed to get pending nonce from base node: %w", err)
+					return fmt.Errorf("failed to get pending nonce from node: %w", err)
 				}
 
 				if baseNonce == nonce {
@@ -375,13 +374,13 @@ func (el *L2ELNode) PendingNonceMatchedFn(account common.Address, nonce uint64, 
 					return nil
 				}
 
-				logger.Debug("Pending nonce mismatch", "base", baseNonce, "nonce", nonce)
-				return fmt.Errorf("expected pending nonce to match: base=%d, nonce=%d", baseNonce, nonce)
+				logger.Debug("Pending nonce mismatch", "node nonce", baseNonce, "nonce", nonce)
+				return fmt.Errorf("expected pending nonce to match: node nonce=%d, reference nonce=%d", baseNonce, nonce)
 			})
 	}
 }
 
-// PendingNonceMatched checks that the pending nonce of an account matches between two L2EL nodes
+// PendingNonceMatched checks that the pending nonce of an account matches the reference nonce
 func (el *L2ELNode) PendingNonceMatched(account common.Address, nonce uint64, attempts int, duration time.Duration) {
 	el.require.NoError(el.PendingNonceMatchedFn(account, nonce, attempts, duration)())
 }


### PR DESCRIPTION
Fixes flaky `TestBatcherFullChannelsAfterDowntime`: https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/109897/workflows/2139022a-304d-4dbd-a208-1431ff221b5a/jobs/4176693/tests  

This is due to blocks being sequenced too quickly for the EL to update the pending nonce of a sending EOA.