### PR TITLE
feat(op-deployer): add runWithBytes to missing contracts

### DIFF
--- a/packages/contracts-bedrock/scripts/deploy/DeployAlphabetVM.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployAlphabetVM.s.sol
@@ -29,6 +29,12 @@ contract DeployAlphabetVM is Script {
         output_.alphabetVM = alphabetVM;
     }
 
+    function runWithBytes(bytes memory _input) public returns (bytes memory) {
+        Input memory input = abi.decode(_input, (Input));
+        Output memory output = run(input);
+        return abi.encode(output);
+    }
+
     function assertValidInput(Input memory _input) private pure {
         require(_input.absolutePrestate != bytes32(0), "DeployAlphabetVM: absolutePrestate not set");
         require(address(_input.preimageOracle) != address(0), "DeployAlphabetVM: preimageOracle not set");

--- a/packages/contracts-bedrock/scripts/deploy/DeployAltDA.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployAltDA.s.sol
@@ -34,6 +34,12 @@ contract DeployAltDA is Script {
         assertValidOutput(_input, output_);
     }
 
+    function runWithBytes(bytes memory _input) public returns (bytes memory) {
+        Input memory input = abi.decode(_input, (Input));
+        Output memory output = run(input);
+        return abi.encode(output);
+    }
+
     function deployDataAvailabilityChallengeProxy(Input memory _input, Output memory _output) internal virtual {
         bytes32 salt = _input.salt;
         vm.broadcast(msg.sender);

--- a/packages/contracts-bedrock/scripts/deploy/DeployDisputeGame.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployDisputeGame.s.sol
@@ -54,6 +54,12 @@ contract DeployDisputeGame is Script {
         assertValidOutput(_input, output_);
     }
 
+    function runWithBytes(bytes memory _input) public returns (bytes memory) {
+        Input memory input = abi.decode(_input, (Input));
+        Output memory output = run(input);
+        return abi.encode(output);
+    }
+
     function deployDisputeGameImplV2(Input memory _input, Output memory _output) internal {
         // Shove the arguments into a struct to avoid stack-too-deep errors.
         IFaultDisputeGame.GameConstructorParams memory args = IFaultDisputeGame.GameConstructorParams({

--- a/packages/contracts-bedrock/scripts/deploy/DeployMIPS2.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployMIPS2.s.sol
@@ -33,6 +33,12 @@ contract DeployMIPS2 is Script {
         assertValidOutput(_input, output_);
     }
 
+    function runWithBytes(bytes memory _input) public returns (bytes memory) {
+        Input memory input = abi.decode(_input, (Input));
+        Output memory output = run(input);
+        return abi.encode(output);
+    }
+
     function deployMipsSingleton(Input memory _input, Output memory _output) internal {
         uint256 mipsVersion = _input.mipsVersion;
 

--- a/packages/contracts-bedrock/scripts/deploy/ReadSuperchainDeployment.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/ReadSuperchainDeployment.s.sol
@@ -87,4 +87,10 @@ contract ReadSuperchainDeployment is Script {
             output_.requiredProtocolVersion = bytes32(ProtocolVersion.unwrap(output_.protocolVersionsProxy.required()));
         }
     }
+
+    function runWithBytes(bytes memory _input) public returns (bytes memory) {
+        Input memory input = abi.decode(_input, (Input));
+        Output memory output = run(input);
+        return abi.encode(output);
+    }
 }


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Adds `runWithBytes(bytes memory _input)` to the contracts still not having that signature. Used for forge calls (same pattern as with other deployment contracts). 

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
