### PR TITLE
op-supernode: fix env var prefix wrangling

### DIFF
--- a/op-supernode/flags/flags.go
+++ b/op-supernode/flags/flags.go
@@ -96,12 +96,12 @@ func FullDynamicFlags(chains []uint64) []cli.Flag {
 	for _, f := range opnodeflags.Flags {
 		baseName := f.Names()[0]
 		// vn.all.* env var/alias prefixing
-		allEnvs := prefixEnvVar(f, "VN_ALL_")
+		allEnvs := upgradeEnvVarPrefixes(f, opnodeflags.EnvVarPrefix, "VN_ALL")
 		allAliases := prefixAliases(f, VNFlagGlobalPrefix)
 		final = append(final, renameFlagWithEnv(f, VNFlagGlobalPrefix+baseName, allEnvs, allAliases))
 		// per-chain
 		for _, id := range chains {
-			perChainEnvs := prefixEnvVar(f, fmt.Sprintf("VN_%d_", id))
+			perChainEnvs := upgradeEnvVarPrefixes(f, opnodeflags.EnvVarPrefix, fmt.Sprintf("VN_%d", id))
 			perAliases := prefixAliases(f, fmt.Sprintf("%s%d.", VNFlagNamePrefix, id))
 			final = append(final, renameFlagWithEnv(f, fmt.Sprintf("%s%d.%s", VNFlagNamePrefix, id, baseName), perChainEnvs, perAliases))
 		}

--- a/op-supernode/flags/virtual_flags.go
+++ b/op-supernode/flags/virtual_flags.go
@@ -137,21 +137,23 @@ func renameFlagWithEnv(f cli.Flag, name string, envs []string, aliases []string)
 	}
 }
 
-// prefixEnvVar prefixes the env vars of the given flag with the given middle string
-// e.g. "VN_ALL_" or "VN_123_".
-func prefixEnvVar(f cli.Flag, mid string) []string {
+// upgradeEnvVarPrefixes returns a slice of the env vars of the given flag
+// each with a modified prefix, formed by the OP_SUPERNODE prefix
+// followed by given infix such as "VN_ALL"
+// e.g. "OP_NODE_FINALITY_DELAY" becomes "OP_SUPERNODE_VN_ALL_FINALITY_DELAY"
+// or "OP_SUPERNODE_VN_123_FINALITY_DELAY".
+func upgradeEnvVarPrefixes(f cli.Flag, existingPrefix, newInfix string) []string {
 	envs := f.(interface{ GetEnvVars() []string }).GetEnvVars()
 	if len(envs) == 0 {
 		return nil
 	}
 	out := make([]string, 0, len(envs))
 	for _, e := range envs {
-		idx := strings.Index(e, "_")
-		if idx < 0 {
+		suffix := strings.TrimPrefix(e, existingPrefix+"_")
+		if suffix == e {
 			continue
 		}
-		suffix := e[idx+1:]
-		out = append(out, EnvVarPrefix+"_"+mid+suffix)
+		out = append(out, EnvVarPrefix+"_"+newInfix+"_"+suffix)
 	}
 	return out
 }

--- a/op-supernode/flags/virtual_flags.go
+++ b/op-supernode/flags/virtual_flags.go
@@ -151,7 +151,7 @@ func upgradeEnvVarPrefixes(f cli.Flag, existingPrefix, newInfix string) []string
 	for _, e := range envs {
 		suffix := strings.TrimPrefix(e, existingPrefix+"_")
 		if suffix == e {
-			continue
+			panic("encountered unprefixed flag")
 		}
 		out = append(out, EnvVarPrefix+"_"+newInfix+"_"+suffix)
 	}

--- a/op-supernode/flags/virtual_test.go
+++ b/op-supernode/flags/virtual_test.go
@@ -93,6 +93,9 @@ func TestUpgradeEnvVarPrefixes(t *testing.T) {
 	got = upgradeEnvVarPrefixes(flag, "OP_NODE", "VN_ALL")
 	expected = []string{"OP_SUPERNODE_VN_ALL_FINALITY_DELAY"}
 	require.Equal(t, expected, got)
+
+	badFlag := &cli.StringFlag{Name: "flag", EnvVars: []string{"BAD_FLAG_FINALITY_DELAY"}}
+	require.Panics(t, func() { upgradeEnvVarPrefixes(badFlag, "OP_NODE", "VN_987") })
 }
 
 func TestFullDynamicFlags_ClonesAllFlagsForChainsAndGlobal(t *testing.T) {

--- a/op-supernode/flags/virtual_test.go
+++ b/op-supernode/flags/virtual_test.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli/v2"
 
 	opnodeflags "github.com/ethereum-optimism/optimism/op-node/flags"
@@ -82,6 +83,17 @@ func TestParseChainsVariants(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestUpgradeEnvVarPrefixes(t *testing.T) {
+	flag := &cli.StringFlag{Name: "flag", EnvVars: []string{"OP_NODE_FINALITY_DELAY"}}
+	got := upgradeEnvVarPrefixes(flag, "OP_NODE", "VN_987")
+	expected := []string{"OP_SUPERNODE_VN_987_FINALITY_DELAY"}
+	require.Equal(t, expected, got)
+	got = upgradeEnvVarPrefixes(flag, "OP_NODE", "VN_ALL")
+	expected = []string{"OP_SUPERNODE_VN_ALL_FINALITY_DELAY"}
+	require.Equal(t, expected, got)
+
 }
 
 func TestFullDynamicFlags_ClonesAllFlagsForChainsAndGlobal(t *testing.T) {

--- a/op-supernode/flags/virtual_test.go
+++ b/op-supernode/flags/virtual_test.go
@@ -93,7 +93,6 @@ func TestUpgradeEnvVarPrefixes(t *testing.T) {
 	got = upgradeEnvVarPrefixes(flag, "OP_NODE", "VN_ALL")
 	expected = []string{"OP_SUPERNODE_VN_ALL_FINALITY_DELAY"}
 	require.Equal(t, expected, got)
-
 }
 
 func TestFullDynamicFlags_ClonesAllFlagsForChainsAndGlobal(t *testing.T) {


### PR DESCRIPTION
Replace prefixEnvVar with upgradeEnvVarPrefixes(existingPrefix, newInfix) which builds OP_SUPERNODE_<newInfix>_<SUFFIX> env vars from original OP_NODE_* vars. Update FullDynamicFlags callers and add a unit test.

Currently we get 
```
    --vn.all.conductor.enabled          (default: false)                   ($OP_SUPERNODE_VN_ALL_NODE_CONDUCTOR_ENABLED)
          Enable the conductor service
```
when we want
```
    --vn.all.conductor.enabled          (default: false)                   ($OP_SUPERNODE_VN_ALL_CONDUCTOR_ENABLED)
          Enable the conductor service
```
and so on for all of the other flags. This PR makes that fix and adds a little unit test. 

