### PR TITLE
op-supernode: SuperAuthority Object

### DIFF
--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -152,6 +152,8 @@ type OpNode struct {
 	halted atomic.Bool
 
 	tracer tracer.Tracer // used for testing PublishBlock and SignAndPublishL2Payload
+
+	superAuthority SuperAuthority // optional supernode authority for coordination
 }
 
 // New creates a new OpNode instance.
@@ -195,11 +197,17 @@ func NewWithOverride(ctx context.Context, cfg *config.Config, log log.Logger, ap
 	return n, nil
 }
 
+// SuperAuthority is an interface for supernode-level authority operations.
+// It is passed to op-node instances during initialization to provide
+// supernode-specific functionality and coordination.
+type SuperAuthority interface{}
+
 type InitializationOverrides struct {
 	L1Source        L1Source
 	Beacon          L1Beacon
 	RPCHandler      *oprpc.Handler
 	MetricsRegistry func(*prometheus.Registry)
+	SuperAuthority  SuperAuthority
 }
 
 // init progressively creates and sets up all the components of the OpNode
@@ -244,6 +252,9 @@ func (n *OpNode) init(ctx context.Context, cfg *config.Config, overrides Initial
 	} else {
 		n.l1Source = overrides.L1Source
 	}
+
+	// Attach SuperAuthority if provided
+	n.superAuthority = overrides.SuperAuthority
 
 	// initL2 may use side effects to register interop subsystem to the node.EventSystem
 	n.l2Source, n.interopSys, n.l2Driver, n.safeDB, err = initL2(ctx, cfg, n)

--- a/op-supernode/supernode/resources/super_authority.go
+++ b/op-supernode/supernode/resources/super_authority.go
@@ -1,0 +1,19 @@
+package resources
+
+// SuperAuthority is an interface for supernode-level authority operations.
+// It is passed to op-node instances during initialization to provide
+// supernode-specific functionality and coordination.
+type SuperAuthority interface{}
+
+// SupernodeAuthority is the supernode's implementation of SuperAuthority.
+// It provides coordination and authority functions to op-node instances
+// running within the supernode.
+type SupernodeAuthority struct{}
+
+// NewSupernodeAuthority creates a new SupernodeAuthority instance.
+func NewSupernodeAuthority() *SupernodeAuthority {
+	return &SupernodeAuthority{}
+}
+
+// Interface conformance assertion
+var _ SuperAuthority = (*SupernodeAuthority)(nil)

--- a/op-supernode/supernode/supernode.go
+++ b/op-supernode/supernode/supernode.go
@@ -70,11 +70,14 @@ func New(ctx context.Context, log gethlog.Logger, version string, requestStop co
 	s.rpcRouter.SetRootHandler(s.rootRPC)
 	// Build metrics router; attach per-chain registries later
 	s.metricsFanIn = resources.NewMetricsFanIn(len(cfg.Chains))
+	// Create shared SupernodeAuthority for all chain containers
+	superAuthority := resources.NewSupernodeAuthority()
 	for _, id := range cfg.Chains {
 		chainID := eth.ChainIDFromUInt64(id)
 		initOverrides := &rollupNode.InitializationOverrides{
-			L1Source: resources.NewNonCloseableL1Client(s.l1Client),
-			Beacon:   resources.NewNonCloseableL1BeaconClient(s.beaconClient),
+			L1Source:       resources.NewNonCloseableL1Client(s.l1Client),
+			Beacon:         resources.NewNonCloseableL1BeaconClient(s.beaconClient),
+			SuperAuthority: superAuthority,
 		}
 		// no rpc handler is passed to the chain container, it will create a new one per (re)start using rpcRouter.SetHandler
 		if vnCfgs[chainID] == nil {


### PR DESCRIPTION
An empty object, meant to be extended with function-attributes, from which the Virtual `op-node` can make requests of the containing Supernode.

The Supernode object is currently empty so that it can be extended easily without future merge conflicts. I anticipate it will serve:
- isBlockVerified - can identify if verifiers have fully verified the given block
- isBlockInvalid - matches for already known invalid blocks so the payload isn't applied again

This object is like an Interface+Client for the supernode itself, but special purpose for the virtual nodes it contains. When a node sees that its SuperAuthority object is not nil, it can use the functions as authoritative signals, even if it does not understand those signals. Since it is an Authority and it is concerned with Superlayer concerns, I figure SuperAuthority is the right name. But happy to change it.