### PR TITLE
op-program: Reduce disk usage of preimage prestate builds in ci

### DIFF
--- a/op-program/scripts/build-prestates.sh
+++ b/op-program/scripts/build-prestates.sh
@@ -129,10 +129,17 @@ EOF
 VERSIONS_JSON="[]"
 readarray -t VERSIONS < <(git tag --list 'op-program/v*' --sort taggerdate)
 
-for VERSION in "${VERSIONS[@]}"; do
+for i in "${!VERSIONS[@]}"; do
   pushd .
-  build_op_program_prestate "${VERSION}"
+  build_op_program_prestate "${VERSIONS[i]}"
   popd
+  # after every 10 builds, cleanup docker artifacts to reclaim disk space
+  if [ "$CIRCLECI" = "true" ]; then
+    if (( (i + 1) % 10 == 0 )); then
+      echo "Pruning docker build artifacts after ${i} builds"
+      docker system prune -f
+    fi
+  fi
 done
 echo "${VERSIONS_JSON}" > "${VERSIONS_FILE}"
 
@@ -151,10 +158,17 @@ readarray -t KONA_VERSIONS < <(git ls-remote --tags "$KONA_REPO_URL" | grep kona
   | sed 's|.*refs/tags/||' | sed 's/\^{}//' | sort -u \
   | grep -v beta | grep -v alpha | grep -v -F -f excluded.txt)
 
-for VERSION in "${KONA_VERSIONS[@]}"; do
+for i in "${!KONA_VERSIONS[@]}"; do
   pushd .
-  build_kona_prestate "${VERSION}"
+  build_kona_prestate "${KONA_VERSIONS[i]}"
   popd
+  # after every 10 builds, cleanup docker artifacts to reclaim disk space
+  if [ "$CIRCLECI" = "true" ]; then
+    if (( (i + 1) % 10 == 0 )); then
+      echo "Pruning docker build artifacts after ${i} builds"
+      docker system prune -f
+    fi
+  fi
 done
 echo "${VERSIONS_JSON}" > "${VERSIONS_FILE}"
 


### PR DESCRIPTION
The `preimage-reproducibility` job fails in CI because prestate builds generate too much docker build artifacts.
This patch fixes the CI build by deleting unused docker artifacts while the `preimage-reproducibility` job is running. The docker prune is done occasionally to allow for some cached artifact reuse.