### PR TITLE
Add workaround for old buildx version

### DIFF
--- a/kona/docker/fpvm-prestates/justfile
+++ b/kona/docker/fpvm-prestates/justfile
@@ -41,8 +41,18 @@ build-client-prestate-cannon-artifacts \
   mkdir -p $OUTPUT_DIR
 
   echo "Building kona-client (variant: {{kona_client_variant}}) prestate artifacts for the cannon target. 🔫 Cannon Tag: {{cannon_tag}}"
+
+  # Build the --allow flag conditionally (requires Docker Buildx v0.15.0+)
+  ALLOW_FLAG=""
+  BUILDX_VERSION=$(docker buildx version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "0.0.0")
+  MAJOR=$(echo "$BUILDX_VERSION" | cut -d. -f1)
+  MINOR=$(echo "$BUILDX_VERSION" | cut -d. -f2)
+  if [[ "$MAJOR" -gt 0 ]] || [[ "$MAJOR" -eq 0 && "$MINOR" -ge 15 ]]; then
+    ALLOW_FLAG="--allow fs=${CUSTOM_CONFIGS_CONTEXT}"
+  fi
+
   docker buildx bake \
     --set "*.output=$OUTPUT_DIR" \
     -f docker/docker-bake.hcl \
-    --allow fs=${CUSTOM_CONFIGS_CONTEXT} \
+    $ALLOW_FLAG \
     kona-cannon-prestate

--- a/op-devstack/sysgo/l1_nodes.go
+++ b/op-devstack/sysgo/l1_nodes.go
@@ -131,11 +131,8 @@ func WithL1NodesInProcess(l1ELID stack.L1ELNodeID, l1CLID stack.L1CLNodeID) stac
 		})
 
 		l1ELNode := &L1Geth{
-			id: l1ELID,
-			// Use WS for user RPC so op-node components (and op-supernode virtual nodes)
-			// can subscribe to L1 head updates. Using HTTP here causes HeadL1 to remain zero,
-			// which can stall components like the batcher that wait for initialized sync status.
-			userRPC:  firstNonEmpty(l1Geth.Node.WSEndpoint(), l1Geth.Node.HTTPEndpoint()),
+			id:       l1ELID,
+			userRPC:  l1Geth.Node.HTTPEndpoint(),
 			authRPC:  l1Geth.Node.HTTPAuthEndpoint(),
 			l1Geth:   l1Geth,
 			blobPath: blobPath,

--- a/op-devstack/sysgo/l1_nodes.go
+++ b/op-devstack/sysgo/l1_nodes.go
@@ -149,15 +149,6 @@ func WithL1NodesInProcess(l1ELID stack.L1ELNodeID, l1CLID stack.L1CLNodeID) stac
 	})
 }
 
-func firstNonEmpty(values ...string) string {
-	for _, v := range values {
-		if v != "" {
-			return v
-		}
-	}
-	return ""
-}
-
 // WithExtL1Nodes initializes L1 EL and CL nodes that connect to external RPC endpoints
 func WithExtL1Nodes(l1ELID stack.L1ELNodeID, l1CLID stack.L1CLNodeID, elRPCEndpoint string, clRPCEndpoint string) stack.Option[*Orchestrator] {
 	return stack.AfterDeploy(func(orch *Orchestrator) {


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

https://github.com/ethereum-optimism/optimism/pull/18879 introduced major changes to building prestates, and fixed some CI issues that hadn't been tackled yet witht the kona import to the monorepo. It broke some things that can't easily be found locally.

This is claude's fix for [this `unknown flag: --allow` error in CI](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/114412/workflows/2702298f-b836-4947-a797-4c3ac9944e78/jobs/4350736).

It looks like docker buildx in this repo's CI may be an old version that doesn't support the --allow flag. The kona prestate build config that was recently imported into the monorepo uses it. This is a workaround. (Claude is pretty sure that older versions which don't support --allow will still work because on older versions filesystem access was allowed by default, so omitting the flag should work correctly. This is hard to test locally so we'll see.

This PR also reverts a workaround that made devstack prefer ws:// connections because HTTP wasn't working properly with supernode. It's safe to revert because [supernode now supports HTTP polling](https://github.com/ethereum-optimism/optimism/pull/18970/changes#diff-fe13fa33c0b86acb7caa9bac88dabf8b0d7724bfa147abded41f80dd343d7eb5R273).

This is probably not the last build fix for this set of changes since the only way to test is in CI.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
