### PR TITLE
fix(ci/proofs): publish the prestates to the right gcloud folder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3150,11 +3150,11 @@ jobs:
               echo "Publishing commit hash data"
               INFO_FILE=$(mktemp)
               (echo "Commit=<< pipeline.git.revision >>" && echo "Prestate: ${PRESTATE_HASH}") > "${INFO_FILE}"
-              gsutil cp "${INFO_FILE}" "gs://kona-proof-prestates/<<parameters.kind>>/${BRANCH_NAME}-<<parameters.version>>-prestate.bin.gz.txt"
+              gsutil cp "${INFO_FILE}" "gs://oplabs-network-data/proofs/kona/<<parameters.kind>>/${BRANCH_NAME}-<<parameters.version>>-prestate.bin.gz.txt"
               rm "${INFO_FILE}"
               PRESTATE_HASH="${BRANCH_NAME}-<<parameters.version>>"
             fi
-            gsutil cp ./prestate-artifacts-<<parameters.kind>>/prestate.bin.gz "gs://kona-proof-prestates/<<parameters.kind>>/${PRESTATE_HASH}.bin.gz"
+            gsutil cp ./prestate-artifacts-<<parameters.kind>>/prestate.bin.gz "gs://oplabs-network-data/proofs/kona/<<parameters.kind>>/${PRESTATE_HASH}.bin.gz"
             echo "Successfully published prestates artifacts to GCS"
 
   ### END KONA JOBS ###

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3116,8 +3116,9 @@ jobs:
       version:
         description: The version to build (kona-client, kona-client-int)
         type: string
-    docker:
-      - image: <<pipeline.parameters.default_docker_image>>
+    machine:
+      image: <<pipeline.parameters.base_image>>
+      docker_layer_caching: true # we rely on this for faster builds, and actively warm it up for builds with common stages
     resource_class: xlarge
     steps:
       - utils/checkout-with-mise:


### PR DESCRIPTION
## Description

Fix the kona-proof prestate job by publishing to the right folder