### PR TITLE
op-node: remove WS read limits on L2 EL RPC

### DIFF
--- a/op-node/config/l2_el_rpc.go
+++ b/op-node/config/l2_el_rpc.go
@@ -52,7 +52,7 @@ func (cfg *L2EndpointConfig) Setup(ctx context.Context, log log.Logger,
 	}
 	auth := rpc.WithHTTPAuth(gn.NewJWTAuth(cfg.L2EngineJWTSecret))
 	opts := []client.RPCOption{
-		client.WithGethRPCOptions(auth),
+		client.WithGethRPCOptions(auth, rpc.WithWebsocketMessageSizeLimit(0)),
 		client.WithDialAttempts(10),
 		client.WithCallTimeout(cfg.L2EngineCallTimeout),
 		client.WithRPCRecorder(metrics.NewRecorder("engine-api")),


### PR DESCRIPTION
This connection is trusted and the default limits that come with geth are not compatible with the maximum block size that OP stack can reach.