### PR TITLE
fix: only allow enabling permissioned game types in opcm v2

### DIFF
--- a/packages/contracts-bedrock/interfaces/L1/IOPContractsManagerStandardValidator.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IOPContractsManagerStandardValidator.sol
@@ -28,6 +28,7 @@ interface IOPContractsManagerStandardValidator {
         bytes32 absolutePrestate;
         uint256 l2ChainID;
         address proposer;
+        bool isInitialDeployment;
     }
 
     struct ValidationInputDev {
@@ -36,6 +37,7 @@ interface IOPContractsManagerStandardValidator {
         bytes32 cannonKonaPrestate;
         uint256 l2ChainID;
         address proposer;
+        bool isInitialDeployment;
     }
 
     struct ValidationOverrides {

--- a/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
@@ -161,20 +161,13 @@ contract DeployOPChain is Script {
         IOPContractsManagerUtils.DisputeGameConfig[] memory disputeGameConfigs =
             new IOPContractsManagerUtils.DisputeGameConfig[](3);
 
-        // Determine which games should be enabled based on the starting respected game type
-        bool cannonEnabled = _input.disputeGameType.raw() == GameTypes.CANNON.raw();
-        bool permissionedCannonEnabled = true; // PERMISSIONED_CANNON must always be enabled
-        bool cannonKonaEnabled = _input.disputeGameType.raw() == GameTypes.CANNON_KONA.raw();
-
         // Config 0: CANNON
-        IOPContractsManagerUtils.FaultDisputeGameConfig memory cannonConfig =
-            IOPContractsManagerUtils.FaultDisputeGameConfig({ absolutePrestate: _input.disputeAbsolutePrestate });
-
+        // Must be disabled for the initial deployment since no prestate exists for permissionless games.
         disputeGameConfigs[0] = IOPContractsManagerUtils.DisputeGameConfig({
-            enabled: cannonEnabled,
-            initBond: cannonEnabled ? DEFAULT_INIT_BOND : 0,
+            enabled: false,
+            initBond: 0,
             gameType: GameTypes.CANNON,
-            gameArgs: abi.encode(cannonConfig)
+            gameArgs: bytes("")
         });
 
         // Config 1: PERMISSIONED_CANNON (must be enabled)
@@ -186,21 +179,19 @@ contract DeployOPChain is Script {
         });
 
         disputeGameConfigs[1] = IOPContractsManagerUtils.DisputeGameConfig({
-            enabled: permissionedCannonEnabled,
+            enabled: true,
             initBond: DEFAULT_INIT_BOND,
             gameType: GameTypes.PERMISSIONED_CANNON,
             gameArgs: abi.encode(pdgConfig)
         });
 
         // Config 2: CANNON_KONA
-        IOPContractsManagerUtils.FaultDisputeGameConfig memory cannonKonaConfig =
-            IOPContractsManagerUtils.FaultDisputeGameConfig({ absolutePrestate: _input.disputeAbsolutePrestate });
-
+        // Must be disabled for the initial deployment since no prestate exists for permissionless games.
         disputeGameConfigs[2] = IOPContractsManagerUtils.DisputeGameConfig({
-            enabled: cannonKonaEnabled,
-            initBond: cannonKonaEnabled ? DEFAULT_INIT_BOND : 0,
+            enabled: false,
+            initBond: 0,
             gameType: GameTypes.CANNON_KONA,
-            gameArgs: abi.encode(cannonKonaConfig)
+            gameArgs: bytes("")
         });
 
         config_ = IOPContractsManagerV2.FullConfig({
@@ -211,7 +202,7 @@ contract DeployOPChain is Script {
             unsafeBlockSigner: _input.unsafeBlockSigner,
             batcher: _input.batcher,
             startingAnchorRoot: ScriptConstants.DEFAULT_OUTPUT_ROOT(),
-            startingRespectedGameType: _input.disputeGameType,
+            startingRespectedGameType: GameTypes.PERMISSIONED_CANNON,
             basefeeScalar: _input.basefeeScalar,
             blobBasefeeScalar: _input.blobBaseFeeScalar,
             gasLimit: _input.gasLimit,

--- a/packages/contracts-bedrock/snapshots/abi/OPContractsManager.json
+++ b/packages/contracts-bedrock/snapshots/abi/OPContractsManager.json
@@ -805,52 +805,6 @@
           },
           {
             "internalType": "bytes32",
-            "name": "absolutePrestate",
-            "type": "bytes32"
-          },
-          {
-            "internalType": "uint256",
-            "name": "l2ChainID",
-            "type": "uint256"
-          },
-          {
-            "internalType": "address",
-            "name": "proposer",
-            "type": "address"
-          }
-        ],
-        "internalType": "struct OPContractsManagerStandardValidator.ValidationInput",
-        "name": "_input",
-        "type": "tuple"
-      },
-      {
-        "internalType": "bool",
-        "name": "_allowFailure",
-        "type": "bool"
-      }
-    ],
-    "name": "validate",
-    "outputs": [
-      {
-        "internalType": "string",
-        "name": "",
-        "type": "string"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "components": [
-          {
-            "internalType": "contract ISystemConfig",
-            "name": "sysCfg",
-            "type": "address"
-          },
-          {
-            "internalType": "bytes32",
             "name": "cannonPrestate",
             "type": "bytes32"
           },
@@ -868,6 +822,11 @@
             "internalType": "address",
             "name": "proposer",
             "type": "address"
+          },
+          {
+            "internalType": "bool",
+            "name": "isInitialDeployment",
+            "type": "bool"
           }
         ],
         "internalType": "struct OPContractsManagerStandardValidator.ValidationInputDev",
@@ -914,6 +873,62 @@
             "internalType": "address",
             "name": "proposer",
             "type": "address"
+          },
+          {
+            "internalType": "bool",
+            "name": "isInitialDeployment",
+            "type": "bool"
+          }
+        ],
+        "internalType": "struct OPContractsManagerStandardValidator.ValidationInput",
+        "name": "_input",
+        "type": "tuple"
+      },
+      {
+        "internalType": "bool",
+        "name": "_allowFailure",
+        "type": "bool"
+      }
+    ],
+    "name": "validate",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "contract ISystemConfig",
+            "name": "sysCfg",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "absolutePrestate",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint256",
+            "name": "l2ChainID",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "proposer",
+            "type": "address"
+          },
+          {
+            "internalType": "bool",
+            "name": "isInitialDeployment",
+            "type": "bool"
           }
         ],
         "internalType": "struct OPContractsManagerStandardValidator.ValidationInput",
@@ -982,6 +997,11 @@
             "internalType": "address",
             "name": "proposer",
             "type": "address"
+          },
+          {
+            "internalType": "bool",
+            "name": "isInitialDeployment",
+            "type": "bool"
           }
         ],
         "internalType": "struct OPContractsManagerStandardValidator.ValidationInputDev",

--- a/packages/contracts-bedrock/snapshots/abi/OPContractsManagerStandardValidator.json
+++ b/packages/contracts-bedrock/snapshots/abi/OPContractsManagerStandardValidator.json
@@ -365,52 +365,6 @@
           },
           {
             "internalType": "bytes32",
-            "name": "absolutePrestate",
-            "type": "bytes32"
-          },
-          {
-            "internalType": "uint256",
-            "name": "l2ChainID",
-            "type": "uint256"
-          },
-          {
-            "internalType": "address",
-            "name": "proposer",
-            "type": "address"
-          }
-        ],
-        "internalType": "struct OPContractsManagerStandardValidator.ValidationInput",
-        "name": "_input",
-        "type": "tuple"
-      },
-      {
-        "internalType": "bool",
-        "name": "_allowFailure",
-        "type": "bool"
-      }
-    ],
-    "name": "validate",
-    "outputs": [
-      {
-        "internalType": "string",
-        "name": "",
-        "type": "string"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "components": [
-          {
-            "internalType": "contract ISystemConfig",
-            "name": "sysCfg",
-            "type": "address"
-          },
-          {
-            "internalType": "bytes32",
             "name": "cannonPrestate",
             "type": "bytes32"
           },
@@ -428,6 +382,11 @@
             "internalType": "address",
             "name": "proposer",
             "type": "address"
+          },
+          {
+            "internalType": "bool",
+            "name": "isInitialDeployment",
+            "type": "bool"
           }
         ],
         "internalType": "struct OPContractsManagerStandardValidator.ValidationInputDev",
@@ -474,6 +433,62 @@
             "internalType": "address",
             "name": "proposer",
             "type": "address"
+          },
+          {
+            "internalType": "bool",
+            "name": "isInitialDeployment",
+            "type": "bool"
+          }
+        ],
+        "internalType": "struct OPContractsManagerStandardValidator.ValidationInput",
+        "name": "_input",
+        "type": "tuple"
+      },
+      {
+        "internalType": "bool",
+        "name": "_allowFailure",
+        "type": "bool"
+      }
+    ],
+    "name": "validate",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "contract ISystemConfig",
+            "name": "sysCfg",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "absolutePrestate",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint256",
+            "name": "l2ChainID",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "proposer",
+            "type": "address"
+          },
+          {
+            "internalType": "bool",
+            "name": "isInitialDeployment",
+            "type": "bool"
           }
         ],
         "internalType": "struct OPContractsManagerStandardValidator.ValidationInput",
@@ -542,6 +557,11 @@
             "internalType": "address",
             "name": "proposer",
             "type": "address"
+          },
+          {
+            "internalType": "bool",
+            "name": "isInitialDeployment",
+            "type": "bool"
           }
         ],
         "internalType": "struct OPContractsManagerStandardValidator.ValidationInputDev",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -24,12 +24,12 @@
     "sourceCodeHash": "0xfca613b5d055ffc4c3cbccb0773ddb9030abedc1aa6508c9e2e7727cc0cd617b"
   },
   "src/L1/OPContractsManager.sol:OPContractsManager": {
-    "initCodeHash": "0xd4593c8b35e7a1d5371315011c48116594001b198168d416d5df6d43d49f97c8",
+    "initCodeHash": "0xef8060ab00bf797fafe507baa315a196b8389dc7fda18cceef9b79a116a47952",
     "sourceCodeHash": "0xf8900a57ff29a27f99f6f68b2978b7964629a5d4b8bb351394c10431cae0f617"
   },
   "src/L1/OPContractsManagerStandardValidator.sol:OPContractsManagerStandardValidator": {
-    "initCodeHash": "0xdec828fdb9f9bb7a35ca03d851b041fcd088681957642e949b5d320358d9b9a1",
-    "sourceCodeHash": "0x17231caf75773e159b91ad37d798c600ed9662b77c236143022456dc9eb83e47"
+    "initCodeHash": "0xf8754bfbaa0ba2d3ae1c30c83ab770fa42147d50e7398699579eeb598d61793a",
+    "sourceCodeHash": "0x28f1be9fc2ebe29f147bb5e5508ff220b708b4a329982ecd73fcf3a31adf6bde"
   },
   "src/L1/OptimismPortal2.sol:OptimismPortal2": {
     "initCodeHash": "0x2c01bc6c0a55a1a27263224e05c1b28703ff85c61075bae7ab384b3043820ed2",
@@ -52,8 +52,8 @@
     "sourceCodeHash": "0xb3184aa5d95a82109e7134d1f61941b30e25f655b9849a0e303d04bbce0cde0b"
   },
   "src/L1/opcm/OPContractsManagerV2.sol:OPContractsManagerV2": {
-    "initCodeHash": "0x5f3548d6d5502669d34ff3104826d8498c3f74be2f6840a6acb9860e266d96a8",
-    "sourceCodeHash": "0xf7c02dec35e9c34e7e3e8f1fe939f7b84243064b423e38ba82fb06e389732cc7"
+    "initCodeHash": "0xa48d33442f8d4a9ae7f551d58d78e9a0c9a953b980c5ed65ddcb995cad6b5af6",
+    "sourceCodeHash": "0xb5ab1b13cac7cf3fb200298ab8c926c44881f6cecf8f5a62ba13feefef5f1df5"
   },
   "src/L2/BaseFeeVault.sol:BaseFeeVault": {
     "initCodeHash": "0x838bbd7f381e84e21887f72bd1da605bfc4588b3c39aed96cbce67c09335b3ee",

--- a/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
@@ -126,6 +126,7 @@ contract OPContractsManagerStandardValidator is ISemver {
         bytes32 absolutePrestate;
         uint256 l2ChainID;
         address proposer;
+        bool isInitialDeployment;
     }
 
     /// @notice Struct containing the input parameters for the validation process when dev features are enabled.
@@ -135,6 +136,7 @@ contract OPContractsManagerStandardValidator is ISemver {
         bytes32 cannonKonaPrestate;
         uint256 l2ChainID;
         address proposer;
+        bool isInitialDeployment;
     }
 
     /// @notice Struct containing override parameters for the validation process.
@@ -883,26 +885,30 @@ contract OPContractsManagerStandardValidator is ISemver {
         _errors = assertValidPermissionedDisputeGame(
             _errors, _input.sysCfg, _input.cannonPrestate, _input.l2ChainID, _proxyAdmin, _input.proposer, _overrides
         );
-        _errors = assertValidPermissionlessDisputeGame(
-            _errors,
-            _input.sysCfg,
-            GameTypes.CANNON,
-            _input.cannonPrestate,
-            _input.l2ChainID,
-            _proxyAdmin,
-            _overrides,
-            "PLDG"
-        );
-        _errors = assertValidPermissionlessDisputeGame(
-            _errors,
-            _input.sysCfg,
-            GameTypes.CANNON_KONA,
-            _input.cannonKonaPrestate,
-            _input.l2ChainID,
-            _proxyAdmin,
-            _overrides,
-            "CKDG"
-        );
+
+        // During initial deployment, only PERMISSIONED_CANNON should be enabled.
+        if (!_input.isInitialDeployment) {
+            _errors = assertValidPermissionlessDisputeGame(
+                _errors,
+                _input.sysCfg,
+                GameTypes.CANNON,
+                _input.cannonPrestate,
+                _input.l2ChainID,
+                _proxyAdmin,
+                _overrides,
+                "PLDG"
+            );
+            _errors = assertValidPermissionlessDisputeGame(
+                _errors,
+                _input.sysCfg,
+                GameTypes.CANNON_KONA,
+                _input.cannonKonaPrestate,
+                _input.l2ChainID,
+                _proxyAdmin,
+                _overrides,
+                "CKDG"
+            );
+        }
 
         _errors = assertValidETHLockbox(_errors, _input.sysCfg, _proxyAdmin);
 
@@ -935,7 +941,8 @@ contract OPContractsManagerStandardValidator is ISemver {
             cannonPrestate: _input.absolutePrestate,
             cannonKonaPrestate: bytes32(0),
             l2ChainID: _input.l2ChainID,
-            proposer: _input.proposer
+            proposer: _input.proposer,
+            isInitialDeployment: _input.isInitialDeployment
         });
     }
 

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
@@ -643,7 +643,7 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
 
     /// @notice Validates the deployment/upgrade config.
     /// @param _cfg The full config.
-    function _assertValidFullConfig(FullConfig memory _cfg) internal pure {
+    function _assertValidFullConfig(FullConfig memory _cfg, bool _isInitialDeployment) internal pure {
         // Start validating the dispute game configs. Put allowed game types here.
         GameType[] memory validGameTypes = new GameType[](3);
         validGameTypes[0] = GameTypes.CANNON;
@@ -665,6 +665,15 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
 
             // If the game is disabled, we must have a 0 init bond.
             if (!_cfg.disputeGameConfigs[i].enabled && _cfg.disputeGameConfigs[i].initBond != 0) {
+                revert OPContractsManagerV2_InvalidGameConfigs();
+            }
+
+            // During initial deployment, only PERMISSIONED_CANNON can be enabled, because no prestate exists for
+            // permissionless games.
+            if (
+                _isInitialDeployment && (validGameTypes[i].raw() != GameTypes.PERMISSIONED_CANNON.raw())
+                    && _cfg.disputeGameConfigs[i].enabled
+            ) {
                 revert OPContractsManagerV2_InvalidGameConfigs();
             }
         }
@@ -691,7 +700,7 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
         returns (ChainContracts memory)
     {
         // Validate the config.
-        _assertValidFullConfig(_cfg);
+        _assertValidFullConfig(_cfg, _isInitialDeployment);
 
         // Load the implementations.
         IOPContractsManagerContainer.Implementations memory impls = implementations();

--- a/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
@@ -321,7 +321,8 @@ contract OPContractsManager_Upgrade_Harness is CommonTest {
                 cannonPrestate: opChainConfigs[0].cannonPrestate.raw(),
                 cannonKonaPrestate: opChainConfigs[0].cannonKonaPrestate.raw(),
                 l2ChainID: l2ChainId,
-                proposer: initialProposer
+                proposer: initialProposer,
+                isInitialDeployment: false
             }),
             false,
             validationOverrides

--- a/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
@@ -300,7 +300,8 @@ abstract contract OPContractsManagerStandardValidator_TestInit is CommonTest {
                 cannonPrestate: cannonPrestate.raw(),
                 cannonKonaPrestate: cannonKonaPrestate.raw(),
                 l2ChainID: l2ChainId,
-                proposer: proposer
+                proposer: proposer,
+                isInitialDeployment: false
             }),
             _allowFailure
         );
@@ -323,7 +324,8 @@ abstract contract OPContractsManagerStandardValidator_TestInit is CommonTest {
                 cannonPrestate: cannonPrestate.raw(),
                 cannonKonaPrestate: cannonKonaPrestate.raw(),
                 l2ChainID: l2ChainId,
-                proposer: proposer
+                proposer: proposer,
+                isInitialDeployment: false
             }),
             _allowFailure,
             _overrides

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
@@ -150,7 +150,8 @@ contract OPContractsManagerV2_TestInit is CommonTest {
                 cannonPrestate: cannonPrestate.raw(),
                 cannonKonaPrestate: cannonKonaPrestate.raw(),
                 l2ChainID: _deployConfig.l2ChainId,
-                proposer: deployProposer
+                proposer: deployProposer,
+                isInitialDeployment: true
             }),
             false,
             validationOverrides
@@ -400,7 +401,8 @@ contract OPContractsManagerV2_Upgrade_TestInit is OPContractsManagerV2_TestInit 
                 cannonPrestate: cannonPrestate.raw(),
                 cannonKonaPrestate: cannonKonaPrestate.raw(),
                 l2ChainID: l2ChainId,
-                proposer: initialProposer
+                proposer: initialProposer,
+                isInitialDeployment: false
             }),
             false,
             validationOverrides
@@ -1030,10 +1032,10 @@ contract OPContractsManagerV2_Deploy_Test is OPContractsManagerV2_TestInit {
         address initialProposer = DisputeGames.permissionedGameProposer(disputeGameFactory);
         deployConfig.disputeGameConfigs.push(
             IOPContractsManagerUtils.DisputeGameConfig({
-                enabled: true,
-                initBond: DEFAULT_DISPUTE_GAME_INIT_BOND, // Standard init bond
+                enabled: false,
+                initBond: 0,
                 gameType: GameTypes.CANNON,
-                gameArgs: abi.encode(IOPContractsManagerUtils.FaultDisputeGameConfig({ absolutePrestate: cannonPrestate }))
+                gameArgs: bytes("")
             })
         );
         deployConfig.disputeGameConfigs.push(
@@ -1052,12 +1054,10 @@ contract OPContractsManagerV2_Deploy_Test is OPContractsManagerV2_TestInit {
         );
         deployConfig.disputeGameConfigs.push(
             IOPContractsManagerUtils.DisputeGameConfig({
-                enabled: true,
-                initBond: DEFAULT_DISPUTE_GAME_INIT_BOND, // Standard init bond
+                enabled: false,
+                initBond: 0,
                 gameType: GameTypes.CANNON_KONA,
-                gameArgs: abi.encode(
-                    IOPContractsManagerUtils.FaultDisputeGameConfig({ absolutePrestate: cannonKonaPrestate })
-                )
+                gameArgs: bytes("")
             })
         );
     }
@@ -1138,6 +1138,26 @@ contract OPContractsManagerV2_Deploy_Test is OPContractsManagerV2_TestInit {
             deployConfig, abi.encodeWithSelector(IOPContractsManagerV2.OPContractsManagerV2_InvalidGameConfigs.selector)
         );
     }
+
+    function test_deploy_cannonGameEnabled_reverts() public {
+        deployConfig.disputeGameConfigs[0].enabled = true;
+        deployConfig.disputeGameConfigs[0].initBond = 1 ether;
+
+        // nosemgrep: sol-style-use-abi-encodecall
+        runDeployV2(
+            deployConfig, abi.encodeWithSelector(IOPContractsManagerV2.OPContractsManagerV2_InvalidGameConfigs.selector)
+        );
+    }
+
+    function test_deploy_cannonKonaGameEnabled_reverts() public {
+        deployConfig.disputeGameConfigs[2].enabled = true;
+        deployConfig.disputeGameConfigs[2].initBond = 1 ether;
+
+        // nosemgrep: sol-style-use-abi-encodecall
+        runDeployV2(
+            deployConfig, abi.encodeWithSelector(IOPContractsManagerV2.OPContractsManagerV2_InvalidGameConfigs.selector)
+        );
+    }
 }
 
 /// @title OPContractsManagerV2_DevFeatureBitmap_Test
@@ -1188,10 +1208,10 @@ contract OPContractsManagerV2_Migrate_Test is OPContractsManagerV2_TestInit {
         IOPContractsManagerUtils.DisputeGameConfig[] memory dgConfigs =
             new IOPContractsManagerUtils.DisputeGameConfig[](3);
         dgConfigs[0] = IOPContractsManagerUtils.DisputeGameConfig({
-            enabled: true,
-            initBond: 0.08 ether,
+            enabled: false,
+            initBond: 0,
             gameType: GameTypes.CANNON,
-            gameArgs: abi.encode(IOPContractsManagerUtils.FaultDisputeGameConfig({ absolutePrestate: cannonPrestate }))
+            gameArgs: bytes("")
         });
         dgConfigs[1] = IOPContractsManagerUtils.DisputeGameConfig({
             enabled: true,
@@ -1206,10 +1226,10 @@ contract OPContractsManagerV2_Migrate_Test is OPContractsManagerV2_TestInit {
             )
         });
         dgConfigs[2] = IOPContractsManagerUtils.DisputeGameConfig({
-            enabled: true,
-            initBond: 0.08 ether,
+            enabled: false,
+            initBond: 0,
             gameType: GameTypes.CANNON_KONA,
-            gameArgs: abi.encode(IOPContractsManagerUtils.FaultDisputeGameConfig({ absolutePrestate: cannonKonaPrestate }))
+            gameArgs: bytes("")
         });
 
         // Set up the deploy config using struct literal for compile-time field checking.
@@ -1544,10 +1564,10 @@ contract OPContractsManagerV2_FeatBatchUpgrade_Test is OPContractsManagerV2_Test
         address initialProposer = makeAddr("proposer");
         baseConfig.disputeGameConfigs = new IOPContractsManagerUtils.DisputeGameConfig[](3);
         baseConfig.disputeGameConfigs[0] = IOPContractsManagerUtils.DisputeGameConfig({
-            enabled: true,
-            initBond: DEFAULT_DISPUTE_GAME_INIT_BOND,
+            enabled: false,
+            initBond: 0,
             gameType: GameTypes.CANNON,
-            gameArgs: abi.encode(IOPContractsManagerUtils.FaultDisputeGameConfig({ absolutePrestate: cannonPrestate }))
+            gameArgs: bytes("")
         });
         baseConfig.disputeGameConfigs[1] = IOPContractsManagerUtils.DisputeGameConfig({
             enabled: true,
@@ -1562,10 +1582,10 @@ contract OPContractsManagerV2_FeatBatchUpgrade_Test is OPContractsManagerV2_Test
             )
         });
         baseConfig.disputeGameConfigs[2] = IOPContractsManagerUtils.DisputeGameConfig({
-            enabled: true,
-            initBond: DEFAULT_DISPUTE_GAME_INIT_BOND,
+            enabled: false,
+            initBond: 0,
             gameType: GameTypes.CANNON_KONA,
-            gameArgs: abi.encode(IOPContractsManagerUtils.FaultDisputeGameConfig({ absolutePrestate: cannonKonaPrestate }))
+            gameArgs: bytes("")
         });
 
         // 3. Deploy 15 separate chains using opcmV2.deploy().

--- a/packages/contracts-bedrock/test/opcm/DeployOPChain.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployOPChain.t.sol
@@ -242,7 +242,7 @@ contract DeployOPChain_Test is DeployOPChain_TestBase {
         _checkDeploymentAssertions(doo);
     }
 
-    function test_run_cannonGameType_succeeds() public {
+    function test_run_cannonGameTypeIgnored_succeeds() public {
         // Skip test if OPCM v2 is not enabled because OPCM v1 registers PERMISSIONED_CANNON only regardles of the game
         // type.
         skipIfDevFeatureDisabled(DevFeatures.OPCM_V2);
@@ -250,13 +250,13 @@ contract DeployOPChain_Test is DeployOPChain_TestBase {
         deployOPChainInput.disputeGameType = GameTypes.CANNON;
         DeployOPChain.Output memory doo = deployOPChain.run(deployOPChainInput);
 
-        // CANNON should be enabled with init bond
+        // CANNON should be disabled
+        assertEq(doo.disputeGameFactoryProxy.initBonds(GameTypes.CANNON), 0, "CANNON init bond should be 0");
         assertEq(
-            doo.disputeGameFactoryProxy.initBonds(GameTypes.CANNON),
-            deployOPChain.DEFAULT_INIT_BOND(),
-            "CANNON init bond"
+            address(doo.disputeGameFactoryProxy.gameImpls(GameTypes.CANNON)),
+            address(0),
+            "CANNON impl should be the zero address"
         );
-        assertNotEq(address(doo.disputeGameFactoryProxy.gameImpls(GameTypes.CANNON)), address(0), "CANNON impl");
 
         // PERMISSIONED_CANNON must always be enabled
         assertEq(
@@ -272,9 +272,14 @@ contract DeployOPChain_Test is DeployOPChain_TestBase {
 
         // CANNON_KONA should not be enabled
         assertEq(doo.disputeGameFactoryProxy.initBonds(GameTypes.CANNON_KONA), 0, "CANNON_KONA init bond");
+        assertEq(
+            address(doo.disputeGameFactoryProxy.gameImpls(GameTypes.CANNON_KONA)),
+            address(0),
+            "CANNON_KONA impl should be the zero address"
+        );
     }
 
-    function test_run_cannonKonaGameType_succeeds() public {
+    function test_run_cannonKonaGameTypeIgnored_succeeds() public {
         // Skip test if OPCM v2 is not enabled because OPCM v1 registers PERMISSIONED_CANNON only regardles of the game
         // type.
         skipIfDevFeatureDisabled(DevFeatures.OPCM_V2);
@@ -283,13 +288,11 @@ contract DeployOPChain_Test is DeployOPChain_TestBase {
         DeployOPChain.Output memory doo = deployOPChain.run(deployOPChainInput);
 
         // CANNON_KONA should be enabled with init bond
+        assertEq(doo.disputeGameFactoryProxy.initBonds(GameTypes.CANNON_KONA), 0, "CANNON_KONA init bond should be 0");
         assertEq(
-            doo.disputeGameFactoryProxy.initBonds(GameTypes.CANNON_KONA),
-            deployOPChain.DEFAULT_INIT_BOND(),
-            "CANNON_KONA init bond"
-        );
-        assertNotEq(
-            address(doo.disputeGameFactoryProxy.gameImpls(GameTypes.CANNON_KONA)), address(0), "CANNON_KONA impl"
+            address(doo.disputeGameFactoryProxy.gameImpls(GameTypes.CANNON_KONA)),
+            address(0),
+            "CANNON_KONA impl should be the zero address"
         );
 
         // PERMISSIONED_CANNON must always be enabled in OPCM v2
@@ -305,7 +308,12 @@ contract DeployOPChain_Test is DeployOPChain_TestBase {
         );
 
         // CANNON should not be enabled
-        assertEq(doo.disputeGameFactoryProxy.initBonds(GameTypes.CANNON), 0, "CANNON init bond");
+        assertEq(doo.disputeGameFactoryProxy.initBonds(GameTypes.CANNON), 0, "CANNON init bond should be 0");
+        assertEq(
+            address(doo.disputeGameFactoryProxy.gameImpls(GameTypes.CANNON)),
+            address(0),
+            "CANNON impl should be the zero address"
+        );
     }
 
     /// @notice Tests that faultDisputeGame is set to address(0) and permissionedDisputeGame is set to the correct
@@ -383,24 +391,22 @@ contract DeployOPChain_Test is DeployOPChain_TestBase {
             assertNotEq(address(doo.disputeGameFactoryProxy.gameImpls(GameTypes.PERMISSIONED_CANNON)), address(0));
 
             // CANNON is only enabled if it's the starting game type
-            bool cannonEnabled = deployOPChainInput.disputeGameType.raw() == GameTypes.CANNON.raw();
+            assertEq(doo.disputeGameFactoryProxy.initBonds(GameTypes.CANNON), 0, "CANNON init bond should be 0");
             assertEq(
-                doo.disputeGameFactoryProxy.initBonds(GameTypes.CANNON),
-                cannonEnabled ? deployOPChain.DEFAULT_INIT_BOND() : 0
+                address(doo.disputeGameFactoryProxy.gameImpls(GameTypes.CANNON)),
+                address(0),
+                "CANNON impl should be the zero address"
             );
-            if (cannonEnabled) {
-                assertNotEq(address(doo.disputeGameFactoryProxy.gameImpls(GameTypes.CANNON)), address(0));
-            }
 
             // CANNON_KONA is only enabled if it's the starting game type
-            bool cannonKonaEnabled = deployOPChainInput.disputeGameType.raw() == GameTypes.CANNON_KONA.raw();
             assertEq(
-                doo.disputeGameFactoryProxy.initBonds(GameTypes.CANNON_KONA),
-                cannonKonaEnabled ? deployOPChain.DEFAULT_INIT_BOND() : 0
+                doo.disputeGameFactoryProxy.initBonds(GameTypes.CANNON_KONA), 0, "CANNON_KONA init bond should be 0"
             );
-            if (cannonKonaEnabled) {
-                assertNotEq(address(doo.disputeGameFactoryProxy.gameImpls(GameTypes.CANNON_KONA)), address(0));
-            }
+            assertEq(
+                address(doo.disputeGameFactoryProxy.gameImpls(GameTypes.CANNON_KONA)),
+                address(0),
+                "CANNON_KONA impl should be the zero address"
+            );
         }
     }
 }


### PR DESCRIPTION
## Overview
Updates `DeployOPChain` to always use permissioned games as the default configuration and introduces checks in the `OPCM v2` against permissionless deployments.

## Changes
- Default Configuration: Sets the default respected game type to permissioned.
- Disabled Permissionless: Permissionless games are now disabled by default.
- Added a check to revert if permissionless games are enabled during OPCM v2 deployments.