### PR TITLE
chore(mise): use tool_alias rather than alias

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -49,7 +49,7 @@ asterisc = "1.3.0"
 kontrol = "1.0.90"
 binary_signer = "1.0.4"
 
-[alias]
+[tool_alias]
 forge = "ubi:foundry-rs/foundry[exe=forge]"
 cast = "ubi:foundry-rs/foundry[exe=cast]"
 anvil = "ubi:foundry-rs/foundry[exe=anvil]"


### PR DESCRIPTION
Addresses the deprecation warning: 
```
mise WARN  deprecated [alias]: [alias] is deprecated, use [tool_alias] instead
```