### PR TITLE
op-deployer: support op-contracts/v5.0.0 upgrade (#18154) (#18580)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/docker/docker v27.5.1+incompatible
 	github.com/docker/go-connections v0.5.0
 	github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.4-0.20251001155152-4eb15ccedf7e
-	github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20251009180028-9b4658b9b7af
+	github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20251121143344-5ac16e0fbb00
 	github.com/ethereum/go-ethereum v1.16.3
 	github.com/fatih/color v1.18.0
 	github.com/fsnotify/fsnotify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -240,8 +240,8 @@ github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.4-0.20251001155152-4eb15c
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.4-0.20251001155152-4eb15ccedf7e/go.mod h1:DYj7+vYJ4cIB7zera9mv4LcAynCL5u4YVfoeUu6Wa+w=
 github.com/ethereum-optimism/op-geth v1.101604.0-synctest.0 h1:cWnKry8Cgworpw3X+TDEr57DCYefjN9Tmy2eJ9elMzE=
 github.com/ethereum-optimism/op-geth v1.101604.0-synctest.0/go.mod h1:fCNAwDynfAP6EKsmLqwSDUDgi+GtJIir74Ui3fXXMps=
-github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20251009180028-9b4658b9b7af h1:WWz0gJM/boaUImtJnROecPirAerKCLpAU4m6Tx0ArOg=
-github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20251009180028-9b4658b9b7af/go.mod h1:NZ816PzLU1TLv1RdAvYAb6KWOj4Zm5aInT0YpDVml2Y=
+github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20251121143344-5ac16e0fbb00 h1:TR5Y7B+5m63V0Dno7MHcFqv/XZByQzx/4THV1T1A7+U=
+github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20251121143344-5ac16e0fbb00/go.mod h1:NZ816PzLU1TLv1RdAvYAb6KWOj4Zm5aInT0YpDVml2Y=
 github.com/ethereum/c-kzg-4844/v2 v2.1.5 h1:aVtoLK5xwJ6c5RiqO8g8ptJ5KU+2Hdquf6G3aXiHh5s=
 github.com/ethereum/c-kzg-4844/v2 v2.1.5/go.mod h1:u59hRTTah4Co6i9fDWtiCjTrblJv0UwsqZKCc0GfgUs=
 github.com/ethereum/go-bigmodexpfix v0.0.0-20250911101455-f9e208c548ab h1:rvv6MJhy07IMfEKuARQ9TKojGqLVNxQajaXEp/BoqSk=

--- a/op-deployer/pkg/deployer/integration_test/cli/upgrade_test.go
+++ b/op-deployer/pkg/deployer/integration_test/cli/upgrade_test.go
@@ -54,6 +54,11 @@ func TestCLIUpgrade(t *testing.T) {
 			version:     "v4.1.0",
 			forkBlock:   9165154, // one block past the opcm deployment block
 		},
+		{
+			contractTag: standard.ContractsV500Tag,
+			version:     "v5.0.0",
+			forkBlock:   9629972, // one block past the opcm deployment block
+		},
 	}
 
 	for _, tc := range testCases {
@@ -87,7 +92,7 @@ func TestCLIUpgrade(t *testing.T) {
 
 			configData, err := json.MarshalIndent(testConfig, "", "  ")
 			require.NoError(t, err)
-			require.NoError(t, os.WriteFile(configFile, configData, 0644))
+			require.NoError(t, os.WriteFile(configFile, configData, 0o644))
 
 			// Run full cli command to write calldata to outfile
 			output := runner.ExpectSuccess(t, []string{
@@ -115,7 +120,6 @@ func TestCLIUpgrade(t *testing.T) {
 			dataHex := hex.EncodeToString(dump[0].Data)
 			require.True(t, strings.HasPrefix(dataHex, "ff2dd5a1"),
 				"calldata should have opcm.upgrade fcn selector ff2dd5a1, got: %s", dataHex[:8])
-
 		})
 	}
 }

--- a/op-deployer/pkg/deployer/standard/standard.go
+++ b/op-deployer/pkg/deployer/standard/standard.go
@@ -42,8 +42,8 @@ const (
 	ContractsV300Tag        = "op-contracts/v3.0.0"
 	ContractsV400Tag        = "op-contracts/v4.0.0-rc.7"
 	ContractsV410Tag        = "op-contracts/v4.1.0"
-	ContractsV500Tag        = "op-contracts/v5.0.0-rc.2"
-	CurrentTag              = ContractsV410Tag
+	ContractsV500Tag        = "op-contracts/v5.0.0"
+	CurrentTag              = ContractsV500Tag
 )
 
 // TODO(#17505): This address should be updated to the actual address once deployed

--- a/op-deployer/pkg/deployer/upgrade/flags.go
+++ b/op-deployer/pkg/deployer/upgrade/flags.go
@@ -7,6 +7,7 @@ import (
 	v300 "github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/upgrade/v3_0_0"
 	v400 "github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/upgrade/v4_0_0"
 	v410 "github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/upgrade/v4_1_0"
+	v500 "github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/upgrade/v5_0_0"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	"github.com/urfave/cli/v2"
 )
@@ -71,6 +72,17 @@ var Commands = cli.Commands{
 			OutfileFlag,
 		}, oplog.CLIFlags(deployer.EnvVarPrefix)...),
 		Action: UpgradeCLI(v410.DefaultUpgrader),
+	},
+	&cli.Command{
+		Name:  "v5.0.0",
+		Usage: "upgrades a chain to version v5.0.0 (U17)",
+		Flags: append([]cli.Flag{
+			deployer.L1RPCURLFlag,
+			ConfigFlag,
+			OverrideArtifactsURLFlag,
+			OutfileFlag,
+		}, oplog.CLIFlags(deployer.EnvVarPrefix)...),
+		Action: UpgradeCLI(v500.DefaultUpgrader),
 	},
 	&cli.Command{
 		Name:  "embedded",

--- a/op-deployer/pkg/deployer/upgrade/v5_0_0/upgrade.go
+++ b/op-deployer/pkg/deployer/upgrade/v5_0_0/upgrade.go
@@ -1,0 +1,24 @@
+// Package v5_0_0 implements the upgrade to v5.0.0 (U17). The interface for the upgrade is identical
+// to the upgrade for v2.0.0 (U13), so all this package does is implement the Upgrader interface and
+// call into the v2.0.0 upgrade.
+package v5_0_0
+
+import (
+	"encoding/json"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/script"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/artifacts"
+	v200 "github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/upgrade/v2_0_0"
+)
+
+type Upgrader struct{}
+
+func (u *Upgrader) Upgrade(host *script.Host, input json.RawMessage) error {
+	return v200.DefaultUpgrader.Upgrade(host, input)
+}
+
+func (u *Upgrader) ArtifactsURL() string {
+	return artifacts.CreateHttpLocator("b112b16f8939fbb732c0693de3d3bd1e8e3e2f0771f91d5ab300a6c9b7b1af73")
+}
+
+var DefaultUpgrader = new(Upgrader)

--- a/op-validator/pkg/validations/addresses.go
+++ b/op-validator/pkg/validations/addresses.go
@@ -20,7 +20,7 @@ var addresses = map[uint64]map[string]common.Address{
 		standard.ContractsV400Tag: common.HexToAddress("0x3dfc5e44043DC5998928E0b8280136b7352d3F70"),
 		// Bootstrapped on 10/02/2025 using OP Deployer.
 		standard.ContractsV410Tag: common.HexToAddress("0x845FEF377Fa9C678B3eBe33B024678538f1215dD"),
-		// Bootstrapped on 10/27/2025 using OP Deployer (v5.0.0-rc.2).
+		// Bootstrapped on 10/27/2025 using OP Deployer.
 		standard.ContractsV500Tag: common.HexToAddress("0xDCE1A51A25dD5BF02ccB4264D039EDdF11A95b43"),
 	},
 	11155111: {
@@ -34,7 +34,7 @@ var addresses = map[uint64]map[string]common.Address{
 		standard.ContractsV400Tag: common.HexToAddress("0xA8a1529547306FEC7A32a001705160f2110451aE"),
 		// Bootstrapped on 10/02/2025 using OP Deployer.
 		standard.ContractsV410Tag: common.HexToAddress("0x7B4d2a02d5fa6C7C98D835d819956EBB876Ff439"),
-		// Bootstrapped on 10/27/2025 using OP Deployer (v5.0.0-rc.2).
+		// Bootstrapped on 10/27/2025 using OP Deployer.
 		standard.ContractsV500Tag: common.HexToAddress("0x757bFA3AAABcE60112Cee3239DCD05b5F6EFaE3A"),
 	},
 }

--- a/op-validator/pkg/validations/addresses_test.go
+++ b/op-validator/pkg/validations/addresses_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -111,8 +112,7 @@ func testStandardVersionNetwork(t *testing.T, network string) {
 		standard.ContractsV300Tag,
 		standard.ContractsV400Tag,
 		standard.ContractsV410Tag,
-		// Enable whenever we upgrade the superchain registry
-		//standard.ContractsV500Tag,
+		standard.ContractsV500Tag,
 	}
 
 	for _, semver := range contractVersions {
@@ -138,10 +138,12 @@ func testStandardVersion(t *testing.T, address common.Address, rpcClient *rpc.Cl
 
 	w3c := w3.NewClient(rpcClient)
 
-	ver, err := semver.NewVersion(version.SystemConfig.Version)
+	// Semver tags from the registry include the "op-contracts/" prefix.
+	cleanTag := strings.TrimPrefix(strings.TrimPrefix(semverTag, "op-contracts/"), "v")
+	releaseVer, err := semver.NewVersion(cleanTag)
 	require.NoError(t, err)
 
-	if ver.Major() >= 5 {
+	if releaseVer.Major() >= 5 {
 		// For v5.0.0+
 		type implFieldDef struct {
 			implGetter string


### PR DESCRIPTION
* op-deployer: support op-contracts/v5.0.0-rc.2 upgrade (#18154)

* superchain-registry: update validation import to include op-contracts/v5.0.0-rc.2

* op-deployer: support op-contracts/v5.0.0-rc.2 upgrade

* fix(op-deployer): adjust block for v5.0.0

* fix(op-validator): correct semver for v5.0.0