### PR TITLE
fix(mise): rename deprecated [alias] to [tool_alias]

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -49,7 +49,7 @@ git-cliff = "2.12.0"
 kontrol = "1.0.90"
 binary_signer = "1.0.4"
 
-[alias]
+[tool_alias]
 forge = "ubi:foundry-rs/foundry[exe=forge]"
 cast = "ubi:foundry-rs/foundry[exe=cast]"
 anvil = "ubi:foundry-rs/foundry[exe=anvil]"


### PR DESCRIPTION
## Summary
- Renames the deprecated `[alias]` section to `[tool_alias]` in `mise.toml`, fixing the deprecation warning on mise startup.

## Test plan
- [x] Verified `mise` no longer emits the `deprecated [alias]` warning after this change.