### PR TITLE
conductor: Fix nil pointer in Raft snapshot

### DIFF
--- a/op-conductor/consensus/raft_fsm.go
+++ b/op-conductor/consensus/raft_fsm.go
@@ -87,6 +87,7 @@ func (t *unsafeHeadTracker) Snapshot() (raft.FSMSnapshot, error) {
 	}
 
 	return &snapshot{
+		log:        t.log,
 		unsafeHead: t.unsafeHead,
 	}, nil
 }

--- a/op-conductor/consensus/raft_fsm.go
+++ b/op-conductor/consensus/raft_fsm.go
@@ -81,6 +81,11 @@ func (t *unsafeHeadTracker) Snapshot() (raft.FSMSnapshot, error) {
 	t.mtx.RLock()
 	defer t.mtx.RUnlock()
 
+	// Cannot snapshot if no unsafe head has been committed yet
+	if t.unsafeHead == nil {
+		return nil, fmt.Errorf("cannot create snapshot: no unsafe head available")
+	}
+
 	return &snapshot{
 		unsafeHead: t.unsafeHead,
 	}, nil

--- a/op-conductor/consensus/raft_fsm_test.go
+++ b/op-conductor/consensus/raft_fsm_test.go
@@ -69,6 +69,18 @@ func TestUnsafeHeadTracker(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, hexutil.Uint64(333), tracker.unsafeHead.ExecutionPayload.BlockNumber)
 	})
+
+	t.Run("Snapshot with nil unsafeHead", func(t *testing.T) {
+		emptyTracker := &unsafeHeadTracker{
+			log:        testlog.Logger(t, log.LevelDebug),
+			unsafeHead: nil,
+		}
+
+		snapshot, err := emptyTracker.Snapshot()
+		require.Error(t, err)
+		require.Nil(t, snapshot)
+		require.Contains(t, err.Error(), "no unsafe head available")
+	})
 }
 
 type mockReadCloser struct {


### PR DESCRIPTION
Fixes a crash in op-conductor when Raft tries to snapshot before any blocks have been sequenced.

Hit this while migrating from non-HA to HA. During migration, we keep the conductor paused and HA sequencers stopped while they sync. If the sync takes longer than a couple minutes, Raft's periodic snapshot mechanism kicks in and tries to snapshot the FSM state. Problem is, since the sequencers are paused and haven't produced any blocks yet, unsafeHead is nil. When snapshot.Persist() tries to call MarshalSSZ() on this nil pointer, conductor crashes.

Fixes #13363