### PR TITLE
ci(acceptance-tests): enable debug logging for flake-shake gate

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -2281,6 +2281,7 @@ jobs:
               --flake-shake \
               --flake-shake-iterations "$FLAKE_SHAKE_ITERATIONS" \
               --orchestrator sysgo \
+              --log.level debug \
               --logdir "./$OUTPUT_DIR"
       - persist_to_workspace:
           root: op-acceptance-tests


### PR DESCRIPTION
## Summary
- Adds `--log.level debug` to the flake-shake `op-acceptor` invocation in CI
- Previously no log level was set, so it used the default; this makes debug output explicit for better visibility into test failures

## Test plan
- [ ] Verify flake-shake CI job produces debug-level logs on next scheduled run