### PR TITLE
feat(flashblocks): add canonical block reconciliation to cache and service (2)

### DIFF
--- a/op-reth/crates/flashblocks/src/cache.rs
+++ b/op-reth/crates/flashblocks/src/cache.rs
@@ -5,12 +5,15 @@
 
 use crate::{
     sequence::{FlashBlockPendingSequence, SequenceExecutionOutcome},
+    validation::{CanonicalBlockReconciler, ReconciliationStrategy, ReorgDetector},
     worker::BuildArgs,
     FlashBlock, FlashBlockCompleteSequence, PendingFlashBlock,
 };
 use alloy_eips::eip2718::WithEncoded;
 use alloy_primitives::B256;
-use reth_primitives_traits::{NodePrimitives, Recovered, SignedTransaction};
+use reth_primitives_traits::{
+    transaction::TxHashRef, NodePrimitives, Recovered, SignedTransaction,
+};
 use reth_revm::cached::CachedReads;
 use ringbuffer::{AllocRingBuffer, RingBuffer};
 use tokio::sync::broadcast;
@@ -261,12 +264,162 @@ impl<T: SignedTransaction> SequenceManager<T> {
             }
         }
     }
+
+    /// Returns the earliest block number in the pending or cached sequences.
+    pub(crate) fn earliest_block_number(&self) -> Option<u64> {
+        // Check pending first
+        if let Some(pending_block) = self.pending.block_number() {
+            // Also check cache for earlier blocks
+            let cache_earliest =
+                self.completed_cache.iter().map(|(seq, _)| seq.block_number()).min();
+
+            return Some(cache_earliest.map_or(pending_block, |c| c.min(pending_block)));
+        }
+
+        // Fall back to cache only
+        self.completed_cache.iter().map(|(seq, _)| seq.block_number()).min()
+    }
+
+    /// Returns the latest block number in the pending or cached sequences.
+    pub(crate) fn latest_block_number(&self) -> Option<u64> {
+        // Pending is always the latest if it exists
+        if let Some(pending_block) = self.pending.block_number() {
+            return Some(pending_block);
+        }
+
+        // Fall back to cache
+        self.completed_cache.iter().map(|(seq, _)| seq.block_number()).max()
+    }
+
+    /// Returns transaction hashes for a specific block number from pending or cached sequences.
+    pub(crate) fn get_transaction_hashes_for_block(&self, block_number: u64) -> Vec<B256> {
+        // Check pending sequence
+        if self.pending.block_number() == Some(block_number) {
+            return self.pending_transactions.iter().map(|tx| *tx.tx_hash()).collect();
+        }
+
+        // Check cached sequences
+        for (seq, txs) in self.completed_cache.iter() {
+            if seq.block_number() == block_number {
+                return txs.iter().map(|tx| *tx.tx_hash()).collect();
+            }
+        }
+
+        Vec::new()
+    }
+
+    /// Returns true if the given block number is tracked in pending or cached sequences.
+    fn tracks_block_number(&self, block_number: u64) -> bool {
+        // Check pending sequence
+        if self.pending.block_number() == Some(block_number) {
+            return true;
+        }
+
+        // Check cached sequences
+        self.completed_cache.iter().any(|(seq, _)| seq.block_number() == block_number)
+    }
+
+    /// Processes a canonical block and reconciles pending state.
+    ///
+    /// This method determines how to handle the pending flashblock state when a new
+    /// canonical block arrives. It uses the [`CanonicalBlockReconciler`] to decide
+    /// the appropriate strategy based on:
+    /// - Whether canonical has caught up to pending
+    /// - Whether a reorg was detected (transaction mismatch)
+    /// - Whether pending is too far ahead of canonical
+    ///
+    /// Returns the reconciliation strategy that was applied.
+    pub(crate) fn process_canonical_block(
+        &mut self,
+        canonical_block_number: u64,
+        canonical_tx_hashes: &[B256],
+        max_depth: u64,
+    ) -> ReconciliationStrategy {
+        let earliest = self.earliest_block_number();
+        let latest = self.latest_block_number();
+
+        // Only run reorg detection if we actually track the canonical block number.
+        // If we don't track it (block number outside our pending/cached window),
+        // comparing empty tracked hashes to non-empty canonical hashes would falsely
+        // trigger reorg detection.
+        let reorg_detected = if self.tracks_block_number(canonical_block_number) {
+            let tracked_tx_hashes = self.get_transaction_hashes_for_block(canonical_block_number);
+            let reorg_result = ReorgDetector::detect(&tracked_tx_hashes, canonical_tx_hashes);
+            reorg_result.is_reorg()
+        } else {
+            false
+        };
+
+        // Determine reconciliation strategy
+        let strategy = CanonicalBlockReconciler::reconcile(
+            earliest,
+            latest,
+            canonical_block_number,
+            max_depth,
+            reorg_detected,
+        );
+
+        match &strategy {
+            ReconciliationStrategy::CatchUp => {
+                trace!(
+                    target: "flashblocks",
+                    ?latest,
+                    canonical_block_number,
+                    "Canonical caught up - clearing pending state"
+                );
+                self.clear_all();
+            }
+            ReconciliationStrategy::HandleReorg => {
+                warn!(
+                    target: "flashblocks",
+                    canonical_block_number,
+                    canonical_tx_count = canonical_tx_hashes.len(),
+                    "Reorg detected - clearing pending state"
+                );
+                self.clear_all();
+            }
+            ReconciliationStrategy::DepthLimitExceeded { depth, max_depth } => {
+                trace!(
+                    target: "flashblocks",
+                    depth,
+                    max_depth,
+                    "Depth limit exceeded - clearing pending state"
+                );
+                self.clear_all();
+            }
+            ReconciliationStrategy::Continue => {
+                trace!(
+                    target: "flashblocks",
+                    ?earliest,
+                    ?latest,
+                    canonical_block_number,
+                    "Canonical behind pending - continuing"
+                );
+            }
+            ReconciliationStrategy::NoPendingState => {
+                trace!(
+                    target: "flashblocks",
+                    canonical_block_number,
+                    "No pending state to reconcile"
+                );
+            }
+        }
+
+        strategy
+    }
+
+    /// Clears all pending and cached state.
+    fn clear_all(&mut self) {
+        self.pending = FlashBlockPendingSequence::new();
+        self.pending_transactions.clear();
+        self.completed_cache.clear();
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::TestFlashBlockFactory;
+    use crate::{test_utils::TestFlashBlockFactory, validation::ReconciliationStrategy};
     use alloy_primitives::B256;
     use op_alloy_consensus::OpTxEnvelope;
 
@@ -478,5 +631,366 @@ mod tests {
         let args = manager.next_buildable_args(first_parent, 1000000);
         // Should not find it (evicted from ring buffer)
         assert!(args.is_none());
+    }
+
+    // ==================== Canonical Block Reconciliation Tests ====================
+
+    #[test]
+    fn test_process_canonical_block_no_pending_state() {
+        let mut manager: SequenceManager<OpTxEnvelope> = SequenceManager::new(true);
+
+        // No pending state, should return NoPendingState
+        let strategy = manager.process_canonical_block(100, &[], 10);
+        assert_eq!(strategy, ReconciliationStrategy::NoPendingState);
+    }
+
+    #[test]
+    fn test_process_canonical_block_catchup() {
+        let mut manager: SequenceManager<OpTxEnvelope> = SequenceManager::new(true);
+        let factory = TestFlashBlockFactory::new();
+
+        // Insert a flashblock sequence for block 100
+        let fb0 = factory.flashblock_at(0).build();
+        manager.insert_flashblock(fb0).unwrap();
+
+        assert_eq!(manager.pending().block_number(), Some(100));
+
+        // Canonical catches up to block 100
+        let strategy = manager.process_canonical_block(100, &[], 10);
+        assert_eq!(strategy, ReconciliationStrategy::CatchUp);
+
+        // Pending state should be cleared
+        assert!(manager.pending().block_number().is_none());
+    }
+
+    #[test]
+    fn test_process_canonical_block_continue() {
+        let mut manager: SequenceManager<OpTxEnvelope> = SequenceManager::new(true);
+        let factory = TestFlashBlockFactory::new();
+
+        // Insert flashblocks for block 100-102
+        let fb0 = factory.flashblock_at(0).build();
+        manager.insert_flashblock(fb0.clone()).unwrap();
+
+        let fb1 = factory.flashblock_for_next_block(&fb0).build();
+        manager.insert_flashblock(fb1.clone()).unwrap();
+
+        let fb2 = factory.flashblock_for_next_block(&fb1).build();
+        manager.insert_flashblock(fb2).unwrap();
+
+        // Canonical at 99 (behind pending)
+        let strategy = manager.process_canonical_block(99, &[], 10);
+        assert_eq!(strategy, ReconciliationStrategy::Continue);
+
+        // Pending state should still exist
+        assert!(manager.pending().block_number().is_some());
+    }
+
+    #[test]
+    fn test_process_canonical_block_depth_limit_exceeded() {
+        let mut manager: SequenceManager<OpTxEnvelope> = SequenceManager::new(true);
+        let factory = TestFlashBlockFactory::new();
+
+        // Insert flashblocks for block 100-102
+        let fb0 = factory.flashblock_at(0).build();
+        manager.insert_flashblock(fb0.clone()).unwrap();
+
+        let fb1 = factory.flashblock_for_next_block(&fb0).build();
+        manager.insert_flashblock(fb1.clone()).unwrap();
+
+        let fb2 = factory.flashblock_for_next_block(&fb1).build();
+        manager.insert_flashblock(fb2).unwrap();
+
+        // At this point: earliest=100, latest=102
+        // Canonical at 105 with max_depth of 2 (depth = 105 - 100 = 5, which exceeds 2)
+        // But wait - if canonical >= latest, it's CatchUp. So canonical must be < latest (102).
+        // Let's use canonical=101, which is < 102 but depth = 101 - 100 = 1 > 0
+        let strategy = manager.process_canonical_block(101, &[], 0);
+        assert!(matches!(strategy, ReconciliationStrategy::DepthLimitExceeded { .. }));
+
+        // Pending state should be cleared
+        assert!(manager.pending().block_number().is_none());
+    }
+
+    #[test]
+    fn test_earliest_and_latest_block_numbers() {
+        let mut manager: SequenceManager<OpTxEnvelope> = SequenceManager::new(true);
+        let factory = TestFlashBlockFactory::new();
+
+        // Initially no blocks
+        assert!(manager.earliest_block_number().is_none());
+        assert!(manager.latest_block_number().is_none());
+
+        // Insert first flashblock (block 100)
+        let fb0 = factory.flashblock_at(0).build();
+        manager.insert_flashblock(fb0.clone()).unwrap();
+
+        assert_eq!(manager.earliest_block_number(), Some(100));
+        assert_eq!(manager.latest_block_number(), Some(100));
+
+        // Insert next block (block 101) - this caches block 100
+        let fb1 = factory.flashblock_for_next_block(&fb0).build();
+        manager.insert_flashblock(fb1.clone()).unwrap();
+
+        assert_eq!(manager.earliest_block_number(), Some(100));
+        assert_eq!(manager.latest_block_number(), Some(101));
+
+        // Insert another block (block 102)
+        let fb2 = factory.flashblock_for_next_block(&fb1).build();
+        manager.insert_flashblock(fb2).unwrap();
+
+        assert_eq!(manager.earliest_block_number(), Some(100));
+        assert_eq!(manager.latest_block_number(), Some(102));
+    }
+
+    // ==================== Reconciliation Cache Clearing Tests ====================
+
+    #[test]
+    fn test_catchup_clears_all_cached_sequences() {
+        let mut manager: SequenceManager<OpTxEnvelope> = SequenceManager::new(true);
+        let factory = TestFlashBlockFactory::new();
+
+        // Build up cached sequences for blocks 100, 101, 102
+        let fb0 = factory.flashblock_at(0).build();
+        manager.insert_flashblock(fb0.clone()).unwrap();
+
+        let fb1 = factory.flashblock_for_next_block(&fb0).build();
+        manager.insert_flashblock(fb1.clone()).unwrap();
+
+        let fb2 = factory.flashblock_for_next_block(&fb1).build();
+        manager.insert_flashblock(fb2).unwrap();
+
+        // Verify we have cached sequences
+        assert_eq!(manager.completed_cache.len(), 2);
+        assert!(manager.pending().block_number().is_some());
+
+        // Canonical catches up to 102 - should clear everything
+        let strategy = manager.process_canonical_block(102, &[], 10);
+        assert_eq!(strategy, ReconciliationStrategy::CatchUp);
+
+        // Verify all state is cleared
+        assert!(manager.pending().block_number().is_none());
+        assert_eq!(manager.completed_cache.len(), 0);
+    }
+
+    #[test]
+    fn test_reorg_clears_all_cached_sequences() {
+        let mut manager: SequenceManager<OpTxEnvelope> = SequenceManager::new(true);
+        let factory = TestFlashBlockFactory::new();
+
+        // Build pending sequence for block 100
+        let fb0 = factory.flashblock_at(0).build();
+        manager.insert_flashblock(fb0.clone()).unwrap();
+
+        // Add another sequence
+        let fb1 = factory.flashblock_for_next_block(&fb0).build();
+        manager.insert_flashblock(fb1).unwrap();
+
+        // Verify we have state
+        assert!(manager.pending().block_number().is_some());
+        assert!(!manager.completed_cache.is_empty());
+
+        // Simulate reorg at block 100: canonical has different tx than our cached
+        // We need to insert a tx in the sequence to make reorg detection work
+        // The reorg detection compares our pending transactions vs canonical
+        // Since we have no pending transactions (TestFlashBlockFactory creates empty tx lists),
+        // we need to use a different approach - process with tx hashes that don't match empty
+
+        // Actually, let's verify the state clearing on HandleReorg by checking
+        // that any non-empty canonical_tx_hashes when we have state triggers reorg
+        let canonical_tx_hashes = vec![B256::repeat_byte(0xAA)];
+        let strategy = manager.process_canonical_block(100, &canonical_tx_hashes, 10);
+
+        // Should detect reorg (canonical has txs, we have none for that block)
+        assert_eq!(strategy, ReconciliationStrategy::HandleReorg);
+
+        // Verify all state is cleared
+        assert!(manager.pending().block_number().is_none());
+        assert_eq!(manager.completed_cache.len(), 0);
+    }
+
+    #[test]
+    fn test_depth_limit_exceeded_clears_all_state() {
+        let mut manager: SequenceManager<OpTxEnvelope> = SequenceManager::new(true);
+        let factory = TestFlashBlockFactory::new();
+
+        // Build sequences for blocks 100-102
+        let fb0 = factory.flashblock_at(0).build();
+        manager.insert_flashblock(fb0.clone()).unwrap();
+
+        let fb1 = factory.flashblock_for_next_block(&fb0).build();
+        manager.insert_flashblock(fb1.clone()).unwrap();
+
+        let fb2 = factory.flashblock_for_next_block(&fb1).build();
+        manager.insert_flashblock(fb2).unwrap();
+
+        // Verify state exists
+        assert_eq!(manager.earliest_block_number(), Some(100));
+        assert_eq!(manager.latest_block_number(), Some(102));
+
+        // Canonical at 101 with max_depth of 0 (depth = 101 - 100 = 1 > 0)
+        // Since canonical < latest (102), this should trigger depth limit exceeded
+        let strategy = manager.process_canonical_block(101, &[], 0);
+        assert!(matches!(strategy, ReconciliationStrategy::DepthLimitExceeded { .. }));
+
+        // Verify all state is cleared
+        assert!(manager.pending().block_number().is_none());
+        assert_eq!(manager.completed_cache.len(), 0);
+    }
+
+    #[test]
+    fn test_continue_preserves_all_state() {
+        let mut manager: SequenceManager<OpTxEnvelope> = SequenceManager::new(true);
+        let factory = TestFlashBlockFactory::new();
+
+        // Build sequences for blocks 100-102
+        let fb0 = factory.flashblock_at(0).build();
+        manager.insert_flashblock(fb0.clone()).unwrap();
+
+        let fb1 = factory.flashblock_for_next_block(&fb0).build();
+        manager.insert_flashblock(fb1.clone()).unwrap();
+
+        let fb2 = factory.flashblock_for_next_block(&fb1).build();
+        manager.insert_flashblock(fb2).unwrap();
+
+        let cached_count = manager.completed_cache.len();
+
+        // Canonical at 99 (behind pending) with reasonable depth limit
+        let strategy = manager.process_canonical_block(99, &[], 10);
+        assert_eq!(strategy, ReconciliationStrategy::Continue);
+
+        // Verify state is preserved
+        assert_eq!(manager.pending().block_number(), Some(102));
+        assert_eq!(manager.completed_cache.len(), cached_count);
+    }
+
+    #[test]
+    fn test_clear_all_removes_pending_and_cache() {
+        let mut manager: SequenceManager<OpTxEnvelope> = SequenceManager::new(true);
+        let factory = TestFlashBlockFactory::new();
+
+        // Build up state
+        let fb0 = factory.flashblock_at(0).build();
+        manager.insert_flashblock(fb0.clone()).unwrap();
+
+        let fb1 = factory.flashblock_for_next_block(&fb0).build();
+        manager.insert_flashblock(fb1).unwrap();
+
+        // Verify state exists
+        assert!(manager.pending().block_number().is_some());
+        assert!(!manager.completed_cache.is_empty());
+        assert!(!manager.pending_transactions.is_empty() || manager.pending().count() > 0);
+
+        // Clear via catchup
+        manager.process_canonical_block(101, &[], 10);
+
+        // Verify complete clearing
+        assert!(manager.pending().block_number().is_none());
+        assert_eq!(manager.pending().count(), 0);
+        assert!(manager.completed_cache.is_empty());
+        assert!(manager.pending_transactions.is_empty());
+    }
+
+    // ==================== Transaction Hash Tracking Tests ====================
+
+    #[test]
+    fn test_get_transaction_hashes_returns_empty_for_unknown_block() {
+        let manager: SequenceManager<OpTxEnvelope> = SequenceManager::new(true);
+
+        // No flashblocks inserted, should return empty
+        let hashes = manager.get_transaction_hashes_for_block(100);
+        assert!(hashes.is_empty());
+    }
+
+    #[test]
+    fn test_get_transaction_hashes_for_pending_block() {
+        let mut manager: SequenceManager<OpTxEnvelope> = SequenceManager::new(true);
+        let factory = TestFlashBlockFactory::new();
+
+        // Create flashblock without transactions (empty tx list is valid)
+        let fb0 = factory.flashblock_at(0).build();
+        manager.insert_flashblock(fb0).unwrap();
+
+        // Should find (empty) transaction hashes for block 100
+        let hashes = manager.get_transaction_hashes_for_block(100);
+        assert!(hashes.is_empty()); // No transactions in this flashblock
+    }
+
+    #[test]
+    fn test_get_transaction_hashes_for_cached_block() {
+        let mut manager: SequenceManager<OpTxEnvelope> = SequenceManager::new(true);
+        let factory = TestFlashBlockFactory::new();
+
+        // Create first flashblock for block 100
+        let fb0 = factory.flashblock_at(0).build();
+        manager.insert_flashblock(fb0.clone()).unwrap();
+
+        // Create second flashblock for block 101 (caches block 100)
+        let fb1 = factory.flashblock_for_next_block(&fb0).build();
+        manager.insert_flashblock(fb1).unwrap();
+
+        // Should find transaction hashes for cached block 100
+        let hashes = manager.get_transaction_hashes_for_block(100);
+        assert!(hashes.is_empty()); // No transactions in these flashblocks
+
+        // Should find transaction hashes for pending block 101
+        let hashes = manager.get_transaction_hashes_for_block(101);
+        assert!(hashes.is_empty()); // No transactions in these flashblocks
+    }
+
+    #[test]
+    fn test_no_false_reorg_for_untracked_block() {
+        let mut manager: SequenceManager<OpTxEnvelope> = SequenceManager::new(true);
+        let factory = TestFlashBlockFactory::new();
+
+        // Build pending sequence for block 100
+        let fb0 = factory.flashblock_at(0).build();
+        manager.insert_flashblock(fb0.clone()).unwrap();
+
+        // Add another sequence for block 101
+        let fb1 = factory.flashblock_for_next_block(&fb0).build();
+        manager.insert_flashblock(fb1).unwrap();
+
+        // Verify we have state for blocks 100 (cached) and 101 (pending)
+        assert_eq!(manager.earliest_block_number(), Some(100));
+        assert_eq!(manager.latest_block_number(), Some(101));
+
+        // Process canonical block 99 (not tracked) with transactions
+        // This should NOT trigger reorg detection because we don't track block 99
+        let canonical_tx_hashes = vec![B256::repeat_byte(0xAA)];
+        let strategy = manager.process_canonical_block(99, &canonical_tx_hashes, 10);
+
+        // Should continue (not reorg) because block 99 is outside our tracked window
+        assert_eq!(strategy, ReconciliationStrategy::Continue);
+
+        // State should be preserved
+        assert_eq!(manager.pending().block_number(), Some(101));
+        assert!(!manager.completed_cache.is_empty());
+    }
+
+    #[test]
+    fn test_reorg_detected_for_tracked_block_with_different_txs() {
+        let mut manager: SequenceManager<OpTxEnvelope> = SequenceManager::new(true);
+        let factory = TestFlashBlockFactory::new();
+
+        // Build pending sequence for block 100
+        let fb0 = factory.flashblock_at(0).build();
+        manager.insert_flashblock(fb0.clone()).unwrap();
+
+        // Add another sequence for block 101
+        let fb1 = factory.flashblock_for_next_block(&fb0).build();
+        manager.insert_flashblock(fb1).unwrap();
+
+        // Process canonical block 100 (which IS tracked) with different transactions
+        // Our tracked block 100 has empty tx list, canonical has non-empty
+        let canonical_tx_hashes = vec![B256::repeat_byte(0xAA)];
+        let strategy = manager.process_canonical_block(100, &canonical_tx_hashes, 10);
+
+        // Should detect reorg because we track block 100 and txs don't match
+        assert_eq!(strategy, ReconciliationStrategy::HandleReorg);
+
+        // State should be cleared
+        assert!(manager.pending().block_number().is_none());
+        assert!(manager.completed_cache.is_empty());
     }
 }

--- a/op-reth/crates/flashblocks/src/lib.rs
+++ b/op-reth/crates/flashblocks/src/lib.rs
@@ -24,7 +24,10 @@ mod sequence;
 pub use sequence::{FlashBlockCompleteSequence, FlashBlockPendingSequence};
 
 mod service;
-pub use service::{FlashBlockBuildInfo, FlashBlockService};
+pub use service::{
+    create_canonical_block_channel, CanonicalBlockNotification, FlashBlockBuildInfo,
+    FlashBlockService,
+};
 
 mod worker;
 

--- a/op-reth/crates/flashblocks/src/service.rs
+++ b/op-reth/crates/flashblocks/src/service.rs
@@ -1,10 +1,11 @@
 use crate::{
-    cache::SequenceManager, worker::FlashBlockBuilder, FlashBlock, FlashBlockCompleteSequence,
-    FlashBlockCompleteSequenceRx, InProgressFlashBlockRx, PendingFlashBlock,
+    cache::SequenceManager, validation::ReconciliationStrategy, worker::FlashBlockBuilder,
+    FlashBlock, FlashBlockCompleteSequence, FlashBlockCompleteSequenceRx, InProgressFlashBlockRx,
+    PendingFlashBlock,
 };
 use alloy_primitives::B256;
 use futures_util::{FutureExt, Stream, StreamExt};
-use metrics::{Gauge, Histogram};
+use metrics::{Counter, Gauge, Histogram};
 use op_alloy_rpc_types_engine::OpFlashblockPayloadBase;
 use reth_evm::ConfigureEvm;
 use reth_metrics::Metrics;
@@ -17,12 +18,28 @@ use std::{
     time::{Duration, Instant},
 };
 use tokio::{
-    sync::{oneshot, watch},
+    sync::{mpsc, oneshot, watch},
     time::sleep,
 };
 use tracing::*;
 
 const CONNECTION_BACKOUT_PERIOD: Duration = Duration::from_secs(5);
+
+/// Default maximum depth for pending blocks ahead of canonical.
+const DEFAULT_MAX_DEPTH: u64 = 64;
+
+/// Capacity for the canonical block notification channel.
+/// This bounds memory usage while allowing for some buffering during catch-up.
+const CANONICAL_BLOCK_CHANNEL_CAPACITY: usize = 128;
+
+/// Notification about a new canonical block for reconciliation.
+#[derive(Debug, Clone)]
+pub struct CanonicalBlockNotification {
+    /// The canonical block number.
+    pub block_number: u64,
+    /// Transaction hashes in the canonical block.
+    pub tx_hashes: Vec<B256>,
+}
 
 /// The `FlashBlockService` maintains an in-memory [`PendingFlashBlock`] built out of a sequence of
 /// [`FlashBlock`]s.
@@ -35,6 +52,8 @@ pub struct FlashBlockService<
 > {
     /// Incoming flashblock stream.
     incoming_flashblock_rx: S,
+    /// Receiver for canonical block notifications (bounded to prevent OOM).
+    canonical_block_rx: Option<mpsc::Receiver<CanonicalBlockNotification>>,
     /// Signals when a block build is in progress.
     in_progress_tx: watch::Sender<Option<FlashBlockBuildInfo>>,
     /// Broadcast channel to forward received flashblocks from the subscription.
@@ -49,6 +68,8 @@ pub struct FlashBlockService<
     /// Manages flashblock sequences with caching and intelligent build selection.
     sequences: SequenceManager<N::SignedTx>,
 
+    /// Maximum depth for pending blocks ahead of canonical before clearing.
+    max_depth: u64,
     /// `FlashBlock` service's metrics
     metrics: FlashBlockServiceMetrics,
 }
@@ -82,14 +103,40 @@ where
         let (received_flashblocks_tx, _) = tokio::sync::broadcast::channel(128);
         Self {
             incoming_flashblock_rx,
+            canonical_block_rx: None,
             in_progress_tx,
             received_flashblocks_tx,
             builder: FlashBlockBuilder::new(evm_config, provider),
             spawner,
             job: None,
             sequences: SequenceManager::new(compute_state_root),
+            max_depth: DEFAULT_MAX_DEPTH,
             metrics: FlashBlockServiceMetrics::default(),
         }
+    }
+
+    /// Sets the canonical block receiver for reconciliation.
+    ///
+    /// When canonical blocks are received, the service will reconcile the pending
+    /// flashblock state to handle catch-up and reorg scenarios.
+    ///
+    /// The channel should be bounded to prevent unbounded memory growth. Use
+    /// [`create_canonical_block_channel`] to create a properly sized channel.
+    pub fn with_canonical_block_rx(
+        mut self,
+        rx: mpsc::Receiver<CanonicalBlockNotification>,
+    ) -> Self {
+        self.canonical_block_rx = Some(rx);
+        self
+    }
+
+    /// Sets the maximum depth for pending blocks ahead of canonical.
+    ///
+    /// If pending blocks get too far ahead of the canonical chain, the pending
+    /// state will be cleared to prevent unbounded memory growth.
+    pub const fn with_max_depth(mut self, max_depth: u64) -> Self {
+        self.max_depth = max_depth;
+        self
     }
 
     /// Returns the sender half for the received flashblocks broadcast channel.
@@ -121,7 +168,8 @@ where
     /// This loop:
     /// 1. Checks if any build job has completed and processes results
     /// 2. Receives and batches all immediately available flashblocks
-    /// 3. Attempts to build a block from the complete sequence
+    /// 3. Processes canonical block notifications for reconciliation
+    /// 4. Attempts to build a block from the complete sequence
     ///
     /// Note: this should be spawned
     pub async fn run(mut self, tx: watch::Sender<Option<PendingFlashBlock<N>>>) {
@@ -189,7 +237,33 @@ where
                         }
                     }
                 }
+
+                // Event 3: Canonical block notification for reconciliation
+                Some(notification) = async {
+                    match self.canonical_block_rx.as_mut() {
+                        Some(rx) => rx.recv().await,
+                        None => std::future::pending().await,
+                    }
+                } => {
+                    self.process_canonical_block(notification);
+                    // Try to build after reconciliation in case we can now build
+                    self.try_start_build_job();
+                }
             }
+        }
+    }
+
+    /// Processes a canonical block notification and reconciles pending state.
+    fn process_canonical_block(&mut self, notification: CanonicalBlockNotification) {
+        let strategy = self.sequences.process_canonical_block(
+            notification.block_number,
+            &notification.tx_hashes,
+            self.max_depth,
+        );
+
+        // Record metrics based on strategy
+        if matches!(strategy, ReconciliationStrategy::HandleReorg) {
+            self.metrics.reorg_count.increment(1);
         }
     }
 
@@ -262,6 +336,18 @@ pub struct FlashBlockBuildInfo {
 type BuildJob<N> =
     (Instant, oneshot::Receiver<eyre::Result<Option<(PendingFlashBlock<N>, CachedReads)>>>);
 
+/// Creates a bounded channel for canonical block notifications.
+///
+/// This returns a sender/receiver pair with a bounded capacity to prevent
+/// unbounded memory growth. If the receiver falls behind, senders will
+/// block until space is available.
+///
+/// Returns `(sender, receiver)` tuple for use with [`FlashBlockService::with_canonical_block_rx`].
+pub fn create_canonical_block_channel(
+) -> (mpsc::Sender<CanonicalBlockNotification>, mpsc::Receiver<CanonicalBlockNotification>) {
+    mpsc::channel(CANONICAL_BLOCK_CHANNEL_CAPACITY)
+}
+
 #[derive(Metrics)]
 #[metrics(scope = "flashblock_service")]
 struct FlashBlockServiceMetrics {
@@ -273,4 +359,6 @@ struct FlashBlockServiceMetrics {
     current_block_height: Gauge,
     /// Current flashblock index.
     current_index: Gauge,
+    /// Number of reorgs detected during canonical block reconciliation.
+    reorg_count: Counter,
 }

--- a/op-reth/crates/flashblocks/src/validation.rs
+++ b/op-reth/crates/flashblocks/src/validation.rs
@@ -190,9 +190,14 @@ pub enum ReconciliationStrategy {
     CatchUp,
     /// Reorg detected (tx mismatch). Rebuild pending from canonical.
     HandleReorg,
-    /// Pending too far ahead of canonical.
+    /// Pending state window has been open too long.
+    ///
+    /// The `depth` is calculated as `canonical_block_number - earliest_pending_block`,
+    /// representing how many blocks the canonical chain has advanced since we started
+    /// tracking pending state. This limit prevents unbounded memory growth from tracking
+    /// pending state across too many canonical blocks.
     DepthLimitExceeded {
-        /// Current depth of pending blocks.
+        /// How far canonical has advanced since earliest pending block.
         depth: u64,
         /// Configured maximum depth.
         max_depth: u64,
@@ -266,7 +271,8 @@ impl CanonicalBlockReconciler {
             return ReconciliationStrategy::HandleReorg;
         }
 
-        // Check depth limit
+        // Check depth limit: how far has canonical advanced since earliest pending?
+        // This prevents tracking pending state across too many canonical blocks.
         let depth = canonical_block_number.saturating_sub(earliest);
         if depth > max_depth {
             return ReconciliationStrategy::DepthLimitExceeded { depth, max_depth };
@@ -448,6 +454,56 @@ mod tests {
                 ReorgDetectionResult::ReorgDetected { tracked_count: 1, canonical_count: 2 };
             assert!(reorg.is_reorg());
             assert!(!reorg.is_no_reorg());
+        }
+
+        #[test]
+        fn test_reorg_partial_overlap() {
+            // Same first transaction, different second transaction
+            let tracked = vec![B256::repeat_byte(0x01), B256::repeat_byte(0x02)];
+            let canonical = vec![B256::repeat_byte(0x01), B256::repeat_byte(0x03)];
+
+            assert_eq!(
+                ReorgDetector::detect(&tracked, &canonical),
+                ReorgDetectionResult::ReorgDetected { tracked_count: 2, canonical_count: 2 }
+            );
+        }
+
+        #[test]
+        fn test_reorg_subset_not_equal() {
+            // Canonical is a prefix of tracked - still a reorg (different counts)
+            let tracked = vec![B256::repeat_byte(0x01), B256::repeat_byte(0x02)];
+            let canonical = vec![B256::repeat_byte(0x01)];
+
+            assert_eq!(
+                ReorgDetector::detect(&tracked, &canonical),
+                ReorgDetectionResult::ReorgDetected { tracked_count: 2, canonical_count: 1 }
+            );
+
+            // Tracked is a prefix of canonical - still a reorg
+            let tracked = vec![B256::repeat_byte(0x01)];
+            let canonical = vec![B256::repeat_byte(0x01), B256::repeat_byte(0x02)];
+
+            assert_eq!(
+                ReorgDetector::detect(&tracked, &canonical),
+                ReorgDetectionResult::ReorgDetected { tracked_count: 1, canonical_count: 2 }
+            );
+        }
+
+        #[test]
+        fn test_empty_vs_non_empty() {
+            // Empty tracked vs non-empty canonical
+            let canonical = vec![B256::repeat_byte(0x01)];
+            assert_eq!(
+                ReorgDetector::detect(&[], &canonical),
+                ReorgDetectionResult::ReorgDetected { tracked_count: 0, canonical_count: 1 }
+            );
+
+            // Non-empty tracked vs empty canonical
+            let tracked = vec![B256::repeat_byte(0x01)];
+            assert_eq!(
+                ReorgDetector::detect(&tracked, &[]),
+                ReorgDetectionResult::ReorgDetected { tracked_count: 1, canonical_count: 0 }
+            );
         }
     }
 


### PR DESCRIPTION
## Summary
Integrates canonical block reconciliation into the flashblock service and sequence manager:

- Adds `CanonicalBlockNotification` type for receiving canonical block events via channel
- Adds `process_canonical_block()` to `SequenceManager` using validators from PR #1
- Service now accepts optional `canonical_block_rx` channel and processes notifications in the event loop
- Clears pending state on CatchUp, HandleReorg, or DepthLimitExceeded
- Adds `reorg_count` metric counter

## New APIs
- `FlashBlockService::with_canonical_block_rx()` - Sets the canonical block receiver
- `FlashBlockService::with_max_depth()` - Configures max depth (default: 64 blocks)
- `SequenceManager::process_canonical_block()` - Reconciles pending state with canonical
- `SequenceManager::earliest_block_number()` / `latest_block_number()` - Query pending block range

## Test plan
- [x] Test `process_canonical_block` with no pending state → NoPendingState
- [x] Test canonical catches up to pending → CatchUp, state cleared
- [x] Test canonical behind pending → Continue, state preserved
- [x] Test depth limit exceeded → DepthLimitExceeded, state cleared
- [x] Test `earliest_block_number` / `latest_block_number` tracking