### PR TITLE
txmgr: move BlobTipOracle ownership to txmgr

### DIFF
--- a/op-batcher/batcher/service.go
+++ b/op-batcher/batcher/service.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math/big"
 	"sync/atomic"
 	"time"
 
@@ -20,9 +19,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/chaincfg"
 	"github.com/ethereum-optimism/optimism/op-node/params"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
-	"github.com/ethereum-optimism/optimism/op-service/bgpo"
 	"github.com/ethereum-optimism/optimism/op-service/cliapp"
-	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/dial"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/httputil"
@@ -83,10 +80,6 @@ type BatcherService struct {
 	stopped         atomic.Bool
 
 	NotSubmittingOnStart bool
-
-	// BlobGasPriceOracle tracks blob base gas prices for dynamic pricing
-	blobTipOracle *bgpo.BlobTipOracle
-	oracleStopCh  chan struct{}
 }
 
 type DriverSetupOption func(setup *DriverSetup)
@@ -261,58 +254,6 @@ func (bs *BatcherService) initRollupConfig(ctx context.Context) error {
 	return nil
 }
 
-func (bs *BatcherService) initBlobTipOracle(ctx context.Context, cfg *CLIConfig) error {
-	// Only initialize the oracle if we're using blobs or auto mode
-	if cfg.DataAvailabilityType != flags.BlobsType && cfg.DataAvailabilityType != flags.AutoType {
-		bs.Log.Debug("Skipping blob tip oracle initialization (not using blobs)")
-		return nil
-	}
-
-	// Get RPC client from L1 client
-	// The ethclient.Client has a Client() method that returns the underlying *rpc.Client
-	rpcClient := bs.L1Client.Client()
-	if rpcClient == nil {
-		return fmt.Errorf("failed to get RPC client from L1 client")
-	}
-
-	// Get L1 chain config from rollup config
-	l1ChainID := eth.ChainIDFromBig(bs.RollupConfig.L1ChainID)
-	l1ChainConfig := eth.L1ChainConfigByChainID(l1ChainID)
-	if l1ChainConfig == nil {
-		bs.Log.Info("Blob tip oracle not initialized when L1 chain ID is not known (Ethereum mainnet, Sepolia, Holesky, Hoodi)")
-		return nil
-	}
-
-	// Wrap the RPC client to match the client.RPC interface
-	baseRPCClient := client.NewBaseRPCClient(rpcClient)
-
-	// Create the oracle with default config
-	oracleConfig := bgpo.DefaultBlobTipOracleConfig()
-	oracleConfig.NetworkTimeout = bs.NetworkTimeout
-	oracleConfig.MaxBlocks = cfg.TxMgrConfig.BlobTipCapRange
-	oracleConfig.Percentile = cfg.TxMgrConfig.BlobTipCapPercentile
-	minTipCap, err := eth.GweiToWei(cfg.TxMgrConfig.MinTipCapGwei)
-	if err != nil {
-		return fmt.Errorf("invalid min tip cap: %w", err)
-	}
-	oracleConfig.DefaultPriorityFee = minTipCap
-	bs.blobTipOracle = bgpo.NewBlobTipOracle(ctx, baseRPCClient, l1ChainConfig, bs.Log, oracleConfig)
-	bs.oracleStopCh = make(chan struct{})
-
-	bs.Log.Info("Initialized blob tip oracle")
-
-	// Start the blob tip oracle if it's initialized
-	go func() {
-		if err := bs.blobTipOracle.Start(); err != nil {
-			bs.Log.Error("Blob tip oracle stopped with error", "err", err)
-		}
-		close(bs.oracleStopCh)
-	}()
-	bs.blobTipOracle.WaitCachePopulated()
-	bs.Log.Info("Started blob tip oracle")
-	return nil
-}
-
 func (bs *BatcherService) initChannelConfig(cfg *CLIConfig) error {
 	channelTimeout := bs.RollupConfig.ChannelTimeoutBedrock
 	// Use lower channel timeout if granite is scheduled.
@@ -399,48 +340,26 @@ func (bs *BatcherService) initChannelConfig(cfg *CLIConfig) error {
 	return nil
 }
 
-func (bs *BatcherService) initTxManager(ctx context.Context, cfg *CLIConfig) error {
-	// Initialize the blob tip oracle first
-	if err := bs.initBlobTipOracle(ctx, cfg); err != nil {
-		return fmt.Errorf("failed to init blob tip oracle: %w", err)
-	}
-
+func (bs *BatcherService) initTxManager(_ context.Context, cfg *CLIConfig) error {
 	// Create the base config from CLI config
 	txmgrConfig, err := txmgr.NewConfig(cfg.TxMgrConfig, bs.Log)
 	if err != nil {
 		return err
 	}
 
-	// Create a custom gas price estimator that uses the blob tip oracle if available
-	if bs.blobTipOracle != nil {
-		blobTipCapRange := txmgrConfig.BlobTipCapRange
-		blobTipCapPercentile := txmgrConfig.BlobTipCapPercentile
-
-		txmgrConfig.GasPriceEstimatorFn = func(ctx context.Context, backend txmgr.ETHBackend) (*big.Int, *big.Int, *big.Int, *big.Int, error) {
-			tip, err := backend.SuggestGasTipCap(ctx)
-			if err != nil {
-				return nil, nil, nil, nil, err
+	// Configure BTOConfig if using blobs or auto mode
+	if cfg.DataAvailabilityType == flags.BlobsType || cfg.DataAvailabilityType == flags.AutoType {
+		l1ChainID := eth.ChainIDFromBig(bs.RollupConfig.L1ChainID)
+		l1ChainConfig := eth.L1ChainConfigByChainID(l1ChainID)
+		if l1ChainConfig == nil {
+			bs.Log.Warn("Blob tip oracle not initialized: L1 chain config not found for chain ID", "chainID", l1ChainID)
+		} else {
+			txmgrConfig.BTOConfig = &txmgr.BTOConfig{
+				Backend:              bs.L1Client, // ethclient implements BTOBackend
+				ChainConfig:          l1ChainConfig,
+				BlobTipCapRange:      cfg.TxMgrConfig.BlobTipCapRange,
+				BlobTipCapPercentile: cfg.TxMgrConfig.BlobTipCapPercentile,
 			}
-
-			head, err := backend.HeaderByNumber(ctx, nil)
-			if err != nil {
-				return nil, nil, nil, nil, err
-			}
-			if head.BaseFee == nil {
-				return nil, nil, nil, nil, errors.New("txmgr does not support pre-london blocks that do not have a base fee")
-			}
-
-			blobBaseFee, err := backend.BlobBaseFee(ctx)
-			if err != nil {
-				return nil, nil, nil, nil, err
-			}
-
-			suggestedBlobFeeCap, err := bs.blobTipOracle.SuggestBlobTipCap(ctx, blobTipCapRange, blobTipCapPercentile)
-			if err != nil {
-				return nil, nil, nil, nil, fmt.Errorf("blob tip oracle failed to suggest blob tip fee: %w", err)
-			}
-
-			return tip, head.BaseFee, suggestedBlobFeeCap, blobBaseFee, nil
 		}
 	}
 
@@ -574,22 +493,9 @@ func (bs *BatcherService) Stop(ctx context.Context) error {
 
 	// close the TxManager first, so that new work is denied, in-flight work is cancelled as early as possible
 	// (transactions which are expected to be confirmed are still waited for)
+	// TxManager.Close() also stops the blob tip oracle if it's running.
 	if bs.TxManager != nil {
 		bs.TxManager.Close()
-	}
-
-	// Stop the blob tip oracle if it's running
-	if bs.blobTipOracle != nil {
-		bs.blobTipOracle.Close()
-		// Wait for the oracle goroutine to finish
-		if bs.oracleStopCh != nil {
-			select {
-			case <-bs.oracleStopCh:
-				// Oracle stopped
-			case <-ctx.Done():
-				// Context cancelled, force stop
-			}
-		}
 	}
 
 	var result error

--- a/op-deployer/pkg/deployer/broadcaster/gas_estimator.go
+++ b/op-deployer/pkg/deployer/broadcaster/gas_estimator.go
@@ -16,9 +16,6 @@ var (
 	// dummyBlobFee is a dummy value for the blob fee. Since this gas estimator will never
 	// post blobs, it's just set to 1.
 	dummyBlobFee = big.NewInt(1)
-	// dummyBlobTipCap is a dummy value for the blob tip cap. Since this gas estimator will never
-	// post blobs, it's just set to 0.
-	dummyBlobTipCap = big.NewInt(0)
 	// maxTip is the maximum tip that can be suggested by this estimator.
 	maxTip = big.NewInt(50 * 1e9)
 	// minTip is the minimum tip that can be suggested by this estimator.
@@ -28,15 +25,15 @@ var (
 // DeployerGasPriceEstimator is a custom gas price estimator for use with op-deployer.
 // It pads the base fee by 50% and multiplies the suggested tip by 5 up to a max of
 // 50 gwei.
-func DeployerGasPriceEstimator(ctx context.Context, client txmgr.ETHBackend) (*big.Int, *big.Int, *big.Int, *big.Int, error) {
+func DeployerGasPriceEstimator(ctx context.Context, client txmgr.ETHBackend) (*big.Int, *big.Int, *big.Int, error) {
 	chainHead, err := client.HeaderByNumber(ctx, nil)
 	if err != nil {
-		return nil, nil, nil, nil, fmt.Errorf("failed to get block: %w", err)
+		return nil, nil, nil, fmt.Errorf("failed to get block: %w", err)
 	}
 
 	tip, err := client.SuggestGasTipCap(ctx)
 	if err != nil {
-		return nil, nil, nil, nil, fmt.Errorf("failed to get gas tip cap: %w", err)
+		return nil, nil, nil, fmt.Errorf("failed to get gas tip cap: %w", err)
 	}
 
 	baseFeePad := new(big.Int).Div(chainHead.BaseFee, baseFeePadFactor)
@@ -51,5 +48,5 @@ func DeployerGasPriceEstimator(ctx context.Context, client txmgr.ETHBackend) (*b
 		paddedTip.Set(maxTip)
 	}
 
-	return paddedTip, paddedBaseFee, dummyBlobTipCap, dummyBlobFee, nil
+	return paddedTip, paddedBaseFee, dummyBlobFee, nil
 }

--- a/op-e2e/system/da/eip4844_test.go
+++ b/op-e2e/system/da/eip4844_test.go
@@ -294,7 +294,7 @@ func TestBatcherAutoDA(t *testing.T) {
 
 	// Helpers
 	mustGetFees := func() (*big.Int, *big.Int, *big.Int, float64) {
-		tip, baseFee, _, blobBaseFee, err := txmgr.DefaultGasPriceEstimatorFn(ctx, l1Client)
+		tip, baseFee, blobBaseFee, err := txmgr.DefaultGasPriceEstimatorFn(ctx, l1Client)
 		require.NoError(t, err)
 		feeRatio := float64(blobBaseFee.Int64()) / float64(baseFee.Int64()+tip.Int64())
 		t.Logf("L1 fees are: baseFee(%d), tip(%d), blobBaseFee(%d). feeRatio: %f", baseFee, tip, blobBaseFee, feeRatio)

--- a/op-service/bgpo/oracle.go
+++ b/op-service/bgpo/oracle.go
@@ -9,23 +9,30 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/consensus/misc/eip4844"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
-	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/sources/caching"
 )
+
+// BTOBackend is the interface for the blob tip oracle to interact with the L1 chain.
+// ethclient.Client implements this interface.
+type BTOBackend interface {
+	BlockNumber(ctx context.Context) (uint64, error)
+	HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error)
+	BlockByNumber(ctx context.Context, number *big.Int) (*types.Block, error)
+	SubscribeNewHead(ctx context.Context, ch chan<- *types.Header) (ethereum.Subscription, error)
+}
 
 // BlobTipOracle tracks blob base gas prices by subscribing to new block headers
 // and extracts the blob tip caps from blob txs from each block.
 type BlobTipOracle struct {
 	sync.Mutex
 
-	client      *client.PollingClient
+	backend     BTOBackend
 	chainConfig *params.ChainConfig
 	log         log.Logger
 	config      *BlobTipOracleConfig
@@ -42,17 +49,8 @@ type BlobTipOracle struct {
 	ctx    context.Context
 	cancel context.CancelFunc
 
-	sub ethereum.Subscription
-
-	cachePopulated chan struct{}
-}
-
-// rpcBlock structure for fetching blocks with transactions.
-// When eth_getBlockByNumber is called with true, it returns full transaction objects.
-type rpcBlock struct {
-	Number       hexutil.Uint64       `json:"number"`
-	Hash         hexutil.Bytes        `json:"hash"`
-	Transactions []*types.Transaction `json:"transactions"`
+	sub      ethereum.Subscription
+	loopDone chan struct{}
 }
 
 // BlobTipOracleConfig configures the blob tip oracle.
@@ -91,7 +89,7 @@ func DefaultBlobTipOracleConfig() *BlobTipOracleConfig {
 
 // NewBlobTipOracle creates a new blob tip oracle that will subscribe
 // to newHeads and track blob base fees, and extract blob tip caps from blob txs.
-func NewBlobTipOracle(ctx context.Context, rpcClient client.RPC, chainConfig *params.ChainConfig, log log.Logger, config *BlobTipOracleConfig) *BlobTipOracle {
+func NewBlobTipOracle(backend BTOBackend, chainConfig *params.ChainConfig, log log.Logger, config *BlobTipOracleConfig) *BlobTipOracle {
 	defaultConfig := DefaultBlobTipOracleConfig()
 	if config == nil {
 		config = defaultConfig
@@ -109,42 +107,22 @@ func NewBlobTipOracle(ctx context.Context, rpcClient client.RPC, chainConfig *pa
 		config.Percentile = defaultConfig.Percentile
 	}
 
-	logger := log.With("module", "bgpo")
-
-	pollClient := client.NewPollingClient(ctx, logger, rpcClient, client.WithPollRate(config.PollRate))
-
-	oracleCtx, cancel := context.WithCancel(ctx)
+	oracleCtx, cancel := context.WithCancel(context.Background())
 	return &BlobTipOracle{
-		config:         config,
-		client:         pollClient,
-		chainConfig:    chainConfig,
-		log:            log.With("module", "bgpo"),
-		baseFees:       caching.NewLRUCache[uint64, *big.Int](config.Metrics, "bgpo_prices", config.PricesCacheSize),
-		priorityFees:   caching.NewLRUCache[uint64, []*big.Int](config.Metrics, "bgpo_tips", config.BlockCacheSize),
-		ctx:            oracleCtx,
-		cancel:         cancel,
-		cachePopulated: make(chan struct{}),
+		config:       config,
+		backend:      backend,
+		chainConfig:  chainConfig,
+		log:          log.With("module", "bgpo"),
+		baseFees:     caching.NewLRUCache[uint64, *big.Int](config.Metrics, "bgpo_prices", config.PricesCacheSize),
+		priorityFees: caching.NewLRUCache[uint64, []*big.Int](config.Metrics, "bgpo_tips", config.BlockCacheSize),
+		ctx:          oracleCtx,
+		cancel:       cancel,
 	}
 }
 
-// WaitCachePopulated waits for the cache to be populated.
-func (o *BlobTipOracle) WaitCachePopulated() {
-	select {
-	case <-o.cachePopulated:
-		o.log.Info("Done waiting for cache pre-population")
-		return
-	case <-o.ctx.Done():
-		o.log.Error("Cache pre-population timed out", "ctx", o.ctx.Err())
-		return
-	case <-time.After(o.config.NetworkTimeout * time.Duration(o.config.MaxBlocks)):
-		o.log.Error("Cache pre-population timed out after timeout", "timeout", o.config.NetworkTimeout, "maxBlocks", o.config.MaxBlocks)
-		return
-	}
-}
-
-// Start begins subscribing to newHeads and processing headers.
-// Before subscribing, it pre-populates the cache with the last MaxBlocks blocks.
-// This method blocks until the context is canceled or an error occurs.
+// Start starts the oracle's background processing. It returns after the cache is prepopulated and
+// the subscription is set up. To stop the background processing, call [BlobTipOracle.Close]. The
+// background processing will also stop if the subscription fails.
 func (o *BlobTipOracle) Start() error {
 	// Pre-populate cache with recent blocks before subscribing
 	if err := o.prePopulateCache(); err != nil {
@@ -153,53 +131,55 @@ func (o *BlobTipOracle) Start() error {
 
 	headers := make(chan *types.Header, 10)
 
-	doSubscribe := func(ch chan<- *types.Header) (ethereum.Subscription, error) {
-		return o.client.Subscribe(o.ctx, "eth", ch, "newHeads")
-	}
-
-	sub, err := doSubscribe(headers)
+	sub, err := o.backend.SubscribeNewHead(o.ctx, headers)
 	if err != nil {
 		return err
 	}
 	o.sub = sub
-
 	o.log.Info("Blob tip oracle started, subscribed to newHeads")
+
+	o.loopDone = make(chan struct{})
+	go o.processHeaders(headers)
+	return nil
+}
+
+func (o *BlobTipOracle) processHeaders(headers chan *types.Header) {
+	defer o.log.Debug("Blob tip oracle header processing loop exited")
+	defer close(o.loopDone)
 
 	// Process headers as they arrive
 	for {
 		select {
 		case header := <-headers:
 			if err := o.processHeader(header); err != nil {
-				o.log.Error("Error processing header", "err", err, "block", bigs.Uint64Strict(header.Number))
+				o.log.Error("Error processing header", "err", err, "block", header.Number)
 			}
-		case err := <-sub.Err():
+		case err := <-o.sub.Err():
 			if err != nil {
 				o.log.Error("Subscription error", "err", err)
-				return err
+				return
 			}
-			return nil
+			return
 		case <-o.ctx.Done():
 			o.log.Info("Blob tip oracle context canceled")
-			return nil
+			return
 		}
 	}
 }
 
 // prePopulateCache fetches and processes the last MaxBlocks blocks to pre-populate the cache.
 func (o *BlobTipOracle) prePopulateCache() error {
-	defer close(o.cachePopulated) // signal that the cache is populated and we can start using the oracle
 	now := time.Now()
 
 	ctx, cancel := context.WithTimeout(o.ctx, o.config.NetworkTimeout)
 	defer cancel()
 
 	// Get the latest block number
-	var latestBlockNum hexutil.Uint64
-	if err := o.client.CallContext(ctx, &latestBlockNum, "eth_blockNumber"); err != nil {
+	latest, err := o.backend.BlockNumber(ctx)
+	if err != nil {
 		return fmt.Errorf("failed to get latest block number: %w", err)
 	}
 
-	latest := uint64(latestBlockNum)
 	var startBlock uint64
 	if latest >= uint64(o.config.MaxBlocks) {
 		startBlock = latest - uint64(o.config.MaxBlocks) + 1
@@ -212,9 +192,8 @@ func (o *BlobTipOracle) prePopulateCache() error {
 	// Fetch and process each block
 	for blockNum := startBlock; blockNum <= latest; blockNum++ {
 		// Fetch header
-		var header *types.Header
-		blockNumHex := hexutil.EncodeUint64(blockNum)
-		if err := o.client.CallContext(ctx, &header, "eth_getBlockByNumber", blockNumHex, false); err != nil {
+		header, err := o.backend.HeaderByNumber(ctx, big.NewInt(int64(blockNum)))
+		if err != nil {
 			o.log.Debug("Failed to fetch header for pre-population", "block", blockNum, "err", err)
 			continue
 		}
@@ -282,9 +261,8 @@ func (o *BlobTipOracle) fetchBlockBlobFeeCaps(blockNum uint64, baseFee *big.Int)
 	defer cancel()
 
 	// Fetch the block
-	var block rpcBlock
-	blockNumHex := hexutil.EncodeUint64(blockNum)
-	if err := o.client.CallContext(ctx, &block, "eth_getBlockByNumber", blockNumHex, true); err != nil {
+	block, err := o.backend.BlockByNumber(ctx, big.NewInt(int64(blockNum)))
+	if err != nil {
 		o.log.Warn("Failed to fetch block for blob fee caps", "block", blockNum, "err", err)
 		return
 	}
@@ -380,19 +358,19 @@ func (o *BlobTipOracle) SuggestBlobTipCap(ctx context.Context, maxBlocks int, pe
 }
 
 // extractTipsForBlobTxs extracts tips for blob transactions from a block's transactions.
-func (o *BlobTipOracle) extractTipsForBlobTxs(block rpcBlock, baseFee *big.Int) []*big.Int {
+func (o *BlobTipOracle) extractTipsForBlobTxs(block *types.Block, baseFee *big.Int) []*big.Int {
 	var tips []*big.Int
-	for _, tx := range block.Transactions {
+	for _, tx := range block.Transactions() {
 		// Check if it's a blob transaction (type 3) and has blob fee cap
 		if tx.Type() == types.BlobTxType {
 			tip, err := tx.EffectiveGasTip(baseFee) // tip calculated from execution gas, for a type 3 transaction
 			if err != nil {
-				o.log.Error("Failed to calculate effective gas tip", "block", uint64(block.Number), "err", err)
+				o.log.Error("Failed to calculate effective gas tip", "block", block.NumberU64(), "err", err)
 				continue
 			}
 
 			tips = append(tips, tip)
-			o.log.Debug("Extracted tip from blob tx", "block", uint64(block.Number), "tip", tip.String())
+			o.log.Debug("Extracted tip from blob tx", "block", block.NumberU64(), "tip", tip.String())
 		}
 	}
 	return tips
@@ -403,6 +381,9 @@ func (o *BlobTipOracle) Close() {
 	o.cancel()
 	if o.sub != nil {
 		o.sub.Unsubscribe()
+	}
+	if o.loopDone != nil {
+		<-o.loopDone
 	}
 	o.log.Info("Blob tip oracle closed")
 }

--- a/op-service/bgpo/oracle_test.go
+++ b/op-service/bgpo/oracle_test.go
@@ -8,49 +8,73 @@ import (
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
-	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/ethereum/go-ethereum/trie"
 	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 )
 
-type mockRPC struct {
+type mockBTOBackend struct {
 	mock.Mock
 }
 
-func (m *mockRPC) CallContext(ctx context.Context, result any, method string, args ...any) error {
-	callArgs := make([]any, 0, len(args))
-	callArgs = append(callArgs, args...)
-	args_ := m.Called(ctx, result, method, callArgs)
-	return args_.Error(0)
+func (m *mockBTOBackend) BlockNumber(ctx context.Context) (uint64, error) {
+	args := m.Called(ctx)
+	return args.Get(0).(uint64), args.Error(1)
 }
 
-func (m *mockRPC) BatchCallContext(ctx context.Context, b []rpc.BatchElem) error {
-	args_ := m.Called(ctx, b)
-	return args_.Error(0)
-}
-
-func (m *mockRPC) Subscribe(ctx context.Context, namespace string, channel any, args ...any) (ethereum.Subscription, error) {
-	args_ := m.Called(ctx, namespace, channel, args)
-	sub := args_.Get(0)
-	if sub == nil {
-		return nil, args_.Error(1)
+func (m *mockBTOBackend) HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error) {
+	args := m.Called(ctx, number)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
 	}
-	return sub.(ethereum.Subscription), args_.Error(1)
+	return args.Get(0).(*types.Header), args.Error(1)
 }
 
-func (m *mockRPC) Close() {
-	m.Called()
+func (m *mockBTOBackend) BlockByNumber(ctx context.Context, number *big.Int) (*types.Block, error) {
+	args := m.Called(ctx, number)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*types.Block), args.Error(1)
 }
 
-var _ client.RPC = (*mockRPC)(nil)
+func (m *mockBTOBackend) SubscribeNewHead(ctx context.Context, ch chan<- *types.Header) (ethereum.Subscription, error) {
+	args := m.Called(ctx, ch)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(ethereum.Subscription), args.Error(1)
+}
+
+var _ BTOBackend = (*mockBTOBackend)(nil)
+
+// mockSubscription implements ethereum.Subscription for testing.
+type mockSubscription struct {
+	errCh    chan error
+	unsubbed bool
+}
+
+func newMockSubscription() *mockSubscription {
+	return &mockSubscription{
+		errCh: make(chan error, 1),
+	}
+}
+
+func (s *mockSubscription) Unsubscribe() {
+	if !s.unsubbed {
+		s.unsubbed = true
+	}
+}
+
+func (s *mockSubscription) Err() <-chan error {
+	return s.errCh
+}
 
 func createHeader(blockNum uint64, excessBlobGas *uint64) *types.Header {
 	header := &types.Header{
@@ -83,14 +107,22 @@ func createBlobTx(gasTip *big.Int, gasFeeCap *big.Int, blobFeeCap *big.Int) *typ
 	return tx
 }
 
+func createBlock(blockNum uint64, baseFee *big.Int, txs []*types.Transaction) *types.Block {
+	header := &types.Header{
+		Number:  big.NewInt(int64(blockNum)),
+		BaseFee: baseFee,
+		Time:    uint64(time.Now().Unix()),
+	}
+	return types.NewBlock(header, &types.Body{Transactions: txs}, nil, trie.NewStackTrie(nil), types.DefaultBlockConfig)
+}
+
 func TestNewBlobGasPriceOracle(t *testing.T) {
-	ctx := context.Background()
-	mrpc := new(mockRPC)
+	mbackend := new(mockBTOBackend)
 	chainConfig := params.MainnetChainConfig
 	logger := testlog.Logger(t, log.LevelInfo)
 
 	t.Run("with nil config", func(t *testing.T) {
-		oracle := NewBlobTipOracle(ctx, mrpc, chainConfig, logger, nil)
+		oracle := NewBlobTipOracle(mbackend, chainConfig, logger, nil)
 		require.NotNil(t, oracle)
 		require.Equal(t, 20, oracle.config.MaxBlocks)
 		require.Equal(t, 60, oracle.config.Percentile)
@@ -103,7 +135,7 @@ func TestNewBlobGasPriceOracle(t *testing.T) {
 			MaxBlocks:       10,
 			Percentile:      70,
 		}
-		oracle := NewBlobTipOracle(ctx, mrpc, chainConfig, logger, config)
+		oracle := NewBlobTipOracle(mbackend, chainConfig, logger, config)
 		require.NotNil(t, oracle)
 		require.Equal(t, 10, oracle.config.MaxBlocks)
 		require.Equal(t, 70, oracle.config.Percentile)
@@ -116,7 +148,7 @@ func TestNewBlobGasPriceOracle(t *testing.T) {
 			MaxBlocks:       -1,
 			Percentile:      150, // Invalid
 		}
-		oracle := NewBlobTipOracle(ctx, mrpc, chainConfig, logger, config)
+		oracle := NewBlobTipOracle(mbackend, chainConfig, logger, config)
 		require.NotNil(t, oracle)
 		// Should use defaults
 		require.Equal(t, 20, oracle.config.MaxBlocks)
@@ -125,12 +157,11 @@ func TestNewBlobGasPriceOracle(t *testing.T) {
 }
 
 func TestProcessHeader(t *testing.T) {
-	ctx := context.Background()
-	mrpc := new(mockRPC)
+	mbackend := new(mockBTOBackend)
 	chainConfig := params.MainnetChainConfig
 	logger := testlog.Logger(t, log.LevelError)
 
-	oracle := NewBlobTipOracle(ctx, mrpc, chainConfig, logger, &BlobTipOracleConfig{
+	oracle := NewBlobTipOracle(mbackend, chainConfig, logger, &BlobTipOracleConfig{
 		PricesCacheSize: 10,
 		BlockCacheSize:  10,
 		MaxBlocks:       5,
@@ -142,16 +173,8 @@ func TestProcessHeader(t *testing.T) {
 		header := createHeader(100, &excessBlobGas)
 
 		// Mock block fetch for blob fee caps
-		mrpc.On("CallContext", mock.Anything, mock.Anything, "eth_getBlockByNumber", mock.MatchedBy(func(args []any) bool {
-			return len(args) == 2 && args[1] == true
-		})).
-			Run(func(args mock.Arguments) {
-				block := args[1].(*rpcBlock)
-				block.Number = hexutil.Uint64(100)
-				block.Hash = common.Hash{}.Bytes()
-				block.Transactions = []*types.Transaction{}
-			}).
-			Return(nil).Once()
+		emptyBlock := createBlock(100, header.BaseFee, []*types.Transaction{})
+		mbackend.On("BlockByNumber", mock.Anything, big.NewInt(100)).Return(emptyBlock, nil).Once()
 
 		err := oracle.processHeader(header)
 		require.NoError(t, err)
@@ -166,16 +189,8 @@ func TestProcessHeader(t *testing.T) {
 		header := createHeader(101, nil)
 
 		// Mock block fetch
-		mrpc.On("CallContext", mock.Anything, mock.Anything, "eth_getBlockByNumber", mock.MatchedBy(func(args []any) bool {
-			return len(args) == 2 && args[1] == true
-		})).
-			Run(func(args mock.Arguments) {
-				block := args[1].(*rpcBlock)
-				block.Number = hexutil.Uint64(101)
-				block.Hash = common.Hash{}.Bytes()
-				block.Transactions = []*types.Transaction{}
-			}).
-			Return(nil).Once()
+		emptyBlock := createBlock(101, header.BaseFee, []*types.Transaction{})
+		mbackend.On("BlockByNumber", mock.Anything, big.NewInt(101)).Return(emptyBlock, nil).Once()
 
 		err := oracle.processHeader(header)
 		require.NoError(t, err)
@@ -185,16 +200,15 @@ func TestProcessHeader(t *testing.T) {
 		require.Equal(t, uint64(101), latestBlock)
 	})
 
-	mrpc.AssertExpectations(t)
+	mbackend.AssertExpectations(t)
 }
 
 func TestGetLatestBlobBaseFee(t *testing.T) {
-	ctx := context.Background()
-	mrpc := new(mockRPC)
+	mbackend := new(mockBTOBackend)
 	chainConfig := params.MainnetChainConfig
 	logger := testlog.Logger(t, log.LevelError)
 
-	oracle := NewBlobTipOracle(ctx, mrpc, chainConfig, logger, &BlobTipOracleConfig{
+	oracle := NewBlobTipOracle(mbackend, chainConfig, logger, &BlobTipOracleConfig{
 		PricesCacheSize: 10,
 		BlockCacheSize:  10,
 	})
@@ -210,22 +224,11 @@ func TestGetLatestBlobBaseFee(t *testing.T) {
 		header1 := createHeader(300, &excessBlobGas)
 		header2 := createHeader(301, &excessBlobGas)
 
-		mrpc.On("CallContext", mock.Anything, mock.Anything, "eth_getBlockByNumber", mock.MatchedBy(func(args []any) bool {
-			return len(args) == 2 && args[1] == true
-		})).
-			Return(nil).Twice().
-			Run(func(args mock.Arguments) {
-				block := args[1].(*rpcBlock)
-				callArgs := args[3].([]any)
-				blockNumHex := callArgs[0].(string)
-				if blockNumHex == "0x12c" { // 300
-					block.Number = hexutil.Uint64(300)
-				} else {
-					block.Number = hexutil.Uint64(301)
-				}
-				block.Hash = common.Hash{}.Bytes()
-				block.Transactions = []*types.Transaction{}
-			})
+		emptyBlock1 := createBlock(300, header1.BaseFee, []*types.Transaction{})
+		emptyBlock2 := createBlock(301, header2.BaseFee, []*types.Transaction{})
+
+		mbackend.On("BlockByNumber", mock.Anything, big.NewInt(300)).Return(emptyBlock1, nil).Once()
+		mbackend.On("BlockByNumber", mock.Anything, big.NewInt(301)).Return(emptyBlock2, nil).Once()
 
 		err := oracle.processHeader(header1)
 		require.NoError(t, err)
@@ -238,16 +241,16 @@ func TestGetLatestBlobBaseFee(t *testing.T) {
 		require.NotNil(t, fee)
 	})
 
-	mrpc.AssertExpectations(t)
+	mbackend.AssertExpectations(t)
 }
 
 func TestSuggestBlobTipCap(t *testing.T) {
 	ctx := context.Background()
-	mrpc := new(mockRPC)
+	mbackend := new(mockBTOBackend)
 	chainConfig := params.MainnetChainConfig
 	logger := testlog.Logger(t, log.LevelError)
 
-	oracle := NewBlobTipOracle(ctx, mrpc, chainConfig, logger, &BlobTipOracleConfig{
+	oracle := NewBlobTipOracle(mbackend, chainConfig, logger, &BlobTipOracleConfig{
 		PricesCacheSize: 10,
 		BlockCacheSize:  10,
 		MaxBlocks:       5,
@@ -273,16 +276,8 @@ func TestSuggestBlobTipCap(t *testing.T) {
 			tip := big.NewInt(int64((i-400)*1000000 + 1000000)) // 1M, 2M, 3M, 4M, 5M
 			blobTx := createBlobTx(tip, gasFeeCap, blobFeeCap)
 
-			mrpc.On("CallContext", mock.Anything, mock.Anything, "eth_getBlockByNumber", mock.MatchedBy(func(args []any) bool {
-				return len(args) == 2 && args[1] == true
-			})).
-				Run(func(args mock.Arguments) {
-					block := args[1].(*rpcBlock)
-					block.Number = hexutil.Uint64(i)
-					block.Hash = common.Hash{}.Bytes()
-					block.Transactions = []*types.Transaction{blobTx}
-				}).
-				Return(nil).Once()
+			block := createBlock(i, header.BaseFee, []*types.Transaction{blobTx})
+			mbackend.On("BlockByNumber", mock.Anything, big.NewInt(int64(i))).Return(block, nil).Once()
 
 			err := oracle.processHeader(header)
 			require.NoError(t, err)
@@ -304,7 +299,7 @@ func TestSuggestBlobTipCap(t *testing.T) {
 	})
 
 	t.Run("no blob transactions, fallback to base fee", func(t *testing.T) {
-		oracle2 := NewBlobTipOracle(ctx, mrpc, chainConfig, logger, &BlobTipOracleConfig{
+		oracle2 := NewBlobTipOracle(mbackend, chainConfig, logger, &BlobTipOracleConfig{
 			PricesCacheSize:    10,
 			BlockCacheSize:     10,
 			MaxBlocks:          5,
@@ -315,16 +310,8 @@ func TestSuggestBlobTipCap(t *testing.T) {
 		excessBlobGas := uint64(1000000)
 		header := createHeader(500, &excessBlobGas)
 
-		mrpc.On("CallContext", mock.Anything, mock.Anything, "eth_getBlockByNumber", mock.MatchedBy(func(args []any) bool {
-			return len(args) == 2 && args[1] == true
-		})).
-			Run(func(args mock.Arguments) {
-				block := args[1].(*rpcBlock)
-				block.Number = hexutil.Uint64(500)
-				block.Hash = common.Hash{}.Bytes()
-				block.Transactions = []*types.Transaction{} // No blob transactions
-			}).
-			Return(nil).Once()
+		emptyBlock := createBlock(500, header.BaseFee, []*types.Transaction{})
+		mbackend.On("BlockByNumber", mock.Anything, big.NewInt(500)).Return(emptyBlock, nil).Once()
 
 		err := oracle2.processHeader(header)
 		require.NoError(t, err)
@@ -334,16 +321,15 @@ func TestSuggestBlobTipCap(t *testing.T) {
 		require.Equal(t, big.NewInt(101), suggested)
 	})
 
-	mrpc.AssertExpectations(t)
+	mbackend.AssertExpectations(t)
 }
 
 func TestPrePopulateCache(t *testing.T) {
-	ctx := context.Background()
-	mrpc := new(mockRPC)
+	mbackend := new(mockBTOBackend)
 	chainConfig := params.MainnetChainConfig
 	logger := testlog.Logger(t, log.LevelError)
 
-	oracle := NewBlobTipOracle(ctx, mrpc, chainConfig, logger, &BlobTipOracleConfig{
+	oracle := NewBlobTipOracle(mbackend, chainConfig, logger, &BlobTipOracleConfig{
 		PricesCacheSize: 10,
 		BlockCacheSize:  10,
 		MaxBlocks:       3,
@@ -353,42 +339,17 @@ func TestPrePopulateCache(t *testing.T) {
 	t.Run("pre-populate with recent blocks", func(t *testing.T) {
 		latestBlock := uint64(1000)
 
-		// Mock eth_blockNumber (called with no args - empty slice)
-		mrpc.On("CallContext", mock.Anything, mock.Anything, "eth_blockNumber", mock.MatchedBy(func(args []any) bool {
-			return len(args) == 0
-		})).
-			Run(func(args mock.Arguments) {
-				result := args[1].(*hexutil.Uint64)
-				*result = hexutil.Uint64(latestBlock)
-			}).
-			Return(nil).Once()
+		// Mock eth_blockNumber
+		mbackend.On("BlockNumber", mock.Anything).Return(latestBlock, nil).Once()
 
-		// Mock header fetches for blocks 998, 999, 1000
+		// Mock header and block fetches for blocks 998, 999, 1000
 		excessBlobGas := uint64(1000000)
 		for i := uint64(998); i <= 1000; i++ {
 			header := createHeader(i, &excessBlobGas)
+			block := createBlock(i, header.BaseFee, []*types.Transaction{})
 
-			// Mock header fetch (with false for full transactions)
-			mrpc.On("CallContext", mock.Anything, mock.Anything, "eth_getBlockByNumber", mock.MatchedBy(func(args []any) bool {
-				return len(args) == 2 && args[0] == hexutil.EncodeUint64(i) && args[1] == false
-			})).
-				Run(func(args mock.Arguments) {
-					result := args[1].(**types.Header)
-					*result = header
-				}).
-				Return(nil).Once()
-
-			// Mock block fetch for blob fee caps (with true for full transactions)
-			mrpc.On("CallContext", mock.Anything, mock.Anything, "eth_getBlockByNumber", mock.MatchedBy(func(args []any) bool {
-				return len(args) == 2 && args[0] == hexutil.EncodeUint64(i) && args[1] == true
-			})).
-				Run(func(args mock.Arguments) {
-					block := args[1].(*rpcBlock)
-					block.Number = hexutil.Uint64(i)
-					block.Hash = common.Hash{}.Bytes()
-					block.Transactions = []*types.Transaction{}
-				}).
-				Return(nil).Once()
+			mbackend.On("HeaderByNumber", mock.Anything, big.NewInt(int64(i))).Return(header, nil).Once()
+			mbackend.On("BlockByNumber", mock.Anything, big.NewInt(int64(i))).Return(block, nil).Once()
 		}
 
 		err := oracle.prePopulateCache()
@@ -398,16 +359,15 @@ func TestPrePopulateCache(t *testing.T) {
 		require.Equal(t, uint64(1000), latestBlockNum)
 	})
 
-	mrpc.AssertExpectations(t)
+	mbackend.AssertExpectations(t)
 }
 
 func TestExtractBlobFeeCaps(t *testing.T) {
-	ctx := context.Background()
-	mrpc := new(mockRPC)
+	mbackend := new(mockBTOBackend)
 	chainConfig := params.MainnetChainConfig
 	logger := testlog.Logger(t, log.LevelError)
 
-	oracle := NewBlobTipOracle(ctx, mrpc, chainConfig, logger, &BlobTipOracleConfig{
+	oracle := NewBlobTipOracle(mbackend, chainConfig, logger, &BlobTipOracleConfig{
 		PricesCacheSize: 10,
 		BlockCacheSize:  10,
 	})
@@ -416,16 +376,12 @@ func TestExtractBlobFeeCaps(t *testing.T) {
 		baseFee := big.NewInt(2)      // 2 wei
 		blobFeeCap := big.NewInt(300) // 300 wei
 		gasFeeCap := big.NewInt(300)  // 300 wei
-		block := rpcBlock{
-			Number: hexutil.Uint64(600),
-			Hash:   common.Hash{}.Bytes(),
-			Transactions: []*types.Transaction{
-				createBlobTx(big.NewInt(7), gasFeeCap, blobFeeCap),
-				createBlobTx(big.NewInt(8), gasFeeCap, blobFeeCap),
-				createBlobTx(big.NewInt(9), gasFeeCap, blobFeeCap),
-				createBlobTx(big.NewInt(400), gasFeeCap, blobFeeCap),
-			},
-		}
+		block := createBlock(600, baseFee, []*types.Transaction{
+			createBlobTx(big.NewInt(7), gasFeeCap, blobFeeCap),
+			createBlobTx(big.NewInt(8), gasFeeCap, blobFeeCap),
+			createBlobTx(big.NewInt(9), gasFeeCap, blobFeeCap),
+			createBlobTx(big.NewInt(400), gasFeeCap, blobFeeCap),
+		})
 
 		tips := oracle.extractTipsForBlobTxs(block, baseFee)
 		require.Len(t, tips, 4)
@@ -437,20 +393,16 @@ func TestExtractBlobFeeCaps(t *testing.T) {
 
 	t.Run("extract ignores non-blob transactions", func(t *testing.T) {
 		baseFee := big.NewInt(1000000)
-		block := rpcBlock{
-			Number: hexutil.Uint64(601),
-			Hash:   common.Hash{}.Bytes(),
-			Transactions: []*types.Transaction{
-				types.NewTx(&types.LegacyTx{
-					Nonce:    0,
-					GasPrice: big.NewInt(1000000),
-					Gas:      21000,
-					To:       &common.Address{},
-					Value:    big.NewInt(0),
-					Data:     []byte{},
-				}),
-			},
-		}
+		block := createBlock(601, baseFee, []*types.Transaction{
+			types.NewTx(&types.LegacyTx{
+				Nonce:    0,
+				GasPrice: big.NewInt(1000000),
+				Gas:      21000,
+				To:       &common.Address{},
+				Value:    big.NewInt(0),
+				Data:     []byte{},
+			}),
+		})
 
 		feeCaps := oracle.extractTipsForBlobTxs(block, baseFee)
 		require.Len(t, feeCaps, 0)
@@ -460,26 +412,110 @@ func TestExtractBlobFeeCaps(t *testing.T) {
 		baseFee := big.NewInt(1000000)
 		blobFeeCap := big.NewInt(3000000000)
 		gasFeeCap := big.NewInt(3000000000)
-		block := rpcBlock{
-			Number: hexutil.Uint64(602),
-			Hash:   common.Hash{}.Bytes(),
-			Transactions: []*types.Transaction{
-				types.NewTx(&types.LegacyTx{
-					Nonce:    0,
-					GasPrice: big.NewInt(1000000),
-					Gas:      21000,
-					To:       &common.Address{},
-					Value:    big.NewInt(0),
-					Data:     []byte{},
-				}),
-				createBlobTx(big.NewInt(5000000), gasFeeCap, blobFeeCap),
-				createBlobTx(big.NewInt(6000000), gasFeeCap, blobFeeCap),
-			},
-		}
+		block := createBlock(602, baseFee, []*types.Transaction{
+			types.NewTx(&types.LegacyTx{
+				Nonce:    0,
+				GasPrice: big.NewInt(1000000),
+				Gas:      21000,
+				To:       &common.Address{},
+				Value:    big.NewInt(0),
+				Data:     []byte{},
+			}),
+			createBlobTx(big.NewInt(5000000), gasFeeCap, blobFeeCap),
+			createBlobTx(big.NewInt(6000000), gasFeeCap, blobFeeCap),
+		})
 
 		tips := oracle.extractTipsForBlobTxs(block, baseFee)
 		require.Len(t, tips, 2)
 		require.Equal(t, big.NewInt(5000000), tips[0])
 		require.Equal(t, big.NewInt(6000000), tips[1])
+	})
+}
+
+func TestOracleLifecycle(t *testing.T) {
+	mbackend := new(mockBTOBackend)
+	chainConfig := params.MainnetChainConfig
+	logger := testlog.Logger(t, log.LevelDebug)
+
+	oracle := NewBlobTipOracle(mbackend, chainConfig, logger, &BlobTipOracleConfig{
+		PricesCacheSize: 10,
+		BlockCacheSize:  10,
+		MaxBlocks:       2,
+		Percentile:      60,
+		NetworkTimeout:  time.Second,
+	})
+
+	t.Run("start and close", func(t *testing.T) {
+		latestBlock := uint64(100)
+
+		// Mock pre-population calls
+		mbackend.On("BlockNumber", mock.Anything).Return(latestBlock, nil).Once()
+
+		excessBlobGas := uint64(1000000)
+		for i := uint64(99); i <= 100; i++ {
+			header := createHeader(i, &excessBlobGas)
+			block := createBlock(i, header.BaseFee, []*types.Transaction{})
+			mbackend.On("HeaderByNumber", mock.Anything, big.NewInt(int64(i))).Return(header, nil).Once()
+			mbackend.On("BlockByNumber", mock.Anything, big.NewInt(int64(i))).Return(block, nil).Once()
+		}
+
+		// Mock subscription
+		sub := newMockSubscription()
+		var headerCh chan<- *types.Header
+		mbackend.On("SubscribeNewHead", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+			headerCh = args.Get(1).(chan<- *types.Header)
+		}).Return(sub, nil).Once()
+
+		// Start the oracle
+		err := oracle.Start()
+		require.NoError(t, err)
+		select {
+		case <-oracle.loopDone:
+			require.Fail(t, "oracle loop should not be done")
+		default:
+			// Expect loop to block done channel
+		}
+
+		// Verify cache was pre-populated
+		latestBlockNum, fee := oracle.GetLatestBlobBaseFee()
+		require.Equal(t, uint64(100), latestBlockNum)
+		require.NotNil(t, fee)
+
+		// Send a new header through the subscription to verify processing works
+		newHeader := createHeader(101, &excessBlobGas)
+		newBlock := createBlock(101, newHeader.BaseFee, []*types.Transaction{})
+		mbackend.On("BlockByNumber", mock.Anything, big.NewInt(101)).Return(newBlock, nil).Once()
+
+		headerCh <- newHeader
+
+		// Give the goroutine time to process
+		require.Eventually(t, func() bool {
+			latestBlockNum, _ = oracle.GetLatestBlobBaseFee()
+			return latestBlockNum == 101
+		}, time.Second, 10*time.Millisecond)
+
+		// Close the oracle
+		oracle.Close()
+
+		// Verify subscription was unsubscribed
+		require.True(t, sub.unsubbed, "subscription should be unsubscribed after Close")
+		select {
+		case <-oracle.loopDone:
+			// Expect loop to have exited
+		default:
+			require.Fail(t, "oracle loop should have exited after Close")
+		}
+
+		mbackend.AssertExpectations(t)
+	})
+
+	t.Run("close before start is safe", func(t *testing.T) {
+		oracle2 := NewBlobTipOracle(mbackend, chainConfig, logger, &BlobTipOracleConfig{
+			PricesCacheSize: 10,
+			BlockCacheSize:  10,
+		})
+
+		// Should not panic
+		oracle2.Close()
 	})
 }

--- a/op-service/txmgr/cli.go
+++ b/op-service/txmgr/cli.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	opservice "github.com/ethereum-optimism/optimism/op-service"
+	"github.com/ethereum-optimism/optimism/op-service/bgpo"
 	"github.com/ethereum-optimism/optimism/op-service/cliiface"
 	opcrypto "github.com/ethereum-optimism/optimism/op-service/crypto"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -133,6 +134,19 @@ var (
 	// geth enforces a 1 gwei minimum for blob tx fee
 	defaultMinBlobTxFee = big.NewInt(params.GWei)
 )
+
+// BTOConfig configures the BlobTipOracle for dynamic blob tip cap estimation.
+// If provided to txmgr.Config, the txmgr will create and manage a BlobTipOracle.
+type BTOConfig struct {
+	// Backend is the ethclient that implements bgpo.BTOBackend
+	Backend bgpo.BTOBackend
+	// ChainConfig is the L1 chain config for blob fee calculation
+	ChainConfig *params.ChainConfig
+	// BlobTipCapRange is the number of blocks to analyze (default: 20)
+	BlobTipCapRange int
+	// BlobTipCapPercentile is the percentile for tip suggestion (default: 60)
+	BlobTipCapPercentile int
+}
 
 func CLIFlags(envPrefix string) []cli.Flag {
 	return CLIFlagsWithDefaults(envPrefix, DefaultBatcherFlagValues)
@@ -473,9 +487,7 @@ func NewConfig(cfg CLIConfig, l log.Logger) (*Config, error) {
 		return nil, fmt.Errorf("invalid min tip cap: %w", err)
 	}
 
-	var (
-		maxBaseFee, maxTipCap *big.Int
-	)
+	var maxBaseFee, maxTipCap *big.Int
 	if cfg.MaxBaseFeeGwei > 0 {
 		maxBaseFee, err = eth.GweiToWei(cfg.MaxBaseFeeGwei)
 		if err != nil {
@@ -508,8 +520,6 @@ func NewConfig(cfg CLIConfig, l log.Logger) (*Config, error) {
 		SafeAbortNonceTooLowCount:  cfg.SafeAbortNonceTooLowCount,
 		AlreadyPublishedCustomErrs: cfg.AlreadyPublishedCustomErrs,
 		CellProofTime:              cellProofTime,
-		BlobTipCapPercentile:       cfg.BlobTipCapPercentile,
-		BlobTipCapRange:            cfg.BlobTipCapRange,
 	}
 
 	res.RebroadcastInterval.Store(int64(cfg.RebroadcastInterval))
@@ -630,11 +640,9 @@ type Config struct {
 	// instead of using static tip cap for blob transactions.
 	BlobTipCapDynamic atomic.Bool
 
-	// BlobTipCapPercentile is the percentile of recent blob tx tips to use for suggestion (1-100).
-	BlobTipCapPercentile int
-
-	// BlobTipCapRange is the number of recent blocks to analyze for blob tip cap distribution.
-	BlobTipCapRange int
+	// BTOConfig is the configuration for the BlobTipOracle.
+	// If nil, the BlobTipOracle will not be used.
+	BTOConfig *BTOConfig
 }
 
 func (m *Config) Check() error {

--- a/op-service/txmgr/estimator.go
+++ b/op-service/txmgr/estimator.go
@@ -6,27 +6,26 @@ import (
 	"math/big"
 )
 
-type GasPriceEstimatorFn func(ctx context.Context, backend ETHBackend) (*big.Int, *big.Int, *big.Int, *big.Int, error)
+type GasPriceEstimatorFn func(ctx context.Context, backend ETHBackend) (*big.Int, *big.Int, *big.Int, error)
 
-func DefaultGasPriceEstimatorFn(ctx context.Context, backend ETHBackend) (*big.Int, *big.Int, *big.Int, *big.Int, error) {
+func DefaultGasPriceEstimatorFn(ctx context.Context, backend ETHBackend) (*big.Int, *big.Int, *big.Int, error) {
 	tip, err := backend.SuggestGasTipCap(ctx)
 	if err != nil {
-		return nil, nil, nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	head, err := backend.HeaderByNumber(ctx, nil)
 	if err != nil {
-		return nil, nil, nil, nil, err
+		return nil, nil, nil, err
 	}
 	if head.BaseFee == nil {
-		return nil, nil, nil, nil, errors.New("txmgr does not support pre-london blocks that do not have a base fee")
+		return nil, nil, nil, errors.New("txmgr does not support pre-london blocks that do not have a base fee")
 	}
 
 	blobBaseFee, err := backend.BlobBaseFee(ctx)
 	if err != nil {
-		return nil, nil, nil, nil, err
+		return nil, nil, nil, err
 	}
 
-	blobTipFee := big.NewInt(0) // using zero value for the default gas price estimator (if bgpo is not available)
-	return tip, head.BaseFee, blobTipFee, blobBaseFee, nil
+	return tip, head.BaseFee, blobBaseFee, nil
 }

--- a/op-service/txmgr/txmgr.go
+++ b/op-service/txmgr/txmgr.go
@@ -10,6 +10,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/op-service/bgpo"
 	"github.com/ethereum-optimism/optimism/op-service/errutil"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
@@ -26,6 +27,18 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/retry"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr/metrics"
 )
+
+// blobTipOracle is an interface for suggesting blob tip caps.
+// This interface allows the txmgr to use either the real blobTipOracle or a mock for testing.
+type blobTipOracle interface {
+	// Start starts the oracle's background processing.
+	Start() error
+	// SuggestBlobTipCap returns a suggested tip cap for blob transactions.
+	// Pass 0 for maxBlocks or percentile to use the oracle's configured defaults.
+	SuggestBlobTipCap(ctx context.Context, maxBlocks int, percentile int) (*big.Int, error)
+	// Close stops the oracle and releases resources.
+	Close()
+}
 
 const (
 	// geth requires a minimum fee bump of 10% for regular tx resubmission
@@ -146,6 +159,8 @@ type SimpleTxManager struct {
 	metr                metrics.TxMetricer
 	gasPriceEstimatorFn GasPriceEstimatorFn
 
+	blobTipOracle blobTipOracle
+
 	nonce     *uint64
 	nonceLock sync.RWMutex
 
@@ -169,19 +184,50 @@ func NewSimpleTxManagerFromConfig(name string, l log.Logger, m metrics.TxMetrice
 		return nil, fmt.Errorf("invalid config: %w", err)
 	}
 
-	if conf.GasPriceEstimatorFn == nil {
-		conf.GasPriceEstimatorFn = DefaultGasPriceEstimatorFn
+	mgr := &SimpleTxManager{
+		chainID: conf.ChainID,
+		name:    name,
+		cfg:     conf,
+		backend: conf.Backend,
+		l:       l.New("service", name),
+		metr:    m,
 	}
 
-	return &SimpleTxManager{
-		chainID:             conf.ChainID,
-		name:                name,
-		cfg:                 conf,
-		backend:             conf.Backend,
-		l:                   l.New("service", name),
-		metr:                m,
-		gasPriceEstimatorFn: conf.GasPriceEstimatorFn,
-	}, nil
+	// Initialize the BlobTipOracle if BTOConfig is provided
+	if conf.BTOConfig != nil {
+		btoConfig := conf.BTOConfig
+		oracleConfig := bgpo.DefaultBlobTipOracleConfig()
+		oracleConfig.NetworkTimeout = conf.NetworkTimeout
+		if btoConfig.BlobTipCapRange > 0 {
+			oracleConfig.MaxBlocks = btoConfig.BlobTipCapRange
+		}
+		if btoConfig.BlobTipCapPercentile > 0 {
+			oracleConfig.Percentile = btoConfig.BlobTipCapPercentile
+		}
+		// Use MinTipCap as the default priority fee for the oracle
+		if minTipCap := conf.MinTipCap.Load(); minTipCap != nil {
+			oracleConfig.DefaultPriorityFee = minTipCap
+		}
+
+		mgr.blobTipOracle = bgpo.NewBlobTipOracle(
+			btoConfig.Backend, btoConfig.ChainConfig,
+			l.New("module", "BTO"), oracleConfig)
+
+		if err := mgr.blobTipOracle.Start(); err != nil {
+			mgr.l.Error("Blob tip oracle failed to start", "err", err)
+		}
+
+		mgr.l.Info("Started blob tip oracle")
+	}
+
+	// Set up the gas price estimator function
+	if conf.GasPriceEstimatorFn != nil {
+		mgr.gasPriceEstimatorFn = conf.GasPriceEstimatorFn
+	} else {
+		mgr.gasPriceEstimatorFn = DefaultGasPriceEstimatorFn
+	}
+
+	return mgr, nil
 }
 
 func (m *SimpleTxManager) ChainID() eth.ChainID {
@@ -209,6 +255,10 @@ func (m *SimpleTxManager) API() rpc.API {
 // Close closes the underlying connection, and sets the closed flag.
 // once closed, the tx manager will refuse to send any new transactions, and may abandon pending ones.
 func (m *SimpleTxManager) Close() {
+	// Close the blob tip oracle if it's running
+	if m.blobTipOracle != nil {
+		m.blobTipOracle.Close()
+	}
 	m.backend.Close()
 	m.closed.Store(true)
 }
@@ -361,9 +411,6 @@ func (m *SimpleTxManager) craftTx(ctx context.Context, candidate TxCandidate) (*
 	}
 	isBlobTx := len(candidate.Blobs) > 0
 	if isBlobTx {
-		if blobTipCap == nil {
-			return nil, errors.New("expected non-nil blobTipCap for blob tx")
-		}
 		gasTipCap = blobTipCap
 	}
 	gasFeeCap := calcGasFeeCap(baseFee, gasTipCap)
@@ -1024,7 +1071,7 @@ func (m *SimpleTxManager) SuggestGasPriceCaps(ctx context.Context) (*big.Int, *b
 	cCtx, cancel := context.WithTimeout(ctx, m.cfg.NetworkTimeout)
 	defer cancel()
 
-	tip, baseFee, blobTip, blobBaseFee, err := m.gasPriceEstimatorFn(cCtx, m.backend)
+	tip, baseFee, blobBaseFee, err := m.gasPriceEstimatorFn(cCtx, m.backend)
 	if err != nil {
 		m.metr.RPCError()
 		return nil, nil, nil, nil, fmt.Errorf("failed to get gas price estimates: %w", err)
@@ -1033,7 +1080,6 @@ func (m *SimpleTxManager) SuggestGasPriceCaps(ctx context.Context) (*big.Int, *b
 	m.metr.RecordTipCap(tip)
 	m.metr.RecordBaseFee(baseFee)
 	m.metr.RecordBlobBaseFee(blobBaseFee)
-	m.metr.RecordBlobTipCap(blobTip)
 
 	// Enforce minimum base fee and tip cap
 	minTipCap := m.cfg.MinTipCap.Load()
@@ -1042,19 +1088,25 @@ func (m *SimpleTxManager) SuggestGasPriceCaps(ctx context.Context) (*big.Int, *b
 	maxBaseFee := m.cfg.MaxBaseFee.Load()
 	dynamicBlobTipCap := m.cfg.BlobTipCapDynamic.Load()
 
-	m.l.Info("Estimated gas fees & tip caps", "gasTipCap", tip, "baseFee", baseFee,
-		"blobTipCap", blobTip, "blobBaseFee", blobBaseFee, "dynamicBlobTipCap", dynamicBlobTipCap)
-
 	// Enforce tip cap limits
 	if minTipCap != nil && tip.Cmp(minTipCap) == -1 {
 		m.l.Debug("Enforcing min tip cap", "minTipCap", minTipCap, "origTipCap", tip)
 		tip = new(big.Int).Set(minTipCap)
 	}
 
-	if !m.cfg.BlobTipCapDynamic.Load() {
-		// if not using dynamic blob tip cap, set blob tip to normal tip
-		blobTip = tip
+	blobTip := new(big.Int).Set(tip)
+	if m.cfg.BlobTipCapDynamic.Load() {
+		// pass 0, 0 to use configured values
+		blobTip, err = m.blobTipOracle.SuggestBlobTipCap(ctx, 0, 0)
+		if err != nil {
+			return nil, nil, nil, nil, fmt.Errorf("failed to get blob tip cap from oracle: %w", err)
+		}
+		m.metr.RecordBlobTipCap(blobTip)
 	}
+	// Note that we don't enforce a minimum blob tip cap if using the oracle.
+
+	m.l.Info("Estimated gas fees & tip caps", "gasTipCap", tip, "baseFee", baseFee,
+		"blobTipCap", blobTip, "blobBaseFee", blobBaseFee, "dynamicBlobTipCap", dynamicBlobTipCap)
 
 	if maxTipCap != nil && tip.Cmp(maxTipCap) > 0 {
 		return nil, nil, nil, nil, fmt.Errorf("tip is too high: %v, cap:%v", tip, maxTipCap)

--- a/op-service/txmgr/txmgr_test.go
+++ b/op-service/txmgr/txmgr_test.go
@@ -44,6 +44,27 @@ func testSendState() *SendState {
 	return NewSendState(100, time.Hour)
 }
 
+// mockBlobTipOracle is a mock implementation of BlobTipOracle for testing.
+type mockBlobTipOracle struct {
+	suggestedTip *big.Int
+	err          error
+}
+
+func (m *mockBlobTipOracle) Start() error {
+	return nil
+}
+
+func (m *mockBlobTipOracle) SuggestBlobTipCap(ctx context.Context, maxBlocks int, percentile int) (*big.Int, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.suggestedTip, nil
+}
+
+func (m *mockBlobTipOracle) Close() {}
+
+var _ blobTipOracle = (*mockBlobTipOracle)(nil)
+
 // testHarness houses the necessary resources to test the SimpleTxManager.
 type testHarness struct {
 	cfg       *Config
@@ -1122,11 +1143,14 @@ func TestWaitMinedReturnsReceiptAfterFailure(t *testing.T) {
 	require.Equal(t, receipt.TxHash, txHash)
 }
 
-func doGasPriceIncrease(t *testing.T, txTipCap, txFeeCap, newTip, newBaseFee int64, estimator GasPriceEstimatorFn) (*types.Transaction, *types.Transaction, error) {
+func doGasPriceIncrease(t *testing.T, txTipCap, txFeeCap, newTip, newBaseFee int64, txBlobFeeCap *int64, modMgr func(*SimpleTxManager)) (*types.Transaction, *types.Transaction, error) {
 	borkedBackend := failingBackend{
 		gasTip:              big.NewInt(newTip),
 		baseFee:             big.NewInt(newBaseFee),
 		returnSuccessHeader: true,
+	}
+	if txBlobFeeCap != nil {
+		borkedBackend.blobBaseFee = big.NewInt(1)
 	}
 
 	cfg := Config{
@@ -1148,13 +1172,26 @@ func doGasPriceIncrease(t *testing.T, txTipCap, txFeeCap, newTip, newBaseFee int
 		backend:             &borkedBackend,
 		l:                   testlog.Logger(t, log.LevelCrit),
 		metr:                &metrics.NoopTxMetrics{},
-		gasPriceEstimatorFn: estimator,
+		gasPriceEstimatorFn: DefaultGasPriceEstimatorFn,
 	}
 
-	tx := types.NewTx(&types.DynamicFeeTx{
-		GasTipCap: big.NewInt(txTipCap),
-		GasFeeCap: big.NewInt(txFeeCap),
-	})
+	if modMgr != nil {
+		modMgr(mgr)
+	}
+
+	var tx *types.Transaction
+	if txBlobFeeCap != nil {
+		tx = types.NewTx(&types.BlobTx{
+			GasTipCap:  uint256.NewInt(uint64(txTipCap)),
+			GasFeeCap:  uint256.NewInt(uint64(txFeeCap)),
+			BlobFeeCap: uint256.NewInt(uint64(*txBlobFeeCap)),
+		})
+	} else {
+		tx = types.NewTx(&types.DynamicFeeTx{
+			GasTipCap: big.NewInt(txTipCap),
+			GasFeeCap: big.NewInt(txFeeCap),
+		})
+	}
 	newTx, err := mgr.increaseGasPrice(context.Background(), tx)
 	return tx, newTx, err
 }
@@ -1169,7 +1206,7 @@ func TestIncreaseGasPrice(t *testing.T) {
 		{
 			name: "bump at least 1",
 			run: func(t *testing.T) {
-				tx, newTx, err := doGasPriceIncrease(t, 1, 3, 1, 1, DefaultGasPriceEstimatorFn)
+				tx, newTx, err := doGasPriceIncrease(t, 1, 3, 1, 1, nil, nil)
 				require.True(t, newTx.GasFeeCap().Cmp(tx.GasFeeCap()) > 0, "new tx fee cap must be larger")
 				require.True(t, newTx.GasTipCap().Cmp(tx.GasTipCap()) > 0, "new tx tip must be larger")
 				require.NoError(t, err)
@@ -1178,7 +1215,7 @@ func TestIncreaseGasPrice(t *testing.T) {
 		{
 			name: "enforces min bump",
 			run: func(t *testing.T) {
-				tx, newTx, err := doGasPriceIncrease(t, 100, 1000, 101, 460, DefaultGasPriceEstimatorFn)
+				tx, newTx, err := doGasPriceIncrease(t, 100, 1000, 101, 460, nil, nil)
 				require.True(t, newTx.GasFeeCap().Cmp(tx.GasFeeCap()) > 0, "new tx fee cap must be larger")
 				require.True(t, newTx.GasTipCap().Cmp(tx.GasTipCap()) > 0, "new tx tip must be larger")
 				require.NoError(t, err)
@@ -1187,7 +1224,7 @@ func TestIncreaseGasPrice(t *testing.T) {
 		{
 			name: "enforces min bump on only tip increase",
 			run: func(t *testing.T) {
-				tx, newTx, err := doGasPriceIncrease(t, 100, 1000, 101, 440, DefaultGasPriceEstimatorFn)
+				tx, newTx, err := doGasPriceIncrease(t, 100, 1000, 101, 440, nil, nil)
 				require.True(t, newTx.GasFeeCap().Cmp(tx.GasFeeCap()) > 0, "new tx fee cap must be larger")
 				require.True(t, newTx.GasTipCap().Cmp(tx.GasTipCap()) > 0, "new tx tip must be larger")
 				require.NoError(t, err)
@@ -1196,7 +1233,7 @@ func TestIncreaseGasPrice(t *testing.T) {
 		{
 			name: "enforces min bump on only base fee increase",
 			run: func(t *testing.T) {
-				tx, newTx, err := doGasPriceIncrease(t, 100, 1000, 99, 460, DefaultGasPriceEstimatorFn)
+				tx, newTx, err := doGasPriceIncrease(t, 100, 1000, 99, 460, nil, nil)
 				require.True(t, newTx.GasFeeCap().Cmp(tx.GasFeeCap()) > 0, "new tx fee cap must be larger")
 				require.True(t, newTx.GasTipCap().Cmp(tx.GasTipCap()) > 0, "new tx tip must be larger")
 				require.NoError(t, err)
@@ -1205,25 +1242,25 @@ func TestIncreaseGasPrice(t *testing.T) {
 		{
 			name: "uses L1 values when larger",
 			run: func(t *testing.T) {
-				_, newTx, err := doGasPriceIncrease(t, 10, 100, 50, 200, DefaultGasPriceEstimatorFn)
-				require.True(t, newTx.GasFeeCap().Cmp(big.NewInt(450)) == 0, "new tx fee cap must be equal L1")
-				require.True(t, newTx.GasTipCap().Cmp(big.NewInt(50)) == 0, "new tx tip must be equal L1")
+				_, newTx, err := doGasPriceIncrease(t, 10, 100, 50, 200, nil, nil)
+				require.Zero(t, newTx.GasFeeCap().Cmp(big.NewInt(450)), "new tx fee cap must be equal L1")
+				require.Zero(t, newTx.GasTipCap().Cmp(big.NewInt(50)), "new tx tip must be equal L1")
 				require.NoError(t, err)
 			},
 		},
 		{
 			name: "uses L1 tip when larger and threshold FC",
 			run: func(t *testing.T) {
-				_, newTx, err := doGasPriceIncrease(t, 100, 2200, 120, 1050, DefaultGasPriceEstimatorFn)
-				require.True(t, newTx.GasTipCap().Cmp(big.NewInt(120)) == 0, "new tx tip must be equal L1")
-				require.True(t, newTx.GasFeeCap().Cmp(big.NewInt(2420)) == 0, "new tx fee cap must be equal to the threshold value")
+				_, newTx, err := doGasPriceIncrease(t, 100, 2200, 120, 1050, nil, nil)
+				require.Zero(t, newTx.GasTipCap().Cmp(big.NewInt(120)), "new tx tip must be equal L1")
+				require.Zero(t, newTx.GasFeeCap().Cmp(big.NewInt(2420)), "new tx fee cap must be equal to the threshold value")
 				require.NoError(t, err)
 			},
 		},
 		{
 			name: "bumped fee above multiplier limit",
 			run: func(t *testing.T) {
-				_, _, err := doGasPriceIncrease(t, 1, 9999, 1, 1, DefaultGasPriceEstimatorFn)
+				_, _, err := doGasPriceIncrease(t, 1, 9999, 1, 1, nil, nil)
 				require.ErrorContains(t, err, "fee cap")
 				require.NotContains(t, err.Error(), "tip cap")
 			},
@@ -1231,7 +1268,7 @@ func TestIncreaseGasPrice(t *testing.T) {
 		{
 			name: "bumped tip above multiplier limit",
 			run: func(t *testing.T) {
-				_, _, err := doGasPriceIncrease(t, 9999, 0, 0, 9999, DefaultGasPriceEstimatorFn)
+				_, _, err := doGasPriceIncrease(t, 9999, 0, 0, 9999, nil, nil)
 				require.ErrorContains(t, err, "tip cap")
 				require.NotContains(t, err.Error(), "fee cap")
 			},
@@ -1239,7 +1276,7 @@ func TestIncreaseGasPrice(t *testing.T) {
 		{
 			name: "bumped fee and tip above multiplier limit",
 			run: func(t *testing.T) {
-				_, _, err := doGasPriceIncrease(t, 9999, 9999, 1, 1, DefaultGasPriceEstimatorFn)
+				_, _, err := doGasPriceIncrease(t, 9999, 9999, 1, 1, nil, nil)
 				require.ErrorContains(t, err, "tip cap")
 				require.ErrorContains(t, err, "fee cap")
 			},
@@ -1247,28 +1284,42 @@ func TestIncreaseGasPrice(t *testing.T) {
 		{
 			name: "uses L1 FC when larger and threshold tip",
 			run: func(t *testing.T) {
-				_, newTx, err := doGasPriceIncrease(t, 100, 2200, 100, 2000, DefaultGasPriceEstimatorFn)
-				require.True(t, newTx.GasTipCap().Cmp(big.NewInt(110)) == 0, "new tx tip must be equal the threshold value")
+				_, newTx, err := doGasPriceIncrease(t, 100, 2200, 100, 2000, nil, nil)
+				require.Zero(t, newTx.GasTipCap().Cmp(big.NewInt(110)), "new tx tip must be equal the threshold value")
 				t.Log("Vals:", newTx.GasFeeCap())
-				require.True(t, newTx.GasFeeCap().Cmp(big.NewInt(4110)) == 0, "new tx fee cap must be equal L1")
+				require.Zero(t, newTx.GasFeeCap().Cmp(big.NewInt(4110)), "new tx fee cap must be equal L1")
 				require.NoError(t, err)
 			},
 		},
 		{
 			name: "supports extension through custom estimator",
 			run: func(t *testing.T) {
-				estimator := func(ctx context.Context, backend ETHBackend) (*big.Int, *big.Int, *big.Int, *big.Int, error) {
-					return big.NewInt(100), big.NewInt(3000), big.NewInt(100), big.NewInt(100), nil
+				customEstimator := func(ctx context.Context, backend ETHBackend) (*big.Int, *big.Int, *big.Int, error) {
+					return big.NewInt(100), big.NewInt(3000), big.NewInt(100), nil
 				}
-				_, newTx, err := doGasPriceIncrease(t, 70, 2000, 80, 2100, estimator)
+				_, newTx, err := doGasPriceIncrease(t, 70, 2000, 80, 2100, nil, func(mgr *SimpleTxManager) {
+					mgr.gasPriceEstimatorFn = customEstimator
+				})
 				require.NoError(t, err)
-				require.True(t, newTx.GasFeeCap().Cmp(big.NewInt(6100)) == 0)
-				require.True(t, newTx.GasTipCap().Cmp(big.NewInt(100)) == 0)
+				require.Zero(t, newTx.GasFeeCap().Cmp(big.NewInt(6100)))
+				require.Zero(t, newTx.GasTipCap().Cmp(big.NewInt(100)))
+			},
+		},
+		{
+			name: "blob tx uses dynamic blob tip cap from oracle",
+			run: func(t *testing.T) {
+				oracleBlobTipCap := big.NewInt(42)
+				blobFeeCap := int64(50)
+				_, newTx, err := doGasPriceIncrease(t, 10, 100, 1, 1, &blobFeeCap, func(mgr *SimpleTxManager) {
+					mgr.cfg.BlobTipCapDynamic.Store(true)
+					mgr.blobTipOracle = &mockBlobTipOracle{suggestedTip: oracleBlobTipCap}
+				})
+				require.NoError(t, err)
+				require.Equal(t, oracleBlobTipCap, newTx.GasTipCap(), "blob tx should use tip cap from oracle")
 			},
 		},
 	}
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, test.run)
 	}
 }
@@ -1845,12 +1896,11 @@ func TestIncreaseGasPriceSigningErrorWithSend(t *testing.T) {
 func TestTxMgr_BlobTipCapDynamic(t *testing.T) {
 	t.Parallel()
 
-	// Create a custom gas price estimator that returns different values for gasTipCap and blobTipCap
+	// Create a custom gas price estimator
 	gasTipCapVal := big.NewInt(100)
-	blobTipCapVal := big.NewInt(50) // Oracle suggests lower tip cap for blobs
 
-	customEstimator := func(ctx context.Context, backend ETHBackend) (*big.Int, *big.Int, *big.Int, *big.Int, error) {
-		return gasTipCapVal, big.NewInt(7), blobTipCapVal, big.NewInt(50), nil
+	customEstimator := func(ctx context.Context, backend ETHBackend) (*big.Int, *big.Int, *big.Int, error) {
+		return gasTipCapVal, big.NewInt(7), big.NewInt(50), nil
 	}
 
 	t.Run("BlobTipCapDynamic=false uses gasTipCap", func(t *testing.T) {
@@ -1859,6 +1909,12 @@ func TestTxMgr_BlobTipCapDynamic(t *testing.T) {
 		cfg.BlobTipCapDynamic.Store(false)
 
 		h := newTestHarnessWithConfig(t, cfg)
+
+		// Use a different value for oracle tip to verify it's NOT used
+		oracleBlobTipCap := big.NewInt(999)
+		// Inject the mock oracle - it should NOT be used when BlobTipCapDynamic=false
+		h.mgr.blobTipOracle = &mockBlobTipOracle{suggestedTip: oracleBlobTipCap}
+
 		candidate := h.createBlobTxCandidate()
 
 		tx, err := h.mgr.craftTx(context.Background(), candidate)
@@ -1866,8 +1922,9 @@ func TestTxMgr_BlobTipCapDynamic(t *testing.T) {
 		require.NotNil(t, tx)
 		require.Equal(t, byte(types.BlobTxType), tx.Type())
 
-		// When BlobTipCapDynamic is false, blob tx should use gasTipCap
+		// When BlobTipCapDynamic is false, blob tx should use gasTipCap (not oracle)
 		require.Equal(t, gasTipCapVal, tx.GasTipCap(), "blob tx should use gasTipCap when BlobTipCapDynamic=false")
+		require.NotEqual(t, oracleBlobTipCap, tx.GasTipCap(), "blob tx should NOT use oracle tip when BlobTipCapDynamic=false")
 	})
 
 	t.Run("BlobTipCapDynamic=true uses oracle blobTipCap", func(t *testing.T) {
@@ -1876,6 +1933,11 @@ func TestTxMgr_BlobTipCapDynamic(t *testing.T) {
 		cfg.BlobTipCapDynamic.Store(true)
 
 		h := newTestHarnessWithConfig(t, cfg)
+
+		oracleBlobTipCap := big.NewInt(42)
+		// Inject the mock oracle directly into the manager
+		h.mgr.blobTipOracle = &mockBlobTipOracle{suggestedTip: oracleBlobTipCap}
+
 		candidate := h.createBlobTxCandidate()
 
 		tx, err := h.mgr.craftTx(context.Background(), candidate)
@@ -1884,6 +1946,6 @@ func TestTxMgr_BlobTipCapDynamic(t *testing.T) {
 		require.Equal(t, byte(types.BlobTxType), tx.Type())
 
 		// When BlobTipCapDynamic is true, blob tx should use blobTipCap from oracle
-		require.Equal(t, blobTipCapVal, tx.GasTipCap(), "blob tx should use blobTipCap when BlobTipCapDynamic=true")
+		require.Equal(t, oracleBlobTipCap, tx.GasTipCap(), "blob tx should use blobTipCap from oracle when BlobTipCapDynamic=true")
 	})
 }


### PR DESCRIPTION
## Summary

Refactor the BlobTipOracle (BTO) so the txmgr owns and manages it, instead of requiring external services (like batcher) to initialize and inject it via a custom `GasPriceEstimatorFn`.

Note that net code is removed and simplified, the diff is just larger because a few more tests have been added.

**Key changes:**

### bgpo package (`op-service/bgpo/`)
- Add `BTOBackend` interface that `ethclient.Client` implements, replacing low-level RPC client usage
- Refactor `BlobTipOracle` to use `BTOBackend` instead of `PollingClient`
- Remove `rpcBlock` struct (use `*types.Block` directly)
- Add lifecycle test (`TestOracleLifecycle`) for Start/Close

### txmgr package (`op-service/txmgr/`)
- Add `BTOConfig` struct for BTO configuration (Backend, ChainConfig, BlobTipCapRange, BlobTipCapPercentile)
- Add unexported `blobTipOracle` interface to allow mocking in tests
- `SimpleTxManager` now creates, starts, and closes `BlobTipOracle` when `BTOConfig` is provided
- Remove `BlobTipCapRange` and `BlobTipCapPercentile` from `Config` (moved to `BTOConfig`)
- Update `Close()` to properly shut down the oracle
- Add comprehensive tests for dynamic blob tip cap with mock oracle

### batcher service (`op-batcher/`)
- Remove `initBlobTipOracle` method and `blobTipOracle` field
- Remove custom `GasPriceEstimatorFn` setup
- Simplified to just pass `BTOConfig` to txmgr config
- Remove BTO cleanup from `Stop()` (txmgr handles it now)

## Test plan
- [x] `go test ./op-service/bgpo/...` passes
- [x] `go test ./op-service/txmgr/...` passes
- [x] `go test ./op-batcher/...` passes
- [x] `go build ./op-batcher/...` succeeds

🤖 Partially Generated with [Claude Code](https://claude.ai/code)

Based on https://github.com/ethereum-optimism/optimism/pull/19028