### PR TITLE
Require 2 contracts owners to modify the CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,5 @@
+.github/CODEOWNERS @ethereum-optimism/contract-reviewers #[min:2]
+
 # Monorepo - default to go-reviewers
 * @ethereum-optimism/go-reviewers
 


### PR DESCRIPTION
It occurred to me that you only need one reviewer to make a change to CODEOWNERS, so you really only need one reviewer to modify the contracts package.

Opening this in draft for discussion.