### PR TITLE
refactor(op-devstack): introduce unified ID type system (Phase 1)

### DIFF
--- a/op-devstack/stack/component_id.go
+++ b/op-devstack/stack/component_id.go
@@ -1,0 +1,506 @@
+package stack
+
+import (
+	"bytes"
+	"fmt"
+	"log/slog"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/holiman/uint256"
+)
+
+// ComponentKind identifies the type of component.
+// This is used in serialization to make each ID unique and type-safe.
+type ComponentKind string
+
+// All component kinds. These values are used in serialization and must remain stable.
+const (
+	KindL1ELNode          ComponentKind = "L1ELNode"
+	KindL1CLNode          ComponentKind = "L1CLNode"
+	KindL1Network         ComponentKind = "L1Network"
+	KindL2ELNode          ComponentKind = "L2ELNode"
+	KindL2CLNode          ComponentKind = "L2CLNode"
+	KindL2Network         ComponentKind = "L2Network"
+	KindL2Batcher         ComponentKind = "L2Batcher"
+	KindL2Proposer        ComponentKind = "L2Proposer"
+	KindL2Challenger      ComponentKind = "L2Challenger"
+	KindRollupBoostNode   ComponentKind = "RollupBoostNode"
+	KindOPRBuilderNode    ComponentKind = "OPRBuilderNode"
+	KindFaucet            ComponentKind = "Faucet"
+	KindSyncTester        ComponentKind = "SyncTester"
+	KindSupervisor        ComponentKind = "Supervisor"
+	KindConductor         ComponentKind = "Conductor"
+	KindCluster           ComponentKind = "Cluster"
+	KindSuperchain        ComponentKind = "Superchain"
+	KindSupernode         ComponentKind = "Supernode"
+	KindTestSequencer     ComponentKind = "TestSequencer"
+	KindFlashblocksClient ComponentKind = "FlashblocksWSClient"
+)
+
+// IDShape defines which fields an ID uses.
+type IDShape uint8
+
+const (
+	// IDShapeKeyAndChain indicates the ID has both a key and chainID (e.g., L2Batcher-mynode-420)
+	IDShapeKeyAndChain IDShape = iota
+	// IDShapeChainOnly indicates the ID has only a chainID (e.g., L1Network-1)
+	IDShapeChainOnly
+	// IDShapeKeyOnly indicates the ID has only a key (e.g., Supervisor-mysupervisor)
+	IDShapeKeyOnly
+)
+
+// ComponentID is the unified identifier for all components.
+// It contains all possible fields; the shape determines which are used.
+type ComponentID struct {
+	kind    ComponentKind
+	shape   IDShape
+	key     string
+	chainID eth.ChainID
+}
+
+// NewComponentID creates a new ComponentID with key and chainID.
+func NewComponentID(kind ComponentKind, key string, chainID eth.ChainID) ComponentID {
+	return ComponentID{
+		kind:    kind,
+		shape:   IDShapeKeyAndChain,
+		key:     key,
+		chainID: chainID,
+	}
+}
+
+// NewComponentIDChainOnly creates a new ComponentID with only a chainID.
+func NewComponentIDChainOnly(kind ComponentKind, chainID eth.ChainID) ComponentID {
+	return ComponentID{
+		kind:    kind,
+		shape:   IDShapeChainOnly,
+		chainID: chainID,
+	}
+}
+
+// NewComponentIDKeyOnly creates a new ComponentID with only a key.
+func NewComponentIDKeyOnly(kind ComponentKind, key string) ComponentID {
+	return ComponentID{
+		kind:  kind,
+		shape: IDShapeKeyOnly,
+		key:   key,
+	}
+}
+
+func (id ComponentID) Kind() ComponentKind {
+	return id.kind
+}
+
+func (id ComponentID) Shape() IDShape {
+	return id.shape
+}
+
+func (id ComponentID) Key() string {
+	return id.key
+}
+
+func (id ComponentID) ChainID() eth.ChainID {
+	return id.chainID
+}
+
+func (id ComponentID) String() string {
+	switch id.shape {
+	case IDShapeKeyAndChain:
+		return fmt.Sprintf("%s-%s-%s", id.kind, id.key, id.chainID)
+	case IDShapeChainOnly:
+		return fmt.Sprintf("%s-%s", id.kind, id.chainID)
+	case IDShapeKeyOnly:
+		return fmt.Sprintf("%s-%s", id.kind, id.key)
+	default:
+		return fmt.Sprintf("%s-<invalid>", id.kind)
+	}
+}
+
+func (id ComponentID) LogValue() slog.Value {
+	return slog.StringValue(id.String())
+}
+
+func (id ComponentID) MarshalText() ([]byte, error) {
+	if id.shape == IDShapeKeyAndChain || id.shape == IDShapeKeyOnly {
+		if len(id.key) > maxIDLength {
+			return nil, errInvalidID
+		}
+	}
+	return []byte(id.String()), nil
+}
+
+func (id *ComponentID) UnmarshalText(data []byte) error {
+	return id.unmarshalTextWithKind(id.kind, data)
+}
+
+// unmarshalTextWithKind unmarshals the ID, validating that the kind matches.
+func (id *ComponentID) unmarshalTextWithKind(expectedKind ComponentKind, data []byte) error {
+	kindData, rest, ok := bytes.Cut(data, []byte("-"))
+	if !ok {
+		return fmt.Errorf("expected kind-prefix, but id has none: %q", data)
+	}
+	actualKind := ComponentKind(kindData)
+	if actualKind != expectedKind {
+		return fmt.Errorf("id %q has unexpected kind %q, expected %q", string(data), actualKind, expectedKind)
+	}
+
+	// Determine shape based on expected kind
+	shape := kindToShape(expectedKind)
+	id.kind = expectedKind
+	id.shape = shape
+
+	switch shape {
+	case IDShapeKeyAndChain:
+		keyData, chainData, ok := bytes.Cut(rest, []byte("-"))
+		if !ok {
+			return fmt.Errorf("expected chain separator, but found none: %q", string(data))
+		}
+		if len(keyData) > maxIDLength {
+			return errInvalidID
+		}
+		var chainID eth.ChainID
+		if err := chainID.UnmarshalText(chainData); err != nil {
+			return fmt.Errorf("failed to unmarshal chain part: %w", err)
+		}
+		id.key = string(keyData)
+		id.chainID = chainID
+	case IDShapeChainOnly:
+		var chainID eth.ChainID
+		if err := chainID.UnmarshalText(rest); err != nil {
+			return fmt.Errorf("failed to unmarshal chain part: %w", err)
+		}
+		id.chainID = chainID
+		id.key = ""
+	case IDShapeKeyOnly:
+		if len(rest) > maxIDLength {
+			return errInvalidID
+		}
+		id.key = string(rest)
+		id.chainID = eth.ChainID(*uint256.NewInt(0))
+	}
+	return nil
+}
+
+// kindToShape returns the IDShape for a given ComponentKind.
+func kindToShape(kind ComponentKind) IDShape {
+	switch kind {
+	case KindL1Network, KindL2Network:
+		return IDShapeChainOnly
+	case KindSupervisor, KindConductor, KindCluster, KindSuperchain, KindTestSequencer, KindSupernode:
+		return IDShapeKeyOnly
+	default:
+		return IDShapeKeyAndChain
+	}
+}
+
+// Less compares two ComponentIDs for sorting.
+func (id ComponentID) Less(other ComponentID) bool {
+	if id.kind != other.kind {
+		return id.kind < other.kind
+	}
+	if id.key != other.key {
+		return id.key < other.key
+	}
+	return id.chainID.Cmp(other.chainID) < 0
+}
+
+// KindMarker is implemented by marker types to associate them with their ComponentKind.
+// This enables type-safe unmarshaling of ID[T] types.
+type KindMarker interface {
+	componentKind() ComponentKind
+}
+
+// ID is a type-safe wrapper around ComponentID.
+// The type parameter T must implement KindMarker to enable unmarshaling.
+// This prevents accidentally mixing up different ID types (e.g., L2BatcherID vs L2ELNodeID).
+type ID[T KindMarker] struct {
+	ComponentID
+}
+
+// Marker types for each component kind.
+// Each marker implements KindMarker to associate it with the correct ComponentKind.
+type (
+	L1ELNodeMarker          struct{}
+	L1CLNodeMarker          struct{}
+	L1NetworkMarker         struct{}
+	L2ELNodeMarker          struct{}
+	L2CLNodeMarker          struct{}
+	L2NetworkMarker         struct{}
+	L2BatcherMarker         struct{}
+	L2ProposerMarker        struct{}
+	L2ChallengerMarker      struct{}
+	RollupBoostNodeMarker   struct{}
+	OPRBuilderNodeMarker    struct{}
+	FaucetMarker            struct{}
+	SyncTesterMarker        struct{}
+	SupervisorMarker        struct{}
+	ConductorMarker         struct{}
+	ClusterMarker           struct{}
+	SuperchainMarker        struct{}
+	TestSequencerMarker     struct{}
+	FlashblocksClientMarker struct{}
+)
+
+// KindMarker implementations for all marker types.
+func (L1ELNodeMarker) componentKind() ComponentKind          { return KindL1ELNode }
+func (L1CLNodeMarker) componentKind() ComponentKind          { return KindL1CLNode }
+func (L1NetworkMarker) componentKind() ComponentKind         { return KindL1Network }
+func (L2ELNodeMarker) componentKind() ComponentKind          { return KindL2ELNode }
+func (L2CLNodeMarker) componentKind() ComponentKind          { return KindL2CLNode }
+func (L2NetworkMarker) componentKind() ComponentKind         { return KindL2Network }
+func (L2BatcherMarker) componentKind() ComponentKind         { return KindL2Batcher }
+func (L2ProposerMarker) componentKind() ComponentKind        { return KindL2Proposer }
+func (L2ChallengerMarker) componentKind() ComponentKind      { return KindL2Challenger }
+func (RollupBoostNodeMarker) componentKind() ComponentKind   { return KindRollupBoostNode }
+func (OPRBuilderNodeMarker) componentKind() ComponentKind    { return KindOPRBuilderNode }
+func (FaucetMarker) componentKind() ComponentKind            { return KindFaucet }
+func (SyncTesterMarker) componentKind() ComponentKind        { return KindSyncTester }
+func (SupervisorMarker) componentKind() ComponentKind        { return KindSupervisor }
+func (ConductorMarker) componentKind() ComponentKind         { return KindConductor }
+func (ClusterMarker) componentKind() ComponentKind           { return KindCluster }
+func (SuperchainMarker) componentKind() ComponentKind        { return KindSuperchain }
+func (TestSequencerMarker) componentKind() ComponentKind     { return KindTestSequencer }
+func (FlashblocksClientMarker) componentKind() ComponentKind { return KindFlashblocksClient }
+
+// Type-safe ID type aliases using marker types.
+// These maintain backward compatibility with existing code.
+type (
+	L1ELNodeID2          = ID[L1ELNodeMarker]
+	L1CLNodeID2          = ID[L1CLNodeMarker]
+	L1NetworkID2         = ID[L1NetworkMarker]
+	L2ELNodeID2          = ID[L2ELNodeMarker]
+	L2CLNodeID2          = ID[L2CLNodeMarker]
+	L2NetworkID2         = ID[L2NetworkMarker]
+	L2BatcherID2         = ID[L2BatcherMarker]
+	L2ProposerID2        = ID[L2ProposerMarker]
+	L2ChallengerID2      = ID[L2ChallengerMarker]
+	RollupBoostNodeID2   = ID[RollupBoostNodeMarker]
+	OPRBuilderNodeID2    = ID[OPRBuilderNodeMarker]
+	FaucetID2            = ID[FaucetMarker]
+	SyncTesterID2        = ID[SyncTesterMarker]
+	SupervisorID2        = ID[SupervisorMarker]
+	ConductorID2         = ID[ConductorMarker]
+	ClusterID2           = ID[ClusterMarker]
+	SuperchainID2        = ID[SuperchainMarker]
+	TestSequencerID2     = ID[TestSequencerMarker]
+	FlashblocksClientID2 = ID[FlashblocksClientMarker]
+)
+
+// Type-safe constructors for each ID type.
+
+func NewL1ELNodeID2(key string, chainID eth.ChainID) L1ELNodeID2 {
+	return L1ELNodeID2{NewComponentID(KindL1ELNode, key, chainID)}
+}
+
+func NewL1CLNodeID2(key string, chainID eth.ChainID) L1CLNodeID2 {
+	return L1CLNodeID2{NewComponentID(KindL1CLNode, key, chainID)}
+}
+
+func NewL1NetworkID2(chainID eth.ChainID) L1NetworkID2 {
+	return L1NetworkID2{NewComponentIDChainOnly(KindL1Network, chainID)}
+}
+
+func NewL2ELNodeID2(key string, chainID eth.ChainID) L2ELNodeID2 {
+	return L2ELNodeID2{NewComponentID(KindL2ELNode, key, chainID)}
+}
+
+func NewL2CLNodeID2(key string, chainID eth.ChainID) L2CLNodeID2 {
+	return L2CLNodeID2{NewComponentID(KindL2CLNode, key, chainID)}
+}
+
+func NewL2NetworkID2(chainID eth.ChainID) L2NetworkID2 {
+	return L2NetworkID2{NewComponentIDChainOnly(KindL2Network, chainID)}
+}
+
+func NewL2BatcherID2(key string, chainID eth.ChainID) L2BatcherID2 {
+	return L2BatcherID2{NewComponentID(KindL2Batcher, key, chainID)}
+}
+
+func NewL2ProposerID2(key string, chainID eth.ChainID) L2ProposerID2 {
+	return L2ProposerID2{NewComponentID(KindL2Proposer, key, chainID)}
+}
+
+func NewL2ChallengerID2(key string, chainID eth.ChainID) L2ChallengerID2 {
+	return L2ChallengerID2{NewComponentID(KindL2Challenger, key, chainID)}
+}
+
+func NewRollupBoostNodeID2(key string, chainID eth.ChainID) RollupBoostNodeID2 {
+	return RollupBoostNodeID2{NewComponentID(KindRollupBoostNode, key, chainID)}
+}
+
+func NewOPRBuilderNodeID2(key string, chainID eth.ChainID) OPRBuilderNodeID2 {
+	return OPRBuilderNodeID2{NewComponentID(KindOPRBuilderNode, key, chainID)}
+}
+
+func NewFaucetID2(key string, chainID eth.ChainID) FaucetID2 {
+	return FaucetID2{NewComponentID(KindFaucet, key, chainID)}
+}
+
+func NewSyncTesterID2(key string, chainID eth.ChainID) SyncTesterID2 {
+	return SyncTesterID2{NewComponentID(KindSyncTester, key, chainID)}
+}
+
+func NewSupervisorID2(key string) SupervisorID2 {
+	return SupervisorID2{NewComponentIDKeyOnly(KindSupervisor, key)}
+}
+
+func NewConductorID2(key string) ConductorID2 {
+	return ConductorID2{NewComponentIDKeyOnly(KindConductor, key)}
+}
+
+func NewClusterID2(key string) ClusterID2 {
+	return ClusterID2{NewComponentIDKeyOnly(KindCluster, key)}
+}
+
+func NewSuperchainID2(key string) SuperchainID2 {
+	return SuperchainID2{NewComponentIDKeyOnly(KindSuperchain, key)}
+}
+
+func NewTestSequencerID2(key string) TestSequencerID2 {
+	return TestSequencerID2{NewComponentIDKeyOnly(KindTestSequencer, key)}
+}
+
+func NewFlashblocksClientID2(key string, chainID eth.ChainID) FlashblocksClientID2 {
+	return FlashblocksClientID2{NewComponentID(KindFlashblocksClient, key, chainID)}
+}
+
+// ID methods that delegate to ComponentID but preserve type safety.
+
+// Kind returns the ComponentKind for this ID type.
+// Unlike ComponentID.Kind(), this works even on zero values.
+func (id ID[T]) Kind() ComponentKind {
+	var marker T
+	return marker.componentKind()
+}
+
+func (id ID[T]) String() string {
+	return id.ComponentID.String()
+}
+
+func (id ID[T]) LogValue() slog.Value {
+	return id.ComponentID.LogValue()
+}
+
+func (id ID[T]) MarshalText() ([]byte, error) {
+	return id.ComponentID.MarshalText()
+}
+
+func (id *ID[T]) UnmarshalText(data []byte) error {
+	var marker T
+	return id.ComponentID.unmarshalTextWithKind(marker.componentKind(), data)
+}
+
+// Less compares two IDs of the same type for sorting.
+func (id ID[T]) Less(other ID[T]) bool {
+	return id.ComponentID.Less(other.ComponentID)
+}
+
+// SortIDs sorts a slice of IDs of any type.
+func SortIDs[T KindMarker](ids []ID[T]) []ID[T] {
+	return copyAndSort(ids, func(a, b ID[T]) bool {
+		return a.Less(b)
+	})
+}
+
+// AsComponentID returns the underlying ComponentID.
+// This is useful when you need to work with IDs in a type-erased context.
+func (id ID[T]) AsComponentID() ComponentID {
+	return id.ComponentID
+}
+
+// Conversion helpers between old and new ID systems.
+// These enable incremental migration from the old ID types to the new unified system.
+
+// ConvertL2BatcherID converts an old L2BatcherID to the new system.
+func ConvertL2BatcherID(old L2BatcherID) L2BatcherID2 {
+	return NewL2BatcherID2(old.Key(), old.ChainID())
+}
+
+// ConvertL2ELNodeID converts an old L2ELNodeID to the new system.
+func ConvertL2ELNodeID(old L2ELNodeID) L2ELNodeID2 {
+	return NewL2ELNodeID2(old.Key(), old.ChainID())
+}
+
+// ConvertL2CLNodeID converts an old L2CLNodeID to the new system.
+func ConvertL2CLNodeID(old L2CLNodeID) L2CLNodeID2 {
+	return NewL2CLNodeID2(old.Key(), old.ChainID())
+}
+
+// ConvertL1ELNodeID converts an old L1ELNodeID to the new system.
+func ConvertL1ELNodeID(old L1ELNodeID) L1ELNodeID2 {
+	return NewL1ELNodeID2(old.Key(), old.ChainID())
+}
+
+// ConvertL1CLNodeID converts an old L1CLNodeID to the new system.
+func ConvertL1CLNodeID(old L1CLNodeID) L1CLNodeID2 {
+	return NewL1CLNodeID2(old.Key(), old.ChainID())
+}
+
+// ConvertL1NetworkID converts an old L1NetworkID to the new system.
+func ConvertL1NetworkID(old L1NetworkID) L1NetworkID2 {
+	return NewL1NetworkID2(old.ChainID())
+}
+
+// ConvertL2NetworkID converts an old L2NetworkID to the new system.
+func ConvertL2NetworkID(old L2NetworkID) L2NetworkID2 {
+	return NewL2NetworkID2(old.ChainID())
+}
+
+// ConvertL2ProposerID converts an old L2ProposerID to the new system.
+func ConvertL2ProposerID(old L2ProposerID) L2ProposerID2 {
+	return NewL2ProposerID2(old.Key(), old.ChainID())
+}
+
+// ConvertL2ChallengerID converts an old L2ChallengerID to the new system.
+func ConvertL2ChallengerID(old L2ChallengerID) L2ChallengerID2 {
+	return NewL2ChallengerID2(old.Key(), old.ChainID())
+}
+
+// ConvertRollupBoostNodeID converts an old RollupBoostNodeID to the new system.
+func ConvertRollupBoostNodeID(old RollupBoostNodeID) RollupBoostNodeID2 {
+	return NewRollupBoostNodeID2(old.Key(), old.ChainID())
+}
+
+// ConvertOPRBuilderNodeID converts an old OPRBuilderNodeID to the new system.
+func ConvertOPRBuilderNodeID(old OPRBuilderNodeID) OPRBuilderNodeID2 {
+	return NewOPRBuilderNodeID2(old.Key(), old.ChainID())
+}
+
+// ConvertFaucetID converts an old FaucetID to the new system.
+func ConvertFaucetID(old FaucetID) FaucetID2 {
+	return NewFaucetID2(old.Key(), old.ChainID())
+}
+
+// ConvertSyncTesterID converts an old SyncTesterID to the new system.
+func ConvertSyncTesterID(old SyncTesterID) SyncTesterID2 {
+	return NewSyncTesterID2(old.Key(), old.ChainID())
+}
+
+// ConvertSupervisorID converts an old SupervisorID to the new system.
+func ConvertSupervisorID(old SupervisorID) SupervisorID2 {
+	return NewSupervisorID2(string(old))
+}
+
+// ConvertConductorID converts an old ConductorID to the new system.
+func ConvertConductorID(old ConductorID) ConductorID2 {
+	return NewConductorID2(string(old))
+}
+
+// ConvertClusterID converts an old ClusterID to the new system.
+func ConvertClusterID(old ClusterID) ClusterID2 {
+	return NewClusterID2(string(old))
+}
+
+// ConvertSuperchainID converts an old SuperchainID to the new system.
+func ConvertSuperchainID(old SuperchainID) SuperchainID2 {
+	return NewSuperchainID2(string(old))
+}
+
+// ConvertTestSequencerID converts an old TestSequencerID to the new system.
+func ConvertTestSequencerID(old TestSequencerID) TestSequencerID2 {
+	return NewTestSequencerID2(string(old))
+}
+
+// ConvertFlashblocksClientID converts an old FlashblocksWSClientID to the new system.
+func ConvertFlashblocksClientID(old FlashblocksWSClientID) FlashblocksClientID2 {
+	return NewFlashblocksClientID2(idWithChain(old).key, old.ChainID())
+}

--- a/op-devstack/stack/component_id_test.go
+++ b/op-devstack/stack/component_id_test.go
@@ -1,0 +1,333 @@
+package stack
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/stretchr/testify/require"
+)
+
+func TestComponentID_KeyAndChain(t *testing.T) {
+	chainID := eth.ChainIDFromUInt64(420)
+	id := NewComponentID(KindL2Batcher, "mynode", chainID)
+
+	require.Equal(t, KindL2Batcher, id.Kind())
+	require.Equal(t, "mynode", id.Key())
+	require.Equal(t, chainID, id.ChainID())
+	require.Equal(t, IDShapeKeyAndChain, id.Shape())
+	require.Equal(t, "L2Batcher-mynode-420", id.String())
+}
+
+func TestComponentID_ChainOnly(t *testing.T) {
+	chainID := eth.ChainIDFromUInt64(1)
+	id := NewComponentIDChainOnly(KindL1Network, chainID)
+
+	require.Equal(t, KindL1Network, id.Kind())
+	require.Equal(t, "", id.Key())
+	require.Equal(t, chainID, id.ChainID())
+	require.Equal(t, IDShapeChainOnly, id.Shape())
+	require.Equal(t, "L1Network-1", id.String())
+}
+
+func TestComponentID_KeyOnly(t *testing.T) {
+	id := NewComponentIDKeyOnly(KindSupervisor, "mysupervisor")
+
+	require.Equal(t, KindSupervisor, id.Kind())
+	require.Equal(t, "mysupervisor", id.Key())
+	require.Equal(t, eth.ChainID{}, id.ChainID())
+	require.Equal(t, IDShapeKeyOnly, id.Shape())
+	require.Equal(t, "Supervisor-mysupervisor", id.String())
+}
+
+func TestComponentID_MarshalRoundTrip_KeyAndChain(t *testing.T) {
+	chainID := eth.ChainIDFromUInt64(420)
+	original := NewComponentID(KindL2Batcher, "mynode", chainID)
+
+	data, err := original.MarshalText()
+	require.NoError(t, err)
+	require.Equal(t, "L2Batcher-mynode-420", string(data))
+
+	var parsed ComponentID
+	parsed.kind = KindL2Batcher // Must set kind before unmarshal
+	err = parsed.UnmarshalText(data)
+	require.NoError(t, err)
+	require.Equal(t, original, parsed)
+}
+
+func TestComponentID_MarshalRoundTrip_ChainOnly(t *testing.T) {
+	chainID := eth.ChainIDFromUInt64(1)
+	original := NewComponentIDChainOnly(KindL1Network, chainID)
+
+	data, err := original.MarshalText()
+	require.NoError(t, err)
+	require.Equal(t, "L1Network-1", string(data))
+
+	var parsed ComponentID
+	parsed.kind = KindL1Network
+	err = parsed.UnmarshalText(data)
+	require.NoError(t, err)
+	require.Equal(t, original, parsed)
+}
+
+func TestComponentID_MarshalRoundTrip_KeyOnly(t *testing.T) {
+	original := NewComponentIDKeyOnly(KindSupervisor, "mysupervisor")
+
+	data, err := original.MarshalText()
+	require.NoError(t, err)
+	require.Equal(t, "Supervisor-mysupervisor", string(data))
+
+	var parsed ComponentID
+	parsed.kind = KindSupervisor
+	err = parsed.UnmarshalText(data)
+	require.NoError(t, err)
+	require.Equal(t, original, parsed)
+}
+
+func TestComponentID_UnmarshalKindMismatch(t *testing.T) {
+	var id ComponentID
+	id.kind = KindL2Batcher
+	err := id.UnmarshalText([]byte("L2ELNode-mynode-420"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unexpected kind")
+}
+
+func TestID_TypeSafety(t *testing.T) {
+	chainID := eth.ChainIDFromUInt64(420)
+
+	// Create two different ID types with same key and chainID
+	batcherID := NewL2BatcherID2("mynode", chainID)
+	elNodeID := NewL2ELNodeID2("mynode", chainID)
+
+	// They should have different kinds
+	require.Equal(t, KindL2Batcher, batcherID.Kind())
+	require.Equal(t, KindL2ELNode, elNodeID.Kind())
+
+	// Their string representations should be different
+	require.Equal(t, "L2Batcher-mynode-420", batcherID.String())
+	require.Equal(t, "L2ELNode-mynode-420", elNodeID.String())
+
+	// The underlying ComponentIDs should be different due to kind
+	require.NotEqual(t, batcherID.AsComponentID(), elNodeID.AsComponentID())
+}
+
+func TestID_MarshalRoundTrip(t *testing.T) {
+	chainID := eth.ChainIDFromUInt64(420)
+	original := NewL2BatcherID2("mynode", chainID)
+
+	data, err := original.MarshalText()
+	require.NoError(t, err)
+	require.Equal(t, "L2Batcher-mynode-420", string(data))
+
+	// Unmarshal into a zero value - Kind() should still work
+	var parsed L2BatcherID2
+	require.Equal(t, KindL2Batcher, parsed.Kind()) // Works on zero value!
+
+	err = parsed.UnmarshalText(data)
+	require.NoError(t, err)
+	require.Equal(t, original, parsed)
+}
+
+func TestID_UnmarshalKindMismatch(t *testing.T) {
+	// Try to unmarshal an L2ELNode ID into an L2Batcher ID
+	var batcherID L2BatcherID2
+	err := batcherID.UnmarshalText([]byte("L2ELNode-mynode-420"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unexpected kind")
+}
+
+func TestID_ChainOnlyTypes(t *testing.T) {
+	chainID := eth.ChainIDFromUInt64(1)
+	networkID := NewL1NetworkID2(chainID)
+
+	require.Equal(t, KindL1Network, networkID.Kind())
+	require.Equal(t, chainID, networkID.ChainID())
+	require.Equal(t, "L1Network-1", networkID.String())
+
+	data, err := networkID.MarshalText()
+	require.NoError(t, err)
+
+	var parsed L1NetworkID2
+	err = parsed.UnmarshalText(data)
+	require.NoError(t, err)
+	require.Equal(t, networkID, parsed)
+}
+
+func TestID_KeyOnlyTypes(t *testing.T) {
+	supervisorID := NewSupervisorID2("mysupervisor")
+
+	require.Equal(t, KindSupervisor, supervisorID.Kind())
+	require.Equal(t, "mysupervisor", supervisorID.Key())
+	require.Equal(t, "Supervisor-mysupervisor", supervisorID.String())
+
+	data, err := supervisorID.MarshalText()
+	require.NoError(t, err)
+
+	var parsed SupervisorID2
+	err = parsed.UnmarshalText(data)
+	require.NoError(t, err)
+	require.Equal(t, supervisorID, parsed)
+}
+
+func TestID_Sorting(t *testing.T) {
+	chainID1 := eth.ChainIDFromUInt64(100)
+	chainID2 := eth.ChainIDFromUInt64(200)
+
+	ids := []L2BatcherID2{
+		NewL2BatcherID2("charlie", chainID1),
+		NewL2BatcherID2("alice", chainID1),
+		NewL2BatcherID2("alice", chainID2),
+		NewL2BatcherID2("bob", chainID1),
+	}
+
+	sorted := SortIDs(ids)
+
+	// Should be sorted by key first, then by chainID
+	require.Equal(t, "alice", sorted[0].Key())
+	require.Equal(t, chainID1, sorted[0].ChainID())
+	require.Equal(t, "alice", sorted[1].Key())
+	require.Equal(t, chainID2, sorted[1].ChainID())
+	require.Equal(t, "bob", sorted[2].Key())
+	require.Equal(t, "charlie", sorted[3].Key())
+}
+
+func TestID_MapKey(t *testing.T) {
+	chainID := eth.ChainIDFromUInt64(420)
+
+	// IDs should work as map keys
+	m := make(map[L2BatcherID2]string)
+
+	id1 := NewL2BatcherID2("node1", chainID)
+	id2 := NewL2BatcherID2("node2", chainID)
+
+	m[id1] = "value1"
+	m[id2] = "value2"
+
+	require.Equal(t, "value1", m[id1])
+	require.Equal(t, "value2", m[id2])
+
+	// Same key+chainID should retrieve same value
+	id1Copy := NewL2BatcherID2("node1", chainID)
+	require.Equal(t, "value1", m[id1Copy])
+}
+
+func TestAllIDTypes(t *testing.T) {
+	chainID := eth.ChainIDFromUInt64(420)
+
+	// Test all ID constructors and their kinds
+	tests := []struct {
+		name     string
+		id       interface{ Kind() ComponentKind }
+		expected ComponentKind
+	}{
+		{"L1ELNode", NewL1ELNodeID2("node", chainID), KindL1ELNode},
+		{"L1CLNode", NewL1CLNodeID2("node", chainID), KindL1CLNode},
+		{"L1Network", NewL1NetworkID2(chainID), KindL1Network},
+		{"L2ELNode", NewL2ELNodeID2("node", chainID), KindL2ELNode},
+		{"L2CLNode", NewL2CLNodeID2("node", chainID), KindL2CLNode},
+		{"L2Network", NewL2NetworkID2(chainID), KindL2Network},
+		{"L2Batcher", NewL2BatcherID2("node", chainID), KindL2Batcher},
+		{"L2Proposer", NewL2ProposerID2("node", chainID), KindL2Proposer},
+		{"L2Challenger", NewL2ChallengerID2("node", chainID), KindL2Challenger},
+		{"RollupBoostNode", NewRollupBoostNodeID2("node", chainID), KindRollupBoostNode},
+		{"OPRBuilderNode", NewOPRBuilderNodeID2("node", chainID), KindOPRBuilderNode},
+		{"Faucet", NewFaucetID2("node", chainID), KindFaucet},
+		{"SyncTester", NewSyncTesterID2("node", chainID), KindSyncTester},
+		{"Supervisor", NewSupervisorID2("node"), KindSupervisor},
+		{"Conductor", NewConductorID2("node"), KindConductor},
+		{"Cluster", NewClusterID2("node"), KindCluster},
+		{"Superchain", NewSuperchainID2("node"), KindSuperchain},
+		{"TestSequencer", NewTestSequencerID2("node"), KindTestSequencer},
+		{"FlashblocksClient", NewFlashblocksClientID2("node", chainID), KindFlashblocksClient},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, tt.id.Kind())
+		})
+	}
+}
+
+// TestSerializationCompatibility verifies that the new ID system produces
+// the same serialization format as the old system.
+func TestSerializationCompatibility(t *testing.T) {
+	chainID := eth.ChainIDFromUInt64(420)
+
+	// These formats must match the old ID system exactly
+	tests := []struct {
+		name     string
+		id       interface{ MarshalText() ([]byte, error) }
+		expected string
+	}{
+		{"L2Batcher", NewL2BatcherID2("mynode", chainID), "L2Batcher-mynode-420"},
+		{"L2ELNode", NewL2ELNodeID2("mynode", chainID), "L2ELNode-mynode-420"},
+		{"L1Network", NewL1NetworkID2(eth.ChainIDFromUInt64(1)), "L1Network-1"},
+		{"Supervisor", NewSupervisorID2("mysupervisor"), "Supervisor-mysupervisor"},
+		{"RollupBoostNode", NewRollupBoostNodeID2("boost", chainID), "RollupBoostNode-boost-420"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := tt.id.MarshalText()
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, string(data))
+		})
+	}
+}
+
+// TestConversionHelpers verifies that conversion between old and new ID systems
+// preserves all data correctly.
+func TestConversionHelpers(t *testing.T) {
+	chainID := eth.ChainIDFromUInt64(420)
+
+	t.Run("L2BatcherID", func(t *testing.T) {
+		old := NewL2BatcherID("mynode", chainID)
+		new := ConvertL2BatcherID(old)
+		require.Equal(t, KindL2Batcher, new.Kind())
+		require.Equal(t, "mynode", new.Key())
+		require.Equal(t, chainID, new.ChainID())
+		require.Equal(t, old.String(), new.String())
+	})
+
+	t.Run("L2ELNodeID", func(t *testing.T) {
+		old := NewL2ELNodeID("mynode", chainID)
+		new := ConvertL2ELNodeID(old)
+		require.Equal(t, KindL2ELNode, new.Kind())
+		require.Equal(t, "mynode", new.Key())
+		require.Equal(t, chainID, new.ChainID())
+		require.Equal(t, old.String(), new.String())
+	})
+
+	t.Run("L1NetworkID", func(t *testing.T) {
+		old := L1NetworkID(eth.ChainIDFromUInt64(1))
+		new := ConvertL1NetworkID(old)
+		require.Equal(t, KindL1Network, new.Kind())
+		require.Equal(t, eth.ChainIDFromUInt64(1), new.ChainID())
+		require.Equal(t, old.String(), new.String())
+	})
+
+	t.Run("SupervisorID", func(t *testing.T) {
+		old := SupervisorID("mysupervisor")
+		new := ConvertSupervisorID(old)
+		require.Equal(t, KindSupervisor, new.Kind())
+		require.Equal(t, "mysupervisor", new.Key())
+		require.Equal(t, old.String(), new.String())
+	})
+
+	t.Run("RollupBoostNodeID", func(t *testing.T) {
+		old := NewRollupBoostNodeID("boost", chainID)
+		new := ConvertRollupBoostNodeID(old)
+		require.Equal(t, KindRollupBoostNode, new.Kind())
+		require.Equal(t, "boost", new.Key())
+		require.Equal(t, chainID, new.ChainID())
+		require.Equal(t, old.String(), new.String())
+	})
+
+	t.Run("FlashblocksWSClientID", func(t *testing.T) {
+		old := NewFlashblocksWSClientID("fbclient", chainID)
+		new := ConvertFlashblocksClientID(old)
+		require.Equal(t, KindFlashblocksClient, new.Kind())
+		require.Equal(t, "fbclient", new.Key())
+		require.Equal(t, chainID, new.ChainID())
+		require.Equal(t, old.String(), new.String())
+	})
+}


### PR DESCRIPTION
This PR introduces a new unified ID type system for op-devstack that addresses the parallel type system problem where 19 separate ID types each require ~150 lines of boilerplate code. The new system uses Go generics to provide type safety with a single underlying implementation.

**This is Phase 1 of a multi-phase refactor.** It introduces the new types alongside the existing system, with no breaking changes.

## Problem

The current ID system has several issues:

1. **Code Duplication**: 19 ID types × ~150 lines each = ~2,850 lines of nearly identical boilerplate
2. **Parallel Type Systems**: Each ID type (e.g., `L2BatcherID`) has separate marshal/unmarshal, String(), sorting functions
3. **Polymorphic Lookup Complexity**: `RollupBoostNode` is-a `L2ELNode`, but their ID types are separate, requiring manual conversion in lookups
4. **No Unified Querying**: Can't easily query "all components on chain X" without checking each registry

See the [design document](https://www.notion.so/oplabs/Devstack-ID-Type-System-Refactor-2eef153ee1628048bb7ade1030fe6e9b) for the full rationale.

## Solution

Introduce a unified `ComponentID` type with a generic wrapper `ID[T]` for type safety:

```go
// Single underlying type for all IDs
type ComponentID struct {
    kind    ComponentKind
    shape   IDShape
    key     string
    chainID eth.ChainID
}

// Type-safe wrapper using generics
type ID[T KindMarker] struct {
    ComponentID
}

// Marker types provide compile-time type safety
type L2BatcherMarker struct{}
func (L2BatcherMarker) componentKind() ComponentKind { return KindL2Batcher }

// Type alias for backward-compatible naming
type L2BatcherID2 = ID[L2BatcherMarker]
```

## Changes

### New Files

| File | Description |
|------|-------------|
| `stack/component_id.go` | Unified ID system (~500 lines) |
| `stack/component_id_test.go` | Comprehensive test suite (~330 lines) |

### Key Features

- **Single Implementation**: One `MarshalText`/`UnmarshalText` implementation for all ID types
- **Type Safety**: `L2BatcherID2` and `L2ELNodeID2` are distinct types at compile time
- **IDShape**: Handles three ID formats (key+chain, chain-only, key-only) cleanly
- **Conversion Helpers**: `ConvertL2BatcherID(old) L2BatcherID2` for incremental migration
- **Serialization Compatible**: Produces identical output to old system (`"L2Batcher-mynode-420"`)

### Non-Breaking

- Old ID types (`L2BatcherID`, etc.) remain unchanged
- New types use "2" suffix (`L2BatcherID2`, `NewL2BatcherID2()`)
- Both systems can coexist during migration

## Test Plan

- [x] All new ID type constructors create correct kind/key/chainID
- [x] Marshal/Unmarshal round-trip works for all three ID shapes
- [x] Type safety verified (different ID types are not interchangeable)
- [x] Kind mismatch during unmarshal produces clear error
- [x] Conversion helpers preserve all data
- [x] Serialization output matches old system exactly
- [x] IDs work as map keys
- [x] Sorting works correctly
- [x] Existing stack tests pass

## Future Phases

- **Phase 2**: Unified Registry to replace 12+ separate `RWMap` instances
- **Phase 3**: Capability interfaces (`L2ELCapable`) for polymorphic lookups
- **Phase 4**: Remove old ID types, simplify interfaces

## How to Review

1. Start with `stack/component_id.go`:
   - `ComponentID` struct and its methods (lines 1-200)
   - `KindMarker` interface and marker types (lines 200-260)
   - Type aliases and constructors (lines 260-360)
   - `ID[T]` methods (lines 360-400)
   - Conversion helpers (lines 400-500)

2. Review `stack/component_id_test.go` to understand the expected behavior

3. Check the [design document](https://www.notion.so/oplabs/Devstack-ID-Type-System-Refactor-2eef153ee1628048bb7ade1030fe6e9b) for the full rationale
