### PR TITLE
devstack: Introduce supernode abstraction for proofs DSL

### DIFF
--- a/op-devstack/dsl/proofs/dispute_game_factory.go
+++ b/op-devstack/dsl/proofs/dispute_game_factory.go
@@ -43,7 +43,7 @@ type DisputeGameFactory struct {
 	addr          common.Address
 	l2CL          *dsl.L2CLNode
 	l2EL          *dsl.L2ELNode
-	supervisor    *dsl.Supervisor
+	superRoots    SuperRootsSource
 	gameHelper    *GameHelper
 	challengerCfg *challengerConfig.Config
 
@@ -57,7 +57,7 @@ func NewDisputeGameFactory(
 	dgfAddr common.Address,
 	l2CL *dsl.L2CLNode,
 	l2EL *dsl.L2ELNode,
-	supervisor *dsl.Supervisor,
+	superRoots SuperRootsSource,
 	challengerCfg *challengerConfig.Config,
 ) *DisputeGameFactory {
 	dgf := bindings.NewDisputeGameFactory(bindings.WithClient(ethClient), bindings.WithTo(dgfAddr), bindings.WithTest(t))
@@ -71,7 +71,7 @@ func NewDisputeGameFactory(
 		addr:          dgfAddr,
 		l2CL:          l2CL,
 		l2EL:          l2EL,
-		supervisor:    supervisor,
+		superRoots:    superRoots,
 		ethClient:     ethClient,
 		challengerCfg: challengerCfg,
 
@@ -185,7 +185,7 @@ func (f *DisputeGameFactory) WaitForGame() *FaultDisputeGame {
 }
 
 func (f *DisputeGameFactory) StartSuperCannonGame(eoa *dsl.EOA, opts ...GameOpt) *SuperFaultDisputeGame {
-	f.require.NotNil(f.supervisor, "supervisor is required to start super games")
+	f.require.NotNil(f.superRoots, "super roots source is required to start super games")
 
 	return f.startSuperCannonGameOfType(eoa, gameTypes.SuperCannonGameType, opts...)
 }
@@ -198,7 +198,7 @@ func (f *DisputeGameFactory) startSuperCannonGameOfType(eoa *dsl.EOA, gameType g
 	}
 	timestamp := cfg.l2SequenceNumber
 	if !cfg.l2SequenceNumberSet {
-		timestamp = f.supervisor.FetchSyncStatus().SafeTimestamp
+		timestamp = f.superRoots.SafeTimestamp()
 	}
 	extraData := f.createSuperGameExtraData(timestamp, cfg)
 	rootClaim := cfg.rootClaim
@@ -211,15 +211,11 @@ func (f *DisputeGameFactory) startSuperCannonGameOfType(eoa *dsl.EOA, gameType g
 }
 
 func (f *DisputeGameFactory) createSuperGameExtraData(timestamp uint64, cfg *GameCfg) []byte {
-	f.require.NotNil(f.supervisor, "supervisor is required create super games")
+	f.require.NotNil(f.superRoots, "super roots is required create super games")
 	if !cfg.allowFuture {
-		f.supervisor.AwaitMinCrossSafeTimestamp(timestamp)
+		f.superRoots.AwaitMinVerifiedTimestamp(timestamp)
 	}
-	super, err := f.supervisor.FetchSuperRootAtTimestamp(timestamp).ToSuper()
-	f.require.NoError(err, "Failed to fetch super root for timestamp %v", timestamp)
-
-	superV1, ok := super.(*eth.SuperV1)
-	f.require.Truef(ok, "Unsupported super type %T", super)
+	superV1 := f.superRoots.SuperV1AtTimestamp(timestamp)
 	if len(cfg.superOutputRoots) != 0 {
 		f.require.Len(cfg.superOutputRoots, len(superV1.Chains), "Super output roots length mismatch")
 		for i := range superV1.Chains {

--- a/op-devstack/dsl/proofs/super_roots_source.go
+++ b/op-devstack/dsl/proofs/super_roots_source.go
@@ -1,0 +1,90 @@
+package proofs
+
+import (
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/stretchr/testify/require"
+)
+
+// SuperRootsSource is a minimal abstraction for "super-roots" needed by the proofs DSL.
+// It can be backed by either an op-supervisor (legacy) or an op-supernode (replacement).
+type SuperRootsSource interface {
+	// SafeTimestamp retrieves the current safe timestamp from the source
+	SafeTimestamp() uint64
+	// AwaitMinVerifiedTimestamp blocks until the source has verified at least up to the given timestamp
+	AwaitMinVerifiedTimestamp(timestamp uint64)
+	// SuperV1AtTimestamp retrieves the super root at the given timestamp
+	SuperV1AtTimestamp(timestamp uint64) *eth.SuperV1
+}
+
+func NewSuperRootsFromSupervisor(supervisor *dsl.Supervisor) SuperRootsSource {
+	return &supervisorSuperRootsSource{supervisor: supervisor}
+}
+
+func NewSuperRootsFromSupernode(t devtest.T, supernode stack.Supernode) SuperRootsSource {
+	return &supernodeSuperRootsSource{
+		t:         t,
+		require:   require.New(t),
+		supernode: supernode,
+	}
+}
+
+type supervisorSuperRootsSource struct {
+	supervisor *dsl.Supervisor
+}
+
+func (s *supervisorSuperRootsSource) SafeTimestamp() uint64 {
+	return s.supervisor.FetchSyncStatus().SafeTimestamp
+}
+
+func (s *supervisorSuperRootsSource) AwaitMinVerifiedTimestamp(timestamp uint64) {
+	s.supervisor.AwaitMinCrossSafeTimestamp(timestamp)
+}
+
+func (s *supervisorSuperRootsSource) SuperV1AtTimestamp(timestamp uint64) *eth.SuperV1 {
+	super, err := s.supervisor.FetchSuperRootAtTimestamp(timestamp).ToSuper()
+	s.supervisor.Escape().T().Require().NoError(err, "Failed to parse super root at timestamp %v", timestamp)
+	superV1, ok := super.(*eth.SuperV1)
+	s.supervisor.Escape().T().Require().Truef(ok, "Unsupported super type %T", super)
+	return superV1
+}
+
+type supernodeSuperRootsSource struct {
+	t         devtest.T
+	require   *require.Assertions
+	supernode stack.Supernode
+}
+
+func (s *supernodeSuperRootsSource) SafeTimestamp() uint64 {
+	s.t.Error("not yet implemented: supernodeSuperRootsSource.SafeTimestamp")
+	s.t.FailNow()
+	return 0
+}
+
+func (s *supernodeSuperRootsSource) AwaitMinVerifiedTimestamp(timestamp uint64) {
+	s.t.Require().Eventually(func() bool {
+		resp, err := s.supernode.QueryAPI().SuperRootAtTimestamp(s.t.Ctx(), timestamp)
+		s.require.NoError(err, "Failed to fetch supernode status (superroot_atTimestamp)")
+		return resp.Data != nil
+	}, 2*time.Minute, 1*time.Second)
+}
+
+func (s *supernodeSuperRootsSource) SuperV1AtTimestamp(timestamp uint64) *eth.SuperV1 {
+	var resp eth.SuperRootAtTimestampResponse
+	s.t.Require().Eventually(func() bool {
+		r, err := s.supernode.QueryAPI().SuperRootAtTimestamp(s.t.Ctx(), timestamp)
+		if err != nil {
+			return false
+		}
+		resp = r
+		return resp.Data != nil
+	}, 2*time.Minute, 1*time.Second)
+	s.require.NotNil(resp.Data, "Super root data must be present at timestamp %v", timestamp)
+	superV1, ok := resp.Data.Super.(*eth.SuperV1)
+	s.require.Truef(ok, "Unsupported super type %T", resp.Data.Super)
+	return superV1
+}

--- a/op-devstack/presets/interop.go
+++ b/op-devstack/presets/interop.go
@@ -114,7 +114,7 @@ func (s *SimpleInterop) L2Networks() []*dsl.L2Network {
 }
 
 func (s *SimpleInterop) DisputeGameFactory() *proofs.DisputeGameFactory {
-	return proofs.NewDisputeGameFactory(s.T, s.L1Network, s.L1EL.EthClient(), s.L2ChainA.DisputeGameFactoryProxyAddr(), nil, nil, s.Supervisor, nil)
+	return proofs.NewDisputeGameFactory(s.T, s.L1Network, s.L1EL.EthClient(), s.L2ChainA.DisputeGameFactoryProxyAddr(), nil, nil, proofs.NewSuperRootsFromSupervisor(s.Supervisor), nil)
 }
 
 func (s *SingleChainInterop) StandardBridge(l2Chain *dsl.L2Network) *dsl.StandardBridge {

--- a/op-devstack/stack/matcher.go
+++ b/op-devstack/stack/matcher.go
@@ -51,6 +51,8 @@ type L2CLMatcher = Matcher[L2CLNodeID, L2CLNode]
 
 type SupervisorMatcher = Matcher[SupervisorID, Supervisor]
 
+type SupernodeMatcher = Matcher[SupernodeID, Supernode]
+
 type TestSequencerMatcher = Matcher[TestSequencerID, TestSequencer]
 
 type ConductorMatcher = Matcher[ConductorID, Conductor]

--- a/op-devstack/stack/supernode.go
+++ b/op-devstack/stack/supernode.go
@@ -1,0 +1,54 @@
+package stack
+
+import (
+	"log/slog"
+
+	"github.com/ethereum-optimism/optimism/op-service/apis"
+)
+
+// SupernodeID identifies a Supernode by name, is type-safe, and can be value-copied and used as map key.
+type SupernodeID genericID
+
+var _ GenericID = (*SupernodeID)(nil)
+
+const SupernodeKind Kind = "Supernode"
+
+func (id SupernodeID) String() string {
+	return genericID(id).string(SupernodeKind)
+}
+
+func (id SupernodeID) Kind() Kind {
+	return SupernodeKind
+}
+
+func (id SupernodeID) LogValue() slog.Value {
+	return slog.StringValue(id.String())
+}
+
+func (id SupernodeID) MarshalText() ([]byte, error) {
+	return genericID(id).marshalText(SupernodeKind)
+}
+
+func (id *SupernodeID) UnmarshalText(data []byte) error {
+	return (*genericID)(id).unmarshalText(SupernodeKind, data)
+}
+
+func SortSupernodeIDs(ids []SupernodeID) []SupernodeID {
+	return copyAndSortCmp(ids)
+}
+
+func SortSupernodes(elems []Supernode) []Supernode {
+	return copyAndSort(elems, lessElemOrdered[SupernodeID, Supernode])
+}
+
+var _ SupernodeMatcher = SupernodeID("")
+
+func (id SupernodeID) Match(elems []Supernode) []Supernode {
+	return findByID(id, elems)
+}
+
+type Supernode interface {
+	Common
+	ID() SupernodeID
+	QueryAPI() apis.SupernodeQueryAPI
+}

--- a/op-service/apis/supernode.go
+++ b/op-service/apis/supernode.go
@@ -1,0 +1,13 @@
+package apis
+
+import (
+	"context"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+// SupernodeQueryAPI is the minimal API surface the devstack DSL needs from op-supernode.
+// It is intentionally small and can be expanded as needed.
+type SupernodeQueryAPI interface {
+	SuperRootAtTimestamp(ctx context.Context, timestamp uint64) (eth.SuperRootAtTimestampResponse, error)
+}


### PR DESCRIPTION
Adds a `SuperRootsSource` interface that abstracts the source of super-roots in the proofs DSL. This enables the dispute game factory to work with either op-supervisor (legacy) or op-supernode.

part of https://github.com/ethereum-optimism/optimism/issues/18911