### PR TITLE
op-supernode/node: defer to superAuthority about finalized l2 head

### DIFF
--- a/op-acceptance-tests/tests/supernode/interop/head_progression_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/head_progression_test.go
@@ -16,12 +16,16 @@ import (
 // (SafeL2) trails behind the local safe head (LocalSafeL2) and eventually catches up
 // after interop verification completes (assuming no node resets occur).
 //
+// This test also verifies that finalized heads advance and are derived from finalized L1 blocks.
+//
 // This test verifies:
 //   - SafeL2 <= LocalSafeL2 at all times (the exception to this might be during a node reset where the local safe has to catch back up,
 //     but we don't trigger that here)
 //   - SafeL2 advances after verification
 //   - SafeL2 eventually catches up to LocalSafeL2 (assuming we don't insert any invalid message, which we don't)
 //   - EL safe label is consistent with the SafeL2 from the CL
+//   - Finalized head eventually catches up to a snapshot of the safe head
+//   - Finalized L2 blocks are derived from finalized L1 blocks
 func TestSupernodeInterop_SafeHeadTrailsLocalSafe(gt *testing.T) {
 	t := devtest.SerialT(gt)
 	sys := presets.NewTwoL2SupernodeInterop(t, 0)
@@ -79,6 +83,49 @@ func TestSupernodeInterop_SafeHeadTrailsLocalSafe(gt *testing.T) {
 	safeB = sys.L2ELB.BlockRefByLabel(eth.Safe)
 	require.GreaterOrEqual(t, safeA.Number, finalTargetBlockNum)
 	require.GreaterOrEqual(t, safeB.Number, finalTargetBlockNum)
+
+	// Snapshot the current safe head to verify finalized catches up
+	snapshotSafeA := safeA.Number
+	snapshotSafeB := safeB.Number
+	t.Logger().Info("snapshotted safe heads", "safeA", snapshotSafeA, "safeB", snapshotSafeB)
+
+	// Wait for finalized heads to catch up to or past the snapshotted safe heads
+	// Finalized advancement depends on L1 finality, so use more attempts
+	finalizedAttempts := 30
+	dsl.CheckAll(t,
+		sys.L2ACL.ReachedFn(types.Finalized, snapshotSafeA, finalizedAttempts),
+		sys.L2BCL.ReachedFn(types.Finalized, snapshotSafeB, finalizedAttempts),
+	)
+
+	// Verify finalized heads on EL and that they are derived from finalized L1
+	finalizedA := sys.L2ELA.BlockRefByLabel(eth.Finalized)
+	finalizedB := sys.L2ELB.BlockRefByLabel(eth.Finalized)
+	require.GreaterOrEqual(t, finalizedA.Number, snapshotSafeA, "finalized A should catch up to safe snapshot")
+	require.GreaterOrEqual(t, finalizedB.Number, snapshotSafeB, "finalized B should catch up to safe snapshot")
+
+	// Verify that the finalized L2 blocks are derived from finalized L1 blocks
+	// Get the finalized L1 from the sync status to ensure we're checking against what the node sees
+	syncStatusA := sys.L2ACL.SyncStatus()
+	syncStatusB := sys.L2BCL.SyncStatus()
+	finalizedL1 := sys.L1EL.BlockRefByLabel(eth.Finalized)
+
+	require.LessOrEqual(t, finalizedA.L1Origin.Number, finalizedL1.Number,
+		"finalized L2 block A should be derived from at or before finalized L1")
+	require.LessOrEqual(t, finalizedB.L1Origin.Number, finalizedL1.Number,
+		"finalized L2 block B should be derived from at or before finalized L1")
+
+	// Also verify via the sync status FinalizedL1
+	require.LessOrEqual(t, syncStatusA.FinalizedL2.L1Origin.Number, syncStatusA.FinalizedL1.Number,
+		"sync status finalized L2A should be derived from at or before finalized L1")
+	require.LessOrEqual(t, syncStatusB.FinalizedL2.L1Origin.Number, syncStatusB.FinalizedL1.Number,
+		"sync status finalized L2B should be derived from at or before finalized L1")
+
+	t.Logger().Info("finalized heads verified",
+		"finalizedA", finalizedA.Number, "finalizedA.L1Origin", finalizedA.L1Origin.Number,
+		"finalizedB", finalizedB.Number, "finalizedB.L1Origin", finalizedB.L1Origin.Number,
+		"finalizedL1", finalizedL1.Number,
+		"syncStatusA.FinalizedL1", syncStatusA.FinalizedL1.Number,
+		"syncStatusB.FinalizedL1", syncStatusB.FinalizedL1.Number)
 }
 
 // TestSupernodeInterop_SafeHeadWithUnevenProgress tests safe head behavior

--- a/op-acceptance-tests/tests/supernode/interop/head_progression_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/head_progression_test.go
@@ -57,18 +57,25 @@ func TestSupernodeInterop_SafeHeadProgression(gt *testing.T) {
 		sys.L2BCL.ReachedFn(types.CrossSafe, initialTargetBlockNumB-1, attempts),
 	)
 
-	// Expect cross safe to stall since we paused the interop activity
+	// Expect cross safe and finalized to stall since we paused the interop activity
 	numAttempts := 2 // implies a 4s wait
 	dsl.CheckAll(t,
 		sys.L2ACL.NotAdvancedFn(types.CrossSafe, numAttempts),
 		sys.L2BCL.NotAdvancedFn(types.CrossSafe, numAttempts),
+		sys.L2ACL.NotAdvancedFn(types.Finalized, numAttempts),
+		sys.L2BCL.NotAdvancedFn(types.Finalized, numAttempts),
 	)
 
-	// Check EL labels - cross-safe should be stalled below initial target block numbers
+	// Check EL labels - cross-safeand finalized should be
+	// stalled below initial target block numbers
 	safeA := sys.L2ELA.BlockRefByLabel(eth.Safe)
 	safeB := sys.L2ELB.BlockRefByLabel(eth.Safe)
+	finalizedA := sys.L2ELA.BlockRefByLabel(eth.Finalized)
+	finalizedB := sys.L2ELB.BlockRefByLabel(eth.Finalized)
 	require.Less(t, safeA.Number, initialTargetBlockNumA)
 	require.Less(t, safeB.Number, initialTargetBlockNumB)
+	require.Less(t, finalizedA.Number, initialTargetBlockNumA)
+	require.Less(t, finalizedB.Number, initialTargetBlockNumB)
 
 	// Resume interop verification
 	// expect cross safe to catch up
@@ -109,8 +116,8 @@ func TestSupernodeInterop_SafeHeadProgression(gt *testing.T) {
 	)
 
 	// Verify finalized heads on EL
-	finalizedA := sys.L2ELA.BlockRefByLabel(eth.Finalized)
-	finalizedB := sys.L2ELB.BlockRefByLabel(eth.Finalized)
+	finalizedA = sys.L2ELA.BlockRefByLabel(eth.Finalized)
+	finalizedB = sys.L2ELB.BlockRefByLabel(eth.Finalized)
 	require.GreaterOrEqual(t, finalizedA.Number, snapshotSafeA, "finalized A should catch up to safe snapshot")
 	require.GreaterOrEqual(t, finalizedB.Number, snapshotSafeB, "finalized B should catch up to safe snapshot")
 

--- a/op-acceptance-tests/tests/supernode/interop/head_progression_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/head_progression_test.go
@@ -26,7 +26,7 @@ import (
 //   - EL safe label is consistent with the SafeL2 from the CL
 //   - Finalized head eventually catches up to a snapshot of the safe head
 //   - Finalized L2 blocks are derived from finalized L1 blocks
-func TestSupernodeInterop_SafeHeadTrailsLocalSafe(gt *testing.T) {
+func TestSupernodeInterop_SafeHeadProgression(gt *testing.T) {
 	t := devtest.SerialT(gt)
 	sys := presets.NewTwoL2SupernodeInterop(t, 0)
 	attempts := 15 // each attempt is hardcoded with a 2s by the DSL.
@@ -89,6 +89,17 @@ func TestSupernodeInterop_SafeHeadTrailsLocalSafe(gt *testing.T) {
 	snapshotSafeB := safeB.Number
 	t.Logger().Info("snapshotted safe heads", "safeA", snapshotSafeA, "safeB", snapshotSafeB)
 
+	// Sanity check: finalized should be behind safe at this point
+	preFinalizedStatusA := sys.L2ACL.SyncStatus()
+	preFinalizedStatusB := sys.L2BCL.SyncStatus()
+	require.LessOrEqual(t, preFinalizedStatusA.FinalizedL2.Number, snapshotSafeA,
+		"finalized A should be at or behind safe head")
+	require.LessOrEqual(t, preFinalizedStatusB.FinalizedL2.Number, snapshotSafeB,
+		"finalized B should be at or behind safe head")
+	t.Logger().Info("pre-finalized state",
+		"finalizedA", preFinalizedStatusA.FinalizedL2.Number,
+		"finalizedB", preFinalizedStatusB.FinalizedL2.Number)
+
 	// Wait for finalized heads to catch up to or past the snapshotted safe heads
 	// Finalized advancement depends on L1 finality, so use more attempts
 	finalizedAttempts := 30
@@ -97,35 +108,19 @@ func TestSupernodeInterop_SafeHeadTrailsLocalSafe(gt *testing.T) {
 		sys.L2BCL.ReachedFn(types.Finalized, snapshotSafeB, finalizedAttempts),
 	)
 
-	// Verify finalized heads on EL and that they are derived from finalized L1
+	// Verify finalized heads on EL
 	finalizedA := sys.L2ELA.BlockRefByLabel(eth.Finalized)
 	finalizedB := sys.L2ELB.BlockRefByLabel(eth.Finalized)
 	require.GreaterOrEqual(t, finalizedA.Number, snapshotSafeA, "finalized A should catch up to safe snapshot")
 	require.GreaterOrEqual(t, finalizedB.Number, snapshotSafeB, "finalized B should catch up to safe snapshot")
 
-	// Verify that the finalized L2 blocks are derived from finalized L1 blocks
-	// Get the finalized L1 from the sync status to ensure we're checking against what the node sees
-	syncStatusA := sys.L2ACL.SyncStatus()
-	syncStatusB := sys.L2BCL.SyncStatus()
-	finalizedL1 := sys.L1EL.BlockRefByLabel(eth.Finalized)
-
-	require.LessOrEqual(t, finalizedA.L1Origin.Number, finalizedL1.Number,
-		"finalized L2 block A should be derived from at or before finalized L1")
-	require.LessOrEqual(t, finalizedB.L1Origin.Number, finalizedL1.Number,
-		"finalized L2 block B should be derived from at or before finalized L1")
-
-	// Also verify via the sync status FinalizedL1
-	require.LessOrEqual(t, syncStatusA.FinalizedL2.L1Origin.Number, syncStatusA.FinalizedL1.Number,
-		"sync status finalized L2A should be derived from at or before finalized L1")
-	require.LessOrEqual(t, syncStatusB.FinalizedL2.L1Origin.Number, syncStatusB.FinalizedL1.Number,
-		"sync status finalized L2B should be derived from at or before finalized L1")
-
-	t.Logger().Info("finalized heads verified",
-		"finalizedA", finalizedA.Number, "finalizedA.L1Origin", finalizedA.L1Origin.Number,
-		"finalizedB", finalizedB.Number, "finalizedB.L1Origin", finalizedB.L1Origin.Number,
-		"finalizedL1", finalizedL1.Number,
-		"syncStatusA.FinalizedL1", syncStatusA.FinalizedL1.Number,
-		"syncStatusB.FinalizedL1", syncStatusB.FinalizedL1.Number)
+	// Get current safe heads to verify finalized is still at or behind safe
+	currentSafeA := sys.L2ELA.BlockRefByLabel(eth.Safe)
+	currentSafeB := sys.L2ELB.BlockRefByLabel(eth.Safe)
+	require.LessOrEqual(t, finalizedA.Number, currentSafeA.Number,
+		"finalized A should be at or behind current safe head")
+	require.LessOrEqual(t, finalizedB.Number, currentSafeB.Number,
+		"finalized B should be at or behind current safe head")
 }
 
 // TestSupernodeInterop_SafeHeadWithUnevenProgress tests safe head behavior

--- a/op-acceptance-tests/tests/supernode/interop/head_progression_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/head_progression_test.go
@@ -2,6 +2,7 @@ package interop
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -104,6 +105,11 @@ func TestSupernodeInterop_SafeHeadProgression(gt *testing.T) {
 	t.Logger().Info("pre-finalized state",
 		"finalizedA", preFinalizedStatusA.FinalizedL2.Number,
 		"finalizedB", preFinalizedStatusB.FinalizedL2.Number)
+
+	// Wait for L1 head to finalise, which should imply L2 finalized head progression
+	// Use time travel to reduce walltime of test
+	sys.AdvanceTime(90 * time.Second)
+	sys.L1Network.WaitForFinalization()
 
 	// Wait for finalized heads to catch up to or past the snapshotted safe heads
 	// Finalized advancement depends on L1 finality, so use more attempts

--- a/op-acceptance-tests/tests/supernode/interop/head_progression_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/head_progression_test.go
@@ -12,11 +12,9 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
-// TestSupernodeInterop_SafeHeadTrailsLocalSafe tests that the cross-safe head
+// TestSupernodeInterop_SafeHeadProgression tests that the cross-safe head
 // (SafeL2) trails behind the local safe head (LocalSafeL2) and eventually catches up
 // after interop verification completes (assuming no node resets occur).
-//
-// This test also verifies that finalized heads advance and are derived from finalized L1 blocks.
 //
 // This test verifies:
 //   - SafeL2 <= LocalSafeL2 at all times (the exception to this might be during a node reset where the local safe has to catch back up,
@@ -25,7 +23,7 @@ import (
 //   - SafeL2 eventually catches up to LocalSafeL2 (assuming we don't insert any invalid message, which we don't)
 //   - EL safe label is consistent with the SafeL2 from the CL
 //   - Finalized head eventually catches up to a snapshot of the safe head
-//   - Finalized L2 blocks are derived from finalized L1 blocks
+//   - Finalized L2 blocks have sane L1 origins (behind the L1 finalized head)
 func TestSupernodeInterop_SafeHeadProgression(gt *testing.T) {
 	t := devtest.SerialT(gt)
 	sys := presets.NewTwoL2SupernodeInterop(t, 0)
@@ -128,6 +126,17 @@ func TestSupernodeInterop_SafeHeadProgression(gt *testing.T) {
 		"finalized A should be at or behind current safe head")
 	require.LessOrEqual(t, finalizedB.Number, currentSafeB.Number,
 		"finalized B should be at or behind current safe head")
+
+	// Sanity check: L1 origin of L2 finalized head should be <= L1 finalized head
+	l1FinalizedHead := sys.L1EL.BlockRefByLabel(eth.Finalized)
+	t.Logger().Info("L1 finalized head", "number", l1FinalizedHead.Number)
+	t.Logger().Info("L2A finalized L1 origin", "number", finalizedA.L1Origin.Number)
+	t.Logger().Info("L2B finalized L1 origin", "number", finalizedB.L1Origin.Number)
+
+	require.LessOrEqual(t, finalizedA.L1Origin.Number, l1FinalizedHead.Number,
+		"L2A finalized block's L1 origin should be at or behind L1 finalized head")
+	require.LessOrEqual(t, finalizedB.L1Origin.Number, l1FinalizedHead.Number,
+		"L2B finalized block's L1 origin should be at or behind L1 finalized head")
 }
 
 // TestSupernodeInterop_SafeHeadWithUnevenProgress tests safe head behavior

--- a/op-acceptance-tests/tests/supernode/interop/init_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/init_test.go
@@ -12,5 +12,8 @@ import (
 func TestMain(m *testing.M) {
 	// Set the L2CL kind to supernode for all tests in this package
 	_ = os.Setenv("DEVSTACK_L2CL_KIND", "supernode")
-	presets.DoMain(m, presets.WithTwoL2SupernodeInterop(0))
+	presets.DoMain(m,
+		presets.WithTwoL2SupernodeInterop(0),
+		presets.WithTimeTravel(), // Enable time travel for faster tests
+	)
 }

--- a/op-node/rollup/engine/api.go
+++ b/op-node/rollup/engine/api.go
@@ -37,7 +37,7 @@ func (e *EngineController) OpenBlock(ctx context.Context, parent eth.BlockID, at
 	fc := eth.ForkchoiceState{
 		HeadBlockHash:      parent.Hash,
 		SafeBlockHash:      e.SafeL2Head().Hash,
-		FinalizedBlockHash: e.finalizedHead.Hash,
+		FinalizedBlockHash: e.FinalizedHead().Hash,
 	}
 	id, errTyp, err := e.startPayload(ctx, fc, attrs)
 	if err != nil {

--- a/op-node/rollup/engine/build_start.go
+++ b/op-node/rollup/engine/build_start.go
@@ -32,7 +32,7 @@ func (e *EngineController) onBuildStart(ctx context.Context, ev BuildStartEvent)
 	fcEvent := ForkchoiceUpdateEvent{
 		UnsafeL2Head:    ev.Attributes.Parent,
 		SafeL2Head:      e.SafeL2Head(),
-		FinalizedL2Head: e.finalizedHead,
+		FinalizedL2Head: e.FinalizedHead(),
 	}
 	if fcEvent.UnsafeL2Head.Number < fcEvent.FinalizedL2Head.Number {
 		err := fmt.Errorf("invalid block-building pre-state, unsafe head %s is behind finalized head %s", fcEvent.UnsafeL2Head, fcEvent.FinalizedL2Head)

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -232,13 +232,18 @@ func (e *EngineController) SafeL2Head() eth.L2BlockRef {
 
 func (e *EngineController) FinalizedHead() eth.L2BlockRef {
 	if e.superAuthority != nil {
-		f := e.superAuthority.FinalizedL2Head()
+		f, useLocalFinalized := e.superAuthority.FinalizedL2Head()
+		if useLocalFinalized {
+			// No verifiers registered, fall back to local finalized
+			e.log.Debug("super authority has no verifiers, using local finalized head")
+			return e.localFinalizedHead
+		}
 		if (f == eth.BlockID{}) {
-			// No finalized head yet
+			// Verifiers exist but haven't finalized anything yet
 			return eth.L2BlockRef{}
 		}
 		if f.Number > e.localSafeHead.Number {
-			e.log.Debug("super authority fully verified l2 head is ahead of local safe head, using local safe head as FinalizedHead")
+			e.log.Debug("super authority finalized l2 head is ahead of local safe head, using local safe head as FinalizedHead")
 			return e.localSafeHead
 		}
 		br, err := e.engine.L2BlockRefByHash(e.ctx, f.Hash)

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -211,8 +211,12 @@ func (e *EngineController) SafeL2Head() eth.L2BlockRef {
 		}
 		// SuperAuthority provided a cross-verified safe head
 		if (fvshid == eth.BlockID{}) {
-			// Empty BlockID with useLocalSafe=false means no safe head yet
-			return eth.L2BlockRef{}
+			// Fallback to genesis block (safe by consensus)
+			br, err := e.engine.L2BlockRefByNumber(e.ctx, 0)
+			if err != nil {
+				panic("cannot get genesis block from engine")
+			}
+			return br
 		}
 		if fvshid.Number > e.localSafeHead.Number {
 			e.log.Debug("super authority fully verified l2 head is ahead of local safe head, using local safe head as SafeL2Head")
@@ -239,8 +243,12 @@ func (e *EngineController) FinalizedHead() eth.L2BlockRef {
 			return e.localFinalizedHead
 		}
 		if (f == eth.BlockID{}) {
-			// Verifiers exist but haven't finalized anything yet
-			return eth.L2BlockRef{}
+			// Fallback to genesis block (final by consensus)
+			br, err := e.engine.L2BlockRefByNumber(e.ctx, 0)
+			if err != nil {
+				panic("cannot get genesis block from engine")
+			}
+			return br
 		}
 		if f.Number > e.localSafeHead.Number {
 			e.log.Debug("super authority finalized l2 head is ahead of local safe head, using local safe head as FinalizedHead")

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -312,6 +312,7 @@ func (e *EngineController) isEngineInitialELSyncing() bool {
 // SetFinalizedHead implements LocalEngineControl.
 func (e *EngineController) SetFinalizedHead(r eth.L2BlockRef) {
 	e.metrics.RecordL2Ref("l2_finalized", r)
+	e.localFinalizedHead = r
 	e.deprecatedFinalizedHead = r
 	e.needFCUCall = true
 	e.needSafeHeadUpdate = false

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -212,10 +212,11 @@ func (e *EngineController) SafeL2Head() eth.L2BlockRef {
 		}
 		// SuperAuthority provided a cross-verified safe head
 		if (fvshid == eth.BlockID{}) {
-			// Fallback to genesis block (safe by consensus)
+			// Fallback to genesis block (safe by consensus) if possible
 			br, err := e.engine.L2BlockRefByNumber(e.ctx, 0)
 			if err != nil {
-				panic("cannot get genesis block from engine")
+				e.log.Warn("cannot get genesis block from engine")
+				return eth.L2BlockRef{}
 			}
 			return br
 		}
@@ -244,10 +245,11 @@ func (e *EngineController) FinalizedHead() eth.L2BlockRef {
 			return e.localFinalizedHead
 		}
 		if (f == eth.BlockID{}) {
-			// Fallback to genesis block (final by consensus)
+			// Fallback to genesis block (final by consensus) if possible
 			br, err := e.engine.L2BlockRefByNumber(e.ctx, 0)
 			if err != nil {
-				panic("cannot get genesis block from engine")
+				e.log.Warn("cannot get genesis block from engine")
+				return eth.L2BlockRef{}
 			}
 			return br
 		}

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -125,8 +125,9 @@ type EngineController struct {
 	// Derived from L1, and known to be a completed span-batch,
 	// but not cross-verified yet.
 	localSafeHead eth.L2BlockRef
-	// Derived from finalized L1 data,
-	// Only to be used when there is no superAuthority
+	// Derived from finalized L1 data, but not necessarily
+	// verified by the superAuthority.
+	// Only to be used as a FinalizedHead when there is no superAuthority
 	localFinalizedHead eth.L2BlockRef
 	// The unsafe head to roll back to,
 	// after the pendingSafeHead fails to become safe.

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -125,17 +125,20 @@ type EngineController struct {
 	// Derived from L1, and known to be a completed span-batch,
 	// but not cross-verified yet.
 	localSafeHead eth.L2BlockRef
-	// Deprecated: Derived from L1 and cross-verified to have cross-safe dependencies.
-	// FOR USE BY SUPERVISOR ONLY:
-	deprecatedSafeHead eth.L2BlockRef
-
 	// Derived from finalized L1 data,
-	// and cross-verified to only have finalized dependencies.
-	finalizedHead eth.L2BlockRef
+	// Only to be used when there is no superAuthority
+	localFinalizedHead eth.L2BlockRef
 	// The unsafe head to roll back to,
 	// after the pendingSafeHead fails to become safe.
 	// This is changing in the Holocene fork.
 	backupUnsafeHead eth.L2BlockRef
+
+	// Deprecated: Derived from L1 and cross-verified to have cross-safe dependencies.
+	// FOR USE BY SUPERVISOR ONLY:
+	deprecatedSafeHead eth.L2BlockRef
+	// Deprecated: Derived from finalized L1 data,
+	// Only to be used when there is no superAuthority
+	deprecatedFinalizedHead eth.L2BlockRef
 
 	needFCUCall bool
 	// Safe head debouncing: buffer safe head updates until other updates occur
@@ -195,6 +198,9 @@ func NewEngineController(ctx context.Context, engine ExecEngine, log log.Logger,
 	}
 }
 
+// SafeL2Head returns the safe L2 head.
+// If the super authority is enabled, it returns the fully verified L2 head
+// else it returns the local safe L2 head.
 func (e *EngineController) SafeL2Head() eth.L2BlockRef {
 	if e.superAuthority != nil {
 		fvshid, useLocalSafe := e.superAuthority.FullyVerifiedL2Head()
@@ -224,6 +230,29 @@ func (e *EngineController) SafeL2Head() eth.L2BlockRef {
 	}
 }
 
+func (e *EngineController) FinalizedHead() eth.L2BlockRef {
+	if e.superAuthority != nil {
+		f := e.superAuthority.FinalizedL2Head()
+		if (f == eth.BlockID{}) {
+			// No finalized head yet
+			return eth.L2BlockRef{}
+		}
+		if f.Number > e.localSafeHead.Number {
+			e.log.Debug("super authority fully verified l2 head is ahead of local safe head, using local safe head as FinalizedHead")
+			return e.localSafeHead
+		}
+		br, err := e.engine.L2BlockRefByHash(e.ctx, f.Hash)
+		if err != nil {
+			panic("superAuthority supplied an identifier for the finalized head which is not known to the engine")
+		}
+		return br
+	} else if e.supervisorEnabled {
+		return e.deprecatedFinalizedHead
+	} else {
+		return e.localFinalizedHead
+	}
+}
+
 func (e *EngineController) UnsafeL2Head() eth.L2BlockRef {
 	return e.unsafeHead
 }
@@ -233,7 +262,7 @@ func (e *EngineController) PendingSafeL2Head() eth.L2BlockRef {
 }
 
 func (e *EngineController) Finalized() eth.L2BlockRef {
-	return e.finalizedHead
+	return e.FinalizedHead()
 }
 
 func (e *EngineController) BackupUnsafeL2Head() eth.L2BlockRef {
@@ -251,7 +280,7 @@ func (e *EngineController) requestForkchoiceUpdate(ctx context.Context) {
 	e.emitter.Emit(ctx, ForkchoiceUpdateEvent{
 		UnsafeL2Head:    e.unsafeHead,
 		SafeL2Head:      e.SafeL2Head(),
-		FinalizedL2Head: e.finalizedHead,
+		FinalizedL2Head: e.FinalizedHead(),
 	})
 }
 
@@ -270,7 +299,7 @@ func (e *EngineController) isEngineInitialELSyncing() bool {
 // SetFinalizedHead implements LocalEngineControl.
 func (e *EngineController) SetFinalizedHead(r eth.L2BlockRef) {
 	e.metrics.RecordL2Ref("l2_finalized", r)
-	e.finalizedHead = r
+	e.deprecatedFinalizedHead = r
 	e.needFCUCall = true
 	e.needSafeHeadUpdate = false
 }
@@ -341,7 +370,7 @@ func (e *EngineController) onSafeUpdate(ctx context.Context, crossSafe, localSaf
 // First, the pre-state is registered.
 // A callback is returned to then log the changes to the pre-state, if any.
 func (e *EngineController) logSyncProgressMaybe() func() {
-	prevFinalized := e.finalizedHead
+	prevFinalized := e.FinalizedHead()
 	prevSafe := e.SafeL2Head()
 	prevPendingSafe := e.pendingSafeHead
 	prevUnsafe := e.unsafeHead
@@ -352,7 +381,7 @@ func (e *EngineController) logSyncProgressMaybe() func() {
 			return
 		}
 		var reason string
-		if prevFinalized != e.finalizedHead {
+		if prevFinalized != e.FinalizedHead() {
 			reason = "finalized block"
 		} else if prevSafe != e.SafeL2Head() {
 			if prevSafe == prevUnsafe {
@@ -370,7 +399,7 @@ func (e *EngineController) logSyncProgressMaybe() func() {
 		if reason != "" {
 			e.log.Info("Sync progress",
 				"reason", reason,
-				"l2_finalized", e.finalizedHead,
+				"l2_finalized", e.FinalizedHead(),
 				"l2_safe", e.SafeL2Head(),
 				"l2_pending_safe", e.pendingSafeHead,
 				"l2_unsafe", e.unsafeHead,
@@ -429,7 +458,7 @@ func (e *EngineController) initializeUnknowns(ctx context.Context) error {
 		e.log.Info("Loaded initial local-unsafe block ref", "local_unsafe", ref)
 	}
 	var finalizedRef eth.L2BlockRef
-	if e.finalizedHead == (eth.L2BlockRef{}) {
+	if e.FinalizedHead() == (eth.L2BlockRef{}) {
 		var err error
 		finalizedRef, err = e.engine.L2BlockRefByLabel(ctx, eth.Finalized)
 		if err != nil {
@@ -474,15 +503,15 @@ func (e *EngineController) tryUpdateEngineInternal(ctx context.Context) error {
 	if err := e.initializeUnknowns(ctx); err != nil {
 		return derive.NewTemporaryError(fmt.Errorf("cannot update engine until engine forkchoice is initialized: %w", err))
 	}
-	if e.unsafeHead.Number < e.finalizedHead.Number {
-		err := fmt.Errorf("invalid forkchoice state, unsafe head %s is behind finalized head %s", e.unsafeHead, e.finalizedHead)
+	if e.unsafeHead.Number < e.FinalizedHead().Number {
+		err := fmt.Errorf("invalid forkchoice state, unsafe head %s is behind finalized head %s", e.unsafeHead, e.FinalizedHead())
 		e.emitter.Emit(ctx, rollup.CriticalErrorEvent{Err: err}) // make the node exit, things are very wrong.
 		return err
 	}
 	fc := eth.ForkchoiceState{
 		HeadBlockHash:      e.unsafeHead.Hash,
 		SafeBlockHash:      e.SafeL2Head().Hash,
-		FinalizedBlockHash: e.finalizedHead.Hash,
+		FinalizedBlockHash: e.FinalizedHead().Hash,
 	}
 	logFn := e.logSyncProgressMaybe()
 	defer logFn()
@@ -578,7 +607,7 @@ func (e *EngineController) insertUnsafePayload(ctx context.Context, envelope *et
 	fc := eth.ForkchoiceState{
 		HeadBlockHash:      envelope.ExecutionPayload.BlockHash,
 		SafeBlockHash:      e.SafeL2Head().Hash,
-		FinalizedBlockHash: e.finalizedHead.Hash,
+		FinalizedBlockHash: e.FinalizedHead().Hash,
 	}
 	if e.syncStatus == syncStatusFinishedELButNotFinalized {
 		fc.SafeBlockHash = envelope.ExecutionPayload.BlockHash
@@ -693,7 +722,7 @@ func (e *EngineController) tryBackupUnsafeReorg(ctx context.Context) (bool, erro
 	fc := eth.ForkchoiceState{
 		HeadBlockHash:      e.backupUnsafeHead.Hash,
 		SafeBlockHash:      e.SafeL2Head().Hash,
-		FinalizedBlockHash: e.finalizedHead.Hash,
+		FinalizedBlockHash: e.FinalizedHead().Hash,
 	}
 	logFn := e.logSyncProgressMaybe()
 	defer logFn()
@@ -872,8 +901,8 @@ func (e *EngineController) PromoteFinalized(ctx context.Context, ref eth.L2Block
 	e.promoteFinalized(ctx, ref)
 }
 func (e *EngineController) promoteFinalized(ctx context.Context, ref eth.L2BlockRef) {
-	if ref.Number < e.finalizedHead.Number {
-		e.log.Error("Cannot rewind finality,", "ref", ref, "finalized", e.finalizedHead)
+	if ref.Number < e.FinalizedHead().Number {
+		e.log.Error("Cannot rewind finality,", "ref", ref, "finalized", e.FinalizedHead())
 		return
 	}
 	if ref.Number > e.SafeL2Head().Number {
@@ -935,7 +964,7 @@ func (e *EngineController) forceReset(ctx context.Context, localUnsafe, crossUns
 		e.emitter.Emit(ctx, ForkchoiceUpdateInitEvent{
 			UnsafeL2Head:    e.unsafeHead,
 			SafeL2Head:      e.SafeL2Head(),
-			FinalizedL2Head: e.finalizedHead,
+			FinalizedL2Head: e.FinalizedHead(),
 		})
 	} else {
 		// Time to apply the changes to the underlying engine
@@ -947,7 +976,7 @@ func (e *EngineController) forceReset(ctx context.Context, localUnsafe, crossUns
 		CrossUnsafe: e.crossUnsafeHead,
 		LocalSafe:   e.localSafeHead,
 		CrossSafe:   e.SafeL2Head(),
-		Finalized:   e.finalizedHead,
+		Finalized:   e.FinalizedHead(),
 	}
 	// We do not emit the original event values, since those might not be set (optional attributes).
 	e.emitter.Emit(ctx, v)
@@ -1174,7 +1203,7 @@ func (e *EngineController) FollowSource(eSafeBlockRef, eFinalizedRef eth.L2Block
 		}
 		e.tryUpdateLocalSafe(e.ctx, eSafeBlockRef, true, eth.L1BlockRef{})
 		// Directly update the Engine Controller state, bypassing finalizer
-		if e.finalizedHead.Number <= eFinalizedRef.Number {
+		if e.FinalizedHead().Number <= eFinalizedRef.Number {
 			e.promoteFinalized(e.ctx, eFinalizedRef)
 		}
 	}

--- a/op-node/rollup/engine/engine_controller_test.go
+++ b/op-node/rollup/engine/engine_controller_test.go
@@ -388,3 +388,121 @@ func TestEngineController_ForkchoiceUpdateUsesSuperAuthority(t *testing.T) {
 }
 
 // SuperAuthority tests are in super_authority_deny_test.go
+
+// TestEngineController_FinalizedHead tests FinalizedHead behavior with various configurations
+func TestEngineController_FinalizedHead(t *testing.T) {
+	tests := []struct {
+		name            string
+		setupSuperAuth  func() *mockSuperAuthority
+		setupLocalSafe  *eth.L2BlockRef
+		setupLocalFinal *eth.L2BlockRef
+		setupEngine     func(*testutils.MockEngine)
+		expectPanic     string
+		expectResult    *eth.L2BlockRef
+	}{
+		{
+			name: "with SuperAuthority returns finalized block",
+			setupSuperAuth: func() *mockSuperAuthority {
+				return &mockSuperAuthority{
+					finalizedL2Head: eth.BlockID{Hash: common.Hash{0xbb}, Number: 50},
+				}
+			},
+			setupLocalSafe:  &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
+			setupLocalFinal: &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
+			setupEngine: func(m *testutils.MockEngine) {
+				m.ExpectL2BlockRefByHash(common.Hash{0xbb}, eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 50}, nil)
+			},
+			expectResult: &eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 50},
+		},
+		{
+			name: "with SuperAuthority empty BlockID fallback to genesis",
+			setupSuperAuth: func() *mockSuperAuthority {
+				return &mockSuperAuthority{finalizedL2Head: eth.BlockID{}}
+			},
+			setupLocalFinal: &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
+			setupEngine: func(m *testutils.MockEngine) {
+				m.ExpectL2BlockRefByNumber(0, eth.L2BlockRef{Hash: common.Hash{0x00}, Number: 0}, nil)
+			},
+			expectResult: &eth.L2BlockRef{Hash: common.Hash{0x00}, Number: 0},
+		},
+		{
+			name: "with SuperAuthority ahead of local safe uses local safe",
+			setupSuperAuth: func() *mockSuperAuthority {
+				return &mockSuperAuthority{
+					finalizedL2Head: eth.BlockID{Hash: common.Hash{0xbb}, Number: 50},
+				}
+			},
+			setupLocalSafe:  &eth.L2BlockRef{Hash: common.Hash{0xcc}, Number: 40},
+			setupLocalFinal: &eth.L2BlockRef{Hash: common.Hash{0xdd}, Number: 30},
+			expectResult:    &eth.L2BlockRef{Hash: common.Hash{0xcc}, Number: 40},
+		},
+		{
+			name:           "without SuperAuthority returns zero value",
+			setupSuperAuth: func() *mockSuperAuthority { return nil },
+			expectResult:   &eth.L2BlockRef{},
+		},
+		{
+			name: "panics when genesis lookup fails",
+			setupSuperAuth: func() *mockSuperAuthority {
+				return &mockSuperAuthority{finalizedL2Head: eth.BlockID{}}
+			},
+			setupLocalFinal: &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
+			setupEngine: func(m *testutils.MockEngine) {
+				m.ExpectL2BlockRefByNumber(0, eth.L2BlockRef{}, errors.New("genesis not found"))
+			},
+			expectPanic: "cannot get genesis block from engine",
+		},
+		{
+			name: "panics when SuperAuthority block unknown to engine",
+			setupSuperAuth: func() *mockSuperAuthority {
+				return &mockSuperAuthority{
+					finalizedL2Head: eth.BlockID{Hash: common.Hash{0x99}, Number: 50},
+				}
+			},
+			setupLocalSafe:  &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
+			setupLocalFinal: &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
+			setupEngine: func(m *testutils.MockEngine) {
+				m.ExpectL2BlockRefByHash(common.Hash{0x99}, eth.L2BlockRef{}, errors.New("block not found"))
+			},
+			expectPanic: "superAuthority supplied an identifier for the finalized head which is not known to the engine",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var mockEngine *testutils.MockEngine
+			if tt.setupEngine != nil {
+				mockEngine = &testutils.MockEngine{}
+			}
+
+			cfg := &rollup.Config{}
+			emitter := &testutils.MockEmitter{}
+			var superAuthority rollup.SuperAuthority
+			if tt.setupSuperAuth != nil {
+				if sa := tt.setupSuperAuth(); sa != nil {
+					superAuthority = sa
+				}
+			}
+			ec := NewEngineController(context.Background(), mockEngine, testlog.Logger(t, 0), metrics.NoopMetrics, cfg, &sync.Config{}, false, &testutils.MockL1Source{}, emitter, superAuthority)
+			if tt.setupLocalSafe != nil {
+				ec.SetLocalSafeHead(*tt.setupLocalSafe)
+			}
+			if tt.setupLocalFinal != nil {
+				ec.SetFinalizedHead(*tt.setupLocalFinal)
+			}
+
+			if tt.setupEngine != nil {
+				tt.setupEngine(mockEngine)
+			}
+
+			if tt.expectPanic != "" {
+				require.PanicsWithValue(t, tt.expectPanic, func() {
+					ec.FinalizedHead()
+				})
+			} else {
+				result := ec.FinalizedHead()
+				require.Equal(t, *tt.expectResult, result)
+			}
+		})
+	}
+}

--- a/op-node/rollup/engine/engine_controller_test.go
+++ b/op-node/rollup/engine/engine_controller_test.go
@@ -241,12 +241,15 @@ func TestEngineController_SafeL2Head(t *testing.T) {
 			expectResult: &eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 50},
 		},
 		{
-			name:              "with SuperAuthority empty BlockID returns empty",
+			name:              "with SuperAuthority empty BlockID returns genesis",
 			supervisorEnabled: true,
 			setupSuperAuth: func() *mockSuperAuthority {
 				return &mockSuperAuthority{fullyVerifiedL2Head: eth.BlockID{}}
 			},
-			expectResult: &eth.L2BlockRef{},
+			setupEngine: func(m *testutils.MockEngine) {
+				m.ExpectL2BlockRefByNumber(0, eth.L2BlockRef{Hash: common.Hash{0x00}, Number: 0}, nil)
+			},
+			expectResult: &eth.L2BlockRef{Hash: common.Hash{0x00}, Number: 0},
 		},
 		{
 			name:              "without SuperAuthority but supervisor enabled uses deprecated",
@@ -345,15 +348,16 @@ func TestEngineController_ForkchoiceUpdateUsesSuperAuthority(t *testing.T) {
 		Hash:   common.Hash{0xdd},
 		Number: 60,
 	}
+	finalizedRef := eth.L2BlockRef{Hash: common.Hash{0xcc}, Number: 50}
 	mockSA := &mockSuperAuthority{
 		fullyVerifiedL2Head: verifiedRef.ID(),
+		finalizedL2Head:     finalizedRef.ID(),
 	}
 	ec := NewEngineController(context.Background(), mockEngine, testlog.Logger(t, 0), metrics.NoopMetrics, cfg, &sync.Config{}, true, &testutils.MockL1Source{}, emitter, mockSA)
 
 	// Set heads
 	unsafeRef := eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100}
 	localSafeRef := eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 80}
-	finalizedRef := eth.L2BlockRef{Hash: common.Hash{0xcc}, Number: 50}
 
 	ec.unsafeHead = unsafeRef
 	ec.SetLocalSafeHead(localSafeRef)
@@ -364,6 +368,10 @@ func TestEngineController_ForkchoiceUpdateUsesSuperAuthority(t *testing.T) {
 	// SafeL2Head is called multiple times during initialization and forkchoice - be generous
 	for i := 0; i < 10; i++ {
 		mockEngine.ExpectL2BlockRefByHash(verifiedRef.Hash, verifiedRef, nil)
+	}
+	// FinalizedHead is also called and will look up the finalized block by hash
+	for i := 0; i < 10; i++ {
+		mockEngine.ExpectL2BlockRefByHash(finalizedRef.Hash, finalizedRef, nil)
 	}
 	mockEngine.ExpectL2BlockRefByLabel(eth.Safe, localSafeRef, nil)
 	mockEngine.ExpectL2BlockRefByLabel(eth.Finalized, finalizedRef, nil)

--- a/op-node/rollup/engine/engine_controller_test.go
+++ b/op-node/rollup/engine/engine_controller_test.go
@@ -450,7 +450,7 @@ func TestEngineController_FinalizedHead(t *testing.T) {
 			expectResult:   &eth.L2BlockRef{},
 		},
 		{
-			name: "panics when genesis lookup fails",
+			name: "returns empty block when genesis lookup fails",
 			setupSuperAuth: func() *mockSuperAuthority {
 				return &mockSuperAuthority{finalizedL2Head: eth.BlockID{}}
 			},
@@ -458,7 +458,7 @@ func TestEngineController_FinalizedHead(t *testing.T) {
 			setupEngine: func(m *testutils.MockEngine) {
 				m.ExpectL2BlockRefByNumber(0, eth.L2BlockRef{}, errors.New("genesis not found"))
 			},
-			expectPanic: "cannot get genesis block from engine",
+			expectResult: &eth.L2BlockRef{},
 		},
 		{
 			name: "panics when SuperAuthority block unknown to engine",

--- a/op-node/rollup/engine/super_authority_mock_test.go
+++ b/op-node/rollup/engine/super_authority_mock_test.go
@@ -11,6 +11,7 @@ import (
 // mockSuperAuthority implements SuperAuthority for testing.
 type mockSuperAuthority struct {
 	fullyVerifiedL2Head eth.BlockID
+	finalizedL2Head     eth.BlockID
 	deniedBlocks        map[uint64]common.Hash
 	shouldError         bool
 }
@@ -41,8 +42,7 @@ func (m *mockSuperAuthority) FullyVerifiedL2Head() (eth.BlockID, bool) {
 }
 
 func (m *mockSuperAuthority) FinalizedL2Head() (eth.BlockID, bool) {
-	// TODO: implement proper mock behavior
-	return eth.BlockID{}, false
+	return m.finalizedL2Head, false
 }
 
 var _ rollup.SuperAuthority = (*mockSuperAuthority)(nil)

--- a/op-node/rollup/engine/super_authority_mock_test.go
+++ b/op-node/rollup/engine/super_authority_mock_test.go
@@ -40,4 +40,9 @@ func (m *mockSuperAuthority) FullyVerifiedL2Head() (eth.BlockID, bool) {
 	return m.fullyVerifiedL2Head, false
 }
 
+func (m *mockSuperAuthority) FinalizedL2Head() eth.BlockID {
+	// TODO
+	return eth.BlockID{}
+}
+
 var _ rollup.SuperAuthority = (*mockSuperAuthority)(nil)

--- a/op-node/rollup/engine/super_authority_mock_test.go
+++ b/op-node/rollup/engine/super_authority_mock_test.go
@@ -40,9 +40,9 @@ func (m *mockSuperAuthority) FullyVerifiedL2Head() (eth.BlockID, bool) {
 	return m.fullyVerifiedL2Head, false
 }
 
-func (m *mockSuperAuthority) FinalizedL2Head() eth.BlockID {
-	// TODO
-	return eth.BlockID{}
+func (m *mockSuperAuthority) FinalizedL2Head() (eth.BlockID, bool) {
+	// TODO: implement proper mock behavior
+	return eth.BlockID{}, false
 }
 
 var _ rollup.SuperAuthority = (*mockSuperAuthority)(nil)

--- a/op-node/rollup/iface.go
+++ b/op-node/rollup/iface.go
@@ -16,8 +16,10 @@ type SuperAuthority interface {
 	// If useLocalSafe is false, the BlockID is the cross-verified safe head.
 	FullyVerifiedL2Head() (head eth.BlockID, useLocalSafe bool)
 	// FinalizedL2Head returns the finalized L2 head block reference.
-	// It returns an empty L2BlockRef if no finalized head can be determined.
-	FinalizedL2Head() eth.BlockID
+	// The second return value indicates whether the caller should fall back to local-finalized.
+	// If useLocalFinalized is true, the BlockID return value should be ignored and local-finalized used instead.
+	// If useLocalFinalized is false, the BlockID is the cross-verified finalized head.
+	FinalizedL2Head() (head eth.BlockID, useLocalFinalized bool)
 	// IsDenied checks if a payload hash is denied at the given block number.
 	// Returns true if the payload should not be applied.
 	// The error indicates if the check could not be performed (should be logged but not fatal).

--- a/op-node/rollup/iface.go
+++ b/op-node/rollup/iface.go
@@ -15,6 +15,9 @@ type SuperAuthority interface {
 	// If useLocalSafe is true, the BlockID return value should be ignored and local-safe used instead.
 	// If useLocalSafe is false, the BlockID is the cross-verified safe head.
 	FullyVerifiedL2Head() (head eth.BlockID, useLocalSafe bool)
+	// FinalizedL2Head returns the finalized L2 head block reference.
+	// It returns an empty L2BlockRef if no finalized head can be determined.
+	FinalizedL2Head() eth.BlockID
 	// IsDenied checks if a payload hash is denied at the given block number.
 	// Returns true if the payload should not be applied.
 	// The error indicates if the check could not be performed (should be logged but not fatal).

--- a/op-supernode/supernode/activity/activity.go
+++ b/op-supernode/supernode/activity/activity.go
@@ -38,4 +38,5 @@ type VerificationActivity interface {
 	CurrentL1() eth.BlockID
 	VerifiedAtTimestamp(ts uint64) (bool, error)
 	LatestVerifiedL2Block(chainID eth.ChainID) (eth.BlockID, uint64)
+	LatestFinalizedL2Block(chainID eth.ChainID) (eth.BlockID, uint64)
 }

--- a/op-supernode/supernode/activity/activity.go
+++ b/op-supernode/supernode/activity/activity.go
@@ -38,5 +38,5 @@ type VerificationActivity interface {
 	CurrentL1() eth.BlockID
 	VerifiedAtTimestamp(ts uint64) (bool, error)
 	LatestVerifiedL2Block(chainID eth.ChainID) (eth.BlockID, uint64)
-	LatestFinalizedL2Block(chainID eth.ChainID) (eth.BlockID, uint64)
+	VerifiedBlockAtL1(chainID eth.ChainID, l1Block eth.L1BlockRef) (eth.BlockID, uint64)
 }

--- a/op-supernode/supernode/activity/activity.go
+++ b/op-supernode/supernode/activity/activity.go
@@ -35,8 +35,22 @@ type RPCActivity interface {
 type VerificationActivity interface {
 	Activity
 	Name() string
+
+	// Reset resets the activity's state.
+	Reset(chainID eth.ChainID, timestamp uint64, invalidatedBlock eth.BlockRef)
+
+	// CurrentL1 returns the current L1 block ID.
 	CurrentL1() eth.BlockID
+
+	// VerifiedAtTimestamp returns true if the activity has verified the data at the given timestamp.
 	VerifiedAtTimestamp(ts uint64) (bool, error)
+
+	// LatestVerifiedL2Block returns the latest L2 block which has been verified,
+	// along with the timestamp at which it was verified.
 	LatestVerifiedL2Block(chainID eth.ChainID) (eth.BlockID, uint64)
+
+	// VerifiedBlockAtL1 returns the verified L2 block and timestamp
+	// which guarantees that the verified data at that timestamp
+	// originates from or before the supplied L1 block.
 	VerifiedBlockAtL1(chainID eth.ChainID, l1Block eth.L1BlockRef) (eth.BlockID, uint64)
 }

--- a/op-supernode/supernode/activity/interop/algo.go
+++ b/op-supernode/supernode/activity/interop/algo.go
@@ -36,9 +36,10 @@ var (
 //   - Verify the initiating message exists in the source chain's logsDB
 //   - Verify the initiating message timestamp < executing message timestamp
 //   - Verify the initiating message hasn't expired (within ExpiryTime)
-func (i *Interop) verifyInteropMessages(ts uint64, blocksAtTimestamp map[eth.ChainID]eth.BlockID) (Result, error) {
+func (i *Interop) verifyInteropMessages(ts uint64, l1Head eth.BlockID, blocksAtTimestamp map[eth.ChainID]eth.BlockID) (Result, error) {
 	result := Result{
 		Timestamp:    ts,
+		L1Head:       l1Head,
 		L2Heads:      make(map[eth.ChainID]eth.BlockID),
 		InvalidHeads: make(map[eth.ChainID]eth.BlockID),
 	}

--- a/op-supernode/supernode/activity/interop/algo.go
+++ b/op-supernode/supernode/activity/interop/algo.go
@@ -3,6 +3,7 @@ package interop
 import (
 	"errors"
 	"fmt"
+	"math"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
@@ -43,11 +44,12 @@ func (i *Interop) verifyInteropMessages(ts uint64, blocksAtTimestamp map[eth.Cha
 		InvalidHeads: make(map[eth.ChainID]eth.BlockID),
 	}
 
-	// Compute L1Inclusion: the earliest L1 block from which all L2 blocks at the given
-	// timestamp.
-	// This uses OptimisticAt to query the SafeDB for each chain's L1 inclusion block
-	var maxL1Inclusion eth.BlockID
-	firstL1 := true
+	// Compute L1Inclusion: the earliest L1 block such that all L2 blocks at the
+	// supplied timestamp were derived
+	// from a source at or before that L1 block.
+	earliestL1Inclusion := eth.BlockID{
+		Number: math.MaxUint64,
+	}
 	for chainID := range blocksAtTimestamp {
 		chain, ok := i.chains[chainID]
 		if !ok {
@@ -58,12 +60,11 @@ func (i *Interop) verifyInteropMessages(ts uint64, blocksAtTimestamp map[eth.Cha
 			i.log.Error("failed to get L1 inclusion for L2 block", "chainID", chainID, "timestamp", ts, "err", err)
 			return Result{}, fmt.Errorf("chain %s: failed to get L1 inclusion: %w", chainID, err)
 		}
-		if firstL1 || l1Block.Number > maxL1Inclusion.Number {
-			maxL1Inclusion = l1Block
-			firstL1 = false
+		if l1Block.Number < earliestL1Inclusion.Number {
+			earliestL1Inclusion = l1Block
 		}
 	}
-	result.L1Inclusion = maxL1Inclusion
+	result.L1Inclusion = earliestL1Inclusion
 
 	for chainID, expectedBlock := range blocksAtTimestamp {
 		db, ok := i.logsDBs[chainID]

--- a/op-supernode/supernode/activity/interop/algo.go
+++ b/op-supernode/supernode/activity/interop/algo.go
@@ -36,13 +36,33 @@ var (
 //   - Verify the initiating message exists in the source chain's logsDB
 //   - Verify the initiating message timestamp < executing message timestamp
 //   - Verify the initiating message hasn't expired (within ExpiryTime)
-func (i *Interop) verifyInteropMessages(ts uint64, l1Head eth.BlockID, blocksAtTimestamp map[eth.ChainID]eth.BlockID) (Result, error) {
+func (i *Interop) verifyInteropMessages(ts uint64, blocksAtTimestamp map[eth.ChainID]eth.BlockID) (Result, error) {
 	result := Result{
 		Timestamp:    ts,
-		L1Head:       l1Head,
 		L2Heads:      make(map[eth.ChainID]eth.BlockID),
 		InvalidHeads: make(map[eth.ChainID]eth.BlockID),
 	}
+
+	// Compute L1Inclusion: the maximum L1 block from which any L2 block was included
+	// This uses OptimisticAt to query the SafeDB for each chain's L1 inclusion block
+	var maxL1Inclusion eth.BlockID
+	firstL1 := true
+	for chainID := range blocksAtTimestamp {
+		chain, ok := i.chains[chainID]
+		if !ok {
+			continue
+		}
+		_, l1Block, err := chain.OptimisticAt(i.ctx, ts)
+		if err != nil {
+			i.log.Error("failed to get L1 inclusion for L2 block", "chainID", chainID, "timestamp", ts, "err", err)
+			return Result{}, fmt.Errorf("chain %s: failed to get L1 inclusion: %w", chainID, err)
+		}
+		if firstL1 || l1Block.Number > maxL1Inclusion.Number {
+			maxL1Inclusion = l1Block
+			firstL1 = false
+		}
+	}
+	result.L1Inclusion = maxL1Inclusion
 
 	for chainID, expectedBlock := range blocksAtTimestamp {
 		db, ok := i.logsDBs[chainID]

--- a/op-supernode/supernode/activity/interop/algo.go
+++ b/op-supernode/supernode/activity/interop/algo.go
@@ -43,7 +43,8 @@ func (i *Interop) verifyInteropMessages(ts uint64, blocksAtTimestamp map[eth.Cha
 		InvalidHeads: make(map[eth.ChainID]eth.BlockID),
 	}
 
-	// Compute L1Inclusion: the maximum L1 block from which any L2 block was included
+	// Compute L1Inclusion: the earliest L1 block from which all L2 blocks at the given
+	// timestamp.
 	// This uses OptimisticAt to query the SafeDB for each chain's L1 inclusion block
 	var maxL1Inclusion eth.BlockID
 	firstL1 := true

--- a/op-supernode/supernode/activity/interop/algo.go
+++ b/op-supernode/supernode/activity/interop/algo.go
@@ -64,6 +64,9 @@ func (i *Interop) verifyInteropMessages(ts uint64, blocksAtTimestamp map[eth.Cha
 			earliestL1Inclusion = l1Block
 		}
 	}
+	if earliestL1Inclusion.Number == math.MaxUint64 {
+		return Result{}, fmt.Errorf("no L1 inclusion found for timestamp %d", ts)
+	}
 	result.L1Inclusion = earliestL1Inclusion
 
 	for chainID, expectedBlock := range blocksAtTimestamp {

--- a/op-supernode/supernode/activity/interop/algo_test.go
+++ b/op-supernode/supernode/activity/interop/algo_test.go
@@ -1,6 +1,7 @@
 package interop
 
 import (
+	"context"
 	"errors"
 	"math/big"
 	"testing"
@@ -12,6 +13,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-supernode/supernode/activity"
+	cc "github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/reads"
 	suptypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
@@ -19,6 +22,14 @@ import (
 // =============================================================================
 // TestVerifyInteropMessages - Table-Driven Tests
 // =============================================================================
+
+// newMockChainWithL1 creates a mock chain with the specified L1 block for OptimisticAt
+func newMockChainWithL1(chainID eth.ChainID, l1Block eth.BlockID) *algoMockChain {
+	return &algoMockChain{
+		id:           chainID,
+		optimisticL1: l1Block,
+	}
+}
 
 // verifyInteropTestCase defines a single test case for verifyInteropMessages
 type verifyInteropTestCase struct {
@@ -59,6 +70,7 @@ func TestVerifyInteropMessages(t *testing.T) {
 				chainID := eth.ChainIDFromUInt64(10)
 				blockHash := common.HexToHash("0x123")
 				expectedBlock := eth.BlockID{Number: 100, Hash: blockHash}
+				l1Block := eth.BlockID{Number: 50, Hash: common.HexToHash("0xL1")}
 
 				mockDB := &algoMockLogsDB{
 					openBlockRef:     eth.BlockRef{Hash: blockHash, Number: 100, Time: 1000},
@@ -68,6 +80,7 @@ func TestVerifyInteropMessages(t *testing.T) {
 				interop := &Interop{
 					log:     gethlog.New(),
 					logsDBs: map[eth.ChainID]LogsDB{chainID: mockDB},
+					chains:  map[eth.ChainID]cc.ChainContainer{chainID: newMockChainWithL1(chainID, l1Block)},
 				}
 
 				return interop, 1000, map[eth.ChainID]eth.BlockID{chainID: expectedBlock}
@@ -91,6 +104,7 @@ func TestVerifyInteropMessages(t *testing.T) {
 
 				sourceBlock := eth.BlockID{Number: 50, Hash: sourceBlockHash}
 				destBlock := eth.BlockID{Number: 100, Hash: destBlockHash}
+				l1Block := eth.BlockID{Number: 40, Hash: common.HexToHash("0xL1")}
 
 				execMsg := &suptypes.ExecutingMessage{
 					ChainID:   sourceChainID,
@@ -117,6 +131,10 @@ func TestVerifyInteropMessages(t *testing.T) {
 					logsDBs: map[eth.ChainID]LogsDB{
 						sourceChainID: sourceDB,
 						destChainID:   destDB,
+					},
+					chains: map[eth.ChainID]cc.ChainContainer{
+						sourceChainID: newMockChainWithL1(sourceChainID, l1Block),
+						destChainID:   newMockChainWithL1(destChainID, l1Block),
 					},
 				}
 
@@ -145,6 +163,7 @@ func TestVerifyInteropMessages(t *testing.T) {
 
 				sourceBlock := eth.BlockID{Number: 50, Hash: sourceBlockHash}
 				destBlock := eth.BlockID{Number: 100, Hash: destBlockHash}
+				l1Block := eth.BlockID{Number: 40, Hash: common.HexToHash("0xL1")}
 
 				execMsg := &suptypes.ExecutingMessage{
 					ChainID:   sourceChainID,
@@ -172,6 +191,10 @@ func TestVerifyInteropMessages(t *testing.T) {
 						sourceChainID: sourceDB,
 						destChainID:   destDB,
 					},
+					chains: map[eth.ChainID]cc.ChainContainer{
+						sourceChainID: newMockChainWithL1(sourceChainID, l1Block),
+						destChainID:   newMockChainWithL1(destChainID, l1Block),
+					},
 				}
 
 				return interop, execTimestamp, map[eth.ChainID]eth.BlockID{
@@ -197,6 +220,9 @@ func TestVerifyInteropMessages(t *testing.T) {
 				interop := &Interop{
 					log:     gethlog.New(),
 					logsDBs: map[eth.ChainID]LogsDB{registeredChain: mockDB},
+					chains: map[eth.ChainID]cc.ChainContainer{
+						registeredChain: newMockChainWithL1(registeredChain, eth.BlockID{Number: 40, Hash: common.HexToHash("0xL1")}),
+					},
 				}
 
 				return interop, 1000, map[eth.ChainID]eth.BlockID{
@@ -218,6 +244,7 @@ func TestVerifyInteropMessages(t *testing.T) {
 			setup: func() (*Interop, uint64, map[eth.ChainID]eth.BlockID) {
 				chainID := eth.ChainIDFromUInt64(10)
 				expectedBlock := eth.BlockID{Number: 100, Hash: common.HexToHash("0xExpected")}
+				l1Block := eth.BlockID{Number: 40, Hash: common.HexToHash("0xL1")}
 
 				mockDB := &algoMockLogsDB{
 					openBlockRef: eth.BlockRef{
@@ -230,6 +257,7 @@ func TestVerifyInteropMessages(t *testing.T) {
 				interop := &Interop{
 					log:     gethlog.New(),
 					logsDBs: map[eth.ChainID]LogsDB{chainID: mockDB},
+					chains:  map[eth.ChainID]cc.ChainContainer{chainID: newMockChainWithL1(chainID, l1Block)},
 				}
 
 				return interop, 1000, map[eth.ChainID]eth.BlockID{chainID: expectedBlock}
@@ -276,6 +304,10 @@ func TestVerifyInteropMessages(t *testing.T) {
 						sourceChainID: sourceDB,
 						destChainID:   destDB,
 					},
+					chains: map[eth.ChainID]cc.ChainContainer{
+						sourceChainID: newMockChainWithL1(sourceChainID, eth.BlockID{Number: 40, Hash: common.HexToHash("0xL1")}),
+						destChainID:   newMockChainWithL1(destChainID, eth.BlockID{Number: 40, Hash: common.HexToHash("0xL1")}),
+					},
 				}
 
 				return interop, 1000, map[eth.ChainID]eth.BlockID{destChainID: destBlock}
@@ -320,6 +352,10 @@ func TestVerifyInteropMessages(t *testing.T) {
 						sourceChainID: sourceDB,
 						destChainID:   destDB,
 					},
+					chains: map[eth.ChainID]cc.ChainContainer{
+						sourceChainID: newMockChainWithL1(sourceChainID, eth.BlockID{Number: 40, Hash: common.HexToHash("0xL1")}),
+						destChainID:   newMockChainWithL1(destChainID, eth.BlockID{Number: 40, Hash: common.HexToHash("0xL1")}),
+					},
 				}
 
 				return interop, 1000, map[eth.ChainID]eth.BlockID{destChainID: destBlock}
@@ -359,6 +395,10 @@ func TestVerifyInteropMessages(t *testing.T) {
 					logsDBs: map[eth.ChainID]LogsDB{
 						destChainID: destDB,
 						// Note: unknownSourceChain NOT in logsDBs
+					},
+					chains: map[eth.ChainID]cc.ChainContainer{
+						unknownSourceChain: newMockChainWithL1(unknownSourceChain, eth.BlockID{Number: 40, Hash: common.HexToHash("0xL1")}),
+						destChainID:        newMockChainWithL1(destChainID, eth.BlockID{Number: 40, Hash: common.HexToHash("0xL1")}),
 					},
 				}
 
@@ -408,6 +448,10 @@ func TestVerifyInteropMessages(t *testing.T) {
 					logsDBs: map[eth.ChainID]LogsDB{
 						sourceChainID: sourceDB,
 						destChainID:   destDB,
+					},
+					chains: map[eth.ChainID]cc.ChainContainer{
+						sourceChainID: newMockChainWithL1(sourceChainID, eth.BlockID{Number: 40, Hash: common.HexToHash("0xL1")}),
+						destChainID:   newMockChainWithL1(destChainID, eth.BlockID{Number: 40, Hash: common.HexToHash("0xL1")}),
 					},
 				}
 
@@ -463,6 +507,11 @@ func TestVerifyInteropMessages(t *testing.T) {
 						validChainID:   validDB,
 						invalidChainID: invalidDB,
 					},
+					chains: map[eth.ChainID]cc.ChainContainer{
+						invalidChainID: newMockChainWithL1(invalidChainID, eth.BlockID{Number: 40, Hash: common.HexToHash("0xL1")}),
+						sourceChainID:  newMockChainWithL1(sourceChainID, eth.BlockID{Number: 40, Hash: common.HexToHash("0xL1")}),
+						validChainID:   newMockChainWithL1(validChainID, eth.BlockID{Number: 40, Hash: common.HexToHash("0xL1")}),
+					},
 				}
 
 				return interop, 1000, map[eth.ChainID]eth.BlockID{
@@ -482,12 +531,212 @@ func TestVerifyInteropMessages(t *testing.T) {
 				require.Contains(t, result.InvalidHeads, invalidChainID)
 			},
 		},
+		// L1Inclusion tests
+		{
+			name: "L1Inclusion/SingleChain",
+			setup: func() (*Interop, uint64, map[eth.ChainID]eth.BlockID) {
+				chainID := eth.ChainIDFromUInt64(10)
+				blockHash := common.HexToHash("0x123")
+				expectedBlock := eth.BlockID{Number: 100, Hash: blockHash}
+				l1Block := eth.BlockID{Number: 50, Hash: common.HexToHash("0xL1")}
+
+				mockDB := &algoMockLogsDB{
+					openBlockRef:     eth.BlockRef{Hash: blockHash, Number: 100, Time: 1000},
+					openBlockExecMsg: nil,
+				}
+
+				mockChain := &algoMockChain{
+					id:           chainID,
+					optimisticL1: l1Block,
+				}
+
+				interop := &Interop{
+					log:     gethlog.New(),
+					logsDBs: map[eth.ChainID]LogsDB{chainID: mockDB},
+					chains:  map[eth.ChainID]cc.ChainContainer{chainID: mockChain},
+				}
+
+				return interop, 1000, map[eth.ChainID]eth.BlockID{chainID: expectedBlock}
+			},
+			validate: func(t *testing.T, result Result) {
+				chainID := eth.ChainIDFromUInt64(10)
+				expectedBlock := eth.BlockID{Number: 100, Hash: common.HexToHash("0x123")}
+				expectedL1 := eth.BlockID{Number: 50, Hash: common.HexToHash("0xL1")}
+				require.True(t, result.IsValid())
+				require.Empty(t, result.InvalidHeads)
+				require.Equal(t, expectedBlock, result.L2Heads[chainID])
+				require.Equal(t, expectedL1, result.L1Inclusion)
+			},
+		},
+		{
+			name: "L1Inclusion/MultipleChains_EarliestL1Selected",
+			setup: func() (*Interop, uint64, map[eth.ChainID]eth.BlockID) {
+				chain1ID := eth.ChainIDFromUInt64(10)
+				chain2ID := eth.ChainIDFromUInt64(8453)
+				chain3ID := eth.ChainIDFromUInt64(420)
+
+				block1 := eth.BlockID{Number: 100, Hash: common.HexToHash("0x1")}
+				block2 := eth.BlockID{Number: 200, Hash: common.HexToHash("0x2")}
+				block3 := eth.BlockID{Number: 150, Hash: common.HexToHash("0x3")}
+
+				// Chain 1 has L1 at 60 (highest)
+				// Chain 2 has L1 at 45 (earliest - should be selected)
+				// Chain 3 has L1 at 50 (middle)
+				l1Block1 := eth.BlockID{Number: 60, Hash: common.HexToHash("0xL1_1")}
+				l1Block2 := eth.BlockID{Number: 45, Hash: common.HexToHash("0xL1_2")}
+				l1Block3 := eth.BlockID{Number: 50, Hash: common.HexToHash("0xL1_3")}
+
+				mockDB1 := &algoMockLogsDB{
+					openBlockRef:     eth.BlockRef{Hash: block1.Hash, Number: block1.Number, Time: 1000},
+					openBlockExecMsg: nil,
+				}
+				mockDB2 := &algoMockLogsDB{
+					openBlockRef:     eth.BlockRef{Hash: block2.Hash, Number: block2.Number, Time: 1000},
+					openBlockExecMsg: nil,
+				}
+				mockDB3 := &algoMockLogsDB{
+					openBlockRef:     eth.BlockRef{Hash: block3.Hash, Number: block3.Number, Time: 1000},
+					openBlockExecMsg: nil,
+				}
+
+				mockChain1 := &algoMockChain{id: chain1ID, optimisticL1: l1Block1}
+				mockChain2 := &algoMockChain{id: chain2ID, optimisticL1: l1Block2}
+				mockChain3 := &algoMockChain{id: chain3ID, optimisticL1: l1Block3}
+
+				interop := &Interop{
+					log: gethlog.New(),
+					logsDBs: map[eth.ChainID]LogsDB{
+						chain1ID: mockDB1,
+						chain2ID: mockDB2,
+						chain3ID: mockDB3,
+					},
+					chains: map[eth.ChainID]cc.ChainContainer{
+						chain1ID: mockChain1,
+						chain2ID: mockChain2,
+						chain3ID: mockChain3,
+					},
+				}
+
+				return interop, 1000, map[eth.ChainID]eth.BlockID{
+					chain1ID: block1,
+					chain2ID: block2,
+					chain3ID: block3,
+				}
+			},
+			validate: func(t *testing.T, result Result) {
+				// The earliest L1 block (45) should be selected
+				expectedL1 := eth.BlockID{Number: 45, Hash: common.HexToHash("0xL1_2")}
+				require.True(t, result.IsValid())
+				require.Empty(t, result.InvalidHeads)
+				require.Equal(t, expectedL1, result.L1Inclusion)
+				require.Len(t, result.L2Heads, 3)
+			},
+		},
+		{
+			name: "L1Inclusion/ChainNotInChainsMap_Skipped",
+			setup: func() (*Interop, uint64, map[eth.ChainID]eth.BlockID) {
+				chain1ID := eth.ChainIDFromUInt64(10)
+				chain2ID := eth.ChainIDFromUInt64(8453) // Not in chains map
+
+				block1 := eth.BlockID{Number: 100, Hash: common.HexToHash("0x1")}
+				block2 := eth.BlockID{Number: 200, Hash: common.HexToHash("0x2")}
+
+				l1Block1 := eth.BlockID{Number: 50, Hash: common.HexToHash("0xL1_1")}
+
+				mockDB1 := &algoMockLogsDB{
+					openBlockRef:     eth.BlockRef{Hash: block1.Hash, Number: block1.Number, Time: 1000},
+					openBlockExecMsg: nil,
+				}
+				mockDB2 := &algoMockLogsDB{
+					openBlockRef:     eth.BlockRef{Hash: block2.Hash, Number: block2.Number, Time: 1000},
+					openBlockExecMsg: nil,
+				}
+
+				mockChain1 := &algoMockChain{id: chain1ID, optimisticL1: l1Block1}
+
+				interop := &Interop{
+					log: gethlog.New(),
+					logsDBs: map[eth.ChainID]LogsDB{
+						chain1ID: mockDB1,
+						chain2ID: mockDB2,
+					},
+					chains: map[eth.ChainID]cc.ChainContainer{
+						chain1ID: mockChain1,
+						// chain2ID is NOT in the chains map
+					},
+				}
+
+				return interop, 1000, map[eth.ChainID]eth.BlockID{
+					chain1ID: block1,
+					chain2ID: block2,
+				}
+			},
+			validate: func(t *testing.T, result Result) {
+				chain2ID := eth.ChainIDFromUInt64(8453)
+				expectedL1 := eth.BlockID{Number: 50, Hash: common.HexToHash("0xL1_1")}
+				require.True(t, result.IsValid())
+				require.Empty(t, result.InvalidHeads)
+				// chain2 should still be in L2Heads even though it's not in chains map
+				require.Contains(t, result.L2Heads, chain2ID)
+				// L1Inclusion should only consider chain1
+				require.Equal(t, expectedL1, result.L1Inclusion)
+			},
+		},
+		{
+			name: "L1Inclusion/OptimisticAtError_ReturnsError",
+			setup: func() (*Interop, uint64, map[eth.ChainID]eth.BlockID) {
+				chainID := eth.ChainIDFromUInt64(10)
+				blockHash := common.HexToHash("0x123")
+				expectedBlock := eth.BlockID{Number: 100, Hash: blockHash}
+
+				mockDB := &algoMockLogsDB{
+					openBlockRef:     eth.BlockRef{Hash: blockHash, Number: 100, Time: 1000},
+					openBlockExecMsg: nil,
+				}
+
+				mockChain := &algoMockChain{
+					id:              chainID,
+					optimisticAtErr: errors.New("optimistic at error"),
+				}
+
+				interop := &Interop{
+					log:     gethlog.New(),
+					logsDBs: map[eth.ChainID]LogsDB{chainID: mockDB},
+					chains:  map[eth.ChainID]cc.ChainContainer{chainID: mockChain},
+				}
+
+				return interop, 1000, map[eth.ChainID]eth.BlockID{chainID: expectedBlock}
+			},
+			expectError: true,
+			errorMsg:    "failed to get L1 inclusion",
+			validate: func(t *testing.T, result Result) {
+				require.True(t, result.IsEmpty())
+			},
+		},
+		{
+			name: "L1Inclusion/NoChains_Error",
+			setup: func() (*Interop, uint64, map[eth.ChainID]eth.BlockID) {
+				interop := &Interop{
+					log:     gethlog.New(),
+					logsDBs: map[eth.ChainID]LogsDB{},
+					chains:  map[eth.ChainID]cc.ChainContainer{},
+				}
+
+				return interop, 1000, map[eth.ChainID]eth.BlockID{}
+			},
+			expectError: true,
+			errorMsg:    "no L1 inclusion found",
+			validate: func(t *testing.T, result Result) {
+				require.True(t, result.IsEmpty())
+			},
+		},
 		// Error cases
 		{
 			name: "Errors/OpenBlockError",
 			setup: func() (*Interop, uint64, map[eth.ChainID]eth.BlockID) {
 				chainID := eth.ChainIDFromUInt64(10)
 				block := eth.BlockID{Number: 100, Hash: common.HexToHash("0x123")}
+				l1Block := eth.BlockID{Number: 40, Hash: common.HexToHash("0xL1")}
 
 				mockDB := &algoMockLogsDB{
 					openBlockErr: errors.New("database error"),
@@ -496,6 +745,7 @@ func TestVerifyInteropMessages(t *testing.T) {
 				interop := &Interop{
 					log:     gethlog.New(),
 					logsDBs: map[eth.ChainID]LogsDB{chainID: mockDB},
+					chains:  map[eth.ChainID]cc.ChainContainer{chainID: newMockChainWithL1(chainID, l1Block)},
 				}
 
 				return interop, 1000, map[eth.ChainID]eth.BlockID{chainID: block}
@@ -596,3 +846,62 @@ func (m *testBlockInfo) Header() *types.Header                                { 
 func (m *testBlockInfo) ID() eth.BlockID                                      { return eth.BlockID{Hash: m.hash, Number: m.number} }
 
 var _ eth.BlockInfo = (*testBlockInfo)(nil)
+
+// =============================================================================
+// Mock Chain Container for Algo Tests
+// =============================================================================
+
+// algoMockChain is a simplified mock chain container for algo tests
+type algoMockChain struct {
+	id              eth.ChainID
+	optimisticL2    eth.BlockID
+	optimisticL1    eth.BlockID
+	optimisticAtErr error
+}
+
+func (m *algoMockChain) ID() eth.ChainID                                  { return m.id }
+func (m *algoMockChain) Start(ctx context.Context) error                  { return nil }
+func (m *algoMockChain) Stop(ctx context.Context) error                   { return nil }
+func (m *algoMockChain) Pause(ctx context.Context) error                  { return nil }
+func (m *algoMockChain) Resume(ctx context.Context) error                 { return nil }
+func (m *algoMockChain) RegisterVerifier(v activity.VerificationActivity) {}
+func (m *algoMockChain) LocalSafeBlockAtTimestamp(ctx context.Context, ts uint64) (eth.L2BlockRef, error) {
+	return eth.L2BlockRef{}, nil
+}
+func (m *algoMockChain) VerifiedAt(ctx context.Context, ts uint64) (eth.BlockID, eth.BlockID, error) {
+	return eth.BlockID{}, eth.BlockID{}, nil
+}
+func (m *algoMockChain) L1ForL2(ctx context.Context, l2Block eth.BlockID) (eth.BlockID, error) {
+	return eth.BlockID{}, nil
+}
+func (m *algoMockChain) OptimisticAt(ctx context.Context, ts uint64) (eth.BlockID, eth.BlockID, error) {
+	if m.optimisticAtErr != nil {
+		return eth.BlockID{}, eth.BlockID{}, m.optimisticAtErr
+	}
+	return m.optimisticL2, m.optimisticL1, nil
+}
+func (m *algoMockChain) OutputRootAtL2BlockNumber(ctx context.Context, l2BlockNum uint64) (eth.Bytes32, error) {
+	return eth.Bytes32{}, nil
+}
+func (m *algoMockChain) OptimisticOutputAtTimestamp(ctx context.Context, ts uint64) (*eth.OutputResponse, error) {
+	return nil, nil
+}
+func (m *algoMockChain) FetchReceipts(ctx context.Context, blockID eth.BlockID) (eth.BlockInfo, types.Receipts, error) {
+	return nil, types.Receipts{}, nil
+}
+func (m *algoMockChain) SyncStatus(ctx context.Context) (*eth.SyncStatus, error) {
+	return &eth.SyncStatus{}, nil
+}
+func (m *algoMockChain) RewindEngine(ctx context.Context, timestamp uint64, invalidatedBlock eth.BlockRef) error {
+	return nil
+}
+func (m *algoMockChain) BlockTime() uint64 { return 1 }
+func (m *algoMockChain) InvalidateBlock(ctx context.Context, height uint64, payloadHash common.Hash) (bool, error) {
+	return false, nil
+}
+func (m *algoMockChain) IsDenied(height uint64, payloadHash common.Hash) (bool, error) {
+	return false, nil
+}
+func (m *algoMockChain) SetResetCallback(cb cc.ResetCallback) {}
+
+var _ cc.ChainContainer = (*algoMockChain)(nil)

--- a/op-supernode/supernode/activity/interop/algo_test.go
+++ b/op-supernode/supernode/activity/interop/algo_test.go
@@ -32,8 +32,7 @@ type verifyInteropTestCase struct {
 func runVerifyInteropTest(t *testing.T, tc verifyInteropTestCase) {
 	t.Parallel()
 	interop, timestamp, blocks := tc.setup()
-	l1Head := eth.BlockID{Number: 1000, Hash: common.HexToHash("0xL1")}
-	result, err := interop.verifyInteropMessages(timestamp, l1Head, blocks)
+	result, err := interop.verifyInteropMessages(timestamp, blocks)
 
 	if tc.expectError {
 		require.Error(t, err)

--- a/op-supernode/supernode/activity/interop/algo_test.go
+++ b/op-supernode/supernode/activity/interop/algo_test.go
@@ -32,7 +32,8 @@ type verifyInteropTestCase struct {
 func runVerifyInteropTest(t *testing.T, tc verifyInteropTestCase) {
 	t.Parallel()
 	interop, timestamp, blocks := tc.setup()
-	result, err := interop.verifyInteropMessages(timestamp, blocks)
+	l1Head := eth.BlockID{Number: 1000, Hash: common.HexToHash("0xL1")}
+	result, err := interop.verifyInteropMessages(timestamp, l1Head, blocks)
 
 	if tc.expectError {
 		require.Error(t, err)

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -54,7 +54,7 @@ type Interop struct {
 	currentL1   eth.BlockID
 	finalizedL1 eth.BlockID
 
-	verifyFn func(ts uint64, l1Head eth.BlockID, blocksAtTimestamp map[eth.ChainID]eth.BlockID) (Result, error)
+	verifyFn func(ts uint64, blocksAtTimestamp map[eth.ChainID]eth.BlockID) (Result, error)
 
 	// pauseAtTimestamp is used for integration test control only.
 	// When non-zero, progressInterop will return early without processing
@@ -195,7 +195,7 @@ func (i *Interop) progressAndRecord() (bool, error) {
 	i.finalizedL1 = finalizedL1
 
 	// Perform the interop evaluation
-	result, err := i.progressInterop(localCurrentL1)
+	result, err := i.progressInterop()
 	if err != nil {
 		i.log.Error("failed to progress interop", "err", err)
 		return false, err
@@ -217,13 +217,13 @@ func (i *Interop) progressAndRecord() (bool, error) {
 	// the current L1s being considered by the Activity right now depend on what progress was made:
 	// - if interop failed to run, the current L1s are not updated
 	// - if interop ran but did not advance the verified timestamp, the CurrentL1 values collected are used directly
-	// - if interop ran and advanced the verified timestamp, the CurrentL1 is the L1 head at the verified timestamp
+	// - if interop ran and advanced the verified timestamp, the L1Inclusion is the L1 inclusion at the verified timestamp
 	// this is because the individual chains may advance their CurrentL1, and if progress is being made, we might not be done using the collected L1s.
 	verifiedAdvanced := !result.IsEmpty()
 	i.mu.Lock()
 	if verifiedAdvanced {
-		// the new CurrentL1 is the L1 head at the verified timestamp
-		i.currentL1 = result.L1Head
+		// the new CurrentL1 is the L1 inclusion at the verified timestamp
+		i.currentL1 = result.L1Inclusion
 	} else {
 		// the new CurrentL1 is the lowest CurrentL1 from the collected chains
 		i.currentL1 = localCurrentL1
@@ -268,7 +268,7 @@ func (i *Interop) collectFinalizedL1() (eth.BlockID, error) {
 	return finalizedL1, nil
 }
 
-func (i *Interop) progressInterop(l1Head eth.BlockID) (Result, error) {
+func (i *Interop) progressInterop() (Result, error) {
 	start := time.Now()
 	defer func() {
 		i.log.Debug("progressInterop: time taken", "time", time.Since(start))
@@ -323,7 +323,7 @@ func (i *Interop) progressInterop(l1Head eth.BlockID) (Result, error) {
 
 	// 3: validate interop messages
 	// and return the result and any errors
-	return i.verifyFn(ts, l1Head, blocksAtTimestamp)
+	return i.verifyFn(ts, blocksAtTimestamp)
 }
 
 func (i *Interop) handleResult(result Result) error {
@@ -462,7 +462,7 @@ func (i *Interop) LatestFinalizedL2Block(chainID eth.ChainID) (eth.BlockID, uint
 	}
 
 	// Search backwards from the last timestamp to find the latest result
-	// where the L1 head is at or below the finalized L1 block number
+	// where the L1 inclusion block is at or below the finalized L1 block number
 	for ts := lastTs; ts > 0; ts-- {
 		result, err := i.verifiedDB.Get(ts)
 		if err != nil {
@@ -470,8 +470,8 @@ func (i *Interop) LatestFinalizedL2Block(chainID eth.ChainID) (eth.BlockID, uint
 			continue
 		}
 
-		// Check if this result's L1 head is at or below finalized L1
-		if result.L1Head.Number <= finalizedL1.Number {
+		// Check if this result's L1 inclusion is at or below finalized L1
+		if result.L1Inclusion.Number <= finalizedL1.Number {
 			// Found a finalized result, return the L2 head for this chain
 			head, ok := result.L2Heads[chainID]
 			if !ok {

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -51,8 +51,7 @@ type Interop struct {
 	cancel  context.CancelFunc
 	started bool
 
-	currentL1   eth.BlockID
-	finalizedL1 eth.BlockID
+	currentL1 eth.BlockID
 
 	verifyFn func(ts uint64, blocksAtTimestamp map[eth.ChainID]eth.BlockID) (Result, error)
 
@@ -187,12 +186,6 @@ func (i *Interop) progressAndRecord() (bool, error) {
 		i.log.Error("failed to collect current L1", "err", err)
 		return false, err
 	}
-	finalizedL1, err := i.collectFinalizedL1()
-	if err != nil {
-		i.log.Error("failed to collect finalized L1", "err", err)
-		return false, err
-	}
-	i.finalizedL1 = finalizedL1
 
 	// Perform the interop evaluation
 	result, err := i.progressInterop()
@@ -445,15 +438,7 @@ func (i *Interop) LatestVerifiedL2Block(chainID eth.ChainID) (eth.BlockID, uint6
 	return head, ts
 }
 
-func (i *Interop) LatestFinalizedL2Block(chainID eth.ChainID) (eth.BlockID, uint64) {
-	i.mu.RLock()
-	finalizedL1 := i.finalizedL1
-	i.mu.RUnlock()
-
-	// If no finalized L1 yet, return empty
-	if finalizedL1.Number == 0 {
-		return eth.BlockID{}, 0
-	}
+func (i *Interop) VerifiedBlockAtL1(chainID eth.ChainID, l1Block eth.L1BlockRef) (eth.BlockID, uint64) {
 
 	// Get the last verified timestamp
 	lastTs, ok := i.verifiedDB.LastTimestamp()
@@ -462,7 +447,7 @@ func (i *Interop) LatestFinalizedL2Block(chainID eth.ChainID) (eth.BlockID, uint
 	}
 
 	// Search backwards from the last timestamp to find the latest result
-	// where the L1 inclusion block is at or below the finalized L1 block number
+	// where the L1 inclusion block is at or below the supplied L1 block number
 	for ts := lastTs; ts > 0; ts-- {
 		result, err := i.verifiedDB.Get(ts)
 		if err != nil {
@@ -470,8 +455,8 @@ func (i *Interop) LatestFinalizedL2Block(chainID eth.ChainID) (eth.BlockID, uint
 			continue
 		}
 
-		// Check if this result's L1 inclusion is at or below finalized L1
-		if result.L1Inclusion.Number <= finalizedL1.Number {
+		// Check if this result's L1 inclusion is at or below the supplied L1 block number
+		if result.L1Inclusion.Number <= l1Block.Number {
 			// Found a finalized result, return the L2 head for this chain
 			head, ok := result.L2Heads[chainID]
 			if !ok {

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -421,6 +421,9 @@ func (i *Interop) LatestVerifiedL2Block(chainID eth.ChainID) (eth.BlockID, uint6
 	return head, ts
 }
 
+// VerifiedBlockAtL1 returns the verified L2 block and timestamp
+// which guarantees that the verified data at that pauseAtTimestamp
+// originates from or before the supplied L1 block.
 func (i *Interop) VerifiedBlockAtL1(chainID eth.ChainID, l1Block eth.L1BlockRef) (eth.BlockID, uint64) {
 
 	// Get the last verified timestamp
@@ -449,7 +452,7 @@ func (i *Interop) VerifiedBlockAtL1(chainID eth.ChainID, l1Block eth.L1BlockRef)
 		}
 	}
 
-	// No finalized results found
+	// No verified block found
 	return eth.BlockID{}, 0
 }
 

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -51,7 +51,8 @@ type Interop struct {
 	cancel  context.CancelFunc
 	started bool
 
-	currentL1 eth.BlockID
+	currentL1   eth.BlockID
+	finalizedL1 eth.BlockID
 
 	verifyFn func(ts uint64, blocksAtTimestamp map[eth.ChainID]eth.BlockID) (Result, error)
 
@@ -100,7 +101,6 @@ func New(
 		verifiedDB:          verifiedDB,
 		logsDBs:             logsDBs,
 		dataDir:             dataDir,
-		currentL1:           eth.BlockID{},
 		activationTimestamp: activationTimestamp,
 	}
 	// default to using the verifyInteropMessages function
@@ -187,6 +187,13 @@ func (i *Interop) progressAndRecord() (bool, error) {
 		i.log.Error("failed to collect current L1", "err", err)
 		return false, err
 	}
+	finalizedL1, err := i.collectFinalizedL1()
+	if err != nil {
+		i.log.Error("failed to collect finalized L1", "err", err)
+		return false, err
+	}
+	i.finalizedL1 = finalizedL1
+
 	// Perform the interop evaluation
 	result, err := i.progressInterop()
 	if err != nil {
@@ -242,6 +249,23 @@ func (i *Interop) collectCurrentL1() (eth.BlockID, error) {
 		}
 	}
 	return currentL1, nil
+}
+
+func (i *Interop) collectFinalizedL1() (eth.BlockID, error) {
+	var finalizedL1 eth.BlockID
+	first := true
+	for _, chain := range i.chains {
+		status, err := chain.SyncStatus(i.ctx)
+		if err != nil {
+			return eth.BlockID{}, fmt.Errorf("chain %s not ready: %w", chain.ID(), err)
+		}
+		block := status.FinalizedL1
+		if first || block.Number < finalizedL1.Number {
+			finalizedL1 = block.ID()
+			first = false
+		}
+	}
+	return finalizedL1, nil
 }
 
 func (i *Interop) progressInterop() (Result, error) {
@@ -423,6 +447,14 @@ func (i *Interop) LatestVerifiedL2Block(chainID eth.ChainID) (eth.BlockID, uint6
 
 func (i *Interop) LatestFinalizedL2Block(chainID eth.ChainID) (eth.BlockID, uint64) {
 	// TODO: implement finalized block tracking
+	// we can use i.finalizedL1 to get the finalized l1 block number
+	// then we just need to get the latest result from verifiedDB with an l1 block number
+	// at that head or below
+	res,err :=i.verifiedDB.Get(1)
+	if err != nil {
+		return eth.BlockID{}, 0
+	}
+	res.
 	return eth.BlockID{}, 0
 }
 

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -54,7 +54,7 @@ type Interop struct {
 	currentL1   eth.BlockID
 	finalizedL1 eth.BlockID
 
-	verifyFn func(ts uint64, blocksAtTimestamp map[eth.ChainID]eth.BlockID) (Result, error)
+	verifyFn func(ts uint64, l1Head eth.BlockID, blocksAtTimestamp map[eth.ChainID]eth.BlockID) (Result, error)
 
 	// pauseAtTimestamp is used for integration test control only.
 	// When non-zero, progressInterop will return early without processing
@@ -195,7 +195,7 @@ func (i *Interop) progressAndRecord() (bool, error) {
 	i.finalizedL1 = finalizedL1
 
 	// Perform the interop evaluation
-	result, err := i.progressInterop()
+	result, err := i.progressInterop(localCurrentL1)
 	if err != nil {
 		i.log.Error("failed to progress interop", "err", err)
 		return false, err
@@ -268,7 +268,7 @@ func (i *Interop) collectFinalizedL1() (eth.BlockID, error) {
 	return finalizedL1, nil
 }
 
-func (i *Interop) progressInterop() (Result, error) {
+func (i *Interop) progressInterop(l1Head eth.BlockID) (Result, error) {
 	start := time.Now()
 	defer func() {
 		i.log.Debug("progressInterop: time taken", "time", time.Since(start))
@@ -323,7 +323,7 @@ func (i *Interop) progressInterop() (Result, error) {
 
 	// 3: validate interop messages
 	// and return the result and any errors
-	return i.verifyFn(ts, blocksAtTimestamp)
+	return i.verifyFn(ts, l1Head, blocksAtTimestamp)
 }
 
 func (i *Interop) handleResult(result Result) error {

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -450,11 +450,10 @@ func (i *Interop) LatestFinalizedL2Block(chainID eth.ChainID) (eth.BlockID, uint
 	// we can use i.finalizedL1 to get the finalized l1 block number
 	// then we just need to get the latest result from verifiedDB with an l1 block number
 	// at that head or below
-	res,err :=i.verifiedDB.Get(1)
+	_, err := i.verifiedDB.Get(1)
 	if err != nil {
 		return eth.BlockID{}, 0
 	}
-	res.
 	return eth.BlockID{}, 0
 }
 

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -421,6 +421,11 @@ func (i *Interop) LatestVerifiedL2Block(chainID eth.ChainID) (eth.BlockID, uint6
 	return head, ts
 }
 
+func (i *Interop) LatestFinalizedL2Block(chainID eth.ChainID) (eth.BlockID, uint64) {
+	// TODO: implement finalized block tracking
+	return eth.BlockID{}, 0
+}
+
 // Reset is called when a chain container resets due to an invalidated block.
 // It prunes the logsDB and verifiedDB for that chain at and after the timestamp.
 // The invalidatedBlock contains the block info that triggered the reset.

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -446,14 +446,42 @@ func (i *Interop) LatestVerifiedL2Block(chainID eth.ChainID) (eth.BlockID, uint6
 }
 
 func (i *Interop) LatestFinalizedL2Block(chainID eth.ChainID) (eth.BlockID, uint64) {
-	// TODO: implement finalized block tracking
-	// we can use i.finalizedL1 to get the finalized l1 block number
-	// then we just need to get the latest result from verifiedDB with an l1 block number
-	// at that head or below
-	_, err := i.verifiedDB.Get(1)
-	if err != nil {
+	i.mu.RLock()
+	finalizedL1 := i.finalizedL1
+	i.mu.RUnlock()
+
+	// If no finalized L1 yet, return empty
+	if finalizedL1.Number == 0 {
 		return eth.BlockID{}, 0
 	}
+
+	// Get the last verified timestamp
+	lastTs, ok := i.verifiedDB.LastTimestamp()
+	if !ok {
+		return eth.BlockID{}, 0
+	}
+
+	// Search backwards from the last timestamp to find the latest result
+	// where the L1 head is at or below the finalized L1 block number
+	for ts := lastTs; ts > 0; ts-- {
+		result, err := i.verifiedDB.Get(ts)
+		if err != nil {
+			// Timestamp might not exist (due to gaps or rewinds), continue searching
+			continue
+		}
+
+		// Check if this result's L1 head is at or below finalized L1
+		if result.L1Head.Number <= finalizedL1.Number {
+			// Found a finalized result, return the L2 head for this chain
+			head, ok := result.L2Heads[chainID]
+			if !ok {
+				return eth.BlockID{}, 0
+			}
+			return head, ts
+		}
+	}
+
+	// No finalized results found
 	return eth.BlockID{}, 0
 }
 

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -244,23 +244,6 @@ func (i *Interop) collectCurrentL1() (eth.BlockID, error) {
 	return currentL1, nil
 }
 
-func (i *Interop) collectFinalizedL1() (eth.BlockID, error) {
-	var finalizedL1 eth.BlockID
-	first := true
-	for _, chain := range i.chains {
-		status, err := chain.SyncStatus(i.ctx)
-		if err != nil {
-			return eth.BlockID{}, fmt.Errorf("chain %s not ready: %w", chain.ID(), err)
-		}
-		block := status.FinalizedL1
-		if first || block.Number < finalizedL1.Number {
-			finalizedL1 = block.ID()
-			first = false
-		}
-	}
-	return finalizedL1, nil
-}
-
 func (i *Interop) progressInterop() (Result, error) {
 	start := time.Now()
 	defer func() {

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -425,7 +425,6 @@ func (i *Interop) LatestVerifiedL2Block(chainID eth.ChainID) (eth.BlockID, uint6
 // which guarantees that the verified data at that pauseAtTimestamp
 // originates from or before the supplied L1 block.
 func (i *Interop) VerifiedBlockAtL1(chainID eth.ChainID, l1Block eth.L1BlockRef) (eth.BlockID, uint64) {
-
 	// Get the last verified timestamp
 	lastTs, ok := i.verifiedDB.LastTimestamp()
 	if !ok {

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -424,14 +424,14 @@ func TestProgressInterop(t *testing.T) {
 	t.Parallel()
 
 	// Default verifyFn that passes through
-	passThroughVerifyFn := func(ts uint64, l1Head eth.BlockID, blocks map[eth.ChainID]eth.BlockID) (Result, error) {
-		return Result{Timestamp: ts, L1Head: l1Head, L2Heads: blocks}, nil
+	passThroughVerifyFn := func(ts uint64, blocks map[eth.ChainID]eth.BlockID) (Result, error) {
+		return Result{Timestamp: ts, L1Inclusion: eth.BlockID{Number: 100}, L2Heads: blocks}, nil
 	}
 
 	tests := []struct {
 		name     string
 		setup    func(h *interopTestHarness) *interopTestHarness
-		verifyFn func(ts uint64, l1Head eth.BlockID, blocks map[eth.ChainID]eth.BlockID) (Result, error)
+		verifyFn func(ts uint64, blocks map[eth.ChainID]eth.BlockID) (Result, error)
 		assert   func(t *testing.T, result Result, err error)
 		run      func(t *testing.T, h *interopTestHarness) // override for complex cases
 	}{
@@ -459,9 +459,7 @@ func TestProgressInterop(t *testing.T) {
 				h.interop.verifyFn = passThroughVerifyFn
 
 				// First progress
-				l1Head, err := h.interop.collectCurrentL1()
-				require.NoError(t, err)
-				result1, err := h.interop.progressInterop(l1Head)
+				result1, err := h.interop.progressInterop()
 				require.NoError(t, err)
 				require.Equal(t, uint64(1000), result1.Timestamp)
 
@@ -470,9 +468,7 @@ func TestProgressInterop(t *testing.T) {
 				require.NoError(t, err)
 
 				// Second progress should use next timestamp
-				l1Head, err = h.interop.collectCurrentL1()
-				require.NoError(t, err)
-				result2, err := h.interop.progressInterop(l1Head)
+				result2, err := h.interop.progressInterop()
 				require.NoError(t, err)
 				require.Equal(t, uint64(1001), result2.Timestamp)
 			},
@@ -509,7 +505,7 @@ func TestProgressInterop(t *testing.T) {
 					m.blockAtTimestamp = eth.L2BlockRef{Number: 500, Hash: common.HexToHash("0xL2")}
 				}).Build()
 			},
-			verifyFn: func(ts uint64, l1Head eth.BlockID, blocks map[eth.ChainID]eth.BlockID) (Result, error) {
+			verifyFn: func(ts uint64, blocks map[eth.ChainID]eth.BlockID) (Result, error) {
 				return Result{}, errors.New("verification failed")
 			},
 			assert: func(t *testing.T, result Result, err error) {
@@ -531,10 +527,7 @@ func TestProgressInterop(t *testing.T) {
 			if tc.verifyFn != nil {
 				h.interop.verifyFn = tc.verifyFn
 			}
-			// Collect L1 head for progressInterop
-			l1Head, err := h.interop.collectCurrentL1()
-			require.NoError(t, err)
-			result, err := h.interop.progressInterop(l1Head)
+			result, err := h.interop.progressInterop()
 			tc.assert(t, result, err)
 		})
 	}
@@ -590,13 +583,11 @@ func TestVerifiedAtTimestamp(t *testing.T) {
 				}).Build()
 			},
 			run: func(t *testing.T, h *interopTestHarness) {
-				h.interop.verifyFn = func(ts uint64, l1Head eth.BlockID, blocks map[eth.ChainID]eth.BlockID) (Result, error) {
-					return Result{Timestamp: ts, L1Head: l1Head, L2Heads: blocks}, nil
+				h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID) (Result, error) {
+					return Result{Timestamp: ts, L1Inclusion: eth.BlockID{Number: 100}, L2Heads: blocks}, nil
 				}
 
-				l1Head, err := h.interop.collectCurrentL1()
-				require.NoError(t, err)
-				result, err := h.interop.progressInterop(l1Head)
+				result, err := h.interop.progressInterop()
 				require.NoError(t, err)
 
 				err = h.interop.handleResult(result)
@@ -653,7 +644,7 @@ func TestHandleResult(t *testing.T) {
 				mock := h.Mock(10)
 				validResult := Result{
 					Timestamp: 1000,
-					L1Head:    eth.BlockID{Number: 100, Hash: common.HexToHash("0xL1")},
+					L1Inclusion:    eth.BlockID{Number: 100, Hash: common.HexToHash("0xL1")},
 					L2Heads: map[eth.ChainID]eth.BlockID{
 						mock.id: {Number: 500, Hash: common.HexToHash("0xL2")},
 					},
@@ -669,7 +660,7 @@ func TestHandleResult(t *testing.T) {
 				retrieved, err := h.interop.verifiedDB.Get(1000)
 				require.NoError(t, err)
 				require.Equal(t, validResult.Timestamp, retrieved.Timestamp)
-				require.Equal(t, validResult.L1Head, retrieved.L1Head)
+				require.Equal(t, validResult.L1Inclusion, retrieved.L1Inclusion)
 				require.Equal(t, validResult.L2Heads[mock.id], retrieved.L2Heads[mock.id])
 			},
 		},
@@ -682,7 +673,7 @@ func TestHandleResult(t *testing.T) {
 				mock := h.Mock(10)
 				invalidResult := Result{
 					Timestamp: 1000,
-					L1Head:    eth.BlockID{Number: 100, Hash: common.HexToHash("0xL1")},
+					L1Inclusion:    eth.BlockID{Number: 100, Hash: common.HexToHash("0xL1")},
 					L2Heads: map[eth.ChainID]eth.BlockID{
 						mock.id: {Number: 500, Hash: common.HexToHash("0xL2")},
 					},
@@ -783,7 +774,7 @@ func TestInvalidateBlock(t *testing.T) {
 
 				invalidResult := Result{
 					Timestamp: 1000,
-					L1Head:    eth.BlockID{Number: 100, Hash: common.HexToHash("0xL1")},
+					L1Inclusion:    eth.BlockID{Number: 100, Hash: common.HexToHash("0xL1")},
 					L2Heads: map[eth.ChainID]eth.BlockID{
 						mock1.id: {Number: 500, Hash: common.HexToHash("0xL2-1")},
 						mock2.id: {Number: 600, Hash: common.HexToHash("0xL2-2")},
@@ -860,17 +851,17 @@ func TestProgressAndRecord(t *testing.T) {
 				}).Build()
 			},
 			run: func(t *testing.T, h *interopTestHarness) {
-				expectedL1Head := eth.BlockID{Number: 150, Hash: common.HexToHash("0xL1Result")}
-				h.interop.verifyFn = func(ts uint64, l1Head eth.BlockID, blocks map[eth.ChainID]eth.BlockID) (Result, error) {
-					return Result{Timestamp: ts, L1Head: expectedL1Head, L2Heads: blocks}, nil
+				expectedL1Inclusion := eth.BlockID{Number: 150, Hash: common.HexToHash("0xL1Result")}
+				h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID) (Result, error) {
+					return Result{Timestamp: ts, L1Inclusion: expectedL1Inclusion, L2Heads: blocks}, nil
 				}
 
 				madeProgress, err := h.interop.progressAndRecord()
 				require.NoError(t, err)
 				require.True(t, madeProgress, "valid result should advance verified timestamp")
 
-				require.Equal(t, expectedL1Head.Number, h.interop.currentL1.Number)
-				require.Equal(t, expectedL1Head.Hash, h.interop.currentL1.Hash)
+				require.Equal(t, expectedL1Inclusion.Number, h.interop.currentL1.Number)
+				require.Equal(t, expectedL1Inclusion.Hash, h.interop.currentL1.Hash)
 			},
 		},
 		{
@@ -886,10 +877,10 @@ func TestProgressAndRecord(t *testing.T) {
 				initialL1 := eth.BlockID{Number: 50, Hash: common.HexToHash("0x50")}
 				h.interop.currentL1 = initialL1
 
-				h.interop.verifyFn = func(ts uint64, l1Head eth.BlockID, blocks map[eth.ChainID]eth.BlockID) (Result, error) {
+				h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID) (Result, error) {
 					return Result{
 						Timestamp:    ts,
-						L1Head:       eth.BlockID{Number: 999, Hash: common.HexToHash("0xShouldNotBeUsed")},
+						L1Inclusion:  eth.BlockID{Number: 999, Hash: common.HexToHash("0xShouldNotBeUsed")},
 						L2Heads:      blocks,
 						InvalidHeads: map[eth.ChainID]eth.BlockID{mock.id: {Number: 100}},
 					}, nil
@@ -949,8 +940,8 @@ func TestInterop_FullCycle(t *testing.T) {
 	require.False(t, hasBlocks)
 
 	// Stub verifyFn
-	interop.verifyFn = func(ts uint64, l1Head eth.BlockID, blocks map[eth.ChainID]eth.BlockID) (Result, error) {
-		return Result{Timestamp: ts, L1Head: l1Head, L2Heads: blocks}, nil
+	interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID) (Result, error) {
+		return Result{Timestamp: ts, L1Inclusion: eth.BlockID{Number: 100}, L2Heads: blocks}, nil
 	}
 
 	// Run 3 cycles
@@ -959,7 +950,7 @@ func TestInterop_FullCycle(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, uint64(1000), l1.Number)
 
-		result, err := interop.progressInterop(l1)
+		result, err := interop.progressInterop()
 		require.NoError(t, err)
 		require.False(t, result.IsEmpty())
 
@@ -1000,7 +991,7 @@ func TestResult_IsEmpty(t *testing.T) {
 	}{
 		{"zero value", Result{}, true},
 		{"only timestamp", Result{Timestamp: 1000}, true},
-		{"with L1Head", Result{Timestamp: 1000, L1Head: eth.BlockID{Number: 100}}, false},
+		{"with L1Head", Result{Timestamp: 1000, L1Inclusion: eth.BlockID{Number: 100}}, false},
 		{"with L2Heads", Result{Timestamp: 1000, L2Heads: map[eth.ChainID]eth.BlockID{eth.ChainIDFromUInt64(10): {Number: 50}}}, false},
 		{"with InvalidHeads", Result{Timestamp: 1000, InvalidHeads: map[eth.ChainID]eth.BlockID{eth.ChainIDFromUInt64(10): {Number: 50}}}, false},
 	}
@@ -1275,7 +1266,7 @@ func TestReset(t *testing.T) {
 				for ts := uint64(98); ts <= 102; ts++ {
 					err := h.interop.verifiedDB.Commit(VerifiedResult{
 						Timestamp: ts,
-						L1Head:    eth.BlockID{Number: ts},
+						L1Inclusion:    eth.BlockID{Number: ts},
 						L2Heads:   map[eth.ChainID]eth.BlockID{mock.id: {Number: ts}},
 					})
 					require.NoError(t, err)

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -1052,6 +1052,11 @@ type mockChainContainer struct {
 	invalidateBlockCalls []invalidateBlockCall
 	invalidateBlockRet   bool
 	invalidateBlockErr   error
+
+	// OptimisticAt fields
+	optimisticL2    eth.BlockID
+	optimisticL1    eth.BlockID
+	optimisticAtErr error
 }
 
 type invalidateBlockCall struct {
@@ -1090,7 +1095,12 @@ func (m *mockChainContainer) L1ForL2(ctx context.Context, l2Block eth.BlockID) (
 	return eth.BlockID{}, nil
 }
 func (m *mockChainContainer) OptimisticAt(ctx context.Context, ts uint64) (eth.BlockID, eth.BlockID, error) {
-	return eth.BlockID{}, eth.BlockID{}, nil
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.optimisticAtErr != nil {
+		return eth.BlockID{}, eth.BlockID{}, m.optimisticAtErr
+	}
+	return m.optimisticL2, m.optimisticL1, nil
 }
 func (m *mockChainContainer) OutputRootAtL2BlockNumber(ctx context.Context, l2BlockNum uint64) (eth.Bytes32, error) {
 	return eth.Bytes32{}, nil

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -424,14 +424,14 @@ func TestProgressInterop(t *testing.T) {
 	t.Parallel()
 
 	// Default verifyFn that passes through
-	passThroughVerifyFn := func(ts uint64, blocks map[eth.ChainID]eth.BlockID) (Result, error) {
-		return Result{Timestamp: ts, L2Heads: blocks}, nil
+	passThroughVerifyFn := func(ts uint64, l1Head eth.BlockID, blocks map[eth.ChainID]eth.BlockID) (Result, error) {
+		return Result{Timestamp: ts, L1Head: l1Head, L2Heads: blocks}, nil
 	}
 
 	tests := []struct {
 		name     string
 		setup    func(h *interopTestHarness) *interopTestHarness
-		verifyFn func(ts uint64, blocks map[eth.ChainID]eth.BlockID) (Result, error)
+		verifyFn func(ts uint64, l1Head eth.BlockID, blocks map[eth.ChainID]eth.BlockID) (Result, error)
 		assert   func(t *testing.T, result Result, err error)
 		run      func(t *testing.T, h *interopTestHarness) // override for complex cases
 	}{
@@ -459,7 +459,9 @@ func TestProgressInterop(t *testing.T) {
 				h.interop.verifyFn = passThroughVerifyFn
 
 				// First progress
-				result1, err := h.interop.progressInterop()
+				l1Head, err := h.interop.collectCurrentL1()
+				require.NoError(t, err)
+				result1, err := h.interop.progressInterop(l1Head)
 				require.NoError(t, err)
 				require.Equal(t, uint64(1000), result1.Timestamp)
 
@@ -468,7 +470,9 @@ func TestProgressInterop(t *testing.T) {
 				require.NoError(t, err)
 
 				// Second progress should use next timestamp
-				result2, err := h.interop.progressInterop()
+				l1Head, err = h.interop.collectCurrentL1()
+				require.NoError(t, err)
+				result2, err := h.interop.progressInterop(l1Head)
 				require.NoError(t, err)
 				require.Equal(t, uint64(1001), result2.Timestamp)
 			},
@@ -505,7 +509,7 @@ func TestProgressInterop(t *testing.T) {
 					m.blockAtTimestamp = eth.L2BlockRef{Number: 500, Hash: common.HexToHash("0xL2")}
 				}).Build()
 			},
-			verifyFn: func(ts uint64, blocks map[eth.ChainID]eth.BlockID) (Result, error) {
+			verifyFn: func(ts uint64, l1Head eth.BlockID, blocks map[eth.ChainID]eth.BlockID) (Result, error) {
 				return Result{}, errors.New("verification failed")
 			},
 			assert: func(t *testing.T, result Result, err error) {
@@ -527,7 +531,10 @@ func TestProgressInterop(t *testing.T) {
 			if tc.verifyFn != nil {
 				h.interop.verifyFn = tc.verifyFn
 			}
-			result, err := h.interop.progressInterop()
+			// Collect L1 head for progressInterop
+			l1Head, err := h.interop.collectCurrentL1()
+			require.NoError(t, err)
+			result, err := h.interop.progressInterop(l1Head)
 			tc.assert(t, result, err)
 		})
 	}
@@ -583,11 +590,13 @@ func TestVerifiedAtTimestamp(t *testing.T) {
 				}).Build()
 			},
 			run: func(t *testing.T, h *interopTestHarness) {
-				h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID) (Result, error) {
-					return Result{Timestamp: ts, L2Heads: blocks}, nil
+				h.interop.verifyFn = func(ts uint64, l1Head eth.BlockID, blocks map[eth.ChainID]eth.BlockID) (Result, error) {
+					return Result{Timestamp: ts, L1Head: l1Head, L2Heads: blocks}, nil
 				}
 
-				result, err := h.interop.progressInterop()
+				l1Head, err := h.interop.collectCurrentL1()
+				require.NoError(t, err)
+				result, err := h.interop.progressInterop(l1Head)
 				require.NoError(t, err)
 
 				err = h.interop.handleResult(result)
@@ -852,7 +861,7 @@ func TestProgressAndRecord(t *testing.T) {
 			},
 			run: func(t *testing.T, h *interopTestHarness) {
 				expectedL1Head := eth.BlockID{Number: 150, Hash: common.HexToHash("0xL1Result")}
-				h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID) (Result, error) {
+				h.interop.verifyFn = func(ts uint64, l1Head eth.BlockID, blocks map[eth.ChainID]eth.BlockID) (Result, error) {
 					return Result{Timestamp: ts, L1Head: expectedL1Head, L2Heads: blocks}, nil
 				}
 
@@ -877,7 +886,7 @@ func TestProgressAndRecord(t *testing.T) {
 				initialL1 := eth.BlockID{Number: 50, Hash: common.HexToHash("0x50")}
 				h.interop.currentL1 = initialL1
 
-				h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID) (Result, error) {
+				h.interop.verifyFn = func(ts uint64, l1Head eth.BlockID, blocks map[eth.ChainID]eth.BlockID) (Result, error) {
 					return Result{
 						Timestamp:    ts,
 						L1Head:       eth.BlockID{Number: 999, Hash: common.HexToHash("0xShouldNotBeUsed")},
@@ -940,8 +949,8 @@ func TestInterop_FullCycle(t *testing.T) {
 	require.False(t, hasBlocks)
 
 	// Stub verifyFn
-	interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID) (Result, error) {
-		return Result{Timestamp: ts, L2Heads: blocks}, nil
+	interop.verifyFn = func(ts uint64, l1Head eth.BlockID, blocks map[eth.ChainID]eth.BlockID) (Result, error) {
+		return Result{Timestamp: ts, L1Head: l1Head, L2Heads: blocks}, nil
 	}
 
 	// Run 3 cycles
@@ -950,7 +959,7 @@ func TestInterop_FullCycle(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, uint64(1000), l1.Number)
 
-		result, err := interop.progressInterop()
+		result, err := interop.progressInterop(l1)
 		require.NoError(t, err)
 		require.False(t, result.IsEmpty())
 

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -643,8 +643,8 @@ func TestHandleResult(t *testing.T) {
 			run: func(t *testing.T, h *interopTestHarness) {
 				mock := h.Mock(10)
 				validResult := Result{
-					Timestamp: 1000,
-					L1Inclusion:    eth.BlockID{Number: 100, Hash: common.HexToHash("0xL1")},
+					Timestamp:   1000,
+					L1Inclusion: eth.BlockID{Number: 100, Hash: common.HexToHash("0xL1")},
 					L2Heads: map[eth.ChainID]eth.BlockID{
 						mock.id: {Number: 500, Hash: common.HexToHash("0xL2")},
 					},
@@ -672,8 +672,8 @@ func TestHandleResult(t *testing.T) {
 			run: func(t *testing.T, h *interopTestHarness) {
 				mock := h.Mock(10)
 				invalidResult := Result{
-					Timestamp: 1000,
-					L1Inclusion:    eth.BlockID{Number: 100, Hash: common.HexToHash("0xL1")},
+					Timestamp:   1000,
+					L1Inclusion: eth.BlockID{Number: 100, Hash: common.HexToHash("0xL1")},
 					L2Heads: map[eth.ChainID]eth.BlockID{
 						mock.id: {Number: 500, Hash: common.HexToHash("0xL2")},
 					},
@@ -773,8 +773,8 @@ func TestInvalidateBlock(t *testing.T) {
 				mock2 := h.Mock(8453)
 
 				invalidResult := Result{
-					Timestamp: 1000,
-					L1Inclusion:    eth.BlockID{Number: 100, Hash: common.HexToHash("0xL1")},
+					Timestamp:   1000,
+					L1Inclusion: eth.BlockID{Number: 100, Hash: common.HexToHash("0xL1")},
 					L2Heads: map[eth.ChainID]eth.BlockID{
 						mock1.id: {Number: 500, Hash: common.HexToHash("0xL2-1")},
 						mock2.id: {Number: 600, Hash: common.HexToHash("0xL2-2")},
@@ -1265,9 +1265,9 @@ func TestReset(t *testing.T) {
 				// Add some verified results
 				for ts := uint64(98); ts <= 102; ts++ {
 					err := h.interop.verifiedDB.Commit(VerifiedResult{
-						Timestamp: ts,
-						L1Inclusion:    eth.BlockID{Number: ts},
-						L2Heads:   map[eth.ChainID]eth.BlockID{mock.id: {Number: ts}},
+						Timestamp:   ts,
+						L1Inclusion: eth.BlockID{Number: ts},
+						L2Heads:     map[eth.ChainID]eth.BlockID{mock.id: {Number: ts}},
 					})
 					require.NoError(t, err)
 				}

--- a/op-supernode/supernode/activity/interop/types.go
+++ b/op-supernode/supernode/activity/interop/types.go
@@ -5,19 +5,19 @@ import (
 )
 
 // VerifiedResult represents the verified state at a specific timestamp.
-// It contains the L1 head from which the L2 heads were derived,
+// It contains the L1 inclusion block from which the L2 heads were included,
 // and a map of each chain's L2 head at that timestamp.
 type VerifiedResult struct {
-	Timestamp uint64                      `json:"timestamp"`
-	L1Head    eth.BlockID                 `json:"l1Head"`
-	L2Heads   map[eth.ChainID]eth.BlockID `json:"l2Heads"`
+	Timestamp   uint64                      `json:"timestamp"`
+	L1Inclusion eth.BlockID                 `json:"l1Inclusion"`
+	L2Heads     map[eth.ChainID]eth.BlockID `json:"l2Heads"`
 }
 
 // Result represents the result of interop validation at a specific timestamp given current data.
 // it contains all the same information as VerifiedResult, but also contains a list of invalid heads.
 type Result struct {
 	Timestamp    uint64                      `json:"timestamp"`
-	L1Head       eth.BlockID                 `json:"l1Head"`
+	L1Inclusion  eth.BlockID                 `json:"l1Inclusion"`
 	L2Heads      map[eth.ChainID]eth.BlockID `json:"l2Heads"`
 	InvalidHeads map[eth.ChainID]eth.BlockID `json:"invalidHeads"`
 }
@@ -27,13 +27,13 @@ func (r *Result) IsValid() bool {
 }
 
 func (r *Result) IsEmpty() bool {
-	return r.L1Head == (eth.BlockID{}) && len(r.L2Heads) == 0 && len(r.InvalidHeads) == 0
+	return r.L1Inclusion == (eth.BlockID{}) && len(r.L2Heads) == 0 && len(r.InvalidHeads) == 0
 }
 
 func (r *Result) ToVerifiedResult() VerifiedResult {
 	return VerifiedResult{
-		Timestamp: r.Timestamp,
-		L1Head:    r.L1Head,
-		L2Heads:   r.L2Heads,
+		Timestamp:   r.Timestamp,
+		L1Inclusion: r.L1Inclusion,
+		L2Heads:     r.L2Heads,
 	}
 }

--- a/op-supernode/supernode/activity/interop/types_test.go
+++ b/op-supernode/supernode/activity/interop/types_test.go
@@ -14,7 +14,7 @@ func TestResult_IsValid(t *testing.T) {
 	t.Run("returns true when InvalidHeads is nil", func(t *testing.T) {
 		r := Result{
 			Timestamp:    100,
-			L1Inclusion:       eth.BlockID{Number: 1},
+			L1Inclusion:  eth.BlockID{Number: 1},
 			L2Heads:      map[eth.ChainID]eth.BlockID{eth.ChainIDFromUInt64(10): {Number: 100}},
 			InvalidHeads: nil,
 		}
@@ -24,7 +24,7 @@ func TestResult_IsValid(t *testing.T) {
 	t.Run("returns true when InvalidHeads is empty map", func(t *testing.T) {
 		r := Result{
 			Timestamp:    100,
-			L1Inclusion:       eth.BlockID{Number: 1},
+			L1Inclusion:  eth.BlockID{Number: 1},
 			L2Heads:      map[eth.ChainID]eth.BlockID{eth.ChainIDFromUInt64(10): {Number: 100}},
 			InvalidHeads: map[eth.ChainID]eth.BlockID{},
 		}
@@ -33,9 +33,9 @@ func TestResult_IsValid(t *testing.T) {
 
 	t.Run("returns false when InvalidHeads has entries", func(t *testing.T) {
 		r := Result{
-			Timestamp: 100,
-			L1Inclusion:    eth.BlockID{Number: 1},
-			L2Heads:   map[eth.ChainID]eth.BlockID{eth.ChainIDFromUInt64(10): {Number: 100}},
+			Timestamp:   100,
+			L1Inclusion: eth.BlockID{Number: 1},
+			L2Heads:     map[eth.ChainID]eth.BlockID{eth.ChainIDFromUInt64(10): {Number: 100}},
 			InvalidHeads: map[eth.ChainID]eth.BlockID{
 				eth.ChainIDFromUInt64(10): {Number: 100, Hash: common.HexToHash("0xbad")},
 			},
@@ -86,9 +86,9 @@ func TestResult_ToVerifiedResult(t *testing.T) {
 
 	t.Run("handles nil L2Heads", func(t *testing.T) {
 		r := Result{
-			Timestamp: 100,
-			L1Inclusion:    eth.BlockID{Number: 1},
-			L2Heads:   nil,
+			Timestamp:   100,
+			L1Inclusion: eth.BlockID{Number: 1},
+			L2Heads:     nil,
 		}
 
 		verified := r.ToVerifiedResult()
@@ -99,9 +99,9 @@ func TestResult_ToVerifiedResult(t *testing.T) {
 
 	t.Run("handles empty L2Heads", func(t *testing.T) {
 		r := Result{
-			Timestamp: 100,
-			L1Inclusion:    eth.BlockID{Number: 1},
-			L2Heads:   map[eth.ChainID]eth.BlockID{},
+			Timestamp:   100,
+			L1Inclusion: eth.BlockID{Number: 1},
+			L2Heads:     map[eth.ChainID]eth.BlockID{},
 		}
 
 		verified := r.ToVerifiedResult()
@@ -112,8 +112,8 @@ func TestResult_ToVerifiedResult(t *testing.T) {
 	t.Run("original Result unchanged after conversion", func(t *testing.T) {
 		chainID := eth.ChainIDFromUInt64(10)
 		r := Result{
-			Timestamp: 100,
-			L1Inclusion:    eth.BlockID{Number: 1},
+			Timestamp:   100,
+			L1Inclusion: eth.BlockID{Number: 1},
 			L2Heads: map[eth.ChainID]eth.BlockID{
 				chainID: {Number: 200},
 			},

--- a/op-supernode/supernode/activity/interop/types_test.go
+++ b/op-supernode/supernode/activity/interop/types_test.go
@@ -14,7 +14,7 @@ func TestResult_IsValid(t *testing.T) {
 	t.Run("returns true when InvalidHeads is nil", func(t *testing.T) {
 		r := Result{
 			Timestamp:    100,
-			L1Head:       eth.BlockID{Number: 1},
+			L1Inclusion:       eth.BlockID{Number: 1},
 			L2Heads:      map[eth.ChainID]eth.BlockID{eth.ChainIDFromUInt64(10): {Number: 100}},
 			InvalidHeads: nil,
 		}
@@ -24,7 +24,7 @@ func TestResult_IsValid(t *testing.T) {
 	t.Run("returns true when InvalidHeads is empty map", func(t *testing.T) {
 		r := Result{
 			Timestamp:    100,
-			L1Head:       eth.BlockID{Number: 1},
+			L1Inclusion:       eth.BlockID{Number: 1},
 			L2Heads:      map[eth.ChainID]eth.BlockID{eth.ChainIDFromUInt64(10): {Number: 100}},
 			InvalidHeads: map[eth.ChainID]eth.BlockID{},
 		}
@@ -34,7 +34,7 @@ func TestResult_IsValid(t *testing.T) {
 	t.Run("returns false when InvalidHeads has entries", func(t *testing.T) {
 		r := Result{
 			Timestamp: 100,
-			L1Head:    eth.BlockID{Number: 1},
+			L1Inclusion:    eth.BlockID{Number: 1},
 			L2Heads:   map[eth.ChainID]eth.BlockID{eth.ChainIDFromUInt64(10): {Number: 100}},
 			InvalidHeads: map[eth.ChainID]eth.BlockID{
 				eth.ChainIDFromUInt64(10): {Number: 100, Hash: common.HexToHash("0xbad")},
@@ -64,7 +64,7 @@ func TestResult_ToVerifiedResult(t *testing.T) {
 
 		r := Result{
 			Timestamp: 12345,
-			L1Head: eth.BlockID{
+			L1Inclusion: eth.BlockID{
 				Hash:   common.HexToHash("0x1111"),
 				Number: 100,
 			},
@@ -80,14 +80,14 @@ func TestResult_ToVerifiedResult(t *testing.T) {
 		verified := r.ToVerifiedResult()
 
 		require.Equal(t, r.Timestamp, verified.Timestamp)
-		require.Equal(t, r.L1Head, verified.L1Head)
+		require.Equal(t, r.L1Inclusion, verified.L1Inclusion)
 		require.Equal(t, r.L2Heads, verified.L2Heads)
 	})
 
 	t.Run("handles nil L2Heads", func(t *testing.T) {
 		r := Result{
 			Timestamp: 100,
-			L1Head:    eth.BlockID{Number: 1},
+			L1Inclusion:    eth.BlockID{Number: 1},
 			L2Heads:   nil,
 		}
 
@@ -100,7 +100,7 @@ func TestResult_ToVerifiedResult(t *testing.T) {
 	t.Run("handles empty L2Heads", func(t *testing.T) {
 		r := Result{
 			Timestamp: 100,
-			L1Head:    eth.BlockID{Number: 1},
+			L1Inclusion:    eth.BlockID{Number: 1},
 			L2Heads:   map[eth.ChainID]eth.BlockID{},
 		}
 
@@ -113,7 +113,7 @@ func TestResult_ToVerifiedResult(t *testing.T) {
 		chainID := eth.ChainIDFromUInt64(10)
 		r := Result{
 			Timestamp: 100,
-			L1Head:    eth.BlockID{Number: 1},
+			L1Inclusion:    eth.BlockID{Number: 1},
 			L2Heads: map[eth.ChainID]eth.BlockID{
 				chainID: {Number: 200},
 			},

--- a/op-supernode/supernode/activity/interop/verified_db_test.go
+++ b/op-supernode/supernode/activity/interop/verified_db_test.go
@@ -88,33 +88,33 @@ func TestVerifiedDB_SequentialCommits(t *testing.T) {
 
 	// Commit first timestamp
 	err = db.Commit(VerifiedResult{
-		Timestamp: 100,
-		L1Inclusion:    eth.BlockID{Hash: common.HexToHash("0x01"), Number: 1},
-		L2Heads:   map[eth.ChainID]eth.BlockID{chainID: {Hash: common.HexToHash("0x02"), Number: 2}},
+		Timestamp:   100,
+		L1Inclusion: eth.BlockID{Hash: common.HexToHash("0x01"), Number: 1},
+		L2Heads:     map[eth.ChainID]eth.BlockID{chainID: {Hash: common.HexToHash("0x02"), Number: 2}},
 	})
 	require.NoError(t, err)
 
 	// Commit next sequential timestamp should succeed
 	err = db.Commit(VerifiedResult{
-		Timestamp: 101,
-		L1Inclusion:    eth.BlockID{Hash: common.HexToHash("0x03"), Number: 3},
-		L2Heads:   map[eth.ChainID]eth.BlockID{chainID: {Hash: common.HexToHash("0x04"), Number: 4}},
+		Timestamp:   101,
+		L1Inclusion: eth.BlockID{Hash: common.HexToHash("0x03"), Number: 3},
+		L2Heads:     map[eth.ChainID]eth.BlockID{chainID: {Hash: common.HexToHash("0x04"), Number: 4}},
 	})
 	require.NoError(t, err)
 
 	// Try to commit non-sequential timestamp (gap)
 	err = db.Commit(VerifiedResult{
-		Timestamp: 105,
-		L1Inclusion:    eth.BlockID{Hash: common.HexToHash("0x05"), Number: 5},
-		L2Heads:   map[eth.ChainID]eth.BlockID{chainID: {Hash: common.HexToHash("0x06"), Number: 6}},
+		Timestamp:   105,
+		L1Inclusion: eth.BlockID{Hash: common.HexToHash("0x05"), Number: 5},
+		L2Heads:     map[eth.ChainID]eth.BlockID{chainID: {Hash: common.HexToHash("0x06"), Number: 6}},
 	})
 	require.ErrorIs(t, err, ErrNonSequential)
 
 	// Try to commit already committed timestamp
 	err = db.Commit(VerifiedResult{
-		Timestamp: 100,
-		L1Inclusion:    eth.BlockID{Hash: common.HexToHash("0x07"), Number: 7},
-		L2Heads:   map[eth.ChainID]eth.BlockID{chainID: {Hash: common.HexToHash("0x08"), Number: 8}},
+		Timestamp:   100,
+		L1Inclusion: eth.BlockID{Hash: common.HexToHash("0x07"), Number: 7},
+		L2Heads:     map[eth.ChainID]eth.BlockID{chainID: {Hash: common.HexToHash("0x08"), Number: 8}},
 	})
 	require.ErrorIs(t, err, ErrAlreadyCommitted)
 
@@ -132,16 +132,16 @@ func TestVerifiedDB_Persistence(t *testing.T) {
 	require.NoError(t, err)
 
 	err = db.Commit(VerifiedResult{
-		Timestamp: 500,
-		L1Inclusion:    eth.BlockID{Hash: common.HexToHash("0xaaaa"), Number: 50},
-		L2Heads:   map[eth.ChainID]eth.BlockID{chainID: {Hash: common.HexToHash("0xbbbb"), Number: 100}},
+		Timestamp:   500,
+		L1Inclusion: eth.BlockID{Hash: common.HexToHash("0xaaaa"), Number: 50},
+		L2Heads:     map[eth.ChainID]eth.BlockID{chainID: {Hash: common.HexToHash("0xbbbb"), Number: 100}},
 	})
 	require.NoError(t, err)
 
 	err = db.Commit(VerifiedResult{
-		Timestamp: 501,
-		L1Inclusion:    eth.BlockID{Hash: common.HexToHash("0xcccc"), Number: 51},
-		L2Heads:   map[eth.ChainID]eth.BlockID{chainID: {Hash: common.HexToHash("0xdddd"), Number: 101}},
+		Timestamp:   501,
+		L1Inclusion: eth.BlockID{Hash: common.HexToHash("0xcccc"), Number: 51},
+		L2Heads:     map[eth.ChainID]eth.BlockID{chainID: {Hash: common.HexToHash("0xdddd"), Number: 101}},
 	})
 	require.NoError(t, err)
 
@@ -169,9 +169,9 @@ func TestVerifiedDB_Persistence(t *testing.T) {
 
 	// Next commit should continue from last timestamp
 	err = db2.Commit(VerifiedResult{
-		Timestamp: 502,
-		L1Inclusion:    eth.BlockID{Hash: common.HexToHash("0xeeee"), Number: 52},
-		L2Heads:   map[eth.ChainID]eth.BlockID{chainID: {Hash: common.HexToHash("0xffff"), Number: 102}},
+		Timestamp:   502,
+		L1Inclusion: eth.BlockID{Hash: common.HexToHash("0xeeee"), Number: 52},
+		L2Heads:     map[eth.ChainID]eth.BlockID{chainID: {Hash: common.HexToHash("0xffff"), Number: 102}},
 	})
 	require.NoError(t, err)
 }
@@ -192,9 +192,9 @@ func TestVerifiedDB_RewindTo(t *testing.T) {
 		// Commit several timestamps
 		for ts := uint64(100); ts <= 105; ts++ {
 			err = db.Commit(VerifiedResult{
-				Timestamp: ts,
-				L1Inclusion:    eth.BlockID{Hash: common.BytesToHash([]byte{byte(ts)}), Number: ts},
-				L2Heads:   map[eth.ChainID]eth.BlockID{chainID: {Hash: common.BytesToHash([]byte{byte(ts + 100)}), Number: ts}},
+				Timestamp:   ts,
+				L1Inclusion: eth.BlockID{Hash: common.BytesToHash([]byte{byte(ts)}), Number: ts},
+				L2Heads:     map[eth.ChainID]eth.BlockID{chainID: {Hash: common.BytesToHash([]byte{byte(ts + 100)}), Number: ts}},
 			})
 			require.NoError(t, err)
 		}
@@ -240,9 +240,9 @@ func TestVerifiedDB_RewindTo(t *testing.T) {
 		// Commit up to timestamp 100
 		for ts := uint64(98); ts <= 100; ts++ {
 			err = db.Commit(VerifiedResult{
-				Timestamp: ts,
-				L1Inclusion:    eth.BlockID{Hash: common.BytesToHash([]byte{byte(ts)}), Number: ts},
-				L2Heads:   map[eth.ChainID]eth.BlockID{chainID: {Hash: common.BytesToHash([]byte{byte(ts + 100)}), Number: ts}},
+				Timestamp:   ts,
+				L1Inclusion: eth.BlockID{Hash: common.BytesToHash([]byte{byte(ts)}), Number: ts},
+				L2Heads:     map[eth.ChainID]eth.BlockID{chainID: {Hash: common.BytesToHash([]byte{byte(ts + 100)}), Number: ts}},
 			})
 			require.NoError(t, err)
 		}
@@ -270,9 +270,9 @@ func TestVerifiedDB_RewindTo(t *testing.T) {
 		// Commit a few entries
 		for ts := uint64(100); ts <= 102; ts++ {
 			err = db.Commit(VerifiedResult{
-				Timestamp: ts,
-				L1Inclusion:    eth.BlockID{Hash: common.BytesToHash([]byte{byte(ts)}), Number: ts},
-				L2Heads:   map[eth.ChainID]eth.BlockID{chainID: {Hash: common.BytesToHash([]byte{byte(ts + 100)}), Number: ts}},
+				Timestamp:   ts,
+				L1Inclusion: eth.BlockID{Hash: common.BytesToHash([]byte{byte(ts)}), Number: ts},
+				L2Heads:     map[eth.ChainID]eth.BlockID{chainID: {Hash: common.BytesToHash([]byte{byte(ts + 100)}), Number: ts}},
 			})
 			require.NoError(t, err)
 		}
@@ -307,9 +307,9 @@ func TestVerifiedDB_RewindTo(t *testing.T) {
 		// Commit 100-105
 		for ts := uint64(100); ts <= 105; ts++ {
 			err = db.Commit(VerifiedResult{
-				Timestamp: ts,
-				L1Inclusion:    eth.BlockID{Hash: common.BytesToHash([]byte{byte(ts)}), Number: ts},
-				L2Heads:   map[eth.ChainID]eth.BlockID{chainID: {Hash: common.BytesToHash([]byte{byte(ts + 100)}), Number: ts}},
+				Timestamp:   ts,
+				L1Inclusion: eth.BlockID{Hash: common.BytesToHash([]byte{byte(ts)}), Number: ts},
+				L2Heads:     map[eth.ChainID]eth.BlockID{chainID: {Hash: common.BytesToHash([]byte{byte(ts + 100)}), Number: ts}},
 			})
 			require.NoError(t, err)
 		}
@@ -320,9 +320,9 @@ func TestVerifiedDB_RewindTo(t *testing.T) {
 
 		// Should be able to commit 103 again (sequential from 102)
 		err = db.Commit(VerifiedResult{
-			Timestamp: 103,
-			L1Inclusion:    eth.BlockID{Hash: common.HexToHash("0xNEW"), Number: 103},
-			L2Heads:   map[eth.ChainID]eth.BlockID{chainID: {Hash: common.HexToHash("0xNEW2"), Number: 103}},
+			Timestamp:   103,
+			L1Inclusion: eth.BlockID{Hash: common.HexToHash("0xNEW"), Number: 103},
+			L2Heads:     map[eth.ChainID]eth.BlockID{chainID: {Hash: common.HexToHash("0xNEW2"), Number: 103}},
 		})
 		require.NoError(t, err)
 

--- a/op-supernode/supernode/activity/interop/verified_db_test.go
+++ b/op-supernode/supernode/activity/interop/verified_db_test.go
@@ -28,7 +28,7 @@ func TestVerifiedDB_WriteAndRead(t *testing.T) {
 
 	result1 := VerifiedResult{
 		Timestamp: 1000,
-		L1Head: eth.BlockID{
+		L1Inclusion: eth.BlockID{
 			Hash:   common.HexToHash("0x1111111111111111111111111111111111111111111111111111111111111111"),
 			Number: 100,
 		},
@@ -57,7 +57,7 @@ func TestVerifiedDB_WriteAndRead(t *testing.T) {
 	retrieved, err := db.Get(1000)
 	require.NoError(t, err)
 	require.Equal(t, result1.Timestamp, retrieved.Timestamp)
-	require.Equal(t, result1.L1Head, retrieved.L1Head)
+	require.Equal(t, result1.L1Inclusion, retrieved.L1Inclusion)
 	require.Equal(t, len(result1.L2Heads), len(retrieved.L2Heads))
 	require.Equal(t, result1.L2Heads[chainID1], retrieved.L2Heads[chainID1])
 	require.Equal(t, result1.L2Heads[chainID2], retrieved.L2Heads[chainID2])
@@ -89,7 +89,7 @@ func TestVerifiedDB_SequentialCommits(t *testing.T) {
 	// Commit first timestamp
 	err = db.Commit(VerifiedResult{
 		Timestamp: 100,
-		L1Head:    eth.BlockID{Hash: common.HexToHash("0x01"), Number: 1},
+		L1Inclusion:    eth.BlockID{Hash: common.HexToHash("0x01"), Number: 1},
 		L2Heads:   map[eth.ChainID]eth.BlockID{chainID: {Hash: common.HexToHash("0x02"), Number: 2}},
 	})
 	require.NoError(t, err)
@@ -97,7 +97,7 @@ func TestVerifiedDB_SequentialCommits(t *testing.T) {
 	// Commit next sequential timestamp should succeed
 	err = db.Commit(VerifiedResult{
 		Timestamp: 101,
-		L1Head:    eth.BlockID{Hash: common.HexToHash("0x03"), Number: 3},
+		L1Inclusion:    eth.BlockID{Hash: common.HexToHash("0x03"), Number: 3},
 		L2Heads:   map[eth.ChainID]eth.BlockID{chainID: {Hash: common.HexToHash("0x04"), Number: 4}},
 	})
 	require.NoError(t, err)
@@ -105,7 +105,7 @@ func TestVerifiedDB_SequentialCommits(t *testing.T) {
 	// Try to commit non-sequential timestamp (gap)
 	err = db.Commit(VerifiedResult{
 		Timestamp: 105,
-		L1Head:    eth.BlockID{Hash: common.HexToHash("0x05"), Number: 5},
+		L1Inclusion:    eth.BlockID{Hash: common.HexToHash("0x05"), Number: 5},
 		L2Heads:   map[eth.ChainID]eth.BlockID{chainID: {Hash: common.HexToHash("0x06"), Number: 6}},
 	})
 	require.ErrorIs(t, err, ErrNonSequential)
@@ -113,7 +113,7 @@ func TestVerifiedDB_SequentialCommits(t *testing.T) {
 	// Try to commit already committed timestamp
 	err = db.Commit(VerifiedResult{
 		Timestamp: 100,
-		L1Head:    eth.BlockID{Hash: common.HexToHash("0x07"), Number: 7},
+		L1Inclusion:    eth.BlockID{Hash: common.HexToHash("0x07"), Number: 7},
 		L2Heads:   map[eth.ChainID]eth.BlockID{chainID: {Hash: common.HexToHash("0x08"), Number: 8}},
 	})
 	require.ErrorIs(t, err, ErrAlreadyCommitted)
@@ -133,14 +133,14 @@ func TestVerifiedDB_Persistence(t *testing.T) {
 
 	err = db.Commit(VerifiedResult{
 		Timestamp: 500,
-		L1Head:    eth.BlockID{Hash: common.HexToHash("0xaaaa"), Number: 50},
+		L1Inclusion:    eth.BlockID{Hash: common.HexToHash("0xaaaa"), Number: 50},
 		L2Heads:   map[eth.ChainID]eth.BlockID{chainID: {Hash: common.HexToHash("0xbbbb"), Number: 100}},
 	})
 	require.NoError(t, err)
 
 	err = db.Commit(VerifiedResult{
 		Timestamp: 501,
-		L1Head:    eth.BlockID{Hash: common.HexToHash("0xcccc"), Number: 51},
+		L1Inclusion:    eth.BlockID{Hash: common.HexToHash("0xcccc"), Number: 51},
 		L2Heads:   map[eth.ChainID]eth.BlockID{chainID: {Hash: common.HexToHash("0xdddd"), Number: 101}},
 	})
 	require.NoError(t, err)
@@ -161,7 +161,7 @@ func TestVerifiedDB_Persistence(t *testing.T) {
 	result, err := db2.Get(500)
 	require.NoError(t, err)
 	require.Equal(t, uint64(500), result.Timestamp)
-	require.Equal(t, common.HexToHash("0xaaaa"), result.L1Head.Hash)
+	require.Equal(t, common.HexToHash("0xaaaa"), result.L1Inclusion.Hash)
 
 	result, err = db2.Get(501)
 	require.NoError(t, err)
@@ -170,7 +170,7 @@ func TestVerifiedDB_Persistence(t *testing.T) {
 	// Next commit should continue from last timestamp
 	err = db2.Commit(VerifiedResult{
 		Timestamp: 502,
-		L1Head:    eth.BlockID{Hash: common.HexToHash("0xeeee"), Number: 52},
+		L1Inclusion:    eth.BlockID{Hash: common.HexToHash("0xeeee"), Number: 52},
 		L2Heads:   map[eth.ChainID]eth.BlockID{chainID: {Hash: common.HexToHash("0xffff"), Number: 102}},
 	})
 	require.NoError(t, err)
@@ -193,7 +193,7 @@ func TestVerifiedDB_RewindTo(t *testing.T) {
 		for ts := uint64(100); ts <= 105; ts++ {
 			err = db.Commit(VerifiedResult{
 				Timestamp: ts,
-				L1Head:    eth.BlockID{Hash: common.BytesToHash([]byte{byte(ts)}), Number: ts},
+				L1Inclusion:    eth.BlockID{Hash: common.BytesToHash([]byte{byte(ts)}), Number: ts},
 				L2Heads:   map[eth.ChainID]eth.BlockID{chainID: {Hash: common.BytesToHash([]byte{byte(ts + 100)}), Number: ts}},
 			})
 			require.NoError(t, err)
@@ -241,7 +241,7 @@ func TestVerifiedDB_RewindTo(t *testing.T) {
 		for ts := uint64(98); ts <= 100; ts++ {
 			err = db.Commit(VerifiedResult{
 				Timestamp: ts,
-				L1Head:    eth.BlockID{Hash: common.BytesToHash([]byte{byte(ts)}), Number: ts},
+				L1Inclusion:    eth.BlockID{Hash: common.BytesToHash([]byte{byte(ts)}), Number: ts},
 				L2Heads:   map[eth.ChainID]eth.BlockID{chainID: {Hash: common.BytesToHash([]byte{byte(ts + 100)}), Number: ts}},
 			})
 			require.NoError(t, err)
@@ -271,7 +271,7 @@ func TestVerifiedDB_RewindTo(t *testing.T) {
 		for ts := uint64(100); ts <= 102; ts++ {
 			err = db.Commit(VerifiedResult{
 				Timestamp: ts,
-				L1Head:    eth.BlockID{Hash: common.BytesToHash([]byte{byte(ts)}), Number: ts},
+				L1Inclusion:    eth.BlockID{Hash: common.BytesToHash([]byte{byte(ts)}), Number: ts},
 				L2Heads:   map[eth.ChainID]eth.BlockID{chainID: {Hash: common.BytesToHash([]byte{byte(ts + 100)}), Number: ts}},
 			})
 			require.NoError(t, err)
@@ -308,7 +308,7 @@ func TestVerifiedDB_RewindTo(t *testing.T) {
 		for ts := uint64(100); ts <= 105; ts++ {
 			err = db.Commit(VerifiedResult{
 				Timestamp: ts,
-				L1Head:    eth.BlockID{Hash: common.BytesToHash([]byte{byte(ts)}), Number: ts},
+				L1Inclusion:    eth.BlockID{Hash: common.BytesToHash([]byte{byte(ts)}), Number: ts},
 				L2Heads:   map[eth.ChainID]eth.BlockID{chainID: {Hash: common.BytesToHash([]byte{byte(ts + 100)}), Number: ts}},
 			})
 			require.NoError(t, err)
@@ -321,7 +321,7 @@ func TestVerifiedDB_RewindTo(t *testing.T) {
 		// Should be able to commit 103 again (sequential from 102)
 		err = db.Commit(VerifiedResult{
 			Timestamp: 103,
-			L1Head:    eth.BlockID{Hash: common.HexToHash("0xNEW"), Number: 103},
+			L1Inclusion:    eth.BlockID{Hash: common.HexToHash("0xNEW"), Number: 103},
 			L2Heads:   map[eth.ChainID]eth.BlockID{chainID: {Hash: common.HexToHash("0xNEW2"), Number: 103}},
 		})
 		require.NoError(t, err)
@@ -329,6 +329,6 @@ func TestVerifiedDB_RewindTo(t *testing.T) {
 		// Verify new data
 		result, err := db.Get(103)
 		require.NoError(t, err)
-		require.Equal(t, common.HexToHash("0xNEW"), result.L1Head.Hash)
+		require.Equal(t, common.HexToHash("0xNEW"), result.L1Inclusion.Hash)
 	})
 }

--- a/op-supernode/supernode/chain_container/chain_container.go
+++ b/op-supernode/supernode/chain_container/chain_container.go
@@ -315,7 +315,7 @@ func (c *simpleChainContainer) LocalSafeBlockAtTimestamp(ctx context.Context, ts
 	}
 	head := ss.LocalSafeL2
 	if num > head.Number {
-		c.log.Warn("target block number exceeds local safe head", "targetBlockNumber", num, "head", head.Number)
+		c.log.Debug("target block number exceeds local safe head", "targetBlockNumber", num, "head", head.Number)
 		return eth.L2BlockRef{}, ethereum.NotFound
 	}
 

--- a/op-supernode/supernode/chain_container/chain_container_test.go
+++ b/op-supernode/supernode/chain_container/chain_container_test.go
@@ -98,7 +98,7 @@ func (m *mockVirtualNode) SafeHeadAtL1(ctx context.Context, l1BlockNum uint64) (
 }
 
 // L1AtSafeHead implements virtual_node.VirtualNode L1AtSafeHead
-func (m mockVirtualNode) L1AtSafeHead(ctx context.Context, target eth.BlockID) (eth.BlockID, error) {
+func (m *mockVirtualNode) L1AtSafeHead(ctx context.Context, target eth.BlockID) (eth.BlockID, error) {
 	return m.safeHeadL1, m.safeHeadErr
 }
 

--- a/op-supernode/supernode/chain_container/chain_container_test.go
+++ b/op-supernode/supernode/chain_container/chain_container_test.go
@@ -98,7 +98,7 @@ func (m *mockVirtualNode) SafeHeadAtL1(ctx context.Context, l1BlockNum uint64) (
 }
 
 // L1AtSafeHead implements virtual_node.VirtualNode L1AtSafeHead
-func (m *mockVirtualNode) L1AtSafeHead(ctx context.Context, target eth.BlockID) (eth.BlockID, error) {
+func (m mockVirtualNode) L1AtSafeHead(ctx context.Context, target eth.BlockID) (eth.BlockID, error) {
 	return m.safeHeadL1, m.safeHeadErr
 }
 
@@ -113,6 +113,7 @@ func (m *mockVirtualNode) SyncStatus(ctx context.Context) (*eth.SyncStatus, erro
 		return nil, m.safeHeadErr
 	}
 	return &eth.SyncStatus{
+		FinalizedL1: eth.L1BlockRef{},
 		CurrentL1:   eth.L1BlockRef{Hash: m.safeHeadL1.Hash, Number: m.safeHeadL1.Number},
 		LocalSafeL2: eth.L2BlockRef{Hash: m.safeHeadL2.Hash, Number: m.safeHeadL2.Number},
 	}, nil
@@ -177,7 +178,7 @@ func (m *mockVerificationActivity) LatestVerifiedL2Block(chainID eth.ChainID) (e
 }
 func (m *mockVerificationActivity) Reset(chainID eth.ChainID, timestamp uint64, invalidatedBlock eth.BlockRef) {
 }
-func (m *mockVerificationActivity) LatestFinalizedL2Block(chainID eth.ChainID) (eth.BlockID, uint64) {
+func (m *mockVerificationActivity) VerifiedBlockAtL1(chainID eth.ChainID, l1BlockRef eth.L1BlockRef) (eth.BlockID, uint64) {
 	return eth.BlockID{}, 0
 }
 

--- a/op-supernode/supernode/chain_container/chain_container_test.go
+++ b/op-supernode/supernode/chain_container/chain_container_test.go
@@ -177,6 +177,9 @@ func (m *mockVerificationActivity) LatestVerifiedL2Block(chainID eth.ChainID) (e
 }
 func (m *mockVerificationActivity) Reset(chainID eth.ChainID, timestamp uint64, invalidatedBlock eth.BlockRef) {
 }
+func (m *mockVerificationActivity) LatestFinalizedL2Block(chainID eth.ChainID) (eth.BlockID, uint64) {
+	return eth.BlockID{}, 0
+}
 
 // Test helpers
 func createTestVNConfig() *opnodecfg.Config {

--- a/op-supernode/supernode/chain_container/super_authority.go
+++ b/op-supernode/supernode/chain_container/super_authority.go
@@ -44,8 +44,21 @@ func (c *simpleChainContainer) FullyVerifiedL2Head() (eth.BlockID, bool) {
 }
 
 func (c *simpleChainContainer) FinalizedL2Head() eth.BlockID {
-	// TODO
-	return eth.BlockID{}
+	timestamp := uint64(math.MaxUint64)
+	oldestFinalizedBlock := eth.BlockID{}
+	for _, v := range c.verifiers {
+		bId, ts := v.LatestFinalizedL2Block(c.chainID)
+		if (bId == eth.BlockID{} || ts == 0) {
+			return bId
+		}
+		if ts < timestamp {
+			timestamp = ts
+			oldestFinalizedBlock = bId
+		} else if ts == timestamp && bId != oldestFinalizedBlock {
+			panic("verifiers disagree on block hash for same timestamp")
+		}
+	}
+	return oldestFinalizedBlock
 }
 
 // IsDenied checks if a block hash is on the deny list at the given height.

--- a/op-supernode/supernode/chain_container/super_authority.go
+++ b/op-supernode/supernode/chain_container/super_authority.go
@@ -43,13 +43,27 @@ func (c *simpleChainContainer) FullyVerifiedL2Head() (eth.BlockID, bool) {
 	return oldestVerifiedBlock, false
 }
 
-func (c *simpleChainContainer) FinalizedL2Head() eth.BlockID {
+// FinalizedL2Head returns the finalized L2 head block identifier.
+// The second return value indicates whether the caller should fall back to local-finalized.
+// Returns (empty, true) only when no verifiers are registered.
+// Returns (empty, false) when verifiers are registered but haven't finalized anything yet.
+// Panics if verifiers disagree on the block hash for the same timestamp.
+func (c *simpleChainContainer) FinalizedL2Head() (eth.BlockID, bool) {
+	// If no verifiers registered, signal fallback to local-finalized
+	if len(c.verifiers) == 0 {
+		c.log.Debug("FinalizedL2Head: no verifiers registered, signaling local-finalized fallback")
+		return eth.BlockID{}, true
+	}
+
 	timestamp := uint64(math.MaxUint64)
 	oldestFinalizedBlock := eth.BlockID{}
 	for _, v := range c.verifiers {
 		bId, ts := v.LatestFinalizedL2Block(c.chainID)
+		// If any verifier returns empty, return empty but don't signal fallback
+		// The verifier exists but hasn't finalized anything yet
 		if (bId == eth.BlockID{} || ts == 0) {
-			return bId
+			c.log.Debug("FinalizedL2Head: verifier returned empty, returning empty without fallback", "verifier", v.Name())
+			return eth.BlockID{}, false
 		}
 		if ts < timestamp {
 			timestamp = ts
@@ -58,7 +72,9 @@ func (c *simpleChainContainer) FinalizedL2Head() eth.BlockID {
 			panic("verifiers disagree on block hash for same timestamp")
 		}
 	}
-	return oldestFinalizedBlock
+
+	c.log.Debug("FinalizedL2Head: returning finalized block", "block", oldestFinalizedBlock, "timestamp", timestamp)
+	return oldestFinalizedBlock, false
 }
 
 // IsDenied checks if a block hash is on the deny list at the given height.

--- a/op-supernode/supernode/chain_container/super_authority.go
+++ b/op-supernode/supernode/chain_container/super_authority.go
@@ -1,6 +1,7 @@
 package chain_container
 
 import (
+	"context"
 	"fmt"
 	"math"
 
@@ -55,10 +56,15 @@ func (c *simpleChainContainer) FinalizedL2Head() (eth.BlockID, bool) {
 		return eth.BlockID{}, true
 	}
 
+	ss, err := c.vn.SyncStatus(context.Background())
+	if err != nil {
+		c.log.Error("FinalizedL2Head: failed to get sync status", "err", err)
+		return eth.BlockID{}, true
+	}
 	timestamp := uint64(math.MaxUint64)
 	oldestFinalizedBlock := eth.BlockID{}
 	for _, v := range c.verifiers {
-		bId, ts := v.LatestFinalizedL2Block(c.chainID)
+		bId, ts := v.VerifiedBlockAtL1(c.chainID, ss.FinalizedL1)
 		// If any verifier returns empty, return empty but don't signal fallback
 		// The verifier exists but hasn't finalized anything yet
 		if (bId == eth.BlockID{} || ts == 0) {

--- a/op-supernode/supernode/chain_container/super_authority.go
+++ b/op-supernode/supernode/chain_container/super_authority.go
@@ -43,6 +43,11 @@ func (c *simpleChainContainer) FullyVerifiedL2Head() (eth.BlockID, bool) {
 	return oldestVerifiedBlock, false
 }
 
+func (c *simpleChainContainer) FinalizedL2Head() eth.BlockID {
+	// TODO
+	return eth.BlockID{}
+}
+
 // IsDenied checks if a block hash is on the deny list at the given height.
 func (c *simpleChainContainer) IsDenied(height uint64, payloadHash common.Hash) (bool, error) {
 	if c.denyList == nil {

--- a/op-supernode/supernode/chain_container/super_authority_test.go
+++ b/op-supernode/supernode/chain_container/super_authority_test.go
@@ -13,8 +13,10 @@ import (
 
 // mockVerificationActivityForSuperAuthority provides controlled test data for SuperAuthority tests
 type mockVerificationActivityForSuperAuthority struct {
-	latestVerifiedBlock eth.BlockID
-	latestVerifiedTS    uint64
+	latestVerifiedBlock  eth.BlockID
+	latestVerifiedTS     uint64
+	latestFinalizedBlock eth.BlockID
+	latestFinalizedTS    uint64
 }
 
 func (m *mockVerificationActivityForSuperAuthority) Start(ctx context.Context) error { return nil }
@@ -31,7 +33,7 @@ func (m *mockVerificationActivityForSuperAuthority) LatestVerifiedL2Block(chainI
 }
 func (m *mockVerificationActivityForSuperAuthority) Reset(eth.ChainID, uint64, eth.BlockRef) {}
 func (m *mockVerificationActivityForSuperAuthority) LatestFinalizedL2Block(chainID eth.ChainID) (eth.BlockID, uint64) {
-	return eth.BlockID{}, 0
+	return m.latestFinalizedBlock, m.latestFinalizedTS
 }
 
 var _ activity.VerificationActivity = (*mockVerificationActivityForSuperAuthority)(nil)
@@ -187,4 +189,122 @@ func TestChainContainer_FullyVerifiedL2Head_AllUnverified(t *testing.T) {
 	result, useLocalSafe := cc.FullyVerifiedL2Head()
 	require.Equal(t, eth.BlockID{}, result, "should return empty BlockID when all verifiers are unverified")
 	require.False(t, useLocalSafe, "should not signal fallback when verifiers exist but are unverified")
+}
+
+// TestChainContainer_FinalizedL2Head_MultipleVerifiers tests that FinalizedL2Head
+// returns the block with the minimum (oldest) timestamp across all verifiers
+func TestChainContainer_FinalizedL2Head_MultipleVerifiers(t *testing.T) {
+	t.Parallel()
+
+	chainID := eth.ChainIDFromUInt64(420)
+	cc := newTestChainContainer(t, chainID)
+
+	// Setup three verifiers with different timestamps
+	verifier1 := &mockVerificationActivityForSuperAuthority{
+		latestFinalizedBlock: eth.BlockID{Hash: [32]byte{1}, Number: 100},
+		latestFinalizedTS:    1000, // oldest
+	}
+	verifier2 := &mockVerificationActivityForSuperAuthority{
+		latestFinalizedBlock: eth.BlockID{Hash: [32]byte{2}, Number: 200},
+		latestFinalizedTS:    2000, // middle
+	}
+	verifier3 := &mockVerificationActivityForSuperAuthority{
+		latestFinalizedBlock: eth.BlockID{Hash: [32]byte{3}, Number: 300},
+		latestFinalizedTS:    3000, // newest
+	}
+
+	cc.verifiers = []activity.VerificationActivity{verifier1, verifier2, verifier3}
+
+	// Should return the block with minimum timestamp (verifier1)
+	result, useLocalFinalized := cc.FinalizedL2Head()
+	require.Equal(t, verifier1.latestFinalizedBlock, result, "should return oldest finalized block")
+	require.False(t, useLocalFinalized, "should not signal fallback when verifiers have finalized blocks")
+}
+
+// TestChainContainer_FinalizedL2Head_NoVerifiers tests that FinalizedL2Head
+// returns an empty BlockID and signals fallback when there are no verification activities
+func TestChainContainer_FinalizedL2Head_NoVerifiers(t *testing.T) {
+	t.Parallel()
+
+	chainID := eth.ChainIDFromUInt64(420)
+	cc := newTestChainContainer(t, chainID)
+
+	result, useLocalFinalized := cc.FinalizedL2Head()
+	require.Equal(t, eth.BlockID{}, result, "should return empty BlockID with no verifiers")
+	require.True(t, useLocalFinalized, "should signal fallback to local-finalized when no verifiers registered")
+}
+
+// TestChainContainer_FinalizedL2Head_OneUnfinalized tests that FinalizedL2Head
+// returns an empty BlockID without signaling fallback if any verifier returns an unfinalized state
+func TestChainContainer_FinalizedL2Head_OneUnfinalized(t *testing.T) {
+	t.Parallel()
+
+	chainID := eth.ChainIDFromUInt64(420)
+	cc := newTestChainContainer(t, chainID)
+
+	// Setup verifiers where one is unfinalized (empty BlockID)
+	verifier1 := &mockVerificationActivityForSuperAuthority{
+		latestFinalizedBlock: eth.BlockID{Hash: [32]byte{1}, Number: 100},
+		latestFinalizedTS:    1000,
+	}
+	verifier2 := &mockVerificationActivityForSuperAuthority{
+		latestFinalizedBlock: eth.BlockID{}, // unfinalized
+		latestFinalizedTS:    0,             // zero timestamp
+	}
+	verifier3 := &mockVerificationActivityForSuperAuthority{
+		latestFinalizedBlock: eth.BlockID{Hash: [32]byte{3}, Number: 300},
+		latestFinalizedTS:    3000,
+	}
+
+	cc.verifiers = []activity.VerificationActivity{verifier1, verifier2, verifier3}
+
+	// Should return empty BlockID (conservative approach) but NOT signal fallback
+	result, useLocalFinalized := cc.FinalizedL2Head()
+	require.Equal(t, eth.BlockID{}, result, "should return empty BlockID when any verifier is unfinalized")
+	require.False(t, useLocalFinalized, "should not signal fallback when verifiers exist but are unfinalized")
+}
+
+// TestChainContainer_FinalizedL2Head_SingleVerifier tests the simple case
+// with just one verification activity
+func TestChainContainer_FinalizedL2Head_SingleVerifier(t *testing.T) {
+	t.Parallel()
+
+	chainID := eth.ChainIDFromUInt64(420)
+	cc := newTestChainContainer(t, chainID)
+
+	verifier := &mockVerificationActivityForSuperAuthority{
+		latestFinalizedBlock: eth.BlockID{Hash: [32]byte{1}, Number: 100},
+		latestFinalizedTS:    1000,
+	}
+
+	cc.verifiers = []activity.VerificationActivity{verifier}
+
+	result, useLocalFinalized := cc.FinalizedL2Head()
+	require.Equal(t, verifier.latestFinalizedBlock, result, "should return the single verifier's block")
+	require.False(t, useLocalFinalized, "should not signal fallback when verifier has finalized blocks")
+}
+
+// TestChainContainer_FinalizedL2Head_AllUnfinalized tests that an empty BlockID
+// is returned without signaling fallback when all verifiers are unfinalized
+func TestChainContainer_FinalizedL2Head_AllUnfinalized(t *testing.T) {
+	t.Parallel()
+
+	chainID := eth.ChainIDFromUInt64(420)
+	cc := newTestChainContainer(t, chainID)
+
+	// All verifiers unfinalized
+	verifier1 := &mockVerificationActivityForSuperAuthority{
+		latestFinalizedBlock: eth.BlockID{},
+		latestFinalizedTS:    0,
+	}
+	verifier2 := &mockVerificationActivityForSuperAuthority{
+		latestFinalizedBlock: eth.BlockID{},
+		latestFinalizedTS:    0,
+	}
+
+	cc.verifiers = []activity.VerificationActivity{verifier1, verifier2}
+
+	result, useLocalFinalized := cc.FinalizedL2Head()
+	require.Equal(t, eth.BlockID{}, result, "should return empty BlockID when all verifiers are unfinalized")
+	require.False(t, useLocalFinalized, "should not signal fallback when verifiers exist but are unfinalized")
 }

--- a/op-supernode/supernode/chain_container/super_authority_test.go
+++ b/op-supernode/supernode/chain_container/super_authority_test.go
@@ -30,6 +30,9 @@ func (m *mockVerificationActivityForSuperAuthority) LatestVerifiedL2Block(chainI
 	return m.latestVerifiedBlock, m.latestVerifiedTS
 }
 func (m *mockVerificationActivityForSuperAuthority) Reset(eth.ChainID, uint64, eth.BlockRef) {}
+func (m *mockVerificationActivityForSuperAuthority) LatestFinalizedL2Block(chainID eth.ChainID) (eth.BlockID, uint64) {
+	return eth.BlockID{}, 0
+}
 
 var _ activity.VerificationActivity = (*mockVerificationActivityForSuperAuthority)(nil)
 

--- a/op-supernode/supernode/chain_container/super_authority_test.go
+++ b/op-supernode/supernode/chain_container/super_authority_test.go
@@ -32,7 +32,7 @@ func (m *mockVerificationActivityForSuperAuthority) LatestVerifiedL2Block(chainI
 	return m.latestVerifiedBlock, m.latestVerifiedTS
 }
 func (m *mockVerificationActivityForSuperAuthority) Reset(eth.ChainID, uint64, eth.BlockRef) {}
-func (m *mockVerificationActivityForSuperAuthority) LatestFinalizedL2Block(chainID eth.ChainID) (eth.BlockID, uint64) {
+func (m *mockVerificationActivityForSuperAuthority) VerifiedBlockAtL1(chainID eth.ChainID, l1BlockRef eth.L1BlockRef) (eth.BlockID, uint64) {
 	return m.latestFinalizedBlock, m.latestFinalizedTS
 }
 
@@ -44,6 +44,7 @@ func newTestChainContainer(t *testing.T, chainID eth.ChainID) *simpleChainContai
 		chainID:   chainID,
 		verifiers: []activity.VerificationActivity{},
 		log:       testlog.Logger(t, log.LevelDebug),
+		vn:        &mockVirtualNode{},
 	}
 }
 


### PR DESCRIPTION
Closes https://github.com/ethereum-optimism/optimism/issues/19188

## op-node
* the engine controller now defers to the `superAuthority` for the `FinalizedL2Head`, following the pattern establshed for the `SafeL2Head` in #19110 
* The engine controller falls back to genesis when no finalized blocks are available yet from the `superAuthority` (also for safe / fully verified head)**
    - This is important to prevent FCU calls being _blocked_ on an initial finalized head existing
    - equally, we cannot rely on the EL being able to provide this block at all times (from empirical experience in tests), so we don't treat it as a critical error if we can't get the genesis block 

## op-supernode
* computes `L1Inclusion` directly in `verifyInteropMessages()` by querying SafeDB for each chain's actual L1 inclusion block. This was missing previously.
* Renamed `L1Head` → `L1Inclusion` throughout the supernode codebase (the L1 block that included the verified L2 blocks)
* Added proper finalized head tracking in the chain container `SuperAuthority` implementation:
  - `FinalizedL2Head()`  checks `L1Inclusion.Number <= finalizedL1.Number` where `finalizedL1` is scraped from the virtual node's syncStatus


Tests:
* Added sanity checks to existing acceptance test (that verify L2 finalized blocks' L1 origins are always ≤ L1 finalized head)
* Test asserts that finalized l2 head eventually progresses
* Enabled time travel in interop tests to allow tests to be sped up

