### PR TITLE
ci: Fix `kona-publish-prestates`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -550,7 +550,7 @@ commands:
       features:
         description: "Comma-separated list of features to restore the cache for"
         type: string
-        default: ""
+        default: "default"
       prefix:
         description: "Prefix to add to the cache key"
         type: string
@@ -3126,8 +3126,8 @@ jobs:
           components: llvm-tools-preview
       - rust-prepare-and-restore-cache:
           directory: kona
-          binaries: kona-client
           needs_clang: true
+          profile: release
       - gcp-cli/install
       - gcp-oidc-authenticate:
           gcp_cred_config_file_path: /tmp/gcp_cred_config.json


### PR DESCRIPTION
**Description**

The `kona-publish-prestates` workflow was invoking `rust-prepare-and-restore-cache` with the wrong arguments.

```
Error calling workflow: 'kona-publish-prestates'
Error calling job: 'kona-publish-prestate-artifacts'
Error calling command: 'rust-prepare-and-restore-cache'
Unexpected argument(s): binaries
```
