### PR TITLE
All immutable variables in OPContractsManagerV2 must start with opcM except otherwise allowed

### DIFF
--- a/.semgrep/rules/sol-rules.yaml
+++ b/.semgrep/rules/sol-rules.yaml
@@ -409,3 +409,16 @@ rules:
         - packages/contracts-bedrock/test
       exclude:
         - packages/contracts-bedrock/test/setup/Test.sol
+
+  - id: sol-safety-opcmv2-immutable-prefix
+    languages: [solidity]
+    severity: ERROR
+    message: All immutable variables in OPContractsManagerV2 must start with 'opcm'
+    pattern-regex: |
+      ^\s*(?!/\*|//|\*)\w+\s+public\s+immutable\s+(?!(?:opcm\w*|contractsContainer\s*;))\w+;
+    # To add more allowed names, add them to the regex alternation in the negative lookahead.
+    # Example (to add standardValidator as an allowed variable name that does not start with 'opcm'):
+    # pattern-regex: ^\s*(?!/\*|//|\*)\w+\s+public\s+immutable\s+(?!(?:opcm\w*|contractsContainer\s*;|standardValidator\s*;))\w+;
+    paths:
+      include:
+        - packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol


### PR DESCRIPTION
A semgrep rule that checks that all OPCM V2 variables are prefixed with opcm except otherwise allowed. That way, it is going to be identified as an OPCM component by the VerifyOPCM script so that its contractsContainer address is accounted for when checking consistency among all OPCM components