### PR TITLE
Use https for git submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -34,10 +34,10 @@
 	url = https://github.com/ethereum-optimism/superchain-registry
 [submodule "op-rbuilder"]
 	path = op-rbuilder
-	url = git@github.com:flashbots/op-rbuilder.git
+	url = https://github.com/flashbots/op-rbuilder
 [submodule "rollup-boost"]
 	path = rollup-boost
-	url = git@github.com:flashbots/rollup-boost.git
+	url = https://github.com/flashbots/rollup-boost
 [submodule "kona"]
 	path = kona
-	url = git@github.com:op-rs/kona.git
+	url = https://github.com/op-rs/kona


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Most of the git submodules use https (the forge libs). But the three newest ones (the explicitly added ones) use SSH. They should be consistent. `git submodule update` won't work for anyone who doesn't have an SSH public key registered with github, which is less common for most contributors than github auth via https.

NOTE! This means everyone will need to do `git submodule sync && git submodule update`.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
