### PR TITLE
docs: complete docs/README.md and refine CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -55,4 +55,4 @@
 /packages/contracts-bedrock/**/*.md      @ethereum-optimism/contract-reviewers
 
 # Security docs
-/docs @ethereum-optimism/evm-safety
+/docs/security-reviews @ethereum-optimism/evm-safety

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,5 +4,7 @@ The `docs/` directory contains Optimism documentation closely tied to the implem
 
 The directory layout is divided into the following sub-directories.
 
+- [`ai/`](./ai/): AI agent guidance for development in the monorepo.
+- [`handbook/`](./handbook/): Development handbook and guidelines.
 - [`postmortems/`](./postmortems/): Timestamped post-mortem documents.
-- [`security-reviews`](./security-reviews/): Audit summaries and other security review documents.
+- [`security-reviews/`](./security-reviews/): Audit summaries and other security review documents.


### PR DESCRIPTION
Add descriptions for the `ai/` and `handbook/` directories in the docs README. Refine the CODEOWNERS pattern for security-reviews to be more specific, and fix the trailing slash formatting for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)