### PR TITLE
feat(op-service): add route-specific JWT authentication support

### DIFF
--- a/op-service/rpc/handler.go
+++ b/op-service/rpc/handler.go
@@ -38,8 +38,11 @@ type Handler struct {
 	corsHosts      []string
 	vHosts         []string
 	jwtSecret      []byte
-	wsEnabled      bool
-	httpRecorder   opmetrics.HTTPRecorder
+	// rootRPCAuthenticated overrides the auth behavior of the root RPC route.
+	// nil means "use global JWT presence", matching AddRPCWithAuthentication semantics.
+	rootRPCAuthenticated *bool
+	wsEnabled            bool
+	httpRecorder         opmetrics.HTTPRecorder
 
 	log         log.Logger
 	middlewares []Middleware
@@ -79,7 +82,7 @@ func NewHandler(appVersion string, opts ...Option) *Handler {
 	handler = oplog.NewLoggingMiddleware(bs.log, handler)
 	bs.outer = handler
 
-	if err := bs.AddRPC(rootRoute); err != nil {
+	if err := bs.AddRPCWithAuthentication(rootRoute, bs.rootRPCAuthenticated); err != nil {
 		panic(fmt.Errorf("failed to register root RPC server: %w", err))
 	}
 

--- a/op-service/rpc/handler_options.go
+++ b/op-service/rpc/handler_options.go
@@ -13,6 +13,15 @@ type Option func(b *Handler)
 
 type Middleware func(next http.Handler) http.Handler
 
+// WithRootRPCAuthentication configures the authentication setting of the root RPC route ("/").
+// By default (no option set), the presence of a JWT secret determines if the root RPC route is authenticated.
+// This can be overridden to support a public root RPC route while using JWT for other sub-routes.
+func WithRootRPCAuthentication(isAuthenticated bool) Option {
+	return func(b *Handler) {
+		b.rootRPCAuthenticated = &isAuthenticated
+	}
+}
+
 func WithHealthzHandler(hdlr http.Handler) Option {
 	return func(b *Handler) {
 		b.healthzHandler = hdlr

--- a/op-service/rpc/handler_test.go
+++ b/op-service/rpc/handler_test.go
@@ -108,3 +108,83 @@ func TestHandlerAuthentication(t *testing.T) {
 		require.Equal(t, 12, res)
 	})
 }
+
+func TestHandlerAuthenticationWithPublicRoot(t *testing.T) {
+	logger := testlog.Logger(t, log.LevelInfo)
+
+	// generate JWT Secret
+	var jwtSecret eth.Bytes32
+	_, err := io.ReadFull(rand.Reader, jwtSecret[:])
+	require.NoError(t, err)
+
+	server := ServerFromConfig(&ServerConfig{
+		RpcOptions: []Option{
+			WithLogger(logger),
+			WithWebsocketEnabled(),
+			WithJWTSecret(jwtSecret[:]),
+			WithRootRPCAuthentication(false),
+		},
+		Host:       "127.0.0.1",
+		Port:       0,
+		AppVersion: "test",
+	})
+
+	namespace := "test"
+	server.AddAPI(rpc.API{
+		Namespace: namespace,
+		Service:   new(testAPI),
+	})
+
+	isAuthenticated := true
+	require.NoError(t, server.Handler.AddRPCWithAuthentication("/admin", &isAuthenticated))
+	require.NoError(t, server.AddAPIToRPC("/admin", rpc.API{
+		Namespace: namespace,
+		Service:   new(testAPI),
+	}))
+
+	require.NoError(t, server.Start(), "must start")
+	t.Cleanup(func() {
+		err := server.Stop()
+		if err != nil {
+			panic(err)
+		}
+	})
+
+	endpoint := "http://" + server.Endpoint()
+
+	publicClient, err := rpc.Dial(endpoint)
+	require.NoError(t, err)
+	t.Cleanup(publicClient.Close)
+
+	adminUnauthenticatedClient, err := rpc.Dial(endpoint + "/admin")
+	require.NoError(t, err)
+	t.Cleanup(adminUnauthenticatedClient.Close)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	adminAuthenticatedClient, err := client.NewRPC(
+		ctx,
+		logger,
+		endpoint+"/admin",
+		client.WithGethRPCOptions(rpc.WithHTTPAuth(gn.NewJWTAuth(jwtSecret))),
+	)
+	require.NoError(t, err)
+	t.Cleanup(adminAuthenticatedClient.Close)
+
+	t.Run("public root RPC", func(t *testing.T) {
+		var res int
+		require.NoError(t, publicClient.Call(&res, namespace+"_frobnicate", 2))
+		require.Equal(t, 4, res)
+	})
+
+	t.Run("authenticated sub-route - unauthenticated", func(t *testing.T) {
+		var res int
+		require.ErrorContains(t, adminUnauthenticatedClient.Call(&res, namespace+"_frobnicate", 2), "missing token")
+	})
+
+	t.Run("authenticated sub-route - authenticated", func(t *testing.T) {
+		var res int
+		require.NoError(t, adminAuthenticatedClient.CallContext(ctx, &res, namespace+"_frobnicate", 6))
+		require.Equal(t, 12, res)
+	})
+}


### PR DESCRIPTION
## Summary

Add ability to configure different authentication handlers per route in the RPC handler, enabling public APIs on the root path while protecting admin APIs with JWT authentication on a separate route (e.g., `/admin`).

### Changes
- Add `rootRPCAuthenticated` field to handler to control root route authentication separately
- Add `WithRootRPCAuthentication()` option function for configuring root auth behavior
- Add test case `TestHandlerAuthenticationWithPublicRoot` demonstrating public root + authenticated sub-routes

### Use Case
This enables services like op-interop-filter to expose public supervisor APIs on `/` while protecting admin APIs (failsafe control) on `/admin` with JWT authentication.

### Files Changed
- `op-service/rpc/handler.go` - Added root auth control
- `op-service/rpc/handler_options.go` - New option function
- `op-service/rpc/handler_test.go` - Test coverage

## Test plan
- [x] Unit test for public root + authenticated sub-route pattern
- [ ] Manual testing in op-interop-filter (separate PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)