### PR TITLE
ci: migrate docker builds to GitHub Actions (except op-deployer)

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -3210,12 +3210,6 @@ workflows:
             - check-generated-mocks-op-node
             - check-generated-mocks-op-service
             - op-program-compat
-            # Not needed for the devnet but we want to make sure they build successfully
-            - cannon-docker-build
-            - op-dispute-mon-docker-build
-            - op-program-docker-build
-            - op-supervisor-docker-build
-            - op-test-sequencer-docker-build
             - go-tests-short
             - sanitize-op-program
           context:
@@ -3227,22 +3221,7 @@ workflows:
           matrix:
             parameters:
               docker_name:
-                - op-node
-                - op-batcher
-                - op-faucet
-                - op-program
-                - op-proposer
-                - op-challenger
-                - op-dispute-mon
                 - op-deployer
-                - op-conductor
-                - da-server
-                - op-supervisor
-                - op-supernode
-                - op-test-sequencer
-                - cannon
-                - op-dripper
-                - op-interop-mon
           context:
             - circleci-repo-readonly-authenticated-github-token
           requires:
@@ -3354,27 +3333,11 @@ workflows:
               only: /^op-deployer.*/ # ensure contract artifacts are embedded in op-deployer binary
             branches:
               ignore: /.*/
-      # Standard (medium) cross-platform docker images go here
       - docker-build:
           matrix:
             parameters:
               docker_name:
-                - op-node
-                - op-batcher
                 - op-deployer
-                - op-faucet
-                - op-proposer
-                - op-challenger
-                - op-dispute-mon
-                - op-conductor
-                - da-server
-                - op-ufm
-                - op-supervisor
-                - op-supernode
-                - op-test-sequencer
-                - cannon
-                - op-dripper
-                - op-interop-mon
           name: <<matrix.docker_name>>-docker-release
           docker_tags: <<pipeline.git.revision>>
           platforms: "linux/amd64,linux/arm64"
@@ -3390,46 +3353,14 @@ workflows:
           requires:
             - initialize
             - contracts-bedrock-build
-      # Checks for cross-platform images go here
       - check-cross-platform:
           matrix:
             parameters:
               op_component:
-                - op-node
-                - op-batcher
                 - op-deployer
-                - op-faucet
-                - op-proposer
-                - op-challenger
-                - op-dispute-mon
-                - op-conductor
-                - da-server
-                - op-ufm
-                - op-supervisor
-                - op-supernode
-                - op-test-sequencer
-                - op-deployer
-                - cannon
-                - op-dripper
-                - op-interop-mon
           name: <<matrix.op_component>>-cross-platform
           requires:
-            - op-node-docker-release
-            - op-batcher-docker-release
             - op-deployer-docker-release
-            - op-faucet-docker-release
-            - op-proposer-docker-release
-            - op-challenger-docker-release
-            - op-dispute-mon-docker-release
-            - op-conductor-docker-release
-            - da-server-docker-release
-            - op-ufm-docker-release
-            - op-supervisor-docker-release
-            - op-supernode-docker-release
-            - op-test-sequencer-docker-release
-            - cannon-docker-release
-            - op-dripper-docker-release
-            - op-interop-mon-docker-release
           context:
             - circleci-repo-readonly-authenticated-github-token
       - cannon-prestate:
@@ -3577,21 +3508,7 @@ workflows:
           matrix:
             parameters:
               docker_name:
-                - op-node
-                - op-batcher
                 - op-deployer
-                - op-faucet
-                - op-program
-                - op-proposer
-                - op-challenger
-                - op-dispute-mon
-                - op-conductor
-                - op-supervisor
-                - op-supernode
-                - op-test-sequencer
-                - cannon
-                - op-dripper
-                - op-interop-mon
           name: <<matrix.docker_name>>-docker-publish
           docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
           platforms: "linux/amd64,linux/arm64"
@@ -3606,21 +3523,7 @@ workflows:
           matrix:
             parameters:
               op_component:
-                - op-node
-                - op-batcher
                 - op-deployer
-                - op-faucet
-                - op-program
-                - op-proposer
-                - op-challenger
-                - op-dispute-mon
-                - op-conductor
-                - op-supervisor
-                - op-supernode
-                - op-test-sequencer
-                - cannon
-                - op-dripper
-                - op-interop-mon
           name: <<matrix.op_component>>-cross-platform
           requires:
             - <<matrix.op_component>>-docker-publish

--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -13,6 +13,9 @@ on:
       - 'docker-bake.hcl'
       - '.github/workflows/branches.yaml'
       - 'ops/scripts/compute-git-versions.sh'
+  schedule:
+    # Daily builds at 2 AM UTC (matches CircleCI schedule)
+    - cron: '0 2 * * *'
 
 jobs:
   prep:
@@ -32,20 +35,20 @@ jobs:
         uses: actions/checkout@71cf2267d89c5cb81562390fa70a37fa40b1305e # v6
         with:
           fetch-depth: 0
+          ref: ${{ github.event_name == 'schedule' && 'develop' || '' }}
       - uses: ./.github/actions/docker-build-prep
         id: prep
 
-  local:
+  build:
     needs: prep
-    # only build if push to develop, or PR from a local branch (not a fork)
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+    # only build if push to develop, scheduled run, or PR from a local branch (not a fork)
+    if: github.event_name == 'push' || github.event_name == 'schedule' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
     strategy:
       fail-fast: false
       matrix:
         image_name:
           - op-node
           - op-batcher
-          - op-deployer
           - op-faucet
           - op-program
           - op-proposer
@@ -59,15 +62,14 @@ jobs:
           - cannon
           - op-dripper
           - op-interop-mon
-    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@d04222c229c50320f513afe678b3264869ea11a9
+    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@f8f3cb4800e538003134fb5f50cc734c2c98d762
     with:
       mode: bake
       image_name: ${{ matrix.image_name }}
       bake_file: docker-bake.hcl
       target: ${{ matrix.image_name }}
-      tag: ${{ github.event_name == 'push' && 'develop' || format('pr-{0}', github.event.pull_request.number) }}
       gcp_project_id: ${{ vars.GCP_PROJECT_ID_OPLABS_TOOLS_ARTIFACTS }}
-      registry: us-docker.pkg.dev/oplabs-tools-artifacts/oss
+      registry: us-docker.pkg.dev/oplabs-tools-artifacts/images
       env: |
         GIT_VERSION=${{ fromJson(needs.prep.outputs.versions)[matrix.image_name] }}
         KONA_VERSION=${{ needs.prep.outputs.kona_version }}
@@ -79,7 +81,7 @@ jobs:
       id-token: write
       attestations: write
 
-  fork:
+  build-fork:
     needs: prep
     # only build if PR from a fork
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
@@ -89,7 +91,6 @@ jobs:
         image_name:
           - op-node
           - op-batcher
-          - op-deployer
           - op-faucet
           - op-program
           - op-proposer
@@ -103,7 +104,7 @@ jobs:
           - cannon
           - op-dripper
           - op-interop-mon
-    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@d04222c229c50320f513afe678b3264869ea11a9
+    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@f8f3cb4800e538003134fb5f50cc734c2c98d762
     with:
       mode: bake
       image_name: ${{ matrix.image_name }}
@@ -120,3 +121,34 @@ jobs:
     permissions:
       contents: read
 
+  check-cross-platform:
+    needs: [build, build-fork]
+    if: always() && (needs.build.result == 'success' || needs.build-fork.result == 'success')
+    strategy:
+      fail-fast: false
+      matrix:
+        image_name:
+          - op-node
+          - op-batcher
+          - op-faucet
+          - op-program
+          - op-proposer
+          - op-challenger
+          - op-dispute-mon
+          - op-conductor
+          - da-server
+          - op-supervisor
+          - op-supernode
+          - op-test-sequencer
+          - cannon
+          - op-dripper
+          - op-interop-mon
+        runner:
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    env:
+      IMAGE: ${{ needs.build-fork.result == 'success' && format('ttl.sh/{0}/{1}:24h', github.sha, matrix.image_name) || format('us-docker.pkg.dev/oplabs-tools-artifacts/images/{0}:{1}', matrix.image_name, github.sha) }}
+    steps:
+      - name: Run image
+        run: docker run $IMAGE ${{ matrix.image_name }} --version

--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -13,6 +13,7 @@ on:
       - 'docker-bake.hcl'
       - '.github/workflows/branches.yaml'
       - 'ops/scripts/compute-git-versions.sh'
+  merge_group:
   schedule:
     # Daily builds at 2 AM UTC (matches CircleCI schedule)
     - cron: '0 2 * * *'
@@ -41,8 +42,8 @@ jobs:
 
   build:
     needs: prep
-    # only build if push to develop, scheduled run, or PR from a local branch (not a fork)
-    if: github.event_name == 'push' || github.event_name == 'schedule' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+    # only build if push to develop, scheduled run, merge queue, or PR from a local branch (not a fork)
+    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'merge_group' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/tags.yaml
+++ b/.github/workflows/tags.yaml
@@ -32,7 +32,7 @@ jobs:
 
   release:
     needs: prep
-    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@d04222c229c50320f513afe678b3264869ea11a9
+    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@f8f3cb4800e538003134fb5f50cc734c2c98d762
     with:
       mode: bake
       image_name: ${{ needs.prep.outputs.image_name }}
@@ -40,7 +40,7 @@ jobs:
       target: ${{ needs.prep.outputs.image_name }}
       tag: ${{ needs.prep.outputs.version }}
       gcp_project_id: ${{ vars.GCP_PROJECT_ID_OPLABS_TOOLS_ARTIFACTS }}
-      registry: us-docker.pkg.dev/oplabs-tools-artifacts/oss
+      registry: us-docker.pkg.dev/oplabs-tools-artifacts/images
       env: |
         GIT_VERSION=${{ fromJson(needs.prep.outputs.versions)[needs.prep.outputs.image_name] }}
         KONA_VERSION=${{ needs.prep.outputs.kona_version }}


### PR DESCRIPTION
Migrate Docker image builds from CircleCI to GitHub Actions for all images except `op-deployer`.

## Changes

**GitHub Actions:**
- Build all images (except op-deployer) in GHA with multi-arch support (amd64/arm64)
- Add scheduled daily builds at 2 AM UTC
- Add cross-platform verification job
- Push to `images` registry instead of `oss`
- Rename jobs: `local` → `build`, `fork` → `build-fork`

**CircleCI:**
- Keep `op-deployer` builds in CircleCI (main, release, scheduled workflows)
- Remove all other images from docker-build matrices

## Why op-deployer stays in CircleCI

`op-deployer` embeds compiled Solidity contract artifacts via `go:embed`. The CircleCI pipeline has an existing `contracts-bedrock-build` job that compiles these artifacts and passes them via workspace attachment. Replicating this in GHA requires changes to the Dockerfile build process that need more work.