### PR TITLE
op-supernode: Interop Activity

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -64,6 +64,7 @@ require (
 	github.com/spf13/afero v1.12.0
 	github.com/stretchr/testify v1.10.0
 	github.com/urfave/cli/v2 v2.27.6
+	go.etcd.io/bbolt v1.3.5
 	go.opentelemetry.io/otel v1.34.0
 	go.opentelemetry.io/otel/trace v1.34.0
 	golang.org/x/crypto v0.37.0
@@ -277,7 +278,6 @@ require (
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
 	github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
-	go.etcd.io/bbolt v1.3.5 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/host v0.53.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.59.0 // indirect

--- a/op-supernode/config/config.go
+++ b/op-supernode/config/config.go
@@ -13,15 +13,16 @@ import (
 )
 
 type CLIConfig struct {
-	Chains        []uint64
-	DataDir       string
-	L1NodeAddr    string
-	L1BeaconAddr  string
-	RPCConfig     oprpc.CLIConfig
-	LogConfig     oplog.CLIConfig
-	MetricsConfig opmetrics.CLIConfig
-	PprofConfig   oppprof.CLIConfig
-	RawCtx        *cli.Context
+	Chains                     []uint64
+	DataDir                    string
+	L1NodeAddr                 string
+	L1BeaconAddr               string
+	RPCConfig                  oprpc.CLIConfig
+	LogConfig                  oplog.CLIConfig
+	MetricsConfig              opmetrics.CLIConfig
+	PprofConfig                oppprof.CLIConfig
+	RawCtx                     *cli.Context
+	InteropActivationTimestamp uint64
 }
 
 func (c *CLIConfig) Check() error {

--- a/op-supernode/flags/flags.go
+++ b/op-supernode/flags/flags.go
@@ -63,6 +63,16 @@ var optionalFlags = []cli.Flag{
 	DisableP2P,
 }
 
+// activityFlags holds flags registered by activity packages via RegisterActivityFlags.
+// Activities call this during their init() to register their own CLI flags.
+var activityFlags []cli.Flag
+
+// RegisterActivityFlags allows activity packages to register their CLI flags.
+// This should be called from an activity's init() function.
+func RegisterActivityFlags(flags ...cli.Flag) {
+	activityFlags = append(activityFlags, flags...)
+}
+
 func init() {
 	optionalFlags = append(optionalFlags, L1BeaconAddr)
 	optionalFlags = append(optionalFlags, DataDirFlag)
@@ -106,5 +116,8 @@ func FullDynamicFlags(chains []uint64) []cli.Flag {
 			final = append(final, renameFlagWithEnv(f, fmt.Sprintf("%s%d.%s", VNFlagNamePrefix, id, baseName), perChainEnvs, perAliases))
 		}
 	}
+
+	// add the activity flags that were registered by activities during their init() functions
+	final = append(final, activityFlags...)
 	return final
 }

--- a/op-supernode/supernode/activity/activity.go
+++ b/op-supernode/supernode/activity/activity.go
@@ -29,6 +29,7 @@ type RPCActivity interface {
 // VerificationActivity is an Activity that can be used to verify the correctness of the Supernode's Chains
 type VerificationActivity interface {
 	Activity
+	Name() string
 	CurrentL1() eth.BlockID
 	VerifiedAtTimestamp(ts uint64) (bool, error)
 }

--- a/op-supernode/supernode/activity/activity.go
+++ b/op-supernode/supernode/activity/activity.go
@@ -1,6 +1,10 @@
 package activity
 
-import "context"
+import (
+	"context"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
 
 // Activity is an open interface to collect pluggable behaviors which satisfy sub-activitiy interfaces.
 type Activity interface {
@@ -20,4 +24,11 @@ type RPCActivity interface {
 	Activity
 	RPCNamespace() string
 	RPCService() interface{}
+}
+
+// VerificationActivity is an Activity that can be used to verify the correctness of the Supernode's Chains
+type VerificationActivity interface {
+	Activity
+	CurrentL1() eth.BlockID
+	VerifiedAtTimestamp(ts uint64) (bool, error)
 }

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum-optimism/optimism/op-supernode/flags"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/activity"
 	cc "github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container"
@@ -19,8 +18,9 @@ import (
 
 // Compile-time interface conformance assertions.
 var (
-	_ activity.RunnableActivity     = (*Interop)(nil)
-	_ activity.VerificationActivity = (*Interop)(nil)
+	_            activity.RunnableActivity     = (*Interop)(nil)
+	_            activity.VerificationActivity = (*Interop)(nil)
+	tickerPeriod                               = 500 * time.Millisecond
 )
 
 // InteropActivationTimestampFlag is the CLI flag for the interop activation timestamp.
@@ -47,7 +47,6 @@ type Interop struct {
 	cancel  context.CancelFunc
 	started bool
 
-	l1Client  *sources.L1Client
 	currentL1 eth.BlockID
 
 	verifyFn func(ts uint64, blocksAtTimestamp map[eth.ChainID]eth.BlockID) (Result, error)
@@ -63,7 +62,6 @@ func New(
 	activationTimestamp uint64,
 	chains map[eth.ChainID]cc.ChainContainer,
 	dataDir string,
-	l1Client *sources.L1Client,
 ) *Interop {
 	verifiedDB, err := OpenVerifiedDB(dataDir)
 	if err != nil {
@@ -73,7 +71,6 @@ func New(
 	i := &Interop{
 		log:                 log,
 		chains:              chains,
-		l1Client:            l1Client,
 		verifiedDB:          verifiedDB,
 		currentL1:           eth.BlockID{},
 		activationTimestamp: activationTimestamp,
@@ -97,7 +94,7 @@ func (i *Interop) Start(ctx context.Context) error {
 	i.mu.Unlock()
 
 	// Periodically query each chain container for its current safe head and log it.
-	ticker := time.NewTicker(500 * time.Millisecond)
+	ticker := time.NewTicker(tickerPeriod)
 	defer ticker.Stop()
 
 	for {
@@ -107,7 +104,7 @@ func (i *Interop) Start(ctx context.Context) error {
 		case <-ticker.C:
 			err := i.progressAndRecord()
 			if err != nil {
-				i.log.Error("failed to process and record interop", "err", err)
+				i.log.Error("failed to progress and record interop", "err", err)
 				time.Sleep(2 * time.Second)
 				continue
 			}
@@ -138,7 +135,7 @@ func (i *Interop) progressAndRecord() error {
 	// Perform the interop evaluation
 	result, err := i.progressInterop()
 	if err != nil {
-		i.log.Error("failed to process interop", "err", err)
+		i.log.Error("failed to progress interop", "err", err)
 		return err
 	}
 
@@ -300,10 +297,12 @@ func (i *Interop) checkChainsReady(ts uint64) (map[eth.ChainID]eth.BlockID, erro
 	return blocksAtTimestamp, nil
 }
 
+// TODO(#18743): Interop Algorithm
 func (i *Interop) loadLogs(ts uint64) error {
 	return nil
 }
 
+// TODO(#18743): Interop Algorithm
 func (i *Interop) verifyInteropMessages(ts uint64, blocksAtTimestamp map[eth.ChainID]eth.BlockID) (Result, error) {
 	result := Result{Timestamp: ts, L2Heads: make(map[eth.ChainID]eth.BlockID)}
 	for _, chain := range i.chains {
@@ -313,6 +312,7 @@ func (i *Interop) verifyInteropMessages(ts uint64, blocksAtTimestamp map[eth.Cha
 	return result, nil
 }
 
+// TODO(#18944): Invalidate Block
 func (i *Interop) invalidateBlock(chainID eth.ChainID, blockID eth.BlockID) error {
 	return nil
 }

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -51,6 +51,10 @@ type Interop struct {
 	currentL1s map[eth.ChainID]eth.BlockID
 }
 
+func (i *Interop) Name() string {
+	return "interop"
+}
+
 // New constructs a new Interop activity.
 func New(
 	log gethlog.Logger,
@@ -247,11 +251,6 @@ func (i *Interop) progressInterop() error {
 // checkChainsReady checks if all chains are ready to process the next timestamp.
 // Queries all chains in parallel for better performance.
 func (i *Interop) checkChainsReady(ts uint64) (map[eth.ChainID]eth.BlockID, error) {
-	start := time.Now()
-	defer func() {
-		i.log.Info("checkChainsReady: time taken", "time", time.Since(start))
-	}()
-
 	type result struct {
 		chainID eth.ChainID
 		blockID eth.BlockID
@@ -286,18 +285,10 @@ func (i *Interop) checkChainsReady(ts uint64) (map[eth.ChainID]eth.BlockID, erro
 }
 
 func (i *Interop) loadLogs(ts uint64) error {
-	start := time.Now()
-	defer func() {
-		i.log.Info("loadLogs: time taken", "time", time.Since(start))
-	}()
 	return nil
 }
 
 func (i *Interop) verifyInteropMessages(ts uint64, blocksAtTimestamp map[eth.ChainID]eth.BlockID) (Result, error) {
-	start := time.Now()
-	defer func() {
-		i.log.Info("verifyInteropMessages: time taken", "time", time.Since(start))
-	}()
 	result := Result{Timestamp: ts, L2Heads: make(map[eth.ChainID]eth.BlockID)}
 	for _, chain := range i.chains {
 		blockID := blocksAtTimestamp[chain.ID()]
@@ -307,18 +298,10 @@ func (i *Interop) verifyInteropMessages(ts uint64, blocksAtTimestamp map[eth.Cha
 }
 
 func (i *Interop) invalidateBlock(chainID eth.ChainID, blockID eth.BlockID) error {
-	start := time.Now()
-	defer func() {
-		i.log.Info("invalidateBlock: time taken", "time", time.Since(start))
-	}()
 	return nil
 }
 
 func (i *Interop) commitVerifiedResult(timestamp uint64, verifiedResult VerifiedResult) error {
-	start := time.Now()
-	defer func() {
-		i.log.Info("commitVerifiedResult: time taken", "time", time.Since(start))
-	}()
 	return i.verifiedDB.Commit(verifiedResult)
 }
 

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -1,0 +1,159 @@
+package interop
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-supernode/supernode/activity"
+	cc "github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container"
+	gethlog "github.com/ethereum/go-ethereum/log"
+)
+
+// Compile-time interface conformance assertions.
+var (
+	_ activity.RunnableActivity     = (*Interop)(nil)
+	_ activity.VerificationActivity = (*Interop)(nil)
+)
+
+// Interop is a VerificationActivity that can also run background work.
+// Skeleton implementation: wiring, lifecycle, and interface surface only.
+type Interop struct {
+	log    gethlog.Logger
+	chains map[eth.ChainID]cc.ChainContainer
+
+	lastProcessedTimestamp uint64
+
+	mu      sync.RWMutex
+	ctx     context.Context
+	cancel  context.CancelFunc
+	started bool
+}
+
+// New constructs a new Interop activity.
+func New(log gethlog.Logger, chains map[eth.ChainID]cc.ChainContainer) *Interop {
+	return &Interop{
+		log:    log,
+		chains: chains,
+	}
+}
+
+// Start begins the Interop activity background loop and blocks until ctx is canceled.
+func (i *Interop) Start(ctx context.Context) error {
+	i.mu.Lock()
+	if i.started {
+		i.mu.Unlock()
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	i.ctx, i.cancel = context.WithCancel(ctx)
+	i.started = true
+	i.mu.Unlock()
+
+	// Periodically query each chain container for its current safe head and log it.
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-i.ctx.Done():
+			return i.ctx.Err()
+		case <-ticker.C:
+			err := i.processInterop()
+			if err != nil {
+				i.log.Error("failed to process interop", "err", err)
+			}
+		}
+	}
+}
+
+// Stop stops the Interop activity.
+func (i *Interop) Stop(ctx context.Context) error {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if i.cancel != nil {
+		i.cancel()
+	}
+	return nil
+}
+
+func (i *Interop) processInterop() error {
+	// 1: check if all chains are ready to process the next timestamp.
+	// The next timestamp to process is the previous timestamp + 1.
+	// if all chains are ready, we can process the next timestamp.
+	nextTimestamp := i.lastProcessedTimestamp + 1
+	ready, err := i.checkChainsReady(nextTimestamp)
+	if err != nil {
+		i.log.Error("failed to check chains ready", "err", err)
+	}
+	if !ready {
+		i.log.Info("chains not ready, skipping timestamp", "timestamp", nextTimestamp)
+		return nil
+	}
+
+	// 2: validate interop messages
+	// logs up through the next timestamp are to be downloaded and verified against other available data
+	results, err := i.validateInterop(nextTimestamp)
+	if err != nil {
+		i.log.Error("failed to validate interop", "err", err)
+		return err
+	}
+
+	// 3: check if the results are valid.
+	// Any invalid results will be added to the Denylist of the chain containers.
+	allValid := true
+	for chainID, result := range results {
+		if result.err != nil {
+			allValid = false
+			i.log.Error("interop validation failed", "chain", chainID, "result", result)
+			i.invalidateBlock(chainID, result.blockID)
+		}
+	}
+	if !allValid {
+		i.log.Info("interop validation failed, skipping timestamp", "timestamp", nextTimestamp)
+		return nil
+	}
+
+	// 4: commit the valid results.
+	err = i.commitValidResults(results)
+	if err != nil {
+		i.log.Error("failed to commit interop", "err", err)
+		return nil
+	}
+	return nil
+}
+
+func (i *Interop) checkChainsReady(ts uint64) (bool, error) {
+	return true, nil
+}
+
+func (i *Interop) validateInterop(ts uint64) (map[eth.ChainID]interopResult, error) {
+	return nil, nil
+}
+
+func (i *Interop) invalidateBlock(chainID eth.ChainID, blockID eth.BlockID) error {
+	return nil
+}
+
+func (i *Interop) commitValidResults(results map[eth.ChainID]interopResult) error {
+	return nil
+}
+
+type interopResult struct {
+	chainID eth.ChainID
+	blockID eth.BlockID
+	err     error
+}
+
+// CurrentL1 reports the most recent verified L1 block known to this verification activity.
+// Skeleton returns the zero value until implemented.
+func (i *Interop) CurrentL1() eth.BlockID {
+	return eth.BlockID{}
+}
+
+// VerifiedAtTimestamp returns whether the data is verified at the given timestamp.
+// Skeleton returns false until implemented.
+func (i *Interop) VerifiedAtTimestamp(ts uint64) (bool, error) {
+	return false, nil
+}

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/activity"
 	cc "github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container"
 	"github.com/ethereum/go-ethereum"
-	gethlog "github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/urfave/cli/v2"
 )
 
@@ -36,7 +36,7 @@ func init() {
 
 // Interop is a VerificationActivity that can also run background work as a RunnableActivity.
 type Interop struct {
-	log                 gethlog.Logger
+	log                 log.Logger
 	chains              map[eth.ChainID]cc.ChainContainer
 	activationTimestamp uint64
 
@@ -47,8 +47,8 @@ type Interop struct {
 	cancel  context.CancelFunc
 	started bool
 
-	l1Client   *sources.L1Client
-	currentL1s map[eth.ChainID]eth.BlockID
+	l1Client  *sources.L1Client
+	currentL1 eth.BlockID
 }
 
 func (i *Interop) Name() string {
@@ -57,7 +57,7 @@ func (i *Interop) Name() string {
 
 // New constructs a new Interop activity.
 func New(
-	log gethlog.Logger,
+	log log.Logger,
 	activationTimestamp uint64,
 	chains map[eth.ChainID]cc.ChainContainer,
 	dataDir string,
@@ -73,7 +73,7 @@ func New(
 		chains:              chains,
 		l1Client:            l1Client,
 		verifiedDB:          verifiedDB,
-		currentL1s:          make(map[eth.ChainID]eth.BlockID),
+		currentL1:           eth.BlockID{},
 		activationTimestamp: activationTimestamp,
 	}
 }
@@ -99,25 +99,9 @@ func (i *Interop) Start(ctx context.Context) error {
 		case <-i.ctx.Done():
 			return i.ctx.Err()
 		case <-ticker.C:
-			// Check the L1s of each chain prior to performing interop
-			currentL1s, err := i.collectCurrentL1s()
+			err := i.progressAndRecord()
 			if err != nil {
-				i.log.Error("failed to collect current L1s", "err", err)
-				time.Sleep(2 * time.Second)
-				continue
-			}
-			// Perform the interop evaluation
-			err = i.progressInterop()
-			if err != nil {
-				i.log.Error("failed to process interop", "err", err)
-				time.Sleep(2 * time.Second)
-				continue
-			}
-			// Once the interop is complete, update the current L1s
-			// This ensures the current L1s were available for the whole interop process.
-			err = i.updateCurrentL1s(currentL1s)
-			if err != nil {
-				i.log.Error("failed to update current L1s", "err", err)
+				i.log.Error("failed to process and record interop", "err", err)
 				time.Sleep(2 * time.Second)
 				continue
 			}
@@ -138,53 +122,73 @@ func (i *Interop) Stop(ctx context.Context) error {
 	return nil
 }
 
-// collectCurrentL1s collects the current L1 heads of all chains.
-// currentL1 is *not* the L1 head related to the verified timestamp, but rather the
-// furthest L1 head that has been processed by the chain.
-func (i *Interop) collectCurrentL1s() (map[eth.ChainID]eth.BlockID, error) {
-	currentL1s := map[eth.ChainID]eth.BlockID{}
-	for _, chain := range i.chains {
-		status, err := chain.SyncStatus(i.ctx)
-		if err != nil {
-			return nil, fmt.Errorf("chain %s not ready: %w", chain.ID(), err)
-		}
-		block := status.CurrentL1
-		// Check if the block is empty (derivation pipeline hasn't started yet)
-		if block == (eth.BlockRef{}) {
-			return nil, fmt.Errorf("chain %s not ready: CurrentL1 not yet populated", chain.ID())
-		}
-		currentL1s[chain.ID()] = block.ID()
+func (i *Interop) progressAndRecord() error {
+	// Check the L1s of each chain prior to performing interop
+	localCurrentL1, err := i.collectCurrentL1()
+	if err != nil {
+		i.log.Error("failed to collect current L1", "err", err)
+		return err
 	}
-	return currentL1s, nil
-}
-
-var ErrInconsistentL1Heads = errors.New("inconsistent L1 heads")
-
-// updateCurrentL1s updates the current processed L1s if they are consistent
-func (i *Interop) updateCurrentL1s(currentL1s map[eth.ChainID]eth.BlockID) error {
-	for _, l1Head := range currentL1s {
-		i.log.Info("updating current L1s", "l1Head", l1Head)
-		// if the current L1 head is empty, no inconsistency to consider
-		if l1Head == (eth.BlockID{}) {
-			continue
-		}
-		header, err := i.l1Client.L1BlockRefByNumber(i.ctx, l1Head.Number)
-		if err != nil {
-			return err
-		}
-		if header.ID() != l1Head {
-			return ErrInconsistentL1Heads
-		}
+	// Perform the interop evaluation
+	result, err := i.progressInterop()
+	if err != nil {
+		i.log.Error("failed to process interop", "err", err)
+		return err
 	}
-	i.currentL1s = currentL1s
-	i.log.Info("updated current L1s", "currentL1s", currentL1s)
+
+	// Handle the result by comitting verified results or invalidating blocks
+	err = i.handleResult(result)
+	if err != nil {
+		i.log.Error("failed to handle result", "err", err)
+		return err
+	}
+	// if the result is invalid, exit without updating the current L1s
+	if !result.IsEmpty() && !result.IsValid() {
+		i.log.Warn("result is invalid, skipping current L1 update", "results", result)
+		return nil
+	}
+
+	// Once interop is complete and recorded, update the current L1s
+	// the current L1s being considered by the Activity right now depend on what progress was made:
+	// - if interop failed to run, the current L1s are not updated
+	// - if interop ran but did not advance the verified timestamp, the CurrentL1 values collected are used directly
+	// - if interop ran and advanced the verified timestamp, the CurrentL1 is the L1 head at the verified timestamp
+	// this is because the individual chains may advance their CurrentL1, and if progress is being made, we might not be done using the collected L1s.
+	i.mu.Lock()
+	if !result.IsEmpty() {
+		// the new CurrentL1 is the L1 head at the verified timestamp
+		i.currentL1 = result.L1Head
+	} else {
+		// the new CurrentL1 is the lowest CurrentL1 from the collected chains
+		i.currentL1 = localCurrentL1
+	}
+	i.mu.Unlock()
 	return nil
 }
 
-func (i *Interop) progressInterop() error {
+// collectCurrentL1 collects the current L1 head of all chains,
+// which is the minimum L1 head of all the derivation pipelines in Chain Containers
+func (i *Interop) collectCurrentL1() (eth.BlockID, error) {
+	var currentL1 eth.BlockID
+	first := true
+	for _, chain := range i.chains {
+		status, err := chain.SyncStatus(i.ctx)
+		if err != nil {
+			return eth.BlockID{}, fmt.Errorf("chain %s not ready: %w", chain.ID(), err)
+		}
+		block := status.CurrentL1
+		if first || block.Number < currentL1.Number {
+			currentL1 = block.ID()
+			first = false
+		}
+	}
+	return currentL1, nil
+}
+
+func (i *Interop) progressInterop() (Result, error) {
 	start := time.Now()
 	defer func() {
-		i.log.Info("progressInterop: time taken", "time", time.Since(start))
+		i.log.Debug("progressInterop: time taken", "time", time.Since(start))
 	}()
 
 	// 0: identify the next timestamp to process.
@@ -206,45 +210,48 @@ func (i *Interop) progressInterop() error {
 	if err != nil {
 		if errors.Is(err, ethereum.NotFound) {
 			// if the chains are not ready, we can return early and wait for the next timestamp
+			// no error is returned, as this is expected behavior
 			i.log.Info("chains not ready, returning early", "timestamp", ts)
-			return nil
+			return Result{}, nil
 		}
 		// other errors should be treated as fatal and returned to the caller
-		return err
+		return Result{}, err
 	}
 
 	// 2: load the logs up through the next timestamp
 	// the previous timestamp is assumed to already be downloaded and verified
 	if err := i.loadLogs(ts); err != nil {
 		i.log.Error("failed to load logs", "err", err)
-		return err
+		return Result{}, err
 	}
 
 	// 3: validate interop messages
-	// logs up through the next timestamp are to be downloaded and verified against other available data
-	result, err := i.verifyInteropMessages(ts, blocksAtTimestamp)
-	if err != nil {
-		i.log.Error("failed to validate interop", "err", err)
-		return err
+	// and return the result and any errors
+	return i.verifyInteropMessages(ts, blocksAtTimestamp)
+}
+
+func (i *Interop) handleResult(result Result) error {
+	// if the result is empty, return nil
+	if result.IsEmpty() {
+		return nil
 	}
 
-	// 3: check if the results are valid.
-	// Any invalid results will be added to the Denylist of the chain containers.
+	// if the result is empty, return nil
+	// if the result is invalid, invalidate the blocks
 	if !result.IsValid() {
 		i.log.Error("interop validation failed", "results", result)
 		for chainID, invalidHead := range result.InvalidHeads {
 			i.invalidateBlock(chainID, invalidHead)
 		}
-		return nil
 	}
 
-	// 4: commit the verified results.
-	err = i.commitVerifiedResult(ts, result.ToVerifiedResult())
+	// if the result is valid, commit the verified result
+	err := i.commitVerifiedResult(result.Timestamp, result.ToVerifiedResult())
 	if err != nil {
-		i.log.Error("failed to commit interop", "err", err)
-		return nil
+		i.log.Error("failed to commit verified result", "err", err)
+		return err
 	}
-	i.log.Info("committed verified result", "timestamp", ts)
+	i.log.Info("committed verified result", "timestamp", result.Timestamp)
 	return nil
 }
 
@@ -308,16 +315,9 @@ func (i *Interop) commitVerifiedResult(timestamp uint64, verifiedResult Verified
 // CurrentL1 returns the L1 block which has been fully considered for interop,
 // whether or not it advanced the verified timestamp.
 func (i *Interop) CurrentL1() eth.BlockID {
-	minCurrentL1 := eth.BlockID{}
-	for _, currentL1 := range i.currentL1s {
-		if minCurrentL1 == (eth.BlockID{}) {
-			minCurrentL1 = currentL1
-		}
-		if currentL1.Number < minCurrentL1.Number {
-			minCurrentL1 = currentL1
-		}
-	}
-	return minCurrentL1
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	return i.currentL1
 }
 
 // VerifiedAtTimestamp returns whether the data is verified at the given timestamp.

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -2,13 +2,19 @@ package interop
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"sync"
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/sources"
+	"github.com/ethereum-optimism/optimism/op-supernode/flags"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/activity"
 	cc "github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container"
+	"github.com/ethereum/go-ethereum"
 	gethlog "github.com/ethereum/go-ethereum/log"
+	"github.com/urfave/cli/v2"
 )
 
 // Compile-time interface conformance assertions.
@@ -17,25 +23,54 @@ var (
 	_ activity.VerificationActivity = (*Interop)(nil)
 )
 
-// Interop is a VerificationActivity that can also run background work.
-// Skeleton implementation: wiring, lifecycle, and interface surface only.
-type Interop struct {
-	log    gethlog.Logger
-	chains map[eth.ChainID]cc.ChainContainer
+// InteropActivationTimestampFlag is the CLI flag for the interop activation timestamp.
+var InteropActivationTimestampFlag = &cli.Uint64Flag{
+	Name:  "interop.activation-timestamp",
+	Usage: "The timestamp at which interop should start",
+	Value: 0,
+}
 
-	lastProcessedTimestamp uint64
+func init() {
+	flags.RegisterActivityFlags(InteropActivationTimestampFlag)
+}
+
+// Interop is a VerificationActivity that can also run background work as a RunnableActivity.
+type Interop struct {
+	log                 gethlog.Logger
+	chains              map[eth.ChainID]cc.ChainContainer
+	activationTimestamp uint64
+
+	verifiedDB *VerifiedDB
 
 	mu      sync.RWMutex
 	ctx     context.Context
 	cancel  context.CancelFunc
 	started bool
+
+	l1Client   *sources.L1Client
+	currentL1s map[eth.ChainID]eth.BlockID
 }
 
 // New constructs a new Interop activity.
-func New(log gethlog.Logger, chains map[eth.ChainID]cc.ChainContainer) *Interop {
+func New(
+	log gethlog.Logger,
+	activationTimestamp uint64,
+	chains map[eth.ChainID]cc.ChainContainer,
+	dataDir string,
+	l1Client *sources.L1Client,
+) *Interop {
+	verifiedDB, err := OpenVerifiedDB(dataDir)
+	if err != nil {
+		log.Error("failed to open verified DB", "err", err)
+		return nil
+	}
 	return &Interop{
-		log:    log,
-		chains: chains,
+		log:                 log,
+		chains:              chains,
+		l1Client:            l1Client,
+		verifiedDB:          verifiedDB,
+		currentL1s:          make(map[eth.ChainID]eth.BlockID),
+		activationTimestamp: activationTimestamp,
 	}
 }
 
@@ -52,7 +87,7 @@ func (i *Interop) Start(ctx context.Context) error {
 	i.mu.Unlock()
 
 	// Periodically query each chain container for its current safe head and log it.
-	ticker := time.NewTicker(2 * time.Second)
+	ticker := time.NewTicker(500 * time.Millisecond)
 	defer ticker.Stop()
 
 	for {
@@ -60,9 +95,27 @@ func (i *Interop) Start(ctx context.Context) error {
 		case <-i.ctx.Done():
 			return i.ctx.Err()
 		case <-ticker.C:
-			err := i.processInterop()
+			// Check the L1s of each chain prior to performing interop
+			currentL1s, err := i.collectCurrentL1s()
+			if err != nil {
+				i.log.Error("failed to collect current L1s", "err", err)
+				time.Sleep(2 * time.Second)
+				continue
+			}
+			// Perform the interop evaluation
+			err = i.progressInterop()
 			if err != nil {
 				i.log.Error("failed to process interop", "err", err)
+				time.Sleep(2 * time.Second)
+				continue
+			}
+			// Once the interop is complete, update the current L1s
+			// This ensures the current L1s were available for the whole interop process.
+			err = i.updateCurrentL1s(currentL1s)
+			if err != nil {
+				i.log.Error("failed to update current L1s", "err", err)
+				time.Sleep(2 * time.Second)
+				continue
 			}
 		}
 	}
@@ -75,26 +128,97 @@ func (i *Interop) Stop(ctx context.Context) error {
 	if i.cancel != nil {
 		i.cancel()
 	}
+	if i.verifiedDB != nil {
+		return i.verifiedDB.Close()
+	}
 	return nil
 }
 
-func (i *Interop) processInterop() error {
-	// 1: check if all chains are ready to process the next timestamp.
-	// The next timestamp to process is the previous timestamp + 1.
-	// if all chains are ready, we can process the next timestamp.
-	nextTimestamp := i.lastProcessedTimestamp + 1
-	ready, err := i.checkChainsReady(nextTimestamp)
-	if err != nil {
-		i.log.Error("failed to check chains ready", "err", err)
+// collectCurrentL1s collects the current L1 heads of all chains.
+// currentL1 is *not* the L1 head related to the verified timestamp, but rather the
+// furthest L1 head that has been processed by the chain.
+func (i *Interop) collectCurrentL1s() (map[eth.ChainID]eth.BlockID, error) {
+	currentL1s := map[eth.ChainID]eth.BlockID{}
+	for _, chain := range i.chains {
+		status, err := chain.SyncStatus(i.ctx)
+		if err != nil {
+			return nil, fmt.Errorf("chain %s not ready: %w", chain.ID(), err)
+		}
+		block := status.CurrentL1
+		// Check if the block is empty (derivation pipeline hasn't started yet)
+		if block == (eth.BlockRef{}) {
+			return nil, fmt.Errorf("chain %s not ready: CurrentL1 not yet populated", chain.ID())
+		}
+		currentL1s[chain.ID()] = block.ID()
 	}
-	if !ready {
-		i.log.Info("chains not ready, skipping timestamp", "timestamp", nextTimestamp)
-		return nil
+	return currentL1s, nil
+}
+
+var ErrInconsistentL1Heads = errors.New("inconsistent L1 heads")
+
+// updateCurrentL1s updates the current processed L1s if they are consistent
+func (i *Interop) updateCurrentL1s(currentL1s map[eth.ChainID]eth.BlockID) error {
+	for _, l1Head := range currentL1s {
+		i.log.Info("updating current L1s", "l1Head", l1Head)
+		// if the current L1 head is empty, no inconsistency to consider
+		if l1Head == (eth.BlockID{}) {
+			continue
+		}
+		header, err := i.l1Client.L1BlockRefByNumber(i.ctx, l1Head.Number)
+		if err != nil {
+			return err
+		}
+		if header.ID() != l1Head {
+			return ErrInconsistentL1Heads
+		}
+	}
+	i.currentL1s = currentL1s
+	i.log.Info("updated current L1s", "currentL1s", currentL1s)
+	return nil
+}
+
+func (i *Interop) progressInterop() error {
+	start := time.Now()
+	defer func() {
+		i.log.Info("progressInterop: time taken", "time", time.Since(start))
+	}()
+
+	// 0: identify the next timestamp to process.
+	// The next timestamp to process is the previous timestamp + 1.
+	// if the database is not initialized, we use the activation timestamp instead.
+	lastTimestamp, initialized := i.verifiedDB.LastTimestamp()
+	i.log.Info("last timestamp", "lastTimestamp", lastTimestamp, "initialized", initialized)
+	i.log.Info("activation timestamp", "activationTimestamp", i.activationTimestamp)
+	var ts uint64
+	if !initialized {
+		ts = i.activationTimestamp
+	} else {
+		ts = lastTimestamp + 1
 	}
 
-	// 2: validate interop messages
+	// 1: check if all chains are ready to process the next timestamp.
+	// if all chains are ready, we can proceed to download the logs
+	blocksAtTimestamp, err := i.checkChainsReady(ts)
+	if err != nil {
+		if errors.Is(err, ethereum.NotFound) {
+			// if the chains are not ready, we can return early and wait for the next timestamp
+			i.log.Info("chains not ready, returning early", "timestamp", ts)
+			return nil
+		}
+		// other errors should be treated as fatal and returned to the caller
+		return err
+	}
+
+	// 2: load the logs up through the next timestamp
+	// the previous timestamp is assumed to already be downloaded and verified
+	if err := i.loadLogs(ts); err != nil {
+		i.log.Error("failed to load logs", "err", err)
+		return err
+	}
+
+	// 3: validate interop messages
 	// logs up through the next timestamp are to be downloaded and verified against other available data
-	results, err := i.validateInterop(nextTimestamp)
+	result, err := i.verifyInteropMessages(ts, blocksAtTimestamp)
 	if err != nil {
 		i.log.Error("failed to validate interop", "err", err)
 		return err
@@ -102,58 +226,118 @@ func (i *Interop) processInterop() error {
 
 	// 3: check if the results are valid.
 	// Any invalid results will be added to the Denylist of the chain containers.
-	allValid := true
-	for chainID, result := range results {
-		if result.err != nil {
-			allValid = false
-			i.log.Error("interop validation failed", "chain", chainID, "result", result)
-			i.invalidateBlock(chainID, result.blockID)
+	if !result.IsValid() {
+		i.log.Error("interop validation failed", "results", result)
+		for chainID, invalidHead := range result.InvalidHeads {
+			i.invalidateBlock(chainID, invalidHead)
 		}
-	}
-	if !allValid {
-		i.log.Info("interop validation failed, skipping timestamp", "timestamp", nextTimestamp)
 		return nil
 	}
 
-	// 4: commit the valid results.
-	err = i.commitValidResults(results)
+	// 4: commit the verified results.
+	err = i.commitVerifiedResult(ts, result.ToVerifiedResult())
 	if err != nil {
 		i.log.Error("failed to commit interop", "err", err)
 		return nil
 	}
+	i.log.Info("committed verified result", "timestamp", ts)
 	return nil
 }
 
-func (i *Interop) checkChainsReady(ts uint64) (bool, error) {
-	return true, nil
+// checkChainsReady checks if all chains are ready to process the next timestamp.
+// Queries all chains in parallel for better performance.
+func (i *Interop) checkChainsReady(ts uint64) (map[eth.ChainID]eth.BlockID, error) {
+	start := time.Now()
+	defer func() {
+		i.log.Info("checkChainsReady: time taken", "time", time.Since(start))
+	}()
+
+	type result struct {
+		chainID eth.ChainID
+		blockID eth.BlockID
+		err     error
+	}
+
+	results := make(chan result, len(i.chains))
+
+	// Query all chains in parallel
+	for _, chain := range i.chains {
+		go func(c cc.ChainContainer) {
+			block, err := c.BlockAtTimestamp(i.ctx, ts, eth.Safe)
+			if err != nil {
+				results <- result{chainID: c.ID(), err: fmt.Errorf("chain %s not ready for timestamp %d: %w", c.ID(), ts, err)}
+				return
+			}
+			results <- result{chainID: c.ID(), blockID: block.ID()}
+		}(chain)
+	}
+
+	// Collect results
+	blocksAtTimestamp := make(map[eth.ChainID]eth.BlockID)
+	for range i.chains {
+		r := <-results
+		if r.err != nil {
+			return nil, r.err
+		}
+		blocksAtTimestamp[r.chainID] = r.blockID
+	}
+
+	return blocksAtTimestamp, nil
 }
 
-func (i *Interop) validateInterop(ts uint64) (map[eth.ChainID]interopResult, error) {
-	return nil, nil
+func (i *Interop) loadLogs(ts uint64) error {
+	start := time.Now()
+	defer func() {
+		i.log.Info("loadLogs: time taken", "time", time.Since(start))
+	}()
+	return nil
+}
+
+func (i *Interop) verifyInteropMessages(ts uint64, blocksAtTimestamp map[eth.ChainID]eth.BlockID) (Result, error) {
+	start := time.Now()
+	defer func() {
+		i.log.Info("verifyInteropMessages: time taken", "time", time.Since(start))
+	}()
+	result := Result{Timestamp: ts, L2Heads: make(map[eth.ChainID]eth.BlockID)}
+	for _, chain := range i.chains {
+		blockID := blocksAtTimestamp[chain.ID()]
+		result.L2Heads[chain.ID()] = blockID
+	}
+	return result, nil
 }
 
 func (i *Interop) invalidateBlock(chainID eth.ChainID, blockID eth.BlockID) error {
+	start := time.Now()
+	defer func() {
+		i.log.Info("invalidateBlock: time taken", "time", time.Since(start))
+	}()
 	return nil
 }
 
-func (i *Interop) commitValidResults(results map[eth.ChainID]interopResult) error {
-	return nil
+func (i *Interop) commitVerifiedResult(timestamp uint64, verifiedResult VerifiedResult) error {
+	start := time.Now()
+	defer func() {
+		i.log.Info("commitVerifiedResult: time taken", "time", time.Since(start))
+	}()
+	return i.verifiedDB.Commit(verifiedResult)
 }
 
-type interopResult struct {
-	chainID eth.ChainID
-	blockID eth.BlockID
-	err     error
-}
-
-// CurrentL1 reports the most recent verified L1 block known to this verification activity.
-// Skeleton returns the zero value until implemented.
+// CurrentL1 returns the L1 block which has been fully considered for interop,
+// whether or not it advanced the verified timestamp.
 func (i *Interop) CurrentL1() eth.BlockID {
-	return eth.BlockID{}
+	minCurrentL1 := eth.BlockID{}
+	for _, currentL1 := range i.currentL1s {
+		if minCurrentL1 == (eth.BlockID{}) {
+			minCurrentL1 = currentL1
+		}
+		if currentL1.Number < minCurrentL1.Number {
+			minCurrentL1 = currentL1
+		}
+	}
+	return minCurrentL1
 }
 
 // VerifiedAtTimestamp returns whether the data is verified at the given timestamp.
-// Skeleton returns false until implemented.
 func (i *Interop) VerifiedAtTimestamp(ts uint64) (bool, error) {
-	return false, nil
+	return i.verifiedDB.Has(ts)
 }

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -49,6 +49,8 @@ type Interop struct {
 
 	l1Client  *sources.L1Client
 	currentL1 eth.BlockID
+
+	verifyFn func(ts uint64, blocksAtTimestamp map[eth.ChainID]eth.BlockID) (Result, error)
 }
 
 func (i *Interop) Name() string {
@@ -68,7 +70,7 @@ func New(
 		log.Error("failed to open verified DB", "err", err)
 		return nil
 	}
-	return &Interop{
+	i := &Interop{
 		log:                 log,
 		chains:              chains,
 		l1Client:            l1Client,
@@ -76,6 +78,10 @@ func New(
 		currentL1:           eth.BlockID{},
 		activationTimestamp: activationTimestamp,
 	}
+	// default to using the verifyInteropMessages function
+	// (can be overridden by tests)
+	i.verifyFn = i.verifyInteropMessages
+	return i
 }
 
 // Start begins the Interop activity background loop and blocks until ctx is canceled.
@@ -227,7 +233,7 @@ func (i *Interop) progressInterop() (Result, error) {
 
 	// 3: validate interop messages
 	// and return the result and any errors
-	return i.verifyInteropMessages(ts, blocksAtTimestamp)
+	return i.verifyFn(ts, blocksAtTimestamp)
 }
 
 func (i *Interop) handleResult(result Result) error {

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -136,7 +136,7 @@ func (i *Interop) progressAndRecord() error {
 		return err
 	}
 
-	// Handle the result by comitting verified results or invalidating blocks
+	// Handle the result by committing verified results or invalidating blocks
 	err = i.handleResult(result)
 	if err != nil {
 		i.log.Error("failed to handle result", "err", err)
@@ -236,13 +236,16 @@ func (i *Interop) handleResult(result Result) error {
 		return nil
 	}
 
-	// if the result is empty, return nil
-	// if the result is invalid, invalidate the blocks
+	// if the result is invalid, invalidate the blocks and return
 	if !result.IsValid() {
 		i.log.Error("interop validation failed", "results", result)
 		for chainID, invalidHead := range result.InvalidHeads {
-			i.invalidateBlock(chainID, invalidHead)
+			if err := i.invalidateBlock(chainID, invalidHead); err != nil {
+				i.log.Error("failed to invalidate block", "chainID", chainID, "blockID", invalidHead, "err", err)
+				return err
+			}
 		}
+		return nil
 	}
 
 	// if the result is valid, commit the verified result

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -840,6 +840,19 @@ func TestProgressAndRecord_ValidResult_SetsL1ToResultL1Head(t *testing.T) {
 	require.NotNil(t, interop)
 	interop.ctx = context.Background()
 
+	// Override verifyFn to return a valid result with a specific L1Head
+	expectedL1Head := eth.BlockID{Number: 150, Hash: common.HexToHash("0xL1Result")}
+	interop.verifyFn = func(ts uint64, blocksAtTimestamp map[eth.ChainID]eth.BlockID) (Result, error) {
+		return Result{
+			Timestamp: ts,
+			L1Head:    expectedL1Head,
+			L2Heads: map[eth.ChainID]eth.BlockID{
+				mock.id: blocksAtTimestamp[mock.id],
+			},
+			InvalidHeads: nil, // valid result
+		}, nil
+	}
+
 	// Verify currentL1 starts empty
 	require.Equal(t, eth.BlockID{}, interop.currentL1)
 
@@ -847,12 +860,8 @@ func TestProgressAndRecord_ValidResult_SetsL1ToResultL1Head(t *testing.T) {
 
 	require.NoError(t, err)
 	// When result is valid (non-empty), currentL1 should be set to result.L1Head
-	// Note: The current implementation sets result.L1Head which is empty (eth.BlockID{})
-	// because verifyInteropMessages doesn't populate L1Head. This test verifies current behavior.
-	// The currentL1 will be result.L1Head (which may be empty in stub implementation)
-	// This is the expected behavior based on the code:
-	// if !result.IsEmpty() { i.currentL1 = result.L1Head }
-	require.Equal(t, eth.BlockID{}, interop.currentL1) // result.L1Head is empty in stub
+	require.Equal(t, expectedL1Head.Number, interop.currentL1.Number)
+	require.Equal(t, expectedL1Head.Hash, interop.currentL1.Hash)
 }
 
 func TestProgressAndRecord_InvalidResult_DoesNotUpdateL1(t *testing.T) {
@@ -872,17 +881,26 @@ func TestProgressAndRecord_InvalidResult_DoesNotUpdateL1(t *testing.T) {
 	initialL1 := eth.BlockID{Number: 50, Hash: common.HexToHash("0x50")}
 	interop.currentL1 = initialL1
 
-	// First, make a valid progress to initialize the DB
+	// Override verifyFn to return an invalid result (has InvalidHeads)
+	interop.verifyFn = func(ts uint64, blocksAtTimestamp map[eth.ChainID]eth.BlockID) (Result, error) {
+		return Result{
+			Timestamp: ts,
+			L1Head:    eth.BlockID{Number: 999, Hash: common.HexToHash("0xShouldNotBeUsed")},
+			L2Heads: map[eth.ChainID]eth.BlockID{
+				mock.id: blocksAtTimestamp[mock.id],
+			},
+			InvalidHeads: map[eth.ChainID]eth.BlockID{
+				mock.id: {Number: 100, Hash: common.HexToHash("0xBAD")}, // marks result as invalid
+			},
+		}, nil
+	}
+
 	err := interop.progressAndRecord()
+
 	require.NoError(t, err)
-
-	// Now we need to test invalid result. Since verifyInteropMessages is a stub
-	// that always returns valid results, we test the logic by calling handleResult
-	// directly with an invalid result and checking currentL1 behavior.
-	// The actual progressAndRecord would need the stub to be changed to produce invalid results.
-
-	// For now, verify valid result updated currentL1
-	// This confirms the valid path works; invalid path requires stub modification or direct test
+	// When result is invalid, currentL1 should NOT be updated (remains at initial value)
+	require.Equal(t, initialL1.Number, interop.currentL1.Number)
+	require.Equal(t, initialL1.Hash, interop.currentL1.Hash)
 }
 
 func TestProgressAndRecord_CollectL1Error_ReturnsError(t *testing.T) {

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -94,7 +94,7 @@ func TestNew_ValidInputs(t *testing.T) {
 		eth.ChainIDFromUInt64(10): newMockChainContainer(10),
 	}
 
-	interop := New(testLogger(), 1000, chains, dataDir, nil)
+	interop := New(testLogger(), 1000, chains, dataDir)
 
 	require.NotNil(t, interop)
 	require.Equal(t, uint64(1000), interop.activationTimestamp)
@@ -110,7 +110,7 @@ func TestNew_InvalidDataDir(t *testing.T) {
 
 	chains := map[eth.ChainID]cc.ChainContainer{}
 
-	interop := New(testLogger(), 1000, chains, invalidDir, nil)
+	interop := New(testLogger(), 1000, chains, invalidDir)
 
 	// New returns nil when DB fails to open
 	require.Nil(t, interop)
@@ -122,7 +122,7 @@ func TestNew_EmptyChains(t *testing.T) {
 
 	chains := map[eth.ChainID]cc.ChainContainer{}
 
-	interop := New(testLogger(), 0, chains, dataDir, nil)
+	interop := New(testLogger(), 0, chains, dataDir)
 
 	require.NotNil(t, interop)
 	require.Empty(t, interop.chains)
@@ -138,7 +138,7 @@ func TestNew_MultipleChains(t *testing.T) {
 		eth.ChainIDFromUInt64(420):  newMockChainContainer(420),
 	}
 
-	interop := New(testLogger(), 500, chains, dataDir, nil)
+	interop := New(testLogger(), 500, chains, dataDir)
 
 	require.NotNil(t, interop)
 	require.Len(t, interop.chains, 3)
@@ -157,7 +157,7 @@ func TestStart_BlocksUntilContextCanceled(t *testing.T) {
 	mock.blockAtTimestamp = eth.L2BlockRef{Number: 50}
 
 	chains := map[eth.ChainID]cc.ChainContainer{mock.id: mock}
-	interop := New(testLogger(), 1000, chains, dataDir, nil)
+	interop := New(testLogger(), 1000, chains, dataDir)
 	require.NotNil(t, interop)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -198,7 +198,7 @@ func TestStart_AlreadyStarted(t *testing.T) {
 	mock.currentL1 = eth.BlockRef{Number: 100, Hash: common.HexToHash("0x1")}
 
 	chains := map[eth.ChainID]cc.ChainContainer{mock.id: mock}
-	interop := New(testLogger(), 1000, chains, dataDir, nil)
+	interop := New(testLogger(), 1000, chains, dataDir)
 	require.NotNil(t, interop)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -229,7 +229,7 @@ func TestStop_ClosesVerifiedDB(t *testing.T) {
 	dataDir := t.TempDir()
 
 	chains := map[eth.ChainID]cc.ChainContainer{}
-	interop := New(testLogger(), 1000, chains, dataDir, nil)
+	interop := New(testLogger(), 1000, chains, dataDir)
 	require.NotNil(t, interop)
 
 	err := interop.Stop(context.Background())
@@ -249,7 +249,7 @@ func TestStop_CancelsRunningContext(t *testing.T) {
 	mock.blockAtTimestampErr = ethereum.NotFound // Keep it in "not ready" state
 
 	chains := map[eth.ChainID]cc.ChainContainer{mock.id: mock}
-	interop := New(testLogger(), 1000, chains, dataDir, nil)
+	interop := New(testLogger(), 1000, chains, dataDir)
 	require.NotNil(t, interop)
 
 	ctx := context.Background()
@@ -286,7 +286,7 @@ func TestStop_NilCancel(t *testing.T) {
 	dataDir := t.TempDir()
 
 	chains := map[eth.ChainID]cc.ChainContainer{}
-	interop := New(testLogger(), 1000, chains, dataDir, nil)
+	interop := New(testLogger(), 1000, chains, dataDir)
 	require.NotNil(t, interop)
 
 	// Stop without ever starting - cancel is nil
@@ -312,7 +312,7 @@ func TestCollectCurrentL1_ReturnsMinimum(t *testing.T) {
 		mock1.id: mock1,
 		mock2.id: mock2,
 	}
-	interop := New(testLogger(), 1000, chains, dataDir, nil)
+	interop := New(testLogger(), 1000, chains, dataDir)
 	require.NotNil(t, interop)
 	interop.ctx = context.Background()
 
@@ -331,7 +331,7 @@ func TestCollectCurrentL1_ChainNotReady_Error(t *testing.T) {
 	mock.currentL1Err = errors.New("chain not synced")
 
 	chains := map[eth.ChainID]cc.ChainContainer{mock.id: mock}
-	interop := New(testLogger(), 1000, chains, dataDir, nil)
+	interop := New(testLogger(), 1000, chains, dataDir)
 	require.NotNil(t, interop)
 	interop.ctx = context.Background()
 
@@ -347,7 +347,7 @@ func TestCollectCurrentL1_EmptyChains(t *testing.T) {
 	dataDir := t.TempDir()
 
 	chains := map[eth.ChainID]cc.ChainContainer{}
-	interop := New(testLogger(), 1000, chains, dataDir, nil)
+	interop := New(testLogger(), 1000, chains, dataDir)
 	require.NotNil(t, interop)
 	interop.ctx = context.Background()
 
@@ -365,7 +365,7 @@ func TestCollectCurrentL1_SingleChain(t *testing.T) {
 	mock.currentL1 = eth.BlockRef{Number: 500, Hash: common.HexToHash("0x5")}
 
 	chains := map[eth.ChainID]cc.ChainContainer{mock.id: mock}
-	interop := New(testLogger(), 1000, chains, dataDir, nil)
+	interop := New(testLogger(), 1000, chains, dataDir)
 	require.NotNil(t, interop)
 	interop.ctx = context.Background()
 
@@ -394,7 +394,7 @@ func TestCheckChainsReady_AllReady(t *testing.T) {
 		mock1.id: mock1,
 		mock2.id: mock2,
 	}
-	interop := New(testLogger(), 1000, chains, dataDir, nil)
+	interop := New(testLogger(), 1000, chains, dataDir)
 	require.NotNil(t, interop)
 	interop.ctx = context.Background()
 
@@ -420,7 +420,7 @@ func TestCheckChainsReady_OneNotReady(t *testing.T) {
 		mock1.id: mock1,
 		mock2.id: mock2,
 	}
-	interop := New(testLogger(), 1000, chains, dataDir, nil)
+	interop := New(testLogger(), 1000, chains, dataDir)
 	require.NotNil(t, interop)
 	interop.ctx = context.Background()
 
@@ -435,7 +435,7 @@ func TestCheckChainsReady_EmptyChains(t *testing.T) {
 	dataDir := t.TempDir()
 
 	chains := map[eth.ChainID]cc.ChainContainer{}
-	interop := New(testLogger(), 1000, chains, dataDir, nil)
+	interop := New(testLogger(), 1000, chains, dataDir)
 	require.NotNil(t, interop)
 	interop.ctx = context.Background()
 
@@ -460,7 +460,7 @@ func TestCheckChainsReady_ParallelQueries(t *testing.T) {
 		chains[mock.id] = mock
 	}
 
-	interop := New(testLogger(), 1000, chains, dataDir, nil)
+	interop := New(testLogger(), 1000, chains, dataDir)
 	require.NotNil(t, interop)
 	interop.ctx = context.Background()
 
@@ -487,7 +487,7 @@ func TestProgressInterop_NotInitialized_UsesActivationTimestamp(t *testing.T) {
 	mock.blockAtTimestamp = eth.L2BlockRef{Number: 100, Hash: common.HexToHash("0x1")}
 
 	chains := map[eth.ChainID]cc.ChainContainer{mock.id: mock}
-	interop := New(testLogger(), 5000, chains, dataDir, nil) // activation at 5000
+	interop := New(testLogger(), 5000, chains, dataDir) // activation at 5000
 	require.NotNil(t, interop)
 	interop.ctx = context.Background()
 
@@ -507,7 +507,7 @@ func TestProgressInterop_Initialized_UsesNextTimestamp(t *testing.T) {
 	mock.blockAtTimestamp = eth.L2BlockRef{Number: 100, Hash: common.HexToHash("0x1")}
 
 	chains := map[eth.ChainID]cc.ChainContainer{mock.id: mock}
-	interop := New(testLogger(), 1000, chains, dataDir, nil)
+	interop := New(testLogger(), 1000, chains, dataDir)
 	require.NotNil(t, interop)
 	interop.ctx = context.Background()
 
@@ -534,7 +534,7 @@ func TestProgressInterop_ChainsNotReady_ReturnsEmptyResult(t *testing.T) {
 	mock.blockAtTimestampErr = ethereum.NotFound // Not ready
 
 	chains := map[eth.ChainID]cc.ChainContainer{mock.id: mock}
-	interop := New(testLogger(), 1000, chains, dataDir, nil)
+	interop := New(testLogger(), 1000, chains, dataDir)
 	require.NotNil(t, interop)
 	interop.ctx = context.Background()
 
@@ -552,7 +552,7 @@ func TestProgressInterop_ChainError(t *testing.T) {
 	mock.blockAtTimestampErr = errors.New("internal error")
 
 	chains := map[eth.ChainID]cc.ChainContainer{mock.id: mock}
-	interop := New(testLogger(), 1000, chains, dataDir, nil)
+	interop := New(testLogger(), 1000, chains, dataDir)
 	require.NotNil(t, interop)
 	interop.ctx = context.Background()
 
@@ -572,7 +572,7 @@ func TestCurrentL1_ReturnsStoredValue(t *testing.T) {
 	dataDir := t.TempDir()
 
 	chains := map[eth.ChainID]cc.ChainContainer{}
-	interop := New(testLogger(), 1000, chains, dataDir, nil)
+	interop := New(testLogger(), 1000, chains, dataDir)
 	require.NotNil(t, interop)
 
 	interop.currentL1 = eth.BlockID{Number: 100, Hash: common.HexToHash("0x1")}
@@ -588,7 +588,7 @@ func TestCurrentL1_EmptyReturnsZero(t *testing.T) {
 	dataDir := t.TempDir()
 
 	chains := map[eth.ChainID]cc.ChainContainer{}
-	interop := New(testLogger(), 1000, chains, dataDir, nil)
+	interop := New(testLogger(), 1000, chains, dataDir)
 	require.NotNil(t, interop)
 
 	result := interop.CurrentL1()
@@ -608,7 +608,7 @@ func TestVerifiedAtTimestamp_Exists(t *testing.T) {
 	mock.blockAtTimestamp = eth.L2BlockRef{Number: 100}
 
 	chains := map[eth.ChainID]cc.ChainContainer{mock.id: mock}
-	interop := New(testLogger(), 1000, chains, dataDir, nil)
+	interop := New(testLogger(), 1000, chains, dataDir)
 	require.NotNil(t, interop)
 	interop.ctx = context.Background()
 
@@ -631,7 +631,7 @@ func TestVerifiedAtTimestamp_NotExists(t *testing.T) {
 	dataDir := t.TempDir()
 
 	chains := map[eth.ChainID]cc.ChainContainer{}
-	interop := New(testLogger(), 1000, chains, dataDir, nil)
+	interop := New(testLogger(), 1000, chains, dataDir)
 	require.NotNil(t, interop)
 
 	verified, err := interop.VerifiedAtTimestamp(9999)
@@ -655,7 +655,7 @@ func TestVerifyInteropMessages_CopiesBlocks(t *testing.T) {
 		mock1.id: mock1,
 		mock2.id: mock2,
 	}
-	interop := New(testLogger(), 1000, chains, dataDir, nil)
+	interop := New(testLogger(), 1000, chains, dataDir)
 	require.NotNil(t, interop)
 
 	blocksAtTimestamp := map[eth.ChainID]eth.BlockID{
@@ -682,7 +682,7 @@ func TestHandleResult_EmptyResult_ReturnsNil(t *testing.T) {
 	dataDir := t.TempDir()
 
 	chains := map[eth.ChainID]cc.ChainContainer{}
-	interop := New(testLogger(), 1000, chains, dataDir, nil)
+	interop := New(testLogger(), 1000, chains, dataDir)
 	require.NotNil(t, interop)
 
 	emptyResult := Result{}
@@ -703,7 +703,7 @@ func TestHandleResult_ValidResult_CommitsToDb(t *testing.T) {
 
 	mock := newMockChainContainer(10)
 	chains := map[eth.ChainID]cc.ChainContainer{mock.id: mock}
-	interop := New(testLogger(), 1000, chains, dataDir, nil)
+	interop := New(testLogger(), 1000, chains, dataDir)
 	require.NotNil(t, interop)
 
 	validResult := Result{
@@ -732,7 +732,7 @@ func TestHandleResult_InvalidResult_DoesNotCommitToDb(t *testing.T) {
 
 	mock := newMockChainContainer(10)
 	chains := map[eth.ChainID]cc.ChainContainer{mock.id: mock}
-	interop := New(testLogger(), 1000, chains, dataDir, nil)
+	interop := New(testLogger(), 1000, chains, dataDir)
 	require.NotNil(t, interop)
 
 	invalidResult := Result{
@@ -767,7 +767,7 @@ func TestHandleResult_InvalidResult_MultipleInvalidHeads(t *testing.T) {
 		mock1.id: mock1,
 		mock2.id: mock2,
 	}
-	interop := New(testLogger(), 1000, chains, dataDir, nil)
+	interop := New(testLogger(), 1000, chains, dataDir)
 	require.NotNil(t, interop)
 
 	invalidResult := Result{
@@ -812,7 +812,7 @@ func TestProgressAndRecord_EmptyResult_SetsL1ToCollectedMinimum(t *testing.T) {
 		mock1.id: mock1,
 		mock2.id: mock2,
 	}
-	interop := New(testLogger(), 1000, chains, dataDir, nil)
+	interop := New(testLogger(), 1000, chains, dataDir)
 	require.NotNil(t, interop)
 	interop.ctx = context.Background()
 
@@ -836,7 +836,7 @@ func TestProgressAndRecord_ValidResult_SetsL1ToResultL1Head(t *testing.T) {
 	mock.blockAtTimestamp = eth.L2BlockRef{Number: 100, Hash: common.HexToHash("0xL2")}
 
 	chains := map[eth.ChainID]cc.ChainContainer{mock.id: mock}
-	interop := New(testLogger(), 1000, chains, dataDir, nil)
+	interop := New(testLogger(), 1000, chains, dataDir)
 	require.NotNil(t, interop)
 	interop.ctx = context.Background()
 
@@ -873,7 +873,7 @@ func TestProgressAndRecord_InvalidResult_DoesNotUpdateL1(t *testing.T) {
 	mock.blockAtTimestamp = eth.L2BlockRef{Number: 100, Hash: common.HexToHash("0xL2")}
 
 	chains := map[eth.ChainID]cc.ChainContainer{mock.id: mock}
-	interop := New(testLogger(), 1000, chains, dataDir, nil)
+	interop := New(testLogger(), 1000, chains, dataDir)
 	require.NotNil(t, interop)
 	interop.ctx = context.Background()
 
@@ -911,7 +911,7 @@ func TestProgressAndRecord_CollectL1Error_ReturnsError(t *testing.T) {
 	mock.currentL1Err = errors.New("L1 sync error")
 
 	chains := map[eth.ChainID]cc.ChainContainer{mock.id: mock}
-	interop := New(testLogger(), 1000, chains, dataDir, nil)
+	interop := New(testLogger(), 1000, chains, dataDir)
 	require.NotNil(t, interop)
 	interop.ctx = context.Background()
 
@@ -930,7 +930,7 @@ func TestProgressAndRecord_ProgressInteropError_ReturnsError(t *testing.T) {
 	mock.blockAtTimestampErr = errors.New("internal chain error")
 
 	chains := map[eth.ChainID]cc.ChainContainer{mock.id: mock}
-	interop := New(testLogger(), 1000, chains, dataDir, nil)
+	interop := New(testLogger(), 1000, chains, dataDir)
 	require.NotNil(t, interop)
 	interop.ctx = context.Background()
 
@@ -953,7 +953,7 @@ func TestInterop_FullCycle(t *testing.T) {
 	mock.blockAtTimestamp = eth.L2BlockRef{Number: 500, Hash: common.HexToHash("0xL2")}
 
 	chains := map[eth.ChainID]cc.ChainContainer{mock.id: mock}
-	interop := New(testLogger(), 100, chains, dataDir, nil)
+	interop := New(testLogger(), 100, chains, dataDir)
 	require.NotNil(t, interop)
 	interop.ctx = context.Background()
 

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -726,7 +726,7 @@ func TestHandleResult_ValidResult_CommitsToDb(t *testing.T) {
 	require.True(t, has)
 }
 
-func TestHandleResult_InvalidResult_StillCommitsToDb(t *testing.T) {
+func TestHandleResult_InvalidResult_DoesNotCommitToDb(t *testing.T) {
 	t.Parallel()
 	dataDir := t.TempDir()
 
@@ -751,10 +751,10 @@ func TestHandleResult_InvalidResult_StillCommitsToDb(t *testing.T) {
 	err := interop.handleResult(invalidResult)
 
 	require.NoError(t, err)
-	// Invalid results still get committed (with the invalid heads recorded)
+	// Invalid results trigger block invalidation but are NOT committed to the verified DB
 	has, err := interop.verifiedDB.Has(1000)
 	require.NoError(t, err)
-	require.True(t, has)
+	require.False(t, has)
 }
 
 func TestHandleResult_InvalidResult_MultipleInvalidHeads(t *testing.T) {
@@ -786,10 +786,10 @@ func TestHandleResult_InvalidResult_MultipleInvalidHeads(t *testing.T) {
 	err := interop.handleResult(invalidResult)
 
 	require.NoError(t, err)
-	// Result should still be committed
+	// Invalid results trigger block invalidation but are NOT committed to the verified DB
 	has, err := interop.verifiedDB.Has(1000)
 	require.NoError(t, err)
-	require.True(t, has)
+	require.False(t, has)
 }
 
 // =============================================================================

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -71,31 +71,11 @@ func (m *mockChainContainer) OutputRootAtL2BlockNumber(ctx context.Context, l2Bl
 func (m *mockChainContainer) OptimisticOutputAtTimestamp(ctx context.Context, ts uint64) (*eth.OutputResponse, error) {
 	return nil, nil
 }
+func (m *mockChainContainer) SyncStatus(ctx context.Context) (*eth.SyncStatus, error) {
+	return &eth.SyncStatus{}, nil
+}
 
 var _ cc.ChainContainer = (*mockChainContainer)(nil)
-
-// mockL1Client mocks the L1Client for testing L1 consistency checks
-type mockL1Client struct {
-	blockRefs map[uint64]eth.L1BlockRef
-	err       error
-}
-
-func newMockL1Client() *mockL1Client {
-	return &mockL1Client{
-		blockRefs: make(map[uint64]eth.L1BlockRef),
-	}
-}
-
-func (m *mockL1Client) L1BlockRefByNumber(ctx context.Context, num uint64) (eth.L1BlockRef, error) {
-	if m.err != nil {
-		return eth.L1BlockRef{}, m.err
-	}
-	ref, ok := m.blockRefs[num]
-	if !ok {
-		return eth.L1BlockRef{}, ethereum.NotFound
-	}
-	return ref, nil
-}
 
 // Helper to create a test logger
 func testLogger() gethlog.Logger {
@@ -119,7 +99,7 @@ func TestNew_ValidInputs(t *testing.T) {
 	require.NotNil(t, interop)
 	require.Equal(t, uint64(1000), interop.activationTimestamp)
 	require.NotNil(t, interop.verifiedDB)
-	require.NotNil(t, interop.currentL1s)
+	require.Equal(t, eth.BlockID{}, interop.currentL1) // starts empty
 	require.Len(t, interop.chains, 1)
 }
 
@@ -187,18 +167,27 @@ func TestStart_BlocksUntilContextCanceled(t *testing.T) {
 		done <- interop.Start(ctx)
 	}()
 
-	// Give it time to start the loop
-	time.Sleep(100 * time.Millisecond)
+	// Wait for it to start the loop
+	require.Eventually(t, func() bool {
+		interop.mu.RLock()
+		defer interop.mu.RUnlock()
+		return interop.started
+	}, 5*time.Second, 100*time.Millisecond, "Start should mark as started")
 
 	// Cancel and verify it exits
 	cancel()
 
-	select {
-	case err := <-done:
-		require.ErrorIs(t, err, context.Canceled)
-	case <-time.After(2 * time.Second):
-		t.Fatal("Start should exit after context cancellation")
-	}
+	var err error
+	require.Eventually(t, func() bool {
+		select {
+		case err = <-done:
+			return true
+		default:
+			return false
+		}
+	}, 5*time.Second, 100*time.Millisecond, "Start should exit after context cancellation")
+
+	require.ErrorIs(t, err, context.Canceled)
 }
 
 func TestStart_AlreadyStarted(t *testing.T) {
@@ -221,10 +210,14 @@ func TestStart_AlreadyStarted(t *testing.T) {
 	}()
 
 	// Wait for it to mark as started
-	time.Sleep(100 * time.Millisecond)
+	require.Eventually(t, func() bool {
+		interop.mu.RLock()
+		defer interop.mu.RUnlock()
+		return interop.started
+	}, 5*time.Second, 100*time.Millisecond, "Start should mark as started")
 
-	// Try to start again - should block on context
-	ctx2, cancel2 := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	// Try to start again - should block on context and return deadline exceeded
+	ctx2, cancel2 := context.WithTimeout(context.Background(), 500*time.Millisecond)
 	defer cancel2()
 
 	err := interop.Start(ctx2)
@@ -266,19 +259,26 @@ func TestStop_CancelsRunningContext(t *testing.T) {
 		done <- interop.Start(ctx)
 	}()
 
-	// Wait for start
-	time.Sleep(100 * time.Millisecond)
+	// Wait for it to start
+	require.Eventually(t, func() bool {
+		interop.mu.RLock()
+		defer interop.mu.RUnlock()
+		return interop.started
+	}, 5*time.Second, 100*time.Millisecond, "Start should mark as started")
 
 	// Stop should cancel the internal context
 	err := interop.Stop(context.Background())
 	require.NoError(t, err)
 
-	select {
-	case <-done:
-		// Success - Start exited
-	case <-time.After(2 * time.Second):
-		t.Fatal("Start should exit after Stop is called")
-	}
+	// Verify Start exited
+	require.Eventually(t, func() bool {
+		select {
+		case <-done:
+			return true
+		default:
+			return false
+		}
+	}, 5*time.Second, 100*time.Millisecond, "Start should exit after Stop is called")
 }
 
 func TestStop_NilCancel(t *testing.T) {
@@ -295,18 +295,18 @@ func TestStop_NilCancel(t *testing.T) {
 }
 
 // =============================================================================
-// collectCurrentL1s Tests
+// collectCurrentL1 Tests
 // =============================================================================
 
-func TestCollectCurrentL1s_Success(t *testing.T) {
+func TestCollectCurrentL1_ReturnsMinimum(t *testing.T) {
 	t.Parallel()
 	dataDir := t.TempDir()
 
 	mock1 := newMockChainContainer(10)
-	mock1.currentL1 = eth.BlockRef{Number: 100, Hash: common.HexToHash("0x1")}
+	mock1.currentL1 = eth.BlockRef{Number: 200, Hash: common.HexToHash("0x2")}
 
 	mock2 := newMockChainContainer(8453)
-	mock2.currentL1 = eth.BlockRef{Number: 200, Hash: common.HexToHash("0x2")}
+	mock2.currentL1 = eth.BlockRef{Number: 100, Hash: common.HexToHash("0x1")} // minimum
 
 	chains := map[eth.ChainID]cc.ChainContainer{
 		mock1.id: mock1,
@@ -316,15 +316,14 @@ func TestCollectCurrentL1s_Success(t *testing.T) {
 	require.NotNil(t, interop)
 	interop.ctx = context.Background()
 
-	l1s, err := interop.collectCurrentL1s()
+	l1, err := interop.collectCurrentL1()
 
 	require.NoError(t, err)
-	require.Len(t, l1s, 2)
-	require.Equal(t, uint64(100), l1s[mock1.id].Number)
-	require.Equal(t, uint64(200), l1s[mock2.id].Number)
+	require.Equal(t, uint64(100), l1.Number)
+	require.Equal(t, common.HexToHash("0x1"), l1.Hash)
 }
 
-func TestCollectCurrentL1s_ChainNotReady_Error(t *testing.T) {
+func TestCollectCurrentL1_ChainNotReady_Error(t *testing.T) {
 	t.Parallel()
 	dataDir := t.TempDir()
 
@@ -336,164 +335,45 @@ func TestCollectCurrentL1s_ChainNotReady_Error(t *testing.T) {
 	require.NotNil(t, interop)
 	interop.ctx = context.Background()
 
-	l1s, err := interop.collectCurrentL1s()
+	l1, err := interop.collectCurrentL1()
 
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "not ready")
-	require.Nil(t, l1s)
+	require.Equal(t, eth.BlockID{}, l1)
 }
 
-func TestCollectCurrentL1s_EmptyBlockRef(t *testing.T) {
+func TestCollectCurrentL1_EmptyChains(t *testing.T) {
+	t.Parallel()
+	dataDir := t.TempDir()
+
+	chains := map[eth.ChainID]cc.ChainContainer{}
+	interop := New(testLogger(), 1000, chains, dataDir, nil)
+	require.NotNil(t, interop)
+	interop.ctx = context.Background()
+
+	l1, err := interop.collectCurrentL1()
+
+	require.NoError(t, err)
+	require.Equal(t, eth.BlockID{}, l1)
+}
+
+func TestCollectCurrentL1_SingleChain(t *testing.T) {
 	t.Parallel()
 	dataDir := t.TempDir()
 
 	mock := newMockChainContainer(10)
-	mock.currentL1 = eth.BlockRef{} // Empty - derivation not started
+	mock.currentL1 = eth.BlockRef{Number: 500, Hash: common.HexToHash("0x5")}
 
 	chains := map[eth.ChainID]cc.ChainContainer{mock.id: mock}
 	interop := New(testLogger(), 1000, chains, dataDir, nil)
 	require.NotNil(t, interop)
 	interop.ctx = context.Background()
 
-	l1s, err := interop.collectCurrentL1s()
-
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "not yet populated")
-	require.Nil(t, l1s)
-}
-
-func TestCollectCurrentL1s_EmptyChains(t *testing.T) {
-	t.Parallel()
-	dataDir := t.TempDir()
-
-	chains := map[eth.ChainID]cc.ChainContainer{}
-	interop := New(testLogger(), 1000, chains, dataDir, nil)
-	require.NotNil(t, interop)
-	interop.ctx = context.Background()
-
-	l1s, err := interop.collectCurrentL1s()
+	l1, err := interop.collectCurrentL1()
 
 	require.NoError(t, err)
-	require.Empty(t, l1s)
-}
-
-// =============================================================================
-// updateCurrentL1s Tests
-// =============================================================================
-
-// testableInterop wraps Interop with a mock L1 client for testing
-type testableInterop struct {
-	*Interop
-	mockL1 *mockL1Client
-}
-
-func newTestableInterop(t *testing.T, chains map[eth.ChainID]cc.ChainContainer, activationTs uint64) *testableInterop {
-	dataDir := t.TempDir()
-	interop := New(testLogger(), activationTs, chains, dataDir, nil)
-	require.NotNil(t, interop)
-	interop.ctx = context.Background()
-
-	mockL1 := newMockL1Client()
-	return &testableInterop{
-		Interop: interop,
-		mockL1:  mockL1,
-	}
-}
-
-// Override updateCurrentL1s to use mock L1 client
-func (ti *testableInterop) updateCurrentL1sWithMock(currentL1s map[eth.ChainID]eth.BlockID) error {
-	for _, l1Head := range currentL1s {
-		ti.log.Info("updating current L1s", "l1Head", l1Head)
-		if l1Head == (eth.BlockID{}) {
-			continue
-		}
-		header, err := ti.mockL1.L1BlockRefByNumber(ti.ctx, l1Head.Number)
-		if err != nil {
-			return err
-		}
-		if header.ID() != l1Head {
-			return ErrInconsistentL1Heads
-		}
-	}
-	ti.currentL1s = currentL1s
-	return nil
-}
-
-func TestUpdateCurrentL1s_Success(t *testing.T) {
-	t.Parallel()
-
-	chains := map[eth.ChainID]cc.ChainContainer{}
-	ti := newTestableInterop(t, chains, 1000)
-
-	blockHash := common.HexToHash("0xabc")
-	ti.mockL1.blockRefs[100] = eth.L1BlockRef{
-		Hash:   blockHash,
-		Number: 100,
-	}
-
-	currentL1s := map[eth.ChainID]eth.BlockID{
-		eth.ChainIDFromUInt64(10): {Hash: blockHash, Number: 100},
-	}
-
-	err := ti.updateCurrentL1sWithMock(currentL1s)
-
-	require.NoError(t, err)
-	require.Equal(t, currentL1s, ti.currentL1s)
-}
-
-func TestUpdateCurrentL1s_InconsistentHeads(t *testing.T) {
-	t.Parallel()
-
-	chains := map[eth.ChainID]cc.ChainContainer{}
-	ti := newTestableInterop(t, chains, 1000)
-
-	// L1 client returns different hash for same block number (reorg)
-	ti.mockL1.blockRefs[100] = eth.L1BlockRef{
-		Hash:   common.HexToHash("0xdifferent"),
-		Number: 100,
-	}
-
-	currentL1s := map[eth.ChainID]eth.BlockID{
-		eth.ChainIDFromUInt64(10): {Hash: common.HexToHash("0xoriginal"), Number: 100},
-	}
-
-	err := ti.updateCurrentL1sWithMock(currentL1s)
-
-	require.ErrorIs(t, err, ErrInconsistentL1Heads)
-}
-
-func TestUpdateCurrentL1s_EmptyBlockID(t *testing.T) {
-	t.Parallel()
-
-	chains := map[eth.ChainID]cc.ChainContainer{}
-	ti := newTestableInterop(t, chains, 1000)
-
-	// Empty BlockID should be skipped
-	currentL1s := map[eth.ChainID]eth.BlockID{
-		eth.ChainIDFromUInt64(10): {}, // Empty
-	}
-
-	err := ti.updateCurrentL1sWithMock(currentL1s)
-
-	require.NoError(t, err)
-}
-
-func TestUpdateCurrentL1s_L1ClientError(t *testing.T) {
-	t.Parallel()
-
-	chains := map[eth.ChainID]cc.ChainContainer{}
-	ti := newTestableInterop(t, chains, 1000)
-
-	ti.mockL1.err = errors.New("L1 RPC error")
-
-	currentL1s := map[eth.ChainID]eth.BlockID{
-		eth.ChainIDFromUInt64(10): {Hash: common.HexToHash("0x1"), Number: 100},
-	}
-
-	err := ti.updateCurrentL1sWithMock(currentL1s)
-
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "L1 RPC error")
+	require.Equal(t, uint64(500), l1.Number)
+	require.Equal(t, common.HexToHash("0x5"), l1.Hash)
 }
 
 // =============================================================================
@@ -611,14 +491,12 @@ func TestProgressInterop_NotInitialized_UsesActivationTimestamp(t *testing.T) {
 	require.NotNil(t, interop)
 	interop.ctx = context.Background()
 
-	err := interop.progressInterop()
+	result, err := interop.progressInterop()
 
 	require.NoError(t, err)
-
-	// Check that timestamp 5000 was committed
-	has, err := interop.verifiedDB.Has(5000)
-	require.NoError(t, err)
-	require.True(t, has)
+	require.False(t, result.IsEmpty())
+	require.Equal(t, uint64(5000), result.Timestamp)
+	require.True(t, result.IsValid())
 }
 
 func TestProgressInterop_Initialized_UsesNextTimestamp(t *testing.T) {
@@ -633,20 +511,22 @@ func TestProgressInterop_Initialized_UsesNextTimestamp(t *testing.T) {
 	require.NotNil(t, interop)
 	interop.ctx = context.Background()
 
-	// First progress - commits timestamp 1000
-	err := interop.progressInterop()
+	// First progress - returns result for timestamp 1000
+	result1, err := interop.progressInterop()
+	require.NoError(t, err)
+	require.Equal(t, uint64(1000), result1.Timestamp)
+
+	// Commit the result so DB is initialized
+	err = interop.handleResult(result1)
 	require.NoError(t, err)
 
-	// Second progress - should commit timestamp 1001
-	err = interop.progressInterop()
+	// Second progress - should return result for timestamp 1001
+	result2, err := interop.progressInterop()
 	require.NoError(t, err)
-
-	has, err := interop.verifiedDB.Has(1001)
-	require.NoError(t, err)
-	require.True(t, has)
+	require.Equal(t, uint64(1001), result2.Timestamp)
 }
 
-func TestProgressInterop_ChainsNotReady_ReturnsEarly(t *testing.T) {
+func TestProgressInterop_ChainsNotReady_ReturnsEmptyResult(t *testing.T) {
 	t.Parallel()
 	dataDir := t.TempDir()
 
@@ -658,14 +538,10 @@ func TestProgressInterop_ChainsNotReady_ReturnsEarly(t *testing.T) {
 	require.NotNil(t, interop)
 	interop.ctx = context.Background()
 
-	err := interop.progressInterop()
+	result, err := interop.progressInterop()
 
-	require.NoError(t, err) // Returns nil when chains not ready
-
-	// Nothing should be committed
-	has, err := interop.verifiedDB.Has(1000)
-	require.NoError(t, err)
-	require.False(t, has)
+	require.NoError(t, err) // Returns nil error when chains not ready
+	require.True(t, result.IsEmpty())
 }
 
 func TestProgressInterop_ChainError(t *testing.T) {
@@ -680,17 +556,18 @@ func TestProgressInterop_ChainError(t *testing.T) {
 	require.NotNil(t, interop)
 	interop.ctx = context.Background()
 
-	err := interop.progressInterop()
+	result, err := interop.progressInterop()
 
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "internal error")
+	require.True(t, result.IsEmpty())
 }
 
 // =============================================================================
 // CurrentL1 Tests
 // =============================================================================
 
-func TestCurrentL1_ReturnsMinimum(t *testing.T) {
+func TestCurrentL1_ReturnsStoredValue(t *testing.T) {
 	t.Parallel()
 	dataDir := t.TempDir()
 
@@ -698,11 +575,7 @@ func TestCurrentL1_ReturnsMinimum(t *testing.T) {
 	interop := New(testLogger(), 1000, chains, dataDir, nil)
 	require.NotNil(t, interop)
 
-	interop.currentL1s = map[eth.ChainID]eth.BlockID{
-		eth.ChainIDFromUInt64(10):   {Number: 300, Hash: common.HexToHash("0x3")},
-		eth.ChainIDFromUInt64(8453): {Number: 100, Hash: common.HexToHash("0x1")}, // Minimum
-		eth.ChainIDFromUInt64(420):  {Number: 200, Hash: common.HexToHash("0x2")},
-	}
+	interop.currentL1 = eth.BlockID{Number: 100, Hash: common.HexToHash("0x1")}
 
 	result := interop.CurrentL1()
 
@@ -723,23 +596,6 @@ func TestCurrentL1_EmptyReturnsZero(t *testing.T) {
 	require.Equal(t, eth.BlockID{}, result)
 }
 
-func TestCurrentL1_SingleChain(t *testing.T) {
-	t.Parallel()
-	dataDir := t.TempDir()
-
-	chains := map[eth.ChainID]cc.ChainContainer{}
-	interop := New(testLogger(), 1000, chains, dataDir, nil)
-	require.NotNil(t, interop)
-
-	interop.currentL1s = map[eth.ChainID]eth.BlockID{
-		eth.ChainIDFromUInt64(10): {Number: 500, Hash: common.HexToHash("0x5")},
-	}
-
-	result := interop.CurrentL1()
-
-	require.Equal(t, uint64(500), result.Number)
-}
-
 // =============================================================================
 // VerifiedAtTimestamp Tests
 // =============================================================================
@@ -756,8 +612,12 @@ func TestVerifiedAtTimestamp_Exists(t *testing.T) {
 	require.NotNil(t, interop)
 	interop.ctx = context.Background()
 
-	// Progress to commit timestamp 1000
-	err := interop.progressInterop()
+	// Progress to get result for timestamp 1000
+	result, err := interop.progressInterop()
+	require.NoError(t, err)
+
+	// Commit the result to DB
+	err = interop.handleResult(result)
 	require.NoError(t, err)
 
 	verified, err := interop.VerifiedAtTimestamp(1000)
@@ -814,6 +674,255 @@ func TestVerifyInteropMessages_CopiesBlocks(t *testing.T) {
 }
 
 // =============================================================================
+// handleResult Tests
+// =============================================================================
+
+func TestHandleResult_EmptyResult_ReturnsNil(t *testing.T) {
+	t.Parallel()
+	dataDir := t.TempDir()
+
+	chains := map[eth.ChainID]cc.ChainContainer{}
+	interop := New(testLogger(), 1000, chains, dataDir, nil)
+	require.NotNil(t, interop)
+
+	emptyResult := Result{}
+	require.True(t, emptyResult.IsEmpty())
+
+	err := interop.handleResult(emptyResult)
+
+	require.NoError(t, err)
+	// Empty result should not commit anything to DB
+	has, err := interop.verifiedDB.Has(0)
+	require.NoError(t, err)
+	require.False(t, has)
+}
+
+func TestHandleResult_ValidResult_CommitsToDb(t *testing.T) {
+	t.Parallel()
+	dataDir := t.TempDir()
+
+	mock := newMockChainContainer(10)
+	chains := map[eth.ChainID]cc.ChainContainer{mock.id: mock}
+	interop := New(testLogger(), 1000, chains, dataDir, nil)
+	require.NotNil(t, interop)
+
+	validResult := Result{
+		Timestamp: 1000,
+		L1Head:    eth.BlockID{Number: 100, Hash: common.HexToHash("0xL1")},
+		L2Heads: map[eth.ChainID]eth.BlockID{
+			mock.id: {Number: 500, Hash: common.HexToHash("0xL2")},
+		},
+		InvalidHeads: nil, // No invalid heads = valid result
+	}
+	require.True(t, validResult.IsValid())
+	require.False(t, validResult.IsEmpty())
+
+	err := interop.handleResult(validResult)
+
+	require.NoError(t, err)
+	// Valid result should be committed to DB
+	has, err := interop.verifiedDB.Has(1000)
+	require.NoError(t, err)
+	require.True(t, has)
+}
+
+func TestHandleResult_InvalidResult_StillCommitsToDb(t *testing.T) {
+	t.Parallel()
+	dataDir := t.TempDir()
+
+	mock := newMockChainContainer(10)
+	chains := map[eth.ChainID]cc.ChainContainer{mock.id: mock}
+	interop := New(testLogger(), 1000, chains, dataDir, nil)
+	require.NotNil(t, interop)
+
+	invalidResult := Result{
+		Timestamp: 1000,
+		L1Head:    eth.BlockID{Number: 100, Hash: common.HexToHash("0xL1")},
+		L2Heads: map[eth.ChainID]eth.BlockID{
+			mock.id: {Number: 500, Hash: common.HexToHash("0xL2")},
+		},
+		InvalidHeads: map[eth.ChainID]eth.BlockID{
+			mock.id: {Number: 500, Hash: common.HexToHash("0xBAD")}, // Has invalid heads
+		},
+	}
+	require.False(t, invalidResult.IsValid())
+	require.False(t, invalidResult.IsEmpty())
+
+	err := interop.handleResult(invalidResult)
+
+	require.NoError(t, err)
+	// Invalid results still get committed (with the invalid heads recorded)
+	has, err := interop.verifiedDB.Has(1000)
+	require.NoError(t, err)
+	require.True(t, has)
+}
+
+func TestHandleResult_InvalidResult_MultipleInvalidHeads(t *testing.T) {
+	t.Parallel()
+	dataDir := t.TempDir()
+
+	mock1 := newMockChainContainer(10)
+	mock2 := newMockChainContainer(8453)
+	chains := map[eth.ChainID]cc.ChainContainer{
+		mock1.id: mock1,
+		mock2.id: mock2,
+	}
+	interop := New(testLogger(), 1000, chains, dataDir, nil)
+	require.NotNil(t, interop)
+
+	invalidResult := Result{
+		Timestamp: 1000,
+		L1Head:    eth.BlockID{Number: 100, Hash: common.HexToHash("0xL1")},
+		L2Heads: map[eth.ChainID]eth.BlockID{
+			mock1.id: {Number: 500, Hash: common.HexToHash("0xL2a")},
+			mock2.id: {Number: 600, Hash: common.HexToHash("0xL2b")},
+		},
+		InvalidHeads: map[eth.ChainID]eth.BlockID{
+			mock1.id: {Number: 500, Hash: common.HexToHash("0xBAD1")},
+			mock2.id: {Number: 600, Hash: common.HexToHash("0xBAD2")},
+		},
+	}
+
+	err := interop.handleResult(invalidResult)
+
+	require.NoError(t, err)
+	// Result should still be committed
+	has, err := interop.verifiedDB.Has(1000)
+	require.NoError(t, err)
+	require.True(t, has)
+}
+
+// =============================================================================
+// progressAndRecord L1 Update Tests
+// =============================================================================
+
+func TestProgressAndRecord_EmptyResult_SetsL1ToCollectedMinimum(t *testing.T) {
+	t.Parallel()
+	dataDir := t.TempDir()
+
+	mock1 := newMockChainContainer(10)
+	mock1.currentL1 = eth.BlockRef{Number: 200, Hash: common.HexToHash("0x2")}
+	mock1.blockAtTimestampErr = ethereum.NotFound // Chains not ready -> empty result
+
+	mock2 := newMockChainContainer(8453)
+	mock2.currentL1 = eth.BlockRef{Number: 100, Hash: common.HexToHash("0x1")} // This is minimum
+	mock2.blockAtTimestampErr = ethereum.NotFound
+
+	chains := map[eth.ChainID]cc.ChainContainer{
+		mock1.id: mock1,
+		mock2.id: mock2,
+	}
+	interop := New(testLogger(), 1000, chains, dataDir, nil)
+	require.NotNil(t, interop)
+	interop.ctx = context.Background()
+
+	// Verify currentL1 starts empty
+	require.Equal(t, eth.BlockID{}, interop.currentL1)
+
+	err := interop.progressAndRecord()
+
+	require.NoError(t, err)
+	// When result is empty, currentL1 should be set to the collected minimum
+	require.Equal(t, uint64(100), interop.currentL1.Number)
+	require.Equal(t, common.HexToHash("0x1"), interop.currentL1.Hash)
+}
+
+func TestProgressAndRecord_ValidResult_SetsL1ToResultL1Head(t *testing.T) {
+	t.Parallel()
+	dataDir := t.TempDir()
+
+	mock := newMockChainContainer(10)
+	mock.currentL1 = eth.BlockRef{Number: 200, Hash: common.HexToHash("0x200")}
+	mock.blockAtTimestamp = eth.L2BlockRef{Number: 100, Hash: common.HexToHash("0xL2")}
+
+	chains := map[eth.ChainID]cc.ChainContainer{mock.id: mock}
+	interop := New(testLogger(), 1000, chains, dataDir, nil)
+	require.NotNil(t, interop)
+	interop.ctx = context.Background()
+
+	// Verify currentL1 starts empty
+	require.Equal(t, eth.BlockID{}, interop.currentL1)
+
+	err := interop.progressAndRecord()
+
+	require.NoError(t, err)
+	// When result is valid (non-empty), currentL1 should be set to result.L1Head
+	// Note: The current implementation sets result.L1Head which is empty (eth.BlockID{})
+	// because verifyInteropMessages doesn't populate L1Head. This test verifies current behavior.
+	// The currentL1 will be result.L1Head (which may be empty in stub implementation)
+	// This is the expected behavior based on the code:
+	// if !result.IsEmpty() { i.currentL1 = result.L1Head }
+	require.Equal(t, eth.BlockID{}, interop.currentL1) // result.L1Head is empty in stub
+}
+
+func TestProgressAndRecord_InvalidResult_DoesNotUpdateL1(t *testing.T) {
+	t.Parallel()
+	dataDir := t.TempDir()
+
+	mock := newMockChainContainer(10)
+	mock.currentL1 = eth.BlockRef{Number: 200, Hash: common.HexToHash("0x200")}
+	mock.blockAtTimestamp = eth.L2BlockRef{Number: 100, Hash: common.HexToHash("0xL2")}
+
+	chains := map[eth.ChainID]cc.ChainContainer{mock.id: mock}
+	interop := New(testLogger(), 1000, chains, dataDir, nil)
+	require.NotNil(t, interop)
+	interop.ctx = context.Background()
+
+	// Set an initial currentL1 value
+	initialL1 := eth.BlockID{Number: 50, Hash: common.HexToHash("0x50")}
+	interop.currentL1 = initialL1
+
+	// First, make a valid progress to initialize the DB
+	err := interop.progressAndRecord()
+	require.NoError(t, err)
+
+	// Now we need to test invalid result. Since verifyInteropMessages is a stub
+	// that always returns valid results, we test the logic by calling handleResult
+	// directly with an invalid result and checking currentL1 behavior.
+	// The actual progressAndRecord would need the stub to be changed to produce invalid results.
+
+	// For now, verify valid result updated currentL1
+	// This confirms the valid path works; invalid path requires stub modification or direct test
+}
+
+func TestProgressAndRecord_CollectL1Error_ReturnsError(t *testing.T) {
+	t.Parallel()
+	dataDir := t.TempDir()
+
+	mock := newMockChainContainer(10)
+	mock.currentL1Err = errors.New("L1 sync error")
+
+	chains := map[eth.ChainID]cc.ChainContainer{mock.id: mock}
+	interop := New(testLogger(), 1000, chains, dataDir, nil)
+	require.NotNil(t, interop)
+	interop.ctx = context.Background()
+
+	err := interop.progressAndRecord()
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not ready")
+}
+
+func TestProgressAndRecord_ProgressInteropError_ReturnsError(t *testing.T) {
+	t.Parallel()
+	dataDir := t.TempDir()
+
+	mock := newMockChainContainer(10)
+	mock.currentL1 = eth.BlockRef{Number: 100, Hash: common.HexToHash("0x1")}
+	mock.blockAtTimestampErr = errors.New("internal chain error")
+
+	chains := map[eth.ChainID]cc.ChainContainer{mock.id: mock}
+	interop := New(testLogger(), 1000, chains, dataDir, nil)
+	require.NotNil(t, interop)
+	interop.ctx = context.Background()
+
+	err := interop.progressAndRecord()
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "internal chain error")
+}
+
+// =============================================================================
 // Integration Tests
 // =============================================================================
 
@@ -832,13 +941,18 @@ func TestInterop_FullCycle(t *testing.T) {
 
 	// Simulate multiple interop cycles
 	for i := 0; i < 3; i++ {
-		// Collect L1s
-		l1s, err := interop.collectCurrentL1s()
+		// Collect L1 (returns minimum across chains)
+		l1, err := interop.collectCurrentL1()
 		require.NoError(t, err)
-		require.Len(t, l1s, 1)
+		require.Equal(t, uint64(1000), l1.Number)
 
-		// Progress
-		err = interop.progressInterop()
+		// Progress and get result
+		result, err := interop.progressInterop()
+		require.NoError(t, err)
+		require.False(t, result.IsEmpty())
+
+		// Handle the result (commits to DB)
+		err = interop.handleResult(result)
 		require.NoError(t, err)
 	}
 

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -42,12 +42,6 @@ func (m *mockChainContainer) Stop(ctx context.Context) error   { return nil }
 func (m *mockChainContainer) Pause(ctx context.Context) error  { return nil }
 func (m *mockChainContainer) Resume(ctx context.Context) error { return nil }
 
-func (m *mockChainContainer) CurrentL1(ctx context.Context) (eth.BlockRef, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	return m.currentL1, m.currentL1Err
-}
-
 func (m *mockChainContainer) RegisterVerifier(v activity.VerificationActivity) {
 }
 func (m *mockChainContainer) BlockAtTimestamp(ctx context.Context, ts uint64, label eth.BlockLabel) (eth.L2BlockRef, error) {
@@ -72,7 +66,12 @@ func (m *mockChainContainer) OptimisticOutputAtTimestamp(ctx context.Context, ts
 	return nil, nil
 }
 func (m *mockChainContainer) SyncStatus(ctx context.Context) (*eth.SyncStatus, error) {
-	return &eth.SyncStatus{}, nil
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.currentL1Err != nil {
+		return nil, m.currentL1Err
+	}
+	return &eth.SyncStatus{CurrentL1: m.currentL1}, nil
 }
 
 var _ cc.ChainContainer = (*mockChainContainer)(nil)

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -1,0 +1,848 @@
+package interop
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	cc "github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container"
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	gethlog "github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+)
+
+// mockChainContainer implements cc.ChainContainer for testing
+type mockChainContainer struct {
+	id eth.ChainID
+
+	currentL1    eth.BlockRef
+	currentL1Err error
+
+	blockAtTimestamp    eth.L2BlockRef
+	blockAtTimestampErr error
+
+	mu sync.Mutex
+}
+
+func newMockChainContainer(id uint64) *mockChainContainer {
+	return &mockChainContainer{
+		id: eth.ChainIDFromUInt64(id),
+	}
+}
+
+func (m *mockChainContainer) ID() eth.ChainID { return m.id }
+
+func (m *mockChainContainer) Start(ctx context.Context) error  { return nil }
+func (m *mockChainContainer) Stop(ctx context.Context) error   { return nil }
+func (m *mockChainContainer) Pause(ctx context.Context) error  { return nil }
+func (m *mockChainContainer) Resume(ctx context.Context) error { return nil }
+
+func (m *mockChainContainer) CurrentL1(ctx context.Context) (eth.BlockRef, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.currentL1, m.currentL1Err
+}
+
+func (m *mockChainContainer) BlockAtTimestamp(ctx context.Context, ts uint64, label eth.BlockLabel) (eth.L2BlockRef, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.blockAtTimestamp, m.blockAtTimestampErr
+}
+
+func (m *mockChainContainer) VerifiedAt(ctx context.Context, ts uint64) (eth.BlockID, eth.BlockID, error) {
+	return eth.BlockID{}, eth.BlockID{}, nil
+}
+func (m *mockChainContainer) L1ForL2(ctx context.Context, l2Block eth.BlockID) (eth.BlockID, error) {
+	return eth.BlockID{}, nil
+}
+func (m *mockChainContainer) OptimisticAt(ctx context.Context, ts uint64) (eth.BlockID, eth.BlockID, error) {
+	return eth.BlockID{}, eth.BlockID{}, nil
+}
+func (m *mockChainContainer) OutputRootAtL2BlockNumber(ctx context.Context, l2BlockNum uint64) (eth.Bytes32, error) {
+	return eth.Bytes32{}, nil
+}
+func (m *mockChainContainer) OptimisticOutputAtTimestamp(ctx context.Context, ts uint64) (*eth.OutputResponse, error) {
+	return nil, nil
+}
+
+var _ cc.ChainContainer = (*mockChainContainer)(nil)
+
+// mockL1Client mocks the L1Client for testing L1 consistency checks
+type mockL1Client struct {
+	blockRefs map[uint64]eth.L1BlockRef
+	err       error
+}
+
+func newMockL1Client() *mockL1Client {
+	return &mockL1Client{
+		blockRefs: make(map[uint64]eth.L1BlockRef),
+	}
+}
+
+func (m *mockL1Client) L1BlockRefByNumber(ctx context.Context, num uint64) (eth.L1BlockRef, error) {
+	if m.err != nil {
+		return eth.L1BlockRef{}, m.err
+	}
+	ref, ok := m.blockRefs[num]
+	if !ok {
+		return eth.L1BlockRef{}, ethereum.NotFound
+	}
+	return ref, nil
+}
+
+// Helper to create a test logger
+func testLogger() gethlog.Logger {
+	return gethlog.New()
+}
+
+// =============================================================================
+// Constructor Tests
+// =============================================================================
+
+func TestNew_ValidInputs(t *testing.T) {
+	t.Parallel()
+	dataDir := t.TempDir()
+
+	chains := map[eth.ChainID]cc.ChainContainer{
+		eth.ChainIDFromUInt64(10): newMockChainContainer(10),
+	}
+
+	interop := New(testLogger(), 1000, chains, dataDir, nil)
+
+	require.NotNil(t, interop)
+	require.Equal(t, uint64(1000), interop.activationTimestamp)
+	require.NotNil(t, interop.verifiedDB)
+	require.NotNil(t, interop.currentL1s)
+	require.Len(t, interop.chains, 1)
+}
+
+func TestNew_InvalidDataDir(t *testing.T) {
+	t.Parallel()
+	// Use a path that can't be written to
+	invalidDir := "/nonexistent/path/that/cannot/exist/db"
+
+	chains := map[eth.ChainID]cc.ChainContainer{}
+
+	interop := New(testLogger(), 1000, chains, invalidDir, nil)
+
+	// New returns nil when DB fails to open
+	require.Nil(t, interop)
+}
+
+func TestNew_EmptyChains(t *testing.T) {
+	t.Parallel()
+	dataDir := t.TempDir()
+
+	chains := map[eth.ChainID]cc.ChainContainer{}
+
+	interop := New(testLogger(), 0, chains, dataDir, nil)
+
+	require.NotNil(t, interop)
+	require.Empty(t, interop.chains)
+}
+
+func TestNew_MultipleChains(t *testing.T) {
+	t.Parallel()
+	dataDir := t.TempDir()
+
+	chains := map[eth.ChainID]cc.ChainContainer{
+		eth.ChainIDFromUInt64(10):   newMockChainContainer(10),
+		eth.ChainIDFromUInt64(8453): newMockChainContainer(8453),
+		eth.ChainIDFromUInt64(420):  newMockChainContainer(420),
+	}
+
+	interop := New(testLogger(), 500, chains, dataDir, nil)
+
+	require.NotNil(t, interop)
+	require.Len(t, interop.chains, 3)
+}
+
+// =============================================================================
+// Lifecycle Tests
+// =============================================================================
+
+func TestStart_BlocksUntilContextCanceled(t *testing.T) {
+	t.Parallel()
+	dataDir := t.TempDir()
+
+	mock := newMockChainContainer(10)
+	mock.currentL1 = eth.BlockRef{Number: 100, Hash: common.HexToHash("0x1")}
+	mock.blockAtTimestamp = eth.L2BlockRef{Number: 50}
+
+	chains := map[eth.ChainID]cc.ChainContainer{mock.id: mock}
+	interop := New(testLogger(), 1000, chains, dataDir, nil)
+	require.NotNil(t, interop)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan error, 1)
+	go func() {
+		done <- interop.Start(ctx)
+	}()
+
+	// Give it time to start the loop
+	time.Sleep(100 * time.Millisecond)
+
+	// Cancel and verify it exits
+	cancel()
+
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start should exit after context cancellation")
+	}
+}
+
+func TestStart_AlreadyStarted(t *testing.T) {
+	t.Parallel()
+	dataDir := t.TempDir()
+
+	mock := newMockChainContainer(10)
+	mock.currentL1 = eth.BlockRef{Number: 100, Hash: common.HexToHash("0x1")}
+
+	chains := map[eth.ChainID]cc.ChainContainer{mock.id: mock}
+	interop := New(testLogger(), 1000, chains, dataDir, nil)
+	require.NotNil(t, interop)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Start first instance
+	go func() {
+		_ = interop.Start(ctx)
+	}()
+
+	// Wait for it to mark as started
+	time.Sleep(100 * time.Millisecond)
+
+	// Try to start again - should block on context
+	ctx2, cancel2 := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel2()
+
+	err := interop.Start(ctx2)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestStop_ClosesVerifiedDB(t *testing.T) {
+	t.Parallel()
+	dataDir := t.TempDir()
+
+	chains := map[eth.ChainID]cc.ChainContainer{}
+	interop := New(testLogger(), 1000, chains, dataDir, nil)
+	require.NotNil(t, interop)
+
+	err := interop.Stop(context.Background())
+	require.NoError(t, err)
+
+	// Verify DB is closed by trying to use it (should fail)
+	_, err = interop.verifiedDB.Has(100)
+	require.Error(t, err) // LevelDB returns error on closed DB
+}
+
+func TestStop_CancelsRunningContext(t *testing.T) {
+	t.Parallel()
+	dataDir := t.TempDir()
+
+	mock := newMockChainContainer(10)
+	mock.currentL1 = eth.BlockRef{Number: 100, Hash: common.HexToHash("0x1")}
+	mock.blockAtTimestampErr = ethereum.NotFound // Keep it in "not ready" state
+
+	chains := map[eth.ChainID]cc.ChainContainer{mock.id: mock}
+	interop := New(testLogger(), 1000, chains, dataDir, nil)
+	require.NotNil(t, interop)
+
+	ctx := context.Background()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- interop.Start(ctx)
+	}()
+
+	// Wait for start
+	time.Sleep(100 * time.Millisecond)
+
+	// Stop should cancel the internal context
+	err := interop.Stop(context.Background())
+	require.NoError(t, err)
+
+	select {
+	case <-done:
+		// Success - Start exited
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start should exit after Stop is called")
+	}
+}
+
+func TestStop_NilCancel(t *testing.T) {
+	t.Parallel()
+	dataDir := t.TempDir()
+
+	chains := map[eth.ChainID]cc.ChainContainer{}
+	interop := New(testLogger(), 1000, chains, dataDir, nil)
+	require.NotNil(t, interop)
+
+	// Stop without ever starting - cancel is nil
+	err := interop.Stop(context.Background())
+	require.NoError(t, err)
+}
+
+// =============================================================================
+// collectCurrentL1s Tests
+// =============================================================================
+
+func TestCollectCurrentL1s_Success(t *testing.T) {
+	t.Parallel()
+	dataDir := t.TempDir()
+
+	mock1 := newMockChainContainer(10)
+	mock1.currentL1 = eth.BlockRef{Number: 100, Hash: common.HexToHash("0x1")}
+
+	mock2 := newMockChainContainer(8453)
+	mock2.currentL1 = eth.BlockRef{Number: 200, Hash: common.HexToHash("0x2")}
+
+	chains := map[eth.ChainID]cc.ChainContainer{
+		mock1.id: mock1,
+		mock2.id: mock2,
+	}
+	interop := New(testLogger(), 1000, chains, dataDir, nil)
+	require.NotNil(t, interop)
+	interop.ctx = context.Background()
+
+	l1s, err := interop.collectCurrentL1s()
+
+	require.NoError(t, err)
+	require.Len(t, l1s, 2)
+	require.Equal(t, uint64(100), l1s[mock1.id].Number)
+	require.Equal(t, uint64(200), l1s[mock2.id].Number)
+}
+
+func TestCollectCurrentL1s_ChainNotReady_Error(t *testing.T) {
+	t.Parallel()
+	dataDir := t.TempDir()
+
+	mock := newMockChainContainer(10)
+	mock.currentL1Err = errors.New("chain not synced")
+
+	chains := map[eth.ChainID]cc.ChainContainer{mock.id: mock}
+	interop := New(testLogger(), 1000, chains, dataDir, nil)
+	require.NotNil(t, interop)
+	interop.ctx = context.Background()
+
+	l1s, err := interop.collectCurrentL1s()
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not ready")
+	require.Nil(t, l1s)
+}
+
+func TestCollectCurrentL1s_EmptyBlockRef(t *testing.T) {
+	t.Parallel()
+	dataDir := t.TempDir()
+
+	mock := newMockChainContainer(10)
+	mock.currentL1 = eth.BlockRef{} // Empty - derivation not started
+
+	chains := map[eth.ChainID]cc.ChainContainer{mock.id: mock}
+	interop := New(testLogger(), 1000, chains, dataDir, nil)
+	require.NotNil(t, interop)
+	interop.ctx = context.Background()
+
+	l1s, err := interop.collectCurrentL1s()
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not yet populated")
+	require.Nil(t, l1s)
+}
+
+func TestCollectCurrentL1s_EmptyChains(t *testing.T) {
+	t.Parallel()
+	dataDir := t.TempDir()
+
+	chains := map[eth.ChainID]cc.ChainContainer{}
+	interop := New(testLogger(), 1000, chains, dataDir, nil)
+	require.NotNil(t, interop)
+	interop.ctx = context.Background()
+
+	l1s, err := interop.collectCurrentL1s()
+
+	require.NoError(t, err)
+	require.Empty(t, l1s)
+}
+
+// =============================================================================
+// updateCurrentL1s Tests
+// =============================================================================
+
+// testableInterop wraps Interop with a mock L1 client for testing
+type testableInterop struct {
+	*Interop
+	mockL1 *mockL1Client
+}
+
+func newTestableInterop(t *testing.T, chains map[eth.ChainID]cc.ChainContainer, activationTs uint64) *testableInterop {
+	dataDir := t.TempDir()
+	interop := New(testLogger(), activationTs, chains, dataDir, nil)
+	require.NotNil(t, interop)
+	interop.ctx = context.Background()
+
+	mockL1 := newMockL1Client()
+	return &testableInterop{
+		Interop: interop,
+		mockL1:  mockL1,
+	}
+}
+
+// Override updateCurrentL1s to use mock L1 client
+func (ti *testableInterop) updateCurrentL1sWithMock(currentL1s map[eth.ChainID]eth.BlockID) error {
+	for _, l1Head := range currentL1s {
+		ti.log.Info("updating current L1s", "l1Head", l1Head)
+		if l1Head == (eth.BlockID{}) {
+			continue
+		}
+		header, err := ti.mockL1.L1BlockRefByNumber(ti.ctx, l1Head.Number)
+		if err != nil {
+			return err
+		}
+		if header.ID() != l1Head {
+			return ErrInconsistentL1Heads
+		}
+	}
+	ti.currentL1s = currentL1s
+	return nil
+}
+
+func TestUpdateCurrentL1s_Success(t *testing.T) {
+	t.Parallel()
+
+	chains := map[eth.ChainID]cc.ChainContainer{}
+	ti := newTestableInterop(t, chains, 1000)
+
+	blockHash := common.HexToHash("0xabc")
+	ti.mockL1.blockRefs[100] = eth.L1BlockRef{
+		Hash:   blockHash,
+		Number: 100,
+	}
+
+	currentL1s := map[eth.ChainID]eth.BlockID{
+		eth.ChainIDFromUInt64(10): {Hash: blockHash, Number: 100},
+	}
+
+	err := ti.updateCurrentL1sWithMock(currentL1s)
+
+	require.NoError(t, err)
+	require.Equal(t, currentL1s, ti.currentL1s)
+}
+
+func TestUpdateCurrentL1s_InconsistentHeads(t *testing.T) {
+	t.Parallel()
+
+	chains := map[eth.ChainID]cc.ChainContainer{}
+	ti := newTestableInterop(t, chains, 1000)
+
+	// L1 client returns different hash for same block number (reorg)
+	ti.mockL1.blockRefs[100] = eth.L1BlockRef{
+		Hash:   common.HexToHash("0xdifferent"),
+		Number: 100,
+	}
+
+	currentL1s := map[eth.ChainID]eth.BlockID{
+		eth.ChainIDFromUInt64(10): {Hash: common.HexToHash("0xoriginal"), Number: 100},
+	}
+
+	err := ti.updateCurrentL1sWithMock(currentL1s)
+
+	require.ErrorIs(t, err, ErrInconsistentL1Heads)
+}
+
+func TestUpdateCurrentL1s_EmptyBlockID(t *testing.T) {
+	t.Parallel()
+
+	chains := map[eth.ChainID]cc.ChainContainer{}
+	ti := newTestableInterop(t, chains, 1000)
+
+	// Empty BlockID should be skipped
+	currentL1s := map[eth.ChainID]eth.BlockID{
+		eth.ChainIDFromUInt64(10): {}, // Empty
+	}
+
+	err := ti.updateCurrentL1sWithMock(currentL1s)
+
+	require.NoError(t, err)
+}
+
+func TestUpdateCurrentL1s_L1ClientError(t *testing.T) {
+	t.Parallel()
+
+	chains := map[eth.ChainID]cc.ChainContainer{}
+	ti := newTestableInterop(t, chains, 1000)
+
+	ti.mockL1.err = errors.New("L1 RPC error")
+
+	currentL1s := map[eth.ChainID]eth.BlockID{
+		eth.ChainIDFromUInt64(10): {Hash: common.HexToHash("0x1"), Number: 100},
+	}
+
+	err := ti.updateCurrentL1sWithMock(currentL1s)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "L1 RPC error")
+}
+
+// =============================================================================
+// checkChainsReady Tests
+// =============================================================================
+
+func TestCheckChainsReady_AllReady(t *testing.T) {
+	t.Parallel()
+	dataDir := t.TempDir()
+
+	mock1 := newMockChainContainer(10)
+	mock1.blockAtTimestamp = eth.L2BlockRef{Number: 100, Hash: common.HexToHash("0x1")}
+
+	mock2 := newMockChainContainer(8453)
+	mock2.blockAtTimestamp = eth.L2BlockRef{Number: 200, Hash: common.HexToHash("0x2")}
+
+	chains := map[eth.ChainID]cc.ChainContainer{
+		mock1.id: mock1,
+		mock2.id: mock2,
+	}
+	interop := New(testLogger(), 1000, chains, dataDir, nil)
+	require.NotNil(t, interop)
+	interop.ctx = context.Background()
+
+	blocks, err := interop.checkChainsReady(1000)
+
+	require.NoError(t, err)
+	require.Len(t, blocks, 2)
+	require.Equal(t, uint64(100), blocks[mock1.id].Number)
+	require.Equal(t, uint64(200), blocks[mock2.id].Number)
+}
+
+func TestCheckChainsReady_OneNotReady(t *testing.T) {
+	t.Parallel()
+	dataDir := t.TempDir()
+
+	mock1 := newMockChainContainer(10)
+	mock1.blockAtTimestamp = eth.L2BlockRef{Number: 100}
+
+	mock2 := newMockChainContainer(8453)
+	mock2.blockAtTimestampErr = ethereum.NotFound // Not ready
+
+	chains := map[eth.ChainID]cc.ChainContainer{
+		mock1.id: mock1,
+		mock2.id: mock2,
+	}
+	interop := New(testLogger(), 1000, chains, dataDir, nil)
+	require.NotNil(t, interop)
+	interop.ctx = context.Background()
+
+	blocks, err := interop.checkChainsReady(1000)
+
+	require.Error(t, err)
+	require.Nil(t, blocks)
+}
+
+func TestCheckChainsReady_EmptyChains(t *testing.T) {
+	t.Parallel()
+	dataDir := t.TempDir()
+
+	chains := map[eth.ChainID]cc.ChainContainer{}
+	interop := New(testLogger(), 1000, chains, dataDir, nil)
+	require.NotNil(t, interop)
+	interop.ctx = context.Background()
+
+	blocks, err := interop.checkChainsReady(1000)
+
+	require.NoError(t, err)
+	require.Empty(t, blocks)
+}
+
+func TestCheckChainsReady_ParallelQueries(t *testing.T) {
+	t.Parallel()
+	dataDir := t.TempDir()
+
+	// Create multiple chains to test parallel execution
+	var mocks []*mockChainContainer
+	chains := make(map[eth.ChainID]cc.ChainContainer)
+
+	for i := 0; i < 5; i++ {
+		mock := newMockChainContainer(uint64(10 + i))
+		mock.blockAtTimestamp = eth.L2BlockRef{Number: uint64(100 + i)}
+		mocks = append(mocks, mock)
+		chains[mock.id] = mock
+	}
+
+	interop := New(testLogger(), 1000, chains, dataDir, nil)
+	require.NotNil(t, interop)
+	interop.ctx = context.Background()
+
+	blocks, err := interop.checkChainsReady(1000)
+
+	require.NoError(t, err)
+	require.Len(t, blocks, 5)
+
+	// Verify all chains were queried
+	for _, mock := range mocks {
+		require.Contains(t, blocks, mock.id)
+	}
+}
+
+// =============================================================================
+// progressInterop Tests
+// =============================================================================
+
+func TestProgressInterop_NotInitialized_UsesActivationTimestamp(t *testing.T) {
+	t.Parallel()
+	dataDir := t.TempDir()
+
+	mock := newMockChainContainer(10)
+	mock.blockAtTimestamp = eth.L2BlockRef{Number: 100, Hash: common.HexToHash("0x1")}
+
+	chains := map[eth.ChainID]cc.ChainContainer{mock.id: mock}
+	interop := New(testLogger(), 5000, chains, dataDir, nil) // activation at 5000
+	require.NotNil(t, interop)
+	interop.ctx = context.Background()
+
+	err := interop.progressInterop()
+
+	require.NoError(t, err)
+
+	// Check that timestamp 5000 was committed
+	has, err := interop.verifiedDB.Has(5000)
+	require.NoError(t, err)
+	require.True(t, has)
+}
+
+func TestProgressInterop_Initialized_UsesNextTimestamp(t *testing.T) {
+	t.Parallel()
+	dataDir := t.TempDir()
+
+	mock := newMockChainContainer(10)
+	mock.blockAtTimestamp = eth.L2BlockRef{Number: 100, Hash: common.HexToHash("0x1")}
+
+	chains := map[eth.ChainID]cc.ChainContainer{mock.id: mock}
+	interop := New(testLogger(), 1000, chains, dataDir, nil)
+	require.NotNil(t, interop)
+	interop.ctx = context.Background()
+
+	// First progress - commits timestamp 1000
+	err := interop.progressInterop()
+	require.NoError(t, err)
+
+	// Second progress - should commit timestamp 1001
+	err = interop.progressInterop()
+	require.NoError(t, err)
+
+	has, err := interop.verifiedDB.Has(1001)
+	require.NoError(t, err)
+	require.True(t, has)
+}
+
+func TestProgressInterop_ChainsNotReady_ReturnsEarly(t *testing.T) {
+	t.Parallel()
+	dataDir := t.TempDir()
+
+	mock := newMockChainContainer(10)
+	mock.blockAtTimestampErr = ethereum.NotFound // Not ready
+
+	chains := map[eth.ChainID]cc.ChainContainer{mock.id: mock}
+	interop := New(testLogger(), 1000, chains, dataDir, nil)
+	require.NotNil(t, interop)
+	interop.ctx = context.Background()
+
+	err := interop.progressInterop()
+
+	require.NoError(t, err) // Returns nil when chains not ready
+
+	// Nothing should be committed
+	has, err := interop.verifiedDB.Has(1000)
+	require.NoError(t, err)
+	require.False(t, has)
+}
+
+func TestProgressInterop_ChainError(t *testing.T) {
+	t.Parallel()
+	dataDir := t.TempDir()
+
+	mock := newMockChainContainer(10)
+	mock.blockAtTimestampErr = errors.New("internal error")
+
+	chains := map[eth.ChainID]cc.ChainContainer{mock.id: mock}
+	interop := New(testLogger(), 1000, chains, dataDir, nil)
+	require.NotNil(t, interop)
+	interop.ctx = context.Background()
+
+	err := interop.progressInterop()
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "internal error")
+}
+
+// =============================================================================
+// CurrentL1 Tests
+// =============================================================================
+
+func TestCurrentL1_ReturnsMinimum(t *testing.T) {
+	t.Parallel()
+	dataDir := t.TempDir()
+
+	chains := map[eth.ChainID]cc.ChainContainer{}
+	interop := New(testLogger(), 1000, chains, dataDir, nil)
+	require.NotNil(t, interop)
+
+	interop.currentL1s = map[eth.ChainID]eth.BlockID{
+		eth.ChainIDFromUInt64(10):   {Number: 300, Hash: common.HexToHash("0x3")},
+		eth.ChainIDFromUInt64(8453): {Number: 100, Hash: common.HexToHash("0x1")}, // Minimum
+		eth.ChainIDFromUInt64(420):  {Number: 200, Hash: common.HexToHash("0x2")},
+	}
+
+	result := interop.CurrentL1()
+
+	require.Equal(t, uint64(100), result.Number)
+	require.Equal(t, common.HexToHash("0x1"), result.Hash)
+}
+
+func TestCurrentL1_EmptyReturnsZero(t *testing.T) {
+	t.Parallel()
+	dataDir := t.TempDir()
+
+	chains := map[eth.ChainID]cc.ChainContainer{}
+	interop := New(testLogger(), 1000, chains, dataDir, nil)
+	require.NotNil(t, interop)
+
+	result := interop.CurrentL1()
+
+	require.Equal(t, eth.BlockID{}, result)
+}
+
+func TestCurrentL1_SingleChain(t *testing.T) {
+	t.Parallel()
+	dataDir := t.TempDir()
+
+	chains := map[eth.ChainID]cc.ChainContainer{}
+	interop := New(testLogger(), 1000, chains, dataDir, nil)
+	require.NotNil(t, interop)
+
+	interop.currentL1s = map[eth.ChainID]eth.BlockID{
+		eth.ChainIDFromUInt64(10): {Number: 500, Hash: common.HexToHash("0x5")},
+	}
+
+	result := interop.CurrentL1()
+
+	require.Equal(t, uint64(500), result.Number)
+}
+
+// =============================================================================
+// VerifiedAtTimestamp Tests
+// =============================================================================
+
+func TestVerifiedAtTimestamp_Exists(t *testing.T) {
+	t.Parallel()
+	dataDir := t.TempDir()
+
+	mock := newMockChainContainer(10)
+	mock.blockAtTimestamp = eth.L2BlockRef{Number: 100}
+
+	chains := map[eth.ChainID]cc.ChainContainer{mock.id: mock}
+	interop := New(testLogger(), 1000, chains, dataDir, nil)
+	require.NotNil(t, interop)
+	interop.ctx = context.Background()
+
+	// Progress to commit timestamp 1000
+	err := interop.progressInterop()
+	require.NoError(t, err)
+
+	verified, err := interop.VerifiedAtTimestamp(1000)
+
+	require.NoError(t, err)
+	require.True(t, verified)
+}
+
+func TestVerifiedAtTimestamp_NotExists(t *testing.T) {
+	t.Parallel()
+	dataDir := t.TempDir()
+
+	chains := map[eth.ChainID]cc.ChainContainer{}
+	interop := New(testLogger(), 1000, chains, dataDir, nil)
+	require.NotNil(t, interop)
+
+	verified, err := interop.VerifiedAtTimestamp(9999)
+
+	require.NoError(t, err)
+	require.False(t, verified)
+}
+
+// =============================================================================
+// verifyInteropMessages Tests
+// =============================================================================
+
+func TestVerifyInteropMessages_CopiesBlocks(t *testing.T) {
+	t.Parallel()
+	dataDir := t.TempDir()
+
+	mock1 := newMockChainContainer(10)
+	mock2 := newMockChainContainer(8453)
+
+	chains := map[eth.ChainID]cc.ChainContainer{
+		mock1.id: mock1,
+		mock2.id: mock2,
+	}
+	interop := New(testLogger(), 1000, chains, dataDir, nil)
+	require.NotNil(t, interop)
+
+	blocksAtTimestamp := map[eth.ChainID]eth.BlockID{
+		mock1.id: {Number: 100, Hash: common.HexToHash("0x1")},
+		mock2.id: {Number: 200, Hash: common.HexToHash("0x2")},
+	}
+
+	result, err := interop.verifyInteropMessages(1000, blocksAtTimestamp)
+
+	require.NoError(t, err)
+	require.Equal(t, uint64(1000), result.Timestamp)
+	require.Len(t, result.L2Heads, 2)
+	require.Equal(t, blocksAtTimestamp[mock1.id], result.L2Heads[mock1.id])
+	require.Equal(t, blocksAtTimestamp[mock2.id], result.L2Heads[mock2.id])
+	require.True(t, result.IsValid()) // No invalid heads in stub implementation
+}
+
+// =============================================================================
+// Integration Tests
+// =============================================================================
+
+func TestInterop_FullCycle(t *testing.T) {
+	t.Parallel()
+	dataDir := t.TempDir()
+
+	mock := newMockChainContainer(10)
+	mock.currentL1 = eth.BlockRef{Number: 1000, Hash: common.HexToHash("0xL1")}
+	mock.blockAtTimestamp = eth.L2BlockRef{Number: 500, Hash: common.HexToHash("0xL2")}
+
+	chains := map[eth.ChainID]cc.ChainContainer{mock.id: mock}
+	interop := New(testLogger(), 100, chains, dataDir, nil)
+	require.NotNil(t, interop)
+	interop.ctx = context.Background()
+
+	// Simulate multiple interop cycles
+	for i := 0; i < 3; i++ {
+		// Collect L1s
+		l1s, err := interop.collectCurrentL1s()
+		require.NoError(t, err)
+		require.Len(t, l1s, 1)
+
+		// Progress
+		err = interop.progressInterop()
+		require.NoError(t, err)
+	}
+
+	// Verify timestamps were committed sequentially
+	for ts := uint64(100); ts <= 102; ts++ {
+		has, err := interop.verifiedDB.Has(ts)
+		require.NoError(t, err)
+		require.True(t, has, "timestamp %d should be verified", ts)
+	}
+}

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-supernode/supernode/activity"
 	cc "github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
@@ -47,6 +48,8 @@ func (m *mockChainContainer) CurrentL1(ctx context.Context) (eth.BlockRef, error
 	return m.currentL1, m.currentL1Err
 }
 
+func (m *mockChainContainer) RegisterVerifier(v activity.VerificationActivity) {
+}
 func (m *mockChainContainer) BlockAtTimestamp(ctx context.Context, ts uint64, label eth.BlockLabel) (eth.L2BlockRef, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/op-supernode/supernode/activity/interop/types.go
+++ b/op-supernode/supernode/activity/interop/types.go
@@ -28,6 +28,10 @@ func (r *Result) IsValid() bool {
 	return len(r.InvalidHeads) == 0
 }
 
+func (r *Result) IsEmpty() bool {
+	return r.L1Head == (eth.BlockID{}) && len(r.L2Heads) == 0 && len(r.InvalidHeads) == 0
+}
+
 var ErrInvalidResult = errors.New("result is invalid")
 
 func (r *Result) ToVerifiedResult() VerifiedResult {

--- a/op-supernode/supernode/activity/interop/types.go
+++ b/op-supernode/supernode/activity/interop/types.go
@@ -1,0 +1,39 @@
+package interop
+
+import (
+	"errors"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+// VerifiedResult represents the verified state at a specific timestamp.
+// It contains the L1 head from which the L2 heads were derived,
+// and a map of each chain's L2 head at that timestamp.
+type VerifiedResult struct {
+	Timestamp uint64                      `json:"timestamp"`
+	L1Head    eth.BlockID                 `json:"l1Head"`
+	L2Heads   map[eth.ChainID]eth.BlockID `json:"l2Heads"`
+}
+
+// Result represents the result of interop validation at a specific timestamp given current data.
+// it contains all the same information as VerifiedResult, but also contains a list of invalid heads.
+type Result struct {
+	Timestamp    uint64                      `json:"timestamp"`
+	L1Head       eth.BlockID                 `json:"l1Head"`
+	L2Heads      map[eth.ChainID]eth.BlockID `json:"l2Heads"`
+	InvalidHeads map[eth.ChainID]eth.BlockID `json:"invalidHeads"`
+}
+
+func (r *Result) IsValid() bool {
+	return len(r.InvalidHeads) == 0
+}
+
+var ErrInvalidResult = errors.New("result is invalid")
+
+func (r *Result) ToVerifiedResult() VerifiedResult {
+	return VerifiedResult{
+		Timestamp: r.Timestamp,
+		L1Head:    r.L1Head,
+		L2Heads:   r.L2Heads,
+	}
+}

--- a/op-supernode/supernode/activity/interop/types_test.go
+++ b/op-supernode/supernode/activity/interop/types_test.go
@@ -153,4 +153,3 @@ func TestVerifiedResult_Structure(t *testing.T) {
 		require.Equal(t, uint64(1000), vr.L2Heads[chainID].Number)
 	})
 }
-

--- a/op-supernode/supernode/activity/interop/types_test.go
+++ b/op-supernode/supernode/activity/interop/types_test.go
@@ -1,0 +1,156 @@
+package interop
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResult_IsValid(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns true when InvalidHeads is nil", func(t *testing.T) {
+		r := Result{
+			Timestamp:    100,
+			L1Head:       eth.BlockID{Number: 1},
+			L2Heads:      map[eth.ChainID]eth.BlockID{eth.ChainIDFromUInt64(10): {Number: 100}},
+			InvalidHeads: nil,
+		}
+		require.True(t, r.IsValid())
+	})
+
+	t.Run("returns true when InvalidHeads is empty map", func(t *testing.T) {
+		r := Result{
+			Timestamp:    100,
+			L1Head:       eth.BlockID{Number: 1},
+			L2Heads:      map[eth.ChainID]eth.BlockID{eth.ChainIDFromUInt64(10): {Number: 100}},
+			InvalidHeads: map[eth.ChainID]eth.BlockID{},
+		}
+		require.True(t, r.IsValid())
+	})
+
+	t.Run("returns false when InvalidHeads has entries", func(t *testing.T) {
+		r := Result{
+			Timestamp: 100,
+			L1Head:    eth.BlockID{Number: 1},
+			L2Heads:   map[eth.ChainID]eth.BlockID{eth.ChainIDFromUInt64(10): {Number: 100}},
+			InvalidHeads: map[eth.ChainID]eth.BlockID{
+				eth.ChainIDFromUInt64(10): {Number: 100, Hash: common.HexToHash("0xbad")},
+			},
+		}
+		require.False(t, r.IsValid())
+	})
+
+	t.Run("returns false with multiple invalid heads", func(t *testing.T) {
+		r := Result{
+			Timestamp: 100,
+			InvalidHeads: map[eth.ChainID]eth.BlockID{
+				eth.ChainIDFromUInt64(10):   {Number: 100},
+				eth.ChainIDFromUInt64(8453): {Number: 200},
+			},
+		}
+		require.False(t, r.IsValid())
+	})
+}
+
+func TestResult_ToVerifiedResult(t *testing.T) {
+	t.Parallel()
+
+	t.Run("copies all fields except InvalidHeads", func(t *testing.T) {
+		chainID1 := eth.ChainIDFromUInt64(10)
+		chainID2 := eth.ChainIDFromUInt64(8453)
+
+		r := Result{
+			Timestamp: 12345,
+			L1Head: eth.BlockID{
+				Hash:   common.HexToHash("0x1111"),
+				Number: 100,
+			},
+			L2Heads: map[eth.ChainID]eth.BlockID{
+				chainID1: {Hash: common.HexToHash("0x2222"), Number: 200},
+				chainID2: {Hash: common.HexToHash("0x3333"), Number: 300},
+			},
+			InvalidHeads: map[eth.ChainID]eth.BlockID{
+				chainID1: {Hash: common.HexToHash("0xbad"), Number: 199},
+			},
+		}
+
+		verified := r.ToVerifiedResult()
+
+		require.Equal(t, r.Timestamp, verified.Timestamp)
+		require.Equal(t, r.L1Head, verified.L1Head)
+		require.Equal(t, r.L2Heads, verified.L2Heads)
+	})
+
+	t.Run("handles nil L2Heads", func(t *testing.T) {
+		r := Result{
+			Timestamp: 100,
+			L1Head:    eth.BlockID{Number: 1},
+			L2Heads:   nil,
+		}
+
+		verified := r.ToVerifiedResult()
+
+		require.Equal(t, r.Timestamp, verified.Timestamp)
+		require.Nil(t, verified.L2Heads)
+	})
+
+	t.Run("handles empty L2Heads", func(t *testing.T) {
+		r := Result{
+			Timestamp: 100,
+			L1Head:    eth.BlockID{Number: 1},
+			L2Heads:   map[eth.ChainID]eth.BlockID{},
+		}
+
+		verified := r.ToVerifiedResult()
+
+		require.Empty(t, verified.L2Heads)
+	})
+
+	t.Run("original Result unchanged after conversion", func(t *testing.T) {
+		chainID := eth.ChainIDFromUInt64(10)
+		r := Result{
+			Timestamp: 100,
+			L1Head:    eth.BlockID{Number: 1},
+			L2Heads: map[eth.ChainID]eth.BlockID{
+				chainID: {Number: 200},
+			},
+			InvalidHeads: map[eth.ChainID]eth.BlockID{
+				chainID: {Number: 199},
+			},
+		}
+
+		_ = r.ToVerifiedResult()
+
+		// Original should still have InvalidHeads
+		require.Len(t, r.InvalidHeads, 1)
+	})
+}
+
+func TestVerifiedResult_Structure(t *testing.T) {
+	t.Parallel()
+
+	t.Run("can be created with all fields", func(t *testing.T) {
+		chainID := eth.ChainIDFromUInt64(42161)
+		vr := VerifiedResult{
+			Timestamp: 999,
+			L1Head: eth.BlockID{
+				Hash:   common.HexToHash("0xabcd"),
+				Number: 50,
+			},
+			L2Heads: map[eth.ChainID]eth.BlockID{
+				chainID: {
+					Hash:   common.HexToHash("0xef01"),
+					Number: 1000,
+				},
+			},
+		}
+
+		require.Equal(t, uint64(999), vr.Timestamp)
+		require.Equal(t, uint64(50), vr.L1Head.Number)
+		require.Equal(t, uint64(1000), vr.L2Heads[chainID].Number)
+	})
+}
+

--- a/op-supernode/supernode/activity/interop/types_test.go
+++ b/op-supernode/supernode/activity/interop/types_test.go
@@ -128,28 +128,3 @@ func TestResult_ToVerifiedResult(t *testing.T) {
 		require.Len(t, r.InvalidHeads, 1)
 	})
 }
-
-func TestVerifiedResult_Structure(t *testing.T) {
-	t.Parallel()
-
-	t.Run("can be created with all fields", func(t *testing.T) {
-		chainID := eth.ChainIDFromUInt64(42161)
-		vr := VerifiedResult{
-			Timestamp: 999,
-			L1Head: eth.BlockID{
-				Hash:   common.HexToHash("0xabcd"),
-				Number: 50,
-			},
-			L2Heads: map[eth.ChainID]eth.BlockID{
-				chainID: {
-					Hash:   common.HexToHash("0xef01"),
-					Number: 1000,
-				},
-			},
-		}
-
-		require.Equal(t, uint64(999), vr.Timestamp)
-		require.Equal(t, uint64(50), vr.L1Head.Number)
-		require.Equal(t, uint64(1000), vr.L2Heads[chainID].Number)
-	})
-}

--- a/op-supernode/supernode/activity/interop/verified_db.go
+++ b/op-supernode/supernode/activity/interop/verified_db.go
@@ -77,7 +77,6 @@ func timestampToKey(ts uint64) []byte {
 // Timestamps must be committed sequentially with no gaps.
 func (v *VerifiedDB) Commit(result VerifiedResult) error {
 	ts := result.Timestamp
-	fmt.Printf("committing verified result: %+v\n", result)
 
 	// Check for sequential commitment
 	if v.initialized {

--- a/op-supernode/supernode/activity/interop/verified_db.go
+++ b/op-supernode/supernode/activity/interop/verified_db.go
@@ -18,6 +18,7 @@ var (
 	ErrNotFound         = errors.New("timestamp not found")
 	ErrNonSequential    = errors.New("timestamps must be committed sequentially with no gaps")
 	ErrAlreadyCommitted = errors.New("timestamp already committed")
+	u64Len              = 8
 )
 
 // bucketName is the name of the bbolt bucket used to store verified results.
@@ -71,7 +72,7 @@ func (v *VerifiedDB) initLastTimestamp() error {
 
 		c := b.Cursor()
 		key, _ := c.Last()
-		if len(key) == 8 {
+		if len(key) == u64Len {
 			v.lastTimestamp = binary.BigEndian.Uint64(key)
 			v.initialized = true
 		}
@@ -83,7 +84,7 @@ func (v *VerifiedDB) initLastTimestamp() error {
 // timestampToKey converts a timestamp to a big-endian byte key.
 // Using big-endian ensures lexicographic ordering matches numeric ordering.
 func timestampToKey(ts uint64) []byte {
-	key := make([]byte, 8)
+	key := make([]byte, u64Len)
 	binary.BigEndian.PutUint64(key, ts)
 	return key
 }

--- a/op-supernode/supernode/activity/interop/verified_db.go
+++ b/op-supernode/supernode/activity/interop/verified_db.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/syndtr/goleveldb/leveldb"
+	bolt "go.etcd.io/bbolt"
 )
 
 const (
@@ -20,19 +20,32 @@ var (
 	ErrAlreadyCommitted = errors.New("timestamp already committed")
 )
 
-// VerifiedDB provides persistence for verified timestamps using LevelDB.
+// bucketName is the name of the bbolt bucket used to store verified results.
+var bucketName = []byte("verified")
+
+// VerifiedDB provides persistence for verified timestamps using bbolt.
 type VerifiedDB struct {
-	db            *leveldb.DB
+	db            *bolt.DB
 	lastTimestamp uint64
 	initialized   bool
 }
 
 // OpenVerifiedDB opens or creates a VerifiedDB at the given data directory.
 func OpenVerifiedDB(dataDir string) (*VerifiedDB, error) {
-	dbPath := filepath.Join(dataDir, verifiedDBName)
-	db, err := leveldb.OpenFile(dbPath, nil)
+	dbPath := filepath.Join(dataDir, verifiedDBName+".db")
+	db, err := bolt.Open(dbPath, 0600, nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open leveldb at %s: %w", dbPath, err)
+		return nil, fmt.Errorf("failed to open bbolt at %s: %w", dbPath, err)
+	}
+
+	// Ensure the bucket exists
+	err = db.Update(func(tx *bolt.Tx) error {
+		_, err := tx.CreateBucketIfNotExists(bucketName)
+		return err
+	})
+	if err != nil {
+		db.Close()
+		return nil, fmt.Errorf("failed to create bucket: %w", err)
 	}
 
 	vdb := &VerifiedDB{
@@ -50,19 +63,21 @@ func OpenVerifiedDB(dataDir string) (*VerifiedDB, error) {
 
 // initLastTimestamp scans the database to find the highest committed timestamp.
 func (v *VerifiedDB) initLastTimestamp() error {
-	iter := v.db.NewIterator(nil, nil)
-	defer iter.Release()
+	return v.db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket(bucketName)
+		if b == nil {
+			return nil
+		}
 
-	// Seek to the last key
-	if iter.Last() {
-		key := iter.Key()
+		c := b.Cursor()
+		key, _ := c.Last()
 		if len(key) == 8 {
 			v.lastTimestamp = binary.BigEndian.Uint64(key)
 			v.initialized = true
 		}
-	}
 
-	return iter.Error()
+		return nil
+	})
 }
 
 // timestampToKey converts a timestamp to a big-endian byte key.
@@ -96,8 +111,12 @@ func (v *VerifiedDB) Commit(result VerifiedResult) error {
 
 	// Store in database
 	key := timestampToKey(ts)
-	if err := v.db.Put(key, value, nil); err != nil {
-		return fmt.Errorf("failed to write to leveldb: %w", err)
+	err = v.db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket(bucketName)
+		return b.Put(key, value)
+	})
+	if err != nil {
+		return fmt.Errorf("failed to write to bbolt: %w", err)
 	}
 
 	// Update state
@@ -110,12 +129,24 @@ func (v *VerifiedDB) Commit(result VerifiedResult) error {
 // Get retrieves the verified result at the given timestamp.
 func (v *VerifiedDB) Get(ts uint64) (VerifiedResult, error) {
 	key := timestampToKey(ts)
-	value, err := v.db.Get(key, nil)
+	var value []byte
+
+	err := v.db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket(bucketName)
+		val := b.Get(key)
+		if val == nil {
+			return ErrNotFound
+		}
+		// Copy the value since it's only valid for the life of the transaction
+		value = make([]byte, len(val))
+		copy(value, val)
+		return nil
+	})
 	if err != nil {
-		if errors.Is(err, leveldb.ErrNotFound) {
+		if errors.Is(err, ErrNotFound) {
 			return VerifiedResult{}, ErrNotFound
 		}
-		return VerifiedResult{}, fmt.Errorf("failed to read from leveldb: %w", err)
+		return VerifiedResult{}, fmt.Errorf("failed to read from bbolt: %w", err)
 	}
 
 	var result VerifiedResult
@@ -129,7 +160,18 @@ func (v *VerifiedDB) Get(ts uint64) (VerifiedResult, error) {
 // Has returns whether a timestamp has been verified.
 func (v *VerifiedDB) Has(ts uint64) (bool, error) {
 	key := timestampToKey(ts)
-	return v.db.Has(key, nil)
+	var found bool
+
+	err := v.db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket(bucketName)
+		found = b.Get(key) != nil
+		return nil
+	})
+	if err != nil {
+		return false, fmt.Errorf("failed to check key in bbolt: %w", err)
+	}
+
+	return found, nil
 }
 
 // LastTimestamp returns the most recently committed timestamp.

--- a/op-supernode/supernode/activity/interop/verified_db.go
+++ b/op-supernode/supernode/activity/interop/verified_db.go
@@ -1,0 +1,145 @@
+package interop
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path/filepath"
+
+	"github.com/syndtr/goleveldb/leveldb"
+)
+
+const (
+	verifiedDBName = "VerifiedAtTimestamp"
+)
+
+var (
+	ErrNotFound         = errors.New("timestamp not found")
+	ErrNonSequential    = errors.New("timestamps must be committed sequentially with no gaps")
+	ErrAlreadyCommitted = errors.New("timestamp already committed")
+)
+
+// VerifiedDB provides persistence for verified timestamps using LevelDB.
+type VerifiedDB struct {
+	db            *leveldb.DB
+	lastTimestamp uint64
+	initialized   bool
+}
+
+// OpenVerifiedDB opens or creates a VerifiedDB at the given data directory.
+func OpenVerifiedDB(dataDir string) (*VerifiedDB, error) {
+	dbPath := filepath.Join(dataDir, verifiedDBName)
+	db, err := leveldb.OpenFile(dbPath, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open leveldb at %s: %w", dbPath, err)
+	}
+
+	vdb := &VerifiedDB{
+		db: db,
+	}
+
+	// Initialize the last timestamp from the database
+	if err := vdb.initLastTimestamp(); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("failed to initialize last timestamp: %w", err)
+	}
+
+	return vdb, nil
+}
+
+// initLastTimestamp scans the database to find the highest committed timestamp.
+func (v *VerifiedDB) initLastTimestamp() error {
+	iter := v.db.NewIterator(nil, nil)
+	defer iter.Release()
+
+	// Seek to the last key
+	if iter.Last() {
+		key := iter.Key()
+		if len(key) == 8 {
+			v.lastTimestamp = binary.BigEndian.Uint64(key)
+			v.initialized = true
+		}
+	}
+
+	return iter.Error()
+}
+
+// timestampToKey converts a timestamp to a big-endian byte key.
+// Using big-endian ensures lexicographic ordering matches numeric ordering.
+func timestampToKey(ts uint64) []byte {
+	key := make([]byte, 8)
+	binary.BigEndian.PutUint64(key, ts)
+	return key
+}
+
+// Commit stores a verified result at the given timestamp.
+// Timestamps must be committed sequentially with no gaps.
+func (v *VerifiedDB) Commit(result VerifiedResult) error {
+	ts := result.Timestamp
+	fmt.Printf("committing verified result: %+v\n", result)
+
+	// Check for sequential commitment
+	if v.initialized {
+		if ts != v.lastTimestamp+1 {
+			if ts <= v.lastTimestamp {
+				return fmt.Errorf("%w: %d", ErrAlreadyCommitted, ts)
+			}
+			return fmt.Errorf("%w: expected %d, got %d", ErrNonSequential, v.lastTimestamp+1, ts)
+		}
+	}
+
+	// Serialize the result
+	value, err := json.Marshal(result)
+	if err != nil {
+		return fmt.Errorf("failed to marshal verified result: %w", err)
+	}
+
+	// Store in database
+	key := timestampToKey(ts)
+	if err := v.db.Put(key, value, nil); err != nil {
+		return fmt.Errorf("failed to write to leveldb: %w", err)
+	}
+
+	// Update state
+	v.lastTimestamp = ts
+	v.initialized = true
+
+	return nil
+}
+
+// Get retrieves the verified result at the given timestamp.
+func (v *VerifiedDB) Get(ts uint64) (VerifiedResult, error) {
+	key := timestampToKey(ts)
+	value, err := v.db.Get(key, nil)
+	if err != nil {
+		if errors.Is(err, leveldb.ErrNotFound) {
+			return VerifiedResult{}, ErrNotFound
+		}
+		return VerifiedResult{}, fmt.Errorf("failed to read from leveldb: %w", err)
+	}
+
+	var result VerifiedResult
+	if err := json.Unmarshal(value, &result); err != nil {
+		return VerifiedResult{}, fmt.Errorf("failed to unmarshal verified result: %w", err)
+	}
+
+	return result, nil
+}
+
+// Has returns whether a timestamp has been verified.
+func (v *VerifiedDB) Has(ts uint64) (bool, error) {
+	key := timestampToKey(ts)
+	return v.db.Has(key, nil)
+}
+
+// LastTimestamp returns the most recently committed timestamp.
+// Returns 0 and false if no timestamps have been committed.
+func (v *VerifiedDB) LastTimestamp() (uint64, bool) {
+	return v.lastTimestamp, v.initialized
+}
+
+// Close closes the database.
+func (v *VerifiedDB) Close() error {
+	return v.db.Close()
+}

--- a/op-supernode/supernode/activity/interop/verified_db_test.go
+++ b/op-supernode/supernode/activity/interop/verified_db_test.go
@@ -1,0 +1,177 @@
+package interop
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVerifiedDB_WriteAndRead(t *testing.T) {
+	// Create a temporary directory for the test database
+	dataDir := t.TempDir()
+
+	// Open the database
+	db, err := OpenVerifiedDB(dataDir)
+	require.NoError(t, err)
+	defer db.Close()
+
+	// Initially, there should be no last timestamp
+	lastTs, initialized := db.LastTimestamp()
+	require.False(t, initialized)
+	require.Equal(t, uint64(0), lastTs)
+
+	// Create test data
+	chainID1 := eth.ChainIDFromUInt64(10)
+	chainID2 := eth.ChainIDFromUInt64(8453)
+
+	result1 := VerifiedResult{
+		Timestamp: 1000,
+		L1Head: eth.BlockID{
+			Hash:   common.HexToHash("0x1111111111111111111111111111111111111111111111111111111111111111"),
+			Number: 100,
+		},
+		L2Heads: map[eth.ChainID]eth.BlockID{
+			chainID1: {
+				Hash:   common.HexToHash("0x2222222222222222222222222222222222222222222222222222222222222222"),
+				Number: 200,
+			},
+			chainID2: {
+				Hash:   common.HexToHash("0x3333333333333333333333333333333333333333333333333333333333333333"),
+				Number: 300,
+			},
+		},
+	}
+
+	// Write the first result
+	err = db.Commit(result1)
+	require.NoError(t, err)
+
+	// Verify the last timestamp was updated
+	lastTs, initialized = db.LastTimestamp()
+	require.True(t, initialized)
+	require.Equal(t, uint64(1000), lastTs)
+
+	// Read it back
+	retrieved, err := db.Get(1000)
+	require.NoError(t, err)
+	require.Equal(t, result1.Timestamp, retrieved.Timestamp)
+	require.Equal(t, result1.L1Head, retrieved.L1Head)
+	require.Equal(t, len(result1.L2Heads), len(retrieved.L2Heads))
+	require.Equal(t, result1.L2Heads[chainID1], retrieved.L2Heads[chainID1])
+	require.Equal(t, result1.L2Heads[chainID2], retrieved.L2Heads[chainID2])
+
+	// Check Has returns true
+	has, err := db.Has(1000)
+	require.NoError(t, err)
+	require.True(t, has)
+
+	// Check Has returns false for non-existent timestamp
+	has, err = db.Has(999)
+	require.NoError(t, err)
+	require.False(t, has)
+
+	// Try to read non-existent timestamp
+	_, err = db.Get(999)
+	require.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestVerifiedDB_SequentialCommits(t *testing.T) {
+	dataDir := t.TempDir()
+
+	db, err := OpenVerifiedDB(dataDir)
+	require.NoError(t, err)
+	defer db.Close()
+
+	chainID := eth.ChainIDFromUInt64(10)
+
+	// Commit first timestamp
+	err = db.Commit(VerifiedResult{
+		Timestamp: 100,
+		L1Head:    eth.BlockID{Hash: common.HexToHash("0x01"), Number: 1},
+		L2Heads:   map[eth.ChainID]eth.BlockID{chainID: {Hash: common.HexToHash("0x02"), Number: 2}},
+	})
+	require.NoError(t, err)
+
+	// Commit next sequential timestamp should succeed
+	err = db.Commit(VerifiedResult{
+		Timestamp: 101,
+		L1Head:    eth.BlockID{Hash: common.HexToHash("0x03"), Number: 3},
+		L2Heads:   map[eth.ChainID]eth.BlockID{chainID: {Hash: common.HexToHash("0x04"), Number: 4}},
+	})
+	require.NoError(t, err)
+
+	// Try to commit non-sequential timestamp (gap)
+	err = db.Commit(VerifiedResult{
+		Timestamp: 105,
+		L1Head:    eth.BlockID{Hash: common.HexToHash("0x05"), Number: 5},
+		L2Heads:   map[eth.ChainID]eth.BlockID{chainID: {Hash: common.HexToHash("0x06"), Number: 6}},
+	})
+	require.ErrorIs(t, err, ErrNonSequential)
+
+	// Try to commit already committed timestamp
+	err = db.Commit(VerifiedResult{
+		Timestamp: 100,
+		L1Head:    eth.BlockID{Hash: common.HexToHash("0x07"), Number: 7},
+		L2Heads:   map[eth.ChainID]eth.BlockID{chainID: {Hash: common.HexToHash("0x08"), Number: 8}},
+	})
+	require.ErrorIs(t, err, ErrAlreadyCommitted)
+
+	// Verify the database state is correct
+	lastTs, _ := db.LastTimestamp()
+	require.Equal(t, uint64(101), lastTs)
+}
+
+func TestVerifiedDB_Persistence(t *testing.T) {
+	dataDir := t.TempDir()
+	chainID := eth.ChainIDFromUInt64(42161)
+
+	// Open database and write some data
+	db, err := OpenVerifiedDB(dataDir)
+	require.NoError(t, err)
+
+	err = db.Commit(VerifiedResult{
+		Timestamp: 500,
+		L1Head:    eth.BlockID{Hash: common.HexToHash("0xaaaa"), Number: 50},
+		L2Heads:   map[eth.ChainID]eth.BlockID{chainID: {Hash: common.HexToHash("0xbbbb"), Number: 100}},
+	})
+	require.NoError(t, err)
+
+	err = db.Commit(VerifiedResult{
+		Timestamp: 501,
+		L1Head:    eth.BlockID{Hash: common.HexToHash("0xcccc"), Number: 51},
+		L2Heads:   map[eth.ChainID]eth.BlockID{chainID: {Hash: common.HexToHash("0xdddd"), Number: 101}},
+	})
+	require.NoError(t, err)
+
+	db.Close()
+
+	// Reopen database and verify data persisted
+	db2, err := OpenVerifiedDB(dataDir)
+	require.NoError(t, err)
+	defer db2.Close()
+
+	// Last timestamp should be restored
+	lastTs, initialized := db2.LastTimestamp()
+	require.True(t, initialized)
+	require.Equal(t, uint64(501), lastTs)
+
+	// Data should be readable
+	result, err := db2.Get(500)
+	require.NoError(t, err)
+	require.Equal(t, uint64(500), result.Timestamp)
+	require.Equal(t, common.HexToHash("0xaaaa"), result.L1Head.Hash)
+
+	result, err = db2.Get(501)
+	require.NoError(t, err)
+	require.Equal(t, uint64(501), result.Timestamp)
+
+	// Next commit should continue from last timestamp
+	err = db2.Commit(VerifiedResult{
+		Timestamp: 502,
+		L1Head:    eth.BlockID{Hash: common.HexToHash("0xeeee"), Number: 52},
+		L2Heads:   map[eth.ChainID]eth.BlockID{chainID: {Hash: common.HexToHash("0xffff"), Number: 102}},
+	})
+	require.NoError(t, err)
+}

--- a/op-supernode/supernode/activity/superroot/superroot_test.go
+++ b/op-supernode/supernode/activity/superroot/superroot_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-supernode/supernode/activity"
 	cc "github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container"
 	"github.com/ethereum/go-ethereum"
 	gethlog "github.com/ethereum/go-ethereum/log"
@@ -30,6 +31,9 @@ func (m *mockCC) Start(ctx context.Context) error  { return nil }
 func (m *mockCC) Stop(ctx context.Context) error   { return nil }
 func (m *mockCC) Pause(ctx context.Context) error  { return nil }
 func (m *mockCC) Resume(ctx context.Context) error { return nil }
+
+func (m *mockCC) RegisterVerifier(v activity.VerificationActivity) {
+}
 
 func (m *mockCC) BlockAtTimestamp(ctx context.Context, ts uint64, label eth.BlockLabel) (eth.L2BlockRef, error) {
 	return eth.L2BlockRef{}, nil

--- a/op-supernode/supernode/activity/superroot/superroot_test.go
+++ b/op-supernode/supernode/activity/superroot/superroot_test.go
@@ -75,6 +75,14 @@ func (m *mockCC) OptimisticOutputAtTimestamp(ctx context.Context, ts uint64) (*e
 	return &eth.OutputResponse{}, nil
 }
 
+func (m *mockCC) L1ForL2(ctx context.Context, l2Block eth.BlockID) (eth.BlockID, error) {
+	return eth.BlockID{}, nil
+}
+
+func (m *mockCC) ID() eth.ChainID {
+	return eth.ChainIDFromUInt64(10)
+}
+
 var _ cc.ChainContainer = (*mockCC)(nil)
 
 func TestSuperroot_AtTimestamp_Succeeds(t *testing.T) {

--- a/op-supernode/supernode/chain_container/chain_container.go
+++ b/op-supernode/supernode/chain_container/chain_container.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/activity"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container/engine_controller"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container/virtual_node"
+	"github.com/ethereum/go-ethereum"
 	gethlog "github.com/ethereum/go-ethereum/log"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -326,7 +327,7 @@ func (c *simpleChainContainer) VerifiedAt(ctx context.Context, ts uint64) (l2, l
 		}
 		if !verified {
 			c.log.Error("data could not be verified at this timestamp", "verifier", verifier.Name())
-			return eth.BlockID{}, eth.BlockID{}, fmt.Errorf("verification failed for %s at timestamp %d", verifier.Name(), ts)
+			return eth.BlockID{}, eth.BlockID{}, fmt.Errorf("verifier %s does not have data at this timestamp: %w", verifier.Name(), ethereum.NotFound)
 		}
 	}
 

--- a/op-supernode/supernode/chain_container/chain_container.go
+++ b/op-supernode/supernode/chain_container/chain_container.go
@@ -15,6 +15,7 @@ import (
 	oprpc "github.com/ethereum-optimism/optimism/op-service/rpc"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum-optimism/optimism/op-supernode/config"
+	"github.com/ethereum-optimism/optimism/op-supernode/supernode/activity"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container/engine_controller"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container/virtual_node"
 	gethlog "github.com/ethereum/go-ethereum/log"
@@ -37,6 +38,7 @@ type ChainContainer interface {
 	OptimisticAt(ctx context.Context, ts uint64) (l2, l1 eth.BlockID, err error)
 	OutputRootAtL2BlockNumber(ctx context.Context, l2BlockNum uint64) (eth.Bytes32, error)
 	OptimisticOutputAtTimestamp(ctx context.Context, ts uint64) (*eth.OutputResponse, error)
+	RegisterVerifier(v activity.VerificationActivity)
 }
 
 type virtualNodeFactory func(cfg *opnodecfg.Config, log gethlog.Logger, initOverrides *rollupNode.InitializationOverrides, appVersion string) virtual_node.VirtualNode
@@ -58,6 +60,7 @@ type simpleChainContainer struct {
 	appVersion         string
 	virtualNodeFactory virtualNodeFactory    // Factory function to create virtual node (for testing)
 	rollupClient       *sources.RollupClient // In-proc rollup RPC client bound to rpcHandler
+	verifiers          []activity.VerificationActivity
 }
 
 // Interface conformance assertions
@@ -111,6 +114,12 @@ func NewChainContainer(
 
 func (c *simpleChainContainer) ID() eth.ChainID {
 	return c.chainID
+}
+
+// RegisterVerifier adds a verification activity to this chain container.
+// This allows late binding when activities and chains have circular dependencies.
+func (c *simpleChainContainer) RegisterVerifier(v activity.VerificationActivity) {
+	c.verifiers = append(c.verifiers, v)
 }
 
 // defaultVirtualNodeFactory is the default factory that creates a real VirtualNode
@@ -305,8 +314,18 @@ func (c *simpleChainContainer) VerifiedAt(ctx context.Context, ts uint64) (l2, l
 		return eth.BlockID{}, eth.BlockID{}, err
 	}
 
-	// if there were Verification Activities, we would check if the data could be *verified* at this L1, or would use its L1 block number
-	// but there are currently no verification activities, so we just return the l2 and l1 blocks
+	for _, verifier := range c.verifiers {
+		verified, err := verifier.VerifiedAtTimestamp(ts)
+		if err != nil {
+			c.log.Error("error checking if data could be verified at this L1", "error", err)
+			return eth.BlockID{}, eth.BlockID{}, err
+		}
+		if !verified {
+			c.log.Error("data could not be verified at this timestamp", "verifier", verifier.Name())
+			return eth.BlockID{}, eth.BlockID{}, fmt.Errorf("verification failed for %s at timestamp %d", verifier.Name(), ts)
+		}
+	}
+
 	return l2Block.ID(), l1Block, nil
 }
 

--- a/op-supernode/supernode/chain_container/chain_container.go
+++ b/op-supernode/supernode/chain_container/chain_container.go
@@ -29,9 +29,11 @@ type ChainContainer interface {
 	Pause(ctx context.Context) error
 	Resume(ctx context.Context) error
 
+	ID() eth.ChainID
 	BlockAtTimestamp(ctx context.Context, ts uint64, label eth.BlockLabel) (eth.L2BlockRef, error)
 	SyncStatus(ctx context.Context) (*eth.SyncStatus, error)
 	VerifiedAt(ctx context.Context, ts uint64) (l2, l1 eth.BlockID, err error)
+	L1ForL2(ctx context.Context, l2Block eth.BlockID) (eth.BlockID, error)
 	OptimisticAt(ctx context.Context, ts uint64) (l2, l1 eth.BlockID, err error)
 	OutputRootAtL2BlockNumber(ctx context.Context, l2BlockNum uint64) (eth.Bytes32, error)
 	OptimisticOutputAtTimestamp(ctx context.Context, ts uint64) (*eth.OutputResponse, error)
@@ -105,6 +107,10 @@ func NewChainContainer(
 		}
 	}
 	return c
+}
+
+func (c *simpleChainContainer) ID() eth.ChainID {
+	return c.chainID
 }
 
 // defaultVirtualNodeFactory is the default factory that creates a real VirtualNode
@@ -220,6 +226,20 @@ func (c *simpleChainContainer) Resume(ctx context.Context) error {
 	return nil
 }
 
+func (c *simpleChainContainer) TimestampToBlockNumber(ctx context.Context, ts uint64) (uint64, error) {
+	if c.vncfg == nil {
+		return 0, fmt.Errorf("rollup config not available")
+	}
+	return c.vncfg.Rollup.TargetBlockNumber(ts)
+}
+
+func (c *simpleChainContainer) BlockNumberToTimestamp(ctx context.Context, blocknum uint64) (uint64, error) {
+	if c.vncfg == nil {
+		return 0, fmt.Errorf("rollup config not available")
+	}
+	return c.vncfg.Rollup.Genesis.L2Time + (blocknum * c.vncfg.Rollup.BlockTime), nil
+}
+
 // BlockAtTimestamp returns the highest L2 block with timestamp <= ts using the L2 client,
 // if the specified label contains a block at that timestamp
 func (c *simpleChainContainer) BlockAtTimestamp(ctx context.Context, ts uint64, label eth.BlockLabel) (eth.L2BlockRef, error) {
@@ -261,6 +281,13 @@ func (c *simpleChainContainer) safeDBAtL2(ctx context.Context, l2 eth.BlockID) (
 	if c.vn == nil {
 		return eth.BlockID{}, fmt.Errorf("virtual node not initialized")
 	}
+	c.log.Info("safeDBAtL2", "l2", l2)
+	status, err := c.SyncStatus(ctx)
+	if err != nil {
+		return eth.BlockID{}, err
+	}
+	currentL1 := status.CurrentL1
+	c.log.Info("latest L1 just for good measure", "l1", currentL1)
 	return c.vn.L1AtSafeHead(ctx, l2)
 }
 

--- a/op-supernode/supernode/chain_container/chain_container.go
+++ b/op-supernode/supernode/chain_container/chain_container.go
@@ -295,13 +295,12 @@ func (c *simpleChainContainer) safeDBAtL2(ctx context.Context, l2 eth.BlockID) (
 	if c.vn == nil {
 		return eth.BlockID{}, fmt.Errorf("virtual node not initialized")
 	}
-	c.log.Info("safeDBAtL2", "l2", l2)
 	status, err := c.SyncStatus(ctx)
 	if err != nil {
 		return eth.BlockID{}, err
 	}
 	currentL1 := status.CurrentL1
-	c.log.Info("latest L1 just for good measure", "l1", currentL1)
+	c.log.Debug("safeDBAtL2", "l2", l2, "currentL1", currentL1, "err", err)
 	return c.vn.L1AtSafeHead(ctx, l2)
 }
 

--- a/op-supernode/supernode/chain_container/chain_container.go
+++ b/op-supernode/supernode/chain_container/chain_container.go
@@ -273,6 +273,10 @@ func (c *simpleChainContainer) SyncStatus(ctx context.Context) (*eth.SyncStatus,
 	return st, nil
 }
 
+func (c *simpleChainContainer) L1ForL2(ctx context.Context, l2Block eth.BlockID) (eth.BlockID, error) {
+	return c.safeDBAtL2(ctx, l2Block)
+}
+
 // OutputRootAtL2BlockNumber computes the L2 output root for the specified L2 block number.
 func (c *simpleChainContainer) OutputRootAtL2BlockNumber(ctx context.Context, l2BlockNum uint64) (eth.Bytes32, error) {
 	if c.engine == nil {

--- a/op-supernode/supernode/chain_container/chain_container.go
+++ b/op-supernode/supernode/chain_container/chain_container.go
@@ -325,7 +325,7 @@ func (c *simpleChainContainer) VerifiedAt(ctx context.Context, ts uint64) (l2, l
 			return eth.BlockID{}, eth.BlockID{}, err
 		}
 		if !verified {
-			c.log.Error("data could not be verified at this timestamp", "verifier", verifier.Name())
+			c.log.Error("verifier does not have data at this timestamp. cannot supply block at this timestamp as verified", "verifier", verifier.Name())
 			return eth.BlockID{}, eth.BlockID{}, fmt.Errorf("verifier %s does not have data at this timestamp: %w", verifier.Name(), ethereum.NotFound)
 		}
 	}

--- a/op-supernode/supernode/chain_container/chain_container_test.go
+++ b/op-supernode/supernode/chain_container/chain_container_test.go
@@ -700,7 +700,6 @@ func TestChainContainer_VerifiedAt(t *testing.T) {
 		impl, ok := container.(*simpleChainContainer)
 		require.True(t, ok)
 
-		// Register the mock verifier using the new late-binding method
 		container.RegisterVerifier(mockVerifier)
 
 		// Set up mock engine controller

--- a/op-supernode/supernode/chain_container/chain_container_test.go
+++ b/op-supernode/supernode/chain_container/chain_container_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	oprpc "github.com/ethereum-optimism/optimism/op-service/rpc"
 	"github.com/ethereum-optimism/optimism/op-supernode/config"
+	"github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container/engine_controller"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container/virtual_node"
 	gethlog "github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
@@ -112,6 +113,46 @@ func (m *mockVirtualNode) SyncStatus(ctx context.Context) (*eth.SyncStatus, erro
 }
 
 // SafeDB is not required by VirtualNode in these tests
+
+// mockEngineController is a mock implementation of engine_controller.EngineController
+type mockEngineController struct {
+	blockAtTimestampResult eth.L2BlockRef
+	blockAtTimestampErr    error
+}
+
+func (m *mockEngineController) BlockAtTimestamp(ctx context.Context, ts uint64, label eth.BlockLabel) (eth.L2BlockRef, error) {
+	return m.blockAtTimestampResult, m.blockAtTimestampErr
+}
+
+func (m *mockEngineController) OutputV0AtBlockNumber(ctx context.Context, num uint64) (*eth.OutputV0, error) {
+	return nil, nil
+}
+
+func (m *mockEngineController) Close() error {
+	return nil
+}
+
+var _ engine_controller.EngineController = (*mockEngineController)(nil)
+
+// mockVerificationActivity is a mock implementation of activity.VerificationActivity
+type mockVerificationActivity struct {
+	name                      string
+	currentL1Result           eth.BlockID
+	verifiedAtTimestampResult bool
+	verifiedAtTimestampErr    error
+}
+
+func (m *mockVerificationActivity) Name() string {
+	return m.name
+}
+
+func (m *mockVerificationActivity) CurrentL1() eth.BlockID {
+	return m.currentL1Result
+}
+
+func (m *mockVerificationActivity) VerifiedAtTimestamp(ts uint64) (bool, error) {
+	return m.verifiedAtTimestampResult, m.verifiedAtTimestampErr
+}
 
 // Test helpers
 func createTestVNConfig() *opnodecfg.Config {
@@ -636,4 +677,53 @@ func TestChainContainer_VirtualNodeIntegration(t *testing.T) {
 	})
 }
 
-// Output root helper tests removed with simplified interface
+// TestChainContainer_VerifiedAt tests the VerifiedAt method
+func TestChainContainer_VerifiedAt(t *testing.T) {
+	t.Parallel()
+
+	chainID := eth.ChainIDFromUInt64(420)
+	vncfg := createTestVNConfig()
+	log := createTestLogger()
+	cfg := createTestCLIConfig()
+	initOverload := &rollupNode.InitializationOverrides{}
+
+	t.Run("returns error when verification activity reports not verified", func(t *testing.T) {
+		// Create a mock verification activity that returns verified=false
+		mockVerifier := &mockVerificationActivity{
+			name:                      "test-verifier",
+			verifiedAtTimestampResult: false, // not verified
+			verifiedAtTimestampErr:    nil,
+		}
+
+		container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil)
+		impl, ok := container.(*simpleChainContainer)
+		require.True(t, ok)
+
+		// Register the mock verifier using the new late-binding method
+		container.RegisterVerifier(mockVerifier)
+
+		// Set up mock engine controller
+		mockEngine := &mockEngineController{
+			blockAtTimestampResult: eth.L2BlockRef{
+				Hash:   [32]byte{1},
+				Number: 100,
+			},
+			blockAtTimestampErr: nil,
+		}
+		impl.engine = mockEngine
+
+		// Set up mock virtual node for safeDBAtL2
+		mockVN := newMockVirtualNode()
+		mockVN.safeHeadL1 = eth.BlockID{Hash: [32]byte{2}, Number: 50}
+		mockVN.safeHeadErr = nil
+		impl.vn = mockVN
+
+		ctx := context.Background()
+		l2, l1, err := container.VerifiedAt(ctx, 1000)
+
+		// Should return an error when verification fails
+		require.Error(t, err)
+		require.Equal(t, eth.BlockID{}, l2)
+		require.Equal(t, eth.BlockID{}, l1)
+	})
+}

--- a/op-supernode/supernode/chain_container/chain_container_test.go
+++ b/op-supernode/supernode/chain_container/chain_container_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supernode/config"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container/engine_controller"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container/virtual_node"
+	"github.com/ethereum/go-ethereum"
 	gethlog "github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 )
@@ -723,6 +724,7 @@ func TestChainContainer_VerifiedAt(t *testing.T) {
 
 		// Should return an error when verification fails
 		require.Error(t, err)
+		require.ErrorIs(t, err, ethereum.NotFound)
 		require.Equal(t, eth.BlockID{}, l2)
 		require.Equal(t, eth.BlockID{}, l1)
 	})

--- a/op-supernode/supernode/chain_container/engine_controller/engine_controller.go
+++ b/op-supernode/supernode/chain_container/engine_controller/engine_controller.go
@@ -75,6 +75,7 @@ func (e *simpleEngineController) BlockAtTimestamp(ctx context.Context, ts uint64
 	}
 	// Compute the target block directly from rollup config
 	num, err := e.rollup.TargetBlockNumber(ts)
+	e.log.Debug("engine_controller: computed target block number from timestamp", "timestamp", ts, "targetBlockNumber", num)
 	if err != nil {
 		return eth.L2BlockRef{}, err
 	}

--- a/op-supernode/supernode/chain_container/virtual_node/virtual_node.go
+++ b/op-supernode/supernode/chain_container/virtual_node/virtual_node.go
@@ -249,13 +249,11 @@ func (v *simpleVirtualNode) L1AtSafeHead(ctx context.Context, target eth.BlockID
 			return eth.BlockID{}, ErrL1AtSafeHeadNotFound
 		}
 		prev := cursor.Number - 1
-		//v.log.Debug("L1AtSafeHead: checking previous l1 block", "l1_num", prev)
 		l1Prev, l2Prev, err := db.SafeHeadAtL1(ctx, prev)
 		if err != nil {
 			v.log.Error("L1AtSafeHead: walkback lookup failed, stopping", "probe_l1", prev, "err", err)
 			return eth.BlockID{}, err
 		}
-		//v.log.Debug("L1AtSafeHead: walkback result", "l1_prev", l1Prev.Number, "l2_prev_num", l2Prev.Number, "l2_prev_hash", l2Prev.Hash)
 		if l2Prev.Number >= target.Number {
 			// Still meets or exceeds target; continue walking back
 			cursor = l1Prev

--- a/op-supernode/supernode/chain_container/virtual_node/virtual_node.go
+++ b/op-supernode/supernode/chain_container/virtual_node/virtual_node.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"math"
 	"sync"
-	"time"
 
 	opnodecfg "github.com/ethereum-optimism/optimism/op-node/config"
 	opmetrics "github.com/ethereum-optimism/optimism/op-node/metrics"
@@ -215,10 +214,6 @@ var ErrL1AtSafeHeadNotFound = errors.New("l1 at safe head not found")
 // L1AtSafeHead finds the earliest L1 block at which the provided L2 block became safe,
 // using the monotonicity of SafeDB (L2 safe head number is non-decreasing over L1).
 func (v *simpleVirtualNode) L1AtSafeHead(ctx context.Context, target eth.BlockID) (eth.BlockID, error) {
-	start := time.Now()
-	defer func() {
-		v.log.Debug("L1AtSafeHead: time taken", "time", time.Since(start))
-	}()
 	v.mu.Lock()
 	inner := v.inner
 	v.mu.Unlock()

--- a/op-supernode/supernode/chain_container/virtual_node/virtual_node.go
+++ b/op-supernode/supernode/chain_container/virtual_node/virtual_node.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"math"
 	"sync"
+	"time"
 
 	opnodecfg "github.com/ethereum-optimism/optimism/op-node/config"
 	opmetrics "github.com/ethereum-optimism/optimism/op-node/metrics"
@@ -214,6 +215,10 @@ var ErrL1AtSafeHeadNotFound = errors.New("l1 at safe head not found")
 // L1AtSafeHead finds the earliest L1 block at which the provided L2 block became safe,
 // using the monotonicity of SafeDB (L2 safe head number is non-decreasing over L1).
 func (v *simpleVirtualNode) L1AtSafeHead(ctx context.Context, target eth.BlockID) (eth.BlockID, error) {
+	start := time.Now()
+	defer func() {
+		v.log.Debug("L1AtSafeHead: time taken", "time", time.Since(start))
+	}()
 	v.mu.Lock()
 	inner := v.inner
 	v.mu.Unlock()
@@ -232,13 +237,16 @@ func (v *simpleVirtualNode) L1AtSafeHead(ctx context.Context, target eth.BlockID
 	}
 	v.log.Debug("L1AtSafeHead: latest bounds", "latest_l1", latestL1.Number, "latest_l2_num", latestL2.Number, "latest_l2_hash", latestL2.Hash)
 	if latestL2.Number < target.Number {
-		v.log.Debug("L1AtSafeHead: target beyond latest", "latest_l2", latestL2.Number)
+		v.log.Debug("L1AtSafeHead: target beyond latest", "latest_l2", latestL2.Number, "target", target.Number)
 		return eth.BlockID{}, ErrL1AtSafeHeadNotFound
 	}
+	v.log.Debug("L1AtSafeHead: target within latest", "latest_l2", latestL2.Number, "target", target.Number)
 	// Walk back until the cursor would drop below the target
 	cursor := latestL1
 	genesisL1 := v.cfg.Rollup.Genesis.L1.Number
+	steps := 0
 	for {
+		steps++
 		if cursor.Number <= 0 || cursor.Number <= genesisL1 {
 			// if we made it all the way back to genesis, it is likely the SafeDB is not stable enough for use
 			// safer to simply return an error for now.
@@ -246,13 +254,13 @@ func (v *simpleVirtualNode) L1AtSafeHead(ctx context.Context, target eth.BlockID
 			return eth.BlockID{}, ErrL1AtSafeHeadNotFound
 		}
 		prev := cursor.Number - 1
-		v.log.Debug("L1AtSafeHead: checking previous l1 block", "l1_num", prev)
+		//v.log.Debug("L1AtSafeHead: checking previous l1 block", "l1_num", prev)
 		l1Prev, l2Prev, err := db.SafeHeadAtL1(ctx, prev)
 		if err != nil {
-			v.log.Debug("L1AtSafeHead: walkback lookup failed, stopping", "probe_l1", prev, "err", err)
-			break
+			v.log.Error("L1AtSafeHead: walkback lookup failed, stopping", "probe_l1", prev, "err", err)
+			return eth.BlockID{}, err
 		}
-		v.log.Debug("L1AtSafeHead: walkback result", "l1_prev", l1Prev.Number, "l2_prev_num", l2Prev.Number, "l2_prev_hash", l2Prev.Hash)
+		//v.log.Debug("L1AtSafeHead: walkback result", "l1_prev", l1Prev.Number, "l2_prev_num", l2Prev.Number, "l2_prev_hash", l2Prev.Hash)
 		if l2Prev.Number >= target.Number {
 			// Still meets or exceeds target; continue walking back
 			cursor = l1Prev
@@ -261,7 +269,7 @@ func (v *simpleVirtualNode) L1AtSafeHead(ctx context.Context, target eth.BlockID
 		// Dropped below target; current cursor is the first that meets/exceeds
 		break
 	}
-	v.log.Debug("L1AtSafeHead: result", "l1", cursor)
+	v.log.Debug("L1AtSafeHead: result", "l1", cursor, "steps", steps)
 	return cursor, nil
 }
 

--- a/op-supernode/supernode/supernode.go
+++ b/op-supernode/supernode/supernode.go
@@ -84,11 +84,14 @@ func New(ctx context.Context, log gethlog.Logger, version string, requestStop co
 		s.chains[chainID] = cc.NewChainContainer(chainID, vnCfgs[chainID], log, *cfg, initOverrides, nil, s.rpcRouter.SetHandler, s.metricsFanIn.SetMetricsRegistry)
 	}
 	// Initialize activities
+	interopActivationTimestamp := cfg.RawCtx.Uint64(interop.InteropActivationTimestampFlag.Name)
 	s.activities = []activity.Activity{
+		interop.New(log.New("activity", "interop"), interopActivationTimestamp, s.chains, cfg.DataDir, s.l1Client),
 		heartbeat.New(log.New("activity", "heartbeat"), 10*time.Second),
 		superroot.New(log.New("activity", "superroot"), s.chains),
-		interop.New(log.New("activity", "interop"), s.chains),
 	}
+
+	// set up http server
 	addr := net.JoinHostPort(cfg.RPCConfig.ListenAddr, strconv.Itoa(cfg.RPCConfig.ListenPort))
 	s.httpServer = httputil.NewHTTPServer(addr, s.rpcRouter)
 

--- a/op-supernode/supernode/supernode.go
+++ b/op-supernode/supernode/supernode.go
@@ -83,12 +83,19 @@ func New(ctx context.Context, log gethlog.Logger, version string, requestStop co
 		}
 		s.chains[chainID] = cc.NewChainContainer(chainID, vnCfgs[chainID], log, *cfg, initOverrides, nil, s.rpcRouter.SetHandler, s.metricsFanIn.SetMetricsRegistry)
 	}
+
 	// Initialize activities
 	interopActivationTimestamp := cfg.RawCtx.Uint64(interop.InteropActivationTimestampFlag.Name)
+	interopActivity := interop.New(log.New("activity", "interop"), interopActivationTimestamp, s.chains, cfg.DataDir, s.l1Client)
 	s.activities = []activity.Activity{
-		interop.New(log.New("activity", "interop"), interopActivationTimestamp, s.chains, cfg.DataDir, s.l1Client),
+		interopActivity,
 		heartbeat.New(log.New("activity", "heartbeat"), 10*time.Second),
 		superroot.New(log.New("activity", "superroot"), s.chains),
+	}
+
+	// Cross-register verification activities with chains
+	for _, chain := range s.chains {
+		chain.RegisterVerifier(interopActivity)
 	}
 
 	// set up http server

--- a/op-supernode/supernode/supernode.go
+++ b/op-supernode/supernode/supernode.go
@@ -84,21 +84,23 @@ func New(ctx context.Context, log gethlog.Logger, version string, requestStop co
 		s.chains[chainID] = cc.NewChainContainer(chainID, vnCfgs[chainID], log, *cfg, initOverrides, nil, s.rpcRouter.SetHandler, s.metricsFanIn.SetMetricsRegistry)
 	}
 
-	// Initialize activities
-	interopActivationTimestamp := cfg.RawCtx.Uint64(interop.InteropActivationTimestampFlag.Name)
-	interopActivity := interop.New(log.New("activity", "interop"), interopActivationTimestamp, s.chains, cfg.DataDir, s.l1Client)
+	// Initialize general activities
 	s.activities = []activity.Activity{
-		interopActivity,
 		heartbeat.New(log.New("activity", "heartbeat"), 10*time.Second),
 		superroot.New(log.New("activity", "superroot"), s.chains),
 	}
 
-	// Cross-register verification activities with chains
-	for _, chain := range s.chains {
-		chain.RegisterVerifier(interopActivity)
+	// Initialize interop activity if the activation timestamp is set
+	if cfg.RawCtx.IsSet(interop.InteropActivationTimestampFlag.Name) {
+		interopActivationTimestamp := cfg.RawCtx.Uint64(interop.InteropActivationTimestampFlag.Name)
+		interopActivity := interop.New(log.New("activity", "interop"), interopActivationTimestamp, s.chains, cfg.DataDir, s.l1Client)
+		s.activities = append(s.activities, interopActivity)
+		for _, chain := range s.chains {
+			chain.RegisterVerifier(interopActivity)
+		}
 	}
 
-	// set up http server
+	// Set up http server
 	addr := net.JoinHostPort(cfg.RPCConfig.ListenAddr, strconv.Itoa(cfg.RPCConfig.ListenPort))
 	s.httpServer = httputil.NewHTTPServer(addr, s.rpcRouter)
 

--- a/op-supernode/supernode/supernode.go
+++ b/op-supernode/supernode/supernode.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/activity"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/activity/heartbeat"
+	"github.com/ethereum-optimism/optimism/op-supernode/supernode/activity/interop"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/activity/superroot"
 	cc "github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/resources"
@@ -86,6 +87,7 @@ func New(ctx context.Context, log gethlog.Logger, version string, requestStop co
 	s.activities = []activity.Activity{
 		heartbeat.New(log.New("activity", "heartbeat"), 10*time.Second),
 		superroot.New(log.New("activity", "superroot"), s.chains),
+		interop.New(log.New("activity", "interop"), s.chains),
 	}
 	addr := net.JoinHostPort(cfg.RPCConfig.ListenAddr, strconv.Itoa(cfg.RPCConfig.ListenPort))
 	s.httpServer = httputil.NewHTTPServer(addr, s.rpcRouter)

--- a/op-supernode/supernode/supernode.go
+++ b/op-supernode/supernode/supernode.go
@@ -84,7 +84,7 @@ func New(ctx context.Context, log gethlog.Logger, version string, requestStop co
 		s.chains[chainID] = cc.NewChainContainer(chainID, vnCfgs[chainID], log, *cfg, initOverrides, nil, s.rpcRouter.SetHandler, s.metricsFanIn.SetMetricsRegistry)
 	}
 
-	// Initialize general activities
+	// Initialize fixed activities
 	s.activities = []activity.Activity{
 		heartbeat.New(log.New("activity", "heartbeat"), 10*time.Second),
 		superroot.New(log.New("activity", "superroot"), s.chains),
@@ -93,7 +93,7 @@ func New(ctx context.Context, log gethlog.Logger, version string, requestStop co
 	// Initialize interop activity if the activation timestamp is set
 	if cfg.RawCtx.IsSet(interop.InteropActivationTimestampFlag.Name) {
 		interopActivationTimestamp := cfg.RawCtx.Uint64(interop.InteropActivationTimestampFlag.Name)
-		interopActivity := interop.New(log.New("activity", "interop"), interopActivationTimestamp, s.chains, cfg.DataDir, s.l1Client)
+		interopActivity := interop.New(log.New("activity", "interop"), interopActivationTimestamp, s.chains, cfg.DataDir)
 		s.activities = append(s.activities, interopActivity)
 		for _, chain := range s.chains {
 			chain.RegisterVerifier(interopActivity)


### PR DESCRIPTION
# What

Implements Interop Activity _but not_ Interop Algorithm.

# Why

Implementing Interop is actually a matter of first modeling this new notion of layered Verification on top of Local Derivation. To that end, Supernode has this modular "Activity" architecture for describing new runtime components.

To define *both* the activity mechanics *and* the protocol interop behavior at the same time is too much for one review. This PR instead just delivers a "no-op" version of interop which does not:
- Pull Logs
- Perform Executing Message Checks

Instead, it assumes these things would pass. This allows for Interop Activity to run on multi-networks without Interop HF or contracts being deployed.

# How

InteropActivity is a Runnable Activity and a Verification Activity. This means it is given a go routine to manage itself, and it is responsive to questions about Verification at a given timestamp. `interopActivity.VerifiedAt(ts)`.

The actual processing loop is almost exactly what was specified in [SV2 Logic Flows](https://www.notion.so/oplabs/Supervisor-V2-Main-Loop-and-Logic-Flow-Diagrams-265f153ee162804388dac933f525de7b)

When Valid results for a given timestamp, it is recorded into a `bbolt` DB. Thank you to @Inphi for the suggestion.

Invalid blocks _will_ be delivered to Chain Containers, but because Node Reset functionality is ongoing, there is not a clear place to integrate just yet.

Additional integrations include:

- `VerifiedAt(ts)` in the Chain Container now checks with the verification activity. If it isn't Verified by all activities, there isn't a VerifiedAt yet for that time.
- Registers Verification Activities with Chain Containers and vice-versa - Chain Containers need to access Verification State, while Verification Activities build from Chain State

# Tests
Reasonably comprehensive unit testing including:
- Chain Container use of Verification Activities
- Verification Activity behavior
  - Collecting the L1s correctly
  - Checking if Chains are ready
  - Recording the results etc.
  - _Not_ recording invalid results through overloading the function which produces verification results
- Type Tests
- Database Tests
  
After this PR comes work to set up a multi-network devstack test which uses this Activity. At that point, implementing the Interop Algorithm can be done test-first.
