### PR TITLE
feat(op-deployer): add forge flag to bootstrap + apply

### DIFF
--- a/op-deployer/cmd/op-deployer/main.go
+++ b/op-deployer/cmd/op-deployer/main.go
@@ -5,10 +5,16 @@ import (
 	"os"
 
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/cli"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/artifacts"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/version"
 )
 
 func main() {
+	// Ensure cleanup happens on exit
+	defer func() {
+		_ = artifacts.CleanupAll()
+	}()
+
 	app := cli.NewApp(version.VersionWithMeta)
 	app.Writer = os.Stdout
 	app.ErrWriter = os.Stderr

--- a/op-deployer/pkg/deployer/apply.go
+++ b/op-deployer/pkg/deployer/apply.go
@@ -172,6 +172,7 @@ func Apply(ctx context.Context, cfg ApplyConfig) error {
 		CacheDir:           cfg.CacheDir,
 		PreStateBuilder:    cfg.PreStateBuilder,
 		UseForge:           cfg.UseForge,
+		PrivateKey:         cfg.PrivateKey,
 	}); err != nil {
 		return err
 	}
@@ -195,6 +196,7 @@ type ApplyPipelineOpts struct {
 	CacheDir           string
 	PreStateBuilder    pipeline.PreStateBuilder
 	UseForge           bool
+	PrivateKey         string
 }
 
 func ApplyPipeline(
@@ -341,9 +343,6 @@ func ApplyPipeline(
 	// Initialize Forge client if UseForge flag is enabled
 	var forgeClient *forge.Client
 	if opts.UseForge {
-		// Get the path to artifacts directory for Forge
-		// Forge needs to run from a directory containing foundry.toml
-		// We try to get the path from the artifacts filesystem
 		artifactsPath := fmt.Sprintf("%v", bundle.L1)
 		forgeClient, err = forge.NewStandardClient(artifactsPath)
 		if err != nil {
@@ -361,6 +360,8 @@ func ApplyPipeline(
 		Scripts:      opcmScripts,
 		ForgeClient:  forgeClient,
 		UseForge:     opts.UseForge,
+		L1RPCUrl:     opts.L1RPCUrl,
+		PrivateKey:   opts.PrivateKey,
 		Context:      ctx,
 	}
 

--- a/op-deployer/pkg/deployer/apply.go
+++ b/op-deployer/pkg/deployer/apply.go
@@ -218,11 +218,10 @@ func ApplyPipeline(
 	if intent.L1ContractsLocator.Equal(intent.L2ContractsLocator) {
 		l2ArtifactsFS = l1ArtifactsFS
 	} else {
-		l2Afs, err := artifacts.Download(ctx, intent.L2ContractsLocator, ioutil.BarProgressor(), opts.CacheDir)
+		l2ArtifactsFS, err = artifacts.Download(ctx, intent.L2ContractsLocator, ioutil.BarProgressor(), opts.CacheDir)
 		if err != nil {
 			return fmt.Errorf("failed to download L2 artifacts: %w", err)
 		}
-		l2ArtifactsFS = l2Afs
 	}
 
 	bundle := pipeline.ArtifactsBundle{

--- a/op-deployer/pkg/deployer/artifacts/cleanup.go
+++ b/op-deployer/pkg/deployer/artifacts/cleanup.go
@@ -25,9 +25,7 @@ func getGlobalTracker() *TempDirTracker {
 		go func() {
 			defer close(globalCleanupDone)
 			<-sigChan
-			if err := globalTracker.Cleanup(); err != nil {
-				// We can't log here as the process is shutting down
-			}
+			_ = globalTracker.Cleanup() // We can't log here as the process is shutting down
 		}()
 	})
 	return globalTracker

--- a/op-deployer/pkg/deployer/artifacts/cleanup.go
+++ b/op-deployer/pkg/deployer/artifacts/cleanup.go
@@ -1,0 +1,47 @@
+package artifacts
+
+import (
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+)
+
+var (
+	globalTracker     *TempDirTracker
+	globalTrackerOnce sync.Once
+	globalCleanupDone chan struct{}
+)
+
+// getGlobalTracker returns the global tracker, initializing it on first use
+func getGlobalTracker() *TempDirTracker {
+	globalTrackerOnce.Do(func() {
+		globalTracker = NewTempDirTracker()
+		globalCleanupDone = make(chan struct{})
+
+		sigChan := make(chan os.Signal, 1)
+		signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
+
+		go func() {
+			defer close(globalCleanupDone)
+			<-sigChan
+			if err := globalTracker.Cleanup(); err != nil {
+				// We can't log here as the process is shutting down
+			}
+		}()
+	})
+	return globalTracker
+}
+
+// RegisterForCleanup registers a directory for automatic cleanup on process exit
+func RegisterForCleanup(dirPath string) {
+	tracker := getGlobalTracker()
+	tracker.Add(dirPath)
+}
+
+// WaitForCleanup waits for cleanup to complete (useful for testing)
+func WaitForCleanup() {
+	if globalCleanupDone != nil {
+		<-globalCleanupDone
+	}
+}

--- a/op-deployer/pkg/deployer/artifacts/cleanup.go
+++ b/op-deployer/pkg/deployer/artifacts/cleanup.go
@@ -1,45 +1,36 @@
 package artifacts
 
 import (
-	"os"
-	"os/signal"
 	"sync"
-	"syscall"
 )
 
 var (
 	globalTracker     *TempDirTracker
 	globalTrackerOnce sync.Once
-	globalCleanupDone chan struct{}
 )
 
 // getGlobalTracker returns the global tracker, initializing it on first use
 func getGlobalTracker() *TempDirTracker {
 	globalTrackerOnce.Do(func() {
 		globalTracker = NewTempDirTracker()
-		globalCleanupDone = make(chan struct{})
-
-		sigChan := make(chan os.Signal, 1)
-		signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
-
-		go func() {
-			defer close(globalCleanupDone)
-			<-sigChan
-			_ = globalTracker.Cleanup() // We can't log here as the process is shutting down
-		}()
 	})
 	return globalTracker
 }
 
-// RegisterForCleanup registers a directory for automatic cleanup on process exit
+// RegisterForCleanup registers a directory for cleanup
 func RegisterForCleanup(dirPath string) {
 	tracker := getGlobalTracker()
 	tracker.Add(dirPath)
 }
 
-// WaitForCleanup waits for cleanup to complete (useful for testing)
-func WaitForCleanup() {
-	if globalCleanupDone != nil {
-		<-globalCleanupDone
-	}
+// CleanupAll performs cleanup of all registered temporary directories
+func CleanupAll() error {
+	tracker := getGlobalTracker()
+	return tracker.Cleanup()
+}
+
+// GetCleanupDirs returns a copy of currently registered cleanup directories
+func GetCleanupDirs() []string {
+	tracker := getGlobalTracker()
+	return tracker.GetTempDirs()
 }

--- a/op-deployer/pkg/deployer/artifacts/download.go
+++ b/op-deployer/pkg/deployer/artifacts/download.go
@@ -83,6 +83,9 @@ func downloadHTTP(ctx context.Context, u *url.URL, progressor ioutil.Progressor,
 	if err != nil {
 		return nil, fmt.Errorf("failed to create temp dir: %w", err)
 	}
+
+	// Register for automatic cleanup on process exit
+	RegisterForCleanup(tmpDir)
 	if strings.HasSuffix(tarballPath, ".tzst") {
 		_, err := ExtractFromFile(tmpDir, tarballPath)
 		if err != nil {

--- a/op-deployer/pkg/deployer/artifacts/embedded.go
+++ b/op-deployer/pkg/deployer/artifacts/embedded.go
@@ -43,6 +43,9 @@ func ExtractEmbedded(destDir string) (foundry.StatDirFs, error) {
 		return nil, fmt.Errorf("failed to create temp untar dir: %w", err)
 	}
 
+	// Register for automatic cleanup on process exit
+	RegisterForCleanup(untarPath)
+
 	tr := tar.NewReader(reader)
 	if err := ioutil.Untar(untarPath, tr); err != nil {
 		return nil, fmt.Errorf("failed to untar embedded artifacts: %w", err)
@@ -83,6 +86,9 @@ func ExtractFromFile(destDir string, tarFilePath string) (foundry.StatDirFs, err
 	if err != nil {
 		return nil, fmt.Errorf("failed to create temp untar dir: %w", err)
 	}
+
+	// Register for automatic cleanup on process exit
+	RegisterForCleanup(untarPath)
 
 	tr := tar.NewReader(reader)
 	if err := ioutil.Untar(untarPath, tr); err != nil {

--- a/op-deployer/pkg/deployer/artifacts/tracker.go
+++ b/op-deployer/pkg/deployer/artifacts/tracker.go
@@ -1,0 +1,55 @@
+package artifacts
+
+import (
+	"os"
+	"sync"
+)
+
+type TempDirTracker struct {
+	mu       sync.Mutex
+	tempDirs []string
+}
+
+// NewTempDirTracker creates a new tracker for temporary directories.
+func NewTempDirTracker() *TempDirTracker {
+	return &TempDirTracker{
+		tempDirs: make([]string, 0),
+	}
+}
+
+// Add registers a temporary directory for cleanup.
+func (t *TempDirTracker) Add(dirPath string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.tempDirs = append(t.tempDirs, dirPath)
+}
+
+// Cleanup removes all tracked temporary directories.
+func (t *TempDirTracker) Cleanup() error {
+	t.mu.Lock()
+	dirs := make([]string, len(t.tempDirs))
+	copy(dirs, t.tempDirs)
+	t.mu.Unlock()
+
+	var lastErr error
+	for _, dir := range dirs {
+		if err := os.RemoveAll(dir); err != nil && !os.IsNotExist(err) {
+			lastErr = err
+		}
+	}
+
+	t.mu.Lock()
+	t.tempDirs = nil
+	t.mu.Unlock()
+
+	return lastErr
+}
+
+// GetTempDirs returns a copy of the tracked directories (for testing/debugging).
+func (t *TempDirTracker) GetTempDirs() []string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	dirs := make([]string, len(t.tempDirs))
+	copy(dirs, t.tempDirs)
+	return dirs
+}

--- a/op-deployer/pkg/deployer/artifacts/tracker_test.go
+++ b/op-deployer/pkg/deployer/artifacts/tracker_test.go
@@ -1,0 +1,46 @@
+package artifacts
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTempDirTracker(t *testing.T) {
+	tracker := NewTempDirTracker()
+
+	require.Empty(t, tracker.GetTempDirs())
+
+	tempDir1 := t.TempDir()
+	tempDir2 := t.TempDir()
+
+	tracker.Add(tempDir1)
+	tracker.Add(tempDir2)
+
+	dirs := tracker.GetTempDirs()
+	require.Len(t, dirs, 2)
+	require.Contains(t, dirs, tempDir1)
+	require.Contains(t, dirs, tempDir2)
+
+	testFile := filepath.Join(tempDir1, "test.txt")
+	require.NoError(t, os.WriteFile(testFile, []byte("test content"), 0644))
+
+	require.FileExists(t, testFile)
+
+	require.NoError(t, tracker.Cleanup())
+
+	require.NoDirExists(t, tempDir1)
+	require.NoDirExists(t, tempDir2)
+
+	require.Empty(t, tracker.GetTempDirs())
+}
+
+func TestTempDirTrackerCleanupNonexistent(t *testing.T) {
+	tracker := NewTempDirTracker()
+
+	tracker.Add("/nonexistent/directory")
+
+	require.NoError(t, tracker.Cleanup())
+}

--- a/op-deployer/pkg/deployer/bootstrap/flags.go
+++ b/op-deployer/pkg/deployer/bootstrap/flags.go
@@ -196,6 +196,7 @@ var ImplementationsFlags = []cli.Flag{
 	deployer.VerifierFlag,
 	deployer.VerifierUrlFlag,
 	deployer.VerifierAPIKeyFlag,
+	deployer.UseForgeFlag,
 }
 
 var ProxyFlags = []cli.Flag{
@@ -221,6 +222,7 @@ var SuperchainFlags = []cli.Flag{
 	deployer.VerifierFlag,
 	deployer.VerifierUrlFlag,
 	deployer.VerifierAPIKeyFlag,
+	deployer.UseForgeFlag,
 }
 
 var ValidatorFlags = []cli.Flag{

--- a/op-deployer/pkg/deployer/bootstrap/implementations.go
+++ b/op-deployer/pkg/deployer/bootstrap/implementations.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/artifacts"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/broadcaster"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/forge"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/opcm"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/verify"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/env"
@@ -51,6 +52,7 @@ type ImplementationsConfig struct {
 	SuperchainProxyAdmin            common.Address     `cli:"superchain-proxy-admin"`
 	Challenger                      common.Address     `cli:"challenger"`
 	CacheDir                        string             `cli:"cache-dir"`
+	UseForge                        bool               `cli:"use-forge"`
 
 	Logger log.Logger
 
@@ -204,77 +206,96 @@ func Implementations(ctx context.Context, cfg ImplementationsConfig) (opcm.Deplo
 		return dio, fmt.Errorf("failed to download artifacts: %w", err)
 	}
 
-	l1Client, err := ethclient.Dial(cfg.L1RPCUrl)
-	if err != nil {
-		return dio, fmt.Errorf("failed to connect to L1 RPC: %w", err)
+	input := opcm.DeployImplementationsInput{
+		WithdrawalDelaySeconds:          new(big.Int).SetUint64(cfg.WithdrawalDelaySeconds),
+		MinProposalSizeBytes:            new(big.Int).SetUint64(cfg.MinProposalSizeBytes),
+		ChallengePeriodSeconds:          new(big.Int).SetUint64(cfg.ChallengePeriodSeconds),
+		ProofMaturityDelaySeconds:       new(big.Int).SetUint64(cfg.ProofMaturityDelaySeconds),
+		DisputeGameFinalityDelaySeconds: new(big.Int).SetUint64(cfg.DisputeGameFinalityDelaySeconds),
+		MipsVersion:                     new(big.Int).SetUint64(uint64(cfg.MIPSVersion)),
+		DevFeatureBitmap:                cfg.DevFeatureBitmap,
+		FaultGameV2MaxGameDepth:         new(big.Int).SetUint64(cfg.FaultGameMaxGameDepth),
+		FaultGameV2SplitDepth:           new(big.Int).SetUint64(cfg.FaultGameSplitDepth),
+		FaultGameV2ClockExtension:       new(big.Int).SetUint64(cfg.FaultGameClockExtension),
+		FaultGameV2MaxClockDuration:     new(big.Int).SetUint64(cfg.FaultGameMaxClockDuration),
+		SuperchainConfigProxy:           cfg.SuperchainConfigProxy,
+		ProtocolVersionsProxy:           cfg.ProtocolVersionsProxy,
+		SuperchainProxyAdmin:            cfg.SuperchainProxyAdmin,
+		L1ProxyAdminOwner:               cfg.L1ProxyAdminOwner,
+		Challenger:                      cfg.Challenger,
 	}
 
-	chainID, err := l1Client.ChainID(ctx)
-	if err != nil {
-		return dio, fmt.Errorf("failed to get chain ID: %w", err)
-	}
+	if cfg.UseForge {
+		lgr.Info("using Forge for DeployImplementations")
+		forgeClient, err := forge.NewStandardClient(fmt.Sprintf("%v", artifactsFS))
+		if err != nil {
+			return dio, fmt.Errorf("failed to create forge client: %w", err)
+		}
 
-	signer := opcrypto.SignerFnFromBind(opcrypto.PrivateKeySignerFn(cfg.privateKeyECDSA, chainID))
-	chainDeployer := crypto.PubkeyToAddress(cfg.privateKeyECDSA.PublicKey)
+		forgeCaller := opcm.NewDeployImplementationsForgeCaller(forgeClient)
+		forgeOpts := []string{
+			"--rpc-url", cfg.L1RPCUrl,
+			"--broadcast",
+			"--private-key", cfg.PrivateKey,
+		}
+		dio, _, err = forgeCaller(ctx, input, forgeOpts...)
+		if err != nil {
+			return dio, fmt.Errorf("failed to deploy implementations with Forge: %w", err)
+		}
+	} else {
+		l1Client, err := ethclient.Dial(cfg.L1RPCUrl)
+		if err != nil {
+			return dio, fmt.Errorf("failed to connect to L1 RPC: %w", err)
+		}
 
-	bcaster, err := broadcaster.NewKeyedBroadcaster(broadcaster.KeyedBroadcasterOpts{
-		Logger:  lgr,
-		ChainID: chainID,
-		Client:  l1Client,
-		Signer:  signer,
-		From:    chainDeployer,
-	})
-	if err != nil {
-		return dio, fmt.Errorf("failed to create broadcaster: %w", err)
-	}
+		chainID, err := l1Client.ChainID(ctx)
+		if err != nil {
+			return dio, fmt.Errorf("failed to get chain ID: %w", err)
+		}
 
-	l1RPC, err := rpc.Dial(cfg.L1RPCUrl)
-	if err != nil {
-		return dio, fmt.Errorf("failed to connect to L1 RPC: %w", err)
-	}
+		signer := opcrypto.SignerFnFromBind(opcrypto.PrivateKeySignerFn(cfg.privateKeyECDSA, chainID))
+		chainDeployer := crypto.PubkeyToAddress(cfg.privateKeyECDSA.PublicKey)
 
-	l1Host, err := env.DefaultForkedScriptHost(
-		ctx,
-		bcaster,
-		lgr,
-		chainDeployer,
-		artifactsFS,
-		l1RPC,
-	)
-	if err != nil {
-		return dio, fmt.Errorf("failed to create script host: %w", err)
-	}
+		bcaster, err := broadcaster.NewKeyedBroadcaster(broadcaster.KeyedBroadcasterOpts{
+			Logger:  lgr,
+			ChainID: chainID,
+			Client:  l1Client,
+			Signer:  signer,
+			From:    chainDeployer,
+		})
+		if err != nil {
+			return dio, fmt.Errorf("failed to create broadcaster: %w", err)
+		}
 
-	opcmScripts, err := opcm.NewScripts(l1Host)
-	if err != nil {
-		return dio, fmt.Errorf("failed to load OPCM scripts: %w", err)
-	}
+		l1RPC, err := rpc.Dial(cfg.L1RPCUrl)
+		if err != nil {
+			return dio, fmt.Errorf("failed to connect to L1 RPC: %w", err)
+		}
 
-	if dio, err = opcmScripts.DeployImplementations.Run(
-		opcm.DeployImplementationsInput{
-			WithdrawalDelaySeconds:          new(big.Int).SetUint64(cfg.WithdrawalDelaySeconds),
-			MinProposalSizeBytes:            new(big.Int).SetUint64(cfg.MinProposalSizeBytes),
-			ChallengePeriodSeconds:          new(big.Int).SetUint64(cfg.ChallengePeriodSeconds),
-			ProofMaturityDelaySeconds:       new(big.Int).SetUint64(cfg.ProofMaturityDelaySeconds),
-			DisputeGameFinalityDelaySeconds: new(big.Int).SetUint64(cfg.DisputeGameFinalityDelaySeconds),
-			MipsVersion:                     new(big.Int).SetUint64(uint64(cfg.MIPSVersion)),
-			DevFeatureBitmap:                cfg.DevFeatureBitmap,
-			FaultGameV2MaxGameDepth:         new(big.Int).SetUint64(cfg.FaultGameMaxGameDepth),
-			FaultGameV2SplitDepth:           new(big.Int).SetUint64(cfg.FaultGameSplitDepth),
-			FaultGameV2ClockExtension:       new(big.Int).SetUint64(cfg.FaultGameClockExtension),
-			FaultGameV2MaxClockDuration:     new(big.Int).SetUint64(cfg.FaultGameMaxClockDuration),
-			SuperchainConfigProxy:           cfg.SuperchainConfigProxy,
-			ProtocolVersionsProxy:           cfg.ProtocolVersionsProxy,
-			SuperchainProxyAdmin:            cfg.SuperchainProxyAdmin,
-			L1ProxyAdminOwner:               cfg.L1ProxyAdminOwner,
-			Challenger:                      cfg.Challenger,
-		},
-	); err != nil {
-		return dio, fmt.Errorf("error deploying implementations: %w", err)
-	}
+		l1Host, err := env.DefaultForkedScriptHost(
+			ctx,
+			bcaster,
+			lgr,
+			chainDeployer,
+			artifactsFS,
+			l1RPC,
+		)
+		if err != nil {
+			return dio, fmt.Errorf("failed to create script host: %w", err)
+		}
 
-	if _, err := bcaster.Broadcast(ctx); err != nil {
-		return dio, fmt.Errorf("failed to broadcast: %w", err)
+		opcmScripts, err := opcm.NewScripts(l1Host)
+		if err != nil {
+			return dio, fmt.Errorf("failed to load OPCM scripts: %w", err)
+		}
+
+		if dio, err = opcmScripts.DeployImplementations.Run(input); err != nil {
+			return dio, fmt.Errorf("error deploying implementations: %w", err)
+		}
+
+		if _, err := bcaster.Broadcast(ctx); err != nil {
+			return dio, fmt.Errorf("failed to broadcast: %w", err)
+		}
 	}
 
 	lgr.Info("deployed implementations")

--- a/op-deployer/pkg/deployer/bootstrap/implementations_test.go
+++ b/op-deployer/pkg/deployer/bootstrap/implementations_test.go
@@ -65,10 +65,10 @@ func testImplementations(t *testing.T, forkRPCURL string) {
 
 	proxyAdminOwner, err := standard.L1ProxyAdminOwner(uint64(chainID.Uint64()))
 	require.NoError(t, err)
-	deploy := func() opcm.DeployImplementationsOutput {
+		deploy := func() opcm.DeployImplementationsOutput {
 		out, err := Implementations(ctx, ImplementationsConfig{
 			L1RPCUrl:                        l1RPC,
-			PrivateKey:                      "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+			PrivateKey:                      testutil.AnvilDefaultPrivateKey,
 			ArtifactsLocator:                loc,
 			Logger:                          lgr,
 			WithdrawalDelaySeconds:          standard.WithdrawalDelaySeconds,

--- a/op-deployer/pkg/deployer/bootstrap/implementations_test.go
+++ b/op-deployer/pkg/deployer/bootstrap/implementations_test.go
@@ -65,7 +65,7 @@ func testImplementations(t *testing.T, forkRPCURL string) {
 
 	proxyAdminOwner, err := standard.L1ProxyAdminOwner(uint64(chainID.Uint64()))
 	require.NoError(t, err)
-		deploy := func() opcm.DeployImplementationsOutput {
+	deploy := func() opcm.DeployImplementationsOutput {
 		out, err := Implementations(ctx, ImplementationsConfig{
 			L1RPCUrl:                        l1RPC,
 			PrivateKey:                      testutil.AnvilDefaultPrivateKey,

--- a/op-deployer/pkg/deployer/bootstrap/superchain.go
+++ b/op-deployer/pkg/deployer/bootstrap/superchain.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/artifacts"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/broadcaster"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/forge"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/opcm"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/verify"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/env"
@@ -33,6 +34,7 @@ type SuperchainConfig struct {
 	Logger           log.Logger
 	ArtifactsLocator *artifacts.Locator
 	CacheDir         string
+	UseForge         bool
 
 	privateKeyECDSA *ecdsa.PrivateKey
 
@@ -103,12 +105,14 @@ func SuperchainCLI(cliCtx *cli.Context) error {
 	recommendedVersionStr := cliCtx.String(RecommendedProtocolVersionFlagName)
 	outfile := cliCtx.String(OutfileFlagName)
 	cacheDir := cliCtx.String(deployer.CacheDirFlag.Name)
+	useForge := cliCtx.Bool(deployer.UseForgeFlagName)
 	cfg := SuperchainConfig{
 		L1RPCUrl:                  l1RPCUrl,
 		PrivateKey:                privateKey,
 		Logger:                    l,
 		ArtifactsLocator:          artifactsLocator,
 		CacheDir:                  cacheDir,
+		UseForge:                  useForge,
 		SuperchainProxyAdminOwner: superchainProxyAdminOwner,
 		ProtocolVersionsOwner:     protocolVersionsOwner,
 		Guardian:                  guardian,
@@ -193,68 +197,87 @@ func Superchain(ctx context.Context, cfg SuperchainConfig) (opcm.DeploySuperchai
 		return dso, fmt.Errorf("failed to download artifacts: %w", err)
 	}
 
-	l1Client, err := ethclient.Dial(cfg.L1RPCUrl)
-	if err != nil {
-		return dso, fmt.Errorf("failed to connect to L1 RPC: %w", err)
+	input := opcm.DeploySuperchainInput{
+		SuperchainProxyAdminOwner:  cfg.SuperchainProxyAdminOwner,
+		ProtocolVersionsOwner:      cfg.ProtocolVersionsOwner,
+		Guardian:                   cfg.Guardian,
+		Paused:                     cfg.Paused,
+		RequiredProtocolVersion:    cfg.RequiredProtocolVersion,
+		RecommendedProtocolVersion: cfg.RecommendedProtocolVersion,
 	}
 
-	chainID, err := l1Client.ChainID(ctx)
-	if err != nil {
-		return dso, fmt.Errorf("failed to get chain ID: %w", err)
-	}
+	if cfg.UseForge {
+		lgr.Info("using Forge for DeploySuperchain")
+		forgeClient, err := forge.NewStandardClient(fmt.Sprintf("%v", artifactsFS))
+		if err != nil {
+			return dso, fmt.Errorf("failed to create forge client: %w", err)
+		}
 
-	signer := opcrypto.SignerFnFromBind(opcrypto.PrivateKeySignerFn(cfg.privateKeyECDSA, chainID))
-	chainDeployer := crypto.PubkeyToAddress(cfg.privateKeyECDSA.PublicKey)
+		forgeCaller := opcm.NewDeploySuperchainForgeCaller(forgeClient)
+		forgeOpts := []string{
+			"--rpc-url", cfg.L1RPCUrl,
+			"--broadcast",
+			"--private-key", cfg.PrivateKey,
+		}
+		dso, _, err = forgeCaller(ctx, input, forgeOpts...)
+		if err != nil {
+			return dso, fmt.Errorf("failed to deploy superchain with Forge: %w", err)
+		}
+	} else {
+		l1Client, err := ethclient.Dial(cfg.L1RPCUrl)
+		if err != nil {
+			return dso, fmt.Errorf("failed to connect to L1 RPC: %w", err)
+		}
 
-	bcaster, err := broadcaster.NewKeyedBroadcaster(broadcaster.KeyedBroadcasterOpts{
-		Logger:  lgr,
-		ChainID: chainID,
-		Client:  l1Client,
-		Signer:  signer,
-		From:    chainDeployer,
-	})
-	if err != nil {
-		return dso, fmt.Errorf("failed to create broadcaster: %w", err)
-	}
+		chainID, err := l1Client.ChainID(ctx)
+		if err != nil {
+			return dso, fmt.Errorf("failed to get chain ID: %w", err)
+		}
 
-	l1RPC, err := rpc.Dial(cfg.L1RPCUrl)
-	if err != nil {
-		return dso, fmt.Errorf("failed to connect to L1 RPC: %w", err)
-	}
+		signer := opcrypto.SignerFnFromBind(opcrypto.PrivateKeySignerFn(cfg.privateKeyECDSA, chainID))
+		chainDeployer := crypto.PubkeyToAddress(cfg.privateKeyECDSA.PublicKey)
 
-	l1Host, err := env.DefaultForkedScriptHost(
-		ctx,
-		bcaster,
-		lgr,
-		chainDeployer,
-		artifactsFS,
-		l1RPC,
-	)
-	if err != nil {
-		return dso, fmt.Errorf("failed to create script host: %w", err)
-	}
+		bcaster, err := broadcaster.NewKeyedBroadcaster(broadcaster.KeyedBroadcasterOpts{
+			Logger:  lgr,
+			ChainID: chainID,
+			Client:  l1Client,
+			Signer:  signer,
+			From:    chainDeployer,
+		})
+		if err != nil {
+			return dso, fmt.Errorf("failed to create broadcaster: %w", err)
+		}
 
-	opcmScripts, err := opcm.NewScripts(l1Host)
-	if err != nil {
-		return dso, fmt.Errorf("failed to load OPCM scripts: %w", err)
-	}
+		l1RPC, err := rpc.Dial(cfg.L1RPCUrl)
+		if err != nil {
+			return dso, fmt.Errorf("failed to connect to L1 RPC: %w", err)
+		}
 
-	dso, err = opcmScripts.DeploySuperchain.Run(
-		opcm.DeploySuperchainInput{
-			SuperchainProxyAdminOwner:  cfg.SuperchainProxyAdminOwner,
-			ProtocolVersionsOwner:      cfg.ProtocolVersionsOwner,
-			Guardian:                   cfg.Guardian,
-			Paused:                     cfg.Paused,
-			RequiredProtocolVersion:    cfg.RequiredProtocolVersion,
-			RecommendedProtocolVersion: cfg.RecommendedProtocolVersion,
-		},
-	)
-	if err != nil {
-		return dso, fmt.Errorf("error deploying superchain: %w", err)
-	}
+		l1Host, err := env.DefaultForkedScriptHost(
+			ctx,
+			bcaster,
+			lgr,
+			chainDeployer,
+			artifactsFS,
+			l1RPC,
+		)
+		if err != nil {
+			return dso, fmt.Errorf("failed to create script host: %w", err)
+		}
 
-	if _, err := bcaster.Broadcast(ctx); err != nil {
-		return dso, fmt.Errorf("failed to broadcast: %w", err)
+		opcmScripts, err := opcm.NewScripts(l1Host)
+		if err != nil {
+			return dso, fmt.Errorf("failed to load OPCM scripts: %w", err)
+		}
+
+		dso, err = opcmScripts.DeploySuperchain.Run(input)
+		if err != nil {
+			return dso, fmt.Errorf("error deploying superchain: %w", err)
+		}
+
+		if _, err := bcaster.Broadcast(ctx); err != nil {
+			return dso, fmt.Errorf("failed to broadcast: %w", err)
+		}
 	}
 
 	lgr.Info("deployed superchain configuration")

--- a/op-deployer/pkg/deployer/bootstrap/superchain_test.go
+++ b/op-deployer/pkg/deployer/bootstrap/superchain_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/testutils/devnet"
 
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/artifacts"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/testutil"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -53,7 +54,7 @@ func testSuperchain(t *testing.T, forkRPCURL string) {
 
 	out, err := Superchain(ctx, SuperchainConfig{
 		L1RPCUrl:         l1RPC,
-		PrivateKey:       "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+		PrivateKey:       testutil.AnvilDefaultPrivateKey,
 		ArtifactsLocator: artifacts.EmbeddedLocator,
 		Logger:           lgr,
 

--- a/op-deployer/pkg/deployer/integration_test/cli/bootstrap_forge_test.go
+++ b/op-deployer/pkg/deployer/integration_test/cli/bootstrap_forge_test.go
@@ -1,0 +1,183 @@
+package cli
+
+import (
+	"encoding/json"
+	"math/big"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/addresses"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/integration_test/shared"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/opcm"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/standard"
+	"github.com/ethereum-optimism/optimism/op-service/testutils/devnet"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCLIBootstrapForge tests the bootstrap commands via CLI using Forge
+func TestCLIBootstrapForge(t *testing.T) {
+	// Use the same chain ID that anvil runs on
+	l1ChainID := uint64(devnet.DefaultChainID)
+	l1ChainIDBig := big.NewInt(int64(l1ChainID))
+
+	// Get dev keys for role addresses
+	dk, err := devkeys.NewMnemonicDevKeys(devkeys.TestMnemonic)
+	require.NoError(t, err)
+
+	// Get addresses for required roles
+	superchainProxyAdminOwner := shared.AddrFor(t, dk, devkeys.L1ProxyAdminOwnerRole.Key(l1ChainIDBig))
+	protocolVersionsOwner := shared.AddrFor(t, dk, devkeys.SuperchainDeployerKey.Key(l1ChainIDBig))
+	guardian := shared.AddrFor(t, dk, devkeys.SuperchainConfigGuardianKey.Key(l1ChainIDBig))
+	challenger := shared.AddrFor(t, dk, devkeys.ChallengerRole.Key(l1ChainIDBig))
+
+	t.Run("bootstrap superchain with forge", func(t *testing.T) {
+		runner := NewCLITestRunnerWithNetwork(t)
+		workDir := runner.GetWorkDir()
+
+		superchainOutputFile := filepath.Join(workDir, "bootstrap_superchain_forge.json")
+
+		// Run bootstrap superchain command with --use-forge
+		output := runner.ExpectSuccessWithNetwork(t, []string{
+			"bootstrap", "superchain",
+			"--outfile", superchainOutputFile,
+			"--superchain-proxy-admin-owner", superchainProxyAdminOwner.Hex(),
+			"--protocol-versions-owner", protocolVersionsOwner.Hex(),
+			"--guardian", guardian.Hex(),
+			"--use-forge",
+		}, nil)
+
+		t.Logf("Bootstrap superchain (forge) output:\n%s", output)
+
+		// Verify output file was created
+		require.FileExists(t, superchainOutputFile)
+
+		// Parse and validate the output
+		var superchainOutput opcm.DeploySuperchainOutput
+		data, err := os.ReadFile(superchainOutputFile)
+		require.NoError(t, err)
+		err = json.Unmarshal(data, &superchainOutput)
+		require.NoError(t, err)
+		require.NoError(t, addresses.CheckNoZeroAddresses(superchainOutput))
+	})
+
+	t.Run("bootstrap implementations with forge", func(t *testing.T) {
+		runner := NewCLITestRunnerWithNetwork(t)
+		workDir := runner.GetWorkDir()
+
+		// First, we need a superchain deployment using Forge
+		superchainOutputFile := filepath.Join(workDir, "bootstrap_superchain_for_impls_forge.json")
+		runner.ExpectSuccessWithNetwork(t, []string{
+			"bootstrap", "superchain",
+			"--outfile", superchainOutputFile,
+			"--superchain-proxy-admin-owner", superchainProxyAdminOwner.Hex(),
+			"--protocol-versions-owner", protocolVersionsOwner.Hex(),
+			"--guardian", guardian.Hex(),
+			"--use-forge",
+		}, nil)
+
+		// Parse superchain output to get addresses
+		var superchainOutput opcm.DeploySuperchainOutput
+		data, err := os.ReadFile(superchainOutputFile)
+		require.NoError(t, err)
+		err = json.Unmarshal(data, &superchainOutput)
+		require.NoError(t, err)
+		require.NoError(t, addresses.CheckNoZeroAddresses(superchainOutput))
+
+		implsOutputFile := filepath.Join(workDir, "bootstrap_implementations_forge.json")
+
+		// Run bootstrap implementations command with --use-forge
+		output := runner.ExpectSuccessWithNetwork(t, []string{
+			"bootstrap", "implementations",
+			"--outfile", implsOutputFile,
+			"--mips-version", strconv.Itoa(int(standard.MIPSVersion)),
+			"--protocol-versions-proxy", superchainOutput.ProtocolVersionsProxy.Hex(),
+			"--superchain-config-proxy", superchainOutput.SuperchainConfigProxy.Hex(),
+			"--l1-proxy-admin-owner", superchainProxyAdminOwner.Hex(),
+			"--superchain-proxy-admin", superchainOutput.SuperchainProxyAdmin.Hex(),
+			"--challenger", challenger.Hex(),
+			"--use-forge",
+		}, nil)
+
+		t.Logf("Bootstrap implementations (forge) output:\n%s", output)
+
+		// Verify output file was created
+		require.FileExists(t, implsOutputFile)
+
+		// Parse and validate the output
+		var implsOutput opcm.DeployImplementationsOutput
+		data, err = os.ReadFile(implsOutputFile)
+		require.NoError(t, err)
+		err = json.Unmarshal(data, &implsOutput)
+		require.NoError(t, err)
+
+		// We only check specific addresses that are always set
+		require.NotEqual(t, common.Address{}, implsOutput.Opcm, "Opcm should be set")
+		require.NotEqual(t, common.Address{}, implsOutput.OpcmStandardValidator, "OpcmStandardValidator should be set")
+		require.NotEqual(t, common.Address{}, implsOutput.DelayedWETHImpl, "DelayedWETHImpl should be set")
+		require.NotEqual(t, common.Address{}, implsOutput.OptimismPortalImpl, "OptimismPortalImpl should be set")
+		require.NotEqual(t, common.Address{}, implsOutput.ETHLockboxImpl, "ETHLockboxImpl should be set")
+		require.NotEqual(t, common.Address{}, implsOutput.PreimageOracleSingleton, "PreimageOracleSingleton should be set")
+		require.NotEqual(t, common.Address{}, implsOutput.MipsSingleton, "MipsSingleton should be set")
+		require.NotEqual(t, common.Address{}, implsOutput.SystemConfigImpl, "SystemConfigImpl should be set")
+		require.NotEqual(t, common.Address{}, implsOutput.L1CrossDomainMessengerImpl, "L1CrossDomainMessengerImpl should be set")
+		require.NotEqual(t, common.Address{}, implsOutput.L1ERC721BridgeImpl, "L1ERC721BridgeImpl should be set")
+		require.NotEqual(t, common.Address{}, implsOutput.L1StandardBridgeImpl, "L1StandardBridgeImpl should be set")
+		require.NotEqual(t, common.Address{}, implsOutput.OptimismMintableERC20FactoryImpl, "OptimismMintableERC20FactoryImpl should be set")
+		require.NotEqual(t, common.Address{}, implsOutput.DisputeGameFactoryImpl, "DisputeGameFactoryImpl should be set")
+		require.NotEqual(t, common.Address{}, implsOutput.AnchorStateRegistryImpl, "AnchorStateRegistryImpl should be set")
+		require.NotEqual(t, common.Address{}, implsOutput.SuperchainConfigImpl, "SuperchainConfigImpl should be set")
+		require.NotEqual(t, common.Address{}, implsOutput.ProtocolVersionsImpl, "ProtocolVersionsImpl should be set")
+	})
+
+	t.Run("bootstrap end-to-end with forge", func(t *testing.T) {
+		runner := NewCLITestRunnerWithNetwork(t)
+		workDir := runner.GetWorkDir()
+
+		// Step 1: Bootstrap superchain with Forge
+		superchainOutputFile := filepath.Join(workDir, "e2e_superchain_forge.json")
+		runner.ExpectSuccessWithNetwork(t, []string{
+			"bootstrap", "superchain",
+			"--outfile", superchainOutputFile,
+			"--superchain-proxy-admin-owner", superchainProxyAdminOwner.Hex(),
+			"--protocol-versions-owner", protocolVersionsOwner.Hex(),
+			"--guardian", guardian.Hex(),
+			"--use-forge",
+		}, nil)
+
+		var superchainOutput opcm.DeploySuperchainOutput
+		data, err := os.ReadFile(superchainOutputFile)
+		require.NoError(t, err)
+		err = json.Unmarshal(data, &superchainOutput)
+		require.NoError(t, err)
+
+		// Step 2: Bootstrap implementations with Forge
+		implsOutputFile := filepath.Join(workDir, "e2e_implementations_forge.json")
+		runner.ExpectSuccessWithNetwork(t, []string{
+			"bootstrap", "implementations",
+			"--outfile", implsOutputFile,
+			"--mips-version", strconv.Itoa(int(standard.MIPSVersion)),
+			"--protocol-versions-proxy", superchainOutput.ProtocolVersionsProxy.Hex(),
+			"--superchain-config-proxy", superchainOutput.SuperchainConfigProxy.Hex(),
+			"--l1-proxy-admin-owner", superchainProxyAdminOwner.Hex(),
+			"--superchain-proxy-admin", superchainOutput.SuperchainProxyAdmin.Hex(),
+			"--challenger", challenger.Hex(),
+			"--use-forge",
+		}, nil)
+
+		var implsOutput opcm.DeployImplementationsOutput
+		data, err = os.ReadFile(implsOutputFile)
+		require.NoError(t, err)
+		err = json.Unmarshal(data, &implsOutput)
+		require.NoError(t, err)
+
+		// Verify all outputs have valid addresses
+		require.NoError(t, addresses.CheckNoZeroAddresses(superchainOutput))
+		require.NotEqual(t, common.Address{}, implsOutput.Opcm, "Opcm should be set")
+
+		t.Log("✓ End-to-end bootstrap with Forge completed successfully")
+	})
+}

--- a/op-deployer/pkg/deployer/integration_test/cli/e2e_apply_forge_test.go
+++ b/op-deployer/pkg/deployer/integration_test/cli/e2e_apply_forge_test.go
@@ -1,0 +1,86 @@
+package cli
+
+import (
+	"math/big"
+	"path/filepath"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/addresses"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/integration_test/shared"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/pipeline"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/standard"
+	"github.com/ethereum-optimism/optimism/op-service/testutils/devnet"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCLIEndToEndApplyForge tests the full end-to-end apply workflow via CLI using Forge
+func TestCLIEndToEndApplyForge(t *testing.T) {
+	runner := NewCLITestRunnerWithNetwork(t)
+
+	workDir := runner.GetWorkDir()
+	// Use the same chain ID that anvil runs on
+	l1ChainID := uint64(devnet.DefaultChainID)
+	l2ChainID := uint256.NewInt(1)
+
+	dk, err := devkeys.NewMnemonicDevKeys(devkeys.TestMnemonic)
+	require.NoError(t, err)
+
+	t.Run("single chain with forge", func(t *testing.T) {
+		intent, _ := cliInitIntent(t, runner, l1ChainID, []common.Hash{l2ChainID.Bytes32()})
+		// Ensure OPCM address is nil so it gets deployed via pipeline (using Forge)
+		intent.OPCMAddress = nil
+
+		if intent.SuperchainRoles == nil {
+			t.Log("SuperchainRoles is nil, initializing...")
+			intent.SuperchainRoles = &addresses.SuperchainRoles{}
+		}
+
+		l1ChainIDBig := big.NewInt(int64(l1ChainID))
+		intent.SuperchainRoles.SuperchainProxyAdminOwner = shared.AddrFor(t, dk, devkeys.L1ProxyAdminOwnerRole.Key(l1ChainIDBig))
+		intent.SuperchainRoles.SuperchainGuardian = shared.AddrFor(t, dk, devkeys.SuperchainConfigGuardianKey.Key(l1ChainIDBig))
+		intent.SuperchainRoles.ProtocolVersionsOwner = shared.AddrFor(t, dk, devkeys.SuperchainDeployerKey.Key(l1ChainIDBig))
+		intent.SuperchainRoles.Challenger = shared.AddrFor(t, dk, devkeys.ChallengerRole.Key(l1ChainIDBig))
+
+		for _, chain := range intent.Chains {
+			chain.Roles.L1ProxyAdminOwner = shared.AddrFor(t, dk, devkeys.L2ProxyAdminOwnerRole.Key(l1ChainIDBig))
+			chain.Roles.L2ProxyAdminOwner = shared.AddrFor(t, dk, devkeys.L2ProxyAdminOwnerRole.Key(l1ChainIDBig))
+			chain.Roles.SystemConfigOwner = shared.AddrFor(t, dk, devkeys.SystemConfigOwner.Key(l1ChainIDBig))
+			chain.Roles.UnsafeBlockSigner = shared.AddrFor(t, dk, devkeys.SequencerP2PRole.Key(l1ChainIDBig))
+			chain.Roles.Batcher = shared.AddrFor(t, dk, devkeys.BatcherRole.Key(l1ChainIDBig))
+			chain.Roles.Proposer = shared.AddrFor(t, dk, devkeys.ProposerRole.Key(l1ChainIDBig))
+			chain.Roles.Challenger = shared.AddrFor(t, dk, devkeys.ChallengerRole.Key(l1ChainIDBig))
+
+			chain.BaseFeeVaultRecipient = shared.AddrFor(t, dk, devkeys.BaseFeeVaultRecipientRole.Key(l1ChainIDBig))
+			chain.L1FeeVaultRecipient = shared.AddrFor(t, dk, devkeys.L1FeeVaultRecipientRole.Key(l1ChainIDBig))
+			chain.SequencerFeeVaultRecipient = shared.AddrFor(t, dk, devkeys.SequencerFeeVaultRecipientRole.Key(l1ChainIDBig))
+			chain.OperatorFeeVaultRecipient = shared.AddrFor(t, dk, devkeys.OperatorFeeVaultRecipientRole.Key(l1ChainIDBig))
+
+			chain.Eip1559DenominatorCanyon = standard.Eip1559DenominatorCanyon
+			chain.Eip1559Denominator = standard.Eip1559Denominator
+			chain.Eip1559Elasticity = standard.Eip1559Elasticity
+		}
+		require.NoError(t, intent.WriteToFile(filepath.Join(workDir, "intent.toml")))
+
+		// Apply with live deployment AND --use-forge
+		// Assuming flag is --use-forge. If specific name differs, I'll need to check.
+		runner.ExpectSuccessWithNetwork(t, []string{
+			"apply",
+			"--deployment-target", "live",
+			"--workdir", workDir,
+			"--use-forge",
+		}, nil)
+
+		// Verify final state
+		finalState, err := pipeline.ReadState(workDir)
+		require.NoError(t, err)
+		require.Len(t, finalState.Chains, 1)
+		require.Equal(t, common.Hash(l2ChainID.Bytes32()), finalState.Chains[0].ID)
+		require.NotNil(t, finalState.AppliedIntent)
+
+		// Additional check to verify addresses are populated (meaning successful deployment)
+		require.NotEmpty(t, finalState.Chains[0].OpChainContracts.SystemConfigProxy)
+	})
+}

--- a/op-deployer/pkg/deployer/pipeline/env.go
+++ b/op-deployer/pkg/deployer/pipeline/env.go
@@ -33,6 +33,8 @@ type Env struct {
 	Scripts      *opcm.Scripts
 	ForgeClient  *forge.Client
 	UseForge     bool
+	L1RPCUrl     string
+	PrivateKey   string
 	Context      context.Context
 }
 

--- a/op-deployer/pkg/deployer/pipeline/implementations.go
+++ b/op-deployer/pkg/deployer/pipeline/implementations.go
@@ -1,6 +1,7 @@
 package pipeline
 
 import (
+	"context"
 	"fmt"
 	"math/big"
 
@@ -43,28 +44,49 @@ func DeployImplementations(env *Env, intent *state.Intent, st *state.State) erro
 		return fmt.Errorf("error merging proof params from overrides: %w", err)
 	}
 
-	dio, err := env.Scripts.DeployImplementations.Run(
-		opcm.DeployImplementationsInput{
-			WithdrawalDelaySeconds:          new(big.Int).SetUint64(proofParams.WithdrawalDelaySeconds),
-			MinProposalSizeBytes:            new(big.Int).SetUint64(proofParams.MinProposalSizeBytes),
-			ChallengePeriodSeconds:          new(big.Int).SetUint64(proofParams.ChallengePeriodSeconds),
-			ProofMaturityDelaySeconds:       new(big.Int).SetUint64(proofParams.ProofMaturityDelaySeconds),
-			DisputeGameFinalityDelaySeconds: new(big.Int).SetUint64(proofParams.DisputeGameFinalityDelaySeconds),
-			MipsVersion:                     new(big.Int).SetUint64(proofParams.MIPSVersion),
-			DevFeatureBitmap:                proofParams.DevFeatureBitmap,
-			FaultGameV2MaxGameDepth:         new(big.Int).SetUint64(proofParams.DisputeMaxGameDepth),
-			FaultGameV2SplitDepth:           new(big.Int).SetUint64(proofParams.DisputeSplitDepth),
-			FaultGameV2ClockExtension:       new(big.Int).SetUint64(proofParams.DisputeClockExtension),
-			FaultGameV2MaxClockDuration:     new(big.Int).SetUint64(proofParams.DisputeMaxClockDuration),
-			SuperchainConfigProxy:           st.SuperchainDeployment.SuperchainConfigProxy,
-			ProtocolVersionsProxy:           st.SuperchainDeployment.ProtocolVersionsProxy,
-			SuperchainProxyAdmin:            st.SuperchainDeployment.SuperchainProxyAdminImpl,
-			L1ProxyAdminOwner:               st.SuperchainRoles.SuperchainProxyAdminOwner,
-			Challenger:                      st.SuperchainRoles.Challenger,
-		},
-	)
-	if err != nil {
-		return fmt.Errorf("error deploying implementations: %w", err)
+	var dio opcm.DeployImplementationsOutput
+	input := opcm.DeployImplementationsInput{
+		WithdrawalDelaySeconds:          new(big.Int).SetUint64(proofParams.WithdrawalDelaySeconds),
+		MinProposalSizeBytes:            new(big.Int).SetUint64(proofParams.MinProposalSizeBytes),
+		ChallengePeriodSeconds:          new(big.Int).SetUint64(proofParams.ChallengePeriodSeconds),
+		ProofMaturityDelaySeconds:       new(big.Int).SetUint64(proofParams.ProofMaturityDelaySeconds),
+		DisputeGameFinalityDelaySeconds: new(big.Int).SetUint64(proofParams.DisputeGameFinalityDelaySeconds),
+		MipsVersion:                     new(big.Int).SetUint64(proofParams.MIPSVersion),
+		DevFeatureBitmap:                proofParams.DevFeatureBitmap,
+		FaultGameV2MaxGameDepth:         new(big.Int).SetUint64(proofParams.DisputeMaxGameDepth),
+		FaultGameV2SplitDepth:           new(big.Int).SetUint64(proofParams.DisputeSplitDepth),
+		FaultGameV2ClockExtension:       new(big.Int).SetUint64(proofParams.DisputeClockExtension),
+		FaultGameV2MaxClockDuration:     new(big.Int).SetUint64(proofParams.DisputeMaxClockDuration),
+		SuperchainConfigProxy:           st.SuperchainDeployment.SuperchainConfigProxy,
+		ProtocolVersionsProxy:           st.SuperchainDeployment.ProtocolVersionsProxy,
+		SuperchainProxyAdmin:            st.SuperchainDeployment.SuperchainProxyAdminImpl,
+		L1ProxyAdminOwner:               st.SuperchainRoles.SuperchainProxyAdminOwner,
+		Challenger:                      st.SuperchainRoles.Challenger,
+	}
+
+	if env.UseForge {
+		if env.ForgeClient == nil {
+			return fmt.Errorf("Forge client is nil but UseForge is enabled")
+		}
+		if env.Context == nil {
+			env.Context = context.Background()
+		}
+		lgr.Info("using Forge for DeployImplementations")
+		forgeCaller := opcm.NewDeployImplementationsForgeCaller(env.ForgeClient)
+		forgeOpts := []string{
+			"--rpc-url", env.L1RPCUrl,
+			"--broadcast",
+			"--private-key", env.PrivateKey,
+		}
+		dio, _, err = forgeCaller(env.Context, input, forgeOpts...)
+		if err != nil {
+			return fmt.Errorf("failed to deploy implementations with Forge: %w", err)
+		}
+	} else {
+		dio, err = env.Scripts.DeployImplementations.Run(input)
+		if err != nil {
+			return fmt.Errorf("error deploying implementations: %w", err)
+		}
 	}
 
 	st.ImplementationsDeployment = &addresses.ImplementationsContracts{

--- a/op-deployer/pkg/deployer/pipeline/opchain.go
+++ b/op-deployer/pkg/deployer/pipeline/opchain.go
@@ -1,6 +1,7 @@
 package pipeline
 
 import (
+	"context"
 	"fmt"
 	"math/big"
 
@@ -34,9 +35,29 @@ func DeployOPChain(env *Env, intent *state.Intent, st *state.State, chainID comm
 		return fmt.Errorf("error making deploy OP chain input: %w", err)
 	}
 
-	dco, err = env.Scripts.DeployOPChain.Run(dci)
-	if err != nil {
-		return fmt.Errorf("error deploying OP chain: %w", err)
+	if env.UseForge {
+		if env.ForgeClient == nil {
+			return fmt.Errorf("Forge client is nil but UseForge is enabled")
+		}
+		if env.Context == nil {
+			env.Context = context.Background()
+		}
+		lgr.Info("using Forge for DeployOPChain")
+		forgeCaller := opcm.NewDeployOPChainForgeCaller(env.ForgeClient)
+		forgeOpts := []string{
+			"--rpc-url", env.L1RPCUrl,
+			"--broadcast",
+			"--private-key", env.PrivateKey,
+		}
+		dco, _, err = forgeCaller(env.Context, dci, forgeOpts...)
+		if err != nil {
+			return fmt.Errorf("failed to deploy OP Chain with Forge: %w", err)
+		}
+	} else {
+		dco, err = env.Scripts.DeployOPChain.Run(dci)
+		if err != nil {
+			return fmt.Errorf("error deploying OP chain: %w", err)
+		}
 	}
 
 	readInput := opcm.ReadImplementationAddressesInput{
@@ -51,14 +72,27 @@ func DeployOPChain(env *Env, intent *state.Intent, st *state.State, chainID comm
 		Opcm:                              dci.Opcm,
 	}
 
-	readImplementations, err := opcm.NewReadImplementationAddressesScript(env.L1ScriptHost)
-	if err != nil {
-		return fmt.Errorf("failed to load ReadImplementationAddresses script: %w", err)
-	}
+	var impls opcm.ReadImplementationAddressesOutput
+	if env.UseForge {
+		lgr.Info("using Forge for ReadImplementationAddresses")
+		forgeCaller := opcm.NewReadImplementationAddressesForgeCaller(env.ForgeClient)
+		forgeOpts := []string{
+			"--rpc-url", env.L1RPCUrl,
+		}
+		impls, _, err = forgeCaller(env.Context, readInput, forgeOpts...)
+		if err != nil {
+			return fmt.Errorf("failed to run ReadImplementationAddresses with Forge: %w", err)
+		}
+	} else {
+		readImplementations, err := opcm.NewReadImplementationAddressesScript(env.L1ScriptHost)
+		if err != nil {
+			return fmt.Errorf("failed to load ReadImplementationAddresses script: %w", err)
+		}
 
-	impls, err := readImplementations.Run(readInput)
-	if err != nil {
-		return fmt.Errorf("failed to run ReadImplementationAddresses script: %w", err)
+		impls, err = readImplementations.Run(readInput)
+		if err != nil {
+			return fmt.Errorf("failed to run ReadImplementationAddresses script: %w", err)
+		}
 	}
 
 	st.Chains = append(st.Chains, makeChainState(chainID, impls, dco))

--- a/op-deployer/pkg/deployer/pipeline/opchain_test.go
+++ b/op-deployer/pkg/deployer/pipeline/opchain_test.go
@@ -229,7 +229,7 @@ func TestDeployOPChain_WithForge(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, anvil.Start())
 	t.Cleanup(func() {
-		anvil.Stop()
+		require.NoError(t, anvil.Stop())
 	})
 
 	l1RPCUrl := anvil.RPCUrl()

--- a/op-deployer/pkg/deployer/pipeline/opchain_test.go
+++ b/op-deployer/pkg/deployer/pipeline/opchain_test.go
@@ -1,12 +1,28 @@
 package pipeline
 
 import (
+	"context"
+	"fmt"
+	"log/slog"
 	"strings"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/addresses"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/script"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/script/forking"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/artifacts"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/broadcaster"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/forge"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/opcm"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/state"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/testutil"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/env"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-service/testutils/devnet"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_makeDCI_OpcmAddress(t *testing.T) {
@@ -195,4 +211,125 @@ func Test_makeDCI_OpcmAddress(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDeployOPChain_WithForge(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	embeddedArtifactsFS, err := artifacts.ExtractEmbedded(tmpDir)
+	require.NoError(t, err)
+
+	forgeClient, err := forge.NewStandardClient(fmt.Sprintf("%v", embeddedArtifactsFS))
+	require.NoError(t, err)
+
+	_, afacts := testutil.LocalArtifacts(t)
+	lgr := testlog.Logger(t, slog.LevelInfo)
+	anvil, err := devnet.NewAnvil(lgr)
+	require.NoError(t, err)
+	require.NoError(t, anvil.Start())
+	t.Cleanup(func() {
+		anvil.Stop()
+	})
+
+	l1RPCUrl := anvil.RPCUrl()
+	privateKey := "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+
+	l1RPC, err := rpc.Dial(l1RPCUrl)
+	require.NoError(t, err)
+	l1Client := ethclient.NewClient(l1RPC)
+
+	host, err := env.DefaultScriptHost(
+		broadcaster.NoopBroadcaster(),
+		lgr,
+		common.Address{'D'},
+		afacts,
+		script.WithForkHook(func(cfg *script.ForkConfig) (forking.ForkSource, error) {
+			src, err := forking.RPCSourceByNumber(cfg.URLOrAlias, l1RPC, *cfg.BlockNumber)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create RPC fork source: %w", err)
+			}
+			return forking.Cache(src), nil
+		}),
+	)
+	require.NoError(t, err)
+
+	latest, err := l1Client.HeaderByNumber(ctx, nil)
+	require.NoError(t, err)
+
+	_, err = host.CreateSelectFork(
+		script.ForkWithURLOrAlias("main"),
+		script.ForkWithBlockNumberU256(latest.Number),
+	)
+	require.NoError(t, err)
+
+	// Load scripts
+	opcmScripts := &opcm.Scripts{}
+
+	chainID := common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000300")
+	salt := common.HexToHash("0x1234567890123456789012345678901234567890123456789012345678901234")
+
+	// Create test input
+	intent := &state.Intent{
+		GlobalDeployOverrides: make(map[string]any),
+		Chains: []*state.ChainIntent{
+			{
+				ID: chainID,
+				Roles: state.ChainRoles{
+					L1ProxyAdminOwner: common.Address{'A'},
+					SystemConfigOwner: common.Address{'B'},
+					Batcher:           common.Address{'C'},
+					UnsafeBlockSigner: common.Address{'D'},
+					Proposer:          common.Address{'E'},
+					Challenger:        common.Address{'F'},
+				},
+				GasLimit: 60_000_000,
+			},
+		},
+		SuperchainRoles: &addresses.SuperchainRoles{
+			SuperchainProxyAdminOwner: common.Address{'S'},
+			ProtocolVersionsOwner:     common.Address{'P'},
+			SuperchainGuardian:        common.Address{'G'},
+			Challenger:                common.HexToAddress("0xEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE"),
+		},
+	}
+
+	st := &state.State{
+		Version:     1,
+		Create2Salt: salt,
+	}
+
+	pEnv := &Env{
+		Logger:       lgr,
+		Scripts:      opcmScripts,
+		ForgeClient:  forgeClient,
+		UseForge:     true,
+		Context:      ctx,
+		Broadcaster:  broadcaster.NoopBroadcaster(),
+		StateWriter:  NoopStateWriter(),
+		L1ScriptHost: host,
+		L1RPCUrl:     l1RPCUrl,
+		PrivateKey:   privateKey,
+	}
+
+	err = DeploySuperchain(pEnv, intent, st)
+	require.NoError(t, err)
+
+	err = DeployImplementations(pEnv, intent, st)
+	require.NoError(t, err)
+
+	err = DeployOPChain(pEnv, intent, st, chainID)
+	require.NoError(t, err)
+
+	require.Len(t, st.Chains, 1)
+	require.Equal(t, chainID, st.Chains[0].ID)
+
+	chainState := st.Chains[0]
+	require.NotEqual(t, common.Address{}, chainState.OpChainContracts.OpChainProxyAdminImpl)
+	require.NotEqual(t, common.Address{}, chainState.OpChainContracts.AddressManagerImpl)
+	require.NotEqual(t, common.Address{}, chainState.OpChainContracts.L1Erc721BridgeProxy)
+	require.NotEqual(t, common.Address{}, chainState.OpChainContracts.SystemConfigProxy)
+	require.NotEqual(t, common.Address{}, chainState.OpChainContracts.OptimismMintableErc20FactoryProxy)
+	require.NotEqual(t, common.Address{}, chainState.OpChainContracts.L1StandardBridgeProxy)
+	require.NotEqual(t, common.Address{}, chainState.OpChainContracts.L1CrossDomainMessengerProxy)
 }

--- a/op-deployer/pkg/deployer/pipeline/superchain.go
+++ b/op-deployer/pkg/deployer/pipeline/superchain.go
@@ -40,9 +40,17 @@ func DeploySuperchain(env *Env, intent *state.Intent, st *state.State) error {
 		if env.Context == nil {
 			env.Context = context.Background()
 		}
+		if env.PrivateKey == "" {
+			return fmt.Errorf("private key is required when UseForge is enabled")
+		}
 		lgr.Info("using Forge for DeploySuperchain")
 		forgeCaller := opcm.NewDeploySuperchainForgeCaller(env.ForgeClient)
-		dso, _, err = forgeCaller(env.Context, input)
+		forgeOpts := []string{
+			"--rpc-url", env.L1RPCUrl,
+			"--broadcast",
+			"--private-key", env.PrivateKey,
+		}
+		dso, _, err = forgeCaller(env.Context, input, forgeOpts...)
 		if err != nil {
 			return fmt.Errorf("failed to deploy superchain with Forge: %w", err)
 		}

--- a/op-deployer/pkg/deployer/pipeline/superchain_test.go
+++ b/op-deployer/pkg/deployer/pipeline/superchain_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/env"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-service/testutils/devnet"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/stretchr/testify/require"
@@ -26,18 +27,24 @@ func TestDeploySuperchain_WithForge(t *testing.T) {
 	ctx := context.Background()
 	tmpDir := t.TempDir()
 
-	// Extract embedded artifacts
 	embeddedArtifactsFS, err := artifacts.ExtractEmbedded(tmpDir)
 	require.NoError(t, err)
 
-	// Create Forge client
 	forgeClient, err := forge.NewStandardClient(fmt.Sprintf("%v", embeddedArtifactsFS))
 	require.NoError(t, err)
 
-	// Create a test host for other scripts (even though we won't use it for DeploySuperchain)
-	// We use LocalArtifacts which should have compatible versions
 	_, afacts := testutil.LocalArtifacts(t)
 	lgr := testlog.Logger(t, slog.LevelInfo)
+	anvil, err := devnet.NewAnvil(lgr)
+	require.NoError(t, err)
+	require.NoError(t, anvil.Start())
+	t.Cleanup(func() {
+		require.NoError(t, anvil.Stop())
+	})
+
+	l1RPCUrl := anvil.RPCUrl()
+	privateKey := "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+
 	host, err := env.DefaultScriptHost(
 		broadcaster.NoopBroadcaster(),
 		lgr,
@@ -46,11 +53,9 @@ func TestDeploySuperchain_WithForge(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	// Load scripts (needed for Env, even though we'll use Forge for DeploySuperchain)
 	opcmScripts, err := opcm.NewScripts(host)
 	require.NoError(t, err)
 
-	// Create test input
 	intent := &state.Intent{
 		SuperchainRoles: &addresses.SuperchainRoles{
 			SuperchainProxyAdminOwner: common.BigToAddress(big.NewInt(1)),
@@ -62,7 +67,6 @@ func TestDeploySuperchain_WithForge(t *testing.T) {
 		Version: 1,
 	}
 
-	// Create Env with Forge enabled
 	pEnv := &Env{
 		Logger:      lgr,
 		Scripts:     opcmScripts,
@@ -71,24 +75,22 @@ func TestDeploySuperchain_WithForge(t *testing.T) {
 		Context:     ctx,
 		Broadcaster: broadcaster.NoopBroadcaster(),
 		StateWriter: NoopStateWriter(),
+		L1RPCUrl:    l1RPCUrl,
+		PrivateKey:  privateKey,
 	}
 
-	// Test DeploySuperchain with Forge
 	err = DeploySuperchain(pEnv, intent, st)
 	require.NoError(t, err)
 
-	// Verify the deployment was successful
 	require.NotNil(t, st.SuperchainDeployment)
 	require.NotNil(t, st.SuperchainRoles)
 
-	// Verify addresses are set
 	require.NotEqual(t, common.Address{}, st.SuperchainDeployment.SuperchainProxyAdminImpl)
 	require.NotEqual(t, common.Address{}, st.SuperchainDeployment.SuperchainConfigProxy)
 	require.NotEqual(t, common.Address{}, st.SuperchainDeployment.SuperchainConfigImpl)
 	require.NotEqual(t, common.Address{}, st.SuperchainDeployment.ProtocolVersionsProxy)
 	require.NotEqual(t, common.Address{}, st.SuperchainDeployment.ProtocolVersionsImpl)
 
-	// Verify roles match
 	require.Equal(t, intent.SuperchainRoles.SuperchainProxyAdminOwner, st.SuperchainRoles.SuperchainProxyAdminOwner)
 	require.Equal(t, intent.SuperchainRoles.ProtocolVersionsOwner, st.SuperchainRoles.ProtocolVersionsOwner)
 	require.Equal(t, intent.SuperchainRoles.SuperchainGuardian, st.SuperchainRoles.SuperchainGuardian)
@@ -98,17 +100,24 @@ func TestDeploySuperchain_WithForgeEverywhere(t *testing.T) {
 	ctx := context.Background()
 	tmpDir := t.TempDir()
 
-	// Extract embedded artifacts
 	embeddedArtifactsFS, err := artifacts.ExtractEmbedded(tmpDir)
 	require.NoError(t, err)
 
-	// Create Forge client
 	forgeClient, err := forge.NewStandardClient(fmt.Sprintf("%v", embeddedArtifactsFS))
 	require.NoError(t, err)
 
-	// Create a test host for other scripts (even though we won't use it for DeploySuperchain)
 	_, afacts := testutil.LocalArtifacts(t)
 	lgr := testlog.Logger(t, slog.LevelInfo)
+	anvil, err := devnet.NewAnvil(lgr)
+	require.NoError(t, err)
+	require.NoError(t, anvil.Start())
+	t.Cleanup(func() {
+		require.NoError(t, anvil.Stop())
+	})
+
+	l1RPCUrl := anvil.RPCUrl()
+	privateKey := "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+
 	host, err := env.DefaultScriptHost(
 		broadcaster.NoopBroadcaster(),
 		lgr,
@@ -117,11 +126,9 @@ func TestDeploySuperchain_WithForgeEverywhere(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	// Load scripts (needed for Env, even though we'll use Forge for DeploySuperchain)
 	opcmScripts, err := opcm.NewScripts(host)
 	require.NoError(t, err)
 
-	// Create test input
 	intent := &state.Intent{
 		SuperchainRoles: &addresses.SuperchainRoles{
 			SuperchainProxyAdminOwner: common.BigToAddress(big.NewInt(1)),
@@ -133,7 +140,6 @@ func TestDeploySuperchain_WithForgeEverywhere(t *testing.T) {
 		Version: 1,
 	}
 
-	// Create Env with UseForge enabled
 	pEnv := &Env{
 		Logger:      lgr,
 		Scripts:     opcmScripts,
@@ -142,17 +148,16 @@ func TestDeploySuperchain_WithForgeEverywhere(t *testing.T) {
 		Context:     ctx,
 		Broadcaster: broadcaster.NoopBroadcaster(),
 		StateWriter: NoopStateWriter(),
+		L1RPCUrl:    l1RPCUrl,
+		PrivateKey:  privateKey,
 	}
 
-	// Test DeploySuperchain with Forge
 	err = DeploySuperchain(pEnv, intent, st)
 	require.NoError(t, err)
 
-	// Verify the deployment was successful
 	require.NotNil(t, st.SuperchainDeployment)
 	require.NotNil(t, st.SuperchainRoles)
 
-	// Verify addresses are set
 	require.NotEqual(t, common.Address{}, st.SuperchainDeployment.SuperchainProxyAdminImpl)
 	require.NotEqual(t, common.Address{}, st.SuperchainDeployment.SuperchainConfigProxy)
 	require.NotEqual(t, common.Address{}, st.SuperchainDeployment.SuperchainConfigImpl)
@@ -164,18 +169,14 @@ func TestDeploySuperchain_WithForge_ManualCall(t *testing.T) {
 	ctx := context.Background()
 	tmpDir := t.TempDir()
 
-	// Extract embedded artifacts
 	embeddedArtifactsFS, err := artifacts.ExtractEmbedded(tmpDir)
 	require.NoError(t, err)
 
-	// Create Forge client
 	forgeClient, err := forge.NewStandardClient(fmt.Sprintf("%v", embeddedArtifactsFS))
 	require.NoError(t, err)
 
-	// Create Forge caller directly (similar to TestNewDeploySuperchainScriptForge)
 	deploySuperchain := opcm.NewDeploySuperchainForgeCaller(forgeClient)
 
-	// Create input matching what DeploySuperchain would use
 	input := opcm.DeploySuperchainInput{
 		Guardian:                   common.BigToAddress(big.NewInt(1)),
 		ProtocolVersionsOwner:      common.BigToAddress(big.NewInt(2)),
@@ -185,13 +186,11 @@ func TestDeploySuperchain_WithForge_ManualCall(t *testing.T) {
 		RecommendedProtocolVersion: params.ProtocolVersion(rollup.OPStackSupport),
 	}
 
-	// Call Forge script
 	output, recompiled, err := deploySuperchain(ctx, input)
 	require.NoError(t, err)
 	require.False(t, recompiled, "script should not be recompiled")
 	require.NotNil(t, output)
 
-	// Verify output addresses are set
 	require.NotEqual(t, common.Address{}, output.SuperchainProxyAdmin)
 	require.NotEqual(t, common.Address{}, output.SuperchainConfigProxy)
 	require.NotEqual(t, common.Address{}, output.SuperchainConfigImpl)

--- a/op-deployer/pkg/deployer/testutil/constants.go
+++ b/op-deployer/pkg/deployer/testutil/constants.go
@@ -1,0 +1,4 @@
+package testutil
+
+// AnvilDefaultPrivateKey is the default private key for tests that need a funded account.
+const AnvilDefaultPrivateKey = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"

--- a/op-deployer/scripts/test-sepolia-op-deployer.sh
+++ b/op-deployer/scripts/test-sepolia-op-deployer.sh
@@ -576,6 +576,21 @@ case "$DEPLOY_TYPE" in
             fi
         fi
         
+        USE_FORGE=false
+        if [ -n "${DEPLOYER_USE_FORGE:-}" ]; then
+            USE_FORGE=true
+            echo ""
+            echo -e "${GREEN}✓ Using Forge from environment${NC}"
+        else
+            echo ""
+            echo -e "${YELLOW}Deployment Engine${NC}"
+            echo "  1) Use default Go scripts (recommended)"
+            echo "  2) Use Forge scripts"
+            echo ""
+            read -r -p "Select deployment engine [1-2, default 1]: " ENGINE_CHOICE
+            [ "$ENGINE_CHOICE" == "2" ] && USE_FORGE=true
+        fi
+        
         AUTO_VALIDATE_ENABLED=false
         if [ -n "${DEPLOYER_AUTO_VALIDATE:-}" ]; then
             AUTO_VALIDATE_ENABLED=true
@@ -599,6 +614,11 @@ case "$DEPLOY_TYPE" in
         echo "  Workdir: $WORKDIR"
         echo "  L1 Chain ID: $L1_CHAIN_ID"
         echo "  L2 Chain ID: $L2_CHAIN_ID"
+        if [ "$USE_FORGE" == "true" ]; then
+            echo -e "  Engine: ${GREEN}Forge scripts${NC}"
+        else
+            echo -e "  Engine: ${GREEN}Go scripts (default)${NC}"
+        fi
         if [ "$AUTO_VALIDATE_ENABLED" == "true" ]; then
             echo -e "  Validation: ${GREEN}Enabled (auto-detect version and chain ID)${NC}"
         else
@@ -631,6 +651,7 @@ case "$DEPLOY_TYPE" in
             "--deployment-target" "live"
         )
         
+        [ "$USE_FORGE" == "true" ] && APPLY_CMD+=("--use-forge")
         [ "$AUTO_VALIDATE_ENABLED" == "true" ] && APPLY_CMD+=("--validate" "auto")
         
         if "${APPLY_CMD[@]}"; then
@@ -828,19 +849,7 @@ if [ "$DEPLOY_TYPE" == "1" ] || [ "$DEPLOY_TYPE" == "2" ]; then
         [[ "$VERIFIER_TYPE" == *"etherscan"* ]] && [ -n "$ETHERSCAN_API_KEY" ] && CMD+=("--verifier-api-key" "$ETHERSCAN_API_KEY")
     fi
     
-    USE_FORGE=false
-    if [ -n "${DEPLOYER_USE_FORGE:-}" ]; then
-        USE_FORGE=true
-        echo -e "${GREEN}✓ Using Forge from environment${NC}"
-    else
-        echo ""
-        echo -e "${YELLOW}Deployment Engine${NC}"
-        echo "  1) Use default Go scripts (recommended)"
-        echo "  2) Use Forge scripts"
-        echo ""
-        read -r -p "Select deployment engine [1-2, default 1]: " ENGINE_CHOICE
-        [ "$ENGINE_CHOICE" == "2" ] && USE_FORGE=true
-    fi
+
     
     [ "$USE_FORGE" == "true" ] && CMD+=("--use-forge")
     

--- a/op-deployer/scripts/test-sepolia-op-deployer.sh
+++ b/op-deployer/scripts/test-sepolia-op-deployer.sh
@@ -828,6 +828,22 @@ if [ "$DEPLOY_TYPE" == "1" ] || [ "$DEPLOY_TYPE" == "2" ]; then
         [[ "$VERIFIER_TYPE" == *"etherscan"* ]] && [ -n "$ETHERSCAN_API_KEY" ] && CMD+=("--verifier-api-key" "$ETHERSCAN_API_KEY")
     fi
     
+    USE_FORGE=false
+    if [ -n "${DEPLOYER_USE_FORGE:-}" ]; then
+        USE_FORGE=true
+        echo -e "${GREEN}✓ Using Forge from environment${NC}"
+    else
+        echo ""
+        echo -e "${YELLOW}Deployment Engine${NC}"
+        echo "  1) Use default Go scripts (recommended)"
+        echo "  2) Use Forge scripts"
+        echo ""
+        read -r -p "Select deployment engine [1-2, default 1]: " ENGINE_CHOICE
+        [ "$ENGINE_CHOICE" == "2" ] && USE_FORGE=true
+    fi
+    
+    [ "$USE_FORGE" == "true" ] && CMD+=("--use-forge")
+    
     if "${CMD[@]}"; then
         echo ""
         echo -e "${BLUE}═══════════════════════════════════════════════════════════════${NC}"


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Second part of adding the forge flag to op-deployer.

- Adds support for forge on the bootstrap scripts
- Wraps DeployOPChain and DeployImplementations
- Adds support to the `./scripts/test-sepolia-op-deployer.sh` script for using forge
- Sorts out the artifacts bloating issue

This has been tested with the `test-sepolia-op-deployer.sh` script.

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
