### PR TITLE
ci: Fix contracts test-upgrade test junit output

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1249,8 +1249,9 @@ jobs:
           name: Run tests
           command: |
             mkdir -p results
-            just test-upgrade --junit > results/results.xml
+            just test-upgrade
           environment:
+            JUNIT_TEST_PATH: results/results.xml
             FOUNDRY_FUZZ_SEED: 42424242
             FOUNDRY_FUZZ_RUNS: 1
             FOUNDRY_PROFILE: ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1041,9 +1041,10 @@ jobs:
           name: Run heavy fuzz tests
           command: |
             mkdir -p results
-            just test --junit > results/results.xml
+            just test
           environment:
             FOUNDRY_PROFILE: ciheavy
+            JUNIT_TEST_PATH: results/results.xml
           working_directory: packages/contracts-bedrock
           no_output_timeout: 90m
       - run:

--- a/packages/contracts-bedrock/justfile
+++ b/packages/contracts-bedrock/justfile
@@ -73,7 +73,12 @@ clean:
 
 # Runs standard contract tests.
 test *ARGS: build-go-ffi
-  forge test {{ARGS}}
+  #!/bin/bash
+  if [ -n "$JUNIT_TEST_PATH" ]; then
+    forge test {{ARGS}} --junit > "$JUNIT_TEST_PATH"
+  else
+    forge test {{ARGS}}
+  fi
 
 # Runs standard contract tests (developer mode).
 test-dev *ARGS: build-go-ffi
@@ -115,7 +120,12 @@ prepare-upgrade-env *ARGS : build-go-ffi
 
 # Runs upgrade path variant of contract tests.
 test-upgrade *ARGS:
-  just prepare-upgrade-env "forge test {{ARGS}}"
+  #!/bin/bash
+  if [ -n "$JUNIT_TEST_PATH" ]; then
+    just prepare-upgrade-env "forge test {{ARGS}} --junit > \"$JUNIT_TEST_PATH\""
+  else
+    just prepare-upgrade-env "forge test {{ARGS}}"
+  fi
 
 test-upgrade-rerun *ARGS: build-go-ffi
   just test-upgrade {{ARGS}} --rerun -vvvv


### PR DESCRIPTION
The patch fixes an issue in the contracts-test-upgrade CI job were it generated malformed junit XML reports. The issue occurred because:
1. The CCI config redirected all output to the XML file
2. The test-upgrade target calls `prepare-upgrade-env`, which outputs non-XML content to stdout
3. This non-XML output was being captured by the shell redirect, corrupting the junit XML file
