### PR TITLE
feat(consensus): implement InMemorySize for op types

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -121,9 +121,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "1.5.2"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed1958f0294ecc05ebe7b3c9a8662a3e221c2523b7f2bcd94c7a651efbd510bf"
+checksum = "4e4ff99651d46cef43767b5e8262ea228cd05287409ccb0c947cc25e70a952f9"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -240,9 +240,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "1.5.2"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "813a67f87e56b38554d18b182616ee5006e8e2bf9df96a0df8bf29dff1d52e3f"
+checksum = "def1626eea28d48c6cc0a6f16f34d4af0001906e4f889df6c660b39c86fd044d"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -724,9 +724,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "1.5.2"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "946a0d413dbb5cd9adba0de5f8a1a34d5b77deda9b69c1d7feed8fc875a1aa26"
+checksum = "9e6d631f8b975229361d8af7b2c749af31c73b3cf1352f90e144ddb06227105e"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -941,9 +941,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "1.5.2"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45ceac797eb8a56bdf5ab1fab353072c17d472eab87645ca847afe720db3246d"
+checksum = "397406cf04b11ca2a48e6f81804c70af3f40a36abf648e11dc7416043eb0834d"
 dependencies = [
  "darling 0.21.3",
  "proc-macro2",
@@ -3113,7 +3113,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.114",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -404,7 +404,7 @@ alloy-trie = { version = "0.9.3", default-features = false }
 
 alloy-hardforks = { version = "0.4.7", default-features = false }
 
-alloy-consensus = { version = "1.5.2", default-features = false }
+alloy-consensus = { version = "1.6.2", default-features = false }
 alloy-contract = { version = "1.5.2", default-features = false }
 alloy-eips = { version = "1.5.2", default-features = false }
 alloy-genesis = { version = "1.5.2", default-features = false }

--- a/rust/op-alloy/crates/consensus/src/lib.rs
+++ b/rust/op-alloy/crates/consensus/src/lib.rs
@@ -32,6 +32,8 @@ pub use eip1559::{
 mod source;
 pub use source::*;
 
+mod size;
+
 mod block;
 pub use block::OpBlock;
 

--- a/rust/op-alloy/crates/consensus/src/size.rs
+++ b/rust/op-alloy/crates/consensus/src/size.rs
@@ -1,0 +1,75 @@
+use alloy_consensus::InMemorySize;
+
+use crate::{
+    OpDepositReceipt, OpPooledTransaction, OpReceipt, OpTxEnvelope, OpTxType, OpTypedTransaction,
+    TxDeposit,
+};
+
+impl InMemorySize for OpTxType {
+    #[inline]
+    fn size(&self) -> usize {
+        core::mem::size_of::<Self>()
+    }
+}
+
+impl InMemorySize for TxDeposit {
+    #[inline]
+    fn size(&self) -> usize {
+        Self::size(self)
+    }
+}
+
+impl InMemorySize for OpDepositReceipt {
+    fn size(&self) -> usize {
+        self.inner.size()
+            + core::mem::size_of_val(&self.deposit_nonce)
+            + core::mem::size_of_val(&self.deposit_receipt_version)
+    }
+}
+
+impl InMemorySize for OpReceipt {
+    fn size(&self) -> usize {
+        match self {
+            Self::Legacy(receipt)
+            | Self::Eip2930(receipt)
+            | Self::Eip1559(receipt)
+            | Self::Eip7702(receipt) => receipt.size(),
+            Self::Deposit(receipt) => receipt.size(),
+        }
+    }
+}
+
+impl InMemorySize for OpTypedTransaction {
+    fn size(&self) -> usize {
+        match self {
+            Self::Legacy(tx) => tx.size(),
+            Self::Eip2930(tx) => tx.size(),
+            Self::Eip1559(tx) => tx.size(),
+            Self::Eip7702(tx) => tx.size(),
+            Self::Deposit(tx) => tx.size(),
+        }
+    }
+}
+
+impl InMemorySize for OpPooledTransaction {
+    fn size(&self) -> usize {
+        match self {
+            Self::Legacy(tx) => tx.size(),
+            Self::Eip2930(tx) => tx.size(),
+            Self::Eip1559(tx) => tx.size(),
+            Self::Eip7702(tx) => tx.size(),
+        }
+    }
+}
+
+impl InMemorySize for OpTxEnvelope {
+    fn size(&self) -> usize {
+        match self {
+            Self::Legacy(tx) => tx.size(),
+            Self::Eip2930(tx) => tx.size(),
+            Self::Eip1559(tx) => tx.size(),
+            Self::Eip7702(tx) => tx.size(),
+            Self::Deposit(tx) => tx.size(),
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Port of [alloy-rs/op-alloy#624](https://github.com/alloy-rs/op-alloy/pull/624) — implement `alloy_consensus::InMemorySize` for op consensus types.

## Changes

- Bump `alloy-consensus` min to 1.6.2 (which includes `InMemorySize`)
- Add `InMemorySize` impls for: `OpTxType`, `TxDeposit`, `OpDepositReceipt`, `OpReceipt`, `OpTypedTransaction`, `OpPooledTransaction`, `OpTxEnvelope`

## Testing

`cargo check -p op-alloy-consensus` passes.

Prompted by: mattsse