### PR TITLE
op-node: return error instead of panic when L1 chain ID is nil

### DIFF
--- a/op-node/service.go
+++ b/op-node/service.go
@@ -293,7 +293,7 @@ func applyOverrides(ctx cliiface.Context, rollupConfig *rollup.Config) {
 
 func NewL1ChainConfig(chainId *big.Int, ctx cliiface.Context, log log.Logger) (*params.ChainConfig, error) {
 	if chainId == nil {
-		panic("l1 chain id is nil")
+		return nil, fmt.Errorf("l1 chain id is nil")
 	}
 
 	if cfg := eth.L1ChainConfigByChainID(eth.ChainIDFromBig(chainId)); cfg != nil {

--- a/op-node/service_l1_chain_config_test.go
+++ b/op-node/service_l1_chain_config_test.go
@@ -117,12 +117,13 @@ func TestNewL1ChainConfig_CustomDirectAndEmbeddedAndNil(t *testing.T) {
 		require.Equal(t, custom.ChainID, cfg.ChainID)
 	})
 
-	t.Run("nil-chainid-panics", func(t *testing.T) {
+	t.Run("nil-chainid-errors", func(t *testing.T) {
 		app := cli.NewApp()
 		ctx := cli.NewContext(app, nil, nil)
-		require.Panics(t, func() {
-			_, _ = NewL1ChainConfig(nil, ctx, logger)
-		})
+
+		_, err := NewL1ChainConfig(nil, ctx, logger)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "l1 chain id is nil")
 	})
 
 	t.Run("nil-blob-schedule-config-returns-error", func(t *testing.T) {


### PR DESCRIPTION
NewL1ChainConfig previously panicked when chainId was nil, even though this
value originates from external configuration or RPC. Replace the panic with
a returned error and update tests to reflect the new, controlled behavior.

