### PR TITLE
txmgr: move BTO config setup to txmgr

### DIFF
--- a/op-batcher/batcher/config.go
+++ b/op-batcher/batcher/config.go
@@ -211,12 +211,6 @@ func (c *CLIConfig) Check() error {
 	if err := c.TxMgrConfig.Check(); err != nil {
 		return err
 	}
-	if c.TxMgrConfig.BlobTipCapPercentile < 1 || c.TxMgrConfig.BlobTipCapPercentile > 100 {
-		return fmt.Errorf("blob-tip-cap-percentile must be between 1 and 100, got %d", c.TxMgrConfig.BlobTipCapPercentile)
-	}
-	if c.TxMgrConfig.BlobTipCapRange < 1 {
-		return fmt.Errorf("blob-tip-cap-range must be at least 1, got %d", c.TxMgrConfig.BlobTipCapRange)
-	}
 	if err := c.RPC.Check(); err != nil {
 		return err
 	}

--- a/op-batcher/batcher/config_test.go
+++ b/op-batcher/batcher/config_test.go
@@ -145,21 +145,6 @@ func TestBatcherConfig(t *testing.T) {
 			},
 			errString: "throttle.upper-threshold must be greater than throttle.lower-threshold",
 		},
-		{
-			name:      "blob tip cap percentile too low",
-			override:  func(c *batcher.CLIConfig) { c.TxMgrConfig.BlobTipCapPercentile = 0 },
-			errString: "blob-tip-cap-percentile must be between 1 and 100",
-		},
-		{
-			name:      "blob tip cap percentile too high",
-			override:  func(c *batcher.CLIConfig) { c.TxMgrConfig.BlobTipCapPercentile = 101 },
-			errString: "blob-tip-cap-percentile must be between 1 and 100",
-		},
-		{
-			name:      "blob tip cap range too low",
-			override:  func(c *batcher.CLIConfig) { c.TxMgrConfig.BlobTipCapRange = 0 },
-			errString: "blob-tip-cap-range must be at least 1",
-		},
 	}
 
 	for _, test := range tests {

--- a/op-batcher/batcher/service.go
+++ b/op-batcher/batcher/service.go
@@ -347,22 +347,6 @@ func (bs *BatcherService) initTxManager(_ context.Context, cfg *CLIConfig) error
 		return err
 	}
 
-	// Configure BTOConfig if using blobs or auto mode
-	if cfg.DataAvailabilityType == flags.BlobsType || cfg.DataAvailabilityType == flags.AutoType {
-		l1ChainID := eth.ChainIDFromBig(bs.RollupConfig.L1ChainID)
-		l1ChainConfig := eth.L1ChainConfigByChainID(l1ChainID)
-		if l1ChainConfig == nil {
-			bs.Log.Warn("Blob tip oracle not initialized: L1 chain config not found for chain ID", "chainID", l1ChainID)
-		} else {
-			txmgrConfig.BTOConfig = &txmgr.BTOConfig{
-				Backend:              bs.L1Client, // ethclient implements BTOBackend
-				ChainConfig:          l1ChainConfig,
-				BlobTipCapRange:      cfg.TxMgrConfig.BlobTipCapRange,
-				BlobTipCapPercentile: cfg.TxMgrConfig.BlobTipCapPercentile,
-			}
-		}
-	}
-
 	txManager, err := txmgr.NewSimpleTxManagerFromConfig("batcher", bs.Log, bs.Metrics, txmgrConfig)
 	if err != nil {
 		return err

--- a/op-batcher/flags/flags.go
+++ b/op-batcher/flags/flags.go
@@ -195,7 +195,7 @@ func init() {
 	optionalFlags = append(optionalFlags, oplog.CLIFlags(EnvVarPrefix)...)
 	optionalFlags = append(optionalFlags, opmetrics.CLIFlags(EnvVarPrefix)...)
 	optionalFlags = append(optionalFlags, oppprof.CLIFlags(EnvVarPrefix)...)
-	optionalFlags = append(optionalFlags, txmgr.CLIFlags(EnvVarPrefix)...)
+	optionalFlags = append(optionalFlags, txmgr.CLIFlagsWithBTO(EnvVarPrefix)...)
 	optionalFlags = append(optionalFlags, altda.CLIFlags(EnvVarPrefix, "")...)
 
 	Flags = append(requiredFlags, optionalFlags...)

--- a/op-service/txmgr/cli.go
+++ b/op-service/txmgr/cli.go
@@ -127,8 +127,8 @@ var (
 		ReceiptQueryInterval:      12 * time.Second,
 		CellProofTime:             defaultCellProofTime,
 		BlobTipCapDynamic:         false,
-		BlobTipCapPercentile:      60,
-		BlobTipCapRange:           20,
+		BlobTipCapPercentile:      0,
+		BlobTipCapRange:           0,
 	}
 
 	// geth enforces a 1 gwei minimum for blob tx fee
@@ -150,6 +150,40 @@ type BTOConfig struct {
 
 func CLIFlags(envPrefix string) []cli.Flag {
 	return CLIFlagsWithDefaults(envPrefix, DefaultBatcherFlagValues)
+}
+
+// CLIFlagsWithBTO returns CLIFlags with the BlobTipOracle flags included.
+// Only the batcher should use this, as it's the only service that uses blob transactions.
+func CLIFlagsWithBTO(envPrefix string) []cli.Flag {
+	return CLIFlagsWithDefaultsAndBTO(envPrefix, DefaultBatcherFlagValues)
+}
+
+// CLIFlagsWithDefaultsAndBTO returns CLIFlagsWithDefaults with the BlobTipOracle flags included.
+// Only the batcher should use this, as it's the only service that uses blob transactions.
+func CLIFlagsWithDefaultsAndBTO(envPrefix string, defaults DefaultFlagValues) []cli.Flag {
+	prefixEnvVars := func(name string) []string {
+		return opservice.PrefixEnvVar(envPrefix, name)
+	}
+	return append(CLIFlagsWithDefaults(envPrefix, defaults),
+		&cli.BoolFlag{
+			Name:    BlobTipCapDynamicFlagName,
+			Usage:   "Use dynamic blob tip cap from the blob tip oracle instead of static tip cap for blob transactions. Regular transactions still use min-tip-cap/max-tip-cap.",
+			EnvVars: prefixEnvVars("TXMGR_BLOB_TIP_CAP_DYNAMIC"),
+			Value:   defaults.BlobTipCapDynamic,
+		},
+		&cli.IntFlag{
+			Name:    BlobTipCapPercentileFlagName,
+			Usage:   "Percentile of recent blob tx tips to use for suggestion (1-100). Only used when blob-tip-cap-dynamic is enabled.",
+			EnvVars: prefixEnvVars("TXMGR_BLOB_TIP_CAP_PERCENTILE"),
+			Value:   defaults.BlobTipCapPercentile,
+		},
+		&cli.IntFlag{
+			Name:    BlobTipCapRangeFlagName,
+			Usage:   "Number of recent blocks to analyze for blob tip cap distribution. Only used when blob-tip-cap-dynamic is enabled.",
+			EnvVars: prefixEnvVars("TXMGR_BLOB_TIP_CAP_RANGE"),
+			Value:   defaults.BlobTipCapRange,
+		},
+	)
 }
 
 func CLIFlagsWithDefaults(envPrefix string, defaults DefaultFlagValues) []cli.Flag {
@@ -277,24 +311,6 @@ func CLIFlagsWithDefaults(envPrefix string, defaults DefaultFlagValues) []cli.Fl
 			EnvVars: prefixEnvVars("TXMGR_CELL_PROOF_TIME"),
 			Value:   defaults.CellProofTime,
 		},
-		&cli.BoolFlag{
-			Name:    BlobTipCapDynamicFlagName,
-			Usage:   "Use dynamic blob tip cap from the blob tip oracle instead of static tip cap for blob transactions. Regular transactions still use min-tip-cap/max-tip-cap.",
-			EnvVars: prefixEnvVars("TXMGR_BLOB_TIP_CAP_DYNAMIC"),
-			Value:   defaults.BlobTipCapDynamic,
-		},
-		&cli.IntFlag{
-			Name:    BlobTipCapPercentileFlagName,
-			Usage:   "Percentile of recent blob tx tips to use for suggestion (1-100). Only used when blob-tip-cap-dynamic is enabled.",
-			EnvVars: prefixEnvVars("TXMGR_BLOB_TIP_CAP_PERCENTILE"),
-			Value:   defaults.BlobTipCapPercentile,
-		},
-		&cli.IntFlag{
-			Name:    BlobTipCapRangeFlagName,
-			Usage:   "Number of recent blocks to analyze for blob tip cap distribution. Only used when blob-tip-cap-dynamic is enabled.",
-			EnvVars: prefixEnvVars("TXMGR_BLOB_TIP_CAP_RANGE"),
-			Value:   defaults.BlobTipCapRange,
-		},
 	}, opsigner.CLIFlags(envPrefix, "")...)
 }
 
@@ -383,6 +399,14 @@ func (m CLIConfig) Check() error {
 	if m.SafeAbortNonceTooLowCount == 0 {
 		return errors.New("SafeAbortNonceTooLowCount must not be 0")
 	}
+	if m.BlobTipCapDynamic {
+		if m.BlobTipCapPercentile < 1 || m.BlobTipCapPercentile > 100 {
+			return fmt.Errorf("BlobTipCapPercentile must be between 1 and 100, got %d", m.BlobTipCapPercentile)
+		}
+		if m.BlobTipCapRange < 1 {
+			return fmt.Errorf("BlobTipCapRange must be at least 1, got %d", m.BlobTipCapRange)
+		}
+	}
 	if err := m.SignerCLIConfig.Check(); err != nil {
 		return err
 	}
@@ -456,7 +480,7 @@ func NewConfig(cfg CLIConfig, l log.Logger) (*Config, error) {
 	defer cancel()
 	chainID, err := l1.ChainID(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("could not dial fetch L1 chain ID: %w", err)
+		return nil, fmt.Errorf("could not fetch L1 chain ID: %w", err)
 	}
 
 	// Allow backwards compatible ways of specifying the HD path
@@ -522,6 +546,22 @@ func NewConfig(cfg CLIConfig, l log.Logger) (*Config, error) {
 		CellProofTime:              cellProofTime,
 	}
 
+	if cfg.BlobTipCapDynamic {
+		l1ChainID := eth.ChainIDFromBig(chainID)
+		l1ChainConfig := eth.L1ChainConfigByChainID(l1ChainID)
+		if l1ChainConfig == nil {
+			return nil, fmt.Errorf("failed to initialize blob tip oracle: L1 chain config not found for chain ID %s", chainID)
+		} else {
+			res.BlobTipCapDynamic.Store(cfg.BlobTipCapDynamic)
+			res.BTOConfig = &BTOConfig{
+				Backend:              l1,
+				ChainConfig:          l1ChainConfig,
+				BlobTipCapRange:      cfg.BlobTipCapRange,
+				BlobTipCapPercentile: cfg.BlobTipCapPercentile,
+			}
+		}
+	}
+
 	res.RebroadcastInterval.Store(int64(cfg.RebroadcastInterval))
 	res.ResubmissionTimeout.Store(int64(cfg.ResubmissionTimeout))
 	res.FeeLimitThreshold.Store(feeLimitThreshold)
@@ -531,7 +571,6 @@ func NewConfig(cfg CLIConfig, l log.Logger) (*Config, error) {
 	res.MinTipCap.Store(minTipCap)
 	res.MaxTipCap.Store(maxTipCap)
 	res.MinBlobTxFee.Store(defaultMinBlobTxFee)
-	res.BlobTipCapDynamic.Store(cfg.BlobTipCapDynamic)
 
 	return &res, nil
 }

--- a/op-service/txmgr/cli_test.go
+++ b/op-service/txmgr/cli_test.go
@@ -9,9 +9,7 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-var (
-	l1EthRpcValue = "http://localhost:9546"
-)
+var l1EthRpcValue = "http://localhost:9546"
 
 func TestDefaultCLIOptionsMatchDefaultConfig(t *testing.T) {
 	cfg := configForArgs()
@@ -28,7 +26,7 @@ func TestDefaultConfigIsValid(t *testing.T) {
 func configForArgs(args ...string) CLIConfig {
 	app := cli.NewApp()
 	// txmgr expects the --l1-eth-rpc option to be declared externally
-	flags := append(CLIFlags("TEST_"), &cli.StringFlag{
+	flags := append(CLIFlagsWithBTO("TEST_"), &cli.StringFlag{
 		Name:  L1RPCFlagName,
 		Value: l1EthRpcValue,
 	})
@@ -41,6 +39,109 @@ func configForArgs(args ...string) CLIConfig {
 	}
 	_ = app.Run(args)
 	return config
+}
+
+func TestCLIConfigCheck(t *testing.T) {
+	tests := []struct {
+		name      string
+		override  func(*CLIConfig)
+		errString string
+	}{
+		{
+			name:      "empty L1 RPC URL",
+			override:  func(c *CLIConfig) { c.L1RPCURL = "" },
+			errString: "must provide a L1 RPC url",
+		},
+		{
+			name:      "zero NumConfirmations",
+			override:  func(c *CLIConfig) { c.NumConfirmations = 0 },
+			errString: "NumConfirmations must not be 0",
+		},
+		{
+			name:      "zero NetworkTimeout",
+			override:  func(c *CLIConfig) { c.NetworkTimeout = 0 },
+			errString: "must provide NetworkTimeout",
+		},
+		{
+			name:      "zero FeeLimitMultiplier",
+			override:  func(c *CLIConfig) { c.FeeLimitMultiplier = 0 },
+			errString: "must provide FeeLimitMultiplier",
+		},
+		{
+			name: "minBaseFee smaller than minTipCap",
+			override: func(c *CLIConfig) {
+				c.MinBaseFeeGwei = 1.0
+				c.MinTipCapGwei = 2.0
+			},
+			errString: "minBaseFee smaller than minTipCap",
+		},
+		{
+			name:      "zero ResubmissionTimeout",
+			override:  func(c *CLIConfig) { c.ResubmissionTimeout = 0 },
+			errString: "must provide ResubmissionTimeout",
+		},
+		{
+			name:      "zero ReceiptQueryInterval",
+			override:  func(c *CLIConfig) { c.ReceiptQueryInterval = 0 },
+			errString: "must provide ReceiptQueryInterval",
+		},
+		{
+			name:      "zero TxNotInMempoolTimeout",
+			override:  func(c *CLIConfig) { c.TxNotInMempoolTimeout = 0 },
+			errString: "must provide TxNotInMempoolTimeout",
+		},
+		{
+			name:      "zero SafeAbortNonceTooLowCount",
+			override:  func(c *CLIConfig) { c.SafeAbortNonceTooLowCount = 0 },
+			errString: "SafeAbortNonceTooLowCount must not be 0",
+		},
+		{
+			name: "BlobTipCapPercentile too low",
+			override: func(c *CLIConfig) {
+				c.BlobTipCapDynamic = true
+				c.BlobTipCapPercentile = 0
+			},
+			errString: "BlobTipCapPercentile must be between 1 and 100",
+		},
+		{
+			name: "BlobTipCapPercentile too high",
+			override: func(c *CLIConfig) {
+				c.BlobTipCapDynamic = true
+				c.BlobTipCapPercentile = 101
+			},
+			errString: "BlobTipCapPercentile must be between 1 and 100",
+		},
+		{
+			name: "BlobTipCapRange too low",
+			override: func(c *CLIConfig) {
+				c.BlobTipCapDynamic = true
+				c.BlobTipCapRange = 0
+			},
+			errString: "BlobTipCapRange must be at least 1",
+		},
+		{
+			name: "BTO validation skipped when BlobTipCapDynamic is false",
+			override: func(c *CLIConfig) {
+				c.BlobTipCapDynamic = false
+				c.BlobTipCapPercentile = 0
+				c.BlobTipCapRange = 0
+			},
+			errString: "", // No error expected
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := NewCLIConfig(l1EthRpcValue, DefaultBatcherFlagValues)
+			tc.override(&cfg)
+			err := cfg.Check()
+			if tc.errString == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tc.errString)
+			}
+		})
+	}
 }
 
 func TestFallbackToOsakaCellProofTimeIfKnown(t *testing.T) {


### PR DESCRIPTION
## Summary

Move BlobTipOracle configuration from batcher to txmgr:

- BTO config is now set up in `txmgr.NewConfig()` when `BlobTipCapDynamic` is enabled, rather than in batcher's `initTxManager()`
- BTO CLI flags are now only exposed via `CLIFlagsWithBTO()`, which only the batcher uses
- BTO validation moved from batcher to txmgr's `CLIConfig.Check()`
- Added comprehensive tests for `CLIConfig.Check()`

This follows #19032 that moved BTO ownership to txmgr, completing the consolidation of BTO logic in the txmgr package.

## Test plan

- [x] `go test ./op-service/txmgr/...` - All tests pass
- [x] `go test ./op-batcher/...` - All tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)