### PR TITLE
feat: implement alloy traits for OP types and add newtype wrappers

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -121,9 +121,7 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed1958f0294ecc05ebe7b3c9a8662a3e221c2523b7f2bcd94c7a651efbd510bf"
+version = "1.6.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -149,9 +147,7 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f752e99497ddc39e22d547d7dfe516af10c979405a034ed90e69b914b7dddeae"
+version = "1.6.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -240,9 +236,7 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "813a67f87e56b38554d18b182616ee5006e8e2bf9df96a0df8bf29dff1d52e3f"
+version = "1.6.1"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -330,9 +324,7 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2dd146b3de349a6ffaa4e4e319ab3a90371fb159fb0bddeb1c7bbe8b1792eff"
+version = "1.6.1"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -345,9 +337,7 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c12278ffbb8872dfba3b2f17d8ea5e8503c2df5155d9bc5ee342794bde505c3"
+version = "1.6.1"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -371,9 +361,7 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "833037c04917bc2031541a60e8249e4ab5500e24c637c1c62e95e963a655d66f"
+version = "1.6.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -596,9 +584,7 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1cf5a093e437dfd62df48e480f24e1a3807632358aad6816d7a52875f1c04aa"
+version = "1.6.1"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -639,9 +625,7 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "336ef381c7409f23c69f6e79bddc1917b6e832cff23e7a5cf84b9381d53582e6"
+version = "1.6.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -660,9 +644,7 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28e97603095020543a019ab133e0e3dc38cd0819f19f19bdd70c642404a54751"
+version = "1.6.1"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -723,9 +705,7 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "946a0d413dbb5cd9adba0de5f8a1a34d5b77deda9b69c1d7feed8fc875a1aa26"
+version = "1.6.1"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -735,9 +715,7 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f7481dc8316768f042495eaf305d450c32defbc9bce09d8bf28afcd956895bb"
+version = "1.6.1"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -940,9 +918,7 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45ceac797eb8a56bdf5ab1fab353072c17d472eab87645ca847afe720db3246d"
+version = "1.6.1"
 dependencies = [
  "darling 0.21.3",
  "proc-macro2",
@@ -1013,7 +989,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1024,7 +1000,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3308,7 +3284,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3610,7 +3586,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4789,7 +4765,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.57.0",
 ]
 
 [[package]]
@@ -5174,7 +5150,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7670,7 +7646,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7931,6 +7907,7 @@ version = "0.23.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
+ "alloy-network",
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -13160,7 +13137,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -14158,7 +14135,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -14935,7 +14912,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5f7c95348f20c1c913d72157b3c6dee6ea3e30b3d19502c5a7f6d3f160dacbf"
 dependencies = [
  "cc",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -15484,7 +15461,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -633,3 +633,15 @@ op-alloy-rpc-types = { path = "op-alloy/crates/rpc-types" }
 op-alloy = { path = "op-alloy/crates/op-alloy" }
 # Duplicated by: alloy-evm (crates.io)
 alloy-op-hardforks = { path = "alloy-op-hardforks/" }
+# Local alloy crates with new traits (InMemorySize, SignedTransaction, etc.)
+alloy-consensus = { path = "/Users/theo/alloy-trait-migration/crates/consensus" }
+alloy-rpc-types-engine = { path = "/Users/theo/alloy-trait-migration/crates/rpc-types-engine" }
+alloy-network = { path = "/Users/theo/alloy-trait-migration/crates/network" }
+alloy-eips = { path = "/Users/theo/alloy-trait-migration/crates/eips" }
+alloy-serde = { path = "/Users/theo/alloy-trait-migration/crates/serde" }
+alloy-json-rpc = { path = "/Users/theo/alloy-trait-migration/crates/json-rpc" }
+alloy-network-primitives = { path = "/Users/theo/alloy-trait-migration/crates/network-primitives" }
+alloy-rpc-types-eth = { path = "/Users/theo/alloy-trait-migration/crates/rpc-types-eth" }
+alloy-signer = { path = "/Users/theo/alloy-trait-migration/crates/signer" }
+alloy-consensus-any = { path = "/Users/theo/alloy-trait-migration/crates/consensus-any" }
+alloy-rpc-types-any = { path = "/Users/theo/alloy-trait-migration/crates/rpc-types-any" }

--- a/rust/op-alloy/crates/consensus/src/alloy_traits.rs
+++ b/rust/op-alloy/crates/consensus/src/alloy_traits.rs
@@ -1,0 +1,113 @@
+//! Implementations of alloy-consensus traits for OP consensus types.
+//!
+//! This module provides implementations of [`InMemorySize`], [`SignedTransaction`],
+//! and [`SerdeBincodeCompat`] for Optimism consensus types.
+
+use alloy_consensus::size::InMemorySize;
+
+// ===== InMemorySize implementations =====
+
+impl InMemorySize for crate::OpTxType {
+    fn size(&self) -> usize {
+        core::mem::size_of::<Self>()
+    }
+}
+
+impl InMemorySize for crate::TxDeposit {
+    fn size(&self) -> usize {
+        self.size()
+    }
+}
+
+impl InMemorySize for crate::OpDepositReceipt {
+    fn size(&self) -> usize {
+        let Self { inner, deposit_nonce, deposit_receipt_version } = self;
+        inner.size() +
+            core::mem::size_of_val(deposit_nonce) +
+            core::mem::size_of_val(deposit_receipt_version)
+    }
+}
+
+impl InMemorySize for crate::OpReceipt {
+    fn size(&self) -> usize {
+        match self {
+            Self::Legacy(receipt) |
+            Self::Eip2930(receipt) |
+            Self::Eip1559(receipt) |
+            Self::Eip7702(receipt) => receipt.size(),
+            Self::Deposit(receipt) => receipt.size(),
+        }
+    }
+}
+
+impl InMemorySize for crate::OpTypedTransaction {
+    fn size(&self) -> usize {
+        match self {
+            Self::Legacy(tx) => tx.size(),
+            Self::Eip2930(tx) => tx.size(),
+            Self::Eip1559(tx) => tx.size(),
+            Self::Eip7702(tx) => tx.size(),
+            Self::Deposit(tx) => tx.size(),
+        }
+    }
+}
+
+impl InMemorySize for crate::OpPooledTransaction {
+    fn size(&self) -> usize {
+        match self {
+            Self::Legacy(tx) => tx.size(),
+            Self::Eip2930(tx) => tx.size(),
+            Self::Eip1559(tx) => tx.size(),
+            Self::Eip7702(tx) => tx.size(),
+        }
+    }
+}
+
+impl InMemorySize for crate::OpTxEnvelope {
+    fn size(&self) -> usize {
+        match self {
+            Self::Legacy(tx) => tx.size(),
+            Self::Eip2930(tx) => tx.size(),
+            Self::Eip1559(tx) => tx.size(),
+            Self::Eip7702(tx) => tx.size(),
+            Self::Deposit(tx) => tx.size(),
+        }
+    }
+}
+
+// ===== SignedTransaction implementations =====
+
+#[cfg(feature = "k256")]
+impl alloy_consensus::SignedTransaction for crate::OpTxEnvelope {}
+
+#[cfg(feature = "k256")]
+impl alloy_consensus::SignedTransaction for crate::OpPooledTransaction {}
+
+// ===== SerdeBincodeCompat implementations =====
+
+#[cfg(all(feature = "serde", feature = "serde-bincode-compat"))]
+impl alloy_consensus::SerdeBincodeCompat for crate::OpTxEnvelope {
+    type BincodeRepr<'a> =
+        crate::serde_bincode_compat::transaction::OpTxEnvelope<'a>;
+
+    fn as_repr(&self) -> Self::BincodeRepr<'_> {
+        self.into()
+    }
+
+    fn from_repr(repr: Self::BincodeRepr<'_>) -> Self {
+        repr.into()
+    }
+}
+
+#[cfg(all(feature = "serde", feature = "serde-bincode-compat"))]
+impl alloy_consensus::SerdeBincodeCompat for crate::OpReceipt {
+    type BincodeRepr<'a> = crate::serde_bincode_compat::OpReceipt<'a>;
+
+    fn as_repr(&self) -> Self::BincodeRepr<'_> {
+        self.into()
+    }
+
+    fn from_repr(repr: Self::BincodeRepr<'_>) -> Self {
+        repr.into()
+    }
+}

--- a/rust/op-alloy/crates/consensus/src/lib.rs
+++ b/rust/op-alloy/crates/consensus/src/lib.rs
@@ -12,6 +12,8 @@ extern crate alloc;
 #[cfg(feature = "alloy-compat")]
 mod alloy_compat;
 
+mod alloy_traits;
+
 mod receipts;
 pub use receipts::{
     OpDepositReceipt, OpDepositReceiptWithBloom, OpReceipt, OpReceiptEnvelope, OpTxReceipt,

--- a/rust/op-alloy/crates/network/Cargo.toml
+++ b/rust/op-alloy/crates/network/Cargo.toml
@@ -17,7 +17,7 @@ workspace = true
 [dependencies]
 # Workspace
 op-alloy-consensus = { workspace = true, features = ["alloy-compat"] }
-op-alloy-rpc-types.workspace = true
+op-alloy-rpc-types = { workspace = true, features = ["alloy-compat"] }
 
 # Alloy
 alloy-consensus.workspace = true

--- a/rust/op-alloy/crates/network/src/alloy_traits.rs
+++ b/rust/op-alloy/crates/network/src/alloy_traits.rs
@@ -1,0 +1,36 @@
+//! Implementations of alloy-network conversion traits for OP network types.
+//!
+//! Only traits that use [`Optimism`] (a local type) can be implemented here
+//! due to the orphan rule. The remaining conversion trait impls
+//! ([`FromConsensusTx`], [`TryIntoSimTx`], [`SignableTxRequest`])
+//! live in `op-alloy-rpc-types` behind the `alloy-compat` feature.
+
+use alloy_network::convert::{TryFromReceiptResponse, TryFromTransactionResponse};
+use op_alloy_consensus::OpTxEnvelope;
+use std::convert::Infallible;
+
+use crate::Optimism;
+
+// ===== TryFromTransactionResponse =====
+
+impl TryFromTransactionResponse<Optimism> for OpTxEnvelope {
+    type Error = Infallible;
+
+    fn from_transaction_response(
+        transaction_response: op_alloy_rpc_types::Transaction,
+    ) -> Result<Self, Self::Error> {
+        Ok(transaction_response.inner.into_inner())
+    }
+}
+
+// ===== TryFromReceiptResponse =====
+
+impl TryFromReceiptResponse<Optimism> for op_alloy_consensus::OpReceipt {
+    type Error = Infallible;
+
+    fn from_receipt_response(
+        receipt_response: op_alloy_rpc_types::OpTransactionReceipt,
+    ) -> Result<Self, Self::Error> {
+        Ok(receipt_response.inner.inner.into_components().0.map_logs(Into::into))
+    }
+}

--- a/rust/op-alloy/crates/network/src/lib.rs
+++ b/rust/op-alloy/crates/network/src/lib.rs
@@ -8,6 +8,8 @@
 
 pub use alloy_network::*;
 
+mod alloy_traits;
+
 use alloy_consensus::{ReceiptWithBloom, TxEnvelope, TxType, TypedTransaction};
 use alloy_primitives::{Address, Bytes, ChainId, TxKind, U256};
 use alloy_rpc_types_eth::AccessList;

--- a/rust/op-alloy/crates/rpc-types-engine/src/alloy_traits.rs
+++ b/rust/op-alloy/crates/rpc-types-engine/src/alloy_traits.rs
@@ -1,0 +1,60 @@
+//! Implementations of alloy-rpc-types-engine traits for OP engine types.
+
+use alloc::vec::Vec;
+use alloy_eips::eip4895::Withdrawal;
+use alloy_primitives::{B256, Bytes};
+use alloy_rpc_types_engine::traits::{
+    ExecutionPayload as ExecutionPayloadTrait, PayloadAttributes as PayloadAttributesTrait,
+};
+
+impl PayloadAttributesTrait for crate::OpPayloadAttributes {
+    fn timestamp(&self) -> u64 {
+        self.payload_attributes.timestamp
+    }
+
+    fn withdrawals(&self) -> Option<&Vec<Withdrawal>> {
+        self.payload_attributes.withdrawals.as_ref()
+    }
+
+    fn parent_beacon_block_root(&self) -> Option<B256> {
+        self.payload_attributes.parent_beacon_block_root
+    }
+}
+
+impl ExecutionPayloadTrait for crate::OpExecutionData {
+    fn parent_hash(&self) -> B256 {
+        self.parent_hash()
+    }
+
+    fn block_hash(&self) -> B256 {
+        self.block_hash()
+    }
+
+    fn block_number(&self) -> u64 {
+        self.block_number()
+    }
+
+    fn withdrawals(&self) -> Option<&Vec<Withdrawal>> {
+        self.payload.as_v2().map(|p| &p.withdrawals)
+    }
+
+    fn block_access_list(&self) -> Option<&Bytes> {
+        None
+    }
+
+    fn parent_beacon_block_root(&self) -> Option<B256> {
+        self.sidecar.parent_beacon_block_root()
+    }
+
+    fn timestamp(&self) -> u64 {
+        self.payload.as_v1().timestamp
+    }
+
+    fn gas_used(&self) -> u64 {
+        self.payload.as_v1().gas_used
+    }
+
+    fn transaction_count(&self) -> usize {
+        self.payload.as_v1().transactions.len()
+    }
+}

--- a/rust/op-alloy/crates/rpc-types-engine/src/lib.rs
+++ b/rust/op-alloy/crates/rpc-types-engine/src/lib.rs
@@ -11,6 +11,9 @@ extern crate alloc;
 
 pub use alloy_rpc_types_engine::ForkchoiceUpdateVersion;
 
+#[cfg(feature = "serde")]
+mod alloy_traits;
+
 mod attributes;
 pub use attributes::OpPayloadAttributes;
 

--- a/rust/op-alloy/crates/rpc-types/Cargo.toml
+++ b/rust/op-alloy/crates/rpc-types/Cargo.toml
@@ -22,6 +22,7 @@ op-alloy-consensus = { workspace = true, features = ["serde"] }
 alloy-serde.workspace = true
 alloy-consensus.workspace = true
 alloy-network-primitives.workspace = true
+alloy-network = { workspace = true, optional = true }
 alloy-eips = { workspace = true, features = ["serde"] }
 alloy-rpc-types-eth = { workspace = true, features = ["serde"] }
 alloy-primitives = { workspace = true, features = ["map", "rlp", "serde"] }
@@ -73,6 +74,7 @@ arbitrary = [
 	"alloy-eips/arbitrary",
 	"alloy-serde/arbitrary"
 ]
+alloy-compat = ["dep:alloy-network"]
 k256 = ["alloy-rpc-types-eth/k256", "op-alloy-consensus/k256"]
 serde = [
 	"op-alloy-consensus/serde",

--- a/rust/op-alloy/crates/rpc-types/src/alloy_traits.rs
+++ b/rust/op-alloy/crates/rpc-types/src/alloy_traits.rs
@@ -1,0 +1,70 @@
+//! Implementations of alloy-network conversion traits for OP RPC types.
+//!
+//! These impls are gated behind the `alloy-compat` feature because they
+//! require `alloy-network` and `alloy-signer` dependencies.
+
+use alloy_consensus::{
+    SignableTransaction, error::ValueError, transaction::Recovered,
+};
+use alloy_network::convert::{
+    FromConsensusTx, SignTxRequestError, SignableTxRequest, TryIntoSimTx,
+};
+use alloy_primitives::{Address, Signature};
+use op_alloy_consensus::{
+    OpTransaction, OpTxEnvelope,
+    transaction::OpTransactionInfo,
+};
+use std::convert::Infallible;
+
+use crate::{OpTransactionRequest, Transaction};
+
+// ===== FromConsensusTx =====
+
+impl<T: OpTransaction + alloy_consensus::Transaction> FromConsensusTx<T> for Transaction<T> {
+    type TxInfo = OpTransactionInfo;
+    type Err = Infallible;
+
+    fn from_consensus_tx(
+        tx: T,
+        signer: Address,
+        tx_info: Self::TxInfo,
+    ) -> Result<Self, Self::Err> {
+        Ok(Self::from_transaction(Recovered::new_unchecked(tx, signer), tx_info))
+    }
+}
+
+// ===== TryIntoSimTx =====
+
+impl TryIntoSimTx<OpTxEnvelope> for OpTransactionRequest {
+    fn try_into_sim_tx(self) -> Result<OpTxEnvelope, ValueError<Self>> {
+        let tx = self
+            .build_typed_tx()
+            .map_err(|request| ValueError::new(request, "Required fields missing"))?;
+
+        // Create an empty signature for the transaction.
+        let signature = Signature::new(Default::default(), Default::default(), false);
+
+        Ok(tx.into_signed(signature).into())
+    }
+}
+
+// ===== SignableTxRequest =====
+
+impl SignableTxRequest<OpTxEnvelope> for OpTransactionRequest {
+    async fn try_build_and_sign(
+        self,
+        signer: impl alloy_network::TxSigner<Signature> + Send,
+    ) -> Result<OpTxEnvelope, SignTxRequestError> {
+        let mut tx =
+            self.build_typed_tx().map_err(|_| SignTxRequestError::InvalidTransactionRequest)?;
+
+        // sanity check: deposit transactions must not be signed by the user
+        if tx.is_deposit() {
+            return Err(SignTxRequestError::InvalidTransactionRequest);
+        }
+
+        let signature = signer.sign_transaction(&mut tx).await?;
+
+        Ok(tx.into_signed(signature).into())
+    }
+}

--- a/rust/op-alloy/crates/rpc-types/src/lib.rs
+++ b/rust/op-alloy/crates/rpc-types/src/lib.rs
@@ -9,6 +9,9 @@
 
 extern crate alloc;
 
+#[cfg(feature = "alloy-compat")]
+mod alloy_traits;
+
 mod genesis;
 pub use genesis::{OpBaseFeeInfo, OpChainInfo, OpGenesisInfo};
 

--- a/rust/op-reth/crates/primitives/Cargo.toml
+++ b/rust/op-reth/crates/primitives/Cargo.toml
@@ -14,6 +14,8 @@ workspace = true
 [dependencies]
 # reth
 reth-primitives-traits = { workspace = true, features = ["op"] }
+reth-codecs = { workspace = true, optional = true, features = ["op"] }
+reth-zstd-compressors = { workspace = true, optional = true }
 
 # ethereum
 alloy-primitives.workspace = true
@@ -25,8 +27,13 @@ alloy-rlp.workspace = true
 op-alloy-consensus.workspace = true
 
 # codec
+bytes = { workspace = true, optional = true }
+modular-bitfield = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 serde_with = { workspace = true, optional = true }
+
+# misc
+arbitrary = { workspace = true, optional = true }
 
 [dev-dependencies]
 reth-codecs = { workspace = true, features = ["test-utils", "op"] }
@@ -63,6 +70,10 @@ std = [
 alloy-compat = ["op-alloy-consensus/alloy-compat"]
 reth-codec = [
     "std",
+    "dep:reth-codecs",
+    "dep:reth-zstd-compressors",
+    "dep:bytes",
+    "dep:modular-bitfield",
     "reth-primitives-traits/reth-codec",
 ]
 serde = [
@@ -87,6 +98,7 @@ serde-bincode-compat = [
 ]
 arbitrary = [
     "std",
+    "dep:arbitrary",
     "reth-primitives-traits/arbitrary",
     "op-alloy-consensus/arbitrary",
     "alloy-consensus/arbitrary",

--- a/rust/op-reth/crates/primitives/src/compact.rs
+++ b/rust/op-reth/crates/primitives/src/compact.rs
@@ -1,0 +1,11 @@
+//! Compact codec implementations for Optimism types.
+//!
+//! This module provides newtype wrappers around `op-alloy-consensus` types
+//! and implements the `reth-codecs` `Compact` trait for them.
+//!
+//! These wrappers exist to satisfy the Rust orphan rule: neither `Compact` (from `reth-codecs`)
+//! nor the OP types (from `op-alloy-consensus`) are defined in this crate, so we need local
+//! newtypes to implement the trait.
+
+pub mod receipt;
+pub mod transaction;

--- a/rust/op-reth/crates/primitives/src/compact/receipt.rs
+++ b/rust/op-reth/crates/primitives/src/compact/receipt.rs
@@ -1,0 +1,128 @@
+//! Compact codec implementations for OP receipt types.
+
+use alloc::{borrow::Cow, vec::Vec};
+use alloy_consensus::{Receipt, TxReceipt};
+use alloy_primitives::Log;
+use core::ops::{Deref, DerefMut};
+use op_alloy_consensus::{OpDepositReceipt, OpReceipt, OpTxType};
+use reth_codecs::{Compact, CompactZstd};
+
+/// Compressed representation of an [`OpReceipt`] for storage.
+#[derive(CompactZstd)]
+#[reth_codecs(crate = "reth_codecs")]
+#[reth_zstd(
+    compressor = reth_zstd_compressors::RECEIPT_COMPRESSOR,
+    decompressor = reth_zstd_compressors::RECEIPT_DECOMPRESSOR
+)]
+struct CompactOpReceipt<'a> {
+    tx_type: OpTxType,
+    success: bool,
+    cumulative_gas_used: u64,
+    #[expect(clippy::owned_cow)]
+    logs: Cow<'a, Vec<Log>>,
+    deposit_nonce: Option<u64>,
+    deposit_receipt_version: Option<u64>,
+}
+
+impl<'a> From<&'a OpReceipt> for CompactOpReceipt<'a> {
+    fn from(receipt: &'a OpReceipt) -> Self {
+        Self {
+            tx_type: receipt.tx_type(),
+            success: receipt.status(),
+            cumulative_gas_used: receipt.cumulative_gas_used(),
+            logs: Cow::Borrowed(&receipt.as_receipt().logs),
+            deposit_nonce: if let OpReceipt::Deposit(receipt) = receipt {
+                receipt.deposit_nonce
+            } else {
+                None
+            },
+            deposit_receipt_version: if let OpReceipt::Deposit(receipt) = receipt {
+                receipt.deposit_receipt_version
+            } else {
+                None
+            },
+        }
+    }
+}
+
+impl From<CompactOpReceipt<'_>> for OpReceipt {
+    fn from(receipt: CompactOpReceipt<'_>) -> Self {
+        let CompactOpReceipt {
+            tx_type,
+            success,
+            cumulative_gas_used,
+            logs,
+            deposit_nonce,
+            deposit_receipt_version,
+        } = receipt;
+
+        let inner =
+            Receipt { status: success.into(), cumulative_gas_used, logs: logs.into_owned() };
+
+        match tx_type {
+            OpTxType::Legacy => Self::Legacy(inner),
+            OpTxType::Eip2930 => Self::Eip2930(inner),
+            OpTxType::Eip1559 => Self::Eip1559(inner),
+            OpTxType::Eip7702 => Self::Eip7702(inner),
+            OpTxType::Deposit => {
+                Self::Deposit(OpDepositReceipt { inner, deposit_nonce, deposit_receipt_version })
+            }
+        }
+    }
+}
+
+/// Newtype wrapper around [`OpReceipt`] for `Compact` implementation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct OpRcpt(pub OpReceipt);
+
+impl Deref for OpRcpt {
+    type Target = OpReceipt;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for OpRcpt {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl From<OpReceipt> for OpRcpt {
+    fn from(receipt: OpReceipt) -> Self {
+        Self(receipt)
+    }
+}
+
+impl From<OpRcpt> for OpReceipt {
+    fn from(receipt: OpRcpt) -> Self {
+        receipt.0
+    }
+}
+
+impl Compact for OpRcpt {
+    fn to_compact<B>(&self, buf: &mut B) -> usize
+    where
+        B: bytes::BufMut + AsMut<[u8]>,
+    {
+        CompactOpReceipt::from(&self.0).to_compact(buf)
+    }
+
+    fn from_compact(buf: &[u8], len: usize) -> (Self, &[u8]) {
+        let (receipt, buf) = CompactOpReceipt::from_compact(buf, len);
+        (Self(receipt.into()), buf)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reth_codecs::{test_utils::UnusedBits, validate_bitflag_backwards_compat};
+
+    #[test]
+    fn test_ensure_backwards_compatibility() {
+        assert_eq!(CompactOpReceipt::bitflag_encoded_bytes(), 2);
+        validate_bitflag_backwards_compat!(CompactOpReceipt<'_>, UnusedBits::NotZero);
+    }
+}

--- a/rust/op-reth/crates/primitives/src/compact/transaction.rs
+++ b/rust/op-reth/crates/primitives/src/compact/transaction.rs
@@ -1,0 +1,446 @@
+//! Compact codec implementations for OP transaction types.
+//!
+//! This module provides newtype wrappers around `op-alloy-consensus` transaction types
+//! with `Compact` trait implementations for database storage.
+
+use alloc::vec::Vec;
+use alloy_consensus::{
+    Transaction, constants::EIP7702_TX_TYPE_ID, Signed, TxEip1559, TxEip2930, TxEip7702, TxLegacy,
+};
+use alloy_primitives::{Address, Bytes, Sealed, Signature, TxKind, B256, U256};
+use bytes::{Buf, BufMut};
+use core::ops::{Deref, DerefMut};
+use op_alloy_consensus::{OpTxEnvelope, OpTypedTransaction};
+use reth_codecs::{
+    Compact,
+    txtype::{
+        COMPACT_EXTENDED_IDENTIFIER_FLAG, COMPACT_IDENTIFIER_EIP1559, COMPACT_IDENTIFIER_EIP2930,
+        COMPACT_IDENTIFIER_LEGACY,
+    },
+};
+
+// ===== TxDeposit helper for derive =====
+
+/// Deposit transactions, also known as deposits are initiated on L1, and executed on L2.
+///
+/// This is a helper type to use derive on it instead of manually managing `bitfield`.
+///
+/// By deriving `Compact` here, any future changes or enhancements to the `Compact` derive
+/// will automatically apply to this type.
+///
+/// Notice: Make sure this struct is 1:1 with [`op_alloy_consensus::TxDeposit`]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default, Compact)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[reth_codecs(crate = "reth_codecs")]
+pub(crate) struct TxDepositCompact {
+    source_hash: B256,
+    from: Address,
+    to: TxKind,
+    mint: Option<u128>,
+    value: U256,
+    gas_limit: u64,
+    is_system_transaction: bool,
+    input: Bytes,
+}
+
+// ===== OpDeposit newtype =====
+
+/// Newtype wrapper around [`op_alloy_consensus::TxDeposit`] for `Compact` implementation.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[repr(transparent)]
+pub struct OpDeposit(pub op_alloy_consensus::TxDeposit);
+
+impl Deref for OpDeposit {
+    type Target = op_alloy_consensus::TxDeposit;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for OpDeposit {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl From<op_alloy_consensus::TxDeposit> for OpDeposit {
+    fn from(tx: op_alloy_consensus::TxDeposit) -> Self {
+        Self(tx)
+    }
+}
+
+impl From<OpDeposit> for op_alloy_consensus::TxDeposit {
+    fn from(tx: OpDeposit) -> Self {
+        tx.0
+    }
+}
+
+impl Compact for OpDeposit {
+    fn to_compact<B>(&self, buf: &mut B) -> usize
+    where
+        B: bytes::BufMut + AsMut<[u8]>,
+    {
+        let tx = TxDepositCompact {
+            source_hash: self.0.source_hash,
+            from: self.0.from,
+            to: self.0.to,
+            mint: match self.0.mint {
+                0 => None,
+                v => Some(v),
+            },
+            value: self.0.value,
+            gas_limit: self.0.gas_limit,
+            is_system_transaction: self.0.is_system_transaction,
+            input: self.0.input.clone(),
+        };
+        tx.to_compact(buf)
+    }
+
+    fn from_compact(buf: &[u8], len: usize) -> (Self, &[u8]) {
+        let (tx, remaining) = TxDepositCompact::from_compact(buf, len);
+        let alloy_tx = op_alloy_consensus::TxDeposit {
+            source_hash: tx.source_hash,
+            from: tx.from,
+            to: tx.to,
+            mint: tx.mint.unwrap_or_default(),
+            value: tx.value,
+            gas_limit: tx.gas_limit,
+            is_system_transaction: tx.is_system_transaction,
+            input: tx.input,
+        };
+        (Self(alloy_tx), remaining)
+    }
+}
+
+// ===== OpTxTy newtype =====
+
+/// Newtype wrapper around [`op_alloy_consensus::OpTxType`] for `Compact` implementation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(transparent)]
+pub struct OpTxTy(pub op_alloy_consensus::OpTxType);
+
+impl Deref for OpTxTy {
+    type Target = op_alloy_consensus::OpTxType;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl From<op_alloy_consensus::OpTxType> for OpTxTy {
+    fn from(ty: op_alloy_consensus::OpTxType) -> Self {
+        Self(ty)
+    }
+}
+
+impl From<OpTxTy> for op_alloy_consensus::OpTxType {
+    fn from(ty: OpTxTy) -> Self {
+        ty.0
+    }
+}
+
+impl Compact for OpTxTy {
+    fn to_compact<B>(&self, buf: &mut B) -> usize
+    where
+        B: bytes::BufMut + AsMut<[u8]>,
+    {
+        use op_alloy_consensus::OpTxType;
+        match self.0 {
+            OpTxType::Legacy => COMPACT_IDENTIFIER_LEGACY,
+            OpTxType::Eip2930 => COMPACT_IDENTIFIER_EIP2930,
+            OpTxType::Eip1559 => COMPACT_IDENTIFIER_EIP1559,
+            OpTxType::Eip7702 => {
+                buf.put_u8(EIP7702_TX_TYPE_ID);
+                COMPACT_EXTENDED_IDENTIFIER_FLAG
+            }
+            OpTxType::Deposit => {
+                buf.put_u8(op_alloy_consensus::DEPOSIT_TX_TYPE_ID);
+                COMPACT_EXTENDED_IDENTIFIER_FLAG
+            }
+        }
+    }
+
+    fn from_compact(mut buf: &[u8], identifier: usize) -> (Self, &[u8]) {
+        use op_alloy_consensus::OpTxType;
+        (
+            Self(match identifier {
+                COMPACT_IDENTIFIER_LEGACY => OpTxType::Legacy,
+                COMPACT_IDENTIFIER_EIP2930 => OpTxType::Eip2930,
+                COMPACT_IDENTIFIER_EIP1559 => OpTxType::Eip1559,
+                COMPACT_EXTENDED_IDENTIFIER_FLAG => {
+                    let extended_identifier = buf.get_u8();
+                    match extended_identifier {
+                        EIP7702_TX_TYPE_ID => OpTxType::Eip7702,
+                        op_alloy_consensus::DEPOSIT_TX_TYPE_ID => OpTxType::Deposit,
+                        _ => panic!("Unsupported OpTxType identifier: {extended_identifier}"),
+                    }
+                }
+                _ => panic!("Unknown identifier for TxType: {identifier}"),
+            }),
+            buf,
+        )
+    }
+}
+
+// ===== OpTypedTx newtype =====
+
+/// Newtype wrapper around [`op_alloy_consensus::OpTypedTransaction`] for `Compact`
+/// implementation.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[repr(transparent)]
+pub struct OpTypedTx(pub OpTypedTransaction);
+
+impl Deref for OpTypedTx {
+    type Target = OpTypedTransaction;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for OpTypedTx {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl From<OpTypedTransaction> for OpTypedTx {
+    fn from(tx: OpTypedTransaction) -> Self {
+        Self(tx)
+    }
+}
+
+impl From<OpTypedTx> for OpTypedTransaction {
+    fn from(tx: OpTypedTx) -> Self {
+        tx.0
+    }
+}
+
+#[cfg(any(test, feature = "arbitrary"))]
+impl<'a> arbitrary::Arbitrary<'a> for OpTypedTx {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        OpTypedTransaction::arbitrary(u).map(Self)
+    }
+}
+
+impl Compact for OpTypedTx {
+    fn to_compact<B>(&self, out: &mut B) -> usize
+    where
+        B: bytes::BufMut + AsMut<[u8]>,
+    {
+        let identifier = OpTxTy(self.0.tx_type()).to_compact(out);
+        match &self.0 {
+            OpTypedTransaction::Legacy(tx) => tx.to_compact(out),
+            OpTypedTransaction::Eip2930(tx) => tx.to_compact(out),
+            OpTypedTransaction::Eip1559(tx) => tx.to_compact(out),
+            OpTypedTransaction::Eip7702(tx) => tx.to_compact(out),
+            OpTypedTransaction::Deposit(tx) => OpDeposit(tx.clone()).to_compact(out),
+        };
+        identifier
+    }
+
+    fn from_compact(buf: &[u8], identifier: usize) -> (Self, &[u8]) {
+        use op_alloy_consensus::OpTxType;
+        let (tx_type, buf) = OpTxTy::from_compact(buf, identifier);
+        match tx_type.0 {
+            OpTxType::Legacy => {
+                let (tx, buf) = Compact::from_compact(buf, buf.len());
+                (Self(OpTypedTransaction::Legacy(tx)), buf)
+            }
+            OpTxType::Eip2930 => {
+                let (tx, buf) = Compact::from_compact(buf, buf.len());
+                (Self(OpTypedTransaction::Eip2930(tx)), buf)
+            }
+            OpTxType::Eip1559 => {
+                let (tx, buf) = Compact::from_compact(buf, buf.len());
+                (Self(OpTypedTransaction::Eip1559(tx)), buf)
+            }
+            OpTxType::Eip7702 => {
+                let (tx, buf) = Compact::from_compact(buf, buf.len());
+                (Self(OpTypedTransaction::Eip7702(tx)), buf)
+            }
+            OpTxType::Deposit => {
+                let (tx, buf) = OpDeposit::from_compact(buf, buf.len());
+                (Self(OpTypedTransaction::Deposit(tx.0)), buf)
+            }
+        }
+    }
+}
+
+// ===== OpTx newtype =====
+
+/// Newtype wrapper around [`OpTxEnvelope`] for `Compact` implementation.
+///
+/// Uses the same compact encoding format as the bare `OpTxEnvelope` implementation in
+/// `reth-codecs`: a leading byte of bitflags (IsCompressed, TxType, Signature), followed
+/// by the signature and the (optionally zstd-compressed) transaction body.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct OpTx(pub OpTxEnvelope);
+
+impl Deref for OpTx {
+    type Target = OpTxEnvelope;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for OpTx {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl From<OpTxEnvelope> for OpTx {
+    fn from(tx: OpTxEnvelope) -> Self {
+        Self(tx)
+    }
+}
+
+impl From<OpTx> for OpTxEnvelope {
+    fn from(tx: OpTx) -> Self {
+        tx.0
+    }
+}
+
+const DEPOSIT_SIGNATURE: Signature = Signature::new(U256::ZERO, U256::ZERO, false);
+
+/// Returns the signature for this envelope variant.
+fn envelope_signature(tx: &OpTxEnvelope) -> &Signature {
+    match tx {
+        OpTxEnvelope::Legacy(tx) => tx.signature(),
+        OpTxEnvelope::Eip2930(tx) => tx.signature(),
+        OpTxEnvelope::Eip1559(tx) => tx.signature(),
+        OpTxEnvelope::Eip7702(tx) => tx.signature(),
+        OpTxEnvelope::Deposit(_) => &DEPOSIT_SIGNATURE,
+    }
+}
+
+/// Serializes the inner transaction body (without signature or type) using Compact encoding.
+fn tx_to_compact(tx: &OpTxEnvelope, buf: &mut (impl BufMut + AsMut<[u8]>)) {
+    match tx {
+        OpTxEnvelope::Legacy(tx) => {
+            tx.tx().to_compact(buf);
+        }
+        OpTxEnvelope::Eip2930(tx) => {
+            tx.tx().to_compact(buf);
+        }
+        OpTxEnvelope::Eip1559(tx) => {
+            tx.tx().to_compact(buf);
+        }
+        OpTxEnvelope::Eip7702(tx) => {
+            tx.tx().to_compact(buf);
+        }
+        OpTxEnvelope::Deposit(tx) => {
+            OpDeposit((**tx).clone()).to_compact(buf);
+        }
+    };
+}
+
+/// Deserializes a transaction from the given tx type, buffer and signature.
+fn tx_from_compact(
+    buf: &[u8],
+    tx_type: OpTxTy,
+    signature: Signature,
+) -> (OpTxEnvelope, &[u8]) {
+    use op_alloy_consensus::OpTxType;
+    match tx_type.0 {
+        OpTxType::Legacy => {
+            let (tx, buf) = TxLegacy::from_compact(buf, buf.len());
+            let tx = Signed::new_unhashed(tx, signature);
+            (OpTxEnvelope::Legacy(tx), buf)
+        }
+        OpTxType::Eip2930 => {
+            let (tx, buf) = TxEip2930::from_compact(buf, buf.len());
+            let tx = Signed::new_unhashed(tx, signature);
+            (OpTxEnvelope::Eip2930(tx), buf)
+        }
+        OpTxType::Eip1559 => {
+            let (tx, buf) = TxEip1559::from_compact(buf, buf.len());
+            let tx = Signed::new_unhashed(tx, signature);
+            (OpTxEnvelope::Eip1559(tx), buf)
+        }
+        OpTxType::Eip7702 => {
+            let (tx, buf) = TxEip7702::from_compact(buf, buf.len());
+            let tx = Signed::new_unhashed(tx, signature);
+            (OpTxEnvelope::Eip7702(tx), buf)
+        }
+        OpTxType::Deposit => {
+            let (tx, buf) = OpDeposit::from_compact(buf, buf.len());
+            let tx = Sealed::new(tx.0);
+            (OpTxEnvelope::Deposit(tx), buf)
+        }
+    }
+}
+
+impl Compact for OpTx {
+    fn to_compact<B>(&self, buf: &mut B) -> usize
+    where
+        B: BufMut + AsMut<[u8]>,
+    {
+        let start = buf.as_mut().len();
+
+        // Placeholder for bitflags.
+        // The first byte uses 4 bits as flags: IsCompressed[1bit], TxType[2bits], Signature[1bit]
+        buf.put_u8(0);
+
+        let sig_bit = envelope_signature(&self.0).to_compact(buf) as u8;
+        let zstd_bit = self.0.input().len() >= 32;
+
+        let tx_bits = if zstd_bit {
+            // compress the tx prefixed with txtype
+            let mut tx_buf = Vec::with_capacity(256);
+            let tx_bits = OpTxTy(OpTxEnvelope::tx_type(&self.0)).to_compact(&mut tx_buf) as u8;
+            tx_to_compact(&self.0, &mut tx_buf);
+
+            buf.put_slice(
+                &reth_zstd_compressors::TRANSACTION_COMPRESSOR.with(|compressor| {
+                    compressor.borrow_mut().compress(&tx_buf)
+                })
+                .expect("Failed to compress"),
+            );
+            tx_bits
+        } else {
+            let tx_bits =
+                OpTxTy(OpTxEnvelope::tx_type(&self.0)).to_compact(buf) as u8;
+            tx_to_compact(&self.0, buf);
+            tx_bits
+        };
+
+        let flags = sig_bit | (tx_bits << 1) | ((zstd_bit as u8) << 3);
+        buf.as_mut()[start] = flags;
+
+        buf.as_mut().len() - start
+    }
+
+    fn from_compact(mut buf: &[u8], _len: usize) -> (Self, &[u8]) {
+        let flags = buf.get_u8() as usize;
+
+        let sig_bit = flags & 1;
+        let tx_bits = (flags & 0b110) >> 1;
+        let zstd_bit = flags >> 3;
+
+        let (signature, buf) = Signature::from_compact(buf, sig_bit);
+
+        let (transaction, buf) = if zstd_bit != 0 {
+            reth_zstd_compressors::TRANSACTION_DECOMPRESSOR.with(|decompressor| {
+                let mut decompressor = decompressor.borrow_mut();
+                let decompressed = decompressor.decompress(buf);
+                let (tx_type, tx_buf) = OpTxTy::from_compact(decompressed, tx_bits);
+                let (tx, _) = tx_from_compact(tx_buf, tx_type, signature);
+                (tx, buf)
+            })
+        } else {
+            let (tx_type, buf) = OpTxTy::from_compact(buf, tx_bits);
+            tx_from_compact(buf, tx_type, signature)
+        };
+
+        (Self(transaction), buf)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reth_codecs::generate_tests;
+
+    generate_tests!(#[reth_codecs, compact] OpTypedTx, OpTypedTxTests);
+}

--- a/rust/op-reth/crates/primitives/src/lib.rs
+++ b/rust/op-reth/crates/primitives/src/lib.rs
@@ -11,6 +11,14 @@
 #![allow(unused)]
 extern crate alloc;
 
+#[cfg(feature = "reth-codec")]
+pub mod compact;
+#[cfg(feature = "reth-codec")]
+pub use compact::{
+    receipt::OpRcpt,
+    transaction::{OpDeposit, OpTx, OpTxTy, OpTypedTx},
+};
+
 pub mod bedrock;
 
 // Re-export predeploys from op-alloy-consensus


### PR DESCRIPTION
## Summary

- Implement alloy traits natively for OP types across op-alloy crates (no reth dependency needed)
- `op-alloy-consensus`: `InMemorySize`, `SignedTransaction`, `SerdeBincodeCompat` for `OpTxEnvelope`, `OpReceipt`, `OpPooledTransaction`, etc.
- `op-alloy-rpc-types-engine`: `PayloadAttributes`, `ExecutionPayload` for `OpPayloadAttributes`, `OpExecutionData`
- `op-alloy-rpc-types` + `op-alloy-network`: `FromConsensusTx`, `SignableTxRequest`, `TryIntoSimTx`, `TryFromTransactionResponse`, `TryFromReceiptResponse`
- Add newtype wrappers in `reth-optimism-primitives` (`OpTx`, `OpRcpt`, etc.) for `Compact`/`Compress`/`Decompress` storage traits

## Motivation

Part of a multi-repo effort to remove `op-alloy-*` dependencies from core reth crates. Traits moved to alloy (see companion PR) are now implemented here for OP types. Newtype wrappers solve the orphan rule for reth-specific storage traits.

## Test plan

- [ ] `cargo check --workspace --all-features`
- [ ] `cargo nextest run --workspace`
- [ ] Verify all 26 compact tests pass in `reth-optimism-primitives`

🤖 Generated with [Claude Code](https://claude.com/claude-code)