### PR TITLE
sysgo: restore portal ProxyAdmin owners after superroot migration

### DIFF
--- a/op-acceptance-tests/tests/isthmus/preinterop/interop_readiness_test.go
+++ b/op-acceptance-tests/tests/isthmus/preinterop/interop_readiness_test.go
@@ -103,7 +103,6 @@ func init() {
 }
 
 func TestInteropReadiness(gt *testing.T) {
-	gt.Skip("TODO(#18616): Skipping interop readiness test for now")
 	t := devtest.ParallelT(gt)
 	sys := presets.NewSimpleInterop(t)
 

--- a/op-devstack/sysgo/superroot.go
+++ b/op-devstack/sysgo/superroot.go
@@ -523,6 +523,26 @@ func resetOwnershipAfterMigration(
 		l1PAO,
 	)
 
+	// The migration temporarily transfers ownership of each portal ProxyAdmin to the DelegateCallProxy
+	// to satisfy the delegatecall requirement of the OPCM. Reset these back to the L1 proxy admin owner
+	// after the shared admin contracts are restored.
+	for _, cfg := range opChainConfigs {
+		portal := getOptimismPortal(t, w3Client, cfg.SystemConfigProxy)
+		portalProxyAdmin := getProxyAdmin(t, w3Client, portal)
+		// In some setups the migration may already restore ownership. Only reset when still owned by the proxy.
+		if getOwner(t, w3Client, portalProxyAdmin) == delegateCallProxy {
+			transferOwnershipForDelegateCallProxy(
+				t,
+				l1ChainID,
+				ownerPrivateKey,
+				client,
+				delegateCallProxy,
+				portalProxyAdmin,
+				l1PAO,
+			)
+		}
+	}
+
 	// The Proxy Admin owner is changed. Assert that the admin of other proxies are consistent
 	var sharedAnchorStateRegistryProxy common.Address
 	err = w3Client.Call(w3eth.CallFunc(portal0, anchorStateRegistryFn).Returns(&sharedAnchorStateRegistryProxy))


### PR DESCRIPTION
During OPCM super-roots migration we temporarily transfer each OptimismPortal’s ProxyAdmin ownership to the DelegateCallProxy. Restore each portal ProxyAdmin back to the L1PAO after shared admin contracts are reset so both portals report the expected proxyAdminOwner()

With this we can re-enable the TestInteropReadiness acceptance-test

fixes https://github.com/ethereum-optimism/optimism/issues/18616