### PR TITLE
fix: revert with reason in UpgradeOPChain and UpgradeSuperchainConfig

### DIFF
--- a/packages/contracts-bedrock/scripts/deploy/UpgradeOPChain.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/UpgradeOPChain.s.sol
@@ -118,7 +118,11 @@ contract UpgradeOPChain is Script {
                 OPContractsManager.upgrade, abi.decode(_upgradeInput, (OPContractsManager.OpChainConfig[]))
             );
         }
-        (bool success,) = _prank.call(data);
-        require(success, "UpgradeOPChain: upgrade failed");
+        (bool success, bytes memory returnData) = _prank.call(data);
+        if (!success) {
+            assembly {
+                revert(add(returnData, 0x20), mload(returnData))
+            }
+        }
     }
 }

--- a/packages/contracts-bedrock/scripts/deploy/UpgradeSuperchainConfig.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/UpgradeSuperchainConfig.s.sol
@@ -77,7 +77,11 @@ contract UpgradeSuperchainConfig is Script {
         } else {
             data = abi.encodeCall(IOPContractsManager.upgradeSuperchainConfig, _input.superchainConfig);
         }
-        (bool success,) = _prank.call(data);
-        require(success, "UpgradeSuperchainConfig: upgrade failed");
+        (bool success, bytes memory returnData) = _prank.call(data);
+        if (!success) {
+            assembly {
+                revert(add(returnData, 0x20), mload(returnData))
+            }
+        }
     }
 }

--- a/packages/contracts-bedrock/test/opcm/UpgradeOPChain.t.sol
+++ b/packages/contracts-bedrock/test/opcm/UpgradeOPChain.t.sol
@@ -407,6 +407,25 @@ contract UpgradeOPChain_Test is Test {
         );
         upgradeOPChain.run(uoci);
     }
+
+    /// @notice This test verifies that the UpgradeOPChain script correctly reverts when the OPCM upgrade
+    /// call fails
+    function test_upgrade_whenOPCMReverts_reverts() public {
+        address systemConfigProxy = makeAddr("systemConfig");
+        config = OPContractsManager.OpChainConfig({
+            systemConfigProxy: ISystemConfig(systemConfigProxy),
+            cannonPrestate: Claim.wrap(bytes32(uint256(1))),
+            cannonKonaPrestate: Claim.wrap(bytes32(uint256(2)))
+        });
+        OPContractsManager.OpChainConfig[] memory configs = new OPContractsManager.OpChainConfig[](1);
+        configs[0] = config;
+        uoci.set(uoci.upgradeInput.selector, configs);
+
+        vm.mockCallRevert(prank, OPContractsManager.upgrade.selector, abi.encode("UpgradeOPChain: upgrade failed"));
+
+        vm.expectRevert("UpgradeOPChain: upgrade failed");
+        upgradeOPChain.run(uoci);
+    }
 }
 
 contract UpgradeOPChain_TestV2 is Test {
@@ -469,6 +488,32 @@ contract UpgradeOPChain_TestV2 is Test {
         emit UpgradeCalled(
             address(upgradeInput.systemConfig), upgradeInput.disputeGameConfigs, upgradeInput.extraInstructions
         );
+        upgradeOPChain.run(uoci);
+    }
+
+    /// @notice This test verifies that the UpgradeOPChain script correctly reverts when the OPCM v2 upgrade
+    /// call fails.
+    function test_upgrade_whenOPCMV2Reverts_reverts() public {
+        address systemConfig = makeAddr("systemConfig");
+        IOPContractsManagerUtils.DisputeGameConfig[] memory disputeGameConfigs =
+            new IOPContractsManagerUtils.DisputeGameConfig[](1);
+        disputeGameConfigs[0] = IOPContractsManagerUtils.DisputeGameConfig({
+            enabled: true,
+            initBond: 1 ether,
+            gameType: GameType.wrap(0),
+            gameArgs: abi.encode("test")
+        });
+
+        OPContractsManagerV2.UpgradeInput memory upgradeInput = OPContractsManagerV2.UpgradeInput({
+            systemConfig: ISystemConfig(systemConfig),
+            disputeGameConfigs: disputeGameConfigs,
+            extraInstructions: new IOPContractsManagerUtils.ExtraInstruction[](0)
+        });
+        uoci.set(uoci.upgradeInput.selector, upgradeInput);
+
+        vm.mockCallRevert(prank, OPContractsManagerV2.upgrade.selector, abi.encode("UpgradeOPChain: upgrade failed"));
+
+        vm.expectRevert("UpgradeOPChain: upgrade failed");
         upgradeOPChain.run(uoci);
     }
 }

--- a/packages/contracts-bedrock/test/opcm/UpgradeSuperchainConfig.t.sol
+++ b/packages/contracts-bedrock/test/opcm/UpgradeSuperchainConfig.t.sol
@@ -8,6 +8,7 @@ import { Test } from "test/setup/Test.sol";
 import { UpgradeSuperchainConfig } from "scripts/deploy/UpgradeSuperchainConfig.s.sol";
 
 // Interfaces
+import { IOPContractsManager } from "interfaces/L1/IOPContractsManager.sol";
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 import { IOPContractsManagerV2 } from "interfaces/L1/opcm/IOPContractsManagerV2.sol";
 import { IOPContractsManagerUtils } from "interfaces/L1/opcm/IOPContractsManagerUtils.sol";
@@ -94,6 +95,19 @@ contract UpgradeSuperchainConfigV1_Run_Test is Test {
         upgradeSuperchainConfig.run(input);
         input.superchainConfig = ISuperchainConfig(address(superchainConfig));
     }
+
+    /// @notice Tests that the UpgradeSuperchainConfig script reverts when the OPCM upgradeSuperchainConfig
+    /// call fails
+    function test_upgrade_whenOPCMReverts_reverts() public {
+        vm.mockCallRevert(
+            prank,
+            IOPContractsManager.upgradeSuperchainConfig.selector,
+            abi.encode("UpgradeSuperchainConfig: upgrade failed")
+        );
+
+        vm.expectRevert("UpgradeSuperchainConfig: upgrade failed");
+        upgradeSuperchainConfig.run(input);
+    }
 }
 
 /// @title UpgradeSuperchainConfigV2_Run_Test
@@ -142,5 +156,20 @@ contract UpgradeSuperchainConfigV2_Run_Test is Test {
             superchainConfig: superchainConfig,
             extraInstructions: extraInstructions
         });
+    }
+
+    /// @notice Tests that the UpgradeSuperchainConfig script reverts when the OPCM v2 upgradeSuperchain
+    /// call fails
+    function test_upgrade_whenOPCMV2Reverts_reverts() public {
+        UpgradeSuperchainConfig.Input memory input = _getInput(new IOPContractsManagerUtils.ExtraInstruction[](0));
+
+        vm.mockCallRevert(
+            prank,
+            IOPContractsManagerV2.upgradeSuperchain.selector,
+            abi.encode("UpgradeSuperchainConfig: upgrade failed")
+        );
+
+        vm.expectRevert("UpgradeSuperchainConfig: upgrade failed");
+        upgradeSuperchainConfig.run(input);
     }
 }


### PR DESCRIPTION
**Description**
When OPCM upgrade calls fail, the scripts `UpgradeOPChain` and  `UpgradeSuperchainConfig ` now surface the real revert reason instead of a generic error. 

**Tests**
Tests were added to cover these failure paths in:
- `packages/contracts-bedrock/test/opcm/UpgradeOPChain.t.sol`
- `packages/contracts-bedrock/test/opcm/UpgradeSuperchainConfig.t.sol`