### PR TITLE
fix: Apply deployment overrides when checking custom intent

### DIFF
--- a/op-deployer/pkg/deployer/state/intent.go
+++ b/op-deployer/pkg/deployer/state/intent.go
@@ -121,6 +121,16 @@ func (c *Intent) validateCustomConfig() error {
 		return errors.New("must define at least one l2 chain")
 	}
 
+	// Apply global deploy overrides to each chain intent before validating them.
+	for index, chain := range c.Chains {
+		chainWithOverrides, err := jsonutil.MergeJSON(chain, c.GlobalDeployOverrides)
+		if err == nil {
+			// To mitigate any errors and preserve the existing behavior, we don't error out here
+			// if the merging does not succeed. Instead, we only apply the global overrides on success
+			c.Chains[index] = chainWithOverrides
+		}
+	}
+
 	for _, chain := range c.Chains {
 		if err := chain.Check(); err != nil {
 			return err

--- a/op-deployer/pkg/deployer/state/intent_test.go
+++ b/op-deployer/pkg/deployer/state/intent_test.go
@@ -198,6 +198,89 @@ func TestValidateCustomValues(t *testing.T) {
 	}
 }
 
+func TestValidateCustomValuesWithGlobalOverrides(t *testing.T) {
+	intent, err := NewIntentCustom(1, []common.Hash{common.HexToHash("0x336")})
+	require.NoError(t, err)
+
+	err = intent.Check()
+	require.Error(t, err)
+	require.ErrorIs(t, err, addresses.ErrZeroAddress)
+
+	setSuperchainRoles(&intent)
+	setChainRoles(&intent)
+	setEip1559Params(&intent)
+	setFeeAddresses(&intent)
+
+	err = intent.Check()
+	require.NoError(t, err)
+
+	// First we set the value to a zero address to trigger the error
+	intent.Chains[0].OperatorFeeVaultRecipient = common.Address{}
+
+	err = intent.Check()
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrFeeVaultZeroAddress)
+
+	// We set a global override for the operator fee vault
+	intent.GlobalDeployOverrides = map[string]any{"operatorFeeVaultRecipient": common.HexToAddress("0x0B")}
+
+	// And check that we had no error
+	err = intent.Check()
+	require.NoError(t, err)
+
+	tests := []struct {
+		name    string
+		mutator func(intent *Intent)
+		err     error
+	}{
+		{
+			"both OPCM and SuperchainRoles defined",
+			func(intent *Intent) {
+				addr := common.HexToAddress("0x9999")
+				intent.SuperchainRoles = &addresses.SuperchainRoles{
+					SuperchainGuardian: addr,
+				}
+				intent.OPCMAddress = &addr
+			},
+			ErrIncompatibleValue,
+		},
+		{
+			"neither OPCM or SuperchainRoles defined",
+			func(intent *Intent) {
+				intent.OPCMAddress = nil
+				intent.SuperchainRoles = nil
+			},
+			ErrIncompatibleValue,
+		},
+		{
+			"zero address for revenue share chain fees recipient when enabled",
+			func(intent *Intent) {
+				intent.Chains[0].UseRevenueShare = true
+				intent.Chains[0].ChainFeesRecipient = common.Address{}
+			},
+			ErrRevenueShareZeroAddress,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			intent, err := NewIntentCustom(11155111, []common.Hash{common.HexToHash("0x336")})
+			require.NoError(t, err)
+
+			setSuperchainRoles(&intent)
+			setChainRoles(&intent)
+
+			setEip1559Params(&intent)
+			setFeeAddresses(&intent)
+
+			tt.mutator(&intent)
+
+			err = intent.Check()
+			require.Error(t, err)
+			require.ErrorIs(t, err, tt.err)
+		})
+	}
+}
+
 func setSuperchainRoles(intent *Intent) {
 	intent.SuperchainRoles = &addresses.SuperchainRoles{
 		SuperchainProxyAdminOwner: common.HexToAddress("0xa"),


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Currently, we rely on deployment overrides when running `op-deployer` v5 in netchef, specifically to set the `operatorFeeVaultRecipient`. However, the merging of the global overrides is only being done in specific points in the codebase and was not being applied to the `Apply` action.