### PR TITLE
ci: test circleci-utils mise v2026.2.2 update

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -88,7 +88,7 @@ orbs:
   slack: circleci/slack@6.0.0
   shellcheck: circleci/shellcheck@3.2.0
   codecov: codecov/codecov@5.0.3
-  utils: ethereum-optimism/circleci-utils@1.0.23
+  utils: ethereum-optimism/circleci-utils@dev:sc-mise-v
   docker: circleci/docker@2.8.2
   github-cli: circleci/github-cli@2.7.0
 

--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -6,7 +6,7 @@ version: 2.1
 # No workflows are defined here - workflows remain in each project's config.
 
 orbs:
-  utils: ethereum-optimism/circleci-utils@1.0.23
+  utils: ethereum-optimism/circleci-utils@dev:sc-mise-v
 
 parameters:
   default_docker_image:


### PR DESCRIPTION
## Note

DO NOT MERGE - Test PR Only

## Summary
- Bump `circleci-utils` orb to `dev:sc-mise-v` to test the mise v2026.2.2 update from https://github.com/ethereum-optimism/circleci-utils/pull/24
- Affects both `main.yml` and `rust-ci.yml` CI configs

## Test plan
- [ ] Verify CI pipelines pass with the updated mise version
- [ ] Revert to production orb version before merging (or after circleci-utils PR #24 is released)