### PR TITLE
fix(op-service): bump websocket read limit to 10MB to not fail when reading the Flashblocks websocket stream

### DIFF
--- a/op-service/client/ws.go
+++ b/op-service/client/ws.go
@@ -96,6 +96,7 @@ func DialWS(ctx context.Context, cfg WSConfig) (*WSClient, error) {
 		}
 		return nil, err
 	}
+	conn.SetReadLimit(1024 * 1024 * 10) // Set the read limit per-message to 10MB
 
 	if cfg.Log != nil {
 		cfg.Log.Info("Websocket connection established", "url", cfg.URL)


### PR DESCRIPTION
**Description**

Using `op-conductor` as a layer in between the `websocket-proxy` and `rollup-boost` allows us to have confidence that we are always only streaming Flashblocks from the active leader at a given time. However, the Websocket Driver being used from the `coder/websocket` library defaults to having a read limit per message of ~32kb. 

This limit is exceeded very regularly on Base Mainnet, and occasionally on Base Sepolia. Using `op-conductor` as the middleman then means that it fails to read messages from `rollup-boost` occasionally, and therefore downstream customers end up missing Flashblocks in between as those Flashblocks never make it to the `websocket-proxy` server.

This PR bumps the read limit from the default 32kb to 10MB, which should be more than enough buffer for any use case. Since all listeners are to trusted endpoints only, the increased buffer does not open any external DoS vectors and feels reasonable.

**Tests**

N/A

**Additional context**

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
