### PR TITLE
fix: alt da: handle no commitments case when finalized head is updated

### DIFF
--- a/op-alt-da/damgr.go
+++ b/op-alt-da/damgr.go
@@ -116,22 +116,17 @@ func (d *DA) OnFinalizedHeadSignal(f HeadSignalFn) {
 // It is called by the Finalize function, as it has an L1 finalized head to use.
 func (d *DA) updateFinalizedHead(l1Finalized eth.L1BlockRef) {
 	d.l1FinalizedHead = l1Finalized
+
+	// If there are no commitments or challenges being tracked, finalizedHead is managed
+	// by updateFinalizedFromL1 (called from AdvanceL1Origin) which calculates it based
+	// on l1FinalizedHead - challengeWindow. Preserve that value.
+	if d.state.NoCommitments() {
+		return
+	}
+
 	// Prune the state to the finalized head
 	d.state.Prune(l1Finalized.ID())
-
-	// If there are no commitments being tracked (e.g., batcher is using L1 DA instead of alt-DA,
-	// or all alt-DA commitments have been finalized), we can advance finalization based on L1 finality.
-	// When there are no pending alt-DA commitments, L1 finality is sufficient for data availability.
-	// We use the maximum of lastPrunedCommitment and l1Finalized to ensure monotonic progress.
-	if d.state.NoCommitments() {
-		if d.state.lastPrunedCommitment == (eth.L1BlockRef{}) || d.state.lastPrunedCommitment.Number < l1Finalized.Number {
-			d.finalizedHead = l1Finalized
-		} else {
-			d.finalizedHead = d.state.lastPrunedCommitment
-		}
-	} else {
-		d.finalizedHead = d.state.lastPrunedCommitment
-	}
+	d.finalizedHead = d.state.lastPrunedCommitment
 }
 
 // updateFinalizedFromL1 updates the finalized head based on the challenge window.

--- a/op-alt-da/damgr.go
+++ b/op-alt-da/damgr.go
@@ -118,7 +118,20 @@ func (d *DA) updateFinalizedHead(l1Finalized eth.L1BlockRef) {
 	d.l1FinalizedHead = l1Finalized
 	// Prune the state to the finalized head
 	d.state.Prune(l1Finalized.ID())
-	d.finalizedHead = d.state.lastPrunedCommitment
+
+	// If there are no commitments being tracked (e.g., batcher is using L1 DA instead of alt-DA,
+	// or all alt-DA commitments have been finalized), we can advance finalization based on L1 finality.
+	// When there are no pending alt-DA commitments, L1 finality is sufficient for data availability.
+	// We use the maximum of lastPrunedCommitment and l1Finalized to ensure monotonic progress.
+	if d.state.NoCommitments() {
+		if d.state.lastPrunedCommitment == (eth.L1BlockRef{}) || d.state.lastPrunedCommitment.Number < l1Finalized.Number {
+			d.finalizedHead = l1Finalized
+		} else {
+			d.finalizedHead = d.state.lastPrunedCommitment
+		}
+	} else {
+		d.finalizedHead = d.state.lastPrunedCommitment
+	}
 }
 
 // updateFinalizedFromL1 updates the finalized head based on the challenge window.

--- a/op-alt-da/damgr_test.go
+++ b/op-alt-da/damgr_test.go
@@ -227,6 +227,129 @@ func (m *mockL1Fetcher) ExpectL1BlockRefByNumber(num uint64, ref eth.L1BlockRef,
 	m.Mock.On("L1BlockRefByNumber", num).Once().Return(ref, err)
 }
 
+// TestUpdateFinalizedHead tests the updateFinalizedHead behavior with and without commitments
+func TestUpdateFinalizedHead(t *testing.T) {
+	logger := testlog.Logger(t, log.LevelInfo)
+	cfg := Config{
+		ResolveWindow:   6,
+		ChallengeWindow: 6,
+	}
+
+	t.Run("no commitments with empty lastPrunedCommitment uses l1Finalized", func(t *testing.T) {
+		state := NewState(logger, &NoopMetrics{}, cfg)
+		storage := NewMockDAClient(logger)
+		da := NewAltDAWithState(logger, cfg, storage, &NoopMetrics{}, state)
+
+		// Verify state has no commitments
+		require.True(t, state.NoCommitments())
+		require.Equal(t, eth.L1BlockRef{}, state.lastPrunedCommitment)
+
+		// Call Finalize with l1Finalized
+		l1Finalized := l1Ref(100)
+		da.Finalize(l1Finalized)
+
+		// finalizedHead should be l1Finalized since there are no commitments
+		require.Equal(t, l1Finalized, da.finalizedHead)
+	})
+
+	t.Run("no commitments with lastPrunedCommitment lower than l1Finalized uses l1Finalized", func(t *testing.T) {
+		rng := rand.New(rand.NewSource(1234))
+		state := NewState(logger, &NoopMetrics{}, cfg)
+		storage := NewMockDAClient(logger)
+		da := NewAltDAWithState(logger, cfg, storage, &NoopMetrics{}, state)
+
+		// Track and expire a commitment to set lastPrunedCommitment
+		c1 := RandomCommitment(rng)
+		bn1 := uint64(10)
+		state.TrackCommitment(c1, l1Ref(bn1))
+		require.NoError(t, state.ExpireCommitments(bID(bn1+cfg.ChallengeWindow)))
+		state.Prune(bID(bn1 + cfg.ChallengeWindow))
+
+		// Verify lastPrunedCommitment is set
+		require.Equal(t, l1Ref(bn1), state.lastPrunedCommitment)
+		require.True(t, state.NoCommitments())
+
+		// Call Finalize with l1Finalized higher than lastPrunedCommitment
+		l1Finalized := l1Ref(100)
+		da.Finalize(l1Finalized)
+
+		// finalizedHead should be l1Finalized since it's higher
+		require.Equal(t, l1Finalized, da.finalizedHead)
+	})
+
+	t.Run("no commitments with lastPrunedCommitment higher than l1Finalized uses lastPrunedCommitment", func(t *testing.T) {
+		rng := rand.New(rand.NewSource(1234))
+		state := NewState(logger, &NoopMetrics{}, cfg)
+		storage := NewMockDAClient(logger)
+		da := NewAltDAWithState(logger, cfg, storage, &NoopMetrics{}, state)
+
+		// Track and expire a commitment to set lastPrunedCommitment at a high block
+		c1 := RandomCommitment(rng)
+		bn1 := uint64(200)
+		state.TrackCommitment(c1, l1Ref(bn1))
+		require.NoError(t, state.ExpireCommitments(bID(bn1+cfg.ChallengeWindow)))
+		state.Prune(bID(bn1 + cfg.ChallengeWindow))
+
+		// Verify lastPrunedCommitment is set
+		require.Equal(t, l1Ref(bn1), state.lastPrunedCommitment)
+		require.True(t, state.NoCommitments())
+
+		// Call Finalize with l1Finalized lower than lastPrunedCommitment
+		l1Finalized := l1Ref(100)
+		da.Finalize(l1Finalized)
+
+		// finalizedHead should be lastPrunedCommitment since it's higher
+		require.Equal(t, l1Ref(bn1), da.finalizedHead)
+	})
+
+	t.Run("with pending commitments uses lastPrunedCommitment", func(t *testing.T) {
+		rng := rand.New(rand.NewSource(1234))
+		state := NewState(logger, &NoopMetrics{}, cfg)
+		storage := NewMockDAClient(logger)
+		da := NewAltDAWithState(logger, cfg, storage, &NoopMetrics{}, state)
+
+		// Track a commitment that will be pruned
+		c1 := RandomCommitment(rng)
+		bn1 := uint64(10)
+		state.TrackCommitment(c1, l1Ref(bn1))
+		require.NoError(t, state.ExpireCommitments(bID(bn1+cfg.ChallengeWindow)))
+		state.Prune(bID(bn1 + cfg.ChallengeWindow))
+
+		// Track another commitment that won't be expired/pruned
+		c2 := RandomCommitment(rng)
+		bn2 := uint64(50)
+		state.TrackCommitment(c2, l1Ref(bn2))
+
+		// Verify state has pending commitments
+		require.False(t, state.NoCommitments())
+		require.Equal(t, l1Ref(bn1), state.lastPrunedCommitment)
+
+		// Call Finalize with l1Finalized higher than lastPrunedCommitment
+		l1Finalized := l1Ref(100)
+		da.Finalize(l1Finalized)
+
+		// finalizedHead should be lastPrunedCommitment because there are pending commitments
+		require.Equal(t, l1Ref(bn1), da.finalizedHead)
+	})
+
+	t.Run("finalized head signal handler is called with correct value", func(t *testing.T) {
+		state := NewState(logger, &NoopMetrics{}, cfg)
+		storage := NewMockDAClient(logger)
+		da := NewAltDAWithState(logger, cfg, storage, &NoopMetrics{}, state)
+
+		var receivedHead eth.L1BlockRef
+		da.OnFinalizedHeadSignal(func(ref eth.L1BlockRef) {
+			receivedHead = ref
+		})
+
+		l1Finalized := l1Ref(100)
+		da.Finalize(l1Finalized)
+
+		// Handler should receive the finalized head
+		require.Equal(t, l1Finalized, receivedHead)
+	})
+}
+
 func TestAdvanceChallengeOrigin(t *testing.T) {
 	logger := testlog.Logger(t, log.LevelWarn)
 	ctx := context.Background()

--- a/op-alt-da/damgr_test.go
+++ b/op-alt-da/damgr_test.go
@@ -227,7 +227,9 @@ func (m *mockL1Fetcher) ExpectL1BlockRefByNumber(num uint64, ref eth.L1BlockRef,
 	m.Mock.On("L1BlockRefByNumber", num).Once().Return(ref, err)
 }
 
-// TestUpdateFinalizedHead tests the updateFinalizedHead behavior with and without commitments
+// TestUpdateFinalizedHead tests the updateFinalizedHead behavior with and without commitments.
+// When there are no commitments, updateFinalizedHead preserves the existing finalizedHead,
+// which is managed by updateFinalizedFromL1 called from AdvanceL1Origin.
 func TestUpdateFinalizedHead(t *testing.T) {
 	logger := testlog.Logger(t, log.LevelInfo)
 	cfg := Config{
@@ -235,24 +237,29 @@ func TestUpdateFinalizedHead(t *testing.T) {
 		ChallengeWindow: 6,
 	}
 
-	t.Run("no commitments with empty lastPrunedCommitment uses l1Finalized", func(t *testing.T) {
+	t.Run("no commitments preserves existing finalizedHead unchanged", func(t *testing.T) {
 		state := NewState(logger, &NoopMetrics{}, cfg)
 		storage := NewMockDAClient(logger)
 		da := NewAltDAWithState(logger, cfg, storage, &NoopMetrics{}, state)
 
 		// Verify state has no commitments
 		require.True(t, state.NoCommitments())
-		require.Equal(t, eth.L1BlockRef{}, state.lastPrunedCommitment)
+
+		// Set an initial finalizedHead (simulating what updateFinalizedFromL1 would do)
+		initialFinalizedHead := l1Ref(50)
+		da.finalizedHead = initialFinalizedHead
 
 		// Call Finalize with l1Finalized
 		l1Finalized := l1Ref(100)
 		da.Finalize(l1Finalized)
 
-		// finalizedHead should be l1Finalized since there are no commitments
-		require.Equal(t, l1Finalized, da.finalizedHead)
+		// finalizedHead should be preserved (not overwritten) since there are no commitments
+		require.Equal(t, initialFinalizedHead, da.finalizedHead)
+		// l1FinalizedHead should be updated
+		require.Equal(t, l1Finalized, da.l1FinalizedHead)
 	})
 
-	t.Run("no commitments with lastPrunedCommitment lower than l1Finalized uses l1Finalized", func(t *testing.T) {
+	t.Run("no commitments after all pruned preserves existing finalizedHead", func(t *testing.T) {
 		rng := rand.New(rand.NewSource(1234))
 		state := NewState(logger, &NoopMetrics{}, cfg)
 		storage := NewMockDAClient(logger)
@@ -265,44 +272,23 @@ func TestUpdateFinalizedHead(t *testing.T) {
 		require.NoError(t, state.ExpireCommitments(bID(bn1+cfg.ChallengeWindow)))
 		state.Prune(bID(bn1 + cfg.ChallengeWindow))
 
-		// Verify lastPrunedCommitment is set
+		// Verify lastPrunedCommitment is set and no more commitments
 		require.Equal(t, l1Ref(bn1), state.lastPrunedCommitment)
 		require.True(t, state.NoCommitments())
 
-		// Call Finalize with l1Finalized higher than lastPrunedCommitment
+		// Simulate updateFinalizedFromL1 having set the finalizedHead
+		initialFinalizedHead := l1Ref(80)
+		da.finalizedHead = initialFinalizedHead
+
+		// Call Finalize with l1Finalized
 		l1Finalized := l1Ref(100)
 		da.Finalize(l1Finalized)
 
-		// finalizedHead should be l1Finalized since it's higher
-		require.Equal(t, l1Finalized, da.finalizedHead)
+		// finalizedHead should be preserved since there are no commitments
+		require.Equal(t, initialFinalizedHead, da.finalizedHead)
 	})
 
-	t.Run("no commitments with lastPrunedCommitment higher than l1Finalized uses lastPrunedCommitment", func(t *testing.T) {
-		rng := rand.New(rand.NewSource(1234))
-		state := NewState(logger, &NoopMetrics{}, cfg)
-		storage := NewMockDAClient(logger)
-		da := NewAltDAWithState(logger, cfg, storage, &NoopMetrics{}, state)
-
-		// Track and expire a commitment to set lastPrunedCommitment at a high block
-		c1 := RandomCommitment(rng)
-		bn1 := uint64(200)
-		state.TrackCommitment(c1, l1Ref(bn1))
-		require.NoError(t, state.ExpireCommitments(bID(bn1+cfg.ChallengeWindow)))
-		state.Prune(bID(bn1 + cfg.ChallengeWindow))
-
-		// Verify lastPrunedCommitment is set
-		require.Equal(t, l1Ref(bn1), state.lastPrunedCommitment)
-		require.True(t, state.NoCommitments())
-
-		// Call Finalize with l1Finalized lower than lastPrunedCommitment
-		l1Finalized := l1Ref(100)
-		da.Finalize(l1Finalized)
-
-		// finalizedHead should be lastPrunedCommitment since it's higher
-		require.Equal(t, l1Ref(bn1), da.finalizedHead)
-	})
-
-	t.Run("with pending commitments uses lastPrunedCommitment", func(t *testing.T) {
+	t.Run("with pending commitments prunes and uses lastPrunedCommitment", func(t *testing.T) {
 		rng := rand.New(rand.NewSource(1234))
 		state := NewState(logger, &NoopMetrics{}, cfg)
 		storage := NewMockDAClient(logger)
@@ -332,10 +318,43 @@ func TestUpdateFinalizedHead(t *testing.T) {
 		require.Equal(t, l1Ref(bn1), da.finalizedHead)
 	})
 
+	t.Run("with commitments prunes up to l1Finalized and updates finalizedHead", func(t *testing.T) {
+		rng := rand.New(rand.NewSource(1234))
+		state := NewState(logger, &NoopMetrics{}, cfg)
+		storage := NewMockDAClient(logger)
+		da := NewAltDAWithState(logger, cfg, storage, &NoopMetrics{}, state)
+
+		// Track and expire multiple commitments
+		c1 := RandomCommitment(rng)
+		bn1 := uint64(10)
+		state.TrackCommitment(c1, l1Ref(bn1))
+
+		c2 := RandomCommitment(rng)
+		bn2 := uint64(20)
+		state.TrackCommitment(c2, l1Ref(bn2))
+
+		// Expire both commitments
+		require.NoError(t, state.ExpireCommitments(bID(bn2+cfg.ChallengeWindow)))
+
+		// Verify we have expired commitments ready to prune
+		require.False(t, state.NoCommitments())
+
+		// Call Finalize - this should prune up to l1Finalized
+		l1Finalized := l1Ref(bn2 + cfg.ChallengeWindow)
+		da.Finalize(l1Finalized)
+
+		// Both commitments should be pruned, finalizedHead should be the last pruned one
+		require.Equal(t, l1Ref(bn2), da.finalizedHead)
+	})
+
 	t.Run("finalized head signal handler is called with correct value", func(t *testing.T) {
 		state := NewState(logger, &NoopMetrics{}, cfg)
 		storage := NewMockDAClient(logger)
 		da := NewAltDAWithState(logger, cfg, storage, &NoopMetrics{}, state)
+
+		// Set initial finalizedHead (simulating updateFinalizedFromL1)
+		initialFinalizedHead := l1Ref(50)
+		da.finalizedHead = initialFinalizedHead
 
 		var receivedHead eth.L1BlockRef
 		da.OnFinalizedHeadSignal(func(ref eth.L1BlockRef) {
@@ -345,8 +364,8 @@ func TestUpdateFinalizedHead(t *testing.T) {
 		l1Finalized := l1Ref(100)
 		da.Finalize(l1Finalized)
 
-		// Handler should receive the finalized head
-		require.Equal(t, l1Finalized, receivedHead)
+		// Handler should receive the preserved finalizedHead (since no commitments)
+		require.Equal(t, initialFinalizedHead, receivedHead)
 	})
 }
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

When there are no alt-DA commitments being tracked (e.g., batcher is using calldata/blobs instead of alt-DA), the `updateFinalizedHead` function was overwriting `finalizedHead` with `lastPrunedCommitment`, which could be zero or stale.

With this fix, the `finalizedHead` in the "no commitments" case should be managed by `updateFinalizedFromL1` (called from `AdvanceL1Origin`), which calculates it as l1FinalizedHead - challengeWindow. The fix is in the `updateFinalizedHead` function and aims to preserve that value when there are no commitments to track.

**Tests**

Added TestUpdateFinalizedHead with 5 sub-tests covering:
- Verifies that when no commitments exist, the existing `finalizedHead` is preserved
- Verifies that after all commitments are pruned, subsequent `Finalize` calls preserve `finalizedHead`
- Verifies that with pending commitments, Prune is called and `lastPrunedCommitment` is used
- Verifies multiple commitments are pruned correctly
- Verifies the signal handler receives the correct `finalizedHead`

---
- Fixes #18865 
