### PR TITLE
op-acceptor: Update to 3.8.3

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -39,7 +39,7 @@ anvil = "1.2.3"
 codecov-uploader = "0.8.0"
 goreleaser-pro = "2.11.2"
 kurtosis = "1.8.1"
-op-acceptor = "op-acceptor/v3.8.2"
+op-acceptor = "op-acceptor/v3.8.3"
 git-cliff = "2.12.0"
 
 # Fake dependencies

--- a/op-acceptance-tests/justfile
+++ b/op-acceptance-tests/justfile
@@ -1,6 +1,6 @@
 REPO_ROOT := `realpath ..`  # path to the root of the optimism monorepo
 KURTOSIS_DIR := REPO_ROOT + "/kurtosis-devnet"
-ACCEPTOR_VERSION := env_var_or_default("ACCEPTOR_VERSION", "v3.8.2")
+ACCEPTOR_VERSION := env_var_or_default("ACCEPTOR_VERSION", "v3.8.3")
 DOCKER_REGISTRY := env_var_or_default("DOCKER_REGISTRY", "us-docker.pkg.dev/oplabs-tools-artifacts/images")
 ACCEPTOR_IMAGE := env_var_or_default("ACCEPTOR_IMAGE", DOCKER_REGISTRY + "/op-acceptor:" + ACCEPTOR_VERSION)
 


### PR DESCRIPTION
**Description**

Includes fixes to capture logs for tests that time out.
