### PR TITLE
feat(ci): refactor circleci configs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,13 @@ parameters:
   ai_contracts_test_dispatch:
     type: boolean
     default: false
+  kona_dispatch:
+    type: boolean
+    default: false
   op_alloy_dispatch:
+    type: boolean
+    default: false
+  alloy_op_hardforks_dispatch:
     type: boolean
     default: false
   alloy_op_evm_dispatch:
@@ -133,21 +139,31 @@ workflows:
             .* flake-shake-iterations << pipeline.parameters.flake-shake-iterations >> .circleci/continue/main.yml
             .* flake-shake-workers << pipeline.parameters.flake-shake-workers >> .circleci/continue/main.yml
             .* go-cache-version << pipeline.parameters.go-cache-version >> .circleci/continue/main.yml
-            kona/.* kona_dispatch true .circleci/continue/kona.yml
+
+            kona/.* kona_dispatch << pipeline.parameters.kona_dispatch >> .circleci/continue/kona.yml
             kona/.* default_docker_image << pipeline.parameters.default_docker_image >> .circleci/continue/kona.yml
             kona/.* base_image << pipeline.parameters.base_image >> .circleci/continue/kona.yml
             kona/.* go-cache-version << pipeline.parameters.go-cache-version >> .circleci/continue/kona.yml
-            op-alloy/.* op_alloy_dispatch true .circleci/continue/op-alloy.yml
+            kona/.* default_docker_image << pipeline.parameters.default_docker_image >> .circleci/continue/rust-ci.yml
+
+            op-alloy/.* op_alloy_dispatch << pipeline.parameters.op_alloy_dispatch >> .circleci/continue/op-alloy.yml
             op-alloy/.* default_docker_image << pipeline.parameters.default_docker_image >> .circleci/continue/op-alloy.yml
-            alloy-op-hardforks/.* alloy_op_hardforks_dispatch true .circleci/continue/alloy-op-hardforks.yml
+            op-alloy/.* default_docker_image << pipeline.parameters.default_docker_image >> .circleci/continue/rust-ci.yml
+
+            alloy-op-hardforks/.* alloy_op_hardforks_dispatch << pipeline.parameters.alloy_op_hardforks_dispatch >> .circleci/continue/alloy-op-hardforks.yml
             alloy-op-hardforks/.* default_docker_image << pipeline.parameters.default_docker_image >> .circleci/continue/alloy-op-hardforks.yml
-            alloy-op-evm/.* alloy_op_evm_dispatch true .circleci/continue/alloy-op-evm.yml
+            alloy-op-hardforks/.* default_docker_image << pipeline.parameters.default_docker_image >> .circleci/continue/rust-ci.yml
+
+            alloy-op-evm/.* alloy_op_evm_dispatch << pipeline.parameters.alloy_op_evm_dispatch >> .circleci/continue/alloy-op-evm.yml
             alloy-op-evm/.* default_docker_image << pipeline.parameters.default_docker_image >> .circleci/continue/alloy-op-evm.yml
             alloy-op-evm/.* base_image << pipeline.parameters.base_image >> .circleci/continue/alloy-op-evm.yml
-            op-reth/.* op_reth_dispatch true .circleci/continue/op-reth.yml
+            alloy-op-evm/.* default_docker_image << pipeline.parameters.default_docker_image >> .circleci/continue/rust-ci.yml
+
+            op-reth/.* op_reth_dispatch << pipeline.parameters.op_reth_dispatch >> .circleci/continue/op-reth.yml
             op-reth/.* default_docker_image << pipeline.parameters.default_docker_image >> .circleci/continue/op-reth.yml
             op-reth/.* base_image << pipeline.parameters.base_image >> .circleci/continue/op-reth.yml
             op-reth/.* go-cache-version << pipeline.parameters.go-cache-version >> .circleci/continue/op-reth.yml
+            op-reth/.* default_docker_image << pipeline.parameters.default_docker_image >> .circleci/continue/rust-ci.yml
 
   setup-tag:
     when:

--- a/.circleci/continue/alloy-op-evm.yml
+++ b/.circleci/continue/alloy-op-evm.yml
@@ -2,277 +2,15 @@ version: 2.1
 
 # Alloy-op-evm CI Continuation Configuration
 # This file contains ONLY alloy-op-evm-specific jobs and workflows.
-# It is merged with main.yml when alloy-op-evm/** changes are detected.
-# Shared orbs, commands, and jobs come from main.yml during merge.
+# It is merged with main.yml and rust-ci.yml when alloy-op-evm/** changes are detected.
+# Shared orbs, commands, and jobs come from main.yml and rust-ci.yml during merge.
 
-# Orbs used by alloy-op-evm jobs (also in main.yml, merged during continuation)
-orbs:
-  utils: ethereum-optimism/circleci-utils@1.0.23
 
 parameters:
   # Required parameters (also in main.yml, merged during continuation)
-  default_docker_image:
-    type: string
-    default: cimg/base:2024.01
   alloy_op_evm_dispatch:
     type: boolean
     default: false
-
-# ============================================================================
-# ALLOY-OP-EVM JOBS
-# ============================================================================
-jobs:
-  # ============================================================================
-  # Alloy-op-evm Jobs (migrated from alloy-op-evm/.github/workflows/ci.yml)
-  # ============================================================================
-
-  # Alloy-op-evm tests (from ci.yml)
-  alloy-op-evm-cargo-tests:
-    parameters:
-      flags:
-        description: Feature flags for the test
-        type: string
-        default: ""
-    docker:
-      - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: xlarge
-    steps:
-      - utils/checkout-with-mise:
-          checkout-method: blobless
-      - rust-prepare-and-restore-cache: &alloy-op-evm-tests-cache
-          directory: alloy-op-evm
-          prefix: alloy-op-evm-tests
-          profile: "release"
-      - install-cargo-binstall
-      - run:
-          name: Install nextest
-          command: |
-            command -v cargo-nextest >/dev/null || cargo binstall --no-confirm cargo-nextest
-      - run:
-          name: Run cargo tests <<parameters.flags>>
-          working_directory: alloy-op-evm
-          no_output_timeout: 30m
-          command: |
-            cargo nextest run --workspace <<parameters.flags>>
-      - rust-save-build-cache: *alloy-op-evm-tests-cache
-
-  # Alloy-op-evm doc tests (from ci.yml)
-  alloy-op-evm-doctest:
-    docker:
-      - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: xlarge
-    steps:
-      - utils/checkout-with-mise:
-          checkout-method: blobless
-      - rust-prepare-and-restore-cache: &alloy-op-evm-doctest-cache
-          directory: alloy-op-evm
-          prefix: alloy-op-evm-doctest
-      - run:
-          name: Run doc tests
-          working_directory: alloy-op-evm
-          no_output_timeout: 30m
-          command: |
-            cargo test --workspace --doc
-            cargo test --all-features --workspace --doc
-      - rust-save-build-cache: *alloy-op-evm-doctest-cache
-
-  # Alloy-op-evm wasm-unknown build (from ci.yml)
-  alloy-op-evm-wasm-unknown:
-    docker:
-      - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: xlarge
-    steps:
-      - utils/checkout-with-mise:
-          checkout-method: blobless
-      - rust-prepare
-      - rust-install-toolchain:
-          target: wasm32-unknown-unknown
-      - install-cargo-binstall
-      - run:
-          name: Install cargo-hack
-          command: |
-            command -v cargo-hack >/dev/null || cargo binstall --no-confirm cargo-hack
-      - run:
-          name: Build for wasm32-unknown-unknown
-          working_directory: alloy-op-evm
-          no_output_timeout: 30m
-          command: |
-            cargo hack build --workspace --ignore-unknown-features --features ws --target wasm32-unknown-unknown --no-default-features
-
-  # Alloy-op-evm wasm-wasi build (from ci.yml)
-  alloy-op-evm-wasm-wasi:
-    docker:
-      - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: xlarge
-    steps:
-      - utils/checkout-with-mise:
-          checkout-method: blobless
-      - rust-prepare
-      - rust-install-toolchain:
-          target: wasm32-wasip1
-      - install-cargo-binstall
-      - run:
-          name: Install cargo-hack
-          command: |
-            command -v cargo-hack >/dev/null || cargo binstall --no-confirm cargo-hack
-      - run:
-          name: Build for wasm32-wasip1
-          working_directory: alloy-op-evm
-          no_output_timeout: 30m
-          command: |
-            cargo hack build --workspace --target wasm32-wasip1
-
-  # Alloy-op-evm feature checks (from ci.yml)
-  alloy-op-evm-feature-checks:
-    docker:
-      - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: xlarge
-    steps:
-      - utils/checkout-with-mise:
-          checkout-method: blobless
-      - rust-prepare-and-restore-cache: &alloy-op-evm-feature-checks-cache
-          directory: alloy-op-evm
-          prefix: alloy-op-evm-feature-checks
-      - install-cargo-binstall
-      - run:
-          name: Install cargo-hack
-          command: |
-            command -v cargo-hack >/dev/null || cargo binstall --no-confirm cargo-hack
-      - run:
-          name: Check feature powerset
-          working_directory: alloy-op-evm
-          no_output_timeout: 30m
-          command: |
-            cargo hack check --feature-powerset --depth 1
-      - rust-save-build-cache: *alloy-op-evm-feature-checks-cache
-
-  # Alloy-op-evm check no_std (from ci.yml)
-  alloy-op-evm-check-no-std:
-    docker:
-      - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: xlarge
-    steps:
-      - utils/checkout-with-mise:
-          checkout-method: blobless
-      - rust-prepare
-      - rust-install-toolchain:
-          channel: stable
-      - run:
-          name: Check no_std compatibility
-          working_directory: alloy-op-evm
-          no_output_timeout: 30m
-          command: |
-            ./scripts/check_no_std.sh
-
-  # Alloy-op-evm clippy (from ci.yml)
-  alloy-op-evm-clippy:
-    docker:
-      - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: xlarge
-    steps:
-      - utils/checkout-with-mise:
-          checkout-method: blobless
-      - rust-prepare-and-restore-cache: &alloy-op-evm-clippy-cache
-          directory: alloy-op-evm
-          prefix: alloy-op-evm-clippy
-          features: "all"
-      - rust-install-toolchain:
-          channel: nightly
-          components: clippy
-      - run:
-          name: Run clippy
-          working_directory: alloy-op-evm
-          no_output_timeout: 30m
-          environment:
-            RUSTFLAGS: -Dwarnings
-          command: |
-            cargo +nightly clippy --workspace --all-targets --all-features
-      - rust-save-build-cache: *alloy-op-evm-clippy-cache
-
-  # Alloy-op-evm docs build (from ci.yml)
-  alloy-op-evm-docs:
-    docker:
-      - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: xlarge
-    steps:
-      - utils/checkout-with-mise:
-          checkout-method: blobless
-      - rust-prepare-and-restore-cache: &alloy-op-evm-docs-cache
-          directory: alloy-op-evm
-          prefix: alloy-op-evm-docs
-          features: "all"
-      - rust-install-toolchain:
-          channel: nightly
-      - run:
-          name: Build documentation
-          working_directory: alloy-op-evm
-          no_output_timeout: 30m
-          environment:
-            RUSTDOCFLAGS: --cfg docsrs -D warnings --show-type-layout --generate-link-to-definition -Zunstable-options
-          command: |
-            cargo +nightly doc --workspace --all-features --no-deps --document-private-items
-      - rust-save-build-cache: *alloy-op-evm-docs-cache
-
-  # Alloy-op-evm fmt check (from ci.yml)
-  alloy-op-evm-fmt:
-    docker:
-      - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: medium
-    steps:
-      - utils/checkout-with-mise:
-          checkout-method: blobless
-      - rust-prepare
-      - rust-install-toolchain:
-          channel: nightly
-          components: rustfmt
-      - run:
-          name: Check formatting
-          working_directory: alloy-op-evm
-          command: |
-            cargo fmt --all --check
-
-  # Alloy-op-evm deny (from ci.yml)
-  alloy-op-evm-deny:
-    docker:
-      - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: medium
-    steps:
-      - utils/checkout-with-mise:
-          checkout-method: blobless
-      - rust-prepare
-      - install-cargo-binstall
-      - run:
-          name: Install cargo-deny
-          command: |
-            command -v cargo-deny >/dev/null || cargo binstall --no-confirm cargo-deny
-      - run:
-          name: Run cargo deny
-          working_directory: alloy-op-evm
-          command: |
-            cargo deny check
-
-  # Alloy-op-evm zepter (from ci.yml)
-  alloy-op-evm-zepter:
-    docker:
-      - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: medium
-    steps:
-      - utils/checkout-with-mise:
-          checkout-method: blobless
-      - rust-prepare
-      - install-cargo-binstall
-      - run:
-          name: Install zepter
-          command: |
-            command -v zepter >/dev/null || cargo binstall --no-confirm zepter
-            zepter --version
-      - run:
-          name: Check feature propagation
-          working_directory: alloy-op-evm
-          command: |
-            zepter run check
-
-  ### END ALLOY-OP-EVM JOBS ###
 
 # ============================================================================
 # ALLOY-OP-EVM WORKFLOWS
@@ -288,55 +26,93 @@ workflows:
             - equal: [true, <<pipeline.parameters.alloy_op_evm_dispatch>>]
             - equal: ["api", << pipeline.trigger_source >>]
     jobs:
-      # Test jobs with different feature flags
-      - alloy-op-evm-cargo-tests:
+      # Build (shared job from main.yml)
+      - rust-build-binary:
+          name: alloy-op-evm-build
+          directory: alloy-op-evm
           context: &alloy-op-evm-job-context
             - circleci-repo-readonly-authenticated-github-token
+
+      # Test jobs (shared)
+      - rust-ci-cargo-tests:
+          context: *alloy-op-evm-job-context
           name: alloy-op-evm-test-no-default-features
+          directory: alloy-op-evm
           flags: "--no-default-features"
-      - alloy-op-evm-cargo-tests:
+      - rust-ci-cargo-tests:
           context: *alloy-op-evm-job-context
           name: alloy-op-evm-test-default
-          flags: ""
-      - alloy-op-evm-cargo-tests:
+          directory: alloy-op-evm
+      - rust-ci-cargo-tests:
           context: *alloy-op-evm-job-context
           name: alloy-op-evm-test-all-features
+          directory: alloy-op-evm
           flags: "--all-features"
 
-      # Doc tests
-      - alloy-op-evm-doctest:
+      # Doc tests (shared job)
+      - rust-ci-doctest:
+          name: alloy-op-evm-doctest
+          directory: alloy-op-evm
+          command: |
+            cargo test --workspace --doc
+            cargo test --all-features --workspace --doc
           context: *alloy-op-evm-job-context
 
-      # WASM builds
-      - alloy-op-evm-wasm-unknown:
+      # WASM builds (shared job)
+      - rust-ci-cargo-hack-build:
+          name: alloy-op-evm-wasm-unknown
+          directory: alloy-op-evm
+          target: wasm32-unknown-unknown
+          flags: "--workspace --ignore-unknown-features --features ws --no-default-features"
           context: *alloy-op-evm-job-context
-      - alloy-op-evm-wasm-wasi:
-          context: *alloy-op-evm-job-context
-
-      # Feature checks
-      - alloy-op-evm-feature-checks:
-          context: *alloy-op-evm-job-context
-
-      # no_std check
-      - alloy-op-evm-check-no-std:
-          context: *alloy-op-evm-job-context
-
-      # Linting
-      - alloy-op-evm-clippy:
+      - rust-ci-cargo-hack-build:
+          name: alloy-op-evm-wasm-wasi
+          directory: alloy-op-evm
+          target: wasm32-wasip1
           context: *alloy-op-evm-job-context
 
-      # Documentation
-      - alloy-op-evm-docs:
+      # Feature checks (shared job)
+      - rust-ci-cargo-hack:
+          name: alloy-op-evm-feature-checks
+          directory: alloy-op-evm
+          flags: "--feature-powerset --depth 1"
           context: *alloy-op-evm-job-context
 
-      # Formatting
-      - alloy-op-evm-fmt:
+      # no_std check (shared job)
+      - rust-ci-check-no-std:
+          name: alloy-op-evm-check-no-std
+          directory: alloy-op-evm
           context: *alloy-op-evm-job-context
 
-      # Dependencies check
-      - alloy-op-evm-deny:
+      # Linting (shared job)
+      - rust-ci-clippy:
+          name: alloy-op-evm-clippy
+          directory: alloy-op-evm
+          toolchain: nightly
+          command: "cargo +nightly clippy --workspace --all-targets --all-features"
           context: *alloy-op-evm-job-context
 
-      # Feature propagation check
-      - alloy-op-evm-zepter:
+      # Documentation (shared job)
+      - rust-ci-docs:
+          name: alloy-op-evm-docs
+          directory: alloy-op-evm
+          context: *alloy-op-evm-job-context
+
+      # Formatting (shared job)
+      - rust-ci-fmt:
+          name: alloy-op-evm-fmt
+          directory: alloy-op-evm
+          command: "cargo fmt --all --check"
+          context: *alloy-op-evm-job-context
+
+      # Dependencies check (shared job)
+      - rust-ci-deny:
+          name: alloy-op-evm-deny
+          directory: alloy-op-evm
+          context: *alloy-op-evm-job-context
+
+      # Feature propagation check (shared job)
+      - rust-ci-zepter:
+          name: alloy-op-evm-zepter
+          directory: alloy-op-evm
           context: *alloy-op-evm-job-context

--- a/.circleci/continue/alloy-op-hardforks.yml
+++ b/.circleci/continue/alloy-op-hardforks.yml
@@ -2,210 +2,14 @@ version: 2.1
 
 # alloy-op-hardforks CI Continuation Configuration
 # This file contains ONLY alloy-op-hardforks-specific jobs and workflows.
-# It is merged with main.yml when alloy-op-hardforks/** changes are detected.
-# Shared orbs, commands, and jobs come from main.yml during merge.
-
-# Orbs used by alloy-op-hardforks jobs (also in main.yml, merged during continuation)
-orbs:
-  utils: ethereum-optimism/circleci-utils@1.0.23
+# It is merged with main.yml and rust-ci.yml when alloy-op-hardforks/** changes are detected.
+# Shared orbs, commands, and jobs come from main.yml and rust-ci.yml during merge.
 
 parameters:
   # Required parameters (also in main.yml, merged during continuation)
-  default_docker_image:
-    type: string
-    default: cimg/base:2024.01
   alloy_op_hardforks_dispatch:
     type: boolean
     default: false
-
-jobs:
-  # ============================================================================
-  # alloy-op-hardforks Jobs (migrated from alloy-op-hardforks/.github/workflows/ci.yml)
-  # ============================================================================
-
-  # alloy-op-hardforks Rust CI - Tests with matrix (from ci.yml)
-  alloy-op-hardforks-cargo-tests:
-    parameters:
-      rust_version:
-        description: The Rust version to test with (stable, beta, nightly, or MSRV)
-        type: string
-      feature_flags:
-        description: The feature flags to use (empty, --no-default-features, --all-features)
-        type: string
-        default: ""
-    docker:
-      - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: xlarge
-    environment:
-      CARGO_TERM_COLOR: always
-    steps:
-      - utils/checkout-with-mise:
-          checkout-method: blobless
-      - rust-prepare-and-restore-cache:
-          directory: alloy-op-hardforks
-          prefix: alloy-op-hardforks-tests-<<parameters.rust_version>>
-      - rust-install-toolchain:
-          toolchain_version: <<parameters.rust_version>>
-      - run:
-          name: Build alloy-op-hardforks (<<parameters.rust_version>> <<parameters.feature_flags>>)
-          working_directory: alloy-op-hardforks
-          no_output_timeout: 30m
-          command: |
-            cargo build --workspace <<parameters.feature_flags>>
-      - run:
-          name: Test alloy-op-hardforks (<<parameters.rust_version>> <<parameters.feature_flags>>)
-          working_directory: alloy-op-hardforks
-          no_output_timeout: 30m
-          command: |
-            cargo test --workspace <<parameters.feature_flags>>
-      - rust-save-build-cache:
-          directory: alloy-op-hardforks
-          prefix: alloy-op-hardforks-tests-<<parameters.rust_version>>
-
-  # alloy-op-hardforks Rust CI - Check no_std compatibility (from ci.yml)
-  alloy-op-hardforks-check-no-std:
-    docker:
-      - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: xlarge
-    environment:
-      CARGO_TERM_COLOR: always
-    steps:
-      - utils/checkout-with-mise:
-          checkout-method: blobless
-      - rust-prepare
-      - rust-install-toolchain:
-          toolchain_version: stable
-          target: riscv32imac-unknown-none-elf
-      - run:
-          name: Check no_std compatibility
-          working_directory: alloy-op-hardforks
-          no_output_timeout: 30m
-          command: |
-            cargo check --target riscv32imac-unknown-none-elf --no-default-features
-
-  # alloy-op-hardforks Rust CI - Feature powerset checks (from ci.yml)
-  alloy-op-hardforks-cargo-hack:
-    docker:
-      - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: xlarge
-    environment:
-      CARGO_TERM_COLOR: always
-    steps:
-      - utils/checkout-with-mise:
-          checkout-method: blobless
-      - rust-prepare-and-restore-cache: &alloy-op-hardforks-hack-cache
-          directory: alloy-op-hardforks
-          prefix: alloy-op-hardforks-hack
-          features: "all"
-      - install-cargo-binstall
-      - run:
-          name: Install cargo-hack
-          command: |
-            command -v cargo-hack >/dev/null || cargo binstall --no-confirm cargo-hack
-      - run:
-          name: Run cargo hack feature powerset
-          working_directory: alloy-op-hardforks
-          no_output_timeout: 30m
-          command: |
-            cargo hack check --feature-powerset --depth 2
-      - rust-save-build-cache: *alloy-op-hardforks-hack-cache
-
-  # alloy-op-hardforks Rust CI - Clippy (from ci.yml)
-  alloy-op-hardforks-clippy:
-    docker:
-      - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: xlarge
-    environment:
-      CARGO_TERM_COLOR: always
-      RUSTFLAGS: -Dwarnings
-    steps:
-      - utils/checkout-with-mise:
-          checkout-method: blobless
-      - rust-prepare-and-restore-cache: &alloy-op-hardforks-clippy-cache
-          directory: alloy-op-hardforks
-          prefix: alloy-op-hardforks-clippy
-          features: "all"
-      - rust-install-toolchain:
-          toolchain_version: stable
-          components: clippy
-      - run:
-          name: Run clippy
-          working_directory: alloy-op-hardforks
-          no_output_timeout: 30m
-          command: |
-            cargo clippy --workspace --all-targets --all-features
-      - rust-save-build-cache: *alloy-op-hardforks-clippy-cache
-
-  # alloy-op-hardforks Rust CI - Documentation (from ci.yml)
-  alloy-op-hardforks-docs:
-    docker:
-      - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: xlarge
-    environment:
-      CARGO_TERM_COLOR: always
-      RUSTDOCFLAGS: --cfg docsrs -D warnings -Zunstable-options --show-type-layout --generate-link-to-definition
-    steps:
-      - utils/checkout-with-mise:
-          checkout-method: blobless
-      - rust-prepare-and-restore-cache: &alloy-op-hardforks-docs-cache
-          directory: alloy-op-hardforks
-          prefix: alloy-op-hardforks-docs
-      - rust-install-toolchain:
-          toolchain_version: nightly
-      - run:
-          name: Build documentation
-          working_directory: alloy-op-hardforks
-          no_output_timeout: 30m
-          command: |
-            cargo doc --workspace --all-features --no-deps --document-private-items
-      - rust-save-build-cache: *alloy-op-hardforks-docs-cache
-
-  # alloy-op-hardforks Rust CI - Format check (from ci.yml)
-  alloy-op-hardforks-fmt:
-    docker:
-      - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: medium
-    environment:
-      CARGO_TERM_COLOR: always
-    steps:
-      - utils/checkout-with-mise:
-          checkout-method: blobless
-      - rust-prepare
-      - rust-install-toolchain:
-          toolchain_version: nightly
-          components: rustfmt
-      - run:
-          name: Check formatting
-          working_directory: alloy-op-hardforks
-          command: |
-            cargo fmt --all --check
-
-  # alloy-op-hardforks Rust CI - Cargo deny (from ci.yml)
-  alloy-op-hardforks-cargo-deny:
-    docker:
-      - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: medium
-    environment:
-      CARGO_TERM_COLOR: always
-    steps:
-      - utils/checkout-with-mise:
-          checkout-method: blobless
-      - rust-prepare-and-restore-cache: &alloy-op-hardforks-deny-cache
-          directory: alloy-op-hardforks
-          prefix: alloy-op-hardforks-deny
-      - install-cargo-binstall
-      - run:
-          name: Install cargo-deny
-          command: |
-            command -v cargo-deny >/dev/null || cargo binstall --no-confirm cargo-deny
-      - run:
-          name: Run cargo deny
-          working_directory: alloy-op-hardforks
-          command: |
-            cargo deny check
-      - rust-save-build-cache: *alloy-op-hardforks-deny-cache
-
-  ### END alloy-op-hardforks JOBS ###
 
 workflows:
   # ============================================================================
@@ -218,33 +22,57 @@ workflows:
     when:
       or:
         - equal: ["webhook", << pipeline.trigger_source >>]
-        - equal: ["api", << pipeline.trigger_source >>]
+        - and:
+            - equal: [true, <<pipeline.parameters.alloy_op_hardforks_dispatch>>]
+            - equal: ["api", << pipeline.trigger_source >>]
     jobs:
-      # Test matrix: Rust versions x feature flags
-      - alloy-op-hardforks-cargo-tests:
+      # Build (shared job from main.yml)
+      - rust-build-binary:
+          name: alloy-op-hardforks-build
+          directory: alloy-op-hardforks
           context: &alloy-op-hardforks-context
             - circleci-repo-readonly-authenticated-github-token
-          name: alloy-op-hardforks-test-<<matrix.rust_version>>-<<matrix.feature_flags>>
+
+      # Test matrix: Rust versions x feature flags (shared job)
+      - rust-ci-cargo-tests:
+          context: *alloy-op-hardforks-context
+          name: alloy-op-hardforks-test-<<matrix.rust_version>>-<<matrix.flags>>
+          directory: alloy-op-hardforks
           matrix:
-            alias: test-matrix
             parameters:
               rust_version: ["stable", "beta", "nightly", "1.85"]
-              feature_flags: ["--no-default-features", "", "--all-features"]
-      # Check no_std compatibility
-      - alloy-op-hardforks-check-no-std:
+              flags: ["--no-default-features", "", "--all-features"]
+      # Check no_std compatibility (shared job)
+      - rust-ci-check-no-std:
+          name: alloy-op-hardforks-check-no-std
+          directory: alloy-op-hardforks
           context: *alloy-op-hardforks-context
-      # Feature powerset checks with cargo-hack
-      - alloy-op-hardforks-cargo-hack:
+      # Feature powerset checks with cargo-hack (shared job)
+      - rust-ci-cargo-hack:
+          name: alloy-op-hardforks-cargo-hack
+          directory: alloy-op-hardforks
+          flags: "--feature-powerset --depth 2"
           context: *alloy-op-hardforks-context
-      # Clippy lints
-      - alloy-op-hardforks-clippy:
+      # Clippy lints (shared job)
+      - rust-ci-clippy:
+          name: alloy-op-hardforks-clippy
+          directory: alloy-op-hardforks
           context: *alloy-op-hardforks-context
-      # Documentation build
-      - alloy-op-hardforks-docs:
+      # Documentation build (shared job)
+      - rust-ci-docs:
+          name: alloy-op-hardforks-docs
+          directory: alloy-op-hardforks
+          command: "cargo doc --workspace --all-features --no-deps --document-private-items"
+          rustdocflags: "--cfg docsrs -D warnings -Zunstable-options --show-type-layout --generate-link-to-definition"
           context: *alloy-op-hardforks-context
-      # Format check
-      - alloy-op-hardforks-fmt:
+      # Format check (shared job)
+      - rust-ci-fmt:
+          name: alloy-op-hardforks-fmt
+          directory: alloy-op-hardforks
+          command: "cargo fmt --all --check"
           context: *alloy-op-hardforks-context
-      # Cargo deny (license/security checks)
-      - alloy-op-hardforks-cargo-deny:
+      # Cargo deny (shared job)
+      - rust-ci-deny:
+          name: alloy-op-hardforks-cargo-deny
+          directory: alloy-op-hardforks
           context: *alloy-op-hardforks-context

--- a/.circleci/continue/kona.yml
+++ b/.circleci/continue/kona.yml
@@ -5,14 +5,6 @@ version: 2.1
 # It is merged with main.yml when kona/** changes are detected.
 # Shared orbs, commands, and jobs come from main.yml during merge.
 
-# Orbs used by Kona jobs (also in main.yml, merged during continuation)
-orbs:
-  go: circleci/go@1.8.0
-  gcp-cli: circleci/gcp-cli@3.0.1
-  slack: circleci/slack@6.0.0
-  codecov: codecov/codecov@5.0.3
-  utils: ethereum-optimism/circleci-utils@1.0.23
-
 parameters:
   # Required parameters (also in main.yml, merged during continuation)
   default_docker_image:
@@ -28,7 +20,7 @@ parameters:
     type: string
     default: "v0.0"
 
-# Commands used by Kona jobs (also defined in main.yml, merged during continuation)
+# Commands used only by Kona-specific jobs (shared Rust commands are in rust-ci.yml)
 commands:
   install-zstd:
     description: "Install zstd compression utility"
@@ -36,18 +28,6 @@ commands:
       - run:
           name: Install zstd
           command: sudo apt-get update && sudo apt-get install -y zstd=1.4.8*
-
-  install-cargo-binstall:
-    description: "Install cargo-binstall for fast binary installations"
-    steps:
-      - run:
-          name: Install cargo-binstall
-          command: |
-            if command -v cargo-binstall >/dev/null 2>&1; then
-              echo "cargo-binstall already installed"
-              exit 0
-            fi
-            curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
 
   go-restore-cache:
     parameters:
@@ -84,264 +64,6 @@ commands:
             - ~/.cache/go-build
             - ~/go/pkg/mod
           key: go-<<parameters.namespace>>-<<parameters.version>>-<<parameters.module>>-{{ checksum "<<parameters.module>>/go.mod" }}-{{ checksum "<<parameters.module>>/go.sum" }}
-
-  rust-install-toolchain:
-    description: "Install Rust toolchain via rustup"
-    parameters:
-      channel:
-        description: The Rust channel release to use (stable, nightly, etc.)
-        type: string
-        default: "stable"
-      components:
-        description: Components to install (space or comma separated)
-        type: string
-        default: ""
-      toolchain_version:
-        description: The specific toolchain version for stable channel
-        type: string
-        default: "1.92.0"
-      target:
-        description: A custom target architecture to add to the toolchain
-        type: string
-        default: ""
-    steps:
-      - run:
-          name: Install Rust toolchain (<< parameters.channel >>)
-          command: |
-            rustup default << parameters.toolchain_version >>
-
-            if [ -n "<< parameters.components >>" ]; then
-              rustup component add << parameters.components >>
-            fi
-            if [ -n "<< parameters.target >>" ]; then
-              rustup target add << parameters.target >>
-            fi
-
-  rust-setup-env:
-    description: "Fix rust mise environment variables"
-    steps:
-      - run:
-          name: Fix mise environment variables
-          command: |
-            echo "export CARGO_HOME=${MISE_CARGO_HOME}" >> "$BASH_ENV"
-            echo "export RUSTUP_HOME=${MISE_RUSTUP_HOME}" >> "$BASH_ENV"
-            echo "source ${MISE_CARGO_HOME}/env" >> "$BASH_ENV"
-      - run:
-          name: Configure Rust binary paths (sysgo)
-          command: |
-            ROOT_DIR="$(pwd)"
-            BIN_DIR="$ROOT_DIR/.circleci-cache/rust-binaries"
-            echo "export RUST_BINARY_PATH_KONA_NODE=$ROOT_DIR/kona/target/release/kona-node" >> "$BASH_ENV"
-            echo "export RUST_BINARY_PATH_KONA_SUPERVISOR=$ROOT_DIR/kona/target/release/kona-supervisor" >> "$BASH_ENV"
-            echo "export RUST_BINARY_PATH_OP_RBUILDER=$BIN_DIR/op-rbuilder" >> "$BASH_ENV"
-            echo "export RUST_BINARY_PATH_ROLLUP_BOOST=$BIN_DIR/rollup-boost" >> "$BASH_ENV"
-
-  rust-prepare:
-    parameters:
-      needs_clang:
-        description: "Whether to install clang (needed by bindgen for reth-mdbx-sys)."
-        type: boolean
-        default: true
-    description: "Prepare the Rust environment for the build."
-    steps:
-      - rust-setup-env
-      - when:
-          condition: << parameters.needs_clang >>
-          steps:
-            - run:
-                name: Install clang
-                command: |
-                  export NEEDRESTART_MODE=a
-                  sudo -E apt-get update --yes
-                  sudo -E apt-get install -y --no-install-recommends clang llvm-dev libclang-dev
-
-  rust-restore-build-cache:
-    description: "Restore the target directory cache for a Rust workspace"
-    parameters:
-      directory:
-        description: "Directory containing the Cargo workspace"
-        type: string
-      version:
-        description: "Version of the cache"
-        type: string
-        default: "15"
-      profile:
-        description: "Profile to restore the cache for"
-        type: string
-        default: "debug"
-      features:
-        description: "Comma-separated list of features to restore the cache for"
-        type: string
-        default: ""
-      prefix:
-        description: "Prefix to add to the cache key"
-        type: string
-        default: "rust-build"
-    steps:
-      - restore_cache:
-          name: Restore << parameters.directory >> target cache
-          keys:
-            - << parameters.prefix >>-v<< parameters.version >>-{{ checksum "<< parameters.directory >>/Cargo.lock" }}-<< parameters.profile >>-<< parameters.features >>
-            - << parameters.prefix >>-v<< parameters.version >>-{{ checksum "<< parameters.directory >>/Cargo.lock" }}-<< parameters.profile >>
-            - << parameters.prefix >>-v<< parameters.version >>-{{ checksum "<< parameters.directory >>/Cargo.lock" }}
-      - restore_cache:
-          name: Restore << parameters.directory >> registry cache (mise)
-          keys:
-            - << parameters.prefix >>-registry-v<< parameters.version >>-{{ checksum "<< parameters.directory >>/Cargo.lock" }}
-
-  rust-save-build-cache:
-    description: "Save the target directory cache for a Rust workspace"
-    parameters:
-      directory:
-        description: "Directory containing the Cargo workspace"
-        type: string
-      version:
-        description: "Version of the cache"
-        type: string
-        default: "15"
-      profile:
-        description: "Profile to save the cache for"
-        type: string
-        default: "debug"
-      features:
-        description: "Comma-separated list of features to save the cache for"
-        type: string
-        default: ""
-      prefix:
-        description: "Prefix to add to the cache key"
-        type: string
-        default: "rust-build"
-    steps:
-      - save_cache:
-          key: << parameters.prefix >>-registry-v<< parameters.version >>-{{ checksum "<< parameters.directory >>/Cargo.lock" }}
-          name: Save << parameters.directory >> registry cache (mise)
-          paths:
-            - /data/mise-data/.cargo/registry
-            - /data/mise-data/.cargo/git
-            - /data/mise-data/.cargo/bin
-            - /data/mise-data/.rustup
-      - save_cache:
-          key: << parameters.prefix >>-v<< parameters.version >>-{{ checksum "<< parameters.directory >>/Cargo.lock" }}-<< parameters.profile >>-<< parameters.features >>
-          name: Save << parameters.directory >> target cache
-          paths:
-            - << parameters.directory >>/target/<< parameters.profile >>
-
-  rust-prepare-and-restore-cache:
-    description: "Prepare the Rust environment and restore the cache"
-    parameters:
-      needs_clang:
-        description: "Whether to install clang (needed by bindgen for reth-mdbx-sys)"
-        type: boolean
-        default: true
-      directory:
-        description: "Directory containing the Cargo workspace"
-        type: string
-      version:
-        description: "Version of the cache"
-        type: string
-        default: "15"
-      profile:
-        description: "Profile to restore the cache for"
-        type: string
-        default: "debug"
-      features:
-        description: "Comma-separated list of features to restore the cache for"
-        type: string
-        default: "default"
-      prefix:
-        description: "Prefix to add to the cache key"
-        type: string
-        default: "rust-build"
-    steps:
-      - rust-prepare:
-          needs_clang: << parameters.needs_clang >>
-      - rust-restore-build-cache:
-          version: << parameters.version >>
-          directory: << parameters.directory >>
-          profile: << parameters.profile >>
-          features: << parameters.features >>
-          prefix: << parameters.prefix >>
-
-  rust-build:
-    description: "Build a Rust workspace with target directory caching"
-    parameters:
-      directory:
-        description: "Directory containing the Cargo workspace"
-        type: string
-      needs_clang:
-        description: "Whether to install clang (needed by bindgen for reth-mdbx-sys)"
-        type: boolean
-        default: true
-      version:
-        description: "Version of the cache"
-        type: string
-        default: "15"
-      profile:
-        description: "Profile to build the binary with"
-        type: string
-        default: "debug"
-      features:
-        description: "Comma-separated list of features to build the binary with"
-        type: string
-        default: "default"
-      package:
-        description: "Package name to build. If not specified, the workspace will be built."
-        type: string
-        default: ""
-      binary:
-        description: "Binary name to build. If not specified, all targets will be built."
-        type: string
-        default: ""
-      save_cache:
-        description: "Whether to save the cache at the end of the build"
-        type: boolean
-        default: false
-    steps:
-      - utils/checkout-with-mise:
-          checkout-method: blobless
-      - rust-prepare-and-restore-cache:
-          needs_clang: << parameters.needs_clang >>
-          version: << parameters.version >>
-          directory: << parameters.directory >>
-          profile: << parameters.profile >>
-          features: << parameters.features >>
-      - run:
-          name: Build << parameters.directory >>
-          command: |
-            PWD=$(pwd)
-            export CARGO_TARGET_DIR="$PWD/<< parameters.directory >>/target"
-            echo "CARGO_TARGET_DIR: $CARGO_TARGET_DIR"
-            export PROFILE="--profile << parameters.profile >>"
-
-            if [ "<< parameters.profile >>" = "debug" ]; then
-              export PROFILE="--profile dev"
-            fi
-
-            export PACKAGE="--workspace"
-            if [ -n "<< parameters.package >>" ]; then
-              export PACKAGE="--package << parameters.package >>"
-            fi
-
-            export BINARY="--all-targets"
-            if [ -n "<< parameters.binary >>" ]; then
-              export BINARY="--bin << parameters.binary >>"
-            fi
-
-            export FEATURES="--features << parameters.features >>"
-            if [ "<< parameters.features >>" = "all" ]; then
-              export FEATURES="--all-features"
-            fi
-
-            cd << parameters.directory >> && cargo build $PROFILE $TARGET $PACKAGE $FEATURES
-          no_output_timeout: 30m
-      - when:
-          condition: << parameters.save_cache >>
-          steps:
-            - rust-save-build-cache:
-                directory: << parameters.directory >>
-                version: << parameters.version >>
-                profile: << parameters.profile >>
-                features: << parameters.features >>
 
   gcp-oidc-authenticate:
     description: "Authenticate with GCP using a CircleCI OIDC token."
@@ -559,31 +281,6 @@ jobs:
               $L2_CHAIN_ID
             cargo llvm-cov report --lcov --output-path client_host_cov.lcov
 
-  # Kona Rust CI - Tests (from rust_ci.yaml)
-  kona-cargo-tests:
-    docker:
-      - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: xlarge
-    steps:
-      - utils/checkout-with-mise:
-          checkout-method: blobless
-      - rust-prepare-and-restore-cache: &kona-tests-cache
-          directory: kona
-          prefix: kona-tests
-          profile: "release"
-      - install-cargo-binstall
-      - run:
-          name: Install nextest
-          command: |
-            command -v cargo-nextest >/dev/null || cargo binstall --no-confirm cargo-nextest
-      - run:
-          name: Run cargo tests
-          working_directory: kona
-          no_output_timeout: 40m
-          command: |
-            just test
-      - rust-save-build-cache: *kona-tests-cache
-
   # Kona Rust CI - Lint (from rust_ci.yaml)
   kona-cargo-lint:
     parameters:
@@ -648,148 +345,6 @@ jobs:
             just benches
       - rust-save-build-cache: *kona-benches-cache
 
-  # Kona Rust CI - Check unused dependencies (from rust_ci.yaml)
-  kona-cargo-udeps:
-    docker:
-      - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: xlarge
-    steps:
-      - utils/checkout-with-mise:
-          checkout-method: blobless
-      - rust-prepare-and-restore-cache: &kona-udeps-cache
-          directory: kona
-          prefix: kona-udeps
-          profile: "release"
-      - install-cargo-binstall
-      - run:
-          name: Install cargo-udeps
-          command: |
-            command -v cargo-udeps >/dev/null || cargo binstall --no-confirm cargo-udeps
-      - run:
-          name: Check unused dependencies
-          working_directory: kona
-          no_output_timeout: 40m
-          command: |
-            just check-udeps
-      - rust-save-build-cache: *kona-udeps-cache
-
-  # Kona Rust CI - Doc lint (from rust_ci.yaml)
-  kona-cargo-doc-lint:
-    docker:
-      - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: xlarge
-    steps:
-      - utils/checkout-with-mise:
-          checkout-method: blobless
-      - rust-prepare-and-restore-cache:
-          directory: kona
-      - run:
-          name: Lint documentation
-          working_directory: kona
-          no_output_timeout: 40m
-          command: |
-            just lint-docs
-
-  # Kona Rust CI - Doc tests (from rust_ci.yaml)
-  kona-cargo-doc-test:
-    docker:
-      - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: xlarge
-    steps:
-      - utils/checkout-with-mise:
-          checkout-method: blobless
-      - rust-prepare-and-restore-cache: &kona-doc-test-cache
-          directory: kona
-          prefix: kona-doc-test
-      - run:
-          name: Run doc tests
-          working_directory: kona
-          no_output_timeout: 40m
-          command: |
-            just test-docs
-      - rust-save-build-cache: *kona-doc-test-cache
-
-  # Kona Rust CI - Typos (from rust_ci.yaml)
-  kona-typos:
-    docker:
-      - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: medium
-    steps:
-      - utils/checkout-with-mise:
-          checkout-method: blobless
-      - rust-prepare
-      - install-cargo-binstall
-      - run:
-          name: Install typos-cli
-          command: |
-            command -v typos >/dev/null || cargo binstall --no-confirm typos-cli
-      - run:
-          name: Check for typos
-          working_directory: kona
-          command: |
-            typos
-
-  # Kona Rust CI - Cargo hack (from rust_ci.yaml)
-  kona-cargo-hack:
-    docker:
-      - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: xlarge
-    parallelism: 4
-    steps:
-      - utils/checkout-with-mise:
-          checkout-method: blobless
-      - rust-prepare-and-restore-cache:
-          directory: kona
-          features: "all"
-      - install-cargo-binstall
-      - run:
-          name: Install cargo-hack
-          command: |
-            command -v cargo-hack >/dev/null || cargo binstall --no-confirm cargo-hack
-      - run:
-          name: Shard and run cargo hack
-          working_directory: kona
-          no_output_timeout: 40m
-          command: |
-            set -euo pipefail
-
-            # 1) Produce the full list of concrete cargo commands (one per line)
-            cargo hack check \
-              --feature-powerset --no-dev-deps \
-              --workspace --locked \
-              --print-command-list > /tmp/hack_cmds.txt
-
-            # 2) Take only this node's slice
-            awk "NR % ${CIRCLE_NODE_TOTAL} == ${CIRCLE_NODE_INDEX}" /tmp/hack_cmds.txt \
-              > /tmp/hack_cmds_shard.txt
-
-            echo "Node ${CIRCLE_NODE_INDEX}/${CIRCLE_NODE_TOTAL} running $(wc -l < /tmp/hack_cmds_shard.txt) cases"
-
-            # 3) Execute
-            while IFS= read -r cmd; do
-              echo ">>> $cmd"
-              bash -lc "$cmd"
-            done < /tmp/hack_cmds_shard.txt
-
-  # Kona Rust CI - Check no_std (from rust_ci.yaml)
-  kona-check-no-std:
-    docker:
-      - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: xlarge
-    steps:
-      - utils/checkout-with-mise:
-          checkout-method: blobless
-      - rust-prepare
-      - rust-install-toolchain:
-          toolchain_version: 1.88.0
-          target: riscv32imac-unknown-none-elf
-      - run:
-          name: Check no_std compatibility
-          working_directory: kona
-          no_output_timeout: 30m
-          command: |
-            just check-no-std
-
   # Kona Rust CI - Coverage (from rust_ci.yaml)
   kona-coverage:
     docker:
@@ -828,52 +383,6 @@ jobs:
       - store_test_results:
           path: kona/junit.xml
       - rust-save-build-cache: *kona-coverage-cache
-
-  # Kona Rust CI - Deny (from rust_ci.yaml)
-  kona-cargo-deny:
-    docker:
-      - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: medium
-    steps:
-      - utils/checkout-with-mise:
-          checkout-method: blobless
-      - rust-prepare-and-restore-cache: &kona-deny-cache
-          directory: kona
-          prefix: kona-deny
-          version: "1"
-      - install-cargo-binstall
-      - run:
-          name: Install cargo-deny
-          command: |
-            command -v cargo-deny >/dev/null || cargo binstall --no-confirm cargo-deny
-      - run:
-          name: Run cargo deny
-          working_directory: kona
-          command: |
-            cargo deny check
-      - rust-save-build-cache: *kona-deny-cache
-
-  # Kona Rust CI - Zepter (from rust_ci.yaml)
-  kona-zepter:
-    docker:
-      - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: medium
-    steps:
-      - utils/checkout-with-mise:
-          checkout-method: blobless
-      - rust-prepare
-      - install-cargo-binstall
-      - run:
-          name: Install zepter
-          command: |
-            command -v zepter >/dev/null || cargo binstall --no-confirm zepter
-            zepter --version
-      - run:
-          name: Format and lint features
-          working_directory: kona
-          command: |
-            zepter format features
-            zepter
 
   # Kona Docs Build (from docs.yaml)
   kona-docs-build:
@@ -1002,21 +511,6 @@ jobs:
             gsutil cp ./prestate-artifacts-<<parameters.kind>>/prestate.bin.gz "gs://oplabs-network-data/proofs/kona/<<parameters.kind>>/${PRESTATE_HASH}.bin.gz"
             echo "Successfully published prestates artifacts to GCS"
 
-  # Kona Update Monorepo (for scheduled sync)
-  kona-update-monorepo:
-    docker:
-      - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: medium
-    steps:
-      - utils/checkout-with-mise:
-          checkout-method: blobless
-      - run:
-          name: Check for kona upstream updates
-          working_directory: kona
-          command: |
-            echo "Checking for kona upstream updates..."
-            # This is a placeholder - implement actual sync logic as needed
-
 # ============================================================================
 # KONA WORKFLOWS
 # ============================================================================
@@ -1075,38 +569,72 @@ workflows:
           matrix:
             parameters:
               target: ["cannon-client", "asterisc-client"]
-      - kona-cargo-tests:
+      - rust-ci-cargo-tests:
           <<: *kona-job-base
+          name: kona-cargo-tests
+          directory: kona
       - kona-cargo-lint:
           <<: *kona-job-base
           name: kona-lint-<<matrix.target>>
           matrix:
             parameters:
-              target: ["native", "cannon", "asterisc"]
+              target: ["cannon", "asterisc"]
+      - rust-ci-fmt:
+          <<: *kona-job-base
+          name: kona-fmt
+          directory: kona
+      - rust-ci-clippy:
+          <<: *kona-job-base
+          name: kona-clippy
+          directory: kona
       - kona-cargo-build-benches:
           <<: *kona-job-base
-      - kona-cargo-udeps:
+      - rust-ci-udeps:
           <<: *kona-job-base
-      - kona-cargo-doc-lint:
+          name: kona-cargo-udeps
+          directory: kona
+      - rust-ci-docs:
           <<: *kona-job-base
-      - kona-cargo-doc-test:
+          name: kona-cargo-doc-lint
+          directory: kona
+          command: "just lint-docs"
+          rustdocflags: "-D warnings"
+      - rust-ci-doctest:
           <<: *kona-job-base
-      - kona-typos:
+          name: kona-cargo-doc-test
+          directory: kona
+          command: "just test-docs"
+      - rust-ci-typos:
           <<: *kona-job-base
-      - kona-cargo-deny:
+          name: kona-typos
+          directory: kona
+      - rust-ci-deny:
           <<: *kona-job-base
-      - kona-zepter:
+          name: kona-cargo-deny
+          directory: kona
+      - rust-ci-zepter:
           <<: *kona-job-base
-      - kona-check-no-std:
+          name: kona-zepter
+          directory: kona
+          command: |
+            zepter format features
+            zepter
+      - rust-ci-check-no-std:
           <<: *kona-job-base
+          name: kona-check-no-std
+          directory: kona
+          toolchain: "1.88.0"
       - kona-coverage:
           context:
             - circleci-repo-readonly-authenticated-github-token
           requires:
             - kona-cargo-tests
-      - kona-cargo-hack:
-          context:
-            - circleci-repo-readonly-authenticated-github-token
+      - rust-ci-cargo-hack:
+          <<: *kona-job-base
+          name: kona-cargo-hack
+          directory: kona
+          flags: "--feature-powerset --no-dev-deps --workspace"
+          parallelism: 4
           requires:
             - kona-build-release
             - kona-build-debug

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -583,6 +583,10 @@ commands:
         description: "Binary name to build. If not specified, all targets will be built."
         type: string
         default: ""
+      toolchain:
+        description: "Rust toolchain version to install before building (empty = use default)"
+        type: string
+        default: ""
       save_cache:
         description: "Whether to save the cache at the end of the build"
         type: boolean
@@ -596,6 +600,11 @@ commands:
           directory: << parameters.directory >>
           profile: << parameters.profile >>
           features: << parameters.features >>
+      - when:
+          condition: << parameters.toolchain >>
+          steps:
+            - rust-install-toolchain:
+                toolchain_version: << parameters.toolchain >>
       - run:
           name: Build << parameters.directory >>
           command: |
@@ -670,6 +679,10 @@ jobs:
         description: "Binary name to build. If not specified, all targets will be built."
         type: string
         default: ""
+      toolchain:
+        description: "Rust toolchain version to install before building (empty = use default)"
+        type: string
+        default: ""
       save_cache:
         description: "Whether to save the cache at the end of the build"
         type: boolean
@@ -683,6 +696,7 @@ jobs:
           features: << parameters.features >>
           package: << parameters.package >>
           binary: << parameters.binary >>
+          toolchain: << parameters.toolchain >>
           save_cache: << parameters.save_cache >>
 
   # Build a single Rust binary from a submodule.

--- a/.circleci/continue/op-alloy.yml
+++ b/.circleci/continue/op-alloy.yml
@@ -2,11 +2,8 @@ version: 2.1
 
 # Op-Alloy CI Continuation Configuration
 # This file contains ONLY Op-Alloy-specific jobs and workflows.
-# It is merged with main.yml when op-alloy/** changes are detected.
-# Shared orbs, commands, and jobs come from main.yml during merge.
-
-orbs:
-  utils: ethereum-optimism/circleci-utils@1.0.23
+# It is merged with main.yml and rust-ci.yml when op-alloy/** changes are detected.
+# Shared orbs, commands, and jobs come from main.yml and rust-ci.yml during merge.
 
 parameters:
   default_docker_image:
@@ -17,229 +14,9 @@ parameters:
     default: false
 
 # ============================================================================
-# Op-Alloy Jobs (migrated from op-alloy/.github/workflows)
+# Op-Alloy Jobs (project-specific only; shared jobs are in rust-ci.yml)
 # ============================================================================
 jobs:
-  # Op-Alloy Rust CI - Tests (from ci.yml)
-  op-alloy-cargo-tests:
-    parameters:
-      rust_version:
-        description: The Rust version to use
-        type: string
-        default: "stable"
-      flags:
-        description: Feature flags for cargo
-        type: string
-        default: ""
-    docker:
-      - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: xlarge
-    steps:
-      - utils/checkout-with-mise:
-          checkout-method: blobless
-      - rust-prepare-and-restore-cache: &op-alloy-tests-cache
-          directory: op-alloy
-          prefix: op-alloy-tests
-          profile: "release"
-      - rust-install-toolchain:
-          toolchain_version: << parameters.rust_version >>
-      - install-cargo-binstall
-      - run:
-          name: Install nextest
-          command: |
-            command -v cargo-nextest >/dev/null || cargo binstall --no-confirm cargo-nextest
-      - run:
-          name: Build or test (MSRV builds only)
-          working_directory: op-alloy
-          no_output_timeout: 40m
-          command: |
-            cargo nextest run --workspace << parameters.flags >>
-      - rust-save-build-cache: *op-alloy-tests-cache
-
-  # Op-Alloy Rust CI - Doc Tests (from ci.yml)
-  op-alloy-cargo-doctest:
-    docker:
-      - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: xlarge
-    steps:
-      - utils/checkout-with-mise:
-          checkout-method: blobless
-      - rust-prepare-and-restore-cache: &op-alloy-doctest-cache
-          directory: op-alloy
-          prefix: op-alloy-doctest
-      - run:
-          name: Run doc tests
-          working_directory: op-alloy
-          no_output_timeout: 40m
-          command: |
-            just test-docs
-      - rust-save-build-cache: *op-alloy-doctest-cache
-
-  # Op-Alloy Rust CI - WASM Unknown Target (from ci.yml)
-  op-alloy-wasm-unknown:
-    docker:
-      - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: xlarge
-    steps:
-      - utils/checkout-with-mise:
-          checkout-method: blobless
-      - rust-prepare-and-restore-cache: &op-alloy-wasm-unknown-cache
-          directory: op-alloy
-          prefix: op-alloy-wasm-unknown
-      - rust-install-toolchain:
-          target: wasm32-unknown-unknown
-      - install-cargo-binstall
-      - run:
-          name: Install cargo-hack
-          command: |
-            command -v cargo-hack >/dev/null || cargo binstall --no-confirm cargo-hack
-      - run:
-          name: Build for wasm32-unknown-unknown
-          working_directory: op-alloy
-          no_output_timeout: 40m
-          command: |
-            cargo hack build --workspace --target wasm32-unknown-unknown --exclude op-alloy-network --exclude op-alloy-rpc-jsonrpsee --exclude op-alloy-provider
-      - rust-save-build-cache: *op-alloy-wasm-unknown-cache
-
-  # Op-Alloy Rust CI - WASM WASI Target (from ci.yml)
-  op-alloy-wasm-wasi:
-    docker:
-      - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: xlarge
-    steps:
-      - utils/checkout-with-mise:
-          checkout-method: blobless
-      - rust-prepare-and-restore-cache: &op-alloy-wasm-wasi-cache
-          directory: op-alloy
-          prefix: op-alloy-wasm-wasi
-      - rust-install-toolchain:
-          target: wasm32-wasip1
-      - install-cargo-binstall
-      - run:
-          name: Install cargo-hack
-          command: |
-            command -v cargo-hack >/dev/null || cargo binstall --no-confirm cargo-hack
-      - run:
-          name: Build for wasm32-wasip1
-          working_directory: op-alloy
-          no_output_timeout: 40m
-          command: |
-            cargo hack build --workspace --target wasm32-wasip1 --exclude op-alloy-network --exclude op-alloy-rpc-types --exclude op-alloy-provider --exclude op-alloy-rpc-jsonrpsee
-      - rust-save-build-cache: *op-alloy-wasm-wasi-cache
-
-  # Op-Alloy Rust CI - no_std Check (from ci.yml)
-  op-alloy-check-no-std:
-    docker:
-      - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: xlarge
-    steps:
-      - utils/checkout-with-mise:
-          checkout-method: blobless
-      - rust-prepare-and-restore-cache: &op-alloy-no-std-cache
-          directory: op-alloy
-          prefix: op-alloy-no-std
-      - rust-install-toolchain:
-          target: riscv32imac-unknown-none-elf
-      - run:
-          name: Add target to stable toolchain
-          command: |
-            rustup target add riscv32imac-unknown-none-elf --toolchain stable
-      - run:
-          name: Check no_std compatibility
-          working_directory: op-alloy
-          no_output_timeout: 30m
-          command: |
-            ./scripts/check_no_std.sh
-      - rust-save-build-cache: *op-alloy-no-std-cache
-
-  # Op-Alloy Rust CI - Feature Checks (from ci.yml)
-  op-alloy-feature-checks:
-    docker:
-      - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: xlarge
-    steps:
-      - utils/checkout-with-mise:
-          checkout-method: blobless
-      - rust-prepare-and-restore-cache: &op-alloy-feature-checks-cache
-          directory: op-alloy
-          prefix: op-alloy-feature-checks
-      - install-cargo-binstall
-      - run:
-          name: Install cargo-hack
-          command: |
-            command -v cargo-hack >/dev/null || cargo binstall --no-confirm cargo-hack
-      - run:
-          name: Run feature powerset check (depth 1)
-          working_directory: op-alloy
-          no_output_timeout: 40m
-          command: |
-            cargo hack check --feature-powerset --depth 1
-      - rust-save-build-cache: *op-alloy-feature-checks-cache
-
-  # Op-Alloy Rust CI - Clippy (from ci.yml)
-  op-alloy-clippy:
-    docker:
-      - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: xlarge
-    steps:
-      - utils/checkout-with-mise:
-          checkout-method: blobless
-      - rust-prepare-and-restore-cache: &op-alloy-clippy-cache
-          directory: op-alloy
-          prefix: op-alloy-clippy
-      - rust-install-toolchain:
-          components: clippy
-      - run:
-          name: Run clippy
-          working_directory: op-alloy
-          no_output_timeout: 40m
-          command: |
-            just clippy
-      - rust-save-build-cache: *op-alloy-clippy-cache
-
-  # Op-Alloy Rust CI - Docs (from ci.yml)
-  op-alloy-docs:
-    docker:
-      - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: xlarge
-    steps:
-      - utils/checkout-with-mise:
-          checkout-method: blobless
-      - rust-prepare-and-restore-cache: &op-alloy-docs-cache
-          directory: op-alloy
-          prefix: op-alloy-docs
-      - rust-install-toolchain:
-          channel: nightly
-          toolchain_version: nightly
-      - run:
-          name: Build documentation
-          working_directory: op-alloy
-          no_output_timeout: 40m
-          environment:
-            RUSTDOCFLAGS: "--cfg docsrs -D warnings --show-type-layout --generate-link-to-definition --enable-index-page -Zunstable-options"
-          command: |
-            cargo doc --workspace --all-features --no-deps --document-private-items
-      - rust-save-build-cache: *op-alloy-docs-cache
-
-  # Op-Alloy Rust CI - Format Check (from ci.yml)
-  op-alloy-fmt:
-    docker:
-      - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: medium
-    steps:
-      - utils/checkout-with-mise:
-          checkout-method: blobless
-      - rust-prepare
-      - rust-install-toolchain:
-          channel: nightly
-          toolchain_version: nightly
-          components: rustfmt
-      - run:
-          name: Check formatting
-          working_directory: op-alloy
-          command: |
-            just fmt-check
-
   # Op-Alloy Rust CI - Examples (from ci.yml)
   op-alloy-examples:
     docker:
@@ -284,109 +61,6 @@ jobs:
             just check
       - rust-save-build-cache: *op-alloy-cfg-check-cache
 
-  # Op-Alloy Rust CI - Typos (from lint.yml)
-  op-alloy-typos:
-    docker:
-      - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: medium
-    steps:
-      - utils/checkout-with-mise:
-          checkout-method: blobless
-      - rust-prepare
-      - install-cargo-binstall
-      - run:
-          name: Install typos-cli
-          command: |
-            command -v typos >/dev/null || cargo binstall --no-confirm typos-cli
-      - run:
-          name: Check for typos
-          working_directory: op-alloy
-          command: |
-            typos
-
-  # Op-Alloy Rust CI - Cargo Deny (from deps.yml)
-  op-alloy-cargo-deny:
-    docker:
-      - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: medium
-    steps:
-      - utils/checkout-with-mise:
-          checkout-method: blobless
-      - rust-prepare
-      - install-cargo-binstall
-      - run:
-          name: Install cargo-deny
-          command: |
-            command -v cargo-deny >/dev/null || cargo binstall --no-confirm cargo-deny
-      - run:
-          name: Run cargo deny
-          working_directory: op-alloy
-          command: |
-            cargo deny check
-
-  # Op-Alloy Rust CI - Zepter (from lint.yml)
-  op-alloy-zepter:
-    docker:
-      - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: medium
-    steps:
-      - utils/checkout-with-mise:
-          checkout-method: blobless
-      - rust-prepare
-      - install-cargo-binstall
-      - run:
-          name: Install zepter
-          command: |
-            command -v zepter >/dev/null || cargo binstall --no-confirm zepter
-            zepter --version
-      - run:
-          name: Check feature propagation
-          working_directory: op-alloy
-          command: |
-            time zepter run check
-
-  # Op-Alloy Rust CI - Cargo Hack (from ci.yml)
-  op-alloy-cargo-hack:
-    docker:
-      - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: xlarge
-    parallelism: 4
-    steps:
-      - utils/checkout-with-mise:
-          checkout-method: blobless
-      - rust-prepare-and-restore-cache:
-          directory: op-alloy
-          features: "all"
-      - install-cargo-binstall
-      - run:
-          name: Install cargo-hack
-          command: |
-            command -v cargo-hack >/dev/null || cargo binstall --no-confirm cargo-hack
-      - run:
-          name: Shard and run cargo hack
-          working_directory: op-alloy
-          no_output_timeout: 40m
-          command: |
-            set -euo pipefail
-
-            # 1) Produce the full list of concrete cargo commands (one per line)
-            cargo hack check \
-              --feature-powerset --no-dev-deps \
-              --workspace --locked \
-              --print-command-list > /tmp/hack_cmds.txt
-
-            # 2) Take only this node's slice
-            awk "NR % ${CIRCLE_NODE_TOTAL} == ${CIRCLE_NODE_INDEX}" /tmp/hack_cmds.txt \
-              > /tmp/hack_cmds_shard.txt
-
-            echo "Node ${CIRCLE_NODE_INDEX}/${CIRCLE_NODE_TOTAL} running $(wc -l < /tmp/hack_cmds_shard.txt) cases"
-
-            # 3) Execute
-            while IFS= read -r cmd; do
-              echo ">>> $cmd"
-              bash -lc "$cmd"
-            done < /tmp/hack_cmds_shard.txt
-
 ### END OP-ALLOY JOBS ###
 
 # ============================================================================
@@ -401,90 +75,156 @@ workflows:
             - equal: [true, <<pipeline.parameters.op_alloy_dispatch>>]
             - equal: ["api", << pipeline.trigger_source >>]
     jobs:
-      # Rust CI jobs (from ci.yml)
-      - op-alloy-cargo-tests:
+      # Build (shared job from main.yml)
+      - rust-build-binary:
+          name: op-alloy-build
+          directory: op-alloy
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+
+      # Rust CI jobs (shared job)
+      - rust-ci-cargo-tests:
           name: op-alloy-test-stable
-          rust_version: "stable"
-          flags: ""
+          directory: op-alloy
           context:
             - circleci-repo-readonly-authenticated-github-token
-      - op-alloy-cargo-tests:
+      - rust-ci-cargo-tests:
           name: op-alloy-test-stable-no-default
-          rust_version: "stable"
+          directory: op-alloy
           flags: "--no-default-features"
           context:
             - circleci-repo-readonly-authenticated-github-token
-      - op-alloy-cargo-tests:
+      - rust-ci-cargo-tests:
           name: op-alloy-test-stable-all-features
-          rust_version: "stable"
+          directory: op-alloy
           flags: "--all-features"
           context:
             - circleci-repo-readonly-authenticated-github-token
-      - op-alloy-cargo-tests:
+      - rust-ci-cargo-tests:
           name: op-alloy-test-nightly
+          directory: op-alloy
           rust_version: "nightly"
-          flags: ""
           context:
             - circleci-repo-readonly-authenticated-github-token
-      - op-alloy-cargo-tests:
+      - rust-ci-cargo-tests:
           name: op-alloy-test-nightly-no-default
+          directory: op-alloy
           rust_version: "nightly"
           flags: "--no-default-features"
           context:
             - circleci-repo-readonly-authenticated-github-token
-      - op-alloy-cargo-tests:
+      - rust-ci-cargo-tests:
           name: op-alloy-test-nightly-all-features
+          directory: op-alloy
           rust_version: "nightly"
           flags: "--all-features"
           context:
             - circleci-repo-readonly-authenticated-github-token
-      - op-alloy-cargo-tests:
+      - rust-ci-cargo-tests:
           name: op-alloy-build-msrv
+          directory: op-alloy
           rust_version: "1.88"
-          flags: ""
           context:
             - circleci-repo-readonly-authenticated-github-token
-      - op-alloy-cargo-tests:
+      - rust-ci-cargo-tests:
           name: op-alloy-build-msrv-no-default
+          directory: op-alloy
           rust_version: "1.88"
           flags: "--no-default-features"
           context:
             - circleci-repo-readonly-authenticated-github-token
 
-      - op-alloy-cargo-doctest: &op-alloy-job-base
+      # Doc tests (shared job)
+      - rust-ci-doctest:
+          name: op-alloy-cargo-doctest
+          directory: op-alloy
+          command: "just test-docs"
           context:
             - circleci-repo-readonly-authenticated-github-token
-      - op-alloy-wasm-unknown:
-          <<: *op-alloy-job-base
-      - op-alloy-wasm-wasi:
-          <<: *op-alloy-job-base
-      - op-alloy-check-no-std:
-          <<: *op-alloy-job-base
-      - op-alloy-feature-checks:
-          <<: *op-alloy-job-base
-      - op-alloy-clippy:
-          <<: *op-alloy-job-base
-      - op-alloy-docs:
-          <<: *op-alloy-job-base
-      - op-alloy-fmt:
-          <<: *op-alloy-job-base
+      - rust-ci-cargo-hack-build:
+          name: op-alloy-wasm-unknown
+          directory: op-alloy
+          target: wasm32-unknown-unknown
+          flags: "--workspace --exclude op-alloy-network --exclude op-alloy-rpc-jsonrpsee --exclude op-alloy-provider"
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+      - rust-ci-cargo-hack-build:
+          name: op-alloy-wasm-wasi
+          directory: op-alloy
+          target: wasm32-wasip1
+          flags: "--workspace --exclude op-alloy-network --exclude op-alloy-rpc-types --exclude op-alloy-provider --exclude op-alloy-rpc-jsonrpsee"
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+      - rust-ci-check-no-std:
+          name: op-alloy-check-no-std
+          directory: op-alloy
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+      - rust-ci-cargo-hack:
+          name: op-alloy-feature-checks
+          directory: op-alloy
+          flags: "--feature-powerset --depth 1"
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+
+      # Clippy (shared job)
+      - rust-ci-clippy:
+          name: op-alloy-clippy
+          directory: op-alloy
+          command: "just clippy"
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+
+      # Documentation (shared job)
+      - rust-ci-docs:
+          name: op-alloy-docs
+          directory: op-alloy
+          command: "cargo doc --workspace --all-features --no-deps --document-private-items"
+          rustdocflags: "--cfg docsrs -D warnings --show-type-layout --generate-link-to-definition --enable-index-page -Zunstable-options"
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+
+      # Formatting (shared job)
+      - rust-ci-fmt:
+          name: op-alloy-fmt
+          directory: op-alloy
+          command: "just fmt-check"
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+
       - op-alloy-examples:
-          <<: *op-alloy-job-base
+          context:
+            - circleci-repo-readonly-authenticated-github-token
       - op-alloy-cfg-check:
-          <<: *op-alloy-job-base
+          context:
+            - circleci-repo-readonly-authenticated-github-token
 
-      # Lint jobs (from lint.yml)
-      - op-alloy-typos:
-          <<: *op-alloy-job-base
-      - op-alloy-zepter:
-          <<: *op-alloy-job-base
+      # Lint jobs (shared)
+      - rust-ci-typos:
+          name: op-alloy-typos
+          directory: op-alloy
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+      - rust-ci-zepter:
+          name: op-alloy-zepter
+          directory: op-alloy
+          command: "time zepter run check"
+          context:
+            - circleci-repo-readonly-authenticated-github-token
 
-      # Deps jobs (from deps.yml)
-      - op-alloy-cargo-deny:
-          <<: *op-alloy-job-base
+      # Deps jobs (shared)
+      - rust-ci-deny:
+          name: op-alloy-cargo-deny
+          directory: op-alloy
+          context:
+            - circleci-repo-readonly-authenticated-github-token
 
       # Feature powerset (from ci.yml) - runs after initial checks
-      - op-alloy-cargo-hack:
+      - rust-ci-cargo-hack:
+          name: op-alloy-cargo-hack
+          directory: op-alloy
+          flags: "--feature-powerset --no-dev-deps --workspace"
+          parallelism: 4
           context:
             - circleci-repo-readonly-authenticated-github-token
           requires:

--- a/.circleci/continue/op-reth.yml
+++ b/.circleci/continue/op-reth.yml
@@ -2,8 +2,8 @@ version: 2.1
 
 # OP-Reth CI Continuation Configuration
 # This file contains ONLY op-reth-specific jobs and workflows.
-# It is merged with main.yml when op-reth/** changes are detected.
-# Shared orbs, commands, and jobs come from main.yml during merge.
+# It is merged with main.yml and rust-ci.yml when op-reth/** changes are detected.
+# Shared orbs, commands, and jobs come from main.yml and rust-ci.yml during merge.
 
 parameters:
   # Required parameters (also in main.yml, merged during continuation)
@@ -21,207 +21,12 @@ parameters:
     default: "v0.0"
 
 # ============================================================================
-# OP-RETH JOBS
+# OP-RETH JOBS (project-specific only; shared jobs are in rust-ci.yml)
 # ============================================================================
 # Note: Commands like rust-prepare, rust-restore-build-cache, rust-save-build-cache,
 # rust-prepare-and-restore-cache, rust-install-toolchain, install-cargo-binstall,
 # and notify-failures-on-develop are imported from main.yml
 jobs:
-  # OP-Reth Clippy lint
-  op-reth-clippy:
-    docker:
-      - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: xlarge
-    steps:
-      - utils/checkout-with-mise:
-          checkout-method: blobless
-      - rust-prepare-and-restore-cache:
-          directory: op-reth
-          profile: debug
-          features: "all"
-      - rust-install-toolchain:
-          components: clippy
-      - run:
-          name: Run clippy on op-reth workspace
-          working_directory: op-reth
-          no_output_timeout: 40m
-          command: |
-            cargo clippy --workspace --lib --examples --tests --benches --all-features --locked
-          environment:
-            RUSTFLAGS: -D warnings
-      - rust-save-build-cache:
-          directory: op-reth
-          profile: debug
-          features: "all"
-
-  # OP-Reth format check
-  op-reth-fmt:
-    docker:
-      - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: medium
-    steps:
-      - utils/checkout-with-mise:
-          checkout-method: blobless
-      - rust-prepare
-      - rust-install-toolchain:
-          components: rustfmt
-          channel: nightly
-      - run:
-          name: Check formatting
-          working_directory: op-reth
-          command: cargo +nightly fmt --all --check
-
-  # OP-Reth typos check
-  op-reth-typos:
-    docker:
-      - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: medium
-    steps:
-      - utils/checkout-with-mise:
-          checkout-method: blobless
-      - rust-prepare
-      - install-cargo-binstall
-      - run:
-          name: Install typos-cli
-          command: |
-            command -v typos >/dev/null || cargo binstall --no-confirm typos-cli
-      - run:
-          name: Check for typos
-          working_directory: op-reth
-          command: typos
-
-  # OP-Reth unused dependencies check
-  op-reth-udeps:
-    docker:
-      - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: xlarge
-    steps:
-      - utils/checkout-with-mise:
-          checkout-method: blobless
-      - rust-prepare-and-restore-cache: &op-reth-udeps-cache
-          directory: op-reth
-          prefix: op-reth-udeps
-          profile: "release"
-      - rust-install-toolchain:
-          channel: nightly
-      - install-cargo-binstall
-      - run:
-          name: Install cargo-udeps
-          command: |
-            command -v cargo-udeps >/dev/null || cargo binstall --no-confirm cargo-udeps
-      - run:
-          name: Check unused dependencies
-          working_directory: op-reth
-          no_output_timeout: 40m
-          command: |
-            cargo +nightly udeps --workspace --lib --examples --tests --benches --all-features --locked
-      - rust-save-build-cache: *op-reth-udeps-cache
-
-  # OP-Reth cargo deny
-  op-reth-deny:
-    docker:
-      - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: medium
-    steps:
-      - utils/checkout-with-mise:
-          checkout-method: blobless
-      - rust-prepare
-      - install-cargo-binstall
-      - run:
-          name: Install cargo-deny
-          command: |
-            command -v cargo-deny >/dev/null || cargo binstall --no-confirm cargo-deny
-      - run:
-          name: Run cargo deny
-          working_directory: op-reth
-          command: cargo deny --all-features check all
-
-  # OP-Reth doc tests
-  op-reth-doc-test:
-    docker:
-      - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: xlarge
-    steps:
-      - utils/checkout-with-mise:
-          checkout-method: blobless
-      - rust-prepare-and-restore-cache: &op-reth-doc-cache
-          directory: op-reth
-          prefix: op-reth-doc
-      - run:
-          name: Run doc tests
-          working_directory: op-reth
-          no_output_timeout: 40m
-          command: cargo test --doc --workspace --all-features
-      - rust-save-build-cache: *op-reth-doc-cache
-
-  # OP-Reth unit tests (optimism)
-  op-reth-unit-tests:
-    docker:
-      - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: xlarge
-    parameters:
-      storage:
-        description: "Storage type (stable or edge)"
-        type: string
-        default: "stable"
-    steps:
-      - utils/checkout-with-mise:
-          checkout-method: blobless
-      - rust-prepare-and-restore-cache: &op-reth-tests-cache
-          directory: op-reth
-          prefix: op-reth-tests-<<parameters.storage>>
-          profile: debug
-      - install-cargo-binstall
-      - run:
-          name: Install nextest
-          command: |
-            command -v cargo-nextest >/dev/null || cargo binstall --no-confirm cargo-nextest
-      - run:
-          name: Run op-reth unit tests (<<parameters.storage>>)
-          working_directory: op-reth
-          no_output_timeout: 40m
-          environment:
-            RUST_BACKTRACE: 1
-          command: |
-            EDGE_FEATURES=""
-            if [ "<<parameters.storage>>" = "edge" ]; then
-              EDGE_FEATURES="edge"
-            fi
-            cargo nextest run \
-              --features "asm-keccak $EDGE_FEATURES" --locked \
-              --workspace \
-              --no-tests=warn \
-              -E "!kind(test) and not binary(e2e_testsuite)"
-      - rust-save-build-cache: *op-reth-tests-cache
-
-  # OP-Reth integration tests
-  op-reth-integration-tests:
-    docker:
-      - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: xlarge
-    steps:
-      - utils/checkout-with-mise:
-          checkout-method: blobless
-      - rust-prepare-and-restore-cache: &op-reth-integration-cache
-          directory: op-reth
-          prefix: op-reth-integration
-          profile: debug
-      - install-cargo-binstall
-      - run:
-          name: Install nextest
-          command: |
-            command -v cargo-nextest >/dev/null || cargo binstall --no-confirm cargo-nextest
-      - run:
-          name: Run op-reth integration tests
-          working_directory: op-reth
-          no_output_timeout: 60m
-          environment:
-            RUST_BACKTRACE: 1
-          command: |
-            cargo nextest run \
-              --locked -p reth-optimism-node
-      - rust-save-build-cache: *op-reth-integration-cache
-
   # OP-Reth compact codec backwards compatibility
   op-reth-compact-codec:
     docker:
@@ -259,29 +64,6 @@ jobs:
             cargo run --bin op-reth --features "dev" --manifest-path bin/Cargo.toml -- test-vectors compact --read
       - rust-save-build-cache: *op-reth-compact-cache
 
-  # OP-Reth MSRV check
-  op-reth-msrv:
-    docker:
-      - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: xlarge
-    steps:
-      - utils/checkout-with-mise:
-          checkout-method: blobless
-      - rust-prepare-and-restore-cache: &op-reth-msrv-cache
-          directory: op-reth
-          prefix: op-reth-msrv
-          profile: debug
-      - rust-install-toolchain:
-          toolchain_version: "1.88.0"  # MSRV
-      - run:
-          name: Build op-reth with MSRV
-          working_directory: op-reth
-          no_output_timeout: 40m
-          command: cargo build --bin op-reth --workspace
-          environment:
-            RUSTFLAGS: -D warnings
-      - rust-save-build-cache: *op-reth-msrv-cache
-
   # OP-Reth Windows cross-compile check
   op-reth-windows-check:
     docker:
@@ -306,80 +88,6 @@ jobs:
           command: cargo check -p op-reth --target x86_64-pc-windows-gnu
       - rust-save-build-cache: *op-reth-windows-cache
 
-  # OP-Reth crate checks (cargo hack)
-  op-reth-crate-checks:
-    docker:
-      - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: xlarge
-    parallelism: 3
-    steps:
-      - utils/checkout-with-mise:
-          checkout-method: blobless
-      - rust-prepare-and-restore-cache: &op-reth-hack-cache
-          directory: op-reth
-          prefix: op-reth-hack
-          profile: debug
-      - install-cargo-binstall
-      - run:
-          name: Install cargo-hack
-          command: |
-            command -v cargo-hack >/dev/null || cargo binstall --no-confirm cargo-hack
-      - run:
-          name: Run cargo hack check (partition ${CIRCLE_NODE_INDEX}/${CIRCLE_NODE_TOTAL})
-          working_directory: op-reth
-          no_output_timeout: 60m
-          command: |
-            PARTITION=$((CIRCLE_NODE_INDEX + 1))
-            cargo hack check --workspace --partition $PARTITION/$CIRCLE_NODE_TOTAL
-      - rust-save-build-cache: *op-reth-hack-cache
-
-  # OP-Reth feature propagation check (zepter)
-  op-reth-feature-propagation:
-    docker:
-      - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: medium
-    steps:
-      - utils/checkout-with-mise:
-          checkout-method: blobless
-      - rust-prepare
-      - install-cargo-binstall
-      - run:
-          name: Install zepter
-          command: |
-            command -v zepter >/dev/null || cargo binstall --no-confirm zepter
-      - run:
-          name: Eagerly pull dependencies
-          working_directory: op-reth
-          command: cargo metadata --format-version=1 --locked > /dev/null
-      - run:
-          name: Check feature propagation
-          working_directory: op-reth
-          command: zepter run check
-
-  # OP-Reth build binary (release)
-  op-reth-build-release:
-    docker:
-      - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: xlarge
-    steps:
-      - utils/checkout-with-mise:
-          checkout-method: blobless
-      - rust-prepare-and-restore-cache: &op-reth-release-cache
-          directory: op-reth
-          prefix: op-reth-release
-          profile: release
-      - run:
-          name: Build op-reth release
-          working_directory: op-reth
-          no_output_timeout: 40m
-          command: |
-            cargo build --release --bin op-reth
-      - rust-save-build-cache: *op-reth-release-cache
-      - persist_to_workspace:
-          root: .
-          paths:
-            - op-reth/target/release/op-reth
-
 # ============================================================================
 # OP-RETH WORKFLOWS
 # ============================================================================
@@ -393,51 +101,91 @@ workflows:
             - equal: [true, <<pipeline.parameters.op_reth_dispatch>>]
             - equal: ["api", << pipeline.trigger_source >>]
     jobs:
-      # Lint jobs
-      - op-reth-clippy:
+      # Lint jobs (shared)
+      - rust-ci-clippy:
+          name: op-reth-clippy
+          directory: op-reth
+          command: "cargo clippy --workspace --lib --examples --tests --benches --all-features --locked"
           context:
             - circleci-repo-readonly-authenticated-github-token
-      - op-reth-fmt:
+      - rust-ci-fmt:
+          name: op-reth-fmt
+          directory: op-reth
           context:
             - circleci-repo-readonly-authenticated-github-token
-      - op-reth-typos:
+      - rust-ci-typos:
+          name: op-reth-typos
+          directory: op-reth
           context:
             - circleci-repo-readonly-authenticated-github-token
-      - op-reth-deny:
+      - rust-ci-deny:
+          name: op-reth-deny
+          directory: op-reth
+          command: "cargo deny --all-features check all"
           context:
             - circleci-repo-readonly-authenticated-github-token
-      - op-reth-feature-propagation:
+      - rust-ci-zepter:
+          name: op-reth-feature-propagation
+          directory: op-reth
+          command: |
+            cargo metadata --format-version=1 --locked > /dev/null
+            zepter run check
           context:
             - circleci-repo-readonly-authenticated-github-token
 
-      # Crate checks (parallelized)
-      - op-reth-crate-checks:
+      # Crate checks (parallelized, shared job)
+      - rust-ci-cargo-hack:
+          name: op-reth-crate-checks
+          directory: op-reth
+          flags: "--workspace"
+          parallelism: 3
           context:
             - circleci-repo-readonly-authenticated-github-token
 
       # Build checks
-      - op-reth-msrv:
+      - rust-build-binary:
+          name: op-reth-msrv
+          directory: op-reth
+          binary: op-reth
+          toolchain: "1.88.0"
           context:
             - circleci-repo-readonly-authenticated-github-token
       - op-reth-windows-check:
           context:
             - circleci-repo-readonly-authenticated-github-token
-      - op-reth-build-release:
+      - rust-build-binary:
+          name: op-reth-build-release
+          directory: op-reth
+          profile: release
+          binary: op-reth
           context:
             - circleci-repo-readonly-authenticated-github-token
 
-      # Test jobs
-      - op-reth-unit-tests:
-          name: op-reth-unit-tests-<<matrix.storage>>
-          matrix:
-            parameters:
-              storage: ["stable", "edge"]
+      # Test jobs (shared) - stable and edge storage variants
+      - rust-ci-cargo-tests:
+          name: op-reth-unit-tests-stable
+          directory: op-reth
+          cache_profile: debug
           context:
             - circleci-repo-readonly-authenticated-github-token
-      - op-reth-integration-tests:
+      - rust-ci-cargo-tests:
+          name: op-reth-unit-tests-edge
+          directory: op-reth
+          flags: "edge"
+          cache_profile: debug
           context:
             - circleci-repo-readonly-authenticated-github-token
-      - op-reth-doc-test:
+      - rust-ci-cargo-tests:
+          name: op-reth-integration-tests
+          directory: op-reth
+          command: test-integration
+          cache_profile: debug
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+      - rust-ci-doctest:
+          name: op-reth-doc-test
+          directory: op-reth
+          command: "cargo test --doc --workspace --all-features"
           context:
             - circleci-repo-readonly-authenticated-github-token
 
@@ -447,7 +195,9 @@ workflows:
             - circleci-repo-readonly-authenticated-github-token
 
       # Udeps (slower, depends on other jobs)
-      - op-reth-udeps:
+      - rust-ci-udeps:
+          name: op-reth-udeps
+          directory: op-reth
           context:
             - circleci-repo-readonly-authenticated-github-token
           requires:

--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -1,0 +1,655 @@
+version: 2.1
+
+# Shared Rust CI Commands and Jobs
+# This file contains common commands and parameterized jobs used by multiple Rust subproject configs.
+# Each subproject config references these jobs from its workflows section.
+# No workflows are defined here - workflows remain in each project's config.
+
+orbs:
+  utils: ethereum-optimism/circleci-utils@1.0.23
+
+parameters:
+  default_docker_image:
+    type: string
+    default: cimg/base:2024.01
+
+commands:
+  install-cargo-binstall:
+    description: "Install cargo-binstall for fast binary installations"
+    steps:
+      - run:
+          name: Install cargo-binstall
+          command: |
+            if command -v cargo-binstall >/dev/null 2>&1; then
+              echo "cargo-binstall already installed"
+              exit 0
+            fi
+            curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+
+  rust-install-toolchain:
+    description: "Install Rust toolchain via rustup"
+    parameters:
+      channel:
+        description: The Rust channel release to use (stable, nightly, etc.)
+        type: string
+        default: "stable"
+      components:
+        description: Components to install (space or comma separated)
+        type: string
+        default: ""
+      toolchain_version:
+        description: The specific toolchain version for stable channel
+        type: string
+        default: "1.92.0"
+      target:
+        description: A custom target architecture to add to the toolchain
+        type: string
+        default: ""
+    steps:
+      - run:
+          name: Install Rust toolchain (<< parameters.channel >>)
+          command: |
+            rustup default << parameters.toolchain_version >>
+
+            if [ -n "<< parameters.components >>" ]; then
+              rustup component add << parameters.components >>
+            fi
+            if [ -n "<< parameters.target >>" ]; then
+              rustup target add << parameters.target >>
+            fi
+
+  rust-setup-env:
+    description: "Fix rust mise environment variables"
+    steps:
+      - run:
+          name: Fix mise environment variables
+          command: |
+            echo "export CARGO_HOME=${MISE_CARGO_HOME}" >> "$BASH_ENV"
+            echo "export RUSTUP_HOME=${MISE_RUSTUP_HOME}" >> "$BASH_ENV"
+            echo "source ${MISE_CARGO_HOME}/env" >> "$BASH_ENV"
+      - run:
+          name: Configure Rust binary paths (sysgo)
+          command: |
+            ROOT_DIR="$(pwd)"
+            BIN_DIR="$ROOT_DIR/.circleci-cache/rust-binaries"
+            echo "export RUST_BINARY_PATH_KONA_NODE=$ROOT_DIR/kona/target/release/kona-node" >> "$BASH_ENV"
+            echo "export RUST_BINARY_PATH_KONA_SUPERVISOR=$ROOT_DIR/kona/target/release/kona-supervisor" >> "$BASH_ENV"
+            echo "export RUST_BINARY_PATH_OP_RBUILDER=$BIN_DIR/op-rbuilder" >> "$BASH_ENV"
+            echo "export RUST_BINARY_PATH_ROLLUP_BOOST=$BIN_DIR/rollup-boost" >> "$BASH_ENV"
+
+  rust-prepare:
+    parameters:
+      needs_clang:
+        description: "Whether to install clang (needed by bindgen for reth-mdbx-sys)."
+        type: boolean
+        default: true
+    description: "Prepare the Rust environment for the build."
+    steps:
+      - rust-setup-env
+      - when:
+          condition: << parameters.needs_clang >>
+          steps:
+            - run:
+                name: Install clang
+                command: |
+                  export NEEDRESTART_MODE=a
+                  sudo -E apt-get update --yes
+                  sudo -E apt-get install -y --no-install-recommends clang llvm-dev libclang-dev
+
+  rust-restore-build-cache:
+    description: "Restore the target directory cache for a Rust workspace"
+    parameters: &cache-params
+      directory:
+        description: "Directory containing the Cargo workspace"
+        type: string
+      version:
+        description: "Version of the cache"
+        type: string
+        default: "15"
+      profile:
+        description: "Profile to restore the cache for"
+        type: string
+        default: "debug"
+      features:
+        description: "Comma-separated list of features to restore the cache for"
+        type: string
+        default: ""
+      prefix:
+        description: "Prefix to add to the cache key"
+        type: string
+        default: "rust-build"
+    steps:
+      - restore_cache:
+          name: Restore << parameters.directory >> target cache
+          keys:
+            - << parameters.prefix >>-v<< parameters.version >>-{{ checksum "<< parameters.directory >>/Cargo.lock" }}-<< parameters.profile >>-<< parameters.features >>
+            - << parameters.prefix >>-v<< parameters.version >>-{{ checksum "<< parameters.directory >>/Cargo.lock" }}-<< parameters.profile >>
+            - << parameters.prefix >>-v<< parameters.version >>-{{ checksum "<< parameters.directory >>/Cargo.lock" }}
+      - restore_cache:
+          name: Restore << parameters.directory >> registry cache (mise)
+          keys:
+            - << parameters.prefix >>-registry-v<< parameters.version >>-{{ checksum "<< parameters.directory >>/Cargo.lock" }}
+
+  rust-save-build-cache:
+    description: "Save the target directory cache for a Rust workspace"
+    parameters: *cache-params
+    steps:
+      - save_cache:
+          key: << parameters.prefix >>-registry-v<< parameters.version >>-{{ checksum "<< parameters.directory >>/Cargo.lock" }}
+          name: Save << parameters.directory >> registry cache (mise)
+          paths:
+            - /data/mise-data/.cargo/registry
+            - /data/mise-data/.cargo/git
+            - /data/mise-data/.cargo/bin
+            - /data/mise-data/.rustup
+      - save_cache:
+          key: << parameters.prefix >>-v<< parameters.version >>-{{ checksum "<< parameters.directory >>/Cargo.lock" }}-<< parameters.profile >>-<< parameters.features >>
+          name: Save << parameters.directory >> target cache
+          paths:
+            - << parameters.directory >>/target/<< parameters.profile >>
+
+  rust-prepare-and-restore-cache:
+    description: "Prepare the Rust environment and restore the cache"
+    parameters:
+      <<: *cache-params
+      needs_clang:
+        description: "Whether to install clang (needed by bindgen for reth-mdbx-sys)"
+        type: boolean
+        default: true
+      features:
+        description: "Comma-separated list of features to restore the cache for"
+        type: string
+        default: "default"
+    steps:
+      - rust-prepare:
+          needs_clang: << parameters.needs_clang >>
+      - rust-restore-build-cache:
+          version: << parameters.version >>
+          directory: << parameters.directory >>
+          profile: << parameters.profile >>
+          features: << parameters.features >>
+          prefix: << parameters.prefix >>
+
+  rust-build:
+    description: "Build a Rust workspace with target directory caching"
+    parameters:
+      <<: *cache-params
+      needs_clang:
+        description: "Whether to install clang (needed by bindgen for reth-mdbx-sys)"
+        type: boolean
+        default: true
+      features:
+        description: "Comma-separated list of features to build the binary with"
+        type: string
+        default: "default"
+      package:
+        description: "Package name to build. If not specified, the workspace will be built."
+        type: string
+        default: ""
+      binary:
+        description: "Binary name to build. If not specified, all targets will be built."
+        type: string
+        default: ""
+      toolchain:
+        description: "Rust toolchain version to install before building (empty = use default)"
+        type: string
+        default: ""
+      save_cache:
+        description: "Whether to save the cache at the end of the build"
+        type: boolean
+        default: false
+    steps:
+      - utils/checkout-with-mise:
+          checkout-method: blobless
+      - rust-prepare-and-restore-cache:
+          needs_clang: << parameters.needs_clang >>
+          version: << parameters.version >>
+          directory: << parameters.directory >>
+          profile: << parameters.profile >>
+          features: << parameters.features >>
+      - when:
+          condition: << parameters.toolchain >>
+          steps:
+            - rust-install-toolchain:
+                toolchain_version: << parameters.toolchain >>
+      - run:
+          name: Build << parameters.directory >>
+          command: |
+            PWD=$(pwd)
+            export CARGO_TARGET_DIR="$PWD/<< parameters.directory >>/target"
+            echo "CARGO_TARGET_DIR: $CARGO_TARGET_DIR"
+            export PROFILE="--profile << parameters.profile >>"
+
+            if [ "<< parameters.profile >>" = "debug" ]; then
+              export PROFILE="--profile dev"
+            fi
+
+            export PACKAGE="--workspace"
+            if [ -n "<< parameters.package >>" ]; then
+              export PACKAGE="--package << parameters.package >>"
+            fi
+
+            export BINARY="--all-targets"
+            if [ -n "<< parameters.binary >>" ]; then
+              export BINARY="--bin << parameters.binary >>"
+            fi
+
+            export FEATURES="--features << parameters.features >>"
+            if [ "<< parameters.features >>" = "all" ]; then
+              export FEATURES="--all-features"
+            fi
+
+            cd << parameters.directory >> && cargo build $PROFILE $TARGET $PACKAGE $FEATURES
+          no_output_timeout: 30m
+      - when:
+          condition: << parameters.save_cache >>
+          steps:
+            - rust-save-build-cache:
+                directory: << parameters.directory >>
+                version: << parameters.version >>
+                profile: << parameters.profile >>
+                features: << parameters.features >>
+
+jobs:
+  # Shared format check job
+  rust-ci-fmt:
+    parameters:
+      directory:
+        description: "Directory containing the Cargo workspace"
+        type: string
+      command:
+        description: "Format check command to run"
+        type: string
+        default: "cargo +nightly fmt --all --check"
+    docker:
+      - image: <<pipeline.parameters.default_docker_image>>
+    resource_class: medium
+    steps:
+      - utils/checkout-with-mise:
+          checkout-method: blobless
+      - rust-prepare-and-restore-cache: &fmt-cache-args
+          directory: <<parameters.directory>>
+          prefix: <<parameters.directory>>-fmt
+      - rust-install-toolchain:
+          channel: nightly
+          toolchain_version: nightly
+          components: rustfmt
+      - run:
+          name: Check formatting
+          working_directory: <<parameters.directory>>
+          command: <<parameters.command>>
+      - rust-save-build-cache: *fmt-cache-args
+
+  # Shared clippy lint job
+  rust-ci-clippy:
+    parameters:
+      directory:
+        description: "Directory containing the Cargo workspace"
+        type: string
+      command:
+        description: "Clippy command to run"
+        type: string
+        default: "cargo clippy --workspace --all-targets --all-features"
+      toolchain:
+        description: "Rust toolchain to use (stable or nightly)"
+        type: string
+        default: "stable"
+    docker:
+      - image: <<pipeline.parameters.default_docker_image>>
+    resource_class: xlarge
+    steps:
+      - utils/checkout-with-mise:
+          checkout-method: blobless
+      - rust-prepare-and-restore-cache: &clippy-cache-args
+          directory: <<parameters.directory>>
+          prefix: <<parameters.directory>>-clippy
+          features: "all"
+      - rust-install-toolchain:
+          channel: <<parameters.toolchain>>
+          toolchain_version: <<parameters.toolchain>>
+          components: clippy
+      - run:
+          name: Run clippy
+          working_directory: <<parameters.directory>>
+          no_output_timeout: 30m
+          environment:
+            RUSTFLAGS: -Dwarnings
+          command: <<parameters.command>>
+      - rust-save-build-cache: *clippy-cache-args
+
+  # Shared cargo deny job
+  rust-ci-deny:
+    parameters:
+      directory:
+        description: "Directory containing the Cargo workspace"
+        type: string
+      command:
+        description: "Cargo deny command to run"
+        type: string
+        default: "cargo deny check"
+    docker:
+      - image: <<pipeline.parameters.default_docker_image>>
+    resource_class: medium
+    steps:
+      - utils/checkout-with-mise:
+          checkout-method: blobless
+      - rust-prepare-and-restore-cache: &deny-cache-args
+          directory: <<parameters.directory>>
+          prefix: <<parameters.directory>>-deny
+      - install-cargo-binstall
+      - run:
+          name: Install cargo-deny
+          command: |
+            command -v cargo-deny >/dev/null || cargo binstall --no-confirm cargo-deny
+      - run:
+          name: Run cargo deny
+          working_directory: <<parameters.directory>>
+          command: <<parameters.command>>
+      - rust-save-build-cache: *deny-cache-args
+
+  # Shared zepter feature propagation job
+  rust-ci-zepter:
+    parameters:
+      directory:
+        description: "Directory containing the Cargo workspace"
+        type: string
+      command:
+        description: "Zepter command to run"
+        type: string
+        default: "zepter run check"
+    docker:
+      - image: <<pipeline.parameters.default_docker_image>>
+    resource_class: medium
+    steps:
+      - utils/checkout-with-mise:
+          checkout-method: blobless
+      - rust-prepare-and-restore-cache: &zepter-cache-args
+          directory: <<parameters.directory>>
+          prefix: <<parameters.directory>>-zepter
+      - install-cargo-binstall
+      - run:
+          name: Install zepter
+          command: |
+            command -v zepter >/dev/null || cargo binstall --no-confirm zepter
+            zepter --version
+      - run:
+          name: Check feature propagation
+          working_directory: <<parameters.directory>>
+          command: <<parameters.command>>
+      - rust-save-build-cache: *zepter-cache-args
+
+  # Shared typos check job
+  rust-ci-typos:
+    parameters:
+      directory:
+        description: "Directory containing the Cargo workspace"
+        type: string
+    docker:
+      - image: <<pipeline.parameters.default_docker_image>>
+    resource_class: medium
+    steps:
+      - utils/checkout-with-mise:
+          checkout-method: blobless
+      - rust-prepare-and-restore-cache: &typos-cache-args
+          directory: <<parameters.directory>>
+          prefix: <<parameters.directory>>-typos
+      - install-cargo-binstall
+      - run:
+          name: Install typos-cli
+          command: |
+            command -v typos >/dev/null || cargo binstall --no-confirm typos-cli
+      - run:
+          name: Check for typos
+          working_directory: <<parameters.directory>>
+          command: typos
+      - rust-save-build-cache: *typos-cache-args
+
+  # Shared no_std compatibility check job
+  rust-ci-check-no-std:
+    parameters:
+      directory:
+        description: "Directory containing the Cargo workspace"
+        type: string
+      target:
+        description: "Target architecture for no_std check"
+        type: string
+        default: "riscv32imac-unknown-none-elf"
+      toolchain:
+        description: "Rust toolchain version to use"
+        type: string
+        default: "stable"
+    docker:
+      - image: <<pipeline.parameters.default_docker_image>>
+    resource_class: xlarge
+    steps:
+      - utils/checkout-with-mise:
+          checkout-method: blobless
+      - rust-prepare-and-restore-cache: &no-std-cache-args
+          directory: <<parameters.directory>>
+          prefix: <<parameters.directory>>-no-std
+      - rust-install-toolchain:
+          toolchain_version: <<parameters.toolchain>>
+          target: <<parameters.target>>
+      - run:
+          name: Check no_std compatibility
+          working_directory: <<parameters.directory>>
+          no_output_timeout: 30m
+          command: just check-no-std
+      - rust-save-build-cache: *no-std-cache-args
+
+  # Shared documentation build job
+  rust-ci-docs:
+    parameters:
+      directory:
+        description: "Directory containing the Cargo workspace"
+        type: string
+      command:
+        description: "Doc build command to run"
+        type: string
+        default: "cargo +nightly doc --workspace --all-features --no-deps --document-private-items"
+      rustdocflags:
+        description: "RUSTDOCFLAGS environment variable"
+        type: string
+        default: "--cfg docsrs -D warnings --show-type-layout --generate-link-to-definition -Zunstable-options"
+    docker:
+      - image: <<pipeline.parameters.default_docker_image>>
+    resource_class: xlarge
+    steps:
+      - utils/checkout-with-mise:
+          checkout-method: blobless
+      - rust-prepare-and-restore-cache: &docs-cache-args
+          directory: <<parameters.directory>>
+          prefix: <<parameters.directory>>-docs
+          features: "all"
+      - rust-install-toolchain:
+          channel: nightly
+          toolchain_version: nightly
+      - run:
+          name: Build documentation
+          working_directory: <<parameters.directory>>
+          no_output_timeout: 30m
+          environment:
+            RUSTDOCFLAGS: <<parameters.rustdocflags>>
+          command: <<parameters.command>>
+      - rust-save-build-cache: *docs-cache-args
+
+  # Shared doc test job
+  rust-ci-doctest:
+    parameters:
+      directory:
+        description: "Directory containing the Cargo workspace"
+        type: string
+      command:
+        description: "Doc test command to run"
+        type: string
+        default: "cargo test --workspace --doc"
+    docker:
+      - image: <<pipeline.parameters.default_docker_image>>
+    resource_class: xlarge
+    steps:
+      - utils/checkout-with-mise:
+          checkout-method: blobless
+      - rust-prepare-and-restore-cache: &doctest-cache-args
+          directory: <<parameters.directory>>
+          prefix: <<parameters.directory>>-doctest
+      - run:
+          name: Run doc tests
+          working_directory: <<parameters.directory>>
+          no_output_timeout: 30m
+          command: <<parameters.command>>
+      - rust-save-build-cache: *doctest-cache-args
+
+  # Shared cargo tests job
+  rust-ci-cargo-tests:
+    parameters:
+      directory:
+        description: "Directory containing the Cargo workspace"
+        type: string
+      command:
+        description: "Just recipe to run (e.g. test, test-integration)"
+        type: string
+        default: "test"
+      flags:
+        description: "Flags passed to just command (e.g. --all-features, --no-default-features)"
+        type: string
+        default: ""
+      rust_version:
+        description: "Rust toolchain version to use"
+        type: string
+        default: "stable"
+      cache_profile:
+        description: "Build profile for caching"
+        type: string
+        default: "release"
+    docker:
+      - image: <<pipeline.parameters.default_docker_image>>
+    resource_class: xlarge
+    steps:
+      - utils/checkout-with-mise:
+          checkout-method: blobless
+      - rust-prepare-and-restore-cache: &tests-cache-args
+          directory: <<parameters.directory>>
+          prefix: <<parameters.directory>>-tests
+          profile: <<parameters.cache_profile>>
+      - rust-install-toolchain:
+          toolchain_version: <<parameters.rust_version>>
+      - install-cargo-binstall
+      - run:
+          name: Install nextest
+          command: |
+            command -v cargo-nextest >/dev/null || cargo binstall --no-confirm cargo-nextest
+      - run:
+          name: Run cargo tests
+          working_directory: <<parameters.directory>>
+          no_output_timeout: 40m
+          command: just <<parameters.command>> <<parameters.flags>>
+      - rust-save-build-cache: *tests-cache-args
+
+  # Shared unused dependencies check job
+  rust-ci-udeps:
+    parameters:
+      directory:
+        description: "Directory containing the Cargo workspace"
+        type: string
+    docker:
+      - image: <<pipeline.parameters.default_docker_image>>
+    resource_class: xlarge
+    steps:
+      - utils/checkout-with-mise:
+          checkout-method: blobless
+      - rust-prepare-and-restore-cache: &udeps-cache-args
+          directory: <<parameters.directory>>
+          prefix: <<parameters.directory>>-udeps
+          profile: "release"
+      - rust-install-toolchain:
+          channel: nightly
+          toolchain_version: nightly
+      - install-cargo-binstall
+      - run:
+          name: Install cargo-udeps
+          command: |
+            command -v cargo-udeps >/dev/null || cargo binstall --no-confirm cargo-udeps
+      - run:
+          name: Check unused dependencies
+          working_directory: <<parameters.directory>>
+          no_output_timeout: 40m
+          command: just check-udeps
+      - rust-save-build-cache: *udeps-cache-args
+
+  # Shared cargo hack build job (cross-compile targets like WASM)
+  rust-ci-cargo-hack-build:
+    parameters:
+      directory:
+        description: "Directory containing the Cargo workspace"
+        type: string
+      target:
+        description: "Target architecture to build for (e.g. wasm32-unknown-unknown)"
+        type: string
+      flags:
+        description: "Flags appended to cargo hack build --target <target>"
+        type: string
+        default: "--workspace"
+    docker:
+      - image: <<pipeline.parameters.default_docker_image>>
+    resource_class: xlarge
+    steps:
+      - utils/checkout-with-mise:
+          checkout-method: blobless
+      - rust-prepare-and-restore-cache: &hack-build-cache-args
+          directory: <<parameters.directory>>
+          prefix: <<parameters.directory>>-hack-build
+      - rust-install-toolchain:
+          target: <<parameters.target>>
+      - install-cargo-binstall
+      - run:
+          name: Install cargo-hack
+          command: |
+            command -v cargo-hack >/dev/null || cargo binstall --no-confirm cargo-hack
+      - run:
+          name: Build for <<parameters.target>>
+          working_directory: <<parameters.directory>>
+          no_output_timeout: 40m
+          command: cargo hack build --target <<parameters.target>> <<parameters.flags>>
+      - rust-save-build-cache: *hack-build-cache-args
+
+  # Shared cargo hack job
+  rust-ci-cargo-hack:
+    parameters:
+      directory:
+        description: "Directory containing the Cargo workspace"
+        type: string
+      flags:
+        description: "Flags appended to cargo hack check (e.g. --feature-powerset --depth 2)"
+        type: string
+        default: "--feature-powerset --no-dev-deps --workspace"
+      parallelism:
+        description: "Number of parallel nodes (adds --partition automatically when > 1)"
+        type: integer
+        default: 1
+    docker:
+      - image: <<pipeline.parameters.default_docker_image>>
+    resource_class: xlarge
+    parallelism: <<parameters.parallelism>>
+    steps:
+      - utils/checkout-with-mise:
+          checkout-method: blobless
+      - rust-prepare-and-restore-cache: &hack-cache-args
+          directory: <<parameters.directory>>
+          prefix: <<parameters.directory>>-hack
+          features: "all"
+      - install-cargo-binstall
+      - run:
+          name: Install cargo-hack
+          command: |
+            command -v cargo-hack >/dev/null || cargo binstall --no-confirm cargo-hack
+      - run:
+          name: Run cargo hack
+          working_directory: <<parameters.directory>>
+          no_output_timeout: 60m
+          command: |
+            PARTITION_FLAG=""
+            if [ "$CIRCLE_NODE_TOTAL" -gt 1 ]; then
+              PARTITION_FLAG="--partition $((CIRCLE_NODE_INDEX + 1))/$CIRCLE_NODE_TOTAL"
+            fi
+            cargo hack check <<parameters.flags>> $PARTITION_FLAG
+      - rust-save-build-cache: *hack-cache-args

--- a/alloy-op-evm/justfile
+++ b/alloy-op-evm/justfile
@@ -1,0 +1,12 @@
+# default recipe to display help information
+default:
+  @just --list
+
+# Run cargo tests
+test *args='':
+  cargo nextest run --workspace {{args}}
+
+# Check no_std compatibility
+check-no-std:
+  rustup target add riscv32imac-unknown-none-elf
+  cargo check -p alloy-op-evm --target riscv32imac-unknown-none-elf --no-default-features

--- a/alloy-op-hardforks/Cargo.toml
+++ b/alloy-op-hardforks/Cargo.toml
@@ -33,6 +33,7 @@ auto_impl = "1"
 serde = { version = "1.0", features = ["derive", "alloc"], default-features = false, optional = true }
 
 [features]
+default = []
 serde = [
 	"dep:serde",
 	"alloy-hardforks/serde"

--- a/alloy-op-hardforks/justfile
+++ b/alloy-op-hardforks/justfile
@@ -1,0 +1,12 @@
+# default recipe to display help information
+default:
+  @just --list
+
+# Run cargo tests
+test *args='':
+  cargo test --workspace {{args}}
+
+# Check no_std compatibility
+check-no-std:
+  rustup target add riscv32imac-unknown-none-elf
+  cargo check --target riscv32imac-unknown-none-elf --no-default-features

--- a/op-alloy/Justfile
+++ b/op-alloy/Justfile
@@ -14,9 +14,9 @@ default:
 # Run all tests
 tests: test test-docs
 
-# Test for the native target with all features. By default, excludes online tests.
-test:
-  cargo nextest run --workspace --all --all-features
+# Test for the native target with optional flags.
+test *args='':
+  cargo nextest run --workspace {{args}}
 
 # Test the Rust documentation
 test-docs:
@@ -67,6 +67,11 @@ source:
 # Generate file bindings for super-registry
 bind:
   @just --justfile ./crates/registry/Justfile bind
+
+# Check no_std compatibility
+check-no-std:
+  rustup target add riscv32imac-unknown-none-elf
+  cargo check -p op-alloy -p op-alloy-consensus -p op-alloy-rpc-types -p op-alloy-rpc-types-engine --target riscv32imac-unknown-none-elf --no-default-features
 
 # List all available examples and run each one
 examples:

--- a/op-reth/justfile
+++ b/op-reth/justfile
@@ -1,0 +1,21 @@
+# default recipe to display help information
+default:
+  @just --list
+
+# Check for unused dependencies in the crate graph.
+check-udeps:
+  cargo +nightly udeps --workspace --lib --examples --tests --benches --all-features --locked
+
+# Run unit tests with optional edge storage feature
+test edge='':
+  #!/usr/bin/env bash
+  set -euo pipefail
+  RUST_BACKTRACE=1 cargo nextest run \
+    --features "asm-keccak {{edge}}" --locked \
+    --workspace \
+    --no-tests=warn \
+    -E "!kind(test) and not binary(e2e_testsuite)"
+
+# Run integration tests for reth-optimism-node
+test-integration:
+  RUST_BACKTRACE=1 cargo nextest run --locked -p reth-optimism-node


### PR DESCRIPTION
## Summary
- Refactors CircleCI configuration by extracting shared Rust CI logic into a common `rust-ci.yml` template
- Simplifies individual project CI configs (`alloy-op-evm`, `alloy-op-hardforks`, `kona`, `op-alloy`, `op-reth`) by reusing the shared template
- Adds `justfile` targets for `alloy-op-evm`, `alloy-op-hardforks`, and `op-reth`; updates `op-alloy` Justfile
- Fix the API triggers for the individual rust jobs (ensure that we can trigger rust jobs through the API correctly)

## Test plan
- [x] Verify CircleCI pipeline triggers correctly on each sub-project
- [x] Confirm shared `rust-ci.yml` jobs run as expected
- [x] Check that justfile commands work locally for each project

## Note
Should close https://github.com/ethereum-optimism/optimism/issues/18927?issue=ethereum-optimism%7Coptimism%7C18928

🤖 Generated with [Claude Code](https://claude.com/claude-code)