### PR TITLE
ci: test factory reusable workflow upgrade

### DIFF
--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -66,7 +66,7 @@ jobs:
           - op-interop-mon
           - op-rbuilder
           - kona-node
-    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@f8f3cb4800e538003134fb5f50cc734c2c98d762
+    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@78b6ef16e6c904406484106efe8c15189f36a23c
     with:
       mode: bake
       image_name: ${{ matrix.image_name }}
@@ -109,7 +109,7 @@ jobs:
           - op-interop-mon
           - op-rbuilder
           - kona-node
-    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@f8f3cb4800e538003134fb5f50cc734c2c98d762
+    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@78b6ef16e6c904406484106efe8c15189f36a23c
     with:
       mode: bake
       image_name: ${{ matrix.image_name }}


### PR DESCRIPTION
## Summary

Testing backward compatibility of the factory reusable workflow upgrade.

The factory workflow was updated to support building from external repositories via `source_repo` input. This PR verifies that the default behavior (using git context from the calling repo) still works correctly.

## Changes in factory

- Added `source_repo` and `source_ref` inputs for building from external repositories
- Added `source_token` secret for private repository access
- Made GCP auth conditional on `gcp_project_id` being set
- When `source_repo` is empty (default), behavior is unchanged

## Test plan

- [ ] Verify the `build` job completes successfully (default git context)
- [ ] Verify the `build-fork` job logic is unchanged