### PR TITLE
fix(op-conductor): Fix websocket disconnections caused by incorrect use of timeouts

### DIFF
--- a/op-conductor/rpc/ws/flashblocks_handler.go
+++ b/op-conductor/rpc/ws/flashblocks_handler.go
@@ -19,14 +19,15 @@ import (
 const (
 	// reconnectDelay is the delay between reconnection attempts
 	reconnectDelay = 5 * time.Second
-	// pingInterval is how often to send pings to keep connections alive
-	pingInterval = 15 * time.Second
-	// pongTimeout is how long to wait for a pong response
-	pongTimeout = 10 * time.Second
 	// writeTimeout for all message writes
 	writeTimeout = 5 * time.Second
 	// send channel buffer size
 	sendChannelBufferSize = 256
+	// defaultPingInterval is how often to send keepalive pings on WebSocket connections.
+	defaultPingInterval = 15 * time.Second
+	// defaultPongTimeout is how long to wait for a pong response before treating
+	// the connection as stale.
+	defaultPongTimeout = 10 * time.Second
 )
 
 // FlashblockHandler manages WebSocket connections for flashblocks
@@ -61,6 +62,8 @@ type Handler struct {
 	httpServer          *httputil.HTTPServer
 	hub                 *Hub
 	boundPort           int
+	pingInterval        time.Duration
+	pongTimeout         time.Duration
 }
 
 // NewHandler creates a new flashblocks handler
@@ -76,10 +79,12 @@ func NewHandler(cfg Config, log log.Logger, isLeaderFn func(context.Context) boo
 
 	// Initialize the handler
 	handler := &Handler{
-		cfg:        cfg,
-		log:        log,
-		isLeaderFn: isLeaderFn,
-		metrics:    m,
+		cfg:          cfg,
+		log:          log,
+		isLeaderFn:   isLeaderFn,
+		metrics:      m,
+		pingInterval: defaultPingInterval,
+		pongTimeout:  defaultPongTimeout,
 	}
 
 	// Try to establish initial connection to rollup boost WebSocket
@@ -263,7 +268,7 @@ func (h *Handler) listenToRollupBoost(ctx context.Context) {
 }
 
 func (h *Handler) pingUpstream(ctx context.Context) {
-	ticker := time.NewTicker(pingInterval)
+	ticker := time.NewTicker(h.pingInterval)
 	defer ticker.Stop()
 
 	for {
@@ -275,7 +280,7 @@ func (h *Handler) pingUpstream(ctx context.Context) {
 			if conn == nil {
 				return
 			}
-			pingCtx, cancel := context.WithTimeout(ctx, pongTimeout)
+			pingCtx, cancel := context.WithTimeout(ctx, h.pongTimeout)
 			err := conn.Ping(pingCtx)
 			cancel()
 			if err != nil {

--- a/op-conductor/rpc/ws/flashblocks_handler.go
+++ b/op-conductor/rpc/ws/flashblocks_handler.go
@@ -215,6 +215,7 @@ func (h *Handler) listenToRollupBoost(ctx context.Context) {
 				time.Sleep(500 * time.Millisecond)
 				continue
 			}
+
 			// Try to connect if not connected indefinitely
 			if h.rollupBoostConn == nil {
 				h.log.Info("reconnecting to rollup boost WebSocket", "url", h.cfg.RollupBoostWsURL)
@@ -229,7 +230,6 @@ func (h *Handler) listenToRollupBoost(ctx context.Context) {
 				if err != nil {
 					h.log.Warn("failed to connect to rollup boost WebSocket, will retry",
 						"err", err, "retryIn", reconnectDelay)
-					// add a metric for the number of times we've tried to connect
 					h.metrics.RecordRollupBoostConnectionAttempts(false, h.cfg.RollupBoostWsURL)
 					time.Sleep(reconnectDelay)
 					continue
@@ -238,12 +238,14 @@ func (h *Handler) listenToRollupBoost(ctx context.Context) {
 				h.rollupBoostConn = conn
 				h.log.Info("successfully connected to rollup boost WebSocket")
 				h.metrics.RecordRollupBoostConnectionAttempts(true, h.cfg.RollupBoostWsURL)
+
+				// Start keepalive pings on the upstream connection.
+				// If the ping fails (stale TCP connection), close the conn
+				// so the read below errors out and triggers reconnection.
+				go h.pingUpstream(ctx)
 			}
 
-			// Read with timeout
-			readCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-			_, message, err := h.rollupBoostConn.Read(readCtx)
-			cancel()
+			_, message, err := h.rollupBoostConn.Read(ctx)
 
 			if err != nil {
 				h.log.Warn("error reading from rollup boost WebSocket", "err", err)
@@ -256,6 +258,31 @@ func (h *Handler) listenToRollupBoost(ctx context.Context) {
 			}
 
 			h.handleRollupBoostMessage(ctx, message)
+		}
+	}
+}
+
+func (h *Handler) pingUpstream(ctx context.Context) {
+	ticker := time.NewTicker(pingInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			conn := h.rollupBoostConn
+			if conn == nil {
+				return
+			}
+			pingCtx, cancel := context.WithTimeout(ctx, pongTimeout)
+			err := conn.Ping(pingCtx)
+			cancel()
+			if err != nil {
+				h.log.Warn("upstream ping failed, closing connection for reconnect", "err", err)
+				conn.Close(websocket.StatusInternalError, "ping timeout")
+				return
+			}
 		}
 	}
 }

--- a/op-conductor/rpc/ws/server.go
+++ b/op-conductor/rpc/ws/server.go
@@ -239,7 +239,7 @@ func (h *Handler) writePump(client *Client) {
 	}()
 
 	// Configure ping for connection keepalive
-	pingTicker := time.NewTicker(pingInterval)
+	pingTicker := time.NewTicker(h.pingInterval)
 	defer pingTicker.Stop()
 
 	for {
@@ -265,7 +265,7 @@ func (h *Handler) writePump(client *Client) {
 			}
 
 		case <-pingTicker.C:
-			pingCtx, cancel := context.WithTimeout(client.ctx, pongTimeout)
+			pingCtx, cancel := context.WithTimeout(client.ctx, h.pongTimeout)
 			err := client.conn.Ping(pingCtx)
 			cancel()
 

--- a/op-conductor/rpc/ws/server.go
+++ b/op-conductor/rpc/ws/server.go
@@ -2,7 +2,6 @@ package ws
 
 import (
 	"context"
-	"errors"
 	"net/http"
 	"sync"
 	"time"
@@ -213,10 +212,11 @@ func (h *Handler) serveWs(w http.ResponseWriter, r *http.Request) {
 	h.readPump(client)
 }
 
-// readPump for followers where you don't expect regular data messages
+// readPump drains control frames (ping/pong/close) from a subscribe-only
+// client. CloseRead handles this internally and cancels the returned context
+// when the connection is closed, at which point we unregister the client.
 func (h *Handler) readPump(client *Client) {
 	defer func() {
-		// Unregister the client when the read pump exits
 		select {
 		case h.hub.unregister <- client:
 		case <-h.hub.done:
@@ -226,34 +226,8 @@ func (h *Handler) readPump(client *Client) {
 		h.log.Info("WebSocket read pump exited, client unregistered")
 	}()
 
-	for {
-		select {
-		case <-client.ctx.Done():
-			return
-		default:
-			// Always read to process control frames (ping/pong/close)
-			readCtx, cancel := context.WithTimeout(client.ctx, 30*time.Second)
-			_, message, err := client.conn.Read(readCtx)
-			cancel()
-
-			if err != nil {
-				if errors.Is(err, context.DeadlineExceeded) {
-					// Timeout is expected when no messages - continue reading
-					h.log.Debug("Read timeout occurred, continuing to process control frames")
-					continue
-				}
-				if websocket.CloseStatus(err) != -1 {
-					h.log.Debug("Client closed connection", "code", websocket.CloseStatus(err))
-					return
-				}
-				h.log.Debug("Error reading from WebSocket client", "err", err)
-				return
-			}
-
-			// Handle any data messages from clients if needed
-			h.log.Debug("Received message from client", "message", string(message))
-		}
-	}
+	closed := client.conn.CloseRead(client.ctx)
+	<-closed.Done()
 }
 
 // writePump pumps messages from the hub to the WebSocket connection

--- a/op-conductor/rpc/ws/server_test.go
+++ b/op-conductor/rpc/ws/server_test.go
@@ -414,12 +414,6 @@ func TestConcurrentConnections(t *testing.T) {
 			}
 			defer client.Close()
 
-			// Send a test message
-			err = client.Write(ctx, []byte("test message"))
-			if err != nil {
-				t.Errorf("Client %d write failed: %v", clientIdx, err)
-			}
-
 			// Keep connection alive for a short time
 			select {
 			case <-ctx.Done():

--- a/op-conductor/rpc/ws/server_test.go
+++ b/op-conductor/rpc/ws/server_test.go
@@ -162,7 +162,7 @@ func (tc *testClient) Write(ctx context.Context, data []byte) error {
 	return tc.conn.Write(ctx, websocket.MessageText, data)
 }
 
-// setupTestServer creates a test WebSocket server with event tracking
+// setupTestServer creates a test WebSocket server with event tracking.
 func setupTestServer(t *testing.T) (*Handler, *testEventTracker, *httptest.Server, func()) {
 	t.Helper()
 
@@ -175,10 +175,12 @@ func setupTestServer(t *testing.T) (*Handler, *testEventTracker, *httptest.Serve
 	isLeaderFn := func(ctx context.Context) bool { return true }
 
 	handler := &Handler{
-		cfg:        cfg,
-		log:        logger,
-		isLeaderFn: isLeaderFn,
-		metrics:    &metrics.NoopMetricsImpl{},
+		cfg:          cfg,
+		log:          logger,
+		isLeaderFn:   isLeaderFn,
+		metrics:      &metrics.NoopMetricsImpl{},
+		pingInterval: defaultPingInterval,
+		pongTimeout:  defaultPongTimeout,
 	}
 
 	// Create event tracker for testing
@@ -291,11 +293,11 @@ func TestPingPongMechanism(t *testing.T) {
 
 // TestServerInitiatedPing tests that the server sends pings to clients
 func TestServerInitiatedPing(t *testing.T) {
-	_, tracker, server, cleanup := setupTestServer(t)
+	handler, tracker, server, cleanup := setupTestServer(t)
 	defer cleanup()
 
 	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/ws"
-	ctx, cancel := context.WithTimeout(context.Background(), pingInterval+(5*time.Second))
+	ctx, cancel := context.WithTimeout(context.Background(), handler.pingInterval+(5*time.Second))
 	defer cancel()
 
 	// Create test client
@@ -310,7 +312,7 @@ func TestServerInitiatedPing(t *testing.T) {
 
 	// Wait for server to send a ping
 	select {
-	case <-time.After(pingInterval + (2 * time.Second)):
+	case <-time.After(handler.pingInterval + (2 * time.Second)):
 		t.Error("Timeout waiting for server ping")
 	case <-client.pingsReceived:
 		t.Log("Client received ping from server")
@@ -520,4 +522,152 @@ func TestHubShutdown(t *testing.T) {
 	}
 
 	t.Log("Hub shutdown completed successfully")
+}
+
+// TestUpstreamPingDetectsAndReconnectsOnSilentConnection verifies that
+// pingUpstream detects a TCP-alive / application-silent upstream and
+// triggers reconnection within pingInterval+pongTimeout, rather than waiting
+// for a 30 s per-Read timeout.
+//
+// Before the fix, listenToRollupBoost used context.WithTimeout(ctx, 30s) on
+// every Read call. coder/websocket destroys the TCP connection when a context
+// deadline expires (coder/websocket#242), so the upstream link was reset every
+// 30 s even when healthy, causing periodic flashblock gaps. The fix removes the
+// read timeout and adds pingUpstream so that only genuinely stale connections
+// trigger reconnection.
+//
+// This test fails without pingUpstream (old code) because a silent connection
+// is not detected within the test window; it passes with pingUpstream because
+// the pong timeout fires well within the deadline.
+func TestUpstreamPingDetectsAndReconnectsOnSilentConnection(t *testing.T) {
+	// Use short ping parameters so the test completes in ~400 ms.
+	const testPingInterval = 200 * time.Millisecond
+	const testPongTimeout = 100 * time.Millisecond
+
+	var connectCount atomic.Int64
+
+	// Upstream server: accepts connections and sends one flashblock message, but
+	// never answers pings (simulates a TCP-alive / application-silent link).
+	// CloseRead handles the WS close handshake so pingUpstream's conn.Close
+	// completes promptly; OnPingReceived=false suppresses pong replies.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
+			CompressionMode: websocket.CompressionDisabled,
+			OnPingReceived:  func(_ context.Context, _ []byte) bool { return false },
+		})
+		if err != nil {
+			return
+		}
+		defer conn.CloseNow()
+		connectCount.Add(1)
+
+		// Send one message so the first connection is productive.
+		_ = conn.Write(r.Context(), websocket.MessageText, []byte(`{"slot":1}`))
+
+		// CloseRead responds to close frames (so conn.Close in pingUpstream
+		// can complete the handshake promptly) but pings go unanswered.
+		closed := conn.CloseRead(r.Context())
+		<-closed.Done()
+	}))
+	t.Cleanup(upstream.Close)
+
+	wsURL := "ws" + strings.TrimPrefix(upstream.URL, "http")
+
+	handler := &Handler{
+		cfg: Config{
+			WebsocketServerPort: 0,
+			RollupBoostWsURL:    wsURL,
+		},
+		log:          log.New("test", "upstream-reconnect"),
+		isLeaderFn:   func(context.Context) bool { return true },
+		metrics:      &metrics.NoopMetricsImpl{},
+		pingInterval: testPingInterval,
+		pongTimeout:  testPongTimeout,
+	}
+	handler.hub = newHub(handler.metrics)
+	go handler.hub.run()
+	t.Cleanup(func() {
+		select {
+		case <-handler.hub.done:
+		default:
+			close(handler.hub.done)
+		}
+	})
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	go handler.listenToRollupBoost(ctx)
+
+	// Expect ≥2 upstream connections: the initial dial plus one reconnect
+	// triggered by the pong timeout (testPingInterval + testPongTimeout ≈ 300 ms).
+	deadline := time.NewTimer(testPingInterval + testPongTimeout + 500*time.Millisecond)
+	defer deadline.Stop()
+	poll := time.NewTicker(20 * time.Millisecond)
+	defer poll.Stop()
+
+	for {
+		select {
+		case <-deadline.C:
+			t.Fatalf(
+				"upstream reconnect not observed: got %d connections (want ≥2); "+
+					"without pingUpstream a silent connection is not detected until the 30 s read timeout",
+				connectCount.Load(),
+			)
+		case <-poll.C:
+			if connectCount.Load() >= 2 {
+				return // reconnect observed — test passes
+			}
+		}
+	}
+}
+
+// TestReadPumpClientRemainsRegisteredDuringPingCycles verifies that a
+// subscribe-only client is not dropped by the server during normal operation.
+//
+// The old readPump implementation issued conn.Read with a 30 s timeout on each
+// iteration. When that deadline expired, coder/websocket destroyed the TCP
+// connection (coder/websocket#242), unregistering the client even though the
+// connection was healthy. The new implementation uses conn.CloseRead, which has
+// no per-call timeout and properly handles control frames without destroying
+// the underlying connection.
+//
+// Note: this test validates correct behaviour across multiple ping cycles but
+// does not fast-fail with the old 30 s hardcoded timeout (that would require
+// waiting >30 s). See TestUpstreamPingDetectsAndReconnectsOnSilentConnection
+// for the full root-cause regression test of the timeout-destroys-TCP bug.
+func TestReadPumpClientRemainsRegisteredDuringPingCycles(t *testing.T) {
+	// Run several server→client ping cycles quickly to exercise the
+	// control-frame path through readPump / CloseRead.
+	const testPingInterval = 50 * time.Millisecond
+	const testPongTimeout = 25 * time.Millisecond
+
+	handler, tracker, server, cleanup := setupTestServer(t)
+	handler.pingInterval = testPingInterval
+	handler.pongTimeout = testPongTimeout
+	defer cleanup()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/ws"
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	client, err := newTestClient(ctx, wsURL)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer client.Close()
+
+	waitForClientCount(t, tracker, 1, 2*time.Second, "initial connection")
+
+	// Let 5 server-initiated ping/pong cycles complete.
+	time.Sleep(5 * testPingInterval)
+
+	if tracker.getClientCount() != 1 {
+		t.Fatal("client was unexpectedly unregistered during idle ping cycles")
+	}
+
+	// Confirm the client can still receive broadcasts after the idle period.
+	const msg = "post-idle-broadcast"
+	handler.BroadcastMessage([]byte(msg))
+	waitForMessage(t, client, msg, 2*time.Second, "broadcast after ping cycles")
 }

--- a/op-conductor/rpc/ws/server_test.go
+++ b/op-conductor/rpc/ws/server_test.go
@@ -558,7 +558,7 @@ func TestUpstreamPingDetectsAndReconnectsOnSilentConnection(t *testing.T) {
 		if err != nil {
 			return
 		}
-		defer conn.CloseNow()
+		defer conn.CloseNow() //nolint:errcheck
 		connectCount.Add(1)
 
 		// Send one message so the first connection is productive.

--- a/op-service/client/ws.go
+++ b/op-service/client/ws.go
@@ -108,6 +108,14 @@ func DialWS(ctx context.Context, cfg WSConfig) (*WSClient, error) {
 	}, nil
 }
 
+// Ping sends a ping to the peer and waits for a pong.
+func (c *WSClient) Ping(ctx context.Context) error {
+	if c == nil || c.conn == nil {
+		return nil
+	}
+	return c.conn.Ping(ctx)
+}
+
 // Close closes the websocket connection with the given status and reason.
 func (c *WSClient) Close(status websocket.StatusCode, reason string) error {
 	if c == nil || c.conn == nil {
@@ -117,13 +125,10 @@ func (c *WSClient) Close(status websocket.StatusCode, reason string) error {
 }
 
 // Read reads the next message from the websocket connection.
-// If the context has no deadline, a default read timeout from the config is applied.
+// No default timeout is injected because coder/websocket destroys the
+// underlying TCP connection when a read context expires (coder/websocket#242).
+// Callers that need a bounded read should pass a context with a deadline.
 func (c *WSClient) Read(ctx context.Context) (websocket.MessageType, []byte, error) {
-	if deadline, ok := ctx.Deadline(); !ok || time.Until(deadline) <= 0 {
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, c.config.ReadTimeout)
-		defer cancel()
-	}
 	return c.conn.Read(ctx)
 }
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Fixes an issue in op-conductor's websocket proxy, which previously caused it to consistently disconnect downstream clients every 30s

Downstream (`readPump`): replace manual `Read` loop with `CloseRead`, which drains control frames internally and returns a context that cancels on connection close. Subscribe-only clients never send data messages, so `CloseRead` is the correct primitive.

Upstream (`listenToRollupBoost`): replace `Read` with 30s timeout context with a long-lived `Read` plus a separate `pingUpstream` goroutine that detects stale connections and triggers reconnection via read error.

Both paths previously used per-`Read` timeout contexts that caused `coder/websocket` to destroy the TCP connection every 30s (https://github.com/coder/websocket/issues/242), resulting in periodic flashblock gaps.

Also: `WSClient.Read` was injecting a default 30s timeout, which silently killed long-lived connections.

**Tests**

Adds tests to validate that the websocket connection does not time out after the configured ping/pong cadence. This uses a shortened cadence in tests to avoid spending 30s+ on these tests.

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
