### PR TITLE
contracts: Switch DisputeGameFactory to use CREATE2 when creating games

### DIFF
--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -192,8 +192,8 @@
     "sourceCodeHash": "0xdebf2ab3af4d5549c40e9dd9db6b2458af286f323b6891f3b0c4e89f3c8928db"
   },
   "src/dispute/DisputeGameFactory.sol:DisputeGameFactory": {
-    "initCodeHash": "0xb7ef378c93102b733ec5e96f6448cdae0057b24be05ac99512fd155c0d7d3512",
-    "sourceCodeHash": "0xb6a8606b6849a28ee413d257a02732794e75165f40810ad1e0721204fce4ba36"
+    "initCodeHash": "0x534308ec135c86df2ea0d2f5f584e89b34f85dccb27349741bcba7e8d17bd8bc",
+    "sourceCodeHash": "0x7e68423e4c4ca7725a0c625aa3df9a3db0d7027eaddfdb2e7fa65329666b7a54"
   },
   "src/dispute/FaultDisputeGame.sol:FaultDisputeGame": {
     "initCodeHash": "0x2493823ad9fb986a696e61ce8a8ef50c548c6a4e0affeeec63edd119ca206083",

--- a/packages/contracts-bedrock/src/dispute/DisputeGameFactory.sol
+++ b/packages/contracts-bedrock/src/dispute/DisputeGameFactory.sol
@@ -56,8 +56,8 @@ contract DisputeGameFactory is ProxyAdminOwnedBase, ReinitializableBase, Ownable
     }
 
     /// @notice Semantic version.
-    /// @custom:semver 1.5.0
-    string public constant version = "1.5.0";
+    /// @custom:semver 1.6.0
+    string public constant version = "1.6.0";
 
     /// @notice `gameImpls` is a mapping that maps `GameType`s to their respective
     ///         `IDisputeGame` implementations.
@@ -165,7 +165,16 @@ contract DisputeGameFactory is ProxyAdminOwnedBase, ReinitializableBase, Ownable
         // Get the hash of the parent block.
         bytes32 parentHash = blockhash(block.number - 1);
 
-        if (gameArgs[_gameType].length == 0) {
+        // Compute the unique identifier for the dispute game.
+        Hash uuid = getGameUUID(_gameType, _rootClaim, _extraData);
+
+        // If a dispute game with the same UUID already exists, revert.
+        if (GameId.unwrap(_disputeGames[uuid]) != bytes32(0)) revert GameAlreadyExists(uuid);
+
+        // Cache the implementation args to avoid stack too deep.
+        bytes memory implArgs = gameArgs[_gameType];
+
+        if (implArgs.length == 0) {
             // Clone the implementation contract and initialize it with the given parameters.
             //
             // CWIA Calldata Layout:
@@ -177,7 +186,11 @@ contract DisputeGameFactory is ProxyAdminOwnedBase, ReinitializableBase, Ownable
             // │ [52, 84)             │ Parent block hash at creation time  │
             // │ [84, 84 + n)         │ Extra data (opaque)                 │
             // └──────────────────────┴─────────────────────────────────────┘
-            proxy_ = IDisputeGame(address(impl).clone(abi.encodePacked(msg.sender, _rootClaim, parentHash, _extraData)));
+            proxy_ = IDisputeGame(
+                address(impl).cloneDeterministic(
+                    abi.encodePacked(msg.sender, _rootClaim, parentHash, _extraData), Hash.unwrap(uuid)
+                )
+            );
         } else {
             // Clone the implementation contract and initialize it with the given parameters.
             //
@@ -193,18 +206,13 @@ contract DisputeGameFactory is ProxyAdminOwnedBase, ReinitializableBase, Ownable
             // │ [88 + n, 88 + n + m) │ Implementation args (opaque)        │
             // └──────────────────────┴─────────────────────────────────────┘
             proxy_ = IDisputeGame(
-                address(impl).clone(
-                    abi.encodePacked(msg.sender, _rootClaim, parentHash, _gameType, _extraData, gameArgs[_gameType])
+                address(impl).cloneDeterministic(
+                    abi.encodePacked(msg.sender, _rootClaim, parentHash, _gameType, _extraData, implArgs),
+                    Hash.unwrap(uuid)
                 )
             );
         }
         proxy_.initialize{ value: msg.value }();
-
-        // Compute the unique identifier for the dispute game.
-        Hash uuid = getGameUUID(_gameType, _rootClaim, _extraData);
-
-        // If a dispute game with the same UUID already exists, revert.
-        if (GameId.unwrap(_disputeGames[uuid]) != bytes32(0)) revert GameAlreadyExists(uuid);
 
         // Pack the game ID.
         GameId id = LibGameId.pack(_gameType, Timestamp.wrap(uint64(block.timestamp)), address(proxy_));

--- a/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
+++ b/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
@@ -567,6 +567,52 @@ contract DisputeGameFactory_Create_Test is DisputeGameFactory_TestInit {
         assertEq(Duration.unwrap(game_.clockExtension()), Duration.unwrap(Duration.wrap(3 hours)));
         assertEq(Duration.unwrap(game_.maxClockDuration()), Duration.unwrap(Duration.wrap(3.5 days)));
     }
+
+    /// @notice Tests that games get unique addresses based on their inputs (gameType, rootClaim, extraData)
+    ///         even when the factory's nonce is unchanged. This test would fail if CREATE was used instead
+    ///         of CREATE2, since CREATE only depends on deployer address and nonce.
+    function test_create_uniqueAddressFromInputs_succeeds() public {
+        // Set up the implementation for the game type
+        disputeGameFactory.setImplementation(GameTypes.CANNON, IDisputeGame(address(fakeClone)));
+        disputeGameFactory.setInitBond(GameTypes.CANNON, 0);
+
+        Claim rootClaim1 = changeClaimStatus(Claim.wrap(bytes32(uint256(1))), VMStatuses.INVALID);
+        Claim rootClaim2 = changeClaimStatus(Claim.wrap(bytes32(uint256(2))), VMStatuses.INVALID);
+
+        // Take a snapshot of the state before creating any games
+        uint256 snapshot = vm.snapshotState();
+
+        // Create game with first set of inputs and store address
+        address addr1 = address(disputeGameFactory.create(GameTypes.CANNON, rootClaim1, abi.encode(uint256(100))));
+
+        // Revert to the snapshot - this resets the factory's nonce to what it was before
+        vm.revertTo(snapshot);
+
+        // Create game with different rootClaim at the "same nonce"
+        address addr2 = address(disputeGameFactory.create(GameTypes.CANNON, rootClaim2, abi.encode(uint256(100))));
+
+        // The addresses should be different because CREATE2 uses the inputs (via UUID salt)
+        // With CREATE, these would be the same address since nonce is the same
+        assertTrue(addr1 != addr2, "Different rootClaim should produce different address");
+
+        // Revert again and test with different extraData
+        vm.revertTo(snapshot);
+        address addr3 = address(disputeGameFactory.create(GameTypes.CANNON, rootClaim1, abi.encode(uint256(200))));
+        assertTrue(addr1 != addr3, "Different extraData should produce different address");
+
+        // Revert again and test with different gameType
+        vm.revertTo(snapshot);
+        disputeGameFactory.setImplementation(GameTypes.PERMISSIONED_CANNON, IDisputeGame(address(fakeClone)));
+        disputeGameFactory.setInitBond(GameTypes.PERMISSIONED_CANNON, 0);
+        address addr4 =
+            address(disputeGameFactory.create(GameTypes.PERMISSIONED_CANNON, rootClaim1, abi.encode(uint256(100))));
+        assertTrue(addr1 != addr4, "Different gameType should produce different address");
+
+        // Finally, verify that same inputs at the "same nonce" produce the same address (deterministic)
+        vm.revertTo(snapshot);
+        address addr5 = address(disputeGameFactory.create(GameTypes.CANNON, rootClaim1, abi.encode(uint256(100))));
+        assertEq(addr1, addr5, "Same inputs should produce same address (CREATE2 is deterministic)");
+    }
 }
 
 /// @title DisputeGameFactory_SetImplementation_Test


### PR DESCRIPTION
**Description**

Switch `DisputeGameFactory` from using `CREATE` to `CREATE2` when creating games. This ensures that if there is a reorg and a game with different parameters is created at the index it will have a different address. 

**Tests**

Added contract test to confirm the address differs.  There's otherwise no change in behaviour and existing tests continue to pass.