### PR TITLE
feat(op-interop-filter): implement core filtering logic

### DIFF
--- a/op-interop-filter/cmd/dashboard/main.go
+++ b/op-interop-filter/cmd/dashboard/main.go
@@ -1,0 +1,560 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"os/signal"
+	"sort"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/urfave/cli/v2"
+)
+
+// chainNames maps chain IDs to human-readable names
+var chainNames = map[string]string{
+	"11155420": "OP Sepolia",
+	"1301":     "Unichain Sepolia",
+	"10":       "OP Mainnet",
+	"1":        "Ethereum",
+	"8453":     "Base",
+	"84532":    "Base Sepolia",
+}
+
+// chainExplorers maps chain IDs to Blockscout explorer base URLs
+var chainExplorers = map[string]string{
+	"11155420": "https://optimism-sepolia.blockscout.com",
+	"1301":     "https://unichain-sepolia.blockscout.com",
+	"10":       "https://optimism.blockscout.com",
+	"8453":     "https://base.blockscout.com",
+	"84532":    "https://base-sepolia.blockscout.com",
+}
+
+// RecentQuery matches the spammer's RecentQuery struct
+// Note: ChainID is string because eth.ChainID serializes to decimal string via MarshalText
+type RecentQuery struct {
+	Timestamp   string `json:"timestamp"`
+	ChainID     string `json:"chain_id"`
+	BlockNumber uint64 `json:"block_number"`
+	TxHash      string `json:"tx_hash"`
+	LogIndex    uint   `json:"log_index"`
+	Address     string `json:"address"`
+	QueryType   string `json:"query_type"`
+	Result      string `json:"result"`
+}
+
+var (
+	FilterMetricsFlag = &cli.StringFlag{
+		Name:    "filter-metrics",
+		Usage:   "Filter service metrics endpoint",
+		Value:   "http://localhost:7300/metrics",
+		EnvVars: []string{"FILTER_METRICS"},
+	}
+	SpammerMetricsFlag = &cli.StringFlag{
+		Name:    "spammer-metrics",
+		Usage:   "Spammer metrics endpoints (comma-separated for multiple chains)",
+		Value:   "http://localhost:7301/metrics",
+		EnvVars: []string{"SPAMMER_METRICS"},
+	}
+	RefreshIntervalFlag = &cli.StringFlag{
+		Name:    "refresh",
+		Usage:   "Refresh interval (e.g., 1s, 2s)",
+		Value:   "2s",
+		EnvVars: []string{"REFRESH_INTERVAL"},
+	}
+)
+
+type Metrics struct {
+	// Filter metrics
+	FilterUp           float64
+	FilterFailsafe     float64
+	FilterChainReady   map[string]float64
+	FilterChainHead    map[string]float64
+	FilterBackfillProg map[string]float64
+	FilterCheckSuccess float64
+	FilterCheckFailed  float64
+	FilterReorgs       map[string]float64
+
+	// LogsDB metrics
+	LogsDBFirstBlock   map[string]float64
+	LogsDBBlocksSealed map[string]float64
+	LogsDBLogsAdded    map[string]float64
+	LogsDBEntries      map[string]float64
+
+	// Spammer metrics
+	SpammerUp              float64
+	SpammerValidAccepted   float64
+	SpammerValidRejected   float64
+	SpammerInvalidAccepted float64
+	SpammerInvalidRejected float64
+	SpammerErrors          float64
+	SpammerLatencyValid    float64
+	SpammerLatencyInvalid  float64
+}
+
+func main() {
+	app := cli.NewApp()
+	app.Name = "filter-dashboard"
+	app.Usage = "Terminal dashboard for op-interop-filter observability"
+	app.Flags = []cli.Flag{
+		FilterMetricsFlag,
+		SpammerMetricsFlag,
+		RefreshIntervalFlag,
+	}
+	app.Action = run
+
+	if err := app.Run(os.Args); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(cliCtx *cli.Context) error {
+	filterURL := cliCtx.String(FilterMetricsFlag.Name)
+	spammerURLsStr := cliCtx.String(SpammerMetricsFlag.Name)
+	refreshStr := cliCtx.String(RefreshIntervalFlag.Name)
+
+	// Parse comma-separated spammer URLs
+	spammerURLs := strings.Split(spammerURLsStr, ",")
+	for i := range spammerURLs {
+		spammerURLs[i] = strings.TrimSpace(spammerURLs[i])
+	}
+
+	refresh, err := time.ParseDuration(refreshStr)
+	if err != nil {
+		return fmt.Errorf("invalid refresh interval: %w", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Handle interrupt
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sigCh
+		cancel()
+	}()
+
+	startTime := time.Now()
+	ticker := time.NewTicker(refresh)
+	defer ticker.Stop()
+
+	// Initial render
+	render(filterURL, spammerURLs, startTime)
+
+	for {
+		select {
+		case <-ctx.Done():
+			clearScreen()
+			fmt.Println("Dashboard stopped.")
+			return nil
+		case <-ticker.C:
+			render(filterURL, spammerURLs, startTime)
+		}
+	}
+}
+
+func render(filterURL string, spammerURLs []string, startTime time.Time) {
+	clearScreen()
+
+	m := fetchAllMetrics(filterURL, spammerURLs)
+	uptime := time.Since(startTime).Round(time.Second)
+
+	// Header
+	fmt.Println("╔══════════════════════════════════════════════════════════════════════════════╗")
+	printLine("           OP-INTEROP-FILTER DASHBOARD")
+	printLine(fmt.Sprintf("  Uptime: %-20s                            %s", uptime, time.Now().Format("15:04:05")))
+	fmt.Println("╠══════════════════════════════════════════════════════════════════════════════╣")
+
+	// Filter Service Status
+	filterStatus := "[DOWN]"
+	if m.FilterUp > 0 {
+		filterStatus = "[UP]"
+	}
+	failsafeStatus := "[OK]"
+	if m.FilterFailsafe > 0 {
+		failsafeStatus = "[TRIGGERED]"
+	}
+
+	printLine("  FILTER SERVICE")
+	printLine(fmt.Sprintf("    Status: %-10s  Failsafe: %-12s", filterStatus, failsafeStatus))
+
+	// Chain status (sorted for consistent display)
+	if len(m.FilterChainHead) > 0 {
+		chainIDs := make([]string, 0, len(m.FilterChainHead))
+		for chainID := range m.FilterChainHead {
+			chainIDs = append(chainIDs, chainID)
+		}
+		sort.Strings(chainIDs)
+
+		for _, chainID := range chainIDs {
+			head := m.FilterChainHead[chainID]
+			ready := "..."
+			if r, ok := m.FilterChainReady[chainID]; ok && r > 0 {
+				ready = "[ready]"
+			}
+			backfill := 0.0
+			if bf, ok := m.FilterBackfillProg[chainID]; ok {
+				backfill = bf * 100
+			}
+			reorgs := 0.0
+			if r, ok := m.FilterReorgs[chainID]; ok {
+				reorgs = r
+			}
+			name := chainName(chainID)
+			printLine(fmt.Sprintf("    %-18s %-7s Head=%-10.0f Backfill=%5.1f%% Reorgs=%.0f",
+				name, ready, head, backfill, reorgs))
+		}
+	} else {
+		printLine("    No chain data available")
+	}
+
+	// Total requests
+	totalChecks := m.FilterCheckSuccess + m.FilterCheckFailed
+	printLine(fmt.Sprintf("    Requests: %.0f total", totalChecks))
+
+	fmt.Println("╠══════════════════════════════════════════════════════════════════════════════╣")
+
+	// LogsDB Stats (sorted for consistent display)
+	printLine("  LOGSDB")
+	if len(m.LogsDBBlocksSealed) > 0 {
+		chainIDs := make([]string, 0, len(m.LogsDBBlocksSealed))
+		for chainID := range m.LogsDBBlocksSealed {
+			chainIDs = append(chainIDs, chainID)
+		}
+		sort.Strings(chainIDs)
+
+		for _, chainID := range chainIDs {
+			firstBlock := m.LogsDBFirstBlock[chainID]
+			blocksSealed := m.LogsDBBlocksSealed[chainID]
+			logsAdded := m.LogsDBLogsAdded[chainID]
+			entries := m.LogsDBEntries[chainID]
+			name := chainName(chainID)
+			printLine(fmt.Sprintf("    %-18s Blocks=%-8.0f Logs=%-8.0f Entries=%-8.0f",
+				name, blocksSealed, logsAdded, entries))
+			printLine(fmt.Sprintf("                        First Block=%-10.0f", firstBlock))
+		}
+	} else {
+		printLine("    No LogsDB data available")
+	}
+
+	fmt.Println("╠══════════════════════════════════════════════════════════════════════════════╣")
+
+	// Spammer Status
+	spammerStatus := "[DOWN]"
+	if m.SpammerUp > 0 {
+		spammerStatus = "[UP]"
+	}
+
+	printLine("  SPAMMER")
+	printLine(fmt.Sprintf("    Status: %-10s  Errors: %.0f", spammerStatus, m.SpammerErrors))
+
+	// Query stats
+	validTotal := m.SpammerValidAccepted + m.SpammerValidRejected
+	invalidTotal := m.SpammerInvalidAccepted + m.SpammerInvalidRejected
+	allQueries := validTotal + invalidTotal
+
+	printLine(fmt.Sprintf("    Valid queries:   %-6.0f (accepted: %.0f, rejected: %.0f)",
+		validTotal, m.SpammerValidAccepted, m.SpammerValidRejected))
+	printLine(fmt.Sprintf("    Invalid queries: %-6.0f (accepted: %.0f, rejected: %.0f)",
+		invalidTotal, m.SpammerInvalidAccepted, m.SpammerInvalidRejected))
+
+	// Calculate correctness
+	correct := m.SpammerValidAccepted + m.SpammerInvalidRejected
+	correctRate := 0.0
+	if allQueries > 0 {
+		correctRate = (correct / allQueries) * 100
+	}
+
+	fmt.Println("╠══════════════════════════════════════════════════════════════════════════════╣")
+	printLine("  SUMMARY")
+	printLine(fmt.Sprintf("    Total Queries: %-8.0f  Correctness: %6.2f%%", allQueries, correctRate))
+
+	// Progress bar for correctness
+	barWidth := 40
+	filled := int(correctRate / 100 * float64(barWidth))
+	bar := strings.Repeat("=", filled) + strings.Repeat("-", barWidth-filled)
+	printLine(fmt.Sprintf("    [%s]", bar))
+
+	fmt.Println("╠══════════════════════════════════════════════════════════════════════════════╣")
+
+	// Recent queries - grouped by chain
+	printLine("  RECENT QUERIES (newest first)")
+
+	// Fetch queries from all spammer endpoints
+	recentQueryList := fetchRecentQueriesFromAll(spammerURLs)
+
+	// Group by chain ID (string since eth.ChainID serializes to decimal string)
+	queriesByChain := make(map[string][]RecentQuery)
+	for _, q := range recentQueryList {
+		queriesByChain[q.ChainID] = append(queriesByChain[q.ChainID], q)
+	}
+
+	if len(queriesByChain) > 0 {
+		// Sort chain IDs for consistent display
+		chainIDs := make([]string, 0, len(queriesByChain))
+		for chainID := range queriesByChain {
+			chainIDs = append(chainIDs, chainID)
+		}
+		sort.Strings(chainIDs)
+
+		for _, chainID := range chainIDs {
+			queries := queriesByChain[chainID]
+			name := chainName(chainID)
+			printLine(fmt.Sprintf("  --- %s ---", name))
+
+			// Show up to 3 per chain
+			limit := 3
+			if len(queries) < limit {
+				limit = len(queries)
+			}
+			for i := 0; i < limit; i++ {
+				q := queries[i]
+				icon := "OK"
+				if (q.QueryType == "valid" && q.Result == "rejected") ||
+					(q.QueryType == "invalid" && q.Result == "accepted") {
+					icon = "!!"
+				}
+				// Shorten tx hash for display
+				txShort := q.TxHash
+				if len(txShort) > 18 {
+					txShort = txShort[:10] + "..." + txShort[len(txShort)-6:]
+				}
+				printLine(fmt.Sprintf("  [%s] %s blk=%-8d log=%-3d tx=%s",
+					icon, q.Timestamp, q.BlockNumber, q.LogIndex, txShort))
+				// Show address and result on second line
+				addrShort := q.Address
+				if len(addrShort) > 22 {
+					addrShort = addrShort[:12] + "..." + addrShort[len(addrShort)-8:]
+				}
+				printLine(fmt.Sprintf("       addr=%s type=%-7s result=%-8s",
+					addrShort, q.QueryType, q.Result))
+				// Show explorer link on third line
+				if explorer, ok := chainExplorers[q.ChainID]; ok {
+					printLine(fmt.Sprintf("       %s/tx/%s", explorer, q.TxHash))
+				}
+			}
+		}
+	} else {
+		printLine("    No recent queries")
+	}
+
+	fmt.Println("╚══════════════════════════════════════════════════════════════════════════════╝")
+	fmt.Println("Press Ctrl+C to exit")
+}
+
+func clearScreen() {
+	fmt.Print("\033[H\033[2J")
+}
+
+// boxWidth is the inner width of the dashboard box (between the ║ characters)
+const boxWidth = 76
+
+// printLine prints a line with proper padding to align the right border
+// It accounts for emoji display width (emojis display as 2 chars but are 1 rune)
+func printLine(content string) {
+	// Count display width (emojis count as 2)
+	displayWidth := 0
+	for _, r := range content {
+		if r > 0x1F600 || (r >= 0x2600 && r <= 0x27BF) || (r >= 0x1F300 && r <= 0x1F9FF) {
+			displayWidth += 2 // emoji takes 2 display columns
+		} else {
+			displayWidth += 1
+		}
+	}
+
+	padding := boxWidth - displayWidth
+	if padding < 0 {
+		padding = 0
+	}
+	fmt.Printf("║%s%s║\n", content, strings.Repeat(" ", padding))
+}
+
+func fetchAllMetrics(filterURL string, spammerURLs []string) Metrics {
+	m := Metrics{
+		FilterChainReady:   make(map[string]float64),
+		FilterChainHead:    make(map[string]float64),
+		FilterBackfillProg: make(map[string]float64),
+		FilterReorgs:       make(map[string]float64),
+		LogsDBFirstBlock:   make(map[string]float64),
+		LogsDBBlocksSealed: make(map[string]float64),
+		LogsDBLogsAdded:    make(map[string]float64),
+		LogsDBEntries:      make(map[string]float64),
+	}
+
+	// Fetch filter metrics
+	filterMetrics := fetchMetrics(filterURL)
+	m.FilterUp = filterMetrics["op_interop_filter_up"]
+	m.FilterFailsafe = filterMetrics["op_interop_filter_failsafe_enabled"]
+	m.FilterCheckSuccess = filterMetrics["op_interop_filter_check_access_list_total{success=\"true\"}"]
+	m.FilterCheckFailed = filterMetrics["op_interop_filter_check_access_list_total{success=\"false\"}"]
+
+	// Parse chain-specific metrics
+	for k, v := range filterMetrics {
+		if strings.HasPrefix(k, "op_interop_filter_chain_ready{") {
+			chainID := extractLabel(k, "chain_id")
+			m.FilterChainReady[chainID] = v
+		}
+		if strings.HasPrefix(k, "op_interop_filter_chain_head{") {
+			chainID := extractLabel(k, "chain_id")
+			m.FilterChainHead[chainID] = v
+		}
+		if strings.HasPrefix(k, "op_interop_filter_backfill_progress{") {
+			chainID := extractLabel(k, "chain_id")
+			m.FilterBackfillProg[chainID] = v
+		}
+		if strings.HasPrefix(k, "op_interop_filter_reorg_detected_total{") {
+			chainID := extractLabel(k, "chain_id")
+			m.FilterReorgs[chainID] = v
+		}
+		// LogsDB metrics
+		if strings.HasPrefix(k, "op_interop_filter_logsdb_first_block{") {
+			chainID := extractLabel(k, "chain_id")
+			m.LogsDBFirstBlock[chainID] = v
+		}
+		if strings.HasPrefix(k, "op_interop_filter_logsdb_blocks_sealed_total{") {
+			chainID := extractLabel(k, "chain_id")
+			m.LogsDBBlocksSealed[chainID] = v
+		}
+		if strings.HasPrefix(k, "op_interop_filter_logsdb_logs_added_total{") {
+			chainID := extractLabel(k, "chain_id")
+			m.LogsDBLogsAdded[chainID] = v
+		}
+		if strings.HasPrefix(k, "op_interop_filter_logsdb_entries{") {
+			chainID := extractLabel(k, "chain_id")
+			m.LogsDBEntries[chainID] = v
+		}
+	}
+
+	// Fetch spammer metrics from all spammer endpoints and aggregate
+	for _, spammerURL := range spammerURLs {
+		spammerMetrics := fetchMetrics(spammerURL)
+		// Take the max of "up" values (any spammer up = spammer up)
+		if spammerMetrics["filter_spammer_up"] > m.SpammerUp {
+			m.SpammerUp = spammerMetrics["filter_spammer_up"]
+		}
+		// Sum errors and query counts across all spammers
+		m.SpammerErrors += spammerMetrics["filter_spammer_errors_total"]
+		m.SpammerValidAccepted += findMetricWithLabels(spammerMetrics, "filter_spammer_queries_total{",
+			map[string]string{"type": "valid", "result": "accepted"})
+		m.SpammerValidRejected += findMetricWithLabels(spammerMetrics, "filter_spammer_queries_total{",
+			map[string]string{"type": "valid", "result": "rejected"})
+		m.SpammerInvalidAccepted += findMetricWithLabels(spammerMetrics, "filter_spammer_queries_total{",
+			map[string]string{"type": "invalid", "result": "accepted"})
+		m.SpammerInvalidRejected += findMetricWithLabels(spammerMetrics, "filter_spammer_queries_total{",
+			map[string]string{"type": "invalid", "result": "rejected"})
+	}
+
+	return m
+}
+
+func fetchMetrics(url string) map[string]float64 {
+	result := make(map[string]float64)
+
+	client := &http.Client{Timeout: 2 * time.Second}
+	resp, err := client.Get(url)
+	if err != nil {
+		return result
+	}
+	defer resp.Body.Close()
+
+	scanner := bufio.NewScanner(resp.Body)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "#") || line == "" {
+			continue
+		}
+
+		// Parse prometheus text format: metric_name{labels} value
+		parts := strings.Fields(line)
+		if len(parts) < 2 {
+			continue
+		}
+
+		metricName := parts[0]
+		value, err := strconv.ParseFloat(parts[1], 64)
+		if err != nil {
+			continue
+		}
+
+		result[metricName] = value
+	}
+
+	return result
+}
+
+func extractLabel(metric, labelName string) string {
+	// Extract label value from metric like: metric_name{chain_id="123"}
+	start := strings.Index(metric, labelName+"=\"")
+	if start == -1 {
+		return ""
+	}
+	start += len(labelName) + 2
+	end := strings.Index(metric[start:], "\"")
+	if end == -1 {
+		return ""
+	}
+	return metric[start : start+end]
+}
+
+// chainName returns a human-readable name for a chain ID
+func chainName(chainID string) string {
+	if name, ok := chainNames[chainID]; ok {
+		return name
+	}
+	return "Chain " + chainID
+}
+
+// hasLabels checks if a metric has the specified label values (order-independent)
+func hasLabels(metric string, labels map[string]string) bool {
+	for k, v := range labels {
+		if extractLabel(metric, k) != v {
+			return false
+		}
+	}
+	return true
+}
+
+// findMetricWithLabels finds a metric value with specific labels
+func findMetricWithLabels(metrics map[string]float64, prefix string, labels map[string]string) float64 {
+	for k, v := range metrics {
+		if strings.HasPrefix(k, prefix) && hasLabels(k, labels) {
+			return v
+		}
+	}
+	return 0
+}
+
+func fetchRecentQueries(spammerURL string) []RecentQuery {
+	// Convert metrics URL to recent URL (replace /metrics with /recent)
+	recentURL := strings.Replace(spammerURL, "/metrics", "/recent", 1)
+
+	client := &http.Client{Timeout: 2 * time.Second}
+	resp, err := client.Get(recentURL)
+	if err != nil {
+		return nil
+	}
+	defer resp.Body.Close()
+
+	var queries []RecentQuery
+	if err := json.NewDecoder(resp.Body).Decode(&queries); err != nil {
+		return nil
+	}
+	return queries
+}
+
+func fetchRecentQueriesFromAll(spammerURLs []string) []RecentQuery {
+	var allQueries []RecentQuery
+	for _, url := range spammerURLs {
+		queries := fetchRecentQueries(url)
+		allQueries = append(allQueries, queries...)
+	}
+	return allQueries
+}

--- a/op-interop-filter/cmd/spammer/main.go
+++ b/op-interop-filter/cmd/spammer/main.go
@@ -1,0 +1,671 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/rand"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	gethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/urfave/cli/v2"
+
+	opservice "github.com/ethereum-optimism/optimism/op-service"
+	"github.com/ethereum-optimism/optimism/op-service/cliapp"
+	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/ctxinterrupt"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	oplog "github.com/ethereum-optimism/optimism/op-service/log"
+	"github.com/ethereum-optimism/optimism/op-service/sources"
+	suptypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+)
+
+var (
+	Version   = "v0.0.1"
+	GitCommit = ""
+	GitDate   = ""
+)
+
+var (
+	L2RPCFlag = &cli.StringFlag{
+		Name:     "l2-rpc",
+		Usage:    "L2 RPC endpoint URL",
+		Required: true,
+		EnvVars:  []string{"L2_RPC"},
+	}
+	FilterRPCFlag = &cli.StringFlag{
+		Name:     "filter-rpc",
+		Usage:    "Filter service RPC endpoint URL",
+		Required: true,
+		EnvVars:  []string{"FILTER_RPC"},
+	}
+	ChainIDFlag = &cli.Uint64Flag{
+		Name:     "chain-id",
+		Usage:    "Chain ID to test",
+		Required: true,
+		EnvVars:  []string{"CHAIN_ID"},
+	}
+	NumQueriesFlag = &cli.IntFlag{
+		Name:    "num-queries",
+		Usage:   "Number of queries to run (0 = run forever)",
+		Value:   100,
+		EnvVars: []string{"NUM_QUERIES"},
+	}
+	BlockRangeFlag = &cli.IntFlag{
+		Name:    "block-range",
+		Usage:   "Number of recent blocks to sample from",
+		Value:   100,
+		EnvVars: []string{"BLOCK_RANGE"},
+	}
+	QueryIntervalFlag = &cli.StringFlag{
+		Name:    "query-interval",
+		Usage:   "Interval between queries (e.g., 100ms, 1s)",
+		Value:   "500ms",
+		EnvVars: []string{"QUERY_INTERVAL"},
+	}
+	MetricsPortFlag = &cli.IntFlag{
+		Name:    "metrics.port",
+		Usage:   "Port for Prometheus metrics server",
+		Value:   7301,
+		EnvVars: []string{"METRICS_PORT"},
+	}
+	MetricsEnabledFlag = &cli.BoolFlag{
+		Name:    "metrics.enabled",
+		Usage:   "Enable Prometheus metrics",
+		Value:   true,
+		EnvVars: []string{"METRICS_ENABLED"},
+	}
+)
+
+// Metrics for the spammer
+type SpammerMetrics struct {
+	queriesTotal      *prometheus.CounterVec
+	queryLatency      *prometheus.HistogramVec
+	errorsTotal       prometheus.Counter
+	uptime            prometheus.Gauge
+	currentBlockRange prometheus.Gauge
+}
+
+// RecentQuery stores info about a recent query for debugging
+type RecentQuery struct {
+	Timestamp   string      `json:"timestamp"`
+	ChainID     eth.ChainID `json:"chain_id"`
+	BlockNumber uint64      `json:"block_number"`
+	TxHash      string      `json:"tx_hash"`
+	LogIndex    uint        `json:"log_index"`
+	Address     string      `json:"address"`
+	QueryType   string      `json:"query_type"` // "valid" or "invalid"
+	Result      string      `json:"result"`     // "accepted" or "rejected"
+}
+
+// RecentQueries is a thread-safe ring buffer of recent queries
+type RecentQueries struct {
+	mu      sync.RWMutex
+	queries []RecentQuery
+	maxSize int
+}
+
+func NewRecentQueries(size int) *RecentQueries {
+	return &RecentQueries{
+		queries: make([]RecentQuery, 0, size),
+		maxSize: size,
+	}
+}
+
+func (r *RecentQueries) Add(q RecentQuery) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.queries) >= r.maxSize {
+		// Remove oldest
+		r.queries = r.queries[1:]
+	}
+	r.queries = append(r.queries, q)
+}
+
+func (r *RecentQueries) Get() []RecentQuery {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	// Return in reverse order (newest first)
+	result := make([]RecentQuery, len(r.queries))
+	for i, q := range r.queries {
+		result[len(r.queries)-1-i] = q
+	}
+	return result
+}
+
+func newSpammerMetrics(reg prometheus.Registerer) *SpammerMetrics {
+	m := &SpammerMetrics{
+		queriesTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: "filter_spammer",
+			Name:      "queries_total",
+			Help:      "Total number of queries sent",
+		}, []string{"type", "result"}),
+		queryLatency: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: "filter_spammer",
+			Name:      "query_latency_seconds",
+			Help:      "Latency of filter queries",
+			Buckets:   []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5},
+		}, []string{"type"}),
+		errorsTotal: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: "filter_spammer",
+			Name:      "errors_total",
+			Help:      "Total number of unexpected errors",
+		}),
+		uptime: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: "filter_spammer",
+			Name:      "up",
+			Help:      "1 if spammer is running",
+		}),
+		currentBlockRange: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: "filter_spammer",
+			Name:      "block_range",
+			Help:      "Number of blocks in sample range",
+		}),
+	}
+
+	reg.MustRegister(m.queriesTotal)
+	reg.MustRegister(m.queryLatency)
+	reg.MustRegister(m.errorsTotal)
+	reg.MustRegister(m.uptime)
+	reg.MustRegister(m.currentBlockRange)
+
+	return m
+}
+
+func main() {
+	oplog.SetupDefaults()
+
+	app := cli.NewApp()
+	app.Name = "filter-spammer"
+	app.Usage = "Spam the interop filter service with queries to validate its behavior"
+	app.Version = opservice.FormatVersion(Version, GitCommit, GitDate, "")
+	app.Flags = cliapp.ProtectFlags(append([]cli.Flag{
+		L2RPCFlag,
+		FilterRPCFlag,
+		ChainIDFlag,
+		NumQueriesFlag,
+		BlockRangeFlag,
+		QueryIntervalFlag,
+		MetricsPortFlag,
+		MetricsEnabledFlag,
+	}, oplog.CLIFlags("SPAMMER")...))
+	app.Action = run
+
+	ctx := ctxinterrupt.WithSignalWaiterMain(context.Background())
+	err := app.RunContext(ctx, os.Args)
+	if err != nil {
+		log.Crit("Application failed", "err", err)
+	}
+}
+
+func run(cliCtx *cli.Context) error {
+	logger := oplog.NewLogger(os.Stdout, oplog.ReadCLIConfig(cliCtx))
+
+	l2RPC := cliCtx.String(L2RPCFlag.Name)
+	filterRPC := cliCtx.String(FilterRPCFlag.Name)
+	chainID := cliCtx.Uint64(ChainIDFlag.Name)
+	numQueries := cliCtx.Int(NumQueriesFlag.Name)
+	blockRange := cliCtx.Int(BlockRangeFlag.Name)
+	queryIntervalStr := cliCtx.String(QueryIntervalFlag.Name)
+	metricsPort := cliCtx.Int(MetricsPortFlag.Name)
+	metricsEnabled := cliCtx.Bool(MetricsEnabledFlag.Name)
+
+	queryInterval, err := time.ParseDuration(queryIntervalStr)
+	if err != nil {
+		return fmt.Errorf("invalid query-interval: %w", err)
+	}
+
+	ctx := cliCtx.Context
+
+	// Setup metrics and recent queries tracking
+	var metrics *SpammerMetrics
+	recentQueries := NewRecentQueries(10) // Track last 10 queries
+
+	if metricsEnabled {
+		reg := prometheus.NewRegistry()
+		metrics = newSpammerMetrics(reg)
+		metrics.uptime.Set(1)
+		metrics.currentBlockRange.Set(float64(blockRange))
+
+		// Start metrics server with /recent endpoint
+		mux := http.NewServeMux()
+		mux.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{}))
+		mux.HandleFunc("/recent", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(recentQueries.Get())
+		})
+		server := &http.Server{
+			Addr:    fmt.Sprintf(":%d", metricsPort),
+			Handler: mux,
+		}
+		go func() {
+			logger.Info("Starting metrics server", "port", metricsPort)
+			if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+				logger.Error("Metrics server error", "err", err)
+			}
+		}()
+		defer func() { _ = server.Shutdown(context.Background()) }()
+	}
+
+	logger.Info("Starting filter spammer",
+		"l2RPC", l2RPC,
+		"filterRPC", filterRPC,
+		"chainID", chainID,
+		"numQueries", numQueries,
+		"blockRange", blockRange,
+		"queryInterval", queryInterval,
+		"metricsEnabled", metricsEnabled,
+		"metricsPort", metricsPort,
+	)
+
+	// Connect to L2 RPC
+	l2Client, err := client.NewRPC(ctx, logger, l2RPC)
+	if err != nil {
+		return fmt.Errorf("failed to connect to L2 RPC: %w", err)
+	}
+	defer l2Client.Close()
+
+	ethClient, err := sources.NewEthClient(l2Client, logger, nil, &sources.EthClientConfig{
+		MaxRequestsPerBatch:   20,
+		MaxConcurrentRequests: 10,
+		TrustRPC:              true,
+		MustBePostMerge:       false,
+		RPCProviderKind:       sources.RPCKindBasic,
+		ReceiptsCacheSize:     100,
+		TransactionsCacheSize: 100,
+		HeadersCacheSize:      100,
+		PayloadsCacheSize:     100,
+		BlockRefsCacheSize:    100,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create eth client: %w", err)
+	}
+	defer ethClient.Close()
+
+	// Connect to filter RPC
+	filterClient, err := rpc.DialContext(ctx, filterRPC)
+	if err != nil {
+		return fmt.Errorf("failed to connect to filter RPC: %w", err)
+	}
+	defer filterClient.Close()
+
+	// Check filter is ready (not in failsafe)
+	var failsafe bool
+	if err := filterClient.CallContext(ctx, &failsafe, "admin_getFailsafeEnabled"); err != nil {
+		return fmt.Errorf("failed to check filter failsafe: %w", err)
+	}
+	if failsafe {
+		return errors.New("filter service is in failsafe mode")
+	}
+	logger.Info("Filter service responding", "failsafe", failsafe)
+
+	// Wait for backfill to complete by doing a test query
+	// The filter returns "service not ready, backfill in progress" until ready
+	logger.Info("Waiting for filter backfill to complete...")
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		// Try a dummy checkAccessList call with empty access list
+		// If backfill is in progress, it will return "backfill in progress"
+		// If ready, it will succeed (empty list = valid)
+		var result any
+		err := filterClient.CallContext(ctx, &result, "supervisor_checkAccessList", []any{}, "finalized", map[string]any{
+			"chainID":   fmt.Sprintf("0x%x", chainID),
+			"timestamp": "0x0",
+			"blockNum":  "0x0",
+		})
+		if err == nil {
+			logger.Info("Filter backfill complete, ready to spam")
+			break
+		}
+		errStr := err.Error()
+		if strings.Contains(errStr, "backfill") || strings.Contains(errStr, "uninitialized") {
+			logger.Debug("Backfill still in progress, waiting...", "err", errStr)
+			time.Sleep(2 * time.Second)
+			continue
+		}
+		// Other errors mean backfill is done but query failed for other reason
+		logger.Info("Filter backfill complete, ready to spam", "testErr", errStr)
+		break
+	}
+
+	// Get current head
+	head, err := ethClient.InfoByLabel(ctx, eth.Unsafe)
+	if err != nil {
+		return fmt.Errorf("failed to get head: %w", err)
+	}
+	headNum := head.NumberU64()
+	logger.Info("Current L2 head", "block", headNum)
+
+	// Calculate block range to sample from
+	startBlock := headNum - uint64(blockRange)
+	if startBlock < 1 {
+		startBlock = 1
+	}
+
+	spammer := &Spammer{
+		logger:        logger,
+		ethClient:     ethClient,
+		filterClient:  filterClient,
+		chainID:       eth.ChainIDFromUInt64(chainID),
+		startBlock:    startBlock,
+		endBlock:      headNum,
+		metrics:       metrics,
+		recentQueries: recentQueries,
+	}
+
+	// Run queries
+	ticker := time.NewTicker(queryInterval)
+	defer ticker.Stop()
+
+	validQueries := 0
+	invalidQueries := 0
+	errorCount := 0
+
+	for i := 0; numQueries == 0 || i < numQueries; i++ {
+		select {
+		case <-ctx.Done():
+			logger.Info("Shutting down", "validQueries", validQueries, "invalidQueries", invalidQueries, "errors", errorCount)
+			return nil
+		case <-ticker.C:
+			// Alternate between valid and invalid queries
+			if i%2 == 0 {
+				if err := spammer.RunValidQuery(ctx); err != nil {
+					logger.Error("Valid query failed unexpectedly", "err", err, "query", i)
+					errorCount++
+					if metrics != nil {
+						metrics.errorsTotal.Inc()
+					}
+					if errorCount > 10 {
+						return fmt.Errorf("too many errors (%d): last error: %w", errorCount, err)
+					}
+				} else {
+					validQueries++
+					logger.Debug("Valid query passed", "query", i)
+				}
+			} else {
+				if err := spammer.RunInvalidQuery(ctx); err != nil {
+					logger.Error("Invalid query test failed", "err", err, "query", i)
+					errorCount++
+					if metrics != nil {
+						metrics.errorsTotal.Inc()
+					}
+					if errorCount > 10 {
+						return fmt.Errorf("too many errors (%d): last error: %w", errorCount, err)
+					}
+				} else {
+					invalidQueries++
+					logger.Debug("Invalid query rejected as expected", "query", i)
+				}
+			}
+
+			if (i+1)%20 == 0 {
+				logger.Info("Progress", "queries", i+1, "valid", validQueries, "invalid", invalidQueries, "errors", errorCount)
+			}
+		}
+	}
+
+	logger.Info("Spammer completed successfully",
+		"validQueries", validQueries,
+		"invalidQueries", invalidQueries,
+		"errors", errorCount,
+	)
+
+	if errorCount > 0 {
+		return fmt.Errorf("completed with %d errors", errorCount)
+	}
+	return nil
+}
+
+// Spammer handles the spam testing logic
+type Spammer struct {
+	logger        log.Logger
+	ethClient     *sources.EthClient
+	filterClient  *rpc.Client
+	chainID       eth.ChainID
+	startBlock    uint64
+	endBlock      uint64
+	metrics       *SpammerMetrics
+	recentQueries *RecentQueries
+}
+
+// RunValidQuery fetches a random log and verifies the filter accepts it
+func (s *Spammer) RunValidQuery(ctx context.Context) error {
+	start := time.Now()
+
+	// Pick a random block
+	blockNum := s.startBlock + uint64(rand.Int63n(int64(s.endBlock-s.startBlock+1)))
+
+	// Get block info
+	block, err := s.ethClient.InfoByNumber(ctx, blockNum)
+	if err != nil {
+		return fmt.Errorf("failed to get block %d: %w", blockNum, err)
+	}
+
+	// Get receipts
+	_, receipts, err := s.ethClient.FetchReceipts(ctx, block.Hash())
+	if err != nil {
+		return fmt.Errorf("failed to get receipts for block %d: %w", blockNum, err)
+	}
+
+	// Find a block with logs
+	var foundLog bool
+	for _, receipt := range receipts {
+		if len(receipt.Logs) == 0 {
+			continue
+		}
+
+		// Pick a random log from this receipt
+		logIdx := rand.Intn(len(receipt.Logs))
+		log := receipt.Logs[logIdx]
+
+		// Compute the log hash
+		logHash := LogToLogHash(log)
+
+		// Create access entry
+		access := suptypes.ChecksumArgs{
+			BlockNumber: blockNum,
+			LogIndex:    uint32(log.Index),
+			Timestamp:   block.Time(),
+			ChainID:     s.chainID,
+			LogHash:     logHash,
+		}.Access()
+
+		// Encode and query
+		entries := suptypes.EncodeAccessList([]suptypes.Access{access})
+
+		execDesc := suptypes.ExecutingDescriptor{
+			ChainID:   s.chainID,
+			Timestamp: block.Time(),
+		}
+
+		err := s.filterClient.CallContext(ctx, nil, "supervisor_checkAccessList", entries, suptypes.LocalUnsafe, execDesc)
+
+		// Record metrics
+		if s.metrics != nil {
+			s.metrics.queryLatency.WithLabelValues("valid").Observe(time.Since(start).Seconds())
+		}
+
+		// Determine result
+		result := "accepted"
+		if err != nil {
+			result = "rejected"
+			if s.metrics != nil {
+				s.metrics.queriesTotal.WithLabelValues("valid", "rejected").Inc()
+			}
+		} else {
+			if s.metrics != nil {
+				s.metrics.queriesTotal.WithLabelValues("valid", "accepted").Inc()
+			}
+		}
+
+		// Record to recent queries
+		if s.recentQueries != nil {
+			s.recentQueries.Add(RecentQuery{
+				Timestamp:   time.Now().Format("15:04:05"),
+				ChainID:     s.chainID,
+				BlockNumber: blockNum,
+				TxHash:      receipt.TxHash.Hex(),
+				LogIndex:    log.Index,
+				Address:     log.Address.Hex(),
+				QueryType:   "valid",
+				Result:      result,
+			})
+		}
+
+		if err != nil {
+			// Check if this is a "skipped data" error (block outside filter's range)
+			// This means the block is too old for the filter to search, not a real error
+			if strings.Contains(err.Error(), "skipped data") {
+				s.logger.Debug("Block outside filter's searchable range, retrying with different block",
+					"block", blockNum, "err", err)
+				return s.RunValidQuery(ctx) // Try again with a different block
+			}
+			return fmt.Errorf("valid query rejected: block=%d logIdx=%d err=%w", blockNum, log.Index, err)
+		}
+
+		foundLog = true
+		break
+	}
+
+	if !foundLog {
+		// Block had no logs, try again with a different block
+		return s.RunValidQuery(ctx)
+	}
+
+	return nil
+}
+
+// RunInvalidQuery creates an invalid query and verifies the filter rejects it
+func (s *Spammer) RunInvalidQuery(ctx context.Context) error {
+	start := time.Now()
+
+	// Pick a random block
+	blockNum := s.startBlock + uint64(rand.Int63n(int64(s.endBlock-s.startBlock+1)))
+
+	// Get block info
+	block, err := s.ethClient.InfoByNumber(ctx, blockNum)
+	if err != nil {
+		return fmt.Errorf("failed to get block %d: %w", blockNum, err)
+	}
+
+	// Get receipts
+	_, receipts, err := s.ethClient.FetchReceipts(ctx, block.Hash())
+	if err != nil {
+		return fmt.Errorf("failed to get receipts for block %d: %w", blockNum, err)
+	}
+
+	// Find a block with logs
+	var foundLog bool
+	for _, receipt := range receipts {
+		if len(receipt.Logs) == 0 {
+			continue
+		}
+
+		// Pick a random log from this receipt
+		logIdx := rand.Intn(len(receipt.Logs))
+		log := receipt.Logs[logIdx]
+
+		// Compute the log hash
+		logHash := LogToLogHash(log)
+
+		// Create access entry with WRONG checksum (flip a byte)
+		access := suptypes.ChecksumArgs{
+			BlockNumber: blockNum,
+			LogIndex:    uint32(log.Index),
+			Timestamp:   block.Time(),
+			ChainID:     s.chainID,
+			LogHash:     logHash,
+		}.Access()
+
+		// Corrupt the checksum (flip byte at index 10, preserving prefix byte at 0)
+		access.Checksum[10] ^= 0xFF
+
+		// Encode and query
+		entries := suptypes.EncodeAccessList([]suptypes.Access{access})
+
+		execDesc := suptypes.ExecutingDescriptor{
+			ChainID:   s.chainID,
+			Timestamp: block.Time(),
+		}
+
+		err := s.filterClient.CallContext(ctx, nil, "supervisor_checkAccessList", entries, suptypes.LocalUnsafe, execDesc)
+
+		// Record metrics
+		if s.metrics != nil {
+			s.metrics.queryLatency.WithLabelValues("invalid").Observe(time.Since(start).Seconds())
+		}
+
+		// Determine result
+		result := "rejected"
+		if err == nil {
+			result = "accepted"
+			if s.metrics != nil {
+				s.metrics.queriesTotal.WithLabelValues("invalid", "accepted").Inc()
+			}
+		} else {
+			// Error expected - query was correctly rejected
+			if s.metrics != nil {
+				s.metrics.queriesTotal.WithLabelValues("invalid", "rejected").Inc()
+			}
+		}
+
+		// Record to recent queries
+		if s.recentQueries != nil {
+			s.recentQueries.Add(RecentQuery{
+				Timestamp:   time.Now().Format("15:04:05"),
+				ChainID:     s.chainID,
+				BlockNumber: blockNum,
+				TxHash:      receipt.TxHash.Hex(),
+				LogIndex:    log.Index,
+				Address:     log.Address.Hex(),
+				QueryType:   "invalid",
+				Result:      result,
+			})
+		}
+
+		if err == nil {
+			return fmt.Errorf("invalid query was accepted: block=%d logIdx=%d", blockNum, log.Index)
+		}
+
+		foundLog = true
+		break
+	}
+
+	if !foundLog {
+		// Block had no logs, try again with a different block
+		return s.RunInvalidQuery(ctx)
+	}
+
+	return nil
+}
+
+// LogToLogHash computes the log hash used in LogsDB
+// This matches processors.LogToLogHash
+func LogToLogHash(l *gethtypes.Log) common.Hash {
+	// Compute payload hash from topics and data
+	msg := make([]byte, 0)
+	for _, topic := range l.Topics {
+		msg = append(msg, topic.Bytes()...)
+	}
+	msg = append(msg, l.Data...)
+	payloadHash := crypto.Keccak256Hash(msg)
+
+	// Compute log hash
+	return suptypes.PayloadHashToLogHash(payloadHash, l.Address)
+}

--- a/op-interop-filter/cmd/spammer/main.go
+++ b/op-interop-filter/cmd/spammer/main.go
@@ -301,14 +301,16 @@ func run(cliCtx *cli.Context) error {
 	defer filterClient.Close()
 
 	// Check filter is ready (not in failsafe)
+	// Note: admin API may require JWT authentication, so this is optional
 	var failsafe bool
 	if err := filterClient.CallContext(ctx, &failsafe, "admin_getFailsafeEnabled"); err != nil {
-		return fmt.Errorf("failed to check filter failsafe: %w", err)
+		logger.Warn("Could not check failsafe status (admin API may require auth)", "err", err)
+	} else {
+		if failsafe {
+			return errors.New("filter service is in failsafe mode")
+		}
+		logger.Info("Filter service responding", "failsafe", failsafe)
 	}
-	if failsafe {
-		return errors.New("filter service is in failsafe mode")
-	}
-	logger.Info("Filter service responding", "failsafe", failsafe)
 
 	// Wait for backfill to complete by doing a test query
 	// The filter returns "service not ready, backfill in progress" until ready
@@ -489,9 +491,11 @@ func (s *Spammer) RunValidQuery(ctx context.Context) error {
 		// Encode and query
 		entries := suptypes.EncodeAccessList([]suptypes.Access{access})
 
+		// Use a timestamp after the initiating message's timestamp
+		// Same-timestamp execution is invalid per spec
 		execDesc := suptypes.ExecutingDescriptor{
 			ChainID:   s.chainID,
-			Timestamp: block.Time(),
+			Timestamp: block.Time() + 1, // Execute at least 1 second later
 		}
 
 		err := s.filterClient.CallContext(ctx, nil, "supervisor_checkAccessList", entries, suptypes.LocalUnsafe, execDesc)
@@ -599,9 +603,11 @@ func (s *Spammer) RunInvalidQuery(ctx context.Context) error {
 		// Encode and query
 		entries := suptypes.EncodeAccessList([]suptypes.Access{access})
 
+		// Use a timestamp after the initiating message's timestamp
+		// Same-timestamp execution is invalid per spec
 		execDesc := suptypes.ExecutingDescriptor{
 			ChainID:   s.chainID,
-			Timestamp: block.Time(),
+			Timestamp: block.Time() + 1, // Execute at least 1 second later
 		}
 
 		err := s.filterClient.CallContext(ctx, nil, "supervisor_checkAccessList", entries, suptypes.LocalUnsafe, execDesc)

--- a/op-interop-filter/filter/backend.go
+++ b/op-interop-filter/filter/backend.go
@@ -2,55 +2,362 @@ package filter
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/op-interop-filter/metrics"
+	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
-// Backend coordinates chain ingesters and handles the failsafe state.
-// This is a stub implementation - the actual logic will be added in a follow-up PR.
+// Backend coordinates chain ingesters, manages failsafe state, and handles CheckAccessList requests.
 type Backend struct {
 	log     log.Logger
 	metrics metrics.Metricer
 	cfg     *Config
+
+	// Chain ingesters keyed by chain ID
+	chains   map[eth.ChainID]*ChainIngester
+	chainsMu sync.RWMutex
+
+	// Failsafe state
+	failsafe atomic.Bool
+
+	// Cross-unsafe validation state
+	// Tracks minimum timestamp across all chains for validation
+	pendingExecMsgs map[eth.ChainID]map[uint64][]*types.ExecutingMessage // chainID -> timestamp -> execMsgs
+	pendingMu       sync.Mutex
+
+	// Context for shutdown
+	ctx    context.Context
+	cancel context.CancelFunc
 }
 
 // NewBackend creates a new Backend instance
-func NewBackend(ctx context.Context, logger log.Logger, m metrics.Metricer, cfg *Config) (*Backend, error) {
+func NewBackend(parentCtx context.Context, logger log.Logger, m metrics.Metricer, cfg *Config) (*Backend, error) {
+	ctx, cancel := context.WithCancel(parentCtx)
+
 	b := &Backend{
-		log:     logger,
-		metrics: m,
-		cfg:     cfg,
+		log:             logger,
+		metrics:         m,
+		cfg:             cfg,
+		chains:          make(map[eth.ChainID]*ChainIngester),
+		pendingExecMsgs: make(map[eth.ChainID]map[uint64][]*types.ExecutingMessage),
+		ctx:             ctx,
+		cancel:          cancel,
 	}
-	logger.Info("Created backend", "chains", len(cfg.L2RPCs))
+
+	// Create chain ingesters for each L2 RPC
+	for _, rpcURL := range cfg.L2RPCs {
+		// Query chain ID from the RPC
+		chainID, err := b.queryChainID(ctx, rpcURL)
+		if err != nil {
+			cancel()
+			return nil, fmt.Errorf("failed to query chain ID from %s: %w", rpcURL, err)
+		}
+
+		logger.Info("Creating chain ingester", "chain", chainID, "rpc", rpcURL)
+
+		ingester, err := NewChainIngester(
+			ctx,
+			logger,
+			m,
+			chainID,
+			rpcURL,
+			cfg.DataDir,
+			cfg.BackfillDuration,
+			b.onExecutingMessages,
+			b.onReorg,
+		)
+		if err != nil {
+			cancel()
+			return nil, fmt.Errorf("failed to create chain ingester for chain %s: %w", chainID, err)
+		}
+
+		b.chains[chainID] = ingester
+		b.pendingExecMsgs[chainID] = make(map[uint64][]*types.ExecutingMessage)
+	}
+
+	logger.Info("Created backend", "chains", len(b.chains))
 	return b, nil
 }
 
-// Start starts the backend
+// queryChainID queries the chain ID from an RPC endpoint
+func (b *Backend) queryChainID(ctx context.Context, rpcURL string) (eth.ChainID, error) {
+	rpcClient, err := client.NewRPC(ctx, b.log, rpcURL)
+	if err != nil {
+		return eth.ChainID{}, fmt.Errorf("failed to create RPC client: %w", err)
+	}
+	defer rpcClient.Close()
+
+	var chainIDHex string
+	if err := rpcClient.CallContext(ctx, &chainIDHex, "eth_chainId"); err != nil {
+		return eth.ChainID{}, fmt.Errorf("failed to query chain ID: %w", err)
+	}
+
+	chainID, err := eth.ChainIDFromString(chainIDHex)
+	if err != nil {
+		return eth.ChainID{}, fmt.Errorf("invalid chain ID response: %w", err)
+	}
+
+	return chainID, nil
+}
+
+// Start starts all chain ingesters
 func (b *Backend) Start(ctx context.Context) error {
-	b.log.Info("Starting backend (stub)")
+	b.log.Info("Starting backend")
+
+	for chainID, ingester := range b.chains {
+		if err := ingester.Start(); err != nil {
+			return fmt.Errorf("failed to start chain ingester for chain %s: %w", chainID, err)
+		}
+	}
+
 	return nil
 }
 
-// Stop stops the backend
+// Stop stops all chain ingesters
 func (b *Backend) Stop(ctx context.Context) error {
-	b.log.Info("Stopping backend (stub)")
-	return nil
+	b.log.Info("Stopping backend")
+	b.cancel()
+
+	var result error
+	for chainID, ingester := range b.chains {
+		if err := ingester.Stop(); err != nil {
+			result = errors.Join(result, fmt.Errorf("failed to stop chain ingester for chain %s: %w", chainID, err))
+		}
+	}
+
+	return result
 }
 
 // FailsafeEnabled returns whether failsafe is enabled
 func (b *Backend) FailsafeEnabled() bool {
-	return false
+	return b.failsafe.Load()
+}
+
+// SetFailsafeEnabled sets the failsafe state
+func (b *Backend) SetFailsafeEnabled(enabled bool) {
+	b.failsafe.Store(enabled)
+	b.metrics.RecordFailsafeEnabled(enabled)
+	b.log.Info("Failsafe state changed", "enabled", enabled)
+}
+
+// Ready returns true if all chains have completed backfill
+func (b *Backend) Ready() bool {
+	b.chainsMu.RLock()
+	defer b.chainsMu.RUnlock()
+
+	for _, ingester := range b.chains {
+		if !ingester.Ready() {
+			return false
+		}
+	}
+
+	return len(b.chains) > 0
 }
 
 // CheckAccessList validates the given access list entries.
-// This is a stub implementation that always returns ErrUninitialized.
 func (b *Backend) CheckAccessList(ctx context.Context, inboxEntries []common.Hash,
 	minSafety types.SafetyLevel, execDescriptor types.ExecutingDescriptor) error {
 
-	b.metrics.RecordCheckAccessList(false)
-	return types.ErrUninitialized
+	// Check failsafe first
+	if b.failsafe.Load() {
+		b.metrics.RecordCheckAccessList(false)
+		return types.ErrFailsafeEnabled
+	}
+
+	// Check if all chains are ready
+	if !b.Ready() {
+		b.metrics.RecordCheckAccessList(false)
+		return types.ErrUninitialized
+	}
+
+	// Only LocalUnsafe is supported for now (we don't track derivation)
+	if minSafety != types.LocalUnsafe {
+		b.metrics.RecordCheckAccessList(false)
+		return fmt.Errorf("unsupported safety level %s: only %s is supported", minSafety, types.LocalUnsafe)
+	}
+
+	// Parse and validate each access entry
+	remaining := inboxEntries
+	for len(remaining) > 0 {
+		var access types.Access
+		var err error
+		remaining, access, err = types.ParseAccess(remaining)
+		if err != nil {
+			b.metrics.RecordCheckAccessList(false)
+			return fmt.Errorf("failed to parse access entry: %w", err)
+		}
+
+		// Validate the access entry
+		if err := b.validateAccess(ctx, access, execDescriptor); err != nil {
+			b.metrics.RecordCheckAccessList(false)
+			return err
+		}
+	}
+
+	b.metrics.RecordCheckAccessList(true)
+	return nil
+}
+
+// validateAccess validates a single access entry
+func (b *Backend) validateAccess(ctx context.Context, access types.Access, execDescriptor types.ExecutingDescriptor) error {
+	// Find the chain ingester for this access entry
+	b.chainsMu.RLock()
+	ingester, ok := b.chains[access.ChainID]
+	b.chainsMu.RUnlock()
+
+	if !ok {
+		return fmt.Errorf("chain %s: %w", access.ChainID, types.ErrUnknownChain)
+	}
+
+	// Important invariant: Messages initiated and executed in the same timestamp are invalid
+	if access.Timestamp == execDescriptor.Timestamp {
+		return fmt.Errorf("message initiated at same timestamp as execution (%d): %w",
+			access.Timestamp, types.ErrConflict)
+	}
+
+	// Check timeout validity
+	if execDescriptor.Timeout > 0 {
+		// The message must be valid from execDescriptor.Timestamp to execDescriptor.Timestamp + Timeout
+		// This means the initiating message timestamp must be strictly less than execDescriptor.Timestamp
+		if access.Timestamp >= execDescriptor.Timestamp {
+			return fmt.Errorf("initiating message timestamp %d not before execution timestamp %d: %w",
+				access.Timestamp, execDescriptor.Timestamp, types.ErrConflict)
+		}
+	}
+
+	// Create query and check if log exists
+	query := access.Query()
+	_, err := ingester.Contains(query)
+	if err != nil {
+		return fmt.Errorf("log validation failed for chain %s, block %d, index %d: %w",
+			access.ChainID, access.BlockNumber, access.LogIndex, err)
+	}
+
+	return nil
+}
+
+// Rewind rewinds a chain to a specific block
+func (b *Backend) Rewind(ctx context.Context, chainID eth.ChainID, newHead eth.BlockID) error {
+	b.chainsMu.RLock()
+	ingester, ok := b.chains[chainID]
+	b.chainsMu.RUnlock()
+
+	if !ok {
+		return types.ErrUnknownChain
+	}
+
+	return ingester.Rewind(newHead)
+}
+
+// onExecutingMessages is called when executing messages are detected during ingestion
+func (b *Backend) onExecutingMessages(chainID eth.ChainID, timestamp uint64, execMsgs []*types.ExecutingMessage) {
+	b.pendingMu.Lock()
+	defer b.pendingMu.Unlock()
+
+	// Store pending executing messages for cross-unsafe validation
+	if _, ok := b.pendingExecMsgs[chainID]; !ok {
+		b.pendingExecMsgs[chainID] = make(map[uint64][]*types.ExecutingMessage)
+	}
+	b.pendingExecMsgs[chainID][timestamp] = append(b.pendingExecMsgs[chainID][timestamp], execMsgs...)
+
+	// Try to validate cross-unsafe messages
+	b.tryValidateCrossUnsafe()
+}
+
+// tryValidateCrossUnsafe validates executing messages when all chains have caught up
+func (b *Backend) tryValidateCrossUnsafe() {
+	// Find minimum timestamp across all chains
+	minTimestamp := uint64(0)
+	first := true
+
+	b.chainsMu.RLock()
+	for _, ingester := range b.chains {
+		ts, ok := ingester.LatestTimestamp()
+		if !ok {
+			// Chain not ready yet
+			b.chainsMu.RUnlock()
+			return
+		}
+		if first || ts < minTimestamp {
+			minTimestamp = ts
+			first = false
+		}
+	}
+	b.chainsMu.RUnlock()
+
+	if first {
+		return // No chains
+	}
+
+	// Validate all pending executing messages with timestamp <= minTimestamp
+	for chainID, timestampMsgs := range b.pendingExecMsgs {
+		for ts, execMsgs := range timestampMsgs {
+			if ts > minTimestamp {
+				continue // Not ready to validate yet
+			}
+
+			for _, execMsg := range execMsgs {
+				if err := b.validateExecutingMessage(execMsg); err != nil {
+					b.log.Error("Cross-unsafe validation failed, enabling failsafe",
+						"chain", chainID,
+						"timestamp", ts,
+						"execMsg", execMsg,
+						"err", err)
+					b.SetFailsafeEnabled(true)
+					return
+				}
+			}
+
+			// Clean up validated messages
+			delete(b.pendingExecMsgs[chainID], ts)
+		}
+	}
+}
+
+// validateExecutingMessage validates a single executing message against the source chain
+func (b *Backend) validateExecutingMessage(execMsg *types.ExecutingMessage) error {
+	b.chainsMu.RLock()
+	ingester, ok := b.chains[execMsg.ChainID]
+	b.chainsMu.RUnlock()
+
+	if !ok {
+		return fmt.Errorf("source chain %s: %w", execMsg.ChainID, types.ErrUnknownChain)
+	}
+
+	query := types.ContainsQuery{
+		Timestamp: execMsg.Timestamp,
+		BlockNum:  execMsg.BlockNum,
+		LogIdx:    execMsg.LogIdx,
+		Checksum:  execMsg.Checksum,
+	}
+
+	_, err := ingester.Contains(query)
+	return err
+}
+
+// onReorg is called when a reorg is detected on a chain
+func (b *Backend) onReorg(chainID eth.ChainID) {
+	b.log.Warn("Reorg detected, enabling failsafe", "chain", chainID)
+	b.SetFailsafeEnabled(true)
+}
+
+// GetChainIDs returns the chain IDs of all configured chains
+func (b *Backend) GetChainIDs() []eth.ChainID {
+	b.chainsMu.RLock()
+	defer b.chainsMu.RUnlock()
+
+	chainIDs := make([]eth.ChainID, 0, len(b.chains))
+	for chainID := range b.chains {
+		chainIDs = append(chainIDs, chainID)
+	}
+	return chainIDs
 }

--- a/op-interop-filter/filter/backend.go
+++ b/op-interop-filter/filter/backend.go
@@ -320,7 +320,18 @@ func (b *Backend) tryValidateCrossUnsafe() {
 			// Clean up validated messages
 			delete(b.pendingExecMsgs[chainID], ts)
 		}
+
+		// Record pending messages metric for this chain
+		var pendingCount int64
+		for _, msgs := range b.pendingExecMsgs[chainID] {
+			pendingCount += int64(len(msgs))
+		}
+		chainIDUint64, _ := chainID.Uint64()
+		b.metrics.RecordPendingExecMsgs(chainIDUint64, pendingCount)
 	}
+
+	// Record the validated timestamp
+	b.metrics.RecordCrossUnsafeValidatedTimestamp(minTimestamp)
 }
 
 // validateExecutingMessage validates a single executing message against the source chain

--- a/op-interop-filter/filter/backend_test.go
+++ b/op-interop-filter/filter/backend_test.go
@@ -1,0 +1,143 @@
+package filter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-interop-filter/metrics"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+)
+
+func TestBackend_FailsafeEnabled(t *testing.T) {
+	backend := newTestBackend(t)
+
+	// Failsafe should be disabled by default
+	require.False(t, backend.FailsafeEnabled())
+
+	// Enable failsafe
+	backend.SetFailsafeEnabled(true)
+	require.True(t, backend.FailsafeEnabled())
+
+	// Disable failsafe
+	backend.SetFailsafeEnabled(false)
+	require.False(t, backend.FailsafeEnabled())
+}
+
+func TestBackend_CheckAccessList_FailsafeEnabled(t *testing.T) {
+	backend := newTestBackendWithMockChain(t)
+
+	// Enable failsafe
+	backend.SetFailsafeEnabled(true)
+
+	// CheckAccessList should return ErrFailsafeEnabled
+	err := backend.CheckAccessList(
+		context.Background(),
+		[]common.Hash{},
+		types.LocalUnsafe,
+		types.ExecutingDescriptor{},
+	)
+	require.ErrorIs(t, err, types.ErrFailsafeEnabled)
+}
+
+func TestBackend_CheckAccessList_NotReady(t *testing.T) {
+	backend := newTestBackend(t)
+
+	// Backend with no chains is not ready
+	err := backend.CheckAccessList(
+		context.Background(),
+		[]common.Hash{},
+		types.LocalUnsafe,
+		types.ExecutingDescriptor{},
+	)
+	require.ErrorIs(t, err, types.ErrUninitialized)
+}
+
+func TestBackend_Ready_NoChains(t *testing.T) {
+	backend := newTestBackend(t)
+
+	// Backend with no chains should not be ready
+	require.False(t, backend.Ready())
+}
+
+func TestBackend_Ready_WithChains(t *testing.T) {
+	backend := newTestBackendWithMockChain(t)
+
+	// Backend with mock ready chain should be ready
+	require.True(t, backend.Ready())
+}
+
+func TestBackend_OnReorg_EnablesFailsafe(t *testing.T) {
+	backend := newTestBackend(t)
+
+	// Failsafe should be disabled initially
+	require.False(t, backend.FailsafeEnabled())
+
+	// Simulate a reorg callback
+	backend.onReorg(eth.ChainIDFromUInt64(1))
+
+	// Failsafe should now be enabled
+	require.True(t, backend.FailsafeEnabled())
+}
+
+func TestBackend_CheckAccessList_UnsupportedSafetyLevel(t *testing.T) {
+	backend := newTestBackendWithMockChain(t)
+
+	// CrossUnsafe is not supported
+	err := backend.CheckAccessList(
+		context.Background(),
+		[]common.Hash{},
+		types.CrossUnsafe,
+		types.ExecutingDescriptor{},
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unsupported safety level")
+}
+
+// Test helpers
+
+func newTestBackend(t *testing.T) *Backend {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	return &Backend{
+		log:             log.New(),
+		metrics:         metrics.NoopMetrics,
+		cfg:             &Config{},
+		chains:          make(map[eth.ChainID]*ChainIngester),
+		pendingExecMsgs: make(map[eth.ChainID]map[uint64][]*types.ExecutingMessage),
+		ctx:             ctx,
+		cancel:          cancel,
+	}
+}
+
+func newTestBackendWithMockChain(t *testing.T) *Backend {
+	backend := newTestBackend(t)
+
+	// Add a mock chain ingester that reports as ready
+	chainID := eth.ChainIDFromUInt64(1)
+	mockIngester := &mockChainIngester{ready: true}
+	backend.chains[chainID] = mockIngester.asChainIngester()
+	backend.pendingExecMsgs[chainID] = make(map[uint64][]*types.ExecutingMessage)
+
+	return backend
+}
+
+// mockChainIngester provides a minimal mock for testing
+type mockChainIngester struct {
+	ready bool
+}
+
+// asChainIngester converts the mock into a real ChainIngester with only the ready field set
+// This is a workaround since we can't easily mock the ChainIngester struct
+func (m *mockChainIngester) asChainIngester() *ChainIngester {
+	c := &ChainIngester{}
+	if m.ready {
+		c.ready.Store(true)
+	}
+	return c
+}

--- a/op-interop-filter/filter/chain_ingester.go
+++ b/op-interop-filter/filter/chain_ingester.go
@@ -308,6 +308,9 @@ func (c *ChainIngester) backfill(startBlock, endBlock uint64) error {
 				"progress", fmt.Sprintf("%d%%", progress))
 			lastProgress = progress
 			lastLog = time.Now()
+			// Record backfill progress metric
+			chainIDUint64, _ := c.chainID.Uint64()
+			c.metrics.RecordBackfillProgress(chainIDUint64, float64(progress)/100.0)
 		}
 	}
 
@@ -458,6 +461,8 @@ func (c *ChainIngester) ingestBlock(blockNum uint64) error {
 	// Update metrics
 	chainIDUint64, _ := c.chainID.Uint64()
 	c.metrics.RecordChainHead(chainIDUint64, blockNum)
+	c.metrics.RecordBlocksSealed(chainIDUint64, 1)
+	c.metrics.RecordLogsAdded(chainIDUint64, int64(logIndex))
 
 	// Notify about executing messages
 	if len(execMsgs) > 0 && c.onExecMsg != nil {
@@ -470,6 +475,8 @@ func (c *ChainIngester) ingestBlock(blockNum uint64) error {
 // triggerReorg handles reorg detection
 func (c *ChainIngester) triggerReorg() {
 	c.log.Warn("Reorg detected, triggering failsafe")
+	chainIDUint64, _ := c.chainID.Uint64()
+	c.metrics.RecordReorgDetected(chainIDUint64)
 	if c.onReorg != nil {
 		c.onReorg(c.chainID)
 	}

--- a/op-interop-filter/filter/chain_ingester.go
+++ b/op-interop-filter/filter/chain_ingester.go
@@ -263,6 +263,15 @@ func (c *ChainIngester) runIngestion() {
 
 	c.log.Info("Starting backfill", "from", startBlock, "to", head.NumberU64(), "blocks", head.NumberU64()-startBlock+1)
 
+	// Initialize the LogsDB with the parent block of the start block
+	// This is needed because the LogsDB requires a sealed parent block before adding logs
+	if startBlock > 0 {
+		if err := c.initializeAnchorBlock(startBlock - 1); err != nil {
+			c.log.Error("Failed to initialize anchor block", "err", err)
+			return
+		}
+	}
+
 	// Backfill
 	if err := c.backfill(startBlock, head.NumberU64()); err != nil {
 		if errors.Is(err, context.Canceled) {
@@ -280,6 +289,33 @@ func (c *ChainIngester) runIngestion() {
 
 	// Live polling loop
 	c.pollLoop()
+}
+
+// initializeAnchorBlock seals the anchor block in the LogsDB
+// This must be done before any logs can be added, as logs reference their parent block
+func (c *ChainIngester) initializeAnchorBlock(blockNum uint64) error {
+	c.log.Info("Initializing anchor block", "block", blockNum)
+
+	// Fetch the anchor block info
+	blockInfo, err := c.ethClient.InfoByNumber(c.ctx, blockNum)
+	if err != nil {
+		return fmt.Errorf("failed to get anchor block info: %w", err)
+	}
+
+	blockID := eth.BlockID{Hash: blockInfo.Hash(), Number: blockInfo.NumberU64()}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Seal the anchor block with no logs
+	// For the very first block, use zero hash as parent
+	parentHash := blockInfo.ParentHash()
+	if err := c.logsDB.SealBlock(parentHash, blockID, blockInfo.Time()); err != nil {
+		return fmt.Errorf("failed to seal anchor block: %w", err)
+	}
+
+	c.log.Info("Initialized anchor block", "block", blockNum, "hash", blockID.Hash)
+	return nil
 }
 
 // backfill ingests blocks from startBlock to endBlock

--- a/op-interop-filter/filter/chain_ingester.go
+++ b/op-interop-filter/filter/chain_ingester.go
@@ -1,0 +1,512 @@
+package filter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-interop-filter/metrics"
+	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/sources"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/db/logs"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/processors"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/reads"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+)
+
+const (
+	defaultBlockTime = 2 * time.Second
+	pollInterval     = 2 * time.Second
+)
+
+// ExecutingMessageCallback is called when executing messages are detected during ingestion
+type ExecutingMessageCallback func(chainID eth.ChainID, timestamp uint64, execMsgs []*types.ExecutingMessage)
+
+// ReorgCallback is called when a reorg is detected
+type ReorgCallback func(chainID eth.ChainID)
+
+// ChainIngester handles block ingestion and log storage for a single chain
+type ChainIngester struct {
+	log     log.Logger
+	metrics metrics.Metricer
+	chainID eth.ChainID
+
+	rpcClient  client.RPC
+	ethClient  *sources.EthClient
+	logsDB     *logs.DB
+	dataDir    string
+	backfillDuration time.Duration
+
+	ready   atomic.Bool
+	stopped atomic.Bool
+
+	onExecMsg ExecutingMessageCallback
+	onReorg   ReorgCallback
+
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+	mu     sync.RWMutex // protects logsDB access during rewind
+}
+
+// NewChainIngester creates a new ChainIngester for the given chain
+func NewChainIngester(
+	parentCtx context.Context,
+	logger log.Logger,
+	m metrics.Metricer,
+	chainID eth.ChainID,
+	rpcURL string,
+	dataDir string,
+	backfillDuration time.Duration,
+	onExecMsg ExecutingMessageCallback,
+	onReorg ReorgCallback,
+) (*ChainIngester, error) {
+	ctx, cancel := context.WithCancel(parentCtx)
+
+	logger = logger.New("chain", chainID)
+
+	// Create RPC client
+	rpcClient, err := client.NewRPC(ctx, logger, rpcURL)
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("failed to create RPC client for chain %s: %w", chainID, err)
+	}
+
+	// Create eth client
+	ethClient, err := sources.NewEthClient(
+		rpcClient,
+		logger,
+		nil,    // metrics
+		&sources.EthClientConfig{
+			ReceiptsCacheSize:     1000,
+			TransactionsCacheSize: 1000,
+			HeadersCacheSize:      1000,
+			PayloadsCacheSize:     100,
+			MaxRequestsPerBatch:   20,
+			MaxConcurrentRequests: 10,
+			TrustRPC:              false,
+			MustBePostMerge:       true,
+			RPCProviderKind:       sources.RPCKindStandard,
+		},
+	)
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("failed to create eth client for chain %s: %w", chainID, err)
+	}
+
+	return &ChainIngester{
+		log:              logger,
+		metrics:          m,
+		chainID:          chainID,
+		rpcClient:        rpcClient,
+		ethClient:        ethClient,
+		dataDir:          dataDir,
+		backfillDuration: backfillDuration,
+		onExecMsg:        onExecMsg,
+		onReorg:          onReorg,
+		ctx:              ctx,
+		cancel:           cancel,
+	}, nil
+}
+
+// Start begins block ingestion
+func (c *ChainIngester) Start() error {
+	c.log.Info("Starting chain ingester")
+
+	// Initialize LogsDB
+	if err := c.initLogsDB(); err != nil {
+		return fmt.Errorf("failed to init logs DB: %w", err)
+	}
+
+	// Start ingestion goroutine
+	c.wg.Add(1)
+	go c.runIngestion()
+
+	return nil
+}
+
+// Stop gracefully stops the chain ingester
+func (c *ChainIngester) Stop() error {
+	if !c.stopped.CompareAndSwap(false, true) {
+		return nil
+	}
+	c.log.Info("Stopping chain ingester")
+	c.cancel()
+	c.wg.Wait()
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.logsDB != nil {
+		if err := c.logsDB.Close(); err != nil {
+			return fmt.Errorf("failed to close logs DB: %w", err)
+		}
+	}
+	return nil
+}
+
+// Ready returns true if backfill is complete
+func (c *ChainIngester) Ready() bool {
+	return c.ready.Load()
+}
+
+// ChainID returns the chain ID
+func (c *ChainIngester) ChainID() eth.ChainID {
+	return c.chainID
+}
+
+// Contains checks if a log exists in the database
+func (c *ChainIngester) Contains(query types.ContainsQuery) (types.BlockSeal, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if c.logsDB == nil {
+		return types.BlockSeal{}, types.ErrUninitialized
+	}
+
+	return c.logsDB.Contains(query)
+}
+
+// LatestBlock returns the latest sealed block
+func (c *ChainIngester) LatestBlock() (eth.BlockID, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if c.logsDB == nil {
+		return eth.BlockID{}, false
+	}
+
+	return c.logsDB.LatestSealedBlock()
+}
+
+// LatestTimestamp returns the timestamp of the latest sealed block
+func (c *ChainIngester) LatestTimestamp() (uint64, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if c.logsDB == nil {
+		return 0, false
+	}
+
+	latestBlock, ok := c.logsDB.LatestSealedBlock()
+	if !ok {
+		return 0, false
+	}
+
+	seal, err := c.logsDB.FindSealedBlock(latestBlock.Number)
+	if err != nil {
+		return 0, false
+	}
+
+	return seal.Timestamp, true
+}
+
+// initLogsDB initializes the logs database
+func (c *ChainIngester) initLogsDB() error {
+	var dbPath string
+	if c.dataDir != "" {
+		chainDir := filepath.Join(c.dataDir, fmt.Sprintf("chain-%s", c.chainID))
+		if err := os.MkdirAll(chainDir, 0755); err != nil {
+			return fmt.Errorf("failed to create chain directory: %w", err)
+		}
+		dbPath = filepath.Join(chainDir, "logs.db")
+	} else {
+		// Use temp directory if no data dir specified
+		tempDir, err := os.MkdirTemp("", fmt.Sprintf("interop-filter-chain-%s-*", c.chainID))
+		if err != nil {
+			return fmt.Errorf("failed to create temp directory: %w", err)
+		}
+		dbPath = filepath.Join(tempDir, "logs.db")
+		c.log.Warn("Using temporary directory for logs DB", "path", dbPath)
+	}
+
+	db, err := logs.NewFromFile(c.log, &logsDBMetrics{m: c.metrics, chainID: c.chainID}, c.chainID, dbPath, true)
+	if err != nil {
+		return fmt.Errorf("failed to open logs DB: %w", err)
+	}
+
+	c.mu.Lock()
+	c.logsDB = db
+	c.mu.Unlock()
+
+	c.log.Info("Initialized logs DB", "path", dbPath)
+	return nil
+}
+
+// runIngestion runs the main ingestion loop
+func (c *ChainIngester) runIngestion() {
+	defer c.wg.Done()
+
+	// Get current head
+	head, err := c.ethClient.InfoByLabel(c.ctx, eth.Unsafe)
+	if err != nil {
+		c.log.Error("Failed to get current head", "err", err)
+		return
+	}
+	c.log.Info("Current chain head", "block", head.NumberU64(), "hash", head.Hash())
+
+	// Calculate backfill start block
+	blocksToBackfill := uint64(c.backfillDuration / defaultBlockTime)
+	var startBlock uint64
+	if head.NumberU64() > blocksToBackfill {
+		startBlock = head.NumberU64() - blocksToBackfill
+	} else {
+		startBlock = 1 // Start from block 1, not genesis
+	}
+
+	c.log.Info("Starting backfill", "from", startBlock, "to", head.NumberU64(), "blocks", head.NumberU64()-startBlock+1)
+
+	// Backfill
+	if err := c.backfill(startBlock, head.NumberU64()); err != nil {
+		if errors.Is(err, context.Canceled) {
+			c.log.Info("Backfill canceled")
+			return
+		}
+		c.log.Error("Backfill failed", "err", err)
+		c.triggerReorg()
+		return
+	}
+
+	// Mark as ready
+	c.ready.Store(true)
+	c.log.Info("Backfill complete, starting live ingestion")
+
+	// Live polling loop
+	c.pollLoop()
+}
+
+// backfill ingests blocks from startBlock to endBlock
+func (c *ChainIngester) backfill(startBlock, endBlock uint64) error {
+	totalBlocks := endBlock - startBlock + 1
+	lastProgress := 0
+	lastLog := time.Now()
+
+	for blockNum := startBlock; blockNum <= endBlock; blockNum++ {
+		select {
+		case <-c.ctx.Done():
+			return c.ctx.Err()
+		default:
+		}
+
+		if err := c.ingestBlock(blockNum); err != nil {
+			return fmt.Errorf("failed to ingest block %d: %w", blockNum, err)
+		}
+
+		// Progress reporting
+		progress := int((blockNum - startBlock + 1) * 100 / totalBlocks)
+		if progress >= lastProgress+10 || time.Since(lastLog) > 10*time.Second {
+			c.log.Info("Backfill progress",
+				"block", blockNum,
+				"total", endBlock,
+				"progress", fmt.Sprintf("%d%%", progress))
+			lastProgress = progress
+			lastLog = time.Now()
+		}
+	}
+
+	return nil
+}
+
+// pollLoop polls for new blocks
+func (c *ChainIngester) pollLoop() {
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-c.ctx.Done():
+			return
+		case <-ticker.C:
+			if err := c.pollNewBlocks(); err != nil {
+				if errors.Is(err, context.Canceled) {
+					return
+				}
+				c.log.Error("Failed to poll new blocks", "err", err)
+				// Don't trigger failsafe on transient errors
+			}
+		}
+	}
+}
+
+// pollNewBlocks checks for and ingests new blocks
+func (c *ChainIngester) pollNewBlocks() error {
+	head, err := c.ethClient.InfoByLabel(c.ctx, eth.Unsafe)
+	if err != nil {
+		return fmt.Errorf("failed to get head: %w", err)
+	}
+
+	latestBlock, ok := c.LatestBlock()
+	if !ok {
+		return fmt.Errorf("no latest block in DB")
+	}
+
+	// Check for reorg
+	if head.NumberU64() < latestBlock.Number {
+		c.log.Warn("Detected reorg: head is behind latest block",
+			"head", head.NumberU64(),
+			"latest", latestBlock.Number)
+		c.triggerReorg()
+		return nil
+	}
+
+	// Ingest any missing blocks
+	for blockNum := latestBlock.Number + 1; blockNum <= head.NumberU64(); blockNum++ {
+		if err := c.ingestBlock(blockNum); err != nil {
+			return fmt.Errorf("failed to ingest block %d: %w", blockNum, err)
+		}
+	}
+
+	return nil
+}
+
+// ingestBlock ingests a single block
+func (c *ChainIngester) ingestBlock(blockNum uint64) error {
+	// Fetch block info
+	blockInfo, err := c.ethClient.InfoByNumber(c.ctx, blockNum)
+	if err != nil {
+		return fmt.Errorf("failed to get block info: %w", err)
+	}
+
+	// Construct block ID
+	blockID := eth.BlockID{Hash: blockInfo.Hash(), Number: blockInfo.NumberU64()}
+
+	// Fetch receipts
+	_, receipts, err := c.ethClient.FetchReceipts(c.ctx, blockInfo.Hash())
+	if err != nil {
+		return fmt.Errorf("failed to get receipts: %w", err)
+	}
+
+	// Check for reorg (parent hash mismatch)
+	c.mu.RLock()
+	latestBlock, hasLatest := c.logsDB.LatestSealedBlock()
+	c.mu.RUnlock()
+
+	if hasLatest && blockNum == latestBlock.Number+1 {
+		if blockInfo.ParentHash() != latestBlock.Hash {
+			c.log.Warn("Detected reorg: parent hash mismatch",
+				"block", blockNum,
+				"expected_parent", latestBlock.Hash,
+				"actual_parent", blockInfo.ParentHash())
+			c.triggerReorg()
+			return nil
+		}
+	}
+
+	// Process logs and add to DB
+	var execMsgs []*types.ExecutingMessage
+	var logIndex uint32
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Get parent block ID for AddLog
+	parentBlock := eth.BlockID{Hash: blockInfo.ParentHash(), Number: blockNum - 1}
+	if blockNum == 0 {
+		parentBlock = eth.BlockID{}
+	}
+
+	for _, receipt := range receipts {
+		for _, l := range receipt.Logs {
+			// Compute log hash
+			logHash := processors.LogToLogHash(l)
+
+			// Check if this is an executing message
+			execMsg, err := processors.DecodeExecutingMessageLog(l)
+			if err != nil {
+				c.log.Debug("Failed to decode executing message", "err", err)
+			}
+
+			// Add log to DB
+			if err := c.logsDB.AddLog(logHash, parentBlock, logIndex, execMsg); err != nil {
+				// Check for conflict (reorg indicator)
+				if errors.Is(err, types.ErrConflict) {
+					c.log.Warn("Conflict adding log, triggering reorg", "err", err)
+					c.mu.Unlock()
+					c.triggerReorg()
+					c.mu.Lock()
+					return nil
+				}
+				return fmt.Errorf("failed to add log: %w", err)
+			}
+
+			if execMsg != nil {
+				execMsgs = append(execMsgs, execMsg)
+			}
+			logIndex++
+		}
+	}
+
+	// Seal the block
+	if err := c.logsDB.SealBlock(blockInfo.ParentHash(), blockID, blockInfo.Time()); err != nil {
+		if errors.Is(err, types.ErrConflict) {
+			c.log.Warn("Conflict sealing block, triggering reorg", "err", err)
+			c.mu.Unlock()
+			c.triggerReorg()
+			c.mu.Lock()
+			return nil
+		}
+		return fmt.Errorf("failed to seal block: %w", err)
+	}
+
+	// Update metrics
+	chainIDUint64, _ := c.chainID.Uint64()
+	c.metrics.RecordChainHead(chainIDUint64, blockNum)
+
+	// Notify about executing messages
+	if len(execMsgs) > 0 && c.onExecMsg != nil {
+		c.onExecMsg(c.chainID, blockInfo.Time(), execMsgs)
+	}
+
+	return nil
+}
+
+// triggerReorg handles reorg detection
+func (c *ChainIngester) triggerReorg() {
+	c.log.Warn("Reorg detected, triggering failsafe")
+	if c.onReorg != nil {
+		c.onReorg(c.chainID)
+	}
+}
+
+// Rewind rewinds the chain to the specified block
+func (c *ChainIngester) Rewind(newHead eth.BlockID) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.logsDB == nil {
+		return types.ErrUninitialized
+	}
+
+	// Use a no-op invalidator since we don't have cross-safe tracking
+	inv := &noopInvalidator{}
+
+	return c.logsDB.Rewind(inv, newHead)
+}
+
+// logsDBMetrics implements the logs.Metrics interface
+type logsDBMetrics struct {
+	m       metrics.Metricer
+	chainID eth.ChainID
+}
+
+func (l *logsDBMetrics) RecordDBEntryCount(kind string, count int64) {
+	// Could add more detailed metrics here if needed
+}
+
+func (l *logsDBMetrics) RecordDBSearchEntriesRead(count int64) {
+	// Could add more detailed metrics here if needed
+}
+
+// noopInvalidator is a no-op implementation of reads.Invalidator
+type noopInvalidator struct{}
+
+func (n *noopInvalidator) TryInvalidate(inv reads.InvalidationRule) (func(), error) {
+	return func() {}, nil
+}

--- a/op-interop-filter/filter/frontend.go
+++ b/op-interop-filter/filter/frontend.go
@@ -2,7 +2,6 @@ package filter
 
 import (
 	"context"
-	"errors"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -40,13 +39,14 @@ func (a *AdminFrontend) GetFailsafeEnabled(ctx context.Context) (bool, error) {
 	return a.backend.FailsafeEnabled(), nil
 }
 
-// SetFailsafeEnabled enables or disables failsafe mode (TODO: implement)
+// SetFailsafeEnabled enables or disables failsafe mode
 func (a *AdminFrontend) SetFailsafeEnabled(ctx context.Context, enabled bool) error {
-	return errors.New("SetFailsafeEnabled not yet implemented")
+	a.backend.SetFailsafeEnabled(enabled)
+	return nil
 }
 
-// Rewind rewinds chain state to a specific block (TODO: implement)
+// Rewind rewinds chain state to a specific block.
 // This can be used to recover from reorg-induced stuck states.
 func (a *AdminFrontend) Rewind(ctx context.Context, chain eth.ChainID, block eth.BlockID) error {
-	return errors.New("Rewind not yet implemented")
+	return a.backend.Rewind(ctx, chain, block)
 }

--- a/op-interop-filter/metrics/metrics.go
+++ b/op-interop-filter/metrics/metrics.go
@@ -16,6 +16,12 @@ type Metricer interface {
 	RecordFailsafeEnabled(enabled bool)
 	RecordChainHead(chainID uint64, blockNum uint64)
 	RecordCheckAccessList(success bool)
+	RecordBackfillProgress(chainID uint64, progress float64)
+	RecordReorgDetected(chainID uint64)
+	RecordLogsAdded(chainID uint64, count int64)
+	RecordBlocksSealed(chainID uint64, count int64)
+	RecordCrossUnsafeValidatedTimestamp(timestamp uint64)
+	RecordPendingExecMsgs(chainID uint64, count int64)
 }
 
 type Metrics struct {
@@ -28,6 +34,14 @@ type Metrics struct {
 	failsafeEnabled  prometheus.Gauge
 	chainHead        *prometheus.GaugeVec
 	checkAccessTotal *prometheus.CounterVec
+
+	// Chain-specific metrics
+	backfillProgress             *prometheus.GaugeVec
+	reorgDetectedTotal           *prometheus.CounterVec
+	logsAddedTotal               *prometheus.CounterVec
+	blocksSealedTotal            *prometheus.CounterVec
+	crossUnsafeValidatedTimestamp prometheus.Gauge
+	pendingExecMsgs              *prometheus.GaugeVec
 }
 
 var _ Metricer = (*Metrics)(nil)
@@ -76,6 +90,42 @@ func NewMetrics(procName string) *Metrics {
 			Name:      "check_access_list_total",
 			Help:      "Total checkAccessList requests",
 		}, []string{"success"}),
+
+		backfillProgress: factory.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: ns,
+			Name:      "backfill_progress",
+			Help:      "Backfill progress (0-1) per chain",
+		}, []string{"chain_id"}),
+
+		reorgDetectedTotal: factory.NewCounterVec(prometheus.CounterOpts{
+			Namespace: ns,
+			Name:      "reorg_detected_total",
+			Help:      "Total reorgs detected per chain",
+		}, []string{"chain_id"}),
+
+		logsAddedTotal: factory.NewCounterVec(prometheus.CounterOpts{
+			Namespace: ns,
+			Name:      "logs_added_total",
+			Help:      "Total logs added to DB per chain",
+		}, []string{"chain_id"}),
+
+		blocksSealedTotal: factory.NewCounterVec(prometheus.CounterOpts{
+			Namespace: ns,
+			Name:      "blocks_sealed_total",
+			Help:      "Total blocks sealed per chain",
+		}, []string{"chain_id"}),
+
+		crossUnsafeValidatedTimestamp: factory.NewGauge(prometheus.GaugeOpts{
+			Namespace: ns,
+			Name:      "cross_unsafe_validated_timestamp",
+			Help:      "Latest cross-unsafe validated timestamp",
+		}),
+
+		pendingExecMsgs: factory.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: ns,
+			Name:      "pending_exec_msgs",
+			Help:      "Pending executing messages awaiting cross-unsafe validation per chain",
+		}, []string{"chain_id"}),
 	}
 }
 
@@ -115,13 +165,43 @@ func (m *Metrics) RecordCheckAccessList(success bool) {
 	m.checkAccessTotal.WithLabelValues(label).Inc()
 }
 
+func (m *Metrics) RecordBackfillProgress(chainID uint64, progress float64) {
+	m.backfillProgress.WithLabelValues(strconv.FormatUint(chainID, 10)).Set(progress)
+}
+
+func (m *Metrics) RecordReorgDetected(chainID uint64) {
+	m.reorgDetectedTotal.WithLabelValues(strconv.FormatUint(chainID, 10)).Inc()
+}
+
+func (m *Metrics) RecordLogsAdded(chainID uint64, count int64) {
+	m.logsAddedTotal.WithLabelValues(strconv.FormatUint(chainID, 10)).Add(float64(count))
+}
+
+func (m *Metrics) RecordBlocksSealed(chainID uint64, count int64) {
+	m.blocksSealedTotal.WithLabelValues(strconv.FormatUint(chainID, 10)).Add(float64(count))
+}
+
+func (m *Metrics) RecordCrossUnsafeValidatedTimestamp(timestamp uint64) {
+	m.crossUnsafeValidatedTimestamp.Set(float64(timestamp))
+}
+
+func (m *Metrics) RecordPendingExecMsgs(chainID uint64, count int64) {
+	m.pendingExecMsgs.WithLabelValues(strconv.FormatUint(chainID, 10)).Set(float64(count))
+}
+
 // NoopMetrics is a no-op implementation for testing
 var NoopMetrics Metricer = &noopMetrics{}
 
 type noopMetrics struct{}
 
-func (n *noopMetrics) RecordInfo(version string)                       {}
-func (n *noopMetrics) RecordUp()                                       {}
-func (n *noopMetrics) RecordFailsafeEnabled(enabled bool)              {}
-func (n *noopMetrics) RecordChainHead(chainID uint64, blockNum uint64) {}
-func (n *noopMetrics) RecordCheckAccessList(success bool)              {}
+func (n *noopMetrics) RecordInfo(version string)                             {}
+func (n *noopMetrics) RecordUp()                                             {}
+func (n *noopMetrics) RecordFailsafeEnabled(enabled bool)                    {}
+func (n *noopMetrics) RecordChainHead(chainID uint64, blockNum uint64)       {}
+func (n *noopMetrics) RecordCheckAccessList(success bool)                    {}
+func (n *noopMetrics) RecordBackfillProgress(chainID uint64, progress float64) {}
+func (n *noopMetrics) RecordReorgDetected(chainID uint64)                    {}
+func (n *noopMetrics) RecordLogsAdded(chainID uint64, count int64)           {}
+func (n *noopMetrics) RecordBlocksSealed(chainID uint64, count int64)        {}
+func (n *noopMetrics) RecordCrossUnsafeValidatedTimestamp(timestamp uint64)  {}
+func (n *noopMetrics) RecordPendingExecMsgs(chainID uint64, count int64)     {}


### PR DESCRIPTION
## Summary

Implements the core `op-interop-filter` service logic for validating interop executing messages, decoupled from the supernode.

**Key components:**
- **ChainIngester interface**: Defines chain ingestion contract - implementations handle backfill, polling, and cross-chain coordination
- **Backend**: Coordinates multiple chain ingesters, manages failsafe state, implements cross-unsafe validation
- **Frontend**: RPC handlers for `supervisor_checkAccessList` and admin APIs
- **Metrics**: Comprehensive Prometheus instrumentation for observability

## Review Guide

**Recommended review order:**

1. **Start with the interfaces** (`interfaces.go`) - understand the `ChainIngester` contract and `Backend` interface. This establishes the mental model for how components interact.

2. **Review the Backend** (`backend.go`) - see how the Backend coordinates chain ingesters and implements the validation flow.

3. **Review implementations** - once you understand the interface contract:
   - `LogsDBChainIngester` - production implementation with RPC polling and LogsDB storage
   - `MockChainIngester` - test implementation for unit testing

4. **Frontend/Config/Service** - standard wiring, less critical to understand the core logic

## Test Coverage

The test suite covers:
- **ValidateMessageTiming**: Boundary conditions for message expiry validation
- **Backend failsafe**: Manual and automatic failsafe triggering
- **CrossValidator**: Timeout expiry, cross-unsafe timestamps, unknown chains, checksum verification
- **Binary search**: `findBlockByTimestamp` sanity check

**Note**: `LogsDBChainIngester` integration tests are deferred to a follow-up PR with Kurtosis/devstack preset, as they require real chain interaction to meaningfully test reorg detection and RPC polling.

## Test plan

- [x] Unit tests pass: `go test ./op-interop-filter/...`
- [ ] Integration testing with devstack (follow-up PR)

🤖 Generated with [Claude Code](https://claude.ai/code)