### PR TITLE
op-conductor: remove dead advertisedAddr field

### DIFF
--- a/op-conductor/consensus/raft.go
+++ b/op-conductor/consensus/raft.go
@@ -30,9 +30,6 @@ type RaftConsensus struct {
 	r        *raft.Raft
 
 	transport *raft.NetworkTransport
-	// advertisedAddr is the host & port to contact this server.
-	// If empty, the address of the transport should be used instead.
-	advertisedAddr string
 
 	unsafeTracker *unsafeHeadTracker
 }
@@ -188,9 +185,6 @@ func NewRaftConsensus(log log.Logger, cfg *RaftConsensusConfig) (*RaftConsensus,
 // If no explicit address to advertise was configured,
 // the local network address that the raft-consensus server is listening on will be used.
 func (rc *RaftConsensus) Addr() string {
-	if rc.advertisedAddr != "" {
-		return rc.advertisedAddr
-	}
 	return string(rc.transport.LocalAddr())
 }
 


### PR DESCRIPTION
This change removes the unused advertisedAddr field from RaftConsensus and simplifies Addr() to always return the underlying transport’s LocalAddr. The advertised address semantics are already fully handled by hashicorp/raft via the TCP stream layer, so carrying a separate field was redundant and misleading. The behavior of Addr() remains unchanged, but the code is now clearer and avoids suggesting that an extra advertised address is maintained at the RaftConsensus level.