### PR TITLE
op-e2e,op-acceptance-tests,op-devstack,op-sync-tester: Use Uint64Strict

### DIFF
--- a/op-acceptance-tests/tests/base/deposit/deposit_test.go
+++ b/op-acceptance-tests/tests/base/deposit/deposit_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl/contract"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/txintent/bindings"
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
@@ -64,7 +65,7 @@ func TestL1ToL2Deposit(gt *testing.T) {
 	// Wait for the sequencer to process the deposit
 	t.Require().Eventually(func() bool {
 		head := sys.L2CL.HeadBlockRef(supervisorTypes.LocalUnsafe)
-		return head.L1Origin.Number >= receipt.BlockNumber.Uint64()
+		return head.L1Origin.Number >= bigs.Uint64Strict(receipt.BlockNumber)
 	}, sys.L1EL.TransactionTimeout(), time.Second, "awaiting deposit to be processed by L2")
 
 	alicel2.WaitForBalance(initialL2Balance.Add(depositAmount))

--- a/op-acceptance-tests/tests/fjord/check_scripts_test.go
+++ b/op-acceptance-tests/tests/fjord/check_scripts_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/txintent/contractio"
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
 
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -164,7 +165,7 @@ func checkFastLZTransactions(t devtest.T, ctx context.Context, sys *presets.Mini
 		fastLzSize := uint64(types.FlzCompressLen(txUnsigned) + 68)
 		gethGPOFee, err := dsl.CalculateFjordL1Cost(ctx, l2Client, types.RollupCostData{FastLzSize: fastLzSize}, receipt.BlockHash)
 		require.NoError(err)
-		require.Equalf(gethGPOFee.Uint64(), gpoFee.Uint64(), "GPO L1 fee mismatch (expected=%d actual=%d)", gethGPOFee.Uint64(), gpoFee.Uint64())
+		require.Equalf(bigs.Uint64Strict(gethGPOFee), bigs.Uint64Strict(gpoFee), "GPO L1 fee mismatch (expected=%v actual=%v)", gethGPOFee, gpoFee)
 
 		expectedFee, err := dsl.CalculateFjordL1Cost(ctx, l2Client, signedTx.RollupCostData(), receipt.BlockHash)
 		require.NoError(err)
@@ -177,7 +178,7 @@ func checkFastLZTransactions(t devtest.T, ctx context.Context, sys *presets.Mini
 		flzUpperBound := uint64(txLenGPO + txLenGPO/255 + 16)
 		upperBoundCost, err := dsl.CalculateFjordL1Cost(ctx, l2Client, types.RollupCostData{FastLzSize: flzUpperBound}, receipt.BlockHash)
 		require.NoError(err)
-		require.Equalf(upperBoundCost.Uint64(), upperBound.Uint64(), "GPO L1 upper bound mismatch (expected=%d actual=%d)", upperBoundCost.Uint64(), upperBound.Uint64())
+		require.Equalf(bigs.Uint64Strict(upperBoundCost), bigs.Uint64Strict(upperBound), "GPO L1 upper bound mismatch (expected=%v actual=%v)", upperBoundCost, upperBound)
 
 		_, err = contractio.Read(gasPriceOracle.BaseFeeScalar(), ctx)
 		require.NoError(err)

--- a/op-acceptance-tests/tests/interop/loadtest/invalid_msg_test.go
+++ b/op-acceptance-tests/tests/interop/loadtest/invalid_msg_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/txinclude"
 	"github.com/ethereum-optimism/optimism/op-service/txintent"
@@ -129,7 +130,7 @@ func TestRelayWithInvalidMessagesSteady(gt *testing.T) {
 		OpaqueData: []byte{34, 56},
 	}))
 	t.Require().NoError(err)
-	ref := l2A.EL.BlockRefByNumber(initTx.Receipt.BlockNumber.Uint64())
+	ref := l2A.EL.BlockRefByNumber(bigs.Uint64Strict(initTx.Receipt.BlockNumber))
 	out := new(txintent.InteropOutput)
 	t.Require().NoError(out.FromReceipt(t.Ctx(), initTx.Receipt, ref.BlockRef(), l2A.EL.ChainID()))
 	t.Require().Len(out.Entries, 1)

--- a/op-acceptance-tests/tests/interop/message/interop_happy_tx_test.go
+++ b/op-acceptance-tests/tests/interop/message/interop_happy_tx_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	stypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
@@ -45,12 +46,12 @@ func TestInteropHappyTx(gt *testing.T) {
 	// confirm that the cross-safe safety passed init and exec receipts and that blocks were not reorged
 	dsl.CheckAll(t,
 		sys.L2CLA.ReachedRefFn(stypes.CrossSafe, eth.BlockID{
-			Number: initReceipt.BlockNumber.Uint64(),
+			Number: bigs.Uint64Strict(initReceipt.BlockNumber),
 			Hash:   initReceipt.BlockHash,
 			// TODO(#16598): Make this relative to the block time
 		}, 500),
 		sys.L2CLB.ReachedRefFn(stypes.CrossSafe, eth.BlockID{
-			Number: execReceipt.BlockNumber.Uint64(),
+			Number: bigs.Uint64Strict(execReceipt.BlockNumber),
 			Hash:   execReceipt.BlockHash,
 			// TODO(#16598): Make this relative to the block time
 		}, 500),

--- a/op-acceptance-tests/tests/interop/message/interop_msg_test.go
+++ b/op-acceptance-tests/tests/interop/message/interop_msg_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	suptypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
@@ -78,7 +79,7 @@ func TestInitExecMsgWithDSL(gt *testing.T) {
 
 	// Write: Alice triggers initiating message
 	receipt := contract.Write(alice, eventLogger.EmitLog(topics, data))
-	block, err := clientA.BlockRefByNumber(t.Ctx(), receipt.BlockNumber.Uint64())
+	block, err := clientA.BlockRefByNumber(t.Ctx(), bigs.Uint64Strict(receipt.BlockNumber))
 	require.NoError(err)
 
 	sys.Supervisor.WaitForUnsafeHeadToAdvance(alice.ChainID(), 2)
@@ -89,7 +90,7 @@ func TestInitExecMsgWithDSL(gt *testing.T) {
 	payload := suptypes.LogToMessagePayload(receipt.Logs[logIdx])
 	identifier := suptypes.Identifier{
 		Origin:      eventLoggerAddress,
-		BlockNumber: receipt.BlockNumber.Uint64(),
+		BlockNumber: bigs.Uint64Strict(receipt.BlockNumber),
 		LogIndex:    logIdx,
 		Timestamp:   block.Time,
 		ChainID:     sys.L2ELA.ChainID(),

--- a/op-acceptance-tests/tests/interop/reorgs/init_exec_msg_test.go
+++ b/op-acceptance-tests/tests/interop/reorgs/init_exec_msg_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack/match"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/txintent"
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
@@ -116,7 +117,7 @@ func TestReorgInitExecMsg(gt *testing.T) {
 	// sequence a conflicting block with a simple transfer tx, based on the parent of the parent of the unsafe head
 	{
 		var err error
-		divergenceBlockNumber_B = execReceipt.BlockNumber.Uint64()
+		divergenceBlockNumber_B = bigs.Uint64Strict(execReceipt.BlockNumber)
 		originalRef_B, err = sys.L2ELB.Escape().L2EthClient().L2BlockRefByHash(ctx, execReceipt.BlockHash)
 		require.NoError(t, err, "Expected to be able to call L2BlockRefByHash API, but got error")
 

--- a/op-acceptance-tests/tests/interop/seqwindow/expiry_test.go
+++ b/op-acceptance-tests/tests/interop/seqwindow/expiry_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
@@ -36,7 +37,7 @@ func TestSequencingWindowExpiry(gt *testing.T) {
 	require.Eventually(func() bool {
 		stat, err := sys.L2CLA.Escape().RollupAPI().SyncStatus(t.Ctx())
 		require.NoError(err)
-		return stat.SafeL2.Number > receipt1.BlockNumber.Uint64()
+		return stat.SafeL2.Number > bigs.Uint64Strict(receipt1.BlockNumber)
 	}, time.Second*45, time.Second, "wait for tx 1 to be safe")
 	t.Logger().Info("Tx 1 is safe now")
 
@@ -74,7 +75,7 @@ func TestSequencingWindowExpiry(gt *testing.T) {
 	receipt2, err := tx2.Included.Eval(t.Ctx())
 	require.NoError(err)
 	// Now get the block that included the tx. This block will change.
-	old := eth.L2BlockRef{Hash: receipt2.BlockHash, Number: receipt2.BlockNumber.Uint64()}
+	old := eth.L2BlockRef{Hash: receipt2.BlockHash, Number: bigs.Uint64Strict(receipt2.BlockNumber)}
 	t.Logger().Info("Confirmed tx 2, which will be reorged out later",
 		"tx", receipt2.TxHash, "l2Block", old)
 	// The logs will show a "Chain reorg detected" from op-geth.
@@ -157,10 +158,10 @@ func TestSequencingWindowExpiry(gt *testing.T) {
 		status := sys.L2CLA.SyncStatus()
 		t.Logger().Info("Awaiting tx safety",
 			"local-unsafe", status.UnsafeL2, "local-safe", status.LocalSafeL2)
-		return status.SafeL2.Number > receipt3.BlockNumber.Uint64()
+		return status.SafeL2.Number > bigs.Uint64Strict(receipt3.BlockNumber)
 	}, time.Second*60, time.Second, "wait for tx 3 to be safe")
 	t.Logger().Info("Tx 3 is safe now")
 	// Sanity check the block the tx was included is really still canonical
-	got := sys.L2ELA.BlockRefByNumber(receipt3.BlockNumber.Uint64())
+	got := sys.L2ELA.BlockRefByNumber(bigs.Uint64Strict(receipt3.BlockNumber))
 	t.Require().Equal(receipt3.BlockHash, got.Hash, "tx 3 was included in canonical block")
 }

--- a/op-acceptance-tests/tests/interop/upgrade/post_test.go
+++ b/op-acceptance-tests/tests/interop/upgrade/post_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	stypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 )
@@ -178,11 +179,11 @@ func verifyInteropMessagesProgression(t devtest.T, sys *presets.SimpleInterop, i
 	// Verify cross-safe progression for both messages
 	dsl.CheckAll(t,
 		sys.L2CLA.ReachedRefFn(stypes.CrossSafe, eth.BlockID{
-			Number: initReceipt.BlockNumber.Uint64(),
+			Number: bigs.Uint64Strict(initReceipt.BlockNumber),
 			Hash:   initReceipt.BlockHash,
 		}, 60),
 		sys.L2CLB.ReachedRefFn(stypes.CrossSafe, eth.BlockID{
-			Number: execReceipt.BlockNumber.Uint64(),
+			Number: bigs.Uint64Strict(execReceipt.BlockNumber),
 			Hash:   execReceipt.BlockHash,
 		}, 60),
 	)

--- a/op-acceptance-tests/tests/isthmus/pectra/pectra_features_test.go
+++ b/op-acceptance-tests/tests/isthmus/pectra/pectra_features_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-devstack/shim"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack/match"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
 	"github.com/ethereum/go-ethereum/common"
@@ -288,7 +289,7 @@ func deployProgram(t devtest.T, user *dsl.EOA, bytecode []byte) common.Address {
 	t.Logf("Deployment receipt: Status=%d, GasUsed=%d, CumulativeGasUsed=%d",
 		receipt.Status, receipt.GasUsed, receipt.CumulativeGasUsed)
 	t.Logf("Deployment transaction: BlockNumber=%d, TransactionIndex=%d",
-		receipt.BlockNumber.Uint64(), receipt.TransactionIndex)
+		bigs.Uint64Strict(receipt.BlockNumber), receipt.TransactionIndex)
 
 	require.Equal(uint64(1), receipt.Status, "Contract deployment failed")
 	require.NotNil(receipt.ContractAddress, "Contract address not set in receipt")

--- a/op-acceptance-tests/tests/jovian/da_footprint.go
+++ b/op-acceptance-tests/tests/jovian/da_footprint.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/txintent/contractio"
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
 
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 )
@@ -153,7 +154,7 @@ func TestDAFootprint(gt *testing.T) {
 				// Retrying up to 100 times is overkill, but lower values may not work on
 				// persistent networks. See the following issue for more details.
 				// https://github.com/ethereum-optimism/optimism/issues/18061
-				env.l2EL.WaitL1OriginReached(eth.Unsafe, rec.BlockNumber.Uint64(), 100)
+				env.l2EL.WaitL1OriginReached(eth.Unsafe, bigs.Uint64Strict(rec.BlockNumber), 100)
 			} else {
 				scalar := env.getDAFootprintGasScalarOfSystemConfig(t)
 				if scalar != 0 {
@@ -220,7 +221,7 @@ func TestDAFootprint(gt *testing.T) {
 				require.NotNil(recScalar, "nil receipt DA footprint gas scalar")
 				require.EqualValues(tc.expected, *recScalar, "DA footprint gas scalar mismatch in receipt")
 
-				txDAFootprint := tx.RollupCostData().EstimatedDASize().Uint64() * uint64(tc.expected)
+				txDAFootprint := bigs.Uint64Strict(tx.RollupCostData().EstimatedDASize()) * uint64(tc.expected)
 				require.Equal(txDAFootprint, receipts[i].BlobGasUsed, "tx DA footprint mismatch with receipt")
 				totalDAFootprint += txDAFootprint
 			}

--- a/op-devstack/dsl/bridge.go
+++ b/op-devstack/dsl/bridge.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-node/withdrawals"
 	"github.com/ethereum-optimism/optimism/op-service/apis"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/txintent/bindings"
 	"github.com/ethereum-optimism/optimism/op-service/txintent/contractio"
@@ -276,7 +277,7 @@ type disputeGame struct {
 // when required by the respected game type
 func (b *StandardBridge) forGamePublished(l2BlockNumber *big.Int) disputeGame {
 	respectedGameType := b.RespectedGameType()
-	l2SequenceNumber := l2BlockNumber.Uint64()
+	l2SequenceNumber := bigs.Uint64Strict(l2BlockNumber)
 	superRootsActive := b.UsesSuperRoots()
 	if superRootsActive {
 		l2SequenceNumber = b.rollupCfg.TimestampForBlock(l2SequenceNumber)
@@ -298,7 +299,7 @@ func (b *StandardBridge) forGamePublished(l2BlockNumber *big.Int) disputeGame {
 			bindings.WithTest(b.t))
 		seqNum, err := contractio.Read(gameContract.L2SequenceNumber(), b.ctx)
 		b.require.NoError(err, "Failed to read sequence number")
-		gameSeqNum = seqNum.Uint64()
+		gameSeqNum = bigs.Uint64Strict(seqNum)
 		b.log.Info("Found latest game", "index", gameIndex, "seqNum", gameSeqNum)
 		return gameSeqNum >= l2SequenceNumber
 	}, 90*time.Second, 100*time.Millisecond, "did not find a game of type %v at or after l2 sequence number %v", respectedGameType, l2SequenceNumber)
@@ -585,7 +586,7 @@ func hasOperatorFee(rcpt *types.Receipt) bool {
 
 func (b *StandardBridge) receiptTimestamp(rcpt *types.Receipt, client apis.EthClient) *uint64 {
 	b.require.NotNil(rcpt.BlockNumber, "receipt missing block number")
-	blockInfo, err := client.InfoByNumber(b.ctx, rcpt.BlockNumber.Uint64())
+	blockInfo, err := client.InfoByNumber(b.ctx, bigs.Uint64Strict(rcpt.BlockNumber))
 	b.require.NoError(err, "failed to fetch block info for receipt")
 	ts := blockInfo.Time()
 	return &ts

--- a/op-devstack/dsl/ecotone_fees.go
+++ b/op-devstack/dsl/ecotone_fees.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack/match"
 	"github.com/ethereum-optimism/optimism/op-service/apis"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -159,7 +160,7 @@ func (ef *EcotoneFees) validateEcotoneFeatures(receipt *types.Receipt, l1Fee *bi
 	ef.require.True(l1Fee.Cmp(big.NewInt(0)) > 0, "L1 fee should be greater than 0 in Ecotone")
 	ef.require.Greater(receipt.GasUsed, uint64(20000), "Gas used should be reasonable for transfer")
 	ef.require.Less(receipt.GasUsed, uint64(50000), "Gas used should not be excessive")
-	ef.require.Greater(receipt.EffectiveGasPrice.Uint64(), uint64(0), "Effective gas price should be > 0")
+	ef.require.Greater(bigs.Uint64Strict(receipt.EffectiveGasPrice), uint64(0), "Effective gas price should be > 0")
 }
 
 func (ef *EcotoneFees) validateReceiptFees(receipt *types.Receipt, l1Fee, vaultBaseFee, vaultL2Fee, receiptBaseFee, receiptL2Fee *big.Int) {

--- a/op-devstack/dsl/fjord_fees.go
+++ b/op-devstack/dsl/fjord_fees.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack/match"
 	"github.com/ethereum-optimism/optimism/op-service/apis"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/txintent/bindings"
 	"github.com/ethereum-optimism/optimism/op-service/txintent/contractio"
@@ -325,7 +326,7 @@ func ReadGasPriceOracleL1FeeUpperBoundAt(ctx context.Context, client apis.EthCli
 func ValidateL1FeeMatches(t devtest.T, calculatedFee, receiptFee *big.Int) {
 	require := t.Require()
 	require.NotNil(receiptFee, "L1 fee should be present in receipt")
-	require.Equalf(calculatedFee.Uint64(), receiptFee.Uint64(), "L1 fee mismatch (expected=%d actual=%d)", calculatedFee.Uint64(), receiptFee.Uint64())
+	require.Equalf(bigs.Uint64Strict(calculatedFee), bigs.Uint64Strict(receiptFee), "L1 fee mismatch (expected=%v actual=%v)", calculatedFee, receiptFee)
 }
 
 // CalculateFjordL1Cost calculates L1 cost using Fjord formula with block-specific L1 state

--- a/op-devstack/dsl/multi_client.go
+++ b/op-devstack/dsl/multi_client.go
@@ -10,6 +10,7 @@ import (
 
 	"math/big"
 
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/retry"
 	"github.com/ethereum/go-ethereum/common"
@@ -176,7 +177,7 @@ func (mc *MultiClient) verifyFollowersWithRetry(
 		go func() {
 			defer wg.Done()
 			hash, err := retry.Do(ctx, mc.maxAttempts, mc.retryStrategy, func() (common.Hash, error) {
-				info, err := client.InfoByNumber(ctx, blockNum.Uint64())
+				info, err := client.InfoByNumber(ctx, bigs.Uint64Strict(blockNum))
 				if err != nil {
 					return common.Hash{}, err
 				}

--- a/op-devstack/dsl/proofs/dispute_game_factory.go
+++ b/op-devstack/dsl/proofs/dispute_game_factory.go
@@ -28,6 +28,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl/contract"
 	"github.com/ethereum-optimism/optimism/op-service/apis"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/txintent/bindings"
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
 )
@@ -393,7 +394,7 @@ type ethClientHeaderProvider struct {
 }
 
 func (p *ethClientHeaderProvider) HeaderByNumber(ctx context.Context, blockNum *big.Int) (*types.Header, error) {
-	info, err := p.client.InfoByNumber(ctx, blockNum.Uint64())
+	info, err := p.client.InfoByNumber(ctx, bigs.Uint64Strict(blockNum))
 	if err != nil {
 		return nil, err
 	}

--- a/op-devstack/dsl/proofs/fault_dispute_game.go
+++ b/op-devstack/dsl/proofs/fault_dispute_game.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl/contract"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/txintent/bindings"
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
 )
@@ -58,11 +59,11 @@ func (g *FaultDisputeGame) GameType() gameTypes.GameType {
 }
 
 func (g *FaultDisputeGame) MaxDepth() challengerTypes.Depth {
-	return challengerTypes.Depth(contract.Read(g.game.MaxGameDepth()).Uint64())
+	return challengerTypes.Depth(bigs.Uint64Strict(contract.Read(g.game.MaxGameDepth())))
 }
 
 func (g *FaultDisputeGame) SplitDepth() challengerTypes.Depth {
-	return challengerTypes.Depth(contract.Read(g.game.SplitDepth()).Uint64())
+	return challengerTypes.Depth(bigs.Uint64Strict(contract.Read(g.game.SplitDepth())))
 }
 
 func (g *FaultDisputeGame) RootClaim() *Claim {
@@ -70,7 +71,7 @@ func (g *FaultDisputeGame) RootClaim() *Claim {
 }
 
 func (g *FaultDisputeGame) L2SequenceNumber() uint64 {
-	return contract.Read(g.game.L2SequenceNumber()).Uint64()
+	return bigs.Uint64Strict(contract.Read(g.game.L2SequenceNumber()))
 }
 
 func (g *FaultDisputeGame) StartingL2SequenceNumber() uint64 {
@@ -159,7 +160,7 @@ func (g *FaultDisputeGame) allClaims() []bindings.Claim {
 }
 
 func (g *FaultDisputeGame) claimCount() uint64 {
-	return contract.Read(g.game.ClaimDataLen()).Uint64()
+	return bigs.Uint64Strict(contract.Read(g.game.ClaimDataLen()))
 }
 
 func (g *FaultDisputeGame) waitForClaim(timeout time.Duration, errorMsg string, predicate func(claimIdx uint64, claim bindings.Claim) bool) (uint64, bindings.Claim) {

--- a/op-devstack/dsl/proofs/game_helper.go
+++ b/op-devstack/dsl/proofs/game_helper.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	opservice "github.com/ethereum-optimism/optimism/op-service"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
 )
 
@@ -171,7 +172,7 @@ func (gs *GameHelper) DisputeL2SequenceNumber(eoa *dsl.EOA, game *FaultDisputeGa
 	startingSeqNumber := game.StartingL2SequenceNumber()
 	gs.require.Greater(l2SequenceNumber, startingSeqNumber, "Cannot dispute things at or prior to the starting block")
 	seqNumAtPosition := func(pos challengerTypes.Position) uint64 {
-		return pos.TraceIndex(splitDepth).Uint64() + startingSeqNumber + 1
+		return bigs.Uint64Strict(pos.TraceIndex(splitDepth)) + startingSeqNumber + 1
 	}
 	shouldMoveLeftFrom := func(pos challengerTypes.Position) bool {
 		// Move left when equal to the sequence number so that we disagree with it
@@ -214,7 +215,7 @@ func (gs *GameHelper) DisputeToStep(eoa *dsl.EOA, game *FaultDisputeGame, startC
 	traceIndexAtPosition := func(pos challengerTypes.Position) uint64 {
 		relativeFinalPosition, err := pos.RelativeToAncestorAtDepth(splitDepth + 1)
 		gs.require.NoError(err, "Failed to calculate relative position")
-		return relativeFinalPosition.TraceIndex(maxDepth - splitDepth - 1).Uint64()
+		return bigs.Uint64Strict(relativeFinalPosition.TraceIndex(maxDepth - splitDepth - 1))
 	}
 	shouldMoveLeftFrom := func(pos challengerTypes.Position) bool {
 		// Move left when equal to the trace index so that we disagree with it
@@ -347,14 +348,14 @@ func (gs *GameHelper) totalMoveBonds(game *FaultDisputeGame, moves []GameHelperM
 	preExistingClaimCount := game.claimCount()
 	totalBond := eth.Ether(0)
 	for i, move := range moves {
-		parentPos := claimPositions[move.ParentIdx.Uint64()]
+		parentPos := claimPositions[bigs.Uint64Strict(move.ParentIdx)]
 		if parentPos == (challengerTypes.Position{}) {
-			gs.require.LessOrEqual(move.ParentIdx.Uint64(), preExistingClaimCount, "No parent position found - moves may be out of order")
+			gs.require.LessOrEqual(bigs.Uint64Strict(move.ParentIdx), preExistingClaimCount, "No parent position found - moves may be out of order")
 			// Handle cases were there are existing claims and we're adding moves that reference them
 			gs.t.Logf("Loading parent position for existing claim at index %v", move.ParentIdx)
-			parentClaim := game.ClaimAtIndex(move.ParentIdx.Uint64())
+			parentClaim := game.ClaimAtIndex(bigs.Uint64Strict(move.ParentIdx))
 			parentPos = parentClaim.Position()
-			claimPositions[move.ParentIdx.Uint64()] = parentPos
+			claimPositions[bigs.Uint64Strict(move.ParentIdx)] = parentPos
 		}
 		childPos := parentPos.Defend()
 		if move.Attack {

--- a/op-e2e/actions/altda/altda_test.go
+++ b/op-e2e/actions/altda/altda_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/node/safedb"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/event"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
@@ -107,11 +108,11 @@ func NewL2AltDA(t helpers.Testing, params ...AltDAParam) *L2AltDA {
 
 	challengeWindow, err := contract.ChallengeWindow(nil)
 	require.NoError(t, err)
-	require.Equal(t, altDACfg.ChallengeWindow, challengeWindow.Uint64())
+	require.Equal(t, altDACfg.ChallengeWindow, bigs.Uint64Strict(challengeWindow))
 
 	resolveWindow, err := contract.ResolveWindow(nil)
 	require.NoError(t, err)
-	require.Equal(t, altDACfg.ResolveWindow, resolveWindow.Uint64())
+	require.Equal(t, altDACfg.ResolveWindow, bigs.Uint64Strict(resolveWindow))
 
 	return &L2AltDA{
 		log:       log,
@@ -174,7 +175,7 @@ func (a *L2AltDA) ActNewL2Tx(t helpers.Testing) {
 	a.miner.ActL1IncludeTx(a.dp.Addresses.Batcher)(t)
 	a.miner.ActL1EndBlock(t)
 
-	a.lastCommBn = a.miner.L1Chain().CurrentBlock().Number.Uint64()
+	a.lastCommBn = bigs.Uint64Strict(a.miner.L1Chain().CurrentBlock().Number)
 }
 
 func (a *L2AltDA) ActDeleteLastInput(t helpers.Testing) {
@@ -215,7 +216,7 @@ func (a *L2AltDA) ActChallengeInput(t helpers.Testing, comm []byte, bn uint64) {
 
 func (a *L2AltDA) ActExpireLastInput(t helpers.Testing) {
 	reorgWindow := a.altDACfg.ResolveWindow + a.altDACfg.ChallengeWindow
-	for a.miner.L1Chain().CurrentBlock().Number.Uint64() <= a.lastCommBn+reorgWindow {
+	for bigs.Uint64Strict(a.miner.L1Chain().CurrentBlock().Number) <= a.lastCommBn+reorgWindow {
 		a.miner.ActL1StartBlock(12)(t)
 		a.miner.ActL1EndBlock(t)
 	}
@@ -256,7 +257,7 @@ func (a *L2AltDA) GetLastTxBlock(t helpers.Testing) *types.Block {
 }
 
 func (a *L2AltDA) ActL1Finalized(t helpers.Testing) {
-	latest := a.miner.L1Chain().CurrentBlock().Number.Uint64()
+	latest := bigs.Uint64Strict(a.miner.L1Chain().CurrentBlock().Number)
 	a.miner.ActL1Safe(t, latest)
 	a.miner.ActL1Finalize(t, latest)
 	a.sequencer.ActL1FinalizedSignal(t)
@@ -492,7 +493,7 @@ func TestAltDA_SequencerStalledMultiChallenges(gt *testing.T) {
 	comm2 := a.lastComm
 	_, err = a.storage.GetInput(t.Ctx(), altda.Keccak256Commitment(comm2[1:]))
 	require.NoError(t, err)
-	a.lastCommBn = a.miner.L1Chain().CurrentBlock().Number.Uint64()
+	a.lastCommBn = bigs.Uint64Strict(a.miner.L1Chain().CurrentBlock().Number)
 
 	// ensure the second commitment is distinct from the first
 	require.NotEqual(t, comm1, comm2)

--- a/op-e2e/actions/derivation/batch_queue_test.go
+++ b/op-e2e/actions/derivation/batch_queue_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/node/safedb"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum/go-ethereum/log"
@@ -41,7 +42,7 @@ func TestDeriveChainFromNearL1Genesis(gt *testing.T) {
 	miner, seqEngine, sequencer := helpers.SetupSequencerTest(t, sd, logger)
 
 	miner.ActEmptyBlock(t)
-	require.EqualValues(gt, 1, miner.L1Chain().CurrentBlock().Number.Uint64())
+	require.EqualValues(gt, 1, bigs.Uint64Strict(miner.L1Chain().CurrentBlock().Number))
 
 	ref, err := derive.L2BlockToBlockRef(sequencer.RollupCfg, seqEngine.L2Chain().Genesis())
 	require.NoError(gt, err)
@@ -49,7 +50,7 @@ func TestDeriveChainFromNearL1Genesis(gt *testing.T) {
 
 	sequencer.ActL1HeadSignal(t)
 	sequencer.ActBuildToL1Head(t)
-	l2BlockNum := seqEngine.L2Chain().CurrentBlock().Number.Uint64()
+	l2BlockNum := bigs.Uint64Strict(seqEngine.L2Chain().CurrentBlock().Number)
 	ref, err = derive.L2BlockToBlockRef(sequencer.RollupCfg, seqEngine.L2Chain().GetBlockByNumber(l2BlockNum))
 	require.NoError(gt, err)
 	require.EqualValues(gt, 1, ref.L1Origin.Number)
@@ -74,21 +75,21 @@ func TestDeriveChainFromNearL1Genesis(gt *testing.T) {
 	miner.ActL1EndBlock(t)
 	bl := miner.L1Chain().CurrentBlock()
 	logger.Info("Produced L1 block with batch",
-		"num", miner.L1Chain().CurrentBlock().Number.Uint64(),
+		"num", bigs.Uint64Strict(miner.L1Chain().CurrentBlock().Number),
 		"txs", len(miner.L1Chain().GetBlockByHash(bl.Hash()).Transactions()))
 
 	// Process batches so safe head updates
 	sequencer.ActL1HeadSignal(t)
 	sequencer.ActL2PipelineFull(t)
-	require.EqualValues(gt, l2BlockNum, seqEngine.L2Chain().CurrentSafeBlock().Number.Uint64())
+	require.EqualValues(gt, l2BlockNum, bigs.Uint64Strict(seqEngine.L2Chain().CurrentSafeBlock().Number))
 
 	// Finalize L1 and process so L2 finalized updates
-	miner.ActL1Safe(t, miner.L1Chain().CurrentBlock().Number.Uint64())
-	miner.ActL1Finalize(t, miner.L1Chain().CurrentBlock().Number.Uint64())
+	miner.ActL1Safe(t, bigs.Uint64Strict(miner.L1Chain().CurrentBlock().Number))
+	miner.ActL1Finalize(t, bigs.Uint64Strict(miner.L1Chain().CurrentBlock().Number))
 	sequencer.ActL1SafeSignal(t)
 	sequencer.ActL1FinalizedSignal(t)
 	sequencer.ActL2PipelineFull(t)
-	require.EqualValues(gt, l2BlockNum, seqEngine.L2Chain().CurrentFinalBlock().Number.Uint64())
+	require.EqualValues(gt, l2BlockNum, bigs.Uint64Strict(seqEngine.L2Chain().CurrentFinalBlock().Number))
 
 	// Create a new verifier using the existing engine so it already has the safe and finalized heads set.
 	// This is the same situation as if op-node restarted at this point.
@@ -97,8 +98,8 @@ func TestDeriveChainFromNearL1Genesis(gt *testing.T) {
 	verifier := helpers.NewL2Verifier(t, logger, miner.L1Client(t, sd.RollupCfg), miner.BlobStore(), altda.Disabled,
 		l2Cl, sd.RollupCfg, sd.L1Cfg.Config, sd.DependencySet, &sync.Config{}, safedb.Disabled)
 	verifier.ActL2PipelineFull(t) // Should not get stuck in a reset loop forever
-	require.EqualValues(gt, l2BlockNum, seqEngine.L2Chain().CurrentSafeBlock().Number.Uint64())
-	require.EqualValues(gt, l2BlockNum, seqEngine.L2Chain().CurrentFinalBlock().Number.Uint64())
+	require.EqualValues(gt, l2BlockNum, bigs.Uint64Strict(seqEngine.L2Chain().CurrentSafeBlock().Number))
+	require.EqualValues(gt, l2BlockNum, bigs.Uint64Strict(seqEngine.L2Chain().CurrentFinalBlock().Number))
 	syncStatus := verifier.SyncStatus()
 	require.EqualValues(gt, l2BlockNum, syncStatus.SafeL2.Number)
 	require.EqualValues(gt, l2BlockNum, syncStatus.FinalizedL2.Number)

--- a/op-e2e/actions/derivation/blocktime_test.go
+++ b/op-e2e/actions/derivation/blocktime_test.go
@@ -8,6 +8,7 @@ import (
 	actionsHelpers "github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
 	upgradesHelpers "github.com/ethereum-optimism/optimism/op-e2e/actions/upgrades/helpers"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -81,7 +82,7 @@ func BatchInLastPossibleBlocks(gt *testing.T, deltaTimeOffset *hexutil.Uint64) {
 		sequencer.ActL2EndBlock(t)
 	}
 	verifyChainStateOnSequencer := func(l1Number, unsafeHead, unsafeHeadOrigin, safeHead, safeHeadOrigin uint64) {
-		require.Equal(t, l1Number, miner.L1Chain().CurrentHeader().Number.Uint64())
+		require.Equal(t, l1Number, bigs.Uint64Strict(miner.L1Chain().CurrentHeader().Number))
 		require.Equal(t, unsafeHead, sequencer.L2Unsafe().Number)
 		require.Equal(t, unsafeHeadOrigin, sequencer.L2Unsafe().L1Origin.Number)
 		require.Equal(t, safeHead, sequencer.L2Safe().Number)
@@ -201,7 +202,7 @@ func LargeL1Gaps(gt *testing.T, deltaTimeOffset *hexutil.Uint64) {
 	}
 
 	verifyChainStateOnSequencer := func(l1Number, unsafeHead, unsafeHeadOrigin, safeHead, safeHeadOrigin uint64) {
-		require.Equal(t, l1Number, miner.L1Chain().CurrentHeader().Number.Uint64())
+		require.Equal(t, l1Number, bigs.Uint64Strict(miner.L1Chain().CurrentHeader().Number))
 		require.Equal(t, unsafeHead, sequencer.L2Unsafe().Number)
 		require.Equal(t, unsafeHeadOrigin, sequencer.L2Unsafe().L1Origin.Number)
 		require.Equal(t, safeHead, sequencer.L2Safe().Number)
@@ -209,7 +210,7 @@ func LargeL1Gaps(gt *testing.T, deltaTimeOffset *hexutil.Uint64) {
 	}
 
 	verifyChainStateOnVerifier := func(l1Number, unsafeHead, unsafeHeadOrigin, safeHead, safeHeadOrigin uint64) {
-		require.Equal(t, l1Number, miner.L1Chain().CurrentHeader().Number.Uint64())
+		require.Equal(t, l1Number, bigs.Uint64Strict(miner.L1Chain().CurrentHeader().Number))
 		require.Equal(t, unsafeHead, verifier.L2Unsafe().Number)
 		require.Equal(t, unsafeHeadOrigin, verifier.L2Unsafe().L1Origin.Number)
 		require.Equal(t, safeHead, verifier.L2Safe().Number)

--- a/op-e2e/actions/derivation/l2_verifier_test.go
+++ b/op-e2e/actions/derivation/l2_verifier_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 )
 
@@ -30,13 +31,13 @@ func TestL2Verifier_SequenceWindow(gt *testing.T) {
 	miner.ActL1SetFeeRecipient(common.Address{'A'})
 
 	// Make two sequence windows worth of empty L1 blocks. After we pass the first sequence window, the L2 chain should get blocks
-	for miner.L1Chain().CurrentBlock().Number.Uint64() < sd.RollupCfg.SeqWindowSize*2 {
+	for bigs.Uint64Strict(miner.L1Chain().CurrentBlock().Number) < sd.RollupCfg.SeqWindowSize*2 {
 		miner.ActL1StartBlock(10)(t)
 		miner.ActL1EndBlock(t)
 
 		verifier.ActL2PipelineFull(t)
 
-		l1Head := miner.L1Chain().CurrentBlock().Number.Uint64()
+		l1Head := bigs.Uint64Strict(miner.L1Chain().CurrentBlock().Number)
 		expectedL1Origin := uint64(0)
 		// as soon as we complete the sequence window, we force-adopt the L1 origin
 		if l1Head >= sd.RollupCfg.SeqWindowSize {
@@ -64,7 +65,7 @@ func TestL2Verifier_SequenceWindow(gt *testing.T) {
 	verifier.ActL2PipelineFull(t)
 	require.Equal(t, tip2N.SafeL2, verifier.SyncStatus().SafeL2)
 
-	for miner.L1Chain().CurrentBlock().Number.Uint64() < sd.RollupCfg.SeqWindowSize*2 {
+	for bigs.Uint64Strict(miner.L1Chain().CurrentBlock().Number) < sd.RollupCfg.SeqWindowSize*2 {
 		miner.ActL1StartBlock(10)(t)
 		miner.ActL1EndBlock(t)
 	}

--- a/op-e2e/actions/derivation/reorg_test.go
+++ b/op-e2e/actions/derivation/reorg_test.go
@@ -20,6 +20,7 @@ import (
 
 	altda "github.com/ethereum-optimism/optimism/op-alt-da"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
@@ -759,7 +760,7 @@ func ConflictingL2Blocks(gt *testing.T, deltaTimeOffset *hexutil.Uint64) {
 	miner.ActL1StartBlock(12)(t)
 	miner.ActL1IncludeTx(sd.RollupCfg.Genesis.SystemConfig.BatcherAddr)(t)
 	miner.ActL1EndBlock(t)
-	l1Number := miner.L1Chain().CurrentHeader().Number.Uint64()
+	l1Number := bigs.Uint64Strict(miner.L1Chain().CurrentHeader().Number)
 
 	// show latest L1 block with new batch data to verifier, and make it sync.
 	verifier.ActL1HeadSignal(t)

--- a/op-e2e/actions/derivation/system_config_test.go
+++ b/op-e2e/actions/derivation/system_config_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 )
@@ -116,8 +117,8 @@ func BatcherKeyRotation(gt *testing.T, deltaTimeOffset *hexutil.Uint64) {
 	receipt, err := miner.EthClient().TransactionReceipt(t.Ctx(), tx.Hash())
 	require.NoError(t, err)
 
-	cfgChangeL1BlockNum := miner.L1Chain().CurrentBlock().Number.Uint64()
-	require.Equal(t, cfgChangeL1BlockNum, receipt.BlockNumber.Uint64())
+	cfgChangeL1BlockNum := bigs.Uint64Strict(miner.L1Chain().CurrentBlock().Number)
+	require.Equal(t, cfgChangeL1BlockNum, bigs.Uint64Strict(receipt.BlockNumber))
 
 	// sequence L2 blocks, and submit with new batcher
 	sequencer.ActL1HeadSignal(t)
@@ -276,7 +277,7 @@ func GPOParamsChange(gt *testing.T, deltaTimeOffset *hexutil.Uint64) {
 		),
 		new(big.Float).SetInt(receipt.L1Fee), "fee field in receipt matches gas used times scalar times basefee")
 	// receipt.L1GasUsed includes the overhead already, so subtract that before passing it into the L1 cost func
-	l1Cost := types.L1Cost(receipt.L1GasUsed.Uint64()-2100, basefee, big.NewInt(2100), big.NewInt(1000_000))
+	l1Cost := types.L1Cost(bigs.Uint64Strict(receipt.L1GasUsed)-2100, basefee, big.NewInt(2100), big.NewInt(1000_000))
 	require.Equal(t, l1Cost, receipt.L1Fee, "L1 fee is computed with standard GPO params")
 	require.Equal(t, "1", receipt.FeeScalar.String(), "1000_000 divided by 6 decimals = float(1)")
 
@@ -333,7 +334,7 @@ func GPOParamsChange(gt *testing.T, deltaTimeOffset *hexutil.Uint64) {
 	require.Equal(t, basefeeGPOUpdate, receipt.L1GasPrice, "L1 gas price matches basefee of L1 origin")
 	require.NotZero(t, receipt.L1GasUsed, "L2 tx uses L1 data")
 	// subtract overhead from L1GasUsed receipt field, types.L1Cost applies it again
-	l1Cost = types.L1Cost(receipt.L1GasUsed.Uint64()-1000, basefeeGPOUpdate, big.NewInt(1000), big.NewInt(2_300_000))
+	l1Cost = types.L1Cost(bigs.Uint64Strict(receipt.L1GasUsed)-1000, basefeeGPOUpdate, big.NewInt(1000), big.NewInt(2_300_000))
 	require.Equal(t, l1Cost, receipt.L1Fee, "L1 fee is computed with updated GPO params")
 	require.Equal(t, "2.3", receipt.FeeScalar.String(), "2_300_000 divided by 6 decimals = float(2.3)")
 
@@ -354,7 +355,7 @@ func GPOParamsChange(gt *testing.T, deltaTimeOffset *hexutil.Uint64) {
 	require.Equal(t, basefee, receipt.L1GasPrice, "L1 gas price matches basefee of L1 origin")
 	require.NotZero(t, receipt.L1GasUsed, "L2 tx uses L1 data")
 	// subtract overhead from L1GasUsed receipt field, types.L1Cost applies it again
-	l1Cost = types.L1Cost(receipt.L1GasUsed.Uint64()-1000, basefee, big.NewInt(1000), big.NewInt(2_300_000))
+	l1Cost = types.L1Cost(bigs.Uint64Strict(receipt.L1GasUsed)-1000, basefee, big.NewInt(1000), big.NewInt(2_300_000))
 	require.Equal(t, l1Cost, receipt.L1Fee, "L1 fee is computed with updated GPO params")
 	require.Equal(t, "2.3", receipt.FeeScalar.String(), "2_300_000 divided by 6 decimals = float(2.3)")
 }

--- a/op-e2e/actions/helpers/l1_miner.go
+++ b/op-e2e/actions/helpers/l1_miner.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ethereum/go-ethereum/triedb"
 
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/blobstore"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
@@ -273,7 +274,7 @@ func (s *L1Miner) ActL1EndBlock(t Testing) *types.Block {
 
 	isCancun := s.l1Cfg.Config.IsCancun(s.l1BuildingHeader.Number, s.l1BuildingHeader.Time)
 	// Write state changes to db
-	root, err := s.l1BuildingState.Commit(s.l1BuildingHeader.Number.Uint64(), s.l1Cfg.Config.IsEIP158(s.l1BuildingHeader.Number), isCancun)
+	root, err := s.l1BuildingState.Commit(bigs.Uint64Strict(s.l1BuildingHeader.Number), s.l1Cfg.Config.IsEIP158(s.l1BuildingHeader.Number), isCancun)
 	if err != nil {
 		t.Fatalf("l1 state write error: %v", err)
 	}

--- a/op-e2e/actions/helpers/l1_replica.go
+++ b/op-e2e/actions/helpers/l1_replica.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/client"
 	opeth "github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
@@ -53,7 +54,7 @@ type L1Replica struct {
 // NewL1Replica constructs a L1Replica starting at the given genesis.
 func NewL1Replica(t Testing, log log.Logger, genesis *core.Genesis) *L1Replica {
 	ethCfg := &ethconfig.Config{
-		NetworkId:                 genesis.Config.ChainID.Uint64(),
+		NetworkId:                 bigs.Uint64Strict(genesis.Config.ChainID),
 		Genesis:                   genesis,
 		RollupDisableTxPoolGossip: true,
 		StateScheme:               rawdb.HashScheme,
@@ -112,14 +113,14 @@ func (s *L1Replica) ActL1RewindDepth(depth uint64) Action {
 		if depth == 0 {
 			return
 		}
-		head := s.l1Chain.CurrentHeader().Number.Uint64()
+		head := bigs.Uint64Strict(s.l1Chain.CurrentHeader().Number)
 		if head < depth {
 			t.InvalidAction("cannot rewind L1 past genesis (current: %d, rewind depth: %d)", head, depth)
 			return
 		}
 		finalized := s.l1Chain.CurrentFinalBlock()
-		if finalized != nil && head < finalized.Number.Uint64()+depth {
-			t.InvalidAction("cannot rewind head of chain past finalized block %d with rewind depth %d", finalized.Number.Uint64(), depth)
+		if finalized != nil && head < bigs.Uint64Strict(finalized.Number)+depth {
+			t.InvalidAction("cannot rewind head of chain past finalized block %d with rewind depth %d", bigs.Uint64Strict(finalized.Number), depth)
 			return
 		}
 		if err := s.l1Chain.SetHead(head - depth); err != nil {
@@ -133,7 +134,7 @@ func (s *L1Replica) ActL1RewindDepth(depth uint64) Action {
 func (s *L1Replica) ActL1Sync(canonL1 func(num uint64) *types.Block) Action {
 	return func(t Testing) {
 		selfHead := s.l1Chain.CurrentHeader()
-		n := selfHead.Number.Uint64()
+		n := bigs.Uint64Strict(selfHead.Number)
 		expected := canonL1(n)
 		if expected == nil || selfHead.Hash() != expected.Hash() {
 			s.ActL1RewindToParent(t)
@@ -213,7 +214,7 @@ func (s *L1Replica) UnsafeNum() uint64 {
 	head := s.l1Chain.CurrentBlock()
 	headNum := uint64(0)
 	if head != nil {
-		headNum = head.Number.Uint64()
+		headNum = bigs.Uint64Strict(head.Number)
 	}
 	return headNum
 }
@@ -222,7 +223,7 @@ func (s *L1Replica) SafeNum() uint64 {
 	safe := s.l1Chain.CurrentSafeBlock()
 	safeNum := uint64(0)
 	if safe != nil {
-		safeNum = safe.Number.Uint64()
+		safeNum = bigs.Uint64Strict(safe.Number)
 	}
 	return safeNum
 }
@@ -231,7 +232,7 @@ func (s *L1Replica) FinalizedNum() uint64 {
 	finalized := s.l1Chain.CurrentFinalBlock()
 	finalizedNum := uint64(0)
 	if finalized != nil {
-		finalizedNum = finalized.Number.Uint64()
+		finalizedNum = bigs.Uint64Strict(finalized.Number)
 	}
 	return finalizedNum
 }

--- a/op-e2e/actions/helpers/l1_replica_test.go
+++ b/op-e2e/actions/helpers/l1_replica_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
@@ -84,7 +85,7 @@ func TestL1Replica_ActL1Sync(gt *testing.T) {
 	})
 	syncFromA := replica1.ActL1Sync(canonL1(chainA))
 	// sync canonical chain A
-	for replica1.l1Chain.CurrentBlock().Number.Uint64()+1 < uint64(len(chainA)) {
+	for bigs.Uint64Strict(replica1.l1Chain.CurrentBlock().Number)+1 < uint64(len(chainA)) {
 		syncFromA(t)
 	}
 	require.Equal(t, replica1.l1Chain.CurrentBlock().Hash(), chainA[len(chainA)-1].Hash(), "sync replica1 to head of chain A")
@@ -93,7 +94,7 @@ func TestL1Replica_ActL1Sync(gt *testing.T) {
 
 	// sync new canonical chain B
 	syncFromB := replica1.ActL1Sync(canonL1(chainB))
-	for replica1.l1Chain.CurrentBlock().Number.Uint64()+1 < uint64(len(chainB)) {
+	for bigs.Uint64Strict(replica1.l1Chain.CurrentBlock().Number)+1 < uint64(len(chainB)) {
 		syncFromB(t)
 	}
 	require.Equal(t, replica1.l1Chain.CurrentBlock().Hash(), chainB[len(chainB)-1].Hash(), "sync replica1 to head of chain B")
@@ -104,7 +105,7 @@ func TestL1Replica_ActL1Sync(gt *testing.T) {
 		_ = replica2.Close()
 	})
 	syncFromOther := replica2.ActL1Sync(replica1.CanonL1Chain())
-	for replica2.l1Chain.CurrentBlock().Number.Uint64()+1 < uint64(len(chainB)) {
+	for bigs.Uint64Strict(replica2.l1Chain.CurrentBlock().Number)+1 < uint64(len(chainB)) {
 		syncFromOther(t)
 	}
 	require.Equal(t, replica2.l1Chain.CurrentBlock().Hash(), chainB[len(chainB)-1].Hash(), "sync replica2 to head of chain B")

--- a/op-e2e/actions/helpers/l2_engine.go
+++ b/op-e2e/actions/helpers/l2_engine.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
@@ -75,7 +76,7 @@ func NewL2Engine(t Testing, log log.Logger, genesis *core.Genesis, jwtPath strin
 
 func newBackend(t e2eutils.TestingBase, genesis *core.Genesis, jwtPath string, options []EngineOption) (*node.Node, *geth.Ethereum, *engineApiBackend) {
 	ethCfg := &ethconfig.Config{
-		NetworkId:   genesis.Config.ChainID.Uint64(),
+		NetworkId:   bigs.Uint64Strict(genesis.Config.ChainID),
 		Genesis:     genesis,
 		StateScheme: rawdb.HashScheme,
 		NoPruning:   true,

--- a/op-e2e/actions/helpers/l2_engine_test.go
+++ b/op-e2e/actions/helpers/l2_engine_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
 	"github.com/ethereum-optimism/optimism/op-program/client/l2/engineapi"
 	"github.com/ethereum-optimism/optimism/op-program/client/l2/engineapi/test"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
@@ -202,7 +203,7 @@ func TestL2EngineAPIBlockBuilding(gt *testing.T) {
 	require.Equal(gt, 1, engine.l2Chain.GetBlockByHash(engine.l2Chain.CurrentBlock().Hash()).Transactions().Len(), "tx from alice is included")
 	buildBlock(false)
 	require.Zero(t, engine.l2Chain.GetBlockByHash(engine.l2Chain.CurrentBlock().Hash()).Transactions().Len(), "no tx included")
-	require.Equal(t, uint64(3), engine.l2Chain.CurrentBlock().Number.Uint64(), "built 3 blocks")
+	require.Equal(t, uint64(3), bigs.Uint64Strict(engine.l2Chain.CurrentBlock().Number), "built 3 blocks")
 }
 
 func TestL2EngineAPIFail(gt *testing.T) {

--- a/op-e2e/actions/helpers/user.go
+++ b/op-e2e/actions/helpers/user.go
@@ -32,6 +32,7 @@ import (
 	bindingspreview "github.com/ethereum-optimism/optimism/op-node/bindings/preview"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-node/withdrawals"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 )
 
 type L1Bindings struct {
@@ -229,7 +230,7 @@ func (s *BasicUser[B]) ActRandomTxData(t Testing) {
 func (s *BasicUser[B]) PendingNonce(t Testing) uint64 {
 	t.Helper()
 	if s.txOpts.Nonce != nil {
-		return s.txOpts.Nonce.Uint64()
+		return bigs.Uint64Strict(s.txOpts.Nonce)
 	}
 	// fetch from pending state
 	nonce, err := s.env.EthCl.PendingNonceAt(t.Ctx(), s.address)

--- a/op-e2e/actions/interop/dsl/assertions.go
+++ b/op-e2e/actions/interop/dsl/assertions.go
@@ -4,6 +4,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/stretchr/testify/assert"
@@ -40,7 +41,7 @@ func RequireUnsafeTimeOffset(t helpers.Testing, c *Chain, timeOffset uint64) {
 func RequireL1Heads(t helpers.Testing, system *InteropDSL, latest, finalized uint64) {
 	latestHeader, err := system.Actors.L1Miner.EthClient().BlockByNumber(t.Ctx(), big.NewInt(int64(rpc.LatestBlockNumber)))
 	require.NoError(t, err)
-	require.Equal(t, latest, latestHeader.Number().Uint64(), "L1 latest number does not match expectation")
+	require.Equal(t, latest, bigs.Uint64Strict(latestHeader.Number()), "L1 latest number does not match expectation")
 
 	finalizedHeader, err := system.Actors.L1Miner.EthClient().BlockByNumber(t.Ctx(), big.NewInt(int64(rpc.FinalizedBlockNumber)))
 
@@ -51,7 +52,7 @@ func RequireL1Heads(t helpers.Testing, system *InteropDSL, latest, finalized uin
 		}
 		finalizedActual = 0
 	} else {
-		finalizedActual = finalizedHeader.Number().Uint64()
+		finalizedActual = bigs.Uint64Strict(finalizedHeader.Number())
 	}
 
 	require.Equal(t, finalized, finalizedActual, "L1 finalized number does not match expectation")

--- a/op-e2e/actions/interop/dsl/dsl.go
+++ b/op-e2e/actions/interop/dsl/dsl.go
@@ -3,6 +3,7 @@ package dsl
 import (
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/event"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
@@ -270,7 +271,7 @@ func (d *InteropDSL) AdvanceL1(optionalArgs ...func(*AdvanceL1Opts)) {
 	for _, arg := range optionalArgs {
 		arg(&opts)
 	}
-	expectedL1BlockNum := d.Actors.L1Miner.L1Chain().CurrentBlock().Number.Uint64() + 1
+	expectedL1BlockNum := bigs.Uint64Strict(d.Actors.L1Miner.L1Chain().CurrentBlock().Number) + 1
 	d.Actors.L1Miner.ActL1StartBlock(opts.L1BlockTimeSeconds)(d.t)
 	for _, txInclusion := range opts.TxInclusion {
 		txInclusion(d.t)

--- a/op-e2e/actions/interop/dsl/inbox.go
+++ b/op-e2e/actions/interop/dsl/inbox.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-core/predeploys"
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/contracts/bindings/inbox"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	stypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
@@ -99,9 +100,9 @@ func (i *InboxContract) Execute(user *DSLUser, initTx *GeneratedTransaction, arg
 		require.NoError(i.t, err)
 		id := stypes.Identifier{
 			Origin:      ident.Origin,
-			BlockNumber: ident.BlockNumber.Uint64(),
-			LogIndex:    uint32(ident.LogIndex.Uint64()),
-			Timestamp:   ident.Timestamp.Uint64(),
+			BlockNumber: bigs.Uint64Strict(ident.BlockNumber),
+			LogIndex:    uint32(bigs.Uint64Strict(ident.LogIndex)),
+			Timestamp:   bigs.Uint64Strict(ident.Timestamp),
 			ChainID:     eth.ChainIDFromBig(ident.ChainId),
 		}
 		msgHash := crypto.Keccak256Hash(payload)

--- a/op-e2e/actions/interop/dsl/transactions.go
+++ b/op-e2e/actions/interop/dsl/transactions.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
 	"github.com/ethereum-optimism/optimism/op-e2e/bindingspreview"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/contracts/bindings/inbox"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	stypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -74,7 +75,7 @@ func (m *GeneratedTransaction) Identifier() inbox.Identifier {
 }
 
 func Identifier(chain *Chain, tx *types.Transaction, rcpt *types.Receipt) inbox.Identifier {
-	blockTime := chain.RollupCfg.TimestampForBlock(rcpt.BlockNumber.Uint64())
+	blockTime := chain.RollupCfg.TimestampForBlock(bigs.Uint64Strict(rcpt.BlockNumber))
 	return inbox.Identifier{
 		Origin:      *tx.To(),
 		BlockNumber: rcpt.BlockNumber,

--- a/op-e2e/actions/interop/dsl/utils.go
+++ b/op-e2e/actions/interop/dsl/utils.go
@@ -2,6 +2,7 @@ package dsl
 
 import (
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/stretchr/testify/assert"
@@ -15,7 +16,7 @@ func AssertAncestorDescendantRelationship(t helpers.Testing, chain *Chain, ances
 	for current.Number > ancestor.Number && current.Number > 0 {
 		header, err := chain.SequencerEngine.Eth.APIBackend.HeaderByNumber(t.Ctx(), rpc.BlockNumber(current.Number-1))
 		result = result && assert.NoError(t, err)
-		current = eth.BlockID{Hash: header.Hash(), Number: header.Number.Uint64()}
+		current = eth.BlockID{Hash: header.Hash(), Number: bigs.Uint64Strict(header.Number)}
 	}
 	return result && assert.Equal(t, current, ancestor, "descendant block is not a descendant of the ancestor block")
 }

--- a/op-e2e/actions/interop/emitter_contract_test.go
+++ b/op-e2e/actions/interop/emitter_contract_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/contracts/bindings/emit"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/contracts/bindings/inbox"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/event"
 	stypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
@@ -159,7 +160,7 @@ func idForTx(t helpers.Testing, tx *types.Transaction, srcChain *dsl.Chain) styp
 
 	return stypes.Identifier{
 		Origin:      *tx.To(),
-		BlockNumber: receipt.BlockNumber.Uint64(),
+		BlockNumber: bigs.Uint64Strict(receipt.BlockNumber),
 		LogIndex:    0,
 		Timestamp:   block.Time(),
 		ChainID:     eth.ChainIDFromBig(srcChain.RollupCfg.L2ChainID),

--- a/op-e2e/actions/interop/interop_msg_test.go
+++ b/op-e2e/actions/interop/interop_msg_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
 
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	suptypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
@@ -832,7 +833,7 @@ func TestCrossPatternSameTimestamp(gt *testing.T) {
 	// check tx1 first instead of tx0 not to make tx0 submitted
 	receipt, err := tx1.PlannedTx.Included.Eval(t.Ctx())
 	require.NoError(t, err)
-	require.Equal(t, targetBlockNum, receipt.BlockNumber.Uint64())
+	require.Equal(t, targetBlockNum, bigs.Uint64Strict(receipt.BlockNumber))
 	block, err := tx1.PlannedTx.IncludedBlock.Eval(t.Ctx())
 	require.NoError(t, err)
 	require.Equal(t, targetTime, block.Time)
@@ -848,7 +849,7 @@ func TestCrossPatternSameTimestamp(gt *testing.T) {
 	// check tx3 first instead of tx2 not to make tx2 submitted
 	receipt, err = tx3.PlannedTx.Included.Eval(t.Ctx())
 	require.NoError(t, err)
-	require.Equal(t, targetBlockNum, receipt.BlockNumber.Uint64())
+	require.Equal(t, targetBlockNum, bigs.Uint64Strict(receipt.BlockNumber))
 	block, err = tx3.PlannedTx.IncludedBlock.Eval(t.Ctx())
 	require.NoError(t, err)
 	require.Equal(t, targetTime, block.Time)

--- a/op-e2e/actions/interop/interop_test.go
+++ b/op-e2e/actions/interop/interop_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/contracts/bindings/emit"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/interop/indexing"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/event"
 	stypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
@@ -92,7 +93,7 @@ func TestFullInterop(gt *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, head, supervisorStatus.Chains[chain.ChainID].LocalUnsafe.ID())
 		// Local-safe does not count as "safe" in RPC
-		n := chain.SequencerEngine.L2Chain().CurrentSafeBlock().Number.Uint64()
+		n := bigs.Uint64Strict(chain.SequencerEngine.L2Chain().CurrentSafeBlock().Number)
 		require.Equal(t, uint64(0), n)
 
 		// Make the supervisor aware of the new L1 block

--- a/op-e2e/actions/interop/proofs_test.go
+++ b/op-e2e/actions/interop/proofs_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-program/client/claim"
 	"github.com/ethereum-optimism/optimism/op-program/client/interop"
 	"github.com/ethereum-optimism/optimism/op-program/client/interop/types"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
@@ -596,7 +597,7 @@ func TestInteropFaultProofs_MessageExpiry(gt *testing.T) {
 
 	// Advance the chain until the init msg expires
 	msgExpiryTime := system.DepSet().MessageExpiryWindow()
-	end := emitTx.Identifier().Timestamp.Uint64() + msgExpiryTime
+	end := bigs.Uint64Strict(emitTx.Identifier().Timestamp) + msgExpiryTime
 	system.AddL2Block(actors.ChainA, dsl.WithL2BlocksUntilTimestamp(end))
 	system.AddL2Block(actors.ChainB, dsl.WithL2BlocksUntilTimestamp(end))
 	system.SubmitBatchData()

--- a/op-e2e/actions/interop/reset_test.go
+++ b/op-e2e/actions/interop/reset_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/interop/dsl"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/event"
 	"github.com/stretchr/testify/require"
@@ -78,7 +79,7 @@ func TestReset(gt *testing.T) {
 			require.Equal(t, head, status.LocalSafeL2.ID())
 			require.Equal(t, uint64(prevBlockNum), status.SafeL2.Number)
 			// Local-safe does not count as "safe" in RPC
-			n := actors.ChainA.SequencerEngine.L2Chain().CurrentSafeBlock().Number.Uint64()
+			n := bigs.Uint64Strict(actors.ChainA.SequencerEngine.L2Chain().CurrentSafeBlock().Number)
 			require.Equal(t, uint64(prevBlockNum), n)
 		}
 

--- a/op-e2e/actions/proofs/activation_block_test.go
+++ b/op-e2e/actions/proofs/activation_block_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/stretchr/testify/require"
 
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 )
@@ -98,5 +99,5 @@ func testActivationBlockTxOmission(gt *testing.T, testCfg *helpers.TestCfg[activ
 	preActHeader := engine.L2Chain().GetHeaderByHash(actHeader.ParentHash)
 	require.Equal(t, eth.HeaderBlockID(preActHeader), eth.HeaderBlockID(l2SafeHead), "derivation only reaches pre-upgrade block")
 
-	env.RunFaultProofProgramFromGenesis(t, l2SafeHead.Number.Uint64(), testCfg.CheckResult, testCfg.InputParams...)
+	env.RunFaultProofProgramFromGenesis(t, bigs.Uint64Strict(l2SafeHead.Number), testCfg.CheckResult, testCfg.InputParams...)
 }

--- a/op-e2e/actions/proofs/bad_tx_in_batch_test.go
+++ b/op-e2e/actions/proofs/bad_tx_in_batch_test.go
@@ -5,6 +5,7 @@ import (
 
 	actionsHelpers "github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/proofs/helpers"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/require"
@@ -71,7 +72,7 @@ func runBadTxInBatchTest(gt *testing.T, testCfg *helpers.TestCfg[int64]) {
 	// If post-holocene, the block should be reduced to deposits only.
 	l2SafeHead := env.Engine.L2Chain().CurrentSafeBlock()
 	if !env.Sd.RollupCfg.IsHolocene(l2SafeHead.Time) {
-		require.Equal(t, uint64(0), l2SafeHead.Number.Uint64())
+		require.Equal(t, uint64(0), bigs.Uint64Strict(l2SafeHead.Number))
 
 		// Reset the batcher and submit a valid batch.
 		env.Batcher.Reset()
@@ -86,14 +87,14 @@ func runBadTxInBatchTest(gt *testing.T, testCfg *helpers.TestCfg[int64]) {
 		env.Sequencer.ActL2PipelineFull(t)
 
 		l1Head := env.Miner.L1Chain().CurrentBlock()
-		require.Equal(t, uint64(2), l1Head.Number.Uint64())
+		require.Equal(t, uint64(2), bigs.Uint64Strict(l1Head.Number))
 	}
 
 	// Ensure the safe head has advanced.
 	l2SafeHead = env.Engine.L2Chain().CurrentSafeBlock()
-	require.Equal(t, uint64(1), l2SafeHead.Number.Uint64())
+	require.Equal(t, uint64(1), bigs.Uint64Strict(l2SafeHead.Number))
 
-	env.RunFaultProofProgramFromGenesis(t, l2SafeHead.Number.Uint64(), testCfg.CheckResult, testCfg.InputParams...)
+	env.RunFaultProofProgramFromGenesis(t, bigs.Uint64Strict(l2SafeHead.Number), testCfg.CheckResult, testCfg.InputParams...)
 }
 
 func runBadTxInBatch_ResubmitBadFirstFrame_Test(gt *testing.T, testCfg *helpers.TestCfg[int64]) {
@@ -156,7 +157,7 @@ func runBadTxInBatch_ResubmitBadFirstFrame_Test(gt *testing.T, testCfg *helpers.
 	// If post-holocene, the block should be reduced to deposits only.
 	l2SafeHead := env.Engine.L2Chain().CurrentSafeBlock()
 	if !env.Sd.RollupCfg.IsHolocene(l2SafeHead.Time) {
-		require.Equal(t, uint64(0), l2SafeHead.Number.Uint64())
+		require.Equal(t, uint64(0), bigs.Uint64Strict(l2SafeHead.Number))
 
 		// Reset the batcher and submit a valid batch.
 		env.Batcher.Reset()
@@ -171,14 +172,14 @@ func runBadTxInBatch_ResubmitBadFirstFrame_Test(gt *testing.T, testCfg *helpers.
 		env.Sequencer.ActL2PipelineFull(t)
 
 		l1Head := env.Miner.L1Chain().CurrentBlock()
-		require.Equal(t, uint64(2), l1Head.Number.Uint64())
+		require.Equal(t, uint64(2), bigs.Uint64Strict(l1Head.Number))
 	}
 
 	// Ensure the safe head has advanced.
 	l2SafeHead = env.Engine.L2Chain().CurrentSafeBlock()
-	require.Equal(t, uint64(2), l2SafeHead.Number.Uint64())
+	require.Equal(t, uint64(2), bigs.Uint64Strict(l2SafeHead.Number))
 
-	env.RunFaultProofProgramFromGenesis(t, l2SafeHead.Number.Uint64(), testCfg.CheckResult, testCfg.InputParams...)
+	env.RunFaultProofProgramFromGenesis(t, bigs.Uint64Strict(l2SafeHead.Number), testCfg.CheckResult, testCfg.InputParams...)
 }
 
 func Test_ProgramAction_BadTxInBatch(gt *testing.T) {

--- a/op-e2e/actions/proofs/block_data_hint_test.go
+++ b/op-e2e/actions/proofs/block_data_hint_test.go
@@ -13,6 +13,7 @@ import (
 	preimage "github.com/ethereum-optimism/optimism/op-preimage"
 	"github.com/ethereum-optimism/optimism/op-program/client/l2"
 	"github.com/ethereum-optimism/optimism/op-program/host/kvstore"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/event"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
@@ -58,24 +59,24 @@ func Test_ProgramAction_BlockDataHint(gt *testing.T) {
 	l2SafeHead := env.Engine.L2Chain().CurrentSafeBlock()
 
 	// Ensure there is only 1 block on L1.
-	require.Equal(t, uint64(1), l1Head.Number.Uint64())
+	require.Equal(t, uint64(1), bigs.Uint64Strict(l1Head.Number))
 	// Ensure the block is marked as safe before we attempt to fault prove it.
-	require.Equal(t, uint64(1), l2SafeHead.Number.Uint64())
+	require.Equal(t, uint64(1), bigs.Uint64Strict(l2SafeHead.Number))
 
 	// Now create a verifier that syncs up to the safe head parent
 	// This simulates a reorg view for the program reexecution
 	verifier, verifierEngine := createVerifier(t, env)
 	verifier.ActL2EventsUntil(t, func(ev event.Event) bool {
-		until := l2SafeHead.Number.Uint64() - 1
+		until := bigs.Uint64Strict(l2SafeHead.Number) - 1
 		ref, err := verifier.Eng.BlockRefByNumber(context.Background(), until)
 		require.NoError(t, err)
 		return ref.Number == until
 	}, 20, false)
 	// Ensure that the block isn't available
-	_, err := verifier.Eng.BlockRefByNumber(context.Background(), l2SafeHead.Number.Uint64())
+	_, err := verifier.Eng.BlockRefByNumber(context.Background(), bigs.Uint64Strict(l2SafeHead.Number))
 	require.ErrorIs(t, err, ethereum.NotFound)
 
-	l2ClaimedBlockNumber := l2SafeHead.Number.Uint64()
+	l2ClaimedBlockNumber := bigs.Uint64Strict(l2SafeHead.Number)
 	syncedRollupClient := env.Sequencer.RollupClient()
 	l2PreBlockNum := l2ClaimedBlockNumber - 1
 	preRoot, err := syncedRollupClient.OutputAtBlock(t.Ctx(), l2PreBlockNum)

--- a/op-e2e/actions/proofs/channel_timeout_test.go
+++ b/op-e2e/actions/proofs/channel_timeout_test.go
@@ -6,6 +6,7 @@ import (
 	actionsHelpers "github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/proofs/helpers"
 	"github.com/ethereum-optimism/optimism/op-program/client/claim"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
@@ -51,7 +52,7 @@ func runChannelTimeoutTest(gt *testing.T, testCfg *helpers.TestCfg[any]) {
 
 	// Ensure that the safe head has not advanced - the channel is incomplete.
 	l2SafeHead := env.Engine.L2Chain().CurrentSafeBlock()
-	require.Equal(t, uint64(0), l2SafeHead.Number.Uint64())
+	require.Equal(t, uint64(0), bigs.Uint64Strict(l2SafeHead.Number))
 
 	// Time out the channel by mining `channelTimeout + 1` empty blocks on L1.
 	for i := uint64(0); i < channelTimeout+1; i++ {
@@ -65,7 +66,7 @@ func runChannelTimeoutTest(gt *testing.T, testCfg *helpers.TestCfg[any]) {
 
 	// Ensure the safe head has still not advanced.
 	l2SafeHead = env.Engine.L2Chain().CurrentSafeBlock()
-	require.Equal(t, uint64(0), l2SafeHead.Number.Uint64())
+	require.Equal(t, uint64(0), bigs.Uint64Strict(l2SafeHead.Number))
 
 	// Ensure that the channel was timed out.
 	require.EqualValues(t, 1, timedOutChannels)
@@ -99,10 +100,10 @@ func runChannelTimeoutTest(gt *testing.T, testCfg *helpers.TestCfg[any]) {
 
 	// Ensure the safe head has still advanced to L2 block # NumL2Blocks.
 	l2SafeHead = env.Engine.L2Chain().CurrentSafeBlock()
-	require.EqualValues(t, NumL2Blocks, l2SafeHead.Number.Uint64())
+	require.EqualValues(t, NumL2Blocks, bigs.Uint64Strict(l2SafeHead.Number))
 
 	// Run FPP from genesis up to safe head
-	env.RunFaultProofProgramFromGenesis(t, l2SafeHead.Number.Uint64(), testCfg.CheckResult, testCfg.InputParams...)
+	env.RunFaultProofProgramFromGenesis(t, bigs.Uint64Strict(l2SafeHead.Number), testCfg.CheckResult, testCfg.InputParams...)
 }
 
 func runChannelTimeoutTest_CloseChannelLate(gt *testing.T, testCfg *helpers.TestCfg[any]) {
@@ -145,7 +146,7 @@ func runChannelTimeoutTest_CloseChannelLate(gt *testing.T, testCfg *helpers.Test
 
 	// Ensure that the safe head has not advanced - the channel is incomplete.
 	l2SafeHead := env.Engine.L2Chain().CurrentSafeBlock()
-	require.Equal(t, uint64(0), l2SafeHead.Number.Uint64())
+	require.Equal(t, uint64(0), bigs.Uint64Strict(l2SafeHead.Number))
 
 	// Time out the channel by mining `channelTimeout + 1` empty blocks on L1.
 	for i := uint64(0); i < channelTimeout+1; i++ {
@@ -159,7 +160,7 @@ func runChannelTimeoutTest_CloseChannelLate(gt *testing.T, testCfg *helpers.Test
 
 	// Ensure the safe head has still not advanced.
 	l2SafeHead = env.Engine.L2Chain().CurrentSafeBlock()
-	require.Equal(t, uint64(0), l2SafeHead.Number.Uint64())
+	require.Equal(t, uint64(0), bigs.Uint64Strict(l2SafeHead.Number))
 
 	// Ensure that the channel was timed out.
 	require.EqualValues(t, 1, timedOutChannels)
@@ -188,7 +189,7 @@ func runChannelTimeoutTest_CloseChannelLate(gt *testing.T, testCfg *helpers.Test
 
 	// Ensure the safe head has still not advanced.
 	l2SafeHead = env.Engine.L2Chain().CurrentSafeBlock()
-	require.Equal(t, uint64(0), l2SafeHead.Number.Uint64())
+	require.Equal(t, uint64(0), bigs.Uint64Strict(l2SafeHead.Number))
 
 	// Instruct the batcher to submit the blocks to L1 in a new channel.
 	for _, frame := range [][]byte{firstFrame, finalFrame} {
@@ -207,10 +208,10 @@ func runChannelTimeoutTest_CloseChannelLate(gt *testing.T, testCfg *helpers.Test
 
 	// Ensure the safe head has still advanced to L2 block # NumL2Blocks.
 	l2SafeHead = env.Engine.L2Chain().CurrentSafeBlock()
-	require.EqualValues(t, NumL2Blocks, l2SafeHead.Number.Uint64())
+	require.EqualValues(t, NumL2Blocks, bigs.Uint64Strict(l2SafeHead.Number))
 
 	// Run FPP from genesis up to safe head
-	env.RunFaultProofProgramFromGenesis(t, l2SafeHead.Number.Uint64(), testCfg.CheckResult, testCfg.InputParams...)
+	env.RunFaultProofProgramFromGenesis(t, bigs.Uint64Strict(l2SafeHead.Number), testCfg.CheckResult, testCfg.InputParams...)
 }
 
 func Test_ProgramAction_ChannelTimeout(gt *testing.T) {

--- a/op-e2e/actions/proofs/garbage_channel_test.go
+++ b/op-e2e/actions/proofs/garbage_channel_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/proofs/helpers"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
 	"github.com/ethereum-optimism/optimism/op-program/client/claim"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
@@ -68,7 +69,7 @@ func runGarbageChannelTest(gt *testing.T, testCfg *helpers.TestCfg[actionsHelper
 
 	// Ensure that the safe head has not advanced - the channel is incomplete.
 	l2SafeHead := env.Engine.L2Chain().CurrentSafeBlock()
-	require.Equal(t, uint64(0), l2SafeHead.Number.Uint64())
+	require.Equal(t, uint64(0), bigs.Uint64Strict(l2SafeHead.Number))
 
 	// Buffer the second half of L2 blocks in the batcher.
 	for i := 0; i < NumL2Blocks/2; i++ {
@@ -84,7 +85,7 @@ func runGarbageChannelTest(gt *testing.T, testCfg *helpers.TestCfg[actionsHelper
 
 	// Ensure that the safe head has not advanced - the channel is incomplete.
 	l2SafeHead = env.Engine.L2Chain().CurrentSafeBlock()
-	require.Equal(t, uint64(0), l2SafeHead.Number.Uint64())
+	require.Equal(t, uint64(0), bigs.Uint64Strict(l2SafeHead.Number))
 
 	// Submit the correct second frame.
 	env.Batcher.ActL2BatchSubmitRaw(t, expectedSecondFrame)
@@ -93,10 +94,10 @@ func runGarbageChannelTest(gt *testing.T, testCfg *helpers.TestCfg[actionsHelper
 
 	// Ensure that the safe head has advanced - the channel is complete.
 	l2SafeHead = env.Engine.L2Chain().CurrentSafeBlock()
-	require.Equal(t, uint64(NumL2Blocks), l2SafeHead.Number.Uint64())
+	require.Equal(t, uint64(NumL2Blocks), bigs.Uint64Strict(l2SafeHead.Number))
 
 	// Run FPP from genesis up to safe head
-	env.RunFaultProofProgramFromGenesis(t, l2SafeHead.Number.Uint64(), testCfg.CheckResult, testCfg.InputParams...)
+	env.RunFaultProofProgramFromGenesis(t, bigs.Uint64Strict(l2SafeHead.Number), testCfg.CheckResult, testCfg.InputParams...)
 }
 
 func Test_ProgramAction_GarbageChannel(gt *testing.T) {

--- a/op-e2e/actions/proofs/holocene_batches_test.go
+++ b/op-e2e/actions/proofs/holocene_batches_test.go
@@ -7,6 +7,7 @@ import (
 	actionsHelpers "github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/proofs/helpers"
 	"github.com/ethereum-optimism/optimism/op-program/client/claim"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
@@ -99,7 +100,7 @@ func Test_ProgramAction_HoloceneBatches(gt *testing.T) {
 		}
 
 		targetHeadNumber := max(testCfg.Custom.blocks)
-		for env.Engine.L2Chain().CurrentBlock().Number.Uint64() < uint64(targetHeadNumber) {
+		for bigs.Uint64Strict(env.Engine.L2Chain().CurrentBlock().Number) < uint64(targetHeadNumber) {
 			env.Sequencer.ActL2StartBlock(t)
 			// Send an L2 tx
 			env.Alice.L2.ActResetTxOpts(t)

--- a/op-e2e/actions/proofs/holocene_frame_test.go
+++ b/op-e2e/actions/proofs/holocene_frame_test.go
@@ -7,6 +7,7 @@ import (
 	actionsHelpers "github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/proofs/helpers"
 	"github.com/ethereum-optimism/optimism/op-program/client/claim"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
@@ -61,7 +62,7 @@ func Test_ProgramAction_HoloceneFrames(gt *testing.T) {
 
 		blocks := []uint{1, 2, 3}
 		targetHeadNumber := 3
-		for env.Engine.L2Chain().CurrentBlock().Number.Uint64() < uint64(targetHeadNumber) {
+		for bigs.Uint64Strict(env.Engine.L2Chain().CurrentBlock().Number) < uint64(targetHeadNumber) {
 			env.Sequencer.ActL2StartBlock(t)
 			// Send an L2 tx
 			env.Alice.L2.ActResetTxOpts(t)

--- a/op-e2e/actions/proofs/holocene_invalid_batch_test.go
+++ b/op-e2e/actions/proofs/holocene_invalid_batch_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/proofs/helpers"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
 	"github.com/ethereum-optimism/optimism/op-program/client/claim"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
@@ -178,8 +179,8 @@ func Test_ProgramAction_HoloceneInvalidBatch(gt *testing.T) {
 		}
 
 		targetHeadNumber := max(testCfg.Custom.blocks)
-		for env.Engine.L2Chain().CurrentBlock().Number.Uint64() < uint64(targetHeadNumber) {
-			parentNum := env.Engine.L2Chain().CurrentBlock().Number.Uint64()
+		for bigs.Uint64Strict(env.Engine.L2Chain().CurrentBlock().Number) < uint64(targetHeadNumber) {
+			parentNum := bigs.Uint64Strict(env.Engine.L2Chain().CurrentBlock().Number)
 
 			if testCfg.Custom.breachMaxSequencerDrift {
 				// prevent L1 origin from progressing

--- a/op-e2e/actions/proofs/isthmus_fork_test.go
+++ b/op-e2e/actions/proofs/isthmus_fork_test.go
@@ -356,7 +356,7 @@ func testIsthmusNetworkUpgradeTransactions(gt *testing.T, testCfg *helpers.TestC
 	// get latest block
 	latestBlock, err := ethCl.BlockByNumber(context.Background(), nil)
 	require.NoError(t, err)
-	require.Equal(t, sequencer.L2Unsafe().Number, latestBlock.Number().Uint64())
+	require.Equal(t, sequencer.L2Unsafe().Number, latestBlock.NumberU64())
 
 	transactions := latestBlock.Transactions()
 

--- a/op-e2e/actions/proofs/jovian_dafootprint_test.go
+++ b/op-e2e/actions/proofs/jovian_dafootprint_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/proofs/helpers"
 	"github.com/ethereum-optimism/optimism/op-e2e/bindings"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -107,7 +108,7 @@ func Test_ProgramAction_JovianDAFootprint(gt *testing.T) {
 			tx := types.MustSignNewTx(env.Dp.Secrets.Alice, signer, txData)
 
 			// Estimate incremental DA footprint if we include this tx.
-			est := tx.RollupCostData().EstimatedDASize().Uint64() * uint64(effectiveScalar)
+			est := bigs.Uint64Strict(tx.RollupCostData().EstimatedDASize()) * uint64(effectiveScalar)
 			if runningDAFootprint+est > gasLimit {
 				break
 			} else if isLowScalar && runningGas+tx.Gas() > gasLimit {
@@ -151,7 +152,7 @@ func Test_ProgramAction_JovianDAFootprint(gt *testing.T) {
 			require.NotNil(t, recScalar, "nil receipt DA footprint gas scalar")
 			require.EqualValues(t, effectiveScalar, *recScalar, "DA footprint gas scalar mismatch in receipt")
 
-			txDAFootprint := tx.RollupCostData().EstimatedDASize().Uint64() * uint64(effectiveScalar)
+			txDAFootprint := bigs.Uint64Strict(tx.RollupCostData().EstimatedDASize()) * uint64(effectiveScalar)
 			require.Equal(t, txDAFootprint, receipts[i].BlobGasUsed, "tx DA footprint mismatch with receipt")
 			expectedDAFootprint += txDAFootprint
 		}

--- a/op-e2e/actions/proofs/jovian_minbasefee_test.go
+++ b/op-e2e/actions/proofs/jovian_minbasefee_test.go
@@ -10,6 +10,7 @@ import (
 	actionsHelpers "github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/proofs/helpers"
 	"github.com/ethereum-optimism/optimism/op-e2e/bindings"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/consensus/misc/eip1559"
@@ -91,7 +92,7 @@ func Test_ProgramAction_JovianMinBaseFee(gt *testing.T) {
 		require.Equal(t, expectedJovianExtraDataWithMinFee, blockAfterSystemConfigChange.Extra(), "block should have updated Jovian extraData with min base fee")
 
 		// Verify base fee is clamped
-		require.GreaterOrEqual(t, blockAfterSystemConfigChange.BaseFee().Uint64(), minBaseFee, "base fee should be >= minimum base fee")
+		require.GreaterOrEqual(t, bigs.Uint64Strict(blockAfterSystemConfigChange.BaseFee()), minBaseFee, "base fee should be >= minimum base fee")
 
 		if !jovianAtGenesis {
 			// Verify Jovian fork activation occurred by checking for the activation log

--- a/op-e2e/actions/proofs/l1_lookback_test.go
+++ b/op-e2e/actions/proofs/l1_lookback_test.go
@@ -6,6 +6,7 @@ import (
 	actionsHelpers "github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/proofs/helpers"
 	"github.com/ethereum-optimism/optimism/op-program/client/claim"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
@@ -42,7 +43,7 @@ func runL1LookbackTest(gt *testing.T, testCfg *helpers.TestCfg[any]) {
 
 	// Ensure that the safe head has advanced to `NumL2Blocks`.
 	l2SafeHead := env.Engine.L2Chain().CurrentSafeBlock()
-	require.EqualValues(t, numL2Blocks, l2SafeHead.Number.Uint64())
+	require.EqualValues(t, numL2Blocks, bigs.Uint64Strict(l2SafeHead.Number))
 
 	// Run the FPP on the configured L2 block.
 	env.RunFaultProofProgramFromGenesis(t, numL2Blocks/2, testCfg.CheckResult, testCfg.InputParams...)
@@ -119,7 +120,7 @@ func runL1LookbackTest_ReopenChannel(gt *testing.T, testCfg *helpers.TestCfg[any
 
 	// Ensure that the safe head has advanced to `NumL2Blocks`.
 	l2SafeHead := env.Engine.L2Chain().CurrentSafeBlock()
-	require.EqualValues(t, numL2Blocks, l2SafeHead.Number.Uint64())
+	require.EqualValues(t, numL2Blocks, bigs.Uint64Strict(l2SafeHead.Number))
 
 	// Run the FPP on the configured L2 block.
 	env.RunFaultProofProgramFromGenesis(t, numL2Blocks/2, testCfg.CheckResult, testCfg.InputParams...)

--- a/op-e2e/actions/proofs/l1_prague_fork_test.go
+++ b/op-e2e/actions/proofs/l1_prague_fork_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
 	actionsHelpers "github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/proofs/helpers"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -68,10 +69,10 @@ func Test_ProgramAction_PragueForkAfterGenesis(gt *testing.T) {
 
 		requirePragueStatusOnL1 := func(active bool, block *types.Header) {
 			if active {
-				require.True(t, env.Sd.L1Cfg.Config.IsPrague(block.Number, block.Time), "Prague should be active at block", block.Number.Uint64())
+				require.True(t, env.Sd.L1Cfg.Config.IsPrague(block.Number, block.Time), "Prague should be active at block", bigs.Uint64Strict(block.Number))
 				require.NotNil(t, block.RequestsHash, "Prague header requests hash should be non-nil")
 			} else {
-				require.False(t, env.Sd.L1Cfg.Config.IsPrague(block.Number, block.Time), "Prague should not be active yet at block", block.Number.Uint64())
+				require.False(t, env.Sd.L1Cfg.Config.IsPrague(block.Number, block.Time), "Prague should not be active yet at block", bigs.Uint64Strict(block.Number))
 				require.Nil(t, block.RequestsHash, "Prague header requests hash should be nil")
 			}
 		}

--- a/op-e2e/actions/proofs/operator_fee_fix_transition_test.go
+++ b/op-e2e/actions/proofs/operator_fee_fix_transition_test.go
@@ -10,6 +10,7 @@ import (
 	actionsHelpers "github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/proofs/helpers"
 	"github.com/ethereum-optimism/optimism/op-e2e/bindings"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -79,9 +80,9 @@ func Test_ProgramAction_OperatorFeeFixTransition(gt *testing.T) {
 			gpoOperatorFee, err := gpo.GetOperatorFee(nil, new(big.Int).SetUint64(gasUsed))
 			require.NoError(t, err)
 			if isJovian {
-				require.Equal(t, expectedOperatorFeeJovian, gpoOperatorFee.Uint64())
+				require.Equal(t, expectedOperatorFeeJovian, bigs.Uint64Strict(gpoOperatorFee))
 			} else {
-				require.Equal(t, expectedOperatorFeeIsthmus, gpoOperatorFee.Uint64())
+				require.Equal(t, expectedOperatorFeeIsthmus, bigs.Uint64Strict(gpoOperatorFee))
 			}
 		}
 
@@ -111,7 +112,7 @@ func Test_ProgramAction_OperatorFeeFixTransition(gt *testing.T) {
 		}
 
 		checkFeeVaultChanges := func(initialBalance *big.Int, finalBalance *big.Int, expectedOperatorFee uint64) {
-			delta := new(big.Int).Sub(finalBalance, initialBalance).Uint64()
+			delta := bigs.Uint64Strict(new(big.Int).Sub(finalBalance, initialBalance))
 			require.Equal(t, expectedOperatorFee, delta)
 		}
 

--- a/op-e2e/actions/proofs/operator_fee_test.go
+++ b/op-e2e/actions/proofs/operator_fee_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/proofs/helpers"
 	"github.com/ethereum-optimism/optimism/op-e2e/bindings"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -388,7 +389,7 @@ func Test_ProgramAction_OperatorFeeConsistency(gt *testing.T) {
 			require.Equal(t, eth.HeaderBlockID(l2SafeHead), eth.HeaderBlockID(l2UnsafeHead), "derivation leads to the same block")
 		}
 
-		env.RunFaultProofProgramFromGenesis(t, l2SafeHead.Number.Uint64(), testCfg.CheckResult, testCfg.InputParams...)
+		env.RunFaultProofProgramFromGenesis(t, bigs.Uint64Strict(l2SafeHead.Number), testCfg.CheckResult, testCfg.InputParams...)
 	}
 
 	matrix := helpers.NewMatrix[testCase]()

--- a/op-e2e/actions/proofs/pectra_blob_schedule_test.go
+++ b/op-e2e/actions/proofs/pectra_blob_schedule_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/stretchr/testify/require"
 
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/consensus/misc/eip4844"
@@ -85,7 +86,7 @@ func testPectraBlobSchedule(gt *testing.T, testCfg *helpers.TestCfg[any]) {
 	cancunBBF1 := eth.CalcBlobFeeCancun(*l1_1.ExcessBlobGas)
 	pragueBBF1 := eip4844.CalcBlobFee(env.Sd.L1Cfg.Config, l1_1)
 	// Make sure they differ.
-	require.Less(t, pragueBBF1.Uint64(), cancunBBF1.Uint64())
+	require.Less(t, bigs.Uint64Strict(pragueBBF1), bigs.Uint64Strict(cancunBBF1))
 	opts := &bind.CallOpts{}
 	bbf1, err := l1Block.BlobBaseFee(opts)
 	require.NoError(t, err)
@@ -115,7 +116,7 @@ func testPectraBlobSchedule(gt *testing.T, testCfg *helpers.TestCfg[any]) {
 
 	cancunBBF2 := eth.CalcBlobFeeCancun(*l1_2.ExcessBlobGas)
 	pragueBBF2 := eip4844.CalcBlobFee(env.Sd.L1Cfg.Config, l1_2)
-	require.Less(t, pragueBBF2.Uint64(), cancunBBF2.Uint64())
+	require.Less(t, bigs.Uint64Strict(pragueBBF2), bigs.Uint64Strict(cancunBBF2))
 	bbf2, err := l1Block.BlobBaseFee(opts)
 	require.NoError(t, err)
 	t.Logf("BlobBaseFee2: %v", bbf2)
@@ -129,7 +130,7 @@ func testPectraBlobSchedule(gt *testing.T, testCfg *helpers.TestCfg[any]) {
 	l2SafeHead := env.Engine.L2Chain().CurrentSafeBlock()
 	require.Equal(t, eth.HeaderBlockID(l2SafeHead), eth.HeaderBlockID(l2UnsafeHead), "derivation leads to the same block")
 
-	env.RunFaultProofProgramFromGenesis(t, l2SafeHead.Number.Uint64(), testCfg.CheckResult, testCfg.InputParams...)
+	env.RunFaultProofProgramFromGenesis(t, bigs.Uint64Strict(l2SafeHead.Number), testCfg.CheckResult, testCfg.InputParams...)
 }
 
 func ptr[T any](v T) *T {

--- a/op-e2e/actions/proofs/precompile_test.go
+++ b/op-e2e/actions/proofs/precompile_test.go
@@ -16,6 +16,7 @@ import (
 	hostcommon "github.com/ethereum-optimism/optimism/op-program/host/common"
 	hostconfig "github.com/ethereum-optimism/optimism/op-program/host/config"
 	"github.com/ethereum-optimism/optimism/op-program/host/kvstore"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/vm"
@@ -75,11 +76,11 @@ func runPrecompileHintTest(gt *testing.T, testCase PrecompileTestFixture, testCf
 	l2SafeHead := env.Engine.L2Chain().CurrentSafeBlock()
 
 	// Ensure there is only 1 block on L1.
-	require.Equal(t, uint64(1), l1Head.Number.Uint64())
+	require.Equal(t, uint64(1), bigs.Uint64Strict(l1Head.Number))
 	// Ensure the block is marked as safe before we attempt to fault prove it.
-	require.Equal(t, uint64(1), l2SafeHead.Number.Uint64())
+	require.Equal(t, uint64(1), bigs.Uint64Strict(l2SafeHead.Number))
 
-	defaultParam := helpers.WithPreInteropDefaults(t, l2SafeHead.Number.Uint64(), env.Sequencer.L2Verifier, env.Engine)
+	defaultParam := helpers.WithPreInteropDefaults(t, bigs.Uint64Strict(l2SafeHead.Number), env.Sequencer.L2Verifier, env.Engine)
 	fixtureInputParams := []helpers.FixtureInputParam{defaultParam, helpers.WithL1Head(l1Head.Hash())}
 	var fixtureInputs helpers.FixtureInputs
 	for _, apply := range fixtureInputParams {
@@ -241,16 +242,16 @@ func runPrecompileTest(gt *testing.T, testCfg *helpers.TestCfg[PrecompileTestFix
 	l1Head := env.Miner.L1Chain().CurrentBlock()
 	l2SafeHead := env.Engine.L2Chain().CurrentSafeBlock()
 
-	require.Equal(t, uint64(1), l1Head.Number.Uint64())
+	require.Equal(t, uint64(1), bigs.Uint64Strict(l1Head.Number))
 	// Ensure the block is marked as safe before we attempt to fault prove it.
-	require.Equal(t, uint64(2), l2SafeHead.Number.Uint64())
+	require.Equal(t, uint64(2), bigs.Uint64Strict(l2SafeHead.Number))
 
-	defaultParam := helpers.WithPreInteropDefaults(t, l2SafeHead.Number.Uint64(), env.Sequencer.L2Verifier, env.Engine)
+	defaultParam := helpers.WithPreInteropDefaults(t, bigs.Uint64Strict(l2SafeHead.Number), env.Sequencer.L2Verifier, env.Engine)
 	fixtureInputParams := []helpers.FixtureInputParam{defaultParam, helpers.WithL1Head(l1Head.Hash())}
 	var fixtureInputs helpers.FixtureInputs
 	for _, apply := range fixtureInputParams {
 		apply(&fixtureInputs)
 	}
 
-	env.RunFaultProofProgram(t, l2SafeHead.Number.Uint64(), helpers.ExpectNoError(), fixtureInputParams...)
+	env.RunFaultProofProgram(t, bigs.Uint64Strict(l2SafeHead.Number), helpers.ExpectNoError(), fixtureInputParams...)
 }

--- a/op-e2e/actions/proofs/sequence_window_expiry_test.go
+++ b/op-e2e/actions/proofs/sequence_window_expiry_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/proofs/helpers"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
 	"github.com/ethereum-optimism/optimism/op-program/client/claim"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
@@ -55,7 +56,7 @@ func runSequenceWindowExpireTest(gt *testing.T, testCfg *helpers.TestCfg[any]) {
 
 	// Ensure the safe head is still 0.
 	l2SafeHead := env.Engine.L2Chain().CurrentSafeBlock()
-	require.EqualValues(t, 0, l2SafeHead.Number.Uint64())
+	require.EqualValues(t, 0, bigs.Uint64Strict(l2SafeHead.Number))
 
 	// Ask the sequencer to derive the deposit-only L2 chain.
 	env.Sequencer.ActL1HeadSignal(t)
@@ -63,10 +64,10 @@ func runSequenceWindowExpireTest(gt *testing.T, testCfg *helpers.TestCfg[any]) {
 
 	// Ensure the safe head advanced forcefully.
 	l2SafeHead = env.Engine.L2Chain().CurrentSafeBlock()
-	require.Greater(t, l2SafeHead.Number.Uint64(), uint64(0),
+	require.Greater(t, bigs.Uint64Strict(l2SafeHead.Number), uint64(0),
 		"The safe head failed to progress after the sequencing window expired (expected deposit-only blocks to be derived).")
 
-	env.RunFaultProofProgram(t, l2SafeHead.Number.Uint64()/2, testCfg.CheckResult, testCfg.InputParams...)
+	env.RunFaultProofProgram(t, bigs.Uint64Strict(l2SafeHead.Number)/2, testCfg.CheckResult, testCfg.InputParams...)
 
 	// Set recover mode on the sequencer:
 	env.Sequencer.ActSetRecoverMode(t, true)
@@ -200,7 +201,7 @@ func runSequenceWindowExpire_ChannelCloseAfterWindowExpiry_Test(gt *testing.T, t
 
 	// Ensure the safe head is still 0.
 	l2SafeHead := env.Engine.L2Chain().CurrentSafeBlock()
-	require.EqualValues(t, 0, l2SafeHead.Number.Uint64())
+	require.EqualValues(t, 0, bigs.Uint64Strict(l2SafeHead.Number))
 
 	// Cache the next frame data before expiring the sequence window, but don't submit it yet.
 	env.Batcher.ActL2BatchBuffer(t)
@@ -232,7 +233,7 @@ func runSequenceWindowExpire_ChannelCloseAfterWindowExpiry_Test(gt *testing.T, t
 
 	// Ensure the safe head is still 0.
 	l2SafeHead = env.Engine.L2Chain().CurrentSafeBlock()
-	require.EqualValues(t, 0, l2SafeHead.Number.Uint64())
+	require.EqualValues(t, 0, bigs.Uint64Strict(l2SafeHead.Number))
 
 	// Ask the sequencer to derive the deposit-only L2 chain.
 	env.Sequencer.ActL1HeadSignal(t)
@@ -240,10 +241,10 @@ func runSequenceWindowExpire_ChannelCloseAfterWindowExpiry_Test(gt *testing.T, t
 
 	// Ensure the safe head advanced forcefully.
 	l2SafeHead = env.Engine.L2Chain().CurrentSafeBlock()
-	require.Greater(t, l2SafeHead.Number.Uint64(), uint64(0))
+	require.Greater(t, bigs.Uint64Strict(l2SafeHead.Number), uint64(0))
 
 	// Run the FPP on one of the auto-derived blocks.
-	env.RunFaultProofProgram(t, l2SafeHead.Number.Uint64()/2, testCfg.CheckResult, testCfg.InputParams...)
+	env.RunFaultProofProgram(t, bigs.Uint64Strict(l2SafeHead.Number)/2, testCfg.CheckResult, testCfg.InputParams...)
 }
 
 func Test_ProgramAction_SequenceWindowExpired(gt *testing.T) {

--- a/op-e2e/actions/proofs/simple_program_test.go
+++ b/op-e2e/actions/proofs/simple_program_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
 	actionsHelpers "github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/proofs/helpers"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/stretchr/testify/require"
 )
@@ -46,11 +47,11 @@ func runSimpleProgramTest(gt *testing.T, testCfg *helpers.TestCfg[any]) {
 	l2SafeHead := env.Engine.L2Chain().CurrentSafeBlock()
 
 	// Ensure there is only 1 block on L1.
-	require.Equal(t, uint64(1), l1Head.Number.Uint64())
+	require.Equal(t, uint64(1), bigs.Uint64Strict(l1Head.Number))
 	// Ensure the block is marked as safe before we attempt to fault prove it.
-	require.Equal(t, uint64(1), l2SafeHead.Number.Uint64())
+	require.Equal(t, uint64(1), bigs.Uint64Strict(l2SafeHead.Number))
 
-	env.RunFaultProofProgramFromGenesis(t, l2SafeHead.Number.Uint64(), testCfg.CheckResult, testCfg.InputParams...)
+	env.RunFaultProofProgramFromGenesis(t, bigs.Uint64Strict(l2SafeHead.Number), testCfg.CheckResult, testCfg.InputParams...)
 }
 
 func Test_ProgramAction_SimpleEmptyChain(gt *testing.T) {

--- a/op-e2e/actions/proofs/trace_extension_test.go
+++ b/op-e2e/actions/proofs/trace_extension_test.go
@@ -6,6 +6,7 @@ import (
 	actionsHelpers "github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/proofs/helpers"
 	"github.com/ethereum-optimism/optimism/op-program/client/claim"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
@@ -24,14 +25,14 @@ func runSafeHeadTraceExtensionTest(gt *testing.T, testCfg *helpers.TestCfg[any])
 	l2SafeHead := env.Engine.L2Chain().CurrentSafeBlock()
 
 	// Ensure there is only 1 block on L1.
-	require.Equal(t, uint64(1), l1Head.Number.Uint64())
+	require.Equal(t, uint64(1), bigs.Uint64Strict(l1Head.Number))
 	// Ensure the block is marked as safe before we attempt to fault prove it.
-	require.Equal(t, uint64(1), l2SafeHead.Number.Uint64())
+	require.Equal(t, uint64(1), bigs.Uint64Strict(l2SafeHead.Number))
 
 	// Set claimed L2 block number to be past the actual safe head (still using the safe head output as the claim)
-	params := []helpers.FixtureInputParam{helpers.WithL2BlockNumber(l2SafeHead.Number.Uint64() + 1)}
+	params := []helpers.FixtureInputParam{helpers.WithL2BlockNumber(bigs.Uint64Strict(l2SafeHead.Number) + 1)}
 	params = append(params, testCfg.InputParams...)
-	env.RunFaultProofProgram(t, l2SafeHead.Number.Uint64(), testCfg.CheckResult, params...)
+	env.RunFaultProofProgram(t, bigs.Uint64Strict(l2SafeHead.Number), testCfg.CheckResult, params...)
 }
 
 // Test_ProgramAction_SafeHeadTraceExtension checks that op-program correctly handles the trace extension case where

--- a/op-e2e/actions/proposer/l2_proposer_test.go
+++ b/op-e2e/actions/proposer/l2_proposer_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/bindings"
 	"github.com/ethereum-optimism/optimism/op-e2e/bindingspreview"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 )
@@ -105,7 +106,7 @@ func runProposerTest(gt *testing.T, deltaTimeOffset *hexutil.Uint64, allocType c
 	require.NoError(t, err)
 	gameCount, err := disputeGameFactoryContract.GameCount(&bind.CallOpts{})
 	require.NoError(t, err)
-	require.Greater(t, gameCount.Uint64(), uint64(0), "game count must be greater than 0")
+	require.Greater(t, bigs.Uint64Strict(gameCount), uint64(0), "game count must be greater than 0")
 	latestGames, err := disputeGameFactoryContract.FindLatestGames(&bind.CallOpts{}, respectedGameType, new(big.Int).Sub(gameCount, common.Big1), common.Big1)
 	require.NoError(t, err)
 	require.Greater(t, len(latestGames), 0, "latest games must be greater than 0")
@@ -115,7 +116,7 @@ func runProposerTest(gt *testing.T, deltaTimeOffset *hexutil.Uint64, allocType c
 	block, err := seqEngine.EthClient().BlockByNumber(t.Ctx(), gameBlockNumber)
 	require.NoError(t, err)
 	require.Less(t, block.Time(), latestGame.Timestamp, "output is registered with L1 timestamp of proposal tx, past L2 block")
-	outputComputed, err := sequencer.RollupClient().OutputAtBlock(t.Ctx(), gameBlockNumber.Uint64())
+	outputComputed, err := sequencer.RollupClient().OutputAtBlock(t.Ctx(), bigs.Uint64Strict(gameBlockNumber))
 	require.NoError(t, err)
 	require.Equal(t, eth.Bytes32(latestGame.RootClaim), outputComputed.OutputRoot, "output roots must match")
 }

--- a/op-e2e/actions/safedb/safedb_test.go
+++ b/op-e2e/actions/safedb/safedb_test.go
@@ -6,6 +6,7 @@ import (
 
 	actionsHelpers "github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/safedb/helpers"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -44,7 +45,7 @@ func TestRecordSafeHeadUpdates(gt *testing.T) {
 
 	// Verify the safe head is recorded
 	l1Head := miner.L1Chain().CurrentBlock()
-	firstSafeHeadUpdateL1Block := l1Head.Number.Uint64()
+	firstSafeHeadUpdateL1Block := bigs.Uint64Strict(l1Head.Number)
 	response, err := verifier.RollupClient().SafeHeadAtL1Block(context.Background(), firstSafeHeadUpdateL1Block)
 	require.NoError(t, err)
 	require.Equal(t, eth.HeaderBlockID(l1Head), response.L1Block)
@@ -103,7 +104,7 @@ func TestRecordSafeHeadUpdates(gt *testing.T) {
 
 	// Verify the safe head is recorded again
 	l1Head = miner.L1Chain().CurrentBlock()
-	firstSafeHeadUpdateL1Block = l1Head.Number.Uint64()
+	firstSafeHeadUpdateL1Block = bigs.Uint64Strict(l1Head.Number)
 	response, err = verifier.RollupClient().SafeHeadAtL1Block(context.Background(), firstSafeHeadUpdateL1Block)
 	require.NoError(t, err)
 	require.Equal(t, eth.HeaderBlockID(l1Head), response.L1Block)

--- a/op-e2e/actions/sync/sync_test.go
+++ b/op-e2e/actions/sync/sync_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	engine2 "github.com/ethereum-optimism/optimism/op-node/rollup/engine"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/event"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
@@ -133,8 +134,8 @@ func FinalizeWhileSyncing(gt *testing.T, deltaTimeOffset *hexutil.Uint64) {
 	}
 	l1Head := miner.L1Chain().CurrentHeader()
 	// finalize all of L1
-	miner.ActL1Safe(t, l1Head.Number.Uint64())
-	miner.ActL1Finalize(t, l1Head.Number.Uint64())
+	miner.ActL1Safe(t, bigs.Uint64Strict(l1Head.Number))
+	miner.ActL1Finalize(t, bigs.Uint64Strict(l1Head.Number))
 
 	// Now signal L1 finality to the verifier, while the verifier is not synced.
 	verifier.ActL1HeadSignal(t)

--- a/op-e2e/actions/upgrades/ecotone_fork_test.go
+++ b/op-e2e/actions/upgrades/ecotone_fork_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/bindings"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 )
 
@@ -87,7 +88,7 @@ func TestEcotoneNetworkUpgradeTransactions(gt *testing.T) {
 	// get latest block
 	latestBlock, err := ethCl.BlockByNumber(context.Background(), nil)
 	require.NoError(t, err)
-	require.Equal(t, sequencer.L2Unsafe().Number, latestBlock.Number().Uint64())
+	require.Equal(t, sequencer.L2Unsafe().Number, latestBlock.NumberU64())
 
 	transactions := latestBlock.Transactions()
 	// L1Block: 1 set-L1-info + 2 deploys + 2 upgradeTo + 1 enable ecotone on GPO + 1 4788 deploy
@@ -133,7 +134,7 @@ func TestEcotoneNetworkUpgradeTransactions(gt *testing.T) {
 	// The L1 info tx does not get included until after the Ecotone upgrade.
 	// The scalars are thus empty during activation, and only deposits are included, so the L1 fee is unused.
 	require.True(t, cost.IsUint64())
-	require.Equal(t, cost.Uint64(), uint64(0), "expecting zero scalars within activation block")
+	require.Equal(t, bigs.Uint64Strict(cost), uint64(0), "expecting zero scalars within activation block")
 
 	// Check that Ecotone was activated
 	isEcotone, err := gasPriceOracle.IsEcotone(nil)
@@ -159,7 +160,7 @@ func TestEcotoneNetworkUpgradeTransactions(gt *testing.T) {
 		require.NoError(t, err)
 		timeBig := new(big.Int).SetBytes(timeValue)
 		require.True(t, timeBig.IsUint64())
-		require.Equal(t, expectedTime, timeBig.Uint64(), msg)
+		require.Equal(t, expectedTime, bigs.Uint64Strict(timeBig), msg)
 	}
 	// The header will always have the beacon-block-root, at the very start.
 	require.NotNil(t, latestBlock.BeaconRoot())
@@ -198,7 +199,7 @@ func TestEcotoneNetworkUpgradeTransactions(gt *testing.T) {
 	require.NoError(t, err)
 	// The GPO getL1Fee contract returns the L1 fee with approximate signature overhead pre-included,
 	// like the pre-regolith L1 fee. We do the full fee check below. Just sanity check it is not zero anymore first.
-	require.Greater(t, cost.Uint64(), uint64(0), "expecting non-zero scalars after activation block")
+	require.Greater(t, bigs.Uint64Strict(cost), uint64(0), "expecting non-zero scalars after activation block")
 
 	// Get L1Block info
 	l1Block, err := bindings.NewL1BlockCaller(predeploys.L1BlockAddr, ethCl)
@@ -211,7 +212,7 @@ func TestEcotoneNetworkUpgradeTransactions(gt *testing.T) {
 	require.NoError(t, err)
 	l1Basefee, err := l1Block.Basefee(nil)
 	require.NoError(t, err)
-	require.Equal(t, l1OriginBlock.BaseFee().Uint64(), l1Basefee.Uint64(), "basefee must match")
+	require.Equal(t, bigs.Uint64Strict(l1OriginBlock.BaseFee()), bigs.Uint64Strict(l1Basefee), "basefee must match")
 
 	// calldataGas*(l1BaseFee*16*l1BaseFeeScalar + l1BlobBaseFee*l1BlobBaseFeeScalar)/16e6
 	// _getCalldataGas in GPO adds the cost of 68 non-zero bytes for signature/rlp overhead.

--- a/op-e2e/actions/upgrades/fjord_fork_test.go
+++ b/op-e2e/actions/upgrades/fjord_fork_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/bindings"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 )
 
@@ -62,7 +63,7 @@ func TestFjordNetworkUpgradeTransactions(gt *testing.T) {
 	// get latest block
 	latestBlock, err := ethCl.BlockByNumber(context.Background(), nil)
 	require.NoError(t, err)
-	require.Equal(t, sequencer.L2Unsafe().Number, latestBlock.Number().Uint64())
+	require.Equal(t, sequencer.L2Unsafe().Number, latestBlock.NumberU64())
 
 	transactions := latestBlock.Transactions()
 	// L1Block: 1 set-L1-info + 1 deploys + 1 upgradeTo + 1 enable fjord on GPO
@@ -98,7 +99,7 @@ func TestFjordNetworkUpgradeTransactions(gt *testing.T) {
 
 	gpoL1GasUsed, err := gasPriceOracle.GetL1GasUsed(&bind.CallOpts{}, txData)
 	require.NoError(t, err)
-	require.Equal(gt, uint64(1_888), gpoL1GasUsed.Uint64())
+	require.Equal(gt, uint64(1_888), bigs.Uint64Strict(gpoL1GasUsed))
 
 	// Check that GetL1Fee takes into account fast LZ
 	gpoFee, err := gasPriceOracle.GetL1Fee(&bind.CallOpts{}, txData)
@@ -107,7 +108,7 @@ func TestFjordNetworkUpgradeTransactions(gt *testing.T) {
 	gethFee := fjordL1Cost(t, gasPriceOracle, types.RollupCostData{
 		FastLzSize: uint64(types.FlzCompressLen(txData) + 68),
 	})
-	require.Equal(t, gethFee.Uint64(), gpoFee.Uint64())
+	require.Equal(t, bigs.Uint64Strict(gethFee), bigs.Uint64Strict(gpoFee))
 
 	// Check that L1FeeUpperBound works
 	upperBound, err := gasPriceOracle.GetL1FeeUpperBound(&bind.CallOpts{}, big.NewInt(int64(len(txData))))
@@ -117,7 +118,7 @@ func TestFjordNetworkUpgradeTransactions(gt *testing.T) {
 	flzUpperBound := uint64(txLen + txLen/255 + 16)
 
 	upperBoundCost := fjordL1Cost(t, gasPriceOracle, types.RollupCostData{FastLzSize: flzUpperBound})
-	require.Equal(t, upperBoundCost.Uint64(), upperBound.Uint64())
+	require.Equal(t, bigs.Uint64Strict(upperBoundCost), bigs.Uint64Strict(upperBound))
 }
 
 func fjordL1Cost(t require.TestingT, gasPriceOracle *bindings.GasPriceOracleCaller, rollupCostData types.RollupCostData) *big.Int {

--- a/op-e2e/e2eutils/disputegame/cannon_helper.go
+++ b/op-e2e/e2eutils/disputegame/cannon_helper.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/transactions"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
 	preimage "github.com/ethereum-optimism/optimism/op-preimage"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
@@ -316,7 +317,7 @@ func (g *CannonHelper) ChallengeToPreimageLoadAtTarget(ctx context.Context, cann
 	provider, _, outputRootClaim := cannonTraceProviderFunc()
 	splitDepth := g.splitGame.SplitDepth(ctx)
 	execDepth := g.splitGame.ExecDepth(ctx)
-	g.require.NotEqual(outputRootClaim.Position.TraceIndex(execDepth).Uint64(), targetTraceIndex, "cannot move to defend a terminal trace index")
+	g.require.NotEqual(bigs.Uint64Strict(outputRootClaim.Position.TraceIndex(execDepth)), targetTraceIndex, "cannot move to defend a terminal trace index")
 	g.require.EqualValues(splitDepth+1, outputRootClaim.Depth(), "supplied claim must be the root of an execution game")
 	g.require.EqualValues(execDepth%2, 1, "execution game depth must be odd") // since we're challenging the execution root claim
 
@@ -387,7 +388,7 @@ func (g *CannonHelper) VerifyPreimageAtTarget(ctx context.Context, cannonTracePr
 	provider, localContext, outputRootClaim := cannonTraceProviderFunc()
 
 	pos := types.NewPosition(execDepth, new(big.Int).SetUint64(targetTraceIndex))
-	g.require.Equal(targetTraceIndex, pos.TraceIndex(execDepth).Uint64())
+	g.require.Equal(targetTraceIndex, bigs.Uint64Strict(pos.TraceIndex(execDepth)))
 
 	prestate, proof, oracleData, err := provider.GetStepData(ctx, pos)
 	g.require.NoError(err, "Failed to get step data")
@@ -492,22 +493,22 @@ func traceBisection(
 	execClaimPosition, err := claim.Position.RelativeToAncestorAtDepth(splitDepth + 1)
 	require.NoError(t, err)
 
-	claimTraceIndex := execClaimPosition.TraceIndex(execDepth).Uint64()
+	claimTraceIndex := bigs.Uint64Strict(execClaimPosition.TraceIndex(execDepth))
 	t.Logf("Bisecting: Into targetTraceIndex %v: claimIndex=%v at depth=%v. claimPosition=%v execClaimPosition=%v claimTraceIndex=%v",
 		targetTraceIndex, claim.Index, claim.Depth(), claim.Position, execClaimPosition, claimTraceIndex)
 
 	// We always want to position ourselves such that the challenger generates proofs for the targetTraceIndex as prestate
 	if execClaimPosition.Depth() == execDepth-1 {
-		if execClaimPosition.TraceIndex(execDepth).Uint64() == targetTraceIndex {
+		if bigs.Uint64Strict(execClaimPosition.TraceIndex(execDepth)) == targetTraceIndex {
 			newPosition := execClaimPosition.Attack()
 			correct, err := provider.Get(ctx, newPosition)
 			require.NoError(t, err)
 			t.Logf("Bisecting: Attack correctly for step at newPosition=%v execIndexAtDepth=%v", newPosition, newPosition.TraceIndex(execDepth))
 			return claim.Attack(ctx, correct)
-		} else if execClaimPosition.TraceIndex(execDepth).Uint64() > targetTraceIndex {
+		} else if bigs.Uint64Strict(execClaimPosition.TraceIndex(execDepth)) > targetTraceIndex {
 			t.Logf("Bisecting: Attack incorrectly for step")
 			return claim.Attack(ctx, common.Hash{0xdd})
-		} else if execClaimPosition.TraceIndex(execDepth).Uint64()+1 == targetTraceIndex {
+		} else if bigs.Uint64Strict(execClaimPosition.TraceIndex(execDepth))+1 == targetTraceIndex {
 			t.Logf("Bisecting: Defend incorrectly for step")
 			return claim.Defend(ctx, common.Hash{0xcc})
 		} else {
@@ -521,9 +522,9 @@ func traceBisection(
 
 	// Attack or Defend depending on whether the claim we're responding to is to the left or right of the trace index
 	// Induce the honest challenger to attack or defend depending on whether our new position will be to the left or right of the trace index
-	if execClaimPosition.TraceIndex(execDepth).Uint64() < targetTraceIndex && claim.Depth() != splitDepth+1 {
+	if bigs.Uint64Strict(execClaimPosition.TraceIndex(execDepth)) < targetTraceIndex && claim.Depth() != splitDepth+1 {
 		newPosition := execClaimPosition.Defend()
-		if newPosition.TraceIndex(execDepth).Uint64() < targetTraceIndex {
+		if bigs.Uint64Strict(newPosition.TraceIndex(execDepth)) < targetTraceIndex {
 			t.Logf("Bisecting: Defend correct. newPosition=%v execIndexAtDepth=%v", newPosition, newPosition.TraceIndex(execDepth))
 			correct, err := provider.Get(ctx, newPosition)
 			require.NoError(t, err)
@@ -534,7 +535,7 @@ func traceBisection(
 		}
 	} else {
 		newPosition := execClaimPosition.Attack()
-		if newPosition.TraceIndex(execDepth).Uint64() < targetTraceIndex {
+		if bigs.Uint64Strict(newPosition.TraceIndex(execDepth)) < targetTraceIndex {
 			t.Logf("Bisecting: Attack correct. newPosition=%v execIndexAtDepth=%v", newPosition, newPosition.TraceIndex(execDepth))
 			correct, err := provider.Get(ctx, newPosition)
 			require.NoError(t, err)
@@ -558,10 +559,10 @@ func topGameTraceBisection(
 ) *ClaimHelper {
 	require.True(t, claim.IsOutputRoot(ctx), "bisecting a bottom claim is not supported")
 
-	claimTraceIndex := claim.Position.TraceIndex(splitDepth).Uint64()
+	claimTraceIndex := bigs.Uint64Strict(claim.Position.TraceIndex(splitDepth))
 	if claimTraceIndex < targetTraceIndex {
 		newPosition := claim.Position.Defend()
-		if newPosition.TraceIndex(splitDepth).Uint64() < targetTraceIndex {
+		if bigs.Uint64Strict(newPosition.TraceIndex(splitDepth)) < targetTraceIndex {
 			response, err := provider.Get(ctx, newPosition)
 			require.NoError(t, err)
 			return claim.Defend(ctx, response)
@@ -570,7 +571,7 @@ func topGameTraceBisection(
 		}
 	} else {
 		newPosition := claim.Position.Attack()
-		if newPosition.TraceIndex(splitDepth).Uint64() < targetTraceIndex {
+		if bigs.Uint64Strict(newPosition.TraceIndex(splitDepth)) < targetTraceIndex {
 			response, err := provider.Get(ctx, newPosition)
 			require.NoError(t, err)
 			return claim.Attack(ctx, response)

--- a/op-e2e/e2eutils/disputegame/preimage/preimage_helper.go
+++ b/op-e2e/e2eutils/disputegame/preimage/preimage_helper.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-challenger/game/keccak/types"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/transactions"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
@@ -90,9 +91,9 @@ func (h *Helper) UploadLargePreimage(ctx context.Context, dataSize int, modifier
 			h.require.NoError(err)
 		}
 		for _, modifier := range modifiers {
-			modifier(startBlock.Uint64(), &inputData)
+			modifier(bigs.Uint64Strict(startBlock), &inputData)
 		}
-		h.t.Logf("Uploading %v parts of preimage %v starting at block %v of about %v Finalize: %v", len(inputData.Commitments), uuid.Uint64(), startBlock.Uint64(), totalBlocks, inputData.Finalize)
+		h.t.Logf("Uploading %v parts of preimage %v starting at block %v of about %v Finalize: %v", len(inputData.Commitments), bigs.Uint64Strict(uuid), bigs.Uint64Strict(startBlock), totalBlocks, inputData.Finalize)
 		tx, err := h.oracle.AddLeaves(uuid, startBlock, inputData.Input, inputData.Commitments, inputData.Finalize)
 		h.require.NoError(err)
 		// Can't use EstimateGas because all the transactions will be sent in a batch, and the contract checks the

--- a/op-e2e/e2eutils/disputegame/split_game_helper.go
+++ b/op-e2e/e2eutils/disputegame/split_game_helper.go
@@ -14,6 +14,7 @@ import (
 	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/transactions"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/errutil"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
@@ -93,7 +94,7 @@ func (g *SplitGameHelper) WaitForCorrectClaim(ctx context.Context, claimIdx int6
 	g.WaitForClaimCount(ctx, claimIdx+1)
 	claim := g.getClaim(ctx, claimIdx)
 	value := g.correctClaimValue(ctx, claim.Position)
-	g.Require.EqualValuesf(value, claim.Value, "Incorrect claim value at claim %v at position %v", claimIdx, claim.Position.ToGIndex().Uint64())
+	g.Require.EqualValuesf(value, claim.Value, "Incorrect claim value at claim %v at position %v", claimIdx, bigs.Uint64Strict(claim.Position.ToGIndex()))
 }
 
 func (g *SplitGameHelper) correctClaimValue(ctx context.Context, pos types.Position) common.Hash {
@@ -350,9 +351,9 @@ func (g *SplitGameHelper) WaitForInactivity(ctx context.Context, numInactiveBloc
 		select {
 		case head := <-headCh:
 			if lastActiveBlock == 0 {
-				lastActiveBlock = head.Number.Uint64()
+				lastActiveBlock = bigs.Uint64Strict(head.Number)
 				continue
-			} else if lastActiveBlock+uint64(numInactiveBlocks) < head.Number.Uint64() {
+			} else if lastActiveBlock+uint64(numInactiveBlocks) < bigs.Uint64Strict(head.Number) {
 				return
 			}
 			block, err := g.Client.BlockByNumber(ctx, head.Number)
@@ -365,7 +366,7 @@ func (g *SplitGameHelper) WaitForInactivity(ctx context.Context, numInactiveBloc
 			}
 			if numActions != 0 {
 				g.T.Logf("Game %v has %v actions in block %d. Resetting inactivity timeout", g.Addr, numActions, block.NumberU64())
-				lastActiveBlock = head.Number.Uint64()
+				lastActiveBlock = bigs.Uint64Strict(head.Number)
 			}
 		case err := <-headSub.Err():
 			g.Require.NoError(err)

--- a/op-e2e/e2eutils/disputegame/super_cannon_helper.go
+++ b/op-e2e/e2eutils/disputegame/super_cannon_helper.go
@@ -18,6 +18,7 @@ import (
 	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-challenger/metrics"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/challenger"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -104,7 +105,7 @@ func (g *SuperCannonGameHelper) ChallengeToPreimageLoad(ctx context.Context, top
 
 	splitDepth := g.splitGame.SplitDepth(ctx)
 	execDepth := g.splitGame.ExecDepth(ctx)
-	g.require.NotEqual(topGameLeaf.Position.TraceIndex(execDepth).Uint64(), targetTraceIndex, "cannot move to defend a terminal trace index")
+	g.require.NotEqual(bigs.Uint64Strict(topGameLeaf.Position.TraceIndex(execDepth)), targetTraceIndex, "cannot move to defend a terminal trace index")
 	g.require.EqualValues(splitDepth+1, topGameLeaf.Depth(), "supplied claim must be the root of an execution game")
 	g.require.EqualValues(execDepth%2, 0, "execution game depth must be even") // since we're supporting the execution root claim
 

--- a/op-e2e/e2eutils/geth/fakepos.go
+++ b/op-e2e/e2eutils/geth/fakepos.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
 
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/clock"
 	opeth "github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
@@ -117,15 +118,15 @@ func (f *FakePoS) Start() error {
 				if err != nil { // fallback to finalized if nothing is safe
 					safe = finalized
 				}
-				if head.Number.Uint64() > f.finalizedDistance { // progress finalized block, if we can
-					finalized, err = f.eth.HeaderByNumber(context.Background(), new(big.Int).SetUint64(head.Number.Uint64()-f.finalizedDistance))
+				if bigs.Uint64Strict(head.Number) > f.finalizedDistance { // progress finalized block, if we can
+					finalized, err = f.eth.HeaderByNumber(context.Background(), new(big.Int).SetUint64(bigs.Uint64Strict(head.Number)-f.finalizedDistance))
 					if err != nil {
 						f.log.Warn("Failed to finalized header", "err", err)
 						continue
 					}
 				}
-				if head.Number.Uint64() > f.safeDistance { // progress safe block, if we can
-					safe, err = f.eth.HeaderByNumber(context.Background(), new(big.Int).SetUint64(head.Number.Uint64()-f.safeDistance))
+				if bigs.Uint64Strict(head.Number) > f.safeDistance { // progress safe block, if we can
+					safe, err = f.eth.HeaderByNumber(context.Background(), new(big.Int).SetUint64(bigs.Uint64Strict(head.Number)-f.safeDistance))
 					if err != nil {
 						f.log.Warn("Failed to safe header", "err", err)
 						continue
@@ -158,7 +159,7 @@ func (f *FakePoS) Start() error {
 					Withdrawals:           withdrawals,
 				}
 				parentBeaconBlockRoot := f.FakeBeaconBlockRoot(head.Time) // parent beacon block root
-				nextHeight := new(big.Int).SetUint64(head.Number.Uint64() + 1)
+				nextHeight := new(big.Int).SetUint64(bigs.Uint64Strict(head.Number) + 1)
 				isCancun := f.config.IsCancun(nextHeight, newBlockTime)
 				isPrague := f.config.IsPrague(nextHeight, newBlockTime)
 				isOsaka := f.config.IsOsaka(nextHeight, newBlockTime)

--- a/op-e2e/e2eutils/geth/geth.go
+++ b/op-e2e/e2eutils/geth/geth.go
@@ -27,12 +27,13 @@ import (
 	_ "github.com/ethereum/go-ethereum/eth/tracers/js"
 	_ "github.com/ethereum/go-ethereum/eth/tracers/native"
 
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/clock"
 )
 
 func InitL1(blockTime uint64, finalizedDistance uint64, genesis *core.Genesis, c clock.Clock, blobPoolDir string, beaconSrv Beacon, opts ...GethOption) (*GethInstance, *FakePoS, error) {
 	ethConfig := &ethconfig.Config{
-		NetworkId: genesis.Config.ChainID.Uint64(),
+		NetworkId: bigs.Uint64Strict(genesis.Config.ChainID),
 		Genesis:   genesis,
 		BlobPool: blobpool.Config{
 			Datadir:   blobPoolDir,
@@ -102,7 +103,7 @@ func (b *gethBackend) HeaderByNumber(_ context.Context, num *big.Int) (*types.He
 			h = b.chain.CurrentFinalBlock()
 		}
 	} else {
-		h = b.chain.GetHeaderByNumber(num.Uint64())
+		h = b.chain.GetHeaderByNumber(bigs.Uint64Strict(num))
 	}
 	if h == nil {
 		return nil, ethereum.NotFound
@@ -130,7 +131,7 @@ type GethOption func(ethCfg *ethconfig.Config, nodeCfg *node.Config) error
 // InitL2 inits a L2 geth node.
 func InitL2(name string, genesis *core.Genesis, jwtPath string, opts ...GethOption) (*GethInstance, error) {
 	ethConfig := &ethconfig.Config{
-		NetworkId:   genesis.Config.ChainID.Uint64(),
+		NetworkId:   bigs.Uint64Strict(genesis.Config.ChainID),
 		Genesis:     genesis,
 		StateScheme: rawdb.HashScheme,
 		Miner: miner.Config{

--- a/op-e2e/e2eutils/geth/wait.go
+++ b/op-e2e/e2eutils/geth/wait.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -224,7 +225,7 @@ func waitForBlockTag(number *big.Int, client *ethclient.Client, timeout time.Dur
 				}
 				return nil, err
 			}
-			if block != nil && block.NumberU64() >= number.Uint64() {
+			if block != nil && block.NumberU64() >= bigs.Uint64Strict(number) {
 				return client.BlockByNumber(ctx, number)
 			}
 		case <-ctx.Done():

--- a/op-e2e/e2eutils/intentbuilder/builder.go
+++ b/op-e2e/e2eutils/intentbuilder/builder.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/artifacts"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/standard"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/state"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
@@ -200,7 +201,7 @@ func (b *intentBuilder) L1() L1Configurator {
 }
 
 func (b *intentBuilder) WithL1(l1ChainID eth.ChainID) (Builder, L1Configurator) {
-	b.intent.L1ChainID = l1ChainID.ToBig().Uint64()
+	b.intent.L1ChainID = bigs.Uint64Strict(l1ChainID.ToBig())
 	return b, &l1Configurator{builder: b}
 }
 
@@ -288,7 +289,7 @@ type l1Configurator struct {
 }
 
 func (c *l1Configurator) WithChainID(chainID eth.ChainID) L1Configurator {
-	c.builder.intent.L1ChainID = chainID.ToBig().Uint64()
+	c.builder.intent.L1ChainID = bigs.Uint64Strict(chainID.ToBig())
 	return c
 }
 

--- a/op-e2e/e2eutils/wait/withdrawals.go
+++ b/op-e2e/e2eutils/wait/withdrawals.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/bindings"
 	bindingspreview "github.com/ethereum-optimism/optimism/op-node/bindings/preview"
 	"github.com/ethereum-optimism/optimism/op-node/withdrawals"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -46,7 +47,7 @@ func ForGamePublished(ctx context.Context, client *ethclient.Client, optimismPor
 	if err != nil {
 		return 0, err
 	}
-	return outputBlockNum.Uint64(), nil
+	return bigs.Uint64Strict(outputBlockNum), nil
 }
 
 // ForWithdrawalCheck waits until the withdrawal check in the portal succeeds.

--- a/op-e2e/faultproofs/cannon_benchmark_test.go
+++ b/op-e2e/faultproofs/cannon_benchmark_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-core/predeploys"
 	"github.com/ethereum-optimism/optimism/op-e2e/bindings"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 )
 
@@ -76,12 +77,12 @@ func testBenchmarkCannonFPP(t *testing.T, allocType config.AllocType) {
 
 	t.Log("Determine L2 claim")
 	l2ClaimBlockNumber := receipt.BlockNumber
-	l2Output, err := rollupClient.OutputAtBlock(ctx, l2ClaimBlockNumber.Uint64())
+	l2Output, err := rollupClient.OutputAtBlock(ctx, bigs.Uint64Strict(l2ClaimBlockNumber))
 	require.NoError(t, err, "could not get expected output")
 	l2Claim := l2Output.OutputRoot
 
 	t.Log("Determine L1 head that includes all batches required for L2 claim block")
-	require.NoError(t, wait.ForSafeBlock(ctx, rollupClient, l2ClaimBlockNumber.Uint64()))
+	require.NoError(t, wait.ForSafeBlock(ctx, rollupClient, bigs.Uint64Strict(l2ClaimBlockNumber)))
 	l1HeadBlock, err := l1Client.BlockByNumber(ctx, nil)
 	require.NoError(t, err, "get l1 head block")
 	l1Head := l1HeadBlock.Hash()

--- a/op-e2e/faultproofs/output_alphabet_test.go
+++ b/op-e2e/faultproofs/output_alphabet_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/challenger"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/disputegame"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
@@ -86,7 +87,7 @@ func TestOutputAlphabetGame_ReclaimBond(t *testing.T) {
 
 	// The dispute game should have a zero balance
 	balance := game.WethBalance(ctx, game.Addr)
-	require.Zero(t, balance.Uint64())
+	require.Zero(t, bigs.Uint64Strict(balance))
 
 	alice := sys.Cfg.Secrets.Addresses().Alice
 

--- a/op-e2e/faultproofs/output_alphabet_test.go
+++ b/op-e2e/faultproofs/output_alphabet_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/challenger"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/disputegame"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
-	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
@@ -87,7 +86,7 @@ func TestOutputAlphabetGame_ReclaimBond(t *testing.T) {
 
 	// The dispute game should have a zero balance
 	balance := game.WethBalance(ctx, game.Addr)
-	require.Zero(t, bigs.Uint64Strict(balance))
+	require.Zero(t, balance.BitLen(), "Expected zero WETH balance, got %v", balance)
 
 	alice := sys.Cfg.Secrets.Addresses().Alice
 

--- a/op-e2e/faultproofs/output_cannon_test.go
+++ b/op-e2e/faultproofs/output_cannon_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/disputegame/preimage"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
 	oppreimage "github.com/ethereum-optimism/optimism/op-preimage"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
@@ -298,7 +299,7 @@ func testOutputCannonStepWithKzgPointEvaluation(t *testing.T, allocType config.A
 		t.Logf("KZG Point Evaluation block number: %d", precompileBlock)
 
 		disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
-		game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", precompileBlock.Uint64(), common.Hash{0x01, 0xaa})
+		game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", bigs.Uint64Strict(precompileBlock), common.Hash{0x01, 0xaa})
 		require.NotNil(t, game)
 		outputRootClaim := game.DisputeLastBlock(ctx)
 		game.LogGameData(ctx)

--- a/op-e2e/faultproofs/precompile_test.go
+++ b/op-e2e/faultproofs/precompile_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/challenger"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/disputegame"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 )
 
@@ -73,12 +74,12 @@ func TestPrecompile(t *testing.T) {
 
 		t.Log("Determine L2 claim")
 		l2ClaimBlockNumber := receipt.BlockNumber
-		l2Output, err := rollupClient.OutputAtBlock(ctx, l2ClaimBlockNumber.Uint64())
+		l2Output, err := rollupClient.OutputAtBlock(ctx, bigs.Uint64Strict(l2ClaimBlockNumber))
 		require.NoError(t, err, "could not get expected output")
 		l2Claim := l2Output.OutputRoot
 
 		t.Log("Determine L1 head that includes all batches required for L2 claim block")
-		require.NoError(t, wait.ForSafeBlock(ctx, rollupClient, l2ClaimBlockNumber.Uint64()))
+		require.NoError(t, wait.ForSafeBlock(ctx, rollupClient, bigs.Uint64Strict(l2ClaimBlockNumber)))
 		l1HeadBlock, err := l1Client.BlockByNumber(ctx, nil)
 		require.NoError(t, err, "get l1 head block")
 		l1Head := l1HeadBlock.Hash()
@@ -116,7 +117,7 @@ func TestDisputePrecompile(t *testing.T) {
 		})
 
 		disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
-		game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", receipt.BlockNumber.Uint64(), common.Hash{0x01, 0xaa})
+		game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", bigs.Uint64Strict(receipt.BlockNumber), common.Hash{0x01, 0xaa})
 		require.NotNil(t, game)
 		outputRootClaim := game.DisputeLastBlock(ctx)
 		game.LogGameData(ctx)
@@ -187,12 +188,12 @@ func TestGranitePrecompiles(t *testing.T) {
 		t.Logf("Transaction hash %v", tx.Hash())
 		t.Log("Determine L2 claim")
 		l2ClaimBlockNumber := receipt.BlockNumber
-		l2Output, err := rollupClient.OutputAtBlock(ctx, l2ClaimBlockNumber.Uint64())
+		l2Output, err := rollupClient.OutputAtBlock(ctx, bigs.Uint64Strict(l2ClaimBlockNumber))
 		require.NoError(t, err, "could not get expected output")
 		l2Claim := l2Output.OutputRoot
 
 		t.Log("Determine L1 head that includes all batches required for L2 claim block")
-		require.NoError(t, wait.ForSafeBlock(ctx, rollupClient, l2ClaimBlockNumber.Uint64()))
+		require.NoError(t, wait.ForSafeBlock(ctx, rollupClient, bigs.Uint64Strict(l2ClaimBlockNumber)))
 		l1HeadBlock, err := l1Client.BlockByNumber(ctx, nil)
 		require.NoError(t, err, "get l1 head block")
 		l1Head := l1HeadBlock.Hash()

--- a/op-e2e/faultproofs/util_interop.go
+++ b/op-e2e/faultproofs/util_interop.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
 	"github.com/ethereum-optimism/optimism/op-e2e/interop"
 	"github.com/ethereum-optimism/optimism/op-e2e/system/e2esys"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/stretchr/testify/require"
 )
@@ -31,7 +32,7 @@ func StartInteropFaultDisputeSystem(t *testing.T, opts ...faultDisputeConfigOpts
 	}
 
 	recipe := interopgen.InteropDevRecipe{
-		L1ChainID:        InteropL1ChainID.Uint64(),
+		L1ChainID:        bigs.Uint64Strict(InteropL1ChainID),
 		L2s:              []interopgen.InteropDevL2Recipe{{ChainID: 900200}, {ChainID: 900201}},
 		GenesisTimestamp: uint64(time.Now().Unix() + 3), // start chain 3 seconds from now
 	}

--- a/op-e2e/interop/interop_test.go
+++ b/op-e2e/interop/interop_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/interopgen"
 	"github.com/ethereum-optimism/optimism/op-e2e/system/helpers"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 	gethCore "github.com/ethereum/go-ethereum/core"
 	gethTypes "github.com/ethereum/go-ethereum/core/types"
@@ -270,15 +271,15 @@ func TestInteropBlockBuilding(t *testing.T) {
 		ctx, cancel = context.WithTimeout(context.Background(), 30*time.Second)
 		emitRec := s2.EmitData(ctx, chainA, "sequencer", "Alice", "hello world")
 		cancel()
-		t.Logf("Emitted a log event in block %d", emitRec.BlockNumber.Uint64())
+		t.Logf("Emitted a log event in block %d", bigs.Uint64Strict(emitRec.BlockNumber))
 
 		// Wait for initiating side to become cross-unsafe
 		require.Eventually(t, func() bool {
 			status, err := rollupClA.SyncStatus(context.Background())
 			require.NoError(t, err)
-			return status.CrossUnsafeL2.Number >= emitRec.BlockNumber.Uint64()
+			return status.CrossUnsafeL2.Number >= bigs.Uint64Strict(emitRec.BlockNumber)
 		}, time.Second*60, time.Second, "wait for emitted data to become cross-unsafe")
-		t.Logf("Reached cross-unsafe block %d", emitRec.BlockNumber.Uint64())
+		t.Logf("Reached cross-unsafe block %d", bigs.Uint64Strict(emitRec.BlockNumber))
 
 		// Identify the log
 		require.Len(t, emitRec.Logs, 1)

--- a/op-e2e/opgeth/op_geth_test.go
+++ b/op-e2e/opgeth/op_geth_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/system/e2esys"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
@@ -340,11 +341,11 @@ func TestPreregolith(t *testing.T) {
 
 			contractBalance, err := opGeth.L2Client.BalanceAt(ctx, incorrectContractAddress, nil)
 			require.NoError(t, err)
-			require.Equal(t, uint64(0), contractBalance.Uint64(), "balance unchanged on incorrect contract address")
+			require.Equal(t, uint64(0), bigs.Uint64Strict(contractBalance), "balance unchanged on incorrect contract address")
 
 			contractBalance, err = opGeth.L2Client.BalanceAt(ctx, correctContractAddress, nil)
 			require.NoError(t, err)
-			require.Equal(t, uint64(params.Ether), contractBalance.Uint64(), "balance changed on correct contract address")
+			require.Equal(t, uint64(params.Ether), bigs.Uint64Strict(contractBalance), "balance changed on correct contract address")
 
 			// Check the actual transaction nonce is reported correctly when retrieving the tx from the API.
 			tx, _, err := opGeth.L2Client.TransactionByHash(ctx, contractCreateTx.Hash())
@@ -527,7 +528,7 @@ func TestRegolith(t *testing.T) {
 
 			contractBalance, err := opGeth.L2Client.BalanceAt(ctx, createRcpt.ContractAddress, nil)
 			require.NoError(t, err)
-			require.Equal(t, uint64(params.Ether), contractBalance.Uint64(), "balance changed on correct contract address")
+			require.Equal(t, uint64(params.Ether), bigs.Uint64Strict(contractBalance), "balance changed on correct contract address")
 
 			// Check the actual transaction nonce is reported correctly when retrieving the tx from the API.
 			tx, _, err := opGeth.L2Client.TransactionByHash(ctx, contractCreateTx.Hash())

--- a/op-e2e/opgeth/op_geth_test.go
+++ b/op-e2e/opgeth/op_geth_test.go
@@ -341,11 +341,12 @@ func TestPreregolith(t *testing.T) {
 
 			contractBalance, err := opGeth.L2Client.BalanceAt(ctx, incorrectContractAddress, nil)
 			require.NoError(t, err)
-			require.Equal(t, uint64(0), bigs.Uint64Strict(contractBalance), "balance unchanged on incorrect contract address")
+			require.Zero(t, contractBalance.BitLen(), "balance unchanged on incorrect contract address")
 
 			contractBalance, err = opGeth.L2Client.BalanceAt(ctx, correctContractAddress, nil)
 			require.NoError(t, err)
-			require.Equal(t, uint64(params.Ether), bigs.Uint64Strict(contractBalance), "balance changed on correct contract address")
+			require.Truef(t, bigs.Equal(big.NewInt(params.Ether), contractBalance),
+				"balance changed on correct contract address, expected %v, got %v", params.Ether, contractBalance)
 
 			// Check the actual transaction nonce is reported correctly when retrieving the tx from the API.
 			tx, _, err := opGeth.L2Client.TransactionByHash(ctx, contractCreateTx.Hash())
@@ -528,7 +529,7 @@ func TestRegolith(t *testing.T) {
 
 			contractBalance, err := opGeth.L2Client.BalanceAt(ctx, createRcpt.ContractAddress, nil)
 			require.NoError(t, err)
-			require.Equal(t, uint64(params.Ether), bigs.Uint64Strict(contractBalance), "balance changed on correct contract address")
+			require.Truef(t, bigs.Equal(big.NewInt(params.Ether), contractBalance), "balance changed on correct contract address, expected %v, got %v", params.Ether, contractBalance)
 
 			// Check the actual transaction nonce is reported correctly when retrieving the tx from the API.
 			tx, _, err := opGeth.L2Client.TransactionByHash(ctx, contractCreateTx.Hash())

--- a/op-e2e/system/bridge/validity_test.go
+++ b/op-e2e/system/bridge/validity_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
 	"github.com/ethereum-optimism/optimism/op-node/bindings"
 	bindingspreview "github.com/ethereum-optimism/optimism/op-node/bindings/preview"
-	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/testutils/fuzzerutils"
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -383,7 +382,7 @@ func testMixedWithdrawalValidity(t *testing.T, allocType config.AllocType) {
 			fromAddr := crypto.PubkeyToAddress(transactor.Account.Key.PublicKey)
 			fromBalance, err := l2Verif.BalanceAt(context.Background(), fromAddr, nil)
 			require.NoError(t, err)
-			require.Greaterf(t, bigs.Uint64Strict(fromBalance), uint64(700_000_000_000), "insufficient balance for %s", fromAddr)
+			require.Truef(t, fromBalance.Cmp(big.NewInt(700_000_000_000)) > 0, "insufficient balance for %s", fromAddr)
 
 			// Initiate Withdrawal
 			withdrawAmount := big.NewInt(500_000_000_000)

--- a/op-e2e/system/bridge/validity_test.go
+++ b/op-e2e/system/bridge/validity_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
 	"github.com/ethereum-optimism/optimism/op-node/bindings"
 	bindingspreview "github.com/ethereum-optimism/optimism/op-node/bindings/preview"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/testutils/fuzzerutils"
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -382,7 +383,7 @@ func testMixedWithdrawalValidity(t *testing.T, allocType config.AllocType) {
 			fromAddr := crypto.PubkeyToAddress(transactor.Account.Key.PublicKey)
 			fromBalance, err := l2Verif.BalanceAt(context.Background(), fromAddr, nil)
 			require.NoError(t, err)
-			require.Greaterf(t, fromBalance.Uint64(), uint64(700_000_000_000), "insufficient balance for %s", fromAddr)
+			require.Greaterf(t, bigs.Uint64Strict(fromBalance), uint64(700_000_000_000), "insufficient balance for %s", fromAddr)
 
 			// Initiate Withdrawal
 			withdrawAmount := big.NewInt(500_000_000_000)

--- a/op-e2e/system/da/brotli_batcher_test.go
+++ b/op-e2e/system/da/brotli_batcher_test.go
@@ -17,6 +17,7 @@ import (
 
 	batcherFlags "github.com/ethereum-optimism/optimism/op-batcher/flags"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -113,7 +114,7 @@ func TestBrotliBatcherFjord(t *testing.T) {
 		// wait for chain to be marked as "safe" (i.e. confirm batch-submission works)
 		stat, err := rollupClient.SyncStatus(context.Background())
 		require.NoError(t, err)
-		return stat.SafeL2.Number >= receipt.BlockNumber.Uint64()
+		return stat.SafeL2.Number >= bigs.Uint64Strict(receipt.BlockNumber)
 	}, time.Second*20, time.Second, "expected L2 to be batch-submitted and labeled as safe")
 
 	// check that the L2 tx is still canonical

--- a/op-e2e/system/da/dencun_test.go
+++ b/op-e2e/system/da/dencun_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/transactions"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
 	"github.com/ethereum-optimism/optimism/op-e2e/system/e2esys"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
@@ -31,7 +32,7 @@ func TestSystemE2EDencunAtGenesisWithBlobs(t *testing.T) {
 
 	// send a blob-containing txn on l1
 	ethPrivKey := sys.Cfg.Secrets.Alice
-	txData := transactions.CreateEmptyBlobTx(true, sys.Cfg.L1ChainIDBig().Uint64())
+	txData := transactions.CreateEmptyBlobTx(true, bigs.Uint64Strict(sys.Cfg.L1ChainIDBig()))
 	tx := types.MustSignNewTx(ethPrivKey, types.LatestSignerForChainID(cfg.L1ChainIDBig()), txData)
 	// send blob-containing txn
 	sendCtx, sendCancel := context.WithTimeout(context.Background(), 15*time.Second)
@@ -45,7 +46,7 @@ func TestSystemE2EDencunAtGenesisWithBlobs(t *testing.T) {
 	require.Nil(t, err, "Waiting for blob tx on L1")
 	// end sending blob-containing txns on l1
 	l2Client := sys.NodeClient("sequencer")
-	finalizedBlock, err := geth.WaitForL1OriginOnL2(sys.RollupConfig, blockContainsBlob.BlockNumber.Uint64(), l2Client, 30*time.Duration(cfg.DeployConfig.L1BlockTime)*time.Second)
+	finalizedBlock, err := geth.WaitForL1OriginOnL2(sys.RollupConfig, bigs.Uint64Strict(blockContainsBlob.BlockNumber), l2Client, 30*time.Duration(cfg.DeployConfig.L1BlockTime)*time.Second)
 	require.Nil(t, err, "Waiting for L1 origin of blob tx on L2")
 	finalizationTimeout := 30 * time.Duration(cfg.DeployConfig.L1BlockTime) * time.Second
 	_, err = geth.WaitForBlockToBeSafe(finalizedBlock.Header().Number, l2Client, finalizationTimeout)

--- a/op-e2e/system/da/eip4844_test.go
+++ b/op-e2e/system/da/eip4844_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/transactions"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
@@ -173,7 +174,7 @@ func testSystem4844E2E(t *testing.T, multiBlob bool, daType batcherFlags.DataAva
 		// wait for chain to be marked as "safe" (i.e. confirm batch-submission works)
 		stat, err := rollupClient.SyncStatus(context.Background())
 		require.NoError(ct, err)
-		require.GreaterOrEqual(ct, stat.SafeL2.Number, receipt.BlockNumber.Uint64())
+		require.GreaterOrEqual(ct, stat.SafeL2.Number, bigs.Uint64Strict(receipt.BlockNumber))
 	}, time.Second*20, time.Second, "expected L2 to be batch-submitted and labeled as safe")
 
 	// check that the L2 tx is still canonical

--- a/op-e2e/system/fees/eip1559params_test.go
+++ b/op-e2e/system/fees/eip1559params_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/geth"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
 	"github.com/ethereum-optimism/optimism/op-e2e/system/e2esys"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/consensus/misc/eip1559"
@@ -82,7 +83,7 @@ func TestEIP1559Params(t *testing.T) {
 	require.NoError(t, err, "reading elasticity")
 	require.Equal(t, expectedElasticity, elasticity)
 
-	_, err = geth.WaitForL1OriginOnL2(sys.RollupConfig, receipt.BlockNumber.Uint64(), l2Seq, txTimeoutDuration)
+	_, err = geth.WaitForL1OriginOnL2(sys.RollupConfig, bigs.Uint64Strict(receipt.BlockNumber), l2Seq, txTimeoutDuration)
 	require.NoError(t, err, "waiting for L2 block to include the sysconfig update")
 
 	h, err := l2Seq.HeaderByNumber(context.Background(), nil)

--- a/op-e2e/system/fees/fees_test.go
+++ b/op-e2e/system/fees/fees_test.go
@@ -184,7 +184,8 @@ func testFees(t *testing.T, cfg e2esys.SystemConfig) {
 	// Simple transfer from signer to random account
 	startBalance := balanceAt(fromAddr, big.NewInt(rpc.EarliestBlockNumber.Int64()))
 
-	require.Greater(t, bigs.Uint64Strict(startBalance), bigs.Uint64Strict(big.NewInt(params.Ether)))
+	require.True(t, startBalance.Cmp(big.NewInt(params.Ether)) > 0,
+		"Expected start balance (%v) to be greater than 1 ether (%v)", startBalance, params.Ether)
 
 	transferAmount := big.NewInt(params.Ether)
 	gasTip := big.NewInt(10)

--- a/op-e2e/system/fees/fees_test.go
+++ b/op-e2e/system/fees/fees_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/geth"
 	"github.com/ethereum-optimism/optimism/op-e2e/system/e2esys"
 	"github.com/ethereum-optimism/optimism/op-e2e/system/helpers"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -147,7 +148,7 @@ func testFees(t *testing.T, cfg e2esys.SystemConfig) {
 	if !sys.RollupConfig.IsEcotone(sys.L2GenesisCfg.Timestamp) {
 		overhead, err := gpoContract.Overhead(&bind.CallOpts{})
 		require.Nil(t, err, "reading gpo overhead")
-		require.Equal(t, overhead.Uint64(), cfg.DeployConfig.GasPriceOracleOverhead, "wrong gpo overhead")
+		require.Equal(t, bigs.Uint64Strict(overhead), cfg.DeployConfig.GasPriceOracleOverhead, "wrong gpo overhead")
 
 		scalar, err := gpoContract.Scalar(&bind.CallOpts{})
 		require.Nil(t, err, "reading gpo scalar")
@@ -163,7 +164,7 @@ func testFees(t *testing.T, cfg e2esys.SystemConfig) {
 	decimals, err := gpoContract.Decimals(&bind.CallOpts{})
 	require.Nil(t, err, "reading gpo decimals")
 
-	require.Equal(t, decimals.Uint64(), uint64(6), "wrong gpo decimals")
+	require.Equal(t, bigs.Uint64Strict(decimals), uint64(6), "wrong gpo decimals")
 
 	baseFeeRecipientStartBalance := balanceAt(predeploys.BaseFeeVaultAddr, big.NewInt(rpc.EarliestBlockNumber.Int64()))
 	l1FeeRecipientStartBalance := balanceAt(predeploys.L1FeeVaultAddr, big.NewInt(rpc.EarliestBlockNumber.Int64()))
@@ -183,7 +184,7 @@ func testFees(t *testing.T, cfg e2esys.SystemConfig) {
 	// Simple transfer from signer to random account
 	startBalance := balanceAt(fromAddr, big.NewInt(rpc.EarliestBlockNumber.Int64()))
 
-	require.Greater(t, startBalance.Uint64(), big.NewInt(params.Ether).Uint64())
+	require.Greater(t, bigs.Uint64Strict(startBalance), bigs.Uint64Strict(big.NewInt(params.Ether)))
 
 	transferAmount := big.NewInt(params.Ether)
 	gasTip := big.NewInt(10)
@@ -269,7 +270,7 @@ func testFees(t *testing.T, cfg e2esys.SystemConfig) {
 		// Geth Linear Regression: -42.5856 + 102 * 0.8365 = 42.7374
 		// GPO Linear Regression: -42.5856 + 170 * 0.8365 = 99.6194
 		// The additional 68 (170 vs. 102) is due to the GPO adding 68 bytes to account for the signature.
-		require.Greater(t, types.MinTransactionSize.Uint64(), uint64(99))
+		require.Greater(t, bigs.Uint64Strict(types.MinTransactionSize), uint64(99))
 		// Because of this, we don't need to do any adjustment as the GPO and cost func are both bounded to the minimum value.
 		// However, if the fastlz regression output is ever larger than the minimum, this will require an adjustment.
 	} else if sys.RollupConfig.IsRegolith(header.Time) {

--- a/op-e2e/system/fees/gaspriceoracle_test.go
+++ b/op-e2e/system/fees/gaspriceoracle_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/geth"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
 	"github.com/ethereum-optimism/optimism/op-e2e/system/e2esys"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/stretchr/testify/require"
@@ -64,7 +65,7 @@ func TestGasPriceOracleFeeUpdates(t *testing.T) {
 	receipt, err := wait.ForReceiptOK(ctx, l1Client, tx.Hash())
 	require.NoError(t, err, "Waiting for sysconfig set gas config update tx")
 
-	_, err = geth.WaitForL1OriginOnL2(sys.RollupConfig, receipt.BlockNumber.Uint64(), l2Seq, txTimeoutDuration)
+	_, err = geth.WaitForL1OriginOnL2(sys.RollupConfig, bigs.Uint64Strict(receipt.BlockNumber), l2Seq, txTimeoutDuration)
 	require.NoError(t, err, "waiting for L2 block to include the sysconfig update")
 
 	baseFeeScalar, err := gpoContract.BaseFeeScalar(&bind.CallOpts{})
@@ -89,7 +90,7 @@ func TestGasPriceOracleFeeUpdates(t *testing.T) {
 	receipt, err = wait.ForReceiptOK(ctx, l1Client, tx.Hash())
 	require.NoError(t, err, "Waiting for sysconfig set gas config update tx")
 
-	_, err = geth.WaitForL1OriginOnL2(sys.RollupConfig, receipt.BlockNumber.Uint64(), l2Seq, txTimeoutDuration)
+	_, err = geth.WaitForL1OriginOnL2(sys.RollupConfig, bigs.Uint64Strict(receipt.BlockNumber), l2Seq, txTimeoutDuration)
 	require.NoError(t, err, "waiting for L2 block to include the sysconfig update")
 
 	baseFeeScalar, err = gpoContract.BaseFeeScalar(&bind.CallOpts{})

--- a/op-e2e/system/p2p/reqresp_test.go
+++ b/op-e2e/system/p2p/reqresp_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup/driver"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/interop"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/endpoint"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
@@ -181,7 +182,7 @@ func TestSystemP2PAltSync(t *testing.T) {
 	require.Equal(t, receiptSeq, receiptVerif)
 
 	// Verify that the tx was received via P2P sync
-	require.Contains(t, syncedPayloads, eth.BlockID{Hash: receiptVerif.BlockHash, Number: receiptVerif.BlockNumber.Uint64()}.String())
+	require.Contains(t, syncedPayloads, eth.BlockID{Hash: receiptVerif.BlockHash, Number: bigs.Uint64Strict(receiptVerif.BlockNumber)}.String())
 
 	// Verify that everything that was received was published
 	require.GreaterOrEqual(t, len(published), len(syncedPayloads))

--- a/op-e2e/system/proofs/system_fpp_test.go
+++ b/op-e2e/system/proofs/system_fpp_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-program/client/claim"
 	opp "github.com/ethereum-optimism/optimism/op-program/host"
 	oppconf "github.com/ethereum-optimism/optimism/op-program/host/config"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 )
 
@@ -130,10 +131,10 @@ func testVerifyL2OutputRootEmptyBlock(t *testing.T, detached bool, spanBatchActi
 		opts.ToAddr = &cfg.Secrets.Addresses().Bob
 		opts.Value = big.NewInt(1_000)
 	})
-	require.NoError(t, wait.ForSafeBlock(ctx, rollupClient, receipt.BlockNumber.Uint64()))
+	require.NoError(t, wait.ForSafeBlock(ctx, rollupClient, bigs.Uint64Strict(receipt.BlockNumber)))
 
 	t.Logf("Capture current L2 head as agreed starting point. l2Head=%x l2BlockNumber=%v", receipt.BlockHash, receipt.BlockNumber)
-	agreedL2Output, err := rollupClient.OutputAtBlock(ctx, receipt.BlockNumber.Uint64())
+	agreedL2Output, err := rollupClient.OutputAtBlock(ctx, bigs.Uint64Strict(receipt.BlockNumber))
 	require.NoError(t, err, "could not retrieve l2 agreed block")
 	l2Head := agreedL2Output.BlockRef.Hash
 	l2OutputRoot := agreedL2Output.OutputRoot
@@ -162,7 +163,7 @@ func testVerifyL2OutputRootEmptyBlock(t *testing.T, detached bool, spanBatchActi
 	t.Log("Determine L2 claim")
 	l2ClaimBlock, err := l2Seq.BlockByNumber(ctx, big.NewInt(int64(safeBlock.NumberU64()+2)))
 	require.NoError(t, err, "get L2 claim block number")
-	l2ClaimBlockNumber := l2ClaimBlock.Number().Uint64()
+	l2ClaimBlockNumber := bigs.Uint64Strict(l2ClaimBlock.Number())
 	l2Output, err := rollupClient.OutputAtBlock(ctx, l2ClaimBlockNumber)
 	require.NoError(t, err, "could not get expected output")
 	l2Claim := l2Output.OutputRoot
@@ -177,7 +178,7 @@ func testVerifyL2OutputRootEmptyBlock(t *testing.T, detached bool, spanBatchActi
 		opts.Value = big.NewInt(1_000)
 		opts.Nonce = 1
 	})
-	require.NoError(t, wait.ForSafeBlock(ctx, rollupClient, receipt.BlockNumber.Uint64()))
+	require.NoError(t, wait.ForSafeBlock(ctx, rollupClient, bigs.Uint64Strict(receipt.BlockNumber)))
 
 	t.Log("Determine L1 head that includes batch after sequence of empty blocks")
 	l1HeadBlock, err := l1Client.BlockByNumber(ctx, nil)

--- a/op-e2e/system/verifier/legacy_pending_test.go
+++ b/op-e2e/system/verifier/legacy_pending_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/geth"
 	"github.com/ethereum-optimism/optimism/op-e2e/system/e2esys"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/eth/ethconfig"
@@ -72,7 +73,7 @@ func TestPendingGasLimit(t *testing.T) {
 
 		// Stop once the verifier passes genesis:
 		// this implies we checked a new block from the sequencer, on both sequencer and verifier nodes.
-		if latestVerifHeader.Number.Uint64() > 0 {
+		if bigs.Uint64Strict(latestVerifHeader.Number) > 0 {
 			break
 		}
 		time.Sleep(500 * time.Millisecond)
@@ -109,7 +110,7 @@ func TestPendingBlockIsLatest(t *testing.T) {
 			require.NoError(t, err)
 			latest, err := l2Seq.HeaderByNumber(context.Background(), nil)
 			require.NoError(t, err)
-			if pending.Number.Uint64() == latest.Number.Uint64() {
+			if bigs.Uint64Strict(pending.Number) == bigs.Uint64Strict(latest.Number) {
 				require.Equal(t, pending.Hash(), latest.Hash(), "pending must exactly match latest header")
 				return
 			}

--- a/op-e2e/system/verifier/sequencer_window_test.go
+++ b/op-e2e/system/verifier/sequencer_window_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
 	"github.com/ethereum-optimism/optimism/op-e2e/system/e2esys"
 	"github.com/ethereum-optimism/optimism/op-e2e/system/helpers"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
@@ -56,7 +57,7 @@ func TestMissingBatchE2E(t *testing.T) {
 	// Wait a short time for the L2 reorg to occur on the sequencer as well.
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	err = wait.ForSafeBlock(ctx, seqRollupClient, receipt.BlockNumber.Uint64())
+	err = wait.ForSafeBlock(ctx, seqRollupClient, bigs.Uint64Strict(receipt.BlockNumber))
 	require.Nil(t, err, "timeout waiting for L2 reorg on sequencer safe head")
 
 	// Assert that the reconciliation process did an L2 reorg on the sequencer to remove the invalid block

--- a/op-sync-tester/synctester/backend/sync_tester.go
+++ b/op-sync-tester/synctester/backend/sync_tester.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
 
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/config"
 	"github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/session"
 	sttypes "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/types"
@@ -132,7 +133,7 @@ func (s *SyncTester) GetBlockReceipts(ctx context.Context, blockNrOrHash rpc.Blo
 			logger.Warn("L2 Block has zero receipts", "blockNrHash", blockNrOrHash)
 			return nil, errors.New("no receipts")
 		}
-		target := receipts[0].BlockNumber.Uint64()
+		target := bigs.Uint64Strict(receipts[0].BlockNumber)
 		if target > session.CurrentState.Latest {
 			logger.Warn("Requested block is ahead of sync tester state", "requested", target)
 			return nil, ethereum.NotFound
@@ -153,7 +154,7 @@ func (s *SyncTester) GetBlockByHash(ctx context.Context, hash common.Hash, fullT
 		if err := json.Unmarshal(raw, &header); err != nil {
 			return nil, err
 		}
-		target := header.Number.ToInt().Uint64()
+		target := bigs.Uint64Strict(header.Number.ToInt())
 		if target > session.CurrentState.Latest {
 			logger.Warn("Requested block is ahead of sync tester state", "requested", target)
 			return nil, ethereum.NotFound

--- a/op-sync-tester/synctester/backend/sync_tester_test.go
+++ b/op-sync-tester/synctester/backend/sync_tester_test.go
@@ -7,6 +7,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/session"
@@ -208,7 +209,7 @@ func TestSyncTester_GetBlockByHash(t *testing.T) {
 
 			var header HeaderNumberOnly
 			require.NoError(t, json.Unmarshal(raw, &header))
-			require.EqualValues(t, tc.rawNumber, header.Number.ToInt().Uint64())
+			require.EqualValues(t, tc.rawNumber, bigs.Uint64Strict(header.Number.ToInt()))
 		})
 	}
 }
@@ -333,7 +334,7 @@ func TestSyncTester_GetBlockByNumber(t *testing.T) {
 			require.NotNil(t, raw)
 			var header HeaderNumberOnly
 			require.NoError(t, json.Unmarshal(raw, &header))
-			require.EqualValues(t, tc.wantNum, header.Number.ToInt().Uint64())
+			require.EqualValues(t, tc.wantNum, bigs.Uint64Strict(header.Number.ToInt()))
 		})
 	}
 }
@@ -474,7 +475,7 @@ func TestSyncTester_GetBlockReceipts(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, recs)
 			require.GreaterOrEqual(t, len(recs), 1)
-			require.EqualValues(t, tc.wantFirstBN, recs[0].BlockNumber.Uint64())
+			require.EqualValues(t, tc.wantFirstBN, bigs.Uint64Strict(recs[0].BlockNumber))
 		})
 	}
 }


### PR DESCRIPTION
**Description**

Brings our acceptance and e2e code into compliance with the new lint check.
