### PR TITLE
Revert "feat(op-deployer): build contracts in docker (#19088)"

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -3290,6 +3290,16 @@ workflows:
               only: /^(da-server|cannon|ufm-[a-z0-9\-]*|op-[a-z0-9\-]*)\/v.*/
             branches:
               ignore: /.*/
+      - contracts-bedrock-build:
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+          requires:
+            - initialize
+          filters:
+            tags:
+              only: /^op-deployer.*/ # ensure contract artifacts are embedded in op-deployer binary
+            branches:
+              ignore: /.*/
       - docker-build:
           matrix:
             parameters:
@@ -3309,6 +3319,7 @@ workflows:
             - oplabs-gcr-release
           requires:
             - initialize
+            - contracts-bedrock-build
       - check-cross-platform:
           matrix:
             parameters:

--- a/op-deployer/justfile
+++ b/op-deployer/justfile
@@ -27,7 +27,7 @@ _LDFLAGSSTRING := "'" + trim(
 
 build-go: (go_build "./bin/op-deployer" "./cmd/op-deployer" "-ldflags" _LDFLAGSSTRING)
 
-docker-build:
+docker-build: build-contracts copy-contract-artifacts
     #!/bin/bash
     cd ..
     export GIT_VERSION="untagged"

--- a/ops/docker/op-stack-go/Dockerfile
+++ b/ops/docker/op-stack-go/Dockerfile
@@ -178,18 +178,10 @@ RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache
 
 FROM --platform=$BUILDPLATFORM builder AS op-deployer-builder
 ARG OP_DEPLOYER_VERSION=v0.0.0
-ARG REPO_URL=https://github.com/ethereum-optimism/optimism.git
 COPY --from=builder_foundry /usr/local/bin/forge /usr/local/bin/forge
-# Initialize submodules for contracts build. We fetch the tree (without blobs) to get
-# submodule commit SHAs, then clone each submodule at its pinned version.
-RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build \
-  git init && \
-  git remote add origin $REPO_URL && \
-  git fetch --depth 1 --filter=blob:none origin "$GIT_COMMIT" && \
-  git checkout FETCH_HEAD -- packages/contracts-bedrock/lib && \
-  git submodule update --init --recursive --depth 1 -j 8 packages/contracts-bedrock/lib && \
+RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build just \
   GOOS=$TARGETOS GOARCH=$TARGETARCH GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE VERSION="$OP_DEPLOYER_VERSION" \
-  just op-deployer/build
+  op-deployer/build-go
 
 FROM --platform=$BUILDPLATFORM builder AS op-dripper-builder
 ARG OP_DRIPPER_VERSION=v0.0.0

--- a/ops/docker/op-stack-go/Dockerfile.dockerignore
+++ b/ops/docker/op-stack-go/Dockerfile.dockerignore
@@ -2,7 +2,6 @@
 # node_modules, packages (contains git submodules and node modules etc.), devnet dirs etc. all add up a lot.
 *
 
-!/.gitmodules
 !/cannon
 !/devnet-sdk
 !/op-core
@@ -11,7 +10,7 @@
 !/op-deployer
 !/op-dripper
 !/op-challenger
-!/packages/contracts-bedrock
+!/packages/contracts-bedrock/snapshots
 !/op-dispute-mon
 !/op-conductor
 !/op-node
@@ -42,7 +41,6 @@ kona/.git
 **/bin
 **/testdata
 **/tests
-packages/contracts-bedrock/lib/
 
 # Re-include kona/bin which is excluded by **/bin above
 !/kona/bin


### PR DESCRIPTION
This reverts commit 513eca1766d7a9746ab66eaf6990d0daf8b17795.

The op-deployer-docker-build job is failing after this change. https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/115293/workflows/64dc64bd-7aaf-479e-90bd-e9dbddf1b689/jobs/4386901