### PR TITLE
ci: Generate test results XML of forge tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -922,14 +922,6 @@ jobs:
       test_list:
         description: List of test files to run
         type: string
-      test_command:
-        description: Test command to execute (test or coverage)
-        type: string
-        default: test
-      test_flags:
-        description: Additional flags to pass to the test command
-        type: string
-        default: ""
       test_timeout:
         description: Timeout for running tests
         type: string
@@ -987,7 +979,8 @@ jobs:
             TEST_FILES=$(echo "$TEST_FILES" | circleci tests split --split-by=timings)
             TEST_FILES=$(echo "$TEST_FILES" | sed 's|^test/||')
             MATCH_PATH="./test/{$(echo "$TEST_FILES" | paste -sd "," -)}"
-            forge <<parameters.test_command>> <<parameters.test_flags>> --match-path "$MATCH_PATH"
+            mkdir -p results
+            forge test --match-path "$MATCH_PATH" --junit > results/results.xml
           environment:
             FOUNDRY_PROFILE: <<parameters.test_profile>>
           working_directory: packages/contracts-bedrock
@@ -999,6 +992,11 @@ jobs:
             FOUNDRY_PROFILE: ci
           working_directory: packages/contracts-bedrock
           when: on_fail
+      - when:
+          condition: always
+          steps:
+            - store_test_results:
+                path: packages/contracts-bedrock/results/results.xml
       - run:
           name: Lint forge test names
           command: just lint-forge-tests-check-no-build
@@ -1033,7 +1031,9 @@ jobs:
           working_directory: packages/contracts-bedrock
       - run:
           name: Run heavy fuzz tests
-          command: just test
+          command: |
+            mkdir -p results
+            just test --junit > results/results.xml
           environment:
             FOUNDRY_PROFILE: ciheavy
           working_directory: packages/contracts-bedrock
@@ -1050,6 +1050,11 @@ jobs:
           key: golang-build-cache-contracts-bedrock-heavy-fuzz-{{ checksum "go.sum" }}
           paths:
             - "~/.cache/go-build"
+      - when:
+          condition: always
+          steps:
+            - store_test_results:
+                path: packages/contracts-bedrock/results/results.xml
       - notify-failures-on-develop
 
   # AI Contracts Test Maintenance System
@@ -1090,10 +1095,6 @@ jobs:
       - image: <<pipeline.parameters.default_docker_image>>
     resource_class: 2xlarge
     parameters:
-      test_flags:
-        description: Additional flags to pass to the test command
-        type: string
-        default: ""
       test_timeout:
         description: Timeout for running tests
         type: string
@@ -1151,7 +1152,7 @@ jobs:
           working_directory: packages/contracts-bedrock
       - run:
           name: Run coverage tests
-          command: just coverage-lcov-all <<parameters.test_flags>>
+          command: just coverage-lcov-all
           environment:
             FOUNDRY_PROFILE: <<parameters.test_profile>>
             ETH_RPC_URL: https://ci-mainnet-l1-archive.optimism.io
@@ -1234,7 +1235,9 @@ jobs:
           features: <<parameters.features>>
       - run:
           name: Run tests
-          command: just test-upgrade
+          command: |
+            mkdir -p results
+            just test-upgrade --junit > results/results.xml
           environment:
             FOUNDRY_FUZZ_SEED: 42424242
             FOUNDRY_FUZZ_RUNS: 1
@@ -1271,6 +1274,11 @@ jobs:
       - store_artifacts:
           path: packages/contracts-bedrock/failed-test-traces.log
           when: on_fail
+      - when:
+          condition: always
+          steps:
+            - store_test_results:
+                path: packages/contracts-bedrock/results/results.xml
       - notify-failures-on-develop
 
   contracts-bedrock-upload:


### PR DESCRIPTION
Integrate forge test results with CCI for easier user feedback. It can be difficult to figure out which tests failed from reading the CCI console output, even after running a `just test-rerun` job.
Here's an illustration of a sample failed test:

<img width="1508" height="432" alt="image" src="https://github.com/user-attachments/assets/9a063cd9-f842-41ba-ba5c-e77d20e3e557" />

This PR also allows test insights on past test performance to be generated from the results by CCI.

### Consideration

Contract testing In CI occurs in two steps: First to run all tests, which dumps test logs to the console, then a rerun on only the failed tests. The rerun is logged to a file and console output. This patch removes the console logging done by the first test execution. So users will no longer have access to the logs of forge tests that succeeded.