### PR TITLE
fix: add compiler restriction for StorageSetter to align profiles

### DIFF
--- a/packages/contracts-bedrock/foundry.toml
+++ b/packages/contracts-bedrock/foundry.toml
@@ -164,6 +164,7 @@ compilation_restrictions = [
   { paths = "src/L1/opcm/OPContractsManagerContainer.sol", optimizer_runs = 0 },
   { paths = "src/L1/OptimismPortal2.sol", optimizer_runs = 0 },
   { paths = "src/L1/ProtocolVersions.sol", optimizer_runs = 0 },
+  { paths = "src/universal/StorageSetter.sol", optimizer_runs = 0 }
 ]
 
 ################################################################


### PR DESCRIPTION
**Description**

Correcting a missing StorageSetter setting in the lite profile compiler restrictions

**Tests**

Verified tests pass and build and no change to semver-lock.json

**Additional context**

Fixed the toml to follow the guidance in a comment at the top of the file

```
IMPORTANT:
 When adding any new compiler profiles or compilation restrictions, you must
 also update the restrictions in the "LITE" profile to match. This guarantees
 that builds will fully overwrite one another without needing to clean the
 entire build directory.

```
**Metadata**

N/A


