### PR TITLE
fix(op-conductor): handle Stop() being called before Start() in health monitor

### DIFF
--- a/op-conductor/health/monitor.go
+++ b/op-conductor/health/monitor.go
@@ -129,7 +129,9 @@ func (hm *SequencerHealthMonitor) Start(ctx context.Context) error {
 // Stop implements HealthMonitor.
 func (hm *SequencerHealthMonitor) Stop() error {
 	hm.log.Info("stopping health monitor")
-	hm.cancel()
+	if hm.cancel != nil {
+		hm.cancel()
+	}
 	hm.wg.Wait()
 
 	hm.log.Info("health monitor stopped")

--- a/op-conductor/health/monitor.go
+++ b/op-conductor/health/monitor.go
@@ -131,8 +131,8 @@ func (hm *SequencerHealthMonitor) Stop() error {
 	hm.log.Info("stopping health monitor")
 	if hm.cancel != nil {
 		hm.cancel()
+		hm.wg.Wait()
 	}
-	hm.wg.Wait()
 
 	hm.log.Info("health monitor stopped")
 	return nil


### PR DESCRIPTION
## Summary

- Fix panic in `SequencerHealthMonitor.Stop()` when called before `Start()`
- Add nil check for `cancel` function before calling it
- This can happen when `OpConductor` initialization fails and `Stop()` is called to clean up resources (see `service.go:96`)

## Test plan

- [x] Existing tests pass (`go test ./op-conductor/health/...` and `go test ./op-conductor/conductor/...`)
- [x] `TestHandleInitError` covers the scenario where `Stop()` is called after failed `init()`