### PR TITLE
fix: pdg implementations to non-zero address on v2 codepath

### DIFF
--- a/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
@@ -28,7 +28,7 @@ import { IL1ERC721Bridge } from "interfaces/L1/IL1ERC721Bridge.sol";
 import { IL1StandardBridge } from "interfaces/L1/IL1StandardBridge.sol";
 import { IOptimismMintableERC20Factory } from "interfaces/universal/IOptimismMintableERC20Factory.sol";
 import { IETHLockbox } from "interfaces/L1/IETHLockbox.sol";
-import { GameTypes } from "src/dispute/lib/Types.sol";
+import { GameTypes, GameType } from "src/dispute/lib/Types.sol";
 
 contract DeployOPChain is Script {
     /// @notice The default init bond for the dispute games.
@@ -223,9 +223,13 @@ contract DeployOPChain is Script {
     /// @return output_ The output parameters.
     function _fromOPCMV2OutputToOutput(IOPContractsManagerV2.ChainContracts memory _chainContracts)
         internal
-        pure
+        view
         returns (Output memory output_)
     {
+        // PERMISSIONED_CANNON must be enabled.
+        address permissionedDgImpl =
+            address(_chainContracts.disputeGameFactory.gameImpls(GameTypes.PERMISSIONED_CANNON));
+
         output_ = Output({
             opChainProxyAdmin: _chainContracts.proxyAdmin,
             addressManager: _chainContracts.addressManager,
@@ -238,10 +242,11 @@ contract DeployOPChain is Script {
             ethLockboxProxy: _chainContracts.ethLockbox,
             disputeGameFactoryProxy: _chainContracts.disputeGameFactory,
             anchorStateRegistryProxy: _chainContracts.anchorStateRegistry,
+            // Explicitly set to address(0) maintaining consistency with OPCM v1 behavior.
             faultDisputeGame: IFaultDisputeGame(address(0)),
-            permissionedDisputeGame: IPermissionedDisputeGame(address(0)),
+            permissionedDisputeGame: IPermissionedDisputeGame(permissionedDgImpl),
             delayedWETHPermissionedGameProxy: _chainContracts.delayedWETH,
-            delayedWETHPermissionlessGameProxy: IDelayedWETH(payable(address(0)))
+            delayedWETHPermissionlessGameProxy: IDelayedWETH(payable(_chainContracts.delayedWETH))
         });
     }
 

--- a/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
@@ -28,7 +28,7 @@ import { IL1ERC721Bridge } from "interfaces/L1/IL1ERC721Bridge.sol";
 import { IL1StandardBridge } from "interfaces/L1/IL1StandardBridge.sol";
 import { IOptimismMintableERC20Factory } from "interfaces/universal/IOptimismMintableERC20Factory.sol";
 import { IETHLockbox } from "interfaces/L1/IETHLockbox.sol";
-import { GameTypes, GameType } from "src/dispute/lib/Types.sol";
+import { GameTypes } from "src/dispute/lib/Types.sol";
 
 contract DeployOPChain is Script {
     /// @notice The default init bond for the dispute games.

--- a/packages/contracts-bedrock/test/opcm/DeployOPChain.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployOPChain.t.sol
@@ -308,6 +308,40 @@ contract DeployOPChain_Test is DeployOPChain_TestBase {
         assertEq(doo.disputeGameFactoryProxy.initBonds(GameTypes.CANNON), 0, "CANNON init bond");
     }
 
+    /// @notice Tests that faultDisputeGame is set to address(0) and permissionedDisputeGame is set to the correct
+    /// implementation for GameTypes.PERMISSIONED_CANNON.
+    function test_run_faultDisputeGamePermissionedCannon_succeeds() public {
+        skipIfDevFeatureDisabled(DevFeatures.OPCM_V2);
+
+        _assertDisputeGames(GameTypes.PERMISSIONED_CANNON);
+    }
+
+    /// @notice Tests that faultDisputeGame is set to address(0) when disputeGameType is GameTypes.CANNON.
+    function test_run_faultDisputeGameCannon_succeeds() public {
+        skipIfDevFeatureDisabled(DevFeatures.OPCM_V2);
+
+        _assertDisputeGames(GameTypes.CANNON);
+    }
+
+    /// @notice Tests that faultDisputeGame is set to address(0) when disputeGameType is GameTypes.CANNON_KONA.
+    function test_run_faultDisputeGameCannonKona_succeeds() public {
+        skipIfDevFeatureDisabled(DevFeatures.OPCM_V2);
+
+        _assertDisputeGames(GameTypes.CANNON_KONA);
+    }
+
+    /// @notice Helper function that runs DeployOPChain.run and asserts DeployOPChain.Output.faultDisputeGame is set to
+    /// address(0) and DeployOPChain.Output.permissionedDisputeGame is set to the correct implementation.
+    function _assertDisputeGames(GameType _gameType) internal {
+        deployOPChainInput.disputeGameType = _gameType;
+
+        DeployOPChain.Output memory doo = deployOPChain.run(deployOPChainInput);
+
+        address expectedPermissioned = address(doo.disputeGameFactoryProxy.gameImpls(GameTypes.PERMISSIONED_CANNON));
+        assertEq(address(doo.permissionedDisputeGame), expectedPermissioned, "PDG impl");
+        assertEq(address(doo.faultDisputeGame), address(0), "FDG should be set to address(0)");
+    }
+
     /// @notice Checks for additional assertions that are not covered by the basic non-zero and code checks in
     /// `DeployOPChain.checkOutput`.
     /// @param doo The output of the deployment.


### PR DESCRIPTION
### Overview
Currently, DeployOPChain.s.sol fails to record the correct Permissioned Dispute Game implementation address in the output when using OPCM v2. We will continue to set the standard FaultDisputeGame as address(0).

### Changes
- Obtains the Permissioned Dispute Game implementation address from the OPCM v2 deployment output.
- Obtains the Delayed WETH address from the deployment output when using OPCM v2.