### PR TITLE
fix: use enode URI when removing peer

### DIFF
--- a/op-devstack/sysgo/l2_el_p2p_util.go
+++ b/op-devstack/sysgo/l2_el_p2p_util.go
@@ -96,7 +96,7 @@ func DisconnectP2P(ctx context.Context, require *testreq.Assertions, initiator R
 	expectedID := targetNode.ID().String()
 
 	var peerRemoved bool
-	require.NoError(initiator.CallContext(ctx, &peerRemoved, "admin_removePeer", targetInfo.ENR), "add peer")
+	require.NoError(initiator.CallContext(ctx, &peerRemoved, "admin_removePeer", targetInfo.Enode), "remove peer")
 	require.True(peerRemoved, "should have removed peer successfully")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)


### PR DESCRIPTION
**Description**
Use `targetInfo.Enode` for `admin_removePeer` so peer removal matches addPeer and succeeds against geth.

**Tests**
Not run (small, targeted change; repo not set up here).

