### PR TITLE
chore: improve comments accuracy (#741)

### DIFF
--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -88,8 +88,8 @@
     "sourceCodeHash": "0x34186bcab29963237b4e0d7575b0a1cff7caf42ccdb55d4b2b2c767db3279189"
   },
   "src/L2/L1Withdrawer.sol:L1Withdrawer": {
-    "initCodeHash": "0x91e0be0d49636212678191c06b9b6840c399f08ad946bc7b52f24231691be28b",
-    "sourceCodeHash": "0x25422bdaf51d611c1688a835737368c0ff2ab639dac852af8a20ebb4e16fc103"
+    "initCodeHash": "0x6efb9055142e90b408c6312074243769df0d365f6f984e226e0320bec55a45b8",
+    "sourceCodeHash": "0x6a12e541b47b79f19d1061ff7b64ffdcffa1e8d06225cca6798daca53fd96890"
   },
   "src/L2/L2CrossDomainMessenger.sol:L2CrossDomainMessenger": {
     "initCodeHash": "0xe160be403df12709c371c33195d1b9c3b5e9499e902e86bdabc8eed749c3fd61",

--- a/packages/contracts-bedrock/src/L2/L1Withdrawer.sol
+++ b/packages/contracts-bedrock/src/L2/L1Withdrawer.sol
@@ -58,7 +58,7 @@ contract L1Withdrawer is ISemver {
     /// @param _minWithdrawalAmount The minimum amount of ETH required to trigger a withdrawal.
     /// @param _recipient The L1 address that will receive withdrawals.
     /// @param _withdrawalGasLimit The gas limit for the L1 withdrawal transaction.
-    /// @dev If target on L1 is `FeesDepositor`, the gas limit should be above 800k gas.
+    /// @dev If target on L1 is `FeesDepositor`, the gas limit should be at or above 800k gas.
     constructor(uint256 _minWithdrawalAmount, address _recipient, uint32 _withdrawalGasLimit) {
         minWithdrawalAmount = _minWithdrawalAmount;
         recipient = _recipient;
@@ -105,7 +105,7 @@ contract L1Withdrawer is ISemver {
 
     /// @notice Updates the withdrawal gas limit. Only callable by the ProxyAdmin owner.
     /// @param _newWithdrawalGasLimit The new withdrawal gas limit.
-    /// @dev If target on L1 is `FeesDepositor`, the gas limit should be above 800k gas.
+    /// @dev If target on L1 is `FeesDepositor`, the gas limit should be at or above 800k gas.
     function setWithdrawalGasLimit(uint32 _newWithdrawalGasLimit) external {
         if (msg.sender != IProxyAdmin(Predeploys.PROXY_ADMIN).owner()) {
             revert L1Withdrawer_OnlyProxyAdminOwner();

--- a/packages/contracts-bedrock/src/L2/L1Withdrawer.sol
+++ b/packages/contracts-bedrock/src/L2/L1Withdrawer.sol
@@ -51,8 +51,8 @@ contract L1Withdrawer is ISemver {
     event WithdrawalGasLimitUpdated(uint32 oldWithdrawalGasLimit, uint32 newWithdrawalGasLimit);
 
     /// @notice Semantic version.
-    /// @custom:semver 1.0.0
-    string public constant version = "1.0.0";
+    /// @custom:semver 1.0.1
+    string public constant version = "1.0.1";
 
     /// @notice Constructs the L1Withdrawer contract.
     /// @param _minWithdrawalAmount The minimum amount of ETH required to trigger a withdrawal.


### PR DESCRIPTION
**Description**

Small PR improving the accuracy of the comments related to the gas required for the FeesDepositor. Here is a Gist with the traces of the gas costs when FeesDepositor receives ETH and triggers/doesn't trigger a portal deposit: https://gist.github.com/0xChin/f0e05c23599b9966f5601d27f71f5aae


Clarifies `L1Withdrawer.sol` natSpec to state the L1 gas limit for `FeesDepositor` must be at or above 800k gas.

---

Author: @0xChin 
