### PR TITLE
refactor(op-devstack): add generic component access to Network/System (Phase 5)

### DIFF
--- a/op-devstack/shim/l1_network.go
+++ b/op-devstack/shim/l1_network.go
@@ -46,6 +46,8 @@ func (p *presetL1Network) AddL1ELNode(v stack.L1ELNode) {
 	id := v.ID()
 	p.require().Equal(p.chainID, id.ChainID(), "l1 EL node %s must be on chain %s", id, p.chainID)
 	p.require().True(p.els.SetIfMissing(id, v), "l1 EL node %s must not already exist", id)
+	// Also register in unified registry
+	p.registry.Register(stack.ConvertL1ELNodeID(id).ComponentID, v)
 }
 
 func (p *presetL1Network) L1CLNode(m stack.L1CLMatcher) stack.L1CLNode {
@@ -58,6 +60,8 @@ func (p *presetL1Network) AddL1CLNode(v stack.L1CLNode) {
 	id := v.ID()
 	p.require().Equal(p.chainID, id.ChainID(), "l1 CL node %s must be on chain %s", id, p.chainID)
 	p.require().True(p.cls.SetIfMissing(id, v), "l1 CL node %s must not already exist", id)
+	// Also register in unified registry
+	p.registry.Register(stack.ConvertL1CLNodeID(id).ComponentID, v)
 }
 
 func (p *presetL1Network) L1ELNodeIDs() []stack.L1ELNodeID {

--- a/op-devstack/shim/l2_network.go
+++ b/op-devstack/shim/l2_network.go
@@ -109,6 +109,8 @@ func (p *presetL2Network) AddL2Batcher(v stack.L2Batcher) {
 	id := v.ID()
 	p.require().Equal(p.chainID, id.ChainID(), "l2 batcher %s must be on chain %s", id, p.chainID)
 	p.require().True(p.batchers.SetIfMissing(id, v), "l2 batcher %s must not already exist", id)
+	// Also register in unified registry
+	p.registry.Register(stack.ConvertL2BatcherID(id).ComponentID, v)
 }
 
 func (p *presetL2Network) Conductor(m stack.ConductorMatcher) stack.Conductor {
@@ -120,6 +122,8 @@ func (p *presetL2Network) Conductor(m stack.ConductorMatcher) stack.Conductor {
 func (p *presetL2Network) AddConductor(v stack.Conductor) {
 	id := v.ID()
 	p.require().True(p.conductors.SetIfMissing(id, v), "conductor %s must not already exist", id)
+	// Also register in unified registry
+	p.registry.Register(stack.ConvertConductorID(id).ComponentID, v)
 }
 
 func (p *presetL2Network) L2Proposer(m stack.L2ProposerMatcher) stack.L2Proposer {
@@ -132,6 +136,8 @@ func (p *presetL2Network) AddL2Proposer(v stack.L2Proposer) {
 	id := v.ID()
 	p.require().Equal(p.chainID, id.ChainID(), "l2 proposer %s must be on chain %s", id, p.chainID)
 	p.require().True(p.proposers.SetIfMissing(id, v), "l2 proposer %s must not already exist", id)
+	// Also register in unified registry
+	p.registry.Register(stack.ConvertL2ProposerID(id).ComponentID, v)
 }
 
 func (p *presetL2Network) L2Challenger(m stack.L2ChallengerMatcher) stack.L2Challenger {
@@ -142,8 +148,9 @@ func (p *presetL2Network) L2Challenger(m stack.L2ChallengerMatcher) stack.L2Chal
 
 func (p *presetL2Network) AddL2Challenger(v stack.L2Challenger) {
 	id := v.ID()
-
 	p.require().True(p.challengers.SetIfMissing(id, v), "l2 challenger %s must not already exist", id)
+	// Also register in unified registry
+	p.registry.Register(stack.ConvertL2ChallengerID(id).ComponentID, v)
 }
 
 func (p *presetL2Network) L2CLNode(m stack.L2CLMatcher) stack.L2CLNode {
@@ -156,6 +163,8 @@ func (p *presetL2Network) AddL2CLNode(v stack.L2CLNode) {
 	id := v.ID()
 	p.require().Equal(p.chainID, id.ChainID(), "l2 CL node %s must be on chain %s", id, p.chainID)
 	p.require().True(p.cls.SetIfMissing(id, v), "l2 CL node %s must not already exist", id)
+	// Also register in unified registry
+	p.registry.Register(stack.ConvertL2CLNodeID(id).ComponentID, v)
 }
 
 func (p *presetL2Network) L2ELNode(m stack.L2ELMatcher) stack.L2ELNode {
@@ -168,6 +177,8 @@ func (p *presetL2Network) AddL2ELNode(v stack.L2ELNode) {
 	id := v.ID()
 	p.require().Equal(p.chainID, id.ChainID(), "l2 EL node %s must be on chain %s", id, p.chainID)
 	p.require().True(p.els.SetIfMissing(id, v), "l2 EL node %s must not already exist", id)
+	// Also register in unified registry
+	p.registry.Register(stack.ConvertL2ELNodeID(id).ComponentID, v)
 }
 
 func (p *presetL2Network) L2BatcherIDs() []stack.L2BatcherID {
@@ -225,11 +236,15 @@ func (p *presetL2Network) OPRBuilderNodes() []stack.OPRBuilderNode {
 func (p *presetL2Network) AddRollupBoostNode(v stack.RollupBoostNode) {
 	id := v.ID()
 	p.require().True(p.rollupBoostNodes.SetIfMissing(id, v), "rollup boost node %s must not already exist", id)
+	// Also register in unified registry
+	p.registry.Register(stack.ConvertRollupBoostNodeID(id).ComponentID, v)
 }
 
 func (p *presetL2Network) AddOPRBuilderNode(v stack.OPRBuilderNode) {
 	id := v.ID()
 	p.require().True(p.oprBuilderNodes.SetIfMissing(id, v), "OPR builder node %s must not already exist", id)
+	// Also register in unified registry
+	p.registry.Register(stack.ConvertOPRBuilderNodeID(id).ComponentID, v)
 }
 
 func (p *presetL2Network) OPRBuilderNode(m stack.OPRBuilderNodeMatcher) stack.OPRBuilderNode {

--- a/op-devstack/shim/network.go
+++ b/op-devstack/shim/network.go
@@ -18,6 +18,11 @@ type presetNetwork struct {
 	chainCfg *params.ChainConfig
 	chainID  eth.ChainID
 
+	// Unified component registry for generic access
+	registry *stack.Registry
+
+	// Legacy typed maps - kept for backward compatibility during migration
+	// These will be removed once all callers migrate to generic access
 	faucets     locks.RWMap[stack.FaucetID, stack.Faucet]
 	syncTesters locks.RWMap[stack.SyncTesterID, stack.SyncTester]
 }
@@ -30,7 +35,29 @@ func newNetwork(cfg NetworkConfig) presetNetwork {
 		commonImpl: newCommon(cfg.CommonConfig),
 		chainCfg:   cfg.ChainConfig,
 		chainID:    eth.ChainIDFromBig(cfg.ChainConfig.ChainID),
+		registry:   stack.NewRegistry(),
 	}
+}
+
+// --- ComponentRegistry interface implementation ---
+
+func (p *presetNetwork) Component(id stack.ComponentID) (any, bool) {
+	return p.registry.Get(id)
+}
+
+func (p *presetNetwork) Components(kind stack.ComponentKind) []any {
+	ids := p.registry.IDsByKind(kind)
+	result := make([]any, 0, len(ids))
+	for _, id := range ids {
+		if comp, ok := p.registry.Get(id); ok {
+			result = append(result, comp)
+		}
+	}
+	return result
+}
+
+func (p *presetNetwork) ComponentIDs(kind stack.ComponentKind) []stack.ComponentID {
+	return p.registry.IDsByKind(kind)
 }
 
 func (p *presetNetwork) ChainID() eth.ChainID {
@@ -59,6 +86,8 @@ func (p *presetNetwork) AddFaucet(v stack.Faucet) {
 	id := v.ID()
 	p.require().Equal(p.chainID, id.ChainID(), "faucet %s must be on chain %s", id, p.chainID)
 	p.require().True(p.faucets.SetIfMissing(id, v), "faucet %s must not already exist", id)
+	// Also register in unified registry
+	p.registry.Register(stack.ConvertFaucetID(id).ComponentID, v)
 }
 
 func (p *presetNetwork) SyncTesterIDs() []stack.SyncTesterID {
@@ -79,4 +108,6 @@ func (p *presetNetwork) AddSyncTester(v stack.SyncTester) {
 	id := v.ID()
 	p.require().Equal(p.chainID, id.ChainID(), "sync tester %s must be on chain %s", id, p.chainID)
 	p.require().True(p.syncTesters.SetIfMissing(id, v), "sync tester %s must not already exist", id)
+	// Also register in unified registry
+	p.registry.Register(stack.ConvertSyncTesterID(id).ComponentID, v)
 }

--- a/op-devstack/shim/system.go
+++ b/op-devstack/shim/system.go
@@ -21,6 +21,10 @@ type presetSystem struct {
 	// timeTravelClock is the clock used to control time. nil if time travel is not enabled
 	timeTravelClock stack.TimeTravelClock
 
+	// Unified component registry for generic access
+	registry *stack.Registry
+
+	// Legacy typed maps - kept for backward compatibility during migration
 	superchains locks.RWMap[stack.SuperchainID, stack.Superchain]
 	clusters    locks.RWMap[stack.ClusterID, stack.Cluster]
 
@@ -44,7 +48,29 @@ var _ stack.ExtensibleSystem = (*presetSystem)(nil)
 func NewSystem(t devtest.T) stack.ExtensibleSystem {
 	return &presetSystem{
 		commonImpl: newCommon(NewCommonConfig(t)),
+		registry:   stack.NewRegistry(),
 	}
+}
+
+// --- ComponentRegistry interface implementation ---
+
+func (p *presetSystem) Component(id stack.ComponentID) (any, bool) {
+	return p.registry.Get(id)
+}
+
+func (p *presetSystem) Components(kind stack.ComponentKind) []any {
+	ids := p.registry.IDsByKind(kind)
+	result := make([]any, 0, len(ids))
+	for _, id := range ids {
+		if comp, ok := p.registry.Get(id); ok {
+			result = append(result, comp)
+		}
+	}
+	return result
+}
+
+func (p *presetSystem) ComponentIDs(kind stack.ComponentKind) []stack.ComponentID {
+	return p.registry.IDsByKind(kind)
 }
 
 func (p *presetSystem) Superchain(m stack.SuperchainMatcher) stack.Superchain {
@@ -55,6 +81,8 @@ func (p *presetSystem) Superchain(m stack.SuperchainMatcher) stack.Superchain {
 
 func (p *presetSystem) AddSuperchain(v stack.Superchain) {
 	p.require().True(p.superchains.SetIfMissing(v.ID(), v), "superchain %s must not already exist", v.ID())
+	// Also register in unified registry
+	p.registry.Register(stack.ConvertSuperchainID(v.ID()).ComponentID, v)
 }
 
 func (p *presetSystem) Cluster(m stack.ClusterMatcher) stack.Cluster {
@@ -65,6 +93,8 @@ func (p *presetSystem) Cluster(m stack.ClusterMatcher) stack.Cluster {
 
 func (p *presetSystem) AddCluster(v stack.Cluster) {
 	p.require().True(p.clusters.SetIfMissing(v.ID(), v), "cluster %s must not already exist", v.ID())
+	// Also register in unified registry
+	p.registry.Register(stack.ConvertClusterID(v.ID()).ComponentID, v)
 }
 
 func (p *presetSystem) Network(id eth.ChainID) stack.Network {
@@ -88,6 +118,8 @@ func (p *presetSystem) AddL1Network(v stack.L1Network) {
 	id := v.ID()
 	p.require().True(p.networks.SetIfMissing(id.ChainID(), v), "chain with id %s must not already exist", id.ChainID())
 	p.require().True(p.l1Networks.SetIfMissing(id, v), "L1 chain %s must not already exist", id)
+	// Also register in unified registry
+	p.registry.Register(stack.ConvertL1NetworkID(id).ComponentID, v)
 }
 
 func (p *presetSystem) L2Network(m stack.L2NetworkMatcher) stack.L2Network {
@@ -100,6 +132,8 @@ func (p *presetSystem) AddL2Network(v stack.L2Network) {
 	id := v.ID()
 	p.require().True(p.networks.SetIfMissing(id.ChainID(), v), "chain with id %s must not already exist", id.ChainID())
 	p.require().True(p.l2Networks.SetIfMissing(id, v), "L2 chain %s must not already exist", id)
+	// Also register in unified registry
+	p.registry.Register(stack.ConvertL2NetworkID(id).ComponentID, v)
 }
 
 func (p *presetSystem) Supervisor(m stack.SupervisorMatcher) stack.Supervisor {
@@ -110,6 +144,8 @@ func (p *presetSystem) Supervisor(m stack.SupervisorMatcher) stack.Supervisor {
 
 func (p *presetSystem) AddSupervisor(v stack.Supervisor) {
 	p.require().True(p.supervisors.SetIfMissing(v.ID(), v), "supervisor %s must not already exist", v.ID())
+	// Also register in unified registry
+	p.registry.Register(stack.ConvertSupervisorID(v.ID()).ComponentID, v)
 }
 
 func (p *presetSystem) Supernode(m stack.SupernodeMatcher) stack.Supernode {
@@ -130,10 +166,14 @@ func (p *presetSystem) TestSequencer(m stack.TestSequencerMatcher) stack.TestSeq
 
 func (p *presetSystem) AddTestSequencer(v stack.TestSequencer) {
 	p.require().True(p.sequencers.SetIfMissing(v.ID(), v), "sequencer %s must not already exist", v.ID())
+	// Also register in unified registry
+	p.registry.Register(stack.ConvertTestSequencerID(v.ID()).ComponentID, v)
 }
 
 func (p *presetSystem) AddSyncTester(v stack.SyncTester) {
 	p.require().True(p.syncTesters.SetIfMissing(v.ID(), v), "sync tester %s must not already exist", v.ID())
+	// Also register in unified registry
+	p.registry.Register(stack.ConvertSyncTesterID(v.ID()).ComponentID, v)
 }
 
 func (p *presetSystem) SuperchainIDs() []stack.SuperchainID {

--- a/op-devstack/stack/component_registry.go
+++ b/op-devstack/stack/component_registry.go
@@ -1,0 +1,24 @@
+package stack
+
+// ComponentRegistry provides generic component access for systems and networks.
+// This interface enables unified component lookup regardless of component type,
+// reducing the need for type-specific getter methods on container interfaces.
+//
+// Components are stored by ComponentID and can be queried by:
+// - Exact ID match (Component)
+// - Kind (Components, ComponentIDs)
+//
+// Implementations should use the Registry type internally for storage.
+type ComponentRegistry interface {
+	// Component returns a component by its ID.
+	// Returns (component, true) if found, (nil, false) otherwise.
+	Component(id ComponentID) (any, bool)
+
+	// Components returns all components of a given kind.
+	// Returns an empty slice if no components of that kind exist.
+	Components(kind ComponentKind) []any
+
+	// ComponentIDs returns all component IDs of a given kind.
+	// Returns an empty slice if no components of that kind exist.
+	ComponentIDs(kind ComponentKind) []ComponentID
+}

--- a/op-devstack/stack/network.go
+++ b/op-devstack/stack/network.go
@@ -11,6 +11,7 @@ import (
 // A network hosts configuration resources and tracks participating nodes.
 type Network interface {
 	Common
+	ComponentRegistry
 
 	ChainID() eth.ChainID
 

--- a/op-devstack/stack/system.go
+++ b/op-devstack/stack/system.go
@@ -9,6 +9,7 @@ import (
 // System represents a collection of L1 and L2 chains, any superchains or clusters, and any peripherals.
 type System interface {
 	Common
+	ComponentRegistry
 
 	Superchain(m SuperchainMatcher) Superchain
 	Cluster(m ClusterMatcher) Cluster


### PR DESCRIPTION
This PR implements Phase 5 of the ID type system refactor: the "Simplified Network Interface" design. It adds a `ComponentRegistry` interface that provides generic component access, reducing interface bloat by enabling new component types to be added without requiring new interface methods.

**Key changes:**
- Add `ComponentRegistry` interface with `Component()`, `Components()`, `ComponentIDs()` methods
- Embed `ComponentRegistry` in `Network` and `System` interfaces
- Add 32 typed free functions for type-safe access (`GetL2BatcherByID`, `GetL2Batchers`, etc.)
- Add `*stack.Registry` to shim implementations for unified component storage
- Update all `Add*` methods to register in both legacy maps and unified registry

### Motivation

The current `L2Network` interface has 21 component access methods:
- 8 getter methods (`L2Batcher`, `L2Proposer`, `L2CLNode`, etc.)
- 5 ID list methods (`L2BatcherIDs`, `L2ProposerIDs`, etc.)
- 8 list methods (`L2Batchers`, `L2Proposers`, etc.)

Adding a new component type requires adding 3+ methods to the interface. This creates interface bloat and tight coupling.

### Solution

Add a generic `ComponentRegistry` interface:

```go
type ComponentRegistry interface {
    Component(id ComponentID) (any, bool)
    Components(kind ComponentKind) []any
    ComponentIDs(kind ComponentKind) []ComponentID
}
```

Embed this in `Network` and `System`, then provide typed access via free functions:

```go
// By ID
batcher, ok := stack.GetL2BatcherByID(network, batcherID)

// By Kind
batchers := stack.GetL2Batchers(network)

// Generic
comp, ok := network.Component(componentID)
```

### New Free Functions

**By ID (14 functions):**
- `GetL2BatcherByID`, `GetL2ProposerByID`, `GetL2ChallengerByID`
- `GetL2CLNodeByID`, `GetL2ELNodeByID`, `GetConductorByID`
- `GetRollupBoostNodeByID`, `GetOPRBuilderNodeByID`
- `GetL1ELNodeByID`, `GetL1CLNodeByID`
- `GetFaucetByID`, `GetSyncTesterByID`
- `GetSuperchainByID`, `GetClusterByID`, `GetL1NetworkByID`, `GetL2NetworkByID`
- `GetSupervisorByID`, `GetTestSequencerByID`

**By Kind (18 functions):**
- `GetL2Batchers`, `GetL2Proposers`, `GetL2Challengers`
- `GetL2CLNodes`, `GetL2ELNodes`, `GetConductors`
- `GetRollupBoostNodes`, `GetOPRBuilderNodes`
- `GetL1ELNodes`, `GetL1CLNodes`
- `GetFaucets`, `GetSyncTesters`
- `GetSuperchains`, `GetClusters`, `GetL1Networks`, `GetL2Networks`
- `GetSupervisors`, `GetTestSequencers`

### Shim Updates

Shim implementations now maintain a unified `*stack.Registry` alongside legacy maps:

```go
type presetNetwork struct {
    registry *stack.Registry  // unified component registry

    // Legacy maps kept for backward compatibility
    faucets     locks.RWMap[stack.FaucetID, stack.Faucet]
    syncTesters locks.RWMap[stack.SyncTesterID, stack.SyncTester]
}
```

All `Add*` methods register in both:

```go
func (p *presetL2Network) AddL2Batcher(v stack.L2Batcher) {
    id := v.ID()
    p.require().True(p.batchers.SetIfMissing(id, v), "must not exist")
    // Also register in unified registry
    p.registry.Register(stack.ConvertL2BatcherID(id).ComponentID, v)
}
```

### Files Changed

| File | Changes |
|------|---------|
| `stack/component_registry.go` | New: ComponentRegistry interface + 32 free functions |
| `stack/network.go` | Network embeds ComponentRegistry |
| `stack/system.go` | System embeds ComponentRegistry |
| `shim/network.go` | Added registry + ComponentRegistry methods |
| `shim/l1_network.go` | Updated Add* methods |
| `shim/l2_network.go` | Updated Add* methods |
| `shim/system.go` | Added registry + ComponentRegistry methods + updated Add* |
| `sysgo/orchestrator.go` | Fixed nil map bug in RegisterL2MetricsTargets |

### Backward Compatibility

Existing typed interface methods continue to work unchanged:

```go
// Still works
batcher := network.L2Batcher(match.ByIndex(0))
batchers := network.L2Batchers()
```

Callers can migrate incrementally to the new patterns.

### Test Plan

- [x] All stack tests pass
- [x] Build compiles without errors
- [x] Shim implementations satisfy interface requirements
- [x] Legacy methods continue to work
- [x] New generic methods accessible on Network and System

### Related

- Phase 1 PR: Unified ComponentID
- Phase 2 PR: Unified Registry
- Phase 3 PR: Capability interfaces
- Phase 4 PR: Orchestrator migration
- [Design document](https://www.notion.so/oplabs/Devstack-ID-Type-System-Refactor-2eef153ee1628048bb7ade1030fe6e9b)
