### PR TITLE
chore(circleci): circleci-utils v1.0.24

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -88,7 +88,7 @@ orbs:
   slack: circleci/slack@6.0.0
   shellcheck: circleci/shellcheck@3.2.0
   codecov: codecov/codecov@5.0.3
-  utils: ethereum-optimism/circleci-utils@1.0.23
+  utils: ethereum-optimism/circleci-utils@1.0.24
   docker: circleci/docker@2.8.2
   github-cli: circleci/github-cli@2.7.0
 

--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -4,7 +4,7 @@ version: 2.1
 # This file contains all Rust CI commands, parameterized jobs, crate-specific jobs, and workflows.
 
 orbs:
-  utils: ethereum-optimism/circleci-utils@1.0.23
+ utils: ethereum-optimism/circleci-utils@1.0.24
   gcp-cli: circleci/gcp-cli@3.0.1
   codecov: codecov/codecov@5.0.3
 


### PR DESCRIPTION
**Description**

Updates circleci-utils which updates mise to v2026.2.2

**Tests**

https://github.com/ethereum-optimism/optimism/pull/19118