### PR TITLE
ci: Fix continuation of git tag release triggers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,8 +96,10 @@ orbs:
 
 workflows:
   setup:
+    when:
+      equal: ["", << pipeline.git.tag >>]
     jobs:
-      - path-filtering/filter:
+      - path-filtering/filter: &path_filter
           base-revision: develop
           config-path: .circleci/continue/main.yml
           mapping: |
@@ -130,3 +132,15 @@ workflows:
             kona/.* default_docker_image << pipeline.parameters.default_docker_image >> .circleci/continue/kona.yml
             kona/.* base_image << pipeline.parameters.base_image >> .circleci/continue/kona.yml
             kona/.* go-cache-version << pipeline.parameters.go-cache-version >> .circleci/continue/kona.yml
+
+  setup-tag:
+    when:
+      not:
+        equal: ["", << pipeline.git.tag >>]
+    jobs:
+      - path-filtering/filter:
+          <<: *path_filter
+          # Tag pipelines can point directly at the base revision (e.g. a tag cut from develop),
+          # resulting in an empty diff and a skipped continuation. Diff against the first parent
+          # to ensure continuation always runs for tag pushes.
+          base-revision: "<< pipeline.git.revision >>^"

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -3015,15 +3015,17 @@ workflows:
             - cannon-prestate-quick
   main:
     when:
-      or:
-        - equal: ["webhook", << pipeline.trigger_source >>]
-        - and:
-            - equal: [true, <<pipeline.parameters.main_dispatch>>]
-            - equal: ["api", << pipeline.trigger_source >>]
-            - equal: [
-                  << pipeline.parameters.github-event-type >>,
-                  "__not_set__",
-                ] #this is to prevent triggering this workflow as the default value is always set for main_dispatch
+      and:
+        - equal: ["", << pipeline.git.tag >>]
+        - or:
+            - equal: ["webhook", << pipeline.trigger_source >>]
+            - and:
+                - equal: [true, <<pipeline.parameters.main_dispatch>>]
+                - equal: ["api", << pipeline.trigger_source >>]
+                - equal: [
+                      << pipeline.parameters.github-event-type >>,
+                      "__not_set__",
+                    ] #this is to prevent triggering this workflow as the default value is always set for main_dispatch
     jobs:
       - contracts-bedrock-build:
           name: contracts-bedrock-build


### PR DESCRIPTION
Dynamic config tag pipelines could skip continuation when a tag is cut from develop (empty diff vs base-revision: develop).

To fix, we add a dedicated setup-tag workflow that always runs on tag pushes and diffs against `<< pipeline.git.revision >>`'s parent, ensuring .circleci/continue/main.yml is continued and release workflows appear for tag pushes.

This ensures that the `release` workflow is triggered when a git tag is cut.