### PR TITLE
fix: broken links, references, and typo errors

### DIFF
--- a/devnet-sdk/book/src/dsl/style_guide.md
+++ b/devnet-sdk/book/src/dsl/style_guide.md
@@ -46,7 +46,7 @@ block := node.GetBalance(user)
 node.VerifyBalance(user, 10 * constants.Eth)
 
 // Better? Select the entry point to be as declarative as possible
-user.VerifyBalacne(10 * constants.Eth) // implementation could verify balance on all nodes automatically
+user.VerifyBalance(10 * constants.Eth) // implementation could verify balance on all nodes automatically
 ```
 
 

--- a/op-acceptance-tests/README.md
+++ b/op-acceptance-tests/README.md
@@ -212,7 +212,7 @@ gates:
     tests:
       - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/yourtest
         timeout: 10m
-        metatada:
+        metadata:
           owner: stefano
 ```
 

--- a/op-batcher/readme.md
+++ b/op-batcher/readme.md
@@ -61,7 +61,7 @@ The `receiptsLoop` which
 The `throttlingLoop` which
 
 1. Waits for a signal from the `blockLoadingLoop`
-2. Calls (potentially multiple) sequencers over RPC and tells them to throttle or unthrottle -- that is, to limit (or not) the amount of L2 data they produce. See the (section below)[#data-availability-backlog]. Each sequencer is throttled in parallel by a separate sub-goroutine (not shown in the below diagram). Additional endpoints, such as builders in a rollup-boost setup, may also be configured to be throttled.
+2. Calls (potentially multiple) sequencers over RPC and tells them to throttle or unthrottle -- that is, to limit (or not) the amount of L2 data they produce. See the [section below](#data-availability-backlog). Each sequencer is throttled in parallel by a separate sub-goroutine (not shown in the below diagram). Additional endpoints, such as builders in a rollup-boost setup, may also be configured to be throttled.
 
 The relationships are shown in this diagram:
 

--- a/op-supernode/README.md
+++ b/op-supernode/README.md
@@ -12,7 +12,7 @@ Chain containers manage the runtime of the CL as a local process called a "Virtu
 only by `op-node` itself.
 Chain Containers provide a stable interface to get data from the chain or affect the chain without needing to operate on the internals of
 that chain.
-Chain Containers also allow for multiple chains to be derived inside of the same `op-supernode`. Because theya re isolated,
+Chain Containers also allow for multiple chains to be derived inside of the same `op-supernode`. Because they are isolated,
 running many chains worth of derivation is trivial.
 
 

--- a/op-supernode/README.md
+++ b/op-supernode/README.md
@@ -32,7 +32,7 @@ but redundant access is eliminated.
 
 Because `op-node` is the only implementation of Virtual Nodes presently, it gets special treatment when the application starts up.
 In specific, all those flags which are found in `op-node` are upstreamed with namespacing into the `op-supernode` flags.
-This allows for *roughly* 1:1 setup and behavior between Node and Supernode, with cavets listed below.
+This allows for *roughly* 1:1 setup and behavior between Node and Supernode, with caveats listed below.
 - To set a value for one chain, use `--vn.<chainID>.<flag>`
 - To set a value for *all* chains, use `--vn.all.<flag>`
 - Some behaviors are expected to be configured at the `op-supernode` level and are not respected per usual when the application starts:

--- a/op-supervisor/README.md
+++ b/op-supervisor/README.md
@@ -283,7 +283,7 @@ follow up with asynchronous full verification of the safety.
 ### Vision
 
 The `op-supervisor` is actively changing.
-The most immediate changes are that to the architecture and data flow, as outlined in [design-doc 171].
+The most immediate changes are that to the architecture and data flow, as outlined in [design-doc 171](https://github.com/ethereum-optimism/design-docs/blob/main/protocol/supervisor-dataflow.md).
 
 Further background on the design-choices of op-supervisor can be found in the
 [superchain backend design-doc](https://github.com/ethereum-optimism/design-docs/blob/main/protocol/superchain-backend.md).
@@ -298,7 +298,7 @@ Further background on the design-choices of op-supervisor can be found in the
 
 ## Failure modes
 
-See [design-doc 171] for discussion of missing data and syncing related failure modes.
+See [design-doc 171](https://github.com/ethereum-optimism/design-docs/blob/main/protocol/supervisor-dataflow.md) for discussion of missing data and syncing related failure modes.
 
 Generally the supervisor aims to provide existing static data in the case of disruption of cross-chain verification,
 such that a chain which does not take on new interop dependencies, can continue to be extended with safe blocks.

--- a/packages/contracts-bedrock/test/kontrol/README.md
+++ b/packages/contracts-bedrock/test/kontrol/README.md
@@ -219,7 +219,7 @@ Method 1: GitHub's `gh` CLI tool
 
 Method 2: [Github API](https://docs.github.com/en/rest/actions/artifacts?apiVersion=2022-11-28)
 List the artifacts for a run:
-- GET /repos/{owner}/{repo}/actions/runs/{run_id}/artifacts -- See [documentation](httpshttps://docs.github.com/en/rest/actions/artifacts?apiVersion=2022-11-28#list-workflow-run-artifacts) for more details
+- GET /repos/{owner}/{repo}/actions/runs/{run_id}/artifacts -- See [documentation](https://docs.github.com/en/rest/actions/artifacts?apiVersion=2022-11-28#list-workflow-run-artifacts) for more details
 ```bash
 curl -L \
   -H "Accept: application/vnd.github+json" \


### PR DESCRIPTION
# Description
## Broken links
1. There was an error in this [README](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/test/kontrol/README.md#deployment-summary-process ) file: it was specified twice (httpshttps), which is why the link did not work:
<img width="839" height="337" alt="image" src="https://github.com/user-attachments/assets/df125571-cac9-4d50-918f-e4331b5490c4" />

FIxed.

2. Incorrect Markdown syntax for linking to a section in this [FILE](https://github.com/ethereum-optimism/optimism/blob/develop/op-batcher/readme.md):
<img width="1037" height="90" alt="image" src="https://github.com/user-attachments/assets/f36225b8-70d3-48d9-86bf-4b1505a28af7" />

Fixed.

## Add links
1. This [FILE](https://github.com/ethereum-optimism/optimism/blob/develop/op-supervisor/README.md) refers twice to [design-docs 171], but the link itself is missing:
<img width="1056" height="501" alt="image" src="https://github.com/user-attachments/assets/fb775475-cb36-4890-ae82-8bfe88885ce5" />

A quick search revealed the following:

- An [ISSUE](https://github.com/ethereum-optimism/optimism/issues/13322) where developers discuss this
- The issue contains a link to [PR-171](https://github.com/ethereum-optimism/design-docs/pull/171/changes), which contains this [FILE](https://github.com/ethereum-optimism/design-docs/blob/main/protocol/supervisor-dataflow.md).
- The contents of this file fully correspond to the architectural changes and data flow op-supervisor described in the documentation, which is referenced in [design-docs 171].

In this regard, I have added a link to the relevant file.

## Typo errors
- VerifyBalacne > VerifyBalance
- theya re > they are
-  cavets > caveats
- metatada > metadata

If there are any errors or comments for correction, please leave feedback.