### PR TITLE
op-devstack: parallelize service startup and batch migration transactions

### DIFF
--- a/op-devstack/stack/orchestrator.go
+++ b/op-devstack/stack/orchestrator.go
@@ -1,6 +1,8 @@
 package stack
 
 import (
+	"sync"
+
 	"github.com/ethereum-optimism/optimism/op-devstack/compat"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 )
@@ -140,6 +142,83 @@ func (c CombinedOption[O]) PreHydrate(sys System) {
 
 func (c CombinedOption[O]) PostHydrate(sys System) {
 	for _, opt := range c {
+		opt.PostHydrate(sys)
+	}
+}
+
+// ParallelOption wraps multiple options whose AfterDeploy phases
+// can safely run concurrently. All other lifecycle phases run sequentially.
+// Use this to parallelize independent service startups within a dependency level.
+type ParallelOption[O Orchestrator] struct {
+	opts []Option[O]
+}
+
+var _ CommonOption = (*ParallelOption[Orchestrator])(nil)
+
+// InParallel creates a ParallelOption that runs AfterDeploy concurrently for all given options.
+// BeforeDeploy, Deploy, Finally, PreHydrate, and PostHydrate still run sequentially.
+func InParallel[O Orchestrator](opts ...Option[O]) *ParallelOption[O] {
+	return &ParallelOption[O]{opts: opts}
+}
+
+func (p *ParallelOption[O]) BeforeDeploy(orch O) {
+	for _, opt := range p.opts {
+		opt.BeforeDeploy(orch)
+	}
+}
+
+func (p *ParallelOption[O]) Deploy(orch O) {
+	for _, opt := range p.opts {
+		opt.Deploy(orch)
+	}
+}
+
+func (p *ParallelOption[O]) AfterDeploy(orch O) {
+	if len(p.opts) <= 1 {
+		for _, opt := range p.opts {
+			opt.AfterDeploy(orch)
+		}
+		return
+	}
+
+	var wg sync.WaitGroup
+	panics := make(chan any, len(p.opts))
+
+	for _, opt := range p.opts {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					panics <- r
+				}
+			}()
+			opt.AfterDeploy(orch)
+		}()
+	}
+
+	wg.Wait()
+	close(panics)
+
+	if r, ok := <-panics; ok {
+		panic(r)
+	}
+}
+
+func (p *ParallelOption[O]) Finally(orch O) {
+	for _, opt := range p.opts {
+		opt.Finally(orch)
+	}
+}
+
+func (p *ParallelOption[O]) PreHydrate(sys System) {
+	for _, opt := range p.opts {
+		opt.PreHydrate(sys)
+	}
+}
+
+func (p *ParallelOption[O]) PostHydrate(sys System) {
+	for _, opt := range p.opts {
 		opt.PostHydrate(sys)
 	}
 }

--- a/op-devstack/stack/orchestrator_parallel_test.go
+++ b/op-devstack/stack/orchestrator_parallel_test.go
@@ -1,0 +1,104 @@
+package stack
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/compat"
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+)
+
+// mockOrch satisfies Orchestrator for testing parallel execution.
+// All methods are stubs since tests pass nil and don't invoke them.
+type mockOrch struct{}
+
+func (m *mockOrch) P() devtest.P               { return nil }
+func (m *mockOrch) Hydrate(_ ExtensibleSystem) {}
+func (m *mockOrch) ControlPlane() ControlPlane { return nil }
+func (m *mockOrch) Type() compat.Type          { return "test" }
+func (m *mockOrch) PreHydrate(_ System)        {}
+func (m *mockOrch) PostHydrate(_ System)       {}
+
+var _ Orchestrator = (*mockOrch)(nil)
+
+// simOption creates an option that simulates work taking `d` duration in AfterDeploy
+func simOption(d time.Duration, counter *atomic.Int32) Option[*mockOrch] {
+	return FnOption[*mockOrch]{
+		AfterDeployFn: func(_ *mockOrch) {
+			time.Sleep(d)
+			counter.Add(1)
+		},
+	}
+}
+
+func TestInParallelRunsConcurrently(t *testing.T) {
+	var counter atomic.Int32
+
+	sleepDur := 100 * time.Millisecond
+	numOpts := 4
+
+	opts := make([]Option[*mockOrch], numOpts)
+	for i := range opts {
+		opts[i] = simOption(sleepDur, &counter)
+	}
+
+	// Sequential: should take ~numOpts * sleepDur
+	counter.Store(0)
+	seqStart := time.Now()
+	combined := Combine(opts...)
+	combined.AfterDeploy(nil)
+	seqDur := time.Since(seqStart)
+	require.Equal(t, int32(numOpts), counter.Load())
+
+	// Parallel: should take ~sleepDur (all run concurrently)
+	counter.Store(0)
+	parStart := time.Now()
+	par := InParallel(opts...)
+	par.AfterDeploy(nil)
+	parDur := time.Since(parStart)
+	require.Equal(t, int32(numOpts), counter.Load())
+
+	t.Logf("Sequential: %v", seqDur)
+	t.Logf("Parallel:   %v", parDur)
+	t.Logf("Speedup:    %.1fx", float64(seqDur)/float64(parDur))
+
+	// Parallel should be at least 2x faster than sequential
+	require.Less(t, parDur, seqDur/2, "parallel should be significantly faster than sequential")
+}
+
+func TestInParallelPanicPropagation(t *testing.T) {
+	var counter atomic.Int32
+
+	opts := []Option[*mockOrch]{
+		simOption(10*time.Millisecond, &counter),
+		FnOption[*mockOrch]{
+			AfterDeployFn: func(_ *mockOrch) {
+				panic("test panic")
+			},
+		},
+		simOption(10*time.Millisecond, &counter),
+	}
+
+	par := InParallel(opts...)
+	require.Panics(t, func() {
+		par.AfterDeploy(nil)
+	})
+}
+
+func TestInParallelSingleOption(t *testing.T) {
+	var counter atomic.Int32
+	opt := simOption(10*time.Millisecond, &counter)
+
+	par := InParallel(opt)
+	par.AfterDeploy(nil)
+	require.Equal(t, int32(1), counter.Load())
+}
+
+func TestInParallelEmpty(t *testing.T) {
+	par := InParallel[*mockOrch]()
+	// Should not panic
+	par.AfterDeploy(nil)
+}

--- a/op-devstack/sysgo/superroot.go
+++ b/op-devstack/sysgo/superroot.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"encoding/json"
+	"fmt"
 	"math/big"
 	"os"
 	"path"
@@ -23,6 +24,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
+	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -75,31 +77,56 @@ func withSuperRoots(l1ChainID eth.ChainID, l1ELID stack.L1ELNodeID, clIDs []stac
 			client := ethclient.NewClient(rpcClient)
 			w3Client := w3.NewClient(rpcClient)
 
-			var superrootTime uint64
-			// Supernode does not support super roots at geensis.
-			// So let's wait for safe heads to advance before querying atTimestamp.
+			// Supernode does not support super roots at genesis.
+			// Wait for all L2 safe heads to advance in parallel before querying atTimestamp.
+			// TODO(#18947): Ideally, we should be able to wait on the supernode's SyncStatus directly
+			// rather than check the sync statuses of all CLs
+			type safeHeadResult struct {
+				time uint64
+				err  error
+			}
+			safeHeadCh := make(chan safeHeadResult, len(clIDs))
 			for _, clID := range clIDs {
-				cl, ok := o.l2CLs.Get(clID)
-				require.True(ok, "must have L2 CL node")
-				// TODO(#18947): Ideally, we should be able to wait on the supernode's SyncStatus directly
-				// rather than check the sync statuses of all CLs
-				rollupClient, err := dial.DialRollupClientWithTimeout(t.Ctx(), t.Logger(), cl.UserRPC())
-				t.Require().NoError(err)
-				defer rollupClient.Close()
-				ctx, cancel := context.WithTimeout(t.Ctx(), time.Minute*2)
-				err = wait.For(ctx, time.Second*1, func() (bool, error) {
-					status, err := rollupClient.SyncStatus(ctx)
+				go func(clID stack.L2CLNodeID) {
+					cl, ok := o.l2CLs.Get(clID)
+					if !ok {
+						safeHeadCh <- safeHeadResult{err: fmt.Errorf("must have L2 CL node %v", clID)}
+						return
+					}
+					rollupClient, err := dial.DialRollupClientWithTimeout(t.Ctx(), t.Logger(), cl.UserRPC())
 					if err != nil {
-						return false, err
+						safeHeadCh <- safeHeadResult{err: fmt.Errorf("dialing rollup client for %v: %w", clID, err)}
+						return
 					}
-					if status == nil {
-						return false, nil
+					defer rollupClient.Close()
+					ctx, cancel := context.WithTimeout(t.Ctx(), time.Minute*2)
+					defer cancel()
+					var headTime uint64
+					err = wait.For(ctx, time.Second*1, func() (bool, error) {
+						status, err := rollupClient.SyncStatus(ctx)
+						if err != nil {
+							return false, err
+						}
+						if status == nil {
+							return false, nil
+						}
+						headTime = status.SafeL2.Time
+						return status.SafeL2.Number > 0, nil
+					})
+					if err != nil {
+						safeHeadCh <- safeHeadResult{err: fmt.Errorf("waiting for %v safe head: %w", clID, err)}
+						return
 					}
-					superrootTime = status.SafeL2.Time
-					return status.SafeL2.Number > 0, nil
-				})
-				cancel()
-				t.Require().NoError(err, "waiting for supernode chain safe head to advance failed")
+					safeHeadCh <- safeHeadResult{time: headTime}
+				}(clID)
+			}
+			var superrootTime uint64
+			for range clIDs {
+				r := <-safeHeadCh
+				require.NoError(r.err, "waiting for supernode chain safe head to advance failed")
+				if superrootTime == 0 || r.time < superrootTime {
+					superrootTime = r.time
+				}
 			}
 
 			superRoot := getSuperRootAtTimestamp(t, o, superrootTime)
@@ -203,8 +230,14 @@ func withSuperRoots(l1ChainID eth.ChainID, l1ELID stack.L1ELNodeID, clIDs []stac
 			// The DelegateCallProxy is used to simulate a GnosisSafe proxy that satisfies the delegatecall requirement of the OPCM.
 			delegateCallProxy, proxyContract := deployDelegateCallProxy(t, transactOpts, client, l1pao)
 			oldSuperchainProxyAdminOwner := getOwner(t, w3Client, superchainProxyAdmin)
-			transferOwnership(t, l1PAOKey, client, superchainProxyAdmin, delegateCallProxy)
 
+			// Collect all pre-migration ownership transfer candidates for batch sending.
+			// All transfers move ownership to the delegateCallProxy so the OPCM migration can execute via delegatecall.
+			// Deduplicate by target address: some proxy admins may be shared across chains.
+			preMigrationCandidates := []txmgr.TxCandidate{
+				ownershipTransferCandidate(delegateCallProxy, superchainProxyAdmin),
+			}
+			preMigrationSeen := map[common.Address]bool{superchainProxyAdmin: true}
 			oldDisputeGameFactories := make(map[eth.ChainID]common.Address)
 			for i, opChainConfig := range opChainConfigs {
 				var portal common.Address
@@ -213,12 +246,23 @@ func withSuperRoots(l1ChainID eth.ChainID, l1ELID stack.L1ELNodeID, clIDs []stac
 						w3eth.CallFunc(opChainConfig.SystemConfigProxy, optimismPortalFn).Returns(&portal),
 					))
 				portalProxyAdmin := getProxyAdmin(t, w3Client, portal)
-				transferOwnership(t, l1PAOKey, client, portalProxyAdmin, delegateCallProxy)
+				if !preMigrationSeen[portalProxyAdmin] {
+					preMigrationSeen[portalProxyAdmin] = true
+					preMigrationCandidates = append(preMigrationCandidates,
+						ownershipTransferCandidate(delegateCallProxy, portalProxyAdmin))
+				}
 
 				dgf := getDisputeGameFactory(t, w3Client, portal)
-				transferOwnership(t, l1PAOKey, client, dgf, delegateCallProxy)
+				if !preMigrationSeen[dgf] {
+					preMigrationSeen[dgf] = true
+					preMigrationCandidates = append(preMigrationCandidates,
+						ownershipTransferCandidate(delegateCallProxy, dgf))
+				}
 				oldDisputeGameFactories[l2ChainIDs[i]] = dgf
 			}
+			t.Log("Batch sending pre-migration ownership transfers")
+			_, _, err = transactions.SendTxs(t.Ctx(), client, preMigrationCandidates, l1PAOKey)
+			require.NoError(err, "pre-migration ownership transfers failed")
 
 			t.Log("Executing delegate call")
 			migrateTx, err := proxyContract.ExecuteDelegateCall(transactOpts, opcmAddr, migrateCallData)
@@ -243,30 +287,86 @@ func withSuperRoots(l1ChainID eth.ChainID, l1ELID stack.L1ELNodeID, clIDs []stac
 				}
 			}
 
-			// reset ownership transfers
-			resetOwnershipAfterMigration(t,
-				o,
-				l1ChainID.ToBig(),
-				l1PAOKey,
-				w3Client,
-				client,
-				delegateCallProxy,
-				opChainConfigs,
-			)
+			// Collect all post-migration ownership reset candidates for batch sending.
+			// All resets transfer ownership from the delegateCallProxy back to the original owners.
+			// Deduplicate by target address: e.g. ethLockboxAdmin and portalProxyAdmin can be the same contract.
+			delegateProxyABI, err := delegatecallproxy.DelegatecallproxyMetaData.GetAbi()
+			require.NoError(err, "failed to get delegate call proxy ABI")
 
-			resetOldDisputeGameFactories(t,
-				o,
-				l1ChainID.ToBig(),
-				l1PAOKey,
-				client,
-				delegateCallProxy,
-				oldDisputeGameFactories,
-			)
+			postMigrationCandidates := []txmgr.TxCandidate{}
+			postMigrationSeen := make(map[common.Address]bool)
 
-			transferOwnershipForDelegateCallProxy(t, l1ChainID.ToBig(), l1PAOKey, client, delegateCallProxy, superchainProxyAdmin, oldSuperchainProxyAdminOwner)
+			// Reset shared DGF ownership
+			postMigrationSeen[sharedDGF] = true
+			postMigrationCandidates = append(postMigrationCandidates,
+				delegateProxyTransferCandidate(delegateProxyABI, delegateCallProxy, sharedDGF, l1pao))
 
+			// Reset EthLockbox proxy admin ownership
+			portal0 := getOptimismPortal(t, w3Client, opChainConfigs[0].SystemConfigProxy)
+			var sharedEthLockboxProxy common.Address
+			err = w3Client.Call(w3eth.CallFunc(portal0, ethLockboxFn).Returns(&sharedEthLockboxProxy))
+			require.NoError(err)
+			ethLockboxAdmin := getAdmin(t, w3Client, sharedEthLockboxProxy)
+			if !postMigrationSeen[ethLockboxAdmin] {
+				postMigrationSeen[ethLockboxAdmin] = true
+				postMigrationCandidates = append(postMigrationCandidates,
+					delegateProxyTransferCandidate(delegateProxyABI, delegateCallProxy, ethLockboxAdmin, l1pao))
+			}
+
+			// Reset portal proxy admin ownership (conditional - only if still owned by proxy)
+			for _, cfg := range opChainConfigs {
+				portal := getOptimismPortal(t, w3Client, cfg.SystemConfigProxy)
+				portalProxyAdmin := getProxyAdmin(t, w3Client, portal)
+				if !postMigrationSeen[portalProxyAdmin] && getOwner(t, w3Client, portalProxyAdmin) == delegateCallProxy {
+					postMigrationSeen[portalProxyAdmin] = true
+					postMigrationCandidates = append(postMigrationCandidates,
+						delegateProxyTransferCandidate(delegateProxyABI, delegateCallProxy, portalProxyAdmin, l1pao))
+				}
+			}
+
+			// Reset old dispute game factory ownership
+			for l2ChainID, oldDGF := range oldDisputeGameFactories {
+				if !postMigrationSeen[oldDGF] {
+					postMigrationSeen[oldDGF] = true
+					chainOpsForL2 := devkeys.ChainOperatorKeys(l2ChainID.ToBig())
+					l1PAOForL2, err := o.keys.Address(chainOpsForL2(devkeys.L1ProxyAdminOwnerRole))
+					require.NoError(err, "must have configured L1 proxy admin owner private key")
+					postMigrationCandidates = append(postMigrationCandidates,
+						delegateProxyTransferCandidate(delegateProxyABI, delegateCallProxy, oldDGF, l1PAOForL2))
+				}
+			}
+
+			// Reset superchain proxy admin ownership back to original owner
+			if !postMigrationSeen[superchainProxyAdmin] {
+				postMigrationSeen[superchainProxyAdmin] = true
+				postMigrationCandidates = append(postMigrationCandidates,
+					delegateProxyTransferCandidate(delegateProxyABI, delegateCallProxy, superchainProxyAdmin, oldSuperchainProxyAdminOwner))
+			}
+
+			t.Log("Batch sending post-migration ownership resets")
+			_, _, err = transactions.SendTxs(t.Ctx(), client, postMigrationCandidates, l1PAOKey)
+			require.NoError(err, "post-migration ownership resets failed")
+
+			// Verify ownership was correctly restored
 			superchainProxyAdminOwner := getOwner(t, w3Client, superchainProxyAdmin)
 			t.Require().Equal(oldSuperchainProxyAdminOwner, superchainProxyAdminOwner, "superchain proxy admin owner is not the L1PAO")
+
+			var sharedAnchorStateRegistryProxy common.Address
+			err = w3Client.Call(w3eth.CallFunc(portal0, anchorStateRegistryFn).Returns(&sharedAnchorStateRegistryProxy))
+			require.NoError(err)
+			asrAdminOwner := getProxyAdminOwner(t, w3Client, sharedAnchorStateRegistryProxy)
+			require.Equal(l1pao, asrAdminOwner, "sharedAnchorStateRegistryProxy proxy admin owner is not the L1PAO")
+
+			gameTypes := []uint32{superPermissionedGameType, superCannonGameType}
+			for _, gameType := range gameTypes {
+				var gameArgsBytes []byte
+				err = w3Client.Call(w3eth.CallFunc(sharedDGF, gameArgsFn, gameType).Returns(&gameArgsBytes))
+				require.NoError(err)
+				parsedGameArgs, err := gameargs.Parse(gameArgsBytes)
+				require.NoErrorf(err, "invalid game args for gameType %d", gameType)
+				wethAdminOwner := getProxyAdminOwner(t, w3Client, parsedGameArgs.Weth)
+				require.Equal(l1pao, wethAdminOwner, "wethProxy proxy admin owner is not the L1PAO")
+			}
 
 			for _, l2Deployment := range o.wb.outL2Deployment {
 				l2Deployment.disputeGameFactoryProxy = sharedDGF
@@ -440,6 +540,30 @@ func getProxyAdmin(t devtest.CommonT, client *w3.Client, addr common.Address) co
 	return proxyAdmin
 }
 
+// ownershipTransferCandidate builds a TxCandidate for transferring ownership of a contract to a new owner.
+// Used for batch-sending multiple ownership transfers in a single block.
+func ownershipTransferCandidate(newOwner common.Address, target common.Address) txmgr.TxCandidate {
+	data, err := transferOwnershipFn.EncodeArgs(newOwner)
+	if err != nil {
+		panic(fmt.Sprintf("failed to encode transferOwnership args: %v", err))
+	}
+	to := target
+	return txmgr.TxCandidate{To: &to, TxData: data, GasLimit: 1_000_000}
+}
+
+// delegateProxyTransferCandidate builds a TxCandidate for transferring ownership via the DelegateCallProxy.
+// Used for batch-sending multiple proxy ownership resets in a single block.
+func delegateProxyTransferCandidate(proxyABI *abi.ABI, delegateCallProxyAddr, proxyAdminOwned, newOwner common.Address) txmgr.TxCandidate {
+	contract := batching.NewBoundContract(proxyABI, delegateCallProxyAddr)
+	call := contract.Call("transferOwnership", proxyAdminOwned, newOwner)
+	data, err := call.Pack()
+	if err != nil {
+		panic(fmt.Sprintf("failed to pack delegate proxy transferOwnership: %v", err))
+	}
+	to := delegateCallProxyAddr
+	return txmgr.TxCandidate{To: &to, TxData: data, GasLimit: 1_000_000}
+}
+
 func transferOwnership(t devtest.CommonT, privateKey *ecdsa.PrivateKey, client *ethclient.Client, l1ProxyAdmin common.Address, newOwner common.Address) {
 	data, err := transferOwnershipFn.EncodeArgs(newOwner)
 	t.Require().NoError(err)
@@ -482,108 +606,4 @@ func transferOwnershipForDelegateCallProxy(
 	_, receipt, err := transactions.SendTx(t.Ctx(), client, candidate, privateKey)
 	t.Require().NoErrorf(err, "transferOwnership failed: %v", errutil.TryAddRevertReason(err))
 	t.Require().Equal(receipt.Status, types.ReceiptStatusSuccessful, "transferOwnership failed")
-}
-
-func resetOwnershipAfterMigration(
-	t devtest.CommonT,
-	o *Orchestrator,
-	l1ChainID *big.Int,
-	ownerPrivateKey *ecdsa.PrivateKey,
-	w3Client *w3.Client,
-	client *ethclient.Client,
-	delegateCallProxy common.Address,
-	opChainConfigs []bindings.OPContractsManagerOpChainConfig,
-) {
-	l1PAO, err := o.keys.Address(devkeys.ChainOperatorKeys(l1ChainID)(devkeys.L1ProxyAdminOwnerRole))
-	t.Require().NoError(err, "must have L1 proxy admin owner private key")
-
-	portal0 := getOptimismPortal(t, w3Client, opChainConfigs[0].SystemConfigProxy)
-	sharedDGF := getDisputeGameFactory(t, w3Client, portal0)
-	transferOwnershipForDelegateCallProxy(
-		t,
-		l1ChainID,
-		ownerPrivateKey,
-		client,
-		delegateCallProxy,
-		sharedDGF,
-		l1PAO,
-	)
-
-	var sharedEthLockboxProxy common.Address
-	err = w3Client.Call(w3eth.CallFunc(portal0, ethLockboxFn).Returns(&sharedEthLockboxProxy))
-	t.Require().NoError(err)
-	proxyAdmin := getAdmin(t, w3Client, sharedEthLockboxProxy)
-	transferOwnershipForDelegateCallProxy(
-		t,
-		l1ChainID,
-		ownerPrivateKey,
-		client,
-		delegateCallProxy,
-		proxyAdmin,
-		l1PAO,
-	)
-
-	// The migration temporarily transfers ownership of each portal ProxyAdmin to the DelegateCallProxy
-	// to satisfy the delegatecall requirement of the OPCM. Reset these back to the L1 proxy admin owner
-	// after the shared admin contracts are restored.
-	for _, cfg := range opChainConfigs {
-		portal := getOptimismPortal(t, w3Client, cfg.SystemConfigProxy)
-		portalProxyAdmin := getProxyAdmin(t, w3Client, portal)
-		// In some setups the migration may already restore ownership. Only reset when still owned by the proxy.
-		if getOwner(t, w3Client, portalProxyAdmin) == delegateCallProxy {
-			transferOwnershipForDelegateCallProxy(
-				t,
-				l1ChainID,
-				ownerPrivateKey,
-				client,
-				delegateCallProxy,
-				portalProxyAdmin,
-				l1PAO,
-			)
-		}
-	}
-
-	// The Proxy Admin owner is changed. Assert that the admin of other proxies are consistent
-	var sharedAnchorStateRegistryProxy common.Address
-	err = w3Client.Call(w3eth.CallFunc(portal0, anchorStateRegistryFn).Returns(&sharedAnchorStateRegistryProxy))
-	t.Require().NoError(err)
-	asrAAdminOwner := getProxyAdminOwner(t, w3Client, sharedAnchorStateRegistryProxy)
-	t.Require().Equal(l1PAO, asrAAdminOwner, "sharedAnchorStateRegistryProxy proxy admin owner is not the L1PAO")
-
-	gameTypes := []uint32{superPermissionedGameType, superCannonGameType}
-	for _, gameType := range gameTypes {
-		var gameArgsBytes []byte
-		err = w3Client.Call(w3eth.CallFunc(sharedDGF, gameArgsFn, gameType).Returns(&gameArgsBytes))
-		t.Require().NoError(err)
-		gameArgs, err := gameargs.Parse(gameArgsBytes)
-		t.Require().NoErrorf(err, "invalid game args for gameType %d", gameType)
-		wethAdminOwner := getProxyAdminOwner(t, w3Client, gameArgs.Weth)
-		t.Require().Equal(l1PAO, wethAdminOwner, "wethProxy proxy admin owner is not the L1PAO")
-	}
-}
-
-func resetOldDisputeGameFactories(
-	t devtest.CommonT,
-	o *Orchestrator,
-	l1ChainID *big.Int,
-	ownerPrivateKey *ecdsa.PrivateKey,
-	client *ethclient.Client,
-	delegateCallProxy common.Address,
-	oldDisputeGameFactories map[eth.ChainID]common.Address,
-) {
-	for l2ChainID, oldDGF := range oldDisputeGameFactories {
-		chainOpsForL2 := devkeys.ChainOperatorKeys(l2ChainID.ToBig())
-		l1PAOForL2, err := o.keys.Address(chainOpsForL2(devkeys.L1ProxyAdminOwnerRole))
-		t.Require().NoError(err, "must have configured L1 proxy admin owner private key")
-		// Not required since the old DGFs are not used; but done to prevent surprises later
-		transferOwnershipForDelegateCallProxy(
-			t,
-			l1ChainID,
-			ownerPrivateKey,
-			client,
-			delegateCallProxy,
-			oldDGF,
-			l1PAOForL2,
-		)
-	}
 }

--- a/op-devstack/sysgo/system.go
+++ b/op-devstack/sysgo/system.go
@@ -66,21 +66,27 @@ func defaultMinimalSystemOpts(ids *DefaultMinimalSystemIDs, dest *DefaultMinimal
 		),
 	)
 
+	// Level 1: L1 nodes (must be first)
 	opt.Add(WithL1Nodes(ids.L1EL, ids.L1CL))
 
+	// Level 2: L2 EL (depends on L1)
 	opt.Add(WithL2ELNode(ids.L2EL))
-	opt.Add(WithL2CLNode(ids.L2CL, ids.L1CL, ids.L1EL, ids.L2EL, L2CLSequencer()))
 
-	opt.Add(WithBatcher(ids.L2Batcher, ids.L1EL, ids.L2CL, ids.L2EL))
-	opt.Add(WithProposer(ids.L2Proposer, ids.L1EL, &ids.L2CL, nil))
+	// Level 3: L2 CL + Faucets in parallel (both only need L1 + L2 EL)
+	opt.Add(stack.InParallel[*Orchestrator](
+		WithL2CLNode(ids.L2CL, ids.L1CL, ids.L1EL, ids.L2EL, L2CLSequencer()),
+		WithFaucets([]stack.L1ELNodeID{ids.L1EL}, []stack.L2ELNodeID{ids.L2EL}),
+	))
 
-	opt.Add(WithFaucets([]stack.L1ELNodeID{ids.L1EL}, []stack.L2ELNodeID{ids.L2EL}))
-
-	opt.Add(WithTestSequencer(ids.TestSequencer, ids.L1CL, ids.L2CL, ids.L1EL, ids.L2EL))
-
-	opt.Add(WithL2Challenger(ids.L2Challenger, ids.L1EL, ids.L1CL, nil, nil, &ids.L2CL, []stack.L2ELNodeID{
-		ids.L2EL,
-	}))
+	// Level 4: Services that need L2 CL, in parallel
+	opt.Add(stack.InParallel[*Orchestrator](
+		WithBatcher(ids.L2Batcher, ids.L1EL, ids.L2CL, ids.L2EL),
+		WithProposer(ids.L2Proposer, ids.L1EL, &ids.L2CL, nil),
+		WithTestSequencer(ids.TestSequencer, ids.L1CL, ids.L2CL, ids.L1EL, ids.L2EL),
+		WithL2Challenger(ids.L2Challenger, ids.L1EL, ids.L1CL, nil, nil, &ids.L2CL, []stack.L2ELNodeID{
+			ids.L2EL,
+		}),
+	))
 
 	opt.Add(WithL2MetricsDashboard())
 
@@ -153,19 +159,26 @@ func DefaultTwoL2System(dest *DefaultTwoL2SystemIDs) stack.Option[*Orchestrator]
 
 	opt.Add(WithL1Nodes(ids.L1EL, ids.L1CL))
 
-	opt.Add(WithL2ELNode(ids.L2AEL))
-	opt.Add(WithL2CLNode(ids.L2ACL, ids.L1CL, ids.L1EL, ids.L2AEL, L2CLSequencer()))
+	// Both L2 ELs in parallel
+	opt.Add(stack.InParallel[*Orchestrator](
+		WithL2ELNode(ids.L2AEL),
+		WithL2ELNode(ids.L2BEL),
+	))
 
-	opt.Add(WithL2ELNode(ids.L2BEL))
-	opt.Add(WithL2CLNode(ids.L2BCL, ids.L1CL, ids.L1EL, ids.L2BEL, L2CLSequencer()))
+	// Both L2 CLs + Faucets in parallel
+	opt.Add(stack.InParallel[*Orchestrator](
+		WithL2CLNode(ids.L2ACL, ids.L1CL, ids.L1EL, ids.L2AEL, L2CLSequencer()),
+		WithL2CLNode(ids.L2BCL, ids.L1CL, ids.L1EL, ids.L2BEL, L2CLSequencer()),
+		WithFaucets([]stack.L1ELNodeID{ids.L1EL}, []stack.L2ELNodeID{ids.L2AEL, ids.L2BEL}),
+	))
 
-	opt.Add(WithBatcher(ids.L2ABatcher, ids.L1EL, ids.L2ACL, ids.L2AEL))
-	opt.Add(WithProposer(ids.L2AProposer, ids.L1EL, &ids.L2ACL, nil))
-
-	opt.Add(WithBatcher(ids.L2BBatcher, ids.L1EL, ids.L2BCL, ids.L2BEL))
-	opt.Add(WithProposer(ids.L2BProposer, ids.L1EL, &ids.L2BCL, nil))
-
-	opt.Add(WithFaucets([]stack.L1ELNodeID{ids.L1EL}, []stack.L2ELNodeID{ids.L2AEL, ids.L2BEL}))
+	// All batchers and proposers in parallel
+	opt.Add(stack.InParallel[*Orchestrator](
+		WithBatcher(ids.L2ABatcher, ids.L1EL, ids.L2ACL, ids.L2AEL),
+		WithProposer(ids.L2AProposer, ids.L1EL, &ids.L2ACL, nil),
+		WithBatcher(ids.L2BBatcher, ids.L1EL, ids.L2BCL, ids.L2BEL),
+		WithProposer(ids.L2BProposer, ids.L1EL, &ids.L2BCL, nil),
+	))
 
 	opt.Add(WithL2MetricsDashboard())
 
@@ -198,19 +211,23 @@ func DefaultSupernodeTwoL2System(dest *DefaultTwoL2SystemIDs) stack.Option[*Orch
 
 	opt.Add(WithL1Nodes(ids.L1EL, ids.L1CL))
 
-	opt.Add(WithL2ELNode(ids.L2AEL))
-	opt.Add(WithL2ELNode(ids.L2BEL))
+	// Both L2 ELs in parallel
+	opt.Add(stack.InParallel[*Orchestrator](
+		WithL2ELNode(ids.L2AEL),
+		WithL2ELNode(ids.L2BEL),
+	))
 
 	// Shared supernode for both L2 chains
 	opt.Add(WithSharedSupernodeCLs(ids.Supernode, []L2CLs{{CLID: ids.L2ACL, ELID: ids.L2AEL}, {CLID: ids.L2BCL, ELID: ids.L2BEL}}, ids.L1CL, ids.L1EL))
 
-	opt.Add(WithBatcher(ids.L2ABatcher, ids.L1EL, ids.L2ACL, ids.L2AEL))
-	opt.Add(WithProposer(ids.L2AProposer, ids.L1EL, &ids.L2ACL, nil))
-
-	opt.Add(WithBatcher(ids.L2BBatcher, ids.L1EL, ids.L2BCL, ids.L2BEL))
-	opt.Add(WithProposer(ids.L2BProposer, ids.L1EL, &ids.L2BCL, nil))
-
-	opt.Add(WithFaucets([]stack.L1ELNodeID{ids.L1EL}, []stack.L2ELNodeID{ids.L2AEL, ids.L2BEL}))
+	// All batchers, proposers, and faucets in parallel
+	opt.Add(stack.InParallel[*Orchestrator](
+		WithBatcher(ids.L2ABatcher, ids.L1EL, ids.L2ACL, ids.L2AEL),
+		WithProposer(ids.L2AProposer, ids.L1EL, &ids.L2ACL, nil),
+		WithBatcher(ids.L2BBatcher, ids.L1EL, ids.L2BCL, ids.L2BEL),
+		WithProposer(ids.L2BProposer, ids.L1EL, &ids.L2BCL, nil),
+		WithFaucets([]stack.L1ELNodeID{ids.L1EL}, []stack.L2ELNodeID{ids.L2AEL, ids.L2BEL}),
+	))
 
 	opt.Add(stack.Finally(func(orch *Orchestrator) {
 		*dest = ids
@@ -247,8 +264,11 @@ func DefaultSupernodeInteropTwoL2System(dest *DefaultTwoL2SystemIDs, delaySecond
 
 	opt.Add(WithL1Nodes(ids.L1EL, ids.L1CL))
 
-	opt.Add(WithL2ELNode(ids.L2AEL))
-	opt.Add(WithL2ELNode(ids.L2BEL))
+	// Both L2 ELs in parallel
+	opt.Add(stack.InParallel[*Orchestrator](
+		WithL2ELNode(ids.L2AEL),
+		WithL2ELNode(ids.L2BEL),
+	))
 
 	// Shared supernode for both L2 chains with interop enabled
 	cls := []L2CLs{{CLID: ids.L2ACL, ELID: ids.L2AEL}, {CLID: ids.L2BCL, ELID: ids.L2BEL}}
@@ -258,13 +278,14 @@ func DefaultSupernodeInteropTwoL2System(dest *DefaultTwoL2SystemIDs, delaySecond
 		opt.Add(WithSharedSupernodeCLsInteropDelayed(ids.Supernode, cls, ids.L1CL, ids.L1EL, delaySeconds))
 	}
 
-	opt.Add(WithBatcher(ids.L2ABatcher, ids.L1EL, ids.L2ACL, ids.L2AEL))
-	opt.Add(WithProposer(ids.L2AProposer, ids.L1EL, &ids.L2ACL, nil))
-
-	opt.Add(WithBatcher(ids.L2BBatcher, ids.L1EL, ids.L2BCL, ids.L2BEL))
-	opt.Add(WithProposer(ids.L2BProposer, ids.L1EL, &ids.L2BCL, nil))
-
-	opt.Add(WithFaucets([]stack.L1ELNodeID{ids.L1EL}, []stack.L2ELNodeID{ids.L2AEL, ids.L2BEL}))
+	// All batchers, proposers, and faucets in parallel
+	opt.Add(stack.InParallel[*Orchestrator](
+		WithBatcher(ids.L2ABatcher, ids.L1EL, ids.L2ACL, ids.L2AEL),
+		WithProposer(ids.L2AProposer, ids.L1EL, &ids.L2ACL, nil),
+		WithBatcher(ids.L2BBatcher, ids.L1EL, ids.L2BCL, ids.L2BEL),
+		WithProposer(ids.L2BProposer, ids.L1EL, &ids.L2BCL, nil),
+		WithFaucets([]stack.L1ELNodeID{ids.L1EL}, []stack.L2ELNodeID{ids.L2AEL, ids.L2BEL}),
+	))
 
 	opt.Add(stack.Finally(func(orch *Orchestrator) {
 		*dest = ids
@@ -307,23 +328,28 @@ func DefaultMinimalSystemWithSyncTester(dest *DefaultMinimalSystemWithSyncTester
 		),
 	)
 
+	// Level 1: L1 nodes
 	opt.Add(WithL1Nodes(ids.L1EL, ids.L1CL))
 
+	// Level 2: L2 EL
 	opt.Add(WithL2ELNode(ids.L2EL))
-	opt.Add(WithL2CLNode(ids.L2CL, ids.L1CL, ids.L1EL, ids.L2EL, L2CLSequencer()))
 
-	opt.Add(WithBatcher(ids.L2Batcher, ids.L1EL, ids.L2CL, ids.L2EL))
-	opt.Add(WithProposer(ids.L2Proposer, ids.L1EL, &ids.L2CL, nil))
+	// Level 3: L2 CL + Faucets + SyncTester in parallel (all only need L1 + L2 EL)
+	opt.Add(stack.InParallel[*Orchestrator](
+		WithL2CLNode(ids.L2CL, ids.L1CL, ids.L1EL, ids.L2EL, L2CLSequencer()),
+		WithFaucets([]stack.L1ELNodeID{ids.L1EL}, []stack.L2ELNodeID{ids.L2EL}),
+		WithSyncTester(ids.SyncTester, []stack.L2ELNodeID{ids.L2EL}),
+	))
 
-	opt.Add(WithFaucets([]stack.L1ELNodeID{ids.L1EL}, []stack.L2ELNodeID{ids.L2EL}))
-
-	opt.Add(WithTestSequencer(ids.TestSequencer, ids.L1CL, ids.L2CL, ids.L1EL, ids.L2EL))
-
-	opt.Add(WithL2Challenger(ids.L2Challenger, ids.L1EL, ids.L1CL, nil, nil, &ids.L2CL, []stack.L2ELNodeID{
-		ids.L2EL,
-	}))
-
-	opt.Add(WithSyncTester(ids.SyncTester, []stack.L2ELNodeID{ids.L2EL}))
+	// Level 4: Services that need L2 CL, in parallel
+	opt.Add(stack.InParallel[*Orchestrator](
+		WithBatcher(ids.L2Batcher, ids.L1EL, ids.L2CL, ids.L2EL),
+		WithProposer(ids.L2Proposer, ids.L1EL, &ids.L2CL, nil),
+		WithTestSequencer(ids.TestSequencer, ids.L1CL, ids.L2CL, ids.L1EL, ids.L2EL),
+		WithL2Challenger(ids.L2Challenger, ids.L1EL, ids.L1CL, nil, nil, &ids.L2CL, []stack.L2ELNodeID{
+			ids.L2EL,
+		}),
+	))
 
 	opt.Add(WithL2MetricsDashboard())
 
@@ -378,11 +404,13 @@ func DefaultSingleChainInteropSystem(dest *DefaultSingleChainInteropSystemIDs) s
 	opt := stack.Combine[*Orchestrator]()
 	opt.Add(baseInteropSystem(&ids))
 
-	opt.Add(WithL2Challenger(ids.L2ChallengerA, ids.L1EL, ids.L1CL, &ids.Supervisor, &ids.Cluster, &ids.L2ACL, []stack.L2ELNodeID{
-		ids.L2AEL,
-	}))
-
-	opt.Add(WithFaucets([]stack.L1ELNodeID{ids.L1EL}, []stack.L2ELNodeID{ids.L2AEL}))
+	// Challenger and faucets in parallel (both depend on services started by baseInteropSystem)
+	opt.Add(stack.InParallel[*Orchestrator](
+		WithL2Challenger(ids.L2ChallengerA, ids.L1EL, ids.L1CL, &ids.Supervisor, &ids.Cluster, &ids.L2ACL, []stack.L2ELNodeID{
+			ids.L2AEL,
+		}),
+		WithFaucets([]stack.L1ELNodeID{ids.L1EL}, []stack.L2ELNodeID{ids.L2AEL}),
+	))
 
 	// Upon evaluation of the option, export the contents we created.
 	// Ids here are static, but other things may be exported too.
@@ -418,12 +446,19 @@ func DefaultMinimalInteropSystem(dest *DefaultMinimalSystemIDs) stack.Option[*Or
 
 	// No supervisor - interop with local finality only
 	opt.Add(WithL2ELNode(ids.L2EL))
-	opt.Add(WithL2CLNode(ids.L2CL, ids.L1CL, ids.L1EL, ids.L2EL, L2CLSequencer()))
-	opt.Add(WithTestSequencer(ids.TestSequencer, ids.L1CL, ids.L2CL, ids.L1EL, ids.L2EL))
-	opt.Add(WithBatcher(ids.L2Batcher, ids.L1EL, ids.L2CL, ids.L2EL))
-	opt.Add(WithProposer(ids.L2Proposer, ids.L1EL, &ids.L2CL, nil))
 
-	opt.Add(WithFaucets([]stack.L1ELNodeID{ids.L1EL}, []stack.L2ELNodeID{ids.L2EL}))
+	// L2 CL + Faucets in parallel
+	opt.Add(stack.InParallel[*Orchestrator](
+		WithL2CLNode(ids.L2CL, ids.L1CL, ids.L1EL, ids.L2EL, L2CLSequencer()),
+		WithFaucets([]stack.L1ELNodeID{ids.L1EL}, []stack.L2ELNodeID{ids.L2EL}),
+	))
+
+	// Services that need L2 CL, in parallel
+	opt.Add(stack.InParallel[*Orchestrator](
+		WithTestSequencer(ids.TestSequencer, ids.L1CL, ids.L2CL, ids.L1EL, ids.L2EL),
+		WithBatcher(ids.L2Batcher, ids.L1EL, ids.L2CL, ids.L2EL),
+		WithProposer(ids.L2Proposer, ids.L1EL, &ids.L2CL, nil),
+	))
 
 	opt.Add(WithL2MetricsDashboard())
 
@@ -460,14 +495,16 @@ func baseInteropSystem(ids *DefaultSingleChainInteropSystemIDs) stack.Option[*Or
 
 	opt.Add(WithL2ELNode(ids.L2AEL, L2ELWithSupervisor(ids.Supervisor)))
 	opt.Add(WithL2CLNode(ids.L2ACL, ids.L1CL, ids.L1EL, ids.L2AEL, L2CLSequencer(), L2CLIndexing()))
-	opt.Add(WithTestSequencer(ids.TestSequencer, ids.L1CL, ids.L2ACL, ids.L1EL, ids.L2AEL))
-	opt.Add(WithBatcher(ids.L2ABatcher, ids.L1EL, ids.L2ACL, ids.L2AEL))
 
-	opt.Add(WithManagedBySupervisor(ids.L2ACL, ids.Supervisor))
-
-	// Note: we provide L2 CL nodes still, even though they are not used post-interop.
-	// Since we may create an interop infra-setup, before interop is even scheduled to run.
-	opt.Add(WithProposer(ids.L2AProposer, ids.L1EL, &ids.L2ACL, &ids.Supervisor))
+	// Services that need L2 CL, in parallel
+	opt.Add(stack.InParallel[*Orchestrator](
+		WithTestSequencer(ids.TestSequencer, ids.L1CL, ids.L2ACL, ids.L1EL, ids.L2AEL),
+		WithBatcher(ids.L2ABatcher, ids.L1EL, ids.L2ACL, ids.L2AEL),
+		WithManagedBySupervisor(ids.L2ACL, ids.Supervisor),
+		// Note: we provide L2 CL nodes still, even though they are not used post-interop.
+		// Since we may create an interop infra-setup, before interop is even scheduled to run.
+		WithProposer(ids.L2AProposer, ids.L1EL, &ids.L2ACL, &ids.Supervisor),
+	))
 
 	opt.Add(WithL2MetricsDashboard())
 
@@ -513,24 +550,24 @@ func DefaultInteropSystem(dest *DefaultInteropSystemIDs) stack.Option[*Orchestra
 	))
 	opt.Add(WithL2ELNode(ids.L2BEL, L2ELWithSupervisor(ids.Supervisor)))
 	opt.Add(WithL2CLNode(ids.L2BCL, ids.L1CL, ids.L1EL, ids.L2BEL, L2CLSequencer(), L2CLIndexing()))
-	opt.Add(WithBatcher(ids.L2BBatcher, ids.L1EL, ids.L2BCL, ids.L2BEL))
 
-	opt.Add(WithManagedBySupervisor(ids.L2BCL, ids.Supervisor))
-
-	// Note: we provide L2 CL nodes still, even though they are not used post-interop.
-	// Since we may create an interop infra-setup, before interop is even scheduled to run.
-	opt.Add(WithProposer(ids.L2BProposer, ids.L1EL, &ids.L2BCL, &ids.Supervisor))
-
-	// Deploy separate challengers for each chain.  Can be reduced to a single challenger when the DisputeGameFactory
-	// is actually shared.
-	opt.Add(WithL2Challenger(ids.L2ChallengerA, ids.L1EL, ids.L1CL, &ids.Supervisor, &ids.Cluster, &ids.L2ACL, []stack.L2ELNodeID{
-		ids.L2AEL, ids.L2BEL,
-	}))
-	opt.Add(WithL2Challenger(ids.L2ChallengerB, ids.L1EL, ids.L1CL, &ids.Supervisor, &ids.Cluster, &ids.L2BCL, []stack.L2ELNodeID{
-		ids.L2BEL, ids.L2AEL,
-	}))
-
-	opt.Add(WithFaucets([]stack.L1ELNodeID{ids.L1EL}, []stack.L2ELNodeID{ids.L2AEL, ids.L2BEL}))
+	// Chain B post-CL services, challengers, and faucets in parallel
+	opt.Add(stack.InParallel[*Orchestrator](
+		WithBatcher(ids.L2BBatcher, ids.L1EL, ids.L2BCL, ids.L2BEL),
+		WithManagedBySupervisor(ids.L2BCL, ids.Supervisor),
+		// Note: we provide L2 CL nodes still, even though they are not used post-interop.
+		// Since we may create an interop infra-setup, before interop is even scheduled to run.
+		WithProposer(ids.L2BProposer, ids.L1EL, &ids.L2BCL, &ids.Supervisor),
+		// Deploy separate challengers for each chain.  Can be reduced to a single challenger when the DisputeGameFactory
+		// is actually shared.
+		WithL2Challenger(ids.L2ChallengerA, ids.L1EL, ids.L1CL, &ids.Supervisor, &ids.Cluster, &ids.L2ACL, []stack.L2ELNodeID{
+			ids.L2AEL, ids.L2BEL,
+		}),
+		WithL2Challenger(ids.L2ChallengerB, ids.L1EL, ids.L1CL, &ids.Supervisor, &ids.Cluster, &ids.L2BCL, []stack.L2ELNodeID{
+			ids.L2BEL, ids.L2AEL,
+		}),
+		WithFaucets([]stack.L1ELNodeID{ids.L1EL}, []stack.L2ELNodeID{ids.L2AEL, ids.L2BEL}),
+	))
 
 	opt.Add(WithL2MetricsDashboard())
 
@@ -595,29 +632,35 @@ func defaultSupernodeSuperProofsSystem(dest *DefaultSupernodeInteropProofsSystem
 
 	opt.Add(WithL1Nodes(ids.L1EL, ids.L1CL))
 
-	opt.Add(WithL2ELNode(ids.L2AEL))
-	opt.Add(WithL2ELNode(ids.L2BEL))
+	// Both L2 ELs in parallel
+	opt.Add(stack.InParallel[*Orchestrator](
+		WithL2ELNode(ids.L2AEL),
+		WithL2ELNode(ids.L2BEL),
+	))
 
 	// Shared supernode for both L2 chains (registers per-chain L2CL proxies)
 	opt.Add(WithSharedSupernodeCLs(ids.Supernode, []L2CLs{{CLID: ids.L2ACL, ELID: ids.L2AEL}, {CLID: ids.L2BCL, ELID: ids.L2BEL}}, ids.L1CL, ids.L1EL))
 
-	opt.Add(WithTestSequencer(ids.TestSequencer, ids.L1CL, ids.L2ACL, ids.L1EL, ids.L2AEL))
-
-	opt.Add(WithBatcher(ids.L2ABatcher, ids.L1EL, ids.L2ACL, ids.L2AEL))
-	opt.Add(WithBatcher(ids.L2BBatcher, ids.L1EL, ids.L2BCL, ids.L2BEL))
+	// TestSequencer and batchers in parallel
+	opt.Add(stack.InParallel[*Orchestrator](
+		WithTestSequencer(ids.TestSequencer, ids.L1CL, ids.L2ACL, ids.L1EL, ids.L2AEL),
+		WithBatcher(ids.L2ABatcher, ids.L1EL, ids.L2ACL, ids.L2AEL),
+		WithBatcher(ids.L2BBatcher, ids.L1EL, ids.L2BCL, ids.L2BEL),
+	))
 
 	// Run super roots migration using supernode as super root source
 	opt.Add(WithSuperRootsFromSupernode(ids.L1.ChainID(), ids.L1EL, []stack.L2CLNodeID{ids.L2ACL, ids.L2BCL}, ids.Supernode, ids.L2A.ChainID()))
 
-	// Start challenger after migration; use supernode RPCs as super-roots source.
-	opt.Add(WithSupernodeL2Challenger(ids.L2ChallengerA, ids.L1EL, ids.L1CL, &ids.Supernode, &ids.Cluster, []stack.L2ELNodeID{
-		ids.L2BEL, ids.L2AEL,
-	}))
-
-	// Start proposer after migration; use supernode RPCs as proposal source.
-	opt.Add(WithSupernodeProposer(ids.L2AProposer, ids.L1EL, &ids.Supernode))
-
-	opt.Add(WithFaucets([]stack.L1ELNodeID{ids.L1EL}, []stack.L2ELNodeID{ids.L2AEL, ids.L2BEL}))
+	// Post-migration services in parallel
+	opt.Add(stack.InParallel[*Orchestrator](
+		// Start challenger after migration; use supernode RPCs as super-roots source.
+		WithSupernodeL2Challenger(ids.L2ChallengerA, ids.L1EL, ids.L1CL, &ids.Supernode, &ids.Cluster, []stack.L2ELNodeID{
+			ids.L2BEL, ids.L2AEL,
+		}),
+		// Start proposer after migration; use supernode RPCs as proposal source.
+		WithSupernodeProposer(ids.L2AProposer, ids.L1EL, &ids.Supernode),
+		WithFaucets([]stack.L1ELNodeID{ids.L1EL}, []stack.L2ELNodeID{ids.L2AEL, ids.L2BEL}),
+	))
 
 	opt.Add(WithL2MetricsDashboard())
 
@@ -651,29 +694,37 @@ func defaultSuperProofsSystem(dest *DefaultInteropSystemIDs, deployerOpts ...Dep
 
 	opt.Add(WithSupervisor(ids.Supervisor, ids.Cluster, ids.L1EL))
 
-	opt.Add(WithL2ELNode(ids.L2AEL, L2ELWithSupervisor(ids.Supervisor)))
-	opt.Add(WithL2CLNode(ids.L2ACL, ids.L1CL, ids.L1EL, ids.L2AEL, L2CLSequencer(), L2CLIndexing()))
+	// Both L2 ELs in parallel (both need supervisor)
+	opt.Add(stack.InParallel[*Orchestrator](
+		WithL2ELNode(ids.L2AEL, L2ELWithSupervisor(ids.Supervisor)),
+		WithL2ELNode(ids.L2BEL, L2ELWithSupervisor(ids.Supervisor)),
+	))
 
-	opt.Add(WithL2ELNode(ids.L2BEL, L2ELWithSupervisor(ids.Supervisor)))
-	opt.Add(WithL2CLNode(ids.L2BCL, ids.L1CL, ids.L1EL, ids.L2BEL, L2CLSequencer(), L2CLIndexing()))
+	// Both L2 CLs in parallel
+	opt.Add(stack.InParallel[*Orchestrator](
+		WithL2CLNode(ids.L2ACL, ids.L1CL, ids.L1EL, ids.L2AEL, L2CLSequencer(), L2CLIndexing()),
+		WithL2CLNode(ids.L2BCL, ids.L1CL, ids.L1EL, ids.L2BEL, L2CLSequencer(), L2CLIndexing()),
+	))
 
-	opt.Add(WithTestSequencer(ids.TestSequencer, ids.L1CL, ids.L2ACL, ids.L1EL, ids.L2AEL))
-
-	opt.Add(WithBatcher(ids.L2ABatcher, ids.L1EL, ids.L2ACL, ids.L2AEL))
-	opt.Add(WithBatcher(ids.L2BBatcher, ids.L1EL, ids.L2BCL, ids.L2BEL))
-
-	opt.Add(WithManagedBySupervisor(ids.L2ACL, ids.Supervisor))
-	opt.Add(WithManagedBySupervisor(ids.L2BCL, ids.Supervisor))
-
-	opt.Add(WithFaucets([]stack.L1ELNodeID{ids.L1EL}, []stack.L2ELNodeID{ids.L2AEL, ids.L2BEL}))
+	// Post-CL services in parallel
+	opt.Add(stack.InParallel[*Orchestrator](
+		WithTestSequencer(ids.TestSequencer, ids.L1CL, ids.L2ACL, ids.L1EL, ids.L2AEL),
+		WithBatcher(ids.L2ABatcher, ids.L1EL, ids.L2ACL, ids.L2AEL),
+		WithBatcher(ids.L2BBatcher, ids.L1EL, ids.L2BCL, ids.L2BEL),
+		WithManagedBySupervisor(ids.L2ACL, ids.Supervisor),
+		WithManagedBySupervisor(ids.L2BCL, ids.Supervisor),
+		WithFaucets([]stack.L1ELNodeID{ids.L1EL}, []stack.L2ELNodeID{ids.L2AEL, ids.L2BEL}),
+	))
 
 	opt.Add(WithSuperRoots(ids.L1.ChainID(), ids.L1EL, []stack.L2CLNodeID{ids.L2ACL, ids.L2BCL}, ids.Supervisor, ids.L2A.ChainID()))
 
-	opt.Add(WithSuperProposer(ids.L2AProposer, ids.L1EL, &ids.Supervisor))
-
-	opt.Add(WithSuperL2Challenger(ids.L2ChallengerA, ids.L1EL, ids.L1CL, &ids.Supervisor, &ids.Cluster, []stack.L2ELNodeID{
-		ids.L2BEL, ids.L2AEL,
-	}))
+	// Post-migration services in parallel
+	opt.Add(stack.InParallel[*Orchestrator](
+		WithSuperProposer(ids.L2AProposer, ids.L1EL, &ids.Supervisor),
+		WithSuperL2Challenger(ids.L2ChallengerA, ids.L1EL, ids.L1CL, &ids.Supervisor, &ids.Cluster, []stack.L2ELNodeID{
+			ids.L2BEL, ids.L2AEL,
+		}),
+	))
 
 	opt.Add(WithL2MetricsDashboard())
 
@@ -716,20 +767,28 @@ func MultiSupervisorInteropSystem(dest *MultiSupervisorInteropSystemIDs) stack.O
 	// add backup supervisor
 	opt.Add(WithSupervisor(ids.SupervisorSecondary, ids.Cluster, ids.L1EL))
 
-	opt.Add(WithL2ELNode(ids.L2A2EL, L2ELWithSupervisor(ids.SupervisorSecondary)))
-	opt.Add(WithL2CLNode(ids.L2A2CL, ids.L1CL, ids.L1EL, ids.L2A2EL, L2CLIndexing()))
+	// Both verifier L2 ELs in parallel
+	opt.Add(stack.InParallel[*Orchestrator](
+		WithL2ELNode(ids.L2A2EL, L2ELWithSupervisor(ids.SupervisorSecondary)),
+		WithL2ELNode(ids.L2B2EL, L2ELWithSupervisor(ids.SupervisorSecondary)),
+	))
 
-	opt.Add(WithL2ELNode(ids.L2B2EL, L2ELWithSupervisor(ids.SupervisorSecondary)))
-	opt.Add(WithL2CLNode(ids.L2B2CL, ids.L1CL, ids.L1EL, ids.L2B2EL, L2CLIndexing()))
+	// Both verifier L2 CLs in parallel
+	opt.Add(stack.InParallel[*Orchestrator](
+		WithL2CLNode(ids.L2A2CL, ids.L1CL, ids.L1EL, ids.L2A2EL, L2CLIndexing()),
+		WithL2CLNode(ids.L2B2CL, ids.L1CL, ids.L1EL, ids.L2B2EL, L2CLIndexing()),
+	))
 
-	// verifier must be also managed or it cannot advance
-	// we attach verifier L2CL with backup supervisor
-	opt.Add(WithManagedBySupervisor(ids.L2A2CL, ids.SupervisorSecondary))
-	opt.Add(WithManagedBySupervisor(ids.L2B2CL, ids.SupervisorSecondary))
-
-	// P2P connect L2CL nodes
-	opt.Add(WithL2CLP2PConnection(ids.L2ACL, ids.L2A2CL))
-	opt.Add(WithL2CLP2PConnection(ids.L2BCL, ids.L2B2CL))
+	// Post-CL services in parallel
+	opt.Add(stack.InParallel[*Orchestrator](
+		// verifier must be also managed or it cannot advance
+		// we attach verifier L2CL with backup supervisor
+		WithManagedBySupervisor(ids.L2A2CL, ids.SupervisorSecondary),
+		WithManagedBySupervisor(ids.L2B2CL, ids.SupervisorSecondary),
+		// P2P connect L2CL nodes
+		WithL2CLP2PConnection(ids.L2ACL, ids.L2A2CL),
+		WithL2CLP2PConnection(ids.L2BCL, ids.L2B2CL),
+	))
 
 	opt.Add(WithL2MetricsDashboard())
 
@@ -823,16 +882,16 @@ func singleChainSystemWithFlashblocksOpts(ids *SingleChainSystemWithFlashblocksI
 
 	opt.Add(WithL2CLNode(ids.L2CL, ids.L1CL, ids.L1EL, stack.L2ELNodeID(ids.L2RollupBoost), L2CLSequencer()))
 
-	opt.Add(WithBatcher(ids.L2Batcher, ids.L1EL, ids.L2CL, ids.L2EL))
-	opt.Add(WithProposer(ids.L2Proposer, ids.L1EL, &ids.L2CL, nil))
-
-	opt.Add(WithFaucets([]stack.L1ELNodeID{ids.L1EL}, []stack.L2ELNodeID{ids.L2EL}))
-
-	opt.Add(WithTestSequencer(ids.TestSequencer, ids.L1CL, ids.L2CL, ids.L1EL, ids.L2EL))
-
-	opt.Add(WithL2Challenger(ids.L2Challenger, ids.L1EL, ids.L1CL, nil, nil, &ids.L2CL, []stack.L2ELNodeID{
-		ids.L2EL,
-	}))
+	// Services that need L2 CL, in parallel
+	opt.Add(stack.InParallel[*Orchestrator](
+		WithBatcher(ids.L2Batcher, ids.L1EL, ids.L2CL, ids.L2EL),
+		WithProposer(ids.L2Proposer, ids.L1EL, &ids.L2CL, nil),
+		WithFaucets([]stack.L1ELNodeID{ids.L1EL}, []stack.L2ELNodeID{ids.L2EL}),
+		WithTestSequencer(ids.TestSequencer, ids.L1CL, ids.L2CL, ids.L1EL, ids.L2EL),
+		WithL2Challenger(ids.L2Challenger, ids.L1EL, ids.L1CL, nil, nil, &ids.L2CL, []stack.L2ELNodeID{
+			ids.L2EL,
+		}),
+	))
 
 	opt.Add(WithL2MetricsDashboard())
 

--- a/op-e2e/e2eutils/transactions/send.go
+++ b/op-e2e/e2eutils/transactions/send.go
@@ -91,6 +91,47 @@ func RequireSendTxs(t *testing.T, ctx context.Context, client *ethclient.Client,
 	return txs, receipts
 }
 
+// SendTxs submits multiple transactions attempting to batch them together in blocks as much as possible.
+// Like RequireSendTxs but returns errors instead of requiring *testing.T.
+// Note that if the transactions depend on one another, the gas limit may need to be manually set as estimateGas will
+// be executed before the earlier transactions have been processed.
+func SendTxs(ctx context.Context, client *ethclient.Client, candidates []txmgr.TxCandidate, privKey *ecdsa.PrivateKey, opts ...SendTxOpt) ([]*types.Transaction, []*types.Receipt, error) {
+	if len(candidates) == 0 {
+		return nil, nil, nil
+	}
+	cfg := makeSendTxCfg(opts...)
+	nonce, err := client.PendingNonceAt(ctx, crypto.PubkeyToAddress(privKey.PublicKey))
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get pending nonce: %w", err)
+	}
+
+	txs := make([]*types.Transaction, len(candidates))
+	for i, candidate := range candidates {
+		tx, err := createTx(ctx, client, candidate, privKey, nonce)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to create tx %d: %w", i, err)
+		}
+		txs[i] = tx
+		nonce++
+	}
+
+	for i, tx := range txs {
+		if err := client.SendTransaction(ctx, tx); err != nil {
+			return nil, nil, fmt.Errorf("failed to send tx %d (%s): %w", i, tx.Hash(), errutil.TryAddRevertReason(err))
+		}
+	}
+
+	receipts := make([]*types.Receipt, len(txs))
+	for i, tx := range txs {
+		receipt, err := wait.ForReceiptMaybe(ctx, client, tx.Hash(), cfg.receiptStatus, cfg.ignoreReceiptStatus)
+		if err != nil {
+			return txs, receipts, fmt.Errorf("failed to get receipt for tx %d (%s): %w", i, tx.Hash(), err)
+		}
+		receipts[i] = receipt
+	}
+	return txs, receipts, nil
+}
+
 func SendTx(ctx context.Context, client *ethclient.Client, candidate txmgr.TxCandidate, privKey *ecdsa.PrivateKey, opts ...SendTxOpt) (*types.Transaction, *types.Receipt, error) {
 	cfg := makeSendTxCfg(opts...)
 	nonce, err := client.PendingNonceAt(ctx, crypto.PubkeyToAddress(privKey.PublicKey))


### PR DESCRIPTION
## Problem Statement

Devstack network setup is slow because all services start sequentially and the superroot migration issues ownership-transfer transactions one at a time, each waiting for an L1 block (~6s). This makes acceptance test iteration painfully slow.

## Solution

Add an `InParallel` option combinator that runs `AfterDeploy` phases concurrently, and refactor all devstack presets to group independent services by dependency level. Also batch ownership-transfer transactions in the superroot migration to reduce L1 block waits. 

Key changes:
- Add ParallelOption type and InParallel constructor to stack package
- Refactor system presets to use dependency-level parallelism (e.g. L2 CL + Faucets in parallel, then Batcher + Proposer in parallel)
- Add SendTxs batch utility to transactions package
- Parallelize L2 safe head polling across chains in superroot migration
- Batch pre-migration and post-migration ownership transfers
- Deduplicate shared proxy admin addresses in batched transfers

## Testing

On my machine, proofs and the minimal interop presets are setup in half the time.