### PR TITLE
docs: add TODO checker workflow to docs/ai/ci-ops.md

### DIFF
--- a/.claude/skills/fix-todo/SKILL.md
+++ b/.claude/skills/fix-todo/SKILL.md
@@ -1,0 +1,51 @@
+# fix-todo
+
+Resolve TODO checker CI failures by reopening GitHub issues that still have active TODOs in the codebase.
+
+## When to Use
+
+Use this skill when the scheduled TODO checker CI job fails. The TODO checker validates that TODO comments in the codebase don't reference closed GitHub issues.
+
+### Trigger Phrases
+
+- "Fix the latest TODO checker failure"
+- "Resolve the TODO checker CI failure"
+- "Handle the TODO checker issue"
+- "Reopen issues from TODO checker"
+
+## What This Skill Does
+
+This skill automates the process of:
+1. Finding the latest failed TODO checker job in CircleCI
+2. Extracting which issues were closed but still have active TODOs
+3. Determining who closed each issue
+4. Reading the actual TODO comment from the code
+5. Reopening the issue with proper context and attribution
+
+## Workflow Documentation
+
+The complete step-by-step workflow is documented in:
+**[docs/ai/ci-ops.md](../../docs/ai/ci-ops.md#todo-checker-failures)**
+
+Follow the "TODO Checker Failures" section which includes:
+- Prerequisites (gh CLI authentication)
+- Detailed commands for each step
+- Error handling for edge cases
+- Output format and requirements
+
+## Key Requirements
+
+- Always tag the person who closed the issue (found via GitHub timeline API)
+- Include the exact file location where the TODO exists
+- Include the actual TODO comment line from the code
+- Provide context about what was completed vs what remains
+- Link to the CircleCI job for traceability
+
+## Background
+
+The repository runs a scheduled CircleCI workflow (`scheduled-todo-issues`) every 4 hours that validates TODO comments. TODO comments can reference issues in formats like:
+- `TODO(#1234)` - references ethereum-optimism/optimism
+- `TODO(repo#1234)` - references ethereum-optimism/repo
+- `TODO(org/repo#1234)` - full reference
+
+When an issue is closed but TODOs still reference it, the job fails and issues need to be reopened to track the remaining work.

--- a/.claude/skills/fix-todo/SKILL.md
+++ b/.claude/skills/fix-todo/SKILL.md
@@ -13,34 +13,6 @@ Use this skill when the scheduled TODO checker CI job fails. The TODO checker va
 - "Handle the TODO checker issue"
 - "Reopen issues from TODO checker"
 
-## What This Skill Does
-
-This skill automates the process of:
-1. Finding the latest failed TODO checker job in CircleCI
-2. Extracting which issues were closed but still have active TODOs
-3. Determining who closed each issue
-4. Reading the actual TODO comment from the code
-5. Reopening the issue with proper context and attribution
-
-## Workflow Documentation
-
-The complete step-by-step workflow is documented in:
-**[docs/ai/ci-ops.md](../../docs/ai/ci-ops.md#todo-checker-failures)**
-
-Follow the "TODO Checker Failures" section which includes:
-- Prerequisites (gh CLI authentication)
-- Detailed commands for each step
-- Error handling for edge cases
-- Output format and requirements
-
-## Key Requirements
-
-- Always tag the person who closed the issue (found via GitHub timeline API)
-- Include the exact file location where the TODO exists
-- Include the actual TODO comment line from the code
-- Provide context about what was completed vs what remains
-- Link to the CircleCI job for traceability
-
 ## Background
 
 The repository runs a scheduled CircleCI workflow (`scheduled-todo-issues`) every 4 hours that validates TODO comments. TODO comments can reference issues in formats like:
@@ -49,3 +21,180 @@ The repository runs a scheduled CircleCI workflow (`scheduled-todo-issues`) ever
 - `TODO(org/repo#1234)` - full reference
 
 When an issue is closed but TODOs still reference it, the job fails and issues need to be reopened to track the remaining work.
+
+## Prerequisites
+
+- `gh` CLI authenticated with GitHub
+- Note: CircleCI API is publicly accessible for this repository, no token required
+
+## Workflow
+
+### Step 1: Find the latest scheduled TODO checker job
+
+```bash
+LATEST_PIPELINE=$(curl -s "https://circleci.com/api/v2/project/gh/ethereum-optimism/optimism/pipeline?branch=develop" | \
+  jq -r '.items[] | select(.trigger.type == "scheduled_pipeline") | {id, number, created_at} | @json' | head -1)
+
+PIPELINE_ID=$(echo "$LATEST_PIPELINE" | jq -r '.id')
+PIPELINE_NUMBER=$(echo "$LATEST_PIPELINE" | jq -r '.number')
+```
+
+### Step 2: Get the workflow and job details
+
+Note: The latest scheduled pipeline may only contain a "setup" workflow. Search through recent scheduled pipelines to find one with the "scheduled-todo-issues" workflow.
+
+```bash
+# Find a pipeline with the TODO workflow
+PIPELINE_WITH_TODO=$(curl -s "https://circleci.com/api/v2/project/gh/ethereum-optimism/optimism/pipeline?branch=develop" | \
+  jq -r '.items[] | select(.trigger.type == "scheduled_pipeline") | .id' | while read pid; do
+    workflows=$(curl -s "https://circleci.com/api/v2/pipeline/$pid/workflow" | jq -r '.items[] | .name')
+    if echo "$workflows" | grep -q "scheduled-todo-issues"; then
+      echo "$pid"
+      break
+    fi
+  done)
+
+PIPELINE_ID="$PIPELINE_WITH_TODO"
+PIPELINE_NUMBER=$(curl -s "https://circleci.com/api/v2/project/gh/ethereum-optimism/optimism/pipeline?branch=develop" | \
+  jq -r ".items[] | select(.id == \"$PIPELINE_ID\") | .number")
+
+WORKFLOW_DATA=$(curl -s "https://circleci.com/api/v2/pipeline/$PIPELINE_ID/workflow" | \
+  jq '.items[] | select(.name == "scheduled-todo-issues")')
+WORKFLOW_ID=$(echo "$WORKFLOW_DATA" | jq -r '.id')
+WORKFLOW_STATUS=$(echo "$WORKFLOW_DATA" | jq -r '.status')
+
+JOB_NUMBER=$(curl -s "https://circleci.com/api/v2/workflow/$WORKFLOW_ID/job" | \
+  jq -r '.items[] | .job_number')
+```
+
+Check if the workflow status is "failed". If it's "success" or "running", inform the user there's no failure to fix or to wait for completion.
+
+### Step 3: Fetch the job output to find closed issues
+
+```bash
+OUTPUT_URL=$(curl -s "https://circleci.com/api/v1.1/project/gh/ethereum-optimism/optimism/$JOB_NUMBER" | \
+  jq -r '.steps[] | select(.name | contains("TODO")) | .actions[0].output_url')
+
+curl -s "$OUTPUT_URL" | jq -r '.[].message'
+```
+
+The output will show a table of closed issues. Look for the `[Error] Closed issue details:` section at the end which shows:
+- Repository & Issue (e.g., "ethereum-optimism/optimism #18616")
+- Issue Title
+- Location (e.g., "op-acceptance-tests/tests/isthmus/preinterop/interop_readiness_test.go:106")
+
+### Step 4: Parse the closed issue information
+
+Extract from the "Closed issue details" table:
+- Issue number (e.g., #18616)
+- File path and line number (e.g., `op-acceptance-tests/tests/isthmus/preinterop/interop_readiness_test.go:106`)
+- Issue title
+
+### Step 5: Find who closed the issue
+
+Issues can be closed via PR or directly by a user. Check the timeline to find the most recent person who closed it:
+
+```bash
+ISSUE_NUM="<issue_number>"
+
+# Use GraphQL to get the timeline and find the most recent close event
+CLOSER=$(gh api graphql -f query="
+query {
+  repository(owner: \"ethereum-optimism\", name: \"optimism\") {
+    issue(number: $ISSUE_NUM) {
+      timelineItems(last: 20, itemTypes: [CLOSED_EVENT, REOPENED_EVENT]) {
+        nodes {
+          ... on ClosedEvent {
+            __typename
+            createdAt
+            actor {
+              login
+            }
+            closer {
+              __typename
+            }
+          }
+          ... on ReopenedEvent {
+            __typename
+            createdAt
+            actor {
+              login
+            }
+          }
+        }
+      }
+    }
+  }
+}" --jq '.data.repository.issue.timelineItems.nodes | reverse | .[] | select(.__typename == "ClosedEvent") | .actor.login' | head -1)
+
+echo "Issue closed by: @$CLOSER"
+```
+
+This finds the most recent ClosedEvent in the timeline, which correctly handles cases where an issue was:
+- Closed via PR, then reopened, then closed directly by a user
+- Closed multiple times by different people
+
+Always tag the person from the most recent close event.
+
+### Step 6: Read the actual TODO line from the file
+
+Read the file at the location specified in the error to get the exact TODO comment text.
+
+### Step 7: Reopen the issue with proper attribution
+
+Format the reopening comment following this template:
+
+```bash
+gh issue reopen $ISSUE_NUM --comment "@${CLOSER} Reopening because this issue was closed but there's still a TODO/skip referencing it in the codebase.
+
+[Brief context about what was completed vs what remains]
+
+The [TestName] at \`<file>:<line>\` is still skipped with:
+
+\`\`\`<language>
+<actual TODO line from code>
+\`\`\`
+
+Discovered by the TODO check in CI: https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/${PIPELINE_NUMBER}/workflows/${WORKFLOW_ID}/jobs/${JOB_NUMBER}"
+```
+
+## Requirements
+
+- **Always tag the person who closed the issue** using their GitHub handle (found via the most recent close event in the timeline)
+- **Include the exact file location** where the TODO exists
+- **Include the CircleCI job URL** for traceability
+- **Read and include the actual TODO line** from the code
+- **Provide context** about what was completed vs what remains (if determinable from the issue)
+
+## Output Format
+
+After successfully reopening, report:
+
+```
+✓ TODO checker failure resolved
+
+Issue: #<number> - <title>
+Status: Reopened
+Tagged: @<username>
+Location: <file>:<line>
+
+View issue: https://github.com/ethereum-optimism/optimism/issues/<number>
+CircleCI job: https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/<pipeline>/workflows/<workflow>/jobs/<job>
+```
+
+## TODO Comment Formats
+
+The TODO checker validates these formats:
+- `TODO(#<number>)` - references ethereum-optimism/optimism
+- `TODO(<repo>#<number>)` - references ethereum-optimism/<repo>
+- `TODO(<org>/<repo>#<number>)` - full reference
+
+## Error Handling
+
+**Multiple closed issues**: Process each one sequentially, asking for confirmation before reopening each.
+
+**Issue already reopened**: Check if there's already a comment about the TODO. If not, add a comment with the location.
+
+## About the TODO Checker
+
+The TODO checker runs via `.circleci/continue/main.yml` as a scheduled workflow named `scheduled-todo-issues`. It executes `ops/scripts/todo-checker.sh --verbose --strict --check-closed`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ The OP Stack includes significant Rust implementations:
 
 More detailed guidance for AI agents can be found in:
 
-- [docs/ai/ci-ops.md](docs/ai/ci-ops.md) - CI/CD operations (TODO checker, etc.)
+- [docs/ai/ci-ops.md](docs/ai/ci-ops.md) - CI/CD operations
 - [docs/ai/contract-dev.md](docs/ai/contract-dev.md) - Smart contract development
 - [docs/ai/go-dev.md](docs/ai/go-dev.md) - Go service development
 - [docs/ai/rust-dev.md](docs/ai/rust-dev.md) - Rust development (kona, op-reth, alloy crates)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,7 @@ The OP Stack includes significant Rust implementations:
 
 More detailed guidance for AI agents can be found in:
 
+- [docs/ai/ci-ops.md](docs/ai/ci-ops.md) - CI/CD operations (TODO checker, etc.)
 - [docs/ai/contract-dev.md](docs/ai/contract-dev.md) - Smart contract development
 - [docs/ai/go-dev.md](docs/ai/go-dev.md) - Go service development
 - [docs/ai/rust-dev.md](docs/ai/rust-dev.md) - Rust development (kona, op-reth, alloy crates)

--- a/docs/ai/ci-ops.md
+++ b/docs/ai/ci-ops.md
@@ -4,190 +4,26 @@ This document provides guidance for AI agents working with CI/CD operational tas
 
 ## TODO Checker Failures
 
-The repo runs a scheduled CircleCI job every 4 hours that validates TODO comments don't reference closed GitHub issues. When this job fails, an issue needs to be reopened.
+The repo runs a scheduled CircleCI job every 4 hours that validates TODO comments don't reference closed GitHub issues. When this job fails, issues need to be reopened.
 
-### Trigger Phrases
+### Quick Instructions
 
-When you see phrases like:
-- "Fix the latest TODO checker failure"
-- "Resolve the TODO checker CI failure"
-- "Handle the TODO checker issue"
+1. Find the failed TODO checker job in CircleCI (scheduled workflow named `scheduled-todo-issues`)
+2. Identify which issues were closed but still have active TODOs in the codebase
+3. For each issue:
+   - Determine who closed it (using GitHub timeline API)
+   - Read the actual TODO comment from the code
+   - Reopen with proper attribution and context
+   - Include file location and CircleCI job link
 
-Follow the workflow below.
+### Detailed Workflow
 
-### Prerequisites
+For complete step-by-step instructions with all commands and error handling, see:
+**[.claude/skills/fix-todo/SKILL.md](../../.claude/skills/fix-todo/SKILL.md)**
 
-- `gh` CLI authenticated with GitHub
-- Note: CircleCI API is publicly accessible for this repository, no token required
-
-### Workflow
-
-#### Step 1: Find the latest scheduled TODO checker job
-
-```bash
-LATEST_PIPELINE=$(curl -s "https://circleci.com/api/v2/project/gh/ethereum-optimism/optimism/pipeline?branch=develop" | \
-  jq -r '.items[] | select(.trigger.type == "scheduled_pipeline") | {id, number, created_at} | @json' | head -1)
-
-PIPELINE_ID=$(echo "$LATEST_PIPELINE" | jq -r '.id')
-PIPELINE_NUMBER=$(echo "$LATEST_PIPELINE" | jq -r '.number')
-```
-
-#### Step 2: Get the workflow and job details
-
-Note: The latest scheduled pipeline may only contain a "setup" workflow. Search through recent scheduled pipelines to find one with the "scheduled-todo-issues" workflow.
-
-```bash
-# Find a pipeline with the TODO workflow
-PIPELINE_WITH_TODO=$(curl -s "https://circleci.com/api/v2/project/gh/ethereum-optimism/optimism/pipeline?branch=develop" | \
-  jq -r '.items[] | select(.trigger.type == "scheduled_pipeline") | .id' | while read pid; do
-    workflows=$(curl -s "https://circleci.com/api/v2/pipeline/$pid/workflow" | jq -r '.items[] | .name')
-    if echo "$workflows" | grep -q "scheduled-todo-issues"; then
-      echo "$pid"
-      break
-    fi
-  done)
-
-PIPELINE_ID="$PIPELINE_WITH_TODO"
-PIPELINE_NUMBER=$(curl -s "https://circleci.com/api/v2/project/gh/ethereum-optimism/optimism/pipeline?branch=develop" | \
-  jq -r ".items[] | select(.id == \"$PIPELINE_ID\") | .number")
-
-WORKFLOW_DATA=$(curl -s "https://circleci.com/api/v2/pipeline/$PIPELINE_ID/workflow" | \
-  jq '.items[] | select(.name == "scheduled-todo-issues")')
-WORKFLOW_ID=$(echo "$WORKFLOW_DATA" | jq -r '.id')
-WORKFLOW_STATUS=$(echo "$WORKFLOW_DATA" | jq -r '.status')
-
-JOB_NUMBER=$(curl -s "https://circleci.com/api/v2/workflow/$WORKFLOW_ID/job" | \
-  jq -r '.items[] | .job_number')
-```
-
-Check if the workflow status is "failed". If it's "success" or "running", inform the user there's no failure to fix or to wait for completion.
-
-#### Step 3: Fetch the job output to find closed issues
-
-```bash
-OUTPUT_URL=$(curl -s "https://circleci.com/api/v1.1/project/gh/ethereum-optimism/optimism/$JOB_NUMBER" | \
-  jq -r '.steps[] | select(.name | contains("TODO")) | .actions[0].output_url')
-
-curl -s "$OUTPUT_URL" | jq -r '.[].message'
-```
-
-The output will show a table of closed issues. Look for the `[Error] Closed issue details:` section at the end which shows:
-- Repository & Issue (e.g., "ethereum-optimism/optimism #18616")
-- Issue Title
-- Location (e.g., "op-acceptance-tests/tests/isthmus/preinterop/interop_readiness_test.go:106")
-
-#### Step 4: Parse the closed issue information
-
-Extract from the "Closed issue details" table:
-- Issue number (e.g., #18616)
-- File path and line number (e.g., `op-acceptance-tests/tests/isthmus/preinterop/interop_readiness_test.go:106`)
-- Issue title
-
-#### Step 5: Find who closed the issue
-
-Issues can be closed via PR or directly by a user. Check the timeline to find the most recent person who closed it:
-
-```bash
-ISSUE_NUM="<issue_number>"
-
-# Use GraphQL to get the timeline and find the most recent close event
-CLOSER=$(gh api graphql -f query="
-query {
-  repository(owner: \"ethereum-optimism\", name: \"optimism\") {
-    issue(number: $ISSUE_NUM) {
-      timelineItems(last: 20, itemTypes: [CLOSED_EVENT, REOPENED_EVENT]) {
-        nodes {
-          ... on ClosedEvent {
-            __typename
-            createdAt
-            actor {
-              login
-            }
-            closer {
-              __typename
-            }
-          }
-          ... on ReopenedEvent {
-            __typename
-            createdAt
-            actor {
-              login
-            }
-          }
-        }
-      }
-    }
-  }
-}" --jq '.data.repository.issue.timelineItems.nodes | reverse | .[] | select(.__typename == "ClosedEvent") | .actor.login' | head -1)
-
-echo "Issue closed by: @$CLOSER"
-```
-
-This finds the most recent ClosedEvent in the timeline, which correctly handles cases where an issue was:
-- Closed via PR, then reopened, then closed directly by a user
-- Closed multiple times by different people
-
-Always tag the person from the most recent close event.
-
-#### Step 6: Read the actual TODO line from the file
-
-Read the file at the location specified in the error to get the exact TODO comment text.
-
-#### Step 7: Reopen the issue with proper attribution
-
-Format the reopening comment following this template:
-
-```bash
-gh issue reopen $ISSUE_NUM --comment "@${CLOSER} Reopening because this issue was closed but there's still a TODO/skip referencing it in the codebase.
-
-[Brief context about what was completed vs what remains]
-
-The [TestName] at \`<file>:<line>\` is still skipped with:
-
-\`\`\`<language>
-<actual TODO line from code>
-\`\`\`
-
-Discovered by the TODO check in CI: https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/${PIPELINE_NUMBER}/workflows/${WORKFLOW_ID}/jobs/${JOB_NUMBER}"
-```
-
-### Requirements
-
-- **Always tag the person who closed the issue** using their GitHub handle (found via the most recent close event in the timeline)
-- **Include the exact file location** where the TODO exists
-- **Include the CircleCI job URL** for traceability
-- **Read and include the actual TODO line** from the code
-- **Provide context** about what was completed vs what remains (if determinable from the issue)
-
-### Output Format
-
-After successfully reopening, report:
-
-```
-✓ TODO checker failure resolved
-
-Issue: #<number> - <title>
-Status: Reopened
-Tagged: @<username>
-Location: <file>:<line>
-
-View issue: https://github.com/ethereum-optimism/optimism/issues/<number>
-CircleCI job: https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/<pipeline>/workflows/<workflow>/jobs/<job>
-```
-
-### TODO Comment Formats
-
-The TODO checker validates these formats:
-- `TODO(#<number>)` - references ethereum-optimism/optimism
-- `TODO(<repo>#<number>)` - references ethereum-optimism/<repo>
-- `TODO(<org>/<repo>#<number>)` - full reference
-
-### Error Handling
-
-**Multiple closed issues**: Process each one sequentially, asking for confirmation before reopening each.
-
-**Issue already reopened**: Check if there's already a comment about the TODO. If not, add a comment with the location.
-
-### About the TODO Checker
-
-The TODO checker runs via `.circleci/continue/main.yml` as a scheduled workflow named `scheduled-todo-issues`. It executes `ops/scripts/todo-checker.sh --verbose --strict --check-closed`.
+The skill includes:
+- Detailed commands for querying CircleCI and GitHub APIs
+- How to find who closed an issue
+- Comment template for reopening
+- Error handling for edge cases
+- Output format and requirements

--- a/docs/ai/ci-ops.md
+++ b/docs/ai/ci-ops.md
@@ -17,16 +17,15 @@ Follow the workflow below.
 
 ### Prerequisites
 
-- `CIRCLECI_TOKEN` environment variable (for accessing CircleCI API)
 - `gh` CLI authenticated with GitHub
+- Note: CircleCI API is publicly accessible for this repository, no token required
 
 ### Workflow
 
 #### Step 1: Find the latest scheduled TODO checker job
 
 ```bash
-LATEST_PIPELINE=$(curl -s "https://circleci.com/api/v2/project/gh/ethereum-optimism/optimism/pipeline?branch=develop" \
-  -H "Circle-Token: ${CIRCLECI_TOKEN:-}" | \
+LATEST_PIPELINE=$(curl -s "https://circleci.com/api/v2/project/gh/ethereum-optimism/optimism/pipeline?branch=develop" | \
   jq -r '.items[] | select(.trigger.type == "scheduled_pipeline") | {id, number, created_at} | @json' | head -1)
 
 PIPELINE_ID=$(echo "$LATEST_PIPELINE" | jq -r '.id')
@@ -35,13 +34,29 @@ PIPELINE_NUMBER=$(echo "$LATEST_PIPELINE" | jq -r '.number')
 
 #### Step 2: Get the workflow and job details
 
-```bash
-WORKFLOW_ID=$(curl -s "https://circleci.com/api/v2/pipeline/$PIPELINE_ID/workflow" \
-  -H "Circle-Token: ${CIRCLECI_TOKEN:-}" | \
-  jq -r '.items[] | select(.name | contains("todo")) | .id')
+Note: The latest scheduled pipeline may only contain a "setup" workflow. Search through recent scheduled pipelines to find one with the "scheduled-todo-issues" workflow.
 
-JOB_NUMBER=$(curl -s "https://circleci.com/api/v2/workflow/$WORKFLOW_ID/job" \
-  -H "Circle-Token: ${CIRCLECI_TOKEN:-}" | \
+```bash
+# Find a pipeline with the TODO workflow
+PIPELINE_WITH_TODO=$(curl -s "https://circleci.com/api/v2/project/gh/ethereum-optimism/optimism/pipeline?branch=develop" | \
+  jq -r '.items[] | select(.trigger.type == "scheduled_pipeline") | .id' | while read pid; do
+    workflows=$(curl -s "https://circleci.com/api/v2/pipeline/$pid/workflow" | jq -r '.items[] | .name')
+    if echo "$workflows" | grep -q "scheduled-todo-issues"; then
+      echo "$pid"
+      break
+    fi
+  done)
+
+PIPELINE_ID="$PIPELINE_WITH_TODO"
+PIPELINE_NUMBER=$(curl -s "https://circleci.com/api/v2/project/gh/ethereum-optimism/optimism/pipeline?branch=develop" | \
+  jq -r ".items[] | select(.id == \"$PIPELINE_ID\") | .number")
+
+WORKFLOW_DATA=$(curl -s "https://circleci.com/api/v2/pipeline/$PIPELINE_ID/workflow" | \
+  jq '.items[] | select(.name == "scheduled-todo-issues")')
+WORKFLOW_ID=$(echo "$WORKFLOW_DATA" | jq -r '.id')
+WORKFLOW_STATUS=$(echo "$WORKFLOW_DATA" | jq -r '.status')
+
+JOB_NUMBER=$(curl -s "https://circleci.com/api/v2/workflow/$WORKFLOW_ID/job" | \
   jq -r '.items[] | .job_number')
 ```
 
@@ -50,8 +65,7 @@ Check if the workflow status is "failed". If it's "success" or "running", inform
 #### Step 3: Fetch the job output to find closed issues
 
 ```bash
-OUTPUT_URL=$(curl -s "https://circleci.com/api/v1.1/project/gh/ethereum-optimism/optimism/$JOB_NUMBER" \
-  -H "Circle-Token: ${CIRCLECI_TOKEN:-}" | \
+OUTPUT_URL=$(curl -s "https://circleci.com/api/v1.1/project/gh/ethereum-optimism/optimism/$JOB_NUMBER" | \
   jq -r '.steps[] | select(.name | contains("TODO")) | .actions[0].output_url')
 
 curl -s "$OUTPUT_URL" | jq -r '.[].message'
@@ -71,11 +85,49 @@ Extract from the "Closed issue details" table:
 
 #### Step 5: Find who closed the issue
 
+Issues can be closed via PR or directly by a user. Check the timeline to find the most recent person who closed it:
+
 ```bash
 ISSUE_NUM="<issue_number>"
-CLOSING_PR=$(gh issue view $ISSUE_NUM --json closedByPullRequestsReferences --jq '.closedByPullRequestsReferences[0].number')
-PR_AUTHOR=$(gh pr view $CLOSING_PR --json author --jq '.author.login')
+
+# Use GraphQL to get the timeline and find the most recent close event
+CLOSER=$(gh api graphql -f query="
+query {
+  repository(owner: \"ethereum-optimism\", name: \"optimism\") {
+    issue(number: $ISSUE_NUM) {
+      timelineItems(last: 20, itemTypes: [CLOSED_EVENT, REOPENED_EVENT]) {
+        nodes {
+          ... on ClosedEvent {
+            __typename
+            createdAt
+            actor {
+              login
+            }
+            closer {
+              __typename
+            }
+          }
+          ... on ReopenedEvent {
+            __typename
+            createdAt
+            actor {
+              login
+            }
+          }
+        }
+      }
+    }
+  }
+}" --jq '.data.repository.issue.timelineItems.nodes | reverse | .[] | select(.__typename == "ClosedEvent") | .actor.login' | head -1)
+
+echo "Issue closed by: @$CLOSER"
 ```
+
+This finds the most recent ClosedEvent in the timeline, which correctly handles cases where an issue was:
+- Closed via PR, then reopened, then closed directly by a user
+- Closed multiple times by different people
+
+Always tag the person from the most recent close event.
 
 #### Step 6: Read the actual TODO line from the file
 
@@ -86,7 +138,7 @@ Read the file at the location specified in the error to get the exact TODO comme
 Format the reopening comment following this template:
 
 ```bash
-gh issue reopen $ISSUE_NUM --comment "@${PR_AUTHOR} Reopening because this issue was closed but there's still a TODO/skip referencing it in the codebase.
+gh issue reopen $ISSUE_NUM --comment "@${CLOSER} Reopening because this issue was closed but there's still a TODO/skip referencing it in the codebase.
 
 [Brief context about what was completed vs what remains]
 
@@ -101,7 +153,7 @@ Discovered by the TODO check in CI: https://app.circleci.com/pipelines/github/et
 
 ### Requirements
 
-- **Always tag the person who closed the issue** using their GitHub handle (found via the closing PR)
+- **Always tag the person who closed the issue** using their GitHub handle (found via the most recent close event in the timeline)
 - **Include the exact file location** where the TODO exists
 - **Include the CircleCI job URL** for traceability
 - **Read and include the actual TODO line** from the code
@@ -131,8 +183,6 @@ The TODO checker validates these formats:
 - `TODO(<org>/<repo>#<number>)` - full reference
 
 ### Error Handling
-
-**No CIRCLECI_TOKEN**: Ask the user to set the environment variable or provide the CircleCI job URL directly.
 
 **Multiple closed issues**: Process each one sequentially, asking for confirmation before reopening each.
 

--- a/docs/ai/ci-ops.md
+++ b/docs/ai/ci-ops.md
@@ -1,0 +1,143 @@
+# CI/CD Operations
+
+This document provides guidance for AI agents working with CI/CD operational tasks in the Optimism monorepo.
+
+## TODO Checker Failures
+
+The repo runs a scheduled CircleCI job every 4 hours that validates TODO comments don't reference closed GitHub issues. When this job fails, an issue needs to be reopened.
+
+### Trigger Phrases
+
+When you see phrases like:
+- "Fix the latest TODO checker failure"
+- "Resolve the TODO checker CI failure"
+- "Handle the TODO checker issue"
+
+Follow the workflow below.
+
+### Prerequisites
+
+- `CIRCLECI_TOKEN` environment variable (for accessing CircleCI API)
+- `gh` CLI authenticated with GitHub
+
+### Workflow
+
+#### Step 1: Find the latest scheduled TODO checker job
+
+```bash
+LATEST_PIPELINE=$(curl -s "https://circleci.com/api/v2/project/gh/ethereum-optimism/optimism/pipeline?branch=develop" \
+  -H "Circle-Token: ${CIRCLECI_TOKEN:-}" | \
+  jq -r '.items[] | select(.trigger.type == "scheduled_pipeline") | {id, number, created_at} | @json' | head -1)
+
+PIPELINE_ID=$(echo "$LATEST_PIPELINE" | jq -r '.id')
+PIPELINE_NUMBER=$(echo "$LATEST_PIPELINE" | jq -r '.number')
+```
+
+#### Step 2: Get the workflow and job details
+
+```bash
+WORKFLOW_ID=$(curl -s "https://circleci.com/api/v2/pipeline/$PIPELINE_ID/workflow" \
+  -H "Circle-Token: ${CIRCLECI_TOKEN:-}" | \
+  jq -r '.items[] | select(.name | contains("todo")) | .id')
+
+JOB_NUMBER=$(curl -s "https://circleci.com/api/v2/workflow/$WORKFLOW_ID/job" \
+  -H "Circle-Token: ${CIRCLECI_TOKEN:-}" | \
+  jq -r '.items[] | .job_number')
+```
+
+Check if the workflow status is "failed". If it's "success" or "running", inform the user there's no failure to fix or to wait for completion.
+
+#### Step 3: Fetch the job output to find closed issues
+
+```bash
+OUTPUT_URL=$(curl -s "https://circleci.com/api/v1.1/project/gh/ethereum-optimism/optimism/$JOB_NUMBER" \
+  -H "Circle-Token: ${CIRCLECI_TOKEN:-}" | \
+  jq -r '.steps[] | select(.name | contains("TODO")) | .actions[0].output_url')
+
+curl -s "$OUTPUT_URL" | jq -r '.[].message'
+```
+
+The output will show a table of closed issues. Look for the `[Error] Closed issue details:` section at the end which shows:
+- Repository & Issue (e.g., "ethereum-optimism/optimism #18616")
+- Issue Title
+- Location (e.g., "op-acceptance-tests/tests/isthmus/preinterop/interop_readiness_test.go:106")
+
+#### Step 4: Parse the closed issue information
+
+Extract from the "Closed issue details" table:
+- Issue number (e.g., #18616)
+- File path and line number (e.g., `op-acceptance-tests/tests/isthmus/preinterop/interop_readiness_test.go:106`)
+- Issue title
+
+#### Step 5: Find who closed the issue
+
+```bash
+ISSUE_NUM="<issue_number>"
+CLOSING_PR=$(gh issue view $ISSUE_NUM --json closedByPullRequestsReferences --jq '.closedByPullRequestsReferences[0].number')
+PR_AUTHOR=$(gh pr view $CLOSING_PR --json author --jq '.author.login')
+```
+
+#### Step 6: Read the actual TODO line from the file
+
+Read the file at the location specified in the error to get the exact TODO comment text.
+
+#### Step 7: Reopen the issue with proper attribution
+
+Format the reopening comment following this template:
+
+```bash
+gh issue reopen $ISSUE_NUM --comment "@${PR_AUTHOR} Reopening because this issue was closed but there's still a TODO/skip referencing it in the codebase.
+
+[Brief context about what was completed vs what remains]
+
+The [TestName] at \`<file>:<line>\` is still skipped with:
+
+\`\`\`<language>
+<actual TODO line from code>
+\`\`\`
+
+Discovered by the TODO check in CI: https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/${PIPELINE_NUMBER}/workflows/${WORKFLOW_ID}/jobs/${JOB_NUMBER}"
+```
+
+### Requirements
+
+- **Always tag the person who closed the issue** using their GitHub handle (found via the closing PR)
+- **Include the exact file location** where the TODO exists
+- **Include the CircleCI job URL** for traceability
+- **Read and include the actual TODO line** from the code
+- **Provide context** about what was completed vs what remains (if determinable from the issue)
+
+### Output Format
+
+After successfully reopening, report:
+
+```
+✓ TODO checker failure resolved
+
+Issue: #<number> - <title>
+Status: Reopened
+Tagged: @<username>
+Location: <file>:<line>
+
+View issue: https://github.com/ethereum-optimism/optimism/issues/<number>
+CircleCI job: https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/<pipeline>/workflows/<workflow>/jobs/<job>
+```
+
+### TODO Comment Formats
+
+The TODO checker validates these formats:
+- `TODO(#<number>)` - references ethereum-optimism/optimism
+- `TODO(<repo>#<number>)` - references ethereum-optimism/<repo>
+- `TODO(<org>/<repo>#<number>)` - full reference
+
+### Error Handling
+
+**No CIRCLECI_TOKEN**: Ask the user to set the environment variable or provide the CircleCI job URL directly.
+
+**Multiple closed issues**: Process each one sequentially, asking for confirmation before reopening each.
+
+**Issue already reopened**: Check if there's already a comment about the TODO. If not, add a comment with the location.
+
+### About the TODO Checker
+
+The TODO checker runs via `.circleci/continue/main.yml` as a scheduled workflow named `scheduled-todo-issues`. It executes `ops/scripts/todo-checker.sh --verbose --strict --check-closed`.


### PR DESCRIPTION
## Summary

Adds automated TODO checker failure resolution workflow to the AI agent documentation.

## Changes

- **New file**: `docs/ai/ci-ops.md` - Detailed workflow for resolving TODO checker CI failures
- **Updated**: `AGENTS.md` - References the new ci-ops.md file

## Motivation

The repo runs a scheduled CircleCI job every 4 hours that validates TODO comments don't reference closed GitHub issues. When failures occur, manually investigating and reopening issues is time-consuming.

This documentation enables Claude Code to automatically handle TODO checker failures when users say phrases like "fix the latest TODO checker failure".

## How It Works

The workflow:
1. Finds the latest scheduled TODO checker pipeline via CircleCI API
2. Fetches and parses the job output to identify closed issues
3. Uses GitHub API to find who closed the issue (via the closing PR)
4. Reopens the issue with proper attribution, context, and traceability

## Documentation Pattern

Follows the existing `docs/ai/` structure:
- `docs/ai/ci-ops.md` - CI/CD operations
- `docs/ai/contract-dev.md` - Smart contract development  
- `docs/ai/go-dev.md` - Go service development
- `docs/ai/rust-dev.md` - Rust development

## Example Usage

After merging, Claude Code will automatically handle requests like:
- "Fix the latest TODO checker failure"
- "Resolve the TODO checker CI failure"
- "Handle the TODO checker issue"

The workflow ensures issues are reopened with:
- Attribution to the person who closed it
- Exact file location of the remaining TODO
- CircleCI job URL for traceability
- The actual TODO line from the code