### PR TITLE
fix(op-preimage): disable setnonblock in windows

### DIFF
--- a/op-preimage/filechan.go
+++ b/op-preimage/filechan.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"syscall"
 )
 
 // FileChannel is a unidirectional channel for file I/O
@@ -90,6 +89,6 @@ func ClientPreimageChannel() *ReadWritePair {
 func newFileNonBlocking(fd int, name string) *os.File {
 	// Try to enable non-blocking mode for IO so that read calls return when the file is closed
 	// This may not be possible on all systems so errors are ignored.
-	_ = syscall.SetNonblock(fd, true)
+	setNonblock(fd)
 	return os.NewFile(uintptr(fd), name)
 }

--- a/op-preimage/filechan_unix.go
+++ b/op-preimage/filechan_unix.go
@@ -1,0 +1,10 @@
+//go:build !windows
+
+package preimage
+
+import "syscall"
+
+func setNonblock(fd int) {
+	// Unix only
+	_ = syscall.SetNonblock(fd, true)
+}

--- a/op-preimage/filechan_windows.go
+++ b/op-preimage/filechan_windows.go
@@ -1,0 +1,7 @@
+//go:build windows
+
+package preimage
+
+func setNonblock(fd int) {
+	// SetNonblock is not supported on Windows
+}


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Windows requires a file handle in order to call Setnonblock. This is a bit redundant in our case given that the implementation [does nothing](https://cs.opensource.google/go/go/+/refs/tags/go1.25.5:src/syscall/exec_windows.go;l=149), therefore we just skip the method on windows to avoid the failing build.

```
  ⨯ release failed after 2m44s                      
    error=
    │ build failed: exit status 1: # github.com/ethereum-optimism/optimism/op-preimage
    │ ../op-preimage/filechan.go:93:26: cannot use fd (variable of type int) as syscall.Handle value in argument to syscall.SetNonblock
    target=windows_amd64_v1
```

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
