### PR TITLE
op-sync-tester: Support engine_exchangeCapabilities

### DIFF
--- a/op-service/apis/sync_tester.go
+++ b/op-service/apis/sync_tester.go
@@ -46,4 +46,6 @@ type EngineAPI interface {
 	NewPayloadV2(ctx context.Context, payload *eth.ExecutionPayload) (*eth.PayloadStatusV1, error)
 	NewPayloadV3(ctx context.Context, payload *eth.ExecutionPayload, versionedHashes []common.Hash, beaconRoot *common.Hash) (*eth.PayloadStatusV1, error)
 	NewPayloadV4(ctx context.Context, payload *eth.ExecutionPayload, versionedHashes []common.Hash, beaconRoot *common.Hash, executionRequests []hexutil.Bytes) (*eth.PayloadStatusV1, error)
+
+	ExchangeCapabilities(ctx context.Context, _ []string) []string
 }

--- a/op-sync-tester/synctester/backend/sync_tester.go
+++ b/op-sync-tester/synctester/backend/sync_tester.go
@@ -220,6 +220,27 @@ func (s *SyncTester) ChainId(ctx context.Context) (hexutil.Big, error) {
 	})
 }
 
+func (s *SyncTester) ExchangeCapabilities(ctx context.Context, _ []string) []string {
+	return []string{
+		// getPayload
+		"engine_getPayloadV1",
+		"engine_getPayloadV2",
+		"engine_getPayloadV3",
+		"engine_getPayloadV4",
+
+		// forkchoiceUpdated
+		"engine_forkchoiceUpdatedV1",
+		"engine_forkchoiceUpdatedV2",
+		"engine_forkchoiceUpdatedV3",
+
+		// newPayload
+		"engine_newPayloadV1",
+		"engine_newPayloadV2",
+		"engine_newPayloadV3",
+		"engine_newPayloadV4",
+	}
+}
+
 // GetPayloadV1 only supports V1 payloads.
 func (s *SyncTester) GetPayloadV1(ctx context.Context, payloadID eth.PayloadID) (*eth.ExecutionPayloadEnvelope, error) {
 	return session.WithSession(s.sessMgr, ctx, s.log, func(session *eth.SyncTesterSession, logger log.Logger) (*eth.ExecutionPayloadEnvelope, error) {

--- a/op-sync-tester/synctester/frontend/engine.go
+++ b/op-sync-tester/synctester/frontend/engine.go
@@ -64,3 +64,7 @@ func (e *EngineFrontend) NewPayloadV3(ctx context.Context, payload *eth.Executio
 func (e *EngineFrontend) NewPayloadV4(ctx context.Context, payload *eth.ExecutionPayload, versionedHashes []common.Hash, beaconRoot *common.Hash, executionRequests []hexutil.Bytes) (*eth.PayloadStatusV1, error) {
 	return e.b.NewPayloadV4(ctx, payload, versionedHashes, beaconRoot, executionRequests)
 }
+
+func (e *EngineFrontend) ExchangeCapabilities(ctx context.Context, args []string) []string {
+	return e.b.ExchangeCapabilities(ctx, args)
+}


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Required for kona <> sync tester. Kona checks `engine_exchangeCapabilities` at EL so sync tester must support it.

**Tests**

Tested manually using kona <> sync tester.
