### PR TITLE
Avoid fallback download of artifacts when not on develop 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -231,18 +231,12 @@ commands:
       - run:
           name: Determine target branch for this pipeline
           command: |
-            TARGET_BRANCH=""
-            if [ -n "${CIRCLE_PULL_REQUEST:-}" ]; then
-              TARGET_BRANCH=$(curl -s "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls/${CIRCLE_PULL_REQUEST##*/}" | jq -r .base.ref)
-            fi
+            # Use the get-target-branch.sh script
+            source scripts/ops/get-target-branch.sh
 
-            # Fallbacks when not a PR or API did not return a branch
-            if [ -z "$TARGET_BRANCH" ] || [ "$TARGET_BRANCH" = "null" ]; then
-              TARGET_BRANCH="<< pipeline.git.branch >>"
-            fi
-
-            echo "Resolved TARGET_BRANCH=$TARGET_BRANCH"
+            # Make TARGET_BRANCH available to subsequent steps
             echo "export TARGET_BRANCH=$TARGET_BRANCH" >> "$BASH_ENV"
+          working_directory: packages/contracts-bedrock
 
   setup-features:
     description: "Set up dev and system feature environment variables. Features are auto-classified based on system_features registry."

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -948,7 +948,6 @@ jobs:
           name: Print forge version
           command: forge --version
           working_directory: packages/contracts-bedrock
-      - get-target-branch
       - pull-artifacts-conditional
       - go-restore-cache:
           namespace: packages/contracts-bedrock/scripts/go-ffi
@@ -1117,7 +1116,6 @@ jobs:
           name: Print forge version
           command: forge --version
           working_directory: packages/contracts-bedrock
-      - get-target-branch
       - pull-artifacts-conditional
       - run:
           name: Install lcov
@@ -1212,7 +1210,6 @@ jobs:
           name: Print forge version
           command: forge --version
           working_directory: packages/contracts-bedrock
-      - get-target-branch
       - pull-artifacts-conditional
       - run:
           name: Write pinned block number for cache key

--- a/packages/contracts-bedrock/scripts/checks/check-semver-diff.sh
+++ b/packages/contracts-bedrock/scripts/checks/check-semver-diff.sh
@@ -8,6 +8,10 @@ SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
 # shellcheck source=/dev/null
 source "$SCRIPT_DIR/utils/semver-utils.sh"
 
+# Determine the target branch.
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/../ops/get-target-branch.sh"
+
 # Path to semver-lock.json.
 SEMVER_LOCK="snapshots/semver-lock.json"
 
@@ -32,7 +36,6 @@ temp_dir=$(mktemp -d)
 trap 'rm -rf "$temp_dir"' EXIT
 
 # Exit early if semver-lock.json has not changed.
-TARGET_BRANCH="${TARGET_BRANCH:-develop}"
 UPSTREAM_REF="origin/${TARGET_BRANCH}"
 if ! {
   git diff "$UPSTREAM_REF"...HEAD --name-only

--- a/packages/contracts-bedrock/scripts/ops/get-target-branch.sh
+++ b/packages/contracts-bedrock/scripts/ops/get-target-branch.sh
@@ -1,34 +1,15 @@
 #!/usr/bin/env bash
 # Determines the PR target branch and exports TARGET_BRANCH
-# Can be sourced by other scripts: source scripts/ops/get-target-branch.sh
-# Or called with bash: TARGET_BRANCH=$(bash scripts/ops/get-target-branch.sh)
-
-set -euo pipefail
 
 TARGET_BRANCH=""
-
-# If this is a PR, get the target branch from GitHub API
 if [ -n "${CIRCLE_PULL_REQUEST:-}" ]; then
-  PR_NUMBER="${CIRCLE_PULL_REQUEST##*/}"
-  TARGET_BRANCH=$(curl -sS --fail --connect-timeout 10 --max-time 30 \
-    "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls/${PR_NUMBER}" \
-    2>/dev/null | jq -r .base.ref || echo "")
+  TARGET_BRANCH=$(curl -s "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls/${CIRCLE_PULL_REQUEST##*/}" | jq -r .base.ref)
 fi
 
 # Fallbacks when not a PR or API did not return a branch
 if [ -z "$TARGET_BRANCH" ] || [ "$TARGET_BRANCH" = "null" ]; then
-  # In CircleCI, use the current branch
-  # Locally or when CIRCLE_BRANCH isn't set, default to develop
   TARGET_BRANCH="${CIRCLE_BRANCH:-develop}"
 fi
 
 echo "Resolved TARGET_BRANCH=$TARGET_BRANCH" >&2
-
-# When sourced, export the variable. When called, output to stdout.
-if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
-  # Script is being sourced
-  export TARGET_BRANCH
-else
-  # Script is being executed
-  echo "$TARGET_BRANCH"
-fi
+export TARGET_BRANCH

--- a/packages/contracts-bedrock/scripts/ops/get-target-branch.sh
+++ b/packages/contracts-bedrock/scripts/ops/get-target-branch.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Determines the PR target branch and exports TARGET_BRANCH
+# Can be sourced by other scripts: source scripts/ops/get-target-branch.sh
+# Or called with bash: TARGET_BRANCH=$(bash scripts/ops/get-target-branch.sh)
+
+set -euo pipefail
+
+TARGET_BRANCH=""
+
+# If this is a PR, get the target branch from GitHub API
+if [ -n "${CIRCLE_PULL_REQUEST:-}" ]; then
+  PR_NUMBER="${CIRCLE_PULL_REQUEST##*/}"
+  TARGET_BRANCH=$(curl -sS --fail --connect-timeout 10 --max-time 30 \
+    "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls/${PR_NUMBER}" \
+    2>/dev/null | jq -r .base.ref || echo "")
+fi
+
+# Fallbacks when not a PR or API did not return a branch
+if [ -z "$TARGET_BRANCH" ] || [ "$TARGET_BRANCH" = "null" ]; then
+  # In CircleCI, use the current branch
+  # Locally or when CIRCLE_BRANCH isn't set, default to develop
+  TARGET_BRANCH="${CIRCLE_BRANCH:-develop}"
+fi
+
+echo "Resolved TARGET_BRANCH=$TARGET_BRANCH" >&2
+
+# When sourced, export the variable. When called, output to stdout.
+if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
+  # Script is being sourced
+  export TARGET_BRANCH
+else
+  # Script is being executed
+  echo "$TARGET_BRANCH"
+fi

--- a/packages/contracts-bedrock/scripts/ops/use-latest-fallback.sh
+++ b/packages/contracts-bedrock/scripts/ops/use-latest-fallback.sh
@@ -51,7 +51,8 @@ fi
 
 # Pull artifacts with or without fallback
 if [ "$USE_FALLBACK" = "true" ]; then
-  bash scripts/ops/pull-artifacts.sh --fallback-to-latest
+
+j  bash scripts/ops/pull-artifacts.sh --fallback-to-latest
 else
   bash scripts/ops/pull-artifacts.sh
 fi

--- a/packages/contracts-bedrock/scripts/ops/use-latest-fallback.sh
+++ b/packages/contracts-bedrock/scripts/ops/use-latest-fallback.sh
@@ -6,6 +6,10 @@ set -euo pipefail
 # - develop branch: Always build fresh (accuracy)
 # - force-use-fresh-artifacts label: Override fallback (emergency escape hatch)
 
+# Determine the target branch for this PR
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/get-target-branch.sh"
+
 USE_FALLBACK=false
 
 # Check if we're on a PR (not develop branch)
@@ -43,6 +47,7 @@ if [ "${CIRCLE_BRANCH:-}" != "develop" ]; then
   fi
 fi
 
+echo "TARGET_BRANCH=$TARGET_BRANCH"
 # Ensure that PRs targetting anything other than develop do not use the fallback
 TARGET_BRANCH="${TARGET_BRANCH:-unknown}"
 if [ "$TARGET_BRANCH" != "develop" ]; then

--- a/packages/contracts-bedrock/scripts/ops/use-latest-fallback.sh
+++ b/packages/contracts-bedrock/scripts/ops/use-latest-fallback.sh
@@ -8,6 +8,7 @@ set -euo pipefail
 
 # Determine the target branch for this PR
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
 source "$SCRIPT_DIR/get-target-branch.sh"
 
 USE_FALLBACK=false


### PR DESCRIPTION
This is a cherry pick onto the v6 proposal branch of https://github.com/ethereum-optimism/optimism/pull/18788.

## Summary

Avoids the fallback download of artifacts when not on `develop`. 

This is achieved by refactoring the `get-target-branch` logic from CircleCI config into a reusable script that can be sourced by the `use-latest-fallback` script

## Changes

- Created `scripts/ops/get-target-branch.sh` containing the target branch detection logic
- Updated `scripts/ops/use-latest-fallback.sh` to source the new script
- Updated `scripts/checks/check-semver-diff.sh` to source the new script
- Updated `.circleci/config.yml` to use the new script

## Benefits

- Scripts are now self-contained and determine TARGET_BRANCH themselves
- Can be tested locally without CircleCI environment variables
- Single source of truth for target branch logic
- Less duplication in CircleCI config

