### PR TITLE
chore(rust/zepter): unify zepter configs and fix outdated links

### DIFF
--- a/alloy-op-evm/.config/zepter.yaml
+++ b/alloy-op-evm/.config/zepter.yaml
@@ -13,11 +13,10 @@ workflows:
         "propagate-feature",
         # These are the features to check:
         "--features=std",
-        # Do not try to add a new section into `[features]` of `A` only because `B` expose that feature. There are edge-cases where this is still needed, but we can add them manually.
+        # Do not try to add a new section into `[features]` of `A` only because `B` exposes that feature. There are edge-cases where this is still needed, but we can add them manually.
         "--left-side-feature-missing=ignore",
-        # Ignore the case that `A` it outside of the workspace. Otherwise it will report errors in external dependencies that we have no influence on.
+        # Ignore the case that `A` is outside of the workspace. Otherwise it will report errors in external dependencies that we have no influence on.
         "--left-side-outside-workspace=ignore",
-        # limit to the workspace
         "--show-path",
         "--quiet",
       ]
@@ -28,7 +27,7 @@ workflows:
 # Will be displayed when any workflow fails:
 help:
   text: |
-    Alloy uses the Zepter CLI to detect abnormalities in Cargo features, e.g. missing propagation.
+    Optimism uses the Zepter CLI to detect abnormalities in Cargo features, e.g. missing propagation.
 
     It looks like one more checks failed; please check the console output.
 

--- a/alloy-op-hardforks/.config/zepter.yaml
+++ b/alloy-op-hardforks/.config/zepter.yaml
@@ -13,11 +13,11 @@ workflows:
         "propagate-feature",
         # These are the features to check:
         "--features=std,serde",
-        # Do not try to add a new section into `[features]` of `A` only because `B` expose that feature. There are edge-cases where this is still needed, but we can add them manually.
+        # Do not try to add a new section into `[features]` of `A` only because `B` exposes that feature. There are edge-cases where this is still needed, but we can add them manually.
         "--left-side-feature-missing=ignore",
-        # Ignore the case that `A` it outside of the workspace. Otherwise it will report errors in external dependencies that we have no influence on.
+        # Ignore the case that `A` is outside of the workspace. Otherwise it will report errors in external dependencies that we have no influence on.
         "--left-side-outside-workspace=ignore",
-        # limit to the workspace
+        # Limit to the workspace.
         "--workspace",
         "--show-path",
         "--quiet",
@@ -29,7 +29,7 @@ workflows:
 # Will be displayed when any workflow fails:
 help:
   text: |
-    Alloy uses the Zepter CLI to detect abnormalities in Cargo features, e.g. missing propagation.
+    Optimism uses the Zepter CLI to detect abnormalities in Cargo features, e.g. missing propagation.
 
     It looks like one more checks failed; please check the console output.
 

--- a/kona/.config/zepter.yaml
+++ b/kona/.config/zepter.yaml
@@ -33,7 +33,7 @@ workflows:
 # Will be displayed when any workflow fails:
 help:
   text: |
-    Kona uses the Zepter CLI to detect abnormalities in Cargo features, e.g. missing propagation.
+    Optimism uses the Zepter CLI to detect abnormalities in Cargo features, e.g. missing propagation.
 
     It looks like one more checks failed; please check the console output.
 

--- a/op-alloy/.config/zepter.yaml
+++ b/op-alloy/.config/zepter.yaml
@@ -17,7 +17,7 @@ workflows:
         "--left-side-feature-missing=ignore",
         # Ignore the case that `A` is outside of the workspace. Otherwise it will report errors in external dependencies that we have no influence on.
         "--left-side-outside-workspace=ignore",
-        # limit to the workspace
+        # Limit to the workspace.
         "--workspace",
         "--show-path",
         "--quiet",
@@ -29,11 +29,10 @@ workflows:
 # Will be displayed when any workflow fails:
 help:
   text: |
-    Maili uses the Zepter CLI to detect abnormalities in Cargo features, e.g. missing propagation.
+    Optimism uses the Zepter CLI to detect abnormalities in Cargo features, e.g. missing propagation.
 
     It looks like one more checks failed; please check the console output.
 
     You can try to automatically address them by installing zepter (`cargo install zepter --locked`) and simply running `zepter` in the workspace root.
   links:
-    - "https://github.com/op-rs/maili/pull/134"
     - "https://github.com/ggwpez/zepter"

--- a/op-reth/.config/zepter.yaml
+++ b/op-reth/.config/zepter.yaml
@@ -13,10 +13,9 @@ workflows:
         "propagate-feature",
         # These are the features to check:
         "--features=std,op,dev,asm-keccak,jemalloc,jemalloc-prof,tracy-allocator,tracy,serde-bincode-compat,serde,test-utils,arbitrary,bench,alloy-compat,min-error-logs,min-warn-logs,min-info-logs,min-debug-logs,min-trace-logs,otlp,otlp-logs,js-tracer,portable,keccak-cache-global",
-        # Do not try to add a new section to `[features]` of `A` only because `B` exposes that feature. There are edge-cases where this is still needed, but we can add them manually.
+        # Do not try to add a new section into `[features]` of `A` only because `B` exposes that feature. There are edge-cases where this is still needed, but we can add them manually.
         "--left-side-feature-missing=ignore",
-        # Ignore the case that `A` it outside of the workspace. Otherwise it will report errors in external dependencies that we have no influence on.
-
+        # Ignore the case that `A` is outside of the workspace. Otherwise it will report errors in external dependencies that we have no influence on.
         "--left-side-outside-workspace=ignore",
         # Auxiliary flags:
         "--offline",
@@ -31,11 +30,10 @@ workflows:
 # Will be displayed when any workflow fails:
 help:
   text: |
-    Reth uses the Zepter CLI to detect abnormalities in Cargo features, e.g. missing propagation.
+    Optimism uses the Zepter CLI to detect abnormalities in Cargo features, e.g. missing propagation.
 
     It looks like one more checks failed; please check the console output.
 
     You can try to automatically address them by installing zepter (`cargo install zepter --locked`) and simply running `zepter` in the workspace root.
   links:
-    - "https://github.com/paradigmxyz/reth/pull/11888"
     - "https://github.com/ggwpez/zepter"


### PR DESCRIPTION
## Description

A really small PR to fix/unify comments on the zepter configs for the rust stack. We cannot do much more than that on https://github.com/ethereum-optimism/optimism/issues/18927?issue=ethereum-optimism%7Coptimism%7C18931 because each crate expose different feature sets that are hardcoded in the zepter configs