### PR TITLE
feat: update withdrawal command for output roots in super proposals

### DIFF
--- a/op-acceptance-tests/tests/interop/proofs/withdrawal/withdrawal_test.go
+++ b/op-acceptance-tests/tests/interop/proofs/withdrawal/withdrawal_test.go
@@ -9,43 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestProveFromGameExtraData tests proving withdrawal by reading
-// super root proof directly from the dispute game's extraData instead of supervisor-rpc.
-// This test only verifies the prove step works - finalize is tested in TestSuperRootWithdrawal.
-// NOTE: Does not use AdvanceTime so it can run safely with other tests.
-func TestProveFromGameExtraData(gt *testing.T) {
-	t := devtest.SerialT(gt)
-	sys := presets.NewSimpleInterop(t)
-	sys.L1Network.WaitForOnline()
-
-	initialL1Balance := eth.HalfEther
-	initialL2Balance := eth.ZeroWei
-	depositAmount := eth.OneThirdEther
-	withdrawalAmount := eth.OneTenthEther
-
-	l1User := sys.FunderL1.NewFundedEOA(initialL1Balance)
-	l2User := l1User.AsEL(sys.L2ELA)
-
-	bridge := sys.StandardBridge(sys.L2ChainA)
-	require.True(t, bridge.UsesSuperRoots(), "Expected interop system to be using super roots")
-
-	deposit := bridge.Deposit(depositAmount, l1User)
-	l1User.VerifyBalanceExact(initialL1Balance.Sub(depositAmount).Sub(deposit.GasCost()))
-	l2User.VerifyBalanceExact(initialL2Balance.Add(depositAmount))
-
-	sys.L2ChainA.WaitForBlock()
-
-	withdrawal := bridge.InitiateWithdrawal(withdrawalAmount, l2User)
-	withdrawal.ProveFromGameExtraData(l1User) // Use extraData flow instead of supervisor
-	l2User.VerifyBalanceExact(initialL2Balance.Add(depositAmount).Sub(withdrawalAmount).Sub(withdrawal.InitiateGasCost()))
-
-	// Verify prove succeeded by checking gas was spent
-	l1User.VerifyBalanceExact(initialL1Balance.
-		Sub(depositAmount).
-		Sub(deposit.GasCost()).
-		Sub(withdrawal.ProveGasCost()))
-}
-
 func TestSuperRootWithdrawal(gt *testing.T) {
 	t := devtest.SerialT(gt)
 	sys := presets.NewSimpleInterop(t)

--- a/op-acceptance-tests/tests/interop/proofs/withdrawal/withdrawal_test.go
+++ b/op-acceptance-tests/tests/interop/proofs/withdrawal/withdrawal_test.go
@@ -54,3 +54,45 @@ func TestSuperRootWithdrawal(gt *testing.T) {
 		// Plus received withdrawal amount
 		Add(withdrawalAmount))
 }
+
+// TestSuperRootWithdrawalFromGameExtraData tests proving withdrawal by reading
+// super root proof directly from the dispute game's extraData instead of supervisor-rpc.
+func TestSuperRootWithdrawalFromGameExtraData(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewSimpleInterop(t)
+	sys.L1Network.WaitForOnline()
+
+	initialL1Balance := eth.HalfEther
+	initialL2Balance := eth.ZeroWei
+	depositAmount := eth.OneThirdEther
+	withdrawalAmount := eth.OneTenthEther
+
+	l1User := sys.FunderL1.NewFundedEOA(initialL1Balance)
+	l2User := l1User.AsEL(sys.L2ELA)
+
+	bridge := sys.StandardBridge(sys.L2ChainA)
+	require.True(t, bridge.UsesSuperRoots(), "Expected interop system to be using super roots")
+
+	deposit := bridge.Deposit(depositAmount, l1User)
+	l1User.VerifyBalanceExact(initialL1Balance.Sub(depositAmount).Sub(deposit.GasCost()))
+	l2User.VerifyBalanceExact(initialL2Balance.Add(depositAmount))
+
+	sys.L2ChainA.WaitForBlock()
+
+	withdrawal := bridge.InitiateWithdrawal(withdrawalAmount, l2User)
+	withdrawal.ProveFromGameExtraData(l1User) // Use extraData flow instead of supervisor
+	l2User.VerifyBalanceExact(initialL2Balance.Add(depositAmount).Sub(withdrawalAmount).Sub(withdrawal.InitiateGasCost()))
+
+	sys.AdvanceTime(bridge.GameResolutionDelay())
+	withdrawal.WaitForDisputeGameResolved()
+
+	sys.AdvanceTime(max(bridge.WithdrawalDelay()-bridge.GameResolutionDelay(), bridge.DisputeGameFinalityDelay()))
+	withdrawal.Finalize(l1User)
+
+	l1User.VerifyBalanceExact(initialL1Balance.
+		Sub(depositAmount).
+		Sub(deposit.GasCost()).
+		Sub(withdrawal.ProveGasCost()).
+		Sub(withdrawal.FinalizeGasCost()).
+		Add(withdrawalAmount))
+}

--- a/op-acceptance-tests/tests/interop/proofs/withdrawal/withdrawal_test.go
+++ b/op-acceptance-tests/tests/interop/proofs/withdrawal/withdrawal_test.go
@@ -9,6 +9,43 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestProveFromGameExtraData tests proving withdrawal by reading
+// super root proof directly from the dispute game's extraData instead of supervisor-rpc.
+// This test only verifies the prove step works - finalize is tested in TestSuperRootWithdrawal.
+// NOTE: Does not use AdvanceTime so it can run safely with other tests.
+func TestProveFromGameExtraData(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewSimpleInterop(t)
+	sys.L1Network.WaitForOnline()
+
+	initialL1Balance := eth.HalfEther
+	initialL2Balance := eth.ZeroWei
+	depositAmount := eth.OneThirdEther
+	withdrawalAmount := eth.OneTenthEther
+
+	l1User := sys.FunderL1.NewFundedEOA(initialL1Balance)
+	l2User := l1User.AsEL(sys.L2ELA)
+
+	bridge := sys.StandardBridge(sys.L2ChainA)
+	require.True(t, bridge.UsesSuperRoots(), "Expected interop system to be using super roots")
+
+	deposit := bridge.Deposit(depositAmount, l1User)
+	l1User.VerifyBalanceExact(initialL1Balance.Sub(depositAmount).Sub(deposit.GasCost()))
+	l2User.VerifyBalanceExact(initialL2Balance.Add(depositAmount))
+
+	sys.L2ChainA.WaitForBlock()
+
+	withdrawal := bridge.InitiateWithdrawal(withdrawalAmount, l2User)
+	withdrawal.ProveFromGameExtraData(l1User) // Use extraData flow instead of supervisor
+	l2User.VerifyBalanceExact(initialL2Balance.Add(depositAmount).Sub(withdrawalAmount).Sub(withdrawal.InitiateGasCost()))
+
+	// Verify prove succeeded by checking gas was spent
+	l1User.VerifyBalanceExact(initialL1Balance.
+		Sub(depositAmount).
+		Sub(deposit.GasCost()).
+		Sub(withdrawal.ProveGasCost()))
+}
+
 func TestSuperRootWithdrawal(gt *testing.T) {
 	t := devtest.SerialT(gt)
 	sys := presets.NewSimpleInterop(t)
@@ -52,47 +89,5 @@ func TestSuperRootWithdrawal(gt *testing.T) {
 		Sub(withdrawal.ProveGasCost()).
 		Sub(withdrawal.FinalizeGasCost()).
 		// Plus received withdrawal amount
-		Add(withdrawalAmount))
-}
-
-// TestSuperRootWithdrawalFromGameExtraData tests proving withdrawal by reading
-// super root proof directly from the dispute game's extraData instead of supervisor-rpc.
-func TestSuperRootWithdrawalFromGameExtraData(gt *testing.T) {
-	t := devtest.SerialT(gt)
-	sys := presets.NewSimpleInterop(t)
-	sys.L1Network.WaitForOnline()
-
-	initialL1Balance := eth.HalfEther
-	initialL2Balance := eth.ZeroWei
-	depositAmount := eth.OneThirdEther
-	withdrawalAmount := eth.OneTenthEther
-
-	l1User := sys.FunderL1.NewFundedEOA(initialL1Balance)
-	l2User := l1User.AsEL(sys.L2ELA)
-
-	bridge := sys.StandardBridge(sys.L2ChainA)
-	require.True(t, bridge.UsesSuperRoots(), "Expected interop system to be using super roots")
-
-	deposit := bridge.Deposit(depositAmount, l1User)
-	l1User.VerifyBalanceExact(initialL1Balance.Sub(depositAmount).Sub(deposit.GasCost()))
-	l2User.VerifyBalanceExact(initialL2Balance.Add(depositAmount))
-
-	sys.L2ChainA.WaitForBlock()
-
-	withdrawal := bridge.InitiateWithdrawal(withdrawalAmount, l2User)
-	withdrawal.ProveFromGameExtraData(l1User) // Use extraData flow instead of supervisor
-	l2User.VerifyBalanceExact(initialL2Balance.Add(depositAmount).Sub(withdrawalAmount).Sub(withdrawal.InitiateGasCost()))
-
-	sys.AdvanceTime(bridge.GameResolutionDelay())
-	withdrawal.WaitForDisputeGameResolved()
-
-	sys.AdvanceTime(max(bridge.WithdrawalDelay()-bridge.GameResolutionDelay(), bridge.DisputeGameFinalityDelay()))
-	withdrawal.Finalize(l1User)
-
-	l1User.VerifyBalanceExact(initialL1Balance.
-		Sub(depositAmount).
-		Sub(deposit.GasCost()).
-		Sub(withdrawal.ProveGasCost()).
-		Sub(withdrawal.FinalizeGasCost()).
 		Add(withdrawalAmount))
 }

--- a/op-chain-ops/cmd/withdrawal/README.md
+++ b/op-chain-ops/cmd/withdrawal/README.md
@@ -27,16 +27,6 @@ valid proposal is made for a L2 block at or after the initiating transaction was
 go run . prove --l1 <l1-el-rpc> --l2 <l2-el-rpc> --tx <init-tx-hash> --portal-address <portal-addr> --private-key <private-key>
 ```
 
-When proving super roots, provide the dispute game address:
-
-```shell
-go run . prove --l1 <l1-el-rpc> --l2 <l2-el-rpc> --tx <init-tx-hash> --portal-address <portal-addr> --private-key <private-key> \
-  --dispute-game <dispute-game-proxy-address> --rollup.config <path-to-rollup-config>
-```
-
-This reads the super root proof directly from the `SuperFaultDisputeGame` contract's `extraData()`.
-
-
 ### finalize
 
 The `finalize` subcommand finalizes a withdrawal that has previously been proven. The dispute game must have resolved as

--- a/op-chain-ops/cmd/withdrawal/README.md
+++ b/op-chain-ops/cmd/withdrawal/README.md
@@ -27,11 +27,22 @@ valid proposal is made for a L2 block at or after the initiating transaction was
 go run . prove --l1 <l1-el-rpc> --l2 <l2-el-rpc> --tx <init-tx-hash> --portal-address <portal-addr> --private-key <private-key>
 ```
 
-When proving super roots, you'll need to provide additional flags:
+When proving super roots, you have two options:
 
+**Option 1: Using dispute game address** (recommended - reads proof from on-chain):
+
+```shell
+go run . prove --l1 <l1-el-rpc> --l2 <l2-el-rpc> --tx <init-tx-hash> --portal-address <portal-addr> --private-key <private-key> \
+  --dispute-game <dispute-game-proxy-address> --rollup.config <path-to-rollup-config>
 ```
-shell
-go run . prove --l1 <l1-el-rpc> --l2 <l2-el-rpc> --tx <init-tx-hash> --portal-address <portal-addr> --private-key <private-key>\
+
+This option reads the super root proof directly from the `SuperFaultDisputeGame` contract's `extraData()`,
+eliminating the need for supervisor-rpc and depset flags.
+
+**Option 2: Using supervisor RPC** (legacy - requires supervisor, rollup config, and depset):
+
+```shell
+go run . prove --l1 <l1-el-rpc> --l2 <l2-el-rpc> --tx <init-tx-hash> --portal-address <portal-addr> --private-key <private-key> \
   --supervisor <supervisor-rpc> --rollup.config <path-to-rollup-config> --depset <path-to-dependency-set-json>
 ```
 

--- a/op-chain-ops/cmd/withdrawal/README.md
+++ b/op-chain-ops/cmd/withdrawal/README.md
@@ -27,24 +27,14 @@ valid proposal is made for a L2 block at or after the initiating transaction was
 go run . prove --l1 <l1-el-rpc> --l2 <l2-el-rpc> --tx <init-tx-hash> --portal-address <portal-addr> --private-key <private-key>
 ```
 
-When proving super roots, you have two options:
-
-**Option 1: Using dispute game address** (recommended - reads proof from on-chain):
+When proving super roots, provide the dispute game address:
 
 ```shell
 go run . prove --l1 <l1-el-rpc> --l2 <l2-el-rpc> --tx <init-tx-hash> --portal-address <portal-addr> --private-key <private-key> \
   --dispute-game <dispute-game-proxy-address> --rollup.config <path-to-rollup-config>
 ```
 
-This option reads the super root proof directly from the `SuperFaultDisputeGame` contract's `extraData()`,
-eliminating the need for supervisor-rpc and depset flags.
-
-**Option 2: Using supervisor RPC** (legacy - requires supervisor, rollup config, and depset):
-
-```shell
-go run . prove --l1 <l1-el-rpc> --l2 <l2-el-rpc> --tx <init-tx-hash> --portal-address <portal-addr> --private-key <private-key> \
-  --supervisor <supervisor-rpc> --rollup.config <path-to-rollup-config> --depset <path-to-dependency-set-json>
-```
+This reads the super root proof directly from the `SuperFaultDisputeGame` contract's `extraData()`.
 
 
 ### finalize

--- a/op-chain-ops/cmd/withdrawal/prove.go
+++ b/op-chain-ops/cmd/withdrawal/prove.go
@@ -4,21 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math/big"
 
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
 	opnode_bindings "github.com/ethereum-optimism/optimism/op-node/bindings"
 	bindingspreview "github.com/ethereum-optimism/optimism/op-node/bindings/preview"
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/withdrawals"
 	op_service "github.com/ethereum-optimism/optimism/op-service"
-	"github.com/ethereum-optimism/optimism/op-service/apis"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
-	"github.com/ethereum-optimism/optimism/op-service/txintent/bindings"
-	"github.com/ethereum-optimism/optimism/op-service/txintent/contractio"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
-	"github.com/ethereum-optimism/optimism/packages/contracts-bedrock/snapshots"
-	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -45,17 +38,6 @@ var (
 		EnvVars: op_service.PrefixEnvVar(EnvVarPrefix, "PORTAL_ADDRESS"),
 	}
 
-	// Prove using SuperRoots Flags
-	RollupConfigFlag = &cli.StringFlag{
-		Name:    "rollup.config",
-		Usage:   "Path to the rollup config of the target chain. Only required for proving using super roots.",
-		EnvVars: op_service.PrefixEnvVar(EnvVarPrefix, "ROLLUP_CONFIG"),
-	}
-	DisputeGameFlag = &cli.StringFlag{
-		Name:    "dispute-game",
-		Usage:   "Address of SuperFaultDisputeGame. Required when proving super root withdrawals. Reads super root proof from on-chain extraData.",
-		EnvVars: op_service.PrefixEnvVar(EnvVarPrefix, "DISPUTE_GAME"),
-	}
 )
 
 func ProveWithdrawal(ctx *cli.Context) error {
@@ -111,52 +93,10 @@ func ProveWithdrawal(ctx *cli.Context) error {
 		return fmt.Errorf("could not find a dispute game at or above l2 block number %v: %w", rcpt.BlockNumber, err)
 	}
 
-	l1EthClient, err := createEthClient(ctx, L1Flag.Name)
+	logger.Info("Proving withdrawal")
+	txData, err := txDataForOutputRootProof(ctx.Context, proofClient, l2Client, txHash, factory, portal)
 	if err != nil {
-		return fmt.Errorf("failed to create L1 eth client: %w", err)
-	}
-	boundPortal := bindings.NewBindings[bindings.OptimismPortal2](bindings.WithClient(l1EthClient), bindings.WithTo(portalAddr))
-	usesSuperRoots, err := contractio.Read(boundPortal.SuperRootsActive(), ctx.Context)
-	if err != nil {
-		return fmt.Errorf("failed to fetch uses super roots from portal: %w", err)
-	}
-
-	var txData []byte
-	if !usesSuperRoots {
-		logger.Info("Proving withdrawal using output root proof")
-		txData, err = txDataForOutputRootProof(ctx.Context, proofClient, l2Client, txHash, factory, portal)
-		if err != nil {
-			return err
-		}
-	} else {
-		disputeGameStr := ctx.String(DisputeGameFlag.Name)
-		if disputeGameStr == "" {
-			return errors.New("--dispute-game is required when proving super root withdrawals")
-		}
-
-		logger.Info("Proving withdrawal using super root from dispute game extraData")
-		disputeGameAddr := common.HexToAddress(disputeGameStr)
-
-		rollupCfg, err := loadRollupConfig(ctx, RollupConfigFlag.Name)
-		if err != nil {
-			return fmt.Errorf("failed to load rollup config: %w", err)
-		}
-
-		txData, err = txDataForSuperRootProofFromGame(
-			ctx.Context,
-			l1Client,
-			l1EthClient,
-			proofClient,
-			l2Client,
-			txHash,
-			disputeGameAddr,
-			portalAddr,
-			portal,
-			rollupCfg,
-		)
-		if err != nil {
-			return err
-		}
+		return err
 	}
 
 	rcpt, err = txMgr.Send(ctx.Context, txmgr.TxCandidate{
@@ -200,180 +140,12 @@ func txDataForOutputRootProof(ctx context.Context, proofClient *gethclient.Clien
 	return txData, nil
 }
 
-// txDataForSuperRootProofFromGame builds withdrawal proof tx data by reading the super root proof
-// directly from a SuperFaultDisputeGame's extraData, without requiring supervisor-rpc or depset.
-func txDataForSuperRootProofFromGame(
-	ctx context.Context,
-	l1Client *ethclient.Client,
-	l1EthClient apis.EthClient,
-	proofClient *gethclient.Client,
-	l2Client *ethclient.Client,
-	txHash common.Hash,
-	disputeGameAddr common.Address,
-	portalAddr common.Address,
-	portal *bindingspreview.OptimismPortal2,
-	rollupCfg *rollup.Config,
-) ([]byte, error) {
-	// Load ABI and prepare contract calls
-	gameABI := snapshots.LoadSuperFaultDisputeGameABI()
-
-	// Call extraData() to get encoded super root proof
-	extraDataCallData, err := gameABI.Pack("extraData")
-	if err != nil {
-		return nil, fmt.Errorf("failed to pack extraData call: %w", err)
-	}
-	extraDataResult, err := l1Client.CallContract(ctx, ethereum.CallMsg{
-		To:   &disputeGameAddr,
-		Data: extraDataCallData,
-	}, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to call extraData: %w", err)
-	}
-
-	// Unpack extraData result (returns bytes)
-	unpackedExtra, err := gameABI.Unpack("extraData", extraDataResult)
-	if err != nil {
-		return nil, fmt.Errorf("failed to unpack extraData: %w", err)
-	}
-	if len(unpackedExtra) == 0 {
-		return nil, errors.New("extraData returned empty result")
-	}
-	extraDataBytes, ok := unpackedExtra[0].([]byte)
-	if !ok {
-		return nil, errors.New("extraData result is not []byte")
-	}
-
-	// Decode super root proof from extraData
-	superRootProof, err := withdrawals.DecodeSuperRootProof(extraDataBytes)
-	if err != nil {
-		return nil, fmt.Errorf("failed to decode super root proof: %w", err)
-	}
-
-	// Get target L2 chain ID from portal
-	targetChainID, err := l2ChainIDForPortal(ctx, l1EthClient, portal)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get target chain ID from portal: %w", err)
-	}
-
-	// Find output root index for target chain in the super root proof
-	var outputRootIndex *big.Int
-	for i, outputRoot := range superRootProof.OutputRoots {
-		if outputRoot.ChainID.Uint64() == targetChainID {
-			outputRootIndex = big.NewInt(int64(i))
-			break
-		}
-	}
-	if outputRootIndex == nil {
-		return nil, fmt.Errorf("target chain ID %d not found in super root proof", targetChainID)
-	}
-
-	// Get L2 sequence number (timestamp) from the dispute game
-	seqNumCallData, err := gameABI.Pack("l2SequenceNumber")
-	if err != nil {
-		return nil, fmt.Errorf("failed to pack l2SequenceNumber call: %w", err)
-	}
-	seqNumResult, err := l1Client.CallContract(ctx, ethereum.CallMsg{
-		To:   &disputeGameAddr,
-		Data: seqNumCallData,
-	}, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to call l2SequenceNumber: %w", err)
-	}
-	unpackedSeq, err := gameABI.Unpack("l2SequenceNumber", seqNumResult)
-	if err != nil {
-		return nil, fmt.Errorf("failed to unpack l2SequenceNumber: %w", err)
-	}
-	if len(unpackedSeq) == 0 {
-		return nil, errors.New("l2SequenceNumber returned empty result")
-	}
-	l2SequenceNumber, ok := unpackedSeq[0].(*big.Int)
-	if !ok {
-		return nil, errors.New("l2SequenceNumber result is not *big.Int")
-	}
-
-	// Convert sequence number (timestamp) to L2 block number using rollup config
-	l2BlockNumber, err := rollupCfg.TargetBlockNumber(l2SequenceNumber.Uint64())
-	if err != nil {
-		return nil, fmt.Errorf("failed to get L2 block number from sequence number: %w", err)
-	}
-
-	// Fetch the L2 header at that block
-	l2Header, err := l2Client.HeaderByNumber(ctx, new(big.Int).SetUint64(l2BlockNumber))
-	if err != nil {
-		return nil, fmt.Errorf("failed to get L2 header: %w", err)
-	}
-
-	// Get withdrawal receipt and parse MessagePassed event
-	receipt, err := l2Client.TransactionReceipt(ctx, txHash)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get withdrawal receipt: %w", err)
-	}
-	ev, err := withdrawals.ParseMessagePassed(receipt)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse withdrawal event: %w", err)
-	}
-
-	// Build the withdrawal storage proof
-	withdrawalProof, storageRoot, err := withdrawals.GetWithdrawalProof(ctx, proofClient, ev, l2Header)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get withdrawal proof: %w", err)
-	}
-
-	// Pack the proveWithdrawalTransaction call data
-	txData, err := w3.MustNewFunc("proveWithdrawalTransaction("+
-		"(uint256 Nonce, address Sender, address Target, uint256 Value, uint256 GasLimit, bytes Data),"+
-		"address DisputeGameProxy,"+
-		"uint256 OutputRootIndex,"+
-		"(bytes1 Version, uint64 Timestamp, (uint256 ChainID, bytes32 Root)[] OutputRoots),"+
-		"(bytes32 Version, bytes32 StateRoot, bytes32 MessagePasserStorageRoot, bytes32 LatestBlockhash),"+
-		"bytes[])", "").EncodeArgs(
-		bindingspreview.TypesWithdrawalTransaction{
-			Nonce:    ev.Nonce,
-			Sender:   ev.Sender,
-			Target:   ev.Target,
-			Value:    ev.Value,
-			GasLimit: ev.GasLimit,
-			Data:     ev.Data,
-		},
-		disputeGameAddr,
-		outputRootIndex,
-		superRootProof,
-		opnode_bindings.TypesOutputRootProof{
-			Version:                  [32]byte{},
-			StateRoot:                l2Header.Root,
-			MessagePasserStorageRoot: storageRoot,
-			LatestBlockhash:          l2Header.Hash(),
-		},
-		withdrawalProof,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to pack prove withdrawal transaction: %w", err)
-	}
-	return txData, nil
-}
-
-func l2ChainIDForPortal(ctx context.Context, l1EthClient apis.EthClient, portal *bindingspreview.OptimismPortal2) (uint64, error) {
-	systemConfigAddr, err := portal.SystemConfig(&bind.CallOpts{Context: ctx})
-	if err != nil {
-		return 0, fmt.Errorf("failed to get system config address from portal: %w", err)
-	}
-	systemConfig := bindings.NewSystemConfig(bindings.WithClient(l1EthClient), bindings.WithTo(systemConfigAddr))
-	l2ChainID, err := contractio.Read(systemConfig.L2ChainID(), ctx)
-	if err != nil {
-		return 0, fmt.Errorf("failed to read L2 chain ID from system config: %w", err)
-	}
-	return l2ChainID.Uint64(), nil
-}
-
 func proveFlags() []cli.Flag {
 	cliFlags := []cli.Flag{
 		L1Flag,
 		L2Flag,
 		TxFlag,
 		PortalAddressFlag,
-		// Super Roots Flags
-		RollupConfigFlag,
-		DisputeGameFlag,
 	}
 	cliFlags = append(cliFlags, txmgr.CLIFlagsWithDefaults(EnvVarPrefix, txmgr.DefaultChallengerFlagValues)...)
 	cliFlags = append(cliFlags, oplog.CLIFlags(EnvVarPrefix)...)

--- a/op-chain-ops/cmd/withdrawal/prove.go
+++ b/op-chain-ops/cmd/withdrawal/prove.go
@@ -46,16 +46,6 @@ var (
 	}
 
 	// Prove using SuperRoots Flags
-	SupervisorFlag = &cli.StringFlag{
-		Name:    "supervisor",
-		Usage:   "HTTP provider URL for supervisor. Only required for proving using super roots.",
-		EnvVars: op_service.PrefixEnvVar(EnvVarPrefix, "SUPERVISOR"),
-	}
-	DepSetFlag = &cli.StringFlag{
-		Name:    "depset",
-		Usage:   "Path to the dependency set file. Only required for proving using super roots.",
-		EnvVars: op_service.PrefixEnvVar(EnvVarPrefix, "DEPSET"),
-	}
 	RollupConfigFlag = &cli.StringFlag{
 		Name:    "rollup.config",
 		Usage:   "Path to the rollup config of the target chain. Only required for proving using super roots.",
@@ -63,7 +53,7 @@ var (
 	}
 	DisputeGameFlag = &cli.StringFlag{
 		Name:    "dispute-game",
-		Usage:   "Address of SuperFaultDisputeGame. When provided, reads super root proof from on-chain extraData instead of supervisor-rpc. Requires --rollup.config but not --supervisor or --depset.",
+		Usage:   "Address of SuperFaultDisputeGame. Required when proving super root withdrawals. Reads super root proof from on-chain extraData.",
 		EnvVars: op_service.PrefixEnvVar(EnvVarPrefix, "DISPUTE_GAME"),
 	}
 )
@@ -139,39 +129,33 @@ func ProveWithdrawal(ctx *cli.Context) error {
 			return err
 		}
 	} else {
-		// Check if --dispute-game flag is provided for the new flow
-		if disputeGameStr := ctx.String(DisputeGameFlag.Name); disputeGameStr != "" {
-			logger.Info("Proving withdrawal using super root from dispute game extraData")
-			disputeGameAddr := common.HexToAddress(disputeGameStr)
+		disputeGameStr := ctx.String(DisputeGameFlag.Name)
+		if disputeGameStr == "" {
+			return errors.New("--dispute-game is required when proving super root withdrawals")
+		}
 
-			// Load rollup config (still required for timestamp→block number conversion)
-			rollupCfg, err := loadRollupConfig(ctx, RollupConfigFlag.Name)
-			if err != nil {
-				return fmt.Errorf("failed to load rollup config: %w", err)
-			}
+		logger.Info("Proving withdrawal using super root from dispute game extraData")
+		disputeGameAddr := common.HexToAddress(disputeGameStr)
 
-			txData, err = txDataForSuperRootProofFromGame(
-				ctx.Context,
-				l1Client,
-				l1EthClient,
-				proofClient,
-				l2Client,
-				txHash,
-				disputeGameAddr,
-				portalAddr,
-				portal,
-				rollupCfg,
-			)
-			if err != nil {
-				return err
-			}
-		} else {
-			// Existing supervisor-based flow
-			logger.Info("Proving withdrawal using super root from supervisor")
-			txData, err = txDataForSuperRootProof(ctx, l1EthClient, proofClient, l2Client, txHash, factory, portal)
-			if err != nil {
-				return err
-			}
+		rollupCfg, err := loadRollupConfig(ctx, RollupConfigFlag.Name)
+		if err != nil {
+			return fmt.Errorf("failed to load rollup config: %w", err)
+		}
+
+		txData, err = txDataForSuperRootProofFromGame(
+			ctx.Context,
+			l1Client,
+			l1EthClient,
+			proofClient,
+			l2Client,
+			txHash,
+			disputeGameAddr,
+			portalAddr,
+			portal,
+			rollupCfg,
+		)
+		if err != nil {
+			return err
 		}
 	}
 
@@ -212,70 +196,6 @@ func txDataForOutputRootProof(ctx context.Context, proofClient *gethclient.Clien
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to pack output root prove withdrawal transaction: %w", err)
-	}
-	return txData, nil
-}
-
-func txDataForSuperRootProof(ctx *cli.Context, l1EthClient apis.EthClient, proofClient *gethclient.Client, l2Client *ethclient.Client, txHash common.Hash, factory *opnode_bindings.DisputeGameFactoryCaller, portal *bindingspreview.OptimismPortal2) ([]byte, error) {
-	supervisorClient, err := createSupervisorClient(ctx, SupervisorFlag.Name)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create supervisor client: %w", err)
-	}
-	rollupCfg, err := loadRollupConfig(ctx, RollupConfigFlag.Name)
-	if err != nil {
-		return nil, err
-	}
-	depSet, err := loadDepsetConfig(ctx, DepSetFlag.Name)
-	if err != nil {
-		return nil, err
-	}
-
-	portalL2ChainID, err := l2ChainIDForPortal(ctx.Context, l1EthClient, portal)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get portal chain ID: %w", err)
-	}
-	if portalL2ChainID != rollupCfg.L2ChainID.Uint64() {
-		return nil, fmt.Errorf("portal chain ID %d does not match the provided rollup config chain ID %d", portalL2ChainID, rollupCfg.L2ChainID.Uint64())
-	}
-
-	params, err := withdrawals.ProveWithdrawalParametersSuperRoots(
-		ctx.Context,
-		rollupCfg,
-		depSet,
-		proofClient,
-		l2Client,
-		l2Client,
-		txHash,
-		supervisorClient,
-		factory,
-		&portal.OptimismPortal2Caller,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create withdrawal proof parameters: %w", err)
-	}
-	txData, err := w3.MustNewFunc("proveWithdrawalTransaction("+
-		"(uint256 Nonce, address Sender, address Target, uint256 Value, uint256 GasLimit, bytes Data),"+
-		"address DisputeGameProxy,"+
-		"uint256 OutputRootIndex,"+
-		"(bytes1 Version, uint64 Timestamp, (uint256 ChainID, bytes32 Root)[] OutputRoots),"+
-		"(bytes32 Version, bytes32 StateRoot, bytes32 MessagePasserStorageRoot, bytes32 LatestBlockhash),"+
-		"bytes[])", "").EncodeArgs(
-		bindingspreview.TypesWithdrawalTransaction{
-			Nonce:    params.Nonce,
-			Sender:   params.Sender,
-			Target:   params.Target,
-			Value:    params.Value,
-			GasLimit: params.GasLimit,
-			Data:     params.Data,
-		},
-		params.DisputeGameProxy,
-		params.OutputRootIndex,
-		params.SuperRootProof,
-		params.OutputRootProof,
-		params.WithdrawalProof,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to pack super root prove withdrawal transaction: %w", err)
 	}
 	return txData, nil
 }
@@ -452,8 +372,6 @@ func proveFlags() []cli.Flag {
 		TxFlag,
 		PortalAddressFlag,
 		// Super Roots Flags
-		SupervisorFlag,
-		DepSetFlag,
 		RollupConfigFlag,
 		DisputeGameFlag,
 	}

--- a/op-chain-ops/cmd/withdrawal/prove.go
+++ b/op-chain-ops/cmd/withdrawal/prove.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/big"
 
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
 	opnode_bindings "github.com/ethereum-optimism/optimism/op-node/bindings"
 	bindingspreview "github.com/ethereum-optimism/optimism/op-node/bindings/preview"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/withdrawals"
 	op_service "github.com/ethereum-optimism/optimism/op-service"
 	"github.com/ethereum-optimism/optimism/op-service/apis"
@@ -15,6 +17,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/txintent/bindings"
 	"github.com/ethereum-optimism/optimism/op-service/txintent/contractio"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
+	"github.com/ethereum-optimism/optimism/packages/contracts-bedrock/snapshots"
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -56,6 +60,11 @@ var (
 		Name:    "rollup.config",
 		Usage:   "Path to the rollup config of the target chain. Only required for proving using super roots.",
 		EnvVars: op_service.PrefixEnvVar(EnvVarPrefix, "ROLLUP_CONFIG"),
+	}
+	DisputeGameFlag = &cli.StringFlag{
+		Name:    "dispute-game",
+		Usage:   "Address of SuperFaultDisputeGame. When provided, reads super root proof from on-chain extraData instead of supervisor-rpc. Requires --rollup.config but not --supervisor or --depset.",
+		EnvVars: op_service.PrefixEnvVar(EnvVarPrefix, "DISPUTE_GAME"),
 	}
 )
 
@@ -130,10 +139,39 @@ func ProveWithdrawal(ctx *cli.Context) error {
 			return err
 		}
 	} else {
-		logger.Info("Proving withdrawal using super root proof")
-		txData, err = txDataForSuperRootProof(ctx, l1EthClient, proofClient, l2Client, txHash, factory, portal)
-		if err != nil {
-			return err
+		// Check if --dispute-game flag is provided for the new flow
+		if disputeGameStr := ctx.String(DisputeGameFlag.Name); disputeGameStr != "" {
+			logger.Info("Proving withdrawal using super root from dispute game extraData")
+			disputeGameAddr := common.HexToAddress(disputeGameStr)
+
+			// Load rollup config (still required for timestamp→block number conversion)
+			rollupCfg, err := loadRollupConfig(ctx, RollupConfigFlag.Name)
+			if err != nil {
+				return fmt.Errorf("failed to load rollup config: %w", err)
+			}
+
+			txData, err = txDataForSuperRootProofFromGame(
+				ctx.Context,
+				l1Client,
+				l1EthClient,
+				proofClient,
+				l2Client,
+				txHash,
+				disputeGameAddr,
+				portalAddr,
+				portal,
+				rollupCfg,
+			)
+			if err != nil {
+				return err
+			}
+		} else {
+			// Existing supervisor-based flow
+			logger.Info("Proving withdrawal using super root from supervisor")
+			txData, err = txDataForSuperRootProof(ctx, l1EthClient, proofClient, l2Client, txHash, factory, portal)
+			if err != nil {
+				return err
+			}
 		}
 	}
 
@@ -242,6 +280,158 @@ func txDataForSuperRootProof(ctx *cli.Context, l1EthClient apis.EthClient, proof
 	return txData, nil
 }
 
+// txDataForSuperRootProofFromGame builds withdrawal proof tx data by reading the super root proof
+// directly from a SuperFaultDisputeGame's extraData, without requiring supervisor-rpc or depset.
+func txDataForSuperRootProofFromGame(
+	ctx context.Context,
+	l1Client *ethclient.Client,
+	l1EthClient apis.EthClient,
+	proofClient *gethclient.Client,
+	l2Client *ethclient.Client,
+	txHash common.Hash,
+	disputeGameAddr common.Address,
+	portalAddr common.Address,
+	portal *bindingspreview.OptimismPortal2,
+	rollupCfg *rollup.Config,
+) ([]byte, error) {
+	// Load ABI and prepare contract calls
+	gameABI := snapshots.LoadSuperFaultDisputeGameABI()
+
+	// Call extraData() to get encoded super root proof
+	extraDataCallData, err := gameABI.Pack("extraData")
+	if err != nil {
+		return nil, fmt.Errorf("failed to pack extraData call: %w", err)
+	}
+	extraDataResult, err := l1Client.CallContract(ctx, ethereum.CallMsg{
+		To:   &disputeGameAddr,
+		Data: extraDataCallData,
+	}, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to call extraData: %w", err)
+	}
+
+	// Unpack extraData result (returns bytes)
+	unpackedExtra, err := gameABI.Unpack("extraData", extraDataResult)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unpack extraData: %w", err)
+	}
+	if len(unpackedExtra) == 0 {
+		return nil, errors.New("extraData returned empty result")
+	}
+	extraDataBytes, ok := unpackedExtra[0].([]byte)
+	if !ok {
+		return nil, errors.New("extraData result is not []byte")
+	}
+
+	// Decode super root proof from extraData
+	superRootProof, err := withdrawals.DecodeSuperRootProof(extraDataBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode super root proof: %w", err)
+	}
+
+	// Get target L2 chain ID from portal
+	targetChainID, err := l2ChainIDForPortal(ctx, l1EthClient, portal)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get target chain ID from portal: %w", err)
+	}
+
+	// Find output root index for target chain in the super root proof
+	var outputRootIndex *big.Int
+	for i, outputRoot := range superRootProof.OutputRoots {
+		if outputRoot.ChainID.Uint64() == targetChainID {
+			outputRootIndex = big.NewInt(int64(i))
+			break
+		}
+	}
+	if outputRootIndex == nil {
+		return nil, fmt.Errorf("target chain ID %d not found in super root proof", targetChainID)
+	}
+
+	// Get L2 sequence number (timestamp) from the dispute game
+	seqNumCallData, err := gameABI.Pack("l2SequenceNumber")
+	if err != nil {
+		return nil, fmt.Errorf("failed to pack l2SequenceNumber call: %w", err)
+	}
+	seqNumResult, err := l1Client.CallContract(ctx, ethereum.CallMsg{
+		To:   &disputeGameAddr,
+		Data: seqNumCallData,
+	}, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to call l2SequenceNumber: %w", err)
+	}
+	unpackedSeq, err := gameABI.Unpack("l2SequenceNumber", seqNumResult)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unpack l2SequenceNumber: %w", err)
+	}
+	if len(unpackedSeq) == 0 {
+		return nil, errors.New("l2SequenceNumber returned empty result")
+	}
+	l2SequenceNumber, ok := unpackedSeq[0].(*big.Int)
+	if !ok {
+		return nil, errors.New("l2SequenceNumber result is not *big.Int")
+	}
+
+	// Convert sequence number (timestamp) to L2 block number using rollup config
+	l2BlockNumber, err := rollupCfg.TargetBlockNumber(l2SequenceNumber.Uint64())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get L2 block number from sequence number: %w", err)
+	}
+
+	// Fetch the L2 header at that block
+	l2Header, err := l2Client.HeaderByNumber(ctx, new(big.Int).SetUint64(l2BlockNumber))
+	if err != nil {
+		return nil, fmt.Errorf("failed to get L2 header: %w", err)
+	}
+
+	// Get withdrawal receipt and parse MessagePassed event
+	receipt, err := l2Client.TransactionReceipt(ctx, txHash)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get withdrawal receipt: %w", err)
+	}
+	ev, err := withdrawals.ParseMessagePassed(receipt)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse withdrawal event: %w", err)
+	}
+
+	// Build the withdrawal storage proof
+	withdrawalProof, storageRoot, err := withdrawals.GetWithdrawalProof(ctx, proofClient, ev, l2Header)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get withdrawal proof: %w", err)
+	}
+
+	// Pack the proveWithdrawalTransaction call data
+	txData, err := w3.MustNewFunc("proveWithdrawalTransaction("+
+		"(uint256 Nonce, address Sender, address Target, uint256 Value, uint256 GasLimit, bytes Data),"+
+		"address DisputeGameProxy,"+
+		"uint256 OutputRootIndex,"+
+		"(bytes1 Version, uint64 Timestamp, (uint256 ChainID, bytes32 Root)[] OutputRoots),"+
+		"(bytes32 Version, bytes32 StateRoot, bytes32 MessagePasserStorageRoot, bytes32 LatestBlockhash),"+
+		"bytes[])", "").EncodeArgs(
+		bindingspreview.TypesWithdrawalTransaction{
+			Nonce:    ev.Nonce,
+			Sender:   ev.Sender,
+			Target:   ev.Target,
+			Value:    ev.Value,
+			GasLimit: ev.GasLimit,
+			Data:     ev.Data,
+		},
+		disputeGameAddr,
+		outputRootIndex,
+		superRootProof,
+		opnode_bindings.TypesOutputRootProof{
+			Version:                  [32]byte{},
+			StateRoot:                l2Header.Root,
+			MessagePasserStorageRoot: storageRoot,
+			LatestBlockhash:          l2Header.Hash(),
+		},
+		withdrawalProof,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to pack prove withdrawal transaction: %w", err)
+	}
+	return txData, nil
+}
+
 func l2ChainIDForPortal(ctx context.Context, l1EthClient apis.EthClient, portal *bindingspreview.OptimismPortal2) (uint64, error) {
 	systemConfigAddr, err := portal.SystemConfig(&bind.CallOpts{Context: ctx})
 	if err != nil {
@@ -265,6 +455,7 @@ func proveFlags() []cli.Flag {
 		SupervisorFlag,
 		DepSetFlag,
 		RollupConfigFlag,
+		DisputeGameFlag,
 	}
 	cliFlags = append(cliFlags, txmgr.CLIFlagsWithDefaults(EnvVarPrefix, txmgr.DefaultChallengerFlagValues)...)
 	cliFlags = append(cliFlags, oplog.CLIFlags(EnvVarPrefix)...)

--- a/op-chain-ops/cmd/withdrawal/prove.go
+++ b/op-chain-ops/cmd/withdrawal/prove.go
@@ -37,7 +37,6 @@ var (
 		Usage:   "Address of the optimism portal contract.",
 		EnvVars: op_service.PrefixEnvVar(EnvVarPrefix, "PORTAL_ADDRESS"),
 	}
-
 )
 
 func ProveWithdrawal(ctx *cli.Context) error {

--- a/op-chain-ops/cmd/withdrawal/util.go
+++ b/op-chain-ops/cmd/withdrawal/util.go
@@ -2,14 +2,10 @@ package main
 
 import (
 	"fmt"
-	"os"
 	"time"
 
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
-	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/ctxinterrupt"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
-	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr/metrics"
 	"github.com/ethereum/go-ethereum/log"
@@ -42,27 +38,4 @@ func createTxMgr(ctx *cli.Context, logger log.Logger, rpcUrlFlag string) (*txmgr
 		return nil, fmt.Errorf("failed to create the transaction manager: %w", err)
 	}
 	return txMgr, nil
-}
-
-func createEthClient(ctx *cli.Context, rpcUrlFlag string) (*sources.EthClient, error) {
-	url := ctx.String(rpcUrlFlag)
-	l1RPC, err := client.NewRPC(ctx.Context, log.Root(), url, client.WithDialAttempts(10))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create RPC client: %w", err)
-	}
-	l1Client, err := sources.NewEthClient(l1RPC, log.Root(), nil, sources.DefaultEthClientConfig(10))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create L1 client: %w", err)
-	}
-	return l1Client, nil
-}
-
-func loadRollupConfig(ctx *cli.Context, rollupConfigFlag string) (*rollup.Config, error) {
-	file, err := os.Open(ctx.String(rollupConfigFlag))
-	if err != nil {
-		return nil, fmt.Errorf("failed to open rollup config file: %w", err)
-	}
-	defer file.Close()
-	var rollupConfig rollup.Config
-	return &rollupConfig, rollupConfig.ParseRollupConfig(file)
 }

--- a/op-chain-ops/cmd/withdrawal/util.go
+++ b/op-chain-ops/cmd/withdrawal/util.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"time"
@@ -9,12 +8,10 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/ctxinterrupt"
-	"github.com/ethereum-optimism/optimism/op-service/dial"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr/metrics"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/urfave/cli/v2"
 )
@@ -68,25 +65,4 @@ func loadRollupConfig(ctx *cli.Context, rollupConfigFlag string) (*rollup.Config
 	defer file.Close()
 	var rollupConfig rollup.Config
 	return &rollupConfig, rollupConfig.ParseRollupConfig(file)
-}
-
-func loadDepsetConfig(ctx *cli.Context, depSetFlag string) (depset.DependencySet, error) {
-	data, err := os.ReadFile(ctx.String(depSetFlag))
-	if err != nil {
-		return nil, fmt.Errorf("failed to read depset config: %w", err)
-	}
-	var depsetConfig depset.StaticConfigDependencySet
-	err = json.Unmarshal(data, &depsetConfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse depset config: %w", err)
-	}
-	return &depsetConfig, nil
-}
-
-func createSupervisorClient(ctx *cli.Context, supervisorFlag string) (*sources.SupervisorClient, error) {
-	cl, err := dial.DialSupervisorClientWithTimeout(ctx.Context, log.Root(), ctx.String(supervisorFlag))
-	if err != nil {
-		return nil, fmt.Errorf("failed to dial supervisor: %w", err)
-	}
-	return cl, nil
 }

--- a/op-devstack/dsl/bridge.go
+++ b/op-devstack/dsl/bridge.go
@@ -22,11 +22,15 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/txintent/bindings"
 	"github.com/ethereum-optimism/optimism/op-service/txintent/contractio"
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient/gethclient"
+	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/holiman/uint256"
+
+	"github.com/ethereum-optimism/optimism/packages/contracts-bedrock/snapshots"
 )
 
 // ProvenWithdrawalParameters is the set of parameters to pass to the ProveWithdrawalTransaction
@@ -407,6 +411,40 @@ func (w *Withdrawal) Prove(user *EOA) {
 	}, 30*time.Second, 1*time.Second, "Sending prove transaction")
 }
 
+// ProveFromGameExtraData proves withdrawal by reading super root proof from dispute game's extraData.
+// This mirrors the CLI --dispute-game flow and doesn't require supervisor-rpc.
+func (w *Withdrawal) ProveFromGameExtraData(user *EOA) {
+	w.t.Log("proveWithdrawal: proving withdrawal from game extraData...")
+	params := w.proveWithdrawalParametersFromGameExtraData()
+
+	tx := bindings.WithdrawalTransaction{
+		Nonce:    params.Nonce,
+		Sender:   params.Sender,
+		Target:   params.Target,
+		Value:    params.Value,
+		GasLimit: params.GasLimit,
+		Data:     params.Data,
+	}
+
+	call := w.bridge.l1Portal.ProveWithdrawalTransactionSuperRoot(
+		tx, params.DisputeGameAddress, params.OutputRootIndex,
+		*params.SuperRootProof, params.OutputRootProof, params.WithdrawalProof)
+
+	w.require.Eventually(func() bool {
+		proveReceipt, err := contractio.Write(call, w.ctx, user.Plan())
+		if err != nil {
+			w.log.Error("Failed to send prove transaction", "err", err)
+			return false
+		}
+		w.require.Equal(types.ReceiptStatusSuccessful, proveReceipt.Status, "prove withdrawal was not successful")
+		w.require.Equal(2, len(proveReceipt.Logs)) // emit WithdrawalProven, WithdrawalProvenExtension1
+
+		w.proveParams = params
+		w.proveReceipt = proveReceipt
+		return true
+	}, 30*time.Second, 1*time.Second, "Sending prove transaction")
+}
+
 // ProveWithdrawalParameters calls ProveWithdrawalParametersForBlock with the most recent L2 output after the latest game.
 // Ported from op-node/withdrawals/utils.go to fit in the op-devstack
 func (w *Withdrawal) proveWithdrawalParameters() ProvenWithdrawalParameters {
@@ -481,6 +519,102 @@ func (w *Withdrawal) proveWithdrawalParametersForEvent(ev *nodebindings.L2ToL1Me
 		OutputRootIndex:    outputRootIndex,
 		OutputRootProof: bindings.OutputRootProof{
 			Version:                  [32]byte{}, // Empty for version 1
+			StateRoot:                l2Header.Root(),
+			MessagePasserStorageRoot: *l2Header.WithdrawalsRoot(),
+			LatestBlockhash:          l2Header.Hash(),
+		},
+		WithdrawalProof: trieNodes,
+	}
+}
+
+// proveWithdrawalParametersFromGameExtraData builds withdrawal parameters by reading super root proof
+// directly from the dispute game's extraData, without requiring supervisor-rpc.
+func (w *Withdrawal) proveWithdrawalParametersFromGameExtraData() ProvenWithdrawalParameters {
+	latestGame := w.bridge.forGamePublished(w.initReceipt.BlockNumber)
+	w.require.True(latestGame.UsesSuperRoots, "Game must use super roots for extraData flow")
+
+	// Load ABI and call extraData on the game contract
+	gameABI := snapshots.LoadSuperFaultDisputeGameABI()
+	extraDataCallData, err := gameABI.Pack("extraData")
+	w.require.NoError(err, "failed to pack extraData call")
+
+	extraDataResult, err := w.bridge.l1Client.EthClient().Call(w.ctx, ethereum.CallMsg{
+		To:   &latestGame.Address,
+		Data: extraDataCallData,
+	}, rpc.LatestBlockNumber)
+	w.require.NoError(err, "failed to call extraData")
+
+	unpackedExtra, err := gameABI.Unpack("extraData", extraDataResult)
+	w.require.NoError(err, "failed to unpack extraData")
+	w.require.NotEmpty(unpackedExtra, "extraData returned empty result")
+	extraDataBytes, ok := unpackedExtra[0].([]byte)
+	w.require.True(ok, "extraData result is not []byte")
+
+	// Decode super root proof from extraData
+	superRootProofDecoded, err := withdrawals.DecodeSuperRootProof(extraDataBytes)
+	w.require.NoError(err, "failed to decode super root proof")
+
+	// Find output root index for this chain
+	var outputRootIndex *big.Int
+	for i, outputRoot := range superRootProofDecoded.OutputRoots {
+		if outputRoot.ChainID.Cmp(w.bridge.rollupCfg.L2ChainID) == 0 {
+			outputRootIndex = big.NewInt(int64(i))
+			break
+		}
+	}
+	w.require.NotNil(outputRootIndex, "target chain ID not found in super root proof")
+
+	// Convert decoded proof to bindings format
+	outputRoots := make([]bindings.OutputRootWithChainID, len(superRootProofDecoded.OutputRoots))
+	for i, root := range superRootProofDecoded.OutputRoots {
+		outputRoots[i] = bindings.OutputRootWithChainID{
+			ChainID: root.ChainID,
+			Root:    root.Root,
+		}
+	}
+	superRootProof := &bindings.SuperRootProof{
+		Version:     superRootProofDecoded.Version,
+		Timestamp:   superRootProofDecoded.Timestamp,
+		OutputRoots: outputRoots,
+	}
+
+	// Get L2 header at game's block number
+	l2Header, err := w.bridge.l2Client.InfoByNumber(w.ctx, latestGame.L2BlockNumber)
+	w.require.NoErrorf(err, "failed to fetch block header %v", latestGame.L2BlockNumber)
+
+	// Parse withdrawal event and build storage proof
+	ev, err := withdrawals.ParseMessagePassed(w.initReceipt)
+	w.require.NoError(err, "failed to parse message passed receipt")
+
+	withdrawalHash, err := withdrawals.WithdrawalHash(ev)
+	w.require.NoError(err, "failed to calculate withdrawal hash")
+	slot := withdrawals.StorageSlotOfWithdrawalHash(withdrawalHash)
+
+	p, err := w.bridge.l2Client.GetProof(w.ctx, predeploys.L2ToL1MessagePasserAddr, []common.Hash{slot}, hexutil.Uint64(l2Header.NumberU64()).String())
+	w.require.NoError(err, "failed to fetch proof for withdrawal")
+	w.require.Len(p.StorageProof, 1, "invalid amount of storage proofs")
+
+	err = verifyProof(l2Header.Root(), p)
+	w.require.NoError(err, "failed to verify proof for withdrawal")
+
+	trieNodes := make([][]byte, len(p.StorageProof[0].Proof))
+	for i, s := range p.StorageProof[0].Proof {
+		trieNodes[i] = s
+	}
+
+	return ProvenWithdrawalParameters{
+		Nonce:              ev.Nonce,
+		Sender:             ev.Sender,
+		Target:             ev.Target,
+		Value:              ev.Value,
+		GasLimit:           ev.GasLimit,
+		DisputeGameAddress: latestGame.Address,
+		DisputeGameIndex:   latestGame.Index,
+		Data:               ev.Data,
+		SuperRootProof:     superRootProof,
+		OutputRootIndex:    outputRootIndex,
+		OutputRootProof: bindings.OutputRootProof{
+			Version:                  [32]byte{},
 			StateRoot:                l2Header.Root(),
 			MessagePasserStorageRoot: *l2Header.WithdrawalsRoot(),
 			LatestBlockhash:          l2Header.Hash(),

--- a/op-devstack/dsl/bridge.go
+++ b/op-devstack/dsl/bridge.go
@@ -394,38 +394,6 @@ func (w *Withdrawal) Prove(user *EOA) {
 	}, 30*time.Second, 1*time.Second, "Sending prove transaction")
 }
 
-// ProveFromGameExtraData proves withdrawal by reading super root proof from dispute game's extraData.
-// This mirrors the CLI --dispute-game flow and doesn't require supervisor-rpc.
-func (w *Withdrawal) ProveFromGameExtraData(user *EOA) {
-	w.t.Log("proveWithdrawal: proving withdrawal from game extraData...")
-	params := w.proveWithdrawalParametersFromGameExtraData()
-
-	tx := bindings.WithdrawalTransaction{
-		Nonce:    params.Nonce,
-		Sender:   params.Sender,
-		Target:   params.Target,
-		Value:    params.Value,
-		GasLimit: params.GasLimit,
-		Data:     params.Data,
-	}
-
-	call := w.bridge.l1Portal.ProveWithdrawalTransaction(tx, params.DisputeGameIndex, params.OutputRootProof, params.WithdrawalProof)
-
-	w.require.Eventually(func() bool {
-		proveReceipt, err := contractio.Write(call, w.ctx, user.Plan())
-		if err != nil {
-			w.log.Error("Failed to send prove transaction", "err", err)
-			return false
-		}
-		w.require.Equal(types.ReceiptStatusSuccessful, proveReceipt.Status, "prove withdrawal was not successful")
-		w.require.Equal(2, len(proveReceipt.Logs)) // emit WithdrawalProven, WithdrawalProvenExtension1
-
-		w.proveParams = params
-		w.proveReceipt = proveReceipt
-		return true
-	}, 30*time.Second, 1*time.Second, "Sending prove transaction")
-}
-
 // ProveWithdrawalParameters calls ProveWithdrawalParametersForBlock with the most recent L2 output after the latest game.
 // Ported from op-node/withdrawals/utils.go to fit in the op-devstack
 func (w *Withdrawal) proveWithdrawalParameters() ProvenWithdrawalParameters {
@@ -476,55 +444,6 @@ func (w *Withdrawal) proveWithdrawalParametersForEvent(ev *nodebindings.L2ToL1Me
 		Data:               ev.Data,
 		OutputRootProof: bindings.OutputRootProof{
 			Version:                  [32]byte{}, // Empty for version 1
-			StateRoot:                l2Header.Root(),
-			MessagePasserStorageRoot: *l2Header.WithdrawalsRoot(),
-			LatestBlockhash:          l2Header.Hash(),
-		},
-		WithdrawalProof: trieNodes,
-	}
-}
-
-// proveWithdrawalParametersFromGameExtraData builds withdrawal parameters for super root games.
-// Contract now handles super root proof internally via game.rootClaimByChainId(chainId).
-func (w *Withdrawal) proveWithdrawalParametersFromGameExtraData() ProvenWithdrawalParameters {
-	latestGame := w.bridge.forGamePublished(w.initReceipt.BlockNumber)
-	w.require.True(latestGame.UsesSuperRoots, "Game must use super roots for extraData flow")
-
-	// Get L2 header at game's block number
-	l2Header, err := w.bridge.l2Client.InfoByNumber(w.ctx, latestGame.L2BlockNumber)
-	w.require.NoErrorf(err, "failed to fetch block header %v", latestGame.L2BlockNumber)
-
-	// Parse withdrawal event and build storage proof
-	ev, err := withdrawals.ParseMessagePassed(w.initReceipt)
-	w.require.NoError(err, "failed to parse message passed receipt")
-
-	withdrawalHash, err := withdrawals.WithdrawalHash(ev)
-	w.require.NoError(err, "failed to calculate withdrawal hash")
-	slot := withdrawals.StorageSlotOfWithdrawalHash(withdrawalHash)
-
-	p, err := w.bridge.l2Client.GetProof(w.ctx, predeploys.L2ToL1MessagePasserAddr, []common.Hash{slot}, hexutil.Uint64(l2Header.NumberU64()).String())
-	w.require.NoError(err, "failed to fetch proof for withdrawal")
-	w.require.Len(p.StorageProof, 1, "invalid amount of storage proofs")
-
-	err = verifyProof(l2Header.Root(), p)
-	w.require.NoError(err, "failed to verify proof for withdrawal")
-
-	trieNodes := make([][]byte, len(p.StorageProof[0].Proof))
-	for i, s := range p.StorageProof[0].Proof {
-		trieNodes[i] = s
-	}
-
-	return ProvenWithdrawalParameters{
-		Nonce:              ev.Nonce,
-		Sender:             ev.Sender,
-		Target:             ev.Target,
-		Value:              ev.Value,
-		GasLimit:           ev.GasLimit,
-		DisputeGameAddress: latestGame.Address,
-		DisputeGameIndex:   latestGame.Index,
-		Data:               ev.Data,
-		OutputRootProof: bindings.OutputRootProof{
-			Version:                  [32]byte{},
 			StateRoot:                l2Header.Root(),
 			MessagePasserStorageRoot: *l2Header.WithdrawalsRoot(),
 			LatestBlockhash:          l2Header.Hash(),

--- a/op-devstack/dsl/bridge.go
+++ b/op-devstack/dsl/bridge.go
@@ -22,15 +22,11 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/txintent/bindings"
 	"github.com/ethereum-optimism/optimism/op-service/txintent/contractio"
-	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient/gethclient"
-	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/holiman/uint256"
-
-	"github.com/ethereum-optimism/optimism/packages/contracts-bedrock/snapshots"
 )
 
 // ProvenWithdrawalParameters is the set of parameters to pass to the ProveWithdrawalTransaction
@@ -44,8 +40,6 @@ type ProvenWithdrawalParameters struct {
 	DisputeGameAddress common.Address
 	DisputeGameIndex   *big.Int
 	Data               []byte
-	SuperRootProof     *bindings.SuperRootProof // Only set for games using super roots
-	OutputRootIndex    *big.Int                 // Only set for games using super roots
 	OutputRootProof    bindings.OutputRootProof
 	WithdrawalProof    [][]byte // List of trie nodes to prove L2 storage
 }
@@ -58,9 +52,8 @@ type StandardBridge struct {
 	disputeGameFactory  bindings.DisputeGameFactory
 	rollupCfg           *rollup.Config
 
-	l1Client         *L1ELNode
-	l2Client         apis.EthClient
-	supervisorClient apis.SupervisorQueryAPI
+	l1Client *L1ELNode
+	l2Client apis.EthClient
 
 	// L1 bridge contract
 	l1StandardBridge bindings.L1StandardBridge
@@ -88,10 +81,6 @@ func NewStandardBridge(t devtest.T, l2Network *L2Network, supervisor *Supervisor
 		bindings.WithTo(l2Network.Escape().Deployment().L1StandardBridgeProxyAddr()),
 		bindings.WithTest(t))
 
-	var supervisorClient apis.SupervisorQueryAPI
-	if supervisor != nil {
-		supervisorClient = supervisor.inner.QueryAPI()
-	}
 	return &StandardBridge{
 		commonImpl:          commonFromT(t),
 		l1PortalAddr:        l1PortalAddr,
@@ -102,7 +91,6 @@ func NewStandardBridge(t devtest.T, l2Network *L2Network, supervisor *Supervisor
 
 		l1Client:         l1EL,
 		l2Client:         l2Client,
-		supervisorClient: supervisorClient,
 		l1StandardBridge: l1StandardBridge,
 	}
 }
@@ -388,12 +376,7 @@ func (w *Withdrawal) Prove(user *EOA) {
 		Data:     params.Data,
 	}
 
-	var call bindings.TypedCall[any]
-	if params.SuperRootProof == nil {
-		call = w.bridge.l1Portal.ProveWithdrawalTransaction(tx, params.DisputeGameIndex, params.OutputRootProof, params.WithdrawalProof)
-	} else {
-		call = w.bridge.l1Portal.ProveWithdrawalTransactionSuperRoot(tx, params.DisputeGameAddress, params.OutputRootIndex, *params.SuperRootProof, params.OutputRootProof, params.WithdrawalProof)
-	}
+	call := w.bridge.l1Portal.ProveWithdrawalTransaction(tx, params.DisputeGameIndex, params.OutputRootProof, params.WithdrawalProof)
 	// Retry as withdrawals can't be proven in the same block as the game is created.
 	// estimateGas works against the current head so we may need to retry until it has progressed enough.
 	w.require.Eventually(func() bool {
@@ -426,9 +409,7 @@ func (w *Withdrawal) ProveFromGameExtraData(user *EOA) {
 		Data:     params.Data,
 	}
 
-	call := w.bridge.l1Portal.ProveWithdrawalTransactionSuperRoot(
-		tx, params.DisputeGameAddress, params.OutputRootIndex,
-		*params.SuperRootProof, params.OutputRootProof, params.WithdrawalProof)
+	call := w.bridge.l1Portal.ProveWithdrawalTransaction(tx, params.DisputeGameIndex, params.OutputRootProof, params.WithdrawalProof)
 
 	w.require.Eventually(func() bool {
 		proveReceipt, err := contractio.Write(call, w.ctx, user.Plan())
@@ -484,28 +465,6 @@ func (w *Withdrawal) proveWithdrawalParametersForEvent(ev *nodebindings.L2ToL1Me
 		trieNodes[i] = s
 	}
 
-	var superRootProof *bindings.SuperRootProof
-	var outputRootIndex *big.Int
-	if disputeGame.UsesSuperRoots {
-		response, err := w.bridge.supervisorClient.SuperRootAtTimestamp(w.ctx, hexutil.Uint64(disputeGame.SequenceNumber))
-		w.require.NoErrorf(err, "failed to fetch superRoot for at timestamp %v", disputeGame.SequenceNumber)
-		outputRoots := make([]bindings.OutputRootWithChainID, len(response.Chains))
-		for i, chain := range response.Chains {
-			outputRoots[i] = bindings.OutputRootWithChainID{
-				ChainID: chain.ChainID.ToBig(),
-				Root:    chain.Canonical,
-			}
-			if chain.ChainID == eth.ChainIDFromBig(w.bridge.rollupCfg.L2ChainID) {
-				outputRootIndex = big.NewInt(int64(i))
-			}
-		}
-		superRootProof = &bindings.SuperRootProof{
-			Version:     [1]byte{response.Version},
-			Timestamp:   response.Timestamp,
-			OutputRoots: outputRoots,
-		}
-	}
-
 	return ProvenWithdrawalParameters{
 		Nonce:              ev.Nonce,
 		Sender:             ev.Sender,
@@ -515,8 +474,6 @@ func (w *Withdrawal) proveWithdrawalParametersForEvent(ev *nodebindings.L2ToL1Me
 		DisputeGameAddress: disputeGame.Address,
 		DisputeGameIndex:   disputeGame.Index,
 		Data:               ev.Data,
-		SuperRootProof:     superRootProof,
-		OutputRootIndex:    outputRootIndex,
 		OutputRootProof: bindings.OutputRootProof{
 			Version:                  [32]byte{}, // Empty for version 1
 			StateRoot:                l2Header.Root(),
@@ -527,56 +484,11 @@ func (w *Withdrawal) proveWithdrawalParametersForEvent(ev *nodebindings.L2ToL1Me
 	}
 }
 
-// proveWithdrawalParametersFromGameExtraData builds withdrawal parameters by reading super root proof
-// directly from the dispute game's extraData, without requiring supervisor-rpc.
+// proveWithdrawalParametersFromGameExtraData builds withdrawal parameters for super root games.
+// Contract now handles super root proof internally via game.rootClaimByChainId(chainId).
 func (w *Withdrawal) proveWithdrawalParametersFromGameExtraData() ProvenWithdrawalParameters {
 	latestGame := w.bridge.forGamePublished(w.initReceipt.BlockNumber)
 	w.require.True(latestGame.UsesSuperRoots, "Game must use super roots for extraData flow")
-
-	// Load ABI and call extraData on the game contract
-	gameABI := snapshots.LoadSuperFaultDisputeGameABI()
-	extraDataCallData, err := gameABI.Pack("extraData")
-	w.require.NoError(err, "failed to pack extraData call")
-
-	extraDataResult, err := w.bridge.l1Client.EthClient().Call(w.ctx, ethereum.CallMsg{
-		To:   &latestGame.Address,
-		Data: extraDataCallData,
-	}, rpc.LatestBlockNumber)
-	w.require.NoError(err, "failed to call extraData")
-
-	unpackedExtra, err := gameABI.Unpack("extraData", extraDataResult)
-	w.require.NoError(err, "failed to unpack extraData")
-	w.require.NotEmpty(unpackedExtra, "extraData returned empty result")
-	extraDataBytes, ok := unpackedExtra[0].([]byte)
-	w.require.True(ok, "extraData result is not []byte")
-
-	// Decode super root proof from extraData
-	superRootProofDecoded, err := withdrawals.DecodeSuperRootProof(extraDataBytes)
-	w.require.NoError(err, "failed to decode super root proof")
-
-	// Find output root index for this chain
-	var outputRootIndex *big.Int
-	for i, outputRoot := range superRootProofDecoded.OutputRoots {
-		if outputRoot.ChainID.Cmp(w.bridge.rollupCfg.L2ChainID) == 0 {
-			outputRootIndex = big.NewInt(int64(i))
-			break
-		}
-	}
-	w.require.NotNil(outputRootIndex, "target chain ID not found in super root proof")
-
-	// Convert decoded proof to bindings format
-	outputRoots := make([]bindings.OutputRootWithChainID, len(superRootProofDecoded.OutputRoots))
-	for i, root := range superRootProofDecoded.OutputRoots {
-		outputRoots[i] = bindings.OutputRootWithChainID{
-			ChainID: root.ChainID,
-			Root:    root.Root,
-		}
-	}
-	superRootProof := &bindings.SuperRootProof{
-		Version:     superRootProofDecoded.Version,
-		Timestamp:   superRootProofDecoded.Timestamp,
-		OutputRoots: outputRoots,
-	}
 
 	// Get L2 header at game's block number
 	l2Header, err := w.bridge.l2Client.InfoByNumber(w.ctx, latestGame.L2BlockNumber)
@@ -611,8 +523,6 @@ func (w *Withdrawal) proveWithdrawalParametersFromGameExtraData() ProvenWithdraw
 		DisputeGameAddress: latestGame.Address,
 		DisputeGameIndex:   latestGame.Index,
 		Data:               ev.Data,
-		SuperRootProof:     superRootProof,
-		OutputRootIndex:    outputRootIndex,
 		OutputRootProof: bindings.OutputRootProof{
 			Version:                  [32]byte{},
 			StateRoot:                l2Header.Root(),

--- a/op-node/withdrawals/utils.go
+++ b/op-node/withdrawals/utils.go
@@ -3,7 +3,6 @@ package withdrawals
 import (
 	"bytes"
 	"context"
-	"encoding/binary"
 	"errors"
 	"fmt"
 	"math/big"
@@ -46,54 +45,6 @@ type ProvenWithdrawalParameters struct {
 	Data            []byte
 	OutputRootProof bindings.TypesOutputRootProof
 	WithdrawalProof [][]byte // List of trie nodes to prove L2 storage
-}
-
-type SuperRootProofOutputRoot struct {
-	ChainID *big.Int
-	Root    common.Hash
-}
-
-type SuperRootProof struct {
-	Version     [1]byte
-	Timestamp   uint64
-	OutputRoots []SuperRootProofOutputRoot
-}
-
-// DecodeSuperRootProof decodes SuperFaultDisputeGame extraData bytes into SuperRootProof.
-// Format: 1 byte version (0x01) + 8 bytes timestamp (big-endian) + N*(32 bytes chainId + 32 bytes root)
-func DecodeSuperRootProof(data []byte) (SuperRootProof, error) {
-	if len(data) < 9 {
-		return SuperRootProof{}, errors.New("extraData too short: must be at least 9 bytes")
-	}
-	if data[0] != 0x01 {
-		return SuperRootProof{}, fmt.Errorf("invalid super root version: expected 0x01, got 0x%02x", data[0])
-	}
-
-	timestamp := binary.BigEndian.Uint64(data[1:9])
-	remaining := data[9:]
-
-	if len(remaining) == 0 {
-		return SuperRootProof{}, errors.New("extraData contains no output roots")
-	}
-	if len(remaining)%64 != 0 {
-		return SuperRootProof{}, fmt.Errorf("invalid extraData length: %d bytes after header not divisible by 64", len(remaining))
-	}
-
-	numRoots := len(remaining) / 64
-	outputRoots := make([]SuperRootProofOutputRoot, numRoots)
-	for i := 0; i < numRoots; i++ {
-		off := i * 64
-		outputRoots[i] = SuperRootProofOutputRoot{
-			ChainID: new(big.Int).SetBytes(remaining[off : off+32]),
-			Root:    common.BytesToHash(remaining[off+32 : off+64]),
-		}
-	}
-
-	return SuperRootProof{
-		Version:     [1]byte{0x01},
-		Timestamp:   timestamp,
-		OutputRoots: outputRoots,
-	}, nil
 }
 
 // ProveWithdrawalParametersFaultProofs calls ProveWithdrawalParametersForBlock with the most recent L2 output after the latest game.

--- a/op-node/withdrawals/utils.go
+++ b/op-node/withdrawals/utils.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient/gethclient"
@@ -19,10 +18,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-core/predeploys"
 	"github.com/ethereum-optimism/optimism/op-node/bindings"
 	bindingspreview "github.com/ethereum-optimism/optimism/op-node/bindings/preview"
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
-	"github.com/ethereum-optimism/optimism/op-service/bigs"
-	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
 )
 
 var MessagePassedTopic = crypto.Keccak256Hash([]byte("MessagePassed(uint256,address,address,uint256,uint256,bytes,bytes32)"))
@@ -37,10 +32,6 @@ type ReceiptClient interface {
 
 type HeaderClient interface {
 	HeaderByNumber(context.Context, *big.Int) (*types.Header, error)
-}
-
-type SupervisorClient interface {
-	SuperRootAtTimestamp(context.Context, hexutil.Uint64) (eth.SuperRootResponse, error)
 }
 
 // ProvenWithdrawalParameters is the set of parameters to pass to the ProveWithdrawalTransaction
@@ -105,20 +96,6 @@ func DecodeSuperRootProof(data []byte) (SuperRootProof, error) {
 	}, nil
 }
 
-type ProvenWithdrawalParametersSuperRoots struct {
-	Nonce            *big.Int
-	Sender           common.Address
-	Target           common.Address
-	Value            *big.Int
-	GasLimit         *big.Int
-	Data             []byte
-	DisputeGameProxy common.Address
-	OutputRootIndex  *big.Int // index of the output root in the super root
-	SuperRootProof   SuperRootProof
-	OutputRootProof  bindings.TypesOutputRootProof
-	WithdrawalProof  [][]byte // List of trie nodes to prove L2 storage
-}
-
 // ProveWithdrawalParametersFaultProofs calls ProveWithdrawalParametersForBlock with the most recent L2 output after the latest game.
 func ProveWithdrawalParametersFaultProofs(ctx context.Context, proofCl ProofClient, l2ReceiptCl ReceiptClient, l2HeaderCl HeaderClient, txHash common.Hash, disputeGameFactoryContract *bindings.DisputeGameFactoryCaller, optimismPortal2Contract *bindingspreview.OptimismPortal2Caller) (ProvenWithdrawalParameters, error) {
 	latestGame, err := FindLatestGame(ctx, disputeGameFactoryContract, optimismPortal2Contract)
@@ -134,98 +111,6 @@ func ProveWithdrawalParametersFaultProofs(ctx context.Context, proofCl ProofClie
 		return ProvenWithdrawalParameters{}, fmt.Errorf("failed to get l2Block: %w", err)
 	}
 	return ProveWithdrawalParametersForBlock(ctx, proofCl, l2ReceiptCl, txHash, l2Header, l2OutputIndex)
-}
-
-func ProveWithdrawalParametersSuperRoots(
-	ctx context.Context,
-	rollupCfg *rollup.Config,
-	depSet depset.DependencySet,
-	proofCl ProofClient,
-	l2ReceiptCl ReceiptClient,
-	l2HeaderCl HeaderClient,
-	txHash common.Hash,
-	supervisorClient SupervisorClient,
-	disputeGameFactoryContract *bindings.DisputeGameFactoryCaller,
-	optimismPortal2Contract *bindingspreview.OptimismPortal2Caller,
-) (ProvenWithdrawalParametersSuperRoots, error) {
-	var outputRootIndex *big.Int
-	for i, chain := range depSet.Chains() {
-		if chain.Cmp(eth.ChainIDFromBig(rollupCfg.L2ChainID)) == 0 {
-			outputRootIndex = new(big.Int).SetUint64(uint64(i))
-			break
-		}
-	}
-	if outputRootIndex == nil {
-		return ProvenWithdrawalParametersSuperRoots{}, fmt.Errorf("could not find rollup chain ID in dependency set: %v", rollupCfg.L2ChainID)
-	}
-
-	latestGame, err := FindLatestGame(ctx, disputeGameFactoryContract, optimismPortal2Contract)
-	if err != nil {
-		return ProvenWithdrawalParametersSuperRoots{}, fmt.Errorf("failed to find latest game: %w", err)
-	}
-	disputeGame, err := disputeGameFactoryContract.GameAtIndex(&bind.CallOpts{}, latestGame.Index)
-	if err != nil {
-		return ProvenWithdrawalParametersSuperRoots{}, fmt.Errorf("failed to get dispute game: %w", err)
-	}
-	l2SequenceNumber := new(big.Int).SetBytes(latestGame.ExtraData[0:32])
-
-	superRoot, err := supervisorClient.SuperRootAtTimestamp(ctx, hexutil.Uint64(bigs.Uint64Strict(l2SequenceNumber)))
-	if err != nil {
-		return ProvenWithdrawalParametersSuperRoots{}, fmt.Errorf("failed to get super root: %w", err)
-	}
-
-	l2BlockNumber, err := rollupCfg.TargetBlockNumber(bigs.Uint64Strict(l2SequenceNumber))
-	if err != nil {
-		return ProvenWithdrawalParametersSuperRoots{}, fmt.Errorf("failed to get target block number: %w", err)
-	}
-	l2Header, err := l2HeaderCl.HeaderByNumber(ctx, new(big.Int).SetUint64(l2BlockNumber))
-	if err != nil {
-		return ProvenWithdrawalParametersSuperRoots{}, fmt.Errorf("failed to get l2Block: %w", err)
-	}
-
-	receipt, err := l2ReceiptCl.TransactionReceipt(ctx, txHash)
-	if err != nil {
-		return ProvenWithdrawalParametersSuperRoots{}, err
-	}
-	// Parse the receipt
-	ev, err := ParseMessagePassed(receipt)
-	if err != nil {
-		return ProvenWithdrawalParametersSuperRoots{}, err
-	}
-	withdrawalProof, storageRoot, err := GetWithdrawalProof(ctx, proofCl, ev, l2Header)
-	if err != nil {
-		return ProvenWithdrawalParametersSuperRoots{}, err
-	}
-
-	outputRoots := make([]SuperRootProofOutputRoot, len(superRoot.Chains))
-	for i, chain := range superRoot.Chains {
-		outputRoots[i] = SuperRootProofOutputRoot{
-			ChainID: chain.ChainID.ToBig(),
-			Root:    common.Hash(chain.Canonical),
-		}
-	}
-	return ProvenWithdrawalParametersSuperRoots{
-		Nonce:            ev.Nonce,
-		Sender:           ev.Sender,
-		Target:           ev.Target,
-		Value:            ev.Value,
-		GasLimit:         ev.GasLimit,
-		Data:             ev.Data,
-		DisputeGameProxy: disputeGame.Proxy,
-		OutputRootIndex:  outputRootIndex,
-		SuperRootProof: SuperRootProof{
-			Version:     [1]byte{superRoot.Version},
-			Timestamp:   superRoot.Timestamp,
-			OutputRoots: outputRoots,
-		},
-		OutputRootProof: bindings.TypesOutputRootProof{
-			Version:                  [32]byte{}, // Empty for version 1
-			StateRoot:                l2Header.Root,
-			MessagePasserStorageRoot: storageRoot,
-			LatestBlockhash:          l2Header.Hash(),
-		},
-		WithdrawalProof: withdrawalProof,
-	}, nil
 }
 
 // ProveWithdrawalParametersForBlock queries L1 & L2 to generate all withdrawal parameters and proof necessary to prove a withdrawal on L1.

--- a/op-node/withdrawals/utils.go
+++ b/op-node/withdrawals/utils.go
@@ -3,6 +3,7 @@ package withdrawals
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"math/big"
@@ -65,6 +66,43 @@ type SuperRootProof struct {
 	Version     [1]byte
 	Timestamp   uint64
 	OutputRoots []SuperRootProofOutputRoot
+}
+
+// DecodeSuperRootProof decodes SuperFaultDisputeGame extraData bytes into SuperRootProof.
+// Format: 1 byte version (0x01) + 8 bytes timestamp (big-endian) + N*(32 bytes chainId + 32 bytes root)
+func DecodeSuperRootProof(data []byte) (SuperRootProof, error) {
+	if len(data) < 9 {
+		return SuperRootProof{}, errors.New("extraData too short: must be at least 9 bytes")
+	}
+	if data[0] != 0x01 {
+		return SuperRootProof{}, fmt.Errorf("invalid super root version: expected 0x01, got 0x%02x", data[0])
+	}
+
+	timestamp := binary.BigEndian.Uint64(data[1:9])
+	remaining := data[9:]
+
+	if len(remaining) == 0 {
+		return SuperRootProof{}, errors.New("extraData contains no output roots")
+	}
+	if len(remaining)%64 != 0 {
+		return SuperRootProof{}, fmt.Errorf("invalid extraData length: %d bytes after header not divisible by 64", len(remaining))
+	}
+
+	numRoots := len(remaining) / 64
+	outputRoots := make([]SuperRootProofOutputRoot, numRoots)
+	for i := 0; i < numRoots; i++ {
+		off := i * 64
+		outputRoots[i] = SuperRootProofOutputRoot{
+			ChainID: new(big.Int).SetBytes(remaining[off : off+32]),
+			Root:    common.BytesToHash(remaining[off+32 : off+64]),
+		}
+	}
+
+	return SuperRootProof{
+		Version:     [1]byte{0x01},
+		Timestamp:   timestamp,
+		OutputRoots: outputRoots,
+	}, nil
 }
 
 type ProvenWithdrawalParametersSuperRoots struct {

--- a/op-service/txintent/bindings/OptimismPortal2.go
+++ b/op-service/txintent/bindings/OptimismPortal2.go
@@ -76,8 +76,8 @@ type OptimismPortal2 struct {
 		GasLimit *big.Int
 		Data     []byte
 	}, proofSubmitter common.Address) TypedCall[any] `sol:"finalizeWithdrawalTransactionExternalProof"`
-	Initialize                 func(disputeGameFactory common.Address, systemConfig common.Address, superchainConfig common.Address) TypedCall[any]                        `sol:"initialize"`
+	Initialize                 func(disputeGameFactory common.Address, systemConfig common.Address, superchainConfig common.Address) TypedCall[any]                `sol:"initialize"`
 	ProveWithdrawalTransaction func(tx WithdrawalTransaction, disputeGameIndex *big.Int, outputRootProof OutputRootProof, withdrawalProof [][]byte) TypedCall[any] `sol:"proveWithdrawalTransaction"`
-	SetRespectedGameType                func(gameType uint32) TypedCall[any]                                                                                                                                                          `sol:"setRespectedGameType"`
-	Receive                             func() TypedCall[any]                                                                                                                                                                         `sol:"receive"`
+	SetRespectedGameType       func(gameType uint32) TypedCall[any]                                                                                                `sol:"setRespectedGameType"`
+	Receive                    func() TypedCall[any]                                                                                                               `sol:"receive"`
 }

--- a/op-service/txintent/bindings/OptimismPortal2.go
+++ b/op-service/txintent/bindings/OptimismPortal2.go
@@ -28,17 +28,6 @@ type OutputRootProof struct {
 	LatestBlockhash          [32]byte
 }
 
-type SuperRootProof struct {
-	Version     [1]byte
-	Timestamp   uint64
-	OutputRoots []OutputRootWithChainID
-}
-
-type OutputRootWithChainID struct {
-	ChainID *big.Int
-	Root    [32]byte
-}
-
 type OptimismPortal2 struct {
 	// Read-only functions
 	CheckWithdrawal                 func(withdrawalHash [32]byte, proofSubmitter common.Address) TypedCall[any] `sol:"checkWithdrawal"`
@@ -87,9 +76,8 @@ type OptimismPortal2 struct {
 		GasLimit *big.Int
 		Data     []byte
 	}, proofSubmitter common.Address) TypedCall[any] `sol:"finalizeWithdrawalTransactionExternalProof"`
-	Initialize                          func(disputeGameFactory common.Address, systemConfig common.Address, superchainConfig common.Address) TypedCall[any]                                                                          `sol:"initialize"`
-	ProveWithdrawalTransactionSuperRoot func(tx WithdrawalTransaction, disputeGame common.Address, outputRootIndex *big.Int, superRootProof SuperRootProof, outputRootProof OutputRootProof, withdrawalProof [][]byte) TypedCall[any] `sol:"proveWithdrawalTransaction"`
-	ProveWithdrawalTransaction          func(tx WithdrawalTransaction, disputeGameIndex *big.Int, outputRootProof OutputRootProof, withdrawalProof [][]byte) TypedCall[any]                                                           `sol:"proveWithdrawalTransaction"`
+	Initialize                 func(disputeGameFactory common.Address, systemConfig common.Address, superchainConfig common.Address) TypedCall[any]                        `sol:"initialize"`
+	ProveWithdrawalTransaction func(tx WithdrawalTransaction, disputeGameIndex *big.Int, outputRootProof OutputRootProof, withdrawalProof [][]byte) TypedCall[any] `sol:"proveWithdrawalTransaction"`
 	SetRespectedGameType                func(gameType uint32) TypedCall[any]                                                                                                                                                          `sol:"setRespectedGameType"`
 	Receive                             func() TypedCall[any]                                                                                                                                                                         `sol:"receive"`
 }

--- a/packages/contracts-bedrock/interfaces/L1/IOptimismPortalInterop.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IOptimismPortalInterop.sol
@@ -32,10 +32,6 @@ interface IOptimismPortalInterop is IProxyAdminOwnedBase {
     error OptimismPortal_NoReentrancy();
     error OptimismPortal_ProofNotOldEnough();
     error OptimismPortal_Unproven();
-    error OptimismPortal_InvalidOutputRootIndex();
-    error OptimismPortal_InvalidSuperRootProof();
-    error OptimismPortal_InvalidOutputRootChainId();
-    error OptimismPortal_WrongProofMethod();
     error OptimismPortal_MigratingToSameRegistry();
     error Encoding_EmptySuperRoot();
     error Encoding_InvalidSuperRootVersion();
@@ -96,15 +92,6 @@ interface IOptimismPortalInterop is IProxyAdminOwnedBase {
     function proveWithdrawalTransaction(
         Types.WithdrawalTransaction memory _tx,
         uint256 _disputeGameIndex,
-        Types.OutputRootProof memory _outputRootProof,
-        bytes[] memory _withdrawalProof
-    )
-        external;
-    function proveWithdrawalTransaction(
-        Types.WithdrawalTransaction memory _tx,
-        IDisputeGame _disputeGameProxy,
-        uint256 _outputRootIndex,
-        Types.SuperRootProof memory _superRootProof,
         Types.OutputRootProof memory _outputRootProof,
         bytes[] memory _withdrawalProof
     )

--- a/packages/contracts-bedrock/interfaces/L1/IOptimismPortalInterop.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IOptimismPortalInterop.sol
@@ -33,8 +33,6 @@ interface IOptimismPortalInterop is IProxyAdminOwnedBase {
     error OptimismPortal_ProofNotOldEnough();
     error OptimismPortal_Unproven();
     error OptimismPortal_MigratingToSameRegistry();
-    error Encoding_EmptySuperRoot();
-    error Encoding_InvalidSuperRootVersion();
     error OutOfGas();
     error UnexpectedList();
     error UnexpectedString();

--- a/packages/contracts-bedrock/snapshots/abi/OptimismPortalInterop.json
+++ b/packages/contracts-bedrock/snapshots/abi/OptimismPortalInterop.json
@@ -540,127 +540,6 @@
   {
     "inputs": [
       {
-        "components": [
-          {
-            "internalType": "uint256",
-            "name": "nonce",
-            "type": "uint256"
-          },
-          {
-            "internalType": "address",
-            "name": "sender",
-            "type": "address"
-          },
-          {
-            "internalType": "address",
-            "name": "target",
-            "type": "address"
-          },
-          {
-            "internalType": "uint256",
-            "name": "value",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "gasLimit",
-            "type": "uint256"
-          },
-          {
-            "internalType": "bytes",
-            "name": "data",
-            "type": "bytes"
-          }
-        ],
-        "internalType": "struct Types.WithdrawalTransaction",
-        "name": "_tx",
-        "type": "tuple"
-      },
-      {
-        "internalType": "contract IDisputeGame",
-        "name": "_disputeGameProxy",
-        "type": "address"
-      },
-      {
-        "internalType": "uint256",
-        "name": "_outputRootIndex",
-        "type": "uint256"
-      },
-      {
-        "components": [
-          {
-            "internalType": "bytes1",
-            "name": "version",
-            "type": "bytes1"
-          },
-          {
-            "internalType": "uint64",
-            "name": "timestamp",
-            "type": "uint64"
-          },
-          {
-            "components": [
-              {
-                "internalType": "uint256",
-                "name": "chainId",
-                "type": "uint256"
-              },
-              {
-                "internalType": "bytes32",
-                "name": "root",
-                "type": "bytes32"
-              }
-            ],
-            "internalType": "struct Types.OutputRootWithChainId[]",
-            "name": "outputRoots",
-            "type": "tuple[]"
-          }
-        ],
-        "internalType": "struct Types.SuperRootProof",
-        "name": "_superRootProof",
-        "type": "tuple"
-      },
-      {
-        "components": [
-          {
-            "internalType": "bytes32",
-            "name": "version",
-            "type": "bytes32"
-          },
-          {
-            "internalType": "bytes32",
-            "name": "stateRoot",
-            "type": "bytes32"
-          },
-          {
-            "internalType": "bytes32",
-            "name": "messagePasserStorageRoot",
-            "type": "bytes32"
-          },
-          {
-            "internalType": "bytes32",
-            "name": "latestBlockhash",
-            "type": "bytes32"
-          }
-        ],
-        "internalType": "struct Types.OutputRootProof",
-        "name": "_outputRootProof",
-        "type": "tuple"
-      },
-      {
-        "internalType": "bytes[]",
-        "name": "_withdrawalProof",
-        "type": "bytes[]"
-      }
-    ],
-    "name": "proveWithdrawalTransaction",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
         "internalType": "bytes32",
         "name": "",
         "type": "bytes32"
@@ -978,16 +857,6 @@
   },
   {
     "inputs": [],
-    "name": "Encoding_EmptySuperRoot",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "Encoding_InvalidSuperRootVersion",
-    "type": "error"
-  },
-  {
-    "inputs": [],
     "name": "InvalidDataRemainder",
     "type": "error"
   },
@@ -1043,16 +912,6 @@
   },
   {
     "inputs": [],
-    "name": "OptimismPortal_InvalidOutputRootChainId",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "OptimismPortal_InvalidOutputRootIndex",
-    "type": "error"
-  },
-  {
-    "inputs": [],
     "name": "OptimismPortal_InvalidOutputRootProof",
     "type": "error"
   },
@@ -1064,11 +923,6 @@
   {
     "inputs": [],
     "name": "OptimismPortal_InvalidRootClaim",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "OptimismPortal_InvalidSuperRootProof",
     "type": "error"
   },
   {
@@ -1089,11 +943,6 @@
   {
     "inputs": [],
     "name": "OptimismPortal_Unproven",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "OptimismPortal_WrongProofMethod",
     "type": "error"
   },
   {

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -36,8 +36,8 @@
     "sourceCodeHash": "0x16fb96f4d29a10d03b3b9c70edf56df51e97c2a1a3f0ba36aae79469b446ad5c"
   },
   "src/L1/OptimismPortalInterop.sol:OptimismPortalInterop": {
-    "initCodeHash": "0xd361ed3b8d56dcc1f3c068ef3af9c83f3da1165bcdab097250ad4772f350c52e",
-    "sourceCodeHash": "0xd7d2166d29a22f3a051bc832cbce05f9ca06f1ac1bfb0790f29579f12bb95b8f"
+    "initCodeHash": "0xbe7924e1aef73d04bd058adf79666a0ce2172d7b18605f0c8296bd1dc75f9b03",
+    "sourceCodeHash": "0x3bf1ea77351cb79fb3fc34d6ad42524f2cba56191dbc0cba2c036cce6f570e80"
   },
   "src/L1/ProtocolVersions.sol:ProtocolVersions": {
     "initCodeHash": "0xcb59ad9a5ec2a0831b7f4daa74bdacba82ffa03035dafb499a732c641e017f4e",

--- a/packages/contracts-bedrock/src/L1/OptimismPortalInterop.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortalInterop.sol
@@ -217,9 +217,9 @@ contract OptimismPortalInterop is Initializable, ResourceMetering, Reinitializab
     error OptimismPortal_MigratingToSameRegistry();
 
     /// @notice Semantic version.
-    /// @custom:semver 5.2.0+interop
+    /// @custom:semver 5.3.0+interop
     function version() public pure virtual returns (string memory) {
-        return "5.2.0+interop";
+        return "5.3.0+interop";
     }
 
     /// @param _proofMaturityDelaySeconds The proof maturity delay in seconds.

--- a/packages/contracts-bedrock/src/L1/OptimismPortalInterop.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortalInterop.sol
@@ -15,7 +15,7 @@ import { Types } from "src/libraries/Types.sol";
 import { Hashing } from "src/libraries/Hashing.sol";
 import { SecureMerkleTrie } from "src/libraries/trie/SecureMerkleTrie.sol";
 import { AddressAliasHelper } from "src/vendor/AddressAliasHelper.sol";
-import { GameStatus, GameType } from "src/dispute/lib/Types.sol";
+import { GameStatus, GameType, Claim } from "src/dispute/lib/Types.sol";
 
 // Interfaces
 import { ISemver } from "interfaces/universal/ISemver.sol";
@@ -212,18 +212,6 @@ contract OptimismPortalInterop is Initializable, ResourceMetering, Reinitializab
 
     /// @notice Thrown when a withdrawal has not been proven.
     error OptimismPortal_Unproven();
-
-    /// @notice Thrown when the wrong proof method is used.
-    error OptimismPortal_WrongProofMethod();
-
-    /// @notice Thrown when a super root proof is invalid.
-    error OptimismPortal_InvalidSuperRootProof();
-
-    /// @notice Thrown when an output root index is invalid.
-    error OptimismPortal_InvalidOutputRootIndex();
-
-    /// @notice Thrown when an output root chain id is invalid.
-    error OptimismPortal_InvalidOutputRootChainId();
 
     /// @notice Thrown when trying to migrate to the same AnchorStateRegistry.
     error OptimismPortal_MigratingToSameRegistry();
@@ -425,40 +413,9 @@ contract OptimismPortalInterop is Initializable, ResourceMetering, Reinitializab
         emit PortalMigrated(oldLockbox, _newLockbox, oldAnchorStateRegistry, _newAnchorStateRegistry);
     }
 
-    /// @notice Proves a withdrawal transaction using a Super Root proof. Only callable when the
-    ///         OptimismPortal is using Super Roots (superRootsActive flag is true).
-    /// @param _tx               Withdrawal transaction to finalize.
-    /// @param _disputeGameProxy Address of the dispute game to prove the withdrawal against.
-    /// @param _outputRootIndex  Index of the target Output Root within the Super Root.
-    /// @param _superRootProof   Inclusion proof of the Output Root within the Super Root.
-    /// @param _outputRootProof  Inclusion proof of the L2ToL1MessagePasser storage root.
-    /// @param _withdrawalProof  Inclusion proof of the withdrawal within the L2ToL1MessagePasser.
-    function proveWithdrawalTransaction(
-        Types.WithdrawalTransaction memory _tx,
-        IDisputeGame _disputeGameProxy,
-        uint256 _outputRootIndex,
-        Types.SuperRootProof calldata _superRootProof,
-        Types.OutputRootProof calldata _outputRootProof,
-        bytes[] calldata _withdrawalProof
-    )
-        external
-    {
-        // Cannot prove withdrawal transactions while the system is paused.
-        _assertNotPaused();
-
-        // Make sure that the OptimismPortal is using Super Roots.
-        if (!superRootsActive) {
-            revert OptimismPortal_WrongProofMethod();
-        }
-
-        // Prove the transaction.
-        _proveWithdrawalTransaction(
-            _tx, _disputeGameProxy, _outputRootIndex, _superRootProof, _outputRootProof, _withdrawalProof
-        );
-    }
-
-    /// @notice Proves a withdrawal transaction using an Output Root proof. Only callable when the
-    ///         OptimismPortal is using Output Roots (superRootsActive flag is false).
+    /// @notice Proves a withdrawal transaction. When super roots are active, uses the game's
+    ///         rootClaimByChainId to get the output root for this chain. When super roots are
+    ///         inactive, validates directly against the game's root claim.
     /// @param _tx               Withdrawal transaction to finalize.
     /// @param _disputeGameIndex Index of the dispute game to prove the withdrawal against.
     /// @param _outputRootProof  Inclusion proof of the L2ToL1MessagePasser storage root.
@@ -471,40 +428,22 @@ contract OptimismPortalInterop is Initializable, ResourceMetering, Reinitializab
     )
         external
     {
-        // Cannot prove withdrawal transactions while the system is paused.
         _assertNotPaused();
 
-        // Make sure that the OptimismPortal is using Output Roots.
-        if (superRootsActive) {
-            revert OptimismPortal_WrongProofMethod();
-        }
-
-        // Fetch the dispute game proxy from the `DisputeGameFactory` contract.
+        // Fetch the dispute game proxy from the DisputeGameFactory contract.
         (,, IDisputeGame disputeGameProxy) = disputeGameFactory().gameAtIndex(_disputeGameIndex);
 
-        // Create a dummy super root proof to pass into the internal function. Note that this is
-        // not a valid Super Root proof but it isn't used anywhere in the internal function when
-        // using Output Roots.
-        Types.SuperRootProof memory superRootProof;
-
-        // Prove the transaction.
-        _proveWithdrawalTransaction(_tx, disputeGameProxy, 0, superRootProof, _outputRootProof, _withdrawalProof);
+        _proveWithdrawalTransaction(_tx, disputeGameProxy, _outputRootProof, _withdrawalProof);
     }
 
-    /// @notice Internal function for proving a withdrawal transaction, used by both the Super Root
-    ///         and Output Root proof functions. Will eventually be replaced with a single function
-    ///         when the Output Root proof method is deprecated.
+    /// @notice Internal function for proving a withdrawal transaction.
     /// @param _tx               Withdrawal transaction to prove.
     /// @param _disputeGameProxy Address of the dispute game to prove the withdrawal against.
-    /// @param _outputRootIndex  Index of the target Output Root within the Super Root.
-    /// @param _superRootProof   Inclusion proof of the Output Root within the Super Root.
     /// @param _outputRootProof  Inclusion proof of the L2ToL1MessagePasser storage root.
     /// @param _withdrawalProof  Inclusion proof of the withdrawal within the L2ToL1MessagePasser.
     function _proveWithdrawalTransaction(
         Types.WithdrawalTransaction memory _tx,
         IDisputeGame _disputeGameProxy,
-        uint256 _outputRootIndex,
-        Types.SuperRootProof memory _superRootProof,
         Types.OutputRootProof memory _outputRootProof,
         bytes[] memory _withdrawalProof
     )
@@ -538,26 +477,15 @@ contract OptimismPortalInterop is Initializable, ResourceMetering, Reinitializab
             revert OptimismPortal_InvalidProofTimestamp();
         }
 
-        // Validate the provided Output Root and/or Super Root proof depending on proof method.
+        // Validate the output root proof depending on proof method.
         if (superRootsActive) {
-            // Verify that the super root can be generated with the elements in the proof.
-            if (_disputeGameProxy.rootClaim().raw() != Hashing.hashSuperRootProof(_superRootProof)) {
-                revert OptimismPortal_InvalidSuperRootProof();
-            }
-
-            // Check that the index exists in the super root proof.
-            if (_outputRootIndex >= _superRootProof.outputRoots.length) {
-                revert OptimismPortal_InvalidOutputRootIndex();
-            }
-
-            // Check that the output root has the correct chain id.
-            Types.OutputRootWithChainId memory outputRoot = _superRootProof.outputRoots[_outputRootIndex];
-            if (outputRoot.chainId != systemConfig.l2ChainId()) {
-                revert OptimismPortal_InvalidOutputRootChainId();
-            }
+            // Get output root for this chain from the game's extraData (super root proof).
+            // Reverts with UnknownChainId if chainId not found in the super root.
+            uint256 chainId = systemConfig.l2ChainId();
+            Claim outputRootClaim = _disputeGameProxy.rootClaimByChainId(chainId);
 
             // Verify that the output root can be generated with the elements in the proof.
-            if (outputRoot.root != Hashing.hashOutputRootProof(_outputRootProof)) {
+            if (outputRootClaim.raw() != Hashing.hashOutputRootProof(_outputRootProof)) {
                 revert OptimismPortal_InvalidOutputRootProof();
             }
         } else {

--- a/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
+++ b/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
@@ -22,6 +22,7 @@ import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 import { DevFeatures } from "src/libraries/DevFeatures.sol";
 import { Features } from "src/libraries/Features.sol";
 import "src/dispute/lib/Types.sol";
+import { UnknownChainId } from "src/dispute/lib/Errors.sol";
 
 // Interfaces
 import { IResourceMetering } from "interfaces/L1/IResourceMetering.sol";
@@ -1168,16 +1169,23 @@ contract OptimismPortal2_ProveWithdrawalTransaction_Test is OptimismPortal2_Test
         });
     }
 
-    /// @notice Tests that `proveWithdrawalTransaction` reverts when using the Output Roots version
-    ///         of `proveWithdrawalTransaction` when `superRootsActive` is true.
-    function test_proveWithdrawalTransaction_outputRootVersionWhenSuperRootsActive_reverts() external {
+    /// @notice Tests that `proveWithdrawalTransaction` reverts when superRootsActive is true
+    ///         and the game's rootClaimByChainId reverts with UnknownChainId.
+    function test_proveWithdrawalTransaction_superRootsVersionBadChainId_reverts() external {
         skipIfDevFeatureDisabled(DevFeatures.OPTIMISM_PORTAL_INTEROP);
 
-        // Set superRootsActive to true.
+        // Enable super roots.
         setSuperRootsActive(true);
 
-        // Should revert.
-        vm.expectRevert(IOptimismPortalInterop.OptimismPortal_WrongProofMethod.selector);
+        // Mock rootClaimByChainId to revert with UnknownChainId.
+        vm.mockCallRevert(
+            address(game),
+            abi.encodeCall(game.rootClaimByChainId, (systemConfig.l2ChainId())),
+            abi.encodeWithSelector(UnknownChainId.selector)
+        );
+
+        // Should revert because chainId not found in super root.
+        vm.expectRevert(UnknownChainId.selector);
         IOptimismPortalInterop(payable(optimismPortal2)).proveWithdrawalTransaction({
             _tx: _defaultTx,
             _disputeGameIndex: _proposedGameIndex,
@@ -1186,207 +1194,51 @@ contract OptimismPortal2_ProveWithdrawalTransaction_Test is OptimismPortal2_Test
         });
     }
 
-    /// @notice Tests that `proveWithdrawalTransaction` reverts when using the Super Roots version
-    ///         of `proveWithdrawalTransaction` when `superRootsActive` is false.
-    function test_proveWithdrawalTransaction_superRootsVersionWhenSuperRootsInactive_reverts() external {
-        skipIfDevFeatureDisabled(DevFeatures.OPTIMISM_PORTAL_INTEROP);
-
-        // Set up a dummy super root proof.
-        Types.OutputRootWithChainId[] memory outputRootWithChainIdArr = new Types.OutputRootWithChainId[](1);
-        outputRootWithChainIdArr[0] =
-            Types.OutputRootWithChainId({ root: _outputRoot, chainId: systemConfig.l2ChainId() });
-        Types.SuperRootProof memory superRootProof = Types.SuperRootProof({
-            version: 0x01,
-            timestamp: uint64(block.timestamp),
-            outputRoots: outputRootWithChainIdArr
-        });
-
-        // Should revert.
-        vm.expectRevert(IOptimismPortalInterop.OptimismPortal_WrongProofMethod.selector);
-        IOptimismPortalInterop(payable(optimismPortal2)).proveWithdrawalTransaction({
-            _tx: _defaultTx,
-            _disputeGameProxy: game,
-            _outputRootIndex: 0,
-            _superRootProof: superRootProof,
-            _outputRootProof: _outputRootProof,
-            _withdrawalProof: _withdrawalProof
-        });
-    }
-
-    /// @notice Tests that `proveWithdrawalTransaction` reverts when using the Super Roots version
-    ///         of `proveWithdrawalTransaction` when the provided proof is invalid.
-    function test_proveWithdrawalTransaction_superRootsVersionBadProof_reverts() external {
-        skipIfDevFeatureDisabled(DevFeatures.OPTIMISM_PORTAL_INTEROP);
-
-        // Enable super roots.
-        setSuperRootsActive(true);
-
-        // Set up a dummy super root proof.
-        Types.OutputRootWithChainId[] memory outputRootWithChainIdArr = new Types.OutputRootWithChainId[](1);
-        outputRootWithChainIdArr[0] =
-            Types.OutputRootWithChainId({ root: _outputRoot, chainId: systemConfig.l2ChainId() });
-        Types.SuperRootProof memory superRootProof = Types.SuperRootProof({
-            version: 0x01,
-            timestamp: uint64(block.timestamp),
-            outputRoots: outputRootWithChainIdArr
-        });
-
-        // Should revert because the proof is wrong.
-        vm.expectRevert(IOptimismPortalInterop.OptimismPortal_InvalidSuperRootProof.selector);
-        IOptimismPortalInterop(payable(optimismPortal2)).proveWithdrawalTransaction({
-            _tx: _defaultTx,
-            _disputeGameProxy: game,
-            _outputRootIndex: 0,
-            _superRootProof: superRootProof,
-            _outputRootProof: _outputRootProof,
-            _withdrawalProof: _withdrawalProof
-        });
-    }
-
-    /// @notice Tests that `proveWithdrawalTransaction` reverts when using the Super Roots version
-    ///         of `proveWithdrawalTransaction` when the provided proof is valid but the index is
-    ///         out of bounds.
-    function test_proveWithdrawalTransaction_superRootsVersionBadIndex_reverts() external {
-        skipIfDevFeatureDisabled(DevFeatures.OPTIMISM_PORTAL_INTEROP);
-
-        // Enable super roots.
-        setSuperRootsActive(true);
-
-        // Set up a dummy super root proof.
-        Types.OutputRootWithChainId[] memory outputRootWithChainIdArr = new Types.OutputRootWithChainId[](1);
-        outputRootWithChainIdArr[0] =
-            Types.OutputRootWithChainId({ root: _outputRoot, chainId: systemConfig.l2ChainId() });
-        Types.SuperRootProof memory superRootProof = Types.SuperRootProof({
-            version: 0x01,
-            timestamp: uint64(block.timestamp),
-            outputRoots: outputRootWithChainIdArr
-        });
-
-        // Figure out what the right hash would be.
-        bytes32 expectedSuperRoot = Hashing.hashSuperRootProof(superRootProof);
-
-        // Mock the game to return the expected super root.
-        vm.mockCall(address(game), abi.encodeCall(game.rootClaim, ()), abi.encode(expectedSuperRoot));
-
-        // Should revert because the proof is wrong.
-        vm.expectRevert(IOptimismPortalInterop.OptimismPortal_InvalidOutputRootIndex.selector);
-        IOptimismPortalInterop(payable(optimismPortal2)).proveWithdrawalTransaction({
-            _tx: _defaultTx,
-            _disputeGameProxy: game,
-            _outputRootIndex: outputRootWithChainIdArr.length, // out of bounds
-            _superRootProof: superRootProof,
-            _outputRootProof: _outputRootProof,
-            _withdrawalProof: _withdrawalProof
-        });
-    }
-
-    /// @notice Tests that `proveWithdrawalTransaction` reverts when using the Super Roots version
-    ///         of `proveWithdrawalTransaction` when the provided proof is valid, index is correct,
-    ///         but the output root has the wrong chain id.
-    function test_proveWithdrawalTransaction_superRootsVersionBadChainId_reverts() external {
-        skipIfDevFeatureDisabled(DevFeatures.OPTIMISM_PORTAL_INTEROP);
-
-        // Enable super roots.
-        setSuperRootsActive(true);
-
-        // Set up a dummy super root proof.
-        Types.OutputRootWithChainId[] memory outputRootWithChainIdArr = new Types.OutputRootWithChainId[](1);
-        outputRootWithChainIdArr[0] = Types.OutputRootWithChainId({
-            root: _outputRoot,
-            chainId: systemConfig.l2ChainId() + 1 // wrong chain id
-         });
-        Types.SuperRootProof memory superRootProof = Types.SuperRootProof({
-            version: 0x01,
-            timestamp: uint64(block.timestamp),
-            outputRoots: outputRootWithChainIdArr
-        });
-
-        // Figure out what the right hash would be.
-        bytes32 expectedSuperRoot = Hashing.hashSuperRootProof(superRootProof);
-
-        // Mock the game to return the expected super root.
-        vm.mockCall(address(game), abi.encodeCall(game.rootClaim, ()), abi.encode(expectedSuperRoot));
-
-        // Should revert because the proof is wrong.
-        vm.expectRevert(IOptimismPortalInterop.OptimismPortal_InvalidOutputRootChainId.selector);
-        IOptimismPortalInterop(payable(optimismPortal2)).proveWithdrawalTransaction({
-            _tx: _defaultTx,
-            _disputeGameProxy: game,
-            _outputRootIndex: 0,
-            _superRootProof: superRootProof,
-            _outputRootProof: _outputRootProof,
-            _withdrawalProof: _withdrawalProof
-        });
-    }
-
-    /// @notice Tests that `proveWithdrawalTransaction` reverts when using the Super Roots version
-    ///         of `proveWithdrawalTransaction` when the provided proof is valid, index is correct,
-    ///         chain id is correct, but the output root proof is invalid.
+    /// @notice Tests that `proveWithdrawalTransaction` reverts when superRootsActive is true
+    ///         and the output root proof doesn't match the game's rootClaimByChainId.
     function test_proveWithdrawalTransaction_superRootsVersionBadOutputRootProof_reverts() external {
         skipIfDevFeatureDisabled(DevFeatures.OPTIMISM_PORTAL_INTEROP);
 
         // Enable super roots.
         setSuperRootsActive(true);
 
-        // Set up a dummy super root proof.
-        Types.OutputRootWithChainId[] memory outputRootWithChainIdArr = new Types.OutputRootWithChainId[](1);
-        outputRootWithChainIdArr[0] = Types.OutputRootWithChainId({
-            root: keccak256(abi.encode(_outputRoot)), // random root so the proof is wrong
-            chainId: systemConfig.l2ChainId()
-        });
-        Types.SuperRootProof memory superRootProof = Types.SuperRootProof({
-            version: 0x01,
-            timestamp: uint64(block.timestamp),
-            outputRoots: outputRootWithChainIdArr
-        });
+        // Mock rootClaimByChainId to return a different output root (wrong one).
+        bytes32 wrongOutputRoot = keccak256(abi.encode(_outputRoot));
+        vm.mockCall(
+            address(game),
+            abi.encodeCall(game.rootClaimByChainId, (systemConfig.l2ChainId())),
+            abi.encode(Claim.wrap(wrongOutputRoot))
+        );
 
-        // Figure out what the right hash would be.
-        bytes32 expectedSuperRoot = Hashing.hashSuperRootProof(superRootProof);
-
-        // Mock the game to return the expected super root.
-        vm.mockCall(address(game), abi.encodeCall(game.rootClaim, ()), abi.encode(expectedSuperRoot));
-
-        // Should revert because the proof is wrong.
+        // Should revert because the output root proof doesn't match.
         vm.expectRevert(IOptimismPortalInterop.OptimismPortal_InvalidOutputRootProof.selector);
         IOptimismPortalInterop(payable(optimismPortal2)).proveWithdrawalTransaction({
             _tx: _defaultTx,
-            _disputeGameProxy: game,
-            _outputRootIndex: 0,
-            _superRootProof: superRootProof,
+            _disputeGameIndex: _proposedGameIndex,
             _outputRootProof: _outputRootProof,
             _withdrawalProof: _withdrawalProof
         });
     }
 
-    /// @notice Tests that `proveWithdrawalTransaction` succeeds when all parameters are valid.
+    /// @notice Tests that `proveWithdrawalTransaction` succeeds when superRootsActive is true
+    ///         and all parameters are valid.
     function test_proveWithdrawalTransaction_superRootsVersion_succeeds() external {
         skipIfDevFeatureDisabled(DevFeatures.OPTIMISM_PORTAL_INTEROP);
 
         // Enable super roots.
         setSuperRootsActive(true);
 
-        // Set up a dummy super root proof.
-        Types.OutputRootWithChainId[] memory outputRootWithChainIdArr = new Types.OutputRootWithChainId[](1);
-        outputRootWithChainIdArr[0] =
-            Types.OutputRootWithChainId({ root: _outputRoot, chainId: systemConfig.l2ChainId() });
-        Types.SuperRootProof memory superRootProof = Types.SuperRootProof({
-            version: 0x01,
-            timestamp: uint64(block.timestamp),
-            outputRoots: outputRootWithChainIdArr
-        });
-
-        // Figure out what the right hash would be.
-        bytes32 expectedSuperRoot = Hashing.hashSuperRootProof(superRootProof);
-
-        // Mock the game to return the expected super root.
-        vm.mockCall(address(game), abi.encodeCall(game.rootClaim, ()), abi.encode(expectedSuperRoot));
+        // Mock rootClaimByChainId to return the correct output root.
+        vm.mockCall(
+            address(game),
+            abi.encodeCall(game.rootClaimByChainId, (systemConfig.l2ChainId())),
+            abi.encode(Claim.wrap(_outputRoot))
+        );
 
         // Should succeed.
         IOptimismPortalInterop(payable(optimismPortal2)).proveWithdrawalTransaction({
             _tx: _defaultTx,
-            _disputeGameProxy: game,
-            _outputRootIndex: 0,
-            _superRootProof: superRootProof,
+            _disputeGameIndex: _proposedGameIndex,
             _outputRootProof: _outputRootProof,
             _withdrawalProof: _withdrawalProof
         });

--- a/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
+++ b/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
@@ -1181,7 +1181,7 @@ contract OptimismPortal2_ProveWithdrawalTransaction_Test is OptimismPortal2_Test
         vm.mockCallRevert(
             address(game),
             abi.encodeCall(game.rootClaimByChainId, (systemConfig.l2ChainId())),
-            abi.encodeWithSelector(UnknownChainId.selector)
+            abi.encodePacked(UnknownChainId.selector)
         );
 
         // Should revert because chainId not found in super root.


### PR DESCRIPTION
**Description**

Update the op-chain-ops/cmd/withdrawal script to have new flags that allow proving a withdrawal using a specific output root in the super proposal. Removes the need for the supervisor-rpc to prove withdrawals

**Tests**

TBD

**Additional context**

N/A

**Metadata**

Completes https://github.com/ethereum-optimism/optimism/issues/18615
