### PR TITLE
fix(op-batcher): use correct variable in oldestL1Origin comparison

### DIFF
--- a/op-batcher/batcher/channel_builder.go
+++ b/op-batcher/batcher/channel_builder.go
@@ -189,7 +189,7 @@ func (c *ChannelBuilder) AddBlock(block SizedBlock) (*derive.L1BlockInfo, error)
 			Number: l1info.Number,
 		}
 	}
-	if c.oldestL1Origin.Number == 0 || l1info.Number < c.latestL1Origin.Number {
+	if c.oldestL1Origin.Number == 0 || l1info.Number < c.oldestL1Origin.Number {
 		c.oldestL1Origin = eth.BlockID{
 			Hash:   l1info.BlockHash,
 			Number: l1info.Number,


### PR DESCRIPTION
Fixed a copy-paste bug in AddBlock where oldestL1Origin was compared against latestL1Origin instead of itself. This caused oldestL1Origin to update incorrectly, potentially affecting sequencer window timeout calculations.