### PR TITLE
Fix unbound variable error in build-prestates.sh

### DIFF
--- a/op-program/scripts/build-prestates.sh
+++ b/op-program/scripts/build-prestates.sh
@@ -92,6 +92,7 @@ function build_prestates() {
     # jq should already be preinstalled in the mise cache.
     # Replace mise.toml with a minimal one to avoid conflicts with other preinstalled dependencies.
     GO_VERSION=$(mise config get tools.go)
+    JUST_VERSION=$(mise config get tools.just)
     cat > mise.toml << EOF
 [tools]
 go = "${GO_VERSION}"


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Adds missing definition of `JUST_VERSION` to fix "unbound variable" error in `build-prestates.sh`.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
