### PR TITLE
feat(op-deployer): op-validator integration

### DIFF
--- a/op-deployer/pkg/cli/app.go
+++ b/op-deployer/pkg/cli/app.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/inspect"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/manage"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/upgrade"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/validate"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/verify"
 
 	"github.com/ethereum-optimism/optimism/op-service/cliapp"
@@ -71,6 +72,11 @@ func NewApp(versionWithMeta string) *cli.App {
 			Name:        "manage",
 			Usage:       "manages the chain",
 			Subcommands: manage.Commands,
+		},
+		{
+			Name:        "validate",
+			Usage:       "validates chain configuration and deployment",
+			Subcommands: validate.Commands(),
 		},
 	}
 	return app

--- a/op-deployer/pkg/deployer/apply.go
+++ b/op-deployer/pkg/deployer/apply.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/big"
 	"strings"
+	"time"
 
 	"github.com/ethereum-optimism/optimism/op-service/ioutil"
 
@@ -19,11 +20,14 @@ import (
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/opcm"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/pipeline"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/state"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/validate"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/verify"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/env"
 	opcrypto "github.com/ethereum-optimism/optimism/op-service/crypto"
 	"github.com/ethereum-optimism/optimism/op-service/ctxinterrupt"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
+	"github.com/ethereum-optimism/optimism/op-validator/pkg/service"
+	"github.com/ethereum-optimism/optimism/op-validator/pkg/validations"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -117,6 +121,10 @@ func ApplyCLI() func(cliCtx *cli.Context) error {
 			return err
 		}
 
+		if err := runValidationAfterApply(ctx, cliCtx, l, workdir, l1RPCUrl, depTarget); err != nil {
+			return fmt.Errorf("validation failed: %w", err)
+		}
+
 		if !cliCtx.Bool(AutoVerifyFlag.Name) {
 			return nil
 		}
@@ -144,6 +152,91 @@ func ApplyCLI() func(cliCtx *cli.Context) error {
 			cliCtx.String(VerifierAPIKeyFlagName),
 		)
 	}
+}
+
+func runValidationAfterApply(ctx context.Context, cliCtx *cli.Context, l log.Logger, workdir, l1RPCUrl string, depTarget DeploymentTarget) error {
+	validateFlag := cliCtx.String(ValidateFlag.Name)
+	// Empty string means validation is disabled
+	if validateFlag == "" {
+		return nil
+	}
+
+	// Skip validation for non-live deployments or when L1 RPC URL is empty
+	// Validation requires a live RPC connection to check contract code
+	if depTarget != DeploymentTargetLive || l1RPCUrl == "" {
+		l.Info("Skipping validation", "reason", "validation requires live deployment with L1 RPC URL", "deployment-target", depTarget, "l1-rpc-url-set", l1RPCUrl != "")
+		return nil
+	}
+
+	st, err := pipeline.ReadState(workdir)
+	if err != nil {
+		return fmt.Errorf("failed to read state for validation: %w", err)
+	}
+
+	if st.AppliedIntent == nil {
+		return fmt.Errorf("cannot validate: no applied intent found")
+	}
+
+	// Add timeout to prevent indefinite hangs
+	// Use a reasonable timeout for validation (5 minutes should be sufficient)
+	validationCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+
+	validatorVersion := validate.DetectValidatorVersion(validateFlag, st.AppliedIntent, l)
+
+	l.Info("Running validation after deployment", "version", validatorVersion, "intent-type", st.AppliedIntent.ConfigType, "timeout", "5m")
+
+	for _, chain := range st.AppliedIntent.Chains {
+		chainID := chain.ID
+		l.Info("Validating chain", "chain-id", chainID.Hex(), "version", validatorVersion)
+
+		chainState, err := st.Chain(chainID)
+		if err != nil {
+			return fmt.Errorf("failed to get chain state for %s: %w", chainID.Hex(), err)
+		}
+
+		validatorCfg, err := validate.BuildValidatorConfigFromState(validationCtx, l, st, chainState, chainID, l1RPCUrl)
+		if err != nil {
+			return fmt.Errorf("failed to build validator config for chain %s: %w", chainID.Hex(), err)
+		}
+
+		// Skip validation if no validator address is available and L1 chain ID is not supported
+		// This handles custom/test deployments where OPCM may not have a validator set
+		if validatorCfg.ValidatorAddress == (common.Address{}) {
+			l1ChainID, err := ChainIDFromRPC(validationCtx, l1RPCUrl)
+			if err != nil {
+				l.Warn("Failed to get L1 chain ID, skipping validation", "chain-id", chainID.Hex(), "error", err)
+				continue
+			}
+			// Check if L1 chain ID is supported (mainnet=1, sepolia=11155111)
+			if l1ChainID.Uint64() != 1 && l1ChainID.Uint64() != 11155111 {
+				l.Info("Skipping validation", "reason", "no validator address available and L1 chain ID not supported", "chain-id", chainID.Hex(), "l1-chain-id", l1ChainID.Uint64())
+				continue
+			}
+		}
+
+		errors, err := service.Validate(validationCtx, l, validatorVersion, validatorCfg)
+		if err != nil {
+			l.Error("Validation failed", "chain-id", chainID.Hex(), "error", err)
+			return fmt.Errorf("validation failed for chain %s: %w", chainID.Hex(), err)
+		}
+
+		out := validations.Output{
+			Errors: errors,
+		}
+
+		l.Info("Validation results", "chain-id", chainID.Hex(), "error-count", len(errors))
+		fmt.Println(out.AsMarkdown())
+
+		if len(errors) > 0 {
+			l.Error("Validation errors found", "chain-id", chainID.Hex(), "error-count", len(errors))
+			return fmt.Errorf("validation errors found for chain %s", chainID.Hex())
+		}
+
+		l.Info("Validation passed", "chain-id", chainID.Hex())
+	}
+
+	return nil
 }
 
 func Apply(ctx context.Context, cfg ApplyConfig) error {

--- a/op-deployer/pkg/deployer/flags.go
+++ b/op-deployer/pkg/deployer/flags.go
@@ -141,6 +141,12 @@ var (
 		EnvVars: PrefixEnvVar("USE_FORGE"),
 		Value:   false,
 	}
+	ValidateFlag = &cli.StringFlag{
+		Name:    "validate",
+		Usage:   "automatically validate deployment after apply. Specify validator version (e.g., v2.0.0) or 'auto' to auto-detect from state.json (default: auto)",
+		EnvVars: PrefixEnvVar("VALIDATE"),
+		Value:   "auto",
+	}
 )
 
 var GlobalFlags = append([]cli.Flag{CacheDirFlag}, oplog.CLIFlags(EnvVarPrefix)...)
@@ -163,6 +169,7 @@ var ApplyFlags = []cli.Flag{
 	VerifierFlag,
 	VerifierUrlFlag,
 	UseForgeFlag,
+	ValidateFlag,
 }
 
 var UpgradeFlags = []cli.Flag{

--- a/op-deployer/pkg/deployer/flags.go
+++ b/op-deployer/pkg/deployer/flags.go
@@ -143,9 +143,9 @@ var (
 	}
 	ValidateFlag = &cli.StringFlag{
 		Name:    "validate",
-		Usage:   "automatically validate deployment after apply. Specify validator version (e.g., v2.0.0) or 'auto' to auto-detect from state.json (default: auto)",
+		Usage:   "automatically validate deployment after apply. Specify validator version (e.g., v2.0.0) or 'auto' to auto-detect from state.json. If not specified, validation is skipped.",
 		EnvVars: PrefixEnvVar("VALIDATE"),
-		Value:   "auto",
+		Value:   "",
 	}
 )
 

--- a/op-deployer/pkg/deployer/integration_test/cli/cli_runner.go
+++ b/op-deployer/pkg/deployer/integration_test/cli/cli_runner.go
@@ -199,3 +199,15 @@ func (r *CLITestRunner) ExpectErrorContains(t *testing.T, args []string, env map
 	require.Contains(t, output, contains, "Error message should contain expected text")
 	return output
 }
+
+// ExpectErrorContainsWithNetwork runs a command with network parameters expecting it to fail with specific error text
+func (r *CLITestRunner) ExpectErrorContainsWithNetwork(t *testing.T, args []string, env map[string]string, contains string) string {
+	r.lgr.Info("Running cli command with network, expecting error")
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	output, err := r.RunWithNetwork(ctx, args, env)
+	require.Error(t, err, "Expected command to fail but it succeeded")
+	require.Contains(t, output, contains, "Error message should contain expected text")
+	return output
+}

--- a/op-deployer/pkg/deployer/integration_test/cli/migrate_test.go
+++ b/op-deployer/pkg/deployer/integration_test/cli/migrate_test.go
@@ -245,6 +245,7 @@ func TestCLIMigrateV1(t *testing.T) {
 		"apply",
 		"--deployment-target", "live",
 		"--workdir", workDir,
+		"--validate", "auto",
 	}, nil)
 
 	// Verify deployment succeeded regardless of validation errors
@@ -478,6 +479,7 @@ func TestCLIMigrateV2(t *testing.T) {
 		"apply",
 		"--deployment-target", "live",
 		"--workdir", workDir,
+		"--validate", "auto",
 	}, nil)
 
 	// Verify deployment succeeded regardless of validation errors

--- a/op-deployer/pkg/deployer/integration_test/cli/migrate_test.go
+++ b/op-deployer/pkg/deployer/integration_test/cli/migrate_test.go
@@ -239,20 +239,30 @@ func TestCLIMigrateV1(t *testing.T) {
 	require.NoError(t, intent.WriteToFile(filepath.Join(workDir, "intent.toml")))
 
 	// Apply deployment
-	runner.ExpectSuccessWithNetwork(t, []string{
+	// Note: Validation will run automatically but may find expected errors for migration test deployments
+	// (e.g., custom dev features, non-standard configurations). We verify deployment succeeded despite validation errors.
+	output, runErr := runner.RunWithNetwork(context.Background(), []string{
 		"apply",
 		"--deployment-target", "live",
 		"--workdir", workDir,
 	}, nil)
 
-	// Read state to get deployed addresses
+	// Verify deployment succeeded regardless of validation errors
 	st, err = pipeline.ReadState(workDir)
-	require.NoError(t, err)
-	require.Len(t, st.Chains, 1)
+	require.NoError(t, err, "State should be readable after apply")
+	require.NotNil(t, st.AppliedIntent, "Applied intent should exist")
+	require.Len(t, st.Chains, 1, "Should have one chain deployed")
+
+	// If there was an error, it should be validation-related, not a deployment failure
+	if runErr != nil {
+		require.Contains(t, output, "validation", "Error should be validation-related, not deployment failure")
+		require.Contains(t, runErr.Error(), "validation", "Error should mention validation")
+	}
+
 	systemConfigProxy := st.Chains[0].SystemConfigProxy
 
 	// Run migrate command
-	output := runner.ExpectSuccessWithNetwork(t, []string{
+	migrateOutput := runner.ExpectSuccessWithNetwork(t, []string{
 		"manage",
 		"migrate",
 		"--l1-rpc-url", l1RPC,
@@ -277,15 +287,15 @@ func TestCLIMigrateV1(t *testing.T) {
 	// Parse output to verify DisputeGameFactory was deployed
 	// Find the JSON output by looking for the opening brace
 	var migrationOutput manage.InteropMigrationOutput
-	jsonStart := strings.Index(output, "{")
+	jsonStart := strings.Index(migrateOutput, "{")
 	if jsonStart == -1 {
-		t.Logf("Full output length: %d", len(output))
-		t.Logf("Full output: %q", output)
+		t.Logf("Full output length: %d", len(migrateOutput))
+		t.Logf("Full output: %q", migrateOutput)
 		t.Fatalf("No JSON output found in output")
 	}
 	// Find the end of the JSON object
-	jsonEnd := strings.Index(output[jsonStart:], "}") + jsonStart + 1
-	jsonOutput := output[jsonStart:jsonEnd]
+	jsonEnd := strings.Index(migrateOutput[jsonStart:], "}") + jsonStart + 1
+	jsonOutput := migrateOutput[jsonStart:jsonEnd]
 	err = json.Unmarshal([]byte(jsonOutput), &migrationOutput)
 	require.NoError(t, err, "Failed to parse migration output: %s", jsonOutput)
 	require.NotEqual(t, common.Address{}, migrationOutput.DisputeGameFactory, "DisputeGameFactory should be deployed")
@@ -462,22 +472,32 @@ func TestCLIMigrateV2(t *testing.T) {
 	require.NoError(t, intent.WriteToFile(filepath.Join(workDir, "intent.toml")))
 
 	// Apply deployment
-	runner.ExpectSuccessWithNetwork(t, []string{
+	// Note: Validation will run automatically but may find expected errors for migration test deployments
+	// (e.g., custom dev features, non-standard configurations). We verify deployment succeeded despite validation errors.
+	output, runErr := runner.RunWithNetwork(context.Background(), []string{
 		"apply",
 		"--deployment-target", "live",
 		"--workdir", workDir,
 	}, nil)
 
-	// Read state to get deployed addresses
+	// Verify deployment succeeded regardless of validation errors
 	st, err = pipeline.ReadState(workDir)
-	require.NoError(t, err)
-	require.Len(t, st.Chains, 1)
+	require.NoError(t, err, "State should be readable after apply")
+	require.NotNil(t, st.AppliedIntent, "Applied intent should exist")
+	require.Len(t, st.Chains, 1, "Should have one chain deployed")
+
+	// If there was an error, it should be validation-related, not a deployment failure
+	if runErr != nil {
+		require.Contains(t, output, "validation", "Error should be validation-related, not deployment failure")
+		require.Contains(t, runErr.Error(), "validation", "Error should mention validation")
+	}
+
 	systemConfigProxy := st.Chains[0].SystemConfigProxy
 
 	// Run migrate-v2 command
 	// Note: dispute-game-type should be 0 (Cannon), not 4 (SuperCannon)
 	// Game type 4 is only for starting-respected-game-type
-	output := runner.ExpectSuccessWithNetwork(t, []string{
+	migrateOutput := runner.ExpectSuccessWithNetwork(t, []string{
 		"manage",
 		"migrate",
 		"--l1-proxy-admin-owner-address", superchainProxyAdminOwner.Hex(),
@@ -497,15 +517,15 @@ func TestCLIMigrateV2(t *testing.T) {
 	// Parse output to verify DisputeGameFactory was deployed
 	// Find the JSON output by looking for the opening brace
 	var migrationOutput manage.InteropMigrationOutput
-	jsonStart := strings.Index(output, "{")
+	jsonStart := strings.Index(migrateOutput, "{")
 	if jsonStart == -1 {
-		t.Logf("Full output length: %d", len(output))
-		t.Logf("Full output: %q", output)
+		t.Logf("Full output length: %d", len(migrateOutput))
+		t.Logf("Full output: %q", migrateOutput)
 		t.Fatalf("No JSON output found in output")
 	}
 	// Find the end of the JSON object
-	jsonEnd := strings.Index(output[jsonStart:], "}") + jsonStart + 1
-	jsonOutput := output[jsonStart:jsonEnd]
+	jsonEnd := strings.Index(migrateOutput[jsonStart:], "}") + jsonStart + 1
+	jsonOutput := migrateOutput[jsonStart:jsonEnd]
 	err = json.Unmarshal([]byte(jsonOutput), &migrationOutput)
 	require.NoError(t, err, "Failed to parse migration output: %s", jsonOutput)
 	require.NotEqual(t, common.Address{}, migrationOutput.DisputeGameFactory, "DisputeGameFactory should be deployed")

--- a/op-deployer/pkg/deployer/integration_test/cli/validate_test.go
+++ b/op-deployer/pkg/deployer/integration_test/cli/validate_test.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"context"
 	"math/big"
 	"path/filepath"
 	"reflect"
@@ -71,9 +70,9 @@ func TestCLIValidate(t *testing.T) {
 		require.NoError(t, intent.WriteToFile(filepath.Join(workDir, "intent.toml")))
 
 		// Apply deployment
-		// Note: Validation will run automatically but may fail due to test chain ID.
-		// We catch this error and verify deployment succeeded despite validation failure.
-		output, runErr := runner.RunWithNetwork(context.Background(), []string{
+		// Note: Validation is skipped for unsupported chain IDs (like test chains).
+		// We verify deployment succeeded, then test validation separately below.
+		runner.ExpectSuccessWithNetwork(t, []string{
 			"apply",
 			"--deployment-target", "live",
 			"--workdir", workDir,
@@ -83,10 +82,6 @@ func TestCLIValidate(t *testing.T) {
 		require.NoError(t, err, "State should be readable after apply")
 		require.NotNil(t, st.AppliedIntent, "Applied intent should exist")
 		require.Len(t, st.Chains, 1, "Should have one chain deployed")
-
-		if runErr != nil {
-			require.Contains(t, output, "validation failed", "Error should be validation-related, not deployment")
-		}
 
 	})
 

--- a/op-deployer/pkg/deployer/integration_test/cli/validate_test.go
+++ b/op-deployer/pkg/deployer/integration_test/cli/validate_test.go
@@ -1,0 +1,166 @@
+package cli
+
+import (
+	"context"
+	"math/big"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/addresses"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/integration_test/shared"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/pipeline"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/standard"
+	"github.com/ethereum-optimism/optimism/op-service/testutils/devnet"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+)
+
+func getL1RPCFromRunner(runner *CLITestRunner) string {
+	v := reflect.ValueOf(runner).Elem()
+	field := v.FieldByName("l1RPC")
+	if field.IsValid() && field.Kind() == reflect.String {
+		return field.String()
+	}
+	return ""
+}
+
+func TestCLIValidate(t *testing.T) {
+	runner := NewCLITestRunnerWithNetwork(t)
+	workDir := runner.GetWorkDir()
+	l1ChainID := uint64(devnet.DefaultChainID)
+	l2ChainID := uint256.NewInt(1)
+
+	dk, err := devkeys.NewMnemonicDevKeys(devkeys.TestMnemonic)
+	require.NoError(t, err)
+
+	t.Run("setup deployment", func(t *testing.T) {
+		intent, _ := cliInitIntent(t, runner, l1ChainID, []common.Hash{l2ChainID.Bytes32()})
+
+		if intent.SuperchainRoles == nil {
+			intent.SuperchainRoles = &addresses.SuperchainRoles{}
+		}
+
+		l1ChainIDBig := big.NewInt(int64(l1ChainID))
+		intent.SuperchainRoles.SuperchainProxyAdminOwner = shared.AddrFor(t, dk, devkeys.L1ProxyAdminOwnerRole.Key(l1ChainIDBig))
+		intent.SuperchainRoles.SuperchainGuardian = shared.AddrFor(t, dk, devkeys.SuperchainConfigGuardianKey.Key(l1ChainIDBig))
+		intent.SuperchainRoles.ProtocolVersionsOwner = shared.AddrFor(t, dk, devkeys.SuperchainDeployerKey.Key(l1ChainIDBig))
+		intent.SuperchainRoles.Challenger = shared.AddrFor(t, dk, devkeys.ChallengerRole.Key(l1ChainIDBig))
+
+		for _, chain := range intent.Chains {
+			chain.Roles.L1ProxyAdminOwner = shared.AddrFor(t, dk, devkeys.L2ProxyAdminOwnerRole.Key(l1ChainIDBig))
+			chain.Roles.L2ProxyAdminOwner = shared.AddrFor(t, dk, devkeys.L2ProxyAdminOwnerRole.Key(l1ChainIDBig))
+			chain.Roles.SystemConfigOwner = shared.AddrFor(t, dk, devkeys.SystemConfigOwner.Key(l1ChainIDBig))
+			chain.Roles.UnsafeBlockSigner = shared.AddrFor(t, dk, devkeys.SequencerP2PRole.Key(l1ChainIDBig))
+			chain.Roles.Batcher = shared.AddrFor(t, dk, devkeys.BatcherRole.Key(l1ChainIDBig))
+			chain.Roles.Proposer = shared.AddrFor(t, dk, devkeys.ProposerRole.Key(l1ChainIDBig))
+			chain.Roles.Challenger = shared.AddrFor(t, dk, devkeys.ChallengerRole.Key(l1ChainIDBig))
+
+			chain.BaseFeeVaultRecipient = shared.AddrFor(t, dk, devkeys.BaseFeeVaultRecipientRole.Key(l1ChainIDBig))
+			chain.L1FeeVaultRecipient = shared.AddrFor(t, dk, devkeys.L1FeeVaultRecipientRole.Key(l1ChainIDBig))
+			chain.SequencerFeeVaultRecipient = shared.AddrFor(t, dk, devkeys.SequencerFeeVaultRecipientRole.Key(l1ChainIDBig))
+			chain.OperatorFeeVaultRecipient = shared.AddrFor(t, dk, devkeys.OperatorFeeVaultRecipientRole.Key(l1ChainIDBig))
+
+			chain.Eip1559DenominatorCanyon = standard.Eip1559DenominatorCanyon
+			chain.Eip1559Denominator = standard.Eip1559Denominator
+			chain.Eip1559Elasticity = standard.Eip1559Elasticity
+		}
+		require.NoError(t, intent.WriteToFile(filepath.Join(workDir, "intent.toml")))
+
+		// Apply deployment
+		// Note: Validation will run automatically but may fail due to test chain ID.
+		// We catch this error and verify deployment succeeded despite validation failure.
+		output, runErr := runner.RunWithNetwork(context.Background(), []string{
+			"apply",
+			"--deployment-target", "live",
+			"--workdir", workDir,
+		}, nil)
+
+		st, err := pipeline.ReadState(workDir)
+		require.NoError(t, err, "State should be readable after apply")
+		require.NotNil(t, st.AppliedIntent, "Applied intent should exist")
+		require.Len(t, st.Chains, 1, "Should have one chain deployed")
+
+		if runErr != nil {
+			require.Contains(t, output, "validation failed", "Error should be validation-related, not deployment")
+		}
+
+	})
+
+	t.Run("validate all chains", func(t *testing.T) {
+		output := runner.ExpectSuccess(t, []string{
+			"validate", "auto",
+			"--l1-rpc-url", getL1RPCFromRunner(runner),
+			"--workdir", workDir,
+		}, nil)
+
+		require.Contains(t, output, "Validating chain", "Should show validation progress")
+		require.Contains(t, output, "Contract validated", "Should validate contracts")
+	})
+
+	t.Run("validate specific chain", func(t *testing.T) {
+		st, err := pipeline.ReadState(workDir)
+		require.NoError(t, err)
+		require.Len(t, st.Chains, 1)
+
+		chainID := st.Chains[0].ID.Hex()
+
+		output := runner.ExpectSuccess(t, []string{
+			"validate", "auto",
+			"--l1-rpc-url", getL1RPCFromRunner(runner),
+			"--workdir", workDir,
+			chainID,
+		}, nil)
+
+		require.Contains(t, output, "Validating chain", "Should show validation progress")
+		require.Contains(t, output, chainID, "Should validate the specified chain")
+	})
+
+	t.Run("validate with fail flag", func(t *testing.T) {
+		output := runner.ExpectSuccess(t, []string{
+			"validate", "auto",
+			"--l1-rpc-url", getL1RPCFromRunner(runner),
+			"--workdir", workDir,
+			"--fail",
+		}, nil)
+
+		require.Contains(t, output, "Validating chain", "Should show validation progress")
+	})
+
+	t.Run("validate fails when no applied intent", func(t *testing.T) {
+		emptyWorkDir := runner.GetWorkDir() + "_empty"
+		runner.ExpectSuccess(t, []string{
+			"init",
+			"--l1-chain-id", "11155111",
+			"--l2-chain-ids", "1",
+			"--workdir", emptyWorkDir,
+		}, nil)
+
+		runner.ExpectErrorContains(t, []string{
+			"validate", "auto",
+			"--l1-rpc-url", getL1RPCFromRunner(runner),
+			"--workdir", emptyWorkDir,
+		}, nil, "cannot validate: no applied intent found")
+	})
+
+	t.Run("validate fails for non-existent chain", func(t *testing.T) {
+		nonExistentChainID := "0x" + strings.Repeat("ff", 32)
+
+		runner.ExpectErrorContains(t, []string{
+			"validate", "auto",
+			"--l1-rpc-url", getL1RPCFromRunner(runner),
+			"--workdir", workDir,
+			nonExistentChainID,
+		}, nil, "chain with ID")
+	})
+
+	t.Run("validate requires l1-rpc-url", func(t *testing.T) {
+		runner.ExpectErrorContains(t, []string{
+			"validate", "auto",
+			"--workdir", workDir,
+		}, nil, "l1-rpc-url")
+	})
+}

--- a/op-deployer/pkg/deployer/validate/helpers.go
+++ b/op-deployer/pkg/deployer/validate/helpers.go
@@ -1,0 +1,126 @@
+package validate
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/opcm"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/standard"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/state"
+	"github.com/ethereum-optimism/optimism/op-validator/pkg/service"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+// DetectValidatorVersion determines the validator version to use based on the validate flag and state.
+func DetectValidatorVersion(validateFlag string, appliedIntent *state.Intent, l log.Logger) string {
+	if validateFlag == "auto" {
+		if appliedIntent.L1ContractsLocator != nil {
+			locatorBytes, err := appliedIntent.L1ContractsLocator.MarshalText()
+			if err == nil {
+				locatorStr := string(locatorBytes)
+				if strings.HasPrefix(locatorStr, "tag://") {
+					version := strings.TrimPrefix(locatorStr, "tag://")
+					l.Info("Auto-detected version from state.json", "version", version)
+					return version
+				}
+				l.Info("Using current standard tag (non-tag locator found)", "version", standard.CurrentTag)
+				return standard.CurrentTag
+			}
+			locatorStr := appliedIntent.L1ContractsLocator.URL.String()
+			if strings.HasPrefix(locatorStr, "tag://") {
+				version := strings.TrimPrefix(locatorStr, "tag://")
+				l.Info("Auto-detected version from state.json", "version", version)
+				return version
+			}
+			l.Info("Using current standard tag", "version", standard.CurrentTag)
+			return standard.CurrentTag
+		}
+		l.Info("Using current standard tag (no L1ContractsLocator found)", "version", standard.CurrentTag)
+		return standard.CurrentTag
+	}
+	if !strings.HasPrefix(validateFlag, "op-contracts/") {
+		return "op-contracts/" + validateFlag
+	}
+	return validateFlag
+}
+
+// GetAbsolutePrestate retrieves the absolute prestate for a chain from various sources.
+func GetAbsolutePrestate(globalState *state.State, chainID common.Hash, l log.Logger) common.Hash {
+	if globalState.PrestateManifest != nil {
+		if hash, ok := (*globalState.PrestateManifest)[chainID.Big().String()]; ok {
+			return common.HexToHash(hash)
+		}
+	}
+	if globalState.AppliedIntent != nil {
+		if chainIntent, err := globalState.AppliedIntent.Chain(chainID); err == nil {
+			if proofParams, ok := chainIntent.DeployOverrides["faultGameAbsolutePrestate"]; ok {
+				if hashStr, ok := proofParams.(string); ok {
+					return common.HexToHash(hashStr)
+				}
+			}
+		}
+	}
+	l.Info("Using standard absolute prestate (prestate not found in state)", "prestate", standard.DisputeAbsolutePrestate.Hex())
+	return standard.DisputeAbsolutePrestate
+}
+
+// GetOPCMValidatorAddress retrieves the validator address from the OPCM contract.
+func GetOPCMValidatorAddress(ctx context.Context, l log.Logger, opcmAddr *common.Address, l1RPCURL string) common.Address {
+	if opcmAddr == nil {
+		return common.Address{}
+	}
+	ethClient, err := ethclient.DialContext(ctx, l1RPCURL)
+	if err != nil {
+		l.Warn("Failed to dial L1 RPC to get validator address", "error", err)
+		return common.Address{}
+	}
+	defer ethClient.Close()
+
+	opcmContract := opcm.NewContract(*opcmAddr, ethClient)
+	validatorAddr, err := opcmContract.OPCMStandardValidator(ctx)
+	if err != nil {
+		l.Warn("Failed to get OPCMStandardValidator address from OPCM", "opcm", opcmAddr.Hex(), "error", err)
+		return common.Address{}
+	}
+	if validatorAddr == (common.Address{}) {
+		l.Warn("OPCMStandardValidator address is zero", "opcm", opcmAddr.Hex())
+		return common.Address{}
+	}
+	l.Info("Found OPCMStandardValidator address from OPCM", "validator", validatorAddr.Hex(), "opcm", opcmAddr.Hex())
+	return validatorAddr
+}
+
+// BuildValidatorConfigFromState builds a validator configuration from the deployment state.
+func BuildValidatorConfigFromState(ctx context.Context, l log.Logger, globalState *state.State, chainState *state.ChainState, chainID common.Hash, l1RPCURL string) (*service.Config, error) {
+	validatorCfg := &service.Config{
+		L1RPCURL: l1RPCURL,
+	}
+
+	validatorCfg.AbsolutePrestate = GetAbsolutePrestate(globalState, chainID, l)
+
+	if chainState.OpChainProxyAdminImpl == (common.Address{}) {
+		return nil, fmt.Errorf("proxy-admin not found in state for chain %s", chainID.Hex())
+	}
+	validatorCfg.ProxyAdmin = chainState.OpChainProxyAdminImpl
+
+	if chainState.SystemConfigProxy == (common.Address{}) {
+		return nil, fmt.Errorf("system-config not found in state for chain %s", chainID.Hex())
+	}
+	validatorCfg.SystemConfig = chainState.SystemConfigProxy
+
+	validatorCfg.L2ChainID = chainID.Big()
+
+	if globalState.AppliedIntent != nil {
+		if chainIntent, err := globalState.AppliedIntent.Chain(chainID); err == nil {
+			validatorCfg.Proposer = chainIntent.Roles.Proposer
+			if validatorAddr := GetOPCMValidatorAddress(ctx, l, globalState.AppliedIntent.OPCMAddress, l1RPCURL); validatorAddr != (common.Address{}) {
+				validatorCfg.ValidatorAddress = validatorAddr
+			}
+		}
+	}
+
+	return validatorCfg, nil
+}

--- a/op-deployer/pkg/deployer/validate/helpers_test.go
+++ b/op-deployer/pkg/deployer/validate/helpers_test.go
@@ -1,0 +1,255 @@
+package validate
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/devnet-sdk/proofs/prestate"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/addresses"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/artifacts"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/standard"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/state"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetAbsolutePrestate(t *testing.T) {
+	tests := []struct {
+		name        string
+		globalState *state.State
+		chainID     common.Hash
+		expected    common.Hash
+		description string
+	}{
+		{
+			name: "from prestate manifest",
+			globalState: &state.State{
+				PrestateManifest: func() *prestate.PrestateManifest {
+					m := prestate.PrestateManifest{
+						"1": "0x1234567890123456789012345678901234567890123456789012345678901234",
+					}
+					return &m
+				}(),
+			},
+			chainID:     common.BigToHash(common.Big1),
+			expected:    common.HexToHash("0x1234567890123456789012345678901234567890123456789012345678901234"),
+			description: "Should return prestate from manifest when available",
+		},
+		{
+			name: "from deploy overrides",
+			globalState: &state.State{
+				AppliedIntent: &state.Intent{
+					Chains: []*state.ChainIntent{
+						{
+							ID: common.BigToHash(common.Big1),
+							DeployOverrides: map[string]interface{}{
+								"faultGameAbsolutePrestate": "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdef",
+							},
+						},
+					},
+				},
+			},
+			chainID:     common.BigToHash(common.Big1),
+			expected:    common.HexToHash("0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdef"),
+			description: "Should return prestate from deploy overrides when manifest not available",
+		},
+		{
+			name: "fallback to standard prestate",
+			globalState: &state.State{
+				AppliedIntent: &state.Intent{
+					Chains: []*state.ChainIntent{
+						{
+							ID:              common.BigToHash(common.Big1),
+							DeployOverrides: map[string]interface{}{},
+						},
+					},
+				},
+			},
+			chainID:     common.BigToHash(common.Big1),
+			expected:    standard.DisputeAbsolutePrestate,
+			description: "Should fallback to standard prestate when not found elsewhere",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := log.New()
+			result := GetAbsolutePrestate(tt.globalState, tt.chainID, logger)
+			require.Equal(t, tt.expected, result, tt.description)
+		})
+	}
+}
+
+func TestBuildValidatorConfigFromState(t *testing.T) {
+	tests := []struct {
+		name        string
+		globalState *state.State
+		chainState  *state.ChainState
+		chainID     common.Hash
+		expectError bool
+		description string
+	}{
+		{
+			name: "valid config with all required fields",
+			globalState: &state.State{
+				AppliedIntent: &state.Intent{
+					Chains: []*state.ChainIntent{
+						{
+							ID: common.BigToHash(common.Big1),
+							Roles: state.ChainRoles{
+								Proposer: common.Address{0x01},
+							},
+						},
+					},
+				},
+			},
+			chainState: &state.ChainState{
+				OpChainContracts: addresses.OpChainContracts{
+					OpChainCoreContracts: addresses.OpChainCoreContracts{
+						OpChainProxyAdminImpl: common.Address{0x02},
+						SystemConfigProxy:     common.Address{0x03},
+					},
+				},
+			},
+			chainID:     common.BigToHash(common.Big1),
+			expectError: false,
+			description: "Should build config successfully with all required fields",
+		},
+		{
+			name: "missing proxy admin",
+			globalState: &state.State{
+				AppliedIntent: &state.Intent{
+					Chains: []*state.ChainIntent{
+						{
+							ID: common.BigToHash(common.Big1),
+						},
+					},
+				},
+			},
+			chainState: &state.ChainState{
+				OpChainContracts: addresses.OpChainContracts{
+					OpChainCoreContracts: addresses.OpChainCoreContracts{
+						OpChainProxyAdminImpl: common.Address{},
+						SystemConfigProxy:     common.Address{0x03},
+					},
+				},
+			},
+			chainID:     common.BigToHash(common.Big1),
+			expectError: true,
+			description: "Should error when proxy admin is missing",
+		},
+		{
+			name: "missing system config",
+			globalState: &state.State{
+				AppliedIntent: &state.Intent{
+					Chains: []*state.ChainIntent{
+						{
+							ID: common.BigToHash(common.Big1),
+						},
+					},
+				},
+			},
+			chainState: &state.ChainState{
+				OpChainContracts: addresses.OpChainContracts{
+					OpChainCoreContracts: addresses.OpChainCoreContracts{
+						OpChainProxyAdminImpl: common.Address{0x02},
+						SystemConfigProxy:     common.Address{},
+					},
+				},
+			},
+			chainID:     common.BigToHash(common.Big1),
+			expectError: true,
+			description: "Should error when system config is missing",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			logger := log.New()
+			l1RPCURL := "http://localhost:99999"
+
+			cfg, err := BuildValidatorConfigFromState(ctx, logger, tt.globalState, tt.chainState, tt.chainID, l1RPCURL)
+
+			if tt.expectError {
+				require.Error(t, err, tt.description)
+				require.Nil(t, cfg)
+			} else {
+				require.NoError(t, err, tt.description)
+				require.NotNil(t, cfg)
+				require.Equal(t, tt.chainState.OpChainContracts.OpChainProxyAdminImpl, cfg.ProxyAdmin)
+				require.Equal(t, tt.chainState.OpChainContracts.SystemConfigProxy, cfg.SystemConfig)
+				require.Equal(t, tt.chainID.Big(), cfg.L2ChainID)
+				// Proposer should be set from chain intent
+				require.Equal(t, common.Address{0x01}, cfg.Proposer)
+			}
+		})
+	}
+}
+
+func TestDetectValidatorVersion(t *testing.T) {
+	tests := []struct {
+		name          string
+		validateFlag  string
+		appliedIntent *state.Intent
+		expected      string
+		description   string
+	}{
+		{
+			name:         "auto with tag locator",
+			validateFlag: "auto",
+			appliedIntent: func() *state.Intent {
+				loc, _ := artifacts.NewLocatorFromURL("tag://op-contracts/v5.0.0")
+				return &state.Intent{
+					L1ContractsLocator: loc,
+				}
+			}(),
+			expected:    "op-contracts/v5.0.0",
+			description: "Should detect version from tag:// locator",
+		},
+		{
+			name:         "auto with non-tag locator",
+			validateFlag: "auto",
+			appliedIntent: func() *state.Intent {
+				loc, _ := artifacts.NewLocatorFromURL("http://example.com/artifacts")
+				return &state.Intent{
+					L1ContractsLocator: loc,
+				}
+			}(),
+			expected:    standard.CurrentTag,
+			description: "Should fallback to current tag for non-tag locator",
+		},
+		{
+			name:         "auto with nil locator",
+			validateFlag: "auto",
+			appliedIntent: &state.Intent{
+				L1ContractsLocator: nil,
+			},
+			expected:    standard.CurrentTag,
+			description: "Should fallback to current tag when locator is nil",
+		},
+		{
+			name:          "explicit version without prefix",
+			validateFlag:  "v2.0.0",
+			appliedIntent: &state.Intent{},
+			expected:      "op-contracts/v2.0.0",
+			description:   "Should add op-contracts/ prefix when missing",
+		},
+		{
+			name:          "explicit version with prefix",
+			validateFlag:  "op-contracts/v3.0.0",
+			appliedIntent: &state.Intent{},
+			expected:      "op-contracts/v3.0.0",
+			description:   "Should use version as-is when prefix already present",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := log.New()
+			result := DetectValidatorVersion(tt.validateFlag, tt.appliedIntent, logger)
+			require.Equal(t, tt.expected, result, tt.description)
+		})
+	}
+}

--- a/op-deployer/pkg/deployer/validate/validate.go
+++ b/op-deployer/pkg/deployer/validate/validate.go
@@ -1,0 +1,134 @@
+package validate
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/pipeline"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/state"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/urfave/cli/v2"
+)
+
+func Commands() []*cli.Command {
+	return []*cli.Command{
+		{
+			Name:      "auto",
+			Usage:     "automatically validate deployment",
+			ArgsUsage: "[chain-id]",
+			Flags: []cli.Flag{
+				&cli.StringFlag{
+					Name:     "l1-rpc-url",
+					Usage:    "L1 RPC URL",
+					Required: true,
+					EnvVars:  []string{"L1_RPC_URL", "ETH_RPC_URL"},
+				},
+				&cli.StringFlag{
+					Name:    "workdir",
+					Usage:   "working directory containing state.json and intent.toml",
+					Value:   ".deployer",
+					EnvVars: []string{"WORKDIR"},
+				},
+				&cli.BoolFlag{
+					Name:    "fail",
+					Usage:   "fail on validation errors",
+					EnvVars: []string{"FAIL"},
+				},
+			},
+			Action: ValidateAuto,
+		},
+	}
+}
+
+func ValidateAuto(cliCtx *cli.Context) error {
+	l1RPCUrl := cliCtx.String("l1-rpc-url")
+	workdir := cliCtx.String("workdir")
+	fail := cliCtx.Bool("fail")
+	chainIDArg := cliCtx.Args().First()
+
+	ctx := cliCtx.Context
+	logger := slog.New(slog.NewTextHandler(cliCtx.App.Writer, nil))
+
+	st, err := pipeline.ReadState(workdir)
+	if err != nil {
+		return fmt.Errorf("failed to read state: %w", err)
+	}
+
+	if st.AppliedIntent == nil {
+		return fmt.Errorf("cannot validate: no applied intent found")
+	}
+
+	ethClient, err := ethclient.DialContext(ctx, l1RPCUrl)
+	if err != nil {
+		return fmt.Errorf("failed to connect to L1 RPC: %w", err)
+	}
+	defer ethClient.Close()
+
+	var chainsToValidate []*state.ChainIntent
+	if chainIDArg != "" {
+		chainID := common.HexToHash(chainIDArg)
+		for _, chain := range st.AppliedIntent.Chains {
+			if chain.ID == chainID {
+				chainsToValidate = append(chainsToValidate, chain)
+				break
+			}
+		}
+		if len(chainsToValidate) == 0 {
+			return fmt.Errorf("chain with ID %s not found in deployment", chainIDArg)
+		}
+	} else {
+		chainsToValidate = st.AppliedIntent.Chains
+	}
+
+	for _, chain := range chainsToValidate {
+		chainID := chain.ID
+		logger.Info("Validating chain", "chain-id", chainID.Hex())
+
+		chainState, err := st.Chain(chainID)
+		if err != nil {
+			return fmt.Errorf("failed to get chain state for %s: %w", chainID.Hex(), err)
+		}
+
+		contractsToCheck := map[string]common.Address{
+			"SystemConfig":           chainState.SystemConfigProxy,
+			"L1CrossDomainMessenger": chainState.L1CrossDomainMessengerProxy,
+			"L1StandardBridge":       chainState.L1StandardBridgeProxy,
+			"OptimismPortal":         chainState.OptimismPortalProxy,
+		}
+
+		for name, addr := range contractsToCheck {
+			if addr == (common.Address{}) {
+				if fail {
+					return fmt.Errorf("contract %s address is zero", name)
+				}
+				logger.Warn("Contract address is zero", "contract", name)
+				continue
+			}
+
+			code, err := ethClient.CodeAt(ctx, addr, nil)
+			if err != nil {
+				if fail {
+					return fmt.Errorf("failed to get code for %s at %s: %w", name, addr.Hex(), err)
+				}
+				logger.Warn("Failed to get contract code", "contract", name, "address", addr.Hex(), "error", err)
+				continue
+			}
+
+			if len(code) == 0 {
+				if fail {
+					return fmt.Errorf("contract %s at %s has no code", name, addr.Hex())
+				}
+				logger.Warn("Contract has no code", "contract", name, "address", addr.Hex())
+				continue
+			}
+
+			logger.Info("Contract validated", "contract", name, "address", addr.Hex())
+		}
+
+		logger.Info("Chain validation completed", "chain-id", chainID.Hex())
+	}
+
+	logger.Info("Validation completed successfully")
+	return nil
+}

--- a/op-validator/pkg/service/flags.go
+++ b/op-validator/pkg/service/flags.go
@@ -39,6 +39,11 @@ var (
 		Usage:    "Proposer address as hex string (required for OPCMStandardValidator)",
 		Required: false,
 	}
+	ValidatorAddressFlag = &cli.StringFlag{
+		Name:     "validator-address",
+		Usage:    "OPCMStandardValidator contract address (required for custom deployments)",
+		Required: false,
+	}
 	FailOnErrorFlag = &cli.BoolFlag{
 		Name:  "fail",
 		Usage: "Exit with non-zero code if validation errors are found",
@@ -54,6 +59,7 @@ var ValidateFlags = []cli.Flag{
 	SystemConfigFlag,
 	L2ChainIDFlag,
 	ProposerFlag,
+	ValidatorAddressFlag,
 	FailOnErrorFlag,
 }
 
@@ -65,6 +71,7 @@ type Config struct {
 	SystemConfig     common.Address
 	L2ChainID        *big.Int
 	Proposer         common.Address
+	ValidatorAddress common.Address
 }
 
 // NewConfig creates a new Config from CLI context
@@ -82,6 +89,11 @@ func NewConfig(ctx *cli.Context) (*Config, error) {
 		proposer = common.HexToAddress(proposerStr)
 	}
 
+	var validatorAddr common.Address
+	if validatorAddrStr := ctx.String(ValidatorAddressFlag.Name); validatorAddrStr != "" {
+		validatorAddr = common.HexToAddress(validatorAddrStr)
+	}
+
 	return &Config{
 		L1RPCURL:         ctx.String(L1RPCURLFlag.Name),
 		AbsolutePrestate: absolutePrestate,
@@ -89,5 +101,6 @@ func NewConfig(ctx *cli.Context) (*Config, error) {
 		SystemConfig:     systemConfig,
 		L2ChainID:        l2ChainID,
 		Proposer:         proposer,
+		ValidatorAddress: validatorAddr,
 	}, nil
 }

--- a/op-validator/pkg/service/validate.go
+++ b/op-validator/pkg/service/validate.go
@@ -8,6 +8,7 @@ import (
 
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	"github.com/ethereum-optimism/optimism/op-validator/pkg/validations"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/urfave/cli/v2"
@@ -40,10 +41,11 @@ func ValidateCmd(cliCtx *cli.Context, release string) error {
 }
 
 func Validate(ctx context.Context, lgr log.Logger, release string, cfg *Config) ([]string, error) {
-	l1Client, err := rpc.Dial(cfg.L1RPCURL)
+	l1Client, err := rpc.DialContext(ctx, cfg.L1RPCURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to dial L1 RPC: %w", err)
 	}
+	defer l1Client.Close()
 
 	var validator validations.Validator
 
@@ -67,11 +69,16 @@ func Validate(ctx context.Context, lgr log.Logger, release string, cfg *Config) 
 	}
 	lgr.Info("Using Validator", "version", release)
 
+	if cfg.ValidatorAddress != (common.Address{}) {
+		lgr.Info("Using custom validator address", "address", cfg.ValidatorAddress.Hex())
+	}
+
 	return validator.Validate(ctx, validations.BaseValidatorInput{
 		ProxyAdminAddress:   cfg.ProxyAdmin,
 		SystemConfigAddress: cfg.SystemConfig,
 		AbsolutePrestate:    cfg.AbsolutePrestate,
 		L2ChainID:           cfg.L2ChainID,
 		Proposer:            cfg.Proposer,
+		ValidatorAddress:    cfg.ValidatorAddress,
 	})
 }

--- a/op-validator/pkg/validations/validations.go
+++ b/op-validator/pkg/validations/validations.go
@@ -62,6 +62,9 @@ type BaseValidatorInput struct {
 	AbsolutePrestate    common.Hash
 	L2ChainID           *big.Int
 	Proposer            common.Address
+	// ValidatorAddress is the custom validator contract address to use.
+	// If zero, the standard validator address for the release/chainID will be used.
+	ValidatorAddress common.Address
 }
 
 // newBaseValidator is used for 1.8.0-4.1.0 validation contracts
@@ -79,14 +82,22 @@ func newOPCMStandardValidator(client *rpc.Client, release string) *OPCMStandardV
 
 // Validate (BaseValidator) is used for 1.8.0-4.1.0 validation contracts
 func (v *BaseValidator) Validate(ctx context.Context, input BaseValidatorInput) ([]string, error) {
-	l1ChainID, err := ethclient.NewClient(v.client).ChainID(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get chain ID: %w", err)
-	}
+	var validatorAddr common.Address
+	if input.ValidatorAddress != (common.Address{}) {
+		// Use custom validator address if provided
+		validatorAddr = input.ValidatorAddress
+	} else {
+		// Fall back to standard validator address lookup
+		l1ChainID, err := ethclient.NewClient(v.client).ChainID(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get chain ID: %w", err)
+		}
 
-	validatorAddr, err := ValidatorAddress(l1ChainID.Uint64(), v.release)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get validator address: %w", err)
+		addr, err := ValidatorAddress(l1ChainID.Uint64(), v.release)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get validator address: %w", err)
+		}
+		validatorAddr = addr
 	}
 
 	var rawOutput []byte
@@ -122,14 +133,22 @@ func (v *OPCMStandardValidator) Validate(ctx context.Context, input BaseValidato
 		return nil, fmt.Errorf("proposer address is required for OPCM validation")
 	}
 
-	l1ChainID, err := ethclient.NewClient(v.client).ChainID(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get chain ID: %w", err)
-	}
+	var validatorAddr common.Address
+	if input.ValidatorAddress != (common.Address{}) {
+		// Use custom validator address if provided
+		validatorAddr = input.ValidatorAddress
+	} else {
+		// Fall back to standard validator address lookup
+		l1ChainID, err := ethclient.NewClient(v.client).ChainID(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get chain ID: %w", err)
+		}
 
-	validatorAddr, err := ValidatorAddress(l1ChainID.Uint64(), v.release)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get validator address: %w", err)
+		addr, err := ValidatorAddress(l1ChainID.Uint64(), v.release)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get validator address: %w", err)
+		}
+		validatorAddr = addr
 	}
 
 	var rawOutput []byte

--- a/ops/docker/op-stack-go/Dockerfile.dockerignore
+++ b/ops/docker/op-stack-go/Dockerfile.dockerignore
@@ -22,6 +22,7 @@
 !/op-supernode
 !/op-interop-filter
 !/op-test-sequencer
+!/op-validator
 !/op-wheel
 !/op-alt-da
 !/op-faucet


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Integrates op-validator with op-deployer so that it can be called automatically after a deployment.

`./scripts/test-sepolia-op-deployer.sh` already has support for using the validate flag after apply.

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
