### PR TITLE
challenger: Fix kona-interop host args

### DIFF
--- a/op-challenger/game/fault/trace/vm/kona_super_server_executor.go
+++ b/op-challenger/game/fault/trace/vm/kona_super_server_executor.go
@@ -51,7 +51,7 @@ func (s *KonaSuperExecutor) OracleCommand(cfg Config, dataDir string, inputs uti
 	}
 
 	if cfg.L1GenesisPath != "" {
-		args = append(args, "--l1-config-path", cfg.L1GenesisPath)
+		args = append(args, "--l1-config-paths", cfg.L1GenesisPath)
 	}
 
 	return args, nil

--- a/op-challenger/game/fault/trace/vm/kona_super_server_executor_test.go
+++ b/op-challenger/game/fault/trace/vm/kona_super_server_executor_test.go
@@ -1,0 +1,45 @@
+package vm
+
+import (
+	"math/big"
+	"slices"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/utils"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSuperKonaFillHostCommand(t *testing.T) {
+	dir := "mockdir"
+	cfg := Config{
+		L1:            "http://localhost:8888",
+		L1Beacon:      "http://localhost:9000",
+		L2s:           []string{"http://localhost:9999", "http://localhost:9998"},
+		Server:        "./bin/mockserver",
+		Networks:      []string{"op-mainnet", "uni-mainnet"},
+		L1GenesisPath: "mockdir/l1-genesis-1.json",
+	}
+	inputs := utils.LocalGameInputs{
+		L1Head:           common.Hash{0x11},
+		AgreedPreState:   common.FromHex("0x33"),
+		L2Claim:          common.Hash{0x44},
+		L2SequenceNumber: big.NewInt(3333),
+	}
+	vmConfig := NewKonaSuperExecutor()
+
+	args, err := vmConfig.OracleCommand(cfg, dir, inputs)
+	require.NoError(t, err)
+
+	require.True(t, slices.Contains(args, "super"))
+	require.True(t, slices.Contains(args, "--server"))
+	require.True(t, slices.Contains(args, "--l1-node-address"))
+	require.True(t, slices.Contains(args, "--l1-beacon-address"))
+	require.True(t, slices.Contains(args, "--l2-node-addresses"))
+	require.True(t, slices.Contains(args, "--l1-head"))
+	require.True(t, slices.Contains(args, "--agreed-l2-pre-state"))
+	require.True(t, slices.Contains(args, "--claimed-l2-post-state"))
+	require.True(t, slices.Contains(args, "--claimed-l2-timestamp"))
+	require.True(t, slices.Contains(args, "--data-dir"))
+	require.True(t, slices.Contains(args, "--l1-config-paths"))
+}


### PR DESCRIPTION
Fixes the flags passed to the kona-interop host by the kona super executor. The `l1-config-paths` was recently changed to allow the kona host to admit multiple L1 genesis (https://github.com/op-rs/kona/pull/2892).

### Testing
```
cd <kona-repo>
cargo build --bin kona-host
cd <optimism-monorepo>
env KONA_HOST_PATH=<kona-repo>/target/debug/kona-host go test -run TestInteropFaultProofs ./op-e2e/actions/interop
```

#### Metadata

part of https://github.com/ethereum-optimism/optimism/issues/18616