### PR TITLE
op-supernode: Update Chain Container Interfaces

### DIFF
--- a/op-supernode/supernode/activity/superroot/superroot_test.go
+++ b/op-supernode/supernode/activity/superroot/superroot_test.go
@@ -31,7 +31,7 @@ func (m *mockCC) Stop(ctx context.Context) error   { return nil }
 func (m *mockCC) Pause(ctx context.Context) error  { return nil }
 func (m *mockCC) Resume(ctx context.Context) error { return nil }
 
-func (m *mockCC) SafeBlockAtTimestamp(ctx context.Context, ts uint64) (eth.L2BlockRef, error) {
+func (m *mockCC) BlockAtTimestamp(ctx context.Context, ts uint64, label eth.BlockLabel) (eth.L2BlockRef, error) {
 	return eth.L2BlockRef{}, nil
 }
 func (m *mockCC) SyncStatus(ctx context.Context) (*eth.SyncStatus, error) {

--- a/op-supernode/supernode/chain_container/chain_container.go
+++ b/op-supernode/supernode/chain_container/chain_container.go
@@ -29,15 +29,11 @@ type ChainContainer interface {
 	Pause(ctx context.Context) error
 	Resume(ctx context.Context) error
 
-	SafeBlockAtTimestamp(ctx context.Context, ts uint64) (eth.L2BlockRef, error)
+	BlockAtTimestamp(ctx context.Context, ts uint64, label eth.BlockLabel) (eth.L2BlockRef, error)
 	SyncStatus(ctx context.Context) (*eth.SyncStatus, error)
-	SafeHeadAtL1(ctx context.Context, l1BlockNum uint64) (l1 eth.BlockID, l2 eth.BlockID, err error)
-	// L1AtSafeHead returns the earliest L1 block at which the given L2 block became safe.
-	L1AtSafeHead(ctx context.Context, l2 eth.BlockID) (eth.BlockID, error)
 	VerifiedAt(ctx context.Context, ts uint64) (l2, l1 eth.BlockID, err error)
 	OptimisticAt(ctx context.Context, ts uint64) (l2, l1 eth.BlockID, err error)
 	OutputRootAtL2BlockNumber(ctx context.Context, l2BlockNum uint64) (eth.Bytes32, error)
-	// OptimisticOutputAtTimestamp returns the full Output at the optimistic L2 block for the given timestamp.
 	OptimisticOutputAtTimestamp(ctx context.Context, ts uint64) (*eth.OutputResponse, error)
 }
 
@@ -224,12 +220,13 @@ func (c *simpleChainContainer) Resume(ctx context.Context) error {
 	return nil
 }
 
-// SafeBlockAtTimestamp returns the highest SAFE L2 block with timestamp <= ts using the L2 client.
-func (c *simpleChainContainer) SafeBlockAtTimestamp(ctx context.Context, ts uint64) (eth.L2BlockRef, error) {
+// BlockAtTimestamp returns the highest L2 block with timestamp <= ts using the L2 client,
+// if the specified label contains a block at that timestamp
+func (c *simpleChainContainer) BlockAtTimestamp(ctx context.Context, ts uint64, label eth.BlockLabel) (eth.L2BlockRef, error) {
 	if c.engine == nil {
 		return eth.L2BlockRef{}, engine_controller.ErrNoEngineClient
 	}
-	return c.engine.SafeBlockAtTimestamp(ctx, ts)
+	return c.engine.BlockAtTimestamp(ctx, ts, label)
 }
 
 // SyncStatus returns the in-process op-node sync status for this chain.
@@ -259,16 +256,8 @@ func (c *simpleChainContainer) OutputRootAtL2BlockNumber(ctx context.Context, l2
 	return eth.OutputRoot(out), nil
 }
 
-// SafeHeadAtL1 queries the embedded op-node RPC handler for the SafeDB mapping at/preceding the given L1 block number.
-func (c *simpleChainContainer) SafeHeadAtL1(ctx context.Context, l1BlockNum uint64) (eth.BlockID, eth.BlockID, error) {
-	if c.vn == nil {
-		return eth.BlockID{}, eth.BlockID{}, fmt.Errorf("virtual node not initialized")
-	}
-	return c.vn.SafeHeadAtL1(ctx, l1BlockNum)
-}
-
-// L1AtSafeHead delegates to the virtual node to resolve the earliest L1 at which the L2 became safe.
-func (c *simpleChainContainer) L1AtSafeHead(ctx context.Context, l2 eth.BlockID) (eth.BlockID, error) {
+// safeDBAtL2 delegates to the virtual node to resolve the earliest L1 at which the L2 became safe.
+func (c *simpleChainContainer) safeDBAtL2(ctx context.Context, l2 eth.BlockID) (eth.BlockID, error) {
 	if c.vn == nil {
 		return eth.BlockID{}, fmt.Errorf("virtual node not initialized")
 	}
@@ -278,12 +267,12 @@ func (c *simpleChainContainer) L1AtSafeHead(ctx context.Context, l2 eth.BlockID)
 // VerifiedAt returns the verified L2 and L1 blocks for the given L2 timestamp.
 // Must return ethereum.NotFound if there is no safe block at the specified timestamp.
 func (c *simpleChainContainer) VerifiedAt(ctx context.Context, ts uint64) (l2, l1 eth.BlockID, err error) {
-	l2Block, err := c.SafeBlockAtTimestamp(ctx, ts)
+	l2Block, err := c.BlockAtTimestamp(ctx, ts, eth.Safe)
 	if err != nil {
 		c.log.Error("error determining l2 block at given timestamp", "error", err)
 		return eth.BlockID{}, eth.BlockID{}, err
 	}
-	l1Block, err := c.L1AtSafeHead(ctx, l2Block.ID())
+	l1Block, err := c.safeDBAtL2(ctx, l2Block.ID())
 	if err != nil {
 		c.log.Error("error determining l1 block number at which l2 block became safe", "error", err)
 		return eth.BlockID{}, eth.BlockID{}, err
@@ -296,12 +285,12 @@ func (c *simpleChainContainer) VerifiedAt(ctx context.Context, ts uint64) (l2, l
 
 // OptimisticAt returns the optimistic (pre-verified) L2 and L1 blocks for the given L2 timestamp.
 func (c *simpleChainContainer) OptimisticAt(ctx context.Context, ts uint64) (l2, l1 eth.BlockID, err error) {
-	l2Block, err := c.SafeBlockAtTimestamp(ctx, ts)
+	l2Block, err := c.BlockAtTimestamp(ctx, ts, eth.Safe)
 	if err != nil {
 		c.log.Error("error determining l2 block at given timestamp", "error", err)
 		return eth.BlockID{}, eth.BlockID{}, err
 	}
-	l1Block, err := c.L1AtSafeHead(ctx, l2Block.ID())
+	l1Block, err := c.safeDBAtL2(ctx, l2Block.ID())
 	if err != nil {
 		c.log.Error("error determining l1 block number at which l2 block became safe", "error", err)
 		return eth.BlockID{}, eth.BlockID{}, err
@@ -319,7 +308,7 @@ func (c *simpleChainContainer) OptimisticOutputAtTimestamp(ctx context.Context, 
 		return nil, fmt.Errorf("rollup client not initialized")
 	}
 	// Determine the optimistic L2 block at timestamp (currently same as safe block at ts)
-	l2Block, err := c.SafeBlockAtTimestamp(ctx, ts)
+	l2Block, err := c.BlockAtTimestamp(ctx, ts, eth.Safe)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve L2 block at timestamp: %w", err)
 	}

--- a/op-supernode/supernode/chain_container/engine_controller/engine_controller.go
+++ b/op-supernode/supernode/chain_container/engine_controller/engine_controller.go
@@ -15,10 +15,10 @@ import (
 
 // EngineController abstracts access to the L2 execution layer
 type EngineController interface {
-	// SafeBlockAtTimestamp returns the L2 block ref for the block at or before the given timestamp,
-	// clamped to the current SAFE head.
-	// Must return ethereum.NotFound if there is no safe block at the specified timestamp.
-	SafeBlockAtTimestamp(ctx context.Context, ts uint64) (eth.L2BlockRef, error)
+	// BlockAtTimestamp returns the L2 block ref for the block at or before the given timestamp,
+	// clamped to the head of the specified label (Safe, Finalized, Unsafe).
+	// Must return ethereum.NotFound if there is no block at the specified timestamp for the given label.
+	BlockAtTimestamp(ctx context.Context, ts uint64, label eth.BlockLabel) (eth.L2BlockRef, error)
 	// OutputV0AtBlockNumber returns the output preimage for the given L2 block number.
 	OutputV0AtBlockNumber(ctx context.Context, num uint64) (*eth.OutputV0, error)
 	// Close releases any underlying RPC resources.
@@ -64,9 +64,9 @@ var (
 	ErrNoRollupConfig = errors.New("rollup config not available")
 )
 
-// SafeBlockAtTimestamp returns the L2 block ref for the block at or before the given timestamp,
-// clamped to the current SAFE head. Must return ethereum.NotFound if no safe block is available at the timestamp.
-func (e *simpleEngineController) SafeBlockAtTimestamp(ctx context.Context, ts uint64) (eth.L2BlockRef, error) {
+// BlockAtTimestamp returns the L2 block ref for the block at or before the given timestamp,
+// clamped to the head of the specified label. Must return ethereum.NotFound if no block is available at the timestamp.
+func (e *simpleEngineController) BlockAtTimestamp(ctx context.Context, ts uint64, label eth.BlockLabel) (eth.L2BlockRef, error) {
 	if e.l2 == nil {
 		return eth.L2BlockRef{}, ErrNoEngineClient
 	}
@@ -78,16 +78,16 @@ func (e *simpleEngineController) SafeBlockAtTimestamp(ctx context.Context, ts ui
 	if err != nil {
 		return eth.L2BlockRef{}, err
 	}
-	safeHead, err := e.l2.L2BlockRefByLabel(ctx, eth.Safe)
+	head, err := e.l2.L2BlockRefByLabel(ctx, label)
 	if err != nil {
 		return eth.L2BlockRef{}, err
 	}
-	if num > safeHead.Number {
-		e.log.Warn("engine_controller: target block number exceeds safe head", "targetBlockNumber", num, "safeHead", safeHead.Number)
+	if num > head.Number {
+		e.log.Warn("engine_controller: target block number exceeds head", "label", label, "targetBlockNumber", num, "head", head.Number)
 		return eth.L2BlockRef{}, ethereum.NotFound
 	}
-	e.log.Debug("engine_controller: computed safe block number from timestamp",
-		"timestamp", ts, "targetBlockNumber", num, "safeHead", safeHead.Number, "safeHeadErr", err)
+	e.log.Debug("engine_controller: computed block number from timestamp",
+		"label", label, "timestamp", ts, "targetBlockNumber", num, "head", head.Number)
 	return e.l2.L2BlockRefByNumber(ctx, num)
 }
 

--- a/op-supernode/supernode/chain_container/engine_controller/engine_controller_test.go
+++ b/op-supernode/supernode/chain_container/engine_controller/engine_controller_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// unified mock covers both payload/output paths and SafeBlockAtTimestamp path
+// unified mock covers both payload/output paths and BlockAtTimestamp path
 
 func TestOutputV0AtBlockNumber_UsesPayloadWhenAvailable(t *testing.T) {
 	t.Parallel()
@@ -89,22 +89,22 @@ func TestEngineController_TargetBlockNumber(t *testing.T) {
 	ec := &simpleEngineController{l2: m, rollup: rcfg, log: gethlog.New()}
 
 	// ts = genesis + 2*3 => block #3, with safe head above target
-	numRef, err := ec.SafeBlockAtTimestamp(context.Background(), 1_000+2*3)
+	numRef, err := ec.BlockAtTimestamp(context.Background(), 1_000+2*3, eth.Safe)
 	require.NoError(t, err)
 	require.Equal(t, uint64(3), m.lastNum)
 	require.Equal(t, m.ref, numRef)
 	// ts = genesis + 2*1000 => block #1000, with safe head now below target
-	_, err = ec.SafeBlockAtTimestamp(context.Background(), 1_000+2*1000)
+	_, err = ec.BlockAtTimestamp(context.Background(), 1_000+2*1000, eth.Safe)
 	require.ErrorIs(t, err, ethereum.NotFound)
 }
 
 func TestEngineController_SentinelErrors(t *testing.T) {
 	t.Parallel()
 	ec := &simpleEngineController{l2: nil, rollup: nil}
-	_, err := ec.SafeBlockAtTimestamp(context.Background(), 0)
+	_, err := ec.BlockAtTimestamp(context.Background(), 0, eth.Safe)
 	require.ErrorIs(t, err, ErrNoEngineClient)
 
 	ec = &simpleEngineController{l2: &mockL2{}, rollup: nil}
-	_, err = ec.SafeBlockAtTimestamp(context.Background(), 0)
+	_, err = ec.BlockAtTimestamp(context.Background(), 0, eth.Safe)
 	require.ErrorIs(t, err, ErrNoRollupConfig)
 }


### PR DESCRIPTION
- `SafeBlockAtTimestamp` is now `BlockAtTimestamp` which accepts a label. I did this with the anticipation of an UnverifiedSafe label, so once it's supported it can be used.
- SafeDB accessors removed from the ChainContainer. The SafeDB is accessed by OptimisticAt and VerifiedAt, but doesn't need direct exposure right now

I'm going to be stacking up more interface extensions and wanted to start from a clean base.

Tests, comments, etc are all updated.