### PR TITLE
op-acceptance: Verify chain with kona proofs interop

### DIFF
--- a/op-acceptance-tests/tests/interop/proofs/fpp_test.go
+++ b/op-acceptance-tests/tests/interop/proofs/fpp_test.go
@@ -1,0 +1,20 @@
+package proofs
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+)
+
+func TestFPP(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewSimpleInterop(t)
+
+	startTimestamp := max(sys.L2ChainA.Escape().RollupConfig().TimestampForBlock(1), sys.L2ChainB.Escape().RollupConfig().TimestampForBlock(1))
+	endTimestamp := sys.L2ChainA.Escape().RollupConfig().TimestampForBlock(5)
+	sys.SuperRoots.AwaitValidatedTimestamp(endTimestamp)
+
+	dgf := sys.DisputeGameFactory()
+	dgf.RunFPP(startTimestamp, endTimestamp)
+}

--- a/op-acceptance-tests/tests/interop/proofs/init_test.go
+++ b/op-acceptance-tests/tests/interop/proofs/init_test.go
@@ -4,8 +4,13 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
 )
 
 func TestMain(m *testing.M) {
-	presets.DoMain(m, presets.WithSuperInteropSupernode())
+	presets.DoMain(m,
+		presets.WithSuperInteropSupernode(),
+		stack.MakeCommon(sysgo.WithChallengerCannonKonaEnabled()),
+	)
 }

--- a/op-devstack/dsl/proofs/dispute_game_factory.go
+++ b/op-devstack/dsl/proofs/dispute_game_factory.go
@@ -488,46 +488,43 @@ func (f *DisputeGameFactory) RunFPP(startTimestamp uint64, endTimestamp uint64) 
 	for i := uint64(0); i < (endTimestamp-startTimestamp)*super.StepsPerTimestamp+3; i++ {
 		pos := challengerTypes.NewPosition(splitDepth, new(big.Int).SetUint64(i))
 
-		// 2. Create LocalGameInputs using the previous claim (or anchor state) as agreed and current as disputed
-		// Get the claim at this position (this is the disputed claim)
+		// Create LocalGameInputs using the previous claim (or anchor state) as agreed and current as disputed
 		claimedPreimage, err := traceProvider.GetPreimageBytes(f.t.Ctx(), pos)
 		f.require.NoError(err, "Failed to get claim at position %v", pos)
-
-		claim := crypto.Keccak256Hash(claimedPreimage)
-
-		// Create LocalGameInputs
 		inputs := utils.LocalGameInputs{
 			L1Head:           l1Head.Hash,
 			AgreedPreState:   agreedPrestate,
-			L2Claim:          claim,
+			L2Claim:          crypto.Keccak256Hash(claimedPreimage),
 			L2SequenceNumber: new(big.Int).SetUint64(endTimestamp),
 		}
 
 		f.log.Info("Created LocalGameInputs for FPP",
-			"position", pos.ToGIndex(),
-			"splitDepth", splitDepth,
-			"i", i,
-			"l1Head", l1Head.Hash,
-			"l2Claim", claim,
+			"index", pos.IndexAtDepth(),
+			"l1Head", inputs.L1Head,
+			"l2Claim", inputs.L2Claim,
 		)
 
-		// Execute the game using the LocalGameInputs and native kona super executor
-		executor := vm.NewNativeKonaSuperExecutor()
-		oracleCommand, err := executor.OracleCommand(f.challengerCfg.CannonKona, tmpDir, inputs)
-		f.require.NoError(err, "Failed to create oracle command")
-		f.log.Info("Executing FPP", "command", oracleCommand)
-		exePath, err := filepath.Abs(oracleCommand[0])
-		f.require.NoError(err, "Failed to get absolute path to executable")
-		cmd := exec.Command(exePath, oracleCommand[1:]...)
-		cmd.Dir = tmpDir
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		err = cmd.Run()
-		f.require.NoError(err, "Failed to execute game")
+		runFPPForStep(f, tmpDir, inputs)
 
 		// This claim becomes the agreed prestate for the next iteration
 		agreedPrestate = claimedPreimage
 	}
+}
+
+// runFPPForStep executes the native kona interop client using the LocalGameInputs and requires the claim to be successfully validated.
+func runFPPForStep(f *DisputeGameFactory, tmpDir string, inputs utils.LocalGameInputs) {
+	executor := vm.NewNativeKonaSuperExecutor()
+	oracleCommand, err := executor.OracleCommand(f.challengerCfg.CannonKona, tmpDir, inputs)
+	f.require.NoError(err, "Failed to create command")
+	f.log.Info("Executing FPP", "command", oracleCommand)
+	exePath, err := filepath.Abs(oracleCommand[0])
+	f.require.NoError(err, "Failed to get absolute path to executable")
+	cmd := exec.Command(exePath, oracleCommand[1:]...)
+	cmd.Dir = tmpDir
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err = cmd.Run()
+	f.require.NoError(err, "Failed to execute game")
 }
 
 type GameHelperEOA struct {

--- a/op-devstack/dsl/proofs/dispute_game_factory.go
+++ b/op-devstack/dsl/proofs/dispute_game_factory.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/outputs"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/prestates"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/super"
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/utils"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/vm"
 	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-challenger/metrics"
@@ -448,6 +449,89 @@ func (f *DisputeGameFactory) safeTimestamp() uint64 {
 	resp, err := f.superNode.QueryAPI().SuperRootAtTimestamp(f.t.Ctx(), now)
 	f.require.NoError(err, "Failed to fetch super root at timestamp")
 	return resp.CurrentSafeTimestamp
+}
+
+func (f *DisputeGameFactory) RunFPP(startTimestamp uint64, endTimestamp uint64) {
+	/*
+		We're going to pretend like there's a dispute game created and check that the fault proof program successfully
+		validates all the claims the honest trace provider returns for the top half of the game.
+		This only needs to support SuperCannonKonaGameType.
+	*/
+	f.require.NotNil(f.superNode, "super node is required to run FPP")
+	f.require.NotNil(f.challengerCfg, "challenger config is required to run FPP")
+
+	// Get the game implementation to read splitDepth
+	gameImpl := f.GameImpl(gameTypes.SuperCannonKonaGameType)
+	splitDepth := gameImpl.SplitDepth()
+
+	// Get the prestate timestamp from the supernode
+
+	// 0. Get the L1 head from the supernode's response at the poststate timestamp
+	// This ensures the supernode has synced to this L1 block
+	superRootResp, err := f.superNode.QueryAPI().SuperRootAtTimestamp(f.t.Ctx(), endTimestamp)
+	f.require.NoError(err, "Failed to fetch super root at timestamp")
+	l1Head := superRootResp.CurrentL1
+
+	// Create a prestate provider for the super root
+	prestateProvider := super.NewSuperNodePrestateProvider(f.superNode.QueryAPI(), startTimestamp)
+
+	// Create the super trace provider to iterate through claims at splitDepth
+	traceProvider := super.NewSuperNodeTraceProvider(
+		f.log.New("role", "fpp-trace"),
+		prestateProvider,
+		f.superNode.QueryAPI(),
+		eth.BlockID{Hash: l1Head.Hash, Number: l1Head.Number},
+		splitDepth,
+		startTimestamp,
+		endTimestamp,
+	)
+
+	// 1. Iterate through valid claims at splitDepth (the leaves of the top game)
+	// At splitDepth, positions have indices from 0 to 2^splitDepth-1
+	// For index i, we create LocalGameInputs
+
+	for i := uint64(0); i < (endTimestamp-startTimestamp)*super.StepsPerTimestamp+3; i++ {
+		// Create position at splitDepth with index i (leaf of the top game)
+		pos := challengerTypes.NewPosition(splitDepth, new(big.Int).SetUint64(i))
+
+		// 2. Create LocalGameInputs using the previous claim (or anchor state) as agreed and current as disputed
+		// Get the claim at this position (this is the disputed claim)
+		claim, err := traceProvider.Get(f.t.Ctx(), pos)
+		f.require.NoError(err, "Failed to get claim at position %v", pos)
+
+		// Determine the agreed prestate:
+		// - If i == 0, use the absolute prestate
+		// - Otherwise, use the claim at position i-1 (the previous position at this depth)
+		var agreedPrestate []byte
+		if i == 0 {
+			absolutePrestate, err := prestateProvider.AbsolutePreState(f.t.Ctx())
+			f.require.NoError(err, "Failed to get absolute prestate")
+			agreedPrestate = absolutePrestate.Marshal()
+		} else {
+			// Get the preimage bytes at the previous position (i-1)
+			prevPos := challengerTypes.NewPosition(splitDepth, new(big.Int).SetUint64(i-1))
+			agreedPrestate, err = traceProvider.GetPreimageBytes(f.t.Ctx(), prevPos)
+			f.require.NoError(err, "Failed to get preimage at previous position %v", prevPos)
+		}
+
+		// Create LocalGameInputs
+		inputs := utils.LocalGameInputs{
+			L1Head:           l1Head.Hash,
+			AgreedPreState:   agreedPrestate,
+			L2Claim:          claim,
+			L2SequenceNumber: new(big.Int).SetUint64(endTimestamp),
+		}
+
+		f.log.Info("Created LocalGameInputs for FPP",
+			"position", pos.ToGIndex(),
+			"splitDepth", splitDepth,
+			"i", i,
+			"l1Head", l1Head.Hash,
+			"l2Claim", claim,
+			"agreedPrestateLen", len(agreedPrestate),
+			"inputs", inputs,
+		)
+	}
 }
 
 type GameHelperEOA struct {

--- a/op-devstack/dsl/proofs/dispute_game_factory.go
+++ b/op-devstack/dsl/proofs/dispute_game_factory.go
@@ -5,7 +5,10 @@ import (
 	"encoding/binary"
 	"math/big"
 	"net/url"
+	"os"
+	"os/exec"
 	"path"
+	"path/filepath"
 	"time"
 
 	challengerConfig "github.com/ethereum-optimism/optimism/op-challenger/config"
@@ -451,31 +454,19 @@ func (f *DisputeGameFactory) safeTimestamp() uint64 {
 	return resp.CurrentSafeTimestamp
 }
 
+// RunFPP runs the fault proof program between the two supplied timestamps. Currently only supports kona-interop.
 func (f *DisputeGameFactory) RunFPP(startTimestamp uint64, endTimestamp uint64) {
-	/*
-		We're going to pretend like there's a dispute game created and check that the fault proof program successfully
-		validates all the claims the honest trace provider returns for the top half of the game.
-		This only needs to support SuperCannonKonaGameType.
-	*/
 	f.require.NotNil(f.superNode, "super node is required to run FPP")
 	f.require.NotNil(f.challengerCfg, "challenger config is required to run FPP")
 
-	// Get the game implementation to read splitDepth
-	gameImpl := f.GameImpl(gameTypes.SuperCannonKonaGameType)
-	splitDepth := gameImpl.SplitDepth()
+	splitDepth := f.GameImpl(gameTypes.SuperCannonKonaGameType).SplitDepth()
 
-	// Get the prestate timestamp from the supernode
-
-	// 0. Get the L1 head from the supernode's response at the poststate timestamp
-	// This ensures the supernode has synced to this L1 block
+	// Use the current L1 head that the super node has processed. Otherwise the trace provider will fail because the node is not sufficiently up to date.
 	superRootResp, err := f.superNode.QueryAPI().SuperRootAtTimestamp(f.t.Ctx(), endTimestamp)
 	f.require.NoError(err, "Failed to fetch super root at timestamp")
 	l1Head := superRootResp.CurrentL1
 
-	// Create a prestate provider for the super root
 	prestateProvider := super.NewSuperNodePrestateProvider(f.superNode.QueryAPI(), startTimestamp)
-
-	// Create the super trace provider to iterate through claims at splitDepth
 	traceProvider := super.NewSuperNodeTraceProvider(
 		f.log.New("role", "fpp-trace"),
 		prestateProvider,
@@ -486,33 +477,23 @@ func (f *DisputeGameFactory) RunFPP(startTimestamp uint64, endTimestamp uint64) 
 		endTimestamp,
 	)
 
-	// 1. Iterate through valid claims at splitDepth (the leaves of the top game)
-	// At splitDepth, positions have indices from 0 to 2^splitDepth-1
-	// For index i, we create LocalGameInputs
+	tmpDir := f.t.TempDir()
 
+	// Starting prestate is the aboslutePrestate
+	absolutePrestate, err := prestateProvider.AbsolutePreState(f.t.Ctx())
+	f.require.NoError(err, "Failed to get absolute prestate")
+	agreedPrestate := absolutePrestate.Marshal()
+
+	// Iterate through valid claims at splitDepth (the leaves of the top game) to get a few steps past the endTimestamp
 	for i := uint64(0); i < (endTimestamp-startTimestamp)*super.StepsPerTimestamp+3; i++ {
-		// Create position at splitDepth with index i (leaf of the top game)
 		pos := challengerTypes.NewPosition(splitDepth, new(big.Int).SetUint64(i))
 
 		// 2. Create LocalGameInputs using the previous claim (or anchor state) as agreed and current as disputed
 		// Get the claim at this position (this is the disputed claim)
-		claim, err := traceProvider.Get(f.t.Ctx(), pos)
+		claimedPreimage, err := traceProvider.GetPreimageBytes(f.t.Ctx(), pos)
 		f.require.NoError(err, "Failed to get claim at position %v", pos)
 
-		// Determine the agreed prestate:
-		// - If i == 0, use the absolute prestate
-		// - Otherwise, use the claim at position i-1 (the previous position at this depth)
-		var agreedPrestate []byte
-		if i == 0 {
-			absolutePrestate, err := prestateProvider.AbsolutePreState(f.t.Ctx())
-			f.require.NoError(err, "Failed to get absolute prestate")
-			agreedPrestate = absolutePrestate.Marshal()
-		} else {
-			// Get the preimage bytes at the previous position (i-1)
-			prevPos := challengerTypes.NewPosition(splitDepth, new(big.Int).SetUint64(i-1))
-			agreedPrestate, err = traceProvider.GetPreimageBytes(f.t.Ctx(), prevPos)
-			f.require.NoError(err, "Failed to get preimage at previous position %v", prevPos)
-		}
+		claim := crypto.Keccak256Hash(claimedPreimage)
 
 		// Create LocalGameInputs
 		inputs := utils.LocalGameInputs{
@@ -528,9 +509,24 @@ func (f *DisputeGameFactory) RunFPP(startTimestamp uint64, endTimestamp uint64) 
 			"i", i,
 			"l1Head", l1Head.Hash,
 			"l2Claim", claim,
-			"agreedPrestateLen", len(agreedPrestate),
-			"inputs", inputs,
 		)
+
+		// Execute the game using the LocalGameInputs and native kona super executor
+		executor := vm.NewNativeKonaSuperExecutor()
+		oracleCommand, err := executor.OracleCommand(f.challengerCfg.CannonKona, tmpDir, inputs)
+		f.require.NoError(err, "Failed to create oracle command")
+		f.log.Info("Executing FPP", "command", oracleCommand)
+		exePath, err := filepath.Abs(oracleCommand[0])
+		f.require.NoError(err, "Failed to get absolute path to executable")
+		cmd := exec.Command(exePath, oracleCommand[1:]...)
+		cmd.Dir = tmpDir
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		err = cmd.Run()
+		f.require.NoError(err, "Failed to execute game")
+
+		// This claim becomes the agreed prestate for the next iteration
+		agreedPrestate = claimedPreimage
 	}
 }
 

--- a/op-devstack/dsl/supernode.go
+++ b/op-devstack/dsl/supernode.go
@@ -2,8 +2,10 @@ package dsl
 
 import (
 	"context"
+	"time"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
 	"github.com/ethereum-optimism/optimism/op-service/apis"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
@@ -56,4 +58,18 @@ func (s *Supernode) AssertSuperRootAtTimestamp(l2SequenceNumber uint64, rootClai
 	s.require.NotNilf(resp.Data, "super root does not exist at time %d", l2SequenceNumber)
 	superRoot := eth.SuperRoot(resp.Data.Super)
 	s.require.Equal(superRoot[:], rootClaim[:])
+}
+
+// AwaitValidatedTimestamp waits for the super-root at the given timestamp to be fully validated
+func (s *Supernode) AwaitValidatedTimestamp(timestamp uint64) {
+	ctx, cancel := context.WithTimeout(s.ctx, DefaultTimeout)
+	defer cancel()
+	err := wait.For(ctx, 1*time.Second, func() (bool, error) {
+		resp, err := s.inner.QueryAPI().SuperRootAtTimestamp(ctx, timestamp)
+		if err != nil {
+			return false, nil // Ignore transient errors.
+		}
+		return resp.Data != nil, nil
+	})
+	s.require.NoError(err, "super-root at timestamp %d was not validated in time", timestamp)
 }

--- a/op-devstack/presets/interop.go
+++ b/op-devstack/presets/interop.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
+	challengerConfig "github.com/ethereum-optimism/optimism/op-challenger/config"
 	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
@@ -41,6 +42,9 @@ type SingleChainInterop struct {
 	FaucetL1 *dsl.Faucet
 	FunderL1 *dsl.Funder
 	FunderA  *dsl.Funder
+
+	// May be nil if not using sysgo
+	challengerConfig *challengerConfig.Config
 }
 
 func NewSingleChainInterop(t devtest.T) *SingleChainInterop {
@@ -68,22 +72,29 @@ func NewSingleChainInterop(t devtest.T) *SingleChainInterop {
 	default:
 		t.Gate().True(false, "expected at least one supervisor or supernode")
 	}
+
+	var challengerCfg *challengerConfig.Config
+	if len(l2A.L2Challengers()) > 0 {
+		challengerCfg = l2A.L2Challengers()[0].Config()
+	}
+
 	out := &SingleChainInterop{
-		Log:           t.Logger(),
-		T:             t,
-		system:        system,
-		TestSequencer: dsl.NewTestSequencer(system.TestSequencer(match.Assume(t, match.FirstTestSequencer))),
-		Supervisor:    supervisor,
-		SuperRoots:    superRoots,
-		ControlPlane:  orch.ControlPlane(),
-		L1Network:     dsl.NewL1Network(l1Net),
-		L1EL:          dsl.NewL1ELNode(l1Net.L1ELNode(match.Assume(t, match.FirstL1EL))),
-		L2ChainA:      dsl.NewL2Network(l2A, orch.ControlPlane()),
-		L2ELA:         dsl.NewL2ELNode(l2A.L2ELNode(match.Assume(t, match.FirstL2EL)), orch.ControlPlane()),
-		L2CLA:         dsl.NewL2CLNode(l2A.L2CLNode(match.Assume(t, match.FirstL2CL)), orch.ControlPlane()),
-		Wallet:        dsl.NewRandomHDWallet(t, 30), // Random for test isolation
-		FaucetA:       dsl.NewFaucet(l2A.Faucet(match.Assume(t, match.FirstFaucet))),
-		L2BatcherA:    dsl.NewL2Batcher(l2A.L2Batcher(match.Assume(t, match.FirstL2Batcher))),
+		Log:              t.Logger(),
+		T:                t,
+		system:           system,
+		TestSequencer:    dsl.NewTestSequencer(system.TestSequencer(match.Assume(t, match.FirstTestSequencer))),
+		Supervisor:       supervisor,
+		SuperRoots:       superRoots,
+		ControlPlane:     orch.ControlPlane(),
+		L1Network:        dsl.NewL1Network(l1Net),
+		L1EL:             dsl.NewL1ELNode(l1Net.L1ELNode(match.Assume(t, match.FirstL1EL))),
+		L2ChainA:         dsl.NewL2Network(l2A, orch.ControlPlane()),
+		L2ELA:            dsl.NewL2ELNode(l2A.L2ELNode(match.Assume(t, match.FirstL2EL)), orch.ControlPlane()),
+		L2CLA:            dsl.NewL2CLNode(l2A.L2CLNode(match.Assume(t, match.FirstL2CL)), orch.ControlPlane()),
+		Wallet:           dsl.NewRandomHDWallet(t, 30), // Random for test isolation
+		FaucetA:          dsl.NewFaucet(l2A.Faucet(match.Assume(t, match.FirstFaucet))),
+		L2BatcherA:       dsl.NewL2Batcher(l2A.L2Batcher(match.Assume(t, match.FirstL2Batcher))),
+		challengerConfig: challengerCfg,
 	}
 	out.FaucetL1 = dsl.NewFaucet(out.L1Network.Escape().Faucet(match.Assume(t, match.FirstFaucet)))
 	out.FunderL1 = dsl.NewFunder(out.Wallet, out.FaucetL1, out.L1EL)
@@ -128,7 +139,7 @@ func (s *SimpleInterop) L2Networks() []*dsl.L2Network {
 
 func (s *SimpleInterop) DisputeGameFactory() *proofs.DisputeGameFactory {
 	supernode := s.system.Supernode(match.Assume(s.T, match.FirstSupernode))
-	return proofs.NewDisputeGameFactory(s.T, s.L1Network, s.L1EL.EthClient(), s.L2ChainA.DisputeGameFactoryProxyAddr(), nil, nil, supernode, nil)
+	return proofs.NewDisputeGameFactory(s.T, s.L1Network, s.L1EL.EthClient(), s.L2ChainA.DisputeGameFactoryProxyAddr(), nil, nil, supernode, s.challengerConfig)
 }
 
 func (s *SingleChainInterop) StandardBridge(l2Chain *dsl.L2Network) *dsl.StandardBridge {

--- a/op-devstack/shared/challenger/challenger.go
+++ b/op-devstack/shared/challenger/challenger.go
@@ -80,7 +80,7 @@ func applyCannonKonaConfig(c *config.Config, rollupCfgs []*rollup.Config, l1Gene
 	if err := applyVmConfig(root, &c.CannonKona, c.Datadir, rollupCfgs, l1Genesis, l2Geneses); err != nil {
 		return err
 	}
-	c.CannonKona.Server = root + "kona/target/debug/kona-host"
+	c.CannonKona.Server = root + "kona/target/release/kona-host"
 	absRoot, err := filepath.Abs(root)
 	if err != nil {
 		return fmt.Errorf("failed to get absolute path to prestate dir: %w", err)

--- a/op-devstack/shared/challenger/challenger.go
+++ b/op-devstack/shared/challenger/challenger.go
@@ -43,6 +43,7 @@ func WithDepset(ds *depset.StaticConfigDependencySet) Option {
 			return fmt.Errorf("failed to write dependency set config: %w", err)
 		}
 		c.Cannon.DepsetConfigPath = path
+		c.CannonKona.DepsetConfigPath = path
 		return nil
 	}
 }
@@ -79,7 +80,7 @@ func applyCannonKonaConfig(c *config.Config, rollupCfgs []*rollup.Config, l1Gene
 	if err := applyVmConfig(root, &c.CannonKona, c.Datadir, rollupCfgs, l1Genesis, l2Geneses); err != nil {
 		return err
 	}
-	c.CannonKona.Server = root + "kona/target/release/kona-host"
+	c.CannonKona.Server = root + "kona/target/debug/kona-host"
 	absRoot, err := filepath.Abs(root)
 	if err != nil {
 		return fmt.Errorf("failed to get absolute path to prestate dir: %w", err)
@@ -177,6 +178,13 @@ func WithPermissionedGameType() Option {
 func WithSuperCannonGameType() Option {
 	return func(c *config.Config) error {
 		c.GameTypes = append(c.GameTypes, gameTypes.SuperCannonGameType)
+		return nil
+	}
+}
+
+func WithSuperCannonKonaGameType() Option {
+	return func(c *config.Config) error {
+		c.GameTypes = append(c.GameTypes, gameTypes.SuperCannonKonaGameType)
 		return nil
 	}
 }

--- a/op-devstack/sysgo/l2_challenger.go
+++ b/op-devstack/sysgo/l2_challenger.go
@@ -169,7 +169,7 @@ func WithL2ChallengerPostDeploy(orch *Orchestrator, challengerID stack.L2Challen
 		if orch.l2ChallengerOpts.useCannonKonaConfig {
 			options = append(options,
 				shared.WithCannonKonaConfig(rollupCfgs, l1Genesis, l2Geneses),
-				shared.WithCannonKonaGameType(),
+				shared.WithSuperCannonKonaGameType(),
 			)
 		}
 		cfg, err = shared.NewInteropChallengerConfig(dir, l1EL.UserRPC(), l1CL.beaconHTTPAddr, superRPC, l2ELRPCs, options...)


### PR DESCRIPTION
**Description**

Adds an acceptance test that generates two very simple (empty) chains and verifies that the claims made by op-challenger's super trace provider are successfully validated by the kona fault proof program.


**Metadata**

#18990 