### PR TITLE
feat(conductor): add demote-voter to conductor rpc

### DIFF
--- a/op-conductor/conductor/service.go
+++ b/op-conductor/conductor/service.go
@@ -620,6 +620,12 @@ func (oc *OpConductor) RemoveServer(_ context.Context, id string, version uint64
 	return oc.cons.RemoveServer(id, version)
 }
 
+// DemoteVoter demotes a voting member to a non-voting member.
+// If the leader is demoted, it will cause a new leader election.
+func (oc *OpConductor) DemoteVoter(_ context.Context, id string, version uint64) error {
+	return oc.cons.DemoteVoter(id, version)
+}
+
 // TransferLeader transfers leadership to another server.
 func (oc *OpConductor) TransferLeader(_ context.Context) error {
 	return oc.cons.TransferLeader()

--- a/op-conductor/rpc/api.go
+++ b/op-conductor/rpc/api.go
@@ -48,6 +48,8 @@ type API interface {
 	AddServerAsNonvoter(ctx context.Context, id string, addr string, version uint64) error
 	// RemoveServer removes a server from the cluster.
 	RemoveServer(ctx context.Context, id string, version uint64) error
+	// DemoteVoter demotes a voting member to a non-voting member. If the leader is demoted, it will cause a new leader election.
+	DemoteVoter(ctx context.Context, id string, version uint64) error
 	// TransferLeader transfers leadership to another server.
 	TransferLeader(ctx context.Context) error
 	// TransferLeaderToServer transfers leadership to a specific server.

--- a/op-conductor/rpc/backend.go
+++ b/op-conductor/rpc/backend.go
@@ -24,6 +24,7 @@ type conductor interface {
 	AddServerAsVoter(ctx context.Context, id string, addr string, version uint64) error
 	AddServerAsNonvoter(ctx context.Context, id string, addr string, version uint64) error
 	RemoveServer(ctx context.Context, id string, version uint64) error
+	DemoteVoter(ctx context.Context, id string, version uint64) error
 	TransferLeader(ctx context.Context) error
 	TransferLeaderToServer(ctx context.Context, id string, addr string) error
 	CommitUnsafePayload(ctx context.Context, payload *eth.ExecutionPayloadEnvelope) error
@@ -86,6 +87,11 @@ func (api *APIBackend) AddServerAsVoter(ctx context.Context, id string, addr str
 // RemoveServer implements API.
 func (api *APIBackend) RemoveServer(ctx context.Context, id string, version uint64) error {
 	return api.con.RemoveServer(ctx, id, version)
+}
+
+// DemoteVoter implements API.
+func (api *APIBackend) DemoteVoter(ctx context.Context, id string, version uint64) error {
+	return api.con.DemoteVoter(ctx, id, version)
 }
 
 // CommitUnsafePayload implements API.

--- a/op-conductor/rpc/client.go
+++ b/op-conductor/rpc/client.go
@@ -75,6 +75,11 @@ func (c *APIClient) RemoveServer(ctx context.Context, id string, version uint64)
 	return c.c.CallContext(ctx, nil, prefixRPC("removeServer"), id, version)
 }
 
+// DemoteVoter implements API.
+func (c *APIClient) DemoteVoter(ctx context.Context, id string, version uint64) error {
+	return c.c.CallContext(ctx, nil, prefixRPC("demoteVoter"), id, version)
+}
+
 // Close closes the underlying RPC client.
 func (c *APIClient) Close() {
 	c.c.Close()


### PR DESCRIPTION
**Description**

This PR exposes the `DemoteVoter` method via the conductor RPC API, allowing operators to demote a voting member to a non-voting member without removing and re-adding the node.

**Problem**

The consensus layer already has a `DemoteVoter` method implemented, but it was not exposed through the RPC API. Without this RPC endpoint, operators who wanted to demote a voter to nonvoter had to:
1. Remove the server via `conductor_removeServer`
2. Re-add it via `conductor_addServerAsNonvoter`
This workaround has a significant drawback: when a node is removed, Raft's default behavior causes it to shut down, requiring a process restart before re-adding.

**Solution**

Expose the existing `DemoteVoter` consensus method through the RPC API as `conductor_demoteVoter`. This allows:
- Direct demotion of a voter to nonvoter in a single RPC call
- No Raft shutdown or process restart required
- Seamless role transitions within the cluster

**Changes**

- Added `DemoteVoter` method to `rpc/api.go` interface
- Added `DemoteVoter` implementation in `rpc/backend.go`
- Added `DemoteVoter` client method in `rpc/client.go`
- Added `DemoteVoter` handler in `conductor/service.go`

**Usage**

```
curl -X POST http://<conductor>:8547 \
  -d '{"jsonrpc":"2.0","method":"conductor_demoteVoter","params":["<server-id>", 0],"id":1}'
```

**Tests**

Manual testing was performed:
1. Started a 3-node conductor cluster with all nodes as voters
2. Called `conductor_demoteVoter` on one node
3. Verified the node transitioned from voter to nonvoter
4. Verified cluster membership reflected the change
5. Verified the demoted node continued to receive log replication
This is a straightforward RPC exposure of an existing consensus method. The underlying `DemoteVoter` functionality is already tested as part of HashiCorp Raft.

**Additional context**

Note: If the leader is demoted, it will trigger a new leader election. This is expected Raft behavior.

**Metadata**

Complements existing cluster management APIs (`addServerAsVoter`, `addServerAsNonvoter`, `removeServer`)
