### PR TITLE
feat(op-reth): pull latest superchain config on startup

### DIFF
--- a/op-reth/Cargo.lock
+++ b/op-reth/Cargo.lock
@@ -8179,6 +8179,7 @@ dependencies = [
  "op-alloy-consensus",
  "op-alloy-rpc-types",
  "paste",
+ "reqwest",
  "reth-chainspec",
  "reth-ethereum-forks",
  "reth-network-peers",
@@ -8189,6 +8190,7 @@ dependencies = [
  "serde_json",
  "tar-no-std",
  "thiserror 2.0.18",
+ "toml",
 ]
 
 [[package]]

--- a/op-reth/crates/chainspec/Cargo.toml
+++ b/op-reth/crates/chainspec/Cargo.toml
@@ -45,6 +45,8 @@ derive_more.workspace = true
 paste = { workspace = true, optional = true }
 thiserror = { workspace = true, optional = true }
 op-alloy-consensus.workspace = true
+reqwest = { workspace = true, features = ["rustls-tls-native-roots", "blocking"], optional = true }
+toml = { workspace = true, optional = true }
 
 [dev-dependencies]
 reth-chainspec = { workspace = true, features = ["test-utils"] }
@@ -52,7 +54,13 @@ alloy-op-hardforks.workspace = true
 
 [features]
 default = ["std"]
-superchain-configs = ["miniz_oxide", "paste", "tar-no-std", "thiserror", "thiserror", "dep:serde"]
+superchain-configs = ["miniz_oxide", "paste", "tar-no-std", "thiserror", "dep:serde"]
+pull-superchain-configs = [
+    "std",
+    "superchain-configs",
+    "dep:reqwest",
+    "dep:toml",
+]
 std = [
     "alloy-chains/std",
     "alloy-genesis/std",

--- a/op-reth/crates/chainspec/src/superchain/configs.rs
+++ b/op-reth/crates/chainspec/src/superchain/configs.rs
@@ -7,6 +7,11 @@ use alloc::{
 use alloy_genesis::Genesis;
 use miniz_oxide::inflate::decompress_to_vec_zlib_with_limit;
 use tar_no_std::{CorruptDataError, TarArchiveRef};
+#[cfg(feature = "pull-superchain-configs")]
+use {
+    reqwest::blocking::Client,
+    std::time::Duration,
+};
 
 /// A genesis file can be up to 100MiB. This is a reasonable limit for the genesis file size.
 const MAX_GENESIS_SIZE: usize = 100 * 1024 * 1024; // 100MiB
@@ -58,17 +63,42 @@ pub(crate) fn read_superchain_genesis(
     Ok(genesis)
 }
 
-/// Reads the [`ChainMetadata`] from the superchain config tar file for a superchain.
+/// Reads the [`ChainMetadata`] for a superchain from the superchain registry github, falling back to the local config tar file.
 /// For example, `read_superchain_config("unichain", "mainnet")`.
 fn read_superchain_metadata(
     name: &str,
     environment: &str,
     archive: &TarArchiveRef<'_>,
 ) -> Result<ChainMetadata, SuperchainConfigError> {
+    #[cfg(feature = "pull-superchain-configs")]
+    if let Some(remote_config) = fetch_superchain_registry_metadata(name, environment) {
+        return Ok(remote_config);
+    }
+
     let config_file = read_file(archive, &format!("configs/{environment}/{name}.json"))?;
     let config_content = String::from_utf8(config_file)?;
     let chain_config: ChainMetadata = serde_json::from_str(&config_content)?;
     Ok(chain_config)
+}
+
+#[cfg(feature = "pull-superchain-configs")]
+fn fetch_superchain_registry_metadata(
+    name: &str,
+    environment: &str,
+) -> Option<ChainMetadata> {
+    const URL: &str =
+        "https://raw.githubusercontent.com/ethereum-optimism/superchain-registry/main/superchain/configs";
+    const TIMEOUT: Duration = Duration::from_secs(5);
+
+    let client = Client::builder().timeout(TIMEOUT).build().ok()?;
+    let url = format!("{URL}/{environment}/{name}.toml");
+    let response = client.get(&url).send().ok()?;
+    if !response.status().is_success() {
+        return None;
+    }
+    let body = response.text().ok()?;
+    let config: ChainMetadata = toml::from_str(&body).ok()?;
+    Some(config)
 }
 
 /// Reads a file from the tar archive. The file path is relative to the root of the tar archive.

--- a/op-reth/crates/cli/Cargo.toml
+++ b/op-reth/crates/cli/Cargo.toml
@@ -35,7 +35,7 @@ reth-node-metrics.workspace = true
 
 ## optimism
 reth-optimism-primitives.workspace = true
-reth-optimism-chainspec = { workspace = true, features = ["superchain-configs"] }
+reth-optimism-chainspec = { workspace = true, features = ["pull-superchain-configs"] }
 reth-optimism-consensus.workspace = true
 
 reth-chainspec.workspace = true
@@ -71,7 +71,7 @@ tempfile.workspace = true
 reth-stages = { workspace = true, features = ["test-utils"] }
 
 [build-dependencies]
-reth-optimism-chainspec = { workspace = true, features = ["std", "superchain-configs"] }
+reth-optimism-chainspec = { workspace = true, features = ["std", "pull-superchain-configs"] }
 
 [features]
 default = []


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Updates the `reth-optimism-chainspec` crate, adding functionality to pull the latest chain configuration directly from the Superchain Registry. If the Superchain Registry is unreachable, it will fall back to the local chain configurations and follow the existing behavior.

This functionality is enabled by the `pull-superchain-configs` feature in the `reth-optimism-chainspec` crate, and does not modify the current functionality when the `superchain-configs` feature is used instead.

**Tests**

No tests added, but happy-path is confirmed to work by actually running it. I'm not familiar with writing tests that mock HTTP requests -- would be happy to see them added!

**Additional context**

With this PR, `op-reth` doesn't need to cut a new release to reflect updates to the Superchain Registry; rather, the node operator simply needs to restart `op-reth` and it will pull the latest config. For chains that do not follow the Superchain upgrade timestamps, this significantly streamlines the process for hardfork enablements (or other configuration changes) to be reflected by node operators.

Before this PR:

- Submit + merge PR to Superchain Registry
- Submit + merge PR to `op-reth` pulling latest Superchain Registry
- Wait for `op-reth` release
- Tell node operators to update to new version of `op-reth`

After this PR:

- Submit + merge PR to Superchain Registry
- Tell node operators to restart `op-reth`
