### PR TITLE
fix: get delayedweth from opcm implementations and remove proxy fetch

### DIFF
--- a/op-deployer/pkg/deployer/opcm/opchain.go
+++ b/op-deployer/pkg/deployer/opcm/opchain.go
@@ -92,7 +92,6 @@ type ReadImplementationAddressesInput struct {
 	L1StandardBridgeProxy             common.Address
 	OptimismPortalProxy               common.Address
 	DisputeGameFactoryProxy           common.Address
-	DelayedWETHPermissionedGameProxy  common.Address
 	Opcm                              common.Address
 }
 

--- a/op-deployer/pkg/deployer/pipeline/opchain.go
+++ b/op-deployer/pkg/deployer/pipeline/opchain.go
@@ -68,7 +68,6 @@ func DeployOPChain(env *Env, intent *state.Intent, st *state.State, chainID comm
 		L1StandardBridgeProxy:             dco.L1StandardBridgeProxy,
 		OptimismPortalProxy:               dco.OptimismPortalProxy,
 		DisputeGameFactoryProxy:           dco.DisputeGameFactoryProxy,
-		DelayedWETHPermissionedGameProxy:  dco.DelayedWETHPermissionedGameProxy,
 		Opcm:                              dci.Opcm,
 	}
 

--- a/packages/contracts-bedrock/scripts/deploy/ReadImplementationAddresses.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/ReadImplementationAddresses.s.sol
@@ -21,7 +21,6 @@ contract ReadImplementationAddresses is Script {
         address l1StandardBridgeProxy;
         address optimismPortalProxy;
         address disputeGameFactoryProxy;
-        address delayedWETHPermissionedGameProxy;
         address opcm;
     }
 
@@ -52,7 +51,6 @@ contract ReadImplementationAddresses is Script {
 
     function run(Input memory _input) public returns (Output memory output_) {
         // Get implementations from EIP-1967 proxies
-        output_.delayedWETH = getEIP1967Impl(_input.delayedWETHPermissionedGameProxy);
         output_.optimismPortal = getEIP1967Impl(_input.optimismPortalProxy);
         output_.systemConfig = getEIP1967Impl(_input.systemConfigProxy);
         output_.l1ERC721Bridge = getEIP1967Impl(_input.l1ERC721BridgeProxy);


### PR DESCRIPTION
**Description**
Source the `DelayedWETH` implementation from `OPCM.implementations()` only, and stop passing and reading the `DelayedWETHPermissionedGameProxy` proxy for that purpose.