### PR TITLE
Supernode: Faster Processing with Backoff

### DIFF
--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -18,9 +18,10 @@ import (
 
 // Compile-time interface conformance assertions.
 var (
-	_            activity.RunnableActivity     = (*Interop)(nil)
-	_            activity.VerificationActivity = (*Interop)(nil)
-	tickerPeriod                               = 500 * time.Millisecond
+	_                  activity.RunnableActivity     = (*Interop)(nil)
+	_                  activity.VerificationActivity = (*Interop)(nil)
+	backoffPeriod                                    = 1 * time.Second // backoff when chains aren't ready
+	errorBackoffPeriod                               = 2 * time.Second // backoff on errors
 )
 
 // InteropActivationTimestampFlag is the CLI flag for the interop activation timestamp.
@@ -114,21 +115,23 @@ func (i *Interop) Start(ctx context.Context) error {
 	i.started = true
 	i.mu.Unlock()
 
-	// Periodically query each chain container for its current safe head and log it.
-	ticker := time.NewTicker(tickerPeriod)
-	defer ticker.Stop()
-
 	for {
 		select {
 		case <-i.ctx.Done():
 			return i.ctx.Err()
-		case <-ticker.C:
-			err := i.progressAndRecord()
+		default:
+			madeProgress, err := i.progressAndRecord()
 			if err != nil {
+				// Error: back off before next attempt
 				i.log.Error("failed to progress and record interop", "err", err)
-				time.Sleep(2 * time.Second)
+				time.Sleep(errorBackoffPeriod)
 				continue
 			}
+			if !madeProgress {
+				// Chains not ready, back off before next attempt
+				time.Sleep(backoffPeriod)
+			}
+			// Otherwise: immediately ready for next iteration (aggressive catch-up)
 		}
 	}
 }
@@ -152,30 +155,32 @@ func (i *Interop) Stop(ctx context.Context) error {
 	return nil
 }
 
-func (i *Interop) progressAndRecord() error {
+// progressAndRecord attempts to progress interop and record the result.
+// Returns (madeProgress, error) where madeProgress indicates if we advanced the verified timestamp.
+func (i *Interop) progressAndRecord() (bool, error) {
 	// Check the L1s of each chain prior to performing interop
 	localCurrentL1, err := i.collectCurrentL1()
 	if err != nil {
 		i.log.Error("failed to collect current L1", "err", err)
-		return err
+		return false, err
 	}
 	// Perform the interop evaluation
 	result, err := i.progressInterop()
 	if err != nil {
 		i.log.Error("failed to progress interop", "err", err)
-		return err
+		return false, err
 	}
 
 	// Handle the result by committing verified results or invalidating blocks
 	err = i.handleResult(result)
 	if err != nil {
 		i.log.Error("failed to handle result", "err", err)
-		return err
+		return false, err
 	}
 	// if the result is invalid, exit without updating the current L1s
 	if !result.IsEmpty() && !result.IsValid() {
 		i.log.Warn("result is invalid, skipping current L1 update", "results", result)
-		return nil
+		return false, nil
 	}
 
 	// Once interop is complete and recorded, update the current L1s
@@ -184,8 +189,9 @@ func (i *Interop) progressAndRecord() error {
 	// - if interop ran but did not advance the verified timestamp, the CurrentL1 values collected are used directly
 	// - if interop ran and advanced the verified timestamp, the CurrentL1 is the L1 head at the verified timestamp
 	// this is because the individual chains may advance their CurrentL1, and if progress is being made, we might not be done using the collected L1s.
+	verifiedAdvanced := !result.IsEmpty()
 	i.mu.Lock()
-	if !result.IsEmpty() {
+	if verifiedAdvanced {
 		// the new CurrentL1 is the L1 head at the verified timestamp
 		i.currentL1 = result.L1Head
 	} else {
@@ -193,7 +199,7 @@ func (i *Interop) progressAndRecord() error {
 		i.currentL1 = localCurrentL1
 	}
 	i.mu.Unlock()
-	return nil
+	return verifiedAdvanced, nil
 }
 
 // collectCurrentL1 collects the current L1 head of all chains,

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -609,8 +609,9 @@ func TestProgressAndRecord(t *testing.T) {
 
 		require.Equal(t, eth.BlockID{}, interop.currentL1)
 
-		err := interop.progressAndRecord()
+		madeProgress, err := interop.progressAndRecord()
 		require.NoError(t, err)
+		require.False(t, madeProgress, "empty result should not advance verified timestamp")
 
 		require.Equal(t, uint64(100), interop.currentL1.Number)
 		require.Equal(t, common.HexToHash("0x1"), interop.currentL1.Hash)
@@ -634,8 +635,9 @@ func TestProgressAndRecord(t *testing.T) {
 			return Result{Timestamp: ts, L1Head: expectedL1Head, L2Heads: blocks}, nil
 		}
 
-		err := interop.progressAndRecord()
+		madeProgress, err := interop.progressAndRecord()
 		require.NoError(t, err)
+		require.True(t, madeProgress, "valid result should advance verified timestamp")
 
 		require.Equal(t, expectedL1Head.Number, interop.currentL1.Number)
 		require.Equal(t, expectedL1Head.Hash, interop.currentL1.Hash)
@@ -666,8 +668,9 @@ func TestProgressAndRecord(t *testing.T) {
 			}, nil
 		}
 
-		err := interop.progressAndRecord()
+		madeProgress, err := interop.progressAndRecord()
 		require.NoError(t, err)
+		require.False(t, madeProgress, "invalid result should not advance verified timestamp")
 
 		require.Equal(t, initialL1.Number, interop.currentL1.Number)
 		require.Equal(t, initialL1.Hash, interop.currentL1.Hash)
@@ -685,8 +688,9 @@ func TestProgressAndRecord(t *testing.T) {
 		require.NotNil(t, interop)
 		interop.ctx = context.Background()
 
-		err := interop.progressAndRecord()
+		madeProgress, err := interop.progressAndRecord()
 		require.Error(t, err)
+		require.False(t, madeProgress, "error should not advance verified timestamp")
 	})
 }
 


### PR DESCRIPTION
# What
Adaptive tick rate for interop activity

- Lowered tickerPeriod from 500ms → 50ms for fast progress when data is available
- Added backoffPeriod (1s) when chains aren't ready, preventing busy-waiting
- Extracted the error sleep into errorBackoffPeriod (2s) for clarity
- progressAndRecord(): Now returns (verifiedAdvanced bool, err error) to signal whether the verified timestamp was advanced, driving the backoff decision
- Unit tests now assert advancement
