### PR TITLE
contracts: Restrict proposed block numbers to uint64

### DIFF
--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -196,12 +196,12 @@
     "sourceCodeHash": "0xb6a8606b6849a28ee413d257a02732794e75165f40810ad1e0721204fce4ba36"
   },
   "src/dispute/FaultDisputeGame.sol:FaultDisputeGame": {
-    "initCodeHash": "0x2806f9c9f0babb80be2a0c40382d265d598632dc6c1902db7f5f8f214d233f2f",
-    "sourceCodeHash": "0xf92368ee087f58ea25cd4fec205098e7d83dbfc3b0a7033989e841b9fa30924a"
+    "initCodeHash": "0x2493823ad9fb986a696e61ce8a8ef50c548c6a4e0affeeec63edd119ca206083",
+    "sourceCodeHash": "0xd6a17c76aed0e561d4b7293dc17157b9435173c0a61ec40dc4ff8e49e2c1e601"
   },
   "src/dispute/PermissionedDisputeGame.sol:PermissionedDisputeGame": {
-    "initCodeHash": "0xfbb451f1a0bf22bb96242db527371dd0b0c3435208f9e074441ec0aacbf414bd",
-    "sourceCodeHash": "0x3cd249d2e07e055a021e15d3f5cb4a7d2290a9b3c28eae60a007529435c97665"
+    "initCodeHash": "0x940289cf9018b6b22b532a90ee1e731427d435d7982e4e78ea44f25e1cb874a2",
+    "sourceCodeHash": "0x8302f265145ebccb05d1dfb123a1176bb0b29a06167817b0020eac104da8a841"
   },
   "src/dispute/SuperFaultDisputeGame.sol:SuperFaultDisputeGame": {
     "initCodeHash": "0xb5ce71bc56109055cd0dc71fc63015443bbdb29c5975e049802cd1b5188f06ca",
@@ -212,8 +212,8 @@
     "sourceCodeHash": "0x314b6e0412f698ce3531e8176ce8e5b8a3976cc3fa9d7ecb1f3278612f90ed4e"
   },
   "src/dispute/zk/OptimisticZkGame.sol:OptimisticZkGame": {
-    "initCodeHash": "0xb362901fedfed4a467b0f3563af7e72f7a15b5eea396273cf9efde975741dae7",
-    "sourceCodeHash": "0x95ffef6a63315730c089038b21d780a6dfec0887b87c1528b6a3329c2c838271"
+    "initCodeHash": "0xffd6e4c9ab9cbbc40d972db32f87d547d5b13b0f122549f588ba39b7ae609311",
+    "sourceCodeHash": "0x276047949a0b0ff4e7057f341a4bf6af58c2e4e1c249dcb0fb1ca6e3feb3bf47"
   },
   "src/legacy/DeployerWhitelist.sol:DeployerWhitelist": {
     "initCodeHash": "0x2e0ef4c341367eb59cc6c25190c64eff441d3fe130189da91d4d126f6bdbc9b5",

--- a/packages/contracts-bedrock/src/dispute/FaultDisputeGame.sol
+++ b/packages/contracts-bedrock/src/dispute/FaultDisputeGame.sol
@@ -147,9 +147,9 @@ contract FaultDisputeGame is Clone, ISemver {
     uint256 internal constant HEADER_BLOCK_NUMBER_INDEX = 8;
 
     /// @notice Semantic version.
-    /// @custom:semver 2.3.0
+    /// @custom:semver 2.4.0
     function version() public pure virtual returns (string memory) {
-        return "2.3.0";
+        return "2.4.0";
     }
 
     /// @notice The starting timestamp of the game
@@ -273,6 +273,7 @@ contract FaultDisputeGame is Clone, ISemver {
         // Do not allow the game to be initialized if the root claim corresponds to a block at or before the
         // configured starting block number.
         if (l2BlockNumber() <= rootBlockNumber) revert UnexpectedRootClaim(rootClaim());
+        if (l2BlockNumber() > type(uint64).max) revert UnexpectedRootClaim(rootClaim());
 
         // Validate parameters that require access to the VM.
         // The PreimageOracle challenge period must fit into uint64 so we can safely use it here.

--- a/packages/contracts-bedrock/src/dispute/PermissionedDisputeGame.sol
+++ b/packages/contracts-bedrock/src/dispute/PermissionedDisputeGame.sol
@@ -26,9 +26,9 @@ contract PermissionedDisputeGame is FaultDisputeGame {
     }
 
     /// @notice Semantic version.
-    /// @custom:semver 2.3.0
+    /// @custom:semver 2.4.0
     function version() public pure override returns (string memory) {
-        return "2.3.0";
+        return "2.4.0";
     }
 
     /// @param _params Parameters for creating a new FaultDisputeGame.

--- a/packages/contracts-bedrock/src/dispute/zk/OptimisticZkGame.sol
+++ b/packages/contracts-bedrock/src/dispute/zk/OptimisticZkGame.sol
@@ -146,8 +146,8 @@ contract OptimisticZkGame is Clone, ISemver, IDisputeGame {
     AccessManager internal immutable ACCESS_MANAGER;
 
     /// @notice Semantic version.
-    /// @custom:semver 0.1.0
-    string public constant version = "0.1.0";
+    /// @custom:semver 0.2.0
+    string public constant version = "0.2.0";
 
     /// @notice The starting timestamp of the game.
     Timestamp public createdAt;
@@ -294,6 +294,9 @@ contract OptimisticZkGame is Clone, ISemver, IDisputeGame {
         // Do not allow the game to be initialized if the root claim corresponds to a block at or before the
         // configured starting block number.
         if (l2SequenceNumber() <= startingProposal.l2SequenceNumber) {
+            revert UnexpectedRootClaim(rootClaim());
+        }
+        if (l2SequenceNumber() > type(uint64).max) {
             revert UnexpectedRootClaim(rootClaim());
         }
 

--- a/packages/contracts-bedrock/test/dispute/FaultDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/dispute/FaultDisputeGame.t.sol
@@ -358,6 +358,18 @@ contract FaultDisputeGame_Initialize_Test is FaultDisputeGame_TestInit {
         );
     }
 
+    /// @notice Tests that the game cannot be initialized with an output root that commits to a block number greater
+    /// than uint64.max
+    function testFuzz_initialize_cannotProposeLargeBlockNumber_reverts(uint256 _blockNumber) public {
+        _blockNumber = bound(_blockNumber, uint256(type(uint64).max) + 1, type(uint256).max);
+
+        Claim claim = _dummyClaim();
+        vm.expectRevert(abi.encodeWithSelector(UnexpectedRootClaim.selector, claim));
+        gameProxy = IFaultDisputeGame(
+            payable(address(disputeGameFactory.create{ value: initBond }(GAME_TYPE, claim, abi.encode(_blockNumber))))
+        );
+    }
+
     /// @notice Tests that the proxy receives ETH from the dispute game factory.
     function test_initialize_receivesETH_succeeds() public {
         uint256 _value = disputeGameFactory.initBonds(GAME_TYPE);
@@ -1302,17 +1314,17 @@ contract FaultDisputeGame_ChallengeRootL2Block_Test is FaultDisputeGame_TestInit
     function testFuzz_challengeRootL2Block_succeeds(
         bytes32 _storageRoot,
         bytes32 _withdrawalRoot,
-        uint256 _l2BlockNumber
+        uint64 _l2BlockNumber
     )
         public
     {
-        _l2BlockNumber = bound(_l2BlockNumber, validL2BlockNumber, type(uint256).max - 1);
+        _l2BlockNumber = uint64(bound(_l2BlockNumber, validL2BlockNumber, type(uint64).max - 1));
 
         (Types.OutputRootProof memory outputRootProof, bytes32 outputRoot, bytes memory headerRLP) =
-            _generateOutputRootProof(_storageRoot, _withdrawalRoot, abi.encodePacked(_l2BlockNumber));
+            _generateOutputRootProof(_storageRoot, _withdrawalRoot, abi.encodePacked(uint256(_l2BlockNumber)));
 
         // Create the dispute game with the output root at the wrong L2 block number.
-        uint256 wrongL2BlockNumber = bound(vm.randomUint(), _l2BlockNumber + 1, type(uint256).max);
+        uint256 wrongL2BlockNumber = vm.randomUint(_l2BlockNumber + 1, type(uint64).max);
         IDisputeGame game = disputeGameFactory.create{ value: initBond }(
             GAME_TYPE, Claim.wrap(outputRoot), abi.encode(wrongL2BlockNumber)
         );
@@ -1341,22 +1353,23 @@ contract FaultDisputeGame_ChallengeRootL2Block_Test is FaultDisputeGame_TestInit
     function testFuzz_challengeRootL2Block_receivesBond_succeeds(
         bytes32 _storageRoot,
         bytes32 _withdrawalRoot,
-        uint256 _l2BlockNumber
+        uint64 _l2BlockNumber
     )
         public
     {
         vm.deal(address(0xb0b), 1 ether);
-        _l2BlockNumber = bound(_l2BlockNumber, validL2BlockNumber, type(uint256).max - 1);
+        _l2BlockNumber = uint64(bound(_l2BlockNumber, validL2BlockNumber, type(uint64).max - 1));
 
         (Types.OutputRootProof memory outputRootProof, bytes32 outputRoot, bytes memory headerRLP) =
-            _generateOutputRootProof(_storageRoot, _withdrawalRoot, abi.encodePacked(_l2BlockNumber));
+            _generateOutputRootProof(_storageRoot, _withdrawalRoot, abi.encodePacked(uint256(_l2BlockNumber)));
 
         // Create the dispute game with the output root at the wrong L2 block number.
         disputeGameFactory.setInitBond(GAME_TYPE, 0.1 ether);
         uint256 balanceBefore = address(this).balance;
-        _l2BlockNumber = bound(vm.randomUint(), _l2BlockNumber + 1, type(uint256).max);
-        IDisputeGame game =
-            disputeGameFactory.create{ value: 0.1 ether }(GAME_TYPE, Claim.wrap(outputRoot), abi.encode(_l2BlockNumber));
+        _l2BlockNumber = uint64(vm.randomUint(_l2BlockNumber + 1, type(uint64).max));
+        IDisputeGame game = disputeGameFactory.create{ value: 0.1 ether }(
+            GAME_TYPE, Claim.wrap(outputRoot), abi.encode(uint256(_l2BlockNumber))
+        );
         IFaultDisputeGame fdg = IFaultDisputeGame(address(game));
 
         // Attack the root as 0xb0b
@@ -1413,18 +1426,19 @@ contract FaultDisputeGame_ChallengeRootL2Block_Test is FaultDisputeGame_TestInit
     function testFuzz_challengeRootL2Block_rightBlockNumber_reverts(
         bytes32 _storageRoot,
         bytes32 _withdrawalRoot,
-        uint256 _l2BlockNumber
+        uint64 _l2BlockNumber
     )
         public
     {
-        _l2BlockNumber = bound(_l2BlockNumber, validL2BlockNumber, type(uint256).max);
+        _l2BlockNumber = uint64(bound(_l2BlockNumber, validL2BlockNumber, type(uint64).max));
 
         (Types.OutputRootProof memory outputRootProof, bytes32 outputRoot, bytes memory headerRLP) =
-            _generateOutputRootProof(_storageRoot, _withdrawalRoot, abi.encodePacked(_l2BlockNumber));
+            _generateOutputRootProof(_storageRoot, _withdrawalRoot, abi.encodePacked(uint256(_l2BlockNumber)));
 
         // Create the dispute game with the output root at the wrong L2 block number.
-        IDisputeGame game =
-            disputeGameFactory.create{ value: initBond }(GAME_TYPE, Claim.wrap(outputRoot), abi.encode(_l2BlockNumber));
+        IDisputeGame game = disputeGameFactory.create{ value: initBond }(
+            GAME_TYPE, Claim.wrap(outputRoot), abi.encode(uint256(_l2BlockNumber))
+        );
 
         // Challenge the L2 block number.
         IFaultDisputeGame fdg = IFaultDisputeGame(address(game));

--- a/packages/contracts-bedrock/test/dispute/zk/OptimisticZkGame.t.sol
+++ b/packages/contracts-bedrock/test/dispute/zk/OptimisticZkGame.t.sol
@@ -222,6 +222,18 @@ contract OptimisticZkGame_Initialize_Test is OptimisticZkGame_TestInit {
         vm.stopPrank();
     }
 
+    function testFuzz_initialize_blockNumberTooLarge_reverts(uint256 _l2SequenceNumber) public {
+        _l2SequenceNumber = bound(_l2SequenceNumber, uint256(type(uint64).max) + 1, type(uint256).max);
+
+        vm.startPrank(proposer);
+        vm.deal(proposer, 1 ether);
+        vm.expectRevert(abi.encodeWithSelector(UnexpectedRootClaim.selector, rootClaim));
+        disputeGameFactory.create{ value: 1 ether }(
+            gameType, rootClaim, abi.encodePacked(_l2SequenceNumber, parentGameIndex)
+        );
+        vm.stopPrank();
+    }
+
     function test_initialize_parentBlacklisted_reverts() public {
         // Blacklist the game on the anchor state registry (which is what's actually used for validation).
         vm.prank(superchainConfig.guardian());


### PR DESCRIPTION
**Description**

Update FaultDisputeGame and OptimisticDisputeGame to revert game creation if the proposed block number is too large for a uint64. Given the JSON-RPC APIs use an int64, no viable block chain can use block numbers that large.

SuperDisputeGame reads the timestamp from the super root which is already restricted to a uint64.

**Tests**

Updated contract fuzz tests. Some had to be adjusted to ensure they chose valid block numbers and new tests added to confirm rejection of numbers > max uint64.

