### PR TITLE
Feat: Op-conductor should transfer leadership if the sequencer does not show signs of recovery

### DIFF
--- a/op-conductor/conductor/config.go
+++ b/op-conductor/conductor/config.go
@@ -89,7 +89,7 @@ type Config struct {
 	// HealthCheck is the health check configuration.
 	HealthCheck HealthCheckConfig
 
-	// HealthRecoveryCheckInterval overrides how often to poll for latest block while waiting for health recovery.
+	// HealthRecoveryCheckInterval is how often to poll for latest block while waiting for health recovery.
 	HealthRecoveryCheckInterval time.Duration
 
 	// HealthRecoveryCallTimeout is the timeout for each RPC call while waiting for health recovery.

--- a/op-conductor/conductor/config.go
+++ b/op-conductor/conductor/config.go
@@ -146,12 +146,6 @@ func (c *Config) Check() error {
 	if err := c.RollupCfg.Check(); err != nil {
 		return errors.Wrap(err, "invalid rollup config")
 	}
-	if c.HealthRecoveryCheckInterval <= 0 {
-		return fmt.Errorf("health recovery check interval must be greater than 0")
-	}
-	if c.HealthRecoveryCallTimeout <= 0 {
-		return fmt.Errorf("health recovery call timeout must be greater than 0")
-	}
 	if err := c.MetricsConfig.Check(); err != nil {
 		return errors.Wrap(err, "invalid metrics config")
 	}

--- a/op-conductor/conductor/config.go
+++ b/op-conductor/conductor/config.go
@@ -89,6 +89,12 @@ type Config struct {
 	// HealthCheck is the health check configuration.
 	HealthCheck HealthCheckConfig
 
+	// HealthRecoveryCheckInterval overrides how often to poll for latest block while waiting for health recovery.
+	HealthRecoveryCheckInterval time.Duration
+
+	// HealthRecoveryCallTimeout is the timeout for each RPC call while waiting for health recovery.
+	HealthRecoveryCallTimeout time.Duration
+
 	// RollupCfg is the rollup config.
 	RollupCfg rollup.Config
 
@@ -139,6 +145,12 @@ func (c *Config) Check() error {
 	}
 	if err := c.RollupCfg.Check(); err != nil {
 		return errors.Wrap(err, "invalid rollup config")
+	}
+	if c.HealthRecoveryCheckInterval <= 0 {
+		return fmt.Errorf("health recovery check interval must be greater than 0")
+	}
+	if c.HealthRecoveryCallTimeout <= 0 {
+		return fmt.Errorf("health recovery call timeout must be greater than 0")
 	}
 	if err := c.MetricsConfig.Check(); err != nil {
 		return errors.Wrap(err, "invalid metrics config")
@@ -206,14 +218,16 @@ func NewConfig(ctx *cli.Context, log log.Logger) (*Config, error) {
 			RollupBoostPartialHealthinessToleranceLimit:           ctx.Uint64(flags.HealthCheckRollupBoostPartialHealthinessToleranceLimit.Name),
 			RollupBoostPartialHealthinessToleranceIntervalSeconds: ctx.Uint64(flags.HealthCheckRollupBoostPartialHealthinessToleranceIntervalSeconds.Name),
 		},
-		RollupCfg:           *rollupCfg,
-		RPCEnableProxy:      ctx.Bool(flags.RPCEnableProxy.Name),
-		RollupBoostWsURL:    ctx.String(flags.RollupBoostWsURL.Name),
-		WebsocketServerPort: ctx.Int(flags.WebsocketServerPort.Name),
-		LogConfig:           oplog.ReadCLIConfig(ctx),
-		MetricsConfig:       opmetrics.ReadCLIConfig(ctx),
-		PprofConfig:         oppprof.ReadCLIConfig(ctx),
-		RPC:                 oprpc.ReadCLIConfig(ctx),
+		HealthRecoveryCheckInterval: ctx.Duration(flags.HealthRecoveryCheckInterval.Name),
+		HealthRecoveryCallTimeout:   ctx.Duration(flags.HealthRecoveryCallTimeout.Name),
+		RollupCfg:                   *rollupCfg,
+		RPCEnableProxy:              ctx.Bool(flags.RPCEnableProxy.Name),
+		RollupBoostWsURL:            ctx.String(flags.RollupBoostWsURL.Name),
+		WebsocketServerPort:         ctx.Int(flags.WebsocketServerPort.Name),
+		LogConfig:                   oplog.ReadCLIConfig(ctx),
+		MetricsConfig:               opmetrics.ReadCLIConfig(ctx),
+		PprofConfig:                 oppprof.ReadCLIConfig(ctx),
+		RPC:                         oprpc.ReadCLIConfig(ctx),
 	}, nil
 }
 

--- a/op-conductor/conductor/service.go
+++ b/op-conductor/conductor/service.go
@@ -42,8 +42,10 @@ var (
 )
 
 const (
+	// Give and unhealthy leader 3 seconds to produce a new block before transferring leadership.
 	defaultBlockProgressCheckInterval = 3 * time.Second
-	defaultBlockProgressCallTimeout   = 1 * time.Second
+	// Calls to eth_getBlockByNumber should be very fast, and we don't want to block the action loop for too long.
+	defaultBlockProgressCallTimeout = 1 * time.Second
 )
 
 // New creates a new OpConductor instance.
@@ -1019,20 +1021,21 @@ func (oc *OpConductor) shouldWaitForHealthRecovery() bool {
 		return false
 	}
 
-	// Todo: is this check needed?
+	// This should never happen, but if it does we will default to the old behavior of waiting.
 	if oc.progressCheckFn == nil {
-		oc.log.Warn("progress check function is not set, transferring leadership")
-		return false
+		oc.log.Warn("progress check function is not set, will wait for health recovery")
+		return true
 	}
 
+	// If we get an error while checking progress that indicates a problem talking to the sequencer so we won't wait.
 	progressing, err := oc.progressCheckFn(oc.shutdownCtx, oc.blockProgressCheckInterval)
 	if err != nil {
-		oc.log.Warn("failed to check sequencer progress while waiting for health recovery, will stop waiting", "err", err)
+		oc.log.Warn("failed to check sequencer progress while waiting for health recovery, will not wait", "err", err)
 		return false
 	}
 
 	if !progressing {
-		oc.log.Warn("sequencer not making progress while waiting for health recovery, will stop waiting")
+		oc.log.Warn("sequencer not making progress while waiting for health recovery, will not wait")
 		return false
 	}
 

--- a/op-conductor/conductor/service.go
+++ b/op-conductor/conductor/service.go
@@ -41,6 +41,11 @@ var (
 	ErrNoUnsafeHead       = errors.New("no unsafe head")
 )
 
+const (
+	defaultBlockProgressCheckInterval = 3 * time.Second
+	defaultBlockProgressCallTimeout   = 10 * time.Second
+)
+
 // New creates a new OpConductor instance.
 func New(ctx context.Context, cfg *Config, log log.Logger, version string) (*OpConductor, error) {
 	return NewOpConductor(ctx, cfg, log, metrics.NewMetrics(), version, nil, nil, nil)
@@ -61,21 +66,29 @@ func NewOpConductor(
 		return nil, errors.Wrap(err, "invalid config")
 	}
 
-	oc := &OpConductor{
-		log:          log,
-		version:      version,
-		cfg:          cfg,
-		metrics:      m,
-		pauseCh:      make(chan struct{}),
-		pauseDoneCh:  make(chan struct{}),
-		resumeCh:     make(chan struct{}),
-		resumeDoneCh: make(chan struct{}),
-		actionCh:     make(chan struct{}, 1),
-		ctrl:         ctrl,
-		cons:         cons,
-		hmon:         hmon,
-		retryBackoff: func() time.Duration { return time.Duration(rand.Intn(2000)) * time.Millisecond },
+	progressInterval := time.Duration(cfg.HealthCheck.Interval) * time.Second
+	if progressInterval == 0 {
+		progressInterval = defaultBlockProgressCheckInterval
 	}
+
+	oc := &OpConductor{
+		log:                        log,
+		version:                    version,
+		cfg:                        cfg,
+		metrics:                    m,
+		pauseCh:                    make(chan struct{}),
+		pauseDoneCh:                make(chan struct{}),
+		resumeCh:                   make(chan struct{}),
+		resumeDoneCh:               make(chan struct{}),
+		actionCh:                   make(chan struct{}, 1),
+		ctrl:                       ctrl,
+		cons:                       cons,
+		hmon:                       hmon,
+		retryBackoff:               func() time.Duration { return time.Duration(rand.Intn(2000)) * time.Millisecond },
+		blockProgressCheckInterval: progressInterval,
+		blockProgressCallTimeout:   defaultBlockProgressCallTimeout,
+	}
+	oc.progressCheckFn = oc.sequencerIsMakingProgress
 	oc.loopActionFn = oc.loopAction
 
 	// explicitly set all atomic.Bool values
@@ -399,6 +412,10 @@ type OpConductor struct {
 	retryBackoff func() time.Duration
 
 	flashblocksHandler ws.FlashblockHandler
+
+	blockProgressCheckInterval time.Duration
+	blockProgressCallTimeout   time.Duration
+	progressCheckFn            func(ctx context.Context, wait time.Duration) (bool, error)
 }
 
 type state struct {
@@ -949,6 +966,41 @@ func (oc *OpConductor) updateSequencerActiveStatus() error {
 	return nil
 }
 
+func (oc *OpConductor) sequencerIsMakingProgress(ctx context.Context, wait time.Duration) (bool, error) {
+	first, err := oc.latestUnsafeBlockWithTimeout(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	if wait > 0 {
+		timer := time.NewTimer(wait)
+		defer timer.Stop()
+
+		select {
+		case <-ctx.Done():
+			return false, ctx.Err()
+		case <-timer.C:
+		}
+	}
+
+	second, err := oc.latestUnsafeBlockWithTimeout(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	return second.NumberU64() > first.NumberU64(), nil
+}
+
+func (oc *OpConductor) latestUnsafeBlockWithTimeout(ctx context.Context) (eth.BlockInfo, error) {
+	reqCtx := ctx
+	if oc.blockProgressCallTimeout > 0 {
+		var cancel context.CancelFunc
+		reqCtx, cancel = context.WithTimeout(ctx, oc.blockProgressCallTimeout)
+		defer cancel()
+	}
+	return oc.ctrl.LatestUnsafeBlock(reqCtx)
+}
+
 // shouldWaitForHealthRecovery determines if the conductor should wait for the sequencer
 // to recover health naturally instead of transferring leadership.
 func (oc *OpConductor) shouldWaitForHealthRecovery() bool {
@@ -964,6 +1016,21 @@ func (oc *OpConductor) shouldWaitForHealthRecovery() bool {
 
 	// Don't wait if rollup boost healthcheck is enabled and partially healthy - transfer leadership instead
 	if (oc.cfg.RollupBoostEnabled || oc.cfg.RollupBoostNextEnabled) && errors.Is(oc.hcerr, health.ErrRollupBoostPartiallyHealthy) {
+		return false
+	}
+
+	if oc.progressCheckFn == nil {
+		oc.log.Warn("progress check function is not set, transferring leadership")
+		return false
+	}
+
+	progressing, err := oc.progressCheckFn(oc.shutdownCtx, oc.blockProgressCheckInterval)
+	if err != nil {
+		oc.log.Warn("failed to check sequencer progress while waiting for health recovery", "err", err)
+		return false
+	}
+	if !progressing {
+		oc.log.Warn("sequencer not making progress while unhealthy leader, transferring leadership")
 		return false
 	}
 

--- a/op-conductor/conductor/service.go
+++ b/op-conductor/conductor/service.go
@@ -975,10 +975,7 @@ func (oc *OpConductor) sequencerIsMakingProgress(ctx context.Context, wait time.
 }
 
 func (oc *OpConductor) latestUnsafeBlockWithTimeout(ctx context.Context) (eth.BlockInfo, error) {
-	// Todo: Is this first assignment necessary?
-	reqCtx := ctx
-	var cancel context.CancelFunc
-	reqCtx, cancel = context.WithTimeout(ctx, oc.cfg.HealthRecoveryCallTimeout)
+	reqCtx, cancel := context.WithTimeout(ctx, oc.cfg.HealthRecoveryCallTimeout)
 	defer cancel()
 	return oc.ctrl.LatestUnsafeBlock(reqCtx)
 }

--- a/op-conductor/conductor/service.go
+++ b/op-conductor/conductor/service.go
@@ -960,14 +960,10 @@ func (oc *OpConductor) sequencerIsMakingProgress(ctx context.Context, wait time.
 		return false, err
 	}
 
-	// Todo: simpler way to sleep?
-	timer := time.NewTimer(wait)
-	defer timer.Stop()
-
-	select {
-	case <-ctx.Done():
-		return false, ctx.Err()
-	case <-timer.C:
+	if wait > 0 {
+		if err := oc.contextAwareWait(ctx, wait); err != nil {
+			return false, err
+		}
 	}
 
 	second, err := oc.latestUnsafeBlockWithTimeout(ctx)
@@ -985,6 +981,19 @@ func (oc *OpConductor) latestUnsafeBlockWithTimeout(ctx context.Context) (eth.Bl
 	reqCtx, cancel = context.WithTimeout(ctx, oc.cfg.HealthRecoveryCallTimeout)
 	defer cancel()
 	return oc.ctrl.LatestUnsafeBlock(reqCtx)
+}
+
+// contextAwareWait waits for the given duration or exits early if the context is cancelled.
+func (oc *OpConductor) contextAwareWait(ctx context.Context, wait time.Duration) error {
+	timer := time.NewTimer(wait)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 // shouldWaitForHealthRecovery determines if the conductor should wait for the sequencer

--- a/op-conductor/conductor/service.go
+++ b/op-conductor/conductor/service.go
@@ -41,13 +41,6 @@ var (
 	ErrNoUnsafeHead       = errors.New("no unsafe head")
 )
 
-const (
-	// Give and unhealthy leader 3 seconds to produce a new block before transferring leadership.
-	defaultBlockProgressCheckInterval = 3 * time.Second
-	// Calls to eth_getBlockByNumber should be very fast, and we don't want to block the action loop for too long.
-	defaultBlockProgressCallTimeout = 1 * time.Second
-)
-
 // New creates a new OpConductor instance.
 func New(ctx context.Context, cfg *Config, log log.Logger, version string) (*OpConductor, error) {
 	return NewOpConductor(ctx, cfg, log, metrics.NewMetrics(), version, nil, nil, nil)
@@ -68,28 +61,24 @@ func NewOpConductor(
 		return nil, errors.Wrap(err, "invalid config")
 	}
 
-	progressInterval := time.Duration(cfg.HealthCheck.Interval) * time.Second
-	if progressInterval == 0 {
-		progressInterval = defaultBlockProgressCheckInterval
-	}
-
 	oc := &OpConductor{
-		log:                        log,
-		version:                    version,
-		cfg:                        cfg,
-		metrics:                    m,
-		pauseCh:                    make(chan struct{}),
-		pauseDoneCh:                make(chan struct{}),
-		resumeCh:                   make(chan struct{}),
-		resumeDoneCh:               make(chan struct{}),
-		actionCh:                   make(chan struct{}, 1),
-		ctrl:                       ctrl,
-		cons:                       cons,
-		hmon:                       hmon,
-		retryBackoff:               func() time.Duration { return time.Duration(rand.Intn(2000)) * time.Millisecond },
-		blockProgressCheckInterval: progressInterval,
-		blockProgressCallTimeout:   defaultBlockProgressCallTimeout,
+		log:                         log,
+		version:                     version,
+		cfg:                         cfg,
+		metrics:                     m,
+		pauseCh:                     make(chan struct{}),
+		pauseDoneCh:                 make(chan struct{}),
+		resumeCh:                    make(chan struct{}),
+		resumeDoneCh:                make(chan struct{}),
+		actionCh:                    make(chan struct{}, 1),
+		ctrl:                        ctrl,
+		cons:                        cons,
+		hmon:                        hmon,
+		retryBackoff:                func() time.Duration { return time.Duration(rand.Intn(2000)) * time.Millisecond },
+		healthRecoveryCheckInterval: cfg.HealthRecoveryCheckInterval,
+		healthRecoveryCallTimeout:   cfg.HealthRecoveryCallTimeout,
 	}
+	// Todo: Why not use sequencerIsMakingProgress directly instead of setting it as a function?
 	oc.progressCheckFn = oc.sequencerIsMakingProgress
 	oc.loopActionFn = oc.loopAction
 
@@ -415,9 +404,9 @@ type OpConductor struct {
 
 	flashblocksHandler ws.FlashblockHandler
 
-	blockProgressCheckInterval time.Duration
-	blockProgressCallTimeout   time.Duration
-	progressCheckFn            func(ctx context.Context, wait time.Duration) (bool, error)
+	healthRecoveryCheckInterval time.Duration
+	healthRecoveryCallTimeout   time.Duration
+	progressCheckFn             func(ctx context.Context, wait time.Duration) (bool, error)
 }
 
 type state struct {
@@ -995,9 +984,9 @@ func (oc *OpConductor) sequencerIsMakingProgress(ctx context.Context, wait time.
 
 func (oc *OpConductor) latestUnsafeBlockWithTimeout(ctx context.Context) (eth.BlockInfo, error) {
 	reqCtx := ctx
-	if oc.blockProgressCallTimeout > 0 {
+	if oc.healthRecoveryCallTimeout > 0 {
 		var cancel context.CancelFunc
-		reqCtx, cancel = context.WithTimeout(ctx, oc.blockProgressCallTimeout)
+		reqCtx, cancel = context.WithTimeout(ctx, oc.healthRecoveryCallTimeout)
 		defer cancel()
 	}
 	return oc.ctrl.LatestUnsafeBlock(reqCtx)
@@ -1028,7 +1017,7 @@ func (oc *OpConductor) shouldWaitForHealthRecovery() bool {
 	}
 
 	// If we get an error while checking progress that indicates a problem talking to the sequencer so we won't wait.
-	progressing, err := oc.progressCheckFn(oc.shutdownCtx, oc.blockProgressCheckInterval)
+	progressing, err := oc.progressCheckFn(oc.shutdownCtx, oc.healthRecoveryCheckInterval)
 	if err != nil {
 		oc.log.Warn("failed to check sequencer progress while waiting for health recovery, will not wait", "err", err)
 		return false

--- a/op-conductor/conductor/service.go
+++ b/op-conductor/conductor/service.go
@@ -952,21 +952,22 @@ func (oc *OpConductor) updateSequencerActiveStatus() error {
 	return nil
 }
 
+// An extremely simple way to know if the sequencer is building blocks.
+// Checks the block height, then waits, then checks again.
 func (oc *OpConductor) sequencerIsMakingProgress(ctx context.Context, wait time.Duration) (bool, error) {
 	first, err := oc.latestUnsafeBlockWithTimeout(ctx)
 	if err != nil {
 		return false, err
 	}
 
-	if wait > 0 {
-		timer := time.NewTimer(wait)
-		defer timer.Stop()
+	// Todo: simpler way to sleep?
+	timer := time.NewTimer(wait)
+	defer timer.Stop()
 
-		select {
-		case <-ctx.Done():
-			return false, ctx.Err()
-		case <-timer.C:
-		}
+	select {
+	case <-ctx.Done():
+		return false, ctx.Err()
+	case <-timer.C:
 	}
 
 	second, err := oc.latestUnsafeBlockWithTimeout(ctx)
@@ -978,6 +979,7 @@ func (oc *OpConductor) sequencerIsMakingProgress(ctx context.Context, wait time.
 }
 
 func (oc *OpConductor) latestUnsafeBlockWithTimeout(ctx context.Context) (eth.BlockInfo, error) {
+	// Todo: Is this first assignment necessary?
 	reqCtx := ctx
 	var cancel context.CancelFunc
 	reqCtx, cancel = context.WithTimeout(ctx, oc.cfg.HealthRecoveryCallTimeout)

--- a/op-conductor/conductor/service.go
+++ b/op-conductor/conductor/service.go
@@ -62,23 +62,20 @@ func NewOpConductor(
 	}
 
 	oc := &OpConductor{
-		log:                         log,
-		version:                     version,
-		cfg:                         cfg,
-		metrics:                     m,
-		pauseCh:                     make(chan struct{}),
-		pauseDoneCh:                 make(chan struct{}),
-		resumeCh:                    make(chan struct{}),
-		resumeDoneCh:                make(chan struct{}),
-		actionCh:                    make(chan struct{}, 1),
-		ctrl:                        ctrl,
-		cons:                        cons,
-		hmon:                        hmon,
-		retryBackoff:                func() time.Duration { return time.Duration(rand.Intn(2000)) * time.Millisecond },
-		healthRecoveryCheckInterval: cfg.HealthRecoveryCheckInterval,
-		healthRecoveryCallTimeout:   cfg.HealthRecoveryCallTimeout,
+		log:          log,
+		version:      version,
+		cfg:          cfg,
+		metrics:      m,
+		pauseCh:      make(chan struct{}),
+		pauseDoneCh:  make(chan struct{}),
+		resumeCh:     make(chan struct{}),
+		resumeDoneCh: make(chan struct{}),
+		actionCh:     make(chan struct{}, 1),
+		ctrl:         ctrl,
+		cons:         cons,
+		hmon:         hmon,
+		retryBackoff: func() time.Duration { return time.Duration(rand.Intn(2000)) * time.Millisecond },
 	}
-	// Todo: Why not use sequencerIsMakingProgress directly instead of setting it as a function?
 	oc.progressCheckFn = oc.sequencerIsMakingProgress
 	oc.loopActionFn = oc.loopAction
 
@@ -404,9 +401,7 @@ type OpConductor struct {
 
 	flashblocksHandler ws.FlashblockHandler
 
-	healthRecoveryCheckInterval time.Duration
-	healthRecoveryCallTimeout   time.Duration
-	progressCheckFn             func(ctx context.Context, wait time.Duration) (bool, error)
+	progressCheckFn func(ctx context.Context, wait time.Duration) (bool, error)
 }
 
 type state struct {
@@ -984,11 +979,9 @@ func (oc *OpConductor) sequencerIsMakingProgress(ctx context.Context, wait time.
 
 func (oc *OpConductor) latestUnsafeBlockWithTimeout(ctx context.Context) (eth.BlockInfo, error) {
 	reqCtx := ctx
-	if oc.healthRecoveryCallTimeout > 0 {
-		var cancel context.CancelFunc
-		reqCtx, cancel = context.WithTimeout(ctx, oc.healthRecoveryCallTimeout)
-		defer cancel()
-	}
+	var cancel context.CancelFunc
+	reqCtx, cancel = context.WithTimeout(ctx, oc.cfg.HealthRecoveryCallTimeout)
+	defer cancel()
 	return oc.ctrl.LatestUnsafeBlock(reqCtx)
 }
 
@@ -1017,7 +1010,7 @@ func (oc *OpConductor) shouldWaitForHealthRecovery() bool {
 	}
 
 	// If we get an error while checking progress that indicates a problem talking to the sequencer so we won't wait.
-	progressing, err := oc.progressCheckFn(oc.shutdownCtx, oc.healthRecoveryCheckInterval)
+	progressing, err := oc.progressCheckFn(oc.shutdownCtx, oc.cfg.HealthRecoveryCheckInterval)
 	if err != nil {
 		oc.log.Warn("failed to check sequencer progress while waiting for health recovery, will not wait", "err", err)
 		return false

--- a/op-conductor/conductor/service.go
+++ b/op-conductor/conductor/service.go
@@ -1003,22 +1003,24 @@ func (oc *OpConductor) shouldWaitForHealthRecovery() bool {
 		return false
 	}
 
-	// This should never happen, but if it does we will default to the old behavior of waiting.
-	if oc.progressCheckFn == nil {
-		oc.log.Warn("progress check function is not set, will wait for health recovery")
-		return true
-	}
+	if oc.cfg.HealthRecoveryCheckInterval > 0 && oc.cfg.HealthRecoveryCallTimeout > 0 {
+		// This should never happen, but if it does we will default to the old behavior of waiting.
+		if oc.progressCheckFn == nil {
+			oc.log.Warn("progress check function is not set, will wait for health recovery")
+			return true
+		}
 
-	// If we get an error while checking progress that indicates a problem talking to the sequencer so we won't wait.
-	progressing, err := oc.progressCheckFn(oc.shutdownCtx, oc.cfg.HealthRecoveryCheckInterval)
-	if err != nil {
-		oc.log.Warn("failed to check sequencer progress while waiting for health recovery, will not wait", "err", err)
-		return false
-	}
+		// If we get an error while checking progress that indicates a problem talking to the sequencer so we won't wait.
+		progressing, err := oc.progressCheckFn(oc.shutdownCtx, oc.cfg.HealthRecoveryCheckInterval)
+		if err != nil {
+			oc.log.Warn("failed to check sequencer progress while waiting for health recovery, will not wait", "err", err)
+			return false
+		}
 
-	if !progressing {
-		oc.log.Warn("sequencer not making progress while waiting for health recovery, will not wait")
-		return false
+		if !progressing {
+			oc.log.Warn("sequencer not making progress while waiting for health recovery, will not wait")
+			return false
+		}
 	}
 
 	return true

--- a/op-conductor/conductor/service.go
+++ b/op-conductor/conductor/service.go
@@ -43,7 +43,7 @@ var (
 
 const (
 	defaultBlockProgressCheckInterval = 3 * time.Second
-	defaultBlockProgressCallTimeout   = 10 * time.Second
+	defaultBlockProgressCallTimeout   = 1 * time.Second
 )
 
 // New creates a new OpConductor instance.
@@ -1019,6 +1019,7 @@ func (oc *OpConductor) shouldWaitForHealthRecovery() bool {
 		return false
 	}
 
+	// Todo: is this check needed?
 	if oc.progressCheckFn == nil {
 		oc.log.Warn("progress check function is not set, transferring leadership")
 		return false
@@ -1026,11 +1027,12 @@ func (oc *OpConductor) shouldWaitForHealthRecovery() bool {
 
 	progressing, err := oc.progressCheckFn(oc.shutdownCtx, oc.blockProgressCheckInterval)
 	if err != nil {
-		oc.log.Warn("failed to check sequencer progress while waiting for health recovery", "err", err)
+		oc.log.Warn("failed to check sequencer progress while waiting for health recovery, will stop waiting", "err", err)
 		return false
 	}
+
 	if !progressing {
-		oc.log.Warn("sequencer not making progress while unhealthy leader, transferring leadership")
+		oc.log.Warn("sequencer not making progress while waiting for health recovery, will stop waiting")
 		return false
 	}
 

--- a/op-conductor/conductor/service.go
+++ b/op-conductor/conductor/service.go
@@ -1006,11 +1006,6 @@ func (oc *OpConductor) shouldWaitForHealthRecovery() bool {
 		return false
 	}
 
-	// Don't wait if rollup boost healthcheck is enabled and partially healthy - transfer leadership instead
-	if (oc.cfg.RollupBoostEnabled || oc.cfg.RollupBoostNextEnabled) && errors.Is(oc.hcerr, health.ErrRollupBoostPartiallyHealthy) {
-		return false
-	}
-
 	if oc.cfg.HealthRecoveryCheckInterval > 0 && oc.cfg.HealthRecoveryCallTimeout > 0 {
 		// This should never happen, but if it does we will default to the old behavior of waiting.
 		if oc.progressCheckFn == nil {
@@ -1026,9 +1021,14 @@ func (oc *OpConductor) shouldWaitForHealthRecovery() bool {
 		}
 
 		if !progressing {
-			oc.log.Warn("sequencer not making progress while waiting for health recovery, will not wait")
+			oc.log.Warn("sequencer not making progress while waiting for health recovery, will not wait any longer")
 			return false
 		}
+	}
+
+	// Don't wait if rollup boost healthcheck is enabled and partially healthy - transfer leadership instead
+	if (oc.cfg.RollupBoostEnabled || oc.cfg.RollupBoostNextEnabled) && errors.Is(oc.hcerr, health.ErrRollupBoostPartiallyHealthy) {
+		return false
 	}
 
 	return true

--- a/op-conductor/conductor/service_test.go
+++ b/op-conductor/conductor/service_test.go
@@ -1220,3 +1220,102 @@ func (s *OpConductorTestSuite) TestRollupBoostPartialFailure() {
 	s.ctrl.AssertNumberOfCalls(s.T(), "StopSequencer", 1)
 	s.cons.AssertNumberOfCalls(s.T(), "TransferLeader", 1)
 }
+
+func (s *OpConductorTestSuite) TestShouldWaitForHealthRecovery_DisabledWhenIntervalZero() {
+	s.conductor.prevState = &state{leader: true, healthy: false, active: false}
+	s.conductor.hcerr = health.ErrSequencerNotHealthy
+	s.conductor.cfg.HealthRecoveryCheckInterval = 0
+	s.conductor.cfg.HealthRecoveryCallTimeout = time.Second
+
+	calls := 0
+	s.conductor.progressCheckFn = func(ctx context.Context, wait time.Duration) (bool, error) {
+		calls++
+		return true, nil
+	}
+
+	s.True(s.conductor.shouldWaitForHealthRecovery())
+	s.Equal(0, calls, "progress check should be skipped when recovery interval is disabled")
+}
+
+func (s *OpConductorTestSuite) TestShouldWaitForHealthRecovery_DisabledWhenTimeoutZero() {
+	s.conductor.prevState = &state{leader: true, healthy: false, active: false}
+	s.conductor.hcerr = health.ErrSequencerNotHealthy
+	s.conductor.cfg.HealthRecoveryCheckInterval = 100 * time.Millisecond
+	s.conductor.cfg.HealthRecoveryCallTimeout = 0
+
+	calls := 0
+	s.conductor.progressCheckFn = func(ctx context.Context, wait time.Duration) (bool, error) {
+		calls++
+		return true, nil
+	}
+
+	s.True(s.conductor.shouldWaitForHealthRecovery())
+	s.Equal(0, calls, "progress check should be skipped when recovery timeout is disabled")
+}
+
+func (s *OpConductorTestSuite) TestShouldWaitForHealthRecovery_WithProgressCheckCalled() {
+	s.conductor.prevState = &state{leader: true, healthy: false, active: false}
+	s.conductor.hcerr = health.ErrSequencerNotHealthy
+	s.conductor.cfg.HealthRecoveryCheckInterval = 100 * time.Millisecond
+	s.conductor.cfg.HealthRecoveryCallTimeout = time.Second
+
+	calls := 0
+	s.conductor.progressCheckFn = func(ctx context.Context, wait time.Duration) (bool, error) {
+		calls++
+		s.Equal(s.conductor.cfg.HealthRecoveryCheckInterval, wait)
+		return true, nil
+	}
+
+	s.conductor.shouldWaitForHealthRecovery()
+	s.Equal(1, calls, "progress check should run when recovery timing is configured")
+}
+
+func (s *OpConductorTestSuite) TestShouldWaitForHealthRecovery_ReturnsTrueWhenProgressing() {
+	s.conductor.prevState = &state{leader: true, healthy: false, active: false}
+	s.conductor.hcerr = health.ErrSequencerNotHealthy
+	s.conductor.cfg.HealthRecoveryCheckInterval = 100 * time.Millisecond
+	s.conductor.cfg.HealthRecoveryCallTimeout = time.Second
+
+	s.conductor.progressCheckFn = func(ctx context.Context, wait time.Duration) (bool, error) {
+		return true, nil
+	}
+
+	s.True(s.conductor.shouldWaitForHealthRecovery())
+}
+
+func (s *OpConductorTestSuite) TestShouldWaitForHealthRecovery_NilProgressCheckFn() {
+	s.conductor.prevState = &state{leader: true, healthy: false, active: false}
+	s.conductor.hcerr = health.ErrSequencerNotHealthy
+	s.conductor.cfg.HealthRecoveryCheckInterval = 100 * time.Millisecond
+	s.conductor.cfg.HealthRecoveryCallTimeout = time.Second
+
+	s.conductor.progressCheckFn = nil
+
+	s.True(s.conductor.shouldWaitForHealthRecovery())
+}
+
+func (s *OpConductorTestSuite) TestShouldWaitForHealthRecovery_NotProgressing() {
+	s.conductor.prevState = &state{leader: true, healthy: false, active: false}
+	s.conductor.hcerr = health.ErrSequencerNotHealthy
+	s.conductor.cfg.HealthRecoveryCheckInterval = 100 * time.Millisecond
+	s.conductor.cfg.HealthRecoveryCallTimeout = time.Second
+
+	s.conductor.progressCheckFn = func(ctx context.Context, wait time.Duration) (bool, error) {
+		return false, nil
+	}
+
+	s.False(s.conductor.shouldWaitForHealthRecovery())
+}
+
+func (s *OpConductorTestSuite) TestShouldWaitForHealthRecovery_ProgressCheckError() {
+	s.conductor.prevState = &state{leader: true, healthy: false, active: false}
+	s.conductor.hcerr = health.ErrSequencerNotHealthy
+	s.conductor.cfg.HealthRecoveryCheckInterval = 100 * time.Millisecond
+	s.conductor.cfg.HealthRecoveryCallTimeout = time.Second
+
+	s.conductor.progressCheckFn = func(ctx context.Context, wait time.Duration) (bool, error) {
+		return false, errors.New("boom")
+	}
+
+	s.False(s.conductor.shouldWaitForHealthRecovery())
+}

--- a/op-conductor/flags/flags.go
+++ b/op-conductor/flags/flags.go
@@ -150,13 +150,11 @@ var (
 		Name:    "health-recovery.check-interval",
 		Usage:   "Interval in seconds to wait between block progress checks while waiting for health recovery.",
 		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "HEALTH_RECOVERY_CHECK_INTERVAL"),
-		Value:   3 * time.Second,
 	}
 	HealthRecoveryCallTimeout = &cli.DurationFlag{
 		Name:    "health-recovery.call-timeout",
 		Usage:   "Timeout in seconds for each block progress check RPC call while waiting for health recovery.",
 		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "HEALTH_RECOVERY_CALL_TIMEOUT"),
-		Value:   1 * time.Second,
 	}
 	Paused = &cli.BoolFlag{
 		Name:    "paused",

--- a/op-conductor/flags/flags.go
+++ b/op-conductor/flags/flags.go
@@ -146,6 +146,18 @@ var (
 		Usage:   "Minimum number of peers required to be considered healthy",
 		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "HEALTHCHECK_MIN_PEER_COUNT"),
 	}
+	HealthRecoveryCheckInterval = &cli.DurationFlag{
+		Name:    "health-recovery.check-interval",
+		Usage:   "Interval in seconds to wait between block progress checks while waiting for health recovery.",
+		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "HEALTH_RECOVERY_CHECK_INTERVAL"),
+		Value:   3 * time.Second,
+	}
+	HealthRecoveryCallTimeout = &cli.DurationFlag{
+		Name:    "health-recovery.call-timeout",
+		Usage:   "Timeout in seconds for each block progress check RPC call while waiting for health recovery.",
+		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "HEALTH_RECOVERY_CALL_TIMEOUT"),
+		Value:   1 * time.Second,
+	}
 	Paused = &cli.BoolFlag{
 		Name:    "paused",
 		Usage:   "Whether the conductor is paused",
@@ -238,6 +250,8 @@ var optionalFlags = []cli.Flag{
 	HealthcheckExecutionP2pCheckApi,
 	HealthCheckRollupBoostPartialHealthinessToleranceLimit,
 	HealthCheckRollupBoostPartialHealthinessToleranceIntervalSeconds,
+	HealthRecoveryCheckInterval,
+	HealthRecoveryCallTimeout,
 }
 
 func init() {


### PR DESCRIPTION
**Description**

There is a (somewhat) edge case where op-conductor will not transfer leadership even though the sequencer is unhealthy. This happens in the following scenario:

- The leader becomes unhealthy
- Since the leader is unhealthy the followers are also necessarily unhealthy
- The leader is transferred to another sequencer
- The new sequencer is unhealthy (as noted above)

In this scenario op-conductor has a special conditional code path which _waits_ for the unhealthy leader to become healthy. Rather than transferring leadership _again_ the code explicitly prefers to wait -- and will _not_ transfer leadership ever again until the sequencer becomes healthy.

The reasoning for this behavior is that you _need_ to give the sequencer time to recover. If you just keep transferring leadership over and over again then _no_ sequencer will _ever_ recover. So this code path is needed.

This PR attempts to improve the logic in that code path. In this scenario, the new code evaluates whether the sequencer is actually building blocks. If it is not building blocks then we will trigger another leadership transfer.

To evaluate block building the PR makes two `eth_getBlockByNumber` calls with some wait interval in between. If the block number progressed then we do not transfer leadership. The wait interval as well as the timeout of the RPC call are both added as optional config vars to op-conductor.

**Tests**

I've added tests to the `op-conductor/conductor/service_test.go` file for all new behavior that was added in `service.go`. The tests do _not_ cover the wiring of the new op-conductor flags.

**Additional context**

This problem caused actual mainnet stalls a few months ago when 2 out of 3 sequencers were unable to talk to the parent chain RPC. In this case op-conductor failed over to the other sequencer which was unable to build blocks and stopped there.

One concern I would like the reviewer to consider is that the calls to `eth_getBlockByNumber` will block the op-conductor loop. I think that's probably OK so long as the interval parameters are set sufficiently low, e.g. a 3-second wait time and a 1-second timeout on RPC calls. However I'm not well-versed enough in the surrounding code to feel super comfortable.

Note that this PR does not consistently check the sequencer is building blocks. It just checks this one time in this one special case and then assumes the sequencer will continue to build blocks. So there is still an edge-edge case where the sequencer is building blocks but then stops before it becomes healthy.

If we want to address that scenario then I believe it will require a much deeper change to op-conductor, e.g. we could add a block velocity metric to the generic HealthCheck. However this PR felt like the right middle ground of a small enough change with large enough impact.