### PR TITLE
op-supernode/virtual_node: Update L1 genesis handling for genesis L2 block

### DIFF
--- a/op-supernode/supernode/chain_container/virtual_node/virtual_node.go
+++ b/op-supernode/supernode/chain_container/virtual_node/virtual_node.go
@@ -226,8 +226,12 @@ func (v *simpleVirtualNode) L1AtSafeHead(ctx context.Context, target eth.BlockID
 	}
 
 	// Special case: genesis L2 block is trivially safe at genesis L1
+	// Note: We use L1 block 0 (not cfg.Genesis.L1) because contracts may have been deployed
+	// earlier than cfg.Genesis.L1, allowing dispute games with L1 heads prior to cfg.Genesis.L1
 	if target == v.cfg.Rollup.Genesis.L2 {
-		return v.cfg.Rollup.Genesis.L1, nil
+		// Return L1 block 0 (L1 genesis)
+		l1Genesis := eth.BlockID{Number: 0} // Hash not necessary
+		return l1Genesis, nil
 	}
 
 	// Get the latest entry to start the walkback

--- a/op-supernode/supernode/chain_container/virtual_node/virtual_node_test.go
+++ b/op-supernode/supernode/chain_container/virtual_node/virtual_node_test.go
@@ -474,7 +474,7 @@ func TestVirtualNode_L1AtSafeHead(t *testing.T) {
 		// Query for genesis L2 block
 		result, err := vn.L1AtSafeHead(context.Background(), genesisL2)
 		require.NoError(t, err)
-		require.Equal(t, genesisL1, result)
+		require.Equal(t, eth.BlockID{}, result) // Genesis L2 target returns genesis L1 directly, but without the hash
 	})
 
 	t.Run("genesis L2 number with different hash is not treated as genesis", func(t *testing.T) {


### PR DESCRIPTION
Clarify that for the genesis L2 block, we always return L1 block 0 without relying on the original configuration's L1 genesis. This allows for more flexibility in dispute game scenarios involving earlier L1 blocks.

Brings into line with this code

https://github.com/ethereum-optimism/optimism/blob/db878818fffe71f3dc9ac5735ea9bfadca00acd5/op-node/rollup/driver/sync_deriver.go#L165-L170