### PR TITLE
Enable UInt64 lint check and fix remaining violations

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -67,8 +67,6 @@ linters:
         text: errors.As
       - path: (.+)\.go$
         text: errors.Is
-      - path: (.+)\.go$
-        text: use bigs.Uint64Strict # Ignore violations until code has been updated
     paths:
       - third_party$
       - builtin$

--- a/devnet-sdk/system/node.go
+++ b/devnet-sdk/system/node.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/devnet-sdk/contracts"
 	"github.com/ethereum-optimism/optimism/devnet-sdk/interfaces"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum/go-ethereum"
@@ -76,7 +77,7 @@ func (n *node) BlockByNumber(ctx context.Context, number *big.Int) (eth.BlockInf
 	}
 	var block eth.BlockInfo
 	if number != nil {
-		block, err = client.InfoByNumber(ctx, number.Uint64())
+		block, err = client.InfoByNumber(ctx, bigs.Uint64Strict(number))
 	} else {
 		block, err = client.InfoByLabel(ctx, eth.Unsafe)
 	}

--- a/devnet-sdk/system/wallet.go
+++ b/devnet-sdk/system/wallet.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	coreTypes "github.com/ethereum/go-ethereum/core/types"
 )
 
@@ -209,9 +210,9 @@ func (i *executeMessageImpl) Call(ctx context.Context) (any, error) {
 	msg := supervisorTypes.Message{
 		Identifier: supervisorTypes.Identifier{
 			Origin:      i.identifier.Origin,
-			BlockNumber: i.identifier.BlockNumber.Uint64(),
-			LogIndex:    uint32(i.identifier.LogIndex.Uint64()),
-			Timestamp:   i.identifier.Timestamp.Uint64(),
+			BlockNumber: bigs.Uint64Strict(i.identifier.BlockNumber),
+			LogIndex:    uint32(bigs.Uint64Strict(i.identifier.LogIndex)),
+			Timestamp:   bigs.Uint64Strict(i.identifier.Timestamp),
 			ChainID:     eth.ChainIDFromBig(i.identifier.ChainId),
 		},
 		PayloadHash: crypto.Keccak256Hash(i.sentMessage),

--- a/kona/tests/supervisor/l2reorg/init_exec_msg_test.go
+++ b/kona/tests/supervisor/l2reorg/init_exec_msg_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack/match"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/txintent"
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
@@ -116,7 +117,7 @@ func TestReorgInitExecMsg(gt *testing.T) {
 	// sequence a conflicting block with a simple transfer tx, based on the parent of the parent of the unsafe head
 	{
 		var err error
-		divergenceBlockNumber_B = execReceipt.BlockNumber.Uint64()
+		divergenceBlockNumber_B = bigs.Uint64Strict(execReceipt.BlockNumber)
 		originalRef_B, err = sys.L2ELB.Escape().L2EthClient().L2BlockRefByHash(ctx, execReceipt.BlockHash)
 		require.NoError(t, err, "Expected to be able to call L2BlockRefByHash API, but got error")
 

--- a/kona/tests/supervisor/message/interop_happy_tx_test.go
+++ b/kona/tests/supervisor/message/interop_happy_tx_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	stypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
@@ -46,11 +47,11 @@ func TestInteropHappyTx(gt *testing.T) {
 	// confirm that the cross-safe safety passed init and exec receipts and that blocks were not reorged
 	dsl.CheckAll(t,
 		sys.L2CLA.ReachedRefFn(stypes.CrossSafe, eth.BlockID{
-			Number: initReceipt.BlockNumber.Uint64(),
+			Number: bigs.Uint64Strict(initReceipt.BlockNumber),
 			Hash:   initReceipt.BlockHash,
 		}, 500),
 		sys.L2CLB.ReachedRefFn(stypes.CrossSafe, eth.BlockID{
-			Number: execReceipt.BlockNumber.Uint64(),
+			Number: bigs.Uint64Strict(execReceipt.BlockNumber),
 			Hash:   execReceipt.BlockHash,
 		}, 500),
 	)

--- a/kona/tests/supervisor/message/interop_msg_test.go
+++ b/kona/tests/supervisor/message/interop_msg_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	suptypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
@@ -80,7 +81,7 @@ func TestInitExecMsgWithDSL(gt *testing.T) {
 
 	// Write: Alice triggers initiating message
 	receipt := contract.Write(alice, eventLogger.EmitLog(topics, data))
-	block, err := clientA.BlockRefByNumber(t.Ctx(), receipt.BlockNumber.Uint64())
+	block, err := clientA.BlockRefByNumber(t.Ctx(), bigs.Uint64Strict(receipt.BlockNumber))
 	require.NoError(err)
 
 	sys.Supervisor.WaitForUnsafeHeadToAdvance(alice.ChainID(), 2)
@@ -91,7 +92,7 @@ func TestInitExecMsgWithDSL(gt *testing.T) {
 	payload := suptypes.LogToMessagePayload(receipt.Logs[logIdx])
 	identifier := suptypes.Identifier{
 		Origin:      eventLoggerAddress,
-		BlockNumber: receipt.BlockNumber.Uint64(),
+		BlockNumber: bigs.Uint64Strict(receipt.BlockNumber),
 		LogIndex:    logIdx,
 		Timestamp:   block.Time,
 		ChainID:     sys.L2ELA.ChainID(),

--- a/kona/tests/supervisor/pre_interop/post_test.go
+++ b/kona/tests/supervisor/pre_interop/post_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack/match"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	stypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 	"github.com/ethereum/go-ethereum/common"
@@ -203,11 +204,11 @@ func verifyInteropMessagesProgression(t devtest.T, sys *presets.SimpleInterop, i
 	// Verify cross-safe progression for both messages
 	dsl.CheckAll(t,
 		sys.L2CLA.ReachedRefFn(stypes.CrossSafe, eth.BlockID{
-			Number: initReceipt.BlockNumber.Uint64(),
+			Number: bigs.Uint64Strict(initReceipt.BlockNumber),
 			Hash:   initReceipt.BlockHash,
 		}, 60),
 		sys.L2CLB.ReachedRefFn(stypes.CrossSafe, eth.BlockID{
-			Number: execReceipt.BlockNumber.Uint64(),
+			Number: bigs.Uint64Strict(execReceipt.BlockNumber),
 			Hash:   execReceipt.BlockHash,
 		}, 60),
 	)

--- a/kona/tests/supervisor/rpc/rpc_test.go
+++ b/kona/tests/supervisor/rpc/rpc_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/interop"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 	"github.com/ethereum/go-ethereum/common"
@@ -224,7 +225,7 @@ func TestRPCCheckAccessList(gt *testing.T) {
 		return args.Access()
 	}
 
-	blockRef := sys.L2ChainA.PublicRPC().BlockRefByNumber(initReceipt.BlockNumber.Uint64())
+	blockRef := sys.L2ChainA.PublicRPC().BlockRefByNumber(bigs.Uint64Strict(initReceipt.BlockNumber))
 
 	var accessEntries []types.Access
 	for _, evLog := range initReceipt.Logs {

--- a/op-alt-da/damgr.go
+++ b/op-alt-da/damgr.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/op-alt-da/bindings"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
@@ -432,7 +433,10 @@ func (d *DA) decodeChallengeStatus(log *types.Log) (ChallengeStatus, CommitmentD
 		return 0, nil, 0, err
 	}
 	d.log.Debug("decoded challenge status event", "log", log, "event", event, "comm", fmt.Sprintf("%x", comm.Encode()))
-	return ChallengeStatus(event.Status), comm, event.ChallengedBlockNumber.Uint64(), nil
+	if !event.ChallengedBlockNumber.IsUint64() {
+		return 0, nil, 0, fmt.Errorf("challenged block number is not a uint64")
+	}
+	return ChallengeStatus(event.Status), comm, bigs.Uint64Strict(event.ChallengedBlockNumber), nil
 }
 
 var (

--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-batcher/metrics"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/queue"
 	"github.com/ethereum/go-ethereum/common"
@@ -129,7 +130,7 @@ func (s *channelManager) TxConfirmed(_id txID, inclusionBlock eth.BlockID) {
 // Panics if the block is not in state.
 func (s *channelManager) rewindToBlock(block eth.BlockID) {
 	initialCursor := s.blockCursor
-	idx := block.Number - s.blocks[0].Number().Uint64()
+	idx := block.Number - bigs.Uint64Strict(s.blocks[0].Number())
 	if s.blocks[idx].Hash() == block.Hash && idx < uint64(s.blockCursor) {
 		s.blockCursor = int(idx)
 	} else {

--- a/op-batcher/batcher/channel_manager_test.go
+++ b/op-batcher/batcher/channel_manager_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	derivetest "github.com/ethereum-optimism/optimism/op-node/rollup/derive/test"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/queue"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
@@ -779,7 +780,7 @@ func newBlock(parent *types.Block, numTransactions int) *types.Block {
 	if parent == nil {
 		rng = rand.New(rand.NewSource(123))
 	} else {
-		rng = rand.New(rand.NewSource(int64(parent.Header().Number.Uint64())))
+		rng = rand.New(rand.NewSource(int64(bigs.Uint64Strict(parent.Header().Number))))
 	}
 	block := derivetest.RandomL2BlockWithChainId(rng, numTransactions, defaultTestRollupConfig.L2ChainID)
 	header := block.Header()

--- a/op-batcher/batcher/types.go
+++ b/op-batcher/batcher/types.go
@@ -42,8 +42,7 @@ func (b *SizedBlock) EstimatedDABytes() uint64 {
 			if tx.IsDepositTx() {
 				continue
 			}
-			// It is safe to assume that the estimated DA size is always a uint64,
-			// so calling Uint64() is safe
+			// It is safe to assume that the estimated DA size is always a uint64
 			daSize += bigs.Uint64Strict(tx.RollupCostData().EstimatedDASize())
 		}
 		b.estimatedDABytes = daSize

--- a/op-batcher/batcher/types.go
+++ b/op-batcher/batcher/types.go
@@ -1,6 +1,7 @@
 package batcher
 
 import (
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
@@ -43,7 +44,7 @@ func (b *SizedBlock) EstimatedDABytes() uint64 {
 			}
 			// It is safe to assume that the estimated DA size is always a uint64,
 			// so calling Uint64() is safe
-			daSize += tx.RollupCostData().EstimatedDASize().Uint64()
+			daSize += bigs.Uint64Strict(tx.RollupCostData().EstimatedDASize())
 		}
 		b.estimatedDABytes = daSize
 	}

--- a/op-chain-ops/cmd/check-derivation/main.go
+++ b/op-chain-ops/cmd/check-derivation/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
 	"github.com/holiman/uint256"
 
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -335,7 +336,7 @@ func confirmTransaction(ctx context.Context, ethClient *ethclient.Client, l2Bloc
 		}
 		block := eth.BlockID{
 			Hash:   receipt.BlockHash,
-			Number: receipt.BlockNumber.Uint64(),
+			Number: bigs.Uint64Strict(receipt.BlockNumber),
 		}
 		log.Info("Transaction receipt found", "block", block, "status", receipt.Status)
 		return block, nil
@@ -365,7 +366,7 @@ func checkConsolidation(cliCtx *cli.Context) error {
 	}
 	l2ChainID := new(big.Int).SetUint64(cliCtx.Uint64("l2-chain-id"))
 	l2BlockTime := uint64(2)
-	rollupCfg, err := rollup.LoadOPStackRollupConfig(l2ChainID.Uint64())
+	rollupCfg, err := rollup.LoadOPStackRollupConfig(bigs.Uint64Strict(l2ChainID))
 	if err == nil {
 		l2BlockTime = rollupCfg.BlockTime
 	} else {

--- a/op-chain-ops/cmd/check-ecotone/main.go
+++ b/op-chain-ops/cmd/check-ecotone/main.go
@@ -30,6 +30,7 @@ import (
 	nbindings "github.com/ethereum-optimism/optimism/op-node/bindings"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	op_service "github.com/ethereum-optimism/optimism/op-service"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/cliapp"
 	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/ctxinterrupt"
@@ -111,7 +112,7 @@ type actionEnv struct {
 
 func (ae *actionEnv) RecordGasUsed(rec *types.Receipt) {
 	ae.gasUsed += rec.GasUsed
-	ae.l1GasUsed += rec.L1GasUsed.Uint64()
+	ae.l1GasUsed += bigs.Uint64Strict(rec.L1GasUsed)
 	ae.log.Debug("Recorded tx receipt gas", "gas_used", rec.GasUsed, "l1_gas_used", rec.L1GasUsed)
 }
 

--- a/op-chain-ops/cmd/check-fjord/checks/checks.go
+++ b/op-chain-ops/cmd/check-fjord/checks/checks.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-core/predeploys"
 	"github.com/ethereum-optimism/optimism/op-e2e/bindings"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 )
 
 type CheckFjordConfig struct {
@@ -38,7 +39,7 @@ type CheckFjordConfig struct {
 
 func (ae *CheckFjordConfig) RecordGasUsed(rec *types.Receipt) {
 	ae.GasUsed += rec.GasUsed
-	ae.L1GasUsed += rec.L1GasUsed.Uint64()
+	ae.L1GasUsed += bigs.Uint64Strict(rec.L1GasUsed)
 	ae.Log.Debug("Recorded tx receipt gas", "gas_used", rec.GasUsed, "l1_gas_used", rec.L1GasUsed)
 }
 
@@ -183,7 +184,7 @@ func sendTxAndCheckFees(ctx context.Context, env *CheckFjordConfig, to *common.A
 		return fmt.Errorf("calling GasPriceOracle.GetL1GasUsed: %w", err)
 	}
 
-	env.Log.Info("retrieved L1 gas used", "gpoL1GasUsed", gpoL1GasUsed.Uint64())
+	env.Log.Info("retrieved L1 gas used", "gpoL1GasUsed", bigs.Uint64Strict(gpoL1GasUsed))
 
 	// Check that GetL1Fee takes into account fast LZ
 	gpoFee, err := gasPriceOracle.GetL1Fee(opts, txUnsigned)
@@ -195,7 +196,7 @@ func sendTxAndCheckFees(ctx context.Context, env *CheckFjordConfig, to *common.A
 	if err != nil {
 		return fmt.Errorf("calculating GPO fjordL1Cost: %w", err)
 	}
-	if gethGPOFee.Uint64() != gpoFee.Uint64() {
+	if !bigs.Equal(gethGPOFee, gpoFee) {
 		return fmt.Errorf("gethGPOFee (%s) does not match gpoFee (%s)", gethGPOFee, gpoFee)
 	}
 	env.Log.Info("gethGPOFee matches gpoFee")
@@ -204,7 +205,7 @@ func sendTxAndCheckFees(ctx context.Context, env *CheckFjordConfig, to *common.A
 	if err != nil {
 		return fmt.Errorf("calculating receipt fjordL1Cost: %w", err)
 	}
-	if gethFee.Uint64() != tx.receipt.L1Fee.Uint64() {
+	if !bigs.Equal(gethFee, tx.receipt.L1Fee) {
 		return fmt.Errorf("gethFee (%s) does not match receipt L1Fee (%s)", gethFee, tx.receipt.L1Fee)
 	}
 	env.Log.Info("gethFee matches receipt fee")
@@ -221,7 +222,7 @@ func sendTxAndCheckFees(ctx context.Context, env *CheckFjordConfig, to *common.A
 	if err != nil {
 		return fmt.Errorf("failed to calculate fjordL1Cost: %w", err)
 	}
-	if upperBoundCost.Uint64() != upperBound.Uint64() {
+	if !bigs.Equal(upperBoundCost, upperBound) {
 		return fmt.Errorf("upperBound (%s) does not meet expectation (%s)", upperBound, upperBoundCost)
 	}
 	env.Log.Info("GPO upper bound matches")

--- a/op-chain-ops/cmd/check-jovian/main.go
+++ b/op-chain-ops/cmd/check-jovian/main.go
@@ -189,7 +189,7 @@ func checkBlock(ctx context.Context, env *actionEnv) error {
 			return fmt.Errorf("tx mined receipt was nil")
 		}
 
-		env.log.Info("tx mined", "txHash", receipt.TxHash.Hex(), "blockNumber", receipt.BlockNumber.Uint64(), "blobGasUsed", receipt.BlobGasUsed)
+		env.log.Info("tx mined", "txHash", receipt.TxHash.Hex(), "blockNumber", receipt.BlockNumber, "blobGasUsed", receipt.BlobGasUsed)
 
 		if receipt.BlobGasUsed == 0 {
 			return fmt.Errorf("receipt.BlobGasUsed was zero (required with Jovian)")

--- a/op-chain-ops/cmd/check-output-root/main.go
+++ b/op-chain-ops/cmd/check-output-root/main.go
@@ -75,8 +75,8 @@ func CalculateOutputRoot(ctx context.Context, rpcUrl string, blockNum uint64) (c
 	}
 	// Isthmus assumes WithdrawalsHash is present in the header.
 	if header.WithdrawalsHash == nil {
-		return common.Hash{}, fmt.Errorf("target block %d (%s) is missing withdrawals hash, required for Isthmus output root calculation",
-			header.Number.Uint64(), header.Hash())
+		return common.Hash{}, fmt.Errorf("target block %v (%s) is missing withdrawals hash, required for Isthmus output root calculation",
+			header.Number, header.Hash())
 	}
 
 	// Construct OutputV0 using StateRoot, WithdrawalsHash (as MessagePasserStorageRoot), and BlockHash

--- a/op-chain-ops/cmd/op-run-block/main.go
+++ b/op-chain-ops/cmd/op-run-block/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ethereum/go-ethereum/triedb"
 
 	op_service "github.com/ethereum-optimism/optimism/op-service"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/cliapp"
 	"github.com/ethereum-optimism/optimism/op-service/ctxinterrupt"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
@@ -224,7 +225,7 @@ func (r remoteChainCtx) CurrentHeader() *types.Header {
 
 // GetHeaderByNumber is part of consensus.ChainHeaderReader
 func (r remoteChainCtx) GetHeaderByNumber(u uint64) *types.Header {
-	if r.hdr.Number.Uint64() == u {
+	if bigs.Uint64Strict(r.hdr.Number) == u {
 		return r.hdr
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)

--- a/op-chain-ops/cmd/op-simulate/main.go
+++ b/op-chain-ops/cmd/op-simulate/main.go
@@ -36,6 +36,7 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 
 	op_service "github.com/ethereum-optimism/optimism/op-service"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/cliapp"
 	"github.com/ethereum-optimism/optimism/op-service/ctxinterrupt"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
@@ -183,7 +184,7 @@ func fetchChainConfig(ctx context.Context, cl *rpc.Client) (*params.ChainConfig,
 	// if we recognize the chain ID, we can get the chain config
 	id := (*big.Int)(&idResult)
 	if id.IsUint64() {
-		cfg, err := superutil.LoadOPStackChainConfigFromChainID(id.Uint64())
+		cfg, err := superutil.LoadOPStackChainConfigFromChainID(bigs.Uint64Strict(id))
 		if err == nil {
 			return cfg, nil
 		}
@@ -245,7 +246,7 @@ func (d *simChainContext) Engine() consensus.Engine {
 }
 
 func (d *simChainContext) GetHeader(h common.Hash, n uint64) *types.Header {
-	if n == d.head.Number.Uint64() {
+	if n == bigs.Uint64Strict(d.head.Number) {
 		return d.head
 	}
 	panic(fmt.Errorf("header retrieval not supported, cannot fetch %s %d", h, n))
@@ -263,7 +264,7 @@ func (d *simChainContext) GetHeaderByHash(hash common.Hash) *types.Header {
 }
 
 func (d *simChainContext) GetHeaderByNumber(number uint64) *types.Header {
-	if d.head.Number.Uint64() == number {
+	if bigs.Uint64Strict(d.head.Number) == number {
 		return d.head
 	}
 	panic(fmt.Errorf("header retrieval not supported, cannot fetch %d", number))
@@ -294,7 +295,7 @@ func simulate(ctx context.Context, logger log.Logger, conf *params.ChainConfig,
 	}
 
 	// load prestate data into memory db state
-	_, err = state.Commit(header.Number.Uint64()-1, true, conf.IsCancun(header.Number, header.Time))
+	_, err = state.Commit(bigs.Uint64Strict(header.Number)-1, true, conf.IsCancun(header.Number, header.Time))
 	if err != nil {
 		return fmt.Errorf("failed to write state data to underlying DB: %w", err)
 	}

--- a/op-chain-ops/cmd/receipt-reference-builder/pull.go
+++ b/op-chain-ops/cmd/receipt-reference-builder/pull.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/dial"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
@@ -49,7 +50,7 @@ func pull(ctx *cli.Context) error {
 		log.Error("Failed to Get Chain ID", "Err", err)
 		return err
 	}
-	chainID := cid.Uint64()
+	chainID := bigs.Uint64Strict(cid)
 
 	// record start time
 	startT := time.Now()

--- a/op-chain-ops/cmd/withdrawal/prove.go
+++ b/op-chain-ops/cmd/withdrawal/prove.go
@@ -10,7 +10,10 @@ import (
 	bindingspreview "github.com/ethereum-optimism/optimism/op-node/bindings/preview"
 	"github.com/ethereum-optimism/optimism/op-node/withdrawals"
 	op_service "github.com/ethereum-optimism/optimism/op-service"
+	"github.com/ethereum-optimism/optimism/op-service/apis"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
+	"github.com/ethereum-optimism/optimism/op-service/txintent/bindings"
+	"github.com/ethereum-optimism/optimism/op-service/txintent/contractio"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -137,6 +140,19 @@ func txDataForOutputRootProof(ctx context.Context, proofClient *gethclient.Clien
 		return nil, fmt.Errorf("failed to pack output root prove withdrawal transaction: %w", err)
 	}
 	return txData, nil
+}
+
+func l2ChainIDForPortal(ctx context.Context, l1EthClient apis.EthClient, portal *bindingspreview.OptimismPortal2) (uint64, error) {
+	systemConfigAddr, err := portal.SystemConfig(&bind.CallOpts{Context: ctx})
+	if err != nil {
+		return 0, fmt.Errorf("failed to get system config address from portal: %w", err)
+	}
+	systemConfig := bindings.NewSystemConfig(bindings.WithClient(l1EthClient), bindings.WithTo(systemConfigAddr))
+	l2ChainID, err := contractio.Read(systemConfig.L2ChainID(), ctx)
+	if err != nil {
+		return 0, fmt.Errorf("failed to read L2 chain ID from system config: %w", err)
+	}
+	return l2ChainID.Uint64(), nil
 }
 
 func proveFlags() []cli.Flag {

--- a/op-chain-ops/cmd/withdrawal/prove.go
+++ b/op-chain-ops/cmd/withdrawal/prove.go
@@ -10,10 +10,7 @@ import (
 	bindingspreview "github.com/ethereum-optimism/optimism/op-node/bindings/preview"
 	"github.com/ethereum-optimism/optimism/op-node/withdrawals"
 	op_service "github.com/ethereum-optimism/optimism/op-service"
-	"github.com/ethereum-optimism/optimism/op-service/apis"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
-	"github.com/ethereum-optimism/optimism/op-service/txintent/bindings"
-	"github.com/ethereum-optimism/optimism/op-service/txintent/contractio"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -140,19 +137,6 @@ func txDataForOutputRootProof(ctx context.Context, proofClient *gethclient.Clien
 		return nil, fmt.Errorf("failed to pack output root prove withdrawal transaction: %w", err)
 	}
 	return txData, nil
-}
-
-func l2ChainIDForPortal(ctx context.Context, l1EthClient apis.EthClient, portal *bindingspreview.OptimismPortal2) (uint64, error) {
-	systemConfigAddr, err := portal.SystemConfig(&bind.CallOpts{Context: ctx})
-	if err != nil {
-		return 0, fmt.Errorf("failed to get system config address from portal: %w", err)
-	}
-	systemConfig := bindings.NewSystemConfig(bindings.WithClient(l1EthClient), bindings.WithTo(systemConfigAddr))
-	l2ChainID, err := contractio.Read(systemConfig.L2ChainID(), ctx)
-	if err != nil {
-		return 0, fmt.Errorf("failed to read L2 chain ID from system config: %w", err)
-	}
-	return l2ChainID.Uint64(), nil
 }
 
 func proveFlags() []cli.Flag {

--- a/op-chain-ops/crossdomain/encoding_test.go
+++ b/op-chain-ops/crossdomain/encoding_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/crossdomain"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/stretchr/testify/require"
 )
 
@@ -24,7 +25,7 @@ func FuzzVersionedNonce(f *testing.F) {
 
 		decodedNonce, decodedVersion := crossdomain.DecodeVersionedNonce(encodedNonce)
 
-		require.Equal(t, decodedNonce.Uint64(), inputNonce.Uint64())
-		require.Equal(t, decodedVersion.Uint64(), inputVersion.Uint64())
+		require.Equal(t, bigs.Uint64Strict(decodedNonce), bigs.Uint64Strict(inputNonce))
+		require.Equal(t, bigs.Uint64Strict(decodedVersion), bigs.Uint64Strict(inputVersion))
 	})
 }

--- a/op-chain-ops/crossdomain/encoding_test.go
+++ b/op-chain-ops/crossdomain/encoding_test.go
@@ -25,7 +25,7 @@ func FuzzVersionedNonce(f *testing.F) {
 
 		decodedNonce, decodedVersion := crossdomain.DecodeVersionedNonce(encodedNonce)
 
-		require.Equal(t, bigs.Uint64Strict(decodedNonce), bigs.Uint64Strict(inputNonce))
-		require.Equal(t, bigs.Uint64Strict(decodedVersion), bigs.Uint64Strict(inputVersion))
+		require.True(t, bigs.Equal(decodedNonce, inputNonce))
+		require.True(t, bigs.Equal(decodedVersion, inputVersion))
 	})
 }

--- a/op-chain-ops/crossdomain/message.go
+++ b/op-chain-ops/crossdomain/message.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -42,7 +43,7 @@ func NewCrossDomainMessage(
 // It does this by looking at the first byte of the nonce.
 func (c *CrossDomainMessage) Version() uint64 {
 	_, version := DecodeVersionedNonce(c.Nonce)
-	return version.Uint64()
+	return bigs.Uint64Strict(version)
 }
 
 // Encode will encode a cross domain message based on the version.

--- a/op-chain-ops/crossdomain/withdrawal_test.go
+++ b/op-chain-ops/crossdomain/withdrawal_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/crossdomain"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/stretchr/testify/require"
@@ -36,11 +37,11 @@ func FuzzEncodeDecodeWithdrawal(f *testing.F) {
 		err = w.Decode(encoded)
 		require.Nil(t, err)
 
-		require.Equal(t, withdrawal.Nonce.Uint64(), w.Nonce.Uint64())
+		require.Equal(t, bigs.Uint64Strict(withdrawal.Nonce), bigs.Uint64Strict(w.Nonce))
 		require.Equal(t, withdrawal.Sender, w.Sender)
 		require.Equal(t, withdrawal.Target, w.Target)
-		require.Equal(t, withdrawal.Value.Uint64(), w.Value.Uint64())
-		require.Equal(t, withdrawal.GasLimit.Uint64(), w.GasLimit.Uint64())
+		require.Equal(t, bigs.Uint64Strict(withdrawal.Value), bigs.Uint64Strict(w.Value))
+		require.Equal(t, bigs.Uint64Strict(withdrawal.GasLimit), bigs.Uint64Strict(w.GasLimit))
 		require.Equal(t, withdrawal.Data, w.Data)
 	})
 }

--- a/op-chain-ops/crossdomain/withdrawal_test.go
+++ b/op-chain-ops/crossdomain/withdrawal_test.go
@@ -9,24 +9,25 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 )
 
 // FuzzEncodeDecodeWithdrawal will fuzz encoding and decoding of a Withdrawal
 func FuzzEncodeDecodeWithdrawal(f *testing.F) {
 	f.Fuzz(func(t *testing.T, _nonce, _sender, _target, _value, _gasLimit, data []byte) {
-		nonce := new(big.Int).SetBytes(_nonce)
+		nonce := new(uint256.Int).SetBytes(_nonce)
 		sender := common.BytesToAddress(_sender)
 		target := common.BytesToAddress(_target)
-		value := new(big.Int).SetBytes(_value)
-		gasLimit := new(big.Int).SetBytes(_gasLimit)
+		value := new(uint256.Int).SetBytes(_value)
+		gasLimit := new(uint256.Int).SetBytes(_gasLimit)
 
 		withdrawal := crossdomain.NewWithdrawal(
-			nonce,
+			nonce.ToBig(),
 			&sender,
 			&target,
-			value,
-			gasLimit,
+			value.ToBig(),
+			gasLimit.ToBig(),
 			data,
 		)
 
@@ -37,11 +38,11 @@ func FuzzEncodeDecodeWithdrawal(f *testing.F) {
 		err = w.Decode(encoded)
 		require.Nil(t, err)
 
-		require.Equal(t, bigs.Uint64Strict(withdrawal.Nonce), bigs.Uint64Strict(w.Nonce))
+		require.Truef(t, bigs.Equal(withdrawal.Nonce, w.Nonce), "nonce: %s != %s", withdrawal.Nonce, w.Nonce)
 		require.Equal(t, withdrawal.Sender, w.Sender)
 		require.Equal(t, withdrawal.Target, w.Target)
-		require.Equal(t, bigs.Uint64Strict(withdrawal.Value), bigs.Uint64Strict(w.Value))
-		require.Equal(t, bigs.Uint64Strict(withdrawal.GasLimit), bigs.Uint64Strict(w.GasLimit))
+		require.Truef(t, bigs.Equal(withdrawal.Value, w.Value), "value: %s != %s", withdrawal.Value, w.Value)
+		require.Truef(t, bigs.Equal(withdrawal.GasLimit, w.GasLimit), "gasLimit: %s != %s", withdrawal.GasLimit, w.GasLimit)
 		require.Equal(t, withdrawal.Data, w.Data)
 	})
 }

--- a/op-chain-ops/interopgen/deploy.go
+++ b/op-chain-ops/interopgen/deploy.go
@@ -22,6 +22,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/manage"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/opcm"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/standard"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
@@ -37,7 +38,7 @@ func Deploy(logger log.Logger, fa *foundry.ArtifactsFS, srcFS *foundry.SourceMap
 		if fmt.Sprintf("%d", l2Cfg.L2ChainID) != id {
 			return nil, nil, fmt.Errorf("chain L2 %s declared different L2 chain ID %d in config", id, l2Cfg.L2ChainID)
 		}
-		if !cfg.L1.ChainID.IsUint64() || cfg.L1.ChainID.Uint64() != l2Cfg.L1ChainID {
+		if !cfg.L1.ChainID.IsUint64() || bigs.Uint64Strict(cfg.L1.ChainID) != l2Cfg.L1ChainID {
 			return nil, nil, fmt.Errorf("chain L2 %s declared different L1 chain ID %d in config than global %d", id, l2Cfg.L1ChainID, cfg.L1.ChainID)
 		}
 	}
@@ -365,7 +366,7 @@ func CompleteL1(l1Host *script.Host, cfg *L1Config) (*L1Output, error) {
 	l1Genesis, err := genesis.NewL1Genesis(&genesis.DeployConfig{
 		L2InitializationConfig: genesis.L2InitializationConfig{
 			L2CoreDeployConfig: genesis.L2CoreDeployConfig{
-				L1ChainID: cfg.ChainID.Uint64(),
+				L1ChainID: bigs.Uint64Strict(cfg.ChainID),
 			},
 			UpgradeScheduleDeployConfig: genesis.UpgradeScheduleDeployConfig{
 				L1CancunTimeOffset: new(hexutil.Uint64),

--- a/op-chain-ops/script/bindings_test.go
+++ b/op-chain-ops/script/bindings_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -55,7 +56,7 @@ func TestBindings(t *testing.T) {
 	result := bindings.Adder(42, 0x1337)
 	require.NoError(t, err)
 	require.True(t, result.IsUint64())
-	require.Equal(t, uint64(42+0x1337), result.Uint64())
+	require.Equal(t, uint64(42+0x1337), bigs.Uint64Strict(result))
 }
 
 type TestContract struct{}

--- a/op-chain-ops/script/cheatcodes_environment.go
+++ b/op-chain-ops/script/cheatcodes_environment.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/holiman/uint256"
 
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -14,7 +15,7 @@ import (
 
 // Warp implements https://book.getfoundry.sh/cheatcodes/warp
 func (c *CheatCodesPrecompile) Warp(timestamp *big.Int) {
-	c.h.env.Context().Time = timestamp.Uint64()
+	c.h.env.Context().Time = bigs.Uint64Strict(timestamp)
 }
 
 // Roll implements https://book.getfoundry.sh/cheatcodes/roll

--- a/op-chain-ops/script/cheatcodes_external.go
+++ b/op-chain-ops/script/cheatcodes_external.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/vm"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/foundry"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 )
 
 // Ffi implements https://book.getfoundry.sh/cheatcodes/ffi
@@ -70,7 +71,7 @@ func (c *CheatCodesPrecompile) Sleep(ms *big.Int) error {
 	if !ms.IsUint64() {
 		return vm.ErrExecutionReverted
 	}
-	time.Sleep(time.Duration(ms.Uint64()) * time.Millisecond)
+	time.Sleep(time.Duration(bigs.Uint64Strict(ms)) * time.Millisecond)
 	return nil
 }
 

--- a/op-chain-ops/script/cheatcodes_utilities.go
+++ b/op-chain-ops/script/cheatcodes_utilities.go
@@ -11,6 +11,7 @@ import (
 
 	hdwallet "github.com/ethereum-optimism/go-ethereum-hdwallet"
 
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -248,7 +249,7 @@ func (c *CheatCodesPrecompile) ComputeCreateAddress_74637a7a(deployer common.Add
 	if !nonce.IsUint64() {
 		return common.Address{}, fmt.Errorf("nonce %s too large to fit in regular nonce type", nonce)
 	}
-	return crypto.CreateAddress(deployer, nonce.Uint64()), nil
+	return crypto.CreateAddress(deployer, bigs.Uint64Strict(nonce)), nil
 }
 
 // unsupported

--- a/op-chain-ops/script/check_super_root.go
+++ b/op-chain-ops/script/check_super_root.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
@@ -222,7 +223,7 @@ func (m *SuperRootMigrator) calculateTargetBlockNumbers(ctx context.Context) err
 			return fmt.Errorf("target timestamp is prior to genesis for endpoint %v", endpoint)
 		}
 		// Compute the target block number
-		targetBlockNumber := new(big.Int).SetUint64(latestBlock.Number().Uint64() - blocksToLookBack)
+		targetBlockNumber := new(big.Int).SetUint64(bigs.Uint64Strict(latestBlock.Number()) - blocksToLookBack)
 
 		// Store the computed values in the chain settings
 		m.chainSettings[endpoint].BlockTime = blockTime
@@ -246,7 +247,7 @@ func (m *SuperRootMigrator) calculateOutputRoots(ctx context.Context) error {
 		// Isthmus assumes WithdrawalsHash is present in the header.
 		if targetHeader.WithdrawalsHash == nil {
 			return fmt.Errorf("target block %d (%s) on chain %s (ID: %s) is missing withdrawals hash, required for Isthmus output root calculation",
-				targetHeader.Number.Uint64(), targetHeader.Hash(), url, settings.ChainID)
+				bigs.Uint64Strict(targetHeader.Number), targetHeader.Hash(), url, settings.ChainID)
 		}
 
 		// Construct OutputV0 using StateRoot, WithdrawalsHash (as MessagePasserStorageRoot), and BlockHash

--- a/op-chain-ops/script/fork.go
+++ b/op-chain-ops/script/fork.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/script/forking"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -35,7 +36,7 @@ func ForkWithBlockNumberU256(num *big.Int) ForkOption {
 		if !num.IsUint64() {
 			return fmt.Errorf("block number %s is too large", num.String())
 		}
-		v := num.Uint64()
+		v := bigs.Uint64Strict(num)
 		cfg.BlockNumber = &v
 		return nil
 	}

--- a/op-chain-ops/script/script.go
+++ b/op-chain-ops/script/script.go
@@ -30,6 +30,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-chain-ops/foundry"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/script/forking"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/srcmap"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 )
 
 // jumpHistory is the amount of successful jumps to track for debugging.
@@ -792,7 +793,7 @@ func (h *Host) StateDump() (*foundry.ForgeAllocs, error) {
 	baseState := h.baseState
 	// We have to commit the existing state to the trie,
 	// for all the state-changes to be captured by the trie iterator.
-	root, err := baseState.Commit(h.env.Context().BlockNumber.Uint64(), true, false)
+	root, err := baseState.Commit(bigs.Uint64Strict(h.env.Context().BlockNumber), true, false)
 	if err != nil {
 		return nil, fmt.Errorf("failed to commit state: %w", err)
 	}

--- a/op-deployer/pkg/deployer/apply.go
+++ b/op-deployer/pkg/deployer/apply.go
@@ -210,8 +210,8 @@ func runValidationAfterApply(ctx context.Context, cliCtx *cli.Context, l log.Log
 				continue
 			}
 			// Check if L1 chain ID is supported (mainnet=1, sepolia=11155111)
-			if l1ChainID.Uint64() != 1 && l1ChainID.Uint64() != 11155111 {
-				l.Info("Skipping validation", "reason", "no validator address available and L1 chain ID not supported", "chain-id", chainID.Hex(), "l1-chain-id", l1ChainID.Uint64())
+			if bigs.Uint64Strict(l1ChainID) != 1 && bigs.Uint64Strict(l1ChainID) != 11155111 {
+				l.Info("Skipping validation", "reason", "no validator address available and L1 chain ID not supported", "chain-id", chainID.Hex(), "l1-chain-id", bigs.Uint64Strict(l1ChainID))
 				continue
 			}
 		}

--- a/op-deployer/pkg/deployer/apply.go
+++ b/op-deployer/pkg/deployer/apply.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/validate"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/verify"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/env"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	opcrypto "github.com/ethereum-optimism/optimism/op-service/crypto"
 	"github.com/ethereum-optimism/optimism/op-service/ctxinterrupt"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
@@ -144,7 +145,7 @@ func ApplyCLI() func(cliCtx *cli.Context) error {
 			ctx,
 			l,
 			l1RPCUrl,
-			chainID.Uint64(),
+			bigs.Uint64Strict(chainID),
 			stateFile,
 			intent.L1ContractsLocator,
 			cliCtx.String(VerifierTypeFlagName),

--- a/op-deployer/pkg/deployer/bootstrap/implementations.go
+++ b/op-deployer/pkg/deployer/bootstrap/implementations.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/opcm"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/verify"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/env"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/cliutil"
 	opcrypto "github.com/ethereum-optimism/optimism/op-service/crypto"
 	"github.com/ethereum-optimism/optimism/op-service/ctxinterrupt"
@@ -184,7 +185,7 @@ func ImplementationsCLI(cliCtx *cli.Context) error {
 		ctx,
 		l,
 		l1RPCUrl,
-		chainID.Uint64(),
+		bigs.Uint64Strict(chainID),
 		verifyFile,
 		cfg.ArtifactsLocator,
 		cliCtx.String(deployer.VerifierTypeFlagName),

--- a/op-deployer/pkg/deployer/bootstrap/implementations_test.go
+++ b/op-deployer/pkg/deployer/bootstrap/implementations_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/opcm"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/standard"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/testutil"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -58,12 +59,12 @@ func testImplementations(t *testing.T, forkRPCURL string) {
 	chainID, err := client.ChainID(ctx)
 	require.NoError(t, err)
 
-	superchain, err := standard.SuperchainFor(chainID.Uint64())
+	superchain, err := standard.SuperchainFor(bigs.Uint64Strict(chainID))
 	require.NoError(t, err)
 
 	loc, _ := testutil.LocalArtifacts(t)
 
-	proxyAdminOwner, err := standard.L1ProxyAdminOwner(uint64(chainID.Uint64()))
+	proxyAdminOwner, err := standard.L1ProxyAdminOwner(bigs.Uint64Strict(chainID))
 	require.NoError(t, err)
 	deploy := func() opcm.DeployImplementationsOutput {
 		out, err := Implementations(ctx, ImplementationsConfig{

--- a/op-deployer/pkg/deployer/bootstrap/superchain.go
+++ b/op-deployer/pkg/deployer/bootstrap/superchain.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/opcm"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/verify"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/env"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	opcrypto "github.com/ethereum-optimism/optimism/op-service/crypto"
 	"github.com/ethereum-optimism/optimism/op-service/ctxinterrupt"
 	"github.com/ethereum-optimism/optimism/op-service/ioutil"
@@ -174,7 +175,7 @@ func SuperchainCLI(cliCtx *cli.Context) error {
 		ctx,
 		l,
 		l1RPCUrl,
-		chainID.Uint64(),
+		bigs.Uint64Strict(chainID),
 		verifyFile,
 		cfg.ArtifactsLocator,
 		cliCtx.String(deployer.VerifierTypeFlagName),

--- a/op-deployer/pkg/deployer/inspect/genesis.go
+++ b/op-deployer/pkg/deployer/inspect/genesis.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/ioutil"
 	"github.com/ethereum-optimism/optimism/op-service/jsonutil"
 	"github.com/urfave/cli/v2"
@@ -73,7 +74,7 @@ func GenesisAndRollup(globalState *state.State, chainID common.Hash) (*core.Gene
 	rollupConfig, err := config.RollupConfig(
 		chainState.StartBlock.ToBlockRef(),
 		l2GenesisBlock.Hash(),
-		l2GenesisBlock.Number().Uint64(),
+		bigs.Uint64Strict(l2GenesisBlock.Number()),
 	)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to build rollup config: %w", err)

--- a/op-deployer/pkg/deployer/integration_test/shared/shared.go
+++ b/op-deployer/pkg/deployer/integration_test/shared/shared.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/state"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/upgrade/embedded"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/env"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
@@ -82,7 +83,7 @@ func NewIntent(
 ) (*state.Intent, *state.State) {
 	intent := &state.Intent{
 		ConfigType: state.IntentTypeCustom,
-		L1ChainID:  l1ChainID.Uint64(),
+		L1ChainID:  bigs.Uint64Strict(l1ChainID),
 		SuperchainRoles: &addresses.SuperchainRoles{
 			SuperchainProxyAdminOwner: AddrFor(t, dk, devkeys.L1ProxyAdminOwnerRole.Key(l1ChainID)),
 			ProtocolVersionsOwner:     AddrFor(t, dk, devkeys.SuperchainDeployerKey.Key(l1ChainID)),

--- a/op-deployer/pkg/deployer/pipeline/env.go
+++ b/op-deployer/pkg/deployer/pipeline/env.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/foundry"
 
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/jsonutil"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
@@ -130,7 +131,7 @@ func RenderGenesisAndRollup(globalState *state.State, chainID common.Hash, useGl
 	rollupConfig, err := config.RollupConfig(
 		chainState.StartBlock.ToBlockRef(),
 		l2GenesisBlock.Hash(),
-		l2GenesisBlock.Number().Uint64(),
+		bigs.Uint64Strict(l2GenesisBlock.Number()),
 	)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to build rollup config: %w", err)

--- a/op-deployer/pkg/deployer/state/deploy_config.go
+++ b/op-deployer/pkg/deployer/state/deploy_config.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 
@@ -91,7 +92,7 @@ func CombineDeployConfig(intent *Intent, chainIntent *ChainIntent, state *State,
 			UpgradeScheduleDeployConfig: *upgradeSchedule,
 			L2CoreDeployConfig: genesis.L2CoreDeployConfig{
 				L1ChainID:                 intent.L1ChainID,
-				L2ChainID:                 chainState.ID.Big().Uint64(),
+				L2ChainID:                 bigs.Uint64Strict(chainState.ID.Big()),
 				L2BlockTime:               2,
 				FinalizationPeriodSeconds: 12,
 				MaxSequencerDrift:         600,

--- a/op-deployer/pkg/deployer/verify/verifier.go
+++ b/op-deployer/pkg/deployer/verify/verifier.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/artifacts"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/flags"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/ctxinterrupt"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	"github.com/ethereum/go-ethereum/log"
@@ -102,7 +103,7 @@ func VerifyCLI(cliCtx *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to get chain ID: %w", err)
 	}
-	l1ChainId := chainId.Uint64()
+	l1ChainId := bigs.Uint64Strict(chainId)
 
 	locator, err := artifacts.NewLocatorFromURL(l1ContractsLocator)
 	if err != nil {

--- a/op-service/bgpo/oracle.go
+++ b/op-service/bgpo/oracle.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/sources/caching"
 )
@@ -169,7 +170,7 @@ func (o *BlobTipOracle) Start() error {
 		select {
 		case header := <-headers:
 			if err := o.processHeader(header); err != nil {
-				o.log.Error("Error processing header", "err", err, "block", header.Number.Uint64())
+				o.log.Error("Error processing header", "err", err, "block", bigs.Uint64Strict(header.Number))
 			}
 		case err := <-sub.Err():
 			if err != nil {
@@ -233,13 +234,13 @@ func (o *BlobTipOracle) prePopulateCache() error {
 // It also triggers an asynchronous fetch of the full block to extract blob fee caps.
 func (o *BlobTipOracle) processHeader(header *types.Header) error {
 	defer func(start time.Time) {
-		o.log.Debug("Processed header", "block", header.Number.Uint64(), "time", time.Since(start))
+		o.log.Debug("Processed header", "block", bigs.Uint64Strict(header.Number), "time", time.Since(start))
 	}(time.Now())
 
 	o.Lock()
 	defer o.Unlock()
 
-	blockNum := header.Number.Uint64()
+	blockNum := bigs.Uint64Strict(header.Number)
 
 	// Calculate blob base fee from the header
 	if _, ok := o.baseFees.Get(blockNum); ok {

--- a/op-service/eth/block_info.go
+++ b/op-service/eth/block_info.go
@@ -3,6 +3,7 @@ package eth
 import (
 	"math/big"
 
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus/misc/eip4844"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -113,7 +114,7 @@ func (h *headerBlockInfo) Root() common.Hash {
 }
 
 func (h *headerBlockInfo) NumberU64() uint64 {
-	return h.header.Number.Uint64()
+	return bigs.Uint64Strict(h.header.Number)
 }
 
 func (h *headerBlockInfo) Time() uint64 {

--- a/op-service/eth/heads.go
+++ b/op-service/eth/heads.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
@@ -45,7 +46,7 @@ func WatchHeadChanges(ctx context.Context, src NewHeadSource, fn HeadSignalFn) (
 			case header := <-headChanges:
 				fn(eventsCtx, L1BlockRef{
 					Hash:       header.Hash(),
-					Number:     header.Number.Uint64(),
+					Number:     bigs.Uint64Strict(header.Number),
 					ParentHash: header.ParentHash,
 					Time:       header.Time,
 				})

--- a/op-service/eth/id.go
+++ b/op-service/eth/id.go
@@ -3,6 +3,7 @@ package eth
 import (
 	"fmt"
 
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 )
@@ -23,11 +24,11 @@ func (id BlockID) TerminalString() string {
 }
 
 func ReceiptBlockID(r *types.Receipt) BlockID {
-	return BlockID{Number: r.BlockNumber.Uint64(), Hash: r.BlockHash}
+	return BlockID{Number: bigs.Uint64Strict(r.BlockNumber), Hash: r.BlockHash}
 }
 
 func HeaderBlockID(h *types.Header) BlockID {
-	return BlockID{Number: h.Number.Uint64(), Hash: h.Hash()}
+	return BlockID{Number: bigs.Uint64Strict(h.Number), Hash: h.Hash()}
 }
 
 type L2BlockRef struct {
@@ -101,7 +102,7 @@ type BlockRef = L1BlockRef
 func BlockRefFromHeader(h *types.Header) *BlockRef {
 	return &BlockRef{
 		Hash:       h.Hash(),
-		Number:     h.Number.Uint64(),
+		Number:     bigs.Uint64Strict(h.Number),
 		ParentHash: h.ParentHash,
 		Time:       h.Time,
 	}

--- a/op-service/eth/transactions.go
+++ b/op-service/eth/transactions.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -79,12 +80,12 @@ func CheckRecentTxs(
 
 	if currentNonce == previousNonce {
 		// Most recent tx is older than the given depth
-		return oldestBlock.Uint64(), false, nil
+		return bigs.Uint64Strict(oldestBlock), false, nil
 	}
 
 	// Use binary search to find the block where the nonce changed
-	low := oldestBlock.Uint64()
-	high := currentBlock.Uint64()
+	low := bigs.Uint64Strict(oldestBlock)
+	high := bigs.Uint64Strict(currentBlock)
 
 	for low < high {
 		mid := (low + high) / 2
@@ -113,5 +114,5 @@ func CheckRecentTxs(
 			low = mid + 1
 		}
 	}
-	return oldestBlock.Uint64(), false, nil
+	return bigs.Uint64Strict(oldestBlock), false, nil
 }

--- a/op-service/gnosis/client.go
+++ b/op-service/gnosis/client.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr/metrics"
 
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -243,9 +244,9 @@ func (c *GnosisClient) ExecuteTransaction(ctx context.Context, safeTx *SafeTrans
 		return nil, fmt.Errorf("failed to get threshold: %w", err)
 	}
 	numSignatures := len(signatures) / 65
-	if numSignatures < int(threshold.Uint64()) {
+	if numSignatures < int(bigs.Uint64Strict(threshold)) {
 		return nil, fmt.Errorf("not enough signatures to execute transaction: have %d, need %d",
-			numSignatures, threshold.Uint64())
+			numSignatures, bigs.Uint64Strict(threshold))
 	}
 	c.lgr.Info("signatures meets threshold", "numSignatures", numSignatures, "threshold", threshold)
 

--- a/op-service/safemath/safemath_test.go
+++ b/op-service/safemath/safemath_test.go
@@ -41,7 +41,8 @@ func testAdd[V constraints.Unsigned](t *testing.T) {
 				got, overflowed := SafeAdd(a, b)
 				require.Equal(t, expectedOverflow, overflowed)
 				// masked expected outcome to int size, since it may have overflowed
-				require.Equal(t, bigs.Uint64Strict(expectedSum)&uint64(m), uint64(got))
+				//nolint:bigint // Overflow is explicitly expected and handled here.
+				require.Equal(t, expectedSum.Uint64()&uint64(m), uint64(got))
 			}
 			{
 				got := SaturatingAdd(a, b)

--- a/op-service/safemath/safemath_test.go
+++ b/op-service/safemath/safemath_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 
@@ -40,14 +41,14 @@ func testAdd[V constraints.Unsigned](t *testing.T) {
 				got, overflowed := SafeAdd(a, b)
 				require.Equal(t, expectedOverflow, overflowed)
 				// masked expected outcome to int size, since it may have overflowed
-				require.Equal(t, expectedSum.Uint64()&uint64(m), uint64(got))
+				require.Equal(t, bigs.Uint64Strict(expectedSum)&uint64(m), uint64(got))
 			}
 			{
 				got := SaturatingAdd(a, b)
 				if expectedOverflow {
 					require.Equal(t, uint64(m), uint64(got))
 				} else {
-					require.Equal(t, expectedSum.Uint64(), uint64(got))
+					require.Equal(t, bigs.Uint64Strict(expectedSum), uint64(got))
 				}
 			}
 		}

--- a/op-service/sources/batching/arrays.go
+++ b/op-service/sources/batching/arrays.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
 )
 
@@ -17,7 +18,7 @@ func ReadArray(ctx context.Context, caller *MultiCaller, block rpcblock.Block, c
 	if err != nil {
 		return nil, fmt.Errorf("failed to load array length: %w", err)
 	}
-	count := result.GetBigInt(0).Uint64()
+	count := bigs.Uint64Strict(result.GetBigInt(0))
 	calls := make([]Call, count)
 	for i := uint64(0); i < count; i++ {
 		calls[i] = getCall(new(big.Int).SetUint64(i))

--- a/op-service/sources/batching/arrays.go
+++ b/op-service/sources/batching/arrays.go
@@ -18,7 +18,11 @@ func ReadArray(ctx context.Context, caller *MultiCaller, block rpcblock.Block, c
 	if err != nil {
 		return nil, fmt.Errorf("failed to load array length: %w", err)
 	}
-	count := bigs.Uint64Strict(result.GetBigInt(0))
+	countBig := result.GetBigInt(0)
+	if !countBig.IsUint64() {
+		return nil, fmt.Errorf("array length is not a uint64: %v", countBig)
+	}
+	count := bigs.Uint64Strict(countBig)
 	calls := make([]Call, count)
 	for i := uint64(0); i < count; i++ {
 		calls[i] = getCall(new(big.Int).SetUint64(i))

--- a/op-service/sources/eth_client_test.go
+++ b/op-service/sources/eth_client_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/sources/caching"
@@ -90,7 +91,7 @@ func randHeader() (*types.Header, *RPCHeader) {
 		ReceiptHash: hdr.ReceiptHash,
 		Bloom:       eth.Bytes256(hdr.Bloom),
 		Difficulty:  *(*hexutil.Big)(hdr.Difficulty),
-		Number:      hexutil.Uint64(hdr.Number.Uint64()),
+		Number:      hexutil.Uint64(bigs.Uint64Strict(hdr.Number)),
 		GasLimit:    hexutil.Uint64(hdr.GasLimit),
 		GasUsed:     hexutil.Uint64(hdr.GasUsed),
 		Time:        hexutil.Uint64(hdr.Time),

--- a/op-service/sources/receipts.go
+++ b/op-service/sources/receipts.go
@@ -3,7 +3,9 @@ package sources
 import (
 	"context"
 	"fmt"
+	"math/big"
 
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -43,7 +45,7 @@ func validateReceipts(block eth.BlockID, receiptHash common.Hash, txHashes []com
 		if r.BlockNumber == nil {
 			return fmt.Errorf("receipt %d has unexpected nil block number, expected %d", i, block.Number)
 		}
-		if r.BlockNumber.Uint64() != block.Number {
+		if !bigs.Equal(r.BlockNumber, new(big.Int).SetUint64(block.Number)) {
 			return fmt.Errorf("receipt %d has unexpected block number %d, expected %d", i, r.BlockNumber, block.Number)
 		}
 		if r.BlockHash != block.Hash {

--- a/op-service/sources/types_test.go
+++ b/op-service/sources/types_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -117,7 +118,7 @@ func TestBlockToExecutionPayloadIncludesEcotoneProperties(t *testing.T) {
 		ReceiptHash:      hdr.ReceiptHash,
 		Bloom:            eth.Bytes256(hdr.Bloom),
 		Difficulty:       *(*hexutil.Big)(hdr.Difficulty),
-		Number:           hexutil.Uint64(hdr.Number.Uint64()),
+		Number:           hexutil.Uint64(bigs.Uint64Strict(hdr.Number)),
 		GasLimit:         hexutil.Uint64(hdr.GasLimit),
 		GasUsed:          hexutil.Uint64(hdr.GasUsed),
 		Time:             hexutil.Uint64(hdr.Time),

--- a/op-service/superutil/chain_config_test.go
+++ b/op-service/superutil/chain_config_test.go
@@ -3,6 +3,7 @@ package superutil
 import (
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/stretchr/testify/require"
 )
 
@@ -11,7 +12,7 @@ func TestLoadOPStackChainConfigFromChainID(t *testing.T) {
 		chainID := uint64(10)
 		cfg, err := LoadOPStackChainConfigFromChainID(chainID)
 		require.NoError(t, err)
-		require.Equal(t, chainID, cfg.ChainID.Uint64())
+		require.Equal(t, chainID, bigs.Uint64Strict(cfg.ChainID))
 	})
 
 	t.Run("nonexistent chain", func(t *testing.T) {

--- a/op-service/txinclude/txbudget_test.go
+++ b/op-service/txinclude/txbudget_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-service/accounting"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -104,7 +105,7 @@ func TestTxBudgetIncluded(t *testing.T) {
 
 	receipt := &types.Receipt{
 		EffectiveGasPrice: eth.WeiU64(1).ToBig(),
-		GasUsed:           budgetedCost.ToBig().Uint64(),
+		GasUsed:           bigs.Uint64Strict(budgetedCost.ToBig()),
 		Type:              types.DynamicFeeTxType,
 
 		L1GasPrice:          big.NewInt(1),

--- a/op-service/txintent/bindings/DisputeGameFactory.go
+++ b/op-service/txintent/bindings/DisputeGameFactory.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"math/big"
 
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -69,7 +70,7 @@ func (d *DisputeGameFactory) ParseDisputeGameCreated(log *types.Log) (*DisputeGa
 	}
 	parsed := &DisputeGameCreated{
 		DisputeProxy: common.HexToAddress(log.Topics[1].Hex()),
-		GameType:     uint32(log.Topics[2].Big().Uint64()),
+		GameType:     uint32(bigs.Uint64Strict(log.Topics[2].Big())),
 		RootClaim:    log.Topics[3],
 	}
 

--- a/op-service/txintent/contractio/call.go
+++ b/op-service/txintent/contractio/call.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
 	"github.com/ethereum-optimism/optimism/op-service/txintent/bindings"
@@ -62,7 +63,7 @@ func ReadArray[T any](ctx context.Context, caller *batching.MultiCaller, countCa
 		return nil, fmt.Errorf("error reading array size: %w", err)
 	}
 
-	count := countResult.Uint64()
+	count := bigs.Uint64Strict(countResult)
 	calls := make([]batching.Call, count)
 	for i := uint64(0); i < count; i++ {
 		typedCall := elemCall(new(big.Int).SetUint64(i))

--- a/op-service/txmgr/metrics/tx_metrics.go
+++ b/op-service/txmgr/metrics/tx_metrics.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
 
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -158,7 +159,7 @@ func (t *TxMetrics) RecordPendingTx(pending int64) {
 
 // TxConfirmed records lots of information about the confirmed transaction
 func (t *TxMetrics) TxConfirmed(receipt *types.Receipt) {
-	fee := float64(receipt.EffectiveGasPrice.Uint64() * receipt.GasUsed / params.GWei)
+	fee := float64(bigs.Uint64Strict(receipt.EffectiveGasPrice) * receipt.GasUsed / params.GWei)
 	t.confirmEvent.Record(receiptStatusString(receipt))
 	t.txL1GasFee.Set(fee)
 	t.txFeesTotal.Add(fee)

--- a/op-service/txmgr/txmgr.go
+++ b/op-service/txmgr/txmgr.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/holiman/uint256"
 
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/retry"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr/metrics"
@@ -864,7 +865,7 @@ func (m *SimpleTxManager) queryReceipt(ctx context.Context, txHash common.Hash, 
 	// Receipt is confirmed to be valid from this point on
 	sendState.TxMined(txHash)
 
-	txHeight := receipt.BlockNumber.Uint64()
+	txHeight := bigs.Uint64Strict(receipt.BlockNumber)
 	tip, err := m.backend.HeaderByNumber(ctx, nil)
 	if err != nil {
 		m.metr.RPCError()
@@ -892,7 +893,7 @@ func (m *SimpleTxManager) queryReceipt(ctx context.Context, txHash common.Hash, 
 	// transaction should be confirmed when txHeight is equal to
 	// tipHeight. The equation is rewritten in this form to avoid
 	// underflows.
-	tipHeight := tip.Number.Uint64()
+	tipHeight := bigs.Uint64Strict(tip.Number)
 	if txHeight+m.cfg.NumConfirmations <= tipHeight+1 {
 		m.l.Info("Transaction confirmed", "tx", txHash,
 			"block", eth.ReceiptBlockID(receipt),

--- a/op-service/txmgr/txmgr_test.go
+++ b/op-service/txmgr/txmgr_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr/metrics"
@@ -276,7 +277,7 @@ func (b *mockBackend) EstimateGas(ctx context.Context, msg ethereum.CallMsg) (ui
 	if msg.GasFeeCap.Cmp(msg.GasTipCap) < 0 {
 		return 0, core.ErrTipAboveFeeCap
 	}
-	return b.g.baseFee().Uint64(), nil
+	return bigs.Uint64Strict(b.g.baseFee()), nil
 }
 
 func (b *mockBackend) SuggestGasTipCap(ctx context.Context) (*big.Int, error) {
@@ -320,11 +321,11 @@ func (b *mockBackend) TransactionReceipt(ctx context.Context, txHash common.Hash
 	// we can assert the proper tx confirmed in our tests.
 	var blobFeeCap uint64
 	if txInfo.blobFeeCap != nil {
-		blobFeeCap = txInfo.blobFeeCap.Uint64()
+		blobFeeCap = bigs.Uint64Strict(txInfo.blobFeeCap)
 	}
 	return &types.Receipt{
 		TxHash:            txHash,
-		GasUsed:           txInfo.gasFeeCap.Uint64(),
+		GasUsed:           bigs.Uint64Strict(txInfo.gasFeeCap),
 		CumulativeGasUsed: blobFeeCap,
 		BlockNumber:       big.NewInt(int64(txInfo.blockNumber)),
 	}, nil
@@ -387,7 +388,7 @@ func TestTxMgrConfirmAtMinGasPrice(t *testing.T) {
 	receipt, err := h.mgr.sendTx(ctx, tx)
 	require.Nil(t, err)
 	require.NotNil(t, receipt)
-	require.Equal(t, gasPricer.expGasFeeCap().Uint64(), receipt.GasUsed)
+	require.Equal(t, bigs.Uint64Strict(gasPricer.expGasFeeCap()), receipt.GasUsed)
 }
 
 // TestTxMgrNeverConfirmCancel asserts that a Send can be canceled even if no
@@ -491,7 +492,7 @@ func TestTxMgrConfirmsAtHigherGasPrice(t *testing.T) {
 	receipt, err := h.mgr.sendTx(ctx, tx)
 	require.Nil(t, err)
 	require.NotNil(t, receipt)
-	require.Equal(t, h.gasPricer.expGasFeeCap().Uint64(), receipt.GasUsed)
+	require.Equal(t, bigs.Uint64Strict(h.gasPricer.expGasFeeCap()), receipt.GasUsed)
 }
 
 // TestTxMgrConfirmsBlobTxAtHigherGasPrice asserts that Send properly returns the max gas price
@@ -526,8 +527,8 @@ func TestTxMgrConfirmsBlobTxAtHigherGasPrice(t *testing.T) {
 	require.NotNil(t, receipt)
 	// the fee cap for the blob tx at epoch == 3 should end up higher than the min required gas
 	// (expFeeCap()) since blob tx fee caps are bumped 100% with each epoch.
-	require.Less(t, h.gasPricer.expGasFeeCap().Uint64(), receipt.GasUsed)
-	require.Equal(t, h.gasPricer.expBlobFeeCap().Uint64(), receipt.CumulativeGasUsed)
+	require.Less(t, bigs.Uint64Strict(h.gasPricer.expGasFeeCap()), receipt.GasUsed)
+	require.Equal(t, bigs.Uint64Strict(h.gasPricer.expBlobFeeCap()), receipt.CumulativeGasUsed)
 }
 
 // errRpcFailure is a sentinel error used in testing to fail publications.
@@ -641,7 +642,7 @@ func TestTxMgr_EstimateGas(t *testing.T) {
 	candidate.GasLimit = 0
 
 	// Gas estimate
-	gasEstimate := h.gasPricer.baseBaseFee.Uint64()
+	gasEstimate := bigs.Uint64Strict(h.gasPricer.baseBaseFee)
 
 	// Craft the transaction.
 	tx, err := h.mgr.craftTx(context.Background(), candidate)
@@ -743,7 +744,7 @@ func TestTxMgrOnlyOnePublicationSucceeds(t *testing.T) {
 	require.Nil(t, err)
 
 	require.NotNil(t, receipt)
-	require.Equal(t, h.gasPricer.expGasFeeCap().Uint64(), receipt.GasUsed)
+	require.Equal(t, bigs.Uint64Strict(h.gasPricer.expGasFeeCap()), receipt.GasUsed)
 }
 
 // TestTxMgrRebroadcastsWithoutGasPriceIncrease tests that the tx manager will rebroadcast a transaction
@@ -820,7 +821,7 @@ func TestTxMgrConfirmsMinGasPriceAfterBumping(t *testing.T) {
 	receipt, err := h.mgr.sendTx(ctx, tx)
 	require.Nil(t, err)
 	require.NotNil(t, receipt)
-	require.Equal(t, h.gasPricer.expGasFeeCap().Uint64(), receipt.GasUsed)
+	require.Equal(t, bigs.Uint64Strict(h.gasPricer.expGasFeeCap()), receipt.GasUsed)
 }
 
 // TestTxMgrRetriesUnbumpableTx tests that a tx whose fees cannot be bumped will still be
@@ -906,7 +907,7 @@ func TestTxMgrDoesntAbortNonceTooLowAfterMiningTx(t *testing.T) {
 	receipt, err := h.mgr.sendTx(ctx, tx)
 	require.Nil(t, err)
 	require.NotNil(t, receipt)
-	require.Equal(t, h.gasPricer.expGasFeeCap().Uint64(), receipt.GasUsed)
+	require.Equal(t, bigs.Uint64Strict(h.gasPricer.expGasFeeCap()), receipt.GasUsed)
 }
 
 // TestWaitMinedReturnsReceiptOnFirstSuccess insta-mines a transaction and
@@ -1062,7 +1063,7 @@ func (b *failingBackend) SuggestGasTipCap(_ context.Context) (*big.Int, error) {
 }
 
 func (b *failingBackend) EstimateGas(ctx context.Context, msg ethereum.CallMsg) (uint64, error) {
-	return b.baseFee.Uint64(), nil
+	return bigs.Uint64Strict(b.baseFee), nil
 }
 
 func (b *failingBackend) NonceAt(_ context.Context, _ common.Address, _ *big.Int) (uint64, error) {

--- a/op-test-sequencer/sequencer/backend/work/builders/fakepos/job.go
+++ b/op-test-sequencer/sequencer/backend/work/builders/fakepos/job.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	opeth "github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
@@ -82,14 +83,14 @@ func (j *Job) setHeadSafeAndFinalized() {
 		j.safe = j.finalized
 	}
 
-	if j.head.Number.Uint64() > j.b.finalizedDistance { // progress finalized block, if we can
-		j.finalized, err = j.b.blockchain.HeaderByNumber(context.Background(), new(big.Int).SetUint64(j.head.Number.Uint64()-j.b.finalizedDistance))
+	if bigs.Uint64Strict(j.head.Number) > j.b.finalizedDistance { // progress finalized block, if we can
+		j.finalized, err = j.b.blockchain.HeaderByNumber(context.Background(), new(big.Int).SetUint64(bigs.Uint64Strict(j.head.Number)-j.b.finalizedDistance))
 		if err != nil {
 			panic("no block found finalizedDistance behind head")
 		}
 	}
-	if j.head.Number.Uint64() > j.b.safeDistance { // progress safe block, if we can
-		j.safe, err = j.b.blockchain.HeaderByNumber(context.Background(), new(big.Int).SetUint64(j.head.Number.Uint64()-j.b.safeDistance))
+	if bigs.Uint64Strict(j.head.Number) > j.b.safeDistance { // progress safe block, if we can
+		j.safe, err = j.b.blockchain.HeaderByNumber(context.Background(), new(big.Int).SetUint64(bigs.Uint64Strict(j.head.Number)-j.b.safeDistance))
 		if err != nil {
 			panic("no block found safeDistance behind head")
 		}
@@ -147,7 +148,7 @@ func (j *Job) Open(ctx context.Context) error {
 
 		j.b.envelopes[envelope.ExecutionPayload.ParentHash] = envelope
 	} else {
-		j.logger.Warn("already had a block with that parent", "parent", j.head.Hash(), "number", j.head.Number.Uint64(), "fee_recipient", envelope.ExecutionPayload.FeeRecipient)
+		j.logger.Warn("already had a block with that parent", "parent", j.head.Hash(), "number", bigs.Uint64Strict(j.head.Number), "fee_recipient", envelope.ExecutionPayload.FeeRecipient)
 
 		j.logger.Warn("updating block hash", "pre", envelope.ExecutionPayload.BlockHash, "fee_recipient", envelope.ExecutionPayload.FeeRecipient, "txs", len(envelope.ExecutionPayload.Transactions))
 

--- a/op-test-sequencer/sequencer/backend/work/builders/fakepos/job.go
+++ b/op-test-sequencer/sequencer/backend/work/builders/fakepos/job.go
@@ -148,7 +148,7 @@ func (j *Job) Open(ctx context.Context) error {
 
 		j.b.envelopes[envelope.ExecutionPayload.ParentHash] = envelope
 	} else {
-		j.logger.Warn("already had a block with that parent", "parent", j.head.Hash(), "number", bigs.Uint64Strict(j.head.Number), "fee_recipient", envelope.ExecutionPayload.FeeRecipient)
+		j.logger.Warn("already had a block with that parent", "parent", j.head.Hash(), "number", j.head.Number, "fee_recipient", envelope.ExecutionPayload.FeeRecipient)
 
 		j.logger.Warn("updating block hash", "pre", envelope.ExecutionPayload.BlockHash, "fee_recipient", envelope.ExecutionPayload.FeeRecipient, "txs", len(envelope.ExecutionPayload.Transactions))
 

--- a/op-validator/pkg/validations/validations.go
+++ b/op-validator/pkg/validations/validations.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/standard"
 
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -93,7 +94,7 @@ func (v *BaseValidator) Validate(ctx context.Context, input BaseValidatorInput) 
 			return nil, fmt.Errorf("failed to get chain ID: %w", err)
 		}
 
-		addr, err := ValidatorAddress(l1ChainID.Uint64(), v.release)
+		addr, err := ValidatorAddress(bigs.Uint64Strict(l1ChainID), v.release)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get validator address: %w", err)
 		}
@@ -144,7 +145,7 @@ func (v *OPCMStandardValidator) Validate(ctx context.Context, input BaseValidato
 			return nil, fmt.Errorf("failed to get chain ID: %w", err)
 		}
 
-		addr, err := ValidatorAddress(l1ChainID.Uint64(), v.release)
+		addr, err := ValidatorAddress(bigs.Uint64Strict(l1ChainID), v.release)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get validator address: %w", err)
 		}

--- a/op-wheel/cheat/cheat.go
+++ b/op-wheel/cheat/cheat.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/trie"
 
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
@@ -87,7 +88,7 @@ type HeadFn func(header *types.Header, headState *state.StateDB) error
 // (unless it ever re-applies the block).
 func (ch *Cheater) RunAndClose(fn HeadFn) error {
 	preHeader := ch.Blockchain.CurrentBlock()
-	if a, b := preHeader.Number.Uint64(), ch.Blockchain.Genesis().NumberU64(); a <= b {
+	if a, b := bigs.Uint64Strict(preHeader.Number), ch.Blockchain.Genesis().NumberU64(); a <= b {
 		return fmt.Errorf("cheating at genesis (head block %d <= genesis block %d) is not supported", a, b)
 	}
 	state, err := ch.Blockchain.StateAt(preHeader.Root)
@@ -105,7 +106,7 @@ func (ch *Cheater) RunAndClose(fn HeadFn) error {
 
 	isCancun := ch.Blockchain.Config().IsCancun(preHeader.Number, preHeader.Time)
 	// commit the changes, and then update the state-root
-	stateRoot, err := state.Commit(preHeader.Number.Uint64()+1, true, isCancun)
+	stateRoot, err := state.Commit(bigs.Uint64Strict(preHeader.Number)+1, true, isCancun)
 	if err != nil {
 		_ = ch.Close()
 		return fmt.Errorf("failed to commit state change: %w", err)
@@ -122,7 +123,7 @@ func (ch *Cheater) RunAndClose(fn HeadFn) error {
 	// based on core.BlockChain.writeHeadBlock:
 	// Add the block to the canonical chain number scheme and mark as the head
 	batch := ch.DB.NewBatch()
-	preID := eth.BlockID{Hash: preHeader.Hash(), Number: preHeader.Number.Uint64()}
+	preID := eth.BlockID{Hash: preHeader.Hash(), Number: bigs.Uint64Strict(preHeader.Number)}
 	if ch.Blockchain.CurrentFinalBlock().Hash() == preID.Hash {
 		rawdb.WriteFinalizedBlockHash(batch, blockHash)
 	}
@@ -323,7 +324,7 @@ func StoragePatch(patch io.Reader, address common.Address) HeadFn {
 			i += 1
 			if i%1000 == 0 { // for every 1000 values, commit to disk
 				// warning: if the account is empty, the storage change will not persist.
-				if _, err := headState.Commit(head.Number.Uint64(), true, false); err != nil {
+				if _, err := headState.Commit(bigs.Uint64Strict(head.Number), true, false); err != nil {
 					return fmt.Errorf("failed to commit state to disk after patching %d entries: %w", i, err)
 				}
 			}

--- a/op-wheel/commands.go
+++ b/op-wheel/commands.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	opservice "github.com/ethereum-optimism/optimism/op-service"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/client"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
@@ -436,7 +437,7 @@ var (
 			bigFlag("nonce", "New nonce of the account"),
 		},
 		Action: CheatAction(false, func(ctx *cli.Context, ch *cheat.Cheater) error {
-			return ch.RunAndClose(cheat.SetNonce(addrFlagValue("address", ctx), bigFlagValue("balance", ctx).Uint64()))
+			return ch.RunAndClose(cheat.SetNonce(addrFlagValue("address", ctx), bigs.Uint64Strict(bigFlagValue("balance", ctx))))
 		}),
 	}
 	CheatPrintHeadBlock = &cli.Command{

--- a/op-wheel/engine/engine.go
+++ b/op-wheel/engine/engine.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/holiman/uint256"
 
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
@@ -258,7 +259,7 @@ func Auto(
 							log.Error("failed to find block for new safe block progress", "err", err)
 							continue
 						}
-						status.Safe = eth.L1BlockRef{Hash: safe.Hash(), Number: safe.Number.Uint64(), Time: safe.Time, ParentHash: safe.ParentHash}
+						status.Safe = eth.L1BlockRef{Hash: safe.Hash(), Number: bigs.Uint64Strict(safe.Number), Time: safe.Time, ParentHash: safe.ParentHash}
 					}
 					if status.Finalized.Number+32 <= status.Safe.Number {
 						finalized, err := getHeader(ctx, client.RPC, methodEthGetBlockByNumber, hexutil.Uint64(status.Safe.Number-32).String())
@@ -267,7 +268,7 @@ func Auto(
 							log.Error("failed to find block for new finalized block progress", "err", err)
 							continue
 						}
-						status.Finalized = eth.L1BlockRef{Hash: finalized.Hash(), Number: finalized.Number.Uint64(), Time: finalized.Time, ParentHash: finalized.ParentHash}
+						status.Finalized = eth.L1BlockRef{Hash: finalized.Hash(), Number: bigs.Uint64Strict(finalized.Number), Time: finalized.Time, ParentHash: finalized.ParentHash}
 					}
 				}
 
@@ -316,8 +317,8 @@ func Status(ctx context.Context, client client.RPC) (*StatusData, error) {
 	}
 	return &StatusData{
 		Head:      eth.L1BlockRef{Hash: head.Hash(), Number: head.NumberU64(), Time: head.Time(), ParentHash: head.ParentHash()},
-		Safe:      eth.L1BlockRef{Hash: safe.Hash(), Number: safe.Number.Uint64(), Time: safe.Time, ParentHash: safe.ParentHash},
-		Finalized: eth.L1BlockRef{Hash: finalized.Hash(), Number: finalized.Number.Uint64(), Time: finalized.Time, ParentHash: finalized.ParentHash},
+		Safe:      eth.L1BlockRef{Hash: safe.Hash(), Number: bigs.Uint64Strict(safe.Number), Time: safe.Time, ParentHash: safe.ParentHash},
+		Finalized: eth.L1BlockRef{Hash: finalized.Hash(), Number: bigs.Uint64Strict(finalized.Number), Time: finalized.Time, ParentHash: finalized.ParentHash},
 		Txs:       uint64(len(head.Transactions())),
 		Gas:       head.GasUsed(),
 		StateRoot: head.Root(),
@@ -386,8 +387,8 @@ func SetForkchoice(ctx context.Context, client *sources.EngineAPIClient, finaliz
 	if err != nil {
 		return fmt.Errorf("failed to get latest block: %w", err)
 	}
-	if unsafeNum > head.Number.Uint64() {
-		return fmt.Errorf("cannot set unsafe (%d) > latest (%d)", unsafeNum, head.Number.Uint64())
+	if unsafeNum > bigs.Uint64Strict(head.Number) {
+		return fmt.Errorf("cannot set unsafe (%d) > latest (%d)", unsafeNum, bigs.Uint64Strict(head.Number))
 	}
 	finalizedHeader, err := getHeader(ctx, client.RPC, methodEthGetBlockByNumber, hexutil.Uint64(finalizedNum).String())
 	if err != nil {
@@ -424,10 +425,10 @@ func Rewind(ctx context.Context, lgr log.Logger, client *sources.EngineAPIClient
 
 	// when rewinding, don't increase unsafe/finalized tags
 	toSafe, toFinalized := toUnsafe, toUnsafe
-	if safe != nil && safe.Number.Uint64() < to {
+	if safe != nil && bigs.Uint64Strict(safe.Number) < to {
 		toSafe = eth.HeaderBlockID(safe)
 	}
-	if finalized != nil && finalized.Number.Uint64() < to {
+	if finalized != nil && bigs.Uint64Strict(finalized.Number) < to {
 		toFinalized = eth.HeaderBlockID(finalized)
 	}
 

--- a/packages/contracts-bedrock/scripts/go-ffi/utils.go
+++ b/packages/contracts-bedrock/scripts/go-ffi/utils.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/bindings"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 )
@@ -177,7 +178,7 @@ func makeDepositTx(
 	// Create deposit transaction source
 	udp := derive.UserDepositSource{
 		L1BlockHash: l1BlockHash,
-		LogIndex:    logIndex.Uint64(),
+		LogIndex:    bigs.Uint64Strict(logIndex),
 	}
 
 	// Create deposit transaction
@@ -185,7 +186,7 @@ func makeDepositTx(
 		SourceHash:          udp.SourceHash(),
 		From:                from,
 		Value:               value,
-		Gas:                 gasLimit.Uint64(),
+		Gas:                 bigs.Uint64Strict(gasLimit),
 		IsSystemTransaction: false, // This will never be a system transaction in the tests.
 		Data:                data,
 	}


### PR DESCRIPTION
**Description**

Stop ignoring the lint check for calls to `Uint64()` and fix the remaining violations.
