### PR TITLE
op-batcher: Record `unsafe_da_bytes` metric even when throttling disabled

### DIFF
--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -423,7 +423,7 @@ func (l *BatchSubmitter) unsafeDABytes() int64 {
 }
 
 // sendToThrottlingLoop sends the current unsafe bytes to the throttling loop.
-// It is not blocking, no signal will be sent if the channel is full.
+// It is not blocking, no signal will be sent if the channel is full or if the throttling loop is not running.
 func (l *BatchSubmitter) sendToThrottlingLoop(unsafeBytesUpdated chan int64) {
 	unsafeDABytes := l.unsafeDABytes()
 	l.Metr.RecordUnsafeDABytes(unsafeDABytes)
@@ -431,6 +431,7 @@ func (l *BatchSubmitter) sendToThrottlingLoop(unsafeBytesUpdated chan int64) {
 	select {
 	case unsafeBytesUpdated <- unsafeDABytes:
 	default:
+		// drop the update if there is no ready reader for the channel
 	}
 }
 

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -428,10 +428,11 @@ func (l *BatchSubmitter) sendToThrottlingLoop(unsafeBytesUpdated chan int64) {
 	if l.Config.ThrottleParams.LowerThreshold == 0 {
 		return
 	}
-
+	unsafeDABytes := l.unsafeDABytes()
+	l.Metr.RecordUnsafeDABytes(unsafeDABytes)
 	// notify the throttling loop it may be time to initiate throttling without blocking
 	select {
-	case unsafeBytesUpdated <- l.unsafeDABytes():
+	case unsafeBytesUpdated <- unsafeDABytes:
 	default:
 	}
 }
@@ -703,7 +704,6 @@ func (l *BatchSubmitter) throttlingLoop(wg *sync.WaitGroup, unsafeBytesUpdated c
 	}
 
 	for unsafeBytes := range unsafeBytesUpdated {
-		l.Metr.RecordUnsafeDABytes(unsafeBytes)
 		newParams := l.throttleController.Update(uint64(unsafeBytes))
 		controllerType := l.throttleController.GetType()
 

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -425,9 +425,6 @@ func (l *BatchSubmitter) unsafeDABytes() int64 {
 // sendToThrottlingLoop sends the current unsafe bytes to the throttling loop.
 // It is not blocking, no signal will be sent if the channel is full.
 func (l *BatchSubmitter) sendToThrottlingLoop(unsafeBytesUpdated chan int64) {
-	if l.Config.ThrottleParams.LowerThreshold == 0 {
-		return
-	}
 	unsafeDABytes := l.unsafeDABytes()
 	l.Metr.RecordUnsafeDABytes(unsafeDABytes)
 	// notify the throttling loop it may be time to initiate throttling without blocking

--- a/op-batcher/batcher/driver_test.go
+++ b/op-batcher/batcher/driver_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-batcher/metrics"
 	"github.com/ethereum-optimism/optimism/op-service/dial"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
@@ -379,6 +380,110 @@ func TestBatchSubmitter_ThrottlingEndpoints(t *testing.T) {
 	t.Run("two normal endpoints", testThrottlingEndpoints(2, 0))
 	t.Run("two failing endpoints", testThrottlingEndpoints(0, 2))
 	t.Run("one normal endpoint, one failing endpoint", testThrottlingEndpoints(1, 1))
+	t.Run("throttling disabled", testThrottlingDisabled)
+}
+
+// testThrottlingDisabled verifies that the batcher works correctly when throttling
+// is disabled (LowerThreshold = 0), and that the throttling loop never starts.
+func testThrottlingDisabled(t *testing.T) {
+	// Create a mock HTTP server to receive throttle updates
+	updateReceived := false
+	server := httptest.NewServer(createHTTPHandler(t, func() {
+		updateReceived = true
+	}, noFailure))
+	defer server.Close()
+
+	// Setup test context
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Create real metrics instead of NoopMetrics so we can verify metric recording
+	metr := metrics.NewMetrics("test")
+
+	ep := newEndpointProvider()
+	cfg := defaultTestRollupConfig
+	cfg.Genesis.L1.Number = genesisL1Origin
+
+	// Create test BatchSubmitter with throttling DISABLED (LowerThreshold = 0)
+	bs := NewBatchSubmitter(DriverSetup{
+		closeApp:     func(cause error) {},
+		Log:          testlog.Logger(t, log.LevelDebug),
+		Metr:         metr, // Use real metrics
+		RollupConfig: cfg,
+		Config: BatcherConfig{
+			ThrottleParams: config.ThrottleParams{
+				ControllerType:      config.StepControllerType,
+				LowerThreshold:      0, // DISABLED
+				UpperThreshold:      0,
+				TxSizeLowerLimit:    5000,
+				TxSizeUpperLimit:    10000,
+				BlockSizeLowerLimit: 20000,
+				BlockSizeUpperLimit: 30000,
+				Endpoints:           []string{server.URL},
+			},
+			NetworkTimeout: time.Second,
+		},
+		ChannelConfig:    defaultTestChannelConfig(),
+		EndpointProvider: ep,
+	})
+
+	bs.shutdownCtx = ctx
+
+	// Create channel (even though throttling loop won't read from it)
+	pendingBytesUpdated := make(chan int64, 10)
+
+	// In the production Start() method, there's a check:
+	// if l.Config.ThrottleParams.LowerThreshold > 0 {
+	//     l.wg.Add(1)
+	//     go l.throttlingLoop(l.wg, unsafeBytesUpdated)
+	// }
+	// We simulate this by not calling throttlingLoop
+
+	// However, the driver should still record the unsafe_da_bytes metric when it processes blocks
+	// First, add a block to the channel manager so unsafeDABytes() returns > 0
+	testBlock := newMiniL2Block(5) // Create a block with 5 transactions
+	err := bs.channelMgr.AddL2Block(testBlock)
+	require.NoError(t, err, "Should be able to add block to channel manager")
+
+	// Now call sendToThrottlingLoop to simulate what happens during block loading
+	// This method ALWAYS records the metric, even if the throttling loop isn't running
+	bs.sendToThrottlingLoop(pendingBytesUpdated)
+
+	// Wait a moment for async metric recording
+	time.Sleep(100 * time.Millisecond)
+
+	// The server should not have received any calls because throttling loop was never started
+	require.False(t, updateReceived, "No throttle updates should be sent when throttling is disabled")
+
+	// Verify the throttle controller remains in default state
+	_, params := bs.throttleController.Load()
+	require.False(t, params.IsThrottling(), "Should not be throttling when disabled")
+	require.Equal(t, 0.0, params.Intensity, "Intensity should be 0 when throttling is disabled")
+
+	// Verify metrics: unsafe_da_bytes metric should still be registered and queryable
+	// even with throttling disabled, though it won't be updated by the throttling loop
+	c := opmetrics.NewMetricChecker(t, metr.Registry())
+	prefix := "op_batcher_test_"
+
+	// The unsafe_da_bytes gauge should exist in the registry
+	unsafeDABytesFamily := c.FindByName(prefix + "unsafe_da_bytes")
+	require.NotNil(t, unsafeDABytesFamily, "unsafe_da_bytes metric should exist even with throttling disabled")
+
+	// Get the metric from the family (it has no labels, so we use empty map)
+	unsafeDABytesMetric := unsafeDABytesFamily.FindByLabels(map[string]string{})
+	require.NotNil(t, unsafeDABytesMetric, "unsafe_da_bytes metric should be queryable")
+
+	// The metric should be greater than 0 since we added a block and called sendToThrottlingLoop
+	// This proves the driver updates the metric even when throttling is disabled
+	metricValue := unsafeDABytesMetric.Gauge.GetValue()
+	require.Greater(t, metricValue, 0.0, "unsafe_da_bytes should be > 0 after adding blocks")
+	t.Logf("unsafe_da_bytes metric value: %.0f (block with 5 txs was added)", metricValue)
+
+	t.Log("Verified: throttling loop does not run when LowerThreshold=0")
+	t.Log("Verified: unsafe_da_bytes metric is recorded by driver even with throttling disabled")
+
+	cancel()
+	close(pendingBytesUpdated)
 }
 
 func TestBatchSubmitter_CriticalError(t *testing.T) {

--- a/op-batcher/batcher/driver_test.go
+++ b/op-batcher/batcher/driver_test.go
@@ -290,7 +290,7 @@ func TestBatchSubmitter_ThrottlingEndpoints(t *testing.T) {
 			// Start throttling loop in a goroutine
 			go bs.throttlingLoop(&wg1, pendingBytesUpdated)
 
-			// Simulate block loading by sending periodically on pendingBytesUpdated
+			// Simulate block loading by calling sendToThrottlingLoop periodically
 			wg2 := sync.WaitGroup{}
 			blockLoadingCtx, cancelBlockLoading := context.WithCancel(context.Background())
 			go func() {
@@ -301,8 +301,9 @@ func TestBatchSubmitter_ThrottlingEndpoints(t *testing.T) {
 					case <-blockLoadingCtx.Done():
 						return
 					default:
-						// Simulate block loading
-						pendingBytesUpdated <- 20000 // the value doesn't actually matter for this test
+						// Simulate block loading - use sendToThrottlingLoop which records metrics
+						// and sends to the channel (this is what the real block loading loop does)
+						bs.sendToThrottlingLoop(pendingBytesUpdated)
 					}
 				}
 

--- a/op-batcher/batcher/driver_test.go
+++ b/op-batcher/batcher/driver_test.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ethereum-optimism/optimism/op-batcher/batcher/throttler"
 	"github.com/ethereum-optimism/optimism/op-batcher/config"
 	"github.com/ethereum-optimism/optimism/op-batcher/metrics"
 	"github.com/ethereum-optimism/optimism/op-service/dial"
@@ -234,7 +233,7 @@ func createHTTPHandler(t *testing.T, cb func(), failureMode handlerFailureMode) 
 func TestBatchSubmitter_ThrottlingEndpoints(t *testing.T) {
 	// Set a very long timeout to avoid flakiness
 	timeout := time.Second * 120
-	testThrottlingEndpoints := func(numHealthyServers, numUnhealthyServers int) func(t *testing.T) {
+	testThrottlingEndpoints := func(numHealthyServers, numUnhealthyServers int, throttlingEnabled bool) func(t *testing.T) {
 
 		return func(t *testing.T) {
 			healthyCalls := make([]int, numHealthyServers)
@@ -259,36 +258,70 @@ func TestBatchSubmitter_ThrottlingEndpoints(t *testing.T) {
 			// Setup test context
 			ctx, cancel := context.WithCancel(context.Background())
 
-			// Add in an endpoint with no server at all, representing an "always down" endpoint
-			urls = append(urls, "http://invalid/")
+			// Add in an endpoint with no server at all, representing an "always down" endpoint (only when throttling enabled)
+			if throttlingEnabled {
+				urls = append(urls, "http://invalid/")
+			}
 
 			t.Log("Throttling endpoints:", urls)
+			t.Logf("Throttling enabled: %v", throttlingEnabled)
 
 			var batcherShutdownError error
 
-			// Create test BatchSubmitter using the setup function
-			bs, _ := setup(t, func(cause error) {
-				batcherShutdownError = cause
+			// Create real metrics instead of NoopMetrics so we can verify metric recording
+			metr := metrics.NewMetrics("test")
+
+			ep := newEndpointProvider()
+			cfg := defaultTestRollupConfig
+			cfg.Genesis.L1.Number = genesisL1Origin
+
+			// Set threshold values based on whether throttling is enabled
+			lowerThreshold := uint64(0)
+			upperThreshold := uint64(0)
+			if throttlingEnabled {
+				lowerThreshold = 10000
+				upperThreshold = 20000
+			}
+
+			// Create test BatchSubmitter
+			bs := NewBatchSubmitter(DriverSetup{
+				closeApp:     func(cause error) { batcherShutdownError = cause },
+				Log:          testlog.Logger(t, log.LevelDebug),
+				Metr:         metr, // Use real metrics
+				RollupConfig: cfg,
+				Config: BatcherConfig{
+					ThrottleParams: config.ThrottleParams{
+						ControllerType:      config.StepControllerType,
+						LowerThreshold:      lowerThreshold,
+						UpperThreshold:      upperThreshold,
+						TxSizeLowerLimit:    5000,
+						TxSizeUpperLimit:    10000,
+						BlockSizeLowerLimit: 20000,
+						BlockSizeUpperLimit: 30000,
+						Endpoints:           urls,
+					},
+					NetworkTimeout: time.Second,
+				},
+				ChannelConfig:    defaultTestChannelConfig(),
+				EndpointProvider: ep,
 			})
+
 			bs.shutdownCtx = ctx
-			bs.Config.NetworkTimeout = time.Second
-			bs.Config.ThrottleParams.Endpoints = urls
-			bs.throttleController = throttler.NewThrottleController(
-				throttler.NewStepStrategy(10000),
-				throttler.ThrottleConfig{
-					TxSizeLowerLimit:    5000,
-					TxSizeUpperLimit:    10000,
-					BlockSizeLowerLimit: 20000,
-					BlockSizeUpperLimit: 30000,
-				})
 
 			// Test the throttling loop
 			pendingBytesUpdated := make(chan int64, 1)
 			wg1 := sync.WaitGroup{}
-			wg1.Add(1)
 
-			// Start throttling loop in a goroutine
-			go bs.throttlingLoop(&wg1, pendingBytesUpdated)
+			// Start throttling loop in a goroutine only if throttling is enabled
+			if throttlingEnabled {
+				wg1.Add(1)
+				go bs.throttlingLoop(&wg1, pendingBytesUpdated)
+			}
+
+			// Add a block to the channel manager so unsafeDABytes() returns > 0
+			testBlock := newMiniL2Block(5) // Create a block with 5 transactions
+			err := bs.channelMgr.AddL2Block(testBlock)
+			require.NoError(t, err, "Should be able to add block to channel manager")
 
 			// Simulate block loading by calling sendToThrottlingLoop periodically
 			wg2 := sync.WaitGroup{}
@@ -318,173 +351,95 @@ func TestBatchSubmitter_ThrottlingEndpoints(t *testing.T) {
 				cancel()
 			})
 
-			require.Eventually(t,
-				func() bool {
-					// Check that all endpoints were called
-					if slices.Contains(healthyCalls, 0) || slices.Contains(unHealthyCalls, 0) {
-						return false
+			// Verify metrics: unsafe_da_bytes metric should be recorded in all cases
+			time.Sleep(200 * time.Millisecond) // Wait for metric updates
+			c := opmetrics.NewMetricChecker(t, metr.Registry())
+			prefix := "op_batcher_test_"
+			unsafeDABytesFamily := c.FindByName(prefix + "unsafe_da_bytes")
+			require.NotNil(t, unsafeDABytesFamily, "unsafe_da_bytes metric should exist")
+			unsafeDABytesMetric := unsafeDABytesFamily.FindByLabels(map[string]string{})
+			require.NotNil(t, unsafeDABytesMetric, "unsafe_da_bytes metric should be queryable")
+			metricValue := unsafeDABytesMetric.Gauge.GetValue()
+			require.Greater(t, metricValue, 0.0, "unsafe_da_bytes should be > 0 after adding blocks")
+			t.Logf("unsafe_da_bytes metric value: %.0f", metricValue)
+
+			if throttlingEnabled {
+				// Only check endpoint calls when throttling is enabled
+				require.Eventually(t,
+					func() bool {
+						// Check that all endpoints were called
+						if slices.Contains(healthyCalls, 0) || slices.Contains(unHealthyCalls, 0) {
+							return false
+						}
+						return true
+					}, time.Second*10, time.Millisecond*10, "All endpoints should have been called within 10s")
+
+				startTestServerAtAddr := func(addr string, handler http.HandlerFunc) *httptest.Server {
+					ln, err := net.Listen("tcp", addr)
+					require.NoError(t, err, "Failed to create new listener for test server")
+
+					s := &httptest.Server{
+						Listener: ln,
+						Config:   &http.Server{Handler: handler},
 					}
-					return true
-				}, time.Second*10, time.Millisecond*10, "All endpoints should have been called within 10s")
-
-			startTestServerAtAddr := func(addr string, handler http.HandlerFunc) *httptest.Server {
-				ln, err := net.Listen("tcp", addr)
-				require.NoError(t, err, "Failed to create new listener for test server")
-
-				s := &httptest.Server{
-					Listener: ln,
-					Config:   &http.Server{Handler: handler},
+					s.Start()
+					return s
 				}
-				s.Start()
-				return s
-			}
 
-			// Take one of the healthy servers down, wait 2s and restart. Check it is called again.
-			if len(healthyServers) > 0 {
-				restartedServerCalled := false
+				// Take one of the healthy servers down, wait 2s and restart. Check it is called again.
+				if len(healthyServers) > 0 {
+					restartedServerCalled := false
 
-				addr := healthyServers[0].Listener.Addr().String()
-				healthyServers[0].Close()
-				time.Sleep(time.Second * 2)
-				startTestServerAtAddr(addr, createHTTPHandler(t, func() { restartedServerCalled = true }, noFailure))
-				defer healthyServers[0].Close()
-				t.Log("restarted server at", addr)
+					addr := healthyServers[0].Listener.Addr().String()
+					healthyServers[0].Close()
+					time.Sleep(time.Second * 2)
+					startTestServerAtAddr(addr, createHTTPHandler(t, func() { restartedServerCalled = true }, noFailure))
+					defer healthyServers[0].Close()
+					t.Log("restarted server at", addr)
 
-				require.Eventually(t, func() bool {
-					return restartedServerCalled
-				}, timeout, time.Millisecond*10, "Restarted server should have been called within 2s")
-			}
+					require.Eventually(t, func() bool {
+						return restartedServerCalled
+					}, timeout, time.Millisecond*10, "Restarted server should have been called within 2s")
+				}
 
-			// Take an unhealthy server down, wait 2s and bring it back up with misconfiguration. Check the batcher exits.
-			if len(unhealthyServers) > 0 {
-				restartedServerCalled := false
+				// Take an unhealthy server down, wait 2s and bring it back up with misconfiguration. Check the batcher exits.
+				if len(unhealthyServers) > 0 {
+					restartedServerCalled := false
 
-				addr := unhealthyServers[0].Listener.Addr().String()
-				unhealthyServers[0].Close()
-				time.Sleep(time.Second * 2)
-				startTestServerAtAddr(addr, createHTTPHandler(t, func() { restartedServerCalled = true }, methodNotFound))
-				defer unhealthyServers[0].Close()
-				t.Log("restarted server at", addr)
+					addr := unhealthyServers[0].Listener.Addr().String()
+					unhealthyServers[0].Close()
+					time.Sleep(time.Second * 2)
+					startTestServerAtAddr(addr, createHTTPHandler(t, func() { restartedServerCalled = true }, methodNotFound))
+					defer unhealthyServers[0].Close()
+					t.Log("restarted server at", addr)
 
-				require.Eventually(t, func() bool {
-					return restartedServerCalled
-				}, timeout, time.Millisecond*10, "Restarted server should have been called within 2s")
+					require.Eventually(t, func() bool {
+						return restartedServerCalled
+					}, timeout, time.Millisecond*10, "Restarted server should have been called within 2s")
 
-				require.Eventually(t, func() bool {
-					return batcherShutdownError != nil
-				}, timeout, time.Millisecond*10, "Batcher should have triggered self shutdown within 2s")
+					require.Eventually(t, func() bool {
+						return batcherShutdownError != nil
+					}, timeout, time.Millisecond*10, "Batcher should have triggered self shutdown within 2s")
 
-				require.Equal(t, batcherShutdownError.Error(), ErrSetMaxDASizeRPCMethodUnavailable("http://"+addr, errors.New("method not found")).Error(), "Batcher shutdown error should be the same as the expected error")
+					require.Equal(t, batcherShutdownError.Error(), ErrSetMaxDASizeRPCMethodUnavailable("http://"+addr, errors.New("method not found")).Error(), "Batcher shutdown error should be the same as the expected error")
+				}
+			} else {
+				// When throttling is disabled, verify endpoints were NOT called
+				time.Sleep(time.Second * 2) // Wait to ensure no calls are made
+				for i := range healthyCalls {
+					require.Equal(t, 0, healthyCalls[i], "No endpoint calls should be made when throttling is disabled")
+				}
+				for i := range unHealthyCalls {
+					require.Equal(t, 0, unHealthyCalls[i], "No endpoint calls should be made when throttling is disabled")
+				}
+				t.Log("Verified: no endpoint calls when throttling disabled")
 			}
 		}
 	}
-	t.Run("two normal endpoints", testThrottlingEndpoints(2, 0))
-	t.Run("two failing endpoints", testThrottlingEndpoints(0, 2))
-	t.Run("one normal endpoint, one failing endpoint", testThrottlingEndpoints(1, 1))
-	t.Run("throttling disabled", testThrottlingDisabled)
-}
-
-// testThrottlingDisabled verifies that the batcher works correctly when throttling
-// is disabled (LowerThreshold = 0), and that the throttling loop never starts.
-func testThrottlingDisabled(t *testing.T) {
-	// Create a mock HTTP server to receive throttle updates
-	updateReceived := false
-	server := httptest.NewServer(createHTTPHandler(t, func() {
-		updateReceived = true
-	}, noFailure))
-	defer server.Close()
-
-	// Setup test context
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	// Create real metrics instead of NoopMetrics so we can verify metric recording
-	metr := metrics.NewMetrics("test")
-
-	ep := newEndpointProvider()
-	cfg := defaultTestRollupConfig
-	cfg.Genesis.L1.Number = genesisL1Origin
-
-	// Create test BatchSubmitter with throttling DISABLED (LowerThreshold = 0)
-	bs := NewBatchSubmitter(DriverSetup{
-		closeApp:     func(cause error) {},
-		Log:          testlog.Logger(t, log.LevelDebug),
-		Metr:         metr, // Use real metrics
-		RollupConfig: cfg,
-		Config: BatcherConfig{
-			ThrottleParams: config.ThrottleParams{
-				ControllerType:      config.StepControllerType,
-				LowerThreshold:      0, // DISABLED
-				UpperThreshold:      0,
-				TxSizeLowerLimit:    5000,
-				TxSizeUpperLimit:    10000,
-				BlockSizeLowerLimit: 20000,
-				BlockSizeUpperLimit: 30000,
-				Endpoints:           []string{server.URL},
-			},
-			NetworkTimeout: time.Second,
-		},
-		ChannelConfig:    defaultTestChannelConfig(),
-		EndpointProvider: ep,
-	})
-
-	bs.shutdownCtx = ctx
-
-	// Create channel (even though throttling loop won't read from it)
-	pendingBytesUpdated := make(chan int64, 10)
-
-	// In the production Start() method, there's a check:
-	// if l.Config.ThrottleParams.LowerThreshold > 0 {
-	//     l.wg.Add(1)
-	//     go l.throttlingLoop(l.wg, unsafeBytesUpdated)
-	// }
-	// We simulate this by not calling throttlingLoop
-
-	// However, the driver should still record the unsafe_da_bytes metric when it processes blocks
-	// First, add a block to the channel manager so unsafeDABytes() returns > 0
-	testBlock := newMiniL2Block(5) // Create a block with 5 transactions
-	err := bs.channelMgr.AddL2Block(testBlock)
-	require.NoError(t, err, "Should be able to add block to channel manager")
-
-	// Now call sendToThrottlingLoop to simulate what happens during block loading
-	// This method ALWAYS records the metric, even if the throttling loop isn't running
-	bs.sendToThrottlingLoop(pendingBytesUpdated)
-
-	// Wait a moment for async metric recording
-	time.Sleep(100 * time.Millisecond)
-
-	// The server should not have received any calls because throttling loop was never started
-	require.False(t, updateReceived, "No throttle updates should be sent when throttling is disabled")
-
-	// Verify the throttle controller remains in default state
-	_, params := bs.throttleController.Load()
-	require.False(t, params.IsThrottling(), "Should not be throttling when disabled")
-	require.Equal(t, 0.0, params.Intensity, "Intensity should be 0 when throttling is disabled")
-
-	// Verify metrics: unsafe_da_bytes metric should still be registered and queryable
-	// even with throttling disabled, though it won't be updated by the throttling loop
-	c := opmetrics.NewMetricChecker(t, metr.Registry())
-	prefix := "op_batcher_test_"
-
-	// The unsafe_da_bytes gauge should exist in the registry
-	unsafeDABytesFamily := c.FindByName(prefix + "unsafe_da_bytes")
-	require.NotNil(t, unsafeDABytesFamily, "unsafe_da_bytes metric should exist even with throttling disabled")
-
-	// Get the metric from the family (it has no labels, so we use empty map)
-	unsafeDABytesMetric := unsafeDABytesFamily.FindByLabels(map[string]string{})
-	require.NotNil(t, unsafeDABytesMetric, "unsafe_da_bytes metric should be queryable")
-
-	// The metric should be greater than 0 since we added a block and called sendToThrottlingLoop
-	// This proves the driver updates the metric even when throttling is disabled
-	metricValue := unsafeDABytesMetric.Gauge.GetValue()
-	require.Greater(t, metricValue, 0.0, "unsafe_da_bytes should be > 0 after adding blocks")
-	t.Logf("unsafe_da_bytes metric value: %.0f (block with 5 txs was added)", metricValue)
-
-	t.Log("Verified: throttling loop does not run when LowerThreshold=0")
-	t.Log("Verified: unsafe_da_bytes metric is recorded by driver even with throttling disabled")
-
-	cancel()
-	close(pendingBytesUpdated)
+	t.Run("two normal endpoints", testThrottlingEndpoints(2, 0, true))
+	t.Run("two failing endpoints", testThrottlingEndpoints(0, 2, true))
+	t.Run("one normal endpoint, one failing endpoint", testThrottlingEndpoints(1, 1, true))
+	t.Run("throttling disabled", testThrottlingEndpoints(1, 0, false))
 }
 
 func TestBatchSubmitter_CriticalError(t *testing.T) {


### PR DESCRIPTION
This means we can still track the metric when throttling is disabled.

Adds to unit tests showing that metrics are always emitted even when throttling is not enabled. 