### PR TITLE
op-acceptance-test: add flashblock acceptance tests for rule-based op-rbuilder

### DIFF
--- a/op-acceptance-tests/tests/flashblocks/init_test.go
+++ b/op-acceptance-tests/tests/flashblocks/init_test.go
@@ -1,12 +1,124 @@
 package flashblocks
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+	"github.com/ethereum/go-ethereum/common"
 )
 
-// TestMain creates the test-setups against the shared backend
+// TestMain creates the test-setups against the shared backend.
+// If FLASHBLOCKS_RULES_TEST is set, it enables rule-based ordering for tests.
 func TestMain(m *testing.M) {
-	presets.DoMain(m, presets.WithSingleChainSystemWithFlashblocks())
+	// Check if rules testing is enabled
+	if os.Getenv("FLASHBLOCKS_RULES_TEST") != "" {
+		runWithRules(m)
+	} else {
+		// Default: run without rules (original behavior)
+		presets.DoMain(m, presets.WithSingleChainSystemWithFlashblocks())
+	}
 }
+
+func runWithRules(m *testing.M) {
+	// Create a fixed directory for rules config (reused across runs)
+	rulesDir := filepath.Join(os.TempDir(), "flashblocks-test-rules")
+	if err := os.MkdirAll(rulesDir, 0755); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to create rules dir: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Write rules file
+	rulesPath := filepath.Join(rulesDir, "test_rules.yaml")
+	if err := os.WriteFile(rulesPath, []byte(TestRulesYAML), 0644); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to write rules file: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Write registry config pointing to rules file
+	registryConfig := fmt.Sprintf(`file:
+  - path: %s
+    name: "Test Rules"
+    enabled: true
+
+refresh_interval: 5
+`, rulesPath)
+
+	registryPath := filepath.Join(rulesDir, "test_registry.yaml")
+	if err := os.WriteFile(registryPath, []byte(registryConfig), 0644); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to write registry file: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Rules config created at: %s\n", registryPath)
+
+	// Set up orchestrator with rules enabled
+	rulesConfig := sysgo.RulesConfig{
+		Enabled:    true,
+		ConfigPath: registryPath,
+	}
+
+	presets.DoMain(m, presets.WithSingleChainSystemWithFlashblocksAndRules(rulesConfig))
+}
+
+// BoostedRecipient is the well-known address that receives boosted transactions in tests.
+// Transactions sent TO this address will be prioritized by the block builder when rules are enabled.
+var BoostedRecipient = common.HexToAddress("0x1111111111111111111111111111111111111111")
+
+// HighPriorityRecipient receives transactions with the highest boost (weight: 5000)
+var HighPriorityRecipient = common.HexToAddress("0x2222222222222222222222222222222222222222")
+
+// MediumPriorityRecipient receives transactions with medium boost (weight: 2000)
+var MediumPriorityRecipient = common.HexToAddress("0x3333333333333333333333333333333333333333")
+
+// LowPriorityRecipient receives transactions with low boost (weight: 500)
+var LowPriorityRecipient = common.HexToAddress("0x4444444444444444444444444444444444444444")
+
+// TestRulesYAML is the rules configuration used for rule ordering tests.
+// It defines multiple boost levels to test priority ordering:
+// - High priority (weight 5000): transactions TO 0x2222...
+// - Medium priority (weight 2000): transactions TO 0x3333...
+// - Low priority (weight 500): transactions TO 0x4444...
+// - Legacy boost (weight 1000): transactions TO 0x1111... (BoostedRecipient)
+const TestRulesYAML = `version: 1
+
+aliases:
+  high_priority_recipients:
+    - "0x2222222222222222222222222222222222222222"
+  medium_priority_recipients:
+    - "0x3333333333333333333333333333333333333333"
+  low_priority_recipients:
+    - "0x4444444444444444444444444444444444444444"
+  boosted_recipients:
+    - "0x1111111111111111111111111111111111111111"
+
+rules:
+  boost:
+    - name: "High Priority Boost"
+      description: "Highest priority transactions"
+      type: to
+      aliases:
+        - "high_priority_recipients"
+      weight: 5000
+    - name: "Medium Priority Boost"
+      description: "Medium priority transactions"
+      type: to
+      aliases:
+        - "medium_priority_recipients"
+      weight: 2000
+    - name: "Low Priority Boost"
+      description: "Low priority transactions"
+      type: to
+      aliases:
+        - "low_priority_recipients"
+      weight: 500
+    - name: "Legacy Boosted Recipient"
+      description: "Boost transactions to test recipient address"
+      type: to
+      aliases:
+        - "boosted_recipients"
+      weight: 1000
+`

--- a/op-acceptance-tests/tests/flashblocks/rules_ordering_test.go
+++ b/op-acceptance-tests/tests/flashblocks/rules_ordering_test.go
@@ -1,0 +1,559 @@
+//go:build !ci
+
+package flashblocks
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/txplan"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+)
+
+// skipIfRulesNotEnabled skips the test if FLASHBLOCKS_RULES_TEST env var is not set.
+// Rule ordering tests require the rules-enabled orchestrator setup.
+func skipIfRulesNotEnabled(t devtest.T) {
+	if os.Getenv("FLASHBLOCKS_RULES_TEST") == "" {
+		t.Skip("Skipping rule ordering test: FLASHBLOCKS_RULES_TEST env var not set")
+	}
+}
+
+// TestBoostPriorityOrdering validates that transactions to addresses with higher
+// boost weights appear earlier in blocks than transactions to lower-weight addresses.
+//
+// Rules configuration (from init_test.go):
+// - HighPriorityRecipient (0x2222...): weight 5000
+// - MediumPriorityRecipient (0x3333...): weight 2000
+// - LowPriorityRecipient (0x4444...): weight 500
+// - No boost for other addresses: weight 0
+//
+// Expected ordering: High (5000) > Medium (2000) > Low (500) > Normal (0)
+// We verify this by checking TransactionIndex in the block - lower index = earlier in block.
+func TestBoostPriorityOrdering(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	skipIfRulesNotEnabled(t)
+
+	logger := t.Logger()
+	tracer := t.Tracer()
+	ctx := t.Ctx()
+
+	sys := presets.NewSingleChainWithFlashblocks(t)
+
+	topLevelCtx, span := tracer.Start(ctx, "test boost priority ordering")
+	defer span.End()
+
+	ctx, cancel := context.WithTimeout(topLevelCtx, 90*time.Second)
+	defer cancel()
+
+	// Drive initial blocks to ensure the system is ready
+	driveViaTestSequencer(t, sys, 3)
+
+	// Create funded senders - one for each priority level
+	fundAmount := eth.Ether(1)
+	senderHigh := sys.FunderL2.NewFundedEOA(fundAmount)
+	senderMedium := sys.FunderL2.NewFundedEOA(fundAmount)
+	senderLow := sys.FunderL2.NewFundedEOA(fundAmount)
+	senderNormal := sys.FunderL2.NewFundedEOA(fundAmount)
+
+	// Create a normal (non-boosted) recipient for comparison
+	normalRecipient := sys.Wallet.NewEOA(sys.L2EL)
+	normalRecipientAddr := normalRecipient.Address()
+
+	logger.Info("Test accounts created",
+		"sender_high", senderHigh.Address().Hex(),
+		"sender_medium", senderMedium.Address().Hex(),
+		"sender_low", senderLow.Address().Hex(),
+		"sender_normal", senderNormal.Address().Hex(),
+		"high_priority_recipient", HighPriorityRecipient.Hex(),
+		"medium_priority_recipient", MediumPriorityRecipient.Hex(),
+		"low_priority_recipient", LowPriorityRecipient.Hex(),
+		"normal_recipient", normalRecipientAddr.Hex(),
+	)
+
+	// Send all transactions concurrently with the same value (to ensure fair comparison)
+	sendAmount := eth.OneHundredthEther
+	var wg sync.WaitGroup
+	var txHigh, txMedium, txLow, txNormal *txplan.PlannedTx
+
+	wg.Add(4)
+
+	// Transaction to high priority recipient (weight 5000)
+	go func() {
+		defer wg.Done()
+		txHigh = senderHigh.Transact(
+			senderHigh.Plan(),
+			txplan.WithTo(&HighPriorityRecipient),
+			txplan.WithValue(sendAmount),
+		)
+	}()
+
+	// Transaction to medium priority recipient (weight 2000)
+	go func() {
+		defer wg.Done()
+		txMedium = senderMedium.Transact(
+			senderMedium.Plan(),
+			txplan.WithTo(&MediumPriorityRecipient),
+			txplan.WithValue(sendAmount),
+		)
+	}()
+
+	// Transaction to low priority recipient (weight 500)
+	go func() {
+		defer wg.Done()
+		txLow = senderLow.Transact(
+			senderLow.Plan(),
+			txplan.WithTo(&LowPriorityRecipient),
+			txplan.WithValue(sendAmount),
+		)
+	}()
+
+	// Transaction to normal recipient (no boost, weight 0)
+	go func() {
+		defer wg.Done()
+		txNormal = senderNormal.Transact(
+			senderNormal.Plan(),
+			txplan.WithTo(&normalRecipientAddr),
+			txplan.WithValue(sendAmount),
+		)
+	}()
+
+	wg.Wait()
+
+	// Wait for all transactions to be included
+	receiptHigh, err := txHigh.Included.Eval(ctx)
+	require.NoError(t, err, "high priority tx should be included")
+	receiptMedium, err := txMedium.Included.Eval(ctx)
+	require.NoError(t, err, "medium priority tx should be included")
+	receiptLow, err := txLow.Included.Eval(ctx)
+	require.NoError(t, err, "low priority tx should be included")
+	receiptNormal, err := txNormal.Included.Eval(ctx)
+	require.NoError(t, err, "normal tx should be included")
+
+	logger.Info("All transactions confirmed",
+		"high_block", receiptHigh.BlockNumber, "high_index", receiptHigh.TransactionIndex,
+		"medium_block", receiptMedium.BlockNumber, "medium_index", receiptMedium.TransactionIndex,
+		"low_block", receiptLow.BlockNumber, "low_index", receiptLow.TransactionIndex,
+		"normal_block", receiptNormal.BlockNumber, "normal_index", receiptNormal.TransactionIndex,
+	)
+
+	// Verify ordering based on boost weights using transaction index in the block
+	// Lower TransactionIndex = earlier in the block = higher priority
+	sameBlock := receiptHigh.BlockNumber.Cmp(receiptMedium.BlockNumber) == 0 &&
+		receiptMedium.BlockNumber.Cmp(receiptLow.BlockNumber) == 0 &&
+		receiptLow.BlockNumber.Cmp(receiptNormal.BlockNumber) == 0
+
+	if sameBlock {
+		logger.Info("All transactions in same block - verifying boost ordering via transaction index")
+
+		// Verify ordering: high < medium < low < normal (lower index = earlier = higher priority)
+		require.Less(t, receiptHigh.TransactionIndex, receiptMedium.TransactionIndex,
+			"high priority (weight 5000) should have lower tx index than medium priority (weight 2000)")
+		require.Less(t, receiptMedium.TransactionIndex, receiptLow.TransactionIndex,
+			"medium priority (weight 2000) should have lower tx index than low priority (weight 500)")
+		require.Less(t, receiptLow.TransactionIndex, receiptNormal.TransactionIndex,
+			"low priority (weight 500) should have lower tx index than normal (no boost)")
+
+		logger.Info("Boost priority ordering verified successfully",
+			"order", fmt.Sprintf("high(idx=%d) < medium(idx=%d) < low(idx=%d) < normal(idx=%d)",
+				receiptHigh.TransactionIndex, receiptMedium.TransactionIndex,
+				receiptLow.TransactionIndex, receiptNormal.TransactionIndex),
+		)
+	} else {
+		// Transactions in different blocks - compare transaction indices within blocks where applicable
+		logger.Info("Transactions in different blocks - comparing indices for transactions in same block",
+			"high_block", receiptHigh.BlockNumber,
+			"medium_block", receiptMedium.BlockNumber,
+			"low_block", receiptLow.BlockNumber,
+			"normal_block", receiptNormal.BlockNumber,
+		)
+
+		// If in same block, higher priority should have lower index
+		if receiptHigh.BlockNumber.Cmp(receiptMedium.BlockNumber) == 0 {
+			require.Less(t, receiptHigh.TransactionIndex, receiptMedium.TransactionIndex,
+				"high priority should have lower tx index than medium in same block")
+		}
+		if receiptMedium.BlockNumber.Cmp(receiptLow.BlockNumber) == 0 {
+			require.Less(t, receiptMedium.TransactionIndex, receiptLow.TransactionIndex,
+				"medium priority should have lower tx index than low in same block")
+		}
+		if receiptLow.BlockNumber.Cmp(receiptNormal.BlockNumber) == 0 {
+			require.Less(t, receiptLow.TransactionIndex, receiptNormal.TransactionIndex,
+				"low priority should have lower tx index than normal in same block")
+		}
+	}
+}
+
+// TestBoostedVsNonBoostedOrdering validates that a boosted transaction appears before
+// a non-boosted transaction even when the non-boosted transaction has a MUCH HIGHER
+// priority fee (gas tip). This proves that rule-based boost takes precedence over
+// economic incentives (EIP-1559 priority fees).
+//
+// Test setup:
+// - Boosted tx: to BoostedRecipient (weight 1000), LOW priority fee (1 gwei tip)
+// - Normal tx: to normal recipient (no boost), HIGH priority fee (100 gwei tip)
+//
+// Expected: Despite 100x higher gas tip, the normal tx should come AFTER the boosted tx.
+func TestBoostedVsNonBoostedOrdering(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	skipIfRulesNotEnabled(t)
+
+	logger := t.Logger()
+	tracer := t.Tracer()
+	ctx := t.Ctx()
+
+	sys := presets.NewSingleChainWithFlashblocks(t)
+
+	topLevelCtx, span := tracer.Start(ctx, "test boosted vs non-boosted ordering")
+	defer span.End()
+
+	ctx, cancel := context.WithTimeout(topLevelCtx, 60*time.Second)
+	defer cancel()
+
+	// Drive initial blocks
+	driveViaTestSequencer(t, sys, 2)
+
+	// Create two funded senders
+	fundAmount := eth.ThreeHundredthsEther
+	senderBoosted := sys.FunderL2.NewFundedEOA(fundAmount)
+	senderNormal := sys.FunderL2.NewFundedEOA(fundAmount)
+
+	// Create a normal recipient
+	normalRecipient := sys.Wallet.NewEOA(sys.L2EL)
+	normalRecipientAddr := normalRecipient.Address()
+
+	// Define gas fee parameters:
+	// - Low priority fee: 1 gwei (for boosted tx)
+	// - High priority fee: 100 gwei (for non-boosted tx) - 100x higher!
+	lowGasTip := big.NewInt(1_000_000_000)    // 1 gwei
+	highGasTip := big.NewInt(100_000_000_000) // 100 gwei
+	// Set fee cap high enough to cover base fee + tip
+	highGasFeeCap := big.NewInt(200_000_000_000) // 200 gwei
+
+	logger.Info("Test accounts created",
+		"sender_boosted", senderBoosted.Address().Hex(),
+		"sender_normal", senderNormal.Address().Hex(),
+		"boosted_recipient", BoostedRecipient.Hex(),
+		"normal_recipient", normalRecipientAddr.Hex(),
+		"boosted_tx_gas_tip", lowGasTip.String(),
+		"normal_tx_gas_tip", highGasTip.String(),
+	)
+
+	// Send transactions concurrently
+	sendAmount := eth.OneHundredthEther
+	var wg sync.WaitGroup
+	var txBoosted, txNormal *txplan.PlannedTx
+
+	wg.Add(2)
+
+	// Transaction to boosted recipient (weight 1000) with LOW priority fee
+	go func() {
+		defer wg.Done()
+		txBoosted = senderBoosted.Transact(
+			senderBoosted.Plan(),
+			txplan.WithTo(&BoostedRecipient),
+			txplan.WithValue(sendAmount),
+			txplan.WithGasTipCap(lowGasTip),
+		)
+	}()
+
+	// Transaction to normal recipient (no boost) with HIGH priority fee
+	// This tx has 100x higher gas tip but should still come AFTER the boosted tx
+	go func() {
+		defer wg.Done()
+		txNormal = senderNormal.Transact(
+			senderNormal.Plan(),
+			txplan.WithTo(&normalRecipientAddr),
+			txplan.WithValue(sendAmount),
+			txplan.WithGasTipCap(highGasTip),
+			txplan.WithGasFeeCap(highGasFeeCap),
+		)
+	}()
+
+	wg.Wait()
+
+	// Wait for transactions to be included
+	receiptBoosted, err := txBoosted.Included.Eval(ctx)
+	require.NoError(t, err, "boosted tx should be included")
+	receiptNormal, err := txNormal.Included.Eval(ctx)
+	require.NoError(t, err, "normal tx should be included")
+
+	logger.Info("Transactions confirmed",
+		"boosted_hash", receiptBoosted.TxHash.Hex(),
+		"boosted_block", receiptBoosted.BlockNumber,
+		"boosted_index", receiptBoosted.TransactionIndex,
+		"boosted_gas_tip", "1 gwei",
+		"normal_hash", receiptNormal.TxHash.Hex(),
+		"normal_block", receiptNormal.BlockNumber,
+		"normal_index", receiptNormal.TransactionIndex,
+		"normal_gas_tip", "100 gwei",
+	)
+
+	// If both transactions are in the same block, boosted should have lower index (come first)
+	// DESPITE the normal tx having 100x higher gas tip
+	if receiptBoosted.BlockNumber.Cmp(receiptNormal.BlockNumber) == 0 {
+		require.Less(t, receiptBoosted.TransactionIndex, receiptNormal.TransactionIndex,
+			"boosted transaction (weight 1000, 1 gwei tip) should have lower tx index than "+
+				"normal transaction (no boost, 100 gwei tip) - proving rules > gas priority")
+
+		logger.Info("Rule-based boost precedence over gas priority verified!",
+			"boosted_index", receiptBoosted.TransactionIndex,
+			"normal_index", receiptNormal.TransactionIndex,
+			"boosted_gas_tip", "1 gwei",
+			"normal_gas_tip", "100 gwei",
+			"conclusion", "rules-based ordering takes precedence over economic incentives",
+		)
+	} else {
+		logger.Info("Transactions in different blocks - ordering verification skipped",
+			"boosted_block", receiptBoosted.BlockNumber,
+			"normal_block", receiptNormal.BlockNumber,
+		)
+	}
+}
+
+// TestSameSenderNonceOrdering verifies that transactions from the same sender
+// maintain nonce ordering regardless of boost rules.
+func TestSameSenderNonceOrdering(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	skipIfRulesNotEnabled(t)
+
+	logger := t.Logger()
+	tracer := t.Tracer()
+	ctx := t.Ctx()
+
+	sys := presets.NewSingleChainWithFlashblocks(t)
+
+	topLevelCtx, span := tracer.Start(ctx, "test same sender nonce ordering")
+	defer span.End()
+
+	ctx, cancel := context.WithTimeout(topLevelCtx, 60*time.Second)
+	defer cancel()
+
+	// Drive initial blocks
+	driveViaTestSequencer(t, sys, 2)
+
+	// Create a single funded sender
+	sender := sys.FunderL2.NewFundedEOA(eth.Ether(1))
+
+	// Create normal recipient
+	normalRecipient := sys.Wallet.NewEOA(sys.L2EL)
+	normalRecipientAddr := normalRecipient.Address()
+
+	logger.Info("Test sender created", "address", sender.Address().Hex())
+
+	sendAmount := eth.OneHundredthEther
+
+	// Send 3 sequential transactions from same sender to different recipients
+	// TX0 -> Normal recipient (no boost)
+	// TX1 -> HighPriorityRecipient (weight 5000)
+	// TX2 -> Normal recipient (no boost)
+	//
+	// Even though TX1 has the highest boost, it must come after TX0 due to nonce ordering
+
+	// TX0: to normal recipient
+	tx0 := sender.Transact(
+		sender.Plan(),
+		txplan.WithTo(&normalRecipientAddr),
+		txplan.WithValue(sendAmount),
+	)
+	receipt0, err := tx0.Included.Eval(ctx)
+	require.NoError(t, err, "tx0 should be included")
+
+	// TX1: to high priority recipient
+	tx1 := sender.Transact(
+		sender.Plan(),
+		txplan.WithTo(&HighPriorityRecipient),
+		txplan.WithValue(sendAmount),
+	)
+	receipt1, err := tx1.Included.Eval(ctx)
+	require.NoError(t, err, "tx1 should be included")
+
+	// TX2: to normal recipient
+	tx2 := sender.Transact(
+		sender.Plan(),
+		txplan.WithTo(&normalRecipientAddr),
+		txplan.WithValue(sendAmount),
+	)
+	receipt2, err := tx2.Included.Eval(ctx)
+	require.NoError(t, err, "tx2 should be included")
+
+	logger.Info("Sequential transactions confirmed",
+		"tx0_hash", receipt0.TxHash.Hex(), "tx0_block", receipt0.BlockNumber, "tx0_index", receipt0.TransactionIndex,
+		"tx1_hash", receipt1.TxHash.Hex(), "tx1_block", receipt1.BlockNumber, "tx1_index", receipt1.TransactionIndex,
+		"tx2_hash", receipt2.TxHash.Hex(), "tx2_block", receipt2.BlockNumber, "tx2_index", receipt2.TransactionIndex,
+	)
+
+	// Verify nonce ordering is preserved
+	// If transactions are in the same block, their indices must reflect nonce order
+	if receipt0.BlockNumber.Cmp(receipt1.BlockNumber) == 0 {
+		require.Less(t, receipt0.TransactionIndex, receipt1.TransactionIndex,
+			"tx0 (nonce N) must have lower index than tx1 (nonce N+1) despite tx1 having higher boost")
+	} else {
+		// If in different blocks, tx0's block must be <= tx1's block
+		require.LessOrEqual(t, receipt0.BlockNumber.Uint64(), receipt1.BlockNumber.Uint64(),
+			"tx0 must be in same or earlier block than tx1")
+	}
+
+	if receipt1.BlockNumber.Cmp(receipt2.BlockNumber) == 0 {
+		require.Less(t, receipt1.TransactionIndex, receipt2.TransactionIndex,
+			"tx1 (nonce N+1) must have lower index than tx2 (nonce N+2)")
+	} else {
+		require.LessOrEqual(t, receipt1.BlockNumber.Uint64(), receipt2.BlockNumber.Uint64(),
+			"tx1 must be in same or earlier block than tx2")
+	}
+
+	logger.Info("Nonce ordering verified - boost rules do not break same-sender ordering")
+}
+
+// TestMultipleSendersWithMixedPriorities tests a realistic scenario with multiple
+// senders sending to different priority recipients concurrently.
+func TestMultipleSendersWithMixedPriorities(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	skipIfRulesNotEnabled(t)
+
+	logger := t.Logger()
+	tracer := t.Tracer()
+	ctx := t.Ctx()
+
+	sys := presets.NewSingleChainWithFlashblocks(t)
+
+	topLevelCtx, span := tracer.Start(ctx, "test multiple senders mixed priorities")
+	defer span.End()
+
+	ctx, cancel := context.WithTimeout(topLevelCtx, 90*time.Second)
+	defer cancel()
+
+	// Drive initial blocks (use 2 to avoid timestamp drift exceeding 5s gossip threshold)
+	driveViaTestSequencer(t, sys, 2)
+
+	fundAmount := eth.ThreeHundredthsEther
+
+	// Create normal recipient for non-boosted transactions
+	normalRecipient := sys.Wallet.NewEOA(sys.L2EL)
+	normalRecipientAddr := normalRecipient.Address()
+
+	// Create senders with their target recipients and weights
+	type senderConfig struct {
+		eoa       *dsl.EOA
+		priority  string
+		recipient common.Address
+		weight    int
+	}
+
+	configs := []struct {
+		priority  string
+		recipient common.Address
+		weight    int
+	}{
+		{"high", HighPriorityRecipient, 5000},
+		{"medium", MediumPriorityRecipient, 2000},
+		{"low", LowPriorityRecipient, 500},
+		{"normal", normalRecipientAddr, 0},
+		{"high", HighPriorityRecipient, 5000},
+		{"normal", normalRecipientAddr, 0},
+	}
+
+	senders := make([]senderConfig, len(configs))
+	for i, cfg := range configs {
+		eoa := sys.FunderL2.NewFundedEOA(fundAmount)
+		senders[i] = senderConfig{
+			eoa:       eoa,
+			priority:  cfg.priority,
+			recipient: cfg.recipient,
+			weight:    cfg.weight,
+		}
+		logger.Debug("Created sender",
+			"index", i,
+			"address", eoa.Address().Hex(),
+			"priority", cfg.priority,
+			"recipient", cfg.recipient.Hex(),
+		)
+	}
+
+	// Send all transactions concurrently
+	sendAmount := eth.OneHundredthEther
+	var wg sync.WaitGroup
+	plannedTxs := make([]*txplan.PlannedTx, len(senders))
+
+	for i := range senders {
+		wg.Add(1)
+		idx := i
+		go func() {
+			defer wg.Done()
+			recipient := senders[idx].recipient
+			plannedTxs[idx] = senders[idx].eoa.Transact(
+				senders[idx].eoa.Plan(),
+				txplan.WithTo(&recipient),
+				txplan.WithValue(sendAmount),
+			)
+		}()
+	}
+	wg.Wait()
+
+	// Wait for all to be included and collect results
+	type txResult struct {
+		receipt  *types.Receipt
+		priority string
+		weight   int
+	}
+	results := make([]txResult, len(senders))
+
+	for i := range senders {
+		receipt, err := plannedTxs[i].Included.Eval(ctx)
+		require.NoError(t, err, fmt.Sprintf("tx%d should be included", i))
+		results[i] = txResult{
+			receipt:  receipt,
+			priority: senders[i].priority,
+			weight:   senders[i].weight,
+		}
+		logger.Info("Transaction confirmed",
+			"index", i,
+			"priority", senders[i].priority,
+			"weight", senders[i].weight,
+			"block", receipt.BlockNumber,
+			"tx_index", receipt.TransactionIndex,
+		)
+	}
+
+	// Group by block and verify ordering within each block
+	blockGroups := make(map[uint64][]txResult)
+	for _, r := range results {
+		blockNum := r.receipt.BlockNumber.Uint64()
+		blockGroups[blockNum] = append(blockGroups[blockNum], r)
+	}
+
+	for blockNum, txs := range blockGroups {
+		if len(txs) < 2 {
+			continue
+		}
+
+		logger.Info("Verifying ordering in block", "block", blockNum, "tx_count", len(txs))
+
+		// Within the same block, higher weight should mean lower tx index
+		for i := 0; i < len(txs); i++ {
+			for j := i + 1; j < len(txs); j++ {
+				if txs[i].weight > txs[j].weight {
+					require.Less(t, txs[i].receipt.TransactionIndex, txs[j].receipt.TransactionIndex,
+						"tx with weight %d should have lower index than tx with weight %d in block %d",
+						txs[i].weight, txs[j].weight, blockNum)
+				} else if txs[i].weight < txs[j].weight {
+					require.Greater(t, txs[i].receipt.TransactionIndex, txs[j].receipt.TransactionIndex,
+						"tx with weight %d should have higher index than tx with weight %d in block %d",
+						txs[i].weight, txs[j].weight, blockNum)
+				}
+			}
+		}
+	}
+
+	logger.Info("Multiple senders mixed priorities test completed")
+}

--- a/op-acceptance-tests/tests/flashblocks/rules_ordering_test.go
+++ b/op-acceptance-tests/tests/flashblocks/rules_ordering_test.go
@@ -6,7 +6,9 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+	"math/rand"
 	"os"
+	"sort"
 	"sync"
 	"testing"
 	"time"
@@ -492,4 +494,195 @@ func TestMultipleSendersWithMixedPriorities(gt *testing.T) {
 		return nil
 	})
 	require.NoError(t, err, "multiple senders mixed priorities verification failed")
+}
+
+// TestSingleSenderRandomNonceOrderWithRandomScores sends 10 transactions from a single sender
+// with explicit nonces, random gas tips, and random boost recipients. The transactions are
+// submitted to the mempool in a shuffled nonce order to verify that op-rbuilder correctly
+// sorts by transaction score while still respecting nonce ordering for the same sender.
+//
+// Setup:
+//   - 1 sender, 10 transactions (nonces base+0 through base+9)
+//   - Each tx gets a random gas tip (1-50 gwei) AND a random recipient from
+//     {HighPriority, MediumPriority, LowPriority, Normal} for varied boost weights
+//   - Transactions are shuffled before submission so the mempool receives them out-of-order
+//
+// Expected: All 10 transactions are included with strict nonce ordering preserved,
+// i.e. within the same block tx with nonce N always has a lower TransactionIndex
+// than tx with nonce N+1, and across blocks lower nonces are in earlier blocks.
+func TestSingleSenderRandomNonceOrderWithRandomScores(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	skipIfRulesNotEnabled(t)
+
+	logger := t.Logger()
+	tracer := t.Tracer()
+	ctx := t.Ctx()
+
+	sys := presets.NewSingleChainWithFlashblocks(t)
+
+	topLevelCtx, span := tracer.Start(ctx, "test single sender random nonce order with random scores")
+	defer span.End()
+
+	ctx, cancel := context.WithTimeout(topLevelCtx, 120*time.Second)
+	defer cancel()
+
+	driveViaTestSequencer(t, sys, 2)
+
+	const txCount = 10
+
+	type recipientInfo struct {
+		addr   common.Address
+		weight int
+	}
+	normalRecipient := sys.Wallet.NewEOA(sys.L2EL)
+	normalRecipientAddr := normalRecipient.Address()
+	recipients := []recipientInfo{
+		{HighPriorityRecipient, 5000},
+		{MediumPriorityRecipient, 2000},
+		{LowPriorityRecipient, 500},
+		{normalRecipientAddr, 0},
+	}
+
+	const maxRetries = 3
+	err := retry.Do0(ctx, maxRetries, &retry.FixedStrategy{Dur: 0}, func() error {
+		sender := sys.FunderL2.NewFundedEOA(eth.Ether(1))
+		baseNonce := sender.PendingNonce()
+
+		logger.Info("Test sender created",
+			"address", sender.Address().Hex(),
+			"baseNonce", baseNonce,
+		)
+
+		rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+		type txConfig struct {
+			nonce     uint64
+			tipGwei   int64
+			recipient recipientInfo
+		}
+		configs := make([]txConfig, txCount)
+		for i := 0; i < txCount; i++ {
+			tipGwei := int64(1 + rng.Intn(50))
+			recip := recipients[rng.Intn(len(recipients))]
+			configs[i] = txConfig{
+				nonce:     baseNonce + uint64(i),
+				tipGwei:   tipGwei,
+				recipient: recip,
+			}
+			logger.Info("Transaction config",
+				"index", i,
+				"nonce", configs[i].nonce,
+				"tipGwei", tipGwei,
+				"recipient", recip.addr.Hex(),
+				"boostWeight", recip.weight,
+			)
+		}
+
+		submitOrder := rng.Perm(txCount)
+		logger.Info("Shuffled submission order", "order", submitOrder)
+
+		sendAmount := eth.OneHundredthEther
+		highFeeCap := new(big.Int).Mul(big.NewInt(200), big.NewInt(1_000_000_000))
+
+		plannedTxs := make([]*txplan.PlannedTx, txCount)
+		var wg sync.WaitGroup
+		for _, idx := range submitOrder {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				cfg := configs[i]
+				tip := new(big.Int).Mul(big.NewInt(cfg.tipGwei), big.NewInt(1_000_000_000))
+				recipAddr := cfg.recipient.addr
+				plannedTxs[i] = sender.Transact(
+					sender.Plan(),
+					txplan.WithStaticNonce(cfg.nonce),
+					txplan.WithTo(&recipAddr),
+					txplan.WithValue(sendAmount),
+					txplan.WithGasTipCap(tip),
+					txplan.WithGasFeeCap(highFeeCap),
+				)
+			}(idx)
+		}
+		wg.Wait()
+
+		type txResult struct {
+			nonce   uint64
+			tipGwei int64
+			weight  int
+			receipt *types.Receipt
+		}
+		results := make([]txResult, txCount)
+		for i := 0; i < txCount; i++ {
+			receipt, err := plannedTxs[i].Included.Eval(ctx)
+			if err != nil {
+				return fmt.Errorf("tx%d (nonce %d) inclusion: %w", i, configs[i].nonce, err)
+			}
+			results[i] = txResult{
+				nonce:   configs[i].nonce,
+				tipGwei: configs[i].tipGwei,
+				weight:  configs[i].recipient.weight,
+				receipt: receipt,
+			}
+			logger.Info("Transaction confirmed",
+				"index", i,
+				"nonce", configs[i].nonce,
+				"tipGwei", configs[i].tipGwei,
+				"boostWeight", configs[i].recipient.weight,
+				"block", receipt.BlockNumber,
+				"txIndex", receipt.TransactionIndex,
+			)
+		}
+
+		sort.Slice(results, func(i, j int) bool {
+			return results[i].nonce < results[j].nonce
+		})
+
+		// Count how many transactions share a block with at least one other tx.
+		// If every tx lands in its own block, nonce ordering is trivially
+		// guaranteed by the protocol and the test does not exercise the builder's
+		// intra-block ordering logic.  Treat that as a retryable condition so the
+		// next attempt (with a fresh sender/nonces) hopefully lands more txs in
+		// the same block.
+		blockCounts := make(map[uint64]int)
+		for _, r := range results {
+			blockCounts[r.receipt.BlockNumber.Uint64()]++
+		}
+		maxPerBlock := 0
+		for _, c := range blockCounts {
+			if c > maxPerBlock {
+				maxPerBlock = c
+			}
+		}
+		if maxPerBlock < 2 {
+			return fmt.Errorf("all %d transactions landed in separate blocks (%d blocks); "+
+				"need at least 2 in the same block to validate intra-block nonce ordering",
+				txCount, len(blockCounts))
+		}
+
+		for i := 0; i < len(results)-1; i++ {
+			cur := results[i]
+			next := results[i+1]
+
+			if cur.receipt.BlockNumber.Cmp(next.receipt.BlockNumber) == 0 {
+				require.Less(t, cur.receipt.TransactionIndex, next.receipt.TransactionIndex,
+					"nonce %d (tip=%d gwei, boost=%d, txIdx=%d) must have lower tx index than nonce %d (tip=%d gwei, boost=%d, txIdx=%d) in block %d",
+					cur.nonce, cur.tipGwei, cur.weight, cur.receipt.TransactionIndex,
+					next.nonce, next.tipGwei, next.weight, next.receipt.TransactionIndex,
+					cur.receipt.BlockNumber)
+			} else {
+				require.Less(t, cur.receipt.BlockNumber.Uint64(), next.receipt.BlockNumber.Uint64(),
+					"nonce %d must be in an earlier block than nonce %d (got blocks %d and %d)",
+					cur.nonce, next.nonce, cur.receipt.BlockNumber, next.receipt.BlockNumber)
+			}
+		}
+
+		logger.Info("Single sender random nonce order test passed - nonce ordering preserved despite random scores and shuffled submission",
+			"txCount", txCount,
+			"blocksUsed", len(blockCounts),
+			"maxTxsInOneBlock", maxPerBlock,
+			"nonceRange", fmt.Sprintf("%d-%d", results[0].nonce, results[len(results)-1].nonce),
+		)
+		return nil
+	})
+	require.NoError(t, err, "single sender random nonce order with random scores verification failed")
 }

--- a/op-acceptance-tests/tests/flashblocks/rules_ordering_test.go
+++ b/op-acceptance-tests/tests/flashblocks/rules_ordering_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/retry"
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -56,107 +57,91 @@ func TestBoostPriorityOrdering(gt *testing.T) {
 	ctx, cancel := context.WithTimeout(topLevelCtx, 90*time.Second)
 	defer cancel()
 
-	// Drive initial blocks to ensure the system is ready
 	driveViaTestSequencer(t, sys, 3)
 
-	// Create funded senders - one for each priority level
-	fundAmount := eth.Ether(1)
-	senderHigh := sys.FunderL2.NewFundedEOA(fundAmount)
-	senderMedium := sys.FunderL2.NewFundedEOA(fundAmount)
-	senderLow := sys.FunderL2.NewFundedEOA(fundAmount)
-	senderNormal := sys.FunderL2.NewFundedEOA(fundAmount)
+	const maxRetries = 3
+	err := retry.Do0(ctx, maxRetries, &retry.FixedStrategy{Dur: 0}, func() error {
+		fundAmount := eth.Ether(1)
+		senderHigh := sys.FunderL2.NewFundedEOA(fundAmount)
+		senderMedium := sys.FunderL2.NewFundedEOA(fundAmount)
+		senderLow := sys.FunderL2.NewFundedEOA(fundAmount)
+		senderNormal := sys.FunderL2.NewFundedEOA(fundAmount)
 
-	// Create a normal (non-boosted) recipient for comparison
-	normalRecipient := sys.Wallet.NewEOA(sys.L2EL)
-	normalRecipientAddr := normalRecipient.Address()
+		normalRecipient := sys.Wallet.NewEOA(sys.L2EL)
+		normalRecipientAddr := normalRecipient.Address()
 
-	logger.Info("Test accounts created",
-		"sender_high", senderHigh.Address().Hex(),
-		"sender_medium", senderMedium.Address().Hex(),
-		"sender_low", senderLow.Address().Hex(),
-		"sender_normal", senderNormal.Address().Hex(),
-		"high_priority_recipient", HighPriorityRecipient.Hex(),
-		"medium_priority_recipient", MediumPriorityRecipient.Hex(),
-		"low_priority_recipient", LowPriorityRecipient.Hex(),
-		"normal_recipient", normalRecipientAddr.Hex(),
-	)
+		sendAmount := eth.OneHundredthEther
+		var wg sync.WaitGroup
+		var txHigh, txMedium, txLow, txNormal *txplan.PlannedTx
 
-	// Send all transactions concurrently with the same value (to ensure fair comparison)
-	sendAmount := eth.OneHundredthEther
-	var wg sync.WaitGroup
-	var txHigh, txMedium, txLow, txNormal *txplan.PlannedTx
+		wg.Add(4)
+		go func() {
+			defer wg.Done()
+			txHigh = senderHigh.Transact(
+				senderHigh.Plan(),
+				txplan.WithTo(&HighPriorityRecipient),
+				txplan.WithValue(sendAmount),
+			)
+		}()
+		go func() {
+			defer wg.Done()
+			txMedium = senderMedium.Transact(
+				senderMedium.Plan(),
+				txplan.WithTo(&MediumPriorityRecipient),
+				txplan.WithValue(sendAmount),
+			)
+		}()
+		go func() {
+			defer wg.Done()
+			txLow = senderLow.Transact(
+				senderLow.Plan(),
+				txplan.WithTo(&LowPriorityRecipient),
+				txplan.WithValue(sendAmount),
+			)
+		}()
+		go func() {
+			defer wg.Done()
+			txNormal = senderNormal.Transact(
+				senderNormal.Plan(),
+				txplan.WithTo(&normalRecipientAddr),
+				txplan.WithValue(sendAmount),
+			)
+		}()
+		wg.Wait()
 
-	wg.Add(4)
+		receiptHigh, err := txHigh.Included.Eval(ctx)
+		if err != nil {
+			return fmt.Errorf("high priority tx inclusion: %w", err)
+		}
+		receiptMedium, err := txMedium.Included.Eval(ctx)
+		if err != nil {
+			return fmt.Errorf("medium priority tx inclusion: %w", err)
+		}
+		receiptLow, err := txLow.Included.Eval(ctx)
+		if err != nil {
+			return fmt.Errorf("low priority tx inclusion: %w", err)
+		}
+		receiptNormal, err := txNormal.Included.Eval(ctx)
+		if err != nil {
+			return fmt.Errorf("normal tx inclusion: %w", err)
+		}
 
-	// Transaction to high priority recipient (weight 5000)
-	go func() {
-		defer wg.Done()
-		txHigh = senderHigh.Transact(
-			senderHigh.Plan(),
-			txplan.WithTo(&HighPriorityRecipient),
-			txplan.WithValue(sendAmount),
+		logger.Info("All transactions confirmed",
+			"high_block", receiptHigh.BlockNumber, "high_index", receiptHigh.TransactionIndex,
+			"medium_block", receiptMedium.BlockNumber, "medium_index", receiptMedium.TransactionIndex,
+			"low_block", receiptLow.BlockNumber, "low_index", receiptLow.TransactionIndex,
+			"normal_block", receiptNormal.BlockNumber, "normal_index", receiptNormal.TransactionIndex,
 		)
-	}()
 
-	// Transaction to medium priority recipient (weight 2000)
-	go func() {
-		defer wg.Done()
-		txMedium = senderMedium.Transact(
-			senderMedium.Plan(),
-			txplan.WithTo(&MediumPriorityRecipient),
-			txplan.WithValue(sendAmount),
-		)
-	}()
+		sameBlock := receiptHigh.BlockNumber.Cmp(receiptMedium.BlockNumber) == 0 &&
+			receiptMedium.BlockNumber.Cmp(receiptLow.BlockNumber) == 0 &&
+			receiptLow.BlockNumber.Cmp(receiptNormal.BlockNumber) == 0
 
-	// Transaction to low priority recipient (weight 500)
-	go func() {
-		defer wg.Done()
-		txLow = senderLow.Transact(
-			senderLow.Plan(),
-			txplan.WithTo(&LowPriorityRecipient),
-			txplan.WithValue(sendAmount),
-		)
-	}()
+		if !sameBlock {
+			return fmt.Errorf("transactions landed in different blocks: high=%d, medium=%d, low=%d, normal=%d",
+				receiptHigh.BlockNumber, receiptMedium.BlockNumber, receiptLow.BlockNumber, receiptNormal.BlockNumber)
+		}
 
-	// Transaction to normal recipient (no boost, weight 0)
-	go func() {
-		defer wg.Done()
-		txNormal = senderNormal.Transact(
-			senderNormal.Plan(),
-			txplan.WithTo(&normalRecipientAddr),
-			txplan.WithValue(sendAmount),
-		)
-	}()
-
-	wg.Wait()
-
-	// Wait for all transactions to be included
-	receiptHigh, err := txHigh.Included.Eval(ctx)
-	require.NoError(t, err, "high priority tx should be included")
-	receiptMedium, err := txMedium.Included.Eval(ctx)
-	require.NoError(t, err, "medium priority tx should be included")
-	receiptLow, err := txLow.Included.Eval(ctx)
-	require.NoError(t, err, "low priority tx should be included")
-	receiptNormal, err := txNormal.Included.Eval(ctx)
-	require.NoError(t, err, "normal tx should be included")
-
-	logger.Info("All transactions confirmed",
-		"high_block", receiptHigh.BlockNumber, "high_index", receiptHigh.TransactionIndex,
-		"medium_block", receiptMedium.BlockNumber, "medium_index", receiptMedium.TransactionIndex,
-		"low_block", receiptLow.BlockNumber, "low_index", receiptLow.TransactionIndex,
-		"normal_block", receiptNormal.BlockNumber, "normal_index", receiptNormal.TransactionIndex,
-	)
-
-	// Verify ordering based on boost weights using transaction index in the block
-	// Lower TransactionIndex = earlier in the block = higher priority
-	sameBlock := receiptHigh.BlockNumber.Cmp(receiptMedium.BlockNumber) == 0 &&
-		receiptMedium.BlockNumber.Cmp(receiptLow.BlockNumber) == 0 &&
-		receiptLow.BlockNumber.Cmp(receiptNormal.BlockNumber) == 0
-
-	if sameBlock {
-		logger.Info("All transactions in same block - verifying boost ordering via transaction index")
-
-		// Verify ordering: high < medium < low < normal (lower index = earlier = higher priority)
 		require.Less(t, receiptHigh.TransactionIndex, receiptMedium.TransactionIndex,
 			"high priority (weight 5000) should have lower tx index than medium priority (weight 2000)")
 		require.Less(t, receiptMedium.TransactionIndex, receiptLow.TransactionIndex,
@@ -169,29 +154,9 @@ func TestBoostPriorityOrdering(gt *testing.T) {
 				receiptHigh.TransactionIndex, receiptMedium.TransactionIndex,
 				receiptLow.TransactionIndex, receiptNormal.TransactionIndex),
 		)
-	} else {
-		// Transactions in different blocks - compare transaction indices within blocks where applicable
-		logger.Info("Transactions in different blocks - comparing indices for transactions in same block",
-			"high_block", receiptHigh.BlockNumber,
-			"medium_block", receiptMedium.BlockNumber,
-			"low_block", receiptLow.BlockNumber,
-			"normal_block", receiptNormal.BlockNumber,
-		)
-
-		// If in same block, higher priority should have lower index
-		if receiptHigh.BlockNumber.Cmp(receiptMedium.BlockNumber) == 0 {
-			require.Less(t, receiptHigh.TransactionIndex, receiptMedium.TransactionIndex,
-				"high priority should have lower tx index than medium in same block")
-		}
-		if receiptMedium.BlockNumber.Cmp(receiptLow.BlockNumber) == 0 {
-			require.Less(t, receiptMedium.TransactionIndex, receiptLow.TransactionIndex,
-				"medium priority should have lower tx index than low in same block")
-		}
-		if receiptLow.BlockNumber.Cmp(receiptNormal.BlockNumber) == 0 {
-			require.Less(t, receiptLow.TransactionIndex, receiptNormal.TransactionIndex,
-				"low priority should have lower tx index than normal in same block")
-		}
-	}
+		return nil
+	})
+	require.NoError(t, err, "boost priority ordering verification failed")
 }
 
 // TestBoostedVsNonBoostedOrdering validates that a boosted transaction appears before
@@ -217,91 +182,71 @@ func TestBoostedVsNonBoostedOrdering(gt *testing.T) {
 	topLevelCtx, span := tracer.Start(ctx, "test boosted vs non-boosted ordering")
 	defer span.End()
 
-	ctx, cancel := context.WithTimeout(topLevelCtx, 60*time.Second)
+	ctx, cancel := context.WithTimeout(topLevelCtx, 90*time.Second)
 	defer cancel()
 
-	// Drive initial blocks
 	driveViaTestSequencer(t, sys, 2)
 
-	// Create two funded senders
-	fundAmount := eth.ThreeHundredthsEther
-	senderBoosted := sys.FunderL2.NewFundedEOA(fundAmount)
-	senderNormal := sys.FunderL2.NewFundedEOA(fundAmount)
+	lowGasTip := big.NewInt(1_000_000_000)
+	highGasTip := big.NewInt(100_000_000_000)
+	highGasFeeCap := big.NewInt(200_000_000_000)
 
-	// Create a normal recipient
-	normalRecipient := sys.Wallet.NewEOA(sys.L2EL)
-	normalRecipientAddr := normalRecipient.Address()
+	const maxRetries = 3
+	err := retry.Do0(ctx, maxRetries, &retry.FixedStrategy{Dur: 0}, func() error {
+		fundAmount := eth.ThreeHundredthsEther
+		senderBoosted := sys.FunderL2.NewFundedEOA(fundAmount)
+		senderNormal := sys.FunderL2.NewFundedEOA(fundAmount)
 
-	// Define gas fee parameters:
-	// - Low priority fee: 1 gwei (for boosted tx)
-	// - High priority fee: 100 gwei (for non-boosted tx) - 100x higher!
-	lowGasTip := big.NewInt(1_000_000_000)    // 1 gwei
-	highGasTip := big.NewInt(100_000_000_000) // 100 gwei
-	// Set fee cap high enough to cover base fee + tip
-	highGasFeeCap := big.NewInt(200_000_000_000) // 200 gwei
+		normalRecipient := sys.Wallet.NewEOA(sys.L2EL)
+		normalRecipientAddr := normalRecipient.Address()
 
-	logger.Info("Test accounts created",
-		"sender_boosted", senderBoosted.Address().Hex(),
-		"sender_normal", senderNormal.Address().Hex(),
-		"boosted_recipient", BoostedRecipient.Hex(),
-		"normal_recipient", normalRecipientAddr.Hex(),
-		"boosted_tx_gas_tip", lowGasTip.String(),
-		"normal_tx_gas_tip", highGasTip.String(),
-	)
+		sendAmount := eth.OneHundredthEther
+		var wg sync.WaitGroup
+		var txBoosted, txNormal *txplan.PlannedTx
 
-	// Send transactions concurrently
-	sendAmount := eth.OneHundredthEther
-	var wg sync.WaitGroup
-	var txBoosted, txNormal *txplan.PlannedTx
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			txBoosted = senderBoosted.Transact(
+				senderBoosted.Plan(),
+				txplan.WithTo(&BoostedRecipient),
+				txplan.WithValue(sendAmount),
+				txplan.WithGasTipCap(lowGasTip),
+			)
+		}()
+		go func() {
+			defer wg.Done()
+			txNormal = senderNormal.Transact(
+				senderNormal.Plan(),
+				txplan.WithTo(&normalRecipientAddr),
+				txplan.WithValue(sendAmount),
+				txplan.WithGasTipCap(highGasTip),
+				txplan.WithGasFeeCap(highGasFeeCap),
+			)
+		}()
+		wg.Wait()
 
-	wg.Add(2)
+		receiptBoosted, err := txBoosted.Included.Eval(ctx)
+		if err != nil {
+			return fmt.Errorf("boosted tx inclusion: %w", err)
+		}
+		receiptNormal, err := txNormal.Included.Eval(ctx)
+		if err != nil {
+			return fmt.Errorf("normal tx inclusion: %w", err)
+		}
 
-	// Transaction to boosted recipient (weight 1000) with LOW priority fee
-	go func() {
-		defer wg.Done()
-		txBoosted = senderBoosted.Transact(
-			senderBoosted.Plan(),
-			txplan.WithTo(&BoostedRecipient),
-			txplan.WithValue(sendAmount),
-			txplan.WithGasTipCap(lowGasTip),
+		logger.Info("Transactions confirmed",
+			"boosted_block", receiptBoosted.BlockNumber,
+			"boosted_index", receiptBoosted.TransactionIndex,
+			"normal_block", receiptNormal.BlockNumber,
+			"normal_index", receiptNormal.TransactionIndex,
 		)
-	}()
 
-	// Transaction to normal recipient (no boost) with HIGH priority fee
-	// This tx has 100x higher gas tip but should still come AFTER the boosted tx
-	go func() {
-		defer wg.Done()
-		txNormal = senderNormal.Transact(
-			senderNormal.Plan(),
-			txplan.WithTo(&normalRecipientAddr),
-			txplan.WithValue(sendAmount),
-			txplan.WithGasTipCap(highGasTip),
-			txplan.WithGasFeeCap(highGasFeeCap),
-		)
-	}()
+		if receiptBoosted.BlockNumber.Cmp(receiptNormal.BlockNumber) != 0 {
+			return fmt.Errorf("transactions landed in different blocks: boosted=%d, normal=%d",
+				receiptBoosted.BlockNumber, receiptNormal.BlockNumber)
+		}
 
-	wg.Wait()
-
-	// Wait for transactions to be included
-	receiptBoosted, err := txBoosted.Included.Eval(ctx)
-	require.NoError(t, err, "boosted tx should be included")
-	receiptNormal, err := txNormal.Included.Eval(ctx)
-	require.NoError(t, err, "normal tx should be included")
-
-	logger.Info("Transactions confirmed",
-		"boosted_hash", receiptBoosted.TxHash.Hex(),
-		"boosted_block", receiptBoosted.BlockNumber,
-		"boosted_index", receiptBoosted.TransactionIndex,
-		"boosted_gas_tip", "1 gwei",
-		"normal_hash", receiptNormal.TxHash.Hex(),
-		"normal_block", receiptNormal.BlockNumber,
-		"normal_index", receiptNormal.TransactionIndex,
-		"normal_gas_tip", "100 gwei",
-	)
-
-	// If both transactions are in the same block, boosted should have lower index (come first)
-	// DESPITE the normal tx having 100x higher gas tip
-	if receiptBoosted.BlockNumber.Cmp(receiptNormal.BlockNumber) == 0 {
 		require.Less(t, receiptBoosted.TransactionIndex, receiptNormal.TransactionIndex,
 			"boosted transaction (weight 1000, 1 gwei tip) should have lower tx index than "+
 				"normal transaction (no boost, 100 gwei tip) - proving rules > gas priority")
@@ -309,16 +254,10 @@ func TestBoostedVsNonBoostedOrdering(gt *testing.T) {
 		logger.Info("Rule-based boost precedence over gas priority verified!",
 			"boosted_index", receiptBoosted.TransactionIndex,
 			"normal_index", receiptNormal.TransactionIndex,
-			"boosted_gas_tip", "1 gwei",
-			"normal_gas_tip", "100 gwei",
-			"conclusion", "rules-based ordering takes precedence over economic incentives",
 		)
-	} else {
-		logger.Info("Transactions in different blocks - ordering verification skipped",
-			"boosted_block", receiptBoosted.BlockNumber,
-			"normal_block", receiptNormal.BlockNumber,
-		)
-	}
+		return nil
+	})
+	require.NoError(t, err, "boosted vs non-boosted ordering verification failed")
 }
 
 // TestSameSenderNonceOrdering verifies that transactions from the same sender
@@ -430,19 +369,11 @@ func TestMultipleSendersWithMixedPriorities(gt *testing.T) {
 	topLevelCtx, span := tracer.Start(ctx, "test multiple senders mixed priorities")
 	defer span.End()
 
-	ctx, cancel := context.WithTimeout(topLevelCtx, 90*time.Second)
+	ctx, cancel := context.WithTimeout(topLevelCtx, 120*time.Second)
 	defer cancel()
 
-	// Drive initial blocks (use 2 to avoid timestamp drift exceeding 5s gossip threshold)
 	driveViaTestSequencer(t, sys, 2)
 
-	fundAmount := eth.ThreeHundredthsEther
-
-	// Create normal recipient for non-boosted transactions
-	normalRecipient := sys.Wallet.NewEOA(sys.L2EL)
-	normalRecipientAddr := normalRecipient.Address()
-
-	// Create senders with their target recipients and weights
 	type senderConfig struct {
 		eoa       *dsl.EOA
 		priority  string
@@ -450,110 +381,115 @@ func TestMultipleSendersWithMixedPriorities(gt *testing.T) {
 		weight    int
 	}
 
-	configs := []struct {
-		priority  string
-		recipient common.Address
-		weight    int
-	}{
-		{"high", HighPriorityRecipient, 5000},
-		{"medium", MediumPriorityRecipient, 2000},
-		{"low", LowPriorityRecipient, 500},
-		{"normal", normalRecipientAddr, 0},
-		{"high", HighPriorityRecipient, 5000},
-		{"normal", normalRecipientAddr, 0},
-	}
-
-	senders := make([]senderConfig, len(configs))
-	for i, cfg := range configs {
-		eoa := sys.FunderL2.NewFundedEOA(fundAmount)
-		senders[i] = senderConfig{
-			eoa:       eoa,
-			priority:  cfg.priority,
-			recipient: cfg.recipient,
-			weight:    cfg.weight,
-		}
-		logger.Debug("Created sender",
-			"index", i,
-			"address", eoa.Address().Hex(),
-			"priority", cfg.priority,
-			"recipient", cfg.recipient.Hex(),
-		)
-	}
-
-	// Send all transactions concurrently
-	sendAmount := eth.OneHundredthEther
-	var wg sync.WaitGroup
-	plannedTxs := make([]*txplan.PlannedTx, len(senders))
-
-	for i := range senders {
-		wg.Add(1)
-		idx := i
-		go func() {
-			defer wg.Done()
-			recipient := senders[idx].recipient
-			plannedTxs[idx] = senders[idx].eoa.Transact(
-				senders[idx].eoa.Plan(),
-				txplan.WithTo(&recipient),
-				txplan.WithValue(sendAmount),
-			)
-		}()
-	}
-	wg.Wait()
-
-	// Wait for all to be included and collect results
 	type txResult struct {
 		receipt  *types.Receipt
 		priority string
 		weight   int
 	}
-	results := make([]txResult, len(senders))
 
-	for i := range senders {
-		receipt, err := plannedTxs[i].Included.Eval(ctx)
-		require.NoError(t, err, fmt.Sprintf("tx%d should be included", i))
-		results[i] = txResult{
-			receipt:  receipt,
-			priority: senders[i].priority,
-			weight:   senders[i].weight,
-		}
-		logger.Info("Transaction confirmed",
-			"index", i,
-			"priority", senders[i].priority,
-			"weight", senders[i].weight,
-			"block", receipt.BlockNumber,
-			"tx_index", receipt.TransactionIndex,
-		)
-	}
+	const maxRetries = 3
+	err := retry.Do0(ctx, maxRetries, &retry.FixedStrategy{Dur: 0}, func() error {
+		fundAmount := eth.ThreeHundredthsEther
 
-	// Group by block and verify ordering within each block
-	blockGroups := make(map[uint64][]txResult)
-	for _, r := range results {
-		blockNum := r.receipt.BlockNumber.Uint64()
-		blockGroups[blockNum] = append(blockGroups[blockNum], r)
-	}
+		normalRecipient := sys.Wallet.NewEOA(sys.L2EL)
+		normalRecipientAddr := normalRecipient.Address()
 
-	for blockNum, txs := range blockGroups {
-		if len(txs) < 2 {
-			continue
+		configs := []struct {
+			priority  string
+			recipient common.Address
+			weight    int
+		}{
+			{"high", HighPriorityRecipient, 5000},
+			{"medium", MediumPriorityRecipient, 2000},
+			{"low", LowPriorityRecipient, 500},
+			{"normal", normalRecipientAddr, 0},
+			{"high", HighPriorityRecipient, 5000},
+			{"normal", normalRecipientAddr, 0},
 		}
 
-		logger.Info("Verifying ordering in block", "block", blockNum, "tx_count", len(txs))
+		senders := make([]senderConfig, len(configs))
+		for i, cfg := range configs {
+			senders[i] = senderConfig{
+				eoa:       sys.FunderL2.NewFundedEOA(fundAmount),
+				priority:  cfg.priority,
+				recipient: cfg.recipient,
+				weight:    cfg.weight,
+			}
+		}
 
-		// Within the same block, higher weight should mean lower tx index
-		for i := 0; i < len(txs); i++ {
-			for j := i + 1; j < len(txs); j++ {
-				if txs[i].weight > txs[j].weight {
-					require.Less(t, txs[i].receipt.TransactionIndex, txs[j].receipt.TransactionIndex,
-						"tx with weight %d should have lower index than tx with weight %d in block %d",
-						txs[i].weight, txs[j].weight, blockNum)
-				} else if txs[i].weight < txs[j].weight {
-					require.Greater(t, txs[i].receipt.TransactionIndex, txs[j].receipt.TransactionIndex,
-						"tx with weight %d should have higher index than tx with weight %d in block %d",
-						txs[i].weight, txs[j].weight, blockNum)
+		sendAmount := eth.OneHundredthEther
+		var wg sync.WaitGroup
+		plannedTxs := make([]*txplan.PlannedTx, len(senders))
+
+		for i := range senders {
+			wg.Add(1)
+			idx := i
+			go func() {
+				defer wg.Done()
+				recipient := senders[idx].recipient
+				plannedTxs[idx] = senders[idx].eoa.Transact(
+					senders[idx].eoa.Plan(),
+					txplan.WithTo(&recipient),
+					txplan.WithValue(sendAmount),
+				)
+			}()
+		}
+		wg.Wait()
+
+		results := make([]txResult, len(senders))
+		for i := range senders {
+			receipt, err := plannedTxs[i].Included.Eval(ctx)
+			if err != nil {
+				return fmt.Errorf("tx%d inclusion: %w", i, err)
+			}
+			results[i] = txResult{
+				receipt:  receipt,
+				priority: senders[i].priority,
+				weight:   senders[i].weight,
+			}
+			logger.Info("Transaction confirmed",
+				"index", i,
+				"priority", senders[i].priority,
+				"weight", senders[i].weight,
+				"block", receipt.BlockNumber,
+				"tx_index", receipt.TransactionIndex,
+			)
+		}
+
+		blockGroups := make(map[uint64][]txResult)
+		for _, r := range results {
+			blockNum := r.receipt.BlockNumber.Uint64()
+			blockGroups[blockNum] = append(blockGroups[blockNum], r)
+		}
+
+		if len(blockGroups) != 1 {
+			blockNumbers := make([]uint64, 0, len(blockGroups))
+			for blockNum := range blockGroups {
+				blockNumbers = append(blockNumbers, blockNum)
+			}
+			return fmt.Errorf("transactions landed in %d different blocks: %v", len(blockGroups), blockNumbers)
+		}
+
+		for blockNum, txs := range blockGroups {
+			logger.Info("Verifying ordering in block", "block", blockNum, "tx_count", len(txs))
+
+			for i := 0; i < len(txs); i++ {
+				for j := i + 1; j < len(txs); j++ {
+					if txs[i].weight > txs[j].weight {
+						require.Less(t, txs[i].receipt.TransactionIndex, txs[j].receipt.TransactionIndex,
+							"tx with weight %d should have lower index than tx with weight %d in block %d",
+							txs[i].weight, txs[j].weight, blockNum)
+					} else if txs[i].weight < txs[j].weight {
+						require.Greater(t, txs[i].receipt.TransactionIndex, txs[j].receipt.TransactionIndex,
+							"tx with weight %d should have higher index than tx with weight %d in block %d",
+							txs[i].weight, txs[j].weight, blockNum)
+					}
 				}
 			}
 		}
-	}
 
-	logger.Info("Multiple senders mixed priorities test completed")
+		logger.Info("Multiple senders mixed priorities test completed successfully")
+		return nil
+	})
+	require.NoError(t, err, "multiple senders mixed priorities verification failed")
 }

--- a/op-devstack/dsl/fb_ws_client.go
+++ b/op-devstack/dsl/fb_ws_client.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"net"
 	"net/http"
 	"time"
 
@@ -112,11 +114,38 @@ func websocketListenFor(ctx context.Context, logger log.Logger, wsURL string, he
 				return nil
 			}
 
+			// Check for close errors first - these are normal termination
 			if websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway, websocket.CloseNoStatusReceived) {
 				logger.Info("WebSocket connection closed by peer", "total_messages", messageCount)
 				return nil
 			}
 
+			// Check if this is an unexpected close error (any close error not handled above)
+			var closeErr *websocket.CloseError
+			if errors.As(err, &closeErr) {
+				logger.Info("WebSocket connection closed unexpectedly", "code", closeErr.Code, "text", closeErr.Text, "total_messages", messageCount)
+				return nil
+			}
+
+			// Check for EOF errors - connection was closed
+			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+				logger.Info("WebSocket connection closed (EOF)", "total_messages", messageCount)
+				return nil
+			}
+
+			// Check for use of closed network connection
+			if errors.Is(err, net.ErrClosed) {
+				logger.Info("WebSocket connection closed (network)", "total_messages", messageCount)
+				return nil
+			}
+
+			// Handle timeout errors - only continue if we haven't received any other error type
+			var netErr net.Error
+			if errors.As(err, &netErr) && netErr.Timeout() {
+				continue
+			}
+
+			// Any other error means the connection is broken - do not attempt to read again
 			logger.Error("Error reading WebSocket message", "error", err, "message_count", messageCount)
 			return fmt.Errorf("error reading WebSocket message: %w", err)
 		}

--- a/op-devstack/dsl/fb_ws_client.go
+++ b/op-devstack/dsl/fb_ws_client.go
@@ -139,7 +139,7 @@ func websocketListenFor(ctx context.Context, logger log.Logger, wsURL string, he
 				return nil
 			}
 
-			// Handle timeout errors - only continue if we haven't received any other error type
+			// Timeout errors are recoverable - keep reading
 			var netErr net.Error
 			if errors.As(err, &netErr) && netErr.Timeout() {
 				continue

--- a/op-devstack/presets/flashblocks.go
+++ b/op-devstack/presets/flashblocks.go
@@ -88,13 +88,3 @@ func NewSingleChainWithFlashblocks(t devtest.T) *SingleChainWithFlashblocks {
 	out.FunderL2 = dsl.NewFunder(out.Wallet, out.FaucetL2, out.L2EL)
 	return out
 }
-
-// NewSingleChainWithFlashblocksAndRules creates a SingleChainWithFlashblocks preset with rules enabled.
-// The rulesConfig specifies the path to the rules configuration file.
-// Note: This function expects the orchestrator to be initialized via DoMain with
-// WithSingleChainSystemWithFlashblocksAndRules(rulesConfig) option.
-func NewSingleChainWithFlashblocksAndRules(t devtest.T) *SingleChainWithFlashblocks {
-	// This uses the same orchestrator as NewSingleChainWithFlashblocks
-	// The rules configuration is set via TestMain using WithSingleChainSystemWithFlashblocksAndRules
-	return NewSingleChainWithFlashblocks(t)
-}

--- a/op-devstack/presets/flashblocks.go
+++ b/op-devstack/presets/flashblocks.go
@@ -45,6 +45,11 @@ func WithSingleChainSystemWithFlashblocks() stack.CommonOption {
 	return stack.MakeCommon(sysgo.DefaultSingleChainSystemWithFlashblocks(&sysgo.SingleChainSystemWithFlashblocksIDs{}))
 }
 
+// WithSingleChainSystemWithFlashblocksAndRules creates a flashblocks system with rules enabled
+func WithSingleChainSystemWithFlashblocksAndRules(rulesConfig sysgo.RulesConfig) stack.CommonOption {
+	return stack.MakeCommon(sysgo.DefaultSingleChainSystemWithFlashblocksAndRules(&sysgo.SingleChainSystemWithFlashblocksIDs{}, rulesConfig))
+}
+
 func NewSingleChainWithFlashblocks(t devtest.T) *SingleChainWithFlashblocks {
 	system := shim.NewSystem(t)
 	orch := Orchestrator()
@@ -82,4 +87,14 @@ func NewSingleChainWithFlashblocks(t devtest.T) *SingleChainWithFlashblocks {
 	out.FunderL1 = dsl.NewFunder(out.Wallet, out.FaucetL1, out.L1EL)
 	out.FunderL2 = dsl.NewFunder(out.Wallet, out.FaucetL2, out.L2EL)
 	return out
+}
+
+// NewSingleChainWithFlashblocksAndRules creates a SingleChainWithFlashblocks preset with rules enabled.
+// The rulesConfig specifies the path to the rules configuration file.
+// Note: This function expects the orchestrator to be initialized via DoMain with
+// WithSingleChainSystemWithFlashblocksAndRules(rulesConfig) option.
+func NewSingleChainWithFlashblocksAndRules(t devtest.T) *SingleChainWithFlashblocks {
+	// This uses the same orchestrator as NewSingleChainWithFlashblocks
+	// The rules configuration is set via TestMain using WithSingleChainSystemWithFlashblocksAndRules
+	return NewSingleChainWithFlashblocks(t)
 }

--- a/op-devstack/sysgo/system.go
+++ b/op-devstack/sysgo/system.go
@@ -618,13 +618,35 @@ func DefaultSingleChainSystemWithFlashblocks(dest *SingleChainSystemWithFlashblo
 }
 
 func singleChainSystemWithFlashblocksOpts(ids *SingleChainSystemWithFlashblocksIDs, dest *SingleChainSystemWithFlashblocksIDs) stack.CombinedOption[*Orchestrator] {
+	return singleChainSystemWithFlashblocksOptsInternal(ids, dest, nil)
+}
+
+// RulesConfig holds configuration for rule-based block building
+type RulesConfig struct {
+	// Enabled determines if rules are enabled
+	Enabled bool
+	// ConfigPath is the path to the rules registry configuration file
+	ConfigPath string
+}
+
+// DefaultSingleChainSystemWithFlashblocksAndRules creates a flashblocks system with rules enabled
+func DefaultSingleChainSystemWithFlashblocksAndRules(dest *SingleChainSystemWithFlashblocksIDs, rulesConfig RulesConfig) stack.Option[*Orchestrator] {
+	ids := NewDefaultSingleChainSystemWithFlashblocksIDs(DefaultL1ID, DefaultL2AID)
+	return singleChainSystemWithFlashblocksOptsInternal(&ids, dest, &rulesConfig)
+}
+
+func singleChainSystemWithFlashblocksOptsInternal(ids *SingleChainSystemWithFlashblocksIDs, dest *SingleChainSystemWithFlashblocksIDs, rulesConfig *RulesConfig) stack.CombinedOption[*Orchestrator] {
 	opt := stack.Combine[*Orchestrator]()
 	// Precompute deterministic P2P identity and peering between sequencer EL and op-rbuilder EL.
 	seqID := NewELNodeIdentity(0)
 	builderID := NewELNodeIdentity(0) // allocate dynamic port for builder
 
 	opt.Add(stack.BeforeDeploy(func(o *Orchestrator) {
-		o.P().Logger().Info("Setting up")
+		if rulesConfig != nil && rulesConfig.Enabled {
+			o.P().Logger().Info("Setting up flashblocks system with rules", "rules_config", rulesConfig.ConfigPath)
+		} else {
+			o.P().Logger().Info("Setting up flashblocks system")
+		}
 	}))
 
 	opt.Add(WithMnemonicKeys(devkeys.TestMnemonic))
@@ -640,11 +662,19 @@ func singleChainSystemWithFlashblocksOpts(ids *SingleChainSystemWithFlashblocksI
 	opt.Add(WithL1Nodes(ids.L1EL, ids.L1CL))
 
 	opt.Add(WithL2ELNode(ids.L2EL, L2ELWithP2PConfig("127.0.0.1", seqID.Port, seqID.KeyHex(), nil, nil)))
-	opt.Add(WithOPRBuilderNode(ids.L2Builder, OPRBuilderWithNodeIdentity(builderID, "127.0.0.1", nil, nil)))
 	// Sequencer adds builder as regular static peer (not trusted)
 	opt.Add(WithL2ELP2PConnection(ids.L2EL, stack.L2ELNodeID(ids.L2Builder), false))
 	// Builder adds sequencer as trusted peer
 	opt.Add(WithL2ELP2PConnection(stack.L2ELNodeID(ids.L2Builder), ids.L2EL, true))
+
+	// Configure OPRBuilder with rules if enabled
+	builderOpts := []OPRBuilderNodeOption{
+		OPRBuilderWithNodeIdentity(builderID, "127.0.0.1", nil, nil),
+	}
+	if rulesConfig != nil && rulesConfig.Enabled && rulesConfig.ConfigPath != "" {
+		builderOpts = append(builderOpts, OPRBuilderNodeWithExtraArgs("--rules.enabled", "--rules.config-path="+rulesConfig.ConfigPath))
+	}
+	opt.Add(WithOPRBuilderNode(ids.L2Builder, builderOpts...))
 	opt.Add(WithRollupBoost(ids.L2RollupBoost, ids.L2EL, RollupBoostWithBuilderNode(ids.L2Builder)))
 
 	opt.Add(WithL2CLNode(ids.L2CL, ids.L1CL, ids.L1EL, stack.L2ELNodeID(ids.L2RollupBoost), L2CLSequencer()))

--- a/op-devstack/sysgo/system.go
+++ b/op-devstack/sysgo/system.go
@@ -662,10 +662,6 @@ func singleChainSystemWithFlashblocksOptsInternal(ids *SingleChainSystemWithFlas
 	opt.Add(WithL1Nodes(ids.L1EL, ids.L1CL))
 
 	opt.Add(WithL2ELNode(ids.L2EL, L2ELWithP2PConfig("127.0.0.1", seqID.Port, seqID.KeyHex(), nil, nil)))
-	// Sequencer adds builder as regular static peer (not trusted)
-	opt.Add(WithL2ELP2PConnection(ids.L2EL, stack.L2ELNodeID(ids.L2Builder), false))
-	// Builder adds sequencer as trusted peer
-	opt.Add(WithL2ELP2PConnection(stack.L2ELNodeID(ids.L2Builder), ids.L2EL, true))
 
 	// Configure OPRBuilder with rules if enabled
 	builderOpts := []OPRBuilderNodeOption{
@@ -675,6 +671,12 @@ func singleChainSystemWithFlashblocksOptsInternal(ids *SingleChainSystemWithFlas
 		builderOpts = append(builderOpts, OPRBuilderNodeWithExtraArgs("--rules.enabled", "--rules.config-path="+rulesConfig.ConfigPath))
 	}
 	opt.Add(WithOPRBuilderNode(ids.L2Builder, builderOpts...))
+
+	// P2P connections must be added AFTER WithOPRBuilderNode so the builder exists
+	// Sequencer adds builder as regular static peer (not trusted)
+	opt.Add(WithL2ELP2PConnection(ids.L2EL, stack.L2ELNodeID(ids.L2Builder), false))
+	// Builder adds sequencer as trusted peer
+	opt.Add(WithL2ELP2PConnection(stack.L2ELNodeID(ids.L2Builder), ids.L2EL, true))
 	opt.Add(WithRollupBoost(ids.L2RollupBoost, ids.L2EL, RollupBoostWithBuilderNode(ids.L2Builder)))
 
 	opt.Add(WithL2CLNode(ids.L2CL, ids.L1CL, ids.L1EL, stack.L2ELNodeID(ids.L2RollupBoost), L2CLSequencer()))


### PR DESCRIPTION
**Description**

This PR adds new flashblock acceptance tests for op-rbuilder with rule-based ordering. 
This allows op-rbuilder to score individual transaction based on some specific ruleset, and include the transactions with the score ordering. 

See corresponding op-rbuilder PR for more detail: https://github.com/ethereum-optimism/op-rbuilder/pull/1

To run these new tests, set flag like this: 
```
export OP_RBUILDER_EXEC_PATH=OP_RBUILDER_PATH
export ROLLUP_BOOST_EXEC_PATH=ROLLUP_BOOST_PATH
FLASHBLOCKS_RULES_TEST=1 just acceptance-test "" flashblocks
```

