### PR TITLE
chore: bump opcmv2 to v7

### DIFF
--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -52,8 +52,8 @@
     "sourceCodeHash": "0xb3184aa5d95a82109e7134d1f61941b30e25f655b9849a0e303d04bbce0cde0b"
   },
   "src/L1/opcm/OPContractsManagerV2.sol:OPContractsManagerV2": {
-    "initCodeHash": "0x9055a087e4d808fbcca8ee2e40eea21567f212ec07498ffb53988b3f0ba331d4",
-    "sourceCodeHash": "0x7b7ced80311619ac0aece5511285a8af093ba0b99019a5bc1cd8fe767f7b7b13"
+    "initCodeHash": "0x7648333338c6ca7e7e39421259b7c78174771263d84d03f9e363a8e0f9ba74f9",
+    "sourceCodeHash": "0x4c4f6079034ed5dfd0bf242a57a353583ed9ff948b6f9018d91b091a555574db"
   },
   "src/L2/BaseFeeVault.sol:BaseFeeVault": {
     "initCodeHash": "0x838bbd7f381e84e21887f72bd1da605bfc4588b3c39aed96cbce67c09335b3ee",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -52,8 +52,8 @@
     "sourceCodeHash": "0xb3184aa5d95a82109e7134d1f61941b30e25f655b9849a0e303d04bbce0cde0b"
   },
   "src/L1/opcm/OPContractsManagerV2.sol:OPContractsManagerV2": {
-    "initCodeHash": "0xa2e3af90e9ff372b737f7eba83d20e44ceb22ed990d290d98b32d2ecb1316101",
-    "sourceCodeHash": "0x3333dd6ca2d7a0575ca9a7c10b79b0a38de8ea0aa550f98b99c11ba1f6b93c84"
+    "initCodeHash": "0x9055a087e4d808fbcca8ee2e40eea21567f212ec07498ffb53988b3f0ba331d4",
+    "sourceCodeHash": "0x7b7ced80311619ac0aece5511285a8af093ba0b99019a5bc1cd8fe767f7b7b13"
   },
   "src/L2/BaseFeeVault.sol:BaseFeeVault": {
     "initCodeHash": "0x838bbd7f381e84e21887f72bd1da605bfc4588b3c39aed96cbce67c09335b3ee",

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
@@ -1006,9 +1006,11 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
         }
 
         // Chains prior to OPCMv2 (version 7.0.0) don't have a functional lastUsedOPCM function on
-        // the SystemConfig contract. The first deployment of OPCMv2 makes this function available,
-        // so we skip this check for versions below 7.0.0.
-        if (SemverComp.lt(_version(), "7.0.0")) {
+        // the SystemConfig contract. The first deployment of OPCMv2 which makes this available is
+        // version 7.0.0. We need to skip the check for 7.x.x OPCM versions because they can't
+        // guarantee that the lastUsedOPCM function will be available on the incoming SystemConfig.
+        // 8.0.0 and later will always have this function available.
+        if (SemverComp.lt(_version(), "8.0.0")) {
             return true;
         }
 

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
@@ -169,9 +169,9 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
     ///         - Major bump: New required sequential upgrade
     ///         - Minor bump: Replacement OPCM for same upgrade
     ///         - Patch bump: Development changes (expected for normal dev work)
-    /// @custom:semver 6.0.7
+    /// @custom:semver 7.0.0
     function version() public pure returns (string memory) {
-        return "6.0.7";
+        return "7.0.0";
     }
 
     /// @param _contractsContainer The container of blueprint and implementation contract addresses.
@@ -304,7 +304,7 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
         // developers start working on the next release this will automatically become false so
         // even if the code is somehow forgotten it will not actually apply to the deployment. Make
         // sure to REMOVE the allowance once the upgrade is complete.
-        if (SemverComp.lt(_version(), "7.0.0")) {
+        if (SemverComp.lt(_version(), "8.0.0")) {
             // Unified DelayedWETH is being deployed for the first time.
             // TODO:(#18382): Remove this allowance after unified DelayedWETH is deployed.
             if (_isMatchingInstruction(_instruction, Constants.PERMITTED_PROXY_DEPLOYMENT_KEY, "DelayedWETH")) {

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
@@ -756,8 +756,8 @@ contract OPContractsManagerV2_Upgrade_Test is OPContractsManagerV2_Upgrade_TestI
 contract OPContractsManagerV2_IsPermittedUpgradeSequence_Test is OPContractsManagerV2_TestInit {
     /// @notice Tests that the upgrade sequence is permitted when using the same OPCM (re-running upgrade).
     function test_isPermittedUpgradeSequence_sameOPCM_succeeds() public {
-        // Mock the OPCM version to be >= 7.0.0 so the check activates.
-        vm.mockCall(address(opcmV2), abi.encodeCall(IOPContractsManagerV2.version, ()), abi.encode("7.0.0"));
+        // Mock the OPCM version to be >= 8.0.0 so the check activates.
+        vm.mockCall(address(opcmV2), abi.encodeCall(IOPContractsManagerV2.version, ()), abi.encode("8.0.0"));
 
         // Mock lastUsedOPCM to return the same OPCM address.
         vm.mockCall(address(systemConfig), abi.encodeCall(ISystemConfig.lastUsedOPCM, ()), abi.encode(address(opcmV2)));
@@ -771,75 +771,21 @@ contract OPContractsManagerV2_IsPermittedUpgradeSequence_Test is OPContractsMana
         // Create a mock address for the "old" OPCM.
         address oldOPCM = makeAddr("oldOPCM");
 
-        // Mock the current OPCM version to be 7.1.0.
-        vm.mockCall(address(opcmV2), abi.encodeCall(IOPContractsManagerV2.version, ()), abi.encode("7.1.0"));
+        // Mock the current OPCM version to be 8.1.0.
+        vm.mockCall(address(opcmV2), abi.encodeCall(IOPContractsManagerV2.version, ()), abi.encode("8.1.0"));
 
         // Mock lastUsedOPCM to return the old OPCM address.
         vm.mockCall(address(systemConfig), abi.encodeCall(ISystemConfig.lastUsedOPCM, ()), abi.encode(oldOPCM));
 
-        // Mock the old OPCM version to be 7.0.0.
-        vm.mockCall(oldOPCM, abi.encodeCall(ISemver.version, ()), abi.encode("7.0.0"));
+        // Mock the old OPCM version to be 8.0.0.
+        vm.mockCall(oldOPCM, abi.encodeCall(ISemver.version, ()), abi.encode("8.0.0"));
 
-        // Should return true because 7.1.0 > 7.0.0 (same major, higher minor).
+        // Should return true because 8.1.0 > 8.0.0 (same major, higher minor).
         assertTrue(opcmV2.isPermittedUpgradeSequence(systemConfig), "same major higher minor should be permitted");
     }
 
     /// @notice Tests that the upgrade sequence is permitted when upgrading to the next major version.
     function test_isPermittedUpgradeSequence_nextMajorVersion_succeeds() public {
-        // Create a mock address for the "old" OPCM.
-        address oldOPCM = makeAddr("oldOPCM");
-
-        // Mock the current OPCM version to be 8.0.0.
-        vm.mockCall(address(opcmV2), abi.encodeCall(IOPContractsManagerV2.version, ()), abi.encode("8.0.0"));
-
-        // Mock lastUsedOPCM to return the old OPCM address.
-        vm.mockCall(address(systemConfig), abi.encodeCall(ISystemConfig.lastUsedOPCM, ()), abi.encode(oldOPCM));
-
-        // Mock the old OPCM version to be 7.2.0.
-        vm.mockCall(oldOPCM, abi.encodeCall(ISemver.version, ()), abi.encode("7.2.0"));
-
-        // Should return true because 8.0.0 is the next major after 7.x.x.
-        assertTrue(opcmV2.isPermittedUpgradeSequence(systemConfig), "next major version should be permitted");
-    }
-
-    /// @notice Tests that the upgrade sequence is not permitted when downgrading (same major, lower minor).
-    function test_isPermittedUpgradeSequence_sameMajorLowerMinor_fails() public {
-        // Create a mock address for the "old" OPCM.
-        address oldOPCM = makeAddr("oldOPCM");
-
-        // Mock the current OPCM version to be 7.0.0.
-        vm.mockCall(address(opcmV2), abi.encodeCall(IOPContractsManagerV2.version, ()), abi.encode("7.0.0"));
-
-        // Mock lastUsedOPCM to return the old OPCM address.
-        vm.mockCall(address(systemConfig), abi.encodeCall(ISystemConfig.lastUsedOPCM, ()), abi.encode(oldOPCM));
-
-        // Mock the old OPCM version to be 7.1.0.
-        vm.mockCall(oldOPCM, abi.encodeCall(ISemver.version, ()), abi.encode("7.1.0"));
-
-        // Should return false because 7.0.0 < 7.1.0 (downgrade).
-        assertFalse(opcmV2.isPermittedUpgradeSequence(systemConfig), "same major lower minor should not be permitted");
-    }
-
-    /// @notice Tests that the upgrade sequence is not permitted when using same minor with different OPCM.
-    function test_isPermittedUpgradeSequence_sameMajorSameMinor_fails() public {
-        // Create a mock address for the "old" OPCM.
-        address oldOPCM = makeAddr("oldOPCM");
-
-        // Mock the current OPCM version to be 7.1.0.
-        vm.mockCall(address(opcmV2), abi.encodeCall(IOPContractsManagerV2.version, ()), abi.encode("7.1.0"));
-
-        // Mock lastUsedOPCM to return the old OPCM address.
-        vm.mockCall(address(systemConfig), abi.encodeCall(ISystemConfig.lastUsedOPCM, ()), abi.encode(oldOPCM));
-
-        // Mock the old OPCM version to be 7.1.0.
-        vm.mockCall(oldOPCM, abi.encodeCall(ISemver.version, ()), abi.encode("7.1.0"));
-
-        // Should return false because 7.1.0 == 7.1.0 (not higher).
-        assertFalse(opcmV2.isPermittedUpgradeSequence(systemConfig), "same major same minor should not be permitted");
-    }
-
-    /// @notice Tests that the upgrade sequence is not permitted when skipping major versions.
-    function test_isPermittedUpgradeSequence_skipMajorVersion_fails() public {
         // Create a mock address for the "old" OPCM.
         address oldOPCM = makeAddr("oldOPCM");
 
@@ -849,10 +795,64 @@ contract OPContractsManagerV2_IsPermittedUpgradeSequence_Test is OPContractsMana
         // Mock lastUsedOPCM to return the old OPCM address.
         vm.mockCall(address(systemConfig), abi.encodeCall(ISystemConfig.lastUsedOPCM, ()), abi.encode(oldOPCM));
 
-        // Mock the old OPCM version to be 7.0.0.
-        vm.mockCall(oldOPCM, abi.encodeCall(ISemver.version, ()), abi.encode("7.0.0"));
+        // Mock the old OPCM version to be 8.2.0.
+        vm.mockCall(oldOPCM, abi.encodeCall(ISemver.version, ()), abi.encode("8.2.0"));
 
-        // Should return false because 9.0.0 skips major version 8.
+        // Should return true because 9.0.0 is the next major after 8.x.x.
+        assertTrue(opcmV2.isPermittedUpgradeSequence(systemConfig), "next major version should be permitted");
+    }
+
+    /// @notice Tests that the upgrade sequence is not permitted when downgrading (same major, lower minor).
+    function test_isPermittedUpgradeSequence_sameMajorLowerMinor_fails() public {
+        // Create a mock address for the "old" OPCM.
+        address oldOPCM = makeAddr("oldOPCM");
+
+        // Mock the current OPCM version to be 8.0.0.
+        vm.mockCall(address(opcmV2), abi.encodeCall(IOPContractsManagerV2.version, ()), abi.encode("8.0.0"));
+
+        // Mock lastUsedOPCM to return the old OPCM address.
+        vm.mockCall(address(systemConfig), abi.encodeCall(ISystemConfig.lastUsedOPCM, ()), abi.encode(oldOPCM));
+
+        // Mock the old OPCM version to be 8.1.0.
+        vm.mockCall(oldOPCM, abi.encodeCall(ISemver.version, ()), abi.encode("8.1.0"));
+
+        // Should return false because 8.0.0 < 8.1.0 (downgrade).
+        assertFalse(opcmV2.isPermittedUpgradeSequence(systemConfig), "same major lower minor should not be permitted");
+    }
+
+    /// @notice Tests that the upgrade sequence is not permitted when using same minor with different OPCM.
+    function test_isPermittedUpgradeSequence_sameMajorSameMinor_fails() public {
+        // Create a mock address for the "old" OPCM.
+        address oldOPCM = makeAddr("oldOPCM");
+
+        // Mock the current OPCM version to be 8.1.0.
+        vm.mockCall(address(opcmV2), abi.encodeCall(IOPContractsManagerV2.version, ()), abi.encode("8.1.0"));
+
+        // Mock lastUsedOPCM to return the old OPCM address.
+        vm.mockCall(address(systemConfig), abi.encodeCall(ISystemConfig.lastUsedOPCM, ()), abi.encode(oldOPCM));
+
+        // Mock the old OPCM version to be 8.1.0.
+        vm.mockCall(oldOPCM, abi.encodeCall(ISemver.version, ()), abi.encode("8.1.0"));
+
+        // Should return false because 8.1.0 == 8.1.0 (not higher).
+        assertFalse(opcmV2.isPermittedUpgradeSequence(systemConfig), "same major same minor should not be permitted");
+    }
+
+    /// @notice Tests that the upgrade sequence is not permitted when skipping major versions.
+    function test_isPermittedUpgradeSequence_skipMajorVersion_fails() public {
+        // Create a mock address for the "old" OPCM.
+        address oldOPCM = makeAddr("oldOPCM");
+
+        // Mock the current OPCM version to be 10.0.0.
+        vm.mockCall(address(opcmV2), abi.encodeCall(IOPContractsManagerV2.version, ()), abi.encode("10.0.0"));
+
+        // Mock lastUsedOPCM to return the old OPCM address.
+        vm.mockCall(address(systemConfig), abi.encodeCall(ISystemConfig.lastUsedOPCM, ()), abi.encode(oldOPCM));
+
+        // Mock the old OPCM version to be 8.0.0.
+        vm.mockCall(oldOPCM, abi.encodeCall(ISemver.version, ()), abi.encode("8.0.0"));
+
+        // Should return false because 10.0.0 skips major version 9.
         assertFalse(opcmV2.isPermittedUpgradeSequence(systemConfig), "skipping major version should not be permitted");
     }
 
@@ -861,34 +861,34 @@ contract OPContractsManagerV2_IsPermittedUpgradeSequence_Test is OPContractsMana
         // Create a mock address for the "old" OPCM.
         address oldOPCM = makeAddr("oldOPCM");
 
-        // Mock the current OPCM version to be 7.0.0.
+        // Mock the current OPCM version to be 8.0.0.
+        vm.mockCall(address(opcmV2), abi.encodeCall(IOPContractsManagerV2.version, ()), abi.encode("8.0.0"));
+
+        // Mock lastUsedOPCM to return the old OPCM address.
+        vm.mockCall(address(systemConfig), abi.encodeCall(ISystemConfig.lastUsedOPCM, ()), abi.encode(oldOPCM));
+
+        // Mock the old OPCM version to be 9.0.0.
+        vm.mockCall(oldOPCM, abi.encodeCall(ISemver.version, ()), abi.encode("9.0.0"));
+
+        // Should return false because 8.0.0 < 9.0.0 (major downgrade).
+        assertFalse(opcmV2.isPermittedUpgradeSequence(systemConfig), "major downgrade should not be permitted");
+    }
+
+    /// @notice Tests that the upgrade sequence check returns true for OPCM versions < 8.0.0.
+    function test_isPermittedUpgradeSequence_versionBelowThreshold_succeeds() public {
+        // Create a mock address for the "old" OPCM that would fail the check if it ran.
+        address oldOPCM = makeAddr("oldOPCM");
+
+        // Mock the current OPCM version to be 7.0.0 (below threshold).
         vm.mockCall(address(opcmV2), abi.encodeCall(IOPContractsManagerV2.version, ()), abi.encode("7.0.0"));
 
         // Mock lastUsedOPCM to return the old OPCM address.
         vm.mockCall(address(systemConfig), abi.encodeCall(ISystemConfig.lastUsedOPCM, ()), abi.encode(oldOPCM));
 
-        // Mock the old OPCM version to be 8.0.0.
-        vm.mockCall(oldOPCM, abi.encodeCall(ISemver.version, ()), abi.encode("8.0.0"));
+        // Mock the old OPCM version to be 10.0.0 (would fail if check ran).
+        vm.mockCall(oldOPCM, abi.encodeCall(ISemver.version, ()), abi.encode("10.0.0"));
 
-        // Should return false because 7.0.0 < 8.0.0 (major downgrade).
-        assertFalse(opcmV2.isPermittedUpgradeSequence(systemConfig), "major downgrade should not be permitted");
-    }
-
-    /// @notice Tests that the upgrade sequence check returns true for OPCM versions < 7.0.0.
-    function test_isPermittedUpgradeSequence_versionBelowThreshold_succeeds() public {
-        // Create a mock address for the "old" OPCM that would fail the check if it ran.
-        address oldOPCM = makeAddr("oldOPCM");
-
-        // Mock the current OPCM version to be 6.0.0 (below threshold).
-        vm.mockCall(address(opcmV2), abi.encodeCall(IOPContractsManagerV2.version, ()), abi.encode("6.0.0"));
-
-        // Mock lastUsedOPCM to return the old OPCM address.
-        vm.mockCall(address(systemConfig), abi.encodeCall(ISystemConfig.lastUsedOPCM, ()), abi.encode(oldOPCM));
-
-        // Mock the old OPCM version to be 9.0.0 (would fail if check ran).
-        vm.mockCall(oldOPCM, abi.encodeCall(ISemver.version, ()), abi.encode("9.0.0"));
-
-        // Should return true because the check is skipped for versions < 7.0.0.
+        // Should return true because the check is skipped for versions < 8.0.0.
         assertTrue(opcmV2.isPermittedUpgradeSequence(systemConfig), "version below threshold should be permitted");
     }
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Bumps OPCMv2 to 7.0.0