### PR TITLE
feat(kona/protocol): make fjord_max_sequencer_drift configurable via RollupConfig

### DIFF
--- a/kona/crates/protocol/genesis/src/chain/config.rs
+++ b/kona/crates/protocol/genesis/src/chain/config.rs
@@ -6,9 +6,9 @@ use alloy_eips::eip1559::BaseFeeParams;
 use alloy_primitives::Address;
 
 use crate::{
-    AddressList, AltDAConfig, BaseFeeConfig, ChainGenesis, GRANITE_CHANNEL_TIMEOUT, HardForkConfig,
-    Roles, RollupConfig, SuperchainLevel, base_fee_params, base_fee_params_canyon,
-    params::base_fee_config, rollup::DEFAULT_INTEROP_MESSAGE_EXPIRY_WINDOW,
+    AddressList, AltDAConfig, BaseFeeConfig, ChainGenesis, FJORD_MAX_SEQUENCER_DRIFT,
+    GRANITE_CHANNEL_TIMEOUT, HardForkConfig, Roles, RollupConfig, SuperchainLevel, base_fee_params,
+    base_fee_params_canyon, params::base_fee_config, rollup::DEFAULT_INTEROP_MESSAGE_EXPIRY_WINDOW,
 };
 
 /// L1 chain configuration from the `alloy-genesis` crate.
@@ -176,6 +176,7 @@ impl ChainConfig {
             // necessary.
             channel_timeout: 300,
             granite_channel_timeout: GRANITE_CHANNEL_TIMEOUT,
+            fjord_max_sequencer_drift: FJORD_MAX_SEQUENCER_DRIFT,
             interop_message_expiry_window: DEFAULT_INTEROP_MESSAGE_EXPIRY_WINDOW,
             chain_op_config: self.base_fee_config(),
             alt_da_config: self.alt_da.clone(),

--- a/kona/crates/protocol/genesis/src/rollup.rs
+++ b/kona/crates/protocol/genesis/src/rollup.rs
@@ -27,6 +27,11 @@ const fn default_granite_channel_timeout() -> u64 {
 }
 
 #[cfg(feature = "serde")]
+const fn default_fjord_max_sequencer_drift() -> u64 {
+    FJORD_MAX_SEQUENCER_DRIFT
+}
+
+#[cfg(feature = "serde")]
 const fn default_interop_message_expiry_window() -> u64 {
     DEFAULT_INTEROP_MESSAGE_EXPIRY_WINDOW
 }
@@ -55,6 +60,9 @@ pub struct RollupConfig {
     /// The channel timeout after the Granite hardfork.
     #[cfg_attr(feature = "serde", serde(default = "default_granite_channel_timeout"))]
     pub granite_channel_timeout: u64,
+    /// The max sequencer drift after the Fjord hardfork.
+    #[cfg_attr(feature = "serde", serde(default = "default_fjord_max_sequencer_drift"))]
+    pub fjord_max_sequencer_drift: u64,
     /// The L1 chain ID
     pub l1_chain_id: u64,
     /// The L2 chain ID
@@ -115,6 +123,7 @@ impl<'a> arbitrary::Arbitrary<'a> for RollupConfig {
             seq_window_size: u.arbitrary()?,
             channel_timeout: u.arbitrary()?,
             granite_channel_timeout: u.arbitrary()?,
+            fjord_max_sequencer_drift: u.arbitrary()?,
             l1_chain_id: u.arbitrary()?,
             l2_chain_id: u.arbitrary()?,
             hardforks: HardForkConfig::arbitrary(u)?,
@@ -142,6 +151,7 @@ impl Default for RollupConfig {
             seq_window_size: 0,
             channel_timeout: 0,
             granite_channel_timeout: GRANITE_CHANNEL_TIMEOUT,
+            fjord_max_sequencer_drift: FJORD_MAX_SEQUENCER_DRIFT,
             l1_chain_id: 0,
             l2_chain_id: Chain::from_id(0),
             hardforks: HardForkConfig::default(),
@@ -331,7 +341,7 @@ impl RollupConfig {
     /// Returns the max sequencer drift for the given timestamp.
     pub fn max_sequencer_drift(&self, timestamp: u64) -> u64 {
         if self.is_fjord_active(timestamp) {
-            FJORD_MAX_SEQUENCER_DRIFT
+            self.fjord_max_sequencer_drift
         } else {
             self.max_sequencer_drift
         }
@@ -775,6 +785,20 @@ mod tests {
     }
 
     #[test]
+    fn test_fjord_max_sequencer_drift() {
+        let mut config = RollupConfig {
+            max_sequencer_drift: 100,
+            hardforks: HardForkConfig { fjord_time: Some(10), ..Default::default() },
+            ..Default::default()
+        };
+        assert_eq!(config.max_sequencer_drift(0), 100);
+        assert_eq!(config.max_sequencer_drift(10), FJORD_MAX_SEQUENCER_DRIFT);
+        config.fjord_max_sequencer_drift = 2892;
+        assert_eq!(config.max_sequencer_drift(0), 100);
+        assert_eq!(config.max_sequencer_drift(10), 2892);
+    }
+
+    #[test]
     #[cfg(feature = "serde")]
     fn test_deserialize_reference_rollup_config() {
         use crate::{OP_MAINNET_BASE_FEE_CONFIG, SystemConfig};
@@ -861,6 +885,7 @@ mod tests {
             seq_window_size: 3600,
             channel_timeout: 300,
             granite_channel_timeout: GRANITE_CHANNEL_TIMEOUT,
+            fjord_max_sequencer_drift: FJORD_MAX_SEQUENCER_DRIFT,
             l1_chain_id: 3151908,
             l2_chain_id: Chain::from_id(1337),
             hardforks: HardForkConfig {

--- a/kona/crates/protocol/registry/src/test_utils/base_mainnet.rs
+++ b/kona/crates/protocol/registry/src/test_utils/base_mainnet.rs
@@ -45,6 +45,7 @@ pub const BASE_MAINNET_CONFIG: RollupConfig = RollupConfig {
     seq_window_size: 3600,
     channel_timeout: 300,
     granite_channel_timeout: 50,
+    fjord_max_sequencer_drift: 1800,
     l1_chain_id: 1,
     l2_chain_id: Chain::base_mainnet(),
     hardforks: HardForkConfig {

--- a/kona/crates/protocol/registry/src/test_utils/base_sepolia.rs
+++ b/kona/crates/protocol/registry/src/test_utils/base_sepolia.rs
@@ -45,6 +45,7 @@ pub const BASE_SEPOLIA_CONFIG: RollupConfig = RollupConfig {
     seq_window_size: 3600,
     channel_timeout: 300,
     granite_channel_timeout: 50,
+    fjord_max_sequencer_drift: 1800,
     l1_chain_id: 11155111,
     l2_chain_id: Chain::base_sepolia(),
     chain_op_config: BASE_SEPOLIA_BASE_FEE_CONFIG,

--- a/kona/crates/protocol/registry/src/test_utils/op_mainnet.rs
+++ b/kona/crates/protocol/registry/src/test_utils/op_mainnet.rs
@@ -45,6 +45,7 @@ pub const OP_MAINNET_CONFIG: RollupConfig = RollupConfig {
     seq_window_size: 3600_u64,
     channel_timeout: 300_u64,
     granite_channel_timeout: 50,
+    fjord_max_sequencer_drift: 1800,
     l1_chain_id: 1_u64,
     l2_chain_id: Chain::optimism_mainnet(),
     chain_op_config: OP_MAINNET_BASE_FEE_CONFIG,

--- a/kona/crates/protocol/registry/src/test_utils/op_sepolia.rs
+++ b/kona/crates/protocol/registry/src/test_utils/op_sepolia.rs
@@ -45,6 +45,7 @@ pub const OP_SEPOLIA_CONFIG: RollupConfig = RollupConfig {
     seq_window_size: 3600,
     channel_timeout: 300,
     granite_channel_timeout: 50,
+    fjord_max_sequencer_drift: 1800,
     l1_chain_id: 11155111,
     l2_chain_id: Chain::optimism_sepolia(),
     chain_op_config: OP_SEPOLIA_BASE_FEE_CONFIG,


### PR DESCRIPTION
## Summary
- Added `fjord_max_sequencer_drift` field to `RollupConfig` to allow chains to customize the max sequencer drift value when Fjord is active
- Follows the existing pattern used by `granite_channel_timeout`

## Motivation
Celo chains require a different `FJORD_MAX_SEQUENCER_DRIFT` value (2892 vs the default 1800). With the default value, ZK proving fails for some historical Celo blocks that exceeded the default max sequencer drift. These blocks were valid and included on the Celo chain, but are rejected as invalid batches when using the default `FJORD_MAX_SEQUENCER_DRIFT`.

To support these blocks, Celo chains need a configurable `fjord_max_sequencer_drift`. `celo-kona` crates extend `kona` by importing `kona` crates and overriding specific structs where customization is needed. This change enables `celo-kona` to override `fjord_max_sequencer_drift` with a chain-specific value.

## Solution
Following the existing pattern established by `granite_channel_timeout`, this PR adds a `fjord_max_sequencer_drift` field to `RollupConfig` that:
- Defaults to `FJORD_MAX_SEQUENCER_DRIFT` (1800) if not specified
- Can be overridden via the rollup config JSON or programmatically outside of kona crates
- Does not affect chains using the default value