### PR TITLE
op-acceptance: Dump stack traces if op-challenger fails to stop

### DIFF
--- a/op-challenger/game/service.go
+++ b/op-challenger/game/service.go
@@ -268,52 +268,62 @@ func (s *Service) Stopped() bool {
 }
 
 func (s *Service) Stop(ctx context.Context) error {
-	s.logger.Info("stopping challenger game service")
+	s.logger.Info("Stopping challenger game service")
 
 	var result error
+	s.logger.Info("Stopping challenger monitor")
+	if s.monitor != nil {
+		s.monitor.StopMonitoring()
+	}
+	s.logger.Info("Stopping challenger scheduler")
 	if s.sched != nil {
 		if err := s.sched.Close(); err != nil {
 			result = errors.Join(result, fmt.Errorf("failed to close scheduler: %w", err))
 		}
 	}
-	if s.monitor != nil {
-		s.monitor.StopMonitoring()
-	}
+	s.logger.Info("Stopping challenger claimer")
 	if s.claimer != nil {
 		if err := s.claimer.Close(); err != nil {
 			result = errors.Join(result, fmt.Errorf("failed to close claimer: %w", err))
 		}
 	}
+	s.logger.Info("Stopping challenger client provider")
 	if s.clientProvider != nil {
 		s.clientProvider.Close()
 	}
+	s.logger.Info("Stopping challenger pprof service")
 	if s.pprofService != nil {
 		if err := s.pprofService.Stop(ctx); err != nil {
 			result = errors.Join(result, fmt.Errorf("failed to close pprof server: %w", err))
 		}
 	}
+	s.logger.Info("Stopping challenger balance metricer")
 	if s.balanceMetricer != nil {
 		if err := s.balanceMetricer.Close(); err != nil {
 			result = errors.Join(result, fmt.Errorf("failed to close balance metricer: %w", err))
 		}
 	}
 
+	s.logger.Info("Stopping challenger tx manager")
 	if s.txMgr != nil {
 		s.txMgr.Close()
 	}
 
+	s.logger.Info("Stopping challenger l1 RPC")
 	if s.l1RPC != nil {
 		s.l1RPC.Close()
 	}
+	s.logger.Info("Stopping challenger l1 client")
 	if s.l1Client != nil {
 		s.l1Client.Close()
 	}
+	s.logger.Info("Stopping challenger metrics server")
 	if s.metricsSrv != nil {
 		if err := s.metricsSrv.Stop(ctx); err != nil {
 			result = errors.Join(result, fmt.Errorf("failed to close metrics server: %w", err))
 		}
 	}
 	s.stopped.Store(true)
-	s.logger.Info("stopped challenger game service", "err", result)
+	s.logger.Info("Stopped challenger game service", "err", result)
 	return result
 }

--- a/op-challenger/game/service.go
+++ b/op-challenger/game/service.go
@@ -271,53 +271,43 @@ func (s *Service) Stop(ctx context.Context) error {
 	s.logger.Info("Stopping challenger game service")
 
 	var result error
-	s.logger.Info("Stopping challenger monitor")
 	if s.monitor != nil {
 		s.monitor.StopMonitoring()
 	}
-	s.logger.Info("Stopping challenger scheduler")
 	if s.sched != nil {
 		if err := s.sched.Close(); err != nil {
 			result = errors.Join(result, fmt.Errorf("failed to close scheduler: %w", err))
 		}
 	}
-	s.logger.Info("Stopping challenger claimer")
 	if s.claimer != nil {
 		if err := s.claimer.Close(); err != nil {
 			result = errors.Join(result, fmt.Errorf("failed to close claimer: %w", err))
 		}
 	}
-	s.logger.Info("Stopping challenger client provider")
 	if s.clientProvider != nil {
 		s.clientProvider.Close()
 	}
-	s.logger.Info("Stopping challenger pprof service")
 	if s.pprofService != nil {
 		if err := s.pprofService.Stop(ctx); err != nil {
 			result = errors.Join(result, fmt.Errorf("failed to close pprof server: %w", err))
 		}
 	}
-	s.logger.Info("Stopping challenger balance metricer")
 	if s.balanceMetricer != nil {
 		if err := s.balanceMetricer.Close(); err != nil {
 			result = errors.Join(result, fmt.Errorf("failed to close balance metricer: %w", err))
 		}
 	}
 
-	s.logger.Info("Stopping challenger tx manager")
 	if s.txMgr != nil {
 		s.txMgr.Close()
 	}
 
-	s.logger.Info("Stopping challenger l1 RPC")
 	if s.l1RPC != nil {
 		s.l1RPC.Close()
 	}
-	s.logger.Info("Stopping challenger l1 client")
 	if s.l1Client != nil {
 		s.l1Client.Close()
 	}
-	s.logger.Info("Stopping challenger metrics server")
 	if s.metricsSrv != nil {
 		if err := s.metricsSrv.Stop(ctx); err != nil {
 			result = errors.Join(result, fmt.Errorf("failed to close metrics server: %w", err))

--- a/op-devstack/sysgo/l2_challenger.go
+++ b/op-devstack/sysgo/l2_challenger.go
@@ -2,6 +2,8 @@ package sysgo
 
 import (
 	"context"
+	"runtime"
+	"time"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
 	opchallenger "github.com/ethereum-optimism/optimism/op-challenger"
@@ -217,7 +219,18 @@ func WithL2ChallengerPostDeploy(orch *Orchestrator, challengerID stack.L2Challen
 		ctx, cancel := context.WithCancel(ctx)
 		cancel() // force-quit
 		logger.Info("Closing challenger")
+		// Start a separate goroutine to print a stack trace if the challenger fails to stop in a timely manner.
+		timer := time.AfterFunc(1*time.Minute, func() {
+			if svc.Stopped() {
+				return
+			}
+			// Print stack trace of all goroutines
+			buf := make([]byte, 1<<20) // 1MB buffer
+			stacklen := runtime.Stack(buf, true)
+			logger.Error("Challenger failed to stop; printing all goroutine stacks:\n%v", string(buf[:stacklen]))
+		})
 		_ = svc.Stop(ctx)
+		timer.Stop()
 		logger.Info("Closed challenger")
 	})
 


### PR DESCRIPTION
**Description**

op-challenger was sometimes failing to stop cleanly in CI (should be fixed by https://github.com/ethereum-optimism/optimism/pull/19203). Tweak the shutdown order slightly to stop attempting to schedule new updates first and update the op-acceptance code to print stack traces if challenger fails to shut down in a timely manner.
