### PR TITLE
refactor: standarize opcmv2 version check

### DIFF
--- a/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
@@ -3,13 +3,13 @@ pragma solidity 0.8.15;
 
 import { Script } from "forge-std/Script.sol";
 
-import { DevFeatures } from "src/libraries/DevFeatures.sol";
 import { Constants } from "src/libraries/Constants.sol";
 import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 import { Solarray } from "scripts/libraries/Solarray.sol";
 import { ChainAssertions } from "scripts/deploy/ChainAssertions.sol";
 import { Constants as ScriptConstants } from "scripts/libraries/Constants.sol";
 import { Types } from "scripts/libraries/Types.sol";
+import { SemverComp } from "src/libraries/SemverComp.sol";
 
 import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
 import { IOPContractsManager } from "interfaces/L1/IOPContractsManager.sol";
@@ -33,6 +33,9 @@ import { GameTypes } from "src/dispute/lib/Types.sol";
 contract DeployOPChain is Script {
     /// @notice The default init bond for the dispute games.
     uint256 public constant DEFAULT_INIT_BOND = 0.08 ether;
+
+    /// @notice Whether to use OPCM v2.
+    bool public isOPCMv2;
 
     /// @notice The output of the DeployOPChain script. This is the same as the DeployOPChainOutput type in the
     /// op-deployer package.
@@ -71,9 +74,10 @@ contract DeployOPChain is Script {
         checkInput(_input);
 
         // Check if OPCM v2 should be used, both v1 and v2 share the same interface for this function.
-        bool useV2 = IOPContractsManager(_input.opcm).isDevFeatureEnabled(DevFeatures.OPCM_V2);
+        require(address(_input.opcm).code.length > 0, "DeployOPChain: OPCM address has no code");
+        isOPCMv2 = SemverComp.gte(IOPContractsManager(_input.opcm).version(), Constants.OPCM_V2_MIN_VERSION);
 
-        if (useV2) {
+        if (isOPCMv2) {
             IOPContractsManagerV2 opcmV2 = IOPContractsManagerV2(_input.opcm);
             IOPContractsManagerV2.FullConfig memory config = _toOPCMV2DeployInput(_input);
 
@@ -351,7 +355,7 @@ contract DeployOPChain is Script {
         // Check dispute games and get superchain config
         address expectedPDGImpl = address(_o.permissionedDisputeGame);
 
-        if (IOPContractsManager(_i.opcm).isDevFeatureEnabled(DevFeatures.OPCM_V2)) {
+        if (isOPCMv2) {
             // OPCM v2: use implementations from v2 contract
             IOPContractsManagerV2 opcmV2 = IOPContractsManagerV2(_i.opcm);
             expectedPDGImpl = opcmV2.implementations().permissionedDisputeGameImpl;

--- a/packages/contracts-bedrock/scripts/deploy/ReadImplementationAddresses.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/ReadImplementationAddresses.s.sol
@@ -9,7 +9,8 @@ import { IOPContractsManagerV2 } from "interfaces/L1/opcm/IOPContractsManagerV2.
 import { IOPContractsManagerContainer } from "interfaces/L1/opcm/IOPContractsManagerContainer.sol";
 import { IAddressManager } from "interfaces/legacy/IAddressManager.sol";
 import { IStaticL1ChugSplashProxy } from "interfaces/legacy/IL1ChugSplashProxy.sol";
-import { DevFeatures } from "src/libraries/DevFeatures.sol";
+import { SemverComp } from "src/libraries/SemverComp.sol";
+import { Constants } from "src/libraries/Constants.sol";
 
 contract ReadImplementationAddresses is Script {
     struct Input {
@@ -63,9 +64,10 @@ contract ReadImplementationAddresses is Script {
         output_.l1StandardBridge = IStaticL1ChugSplashProxy(_input.l1StandardBridgeProxy).getImplementation();
 
         // Check if OPCM v2 is being used
-        bool useV2 = IOPContractsManager(_input.opcm).isDevFeatureEnabled(DevFeatures.OPCM_V2);
+        require(address(_input.opcm).code.length > 0, "ReadImplementationAddresses: OPCM address has no code");
+        bool isOPCMv2 = SemverComp.gte(IOPContractsManager(_input.opcm).version(), Constants.OPCM_V2_MIN_VERSION);
 
-        if (useV2) {
+        if (isOPCMv2) {
             // Get implementations from OPCM V2
             IOPContractsManagerV2 opcmV2 = IOPContractsManagerV2(_input.opcm);
 

--- a/packages/contracts-bedrock/scripts/deploy/ReadSuperchainDeployment.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/ReadSuperchainDeployment.s.sol
@@ -10,6 +10,7 @@ import { IProxy } from "interfaces/universal/IProxy.sol";
 import { IOPContractsManager } from "interfaces/L1/IOPContractsManager.sol";
 import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 import { SemverComp } from "src/libraries/SemverComp.sol";
+import { Constants } from "src/libraries/Constants.sol";
 
 contract ReadSuperchainDeployment is Script {
     struct Input {
@@ -40,7 +41,7 @@ contract ReadSuperchainDeployment is Script {
             isOPCMV2 = true;
         } else {
             require(address(opcm).code.length > 0, "ReadSuperchainDeployment: OPCM address has no code");
-            isOPCMV2 = SemverComp.gte(opcm.version(), "7.0.0");
+            isOPCMV2 = SemverComp.gte(opcm.version(), Constants.OPCM_V2_MIN_VERSION);
         }
 
         if (isOPCMV2) {

--- a/packages/contracts-bedrock/scripts/deploy/UpgradeOPChain.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/UpgradeOPChain.s.sol
@@ -5,8 +5,9 @@ import { Script } from "forge-std/Script.sol";
 import { OPContractsManager } from "src/L1/OPContractsManager.sol";
 import { OPContractsManagerV2 } from "src/L1/opcm/OPContractsManagerV2.sol";
 import { BaseDeployIO } from "scripts/deploy/BaseDeployIO.sol";
-import { DevFeatures } from "src/libraries/DevFeatures.sol";
 import { DummyCaller } from "scripts/libraries/DummyCaller.sol";
+import { SemverComp } from "src/libraries/SemverComp.sol";
+import { Constants } from "src/libraries/Constants.sol";
 
 contract UpgradeOPChainInput is BaseDeployIO {
     address internal _prank;
@@ -28,7 +29,7 @@ contract UpgradeOPChainInput is BaseDeployIO {
     /// @param _sel The selector of the field to set.
     /// @param _value The value to set.
     function set(bytes4 _sel, OPContractsManager.OpChainConfig[] memory _value) public {
-        if (OPContractsManager(opcm()).isDevFeatureEnabled(DevFeatures.OPCM_V2)) {
+        if (SemverComp.gte(OPContractsManager(opcm()).version(), Constants.OPCM_V2_MIN_VERSION)) {
             revert("UpgradeOPCMInput: cannot set OPCM v1 upgrade input when OPCM v2 is enabled");
         }
         require(_value.length > 0, "UpgradeOPCMInput: cannot set empty array");
@@ -44,7 +45,7 @@ contract UpgradeOPChainInput is BaseDeployIO {
     /// @param _sel The selector of the field to set.
     /// @param _value The value to set.
     function set(bytes4 _sel, OPContractsManagerV2.UpgradeInput memory _value) public {
-        if (!OPContractsManager(opcm()).isDevFeatureEnabled(DevFeatures.OPCM_V2)) {
+        if (!SemverComp.gte(OPContractsManager(opcm()).version(), Constants.OPCM_V2_MIN_VERSION)) {
             revert("UpgradeOPCMInput: cannot set OPCM v2 upgrade input when OPCM v1 is enabled");
         }
         require(address(_value.systemConfig) != address(0), "UpgradeOPCMInput: cannot set zero address");
@@ -75,7 +76,7 @@ contract UpgradeOPChain is Script {
         address opcm = _uoci.opcm();
 
         // First, we need to check what version of OPCM is being used.
-        bool useOPCMv2 = OPContractsManager(opcm).isDevFeatureEnabled(DevFeatures.OPCM_V2);
+        bool isOPCMv2 = SemverComp.gte(OPContractsManager(opcm).version(), Constants.OPCM_V2_MIN_VERSION);
 
         // Etch DummyCaller contract. This contract is used to mimic the contract that is used
         // as the source of the delegatecall to the OPCM. In practice this will be the governance
@@ -92,7 +93,7 @@ contract UpgradeOPChain is Script {
         // Call into the DummyCaller. This will perform the delegatecall under the hood.
         // The DummyCaller uses a fallback that reverts on failure, so no need to check success.
         vm.broadcast(msg.sender);
-        _upgrade(prank, useOPCMv2, upgradeInput);
+        _upgrade(prank, isOPCMv2, upgradeInput);
     }
 
     /// @notice Helper function to get the dummy caller code.
@@ -104,11 +105,11 @@ contract UpgradeOPChain is Script {
     /// @notice Helper function to upgrade the OPCM based on the OPCM version. Performs the decoding of the upgrade
     /// input and the delegatecall to the OPCM.
     /// @param _prank The address of the dummy caller contract.
-    /// @param _useOPCMv2 Whether to use OPCM v2.
+    /// @param _isOPCMv2 Whether to use OPCM v2.
     /// @param _upgradeInput The upgrade input.
-    function _upgrade(address _prank, bool _useOPCMv2, bytes memory _upgradeInput) internal {
+    function _upgrade(address _prank, bool _isOPCMv2, bytes memory _upgradeInput) internal {
         bytes memory data;
-        if (_useOPCMv2) {
+        if (_isOPCMv2) {
             data = abi.encodeCall(
                 OPContractsManagerV2.upgrade, abi.decode(_upgradeInput, (OPContractsManagerV2.UpgradeInput))
             );

--- a/packages/contracts-bedrock/scripts/deploy/UpgradeSuperchainConfig.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/UpgradeSuperchainConfig.s.sol
@@ -6,8 +6,9 @@ import { IOPContractsManager } from "interfaces/L1/IOPContractsManager.sol";
 import { IOPContractsManagerV2 } from "interfaces/L1/opcm/IOPContractsManagerV2.sol";
 import { IOPContractsManagerUtils } from "interfaces/L1/opcm/IOPContractsManagerUtils.sol";
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
-import { DevFeatures } from "src/libraries/DevFeatures.sol";
 import { DummyCaller } from "scripts/libraries/DummyCaller.sol";
+import { SemverComp } from "src/libraries/SemverComp.sol";
+import { Constants } from "src/libraries/Constants.sol";
 
 contract UpgradeSuperchainConfig is Script {
     struct Input {
@@ -22,10 +23,9 @@ contract UpgradeSuperchainConfig is Script {
         // Make sure the input is valid
         assertValidInput(_input);
 
-        // Both OPCM v1 and v2 implement the isDevFeatureEnabled function.
-        bool useOPCMv2 = IOPContractsManager(_input.opcm).isDevFeatureEnabled(DevFeatures.OPCM_V2);
-
         address opcm = _input.opcm;
+
+        bool isOPCMv2 = SemverComp.gte(IOPContractsManager(opcm).version(), Constants.OPCM_V2_MIN_VERSION);
 
         // Etch DummyCaller contract. This contract is used to mimic the contract that is used
         // as the source of the delegatecall to the OPCM. In practice this will be the governance
@@ -41,7 +41,7 @@ contract UpgradeSuperchainConfig is Script {
         // Call into the DummyCaller. This will perform the delegatecall under the hood.
         // The DummyCaller uses a fallback that reverts on failure, so no need to check success.
         vm.broadcast(msg.sender);
-        _upgrade(prank, useOPCMv2, _input);
+        _upgrade(prank, isOPCMv2, _input);
     }
 
     /// @notice Asserts that the input is valid.
@@ -62,11 +62,11 @@ contract UpgradeSuperchainConfig is Script {
     /// @notice Helper function to upgrade the OPCM based on the OPCM version. Performs the decoding of the upgrade
     /// input and the delegatecall to the OPCM.
     /// @param _prank The address of the dummy caller contract.
-    /// @param _useOPCMv2 Whether to use OPCM v2.
+    /// @param _isOPCMv2 Whether to use OPCM v2.
     /// @param _input The input.
-    function _upgrade(address _prank, bool _useOPCMv2, Input memory _input) internal {
+    function _upgrade(address _prank, bool _isOPCMv2, Input memory _input) internal {
         bytes memory data;
-        if (_useOPCMv2) {
+        if (_isOPCMv2) {
             data = abi.encodeCall(
                 IOPContractsManagerV2.upgradeSuperchain,
                 IOPContractsManagerV2.SuperchainUpgradeInput({

--- a/packages/contracts-bedrock/scripts/deploy/VerifyOPCM.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/VerifyOPCM.s.sol
@@ -14,6 +14,7 @@ import { Config } from "scripts/libraries/Config.sol";
 import { Bytes } from "src/libraries/Bytes.sol";
 import { DevFeatures } from "src/libraries/DevFeatures.sol";
 import { SemverComp } from "src/libraries/SemverComp.sol";
+import { Constants } from "src/libraries/Constants.sol";
 
 // Interfaces
 import { IOPContractsManager } from "interfaces/L1/IOPContractsManager.sol";
@@ -1154,7 +1155,7 @@ contract VerifyOPCM is Script {
         }
 
         // If the OPCM contract version is greater than or equal to 7.0.0, then it is OPCM V2.
-        return SemverComp.gte(IOPContractsManager(opcmAddress).version(), "7.0.0");
+        return SemverComp.gte(IOPContractsManager(opcmAddress).version(), Constants.OPCM_V2_MIN_VERSION);
     }
 
     /// @notice Gets the address of the OPCM contract from the environment variables.

--- a/packages/contracts-bedrock/src/libraries/Constants.sol
+++ b/packages/contracts-bedrock/src/libraries/Constants.sol
@@ -54,6 +54,9 @@ library Constants {
     ///         contracts to be deployed. Only to be used for deployments.
     bytes internal constant PERMIT_ALL_CONTRACTS_INSTRUCTION = bytes("ALL");
 
+    /// @notice The minimum OPCM version considered to support OPCM v2.
+    string internal constant OPCM_V2_MIN_VERSION = "7.0.0";
+
     /// @notice Returns the default values for the ResourceConfig. These are the recommended values
     ///         for a production network.
     function DEFAULT_RESOURCE_CONFIG() internal pure returns (IResourceMetering.ResourceConfig memory) {

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
@@ -13,6 +13,7 @@ import { Claim, Hash } from "src/dispute/lib/LibUDT.sol";
 import { GameType, GameTypes, Proposal } from "src/dispute/lib/Types.sol";
 import { DevFeatures } from "src/libraries/DevFeatures.sol";
 import { Features } from "src/libraries/Features.sol";
+import { Constants } from "src/libraries/Constants.sol";
 
 // Interfaces
 import { IResourceMetering } from "interfaces/L1/IResourceMetering.sol";
@@ -890,7 +891,11 @@ contract OPContractsManagerV2_IsPermittedUpgradeSequence_Test is OPContractsMana
         address oldOPCM = makeAddr("oldOPCM");
 
         // Mock the current OPCM version to be 7.0.0 (below threshold).
-        vm.mockCall(address(opcmV2), abi.encodeCall(IOPContractsManagerV2.version, ()), abi.encode("7.0.0"));
+        vm.mockCall(
+            address(opcmV2),
+            abi.encodeCall(IOPContractsManagerV2.version, ()),
+            abi.encode(Constants.OPCM_V2_MIN_VERSION)
+        );
 
         // Mock lastUsedOPCM to return the old OPCM address.
         vm.mockCall(address(systemConfig), abi.encodeCall(ISystemConfig.lastUsedOPCM, ()), abi.encode(oldOPCM));

--- a/packages/contracts-bedrock/test/opcm/UpgradeOPChain.t.sol
+++ b/packages/contracts-bedrock/test/opcm/UpgradeOPChain.t.sol
@@ -15,7 +15,7 @@ import { UpgradeOPChain, UpgradeOPChainInput } from "scripts/deploy/UpgradeOPCha
 // Libraries
 import { Claim } from "src/dispute/lib/Types.sol";
 import { GameType } from "src/dispute/lib/LibUDT.sol";
-import { DevFeatures } from "src/libraries/DevFeatures.sol";
+import { Constants } from "src/libraries/Constants.sol";
 
 // Interfaces
 import { IOPContractsManagerUtils } from "interfaces/L1/opcm/IOPContractsManagerUtils.sol";
@@ -326,8 +326,8 @@ contract MockOPCMV1 {
         address indexed sysCfgProxy, bytes32 indexed absolutePrestate, bytes32 indexed cannonKonaPrestate
     );
 
-    function isDevFeatureEnabled(bytes32 /* _feature */ ) public pure returns (bool) {
-        return false;
+    function version() public pure returns (string memory) {
+        return "6.0.0";
     }
 
     function upgrade(OPContractsManager.OpChainConfig[] memory _opChainConfigs) public {
@@ -346,8 +346,8 @@ contract MockOPCMV2 {
         IOPContractsManagerUtils.ExtraInstruction[] indexed extraInstructions
     );
 
-    function isDevFeatureEnabled(bytes32 _feature) public pure returns (bool) {
-        return _feature == DevFeatures.OPCM_V2;
+    function version() public pure returns (string memory) {
+        return Constants.OPCM_V2_MIN_VERSION;
     }
 
     function upgrade(OPContractsManagerV2.UpgradeInput memory _upgradeInput) public {

--- a/packages/contracts-bedrock/test/opcm/UpgradeSuperchainConfig.t.sol
+++ b/packages/contracts-bedrock/test/opcm/UpgradeSuperchainConfig.t.sol
@@ -12,15 +12,16 @@ import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 import { IOPContractsManagerV2 } from "interfaces/L1/opcm/IOPContractsManagerV2.sol";
 import { IOPContractsManagerUtils } from "interfaces/L1/opcm/IOPContractsManagerUtils.sol";
 
-import { DevFeatures } from "src/libraries/DevFeatures.sol";
+// Libraries
+import { Constants } from "src/libraries/Constants.sol";
 
 /// @title MockOPCMV1
 /// @notice This contract is used to mock the OPCM contract and emit an event which we check for in the test.
 contract MockOPCMV1 {
     event UpgradeCalled(address indexed superchainConfig);
 
-    function isDevFeatureEnabled(bytes32 /* _feature */ ) public pure returns (bool) {
-        return false;
+    function version() public pure returns (string memory) {
+        return "6.0.0";
     }
 
     function upgradeSuperchainConfig(ISuperchainConfig _superchainConfig) public {
@@ -33,8 +34,8 @@ contract MockOPCMV1 {
 contract MockOPCMV2 {
     event UpgradeCalled(IOPContractsManagerV2.SuperchainUpgradeInput indexed superchainUpgradeInput);
 
-    function isDevFeatureEnabled(bytes32 _feature) public pure returns (bool) {
-        return _feature == DevFeatures.OPCM_V2;
+    function version() public pure returns (string memory) {
+        return Constants.OPCM_V2_MIN_VERSION;
     }
 
     function upgradeSuperchain(IOPContractsManagerV2.SuperchainUpgradeInput memory _superchainUpgradeInput) public {


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

This PR refactors OPCM version detection by replacing dev feature flags with semantic version checks:

- Adds `OPCM_V2_MIN_VERSION = "7.0.0"` constant in `Constants.sol`
- Replaces `DevFeatures.OPCM_V2` checks with `SemverComp.gte(opcm.version(), Constants.OPCM_V2_MIN_VERSION)` across deployment and upgrade scripts
- Standardizes variable naming from `useV2`/`useOPCMv2` to `isOPCMv2` throughout the codebase.