### PR TITLE
op-acceptance: Change to creating super cannon kona games

### DIFF
--- a/op-acceptance-tests/tests/interop/proofs/challenger_test.go
+++ b/op-acceptance-tests/tests/interop/proofs/challenger_test.go
@@ -25,7 +25,7 @@ func TestChallengerPlaysGame(gt *testing.T) {
 	badClaim := common.HexToHash("0xdeadbeef00000000000000000000000000000000000000000000000000000000")
 	attacker := sys.FunderL1.NewFundedEOA(eth.Ether(15))
 	dgf := sys.DisputeGameFactory()
-	game := dgf.StartSuperCannonGame(attacker, proofs.WithSuperRootFrom(eth.Bytes32(badClaim), eth.Bytes32(badClaim)))
+	game := dgf.StartSuperCannonKonaGame(attacker, proofs.WithSuperRootFrom(eth.Bytes32(badClaim), eth.Bytes32(badClaim)))
 
 	claim := game.RootClaim()                   // This is the bad claim from attacker
 	counterClaim := claim.WaitForCounterClaim() // This is the counter-claim from the challenger
@@ -47,7 +47,7 @@ func TestChallengerRespondsToMultipleInvalidClaims(gt *testing.T) {
 	attacker := sys.FunderL1.NewFundedEOA(eth.TenEther)
 	dgf := sys.DisputeGameFactory()
 
-	game := dgf.StartSuperCannonGame(attacker)
+	game := dgf.StartSuperCannonKonaGame(attacker)
 	claims := game.PerformMoves(attacker,
 		proofs.Move(0, common.Hash{0x01}, true),
 		proofs.Move(1, common.Hash{0x03}, true),
@@ -70,7 +70,7 @@ func TestChallengerRespondsToMultipleInvalidClaimsEOA(gt *testing.T) {
 	dgf := sys.DisputeGameFactory()
 	attacker := dgf.CreateHelperEOA(sys.FunderL1.NewFundedEOA(eth.TenEther))
 
-	game := dgf.StartSuperCannonGame(attacker.EOA)
+	game := dgf.StartSuperCannonKonaGame(attacker.EOA)
 	claims := attacker.PerformMoves(game.FaultDisputeGame,
 		proofs.Move(0, common.Hash{0x01}, true),
 		proofs.Move(1, common.Hash{0x03}, true),

--- a/op-acceptance-tests/tests/isthmus/preinterop/challenger_test.go
+++ b/op-acceptance-tests/tests/isthmus/preinterop/challenger_test.go
@@ -25,7 +25,7 @@ func TestChallengerPlaysGame(gt *testing.T) {
 	attacker := sys.FunderL1.NewFundedEOA(eth.Ether(15))
 	dgf := sys.DisputeGameFactory()
 
-	game := dgf.StartSuperCannonGame(attacker, proofs.WithSuperRootFrom(eth.Bytes32(badClaim), eth.Bytes32(badClaim)))
+	game := dgf.StartSuperCannonKonaGame(attacker, proofs.WithSuperRootFrom(eth.Bytes32(badClaim), eth.Bytes32(badClaim)))
 
 	claim := game.RootClaim()                   // This is the bad claim from attacker
 	counterClaim := claim.WaitForCounterClaim() // This is the counter-claim from the challenger

--- a/op-acceptance-tests/tests/isthmus/preinterop/init_test.go
+++ b/op-acceptance-tests/tests/isthmus/preinterop/init_test.go
@@ -4,8 +4,13 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
 )
 
 func TestMain(m *testing.M) {
-	presets.DoMain(m, presets.WithIsthmusSuperSupernode())
+	presets.DoMain(m,
+		presets.WithIsthmusSuperSupernode(),
+		stack.MakeCommon(sysgo.WithChallengerCannonKonaEnabled()),
+	)
 }

--- a/op-devstack/dsl/proofs/dispute_game_factory.go
+++ b/op-devstack/dsl/proofs/dispute_game_factory.go
@@ -190,13 +190,13 @@ func (f *DisputeGameFactory) WaitForGame() *FaultDisputeGame {
 	return f.GameAtIndex(initialCount)
 }
 
-func (f *DisputeGameFactory) StartSuperCannonGame(eoa *dsl.EOA, opts ...GameOpt) *SuperFaultDisputeGame {
+func (f *DisputeGameFactory) StartSuperCannonKonaGame(eoa *dsl.EOA, opts ...GameOpt) *SuperFaultDisputeGame {
 	f.require.NotNil(f.superNode, "super node is required to start super games")
 
-	return f.startSuperCannonGameOfType(eoa, gameTypes.SuperCannonGameType, opts...)
+	return f.startSuperGameOfType(eoa, gameTypes.SuperCannonKonaGameType, opts...)
 }
 
-func (f *DisputeGameFactory) startSuperCannonGameOfType(eoa *dsl.EOA, gameType gameTypes.GameType, opts ...GameOpt) *SuperFaultDisputeGame {
+func (f *DisputeGameFactory) startSuperGameOfType(eoa *dsl.EOA, gameType gameTypes.GameType, opts ...GameOpt) *SuperFaultDisputeGame {
 	cfg := NewGameCfg(opts...)
 	if len(cfg.superOutputRoots) != 0 && cfg.rootClaimSet {
 		f.t.Error("cannot set both super output roots and root claim in super game")
@@ -274,13 +274,13 @@ func (f *DisputeGameFactory) honestTraceForGame(game *FaultDisputeGame) challeng
 			f.challengerCfg.CannonKona,
 			vm.NewKonaExecutor(),
 		)
-	case gameTypes.SuperCannonGameType:
+	case gameTypes.SuperCannonKonaGameType:
 		return f.honestSuperCannonTrace(
 			game,
-			f.challengerCfg.CannonAbsolutePreStateBaseURL,
-			f.challengerCfg.CannonAbsolutePreState,
-			f.challengerCfg.Cannon,
-			vm.NewOpProgramServerExecutor(f.log),
+			f.challengerCfg.CannonKonaAbsolutePreStateBaseURL,
+			f.challengerCfg.CannonKonaAbsolutePreState,
+			f.challengerCfg.CannonKona,
+			vm.NewKonaSuperExecutor(),
 		)
 	default:
 		f.require.Truef(false, "Honest trace not supported for game type %v", game.GameType())

--- a/op-devstack/shared/challenger/challenger.go
+++ b/op-devstack/shared/challenger/challenger.go
@@ -87,8 +87,14 @@ func applyCannonKonaConfig(c *config.Config, rollupCfgs []*rollup.Config, l1Gene
 	}
 	if interop {
 		c.CannonKonaAbsolutePreStateBaseURL, err = url.Parse("file:" + absRoot + "/kona/prestate-artifacts-cannon-interop")
+		if err != nil {
+			return err
+		}
 	} else {
 		c.CannonKonaAbsolutePreStateBaseURL, err = url.Parse("file:" + absRoot + "/kona/prestate-artifacts-cannon")
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/op-devstack/shared/challenger/challenger.go
+++ b/op-devstack/shared/challenger/challenger.go
@@ -72,7 +72,7 @@ func applyCannonConfig(c *config.Config, rollupCfgs []*rollup.Config, l1Genesis 
 	return nil
 }
 
-func applyCannonKonaConfig(c *config.Config, rollupCfgs []*rollup.Config, l1Genesis *core.Genesis, l2Geneses []*core.Genesis) error {
+func applyCannonKonaConfig(c *config.Config, rollupCfgs []*rollup.Config, l1Genesis *core.Genesis, l2Geneses []*core.Genesis, interop bool) error {
 	root, err := findMonorepoRoot()
 	if err != nil {
 		return err
@@ -85,9 +85,10 @@ func applyCannonKonaConfig(c *config.Config, rollupCfgs []*rollup.Config, l1Gene
 	if err != nil {
 		return fmt.Errorf("failed to get absolute path to prestate dir: %w", err)
 	}
-	c.CannonKonaAbsolutePreStateBaseURL, err = url.Parse("file:" + absRoot + "/kona/prestate-artifacts-cannon")
-	if err != nil {
-		return fmt.Errorf("failed to create kona prestates url: %w", err)
+	if interop {
+		c.CannonKonaAbsolutePreStateBaseURL, err = url.Parse("file:" + absRoot + "/kona/prestate-artifacts-cannon-interop")
+	} else {
+		c.CannonKonaAbsolutePreStateBaseURL, err = url.Parse("file:" + absRoot + "/kona/prestate-artifacts-cannon")
 	}
 	return nil
 }
@@ -150,7 +151,13 @@ func WithCannonConfig(rollupCfgs []*rollup.Config, l1Genesis *core.Genesis, l2Ge
 
 func WithCannonKonaConfig(rollupCfgs []*rollup.Config, l1Genesis *core.Genesis, l2Geneses []*core.Genesis) Option {
 	return func(c *config.Config) error {
-		return applyCannonKonaConfig(c, rollupCfgs, l1Genesis, l2Geneses)
+		return applyCannonKonaConfig(c, rollupCfgs, l1Genesis, l2Geneses, false)
+	}
+}
+
+func WithCannonKonaInteropConfig(rollupCfgs []*rollup.Config, l1Genesis *core.Genesis, l2Geneses []*core.Genesis) Option {
+	return func(c *config.Config) error {
+		return applyCannonKonaConfig(c, rollupCfgs, l1Genesis, l2Geneses, true)
 	}
 }
 

--- a/op-devstack/sysgo/l2_challenger.go
+++ b/op-devstack/sysgo/l2_challenger.go
@@ -168,7 +168,7 @@ func WithL2ChallengerPostDeploy(orch *Orchestrator, challengerID stack.L2Challen
 		}
 		if orch.l2ChallengerOpts.useCannonKonaConfig {
 			options = append(options,
-				shared.WithCannonKonaConfig(rollupCfgs, l1Genesis, l2Geneses),
+				shared.WithCannonKonaInteropConfig(rollupCfgs, l1Genesis, l2Geneses),
 				shared.WithSuperCannonKonaGameType(),
 			)
 		}


### PR DESCRIPTION
**Description**

Change op-acceptance to create super cannon-kona games instead of super cannon. We only intend to support cannon-kona with interop.

**Additional context**

Builds on https://github.com/ethereum-optimism/optimism/pull/18978

