### PR TITLE
chore(ci): remove YAML anchors from CircleCI configs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ workflows:
     when:
       equal: ["", << pipeline.git.tag >>]
     jobs:
-      - path-filtering/filter: &path_filter
+      - path-filtering/filter:
           base-revision: develop
           config-path: .circleci/continue/main.yml
           mapping: |
@@ -146,7 +146,43 @@ workflows:
         equal: ["", << pipeline.git.tag >>]
     jobs:
       - path-filtering/filter:
-          <<: *path_filter
+          base-revision: develop
+          config-path: .circleci/continue/main.yml
+          mapping: |
+            .* default_docker_image << pipeline.parameters.default_docker_image >> .circleci/continue/main.yml
+            .* base_image << pipeline.parameters.base_image >> .circleci/continue/main.yml
+            .* main_dispatch << pipeline.parameters.main_dispatch >> .circleci/continue/main.yml
+            .* fault_proofs_dispatch << pipeline.parameters.fault_proofs_dispatch >> .circleci/continue/main.yml
+            .* reproducibility_dispatch << pipeline.parameters.reproducibility_dispatch >> .circleci/continue/main.yml
+            .* kontrol_dispatch << pipeline.parameters.kontrol_dispatch >> .circleci/continue/main.yml
+            .* cannon_full_test_dispatch << pipeline.parameters.cannon_full_test_dispatch >> .circleci/continue/main.yml
+            .* sdk_dispatch << pipeline.parameters.sdk_dispatch >> .circleci/continue/main.yml
+            .* docker_publish_dispatch << pipeline.parameters.docker_publish_dispatch >> .circleci/continue/main.yml
+            .* publish_contract_artifacts_dispatch << pipeline.parameters.publish_contract_artifacts_dispatch >> .circleci/continue/main.yml
+            .* stale_check_dispatch << pipeline.parameters.stale_check_dispatch >> .circleci/continue/main.yml
+            .* contracts_coverage_dispatch << pipeline.parameters.contracts_coverage_dispatch >> .circleci/continue/main.yml
+            .* heavy_fuzz_dispatch << pipeline.parameters.heavy_fuzz_dispatch >> .circleci/continue/main.yml
+            .* acceptance_tests_dispatch << pipeline.parameters.acceptance_tests_dispatch >> .circleci/continue/main.yml
+            .* sync_test_op_node_dispatch << pipeline.parameters.sync_test_op_node_dispatch >> .circleci/continue/main.yml
+            .* ai_contracts_test_dispatch << pipeline.parameters.ai_contracts_test_dispatch >> .circleci/continue/main.yml
+            .* github-event-type << pipeline.parameters.github-event-type >> .circleci/continue/main.yml
+            .* github-event-action << pipeline.parameters.github-event-action >> .circleci/continue/main.yml
+            .* github-event-base64 << pipeline.parameters.github-event-base64 >> .circleci/continue/main.yml
+            .* devnet-metrics-collect << pipeline.parameters.devnet-metrics-collect >> .circleci/continue/main.yml
+            .* flake-shake-dispatch << pipeline.parameters.flake-shake-dispatch >> .circleci/continue/main.yml
+            .* flake-shake-iterations << pipeline.parameters.flake-shake-iterations >> .circleci/continue/main.yml
+            .* flake-shake-workers << pipeline.parameters.flake-shake-workers >> .circleci/continue/main.yml
+            .* go-cache-version << pipeline.parameters.go-cache-version >> .circleci/continue/main.yml
+
+            rust/.* rust_ci_dispatch << pipeline.parameters.rust_ci_dispatch >> .circleci/continue/rust-ci.yml
+            rust/.* default_docker_image << pipeline.parameters.default_docker_image >> .circleci/continue/rust-ci.yml
+            rust/.* base_image << pipeline.parameters.base_image >> .circleci/continue/rust-ci.yml
+            rust/.* go-cache-version << pipeline.parameters.go-cache-version >> .circleci/continue/rust-ci.yml
+
+            rust/.* rust_e2e_dispatch << pipeline.parameters.rust_e2e_dispatch >> .circleci/continue/rust-e2e.yml
+            rust/.* default_docker_image << pipeline.parameters.default_docker_image >> .circleci/continue/rust-e2e.yml
+            rust/.* go-cache-version << pipeline.parameters.go-cache-version >> .circleci/continue/rust-e2e.yml
+
           filters:
             tags:
               only: /.*/

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -3006,7 +3006,7 @@ workflows:
           features: <<matrix.features>>
           matrix:
             parameters:
-              features: &features_matrix
+              features:
                 - main
                 - CUSTOM_GAS_TOKEN
                 - OPTIMISM_PORTAL_INTEROP
@@ -3022,7 +3022,13 @@ workflows:
           features: <<matrix.features>>
           matrix:
             parameters:
-              features: *features_matrix
+              features:
+                - main
+                - CUSTOM_GAS_TOKEN
+                - OPTIMISM_PORTAL_INTEROP
+                - OPCM_V2
+                - OPCM_V2,CUSTOM_GAS_TOKEN
+                - OPCM_V2,OPTIMISM_PORTAL_INTEROP
           context:
             - circleci-repo-readonly-authenticated-github-token
             - slack
@@ -3035,7 +3041,13 @@ workflows:
           features: <<matrix.features>>
           matrix:
             parameters:
-              features: *features_matrix
+              features:
+                - main
+                - CUSTOM_GAS_TOKEN
+                - OPTIMISM_PORTAL_INTEROP
+                - OPCM_V2
+                - OPCM_V2,CUSTOM_GAS_TOKEN
+                - OPCM_V2,OPTIMISM_PORTAL_INTEROP
           context:
             - circleci-repo-readonly-authenticated-github-token
             - slack
@@ -3047,7 +3059,13 @@ workflows:
           features: <<matrix.features>>
           matrix:
             parameters:
-              features: *features_matrix
+              features:
+                - main
+                - CUSTOM_GAS_TOKEN
+                - OPTIMISM_PORTAL_INTEROP
+                - OPCM_V2
+                - OPCM_V2,CUSTOM_GAS_TOKEN
+                - OPCM_V2,OPTIMISM_PORTAL_INTEROP
           context:
             - circleci-repo-readonly-authenticated-github-token
             - slack
@@ -3519,7 +3537,7 @@ workflows:
           profile: "release"
           context:
             - circleci-repo-readonly-authenticated-github-token
-      - rust-build-submodule: &rust-build-op-rbuilder
+      - rust-build-submodule:
           name: rust-build-op-rbuilder
           directory: op-rbuilder
           binaries: "op-rbuilder"
@@ -3527,7 +3545,7 @@ workflows:
           needs_clang: true
           context:
             - circleci-repo-readonly-authenticated-github-token
-      - rust-build-submodule: &rust-build-rollup-boost
+      - rust-build-submodule:
           name: rust-build-rollup-boost
           directory: rollup-boost
           binaries: "rollup-boost"
@@ -3648,7 +3666,7 @@ workflows:
       - cannon-kona-prestate: # needed for sysgo tests (if any package is in-memory)
           context:
             - circleci-repo-readonly-authenticated-github-token
-      - rust-build-binary: &cannon-kona-host
+      - rust-build-binary:
           name: cannon-kona-host
           directory: rust
           profile: "release"
@@ -3656,7 +3674,7 @@ workflows:
           save_cache: true
           context:
             - circleci-repo-readonly-authenticated-github-token
-      - rust-build-binary: &kona-build-release
+      - rust-build-binary:
           name: kona-build-release
           directory: rust
           profile: "release"
@@ -3664,8 +3682,21 @@ workflows:
           save_cache: true
           context:
             - circleci-repo-readonly-authenticated-github-token
-      - rust-build-submodule: *rust-build-op-rbuilder
-      - rust-build-submodule: *rust-build-rollup-boost
+      - rust-build-submodule:
+          name: rust-build-op-rbuilder
+          directory: op-rbuilder
+          binaries: "op-rbuilder"
+          build_command: cargo build --release -p op-rbuilder --bin op-rbuilder
+          needs_clang: true
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+      - rust-build-submodule:
+          name: rust-build-rollup-boost
+          directory: rollup-boost
+          binaries: "rollup-boost"
+          build_command: cargo build --release -p rollup-boost --bin rollup-boost
+          context:
+            - circleci-repo-readonly-authenticated-github-token
       - rust-binaries-for-sysgo:
           requires:
             - kona-build-release

--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -110,7 +110,7 @@ commands:
 
   rust-restore-build-cache:
     description: "Restore the target directory cache for a Rust workspace"
-    parameters: &cache-params
+    parameters:
       directory:
         description: "Directory containing the Cargo workspace"
         type: string
@@ -144,7 +144,26 @@ commands:
 
   rust-save-build-cache:
     description: "Save the target directory cache for a Rust workspace"
-    parameters: *cache-params
+    parameters:
+      directory:
+        description: "Directory containing the Cargo workspace"
+        type: string
+      version:
+        description: "Version of the cache"
+        type: string
+        default: "15"
+      profile:
+        description: "Profile to restore the cache for"
+        type: string
+        default: "debug"
+      features:
+        description: "Comma-separated list of features to restore the cache for"
+        type: string
+        default: ""
+      prefix:
+        description: "Prefix to add to the cache key"
+        type: string
+        default: "rust-build"
     steps:
       - save_cache:
           key: << parameters.prefix >>-registry-v<< parameters.version >>-{{ checksum "<< parameters.directory >>/Cargo.lock" }}
@@ -163,7 +182,21 @@ commands:
   rust-prepare-and-restore-cache:
     description: "Prepare the Rust environment and restore the cache"
     parameters:
-      <<: *cache-params
+      directory:
+        description: "Directory containing the Cargo workspace"
+        type: string
+      version:
+        description: "Version of the cache"
+        type: string
+        default: "15"
+      profile:
+        description: "Profile to restore the cache for"
+        type: string
+        default: "debug"
+      prefix:
+        description: "Prefix to add to the cache key"
+        type: string
+        default: "rust-build"
       needs_clang:
         description: "Whether to install clang (needed by bindgen for reth-mdbx-sys)"
         type: boolean
@@ -185,7 +218,21 @@ commands:
   rust-build:
     description: "Build a Rust workspace with target directory caching"
     parameters:
-      <<: *cache-params
+      directory:
+        description: "Directory containing the Cargo workspace"
+        type: string
+      version:
+        description: "Version of the cache"
+        type: string
+        default: "15"
+      profile:
+        description: "Profile to restore the cache for"
+        type: string
+        default: "debug"
+      prefix:
+        description: "Prefix to add to the cache key"
+        type: string
+        default: "rust-build"
       needs_clang:
         description: "Whether to install clang (needed by bindgen for reth-mdbx-sys)"
         type: boolean
@@ -331,7 +378,7 @@ jobs:
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
-      - rust-prepare-and-restore-cache: &fmt-cache-args
+      - rust-prepare-and-restore-cache:
           directory: <<parameters.directory>>
           prefix: <<parameters.directory>>-fmt
       - rust-install-toolchain:
@@ -342,7 +389,9 @@ jobs:
           name: Check formatting
           working_directory: <<parameters.directory>>
           command: <<parameters.command>>
-      - rust-save-build-cache: *fmt-cache-args
+      - rust-save-build-cache:
+          directory: <<parameters.directory>>
+          prefix: <<parameters.directory>>-fmt
 
   # Shared clippy lint job
   rust-ci-clippy:
@@ -364,7 +413,7 @@ jobs:
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
-      - rust-prepare-and-restore-cache: &clippy-cache-args
+      - rust-prepare-and-restore-cache:
           directory: <<parameters.directory>>
           prefix: <<parameters.directory>>-clippy
           features: "all"
@@ -379,7 +428,10 @@ jobs:
           environment:
             RUSTFLAGS: -Dwarnings
           command: <<parameters.command>>
-      - rust-save-build-cache: *clippy-cache-args
+      - rust-save-build-cache:
+          directory: <<parameters.directory>>
+          prefix: <<parameters.directory>>-clippy
+          features: "all"
 
   # Shared cargo deny job
   rust-ci-deny:
@@ -397,7 +449,7 @@ jobs:
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
-      - rust-prepare-and-restore-cache: &deny-cache-args
+      - rust-prepare-and-restore-cache:
           directory: <<parameters.directory>>
           prefix: <<parameters.directory>>-deny
       - install-cargo-binstall
@@ -409,7 +461,9 @@ jobs:
           name: Run cargo deny
           working_directory: <<parameters.directory>>
           command: <<parameters.command>>
-      - rust-save-build-cache: *deny-cache-args
+      - rust-save-build-cache:
+          directory: <<parameters.directory>>
+          prefix: <<parameters.directory>>-deny
 
   # Shared zepter feature propagation job
   rust-ci-zepter:
@@ -427,7 +481,7 @@ jobs:
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
-      - rust-prepare-and-restore-cache: &zepter-cache-args
+      - rust-prepare-and-restore-cache:
           directory: <<parameters.directory>>
           prefix: <<parameters.directory>>-zepter
       - install-cargo-binstall
@@ -440,7 +494,9 @@ jobs:
           name: Check feature propagation
           working_directory: <<parameters.directory>>
           command: <<parameters.command>>
-      - rust-save-build-cache: *zepter-cache-args
+      - rust-save-build-cache:
+          directory: <<parameters.directory>>
+          prefix: <<parameters.directory>>-zepter
 
   # Shared typos check job
   rust-ci-typos:
@@ -454,7 +510,7 @@ jobs:
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
-      - rust-prepare-and-restore-cache: &typos-cache-args
+      - rust-prepare-and-restore-cache:
           directory: <<parameters.directory>>
           prefix: <<parameters.directory>>-typos
       - install-cargo-binstall
@@ -466,7 +522,9 @@ jobs:
           name: Check for typos
           working_directory: <<parameters.directory>>
           command: typos
-      - rust-save-build-cache: *typos-cache-args
+      - rust-save-build-cache:
+          directory: <<parameters.directory>>
+          prefix: <<parameters.directory>>-typos
 
   # Shared no_std compatibility check job
   rust-ci-check-no-std:
@@ -492,7 +550,7 @@ jobs:
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
-      - rust-prepare-and-restore-cache: &no-std-cache-args
+      - rust-prepare-and-restore-cache:
           directory: <<parameters.directory>>
           prefix: <<parameters.directory>>-no-std
       - rust-install-toolchain:
@@ -503,7 +561,9 @@ jobs:
           working_directory: <<parameters.directory>>
           no_output_timeout: 30m
           command: <<parameters.command>>
-      - rust-save-build-cache: *no-std-cache-args
+      - rust-save-build-cache:
+          directory: <<parameters.directory>>
+          prefix: <<parameters.directory>>-no-std
 
   # Shared documentation build job
   rust-ci-docs:
@@ -525,7 +585,7 @@ jobs:
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
-      - rust-prepare-and-restore-cache: &docs-cache-args
+      - rust-prepare-and-restore-cache:
           directory: <<parameters.directory>>
           prefix: <<parameters.directory>>-docs
           features: "all"
@@ -539,7 +599,10 @@ jobs:
           environment:
             RUSTDOCFLAGS: <<parameters.rustdocflags>>
           command: <<parameters.command>>
-      - rust-save-build-cache: *docs-cache-args
+      - rust-save-build-cache:
+          directory: <<parameters.directory>>
+          prefix: <<parameters.directory>>-docs
+          features: "all"
 
   # Shared doc test job
   rust-ci-doctest:
@@ -557,7 +620,7 @@ jobs:
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
-      - rust-prepare-and-restore-cache: &doctest-cache-args
+      - rust-prepare-and-restore-cache:
           directory: <<parameters.directory>>
           prefix: <<parameters.directory>>-doctest
       - run:
@@ -565,7 +628,9 @@ jobs:
           working_directory: <<parameters.directory>>
           no_output_timeout: 30m
           command: <<parameters.command>>
-      - rust-save-build-cache: *doctest-cache-args
+      - rust-save-build-cache:
+          directory: <<parameters.directory>>
+          prefix: <<parameters.directory>>-doctest
 
   # Shared cargo tests job
   rust-ci-cargo-tests:
@@ -595,7 +660,7 @@ jobs:
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
-      - rust-prepare-and-restore-cache: &tests-cache-args
+      - rust-prepare-and-restore-cache:
           directory: <<parameters.directory>>
           prefix: <<parameters.directory>>-tests
           profile: <<parameters.cache_profile>>
@@ -611,7 +676,10 @@ jobs:
           working_directory: <<parameters.directory>>
           no_output_timeout: 40m
           command: just <<parameters.command>> <<parameters.flags>>
-      - rust-save-build-cache: *tests-cache-args
+      - rust-save-build-cache:
+          directory: <<parameters.directory>>
+          prefix: <<parameters.directory>>-tests
+          profile: <<parameters.cache_profile>>
 
   # Shared unused dependencies check job
   rust-ci-udeps:
@@ -629,7 +697,7 @@ jobs:
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
-      - rust-prepare-and-restore-cache: &udeps-cache-args
+      - rust-prepare-and-restore-cache:
           directory: <<parameters.directory>>
           prefix: <<parameters.directory>>-udeps
           profile: "release"
@@ -646,7 +714,10 @@ jobs:
           working_directory: <<parameters.directory>>
           no_output_timeout: 40m
           command: <<parameters.command>>
-      - rust-save-build-cache: *udeps-cache-args
+      - rust-save-build-cache:
+          directory: <<parameters.directory>>
+          prefix: <<parameters.directory>>-udeps
+          profile: "release"
 
   # Shared cargo hack build job (cross-compile targets like WASM)
   rust-ci-cargo-hack-build:
@@ -667,7 +738,7 @@ jobs:
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
-      - rust-prepare-and-restore-cache: &hack-build-cache-args
+      - rust-prepare-and-restore-cache:
           directory: <<parameters.directory>>
           prefix: <<parameters.directory>>-hack-build
       - install-cargo-binstall
@@ -680,7 +751,9 @@ jobs:
           working_directory: <<parameters.directory>>
           no_output_timeout: 40m
           command: rustup target add <<parameters.target>> && cargo hack build --target <<parameters.target>> <<parameters.flags>>
-      - rust-save-build-cache: *hack-build-cache-args
+      - rust-save-build-cache:
+          directory: <<parameters.directory>>
+          prefix: <<parameters.directory>>-hack-build
 
   # Shared cargo hack job
   rust-ci-cargo-hack:
@@ -696,7 +769,7 @@ jobs:
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
-      - rust-prepare-and-restore-cache: &hack-cache-args
+      - rust-prepare-and-restore-cache:
           directory: rust
           prefix: rust-hack
           features: "all"
@@ -715,7 +788,10 @@ jobs:
               PARTITION_FLAG="$((CIRCLE_NODE_INDEX + 1))/$CIRCLE_NODE_TOTAL"
             fi
             just hack $PARTITION_FLAG
-      - rust-save-build-cache: *hack-cache-args
+      - rust-save-build-cache:
+          directory: rust
+          prefix: rust-hack
+          features: "all"
 
   # --------------------------------------------------------------------------
   # OP-Reth crate-specific jobs
@@ -729,7 +805,7 @@ jobs:
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
-      - rust-prepare-and-restore-cache: &op-reth-compact-cache
+      - rust-prepare-and-restore-cache:
           directory: rust
           prefix: op-reth-compact
           profile: debug
@@ -754,7 +830,10 @@ jobs:
           name: Read compact vectors on PR branch
           command: |
             cargo run --bin op-reth --features "dev" --manifest-path rust/op-reth/bin/Cargo.toml -- test-vectors compact --read
-      - rust-save-build-cache: *op-reth-compact-cache
+      - rust-save-build-cache:
+          directory: rust
+          prefix: op-reth-compact
+          profile: debug
 
   # OP-Reth Windows cross-compile check
   op-reth-windows-check:
@@ -764,7 +843,7 @@ jobs:
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
-      - rust-prepare-and-restore-cache: &op-reth-windows-cache
+      - rust-prepare-and-restore-cache:
           directory: rust
           prefix: op-reth-windows
           profile: debug
@@ -776,7 +855,10 @@ jobs:
           working_directory: rust
           no_output_timeout: 40m
           command: just --justfile op-reth/justfile check-windows
-      - rust-save-build-cache: *op-reth-windows-cache
+      - rust-save-build-cache:
+          directory: rust
+          prefix: op-reth-windows
+          profile: debug
 
   # --------------------------------------------------------------------------
   # Op-Alloy crate-specific jobs
@@ -789,7 +871,7 @@ jobs:
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
-      - rust-prepare-and-restore-cache: &op-alloy-cfg-check-cache
+      - rust-prepare-and-restore-cache:
           directory: rust
           prefix: op-alloy-cfg-check
       - rust-install-toolchain:
@@ -801,7 +883,9 @@ jobs:
           no_output_timeout: 40m
           command: |
             just --justfile op-alloy/Justfile check
-      - rust-save-build-cache: *op-alloy-cfg-check-cache
+      - rust-save-build-cache:
+          directory: rust
+          prefix: op-alloy-cfg-check
 
   # --------------------------------------------------------------------------
   # Kona crate-specific jobs
@@ -914,7 +998,7 @@ jobs:
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
-      - rust-prepare-and-restore-cache: &kona-benches-cache
+      - rust-prepare-and-restore-cache:
           directory: rust
           prefix: kona-benches
       - run:
@@ -923,7 +1007,9 @@ jobs:
           no_output_timeout: 40m
           command: |
             just benches
-      - rust-save-build-cache: *kona-benches-cache
+      - rust-save-build-cache:
+          directory: rust
+          prefix: kona-benches
 
   # Kona Coverage
   kona-coverage:
@@ -933,7 +1019,7 @@ jobs:
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
-      - rust-prepare-and-restore-cache: &kona-coverage-cache
+      - rust-prepare-and-restore-cache:
           directory: rust
           prefix: kona-coverage
           version: "1"
@@ -960,7 +1046,10 @@ jobs:
           disable_search: true
           files: rust/kona/lcov.info
           flags: unit
-      - rust-save-build-cache: *kona-coverage-cache
+      - rust-save-build-cache:
+          directory: rust
+          prefix: kona-coverage
+          version: "1"
 
   # Kona Docs Build
   kona-docs-build:
@@ -1034,7 +1123,7 @@ jobs:
           checkout-method: blobless
       - rust-install-toolchain:
           components: llvm-tools-preview
-      - rust-prepare-and-restore-cache: &kona-publish-prestate-cache
+      - rust-prepare-and-restore-cache:
           directory: rust
           profile: release
       - gcp-cli/install
@@ -1065,7 +1154,9 @@ jobs:
             fi
             gsutil cp ./prestate-artifacts-<<parameters.kind>>/prestate.bin.gz "gs://oplabs-network-data/proofs/kona/<<parameters.kind>>/${PRESTATE_HASH}.bin.gz"
             echo "Successfully published prestates artifacts to GCS"
-      - rust-save-build-cache: *kona-publish-prestate-cache
+      - rust-save-build-cache:
+          directory: rust
+          profile: release
 
 # ============================================================================
 # WORKFLOWS
@@ -1089,73 +1180,85 @@ workflows:
       - rust-ci-fmt:
           name: rust-fmt
           directory: rust
-          context: &rust-ci-context
+          context:
             - circleci-repo-readonly-authenticated-github-token
 
       - rust-ci-clippy:
           name: rust-clippy
           directory: rust
           command: "cargo clippy --workspace --all-targets --all-features --locked"
-          context: *rust-ci-context
+          context:
+            - circleci-repo-readonly-authenticated-github-token
 
       - rust-ci-deny:
           name: rust-deny
           directory: rust
           command: "cargo deny --all-features check all"
-          context: *rust-ci-context
+          context:
+            - circleci-repo-readonly-authenticated-github-token
 
       - rust-ci-typos:
           name: rust-typos
           directory: rust
-          context: *rust-ci-context
+          context:
+            - circleci-repo-readonly-authenticated-github-token
 
       - rust-ci-zepter:
           name: rust-zepter
           directory: rust
-          context: *rust-ci-context
+          context:
+            - circleci-repo-readonly-authenticated-github-token
 
       - rust-ci-cargo-tests:
           name: rust-tests
           directory: rust
-          context: *rust-ci-context
+          context:
+            - circleci-repo-readonly-authenticated-github-token
 
       - rust-ci-doctest:
           name: rust-doctest
           directory: rust
           command: "cargo test --doc --workspace --all-features"
-          context: *rust-ci-context
+          context:
+            - circleci-repo-readonly-authenticated-github-token
 
       - rust-ci-docs:
           name: rust-docs
           directory: rust
-          context: *rust-ci-context
+          context:
+            - circleci-repo-readonly-authenticated-github-token
 
       - rust-ci-udeps:
           name: rust-udeps
           directory: rust
-          context: *rust-ci-context
+          context:
+            - circleci-repo-readonly-authenticated-github-token
 
       - rust-ci-cargo-hack:
           name: rust-cargo-hack
           parallelism: 6
-          context: *rust-ci-context
+          context:
+            - circleci-repo-readonly-authenticated-github-token
 
       - rust-build-binary:
           name: rust-build
           directory: rust
-          context: *rust-ci-context
+          context:
+            - circleci-repo-readonly-authenticated-github-token
 
       - rust-build-binary:
           name: rust-build-release
           directory: rust
           profile: release
-          context: *rust-ci-context
+          context:
+            - circleci-repo-readonly-authenticated-github-token
 
       - rust-build-binary:
           name: rust-msrv
           directory: rust
           toolchain: "1.88.0"
-          context: *rust-ci-context
+          context:
+            - circleci-repo-readonly-authenticated-github-token
 
       # -----------------------------------------------------------------------
       # Unified cross-compilation jobs
@@ -1169,37 +1272,43 @@ workflows:
             just --justfile alloy-op-evm/justfile check-no-std
             just --justfile alloy-op-hardforks/justfile check-no-std
           toolchain: "1.88.0"
-          context: *rust-ci-context
+          context:
+            - circleci-repo-readonly-authenticated-github-token
 
       - rust-ci-cargo-hack-build:
           name: rust-wasm-unknown
           directory: rust
           target: wasm32-unknown-unknown
           flags: "-p op-alloy-consensus -p op-alloy-rpc-types -p op-alloy-rpc-types-engine -p alloy-op-evm --no-default-features"
-          context: *rust-ci-context
+          context:
+            - circleci-repo-readonly-authenticated-github-token
 
       - rust-ci-cargo-hack-build:
           name: rust-wasm-wasi
           directory: rust
           target: wasm32-wasip1
           flags: "-p op-alloy-consensus -p op-alloy-rpc-types-engine -p alloy-op-evm"
-          context: *rust-ci-context
+          context:
+            - circleci-repo-readonly-authenticated-github-token
 
       # -----------------------------------------------------------------------
       # OP-Reth crate-specific jobs
       # -----------------------------------------------------------------------
       - op-reth-compact-codec:
-          context: *rust-ci-context
+          context:
+            - circleci-repo-readonly-authenticated-github-token
 
       - op-reth-windows-check:
-          context: *rust-ci-context
+          context:
+            - circleci-repo-readonly-authenticated-github-token
 
       - rust-ci-cargo-tests:
           name: op-reth-integration-tests
           directory: rust
           command: "--justfile op-reth/justfile test-integration"
           cache_profile: debug
-          context: *rust-ci-context
+          context:
+            - circleci-repo-readonly-authenticated-github-token
 
       - rust-ci-cargo-tests:
           name: op-reth-tests-edge
@@ -1207,13 +1316,15 @@ workflows:
           command: "--justfile op-reth/justfile test"
           flags: "edge"
           cache_profile: debug
-          context: *rust-ci-context
+          context:
+            - circleci-repo-readonly-authenticated-github-token
 
       # -----------------------------------------------------------------------
       # Op-Alloy crate-specific jobs
       # -----------------------------------------------------------------------
       - op-alloy-cfg-check:
-          context: *rust-ci-context
+          context:
+            - circleci-repo-readonly-authenticated-github-token
 
       # -----------------------------------------------------------------------
       # Kona crate-specific jobs (lint, FPVM builds, benches, coverage)
@@ -1223,26 +1334,31 @@ workflows:
           matrix:
             parameters:
               target: ["cannon", "asterisc"]
-          context: *rust-ci-context
+          context:
+            - circleci-repo-readonly-authenticated-github-token
 
       - kona-build-fpvm:
           name: kona-build-fpvm-<<matrix.target>>
           matrix:
             parameters:
               target: ["cannon-client", "asterisc-client"]
-          context: *rust-ci-context
+          context:
+            - circleci-repo-readonly-authenticated-github-token
 
       - kona-cargo-build-benches:
-          context: *rust-ci-context
+          context:
+            - circleci-repo-readonly-authenticated-github-token
 
       - kona-coverage:
-          context: *rust-ci-context
+          context:
+            - circleci-repo-readonly-authenticated-github-token
           requires:
             - rust-tests
 
       - kona-host-client-offline:
           name: kona-host-client-offline-cannon
-          context: *rust-ci-context
+          context:
+            - circleci-repo-readonly-authenticated-github-token
 
 
   # ==========================================================================

--- a/.circleci/continue/rust-e2e.yml
+++ b/.circleci/continue/rust-e2e.yml
@@ -79,7 +79,7 @@ jobs:
           at: .
       - go-restore-cache:
           namespace: kona-ci
-      - rust-build: &kona-rust-build-release
+      - rust-build:
           directory: rust
           profile: release
           binary: "kona-node"
@@ -121,7 +121,9 @@ jobs:
       - go-restore-cache:
           namespace: kona-ci
       - rust-build:
-          <<: *kona-rust-build-release
+          directory: rust
+          profile: release
+          binary: "kona-node"
       - run:
           name: Run restart tests for node with sysgo orchestrator
           no_output_timeout: 60m
@@ -146,7 +148,8 @@ jobs:
       - utils/checkout-with-mise:
           checkout-method: blobless
       - rust-build:
-          <<: *kona-rust-build-release
+          directory: rust
+          profile: release
           binary: "kona-supervisor"
       - run:
           name: Run supervisor tests for <<parameters.test_pkg>>
@@ -173,7 +176,8 @@ jobs:
       - go-restore-cache:
           namespace: kona-ci
       - rust-build:
-          <<: *kona-rust-build-release
+          directory: rust
+          profile: release
           binary: "kona-host"
       - run:
           name: Build kona and run action tests
@@ -202,19 +206,20 @@ workflows:
           build_args: --skip test
           context:
             - circleci-repo-readonly-authenticated-github-token
-      - cannon-prestate-quick: &rust-e2e-job-base
+      - cannon-prestate-quick:
           context:
             - circleci-repo-readonly-authenticated-github-token
       - cannon-kona-prestate:
-          <<: *rust-e2e-job-base
-      - rust-build-binary: &cannon-kona-host
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+      - rust-build-binary:
           name: cannon-kona-host
           directory: rust
           profile: release
           binary: "kona-host"
           context:
             - circleci-repo-readonly-authenticated-github-token
-      - rust-build-binary: &kona-build-release
+      - rust-build-binary:
           name: kona-build-release
           directory: rust
           profile: release
@@ -243,7 +248,8 @@ workflows:
             - op-reth-build
       - rust-restart-sysgo-tests:
           name: rust-e2e-restart
-          <<: *rust-e2e-job-base
+          context:
+            - circleci-repo-readonly-authenticated-github-token
           requires:
             - contracts-bedrock-build
             - cannon-prestate-quick


### PR DESCRIPTION
## Summary

- Inlines all YAML anchors, aliases, and merge keys in CircleCI continuation configs
- Fixes compatibility with the `circleci/path-filtering@3.0.0` orb's config merge step, which uses `yq eval-all 'explode(.) | . as $item ireduce ({}; . * $item)'` and can fail non-deterministically with anchors (see [path-filtering-orb#100](https://github.com/CircleCI-Public/path-filtering-orb/issues/100))
- Resolves `bad file '.circleci/continue/rust-ci.yml': yaml: line 8: mapping values are not allowed in this context` errors seen in GitHub merge queue

### Files changed
- `.circleci/continue/rust-ci.yml` — inlined `&cache-params`, 18 cache-args anchor pairs, and `&rust-ci-context` (~25 usages)
- `.circleci/continue/rust-e2e.yml` — inlined `&kona-rust-build-release`, `&rust-e2e-job-base`, removed anchor-only markers
- `.circleci/continue/main.yml` — inlined `&features_matrix`, `&rust-build-op-rbuilder`, `&rust-build-rollup-boost`, removed anchor-only markers

## Test plan
- [x] All three files validate as correct YAML with both yq v4.48.1 and v4.34.1
- [x] Full three-file merge pipeline (`yq eval-all 'explode(.) | . as $item ireduce ({}; . * $item)'`) succeeds
- [x] No remaining YAML anchors, aliases, or merge keys
- [x] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)