### PR TITLE
op-acceptance-tests: skip TestBatcherFullChannelsAfterDow…

### DIFF
--- a/op-acceptance-tests/tests/batcher/batcher_test.go
+++ b/op-acceptance-tests/tests/batcher/batcher_test.go
@@ -20,6 +20,8 @@ import (
 )
 
 func TestBatcherFullChannelsAfterDowntime(gt *testing.T) {
+	gt.Skip("Skipping test until we fix nonce too high error: tx: 177 state: 176")
+
 	t := devtest.SerialT(gt)
 	sys := presets.NewSingleChainMultiNodeWithTestSeq(t)
 	l := t.Logger()


### PR DESCRIPTION
This PR is disabling a flaky test due to `nonce too high error`.

Issue to investigate and re-enable in the future: https://github.com/ethereum-optimism/optimism/issues/18886