### PR TITLE
op-supernode: Don't treat all errors as not found

### DIFF
--- a/op-supernode/supernode/activity/superroot/superroot.go
+++ b/op-supernode/supernode/activity/superroot/superroot.go
@@ -2,6 +2,7 @@ package superroot
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -96,9 +97,11 @@ func (s *Superroot) atTimestamp(ctx context.Context, timestamp uint64) (atTimest
 	for chainID, chain := range s.chains {
 		// verifiedAt returns the L2 block which is fully verified at the given timestamp, and the minimum L1 block at which verification is possible
 		verifiedL2, verifiedL1, err := chain.VerifiedAt(ctx, timestamp)
-		if err != nil {
-			s.log.Warn("failed to get verified L1", "chain_id", chainID.String(), "err", err)
-			return atTimestampResponse{}, fmt.Errorf("%w: %w", ethereum.NotFound, err)
+		if errors.Is(err, ethereum.NotFound) {
+			return atTimestampResponse{}, fmt.Errorf("%w: verified L2 block not found for chain %v at timestamp %v", err, chainID, timestamp)
+		} else if err != nil {
+			s.log.Warn("failed to get verified block", "chain_id", chainID.String(), "err", err)
+			return atTimestampResponse{}, fmt.Errorf("failed to get verified block: %w", err)
 		}
 		verified[chainID] = L2WithRequiredL1{
 			L2:            verifiedL2,
@@ -111,20 +114,20 @@ func (s *Superroot) atTimestamp(ctx context.Context, timestamp uint64) (atTimest
 		outRoot, err := chain.OutputRootAtL2BlockNumber(ctx, verifiedL2.Number)
 		if err != nil {
 			s.log.Warn("failed to compute output root at L2 block", "chain_id", chainID.String(), "l2_number", verifiedL2.Number, "err", err)
-			return atTimestampResponse{}, fmt.Errorf("%w: %w", ethereum.NotFound, err)
+			return atTimestampResponse{}, fmt.Errorf("failed to compute output root at L2 block %d for chain ID %v: %w", verifiedL2.Number, chainID, err)
 		}
 		chainOutputs = append(chainOutputs, eth.ChainIDAndOutput{ChainID: chainID, Output: outRoot})
 		// Optimistic output is the full output at the optimistic L2 block for the timestamp
 		optimisticOut, err := chain.OptimisticOutputAtTimestamp(ctx, timestamp)
 		if err != nil {
-			s.log.Warn("failed to get optimistic L1", "chain_id", chainID.String(), "err", err)
-			return atTimestampResponse{}, fmt.Errorf("%w: %w", ethereum.NotFound, err)
+			s.log.Warn("failed to get optimistic block", "chain_id", chainID.String(), "err", err)
+			return atTimestampResponse{}, fmt.Errorf("failed to get optimistic block at timestamp %v for chain ID %v: %w", timestamp, chainID, err)
 		}
 		// Also include the source L1 for context
 		_, optimisticL1, err := chain.OptimisticAt(ctx, timestamp)
 		if err != nil {
 			s.log.Warn("failed to get optimistic source L1", "chain_id", chainID.String(), "err", err)
-			return atTimestampResponse{}, fmt.Errorf("%w: %w", ethereum.NotFound, err)
+			return atTimestampResponse{}, fmt.Errorf("failed to get optimistic source L1 at timestamp %v for chain ID %v: %w", timestamp, chainID, err)
 		}
 		optimistic[chainID] = OutputWithSource{
 			Output:   optimisticOut,

--- a/op-supernode/supernode/chain_container/chain_container.go
+++ b/op-supernode/supernode/chain_container/chain_container.go
@@ -276,6 +276,7 @@ func (c *simpleChainContainer) CurrentL1(ctx context.Context) (eth.BlockRef, err
 }
 
 // VerifiedAt returns the verified L2 and L1 blocks for the given L2 timestamp.
+// Must return ethereum.NotFound if there is no safe block at the specified timestamp.
 func (c *simpleChainContainer) VerifiedAt(ctx context.Context, ts uint64) (l2, l1 eth.BlockID, err error) {
 	l2Block, err := c.SafeBlockAtTimestamp(ctx, ts)
 	if err != nil {

--- a/op-supernode/supernode/chain_container/engine_controller/engine_controller.go
+++ b/op-supernode/supernode/chain_container/engine_controller/engine_controller.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
+	"github.com/ethereum/go-ethereum"
 	gethlog "github.com/ethereum/go-ethereum/log"
 )
 
@@ -16,6 +17,7 @@ import (
 type EngineController interface {
 	// SafeBlockAtTimestamp returns the L2 block ref for the block at or before the given timestamp,
 	// clamped to the current SAFE head.
+	// Must return ethereum.NotFound if there is no safe block at the specified timestamp.
 	SafeBlockAtTimestamp(ctx context.Context, ts uint64) (eth.L2BlockRef, error)
 	// OutputV0AtBlockNumber returns the output preimage for the given L2 block number.
 	OutputV0AtBlockNumber(ctx context.Context, num uint64) (*eth.OutputV0, error)
@@ -60,9 +62,10 @@ func NewEngineControllerFromConfig(ctx context.Context, log gethlog.Logger, vncf
 var (
 	ErrNoEngineClient = errors.New("engine client not initialized")
 	ErrNoRollupConfig = errors.New("rollup config not available")
-	ErrNotFound       = errors.New("not found")
 )
 
+// SafeBlockAtTimestamp returns the L2 block ref for the block at or before the given timestamp,
+// clamped to the current SAFE head. Must return ethereum.NotFound if no safe block is available at the timestamp.
 func (e *simpleEngineController) SafeBlockAtTimestamp(ctx context.Context, ts uint64) (eth.L2BlockRef, error) {
 	if e.l2 == nil {
 		return eth.L2BlockRef{}, ErrNoEngineClient
@@ -81,7 +84,7 @@ func (e *simpleEngineController) SafeBlockAtTimestamp(ctx context.Context, ts ui
 	}
 	if num > safeHead.Number {
 		e.log.Warn("engine_controller: target block number exceeds safe head", "targetBlockNumber", num, "safeHead", safeHead.Number)
-		return eth.L2BlockRef{}, ErrNotFound
+		return eth.L2BlockRef{}, ethereum.NotFound
 	}
 	e.log.Debug("engine_controller: computed safe block number from timestamp",
 		"timestamp", ts, "targetBlockNumber", num, "safeHead", safeHead.Number, "safeHeadErr", err)

--- a/op-supernode/supernode/chain_container/engine_controller/engine_controller_test.go
+++ b/op-supernode/supernode/chain_container/engine_controller/engine_controller_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	gethlog "github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
@@ -94,7 +95,7 @@ func TestEngineController_TargetBlockNumber(t *testing.T) {
 	require.Equal(t, m.ref, numRef)
 	// ts = genesis + 2*1000 => block #1000, with safe head now below target
 	_, err = ec.SafeBlockAtTimestamp(context.Background(), 1_000+2*1000)
-	require.ErrorIs(t, err, ErrNotFound)
+	require.ErrorIs(t, err, ethereum.NotFound)
 }
 
 func TestEngineController_SentinelErrors(t *testing.T) {


### PR DESCRIPTION
**Description**

Modify the error handling in Supernode's superroot_atTimestamp RPC to avoid converting all errors into not found errors. chain container has been modified to return `ethereum.NotFound` instead of a custom error message to follow the pattern elsewhere of using it as a particularly meaningful error type.

**Tests**

Updated unit tests.


**Metadata**

#18524 