### PR TITLE
Remove go 1.24 feature flag, leaving SysGetRandom syscall enabled

### DIFF
--- a/cannon/mipsevm/iface.go
+++ b/cannon/mipsevm/iface.go
@@ -74,7 +74,6 @@ type Metadata interface {
 // Toggles here are temporary and should be removed once the newer state version is deployed widely. The older
 // version can then be supported via multicannon pulling in a specific build and support for it dropped in latest code.
 type FeatureToggles struct {
-	SupportWorkingSysGetRandom bool
 }
 
 type FPVM interface {

--- a/cannon/mipsevm/multithreaded/mips.go
+++ b/cannon/mipsevm/multithreaded/mips.go
@@ -159,10 +159,7 @@ func (m *InstrumentedState) handleSyscall() error {
 		v0 = 0
 		v1 = 0
 	case arch.SysGetRandom:
-		if m.features.SupportWorkingSysGetRandom {
-			v0, v1 = m.syscallGetRandom(a0, a1)
-		}
-		// Otherwise, ignored (noop)
+		v0, v1 = m.syscallGetRandom(a0, a1)
 	case arch.SysMunmap:
 	case arch.SysMprotect:
 	case arch.SysGetAffinity:

--- a/cannon/mipsevm/tests/evm_common_test.go
+++ b/cannon/mipsevm/tests/evm_common_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/program"
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/register"
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/testutil"
-	"github.com/ethereum-optimism/optimism/cannon/mipsevm/versions"
 )
 
 type insnCache interface {
@@ -632,21 +631,6 @@ func TestEVM_MMap(t *testing.T) {
 		Run(t, cases)
 }
 
-func TestEVM_SysGetRandom_isImplemented(t *testing.T) {
-	t.Parallel()
-	// Assert we have at least one vm with the working getrandom syscall
-	foundVmWithSyscallEnabled := false
-	for _, vers := range GetMipsVersionTestCases(t) {
-		features := versions.FeaturesForVersion(vers.Version)
-		foundVmWithSyscallEnabled = foundVmWithSyscallEnabled || features.SupportWorkingSysGetRandom
-	}
-	require.True(t, foundVmWithSyscallEnabled)
-
-	// Assert that latest version has a working getrandom ssycall
-	latestFeatures := versions.FeaturesForVersion(versions.GetExperimentalVersion())
-	require.True(t, latestFeatures.SupportWorkingSysGetRandom)
-}
-
 func TestEVM_SysGetRandom(t *testing.T) {
 	t.Parallel()
 
@@ -702,18 +686,12 @@ func TestEVM_SysGetRandom(t *testing.T) {
 	}
 
 	setExpectations := func(t require.TestingT, testCase testCase, expected *mtutil.ExpectedState, vm VersionedVMTestCase) ExpectedExecResult {
-		isNoop := !versions.FeaturesForVersion(vm.Version).SupportWorkingSysGetRandom
 		expectedMemory := testCase.expectedRandDataMask&randomData | ^testCase.expectedRandDataMask&startingMemory
 
 		expected.ExpectStep()
-		if isNoop {
-			expected.ActiveThread().Registers[register.RegSyscallRet1] = 0
-			expected.ActiveThread().Registers[register.RegSyscallErrno] = 0
-		} else {
-			expected.ActiveThread().Registers[register.RegSyscallRet1] = testCase.expectedReturnValue
-			expected.ActiveThread().Registers[register.RegSyscallErrno] = 0
-			expected.ExpectMemoryWrite(effAddr, expectedMemory)
-		}
+		expected.ActiveThread().Registers[register.RegSyscallRet1] = testCase.expectedReturnValue
+		expected.ActiveThread().Registers[register.RegSyscallErrno] = 0
+		expected.ExpectMemoryWrite(effAddr, expectedMemory)
 		return ExpectNormalExecution()
 	}
 
@@ -984,10 +962,6 @@ func TestEVM_RandomProgram(t *testing.T) {
 		v := v
 		t.Run(v.Name, func(t *testing.T) {
 			t.Parallel()
-
-			if !versions.FeaturesForVersion(v.Version).SupportWorkingSysGetRandom {
-				t.Skip("Skipping vm version that does not support working sys_getrandom")
-			}
 
 			validator := testutil.NewEvmValidator(t, v.StateHashFn, v.Contracts)
 

--- a/cannon/mipsevm/tests/evm_multithreaded64_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded64_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/multithreaded"
 	mtutil "github.com/ethereum-optimism/optimism/cannon/mipsevm/multithreaded/testutil"
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/testutil"
-	"github.com/ethereum-optimism/optimism/cannon/mipsevm/versions"
 )
 
 func TestEVM_MT64_LL(t *testing.T) {
@@ -608,7 +607,6 @@ var NoopSyscalls64 = map[string]uint32{
 	"SysPipe2":        5287,
 	"SysEpollCtl":     5208,
 	"SysEpollPwait":   5272,
-	"SysGetRandom":    5313,
 	"SysUname":        5061,
 	//"SysStat64":       UndefinedSysNr,
 	"SysGetuid": 5100,
@@ -624,49 +622,46 @@ var NoopSyscalls64 = map[string]uint32{
 	"SysTimerDelete":  5220,
 }
 
-func getNoopSyscalls64(vmVersion versions.StateVersion) map[string]uint32 {
-	noOpCalls := maps.Clone(NoopSyscalls64)
-	features := versions.FeaturesForVersion(vmVersion)
-	if features.SupportWorkingSysGetRandom {
-		delete(noOpCalls, "SysGetRandom")
-	}
-	return noOpCalls
-}
-
-func getSupportedSyscalls(vmVersion versions.StateVersion) []uint32 {
-	supportedSyscalls := []uint32{arch.SysMmap, arch.SysBrk, arch.SysClone, arch.SysExitGroup, arch.SysRead, arch.SysWrite, arch.SysFcntl, arch.SysExit, arch.SysSchedYield, arch.SysGetTID, arch.SysFutex, arch.SysOpen, arch.SysNanosleep, arch.SysClockGetTime, arch.SysGetpid, arch.SysEventFd2}
-
-	features := versions.FeaturesForVersion(vmVersion)
-	if features.SupportWorkingSysGetRandom {
-		supportedSyscalls = append(supportedSyscalls, arch.SysGetRandom)
-	}
-	return supportedSyscalls
+var SupportedSyscalls64 = []uint32{
+	arch.SysMmap,
+	arch.SysBrk,
+	arch.SysClone,
+	arch.SysExitGroup,
+	arch.SysRead,
+	arch.SysWrite,
+	arch.SysFcntl,
+	arch.SysExit,
+	arch.SysSchedYield,
+	arch.SysGetTID,
+	arch.SysFutex,
+	arch.SysOpen,
+	arch.SysNanosleep,
+	arch.SysClockGetTime,
+	arch.SysGetpid,
+	arch.SysEventFd2,
+	arch.SysGetRandom,
 }
 
 func TestEVM_NoopSyscall64(t *testing.T) {
 	t.Parallel()
 	for _, vmVersion := range GetMipsVersionTestCases(t) {
-		noOpCalls := getNoopSyscalls64(vmVersion.Version)
-		testNoopSyscall(t, vmVersion, noOpCalls)
+		testNoopSyscall(t, vmVersion, NoopSyscalls64)
 	}
 }
 
 func TestEVM_UnsupportedSyscall64(t *testing.T) {
 	t.Parallel()
-	for _, vmVersion := range GetMipsVersionTestCases(t) {
-		var noopSyscallNums = maps.Values(getNoopSyscalls64(vmVersion.Version))
-		var SupportedSyscalls = getSupportedSyscalls(vmVersion.Version)
-		unsupportedSyscalls := make([]uint32, 0, 400)
-		for i := 5000; i < 5400; i++ {
-			candidate := uint32(i)
-			if slices.Contains(SupportedSyscalls, candidate) || slices.Contains(noopSyscallNums, candidate) {
-				continue
-			}
-			unsupportedSyscalls = append(unsupportedSyscalls, candidate)
+	noopSyscallNums := maps.Values(NoopSyscalls64)
+	unsupportedSyscalls := make([]uint32, 0, 400)
+	for i := 5000; i < 5400; i++ {
+		candidate := uint32(i)
+		if slices.Contains(SupportedSyscalls64, candidate) || slices.Contains(noopSyscallNums, candidate) {
+			continue
 		}
-
-		unsupported := unsupportedSyscalls
-		testUnsupportedSyscall(t, vmVersion, unsupported)
+		unsupportedSyscalls = append(unsupportedSyscalls, candidate)
+	}
+	for _, vmVersion := range GetMipsVersionTestCases(t) {
+		testUnsupportedSyscall(t, vmVersion, unsupportedSyscalls)
 	}
 }
 

--- a/cannon/mipsevm/tests/helpers.go
+++ b/cannon/mipsevm/tests/helpers.go
@@ -88,12 +88,7 @@ func GetMipsVersionTestCases(t require.TestingT) []VersionedVMTestCase {
 	var cases []VersionedVMTestCase
 	for _, version := range versions.StateVersionTypes {
 		if !arch.IsMips32 && versions.IsSupportedMultiThreaded64(version) {
-			goTarget := testutil.Go1_24
-			features := versions.FeaturesForVersion(version)
-			if features.SupportWorkingSysGetRandom {
-				goTarget = testutil.Go1_25
-			}
-			cases = append(cases, GetMultiThreadedTestCase(t, version, goTarget))
+			cases = append(cases, GetMultiThreadedTestCase(t, version, testutil.Go1_25))
 		}
 	}
 	return cases

--- a/cannon/mipsevm/versions/state.go
+++ b/cannon/mipsevm/versions/state.go
@@ -69,9 +69,6 @@ func (s *VersionedState) CreateVM(logger log.Logger, po mipsevm.PreimageOracle, 
 func FeaturesForVersion(version StateVersion) mipsevm.FeatureToggles {
 	features := mipsevm.FeatureToggles{}
 	// Set any required feature toggles based on the state version here.
-	if version >= VersionMultiThreaded64_v5 {
-		features.SupportWorkingSysGetRandom = true
-	}
 	return features
 }
 

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -176,8 +176,8 @@
     "sourceCodeHash": "0x734a6b2aa6406bc145d848ad6071d3af1d40852aeb8f4b2f6f51beaad476e2d3"
   },
   "src/cannon/MIPS64.sol:MIPS64": {
-    "initCodeHash": "0x6a649986370d18e5fddcd89df73e520063fb373f7dba2f731a2b7e79a1c132a5",
-    "sourceCodeHash": "0x657afae82e6e3627389153736e568bf99498a272ec6d9ecc22ecfd645c56c453"
+    "initCodeHash": "0xca65dc03f781641951d24a099ec414be675b8efc28c364673692a7107b31d08f",
+    "sourceCodeHash": "0xe64e95e02828bb3de75c72835f617362ce918c69b12fbd9a33fc53b63165f61a"
   },
   "src/cannon/PreimageOracle.sol:PreimageOracle": {
     "initCodeHash": "0x6af5b0e83b455aab8d0946c160a4dc049a4e03be69f8a2a9e87b574f27b25a66",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -176,8 +176,8 @@
     "sourceCodeHash": "0x734a6b2aa6406bc145d848ad6071d3af1d40852aeb8f4b2f6f51beaad476e2d3"
   },
   "src/cannon/MIPS64.sol:MIPS64": {
-    "initCodeHash": "0xca65dc03f781641951d24a099ec414be675b8efc28c364673692a7107b31d08f",
-    "sourceCodeHash": "0xe64e95e02828bb3de75c72835f617362ce918c69b12fbd9a33fc53b63165f61a"
+    "initCodeHash": "0x13196c1652a1f51cf0c16191f0092898f127eff036c773923c72b02a2823c7f4",
+    "sourceCodeHash": "0xd745aaf4ed265be7be7bff9bca1dd040e15dfe41e3a453906d72ca09a47f2c8b"
   },
   "src/cannon/PreimageOracle.sol:PreimageOracle": {
     "initCodeHash": "0x6af5b0e83b455aab8d0946c160a4dc049a4e03be69f8a2a9e87b574f27b25a66",

--- a/packages/contracts-bedrock/src/cannon/MIPS64.sol
+++ b/packages/contracts-bedrock/src/cannon/MIPS64.sol
@@ -66,8 +66,8 @@ contract MIPS64 is ISemver {
     }
 
     /// @notice The semantic version of the MIPS64 contract.
-    /// @custom:semver 1.9.0
-    string public constant version = "1.9.0";
+    /// @custom:semver 1.10.0
+    string public constant version = "1.10.0";
 
     /// @notice The preimage oracle contract.
     IPreimageOracle internal immutable ORACLE;
@@ -92,8 +92,8 @@ contract MIPS64 is ISemver {
 
     /// @param _oracle The address of the preimage oracle contract.
     constructor(IPreimageOracle _oracle, uint256 _stateVersion) {
-        // Supports VersionMultiThreaded64_v4 (7) and VersionMultiThreaded64_v5 (8)
-        if (_stateVersion != 7 && _stateVersion != 8) {
+        // Supports VersionMultiThreaded64_v5 (8)
+        if (_stateVersion != 8) {
             revert UnsupportedStateVersion();
         }
         ORACLE = _oracle;
@@ -560,10 +560,7 @@ contract MIPS64 is ISemver {
                 v0 = 0;
                 v1 = 0;
             } else if (syscall_no == sys.SYS_GETRANDOM) {
-                if (st.featuresForVersion(STATE_VERSION).supportWorkingSysGetRandom) {
-                    (v0, v1, state.memRoot) = syscallGetRandom(state, a0, a1);
-                }
-                // Otherwise, ignored (noop)
+                (v0, v1, state.memRoot) = syscallGetRandom(state, a0, a1);
             } else if (syscall_no == sys.SYS_MUNMAP) {
                 // ignored
             } else if (syscall_no == sys.SYS_MPROTECT) {

--- a/packages/contracts-bedrock/src/cannon/libraries/MIPS64State.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/MIPS64State.sol
@@ -12,9 +12,8 @@ library MIPS64State {
         uint64 hi;
     }
 
-    struct Features {
-        bool supportWorkingSysGetRandom;
-    }
+    // struct Features {
+    // }
 
     function assertExitedIsValid(uint32 _exited) internal pure {
         if (_exited > 1) {
@@ -22,9 +21,7 @@ library MIPS64State {
         }
     }
 
-    function featuresForVersion(uint256 _version) internal pure returns (Features memory features_) {
-        if (_version >= 8) {
-            features_.supportWorkingSysGetRandom = true;
-        }
-    }
+    // function featuresForVersion(uint256 _version) internal pure returns (Features memory features_) {
+    //     // Set feature toggles based on the state version here.
+    // }
 }

--- a/packages/contracts-bedrock/src/cannon/libraries/MIPS64State.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/MIPS64State.sol
@@ -12,16 +12,9 @@ library MIPS64State {
         uint64 hi;
     }
 
-    // struct Features {
-    // }
-
     function assertExitedIsValid(uint32 _exited) internal pure {
         if (_exited > 1) {
             revert InvalidExitedValue();
         }
     }
-
-    // function featuresForVersion(uint256 _version) internal pure returns (Features memory features_) {
-    //     // Set feature toggles based on the state version here.
-    // }
 }

--- a/packages/contracts-bedrock/test/cannon/MIPS64.t.sol
+++ b/packages/contracts-bedrock/test/cannon/MIPS64.t.sol
@@ -20,7 +20,7 @@ abstract contract MIPS64_TestInit is Test {
     IPreimageOracle oracle;
 
     // Store some data about acceptable versions
-    uint256[2] validVersions = [7, 8];
+    uint256[1] validVersions = [uint256(8)];
     mapping(uint256 => bool) public isValidVersion;
     uint256 maxValidVersion;
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

This removes the `SupportWorkingSysGetRandom` feature flag, in both go and solidity, leaving `SysGetRandom` support enabled, because Cannon version 8 has shipped and go 1.24 is now supported.

It could make sense to leave empty `getNoopSyscalls64()` and `getSupportedSyscalls()`, for the next time. I chose to clean them up, but let me know if you think we should keep them.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

Closes https://github.com/ethereum-optimism/optimism/issues/17178

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
