### PR TITLE
fix(ci): rename continuation config parameters with c- prefix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,38 +103,38 @@ workflows:
           base-revision: develop
           config-path: .circleci/continue/main.yml
           mapping: |
-            .* default_docker_image << pipeline.parameters.default_docker_image >> .circleci/continue/main.yml
-            .* base_image << pipeline.parameters.base_image >> .circleci/continue/main.yml
-            .* main_dispatch << pipeline.parameters.main_dispatch >> .circleci/continue/main.yml
-            .* fault_proofs_dispatch << pipeline.parameters.fault_proofs_dispatch >> .circleci/continue/main.yml
-            .* reproducibility_dispatch << pipeline.parameters.reproducibility_dispatch >> .circleci/continue/main.yml
-            .* kontrol_dispatch << pipeline.parameters.kontrol_dispatch >> .circleci/continue/main.yml
-            .* cannon_full_test_dispatch << pipeline.parameters.cannon_full_test_dispatch >> .circleci/continue/main.yml
-            .* sdk_dispatch << pipeline.parameters.sdk_dispatch >> .circleci/continue/main.yml
-            .* docker_publish_dispatch << pipeline.parameters.docker_publish_dispatch >> .circleci/continue/main.yml
-            .* publish_contract_artifacts_dispatch << pipeline.parameters.publish_contract_artifacts_dispatch >> .circleci/continue/main.yml
-            .* stale_check_dispatch << pipeline.parameters.stale_check_dispatch >> .circleci/continue/main.yml
-            .* contracts_coverage_dispatch << pipeline.parameters.contracts_coverage_dispatch >> .circleci/continue/main.yml
-            .* heavy_fuzz_dispatch << pipeline.parameters.heavy_fuzz_dispatch >> .circleci/continue/main.yml
-            .* sync_test_op_node_dispatch << pipeline.parameters.sync_test_op_node_dispatch >> .circleci/continue/main.yml
-            .* ai_contracts_test_dispatch << pipeline.parameters.ai_contracts_test_dispatch >> .circleci/continue/main.yml
-            .* github-event-type << pipeline.parameters.github-event-type >> .circleci/continue/main.yml
-            .* github-event-action << pipeline.parameters.github-event-action >> .circleci/continue/main.yml
-            .* github-event-base64 << pipeline.parameters.github-event-base64 >> .circleci/continue/main.yml
-            .* devnet-metrics-collect << pipeline.parameters.devnet-metrics-collect >> .circleci/continue/main.yml
-            .* flake-shake-dispatch << pipeline.parameters.flake-shake-dispatch >> .circleci/continue/main.yml
-            .* flake-shake-iterations << pipeline.parameters.flake-shake-iterations >> .circleci/continue/main.yml
-            .* flake-shake-workers << pipeline.parameters.flake-shake-workers >> .circleci/continue/main.yml
-            .* go-cache-version << pipeline.parameters.go-cache-version >> .circleci/continue/main.yml
+            .* c-default_docker_image << pipeline.parameters.default_docker_image >> .circleci/continue/main.yml
+            .* c-base_image << pipeline.parameters.base_image >> .circleci/continue/main.yml
+            .* c-main_dispatch << pipeline.parameters.main_dispatch >> .circleci/continue/main.yml
+            .* c-fault_proofs_dispatch << pipeline.parameters.fault_proofs_dispatch >> .circleci/continue/main.yml
+            .* c-reproducibility_dispatch << pipeline.parameters.reproducibility_dispatch >> .circleci/continue/main.yml
+            .* c-kontrol_dispatch << pipeline.parameters.kontrol_dispatch >> .circleci/continue/main.yml
+            .* c-cannon_full_test_dispatch << pipeline.parameters.cannon_full_test_dispatch >> .circleci/continue/main.yml
+            .* c-sdk_dispatch << pipeline.parameters.sdk_dispatch >> .circleci/continue/main.yml
+            .* c-docker_publish_dispatch << pipeline.parameters.docker_publish_dispatch >> .circleci/continue/main.yml
+            .* c-publish_contract_artifacts_dispatch << pipeline.parameters.publish_contract_artifacts_dispatch >> .circleci/continue/main.yml
+            .* c-stale_check_dispatch << pipeline.parameters.stale_check_dispatch >> .circleci/continue/main.yml
+            .* c-contracts_coverage_dispatch << pipeline.parameters.contracts_coverage_dispatch >> .circleci/continue/main.yml
+            .* c-heavy_fuzz_dispatch << pipeline.parameters.heavy_fuzz_dispatch >> .circleci/continue/main.yml
+            .* c-sync_test_op_node_dispatch << pipeline.parameters.sync_test_op_node_dispatch >> .circleci/continue/main.yml
+            .* c-ai_contracts_test_dispatch << pipeline.parameters.ai_contracts_test_dispatch >> .circleci/continue/main.yml
+            .* c-github-event-type << pipeline.parameters.github-event-type >> .circleci/continue/main.yml
+            .* c-github-event-action << pipeline.parameters.github-event-action >> .circleci/continue/main.yml
+            .* c-github-event-base64 << pipeline.parameters.github-event-base64 >> .circleci/continue/main.yml
+            .* c-devnet-metrics-collect << pipeline.parameters.devnet-metrics-collect >> .circleci/continue/main.yml
+            .* c-flake-shake-dispatch << pipeline.parameters.flake-shake-dispatch >> .circleci/continue/main.yml
+            .* c-flake-shake-iterations << pipeline.parameters.flake-shake-iterations >> .circleci/continue/main.yml
+            .* c-flake-shake-workers << pipeline.parameters.flake-shake-workers >> .circleci/continue/main.yml
+            .* c-go-cache-version << pipeline.parameters.go-cache-version >> .circleci/continue/main.yml
 
-            rust/.* rust_ci_dispatch << pipeline.parameters.rust_ci_dispatch >> .circleci/continue/rust-ci.yml
-            rust/.* default_docker_image << pipeline.parameters.default_docker_image >> .circleci/continue/rust-ci.yml
-            rust/.* base_image << pipeline.parameters.base_image >> .circleci/continue/rust-ci.yml
-            rust/.* go-cache-version << pipeline.parameters.go-cache-version >> .circleci/continue/rust-ci.yml
+            rust/.* c-rust_ci_dispatch << pipeline.parameters.rust_ci_dispatch >> .circleci/continue/rust-ci.yml
+            rust/.* c-default_docker_image << pipeline.parameters.default_docker_image >> .circleci/continue/rust-ci.yml
+            rust/.* c-base_image << pipeline.parameters.base_image >> .circleci/continue/rust-ci.yml
+            rust/.* c-go-cache-version << pipeline.parameters.go-cache-version >> .circleci/continue/rust-ci.yml
 
-            rust/.* rust_e2e_dispatch << pipeline.parameters.rust_e2e_dispatch >> .circleci/continue/rust-e2e.yml
-            rust/.* default_docker_image << pipeline.parameters.default_docker_image >> .circleci/continue/rust-e2e.yml
-            rust/.* go-cache-version << pipeline.parameters.go-cache-version >> .circleci/continue/rust-e2e.yml
+            rust/.* c-rust_e2e_dispatch << pipeline.parameters.rust_e2e_dispatch >> .circleci/continue/rust-e2e.yml
+            rust/.* c-default_docker_image << pipeline.parameters.default_docker_image >> .circleci/continue/rust-e2e.yml
+            rust/.* c-go-cache-version << pipeline.parameters.go-cache-version >> .circleci/continue/rust-e2e.yml
 
   setup-tag:
     when:

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -1,10 +1,10 @@
 version: 2.1
 
 parameters:
-  default_docker_image:
+  c-default_docker_image:
     type: string
     default: cimg/base:2024.01
-  base_image:
+  c-base_image:
     type: string
     default: default
   # The dispatch parameters are used to manually dispatch pipelines that normally only run post-merge on develop
@@ -12,70 +12,70 @@ parameters:
   #   when:
   #     or:
   #       - equal: [ "develop", <<pipeline.git.branch>> ]
-  #       - equal: [ true, <<pipeline.parameters.main_dispatch>> ]
+  #       - equal: [ true, <<pipeline.parameters.c-main_dispatch>> ]
   # Add a new `*_dispatch` parameter for any pipeline you want manual dispatch for.
-  main_dispatch:
+  c-main_dispatch:
     type: boolean
     default: true # default to running main in case the manual run cancelled an automatic run
-  fault_proofs_dispatch:
+  c-fault_proofs_dispatch:
     type: boolean
     default: false
-  reproducibility_dispatch:
+  c-reproducibility_dispatch:
     type: boolean
     default: false
-  kontrol_dispatch:
+  c-kontrol_dispatch:
     type: boolean
     default: false
-  cannon_full_test_dispatch:
+  c-cannon_full_test_dispatch:
     type: boolean
     default: false
-  sdk_dispatch:
+  c-sdk_dispatch:
     type: boolean
     default: false
-  docker_publish_dispatch:
+  c-docker_publish_dispatch:
     type: boolean
     default: false
-  publish_contract_artifacts_dispatch:
+  c-publish_contract_artifacts_dispatch:
     type: boolean
     default: false
-  stale_check_dispatch:
+  c-stale_check_dispatch:
     type: boolean
     default: false
-  contracts_coverage_dispatch:
+  c-contracts_coverage_dispatch:
     type: boolean
     default: false
-  heavy_fuzz_dispatch:
+  c-heavy_fuzz_dispatch:
     type: boolean
     default: false
-  sync_test_op_node_dispatch:
+  c-sync_test_op_node_dispatch:
     type: boolean
     default: false
-  ai_contracts_test_dispatch:
+  c-ai_contracts_test_dispatch:
     type: boolean
     default: false
-  github-event-type:
+  c-github-event-type:
     type: string
     default: "__not_set__"
-  github-event-action:
+  c-github-event-action:
     type: string
     default: "__not_set__"
-  github-event-base64:
+  c-github-event-base64:
     type: string
     default: "__not_set__"
-  devnet-metrics-collect:
+  c-devnet-metrics-collect:
     type: boolean
     default: false
-  flake-shake-dispatch:
+  c-flake-shake-dispatch:
     type: boolean
     default: false
-  flake-shake-iterations:
+  c-flake-shake-iterations:
     type: integer
     default: 300
-  flake-shake-workers:
+  c-flake-shake-workers:
     type: integer
     default: 50
   # go-cache-version can be used as a cache buster when making breaking changes to caching strategy
-  go-cache-version:
+  c-go-cache-version:
     type: string
     default: "v0.0"
 
@@ -334,7 +334,7 @@ commands:
       # Version can be used as a cache buster when making breaking changes to caching strategy
       version:
         type: string
-        default: <<pipeline.parameters.go-cache-version>>
+        default: <<pipeline.parameters.c-go-cache-version>>
     steps:
       - restore_cache:
           name: Restore go cache for <<parameters.namespace>> (<<parameters.module>>/go.mod)
@@ -355,7 +355,7 @@ commands:
         type: string
       version:
         type: string
-        default: <<pipeline.parameters.go-cache-version>>
+        default: <<pipeline.parameters.c-go-cache-version>>
     steps:
       - save_cache:
           name: Save go cache for <<parameters.namespace>> (<<parameters.module>>/go.mod)
@@ -646,7 +646,7 @@ jobs:
   rust-build-binary:
     description: "Build a Rust workspace with target directory caching"
     docker:
-      - image: <<pipeline.parameters.default_docker_image>>
+      - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: xlarge
     parameters:
       directory:
@@ -699,7 +699,7 @@ jobs:
   # Build a single Rust binary from a submodule.
   rust-build-submodule:
     docker:
-      - image: <<pipeline.parameters.default_docker_image>>
+      - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: xlarge
     parameters:
       directory:
@@ -809,7 +809,7 @@ jobs:
         type: string
         default: 30m
     docker:
-      - image: <<pipeline.parameters.default_docker_image>>
+      - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: xlarge
     steps:
       - utils/checkout-with-mise:
@@ -911,7 +911,7 @@ jobs:
                 path: ./op-acceptance-tests/logs
   initialize:
     docker:
-      - image: <<pipeline.parameters.default_docker_image>>
+      - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: large
     steps:
       - run:
@@ -919,7 +919,7 @@ jobs:
 
   cannon-go-lint-and-test:
     docker:
-      - image: <<pipeline.parameters.default_docker_image>>
+      - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: xlarge
     parameters:
       skip_slow_tests:
@@ -984,7 +984,7 @@ jobs:
 
   contracts-bedrock-build:
     docker:
-      - image: <<pipeline.parameters.default_docker_image>>
+      - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: 2xlarge
     parameters:
       build_args:
@@ -1030,7 +1030,7 @@ jobs:
 
   check-kontrol-build:
     docker:
-      - image: <<pipeline.parameters.default_docker_image>>
+      - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: xlarge
     steps:
       - utils/checkout-with-mise:
@@ -1092,7 +1092,7 @@ jobs:
         type: string
         default: medium
     machine:
-      image: <<pipeline.parameters.base_image>>
+      image: <<pipeline.parameters.c-base_image>>
       resource_class: "<<parameters.resource_class>>"
       docker_layer_caching: true # we rely on this for faster builds, and actively warm it up for builds with common stages
     steps:
@@ -1249,7 +1249,7 @@ jobs:
   # Verify newly published images (built on AMD machine) will run on ARM
   check-cross-platform:
     docker:
-      - image: <<pipeline.parameters.default_docker_image>>
+      - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: arm.medium
     parameters:
       registry:
@@ -1294,7 +1294,7 @@ jobs:
   contracts-bedrock-tests:
     circleci_ip_ranges: true
     docker:
-      - image: <<pipeline.parameters.default_docker_image>>
+      - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: 2xlarge
     parameters:
       test_list:
@@ -1386,7 +1386,7 @@ jobs:
   contracts-bedrock-heavy-fuzz-nightly:
     circleci_ip_ranges: true
     docker:
-      - image: <<pipeline.parameters.default_docker_image>>
+      - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: 2xlarge
     steps:
       - utils/checkout-with-mise:
@@ -1444,7 +1444,7 @@ jobs:
   ai-contracts-test:
     circleci_ip_ranges: true
     docker:
-      - image: <<pipeline.parameters.default_docker_image>>
+      - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: medium
     steps:
       - utils/checkout-with-mise:
@@ -1475,7 +1475,7 @@ jobs:
   contracts-bedrock-coverage:
     circleci_ip_ranges: true
     docker:
-      - image: <<pipeline.parameters.default_docker_image>>
+      - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: 2xlarge
     parameters:
       test_timeout:
@@ -1586,7 +1586,7 @@ jobs:
         type: string
         default: ""
     docker:
-      - image: <<pipeline.parameters.default_docker_image>>
+      - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: 2xlarge
     steps:
       - utils/checkout-with-mise:
@@ -1688,7 +1688,7 @@ jobs:
 
   contracts-bedrock-checks:
     docker:
-      - image: <<pipeline.parameters.default_docker_image>>
+      - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: xlarge
     steps:
       - utils/checkout-with-mise:
@@ -1735,7 +1735,7 @@ jobs:
 
   contracts-bedrock-checks-fast:
     docker:
-      - image: <<pipeline.parameters.default_docker_image>>
+      - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: 2xlarge
     steps:
       - utils/checkout-with-mise:
@@ -1763,7 +1763,7 @@ jobs:
         type: boolean
         default: true
     machine:
-      image: <<pipeline.parameters.base_image>>
+      image: <<pipeline.parameters.c-base_image>>
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
@@ -1789,7 +1789,7 @@ jobs:
         type: boolean
         default: false
     docker:
-      - image: <<pipeline.parameters.default_docker_image>>
+      - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: xlarge
     steps:
       - utils/checkout-with-mise:
@@ -1822,7 +1822,7 @@ jobs:
 
   go-lint:
     docker:
-      - image: <<pipeline.parameters.default_docker_image>>
+      - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: large
     steps:
       - utils/checkout-with-mise:
@@ -1841,7 +1841,7 @@ jobs:
 
   check-op-geth-version:
     docker:
-      - image: <<pipeline.parameters.default_docker_image>>
+      - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: small
     steps:
       - utils/checkout-with-mise:
@@ -1883,7 +1883,7 @@ jobs:
         type: integer
         default: 1
     docker:
-      - image: <<pipeline.parameters.default_docker_image>>
+      - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: 2xlarge
     circleci_ip_ranges: true
     parallelism: <<parameters.parallelism>>
@@ -2026,7 +2026,7 @@ jobs:
         default: ""
     resource_class: xlarge
     docker:
-      - image: <<pipeline.parameters.default_docker_image>>
+      - image: <<pipeline.parameters.c-default_docker_image>>
     circleci_ip_ranges: true
     steps:
       - utils/checkout-with-mise:
@@ -2052,7 +2052,7 @@ jobs:
           name: Persist schedule name into env var
           command: |
             echo 'export CIRCLECI_PIPELINE_SCHEDULE_NAME="<< pipeline.schedule.name >>"' >> $BASH_ENV
-            echo 'export CIRCLECI_PARAMETERS_SYNC_TEST_OP_NODE_DISPATCH="<< pipeline.parameters.sync_test_op_node_dispatch >>"' >> $BASH_ENV
+            echo 'export CIRCLECI_PARAMETERS_SYNC_TEST_OP_NODE_DISPATCH="<< pipeline.parameters.c-sync_test_op_node_dispatch >>"' >> $BASH_ENV
       # Run the acceptance tests
       - run:
           name: Run acceptance tests (gate=<<parameters.gate>>)
@@ -2124,7 +2124,7 @@ jobs:
         type: string
         default: 30m
     docker:
-      - image: <<pipeline.parameters.default_docker_image>>
+      - image: <<pipeline.parameters.c-default_docker_image>>
     circleci_ip_ranges: true
     resource_class: 2xlarge+
     steps:
@@ -2234,7 +2234,7 @@ jobs:
     machine:
       image: ubuntu-2404:current
     resource_class: xlarge
-    parallelism: << pipeline.parameters.flake-shake-workers >>
+    parallelism: << pipeline.parameters.c-flake-shake-workers >>
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
@@ -2266,7 +2266,7 @@ jobs:
       - run:
           name: Calculate iterations for worker
           command: |
-            bash ./op-acceptance-tests/scripts/ci_flake_shake_calc_iterations.sh << pipeline.parameters.flake-shake-iterations >>
+            bash ./op-acceptance-tests/scripts/ci_flake_shake_calc_iterations.sh << pipeline.parameters.c-flake-shake-iterations >>
       - run:
           name: Run flake-shake iterations
           no_output_timeout: 3h
@@ -2426,7 +2426,7 @@ jobs:
 
   sanitize-op-program:
     docker:
-      - image: <<pipeline.parameters.default_docker_image>>
+      - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: large
     steps:
       - utils/checkout-with-mise:
@@ -2450,7 +2450,7 @@ jobs:
 
   cannon-prestate-quick:
     docker:
-      - image: <<pipeline.parameters.default_docker_image>>
+      - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: xlarge
     steps:
       - utils/checkout-with-mise:
@@ -2480,7 +2480,7 @@ jobs:
 
   cannon-prestate:
     docker:
-      - image: <<pipeline.parameters.default_docker_image>>
+      - image: <<pipeline.parameters.c-default_docker_image>>
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
@@ -2523,7 +2523,7 @@ jobs:
   # Aggregator job - allows downstream jobs to depend on a single job instead of listing all build jobs.
   rust-binaries-for-sysgo:
     docker:
-      - image: <<pipeline.parameters.default_docker_image>>
+      - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: small
     steps:
       - run:
@@ -2536,7 +2536,7 @@ jobs:
   publish-cannon-prestates:
     resource_class: medium
     docker:
-      - image: <<pipeline.parameters.default_docker_image>>
+      - image: <<pipeline.parameters.c-default_docker_image>>
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
@@ -2614,7 +2614,7 @@ jobs:
 
   cannon-stf-verify:
     docker:
-      - image: <<pipeline.parameters.default_docker_image>>
+      - image: <<pipeline.parameters.c-default_docker_image>>
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
@@ -2675,14 +2675,14 @@ jobs:
 
   bedrock-go-tests: # just a helper, that depends on all the actual test jobs
     docker:
-      - image: <<pipeline.parameters.default_docker_image>>
+      - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: medium
     steps:
       - run: echo Done
 
   analyze-op-program-client:
     docker:
-      - image: <<pipeline.parameters.default_docker_image>>
+      - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: xlarge
     steps:
       - utils/checkout-with-mise:
@@ -2697,7 +2697,7 @@ jobs:
 
   op-program-compat:
     docker:
-      - image: <<pipeline.parameters.default_docker_image>>
+      - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: large
     steps:
       - utils/checkout-with-mise:
@@ -2711,7 +2711,7 @@ jobs:
 
   check-generated-mocks-op-node:
     docker:
-      - image: <<pipeline.parameters.default_docker_image>>
+      - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: large
     steps:
       - utils/checkout-with-mise:
@@ -2725,7 +2725,7 @@ jobs:
 
   check-generated-mocks-op-service:
     docker:
-      - image: <<pipeline.parameters.default_docker_image>>
+      - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: large
     steps:
       - utils/checkout-with-mise:
@@ -2739,7 +2739,7 @@ jobs:
 
   op-deployer-forge-version:
     docker:
-      - image: <<pipeline.parameters.default_docker_image>>
+      - image: <<pipeline.parameters.c-default_docker_image>>
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
@@ -2750,7 +2750,7 @@ jobs:
 
   kontrol-tests:
     docker:
-      - image: <<pipeline.parameters.default_docker_image>>
+      - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: xlarge
     steps:
       - utils/checkout-with-mise:
@@ -2784,7 +2784,7 @@ jobs:
 
   publish-contract-artifacts:
     docker:
-      - image: <<pipeline.parameters.default_docker_image>>
+      - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: 2xlarge
     steps:
       - gcp-cli/install
@@ -2824,7 +2824,7 @@ jobs:
         default: .goreleaser.yaml
         type: string
     docker:
-      - image: <<pipeline.parameters.default_docker_image>>
+      - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: large
     steps:
       - setup_remote_docker:
@@ -2847,7 +2847,7 @@ jobs:
 
   diff-fetcher-forge-artifacts:
     docker:
-      - image: <<pipeline.parameters.default_docker_image>>
+      - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: medium
     steps:
       - utils/checkout-with-mise:
@@ -2898,7 +2898,7 @@ jobs:
     steps:
       - github-cli/install
       - utils/github-event-handler-setup:
-          github_event_base64: << pipeline.parameters.github-event-base64 >>
+          github_event_base64: << pipeline.parameters.c-github-event-base64 >>
           env_prefix: "github_"
       - run:
           name: Close issue if label is added
@@ -2914,7 +2914,7 @@ jobs:
 
   devnet-metrics-collect-authorship:
     docker:
-      - image: <<pipeline.parameters.default_docker_image>>
+      - image: <<pipeline.parameters.c-default_docker_image>>
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
@@ -2974,10 +2974,10 @@ workflows:
         - or:
             - equal: ["webhook", << pipeline.trigger_source >>]
             - and:
-                - equal: [true, <<pipeline.parameters.main_dispatch>>]
+                - equal: [true, <<pipeline.parameters.c-main_dispatch>>]
                 - equal: ["api", << pipeline.trigger_source >>]
                 - equal: [
-                      << pipeline.parameters.github-event-type >>,
+                      << pipeline.parameters.c-github-event-type >>,
                       "__not_set__",
                     ] #this is to prevent triggering this workflow as the default value is always set for main_dispatch
     jobs:
@@ -3431,7 +3431,7 @@ workflows:
             - equal:
                 [
                   true,
-                  <<pipeline.parameters.publish_contract_artifacts_dispatch>>,
+                  <<pipeline.parameters.c-publish_contract_artifacts_dispatch>>,
                 ]
             - equal: ["api", << pipeline.trigger_source >>]
     jobs:
@@ -3446,7 +3446,7 @@ workflows:
             - equal: ["develop", <<pipeline.git.branch>>]
             - equal: ["webhook", << pipeline.trigger_source >>]
         - and:
-            - equal: [true, <<pipeline.parameters.fault_proofs_dispatch>>]
+            - equal: [true, <<pipeline.parameters.c-fault_proofs_dispatch>>]
             - equal: ["api", << pipeline.trigger_source >>]
     jobs:
       - cannon-prestate:
@@ -3490,7 +3490,7 @@ workflows:
             - equal: ["develop", <<pipeline.git.branch>>]
             - equal: ["webhook", << pipeline.trigger_source >>]
         - and:
-            - equal: [true, <<pipeline.parameters.kontrol_dispatch>>]
+            - equal: [true, <<pipeline.parameters.c-kontrol_dispatch>>]
             - equal: ["api", << pipeline.trigger_source >>]
     jobs:
       - kontrol-tests:
@@ -3503,7 +3503,7 @@ workflows:
     when:
       or:
         - equal: [build_four_hours, <<pipeline.schedule.name>>]
-        - equal: [true, << pipeline.parameters.cannon_full_test_dispatch >>]
+        - equal: [true, << pipeline.parameters.c-cannon_full_test_dispatch >>]
     jobs:
       - contracts-bedrock-build:
           build_args: --deny-warnings --skip test
@@ -3524,7 +3524,7 @@ workflows:
       or:
         - equal: [build_daily, <<pipeline.schedule.name>>]
         # Trigger on manual triggers if explicitly requested
-        - equal: [true, << pipeline.parameters.docker_publish_dispatch >>]
+        - equal: [true, << pipeline.parameters.c-docker_publish_dispatch >>]
     jobs:
       - contracts-bedrock-build:
           context:
@@ -3560,7 +3560,7 @@ workflows:
       or:
         - equal: [build_daily, << pipeline.schedule.name >>]
         - and:
-            - equal: [true, << pipeline.parameters.flake-shake-dispatch >>]
+            - equal: [true, << pipeline.parameters.c-flake-shake-dispatch >>]
             - equal: ["api", << pipeline.trigger_source >>]
     jobs:
       - contracts-bedrock-build:
@@ -3608,7 +3608,7 @@ workflows:
       or:
         - equal: [build_daily, <<pipeline.schedule.name>>]
         # Trigger on manual triggers if explicitly requested
-        - equal: [true, << pipeline.parameters.reproducibility_dispatch >>]
+        - equal: [true, << pipeline.parameters.c-reproducibility_dispatch >>]
     jobs:
       - preimage-reproducibility:
           context:
@@ -3620,7 +3620,7 @@ workflows:
       or:
         - equal: [build_daily, <<pipeline.schedule.name>>]
           # Trigger on manual triggers if explicitly requested
-        - equal: [true, << pipeline.parameters.stale_check_dispatch >>]
+        - equal: [true, << pipeline.parameters.c-stale_check_dispatch >>]
     jobs:
       - stale-check:
           context:
@@ -3631,7 +3631,7 @@ workflows:
       or:
         - equal: [build_daily, <<pipeline.schedule.name>>]
         # Trigger on manual triggers if explicitly requested
-        - equal: [true, << pipeline.parameters.sync_test_op_node_dispatch >>]
+        - equal: [true, << pipeline.parameters.c-sync_test_op_node_dispatch >>]
     jobs:
       - contracts-bedrock-build: # needed for sysgo tests
           build_args: --skip test
@@ -3666,7 +3666,7 @@ workflows:
     when:
       or:
         - equal: [build_daily, <<pipeline.schedule.name>>]
-        - equal: [true, << pipeline.parameters.heavy_fuzz_dispatch >>]
+        - equal: [true, << pipeline.parameters.c-heavy_fuzz_dispatch >>]
     jobs:
       - contracts-bedrock-heavy-fuzz-nightly:
           context:
@@ -3676,8 +3676,8 @@ workflows:
     when:
       and:
         - equal: [<< pipeline.trigger_source >>, "api"]
-        - equal: [<< pipeline.parameters.github-event-type >>, "pull_request"]
-        - equal: [<< pipeline.parameters.github-event-action >>, "labeled"]
+        - equal: [<< pipeline.parameters.c-github-event-type >>, "pull_request"]
+        - equal: [<< pipeline.parameters.c-github-event-action >>, "labeled"]
     jobs:
       - close-issue:
           label_name: "auto-close-trivial-contribution"
@@ -3693,7 +3693,7 @@ workflows:
       or:
         - equal: [<< pipeline.trigger_source >>, "webhook"]
         - and:
-            - equal: [true, << pipeline.parameters.devnet-metrics-collect >>]
+            - equal: [true, << pipeline.parameters.c-devnet-metrics-collect >>]
             - equal: [<< pipeline.trigger_source >>, "api"]
     jobs:
       - devnet-metrics-collect-authorship:
@@ -3705,7 +3705,7 @@ workflows:
     when:
       or:
         - equal: [build_mon_thu, <<pipeline.schedule.name>>]
-        - equal: [true, << pipeline.parameters.ai_contracts_test_dispatch >>]
+        - equal: [true, << pipeline.parameters.c-ai_contracts_test_dispatch >>]
     jobs:
       - ai-contracts-test:
           context:

--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -9,16 +9,16 @@ orbs:
   codecov: codecov/codecov@5.0.3
 
 parameters:
-  default_docker_image:
+  c-default_docker_image:
     type: string
     default: cimg/base:2024.01
-  base_image:
+  c-base_image:
     type: string
     default: default
-  rust_ci_dispatch:
+  c-rust_ci_dispatch:
     type: boolean
     default: false
-  go-cache-version:
+  c-go-cache-version:
     type: string
     default: "v0.0"
 
@@ -326,7 +326,7 @@ jobs:
         type: string
         default: "cargo +nightly fmt --all --check"
     docker:
-      - image: <<pipeline.parameters.default_docker_image>>
+      - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: medium
     steps:
       - utils/checkout-with-mise:
@@ -359,7 +359,7 @@ jobs:
         type: string
         default: "stable"
     docker:
-      - image: <<pipeline.parameters.default_docker_image>>
+      - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: xlarge
     steps:
       - utils/checkout-with-mise:
@@ -392,7 +392,7 @@ jobs:
         type: string
         default: "cargo deny check"
     docker:
-      - image: <<pipeline.parameters.default_docker_image>>
+      - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: medium
     steps:
       - utils/checkout-with-mise:
@@ -422,7 +422,7 @@ jobs:
         type: string
         default: "zepter run check"
     docker:
-      - image: <<pipeline.parameters.default_docker_image>>
+      - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: medium
     steps:
       - utils/checkout-with-mise:
@@ -449,7 +449,7 @@ jobs:
         description: "Directory containing the Cargo workspace"
         type: string
     docker:
-      - image: <<pipeline.parameters.default_docker_image>>
+      - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: medium
     steps:
       - utils/checkout-with-mise:
@@ -487,7 +487,7 @@ jobs:
         type: string
         default: "just check-no-std"
     docker:
-      - image: <<pipeline.parameters.default_docker_image>>
+      - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: xlarge
     steps:
       - utils/checkout-with-mise:
@@ -520,7 +520,7 @@ jobs:
         type: string
         default: "--cfg docsrs -D warnings --show-type-layout --generate-link-to-definition -Zunstable-options"
     docker:
-      - image: <<pipeline.parameters.default_docker_image>>
+      - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: xlarge
     steps:
       - utils/checkout-with-mise:
@@ -552,7 +552,7 @@ jobs:
         type: string
         default: "cargo test --workspace --doc"
     docker:
-      - image: <<pipeline.parameters.default_docker_image>>
+      - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: xlarge
     steps:
       - utils/checkout-with-mise:
@@ -590,7 +590,7 @@ jobs:
         type: string
         default: "release"
     docker:
-      - image: <<pipeline.parameters.default_docker_image>>
+      - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: xlarge
     steps:
       - utils/checkout-with-mise:
@@ -624,7 +624,7 @@ jobs:
         type: string
         default: "just check-udeps"
     docker:
-      - image: <<pipeline.parameters.default_docker_image>>
+      - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: xlarge
     steps:
       - utils/checkout-with-mise:
@@ -662,7 +662,7 @@ jobs:
         type: string
         default: "--workspace"
     docker:
-      - image: <<pipeline.parameters.default_docker_image>>
+      - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: xlarge
     steps:
       - utils/checkout-with-mise:
@@ -690,7 +690,7 @@ jobs:
         type: integer
         default: 1
     docker:
-      - image: <<pipeline.parameters.default_docker_image>>
+      - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: xlarge
     parallelism: <<parameters.parallelism>>
     steps:
@@ -724,7 +724,7 @@ jobs:
   # OP-Reth compact codec backwards compatibility
   op-reth-compact-codec:
     docker:
-      - image: <<pipeline.parameters.default_docker_image>>
+      - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: xlarge
     steps:
       - utils/checkout-with-mise:
@@ -759,7 +759,7 @@ jobs:
   # OP-Reth Windows cross-compile check
   op-reth-windows-check:
     docker:
-      - image: <<pipeline.parameters.default_docker_image>>
+      - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: xlarge
     steps:
       - utils/checkout-with-mise:
@@ -784,7 +784,7 @@ jobs:
   # Op-Alloy cfg check
   op-alloy-cfg-check:
     docker:
-      - image: <<pipeline.parameters.default_docker_image>>
+      - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: xlarge
     steps:
       - utils/checkout-with-mise:
@@ -811,7 +811,7 @@ jobs:
   kona-host-client-offline:
     parameters:
     machine:
-      image: <<pipeline.parameters.base_image>>
+      image: <<pipeline.parameters.c-base_image>>
       docker_layer_caching: true
     resource_class: xlarge
     steps:
@@ -867,7 +867,7 @@ jobs:
         description: The lint target (native, cannon, asterisc)
         type: string
     machine:
-      image: <<pipeline.parameters.base_image>>
+      image: <<pipeline.parameters.c-base_image>>
       docker_layer_caching: true
     resource_class: xlarge
     steps:
@@ -892,7 +892,7 @@ jobs:
         description: The build target (cannon-client, asterisc-client)
         type: string
     machine:
-      image: <<pipeline.parameters.base_image>>
+      image: <<pipeline.parameters.c-base_image>>
       docker_layer_caching: true
     resource_class: xlarge
     steps:
@@ -909,7 +909,7 @@ jobs:
   # Kona Build Benchmarks
   kona-cargo-build-benches:
     docker:
-      - image: <<pipeline.parameters.default_docker_image>>
+      - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: 2xlarge
     steps:
       - utils/checkout-with-mise:
@@ -928,7 +928,7 @@ jobs:
   # Kona Coverage
   kona-coverage:
     docker:
-      - image: <<pipeline.parameters.default_docker_image>>
+      - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: xlarge
     steps:
       - utils/checkout-with-mise:
@@ -965,7 +965,7 @@ jobs:
   # Kona Docs Build
   kona-docs-build:
     docker:
-      - image: <<pipeline.parameters.default_docker_image>>
+      - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: xlarge
     steps:
       - utils/checkout-with-mise:
@@ -999,7 +999,7 @@ jobs:
     # OP-Reth docs build
   op-reth-docs-build:
     docker:
-      - image: <<pipeline.parameters.default_docker_image>>
+      - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: xlarge
     steps:
       - utils/checkout-with-mise:
@@ -1026,7 +1026,7 @@ jobs:
   # Kona Link Checker
   kona-link-checker:
     docker:
-      - image: <<pipeline.parameters.default_docker_image>>
+      - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: medium
     steps:
       - utils/checkout-with-mise:
@@ -1053,7 +1053,7 @@ jobs:
         description: The version to build (kona-client, kona-client-int)
         type: string
     machine:
-      image: <<pipeline.parameters.base_image>>
+      image: <<pipeline.parameters.c-base_image>>
       docker_layer_caching: true
     resource_class: xlarge
     steps:
@@ -1108,7 +1108,7 @@ workflows:
       or:
         - equal: ["webhook", << pipeline.trigger_source >>]
         - and:
-            - equal: [true, <<pipeline.parameters.rust_ci_dispatch>>]
+            - equal: [true, <<pipeline.parameters.c-rust_ci_dispatch>>]
             - equal: ["api", << pipeline.trigger_source >>]
     jobs:
       # -----------------------------------------------------------------------

--- a/.circleci/continue/rust-e2e.yml
+++ b/.circleci/continue/rust-e2e.yml
@@ -7,13 +7,13 @@ version: 2.1
 
 parameters:
   # Required parameters (also in main.yml, merged during continuation)
-  default_docker_image:
+  c-default_docker_image:
     type: string
     default: cimg/base:2024.01
-  rust_e2e_dispatch:
+  c-rust_e2e_dispatch:
     type: boolean
     default: false
-  go-cache-version:
+  c-go-cache-version:
     type: string
     default: "v0.0"
 
@@ -28,7 +28,7 @@ commands:
         type: string
       version:
         type: string
-        default: <<pipeline.parameters.go-cache-version>>
+        default: <<pipeline.parameters.c-go-cache-version>>
     steps:
       - restore_cache:
           name: Restore go cache for <<parameters.namespace>> (<<parameters.module>>/go.mod)
@@ -46,7 +46,7 @@ commands:
         type: string
       version:
         type: string
-        default: <<pipeline.parameters.go-cache-version>>
+        default: <<pipeline.parameters.c-go-cache-version>>
     steps:
       - save_cache:
           name: Save go cache for <<parameters.namespace>> (<<parameters.module>>/go.mod)
@@ -70,7 +70,7 @@ jobs:
         type: boolean
         default: false
     docker:
-      - image: <<pipeline.parameters.default_docker_image>>
+      - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: xlarge
     steps:
       - utils/checkout-with-mise:
@@ -111,7 +111,7 @@ jobs:
   # Kona Node Restart Tests (from node_e2e_sysgo_tests.yaml)
   rust-restart-sysgo-tests:
     docker:
-      - image: <<pipeline.parameters.default_docker_image>>
+      - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: xlarge
     steps:
       - utils/checkout-with-mise:
@@ -140,7 +140,7 @@ jobs:
         description: The test package to run
         type: string
     docker:
-      - image: <<pipeline.parameters.default_docker_image>>
+      - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: xlarge
     steps:
       - utils/checkout-with-mise:
@@ -162,7 +162,7 @@ jobs:
         description: The kind of action test (single or interop)
         type: string
     docker:
-      - image: <<pipeline.parameters.default_docker_image>>
+      - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: xlarge
     parallelism: 4
     steps:
@@ -195,7 +195,7 @@ workflows:
       or:
         - equal: ["webhook", << pipeline.trigger_source >>]
         - and:
-            - equal: [true, <<pipeline.parameters.rust_e2e_dispatch>>]
+            - equal: [true, <<pipeline.parameters.c-rust_e2e_dispatch>>]
             - equal: ["api", << pipeline.trigger_source >>]
     jobs:
       - contracts-bedrock-build:
@@ -264,7 +264,7 @@ workflows:
   kona-supervisor-e2e:
     when:
       and:
-        - equal: [true, <<pipeline.parameters.rust_e2e_dispatch>>]
+        - equal: [true, <<pipeline.parameters.c-rust_e2e_dispatch>>]
         - equal: ["api", << pipeline.trigger_source >>]
     jobs:
       - kona-supervisor-e2e-tests:


### PR DESCRIPTION
## Summary

- Rename all pipeline parameters in CircleCI continuation configs (`main.yml`, `rust-ci.yml`, `rust-e2e.yml`) to use a `c-` prefix, eliminating naming overlap with the setup config (`config.yml`)
- This fixes the `{"message":"Conflicting pipeline parameters."}` error that occurs when API-triggered pipelines (e.g. from `opgitgovernance` bot) pass non-default parameter values
- The path-filtering mapping in `config.yml` bridges between the setup parameter names (used by API triggers) and the new `c-` prefixed continuation parameter names

## Context

CircleCI's dynamic configuration has a limitation: when the same pipeline parameter name is defined in both the setup config and the continuation config, API-triggered pipelines fail if they pass a non-default value for that parameter. Webhook and scheduled triggers are unaffected because their parameters stay at default values.

This is a known CircleCI issue discussed in their forums:
- ["Conflicting pipeline parameters." at continuation step when pipeline is triggered via UI](https://discuss.circleci.com/t/conflicting-pipeline-parameters-at-continuation-step-when-pipeline-is-triggered-via-ui/53108)
- ["Conflicting pipeline parameters." at continuation step when pipeline is triggered via curl](https://discuss.circleci.com/t/conflicting-pipeline-parameters-at-continuation-step-when-pipeline-is-triggered-via-curl/41884)
- [Odd behavior with Continuation and Trigger Pipeline from CircleCI UI](https://discuss.circleci.com/t/odd-behavior-with-continuation-and-trigger-pipeline-from-circleci-ui/52064)

## Test plan

- [ ] Verify that webhook-triggered pipelines still work (parameters passed through mapping at default values)
- [ ] Verify that API-triggered pipelines from `opgitgovernance` bot no longer fail with "Conflicting pipeline parameters"
- [ ] Verify that manual dispatch from CircleCI UI works for all `*_dispatch` parameters

🤖 Generated with [Claude Code](https://claude.com/claude-code)