### PR TITLE
chore: add just recipes for devnet-up and devnet-down

### DIFF
--- a/justfile
+++ b/justfile
@@ -46,3 +46,12 @@ update-op-geth ref:
 	go mod tidy; \
 	echo "Updated op-geth to $ver"
 
+  # Starts local devnet (docker-based)
+devnet-up:
+    docker compose -f ops/docker-compose.yml up --build
+
+# Stops local devnet
+devnet-down:
+    docker compose -f ops/docker-compose.yml down
+
+


### PR DESCRIPTION
Adds `just devnet-up` and `just devnet-down` for easier local devnet start/stop using Docker Compose

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
