### PR TITLE
op-supernode: Add error handling and validation to Supernode interop activity pause methods

### DIFF
--- a/op-acceptance-tests/tests/supernode/interop/reorg/invalid_message_reorg_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/reorg/invalid_message_reorg_test.go
@@ -58,7 +58,7 @@ func TestSupernodeInteropInvalidMessageReplacement(gt *testing.T) {
 	targetTimestamp := sys.L2A.TimestampForBlockNum(10)
 	// Pause just after the target to allow verification up to target, then stop
 	pauseTimestamp := targetTimestamp + 1
-	err := sys.Supernode.PauseInterop(pauseTimestamp)
+	err := sys.Supernode.PauseInteropActivity(pauseTimestamp)
 	require.NoError(t, err, "failed to pause interop: activity may have already progressed past target")
 	sys.Supernode.AwaitValidatedTimestamp(targetTimestamp)
 
@@ -90,7 +90,7 @@ func TestSupernodeInteropInvalidMessageReplacement(gt *testing.T) {
 	// Resume interop and observe reorg
 	// Interop activity will proceed and invalidate the block, triggering a rewind, and building a replacement block
 	// We observe resets and replacements, but only proceed on replacement (we may miss reset if it happens quickly)
-	sys.Supernode.ResumeInterop()
+	sys.Supernode.ResumeInteropActivity()
 	require.Eventually(t, func() bool {
 		// Check if the block hash at the invalid block number changed or block doesn't exist
 		// Use the EthClient directly to handle errors (block may not exist after rewind)

--- a/op-acceptance-tests/tests/supernode/interop/reorg/invalid_message_reorg_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/reorg/invalid_message_reorg_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
@@ -24,10 +25,8 @@ import (
 // - A replacement block is built at the same height (deposits-only)
 // - The replacement block's timestamp eventually becomes verified
 func TestSupernodeInteropInvalidMessageReplacement(gt *testing.T) {
-
 	t := devtest.SerialT(gt)
 	sys := presets.NewTwoL2SupernodeInterop(t, 0)
-
 	ctx := t.Ctx()
 
 	// Create funded EOAs on both chains
@@ -54,16 +53,20 @@ func TestSupernodeInteropInvalidMessageReplacement(gt *testing.T) {
 	// Wait for chain B to catch up
 	sys.L2B.WaitForBlock()
 
-	// Wait for some timestamps to be verified first
-	targetTimestamp := sys.L2A.TimestampForBlockNum(2)
-	// set supernode to pause verification just after this timestamp
-	sys.Supernode.PauseInterop(targetTimestamp + 1)
+	// Wait for some timestamps to be verified first, then pause ahead of that
+	// Use a higher block number to avoid race with interop activity startup
+	targetTimestamp := sys.L2A.TimestampForBlockNum(10)
+	// Pause just after the target to allow verification up to target, then stop
+	pauseTimestamp := targetTimestamp + 1
+	err := sys.Supernode.PauseInterop(pauseTimestamp)
+	require.NoError(t, err, "failed to pause interop: activity may have already progressed past target")
 	sys.Supernode.AwaitValidatedTimestamp(targetTimestamp)
 
 	t.Logger().Info("initial verification confirmed", "timestamp", targetTimestamp)
 
 	// Send an INVALID executing message on chain B
 	_, invalidExecReceipt := bob.SendInvalidExecMessage(initTx, 0)
+	require.Equal(t, types.ReceiptStatusSuccessful, invalidExecReceipt.Status)
 	invalidBlockNumber := bigs.Uint64Strict(invalidExecReceipt.BlockNumber)
 	invalidBlockHash := invalidExecReceipt.BlockHash
 	invalidBlockTimestamp := sys.L2B.TimestampForBlockNum(invalidBlockNumber)
@@ -73,8 +76,13 @@ func TestSupernodeInteropInvalidMessageReplacement(gt *testing.T) {
 		"timestamp", invalidBlockTimestamp,
 	)
 
+	// Ensure the invalid block is after the pause point
+	require.Greater(t, invalidBlockTimestamp, pauseTimestamp,
+		"invalid block timestamp must be after pause timestamp to test interop detection")
+
 	// Wait for local safety to include the invalid block
 	require.Eventually(t, func() bool {
+		t.Logger().Info("l2b sync status", "local_safe_l2", sys.L2BCL.SyncStatus())
 		numSafe := sys.L2BCL.SyncStatus().LocalSafeL2.Number >= invalidBlockNumber
 		return numSafe
 	}, 60*time.Second, time.Second, "invalid block should become locally safe")

--- a/op-acceptance-tests/tests/supernode/interop/reorg/invalid_message_reorg_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/reorg/invalid_message_reorg_test.go
@@ -77,8 +77,8 @@ func TestSupernodeInteropInvalidMessageReplacement(gt *testing.T) {
 	)
 
 	// Ensure the invalid block is after the pause point
-	require.Greater(t, invalidBlockTimestamp, pauseTimestamp,
-		"invalid block timestamp must be after pause timestamp to test interop detection")
+	require.GreaterOrEqual(t, invalidBlockTimestamp, pauseTimestamp,
+		"invalid block timestamp must be after or equal to pause timestamp to ensure it can become local safe (until interop activity is resumed)")
 
 	// Wait for local safety to include the invalid block
 	require.Eventually(t, func() bool {

--- a/op-devstack/dsl/supernode.go
+++ b/op-devstack/dsl/supernode.go
@@ -85,20 +85,20 @@ func (s *Supernode) AwaitValidatedTimestamp(timestamp uint64) {
 	s.require.NoError(err, "super-root at timestamp %d was not validated in time", timestamp)
 }
 
-// PauseInterop pauses the interop activity at the given timestamp.
+// PauseInteropActivity pauses the interop activity at the given timestamp.
 // When the interop activity attempts to process this timestamp, it returns early.
 // This function is for integration test control only.
 // Requires the Supernode to be created with NewSupernodeWithTestControl.
 // Returns an error if the activity has already verified past the target timestamp.
-func (s *Supernode) PauseInterop(ts uint64) error {
-	s.require.NotNil(s.testControl, "PauseInterop requires test control; use NewSupernodeWithTestControl")
+func (s *Supernode) PauseInteropActivity(ts uint64) error {
+	s.require.NotNil(s.testControl, "PauseInteropActivity requires test control; use NewSupernodeWithTestControl")
 	return s.testControl.PauseInteropActivity(ts)
 }
 
-// ResumeInterop clears any pause on the interop activity, allowing normal processing.
+// ResumeInteropActivity clears any pause on the interop activity, allowing normal processing.
 // This function is for integration test control only.
 // Requires the Supernode to be created with NewSupernodeWithTestControl.
-func (s *Supernode) ResumeInterop() {
-	s.require.NotNil(s.testControl, "ResumeInterop requires test control; use NewSupernodeWithTestControl")
+func (s *Supernode) ResumeInteropActivity() {
+	s.require.NotNil(s.testControl, "ResumeInteropActivity requires test control; use NewSupernodeWithTestControl")
 	s.testControl.ResumeInteropActivity()
 }

--- a/op-devstack/dsl/supernode.go
+++ b/op-devstack/dsl/supernode.go
@@ -89,9 +89,10 @@ func (s *Supernode) AwaitValidatedTimestamp(timestamp uint64) {
 // When the interop activity attempts to process this timestamp, it returns early.
 // This function is for integration test control only.
 // Requires the Supernode to be created with NewSupernodeWithTestControl.
-func (s *Supernode) PauseInterop(ts uint64) {
+// Returns an error if the activity has already verified past the target timestamp.
+func (s *Supernode) PauseInterop(ts uint64) error {
 	s.require.NotNil(s.testControl, "PauseInterop requires test control; use NewSupernodeWithTestControl")
-	s.testControl.PauseInteropActivity(ts)
+	return s.testControl.PauseInteropActivity(ts)
 }
 
 // ResumeInterop clears any pause on the interop activity, allowing normal processing.

--- a/op-devstack/stack/supernode.go
+++ b/op-devstack/stack/supernode.go
@@ -69,7 +69,8 @@ type InteropTestControl interface {
 	// PauseInteropActivity pauses the interop activity at the given timestamp.
 	// When the interop activity attempts to process this timestamp, it returns early.
 	// This function is for integration test control only.
-	PauseInteropActivity(ts uint64)
+	// Returns an error if the activity has already verified past the target timestamp.
+	PauseInteropActivity(ts uint64) error
 
 	// ResumeInteropActivity clears any pause on the interop activity, allowing normal processing.
 	// This function is for integration test control only.

--- a/op-devstack/sysgo/l2_cl_supernode.go
+++ b/op-devstack/sysgo/l2_cl_supernode.go
@@ -145,12 +145,13 @@ func (n *SuperNode) Stop() {
 
 // PauseInteropActivity pauses the interop activity at the given timestamp.
 // This function is for integration test control only.
-func (n *SuperNode) PauseInteropActivity(ts uint64) {
+func (n *SuperNode) PauseInteropActivity(ts uint64) error {
 	n.mu.Lock()
 	defer n.mu.Unlock()
 	if n.sn != nil {
-		n.sn.PauseInteropActivity(ts)
+		return n.sn.PauseInteropActivity(ts)
 	}
+	return fmt.Errorf("supernode not initialized")
 }
 
 // ResumeInteropActivity clears any pause on the interop activity.

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -165,9 +165,24 @@ func (i *Interop) Stop(ctx context.Context) error {
 // When progressInterop encounters this timestamp, it returns early without processing.
 // This function is for integration test control only.
 // Pass 0 to clear the pause (equivalent to calling Resume).
-func (i *Interop) PauseAt(ts uint64) {
+// Returns an error if the activity has already verified past the target timestamp.
+func (i *Interop) PauseAt(ts uint64) error {
+	// Allow clearing the pause (ts == 0)
+	if ts == 0 {
+		i.pauseAtTimestamp.Store(ts)
+		i.log.Info("interop pause cleared")
+		return nil
+	}
+
+	// Check if we've already verified past this timestamp
+	lastTimestamp, initialized := i.verifiedDB.LastTimestamp()
+	if initialized && lastTimestamp >= ts {
+		return fmt.Errorf("cannot pause at timestamp %d: activity already verified up to %d", ts, lastTimestamp)
+	}
+
 	i.pauseAtTimestamp.Store(ts)
 	i.log.Info("interop pause set", "pauseAtTimestamp", ts)
+	return nil
 }
 
 // Resume clears any pause timestamp, allowing normal processing to continue.

--- a/op-supernode/supernode/supernode.go
+++ b/op-supernode/supernode/supernode.go
@@ -243,14 +243,15 @@ func (s *Supernode) onChainReset(chainID eth.ChainID, timestamp uint64) {
 // PauseInteropActivity pauses the interop activity at the given timestamp.
 // When the interop activity attempts to process this timestamp, it returns early.
 // This function is for integration test control only.
-func (s *Supernode) PauseInteropActivity(ts uint64) {
+// Returns an error if the activity has already verified past the target timestamp.
+func (s *Supernode) PauseInteropActivity(ts uint64) error {
 	for _, a := range s.activities {
 		if ia, ok := a.(*interop.Interop); ok {
-			ia.PauseAt(ts)
-			return
+			return ia.PauseAt(ts)
 		}
 	}
 	s.log.Warn("PauseInterop called but no interop activity found")
+	return fmt.Errorf("no interop activity found")
 }
 
 // ResumeInteropActivity clears any pause on the interop activity, allowing normal processing.


### PR DESCRIPTION
* Highlights a race condition where we pause at a timestamp which was already verified. Surfaces this condition into a legible test error, which is much better than the test continuing and failing on some seemingly unrelated thing later. 

* Pushes the pause timestamp further into the future in the (currently flaky) `TestSupernodeInteropInvalidMessageReplacement`. This makes the race condition much less likely (but not strictly impossible, see comment below for some more ideas we could explore). 

* renames DSL methods for clarity