### PR TITLE
fix(op-node): add SetCodeTxType check to span batch validation

### DIFF
--- a/op-node/rollup/derive/batches.go
+++ b/op-node/rollup/derive/batches.go
@@ -381,6 +381,7 @@ func checkSpanBatch(ctx context.Context, cfg *rollup.Config, log log.Logger, l1B
 			}
 		}
 
+		isIsthmus := cfg.IsIsthmus(blockTimestamp)
 		for i, txBytes := range batch.GetBlockTransactions(i) {
 			if len(txBytes) == 0 {
 				log.Warn("transaction data must not be empty, but found empty tx", "tx_index", i)
@@ -388,6 +389,10 @@ func checkSpanBatch(ctx context.Context, cfg *rollup.Config, log log.Logger, l1B
 			}
 			if txBytes[0] == types.DepositTxType {
 				log.Warn("sequencers may not embed any deposits into batch data, but found tx that has one", "tx_index", i)
+				return BatchDrop
+			}
+			if !isIsthmus && txBytes[0] == types.SetCodeTxType {
+				log.Warn("sequencers may not embed any SetCode transactions before Isthmus", "tx_index", i)
 				return BatchDrop
 			}
 		}


### PR DESCRIPTION
checkSingularBatch rejects SetCode (EIP-7702) transactions before Isthmus, but checkSpanBatch doesn't — this was missed when the check was originally added in b6b9371e21. This aligns span batch validation with singular batch behavior.