### PR TITLE
op-service: use blob tip cap provided by blob tip oracle

### DIFF
--- a/op-batcher/batcher/channel_config_provider.go
+++ b/op-batcher/batcher/channel_config_provider.go
@@ -86,8 +86,6 @@ func (dec *DynamicEthChannelConfig) ChannelConfig(isThrottling bool) ChannelConf
 		computeSingleBlobTxCost(numBlobsPerTx, baseFee, tipCap, blobBaseFee),
 		computeSingleBlobTxCost(numBlobsPerTx, baseFee, blobTipCap, blobBaseFee)
 
-	// TODO(18618): before activating the blob tip oracle, confirm in prod that we mostly get newBlobSavings == true, otherwise
-	// it is not worth it using the oracle
 	oracleBlobSavings := oracleBlobCost.Cmp(blobCost) < 0
 
 	// Now we compare the absolute cost per tx divided by the number of bytes per tx:

--- a/op-service/txmgr/txmgr.go
+++ b/op-service/txmgr/txmgr.go
@@ -397,17 +397,8 @@ func (m *SimpleTxManager) craftTx(ctx context.Context, candidate TxCandidate) (*
 			Sidecar:    sidecar,
 		}
 
-		// graceful upgrade to using blob tip oracle, for now we just compare the fees based on current codebase and the new bgpo module
-		{
-			oracleSavings := blobTipCap.Cmp(gasTipCap) < 0
-
-			// TODO(18618): before activating the blob tip oracle, confirm in prod that we mostly get oracleSavings == true, otherwise
-			// it is not worth it using the oracle
-			m.l.Info("Comparison between blobTipCap and gasTipCap", "blobTipCap", blobTipCap, "gasTipCap", gasTipCap, "oracle_blob_savings", oracleSavings)
-
-			// TODO(18618): when activating the blob tip oracle, we should remove the assignment and use the suggested blob tip cap from the oracle
-			blobTipCap = gasTipCap
-		}
+		oracleSavings := blobTipCap.Cmp(gasTipCap) < 0
+		m.l.Info("Comparison between blobTipCap and gasTipCap", "blobTipCap", blobTipCap, "gasTipCap", gasTipCap, "oracle_blob_savings", oracleSavings)
 
 		if err := finishBlobTx(message, m.chainID, blobTipCap, gasFeeCap, blobFeeCap, candidate.Value); err != nil {
 			return nil, fmt.Errorf("failed to create blob transaction: %w", err)
@@ -913,11 +904,13 @@ func (m *SimpleTxManager) queryReceipt(ctx context.Context, txHash common.Hash, 
 func (m *SimpleTxManager) increaseGasPrice(ctx context.Context, tx *types.Transaction) (*types.Transaction, error) {
 	m.txLogger(tx, true).Info("bumping gas price for transaction")
 	tip, baseFee, blobTipCap, blobBaseFee, err := m.SuggestGasPriceCaps(ctx)
-	// TODO(18618): when activating the blob tip oracle, integrate blobTipCap into the rest of the logic around bumping the gas price when replacing txs
-	_ = blobTipCap
 	if err != nil {
 		m.txLogger(tx, false).Warn("failed to get suggested gas tip and base fee", "err", err)
 		return nil, err
+	}
+
+	if tx.Type() == types.BlobTxType {
+		tip = blobTipCap
 	}
 	bumpedTip, bumpedFee := updateFees(tx.GasTipCap(), tx.GasFeeCap(), tip, baseFee, tx.Type() == types.BlobTxType, m.l)
 


### PR DESCRIPTION
This PR is activating the price for `tip cap` suggested by the `blob tip oracle` when the `op-batcher` is submitting blobs, instead of the statically configured minimum value. Currently the `op-batcher` is over-paying for blob, and this PR enables it to monitor the real-time blob market on the L1 and use a more appropriate value, than a statically defined one.

---

Fixes: https://github.com/ethereum-optimism/optimism/issues/18737
Fixes: https://github.com/ethereum-optimism/optimism/issues/18618

---

TODO:
- [ ] address Go unit tests
- [ ] make the blob tip oracle configurable, so that we can fallback to a static value