### PR TITLE
op-acceptance: Add test for next super root not being available.

### DIFF
--- a/op-acceptance-tests/tests/interop/proofs/fpp/fpp_test.go
+++ b/op-acceptance-tests/tests/interop/proofs/fpp/fpp_test.go
@@ -1,4 +1,4 @@
-package proofs
+package fpp
 
 import (
 	"testing"
@@ -32,6 +32,7 @@ func TestNextSuperRootNotFound(gt *testing.T) {
 
 	// Stop the second sequencer so we have a point where new blocks aren't available (and thus no super root is found)
 	chainBLastBlockHash := sys.L2CLB.StopSequencer()
+	defer sys.L2CLB.StartSequencer() // Start the sequencer again for other tests.
 
 	chainBLastBlock := sys.L2ELB.BlockRefByHash(chainBLastBlockHash)
 

--- a/op-acceptance-tests/tests/interop/proofs/fpp/init_test.go
+++ b/op-acceptance-tests/tests/interop/proofs/fpp/init_test.go
@@ -1,0 +1,16 @@
+package fpp
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+)
+
+func TestMain(m *testing.M) {
+	presets.DoMain(m,
+		presets.WithSuperInteropSupernode(),
+		stack.MakeCommon(sysgo.WithChallengerCannonKonaEnabled()),
+	)
+}

--- a/op-acceptance-tests/tests/interop/proofs/fpp_test.go
+++ b/op-acceptance-tests/tests/interop/proofs/fpp_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
 func TestFPP(gt *testing.T) {
@@ -15,6 +16,43 @@ func TestFPP(gt *testing.T) {
 	endTimestamp := sys.L2ChainA.Escape().RollupConfig().TimestampForBlock(5)
 	sys.SuperRoots.AwaitValidatedTimestamp(endTimestamp)
 
+	dgf := sys.DisputeGameFactory()
+	dgf.RunFPP(startTimestamp, endTimestamp)
+}
+
+func TestNextSuperRootNotFound(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewSimpleInterop(t)
+	blockTime := sys.L2ChainA.Escape().RollupConfig().BlockTime
+
+	// Need to setup situation where the next super root is not found but the next block is safe on the first chain, but not safe on the second.
+	// Wait for at least 1 block to be fully validated on both chains so we have a good starting point.
+	initTimestamp := max(sys.L2ChainA.Escape().RollupConfig().TimestampForBlock(1), sys.L2ChainB.Escape().RollupConfig().TimestampForBlock(1))
+	sys.SuperRoots.AwaitValidatedTimestamp(initTimestamp)
+
+	// Stop the second sequencer so we have a point where new blocks aren't available (and thus no super root is found)
+	chainBLastBlockHash := sys.L2CLB.StopSequencer()
+
+	chainBLastBlock := sys.L2ELB.BlockRefByHash(chainBLastBlockHash)
+
+	// Wait for data to be fully validated up to the last block on second chain.
+	sys.SuperRoots.AwaitValidatedTimestamp(chainBLastBlock.Time)
+
+	// Wait for safe head to advance on first chain to be sure the next block is also safe.
+	sys.L2CLA.Advanced(types.LocalSafe, 1, 10)
+
+	startTimestamp := chainBLastBlock.Time
+	endTimestamp := startTimestamp + blockTime
+
+	// Verify we have a super root at the last block timestamp
+	resp := sys.SuperRoots.SuperRootAtTimestamp(startTimestamp)
+	t.Require().NotNil(resp.Data)
+
+	// But not at the next block
+	resp = sys.SuperRoots.SuperRootAtTimestamp(endTimestamp)
+	t.Require().Nil(resp.Data)
+
+	// Run FPP from timestamp of safe head on second chain, to 2 seconds later.
 	dgf := sys.DisputeGameFactory()
 	dgf.RunFPP(startTimestamp, endTimestamp)
 }


### PR DESCRIPTION
**Description**

Add a test to ensure that the challenger calculates the correct transition when the next superroot is unknown but the first chain does have the next block available on L1.  It should only transition to the invalid hash on the second chain block.

The FPP tests were moved to their own package so they can run in parallel with the other proofs tests since they're pretty long running but can't run in parallel on the same devnet.


**Tests**

Confirmed the test reproduces the original bug by re-introducing the issue into the challenger provider and confirming the FPP run detects the difference.

**Metadata**

fixes #18643 
