### PR TITLE
op-node: add --interop.supervisor-enabled flag

### DIFF
--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -434,6 +434,13 @@ var (
 		TakesFile: true,
 		Category:  InteropCategory,
 	}
+	InteropSupervisorEnabled = &cli.BoolFlag{
+		Name:     "interop.supervisor-enabled",
+		Usage:    "Enable supervisor-based interop features. When false, interop contracts deploy but supervisor logic stays disabled. Defaults to false as supervisor is deprecated.",
+		EnvVars:  prefixEnvVars("INTEROP_SUPERVISOR_ENABLED"),
+		Value:    false,
+		Category: InteropCategory,
+	}
 
 	IgnoreMissingPectraBlobSchedule = &cli.BoolFlag{
 		Name: "ignore-missing-pectra-blob-schedule",
@@ -505,6 +512,7 @@ var optionalFlags = []cli.Flag{
 	InteropRPCPort,
 	InteropJWTSecret,
 	InteropDependencySet,
+	InteropSupervisorEnabled,
 	IgnoreMissingPectraBlobSchedule,
 	ExperimentalOPStackAPI,
 }

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -60,15 +60,15 @@ func NewDriver(
 	l1 = metered.NewMeteredL1Fetcher(l1Tracker, metrics)
 	verifConfDepth := confdepth.NewConfDepth(driverCfg.VerifierConfDepth, statusTracker.L1Head, l1)
 
-	ec := engine.NewEngineController(driverCtx, l2, log, metrics, cfg, syncCfg, l1, sys.Register("engine-controller", nil))
+	ec := engine.NewEngineController(driverCtx, l2, log, metrics, cfg, syncCfg, l1, sys.Register("engine-controller", nil), indexingMode)
 	// TODO(#17115): Refactor dependency cycles
 	ec.SetCrossUpdateHandler(statusTracker)
 
 	var finalizer Finalizer
 	if cfg.AltDAEnabled() {
-		finalizer = finality.NewAltDAFinalizer(driverCtx, log, cfg, driverCfg.Finalizer, l1, altDA, ec)
+		finalizer = finality.NewAltDAFinalizer(driverCtx, log, cfg, driverCfg.Finalizer, l1, altDA, ec, indexingMode)
 	} else {
-		finalizer = finality.NewFinalizer(driverCtx, log, cfg, driverCfg.Finalizer, l1, ec)
+		finalizer = finality.NewFinalizer(driverCtx, log, cfg, driverCfg.Finalizer, l1, ec, indexingMode)
 	}
 	sys.Register("finalizer", finalizer)
 

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -104,6 +104,10 @@ type EngineController struct {
 	elStart    time.Time
 	clock      clock.Clock
 
+	// supervisorEnabled indicates if supervisor-based interop features are enabled.
+	// When false, cross-unsafe and cross-safe promotion happens locally even after interop activation.
+	supervisorEnabled bool
+
 	// L1 chain for reset functionality
 	l1 sync.L1Chain
 
@@ -163,7 +167,7 @@ type EngineController struct {
 var _ event.Deriver = (*EngineController)(nil)
 
 func NewEngineController(ctx context.Context, engine ExecEngine, log log.Logger, m opmetrics.Metricer,
-	rollupCfg *rollup.Config, syncCfg *sync.Config, l1 sync.L1Chain, emitter event.Emitter,
+	rollupCfg *rollup.Config, syncCfg *sync.Config, l1 sync.L1Chain, emitter event.Emitter, supervisorEnabled bool,
 ) *EngineController {
 	syncStatus := syncStatusCL
 	if syncCfg.SyncMode == sync.ELSync {
@@ -171,18 +175,19 @@ func NewEngineController(ctx context.Context, engine ExecEngine, log log.Logger,
 	}
 
 	return &EngineController{
-		engine:         engine,
-		log:            log,
-		metrics:        m,
-		chainSpec:      rollup.NewChainSpec(rollupCfg),
-		rollupCfg:      rollupCfg,
-		syncCfg:        syncCfg,
-		syncStatus:     syncStatus,
-		clock:          clock.SystemClock,
-		l1:             l1,
-		ctx:            ctx,
-		emitter:        emitter,
-		unsafePayloads: NewPayloadsQueue(log, maxUnsafePayloadsMemory, payloadMemSize),
+		engine:            engine,
+		log:               log,
+		metrics:           m,
+		chainSpec:         rollup.NewChainSpec(rollupCfg),
+		rollupCfg:         rollupCfg,
+		syncCfg:           syncCfg,
+		syncStatus:        syncStatus,
+		clock:             clock.SystemClock,
+		l1:                l1,
+		ctx:               ctx,
+		emitter:           emitter,
+		supervisorEnabled: supervisorEnabled,
+		unsafePayloads:    NewPayloadsQueue(log, maxUnsafePayloadsMemory, payloadMemSize),
 	}
 }
 func (e *EngineController) UnsafeL2Head() eth.L2BlockRef {
@@ -712,8 +717,8 @@ func (e *EngineController) OnEvent(ctx context.Context, ev event.Event) bool {
 	//  PromoteSafeEvent fan out is updated to procedural PromoteSafe method call
 	switch x := ev.(type) {
 	case UnsafeUpdateEvent:
-		// pre-interop everything that is local-unsafe is also immediately cross-unsafe.
-		if !e.rollupCfg.IsInterop(x.Ref.Time) {
+		// pre-interop (or if supervisor disabled) everything that is local-unsafe is also immediately cross-unsafe.
+		if !e.rollupCfg.IsInterop(x.Ref.Time) || !e.supervisorEnabled {
 			e.emitter.Emit(ctx, PromoteCrossUnsafeEvent(x))
 		}
 		// Try to apply the forkchoice changes
@@ -722,8 +727,8 @@ func (e *EngineController) OnEvent(ctx context.Context, ev event.Event) bool {
 		e.SetCrossUnsafeHead(x.Ref)
 		e.onUnsafeUpdate(ctx, x.Ref, e.unsafeHead)
 	case LocalSafeUpdateEvent:
-		// pre-interop everything that is local-safe is also immediately cross-safe.
-		if !e.rollupCfg.IsInterop(x.Ref.Time) {
+		// pre-interop (or if supervisor disabled) everything that is local-safe is also immediately cross-safe.
+		if !e.rollupCfg.IsInterop(x.Ref.Time) || !e.supervisorEnabled {
 			e.PromoteSafe(ctx, x.Ref, x.Source)
 		}
 	case InteropInvalidateBlockEvent:

--- a/op-node/rollup/engine/engine_controller_test.go
+++ b/op-node/rollup/engine/engine_controller_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestInvalidPayloadDropsHead(t *testing.T) {
 	emitter := &testutils.MockEmitter{}
-	ec := NewEngineController(context.Background(), nil, testlog.Logger(t, 0), metrics.NoopMetrics, &rollup.Config{}, &sync.Config{}, &testutils.MockL1Source{}, emitter)
+	ec := NewEngineController(context.Background(), nil, testlog.Logger(t, 0), metrics.NoopMetrics, &rollup.Config{}, &sync.Config{}, &testutils.MockL1Source{}, emitter, false)
 
 	payload := &eth.ExecutionPayloadEnvelope{ExecutionPayload: &eth.ExecutionPayload{
 		BlockHash: common.Hash{0x01},
@@ -110,7 +110,7 @@ func TestOnUnsafePayload_EnqueueEmit(t *testing.T) {
 	cfg, _, _, payloadA1 := buildSimpleCfgAndPayload(t)
 
 	emitter := &testutils.MockEmitter{}
-	ec := NewEngineController(context.Background(), nil, testlog.Logger(t, 0), metrics.NoopMetrics, cfg, &sync.Config{}, &testutils.MockL1Source{}, emitter)
+	ec := NewEngineController(context.Background(), nil, testlog.Logger(t, 0), metrics.NoopMetrics, cfg, &sync.Config{}, &testutils.MockL1Source{}, emitter, false)
 
 	emitter.ExpectOnce(PayloadInvalidEvent{})
 	emitter.ExpectOnce(ForkchoiceUpdateEvent{})
@@ -127,7 +127,7 @@ func TestOnForkchoiceUpdate_ProcessRetryAndPop(t *testing.T) {
 
 	emitter := &testutils.MockEmitter{}
 	mockEngine := &testutils.MockEngine{}
-	cl := NewEngineController(context.Background(), mockEngine, testlog.Logger(t, 0), metrics.NoopMetrics, cfg, &sync.Config{SyncMode: sync.CLSync}, &testutils.MockL1Source{}, emitter)
+	cl := NewEngineController(context.Background(), mockEngine, testlog.Logger(t, 0), metrics.NoopMetrics, cfg, &sync.Config{SyncMode: sync.CLSync}, &testutils.MockL1Source{}, emitter, false)
 
 	// queue payload A1
 	emitter.ExpectOnceType("UnsafeUpdateEvent")
@@ -156,7 +156,7 @@ func TestPeekUnsafePayload(t *testing.T) {
 	cfg, _, _, payloadA1 := buildSimpleCfgAndPayload(t)
 
 	emitter := &testutils.MockEmitter{}
-	ec := NewEngineController(context.Background(), nil, testlog.Logger(t, 0), metrics.NoopMetrics, cfg, &sync.Config{SyncMode: sync.CLSync}, &testutils.MockL1Source{}, emitter)
+	ec := NewEngineController(context.Background(), nil, testlog.Logger(t, 0), metrics.NoopMetrics, cfg, &sync.Config{SyncMode: sync.CLSync}, &testutils.MockL1Source{}, emitter, false)
 
 	// empty -> zero
 	_, ref := ec.PeekUnsafePayload()
@@ -174,7 +174,7 @@ func TestPeekUnsafePayload(t *testing.T) {
 func TestPeekUnsafePayload_OnDeriveErrorReturnsZero(t *testing.T) {
 	// missing L1-info in txs will cause derive error
 	emitter := &testutils.MockEmitter{}
-	ec := NewEngineController(context.Background(), nil, testlog.Logger(t, 0), metrics.NoopMetrics, &rollup.Config{}, &sync.Config{SyncMode: sync.CLSync}, &testutils.MockL1Source{}, emitter)
+	ec := NewEngineController(context.Background(), nil, testlog.Logger(t, 0), metrics.NoopMetrics, &rollup.Config{}, &sync.Config{SyncMode: sync.CLSync}, &testutils.MockL1Source{}, emitter, false)
 
 	bad := &eth.ExecutionPayloadEnvelope{ExecutionPayload: &eth.ExecutionPayload{BlockNumber: 1, BlockHash: common.Hash{0xaa}}}
 	_ = ec.unsafePayloads.Push(bad)
@@ -184,7 +184,7 @@ func TestPeekUnsafePayload_OnDeriveErrorReturnsZero(t *testing.T) {
 
 func TestInvalidPayloadForNonHead_NoDrop(t *testing.T) {
 	emitter := &testutils.MockEmitter{}
-	ec := NewEngineController(context.Background(), nil, testlog.Logger(t, 0), metrics.NoopMetrics, &rollup.Config{}, &sync.Config{SyncMode: sync.CLSync}, &testutils.MockL1Source{}, emitter)
+	ec := NewEngineController(context.Background(), nil, testlog.Logger(t, 0), metrics.NoopMetrics, &rollup.Config{}, &sync.Config{SyncMode: sync.CLSync}, &testutils.MockL1Source{}, emitter, false)
 
 	// Head payload (lower block number)
 	head := &eth.ExecutionPayloadEnvelope{ExecutionPayload: &eth.ExecutionPayload{

--- a/op-node/rollup/finality/altda.go
+++ b/op-node/rollup/finality/altda.go
@@ -30,11 +30,12 @@ type AltDAFinalizer struct {
 // NewAltDAFinalizer creates a new AltDAFinalizer instance.
 // The finalizerCfg parameter is optional and may be nil to use default finality behavior.
 // When non-nil, any non-nil fields in finalizerCfg will override the defaults.
+// supervisorEnabled indicates if supervisor-based interop features are enabled.
 func NewAltDAFinalizer(ctx context.Context, log log.Logger, cfg *rollup.Config, finalizerCfg *Config,
 	l1Fetcher FinalizerL1Interface,
-	backend AltDABackend, ec EngineController) *AltDAFinalizer {
+	backend AltDABackend, ec EngineController, supervisorEnabled bool) *AltDAFinalizer {
 
-	inner := NewFinalizer(ctx, log, cfg, finalizerCfg, l1Fetcher, ec)
+	inner := NewFinalizer(ctx, log, cfg, finalizerCfg, l1Fetcher, ec, supervisorEnabled)
 
 	// In alt-da mode, the finalization signal is proxied through the AltDA manager.
 	// Finality signal will come from the DA contract or L1 finality whichever is last.

--- a/op-node/rollup/finality/altda_test.go
+++ b/op-node/rollup/finality/altda_test.go
@@ -108,7 +108,7 @@ func TestAltDAFinalityData(t *testing.T) {
 
 	emitter := &testutils.MockEmitter{}
 	ec := new(fakeEngineController)
-	fi := NewAltDAFinalizer(context.Background(), logger, cfg, nil, l1F, altDABackend, ec)
+	fi := NewAltDAFinalizer(context.Background(), logger, cfg, nil, l1F, altDABackend, ec, false)
 	fi.AttachEmitter(emitter)
 	require.NotNil(t, altDABackend.forwardTo, "altda backend must have access to underlying standard finalizer")
 

--- a/op-node/rollup/finality/finalizer.go
+++ b/op-node/rollup/finality/finalizer.go
@@ -105,6 +105,10 @@ type Finalizer struct {
 
 	cfg *rollup.Config
 
+	// supervisorEnabled indicates if supervisor-based interop features are enabled.
+	// When false, local finality continues even after interop activation.
+	supervisorEnabled bool
+
 	emitter event.Emitter
 
 	engineController EngineController
@@ -134,20 +138,22 @@ type Finalizer struct {
 // NewFinalizer creates a new Finalizer instance.
 // The finalizerCfg parameter is optional and may be nil to use default finality behavior.
 // When non-nil, any non-nil fields in finalizerCfg will override the defaults.
-func NewFinalizer(ctx context.Context, log log.Logger, cfg *rollup.Config, finalizerCfg *Config, l1Fetcher FinalizerL1Interface, ec EngineController) *Finalizer {
+// supervisorEnabled indicates if supervisor-based interop features are enabled.
+func NewFinalizer(ctx context.Context, log log.Logger, cfg *rollup.Config, finalizerCfg *Config, l1Fetcher FinalizerL1Interface, ec EngineController, supervisorEnabled bool) *Finalizer {
 	lookback := calcFinalityLookback(cfg, finalizerCfg)
 	delay := calcFinalityDelay(finalizerCfg)
 	return &Finalizer{
-		ctx:              ctx,
-		cfg:              cfg,
-		log:              log,
-		finalizedL1:      eth.L1BlockRef{},
-		engineController: ec,
-		triedFinalizeAt:  0,
-		finalityData:     make([]FinalityData, 0, lookback),
-		finalityLookback: lookback,
-		finalityDelay:    delay,
-		l1Fetcher:        l1Fetcher,
+		ctx:               ctx,
+		cfg:               cfg,
+		log:               log,
+		supervisorEnabled: supervisorEnabled,
+		finalizedL1:       eth.L1BlockRef{},
+		engineController:  ec,
+		triedFinalizeAt:   0,
+		finalityData:      make([]FinalityData, 0, lookback),
+		finalityLookback:  lookback,
+		finalityDelay:     delay,
+		l1Fetcher:         l1Fetcher,
 	}
 }
 
@@ -298,10 +304,10 @@ func (fi *Finalizer) onDerivedSafeBlock(l2Safe eth.L2BlockRef, derivedFrom eth.L
 	fi.mu.Lock()
 	defer fi.mu.Unlock()
 
-	// Stop registering blocks after interop.
+	// Stop registering blocks after interop only if supervisor is enabled.
 	// Finality in interop is determined by the superchain backend,
 	// i.e. the op-supervisor RPC identifies which L2 block may be finalized.
-	if fi.cfg.IsInterop(l2Safe.Time) {
+	if fi.cfg.IsInterop(l2Safe.Time) && fi.supervisorEnabled {
 		return
 	}
 

--- a/op-node/rollup/finality/finalizer_test.go
+++ b/op-node/rollup/finality/finalizer_test.go
@@ -194,7 +194,7 @@ func TestEngineQueue_Finalize(t *testing.T) {
 
 		emitter := &testutils.MockEmitter{}
 		ec := new(fakeEngineController)
-		fi := NewFinalizer(context.Background(), logger, &rollup.Config{}, nil, l1F, ec)
+		fi := NewFinalizer(context.Background(), logger, &rollup.Config{}, nil, l1F, ec, false)
 		fi.AttachEmitter(emitter)
 
 		// now say C1 was included in D and became the new safe head
@@ -229,7 +229,7 @@ func TestEngineQueue_Finalize(t *testing.T) {
 
 		emitter := &testutils.MockEmitter{}
 		ec := new(fakeEngineController)
-		fi := NewFinalizer(context.Background(), logger, &rollup.Config{}, nil, l1F, ec)
+		fi := NewFinalizer(context.Background(), logger, &rollup.Config{}, nil, l1F, ec, false)
 		fi.AttachEmitter(emitter)
 
 		// now say C1 was included in D and became the new safe head
@@ -268,7 +268,7 @@ func TestEngineQueue_Finalize(t *testing.T) {
 
 		emitter := &testutils.MockEmitter{}
 		ec := new(fakeEngineController)
-		fi := NewFinalizer(context.Background(), logger, &rollup.Config{}, nil, l1F, ec)
+		fi := NewFinalizer(context.Background(), logger, &rollup.Config{}, nil, l1F, ec, false)
 		fi.AttachEmitter(emitter)
 
 		fi.OnEvent(ctx, engine.SafeDerivedEvent{Safe: refC1, Source: refD})
@@ -352,7 +352,7 @@ func TestEngineQueue_Finalize(t *testing.T) {
 
 		emitter := &testutils.MockEmitter{}
 		ec := new(fakeEngineController)
-		fi := NewFinalizer(context.Background(), logger, &rollup.Config{}, nil, l1F, ec)
+		fi := NewFinalizer(context.Background(), logger, &rollup.Config{}, nil, l1F, ec, false)
 		fi.AttachEmitter(emitter)
 
 		// now say B1 was included in C and became the new safe head
@@ -389,7 +389,7 @@ func TestEngineQueue_Finalize(t *testing.T) {
 
 		emitter := &testutils.MockEmitter{}
 		ec := new(fakeEngineController)
-		fi := NewFinalizer(context.Background(), logger, &rollup.Config{}, nil, l1F, ec)
+		fi := NewFinalizer(context.Background(), logger, &rollup.Config{}, nil, l1F, ec, false)
 		fi.AttachEmitter(emitter)
 
 		// now say B1 was included in C and became the new safe head
@@ -473,9 +473,9 @@ func TestEngineQueue_Finalize(t *testing.T) {
 		emitter.AssertExpectations(t)
 	})
 
-	// The Finalizer does not promote any blocks to finalized status after interop.
+	// The Finalizer does not promote any blocks to finalized status after interop when supervisor is enabled.
 	// Blocks after interop are finalized with the interop deriver and interop backend.
-	t.Run("disable-after-interop", func(t *testing.T) {
+	t.Run("disable-after-interop-with-supervisor", func(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelInfo)
 		l1F := &testutils.MockL1Source{}
 		defer l1F.AssertExpectations(t)
@@ -484,9 +484,10 @@ func TestEngineQueue_Finalize(t *testing.T) {
 
 		emitter := &testutils.MockEmitter{}
 		ec := new(fakeEngineController)
+		// supervisorEnabled=true means finalization is handed off to supervisor after interop
 		fi := NewFinalizer(context.Background(), logger, &rollup.Config{
 			InteropTime: &refC1.Time,
-		}, nil, l1F, ec)
+		}, nil, l1F, ec, true)
 		fi.AttachEmitter(emitter)
 
 		// now say C0 and C1 were included in D and became the new safe head
@@ -503,6 +504,37 @@ func TestEngineQueue_Finalize(t *testing.T) {
 		require.Equal(t, refC0, ec.finalizedL2)
 		emitter.AssertExpectations(t)
 	})
+
+	// When supervisor is disabled, finalization continues even after interop activation
+	t.Run("continue-after-interop-without-supervisor", func(t *testing.T) {
+		logger := testlog.Logger(t, log.LevelInfo)
+		l1F := &testutils.MockL1Source{}
+		defer l1F.AssertExpectations(t)
+		l1F.ExpectL1BlockRefByNumber(refD.Number, refD, nil)
+		l1F.ExpectL1BlockRefByNumber(refD.Number, refD, nil)
+
+		emitter := &testutils.MockEmitter{}
+		ec := new(fakeEngineController)
+		// supervisorEnabled=false means local finalization continues even after interop
+		fi := NewFinalizer(context.Background(), logger, &rollup.Config{
+			InteropTime: &refC1.Time,
+		}, nil, l1F, ec, false)
+		fi.AttachEmitter(emitter)
+
+		// now say C0 and C1 were included in D and became the new safe head
+		fi.OnEvent(ctx, engine.SafeDerivedEvent{Safe: refC0, Source: refD})
+		fi.OnEvent(ctx, engine.SafeDerivedEvent{Safe: refC1, Source: refD})
+		fi.OnEvent(ctx, derive.DeriverIdleEvent{Origin: refD})
+		emitter.AssertExpectations(t)
+
+		emitter.ExpectOnce(TryFinalizeEvent{})
+		fi.OnL1Finalized(refD)
+
+		// With supervisor disabled, both C0 and C1 can be finalized (C1 is latest)
+		fi.OnEvent(ctx, TryFinalizeEvent{})
+		require.Equal(t, refC1, ec.finalizedL2)
+		emitter.AssertExpectations(t)
+	})
 }
 
 func TestFinalizerConfig(t *testing.T) {
@@ -516,7 +548,7 @@ func TestFinalizerConfig(t *testing.T) {
 			FinalityLookback: &customLookback,
 		}
 
-		fi := NewFinalizer(context.Background(), logger, &rollup.Config{}, finalizerCfg, l1F, ec)
+		fi := NewFinalizer(context.Background(), logger, &rollup.Config{}, finalizerCfg, l1F, ec, false)
 
 		require.Equal(t, customLookback, fi.finalityLookback, "should use custom finality lookback")
 		require.Equal(t, int(customLookback), cap(fi.finalityData), "finalityData capacity should match custom lookback")
@@ -532,7 +564,7 @@ func TestFinalizerConfig(t *testing.T) {
 			FinalityDelay: &customDelay,
 		}
 
-		fi := NewFinalizer(context.Background(), logger, &rollup.Config{}, finalizerCfg, l1F, ec)
+		fi := NewFinalizer(context.Background(), logger, &rollup.Config{}, finalizerCfg, l1F, ec, false)
 
 		require.Equal(t, customDelay, fi.finalityDelay, "should use custom finality delay")
 	})
@@ -542,7 +574,7 @@ func TestFinalizerConfig(t *testing.T) {
 		l1F := &testutils.MockL1Source{}
 		ec := new(fakeEngineController)
 
-		fi := NewFinalizer(context.Background(), logger, &rollup.Config{}, nil, l1F, ec)
+		fi := NewFinalizer(context.Background(), logger, &rollup.Config{}, nil, l1F, ec, false)
 
 		require.Equal(t, uint64(defaultFinalityLookback), fi.finalityLookback, "should use default finality lookback when config is nil")
 		require.Equal(t, uint64(finalityDelay), fi.finalityDelay, "should use default finality delay when config is nil")
@@ -556,7 +588,7 @@ func TestFinalizerConfig(t *testing.T) {
 		// Passing empty config should behave same as nil
 		finalizerCfg := &Config{}
 
-		fi := NewFinalizer(context.Background(), logger, &rollup.Config{}, finalizerCfg, l1F, ec)
+		fi := NewFinalizer(context.Background(), logger, &rollup.Config{}, finalizerCfg, l1F, ec, false)
 
 		require.Equal(t, uint64(defaultFinalityLookback), fi.finalityLookback, "should use default finality lookback when config fields are nil")
 		require.Equal(t, uint64(finalityDelay), fi.finalityDelay, "should use default finality delay when config fields are nil")
@@ -574,7 +606,7 @@ func TestFinalizerConfig(t *testing.T) {
 			},
 		}
 
-		fi := NewFinalizer(context.Background(), logger, cfg, nil, l1F, ec)
+		fi := NewFinalizer(context.Background(), logger, cfg, nil, l1F, ec, false)
 
 		expectedLookback := uint64(181) // 90 + 90 + 1
 		require.Equal(t, expectedLookback, fi.finalityLookback, "should use alt-da calculated lookback")
@@ -597,7 +629,7 @@ func TestFinalizerConfig(t *testing.T) {
 			FinalityLookback: &customLookback,
 		}
 
-		fi := NewFinalizer(context.Background(), logger, cfg, finalizerCfg, l1F, ec)
+		fi := NewFinalizer(context.Background(), logger, cfg, finalizerCfg, l1F, ec, false)
 
 		require.Equal(t, customLookback, fi.finalityLookback, "custom lookback should override alt-da calculation")
 	})

--- a/op-node/rollup/interop/config.go
+++ b/op-node/rollup/interop/config.go
@@ -13,8 +13,11 @@ import (
 )
 
 type Config struct {
+	// SupervisorEnabled enables supervisor-based interop features.
+	// When false, interop contracts deploy but supervisor logic stays disabled.
+	// Defaults to false as supervisor is deprecated.
+	SupervisorEnabled bool
 	// RPCAddr address to bind RPC server to, to serve external supervisor nodes.
-	// Optional. This will soon be required: running op-node without supervisor is being deprecated.
 	RPCAddr string
 	// RPCPort port to bind RPC server to, to serve external supervisor nodes.
 	// Binds to any available port if set to 0.
@@ -33,6 +36,10 @@ func (cfg *Config) Check() error {
 // Setup creates an interop sub-system. This drives the node syncing.
 // If setup returns a nil system (without error) the node should fall back to legacy mode.
 func (cfg *Config) Setup(ctx context.Context, logger log.Logger, rollupCfg *rollup.Config, l1 L1Source, l2 L2Source, m opmetrics.RPCMetricer) (SubSystem, error) {
+	if !cfg.SupervisorEnabled {
+		logger.Info("Supervisor disabled, using legacy sync mode")
+		return nil, nil // a `nil` system will result in legacy mode.
+	}
 	if cfg.RPCAddr == "" {
 		logger.Warn("No interop RPC configured, falling back to legacy sync mode.")
 		return nil, nil // a `nil` system will result in legacy mode.

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -151,9 +151,10 @@ func NewConfig(ctx cliiface.Context, log log.Logger) (*config.Config, error) {
 
 func NewSupervisorEndpointConfig(ctx cliiface.Context) *interop.Config {
 	return &interop.Config{
-		RPCAddr:          ctx.String(flags.InteropRPCAddr.Name),
-		RPCPort:          ctx.Int(flags.InteropRPCPort.Name),
-		RPCJwtSecretPath: ctx.String(flags.InteropJWTSecret.Name),
+		SupervisorEnabled: ctx.Bool(flags.InteropSupervisorEnabled.Name),
+		RPCAddr:           ctx.String(flags.InteropRPCAddr.Name),
+		RPCPort:           ctx.Int(flags.InteropRPCPort.Name),
+		RPCJwtSecretPath:  ctx.String(flags.InteropJWTSecret.Name),
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `--interop.supervisor-enabled` CLI flag (defaults to `false`)
- Allows deploying interop contracts without activating supervisor logic
- When disabled: local finality continues, cross-unsafe/cross-safe promotion happens locally
- When enabled: full supervisor integration as before (deprecated behavior)

This decouples contract deployment from supervisor activation, enabling testing of interop contracts independently.

## Test plan

- [x] Unit tests updated for both supervisor-enabled and supervisor-disabled modes
- [x] `go build ./op-node/...` passes
- [x] `go test ./op-node/rollup/finality/... ./op-node/rollup/engine/...` passes
- [ ] Integration testing with `InteropTime` set and `--interop.supervisor-enabled=false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)