### PR TITLE
chore: Add SafeRename ioutil utility

### DIFF
--- a/op-deployer/pkg/deployer/forge/binary.go
+++ b/op-deployer/pkg/deployer/forge/binary.go
@@ -254,7 +254,7 @@ func (b *StandardBin) downloadBinary(ctx context.Context, dest string) error {
 	if err := ioutil.Untar(tmpDir, tr); err != nil {
 		return fmt.Errorf("failed to untar: %w", err)
 	}
-	if err := os.Rename(path.Join(tmpDir, "forge"), path.Join(dest, "forge")); err != nil {
+	if err := ioutil.SafeRename(path.Join(tmpDir, "forge"), path.Join(dest, "forge")); err != nil {
 		return fmt.Errorf("failed to move binary: %w", err)
 	}
 	if err := os.Chmod(path.Join(dest, "forge"), 0o755); err != nil {

--- a/op-service/github/release/provider.go
+++ b/op-service/github/release/provider.go
@@ -437,7 +437,7 @@ func (d *GithubReleaseDownloader) download(ctx context.Context, version string, 
 
 	// Move the extracted name to the destination path and ensure it is
 	// executable by clearing/setting appropriate file mode bits.
-	if err := os.Rename(sourcePath, destinationPath); err != nil {
+	if err := ioutil.SafeRename(sourcePath, destinationPath); err != nil {
 		return "", fmt.Errorf("failed to move name from %s to %s: %w", sourcePath, destinationPath, err)
 	}
 	if err := os.Chmod(destinationPath, 0o755); err != nil {

--- a/op-service/ioutil/rename.go
+++ b/op-service/ioutil/rename.go
@@ -1,0 +1,75 @@
+package ioutil
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"syscall"
+
+	"errors"
+)
+
+// SafeRename attempts to rename a file from source to destination.
+// If the rename fails due to cross-device link error, it falls back to copying the file and deleting the source.
+func SafeRename(source, destination string) error {
+	// First see if we can just rename the file normally
+	err := os.Rename(source, destination)
+
+	// If we get an "invalid cross-device link" error, we need to do a copy and delete
+	if err != nil && errors.Is(err, syscall.EXDEV) {
+		return renameCrossDevice(source, destination)
+	}
+
+	return err
+}
+
+func renameCrossDevice(source, destination string) error {
+	// Open the source file
+	src, err := os.Open(source)
+	if err != nil {
+		return fmt.Errorf("rename: failed to open source file %s: %w", source, err)
+	}
+
+	// Create the destination file
+	dst, err := os.Create(destination)
+	if err != nil {
+		// Make sure to close the source file before returning
+		src.Close()
+
+		return fmt.Errorf("rename: failed to create destination file %s: %w", destination, err)
+	}
+
+	// Copy the contents over
+	_, err = io.Copy(dst, src)
+
+	// Close both files
+	err = src.Close()
+	dst.Close()
+
+	if err != nil {
+		return fmt.Errorf("rename: failed to copy source %s to destination %s: %w", source, destination, err)
+	}
+
+	// Get source file permissions
+	fileInfo, err := os.Stat(source)
+	if err != nil {
+		// Remove the destination file if we fail to stat the source
+		os.Remove(destination)
+
+		return fmt.Errorf("rename: failed to stat source %s: %w", source, err)
+	}
+
+	// Apply source file permissions to destination
+	err = os.Chmod(destination, fileInfo.Mode())
+	if err != nil {
+		// Remove the destination file if we fail to apply the permissions
+		os.Remove(destination)
+
+		return fmt.Errorf("rename: failed to apply file permissions to destination %s: %w", destination, err)
+	}
+
+	// Delete the source file
+	os.Remove(source)
+
+	return nil
+}

--- a/op-service/ioutil/rename.go
+++ b/op-service/ioutil/rename.go
@@ -43,7 +43,7 @@ func renameCrossDevice(source, destination string) error {
 	_, err = io.Copy(dst, src)
 
 	// Close both files
-	err = src.Close()
+	src.Close()
 	dst.Close()
 
 	if err != nil {


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

We encountered a problem regarding the github release binary provider where a regular `os.Rename` would result in `invalid cross-device link` errors. These were caused by trying to rename a file across mounts/filesystems.

The new `SafeRename` tries `os.Rename` first, then falls back to copy & delete.

You might notice there are no tests currently - this is due to the lack of cross-platform support for mounting filesystems (which we need to run a full test) - neither `[k8s.io/utils/mount](https://pkg.go.dev/k8s.io/utils/mount)` nor `[github.com/moby/sys/mount](https://pkg.go.dev/github.com/moby/sys/mount)` have support for darwin.

Related to https://github.com/ethereum-optimism/platforms-team/issues/1119