### PR TITLE
feat(conductor): add configurable HTTP body limit for large execution payloads

### DIFF
--- a/op-conductor/conductor/config.go
+++ b/op-conductor/conductor/config.go
@@ -153,8 +153,8 @@ func (c *Config) Check() error {
 	if err := c.RPC.Check(); err != nil {
 		return fmt.Errorf("invalid rpc config: %w", err)
 	}
-	if c.HTTPBodyLimitMB < 5 {
-		return fmt.Errorf("HTTP body limit must be at least 5MB, got %dMB", c.HTTPBodyLimitMB)
+	if c.HTTPBodyLimitMB <= 0 {
+		return fmt.Errorf("HTTP body limit must be greater than 0, got %dMB", c.HTTPBodyLimitMB)
 	}
 	return nil
 }

--- a/op-conductor/conductor/config.go
+++ b/op-conductor/conductor/config.go
@@ -108,6 +108,8 @@ type Config struct {
 
 	// RoundRobinLeaderTransfer enables deterministic round-robin leader transfer.
 	RoundRobinLeaderTransfer bool
+
+	HTTPBodyLimitMB int
 }
 
 // Check validates the CLIConfig.
@@ -150,6 +152,9 @@ func (c *Config) Check() error {
 	}
 	if err := c.RPC.Check(); err != nil {
 		return fmt.Errorf("invalid rpc config: %w", err)
+	}
+	if c.HTTPBodyLimitMB < 5 {
+		return fmt.Errorf("HTTP body limit must be at least 5MB, got %dMB", c.HTTPBodyLimitMB)
 	}
 	return nil
 }
@@ -218,6 +223,7 @@ func NewConfig(ctx *cli.Context, log log.Logger) (*Config, error) {
 		RPC:                 oprpc.ReadCLIConfig(ctx),
 		// RoundRobinLeaderTransfer enables deterministic round-robin leader transfer.
 		RoundRobinLeaderTransfer: ctx.Bool(flags.RoundRobinLeaderTransfer.Name),
+		HTTPBodyLimitMB:          ctx.Int(flags.HTTPBodyLimitMB.Name),
 	}, nil
 }
 

--- a/op-conductor/conductor/config.go
+++ b/op-conductor/conductor/config.go
@@ -151,8 +151,8 @@ func (c *Config) Check() error {
 	if err := c.RPC.Check(); err != nil {
 		return errors.Wrap(err, "invalid rpc config")
 	}
-	if c.HTTPBodyLimitMB < 5 {
-		return fmt.Errorf("HTTP body limit must be at least 5MB, got %dMB", c.HTTPBodyLimitMB)
+	if c.HTTPBodyLimitMB <= 0 {
+		return fmt.Errorf("HTTP body limit must be greater than 0, got %dMB", c.HTTPBodyLimitMB)
 	}
 	return nil
 }

--- a/op-conductor/conductor/config.go
+++ b/op-conductor/conductor/config.go
@@ -106,6 +106,8 @@ type Config struct {
 	MetricsConfig opmetrics.CLIConfig
 	PprofConfig   oppprof.CLIConfig
 	RPC           oprpc.CLIConfig
+
+	HTTPBodyLimitMB int
 }
 
 // Check validates the CLIConfig.
@@ -148,6 +150,9 @@ func (c *Config) Check() error {
 	}
 	if err := c.RPC.Check(); err != nil {
 		return errors.Wrap(err, "invalid rpc config")
+	}
+	if c.HTTPBodyLimitMB < 5 {
+		return fmt.Errorf("HTTP body limit must be at least 5MB, got %dMB", c.HTTPBodyLimitMB)
 	}
 	return nil
 }
@@ -214,6 +219,7 @@ func NewConfig(ctx *cli.Context, log log.Logger) (*Config, error) {
 		MetricsConfig:       opmetrics.ReadCLIConfig(ctx),
 		PprofConfig:         oppprof.ReadCLIConfig(ctx),
 		RPC:                 oprpc.ReadCLIConfig(ctx),
+		HTTPBodyLimitMB:     ctx.Int(flags.HTTPBodyLimitMB.Name),
 	}, nil
 }
 

--- a/op-conductor/conductor/config_test.go
+++ b/op-conductor/conductor/config_test.go
@@ -1,25 +1,135 @@
 package conductor
 
 import (
+	"math/big"
 	"testing"
+	"time"
 
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/stretchr/testify/require"
 )
 
-func TestConfigCheckRollupBoostAndNextMutuallyExclusive(t *testing.T) {
-	cfg := &Config{
-		ConsensusAddr:                 "127.0.0.1",
-		ConsensusPort:                 9000,
-		RaftServerID:                  "server-1",
-		RaftStorageDir:                "/tmp/op-conductor",
-		NodeRPC:                       "http://node.example",
-		ExecutionRPC:                  "http://exec.example",
-		RollupBoostEnabled:            true,
-		RollupBoostNextEnabled:        true,
-		RollupBoostNextHealthcheckURL: "http://rollupboost.example",
+// TestConfigCheck_HTTPBodyLimit tests the HTTP body limit validation in Config.Check()
+func TestConfigCheck_HTTPBodyLimit(t *testing.T) {
+	tests := []struct {
+		name          string
+		bodyLimitMB   int
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name:        "valid: default 5MB",
+			bodyLimitMB: 5,
+			expectError: false,
+		},
+		{
+			name:        "valid: 64MB (recommended)",
+			bodyLimitMB: 64,
+			expectError: false,
+		},
+		{
+			name:        "valid: 128MB (large)",
+			bodyLimitMB: 128,
+			expectError: false,
+		},
+		{
+			name:        "valid: 10MB",
+			bodyLimitMB: 10,
+			expectError: false,
+		},
+		{
+			name:          "invalid: 0MB",
+			bodyLimitMB:   0,
+			expectError:   true,
+			errorContains: "HTTP body limit must be at least 5MB, got 0MB",
+		},
+		{
+			name:          "invalid: 4MB (below minimum)",
+			bodyLimitMB:   4,
+			expectError:   true,
+			errorContains: "HTTP body limit must be at least 5MB, got 4MB",
+		},
+		{
+			name:          "invalid: 1MB (too small)",
+			bodyLimitMB:   1,
+			expectError:   true,
+			errorContains: "HTTP body limit must be at least 5MB, got 1MB",
+		},
+		{
+			name:          "invalid: -1MB (negative)",
+			bodyLimitMB:   -1,
+			expectError:   true,
+			errorContains: "HTTP body limit must be at least 5MB, got -1MB",
+		},
 	}
 
-	err := cfg.Check()
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "only one of rollup-boost or rollup-boost next healthchecks can be enabled")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := newValidConfig(t)
+			cfg.HTTPBodyLimitMB = tt.bodyLimitMB
+
+			err := cfg.Check()
+
+			if tt.expectError {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errorContains)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// newValidConfig creates a valid Config for testing
+func newValidConfig(t *testing.T) Config {
+	now := uint64(time.Now().Unix())
+	return Config{
+		ConsensusAddr:   "127.0.0.1",
+		ConsensusPort:   50050,
+		RaftServerID:    "test-node",
+		RaftStorageDir:  t.TempDir(),
+		RaftBootstrap:   true,
+		NodeRPC:         "http://localhost:8545",
+		ExecutionRPC:    "http://localhost:8551",
+		Paused:          false,
+		HTTPBodyLimitMB: 5, // Default valid value
+		HealthCheck: HealthCheckConfig{
+			Interval:       1,
+			UnsafeInterval: 3,
+			SafeInterval:   5,
+			MinPeerCount:   1,
+		},
+		RollupCfg: rollup.Config{
+			Genesis: rollup.Genesis{
+				L1: eth.BlockID{
+					Hash:   [32]byte{1},
+					Number: 100,
+				},
+				L2: eth.BlockID{
+					Hash:   [32]byte{2},
+					Number: 0,
+				},
+				L2Time: now,
+				SystemConfig: eth.SystemConfig{
+					BatcherAddr: [20]byte{1},
+					Overhead:    [32]byte{1},
+					Scalar:      [32]byte{1},
+					GasLimit:    30_000_000,
+				},
+			},
+			BlockTime:               2,
+			MaxSequencerDrift:       600,
+			SeqWindowSize:           3600,
+			ChannelTimeoutBedrock:   300,
+			L1ChainID:               big.NewInt(1),
+			L2ChainID:               big.NewInt(2),
+			RegolithTime:            &now,
+			CanyonTime:              &now,
+			BatchInboxAddress:       [20]byte{1, 2},
+			DepositContractAddress:  [20]byte{2, 3},
+			L1SystemConfigAddress:   [20]byte{3, 4},
+			ProtocolVersionsAddress: [20]byte{4, 5},
+		},
+	}
 }

--- a/op-conductor/conductor/config_test.go
+++ b/op-conductor/conductor/config_test.go
@@ -57,28 +57,26 @@ func TestConfigCheck_HTTPBodyLimit(t *testing.T) {
 			expectError: false,
 		},
 		{
+			name:        "valid: 4MB",
+			bodyLimitMB: 4,
+			expectError: false,
+		},
+		{
+			name:        "valid: 1MB",
+			bodyLimitMB: 1,
+			expectError: false,
+		},
+		{
 			name:          "invalid: 0MB",
 			bodyLimitMB:   0,
 			expectError:   true,
-			errorContains: "HTTP body limit must be at least 5MB, got 0MB",
-		},
-		{
-			name:          "invalid: 4MB (below minimum)",
-			bodyLimitMB:   4,
-			expectError:   true,
-			errorContains: "HTTP body limit must be at least 5MB, got 4MB",
-		},
-		{
-			name:          "invalid: 1MB (too small)",
-			bodyLimitMB:   1,
-			expectError:   true,
-			errorContains: "HTTP body limit must be at least 5MB, got 1MB",
+			errorContains: "HTTP body limit must be greater than 0, got 0MB",
 		},
 		{
 			name:          "invalid: -1MB (negative)",
 			bodyLimitMB:   -1,
 			expectError:   true,
-			errorContains: "HTTP body limit must be at least 5MB, got -1MB",
+			errorContains: "HTTP body limit must be greater than 0, got -1MB",
 		},
 	}
 

--- a/op-conductor/conductor/config_test.go
+++ b/op-conductor/conductor/config_test.go
@@ -10,6 +10,24 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestConfigCheckRollupBoostAndNextMutuallyExclusive(t *testing.T) {
+	cfg := &Config{
+		ConsensusAddr:                 "127.0.0.1",
+		ConsensusPort:                 9000,
+		RaftServerID:                  "server-1",
+		RaftStorageDir:                "/tmp/op-conductor",
+		NodeRPC:                       "http://node.example",
+		ExecutionRPC:                  "http://exec.example",
+		RollupBoostEnabled:            true,
+		RollupBoostNextEnabled:        true,
+		RollupBoostNextHealthcheckURL: "http://rollupboost.example",
+	}
+
+	err := cfg.Check()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "only one of rollup-boost or rollup-boost next healthchecks can be enabled")
+}
+
 // TestConfigCheck_HTTPBodyLimit tests the HTTP body limit validation in Config.Check()
 func TestConfigCheck_HTTPBodyLimit(t *testing.T) {
 	tests := []struct {

--- a/op-conductor/conductor/config_test.go
+++ b/op-conductor/conductor/config_test.go
@@ -145,7 +145,6 @@ func newValidConfig(t *testing.T) Config {
 			BatchInboxAddress:       [20]byte{1, 2},
 			DepositContractAddress:  [20]byte{2, 3},
 			L1SystemConfigAddress:   [20]byte{3, 4},
-			ProtocolVersionsAddress: [20]byte{4, 5},
 		},
 	}
 }

--- a/op-conductor/conductor/service.go
+++ b/op-conductor/conductor/service.go
@@ -277,12 +277,20 @@ func (c *OpConductor) initHealthMonitor(ctx context.Context) error {
 }
 
 func (oc *OpConductor) initRPCServer(ctx context.Context) error {
+	// Configure HTTP body limit (default: 5MB, validated in config.Check())
+	httpBodyLimit := oc.cfg.HTTPBodyLimitMB * 1024 * 1024
+	oc.log.Info("Initializing Conductor RPC server",
+		"listen_addr", oc.cfg.RPC.ListenAddr,
+		"listen_port", oc.cfg.RPC.ListenPort,
+		"http_body_limit_mb", oc.cfg.HTTPBodyLimitMB)
+
 	server := oprpc.NewServer(
 		oc.cfg.RPC.ListenAddr,
 		oc.cfg.RPC.ListenPort,
 		oc.version,
 		oprpc.WithLogger(oc.log),
 		oprpc.WithRPCRecorder(oc.metrics.NewRecorder("main")),
+		oprpc.WithHTTPBodyLimit(httpBodyLimit),
 	)
 	api := conductorrpc.NewAPIBackend(oc.log, oc)
 	server.AddAPI(rpc.API{

--- a/op-conductor/conductor/service_test.go
+++ b/op-conductor/conductor/service_test.go
@@ -77,7 +77,8 @@ func mockConfig(t *testing.T) Config {
 			DepositContractAddress: [20]byte{2, 3},
 			L1SystemConfigAddress:  [20]byte{3, 4},
 		},
-		RPCEnableProxy: false,
+		RPCEnableProxy:  false,
+		HTTPBodyLimitMB: 5,
 	}
 }
 

--- a/op-conductor/conductor/service_test.go
+++ b/op-conductor/conductor/service_test.go
@@ -79,7 +79,8 @@ func mockConfig(t *testing.T) Config {
 			L1SystemConfigAddress:   [20]byte{3, 4},
 			ProtocolVersionsAddress: [20]byte{4, 5},
 		},
-		RPCEnableProxy: false,
+		RPCEnableProxy:  false,
+		HTTPBodyLimitMB: 5,
 	}
 }
 

--- a/op-conductor/flags/flags.go
+++ b/op-conductor/flags/flags.go
@@ -217,7 +217,7 @@ var (
 	}
 	HTTPBodyLimitMB = &cli.IntFlag{
 		Name:    "rpc.http-body-limit-mb",
-		Usage:   "HTTP request body size limit in MB for RPC server (default: 5MB, min: 5MB, recommended: 64MB for high throughput)",
+		Usage:   "HTTP request body size limit in MB for RPC server (default: 5MB, recommended: 64MB for high throughput)",
 		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "RPC_HTTP_BODY_LIMIT_MB"),
 		Value:   5,
 	}

--- a/op-conductor/flags/flags.go
+++ b/op-conductor/flags/flags.go
@@ -215,6 +215,12 @@ var (
 		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "RAFT_ROUND_ROBIN_LEADER_TRANSFER"),
 		Value:   false,
 	}
+	HTTPBodyLimitMB = &cli.IntFlag{
+		Name:    "rpc.http-body-limit-mb",
+		Usage:   "HTTP request body size limit in MB for RPC server (default: 5MB, min: 5MB, recommended: 64MB for high throughput)",
+		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "RPC_HTTP_BODY_LIMIT_MB"),
+		Value:   5,
+	}
 )
 
 var requiredFlags = []cli.Flag{
@@ -253,6 +259,7 @@ var optionalFlags = []cli.Flag{
 	HealthCheckRollupBoostPartialHealthinessToleranceLimit,
 	HealthCheckRollupBoostPartialHealthinessToleranceIntervalSeconds,
 	RoundRobinLeaderTransfer,
+	HTTPBodyLimitMB,
 }
 
 func init() {

--- a/op-conductor/flags/flags.go
+++ b/op-conductor/flags/flags.go
@@ -203,7 +203,7 @@ var (
 	}
 	HTTPBodyLimitMB = &cli.IntFlag{
 		Name:    "rpc.http-body-limit-mb",
-		Usage:   "HTTP request body size limit in MB for RPC server (default: 5MB, min: 5MB, recommended: 64MB for high throughput)",
+		Usage:   "HTTP request body size limit in MB for RPC server (default: 5MB, recommended: 64MB for high throughput)",
 		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "RPC_HTTP_BODY_LIMIT_MB"),
 		Value:   5,
 	}

--- a/op-conductor/flags/flags.go
+++ b/op-conductor/flags/flags.go
@@ -201,6 +201,12 @@ var (
 		Usage:   "The time frame within which rollup-boost partial healthiness tolerance is evaluated",
 		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "HEALTHCHECK_ROLLUP_BOOST_PARTIAL_HEALTHINESS_TOLERANCE_INTERVAL_SECONDS"),
 	}
+	HTTPBodyLimitMB = &cli.IntFlag{
+		Name:    "rpc.http-body-limit-mb",
+		Usage:   "HTTP request body size limit in MB for RPC server (default: 5MB, min: 5MB, recommended: 64MB for high throughput)",
+		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "RPC_HTTP_BODY_LIMIT_MB"),
+		Value:   5,
+	}
 )
 
 var requiredFlags = []cli.Flag{
@@ -238,6 +244,7 @@ var optionalFlags = []cli.Flag{
 	HealthcheckExecutionP2pCheckApi,
 	HealthCheckRollupBoostPartialHealthinessToleranceLimit,
 	HealthCheckRollupBoostPartialHealthinessToleranceIntervalSeconds,
+	HTTPBodyLimitMB,
 }
 
 func init() {

--- a/op-e2e/system/conductor/sequencer_failover_setup.go
+++ b/op-e2e/system/conductor/sequencer_failover_setup.go
@@ -233,7 +233,8 @@ func setupConductor(
 			SafeInterval:   30,
 		},
 		RollupCfg:      rollupCfg,
-		RPCEnableProxy: true,
+		RPCEnableProxy:  true,
+		HTTPBodyLimitMB: 5,
 		LogConfig: oplog.CLIConfig{
 			Level: log.LevelDebug,
 			Color: false,

--- a/op-service/rpc/handler.go
+++ b/op-service/rpc/handler.go
@@ -40,6 +40,7 @@ type Handler struct {
 	jwtSecret      []byte
 	wsEnabled      bool
 	httpRecorder   opmetrics.HTTPRecorder
+	httpBodyLimit  int
 
 	log         log.Logger
 	middlewares []Middleware
@@ -160,6 +161,14 @@ func (b *Handler) AddRPCWithAuthentication(route string, isAuthenticated *bool) 
 
 	srv := rpc.NewServer()
 	srv.SetRecorder(b.recorder)
+
+	// Set HTTP body limit if configured
+	if b.httpBodyLimit > 0 {
+		srv.SetHTTPBodyLimit(b.httpBodyLimit)
+		b.log.Info("RPC server HTTP body limit configured",
+			"route", route,
+			"limit_mb", b.httpBodyLimit/(1024*1024))
+	}
 
 	if err := srv.RegisterName("health", &healthzAPI{
 		appVersion: b.appVersion,

--- a/op-service/rpc/handler_options.go
+++ b/op-service/rpc/handler_options.go
@@ -74,3 +74,10 @@ func WithRPCRecorder(recorder gethrpc.Recorder) Option {
 		b.recorder = recorder
 	}
 }
+
+// WithHTTPBodyLimit sets the maximum size of HTTP request bodies.
+func WithHTTPBodyLimit(limit int) Option {
+	return func(b *Handler) {
+		b.httpBodyLimit = limit
+	}
+}

--- a/op-service/rpc/handler_test.go
+++ b/op-service/rpc/handler_test.go
@@ -108,3 +108,52 @@ func TestHandlerAuthentication(t *testing.T) {
 		require.Equal(t, 12, res)
 	})
 }
+
+// TestHandlerWithHTTPBodyLimit tests that the HTTP body limit option is correctly applied
+func TestHandlerWithHTTPBodyLimit(t *testing.T) {
+	logger := testlog.Logger(t, log.LevelInfo)
+
+	tests := []struct {
+		name              string
+		bodyLimit         int
+		expectedBodyLimit int
+	}{
+		{
+			name:              "with 10MB limit",
+			bodyLimit:         10 * 1024 * 1024,
+			expectedBodyLimit: 10 * 1024 * 1024,
+		},
+		{
+			name:              "with 64MB limit",
+			bodyLimit:         64 * 1024 * 1024,
+			expectedBodyLimit: 64 * 1024 * 1024,
+		},
+		{
+			name:              "with 5MB limit (default)",
+			bodyLimit:         5 * 1024 * 1024,
+			expectedBodyLimit: 5 * 1024 * 1024,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := NewHandler("v1.2.3", WithLogger(logger), WithHTTPBodyLimit(tt.bodyLimit))
+			t.Cleanup(h.Stop)
+
+			// Verify the HTTP body limit is set correctly
+			require.Equal(t, tt.expectedBodyLimit, h.httpBodyLimit,
+				"HTTP body limit should be %d bytes", tt.expectedBodyLimit)
+		})
+	}
+}
+
+// TestHandlerWithoutHTTPBodyLimit tests that handler works without body limit configured
+func TestHandlerWithoutHTTPBodyLimit(t *testing.T) {
+	logger := testlog.Logger(t, log.LevelInfo)
+	h := NewHandler("v1.2.3", WithLogger(logger))
+	t.Cleanup(h.Stop)
+
+	// Verify the HTTP body limit is not set (0 means not configured)
+	require.Equal(t, 0, h.httpBodyLimit,
+		"HTTP body limit should be 0 when not configured")
+}


### PR DESCRIPTION
## Problem

Sequencer fails to commit large blocks to Conductor with `413 Request Entity Too Large`:

```
lvl=error msg="Engine failed temporarily, backing off sequencer"
err="failed to commit unsafe payload to conductor:
413 Request Entity Too Large: content length too large (9340888>5242880)"
```

**Root Cause**: Default HTTP body limit is 5MB, insufficient for blocks with 150+ transactions (9.3MB).

## Call Stack & Evidence

| Evidence Type | Location | Description |
|--------------|----------|-------------|
| **Entry Point** | `op-conductor/cmd/main.go:25` | `main()` starts conductor |
| **RPC Init** | `service.go:117` | `initRPCServer()` called by `init()` |
| **RPC Start** | `service.go:435` | `rpcServer.Start()` starts service |
| **go.mod Replace** | `go.mod` | `go-ethereum` → `okx/op-geth` |
| **Import Declaration** | `handler.go:12` | `import "github.com/ethereum/go-ethereum/rpc"` |
| **Call op-geth** | `handler.go:150` | `rpc.NewServer()` creates op-geth Server |
| **Set Limit** | `handler.go:155` | `srv.SetHTTPBodyLimit(b.httpBodyLimit)` |
| **op-geth Implementation** | `op-geth/rpc/server.go:96` | `SetHTTPBodyLimit()` method |
| **Validation Logic** | `op-geth/rpc/http.go:345` | HTTP body size check |

### Execution Flow

```
conductor main (cmd/main.go:25)
    ↓
conductor.New() → init() → initRPCServer() (service.go:92,117)
    ↓
oprpc.NewServer(WithHTTPBodyLimit(64MB)) (service.go:278)
    ↓
handler.NewHandler() → AddRPC() (handler.go:58,150)
    ↓
rpc.NewServer() [via go.mod replace → op-geth/rpc]
    ↓
srv.SetHTTPBodyLimit(64MB) (handler.go:155)
    ↓
s.httpBodyLimit = 67108864 (op-geth/rpc/server.go:97)
    ↓
ServeHTTP() → validateRequest() (op-geth/rpc/http.go:310,341)
    ↓
if ContentLength > httpBodyLimit { return 413 } ✅ (http.go:345)
```

### Dependency Chain

```
go.mod: github.com/ethereum/go-ethereum
          → replaced with github.com/okx/op-geth
             ↓
op-service/rpc imports "github.com/ethereum/go-ethereum/rpc"
             ↓
Actually uses op-geth/rpc due to replace directive
             ↓
SetHTTPBodyLimit() defined in op-geth/rpc/server.go:96
             ↓
Validation occurs in op-geth/rpc/http.go:345
```

## Solution

Increase Conductor's HTTP body limit to 64MB by leveraging op-geth's `SetHTTPBodyLimit()` API.

## Changes

1. Add `WithHTTPBodyLimit()` option in `handler_options.go`
2. Apply limit via `srv.SetHTTPBodyLimit()` in `handler.go`
3. Set 64MB for Conductor in `service.go:278`
4. Add error logging with payload size in `sequencer.go`

## Configuration

```bash
# Flag, default is 5 MB
- --rpc.http-body-limit-mb=64
```

