### PR TITLE
op-node: Make sealing duration value configurable

### DIFF
--- a/op-e2e/actions/helpers/l2_sequencer.go
+++ b/op-e2e/actions/helpers/l2_sequencer.go
@@ -72,7 +72,7 @@ func NewL2Sequencer(t Testing, log log.Logger, l1 derive.L1Fetcher, blobSrc deri
 	seqStateListener := config.DisabledConfigPersistence{}
 	conduc := &conductor.NoOpConductor{}
 	asyncGossip := async.NoOpGossiper{}
-	seq := sequencing.NewSequencer(t.Ctx(), log, cfg, attrBuilder, l1OriginSelector,
+	seq := sequencing.NewSequencer(t.Ctx(), log, cfg, 0, attrBuilder, l1OriginSelector,
 		seqStateListener, conduc, asyncGossip, metr, ver.engine)
 	opts := event.WithEmitLimiter(
 		// TestSyncBatchType/DerivationWithFlakyL1RPC does *a lot* of quick retries

--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -271,6 +271,15 @@ var (
 		Value:    false,
 		Category: SequencerCategory,
 	}
+	SequencerSealingDurationFlag = &cli.DurationFlag{
+		Name: "sequencer.sealing-duration",
+		Usage: "This is the amount of the time the sequencer allocates to sealing the block " +
+			"(i.e. it will fetch the payload from the execution engine this much prior to the block's timestamp). " +
+			"If this is <= 0 it is automatically adjusted to 50ms.",
+		EnvVars:  prefixEnvVars("SEQUENCER_SEALING_DURATION"),
+		Value:    50 * time.Millisecond,
+		Category: SequencerCategory,
+	}
 	FinalityLookbackFlag = &cli.Uint64Flag{
 		Name:     "finality.lookback",
 		Usage:    "Number of L1 blocks to look back for finality verification. Uses default calculation if 0 (considers alt-DA challenge/resolve windows if applicable).",
@@ -482,6 +491,7 @@ var optionalFlags = []cli.Flag{
 	SequencerMaxSafeLagFlag,
 	SequencerL1Confs,
 	SequencerRecoverMode,
+	SequencerSealingDurationFlag,
 	FinalityLookbackFlag,
 	FinalityDelayFlag,
 	L1EpochPollIntervalFlag,

--- a/op-node/rollup/driver/config.go
+++ b/op-node/rollup/driver/config.go
@@ -1,6 +1,10 @@
 package driver
 
-import "github.com/ethereum-optimism/optimism/op-node/rollup/finality"
+import (
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup/finality"
+)
 
 type Config struct {
 	// VerifierConfDepth is the distance to keep from the L1 head when reading L1 data for L2 derivation.
@@ -26,6 +30,11 @@ type Config struct {
 	// RecoverMode forces the sequencer to select the next L1 Origin exactly, and create an empty block,
 	// to be compatible with verifiers forcefully generating the same block while catching up the sequencing window timeout.
 	RecoverMode bool `json:"recover_mode"`
+
+	// SequencerSealingDuration is the amount of the time the sequencer allocates to sealing the block
+	// (i.e. it will fetch the payload from the execution engine this much prior to the block's timestamp).
+	// If this is <= 0 it is automatically adjusted to 50ms.
+	SequencerSealingDuration time.Duration `json:"sequencer_sealing_duration"`
 
 	// Finalizer contains runtime configuration for finality behavior.
 	Finalizer *finality.Config `json:"finalizer,omitempty"`

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -119,7 +119,7 @@ func NewDriver(
 		// Connect origin selector to the engine controller for force reset notifications
 		ec.SetOriginSelectorResetter(findL1Origin)
 
-		sequencer = sequencing.NewSequencer(driverCtx, log, cfg, attrBuilder, findL1Origin,
+		sequencer = sequencing.NewSequencer(driverCtx, log, cfg, driverCfg.SequencerSealingDuration, attrBuilder, findL1Origin,
 			sequencerStateListener, sequencerConductor, asyncGossiper, metrics, ec)
 		sys.Register("sequencer", sequencer)
 	} else {

--- a/op-node/rollup/sequencing/sequencer.go
+++ b/op-node/rollup/sequencing/sequencer.go
@@ -21,9 +21,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/event"
 )
 
-// sealingDuration defines the expected time it takes to seal the block
-const sealingDuration = time.Millisecond * 50
-
 var (
 	ErrSequencerAlreadyStarted = errors.New("sequencer already running")
 	ErrSequencerAlreadyStopped = errors.New("sequencer not running")
@@ -82,9 +79,10 @@ type Sequencer struct {
 	// closed when driver system closes, to interrupt any ongoing API calls etc.
 	ctx context.Context
 
-	log       log.Logger
-	rollupCfg *rollup.Config
-	spec      *rollup.ChainSpec
+	log             log.Logger
+	rollupCfg       *rollup.Config
+	spec            *rollup.ChainSpec
+	sealingDuration time.Duration
 
 	maxSafeLag atomic.Uint64
 
@@ -131,6 +129,7 @@ type Sequencer struct {
 var _ SequencerIface = (*Sequencer)(nil)
 
 func NewSequencer(driverCtx context.Context, log log.Logger, rollupCfg *rollup.Config,
+	sealingDuration time.Duration,
 	attributesBuilder derive.AttributesBuilder,
 	l1OriginSelector L1OriginSelectorIface,
 	listener SequencerStateListener,
@@ -139,11 +138,15 @@ func NewSequencer(driverCtx context.Context, log log.Logger, rollupCfg *rollup.C
 	metrics Metrics,
 	eng attributes.EngineController,
 ) *Sequencer {
+	if sealingDuration <= 0 {
+		sealingDuration = time.Millisecond * 50
+	}
 	return &Sequencer{
 		ctx:              driverCtx,
 		log:              log,
 		rollupCfg:        rollupCfg,
 		spec:             rollup.NewChainSpec(rollupCfg),
+		sealingDuration:  sealingDuration,
 		listener:         listener,
 		conductor:        conductor,
 		asyncGossip:      asyncGossip,
@@ -238,11 +241,11 @@ func (d *Sequencer) onBuildStarted(x engine.BuildStartedEvent) {
 	now := d.timeNow()
 	payloadTime := time.Unix(int64(x.Parent.Time+d.rollupCfg.BlockTime), 0)
 	remainingTime := payloadTime.Sub(now)
-	if remainingTime < sealingDuration {
+	if remainingTime < d.sealingDuration {
 		d.nextAction = now // if there's not enough time for sealing, don't wait.
 	} else {
 		// finish with margin of sealing duration before payloadTime
-		d.nextAction = payloadTime.Add(-sealingDuration)
+		d.nextAction = payloadTime.Add(-d.sealingDuration)
 	}
 }
 

--- a/op-node/rollup/sequencing/sequencer.go
+++ b/op-node/rollup/sequencing/sequencer.go
@@ -21,6 +21,9 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/event"
 )
 
+// defaultSealingDuration defines the expected time it takes to seal the block
+const defaultSealingDuration = 50 * time.Millisecond
+
 var (
 	ErrSequencerAlreadyStarted = errors.New("sequencer already running")
 	ErrSequencerAlreadyStopped = errors.New("sequencer not running")
@@ -139,7 +142,7 @@ func NewSequencer(driverCtx context.Context, log log.Logger, rollupCfg *rollup.C
 	eng attributes.EngineController,
 ) *Sequencer {
 	if sealingDuration <= 0 {
-		sealingDuration = time.Millisecond * 50
+		sealingDuration = defaultSealingDuration
 	}
 	return &Sequencer{
 		ctx:              driverCtx,

--- a/op-node/rollup/sequencing/sequencer_test.go
+++ b/op-node/rollup/sequencing/sequencer_test.go
@@ -26,6 +26,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
 )
 
+const defaultSealingDuration = 50 * time.Millisecond
+
 type FakeAttributesBuilder struct {
 	cfg *rollup.Config
 	rng *rand.Rand
@@ -550,7 +552,7 @@ func TestSequencerBuild(t *testing.T) {
 	sealTargetTime, ok := seq.NextAction()
 	require.True(t, ok)
 	buildDuration := sealTargetTime.Sub(time.Unix(int64(head.Time), 0))
-	require.Equal(t, (time.Duration(deps.cfg.BlockTime)*time.Second)-sealingDuration, buildDuration)
+	require.Equal(t, (time.Duration(deps.cfg.BlockTime)*time.Second)-defaultSealingDuration, buildDuration)
 
 	// Now trigger the sequencer to start sealing
 	emitter.ExpectOnce(engine.BuildSealEvent{
@@ -731,7 +733,7 @@ func createSequencer(log log.Logger) (*Sequencer, *sequencerTestDeps) {
 		conductor:   &FakeConductor{},
 		asyncGossip: &FakeAsyncGossip{},
 	}
-	seq := NewSequencer(context.Background(), log, cfg, deps.attribBuilder,
+	seq := NewSequencer(context.Background(), log, cfg, defaultSealingDuration, deps.attribBuilder,
 		deps.l1OriginSelector, deps.seqState, deps.conductor,
 		deps.asyncGossip, metrics.NoopMetrics, fakeEngController{})
 	// We create mock payloads, with the epoch-id as tx[0], rather than proper L1Block-info deposit tx.

--- a/op-node/rollup/sequencing/sequencer_test.go
+++ b/op-node/rollup/sequencing/sequencer_test.go
@@ -26,8 +26,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
 )
 
-const defaultSealingDuration = 50 * time.Millisecond
-
 type FakeAttributesBuilder struct {
 	cfg *rollup.Config
 	rng *rand.Rand

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -214,12 +214,13 @@ func NewConfigPersistence(ctx cliiface.Context) config.ConfigPersistence {
 
 func NewDriverConfig(ctx cliiface.Context) *driver.Config {
 	cfg := &driver.Config{
-		VerifierConfDepth:   ctx.Uint64(flags.VerifierL1Confs.Name),
-		SequencerConfDepth:  ctx.Uint64(flags.SequencerL1Confs.Name),
-		SequencerEnabled:    ctx.Bool(flags.SequencerEnabledFlag.Name),
-		SequencerStopped:    ctx.Bool(flags.SequencerStoppedFlag.Name),
-		SequencerMaxSafeLag: ctx.Uint64(flags.SequencerMaxSafeLagFlag.Name),
-		RecoverMode:         ctx.Bool(flags.SequencerRecoverMode.Name),
+		VerifierConfDepth:        ctx.Uint64(flags.VerifierL1Confs.Name),
+		SequencerConfDepth:       ctx.Uint64(flags.SequencerL1Confs.Name),
+		SequencerEnabled:         ctx.Bool(flags.SequencerEnabledFlag.Name),
+		SequencerStopped:         ctx.Bool(flags.SequencerStoppedFlag.Name),
+		SequencerMaxSafeLag:      ctx.Uint64(flags.SequencerMaxSafeLagFlag.Name),
+		RecoverMode:              ctx.Bool(flags.SequencerRecoverMode.Name),
+		SequencerSealingDuration: ctx.Duration(flags.SequencerSealingDurationFlag.Name),
 	}
 
 	// Populate finality config from flags. A finality config with null fields


### PR DESCRIPTION
**Description**

This allows the sequencer sealing duration to be extended for setups that need more time to seal the block.

**Tests**

Existing tests should pass.