### PR TITLE
Add just version to legacy kona prestate build mise config

### DIFF
--- a/op-program/scripts/build-prestates.sh
+++ b/op-program/scripts/build-prestates.sh
@@ -56,8 +56,9 @@ function build_legacy_kona_prestate() {
     cd kona
   fi
   # kona doesn't define a just dependency in its mise config.
-  # but the monorepo does and it should be preinstalled by now. So let's setup the just shim.
-  MISE_DEFAULT_CONFIG_FILENAME="${WORKTREE_DIR}"/mise.toml mise use just > "${log_file}" 2>&1
+  # but the monorepo does and it should be preinstalled by now. So let's set up the just shim.
+  JUST_VERSION=$(cd "${WORKTREE_DIR}" && mise config get tools.just)
+  mise use "just@${JUST_VERSION}" >> "${log_file}" 2>&1
 
   cd docker/fpvm-prestates
   rm -rf ../../prestate-artifacts-cannon


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

The op-rs/kona repo doesn't have just in its mise.toml. This fixes a CI failure by extracting and using the version from the worktree's mise config.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
