### PR TITLE
txmgr: use blob tip cap during fee increases

### DIFF
--- a/op-batcher/batcher/service.go
+++ b/op-batcher/batcher/service.go
@@ -289,6 +289,8 @@ func (bs *BatcherService) initBlobTipOracle(ctx context.Context, cfg *CLIConfig)
 	// Create the oracle with default config
 	oracleConfig := bgpo.DefaultBlobTipOracleConfig()
 	oracleConfig.NetworkTimeout = bs.NetworkTimeout
+	oracleConfig.MaxBlocks = cfg.TxMgrConfig.BlobTipCapRange
+	oracleConfig.Percentile = cfg.TxMgrConfig.BlobTipCapPercentile
 	minTipCap, err := eth.GweiToWei(cfg.TxMgrConfig.MinTipCapGwei)
 	if err != nil {
 		return fmt.Errorf("invalid min tip cap: %w", err)

--- a/op-service/bgpo/oracle.go
+++ b/op-service/bgpo/oracle.go
@@ -375,7 +375,7 @@ func (o *BlobTipOracle) SuggestBlobTipCap(ctx context.Context, maxBlocks int, pe
 	}
 
 	// No blob transactions found, use the default priority fee - that should almost never happen, so we warn about it
-	o.log.Warn("No recent blob transactions found, using blob base fee + buffer", "block", latestBlockNum, "default_priority_fee", o.config.DefaultPriorityFee.String())
+	o.log.Warn("No recent blob transactions found, using default prio fee", "block", latestBlockNum, "defaultPriorityFee", o.config.DefaultPriorityFee)
 	return new(big.Int).Set(o.config.DefaultPriorityFee), nil
 }
 

--- a/op-service/txmgr/txmgr.go
+++ b/op-service/txmgr/txmgr.go
@@ -359,11 +359,18 @@ func (m *SimpleTxManager) craftTx(ctx context.Context, candidate TxCandidate) (*
 		m.metr.RPCError()
 		return nil, fmt.Errorf("failed to get gas price info or it's too high: %w", err)
 	}
+	isBlobTx := len(candidate.Blobs) > 0
+	if isBlobTx {
+		if blobTipCap == nil {
+			return nil, errors.New("expected non-nil blobTipCap for blob tx")
+		}
+		gasTipCap = blobTipCap
+	}
 	gasFeeCap := calcGasFeeCap(baseFee, gasTipCap)
 
 	var sidecar *types.BlobTxSidecar
 	var blobHashes []common.Hash
-	if len(candidate.Blobs) > 0 {
+	if isBlobTx {
 		if candidate.To == nil {
 			return nil, errors.New("blob txs cannot deploy contracts")
 		}
@@ -385,7 +392,7 @@ func (m *SimpleTxManager) craftTx(ctx context.Context, candidate TxCandidate) (*
 	}
 
 	var txMessage types.TxData
-	if sidecar != nil {
+	if isBlobTx {
 		if blobBaseFee == nil {
 			return nil, errors.New("expected non-nil blobBaseFee")
 		}
@@ -396,13 +403,6 @@ func (m *SimpleTxManager) craftTx(ctx context.Context, candidate TxCandidate) (*
 			Gas:        candidate.GasLimit,
 			BlobHashes: blobHashes,
 			Sidecar:    sidecar,
-		}
-
-		if !m.cfg.BlobTipCapDynamic.Load() {
-			m.l.Debug("Using static blob tip cap", "blobTipCap", gasTipCap, "oracleSuggestion", blobTipCap)
-			blobTipCap = gasTipCap
-		} else {
-			m.l.Info("Using dynamic blob tip cap", "blobTipCap", blobTipCap, "gasTipCap", gasTipCap)
 		}
 
 		if err := finishBlobTx(message, m.chainID, blobTipCap, gasFeeCap, blobFeeCap, candidate.Value); err != nil {
@@ -918,13 +918,15 @@ func (m *SimpleTxManager) queryReceipt(ctx context.Context, txHash common.Hash, 
 func (m *SimpleTxManager) increaseGasPrice(ctx context.Context, tx *types.Transaction) (*types.Transaction, error) {
 	m.txLogger(tx, true).Info("bumping gas price for transaction")
 	tip, baseFee, blobTipCap, blobBaseFee, err := m.SuggestGasPriceCaps(ctx)
-	// TODO(18618): when activating the blob tip oracle, integrate blobTipCap into the rest of the logic around bumping the gas price when replacing txs
-	_ = blobTipCap
 	if err != nil {
 		m.txLogger(tx, false).Warn("failed to get suggested gas tip and base fee", "err", err)
 		return nil, err
 	}
-	bumpedTip, bumpedFee := updateFees(tx.GasTipCap(), tx.GasFeeCap(), tip, baseFee, tx.Type() == types.BlobTxType, m.l)
+	isBlobTx := tx.Type() == types.BlobTxType
+	if isBlobTx {
+		tip = blobTipCap
+	}
+	bumpedTip, bumpedFee := updateFees(tx.GasTipCap(), tx.GasFeeCap(), tip, baseFee, isBlobTx, m.l)
 
 	if err := m.checkLimits(tip, baseFee, bumpedTip, bumpedFee); err != nil {
 		return nil, err
@@ -940,7 +942,7 @@ func (m *SimpleTxManager) increaseGasPrice(ctx context.Context, tx *types.Transa
 		Value:     tx.Value(),
 	}
 	var bumpedBlobFee *big.Int
-	if tx.Type() == types.BlobTxType {
+	if isBlobTx {
 		// Blob transactions have an additional blob gas price we must specify, so we must make sure it is
 		// getting bumped appropriately.
 		bumpedBlobFee = calcThresholdValue(tx.BlobGasFeeCap(), true)
@@ -1022,7 +1024,7 @@ func (m *SimpleTxManager) SuggestGasPriceCaps(ctx context.Context) (*big.Int, *b
 	cCtx, cancel := context.WithTimeout(ctx, m.cfg.NetworkTimeout)
 	defer cancel()
 
-	tip, baseFee, blobTipCap, blobBaseFee, err := m.gasPriceEstimatorFn(cCtx, m.backend)
+	tip, baseFee, blobTip, blobBaseFee, err := m.gasPriceEstimatorFn(cCtx, m.backend)
 	if err != nil {
 		m.metr.RPCError()
 		return nil, nil, nil, nil, fmt.Errorf("failed to get gas price estimates: %w", err)
@@ -1031,29 +1033,34 @@ func (m *SimpleTxManager) SuggestGasPriceCaps(ctx context.Context) (*big.Int, *b
 	m.metr.RecordTipCap(tip)
 	m.metr.RecordBaseFee(baseFee)
 	m.metr.RecordBlobBaseFee(blobBaseFee)
-	m.metr.RecordBlobTipCap(blobTipCap)
+	m.metr.RecordBlobTipCap(blobTip)
 
 	// Enforce minimum base fee and tip cap
 	minTipCap := m.cfg.MinTipCap.Load()
 	maxTipCap := m.cfg.MaxTipCap.Load()
 	minBaseFee := m.cfg.MinBaseFee.Load()
 	maxBaseFee := m.cfg.MaxBaseFee.Load()
+	dynamicBlobTipCap := m.cfg.BlobTipCapDynamic.Load()
 
-	// Enforce minimum tip cap (for non-blob txs)
+	m.l.Info("Estimated gas fees & tip caps", "gasTipCap", tip, "baseFee", baseFee,
+		"blobTipCap", blobTip, "blobBaseFee", blobBaseFee, "dynamicBlobTipCap", dynamicBlobTipCap)
+
+	// Enforce tip cap limits
 	if minTipCap != nil && tip.Cmp(minTipCap) == -1 {
 		m.l.Debug("Enforcing min tip cap", "minTipCap", minTipCap, "origTipCap", tip)
 		tip = new(big.Int).Set(minTipCap)
 	}
+
+	if !m.cfg.BlobTipCapDynamic.Load() {
+		// if not using dynamic blob tip cap, set blob tip to normal tip
+		blobTip = tip
+	}
+
 	if maxTipCap != nil && tip.Cmp(maxTipCap) > 0 {
 		return nil, nil, nil, nil, fmt.Errorf("tip is too high: %v, cap:%v", tip, maxTipCap)
 	}
-
-	// Comparing if the configured min tip cap is higher than the suggested blob tip cap, and if so, it means we are overpaying for the transaction
-	if minTipCap != nil && blobTipCap.Cmp(minTipCap) == -1 {
-		m.l.Warn("Suggested blobTipCap is lower than the configured min tip cap for blob txs", "minTipCap", minTipCap, "blobTipCap", blobTipCap)
-	}
-	if maxTipCap != nil && blobTipCap.Cmp(maxTipCap) > 0 {
-		return nil, nil, nil, nil, fmt.Errorf("blob tip cap is too high: %v, cap:%v", blobTipCap, maxTipCap)
+	if maxTipCap != nil && blobTip.Cmp(maxTipCap) > 0 {
+		return nil, nil, nil, nil, fmt.Errorf("blob tip cap is too high: %v, cap:%v", blobTip, maxTipCap)
 	}
 
 	if minBaseFee != nil && baseFee.Cmp(minBaseFee) == -1 {
@@ -1064,8 +1071,7 @@ func (m *SimpleTxManager) SuggestGasPriceCaps(ctx context.Context) (*big.Int, *b
 		return nil, nil, nil, nil, fmt.Errorf("baseFee is too high: %v, cap:%v", baseFee, maxBaseFee)
 	}
 
-	m.l.Info("Suggested gas price caps", "gasTipCap", tip, "baseFee", baseFee, "blobTipCap", blobTipCap, "blobBaseFee", blobBaseFee)
-	return tip, baseFee, blobTipCap, blobBaseFee, nil
+	return tip, baseFee, blobTip, blobBaseFee, nil
 }
 
 // checkLimits checks that the tip and baseFee have not increased by more than the configured multipliers


### PR DESCRIPTION
## Summary
- Use blob tip cap (instead of regular tip cap) when bumping fees for blob transactions in `increaseGasPrice`
- Previously, blob tip cap was only used during initial tx creation (`craftTx`)
- Add test coverage for blob tx fee bumping with distinct blob tip cap vs regular tip cap

## Test plan
- [x] Existing `TestIncreaseGasPrice` tests pass
- [x] New test case `blob tx uses blob tip cap instead of regular tip cap` verifies the correct behavior
- [x] All txmgr tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)