### PR TITLE
 feat(op-node): add SupervisorEnabled config in op-node

### DIFF
--- a/op-acceptance-tests/tests/interop/upgrade-no-supervisor/init_test.go
+++ b/op-acceptance-tests/tests/interop/upgrade-no-supervisor/init_test.go
@@ -1,0 +1,13 @@
+package upgrade
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+)
+
+func TestMain(m *testing.M) {
+	presets.DoMain(m,
+		presets.WithMinimalInteropNoSupervisor(),
+	)
+}

--- a/op-acceptance-tests/tests/interop/upgrade-no-supervisor/interop_contracts_test.go
+++ b/op-acceptance-tests/tests/interop/upgrade-no-supervisor/interop_contracts_test.go
@@ -1,0 +1,85 @@
+package upgrade
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
+	"github.com/ethereum-optimism/optimism/op-core/forks"
+	"github.com/ethereum-optimism/optimism/op-core/predeploys"
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// TestInteropContractsDeployed verifies that interop contracts are deployed at genesis
+// when supervisor is running but SupervisorEnabled=false in op-node.
+// Note: CrossL2Inbox is only deployed when there are 2+ chains in the dependency set.
+// This test uses a single-chain setup, so only L2ToL2CrossDomainMessenger is deployed.
+func TestInteropContractsDeployed(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewMinimalInteropNoSupervisor(t)
+	require := t.Require()
+	logger := t.Logger()
+
+	// Wait for interop activation - for interop at genesis this is block 0,
+	// but the upgrade transactions run in the first block
+	activationBlock := sys.L2ChainA.AwaitActivation(t, forks.Interop)
+	logger.Info("interop activated", "block", activationBlock.Number, "hash", activationBlock.Hash)
+
+	client := sys.L2ELA.Escape().L2EthClient()
+
+	// Verify L2ToL2CrossDomainMessenger is deployed
+	// (CrossL2Inbox is only deployed when there are 2+ chains in dependency set)
+	implAddrBytes, err := client.GetStorageAt(t.Ctx(), predeploys.L2toL2CrossDomainMessengerAddr,
+		genesis.ImplementationSlot, activationBlock.Hash.String())
+	require.NoError(err)
+	implAddr := common.BytesToAddress(implAddrBytes[:])
+	require.NotEqual(common.Address{}, implAddr, "L2ToL2CrossDomainMessenger should have implementation at %s",
+		predeploys.L2toL2CrossDomainMessengerAddr)
+
+	// Verify the implementation has code
+	code, err := client.CodeAtHash(t.Ctx(), implAddr, activationBlock.Hash)
+	require.NoError(err)
+	require.NotEmpty(code, "L2ToL2CrossDomainMessenger implementation should have code")
+
+	logger.Info("interop contracts deployed successfully with local finality (no supervisor coordination)")
+}
+
+// TestLocalFinalityWithoutSupervisor verifies that local finality and promotion work
+// correctly when interop is active but SupervisorEnabled=false in op-node.
+// The supervisor still runs (required by op-geth) but op-node doesn't wait for it.
+func TestLocalFinalityWithoutSupervisor(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewMinimalInteropNoSupervisor(t)
+	require := t.Require()
+	logger := t.Logger()
+
+	targetBlocks := uint64(5)
+
+	for i := 0; i < 30; i++ {
+		time.Sleep(time.Second * 2)
+
+		status := sys.L2CLA.SyncStatus()
+		require.NotNil(status)
+
+		logger.Info("chain status",
+			"unsafe", status.UnsafeL2.Number,
+			"safe", status.SafeL2.Number,
+			"finalized", status.FinalizedL2.Number,
+		)
+
+		// Without supervisor coordination (SupervisorEnabled=false), local promotion should work:
+		// - UnsafeL2 should advance (sequencer producing blocks)
+		// - SafeL2 should advance (after batches submitted to L1)
+
+		if status.UnsafeL2.Number >= targetBlocks &&
+			status.SafeL2.Number >= targetBlocks-2 {
+			logger.Info("local finality working without supervisor coordination!")
+			return
+		}
+	}
+
+	gt.Errorf("Expected unsafe >= %d and safe >= %d", targetBlocks, targetBlocks-2)
+	gt.FailNow()
+}

--- a/op-acceptance-tests/tests/interop/upgrade-no-supervisor/interop_contracts_test.go
+++ b/op-acceptance-tests/tests/interop/upgrade-no-supervisor/interop_contracts_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 // TestInteropContractsDeployed verifies that interop contracts are deployed at genesis
-// when supervisor is running but SupervisorEnabled=false in op-node.
+// without any supervisor running.
 // Note: CrossL2Inbox is only deployed when there are 2+ chains in the dependency set.
 // This test uses a single-chain setup, so only L2ToL2CrossDomainMessenger is deployed.
 func TestInteropContractsDeployed(gt *testing.T) {
@@ -24,10 +24,10 @@ func TestInteropContractsDeployed(gt *testing.T) {
 
 	// Wait for interop activation - for interop at genesis this is block 0,
 	// but the upgrade transactions run in the first block
-	activationBlock := sys.L2ChainA.AwaitActivation(t, forks.Interop)
+	activationBlock := sys.L2Chain.AwaitActivation(t, forks.Interop)
 	logger.Info("interop activated", "block", activationBlock.Number, "hash", activationBlock.Hash)
 
-	client := sys.L2ELA.Escape().L2EthClient()
+	client := sys.L2EL.Escape().L2EthClient()
 
 	// Verify L2ToL2CrossDomainMessenger is deployed
 	// (CrossL2Inbox is only deployed when there are 2+ chains in dependency set)
@@ -43,12 +43,11 @@ func TestInteropContractsDeployed(gt *testing.T) {
 	require.NoError(err)
 	require.NotEmpty(code, "L2ToL2CrossDomainMessenger implementation should have code")
 
-	logger.Info("interop contracts deployed successfully with local finality (no supervisor coordination)")
+	logger.Info("interop contracts deployed successfully without supervisor")
 }
 
 // TestLocalFinalityWithoutSupervisor verifies that local finality and promotion work
-// correctly when interop is active but SupervisorEnabled=false in op-node.
-// The supervisor still runs (required by op-geth) but op-node doesn't wait for it.
+// correctly when interop is active but no supervisor is running.
 func TestLocalFinalityWithoutSupervisor(gt *testing.T) {
 	t := devtest.SerialT(gt)
 	sys := presets.NewMinimalInteropNoSupervisor(t)
@@ -60,7 +59,7 @@ func TestLocalFinalityWithoutSupervisor(gt *testing.T) {
 	for i := 0; i < 30; i++ {
 		time.Sleep(time.Second * 2)
 
-		status := sys.L2CLA.SyncStatus()
+		status := sys.L2CL.SyncStatus()
 		require.NotNil(status)
 
 		logger.Info("chain status",
@@ -69,13 +68,13 @@ func TestLocalFinalityWithoutSupervisor(gt *testing.T) {
 			"finalized", status.FinalizedL2.Number,
 		)
 
-		// Without supervisor coordination (SupervisorEnabled=false), local promotion should work:
+		// Without supervisor, local promotion should work:
 		// - UnsafeL2 should advance (sequencer producing blocks)
 		// - SafeL2 should advance (after batches submitted to L1)
 
 		if status.UnsafeL2.Number >= targetBlocks &&
 			status.SafeL2.Number >= targetBlocks-2 {
-			logger.Info("local finality working without supervisor coordination!")
+			logger.Info("local finality working without supervisor!")
 			return
 		}
 	}

--- a/op-devstack/presets/interop.go
+++ b/op-devstack/presets/interop.go
@@ -257,17 +257,15 @@ func NewMultiSupervisorInterop(t devtest.T) *MultiSupervisorInterop {
 	return out
 }
 
-// MinimalInteropNoSupervisor is like SingleChainInterop but with SupervisorEnabled=false.
-// This enables testing interop contract deployment with local finality (no supervisor coordination).
-// The supervisor still runs (required by op-geth for interop) but op-node uses local promotion.
+// MinimalInteropNoSupervisor is like Minimal but with interop contracts deployed.
+// No supervisor is running - this tests interop contract deployment with local finality.
 type MinimalInteropNoSupervisor struct {
-	SingleChainInterop
+	Minimal
 }
 
-// WithMinimalInteropNoSupervisor specifies a single-chain interop system but without indexing mode.
-// This means SupervisorEnabled=false in op-node, so local finality is used.
+// WithMinimalInteropNoSupervisor specifies a minimal system with interop contracts but no supervisor.
 func WithMinimalInteropNoSupervisor() stack.CommonOption {
-	return stack.MakeCommon(sysgo.DefaultSingleChainInteropNoIndexingSystem(&sysgo.DefaultSingleChainInteropSystemIDs{}))
+	return stack.MakeCommon(sysgo.DefaultMinimalInteropSystem(&sysgo.DefaultMinimalSystemIDs{}))
 }
 
 // NewMinimalInteropNoSupervisor creates a MinimalInteropNoSupervisor preset for acceptance tests.
@@ -276,29 +274,29 @@ func NewMinimalInteropNoSupervisor(t devtest.T) *MinimalInteropNoSupervisor {
 	orch := Orchestrator()
 	orch.Hydrate(system)
 
-	t.Gate().GreaterOrEqual(len(system.Supervisors()), 1, "expected at least one supervisor")
-
 	l1Net := system.L1Network(match.FirstL1Network)
-	l2A := system.L2Network(match.Assume(t, match.L2ChainA))
+	l2 := system.L2Network(match.Assume(t, match.L2ChainA))
+	sequencerCL := l2.L2CLNode(match.Assume(t, match.WithSequencerActive(t.Ctx())))
+	sequencerEL := l2.L2ELNode(match.Assume(t, match.EngineFor(sequencerCL)))
+
 	out := &MinimalInteropNoSupervisor{
-		SingleChainInterop: SingleChainInterop{
-			Log:           t.Logger(),
-			T:             t,
-			system:        system,
-			Supervisor:    dsl.NewSupervisor(system.Supervisor(match.Assume(t, match.FirstSupervisor)), orch.ControlPlane()),
-			ControlPlane:  orch.ControlPlane(),
-			L1Network:     dsl.NewL1Network(l1Net),
-			L1EL:          dsl.NewL1ELNode(l1Net.L1ELNode(match.Assume(t, match.FirstL1EL))),
-			L2ChainA:      dsl.NewL2Network(l2A, orch.ControlPlane()),
-			L2ELA:         dsl.NewL2ELNode(l2A.L2ELNode(match.Assume(t, match.FirstL2EL)), orch.ControlPlane()),
-			L2CLA:         dsl.NewL2CLNode(l2A.L2CLNode(match.Assume(t, match.FirstL2CL)), orch.ControlPlane()),
-			Wallet:        dsl.NewRandomHDWallet(t, 30),
-			FaucetA:       dsl.NewFaucet(l2A.Faucet(match.Assume(t, match.FirstFaucet))),
-			L2BatcherA:    dsl.NewL2Batcher(l2A.L2Batcher(match.Assume(t, match.FirstL2Batcher))),
+		Minimal: Minimal{
+			Log:          t.Logger(),
+			T:            t,
+			ControlPlane: orch.ControlPlane(),
+			system:       system,
+			L1Network:    dsl.NewL1Network(l1Net),
+			L1EL:         dsl.NewL1ELNode(l1Net.L1ELNode(match.Assume(t, match.FirstL1EL))),
+			L2Chain:      dsl.NewL2Network(l2, orch.ControlPlane()),
+			L2Batcher:    dsl.NewL2Batcher(l2.L2Batcher(match.Assume(t, match.FirstL2Batcher))),
+			L2EL:         dsl.NewL2ELNode(sequencerEL, orch.ControlPlane()),
+			L2CL:         dsl.NewL2CLNode(sequencerCL, orch.ControlPlane()),
+			Wallet:       dsl.NewRandomHDWallet(t, 30),
+			FaucetL2:     dsl.NewFaucet(l2.Faucet(match.Assume(t, match.FirstFaucet))),
 		},
 	}
 	out.FaucetL1 = dsl.NewFaucet(out.L1Network.Escape().Faucet(match.Assume(t, match.FirstFaucet)))
 	out.FunderL1 = dsl.NewFunder(out.Wallet, out.FaucetL1, out.L1EL)
-	out.FunderA = dsl.NewFunder(out.Wallet, out.FaucetA, out.L2ELA)
+	out.FunderL2 = dsl.NewFunder(out.Wallet, out.FaucetL2, out.L2EL)
 	return out
 }

--- a/op-devstack/presets/interop.go
+++ b/op-devstack/presets/interop.go
@@ -256,3 +256,49 @@ func NewMultiSupervisorInterop(t devtest.T) *MultiSupervisorInterop {
 	}
 	return out
 }
+
+// MinimalInteropNoSupervisor is like SingleChainInterop but with SupervisorEnabled=false.
+// This enables testing interop contract deployment with local finality (no supervisor coordination).
+// The supervisor still runs (required by op-geth for interop) but op-node uses local promotion.
+type MinimalInteropNoSupervisor struct {
+	SingleChainInterop
+}
+
+// WithMinimalInteropNoSupervisor specifies a single-chain interop system but without indexing mode.
+// This means SupervisorEnabled=false in op-node, so local finality is used.
+func WithMinimalInteropNoSupervisor() stack.CommonOption {
+	return stack.MakeCommon(sysgo.DefaultSingleChainInteropNoIndexingSystem(&sysgo.DefaultSingleChainInteropSystemIDs{}))
+}
+
+// NewMinimalInteropNoSupervisor creates a MinimalInteropNoSupervisor preset for acceptance tests.
+func NewMinimalInteropNoSupervisor(t devtest.T) *MinimalInteropNoSupervisor {
+	system := shim.NewSystem(t)
+	orch := Orchestrator()
+	orch.Hydrate(system)
+
+	t.Gate().GreaterOrEqual(len(system.Supervisors()), 1, "expected at least one supervisor")
+
+	l1Net := system.L1Network(match.FirstL1Network)
+	l2A := system.L2Network(match.Assume(t, match.L2ChainA))
+	out := &MinimalInteropNoSupervisor{
+		SingleChainInterop: SingleChainInterop{
+			Log:           t.Logger(),
+			T:             t,
+			system:        system,
+			Supervisor:    dsl.NewSupervisor(system.Supervisor(match.Assume(t, match.FirstSupervisor)), orch.ControlPlane()),
+			ControlPlane:  orch.ControlPlane(),
+			L1Network:     dsl.NewL1Network(l1Net),
+			L1EL:          dsl.NewL1ELNode(l1Net.L1ELNode(match.Assume(t, match.FirstL1EL))),
+			L2ChainA:      dsl.NewL2Network(l2A, orch.ControlPlane()),
+			L2ELA:         dsl.NewL2ELNode(l2A.L2ELNode(match.Assume(t, match.FirstL2EL)), orch.ControlPlane()),
+			L2CLA:         dsl.NewL2CLNode(l2A.L2CLNode(match.Assume(t, match.FirstL2CL)), orch.ControlPlane()),
+			Wallet:        dsl.NewRandomHDWallet(t, 30),
+			FaucetA:       dsl.NewFaucet(l2A.Faucet(match.Assume(t, match.FirstFaucet))),
+			L2BatcherA:    dsl.NewL2Batcher(l2A.L2Batcher(match.Assume(t, match.FirstL2Batcher))),
+		},
+	}
+	out.FaucetL1 = dsl.NewFaucet(out.L1Network.Escape().Faucet(match.Assume(t, match.FirstFaucet)))
+	out.FunderL1 = dsl.NewFunder(out.Wallet, out.FaucetL1, out.L1EL)
+	out.FunderA = dsl.NewFunder(out.Wallet, out.FaucetA, out.L2ELA)
+	return out
+}

--- a/op-devstack/sysgo/l2_cl_opnode.go
+++ b/op-devstack/sysgo/l2_cl_opnode.go
@@ -309,9 +309,10 @@ func withOpNode(l2CLID stack.L2CLNodeID, l1CLID stack.L1CLNodeID, l1ELID stack.L
 				SequencerEnabled:   cfg.IsSequencer,
 				SequencerConfDepth: 2,
 			},
-			Rollup:        *l2Net.rollupCfg,
-			DependencySet: depSet,
-			P2PSigner:     p2pSignerSetup, // nil when not sequencer
+			Rollup:            *l2Net.rollupCfg,
+			DependencySet:     depSet,
+			SupervisorEnabled: cfg.IndexingMode,
+			P2PSigner:         p2pSignerSetup, // nil when not sequencer
 			RPC: oprpc.CLIConfig{
 				ListenAddr: "127.0.0.1",
 				// When L2CL starts, store its RPC port here

--- a/op-devstack/sysgo/l2_el_opgeth.go
+++ b/op-devstack/sysgo/l2_el_opgeth.go
@@ -196,10 +196,9 @@ func WithOpGeth(id stack.L2ELNodeID, opts ...L2ELOption) stack.Option[*Orchestra
 		useInterop := l2Net.genesis.Config.InteropTime != nil
 
 		supervisorRPC := ""
-		if useInterop {
-			require.NotNil(cfg.SupervisorID, "supervisor is required for interop")
+		if useInterop && cfg.SupervisorID != nil {
 			sup, ok := orch.supervisors.Get(*cfg.SupervisorID)
-			require.True(ok, "supervisor is required for interop")
+			require.True(ok, "supervisor not found")
 			supervisorRPC = sup.UserRPC()
 		}
 

--- a/op-devstack/sysgo/l2_el_opreth.go
+++ b/op-devstack/sysgo/l2_el_opreth.go
@@ -200,10 +200,9 @@ func WithOpReth(id stack.L2ELNodeID, opts ...L2ELOption) stack.Option[*Orchestra
 		useInterop := l2Net.genesis.Config.InteropTime != nil
 
 		supervisorRPC := ""
-		if useInterop {
-			require.NotNil(cfg.SupervisorID, "supervisor is required for interop")
+		if useInterop && cfg.SupervisorID != nil {
 			sup, ok := orch.supervisors.Get(*cfg.SupervisorID)
-			require.True(ok, "supervisor is required for interop")
+			require.True(ok, "supervisor not found")
 			supervisorRPC = sup.UserRPC()
 		}
 

--- a/op-devstack/sysgo/l2_proposer.go
+++ b/op-devstack/sysgo/l2_proposer.go
@@ -115,16 +115,15 @@ func WithProposerPostDeploy(orch *Orchestrator, proposerID stack.L2ProposerID, l
 		opt(proposerID, proposerCLIConfig)
 	}
 
-	// If interop is scheduled, or if we cannot do the pre-interop connection, then set up with supervisor
-	if l2Net.genesis.Config.InteropTime != nil || l2CLID == nil {
-		require.NotNil(supervisorID, "need supervisor to connect to in interop")
+	// If supervisor is available, use it. Otherwise, connect to L2 CL.
+	if supervisorID != nil {
 		supervisorNode, ok := orch.supervisors.Get(*supervisorID)
-		require.True(ok)
+		require.True(ok, "supervisor not found")
 		proposerCLIConfig.SupervisorRpcs = []string{supervisorNode.UserRPC()}
 	} else {
-		require.NotNil(l2CLID, "need L2 CL to connect to pre-interop")
+		require.NotNil(l2CLID, "need L2 CL to connect to when no supervisor")
 		l2CL, ok := orch.l2CLs.Get(*l2CLID)
-		require.True(ok)
+		require.True(ok, "L2 CL not found")
 		proposerCLIConfig.RollupRpc = l2CL.UserRPC()
 	}
 

--- a/op-devstack/sysgo/system.go
+++ b/op-devstack/sysgo/system.go
@@ -337,6 +337,53 @@ func DefaultSingleChainInteropSystem(dest *DefaultSingleChainInteropSystemIDs) s
 	return opt
 }
 
+// DefaultSingleChainInteropNoIndexingSystem creates a single-chain interop system without indexing mode.
+// This means SupervisorEnabled=false in op-node, so local finality is used instead of supervisor coordination.
+// The supervisor still runs (required by op-geth and proposer for interop).
+func DefaultSingleChainInteropNoIndexingSystem(dest *DefaultSingleChainInteropSystemIDs) stack.Option[*Orchestrator] {
+	ids := NewDefaultSingleChainInteropSystemIDs(DefaultL1ID, DefaultL2AID)
+	opt := stack.Combine[*Orchestrator]()
+
+	opt.Add(stack.BeforeDeploy(func(o *Orchestrator) {
+		o.P().Logger().Info("Setting up (no indexing mode)")
+	}))
+
+	opt.Add(WithMnemonicKeys(devkeys.TestMnemonic))
+
+	opt.Add(WithDeployer(),
+		WithDeployerOptions(
+			WithLocalContractSources(),
+			WithCommons(ids.L1.ChainID()),
+			WithPrefundedL2(ids.L1.ChainID(), ids.L2A.ChainID()),
+			WithInteropAtGenesis(),
+		),
+	)
+
+	opt.Add(WithL1Nodes(ids.L1EL, ids.L1CL))
+
+	opt.Add(WithSupervisor(ids.Supervisor, ids.Cluster, ids.L1EL))
+
+	// Note: L2CLSequencer() but NOT L2CLIndexing() - this means SupervisorEnabled=false in op-node
+	opt.Add(WithL2ELNode(ids.L2AEL, L2ELWithSupervisor(ids.Supervisor)))
+	opt.Add(WithL2CLNode(ids.L2ACL, ids.L1CL, ids.L1EL, ids.L2AEL, L2CLSequencer()))
+	opt.Add(WithTestSequencer(ids.TestSequencer, ids.L1CL, ids.L2ACL, ids.L1EL, ids.L2AEL))
+	opt.Add(WithBatcher(ids.L2ABatcher, ids.L1EL, ids.L2ACL, ids.L2AEL))
+
+	// Note: NOT using WithManagedBySupervisor - local finality should work without supervisor coordination
+	// Proposer still needs supervisor connection for interop
+	opt.Add(WithProposer(ids.L2AProposer, ids.L1EL, &ids.L2ACL, &ids.Supervisor))
+
+	opt.Add(WithFaucets([]stack.L1ELNodeID{ids.L1EL}, []stack.L2ELNodeID{ids.L2AEL}))
+
+	opt.Add(WithL2MetricsDashboard())
+
+	opt.Add(stack.Finally(func(orch *Orchestrator) {
+		*dest = ids
+	}))
+
+	return opt
+}
+
 // baseInteropSystem defines a system that supports interop with a single chain
 // Components which are shared across multiple chains are not started, allowing them to be added later including
 // any additional chains that have been added.

--- a/op-devstack/sysgo/system.go
+++ b/op-devstack/sysgo/system.go
@@ -337,15 +337,14 @@ func DefaultSingleChainInteropSystem(dest *DefaultSingleChainInteropSystemIDs) s
 	return opt
 }
 
-// DefaultSingleChainInteropNoIndexingSystem creates a single-chain interop system without indexing mode.
-// This means SupervisorEnabled=false in op-node, so local finality is used instead of supervisor coordination.
-// The supervisor still runs (required by op-geth and proposer for interop).
-func DefaultSingleChainInteropNoIndexingSystem(dest *DefaultSingleChainInteropSystemIDs) stack.Option[*Orchestrator] {
-	ids := NewDefaultSingleChainInteropSystemIDs(DefaultL1ID, DefaultL2AID)
+// DefaultMinimalInteropSystem creates a minimal system with interop contracts but no supervisor.
+// This tests interop contract deployment with local finality (SupervisorEnabled=false in op-node).
+func DefaultMinimalInteropSystem(dest *DefaultMinimalSystemIDs) stack.Option[*Orchestrator] {
+	ids := NewDefaultMinimalSystemIDs(DefaultL1ID, DefaultL2AID)
 	opt := stack.Combine[*Orchestrator]()
 
 	opt.Add(stack.BeforeDeploy(func(o *Orchestrator) {
-		o.P().Logger().Info("Setting up (no indexing mode)")
+		o.P().Logger().Info("Setting up minimal interop (no supervisor)")
 	}))
 
 	opt.Add(WithMnemonicKeys(devkeys.TestMnemonic))
@@ -354,26 +353,21 @@ func DefaultSingleChainInteropNoIndexingSystem(dest *DefaultSingleChainInteropSy
 		WithDeployerOptions(
 			WithLocalContractSources(),
 			WithCommons(ids.L1.ChainID()),
-			WithPrefundedL2(ids.L1.ChainID(), ids.L2A.ChainID()),
+			WithPrefundedL2(ids.L1.ChainID(), ids.L2.ChainID()),
 			WithInteropAtGenesis(),
 		),
 	)
 
 	opt.Add(WithL1Nodes(ids.L1EL, ids.L1CL))
 
-	opt.Add(WithSupervisor(ids.Supervisor, ids.Cluster, ids.L1EL))
+	// No supervisor - interop with local finality only
+	opt.Add(WithL2ELNode(ids.L2EL))
+	opt.Add(WithL2CLNode(ids.L2CL, ids.L1CL, ids.L1EL, ids.L2EL, L2CLSequencer()))
+	opt.Add(WithTestSequencer(ids.TestSequencer, ids.L1CL, ids.L2CL, ids.L1EL, ids.L2EL))
+	opt.Add(WithBatcher(ids.L2Batcher, ids.L1EL, ids.L2CL, ids.L2EL))
+	opt.Add(WithProposer(ids.L2Proposer, ids.L1EL, &ids.L2CL, nil))
 
-	// Note: L2CLSequencer() but NOT L2CLIndexing() - this means SupervisorEnabled=false in op-node
-	opt.Add(WithL2ELNode(ids.L2AEL, L2ELWithSupervisor(ids.Supervisor)))
-	opt.Add(WithL2CLNode(ids.L2ACL, ids.L1CL, ids.L1EL, ids.L2AEL, L2CLSequencer()))
-	opt.Add(WithTestSequencer(ids.TestSequencer, ids.L1CL, ids.L2ACL, ids.L1EL, ids.L2AEL))
-	opt.Add(WithBatcher(ids.L2ABatcher, ids.L1EL, ids.L2ACL, ids.L2AEL))
-
-	// Note: NOT using WithManagedBySupervisor - local finality should work without supervisor coordination
-	// Proposer still needs supervisor connection for interop
-	opt.Add(WithProposer(ids.L2AProposer, ids.L1EL, &ids.L2ACL, &ids.Supervisor))
-
-	opt.Add(WithFaucets([]stack.L1ELNodeID{ids.L1EL}, []stack.L2ELNodeID{ids.L2AEL}))
+	opt.Add(WithFaucets([]stack.L1ELNodeID{ids.L1EL}, []stack.L2ELNodeID{ids.L2EL}))
 
 	opt.Add(WithL2MetricsDashboard())
 

--- a/op-e2e/actions/helpers/l2_verifier.go
+++ b/op-e2e/actions/helpers/l2_verifier.go
@@ -146,8 +146,11 @@ func NewL2Verifier(t Testing, log log.Logger, l1 derive.L1Fetcher,
 		})
 	}
 
+	// supervisorEnabled when interop system is active
+	supervisorEnabled := interopSys != nil
+
 	metrics := &testutils.TestDerivationMetrics{}
-	ec := engine.NewEngineController(ctx, eng, log, opnodemetrics.NoopMetrics, cfg, syncCfg, l1, sys.Register("engine-controller", nil, opts))
+	ec := engine.NewEngineController(ctx, eng, log, opnodemetrics.NoopMetrics, cfg, syncCfg, supervisorEnabled, l1, sys.Register("engine-controller", nil, opts))
 
 	if mm, ok := interopSys.(*indexing.IndexingMode); ok {
 		mm.SetEngineController(ec)
@@ -155,9 +158,9 @@ func NewL2Verifier(t Testing, log log.Logger, l1 derive.L1Fetcher,
 
 	var finalizer driver.Finalizer
 	if cfg.AltDAEnabled() {
-		finalizer = finality.NewAltDAFinalizer(ctx, log, cfg, nil, l1, altDASrc, ec)
+		finalizer = finality.NewAltDAFinalizer(ctx, log, cfg, nil, supervisorEnabled, l1, altDASrc, ec)
 	} else {
-		finalizer = finality.NewFinalizer(ctx, log, cfg, nil, l1, ec)
+		finalizer = finality.NewFinalizer(ctx, log, cfg, nil, supervisorEnabled, l1, ec)
 	}
 	sys.Register("finalizer", finalizer, opts)
 
@@ -165,7 +168,7 @@ func NewL2Verifier(t Testing, log log.Logger, l1 derive.L1Fetcher,
 	sys.Register("attributes-handler", attrHandler, opts)
 	ec.SetAttributesResetter(attrHandler)
 
-	indexingMode := interopSys != nil
+	indexingMode := supervisorEnabled
 	pipeline := derive.NewDerivationPipeline(log, cfg, depSet, l1, blobsSrc, altDASrc, eng, metrics, indexingMode, l1ChainConfig)
 	pipelineDeriver := derive.NewPipelineDeriver(ctx, pipeline)
 	sys.Register("pipeline", pipelineDeriver, opts)

--- a/op-e2e/interop/supersystem_l2.go
+++ b/op-e2e/interop/supersystem_l2.go
@@ -172,8 +172,9 @@ func (s *interopE2ESystem) newNodeForL2(
 		Driver: driver.Config{
 			SequencerEnabled: isSequencer,
 		},
-		Rollup:        *l2Out.RollupCfg,
-		DependencySet: depSet,
+		Rollup:            *l2Out.RollupCfg,
+		DependencySet:     depSet,
+		SupervisorEnabled: true,
 		P2PSigner: &p2p.PreparedSigner{
 			Signer: opsigner.NewLocalSigner(&p2pKey)},
 		RPC: oprpc.CLIConfig{

--- a/op-node/config/config.go
+++ b/op-node/config/config.go
@@ -93,6 +93,11 @@ type Config struct {
 
 	// Experimental. Enables new opstack RPC namespace. Used by op-test-sequencer.
 	ExperimentalOPStackAPI bool
+
+	// SupervisorEnabled indicates whether supervisor-based interop features are enabled.
+	// When false (default), interop contracts deploy but cross-chain coordination is handled locally.
+	// When true, the node defers cross-unsafe/cross-safe/finality to the supervisor.
+	SupervisorEnabled bool
 }
 
 // ConductorRPCFunc retrieves the endpoint. The RPC may not immediately be available.

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -567,7 +567,7 @@ func initL2(ctx context.Context, cfg *config.Config, node *OpNode) (*sources.Eng
 	}
 
 	indexingMode := false
-	sys, err := cfg.InteropConfig.Setup(ctx, node.log, &node.cfg.Rollup, node.l1Source, l2Source, node.metrics)
+	sys, err := cfg.InteropConfig.Setup(ctx, node.log, &node.cfg.Rollup, cfg.SupervisorEnabled, node.l1Source, l2Source, node.metrics)
 	if err != nil {
 		return nil, nil, nil, nil, fmt.Errorf("failed to setup interop: %w", err)
 	} else if sys != nil { // we continue with legacy mode if no interop sub-system is set up.

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -60,15 +60,15 @@ func NewDriver(
 	l1 = metered.NewMeteredL1Fetcher(l1Tracker, metrics)
 	verifConfDepth := confdepth.NewConfDepth(driverCfg.VerifierConfDepth, statusTracker.L1Head, l1)
 
-	ec := engine.NewEngineController(driverCtx, l2, log, metrics, cfg, syncCfg, l1, sys.Register("engine-controller", nil))
+	ec := engine.NewEngineController(driverCtx, l2, log, metrics, cfg, syncCfg, indexingMode, l1, sys.Register("engine-controller", nil))
 	// TODO(#17115): Refactor dependency cycles
 	ec.SetCrossUpdateHandler(statusTracker)
 
 	var finalizer Finalizer
 	if cfg.AltDAEnabled() {
-		finalizer = finality.NewAltDAFinalizer(driverCtx, log, cfg, driverCfg.Finalizer, l1, altDA, ec)
+		finalizer = finality.NewAltDAFinalizer(driverCtx, log, cfg, driverCfg.Finalizer, indexingMode, l1, altDA, ec)
 	} else {
-		finalizer = finality.NewFinalizer(driverCtx, log, cfg, driverCfg.Finalizer, l1, ec)
+		finalizer = finality.NewFinalizer(driverCtx, log, cfg, driverCfg.Finalizer, indexingMode, l1, ec)
 	}
 	sys.Register("finalizer", finalizer)
 

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -94,15 +94,16 @@ type CrossUpdateHandler interface {
 }
 
 type EngineController struct {
-	engine     ExecEngine // Underlying execution engine RPC
-	log        log.Logger
-	metrics    opmetrics.Metricer
-	syncCfg    *sync.Config
-	syncStatus syncStatusEnum
-	chainSpec  *rollup.ChainSpec
-	rollupCfg  *rollup.Config
-	elStart    time.Time
-	clock      clock.Clock
+	engine            ExecEngine // Underlying execution engine RPC
+	log               log.Logger
+	metrics           opmetrics.Metricer
+	syncCfg           *sync.Config
+	syncStatus        syncStatusEnum
+	chainSpec         *rollup.ChainSpec
+	rollupCfg         *rollup.Config
+	supervisorEnabled bool
+	elStart           time.Time
+	clock             clock.Clock
 
 	// L1 chain for reset functionality
 	l1 sync.L1Chain
@@ -163,7 +164,7 @@ type EngineController struct {
 var _ event.Deriver = (*EngineController)(nil)
 
 func NewEngineController(ctx context.Context, engine ExecEngine, log log.Logger, m opmetrics.Metricer,
-	rollupCfg *rollup.Config, syncCfg *sync.Config, l1 sync.L1Chain, emitter event.Emitter,
+	rollupCfg *rollup.Config, syncCfg *sync.Config, supervisorEnabled bool, l1 sync.L1Chain, emitter event.Emitter,
 ) *EngineController {
 	syncStatus := syncStatusCL
 	if syncCfg.SyncMode == sync.ELSync {
@@ -171,18 +172,19 @@ func NewEngineController(ctx context.Context, engine ExecEngine, log log.Logger,
 	}
 
 	return &EngineController{
-		engine:         engine,
-		log:            log,
-		metrics:        m,
-		chainSpec:      rollup.NewChainSpec(rollupCfg),
-		rollupCfg:      rollupCfg,
-		syncCfg:        syncCfg,
-		syncStatus:     syncStatus,
-		clock:          clock.SystemClock,
-		l1:             l1,
-		ctx:            ctx,
-		emitter:        emitter,
-		unsafePayloads: NewPayloadsQueue(log, maxUnsafePayloadsMemory, payloadMemSize),
+		engine:            engine,
+		log:               log,
+		metrics:           m,
+		chainSpec:         rollup.NewChainSpec(rollupCfg),
+		rollupCfg:         rollupCfg,
+		supervisorEnabled: supervisorEnabled,
+		syncCfg:           syncCfg,
+		syncStatus:        syncStatus,
+		clock:             clock.SystemClock,
+		l1:                l1,
+		ctx:               ctx,
+		emitter:           emitter,
+		unsafePayloads:    NewPayloadsQueue(log, maxUnsafePayloadsMemory, payloadMemSize),
 	}
 }
 func (e *EngineController) UnsafeL2Head() eth.L2BlockRef {
@@ -712,8 +714,8 @@ func (e *EngineController) OnEvent(ctx context.Context, ev event.Event) bool {
 	//  PromoteSafeEvent fan out is updated to procedural PromoteSafe method call
 	switch x := ev.(type) {
 	case UnsafeUpdateEvent:
-		// pre-interop everything that is local-unsafe is also immediately cross-unsafe.
-		if !e.rollupCfg.IsInterop(x.Ref.Time) {
+		// pre-interop (or if supervisor disabled) everything that is local-unsafe is also immediately cross-unsafe.
+		if !e.rollupCfg.IsInterop(x.Ref.Time) || !e.supervisorEnabled {
 			e.emitter.Emit(ctx, PromoteCrossUnsafeEvent(x))
 		}
 		// Try to apply the forkchoice changes
@@ -722,8 +724,8 @@ func (e *EngineController) OnEvent(ctx context.Context, ev event.Event) bool {
 		e.SetCrossUnsafeHead(x.Ref)
 		e.onUnsafeUpdate(ctx, x.Ref, e.unsafeHead)
 	case LocalSafeUpdateEvent:
-		// pre-interop everything that is local-safe is also immediately cross-safe.
-		if !e.rollupCfg.IsInterop(x.Ref.Time) {
+		// pre-interop (or if supervisor disabled) everything that is local-safe is also immediately cross-safe.
+		if !e.rollupCfg.IsInterop(x.Ref.Time) || !e.supervisorEnabled {
 			e.PromoteSafe(ctx, x.Ref, x.Source)
 		}
 	case InteropInvalidateBlockEvent:

--- a/op-node/rollup/engine/engine_controller_test.go
+++ b/op-node/rollup/engine/engine_controller_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestInvalidPayloadDropsHead(t *testing.T) {
 	emitter := &testutils.MockEmitter{}
-	ec := NewEngineController(context.Background(), nil, testlog.Logger(t, 0), metrics.NoopMetrics, &rollup.Config{}, &sync.Config{}, &testutils.MockL1Source{}, emitter)
+	ec := NewEngineController(context.Background(), nil, testlog.Logger(t, 0), metrics.NoopMetrics, &rollup.Config{}, &sync.Config{}, false, &testutils.MockL1Source{}, emitter)
 
 	payload := &eth.ExecutionPayloadEnvelope{ExecutionPayload: &eth.ExecutionPayload{
 		BlockHash: common.Hash{0x01},
@@ -110,7 +110,7 @@ func TestOnUnsafePayload_EnqueueEmit(t *testing.T) {
 	cfg, _, _, payloadA1 := buildSimpleCfgAndPayload(t)
 
 	emitter := &testutils.MockEmitter{}
-	ec := NewEngineController(context.Background(), nil, testlog.Logger(t, 0), metrics.NoopMetrics, cfg, &sync.Config{}, &testutils.MockL1Source{}, emitter)
+	ec := NewEngineController(context.Background(), nil, testlog.Logger(t, 0), metrics.NoopMetrics, cfg, &sync.Config{}, false, &testutils.MockL1Source{}, emitter)
 
 	emitter.ExpectOnce(PayloadInvalidEvent{})
 	emitter.ExpectOnce(ForkchoiceUpdateEvent{})
@@ -127,7 +127,7 @@ func TestOnForkchoiceUpdate_ProcessRetryAndPop(t *testing.T) {
 
 	emitter := &testutils.MockEmitter{}
 	mockEngine := &testutils.MockEngine{}
-	cl := NewEngineController(context.Background(), mockEngine, testlog.Logger(t, 0), metrics.NoopMetrics, cfg, &sync.Config{SyncMode: sync.CLSync}, &testutils.MockL1Source{}, emitter)
+	cl := NewEngineController(context.Background(), mockEngine, testlog.Logger(t, 0), metrics.NoopMetrics, cfg, &sync.Config{SyncMode: sync.CLSync}, false, &testutils.MockL1Source{}, emitter)
 
 	// queue payload A1
 	emitter.ExpectOnceType("UnsafeUpdateEvent")
@@ -156,7 +156,7 @@ func TestPeekUnsafePayload(t *testing.T) {
 	cfg, _, _, payloadA1 := buildSimpleCfgAndPayload(t)
 
 	emitter := &testutils.MockEmitter{}
-	ec := NewEngineController(context.Background(), nil, testlog.Logger(t, 0), metrics.NoopMetrics, cfg, &sync.Config{SyncMode: sync.CLSync}, &testutils.MockL1Source{}, emitter)
+	ec := NewEngineController(context.Background(), nil, testlog.Logger(t, 0), metrics.NoopMetrics, cfg, &sync.Config{SyncMode: sync.CLSync}, false, &testutils.MockL1Source{}, emitter)
 
 	// empty -> zero
 	_, ref := ec.PeekUnsafePayload()
@@ -174,7 +174,7 @@ func TestPeekUnsafePayload(t *testing.T) {
 func TestPeekUnsafePayload_OnDeriveErrorReturnsZero(t *testing.T) {
 	// missing L1-info in txs will cause derive error
 	emitter := &testutils.MockEmitter{}
-	ec := NewEngineController(context.Background(), nil, testlog.Logger(t, 0), metrics.NoopMetrics, &rollup.Config{}, &sync.Config{SyncMode: sync.CLSync}, &testutils.MockL1Source{}, emitter)
+	ec := NewEngineController(context.Background(), nil, testlog.Logger(t, 0), metrics.NoopMetrics, &rollup.Config{}, &sync.Config{SyncMode: sync.CLSync}, false, &testutils.MockL1Source{}, emitter)
 
 	bad := &eth.ExecutionPayloadEnvelope{ExecutionPayload: &eth.ExecutionPayload{BlockNumber: 1, BlockHash: common.Hash{0xaa}}}
 	_ = ec.unsafePayloads.Push(bad)
@@ -184,7 +184,7 @@ func TestPeekUnsafePayload_OnDeriveErrorReturnsZero(t *testing.T) {
 
 func TestInvalidPayloadForNonHead_NoDrop(t *testing.T) {
 	emitter := &testutils.MockEmitter{}
-	ec := NewEngineController(context.Background(), nil, testlog.Logger(t, 0), metrics.NoopMetrics, &rollup.Config{}, &sync.Config{SyncMode: sync.CLSync}, &testutils.MockL1Source{}, emitter)
+	ec := NewEngineController(context.Background(), nil, testlog.Logger(t, 0), metrics.NoopMetrics, &rollup.Config{}, &sync.Config{SyncMode: sync.CLSync}, false, &testutils.MockL1Source{}, emitter)
 
 	// Head payload (lower block number)
 	head := &eth.ExecutionPayloadEnvelope{ExecutionPayload: &eth.ExecutionPayload{

--- a/op-node/rollup/finality/altda.go
+++ b/op-node/rollup/finality/altda.go
@@ -30,11 +30,11 @@ type AltDAFinalizer struct {
 // NewAltDAFinalizer creates a new AltDAFinalizer instance.
 // The finalizerCfg parameter is optional and may be nil to use default finality behavior.
 // When non-nil, any non-nil fields in finalizerCfg will override the defaults.
-func NewAltDAFinalizer(ctx context.Context, log log.Logger, cfg *rollup.Config, finalizerCfg *Config,
+func NewAltDAFinalizer(ctx context.Context, log log.Logger, cfg *rollup.Config, finalizerCfg *Config, supervisorEnabled bool,
 	l1Fetcher FinalizerL1Interface,
 	backend AltDABackend, ec EngineController) *AltDAFinalizer {
 
-	inner := NewFinalizer(ctx, log, cfg, finalizerCfg, l1Fetcher, ec)
+	inner := NewFinalizer(ctx, log, cfg, finalizerCfg, supervisorEnabled, l1Fetcher, ec)
 
 	// In alt-da mode, the finalization signal is proxied through the AltDA manager.
 	// Finality signal will come from the DA contract or L1 finality whichever is last.

--- a/op-node/rollup/finality/altda_test.go
+++ b/op-node/rollup/finality/altda_test.go
@@ -108,7 +108,7 @@ func TestAltDAFinalityData(t *testing.T) {
 
 	emitter := &testutils.MockEmitter{}
 	ec := new(fakeEngineController)
-	fi := NewAltDAFinalizer(context.Background(), logger, cfg, nil, l1F, altDABackend, ec)
+	fi := NewAltDAFinalizer(context.Background(), logger, cfg, nil, false, l1F, altDABackend, ec)
 	fi.AttachEmitter(emitter)
 	require.NotNil(t, altDABackend.forwardTo, "altda backend must have access to underlying standard finalizer")
 

--- a/op-node/rollup/finality/finalizer.go
+++ b/op-node/rollup/finality/finalizer.go
@@ -103,7 +103,8 @@ type Finalizer struct {
 
 	ctx context.Context
 
-	cfg *rollup.Config
+	cfg               *rollup.Config
+	supervisorEnabled bool
 
 	emitter event.Emitter
 
@@ -134,20 +135,21 @@ type Finalizer struct {
 // NewFinalizer creates a new Finalizer instance.
 // The finalizerCfg parameter is optional and may be nil to use default finality behavior.
 // When non-nil, any non-nil fields in finalizerCfg will override the defaults.
-func NewFinalizer(ctx context.Context, log log.Logger, cfg *rollup.Config, finalizerCfg *Config, l1Fetcher FinalizerL1Interface, ec EngineController) *Finalizer {
+func NewFinalizer(ctx context.Context, log log.Logger, cfg *rollup.Config, finalizerCfg *Config, supervisorEnabled bool, l1Fetcher FinalizerL1Interface, ec EngineController) *Finalizer {
 	lookback := calcFinalityLookback(cfg, finalizerCfg)
 	delay := calcFinalityDelay(finalizerCfg)
 	return &Finalizer{
-		ctx:              ctx,
-		cfg:              cfg,
-		log:              log,
-		finalizedL1:      eth.L1BlockRef{},
-		engineController: ec,
-		triedFinalizeAt:  0,
-		finalityData:     make([]FinalityData, 0, lookback),
-		finalityLookback: lookback,
-		finalityDelay:    delay,
-		l1Fetcher:        l1Fetcher,
+		ctx:               ctx,
+		cfg:               cfg,
+		supervisorEnabled: supervisorEnabled,
+		log:               log,
+		finalizedL1:       eth.L1BlockRef{},
+		engineController:  ec,
+		triedFinalizeAt:   0,
+		finalityData:      make([]FinalityData, 0, lookback),
+		finalityLookback:  lookback,
+		finalityDelay:     delay,
+		l1Fetcher:         l1Fetcher,
 	}
 }
 
@@ -298,10 +300,10 @@ func (fi *Finalizer) onDerivedSafeBlock(l2Safe eth.L2BlockRef, derivedFrom eth.L
 	fi.mu.Lock()
 	defer fi.mu.Unlock()
 
-	// Stop registering blocks after interop.
+	// Stop registering blocks after interop only if supervisor is enabled.
 	// Finality in interop is determined by the superchain backend,
 	// i.e. the op-supervisor RPC identifies which L2 block may be finalized.
-	if fi.cfg.IsInterop(l2Safe.Time) {
+	if fi.cfg.IsInterop(l2Safe.Time) && fi.supervisorEnabled {
 		return
 	}
 

--- a/op-node/rollup/finality/finalizer_test.go
+++ b/op-node/rollup/finality/finalizer_test.go
@@ -194,7 +194,7 @@ func TestEngineQueue_Finalize(t *testing.T) {
 
 		emitter := &testutils.MockEmitter{}
 		ec := new(fakeEngineController)
-		fi := NewFinalizer(context.Background(), logger, &rollup.Config{}, nil, l1F, ec)
+		fi := NewFinalizer(context.Background(), logger, &rollup.Config{}, nil, false, l1F, ec)
 		fi.AttachEmitter(emitter)
 
 		// now say C1 was included in D and became the new safe head
@@ -229,7 +229,7 @@ func TestEngineQueue_Finalize(t *testing.T) {
 
 		emitter := &testutils.MockEmitter{}
 		ec := new(fakeEngineController)
-		fi := NewFinalizer(context.Background(), logger, &rollup.Config{}, nil, l1F, ec)
+		fi := NewFinalizer(context.Background(), logger, &rollup.Config{}, nil, false, l1F, ec)
 		fi.AttachEmitter(emitter)
 
 		// now say C1 was included in D and became the new safe head
@@ -268,7 +268,7 @@ func TestEngineQueue_Finalize(t *testing.T) {
 
 		emitter := &testutils.MockEmitter{}
 		ec := new(fakeEngineController)
-		fi := NewFinalizer(context.Background(), logger, &rollup.Config{}, nil, l1F, ec)
+		fi := NewFinalizer(context.Background(), logger, &rollup.Config{}, nil, false, l1F, ec)
 		fi.AttachEmitter(emitter)
 
 		fi.OnEvent(ctx, engine.SafeDerivedEvent{Safe: refC1, Source: refD})
@@ -352,7 +352,7 @@ func TestEngineQueue_Finalize(t *testing.T) {
 
 		emitter := &testutils.MockEmitter{}
 		ec := new(fakeEngineController)
-		fi := NewFinalizer(context.Background(), logger, &rollup.Config{}, nil, l1F, ec)
+		fi := NewFinalizer(context.Background(), logger, &rollup.Config{}, nil, false, l1F, ec)
 		fi.AttachEmitter(emitter)
 
 		// now say B1 was included in C and became the new safe head
@@ -389,7 +389,7 @@ func TestEngineQueue_Finalize(t *testing.T) {
 
 		emitter := &testutils.MockEmitter{}
 		ec := new(fakeEngineController)
-		fi := NewFinalizer(context.Background(), logger, &rollup.Config{}, nil, l1F, ec)
+		fi := NewFinalizer(context.Background(), logger, &rollup.Config{}, nil, false, l1F, ec)
 		fi.AttachEmitter(emitter)
 
 		// now say B1 was included in C and became the new safe head
@@ -486,7 +486,7 @@ func TestEngineQueue_Finalize(t *testing.T) {
 		ec := new(fakeEngineController)
 		fi := NewFinalizer(context.Background(), logger, &rollup.Config{
 			InteropTime: &refC1.Time,
-		}, nil, l1F, ec)
+		}, nil, true, l1F, ec)
 		fi.AttachEmitter(emitter)
 
 		// now say C0 and C1 were included in D and became the new safe head
@@ -516,7 +516,7 @@ func TestFinalizerConfig(t *testing.T) {
 			FinalityLookback: &customLookback,
 		}
 
-		fi := NewFinalizer(context.Background(), logger, &rollup.Config{}, finalizerCfg, l1F, ec)
+		fi := NewFinalizer(context.Background(), logger, &rollup.Config{}, finalizerCfg, false, l1F, ec)
 
 		require.Equal(t, customLookback, fi.finalityLookback, "should use custom finality lookback")
 		require.Equal(t, int(customLookback), cap(fi.finalityData), "finalityData capacity should match custom lookback")
@@ -532,7 +532,7 @@ func TestFinalizerConfig(t *testing.T) {
 			FinalityDelay: &customDelay,
 		}
 
-		fi := NewFinalizer(context.Background(), logger, &rollup.Config{}, finalizerCfg, l1F, ec)
+		fi := NewFinalizer(context.Background(), logger, &rollup.Config{}, finalizerCfg, false, l1F, ec)
 
 		require.Equal(t, customDelay, fi.finalityDelay, "should use custom finality delay")
 	})
@@ -542,7 +542,7 @@ func TestFinalizerConfig(t *testing.T) {
 		l1F := &testutils.MockL1Source{}
 		ec := new(fakeEngineController)
 
-		fi := NewFinalizer(context.Background(), logger, &rollup.Config{}, nil, l1F, ec)
+		fi := NewFinalizer(context.Background(), logger, &rollup.Config{}, nil, false, l1F, ec)
 
 		require.Equal(t, uint64(defaultFinalityLookback), fi.finalityLookback, "should use default finality lookback when config is nil")
 		require.Equal(t, uint64(finalityDelay), fi.finalityDelay, "should use default finality delay when config is nil")
@@ -556,7 +556,7 @@ func TestFinalizerConfig(t *testing.T) {
 		// Passing empty config should behave same as nil
 		finalizerCfg := &Config{}
 
-		fi := NewFinalizer(context.Background(), logger, &rollup.Config{}, finalizerCfg, l1F, ec)
+		fi := NewFinalizer(context.Background(), logger, &rollup.Config{}, finalizerCfg, false, l1F, ec)
 
 		require.Equal(t, uint64(defaultFinalityLookback), fi.finalityLookback, "should use default finality lookback when config fields are nil")
 		require.Equal(t, uint64(finalityDelay), fi.finalityDelay, "should use default finality delay when config fields are nil")
@@ -574,7 +574,7 @@ func TestFinalizerConfig(t *testing.T) {
 			},
 		}
 
-		fi := NewFinalizer(context.Background(), logger, cfg, nil, l1F, ec)
+		fi := NewFinalizer(context.Background(), logger, cfg, nil, false, l1F, ec)
 
 		expectedLookback := uint64(181) // 90 + 90 + 1
 		require.Equal(t, expectedLookback, fi.finalityLookback, "should use alt-da calculated lookback")
@@ -597,7 +597,7 @@ func TestFinalizerConfig(t *testing.T) {
 			FinalityLookback: &customLookback,
 		}
 
-		fi := NewFinalizer(context.Background(), logger, cfg, finalizerCfg, l1F, ec)
+		fi := NewFinalizer(context.Background(), logger, cfg, finalizerCfg, false, l1F, ec)
 
 		require.Equal(t, customLookback, fi.finalityLookback, "custom lookback should override alt-da calculation")
 	})

--- a/op-node/rollup/interop/config.go
+++ b/op-node/rollup/interop/config.go
@@ -32,7 +32,11 @@ func (cfg *Config) Check() error {
 
 // Setup creates an interop sub-system. This drives the node syncing.
 // If setup returns a nil system (without error) the node should fall back to legacy mode.
-func (cfg *Config) Setup(ctx context.Context, logger log.Logger, rollupCfg *rollup.Config, l1 L1Source, l2 L2Source, m opmetrics.RPCMetricer) (SubSystem, error) {
+func (cfg *Config) Setup(ctx context.Context, logger log.Logger, rollupCfg *rollup.Config, supervisorEnabled bool, l1 L1Source, l2 L2Source, m opmetrics.RPCMetricer) (SubSystem, error) {
+	if !supervisorEnabled {
+		logger.Info("Supervisor disabled, using legacy sync mode")
+		return nil, nil // a `nil` system will result in legacy mode.
+	}
 	if cfg.RPCAddr == "" {
 		logger.Warn("No interop RPC configured, falling back to legacy sync mode.")
 		return nil, nil // a `nil` system will result in legacy mode.

--- a/op-node/rollup/interop/iface.go
+++ b/op-node/rollup/interop/iface.go
@@ -29,6 +29,6 @@ type L2Source interface {
 }
 
 type Setup interface {
-	Setup(ctx context.Context, logger log.Logger, rollupCfg *rollup.Config, l1 L1Source, l2 L2Source, m opmetrics.RPCMetricer) (SubSystem, error)
+	Setup(ctx context.Context, logger log.Logger, rollupCfg *rollup.Config, supervisorEnabled bool, l1 L1Source, l2 L2Source, m opmetrics.RPCMetricer) (SubSystem, error)
 	Check() error
 }

--- a/op-program/client/driver/driver.go
+++ b/op-program/client/driver/driver.go
@@ -46,7 +46,7 @@ func NewDriver(logger log.Logger, cfg *rollup.Config, depSet derive.DependencySe
 	pipelineDeriver.AttachEmitter(d)
 
 	syncCfg := &sync.Config{SyncMode: sync.CLSync}
-	ec := engine.NewEngineController(context.Background(), l2Source, logger, metrics.NoopMetrics, cfg, syncCfg, l1Source, d)
+	ec := engine.NewEngineController(context.Background(), l2Source, logger, metrics.NoopMetrics, cfg, syncCfg, false, l1Source, d)
 
 	attrHandler := attributes.NewAttributesHandler(logger, cfg, context.Background(), l2Source, ec)
 	ec.SetAttributesResetter(attrHandler)


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

 Adds SupervisorEnabled field to rollup.Config to decouple supervisor activation from the interop hardfork.

  Motivation: We need to activate the interop hardfork for testing without also activating supervisor logic. However, we can't deprecate the supervisor yet since it's used for critical test coverage in action tests. This is an incremental step toward phasing out the supervisor by decoupling it from the interop HF.

  Changes:
  - Gate cross-unsafe/cross-safe promotion and finality on SupervisorEnabled
  - Default false preserves legacy behavior
  - Set true in action test DSL and devstack when supervisor is used

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

 - Finalizer unit tests cover both SupervisorEnabled=true and false
  - Sysgo devstack tests pass
  - Interop action tests pass


**Additional context**

<!--
Add any other context about the problem you're solving.
-->

We also considered adding this as a flag to the `op-node` (https://github.com/karlfloersch/optimism/pull/22). We decided against this because we do not want end users to accidentally enable this flag. This config is only used for maintaining backwards compatibility with tests.

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->

Fixes `Refresh op-node interop hard fork logic` in interop plan