### PR TITLE
op-challenger,op-dispute-mon,op-program: Use Uint64Strict

### DIFF
--- a/op-challenger/game/fault/claims/claimer.go
+++ b/op-challenger/game/fault/claims/claimer.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts"
 	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 	"github.com/ethereum/go-ethereum/common"
@@ -114,7 +115,7 @@ func (c *Claimer) claimBond(ctx context.Context, contract BondContract, game typ
 		return true, fmt.Errorf("failed to claim credit: %w", err)
 	}
 
-	c.metrics.RecordBondClaimed(credit.Uint64())
+	c.metrics.RecordBondClaimed(bigs.Uint64Strict(credit))
 	return true, nil
 }
 

--- a/op-challenger/game/fault/claims/claimer.go
+++ b/op-challenger/game/fault/claims/claimer.go
@@ -9,7 +9,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts"
 	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/types"
-	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 	"github.com/ethereum/go-ethereum/common"
@@ -21,7 +20,7 @@ type TxSender interface {
 }
 
 type BondClaimMetrics interface {
-	RecordBondClaimed(amount uint64)
+	RecordBondClaimed(amount *big.Int)
 }
 
 type BondContract interface {
@@ -115,7 +114,7 @@ func (c *Claimer) claimBond(ctx context.Context, contract BondContract, game typ
 		return true, fmt.Errorf("failed to claim credit: %w", err)
 	}
 
-	c.metrics.RecordBondClaimed(bigs.Uint64Strict(credit))
+	c.metrics.RecordBondClaimed(credit)
 	return true, nil
 }
 

--- a/op-challenger/game/fault/claims/claimer_test.go
+++ b/op-challenger/game/fault/claims/claimer_test.go
@@ -184,7 +184,7 @@ type mockClaimMetrics struct {
 	RecordBondClaimedCalls int
 }
 
-func (m *mockClaimMetrics) RecordBondClaimed(amount uint64) {
+func (m *mockClaimMetrics) RecordBondClaimed(amount *big.Int) {
 	m.RecordBondClaimedCalls++
 }
 

--- a/op-challenger/game/fault/contracts/faultdisputegame.go
+++ b/op-challenger/game/fault/contracts/faultdisputegame.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts/metrics"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
@@ -208,7 +209,7 @@ func (f *FaultDisputeGameContractLatest) GetGameRange(ctx context.Context) (pres
 func getBlockNumber(result *batching.CallResult, idx int) uint64 {
 	val := result.GetBigInt(idx)
 	if val.IsUint64() {
-		return val.Uint64()
+		return bigs.Uint64Strict(val)
 	}
 	return math.MaxUint64
 }
@@ -317,7 +318,7 @@ func (f *FaultDisputeGameContractLatest) GetSplitDepth(ctx context.Context) (typ
 	if err != nil {
 		return 0, fmt.Errorf("failed to retrieve split depth: %w", err)
 	}
-	return types.Depth(splitDepth.GetBigInt(0).Uint64()), nil
+	return types.Depth(bigs.Uint64Strict(splitDepth.GetBigInt(0))), nil
 }
 
 func (f *FaultDisputeGameContractLatest) GetCredit(ctx context.Context, recipient common.Address) (*big.Int, gameTypes.GameStatus, error) {
@@ -467,7 +468,7 @@ func (f *FaultDisputeGameContractLatest) GetMaxGameDepth(ctx context.Context) (t
 	if err != nil {
 		return 0, fmt.Errorf("failed to fetch max game depth: %w", err)
 	}
-	return types.Depth(result.GetBigInt(0).Uint64()), nil
+	return types.Depth(bigs.Uint64Strict(result.GetBigInt(0))), nil
 }
 
 func (f *FaultDisputeGameContractLatest) GetAbsolutePrestateHash(ctx context.Context) (common.Hash, error) {
@@ -503,7 +504,7 @@ func (f *FaultDisputeGameContractLatest) GetClaimCount(ctx context.Context) (uin
 	if err != nil {
 		return 0, fmt.Errorf("failed to fetch claim count: %w", err)
 	}
-	return result.GetBigInt(0).Uint64(), nil
+	return bigs.Uint64Strict(result.GetBigInt(0)), nil
 }
 
 func (f *FaultDisputeGameContractLatest) GetClaim(ctx context.Context, idx uint64) (types.Claim, error) {

--- a/op-challenger/game/fault/contracts/faultdisputegame0180.go
+++ b/op-challenger/game/fault/contracts/faultdisputegame0180.go
@@ -37,7 +37,7 @@ func (f *FaultDisputeGameContract0180) GetExtendedMetadata(ctx context.Context, 
 		return GameMetadata{}, fmt.Errorf("expected 5 results but got %v", len(results))
 	}
 	l1Head := results[0].GetHash(0)
-	l2BlockNumber := results[1].GetBigInt(0).Uint64()
+	l2BlockNumber := getBlockNumber(results[1], 0)
 	rootClaim := results[2].GetHash(0)
 	status, err := gameTypes.GameStatusFromUint8(results[3].GetUint8(0))
 	if err != nil {

--- a/op-challenger/game/fault/contracts/faultdisputegame080.go
+++ b/op-challenger/game/fault/contracts/faultdisputegame080.go
@@ -44,7 +44,7 @@ func (f *FaultDisputeGameContract080) GetExtendedMetadata(ctx context.Context, b
 		return GameMetadata{}, fmt.Errorf("expected 5 results but got %v", len(results))
 	}
 	l1Head := results[0].GetHash(0)
-	l2BlockNumber := results[1].GetBigInt(0).Uint64()
+	l2BlockNumber := getBlockNumber(results[1], 0)
 	rootClaim := results[2].GetHash(0)
 	status, err := gameTypes.GameStatusFromUint8(results[3].GetUint8(0))
 	if err != nil {

--- a/op-challenger/game/fault/contracts/faultdisputegame_test.go
+++ b/op-challenger/game/fault/contracts/faultdisputegame_test.go
@@ -15,6 +15,7 @@ import (
 	contractMetrics "github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts/metrics"
 	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
@@ -286,7 +287,7 @@ func TestClock_EncodingDecoding(t *testing.T) {
 		clock := decodeClock(encoded)
 		require.Equal(t, 0*time.Second, clock.Duration)
 		require.Equal(t, time.Unix(0, 0), clock.Timestamp)
-		require.Equal(t, encoded.Uint64(), packClock(clock).Uint64())
+		require.Equal(t, bigs.Uint64Strict(encoded), bigs.Uint64Strict(packClock(clock)))
 	})
 }
 
@@ -319,7 +320,7 @@ func TestGetClaim(t *testing.T) {
 			position := big.NewInt(2)
 			clock := big.NewInt(1234)
 			stubRpc.SetResponse(fdgAddr, methodClaim, rpcblock.Latest, []interface{}{idx}, []interface{}{parentIndex, counteredBy, claimant, bond, value, position, clock})
-			status, err := game.GetClaim(context.Background(), idx.Uint64())
+			status, err := game.GetClaim(context.Background(), bigs.Uint64Strict(idx))
 			require.NoError(t, err)
 			require.Equal(t, faultTypes.Claim{
 				ClaimData: faultTypes.ClaimData{
@@ -330,7 +331,7 @@ func TestGetClaim(t *testing.T) {
 				CounteredBy:         counteredBy,
 				Claimant:            claimant,
 				Clock:               decodeClock(big.NewInt(1234)),
-				ContractIndex:       int(idx.Uint64()),
+				ContractIndex:       int(bigs.Uint64Strict(idx)),
 				ParentContractIndex: 1,
 			}, status)
 		})

--- a/op-challenger/game/fault/contracts/gamefactory.go
+++ b/op-challenger/game/fault/contracts/gamefactory.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts/gameargs"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts/metrics"
 	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
@@ -103,7 +104,7 @@ func (f *DisputeGameFactoryContract) GetGameCount(ctx context.Context, blockHash
 	if err != nil {
 		return 0, fmt.Errorf("failed to load game count: %w", err)
 	}
-	return result.GetBigInt(0).Uint64(), nil
+	return bigs.Uint64Strict(result.GetBigInt(0)), nil
 }
 
 func (f *DisputeGameFactoryContract) GetGame(ctx context.Context, idx uint64, block rpcblock.Block) (gameTypes.GameMetadata, error) {

--- a/op-challenger/game/fault/contracts/optimisticzkdisputegame.go
+++ b/op-challenger/game/fault/contracts/optimisticzkdisputegame.go
@@ -157,7 +157,7 @@ func (g *OptimisticZKDisputeGameContractLatest) GetMetadata(ctx context.Context,
 		return GenericGameMetadata{}, fmt.Errorf("expected 4 results but got %v", len(results))
 	}
 	l1Head := results[0].GetHash(0)
-	l2SequenceNumber := results[1].GetBigInt(0).Uint64()
+	l2SequenceNumber := getBlockNumber(results[1], 0)
 	rootClaim := results[2].GetHash(0)
 	status, err := gameTypes.GameStatusFromUint8(results[3].GetUint8(0))
 	if err != nil {
@@ -202,8 +202,8 @@ func (g *OptimisticZKDisputeGameContractLatest) GetGameRange(ctx context.Context
 		retErr = fmt.Errorf("expected 2 results but got %v", len(results))
 		return
 	}
-	prestateBlock = results[0].GetBigInt(0).Uint64()
-	poststateBlock = results[1].GetBigInt(0).Uint64()
+	prestateBlock = getBlockNumber(results[0], 0)
+	poststateBlock = getBlockNumber(results[1], 0)
 	return
 }
 
@@ -227,7 +227,7 @@ func (g *OptimisticZKDisputeGameContractLatest) GetChallengerMetadata(ctx contex
 		return ChallengerMetadata{}, fmt.Errorf("expected 2 results but got %v", len(results))
 	}
 	data := g.decodeClaimData(results[0])
-	l2SeqNum := results[1].GetBigInt(0).Uint64()
+	l2SeqNum := getBlockNumber(results[1], 0)
 	return ChallengerMetadata{
 		ParentIndex:      data.ParentIndex,
 		ProposalStatus:   data.Status,
@@ -259,7 +259,7 @@ func (g *OptimisticZKDisputeGameContractLatest) GetProposal(ctx context.Context)
 	if len(results) != 2 {
 		return common.Hash{}, 0, fmt.Errorf("expected 2 results but got %v", len(results))
 	}
-	return results[0].GetHash(0), results[1].GetBigInt(0).Uint64(), nil
+	return results[0].GetHash(0), getBlockNumber(results[1], 0), nil
 }
 
 func (g *OptimisticZKDisputeGameContractLatest) GetResolvedAt(ctx context.Context, block rpcblock.Block) (time.Time, error) {

--- a/op-challenger/game/fault/contracts/optimisticzkdisputegame_test.go
+++ b/op-challenger/game/fault/contracts/optimisticzkdisputegame_test.go
@@ -10,6 +10,7 @@ import (
 	contractMetrics "github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts/metrics"
 	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
 	batchingTest "github.com/ethereum-optimism/optimism/op-service/sources/batching/test"
@@ -221,7 +222,7 @@ func TestZKGetProposal(t *testing.T) {
 			actualClaim, actualSeqNum, err := game.GetProposal(context.Background())
 			require.NoError(t, err)
 			require.Equal(t, rootClaim, actualClaim)
-			require.Equal(t, l2SequenceNumber.Uint64(), actualSeqNum)
+			require.Equal(t, bigs.Uint64Strict(l2SequenceNumber), actualSeqNum)
 		})
 	}
 }

--- a/op-challenger/game/fault/contracts/oracle.go
+++ b/op-challenger/game/fault/contracts/oracle.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-challenger/game/keccak/merkle"
 	keccakTypes "github.com/ethereum-optimism/optimism/op-challenger/game/keccak/types"
 	preimage "github.com/ethereum-optimism/optimism/op-preimage"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
@@ -170,7 +171,7 @@ func (c *PreimageOracleContractLatest) MinLargePreimageSize(ctx context.Context)
 	if err != nil {
 		return 0, fmt.Errorf("failed to fetch min lpp size bytes: %w", err)
 	}
-	return result.GetBigInt(0).Uint64(), nil
+	return bigs.Uint64Strict(result.GetBigInt(0)), nil
 }
 
 // ChallengePeriod returns the challenge period for large preimages.
@@ -182,7 +183,7 @@ func (c *PreimageOracleContractLatest) ChallengePeriod(ctx context.Context) (uin
 	if err != nil {
 		return 0, fmt.Errorf("failed to fetch challenge period: %w", err)
 	}
-	period := result.GetBigInt(0).Uint64()
+	period := bigs.Uint64Strict(result.GetBigInt(0))
 	c.challengePeriod.Store(period)
 	return period, nil
 }
@@ -386,7 +387,7 @@ func (c *PreimageOracleContractLatest) GetMinBondLPP(ctx context.Context) (*big.
 		return nil, fmt.Errorf("failed to fetch min bond size for LPPs: %w", err)
 	}
 	period := result.GetBigInt(0)
-	c.minBondSizeLPP.Store(period.Uint64())
+	c.minBondSizeLPP.Store(bigs.Uint64Strict(period))
 	return period, nil
 }
 

--- a/op-challenger/game/fault/preimages/large_test.go
+++ b/op-challenger/game/fault/preimages/large_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-challenger/game/keccak/merkle"
 	keccakTypes "github.com/ethereum-optimism/optimism/op-challenger/game/keccak/types"
 	preimage "github.com/ethereum-optimism/optimism/op-preimage"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/clock"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
@@ -405,7 +406,7 @@ func (s *mockPreimageOracleContract) AddLeaves(uuid *big.Int, startingBlockIndex
 	metadata, ok := s.metadata[uuid.String()]
 	require.True(s.t, ok, "adding leaves without init")
 	require.True(s.t, startingBlockIndex.IsUint64())
-	require.EqualValues(s.t, metadata.BlocksProcessed, startingBlockIndex.Uint64())
+	require.EqualValues(s.t, metadata.BlocksProcessed, bigs.Uint64Strict(startingBlockIndex))
 
 	expectedCommitments := len(input) / keccakTypes.BlockSize
 	if finalize {

--- a/op-challenger/game/fault/test/alphabet.go
+++ b/op-challenger/game/fault/test/alphabet.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/alphabet"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 )
 
 func NewAlphabetWithProofProvider(t *testing.T, startingL2BlockNumber *big.Int, maxDepth types.Depth, oracleError error) *AlphabetWithProofProvider {
@@ -35,7 +36,7 @@ func (a *AlphabetWithProofProvider) GetStepData(ctx context.Context, i types.Pos
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	traceIndex := i.TraceIndex(a.depth).Uint64()
+	traceIndex := bigs.Uint64Strict(i.TraceIndex(a.depth))
 	data := types.NewPreimageOracleData([]byte{byte(traceIndex)}, []byte{byte(traceIndex - 1)}, uint32(traceIndex-1))
 	return preimage, []byte{byte(traceIndex - 1)}, data, nil
 }

--- a/op-challenger/game/fault/trace/cannon/provider.go
+++ b/op-challenger/game/fault/trace/cannon/provider.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/vm"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	"github.com/ethereum-optimism/optimism/op-program/host/kvstore"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/ioutil"
 )
 
@@ -60,7 +61,7 @@ func (p *CannonTraceProvider) Get(ctx context.Context, pos types.Position) (comm
 	if !traceIndex.IsUint64() {
 		return common.Hash{}, errors.New("trace index out of bounds")
 	}
-	proof, err := p.loadProof(ctx, traceIndex.Uint64())
+	proof, err := p.loadProof(ctx, bigs.Uint64Strict(traceIndex))
 	if err != nil {
 		return common.Hash{}, err
 	}
@@ -77,7 +78,7 @@ func (p *CannonTraceProvider) GetStepData(ctx context.Context, pos types.Positio
 	if !traceIndex.IsUint64() {
 		return nil, nil, nil, errors.New("trace index out of bounds")
 	}
-	proof, err := p.loadProof(ctx, traceIndex.Uint64())
+	proof, err := p.loadProof(ctx, bigs.Uint64Strict(traceIndex))
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/op-challenger/game/fault/trace/outputs/provider.go
+++ b/op-challenger/game/fault/trace/outputs/provider.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/utils"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
@@ -60,7 +61,7 @@ func (o *OutputTraceProvider) ClaimedBlockNumber(pos types.Position) (uint64, er
 		return 0, fmt.Errorf("%w: %v", ErrIndexTooBig, traceIndex)
 	}
 
-	outputBlock := traceIndex.Uint64() + o.prestateBlock + 1
+	outputBlock := bigs.Uint64Strict(traceIndex) + o.prestateBlock + 1
 	if outputBlock > o.poststateBlock {
 		outputBlock = o.poststateBlock
 	}

--- a/op-challenger/game/fault/trace/outputs/provider_test.go
+++ b/op-challenger/game/fault/trace/outputs/provider_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum/go-ethereum"
@@ -255,7 +256,7 @@ type stubL2HeaderSource struct {
 }
 
 func (s *stubL2HeaderSource) HeaderByNumber(_ context.Context, num *big.Int) (*ethTypes.Header, error) {
-	header, ok := s.headers[num.Uint64()]
+	header, ok := s.headers[bigs.Uint64Strict(num)]
 	if !ok {
 		return nil, ethereum.NotFound
 	}

--- a/op-challenger/game/fault/trace/super/provider_supernode.go
+++ b/op-challenger/game/fault/trace/super/provider_supernode.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	types2 "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	interopTypes "github.com/ethereum-optimism/optimism/op-program/client/interop/types"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -142,7 +143,7 @@ func (s *SuperNodeTraceProvider) ComputeStep(pos types.Position) (timestamp uint
 		return
 	}
 
-	traceIdx := bigIdx.Uint64() + 1
+	traceIdx := bigs.Uint64Strict(bigIdx) + 1
 	timestampIncrements := traceIdx / StepsPerTimestamp
 	timestamp = s.prestateTimestamp + timestampIncrements
 	if timestamp >= s.poststateTimestamp { // Apply trace extension once the claimed timestamp is reached

--- a/op-challenger/game/fault/trace/super/provider_supervisor.go
+++ b/op-challenger/game/fault/trace/super/provider_supervisor.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	interopTypes "github.com/ethereum-optimism/optimism/op-program/client/interop/types"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum/go-ethereum"
@@ -188,7 +189,7 @@ func (s *SupervisorSuperTraceProvider) ComputeStep(pos types.Position) (timestam
 		return
 	}
 
-	traceIdx := bigIdx.Uint64() + 1
+	traceIdx := bigs.Uint64Strict(bigIdx) + 1
 	timestampIncrements := traceIdx / StepsPerTimestamp
 	timestamp = s.prestateTimestamp + timestampIncrements
 	if timestamp >= s.poststateTimestamp { // Apply trace extension once the claimed timestamp is reached

--- a/op-challenger/metrics/metrics.go
+++ b/op-challenger/metrics/metrics.go
@@ -2,6 +2,8 @@ package metrics
 
 import (
 	"io"
+	"math"
+	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -48,7 +50,7 @@ type Metricer interface {
 	RecordPreimageChallengeFailed()
 
 	RecordBondClaimFailed()
-	RecordBondClaimed(amount uint64)
+	RecordBondClaimed(amount *big.Int)
 
 	RecordGamesStatus(inProgress, defenderWon, challengerWon int)
 
@@ -274,8 +276,13 @@ func (m *Metrics) RecordBondClaimFailed() {
 	m.bondClaimFailures.Add(1)
 }
 
-func (m *Metrics) RecordBondClaimed(amount uint64) {
-	m.bondsClaimed.Add(float64(amount))
+func (m *Metrics) RecordBondClaimed(amount *big.Int) {
+	// If the value is too big for a Float64 it will be +Inf, so cap it to MaxFloat64.
+	amt, _ := amount.Float64()
+	if math.IsInf(amt, 1) {
+		amt = math.MaxFloat64
+	}
+	m.bondsClaimed.Add(amt)
 }
 
 func (m *Metrics) RecordClaimResolutionTime(t float64) {

--- a/op-challenger/metrics/noop.go
+++ b/op-challenger/metrics/noop.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"io"
+	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -38,8 +39,8 @@ func (*NoopMetricsImpl) RecordPreimageChallenged()      {}
 func (*NoopMetricsImpl) RecordPreimageChallengeFailed() {}
 func (*NoopMetricsImpl) RecordLargePreimageCount(_ int) {}
 
-func (*NoopMetricsImpl) RecordBondClaimFailed()   {}
-func (*NoopMetricsImpl) RecordBondClaimed(uint64) {}
+func (*NoopMetricsImpl) RecordBondClaimFailed()     {}
+func (*NoopMetricsImpl) RecordBondClaimed(*big.Int) {}
 
 func (*NoopMetricsImpl) RecordClaimResolutionTime(t float64) {}
 func (*NoopMetricsImpl) RecordGameActTime(t float64)         {}

--- a/op-dispute-mon/mon/bonds/collateral_test.go
+++ b/op-dispute-mon/mon/bonds/collateral_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	monTypes "github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
@@ -113,8 +114,8 @@ func TestCalculateRequiredCollateral(t *testing.T) {
 	require.Len(t, actual, 2)
 	require.Contains(t, actual, weth1)
 	require.Contains(t, actual, weth2)
-	require.Equal(t, actual[weth1].Required.Uint64(), uint64(5+7+2+3+6+9+4+1))
-	require.Equal(t, actual[weth1].Actual.Uint64(), weth1Balance.Uint64())
-	require.Equal(t, actual[weth2].Required.Uint64(), uint64(23+46))
-	require.Equal(t, actual[weth2].Actual.Uint64(), weth2Balance.Uint64())
+	require.Equal(t, bigs.Uint64Strict(actual[weth1].Required), uint64(5+7+2+3+6+9+4+1))
+	require.Equal(t, bigs.Uint64Strict(actual[weth1].Actual), bigs.Uint64Strict(weth1Balance))
+	require.Equal(t, bigs.Uint64Strict(actual[weth2].Required), uint64(23+46))
+	require.Equal(t, bigs.Uint64Strict(actual[weth2].Actual), bigs.Uint64Strict(weth2Balance))
 }

--- a/op-dispute-mon/mon/bonds/monitor_test.go
+++ b/op-dispute-mon/mon/bonds/monitor_test.go
@@ -9,6 +9,7 @@ import (
 	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-dispute-mon/metrics"
 	monTypes "github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/clock"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum/go-ethereum/common"
@@ -46,10 +47,10 @@ func TestCheckBonds(t *testing.T) {
 	require.Len(t, metrics.recorded, 2)
 	require.Contains(t, metrics.recorded, weth1)
 	require.Contains(t, metrics.recorded, weth2)
-	require.Equal(t, metrics.recorded[weth1].Required.Uint64(), uint64(2))
-	require.Equal(t, metrics.recorded[weth1].Actual.Uint64(), weth1Balance.Uint64())
-	require.Equal(t, metrics.recorded[weth2].Required.Uint64(), uint64(46))
-	require.Equal(t, metrics.recorded[weth2].Actual.Uint64(), weth2Balance.Uint64())
+	require.Equal(t, bigs.Uint64Strict(metrics.recorded[weth1].Required), uint64(2))
+	require.Equal(t, bigs.Uint64Strict(metrics.recorded[weth1].Actual), bigs.Uint64Strict(weth1Balance))
+	require.Equal(t, bigs.Uint64Strict(metrics.recorded[weth2].Required), uint64(46))
+	require.Equal(t, bigs.Uint64Strict(metrics.recorded[weth2].Actual), bigs.Uint64Strict(weth2Balance))
 
 	require.NotNil(t, logs.FindLog(
 		testlog.NewMessageFilter("Insufficient collateral"),

--- a/op-program/chainconfig/chaincfg_test.go
+++ b/op-program/chainconfig/chaincfg_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-program/chainconfig/test"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/superchain"
 	"github.com/stretchr/testify/require"
@@ -13,8 +14,8 @@ import (
 func TestGetCustomRollupConfig(t *testing.T) {
 	config, err := rollupConfigByChainID(eth.ChainIDFromUInt64(901), test.TestCustomChainConfigFS)
 	require.NoError(t, err)
-	require.Equal(t, config.L1ChainID.Uint64(), uint64(900))
-	require.Equal(t, config.L2ChainID.Uint64(), uint64(901))
+	require.Equal(t, bigs.Uint64Strict(config.L1ChainID), uint64(900))
+	require.Equal(t, bigs.Uint64Strict(config.L2ChainID), uint64(901))
 
 	_, err = rollupConfigByChainID(eth.ChainIDFromUInt64(900), test.TestCustomChainConfigFS)
 	require.Error(t, err)
@@ -29,7 +30,7 @@ func TestGetCustomRollupConfig_Missing(t *testing.T) {
 func TestGetCustomChainConfig(t *testing.T) {
 	config, err := l2ChainConfigByChainID(eth.ChainIDFromUInt64(901), test.TestCustomChainConfigFS)
 	require.NoError(t, err)
-	require.Equal(t, config.ChainID.Uint64(), uint64(901))
+	require.Equal(t, bigs.Uint64Strict(config.ChainID), uint64(901))
 
 	_, err = l2ChainConfigByChainID(eth.ChainIDFromUInt64(900), test.TestCustomChainConfigFS)
 	require.Error(t, err)
@@ -43,7 +44,7 @@ func TestGetCustomChainConfig_Missing(t *testing.T) {
 func TestGetCustomL1ChainConfig(t *testing.T) {
 	config, err := l1ChainConfigByChainID(eth.ChainIDFromUInt64(900), test.TestCustomChainConfigFS)
 	require.NoError(t, err)
-	require.Equal(t, config.ChainID.Uint64(), uint64(900))
+	require.Equal(t, bigs.Uint64Strict(config.ChainID), uint64(900))
 }
 
 func TestGetCustomL1ChainConfig_Missing(t *testing.T) {

--- a/op-program/client/l2/canon.go
+++ b/op-program/client/l2/canon.go
@@ -3,6 +3,7 @@ package l2
 import (
 	"fmt"
 
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 )
@@ -20,7 +21,7 @@ func NewCanonicalBlockHeaderOracle(head *types.Header, blockByHashFn BlockByHash
 	return &CanonicalBlockHeaderOracle{
 		head: head,
 		hashByNum: map[uint64]common.Hash{
-			head.Number.Uint64(): head.Hash(),
+			bigs.Uint64Strict(head.Number): head.Hash(),
 		},
 		earliestIndexedBlock: head,
 		blockByHashFn:        blockByHashFn,
@@ -33,11 +34,11 @@ func (o *CanonicalBlockHeaderOracle) CurrentHeader() *types.Header {
 
 // GetHeaderByNumber walks back from the current head to the requested block number
 func (o *CanonicalBlockHeaderOracle) GetHeaderByNumber(n uint64) *types.Header {
-	if o.head.Number.Uint64() < n {
+	if bigs.Uint64Strict(o.head.Number) < n {
 		return nil
 	}
 
-	if o.earliestIndexedBlock.Number.Uint64() <= n {
+	if bigs.Uint64Strict(o.earliestIndexedBlock.Number) <= n {
 		// guaranteed to be cached during lookup
 		hash, ok := o.hashByNum[n]
 		if !ok {
@@ -47,10 +48,10 @@ func (o *CanonicalBlockHeaderOracle) GetHeaderByNumber(n uint64) *types.Header {
 	}
 
 	h := o.earliestIndexedBlock
-	for h.Number.Uint64() > n {
+	for bigs.Uint64Strict(h.Number) > n {
 		hash := h.ParentHash
 		h = o.blockByHashFn(hash).Header()
-		o.hashByNum[h.Number.Uint64()] = hash
+		o.hashByNum[bigs.Uint64Strict(h.Number)] = hash
 	}
 	o.earliestIndexedBlock = h
 	return h
@@ -61,7 +62,7 @@ func (o *CanonicalBlockHeaderOracle) SetCanonical(head *types.Header) common.Has
 	o.head = head
 
 	// Remove canonical hashes after the new header
-	for n := head.Number.Uint64() + 1; n <= oldHead.Number.Uint64(); n++ {
+	for n := bigs.Uint64Strict(head.Number) + 1; n <= bigs.Uint64Strict(oldHead.Number); n++ {
 		delete(o.hashByNum, n)
 	}
 
@@ -71,13 +72,13 @@ func (o *CanonicalBlockHeaderOracle) SetCanonical(head *types.Header) common.Has
 	h := o.head
 	for {
 		newHash := h.Hash()
-		prevHash, ok := o.hashByNum[h.Number.Uint64()]
+		prevHash, ok := o.hashByNum[bigs.Uint64Strict(h.Number)]
 		if ok && prevHash == newHash {
 			// Connected with the existing canonical chain so stop updating
 			break
 		}
-		o.hashByNum[h.Number.Uint64()] = newHash
-		if h.Number.Uint64() == 0 {
+		o.hashByNum[bigs.Uint64Strict(h.Number)] = newHash
+		if bigs.Uint64Strict(h.Number) == 0 {
 			// Reachable if there aren't any cached blocks at or before the common ancestor
 			break
 		}

--- a/op-program/client/l2/engine_backend.go
+++ b/op-program/client/l2/engine_backend.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-program/client/l2/engineapi"
 	l2Types "github.com/ethereum-optimism/optimism/op-program/client/l2/types"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus"
@@ -145,7 +146,7 @@ func (o *OracleBackedL2Chain) GetBlockByHash(hash common.Hash) *types.Block {
 
 func (o *OracleBackedL2Chain) GetBlock(hash common.Hash, number uint64) *types.Block {
 	var block *types.Block
-	if o.oracleHead.Number.Uint64() < number {
+	if bigs.Uint64Strict(o.oracleHead.Number) < number {
 		// For blocks above the chain head, only consider newly built blocks
 		// Avoids requesting an unknown block from the oracle which would panic.
 		block = o.blocks[hash]

--- a/op-program/client/l2/engineapi/block_processor.go
+++ b/op-program/client/l2/engineapi/block_processor.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum-optimism/optimism/op-core/predeploys"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus"
@@ -186,7 +187,7 @@ func (b *BlockProcessor) Assemble() (*types.Block, types.Receipts, error) {
 
 func (b *BlockProcessor) Commit() error {
 	isCancun := b.dataProvider.Config().IsCancun(b.header.Number, b.header.Time)
-	root, err := b.state.Commit(b.header.Number.Uint64(), b.dataProvider.Config().IsEIP158(b.header.Number), isCancun)
+	root, err := b.state.Commit(bigs.Uint64Strict(b.header.Number), b.dataProvider.Config().IsEIP158(b.header.Number), isCancun)
 	if err != nil {
 		return fmt.Errorf("state write error: %w", err)
 	}

--- a/op-program/client/l2/engineapi/l2_engine_api.go
+++ b/op-program/client/l2/engineapi/l2_engine_api.go
@@ -9,6 +9,7 @@ import (
 	"math/big"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/beacon/engine"
 	"github.com/ethereum/go-ethereum/common"
@@ -494,7 +495,7 @@ func (ea *L2EngineAPI) forkchoiceUpdated(_ context.Context, state *eth.Forkchoic
 		if finalHeader == nil {
 			ea.log.Warn("Final block not available in database", "hash", state.FinalizedBlockHash)
 			return STATUS_INVALID, engine.InvalidForkChoiceState.With(errors.New("final block not available in database"))
-		} else if ea.backend.GetCanonicalHash(finalHeader.Number.Uint64()) != state.FinalizedBlockHash {
+		} else if ea.backend.GetCanonicalHash(bigs.Uint64Strict(finalHeader.Number)) != state.FinalizedBlockHash {
 			ea.log.Warn("Final block not in canonical chain", "number", block.NumberU64(), "hash", state.HeadBlockHash)
 			return STATUS_INVALID, engine.InvalidForkChoiceState.With(errors.New("final block not in canonical chain"))
 		}
@@ -508,7 +509,7 @@ func (ea *L2EngineAPI) forkchoiceUpdated(_ context.Context, state *eth.Forkchoic
 			ea.log.Warn("Safe block not available in database")
 			return STATUS_INVALID, engine.InvalidForkChoiceState.With(errors.New("safe block not available in database"))
 		}
-		if ea.backend.GetCanonicalHash(safeHeader.Number.Uint64()) != state.SafeBlockHash {
+		if ea.backend.GetCanonicalHash(bigs.Uint64Strict(safeHeader.Number)) != state.SafeBlockHash {
 			ea.log.Warn("Safe block not in canonical chain")
 			return STATUS_INVALID, engine.InvalidForkChoiceState.With(errors.New("safe block not in canonical chain"))
 		}

--- a/op-program/client/l2/engineapi/l2_engine_api_test.go
+++ b/op-program/client/l2/engineapi/l2_engine_api_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
 	"github.com/ethereum-optimism/optimism/op-core/forks"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum/go-ethereum/beacon/engine"
@@ -40,7 +41,7 @@ func TestNewPayloadV4(t *testing.T) {
 	for _, c := range cases {
 		genesis := createGenesisWithIsthmusTimeOffset(c.isthmusTime)
 		ethCfg := &ethconfig.Config{
-			NetworkId:   genesis.Config.ChainID.Uint64(),
+			NetworkId:   bigs.Uint64Strict(genesis.Config.ChainID),
 			Genesis:     genesis,
 			StateScheme: rawdb.HashScheme,
 			NoPruning:   true,
@@ -146,7 +147,7 @@ func newStubBackendWithConfig(t *testing.T, ethCfg *ethconfig.Config) *stubCachi
 func newStubBackend(t *testing.T) *stubCachingBackend {
 	genesis := createIsthmusGenesis()
 	ethCfg := &ethconfig.Config{
-		NetworkId:   genesis.Config.ChainID.Uint64(),
+		NetworkId:   bigs.Uint64Strict(genesis.Config.ChainID),
 		Genesis:     genesis,
 		StateScheme: rawdb.HashScheme,
 		NoPruning:   true,

--- a/op-program/client/l2/fast_canon.go
+++ b/op-program/client/l2/fast_canon.go
@@ -6,6 +6,7 @@ import (
 	"math"
 
 	l2Types "github.com/ethereum-optimism/optimism/op-program/client/l2/types"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus"
@@ -66,10 +67,10 @@ func (o *FastCanonicalBlockHeaderOracle) CurrentHeader() *types.Header {
 }
 
 func (o *FastCanonicalBlockHeaderOracle) GetHeaderByNumber(n uint64) *types.Header {
-	if o.head.Number.Uint64() < n {
+	if bigs.Uint64Strict(o.head.Number) < n {
 		return nil
 	}
-	if o.head.Number.Uint64() == n {
+	if bigs.Uint64Strict(o.head.Number) == n {
 		return o.head
 	}
 
@@ -88,8 +89,8 @@ func (o *FastCanonicalBlockHeaderOracle) GetHeaderByNumber(n uint64) *types.Head
 		return o.fallback.GetHeaderByNumber(n)
 	}
 
-	for h.Number.Uint64() > n {
-		headNumber := h.Number.Uint64()
+	for bigs.Uint64Strict(h.Number) > n {
+		headNumber := bigs.Uint64Strict(h.Number)
 		var currEarliestHistory uint64
 		if params.HistoryServeWindow < headNumber {
 			currEarliestHistory = headNumber - params.HistoryServeWindow
@@ -106,7 +107,7 @@ func (o *FastCanonicalBlockHeaderOracle) GetHeaderByNumber(n uint64) *types.Head
 			return o.fallback.GetHeaderByNumber(n)
 		}
 		h = block.Header()
-		o.cache.Add(h.Number.Uint64(), h)
+		o.cache.Add(bigs.Uint64Strict(h.Number), h)
 	}
 	return h
 }

--- a/op-program/client/l2/fast_canon_test.go
+++ b/op-program/client/l2/fast_canon_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-program/client/l2/test"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
@@ -33,7 +34,7 @@ func TestFastCanonBlockHeaderOracle_GetHeaderByNumber(t *testing.T) {
 	miner.Mine(t, nil)
 	miner.Mine(t, nil)
 	head := backend.CurrentHeader()
-	require.Equal(t, uint64(3), head.Number.Uint64())
+	require.Equal(t, uint64(3), bigs.Uint64Strict(head.Number))
 
 	// Create invalid fallback to assert that it's never used.
 	fatalBlockByHash := func(hash common.Hash) *types.Block {
@@ -96,7 +97,7 @@ func TestFastCanonBlockHeaderOracle_LargeWindow(t *testing.T) {
 		miner.Mine(t, nil)
 	}
 	head := backend.CurrentHeader()
-	headNum := head.Number.Uint64()
+	headNum := bigs.Uint64Strict(head.Number)
 	require.Equal(t, uint64(numBlocks), headNum)
 	// Note: we have three non-overlapping historical block windows
 	// head: [8193, 16383]
@@ -153,7 +154,7 @@ func TestFastCannonBlockHeaderOracle_WithFallback(t *testing.T) {
 		miner.Mine(t, nil)
 	}
 	head := backend.CurrentHeader()
-	headNum := head.Number.Uint64()
+	headNum := bigs.Uint64Strict(head.Number)
 	require.Equal(t, uint64(numBlocks), headNum)
 
 	fallbackBlockByHash := newTrackingBlockByHash(backend.GetBlockByHash)
@@ -188,7 +189,7 @@ func TestFastCanonBlockHeaderOracle_PreIsthmus(t *testing.T) {
 		miner.Mine(t, nil)
 	}
 	head := backend.CurrentHeader()
-	headNum := head.Number.Uint64()
+	headNum := bigs.Uint64Strict(head.Number)
 	require.Equal(t, uint64(numBlocks), headNum)
 	preIsthmusHead := backend.GetBlockByNumber(uint64(isthmusBlockActivation) - 1).Header()
 
@@ -196,7 +197,7 @@ func TestFastCanonBlockHeaderOracle_PreIsthmus(t *testing.T) {
 	fallback := NewCanonicalBlockHeaderOracle(preIsthmusHead, fallbackBlockByHash.BlockByHash)
 	canon := NewFastCanonicalBlockHeaderOracle(preIsthmusHead, backend.GetBlockByHash, backend.Config(), stateOracle, rawdb.NewMemoryDatabase(), fallback)
 
-	for i := uint64(0); i <= preIsthmusHead.Number.Uint64(); i++ {
+	for i := uint64(0); i <= bigs.Uint64Strict(preIsthmusHead.Number); i++ {
 		head := canon.GetHeaderByNumber(i)
 		require.Equal(t, backend.GetBlockByNumber(i).Hash(), head.Hash())
 	}
@@ -221,9 +222,9 @@ func TestFastCanonBlockHeaderOracle_SetCanonical(t *testing.T) {
 		require.Equal(t, head.Hash(), canon.CurrentHeader().Hash())
 		require.Equal(t, head.Hash(), fallback.CurrentHeader().Hash())
 
-		parent := backend.GetBlockByNumber(head.Number.Uint64() - 1)
+		parent := backend.GetBlockByNumber(bigs.Uint64Strict(head.Number) - 1)
 		canon.SetCanonical(parent.Header())
-		require.Nil(t, canon.GetHeaderByNumber(head.Number.Uint64()))
+		require.Nil(t, canon.GetHeaderByNumber(bigs.Uint64Strict(head.Number)))
 		require.Equal(t, parent.Hash(), canon.CurrentHeader().Hash())
 		require.Equal(t, parent.Hash(), fallback.CurrentHeader().Hash())
 	})
@@ -238,7 +239,7 @@ func TestFastCanonBlockHeaderOracle_SetCanonical(t *testing.T) {
 			miner.Mine(t, nil)
 		}
 		head := backend.CurrentHeader()
-		headNum := head.Number.Uint64()
+		headNum := bigs.Uint64Strict(head.Number)
 
 		fallback := NewCanonicalBlockHeaderOracle(head, backend.GetBlockByHash)
 		tracker := newTrackingBlockByHash(backend.GetBlockByHash)
@@ -255,7 +256,7 @@ func TestFastCanonBlockHeaderOracle_SetCanonical(t *testing.T) {
 		}
 		forkHead := backend.CurrentHeader()
 		require.NotEqual(t, head.Hash(), forkHead.Hash())
-		require.Equal(t, numBlocks, forkHead.Number.Uint64())
+		require.Equal(t, numBlocks, bigs.Uint64Strict(forkHead.Number))
 
 		newCanonHeadNumber := uint64(9000)
 		canon.SetCanonical(backend.GetBlockByNumber(newCanonHeadNumber).Header())

--- a/op-program/client/l2/test/miner.go
+++ b/op-program/client/l2/test/miner.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-program/client/l2/engineapi"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/beacon/engine"
 	"github.com/ethereum/go-ethereum/common"
@@ -63,7 +64,7 @@ func NewMiner(t *testing.T, logger log.Logger, isthmusTime uint64) (*Miner, *cor
 		ExtraData: []byte{0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8}, // for Holocene eip-1559 params
 	}
 	ethCfg := &ethconfig.Config{
-		NetworkId:                 genesis.Config.ChainID.Uint64(),
+		NetworkId:                 bigs.Uint64Strict(genesis.Config.ChainID),
 		Genesis:                   genesis,
 		RollupDisableTxPoolGossip: true,
 		StateScheme:               rawdb.HashScheme,

--- a/op-program/host/common/l2_sources.go
+++ b/op-program/host/common/l2_sources.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/retry"
 
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/log"
 )
@@ -58,7 +59,7 @@ func NewL2Sources(ctx context.Context, logger log.Logger, configs []*rollup.Conf
 	}
 	rollupConfigs := make(map[uint64]*rollup.Config)
 	for _, rollupCfg := range configs {
-		rollupConfigs[rollupCfg.L2ChainID.Uint64()] = rollupCfg
+		rollupConfigs[bigs.Uint64Strict(rollupCfg.L2ChainID)] = rollupCfg
 	}
 	l2RPCs := make(map[uint64]client.RPC)
 	for _, rpc := range l2Clients {
@@ -86,7 +87,7 @@ func NewL2Sources(ctx context.Context, logger log.Logger, configs []*rollup.Conf
 
 	sources := make(map[uint64]*L2Source)
 	for _, rollupCfg := range rollupConfigs {
-		chainID := rollupCfg.L2ChainID.Uint64()
+		chainID := bigs.Uint64Strict(rollupCfg.L2ChainID)
 		l2RPC, ok := l2RPCs[chainID]
 		if !ok {
 			return nil, fmt.Errorf("%w: %v", ErrNoL2ForRollup, chainID)
@@ -111,6 +112,6 @@ func loadChainID(ctx context.Context, rpc client.RPC) (uint64, error) {
 		if err != nil {
 			return 0, err
 		}
-		return (*big.Int)(&id).Uint64(), nil
+		return bigs.Uint64Strict((*big.Int)(&id)), nil
 	})
 }

--- a/op-program/host/config/config.go
+++ b/op-program/host/config/config.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-program/host/flags"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
@@ -136,14 +137,14 @@ func (c *Config) Check() error {
 	// Make of known rollup chain IDs to whether we have the L2 chain config for it
 	chainIDToHasChainConfig := make(map[uint64]bool, len(c.Rollups))
 	for _, config := range c.Rollups {
-		chainID := config.L2ChainID.Uint64()
+		chainID := bigs.Uint64Strict(config.L2ChainID)
 		if _, ok := chainIDToHasChainConfig[chainID]; ok {
 			return fmt.Errorf("%w for chain ID %v", ErrDuplicateRollup, chainID)
 		}
 		chainIDToHasChainConfig[chainID] = false
 	}
 	for _, config := range c.L2ChainConfigs {
-		chainID := config.ChainID.Uint64()
+		chainID := bigs.Uint64Strict(config.ChainID)
 		if _, ok := chainIDToHasChainConfig[chainID]; !ok {
 			return fmt.Errorf("%w for chain ID %v", ErrNoRollupForGenesis, config.ChainID)
 		}

--- a/op-proposer/contracts/disputegamefactory.go
+++ b/op-proposer/contracts/disputegamefactory.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
@@ -118,7 +119,7 @@ func (f *DisputeGameFactory) gameCount(ctx context.Context) (uint64, error) {
 	if err != nil {
 		return 0, fmt.Errorf("failed to load game count: %w", err)
 	}
-	return result.GetBigInt(0).Uint64(), nil
+	return bigs.Uint64Strict(result.GetBigInt(0)), nil
 }
 
 func (f *DisputeGameFactory) gameAtIndex(ctx context.Context, idx uint64) (gameMetadata, error) {


### PR DESCRIPTION
**Description**

Replace calls to `big.Int.Uint64()` with `bigs.Uint64Strict` to satisfy the new lint check in proofs components.

**Tests**

Covered by existing tests.
