### PR TITLE
kona: Remove IndexedBlobHash usage and simplify blob handling

### DIFF
--- a/rust/kona/bin/host/src/interop/handler.rs
+++ b/rust/kona/bin/host/src/interop/handler.rs
@@ -6,10 +6,7 @@ use crate::{
     backend::util::store_ordered_trie,
 };
 use alloy_consensus::{Header, Sealed};
-use alloy_eips::{
-    eip2718::Encodable2718,
-    eip4844::{BlobTransactionSidecarItem, FIELD_ELEMENTS_PER_BLOB, IndexedBlobHash},
-};
+use alloy_eips::{eip2718::Encodable2718, eip4844::FIELD_ELEMENTS_PER_BLOB};
 use alloy_op_evm::OpEvmFactory;
 use alloy_primitives::{Address, B256, Bytes, keccak256};
 use alloy_provider::Provider;
@@ -34,6 +31,7 @@ use kona_proof::{
 };
 use kona_proof_interop::{HintType, PreState};
 use kona_protocol::{BlockInfo, OutputRoot, Predeploys};
+use kona_providers_alloy::BlobWithCommitmentAndProof;
 use kona_registry::{L1_CONFIGS, ROLLUP_CONFIGS};
 use std::sync::Arc;
 use tokio::task;
@@ -91,36 +89,26 @@ impl HintHandler for InteropHintHandler {
                 store_ordered_trie(kv.as_ref(), raw_receipts.as_slice()).await?;
             }
             HintType::L1Blob => {
-                ensure!(hint.data.len() == 48, "Invalid hint data length");
-
-                let hash_data_bytes: [u8; 32] = hint.data[0..32].try_into()?;
-                let index_data_bytes: [u8; 8] = hint.data[32..40].try_into()?;
-                let timestamp_data_bytes: [u8; 8] = hint.data[40..48].try_into()?;
-
-                let hash: B256 = hash_data_bytes.into();
-                let index = u64::from_be_bytes(index_data_bytes);
-                let timestamp = u64::from_be_bytes(timestamp_data_bytes);
+                let (hash, timestamp) = crate::single::parse_blob_hint(&hint.data)?;
 
                 let partial_block_ref = BlockInfo { timestamp, ..Default::default() };
-                let indexed_hash = IndexedBlobHash { index, hash };
 
-                // Fetch the blob sidecar from the blob provider.
-                let mut sidecars = providers
+                // Fetch the blob with proof from the blob provider.
+                let mut blobs = providers
                     .blobs
-                    .fetch_filtered_blob_sidecars(&partial_block_ref, &[indexed_hash])
+                    .fetch_blobs_with_proofs(&partial_block_ref, &[hash])
                     .await
-                    .map_err(|e| anyhow!("Failed to fetch blob sidecars: {e}"))?;
+                    .map_err(|e| anyhow!("Failed to fetch blobs with proofs: {e}"))?;
 
-                if sidecars.len() != 1 {
-                    anyhow::bail!("Expected 1 sidecar, got {}", sidecars.len());
+                if blobs.len() != 1 {
+                    anyhow::bail!("Expected 1 blob, got {}", blobs.len());
                 }
 
-                let BlobTransactionSidecarItem {
+                let BlobWithCommitmentAndProof {
                     blob,
                     kzg_proof: proof,
                     kzg_commitment: commitment,
-                    ..
-                } = sidecars.pop().expect("Expected 1 sidecar");
+                } = blobs.pop().expect("Expected 1 blob");
 
                 // Acquire a lock on the key-value store and set the preimages.
                 let mut kv_lock = kv.write().await;

--- a/rust/kona/bin/host/src/single/handler.rs
+++ b/rust/kona/bin/host/src/single/handler.rs
@@ -59,7 +59,7 @@ pub fn parse_blob_hint(hint_data: &[u8]) -> Result<(B256, u64)> {
     }
 }
 
-/// The [HintHandler] for the [SingleChainHost].
+/// The [`HintHandler`] for the [`SingleChainHost`].
 #[derive(Debug, Clone, Copy)]
 pub struct SingleChainHintHandler;
 

--- a/rust/kona/bin/host/src/single/handler.rs
+++ b/rust/kona/bin/host/src/single/handler.rs
@@ -414,88 +414,40 @@ impl HintHandler for SingleChainHintHandler {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_parse_blob_hint_legacy_format() {
-        // Legacy format: hash (32 bytes) + index (8 bytes) + timestamp (8 bytes) = 48 bytes
-        let mut hint_data = Vec::new();
+    const TEST_HASH: B256 = B256::new([0x42u8; 32]);
+    const TEST_TIMESTAMP: u64 = 1234567890;
 
-        // Hash (32 bytes)
-        let hash = B256::from([0x42u8; 32]);
-        hint_data.extend_from_slice(hash.as_slice());
+    // Legacy format: hash (32 bytes) + index (8 bytes) + timestamp (8 bytes) = 48 bytes
+    const LEGACY_HINT: [u8; 48] = [
+        0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42,
+        0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42,
+        0x42, 0x42, // Hash (32 bytes):
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFA, 0xCA, // Index (8 bytes, ignored)
+        0x00, 0x00, 0x00, 0x00, 0x49, 0x96, 0x02, 0xD2, // Timestamp (8 bytes): 1234567890
+    ];
 
-        // Index (8 bytes) - legacy field, should be ignored
-        let index = 0x00000000_0000FACAu64;
-        hint_data.extend_from_slice(&index.to_be_bytes());
-
-        // Timestamp (8 bytes)
-        let timestamp = 1234567890u64;
-        hint_data.extend_from_slice(&timestamp.to_be_bytes());
-
-        assert_eq!(hint_data.len(), 48);
-
-        // Parse using the production code
-        let (parsed_hash, parsed_timestamp) = parse_blob_hint(&hint_data).unwrap();
-
-        assert_eq!(parsed_hash, hash);
-        assert_eq!(parsed_timestamp, timestamp);
-    }
+    // New format: hash (32 bytes) + timestamp (8 bytes) = 40 bytes
+    const NEW_HINT: [u8; 40] = [
+        0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42,
+        0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42,
+        0x42, 0x42, // Hash (32 bytes)
+        0x00, 0x00, 0x00, 0x00, 0x49, 0x96, 0x02, 0xD2, // Timestamp (8 bytes): 1234567890
+    ];
 
     #[test]
-    fn test_parse_blob_hint_new_format() {
-        // New format: hash (32 bytes) + timestamp (8 bytes) = 40 bytes
-        let mut hint_data = Vec::new();
+    fn test_parse_blob_hint_formats() {
+        let (legacy_hash, legacy_timestamp) = parse_blob_hint(&LEGACY_HINT).unwrap();
+        let (new_hash, new_timestamp) = parse_blob_hint(&NEW_HINT).unwrap();
 
-        // Hash (32 bytes)
-        let hash = B256::from([0x42u8; 32]);
-        hint_data.extend_from_slice(hash.as_slice());
-
-        // Timestamp (8 bytes)
-        let timestamp = 1234567890u64;
-        hint_data.extend_from_slice(&timestamp.to_be_bytes());
-
-        assert_eq!(hint_data.len(), 40);
-
-        // Parse using the production code
-        let (parsed_hash, parsed_timestamp) = parse_blob_hint(&hint_data).unwrap();
-
-        assert_eq!(parsed_hash, hash);
-        assert_eq!(parsed_timestamp, timestamp);
-    }
-
-    #[test]
-    fn test_parse_blob_hint_both_formats_produce_same_result() {
-        // Use the same hash and timestamp for both formats
-        let hash = B256::from([0x42u8; 32]);
-        let timestamp = 1234567890u64;
-        let index = 0x00000000_0000FACAu64; // This should be ignored in legacy format
-
-        // Create legacy format hint (48 bytes)
-        let mut legacy_hint_data = Vec::new();
-        legacy_hint_data.extend_from_slice(hash.as_slice());
-        legacy_hint_data.extend_from_slice(&index.to_be_bytes());
-        legacy_hint_data.extend_from_slice(&timestamp.to_be_bytes());
-
-        // Create new format hint (40 bytes)
-        let mut new_hint_data = Vec::new();
-        new_hint_data.extend_from_slice(hash.as_slice());
-        new_hint_data.extend_from_slice(&timestamp.to_be_bytes());
-
-        // Parse both using the production code
-        let (legacy_hash, legacy_timestamp) = parse_blob_hint(&legacy_hint_data).unwrap();
-        let (new_hash, new_timestamp) = parse_blob_hint(&new_hint_data).unwrap();
-
-        // Both formats should produce the same hash and timestamp
-        assert_eq!(legacy_hash, new_hash);
-        assert_eq!(legacy_timestamp, new_timestamp);
-        assert_eq!(legacy_hash, hash);
-        assert_eq!(legacy_timestamp, timestamp);
+        assert_eq!(legacy_hash, TEST_HASH);
+        assert_eq!(legacy_timestamp, TEST_TIMESTAMP);
+        assert_eq!(new_hash, TEST_HASH);
+        assert_eq!(new_timestamp, TEST_TIMESTAMP);
     }
 
     #[test]
     fn test_parse_blob_hint_invalid_length() {
-        // Test with invalid length (not 40 or 48 bytes)
         let hint_data = vec![0u8; 35];
-
         let result = parse_blob_hint(&hint_data);
 
         assert!(result.is_err());

--- a/rust/kona/bin/host/src/single/handler.rs
+++ b/rust/kona/bin/host/src/single/handler.rs
@@ -5,10 +5,7 @@ use crate::{
     single::cfg::SingleChainHost,
 };
 use alloy_consensus::Header;
-use alloy_eips::{
-    eip2718::Encodable2718,
-    eip4844::{BlobTransactionSidecarItem, FIELD_ELEMENTS_PER_BLOB, IndexedBlobHash},
-};
+use alloy_eips::{eip2718::Encodable2718, eip4844::FIELD_ELEMENTS_PER_BLOB};
 use alloy_primitives::{Address, B256, Bytes, keccak256};
 use alloy_provider::Provider;
 use alloy_rlp::Decodable;
@@ -19,10 +16,50 @@ use async_trait::async_trait;
 use kona_preimage::{PreimageKey, PreimageKeyType};
 use kona_proof::{Hint, HintType, l1::ROOTS_OF_UNITY};
 use kona_protocol::{BlockInfo, OutputRoot, Predeploys};
+use kona_providers_alloy::BlobWithCommitmentAndProof;
 use op_alloy_rpc_types_engine::OpPayloadAttributes;
 use tracing::warn;
 
-/// The [`HintHandler`] for the [`SingleChainHost`].
+/// Parses a blob hint, supporting both legacy (48-byte) and new (40-byte) formats.
+///
+/// Returns the blob hash and timestamp.
+///
+/// ## Formats
+/// - Legacy: hash (32 bytes) + index (8 bytes) + timestamp (8 bytes) = 48 bytes
+/// - New: hash (32 bytes) + timestamp (8 bytes) = 40 bytes
+///
+/// The legacy index field is parsed but ignored.
+pub fn parse_blob_hint(hint_data: &[u8]) -> Result<(B256, u64)> {
+    match hint_data.len() {
+        48 => {
+            // Legacy format: hash (32) + index (8) + timestamp (8)
+            let hash_data_bytes: [u8; 32] = hint_data[0..32].try_into()?;
+            let _index_data_bytes: [u8; 8] = hint_data[32..40].try_into()?; // index no longer used
+            let timestamp_data_bytes: [u8; 8] = hint_data[40..48].try_into()?;
+
+            let hash: B256 = hash_data_bytes.into();
+            let timestamp = u64::from_be_bytes(timestamp_data_bytes);
+            Ok((hash, timestamp))
+        }
+        40 => {
+            // New format: hash (32) + timestamp (8)
+            let hash_data_bytes: [u8; 32] = hint_data[0..32].try_into()?;
+            let timestamp_data_bytes: [u8; 8] = hint_data[32..40].try_into()?;
+
+            let hash: B256 = hash_data_bytes.into();
+            let timestamp = u64::from_be_bytes(timestamp_data_bytes);
+            Ok((hash, timestamp))
+        }
+        _ => {
+            anyhow::bail!(
+                "Invalid blob hint length: expected 40 or 48 bytes, got {}",
+                hint_data.len()
+            );
+        }
+    }
+}
+
+/// The [HintHandler] for the [SingleChainHost].
 #[derive(Debug, Clone, Copy)]
 pub struct SingleChainHintHandler;
 
@@ -74,33 +111,23 @@ impl HintHandler for SingleChainHintHandler {
                 store_ordered_trie(kv.as_ref(), raw_receipts.as_slice()).await?;
             }
             HintType::L1Blob => {
-                ensure!(hint.data.len() == 48, "Invalid hint data length");
-
-                let hash_data_bytes: [u8; 32] = hint.data[0..32].try_into()?;
-                let index_data_bytes: [u8; 8] = hint.data[32..40].try_into()?;
-                let timestamp_data_bytes: [u8; 8] = hint.data[40..48].try_into()?;
-
-                let hash: B256 = hash_data_bytes.into();
-                let index = u64::from_be_bytes(index_data_bytes);
-                let timestamp = u64::from_be_bytes(timestamp_data_bytes);
+                let (hash, timestamp) = parse_blob_hint(&hint.data)?;
 
                 let partial_block_ref = BlockInfo { timestamp, ..Default::default() };
-                let indexed_hash = IndexedBlobHash { index, hash };
 
                 // Fetch the blobs from the blob provider.
                 let mut blobs = providers
                     .blobs
-                    .fetch_filtered_blob_sidecars(&partial_block_ref, &[indexed_hash])
+                    .fetch_blobs_with_proofs(&partial_block_ref, &[hash])
                     .await
-                    .map_err(|e| anyhow!("Failed to fetch blob sidecars: {e}"))?;
+                    .map_err(|e| anyhow!("Failed to fetch blobs with proofs: {e}"))?;
                 if blobs.len() != 1 {
                     anyhow::bail!("Expected 1 blob, got {}", blobs.len());
                 }
-                let BlobTransactionSidecarItem {
+                let BlobWithCommitmentAndProof {
                     blob,
                     kzg_proof: proof,
                     kzg_commitment: commitment,
-                    ..
                 } = blobs.pop().expect("Expected 1 blob");
 
                 // Acquire a lock on the key-value store and set the preimages.
@@ -380,5 +407,101 @@ impl HintHandler for SingleChainHintHandler {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_blob_hint_legacy_format() {
+        // Legacy format: hash (32 bytes) + index (8 bytes) + timestamp (8 bytes) = 48 bytes
+        let mut hint_data = Vec::new();
+
+        // Hash (32 bytes)
+        let hash = B256::from([0x42u8; 32]);
+        hint_data.extend_from_slice(hash.as_slice());
+
+        // Index (8 bytes) - legacy field, should be ignored
+        let index = 0x00000000_0000FACAu64;
+        hint_data.extend_from_slice(&index.to_be_bytes());
+
+        // Timestamp (8 bytes)
+        let timestamp = 1234567890u64;
+        hint_data.extend_from_slice(&timestamp.to_be_bytes());
+
+        assert_eq!(hint_data.len(), 48);
+
+        // Parse using the production code
+        let (parsed_hash, parsed_timestamp) = parse_blob_hint(&hint_data).unwrap();
+
+        assert_eq!(parsed_hash, hash);
+        assert_eq!(parsed_timestamp, timestamp);
+    }
+
+    #[test]
+    fn test_parse_blob_hint_new_format() {
+        // New format: hash (32 bytes) + timestamp (8 bytes) = 40 bytes
+        let mut hint_data = Vec::new();
+
+        // Hash (32 bytes)
+        let hash = B256::from([0x42u8; 32]);
+        hint_data.extend_from_slice(hash.as_slice());
+
+        // Timestamp (8 bytes)
+        let timestamp = 1234567890u64;
+        hint_data.extend_from_slice(&timestamp.to_be_bytes());
+
+        assert_eq!(hint_data.len(), 40);
+
+        // Parse using the production code
+        let (parsed_hash, parsed_timestamp) = parse_blob_hint(&hint_data).unwrap();
+
+        assert_eq!(parsed_hash, hash);
+        assert_eq!(parsed_timestamp, timestamp);
+    }
+
+    #[test]
+    fn test_parse_blob_hint_both_formats_produce_same_result() {
+        // Use the same hash and timestamp for both formats
+        let hash = B256::from([0x42u8; 32]);
+        let timestamp = 1234567890u64;
+        let index = 0x00000000_0000FACAu64; // This should be ignored in legacy format
+
+        // Create legacy format hint (48 bytes)
+        let mut legacy_hint_data = Vec::new();
+        legacy_hint_data.extend_from_slice(hash.as_slice());
+        legacy_hint_data.extend_from_slice(&index.to_be_bytes());
+        legacy_hint_data.extend_from_slice(&timestamp.to_be_bytes());
+
+        // Create new format hint (40 bytes)
+        let mut new_hint_data = Vec::new();
+        new_hint_data.extend_from_slice(hash.as_slice());
+        new_hint_data.extend_from_slice(&timestamp.to_be_bytes());
+
+        // Parse both using the production code
+        let (legacy_hash, legacy_timestamp) = parse_blob_hint(&legacy_hint_data).unwrap();
+        let (new_hash, new_timestamp) = parse_blob_hint(&new_hint_data).unwrap();
+
+        // Both formats should produce the same hash and timestamp
+        assert_eq!(legacy_hash, new_hash);
+        assert_eq!(legacy_timestamp, new_timestamp);
+        assert_eq!(legacy_hash, hash);
+        assert_eq!(legacy_timestamp, timestamp);
+    }
+
+    #[test]
+    fn test_parse_blob_hint_invalid_length() {
+        // Test with invalid length (not 40 or 48 bytes)
+        let hint_data = vec![0u8; 35];
+
+        let result = parse_blob_hint(&hint_data);
+
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(err_msg.contains("Invalid blob hint length"));
+        assert!(err_msg.contains("expected 40 or 48 bytes"));
+        assert!(err_msg.contains("got 35"));
     }
 }

--- a/rust/kona/bin/host/src/single/mod.rs
+++ b/rust/kona/bin/host/src/single/mod.rs
@@ -7,4 +7,4 @@ mod local_kv;
 pub use local_kv::SingleChainLocalInputs;
 
 mod handler;
-pub use handler::SingleChainHintHandler;
+pub use handler::{SingleChainHintHandler, parse_blob_hint};

--- a/rust/kona/crates/proof/proof/src/l1/blob_provider.rs
+++ b/rust/kona/crates/proof/proof/src/l1/blob_provider.rs
@@ -3,8 +3,8 @@
 use crate::{HintType, errors::OracleProviderError};
 use alloc::{boxed::Box, sync::Arc, vec::Vec};
 use alloy_consensus::Blob;
-use alloy_eips::eip4844::{FIELD_ELEMENTS_PER_BLOB, IndexedBlobHash};
-use alloy_primitives::keccak256;
+use alloy_eips::eip4844::FIELD_ELEMENTS_PER_BLOB;
+use alloy_primitives::{B256, keccak256};
 use ark_bls12_381::Fr;
 use ark_ff::{AdditiveGroup, BigInteger, BigInteger256, Field, PrimeField};
 use async_trait::async_trait;
@@ -39,12 +39,11 @@ impl<T: CommsClient> OracleBlobProvider<T> {
     async fn get_blob(
         &self,
         block_ref: &BlockInfo,
-        blob_hash: &IndexedBlobHash,
+        blob_hash: &B256,
     ) -> Result<Blob, OracleProviderError> {
-        let mut blob_req_meta = [0u8; 48];
-        blob_req_meta[0..32].copy_from_slice(blob_hash.hash.as_ref());
-        blob_req_meta[32..40].copy_from_slice((blob_hash.index).to_be_bytes().as_ref());
-        blob_req_meta[40..48].copy_from_slice(block_ref.timestamp.to_be_bytes().as_ref());
+        let mut blob_req_meta = [0u8; 40];
+        blob_req_meta[0..32].copy_from_slice(blob_hash.as_ref());
+        blob_req_meta[32..40].copy_from_slice(block_ref.timestamp.to_be_bytes().as_ref());
 
         // Send a hint for the blob commitment and field elements.
         HintType::L1Blob.with_data(&[blob_req_meta.as_ref()]).send(self.oracle.as_ref()).await?;
@@ -52,7 +51,7 @@ impl<T: CommsClient> OracleBlobProvider<T> {
         // Fetch the blob commitment.
         let mut commitment = [0u8; 48];
         self.oracle
-            .get_exact(PreimageKey::new(*blob_hash.hash, PreimageKeyType::Sha256), &mut commitment)
+            .get_exact(PreimageKey::new(**blob_hash, PreimageKeyType::Sha256), &mut commitment)
             .await
             .map_err(OracleProviderError::Preimage)?;
 
@@ -77,8 +76,7 @@ impl<T: CommsClient> OracleBlobProvider<T> {
 
         tracing::info!(
             target: "client_blob_oracle",
-            index = blob_hash.index,
-            hash = ?blob_hash.hash,
+            hash = ?blob_hash,
             "Retrieved blob"
         );
 
@@ -94,7 +92,7 @@ impl<T: CommsClient + Sync + Send> BlobProvider for OracleBlobProvider<T> {
     async fn get_and_validate_blobs(
         &mut self,
         block_ref: &BlockInfo,
-        blob_hashes: &[IndexedBlobHash],
+        blob_hashes: &[B256],
     ) -> Result<Vec<Box<Blob>>, Self::Error> {
         let mut blobs = Vec::with_capacity(blob_hashes.len());
         for hash in blob_hashes {

--- a/rust/kona/crates/protocol/derive/src/sources/blobs.rs
+++ b/rust/kona/crates/protocol/derive/src/sources/blobs.rs
@@ -8,8 +8,7 @@ use alloc::{boxed::Box, string::ToString, vec::Vec};
 use alloy_consensus::{
     Transaction, TxEip4844Variant, TxEnvelope, TxType, transaction::SignerRecoverable,
 };
-use alloy_eips::eip4844::IndexedBlobHash;
-use alloy_primitives::{Address, Bytes};
+use alloy_primitives::{Address, B256, Bytes};
 use async_trait::async_trait;
 use kona_protocol::BlockInfo;
 
@@ -46,8 +45,7 @@ where
         &self,
         txs: Vec<TxEnvelope>,
         batcher_address: Address,
-    ) -> (Vec<BlobData>, Vec<IndexedBlobHash>) {
-        let mut index: u64 = 0;
+    ) -> (Vec<BlobData>, Vec<B256>) {
         let mut data = Vec::new();
         let mut hashes = Vec::new();
         for tx in txs {
@@ -69,11 +67,9 @@ where
             let Some(to) = tx_kind else { continue };
 
             if to != self.batcher_address {
-                index += blob_hashes.map_or(0, |h| h.len() as u64);
                 continue;
             }
             if tx.recover_signer().unwrap_or_default() != batcher_address {
-                index += blob_hashes.map_or(0, |h| h.len() as u64);
                 continue;
             }
             if tx.tx_type() != TxType::Eip4844 {
@@ -97,10 +93,8 @@ where
                 continue;
             };
             for hash in blob_hashes {
-                let indexed = IndexedBlobHash { hash, index };
-                hashes.push(indexed);
+                hashes.push(hash);
                 data.push(BlobData::default());
-                index += 1;
             }
         }
         #[cfg(feature = "metrics")]

--- a/rust/kona/crates/protocol/derive/src/test_utils/blob_provider.rs
+++ b/rust/kona/crates/protocol/derive/src/test_utils/blob_provider.rs
@@ -2,7 +2,7 @@
 
 use crate::{BlobProvider, errors::BlobProviderError};
 use alloc::{boxed::Box, vec::Vec};
-use alloy_eips::eip4844::{Blob, IndexedBlobHash};
+use alloy_eips::eip4844::Blob;
 use alloy_primitives::{B256, map::HashMap};
 use async_trait::async_trait;
 use kona_protocol::BlockInfo;
@@ -35,14 +35,14 @@ impl BlobProvider for TestBlobProvider {
     async fn get_and_validate_blobs(
         &mut self,
         _block_ref: &BlockInfo,
-        blob_hashes: &[IndexedBlobHash],
+        blob_hashes: &[B256],
     ) -> Result<Vec<Box<Blob>>, Self::Error> {
         if self.should_error {
             return Err(BlobProviderError::SlotDerivation);
         }
         let mut blobs = Vec::new();
         for blob_hash in blob_hashes {
-            if let Some(data) = self.blobs.get(&blob_hash.hash) {
+            if let Some(data) = self.blobs.get(blob_hash) {
                 blobs.push(Box::new(*data));
             }
         }

--- a/rust/kona/crates/protocol/derive/src/traits/data_sources.rs
+++ b/rust/kona/crates/protocol/derive/src/traits/data_sources.rs
@@ -3,8 +3,8 @@
 
 use crate::{PipelineErrorKind, PipelineResult};
 use alloc::{boxed::Box, fmt::Debug, string::ToString, vec::Vec};
-use alloy_eips::eip4844::{Blob, IndexedBlobHash};
-use alloy_primitives::{Address, Bytes};
+use alloy_eips::eip4844::Blob;
+use alloy_primitives::{Address, B256, Bytes};
 use async_trait::async_trait;
 use core::fmt::Display;
 use kona_protocol::BlockInfo;
@@ -19,7 +19,7 @@ pub trait BlobProvider {
     async fn get_and_validate_blobs(
         &mut self,
         block_ref: &BlockInfo,
-        blob_hashes: &[IndexedBlobHash],
+        blob_hashes: &[B256],
     ) -> Result<Vec<Box<Blob>>, Self::Error>;
 }
 

--- a/rust/kona/crates/providers/providers-alloy/src/beacon_client.rs
+++ b/rust/kona/crates/providers/providers-alloy/src/beacon_client.rs
@@ -2,8 +2,8 @@
 
 #[cfg(feature = "metrics")]
 use crate::Metrics;
-use crate::blobs::BoxedBlobWithIndex;
-use alloy_eips::eip4844::{IndexedBlobHash, env_settings::EnvKzgSettings, kzg_to_versioned_hash};
+use crate::blobs::BoxedBlob;
+use alloy_eips::eip4844::{env_settings::EnvKzgSettings, kzg_to_versioned_hash};
 use alloy_primitives::{B256, FixedBytes};
 use alloy_rpc_types_beacon::sidecar::GetBlobsResponse;
 use alloy_transport_http::reqwest::{self, Client};
@@ -80,12 +80,12 @@ pub trait BeaconClient {
     async fn genesis_time(&self) -> Result<APIGenesisResponse, Self::Error>;
 
     /// Fetches blobs that were confirmed in the specified L1 block with the given slot.
-    /// Blob data is not checked for validity.
+    /// Blob data is checked for validity.
     async fn filtered_beacon_blobs(
         &self,
         slot: u64,
-        blob_hashes: &[IndexedBlobHash],
-    ) -> Result<Vec<BoxedBlobWithIndex>, Self::Error>;
+        blob_hashes: &[B256],
+    ) -> Result<Vec<BoxedBlob>, Self::Error>;
 }
 
 const BLOB_SIZE: usize = 131072;
@@ -154,9 +154,9 @@ impl OnlineBeaconClient {
     async fn filtered_beacon_blobs(
         &self,
         slot: u64,
-        blob_hashes: &[IndexedBlobHash],
-    ) -> Result<Vec<BoxedBlobWithIndex>, BeaconClientError> {
-        let params = blob_hashes.iter().map(|blob| blob.hash.to_string()).collect::<Vec<_>>();
+        blob_hashes: &[B256],
+    ) -> Result<Vec<BoxedBlob>, BeaconClientError> {
+        let params = blob_hashes.iter().map(|hash| hash.to_string()).collect::<Vec<_>>();
         let response = self
             .inner
             .get(format!("{}/{}/{}", self.base, BLOBS_METHOD_PREFIX, slot))
@@ -180,11 +180,11 @@ impl OnlineBeaconClient {
         // whose hash matches the input:
         blob_hashes
             .iter()
-            .map(|blob_hash| -> Result<BoxedBlobWithIndex, BeaconClientError> {
+            .map(|blob_hash| -> Result<BoxedBlob, BeaconClientError> {
                 let matching_data = returned_blobs_mapped_by_hash
-                    .get(&blob_hash.hash)
-                    .ok_or(BeaconClientError::BlobNotFound(blob_hash.hash.to_string()))?;
-                Ok(BoxedBlobWithIndex { blob: Box::new(**matching_data), index: blob_hash.index })
+                    .get(blob_hash)
+                    .ok_or(BeaconClientError::BlobNotFound(blob_hash.to_string()))?;
+                Ok(BoxedBlob { blob: Box::new(**matching_data) })
             })
             .collect::<Result<Vec<_>, BeaconClientError>>()
     }
@@ -234,8 +234,8 @@ impl BeaconClient for OnlineBeaconClient {
     async fn filtered_beacon_blobs(
         &self,
         slot: u64,
-        blob_hashes: &[IndexedBlobHash],
-    ) -> Result<Vec<BoxedBlobWithIndex>, BeaconClientError> {
+        blob_hashes: &[B256],
+    ) -> Result<Vec<BoxedBlob>, BeaconClientError> {
         kona_macros::inc!(gauge, Metrics::BEACON_CLIENT_REQUESTS, "method" => "blobs");
 
         // Try to get the blobs from the blobs endpoint.
@@ -276,15 +276,12 @@ mod tests {
         let garbage_blob_data: Vec<Blob> = vec![FixedBytes::repeat_byte(2)];
         let required_query_param = format!("{TEST_BLOB_HASH_HEX},{TEST_BLOB_HASH_HEX}");
         let test_blob_hash: FixedBytes<32> = FixedBytes::from_hex(TEST_BLOB_HASH_HEX).unwrap();
-        let requested_blob_hashes: Vec<IndexedBlobHash> = vec![
-            IndexedBlobHash { index: 0, hash: test_blob_hash },
-            IndexedBlobHash { index: 2, hash: test_blob_hash },
-        ];
+        let requested_blob_hashes: Vec<B256> = vec![test_blob_hash, test_blob_hash];
 
         struct TestCase {
             name: &'static str,
             mock_response_data: Vec<Blob>,
-            want: Option<Vec<BoxedBlobWithIndex>>, // if none, expect an error
+            want: Option<Vec<BoxedBlob>>, // if none, expect an error
         }
 
         let test_cases = vec![
@@ -292,8 +289,8 @@ mod tests {
                 name: "Repeated Blob Data, expect success",
                 mock_response_data: repeated_blob_data,
                 want: Some(vec![
-                    BoxedBlobWithIndex { index: 0, blob: Box::new(TEST_BLOB_DATA) },
-                    BoxedBlobWithIndex { index: 2, blob: Box::new(TEST_BLOB_DATA) },
+                    BoxedBlob { blob: Box::new(TEST_BLOB_DATA) },
+                    BoxedBlob { blob: Box::new(TEST_BLOB_DATA) },
                 ]),
             },
             TestCase {

--- a/rust/kona/crates/providers/providers-alloy/src/blobs.rs
+++ b/rust/kona/crates/providers/providers-alloy/src/blobs.rs
@@ -31,7 +31,7 @@ pub struct BlobWithCommitmentAndProof {
     pub kzg_proof: Bytes48,
 }
 
-/// An online implementation of the [BlobProvider] trait.
+/// An online implementation of the [`BlobProvider`] trait.
 #[derive(Debug, Clone)]
 pub struct OnlineBlobProvider<B: BeaconClient> {
     /// The Beacon API client.

--- a/rust/kona/crates/providers/providers-alloy/src/blobs.rs
+++ b/rust/kona/crates/providers/providers-alloy/src/blobs.rs
@@ -3,25 +3,35 @@
 use crate::BeaconClient;
 #[cfg(feature = "metrics")]
 use crate::Metrics;
-use alloy_eips::eip4844::{
-    Blob, BlobTransactionSidecarItem, IndexedBlobHash, env_settings::EnvKzgSettings,
-};
-use alloy_primitives::FixedBytes;
+use alloy_eips::eip4844::{Blob, Bytes48, env_settings::EnvKzgSettings};
+use alloy_primitives::{B256, FixedBytes};
 use async_trait::async_trait;
 use kona_derive::{BlobProvider, BlobProviderError};
 use kona_protocol::BlockInfo;
 use std::{boxed::Box, string::ToString, vec::Vec};
 
-/// A boxed blob with index.
+/// A boxed blob.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct BoxedBlobWithIndex {
-    /// The index of the blob.
-    pub index: u64,
+pub struct BoxedBlob {
     /// The blob data.
     pub blob: Box<Blob>,
 }
 
-/// An online implementation of the [`BlobProvider`] trait.
+/// A blob with its KZG commitment and proof.
+///
+/// This is used by the host to store blob preimages. Unlike `BlobTransactionSidecarItem`,
+/// this does not include an index field since blobs are fetched by hash, not by index.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BlobWithCommitmentAndProof {
+    /// The blob data.
+    pub blob: Box<Blob>,
+    /// The KZG commitment for the blob.
+    pub kzg_commitment: Bytes48,
+    /// The KZG proof for the blob.
+    pub kzg_proof: Bytes48,
+}
+
+/// An online implementation of the [BlobProvider] trait.
 #[derive(Debug, Clone)]
 pub struct OnlineBlobProvider<B: BeaconClient> {
     /// The Beacon API client.
@@ -73,8 +83,8 @@ impl<B: BeaconClient> OnlineBlobProvider<B> {
     async fn fetch_filtered_blobs(
         &self,
         slot: u64,
-        blob_hashes: &[IndexedBlobHash],
-    ) -> Result<Vec<BoxedBlobWithIndex>, BlobProviderError> {
+        blob_hashes: &[B256],
+    ) -> Result<Vec<BoxedBlob>, BlobProviderError> {
         kona_macros::inc!(gauge, Metrics::BLOB_FETCHES);
 
         let result = self
@@ -91,13 +101,13 @@ impl<B: BeaconClient> OnlineBlobProvider<B> {
         result
     }
 
-    /// Converts a vector of boxed blobs with index to a vector of blob transaction sidecar items.
+    /// Converts a vector of boxed blobs to a vector of blobs with their KZG commitments and proofs.
     ///
     /// Note: for performance reasons, we need to transmute the blobs to the `c_kzg::Blob` type to
     /// avoid the overhead of moving the blobs around or reallocating the memory.
-    fn sidecar_from_blobs(
-        blobs: Vec<BoxedBlobWithIndex>,
-    ) -> Result<Vec<BlobTransactionSidecarItem>, c_kzg::Error> {
+    fn blobs_with_proofs(
+        blobs: Vec<BoxedBlob>,
+    ) -> Result<Vec<BlobWithCommitmentAndProof>, c_kzg::Error> {
         blobs
             .into_iter()
             .map(|blob| {
@@ -120,8 +130,7 @@ impl<B: BeaconClient> OnlineBlobProvider<B> {
                 let alloy_blob =
                     unsafe { Box::from_raw(Box::<c_kzg::Blob>::into_raw(kzg_blob) as *mut Blob) };
 
-                Ok(BlobTransactionSidecarItem {
-                    index: blob.index,
+                Ok(BlobWithCommitmentAndProof {
                     blob: alloy_blob,
                     kzg_commitment: FixedBytes::from(*commitment),
                     kzg_proof: FixedBytes::from(*proof),
@@ -130,16 +139,17 @@ impl<B: BeaconClient> OnlineBlobProvider<B> {
             .collect()
     }
 
-    /// Fetches blob sidecars for the given block reference and blob hashes.
-    /// Does not validate the blobs. Recomputes the kzg proofs associated with the blobs.
+    /// Fetches and validates blobs for the given block reference and blob hashes.
+    /// Recomputes the kzg proofs associated with the blobs and returns as a vector of
+    /// [`BlobWithCommitmentAndProof`]s.
     ///
     /// Use [`Self::beacon_client`] to fetch the blobs without recomputing the kzg
     /// proofs/commitments.
-    pub async fn fetch_filtered_blob_sidecars(
+    pub async fn fetch_blobs_with_proofs(
         &self,
         block_ref: &BlockInfo,
-        blob_hashes: &[IndexedBlobHash],
-    ) -> Result<Vec<BlobTransactionSidecarItem>, BlobProviderError> {
+        blob_hashes: &[B256],
+    ) -> Result<Vec<BlobWithCommitmentAndProof>, BlobProviderError> {
         if blob_hashes.is_empty() {
             return Ok(Default::default());
         }
@@ -150,7 +160,7 @@ impl<B: BeaconClient> OnlineBlobProvider<B> {
         // Fetch blobs for the slot using.
         let blobs = self.fetch_filtered_blobs(slot, blob_hashes).await?;
 
-        Self::sidecar_from_blobs(blobs)
+        Self::blobs_with_proofs(blobs)
             .map_err(|e| BlobProviderError::Backend(format!("KZG commitment error: {e}")))
     }
 }
@@ -162,36 +172,27 @@ where
 {
     type Error = BlobProviderError;
 
-    /// Fetches blobs that were confirmed in the specified L1 block with the given indexed
-    /// hashes. The blobs are validated for their index and hashes using the specified
-    /// [`IndexedBlobHash`].
+    /// Fetches blobs that were confirmed in the specified L1 block with the given versioned
+    /// hashes. The blobs are already validated by the beacon client by recomputing their
+    /// commitments and checking against the expected hashes.
     async fn get_and_validate_blobs(
         &mut self,
         block_ref: &BlockInfo,
-        blob_hashes: &[IndexedBlobHash],
+        blob_hashes: &[B256],
     ) -> Result<Vec<Box<Blob>>, Self::Error> {
-        // Fetch the blob sidecars for the given block reference and blob hashes.
-        let blobs = self.fetch_filtered_blob_sidecars(block_ref, blob_hashes).await?;
+        if blob_hashes.is_empty() {
+            return Ok(Default::default());
+        }
 
-        // Validate the blob sidecars straight away with the num hashes.
-        let blobs = blobs
-            .into_iter()
-            .enumerate()
-            .map(|(i, sidecar)| {
-                let hash = blob_hashes
-                    .get(i)
-                    .ok_or_else(|| BlobProviderError::Backend("Missing blob hash".to_string()))?
-                    .hash
-                    .as_slice();
+        // Calculate the slot for the given timestamp.
+        let slot = Self::slot(self.genesis_time, self.slot_interval, block_ref.timestamp)?;
 
-                if sidecar.to_kzg_versioned_hash() != hash {
-                    return Err(BlobProviderError::Backend("KZG commitment mismatch".to_string()));
-                }
+        // Fetch and validate blobs from the beacon client.
+        // The beacon client already validates each blob by recomputing its commitment
+        // and checking it against the expected hash.
+        let blobs = self.fetch_filtered_blobs(slot, blob_hashes).await?;
 
-                Ok(sidecar.blob)
-            })
-            .collect::<Result<Vec<Box<Blob>>, BlobProviderError>>()
-            .map_err(|e| BlobProviderError::Backend(e.to_string()))?;
-        Ok(blobs)
+        // Extract the blob data from BoxedBlob wrappers
+        Ok(blobs.into_iter().map(|boxed_blob| boxed_blob.blob).collect())
     }
 }

--- a/rust/kona/crates/providers/providers-alloy/src/lib.rs
+++ b/rust/kona/crates/providers/providers-alloy/src/lib.rs
@@ -17,7 +17,7 @@ pub use beacon_client::{
 };
 
 mod blobs;
-pub use blobs::{BoxedBlobWithIndex, OnlineBlobProvider};
+pub use blobs::{BlobWithCommitmentAndProof, BoxedBlob, OnlineBlobProvider};
 
 mod chain_provider;
 pub use chain_provider::{AlloyChainProvider, AlloyChainProviderError};


### PR DESCRIPTION
* Kona changes corresponding to #19080 
* follows the change in blob hint format from that PR, and remains backwards compatible with old blob hints
* adds about 50 lines of testing code
