### PR TITLE
op-acceptance: Default to enabling cannon kona game types in challenger config

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -3141,6 +3141,7 @@ workflows:
           requires:
             - contracts-bedrock-build
             - cannon-prestate-quick
+            - cannon-kona-prestate
           context:
             - circleci-repo-readonly-authenticated-github-token
           filters:

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -3141,7 +3141,6 @@ workflows:
           requires:
             - contracts-bedrock-build
             - cannon-prestate-quick
-            - cannon-kona-prestate
           context:
             - circleci-repo-readonly-authenticated-github-token
           filters:

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -3141,7 +3141,7 @@ workflows:
           requires:
             - contracts-bedrock-build
             - cannon-prestate-quick
-            - cannon-kona-host
+            - kona-build-release
           context:
             - circleci-repo-readonly-authenticated-github-token
           filters:
@@ -3195,12 +3195,11 @@ workflows:
       - cannon-prestate-quick:
           context:
             - circleci-repo-readonly-authenticated-github-token
-      - rust-build-binary: &cannon-kona-host # Required for sysgo unit tests
-          name: cannon-kona-host
+      - rust-build-binary:
+          name: kona-build-release
           directory: kona
+          needs_clang: true
           profile: "release"
-          binary: "kona-host"
-          save_cache: true
           context:
             - circleci-repo-readonly-authenticated-github-token
       - sanitize-op-program:
@@ -3657,14 +3656,6 @@ workflows:
       - cannon-kona-prestate: # needed for sysgo tests (if any package is in-memory)
           context:
             - circleci-repo-readonly-authenticated-github-token
-      - rust-build-binary: &cannon-kona-host
-          name: cannon-kona-host
-          directory: kona
-          profile: "release"
-          binary: "kona-host"
-          save_cache: true
-          context:
-            - circleci-repo-readonly-authenticated-github-token
       - rust-build-binary: &kona-build-release
           name: kona-build-release
           directory: kona
@@ -3693,7 +3684,6 @@ workflows:
             - contracts-bedrock-build
             - cannon-prestate-quick
             - cannon-kona-prestate
-            - cannon-kona-host
             - rust-binaries-for-sysgo
       # Generate flaky test report
       - generate-flaky-report:

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -3195,9 +3195,6 @@ workflows:
       - cannon-prestate-quick:
           context:
             - circleci-repo-readonly-authenticated-github-token
-      - cannon-kona-prestate: # needed for sysgo tests (if any package is in-memory)
-          context:
-            - circleci-repo-readonly-authenticated-github-token
       - sanitize-op-program:
           requires:
             - cannon-prestate-quick

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -3141,6 +3141,7 @@ workflows:
           requires:
             - contracts-bedrock-build
             - cannon-prestate-quick
+            - cannon-kona-host
           context:
             - circleci-repo-readonly-authenticated-github-token
           filters:
@@ -3192,6 +3193,14 @@ workflows:
           requires:
             - contracts-bedrock-build
       - cannon-prestate-quick:
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+      - rust-build-binary: &cannon-kona-host # Required for sysgo unit tests
+          name: cannon-kona-host
+          directory: kona
+          profile: "release"
+          binary: "kona-host"
+          save_cache: true
           context:
             - circleci-repo-readonly-authenticated-github-token
       - sanitize-op-program:

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -3195,6 +3195,9 @@ workflows:
       - cannon-prestate-quick:
           context:
             - circleci-repo-readonly-authenticated-github-token
+      - cannon-kona-prestate: # needed for sysgo tests (if any package is in-memory)
+          context:
+            - circleci-repo-readonly-authenticated-github-token
       - sanitize-op-program:
           requires:
             - cannon-prestate-quick

--- a/op-acceptance-tests/tests/interop/proofs/init_test.go
+++ b/op-acceptance-tests/tests/interop/proofs/init_test.go
@@ -4,13 +4,10 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
-	"github.com/ethereum-optimism/optimism/op-devstack/stack"
-	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
 )
 
 func TestMain(m *testing.M) {
 	presets.DoMain(m,
 		presets.WithSuperInteropSupernode(),
-		stack.MakeCommon(sysgo.WithChallengerCannonKonaEnabled()),
 	)
 }

--- a/op-acceptance-tests/tests/isthmus/preinterop/init_test.go
+++ b/op-acceptance-tests/tests/isthmus/preinterop/init_test.go
@@ -4,13 +4,10 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
-	"github.com/ethereum-optimism/optimism/op-devstack/stack"
-	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
 )
 
 func TestMain(m *testing.M) {
 	presets.DoMain(m,
 		presets.WithIsthmusSuperSupernode(),
-		stack.MakeCommon(sysgo.WithChallengerCannonKonaEnabled()),
 	)
 }

--- a/op-devstack/presets/proof.go
+++ b/op-devstack/presets/proof.go
@@ -25,13 +25,6 @@ func WithAddedGameType(gameType gameTypes.GameType) stack.CommonOption {
 		stack.MakeCommon(sysgo.WithGameTypeAdded(gameType)), // Add if sysgo is in use
 		RequireGameTypePresent(gameType),                    // Verify present for other chains
 	)
-
-	if gameType == gameTypes.CannonKonaGameType {
-		opts = stack.Combine(
-			opts,
-			stack.MakeCommon(sysgo.WithChallengerCannonKonaEnabled()),
-		)
-	}
 	return opts
 }
 

--- a/op-devstack/sysgo/add_game_type.go
+++ b/op-devstack/sysgo/add_game_type.go
@@ -67,22 +67,11 @@ func WithCannonGameTypeAdded(l1ELID stack.L1ELNodeID, l2ChainID eth.ChainID) sta
 
 func WithCannonKonaGameTypeAdded() stack.Option[*Orchestrator] {
 	return stack.FnOption[*Orchestrator]{
-		BeforeDeployFn: func(o *Orchestrator) {
-			o.l2ChallengerOpts.useCannonKonaConfig = true
-		},
 		FinallyFn: func(o *Orchestrator) {
 			absolutePrestate := getCannonKonaAbsolutePrestate(o.P())
 			for _, l2ChainID := range o.l2Nets.Keys() {
 				addGameType(o, absolutePrestate, gameTypes.CannonKonaGameType, o.l1ELs.Keys()[0], l2ChainID)
 			}
-		},
-	}
-}
-
-func WithChallengerCannonKonaEnabled() stack.Option[*Orchestrator] {
-	return stack.FnOption[*Orchestrator]{
-		BeforeDeployFn: func(o *Orchestrator) {
-			o.l2ChallengerOpts.useCannonKonaConfig = true
 		},
 	}
 }

--- a/op-devstack/sysgo/l2_challenger.go
+++ b/op-devstack/sysgo/l2_challenger.go
@@ -17,10 +17,6 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
-type l2ChallengerOpts struct {
-	useCannonKonaConfig bool
-}
-
 type L2Challenger struct {
 	id       stack.L2ChallengerID
 	service  cliapp.Lifecycle
@@ -122,10 +118,6 @@ func WithL2ChallengerPostDeploy(orch *Orchestrator, challengerID stack.L2Challen
 	}
 	l1Genesis := l1Net.genesis
 
-	if orch.l2ChallengerOpts.useCannonKonaConfig {
-		p.Log("Enabling cannon-kona, you may need to build kona-host and prestates with: cd kona && just")
-	}
-
 	dir := p.TempDir()
 	var cfg *config.Config
 	// If interop is scheduled, or if we cannot do the pre-interop connection, then set up with supervisor
@@ -165,12 +157,8 @@ func WithL2ChallengerPostDeploy(orch *Orchestrator, challengerID stack.L2Challen
 			shared.WithCannonConfig(rollupCfgs, l1Genesis, l2Geneses, prestateVariant),
 			shared.WithSuperCannonGameType(),
 			shared.WithSuperPermissionedGameType(),
-		}
-		if orch.l2ChallengerOpts.useCannonKonaConfig {
-			options = append(options,
-				shared.WithCannonKonaInteropConfig(rollupCfgs, l1Genesis, l2Geneses),
-				shared.WithSuperCannonKonaGameType(),
-			)
+			shared.WithCannonKonaInteropConfig(rollupCfgs, l1Genesis, l2Geneses),
+			shared.WithSuperCannonKonaGameType(),
 		}
 		cfg, err = shared.NewInteropChallengerConfig(dir, l1EL.UserRPC(), l1CL.beaconHTTPAddr, superRPC, l2ELRPCs, options...)
 		require.NoError(err, "Failed to create interop challenger config")
@@ -198,12 +186,8 @@ func WithL2ChallengerPostDeploy(orch *Orchestrator, challengerID stack.L2Challen
 			shared.WithCannonGameType(),
 			shared.WithPermissionedGameType(),
 			shared.WithFastGames(),
-		}
-		if orch.l2ChallengerOpts.useCannonKonaConfig {
-			options = append(options,
-				shared.WithCannonKonaConfig(rollupCfgs, l1Genesis, l2Geneses),
-				shared.WithCannonKonaGameType(),
-			)
+			shared.WithCannonKonaConfig(rollupCfgs, l1Genesis, l2Geneses),
+			shared.WithCannonKonaGameType(),
 		}
 		cfg, err = shared.NewPreInteropChallengerConfig(dir, l1EL.UserRPC(), l1CL.beaconHTTPAddr, l2CL.UserRPC(), l2EL.UserRPC(), options...)
 		require.NoError(err, "Failed to create pre-interop challenger config")

--- a/op-devstack/sysgo/orchestrator.go
+++ b/op-devstack/sysgo/orchestrator.go
@@ -33,7 +33,6 @@ type Orchestrator struct {
 	proposerOptions         []ProposerOption
 	l2CLOptions             L2CLOptionBundle
 	l2ELOptions             L2ELOptionBundle
-	l2ChallengerOpts        l2ChallengerOpts
 	SyncTesterELOptions     SyncTesterELOptionBundle
 	deployerPipelineOptions []DeployerPipelineOption
 


### PR DESCRIPTION
**Description**

Now that kona is in the monorepo and its prestates are built with the same make target as the op-program ones, enable kona in challenger config by default.  The game type still has to be added as with permissionless games but that's typically handled by the proofs system preset.

fixes #19092