### PR TITLE
chore(ctb): move init bond value to CommonTest

### DIFF
--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
@@ -1032,7 +1032,7 @@ contract OPContractsManagerV2_Deploy_Test is OPContractsManagerV2_TestInit {
         deployConfig.disputeGameConfigs.push(
             IOPContractsManagerUtils.DisputeGameConfig({
                 enabled: true,
-                initBond: 0.08 ether, // Standard init bond
+                initBond: DEFAULT_DISPUTE_GAME_INIT_BOND, // Standard init bond
                 gameType: GameTypes.CANNON,
                 gameArgs: abi.encode(IOPContractsManagerUtils.FaultDisputeGameConfig({ absolutePrestate: cannonPrestate }))
             })
@@ -1040,7 +1040,7 @@ contract OPContractsManagerV2_Deploy_Test is OPContractsManagerV2_TestInit {
         deployConfig.disputeGameConfigs.push(
             IOPContractsManagerUtils.DisputeGameConfig({
                 enabled: true,
-                initBond: 0.08 ether, // Standard init bond
+                initBond: DEFAULT_DISPUTE_GAME_INIT_BOND, // Standard init bond
                 gameType: GameTypes.PERMISSIONED_CANNON,
                 gameArgs: abi.encode(
                     IOPContractsManagerUtils.PermissionedDisputeGameConfig({
@@ -1054,7 +1054,7 @@ contract OPContractsManagerV2_Deploy_Test is OPContractsManagerV2_TestInit {
         deployConfig.disputeGameConfigs.push(
             IOPContractsManagerUtils.DisputeGameConfig({
                 enabled: true,
-                initBond: 0.08 ether, // Standard init bond
+                initBond: DEFAULT_DISPUTE_GAME_INIT_BOND, // Standard init bond
                 gameType: GameTypes.CANNON_KONA,
                 gameArgs: abi.encode(
                     IOPContractsManagerUtils.FaultDisputeGameConfig({ absolutePrestate: cannonKonaPrestate })

--- a/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
+++ b/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
@@ -150,7 +150,7 @@ abstract contract DisputeGameFactory_TestInit is CommonTest {
         } else {
             disputeGameFactory.setImplementation(_gameType, IDisputeGame(_gameImpl));
         }
-        disputeGameFactory.setInitBond(_gameType, 0.08 ether);
+        disputeGameFactory.setInitBond(_gameType, DEFAULT_DISPUTE_GAME_INIT_BOND);
         vm.stopPrank();
     }
 

--- a/packages/contracts-bedrock/test/dispute/FaultDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/dispute/FaultDisputeGame.t.sol
@@ -2123,7 +2123,7 @@ contract FaultDisputeGame_GetRequiredBond_Test is FaultDisputeGame_TestInit {
             uint256 bond = gameProxy.getRequiredBond(pos);
 
             // Reasonable approximation for a max depth of 8.
-            uint256 expected = 0.08 ether;
+            uint256 expected = DEFAULT_DISPUTE_GAME_INIT_BOND;
             for (uint64 j = 0; j < i; j++) {
                 expected = expected * 22876;
                 expected = expected / 10000;

--- a/packages/contracts-bedrock/test/dispute/SuperFaultDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/dispute/SuperFaultDisputeGame.t.sol
@@ -1950,7 +1950,7 @@ contract SuperFaultDisputeGame_GetRequiredBond_Test is SuperFaultDisputeGame_Tes
             uint256 bond = gameProxy.getRequiredBond(pos);
 
             // Reasonable approximation for a max depth of 8.
-            uint256 expected = 0.08 ether;
+            uint256 expected = DEFAULT_DISPUTE_GAME_INIT_BOND;
             for (uint64 j = 0; j < i; j++) {
                 expected = expected * 22876;
                 expected = expected / 10000;

--- a/packages/contracts-bedrock/test/setup/CommonTest.sol
+++ b/packages/contracts-bedrock/test/setup/CommonTest.sol
@@ -29,6 +29,9 @@ abstract contract CommonTest is Test, Setup, Events {
 
     bytes32 constant nonZeroHash = keccak256(abi.encode("NON_ZERO"));
 
+    /// @notice The default initial bond value for dispute games.
+    uint256 constant DEFAULT_DISPUTE_GAME_INIT_BOND = 0.08 ether;
+
     FFIInterface constant ffi = FFIInterface(address(uint160(uint256(keccak256(abi.encode("optimism.ffi"))))));
 
     bool useAltDAOverride;


### PR DESCRIPTION
I put the value into CommonTest because this only affected test contracts, so src/libraries/Constants.sol didn't make sense to me