### PR TITLE
fix(ci): rust ci

### DIFF
--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -4,7 +4,7 @@ version: 2.1
 # This file contains all Rust CI commands, parameterized jobs, crate-specific jobs, and workflows.
 
 orbs:
- utils: ethereum-optimism/circleci-utils@1.0.24
+  utils: ethereum-optimism/circleci-utils@1.0.24
   gcp-cli: circleci/gcp-cli@3.0.1
   codecov: codecov/codecov@5.0.3
 


### PR DESCRIPTION
Erroneous spacing lead to Error: bad file '.circleci/continue/rust-ci.yml': yaml: line 8: mapping values are not allowed in this context
