### PR TITLE
op-proposer: Support fetching proposals via supernode rpc

### DIFF
--- a/op-proposer/proposer/config.go
+++ b/op-proposer/proposer/config.go
@@ -18,6 +18,7 @@ import (
 var (
 	ErrMissingRollupRpc     = errors.New("missing rollup rpc")
 	ErrMissingSupervisorRpc = errors.New("missing supervisor rpc or supernode rpc")
+	ErrMissingSource        = errors.New("missing proposal source rpc (rollup, supervisor, or supernode)")
 	ErrConflictingSource    = errors.New("must specify exactly one of rollup rpc, supervisor rpc, or supernode rpc")
 
 	// preInteropGameTypes are  game types that enforce having a rollup rpc.
@@ -127,6 +128,10 @@ func (c *CLIConfig) Check() error {
 	// Require supervisor or supernode RPC for post interop game types
 	if c.DGFAddress != "" && slices.Contains(postInteropGameTypes, c.DisputeGameType) && len(c.SupervisorRpcs) == 0 && len(c.SuperNodeRpcs) == 0 {
 		return ErrMissingSupervisorRpc
+	}
+	// For unknown game types, allow any source, but require at least one.
+	if sourceCount == 0 {
+		return ErrMissingSource
 	}
 
 	return nil

--- a/op-proposer/proposer/config.go
+++ b/op-proposer/proposer/config.go
@@ -17,8 +17,8 @@ import (
 
 var (
 	ErrMissingRollupRpc     = errors.New("missing rollup rpc")
-	ErrMissingSupervisorRpc = errors.New("missing supervisor rpc")
-	ErrConflictingSource    = errors.New("must not specify both a rollup rpc and supervisor rpc")
+	ErrMissingSupervisorRpc = errors.New("missing supervisor rpc or supernode rpc")
+	ErrConflictingSource    = errors.New("must specify exactly one of rollup rpc, supervisor rpc, or supernode rpc")
 
 	// preInteropGameTypes are  game types that enforce having a rollup rpc.
 	// It is ok if this list isn't complete, unknown game types will allow either rollup or supervisor
@@ -45,6 +45,10 @@ type CLIConfig struct {
 
 	// SupervisorRpcs is the list of HTTP provider URLs for supervisor nodes.
 	SupervisorRpcs []string
+
+	// SuperNodeRpcs is the list of HTTP provider URLs for supernode instances.
+	// Mutually exclusive with RollupRpc and SupervisorRpcs.
+	SuperNodeRpcs []string
 
 	// PollInterval is the delay between periodic checks on whether it is time to load an output root and propose it.
 	PollInterval time.Duration
@@ -102,15 +106,26 @@ func (c *CLIConfig) Check() error {
 	if c.ProposalInterval != 0 && c.DGFAddress == "" {
 		return errors.New("the `ProposalInterval` was provided but the `DisputeGameFactory` address was not set")
 	}
-	if c.RollupRpc != "" && len(c.SupervisorRpcs) != 0 {
+	// Check for conflicting RPC sources - only one should be specified
+	sourceCount := 0
+	if c.RollupRpc != "" {
+		sourceCount++
+	}
+	if len(c.SupervisorRpcs) != 0 {
+		sourceCount++
+	}
+	if len(c.SuperNodeRpcs) != 0 {
+		sourceCount++
+	}
+	if sourceCount > 1 {
 		return ErrConflictingSource
 	}
 	// Require rollup RPC for pre interop game types
 	if c.DGFAddress != "" && slices.Contains(preInteropGameTypes, c.DisputeGameType) && c.RollupRpc == "" {
 		return ErrMissingRollupRpc
 	}
-	// Require supervisor RPC for post interop game types
-	if c.DGFAddress != "" && slices.Contains(postInteropGameTypes, c.DisputeGameType) && len(c.SupervisorRpcs) == 0 {
+	// Require supervisor or supernode RPC for post interop game types
+	if c.DGFAddress != "" && slices.Contains(postInteropGameTypes, c.DisputeGameType) && len(c.SupervisorRpcs) == 0 && len(c.SuperNodeRpcs) == 0 {
 		return ErrMissingSupervisorRpc
 	}
 

--- a/op-proposer/proposer/config_test.go
+++ b/op-proposer/proposer/config_test.go
@@ -129,6 +129,15 @@ func TestDisallowAllThreeRPCSources(t *testing.T) {
 	require.ErrorIs(t, cfg.Check(), ErrConflictingSource)
 }
 
+func TestRequireSomeRPCSourceForUnknownGameTypes(t *testing.T) {
+	cfg := validConfig()
+	cfg.RollupRpc = ""
+	cfg.SupervisorRpcs = nil
+	cfg.SuperNodeRpcs = nil
+	cfg.DisputeGameType = 492743
+	require.ErrorIs(t, cfg.Check(), ErrMissingSource)
+}
+
 func validConfig() *CLIConfig {
 	return &CLIConfig{
 		L1EthRpc:                     "http://localhost:8888/l1",

--- a/op-proposer/proposer/config_test.go
+++ b/op-proposer/proposer/config_test.go
@@ -74,11 +74,67 @@ func TestDisallowRollupAndSupervisorRPC(t *testing.T) {
 	require.ErrorIs(t, cfg.Check(), ErrConflictingSource)
 }
 
+func TestSuperNodeRpc(t *testing.T) {
+	for _, gameType := range postInteropGameTypes {
+		t.Run("AllowedWithPostInteropGame", func(t *testing.T) {
+			cfg := validConfig()
+			cfg.DGFAddress = common.Address{0xaa}.Hex()
+			cfg.ProposalInterval = 20
+			cfg.RollupRpc = ""
+			cfg.SupervisorRpcs = nil
+			cfg.SuperNodeRpcs = []string{"http://localhost:8882/supernode"}
+			cfg.DisputeGameType = gameType
+			require.NoError(t, cfg.Check())
+		})
+	}
+
+	t.Run("AllowedForOtherGameTypes", func(t *testing.T) {
+		cfg := validConfig()
+		cfg.DGFAddress = common.Address{0xaa}.Hex()
+		cfg.ProposalInterval = 20
+		cfg.RollupRpc = ""
+		cfg.SupervisorRpcs = nil
+		cfg.SuperNodeRpcs = []string{"http://localhost:8882/supernode"}
+		cfg.DisputeGameType = 492743
+		require.NoError(t, cfg.Check())
+	})
+}
+
+func TestDisallowRollupAndSuperNodeRPC(t *testing.T) {
+	cfg := validConfig()
+	cfg.ProposalInterval = 20
+	cfg.RollupRpc = "http://localhost:8882/rollup"
+	cfg.SuperNodeRpcs = []string{"http://localhost:8882/supernode"}
+	cfg.DisputeGameType = 492743
+	require.ErrorIs(t, cfg.Check(), ErrConflictingSource)
+}
+
+func TestDisallowSupervisorAndSuperNodeRPC(t *testing.T) {
+	cfg := validConfig()
+	cfg.ProposalInterval = 20
+	cfg.RollupRpc = ""
+	cfg.SupervisorRpcs = []string{"http://localhost:8882/supervisor"}
+	cfg.SuperNodeRpcs = []string{"http://localhost:8882/supernode"}
+	cfg.DisputeGameType = 492743
+	require.ErrorIs(t, cfg.Check(), ErrConflictingSource)
+}
+
+func TestDisallowAllThreeRPCSources(t *testing.T) {
+	cfg := validConfig()
+	cfg.ProposalInterval = 20
+	cfg.RollupRpc = "http://localhost:8882/rollup"
+	cfg.SupervisorRpcs = []string{"http://localhost:8882/supervisor"}
+	cfg.SuperNodeRpcs = []string{"http://localhost:8882/supernode"}
+	cfg.DisputeGameType = 492743
+	require.ErrorIs(t, cfg.Check(), ErrConflictingSource)
+}
+
 func validConfig() *CLIConfig {
 	return &CLIConfig{
 		L1EthRpc:                     "http://localhost:8888/l1",
 		RollupRpc:                    "http://localhost:8888/l2",
 		SupervisorRpcs:               nil,
+		SuperNodeRpcs:                nil,
 		PollInterval:                 100,
 		AllowNonFinalized:            false,
 		TxMgrConfig:                  txmgr.NewCLIConfig("http://localhost:8888/l1", txmgr.DefaultBatcherFlagValues),

--- a/op-proposer/proposer/driver.go
+++ b/op-proposer/proposer/driver.go
@@ -302,10 +302,10 @@ func (l *L2OutputSubmitter) waitNodeSync() error {
 		return fmt.Errorf("failed to retrieve current L1 block number: %w", err)
 	}
 
-	return dial.WaitL1Sync(l.ctx, l.Log, l1head, time.Second*12, func(ctx context.Context) (eth.L1BlockRef, error) {
+	return dial.WaitL1Sync(l.ctx, l.Log, l1head, time.Second*12, func(ctx context.Context) (eth.BlockID, error) {
 		status, err := l.ProposalSource.SyncStatus(ctx)
 		if err != nil {
-			return eth.L1BlockRef{}, err
+			return eth.BlockID{}, err
 		}
 		return status.CurrentL1, nil
 	})

--- a/op-proposer/proposer/service.go
+++ b/op-proposer/proposer/service.go
@@ -166,6 +166,9 @@ func (ps *ProposerService) initRPCClients(ctx context.Context, cfg *CLIConfig) e
 		}
 		ps.ProposalSource = source.NewSuperNodeProposalSource(ps.Log, clients...)
 	}
+	if ps.ProposalSource == nil {
+		return ErrMissingSource
+	}
 	return nil
 }
 

--- a/op-proposer/proposer/service.go
+++ b/op-proposer/proposer/service.go
@@ -154,6 +154,18 @@ func (ps *ProposerService) initRPCClients(ctx context.Context, cfg *CLIConfig) e
 		}
 		ps.ProposalSource = source.NewSupervisorProposalSource(ps.Log, clients...)
 	}
+	if len(cfg.SuperNodeRpcs) != 0 {
+		var clients []source.SuperNodeClient
+		for _, url := range cfg.SuperNodeRpcs {
+			cl, err := dial.DialSuperNodeClientWithTimeout(ctx, ps.Log, url,
+				client.WithRPCRecorder(ps.Metrics.NewRecorder("supernode")))
+			if err != nil {
+				return fmt.Errorf("failed to dial supernode RPC client (%v): %w", url, err)
+			}
+			clients = append(clients, cl)
+		}
+		ps.ProposalSource = source.NewSuperNodeProposalSource(ps.Log, clients...)
+	}
 	return nil
 }
 

--- a/op-proposer/proposer/source/source.go
+++ b/op-proposer/proposer/source/source.go
@@ -59,7 +59,7 @@ type ProposalSource interface {
 }
 
 type SyncStatus struct {
-	CurrentL1   eth.L1BlockRef
+	CurrentL1   eth.BlockID
 	SafeL2      uint64
 	FinalizedL2 uint64
 }

--- a/op-proposer/proposer/source/source_rollup.go
+++ b/op-proposer/proposer/source/source_rollup.go
@@ -35,7 +35,7 @@ func (r *RollupProposalSource) SyncStatus(ctx context.Context) (SyncStatus, erro
 		return SyncStatus{}, err
 	}
 	return SyncStatus{
-		CurrentL1:   status.CurrentL1,
+		CurrentL1:   status.CurrentL1.ID(),
 		SafeL2:      status.SafeL2.Number,
 		FinalizedL2: status.FinalizedL2.Number,
 	}, nil

--- a/op-proposer/proposer/source/source_supernode.go
+++ b/op-proposer/proposer/source/source_supernode.go
@@ -86,15 +86,8 @@ func (s *SuperNodeProposalSource) SyncStatus(ctx context.Context) (SyncStatus, e
 		return SyncStatus{}, fmt.Errorf("no available sync status sources: %w", errors.Join(errs...))
 	}
 
-	// CurrentL1 represents the highest L1 block that has been fully derived
-	// and verified by all chains.
-	currentL1 := eth.L1BlockRef{
-		Hash:   earliestResponse.CurrentL1.Hash,
-		Number: earliestResponse.CurrentL1.Number,
-	}
-
 	return SyncStatus{
-		CurrentL1:   currentL1,
+		CurrentL1:   earliestResponse.CurrentL1,
 		SafeL2:      earliestResponse.CurrentSafeTimestamp,
 		FinalizedL2: earliestResponse.CurrentFinalizedTimestamp,
 	}, nil

--- a/op-proposer/proposer/source/source_supernode.go
+++ b/op-proposer/proposer/source/source_supernode.go
@@ -1,0 +1,152 @@
+package source
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+var ErrNoSuperRootData = errors.New("supernode response has no super root data")
+
+// SuperNodeClient is the interface for interacting with an op-supernode.
+type SuperNodeClient interface {
+	SuperRootAtTimestamp(ctx context.Context, timestamp uint64) (eth.SuperRootAtTimestampResponse, error)
+	Close()
+}
+
+// SuperNodeProposalSource fetches super root proposals from op-supernode instances.
+// It supports multiple clients for fault tolerance, querying them in parallel for sync status
+// and falling back to subsequent clients for proposals if earlier ones fail.
+type SuperNodeProposalSource struct {
+	log     log.Logger
+	clients []SuperNodeClient
+}
+
+func NewSuperNodeProposalSource(logger log.Logger, clients ...SuperNodeClient) *SuperNodeProposalSource {
+	if len(clients) == 0 {
+		panic("no supernode clients provided")
+	}
+	return &SuperNodeProposalSource{
+		log:     logger,
+		clients: clients,
+	}
+}
+
+type supernodeStatusResult struct {
+	idx  int
+	resp eth.SuperRootAtTimestampResponse
+	err  error
+}
+
+// SyncStatus returns the current L1 view and the safe/finalized L2 timestamps as reported by the supernode.
+// The timestamps are precomputed by the supernode as the conservative minimum across the dependency set.
+func (s *SuperNodeProposalSource) SyncStatus(ctx context.Context) (SyncStatus, error) {
+	now := uint64(time.Now().Unix())
+
+	var wg sync.WaitGroup
+	results := make(chan supernodeStatusResult, len(s.clients))
+	wg.Add(len(s.clients))
+	for i, client := range s.clients {
+		go func() {
+			defer wg.Done()
+			resp, err := client.SuperRootAtTimestamp(ctx, now)
+			results <- supernodeStatusResult{
+				idx:  i,
+				resp: resp,
+				err:  err,
+			}
+		}()
+	}
+	wg.Wait()
+	close(results)
+
+	var errs []error
+	var earliestResponse eth.SuperRootAtTimestampResponse
+	var hasValidResponse bool
+	for result := range results {
+		if result.err != nil {
+			s.log.Warn("Failed to retrieve sync status from supernode", "idx", result.idx, "err", result.err)
+			errs = append(errs, result.err)
+			continue
+		}
+		// Use the response with the lowest CurrentL1 block number (most conservative)
+		if !hasValidResponse || result.resp.CurrentL1.Number < earliestResponse.CurrentL1.Number {
+			earliestResponse = result.resp
+			hasValidResponse = true
+		}
+	}
+
+	if !hasValidResponse {
+		return SyncStatus{}, fmt.Errorf("no available sync status sources: %w", errors.Join(errs...))
+	}
+
+	// CurrentL1 represents the highest L1 block that has been fully derived
+	// and verified by all chains.
+	currentL1 := eth.L1BlockRef{
+		Hash:   earliestResponse.CurrentL1.Hash,
+		Number: earliestResponse.CurrentL1.Number,
+	}
+
+	return SyncStatus{
+		CurrentL1:   currentL1,
+		SafeL2:      earliestResponse.CurrentSafeTimestamp,
+		FinalizedL2: earliestResponse.CurrentFinalizedTimestamp,
+	}, nil
+}
+
+// ProposalAtSequenceNum fetches the super-root proposal at the given timestamp.
+// It fails over across supernode clients until it finds a response with valid super-root data.
+func (s *SuperNodeProposalSource) ProposalAtSequenceNum(ctx context.Context, timestamp uint64) (Proposal, error) {
+	var errs []error
+	for i, client := range s.clients {
+		resp, err := client.SuperRootAtTimestamp(ctx, timestamp)
+		if err != nil {
+			errs = append(errs, err)
+			s.log.Warn("Failed to retrieve proposal from supernode", "idx", i, "err", err)
+			continue
+		}
+
+		if resp.Data == nil {
+			errs = append(errs, fmt.Errorf("%w: timestamp %d from supernode idx %d", ErrNoSuperRootData, timestamp, i))
+			s.log.Warn("Supernode response has no super root data", "idx", i, "timestamp", timestamp)
+			continue
+		}
+
+		super := resp.Data.Super
+		if super == nil {
+			errs = append(errs, fmt.Errorf("super root data missing super value from supernode idx %d", i))
+			s.log.Warn("Super root data missing super value from supernode", "idx", i, "timestamp", timestamp)
+			continue
+		}
+		if ver := super.Version(); ver != eth.SuperRootVersionV1 {
+			errs = append(errs, fmt.Errorf("unsupported super root version %d from supernode idx %d", ver, i))
+			s.log.Warn("Unsupported super root version from supernode", "idx", i, "version", ver)
+			continue
+		}
+
+		return Proposal{
+			Root:        common.Hash(resp.Data.SuperRoot),
+			SequenceNum: timestamp,
+			Super:       super,
+			CurrentL1: eth.BlockID{
+				Hash:   resp.CurrentL1.Hash,
+				Number: resp.CurrentL1.Number,
+			},
+			// Unsupported by super root proposals
+			Legacy: LegacyProposalData{},
+		}, nil
+	}
+	return Proposal{}, fmt.Errorf("no available proposal sources: %w", errors.Join(errs...))
+}
+
+func (s *SuperNodeProposalSource) Close() {
+	for _, client := range s.clients {
+		client.Close()
+	}
+}

--- a/op-proposer/proposer/source/source_supernode_test.go
+++ b/op-proposer/proposer/source/source_supernode_test.go
@@ -1,0 +1,262 @@
+package source
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSuperNodeSource_SyncStatus(t *testing.T) {
+	t.Run("Single-Success", func(t *testing.T) {
+		client := &mockSuperNodeClient{
+			fn: func(_ context.Context, _ uint64) (eth.SuperRootAtTimestampResponse, error) {
+				return eth.SuperRootAtTimestampResponse{
+					CurrentL1:                 eth.BlockID{Hash: common.Hash{0xaa}, Number: 100},
+					CurrentSafeTimestamp:      111,
+					CurrentFinalizedTimestamp: 222,
+				}, nil
+			},
+		}
+		source := NewSuperNodeProposalSource(testlog.Logger(t, log.LvlInfo), client)
+		status, err := source.SyncStatus(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, SyncStatus{
+			CurrentL1:   eth.L1BlockRef{Hash: common.Hash{0xaa}, Number: 100},
+			SafeL2:      111,
+			FinalizedL2: 222,
+		}, status)
+	})
+
+	t.Run("Multi-ReturnLowestCurrentL1", func(t *testing.T) {
+		client1 := &mockSuperNodeClient{
+			fn: func(_ context.Context, _ uint64) (eth.SuperRootAtTimestampResponse, error) {
+				return eth.SuperRootAtTimestampResponse{
+					CurrentL1:                 eth.BlockID{Hash: common.Hash{0x01}, Number: 999},
+					CurrentSafeTimestamp:      9999,
+					CurrentFinalizedTimestamp: 9999,
+				}, nil
+			},
+		}
+		client2 := &mockSuperNodeClient{
+			fn: func(_ context.Context, _ uint64) (eth.SuperRootAtTimestampResponse, error) {
+				return eth.SuperRootAtTimestampResponse{
+					CurrentL1:                 eth.BlockID{Hash: common.Hash{0x02}, Number: 100},
+					CurrentSafeTimestamp:      123,
+					CurrentFinalizedTimestamp: 456,
+				}, nil
+			},
+		}
+		source := NewSuperNodeProposalSource(testlog.Logger(t, log.LvlInfo), client1, client2)
+		status, err := source.SyncStatus(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, SyncStatus{
+			CurrentL1:   eth.L1BlockRef{Hash: common.Hash{0x02}, Number: 100},
+			SafeL2:      123,
+			FinalizedL2: 456,
+		}, status)
+	})
+
+	t.Run("Multi-SkipFailingClients", func(t *testing.T) {
+		client1 := &mockSuperNodeClient{err: errors.New("test error")}
+		client2 := &mockSuperNodeClient{
+			fn: func(_ context.Context, _ uint64) (eth.SuperRootAtTimestampResponse, error) {
+				return eth.SuperRootAtTimestampResponse{
+					CurrentL1:                 eth.BlockID{Hash: common.Hash{0x02}, Number: 100},
+					CurrentSafeTimestamp:      123,
+					CurrentFinalizedTimestamp: 456,
+				}, nil
+			},
+		}
+		logger, logs := testlog.CaptureLogger(t, log.LvlInfo)
+		source := NewSuperNodeProposalSource(logger, client1, client2)
+		status, err := source.SyncStatus(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, uint64(123), status.SafeL2)
+		require.NotNil(t, logs.FindLog(testlog.NewLevelFilter(slog.LevelWarn), testlog.NewAttributesFilter("err", client1.err.Error())))
+	})
+}
+
+func TestSuperNodeSource_ProposalAtSequenceNum(t *testing.T) {
+	chainA := eth.ChainIDFromUInt64(1)
+	chainB := eth.ChainIDFromUInt64(2)
+	timestamp := uint64(599)
+
+	response := eth.SuperRootAtTimestampResponse{
+		CurrentL1: eth.BlockID{
+			Hash:   common.Hash{0x11},
+			Number: 589111,
+		},
+		ChainIDs: []eth.ChainID{chainA, chainB},
+		Data: &eth.SuperRootResponseData{
+			VerifiedRequiredL1: eth.BlockID{
+				Hash:   common.Hash{0x22},
+				Number: 589100,
+			},
+			Super: eth.NewSuperV1(timestamp, eth.ChainIDAndOutput{
+				ChainID: chainA,
+				Output:  eth.Bytes32{0xa1},
+			}, eth.ChainIDAndOutput{
+				ChainID: chainB,
+				Output:  eth.Bytes32{0xa2},
+			}),
+			SuperRoot: eth.Bytes32{0xaa, 0xbb},
+		},
+	}
+
+	expected := Proposal{
+		Root:        common.Hash(response.Data.SuperRoot),
+		SequenceNum: timestamp,
+		CurrentL1: eth.BlockID{
+			Hash:   response.CurrentL1.Hash,
+			Number: response.CurrentL1.Number,
+		},
+		Legacy: LegacyProposalData{},
+		Super:  response.Data.Super,
+	}
+
+	t.Run("Single-Success", func(t *testing.T) {
+		client := &mockSuperNodeClient{
+			responses: map[uint64]eth.SuperRootAtTimestampResponse{
+				timestamp: response,
+			},
+		}
+		source := NewSuperNodeProposalSource(testlog.Logger(t, log.LvlInfo), client)
+		actual, err := source.ProposalAtSequenceNum(context.Background(), timestamp)
+		require.NoError(t, err)
+		require.Equal(t, expected, actual)
+	})
+
+	t.Run("Single-Error", func(t *testing.T) {
+		expectedErr := errors.New("test error")
+		client := &mockSuperNodeClient{
+			err: expectedErr,
+		}
+		source := NewSuperNodeProposalSource(testlog.Logger(t, log.LvlInfo), client)
+		_, err := source.ProposalAtSequenceNum(context.Background(), 294)
+		require.ErrorIs(t, err, expectedErr)
+	})
+
+	t.Run("Single-NoData", func(t *testing.T) {
+		client := &mockSuperNodeClient{
+			responses: map[uint64]eth.SuperRootAtTimestampResponse{
+				timestamp: {
+					CurrentL1: eth.BlockID{
+						Hash:   common.Hash{0x11},
+						Number: 589111,
+					},
+					Data: nil, // No super root data
+				},
+			},
+		}
+		source := NewSuperNodeProposalSource(testlog.Logger(t, log.LvlInfo), client)
+		_, err := source.ProposalAtSequenceNum(context.Background(), timestamp)
+		require.ErrorIs(t, err, ErrNoSuperRootData)
+	})
+
+	t.Run("Multi-FirstSourceSuccess", func(t *testing.T) {
+		client1 := &mockSuperNodeClient{
+			responses: map[uint64]eth.SuperRootAtTimestampResponse{
+				timestamp: response,
+			},
+		}
+		client2 := &mockSuperNodeClient{}
+		source := NewSuperNodeProposalSource(testlog.Logger(t, log.LvlInfo), client1, client2)
+		actual, err := source.ProposalAtSequenceNum(context.Background(), timestamp)
+		require.NoError(t, err)
+		require.Equal(t, expected, actual)
+		require.Equal(t, 1, client1.requestCount)
+		require.Equal(t, 0, client2.requestCount)
+	})
+
+	t.Run("Multi-FailOverToSecondSource", func(t *testing.T) {
+		client1 := &mockSuperNodeClient{
+			err: errors.New("test error"),
+		}
+		client2 := &mockSuperNodeClient{
+			responses: map[uint64]eth.SuperRootAtTimestampResponse{
+				timestamp: response,
+			},
+		}
+		logger, logs := testlog.CaptureLogger(t, log.LvlInfo)
+		source := NewSuperNodeProposalSource(logger, client1, client2)
+		actual, err := source.ProposalAtSequenceNum(context.Background(), timestamp)
+		require.NoError(t, err)
+		require.Equal(t, expected, actual)
+		require.Equal(t, 1, client1.requestCount)
+		require.Equal(t, 1, client2.requestCount)
+		require.NotNil(t, logs.FindLog(testlog.NewLevelFilter(slog.LevelWarn), testlog.NewAttributesFilter("err", client1.err.Error())))
+	})
+
+	t.Run("Multi-FailOverOnNoData", func(t *testing.T) {
+		client1 := &mockSuperNodeClient{
+			responses: map[uint64]eth.SuperRootAtTimestampResponse{
+				timestamp: {
+					CurrentL1: eth.BlockID{Hash: common.Hash{0x11}, Number: 100},
+					Data:      nil, // No data
+				},
+			},
+		}
+		client2 := &mockSuperNodeClient{
+			responses: map[uint64]eth.SuperRootAtTimestampResponse{
+				timestamp: response,
+			},
+		}
+		logger, logs := testlog.CaptureLogger(t, log.LvlInfo)
+		source := NewSuperNodeProposalSource(logger, client1, client2)
+		actual, err := source.ProposalAtSequenceNum(context.Background(), timestamp)
+		require.NoError(t, err)
+		require.Equal(t, expected, actual)
+		require.Equal(t, 1, client1.requestCount)
+		require.Equal(t, 1, client2.requestCount)
+		require.NotNil(t, logs.FindLog(testlog.NewLevelFilter(slog.LevelWarn), testlog.NewMessageContainsFilter("no super root data")))
+	})
+
+	t.Run("Multi-AllFail", func(t *testing.T) {
+		client1 := &mockSuperNodeClient{
+			err: errors.New("test error1"),
+		}
+		client2 := &mockSuperNodeClient{
+			err: errors.New("test error2"),
+		}
+		logger, logs := testlog.CaptureLogger(t, log.LvlInfo)
+		source := NewSuperNodeProposalSource(logger, client1, client2)
+		_, err := source.ProposalAtSequenceNum(context.Background(), timestamp)
+		require.ErrorIs(t, err, client1.err)
+		require.ErrorIs(t, err, client2.err)
+		require.Equal(t, 1, client1.requestCount)
+		require.Equal(t, 1, client2.requestCount)
+		require.NotNil(t, logs.FindLog(testlog.NewLevelFilter(slog.LevelWarn), testlog.NewAttributesFilter("err", client1.err.Error())))
+		require.NotNil(t, logs.FindLog(testlog.NewLevelFilter(slog.LevelWarn), testlog.NewAttributesFilter("err", client2.err.Error())))
+	})
+}
+
+type mockSuperNodeClient struct {
+	responses    map[uint64]eth.SuperRootAtTimestampResponse
+	fn           func(context.Context, uint64) (eth.SuperRootAtTimestampResponse, error)
+	err          error
+	requestCount int
+}
+
+func (m *mockSuperNodeClient) SuperRootAtTimestamp(ctx context.Context, timestamp uint64) (eth.SuperRootAtTimestampResponse, error) {
+	m.requestCount++
+	if m.fn != nil {
+		return m.fn(ctx, timestamp)
+	}
+	if m.err != nil {
+		return eth.SuperRootAtTimestampResponse{}, m.err
+	}
+	resp, ok := m.responses[timestamp]
+	if !ok {
+		return eth.SuperRootAtTimestampResponse{}, errors.New("timestamp not found in mock")
+	}
+	return resp, nil
+}
+
+func (m *mockSuperNodeClient) Close() {}

--- a/op-proposer/proposer/source/source_supernode_test.go
+++ b/op-proposer/proposer/source/source_supernode_test.go
@@ -28,7 +28,7 @@ func TestSuperNodeSource_SyncStatus(t *testing.T) {
 		status, err := source.SyncStatus(context.Background())
 		require.NoError(t, err)
 		require.Equal(t, SyncStatus{
-			CurrentL1:   eth.L1BlockRef{Hash: common.Hash{0xaa}, Number: 100},
+			CurrentL1:   eth.BlockID{Hash: common.Hash{0xaa}, Number: 100},
 			SafeL2:      111,
 			FinalizedL2: 222,
 		}, status)
@@ -57,7 +57,7 @@ func TestSuperNodeSource_SyncStatus(t *testing.T) {
 		status, err := source.SyncStatus(context.Background())
 		require.NoError(t, err)
 		require.Equal(t, SyncStatus{
-			CurrentL1:   eth.L1BlockRef{Hash: common.Hash{0x02}, Number: 100},
+			CurrentL1:   eth.BlockID{Hash: common.Hash{0x02}, Number: 100},
 			SafeL2:      123,
 			FinalizedL2: 456,
 		}, status)

--- a/op-proposer/proposer/source/source_supervisor.go
+++ b/op-proposer/proposer/source/source_supervisor.go
@@ -80,7 +80,7 @@ func (s *SupervisorProposalSource) SyncStatus(ctx context.Context) (SyncStatus, 
 		return SyncStatus{}, fmt.Errorf("no available sync status sources: %w", errors.Join(errs...))
 	}
 	return SyncStatus{
-		CurrentL1:   earliestResponse.MinSyncedL1,
+		CurrentL1:   earliestResponse.MinSyncedL1.ID(),
 		SafeL2:      earliestResponse.SafeTimestamp,
 		FinalizedL2: earliestResponse.FinalizedTimestamp,
 	}, nil

--- a/op-proposer/proposer/source/source_supervisor_test.go
+++ b/op-proposer/proposer/source/source_supervisor_test.go
@@ -34,7 +34,7 @@ func TestSupervisorSource_SyncStatus(t *testing.T) {
 		actual, err := source.SyncStatus(context.Background())
 		require.NoError(t, err)
 		expected := SyncStatus{
-			CurrentL1:   response.MinSyncedL1,
+			CurrentL1:   response.MinSyncedL1.ID(),
 			SafeL2:      response.SafeTimestamp,
 			FinalizedL2: response.FinalizedTimestamp,
 		}
@@ -90,7 +90,7 @@ func TestSupervisorSource_SyncStatus(t *testing.T) {
 		require.NoError(t, err)
 		// Should use the response with the lowest MinSyncedL1 block number
 		expected := SyncStatus{
-			CurrentL1:   response2.MinSyncedL1,
+			CurrentL1:   response2.MinSyncedL1.ID(),
 			SafeL2:      response2.SafeTimestamp,
 			FinalizedL2: response2.FinalizedTimestamp,
 		}
@@ -120,7 +120,7 @@ func TestSupervisorSource_SyncStatus(t *testing.T) {
 		require.NoError(t, err)
 		// Should use the response with the lowest MinSyncedL1 block number
 		expected := SyncStatus{
-			CurrentL1:   response2.MinSyncedL1,
+			CurrentL1:   response2.MinSyncedL1.ID(),
 			SafeL2:      response2.SafeTimestamp,
 			FinalizedL2: response2.FinalizedTimestamp,
 		}
@@ -162,7 +162,7 @@ func TestSupervisorSource_SyncStatus(t *testing.T) {
 		require.NoError(t, err)
 		// Should use the response with the lowest MinSyncedL1 block number which is L1 genesis
 		expected := SyncStatus{
-			CurrentL1:   response3.MinSyncedL1,
+			CurrentL1:   response3.MinSyncedL1.ID(),
 			SafeL2:      response3.SafeTimestamp,
 			FinalizedL2: response3.FinalizedTimestamp,
 		}
@@ -192,7 +192,7 @@ func TestSupervisorSource_SyncStatus(t *testing.T) {
 		require.NoError(t, err)
 		// Should use the one successful response
 		expected := SyncStatus{
-			CurrentL1:   response.MinSyncedL1,
+			CurrentL1:   response.MinSyncedL1.ID(),
 			SafeL2:      response.SafeTimestamp,
 			FinalizedL2: response.FinalizedTimestamp,
 		}

--- a/op-service/dial/rollup_sync.go
+++ b/op-service/dial/rollup_sync.go
@@ -9,7 +9,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
-type GetL1SyncStatus func(ctx context.Context) (eth.L1BlockRef, error)
+type GetL1SyncStatus func(ctx context.Context) (eth.BlockID, error)
 
 func WaitRollupSync(
 	ctx context.Context,
@@ -18,12 +18,12 @@ func WaitRollupSync(
 	l1BlockTarget uint64,
 	pollInterval time.Duration,
 ) error {
-	return WaitL1Sync(ctx, lgr, l1BlockTarget, pollInterval, func(ctx context.Context) (eth.L1BlockRef, error) {
+	return WaitL1Sync(ctx, lgr, l1BlockTarget, pollInterval, func(ctx context.Context) (eth.BlockID, error) {
 		status, err := rollup.SyncStatus(ctx)
 		if err != nil {
-			return eth.L1BlockRef{}, err
+			return eth.BlockID{}, err
 		}
-		return status.CurrentL1, nil
+		return status.CurrentL1.ID(), nil
 	})
 }
 

--- a/op-service/eth/superroot_at_timestamp.go
+++ b/op-service/eth/superroot_at_timestamp.go
@@ -23,6 +23,14 @@ type SuperRootAtTimestampResponse struct {
 	// CurrentL1 is the highest L1 block that has been fully derived and verified by all chains.
 	CurrentL1 BlockID `json:"current_l1"`
 
+	// CurrentSafeTimestamp is the highest L2 timestamp that is safe across the dependency set at the CurrentL1.
+	// This value is derived from the minimum per-chain safe L2 head timestamp.
+	CurrentSafeTimestamp uint64 `json:"safe_timestamp"`
+
+	// CurrentFinalizedTimestamp is the highest L2 timestamp that is finalized across the dependency set at the CurrentL1.
+	// This value is derived from the minimum per-chain finalized L2 head timestamp.
+	CurrentFinalizedTimestamp uint64 `json:"finalized_timestamp"`
+
 	// OptimisticAtTimestamp is the L2 block that would be applied if verification were assumed to be successful,
 	// and the minimum L1 block required to derive them. If Data is nil, some chains may be absent from this map,
 	// indicating that there is no optimistic block for the chain at the requested timestamp that can be derived

--- a/op-supernode/supernode/activity/superroot/superroot.go
+++ b/op-supernode/supernode/activity/superroot/superroot.go
@@ -40,23 +40,52 @@ func (api *superrootAPI) AtTimestamp(ctx context.Context, timestamp uint64) (eth
 }
 
 func (s *Superroot) atTimestamp(ctx context.Context, timestamp uint64) (eth.SuperRootAtTimestampResponse, error) {
-	optimistic := map[eth.ChainID]eth.OutputWithRequiredL1{}
-	minCurrentL1 := eth.BlockID{}
-	minVerifiedRequiredL1 := eth.BlockID{}
-	chainOutputs := make([]eth.ChainIDAndOutput, 0, len(s.chains))
-
+	var (
+		optimistic            = make(map[eth.ChainID]eth.OutputWithRequiredL1, len(s.chains))
+		minCurrentL1          eth.BlockID
+		minVerifiedRequiredL1 eth.BlockID
+		minSafeTimestamp      uint64
+		minFinalizedTimestamp uint64
+		safeInitialized       bool
+		finalizedInitialized  bool
+		chainOutputs          = make([]eth.ChainIDAndOutput, 0, len(s.chains))
+	)
 	// Get current l1s
 	// this informs callers that the chains local views have considered at least up to this L1 block
 	// TODO(#18651): Currently there are no verifiers to consider, but once there are, this needs to be updated to consider if
 	// they have also processed the L1 data.
 	for chainID, chain := range s.chains {
-		currentL1, err := chain.CurrentL1(ctx)
+		status, err := chain.SyncStatus(ctx)
 		if err != nil {
-			s.log.Warn("failed to get current L1", "chain_id", chainID.String(), "err", err)
+			s.log.Warn("failed to get sync status", "chain_id", chainID.String(), "err", err)
 			return eth.SuperRootAtTimestampResponse{}, err
 		}
-		if currentL1.ID().Number < minCurrentL1.Number || minCurrentL1 == (eth.BlockID{}) {
-			minCurrentL1 = currentL1.ID()
+		if status == nil { // defensive
+			status = &eth.SyncStatus{}
+		}
+
+		currentL1 := status.CurrentL1.ID()
+		if currentL1.Number < minCurrentL1.Number || minCurrentL1 == (eth.BlockID{}) {
+			minCurrentL1 = currentL1
+		}
+		// Conservative aggregation across chains: take the minimum timestamps.
+		// If any chain has a zero timestamp (not initialized), the aggregate is zero.
+		if !safeInitialized {
+			minSafeTimestamp = status.SafeL2.Time
+			safeInitialized = true
+		} else if minSafeTimestamp == 0 || status.SafeL2.Time == 0 {
+			minSafeTimestamp = 0
+		} else if status.SafeL2.Time < minSafeTimestamp {
+			minSafeTimestamp = status.SafeL2.Time
+		}
+
+		if !finalizedInitialized {
+			minFinalizedTimestamp = status.FinalizedL2.Time
+			finalizedInitialized = true
+		} else if minFinalizedTimestamp == 0 || status.FinalizedL2.Time == 0 {
+			minFinalizedTimestamp = 0
+		} else if status.FinalizedL2.Time < minFinalizedTimestamp {
+			minFinalizedTimestamp = status.FinalizedL2.Time
 		}
 	}
 
@@ -106,9 +135,11 @@ func (s *Superroot) atTimestamp(ctx context.Context, timestamp uint64) (eth.Supe
 		return a.Cmp(b)
 	})
 	response := eth.SuperRootAtTimestampResponse{
-		CurrentL1:             minCurrentL1,
-		OptimisticAtTimestamp: optimistic,
-		ChainIDs:              chainIDs,
+		CurrentL1:                 minCurrentL1,
+		CurrentSafeTimestamp:      minSafeTimestamp,
+		CurrentFinalizedTimestamp: minFinalizedTimestamp,
+		OptimisticAtTimestamp:     optimistic,
+		ChainIDs:                  chainIDs,
 	}
 	if !notFound {
 		// Build super root from collected outputs

--- a/op-supernode/supernode/activity/superroot/superroot_test.go
+++ b/op-supernode/supernode/activity/superroot/superroot_test.go
@@ -13,17 +13,17 @@ import (
 )
 
 type mockCC struct {
-	verL2     eth.BlockID
-	verL1     eth.BlockID
-	optL2     eth.BlockID
-	optL1     eth.BlockID
-	output    eth.Bytes32
-	currentL1 eth.BlockRef
+	verL2  eth.BlockID
+	verL1  eth.BlockID
+	optL2  eth.BlockID
+	optL1  eth.BlockID
+	output eth.Bytes32
+	status *eth.SyncStatus
 
-	currentL1Err  error
 	verifiedErr   error
 	outputErr     error
 	optimisticErr error
+	syncStatusErr error
 }
 
 func (m *mockCC) Start(ctx context.Context) error  { return nil }
@@ -34,17 +34,20 @@ func (m *mockCC) Resume(ctx context.Context) error { return nil }
 func (m *mockCC) SafeBlockAtTimestamp(ctx context.Context, ts uint64) (eth.L2BlockRef, error) {
 	return eth.L2BlockRef{}, nil
 }
+func (m *mockCC) SyncStatus(ctx context.Context) (*eth.SyncStatus, error) {
+	if m.syncStatusErr != nil {
+		return nil, m.syncStatusErr
+	}
+	if m.status == nil {
+		return &eth.SyncStatus{}, nil
+	}
+	return m.status, nil
+}
 func (m *mockCC) SafeHeadAtL1(ctx context.Context, l1BlockNum uint64) (eth.BlockID, eth.BlockID, error) {
 	return eth.BlockID{}, eth.BlockID{}, nil
 }
 func (m *mockCC) L1AtSafeHead(ctx context.Context, l2 eth.BlockID) (eth.BlockID, error) {
 	return eth.BlockID{}, nil
-}
-func (m *mockCC) CurrentL1(ctx context.Context) (eth.BlockRef, error) {
-	if m.currentL1Err != nil {
-		return eth.BlockRef{}, m.currentL1Err
-	}
-	return m.currentL1, nil
 }
 func (m *mockCC) VerifiedAt(ctx context.Context, ts uint64) (eth.BlockID, eth.BlockID, error) {
 	if m.verifiedErr != nil {
@@ -78,20 +81,28 @@ func TestSuperroot_AtTimestamp_Succeeds(t *testing.T) {
 	t.Parallel()
 	chains := map[eth.ChainID]cc.ChainContainer{
 		eth.ChainIDFromUInt64(10): &mockCC{
-			verL2:     eth.BlockID{Number: 100},
-			verL1:     eth.BlockID{Number: 1000},
-			optL2:     eth.BlockID{Number: 100},
-			optL1:     eth.BlockID{Number: 1000},
-			output:    eth.Bytes32{},
-			currentL1: eth.BlockRef{Number: 2000},
+			verL2:  eth.BlockID{Number: 100},
+			verL1:  eth.BlockID{Number: 1000},
+			optL2:  eth.BlockID{Number: 100},
+			optL1:  eth.BlockID{Number: 1000},
+			output: eth.Bytes32{},
+			status: &eth.SyncStatus{
+				CurrentL1:   eth.L1BlockRef{Number: 2000},
+				SafeL2:      eth.L2BlockRef{Time: 200},
+				FinalizedL2: eth.L2BlockRef{Time: 150},
+			},
 		},
 		eth.ChainIDFromUInt64(420): &mockCC{
-			verL2:     eth.BlockID{Number: 200},
-			verL1:     eth.BlockID{Number: 1100},
-			optL2:     eth.BlockID{Number: 200},
-			optL1:     eth.BlockID{Number: 1100},
-			output:    eth.Bytes32{},
-			currentL1: eth.BlockRef{Number: 2100},
+			verL2:  eth.BlockID{Number: 200},
+			verL1:  eth.BlockID{Number: 1100},
+			optL2:  eth.BlockID{Number: 200},
+			optL1:  eth.BlockID{Number: 1100},
+			output: eth.Bytes32{},
+			status: &eth.SyncStatus{
+				CurrentL1:   eth.L1BlockRef{Number: 2100},
+				SafeL2:      eth.L2BlockRef{Time: 180},
+				FinalizedL2: eth.L2BlockRef{Time: 140},
+			},
 		},
 	}
 	s := New(gethlog.New(), chains)
@@ -101,6 +112,8 @@ func TestSuperroot_AtTimestamp_Succeeds(t *testing.T) {
 	require.Len(t, out.OptimisticAtTimestamp, 2)
 	// min values
 	require.Equal(t, uint64(2000), out.CurrentL1.Number)
+	require.Equal(t, uint64(180), out.CurrentSafeTimestamp)
+	require.Equal(t, uint64(140), out.CurrentFinalizedTimestamp)
 	require.Equal(t, uint64(1000), out.Data.VerifiedRequiredL1.Number)
 	// With zero outputs, the superroot will be deterministic, just ensure it's set
 	_ = out.Data.SuperRoot
@@ -112,20 +125,20 @@ func TestSuperroot_AtTimestamp_ComputesSuperRoot(t *testing.T) {
 	out2 := eth.Bytes32{2}
 	chains := map[eth.ChainID]cc.ChainContainer{
 		eth.ChainIDFromUInt64(10): &mockCC{
-			verL2:     eth.BlockID{Number: 100},
-			verL1:     eth.BlockID{Number: 1000},
-			optL2:     eth.BlockID{Number: 100},
-			optL1:     eth.BlockID{Number: 1000},
-			output:    out1,
-			currentL1: eth.BlockRef{Number: 2000},
+			verL2:  eth.BlockID{Number: 100},
+			verL1:  eth.BlockID{Number: 1000},
+			optL2:  eth.BlockID{Number: 100},
+			optL1:  eth.BlockID{Number: 1000},
+			output: out1,
+			status: &eth.SyncStatus{CurrentL1: eth.L1BlockRef{Number: 2000}},
 		},
 		eth.ChainIDFromUInt64(420): &mockCC{
-			verL2:     eth.BlockID{Number: 200},
-			verL1:     eth.BlockID{Number: 1100},
-			optL2:     eth.BlockID{Number: 200},
-			optL1:     eth.BlockID{Number: 1100},
-			output:    out2,
-			currentL1: eth.BlockRef{Number: 2100},
+			verL2:  eth.BlockID{Number: 200},
+			verL1:  eth.BlockID{Number: 1100},
+			optL2:  eth.BlockID{Number: 200},
+			optL1:  eth.BlockID{Number: 1100},
+			output: out2,
+			status: &eth.SyncStatus{CurrentL1: eth.L1BlockRef{Number: 2100}},
 		},
 	}
 	ts := uint64(123)
@@ -147,7 +160,7 @@ func TestSuperroot_AtTimestamp_ErrorOnCurrentL1(t *testing.T) {
 	t.Parallel()
 	chains := map[eth.ChainID]cc.ChainContainer{
 		eth.ChainIDFromUInt64(10): &mockCC{
-			currentL1Err: assertErr(),
+			syncStatusErr: assertErr(),
 		},
 	}
 	s := New(gethlog.New(), chains)
@@ -176,12 +189,12 @@ func TestSuperroot_AtTimestamp_NotFoundOnVerifiedAt(t *testing.T) {
 			verifiedErr: fmt.Errorf("nope: %w", ethereum.NotFound),
 		},
 		eth.ChainIDFromUInt64(11): &mockCC{
-			verL2:     eth.BlockID{Number: 200},
-			verL1:     eth.BlockID{Number: 1100},
-			optL2:     eth.BlockID{Number: 200},
-			optL1:     eth.BlockID{Number: 1100},
-			output:    eth.Bytes32{0x12},
-			currentL1: eth.BlockRef{Number: 2100},
+			verL2:  eth.BlockID{Number: 200},
+			verL1:  eth.BlockID{Number: 1100},
+			optL2:  eth.BlockID{Number: 200},
+			optL1:  eth.BlockID{Number: 1100},
+			output: eth.Bytes32{0x12},
+			status: &eth.SyncStatus{CurrentL1: eth.L1BlockRef{Number: 2100}},
 		},
 	}
 	s := New(gethlog.New(), chains)

--- a/op-supernode/supernode/chain_container/chain_container.go
+++ b/op-supernode/supernode/chain_container/chain_container.go
@@ -30,10 +30,10 @@ type ChainContainer interface {
 	Resume(ctx context.Context) error
 
 	SafeBlockAtTimestamp(ctx context.Context, ts uint64) (eth.L2BlockRef, error)
+	SyncStatus(ctx context.Context) (*eth.SyncStatus, error)
 	SafeHeadAtL1(ctx context.Context, l1BlockNum uint64) (l1 eth.BlockID, l2 eth.BlockID, err error)
 	// L1AtSafeHead returns the earliest L1 block at which the given L2 block became safe.
 	L1AtSafeHead(ctx context.Context, l2 eth.BlockID) (eth.BlockID, error)
-	CurrentL1(ctx context.Context) (eth.BlockRef, error)
 	VerifiedAt(ctx context.Context, ts uint64) (l2, l1 eth.BlockID, err error)
 	OptimisticAt(ctx context.Context, ts uint64) (l2, l1 eth.BlockID, err error)
 	OutputRootAtL2BlockNumber(ctx context.Context, l2BlockNum uint64) (eth.Bytes32, error)
@@ -232,6 +232,21 @@ func (c *simpleChainContainer) SafeBlockAtTimestamp(ctx context.Context, ts uint
 	return c.engine.SafeBlockAtTimestamp(ctx, ts)
 }
 
+// SyncStatus returns the in-process op-node sync status for this chain.
+func (c *simpleChainContainer) SyncStatus(ctx context.Context) (*eth.SyncStatus, error) {
+	if c.vn == nil {
+		if c.log != nil {
+			c.log.Warn("SyncStatus: virtual node not initialized")
+		}
+		return &eth.SyncStatus{}, nil
+	}
+	st, err := c.vn.SyncStatus(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return st, nil
+}
+
 // OutputRootAtL2BlockNumber computes the L2 output root for the specified L2 block number.
 func (c *simpleChainContainer) OutputRootAtL2BlockNumber(ctx context.Context, l2BlockNum uint64) (eth.Bytes32, error) {
 	if c.engine == nil {
@@ -258,17 +273,6 @@ func (c *simpleChainContainer) L1AtSafeHead(ctx context.Context, l2 eth.BlockID)
 		return eth.BlockID{}, fmt.Errorf("virtual node not initialized")
 	}
 	return c.vn.L1AtSafeHead(ctx, l2)
-}
-
-// CurrentL1 returns the most recent processed L1 block reference based on the derivation pipeline sync status.
-func (c *simpleChainContainer) CurrentL1(ctx context.Context) (eth.BlockRef, error) {
-	if c.vn == nil {
-		if c.log != nil {
-			c.log.Warn("CurrentL1: virtual node not initialized")
-		}
-		return eth.BlockRef{}, nil
-	}
-	return c.vn.CurrentL1(ctx)
 }
 
 // VerifiedAt returns the verified L2 and L1 blocks for the given L2 timestamp.

--- a/op-supernode/supernode/chain_container/chain_container_test.go
+++ b/op-supernode/supernode/chain_container/chain_container_test.go
@@ -101,9 +101,14 @@ func (m *mockVirtualNode) LastL1(ctx context.Context) (eth.BlockID, error) {
 	return m.safeHeadL1, m.safeHeadErr
 }
 
-// CurrentL1 implements virtual_node.VirtualNode CurrentL1
-func (m *mockVirtualNode) CurrentL1(ctx context.Context) (eth.BlockRef, error) {
-	return eth.BlockRef{Hash: m.safeHeadL1.Hash, Number: m.safeHeadL1.Number}, m.safeHeadErr
+// SyncStatus implements virtual_node.VirtualNode SyncStatus
+func (m *mockVirtualNode) SyncStatus(ctx context.Context) (*eth.SyncStatus, error) {
+	if m.safeHeadErr != nil {
+		return nil, m.safeHeadErr
+	}
+	return &eth.SyncStatus{
+		CurrentL1: eth.L1BlockRef{Hash: m.safeHeadL1.Hash, Number: m.safeHeadL1.Number},
+	}, nil
 }
 
 // SafeDB is not required by VirtualNode in these tests

--- a/op-supernode/supernode/chain_container/virtual_node/virtual_node.go
+++ b/op-supernode/supernode/chain_container/virtual_node/virtual_node.go
@@ -41,7 +41,7 @@ type VirtualNode interface {
 	SafeHeadAtL1(ctx context.Context, l1BlockNum uint64) (eth.BlockID, eth.BlockID, error)
 	// L1AtSafeHead returns the earliest L1 block at which the given L2 block became safe.
 	L1AtSafeHead(ctx context.Context, target eth.BlockID) (eth.BlockID, error)
-	CurrentL1(ctx context.Context) (eth.BlockRef, error)
+	SyncStatus(ctx context.Context) (*eth.SyncStatus, error)
 }
 
 type innerNode interface {
@@ -265,20 +265,14 @@ func (v *simpleVirtualNode) L1AtSafeHead(ctx context.Context, target eth.BlockID
 	return cursor, nil
 }
 
-// CurrentL1 returns the current processed L1 block based on derivation pipeline sync status.
-func (v *simpleVirtualNode) CurrentL1(ctx context.Context) (eth.BlockRef, error) {
+func (v *simpleVirtualNode) SyncStatus(ctx context.Context) (*eth.SyncStatus, error) {
 	v.mu.Lock()
 	inner := v.inner
 	v.mu.Unlock()
 	if inner == nil {
-		return eth.BlockRef{}, ErrVirtualNodeNotRunning
+		return nil, ErrVirtualNodeNotRunning
 	}
 	st := inner.SyncStatus()
-	// Map L1 block ref into generic block ref
-	return eth.BlockRef{
-		Hash:       st.CurrentL1.Hash,
-		Number:     st.CurrentL1.Number,
-		ParentHash: st.CurrentL1.ParentHash,
-		Time:       st.CurrentL1.Time,
-	}, nil
+	cpy := *st
+	return &cpy, nil
 }


### PR DESCRIPTION
For the time being, the supernode RPC is only configurable programmatically. This the minimum required for devstack.

Adding support for supernode RPC via cli will be done at a later date once supernode is production ready for interop proofs.

fixes https://github.com/ethereum-optimism/optimism/issues/18920