### PR TITLE
feat(conductor): fix leader loop switch by adding round-robin leadership transfer

### DIFF
--- a/op-conductor/conductor/config.go
+++ b/op-conductor/conductor/config.go
@@ -106,6 +106,9 @@ type Config struct {
 	MetricsConfig opmetrics.CLIConfig
 	PprofConfig   oppprof.CLIConfig
 	RPC           oprpc.CLIConfig
+
+	// RoundRobinLeaderTransfer enables deterministic round-robin leader transfer.
+	RoundRobinLeaderTransfer bool
 }
 
 // Check validates the CLIConfig.
@@ -214,6 +217,8 @@ func NewConfig(ctx *cli.Context, log log.Logger) (*Config, error) {
 		MetricsConfig:       opmetrics.ReadCLIConfig(ctx),
 		PprofConfig:         oppprof.ReadCLIConfig(ctx),
 		RPC:                 oprpc.ReadCLIConfig(ctx),
+		// RoundRobinLeaderTransfer enables deterministic round-robin leader transfer.
+		RoundRobinLeaderTransfer: ctx.Bool(flags.RoundRobinLeaderTransfer.Name),
 	}, nil
 }
 

--- a/op-conductor/conductor/service.go
+++ b/op-conductor/conductor/service.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/rand"
 	"net/http"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -825,7 +826,13 @@ func (oc *OpConductor) action() {
 func (oc *OpConductor) transferLeader() error {
 	// TransferLeader here will do round robin to try to transfer leadership to the next healthy node.
 	oc.log.Info("transferring leadership", "server", oc.cons.ServerID())
-	err := oc.cons.TransferLeader()
+	// Use round-robin if enabled, otherwise use default Raft leader transfer
+	var err error
+	if oc.cfg.RoundRobinLeaderTransfer {
+		err = oc.transferLeaderRoundRobin()
+	} else {
+		err = oc.cons.TransferLeader()
+	}
 	oc.metrics.RecordLeaderTransfer(err == nil)
 	if err == nil {
 		oc.leader.Store(false)
@@ -841,6 +848,95 @@ func (oc *OpConductor) transferLeader() error {
 		oc.log.Error("failed to transfer leadership", "err", err)
 		return err
 	}
+}
+
+// transferLeaderRoundRobin implements true round-robin leader transfer.
+// This ensures that each cluster member gets a chance to become leader,
+// by always transferring to the next node in sorted order.
+// For example, with nodes [seq1, seq2, seq3]:
+//   - seq1 transfers to seq2
+//   - seq2 transfers to seq3
+//   - seq3 transfers to seq1
+//
+// If a transfer fails (e.g., target node's log is behind), it will try the next node.
+func (oc *OpConductor) transferLeaderRoundRobin() error {
+	// Get cluster membership
+	membership, err := oc.cons.ClusterMembership()
+	if err != nil {
+		return fmt.Errorf("failed to get cluster membership: %w", err)
+	}
+
+	myServerID := oc.cons.ServerID()
+
+	// Collect all voters (including self) for proper ordering
+	var allVoters []consensus.ServerInfo
+	for _, server := range membership.Servers {
+		if server.Suffrage == consensus.Voter {
+			allVoters = append(allVoters, server)
+		}
+	}
+
+	if len(allVoters) <= 1 {
+		return errors.New("no other voters available for leader transfer")
+	}
+
+	// Sort all voters by ServerID to ensure consistent ordering across all nodes.
+	sort.Slice(allVoters, func(i, j int) bool {
+		return allVoters[i].ID < allVoters[j].ID
+	})
+
+	// Find my position in the sorted list
+	myIdx := -1
+	for i, server := range allVoters {
+		if server.ID == myServerID {
+			myIdx = i
+			break
+		}
+	}
+
+	if myIdx == -1 {
+		return errors.New("current server not found in voter list")
+	}
+
+	// Try to transfer to each voter in round-robin order, starting from the next one.
+	// This handles cases where a recently promoted voter may have stale logs.
+	numOtherVoters := len(allVoters) - 1
+	for attempt := 0; attempt < numOtherVoters; attempt++ {
+		targetIdx := (myIdx + 1 + attempt) % len(allVoters)
+		// Skip self
+		if targetIdx == myIdx {
+			continue
+		}
+		target := allVoters[targetIdx]
+
+		oc.log.Info("round-robin transferring leadership",
+			"from", myServerID,
+			"to", target.ID,
+			"targetAddr", target.Addr,
+			"attempt", attempt+1,
+			"totalVoters", len(allVoters),
+		)
+
+		err := oc.cons.TransferLeaderTo(target.ID, target.Addr)
+		if err == nil {
+			return nil // Success
+		}
+
+		// "leadership transfer in progress" means a previous transfer is ongoing, just wait
+		if strings.Contains(err.Error(), "leadership transfer in progress") {
+			oc.log.Debug("leadership transfer already in progress, waiting for completion")
+			return nil
+		}
+
+		// Log the failure and try next voter
+		oc.log.Warn("failed to transfer leadership to voter, trying next",
+			"target", target.ID,
+			"err", err,
+			"attempt", attempt+1,
+		)
+	}
+
+	return errors.New("failed to transfer leadership to any voter")
 }
 
 func (oc *OpConductor) stopSequencer() error {

--- a/op-conductor/conductor/service.go
+++ b/op-conductor/conductor/service.go
@@ -877,7 +877,8 @@ func (oc *OpConductor) transferLeaderRoundRobin() error {
 	}
 
 	if len(allVoters) <= 1 {
-		return errors.New("no other voters available for leader transfer")
+		oc.log.Warn("no other voters available for leader transfer, skipping")
+		return nil
 	}
 
 	// Sort all voters by ServerID to ensure consistent ordering across all nodes.
@@ -936,7 +937,10 @@ func (oc *OpConductor) transferLeaderRoundRobin() error {
 		)
 	}
 
-	return errors.New("failed to transfer leadership to any voter")
+	// All round-robin attempts failed, fall back to Raft's default leader transfer
+	// which selects the candidate with the most up-to-date log.
+	oc.log.Warn("round-robin transfer failed for all voters, falling back to default leader transfer")
+	return oc.cons.TransferLeader()
 }
 
 func (oc *OpConductor) stopSequencer() error {

--- a/op-conductor/conductor/service.go
+++ b/op-conductor/conductor/service.go
@@ -922,8 +922,8 @@ func (oc *OpConductor) transferLeaderRoundRobin() error {
 			return nil // Success
 		}
 
-		// "leadership transfer in progress" means a previous transfer is ongoing, just wait
-		if strings.Contains(err.Error(), "leadership transfer in progress") {
+		// ErrLeadershipTransferInProgress means a previous transfer is ongoing, just wait
+		if errors.Is(err, raft.ErrLeadershipTransferInProgress) {
 			oc.log.Debug("leadership transfer already in progress, waiting for completion")
 			return nil
 		}

--- a/op-conductor/flags/flags.go
+++ b/op-conductor/flags/flags.go
@@ -201,6 +201,16 @@ var (
 		Usage:   "The time frame within which rollup-boost partial healthiness tolerance is evaluated",
 		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "HEALTHCHECK_ROLLUP_BOOST_PARTIAL_HEALTHINESS_TOLERANCE_INTERVAL_SECONDS"),
 	}
+	// RoundRobinLeaderTransfer enables deterministic round-robin leader transfer.
+	// When enabled, leader transfer will cycle through all voters in sorted order (by ServerID),
+	// ensuring that even if only one node in the cluster is healthy, it will eventually become leader.
+	// This is useful when Raft's default log-based leader selection keeps choosing unhealthy nodes.
+	RoundRobinLeaderTransfer = &cli.BoolFlag{
+		Name:    "raft.round-robin-leader-transfer",
+		Usage:   "Enable deterministic round-robin leader transfer instead of Raft's default log-based selection",
+		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "RAFT_ROUND_ROBIN_LEADER_TRANSFER"),
+		Value:   false,
+	}
 )
 
 var requiredFlags = []cli.Flag{
@@ -238,6 +248,7 @@ var optionalFlags = []cli.Flag{
 	HealthcheckExecutionP2pCheckApi,
 	HealthCheckRollupBoostPartialHealthinessToleranceLimit,
 	HealthCheckRollupBoostPartialHealthinessToleranceIntervalSeconds,
+	RoundRobinLeaderTransfer,
 }
 
 func init() {

--- a/op-conductor/flags/flags.go
+++ b/op-conductor/flags/flags.go
@@ -205,9 +205,13 @@ var (
 	// When enabled, leader transfer will cycle through all voters in sorted order (by ServerID),
 	// ensuring that even if only one node in the cluster is healthy, it will eventually become leader.
 	// This is useful when Raft's default log-based leader selection keeps choosing unhealthy nodes.
+	//
+	// NOTE: This flag must be enabled on ALL conductors in the cluster to work as intended.
+	// A mixed configuration (some nodes enabled, some disabled) can cause a leadership bounce loop
+	// between round-robin and log-based selection strategies.
 	RoundRobinLeaderTransfer = &cli.BoolFlag{
 		Name:    "raft.round-robin-leader-transfer",
-		Usage:   "Enable deterministic round-robin leader transfer instead of Raft's default log-based selection",
+		Usage:   "Enable deterministic round-robin leader transfer instead of Raft's default log-based selection. Must be enabled on all conductors in the cluster.",
 		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "RAFT_ROUND_ROBIN_LEADER_TRANSFER"),
 		Value:   false,
 	}


### PR DESCRIPTION
**Description**

This PR adds an optional round-robin leader transfer mechanism to op-conductor, configurable via the `--raft.round-robin-leader-transfer` flag.

**Problem**

The current leader transfer in op-conductor relies on Raft's default `LeadershipTransfer()`, which selects the next leader based on log completeness (the follower with the most up-to-date log). However, this selection mechanism is unaware of application-level health status (op-node & execution layer).
This can cause a problematic scenario where unhealthy nodes keep being elected as leader in a loop:
1. Node A becomes leader but is unhealthy → transfers to Node B (most complete log)
2. Node B becomes leader but is also unhealthy → transfers back to Node A (now has most complete log)
3. Healthy Node C never gets elected because its log is slightly behind

**Solution**

Introduce a deterministic round-robin leader transfer that cycles through all voters in sorted order (by ServerID):
- Node A → Node B → Node C → Node A → ...
This ensures that even if only one node in the cluster is healthy, it will eventually become the leader after at most N-1 transfers.

**Changes**

- Added `--raft.round-robin-leader-transfer` flag (default: false, backward compatible)
- Added transferLeaderRoundRobin() function that:
  - Sorts all voters by ServerID for consistent ordering across nodes
  - Transfers to the next node in sorted order
  - If transfer fails (e.g., target has stale logs), tries the next node
  - Handles "leadership transfer in progress" gracefully

**Tests**

Manual testing was performed with a 4-node conductor cluster where 2 nodes were intentionally made unhealthy. With round-robin enabled, leadership eventually transferred to a healthy node. Without round-robin, leadership kept bouncing between the unhealthy nodes.

**Additional context**

This feature is opt-in and disabled by default to maintain backward compatibility. When disabled, the behavior is identical to the current implementation.
The round-robin approach trades off Raft's "most up-to-date log" optimization for guaranteed leader rotation. In practice, this is acceptable because:
All voters in a healthy cluster should have similar log states
The primary goal of leader transfer in op-conductor is to find a healthy sequencer, not to optimize for log completeness
If a target node's log is too stale, Raft will reject the transfer and we try the next node

**Metadata**

- Related to sequencer high-availability and failover reliability
