### PR TITLE
Graphite prompt to detect foundry deps bump without approved design doc

### DIFF
--- a/ops/ai-eng/graphite/rules.md
+++ b/ops/ai-eng/graphite/rules.md
@@ -69,3 +69,5 @@ If the PR changes the Foundry dependency versions, i.e the `forge`, `cast`, and 
 > This PR includes a change to the Foundry dependency versions, i.e the `forge`, `cast`, and `anvil` versions in `mise.toml`.
 >
 > Please include a reference to the approved and merged design document that approves these foundry versions for usage in the PR description. Otherwise, the PR will not be approved.
+>
+> For more information on the Foundry version upgrade process, please see the [Foundry version upgrade policy](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/book/src/policies/foundry-upgrades.md).

--- a/ops/ai-eng/graphite/rules.md
+++ b/ops/ai-eng/graphite/rules.md
@@ -59,3 +59,13 @@ This section applies to Solidity files ONLY.
   ```
 - Do NOT suggest removing the return value checking on low-level calls following `vm.expectRevert`
 - DO flag if `vm.expectRevert` is used with low-level calls but the return value is not captured and asserted
+
+### Foundry Version Bump Warnings
+
+If the PR changes the Foundry dependency versions, i.e the `forge`, `cast`, and `anvil` versions in `mise.toml`, it MUST also include a reference to the approved and merged design document that approves these foundry versions for usage in the PR description. Otherwise, you MUST leave a prominent comment on the PR with the following message:
+
+> ⚠️ **Foundry Version Bump Without Design Document**
+>
+> This PR includes a change to the Foundry dependency versions, i.e the `forge`, `cast`, and `anvil` versions in `mise.toml`.
+>
+> Please include a reference to the approved and merged design document that approves these foundry versions for usage in the PR description. Otherwise, the PR will not be approved.


### PR DESCRIPTION
Adds graphite detection for Foundry version bumps in PR reviews. Updates ops/ai-eng/graphite/rules.md to require PRs that change forge, cast, or anvil versions in mise.toml to reference an approved and merged design document in the PR description. If missing, graphite flags the PR with a warning that approval requires the design document reference.