### PR TITLE
feat: move feature compatibility validation to Features lib

### DIFF
--- a/packages/contracts-bedrock/scripts/L2Genesis.s.sol
+++ b/packages/contracts-bedrock/scripts/L2Genesis.s.sol
@@ -14,6 +14,7 @@ import { OutputMode, OutputModeUtils, Fork, ForkUtils } from "scripts/libraries/
 import { Predeploys } from "src/libraries/Predeploys.sol";
 import { Preinstalls } from "src/libraries/Preinstalls.sol";
 import { Types } from "src/libraries/Types.sol";
+import { Features } from "src/libraries/Features.sol";
 
 // Interfaces
 import { IOptimismMintableERC721Factory } from "interfaces/L2/IOptimismMintableERC721Factory.sol";
@@ -233,6 +234,9 @@ contract L2Genesis is Script {
     ///      sets the deployed bytecode at their expected predeploy address.
     ///      LEGACY_ERC20_ETH and L1_MESSAGE_SENDER are deprecated and are not set.
     function setPredeployImplementations(Input memory _input) internal {
+        // Validate feature compatibility
+        Features.validateCompatibility(_input.useCustomGasToken, _input.useRevenueShare);
+
         setLegacyMessagePasser(); // 0
         // 01: legacy, not used in OP-Stack
         setDeployerWhitelist(); // 2
@@ -712,10 +716,6 @@ contract L2Genesis is Script {
 
         if (_useCustomGasToken && _withdrawalNetwork == Types.WithdrawalNetwork.L1) {
             revert("FeeVault: withdrawalNetwork type cannot be L1 when custom gas token is enabled");
-        }
-
-        if (_useCustomGasToken && _useRevenueShare) {
-            revert("FeeVault: custom gas token and revenue share cannot be enabled together");
         }
 
         if (_useRevenueShare) {

--- a/packages/contracts-bedrock/src/libraries/Features.sol
+++ b/packages/contracts-bedrock/src/libraries/Features.sol
@@ -15,4 +15,29 @@ library Features {
     ///         gas token in the OptimismPortal. When the CUSTOM_GAS_TOKEN feature is active, the
     ///         deposits and withdrawals of native ETH are disabled.
     bytes32 internal constant CUSTOM_GAS_TOKEN = "CUSTOM_GAS_TOKEN";
+
+    /// @notice The REVENUE_SHARING feature determines if the system is configured to use
+    ///         revenue sharing with fee vaults routing to the FeeSplitter predeploy.
+    ///         This is an L2-only feature configured at genesis time.
+    bytes32 internal constant REVENUE_SHARING = "REVENUE_SHARING";
+
+    /// @notice Error thrown when custom gas token and revenue sharing are both enabled.
+    error Features_CustomGasTokenAndRevenueShareIncompatible();
+
+    /// @notice Validates that custom gas token and revenue sharing are not both enabled.
+    ///         These features are mutually exclusive.
+    ///
+    /// @dev This validation approach is intentionally simple and not designed to scale
+    ///      to a large number of features or complex compatibility rules. As new features are
+    ///      added to the system, they should be evaluated for compatibility with all existing
+    ///      features. If additional incompatibilities are discovered or the number of features
+    ///      grows significantly, a more robust and extensible validation mechanism should be
+    ///      implemented.
+    /// @param _useCustomGasToken Whether custom gas token is enabled.
+    /// @param _useRevenueShare Whether revenue sharing is enabled.
+    function validateCompatibility(bool _useCustomGasToken, bool _useRevenueShare) internal pure {
+        if (_useCustomGasToken && _useRevenueShare) {
+            revert Features_CustomGasTokenAndRevenueShareIncompatible();
+        }
+    }
 }

--- a/packages/contracts-bedrock/src/libraries/Features.sol
+++ b/packages/contracts-bedrock/src/libraries/Features.sol
@@ -4,6 +4,11 @@ pragma solidity ^0.8.0;
 /// @notice Features is a library that stores feature name constants. Can be used alongside the
 ///         feature flagging functionality in the SystemConfig contract to selectively enable or
 ///         disable customizable features of the OP Stack.
+///
+/// @dev IMPORTANT: When adding a new feature to this library, its compatibility with ALL existing
+///      features MUST be carefully evaluated. If the new feature is incompatible with any existing
+///      feature, appropriate validation logic must be added to the validateCompatibility function
+///      or a new validation mechanism must be implemented.
 library Features {
     /// @notice The ETH_LOCKBOX feature determines if the system is configured to use the
     ///         ETHLockbox contract in the OptimismPortal. When the ETH_LOCKBOX feature is active

--- a/packages/contracts-bedrock/test/libraries/Features.t.sol
+++ b/packages/contracts-bedrock/test/libraries/Features.t.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import { Test } from "forge-std/Test.sol";
+import { Features } from "src/libraries/Features.sol";
+
+/// @title FeaturesWrapper
+/// @notice Wrapper contract to test the Features library
+contract FeaturesWrapper {
+    function validateCompatibility(bool _useCustomGasToken, bool _useRevenueShare) external pure {
+        Features.validateCompatibility(_useCustomGasToken, _useRevenueShare);
+    }
+}
+
+/// @title FeaturesTest
+/// @notice Tests for the Features library
+contract FeaturesTest is Test {
+    FeaturesWrapper internal wrapper;
+
+    function setUp() public {
+        wrapper = new FeaturesWrapper();
+    }
+
+    /// @notice Tests that validateCompatibility passes for all valid feature combinations
+    function test_validateCompatibility_succeeds() external view {
+        // Both features disabled
+        wrapper.validateCompatibility(false, false);
+
+        // Only custom gas token enabled
+        wrapper.validateCompatibility(true, false);
+
+        // Only revenue share enabled
+        wrapper.validateCompatibility(false, true);
+    }
+
+    /// @notice Tests that validateCompatibility reverts when both features are enabled
+    function test_validateCompatibility_bothEnabled_reverts() external {
+        vm.expectRevert(Features.Features_CustomGasTokenAndRevenueShareIncompatible.selector);
+        wrapper.validateCompatibility(true, true);
+    }
+}

--- a/packages/contracts-bedrock/test/libraries/Features.t.sol
+++ b/packages/contracts-bedrock/test/libraries/Features.t.sol
@@ -1,41 +1,32 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import { Test } from "forge-std/Test.sol";
+import { Test } from "test/setup/Test.sol";
 import { Features } from "src/libraries/Features.sol";
 
-/// @title FeaturesWrapper
-/// @notice Wrapper contract to test the Features library
-contract FeaturesWrapper {
-    function validateCompatibility(bool _useCustomGasToken, bool _useRevenueShare) external pure {
-        Features.validateCompatibility(_useCustomGasToken, _useRevenueShare);
-    }
-}
-
-/// @title FeaturesTest
-/// @notice Tests for the Features library
-contract FeaturesTest is Test {
-    FeaturesWrapper internal wrapper;
-
-    function setUp() public {
-        wrapper = new FeaturesWrapper();
-    }
-
+/// @title Features_ValidateCompatibility_Test
+/// @notice Tests for the Features library validateCompatibility function
+contract Features_ValidateCompatibility_Test is Test {
     /// @notice Tests that validateCompatibility passes for all valid feature combinations
     function test_validateCompatibility_succeeds() external view {
         // Both features disabled
-        wrapper.validateCompatibility(false, false);
+        this._validateCompatibility(false, false);
 
         // Only custom gas token enabled
-        wrapper.validateCompatibility(true, false);
+        this._validateCompatibility(true, false);
 
         // Only revenue share enabled
-        wrapper.validateCompatibility(false, true);
+        this._validateCompatibility(false, true);
     }
 
     /// @notice Tests that validateCompatibility reverts when both features are enabled
     function test_validateCompatibility_bothEnabled_reverts() external {
         vm.expectRevert(Features.Features_CustomGasTokenAndRevenueShareIncompatible.selector);
-        wrapper.validateCompatibility(true, true);
+        this._validateCompatibility(true, true);
+    }
+
+    /// @notice External helper function to call Features.validateCompatibility (needed for expectRevert)
+    function _validateCompatibility(bool _useCustomGasToken, bool _useRevenueShare) external pure {
+        Features.validateCompatibility(_useCustomGasToken, _useRevenueShare);
     }
 }

--- a/packages/contracts-bedrock/test/scripts/L2Genesis.t.sol
+++ b/packages/contracts-bedrock/test/scripts/L2Genesis.t.sol
@@ -11,6 +11,7 @@ import { LATEST_FORK } from "scripts/libraries/Config.sol";
 
 // Libraries
 import { Predeploys } from "src/libraries/Predeploys.sol";
+import { Features } from "src/libraries/Features.sol";
 
 // Interfaces
 import { ISuperchainRevSharesCalculator } from "interfaces/L2/ISuperchainRevSharesCalculator.sol";
@@ -437,7 +438,7 @@ contract L2Genesis_Run_Test is L2Genesis_TestInit {
     function test_cgt_revenueShare_reverts() external {
         _setInputCGTEnabled();
         input.useRevenueShare = true;
-        vm.expectRevert("FeeVault: custom gas token and revenue share cannot be enabled together");
+        vm.expectRevert(Features.Features_CustomGasTokenAndRevenueShareIncompatible.selector);
         genesis.run(input);
     }
 }


### PR DESCRIPTION
**Description**

This is a baby step towards centralizing feature compatibility validation within a single library.

It does not attempt to be general or easily expandable, but our use case is very simple at the moment: we just have two features that need to be kept separate.

It also doesn't attempt to handle compatibility between DevFeatures and SystemFeatures. 