### PR TITLE
op-e2e: Enable jovian for proofs precompile tests

### DIFF
--- a/op-e2e/faultproofs/util.go
+++ b/op-e2e/faultproofs/util.go
@@ -57,6 +57,7 @@ func WithLatestFork() faultDisputeConfigOpts {
 			genesisActivation := hexutil.Uint64(0)
 			cfg.DeployConfig.L1CancunTimeOffset = &genesisActivation
 			cfg.DeployConfig.L1PragueTimeOffset = &genesisActivation
+			cfg.DeployConfig.L1OsakaTimeOffset = &genesisActivation
 			cfg.DeployConfig.L2GenesisDeltaTimeOffset = &genesisActivation
 			cfg.DeployConfig.L2GenesisEcotoneTimeOffset = &genesisActivation
 			cfg.DeployConfig.L2GenesisFjordTimeOffset = &genesisActivation

--- a/op-e2e/faultproofs/util.go
+++ b/op-e2e/faultproofs/util.go
@@ -63,8 +63,7 @@ func WithLatestFork() faultDisputeConfigOpts {
 			cfg.DeployConfig.L2GenesisGraniteTimeOffset = &genesisActivation
 			cfg.DeployConfig.L2GenesisHoloceneTimeOffset = &genesisActivation
 			cfg.DeployConfig.L2GenesisIsthmusTimeOffset = &genesisActivation
-			// TODO(#17348): Jovian is not supported in op-e2e tests yet
-			//cfg.DeployConfig.L2GenesisJovianTimeOffset = &genesisActivation
+			cfg.DeployConfig.L2GenesisJovianTimeOffset = &genesisActivation
 		})
 	}
 }


### PR DESCRIPTION
**Description**

Enable jovian on L2 and Osaka on L1 as the latest hard fork for proofs e2e tests (actually only affects precompile tests currently).


**Metadata**

fixes #17348 