### PR TITLE
op-node: make gossip network max message size configurable

### DIFF
--- a/op-node/flags/p2p_flags.go
+++ b/op-node/flags/p2p_flags.go
@@ -54,6 +54,7 @@ var (
 	GossipMeshDlazyName          = "p2p.gossip.mesh.dlazy"
 	GossipFloodPublishName       = "p2p.gossip.mesh.floodpublish"
 	GossipTimestampThresholdName = "p2p.gossip.timestamp.threshold"
+	GossipMaxMessageSize         = "p2p.gossip.maxmessagesize"
 	SyncReqRespName              = "p2p.sync.req-resp"
 	SyncOnlyReqToStaticName      = "p2p.sync.onlyreqtostatic"
 	P2PPingName                  = "p2p.ping"
@@ -393,6 +394,14 @@ func P2PFlags(envPrefix string) []cli.Flag {
 			Required: false,
 			Value:    60 * time.Second,
 			EnvVars:  p2pEnv(envPrefix, "GOSSIP_TIMESTAMP_THRESHOLD"),
+			Category: P2PCategory,
+		},
+		&cli.IntFlag{
+			Name:     GossipMaxMessageSize,
+			Usage:    "Threshold for rejecting gossip messages with size bigger than this size in megabytes. Default is 10 megabytes.",
+			Required: false,
+			Value:    10,
+			EnvVars:  p2pEnv(envPrefix, "GOSSIP_MAX_MESSAGE_SIZE"),
 			Category: P2PCategory,
 		},
 		&cli.BoolFlag{

--- a/op-node/p2p/cli/load_config.go
+++ b/op-node/p2p/cli/load_config.go
@@ -377,5 +377,6 @@ func loadGossipOptions(conf *p2p.Config, ctx cliiface.Context) error {
 	conf.MeshDLazy = ctx.Int(flags.GossipMeshDlazyName)
 	conf.FloodPublish = ctx.Bool(flags.GossipFloodPublishName)
 	conf.GossipTimestampThreshold = ctx.Duration(flags.GossipTimestampThresholdName)
+	conf.MaxGossipSize = ctx.Int(flags.GossipMaxMessageSize) * (1 << 20)
 	return nil
 }

--- a/op-node/p2p/config.go
+++ b/op-node/p2p/config.go
@@ -139,6 +139,8 @@ type Config struct {
 	SyncOnlyReqToStatic bool
 
 	EnablePingService bool
+
+	MaxGossipSize int
 }
 
 func DefaultConnManager(conf *Config) (connmgr.ConnManager, error) {
@@ -183,6 +185,10 @@ func (conf *Config) ReqRespSyncEnabled() bool {
 
 func (conf *Config) GetGossipTimestampThreshold() time.Duration {
 	return conf.GossipTimestampThreshold
+}
+
+func (conf *Config) GetMaxGossipSize() int {
+	return conf.MaxGossipSize
 }
 
 const maxMeshParam = 1000

--- a/op-node/p2p/gossip.go
+++ b/op-node/p2p/gossip.go
@@ -28,8 +28,6 @@ import (
 )
 
 const (
-	// maxGossipSize limits the total size of gossip RPC containers as well as decompressed individual messages.
-	maxGossipSize = 10 * (1 << 20)
 	// minGossipSize is used to make sure that there is at least some data to validate the signature against.
 	minGossipSize          = 66
 	maxOutboundQueue       = 256
@@ -61,6 +59,8 @@ type GossipSetupConfigurables interface {
 	ConfigureGossip(rollupCfg *rollup.Config) []pubsub.Option
 	// GetGossipTimestampThreshold returns the threshold for rejecting gossip messages with old timestamps
 	GetGossipTimestampThreshold() time.Duration
+	// GetMaxGossipSize returns the threshold for rejecting large gossip messages
+	GetMaxGossipSize() int
 }
 
 type GossipRuntimeConfig interface {
@@ -101,13 +101,12 @@ func BuildSubscriptionFilter(cfg *rollup.Config) pubsub.SubscriptionFilter {
 
 var msgBufPool = sync.Pool{New: func() any {
 	// note: the topic validator concurrency is limited, so pool won't blow up, even with large pre-allocation.
-	x := make([]byte, 0, maxGossipSize)
-	return &x
+	return &bytes.Buffer{}
 }}
 
 // BuildMsgIdFn builds a generic message ID function for gossipsub that can handle compressed payloads,
 // mirroring the eth2 p2p gossip spec.
-func BuildMsgIdFn(cfg *rollup.Config) pubsub.MsgIdFunction {
+func BuildMsgIdFn(cfg *rollup.Config, gossipConf GossipSetupConfigurables) pubsub.MsgIdFunction {
 	return func(pmsg *pb.Message) string {
 		valid := false
 		var data []byte
@@ -115,14 +114,12 @@ func BuildMsgIdFn(cfg *rollup.Config) pubsub.MsgIdFunction {
 		// The validator can throw away the message later when recognized as invalid,
 		// and the unique hash helps detect duplicates.
 		dLen, err := snappy.DecodedLen(pmsg.Data)
-		if err == nil && dLen <= maxGossipSize {
-			res := msgBufPool.Get().(*[]byte)
+		if err == nil && dLen <= gossipConf.GetMaxGossipSize() {
+			res := msgBufPool.Get().(*bytes.Buffer)
 			defer msgBufPool.Put(res)
-			if data, err = snappy.Decode((*res)[:cap(*res)], pmsg.Data); err == nil {
-				if cap(data) > cap(*res) {
-					// if we ended up growing the slice capacity, fine, keep the larger one.
-					*res = data[:cap(data)]
-				}
+			res.Reset()
+			res.Grow(dLen)
+			if data, err = snappy.Decode(res.AvailableBuffer()[:dLen], pmsg.Data); err == nil {
 				valid = true
 			}
 		}
@@ -185,8 +182,8 @@ func NewGossipSub(p2pCtx context.Context, h host.Host, cfg *rollup.Config, gossi
 		return nil, err
 	}
 	gossipOpts := []pubsub.Option{
-		pubsub.WithMaxMessageSize(maxGossipSize),
-		pubsub.WithMessageIdFn(BuildMsgIdFn(cfg)),
+		pubsub.WithMaxMessageSize(gossipConf.GetMaxGossipSize()),
+		pubsub.WithMessageIdFn(BuildMsgIdFn(cfg, gossipConf)),
 		pubsub.WithNoAuthor(),
 		pubsub.WithMessageSignaturePolicy(pubsub.StrictNoSign),
 		pubsub.WithSubscriptionFilter(BuildSubscriptionFilter(cfg)),
@@ -280,7 +277,7 @@ func BuildBlocksValidator(log log.Logger, cfg *rollup.Config, runCfg GossipRunti
 			log.Warn("invalid snappy compression length data", "err", err, "peer", id)
 			return pubsub.ValidationReject
 		}
-		if outLen > maxGossipSize {
+		if outLen > gossipConf.GetMaxGossipSize() {
 			log.Warn("possible snappy zip bomb, decoded length is too large", "decoded_length", outLen, "peer", id)
 			return pubsub.ValidationReject
 		}
@@ -289,16 +286,14 @@ func BuildBlocksValidator(log log.Logger, cfg *rollup.Config, runCfg GossipRunti
 			return pubsub.ValidationReject
 		}
 
-		res := msgBufPool.Get().(*[]byte)
-		defer msgBufPool.Put(res)
-		data, err := snappy.Decode((*res)[:cap(*res)], message.Data)
+		buf := msgBufPool.Get().(*bytes.Buffer)
+		defer msgBufPool.Put(buf)
+		buf.Reset()
+		buf.Grow(outLen)
+		data, err := snappy.Decode((buf.AvailableBuffer()[:outLen]), message.Data)
 		if err != nil {
 			log.Warn("invalid snappy compression", "err", err, "peer", id)
 			return pubsub.ValidationReject
-		}
-		// if we ended up growing the slice capacity, fine, keep the larger one.
-		if cap(data) > cap(*res) {
-			*res = data[:cap(data)]
 		}
 
 		// message starts with compact-encoding secp256k1 encoded signature
@@ -556,12 +551,9 @@ func (p *publisher) BlocksTopicV4Peers() []peer.ID {
 }
 
 func (p *publisher) PublishSignedL2Payload(ctx context.Context, signedEnvelope *opsigner.SignedExecutionPayloadEnvelope) error {
-	res := msgBufPool.Get().(*[]byte)
-	buf := bytes.NewBuffer((*res)[:0])
-	defer func() {
-		*res = buf.Bytes()
-		defer msgBufPool.Put(res)
-	}()
+	buf := msgBufPool.Get().(*bytes.Buffer)
+	defer msgBufPool.Put(buf)
+	buf.Reset()
 
 	buf.Write(signedEnvelope.Signature[:])
 
@@ -581,12 +573,9 @@ func (p *publisher) PublishSignedL2Payload(ctx context.Context, signedEnvelope *
 }
 
 func (p *publisher) SignAndPublishL2Payload(ctx context.Context, envelope *eth.ExecutionPayloadEnvelope, signer Signer) error {
-	res := msgBufPool.Get().(*[]byte)
-	buf := bytes.NewBuffer((*res)[:0])
-	defer func() {
-		*res = buf.Bytes()
-		defer msgBufPool.Put(res)
-	}()
+	buf := msgBufPool.Get().(*bytes.Buffer)
+	defer msgBufPool.Put(buf)
+	buf.Reset()
 
 	buf.Write(make([]byte, 65))
 

--- a/op-node/p2p/gossip_test.go
+++ b/op-node/p2p/gossip_test.go
@@ -302,3 +302,7 @@ func (m *mockGossipSetupConfigurablesWithThreshold) ConfigureGossip(rollupCfg *r
 func (m *mockGossipSetupConfigurablesWithThreshold) GetGossipTimestampThreshold() time.Duration {
 	return m.threshold
 }
+
+func (m *mockGossipSetupConfigurablesWithThreshold) GetMaxGossipSize() int {
+	return 10 * (1 << 20)
+}

--- a/op-node/p2p/node.go
+++ b/op-node/p2p/node.go
@@ -132,7 +132,7 @@ func (n *NodeP2P) init(
 	}
 	// Activate the P2P req-resp sync if enabled by feature-flag.
 	if setup.ReqRespSyncEnabled() {
-		n.syncCl = NewSyncClient(log, rollupCfg, n.host, gossipIn.OnUnsafeL2Payload, metrics, n.appScorer)
+		n.syncCl = NewSyncClient(log, rollupCfg, n.host, gossipIn.OnUnsafeL2Payload, metrics, n.appScorer, setup)
 		n.host.Network().Notify(&network.NotifyBundle{
 			ConnectedF: func(nw network.Network, conn network.Conn) {
 				n.syncCl.AddPeer(conn.RemotePeer())

--- a/op-node/p2p/prepared.go
+++ b/op-node/p2p/prepared.go
@@ -96,3 +96,7 @@ func (p *Prepared) ReqRespSyncEnabled() bool {
 func (p *Prepared) GetGossipTimestampThreshold() time.Duration {
 	return 60 * time.Second
 }
+
+func (p *Prepared) GetMaxGossipSize() int {
+	return 10 * (1 << 20)
+}

--- a/op-node/p2p/sync.go
+++ b/op-node/p2p/sync.go
@@ -226,7 +226,8 @@ type SyncPeerScorer interface {
 type SyncClient struct {
 	log log.Logger
 
-	cfg *rollup.Config
+	cfg        *rollup.Config
+	gossipConf GossipSetupConfigurables
 
 	metrics   SyncClientMetrics
 	appScorer SyncPeerScorer
@@ -281,12 +282,13 @@ type SyncClient struct {
 	syncOnlyReqToStatic bool
 }
 
-func NewSyncClient(log log.Logger, cfg *rollup.Config, host HostNewStream, rcv receivePayloadFn, metrics SyncClientMetrics, appScorer SyncPeerScorer) *SyncClient {
+func NewSyncClient(log log.Logger, cfg *rollup.Config, host HostNewStream, rcv receivePayloadFn, metrics SyncClientMetrics, appScorer SyncPeerScorer, gossipConf GossipSetupConfigurables) *SyncClient {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	c := &SyncClient{
 		log:                 log,
 		cfg:                 cfg,
+		gossipConf:          gossipConf,
 		metrics:             metrics,
 		appScorer:           appScorer,
 		newStreamFn:         host.NewStream,
@@ -674,6 +676,7 @@ func (s *SyncClient) doRequest(ctx context.Context, id peer.ID, expectedBlockNum
 	// set read timeout (if available)
 	_ = str.SetReadDeadline(time.Now().Add(clientReadResponsetimeout))
 
+	maxGossipSize := (int64)(s.gossipConf.GetMaxGossipSize())
 	// Limit input, as well as output.
 	// Compression may otherwise continue to read ignored data for a small output,
 	// or output more data than desired (zip-bomb)

--- a/op-node/p2p/sync_test.go
+++ b/op-node/p2p/sync_test.go
@@ -165,7 +165,7 @@ func TestSinglePeerSync(t *testing.T) {
 	hostA.SetStreamHandler(PayloadByNumberProtocolID(cfg.L2ChainID), payloadByNumber)
 
 	// Setup host B as the client
-	cl := NewSyncClient(log.New("role", "client"), cfg, hostB, receivePayload, metrics.NoopMetrics, &NoopApplicationScorer{})
+	cl := NewSyncClient(log.New("role", "client"), cfg, hostB, receivePayload, metrics.NoopMetrics, &NoopApplicationScorer{}, &mockGossipSetupConfigurablesWithThreshold{})
 
 	// Setup host B (client) to sync from its peer Host A (server)
 	cl.AddPeer(hostA.ID())
@@ -226,7 +226,7 @@ func TestMultiPeerSync(t *testing.T) {
 		payloadByNumber := MakeStreamHandler(ctx, log.New("serve", "payloads_by_number"), srv.HandleSyncRequest)
 		h.SetStreamHandler(PayloadByNumberProtocolID(cfg.L2ChainID), payloadByNumber)
 
-		cl := NewSyncClient(log.New("role", "client"), cfg, h, receivePayload, metrics.NoopMetrics, &NoopApplicationScorer{})
+		cl := NewSyncClient(log.New("role", "client"), cfg, h, receivePayload, metrics.NoopMetrics, &NoopApplicationScorer{}, &mockGossipSetupConfigurablesWithThreshold{})
 		return cl, received
 	}
 
@@ -372,7 +372,7 @@ func TestNetworkNotifyAddPeerAndRemovePeer(t *testing.T) {
 
 	syncCl := NewSyncClient(log, cfg, hostA, func(ctx context.Context, from peer.ID, payload *eth.ExecutionPayloadEnvelope) error {
 		return nil
-	}, metrics.NoopMetrics, &NoopApplicationScorer{})
+	}, metrics.NoopMetrics, &NoopApplicationScorer{}, &mockGossipSetupConfigurablesWithThreshold{})
 
 	waitChan := make(chan struct{}, 2)
 	var connectedOnce sync.Once


### PR DESCRIPTION
the constant is not compatible with the max block size limit that can be reached with OP Stack. What makes most sense is to make it configurable so that it can be set according to a particular chain's gas limit configuration.

The configuration still defaults to the old constant value.