### PR TITLE
feat: implement alloy traits for OP types and add newtype wrappers

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -121,9 +121,8 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed1958f0294ecc05ebe7b3c9a8662a3e221c2523b7f2bcd94c7a651efbd510bf"
+version = "1.6.1"
+source = "git+https://github.com/theochap/alloy?branch=theo%2Fadd-reth-traits#008019b41da609bf1e5cf2385f85c553d2af9719"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -149,9 +148,8 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f752e99497ddc39e22d547d7dfe516af10c979405a034ed90e69b914b7dddeae"
+version = "1.6.1"
+source = "git+https://github.com/theochap/alloy?branch=theo%2Fadd-reth-traits#008019b41da609bf1e5cf2385f85c553d2af9719"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -240,9 +238,8 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "813a67f87e56b38554d18b182616ee5006e8e2bf9df96a0df8bf29dff1d52e3f"
+version = "1.6.1"
+source = "git+https://github.com/theochap/alloy?branch=theo%2Fadd-reth-traits#008019b41da609bf1e5cf2385f85c553d2af9719"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -267,9 +264,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.27.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1582933a9fc27c0953220eb4f18f6492ff577822e9a8d848890ff59f6b4f5beb"
+checksum = "d2ccfe6d724ceabd5518350cfb34f17dd3a6c3cc33579eee94d98101d3a511ff"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -289,9 +286,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "1.5.2"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05864eef929c4d28895ae4b4d8ac9c6753c4df66e873b9c8fafc8089b59c1502"
+checksum = "a59f6f520c323111650d319451de1edb1e32760029a468105b9d7b0f7c11bdf2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -330,9 +327,8 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2dd146b3de349a6ffaa4e4e319ab3a90371fb159fb0bddeb1c7bbe8b1792eff"
+version = "1.6.1"
+source = "git+https://github.com/theochap/alloy?branch=theo%2Fadd-reth-traits#008019b41da609bf1e5cf2385f85c553d2af9719"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -345,9 +341,8 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c12278ffbb8872dfba3b2f17d8ea5e8503c2df5155d9bc5ee342794bde505c3"
+version = "1.6.1"
+source = "git+https://github.com/theochap/alloy?branch=theo%2Fadd-reth-traits#008019b41da609bf1e5cf2385f85c553d2af9719"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -371,9 +366,8 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "833037c04917bc2031541a60e8249e4ab5500e24c637c1c62e95e963a655d66f"
+version = "1.6.1"
+source = "git+https://github.com/theochap/alloy?branch=theo%2Fadd-reth-traits#008019b41da609bf1e5cf2385f85c553d2af9719"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -444,9 +438,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "1.5.2"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eafa840b0afe01c889a3012bb2fde770a544f74eab2e2870303eb0a5fb869c48"
+checksum = "a3ca4c15818be7ac86208aff3a91b951d14c24e1426e66624e75f2215ba5e2cc"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -489,9 +483,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "1.5.2"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57b3a3b3e4efc9f4d30e3326b6bd6811231d16ef94837e18a802b44ca55119e6"
+checksum = "e9eb9c9371738ac47f589e40aae6e418cb5f7436ad25b87575a7f94a60ccf43b"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -533,9 +527,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "1.5.2"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12768ae6303ec764905a8a7cd472aea9072f9f9c980d18151e26913da8ae0123"
+checksum = "abe0addad5b8197e851062b49dc47157444bced173b601d91e3f9b561a060a50"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -559,9 +553,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "1.5.2"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0622d8bcac2f16727590aa33f4c3f05ea98130e7e4b4924bce8be85da5ad0dae"
+checksum = "74d17d4645a717f0527e491f44f6f7a75c221b9c00ccf79ddba2d26c8e0df4c3"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-debug",
@@ -573,9 +567,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-admin"
-version = "1.5.2"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c38c5ac70457ecc74e87fe1a5a19f936419224ded0eb0636241452412ca92733"
+checksum = "ded79e60d8fd0d7c851044f8b2f2dd7fa8dfa467c577d620595d4de3c31eff7e"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -585,9 +579,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "1.5.2"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae8eb0e5d6c48941b61ab76fabab4af66f7d88309a98aa14ad3dec7911c1eba3"
+checksum = "2593ce5e1fd416e3b094e7671ef361f22e6944545e0e62ee309b6dfbd702225d"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -597,9 +591,8 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1cf5a093e437dfd62df48e480f24e1a3807632358aad6816d7a52875f1c04aa"
+version = "1.6.1"
+source = "git+https://github.com/theochap/alloy?branch=theo%2Fadd-reth-traits#008019b41da609bf1e5cf2385f85c553d2af9719"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -608,9 +601,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-beacon"
-version = "1.5.2"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e07949e912479ef3b848e1cf8db54b534bdd7bc58e6c23f28ea9488960990c8c"
+checksum = "3a647a4e3acf49182135c2333d6f9b11ab8684559ff43ef1958ed762cfe9fe0e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -628,9 +621,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "1.5.2"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "925ff0f48c2169c050f0ae7a82769bdf3f45723d6742ebb6a5efb4ed2f491b26"
+checksum = "2a1dd760b6a798ee045ab6a7bbd1a02ad8bd6a64d8e18d6e41732f4fc4a4fe5c"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -640,9 +633,8 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "336ef381c7409f23c69f6e79bddc1917b6e832cff23e7a5cf84b9381d53582e6"
+version = "1.6.1"
+source = "git+https://github.com/theochap/alloy?branch=theo%2Fadd-reth-traits#008019b41da609bf1e5cf2385f85c553d2af9719"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -661,9 +653,8 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28e97603095020543a019ab133e0e3dc38cd0819f19f19bdd70c642404a54751"
+version = "1.6.1"
+source = "git+https://github.com/theochap/alloy?branch=theo%2Fadd-reth-traits#008019b41da609bf1e5cf2385f85c553d2af9719"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -683,9 +674,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-mev"
-version = "1.5.2"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2805153975e25d38e37ee100880e642d5b24e421ed3014a7d2dae1d9be77562e"
+checksum = "4d4c9229424e77bd97e629fba44dbfdadebe5bfadbb1e53ad4acbc955610b6c7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -698,9 +689,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "1.5.2"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1aec4e1c66505d067933ea1a949a4fb60a19c4cfc2f109aa65873ea99e62ea8"
+checksum = "410a80e9ac786a2d885adfd7da3568e8f392da106cb5432f00eb4787689d281a"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -712,9 +703,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-txpool"
-version = "1.5.2"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25b73c1d6e4f1737a20d246dad5a0abd6c1b76ec4c3d153684ef8c6f1b6bb4f4"
+checksum = "3a8074654c0292783d504bfa1f2691a69f420154ee9a7883f9212eaf611e60cd"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -724,9 +715,8 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "946a0d413dbb5cd9adba0de5f8a1a34d5b77deda9b69c1d7feed8fc875a1aa26"
+version = "1.6.1"
+source = "git+https://github.com/theochap/alloy?branch=theo%2Fadd-reth-traits#008019b41da609bf1e5cf2385f85c553d2af9719"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -736,9 +726,8 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f7481dc8316768f042495eaf305d450c32defbc9bce09d8bf28afcd956895bb"
+version = "1.6.1"
+source = "git+https://github.com/theochap/alloy?branch=theo%2Fadd-reth-traits#008019b41da609bf1e5cf2385f85c553d2af9719"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -751,9 +740,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "1.5.2"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1259dac1f534a4c66c1d65237c89915d0010a2a91d6c3b0bada24dc5ee0fb917"
+checksum = "c28bd71507db58477151a6fe6988fa62a4b778df0f166c3e3e1ef11d059fe5fa"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -840,9 +829,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "1.5.2"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78f169b85eb9334871db986e7eaf59c58a03d86a30cc68b846573d47ed0656bb"
+checksum = "b321f506bd67a434aae8e8a7dfe5373bf66137c149a5f09c9e7dfb0ca43d7c91"
 dependencies = [
  "alloy-json-rpc",
  "auto_impl",
@@ -863,9 +852,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "1.5.2"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "019821102e70603e2c141954418255bec539ef64ac4117f8e84fb493769acf73"
+checksum = "30bf12879a20e1261cd39c3b101856f52d18886907a826e102538897f0d2b66e"
 dependencies = [
  "alloy-json-rpc",
  "alloy-rpc-types-engine",
@@ -884,9 +873,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "1.5.2"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e574ca2f490fb5961d2cdd78188897392c46615cd88b35c202d34bbc31571a81"
+checksum = "b75f2334d400249e9672a1ec402536bab259e27a66201a94c3c9b3f1d3bae241"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -904,9 +893,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "1.5.2"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b92dea6996269769f74ae56475570e3586910661e037b7b52d50c9641f76c68f"
+checksum = "527a0d9c8bbc5c3215b03ad465d4ae8775384ff5faec7c41f033f087c851a9f9"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -921,9 +910,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-trie"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "428aa0f0e0658ff091f8f667c406e034b431cb10abd39de4f507520968acc499"
+checksum = "4d7fd448ab0a017de542de1dcca7a58e7019fe0e7a34ed3f9543ebddf6aceffa"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -933,17 +922,17 @@ dependencies = [
  "derive_more",
  "nybbles",
  "proptest",
- "proptest-derive 0.5.1",
+ "proptest-derive 0.7.0",
  "serde",
  "smallvec",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
 [[package]]
 name = "alloy-tx-macros"
-version = "1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45ceac797eb8a56bdf5ab1fab353072c17d472eab87645ca847afe720db3246d"
+version = "1.6.1"
+source = "git+https://github.com/theochap/alloy?branch=theo%2Fadd-reth-traits#008019b41da609bf1e5cf2385f85c553d2af9719"
 dependencies = [
  "darling 0.21.3",
  "proc-macro2",
@@ -1030,9 +1019,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
 name = "aquamarine"
@@ -2434,9 +2423,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.56"
+version = "4.5.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75ca66430e33a14957acc24c5077b503e7d374151b2b4b3a10c83b4ceb4be0e"
+checksum = "6899ea499e3fb9305a65d5ebf6e3d2248c5fab291f300ad0a704fbe142eae31a"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -2444,9 +2433,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.56"
+version = "4.5.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793207c7fa6300a0608d1080b858e5fdbe713cdc1c8db9fb17777d8a13e63df0"
+checksum = "7b12c8b680195a62a8364d16b8447b01b6c2c8f9aaf68bee653be34d4245e238"
 dependencies = [
  "anstream",
  "anstyle",
@@ -3113,7 +3102,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3946,9 +3935,9 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b375d6465b98090a5f25b1c7703f3859783755aa9a80433b36e0379a3ec2f369"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide 0.8.9",
@@ -4628,9 +4617,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "httpmock"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "511f510e9b1888d67f10bab4397f8b019d2a9b249a2c10acbce2d705b1b32e26"
+checksum = "bf4888a4d02d8e1f92ffb6b4965cf5ff56dda36ef41975f41c6fa0f6bde78c4e"
 dependencies = [
  "assert-json-diff",
  "async-object-pool",
@@ -4721,7 +4710,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.5",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -5116,9 +5105,9 @@ dependencies = [
 
 [[package]]
 name = "interprocess"
-version = "2.2.3"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d941b405bd2322993887859a8ee6ac9134945a24ec5ec763a8a962fc64dfec2d"
+checksum = "7b00d05442c2106c75b7410f820b152f61ec0edc7befcb9b381b673a20314753"
 dependencies = [
  "doctest-file",
  "futures-core",
@@ -7125,6 +7114,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dae608c151f68243f2b000364e1f7b186d9c29845f7d2d85bd31b9ad77ad552b"
+
+[[package]]
 name = "macro-string"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7262,13 +7257,13 @@ dependencies = [
 
 [[package]]
 name = "metrics-process"
-version = "2.4.2"
+version = "2.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f615e08e049bd14a44c4425415782efb9bcd479fc1e19ddeb971509074c060d0"
+checksum = "4268d87f64a752f5a651314fc683f04da10be65701ea3e721ba4d74f79163cac"
 dependencies = [
  "libc",
  "libproc",
- "mach2",
+ "mach2 0.6.0",
  "metrics",
  "once_cell",
  "procfs 0.18.0",
@@ -7800,9 +7795,9 @@ dependencies = [
 
 [[package]]
 name = "nybbles"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5676b5c379cf5b03da1df2b3061c4a4e2aa691086a56ac923e08c143f53f59"
+checksum = "0d49ff0c0d00d4a502b39df9af3a525e1efeb14b9dabb5bb83335284c1309210"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -7934,6 +7929,7 @@ version = "0.23.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
+ "alloy-network",
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -8395,9 +8391,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.5"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9eb05c21a464ea704b53158d358a31e6425db2f63a1a7312268b05fe2b75f7"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -8789,9 +8785,9 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee689443a2bd0a16ab0348b52ee43e3b2d1b1f931c8aa5c9f8de4c86fbe8c40"
+checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
 dependencies = [
  "bit-set",
  "bit-vec",
@@ -8818,9 +8814,9 @@ dependencies = [
 
 [[package]]
 name = "proptest-derive"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee1c9ac207483d5e7db4940700de86a9aae46ef90c48b57f99fe7edb8345e49"
+checksum = "095a99f75c69734802359b682be8daaf8980296731f6470434ea2c652af1dd30"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8829,9 +8825,9 @@ dependencies = [
 
 [[package]]
 name = "proptest-derive"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "095a99f75c69734802359b682be8daaf8980296731f6470434ea2c652af1dd30"
+checksum = "fb6dc647500e84a25a85b100e76c85b8ace114c209432dc174f20aac11d4ed6c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9125,9 +9121,9 @@ dependencies = [
 
 [[package]]
 name = "rapidhash"
-version = "4.2.1"
+version = "4.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d8b5b858a440a0bc02625b62dd95131b9201aa9f69f411195dd4a7cfb1de3d7"
+checksum = "71ec30b38a417407efe7676bad0ca6b78f995f810185ece9af3bd5dc561185a9"
 dependencies = [
  "rand 0.9.2",
  "rustversion",
@@ -9264,9 +9260,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -9276,9 +9272,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -9287,9 +9283,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "regress"
@@ -9356,7 +9352,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 1.0.5",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -12851,9 +12847,9 @@ dependencies = [
 
 [[package]]
 name = "rlimit"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7043b63bd0cd1aaa628e476b80e6d4023a3b50eb32789f2728908107bd0c793a"
+checksum = "f35ee2729c56bb610f6dba436bf78135f728b7373bdffae2ec815b2d3eb98cc3"
 dependencies = [
  "libc",
 ]
@@ -14863,7 +14859,7 @@ dependencies = [
  "cfg-if",
  "itoa",
  "libc",
- "mach2",
+ "mach2 0.5.0",
  "memmap2",
  "smallvec",
  "tracing-core",
@@ -15431,14 +15427,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
 dependencies = [
- "webpki-root-certs 1.0.5",
+ "webpki-root-certs 1.0.6",
 ]
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36a29fc0408b113f68cf32637857ab740edfafdf460c326cd2afaa2d84cc05dc"
+checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -15449,14 +15445,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.5",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12bed680863276c63889429bfd6cab3b99943659923822de1c8a39c49e4d722c"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -16185,18 +16181,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.37"
+version = "0.8.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7456cf00f0685ad319c5b1693f291a650eaf345e941d082fc4e03df8a03996ac"
+checksum = "57cf3aa6855b23711ee9852dfc97dfaa51c45feaba5b645d0c777414d494a961"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.37"
+version = "0.8.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1328722bbf2115db7e19d69ebcc15e795719e2d66b60827c6a69a117365e37a0"
+checksum = "8a616990af1a287837c4fe6596ad77ef57948f787e46ce28e166facc0cc1cb75"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -665,3 +665,16 @@ op-alloy-rpc-types = { path = "op-alloy/crates/rpc-types" }
 op-alloy = { path = "op-alloy/crates/op-alloy" }
 # Duplicated by: alloy-evm (crates.io)
 alloy-op-hardforks = { path = "alloy-op-hardforks/" }
+# alloy crates with new traits (InMemorySize, SignedTransaction, etc.)
+# PR: https://github.com/alloy-rs/alloy/pull/3649
+alloy-consensus = { git = "https://github.com/theochap/alloy", branch = "theo/add-reth-traits" }
+alloy-rpc-types-engine = { git = "https://github.com/theochap/alloy", branch = "theo/add-reth-traits" }
+alloy-network = { git = "https://github.com/theochap/alloy", branch = "theo/add-reth-traits" }
+alloy-eips = { git = "https://github.com/theochap/alloy", branch = "theo/add-reth-traits" }
+alloy-serde = { git = "https://github.com/theochap/alloy", branch = "theo/add-reth-traits" }
+alloy-json-rpc = { git = "https://github.com/theochap/alloy", branch = "theo/add-reth-traits" }
+alloy-network-primitives = { git = "https://github.com/theochap/alloy", branch = "theo/add-reth-traits" }
+alloy-rpc-types-eth = { git = "https://github.com/theochap/alloy", branch = "theo/add-reth-traits" }
+alloy-signer = { git = "https://github.com/theochap/alloy", branch = "theo/add-reth-traits" }
+alloy-consensus-any = { git = "https://github.com/theochap/alloy", branch = "theo/add-reth-traits" }
+alloy-rpc-types-any = { git = "https://github.com/theochap/alloy", branch = "theo/add-reth-traits" }

--- a/rust/op-alloy/crates/consensus/src/alloy_traits.rs
+++ b/rust/op-alloy/crates/consensus/src/alloy_traits.rs
@@ -1,0 +1,113 @@
+//! Implementations of alloy-consensus traits for OP consensus types.
+//!
+//! This module provides implementations of [`InMemorySize`], [`SignedTransaction`],
+//! and [`SerdeBincodeCompat`] for Optimism consensus types.
+
+use alloy_consensus::size::InMemorySize;
+
+// ===== InMemorySize implementations =====
+
+impl InMemorySize for crate::OpTxType {
+    fn size(&self) -> usize {
+        core::mem::size_of::<Self>()
+    }
+}
+
+impl InMemorySize for crate::TxDeposit {
+    fn size(&self) -> usize {
+        self.size()
+    }
+}
+
+impl InMemorySize for crate::OpDepositReceipt {
+    fn size(&self) -> usize {
+        let Self { inner, deposit_nonce, deposit_receipt_version } = self;
+        inner.size() +
+            core::mem::size_of_val(deposit_nonce) +
+            core::mem::size_of_val(deposit_receipt_version)
+    }
+}
+
+impl InMemorySize for crate::OpReceipt {
+    fn size(&self) -> usize {
+        match self {
+            Self::Legacy(receipt) |
+            Self::Eip2930(receipt) |
+            Self::Eip1559(receipt) |
+            Self::Eip7702(receipt) => receipt.size(),
+            Self::Deposit(receipt) => receipt.size(),
+        }
+    }
+}
+
+impl InMemorySize for crate::OpTypedTransaction {
+    fn size(&self) -> usize {
+        match self {
+            Self::Legacy(tx) => tx.size(),
+            Self::Eip2930(tx) => tx.size(),
+            Self::Eip1559(tx) => tx.size(),
+            Self::Eip7702(tx) => tx.size(),
+            Self::Deposit(tx) => tx.size(),
+        }
+    }
+}
+
+impl InMemorySize for crate::OpPooledTransaction {
+    fn size(&self) -> usize {
+        match self {
+            Self::Legacy(tx) => tx.size(),
+            Self::Eip2930(tx) => tx.size(),
+            Self::Eip1559(tx) => tx.size(),
+            Self::Eip7702(tx) => tx.size(),
+        }
+    }
+}
+
+impl InMemorySize for crate::OpTxEnvelope {
+    fn size(&self) -> usize {
+        match self {
+            Self::Legacy(tx) => tx.size(),
+            Self::Eip2930(tx) => tx.size(),
+            Self::Eip1559(tx) => tx.size(),
+            Self::Eip7702(tx) => tx.size(),
+            Self::Deposit(tx) => tx.size(),
+        }
+    }
+}
+
+// ===== SignedTransaction implementations =====
+
+#[cfg(feature = "k256")]
+impl alloy_consensus::SignedTransaction for crate::OpTxEnvelope {}
+
+#[cfg(feature = "k256")]
+impl alloy_consensus::SignedTransaction for crate::OpPooledTransaction {}
+
+// ===== SerdeBincodeCompat implementations =====
+
+#[cfg(all(feature = "serde", feature = "serde-bincode-compat"))]
+impl alloy_consensus::SerdeBincodeCompat for crate::OpTxEnvelope {
+    type BincodeRepr<'a> =
+        crate::serde_bincode_compat::transaction::OpTxEnvelope<'a>;
+
+    fn as_repr(&self) -> Self::BincodeRepr<'_> {
+        self.into()
+    }
+
+    fn from_repr(repr: Self::BincodeRepr<'_>) -> Self {
+        repr.into()
+    }
+}
+
+#[cfg(all(feature = "serde", feature = "serde-bincode-compat"))]
+impl alloy_consensus::SerdeBincodeCompat for crate::OpReceipt {
+    type BincodeRepr<'a> = crate::serde_bincode_compat::OpReceipt<'a>;
+
+    fn as_repr(&self) -> Self::BincodeRepr<'_> {
+        self.into()
+    }
+
+    fn from_repr(repr: Self::BincodeRepr<'_>) -> Self {
+        repr.into()
+    }
+}

--- a/rust/op-alloy/crates/consensus/src/lib.rs
+++ b/rust/op-alloy/crates/consensus/src/lib.rs
@@ -12,6 +12,8 @@ extern crate alloc;
 #[cfg(feature = "alloy-compat")]
 mod alloy_compat;
 
+mod alloy_traits;
+
 mod receipts;
 pub use receipts::{
     OpDepositReceipt, OpDepositReceiptWithBloom, OpReceipt, OpReceiptEnvelope, OpTxReceipt,

--- a/rust/op-alloy/crates/network/Cargo.toml
+++ b/rust/op-alloy/crates/network/Cargo.toml
@@ -17,7 +17,7 @@ workspace = true
 [dependencies]
 # Workspace
 op-alloy-consensus = { workspace = true, features = ["alloy-compat"] }
-op-alloy-rpc-types.workspace = true
+op-alloy-rpc-types = { workspace = true, features = ["alloy-compat"] }
 
 # Alloy
 alloy-consensus.workspace = true

--- a/rust/op-alloy/crates/network/src/alloy_traits.rs
+++ b/rust/op-alloy/crates/network/src/alloy_traits.rs
@@ -1,0 +1,36 @@
+//! Implementations of alloy-network conversion traits for OP network types.
+//!
+//! Only traits that use [`Optimism`] (a local type) can be implemented here
+//! due to the orphan rule. The remaining conversion trait impls
+//! ([`FromConsensusTx`], [`TryIntoSimTx`], [`SignableTxRequest`])
+//! live in `op-alloy-rpc-types` behind the `alloy-compat` feature.
+
+use alloy_network::convert::{TryFromReceiptResponse, TryFromTransactionResponse};
+use op_alloy_consensus::OpTxEnvelope;
+use std::convert::Infallible;
+
+use crate::Optimism;
+
+// ===== TryFromTransactionResponse =====
+
+impl TryFromTransactionResponse<Optimism> for OpTxEnvelope {
+    type Error = Infallible;
+
+    fn from_transaction_response(
+        transaction_response: op_alloy_rpc_types::Transaction,
+    ) -> Result<Self, Self::Error> {
+        Ok(transaction_response.inner.into_inner())
+    }
+}
+
+// ===== TryFromReceiptResponse =====
+
+impl TryFromReceiptResponse<Optimism> for op_alloy_consensus::OpReceipt {
+    type Error = Infallible;
+
+    fn from_receipt_response(
+        receipt_response: op_alloy_rpc_types::OpTransactionReceipt,
+    ) -> Result<Self, Self::Error> {
+        Ok(receipt_response.inner.inner.into_components().0.map_logs(Into::into))
+    }
+}

--- a/rust/op-alloy/crates/network/src/lib.rs
+++ b/rust/op-alloy/crates/network/src/lib.rs
@@ -8,6 +8,8 @@
 
 pub use alloy_network::*;
 
+mod alloy_traits;
+
 use alloy_consensus::{ReceiptWithBloom, TxEnvelope, TxType, TypedTransaction};
 use alloy_primitives::{Address, Bytes, ChainId, TxKind, U256};
 use alloy_rpc_types_eth::AccessList;

--- a/rust/op-alloy/crates/rpc-types-engine/src/alloy_traits.rs
+++ b/rust/op-alloy/crates/rpc-types-engine/src/alloy_traits.rs
@@ -1,0 +1,60 @@
+//! Implementations of alloy-rpc-types-engine traits for OP engine types.
+
+use alloc::vec::Vec;
+use alloy_eips::eip4895::Withdrawal;
+use alloy_primitives::{B256, Bytes};
+use alloy_rpc_types_engine::traits::{
+    ExecutionPayload as ExecutionPayloadTrait, PayloadAttributes as PayloadAttributesTrait,
+};
+
+impl PayloadAttributesTrait for crate::OpPayloadAttributes {
+    fn timestamp(&self) -> u64 {
+        self.payload_attributes.timestamp
+    }
+
+    fn withdrawals(&self) -> Option<&Vec<Withdrawal>> {
+        self.payload_attributes.withdrawals.as_ref()
+    }
+
+    fn parent_beacon_block_root(&self) -> Option<B256> {
+        self.payload_attributes.parent_beacon_block_root
+    }
+}
+
+impl ExecutionPayloadTrait for crate::OpExecutionData {
+    fn parent_hash(&self) -> B256 {
+        self.parent_hash()
+    }
+
+    fn block_hash(&self) -> B256 {
+        self.block_hash()
+    }
+
+    fn block_number(&self) -> u64 {
+        self.block_number()
+    }
+
+    fn withdrawals(&self) -> Option<&Vec<Withdrawal>> {
+        self.payload.as_v2().map(|p| &p.withdrawals)
+    }
+
+    fn block_access_list(&self) -> Option<&Bytes> {
+        None
+    }
+
+    fn parent_beacon_block_root(&self) -> Option<B256> {
+        self.sidecar.parent_beacon_block_root()
+    }
+
+    fn timestamp(&self) -> u64 {
+        self.payload.as_v1().timestamp
+    }
+
+    fn gas_used(&self) -> u64 {
+        self.payload.as_v1().gas_used
+    }
+
+    fn transaction_count(&self) -> usize {
+        self.payload.as_v1().transactions.len()
+    }
+}

--- a/rust/op-alloy/crates/rpc-types-engine/src/lib.rs
+++ b/rust/op-alloy/crates/rpc-types-engine/src/lib.rs
@@ -11,6 +11,9 @@ extern crate alloc;
 
 pub use alloy_rpc_types_engine::ForkchoiceUpdateVersion;
 
+#[cfg(feature = "serde")]
+mod alloy_traits;
+
 mod attributes;
 pub use attributes::OpPayloadAttributes;
 

--- a/rust/op-alloy/crates/rpc-types/Cargo.toml
+++ b/rust/op-alloy/crates/rpc-types/Cargo.toml
@@ -22,6 +22,7 @@ op-alloy-consensus = { workspace = true, features = ["serde"] }
 alloy-serde.workspace = true
 alloy-consensus.workspace = true
 alloy-network-primitives.workspace = true
+alloy-network = { workspace = true, optional = true }
 alloy-eips = { workspace = true, features = ["serde"] }
 alloy-rpc-types-eth = { workspace = true, features = ["serde"] }
 alloy-primitives = { workspace = true, features = ["map", "rlp", "serde"] }
@@ -73,6 +74,7 @@ arbitrary = [
 	"alloy-eips/arbitrary",
 	"alloy-serde/arbitrary"
 ]
+alloy-compat = ["dep:alloy-network"]
 k256 = ["alloy-rpc-types-eth/k256", "op-alloy-consensus/k256"]
 serde = [
 	"op-alloy-consensus/serde",

--- a/rust/op-alloy/crates/rpc-types/src/alloy_traits.rs
+++ b/rust/op-alloy/crates/rpc-types/src/alloy_traits.rs
@@ -1,0 +1,70 @@
+//! Implementations of alloy-network conversion traits for OP RPC types.
+//!
+//! These impls are gated behind the `alloy-compat` feature because they
+//! require `alloy-network` and `alloy-signer` dependencies.
+
+use alloy_consensus::{
+    SignableTransaction, error::ValueError, transaction::Recovered,
+};
+use alloy_network::convert::{
+    FromConsensusTx, SignTxRequestError, SignableTxRequest, TryIntoSimTx,
+};
+use alloy_primitives::{Address, Signature};
+use op_alloy_consensus::{
+    OpTransaction, OpTxEnvelope,
+    transaction::OpTransactionInfo,
+};
+use std::convert::Infallible;
+
+use crate::{OpTransactionRequest, Transaction};
+
+// ===== FromConsensusTx =====
+
+impl<T: OpTransaction + alloy_consensus::Transaction> FromConsensusTx<T> for Transaction<T> {
+    type TxInfo = OpTransactionInfo;
+    type Err = Infallible;
+
+    fn from_consensus_tx(
+        tx: T,
+        signer: Address,
+        tx_info: Self::TxInfo,
+    ) -> Result<Self, Self::Err> {
+        Ok(Self::from_transaction(Recovered::new_unchecked(tx, signer), tx_info))
+    }
+}
+
+// ===== TryIntoSimTx =====
+
+impl TryIntoSimTx<OpTxEnvelope> for OpTransactionRequest {
+    fn try_into_sim_tx(self) -> Result<OpTxEnvelope, ValueError<Self>> {
+        let tx = self
+            .build_typed_tx()
+            .map_err(|request| ValueError::new(request, "Required fields missing"))?;
+
+        // Create an empty signature for the transaction.
+        let signature = Signature::new(Default::default(), Default::default(), false);
+
+        Ok(tx.into_signed(signature).into())
+    }
+}
+
+// ===== SignableTxRequest =====
+
+impl SignableTxRequest<OpTxEnvelope> for OpTransactionRequest {
+    async fn try_build_and_sign(
+        self,
+        signer: impl alloy_network::TxSigner<Signature> + Send,
+    ) -> Result<OpTxEnvelope, SignTxRequestError> {
+        let mut tx =
+            self.build_typed_tx().map_err(|_| SignTxRequestError::InvalidTransactionRequest)?;
+
+        // sanity check: deposit transactions must not be signed by the user
+        if tx.is_deposit() {
+            return Err(SignTxRequestError::InvalidTransactionRequest);
+        }
+
+        let signature = signer.sign_transaction(&mut tx).await?;
+
+        Ok(tx.into_signed(signature).into())
+    }
+}

--- a/rust/op-alloy/crates/rpc-types/src/lib.rs
+++ b/rust/op-alloy/crates/rpc-types/src/lib.rs
@@ -9,6 +9,9 @@
 
 extern crate alloc;
 
+#[cfg(feature = "alloy-compat")]
+mod alloy_traits;
+
 mod genesis;
 pub use genesis::{OpBaseFeeInfo, OpChainInfo, OpGenesisInfo};
 

--- a/rust/op-reth/crates/primitives/Cargo.toml
+++ b/rust/op-reth/crates/primitives/Cargo.toml
@@ -14,6 +14,8 @@ workspace = true
 [dependencies]
 # reth
 reth-primitives-traits = { workspace = true, features = ["op"] }
+reth-codecs = { workspace = true, optional = true, features = ["op"] }
+reth-zstd-compressors = { workspace = true, optional = true }
 
 # ethereum
 alloy-primitives.workspace = true
@@ -25,8 +27,13 @@ alloy-rlp.workspace = true
 op-alloy-consensus.workspace = true
 
 # codec
+bytes = { workspace = true, optional = true }
+modular-bitfield = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 serde_with = { workspace = true, optional = true }
+
+# misc
+arbitrary = { workspace = true, optional = true }
 
 [dev-dependencies]
 reth-codecs = { workspace = true, features = ["test-utils", "op"] }
@@ -63,6 +70,10 @@ std = [
 alloy-compat = ["op-alloy-consensus/alloy-compat"]
 reth-codec = [
     "std",
+    "dep:reth-codecs",
+    "dep:reth-zstd-compressors",
+    "dep:bytes",
+    "dep:modular-bitfield",
     "reth-primitives-traits/reth-codec",
 ]
 serde = [
@@ -87,6 +98,7 @@ serde-bincode-compat = [
 ]
 arbitrary = [
     "std",
+    "dep:arbitrary",
     "reth-primitives-traits/arbitrary",
     "op-alloy-consensus/arbitrary",
     "alloy-consensus/arbitrary",

--- a/rust/op-reth/crates/primitives/src/compact.rs
+++ b/rust/op-reth/crates/primitives/src/compact.rs
@@ -1,0 +1,11 @@
+//! Compact codec implementations for Optimism types.
+//!
+//! This module provides newtype wrappers around `op-alloy-consensus` types
+//! and implements the `reth-codecs` `Compact` trait for them.
+//!
+//! These wrappers exist to satisfy the Rust orphan rule: neither `Compact` (from `reth-codecs`)
+//! nor the OP types (from `op-alloy-consensus`) are defined in this crate, so we need local
+//! newtypes to implement the trait.
+
+pub mod receipt;
+pub mod transaction;

--- a/rust/op-reth/crates/primitives/src/compact/receipt.rs
+++ b/rust/op-reth/crates/primitives/src/compact/receipt.rs
@@ -1,0 +1,128 @@
+//! Compact codec implementations for OP receipt types.
+
+use alloc::{borrow::Cow, vec::Vec};
+use alloy_consensus::{Receipt, TxReceipt};
+use alloy_primitives::Log;
+use core::ops::{Deref, DerefMut};
+use op_alloy_consensus::{OpDepositReceipt, OpReceipt, OpTxType};
+use reth_codecs::{Compact, CompactZstd};
+
+/// Compressed representation of an [`OpReceipt`] for storage.
+#[derive(CompactZstd)]
+#[reth_codecs(crate = "reth_codecs")]
+#[reth_zstd(
+    compressor = reth_zstd_compressors::RECEIPT_COMPRESSOR,
+    decompressor = reth_zstd_compressors::RECEIPT_DECOMPRESSOR
+)]
+struct CompactOpReceipt<'a> {
+    tx_type: OpTxType,
+    success: bool,
+    cumulative_gas_used: u64,
+    #[expect(clippy::owned_cow)]
+    logs: Cow<'a, Vec<Log>>,
+    deposit_nonce: Option<u64>,
+    deposit_receipt_version: Option<u64>,
+}
+
+impl<'a> From<&'a OpReceipt> for CompactOpReceipt<'a> {
+    fn from(receipt: &'a OpReceipt) -> Self {
+        Self {
+            tx_type: receipt.tx_type(),
+            success: receipt.status(),
+            cumulative_gas_used: receipt.cumulative_gas_used(),
+            logs: Cow::Borrowed(&receipt.as_receipt().logs),
+            deposit_nonce: if let OpReceipt::Deposit(receipt) = receipt {
+                receipt.deposit_nonce
+            } else {
+                None
+            },
+            deposit_receipt_version: if let OpReceipt::Deposit(receipt) = receipt {
+                receipt.deposit_receipt_version
+            } else {
+                None
+            },
+        }
+    }
+}
+
+impl From<CompactOpReceipt<'_>> for OpReceipt {
+    fn from(receipt: CompactOpReceipt<'_>) -> Self {
+        let CompactOpReceipt {
+            tx_type,
+            success,
+            cumulative_gas_used,
+            logs,
+            deposit_nonce,
+            deposit_receipt_version,
+        } = receipt;
+
+        let inner =
+            Receipt { status: success.into(), cumulative_gas_used, logs: logs.into_owned() };
+
+        match tx_type {
+            OpTxType::Legacy => Self::Legacy(inner),
+            OpTxType::Eip2930 => Self::Eip2930(inner),
+            OpTxType::Eip1559 => Self::Eip1559(inner),
+            OpTxType::Eip7702 => Self::Eip7702(inner),
+            OpTxType::Deposit => {
+                Self::Deposit(OpDepositReceipt { inner, deposit_nonce, deposit_receipt_version })
+            }
+        }
+    }
+}
+
+/// Newtype wrapper around [`OpReceipt`] for `Compact` implementation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct OpRcpt(pub OpReceipt);
+
+impl Deref for OpRcpt {
+    type Target = OpReceipt;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for OpRcpt {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl From<OpReceipt> for OpRcpt {
+    fn from(receipt: OpReceipt) -> Self {
+        Self(receipt)
+    }
+}
+
+impl From<OpRcpt> for OpReceipt {
+    fn from(receipt: OpRcpt) -> Self {
+        receipt.0
+    }
+}
+
+impl Compact for OpRcpt {
+    fn to_compact<B>(&self, buf: &mut B) -> usize
+    where
+        B: bytes::BufMut + AsMut<[u8]>,
+    {
+        CompactOpReceipt::from(&self.0).to_compact(buf)
+    }
+
+    fn from_compact(buf: &[u8], len: usize) -> (Self, &[u8]) {
+        let (receipt, buf) = CompactOpReceipt::from_compact(buf, len);
+        (Self(receipt.into()), buf)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reth_codecs::{test_utils::UnusedBits, validate_bitflag_backwards_compat};
+
+    #[test]
+    fn test_ensure_backwards_compatibility() {
+        assert_eq!(CompactOpReceipt::bitflag_encoded_bytes(), 2);
+        validate_bitflag_backwards_compat!(CompactOpReceipt<'_>, UnusedBits::NotZero);
+    }
+}

--- a/rust/op-reth/crates/primitives/src/compact/transaction.rs
+++ b/rust/op-reth/crates/primitives/src/compact/transaction.rs
@@ -1,0 +1,446 @@
+//! Compact codec implementations for OP transaction types.
+//!
+//! This module provides newtype wrappers around `op-alloy-consensus` transaction types
+//! with `Compact` trait implementations for database storage.
+
+use alloc::vec::Vec;
+use alloy_consensus::{
+    Transaction, constants::EIP7702_TX_TYPE_ID, Signed, TxEip1559, TxEip2930, TxEip7702, TxLegacy,
+};
+use alloy_primitives::{Address, Bytes, Sealed, Signature, TxKind, B256, U256};
+use bytes::{Buf, BufMut};
+use core::ops::{Deref, DerefMut};
+use op_alloy_consensus::{OpTxEnvelope, OpTypedTransaction};
+use reth_codecs::{
+    Compact,
+    txtype::{
+        COMPACT_EXTENDED_IDENTIFIER_FLAG, COMPACT_IDENTIFIER_EIP1559, COMPACT_IDENTIFIER_EIP2930,
+        COMPACT_IDENTIFIER_LEGACY,
+    },
+};
+
+// ===== TxDeposit helper for derive =====
+
+/// Deposit transactions, also known as deposits are initiated on L1, and executed on L2.
+///
+/// This is a helper type to use derive on it instead of manually managing `bitfield`.
+///
+/// By deriving `Compact` here, any future changes or enhancements to the `Compact` derive
+/// will automatically apply to this type.
+///
+/// Notice: Make sure this struct is 1:1 with [`op_alloy_consensus::TxDeposit`]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default, Compact)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[reth_codecs(crate = "reth_codecs")]
+pub(crate) struct TxDepositCompact {
+    source_hash: B256,
+    from: Address,
+    to: TxKind,
+    mint: Option<u128>,
+    value: U256,
+    gas_limit: u64,
+    is_system_transaction: bool,
+    input: Bytes,
+}
+
+// ===== OpDeposit newtype =====
+
+/// Newtype wrapper around [`op_alloy_consensus::TxDeposit`] for `Compact` implementation.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[repr(transparent)]
+pub struct OpDeposit(pub op_alloy_consensus::TxDeposit);
+
+impl Deref for OpDeposit {
+    type Target = op_alloy_consensus::TxDeposit;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for OpDeposit {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl From<op_alloy_consensus::TxDeposit> for OpDeposit {
+    fn from(tx: op_alloy_consensus::TxDeposit) -> Self {
+        Self(tx)
+    }
+}
+
+impl From<OpDeposit> for op_alloy_consensus::TxDeposit {
+    fn from(tx: OpDeposit) -> Self {
+        tx.0
+    }
+}
+
+impl Compact for OpDeposit {
+    fn to_compact<B>(&self, buf: &mut B) -> usize
+    where
+        B: bytes::BufMut + AsMut<[u8]>,
+    {
+        let tx = TxDepositCompact {
+            source_hash: self.0.source_hash,
+            from: self.0.from,
+            to: self.0.to,
+            mint: match self.0.mint {
+                0 => None,
+                v => Some(v),
+            },
+            value: self.0.value,
+            gas_limit: self.0.gas_limit,
+            is_system_transaction: self.0.is_system_transaction,
+            input: self.0.input.clone(),
+        };
+        tx.to_compact(buf)
+    }
+
+    fn from_compact(buf: &[u8], len: usize) -> (Self, &[u8]) {
+        let (tx, remaining) = TxDepositCompact::from_compact(buf, len);
+        let alloy_tx = op_alloy_consensus::TxDeposit {
+            source_hash: tx.source_hash,
+            from: tx.from,
+            to: tx.to,
+            mint: tx.mint.unwrap_or_default(),
+            value: tx.value,
+            gas_limit: tx.gas_limit,
+            is_system_transaction: tx.is_system_transaction,
+            input: tx.input,
+        };
+        (Self(alloy_tx), remaining)
+    }
+}
+
+// ===== OpTxTy newtype =====
+
+/// Newtype wrapper around [`op_alloy_consensus::OpTxType`] for `Compact` implementation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(transparent)]
+pub struct OpTxTy(pub op_alloy_consensus::OpTxType);
+
+impl Deref for OpTxTy {
+    type Target = op_alloy_consensus::OpTxType;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl From<op_alloy_consensus::OpTxType> for OpTxTy {
+    fn from(ty: op_alloy_consensus::OpTxType) -> Self {
+        Self(ty)
+    }
+}
+
+impl From<OpTxTy> for op_alloy_consensus::OpTxType {
+    fn from(ty: OpTxTy) -> Self {
+        ty.0
+    }
+}
+
+impl Compact for OpTxTy {
+    fn to_compact<B>(&self, buf: &mut B) -> usize
+    where
+        B: bytes::BufMut + AsMut<[u8]>,
+    {
+        use op_alloy_consensus::OpTxType;
+        match self.0 {
+            OpTxType::Legacy => COMPACT_IDENTIFIER_LEGACY,
+            OpTxType::Eip2930 => COMPACT_IDENTIFIER_EIP2930,
+            OpTxType::Eip1559 => COMPACT_IDENTIFIER_EIP1559,
+            OpTxType::Eip7702 => {
+                buf.put_u8(EIP7702_TX_TYPE_ID);
+                COMPACT_EXTENDED_IDENTIFIER_FLAG
+            }
+            OpTxType::Deposit => {
+                buf.put_u8(op_alloy_consensus::DEPOSIT_TX_TYPE_ID);
+                COMPACT_EXTENDED_IDENTIFIER_FLAG
+            }
+        }
+    }
+
+    fn from_compact(mut buf: &[u8], identifier: usize) -> (Self, &[u8]) {
+        use op_alloy_consensus::OpTxType;
+        (
+            Self(match identifier {
+                COMPACT_IDENTIFIER_LEGACY => OpTxType::Legacy,
+                COMPACT_IDENTIFIER_EIP2930 => OpTxType::Eip2930,
+                COMPACT_IDENTIFIER_EIP1559 => OpTxType::Eip1559,
+                COMPACT_EXTENDED_IDENTIFIER_FLAG => {
+                    let extended_identifier = buf.get_u8();
+                    match extended_identifier {
+                        EIP7702_TX_TYPE_ID => OpTxType::Eip7702,
+                        op_alloy_consensus::DEPOSIT_TX_TYPE_ID => OpTxType::Deposit,
+                        _ => panic!("Unsupported OpTxType identifier: {extended_identifier}"),
+                    }
+                }
+                _ => panic!("Unknown identifier for TxType: {identifier}"),
+            }),
+            buf,
+        )
+    }
+}
+
+// ===== OpTypedTx newtype =====
+
+/// Newtype wrapper around [`op_alloy_consensus::OpTypedTransaction`] for `Compact`
+/// implementation.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[repr(transparent)]
+pub struct OpTypedTx(pub OpTypedTransaction);
+
+impl Deref for OpTypedTx {
+    type Target = OpTypedTransaction;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for OpTypedTx {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl From<OpTypedTransaction> for OpTypedTx {
+    fn from(tx: OpTypedTransaction) -> Self {
+        Self(tx)
+    }
+}
+
+impl From<OpTypedTx> for OpTypedTransaction {
+    fn from(tx: OpTypedTx) -> Self {
+        tx.0
+    }
+}
+
+#[cfg(any(test, feature = "arbitrary"))]
+impl<'a> arbitrary::Arbitrary<'a> for OpTypedTx {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        OpTypedTransaction::arbitrary(u).map(Self)
+    }
+}
+
+impl Compact for OpTypedTx {
+    fn to_compact<B>(&self, out: &mut B) -> usize
+    where
+        B: bytes::BufMut + AsMut<[u8]>,
+    {
+        let identifier = OpTxTy(self.0.tx_type()).to_compact(out);
+        match &self.0 {
+            OpTypedTransaction::Legacy(tx) => tx.to_compact(out),
+            OpTypedTransaction::Eip2930(tx) => tx.to_compact(out),
+            OpTypedTransaction::Eip1559(tx) => tx.to_compact(out),
+            OpTypedTransaction::Eip7702(tx) => tx.to_compact(out),
+            OpTypedTransaction::Deposit(tx) => OpDeposit(tx.clone()).to_compact(out),
+        };
+        identifier
+    }
+
+    fn from_compact(buf: &[u8], identifier: usize) -> (Self, &[u8]) {
+        use op_alloy_consensus::OpTxType;
+        let (tx_type, buf) = OpTxTy::from_compact(buf, identifier);
+        match tx_type.0 {
+            OpTxType::Legacy => {
+                let (tx, buf) = Compact::from_compact(buf, buf.len());
+                (Self(OpTypedTransaction::Legacy(tx)), buf)
+            }
+            OpTxType::Eip2930 => {
+                let (tx, buf) = Compact::from_compact(buf, buf.len());
+                (Self(OpTypedTransaction::Eip2930(tx)), buf)
+            }
+            OpTxType::Eip1559 => {
+                let (tx, buf) = Compact::from_compact(buf, buf.len());
+                (Self(OpTypedTransaction::Eip1559(tx)), buf)
+            }
+            OpTxType::Eip7702 => {
+                let (tx, buf) = Compact::from_compact(buf, buf.len());
+                (Self(OpTypedTransaction::Eip7702(tx)), buf)
+            }
+            OpTxType::Deposit => {
+                let (tx, buf) = OpDeposit::from_compact(buf, buf.len());
+                (Self(OpTypedTransaction::Deposit(tx.0)), buf)
+            }
+        }
+    }
+}
+
+// ===== OpTx newtype =====
+
+/// Newtype wrapper around [`OpTxEnvelope`] for `Compact` implementation.
+///
+/// Uses the same compact encoding format as the bare `OpTxEnvelope` implementation in
+/// `reth-codecs`: a leading byte of bitflags (IsCompressed, TxType, Signature), followed
+/// by the signature and the (optionally zstd-compressed) transaction body.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct OpTx(pub OpTxEnvelope);
+
+impl Deref for OpTx {
+    type Target = OpTxEnvelope;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for OpTx {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl From<OpTxEnvelope> for OpTx {
+    fn from(tx: OpTxEnvelope) -> Self {
+        Self(tx)
+    }
+}
+
+impl From<OpTx> for OpTxEnvelope {
+    fn from(tx: OpTx) -> Self {
+        tx.0
+    }
+}
+
+const DEPOSIT_SIGNATURE: Signature = Signature::new(U256::ZERO, U256::ZERO, false);
+
+/// Returns the signature for this envelope variant.
+fn envelope_signature(tx: &OpTxEnvelope) -> &Signature {
+    match tx {
+        OpTxEnvelope::Legacy(tx) => tx.signature(),
+        OpTxEnvelope::Eip2930(tx) => tx.signature(),
+        OpTxEnvelope::Eip1559(tx) => tx.signature(),
+        OpTxEnvelope::Eip7702(tx) => tx.signature(),
+        OpTxEnvelope::Deposit(_) => &DEPOSIT_SIGNATURE,
+    }
+}
+
+/// Serializes the inner transaction body (without signature or type) using Compact encoding.
+fn tx_to_compact(tx: &OpTxEnvelope, buf: &mut (impl BufMut + AsMut<[u8]>)) {
+    match tx {
+        OpTxEnvelope::Legacy(tx) => {
+            tx.tx().to_compact(buf);
+        }
+        OpTxEnvelope::Eip2930(tx) => {
+            tx.tx().to_compact(buf);
+        }
+        OpTxEnvelope::Eip1559(tx) => {
+            tx.tx().to_compact(buf);
+        }
+        OpTxEnvelope::Eip7702(tx) => {
+            tx.tx().to_compact(buf);
+        }
+        OpTxEnvelope::Deposit(tx) => {
+            OpDeposit((**tx).clone()).to_compact(buf);
+        }
+    };
+}
+
+/// Deserializes a transaction from the given tx type, buffer and signature.
+fn tx_from_compact(
+    buf: &[u8],
+    tx_type: OpTxTy,
+    signature: Signature,
+) -> (OpTxEnvelope, &[u8]) {
+    use op_alloy_consensus::OpTxType;
+    match tx_type.0 {
+        OpTxType::Legacy => {
+            let (tx, buf) = TxLegacy::from_compact(buf, buf.len());
+            let tx = Signed::new_unhashed(tx, signature);
+            (OpTxEnvelope::Legacy(tx), buf)
+        }
+        OpTxType::Eip2930 => {
+            let (tx, buf) = TxEip2930::from_compact(buf, buf.len());
+            let tx = Signed::new_unhashed(tx, signature);
+            (OpTxEnvelope::Eip2930(tx), buf)
+        }
+        OpTxType::Eip1559 => {
+            let (tx, buf) = TxEip1559::from_compact(buf, buf.len());
+            let tx = Signed::new_unhashed(tx, signature);
+            (OpTxEnvelope::Eip1559(tx), buf)
+        }
+        OpTxType::Eip7702 => {
+            let (tx, buf) = TxEip7702::from_compact(buf, buf.len());
+            let tx = Signed::new_unhashed(tx, signature);
+            (OpTxEnvelope::Eip7702(tx), buf)
+        }
+        OpTxType::Deposit => {
+            let (tx, buf) = OpDeposit::from_compact(buf, buf.len());
+            let tx = Sealed::new(tx.0);
+            (OpTxEnvelope::Deposit(tx), buf)
+        }
+    }
+}
+
+impl Compact for OpTx {
+    fn to_compact<B>(&self, buf: &mut B) -> usize
+    where
+        B: BufMut + AsMut<[u8]>,
+    {
+        let start = buf.as_mut().len();
+
+        // Placeholder for bitflags.
+        // The first byte uses 4 bits as flags: IsCompressed[1bit], TxType[2bits], Signature[1bit]
+        buf.put_u8(0);
+
+        let sig_bit = envelope_signature(&self.0).to_compact(buf) as u8;
+        let zstd_bit = self.0.input().len() >= 32;
+
+        let tx_bits = if zstd_bit {
+            // compress the tx prefixed with txtype
+            let mut tx_buf = Vec::with_capacity(256);
+            let tx_bits = OpTxTy(OpTxEnvelope::tx_type(&self.0)).to_compact(&mut tx_buf) as u8;
+            tx_to_compact(&self.0, &mut tx_buf);
+
+            buf.put_slice(
+                &reth_zstd_compressors::TRANSACTION_COMPRESSOR.with(|compressor| {
+                    compressor.borrow_mut().compress(&tx_buf)
+                })
+                .expect("Failed to compress"),
+            );
+            tx_bits
+        } else {
+            let tx_bits =
+                OpTxTy(OpTxEnvelope::tx_type(&self.0)).to_compact(buf) as u8;
+            tx_to_compact(&self.0, buf);
+            tx_bits
+        };
+
+        let flags = sig_bit | (tx_bits << 1) | ((zstd_bit as u8) << 3);
+        buf.as_mut()[start] = flags;
+
+        buf.as_mut().len() - start
+    }
+
+    fn from_compact(mut buf: &[u8], _len: usize) -> (Self, &[u8]) {
+        let flags = buf.get_u8() as usize;
+
+        let sig_bit = flags & 1;
+        let tx_bits = (flags & 0b110) >> 1;
+        let zstd_bit = flags >> 3;
+
+        let (signature, buf) = Signature::from_compact(buf, sig_bit);
+
+        let (transaction, buf) = if zstd_bit != 0 {
+            reth_zstd_compressors::TRANSACTION_DECOMPRESSOR.with(|decompressor| {
+                let mut decompressor = decompressor.borrow_mut();
+                let decompressed = decompressor.decompress(buf);
+                let (tx_type, tx_buf) = OpTxTy::from_compact(decompressed, tx_bits);
+                let (tx, _) = tx_from_compact(tx_buf, tx_type, signature);
+                (tx, buf)
+            })
+        } else {
+            let (tx_type, buf) = OpTxTy::from_compact(buf, tx_bits);
+            tx_from_compact(buf, tx_type, signature)
+        };
+
+        (Self(transaction), buf)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reth_codecs::generate_tests;
+
+    generate_tests!(#[reth_codecs, compact] OpTypedTx, OpTypedTxTests);
+}

--- a/rust/op-reth/crates/primitives/src/lib.rs
+++ b/rust/op-reth/crates/primitives/src/lib.rs
@@ -11,6 +11,14 @@
 #![allow(unused)]
 extern crate alloc;
 
+#[cfg(feature = "reth-codec")]
+pub mod compact;
+#[cfg(feature = "reth-codec")]
+pub use compact::{
+    receipt::OpRcpt,
+    transaction::{OpDeposit, OpTx, OpTxTy, OpTypedTx},
+};
+
 pub mod bedrock;
 
 // Re-export predeploys from op-alloy-consensus


### PR DESCRIPTION
## Summary

- Implement alloy traits natively for OP types across op-alloy crates (no reth dependency needed)
- `op-alloy-consensus`: `InMemorySize`, `SignedTransaction`, `SerdeBincodeCompat` for `OpTxEnvelope`, `OpReceipt`, `OpPooledTransaction`, etc.
- `op-alloy-rpc-types-engine`: `PayloadAttributes`, `ExecutionPayload` for `OpPayloadAttributes`, `OpExecutionData`
- `op-alloy-rpc-types` + `op-alloy-network`: `FromConsensusTx`, `SignableTxRequest`, `TryIntoSimTx`, `TryFromTransactionResponse`, `TryFromReceiptResponse`
- Add newtype wrappers in `reth-optimism-primitives` (`OpTx`, `OpRcpt`, etc.) for `Compact`/`Compress`/`Decompress` storage traits

## Motivation

Part of a multi-repo effort to remove `op-alloy-*` dependencies from core reth crates. Traits moved to alloy (see companion PR) are now implemented here for OP types. Newtype wrappers solve the orphan rule for reth-specific storage traits.

## Test plan

- [ ] `cargo check --workspace --all-features`
- [ ] `cargo nextest run --workspace`
- [ ] Verify all 26 compact tests pass in `reth-optimism-primitives`

🤖 Generated with [Claude Code](https://claude.com/claude-code)