### PR TITLE
fix(sysgo/p2p): normalize peer ID format for op-reth compatibility

### DIFF
--- a/op-devstack/sysgo/l2_el_p2p_util.go
+++ b/op-devstack/sysgo/l2_el_p2p_util.go
@@ -2,7 +2,6 @@ package sysgo
 
 import (
 	"context"
-	"os"
 	"slices"
 	"strings"
 	"time"
@@ -44,6 +43,17 @@ type RpcCaller interface {
 	CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error
 }
 
+// normalizePeerID normalizes a peer ID string to a canonical format for comparison.
+// This handles differences in encoding between op-geth and op-reth:
+// - Removes "0x" prefix if present
+// - Converts to lowercase
+// This ensures consistent comparison regardless of whether the ID comes from
+// admin_nodeInfo (op-geth format) or admin_peers (op-reth format).
+func normalizePeerID(id string) string {
+	// Remove "0x" prefix if present and convert to lowercase
+	return strings.TrimPrefix(strings.ToLower(id), "0x")
+}
+
 // ConnectP2P creates a p2p peer connection between node1 and node2.
 func ConnectP2P(ctx context.Context, require *testreq.Assertions, initiator RpcCaller, acceptor RpcCaller, trusted bool) {
 	var targetInfo p2p.NodeInfo
@@ -65,23 +75,17 @@ func ConnectP2P(ctx context.Context, require *testreq.Assertions, initiator RpcC
 		require.True(peerAddedTrusted, "should have added trusted peer successfully")
 	}
 
-	// Skip P2P connection verification if SKIP_P2P_CONNECTION_CHECK is set
-	// FIXME(#18570): it seems we have some issues getting op-reth to connect to op-geth. This is a temporary workaround to ensure we can still run the
-	// devstack tests.
-	if os.Getenv("SKIP_P2P_CONNECTION_CHECK") != "" {
-		return
-	}
-
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
+	normalizedExpectedID := normalizePeerID(expectedID)
 	err = wait.For(ctx, time.Second, func() (bool, error) {
 		var peers []peer
 		if err := initiator.CallContext(ctx, &peers, "admin_peers"); err != nil {
 			return false, err
 		}
 		return slices.ContainsFunc(peers, func(p peer) bool {
-			peerID := strings.TrimPrefix(strings.ToLower(p.ID), "0x")
-			return peerID == strings.ToLower(expectedID)
+			normalizedPeerID := normalizePeerID(p.ID)
+			return normalizedPeerID == normalizedExpectedID
 		}), nil
 	})
 	require.NoError(err, "The peer was not connected")
@@ -101,14 +105,15 @@ func DisconnectP2P(ctx context.Context, require *testreq.Assertions, initiator R
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
+	normalizedExpectedID := normalizePeerID(expectedID)
 	err = wait.For(ctx, time.Second, func() (bool, error) {
 		var peers []peer
 		if err := initiator.CallContext(ctx, &peers, "admin_peers"); err != nil {
 			return false, err
 		}
 		return !slices.ContainsFunc(peers, func(p peer) bool {
-			peerID := strings.TrimPrefix(strings.ToLower(p.ID), "0x")
-			return peerID == strings.ToLower(expectedID)
+			normalizedPeerID := normalizePeerID(p.ID)
+			return normalizedPeerID == normalizedExpectedID
 		}), nil
 	})
 	require.NoError(err, "The peer was not removed")

--- a/op-devstack/sysgo/l2_el_p2p_util_test.go
+++ b/op-devstack/sysgo/l2_el_p2p_util_test.go
@@ -1,0 +1,109 @@
+package sysgo
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNormalizePeerID(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "lowercase without 0x",
+			input:    "abc123def456",
+			expected: "abc123def456",
+		},
+		{
+			name:     "uppercase without 0x",
+			input:    "ABC123DEF456",
+			expected: "abc123def456",
+		},
+		{
+			name:     "lowercase with 0x",
+			input:    "0xabc123def456",
+			expected: "abc123def456",
+		},
+		{
+			name:     "uppercase with 0x",
+			input:    "0xABC123DEF456",
+			expected: "abc123def456",
+		},
+		{
+			name:     "mixed case with 0x",
+			input:    "0xAbC123DeF456",
+			expected: "abc123def456",
+		},
+		{
+			name:     "mixed case without 0x",
+			input:    "AbC123DeF456",
+			expected: "abc123def456",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "only 0x",
+			input:    "0x",
+			expected: "",
+		},
+		{
+			name:     "0x in middle (should not remove)",
+			input:    "abc0x123",
+			expected: "abc0x123",
+		},
+		{
+			name:     "typical enode ID format",
+			input:    "a448f24c6d18e575453db13171562b71999873db5b286df957af199ec94617f7",
+			expected: "a448f24c6d18e575453db13171562b71999873db5b286df957af199ec94617f7",
+		},
+		{
+			name:     "enode ID with 0x prefix",
+			input:    "0xA448F24C6D18E575453DB13171562B71999873DB5B286DF957AF199EC94617F7",
+			expected: "a448f24c6d18e575453db13171562b71999873db5b286df957af199ec94617f7",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := normalizePeerID(tt.input)
+			if result != tt.expected {
+				t.Errorf("normalizePeerID(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+// TestNormalizePeerIDConsistency tests that different formats of the same ID normalize to the same value
+func TestNormalizePeerIDConsistency(t *testing.T) {
+	baseID := "a448f24c6d18e575453db13171562b71999873db5b286df957af199ec94617f7"
+	// Create a mixed case variant manually
+	mixedCase := "A448F24C6D18E575453DB13171562B71999873DB5B286DF957AF199EC94617F7"
+	variants := []string{
+		baseID,
+		"0x" + baseID,
+		strings.ToUpper(baseID),
+		"0x" + strings.ToUpper(baseID),
+		mixedCase, // Mixed case
+		"0x" + mixedCase,
+	}
+
+	normalized := make(map[string]string)
+	for _, variant := range variants {
+		norm := normalizePeerID(variant)
+		normalized[variant] = norm
+	}
+
+	// All variants should normalize to the same value
+	expected := strings.ToLower(baseID)
+	for variant, norm := range normalized {
+		if norm != expected {
+			t.Errorf("normalizePeerID(%q) = %q, expected all variants to normalize to %q", variant, norm, expected)
+		}
+	}
+}
+


### PR DESCRIPTION
Fixes #18570

Normalizes peer ID format differences between op-geth and op-reth to fix P2P connection health checks.

- Add `normalizePeerID()` to handle format differences
- Update peer comparison logic in `ConnectP2P()` and `DisconnectP2P()`
- Remove `SKIP_P2P_CONNECTION_CHECK` workaround
- Add unit tests