### PR TITLE
feat: add SuperFaultDisputeGameV2

### DIFF
--- a/packages/contracts-bedrock/interfaces/dispute/v2/ISuperFaultDisputeGameV2.sol
+++ b/packages/contracts-bedrock/interfaces/dispute/v2/ISuperFaultDisputeGameV2.sol
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import { IDisputeGame } from "interfaces/dispute/IDisputeGame.sol";
+import { IDelayedWETH } from "interfaces/dispute/IDelayedWETH.sol";
+import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.sol";
+import { IBigStepper } from "interfaces/dispute/IBigStepper.sol";
+import { Claim, Position, Clock, Hash, Duration, BondDistributionMode } from "src/dispute/lib/Types.sol";
+
+interface ISuperFaultDisputeGameV2 is IDisputeGame {
+    struct ClaimData {
+        uint32 parentIndex;
+        address counteredBy;
+        address claimant;
+        uint128 bond;
+        Claim claim;
+        Position position;
+        Clock clock;
+    }
+
+    struct ResolutionCheckpoint {
+        bool initialCheckpointComplete;
+        uint32 subgameIndex;
+        Position leftmostPosition;
+        address counteredBy;
+    }
+
+    struct GameConstructorParams {
+        uint256 maxGameDepth;
+        uint256 splitDepth;
+        Duration clockExtension;
+        Duration maxClockDuration;
+    }
+
+    error AlreadyInitialized();
+    error AnchorRootNotFound();
+    error BadExtraData();
+    error BondTransferFailed();
+    error CannotDefendRootClaim();
+    error ClaimAboveSplit();
+    error ClaimAlreadyExists();
+    error ClaimAlreadyResolved();
+    error ClockNotExpired();
+    error ClockTimeExceeded();
+    error DuplicateStep();
+    error GameDepthExceeded();
+    error GameNotInProgress();
+    error IncorrectBondAmount();
+    error InvalidChallengePeriod();
+    error InvalidClockExtension();
+    error InvalidDisputedClaimIndex();
+    error InvalidLocalIdent();
+    error InvalidParent();
+    error InvalidPrestate();
+    error InvalidSplitDepth();
+    error MaxDepthTooLarge();
+    error NoCreditToClaim();
+    error NoChainIdNeeded();
+    error OutOfOrderResolution();
+    error SuperFaultDisputeGameInvalidRootClaim();
+    error UnexpectedRootClaim(Claim rootClaim);
+    error ValidStep();
+    error InvalidBondDistributionMode();
+    error GameNotFinalized();
+    error GameNotResolved();
+    error GamePaused();
+    event Move(uint256 indexed parentIndex, Claim indexed claim, address indexed claimant);
+    event GameClosed(BondDistributionMode bondDistributionMode);
+
+    function absolutePrestate() external view returns (Claim absolutePrestate_);
+    function addLocalData(uint256 _ident, uint256 _execLeafIdx, uint256 _partOffset) external;
+    function anchorStateRegistry() external view returns (IAnchorStateRegistry registry_);
+    function attack(Claim _disputed, uint256 _parentIndex, Claim _claim) external payable;
+    function bondDistributionMode() external view returns (BondDistributionMode);
+    function claimCredit(address _recipient) external;
+    function claimData(uint256)
+        external
+        view // nosemgrep
+        returns (
+            uint32 parentIndex,
+            address counteredBy,
+            address claimant,
+            uint128 bond,
+            Claim claim,
+            Position position,
+            Clock clock
+        );
+    function claimDataLen() external view returns (uint256 len_);
+    function claims(Hash) external view returns (bool);
+    function clockExtension() external view returns (Duration clockExtension_);
+    function closeGame() external;
+    function credit(address _recipient) external view returns (uint256 credit_);
+    function defend(Claim _disputed, uint256 _parentIndex, Claim _claim) external payable;
+    function getChallengerDuration(uint256 _claimIndex) external view returns (Duration duration_);
+    function getNumToResolve(uint256 _claimIndex) external view returns (uint256 numRemainingChildren_);
+    function getRequiredBond(Position _position) external view returns (uint256 requiredBond_);
+    function hasUnlockedCredit(address) external view returns (bool);
+    function maxClockDuration() external view returns (Duration maxClockDuration_);
+    function maxGameDepth() external view returns (uint256 maxGameDepth_);
+    function move(Claim _disputed, uint256 _challengeIndex, Claim _claim, bool _isAttack) external payable;
+    function normalModeCredit(address) external view returns (uint256);
+    function l2SequenceNumber() external pure returns (uint256 l2SequenceNumber_);
+    function refundModeCredit(address) external view returns (uint256);
+    function resolutionCheckpoints(uint256)
+        external
+        view
+        returns (bool initialCheckpointComplete, uint32 subgameIndex, Position leftmostPosition, address counteredBy); // nosemgrep
+    function resolveClaim(uint256 _claimIndex, uint256 _numToResolve) external;
+    function resolvedSubgames(uint256) external view returns (bool);
+    function splitDepth() external view returns (uint256 splitDepth_);
+    function startingSequenceNumber() external view returns (uint256 startingSequenceNumber_);
+    function startingProposal() external view returns (Hash root, uint256 l2SequenceNumber); // nosemgrep
+    function startingRootHash() external view returns (Hash startingRootHash_);
+    function step(uint256 _claimIndex, bool _isAttack, bytes memory _stateData, bytes memory _proof) external;
+    function subgames(uint256, uint256) external view returns (uint256);
+    function version() external pure returns (string memory);
+    function vm() external view returns (IBigStepper vm_);
+    function wasRespectedGameTypeWhenCreated() external view returns (bool);
+    function weth() external view returns (IDelayedWETH weth_);
+
+    function __constructor__(GameConstructorParams memory _params) external;
+}

--- a/packages/contracts-bedrock/snapshots/abi/SuperFaultDisputeGameV2.json
+++ b/packages/contracts-bedrock/snapshots/abi/SuperFaultDisputeGameV2.json
@@ -1,0 +1,1053 @@
+[
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "maxGameDepth",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "splitDepth",
+            "type": "uint256"
+          },
+          {
+            "internalType": "Duration",
+            "name": "clockExtension",
+            "type": "uint64"
+          },
+          {
+            "internalType": "Duration",
+            "name": "maxClockDuration",
+            "type": "uint64"
+          }
+        ],
+        "internalType": "struct SuperFaultDisputeGameV2.GameConstructorParams",
+        "name": "_params",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
+    "name": "absolutePrestate",
+    "outputs": [
+      {
+        "internalType": "Claim",
+        "name": "absolutePrestate_",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_ident",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_execLeafIdx",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_partOffset",
+        "type": "uint256"
+      }
+    ],
+    "name": "addLocalData",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "anchorStateRegistry",
+    "outputs": [
+      {
+        "internalType": "contract IAnchorStateRegistry",
+        "name": "registry_",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "Claim",
+        "name": "_disputed",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_parentIndex",
+        "type": "uint256"
+      },
+      {
+        "internalType": "Claim",
+        "name": "_claim",
+        "type": "bytes32"
+      }
+    ],
+    "name": "attack",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "bondDistributionMode",
+    "outputs": [
+      {
+        "internalType": "enum BondDistributionMode",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_recipient",
+        "type": "address"
+      }
+    ],
+    "name": "claimCredit",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "claimData",
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "parentIndex",
+        "type": "uint32"
+      },
+      {
+        "internalType": "address",
+        "name": "counteredBy",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "claimant",
+        "type": "address"
+      },
+      {
+        "internalType": "uint128",
+        "name": "bond",
+        "type": "uint128"
+      },
+      {
+        "internalType": "Claim",
+        "name": "claim",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "Position",
+        "name": "position",
+        "type": "uint128"
+      },
+      {
+        "internalType": "Clock",
+        "name": "clock",
+        "type": "uint128"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "claimDataLen",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "len_",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "Hash",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "claims",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "clockExtension",
+    "outputs": [
+      {
+        "internalType": "Duration",
+        "name": "clockExtension_",
+        "type": "uint64"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "closeGame",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "createdAt",
+    "outputs": [
+      {
+        "internalType": "Timestamp",
+        "name": "",
+        "type": "uint64"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_recipient",
+        "type": "address"
+      }
+    ],
+    "name": "credit",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "credit_",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "Claim",
+        "name": "_disputed",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_parentIndex",
+        "type": "uint256"
+      },
+      {
+        "internalType": "Claim",
+        "name": "_claim",
+        "type": "bytes32"
+      }
+    ],
+    "name": "defend",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "extraData",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "extraData_",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "gameCreator",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "creator_",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "gameData",
+    "outputs": [
+      {
+        "internalType": "GameType",
+        "name": "gameType_",
+        "type": "uint32"
+      },
+      {
+        "internalType": "Claim",
+        "name": "rootClaim_",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes",
+        "name": "extraData_",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "gameType",
+    "outputs": [
+      {
+        "internalType": "GameType",
+        "name": "gameType_",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_claimIndex",
+        "type": "uint256"
+      }
+    ],
+    "name": "getChallengerDuration",
+    "outputs": [
+      {
+        "internalType": "Duration",
+        "name": "duration_",
+        "type": "uint64"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_claimIndex",
+        "type": "uint256"
+      }
+    ],
+    "name": "getNumToResolve",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "numRemainingChildren_",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "Position",
+        "name": "_position",
+        "type": "uint128"
+      }
+    ],
+    "name": "getRequiredBond",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "requiredBond_",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "hasUnlockedCredit",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "l1Head",
+    "outputs": [
+      {
+        "internalType": "Hash",
+        "name": "l1Head_",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "l2SequenceNumber",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "l2SequenceNumber_",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "maxClockDuration",
+    "outputs": [
+      {
+        "internalType": "Duration",
+        "name": "maxClockDuration_",
+        "type": "uint64"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "maxGameDepth",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "maxGameDepth_",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "Claim",
+        "name": "_disputed",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_challengeIndex",
+        "type": "uint256"
+      },
+      {
+        "internalType": "Claim",
+        "name": "_claim",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bool",
+        "name": "_isAttack",
+        "type": "bool"
+      }
+    ],
+    "name": "move",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "normalModeCredit",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "refundModeCredit",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "resolutionCheckpoints",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "initialCheckpointComplete",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint32",
+        "name": "subgameIndex",
+        "type": "uint32"
+      },
+      {
+        "internalType": "Position",
+        "name": "leftmostPosition",
+        "type": "uint128"
+      },
+      {
+        "internalType": "address",
+        "name": "counteredBy",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "resolve",
+    "outputs": [
+      {
+        "internalType": "enum GameStatus",
+        "name": "status_",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_claimIndex",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_numToResolve",
+        "type": "uint256"
+      }
+    ],
+    "name": "resolveClaim",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "resolvedAt",
+    "outputs": [
+      {
+        "internalType": "Timestamp",
+        "name": "",
+        "type": "uint64"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "resolvedSubgames",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "rootClaim",
+    "outputs": [
+      {
+        "internalType": "Claim",
+        "name": "rootClaim_",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "splitDepth",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "splitDepth_",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "startingProposal",
+    "outputs": [
+      {
+        "internalType": "Hash",
+        "name": "root",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "l2SequenceNumber",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "startingRootHash",
+    "outputs": [
+      {
+        "internalType": "Hash",
+        "name": "startingRootHash_",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "startingSequenceNumber",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "startingSequenceNumber_",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "status",
+    "outputs": [
+      {
+        "internalType": "enum GameStatus",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_claimIndex",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "_isAttack",
+        "type": "bool"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_stateData",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_proof",
+        "type": "bytes"
+      }
+    ],
+    "name": "step",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "subgames",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "version",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "vm",
+    "outputs": [
+      {
+        "internalType": "contract IBigStepper",
+        "name": "vm_",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "wasRespectedGameTypeWhenCreated",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "weth",
+    "outputs": [
+      {
+        "internalType": "contract IDelayedWETH",
+        "name": "weth_",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "enum BondDistributionMode",
+        "name": "bondDistributionMode",
+        "type": "uint8"
+      }
+    ],
+    "name": "GameClosed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "parentIndex",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "Claim",
+        "name": "claim",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "claimant",
+        "type": "address"
+      }
+    ],
+    "name": "Move",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "enum GameStatus",
+        "name": "status",
+        "type": "uint8"
+      }
+    ],
+    "name": "Resolved",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "AlreadyInitialized",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "AnchorRootNotFound",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "BadExtraData",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "BondTransferFailed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "CannotDefendRootClaim",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ClaimAboveSplit",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ClaimAlreadyExists",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ClaimAlreadyResolved",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ClockNotExpired",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ClockTimeExceeded",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DuplicateStep",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "GameDepthExceeded",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "GameNotFinalized",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "GameNotInProgress",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "GameNotResolved",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "GamePaused",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "IncorrectBondAmount",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidBondDistributionMode",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidChallengePeriod",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidClockExtension",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidDisputedClaimIndex",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidLocalIdent",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidParent",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidPrestate",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidSplitDepth",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "MaxDepthTooLarge",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NoChainIdNeeded",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NoCreditToClaim",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "OutOfOrderResolution",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "SuperFaultDisputeGameInvalidRootClaim",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "Claim",
+        "name": "rootClaim",
+        "type": "bytes32"
+      }
+    ],
+    "name": "UnexpectedRootClaim",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ValidStep",
+    "type": "error"
+  }
+]

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -219,6 +219,10 @@
     "initCodeHash": "0x9896fd04e9a3f9fe4f1d6e93eb298b37a6bfa33424aa705e68cc58d0ba7f3f90",
     "sourceCodeHash": "0xc0ff6e93b6e2b9111c11e81b5df8948ab71d02b9d2c4dfda982fcb615519f1f7"
   },
+  "src/dispute/v2/SuperFaultDisputeGameV2.sol:SuperFaultDisputeGameV2": {
+    "initCodeHash": "0xb4a51d5819db35363750aad696c91b60704364a2074dcc7831ef93ef064617eb",
+    "sourceCodeHash": "0x62f45ebe56e6003645858dc2594be1cfa60b95170d3aa394bfecae9f54acd26b"
+  },
   "src/dispute/zk/OPSuccinctFaultDisputeGame.sol:OPSuccinctFaultDisputeGame": {
     "initCodeHash": "0xb9d0d9ca4df242f188b2d5be7d692459a12409a67a6504ef44ef589c6ca2c1a9",
     "sourceCodeHash": "0x85f80adb845f59e9137d462e219c0cdba27058be77d855075e286aa316735aa0"

--- a/packages/contracts-bedrock/snapshots/storageLayout/SuperFaultDisputeGameV2.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/SuperFaultDisputeGameV2.json
@@ -1,0 +1,107 @@
+[
+  {
+    "bytes": "8",
+    "label": "createdAt",
+    "offset": 0,
+    "slot": "0",
+    "type": "Timestamp"
+  },
+  {
+    "bytes": "8",
+    "label": "resolvedAt",
+    "offset": 8,
+    "slot": "0",
+    "type": "Timestamp"
+  },
+  {
+    "bytes": "1",
+    "label": "status",
+    "offset": 16,
+    "slot": "0",
+    "type": "enum GameStatus"
+  },
+  {
+    "bytes": "1",
+    "label": "initialized",
+    "offset": 17,
+    "slot": "0",
+    "type": "bool"
+  },
+  {
+    "bytes": "32",
+    "label": "claimData",
+    "offset": 0,
+    "slot": "1",
+    "type": "struct SuperFaultDisputeGameV2.ClaimData[]"
+  },
+  {
+    "bytes": "32",
+    "label": "normalModeCredit",
+    "offset": 0,
+    "slot": "2",
+    "type": "mapping(address => uint256)"
+  },
+  {
+    "bytes": "32",
+    "label": "claims",
+    "offset": 0,
+    "slot": "3",
+    "type": "mapping(Hash => bool)"
+  },
+  {
+    "bytes": "32",
+    "label": "subgames",
+    "offset": 0,
+    "slot": "4",
+    "type": "mapping(uint256 => uint256[])"
+  },
+  {
+    "bytes": "32",
+    "label": "resolvedSubgames",
+    "offset": 0,
+    "slot": "5",
+    "type": "mapping(uint256 => bool)"
+  },
+  {
+    "bytes": "32",
+    "label": "resolutionCheckpoints",
+    "offset": 0,
+    "slot": "6",
+    "type": "mapping(uint256 => struct SuperFaultDisputeGameV2.ResolutionCheckpoint)"
+  },
+  {
+    "bytes": "64",
+    "label": "startingProposal",
+    "offset": 0,
+    "slot": "7",
+    "type": "struct Proposal"
+  },
+  {
+    "bytes": "1",
+    "label": "wasRespectedGameTypeWhenCreated",
+    "offset": 0,
+    "slot": "9",
+    "type": "bool"
+  },
+  {
+    "bytes": "32",
+    "label": "refundModeCredit",
+    "offset": 0,
+    "slot": "10",
+    "type": "mapping(address => uint256)"
+  },
+  {
+    "bytes": "32",
+    "label": "hasUnlockedCredit",
+    "offset": 0,
+    "slot": "11",
+    "type": "mapping(address => bool)"
+  },
+  {
+    "bytes": "1",
+    "label": "bondDistributionMode",
+    "offset": 0,
+    "slot": "12",
+    "type": "enum BondDistributionMode"
+  }
+]

--- a/packages/contracts-bedrock/src/dispute/v2/SuperFaultDisputeGameV2.sol
+++ b/packages/contracts-bedrock/src/dispute/v2/SuperFaultDisputeGameV2.sol
@@ -1,0 +1,1227 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+// Libraries
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
+import { FixedPointMathLib } from "@solady/utils/FixedPointMathLib.sol";
+import { Clone } from "@solady/utils/Clone.sol";
+import {
+    GameStatus,
+    GameType,
+    BondDistributionMode,
+    Claim,
+    Clock,
+    Duration,
+    Timestamp,
+    Hash,
+    Proposal,
+    LibClock,
+    LocalPreimageKey,
+    VMStatuses
+} from "src/dispute/lib/Types.sol";
+import { Position, LibPosition } from "src/dispute/lib/LibPosition.sol";
+import {
+    InvalidParent,
+    ClaimAlreadyExists,
+    ClaimAlreadyResolved,
+    OutOfOrderResolution,
+    InvalidChallengePeriod,
+    InvalidSplitDepth,
+    InvalidClockExtension,
+    MaxDepthTooLarge,
+    AnchorRootNotFound,
+    AlreadyInitialized,
+    UnexpectedRootClaim,
+    GameNotInProgress,
+    InvalidPrestate,
+    ValidStep,
+    GameDepthExceeded,
+    InvalidDisputedClaimIndex,
+    ClockTimeExceeded,
+    DuplicateStep,
+    CannotDefendRootClaim,
+    IncorrectBondAmount,
+    InvalidLocalIdent,
+    ClockNotExpired,
+    BondTransferFailed,
+    NoCreditToClaim,
+    ClaimAboveSplit,
+    GameNotFinalized,
+    InvalidBondDistributionMode,
+    GameNotResolved,
+    GamePaused,
+    BadExtraData
+} from "src/dispute/lib/Errors.sol";
+
+// Interfaces
+import { ISemver } from "interfaces/universal/ISemver.sol";
+import { IDelayedWETH } from "interfaces/dispute/IDelayedWETH.sol";
+import { IBigStepper, IPreimageOracle } from "interfaces/dispute/IBigStepper.sol";
+import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.sol";
+import { IDisputeGame } from "interfaces/dispute/IDisputeGame.sol";
+
+/// @title SuperFaultDisputeGameV2
+/// @notice An implementation of the `IFaultDisputeGame` interface for interop.
+contract SuperFaultDisputeGameV2 is Clone, ISemver {
+    /// @dev Error to prevent initialization a dispute game with an actually valid, invalid state
+    error SuperFaultDisputeGameInvalidRootClaim();
+    /// @dev Error to prevent passing a chainId to this dispute game
+    error NoChainIdNeeded();
+
+    ////////////////////////////////////////////////////////////////
+    //                         Structs                            //
+    ////////////////////////////////////////////////////////////////
+
+    /// @notice The `ClaimData` struct represents the data associated with a Claim.
+    struct ClaimData {
+        uint32 parentIndex;
+        address counteredBy;
+        address claimant;
+        uint128 bond;
+        Claim claim;
+        Position position;
+        Clock clock;
+    }
+
+    /// @notice The `ResolutionCheckpoint` struct represents the data associated with an in-progress claim resolution.
+    struct ResolutionCheckpoint {
+        bool initialCheckpointComplete;
+        uint32 subgameIndex;
+        Position leftmostPosition;
+        address counteredBy;
+    }
+
+    /// @notice Parameters for creating a new SuperFaultDisputeGame. We place this into a struct to
+    ///         avoid stack-too-deep errors when compiling without the optimizer enabled.
+    struct GameConstructorParams {
+        uint256 maxGameDepth;
+        uint256 splitDepth;
+        Duration clockExtension;
+        Duration maxClockDuration;
+    }
+
+    ////////////////////////////////////////////////////////////////
+    //                         Events                             //
+    ////////////////////////////////////////////////////////////////
+
+    /// @notice Emitted when the game is resolved.
+    /// @param status The status of the game after resolution.
+    event Resolved(GameStatus indexed status);
+
+    /// @notice Emitted when a new claim is added to the DAG by `claimant`
+    /// @param parentIndex The index within the `claimData` array of the parent claim
+    /// @param claim The claim being added
+    /// @param claimant The address of the claimant
+    event Move(uint256 indexed parentIndex, Claim indexed claim, address indexed claimant);
+
+    /// @notice Emitted when the game is closed.
+    event GameClosed(BondDistributionMode bondDistributionMode);
+
+    ////////////////////////////////////////////////////////////////
+    //                         State Vars                         //
+    ////////////////////////////////////////////////////////////////
+
+    /// @notice The constant for invalid root claims.
+    bytes32 internal constant INVALID_ROOT_CLAIM = keccak256("invalid");
+
+    /// @notice The max depth of the game.
+    uint256 internal immutable MAX_GAME_DEPTH;
+
+    /// @notice The max depth of the output bisection portion of the position tree. Immediately beneath
+    ///         this depth, execution trace bisection begins.
+    uint256 internal immutable SPLIT_DEPTH;
+
+    /// @notice The maximum duration that may accumulate on a team's chess clock before they may no longer respond.
+    Duration internal immutable MAX_CLOCK_DURATION;
+
+    /// @notice The duration of the clock extension. Will be doubled if the grandchild is the root claim of an execution
+    ///         trace bisection subgame.
+    Duration internal immutable CLOCK_EXTENSION;
+
+    /// @notice The global root claim's position is always at gindex 1.
+    Position internal constant ROOT_POSITION = Position.wrap(1);
+
+    /// @notice Semantic version.
+    /// @custom:semver 0.7.0
+    function version() public pure virtual returns (string memory) {
+        return "0.7.0";
+    }
+
+    /// @notice The starting timestamp of the game
+    Timestamp public createdAt;
+
+    /// @notice The timestamp of the game's global resolution.
+    Timestamp public resolvedAt;
+
+    /// @notice Returns the current status of the game.
+    GameStatus public status;
+
+    /// @notice Flag for the `initialize` function to prevent re-initialization.
+    bool internal initialized;
+
+    /// @notice An append-only array of all claims made during the dispute game.
+    ClaimData[] public claimData;
+
+    /// @notice Credited balances for winning participants.
+    mapping(address => uint256) public normalModeCredit;
+
+    /// @notice A mapping to allow for constant-time lookups of existing claims.
+    mapping(Hash => bool) public claims;
+
+    /// @notice A mapping of subgames rooted at a claim index to other claim indices in the subgame.
+    mapping(uint256 => uint256[]) public subgames;
+
+    /// @notice A mapping of resolved subgames rooted at a claim index.
+    mapping(uint256 => bool) public resolvedSubgames;
+
+    /// @notice A mapping of claim indices to resolution checkpoints.
+    mapping(uint256 => ResolutionCheckpoint) public resolutionCheckpoints;
+
+    /// @notice The latest finalized output root, serving as the anchor for output bisection.
+    Proposal public startingProposal;
+
+    /// @notice A boolean for whether or not the game type was respected when the game was created.
+    bool public wasRespectedGameTypeWhenCreated;
+
+    /// @notice A mapping of each claimant's refund mode credit.
+    mapping(address => uint256) public refundModeCredit;
+
+    /// @notice A mapping of whether a claimant has unlocked their credit.
+    mapping(address => bool) public hasUnlockedCredit;
+
+    /// @notice The bond distribution mode of the game.
+    BondDistributionMode public bondDistributionMode;
+
+    /// @param _params Parameters for creating a new SuperFaultDisputeGame.
+    constructor(GameConstructorParams memory _params) {
+        // The max game depth may not be greater than `LibPosition.MAX_POSITION_BITLEN - 1`.
+        if (_params.maxGameDepth > LibPosition.MAX_POSITION_BITLEN - 1) revert MaxDepthTooLarge();
+
+        // The split depth plus one cannot be greater than or equal to the max game depth. We add
+        // an additional depth to the split depth to avoid a bug in trace ancestor lookup. We know
+        // that the case where the split depth is the max value for uint256 is equivalent to the
+        // second check though we do need to check it explicitly to avoid an overflow.
+        if (_params.splitDepth == type(uint256).max || _params.splitDepth + 1 >= _params.maxGameDepth) {
+            revert InvalidSplitDepth();
+        }
+
+        // The split depth cannot be 0 or 1 to stay in bounds of clock extension arithmetic.
+        if (_params.splitDepth < 2) revert InvalidSplitDepth();
+
+        // Validate clock extension bounds that don't require VM access.
+        // The split depth extension is always clockExtension * 2.
+        uint256 splitDepthExtension = uint256(_params.clockExtension.raw()) * 2;
+
+        // The split depth extension must fit into a uint64.
+        if (splitDepthExtension > type(uint64).max) revert InvalidClockExtension();
+
+        // The split depth extension may not be greater than the maximum clock duration.
+        if (uint64(splitDepthExtension) > _params.maxClockDuration.raw()) revert InvalidClockExtension();
+
+        // Set up initial game state.
+        MAX_GAME_DEPTH = _params.maxGameDepth;
+        SPLIT_DEPTH = _params.splitDepth;
+        CLOCK_EXTENSION = _params.clockExtension;
+        MAX_CLOCK_DURATION = _params.maxClockDuration;
+    }
+
+    /// @notice Initializes the contract.
+    /// @dev This function may only be called once.
+    function initialize() public payable virtual {
+        // SAFETY: Any revert in this function will bubble up to the DisputeGameFactory and
+        // prevent the game from being created.
+        //
+        // Implicit assumptions:
+        // - The `gameStatus` state variable defaults to 0, which is `GameStatus.IN_PROGRESS`
+        // - The dispute game factory will enforce the required bond to initialize the game.
+        //
+        // Explicit checks:
+        // - The game must not have already been initialized.
+        // - A super root cannot be proposed at or before the starting l2SequenceNumber.
+
+        // INVARIANT: The game must not have already been initialized.
+        if (initialized) revert AlreadyInitialized();
+
+        // Revert if the calldata size is not the expected length.
+        //
+        // This is to prevent adding extra or omitting bytes from to `extraData` that result in a different game UUID
+        // in the factory, but are not used by the game, which would allow for multiple dispute games for the same
+        // super proposal to be created.
+        if (msg.data.length != expectedInitCallDataLength()) revert BadExtraData();
+
+        // Grab the latest anchor root.
+        (Hash root, uint256 rootL2SequenceNumber) = anchorStateRegistry().getAnchorRoot();
+
+        // Should only happen if this is a new game type that hasn't been set up yet.
+        if (root.raw() == bytes32(0)) revert AnchorRootNotFound();
+
+        // Prevent initializing right away with an invalid claim state that is used as convention
+        if (rootClaim().raw() == INVALID_ROOT_CLAIM) revert SuperFaultDisputeGameInvalidRootClaim();
+
+        // Set the starting Proposal.
+        startingProposal = Proposal({ l2SequenceNumber: rootL2SequenceNumber, root: root });
+
+        // The PreimageOracle challenge period must fit into uint64 so we can safely use it here.
+        // Runtime check was added instead of changing the ABI since the contract is already
+        // deployed in production. We perform the same check within the PreimageOracle for the
+        // benefit of developers but also perform this check here defensively.
+        if (vm().oracle().challengePeriod() > type(uint64).max) revert InvalidChallengePeriod();
+
+        // Determine the maximum clock extension which is either the split depth extension or the
+        // maximum game depth extension depending on the configuration of these contracts.
+        uint256 splitDepthExtension = uint256(CLOCK_EXTENSION.raw()) * 2;
+        uint256 maxGameDepthExtension = uint256(CLOCK_EXTENSION.raw()) + uint256(vm().oracle().challengePeriod());
+        uint256 maxClockExtension = Math.max(splitDepthExtension, maxGameDepthExtension);
+
+        // The maximum clock extension must fit into a uint64.
+        if (maxClockExtension > type(uint64).max) revert InvalidClockExtension();
+
+        // The maximum clock extension may not be greater than the maximum clock duration.
+        if (uint64(maxClockExtension) > MAX_CLOCK_DURATION.raw()) revert InvalidClockExtension();
+
+        // The l2ChainId must still exist, yet zero-valued, in the game args for legacy reasons.
+        if (_l2ChainId() != 0) revert NoChainIdNeeded();
+
+        // Do not allow the game to be initialized if the root claim corresponds to a l2 sequence number (timestamp) at
+        // or before the configured starting sequence number.
+        if (l2SequenceNumber() <= rootL2SequenceNumber) revert UnexpectedRootClaim(rootClaim());
+
+        // Set the root claim
+        claimData.push(
+            ClaimData({
+                parentIndex: type(uint32).max,
+                counteredBy: address(0),
+                claimant: gameCreator(),
+                bond: uint128(msg.value),
+                claim: rootClaim(),
+                position: ROOT_POSITION,
+                clock: LibClock.wrap(Duration.wrap(0), Timestamp.wrap(uint64(block.timestamp)))
+            })
+        );
+
+        // Set the game as initialized.
+        initialized = true;
+
+        // Deposit the bond.
+        refundModeCredit[gameCreator()] += msg.value;
+        weth().deposit{ value: msg.value }();
+
+        // Set the game's starting timestamp
+        createdAt = Timestamp.wrap(uint64(block.timestamp));
+
+        // Set whether the game type was respected when the game was created.
+        wasRespectedGameTypeWhenCreated =
+            GameType.unwrap(anchorStateRegistry().respectedGameType()) == GameType.unwrap(gameType());
+    }
+
+    /// @notice Returns the expected calldata length for the initialize method
+    function expectedInitCallDataLength() internal pure returns (uint256) {
+        // Expected length: 6 bytes + immutable args byte count
+        // - 4 bytes: selector
+        // - 2 bytes: CWIA length prefix
+        // - n bytes: Immutable args data
+        return 6 + immutableArgsByteCount();
+    }
+
+    /// @notice Returns the byte count of the immutable args for this contract.
+    function immutableArgsByteCount() internal pure virtual returns (uint256) {
+        // Expected length: 244 bytes
+        // - 20 bytes: creator address
+        // - 32 bytes: root claim
+        // - 32 bytes: l1 head
+        // -  4 bytes: game type
+        // - 32 bytes: extraData
+        // - 32 bytes: absolutePrestate
+        // - 20 bytes: vm address
+        // - 20 bytes: anchorStateRegistry address
+        // - 20 bytes: weth address
+        // - 32 bytes: l2ChainId (unused but kept for compatibility)
+        return 244;
+    }
+
+    ////////////////////////////////////////////////////////////////
+    //                  `IFaultDisputeGame` impl                  //
+    ////////////////////////////////////////////////////////////////
+
+    /// @notice Perform an instruction step via an on-chain fault proof processor.
+    /// @dev This function should point to a fault proof processor in order to execute
+    ///      a step in the fault proof program on-chain. The interface of the fault proof
+    ///      processor contract should adhere to the `IBigStepper` interface.
+    /// @param _claimIndex The index of the challenged claim within `claimData`.
+    /// @param _isAttack Whether or not the step is an attack or a defense.
+    /// @param _stateData The stateData of the step is the preimage of the claim at the given
+    ///        prestate, which is at `_stateIndex` if the move is an attack and `_claimIndex` if
+    ///        the move is a defense. If the step is an attack on the first instruction, it is
+    ///        the absolute prestate of the fault proof VM.
+    /// @param _proof Proof to access memory nodes in the VM's merkle state tree.
+    function step(
+        uint256 _claimIndex,
+        bool _isAttack,
+        bytes calldata _stateData,
+        bytes calldata _proof
+    )
+        public
+        virtual
+    {
+        // INVARIANT: Steps cannot be made unless the game is currently in progress.
+        if (status != GameStatus.IN_PROGRESS) revert GameNotInProgress();
+
+        // Get the parent. If it does not exist, the call will revert with OOB.
+        ClaimData storage parent = claimData[_claimIndex];
+
+        // Pull the parent position out of storage.
+        Position parentPos = parent.position;
+        // Determine the position of the step.
+        Position stepPos = parentPos.move(_isAttack);
+
+        // INVARIANT: A step cannot be made unless the move position is 1 below the `MAX_GAME_DEPTH`
+        if (stepPos.depth() != MAX_GAME_DEPTH + 1) revert InvalidParent();
+
+        // Determine the expected pre & post states of the step.
+        Claim preStateClaim;
+        ClaimData storage postState;
+        if (_isAttack) {
+            // If the step position's index at depth is 0, the prestate is the absolute
+            // prestate.
+            // If the step is an attack at a trace index > 0, the prestate exists elsewhere in
+            // the game state.
+            // NOTE: We localize the `indexAtDepth` for the current execution trace subgame by finding
+            //       the remainder of the index at depth divided by 2 ** (MAX_GAME_DEPTH - SPLIT_DEPTH),
+            //       which is the number of leaves in each execution trace subgame. This is so that we can
+            //       determine whether or not the step position is represents the `ABSOLUTE_PRESTATE`.
+            preStateClaim = (stepPos.indexAtDepth() % (1 << (MAX_GAME_DEPTH - SPLIT_DEPTH))) == 0
+                ? absolutePrestate()
+                : _findTraceAncestor(Position.wrap(parentPos.raw() - 1), parent.parentIndex, false).claim;
+            // For all attacks, the poststate is the parent claim.
+            postState = parent;
+        } else {
+            // If the step is a defense, the poststate exists elsewhere in the game state,
+            // and the parent claim is the expected pre-state.
+            preStateClaim = parent.claim;
+            postState = _findTraceAncestor(Position.wrap(parentPos.raw() + 1), parent.parentIndex, false);
+        }
+
+        // INVARIANT: The prestate is always invalid if the passed `_stateData` is not the
+        //            preimage of the prestate claim hash.
+        //            We ignore the highest order byte of the digest because it is used to
+        //            indicate the VM Status and is added after the digest is computed.
+        if (keccak256(_stateData) << 8 != preStateClaim.raw() << 8) revert InvalidPrestate();
+
+        // Compute the local preimage context for the step.
+        Hash uuid = _findLocalContext(_claimIndex);
+
+        // INVARIANT: If a step is an attack, the poststate is valid if the step produces
+        //            the same poststate hash as the parent claim's value.
+        //            If a step is a defense:
+        //              1. If the parent claim and the found post state agree with each other
+        //                 (depth diff % 2 == 0), the step is valid if it produces the same
+        //                 state hash as the post state's claim.
+        //              2. If the parent claim and the found post state disagree with each other
+        //                 (depth diff % 2 != 0), the parent cannot be countered unless the step
+        //                 produces the same state hash as `postState.claim`.
+        // SAFETY:    While the `attack` path does not need an extra check for the post
+        //            state's depth in relation to the parent, we don't need another
+        //            branch because (n - n) % 2 == 0.
+        bool validStep = vm().step(_stateData, _proof, uuid.raw()) == postState.claim.raw();
+        bool parentPostAgree = (parentPos.depth() - postState.position.depth()) % 2 == 0;
+        if (parentPostAgree == validStep) revert ValidStep();
+
+        // INVARIANT: A step cannot be made against a claim for a second time.
+        if (parent.counteredBy != address(0)) revert DuplicateStep();
+
+        // Set the parent claim as countered. We do not need to append a new claim to the game;
+        // instead, we can just set the existing parent as countered.
+        parent.counteredBy = msg.sender;
+    }
+
+    /// @notice Generic move function, used for both `attack` and `defend` moves.
+    /// @param _disputed The disputed `Claim`.
+    /// @param _challengeIndex The index of the claim being moved against.
+    /// @param _claim The claim at the next logical position in the game.
+    /// @param _isAttack Whether or not the move is an attack or defense.
+    function move(Claim _disputed, uint256 _challengeIndex, Claim _claim, bool _isAttack) public payable virtual {
+        // INVARIANT: Moves cannot be made unless the game is currently in progress.
+        if (status != GameStatus.IN_PROGRESS) revert GameNotInProgress();
+
+        // Get the parent. If it does not exist, the call will revert with OOB.
+        ClaimData memory parent = claimData[_challengeIndex];
+
+        // INVARIANT: The claim at the _challengeIndex must be the disputed claim.
+        if (Claim.unwrap(parent.claim) != Claim.unwrap(_disputed)) revert InvalidDisputedClaimIndex();
+
+        // Compute the position that the claim commits to. Because the parent's position is already
+        // known, we can compute the next position by moving left or right depending on whether
+        // or not the move is an attack or defense.
+        Position parentPos = parent.position;
+        Position nextPosition = parentPos.move(_isAttack);
+        uint256 nextPositionDepth = nextPosition.depth();
+
+        // INVARIANT: A defense can never be made against the root claim of either the output root game or any
+        //            of the execution trace bisection subgames. This is because the root claim commits to the
+        //            entire state. Therefore, the only valid defense is to do nothing if it is agreed with.
+        if ((_challengeIndex == 0 || nextPositionDepth == SPLIT_DEPTH + 2) && !_isAttack) {
+            revert CannotDefendRootClaim();
+        }
+
+        // INVARIANT: A move can never surpass the `MAX_GAME_DEPTH`. The only option to counter a
+        //            claim at this depth is to perform a single instruction step on-chain via
+        //            the `step` function to prove that the state transition produces an unexpected
+        //            post-state.
+        if (nextPositionDepth > MAX_GAME_DEPTH) revert GameDepthExceeded();
+
+        // When the next position surpasses the split depth (i.e., it is the root claim of an execution
+        // trace bisection sub-game), we need to perform some extra verification steps.
+        if (nextPositionDepth == SPLIT_DEPTH + 1) {
+            _verifyExecBisectionRoot(_claim, _challengeIndex, parentPos, _isAttack);
+        }
+
+        // INVARIANT: The `msg.value` must exactly equal the required bond.
+        if (getRequiredBond(nextPosition) != msg.value) revert IncorrectBondAmount();
+
+        // Compute the duration of the next clock. This is done by adding the duration of the
+        // grandparent claim to the difference between the current block timestamp and the
+        // parent's clock timestamp.
+        Duration nextDuration = getChallengerDuration(_challengeIndex);
+
+        // INVARIANT: A move can never be made once its clock has exceeded `MAX_CLOCK_DURATION`
+        //            seconds of time.
+        if (nextDuration.raw() == MAX_CLOCK_DURATION.raw()) revert ClockTimeExceeded();
+
+        // Clock extension is a mechanism that automatically extends the clock for a potential
+        // grandchild claim when there would be less than the clock extension time left if a player
+        // is forced to inherit another team's clock when countering a freeloader claim. Exact
+        // amount of clock extension time depends exactly where we are within the game.
+        uint64 actualExtension;
+        if (nextPositionDepth == MAX_GAME_DEPTH - 1) {
+            // If the next position is `MAX_GAME_DEPTH - 1` then we're about to execute a step. Our
+            // clock extension must therefore account for the LPP challenge period in addition to
+            // the standard clock extension.
+            actualExtension = CLOCK_EXTENSION.raw() + uint64(vm().oracle().challengePeriod());
+        } else if (nextPositionDepth == SPLIT_DEPTH - 1) {
+            // If the next position is `SPLIT_DEPTH - 1` then we're about to begin an execution
+            // trace bisection and we need to give extra time for the off-chain challenge agent to
+            // be able to generate the initial instruction trace on the native FPVM.
+            actualExtension = CLOCK_EXTENSION.raw() * 2;
+        } else {
+            // Otherwise, we just use the standard clock extension.
+            actualExtension = CLOCK_EXTENSION.raw();
+        }
+
+        // Check if we need to apply the clock extension.
+        if (nextDuration.raw() > MAX_CLOCK_DURATION.raw() - actualExtension) {
+            nextDuration = Duration.wrap(MAX_CLOCK_DURATION.raw() - actualExtension);
+        }
+
+        // Construct the next clock with the new duration and the current block timestamp.
+        Clock nextClock = LibClock.wrap(nextDuration, Timestamp.wrap(uint64(block.timestamp)));
+
+        // INVARIANT: There cannot be multiple identical claims with identical moves on the same challengeIndex. Multiple
+        //            claims at the same position may dispute the same challengeIndex. However, they must have different
+        //            values.
+        Hash claimHash = _claim.hashClaimPos(nextPosition, _challengeIndex);
+        if (claims[claimHash]) revert ClaimAlreadyExists();
+        claims[claimHash] = true;
+
+        // Create the new claim.
+        claimData.push(
+            ClaimData({
+                parentIndex: uint32(_challengeIndex),
+                // This is updated during subgame resolution
+                counteredBy: address(0),
+                claimant: msg.sender,
+                bond: uint128(msg.value),
+                claim: _claim,
+                position: nextPosition,
+                clock: nextClock
+            })
+        );
+
+        // Update the subgame rooted at the parent claim.
+        subgames[_challengeIndex].push(claimData.length - 1);
+
+        // Deposit the bond.
+        refundModeCredit[msg.sender] += msg.value;
+        weth().deposit{ value: msg.value }();
+
+        // Emit the appropriate event for the attack or defense.
+        emit Move(_challengeIndex, _claim, msg.sender);
+    }
+
+    /// @notice Attack a disagreed upon `Claim`.
+    /// @param _disputed The `Claim` being attacked.
+    /// @param _parentIndex Index of the `Claim` to attack in the `claimData` array. This must match the `_disputed`
+    /// claim.
+    /// @param _claim The `Claim` at the relative attack position.
+    function attack(Claim _disputed, uint256 _parentIndex, Claim _claim) external payable {
+        move(_disputed, _parentIndex, _claim, true);
+    }
+
+    /// @notice Defend an agreed upon `Claim`.
+    /// @notice _disputed The `Claim` being defended.
+    /// @param _parentIndex Index of the claim to defend in the `claimData` array. This must match the `_disputed`
+    /// claim.
+    /// @param _claim The `Claim` at the relative defense position.
+    function defend(Claim _disputed, uint256 _parentIndex, Claim _claim) external payable {
+        move(_disputed, _parentIndex, _claim, false);
+    }
+
+    /// @notice Posts the requested local data to the VM's `PreimageOralce`.
+    /// @param _ident The local identifier of the data to post.
+    /// @param _execLeafIdx The index of the leaf claim in an execution subgame that requires the local data for a step.
+    /// @param _partOffset The offset of the data to post.
+    function addLocalData(uint256 _ident, uint256 _execLeafIdx, uint256 _partOffset) external {
+        // INVARIANT: Local data can only be added if the game is currently in progress.
+        if (status != GameStatus.IN_PROGRESS) revert GameNotInProgress();
+
+        (Claim starting, Position startingPos, Claim disputed, Position disputedPos) =
+            _findStartingAndDisputedOutputs(_execLeafIdx);
+        Hash uuid = _computeLocalContext(starting, startingPos, disputed, disputedPos);
+
+        IPreimageOracle oracle = vm().oracle();
+        if (_ident == LocalPreimageKey.L1_HEAD_HASH) {
+            // Load the L1 head hash
+            oracle.loadLocalData(_ident, uuid.raw(), l1Head().raw(), 32, _partOffset);
+        } else if (_ident == LocalPreimageKey.STARTING_OUTPUT_ROOT) {
+            // Load the starting proposal's output root.
+            oracle.loadLocalData(_ident, uuid.raw(), starting.raw(), 32, _partOffset);
+        } else if (_ident == LocalPreimageKey.DISPUTED_OUTPUT_ROOT) {
+            // Load the disputed proposal's output root
+            oracle.loadLocalData(_ident, uuid.raw(), disputed.raw(), 32, _partOffset);
+        } else if (_ident == LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER) {
+            oracle.loadLocalData(_ident, uuid.raw(), bytes32(l2SequenceNumber() << 0xC0), 8, _partOffset);
+        } else {
+            revert InvalidLocalIdent();
+        }
+    }
+
+    /// @notice Returns the number of children that still need to be resolved in order to fully resolve a subgame rooted
+    ///         at `_claimIndex`.
+    /// @param _claimIndex The subgame root claim's index within `claimData`.
+    /// @return numRemainingChildren_ The number of children that still need to be checked to resolve the subgame.
+    function getNumToResolve(uint256 _claimIndex) public view returns (uint256 numRemainingChildren_) {
+        ResolutionCheckpoint storage checkpoint = resolutionCheckpoints[_claimIndex];
+        uint256[] storage challengeIndices = subgames[_claimIndex];
+        uint256 challengeIndicesLen = challengeIndices.length;
+
+        numRemainingChildren_ = challengeIndicesLen - checkpoint.subgameIndex;
+    }
+
+    /// @notice The l2SequenceNumber (timestamp) of the disputed super root in game root claim.
+    function l2SequenceNumber() public pure returns (uint256 l2SequenceNumber_) {
+        l2SequenceNumber_ = _getArgUint256(88);
+    }
+
+    /// @notice Only the starting sequence number (timestamp) of the game.
+    function startingSequenceNumber() external view returns (uint256 startingSequenceNumber_) {
+        startingSequenceNumber_ = startingProposal.l2SequenceNumber;
+    }
+
+    /// @notice Starting super root of the game.
+    function startingRootHash() external view returns (Hash startingRootHash_) {
+        startingRootHash_ = startingProposal.root;
+    }
+
+    ////////////////////////////////////////////////////////////////
+    //                    `IDisputeGame` impl                     //
+    ////////////////////////////////////////////////////////////////
+
+    /// @notice If all necessary information has been gathered, this function should mark the game
+    ///         status as either `CHALLENGER_WINS` or `DEFENDER_WINS` and return the status of
+    ///         the resolved game. It is at this stage that the bonds should be awarded to the
+    ///         necessary parties.
+    /// @dev May only be called if the `status` is `IN_PROGRESS`.
+    /// @return status_ The status of the game after resolution.
+    function resolve() external returns (GameStatus status_) {
+        // INVARIANT: Resolution cannot occur unless the game is currently in progress.
+        if (status != GameStatus.IN_PROGRESS) revert GameNotInProgress();
+
+        // INVARIANT: Resolution cannot occur unless the absolute root subgame has been resolved.
+        if (!resolvedSubgames[0]) revert OutOfOrderResolution();
+
+        // Update the global game status; The dispute has concluded.
+        status_ = claimData[0].counteredBy == address(0) ? GameStatus.DEFENDER_WINS : GameStatus.CHALLENGER_WINS;
+        resolvedAt = Timestamp.wrap(uint64(block.timestamp));
+
+        // Update the status and emit the resolved event, note that we're performing an assignment here.
+        emit Resolved(status = status_);
+    }
+
+    /// @notice Resolves the subgame rooted at the given claim index. `_numToResolve` specifies how many children of
+    ///         the subgame will be checked in this call. If `_numToResolve` is less than the number of children, an
+    ///         internal cursor will be updated and this function may be called again to complete resolution of the
+    ///         subgame.
+    /// @dev This function must be called bottom-up in the DAG
+    ///      A subgame is a tree of claims that has a maximum depth of 1.
+    ///      A subgame root claims is valid if, and only if, all of its child claims are invalid.
+    ///      At the deepest level in the DAG, a claim is invalid if there's a successful step against it.
+    /// @param _claimIndex The index of the subgame root claim to resolve.
+    /// @param _numToResolve The number of subgames to resolve in this call. If the input is `0`, and this is the first
+    ///                      page, this function will attempt to check all of the subgame's children at once.
+    function resolveClaim(uint256 _claimIndex, uint256 _numToResolve) external {
+        // INVARIANT: Resolution cannot occur unless the game is currently in progress.
+        if (status != GameStatus.IN_PROGRESS) revert GameNotInProgress();
+
+        ClaimData storage subgameRootClaim = claimData[_claimIndex];
+        Duration challengeClockDuration = getChallengerDuration(_claimIndex);
+
+        // INVARIANT: Cannot resolve a subgame unless the clock of its would-be counter has expired
+        // INVARIANT: Assuming ordered subgame resolution, challengeClockDuration is always >= MAX_CLOCK_DURATION if all
+        // descendant subgames are resolved
+        if (challengeClockDuration.raw() < MAX_CLOCK_DURATION.raw()) revert ClockNotExpired();
+
+        // INVARIANT: Cannot resolve a subgame twice.
+        if (resolvedSubgames[_claimIndex]) revert ClaimAlreadyResolved();
+
+        uint256[] storage challengeIndices = subgames[_claimIndex];
+        uint256 challengeIndicesLen = challengeIndices.length;
+
+        // Uncontested claims are resolved implicitly unless they are the root claim. Pay out the bond to the claimant
+        // and return early.
+        if (challengeIndicesLen == 0 && _claimIndex != 0) {
+            // In the event that the parent claim is at the max depth, there will always be 0 subgames. If the
+            // `counteredBy` field is set and there are no subgames, this implies that the parent claim was successfully
+            // stepped against. In this case, we pay out the bond to the party that stepped against the parent claim.
+            // Otherwise, the parent claim is uncontested, and the bond is returned to the claimant.
+            address counteredBy = subgameRootClaim.counteredBy;
+            address recipient = counteredBy == address(0) ? subgameRootClaim.claimant : counteredBy;
+            _distributeBond(recipient, subgameRootClaim);
+            resolvedSubgames[_claimIndex] = true;
+            return;
+        }
+
+        // Fetch the resolution checkpoint from storage.
+        ResolutionCheckpoint memory checkpoint = resolutionCheckpoints[_claimIndex];
+
+        // If the checkpoint does not currently exist, initialize the current left most position as max u128.
+        if (!checkpoint.initialCheckpointComplete) {
+            checkpoint.leftmostPosition = Position.wrap(type(uint128).max);
+            checkpoint.initialCheckpointComplete = true;
+
+            // If `_numToResolve == 0`, assume that we can check all child subgames in this one callframe.
+            if (_numToResolve == 0) _numToResolve = challengeIndicesLen;
+        }
+
+        // Assume parent is honest until proven otherwise
+        uint256 lastToResolve = checkpoint.subgameIndex + _numToResolve;
+        uint256 finalCursor = lastToResolve > challengeIndicesLen ? challengeIndicesLen : lastToResolve;
+        for (uint256 i = checkpoint.subgameIndex; i < finalCursor; i++) {
+            uint256 challengeIndex = challengeIndices[i];
+
+            // INVARIANT: Cannot resolve a subgame containing an unresolved claim
+            if (!resolvedSubgames[challengeIndex]) revert OutOfOrderResolution();
+
+            ClaimData storage claim = claimData[challengeIndex];
+
+            // If the child subgame is uncountered and further left than the current left-most counter,
+            // update the parent subgame's `countered` address and the current `leftmostCounter`.
+            // The left-most correct counter is preferred in bond payouts in order to discourage attackers
+            // from countering invalid subgame roots via an invalid defense position. As such positions
+            // cannot be correctly countered.
+            // Note that correctly positioned defense, but invalid claimes can still be successfully countered.
+            if (claim.counteredBy == address(0) && checkpoint.leftmostPosition.raw() > claim.position.raw()) {
+                checkpoint.counteredBy = claim.claimant;
+                checkpoint.leftmostPosition = claim.position;
+            }
+        }
+
+        // Increase the checkpoint's cursor position by the number of children that were checked.
+        checkpoint.subgameIndex = uint32(finalCursor);
+
+        // Persist the checkpoint and allow for continuing in a separate transaction, if resolution is not already
+        // complete.
+        resolutionCheckpoints[_claimIndex] = checkpoint;
+
+        // If all children have been traversed in the above loop, the subgame may be resolved. Otherwise, persist the
+        // checkpoint and allow for continuation in a separate transaction.
+        if (checkpoint.subgameIndex == challengeIndicesLen) {
+            address countered = checkpoint.counteredBy;
+
+            // Mark the subgame as resolved.
+            resolvedSubgames[_claimIndex] = true;
+
+            // Distribute the bond to the appropriate party.
+            // If the parent was not successfully countered, pay out the parent's bond to the claimant.
+            // If the parent was successfully countered, pay out the parent's bond to the challenger.
+            _distributeBond(countered == address(0) ? subgameRootClaim.claimant : countered, subgameRootClaim);
+
+            // Once a subgame is resolved, we percolate the result up the DAG so subsequent calls to
+            // resolveClaim will not need to traverse this subgame.
+            subgameRootClaim.counteredBy = countered;
+        }
+    }
+
+    /// @notice Getter for the creator of the dispute game.
+    /// @dev `clones-with-immutable-args` argument #1
+    /// @return creator_ The creator of the dispute game.
+    function gameCreator() public pure returns (address creator_) {
+        creator_ = _getArgAddress(0);
+    }
+
+    /// @notice Getter for the root claim.
+    /// @dev `clones-with-immutable-args` argument #2
+    /// @return rootClaim_ The root claim of the DisputeGame.
+    function rootClaim() public pure returns (Claim rootClaim_) {
+        rootClaim_ = Claim.wrap(_getArgBytes32(20));
+    }
+
+    /// @notice Getter for the parent hash of the L1 block when the dispute game was created.
+    /// @dev `clones-with-immutable-args` argument #3
+    /// @return l1Head_ The parent hash of the L1 block when the dispute game was created.
+    function l1Head() public pure returns (Hash l1Head_) {
+        l1Head_ = Hash.wrap(_getArgBytes32(52));
+    }
+
+    /// @notice Getter for the game type.
+    /// @dev `clones-with-immutable-args` argument #4
+    /// @return gameType_ The type of proof system being used.
+    function gameType() public pure returns (GameType gameType_) {
+        gameType_ = GameType.wrap(_getArgUint32(84));
+    }
+
+    /// @notice Getter for the extra data.
+    /// @dev `clones-with-immutable-args` argument #4
+    /// @return extraData_ Any extra data supplied to the dispute game contract by the creator.
+    function extraData() public pure returns (bytes memory extraData_) {
+        // The extra data starts at the second word within the cwia calldata and
+        // is 32 bytes long.
+        extraData_ = _getArgBytes(88, 32);
+    }
+
+    /// @notice Getter for the absolute prestate of the instruction trace.
+    /// @dev `clones-with-immutable-args` argument #6
+    /// @return absolutePrestate_ The absolute prestate of the instruction trace.
+    function absolutePrestate() public pure returns (Claim absolutePrestate_) {
+        absolutePrestate_ = Claim.wrap(_getArgBytes32(120));
+    }
+
+    /// @notice Getter for the VM implementation.
+    /// @dev `clones-with-immutable-args` argument #7
+    /// @return vm_ The onchain VM implementation address.
+    function vm() public pure returns (IBigStepper vm_) {
+        vm_ = IBigStepper(_getArgAddress(152));
+    }
+
+    /// @notice Getter for the anchor state registry.
+    /// @dev `clones-with-immutable-args` argument #8
+    /// @return registry_ The anchor state registry contract address.
+    function anchorStateRegistry() public pure returns (IAnchorStateRegistry registry_) {
+        registry_ = IAnchorStateRegistry(_getArgAddress(172));
+    }
+
+    /// @notice Getter for the WETH contract.
+    /// @dev `clones-with-immutable-args` argument #9
+    /// @return weth_ The WETH contract for holding ETH.
+    function weth() public pure returns (IDelayedWETH weth_) {
+        weth_ = IDelayedWETH(payable(_getArgAddress(192)));
+    }
+
+    /// @notice Getter for the L2 chain ID.
+    /// @dev `clones-with-immutable-args` argument #10
+    /// @return l2ChainId_ The L2 chain ID.
+    function _l2ChainId() internal pure returns (uint256 l2ChainId_) {
+        l2ChainId_ = _getArgUint256(212);
+    }
+
+    /// @notice A compliant implementation of this interface should return the components of the
+    ///         game UUID's preimage provided in the cwia payload. The preimage of the UUID is
+    ///         constructed as `keccak256(gameType . rootClaim . extraData)` where `.` denotes
+    ///         concatenation.
+    /// @return gameType_ The type of proof system being used.
+    /// @return rootClaim_ The root claim of the DisputeGame.
+    /// @return extraData_ Any extra data supplied to the dispute game contract by the creator.
+    function gameData() external pure returns (GameType gameType_, Claim rootClaim_, bytes memory extraData_) {
+        gameType_ = gameType();
+        rootClaim_ = rootClaim();
+        extraData_ = extraData();
+    }
+
+    ////////////////////////////////////////////////////////////////
+    //                       MISC EXTERNAL                        //
+    ////////////////////////////////////////////////////////////////
+
+    /// @notice Returns the required bond for a given move kind.
+    /// @param _position The position of the bonded interaction.
+    /// @return requiredBond_ The required ETH bond for the given move, in wei.
+    function getRequiredBond(Position _position) public view returns (uint256 requiredBond_) {
+        uint256 depth = uint256(_position.depth());
+        if (depth > MAX_GAME_DEPTH) revert GameDepthExceeded();
+
+        // Values taken from Big Bonds v1.5 (TM) spec.
+        uint256 assumedBaseFee = 200 gwei;
+        uint256 baseGasCharged = 400_000;
+        uint256 highGasCharged = 300_000_000;
+
+        // Goal here is to compute the fixed multiplier that will be applied to the base gas
+        // charged to get the required gas amount for the given depth. We apply this multiplier
+        // some `n` times where `n` is the depth of the position. We are looking for some number
+        // that, when multiplied by itself `MAX_GAME_DEPTH` times and then multiplied by the base
+        // gas charged, will give us the maximum gas that we want to charge.
+        // We want to solve for (highGasCharged/baseGasCharged) ** (1/MAX_GAME_DEPTH).
+        // We know that a ** (b/c) is equal to e ** (ln(a) * (b/c)).
+        // We can compute e ** (ln(a) * (b/c)) quite easily with FixedPointMathLib.
+
+        // Set up a, b, and c.
+        uint256 a = highGasCharged / baseGasCharged;
+        uint256 b = FixedPointMathLib.WAD;
+        uint256 c = MAX_GAME_DEPTH * FixedPointMathLib.WAD;
+
+        // Compute ln(a).
+        // slither-disable-next-line divide-before-multiply
+        uint256 lnA = uint256(FixedPointMathLib.lnWad(int256(a * FixedPointMathLib.WAD)));
+
+        // Computes (b / c) with full precision using WAD = 1e18.
+        uint256 bOverC = FixedPointMathLib.divWad(b, c);
+
+        // Compute e ** (ln(a) * (b/c))
+        // sMulWad can be used here since WAD = 1e18 maintains the same precision.
+        uint256 numerator = FixedPointMathLib.mulWad(lnA, bOverC);
+        int256 base = FixedPointMathLib.expWad(int256(numerator));
+
+        // Compute the required gas amount.
+        int256 rawGas = FixedPointMathLib.powWad(base, int256(depth * FixedPointMathLib.WAD));
+        uint256 requiredGas = FixedPointMathLib.mulWad(baseGasCharged, uint256(rawGas));
+
+        // Compute the required bond.
+        requiredBond_ = assumedBaseFee * requiredGas;
+    }
+
+    /// @notice Claim the credit belonging to the recipient address. Reverts if the game isn't
+    ///         finalized, if the recipient has no credit to claim, or if the bond transfer
+    ///         fails. If the game is finalized but no bond has been paid out yet, this method
+    ///         will determine the bond distribution mode and also try to update anchor game.
+    /// @param _recipient The owner and recipient of the credit.
+    function claimCredit(address _recipient) external {
+        // Close out the game and determine the bond distribution mode if not already set.
+        // We call this as part of claim credit to reduce the number of additional calls that a
+        // Challenger needs to make to this contract.
+        closeGame();
+
+        // Fetch the recipient's credit balance based on the bond distribution mode.
+        uint256 recipientCredit;
+        if (bondDistributionMode == BondDistributionMode.REFUND) {
+            recipientCredit = refundModeCredit[_recipient];
+        } else if (bondDistributionMode == BondDistributionMode.NORMAL) {
+            recipientCredit = normalModeCredit[_recipient];
+        } else {
+            // We shouldn't get here, but sanity check just in case.
+            revert InvalidBondDistributionMode();
+        }
+
+        // If the game is in refund mode, and the recipient has not unlocked their refund mode
+        // credit, we unlock it and return early.
+        if (!hasUnlockedCredit[_recipient]) {
+            hasUnlockedCredit[_recipient] = true;
+            weth().unlock(_recipient, recipientCredit);
+            return;
+        }
+
+        // Revert if the recipient has no credit to claim.
+        if (recipientCredit == 0) revert NoCreditToClaim();
+
+        // Set the recipient's credit balances to 0.
+        refundModeCredit[_recipient] = 0;
+        normalModeCredit[_recipient] = 0;
+
+        // Try to withdraw the WETH amount so it can be used here.
+        weth().withdraw(_recipient, recipientCredit);
+
+        // Transfer the credit to the recipient.
+        (bool success,) = _recipient.call{ value: recipientCredit }(hex"");
+        if (!success) revert BondTransferFailed();
+    }
+
+    /// @notice Closes out the game, determines the bond distribution mode, attempts to register
+    ///         the game as the anchor game, and emits an event.
+    function closeGame() public {
+        // We won't close the game if the system is currently paused. Paused games are temporarily
+        // invalid which would cause the game to go into refund mode and potentially cause some
+        // confusion for honest challengers. By blocking the game from being closed while the
+        // system is paused, the game will only go into refund mode if it ends up being explicitly
+        // invalidated in the AnchorStateRegistry.
+        if (anchorStateRegistry().paused()) {
+            revert GamePaused();
+        }
+
+        // If the bond distribution mode has already been determined, we can return early.
+        if (bondDistributionMode == BondDistributionMode.REFUND || bondDistributionMode == BondDistributionMode.NORMAL)
+        {
+            // We can't revert or we'd break claimCredit().
+            return;
+        } else if (bondDistributionMode != BondDistributionMode.UNDECIDED) {
+            // We shouldn't get here, but sanity check just in case.
+            revert InvalidBondDistributionMode();
+        }
+
+        // Make sure that the game is resolved.
+        // AnchorStateRegistry should be checking this but we're being defensive here.
+        if (resolvedAt.raw() == 0) {
+            revert GameNotResolved();
+        }
+
+        // Game must be finalized according to the AnchorStateRegistry.
+        bool finalized = anchorStateRegistry().isGameFinalized(IDisputeGame(address(this)));
+        if (!finalized) {
+            revert GameNotFinalized();
+        }
+
+        // Try to update the anchor game first. Won't always succeed because delays can lead
+        // to situations in which this game might not be eligible to be a new anchor game.
+        // eip150-safe
+        try anchorStateRegistry().setAnchorState(IDisputeGame(address(this))) { } catch { }
+
+        // Check if the game is a proper game, which will determine the bond distribution mode.
+        bool properGame = anchorStateRegistry().isGameProper(IDisputeGame(address(this)));
+
+        // If the game is a proper game, the bonds should be distributed normally. Otherwise, go
+        // into refund mode and distribute bonds back to their original depositors.
+        if (properGame) {
+            bondDistributionMode = BondDistributionMode.NORMAL;
+        } else {
+            bondDistributionMode = BondDistributionMode.REFUND;
+        }
+
+        // Emit an event to signal that the game has been closed.
+        emit GameClosed(bondDistributionMode);
+    }
+
+    /// @notice Returns the amount of time elapsed on the potential challenger to `_claimIndex`'s chess clock. Maxes
+    ///         out at `MAX_CLOCK_DURATION`.
+    /// @param _claimIndex The index of the subgame root claim.
+    /// @return duration_ The time elapsed on the potential challenger to `_claimIndex`'s chess clock.
+    function getChallengerDuration(uint256 _claimIndex) public view returns (Duration duration_) {
+        // INVARIANT: The game must be in progress to query the remaining time to respond to a given claim.
+        if (status != GameStatus.IN_PROGRESS) {
+            revert GameNotInProgress();
+        }
+
+        // Fetch the subgame root claim.
+        ClaimData storage subgameRootClaim = claimData[_claimIndex];
+
+        // Fetch the parent of the subgame root's clock, if it exists.
+        Clock parentClock;
+        if (subgameRootClaim.parentIndex != type(uint32).max) {
+            parentClock = claimData[subgameRootClaim.parentIndex].clock;
+        }
+
+        // Compute the duration elapsed of the potential challenger's clock.
+        uint64 challengeDuration =
+            uint64(parentClock.duration().raw() + (block.timestamp - subgameRootClaim.clock.timestamp().raw()));
+        duration_ = challengeDuration > MAX_CLOCK_DURATION.raw() ? MAX_CLOCK_DURATION : Duration.wrap(challengeDuration);
+    }
+
+    /// @notice Returns the length of the `claimData` array.
+    function claimDataLen() external view returns (uint256 len_) {
+        len_ = claimData.length;
+    }
+
+    /// @notice Returns the credit balance of a given recipient.
+    /// @param _recipient The recipient of the credit.
+    /// @return credit_ The credit balance of the recipient.
+    function credit(address _recipient) external view returns (uint256 credit_) {
+        if (bondDistributionMode == BondDistributionMode.REFUND) {
+            credit_ = refundModeCredit[_recipient];
+        } else {
+            // Always return normal credit balance by default unless we're in refund mode.
+            credit_ = normalModeCredit[_recipient];
+        }
+    }
+
+    ////////////////////////////////////////////////////////////////
+    //                     IMMUTABLE GETTERS                      //
+    ////////////////////////////////////////////////////////////////
+
+    /// @notice Returns the max game depth.
+    function maxGameDepth() external view returns (uint256 maxGameDepth_) {
+        maxGameDepth_ = MAX_GAME_DEPTH;
+    }
+
+    /// @notice Returns the split depth.
+    function splitDepth() external view returns (uint256 splitDepth_) {
+        splitDepth_ = SPLIT_DEPTH;
+    }
+
+    /// @notice Returns the max clock duration.
+    function maxClockDuration() external view returns (Duration maxClockDuration_) {
+        maxClockDuration_ = MAX_CLOCK_DURATION;
+    }
+
+    /// @notice Returns the clock extension constant.
+    function clockExtension() external view returns (Duration clockExtension_) {
+        clockExtension_ = CLOCK_EXTENSION;
+    }
+
+    ////////////////////////////////////////////////////////////////
+    //                          HELPERS                           //
+    ////////////////////////////////////////////////////////////////
+
+    /// @notice Pays out the bond of a claim to a given recipient.
+    /// @param _recipient The recipient of the bond.
+    /// @param _bonded The claim to pay out the bond of.
+    function _distributeBond(address _recipient, ClaimData storage _bonded) internal {
+        normalModeCredit[_recipient] += _bonded.bond;
+    }
+
+    /// @notice Verifies the integrity of an execution bisection subgame's root claim. Reverts if the claim
+    ///         is invalid.
+    /// @param _rootClaim The root claim of the execution bisection subgame.
+    function _verifyExecBisectionRoot(
+        Claim _rootClaim,
+        uint256 _parentIdx,
+        Position _parentPos,
+        bool _isAttack
+    )
+        internal
+        view
+    {
+        // The root claim of an execution trace bisection sub-game must:
+        // 1. Signal that the VM panicked or resulted in an invalid transition if the disputed super root
+        //    was made by the opposing party.
+        // 2. Signal that the VM resulted in a valid transition if the disputed output root was made by the same party.
+
+        // If the move is a defense, the disputed output could have been made by either party. In this case, we
+        // need to search for the parent output to determine what the expected status byte should be.
+        Position disputedLeafPos = Position.wrap(_parentPos.raw() + 1);
+        ClaimData storage disputed = _findTraceAncestor({ _pos: disputedLeafPos, _start: _parentIdx, _global: true });
+        uint8 vmStatus = uint8(_rootClaim.raw()[0]);
+
+        if (_isAttack || disputed.position.depth() % 2 == SPLIT_DEPTH % 2) {
+            // If the move is an attack, the parent output is always deemed to be disputed. In this case, we only need
+            // to check that the root claim signals that the VM panicked or resulted in an invalid transition.
+            // If the move is a defense, and the disputed output and creator of the execution trace subgame disagree,
+            // the root claim should also signal that the VM panicked or resulted in an invalid transition.
+            if (!(vmStatus == VMStatuses.INVALID.raw() || vmStatus == VMStatuses.PANIC.raw())) {
+                revert UnexpectedRootClaim(_rootClaim);
+            }
+        } else if (vmStatus != VMStatuses.VALID.raw()) {
+            // The disputed output and the creator of the execution trace subgame agree. The status byte should
+            // have signaled that the VM succeeded.
+            revert UnexpectedRootClaim(_rootClaim);
+        }
+    }
+
+    /// @notice Finds the trace ancestor of a given position within the DAG.
+    /// @param _pos The position to find the trace ancestor claim of.
+    /// @param _start The index to start searching from.
+    /// @param _global Whether or not to search the entire dag or just within an execution trace subgame. If set to
+    ///                `true`, and `_pos` is at or above the split depth, this function will revert.
+    /// @return ancestor_ The ancestor claim that commits to the same trace index as `_pos`.
+    function _findTraceAncestor(
+        Position _pos,
+        uint256 _start,
+        bool _global
+    )
+        internal
+        view
+        returns (ClaimData storage ancestor_)
+    {
+        // Grab the trace ancestor's expected position.
+        Position traceAncestorPos = _global ? _pos.traceAncestor() : _pos.traceAncestorBounded(SPLIT_DEPTH);
+
+        // Walk up the DAG to find a claim that commits to the same trace index as `_pos`. It is
+        // guaranteed that such a claim exists.
+        ancestor_ = claimData[_start];
+        while (ancestor_.position.raw() != traceAncestorPos.raw()) {
+            ancestor_ = claimData[ancestor_.parentIndex];
+        }
+    }
+
+    /// @notice Finds the starting and disputed output root for a given `ClaimData` within the DAG. This
+    ///         `ClaimData` must be below the `SPLIT_DEPTH`.
+    /// @param _start The index within `claimData` of the claim to start searching from.
+    /// @return startingClaim_ The starting output root claim.
+    /// @return startingPos_ The starting output root position.
+    /// @return disputedClaim_ The disputed output root claim.
+    /// @return disputedPos_ The disputed output root position.
+    function _findStartingAndDisputedOutputs(uint256 _start)
+        internal
+        view
+        returns (Claim startingClaim_, Position startingPos_, Claim disputedClaim_, Position disputedPos_)
+    {
+        // Fatch the starting claim.
+        uint256 claimIdx = _start;
+        ClaimData storage claim = claimData[claimIdx];
+
+        // If the starting claim's depth is less than or equal to the split depth, we revert as this is UB.
+        if (claim.position.depth() <= SPLIT_DEPTH) revert ClaimAboveSplit();
+
+        // We want to:
+        // 1. Find the first claim at the split depth.
+        // 2. Determine whether it was the starting or disputed output for the exec game.
+        // 3. Find the complimentary claim depending on the info from #2 (pre or post).
+
+        // Walk up the DAG until the ancestor's depth is equal to the split depth.
+        uint256 currentDepth;
+        ClaimData storage execRootClaim = claim;
+        while ((currentDepth = claim.position.depth()) > SPLIT_DEPTH) {
+            uint256 parentIndex = claim.parentIndex;
+
+            // If we're currently at the split depth + 1, we're at the root of the execution sub-game.
+            // We need to keep track of the root claim here to determine whether the execution sub-game was
+            // started with an attack or defense against the output leaf claim.
+            if (currentDepth == SPLIT_DEPTH + 1) execRootClaim = claim;
+
+            claim = claimData[parentIndex];
+            claimIdx = parentIndex;
+        }
+
+        // Determine whether the start of the execution sub-game was an attack or defense to the output root
+        // above. This is important because it determines which claim is the starting output root and which
+        // is the disputed output root.
+        (Position execRootPos, Position outputPos) = (execRootClaim.position, claim.position);
+        bool wasAttack = execRootPos.parent().raw() == outputPos.raw();
+
+        // Determine the starting and disputed output root indices.
+        // 1. If it was an attack, the disputed output root is `claim`, and the starting output root is
+        //    elsewhere in the DAG (it must commit to the block # index at depth of `outputPos - 1`).
+        // 2. If it was a defense, the starting output root is `claim`, and the disputed output root is
+        //    elsewhere in the DAG (it must commit to the block # index at depth of `outputPos + 1`).
+        if (wasAttack) {
+            // If this is an attack on the first super root (the block directly after the starting
+            // timestamp), the starting claim nor position exists in the tree. We leave these as
+            // 0, which can be easily identified due to 0 being an invalid Gindex.
+            if (outputPos.indexAtDepth() > 0) {
+                ClaimData storage starting = _findTraceAncestor(Position.wrap(outputPos.raw() - 1), claimIdx, true);
+                (startingClaim_, startingPos_) = (starting.claim, starting.position);
+            } else {
+                startingClaim_ = Claim.wrap(startingProposal.root.raw());
+            }
+            (disputedClaim_, disputedPos_) = (claim.claim, claim.position);
+        } else {
+            ClaimData storage disputed = _findTraceAncestor(Position.wrap(outputPos.raw() + 1), claimIdx, true);
+            (startingClaim_, startingPos_) = (claim.claim, claim.position);
+            (disputedClaim_, disputedPos_) = (disputed.claim, disputed.position);
+        }
+    }
+
+    /// @notice Finds the local context hash for a given claim index that is present in an execution trace subgame.
+    /// @param _claimIndex The index of the claim to find the local context hash for.
+    /// @return uuid_ The local context hash.
+    function _findLocalContext(uint256 _claimIndex) internal view returns (Hash uuid_) {
+        (Claim starting, Position startingPos, Claim disputed, Position disputedPos) =
+            _findStartingAndDisputedOutputs(_claimIndex);
+        uuid_ = _computeLocalContext(starting, startingPos, disputed, disputedPos);
+    }
+
+    /// @notice Computes the local context hash for a set of starting/disputed claim values and positions.
+    /// @param _starting The starting claim.
+    /// @param _startingPos The starting claim's position.
+    /// @param _disputed The disputed claim.
+    /// @param _disputedPos The disputed claim's position.
+    /// @return uuid_ The local context hash.
+    function _computeLocalContext(
+        Claim _starting,
+        Position _startingPos,
+        Claim _disputed,
+        Position _disputedPos
+    )
+        internal
+        pure
+        returns (Hash uuid_)
+    {
+        // A position of 0 indicates that the starting claim is the absolute prestate. In this special case,
+        // we do not include the starting claim within the local context hash.
+        uuid_ = _startingPos.raw() == 0
+            ? Hash.wrap(keccak256(abi.encode(_disputed, _disputedPos)))
+            : Hash.wrap(keccak256(abi.encode(_starting, _startingPos, _disputed, _disputedPos)));
+    }
+}

--- a/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
+++ b/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
@@ -154,6 +154,10 @@ abstract contract DisputeGameFactory_TestInit is CommonTest {
         internal
         returns (address gameImpl_, AlphabetVM vm_, IPreimageOracle preimageOracle_)
     {
+        if (isDevFeatureEnabled(DevFeatures.OPTIMISM_PORTAL_INTEROP)) {
+            return setupSuperFaultDisputeGameV2(_absolutePrestate);
+        }
+
         bytes memory immutableArgs;
         (immutableArgs, vm_, preimageOracle_) = getSuperFaultDisputeGameV2ImmutableArgs(_absolutePrestate);
 
@@ -243,6 +247,27 @@ abstract contract DisputeGameFactory_TestInit is CommonTest {
             delayedWeth, // 20 bytes
             uint256(0) // 32 bytes (l2ChainId)
         );
+    }
+
+    /// @notice Sets up a super fault game v2 implementation
+    function setupSuperFaultDisputeGameV2(Claim _absolutePrestate)
+        internal
+        returns (address gameImpl_, AlphabetVM vm_, IPreimageOracle preimageOracle_)
+    {
+        bytes memory immutableArgs;
+        (immutableArgs, vm_, preimageOracle_) = getSuperFaultDisputeGameV2ImmutableArgs(_absolutePrestate);
+        gameImpl_ = setupSuperFaultDisputeGameV2(immutableArgs);
+    }
+
+    function setupSuperFaultDisputeGameV2(bytes memory immutableArgs) internal returns (address gameImpl_) {
+        gameImpl_ = DeployUtils.create1({
+            _name: "SuperFaultDisputeGameV2",
+            _args: DeployUtils.encodeConstructor(
+                abi.encodeCall(ISuperFaultDisputeGame.__constructor__, (_getSuperGameConstructorParams()))
+            )
+        });
+
+        _setGame(gameImpl_, GameTypes.SUPER_CANNON, immutableArgs);
     }
 
     /// @notice Sets up a fault game v2 implementation

--- a/packages/contracts-bedrock/test/dispute/SuperFaultDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/dispute/SuperFaultDisputeGame.t.sol
@@ -20,6 +20,7 @@ import { Hashing } from "src/libraries/Hashing.sol";
 import { RLPWriter } from "src/libraries/rlp/RLPWriter.sol";
 import { LibClock } from "src/dispute/lib/LibUDT.sol";
 import { LibPosition } from "src/dispute/lib/LibPosition.sol";
+import { DevFeatures } from "src/libraries/DevFeatures.sol";
 import "src/dispute/lib/Types.sol";
 import "src/dispute/lib/Errors.sol";
 
@@ -54,6 +55,15 @@ contract ClaimCreditReenter {
         }
         claimCredit(address(this));
     }
+}
+
+/// @notice Helper function to copy bytes from one array to another.
+function copyBytes(bytes memory src, bytes memory dest) pure returns (bytes memory) {
+    uint256 byteCount = src.length < dest.length ? src.length : dest.length;
+    for (uint256 i = 0; i < byteCount; i++) {
+        dest[i] = src[i];
+    }
+    return dest;
 }
 
 /// @title BaseSuperFaultDisputeGame_TestInit
@@ -337,6 +347,152 @@ contract SuperFaultDisputeGame_Constructor_Test is SuperFaultDisputeGame_TestIni
                 )
             )
         });
+    }
+}
+
+/// @title SuperFaultDisputeGameV2_Constructor_Test
+/// @notice Tests the `__constructor__` function of the `SuperFaultDisputeGameV2` contract.
+contract SuperFaultDisputeGameV2_Constructor_Test is SuperFaultDisputeGame_TestInit {
+    function setUp() public virtual override {
+        super.setUp();
+        skipIfDevFeatureDisabled(DevFeatures.OPTIMISM_PORTAL_INTEROP);
+    }
+
+    /// @notice Tests that the constructor of the `SuperFaultDisputeGameV2` reverts when the
+    ///         `MAX_GAME_DEPTH` parameter is greater than `LibPosition.MAX_POSITION_BITLEN - 1`.
+    function testFuzz_constructor_maxDepthTooLarge_reverts(uint256 _maxGameDepth) public {
+        _maxGameDepth = bound(_maxGameDepth, LibPosition.MAX_POSITION_BITLEN, type(uint256).max - 1);
+        vm.expectRevert(MaxDepthTooLarge.selector);
+        DeployUtils.create1({
+            _name: "SuperFaultDisputeGameV2",
+            _args: DeployUtils.encodeConstructor(
+                abi.encodeCall(
+                    ISuperFaultDisputeGame.__constructor__,
+                    (
+                        ISuperFaultDisputeGame.GameConstructorParams({
+                            maxGameDepth: _maxGameDepth,
+                            splitDepth: _maxGameDepth + 1,
+                            clockExtension: Duration.wrap(3 hours),
+                            maxClockDuration: Duration.wrap(3.5 days)
+                        })
+                    )
+                )
+            )
+        });
+    }
+
+    /// @notice Tests that the constructor of the `SuperFaultDisputeGameV2` reverts when the `_splitDepth`
+    ///         parameter is greater than or equal to the `MAX_GAME_DEPTH`
+    function testFuzz_constructor_invalidSplitDepth_reverts(uint256 _splitDepth) public {
+        uint256 maxGameDepth = 2 ** 3;
+        _splitDepth = bound(_splitDepth, maxGameDepth - 1, type(uint256).max);
+        vm.expectRevert(InvalidSplitDepth.selector);
+        DeployUtils.create1({
+            _name: "SuperFaultDisputeGameV2",
+            _args: DeployUtils.encodeConstructor(
+                abi.encodeCall(
+                    ISuperFaultDisputeGame.__constructor__,
+                    (
+                        ISuperFaultDisputeGame.GameConstructorParams({
+                            maxGameDepth: maxGameDepth,
+                            splitDepth: _splitDepth,
+                            clockExtension: Duration.wrap(3 hours),
+                            maxClockDuration: Duration.wrap(3.5 days)
+                        })
+                    )
+                )
+            )
+        });
+    }
+
+    /// @notice Tests that the constructor of the `SuperFaultDisputeGameV2` reverts when the `_splitDepth`
+    ///         parameter is less than the minimum split depth (currently 2).
+    function testFuzz_constructor_lowSplitDepth_reverts(uint256 _splitDepth) public {
+        uint256 minSplitDepth = 2;
+        _splitDepth = bound(_splitDepth, 0, minSplitDepth - 1);
+        vm.expectRevert(InvalidSplitDepth.selector);
+        DeployUtils.create1({
+            _name: "SuperFaultDisputeGameV2",
+            _args: DeployUtils.encodeConstructor(
+                abi.encodeCall(
+                    ISuperFaultDisputeGame.__constructor__,
+                    (
+                        ISuperFaultDisputeGame.GameConstructorParams({
+                            maxGameDepth: 2 ** 3,
+                            splitDepth: _splitDepth,
+                            clockExtension: Duration.wrap(3 hours),
+                            maxClockDuration: Duration.wrap(3.5 days)
+                        })
+                    )
+                )
+            )
+        });
+    }
+
+    /// @notice Tests that the constructor of the `SuperFaultDisputeGameV2` reverts when clock
+    ///         extension * 2 is greater than the max clock duration.
+    function testFuzz_constructor_clockExtensionTooLong_reverts(
+        uint64 _maxClockDuration,
+        uint64 _clockExtension
+    )
+        public
+    {
+        // Force the clock extension * 2 to be greater than the max clock duration, but keep things
+        // within bounds of the uint64 type.
+        _maxClockDuration = uint64(bound(_maxClockDuration, 0, type(uint64).max / 2 - 1));
+        _clockExtension = uint64(bound(_clockExtension, _maxClockDuration / 2 + 1, type(uint64).max / 2));
+
+        vm.expectRevert(InvalidClockExtension.selector);
+        DeployUtils.create1({
+            _name: "SuperFaultDisputeGameV2",
+            _args: DeployUtils.encodeConstructor(
+                abi.encodeCall(
+                    ISuperFaultDisputeGame.__constructor__,
+                    (
+                        ISuperFaultDisputeGame.GameConstructorParams({
+                            maxGameDepth: 16,
+                            splitDepth: 8,
+                            clockExtension: Duration.wrap(_clockExtension),
+                            maxClockDuration: Duration.wrap(_maxClockDuration)
+                        })
+                    )
+                )
+            )
+        });
+    }
+
+    /// @notice Tests that the game cannot be initialized with extra immutable args bytes.
+    function test_initialize_extraImmutableArgsBytes_reverts() public {
+        // Get the immutable args
+        bytes memory immutableArgs;
+        (immutableArgs,,) = getSuperFaultDisputeGameV2ImmutableArgs(absolutePrestate);
+
+        // Append an extra byte to the immutable args
+        bytes memory newImmutableArgs = new bytes(immutableArgs.length + 1);
+        copyBytes(immutableArgs, newImmutableArgs);
+
+        // Set up dispute game implementation with target immutableArgs
+        setupSuperFaultDisputeGameV2(newImmutableArgs);
+
+        vm.expectRevert(BadExtraData.selector);
+        disputeGameFactory.create{ value: initBond }(GAME_TYPE, ROOT_CLAIM, extraData);
+    }
+
+    /// @notice Tests that the game cannot be initialized with missing immutable args bytes.
+    function test_initialize_missingImmutableArgsBytes_reverts() public {
+        // Get the immutable args
+        bytes memory immutableArgs;
+        (immutableArgs,,) = getSuperFaultDisputeGameV2ImmutableArgs(absolutePrestate);
+
+        // Remove a byte from the immutable args
+        bytes memory newImmutableArgs = new bytes(immutableArgs.length - 1);
+        copyBytes(immutableArgs, newImmutableArgs);
+
+        // Set up dispute game implementation with target immutableArgs
+        setupSuperFaultDisputeGameV2(newImmutableArgs);
+
+        vm.expectRevert(BadExtraData.selector);
+        disputeGameFactory.create{ value: initBond }(GAME_TYPE, ROOT_CLAIM, extraData);
     }
 }
 


### PR DESCRIPTION
## Summary

Implements SuperFaultDisputeGameV2 following the V2 architecture pattern established in PR #16929.

## Key Changes

### New Files
- **`src/dispute/v2/SuperFaultDisputeGameV2.sol`**: V2 implementation with CWIA helper functions
- **`interfaces/dispute/v2/ISuperFaultDisputeGameV2.sol`**: Interface for SuperFaultDisputeGameV2

### Modified Files
- **`src/libraries/DevFeatures.sol`**: Added `DEPLOY_V2_SUPER_DISPUTE_GAMES` feature flag
- **`test/dispute/SuperFaultDisputeGame.t.sol`**: Added `SuperFaultDisputeGameV2_Constructor_Test` with constructor validation and CWIA tests
- **`test/dispute/DisputeGameFactory.t.sol`**: Added `setupSuperFaultDisputeGameV2()` factory helpers

### Implementation Details

The V2 implementation follows the same CWIA (Clones With Immutable Arguments) pattern as FaultDisputeGameV2:
- Added `expectedInitCallDataLength()` helper returning `6 + immutableArgsByteCount()`
- Added `immutableArgsByteCount()` helper returning `244` (total CWIA bytes)
- Updated version from `0.6.0` to `0.7.0`
- All CWIA offsets remain unchanged (SuperFaultDisputeGame was already V2-compatible)
- Preserves all Super-specific features:
  - `l2SequenceNumber()` instead of `l2BlockNumber()`
  - `startingProposal()` instead of `startingOutputRoot()`
  - No `challengeRootL2Block()` function
  - Validates `l2ChainId` is zero in `initialize()`

### Testing

Added comprehensive tests following the FaultDisputeGameV2 pattern:
- Constructor parameter validation (max depth, split depth, clock extension)
- CWIA validation tests (extra/missing immutable args bytes)
- All tests feature-gated with `DEPLOY_V2_SUPER_DISPUTE_GAMES` flag

### Pre-PR Checks

All checks passing:
- ✓ Build successful
- ✓ All tests compile
- ✓ Interface validation
- ✓ Semver checks
- ✓ Code quality checks

## Test Plan

```bash
# Run V2 tests with feature flag enabled
DEV_FEATURE__DEPLOY_V2_SUPER_DISPUTE_GAMES=true forge test --match-contract SuperFaultDisputeGameV2
```

## Related

- Follows pattern from PR #16929 (FaultDisputeGame → FaultDisputeGameV2)
- Part of the broader V2 dispute game architecture