### PR TITLE
op-acceptance-test: Update stalling chain test to be more robust

### DIFF
--- a/op-acceptance-tests/tests/depreqres/reqressyncdisabled/depreqres_test.go
+++ b/op-acceptance-tests/tests/depreqres/reqressyncdisabled/depreqres_test.go
@@ -2,7 +2,6 @@ package depreqres
 
 import (
 	"testing"
-	"time"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
@@ -14,7 +13,8 @@ import (
 func TestUnsafeChainNotStalling_DisabledReqRespSync(gt *testing.T) {
 	t := devtest.SerialT(gt)
 	sys := presets.NewSingleChainMultiNodeWithoutCheck(t)
-	require := t.Require()
+	// We don't want the safe head to move, as this can also progress the unsafe head
+	sys.L2Batcher.Stop()
 	l := t.Logger()
 
 	l.Info("Confirm that the CL nodes are progressing the unsafe chain")
@@ -28,34 +28,20 @@ func TestUnsafeChainNotStalling_DisabledReqRespSync(gt *testing.T) {
 	sys.L2CLB.DisconnectPeer(sys.L2CL)
 	sys.L2CL.DisconnectPeer(sys.L2CLB)
 
-	ssA_before := sys.L2CL.SyncStatus()
-	ssB_before := sys.L2CLB.SyncStatus()
+	l.Info("Confirm that the CL nodes are disconnected")
+	sys.L2CL.IsP2PDisconnected(sys.L2CLB)
+	sys.L2CLB.IsP2PDisconnected(sys.L2CL)
 
-	l.Info("L2CL status before delay", "unsafeL2", ssA_before.UnsafeL2.ID(), "safeL2", ssA_before.SafeL2.ID())
-	l.Info("L2CLB status before delay", "unsafeL2", ssB_before.UnsafeL2.ID(), "safeL2", ssB_before.SafeL2.ID())
-
-	blockTime := time.Duration(sys.L2Chain.Escape().RollupConfig().BlockTime)
-	time.Sleep(10 * blockTime)
-
-	ssA_after := sys.L2CL.SyncStatus()
-	ssB_after := sys.L2CLB.SyncStatus()
-
-	l.Info("L2CL status after delay", "unsafeL2", ssA_after.UnsafeL2.ID(), "safeL2", ssA_after.SafeL2.ID())
-	l.Info("L2CLB status after delay", "unsafeL2", ssB_after.UnsafeL2.ID(), "safeL2", ssB_after.SafeL2.ID())
-
-	require.Greater(ssA_after.UnsafeL2.Number, ssA_before.UnsafeL2.Number, "unsafe chain for L2CL should have advanced")
-
-	// We wait for 10 block times, and want to check the chain has stalled.
-	// Allow 1 block of progress to account for a race between peers disconnecting and the "before" sync status being queried.
-	require.LessOrEqual(ssB_before.UnsafeL2.Number+1, ssB_after.UnsafeL2.Number, "unsafe chain for L2CLB should have stalled")
+	l.Info("Confirm that the unsafe chain for L2CLB cannot advance")
+	numAttempts := 10
+	sys.L2CL.AdvancedUnsafe(delta, numAttempts) // this is the sequencer, it builds the unsafe chain
+	sys.L2CLB.NotAdvancedUnsafe(numAttempts)
 
 	l.Info("Re-connect L2CL to L2CLB")
 	sys.L2CLB.ConnectPeer(sys.L2CL)
 	sys.L2CL.ConnectPeer(sys.L2CLB)
 
 	l.Info("Confirm that the unsafe chain for L2CLB can advance")
-	dsl.CheckAll(t,
-		sys.L2CLB.AdvancedFn(types.LocalUnsafe, delta, 30),
-		sys.L2ELB.AdvancedFn(eth.Unsafe, delta),
-	)
+	sys.L2CLB.Advanced(types.LocalUnsafe, delta, numAttempts)
+	sys.L2ELB.Advanced(eth.Unsafe, delta)
 }

--- a/op-acceptance-tests/tests/depreqres/reqressyncdisabled/depreqres_test.go
+++ b/op-acceptance-tests/tests/depreqres/reqressyncdisabled/depreqres_test.go
@@ -34,7 +34,8 @@ func TestUnsafeChainNotStalling_DisabledReqRespSync(gt *testing.T) {
 	l.Info("L2CL status before delay", "unsafeL2", ssA_before.UnsafeL2.ID(), "safeL2", ssA_before.SafeL2.ID())
 	l.Info("L2CLB status before delay", "unsafeL2", ssB_before.UnsafeL2.ID(), "safeL2", ssB_before.SafeL2.ID())
 
-	time.Sleep(20 * time.Second)
+	blockTime := time.Duration(sys.L2Chain.Escape().RollupConfig().BlockTime)
+	time.Sleep(10 * blockTime)
 
 	ssA_after := sys.L2CL.SyncStatus()
 	ssB_after := sys.L2CLB.SyncStatus()
@@ -43,7 +44,10 @@ func TestUnsafeChainNotStalling_DisabledReqRespSync(gt *testing.T) {
 	l.Info("L2CLB status after delay", "unsafeL2", ssB_after.UnsafeL2.ID(), "safeL2", ssB_after.SafeL2.ID())
 
 	require.Greater(ssA_after.UnsafeL2.Number, ssA_before.UnsafeL2.Number, "unsafe chain for L2CL should have advanced")
-	require.Equal(ssB_after.UnsafeL2.Number, ssB_before.UnsafeL2.Number, "unsafe chain for L2CLB should have stalled")
+
+	// We wait for 10 block times, and want to check the chain has stalled.
+	// Allow 1 block of progress to account for a race between peers disconnecting and the "before" sync status being queried.
+	require.Less(ssB_before.UnsafeL2.Number+1, ssB_after.UnsafeL2.Number, "unsafe chain for L2CLB should have stalled")
 
 	l.Info("Re-connect L2CL to L2CLB")
 	sys.L2CLB.ConnectPeer(sys.L2CL)

--- a/op-acceptance-tests/tests/depreqres/reqressyncdisabled/depreqres_test.go
+++ b/op-acceptance-tests/tests/depreqres/reqressyncdisabled/depreqres_test.go
@@ -47,7 +47,7 @@ func TestUnsafeChainNotStalling_DisabledReqRespSync(gt *testing.T) {
 
 	// We wait for 10 block times, and want to check the chain has stalled.
 	// Allow 1 block of progress to account for a race between peers disconnecting and the "before" sync status being queried.
-	require.Less(ssB_before.UnsafeL2.Number+1, ssB_after.UnsafeL2.Number, "unsafe chain for L2CLB should have stalled")
+	require.LessOrEqual(ssB_before.UnsafeL2.Number+1, ssB_after.UnsafeL2.Number, "unsafe chain for L2CLB should have stalled")
 
 	l.Info("Re-connect L2CL to L2CLB")
 	sys.L2CLB.ConnectPeer(sys.L2CL)

--- a/op-devstack/dsl/l2_cl.go
+++ b/op-devstack/dsl/l2_cl.go
@@ -351,6 +351,20 @@ func (cl *L2CLNode) IsP2PConnected(peer *L2CLNode) {
 	cl.require.NoError(err, "peer not connected")
 }
 
+func (cl *L2CLNode) IsP2PDisconnected(peer *L2CLNode) {
+	myInfo := cl.PeerInfo()
+	strategy := &retry.ExponentialStrategy{Min: 10 * time.Second, Max: 30 * time.Second, MaxJitter: 250 * time.Millisecond}
+	err := retry.Do0(cl.ctx, 5, strategy, func() error {
+		for _, p := range peer.Peers().Peers {
+			if p.PeerID == myInfo.PeerID {
+				return errors.New("peer still connected")
+			}
+		}
+		return nil
+	})
+	cl.require.NoError(err, "peer not disconnected")
+}
+
 type safeHeadDbMatchOpts struct {
 	minRequiredL2Block *uint64
 }


### PR DESCRIPTION
In response to https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/114795/workflows/e7cca998-1d1d-44ef-aaa9-cae1df63d395/jobs/4365023/tests