### PR TITLE
chore: annual license year update

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 (The MIT License)
 
-Copyright 2020-2025 Optimism
+Copyright 2020-2026 Optimism
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the


### PR DESCRIPTION
Updates the copyright year from 2025 to 2026.

Keeping license files current for the new year.