### PR TITLE
Fix service shutdown, initialization, and state handling issues

### DIFF
--- a/op-dispute-mon/mon/service.go
+++ b/op-dispute-mon/mon/service.go
@@ -275,6 +275,11 @@ func (s *Service) Stop(ctx context.Context) error {
 	s.logger.Info("Stopping dispute mon service")
 
 	var result error
+
+	if s.monitor != nil {
+        s.logger.Info("Stopping monitor")
+        s.monitor.StopMonitoring()
+	}
 	if s.pprofService != nil {
 		if err := s.pprofService.Stop(ctx); err != nil {
 			result = errors.Join(result, fmt.Errorf("failed to close pprof server: %w", err))

--- a/op-interop-mon/monitor/service.go
+++ b/op-interop-mon/monitor/service.go
@@ -333,11 +333,12 @@ func (ms *InteropMonitorService) Stop(ctx context.Context) error {
 	}
 
 	ms.Log.Info("stopping metric collector")
-	if err := ms.collector.Stop(); err != nil {
-		result = errors.Join(result, fmt.Errorf("failed to stop metric collector: %w", err))
-		ms.Log.Error("failed to stop metric collector", "error", err)
+	if ms.collector != nil {
+		if err := ms.collector.Stop(); err != nil {
+			result = errors.Join(result, fmt.Errorf("failed to stop metric collector: %w", err))
+			ms.Log.Error("failed to stop metric collector", "error", err)
+		}
 	}
-
 	ms.Log.Info("stopping rpc server")
 	if ms.rpcServer != nil {
 		if err := ms.rpcServer.Stop(); err != nil {

--- a/op-interop-mon/monitor/service.go
+++ b/op-interop-mon/monitor/service.go
@@ -50,7 +50,7 @@ type InteropMonitorService struct {
 func InteropMonitorServiceFromCLIConfig(ctx context.Context, version string, cfg *CLIConfig, log log.Logger) (*InteropMonitorService, error) {
 	var ms InteropMonitorService
 	if err := ms.initFromCLIConfig(ctx, version, cfg, log); err != nil {
-		return nil, errors.Join(err, ms.Start(ctx))
+		return nil, errors.Join(err, ms.Stop(ctx))
 	}
 	return &ms, nil
 }
@@ -66,7 +66,7 @@ func InteropMonitorServiceFromClients(
 ) (*InteropMonitorService, error) {
 	var ms InteropMonitorService
 	if err := ms.initFromClients(ctx, version, cfg, clients, failsafeClients, log); err != nil {
-		return nil, errors.Join(err, ms.Start(ctx))
+		return nil, errors.Join(err, ms.Stop(ctx))
 	}
 	return &ms, nil
 }

--- a/op-wheel/commands.go
+++ b/op-wheel/commands.go
@@ -437,7 +437,7 @@ var (
 			bigFlag("nonce", "New nonce of the account"),
 		},
 		Action: CheatAction(false, func(ctx *cli.Context, ch *cheat.Cheater) error {
-			return ch.RunAndClose(cheat.SetNonce(addrFlagValue("address", ctx), bigs.Uint64Strict(bigFlagValue("balance", ctx))))
+			return ch.RunAndClose(cheat.SetNonce(addrFlagValue("address", ctx), bigs.Uint64Strict(bigFlagValue("nonce", ctx))))
 		}),
 	}
 	CheatPrintHeadBlock = &cli.Command{


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

1. Corrected account state reading by using `nonce` instead of `balance`.

2. Fixed service initialization error handling to properly clean up partially started services.

3. Ensured dispute monitoring is fully stopped during service shutdown.

4. Prevented nil pointer panic when stopping metric collectors with metrics disabled.

**Tests**
1. **Nonce field usage**
Using the balance field is incorrect, given the `Name: “nonce” `
<img width="837" height="223" alt="image" src="https://github.com/user-attachments/assets/9c6427a7-eefe-4319-ab05-1b8371177053" />

2. **Service initialization failure cleanup** 
Fixed service initialization error handling to call `Stop(ctx)` instead of `Start(ctx)`.
This ensures that partially initialized resources are properly cleaned up and no background processes are accidentally started during error handling.

3. **Dispute monitor shutdown behavior**
Fixed dispute monitor shutdown to explicitly stop background monitoring via `StopMonitoring`.
This prevents monitoring goroutines from continuing to run after the service has been stopped.

4. **Metric collector shutdown when metrics are disabled**
Fixed metric collector shutdown logic by guarding against nil when metrics are disabled.
This prevents a potential nil pointer panic and ensures graceful shutdown behavior.

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
