### PR TITLE
ci: Update golangci-lint to v2.

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,6 +1,6 @@
+version: "2"
 linters:
   enable:
-    - goimports
     - sqlclosecheck
     - bodyclose
     - asciicheck
@@ -13,24 +13,64 @@ linters:
 
     # Enabled by default but be explicit so it's easy to see what we're running
     - errcheck
-    - gosimple
     - govet
     - ineffassign
     - staticcheck
     - unused
-linters-settings:
-  # Require specifying all fields in op-deployer's OPCM input and output structs
-  exhaustruct:
-    include:
-      - '.*op-deployer/pkg/deployer/opcm\..*(Input|Output)$'
-issues:
-  exclude:
-    - 'errors.As'
-    - 'errors.Is'
-  exclude-rules:
-    # Only apply err113 to op-program/client
-    - path-except: 'op-program/client/.*'
-      linters:
-        - err113
-run:
-  timeout: 5m
+  settings:
+    # Require specifying all fields in op-deployer's OPCM input and output structs
+    exhaustruct:
+      include:
+        - .*op-deployer/pkg/deployer/opcm\..*(Input|Output)$
+    staticcheck:
+      checks:
+        - all
+
+        # Disabled checks
+        - -S1000 # should use for range instead of for { select {} }
+        - -QF1001 # could apply De Morgan's law
+        - -QF1002 # could use tagged switch
+        - -QF1003 # could use tagged switch
+        - -QF1006 # could lift into loop condition
+        - -QF1008 # could remove embedded field from selector (note: no benefit from this check)
+        - -QF1009 # want to use time.Time.Equal instead
+        - -QF1011 # could omit type from declaration; it will be inferred from the right-hand side
+        - -QF1012 # Use fmt.Fprintf(...) instead of WriteString(fmt.Sprintf(...))
+        - -ST1003 # capitalization of abbreviations
+        - -ST1005 # error strings should not end with punctuation or newlines
+        - -ST1008 # error should be returned as the last argument
+        - -ST1011 # var is of type time.Duration; don't use unit-specific suffix
+        - -ST1012 # error var mockErr should have name of the form errFoo
+        - -ST1016 # methods on the same type should have the same receiver name
+        - -ST1017 # don't use Yoda conditions
+        - -ST1019 # package is being imported more than once
+        - -ST1023 # should omit type from declaration; it will be inferred from the right-hand side
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      # Only apply err113 to op-program/client
+      - linters:
+          - err113
+        path-except: op-program/client/.*
+      - path: (.+)\.go$
+        text: errors.As
+      - path: (.+)\.go$
+        text: errors.Is
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/mise.toml
+++ b/mise.toml
@@ -2,7 +2,7 @@
 
 # Core dependencies
 go = "1.24.10"
-golangci-lint = "1.64.8"
+golangci-lint = "2.8.0"
 gotestsum = "1.12.3"
 mockery = "2.53.3"
 rust = "1.91.0"


### PR DESCRIPTION
**Description**

New checks added have been disabled to avoid needing to change code with the upgrade. We can decide which checks are useful and enable them individually with fixes.
