### PR TITLE
Fix/stop sequencer deadlock

### DIFF
--- a/op-node/rollup/sequencing/sequencer.go
+++ b/op-node/rollup/sequencing/sequencer.go
@@ -680,7 +680,6 @@ func (d *Sequencer) Stop(ctx context.Context) (common.Hash, error) {
 		} else if !isLeader {
 			d.log.Info("Not leader anymore, skipping head sync wait")
 			break
-			
 		}
 
 		latestHeadSet := make(chan struct{})

--- a/op-node/rollup/sequencing/sequencer.go
+++ b/op-node/rollup/sequencing/sequencer.go
@@ -672,6 +672,17 @@ func (d *Sequencer) Stop(ctx context.Context) (common.Hash, error) {
 
 	// ensure latestHead has been updated to the latest sealed/gossiped block before stopping the sequencer
 	for d.latestHead.Hash != d.latestSealed.Hash {
+
+		// if we are not the leader, latestSealed will never be updated and we will wait forever
+		if isLeader, err := d.conductor.Leader(ctx); err != nil {
+			d.log.Warn("Could not determine leadership while stopping. Skipping wait.", "err", err)
+			break
+		} else if !isLeader {
+			d.log.Info("Not leader anymore, skipping head sync wait")
+			break
+			
+		}
+
 		latestHeadSet := make(chan struct{})
 		d.latestHeadSet = latestHeadSet
 		d.l.Unlock()


### PR DESCRIPTION
Fixes a crash in op-conductor when Raft tries to snapshot before any blocks have been sequenced.

Hit this while migrating from non-HA to HA. During migration, we keep the conductor paused and HA sequencers stopped while they sync. If the sync takes longer than a couple minutes, Raft's periodic snapshot mechanism kicks in and tries to snapshot the FSM state. Problem is, since the sequencers are paused and haven't produced any blocks yet, unsafeHead is nil. When snapshot.Persist() tries to call MarshalSSZ() on this nil pointer, conductor crashes.

Tests

Added a test case for the nil unsafeHead scenario to make sure it returns an error instead of crashing. All existing tests still pass.

Fixes #13363