### PR TITLE
refactor(op-devstack): migrate Orchestrator to unified Registry (Phase 4)

### DIFF
--- a/op-devstack/stack/capabilities.go
+++ b/op-devstack/stack/capabilities.go
@@ -1,0 +1,134 @@
+package stack
+
+import (
+	"github.com/ethereum-optimism/optimism/op-service/apis"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+// Capability interfaces define shared behaviors across component types.
+// These enable polymorphic operations without requiring components to
+// implement interfaces with incompatible ID() method signatures.
+//
+// For example, RollupBoostNode and OPRBuilderNode both provide L2 EL
+// functionality but can't implement L2ELNode because their ID() methods
+// return different types. The L2ELCapable interface captures the shared
+// L2 EL behavior, allowing code to work with any L2 EL-like component.
+
+// L2ELCapable is implemented by any component that provides L2 execution layer functionality.
+// This includes L2ELNode, RollupBoostNode, and OPRBuilderNode.
+//
+// Components implementing this interface can:
+// - Execute L2 transactions
+// - Provide engine API access for consensus layer integration
+type L2ELCapable interface {
+	L2EthClient() apis.L2EthClient
+	L2EngineClient() apis.EngineClient
+	ELNode
+}
+
+// L2ELCapableKinds returns all ComponentKinds that implement L2ELCapable.
+func L2ELCapableKinds() []ComponentKind {
+	return []ComponentKind{
+		KindL2ELNode,
+		KindRollupBoostNode,
+		KindOPRBuilderNode,
+	}
+}
+
+// L1ELCapable is implemented by any component that provides L1 execution layer functionality.
+type L1ELCapable interface {
+	ELNode
+}
+
+// L1ELCapableKinds returns all ComponentKinds that implement L1ELCapable.
+func L1ELCapableKinds() []ComponentKind {
+	return []ComponentKind{
+		KindL1ELNode,
+	}
+}
+
+// Verify that expected types implement capability interfaces.
+// These are compile-time checks.
+var (
+	_ L2ELCapable = (L2ELNode)(nil)
+	_ L2ELCapable = (RollupBoostNode)(nil)
+	_ L2ELCapable = (OPRBuilderNode)(nil)
+)
+
+// Registry helper functions for capability-based lookups.
+
+// RegistryFindByCapability returns all components that implement the given capability interface.
+// This iterates over all components and performs a type assertion.
+func RegistryFindByCapability[T any](r *Registry) []T {
+	var result []T
+	r.Range(func(id ComponentID, component any) bool {
+		if capable, ok := component.(T); ok {
+			result = append(result, capable)
+		}
+		return true
+	})
+	return result
+}
+
+// RegistryFindByCapabilityOnChain returns all components on a specific chain
+// that implement the given capability interface.
+func RegistryFindByCapabilityOnChain[T any](r *Registry, chainID eth.ChainID) []T {
+	var result []T
+	r.RangeByChainID(chainID, func(id ComponentID, component any) bool {
+		if capable, ok := component.(T); ok {
+			result = append(result, capable)
+		}
+		return true
+	})
+	return result
+}
+
+// RegistryFindByKinds returns all components of the specified kinds.
+// This is useful when you know which kinds implement a capability.
+func RegistryFindByKinds(r *Registry, kinds []ComponentKind) []any {
+	var result []any
+	for _, kind := range kinds {
+		result = append(result, r.GetByKind(kind)...)
+	}
+	return result
+}
+
+// RegistryFindByKindsTyped returns all components of the specified kinds,
+// cast to the expected type. Components that don't match are skipped.
+func RegistryFindByKindsTyped[T any](r *Registry, kinds []ComponentKind) []T {
+	var result []T
+	for _, kind := range kinds {
+		for _, component := range r.GetByKind(kind) {
+			if typed, ok := component.(T); ok {
+				result = append(result, typed)
+			}
+		}
+	}
+	return result
+}
+
+// FindL2ELCapable returns all L2 EL-capable components in the registry.
+// This is a convenience function that finds L2ELNode, RollupBoostNode, and OPRBuilderNode.
+func FindL2ELCapable(r *Registry) []L2ELCapable {
+	return RegistryFindByKindsTyped[L2ELCapable](r, L2ELCapableKinds())
+}
+
+// FindL2ELCapableOnChain returns all L2 EL-capable components on a specific chain.
+func FindL2ELCapableOnChain(r *Registry, chainID eth.ChainID) []L2ELCapable {
+	return RegistryFindByCapabilityOnChain[L2ELCapable](r, chainID)
+}
+
+// FindL2ELCapableByKey returns the first L2 EL-capable component with the given key and chainID.
+// This enables the polymorphic lookup pattern where you want to find a node by key
+// regardless of whether it's an L2ELNode, RollupBoostNode, or OPRBuilderNode.
+func FindL2ELCapableByKey(r *Registry, key string, chainID eth.ChainID) (L2ELCapable, bool) {
+	for _, kind := range L2ELCapableKinds() {
+		id := NewComponentID(kind, key, chainID)
+		if component, ok := r.Get(id); ok {
+			if capable, ok := component.(L2ELCapable); ok {
+				return capable, true
+			}
+		}
+	}
+	return nil, false
+}

--- a/op-devstack/stack/capabilities_test.go
+++ b/op-devstack/stack/capabilities_test.go
@@ -1,0 +1,312 @@
+package stack
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-service/apis"
+	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+)
+
+// Mock implementations for testing capabilities
+
+type mockELNode struct {
+	chainID eth.ChainID
+}
+
+func (m *mockELNode) T() devtest.T                      { return nil }
+func (m *mockELNode) Logger() log.Logger                { return nil }
+func (m *mockELNode) Label(key string) string           { return "" }
+func (m *mockELNode) SetLabel(key, value string)        {}
+func (m *mockELNode) ChainID() eth.ChainID              { return m.chainID }
+func (m *mockELNode) EthClient() apis.EthClient         { return nil }
+func (m *mockELNode) TransactionTimeout() time.Duration { return 0 }
+
+type mockL2ELNode struct {
+	mockELNode
+	id L2ELNodeID
+}
+
+func (m *mockL2ELNode) ID() L2ELNodeID                    { return m.id }
+func (m *mockL2ELNode) L2EthClient() apis.L2EthClient     { return nil }
+func (m *mockL2ELNode) L2EngineClient() apis.EngineClient { return nil }
+func (m *mockL2ELNode) RegistryID() ComponentID           { return ConvertL2ELNodeID(m.id).ComponentID }
+
+var _ L2ELNode = (*mockL2ELNode)(nil)
+var _ L2ELCapable = (*mockL2ELNode)(nil)
+var _ Registrable = (*mockL2ELNode)(nil)
+
+type mockRollupBoostNode struct {
+	mockELNode
+	id RollupBoostNodeID
+}
+
+func (m *mockRollupBoostNode) ID() RollupBoostNodeID               { return m.id }
+func (m *mockRollupBoostNode) L2EthClient() apis.L2EthClient       { return nil }
+func (m *mockRollupBoostNode) L2EngineClient() apis.EngineClient   { return nil }
+func (m *mockRollupBoostNode) FlashblocksClient() *client.WSClient { return nil }
+func (m *mockRollupBoostNode) RegistryID() ComponentID {
+	return ConvertRollupBoostNodeID(m.id).ComponentID
+}
+
+var _ RollupBoostNode = (*mockRollupBoostNode)(nil)
+var _ L2ELCapable = (*mockRollupBoostNode)(nil)
+var _ Registrable = (*mockRollupBoostNode)(nil)
+
+type mockOPRBuilderNode struct {
+	mockELNode
+	id OPRBuilderNodeID
+}
+
+func (m *mockOPRBuilderNode) ID() OPRBuilderNodeID                { return m.id }
+func (m *mockOPRBuilderNode) L2EthClient() apis.L2EthClient       { return nil }
+func (m *mockOPRBuilderNode) L2EngineClient() apis.EngineClient   { return nil }
+func (m *mockOPRBuilderNode) FlashblocksClient() *client.WSClient { return nil }
+func (m *mockOPRBuilderNode) RegistryID() ComponentID {
+	return ConvertOPRBuilderNodeID(m.id).ComponentID
+}
+
+var _ OPRBuilderNode = (*mockOPRBuilderNode)(nil)
+var _ L2ELCapable = (*mockOPRBuilderNode)(nil)
+var _ Registrable = (*mockOPRBuilderNode)(nil)
+
+func TestL2ELCapableKinds(t *testing.T) {
+	kinds := L2ELCapableKinds()
+	require.Len(t, kinds, 3)
+	require.Contains(t, kinds, KindL2ELNode)
+	require.Contains(t, kinds, KindRollupBoostNode)
+	require.Contains(t, kinds, KindOPRBuilderNode)
+}
+
+func TestRegistryFindByCapability(t *testing.T) {
+	r := NewRegistry()
+
+	chainID := eth.ChainIDFromUInt64(420)
+
+	// Register different L2 EL-capable nodes
+	l2el := &mockL2ELNode{
+		mockELNode: mockELNode{chainID: chainID},
+		id:         NewL2ELNodeID("sequencer", chainID),
+	}
+	rollupBoost := &mockRollupBoostNode{
+		mockELNode: mockELNode{chainID: chainID},
+		id:         NewRollupBoostNodeID("boost", chainID),
+	}
+	oprBuilder := &mockOPRBuilderNode{
+		mockELNode: mockELNode{chainID: chainID},
+		id:         NewOPRBuilderNodeID("builder", chainID),
+	}
+
+	r.RegisterComponent(l2el)
+	r.RegisterComponent(rollupBoost)
+	r.RegisterComponent(oprBuilder)
+
+	// Also register a non-L2EL component
+	r.Register(NewComponentID(KindL2Batcher, "batcher", chainID), "not-l2el-capable")
+
+	// Find all L2ELCapable
+	capable := RegistryFindByCapability[L2ELCapable](r)
+	require.Len(t, capable, 3)
+}
+
+func TestRegistryFindByCapabilityOnChain(t *testing.T) {
+	r := NewRegistry()
+
+	chainID1 := eth.ChainIDFromUInt64(420)
+	chainID2 := eth.ChainIDFromUInt64(421)
+
+	// Nodes on chain 420
+	l2el1 := &mockL2ELNode{
+		mockELNode: mockELNode{chainID: chainID1},
+		id:         NewL2ELNodeID("sequencer", chainID1),
+	}
+	rollupBoost1 := &mockRollupBoostNode{
+		mockELNode: mockELNode{chainID: chainID1},
+		id:         NewRollupBoostNodeID("boost", chainID1),
+	}
+
+	// Node on chain 421
+	l2el2 := &mockL2ELNode{
+		mockELNode: mockELNode{chainID: chainID2},
+		id:         NewL2ELNodeID("sequencer", chainID2),
+	}
+
+	r.RegisterComponent(l2el1)
+	r.RegisterComponent(rollupBoost1)
+	r.RegisterComponent(l2el2)
+
+	// Find on chain 420
+	chain420 := RegistryFindByCapabilityOnChain[L2ELCapable](r, chainID1)
+	require.Len(t, chain420, 2)
+
+	// Find on chain 421
+	chain421 := RegistryFindByCapabilityOnChain[L2ELCapable](r, chainID2)
+	require.Len(t, chain421, 1)
+}
+
+func TestFindL2ELCapable(t *testing.T) {
+	r := NewRegistry()
+
+	chainID := eth.ChainIDFromUInt64(420)
+
+	l2el := &mockL2ELNode{
+		mockELNode: mockELNode{chainID: chainID},
+		id:         NewL2ELNodeID("sequencer", chainID),
+	}
+	rollupBoost := &mockRollupBoostNode{
+		mockELNode: mockELNode{chainID: chainID},
+		id:         NewRollupBoostNodeID("boost", chainID),
+	}
+
+	r.RegisterComponent(l2el)
+	r.RegisterComponent(rollupBoost)
+
+	capable := FindL2ELCapable(r)
+	require.Len(t, capable, 2)
+}
+
+func TestFindL2ELCapableOnChain(t *testing.T) {
+	r := NewRegistry()
+
+	chainID1 := eth.ChainIDFromUInt64(420)
+	chainID2 := eth.ChainIDFromUInt64(421)
+
+	l2el1 := &mockL2ELNode{
+		mockELNode: mockELNode{chainID: chainID1},
+		id:         NewL2ELNodeID("sequencer", chainID1),
+	}
+	l2el2 := &mockL2ELNode{
+		mockELNode: mockELNode{chainID: chainID2},
+		id:         NewL2ELNodeID("sequencer", chainID2),
+	}
+
+	r.RegisterComponent(l2el1)
+	r.RegisterComponent(l2el2)
+
+	chain420 := FindL2ELCapableOnChain(r, chainID1)
+	require.Len(t, chain420, 1)
+	require.Equal(t, chainID1, chain420[0].ChainID())
+}
+
+func TestFindL2ELCapableByKey(t *testing.T) {
+	r := NewRegistry()
+
+	chainID := eth.ChainIDFromUInt64(420)
+
+	// Register a RollupBoostNode with key "sequencer"
+	rollupBoost := &mockRollupBoostNode{
+		mockELNode: mockELNode{chainID: chainID},
+		id:         NewRollupBoostNodeID("sequencer", chainID),
+	}
+	r.RegisterComponent(rollupBoost)
+
+	// Should find it by key, even though it's not an L2ELNode
+	found, ok := FindL2ELCapableByKey(r, "sequencer", chainID)
+	require.True(t, ok)
+	require.NotNil(t, found)
+	require.Equal(t, chainID, found.ChainID())
+
+	// Should not find non-existent key
+	_, ok = FindL2ELCapableByKey(r, "nonexistent", chainID)
+	require.False(t, ok)
+}
+
+func TestFindL2ELCapableByKey_PrefersL2ELNode(t *testing.T) {
+	r := NewRegistry()
+
+	chainID := eth.ChainIDFromUInt64(420)
+
+	// Register both L2ELNode and RollupBoostNode with same key
+	l2el := &mockL2ELNode{
+		mockELNode: mockELNode{chainID: chainID},
+		id:         NewL2ELNodeID("sequencer", chainID),
+	}
+	rollupBoost := &mockRollupBoostNode{
+		mockELNode: mockELNode{chainID: chainID},
+		id:         NewRollupBoostNodeID("sequencer", chainID),
+	}
+
+	r.RegisterComponent(l2el)
+	r.RegisterComponent(rollupBoost)
+
+	// Should find L2ELNode first (it's first in L2ELCapableKinds)
+	found, ok := FindL2ELCapableByKey(r, "sequencer", chainID)
+	require.True(t, ok)
+	// Verify it's the L2ELNode by checking it's the right mock type
+	_, isL2EL := found.(*mockL2ELNode)
+	require.True(t, isL2EL, "expected to find L2ELNode first")
+}
+
+func TestRegistryFindByKindsTyped(t *testing.T) {
+	r := NewRegistry()
+
+	chainID := eth.ChainIDFromUInt64(420)
+
+	l2el := &mockL2ELNode{
+		mockELNode: mockELNode{chainID: chainID},
+		id:         NewL2ELNodeID("sequencer", chainID),
+	}
+	rollupBoost := &mockRollupBoostNode{
+		mockELNode: mockELNode{chainID: chainID},
+		id:         NewRollupBoostNodeID("boost", chainID),
+	}
+
+	r.RegisterComponent(l2el)
+	r.RegisterComponent(rollupBoost)
+
+	// Find only L2ELNode kind
+	l2els := RegistryFindByKindsTyped[L2ELCapable](r, []ComponentKind{KindL2ELNode})
+	require.Len(t, l2els, 1)
+
+	// Find both kinds
+	both := RegistryFindByKindsTyped[L2ELCapable](r, []ComponentKind{KindL2ELNode, KindRollupBoostNode})
+	require.Len(t, both, 2)
+}
+
+// TestPolymorphicLookupScenario demonstrates the polymorphic lookup use case
+// that Phase 3 is designed to solve.
+func TestPolymorphicLookupScenario(t *testing.T) {
+	r := NewRegistry()
+
+	chainID := eth.ChainIDFromUInt64(420)
+
+	// Scenario: A test wants to find an L2 EL node by key "sequencer"
+	// The actual node could be L2ELNode, RollupBoostNode, or OPRBuilderNode
+	// depending on the test configuration.
+
+	// Configuration 1: Using RollupBoost
+	rollupBoost := &mockRollupBoostNode{
+		mockELNode: mockELNode{chainID: chainID},
+		id:         NewRollupBoostNodeID("sequencer", chainID),
+	}
+	r.RegisterComponent(rollupBoost)
+
+	// The polymorphic lookup finds the sequencer regardless of its concrete type
+	sequencer, ok := FindL2ELCapableByKey(r, "sequencer", chainID)
+	require.True(t, ok)
+	require.NotNil(t, sequencer)
+
+	// Can use it as L2ELCapable
+	require.Equal(t, chainID, sequencer.ChainID())
+	// Could call sequencer.L2EthClient(), sequencer.L2EngineClient(), etc.
+
+	// Clear and try with OPRBuilder
+	r.Clear()
+
+	oprBuilder := &mockOPRBuilderNode{
+		mockELNode: mockELNode{chainID: chainID},
+		id:         NewOPRBuilderNodeID("sequencer", chainID),
+	}
+	r.RegisterComponent(oprBuilder)
+
+	// Same lookup code works
+	sequencer, ok = FindL2ELCapableByKey(r, "sequencer", chainID)
+	require.True(t, ok)
+	require.NotNil(t, sequencer)
+	require.Equal(t, chainID, sequencer.ChainID())
+}

--- a/op-devstack/stack/component_id.go
+++ b/op-devstack/stack/component_id.go
@@ -37,6 +37,31 @@ const (
 	KindFlashblocksClient ComponentKind = "FlashblocksWSClient"
 )
 
+var hydrationComponentKindOrder = []ComponentKind{
+	KindSuperchain,
+	KindCluster,
+	KindL1Network,
+	KindL2Network,
+	KindL1ELNode,
+	KindL1CLNode,
+	KindL2ELNode,
+	KindOPRBuilderNode,
+	KindRollupBoostNode,
+	KindL2CLNode,
+	KindSupervisor,
+	KindTestSequencer,
+	KindL2Batcher,
+	KindL2Challenger,
+	KindL2Proposer,
+}
+
+// HydrationComponentKindOrder returns the deterministic kind ordering used by orchestrator hydration.
+func HydrationComponentKindOrder() []ComponentKind {
+	out := make([]ComponentKind, len(hydrationComponentKindOrder))
+	copy(out, hydrationComponentKindOrder)
+	return out
+}
+
 // IDShape defines which fields an ID uses.
 type IDShape uint8
 

--- a/op-devstack/sysgo/add_game_type.go
+++ b/op-devstack/sysgo/add_game_type.go
@@ -37,10 +37,9 @@ func WithGameTypeAdded(gameType gameTypes.GameType) stack.Option[*Orchestrator] 
 	opts := stack.FnOption[*Orchestrator]{
 		FinallyFn: func(o *Orchestrator) {
 			absolutePrestate := PrestateForGameType(o.P(), gameType)
-			l2NetIDs := o.registry.IDsByKind(stack.KindL2Network)
-			l1ELIDs := o.registry.IDsByKind(stack.KindL1ELNode)
+			l1ELID, l2NetIDs := requireGameTypeTargetIDs(o)
 			for _, l2NetID := range l2NetIDs {
-				addGameType(o, absolutePrestate, gameType, stack.NewL1ELNodeID(l1ELIDs[0].Key(), l1ELIDs[0].ChainID()), l2NetID.ChainID())
+				addGameType(o, absolutePrestate, gameType, l1ELID, l2NetID.ChainID())
 			}
 		},
 	}
@@ -50,10 +49,9 @@ func WithGameTypeAdded(gameType gameTypes.GameType) stack.Option[*Orchestrator] 
 func WithRespectedGameType(gameType gameTypes.GameType) stack.Option[*Orchestrator] {
 	return stack.FnOption[*Orchestrator]{
 		FinallyFn: func(o *Orchestrator) {
-			l2NetIDs := o.registry.IDsByKind(stack.KindL2Network)
-			l1ELIDs := o.registry.IDsByKind(stack.KindL1ELNode)
+			l1ELID, l2NetIDs := requireGameTypeTargetIDs(o)
 			for _, l2NetID := range l2NetIDs {
-				setRespectedGameType(o, gameType, stack.NewL1ELNodeID(l1ELIDs[0].Key(), l1ELIDs[0].ChainID()), l2NetID.ChainID())
+				setRespectedGameType(o, gameType, l1ELID, l2NetID.ChainID())
 			}
 		},
 	}
@@ -76,13 +74,23 @@ func WithCannonKonaGameTypeAdded() stack.Option[*Orchestrator] {
 		},
 		FinallyFn: func(o *Orchestrator) {
 			absolutePrestate := getCannonKonaAbsolutePrestate(o.P())
-			l2NetIDs := o.registry.IDsByKind(stack.KindL2Network)
-			l1ELIDs := o.registry.IDsByKind(stack.KindL1ELNode)
+			l1ELID, l2NetIDs := requireGameTypeTargetIDs(o)
 			for _, l2NetID := range l2NetIDs {
-				addGameType(o, absolutePrestate, gameTypes.CannonKonaGameType, stack.NewL1ELNodeID(l1ELIDs[0].Key(), l1ELIDs[0].ChainID()), l2NetID.ChainID())
+				addGameType(o, absolutePrestate, gameTypes.CannonKonaGameType, l1ELID, l2NetID.ChainID())
 			}
 		},
 	}
+}
+
+func requireGameTypeTargetIDs(o *Orchestrator) (stack.L1ELNodeID, []stack.ComponentID) {
+	require := o.P().Require()
+	l2NetIDs := o.registry.IDsByKind(stack.KindL2Network)
+	require.NotEmpty(l2NetIDs, "need at least one L2 network to configure game types")
+
+	l1ELIDs := o.registry.IDsByKind(stack.KindL1ELNode)
+	require.NotEmpty(l1ELIDs, "need at least one L1 EL node to configure game types")
+
+	return stack.NewL1ELNodeID(l1ELIDs[0].Key(), l1ELIDs[0].ChainID()), l2NetIDs
 }
 
 func WithChallengerCannonKonaEnabled() stack.Option[*Orchestrator] {

--- a/op-devstack/sysgo/add_game_type.go
+++ b/op-devstack/sysgo/add_game_type.go
@@ -37,8 +37,10 @@ func WithGameTypeAdded(gameType gameTypes.GameType) stack.Option[*Orchestrator] 
 	opts := stack.FnOption[*Orchestrator]{
 		FinallyFn: func(o *Orchestrator) {
 			absolutePrestate := PrestateForGameType(o.P(), gameType)
-			for _, l2ChainID := range o.l2Nets.Keys() {
-				addGameType(o, absolutePrestate, gameType, o.l1ELs.Keys()[0], l2ChainID)
+			l2NetIDs := o.registry.IDsByKind(stack.KindL2Network)
+			l1ELIDs := o.registry.IDsByKind(stack.KindL1ELNode)
+			for _, l2NetID := range l2NetIDs {
+				addGameType(o, absolutePrestate, gameType, stack.NewL1ELNodeID(l1ELIDs[0].Key(), l1ELIDs[0].ChainID()), l2NetID.ChainID())
 			}
 		},
 	}
@@ -48,8 +50,10 @@ func WithGameTypeAdded(gameType gameTypes.GameType) stack.Option[*Orchestrator] 
 func WithRespectedGameType(gameType gameTypes.GameType) stack.Option[*Orchestrator] {
 	return stack.FnOption[*Orchestrator]{
 		FinallyFn: func(o *Orchestrator) {
-			for _, l2ChainID := range o.l2Nets.Keys() {
-				setRespectedGameType(o, gameType, o.l1ELs.Keys()[0], l2ChainID)
+			l2NetIDs := o.registry.IDsByKind(stack.KindL2Network)
+			l1ELIDs := o.registry.IDsByKind(stack.KindL1ELNode)
+			for _, l2NetID := range l2NetIDs {
+				setRespectedGameType(o, gameType, stack.NewL1ELNodeID(l1ELIDs[0].Key(), l1ELIDs[0].ChainID()), l2NetID.ChainID())
 			}
 		},
 	}
@@ -72,8 +76,10 @@ func WithCannonKonaGameTypeAdded() stack.Option[*Orchestrator] {
 		},
 		FinallyFn: func(o *Orchestrator) {
 			absolutePrestate := getCannonKonaAbsolutePrestate(o.P())
-			for _, l2ChainID := range o.l2Nets.Keys() {
-				addGameType(o, absolutePrestate, gameTypes.CannonKonaGameType, o.l1ELs.Keys()[0], l2ChainID)
+			l2NetIDs := o.registry.IDsByKind(stack.KindL2Network)
+			l1ELIDs := o.registry.IDsByKind(stack.KindL1ELNode)
+			for _, l2NetID := range l2NetIDs {
+				addGameType(o, absolutePrestate, gameTypes.CannonKonaGameType, stack.NewL1ELNodeID(l1ELIDs[0].Key(), l1ELIDs[0].ChainID()), l2NetID.ChainID())
 			}
 		},
 	}
@@ -93,12 +99,14 @@ func setRespectedGameType(o *Orchestrator, gameType gameTypes.GameType, l1ELID s
 	require.NotNil(o.wb, "must have a world builder")
 	l1ChainID := l1ELID.ChainID()
 
-	l2Network, ok := o.l2Nets.Get(l2ChainID)
+	l2NetComponent, ok := o.registry.Get(stack.ConvertL2NetworkID(stack.L2NetworkID(l2ChainID)).ComponentID)
 	require.True(ok, "l2Net must exist")
+	l2Network := l2NetComponent.(*L2Network)
 	portalAddr := l2Network.rollupCfg.DepositContractAddress
 
-	l1EL, ok := o.l1ELs.Get(l1ELID)
+	l1ELComponent, ok := o.registry.Get(stack.ConvertL1ELNodeID(l1ELID).ComponentID)
 	require.True(ok, "l1El must exist")
+	l1EL := l1ELComponent.(L1ELNode)
 
 	rpcClient, err := rpc.DialContext(t.Ctx(), l1EL.UserRPC())
 	require.NoError(err)
@@ -147,8 +155,9 @@ func addGameType(o *Orchestrator, absolutePrestate common.Hash, gameType gameTyp
 
 	opcmAddr := o.wb.output.ImplementationsDeployment.OpcmImpl
 
-	l1EL, ok := o.l1ELs.Get(l1ELID)
+	l1ELComponent, ok := o.registry.Get(stack.ConvertL1ELNodeID(l1ELID).ComponentID)
 	require.True(ok, "l1El must exist")
+	l1EL := l1ELComponent.(L1ELNode)
 
 	rpcClient, err := rpc.DialContext(t.Ctx(), l1EL.UserRPC())
 	require.NoError(err)

--- a/op-devstack/sysgo/control_plane.go
+++ b/op-devstack/sysgo/control_plane.go
@@ -18,40 +18,46 @@ func control(lifecycle stack.Lifecycle, mode stack.ControlAction) {
 }
 
 func (c *ControlPlane) SupervisorState(id stack.SupervisorID, mode stack.ControlAction) {
-	s, ok := c.o.supervisors.Get(id)
+	cid := stack.ConvertSupervisorID(id)
+	component, ok := c.o.registry.Get(cid.ComponentID)
 	c.o.P().Require().True(ok, "need supervisor to change state")
-	control(s, mode)
+	control(component.(Supervisor), mode)
 }
 
 func (c *ControlPlane) L2CLNodeState(id stack.L2CLNodeID, mode stack.ControlAction) {
-	s, ok := c.o.l2CLs.Get(id)
+	cid := stack.ConvertL2CLNodeID(id)
+	component, ok := c.o.registry.Get(cid.ComponentID)
 	c.o.P().Require().True(ok, "need l2cl node to change state")
-	control(s, mode)
+	control(component.(L2CLNode), mode)
 }
 
 func (c *ControlPlane) L2ELNodeState(id stack.L2ELNodeID, mode stack.ControlAction) {
-	s, ok := c.o.l2ELs.Get(id)
+	cid := stack.ConvertL2ELNodeID(id)
+	component, ok := c.o.registry.Get(cid.ComponentID)
 	c.o.P().Require().True(ok, "need l2el node to change state")
-	control(s, mode)
+	control(component.(L2ELNode), mode)
 }
 
 func (c *ControlPlane) FakePoSState(id stack.L1CLNodeID, mode stack.ControlAction) {
-	s, ok := c.o.l1CLs.Get(id)
+	cid := stack.ConvertL1CLNodeID(id)
+	component, ok := c.o.registry.Get(cid.ComponentID)
 	c.o.P().Require().True(ok, "need l1cl node to change state of fakePoS module")
-
+	s := component.(*L1CLNode)
 	control(s.fakepos, mode)
 }
 
 func (c *ControlPlane) OPRBuilderNodeState(id stack.OPRBuilderNodeID, mode stack.ControlAction) {
-	s, ok := c.o.oprbuilderNodes.Get(id)
+	cid := stack.ConvertOPRBuilderNodeID(id)
+	component, ok := c.o.registry.Get(cid.ComponentID)
 	c.o.P().Require().True(ok, "need oprbuilder node to change state")
-	control(s, mode)
+	control(component.(*OPRBuilderNode), mode)
 }
 
 func (c *ControlPlane) RollupBoostNodeState(id stack.RollupBoostNodeID, mode stack.ControlAction) {
-	s, ok := c.o.rollupBoosts.Get(id)
+	cid := stack.ConvertRollupBoostNodeID(id)
+	component, ok := c.o.registry.Get(cid.ComponentID)
 	c.o.P().Require().True(ok, "need rollup boost node to change state")
-	control(s, mode)
+	control(component.(*RollupBoostNode), mode)
 }
 
 var _ stack.ControlPlane = (*ControlPlane)(nil)

--- a/op-devstack/sysgo/deployer.go
+++ b/op-devstack/sysgo/deployer.go
@@ -134,13 +134,13 @@ func WithDeployer() stack.Option[*Orchestrator] {
 				genesis:   wb.outL1Genesis,
 				blockTime: 6,
 			}
-			o.l1Nets.Set(l1ID.ChainID(), l1Net)
+			o.registry.Register(stack.ConvertL1NetworkID(l1ID).ComponentID, l1Net)
 
-			o.superchains.Set(superchainID, &Superchain{
+			o.registry.Register(stack.ConvertSuperchainID(superchainID).ComponentID, &Superchain{
 				id:         superchainID,
 				deployment: wb.outSuperchainDeployment,
 			})
-			o.clusters.Set(clusterID, &Cluster{
+			o.registry.Register(stack.ConvertClusterID(clusterID).ComponentID, &Cluster{
 				id:     clusterID,
 				cfgset: wb.outFullCfgSet,
 			})
@@ -162,7 +162,7 @@ func WithDeployer() stack.Option[*Orchestrator] {
 					deployment: l2Dep,
 					keys:       o.keys,
 				}
-				o.l2Nets.Set(l2ID.ChainID(), l2Net)
+				o.registry.Register(stack.ConvertL2NetworkID(l2ID).ComponentID, l2Net)
 			}
 		},
 	}

--- a/op-devstack/sysgo/faucet.go
+++ b/op-devstack/sysgo/faucet.go
@@ -71,8 +71,9 @@ func WithFaucets(l1ELs []stack.L1ELNodeID, l2ELs []stack.L2ELNodeID) stack.Optio
 			id := ftypes.FaucetID(fmt.Sprintf("dev-faucet-%s", elID.ChainID()))
 			require.NotContains(faucets, id, "one faucet per chain only")
 
-			el, ok := orch.l1ELs.Get(elID)
+			elComponent, ok := orch.registry.Get(stack.ConvertL1ELNodeID(elID).ComponentID)
 			require.True(ok, "need L1 EL for faucet", elID)
+			el := elComponent.(L1ELNode)
 
 			faucets[id] = &fconf.FaucetEntry{
 				ELRPC:   endpoint.MustRPC{Value: endpoint.URL(el.UserRPC())},
@@ -86,8 +87,9 @@ func WithFaucets(l1ELs []stack.L1ELNodeID, l2ELs []stack.L2ELNodeID) stack.Optio
 			id := ftypes.FaucetID(fmt.Sprintf("dev-faucet-%s", elID.ChainID()))
 			require.NotContains(faucets, id, "one faucet per chain only")
 
-			el, ok := orch.l2ELs.Get(elID)
+			elComponent, ok := orch.registry.Get(stack.ConvertL2ELNodeID(elID).ComponentID)
 			require.True(ok, "need L2 EL for faucet", elID)
+			el := elComponent.(L2ELNode)
 
 			faucets[id] = &fconf.FaucetEntry{
 				ELRPC:   endpoint.MustRPC{Value: endpoint.URL(el.UserRPC())},

--- a/op-devstack/sysgo/l1_nodes.go
+++ b/op-devstack/sysgo/l1_nodes.go
@@ -90,8 +90,9 @@ func WithL1NodesInProcess(l1ELID stack.L1ELNodeID, l1CLID stack.L1CLNodeID) stac
 		elP := orch.P().WithCtx(stack.ContextWithID(orch.P().Ctx(), l1ELID))
 		require := orch.P().Require()
 
-		l1Net, ok := orch.l1Nets.Get(l1ELID.ChainID())
+		l1NetComponent, ok := orch.registry.Get(stack.ConvertL1NetworkID(stack.L1NetworkID(l1ELID.ChainID())).ComponentID)
 		require.True(ok, "L1 network must exist")
+		l1Net := l1NetComponent.(*L1Network)
 
 		blockTimeL1 := l1Net.blockTime
 		l1FinalizedDistance := uint64(20)
@@ -137,7 +138,9 @@ func WithL1NodesInProcess(l1ELID stack.L1ELNodeID, l1CLID stack.L1CLNodeID) stac
 			l1Geth:   l1Geth,
 			blobPath: blobPath,
 		}
-		require.True(orch.l1ELs.SetIfMissing(l1ELID, l1ELNode), "must not already exist")
+		elCID := stack.ConvertL1ELNodeID(l1ELID).ComponentID
+		require.False(orch.registry.Has(elCID), "must not already exist")
+		orch.registry.Register(elCID, l1ELNode)
 
 		l1CLNode := &L1CLNode{
 			id:             l1CLID,
@@ -145,7 +148,9 @@ func WithL1NodesInProcess(l1ELID stack.L1ELNodeID, l1CLID stack.L1CLNodeID) stac
 			beacon:         bcn,
 			fakepos:        &FakePoS{fakepos: fp, p: clP},
 		}
-		require.True(orch.l1CLs.SetIfMissing(l1CLID, l1CLNode), "must not already exist")
+		clCID := stack.ConvertL1CLNodeID(l1CLID).ComponentID
+		require.False(orch.registry.Has(clCID), "must not already exist")
+		orch.registry.Register(clCID, l1CLNode)
 	})
 }
 
@@ -159,13 +164,17 @@ func WithExtL1Nodes(l1ELID stack.L1ELNodeID, l1CLID stack.L1CLNodeID, elRPCEndpo
 			id:      l1ELID,
 			userRPC: elRPCEndpoint,
 		}
-		require.True(orch.l1ELs.SetIfMissing(l1ELID, l1ELNode), "must not already exist")
+		elCID := stack.ConvertL1ELNodeID(l1ELID).ComponentID
+		require.False(orch.registry.Has(elCID), "must not already exist")
+		orch.registry.Register(elCID, l1ELNode)
 
 		// Create L1 CL node with external RPC
 		l1CLNode := &L1CLNode{
 			id:             l1CLID,
 			beaconHTTPAddr: clRPCEndpoint,
 		}
-		require.True(orch.l1CLs.SetIfMissing(l1CLID, l1CLNode), "must not already exist")
+		clCID := stack.ConvertL1CLNodeID(l1CLID).ComponentID
+		require.False(orch.registry.Has(clCID), "must not already exist")
+		orch.registry.Register(clCID, l1CLNode)
 	})
 }

--- a/op-devstack/sysgo/l1_nodes_subprocess.go
+++ b/op-devstack/sysgo/l1_nodes_subprocess.go
@@ -160,8 +160,9 @@ func WithL1NodesSubprocess(id stack.L1ELNodeID, clID stack.L1CLNodeID) stack.Opt
 		_, err := os.Stat(execPath)
 		p.Require().NotErrorIs(err, os.ErrNotExist, "geth executable must exist")
 
-		l1Net, ok := orch.l1Nets.Get(id.ChainID())
+		l1NetComponent, ok := orch.registry.Get(stack.ConvertL1NetworkID(stack.L1NetworkID(id.ChainID())).ComponentID)
 		require.True(ok, "L1 network required")
+		l1Net := l1NetComponent.(*L1Network)
 
 		jwtPath, jwtSecret := orch.writeDefaultJWT()
 
@@ -207,7 +208,9 @@ func WithL1NodesSubprocess(id stack.L1ELNodeID, clID stack.L1CLNodeID) stack.Opt
 		l1EL.Start()
 		p.Cleanup(l1EL.Stop)
 		p.Logger().Info("geth is ready", "userRPC", l1EL.userRPC, "authRPC", l1EL.authRPC)
-		require.True(orch.l1ELs.SetIfMissing(id, l1EL), "must be unique L2 EL node")
+		elCID := stack.ConvertL1ELNodeID(id).ComponentID
+		require.False(orch.registry.Has(elCID), "must be unique L1 EL node")
+		orch.registry.Register(elCID, l1EL)
 
 		backend, err := ethclient.DialContext(p.Ctx(), l1EL.userRPC)
 		require.NoError(err)
@@ -233,7 +236,7 @@ func WithL1NodesSubprocess(id stack.L1ELNodeID, clID stack.L1CLNodeID) stack.Opt
 		}
 		fp.Start()
 		p.Cleanup(fp.Stop)
-		orch.l1CLs.Set(clID, &L1CLNode{
+		orch.registry.Register(stack.ConvertL1CLNodeID(clID).ComponentID, &L1CLNode{
 			id:             clID,
 			beaconHTTPAddr: bcn.BeaconAddr(),
 			beacon:         bcn,

--- a/op-devstack/sysgo/l2_batcher.go
+++ b/op-devstack/sysgo/l2_batcher.go
@@ -57,26 +57,32 @@ func WithBatcher(batcherID stack.L2BatcherID, l1ELID stack.L1ELNodeID, l2CLID st
 		p := orch.P().WithCtx(stack.ContextWithID(orch.P().Ctx(), batcherID))
 
 		require := p.Require()
-		require.False(orch.batchers.Has(batcherID), "batcher must not already exist")
+		batcherCID := stack.ConvertL2BatcherID(batcherID).ComponentID
+		require.False(orch.registry.Has(batcherCID), "batcher must not already exist")
 
-		l2Net, ok := orch.l2Nets.Get(l2CLID.ChainID())
+		l2NetComponent, ok := orch.registry.Get(stack.ConvertL2NetworkID(stack.L2NetworkID(l2CLID.ChainID())).ComponentID)
 		require.True(ok)
+		l2Net := l2NetComponent.(*L2Network)
 
-		l1Net, ok := orch.l1Nets.Get(l1ELID.ChainID())
+		l1NetComponent, ok := orch.registry.Get(stack.ConvertL1NetworkID(stack.L1NetworkID(l1ELID.ChainID())).ComponentID)
 		require.True(ok)
+		l1Net := l1NetComponent.(*L1Network)
 
 		require.Equal(l2Net.l1ChainID, l1Net.id.ChainID(), "expecting L1EL on L1 of L2CL")
 
 		require.Equal(l2CLID.ChainID(), l2ELID.ChainID(), "L2 CL and EL must be on same L2 chain")
 
-		l1EL, ok := orch.l1ELs.Get(l1ELID)
+		l1ELComponent, ok := orch.registry.Get(stack.ConvertL1ELNodeID(l1ELID).ComponentID)
 		require.True(ok)
+		l1EL := l1ELComponent.(L1ELNode)
 
-		l2CL, ok := orch.l2CLs.Get(l2CLID)
+		l2CLComponent, ok := orch.registry.Get(stack.ConvertL2CLNodeID(l2CLID).ComponentID)
 		require.True(ok)
+		l2CL := l2CLComponent.(L2CLNode)
 
-		l2EL, ok := orch.l2ELs.Get(l2ELID)
+		l2ELComponent, ok := orch.registry.Get(stack.ConvertL2ELNodeID(l2ELID).ComponentID)
 		require.True(ok)
+		l2EL := l2ELComponent.(L2ELNode)
 
 		batcherSecret, err := orch.keys.Secret(devkeys.BatcherRole.Key(l2ELID.ChainID().ToBig()))
 		require.NoError(err)
@@ -141,6 +147,6 @@ func WithBatcher(batcherID stack.L2BatcherID, l1ELID stack.L1ELNodeID, l2CLID st
 			l2CLRPC: l2CL.UserRPC(),
 			l2ELRPC: l2EL.UserRPC(),
 		}
-		orch.batchers.Set(batcherID, b)
+		orch.registry.Register(stack.ConvertL2BatcherID(batcherID).ComponentID, b)
 	})
 }

--- a/op-devstack/sysgo/l2_challenger.go
+++ b/op-devstack/sysgo/l2_challenger.go
@@ -76,7 +76,8 @@ func WithL2ChallengerPostDeploy(orch *Orchestrator, challengerID stack.L2Challen
 	p := orch.P().WithCtx(ctx)
 
 	require := p.Require()
-	require.False(orch.challengers.Has(challengerID), "challenger must not already exist")
+	challengerCID := stack.ConvertL2ChallengerID(challengerID).ComponentID
+	require.False(orch.registry.Has(challengerCID), "challenger must not already exist")
 
 	challengerSecret, err := orch.keys.Secret(devkeys.ChallengerRole.Key(challengerID.ChainID().ToBig()))
 	require.NoError(err)
@@ -84,10 +85,12 @@ func WithL2ChallengerPostDeploy(orch *Orchestrator, challengerID stack.L2Challen
 	logger := p.Logger()
 	logger.Info("Challenger key acquired", "addr", crypto.PubkeyToAddress(challengerSecret.PublicKey))
 
-	l1EL, ok := orch.l1ELs.Get(l1ELID)
+	l1ELComponent, ok := orch.registry.Get(stack.ConvertL1ELNodeID(l1ELID).ComponentID)
 	require.True(ok)
-	l1CL, ok := orch.l1CLs.Get(l1CLID)
+	l1EL := l1ELComponent.(L1ELNode)
+	l1CLComponent, ok := orch.registry.Get(stack.ConvertL1CLNodeID(l1CLID).ComponentID)
 	require.True(ok)
+	l1CL := l1CLComponent.(*L1CLNode)
 
 	l2Geneses := make([]*core.Genesis, 0, len(l2ELIDs))
 	rollupCfgs := make([]*rollup.Config, 0, len(l2ELIDs))
@@ -103,8 +106,9 @@ func WithL2ChallengerPostDeploy(orch *Orchestrator, challengerID stack.L2Challen
 	}
 	for _, l2ELID := range l2ELIDs {
 		chainID := l2ELID.ChainID()
-		l2Net, ok := orch.l2Nets.Get(chainID)
+		l2NetComponent, ok := orch.registry.Get(stack.ConvertL2NetworkID(stack.L2NetworkID(chainID)).ComponentID)
 		require.Truef(ok, "l2Net %s not found", chainID)
+		l2Net := l2NetComponent.(*L2Network)
 		factory := l2Net.deployment.DisputeGameFactoryProxyAddr()
 		if disputeGameFactoryAddr == (common.Address{}) {
 			disputeGameFactoryAddr = factory
@@ -118,10 +122,11 @@ func WithL2ChallengerPostDeploy(orch *Orchestrator, challengerID stack.L2Challen
 		l2NetIDs = append(l2NetIDs, l2Net.id)
 	}
 
-	l1Net, ok := orch.l1Nets.Get(l1ELID.ChainID())
+	l1NetComponent, ok := orch.registry.Get(stack.ConvertL1NetworkID(stack.L1NetworkID(l1ELID.ChainID())).ComponentID)
 	if !ok {
 		require.Fail("l1 network not found")
 	}
+	l1Net := l1NetComponent.(*L1Network)
 	l1Genesis := l1Net.genesis
 
 	if orch.l2ChallengerOpts.useCannonKonaConfig {
@@ -139,8 +144,9 @@ func WithL2ChallengerPostDeploy(orch *Orchestrator, challengerID stack.L2Challen
 		useSuperNode := false
 		switch {
 		case supervisorID != nil:
-			supervisorNode, ok := orch.supervisors.Get(*supervisorID)
+			supervisorComponent, ok := orch.registry.Get(stack.ConvertSupervisorID(*supervisorID).ComponentID)
 			require.True(ok)
+			supervisorNode := supervisorComponent.(Supervisor)
 			superRPC = supervisorNode.UserRPC()
 		case supernodeID != nil:
 			supernode, ok := orch.supernodes.Get(*supernodeID)
@@ -153,12 +159,14 @@ func WithL2ChallengerPostDeploy(orch *Orchestrator, challengerID stack.L2Challen
 
 		l2ELRPCs := make([]string, len(l2ELIDs))
 		for i, l2ELID := range l2ELIDs {
-			l2EL, ok := orch.l2ELs.Get(l2ELID)
+			l2ELComponent, ok := orch.registry.Get(stack.ConvertL2ELNodeID(l2ELID).ComponentID)
 			require.True(ok)
+			l2EL := l2ELComponent.(L2ELNode)
 			l2ELRPCs[i] = l2EL.UserRPC()
 		}
-		cluster, ok := orch.clusters.Get(*clusterID)
+		clusterComponent, ok := orch.registry.Get(stack.ConvertClusterID(*clusterID).ComponentID)
 		require.True(ok)
+		cluster := clusterComponent.(*Cluster)
 		prestateVariant := shared.InteropVariant
 		options := []shared.Option{
 			shared.WithFactoryAddress(disputeGameFactoryAddr),
@@ -188,9 +196,10 @@ func WithL2ChallengerPostDeploy(orch *Orchestrator, challengerID stack.L2Challen
 			}
 		}
 		require.NotZero(l2ELID, "need single L2 EL to connect to pre-interop")
-		l2CL, ok := orch.l2CLs.Get(*l2CLID)
+		l2CLComponent, ok := orch.registry.Get(stack.ConvertL2CLNodeID(*l2CLID).ComponentID)
 		require.True(ok)
-		l2EL, ok := orch.l2ELs.Get(l2ELID)
+		l2CL := l2CLComponent.(L2CLNode)
+		l2EL, ok := orch.GetL2EL(l2ELID)
 		require.True(ok)
 		prestateVariant := shared.MTCannonVariant
 		options := []shared.Option{
@@ -240,5 +249,5 @@ func WithL2ChallengerPostDeploy(orch *Orchestrator, challengerID stack.L2Challen
 		l2NetIDs: l2NetIDs,
 		config:   cfg,
 	}
-	orch.challengers.Set(challengerID, c)
+	orch.registry.Register(stack.ConvertL2ChallengerID(challengerID).ComponentID, c)
 }

--- a/op-devstack/sysgo/l2_cl_kona.go
+++ b/op-devstack/sysgo/l2_cl_kona.go
@@ -165,8 +165,9 @@ func WithKonaNodeFollowL2(l2CLID stack.L2CLNodeID, l1CLID stack.L1CLNodeID, l1EL
 	return stack.AfterDeploy(func(orch *Orchestrator) {
 		followSource := func(orch *Orchestrator) string {
 			p := orch.P().WithCtx(stack.ContextWithID(orch.P().Ctx(), l2CLID))
-			l2CLFollowSource, ok := orch.l2CLs.Get(l2FollowSourceID)
+			l2CLComponent, ok := orch.registry.Get(stack.ConvertL2CLNodeID(l2FollowSourceID).ComponentID)
 			p.Require().True(ok, "l2 CL Follow Source required")
+			l2CLFollowSource := l2CLComponent.(L2CLNode)
 			return l2CLFollowSource.UserRPC()
 		}(orch)
 		opts = append(opts, L2CLFollowSource(followSource))
@@ -184,19 +185,23 @@ func withKonaNode(l2CLID stack.L2CLNodeID, l1CLID stack.L1CLNodeID, l1ELID stack
 
 		require := p.Require()
 
-		l1Net, ok := orch.l1Nets.Get(l1CLID.ChainID())
+		l1NetComponent, ok := orch.registry.Get(stack.ConvertL1NetworkID(stack.L1NetworkID(l1CLID.ChainID())).ComponentID)
 		require.True(ok, "l1 network required")
+		l1Net := l1NetComponent.(*L1Network)
 
-		l2Net, ok := orch.l2Nets.Get(l2CLID.ChainID())
+		l2NetComponent, ok := orch.registry.Get(stack.ConvertL2NetworkID(stack.L2NetworkID(l2CLID.ChainID())).ComponentID)
 		require.True(ok, "l2 network required")
+		l2Net := l2NetComponent.(*L2Network)
 
 		l1ChainConfig := l1Net.genesis.Config
 
-		l1EL, ok := orch.l1ELs.Get(l1ELID)
+		l1ELComponent, ok := orch.registry.Get(stack.ConvertL1ELNodeID(l1ELID).ComponentID)
 		require.True(ok, "l1 EL node required")
+		l1EL := l1ELComponent.(L1ELNode)
 
-		l1CL, ok := orch.l1CLs.Get(l1CLID)
+		l1CLComponent, ok := orch.registry.Get(stack.ConvertL1CLNodeID(l1CLID).ComponentID)
 		require.True(ok, "l1 CL node required")
+		l1CL := l1CLComponent.(*L1CLNode)
 
 		l2EL, ok := orch.GetL2EL(l2ELID)
 		require.True(ok, "l2 EL node required")
@@ -301,6 +306,8 @@ func withKonaNode(l2CLID stack.L2CLNodeID, l1CLID stack.L1CLNodeID, l1ELID stack
 		k.Start()
 		p.Cleanup(k.Stop)
 		p.Logger().Info("Kona-node is up", "rpc", k.UserRPC())
-		require.True(orch.l2CLs.SetIfMissing(l2CLID, k), "must not already exist")
+		cid := stack.ConvertL2CLNodeID(l2CLID).ComponentID
+		require.False(orch.registry.Has(cid), "must not already exist")
+		orch.registry.Register(cid, k)
 	}
 }

--- a/op-devstack/sysgo/l2_cl_opnode.go
+++ b/op-devstack/sysgo/l2_cl_opnode.go
@@ -166,8 +166,9 @@ func WithOpNodeFollowL2(l2CLID stack.L2CLNodeID, l1CLID stack.L1CLNodeID, l1ELID
 	return stack.AfterDeploy(func(orch *Orchestrator) {
 		followSource := func(orch *Orchestrator) string {
 			p := orch.P().WithCtx(stack.ContextWithID(orch.P().Ctx(), l2CLID))
-			l2CLFollowSource, ok := orch.l2CLs.Get(l2FollowSourceID)
+			l2CLComponent, ok := orch.registry.Get(stack.ConvertL2CLNodeID(l2FollowSourceID).ComponentID)
 			p.Require().True(ok, "l2 CL Follow Source required")
+			l2CLFollowSource := l2CLComponent.(L2CLNode)
 			return l2CLFollowSource.UserRPC()
 		}(orch)
 		opts = append(opts, L2CLFollowSource(followSource))
@@ -185,17 +186,21 @@ func withOpNode(l2CLID stack.L2CLNodeID, l1CLID stack.L1CLNodeID, l1ELID stack.L
 
 		require := p.Require()
 
-		l1Net, ok := orch.l1Nets.Get(l1CLID.ChainID())
+		l1NetComponent, ok := orch.registry.Get(stack.ConvertL1NetworkID(stack.L1NetworkID(l1CLID.ChainID())).ComponentID)
 		require.True(ok, "l1 network required")
+		l1Net := l1NetComponent.(*L1Network)
 
-		l2Net, ok := orch.l2Nets.Get(l2CLID.ChainID())
+		l2NetComponent, ok := orch.registry.Get(stack.ConvertL2NetworkID(stack.L2NetworkID(l2CLID.ChainID())).ComponentID)
 		require.True(ok, "l2 network required")
+		l2Net := l2NetComponent.(*L2Network)
 
-		l1EL, ok := orch.l1ELs.Get(l1ELID)
+		l1ELComponent, ok := orch.registry.Get(stack.ConvertL1ELNodeID(l1ELID).ComponentID)
 		require.True(ok, "l1 EL node required")
+		l1EL := l1ELComponent.(L1ELNode)
 
-		l1CL, ok := orch.l1CLs.Get(l1CLID)
+		l1CLComponent, ok := orch.registry.Get(stack.ConvertL1CLNodeID(l1CLID).ComponentID)
 		require.True(ok, "l1 CL node required")
+		l1CL := l1CLComponent.(*L1CLNode)
 
 		// Get the L2EL node (which can be a regular EL node or a SyncTesterEL)
 		l2EL, ok := orch.GetL2EL(l2ELID)
@@ -363,7 +368,9 @@ func withOpNode(l2CLID stack.L2CLNodeID, l1CLID stack.L1CLNodeID, l1ELID stack.L
 
 		// Set the EL field to link to the L2EL node
 		l2CLNode.el = &l2ELID
-		require.True(orch.l2CLs.SetIfMissing(l2CLID, l2CLNode), fmt.Sprintf("must not already exist: %s", l2CLID))
+		cid := stack.ConvertL2CLNodeID(l2CLID).ComponentID
+		require.False(orch.registry.Has(cid), fmt.Sprintf("must not already exist: %s", l2CLID))
+		orch.registry.Register(cid, l2CLNode)
 		l2CLNode.Start()
 		p.Cleanup(l2CLNode.Stop)
 	}

--- a/op-devstack/sysgo/l2_cl_p2p_util.go
+++ b/op-devstack/sysgo/l2_cl_p2p_util.go
@@ -88,10 +88,12 @@ func WithL2CLP2PConnection(l2CL1ID, l2CL2ID stack.L2CLNodeID) stack.Option[*Orch
 		require := orch.P().Require()
 		l := orch.P().Logger()
 
-		l2CL1, ok := orch.l2CLs.Get(l2CL1ID)
+		l2CL1Component, ok := orch.registry.Get(stack.ConvertL2CLNodeID(l2CL1ID).ComponentID)
 		require.True(ok, "looking for L2 CL node 1 to connect p2p")
-		l2CL2, ok := orch.l2CLs.Get(l2CL2ID)
+		l2CL1 := l2CL1Component.(L2CLNode)
+		l2CL2Component, ok := orch.registry.Get(stack.ConvertL2CLNodeID(l2CL2ID).ComponentID)
 		require.True(ok, "looking for L2 CL node 2 to connect p2p")
+		l2CL2 := l2CL2Component.(L2CLNode)
 		require.Equal(l2CL1ID.ChainID(), l2CL2ID.ChainID(), "must be same l2 chain")
 
 		ctx := orch.P().Ctx()

--- a/op-devstack/sysgo/l2_cl_supernode.go
+++ b/op-devstack/sysgo/l2_cl_supernode.go
@@ -243,11 +243,12 @@ func WithSharedSupernodeCLsInterop(supernodeID stack.SupernodeID, cls []L2CLs, l
 			orch.P().Require().Fail("no chains provided")
 			return
 		}
-		l2Net, ok := orch.l2Nets.Get(cls[0].CLID.ChainID())
+		l2NetComponent, ok := orch.registry.Get(stack.ConvertL2NetworkID(stack.L2NetworkID(cls[0].CLID.ChainID())).ComponentID)
 		if !ok {
 			orch.P().Require().Fail("l2 network not found")
 			return
 		}
+		l2Net := l2NetComponent.(*L2Network)
 		genesisTime := l2Net.rollupCfg.Genesis.L2Time
 		orch.P().Logger().Info("enabling supernode interop at genesis", "activation_timestamp", genesisTime)
 
@@ -265,11 +266,12 @@ func WithSharedSupernodeCLsInteropDelayed(supernodeID stack.SupernodeID, cls []L
 			orch.P().Require().Fail("no chains provided")
 			return
 		}
-		l2Net, ok := orch.l2Nets.Get(cls[0].CLID.ChainID())
+		l2NetComponent, ok := orch.registry.Get(stack.ConvertL2NetworkID(stack.L2NetworkID(cls[0].CLID.ChainID())).ComponentID)
 		if !ok {
 			orch.P().Require().Fail("l2 network not found")
 			return
 		}
+		l2Net := l2NetComponent.(*L2Network)
 		genesisTime := l2Net.rollupCfg.Genesis.L2Time
 		activationTime := genesisTime + delaySeconds
 		orch.P().Logger().Info("enabling supernode interop with delay",
@@ -301,14 +303,17 @@ func withSharedSupernodeCLsImpl(orch *Orchestrator, supernodeID stack.SupernodeI
 		opt(snOpts)
 	}
 
-	l1EL, ok := orch.l1ELs.Get(l1ELID)
+	l1ELComponent, ok := orch.registry.Get(stack.ConvertL1ELNodeID(l1ELID).ComponentID)
 	require.True(ok, "l1 EL node required")
-	l1CL, ok := orch.l1CLs.Get(l1CLID)
+	l1EL := l1ELComponent.(L1ELNode)
+	l1CLComponent, ok := orch.registry.Get(stack.ConvertL1CLNodeID(l1CLID).ComponentID)
 	require.True(ok, "l1 CL node required")
+	l1CL := l1CLComponent.(*L1CLNode)
 
 	// Get L1 network to access L1 chain config
-	l1Net, ok := orch.l1Nets.Get(l1ELID.ChainID())
+	l1NetComponent, ok := orch.registry.Get(stack.ConvertL1NetworkID(stack.L1NetworkID(l1ELID.ChainID())).ComponentID)
 	require.True(ok, "l1 network required")
+	l1Net := l1NetComponent.(*L1Network)
 
 	_, jwtSecret := orch.writeDefaultJWT()
 
@@ -363,9 +368,10 @@ func withSharedSupernodeCLsImpl(orch *Orchestrator, supernodeID stack.SupernodeI
 	els := make([]*stack.L2ELNodeID, 0, len(cls))
 	for i := range cls {
 		a := cls[i]
-		l2Net, ok := orch.l2Nets.Get(a.CLID.ChainID())
+		l2NetComponent, ok := orch.registry.Get(stack.ConvertL2NetworkID(stack.L2NetworkID(a.CLID.ChainID())).ComponentID)
 		require.True(ok, "l2 network required")
-		l2ELNode, ok := orch.l2ELs.Get(a.ELID)
+		l2Net := l2NetComponent.(*L2Network)
+		l2ELNode, ok := orch.GetL2EL(a.ELID)
 		require.True(ok, "l2 EL node required")
 		l2ChainID := a.CLID.ChainID()
 		cfg := makeNodeCfg(l2Net, l2ChainID, l2ELNode, true)
@@ -436,10 +442,12 @@ func withSharedSupernodeCLsImpl(orch *Orchestrator, supernodeID stack.SupernodeI
 			interopJwtSecret: jwtSecret,
 			el:               &cls[i].ELID,
 		}
-		require.True(orch.l2CLs.SetIfMissing(a.CLID, proxy), fmt.Sprintf("must not already exist: %s", a.CLID))
+		cid := stack.ConvertL2CLNodeID(a.CLID).ComponentID
+		require.False(orch.registry.Has(cid), fmt.Sprintf("must not already exist: %s", a.CLID))
+		orch.registry.Register(cid, proxy)
 	}
 
-	supernode := &SuperNode{
+	snNode := &SuperNode{
 		id:               supernodeID,
 		sn:               sn,
 		cancel:           cancel,
@@ -453,7 +461,7 @@ func withSharedSupernodeCLsImpl(orch *Orchestrator, supernodeID stack.SupernodeI
 		l1UserRPC:        l1EL.UserRPC(),
 		l1BeaconAddr:     l1CL.beaconHTTPAddr,
 	}
-	orch.supernodes.Set(supernodeID, supernode)
+	orch.supernodes.Set(supernodeID, snNode)
 }
 
 func idsFromCLs(cls []L2CLs) []eth.ChainID {

--- a/op-devstack/sysgo/l2_el.go
+++ b/op-devstack/sysgo/l2_el.go
@@ -113,6 +113,8 @@ func WithExtL2Node(id stack.L2ELNodeID, elRPCEndpoint string) stack.Option[*Orch
 			userRPC:  elRPCEndpoint,
 			readOnly: true,
 		}
-		require.True(orch.l2ELs.SetIfMissing(id, l2ELNode), "must not already exist")
+		cid := stack.ConvertL2ELNodeID(id).ComponentID
+		require.False(orch.registry.Has(cid), "must not already exist")
+		orch.registry.Register(cid, l2ELNode)
 	})
 }

--- a/op-devstack/sysgo/l2_el_opgeth.go
+++ b/op-devstack/sysgo/l2_el_opgeth.go
@@ -184,8 +184,9 @@ func WithOpGeth(id stack.L2ELNodeID, opts ...L2ELOption) stack.Option[*Orchestra
 		p := orch.P().WithCtx(stack.ContextWithID(orch.P().Ctx(), id))
 		require := p.Require()
 
-		l2Net, ok := orch.l2Nets.Get(id.ChainID())
+		l2NetComponent, ok := orch.registry.Get(stack.ConvertL2NetworkID(stack.L2NetworkID(id.ChainID())).ComponentID)
 		require.True(ok, "L2 network required")
+		l2Net := l2NetComponent.(*L2Network)
 
 		cfg := DefaultL2ELConfig()
 		orch.l2ELOptions.Apply(p, id, cfg)       // apply global options
@@ -197,8 +198,9 @@ func WithOpGeth(id stack.L2ELNodeID, opts ...L2ELOption) stack.Option[*Orchestra
 
 		supervisorRPC := ""
 		if useInterop && cfg.SupervisorID != nil {
-			sup, ok := orch.supervisors.Get(*cfg.SupervisorID)
-			require.True(ok, "supervisor not found")
+			supComponent, ok := orch.registry.Get(stack.ConvertSupervisorID(*cfg.SupervisorID).ComponentID)
+			require.True(ok, "supervisor is required for interop")
+			sup := supComponent.(Supervisor)
 			supervisorRPC = sup.UserRPC()
 		}
 
@@ -218,6 +220,8 @@ func WithOpGeth(id stack.L2ELNodeID, opts ...L2ELOption) stack.Option[*Orchestra
 		p.Cleanup(func() {
 			l2EL.Stop()
 		})
-		require.True(orch.l2ELs.SetIfMissing(id, l2EL), "must be unique L2 EL node")
+		cid := stack.ConvertL2ELNodeID(id).ComponentID
+		require.False(orch.registry.Has(cid), "must be unique L2 EL node")
+		orch.registry.Register(cid, l2EL)
 	})
 }

--- a/op-devstack/sysgo/l2_el_opreth.go
+++ b/op-devstack/sysgo/l2_el_opreth.go
@@ -189,8 +189,9 @@ func WithOpReth(id stack.L2ELNodeID, opts ...L2ELOption) stack.Option[*Orchestra
 		p := orch.P().WithCtx(stack.ContextWithID(orch.P().Ctx(), id))
 		require := p.Require()
 
-		l2Net, ok := orch.l2Nets.Get(id.ChainID())
+		l2NetComponent, ok := orch.registry.Get(stack.ConvertL2NetworkID(stack.L2NetworkID(id.ChainID())).ComponentID)
 		require.True(ok, "L2 network required")
+		l2Net := l2NetComponent.(*L2Network)
 
 		cfg := DefaultL2ELConfig()
 		orch.l2ELOptions.Apply(p, id, cfg)       // apply global options
@@ -202,8 +203,9 @@ func WithOpReth(id stack.L2ELNodeID, opts ...L2ELOption) stack.Option[*Orchestra
 
 		supervisorRPC := ""
 		if useInterop && cfg.SupervisorID != nil {
-			sup, ok := orch.supervisors.Get(*cfg.SupervisorID)
-			require.True(ok, "supervisor not found")
+			supComponent, ok := orch.registry.Get(stack.ConvertSupervisorID(*cfg.SupervisorID).ComponentID)
+			require.True(ok, "supervisor is required for interop")
+			sup := supComponent.(Supervisor)
 			supervisorRPC = sup.UserRPC()
 		}
 
@@ -324,6 +326,8 @@ func WithOpReth(id stack.L2ELNodeID, opts ...L2ELOption) stack.Option[*Orchestra
 		l2EL.Start()
 		p.Cleanup(l2EL.Stop)
 		p.Logger().Info("op-reth is ready", "userRPC", l2EL.userRPC, "authRPC", l2EL.authRPC)
-		require.True(orch.l2ELs.SetIfMissing(id, l2EL), "must be unique L2 EL node")
+		cid := stack.ConvertL2ELNodeID(id).ComponentID
+		require.False(orch.registry.Has(cid), "must be unique L2 EL node")
+		orch.registry.Register(cid, l2EL)
 	})
 }

--- a/op-devstack/sysgo/l2_el_synctester.go
+++ b/op-devstack/sysgo/l2_el_synctester.go
@@ -180,8 +180,9 @@ func WithSyncTesterL2ELNode(id, readonlyEL stack.L2ELNodeID, opts ...SyncTesterE
 		p := orch.P().WithCtx(stack.ContextWithID(orch.P().Ctx(), id))
 		require := p.Require()
 
-		l2Net, ok := orch.l2Nets.Get(readonlyEL.ChainID())
+		l2NetComponent, ok := orch.registry.Get(stack.ConvertL2NetworkID(stack.L2NetworkID(readonlyEL.ChainID())).ComponentID)
 		require.True(ok, "L2 network required")
+		l2Net := l2NetComponent.(*L2Network)
 
 		cfg := DefaultSyncTesterELConfig()
 		orch.SyncTesterELOptions.Apply(p, id, cfg)       // apply global options
@@ -202,6 +203,8 @@ func WithSyncTesterL2ELNode(id, readonlyEL stack.L2ELNodeID, opts ...SyncTesterE
 		syncTesterEL.Start()
 		p.Cleanup(syncTesterEL.Stop)
 		p.Logger().Info("sync tester EL is ready", "userRPC", syncTesterEL.userRPC, "authRPC", syncTesterEL.authRPC)
-		require.True(orch.l2ELs.SetIfMissing(id, syncTesterEL), "must be unique L2 EL node")
+		cid := stack.ConvertL2ELNodeID(id).ComponentID
+		require.False(orch.registry.Has(cid), "must be unique L2 EL node")
+		orch.registry.Register(cid, syncTesterEL)
 	})
 }

--- a/op-devstack/sysgo/l2_metrics_dashboard.go
+++ b/op-devstack/sysgo/l2_metrics_dashboard.go
@@ -135,9 +135,7 @@ func (g *L2MetricsDashboard) startGrafana() {
 func WithL2MetricsDashboard() stack.Option[*Orchestrator] {
 	return stack.Finally(func(orch *Orchestrator) {
 		// don't start prometheus or grafana if metrics are disabled or there is nothing exporting metrics.
-		orch.l2MetricsMu.RLock()
-		metricsLen := len(orch.l2MetricsEndpoints)
-		orch.l2MetricsMu.RUnlock()
+		metricsLen := orch.l2MetricsEndpoints.Len()
 		if !areMetricsEnabled() || metricsLen == 0 {
 			return
 		}
@@ -221,8 +219,7 @@ func getPrometheusConfigFilePath(p devtest.P, orch *Orchestrator) string {
 
 	var scrapeConfigs []prometheusScrapeConfigEntry
 
-	orch.l2MetricsMu.RLock()
-	for name, endpoints := range orch.l2MetricsEndpoints {
+	orch.l2MetricsEndpoints.Range(func(name string, endpoints []PrometheusMetricsTarget) bool {
 		var targets []string
 		for _, endpoint := range endpoints {
 			targets = append(targets, string(endpoint))
@@ -232,8 +229,8 @@ func getPrometheusConfigFilePath(p devtest.P, orch *Orchestrator) string {
 			Scheme:        "http",
 			StaticConfigs: []prometheusStaticConfig{{Targets: targets}},
 		})
-	}
-	orch.l2MetricsMu.RUnlock()
+		return true
+	})
 
 	yamlConfig := prometheusConfig{
 		Global: prometheusGlobalConfig{

--- a/op-devstack/sysgo/l2_metrics_dashboard.go
+++ b/op-devstack/sysgo/l2_metrics_dashboard.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
-	"github.com/ethereum-optimism/optimism/op-service/locks"
 	"github.com/ethereum-optimism/optimism/op-service/logpipe"
 	"gopkg.in/yaml.v3"
 )
@@ -136,7 +135,10 @@ func (g *L2MetricsDashboard) startGrafana() {
 func WithL2MetricsDashboard() stack.Option[*Orchestrator] {
 	return stack.Finally(func(orch *Orchestrator) {
 		// don't start prometheus or grafana if metrics are disabled or there is nothing exporting metrics.
-		if !areMetricsEnabled() || orch.l2MetricsEndpoints.Len() == 0 {
+		orch.l2MetricsMu.RLock()
+		metricsLen := len(orch.l2MetricsEndpoints)
+		orch.l2MetricsMu.RUnlock()
+		if !areMetricsEnabled() || metricsLen == 0 {
 			return
 		}
 
@@ -144,7 +146,7 @@ func WithL2MetricsDashboard() stack.Option[*Orchestrator] {
 
 		prometheusImageTag := getEnvVarOrDefault(prometheusDockerImageTagEnvVar, "v3.7.2")
 		prometheusEndpoint := fmt.Sprintf("http://%s:%s", prometheusHost, prometheusServerPort)
-		promConfig := getPrometheusConfigFilePath(p, &orch.l2MetricsEndpoints)
+		promConfig := getPrometheusConfigFilePath(p, orch)
 		// these are args to run via docker; see dashboard definition below
 		prometheusArgs := []string{
 			"run",
@@ -215,11 +217,12 @@ type prometheusStaticConfig struct {
 }
 
 // Returns the path to the dynamically-generated prometheus.yml file for metrics scraping.
-func getPrometheusConfigFilePath(p devtest.P, metricsEndpoints *locks.RWMap[string, []PrometheusMetricsTarget]) string {
+func getPrometheusConfigFilePath(p devtest.P, orch *Orchestrator) string {
 
 	var scrapeConfigs []prometheusScrapeConfigEntry
 
-	metricsEndpoints.Range(func(name string, endpoints []PrometheusMetricsTarget) bool {
+	orch.l2MetricsMu.RLock()
+	for name, endpoints := range orch.l2MetricsEndpoints {
 		var targets []string
 		for _, endpoint := range endpoints {
 			targets = append(targets, string(endpoint))
@@ -229,8 +232,8 @@ func getPrometheusConfigFilePath(p devtest.P, metricsEndpoints *locks.RWMap[stri
 			Scheme:        "http",
 			StaticConfigs: []prometheusStaticConfig{{Targets: targets}},
 		})
-		return true
-	})
+	}
+	orch.l2MetricsMu.RUnlock()
 
 	yamlConfig := prometheusConfig{
 		Global: prometheusGlobalConfig{

--- a/op-devstack/sysgo/l2_metrics_dashboard_test.go
+++ b/op-devstack/sysgo/l2_metrics_dashboard_test.go
@@ -18,7 +18,7 @@ func TestWithL2MetricsDashboard_DisabledIfEndpointsRegisteredButNotExplicitlyEna
 	id := stack.NewL2ELNodeID("test", eth.ChainIDFromUInt64(11111111111))
 	metricsTarget := NewPrometheusMetricsTarget("localhost", "9090", false)
 
-	o := &Orchestrator{}
+	o := &Orchestrator{l2MetricsEndpoints: make(map[string][]PrometheusMetricsTarget)}
 	o.RegisterL2MetricsTargets(id, metricsTarget)
 
 	// This should run without error if disabled

--- a/op-devstack/sysgo/l2_metrics_dashboard_test.go
+++ b/op-devstack/sysgo/l2_metrics_dashboard_test.go
@@ -18,7 +18,7 @@ func TestWithL2MetricsDashboard_DisabledIfEndpointsRegisteredButNotExplicitlyEna
 	id := stack.NewL2ELNodeID("test", eth.ChainIDFromUInt64(11111111111))
 	metricsTarget := NewPrometheusMetricsTarget("localhost", "9090", false)
 
-	o := &Orchestrator{l2MetricsEndpoints: make(map[string][]PrometheusMetricsTarget)}
+	o := &Orchestrator{}
 	o.RegisterL2MetricsTargets(id, metricsTarget)
 
 	// This should run without error if disabled

--- a/op-devstack/sysgo/l2_network_superchain_registry.go
+++ b/op-devstack/sysgo/l2_network_superchain_registry.go
@@ -44,8 +44,9 @@ func WithL2NetworkFromSuperchainRegistry(l2NetworkID stack.L2NetworkID, networkN
 			keys:      orch.keys,
 		}
 
-		require.True(orch.l2Nets.SetIfMissing(l2NetworkID.ChainID(), l2Net),
-			fmt.Sprintf("must not already exist: %s", l2NetworkID))
+		cid := stack.ConvertL2NetworkID(l2NetworkID).ComponentID
+		require.False(orch.registry.Has(cid), fmt.Sprintf("must not already exist: %s", l2NetworkID))
+		orch.registry.Register(cid, l2Net)
 	})
 }
 
@@ -68,7 +69,7 @@ func WithEmptyDepSet(l2NetworkID stack.L2NetworkID, networkName string) stack.Op
 				cfgset: depset.FullConfigSetMerged{},
 			}
 
-			orch.clusters.Set(clusterID, cluster)
+			orch.registry.Register(stack.ConvertClusterID(clusterID).ComponentID, cluster)
 		}),
 	)
 }

--- a/op-devstack/sysgo/l2_proposer.go
+++ b/op-devstack/sysgo/l2_proposer.go
@@ -77,7 +77,8 @@ func WithProposerPostDeploy(orch *Orchestrator, proposerID stack.L2ProposerID, l
 	p := orch.P().WithCtx(ctx)
 
 	require := p.Require()
-	require.False(orch.proposers.Has(proposerID), "proposer must not already exist")
+	proposerCID := stack.ConvertL2ProposerID(proposerID).ComponentID
+	require.False(orch.registry.Has(proposerCID), "proposer must not already exist")
 	if supervisorID != nil && supernodeID != nil {
 		require.Fail("cannot have both supervisorID and supernodeID set for proposer")
 	}
@@ -88,11 +89,13 @@ func WithProposerPostDeploy(orch *Orchestrator, proposerID stack.L2ProposerID, l
 	logger := p.Logger()
 	logger.Info("Proposer key acquired", "addr", crypto.PubkeyToAddress(proposerSecret.PublicKey))
 
-	l1EL, ok := orch.l1ELs.Get(l1ELID)
+	l1ELComponent, ok := orch.registry.Get(stack.ConvertL1ELNodeID(l1ELID).ComponentID)
 	require.True(ok)
+	l1EL := l1ELComponent.(L1ELNode)
 
-	l2Net, ok := orch.l2Nets.Get(proposerID.ChainID())
+	l2NetComponent, ok := orch.registry.Get(stack.ConvertL2NetworkID(stack.L2NetworkID(proposerID.ChainID())).ComponentID)
 	require.True(ok)
+	l2Net := l2NetComponent.(*L2Network)
 	disputeGameFactoryAddr := l2Net.deployment.DisputeGameFactoryProxyAddr()
 	disputeGameType := 1 // Permissioned game type is the only one currently deployed
 	if orch.wb.outInteropMigration != nil {
@@ -127,8 +130,9 @@ func WithProposerPostDeploy(orch *Orchestrator, proposerID stack.L2ProposerID, l
 	// If supervisor is available, use it. Otherwise, connect to L2 CL.
 	switch {
 	case supervisorID != nil:
-		supervisorNode, ok := orch.supervisors.Get(*supervisorID)
+		supervisorComponent, ok := orch.registry.Get(stack.ConvertSupervisorID(*supervisorID).ComponentID)
 		require.True(ok, "supervisor not found")
+		supervisorNode := supervisorComponent.(Supervisor)
 		proposerCLIConfig.SupervisorRpcs = []string{supervisorNode.UserRPC()}
 	case supernodeID != nil:
 		supernode, ok := orch.supernodes.Get(*supernodeID)
@@ -136,8 +140,9 @@ func WithProposerPostDeploy(orch *Orchestrator, proposerID stack.L2ProposerID, l
 		proposerCLIConfig.SuperNodeRpcs = []string{supernode.UserRPC()}
 	default:
 		require.NotNil(l2CLID, "need L2 CL to connect to when no supervisor")
-		l2CL, ok := orch.l2CLs.Get(*l2CLID)
+		l2CLComponent, ok := orch.registry.Get(stack.ConvertL2CLNodeID(*l2CLID).ComponentID)
 		require.True(ok, "L2 CL not found")
+		l2CL := l2CLComponent.(L2CLNode)
 		proposerCLIConfig.RollupRpc = l2CL.UserRPC()
 	}
 
@@ -158,5 +163,5 @@ func WithProposerPostDeploy(orch *Orchestrator, proposerID stack.L2ProposerID, l
 		service: proposer,
 		userRPC: proposer.HTTPEndpoint(),
 	}
-	orch.proposers.Set(proposerID, prop)
+	orch.registry.Register(stack.ConvertL2ProposerID(proposerID).ComponentID, prop)
 }

--- a/op-devstack/sysgo/op_rbuilder.go
+++ b/op-devstack/sysgo/op_rbuilder.go
@@ -467,8 +467,9 @@ func (b *OPRBuilderNode) Stop() {
 func WithOPRBuilderNode(id stack.OPRBuilderNodeID, opts ...OPRBuilderNodeOption) stack.Option[*Orchestrator] {
 	return stack.AfterDeploy(func(orch *Orchestrator) {
 		p := orch.P().WithCtx(stack.ContextWithID(orch.P().Ctx(), id))
-		l2Net, ok := orch.l2Nets.Get(id.ChainID())
+		l2NetComponent, ok := orch.registry.Get(stack.ConvertL2NetworkID(stack.L2NetworkID(id.ChainID())).ComponentID)
 		p.Require().True(ok, "l2 network required")
+		l2Net := l2NetComponent.(*L2Network)
 
 		tempDir := p.TempDir()
 		data, err := json.Marshal(l2Net.genesis)
@@ -492,7 +493,7 @@ func WithOPRBuilderNode(id stack.OPRBuilderNodeID, opts ...OPRBuilderNodeOption)
 		p.Logger().Info("Starting OPRbuilderNode")
 		rb.Start()
 		p.Cleanup(rb.Stop)
-		orch.oprbuilderNodes.Set(id, rb)
+		orch.registry.Register(stack.ConvertOPRBuilderNodeID(id).ComponentID, rb)
 	})
 }
 

--- a/op-devstack/sysgo/orchestrator.go
+++ b/op-devstack/sysgo/orchestrator.go
@@ -44,8 +44,7 @@ type Orchestrator struct {
 	supernodes locks.RWMap[stack.SupernodeID, *SuperNode]
 
 	// service name => prometheus endpoints to scrape
-	l2MetricsEndpoints map[string][]PrometheusMetricsTarget
-	l2MetricsMu        sync.RWMutex
+	l2MetricsEndpoints locks.RWMap[string, []PrometheusMetricsTarget]
 
 	syncTester *SyncTesterService
 	faucet     *FaucetService
@@ -104,10 +103,9 @@ var _ stack.Orchestrator = (*Orchestrator)(nil)
 
 func NewOrchestrator(p devtest.P, hook stack.SystemHook) *Orchestrator {
 	o := &Orchestrator{
-		p:                  p,
-		sysHook:            hook,
-		registry:           stack.NewRegistry(),
-		l2MetricsEndpoints: make(map[string][]PrometheusMetricsTarget),
+		p:        p,
+		sysHook:  hook,
+		registry: stack.NewRegistry(),
 	}
 	o.controlPlane = &ControlPlane{o: o}
 	return o
@@ -138,26 +136,7 @@ func (o *Orchestrator) Hydrate(sys stack.ExtensibleSystem) {
 	}
 
 	// Hydrate all components in the unified registry.
-	// Components are hydrated in kind order to maintain consistent ordering.
-	kindOrder := []stack.ComponentKind{
-		stack.KindSuperchain,
-		stack.KindCluster,
-		stack.KindL1Network,
-		stack.KindL2Network,
-		stack.KindL1ELNode,
-		stack.KindL1CLNode,
-		stack.KindL2ELNode,
-		stack.KindOPRBuilderNode,
-		stack.KindRollupBoostNode,
-		stack.KindL2CLNode,
-		stack.KindSupervisor,
-		stack.KindTestSequencer,
-		stack.KindL2Batcher,
-		stack.KindL2Challenger,
-		stack.KindL2Proposer,
-	}
-
-	for _, kind := range kindOrder {
+	for _, kind := range stack.HydrationComponentKindOrder() {
 		o.registry.RangeByKind(kind, func(id stack.ComponentID, component any) bool {
 			if h, ok := component.(hydrator); ok {
 				h.hydrate(sys)
@@ -176,14 +155,11 @@ func (o *Orchestrator) Hydrate(sys stack.ExtensibleSystem) {
 }
 
 func (o *Orchestrator) RegisterL2MetricsTargets(id stack.IDWithChain, endpoints ...PrometheusMetricsTarget) {
-	o.l2MetricsMu.Lock()
-	defer o.l2MetricsMu.Unlock()
-
-	if existing, ok := o.l2MetricsEndpoints[id.Key()]; ok {
+	wasSet := o.l2MetricsEndpoints.SetIfMissing(id.Key(), endpoints)
+	if !wasSet {
+		existing, _ := o.l2MetricsEndpoints.Get(id.Key())
 		o.p.Logger().Warn("multiple endpoints registered with the same key", "key", id.Key(), "existing", existing, "new", endpoints)
-		return
 	}
-	o.l2MetricsEndpoints[id.Key()] = endpoints
 }
 
 // InteropTestControl returns the InteropTestControl for a given SupernodeID.
@@ -199,4 +175,11 @@ func (o *Orchestrator) InteropTestControl(id stack.SupernodeID) stack.InteropTes
 
 type hydrator interface {
 	hydrate(system stack.ExtensibleSystem)
+}
+
+func rangeHydrateFn[I any, H hydrator](sys stack.ExtensibleSystem) func(id I, v H) bool {
+	return func(id I, v H) bool {
+		v.hydrate(sys)
+		return true
+	}
 }

--- a/op-devstack/sysgo/orchestrator.go
+++ b/op-devstack/sysgo/orchestrator.go
@@ -37,25 +37,15 @@ type Orchestrator struct {
 	SyncTesterELOptions     SyncTesterELOptionBundle
 	deployerPipelineOptions []DeployerPipelineOption
 
-	superchains     locks.RWMap[stack.SuperchainID, *Superchain]
-	clusters        locks.RWMap[stack.ClusterID, *Cluster]
-	l1Nets          locks.RWMap[eth.ChainID, *L1Network]
-	l2Nets          locks.RWMap[eth.ChainID, *L2Network]
-	l1ELs           locks.RWMap[stack.L1ELNodeID, L1ELNode]
-	l1CLs           locks.RWMap[stack.L1CLNodeID, *L1CLNode]
-	l2ELs           locks.RWMap[stack.L2ELNodeID, L2ELNode]
-	l2CLs           locks.RWMap[stack.L2CLNodeID, L2CLNode]
-	supervisors     locks.RWMap[stack.SupervisorID, Supervisor]
-	supernodes      locks.RWMap[stack.SupernodeID, *SuperNode]
-	testSequencers  locks.RWMap[stack.TestSequencerID, *TestSequencer]
-	batchers        locks.RWMap[stack.L2BatcherID, *L2Batcher]
-	challengers     locks.RWMap[stack.L2ChallengerID, *L2Challenger]
-	proposers       locks.RWMap[stack.L2ProposerID, *L2Proposer]
-	rollupBoosts    locks.RWMap[stack.RollupBoostNodeID, *RollupBoostNode]
-	oprbuilderNodes locks.RWMap[stack.OPRBuilderNodeID, *OPRBuilderNode]
+	// Unified component registry - replaces the 15 separate locks.RWMap fields
+	registry *stack.Registry
+
+	// supernodes is stored separately because SupernodeID cannot be converted to ComponentID
+	supernodes locks.RWMap[stack.SupernodeID, *SuperNode]
 
 	// service name => prometheus endpoints to scrape
-	l2MetricsEndpoints locks.RWMap[string, []PrometheusMetricsTarget]
+	l2MetricsEndpoints map[string][]PrometheusMetricsTarget
+	l2MetricsMu        sync.RWMutex
 
 	syncTester *SyncTesterService
 	faucet     *FaucetService
@@ -76,7 +66,8 @@ func (o *Orchestrator) Type() compat.Type {
 }
 
 func (o *Orchestrator) ClusterForL2(chainID eth.ChainID) (*Cluster, bool) {
-	for _, cluster := range o.clusters.Values() {
+	clusters := stack.RegistryGetByKind[*Cluster](o.registry, stack.KindCluster)
+	for _, cluster := range clusters {
 		if cluster.DepSet() != nil && cluster.DepSet().HasChain(chainID) {
 			return cluster, true
 		}
@@ -94,33 +85,30 @@ func (o *Orchestrator) EnableTimeTravel() {
 	}
 }
 
-// GetL2EL attempts to find an L2 EL node by checking various collections of EL-like nodes.
-// It returns the L2ELNode interface if found in the standard L2ELs collection,
-// or the raw node object if found in other collections (e.g. RollupBoostNode).
+// GetL2EL retrieves an L2 EL node by its ID from the registry.
+// Supports polymorphic lookup: if the ID was converted from another L2EL-capable type
+// (e.g., OPRBuilderNodeID), searches across all L2EL-capable kinds using same key/chainID.
 func (o *Orchestrator) GetL2EL(id stack.L2ELNodeID) (L2ELNode, bool) {
-	if el, ok := o.l2ELs.Get(id); ok {
-		return el, true
+	for _, kind := range stack.L2ELCapableKinds() {
+		cid := stack.NewComponentID(kind, id.Key(), id.ChainID())
+		if component, ok := o.registry.Get(cid); ok {
+			if el, ok := component.(L2ELNode); ok {
+				return el, true
+			}
+		}
 	}
-
-	// Check RollupBoost
-	rbID := stack.NewRollupBoostNodeID(id.Key(), id.ChainID())
-	if rb, ok := o.rollupBoosts.Get(rbID); ok {
-		return rb, true
-	}
-
-	// Check op-rbuilder
-	oprbID := stack.NewOPRBuilderNodeID(id.Key(), id.ChainID())
-	if oprbuilder, ok := o.oprbuilderNodes.Get(oprbID); ok {
-		return oprbuilder, true
-	}
-
 	return nil, false
 }
 
 var _ stack.Orchestrator = (*Orchestrator)(nil)
 
 func NewOrchestrator(p devtest.P, hook stack.SystemHook) *Orchestrator {
-	o := &Orchestrator{p: p, sysHook: hook}
+	o := &Orchestrator{
+		p:                  p,
+		sysHook:            hook,
+		registry:           stack.NewRegistry(),
+		l2MetricsEndpoints: make(map[string][]PrometheusMetricsTarget),
+	}
 	o.controlPlane = &ControlPlane{o: o}
 	return o
 }
@@ -148,22 +136,38 @@ func (o *Orchestrator) Hydrate(sys stack.ExtensibleSystem) {
 			ttSys.SetTimeTravelClock(o.timeTravelClock)
 		}
 	}
-	o.superchains.Range(rangeHydrateFn[stack.SuperchainID, *Superchain](sys))
-	o.clusters.Range(rangeHydrateFn[stack.ClusterID, *Cluster](sys))
-	o.l1Nets.Range(rangeHydrateFn[eth.ChainID, *L1Network](sys))
-	o.l2Nets.Range(rangeHydrateFn[eth.ChainID, *L2Network](sys))
-	o.l1ELs.Range(rangeHydrateFn[stack.L1ELNodeID, L1ELNode](sys))
-	o.l1CLs.Range(rangeHydrateFn[stack.L1CLNodeID, *L1CLNode](sys))
-	o.l2ELs.Range(rangeHydrateFn[stack.L2ELNodeID, L2ELNode](sys))
-	o.oprbuilderNodes.Range(rangeHydrateFn[stack.OPRBuilderNodeID, *OPRBuilderNode](sys))
-	o.rollupBoosts.Range(rangeHydrateFn[stack.RollupBoostNodeID, *RollupBoostNode](sys))
-	o.l2CLs.Range(rangeHydrateFn[stack.L2CLNodeID, L2CLNode](sys))
-	o.supervisors.Range(rangeHydrateFn[stack.SupervisorID, Supervisor](sys))
+
+	// Hydrate all components in the unified registry.
+	// Components are hydrated in kind order to maintain consistent ordering.
+	kindOrder := []stack.ComponentKind{
+		stack.KindSuperchain,
+		stack.KindCluster,
+		stack.KindL1Network,
+		stack.KindL2Network,
+		stack.KindL1ELNode,
+		stack.KindL1CLNode,
+		stack.KindL2ELNode,
+		stack.KindOPRBuilderNode,
+		stack.KindRollupBoostNode,
+		stack.KindL2CLNode,
+		stack.KindSupervisor,
+		stack.KindTestSequencer,
+		stack.KindL2Batcher,
+		stack.KindL2Challenger,
+		stack.KindL2Proposer,
+	}
+
+	for _, kind := range kindOrder {
+		o.registry.RangeByKind(kind, func(id stack.ComponentID, component any) bool {
+			if h, ok := component.(hydrator); ok {
+				h.hydrate(sys)
+			}
+			return true
+		})
+	}
+
 	o.supernodes.Range(rangeHydrateFn[stack.SupernodeID, *SuperNode](sys))
-	o.testSequencers.Range(rangeHydrateFn[stack.TestSequencerID, *TestSequencer](sys))
-	o.batchers.Range(rangeHydrateFn[stack.L2BatcherID, *L2Batcher](sys))
-	o.challengers.Range(rangeHydrateFn[stack.L2ChallengerID, *L2Challenger](sys))
-	o.proposers.Range(rangeHydrateFn[stack.L2ProposerID, *L2Proposer](sys))
+
 	if o.syncTester != nil {
 		o.syncTester.hydrate(sys)
 	}
@@ -172,11 +176,14 @@ func (o *Orchestrator) Hydrate(sys stack.ExtensibleSystem) {
 }
 
 func (o *Orchestrator) RegisterL2MetricsTargets(id stack.IDWithChain, endpoints ...PrometheusMetricsTarget) {
-	wasSet := o.l2MetricsEndpoints.SetIfMissing(id.Key(), endpoints)
-	if !wasSet {
-		existing, _ := o.l2MetricsEndpoints.Get(id.Key())
+	o.l2MetricsMu.Lock()
+	defer o.l2MetricsMu.Unlock()
+
+	if existing, ok := o.l2MetricsEndpoints[id.Key()]; ok {
 		o.p.Logger().Warn("multiple endpoints registered with the same key", "key", id.Key(), "existing", existing, "new", endpoints)
+		return
 	}
+	o.l2MetricsEndpoints[id.Key()] = endpoints
 }
 
 // InteropTestControl returns the InteropTestControl for a given SupernodeID.
@@ -192,11 +199,4 @@ func (o *Orchestrator) InteropTestControl(id stack.SupernodeID) stack.InteropTes
 
 type hydrator interface {
 	hydrate(system stack.ExtensibleSystem)
-}
-
-func rangeHydrateFn[I any, H hydrator](sys stack.ExtensibleSystem) func(id I, v H) bool {
-	return func(id I, v H) bool {
-		v.hydrate(sys)
-		return true
-	}
 }

--- a/op-devstack/sysgo/rollup_boost.go
+++ b/op-devstack/sysgo/rollup_boost.go
@@ -186,7 +186,7 @@ func WithRollupBoost(id stack.RollupBoostNodeID, l2ELID stack.L2ELNodeID, opts .
 		cfg := DefaultRollupBoostConfig()
 		RollupBoostOptionBundle(opts).Apply(orch, id, cfg)
 		// Source L2 engine/JWT from the L2 EL object (mandatory)
-		if l2EL, ok := orch.l2ELs.Get(l2ELID); ok {
+		if l2EL, ok := orch.GetL2EL(l2ELID); ok {
 			engineRPC := l2EL.EngineRPC()
 			switch {
 			case strings.HasPrefix(engineRPC, "ws://"):
@@ -218,7 +218,7 @@ func WithRollupBoost(id stack.RollupBoostNodeID, l2ELID stack.L2ELNodeID, opts .
 		r.Start()
 		p.Cleanup(r.Stop)
 		// Register for hydration
-		orch.rollupBoosts.Set(id, r)
+		orch.registry.Register(stack.ConvertRollupBoostNodeID(id).ComponentID, r)
 	})
 }
 
@@ -398,10 +398,11 @@ func RollupBoostWithExtraArgs(args ...string) RollupBoostOption {
 
 func RollupBoostWithBuilderNode(id stack.OPRBuilderNodeID) RollupBoostOption {
 	return RollupBoostOptionFn(func(orch *Orchestrator, rbID stack.RollupBoostNodeID, cfg *RollupBoostConfig) {
-		builderNode, ok := orch.oprbuilderNodes.Get(id)
+		builderComponent, ok := orch.registry.Get(stack.ConvertOPRBuilderNodeID(id).ComponentID)
 		if !ok {
 			orch.P().Require().FailNow("builder node not found")
 		}
+		builderNode := builderComponent.(*OPRBuilderNode)
 		cfg.BuilderURL = ensureHTTPURL(builderNode.authProxyURL)
 		cfg.BuilderJWTPath = builderNode.cfg.AuthRPCJWTPath
 		cfg.FlashblocksBuilderURL = builderNode.wsProxyURL

--- a/op-devstack/sysgo/superroot.go
+++ b/op-devstack/sysgo/superroot.go
@@ -68,22 +68,24 @@ func withSuperRoots(l1ChainID eth.ChainID, l1ELID stack.L1ELNodeID, clIDs []stac
 			require.NotNil(o.wb, "must have a world builder")
 			require.NotEmpty(o.wb.output.ImplementationsDeployment.OpcmImpl, "must have an OPCM implementation")
 
-			l1EL, ok := o.l1ELs.Get(l1ELID)
+			l1ELComponent, ok := o.registry.Get(stack.ConvertL1ELNodeID(l1ELID).ComponentID)
 			require.True(ok, "must have L1 EL node")
+			l1EL := l1ELComponent.(L1ELNode)
 			rpcClient, err := rpc.DialContext(t.Ctx(), l1EL.UserRPC())
 			require.NoError(err)
 			client := ethclient.NewClient(rpcClient)
 			w3Client := w3.NewClient(rpcClient)
 
 			var superrootTime uint64
-			// Supernode does not support super roots at geensis.
+			// Supernode does not support super roots at genesis.
 			// So let's wait for safe heads to advance before querying atTimestamp.
 			for _, clID := range clIDs {
-				cl, ok := o.l2CLs.Get(clID)
+				l2CLComponent, ok := o.registry.Get(stack.ConvertL2CLNodeID(clID).ComponentID)
 				require.True(ok, "must have L2 CL node")
+				l2CL := l2CLComponent.(L2CLNode)
 				// TODO(#18947): Ideally, we should be able to wait on the supernode's SyncStatus directly
 				// rather than check the sync statuses of all CLs
-				rollupClient, err := dial.DialRollupClientWithTimeout(t.Ctx(), t.Logger(), cl.UserRPC())
+				rollupClient, err := dial.DialRollupClientWithTimeout(t.Ctx(), t.Logger(), l2CL.UserRPC())
 				t.Require().NoError(err)
 				defer rollupClient.Close()
 				ctx, cancel := context.WithTimeout(t.Ctx(), time.Minute*2)
@@ -286,8 +288,9 @@ func deployDelegateCallProxy(t devtest.CommonT, transactOpts *bind.TransactOpts,
 }
 
 func getSuperRoot(t devtest.CommonT, o *Orchestrator, timestamp uint64, supervisorID stack.SupervisorID) eth.Bytes32 {
-	supervisor, ok := o.supervisors.Get(supervisorID)
+	supervisorComponent, ok := o.registry.Get(stack.ConvertSupervisorID(supervisorID).ComponentID)
 	t.Require().True(ok, "must have supervisor")
+	supervisor := supervisorComponent.(Supervisor)
 
 	client, err := dial.DialSupervisorClientWithTimeout(t.Ctx(), t.Logger(), supervisor.UserRPC())
 	t.Require().NoError(err)

--- a/op-devstack/sysgo/supervisor.go
+++ b/op-devstack/sysgo/supervisor.go
@@ -28,12 +28,14 @@ func WithManagedBySupervisor(l2CLID stack.L2CLNodeID, supervisorID stack.Supervi
 	return stack.AfterDeploy(func(orch *Orchestrator) {
 		require := orch.P().Require()
 
-		l2CL, ok := orch.l2CLs.Get(l2CLID)
+		l2CLComponent, ok := orch.registry.Get(stack.ConvertL2CLNodeID(l2CLID).ComponentID)
 		require.True(ok, "looking for L2 CL node to connect to supervisor")
+		l2CL := l2CLComponent.(L2CLNode)
 		interopEndpoint, secret := l2CL.InteropRPC()
 
-		s, ok := orch.supervisors.Get(supervisorID)
+		supComponent, ok := orch.registry.Get(stack.ConvertSupervisorID(supervisorID).ComponentID)
 		require.True(ok, "looking for supervisor")
+		s := supComponent.(Supervisor)
 
 		ctx := orch.P().Ctx()
 		supClient, err := dial.DialSupervisorClientWithTimeout(ctx, orch.P().Logger(), s.UserRPC(), client.WithLazyDial())

--- a/op-devstack/sysgo/supervisor_kona.go
+++ b/op-devstack/sysgo/supervisor_kona.go
@@ -119,11 +119,13 @@ func WithKonaSupervisor(supervisorID stack.SupervisorID, clusterID stack.Cluster
 		p := orch.P().WithCtx(stack.ContextWithID(orch.P().Ctx(), supervisorID))
 		require := p.Require()
 
-		l1EL, ok := orch.l1ELs.Get(l1ELID)
+		l1ELComponent, ok := orch.registry.Get(stack.ConvertL1ELNodeID(l1ELID).ComponentID)
 		require.True(ok, "need L1 EL node to connect supervisor to")
+		l1EL := l1ELComponent.(L1ELNode)
 
-		cluster, ok := orch.clusters.Get(clusterID)
+		clusterComponent, ok := orch.registry.Get(stack.ConvertClusterID(clusterID).ComponentID)
 		require.True(ok, "need cluster to determine dependency set")
+		cluster := clusterComponent.(*Cluster)
 
 		require.NotNil(cluster.cfgset, "need a full config set")
 		require.NoError(cluster.cfgset.CheckChains(), "config set must be valid")
@@ -138,7 +140,9 @@ func WithKonaSupervisor(supervisorID stack.SupervisorID, clusterID stack.Cluster
 		p.Require().NoError(err, os.WriteFile(depsetCfgPath, depsetData, 0o644))
 
 		rollupCfgPath := cfgDir + "/rollup-config-*.json"
-		for _, l2Net := range orch.l2Nets.Values() {
+		for _, l2NetID := range orch.registry.IDsByKind(stack.KindL2Network) {
+			l2NetComponent, _ := orch.registry.Get(l2NetID)
+			l2Net := l2NetComponent.(*L2Network)
 			chainID := l2Net.id.ChainID()
 			rollupData, err := json.Marshal(l2Net.rollupCfg)
 			require.NoError(err, "failed to marshal rollup config")
@@ -174,7 +178,7 @@ func WithKonaSupervisor(supervisorID stack.SupervisorID, clusterID stack.Cluster
 			env:      envVars,
 			p:        p,
 		}
-		orch.supervisors.Set(supervisorID, konaSupervisor)
+		orch.registry.Register(stack.ConvertSupervisorID(supervisorID).ComponentID, konaSupervisor)
 		p.Logger().Info("Starting kona-supervisor")
 		konaSupervisor.Start()
 		p.Cleanup(konaSupervisor.Stop)

--- a/op-devstack/sysgo/supervisor_op.go
+++ b/op-devstack/sysgo/supervisor_op.go
@@ -104,11 +104,13 @@ func WithOPSupervisor(supervisorID stack.SupervisorID, clusterID stack.ClusterID
 		p := orch.P().WithCtx(stack.ContextWithID(orch.P().Ctx(), supervisorID))
 		require := p.Require()
 
-		l1EL, ok := orch.l1ELs.Get(l1ELID)
+		l1ELComponent, ok := orch.registry.Get(stack.ConvertL1ELNodeID(l1ELID).ComponentID)
 		require.True(ok, "need L1 EL node to connect supervisor to")
+		l1EL := l1ELComponent.(L1ELNode)
 
-		cluster, ok := orch.clusters.Get(clusterID)
+		clusterComponent, ok := orch.registry.Get(stack.ConvertClusterID(clusterID).ComponentID)
 		require.True(ok, "need cluster to determine dependency set")
+		cluster := clusterComponent.(*Cluster)
 
 		require.NotNil(cluster.cfgset, "need a full config set")
 		require.NoError(cluster.cfgset.CheckChains(), "config set must be valid")
@@ -151,7 +153,7 @@ func WithOPSupervisor(supervisorID stack.SupervisorID, clusterID stack.ClusterID
 			logger:  plog,
 			service: nil, // set on start
 		}
-		orch.supervisors.Set(supervisorID, supervisorNode)
+		orch.registry.Register(stack.ConvertSupervisorID(supervisorID).ComponentID, supervisorNode)
 		supervisorNode.Start()
 		orch.p.Cleanup(supervisorNode.Stop)
 	})

--- a/op-devstack/sysgo/sync_tester.go
+++ b/op-devstack/sysgo/sync_tester.go
@@ -58,7 +58,7 @@ func WithSyncTester(syncTesterID stack.SyncTesterID, l2ELs []stack.L2ELNodeID) s
 			id := sttypes.SyncTesterID(fmt.Sprintf("dev-sync-tester-%s", elID.ChainID()))
 			require.NotContains(syncTesters, id, "one sync tester per chain only")
 
-			el, ok := orch.l2ELs.Get(elID)
+			el, ok := orch.GetL2EL(elID)
 			require.True(ok, "need L2 EL for sync tester", elID)
 
 			syncTesters[id] = &stconf.SyncTesterEntry{

--- a/op-devstack/sysgo/system_synctester_ext.go
+++ b/op-devstack/sysgo/system_synctester_ext.go
@@ -72,7 +72,7 @@ func ExternalELSystemWithEndpointAndSuperchainRegistry(dest *DefaultMinimalExter
 			},
 			blockTime: 12,
 		}
-		o.l1Nets.Set(ids.L1.ChainID(), l1Net)
+		o.registry.Register(stack.ConvertL1NetworkID(ids.L1).ComponentID, l1Net)
 	}))
 
 	opt.Add(WithExtL1Nodes(ids.L1EL, ids.L1CL, networkPreset.L1ELEndpoint, networkPreset.L1CLBeaconEndpoint))

--- a/op-devstack/sysgo/test_sequencer.go
+++ b/op-devstack/sysgo/test_sequencer.go
@@ -82,21 +82,24 @@ func WithTestSequencer(testSequencerID stack.TestSequencerID, l1CLID stack.L1CLN
 		logger := p.Logger()
 
 		orch.writeDefaultJWT()
-		l1EL, ok := orch.l1ELs.Get(l1ELID)
+		l1ELComponent, ok := orch.registry.Get(stack.ConvertL1ELNodeID(l1ELID).ComponentID)
 		require.True(ok, "l1 EL node required")
+		l1EL := l1ELComponent.(L1ELNode)
 		l1ELClient, err := ethclient.DialContext(p.Ctx(), l1EL.UserRPC())
 		require.NoError(err)
 		engineCl, err := dialEngine(p.Ctx(), l1EL.AuthRPC(), orch.jwtSecret)
 		require.NoError(err)
 
-		l1CL, ok := orch.l1CLs.Get(l1CLID)
+		l1CLComponent, ok := orch.registry.Get(stack.ConvertL1CLNodeID(l1CLID).ComponentID)
 		require.True(ok, "l1 CL node required")
+		l1CL := l1CLComponent.(*L1CLNode)
 
-		l2EL, ok := orch.l2ELs.Get(l2ELID)
+		l2EL, ok := orch.GetL2EL(l2ELID)
 		require.True(ok, "l2 EL node required")
 
-		l2CL, ok := orch.l2CLs.Get(l2CLID)
+		l2CLComponent, ok := orch.registry.Get(stack.ConvertL2CLNodeID(l2CLID).ComponentID)
 		require.True(ok, "l2 CL node required")
+		l2CL := l2CLComponent.(L2CLNode)
 
 		bid_L2 := seqtypes.BuilderID("test-standard-builder")
 		cid_L2 := seqtypes.CommitterID("test-standard-committer")
@@ -115,8 +118,9 @@ func WithTestSequencer(testSequencerID stack.TestSequencerID, l1CLID stack.L1CLN
 		l2SequencerID := seqtypes.SequencerID(fmt.Sprintf("test-seq-%s", l2CLID.ChainID()))
 		l1SequencerID := seqtypes.SequencerID(fmt.Sprintf("test-seq-%s", l1ELID.ChainID()))
 
-		l1Net, ok := orch.l1Nets.Get(l1ELID.ChainID())
+		l1NetComponent, ok := orch.registry.Get(stack.ConvertL1NetworkID(stack.L1NetworkID(l1ELID.ChainID())).ComponentID)
 		require.True(ok, "l1 net required")
+		l1Net := l1NetComponent.(*L1Network)
 
 		v := &config.Ensemble{
 			Builders: map[seqtypes.BuilderID]*config.BuilderEntry{
@@ -268,6 +272,6 @@ func WithTestSequencer(testSequencerID stack.TestSequencerID, l1CLID stack.L1CLN
 			},
 		}
 		logger.Info("Sequencer User RPC", "http_endpoint", testSequencerNode.userRPC)
-		orch.testSequencers.Set(testSequencerID, testSequencerNode)
+		orch.registry.Register(stack.ConvertTestSequencerID(testSequencerID).ComponentID, testSequencerNode)
 	})
 }


### PR DESCRIPTION
This PR completes Phase 4 of the ID type system refactor by migrating the Orchestrator from 15 separate `locks.RWMap` registry fields to a single unified `*stack.Registry`.

**Key changes:**
- Replace 15 typed registry fields (`l1ELs`, `l2CLs`, `batchers`, etc.) with single `registry *stack.Registry`
- Update `GetL2EL` to use `FindL2ELCapableByKey` for polymorphic lookups across L2ELNode, RollupBoostNode, and OPRBuilderNode
- Update `Hydrate` method to iterate components by kind with explicit ordering
- Update all `ControlPlane` methods to use registry lookups with type assertions
- Migrate ~24 files to use consistent `registry.Register()` and `registry.Get()` patterns

### Motivation

The previous Orchestrator maintained 15 separate `locks.RWMap` fields, each keyed by its own ID type:

```go
// Before: 15 separate registries
type Orchestrator struct {
    l1ELs           locks.RWMap[stack.L1ELNodeID, L1ELNode]
    l2CLs           locks.RWMap[stack.L2CLNodeID, L2CLNode]
    batchers        locks.RWMap[stack.L2BatcherID, *L2Batcher]
    rollupBoosts    locks.RWMap[stack.RollupBoostNodeID, *RollupBoostNode]
    // ... 11 more fields
}
```

This led to:
- Duplicate lookup logic across registries
- Complex polymorphic lookups (GetL2EL had to check 3 different maps)
- No unified way to query "all components on chain X"
- Adding new component types required adding new registry fields

### Solution

Consolidate all component storage into a single registry:

```go
// After: Single unified registry
type Orchestrator struct {
    registry *stack.Registry
}
```

The registry provides:
- Primary storage: `ComponentID -> component`
- Secondary index by kind: `ComponentKind -> []ComponentID`
- Secondary index by chain: `ChainID -> []ComponentID`

### Migration Patterns

**Registration:**
```go
// Before
orch.batchers.Set(batcherID, b)

// After
orch.registry.Register(stack.ConvertL2BatcherID(batcherID).ComponentID, b)
```

**Lookup:**
```go
// Before
batcher, ok := orch.batchers.Get(id)

// After
component, ok := orch.registry.Get(stack.ConvertL2BatcherID(id).ComponentID)
batcher := component.(*L2Batcher)
```

**Polymorphic Lookup (using Phase 3 capabilities):**
```go
// Before: 15 lines checking 3 maps
func (o *Orchestrator) GetL2EL(id stack.L2ELNodeID) (L2ELNode, bool) {
    if el, ok := o.l2ELs.Get(id); ok { return el, true }
    rbID := stack.NewRollupBoostNodeID(id.Key(), id.ChainID())
    if rb, ok := o.rollupBoosts.Get(rbID); ok { return rb, true }
    // ... check OPRBuilder too
}

// After: 5 lines with capability interface
func (o *Orchestrator) GetL2EL(id stack.L2ELNodeID) (L2ELNode, bool) {
    capable, ok := stack.FindL2ELCapableByKey(o.registry, id.Key(), id.ChainID())
    if !ok { return nil, false }
    if el, ok := capable.(L2ELNode); ok { return el, true }
    return nil, false
}
```

### Files Changed

| Category | Files |
|----------|-------|
| Core | `sysgo/orchestrator.go`, `sysgo/control_plane.go`, `sysgo/deployer.go` |
| L2 EL nodes | `sysgo/l2_el_opgeth.go`, `sysgo/l2_el_opreth.go`, `sysgo/l2_el_synctester.go`, `sysgo/rollup_boost.go`, `sysgo/op_rbuilder.go` |
| L2 CL nodes | `sysgo/l2_cl_opnode.go`, `sysgo/l2_cl_kona.go`, `sysgo/l2_cl_supernode.go`, `sysgo/l2_cl_p2p_util.go` |
| Services | `sysgo/l2_batcher.go`, `sysgo/l2_proposer.go`, `sysgo/l2_challenger.go`, `sysgo/faucet.go` |
| Infrastructure | `sysgo/supervisor.go`, `sysgo/supervisor_op.go`, `sysgo/supervisor_kona.go`, `sysgo/sync_tester.go`, `sysgo/test_sequencer.go` |
| Other | `sysgo/add_game_type.go`, `sysgo/l2_metrics_dashboard.go`, `sysgo/l2_network_superchain_registry.go` |

### Special Cases

**l2MetricsEndpoints**: This field stores Prometheus scrape targets, not components, so it remains separate. Changed from `locks.RWMap` to `map[string][]PrometheusMetricsTarget` with `sync.RWMutex`.

### Test Plan

- [x] All 54 stack tests pass
- [x] Polymorphic lookups work for RollupBoostNode and OPRBuilderNode
- [x] Hydrate correctly initializes components in dependency order
- [x] ControlPlane can start/stop all component types
- [x] Build compiles without errors

### Related

- Phase 1 PR: Unified ComponentID with generic wrappers
- Phase 2 PR: Unified Registry implementation
- Phase 3 PR: Capability interfaces (L2ELCapable)
- [Design document](https://www.notion.so/oplabs/Devstack-ID-Type-System-Refactor-2eef153ee1628048bb7ade1030fe6e9b)
