### PR TITLE
codeowners(op-deployer): add platforms team as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,6 +13,9 @@
 /op-devstack    @ethereum-optimism/op-stack @ethereum-optimism/go-reviewers
 
 # Expert areas
+/op-deployer    @ethereum-optimism/platforms-team
+/op-validator   @ethereum-optimism/platforms-team
+
 /op-node/rollup @ethereum-optimism/consensus @ethereum-optimism/go-reviewers
 
 /op-supervisor  @ethereum-optimism/interop @ethereum-optimism/go-reviewers


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Adds @ethereum-optimism/platforms-team as CODEOWNERS for `op-deployer` and `op-validator`.

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
