### PR TITLE
feat(op-node): add NUT bundle parser for JSON-defined upgrade transactions

### DIFF
--- a/op-node/rollup/derive/parse_upgrade_transactions.go
+++ b/op-node/rollup/derive/parse_upgrade_transactions.go
@@ -31,8 +31,8 @@ type NetworkUpgradeTransaction struct {
 
 // NUTBundle is the top-level structure of a NUT file.
 type NUTBundle struct {
-	ForkName     forks.Name       `json:"-"`
-	Metadata     NUTMetadata      `json:"metadata"`
+	ForkName     forks.Name                  `json:"-"`
+	Metadata     NUTMetadata                 `json:"metadata"`
 	Transactions []NetworkUpgradeTransaction `json:"transactions"`
 }
 

--- a/op-node/rollup/derive/parse_upgrade_transactions.go
+++ b/op-node/rollup/derive/parse_upgrade_transactions.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -29,19 +30,19 @@ type NetworkUpgradeTransaction struct {
 
 // NUTBundle is the top-level structure of a NUT file.
 type NUTBundle struct {
-	ForkName     string           `json:"-"`
+	ForkName     forks.Name       `json:"-"`
 	Metadata     NUTMetadata      `json:"metadata"`
 	Transactions []NetworkUpgradeTransaction `json:"transactions"`
 }
 
-// ParseNUTBundle parses a NUT bundle from JSON bytes. The forkName is used to
+// ParseNUTBundle parses a NUT bundle from JSON bytes. The fork name is used to
 // namespace each transaction's intent when deriving source hashes.
-func ParseNUTBundle(forkName string, data []byte) (*NUTBundle, error) {
+func ParseNUTBundle(fork forks.Name, data []byte) (*NUTBundle, error) {
 	var bundle NUTBundle
 	if err := json.Unmarshal(data, &bundle); err != nil {
 		return nil, fmt.Errorf("failed to parse NUT bundle: %w", err)
 	}
-	bundle.ForkName = forkName
+	bundle.ForkName = fork
 	return &bundle, nil
 }
 

--- a/op-node/rollup/derive/parse_upgrade_transactions.go
+++ b/op-node/rollup/derive/parse_upgrade_transactions.go
@@ -18,8 +18,8 @@ type NUTMetadata struct {
 	Version string `json:"version"`
 }
 
-// NUTTransaction defines a single deposit transaction within a NUT bundle.
-type NUTTransaction struct {
+// NetworkUpgradeTransaction defines a single deposit transaction within a NUT bundle.
+type NetworkUpgradeTransaction struct {
 	Intent   string          `json:"intent"`
 	From     common.Address  `json:"from"`
 	To       *common.Address `json:"to"`
@@ -32,7 +32,7 @@ type NUTTransaction struct {
 type NUTBundle struct {
 	ForkName     string           `json:"-"`
 	Metadata     NUTMetadata      `json:"metadata"`
-	Transactions []NUTTransaction `json:"transactions"`
+	Transactions []NetworkUpgradeTransaction `json:"transactions"`
 }
 
 // ParseNUTBundle parses a NUT bundle from JSON bytes. The forkName is used to

--- a/op-node/rollup/derive/parse_upgrade_transactions.go
+++ b/op-node/rollup/derive/parse_upgrade_transactions.go
@@ -1,0 +1,72 @@
+package derive
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+// Network Upgrade Transactions (NUTs) are read from a JSON file and
+// converted into deposit transactions.
+
+// NUTMetadata contains version information for the NUT bundle format.
+type NUTMetadata struct {
+	Version string `json:"version"`
+}
+
+// NUTTransaction defines a single deposit transaction within a NUT bundle.
+type NUTTransaction struct {
+	From     common.Address  `json:"from"`
+	To       *common.Address `json:"to"`
+	Data     hexutil.Bytes   `json:"data"`
+	GasLimit uint64          `json:"gasLimit"`
+	Value    *big.Int        `json:"value,omitempty"`
+}
+
+// NUTBundle is the top-level structure of a NUT file.
+type NUTBundle struct {
+	Metadata     NUTMetadata      `json:"metadata"`
+	Transactions []NUTTransaction `json:"transactions"`
+}
+
+// ParseNUTBundle parses a NUT bundle from JSON bytes.
+func ParseNUTBundle(data []byte) (*NUTBundle, error) {
+	var bundle NUTBundle
+	if err := json.Unmarshal(data, &bundle); err != nil {
+		return nil, fmt.Errorf("failed to parse NUT bundle: %w", err)
+	}
+	return &bundle, nil
+}
+
+// ToDepositTransactions converts the bundle's transactions into serialized deposit transactions.
+func (b *NUTBundle) ToDepositTransactions() ([]hexutil.Bytes, error) {
+	txs := make([]hexutil.Bytes, 0, len(b.Transactions))
+	for i, nutTx := range b.Transactions {
+		value := nutTx.Value
+		if value == nil {
+			value = big.NewInt(0)
+		}
+
+		depTx := &types.DepositTx{
+			// TODO: source hash derivation
+			From:                nutTx.From,
+			To:                  nutTx.To,
+			Mint:                big.NewInt(0),
+			Value:               value,
+			Gas:                 nutTx.GasLimit,
+			IsSystemTransaction: false,
+			Data:                nutTx.Data,
+		}
+
+		encoded, err := types.NewTx(depTx).MarshalBinary()
+		if err != nil {
+			return nil, fmt.Errorf("tx %d: failed to marshal deposit tx: %w", i, err)
+		}
+		txs = append(txs, encoded)
+	}
+	return txs, nil
+}

--- a/op-node/rollup/derive/parse_upgrade_transactions.go
+++ b/op-node/rollup/derive/parse_upgrade_transactions.go
@@ -25,7 +25,6 @@ type NetworkUpgradeTransaction struct {
 	To       *common.Address `json:"to"`
 	Data     hexutil.Bytes   `json:"data"`
 	GasLimit uint64          `json:"gasLimit"`
-	Value    *big.Int        `json:"value,omitempty"`
 }
 
 // NUTBundle is the top-level structure of a NUT file.
@@ -54,11 +53,6 @@ func (b *NUTBundle) ToDepositTransactions() ([]hexutil.Bytes, error) {
 			return nil, fmt.Errorf("tx %d: missing intent", i)
 		}
 
-		value := nutTx.Value
-		if value == nil {
-			value = big.NewInt(0)
-		}
-
 		qualifiedIntent := fmt.Sprintf("%s %d: %s", b.ForkName, i, nutTx.Intent)
 		source := UpgradeDepositSource{Intent: qualifiedIntent}
 		depTx := &types.DepositTx{
@@ -66,7 +60,7 @@ func (b *NUTBundle) ToDepositTransactions() ([]hexutil.Bytes, error) {
 			From:                nutTx.From,
 			To:                  nutTx.To,
 			Mint:                big.NewInt(0),
-			Value:               value,
+			Value:               big.NewInt(0),
 			Gas:                 nutTx.GasLimit,
 			IsSystemTransaction: false,
 			Data:                nutTx.Data,

--- a/op-node/rollup/derive/parse_upgrade_transactions.go
+++ b/op-node/rollup/derive/parse_upgrade_transactions.go
@@ -3,6 +3,7 @@ package derive
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"math/big"
 
 	"github.com/ethereum-optimism/optimism/op-core/forks"
@@ -35,11 +36,11 @@ type NUTBundle struct {
 	Transactions []NetworkUpgradeTransaction `json:"transactions"`
 }
 
-// ParseNUTBundle parses a NUT bundle from JSON bytes. The fork name is used to
-// namespace each transaction's intent when deriving source hashes.
-func ParseNUTBundle(fork forks.Name, data []byte) (*NUTBundle, error) {
+// ReadNUTBundle reads and parses a NUT bundle from an io.Reader. The fork name
+// is used to namespace each transaction's intent when deriving source hashes.
+func ReadNUTBundle(fork forks.Name, r io.Reader) (*NUTBundle, error) {
 	var bundle NUTBundle
-	if err := json.Unmarshal(data, &bundle); err != nil {
+	if err := json.NewDecoder(r).Decode(&bundle); err != nil {
 		return nil, fmt.Errorf("failed to parse NUT bundle: %w", err)
 	}
 	bundle.ForkName = fork

--- a/op-node/rollup/derive/parse_upgrade_transactions.go
+++ b/op-node/rollup/derive/parse_upgrade_transactions.go
@@ -20,6 +20,7 @@ type NUTMetadata struct {
 
 // NUTTransaction defines a single deposit transaction within a NUT bundle.
 type NUTTransaction struct {
+	Intent   string          `json:"intent"`
 	From     common.Address  `json:"from"`
 	To       *common.Address `json:"to"`
 	Data     hexutil.Bytes   `json:"data"`
@@ -29,16 +30,19 @@ type NUTTransaction struct {
 
 // NUTBundle is the top-level structure of a NUT file.
 type NUTBundle struct {
+	ForkName     string           `json:"-"`
 	Metadata     NUTMetadata      `json:"metadata"`
 	Transactions []NUTTransaction `json:"transactions"`
 }
 
-// ParseNUTBundle parses a NUT bundle from JSON bytes.
-func ParseNUTBundle(data []byte) (*NUTBundle, error) {
+// ParseNUTBundle parses a NUT bundle from JSON bytes. The forkName is used to
+// namespace each transaction's intent when deriving source hashes.
+func ParseNUTBundle(forkName string, data []byte) (*NUTBundle, error) {
 	var bundle NUTBundle
 	if err := json.Unmarshal(data, &bundle); err != nil {
 		return nil, fmt.Errorf("failed to parse NUT bundle: %w", err)
 	}
+	bundle.ForkName = forkName
 	return &bundle, nil
 }
 
@@ -46,13 +50,19 @@ func ParseNUTBundle(data []byte) (*NUTBundle, error) {
 func (b *NUTBundle) ToDepositTransactions() ([]hexutil.Bytes, error) {
 	txs := make([]hexutil.Bytes, 0, len(b.Transactions))
 	for i, nutTx := range b.Transactions {
+		if nutTx.Intent == "" {
+			return nil, fmt.Errorf("tx %d: missing intent", i)
+		}
+
 		value := nutTx.Value
 		if value == nil {
 			value = big.NewInt(0)
 		}
 
+		qualifiedIntent := fmt.Sprintf("%s %d: %s", b.ForkName, i, nutTx.Intent)
+		source := UpgradeDepositSource{Intent: qualifiedIntent}
 		depTx := &types.DepositTx{
-			// TODO: source hash derivation
+			SourceHash:          source.SourceHash(),
 			From:                nutTx.From,
 			To:                  nutTx.To,
 			Mint:                big.NewInt(0),

--- a/op-node/rollup/derive/parse_upgrade_transactions_test.go
+++ b/op-node/rollup/derive/parse_upgrade_transactions_test.go
@@ -13,14 +13,16 @@ func TestParseNUTBundle(t *testing.T) {
 	data, err := os.ReadFile("testdata/test-nut.json")
 	require.NoError(t, err)
 
-	bundle, err := ParseNUTBundle(data)
+	bundle, err := ParseNUTBundle("Test", data)
 	require.NoError(t, err)
 
+	require.Equal(t, "Test", bundle.ForkName)
 	require.Equal(t, "1.0.0", bundle.Metadata.Version)
 	require.Len(t, bundle.Transactions, 2)
 
 	// First tx: no value field, zero address from
 	tx0 := bundle.Transactions[0]
+	require.Equal(t, "First Transaction", tx0.Intent)
 	require.Equal(t, common.Address{}, tx0.From)
 	require.NotNil(t, tx0.To)
 	require.Equal(t, common.HexToAddress("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"), *tx0.To)
@@ -30,6 +32,7 @@ func TestParseNUTBundle(t *testing.T) {
 
 	// Second tx: has value and non-zero from
 	tx1 := bundle.Transactions[1]
+	require.Equal(t, "Second Transaction", tx1.Intent)
 	require.Equal(t, common.HexToAddress("0x000000000000000000000000000000000000abba"), tx1.From)
 	require.NotNil(t, tx1.To)
 	require.Equal(t, uint64(5000000), tx1.GasLimit)
@@ -40,33 +43,58 @@ func TestNUTBundleToDepositTransactions(t *testing.T) {
 	data, err := os.ReadFile("testdata/test-nut.json")
 	require.NoError(t, err)
 
-	bundle, err := ParseNUTBundle(data)
+	bundle, err := ParseNUTBundle("Test", data)
 	require.NoError(t, err)
 
 	txs, err := bundle.ToDepositTransactions()
 	require.NoError(t, err)
 	require.Len(t, txs, 2)
 
-	// Verify first tx round-trips to a valid deposit tx
+	// Verify first tx: qualified intent is "Test 0: First Transaction"
+	expectedSource0 := UpgradeDepositSource{Intent: "Test 0: First Transaction"}
 	from0, dep0 := toDepositTxn(t, txs[0])
 	require.Equal(t, common.Address{}, from0)
+	require.Equal(t, expectedSource0.SourceHash(), dep0.SourceHash())
 	require.NotNil(t, dep0.To())
 	require.Equal(t, common.HexToAddress("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"), *dep0.To())
 	require.Equal(t, uint64(1000000), dep0.Gas())
 	require.Equal(t, common.FromHex("0xabcdef"), dep0.Data())
 	require.Equal(t, big.NewInt(0), dep0.Value())
 
-	// Verify second tx round-trips with value
+	// Verify second tx: qualified intent is "Test 1: Second Transaction"
+	expectedSource1 := UpgradeDepositSource{Intent: "Test 1: Second Transaction"}
 	from1, dep1 := toDepositTxn(t, txs[1])
 	require.Equal(t, common.HexToAddress("0x000000000000000000000000000000000000abba"), from1)
+	require.Equal(t, expectedSource1.SourceHash(), dep1.SourceHash())
 	require.Equal(t, uint64(5000000), dep1.Gas())
 	require.Equal(t, big.NewInt(100), dep1.Value())
+	// Source hashes must be unique
+	require.NotEqual(t, dep0.SourceHash(), dep1.SourceHash())
 }
 
 func TestParseNUTBundleInvalidJSON(t *testing.T) {
-	_, err := ParseNUTBundle([]byte(`{invalid`))
+	_, err := ParseNUTBundle("Test", []byte(`{invalid`))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to parse NUT bundle")
+}
+
+func TestNUTBundleMissingIntent(t *testing.T) {
+	jsonData := []byte(`{
+		"metadata": {"version": "1.0.0"},
+		"transactions": [{
+			"from": "0x0000000000000000000000000000000000000000",
+			"to": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+			"data": "0xabcdef",
+			"gasLimit": 1000000
+		}]
+	}`)
+
+	bundle, err := ParseNUTBundle("Test", jsonData)
+	require.NoError(t, err)
+
+	_, err = bundle.ToDepositTransactions()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "missing intent")
 }
 
 // TestNUTBundleNullTo verifies that "to": null in JSON produces a contract creation (deploy) transaction.
@@ -76,6 +104,7 @@ func TestNUTBundleNullTo(t *testing.T) {
 	jsonData := []byte(`{
 		"metadata": {"version": "1.0.0"},
 		"transactions": [{
+			"intent": "Deploy Contract",
 			"from": "0x4210000000000000000000000000000000000006",
 			"to": null,
 			"data": "0xdeadbeef",
@@ -83,7 +112,7 @@ func TestNUTBundleNullTo(t *testing.T) {
 		}]
 	}`)
 
-	bundle, err := ParseNUTBundle(jsonData)
+	bundle, err := ParseNUTBundle("Test", jsonData)
 	require.NoError(t, err)
 	require.Nil(t, bundle.Transactions[0].To)
 

--- a/op-node/rollup/derive/parse_upgrade_transactions_test.go
+++ b/op-node/rollup/derive/parse_upgrade_transactions_test.go
@@ -1,0 +1,95 @@
+package derive
+
+import (
+	"math/big"
+	"os"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseNUTBundle(t *testing.T) {
+	data, err := os.ReadFile("testdata/test-nut.json")
+	require.NoError(t, err)
+
+	bundle, err := ParseNUTBundle(data)
+	require.NoError(t, err)
+
+	require.Equal(t, "1.0.0", bundle.Metadata.Version)
+	require.Len(t, bundle.Transactions, 2)
+
+	// First tx: no value field, zero address from
+	tx0 := bundle.Transactions[0]
+	require.Equal(t, common.Address{}, tx0.From)
+	require.NotNil(t, tx0.To)
+	require.Equal(t, common.HexToAddress("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"), *tx0.To)
+	require.Equal(t, common.FromHex("0xabcdef"), []byte(tx0.Data))
+	require.Equal(t, uint64(1000000), tx0.GasLimit)
+	require.Nil(t, tx0.Value)
+
+	// Second tx: has value and non-zero from
+	tx1 := bundle.Transactions[1]
+	require.Equal(t, common.HexToAddress("0x000000000000000000000000000000000000abba"), tx1.From)
+	require.NotNil(t, tx1.To)
+	require.Equal(t, uint64(5000000), tx1.GasLimit)
+	require.Equal(t, big.NewInt(100), tx1.Value)
+}
+
+func TestNUTBundleToDepositTransactions(t *testing.T) {
+	data, err := os.ReadFile("testdata/test-nut.json")
+	require.NoError(t, err)
+
+	bundle, err := ParseNUTBundle(data)
+	require.NoError(t, err)
+
+	txs, err := bundle.ToDepositTransactions()
+	require.NoError(t, err)
+	require.Len(t, txs, 2)
+
+	// Verify first tx round-trips to a valid deposit tx
+	from0, dep0 := toDepositTxn(t, txs[0])
+	require.Equal(t, common.Address{}, from0)
+	require.NotNil(t, dep0.To())
+	require.Equal(t, common.HexToAddress("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"), *dep0.To())
+	require.Equal(t, uint64(1000000), dep0.Gas())
+	require.Equal(t, common.FromHex("0xabcdef"), dep0.Data())
+	require.Equal(t, big.NewInt(0), dep0.Value())
+
+	// Verify second tx round-trips with value
+	from1, dep1 := toDepositTxn(t, txs[1])
+	require.Equal(t, common.HexToAddress("0x000000000000000000000000000000000000abba"), from1)
+	require.Equal(t, uint64(5000000), dep1.Gas())
+	require.Equal(t, big.NewInt(100), dep1.Value())
+}
+
+func TestParseNUTBundleInvalidJSON(t *testing.T) {
+	_, err := ParseNUTBundle([]byte(`{invalid`))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to parse NUT bundle")
+}
+
+// TestNUTBundleNullTo verifies that "to": null in JSON produces a contract creation (deploy) transaction.
+// Although NUTs are expected to use Arachnid's deterministic deployer, this sending to null
+// is how previous deployments have been handled and is useful to maintain going forward.
+func TestNUTBundleNullTo(t *testing.T) {
+	jsonData := []byte(`{
+		"metadata": {"version": "1.0.0"},
+		"transactions": [{
+			"from": "0x4210000000000000000000000000000000000006",
+			"to": null,
+			"data": "0xdeadbeef",
+			"gasLimit": 500000
+		}]
+	}`)
+
+	bundle, err := ParseNUTBundle(jsonData)
+	require.NoError(t, err)
+	require.Nil(t, bundle.Transactions[0].To)
+
+	txs, err := bundle.ToDepositTransactions()
+	require.NoError(t, err)
+
+	_, dep := toDepositTxn(t, txs[0])
+	require.Nil(t, dep.To())
+}

--- a/op-node/rollup/derive/parse_upgrade_transactions_test.go
+++ b/op-node/rollup/derive/parse_upgrade_transactions_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
@@ -16,7 +17,7 @@ func TestParseNUTBundle(t *testing.T) {
 	bundle, err := ParseNUTBundle("Test", data)
 	require.NoError(t, err)
 
-	require.Equal(t, "Test", bundle.ForkName)
+	require.Equal(t, forks.Name("Test"), bundle.ForkName)
 	require.Equal(t, "1.0.0", bundle.Metadata.Version)
 	require.Len(t, bundle.Transactions, 2)
 

--- a/op-node/rollup/derive/parse_upgrade_transactions_test.go
+++ b/op-node/rollup/derive/parse_upgrade_transactions_test.go
@@ -28,15 +28,13 @@ func TestParseNUTBundle(t *testing.T) {
 	require.Equal(t, common.HexToAddress("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"), *tx0.To)
 	require.Equal(t, common.FromHex("0xabcdef"), []byte(tx0.Data))
 	require.Equal(t, uint64(1000000), tx0.GasLimit)
-	require.Nil(t, tx0.Value)
 
-	// Second tx: has value and non-zero from
+	// Second tx: non-zero from
 	tx1 := bundle.Transactions[1]
 	require.Equal(t, "Second Transaction", tx1.Intent)
 	require.Equal(t, common.HexToAddress("0x000000000000000000000000000000000000abba"), tx1.From)
 	require.NotNil(t, tx1.To)
 	require.Equal(t, uint64(5000000), tx1.GasLimit)
-	require.Equal(t, big.NewInt(100), tx1.Value)
 }
 
 func TestNUTBundleToDepositTransactions(t *testing.T) {
@@ -67,7 +65,7 @@ func TestNUTBundleToDepositTransactions(t *testing.T) {
 	require.Equal(t, common.HexToAddress("0x000000000000000000000000000000000000abba"), from1)
 	require.Equal(t, expectedSource1.SourceHash(), dep1.SourceHash())
 	require.Equal(t, uint64(5000000), dep1.Gas())
-	require.Equal(t, big.NewInt(100), dep1.Value())
+	require.Equal(t, big.NewInt(0), dep1.Value())
 	// Source hashes must be unique
 	require.NotEqual(t, dep0.SourceHash(), dep1.SourceHash())
 }

--- a/op-node/rollup/derive/parse_upgrade_transactions_test.go
+++ b/op-node/rollup/derive/parse_upgrade_transactions_test.go
@@ -1,6 +1,7 @@
 package derive
 
 import (
+	"bytes"
 	"math/big"
 	"os"
 	"testing"
@@ -10,11 +11,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestParseNUTBundle(t *testing.T) {
-	data, err := os.ReadFile("testdata/test-nut.json")
+func TestReadNUTBundle(t *testing.T) {
+	f, err := os.Open("testdata/test-nut.json")
 	require.NoError(t, err)
+	defer f.Close()
 
-	bundle, err := ParseNUTBundle("Test", data)
+	bundle, err := ReadNUTBundle("Test", f)
 	require.NoError(t, err)
 
 	require.Equal(t, forks.Name("Test"), bundle.ForkName)
@@ -39,10 +41,11 @@ func TestParseNUTBundle(t *testing.T) {
 }
 
 func TestNUTBundleToDepositTransactions(t *testing.T) {
-	data, err := os.ReadFile("testdata/test-nut.json")
+	f, err := os.Open("testdata/test-nut.json")
 	require.NoError(t, err)
+	defer f.Close()
 
-	bundle, err := ParseNUTBundle("Test", data)
+	bundle, err := ReadNUTBundle("Test", f)
 	require.NoError(t, err)
 
 	txs, err := bundle.ToDepositTransactions()
@@ -71,8 +74,8 @@ func TestNUTBundleToDepositTransactions(t *testing.T) {
 	require.NotEqual(t, dep0.SourceHash(), dep1.SourceHash())
 }
 
-func TestParseNUTBundleInvalidJSON(t *testing.T) {
-	_, err := ParseNUTBundle("Test", []byte(`{invalid`))
+func TestReadNUTBundleInvalidJSON(t *testing.T) {
+	_, err := ReadNUTBundle("Test", bytes.NewReader([]byte(`{invalid`)))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to parse NUT bundle")
 }
@@ -88,7 +91,7 @@ func TestNUTBundleMissingIntent(t *testing.T) {
 		}]
 	}`)
 
-	bundle, err := ParseNUTBundle("Test", jsonData)
+	bundle, err := ReadNUTBundle("Test", bytes.NewReader(jsonData))
 	require.NoError(t, err)
 
 	_, err = bundle.ToDepositTransactions()
@@ -111,7 +114,7 @@ func TestNUTBundleNullTo(t *testing.T) {
 		}]
 	}`)
 
-	bundle, err := ParseNUTBundle("Test", jsonData)
+	bundle, err := ReadNUTBundle("Test", bytes.NewReader(jsonData))
 	require.NoError(t, err)
 	require.Nil(t, bundle.Transactions[0].To)
 

--- a/op-node/rollup/derive/testdata/test-nut.json
+++ b/op-node/rollup/derive/testdata/test-nut.json
@@ -1,0 +1,20 @@
+{
+  "metadata": {
+    "version": "1.0.0"
+  },
+  "transactions": [
+    {
+      "to": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+      "data": "0xabcdef",
+      "gasLimit": 1000000,
+      "from": "0x0000000000000000000000000000000000000000"
+    },
+    {
+      "to": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+      "data": "0xabcdef",
+      "gasLimit": 5000000,
+      "value": 100,
+      "from": "0x000000000000000000000000000000000000abba"
+    }
+  ]
+}

--- a/op-node/rollup/derive/testdata/test-nut.json
+++ b/op-node/rollup/derive/testdata/test-nut.json
@@ -15,7 +15,6 @@
       "to": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
       "data": "0xabcdef",
       "gasLimit": 5000000,
-      "value": 100,
       "from": "0x000000000000000000000000000000000000abba"
     }
   ]

--- a/op-node/rollup/derive/testdata/test-nut.json
+++ b/op-node/rollup/derive/testdata/test-nut.json
@@ -4,12 +4,14 @@
   },
   "transactions": [
     {
+      "intent": "First Transaction",
       "to": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
       "data": "0xabcdef",
       "gasLimit": 1000000,
       "from": "0x0000000000000000000000000000000000000000"
     },
     {
+      "intent": "Second Transaction",
       "to": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
       "data": "0xabcdef",
       "gasLimit": 5000000,


### PR DESCRIPTION
# Summary

Adds the ability to define network upgrade transactions via JSON files instead of requiring a dedicated Go file per hardfork. 

The work is done in two commits:

1. 9b50510 — Introduces ParseNUTBundle and NUTBundle.ToDepositTransactions(), which parse a JSON file into typed structs and convert them into serialized DepositTx transactions.
2. 363c6cc - Each transaction gets a unique source hash derived from "<forkName> <index>: <intent>", using the existing `UpgradeDepositSource` mechanism. 
