### PR TITLE
Make contractsContainer exist only in utils

### DIFF
--- a/packages/contracts-bedrock/interfaces/L1/opcm/IOPContractsManagerMigrator.sol
+++ b/packages/contracts-bedrock/interfaces/L1/opcm/IOPContractsManagerMigrator.sol
@@ -39,9 +39,5 @@ interface IOPContractsManagerMigrator {
     /// @param _input The input parameters for the migration.
     function migrate(MigrateInput calldata _input) external;
 
-    function __constructor__(
-        IOPContractsManagerContainer _contractsContainer,
-        IOPContractsManagerUtils _utils
-    )
-        external;
+    function __constructor__(IOPContractsManagerUtils _utils) external;
 }

--- a/packages/contracts-bedrock/interfaces/L1/opcm/IOPContractsManagerV2.sol
+++ b/packages/contracts-bedrock/interfaces/L1/opcm/IOPContractsManagerV2.sol
@@ -93,7 +93,6 @@ interface IOPContractsManagerV2 {
     error UnexpectedPreambleData(bytes data);
 
     function __constructor__(
-        IOPContractsManagerContainer _contractsContainer,
         IOPContractsManagerStandardValidator _standardValidator,
         IOPContractsManagerMigrator _migrator,
         IOPContractsManagerUtils _utils

--- a/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
@@ -874,7 +874,7 @@ contract DeployImplementations is Script {
                 _args: DeployUtils.encodeConstructor(
                     abi.encodeCall(
                         IOPContractsManagerV2.__constructor__,
-                        (_output.opcmContainer, _output.opcmStandardValidator, _output.opcmMigrator, _output.opcmUtils)
+                        (_output.opcmStandardValidator, _output.opcmMigrator, _output.opcmUtils)
                     )
                 ),
                 _salt: _salt

--- a/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
@@ -812,7 +812,7 @@ contract DeployImplementations is Script {
             DeployUtils.createDeterministic({
                 _name: "OPContractsManagerMigrator.sol:OPContractsManagerMigrator",
                 _args: DeployUtils.encodeConstructor(
-                    abi.encodeCall(IOPContractsManagerMigrator.__constructor__, (_output.opcmContainer, _output.opcmUtils))
+                    abi.encodeCall(IOPContractsManagerMigrator.__constructor__, (_output.opcmUtils))
                 ),
                 _salt: _salt
             })

--- a/packages/contracts-bedrock/scripts/deploy/VerifyOPCM.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/VerifyOPCM.s.sol
@@ -304,7 +304,6 @@ contract VerifyOPCM is Script {
         refs[0] = OpcmContractRef({ field: "opcm", name: _opcmContractName(), addr: address(_opcm), blueprint: false });
         refs[1] = OpcmContractRef({
             field: "contractsContainer",
-            // nosemgrep: sol-style-vm-env-only-in-config-sol
             name: _isOPCMV2() ? "OPContractsManagerContainer" : "OPContractsManagerContractsContainer",
             addr: contractsContainerAddr,
             blueprint: false

--- a/packages/contracts-bedrock/snapshots/abi/OPContractsManagerMigrator.json
+++ b/packages/contracts-bedrock/snapshots/abi/OPContractsManagerMigrator.json
@@ -2,11 +2,6 @@
   {
     "inputs": [
       {
-        "internalType": "contract IOPContractsManagerContainer",
-        "name": "_contractsContainer",
-        "type": "address"
-      },
-      {
         "internalType": "contract IOPContractsManagerUtils",
         "name": "_utils",
         "type": "address"

--- a/packages/contracts-bedrock/snapshots/abi/OPContractsManagerV2.json
+++ b/packages/contracts-bedrock/snapshots/abi/OPContractsManagerV2.json
@@ -2,11 +2,6 @@
   {
     "inputs": [
       {
-        "internalType": "contract IOPContractsManagerContainer",
-        "name": "_contractsContainer",
-        "type": "address"
-      },
-      {
         "internalType": "contract IOPContractsManagerStandardValidator",
         "name": "_standardValidator",
         "type": "address"

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -52,8 +52,8 @@
     "sourceCodeHash": "0xb3184aa5d95a82109e7134d1f61941b30e25f655b9849a0e303d04bbce0cde0b"
   },
   "src/L1/opcm/OPContractsManagerV2.sol:OPContractsManagerV2": {
-    "initCodeHash": "0x426d53fd2634e081467a8d7bb266870fcdadeb0d23d3d50f47bd862f224c2028",
-    "sourceCodeHash": "0xaa1ea1b099c18edd712fcbde2aa35119b9c2953836e6a0f37d53253b0a1b1f4a"
+    "initCodeHash": "0xd40e4e64d3cf4635550e4d6e68878f9e9cc854ed7a019e4df4c7710037466d8e",
+    "sourceCodeHash": "0xbce990bfabce363186f74f01ede92fef5de362ea5e7e8b9cfda60494b8f0e777"
   },
   "src/L2/BaseFeeVault.sol:BaseFeeVault": {
     "initCodeHash": "0x838bbd7f381e84e21887f72bd1da605bfc4588b3c39aed96cbce67c09335b3ee",

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerMigrator.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerMigrator.sol
@@ -46,19 +46,8 @@ contract OPContractsManagerMigrator is OPContractsManagerUtilsCaller {
     /// @notice Thrown when the starting respected game type is not a valid super game type.
     error OPContractsManagerMigrator_InvalidStartingRespectedGameType();
 
-    /// @notice Container of blueprint and implementation contract addresses.
-    IOPContractsManagerContainer public immutable contractsContainer;
-
-    /// @param _contractsContainer The container of blueprint and implementation contract addresses.
     /// @param _utils The utility functions for the OPContractsManager.
-    constructor(
-        IOPContractsManagerContainer _contractsContainer,
-        IOPContractsManagerUtils _utils
-    )
-        OPContractsManagerUtilsCaller(_utils)
-    {
-        contractsContainer = _contractsContainer;
-    }
+    constructor(IOPContractsManagerUtils _utils) OPContractsManagerUtilsCaller(_utils) { }
 
     /// @notice Migrates one or more OP Stack chains to use the Super Root dispute games and shared
     ///         dispute game contracts.
@@ -159,7 +148,7 @@ contract OPContractsManagerMigrator is OPContractsManagerUtilsCaller {
         // Separate context to avoid stack too deep (isolate the implementations variable).
         {
             // Grab the implementations.
-            IOPContractsManagerContainer.Implementations memory impls = contractsContainer.implementations();
+            IOPContractsManagerContainer.Implementations memory impls = contractsContainer().implementations();
 
             // Initialize the new ETHLockbox.
             _upgrade(
@@ -264,5 +253,11 @@ contract OPContractsManagerMigrator is OPContractsManagerUtilsCaller {
         // (OptimismPortalInterop). If the portal is not on the interop version, this call will
         // fail.
         portal.migrateToSuperRoots(_newLockbox, _newASR);
+    }
+
+    /// @notice Returns the contracts container.
+    /// @return The contracts container.
+    function contractsContainer() public view returns (IOPContractsManagerContainer) {
+        return opcmUtils.contractsContainer();
     }
 }

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
@@ -132,9 +132,6 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
     /// @notice Thrown when an invalid upgrade sequence is provided.
     error OPContractsManagerV2_InvalidUpgradeSequence(string _lastVersion, string _thisVersion);
 
-    /// @notice Container of blueprint and implementation contract addresses.
-    IOPContractsManagerContainer public immutable contractsContainer;
-
     /// @notice Address of the Standard Validator for this OPCM release.
     IOPContractsManagerStandardValidator public immutable opcmStandardValidator;
 
@@ -150,24 +147,21 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
     ///         - Major bump: New required sequential upgrade
     ///         - Minor bump: Replacement OPCM for same upgrade
     ///         - Patch bump: Development changes (expected for normal dev work)
-    /// @custom:semver 7.0.2
+    /// @custom:semver 7.0.3
     function version() public pure returns (string memory) {
-        return "7.0.2";
+        return "7.0.3";
     }
 
-    /// @param _contractsContainer The container of blueprint and implementation contract addresses.
     /// @param _standardValidator The standard validator for this OPCM release.
     /// @param _migrator The migrator contract for this OPCM release.
     /// @param _utils The utility functions for the OPContractsManager.
     constructor(
-        IOPContractsManagerContainer _contractsContainer,
         IOPContractsManagerStandardValidator _standardValidator,
         IOPContractsManagerMigrator _migrator,
         IOPContractsManagerUtils _utils
     )
         OPContractsManagerUtilsCaller(_utils)
     {
-        contractsContainer = _contractsContainer;
         opcmStandardValidator = _standardValidator;
         opcmMigrator = _migrator;
         opcmV2 = this;
@@ -977,19 +971,19 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
 
     /// @notice Returns the blueprint contract addresses.
     function blueprints() public view returns (IOPContractsManagerContainer.Blueprints memory) {
-        return contractsContainer.blueprints();
+        return contractsContainer().blueprints();
     }
 
     /// @notice Returns the implementation contract addresses.
     function implementations() public view returns (IOPContractsManagerContainer.Implementations memory) {
-        return contractsContainer.implementations();
+        return contractsContainer().implementations();
     }
 
     /// @notice Returns the status of a development feature.
     /// @param _feature The feature to check.
     /// @return True if the feature is enabled, false otherwise.
     function isDevFeatureEnabled(bytes32 _feature) public view returns (bool) {
-        return contractsContainer.isDevFeatureEnabled(_feature);
+        return contractsContainer().isDevFeatureEnabled(_feature);
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -1004,9 +998,15 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
         return opcmV2.version();
     }
 
+    /// @notice Returns the contracts container.
+    /// @return The contracts container.
+    function contractsContainer() public view returns (IOPContractsManagerContainer) {
+        return opcmUtils.contractsContainer();
+    }
+
     /// @notice Returns the development feature bitmap.
     /// @return The development feature bitmap.
     function devFeatureBitmap() public view returns (bytes32) {
-        return contractsContainer.devFeatureBitmap();
+        return contractsContainer().devFeatureBitmap();
     }
 }

--- a/packages/contracts-bedrock/test/scripts/VerifyOPCM.t.sol
+++ b/packages/contracts-bedrock/test/scripts/VerifyOPCM.t.sol
@@ -378,7 +378,10 @@ contract VerifyOPCM_Run_Test is VerifyOPCM_TestInit {
         uint256 componentsWithContainerTested = 0;
         for (uint256 i = 0; i < propRefs.length; i++) {
             string memory field = propRefs[i].field;
-            if (_hasContractsContainer(field)) {
+            // We want to do nothing if the field is opcmUtils because it all other components get their
+            // contractsContainer from it
+            // So mocking it to return a different value would make the other components have the same return value.
+            if (_hasContractsContainer(field) && !LibString.eq(field, "opcmUtils")) {
                 // Mock this specific component to return a different address
                 vm.mockCall(
                     propRefs[i].addr,


### PR DESCRIPTION
Make contractsContainer exist only in utils. OPCM V2 can access it through opcmUtils.