### PR TITLE
Fix minor issues in fetcher, metrics namespace, and README

### DIFF
--- a/op-fetcher/pkg/fetcher/fetch/fetch.go
+++ b/op-fetcher/pkg/fetcher/fetch/fetch.go
@@ -38,7 +38,7 @@ func FetchChainInfoCLI() func(ctx *cli.Context) error {
 
 		result, err := fetcher.FetchChainInfo(cliCtx.Context)
 		if err != nil {
-			return fmt.Errorf("failed to validate: %w", err)
+			return fmt.Errorf("failed to fetch chain info: %w", err)
 		}
 
 		fileData := script.CreateChainConfig(result)

--- a/op-node/README.md
+++ b/op-node/README.md
@@ -61,7 +61,6 @@ just op-node
 # - P2P private key: auto-generated when missing, used to maintain a stable peer identity.
 # - Peerstore DB: remember peer records to connect with, used to not wait for peer discovery.
 # - Discovery DB: maintain DHT data, to avoid repeating some discovery work after restarting.
-  --p2p.priv.path=opnode_p2p_priv.txt \
   --p2p.peerstore.path=opnode_peerstore_db \
   --p2p.discovery.path=opnode_discovery_db \
   --p2p.priv.path=opnode_p2p_priv.txt

--- a/op-wheel/engine/metrics.go
+++ b/op-wheel/engine/metrics.go
@@ -8,7 +8,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
-var Namespace = "op_node"
+var Namespace = "op_wheel"
 
 type Metricer interface {
 	RecordBlockFail()


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

1. In the line return `fmt.Errorf(“failed to validate: %w”, err)`, the error message contained incorrect context - it mentioned failed validation, although the error actually occurred when fetching chain info.

2. Duplicate line removed `--p2p.priv.path=opnode_p2p_priv.txt`

3. Incorrect value for the `Namespace` variable in the `op-wheel/engine/metrics.go file`.
Replaced var `Namespace = “op_node”` with `var Namespace = “op_wheel”`
