### PR TITLE
op-acceptance-tests: fix port collisions

### DIFF
--- a/op-devstack/dsl/l2_el.go
+++ b/op-devstack/dsl/l2_el.go
@@ -244,7 +244,7 @@ func (el *L2ELNode) Start() {
 }
 
 func (el *L2ELNode) PeerWith(peer *L2ELNode) {
-	sysgo.ConnectP2P(el.ctx, el.require, el.inner.L2EthClient().RPC(), peer.inner.L2EthClient().RPC())
+	sysgo.ConnectP2P(el.ctx, el.require, el.inner.L2EthClient().RPC(), peer.inner.L2EthClient().RPC(), false)
 }
 
 func (el *L2ELNode) DisconnectPeerWith(peer *L2ELNode) {

--- a/op-devstack/sysgo/el_node_identity.go
+++ b/op-devstack/sysgo/el_node_identity.go
@@ -3,42 +3,23 @@ package sysgo
 import (
 	"crypto/ecdsa"
 	"encoding/hex"
-	"net"
-	"strconv"
 
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/p2p/enode"
 )
 
 type ELNodeIdentity struct {
-	Key   *ecdsa.PrivateKey
-	Port  int
-	Enode string
+	Key  *ecdsa.PrivateKey
+	Port int
 }
 
-func NewELNodeIdentity(addr string, port int) *ELNodeIdentity {
+func NewELNodeIdentity(port int) *ELNodeIdentity {
 	key, err := crypto.GenerateKey()
 	if err != nil {
 		panic(err)
 	}
-	if port <= 0 {
-		portStr, err := getAvailableLocalPort()
-		if err != nil {
-			panic(err)
-		}
-		port, err = strconv.Atoi(portStr)
-		if err != nil {
-			panic(err)
-		}
-	}
-	ip := net.ParseIP(addr)
-	if ip == nil {
-		panic("invalid ip for ELNodeIdentity: " + addr)
-	}
 	return &ELNodeIdentity{
-		Key:   key,
-		Port:  port,
-		Enode: enode.NewV4(&key.PublicKey, ip, port, port).String(),
+		Key:  key,
+		Port: port,
 	}
 }
 

--- a/op-devstack/sysgo/l2_el_p2p_util.go
+++ b/op-devstack/sysgo/l2_el_p2p_util.go
@@ -2,6 +2,7 @@ package sysgo
 
 import (
 	"context"
+	"fmt"
 	"slices"
 	"time"
 
@@ -13,13 +14,13 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/testreq"
 )
 
-func WithL2ELP2PConnection(l2EL1ID, l2EL2ID stack.L2ELNodeID) stack.Option[*Orchestrator] {
+func WithL2ELP2PConnection(l2EL1ID, l2EL2ID stack.L2ELNodeID, trusted bool) stack.Option[*Orchestrator] {
 	return stack.AfterDeploy(func(orch *Orchestrator) {
 		require := orch.P().Require()
 
-		l2EL1, ok := orch.l2ELs.Get(l2EL1ID)
+		l2EL1, ok := orch.GetL2EL(l2EL1ID)
 		require.True(ok, "looking for L2 EL node 1 to connect p2p")
-		l2EL2, ok := orch.l2ELs.Get(l2EL2ID)
+		l2EL2, ok := orch.GetL2EL(l2EL2ID)
 		require.True(ok, "looking for L2 EL node 2 to connect p2p")
 		require.Equal(l2EL1ID.ChainID(), l2EL2ID.ChainID(), "must be same l2 chain")
 
@@ -33,7 +34,7 @@ func WithL2ELP2PConnection(l2EL1ID, l2EL2ID stack.L2ELNodeID) stack.Option[*Orch
 		require.NoError(err, "failed to connect to el2 rpc")
 		defer rpc2.Close()
 
-		ConnectP2P(orch.P().Ctx(), require, rpc1, rpc2)
+		ConnectP2P(orch.P().Ctx(), require, rpc1, rpc2, trusted)
 	})
 }
 
@@ -42,26 +43,41 @@ type RpcCaller interface {
 }
 
 // ConnectP2P creates a p2p peer connection between node1 and node2.
-func ConnectP2P(ctx context.Context, require *testreq.Assertions, initiator RpcCaller, acceptor RpcCaller) {
+func ConnectP2P(ctx context.Context, require *testreq.Assertions, initiator RpcCaller, acceptor RpcCaller, trusted bool) {
 	var targetInfo p2p.NodeInfo
 	require.NoError(acceptor.CallContext(ctx, &targetInfo, "admin_nodeInfo"), "get node info")
+	fmt.Printf("DEBUG: acceptor admin_nodeInfo returned: %+v\n", targetInfo)
+
+	var initiatorInfo p2p.NodeInfo
+	require.NoError(initiator.CallContext(ctx, &initiatorInfo, "admin_nodeInfo"), "get initiator node info")
+	fmt.Printf("DEBUG: initiator admin_nodeInfo returned: %+v\n", initiatorInfo)
 
 	var peerAdded bool
 	require.NoError(initiator.CallContext(ctx, &peerAdded, "admin_addPeer", targetInfo.Enode), "add peer")
+	fmt.Printf("DEBUG: admin_addPeer returned: %v\n", peerAdded)
 	require.True(peerAdded, "should have added peer successfully")
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-	err := wait.For(ctx, time.Second, func() (bool, error) {
-		var peers []peer
-		if err := initiator.CallContext(ctx, &peers, "admin_peers"); err != nil {
-			return false, err
-		}
-		return slices.ContainsFunc(peers, func(p peer) bool {
-			return p.ID == targetInfo.ID
-		}), nil
-	})
-	require.NoError(err, "The peer was not connected")
+	if trusted {
+		var peerAddedTrusted bool
+		require.NoError(initiator.CallContext(ctx, &peerAddedTrusted, "admin_addTrustedPeer", targetInfo.Enode), "add trusted peer")
+		fmt.Printf("DEBUG: admin_addTrustedPeer returned: %v\n", peerAddedTrusted)
+		require.True(peerAddedTrusted, "should have added trusted peer successfully")
+	}
+
+	//ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	//defer cancel()
+	//err := wait.For(ctx, time.Second, func() (bool, error) {
+	//var peers []peer
+	//if err := initiator.CallContext(ctx, &peers, "admin_peers"); err != nil {
+	//fmt.Printf("DEBUG:Error getting peers: %v\n", err)
+	//return false, err
+	//}
+	//fmt.Printf("DEBUG: Peers: %+v, looking for: %s\n", peers, targetInfo.ID)
+	//return slices.ContainsFunc(peers, func(p peer) bool {
+	//return p.ID == targetInfo.ID
+	//}), nil
+	//})
+	//require.NoError(err, "The peer was not connected")
 }
 
 // DisconnectP2P disconnects a p2p peer connection between node1 and node2.

--- a/op-devstack/sysgo/l2_el_p2p_util.go
+++ b/op-devstack/sysgo/l2_el_p2p_util.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/p2p"
+	"github.com/ethereum/go-ethereum/p2p/enode"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
@@ -47,6 +48,10 @@ func ConnectP2P(ctx context.Context, require *testreq.Assertions, initiator RpcC
 	var targetInfo p2p.NodeInfo
 	require.NoError(acceptor.CallContext(ctx, &targetInfo, "admin_nodeInfo"), "get node info")
 	fmt.Printf("DEBUG: acceptor admin_nodeInfo returned: %+v\n", targetInfo)
+	targetNode, err := enode.ParseV4(targetInfo.Enode)
+	require.NoError(err, "failed to parse target node")
+
+	expectedID := targetNode.ID().String()
 
 	var initiatorInfo p2p.NodeInfo
 	require.NoError(initiator.CallContext(ctx, &initiatorInfo, "admin_nodeInfo"), "get initiator node info")
@@ -64,20 +69,20 @@ func ConnectP2P(ctx context.Context, require *testreq.Assertions, initiator RpcC
 		require.True(peerAddedTrusted, "should have added trusted peer successfully")
 	}
 
-	//ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	//defer cancel()
-	//err := wait.For(ctx, time.Second, func() (bool, error) {
-	//var peers []peer
-	//if err := initiator.CallContext(ctx, &peers, "admin_peers"); err != nil {
-	//fmt.Printf("DEBUG:Error getting peers: %v\n", err)
-	//return false, err
-	//}
-	//fmt.Printf("DEBUG: Peers: %+v, looking for: %s\n", peers, targetInfo.ID)
-	//return slices.ContainsFunc(peers, func(p peer) bool {
-	//return p.ID == targetInfo.ID
-	//}), nil
-	//})
-	//require.NoError(err, "The peer was not connected")
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	err = wait.For(ctx, time.Second, func() (bool, error) {
+		var peers []peer
+		if err := initiator.CallContext(ctx, &peers, "admin_peers"); err != nil {
+			fmt.Printf("DEBUG:Error getting peers: %v\n", err)
+			return false, err
+		}
+		fmt.Printf("DEBUG: Peers: %+v, looking for: %s\n", peers, targetInfo.ID)
+		return slices.ContainsFunc(peers, func(p peer) bool {
+			return p.ID == expectedID
+		}), nil
+	})
+	require.NoError(err, "The peer was not connected")
 }
 
 // DisconnectP2P disconnects a p2p peer connection between node1 and node2.

--- a/op-devstack/sysgo/l2_el_p2p_util.go
+++ b/op-devstack/sysgo/l2_el_p2p_util.go
@@ -2,8 +2,8 @@ package sysgo
 
 import (
 	"context"
-	"fmt"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/ethereum/go-ethereum/p2p"
@@ -47,25 +47,20 @@ type RpcCaller interface {
 func ConnectP2P(ctx context.Context, require *testreq.Assertions, initiator RpcCaller, acceptor RpcCaller, trusted bool) {
 	var targetInfo p2p.NodeInfo
 	require.NoError(acceptor.CallContext(ctx, &targetInfo, "admin_nodeInfo"), "get node info")
-	fmt.Printf("DEBUG: acceptor admin_nodeInfo returned: %+v\n", targetInfo)
 	targetNode, err := enode.ParseV4(targetInfo.Enode)
 	require.NoError(err, "failed to parse target node")
-
 	expectedID := targetNode.ID().String()
 
 	var initiatorInfo p2p.NodeInfo
 	require.NoError(initiator.CallContext(ctx, &initiatorInfo, "admin_nodeInfo"), "get initiator node info")
-	fmt.Printf("DEBUG: initiator admin_nodeInfo returned: %+v\n", initiatorInfo)
 
 	var peerAdded bool
 	require.NoError(initiator.CallContext(ctx, &peerAdded, "admin_addPeer", targetInfo.Enode), "add peer")
-	fmt.Printf("DEBUG: admin_addPeer returned: %v\n", peerAdded)
 	require.True(peerAdded, "should have added peer successfully")
 
 	if trusted {
 		var peerAddedTrusted bool
 		require.NoError(initiator.CallContext(ctx, &peerAddedTrusted, "admin_addTrustedPeer", targetInfo.Enode), "add trusted peer")
-		fmt.Printf("DEBUG: admin_addTrustedPeer returned: %v\n", peerAddedTrusted)
 		require.True(peerAddedTrusted, "should have added trusted peer successfully")
 	}
 
@@ -74,12 +69,11 @@ func ConnectP2P(ctx context.Context, require *testreq.Assertions, initiator RpcC
 	err = wait.For(ctx, time.Second, func() (bool, error) {
 		var peers []peer
 		if err := initiator.CallContext(ctx, &peers, "admin_peers"); err != nil {
-			fmt.Printf("DEBUG:Error getting peers: %v\n", err)
 			return false, err
 		}
-		fmt.Printf("DEBUG: Peers: %+v, looking for: %s\n", peers, targetInfo.ID)
 		return slices.ContainsFunc(peers, func(p peer) bool {
-			return p.ID == expectedID
+			peerID := strings.TrimPrefix(strings.ToLower(p.ID), "0x")
+			return peerID == strings.ToLower(expectedID)
 		}), nil
 	})
 	require.NoError(err, "The peer was not connected")
@@ -89,6 +83,9 @@ func ConnectP2P(ctx context.Context, require *testreq.Assertions, initiator RpcC
 func DisconnectP2P(ctx context.Context, require *testreq.Assertions, initiator RpcCaller, acceptor RpcCaller) {
 	var targetInfo p2p.NodeInfo
 	require.NoError(acceptor.CallContext(ctx, &targetInfo, "admin_nodeInfo"), "get node info")
+	targetNode, err := enode.ParseV4(targetInfo.Enode)
+	require.NoError(err, "failed to parse target node")
+	expectedID := targetNode.ID().String()
 
 	var peerRemoved bool
 	require.NoError(initiator.CallContext(ctx, &peerRemoved, "admin_removePeer", targetInfo.ENR), "add peer")
@@ -96,13 +93,14 @@ func DisconnectP2P(ctx context.Context, require *testreq.Assertions, initiator R
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	err := wait.For(ctx, time.Second, func() (bool, error) {
+	err = wait.For(ctx, time.Second, func() (bool, error) {
 		var peers []peer
 		if err := initiator.CallContext(ctx, &peers, "admin_peers"); err != nil {
 			return false, err
 		}
 		return !slices.ContainsFunc(peers, func(p peer) bool {
-			return p.ID == targetInfo.ID
+			peerID := strings.TrimPrefix(strings.ToLower(p.ID), "0x")
+			return peerID == strings.ToLower(expectedID)
 		}), nil
 	})
 	require.NoError(err, "The peer was not removed")

--- a/op-devstack/sysgo/system.go
+++ b/op-devstack/sysgo/system.go
@@ -602,7 +602,7 @@ func NewDefaultSingleChainSystemWithFlashblocksIDs(l1ID, l2ID eth.ChainID) Singl
 		L2:            stack.L2NetworkID(l2ID),
 		L2CL:          stack.NewL2CLNodeID("sequencer", l2ID),
 		L2EL:          stack.NewL2ELNodeID("sequencer", l2ID),
-		L2Builder:     stack.NewOPRBuilderNodeID("sequencer", l2ID),
+		L2Builder:     stack.NewOPRBuilderNodeID("sequencer-builder", l2ID),
 		L2RollupBoost: stack.NewRollupBoostNodeID("rollup-boost", l2ID),
 		L2Batcher:     stack.NewL2BatcherID("main", l2ID),
 		L2Proposer:    stack.NewL2ProposerID("main", l2ID),
@@ -620,8 +620,8 @@ func DefaultSingleChainSystemWithFlashblocks(dest *SingleChainSystemWithFlashblo
 func singleChainSystemWithFlashblocksOpts(ids *SingleChainSystemWithFlashblocksIDs, dest *SingleChainSystemWithFlashblocksIDs) stack.CombinedOption[*Orchestrator] {
 	opt := stack.Combine[*Orchestrator]()
 	// Precompute deterministic P2P identity and peering between sequencer EL and op-rbuilder EL.
-	seqID := NewELNodeIdentity("127.0.0.1", 0)
-	builderID := NewELNodeIdentity("127.0.0.1", 0) // allocate dynamic port for builder
+	seqID := NewELNodeIdentity(0)
+	builderID := NewELNodeIdentity(0) // allocate dynamic port for builder
 
 	opt.Add(stack.BeforeDeploy(func(o *Orchestrator) {
 		o.P().Logger().Info("Setting up")
@@ -639,8 +639,12 @@ func singleChainSystemWithFlashblocksOpts(ids *SingleChainSystemWithFlashblocksI
 
 	opt.Add(WithL1Nodes(ids.L1EL, ids.L1CL))
 
-	opt.Add(WithL2ELNode(ids.L2EL, L2ELWithP2PConfig("127.0.0.1", seqID.Port, seqID.KeyHex(), []string{builderID.Enode}, nil)))
-	opt.Add(WithOPRBuilderNode(ids.L2Builder, OPRBuilderWithNodeIdentity(builderID, "127.0.0.1", []string{seqID.Enode}, []string{seqID.Enode})))
+	opt.Add(WithL2ELNode(ids.L2EL, L2ELWithP2PConfig("127.0.0.1", seqID.Port, seqID.KeyHex(), nil, nil)))
+	opt.Add(WithOPRBuilderNode(ids.L2Builder, OPRBuilderWithNodeIdentity(builderID, "127.0.0.1", nil, nil)))
+	// Sequencer adds builder as regular static peer (not trusted)
+	opt.Add(WithL2ELP2PConnection(ids.L2EL, stack.L2ELNodeID(ids.L2Builder), false))
+	// Builder adds sequencer as trusted peer
+	opt.Add(WithL2ELP2PConnection(stack.L2ELNodeID(ids.L2Builder), ids.L2EL, true))
 	opt.Add(WithRollupBoost(ids.L2RollupBoost, ids.L2EL, RollupBoostWithBuilderNode(ids.L2Builder)))
 
 	opt.Add(WithL2CLNode(ids.L2CL, ids.L1CL, ids.L1EL, stack.L2ELNodeID(ids.L2RollupBoost), L2CLSequencer()))

--- a/op-devstack/sysgo/system_singlechain_multinode.go
+++ b/op-devstack/sysgo/system_singlechain_multinode.go
@@ -45,7 +45,7 @@ func DefaultSingleChainMultiNodeSystem(dest *DefaultSingleChainMultiNodeSystemID
 
 	// P2P connect L2CL nodes
 	opt.Add(WithL2CLP2PConnection(ids.L2CL, ids.L2CLB))
-	opt.Add(WithL2ELP2PConnection(ids.L2EL, ids.L2ELB))
+	opt.Add(WithL2ELP2PConnection(ids.L2EL, ids.L2ELB, false))
 
 	opt.Add(stack.Finally(func(orch *Orchestrator) {
 		*dest = ids

--- a/op-devstack/sysgo/system_singlechain_twoverifiers.go
+++ b/op-devstack/sysgo/system_singlechain_twoverifiers.go
@@ -53,11 +53,11 @@ func DefaultSingleChainTwoVerifiersFollowL2System(dest *DefaultSingleChainTwoVer
 	opt.Add(WithL2CLNodeFollowL2(ids.L2CLC, ids.L1CL, ids.L1EL, ids.L2ELC, ids.L2CLB))
 
 	opt.Add(WithL2CLP2PConnection(ids.L2CL, ids.L2CLB))
-	opt.Add(WithL2ELP2PConnection(ids.L2EL, ids.L2ELB))
+	opt.Add(WithL2ELP2PConnection(ids.L2EL, ids.L2ELB, false))
 	opt.Add(WithL2CLP2PConnection(ids.L2CL, ids.L2CLC))
-	opt.Add(WithL2ELP2PConnection(ids.L2EL, ids.L2ELC))
+	opt.Add(WithL2ELP2PConnection(ids.L2EL, ids.L2ELC, false))
 	opt.Add(WithL2CLP2PConnection(ids.L2CLB, ids.L2CLC))
-	opt.Add(WithL2ELP2PConnection(ids.L2ELB, ids.L2ELC))
+	opt.Add(WithL2ELP2PConnection(ids.L2ELB, ids.L2ELC, false))
 
 	opt.Add(WithBatcher(ids.L2Batcher, ids.L1EL, ids.L2CL, ids.L2EL))
 	opt.Add(WithProposer(ids.L2Proposer, ids.L1EL, &ids.L2CL, nil))


### PR DESCRIPTION
# Overview
Fixes a bug related to port collisions during flashblocks acceptance tests. The issue surface via the following error message:
```
listen tcp 127.0.0.1:42373: bind: address already in use
```

# Root cause
The root cause was a race condition in P2P port allocation:
1. `NewELNodeIdentity()` called `getAvailableLocalPort()` early during setup to pre-allocate P2P ports
2. `getAvailableLocalPort()` opens a listener to find a free port, then immediately closes it
3. Between port "reservation" and when op-geth actually binds to it (after deployer runs, L1 nodes start, etc.), the OS could re-allocate that port to other services (e.g., tcpproxy).
4. When op-geth finally tried to bind, the port was already in use

# Solution
1. Use dynamic port assignment and connect peers after services start
2. Use port 0 - let the OS assign ports when services actually start
3. Remove pre-computed enode - no longer needed since we connect dynamically
4. Connect peers after startup - use `WithL2ELP2PConnection()` to connect P2P after both nodes are running, querying actual ports via `admin_nodeInfo`
5. Fix ID lookup - changed L2Builder key from "sequencer" to "sequencer-builder" to avoid collision in GetL2EL()
6. Normalize node ID comparison - handle format differences between geth (keccak hash) and reth (compressed pubkey) by deriving standardized IDs from enode URLs