### PR TITLE
feat: no beta tags in production upgrade

### DIFF
--- a/packages/contracts-bedrock/interfaces/L1/opcm/IOPContractsManagerContainer.sol
+++ b/packages/contracts-bedrock/interfaces/L1/opcm/IOPContractsManagerContainer.sol
@@ -38,5 +38,6 @@ interface IOPContractsManagerContainer {
     function implementations() external view returns (Implementations memory);
     function isDevFeatureEnabled(bytes32 _feature) external view returns (bool);
     function devFeatureBitmap() external view returns (bytes32);
+    function isProdEnvironment() external view returns (bool);
     function __constructor__(Blueprints memory _blueprints, Implementations memory _implementations, bytes32 _devFeatureBitmap) external;
 }

--- a/packages/contracts-bedrock/interfaces/L1/opcm/IOPContractsManagerContainer.sol
+++ b/packages/contracts-bedrock/interfaces/L1/opcm/IOPContractsManagerContainer.sol
@@ -38,6 +38,5 @@ interface IOPContractsManagerContainer {
     function implementations() external view returns (Implementations memory);
     function isDevFeatureEnabled(bytes32 _feature) external view returns (bool);
     function devFeatureBitmap() external view returns (bytes32);
-    function isProdEnvironment() external view returns (bool);
     function __constructor__(Blueprints memory _blueprints, Implementations memory _implementations, bytes32 _devFeatureBitmap) external;
 }

--- a/packages/contracts-bedrock/interfaces/L1/opcm/IOPContractsManagerUtils.sol
+++ b/packages/contracts-bedrock/interfaces/L1/opcm/IOPContractsManagerUtils.sol
@@ -45,6 +45,7 @@ interface IOPContractsManagerUtils {
     event ProxyCreation(string name, address proxy);
 
     error OPContractsManagerUtils_DowngradeNotAllowed(address _contract);
+    error OPContractsManagerUtils_ExtraTagInProd(address _contract);
     error OPContractsManagerUtils_ConfigLoadFailed(string _name);
     error OPContractsManagerUtils_ProxyMustLoad(string _name);
     error OPContractsManagerUtils_UnsupportedGameType();

--- a/packages/contracts-bedrock/snapshots/abi/OPContractsManagerUtils.json
+++ b/packages/contracts-bedrock/snapshots/abi/OPContractsManagerUtils.json
@@ -688,6 +688,17 @@
   {
     "inputs": [
       {
+        "internalType": "address",
+        "name": "_contract",
+        "type": "address"
+      }
+    ],
+    "name": "OPContractsManagerUtils_ExtraTagInProd",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "string",
         "name": "_name",
         "type": "string"

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerContainer.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerContainer.sol
@@ -97,6 +97,12 @@ contract OPContractsManagerContainer {
         return DevFeatures.isDevFeatureEnabled(devFeatureBitmap, _feature);
     }
 
+    /// @notice Returns true if this is a production environment (mainnet and not testing).
+    /// @return True if production environment, false otherwise.
+    function isProdEnvironment() public view returns (bool) {
+        return block.chainid == 1 && !_isTestingEnvironment();
+    }
+
     /// @notice Returns true if the contract is running in a testing environment. Checks that the
     ///         code for the address 0xbeefcafe is not zero, which is an address that should never
     ///         have any code in production environments but can be made to have code in tests.

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerContainer.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerContainer.sol
@@ -70,7 +70,7 @@ contract OPContractsManagerContainer {
         devFeatureBitmap = _devFeatureBitmap;
 
         // Development features MUST NOT be enabled on Mainnet.
-        if (block.chainid == 1 && !_isTestingEnvironment() && uint256(_devFeatureBitmap) != 0) {
+        if (!_isTestingEnvironment() && uint256(_devFeatureBitmap) != 0) {
             revert OPContractsManagerContainer_DevFeatureInProd();
         }
     }
@@ -97,17 +97,12 @@ contract OPContractsManagerContainer {
         return DevFeatures.isDevFeatureEnabled(devFeatureBitmap, _feature);
     }
 
-    /// @notice Returns true if this is a production environment (mainnet and not testing).
-    /// @return True if production environment, false otherwise.
-    function isProdEnvironment() public view returns (bool) {
-        return block.chainid == 1 && !_isTestingEnvironment();
-    }
-
-    /// @notice Returns true if the contract is running in a testing environment. Checks that the
-    ///         code for the address 0xbeefcafe is not zero, which is an address that should never
-    ///         have any code in production environments but can be made to have code in tests.
+    /// @notice Returns true if the contract is running in a testing environment. Returns true if
+    ///         we're not on mainnet or if the code for the address 0xbeefcafe is not zero. The
+    ///         magic address should never have any code in production environments but can be made
+    ///         to have code in tests.
     /// @return True if the contract is running in a testing environment, false otherwise.
     function _isTestingEnvironment() internal view returns (bool) {
-        return Constants.TESTING_ENVIRONMENT_ADDRESS.code.length > 0;
+        return block.chainid != 1 || Constants.TESTING_ENVIRONMENT_ADDRESS.code.length > 0;
     }
 }

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerUtils.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerUtils.sol
@@ -47,6 +47,10 @@ contract OPContractsManagerUtils {
     /// @param _contract The address of the contract that was attempted to be downgraded.
     error OPContractsManagerUtils_DowngradeNotAllowed(address _contract);
 
+    /// @notice Thrown when user attempts to deploy a contract with extra version tags in production.
+    /// @param _contract The address of the contract with extra version tags.
+    error OPContractsManagerUtils_ExtraTagInProd(address _contract);
+
     /// @notice Thrown when a config load fails.
     /// @param _name The name of the config that failed to load.
     error OPContractsManagerUtils_ConfigLoadFailed(string _name);
@@ -308,6 +312,12 @@ contract OPContractsManagerUtils {
                 && SemverComp.gt(ISemver(_target).version(), ISemver(_implementation).version())
         ) {
             revert OPContractsManagerUtils_DowngradeNotAllowed(address(_target));
+        }
+
+        // Block deployments with extra version tags (prerelease or build metadata) in production.
+        // Only clean X.Y.Z versions are allowed on mainnet.
+        if (contractsContainer.isProdEnvironment() && SemverComp.hasExtraTag(ISemver(_implementation).version())) {
+            revert OPContractsManagerUtils_ExtraTagInProd(_implementation);
         }
 
         // Upgrade to StorageSetter.

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerUtils.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerUtils.sol
@@ -314,9 +314,13 @@ contract OPContractsManagerUtils {
             revert OPContractsManagerUtils_DowngradeNotAllowed(address(_target));
         }
 
-        // Block deployments with extra version tags (prerelease or build metadata) in production.
-        // Only clean X.Y.Z versions are allowed on mainnet.
-        if (contractsContainer.isProdEnvironment() && SemverComp.hasExtraTag(ISemver(_implementation).version())) {
+        // Block deployments with extra version tags (prerelease or build metadata) when dev
+        // features are not enabled. Only clean X.Y.Z versions are allowed unless dev features are
+        // explicitly enabled (which is already blocked on mainnet by the container constructor).
+        if (
+            contractsContainer.devFeatureBitmap() == bytes32(0)
+                && SemverComp.hasExtraTag(ISemver(_implementation).version())
+        ) {
             revert OPContractsManagerUtils_ExtraTagInProd(_implementation);
         }
 

--- a/packages/contracts-bedrock/src/libraries/SemverComp.sol
+++ b/packages/contracts-bedrock/src/libraries/SemverComp.sol
@@ -92,4 +92,11 @@ library SemverComp {
     function gte(string memory _a, string memory _b) internal pure returns (bool) {
         return eq(_a, _b) || gt(_a, _b);
     }
+
+    /// @notice Checks if a semver string has extra tags (prerelease "-" or build metadata "+").
+    /// @param _semver The semver string to check.
+    /// @return True if the semver has extra tags, false otherwise.
+    function hasExtraTag(string memory _semver) internal pure returns (bool) {
+        return LibString.contains(_semver, "-") || LibString.contains(_semver, "+");
+    }
 }

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerUtils.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerUtils.t.sol
@@ -645,12 +645,18 @@ contract OPContractsManagerUtils_Upgrade_Test is OPContractsManagerUtils_TestIni
         );
     }
 
-    /// @notice Tests that upgrade with extra tags succeeds in testing environment.
-    function test_upgrade_extraTagInTestEnv_succeeds() public {
-        // Testing environment is already set up in setUp().
+    /// @notice Tests that upgrade with extra tags succeeds when dev features are enabled.
+    function test_upgrade_extraTagWithDevFeatures_succeeds() public {
+        // Mock devFeatureBitmap to return non-zero (dev features enabled).
+        vm.mockCall(
+            address(container),
+            abi.encodeCall(IOPContractsManagerContainer.devFeatureBitmap, ()),
+            abi.encode(bytes32(uint256(1)))
+        );
+
         OPContractsManagerUtils_ImplV2Beta_Harness implBeta = new OPContractsManagerUtils_ImplV2Beta_Harness();
 
-        // Should succeed because we're in testing environment.
+        // Should succeed because dev features are enabled.
         utils.upgrade(
             proxyAdmin,
             address(proxy),
@@ -661,29 +667,6 @@ contract OPContractsManagerUtils_Upgrade_Test is OPContractsManagerUtils_TestIni
         );
 
         assertEq(proxyAdmin.getProxyImplementation(payable(address(proxy))), address(implBeta));
-    }
-
-    /// @notice Tests that upgrade with extra tags succeeds on non-mainnet chains.
-    function test_upgrade_extraTagOnTestnet_succeeds() public {
-        // Remove testing environment marker.
-        vm.etch(Constants.TESTING_ENVIRONMENT_ADDRESS, hex"");
-
-        // Simulate Sepolia (not mainnet).
-        vm.chainId(11155111);
-
-        OPContractsManagerUtils_ImplV2Interop_Harness implInterop = new OPContractsManagerUtils_ImplV2Interop_Harness();
-
-        // Should succeed because we're not on mainnet.
-        utils.upgrade(
-            proxyAdmin,
-            address(proxy),
-            address(implInterop),
-            abi.encodeCall(OPContractsManagerUtils_ImplV2Interop_Harness.initialize, ()),
-            TEST_SLOT,
-            TEST_OFFSET
-        );
-
-        assertEq(proxyAdmin.getProxyImplementation(payable(address(proxy))), address(implInterop));
     }
 }
 

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerUtils.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerUtils.t.sol
@@ -49,6 +49,24 @@ contract OPContractsManagerUtils_ImplV2_Harness is ISemver {
     function initialize() external { }
 }
 
+/// @title ImplV2Beta_Harness
+/// @notice Implementation with beta prerelease tag for testing extra tag rejection.
+contract OPContractsManagerUtils_ImplV2Beta_Harness is ISemver {
+    /// @custom:semver 2.0.0-beta.1
+    string public constant version = "2.0.0-beta.1";
+
+    function initialize() external { }
+}
+
+/// @title ImplV2Interop_Harness
+/// @notice Implementation with interop build metadata for testing extra tag rejection.
+contract OPContractsManagerUtils_ImplV2Interop_Harness is ISemver {
+    /// @custom:semver 2.0.0+interop
+    string public constant version = "2.0.0+interop";
+
+    function initialize() external { }
+}
+
 /// @title OPContractsManagerUtils_TestInit
 /// @notice Shared setup for OPContractsManagerUtils tests.
 contract OPContractsManagerUtils_TestInit is Test {
@@ -575,6 +593,97 @@ contract OPContractsManagerUtils_Upgrade_Test is OPContractsManagerUtils_TestIni
 
         // Verify the implementation was set.
         assertEq(proxyAdmin.getProxyImplementation(payable(address(proxy))), address(implV1));
+    }
+
+    /// @notice Tests that upgrade reverts with prerelease tag in production environment.
+    function test_upgrade_prereleaseInProd_reverts() public {
+        // Remove testing environment marker to simulate production.
+        vm.etch(Constants.TESTING_ENVIRONMENT_ADDRESS, hex"");
+
+        // Simulate mainnet.
+        vm.chainId(1);
+
+        OPContractsManagerUtils_ImplV2Beta_Harness implBeta = new OPContractsManagerUtils_ImplV2Beta_Harness();
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IOPContractsManagerUtils.OPContractsManagerUtils_ExtraTagInProd.selector, address(implBeta)
+            )
+        );
+        utils.upgrade(
+            proxyAdmin,
+            address(proxy),
+            address(implBeta),
+            abi.encodeCall(OPContractsManagerUtils_ImplV2Beta_Harness.initialize, ()),
+            TEST_SLOT,
+            TEST_OFFSET
+        );
+    }
+
+    /// @notice Tests that upgrade reverts with build metadata tag in production environment.
+    function test_upgrade_buildMetadataInProd_reverts() public {
+        // Remove testing environment marker to simulate production.
+        vm.etch(Constants.TESTING_ENVIRONMENT_ADDRESS, hex"");
+
+        // Simulate mainnet.
+        vm.chainId(1);
+
+        OPContractsManagerUtils_ImplV2Interop_Harness implInterop = new OPContractsManagerUtils_ImplV2Interop_Harness();
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IOPContractsManagerUtils.OPContractsManagerUtils_ExtraTagInProd.selector, address(implInterop)
+            )
+        );
+        utils.upgrade(
+            proxyAdmin,
+            address(proxy),
+            address(implInterop),
+            abi.encodeCall(OPContractsManagerUtils_ImplV2Interop_Harness.initialize, ()),
+            TEST_SLOT,
+            TEST_OFFSET
+        );
+    }
+
+    /// @notice Tests that upgrade with extra tags succeeds in testing environment.
+    function test_upgrade_extraTagInTestEnv_succeeds() public {
+        // Testing environment is already set up in setUp().
+        OPContractsManagerUtils_ImplV2Beta_Harness implBeta = new OPContractsManagerUtils_ImplV2Beta_Harness();
+
+        // Should succeed because we're in testing environment.
+        utils.upgrade(
+            proxyAdmin,
+            address(proxy),
+            address(implBeta),
+            abi.encodeCall(OPContractsManagerUtils_ImplV2Beta_Harness.initialize, ()),
+            TEST_SLOT,
+            TEST_OFFSET
+        );
+
+        assertEq(proxyAdmin.getProxyImplementation(payable(address(proxy))), address(implBeta));
+    }
+
+    /// @notice Tests that upgrade with extra tags succeeds on non-mainnet chains.
+    function test_upgrade_extraTagOnTestnet_succeeds() public {
+        // Remove testing environment marker.
+        vm.etch(Constants.TESTING_ENVIRONMENT_ADDRESS, hex"");
+
+        // Simulate Sepolia (not mainnet).
+        vm.chainId(11155111);
+
+        OPContractsManagerUtils_ImplV2Interop_Harness implInterop = new OPContractsManagerUtils_ImplV2Interop_Harness();
+
+        // Should succeed because we're not on mainnet.
+        utils.upgrade(
+            proxyAdmin,
+            address(proxy),
+            address(implInterop),
+            abi.encodeCall(OPContractsManagerUtils_ImplV2Interop_Harness.initialize, ()),
+            TEST_SLOT,
+            TEST_OFFSET
+        );
+
+        assertEq(proxyAdmin.getProxyImplementation(payable(address(proxy))), address(implInterop));
     }
 }
 

--- a/packages/contracts-bedrock/test/libraries/SemverComp.t.sol
+++ b/packages/contracts-bedrock/test/libraries/SemverComp.t.sol
@@ -190,3 +190,30 @@ contract SemverComp_Gte_Test is SemverComp_TestInit {
         assertFalse(SemverComp.gte("1.9.9", "2.0.0"));
     }
 }
+
+/// @title SemverComp_HasExtraTag_Test
+/// @notice Tests the `hasExtraTag` function behavior.
+contract SemverComp_HasExtraTag_Test is SemverComp_TestInit {
+    function test_hasExtraTag_succeeds() external pure {
+        // Clean versions have no extra tags
+        assertFalse(SemverComp.hasExtraTag("1.2.3"));
+        assertFalse(SemverComp.hasExtraTag("0.0.0"));
+        assertFalse(SemverComp.hasExtraTag("10.20.30"));
+
+        // Prerelease tags
+        assertTrue(SemverComp.hasExtraTag("1.2.3-beta"));
+        assertTrue(SemverComp.hasExtraTag("1.2.3-beta.1"));
+        assertTrue(SemverComp.hasExtraTag("1.2.3-rc.1"));
+        assertTrue(SemverComp.hasExtraTag("1.2.3-alpha"));
+
+        // Build metadata
+        assertTrue(SemverComp.hasExtraTag("1.2.3+interop"));
+        assertTrue(SemverComp.hasExtraTag("1.2.3+interop.10"));
+        assertTrue(SemverComp.hasExtraTag("1.2.3+build.5"));
+        assertTrue(SemverComp.hasExtraTag("1.2.3+custom-gas-token"));
+
+        // Both prerelease and build metadata
+        assertTrue(SemverComp.hasExtraTag("1.2.3-beta.1+interop"));
+        assertTrue(SemverComp.hasExtraTag("1.2.3-rc.1+build.5"));
+    }
+}


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
This PR blocks contracts with beta tags from being used in production upgrades. It requires that the default upgrade (no dev features enabled) MUST NOT allow beta tags. Beta tags CAN be used with dev features. This is a more consistent policy for beta tags and side-steps the problem of downgrades being a potential issue with beta tags.