### PR TITLE
devstack: Ensure Supernode is exposed in the sysgo system

### DIFF
--- a/op-devstack/shim/supernode.go
+++ b/op-devstack/shim/supernode.go
@@ -1,0 +1,42 @@
+package shim
+
+import (
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-service/apis"
+	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/sources"
+)
+
+type SuperNodeConfig struct {
+	CommonConfig
+	ID     stack.SupernodeID
+	Client client.RPC
+}
+
+type rpcSuperNode struct {
+	commonImpl
+	id stack.SupernodeID
+
+	client client.RPC
+	api    apis.SupernodeQueryAPI
+}
+
+var _ stack.Supernode = (*rpcSuperNode)(nil)
+
+func NewSuperNode(cfg SuperNodeConfig) stack.Supernode {
+	cfg.T = cfg.T.WithCtx(stack.ContextWithID(cfg.T.Ctx(), cfg.ID))
+	return &rpcSuperNode{
+		commonImpl: newCommon(cfg.CommonConfig),
+		id:         cfg.ID,
+		client:     cfg.Client,
+		api:        sources.NewSuperNodeClient(cfg.Client),
+	}
+}
+
+func (r *rpcSuperNode) ID() stack.SupernodeID {
+	return r.id
+}
+
+func (r *rpcSuperNode) QueryAPI() apis.SupernodeQueryAPI {
+	return r.api
+}

--- a/op-devstack/shim/system.go
+++ b/op-devstack/shim/system.go
@@ -33,6 +33,7 @@ type presetSystem struct {
 	networks locks.RWMap[eth.ChainID, stack.Network]
 
 	supervisors locks.RWMap[stack.SupervisorID, stack.Supervisor]
+	supernodes  locks.RWMap[stack.SupernodeID, stack.Supernode]
 	sequencers  locks.RWMap[stack.TestSequencerID, stack.TestSequencer]
 	syncTesters locks.RWMap[stack.SyncTesterID, stack.SyncTester]
 }
@@ -111,6 +112,16 @@ func (p *presetSystem) AddSupervisor(v stack.Supervisor) {
 	p.require().True(p.supervisors.SetIfMissing(v.ID(), v), "supervisor %s must not already exist", v.ID())
 }
 
+func (p *presetSystem) Supernode(m stack.SupernodeMatcher) stack.Supernode {
+	v, ok := findMatch(m, p.supernodes.Get, p.Supernodes)
+	p.require().True(ok, "must find supernode %s", m)
+	return v
+}
+
+func (p *presetSystem) AddSupernode(v stack.Supernode) {
+	p.require().True(p.supernodes.SetIfMissing(v.ID(), v), "supernode %s must not already exist", v.ID())
+}
+
 func (p *presetSystem) TestSequencer(m stack.TestSequencerMatcher) stack.TestSequencer {
 	v, ok := findMatch(m, p.sequencers.Get, p.TestSequencers)
 	p.require().True(ok, "must find sequencer %s", m)
@@ -163,6 +174,10 @@ func (p *presetSystem) SupervisorIDs() []stack.SupervisorID {
 
 func (p *presetSystem) Supervisors() []stack.Supervisor {
 	return stack.SortSupervisors(p.supervisors.Values())
+}
+
+func (p *presetSystem) Supernodes() []stack.Supernode {
+	return stack.SortSupernodes(p.supernodes.Values())
 }
 
 func (p *presetSystem) TestSequencers() []stack.TestSequencer {

--- a/op-devstack/stack/match/first.go
+++ b/op-devstack/stack/match/first.go
@@ -10,6 +10,7 @@ var FirstL2Challenger = First[stack.L2ChallengerID, stack.L2Challenger]()
 
 var FirstTestSequencer = First[stack.TestSequencerID, stack.TestSequencer]()
 var FirstSupervisor = First[stack.SupervisorID, stack.Supervisor]()
+var FirstSupernode = First[stack.SupernodeID, stack.Supernode]()
 
 var FirstL1EL = First[stack.L1ELNodeID, stack.L1ELNode]()
 var FirstL1CL = First[stack.L1CLNodeID, stack.L1CLNode]()

--- a/op-devstack/stack/supernode.go
+++ b/op-devstack/stack/supernode.go
@@ -1,9 +1,11 @@
 package stack
 
 import (
+	"fmt"
 	"log/slog"
 
 	"github.com/ethereum-optimism/optimism/op-service/apis"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
 // SupernodeID identifies a Supernode by name, is type-safe, and can be value-copied and used as map key.
@@ -12,6 +14,14 @@ type SupernodeID genericID
 var _ GenericID = (*SupernodeID)(nil)
 
 const SupernodeKind Kind = "Supernode"
+
+func NewSupernodeID(key string, chains ...eth.ChainID) SupernodeID {
+	var s string
+	for _, chain := range chains {
+		s += chain.String()
+	}
+	return SupernodeID(fmt.Sprintf("%s-%s", key, s))
+}
 
 func (id SupernodeID) String() string {
 	return genericID(id).string(SupernodeKind)

--- a/op-devstack/stack/system.go
+++ b/op-devstack/stack/system.go
@@ -18,6 +18,7 @@ type System interface {
 	Network(id eth.ChainID) Network
 
 	Supervisor(m SupervisorMatcher) Supervisor
+	Supernode(m SupernodeMatcher) Supernode
 	TestSequencer(id TestSequencerMatcher) TestSequencer
 
 	SuperchainIDs() []SuperchainID
@@ -31,6 +32,7 @@ type System interface {
 	L1Networks() []L1Network
 	L2Networks() []L2Network
 	Supervisors() []Supervisor
+	Supernodes() []Supernode
 	TestSequencers() []TestSequencer
 }
 
@@ -44,6 +46,7 @@ type ExtensibleSystem interface {
 	AddL1Network(v L1Network)
 	AddL2Network(v L2Network)
 	AddSupervisor(v Supervisor)
+	AddSupernode(v Supernode)
 	AddTestSequencer(v TestSequencer)
 	AddSyncTester(v SyncTester)
 }

--- a/op-devstack/sysgo/l1_nodes.go
+++ b/op-devstack/sysgo/l1_nodes.go
@@ -131,8 +131,11 @@ func WithL1NodesInProcess(l1ELID stack.L1ELNodeID, l1CLID stack.L1CLNodeID) stac
 		})
 
 		l1ELNode := &L1Geth{
-			id:       l1ELID,
-			userRPC:  l1Geth.Node.HTTPEndpoint(),
+			id: l1ELID,
+			// Use WS for user RPC so op-node components (and op-supernode virtual nodes)
+			// can subscribe to L1 head updates. Using HTTP here causes HeadL1 to remain zero,
+			// which can stall components like the batcher that wait for initialized sync status.
+			userRPC:  firstNonEmpty(l1Geth.Node.WSEndpoint(), l1Geth.Node.HTTPEndpoint()),
 			authRPC:  l1Geth.Node.HTTPAuthEndpoint(),
 			l1Geth:   l1Geth,
 			blobPath: blobPath,
@@ -147,6 +150,15 @@ func WithL1NodesInProcess(l1ELID stack.L1ELNodeID, l1CLID stack.L1CLNodeID) stac
 		}
 		require.True(orch.l1CLs.SetIfMissing(l1CLID, l1CLNode), "must not already exist")
 	})
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
 }
 
 // WithExtL1Nodes initializes L1 EL and CL nodes that connect to external RPC endpoints

--- a/op-devstack/sysgo/l2_cl.go
+++ b/op-devstack/sysgo/l2_cl.go
@@ -111,7 +111,8 @@ func WithL2CLNode(l2CLID stack.L2CLNodeID, l1CLID stack.L1CLNodeID, l1ELID stack
 	case "kona":
 		return WithKonaNode(l2CLID, l1CLID, l1ELID, l2ELID, opts...)
 	case "supernode":
-		return WithSuperNode(l2CLID, l1CLID, l1ELID, l2ELID, opts...)
+		var supe stack.SupernodeID // unused; this option is only used for CL tests that don't care about a supernode running
+		return WithSupernode(supe, l2CLID, l1CLID, l1ELID, l2ELID, opts...)
 	default:
 		return WithOpNode(l2CLID, l1CLID, l1ELID, l2ELID, opts...)
 	}

--- a/op-devstack/sysgo/l2_cl_supernode.go
+++ b/op-devstack/sysgo/l2_cl_supernode.go
@@ -3,6 +3,7 @@ package sysgo
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strconv"
 	"sync"
 	"time"
@@ -26,12 +27,13 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/sources"
 	snconfig "github.com/ethereum-optimism/optimism/op-supernode/config"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
 )
 
 type SuperNode struct {
 	mu sync.Mutex
 
-	id               stack.L2CLNodeID
+	id               stack.SupernodeID
 	sn               *supernode.Supernode
 	cancel           context.CancelFunc
 	userRPC          string
@@ -39,7 +41,8 @@ type SuperNode struct {
 	interopJwtSecret eth.Bytes32
 	p                devtest.P
 	logger           log.Logger
-	el               *stack.L2ELNodeID // Optional: nil when using SyncTester
+	els              []*stack.L2ELNodeID // Optional: nil when using SyncTester
+	chains           []eth.ChainID
 	l1UserRPC        string
 	l1BeaconAddr     string
 }
@@ -52,20 +55,28 @@ func (n *SuperNode) hydrate(system stack.ExtensibleSystem) {
 	require.NoError(err)
 	system.T().Cleanup(rpcCl.Close)
 
-	sysL2CL := shim.NewL2CLNode(shim.L2CLNodeConfig{
-		CommonConfig:     shim.NewCommonConfig(system.T()),
-		ID:               n.id,
-		Client:           rpcCl,
-		UserRPC:          n.userRPC,
-		InteropEndpoint:  n.interopEndpoint,
-		InteropJwtSecret: n.interopJwtSecret,
-	})
-	sysL2CL.SetLabel(match.LabelVendor, string(match.OpNode))
-	l2Net := system.L2Network(stack.L2NetworkID(n.id.ChainID()))
-	l2Net.(stack.ExtensibleL2Network).AddL2CLNode(sysL2CL)
-	if n.el != nil {
-		sysL2CL.(stack.LinkableL2CLNode).LinkEL(l2Net.L2ELNode(n.el))
-	}
+	/*
+		sysL2CL := shim.NewL2CLNode(shim.L2CLNodeConfig{
+			CommonConfig:     shim.NewCommonConfig(system.T()),
+			ID:               n.id,
+			Client:           rpcCl,
+			UserRPC:          n.userRPC,
+			InteropEndpoint:  n.interopEndpoint,
+			InteropJwtSecret: n.interopJwtSecret,
+		})
+		sysL2CL.SetLabel(match.LabelVendor, string(match.OpNode))
+		l2Net := system.L2Network(stack.L2NetworkID(n.id.ChainID()))
+		l2Net.(stack.ExtensibleL2Network).AddL2CLNode(sysL2CL)
+		if n.el != nil {
+			sysL2CL.(stack.LinkableL2CLNode).LinkEL(l2Net.L2ELNode(n.el))
+		}
+	*/
+
+	system.AddSupernode(shim.NewSuperNode(shim.SuperNodeConfig{
+		CommonConfig: shim.NewCommonConfig(system.T()),
+		ID:           n.id,
+		Client:       rpcCl,
+	}))
 }
 
 func (n *SuperNode) UserRPC() string {
@@ -84,9 +95,15 @@ func (n *SuperNode) Start() {
 		return
 	}
 
+	n.p.Require().NotEmpty(n.chains, "supernode has no chains configured")
+	chainIDs := make([]uint64, 0, len(n.chains))
+	for _, id := range n.chains {
+		chainIDs = append(chainIDs, eth.EvilChainIDToUInt64(id))
+	}
+
 	// Build CLI config for supernode (single-chain)
 	cfg := &snconfig.CLIConfig{
-		Chains:       []uint64{eth.EvilChainIDToUInt64(n.id.ChainID())},
+		Chains:       chainIDs,
 		DataDir:      n.p.TempDir(),
 		L1NodeAddr:   n.l1UserRPC,
 		L1BeaconAddr: n.l1BeaconAddr,
@@ -142,10 +159,10 @@ func (n *SuperNode) Stop() {
 	n.sn = nil
 }
 
-// WithSuperNode constructs a Supernode-based L2 CL node
-func WithSuperNode(l2CLID stack.L2CLNodeID, l1CLID stack.L1CLNodeID, l1ELID stack.L1ELNodeID, l2ELID stack.L2ELNodeID, opts ...L2CLOption) stack.Option[*Orchestrator] {
+// WithSupernode constructs a Supernode-based L2 CL node
+func WithSupernode(supernodeID stack.SupernodeID, l2CLID stack.L2CLNodeID, l1CLID stack.L1CLNodeID, l1ELID stack.L1ELNodeID, l2ELID stack.L2ELNodeID, opts ...L2CLOption) stack.Option[*Orchestrator] {
 	args := []L2CLs{{CLID: l2CLID, ELID: l2ELID}}
-	return WithSharedSupernodeCLs(args, l1CLID, l1ELID)
+	return WithSharedSupernodeCLs(supernodeID, args, l1CLID, l1ELID)
 }
 
 // SuperNodeProxy is a thin wrapper that points to a shared supernode instance.
@@ -196,7 +213,7 @@ type L2CLs struct {
 }
 
 // WithSharedSupernodeCLs starts one supernode for N L2 chains and registers thin L2CL wrappers.
-func WithSharedSupernodeCLs(cls []L2CLs, l1CLID stack.L1CLNodeID, l1ELID stack.L1ELNodeID) stack.Option[*Orchestrator] {
+func WithSharedSupernodeCLs(supernodeID stack.SupernodeID, cls []L2CLs, l1CLID stack.L1CLNodeID, l1ELID stack.L1ELNodeID) stack.Option[*Orchestrator] {
 	return stack.AfterDeploy(func(orch *Orchestrator) {
 		p := orch.P()
 		require := p.Require()
@@ -215,9 +232,13 @@ func WithSharedSupernodeCLs(cls []L2CLs, l1CLID stack.L1CLNodeID, l1ELID stack.L
 		logger := p.Logger()
 
 		// Build per-chain op-node configs
-		makeNodeCfg := func(l2Net *L2Network, l2EL L2ELNode, isSequencer bool) *config.Config {
+		makeNodeCfg := func(l2Net *L2Network, l2ChainID eth.ChainID, l2EL L2ELNode, isSequencer bool) *config.Config {
 			interopCfg := &interop.Config{}
 			l2EngineAddr := l2EL.EngineRPC()
+			var depSet depset.DependencySet
+			if cluster, ok := orch.ClusterForL2(l2ChainID); ok {
+				depSet = cluster.DepSet()
+			}
 			return &config.Config{
 				L1: &config.L1EndpointConfig{
 					L1NodeAddr:       l1EL.UserRPC(),
@@ -234,6 +255,7 @@ func WithSharedSupernodeCLs(cls []L2CLs, l1CLID stack.L1CLNodeID, l1ELID stack.L
 					L2EngineAddr:      l2EngineAddr,
 					L2EngineJWTSecret: jwtSecret,
 				},
+				DependencySet:                   depSet,
 				Beacon:                          &config.L1BeaconEndpointConfig{BeaconAddr: l1CL.beaconHTTPAddr},
 				Driver:                          driver.Config{SequencerEnabled: isSequencer, SequencerConfDepth: 2},
 				Rollup:                          *l2Net.rollupCfg,
@@ -255,15 +277,20 @@ func WithSharedSupernodeCLs(cls []L2CLs, l1CLID stack.L1CLNodeID, l1ELID stack.L
 		// Gather VN configs and chain IDs
 		vnCfgs := make(map[eth.ChainID]*config.Config)
 		chainIDs := make([]uint64, 0, len(cls))
-		for _, a := range cls {
+		els := make([]*stack.L2ELNodeID, 0, len(cls))
+		for i := range cls {
+			a := cls[i]
 			l2Net, ok := orch.l2Nets.Get(a.CLID.ChainID())
 			require.True(ok, "l2 network required")
 			l2ELNode, ok := orch.l2ELs.Get(a.ELID)
 			require.True(ok, "l2 EL node required")
-			cfg := makeNodeCfg(l2Net, l2ELNode, true)
+			l2ChainID := a.CLID.ChainID()
+			cfg := makeNodeCfg(l2Net, l2ChainID, l2ELNode, true)
+			require.NoError(cfg.Check(), "invalid op-node config for chain %s", a.CLID.ChainID())
 			id := eth.EvilChainIDToUInt64(a.CLID.ChainID())
 			chainIDs = append(chainIDs, id)
 			vnCfgs[eth.ChainIDFromUInt64(id)] = cfg
+			els = append(els, &cls[i].ELID)
 		}
 
 		// Start shared supernode with all chains
@@ -308,7 +335,8 @@ func WithSharedSupernodeCLs(cls []L2CLs, l1CLID stack.L1CLNodeID, l1ELID stack.L
 				time.Sleep(200 * time.Millisecond)
 			}
 		}
-		for _, a := range cls {
+		for i := range cls {
+			a := cls[i]
 			// Multi-chain router exposes per-chain namespace paths
 			rpc := base + "/" + strconv.FormatUint(eth.EvilChainIDToUInt64(a.CLID.ChainID()), 10)
 			waitReady(rpc)
@@ -319,9 +347,42 @@ func WithSharedSupernodeCLs(cls []L2CLs, l1CLID stack.L1CLNodeID, l1ELID stack.L
 				userRPC:          rpc,
 				interopEndpoint:  rpc,
 				interopJwtSecret: jwtSecret,
-				el:               &a.ELID,
+				el:               &cls[i].ELID,
 			}
 			require.True(orch.l2CLs.SetIfMissing(a.CLID, proxy), fmt.Sprintf("must not already exist: %s", a.CLID))
 		}
+
+		supernode := &SuperNode{
+			id:               supernodeID,
+			sn:               sn,
+			cancel:           cancel,
+			userRPC:          base,
+			interopEndpoint:  base,
+			interopJwtSecret: jwtSecret,
+			p:                p,
+			logger:           logger,
+			els:              els,
+			chains:           idsFromCLs(cls),
+			l1UserRPC:        l1EL.UserRPC(),
+			l1BeaconAddr:     l1CL.beaconHTTPAddr,
+		}
+		orch.supernodes.Set(supernodeID, supernode)
 	})
+}
+
+func idsFromCLs(cls []L2CLs) []eth.ChainID {
+	out := make([]eth.ChainID, 0, len(cls))
+	seen := make(map[eth.ChainID]struct{}, len(cls))
+	for _, c := range cls {
+		id := c.CLID.ChainID()
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return eth.EvilChainIDToUInt64(out[i]) < eth.EvilChainIDToUInt64(out[j])
+	})
+	return out
 }

--- a/op-devstack/sysgo/l2_cl_supernode.go
+++ b/op-devstack/sysgo/l2_cl_supernode.go
@@ -42,6 +42,7 @@ type SuperNode struct {
 	p                devtest.P
 	logger           log.Logger
 	els              []*stack.L2ELNodeID // Optional: nil when using SyncTester
+	cls              []stack.L2CLNodeID
 	chains           []eth.ChainID
 	l1UserRPC        string
 	l1BeaconAddr     string
@@ -55,22 +56,22 @@ func (n *SuperNode) hydrate(system stack.ExtensibleSystem) {
 	require.NoError(err)
 	system.T().Cleanup(rpcCl.Close)
 
-	/*
+	for i := range n.cls {
 		sysL2CL := shim.NewL2CLNode(shim.L2CLNodeConfig{
 			CommonConfig:     shim.NewCommonConfig(system.T()),
-			ID:               n.id,
+			ID:               n.cls[i],
 			Client:           rpcCl,
 			UserRPC:          n.userRPC,
 			InteropEndpoint:  n.interopEndpoint,
 			InteropJwtSecret: n.interopJwtSecret,
 		})
 		sysL2CL.SetLabel(match.LabelVendor, string(match.OpNode))
-		l2Net := system.L2Network(stack.L2NetworkID(n.id.ChainID()))
+		l2Net := system.L2Network(stack.L2NetworkID(n.cls[i].ChainID()))
 		l2Net.(stack.ExtensibleL2Network).AddL2CLNode(sysL2CL)
-		if n.el != nil {
-			sysL2CL.(stack.LinkableL2CLNode).LinkEL(l2Net.L2ELNode(n.el))
+		if n.els[i] != nil {
+			sysL2CL.(stack.LinkableL2CLNode).LinkEL(l2Net.L2ELNode(n.els[i]))
 		}
-	*/
+	}
 
 	system.AddSupernode(shim.NewSuperNode(shim.SuperNodeConfig{
 		CommonConfig: shim.NewCommonConfig(system.T()),
@@ -278,6 +279,7 @@ func WithSharedSupernodeCLs(supernodeID stack.SupernodeID, cls []L2CLs, l1CLID s
 		vnCfgs := make(map[eth.ChainID]*config.Config)
 		chainIDs := make([]uint64, 0, len(cls))
 		els := make([]*stack.L2ELNodeID, 0, len(cls))
+		clIDs := make([]stack.L2CLNodeID, len(cls))
 		for i := range cls {
 			a := cls[i]
 			l2Net, ok := orch.l2Nets.Get(a.CLID.ChainID())
@@ -291,6 +293,7 @@ func WithSharedSupernodeCLs(supernodeID stack.SupernodeID, cls []L2CLs, l1CLID s
 			chainIDs = append(chainIDs, id)
 			vnCfgs[eth.ChainIDFromUInt64(id)] = cfg
 			els = append(els, &cls[i].ELID)
+			clIDs = append(clIDs, cls[i].CLID)
 		}
 
 		// Start shared supernode with all chains
@@ -362,6 +365,7 @@ func WithSharedSupernodeCLs(supernodeID stack.SupernodeID, cls []L2CLs, l1CLID s
 			p:                p,
 			logger:           logger,
 			els:              els,
+			cls:              clIDs,
 			chains:           idsFromCLs(cls),
 			l1UserRPC:        l1EL.UserRPC(),
 			l1BeaconAddr:     l1CL.beaconHTTPAddr,

--- a/op-devstack/sysgo/l2_cl_supernode.go
+++ b/op-devstack/sysgo/l2_cl_supernode.go
@@ -42,7 +42,6 @@ type SuperNode struct {
 	p                devtest.P
 	logger           log.Logger
 	els              []*stack.L2ELNodeID // Optional: nil when using SyncTester
-	cls              []stack.L2CLNodeID
 	chains           []eth.ChainID
 	l1UserRPC        string
 	l1BeaconAddr     string
@@ -55,24 +54,8 @@ func (n *SuperNode) hydrate(system stack.ExtensibleSystem) {
 	rpcCl, err := client.NewRPC(system.T().Ctx(), system.Logger(), n.userRPC, client.WithLazyDial())
 	require.NoError(err)
 	system.T().Cleanup(rpcCl.Close)
-
-	for i := range n.cls {
-		sysL2CL := shim.NewL2CLNode(shim.L2CLNodeConfig{
-			CommonConfig:     shim.NewCommonConfig(system.T()),
-			ID:               n.cls[i],
-			Client:           rpcCl,
-			UserRPC:          n.userRPC,
-			InteropEndpoint:  n.interopEndpoint,
-			InteropJwtSecret: n.interopJwtSecret,
-		})
-		sysL2CL.SetLabel(match.LabelVendor, string(match.OpNode))
-		l2Net := system.L2Network(stack.L2NetworkID(n.cls[i].ChainID()))
-		l2Net.(stack.ExtensibleL2Network).AddL2CLNode(sysL2CL)
-		if n.els[i] != nil {
-			sysL2CL.(stack.LinkableL2CLNode).LinkEL(l2Net.L2ELNode(n.els[i]))
-		}
-	}
-
+	// note that the system is also hydrated by the SuperNodeProxy.
+	// It would be redundant to register nodes here as well.
 	system.AddSupernode(shim.NewSuperNode(shim.SuperNodeConfig{
 		CommonConfig: shim.NewCommonConfig(system.T()),
 		ID:           n.id,
@@ -279,7 +262,6 @@ func WithSharedSupernodeCLs(supernodeID stack.SupernodeID, cls []L2CLs, l1CLID s
 		vnCfgs := make(map[eth.ChainID]*config.Config)
 		chainIDs := make([]uint64, 0, len(cls))
 		els := make([]*stack.L2ELNodeID, 0, len(cls))
-		clIDs := make([]stack.L2CLNodeID, len(cls))
 		for i := range cls {
 			a := cls[i]
 			l2Net, ok := orch.l2Nets.Get(a.CLID.ChainID())
@@ -293,7 +275,6 @@ func WithSharedSupernodeCLs(supernodeID stack.SupernodeID, cls []L2CLs, l1CLID s
 			chainIDs = append(chainIDs, id)
 			vnCfgs[eth.ChainIDFromUInt64(id)] = cfg
 			els = append(els, &cls[i].ELID)
-			clIDs = append(clIDs, cls[i].CLID)
 		}
 
 		// Start shared supernode with all chains
@@ -365,7 +346,6 @@ func WithSharedSupernodeCLs(supernodeID stack.SupernodeID, cls []L2CLs, l1CLID s
 			p:                p,
 			logger:           logger,
 			els:              els,
-			cls:              clIDs,
 			chains:           idsFromCLs(cls),
 			l1UserRPC:        l1EL.UserRPC(),
 			l1BeaconAddr:     l1CL.beaconHTTPAddr,

--- a/op-devstack/sysgo/orchestrator.go
+++ b/op-devstack/sysgo/orchestrator.go
@@ -46,6 +46,7 @@ type Orchestrator struct {
 	l2ELs           locks.RWMap[stack.L2ELNodeID, L2ELNode]
 	l2CLs           locks.RWMap[stack.L2CLNodeID, L2CLNode]
 	supervisors     locks.RWMap[stack.SupervisorID, Supervisor]
+	supernodes      locks.RWMap[stack.SupernodeID, *SuperNode]
 	testSequencers  locks.RWMap[stack.TestSequencerID, *TestSequencer]
 	batchers        locks.RWMap[stack.L2BatcherID, *L2Batcher]
 	challengers     locks.RWMap[stack.L2ChallengerID, *L2Challenger]
@@ -158,6 +159,7 @@ func (o *Orchestrator) Hydrate(sys stack.ExtensibleSystem) {
 	o.rollupBoosts.Range(rangeHydrateFn[stack.RollupBoostNodeID, *RollupBoostNode](sys))
 	o.l2CLs.Range(rangeHydrateFn[stack.L2CLNodeID, L2CLNode](sys))
 	o.supervisors.Range(rangeHydrateFn[stack.SupervisorID, Supervisor](sys))
+	o.supernodes.Range(rangeHydrateFn[stack.SupernodeID, *SuperNode](sys))
 	o.testSequencers.Range(rangeHydrateFn[stack.TestSequencerID, *TestSequencer](sys))
 	o.batchers.Range(rangeHydrateFn[stack.L2BatcherID, *L2Batcher](sys))
 	o.challengers.Range(rangeHydrateFn[stack.L2ChallengerID, *L2Challenger](sys))

--- a/op-devstack/sysgo/system.go
+++ b/op-devstack/sysgo/system.go
@@ -107,6 +107,7 @@ type DefaultTwoL2SystemIDs struct {
 	L2BCL stack.L2CLNodeID
 	L2BEL stack.L2ELNodeID
 
+	Supernode   stack.SupernodeID
 	L2ABatcher  stack.L2BatcherID
 	L2AProposer stack.L2ProposerID
 	L2BBatcher  stack.L2BatcherID
@@ -124,6 +125,7 @@ func NewDefaultTwoL2SystemIDs(l1ID, l2AID, l2BID eth.ChainID) DefaultTwoL2System
 		L2B:         stack.L2NetworkID(l2BID),
 		L2BCL:       stack.NewL2CLNodeID("sequencer", l2BID),
 		L2BEL:       stack.NewL2ELNodeID("sequencer", l2BID),
+		Supernode:   stack.NewSupernodeID("supernode-two-l2-system", l2AID, l2BID),
 		L2ABatcher:  stack.NewL2BatcherID("main", l2AID),
 		L2AProposer: stack.NewL2ProposerID("main", l2AID),
 		L2BBatcher:  stack.NewL2BatcherID("main", l2BID),
@@ -200,7 +202,7 @@ func DefaultSupernodeTwoL2System(dest *DefaultTwoL2SystemIDs) stack.Option[*Orch
 	opt.Add(WithL2ELNode(ids.L2BEL))
 
 	// Shared supernode for both L2 chains
-	opt.Add(WithSharedSupernodeCLs([]L2CLs{{CLID: ids.L2ACL, ELID: ids.L2AEL}, {CLID: ids.L2BCL, ELID: ids.L2BEL}}, ids.L1CL, ids.L1EL))
+	opt.Add(WithSharedSupernodeCLs(ids.Supernode, []L2CLs{{CLID: ids.L2ACL, ELID: ids.L2AEL}, {CLID: ids.L2BCL, ELID: ids.L2BEL}}, ids.L1CL, ids.L1EL))
 
 	opt.Add(WithBatcher(ids.L2ABatcher, ids.L1EL, ids.L2ACL, ids.L2AEL))
 	opt.Add(WithProposer(ids.L2AProposer, ids.L1EL, &ids.L2ACL, nil))


### PR DESCRIPTION
This patch wires up supernode into devstack such that it is visible to other components such as the op-challenger.
This change will be used in acceptance-tests to replace supervisor usage by the op-challenger and op-proposer with the sysgo supernode.