### PR TITLE
op-devstack/supernode: allow supernode to be started with interop activity already paused

### DIFF
--- a/op-acceptance-tests/tests/supernode/interop/reorg/init_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/reorg/init_test.go
@@ -7,12 +7,11 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 )
 
-// This magic value means no verification will happen
-var INTEROP_VERIFICATION_PAUSED_AT = uint64(1)
-
-// TestMain creates an isolated two-L2 setup with a shared supernode that has interop enabled.
-// This package tests block invalidation and reorg scenarios that would pollute other tests if run on a shared devnet.
+// TestMain creates an isolated two-L2 setup with a shared supernode that has interop enabled
+// but paused at timestamp 1. This prevents automatic interop verification, allowing tests to
+// control when verification happens. This package tests block invalidation and reorg scenarios
+// that would pollute other tests if run on a shared devnet.
 func TestMain(m *testing.M) {
 	_ = os.Setenv("DEVSTACK_L2CL_KIND", "supernode")
-	presets.DoMain(m, presets.WithTwoL2SupernodeInteropPaused(0, INTEROP_VERIFICATION_PAUSED_AT))
+	presets.DoMain(m, presets.WithTwoL2SupernodeInteropPaused(0))
 }

--- a/op-acceptance-tests/tests/supernode/interop/reorg/init_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/reorg/init_test.go
@@ -7,9 +7,12 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 )
 
+// This magic value means no verification will happen
+var INTEROP_VERIFICATION_PAUSED_AT = uint64(1)
+
 // TestMain creates an isolated two-L2 setup with a shared supernode that has interop enabled.
 // This package tests block invalidation and reorg scenarios that would pollute other tests if run on a shared devnet.
 func TestMain(m *testing.M) {
 	_ = os.Setenv("DEVSTACK_L2CL_KIND", "supernode")
-	presets.DoMain(m, presets.WithTwoL2SupernodeInterop(0))
+	presets.DoMain(m, presets.WithTwoL2SupernodeInteropPaused(0, INTEROP_VERIFICATION_PAUSED_AT))
 }

--- a/op-acceptance-tests/tests/supernode/interop/reorg/invalid_message_reorg_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/reorg/invalid_message_reorg_test.go
@@ -41,11 +41,6 @@ func TestSupernodeInteropInvalidMessageReplacement(gt *testing.T) {
 	sys.L2B.CatchUpTo(sys.L2A)
 	sys.L2A.CatchUpTo(sys.L2B)
 
-	// Pause interop and verify it has stopped
-	// Uses max local safe timestamp from both chains, pauses at +10, awaits validation at +9
-	paused := sys.Supernode.EnsureInteropPaused(sys.L2ACL, sys.L2BCL, 10)
-	t.Logger().Info("interop paused", "paused", paused)
-
 	rng := rand.New(rand.NewSource(12345))
 
 	// Send an initiating message on chain A

--- a/op-devstack/dsl/supernode.go
+++ b/op-devstack/dsl/supernode.go
@@ -109,6 +109,17 @@ func (s *Supernode) ResumeInterop() {
 // 3. Finds the first timestamp that is NOT verified (the actual pause point)
 // Returns the first unverified timestamp (adjusted if pause came in late).
 // Requires the Supernode to be created with NewSupernodeWithTestControl.
+//
+// Note: For tests that want to avoid race conditions, consider using the
+// initial pause feature instead. In TestMain, configure your system with:
+//
+//	WithTwoL2SupernodeInteropPaused(delaySeconds, initialPauseTimestamp)
+//
+// Then in tests, use the regular factory:
+//
+//	NewTwoL2SupernodeInterop(t, delaySeconds)
+//
+// The interop will start paused at the configured timestamp, avoiding race conditions.
 func (s *Supernode) EnsureInteropPaused(clA, clB *L2CLNode, pauseOffset uint64) uint64 {
 	s.require.NotNil(s.testControl, "EnsureInteropPaused requires test control; use NewSupernodeWithTestControl")
 

--- a/op-devstack/dsl/supernode.go
+++ b/op-devstack/dsl/supernode.go
@@ -113,13 +113,13 @@ func (s *Supernode) ResumeInterop() {
 // Note: For tests that want to avoid race conditions, consider using the
 // initial pause feature instead. In TestMain, configure your system with:
 //
-//	WithTwoL2SupernodeInteropPaused(delaySeconds, initialPauseTimestamp)
+//	WithTwoL2SupernodeInteropPaused(delaySeconds)
 //
 // Then in tests, use the regular factory:
 //
 //	NewTwoL2SupernodeInterop(t, delaySeconds)
 //
-// The interop will start paused at the configured timestamp, avoiding race conditions.
+// The interop will start paused at timestamp 1, avoiding race conditions.
 func (s *Supernode) EnsureInteropPaused(clA, clB *L2CLNode, pauseOffset uint64) uint64 {
 	s.require.NotNil(s.testControl, "EnsureInteropPaused requires test control; use NewSupernodeWithTestControl")
 

--- a/op-devstack/presets/twol2.go
+++ b/op-devstack/presets/twol2.go
@@ -43,15 +43,15 @@ func WithTwoL2Supernode() stack.CommonOption {
 // Use delaySeconds=0 for interop at genesis, or a positive value to test the transition from
 // normal safety to interop-verified safety.
 func WithTwoL2SupernodeInterop(delaySeconds uint64) stack.CommonOption {
-	return stack.MakeCommon(sysgo.DefaultSupernodeInteropTwoL2System(&sysgo.DefaultTwoL2SystemIDs{}, delaySeconds, 0))
+	return stack.MakeCommon(sysgo.DefaultSupernodeInteropTwoL2System(&sysgo.DefaultTwoL2SystemIDs{}, delaySeconds, false))
 }
 
 // WithTwoL2SupernodeInteropPaused specifies a two-L2 system using a shared supernode with interop enabled
-// and initially paused at the given timestamp. This avoids race conditions in tests.
-// Use delaySeconds=0 for interop at genesis. The initialPauseTimestamp is the timestamp at which
-// interop verification will pause on startup.
-func WithTwoL2SupernodeInteropPaused(delaySeconds uint64, initialPauseTimestamp uint64) stack.CommonOption {
-	return stack.MakeCommon(sysgo.DefaultSupernodeInteropTwoL2System(&sysgo.DefaultTwoL2SystemIDs{}, delaySeconds, initialPauseTimestamp))
+// and initially paused at timestamp 1. This avoids race conditions in tests by preventing interop
+// verification until explicitly resumed.
+// Use delaySeconds=0 for interop at genesis.
+func WithTwoL2SupernodeInteropPaused(delaySeconds uint64) stack.CommonOption {
+	return stack.MakeCommon(sysgo.DefaultSupernodeInteropTwoL2System(&sysgo.DefaultTwoL2SystemIDs{}, delaySeconds, true))
 }
 
 func NewTwoL2(t devtest.T) *TwoL2 {

--- a/op-devstack/presets/twol2.go
+++ b/op-devstack/presets/twol2.go
@@ -43,7 +43,15 @@ func WithTwoL2Supernode() stack.CommonOption {
 // Use delaySeconds=0 for interop at genesis, or a positive value to test the transition from
 // normal safety to interop-verified safety.
 func WithTwoL2SupernodeInterop(delaySeconds uint64) stack.CommonOption {
-	return stack.MakeCommon(sysgo.DefaultSupernodeInteropTwoL2System(&sysgo.DefaultTwoL2SystemIDs{}, delaySeconds))
+	return stack.MakeCommon(sysgo.DefaultSupernodeInteropTwoL2System(&sysgo.DefaultTwoL2SystemIDs{}, delaySeconds, 0))
+}
+
+// WithTwoL2SupernodeInteropPaused specifies a two-L2 system using a shared supernode with interop enabled
+// and initially paused at the given timestamp. This avoids race conditions in tests.
+// Use delaySeconds=0 for interop at genesis. The initialPauseTimestamp is the timestamp at which
+// interop verification will pause on startup.
+func WithTwoL2SupernodeInteropPaused(delaySeconds uint64, initialPauseTimestamp uint64) stack.CommonOption {
+	return stack.MakeCommon(sysgo.DefaultSupernodeInteropTwoL2System(&sysgo.DefaultTwoL2SystemIDs{}, delaySeconds, initialPauseTimestamp))
 }
 
 func NewTwoL2(t devtest.T) *TwoL2 {

--- a/op-devstack/sysgo/l2_cl_supernode.go
+++ b/op-devstack/sysgo/l2_cl_supernode.go
@@ -221,6 +221,11 @@ type SupernodeConfig struct {
 	// InteropActivationTimestamp enables the interop activity at the given timestamp.
 	// Set to 0 to disable interop (default).
 	InteropActivationTimestamp uint64
+
+	// InitialPauseTimestamp pauses interop verification at the given timestamp on startup.
+	// Set to 0 to start with interop unpaused (default).
+	// This is useful for tests that want to avoid race conditions by starting with interop paused.
+	InitialPauseTimestamp uint64
 }
 
 // SupernodeOption is a functional option for configuring the supernode.
@@ -233,9 +238,18 @@ func WithSupernodeInterop(activationTimestamp uint64) SupernodeOption {
 	}
 }
 
+// WithInitialInteropPause pauses interop verification at the given timestamp on startup.
+// This is useful for tests that want to avoid race conditions by starting with interop paused.
+func WithInitialInteropPause(pauseTimestamp uint64) SupernodeOption {
+	return func(cfg *SupernodeConfig) {
+		cfg.InitialPauseTimestamp = pauseTimestamp
+	}
+}
+
 // WithSharedSupernodeCLsInterop starts one supernode for N L2 chains with interop enabled at genesis.
 // The interop activation timestamp is computed from the first chain's genesis time.
-func WithSharedSupernodeCLsInterop(supernodeID stack.SupernodeID, cls []L2CLs, l1CLID stack.L1CLNodeID, l1ELID stack.L1ELNodeID) stack.Option[*Orchestrator] {
+// Additional options can be passed to configure the supernode (e.g., WithInitialInteropPause).
+func WithSharedSupernodeCLsInterop(supernodeID stack.SupernodeID, cls []L2CLs, l1CLID stack.L1CLNodeID, l1ELID stack.L1ELNodeID, extraOpts ...SupernodeOption) stack.Option[*Orchestrator] {
 	return stack.AfterDeploy(func(orch *Orchestrator) {
 		// Get genesis timestamp from first chain
 		if len(cls) == 0 {
@@ -250,14 +264,17 @@ func WithSharedSupernodeCLsInterop(supernodeID stack.SupernodeID, cls []L2CLs, l
 		genesisTime := l2Net.rollupCfg.Genesis.L2Time
 		orch.P().Logger().Info("enabling supernode interop at genesis", "activation_timestamp", genesisTime)
 
+		// Combine interop option with any extra options
+		opts := append([]SupernodeOption{WithSupernodeInterop(genesisTime)}, extraOpts...)
 		// Call the main implementation with interop enabled
-		withSharedSupernodeCLsImpl(orch, supernodeID, cls, l1CLID, l1ELID, WithSupernodeInterop(genesisTime))
+		withSharedSupernodeCLsImpl(orch, supernodeID, cls, l1CLID, l1ELID, opts...)
 	})
 }
 
 // WithSharedSupernodeCLsInteropDelayed starts one supernode for N L2 chains with interop enabled
 // at a specified offset from genesis. This allows testing the transition from non-interop to interop mode.
-func WithSharedSupernodeCLsInteropDelayed(supernodeID stack.SupernodeID, cls []L2CLs, l1CLID stack.L1CLNodeID, l1ELID stack.L1ELNodeID, delaySeconds uint64) stack.Option[*Orchestrator] {
+// Additional options can be passed to configure the supernode (e.g., WithInitialInteropPause).
+func WithSharedSupernodeCLsInteropDelayed(supernodeID stack.SupernodeID, cls []L2CLs, l1CLID stack.L1CLNodeID, l1ELID stack.L1ELNodeID, delaySeconds uint64, extraOpts ...SupernodeOption) stack.Option[*Orchestrator] {
 	return stack.AfterDeploy(func(orch *Orchestrator) {
 		// Get genesis timestamp from first chain
 		if len(cls) == 0 {
@@ -277,8 +294,10 @@ func WithSharedSupernodeCLsInteropDelayed(supernodeID stack.SupernodeID, cls []L
 			"delay_seconds", delaySeconds,
 		)
 
+		// Combine interop option with any extra options
+		opts := append([]SupernodeOption{WithSupernodeInterop(activationTime)}, extraOpts...)
 		// Call the main implementation with interop enabled at delayed timestamp
-		withSharedSupernodeCLsImpl(orch, supernodeID, cls, l1CLID, l1ELID, WithSupernodeInterop(activationTime))
+		withSharedSupernodeCLsImpl(orch, supernodeID, cls, l1CLID, l1ELID, opts...)
 	})
 }
 
@@ -383,9 +402,13 @@ func withSharedSupernodeCLsImpl(orch *Orchestrator, supernodeID stack.SupernodeI
 		L1BeaconAddr:               l1CL.beaconHTTPAddr,
 		RPCConfig:                  oprpc.CLIConfig{ListenAddr: "127.0.0.1", ListenPort: 0, EnableAdmin: true},
 		InteropActivationTimestamp: snOpts.InteropActivationTimestamp,
+		InitialPauseTimestamp:      snOpts.InitialPauseTimestamp,
 	}
 	if snOpts.InteropActivationTimestamp > 0 {
 		logger.Info("supernode interop enabled", "activation_timestamp", snOpts.InteropActivationTimestamp)
+	}
+	if snOpts.InitialPauseTimestamp > 0 {
+		logger.Info("supernode interop starting paused", "initial_pause_timestamp", snOpts.InitialPauseTimestamp)
 	}
 	ctx, cancel := context.WithCancel(p.Ctx())
 	exitFn := func(err error) { p.Require().NoError(err, "supernode critical error") }

--- a/op-devstack/sysgo/l2_cl_supernode.go
+++ b/op-devstack/sysgo/l2_cl_supernode.go
@@ -222,10 +222,10 @@ type SupernodeConfig struct {
 	// Set to 0 to disable interop (default).
 	InteropActivationTimestamp uint64
 
-	// InitialPauseTimestamp pauses interop verification at the given timestamp on startup.
-	// Set to 0 to start with interop unpaused (default).
+	// StartInteropPaused pauses interop verification at timestamp 1 on startup.
+	// When true, interop will not verify any blocks until resumed.
 	// This is useful for tests that want to avoid race conditions by starting with interop paused.
-	InitialPauseTimestamp uint64
+	StartInteropPaused bool
 }
 
 // SupernodeOption is a functional option for configuring the supernode.
@@ -238,17 +238,17 @@ func WithSupernodeInterop(activationTimestamp uint64) SupernodeOption {
 	}
 }
 
-// WithInitialInteropPause pauses interop verification at the given timestamp on startup.
+// WithStartInteropPaused pauses interop verification at timestamp 1 on startup.
 // This is useful for tests that want to avoid race conditions by starting with interop paused.
-func WithInitialInteropPause(pauseTimestamp uint64) SupernodeOption {
+func WithStartInteropPaused() SupernodeOption {
 	return func(cfg *SupernodeConfig) {
-		cfg.InitialPauseTimestamp = pauseTimestamp
+		cfg.StartInteropPaused = true
 	}
 }
 
 // WithSharedSupernodeCLsInterop starts one supernode for N L2 chains with interop enabled at genesis.
 // The interop activation timestamp is computed from the first chain's genesis time.
-// Additional options can be passed to configure the supernode (e.g., WithInitialInteropPause).
+// Additional options can be passed to configure the supernode (e.g., WithStartInteropPaused).
 func WithSharedSupernodeCLsInterop(supernodeID stack.SupernodeID, cls []L2CLs, l1CLID stack.L1CLNodeID, l1ELID stack.L1ELNodeID, extraOpts ...SupernodeOption) stack.Option[*Orchestrator] {
 	return stack.AfterDeploy(func(orch *Orchestrator) {
 		// Get genesis timestamp from first chain
@@ -273,7 +273,7 @@ func WithSharedSupernodeCLsInterop(supernodeID stack.SupernodeID, cls []L2CLs, l
 
 // WithSharedSupernodeCLsInteropDelayed starts one supernode for N L2 chains with interop enabled
 // at a specified offset from genesis. This allows testing the transition from non-interop to interop mode.
-// Additional options can be passed to configure the supernode (e.g., WithInitialInteropPause).
+// Additional options can be passed to configure the supernode (e.g., WithStartInteropPaused).
 func WithSharedSupernodeCLsInteropDelayed(supernodeID stack.SupernodeID, cls []L2CLs, l1CLID stack.L1CLNodeID, l1ELID stack.L1ELNodeID, delaySeconds uint64, extraOpts ...SupernodeOption) stack.Option[*Orchestrator] {
 	return stack.AfterDeploy(func(orch *Orchestrator) {
 		// Get genesis timestamp from first chain
@@ -402,13 +402,13 @@ func withSharedSupernodeCLsImpl(orch *Orchestrator, supernodeID stack.SupernodeI
 		L1BeaconAddr:               l1CL.beaconHTTPAddr,
 		RPCConfig:                  oprpc.CLIConfig{ListenAddr: "127.0.0.1", ListenPort: 0, EnableAdmin: true},
 		InteropActivationTimestamp: snOpts.InteropActivationTimestamp,
-		InitialPauseTimestamp:      snOpts.InitialPauseTimestamp,
+		StartInteropPaused:         snOpts.StartInteropPaused,
 	}
 	if snOpts.InteropActivationTimestamp > 0 {
 		logger.Info("supernode interop enabled", "activation_timestamp", snOpts.InteropActivationTimestamp)
 	}
-	if snOpts.InitialPauseTimestamp > 0 {
-		logger.Info("supernode interop starting paused", "initial_pause_timestamp", snOpts.InitialPauseTimestamp)
+	if snOpts.StartInteropPaused {
+		logger.Info("supernode interop starting paused at timestamp 1")
 	}
 	ctx, cancel := context.WithCancel(p.Ctx())
 	exitFn := func(err error) { p.Require().NoError(err, "supernode critical error") }

--- a/op-devstack/sysgo/system.go
+++ b/op-devstack/sysgo/system.go
@@ -222,9 +222,9 @@ func DefaultSupernodeTwoL2System(dest *DefaultTwoL2SystemIDs) stack.Option[*Orch
 // DefaultSupernodeInteropTwoL2System runs two L2 chains with a shared supernode that has
 // interop verification enabled. Use delaySeconds=0 for interop at genesis, or a positive value
 // to test the transition from normal safety to interop-verified safety.
-// Use initialPauseTimestamp=0 to start with interop unpaused, or set it to pause interop at that
-// timestamp on startup (useful for avoiding race conditions in tests).
-func DefaultSupernodeInteropTwoL2System(dest *DefaultTwoL2SystemIDs, delaySeconds uint64, initialPauseTimestamp uint64) stack.Option[*Orchestrator] {
+// Use startPaused=false to start with interop unpaused (default), or true to pause interop at
+// timestamp 1 on startup (useful for avoiding race conditions in tests).
+func DefaultSupernodeInteropTwoL2System(dest *DefaultTwoL2SystemIDs, delaySeconds uint64, startPaused bool) stack.Option[*Orchestrator] {
 	ids := NewDefaultTwoL2SystemIDs(DefaultL1ID, DefaultL2AID, DefaultL2BID)
 	opt := stack.Combine[*Orchestrator]()
 	opt.Add(stack.BeforeDeploy(func(o *Orchestrator) {
@@ -255,14 +255,14 @@ func DefaultSupernodeInteropTwoL2System(dest *DefaultTwoL2SystemIDs, delaySecond
 	// Shared supernode for both L2 chains with interop enabled
 	cls := []L2CLs{{CLID: ids.L2ACL, ELID: ids.L2AEL}, {CLID: ids.L2BCL, ELID: ids.L2BEL}}
 	if delaySeconds == 0 {
-		if initialPauseTimestamp > 0 {
-			opt.Add(WithSharedSupernodeCLsInterop(ids.Supernode, cls, ids.L1CL, ids.L1EL, WithInitialInteropPause(initialPauseTimestamp)))
+		if startPaused {
+			opt.Add(WithSharedSupernodeCLsInterop(ids.Supernode, cls, ids.L1CL, ids.L1EL, WithStartInteropPaused()))
 		} else {
 			opt.Add(WithSharedSupernodeCLsInterop(ids.Supernode, cls, ids.L1CL, ids.L1EL))
 		}
 	} else {
-		if initialPauseTimestamp > 0 {
-			opt.Add(WithSharedSupernodeCLsInteropDelayed(ids.Supernode, cls, ids.L1CL, ids.L1EL, delaySeconds, WithInitialInteropPause(initialPauseTimestamp)))
+		if startPaused {
+			opt.Add(WithSharedSupernodeCLsInteropDelayed(ids.Supernode, cls, ids.L1CL, ids.L1EL, delaySeconds, WithStartInteropPaused()))
 		} else {
 			opt.Add(WithSharedSupernodeCLsInteropDelayed(ids.Supernode, cls, ids.L1CL, ids.L1EL, delaySeconds))
 		}

--- a/op-devstack/sysgo/system.go
+++ b/op-devstack/sysgo/system.go
@@ -222,7 +222,9 @@ func DefaultSupernodeTwoL2System(dest *DefaultTwoL2SystemIDs) stack.Option[*Orch
 // DefaultSupernodeInteropTwoL2System runs two L2 chains with a shared supernode that has
 // interop verification enabled. Use delaySeconds=0 for interop at genesis, or a positive value
 // to test the transition from normal safety to interop-verified safety.
-func DefaultSupernodeInteropTwoL2System(dest *DefaultTwoL2SystemIDs, delaySeconds uint64) stack.Option[*Orchestrator] {
+// Use initialPauseTimestamp=0 to start with interop unpaused, or set it to pause interop at that
+// timestamp on startup (useful for avoiding race conditions in tests).
+func DefaultSupernodeInteropTwoL2System(dest *DefaultTwoL2SystemIDs, delaySeconds uint64, initialPauseTimestamp uint64) stack.Option[*Orchestrator] {
 	ids := NewDefaultTwoL2SystemIDs(DefaultL1ID, DefaultL2AID, DefaultL2BID)
 	opt := stack.Combine[*Orchestrator]()
 	opt.Add(stack.BeforeDeploy(func(o *Orchestrator) {
@@ -253,9 +255,17 @@ func DefaultSupernodeInteropTwoL2System(dest *DefaultTwoL2SystemIDs, delaySecond
 	// Shared supernode for both L2 chains with interop enabled
 	cls := []L2CLs{{CLID: ids.L2ACL, ELID: ids.L2AEL}, {CLID: ids.L2BCL, ELID: ids.L2BEL}}
 	if delaySeconds == 0 {
-		opt.Add(WithSharedSupernodeCLsInterop(ids.Supernode, cls, ids.L1CL, ids.L1EL))
+		if initialPauseTimestamp > 0 {
+			opt.Add(WithSharedSupernodeCLsInterop(ids.Supernode, cls, ids.L1CL, ids.L1EL, WithInitialInteropPause(initialPauseTimestamp)))
+		} else {
+			opt.Add(WithSharedSupernodeCLsInterop(ids.Supernode, cls, ids.L1CL, ids.L1EL))
+		}
 	} else {
-		opt.Add(WithSharedSupernodeCLsInteropDelayed(ids.Supernode, cls, ids.L1CL, ids.L1EL, delaySeconds))
+		if initialPauseTimestamp > 0 {
+			opt.Add(WithSharedSupernodeCLsInteropDelayed(ids.Supernode, cls, ids.L1CL, ids.L1EL, delaySeconds, WithInitialInteropPause(initialPauseTimestamp)))
+		} else {
+			opt.Add(WithSharedSupernodeCLsInteropDelayed(ids.Supernode, cls, ids.L1CL, ids.L1EL, delaySeconds))
+		}
 	}
 
 	opt.Add(WithBatcher(ids.L2ABatcher, ids.L1EL, ids.L2ACL, ids.L2AEL))

--- a/op-supernode/config/config.go
+++ b/op-supernode/config/config.go
@@ -23,6 +23,9 @@ type CLIConfig struct {
 	PprofConfig                oppprof.CLIConfig
 	RawCtx                     *cli.Context
 	InteropActivationTimestamp uint64
+	// InitialPauseTimestamp pauses interop verification at this timestamp on startup.
+	// Set to 0 to start with interop unpaused (default).
+	InitialPauseTimestamp uint64
 }
 
 func (c *CLIConfig) Check() error {

--- a/op-supernode/config/config.go
+++ b/op-supernode/config/config.go
@@ -23,9 +23,9 @@ type CLIConfig struct {
 	PprofConfig                oppprof.CLIConfig
 	RawCtx                     *cli.Context
 	InteropActivationTimestamp uint64
-	// InitialPauseTimestamp pauses interop verification at this timestamp on startup.
-	// Set to 0 to start with interop unpaused (default).
-	InitialPauseTimestamp uint64
+	// StartInteropPaused pauses interop verification at timestamp 1 on startup.
+	// When true, interop will not verify any blocks until resumed.
+	StartInteropPaused bool
 }
 
 func (c *CLIConfig) Check() error {

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -66,13 +66,13 @@ func (i *Interop) Name() string {
 }
 
 // New constructs a new Interop activity.
-// If initialPauseTimestamp is non-zero, the activity will start paused at that timestamp.
+// If startPaused is true, the activity will start paused at timestamp 1.
 func New(
 	log log.Logger,
 	activationTimestamp uint64,
 	chains map[eth.ChainID]cc.ChainContainer,
 	dataDir string,
-	initialPauseTimestamp uint64,
+	startPaused bool,
 ) *Interop {
 	verifiedDB, err := OpenVerifiedDB(dataDir)
 	if err != nil {
@@ -110,9 +110,10 @@ func New(
 	i.verifyFn = i.verifyInteropMessages
 
 	// Set initial pause if configured
-	if initialPauseTimestamp > 0 {
-		i.pauseAtTimestamp.Store(initialPauseTimestamp)
-		log.Info("interop activity starting with initial pause", "pauseAtTimestamp", initialPauseTimestamp)
+	// We pause at timestamp 1, which effectively prevents all verification until resumed
+	if startPaused {
+		i.pauseAtTimestamp.Store(1)
+		log.Info("interop activity starting paused at timestamp 1")
 	}
 
 	return i

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -66,11 +66,13 @@ func (i *Interop) Name() string {
 }
 
 // New constructs a new Interop activity.
+// If initialPauseTimestamp is non-zero, the activity will start paused at that timestamp.
 func New(
 	log log.Logger,
 	activationTimestamp uint64,
 	chains map[eth.ChainID]cc.ChainContainer,
 	dataDir string,
+	initialPauseTimestamp uint64,
 ) *Interop {
 	verifiedDB, err := OpenVerifiedDB(dataDir)
 	if err != nil {
@@ -106,6 +108,13 @@ func New(
 	// default to using the verifyInteropMessages function
 	// (can be overridden by tests)
 	i.verifyFn = i.verifyInteropMessages
+
+	// Set initial pause if configured
+	if initialPauseTimestamp > 0 {
+		i.pauseAtTimestamp.Store(initialPauseTimestamp)
+		log.Info("interop activity starting with initial pause", "pauseAtTimestamp", initialPauseTimestamp)
+	}
+
 	return i
 }
 

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -88,7 +88,7 @@ func (h *interopTestHarness) Build() *interopTestHarness {
 	for id, mock := range h.mocks {
 		chains[id] = mock
 	}
-	h.interop = New(testLogger(), h.activationTime, chains, h.dataDir, 0)
+	h.interop = New(testLogger(), h.activationTime, chains, h.dataDir, false)
 	if h.interop != nil {
 		h.interop.ctx = context.Background()
 		h.t.Cleanup(func() { _ = h.interop.Stop(context.Background()) })
@@ -128,7 +128,7 @@ func TestNew(t *testing.T) {
 				return h.WithChain(10, nil).WithChain(8453, nil).SkipBuild()
 			},
 			run: func(t *testing.T, h *interopTestHarness) {
-				interop := New(testLogger(), h.activationTime, h.Chains(), h.dataDir, 0)
+				interop := New(testLogger(), h.activationTime, h.Chains(), h.dataDir, false)
 				require.NotNil(t, interop)
 				t.Cleanup(func() { _ = interop.Stop(context.Background()) })
 
@@ -150,7 +150,7 @@ func TestNew(t *testing.T) {
 				return h.WithDataDir("/nonexistent/path").SkipBuild()
 			},
 			run: func(t *testing.T, h *interopTestHarness) {
-				interop := New(testLogger(), h.activationTime, h.Chains(), h.dataDir, 0)
+				interop := New(testLogger(), h.activationTime, h.Chains(), h.dataDir, false)
 				require.Nil(t, interop)
 			},
 		},
@@ -931,7 +931,7 @@ func TestInterop_FullCycle(t *testing.T) {
 	mock.blockAtTimestamp = eth.L2BlockRef{Number: 500, Hash: common.HexToHash("0xL2")}
 
 	chains := map[eth.ChainID]cc.ChainContainer{mock.id: mock}
-	interop := New(testLogger(), 100, chains, dataDir, 0)
+	interop := New(testLogger(), 100, chains, dataDir, false)
 	require.NotNil(t, interop)
 	interop.ctx = context.Background()
 

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -88,7 +88,7 @@ func (h *interopTestHarness) Build() *interopTestHarness {
 	for id, mock := range h.mocks {
 		chains[id] = mock
 	}
-	h.interop = New(testLogger(), h.activationTime, chains, h.dataDir)
+	h.interop = New(testLogger(), h.activationTime, chains, h.dataDir, 0)
 	if h.interop != nil {
 		h.interop.ctx = context.Background()
 		h.t.Cleanup(func() { _ = h.interop.Stop(context.Background()) })
@@ -128,7 +128,7 @@ func TestNew(t *testing.T) {
 				return h.WithChain(10, nil).WithChain(8453, nil).SkipBuild()
 			},
 			run: func(t *testing.T, h *interopTestHarness) {
-				interop := New(testLogger(), h.activationTime, h.Chains(), h.dataDir)
+				interop := New(testLogger(), h.activationTime, h.Chains(), h.dataDir, 0)
 				require.NotNil(t, interop)
 				t.Cleanup(func() { _ = interop.Stop(context.Background()) })
 
@@ -150,7 +150,7 @@ func TestNew(t *testing.T) {
 				return h.WithDataDir("/nonexistent/path").SkipBuild()
 			},
 			run: func(t *testing.T, h *interopTestHarness) {
-				interop := New(testLogger(), h.activationTime, h.Chains(), h.dataDir)
+				interop := New(testLogger(), h.activationTime, h.Chains(), h.dataDir, 0)
 				require.Nil(t, interop)
 			},
 		},
@@ -931,7 +931,7 @@ func TestInterop_FullCycle(t *testing.T) {
 	mock.blockAtTimestamp = eth.L2BlockRef{Number: 500, Hash: common.HexToHash("0xL2")}
 
 	chains := map[eth.ChainID]cc.ChainContainer{mock.id: mock}
-	interop := New(testLogger(), 100, chains, dataDir)
+	interop := New(testLogger(), 100, chains, dataDir, 0)
 	require.NotNil(t, interop)
 	interop.ctx = context.Background()
 

--- a/op-supernode/supernode/activity/interop/logdb_test.go
+++ b/op-supernode/supernode/activity/interop/logdb_test.go
@@ -456,7 +456,7 @@ func TestLoadLogs_ParentHashMismatch(t *testing.T) {
 	}
 
 	chains := map[eth.ChainID]cc.ChainContainer{chainID: mockChain}
-	interop := New(gethlog.New(), 1000, chains, dataDir)
+	interop := New(gethlog.New(), 1000, chains, dataDir, 0)
 	require.NotNil(t, interop)
 	interop.ctx = context.Background()
 	defer func() { _ = interop.Stop(context.Background()) }()

--- a/op-supernode/supernode/activity/interop/logdb_test.go
+++ b/op-supernode/supernode/activity/interop/logdb_test.go
@@ -456,7 +456,7 @@ func TestLoadLogs_ParentHashMismatch(t *testing.T) {
 	}
 
 	chains := map[eth.ChainID]cc.ChainContainer{chainID: mockChain}
-	interop := New(gethlog.New(), 1000, chains, dataDir, 0)
+	interop := New(gethlog.New(), 1000, chains, dataDir, false)
 	require.NotNil(t, interop)
 	interop.ctx = context.Background()
 	defer func() { _ = interop.Stop(context.Background()) }()

--- a/op-supernode/supernode/supernode.go
+++ b/op-supernode/supernode/supernode.go
@@ -99,7 +99,7 @@ func New(ctx context.Context, log gethlog.Logger, version string, requestStop co
 			cfg.InteropActivationTimestamp,
 			s.chains,
 			cfg.DataDir,
-			cfg.InitialPauseTimestamp,
+			cfg.StartInteropPaused,
 		)
 		s.activities = append(s.activities, interopActivity)
 		for _, chain := range s.chains {

--- a/op-supernode/supernode/supernode.go
+++ b/op-supernode/supernode/supernode.go
@@ -94,7 +94,13 @@ func New(ctx context.Context, log gethlog.Logger, version string, requestStop co
 	log.Info("initializing interop activity? %v", cfg.RawCtx.IsSet(interop.InteropActivationTimestampFlag.Name))
 	// Initialize interop activity if the activation timestamp is set
 	if cfg.InteropActivationTimestamp > 0 {
-		interopActivity := interop.New(log.New("activity", "interop"), cfg.InteropActivationTimestamp, s.chains, cfg.DataDir)
+		interopActivity := interop.New(
+			log.New("activity", "interop"),
+			cfg.InteropActivationTimestamp,
+			s.chains,
+			cfg.DataDir,
+			cfg.InitialPauseTimestamp,
+		)
 		s.activities = append(s.activities, interopActivity)
 		for _, chain := range s.chains {
 			chain.RegisterVerifier(interopActivity)


### PR DESCRIPTION
This should eliminate race conditions and help remove some flakes we are still seeing. 

It should also speed tests up and removes a bunch of waiting and complexity from tests wanting to pause and restart interop. 