### PR TITLE
cherrypick(op-deployer): op-validator and upgrade to v600

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/docker/docker v27.5.1+incompatible
 	github.com/docker/go-connections v0.5.0
 	github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.4-0.20251001155152-4eb15ccedf7e
-	github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20251121143344-5ac16e0fbb00
+	github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20251222224638-de5f8b1ef969
 	github.com/ethereum/go-ethereum v1.16.3
 	github.com/fatih/color v1.18.0
 	github.com/fsnotify/fsnotify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -242,8 +242,8 @@ github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.4-0.20251001155152-4eb15c
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.4-0.20251001155152-4eb15ccedf7e/go.mod h1:DYj7+vYJ4cIB7zera9mv4LcAynCL5u4YVfoeUu6Wa+w=
 github.com/ethereum-optimism/op-geth v1.101603.6-rc.1 h1:C4MAM29WbeXeNELMLpX1xU6c6OIwBRNposAcl1NHvVk=
 github.com/ethereum-optimism/op-geth v1.101603.6-rc.1/go.mod h1:fCNAwDynfAP6EKsmLqwSDUDgi+GtJIir74Ui3fXXMps=
-github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20251121143344-5ac16e0fbb00 h1:TR5Y7B+5m63V0Dno7MHcFqv/XZByQzx/4THV1T1A7+U=
-github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20251121143344-5ac16e0fbb00/go.mod h1:NZ816PzLU1TLv1RdAvYAb6KWOj4Zm5aInT0YpDVml2Y=
+github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20251222224638-de5f8b1ef969 h1:LgVzFdh56iwdH6yefMTfw/UtaBBlGNuNuYAU6UO1JRE=
+github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20251222224638-de5f8b1ef969/go.mod h1:NZ816PzLU1TLv1RdAvYAb6KWOj4Zm5aInT0YpDVml2Y=
 github.com/ethereum/c-kzg-4844/v2 v2.1.5 h1:aVtoLK5xwJ6c5RiqO8g8ptJ5KU+2Hdquf6G3aXiHh5s=
 github.com/ethereum/c-kzg-4844/v2 v2.1.5/go.mod h1:u59hRTTah4Co6i9fDWtiCjTrblJv0UwsqZKCc0GfgUs=
 github.com/ethereum/go-bigmodexpfix v0.0.0-20250911101455-f9e208c548ab h1:rvv6MJhy07IMfEKuARQ9TKojGqLVNxQajaXEp/BoqSk=

--- a/op-deployer/pkg/deployer/integration_test/cli/upgrade_test.go
+++ b/op-deployer/pkg/deployer/integration_test/cli/upgrade_test.go
@@ -59,6 +59,11 @@ func TestCLIUpgrade(t *testing.T) {
 			version:     "v5.0.0",
 			forkBlock:   9629972, // one block past the opcm deployment block
 		},
+		{
+			contractTag: standard.ContractsV600Tag,
+			version:     "v6.0.0-rc.1",
+			forkBlock:   9699895, // one block past the opcm deployment block
+		},
 	}
 
 	for _, tc := range testCases {
@@ -118,8 +123,17 @@ func TestCLIUpgrade(t *testing.T) {
 			require.Len(t, dump, 1)
 			require.Equal(t, l1ProxyAdminOwner.Hex(), dump[0].To.Hex())
 			dataHex := hex.EncodeToString(dump[0].Data)
-			require.True(t, strings.HasPrefix(dataHex, "ff2dd5a1"),
-				"calldata should have opcm.upgrade fcn selector ff2dd5a1, got: %s", dataHex[:8])
+
+			// v6.0.0+ uses a different function signature: upgrade((address,bytes32,bytes32)[])
+			// Older versions use: upgrade((address,address,bytes32)[])
+			var expectedSelector string
+			if tc.version == "v6.0.0-rc.1" {
+				expectedSelector = "cbeda5a7" // upgrade((address,bytes32,bytes32)[])
+			} else {
+				expectedSelector = "ff2dd5a1" // upgrade((address,address,bytes32)[])
+			}
+			require.True(t, strings.HasPrefix(dataHex, expectedSelector),
+				"calldata should have opcm.upgrade fcn selector %s, got: %s", expectedSelector, dataHex[:8])
 		})
 	}
 }

--- a/op-deployer/pkg/deployer/integration_test/cli/upgrade_test.go
+++ b/op-deployer/pkg/deployer/integration_test/cli/upgrade_test.go
@@ -9,14 +9,26 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/broadcaster"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/standard"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/upgrade/v2_0_0"
+	v6_0_0 "github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/upgrade/v6_0_0"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum-optimism/optimism/op-service/testutils/devnet"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
+
+// isKonaVersion checks if the version string represents v6.0.0 or higher
+func isKonaVersion(version string) bool {
+	v, err := semver.NewVersion(version)
+	if err != nil {
+		return false
+	}
+	v6, _ := semver.NewVersion("6.0.0")
+	return v.Compare(v6) >= 0
+}
 
 // TestCLIUpgrade tests the upgrade CLI command for each standard opcm release
 // - forks sepolia at a block before op-sepolia was upgraded
@@ -80,22 +92,37 @@ func TestCLIUpgrade(t *testing.T) {
 			opcm, err := standard.OPCMImplAddressFor(11155111, tc.contractTag)
 			require.NoError(t, err)
 
-			testConfig := v2_0_0.UpgradeOPChainInput{
-				Prank: l1ProxyAdminOwner,
-				Opcm:  opcm,
-				EncodedChainConfigs: []v2_0_0.OPChainConfig{
-					{
-						SystemConfigProxy: systemConfigProxy,
-						ProxyAdmin:        proxyAdminImpl,
-						AbsolutePrestate:  common.HexToHash("0x0abc"),
-					},
-				},
-			}
-
 			configFile := filepath.Join(workDir, "upgrade_config_"+tc.version+".json")
 			outputFile := filepath.Join(workDir, "upgrade_output_"+tc.version+".json")
 
-			configData, err := json.MarshalIndent(testConfig, "", "  ")
+			var configData []byte
+			if isKonaVersion(tc.version) {
+				testConfig := v6_0_0.UpgradeOPChainInput{
+					Prank: l1ProxyAdminOwner,
+					Opcm:  opcm,
+					EncodedChainConfigs: []v6_0_0.OPChainConfig{
+						{
+							SystemConfigProxy:  systemConfigProxy,
+							CannonPrestate:     common.HexToHash("0x0abc"),
+							CannonKonaPrestate: common.HexToHash("0x0def"),
+						},
+					},
+				}
+				configData, err = json.MarshalIndent(testConfig, "", "  ")
+			} else {
+				testConfig := v2_0_0.UpgradeOPChainInput{
+					Prank: l1ProxyAdminOwner,
+					Opcm:  opcm,
+					EncodedChainConfigs: []v2_0_0.OPChainConfig{
+						{
+							SystemConfigProxy: systemConfigProxy,
+							ProxyAdmin:        proxyAdminImpl,
+							AbsolutePrestate:  common.HexToHash("0x0abc"),
+						},
+					},
+				}
+				configData, err = json.MarshalIndent(testConfig, "", "  ")
+			}
 			require.NoError(t, err)
 			require.NoError(t, os.WriteFile(configFile, configData, 0o644))
 
@@ -127,7 +154,7 @@ func TestCLIUpgrade(t *testing.T) {
 			// v6.0.0+ uses a different function signature: upgrade((address,bytes32,bytes32)[])
 			// Older versions use: upgrade((address,address,bytes32)[])
 			var expectedSelector string
-			if tc.version == "v6.0.0-rc.1" {
+			if isKonaVersion(tc.version) {
 				expectedSelector = "cbeda5a7" // upgrade((address,bytes32,bytes32)[])
 			} else {
 				expectedSelector = "ff2dd5a1" // upgrade((address,address,bytes32)[])

--- a/op-deployer/pkg/deployer/standard/standard.go
+++ b/op-deployer/pkg/deployer/standard/standard.go
@@ -43,7 +43,8 @@ const (
 	ContractsV400Tag        = "op-contracts/v4.0.0-rc.7"
 	ContractsV410Tag        = "op-contracts/v4.1.0"
 	ContractsV500Tag        = "op-contracts/v5.0.0"
-	CurrentTag              = ContractsV500Tag
+	ContractsV600Tag        = "op-contracts/v6.0.0-rc.1"
+	CurrentTag              = ContractsV600Tag
 )
 
 var L1FeesDepositor = common.HexToAddress("0xed9B99a703BaD32AC96FDdc313c0652e379251Fd")

--- a/op-deployer/pkg/deployer/upgrade/flags.go
+++ b/op-deployer/pkg/deployer/upgrade/flags.go
@@ -8,6 +8,7 @@ import (
 	v400 "github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/upgrade/v4_0_0"
 	v410 "github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/upgrade/v4_1_0"
 	v500 "github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/upgrade/v5_0_0"
+	v600 "github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/upgrade/v6_0_0"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	"github.com/urfave/cli/v2"
 )
@@ -83,6 +84,17 @@ var Commands = cli.Commands{
 			OutfileFlag,
 		}, oplog.CLIFlags(deployer.EnvVarPrefix)...),
 		Action: UpgradeCLI(v500.DefaultUpgrader),
+	},
+	&cli.Command{
+		Name:  "v6.0.0-rc.1",
+		Usage: "upgrades a chain to version v6.0.0 (U18)",
+		Flags: append([]cli.Flag{
+			deployer.L1RPCURLFlag,
+			ConfigFlag,
+			OverrideArtifactsURLFlag,
+			OutfileFlag,
+		}, oplog.CLIFlags(deployer.EnvVarPrefix)...),
+		Action: UpgradeCLI(v600.DefaultUpgrader),
 	},
 	&cli.Command{
 		Name:  "embedded",

--- a/op-deployer/pkg/deployer/upgrade/v6_0_0/upgrade.go
+++ b/op-deployer/pkg/deployer/upgrade/v6_0_0/upgrade.go
@@ -1,0 +1,58 @@
+package v6_0_0
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/script"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/artifacts"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/opcm"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/lmittmann/w3"
+)
+
+type UpgradeOPChainInput struct {
+	Prank               common.Address  `json:"prank"`
+	Opcm                common.Address  `json:"opcm"`
+	EncodedChainConfigs []OPChainConfig `evm:"-" json:"chainConfigs"`
+}
+
+type OPChainConfig struct {
+	SystemConfigProxy  common.Address `json:"systemConfigProxy"`
+	CannonPrestate     common.Hash    `json:"cannonPrestate"`
+	CannonKonaPrestate common.Hash    `json:"cannonKonaPrestate"`
+}
+
+var opChainConfigEncoder = w3.MustNewFunc("dummy((address systemConfigProxy,bytes32 cannonPrestate,bytes32 cannonKonaPrestate)[])", "")
+
+func (u *UpgradeOPChainInput) OpChainConfigs() ([]byte, error) {
+	data, err := opChainConfigEncoder.EncodeArgs(u.EncodedChainConfigs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode chain configs: %w", err)
+	}
+	return data[4:], nil
+}
+
+type UpgradeOPChain struct {
+	Run func(input common.Address)
+}
+
+func Upgrade(host *script.Host, input UpgradeOPChainInput) error {
+	return opcm.RunScriptVoid(host, input, "UpgradeOPChain.s.sol", "UpgradeOPChain")
+}
+
+type Upgrader struct{}
+
+func (u *Upgrader) Upgrade(host *script.Host, input json.RawMessage) error {
+	var upgradeInput UpgradeOPChainInput
+	if err := json.Unmarshal(input, &upgradeInput); err != nil {
+		return fmt.Errorf("failed to unmarshal input: %w", err)
+	}
+	return Upgrade(host, upgradeInput)
+}
+
+func (u *Upgrader) ArtifactsURL() string {
+	return artifacts.EmbeddedLocatorString
+}
+
+var DefaultUpgrader = new(Upgrader)

--- a/op-deployer/pkg/deployer/upgrade/v6_0_0/upgrade_superchainconfig.go
+++ b/op-deployer/pkg/deployer/upgrade/v6_0_0/upgrade_superchainconfig.go
@@ -1,0 +1,42 @@
+package v6_0_0
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/script"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type UpgradeSuperchainConfigInput struct {
+	Prank            common.Address `json:"prank"`
+	Opcm             common.Address `json:"opcm"`
+	SuperchainConfig common.Address `json:"superchainConfig"`
+}
+
+type UpgradeSuperchainConfigScript script.DeployScriptWithoutOutput[UpgradeSuperchainConfigInput]
+
+// NewDeployImplementationsScript loads and validates the DeployImplementations script contract
+func NewUpgradeSuperchainConfigScript(host *script.Host) (UpgradeSuperchainConfigScript, error) {
+	return script.NewDeployScriptWithoutOutputFromFile[UpgradeSuperchainConfigInput](host, "UpgradeSuperchainConfig.s.sol", "UpgradeSuperchainConfig")
+}
+
+func UpgradeSuperchainConfig(host *script.Host, input UpgradeSuperchainConfigInput) error {
+	upgradeScript, err := NewUpgradeSuperchainConfigScript(host)
+	if err != nil {
+		return fmt.Errorf("failed to load UpgradeSuperchainConfig script: %w", err)
+	}
+	err = upgradeScript.Run(input)
+	if err != nil {
+		return fmt.Errorf("failed to run UpgradeSuperchainConfig script: %w", err)
+	}
+	return nil
+}
+
+func (u *Upgrader) UpgradeSuperchainConfig(host *script.Host, input json.RawMessage) error {
+	var upgradeInput UpgradeSuperchainConfigInput
+	if err := json.Unmarshal(input, &upgradeInput); err != nil {
+		return fmt.Errorf("failed to unmarshal input: %w", err)
+	}
+	return UpgradeSuperchainConfig(host, upgradeInput)
+}

--- a/op-validator/cmd/main.go
+++ b/op-validator/cmd/main.go
@@ -38,6 +38,7 @@ func main() {
 				versionCmd(standard.ContractsV400Tag),
 				versionCmd(standard.ContractsV410Tag),
 				versionCmd(standard.ContractsV500Tag),
+				versionCmd(standard.ContractsV600Tag),
 			},
 		},
 	}

--- a/op-validator/pkg/service/validate.go
+++ b/op-validator/pkg/service/validate.go
@@ -60,6 +60,8 @@ func Validate(ctx context.Context, lgr log.Logger, release string, cfg *Config) 
 		validator = validations.NewV410Validator(l1Client)
 	case standard.ContractsV500Tag:
 		validator = validations.NewV500Validator(l1Client)
+	case standard.ContractsV600Tag:
+		validator = validations.NewV600Validator(l1Client)
 	default:
 		return nil, fmt.Errorf("invalid release: %s", release)
 	}

--- a/op-validator/pkg/validations/addresses.go
+++ b/op-validator/pkg/validations/addresses.go
@@ -22,6 +22,8 @@ var addresses = map[uint64]map[string]common.Address{
 		standard.ContractsV410Tag: common.HexToAddress("0x845FEF377Fa9C678B3eBe33B024678538f1215dD"),
 		// Bootstrapped on 10/27/2025 using OP Deployer.
 		standard.ContractsV500Tag: common.HexToAddress("0xDCE1A51A25dD5BF02ccB4264D039EDdF11A95b43"),
+		// Bootstrapped on 22/12/2025 using OP Deployer.
+		standard.ContractsV600Tag: common.HexToAddress("0x1DDC39863a8A410c36Be05FF8a1074E488f4383C"),
 	},
 	11155111: {
 		// Bootstrapped on 03/02/2025 using OP Deployer.
@@ -36,6 +38,8 @@ var addresses = map[uint64]map[string]common.Address{
 		standard.ContractsV410Tag: common.HexToAddress("0x7B4d2a02d5fa6C7C98D835d819956EBB876Ff439"),
 		// Bootstrapped on 10/27/2025 using OP Deployer.
 		standard.ContractsV500Tag: common.HexToAddress("0x757bFA3AAABcE60112Cee3239DCD05b5F6EFaE3A"),
+		// Bootstrapped on 22/12/2025 using OP Deployer.
+		standard.ContractsV600Tag: common.HexToAddress("0xe77C85F1B690cA19368106ab98e41278d4667b5B"),
 	},
 }
 

--- a/op-validator/pkg/validations/addresses_test.go
+++ b/op-validator/pkg/validations/addresses_test.go
@@ -113,6 +113,7 @@ func testStandardVersionNetwork(t *testing.T, network string) {
 		standard.ContractsV400Tag,
 		standard.ContractsV410Tag,
 		standard.ContractsV500Tag,
+		standard.ContractsV600Tag,
 	}
 
 	for _, semver := range contractVersions {

--- a/op-validator/pkg/validations/validations.go
+++ b/op-validator/pkg/validations/validations.go
@@ -183,6 +183,10 @@ func NewV500Validator(client *rpc.Client) *OPCMStandardValidator {
 	return newOPCMStandardValidator(client, standard.ContractsV500Tag)
 }
 
+func NewV600Validator(client *rpc.Client) *OPCMStandardValidator {
+	return newOPCMStandardValidator(client, standard.ContractsV600Tag)
+}
+
 func parseErrors(output string) []string {
 	if idx := strings.Index(output, ":"); idx != -1 && strings.HasPrefix(output, "Chain") {
 		output = output[idx+1:]

--- a/op-validator/pkg/validations/validations_test.go
+++ b/op-validator/pkg/validations/validations_test.go
@@ -163,3 +163,71 @@ func TestOPCMStandardValidator(t *testing.T) {
 		})
 	}
 }
+
+func TestOPCMStandardValidatorV500(t *testing.T) {
+	callResult := "0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000004b504444472d34302c504444472d44574554482d33302c504444472d414e43484f52502d34302c504c44472d34302c504c44472d44574554482d33302c504c44472d414e43484f52502d3430000000000000000000000000000000000000000000"
+
+	tests := []struct {
+		name        string
+		input       BaseValidatorInput
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name: "successful validation",
+			input: BaseValidatorInput{
+				SystemConfigAddress: common.HexToAddress("0x034edD2A225f7f429A63E0f1D2084B9E0A93b538"),
+				AbsolutePrestate:    common.HexToHash("0x038512e02c4c3f7bdaec27d00edf55b7155e0905301e1a88083e4e0a6764d54c"),
+				L2ChainID:           big.NewInt(11155420),
+				Proposer:            common.HexToAddress("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"),
+			},
+			expectError: false,
+		},
+		{
+			name: "missing proposer address",
+			input: BaseValidatorInput{
+				SystemConfigAddress: common.HexToAddress("0x034edD2A225f7f429A63E0f1D2084B9E0A93b538"),
+				AbsolutePrestate:    common.HexToHash("0x038512e02c4c3f7bdaec27d00edf55b7155e0905301e1a88083e4e0a6764d54c"),
+				L2ChainID:           big.NewInt(11155420),
+				Proposer:            common.Address{},
+			},
+			expectError: true,
+			errorMsg:    "proposer address is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var mockRPC *mockrpc.MockRPC
+			if !tt.expectError {
+				mockRPC = mockrpc.NewMockRPC(
+					t,
+					testlog.Logger(t, slog.LevelInfo),
+					mockrpc.WithOkCall("eth_chainId", mockrpc.NullMatcher(), "0xaa36a7"), // sepolia chain ID in hex
+					mockrpc.WithOkCall("eth_call", mockrpc.AnyParamsMatcher(), callResult),
+				)
+			} else {
+				mockRPC = mockrpc.NewMockRPC(t, testlog.Logger(t, slog.LevelInfo))
+			}
+
+			rpcClient, err := rpc.Dial(mockRPC.Endpoint())
+			require.NoError(t, err)
+
+			validator := NewV600Validator(rpcClient)
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			errCodes, err := validator.Validate(ctx, tt.input)
+
+			if tt.expectError {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errorMsg)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, []string{"PDDG-40", "PDDG-DWETH-30", "PDDG-ANCHORP-40", "PLDG-40", "PLDG-DWETH-30", "PLDG-ANCHORP-40"}, errCodes)
+				mockRPC.AssertExpectations(t)
+			}
+		})
+	}
+}


### PR DESCRIPTION
feat(op-deployer): op-validator and upgrade to v600

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Copies over the op-deployer embedded upgrade to v6.0.0 and adds op-validator v6.0.0 + missing tests.

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
