### PR TITLE
DSL: Coordinate Interop Activity Pause for Acceptance Testing

### DIFF
--- a/op-acceptance-tests/tests/supernode/interop/reorg/invalid_message_reorg_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/reorg/invalid_message_reorg_test.go
@@ -41,6 +41,11 @@ func TestSupernodeInteropInvalidMessageReplacement(gt *testing.T) {
 	sys.L2B.CatchUpTo(sys.L2A)
 	sys.L2A.CatchUpTo(sys.L2B)
 
+	// Pause interop and verify it has stopped
+	// Uses max local safe timestamp from both chains, pauses at +10, awaits validation at +9
+	paused := sys.Supernode.EnsureInteropPaused(sys.L2ACL, sys.L2BCL, 10)
+	t.Logger().Info("interop paused", "paused", paused)
+
 	rng := rand.New(rand.NewSource(12345))
 
 	// Send an initiating message on chain A
@@ -53,14 +58,6 @@ func TestSupernodeInteropInvalidMessageReplacement(gt *testing.T) {
 
 	// Wait for chain B to catch up
 	sys.L2B.WaitForBlock()
-
-	// Wait for some timestamps to be verified first
-	targetTimestamp := sys.L2A.TimestampForBlockNum(2)
-	// set supernode to pause verification just after this timestamp
-	sys.Supernode.PauseInterop(targetTimestamp + 1)
-	sys.Supernode.AwaitValidatedTimestamp(targetTimestamp)
-
-	t.Logger().Info("initial verification confirmed", "timestamp", targetTimestamp)
 
 	// Send an INVALID executing message on chain B
 	_, invalidExecReceipt := bob.SendInvalidExecMessage(initTx, 0)

--- a/op-devstack/dsl/supernode.go
+++ b/op-devstack/dsl/supernode.go
@@ -117,10 +117,7 @@ func (s *Supernode) EnsureInteropPaused(clA, clB *L2CLNode, pauseOffset uint64) 
 	statusB := clB.SyncStatus()
 
 	// Use the maximum local safe timestamp between both chains
-	localSafeTimestamp := statusA.LocalSafeL2.Time
-	if statusB.LocalSafeL2.Time > localSafeTimestamp {
-		localSafeTimestamp = statusB.LocalSafeL2.Time
-	}
+	localSafeTimestamp := max(statusA.LocalSafeL2.Time, statusB.LocalSafeL2.Time)
 
 	s.log.Info("EnsureInteropPaused: initial sync status",
 		"chainA_local_safe_num", statusA.LocalSafeL2.Number,
@@ -147,18 +144,15 @@ func (s *Supernode) EnsureInteropPaused(clA, clB *L2CLNode, pauseOffset uint64) 
 	ctx, cancel := context.WithTimeout(s.ctx, DefaultTimeout)
 	defer cancel()
 
-	actualPauseTimestamp := pauseTimestamp
 	for ts := pauseTimestamp; ts < pauseTimestamp+100; ts++ {
 		resp, err := s.inner.QueryAPI().SuperRootAtTimestamp(ctx, ts)
-		if err != nil {
-			// Transient error - assume not verified
-			actualPauseTimestamp = ts
-			break
-		}
-		if resp.Data == nil {
+		if err != nil || resp.Data == nil {
 			// Found the first unverified timestamp
-			actualPauseTimestamp = ts
-			break
+			s.log.Info("EnsureInteropPaused: confirmed interop is paused",
+				"intendedPauseTimestamp", pauseTimestamp,
+				"actualPauseTimestamp", ts,
+			)
+			return ts
 		}
 		// This timestamp is verified, continue scanning
 		s.log.Warn("EnsureInteropPaused: pause came in late, timestamp already verified",
@@ -167,10 +161,7 @@ func (s *Supernode) EnsureInteropPaused(clA, clB *L2CLNode, pauseOffset uint64) 
 		)
 	}
 
-	s.log.Info("EnsureInteropPaused: confirmed interop is paused",
-		"intendedPauseTimestamp", pauseTimestamp,
-		"actualPauseTimestamp", actualPauseTimestamp,
-	)
-
-	return actualPauseTimestamp
+	s.t.Error("EnsureInteropPaused: failed to find unverified timestamp within 100 timestamps")
+	s.t.FailNow()
+	return pauseTimestamp
 }

--- a/op-devstack/dsl/supernode.go
+++ b/op-devstack/dsl/supernode.go
@@ -101,3 +101,76 @@ func (s *Supernode) ResumeInterop() {
 	s.require.NotNil(s.testControl, "ResumeInterop requires test control; use NewSupernodeWithTestControl")
 	s.testControl.ResumeInteropActivity()
 }
+
+// EnsureInteropPaused pauses the interop activity and verifies it has stopped.
+// It takes the local safe timestamps from two CL nodes, uses the maximum, then:
+// 1. Pauses interop at localSafeTimestamp + pauseOffset
+// 2. Awaits validation of localSafeTimestamp + pauseOffset - 1
+// 3. Finds the first timestamp that is NOT verified (the actual pause point)
+// Returns the first unverified timestamp (adjusted if pause came in late).
+// Requires the Supernode to be created with NewSupernodeWithTestControl.
+func (s *Supernode) EnsureInteropPaused(clA, clB *L2CLNode, pauseOffset uint64) uint64 {
+	s.require.NotNil(s.testControl, "EnsureInteropPaused requires test control; use NewSupernodeWithTestControl")
+
+	// Get the local safe of both chains from sync status
+	statusA := clA.SyncStatus()
+	statusB := clB.SyncStatus()
+
+	// Use the maximum local safe timestamp between both chains
+	localSafeTimestamp := statusA.LocalSafeL2.Time
+	if statusB.LocalSafeL2.Time > localSafeTimestamp {
+		localSafeTimestamp = statusB.LocalSafeL2.Time
+	}
+
+	s.log.Info("EnsureInteropPaused: initial sync status",
+		"chainA_local_safe_num", statusA.LocalSafeL2.Number,
+		"chainA_local_safe_ts", statusA.LocalSafeL2.Time,
+		"chainB_local_safe_num", statusB.LocalSafeL2.Number,
+		"chainB_local_safe_ts", statusB.LocalSafeL2.Time,
+		"localSafeTimestamp", localSafeTimestamp,
+	)
+
+	pauseTimestamp := localSafeTimestamp + pauseOffset
+	awaitTimestamp := pauseTimestamp - 1
+
+	// Pause interop activity at the pause timestamp
+	s.testControl.PauseInteropActivity(pauseTimestamp)
+
+	// Await interop validation of the timestamp before the pause
+	s.AwaitValidatedTimestamp(awaitTimestamp)
+
+	s.log.Info("EnsureInteropPaused: validation confirmed before pause", "timestamp", awaitTimestamp)
+
+	// Find the first timestamp that is NOT verified.
+	// If the pause came in late, some timestamps past pauseTimestamp may already be verified.
+	// We scan forward to find where interop actually stopped.
+	ctx, cancel := context.WithTimeout(s.ctx, DefaultTimeout)
+	defer cancel()
+
+	actualPauseTimestamp := pauseTimestamp
+	for ts := pauseTimestamp; ts < pauseTimestamp+100; ts++ {
+		resp, err := s.inner.QueryAPI().SuperRootAtTimestamp(ctx, ts)
+		if err != nil {
+			// Transient error - assume not verified
+			actualPauseTimestamp = ts
+			break
+		}
+		if resp.Data == nil {
+			// Found the first unverified timestamp
+			actualPauseTimestamp = ts
+			break
+		}
+		// This timestamp is verified, continue scanning
+		s.log.Warn("EnsureInteropPaused: pause came in late, timestamp already verified",
+			"timestamp", ts,
+			"intendedPause", pauseTimestamp,
+		)
+	}
+
+	s.log.Info("EnsureInteropPaused: confirmed interop is paused",
+		"intendedPauseTimestamp", pauseTimestamp,
+		"actualPauseTimestamp", actualPauseTimestamp,
+	)
+
+	return actualPauseTimestamp
+}

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -57,7 +57,7 @@ type Interop struct {
 
 	// pauseAtTimestamp is used for integration test control only.
 	// When non-zero, progressInterop will return early without processing
-	// if the next timestamp to process matches this value.
+	// if the next timestamp to process is >= this value.
 	pauseAtTimestamp atomic.Uint64
 }
 
@@ -162,7 +162,8 @@ func (i *Interop) Stop(ctx context.Context) error {
 }
 
 // PauseAt sets a timestamp at which the interop activity should pause.
-// When progressInterop encounters this timestamp, it returns early without processing.
+// When progressInterop encounters this timestamp or any later timestamp, it returns early without processing.
+// Uses >= check so that if the activity is already beyond the pause point, it will still stop.
 // This function is for integration test control only.
 // Pass 0 to clear the pause (equivalent to calling Resume).
 func (i *Interop) PauseAt(ts uint64) {
@@ -263,8 +264,9 @@ func (i *Interop) progressInterop() (Result, error) {
 	}
 
 	// Check if we're paused at this timestamp (integration test control only)
-	if pauseTs := i.pauseAtTimestamp.Load(); pauseTs != 0 && ts == pauseTs {
-		i.log.Info("interop paused at timestamp", "timestamp", ts)
+	// Uses >= so that if the activity is already beyond the pause point, it will still stop.
+	if pauseTs := i.pauseAtTimestamp.Load(); pauseTs != 0 && ts >= pauseTs {
+		i.log.Info("interop paused at timestamp", "timestamp", ts, "pauseTs", pauseTs)
 		return Result{}, nil
 	}
 


### PR DESCRIPTION
Adds a coordinated interop pause to the DSL.

First the local safe heads are queried,

then an interop-pause is scheduled in the future,

then we await verification up to that pause,

and finally ensure that the timestamp we return is the first timestamp _not verified_.


Technically there is some chance for race if the activity is _actively_ processing a timestamp, but given that the pause is in the future from LocalSafe, it should not trip.