### PR TITLE
feat(op-interop-filter): add JWT authentication for admin API

### DIFF
--- a/op-interop-filter/filter/admin_handler.go
+++ b/op-interop-filter/filter/admin_handler.go
@@ -1,0 +1,22 @@
+package filter
+
+import (
+	"net/http"
+
+	"github.com/ethereum/go-ethereum/node"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+// newJWTProtectedAdminHandler creates an http.Handler for the admin API
+// that requires JWT authentication. It uses go-ethereum's built-in
+// HTTPHandlerStack which handles JWT validation.
+func newJWTProtectedAdminHandler(backend *Backend, jwtSecret []byte) http.Handler {
+	srv := rpc.NewServer()
+	if err := srv.RegisterName("admin", &AdminFrontend{backend: backend}); err != nil {
+		panic(err) // Programming error - should never happen
+	}
+
+	// Wrap with JWT authentication using go-ethereum's handler stack.
+	// This is the same mechanism used by geth and op-service internally.
+	return node.NewHTTPHandlerStack(srv, []string{"*"}, []string{"*"}, jwtSecret)
+}

--- a/op-interop-filter/filter/jwt_auth_test.go
+++ b/op-interop-filter/filter/jwt_auth_test.go
@@ -1,0 +1,167 @@
+package filter
+
+import (
+	"context"
+	"crypto/rand"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	oprpc "github.com/ethereum-optimism/optimism/op-service/rpc"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	gn "github.com/ethereum/go-ethereum/node"
+	"github.com/ethereum/go-ethereum/rpc"
+
+	"github.com/ethereum/go-ethereum/log"
+)
+
+// testSupervisorAPI is a mock supervisor API for testing
+type testSupervisorAPI struct{}
+
+func (t *testSupervisorAPI) Ping(_ context.Context) string {
+	return "pong"
+}
+
+// testAdminAPI is a mock admin API for testing
+type testAdminAPI struct{}
+
+func (t *testAdminAPI) GetFailsafeEnabled(_ context.Context) (bool, error) {
+	return false, nil
+}
+
+// newTestJWTProtectedAdminHandler creates a JWT-protected handler for testing
+func newTestJWTProtectedAdminHandler(jwtSecret []byte) http.Handler {
+	srv := rpc.NewServer()
+	if err := srv.RegisterName("admin", new(testAdminAPI)); err != nil {
+		panic(err)
+	}
+	return gn.NewHTTPHandlerStack(srv, []string{"*"}, []string{"*"}, jwtSecret)
+}
+
+func TestJWTAuthentication(t *testing.T) {
+	logger := testlog.Logger(t, log.LevelInfo)
+
+	// Generate JWT secret
+	var jwtSecret eth.Bytes32
+	_, err := io.ReadFull(rand.Reader, jwtSecret[:])
+	require.NoError(t, err)
+
+	// Create server WITHOUT JWT on root - root stays public for supervisor API
+	server := oprpc.ServerFromConfig(&oprpc.ServerConfig{
+		RpcOptions: []oprpc.Option{
+			oprpc.WithLogger(logger),
+			// No WithJWTSecret - root stays public
+		},
+		Host:       "127.0.0.1",
+		Port:       0,
+		AppVersion: "test",
+	})
+
+	// Register supervisor API on root (public)
+	server.AddAPI(rpc.API{
+		Namespace: "supervisor",
+		Service:   new(testSupervisorAPI),
+	})
+
+	// Register admin API with JWT protection using AddHandler
+	server.AddHandler("/admin", newTestJWTProtectedAdminHandler(jwtSecret[:]))
+
+	require.NoError(t, server.Start())
+	t.Cleanup(func() {
+		_ = server.Stop()
+	})
+
+	endpoint := "http://" + server.Endpoint()
+
+	// Create clients
+	supervisorClient, err := rpc.Dial(endpoint)
+	require.NoError(t, err)
+	t.Cleanup(supervisorClient.Close)
+
+	adminUnauthClient, err := rpc.Dial(endpoint + "/admin")
+	require.NoError(t, err)
+	t.Cleanup(adminUnauthClient.Close)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	adminAuthClient, err := client.NewRPC(
+		ctx,
+		logger,
+		endpoint+"/admin",
+		client.WithGethRPCOptions(rpc.WithHTTPAuth(gn.NewJWTAuth(jwtSecret))),
+	)
+	require.NoError(t, err)
+	t.Cleanup(adminAuthClient.Close)
+
+	t.Run("supervisor API works without JWT", func(t *testing.T) {
+		var res string
+		err := supervisorClient.Call(&res, "supervisor_ping")
+		require.NoError(t, err)
+		require.Equal(t, "pong", res)
+	})
+
+	t.Run("admin API requires JWT - fails without auth", func(t *testing.T) {
+		var res bool
+		err := adminUnauthClient.Call(&res, "admin_getFailsafeEnabled")
+		require.ErrorContains(t, err, "missing token")
+	})
+
+	t.Run("admin API works with valid JWT", func(t *testing.T) {
+		var res bool
+		err := adminAuthClient.CallContext(ctx, &res, "admin_getFailsafeEnabled")
+		require.NoError(t, err)
+		require.Equal(t, false, res)
+	})
+
+	t.Run("supervisor API not accidentally gated when JWT configured", func(t *testing.T) {
+		// This is a regression test - supervisor API must remain public
+		// even when JWT is configured for admin routes
+		var res string
+		err := supervisorClient.Call(&res, "supervisor_ping")
+		require.NoError(t, err, "supervisor API must not require JWT")
+		require.Equal(t, "pong", res)
+	})
+}
+
+func TestSupervisorAPIWithoutJWT(t *testing.T) {
+	logger := testlog.Logger(t, log.LevelInfo)
+
+	// Create server WITHOUT JWT secret - supervisor API works, no admin API
+	server := oprpc.ServerFromConfig(&oprpc.ServerConfig{
+		RpcOptions: []oprpc.Option{
+			oprpc.WithLogger(logger),
+		},
+		Host:       "127.0.0.1",
+		Port:       0,
+		AppVersion: "test",
+	})
+
+	// Register supervisor API on root (no admin without JWT)
+	server.AddAPI(rpc.API{
+		Namespace: "supervisor",
+		Service:   new(testSupervisorAPI),
+	})
+
+	require.NoError(t, server.Start())
+	t.Cleanup(func() {
+		_ = server.Stop()
+	})
+
+	endpoint := "http://" + server.Endpoint()
+	client, err := rpc.Dial(endpoint)
+	require.NoError(t, err)
+	t.Cleanup(client.Close)
+
+	t.Run("supervisor API works without JWT configured", func(t *testing.T) {
+		var res string
+		err := client.Call(&res, "supervisor_ping")
+		require.NoError(t, err)
+		require.Equal(t, "pong", res)
+	})
+}

--- a/op-interop-filter/filter/service.go
+++ b/op-interop-filter/filter/service.go
@@ -145,41 +145,29 @@ func (s *Service) initBackend(ctx context.Context, cfg *Config) error {
 }
 
 func (s *Service) initRPCServer(cfg *Config) error {
-	opts := []oprpc.Option{
-		oprpc.WithLogger(s.log),
-	}
-
-	// Load JWT secret if path is provided (generates new secret if file is empty)
-	if cfg.JWTSecretPath != "" {
-		secret, err := oprpc.ObtainJWTSecret(s.log, cfg.JWTSecretPath, true)
-		if err != nil {
-			return fmt.Errorf("failed to obtain JWT secret: %w", err)
-		}
-		opts = append(opts, oprpc.WithJWTSecret(secret[:]))
-	}
-
+	// Create server without JWT - root route stays public for supervisor API
 	server := oprpc.NewServer(
 		cfg.RPC.ListenAddr,
 		cfg.RPC.ListenPort,
 		s.version,
-		opts...,
+		oprpc.WithLogger(s.log),
 	)
 
-	// Register supervisor query API
+	// Register supervisor query API on root (public, no auth)
 	server.AddAPI(rpc.API{
 		Namespace:     "supervisor",
 		Service:       &QueryFrontend{backend: s.backend},
 		Authenticated: false,
 	})
 
-	// Register admin API (opt-in)
-	if cfg.RPC.EnableAdmin {
-		s.log.Info("Admin RPC enabled")
-		server.AddAPI(rpc.API{
-			Namespace:     "admin",
-			Service:       &AdminFrontend{backend: s.backend},
-			Authenticated: true,
-		})
+	// Register admin API (opt-in, requires JWT)
+	if cfg.RPC.EnableAdmin && cfg.JWTSecretPath != "" {
+		secret, err := oprpc.ObtainJWTSecret(s.log, cfg.JWTSecretPath, true)
+		if err != nil {
+			return fmt.Errorf("failed to obtain JWT secret: %w", err)
+		}
+		server.AddHandler("/admin", newJWTProtectedAdminHandler(s.backend, secret[:]))
+		s.log.Info("Admin RPC enabled", "route", "/admin")
 	}
 
 	s.rpcServer = server


### PR DESCRIPTION
Add JWT-protected admin API at /admin route while keeping supervisor API public on the root route. Uses geth's NewHTTPHandlerStack for JWT validation.

- admin_handler.go: Creates JWT-protected handler (~20 lines)
- service.go: Mounts admin handler when JWT configured
- jwt_auth_test.go: Comprehensive auth tests

Admin API is only available when --rpc.jwt-secret is configured. No op-service changes required.

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

Add JWT authentication for admin API on `op-interop-filter`. The admin API is mounted at `/admin` and requires JWT auth when `--rpc.jwt-secret` is configured. The supervisor access checking API remains public on the root route.


**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

 Added `jwt_auth_test.go` with some JWT authentication tests.

Also did a bit of manual testing

**Additional context**

<!--
Add any other context about the problem you're solving.
-->
N/A
**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
N/A