### PR TITLE
feat(kona-genesis): add rollup_config_override feature for custom max sequencer drift

### DIFF
--- a/rust/kona/crates/protocol/genesis/Cargo.toml
+++ b/rust/kona/crates/protocol/genesis/Cargo.toml
@@ -51,6 +51,7 @@ alloy-primitives = { workspace = true, features = ["rand", "arbitrary"] }
 
 [features]
 default = []
+rollup_config_override = []
 revm = [ "dep:op-revm" ]
 tabled = [ "dep:tabled", "std" ]
 std = [

--- a/rust/kona/crates/protocol/genesis/src/chain/config.rs
+++ b/rust/kona/crates/protocol/genesis/src/chain/config.rs
@@ -5,13 +5,13 @@ use alloy_chains::Chain;
 use alloy_eips::eip1559::BaseFeeParams;
 use alloy_primitives::Address;
 
+#[cfg(feature = "rollup_config_override")]
+use crate::FJORD_MAX_SEQUENCER_DRIFT;
 use crate::{
     AddressList, AltDAConfig, BaseFeeConfig, ChainGenesis, GRANITE_CHANNEL_TIMEOUT, HardForkConfig,
     Roles, RollupConfig, SuperchainLevel, base_fee_params, base_fee_params_canyon,
     params::base_fee_config, rollup::DEFAULT_INTEROP_MESSAGE_EXPIRY_WINDOW,
 };
-#[cfg(feature = "rollup_config_override")]
-use crate::FJORD_MAX_SEQUENCER_DRIFT;
 
 /// L1 chain configuration from the `alloy-genesis` crate.
 pub type L1ChainConfig = alloy_genesis::ChainConfig;

--- a/rust/kona/crates/protocol/genesis/src/chain/config.rs
+++ b/rust/kona/crates/protocol/genesis/src/chain/config.rs
@@ -10,6 +10,8 @@ use crate::{
     Roles, RollupConfig, SuperchainLevel, base_fee_params, base_fee_params_canyon,
     params::base_fee_config, rollup::DEFAULT_INTEROP_MESSAGE_EXPIRY_WINDOW,
 };
+#[cfg(feature = "rollup_config_override")]
+use crate::FJORD_MAX_SEQUENCER_DRIFT;
 
 /// L1 chain configuration from the `alloy-genesis` crate.
 pub type L1ChainConfig = alloy_genesis::ChainConfig;
@@ -176,6 +178,8 @@ impl ChainConfig {
             // necessary.
             channel_timeout: 300,
             granite_channel_timeout: GRANITE_CHANNEL_TIMEOUT,
+            #[cfg(feature = "rollup_config_override")]
+            fjord_max_sequencer_drift: FJORD_MAX_SEQUENCER_DRIFT,
             interop_message_expiry_window: DEFAULT_INTEROP_MESSAGE_EXPIRY_WINDOW,
             chain_op_config: self.base_fee_config(),
             alt_da_config: self.alt_da.clone(),

--- a/rust/kona/crates/protocol/genesis/src/rollup.rs
+++ b/rust/kona/crates/protocol/genesis/src/rollup.rs
@@ -15,11 +15,6 @@ pub const MAX_RLP_BYTES_PER_CHANNEL_FJORD: u64 = 100_000_000;
 /// The max sequencer drift when the Fjord hardfork is active.
 pub const FJORD_MAX_SEQUENCER_DRIFT: u64 = 1800;
 
-/// The max sequencer drift for chains that build only on finalized L1 blocks, where L1 finality
-/// delays can exceed the standard [`FJORD_MAX_SEQUENCER_DRIFT`].
-#[cfg(feature = "rollup_config_override")]
-pub(crate) const FJORD_MAX_SEQUENCER_DRIFT_OVERRIDE: u64 = 2892;
-
 /// The channel timeout once the Granite hardfork is active.
 pub const GRANITE_CHANNEL_TIMEOUT: u64 = 50;
 
@@ -34,6 +29,13 @@ const fn default_granite_channel_timeout() -> u64 {
 #[cfg(feature = "serde")]
 const fn default_interop_message_expiry_window() -> u64 {
     DEFAULT_INTEROP_MESSAGE_EXPIRY_WINDOW
+}
+
+/// The max sequencer drift needs to be changes for some chains, e.g. those that build only on
+/// finalized L1 blocks, where L1 finality delays can exceed the standard [`FJORD_MAX_SEQUENCER_DRIFT`].
+#[cfg(all(feature = "serde", feature = "rollup_config_override"))]
+const fn default_fjord_max_sequencer_drift() -> u64 {
+    FJORD_MAX_SEQUENCER_DRIFT
 }
 
 /// The Rollup configuration.
@@ -60,6 +62,10 @@ pub struct RollupConfig {
     /// The channel timeout after the Granite hardfork.
     #[cfg_attr(feature = "serde", serde(default = "default_granite_channel_timeout"))]
     pub granite_channel_timeout: u64,
+    /// The max sequencer drift after the Fjord hardfork.
+    #[cfg(feature = "rollup_config_override")]
+    #[cfg_attr(feature = "serde", serde(default = "default_fjord_max_sequencer_drift"))]
+    pub fjord_max_sequencer_drift: u64,
     /// The L1 chain ID
     pub l1_chain_id: u64,
     /// The L2 chain ID
@@ -120,6 +126,8 @@ impl<'a> arbitrary::Arbitrary<'a> for RollupConfig {
             seq_window_size: u.arbitrary()?,
             channel_timeout: u.arbitrary()?,
             granite_channel_timeout: u.arbitrary()?,
+            #[cfg(feature = "rollup_config_override")]
+            fjord_max_sequencer_drift: u.arbitrary()?,
             l1_chain_id: u.arbitrary()?,
             l2_chain_id: u.arbitrary()?,
             hardforks: HardForkConfig::arbitrary(u)?,
@@ -147,6 +155,8 @@ impl Default for RollupConfig {
             seq_window_size: 0,
             channel_timeout: 0,
             granite_channel_timeout: GRANITE_CHANNEL_TIMEOUT,
+            #[cfg(feature = "rollup_config_override")]
+            fjord_max_sequencer_drift: FJORD_MAX_SEQUENCER_DRIFT,
             l1_chain_id: 0,
             l2_chain_id: Chain::from_id(0),
             hardforks: HardForkConfig::default(),
@@ -337,12 +347,11 @@ impl RollupConfig {
     pub fn max_sequencer_drift(&self, timestamp: u64) -> u64 {
         if self.is_fjord_active(timestamp) {
             #[cfg(feature = "rollup_config_override")]
-            return FJORD_MAX_SEQUENCER_DRIFT_OVERRIDE;
+            return self.fjord_max_sequencer_drift;
             #[cfg(not(feature = "rollup_config_override"))]
             return FJORD_MAX_SEQUENCER_DRIFT;
-        } else {
-            self.max_sequencer_drift
         }
+        self.max_sequencer_drift
     }
 
     /// Returns the max rlp bytes per channel for the given timestamp.
@@ -779,10 +788,7 @@ mod tests {
         assert_eq!(config.max_sequencer_drift(0), 100);
         config.hardforks.fjord_time = Some(10);
         assert_eq!(config.max_sequencer_drift(0), 100);
-        #[cfg(not(feature = "rollup_config_override"))]
         assert_eq!(config.max_sequencer_drift(10), FJORD_MAX_SEQUENCER_DRIFT);
-        #[cfg(feature = "rollup_config_override")]
-        assert_eq!(config.max_sequencer_drift(10), FJORD_MAX_SEQUENCER_DRIFT_OVERRIDE);
     }
 
     #[test]
@@ -872,6 +878,8 @@ mod tests {
             seq_window_size: 3600,
             channel_timeout: 300,
             granite_channel_timeout: GRANITE_CHANNEL_TIMEOUT,
+            #[cfg(feature = "rollup_config_override")]
+            fjord_max_sequencer_drift: FJORD_MAX_SEQUENCER_DRIFT,
             l1_chain_id: 3151908,
             l2_chain_id: Chain::from_id(1337),
             hardforks: HardForkConfig {
@@ -957,5 +965,42 @@ mod tests {
 
         assert_eq!(cfg.block_number_from_timestamp(20), 5);
         assert_eq!(cfg.block_number_from_timestamp(30), 10);
+    }
+
+    #[cfg(feature = "rollup_config_override")]
+    mod rollup_config_override_tests {
+        use super::*;
+
+        #[test]
+        fn test_max_sequencer_drift_override() {
+            let mut config = RollupConfig {
+                max_sequencer_drift: 100,
+                fjord_max_sequencer_drift: 2892,
+                hardforks: HardForkConfig { fjord_time: Some(10), ..Default::default() },
+                ..Default::default()
+            };
+            assert_eq!(config.max_sequencer_drift(0), 100);
+            assert_eq!(config.max_sequencer_drift(10), 2892);
+            config.fjord_max_sequencer_drift = 3600;
+            assert_eq!(config.max_sequencer_drift(10), 3600);
+        }
+
+        #[test]
+        #[cfg(feature = "serde")]
+        fn test_serde_fjord_max_sequencer_drift_override() {
+            // Default value survives round-trip.
+            let config = RollupConfig::default();
+            assert_eq!(config.fjord_max_sequencer_drift, FJORD_MAX_SEQUENCER_DRIFT);
+            let serialized = serde_json::to_string(&config).unwrap();
+            let deserialized: RollupConfig = serde_json::from_str(&serialized).unwrap();
+            assert_eq!(deserialized.fjord_max_sequencer_drift, FJORD_MAX_SEQUENCER_DRIFT);
+
+            // Custom value survives round-trip.
+            let mut config = config;
+            config.fjord_max_sequencer_drift = 2892;
+            let serialized = serde_json::to_string(&config).unwrap();
+            let deserialized: RollupConfig = serde_json::from_str(&serialized).unwrap();
+            assert_eq!(deserialized.fjord_max_sequencer_drift, 2892);
+        }
     }
 }

--- a/rust/kona/crates/protocol/genesis/src/rollup.rs
+++ b/rust/kona/crates/protocol/genesis/src/rollup.rs
@@ -32,7 +32,8 @@ const fn default_interop_message_expiry_window() -> u64 {
 }
 
 /// The max sequencer drift needs to be changes for some chains, e.g. those that build only on
-/// finalized L1 blocks, where L1 finality delays can exceed the standard [`FJORD_MAX_SEQUENCER_DRIFT`].
+/// finalized L1 blocks, where L1 finality delays can exceed the standard
+/// [`FJORD_MAX_SEQUENCER_DRIFT`].
 #[cfg(all(feature = "serde", feature = "rollup_config_override"))]
 const fn default_fjord_max_sequencer_drift() -> u64 {
     FJORD_MAX_SEQUENCER_DRIFT

--- a/rust/kona/crates/protocol/genesis/src/rollup.rs
+++ b/rust/kona/crates/protocol/genesis/src/rollup.rs
@@ -15,6 +15,11 @@ pub const MAX_RLP_BYTES_PER_CHANNEL_FJORD: u64 = 100_000_000;
 /// The max sequencer drift when the Fjord hardfork is active.
 pub const FJORD_MAX_SEQUENCER_DRIFT: u64 = 1800;
 
+/// The max sequencer drift for chains that build only on finalized L1 blocks, where L1 finality
+/// delays can exceed the standard [`FJORD_MAX_SEQUENCER_DRIFT`].
+#[cfg(feature = "rollup_config_override")]
+pub(crate) const FJORD_MAX_SEQUENCER_DRIFT_OVERRIDE: u64 = 2892;
+
 /// The channel timeout once the Granite hardfork is active.
 pub const GRANITE_CHANNEL_TIMEOUT: u64 = 50;
 
@@ -331,7 +336,10 @@ impl RollupConfig {
     /// Returns the max sequencer drift for the given timestamp.
     pub fn max_sequencer_drift(&self, timestamp: u64) -> u64 {
         if self.is_fjord_active(timestamp) {
-            FJORD_MAX_SEQUENCER_DRIFT
+            #[cfg(feature = "rollup_config_override")]
+            return FJORD_MAX_SEQUENCER_DRIFT_OVERRIDE;
+            #[cfg(not(feature = "rollup_config_override"))]
+            return FJORD_MAX_SEQUENCER_DRIFT;
         } else {
             self.max_sequencer_drift
         }
@@ -771,7 +779,10 @@ mod tests {
         assert_eq!(config.max_sequencer_drift(0), 100);
         config.hardforks.fjord_time = Some(10);
         assert_eq!(config.max_sequencer_drift(0), 100);
+        #[cfg(not(feature = "rollup_config_override"))]
         assert_eq!(config.max_sequencer_drift(10), FJORD_MAX_SEQUENCER_DRIFT);
+        #[cfg(feature = "rollup_config_override")]
+        assert_eq!(config.max_sequencer_drift(10), FJORD_MAX_SEQUENCER_DRIFT_OVERRIDE);
     }
 
     #[test]

--- a/rust/kona/crates/protocol/registry/Cargo.toml
+++ b/rust/kona/crates/protocol/registry/Cargo.toml
@@ -47,6 +47,7 @@ alloy-eips.workspace = true
 
 [features]
 default = []
+rollup_config_override = ["kona-genesis/rollup_config_override"]
 tabled = [ "dep:tabled", "std" ]
 std = [
 	"alloy-chains/std",

--- a/rust/kona/crates/protocol/registry/src/test_utils/base_mainnet.rs
+++ b/rust/kona/crates/protocol/registry/src/test_utils/base_mainnet.rs
@@ -10,8 +10,10 @@ use alloy_op_hardforks::{
 use alloy_primitives::{address, b256, uint};
 use kona_genesis::{
     BASE_MAINNET_BASE_FEE_CONFIG, ChainGenesis, DEFAULT_INTEROP_MESSAGE_EXPIRY_WINDOW,
-    FJORD_MAX_SEQUENCER_DRIFT, HardForkConfig, RollupConfig, SystemConfig,
+    HardForkConfig, RollupConfig, SystemConfig,
 };
+#[cfg(feature = "rollup_config_override")]
+use kona_genesis::FJORD_MAX_SEQUENCER_DRIFT;
 
 /// The [`RollupConfig`] for Base Mainnet.
 pub const BASE_MAINNET_CONFIG: RollupConfig = RollupConfig {

--- a/rust/kona/crates/protocol/registry/src/test_utils/base_mainnet.rs
+++ b/rust/kona/crates/protocol/registry/src/test_utils/base_mainnet.rs
@@ -10,7 +10,7 @@ use alloy_op_hardforks::{
 use alloy_primitives::{address, b256, uint};
 use kona_genesis::{
     BASE_MAINNET_BASE_FEE_CONFIG, ChainGenesis, DEFAULT_INTEROP_MESSAGE_EXPIRY_WINDOW,
-    HardForkConfig, RollupConfig, SystemConfig,
+    FJORD_MAX_SEQUENCER_DRIFT, HardForkConfig, RollupConfig, SystemConfig,
 };
 
 /// The [`RollupConfig`] for Base Mainnet.
@@ -45,6 +45,8 @@ pub const BASE_MAINNET_CONFIG: RollupConfig = RollupConfig {
     seq_window_size: 3600,
     channel_timeout: 300,
     granite_channel_timeout: 50,
+    #[cfg(feature = "rollup_config_override")]
+    fjord_max_sequencer_drift: FJORD_MAX_SEQUENCER_DRIFT,
     l1_chain_id: 1,
     l2_chain_id: Chain::base_mainnet(),
     hardforks: HardForkConfig {

--- a/rust/kona/crates/protocol/registry/src/test_utils/base_sepolia.rs
+++ b/rust/kona/crates/protocol/registry/src/test_utils/base_sepolia.rs
@@ -10,8 +10,10 @@ use alloy_op_hardforks::{
 use alloy_primitives::{address, b256, uint};
 use kona_genesis::{
     BASE_SEPOLIA_BASE_FEE_CONFIG, ChainGenesis, DEFAULT_INTEROP_MESSAGE_EXPIRY_WINDOW,
-    FJORD_MAX_SEQUENCER_DRIFT, HardForkConfig, RollupConfig, SystemConfig,
+    HardForkConfig, RollupConfig, SystemConfig,
 };
+#[cfg(feature = "rollup_config_override")]
+use kona_genesis::FJORD_MAX_SEQUENCER_DRIFT;
 
 /// The [`RollupConfig`] for Base Sepolia.
 pub const BASE_SEPOLIA_CONFIG: RollupConfig = RollupConfig {

--- a/rust/kona/crates/protocol/registry/src/test_utils/base_sepolia.rs
+++ b/rust/kona/crates/protocol/registry/src/test_utils/base_sepolia.rs
@@ -10,7 +10,7 @@ use alloy_op_hardforks::{
 use alloy_primitives::{address, b256, uint};
 use kona_genesis::{
     BASE_SEPOLIA_BASE_FEE_CONFIG, ChainGenesis, DEFAULT_INTEROP_MESSAGE_EXPIRY_WINDOW,
-    HardForkConfig, RollupConfig, SystemConfig,
+    FJORD_MAX_SEQUENCER_DRIFT, HardForkConfig, RollupConfig, SystemConfig,
 };
 
 /// The [`RollupConfig`] for Base Sepolia.
@@ -45,6 +45,8 @@ pub const BASE_SEPOLIA_CONFIG: RollupConfig = RollupConfig {
     seq_window_size: 3600,
     channel_timeout: 300,
     granite_channel_timeout: 50,
+    #[cfg(feature = "rollup_config_override")]
+    fjord_max_sequencer_drift: FJORD_MAX_SEQUENCER_DRIFT,
     l1_chain_id: 11155111,
     l2_chain_id: Chain::base_sepolia(),
     chain_op_config: BASE_SEPOLIA_BASE_FEE_CONFIG,

--- a/rust/kona/crates/protocol/registry/src/test_utils/op_mainnet.rs
+++ b/rust/kona/crates/protocol/registry/src/test_utils/op_mainnet.rs
@@ -9,7 +9,7 @@ use alloy_op_hardforks::{
 };
 use alloy_primitives::{address, b256, uint};
 use kona_genesis::{
-    ChainGenesis, DEFAULT_INTEROP_MESSAGE_EXPIRY_WINDOW, HardForkConfig,
+    ChainGenesis, DEFAULT_INTEROP_MESSAGE_EXPIRY_WINDOW, FJORD_MAX_SEQUENCER_DRIFT, HardForkConfig,
     OP_MAINNET_BASE_FEE_CONFIG, RollupConfig, SystemConfig,
 };
 
@@ -45,6 +45,8 @@ pub const OP_MAINNET_CONFIG: RollupConfig = RollupConfig {
     seq_window_size: 3600_u64,
     channel_timeout: 300_u64,
     granite_channel_timeout: 50,
+    #[cfg(feature = "rollup_config_override")]
+    fjord_max_sequencer_drift: FJORD_MAX_SEQUENCER_DRIFT,
     l1_chain_id: 1_u64,
     l2_chain_id: Chain::optimism_mainnet(),
     chain_op_config: OP_MAINNET_BASE_FEE_CONFIG,

--- a/rust/kona/crates/protocol/registry/src/test_utils/op_mainnet.rs
+++ b/rust/kona/crates/protocol/registry/src/test_utils/op_mainnet.rs
@@ -9,9 +9,11 @@ use alloy_op_hardforks::{
 };
 use alloy_primitives::{address, b256, uint};
 use kona_genesis::{
-    ChainGenesis, DEFAULT_INTEROP_MESSAGE_EXPIRY_WINDOW, FJORD_MAX_SEQUENCER_DRIFT, HardForkConfig,
+    ChainGenesis, DEFAULT_INTEROP_MESSAGE_EXPIRY_WINDOW, HardForkConfig,
     OP_MAINNET_BASE_FEE_CONFIG, RollupConfig, SystemConfig,
 };
+#[cfg(feature = "rollup_config_override")]
+use kona_genesis::FJORD_MAX_SEQUENCER_DRIFT;
 
 /// The [`RollupConfig`] for OP Mainnet.
 pub const OP_MAINNET_CONFIG: RollupConfig = RollupConfig {

--- a/rust/kona/crates/protocol/registry/src/test_utils/op_sepolia.rs
+++ b/rust/kona/crates/protocol/registry/src/test_utils/op_sepolia.rs
@@ -9,7 +9,7 @@ use alloy_op_hardforks::{
 };
 use alloy_primitives::{address, b256, uint};
 use kona_genesis::{
-    ChainGenesis, DEFAULT_INTEROP_MESSAGE_EXPIRY_WINDOW, HardForkConfig,
+    ChainGenesis, DEFAULT_INTEROP_MESSAGE_EXPIRY_WINDOW, FJORD_MAX_SEQUENCER_DRIFT, HardForkConfig,
     OP_SEPOLIA_BASE_FEE_CONFIG, RollupConfig, SystemConfig,
 };
 
@@ -45,6 +45,8 @@ pub const OP_SEPOLIA_CONFIG: RollupConfig = RollupConfig {
     seq_window_size: 3600,
     channel_timeout: 300,
     granite_channel_timeout: 50,
+    #[cfg(feature = "rollup_config_override")]
+    fjord_max_sequencer_drift: FJORD_MAX_SEQUENCER_DRIFT,
     l1_chain_id: 11155111,
     l2_chain_id: Chain::optimism_sepolia(),
     chain_op_config: OP_SEPOLIA_BASE_FEE_CONFIG,

--- a/rust/kona/crates/protocol/registry/src/test_utils/op_sepolia.rs
+++ b/rust/kona/crates/protocol/registry/src/test_utils/op_sepolia.rs
@@ -9,9 +9,11 @@ use alloy_op_hardforks::{
 };
 use alloy_primitives::{address, b256, uint};
 use kona_genesis::{
-    ChainGenesis, DEFAULT_INTEROP_MESSAGE_EXPIRY_WINDOW, FJORD_MAX_SEQUENCER_DRIFT, HardForkConfig,
+    ChainGenesis, DEFAULT_INTEROP_MESSAGE_EXPIRY_WINDOW, HardForkConfig,
     OP_SEPOLIA_BASE_FEE_CONFIG, RollupConfig, SystemConfig,
 };
+#[cfg(feature = "rollup_config_override")]
+use kona_genesis::FJORD_MAX_SEQUENCER_DRIFT;
 
 /// The [`RollupConfig`] for OP Sepolia.
 pub const OP_SEPOLIA_CONFIG: RollupConfig = RollupConfig {


### PR DESCRIPTION
**Description**
Add a `rollup_config_override` feature to kona-genesis that overrides the Fjord max sequencer drift to 2892s for chains building only on finalized L1 blocks, where L1 finality delays can exceed the standard 1800s limit.

Since this is only a temporary solution, I've chosen the small and primitive solution over a more generic approach. Let me know if you prefer a different approach.

**Additional context**

This replaces https://github.com/ethereum-optimism/optimism/pull/18859 until the proper solution is in place, see https://github.com/ethereum-optimism/optimism/pull/18859#issuecomment-3819269696
