### PR TITLE
docs: add status badges to readme header

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
   <br />
   <h3><a href="https://optimism.io">Optimism</a> is Ethereum, scaled.</h3>
   <br />
+  <a href="https://discord.gg/optimism"><img src="https://img.shields.io/discord/667044843901681675.svg?label=Discord&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2" alt="Discord"></a>
+  <a href="https://twitter.com/Optimism"><img src="https://img.shields.io/twitter/follow/Optimism?style=social" alt="Twitter"></a>
+  <a href="https://github.com/ethereum-optimism/optimism/blob/master/LICENSE"><img src="https://img.shields.io/github/license/ethereum-optimism/optimism" alt="License"></a>
+  <br />
 </div>
 
 **Table of Contents**

--- a/README.md
+++ b/README.md
@@ -70,13 +70,16 @@ The Optimism Immunefi program offers up to $2,000,042 for in-scope critical vuln
 ├── <a href="./cannon">cannon</a>: Onchain MIPS instruction emulator for fault proofs
 ├── <a href="./devnet-sdk">devnet-sdk</a>: Comprehensive toolkit for standardized devnet interactions
 ├── <a href="./docs">docs</a>: A collection of documents including audits and post-mortems
+├── <a href="./kona">kona</a>: Rust implementation of the OP Stack rollup state transition
 ├── <a href="./kurtosis-devnet">kurtosis-devnet</a>: OP-Stack Kurtosis devnet
 ├── <a href="./op-acceptance-tests">op-acceptance-tests</a>: Acceptance tests and configuration for OP Stack
+├── <a href="./op-alloy">op-alloy</a>: Alloy definitions for Optimism
 ├── <a href="./op-alt-da">op-alt-da</a>: Alternative Data Availability mode (beta)
 ├── <a href="./op-batcher">op-batcher</a>: L2-Batch Submitter, submits bundles of batches to L1
 ├── <a href="./op-chain-ops">op-chain-ops</a>: State surgery utilities
 ├── <a href="./op-challenger">op-challenger</a>: Dispute game challenge agent
 ├── <a href="./op-conductor">op-conductor</a>: High-availability sequencer service
+├── <a href="./op-core">op-core</a>: Core shared types and predeploys
 ├── <a href="./op-deployer">op-deployer</a>: CLI tool for deploying and upgrading OP Stack smart contracts
 ├── <a href="./op-devstack">op-devstack</a>: Flexible test frontend for integration and acceptance testing
 ├── <a href="./op-dispute-mon">op-dispute-mon</a>: Off-chain service to monitor dispute games
@@ -90,6 +93,7 @@ The Optimism Immunefi program offers up to $2,000,042 for in-scope critical vuln
 ├── <a href="./op-program">op-program</a>: Fault proof program
 ├── <a href="./op-proposer">op-proposer</a>: L2-Output Submitter, submits proposals to L1
 ├── <a href="./op-service">op-service</a>: Common codebase utilities
+├── <a href="./op-supernode">op-supernode</a>: Scalable chain container framework
 ├── <a href="./op-supervisor">op-supervisor</a>: Service to monitor chains and determine cross-chain message safety
 ├── <a href="./op-sync-tester">op-sync-tester</a>: Sync testing utilities
 ├── <a href="./op-test-sequencer">op-test-sequencer</a>: Test sequencer for development
@@ -100,7 +104,6 @@ The Optimism Immunefi program offers up to $2,000,042 for in-scope critical vuln
 ├── <a href="./packages">packages</a>
 │   ├── <a href="./packages/contracts-bedrock">contracts-bedrock</a>: OP Stack smart contracts
 </pre>
-
 ## Development and Release Process
 
 ### Overview


### PR DESCRIPTION
Added standard status badges (Discord, Twitter, License) to the header for better project visibility and quick access to community links.
