### PR TITLE
feat(release/rust): set up release process for rust crates

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -354,3 +354,38 @@ target "kona-node" {
   platforms = split(",", PLATFORMS)
   tags = [for tag in split(",", IMAGE_TAGS) : "${REGISTRY}/${REPOSITORY}/kona-node:${tag}"]
 }
+
+target "kona-host" {
+  dockerfile = "kona/docker/apps/kona_app_generic.dockerfile"
+  context = "rust"
+  args = {
+    REPO_LOCATION = "local"
+    BIN_TARGET = "kona-host"
+    BUILD_PROFILE = "release"
+  }
+  platforms = split(",", PLATFORMS)
+  tags = [for tag in split(",", IMAGE_TAGS) : "${REGISTRY}/${REPOSITORY}/kona-host:${tag}"]
+}
+
+target "kona-client" {
+  dockerfile = "kona/docker/apps/kona_app_generic.dockerfile"
+  context = "rust"
+  args = {
+    REPO_LOCATION = "local"
+    BIN_TARGET = "kona-client"
+    BUILD_PROFILE = "release"
+  }
+  platforms = split(",", PLATFORMS)
+  tags = [for tag in split(",", IMAGE_TAGS) : "${REGISTRY}/${REPOSITORY}/kona-client:${tag}"]
+}
+
+target "op-reth" {
+  dockerfile = "op-reth/DockerfileOp"
+  context = "rust"
+  args = {
+    BUILD_PROFILE = "maxperf"
+    FEATURES = ""
+  }
+  platforms = split(",", PLATFORMS)
+  tags = [for tag in split(",", IMAGE_TAGS) : "${REGISTRY}/${REPOSITORY}/op-reth:${tag}"]
+}

--- a/ops/scripts/compute-git-versions.sh
+++ b/ops/scripts/compute-git-versions.sh
@@ -30,6 +30,10 @@ IMAGES=(
   "cannon"
   "op-dripper"
   "op-interop-mon"
+  "op-reth"
+  "kona-node"
+  "kona-host"
+  "kona-client"
 )
 
 echo "Checking git tags pointing at $GIT_COMMIT:" >&2

--- a/rust/.dockerignore
+++ b/rust/.dockerignore
@@ -1,0 +1,7 @@
+target/
+book/
+assets/
+monorepo/
+.config/
+.github/
+tests/

--- a/rust/op-reth/DockerfileOp
+++ b/rust/op-reth/DockerfileOp
@@ -23,10 +23,10 @@ ENV RUSTFLAGS="$RUSTFLAGS"
 ARG FEATURES=""
 ENV FEATURES=$FEATURES
 
-RUN cargo chef cook --profile $BUILD_PROFILE --features "$FEATURES" --recipe-path recipe.json --manifest-path /app/crates/optimism/bin/Cargo.toml
+RUN cargo chef cook --profile $BUILD_PROFILE --features "$FEATURES" --recipe-path recipe.json --manifest-path /app/op-reth/bin/Cargo.toml
 
 COPY . .
-RUN cargo build --profile $BUILD_PROFILE --features "$FEATURES" --bin op-reth --manifest-path /app/crates/optimism/bin/Cargo.toml
+RUN cargo build --profile $BUILD_PROFILE --features "$FEATURES" --bin op-reth --manifest-path /app/op-reth/bin/Cargo.toml
 
 RUN ls -la /app/target/$BUILD_PROFILE/op-reth
 RUN cp /app/target/$BUILD_PROFILE/op-reth /app/op-reth


### PR DESCRIPTION
## Summary
- Add tag classification step to `tags.yaml` workflow to distinguish Rust crate groups (publish to crates.io) from Docker-only groups (op-reth) and regular Go images
- Add `publish-crates` CI job that publishes crates in dependency order with retry logic and index propagation delays
- Add op-reth Docker bake target, `.dockerignore`, and `compute-git-versions` entry
- Add `cargo-release` configuration for `alloy-op-hardforks` and `op-reth`
- Fix op-reth `DockerfileOp` manifest paths (`crates/optimism/bin` -> `op-reth/bin`)

## Test plan
- [ ] Verify tag classification: `alloy-op-hardforks/v*` triggers `publish-crates` only, `op-reth/v*` triggers `release` (Docker) only, `op-node/v*` triggers `release` only
- [ ] Dry-run `publish-rust-crates.sh` locally for each group to verify crate ordering
- [ ] Verify op-reth Docker build with `docker buildx bake op-reth`

🤖 Generated with [Claude Code](https://claude.com/claude-code)