### PR TITLE
op-acceptance: Add DSL to allow pausing the batcher

### DIFF
--- a/op-acceptance-tests/tests/base/chain/pause_proxy_test.go
+++ b/op-acceptance-tests/tests/base/chain/pause_proxy_test.go
@@ -1,0 +1,72 @@
+package chain
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBatcherPauseProxy tests the batcher pause functionality via RPC proxy.
+// It verifies that:
+// 1. The batcher can be paused at a specific block number via test control
+// 2. The pause state can be queried via IsPaused()
+// 3. The batcher can be unpaused
+// This is a unit/integration test of the pause control API, not an end-to-end
+// test of pause behavior (which would require complex timing and state verification)
+func TestBatcherPauseProxy(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewMinimal(t)
+	l := t.Logger()
+
+	// Use the batcher directly from the system
+	batcher := sys.L2Batcher
+
+	// Test 1: Verify initially not paused
+	l.Info("Test 1: Verifying batcher is initially not paused")
+	isPaused, pauseBlock := batcher.IsPaused()
+	require.False(t, isPaused, "batcher should not be paused initially")
+	require.Equal(t, uint64(0), pauseBlock, "pause block should be 0 when not paused")
+	sys.L2CL.Advanced(types.LocalSafe, 1, 10)
+	l.Info("Verified batcher is not paused initially")
+
+	// Test 2: Pause at a specific block
+	testPauseBlock := uint64(10)
+	l.Info("Test 2: Pausing batcher", "pauseBlock", testPauseBlock)
+	result := batcher.PauseAtBlock(testPauseBlock)
+	require.Equal(t, testPauseBlock, result, "PauseAtBlock should return the pause block")
+	sys.L2CL.Reached(types.LocalSafe, testPauseBlock, 10)
+
+	// Verify the pause was set
+	isPaused, pauseBlock = batcher.IsPaused()
+	require.True(t, isPaused, "batcher should be paused")
+	require.Equal(t, testPauseBlock, pauseBlock, "pause block should match")
+	sys.L2CL.NotAdvanced(types.LocalSafe, 3)
+	l.Info("Verified batcher is paused", "pauseBlock", pauseBlock)
+
+	// Test 3: Change pause block
+	newPauseBlock := uint64(15)
+	l.Info("Test 3: Changing pause block", "newPauseBlock", newPauseBlock)
+	result = batcher.PauseAtBlock(newPauseBlock)
+	require.Equal(t, newPauseBlock, result, "PauseAtBlock should return the new pause block")
+
+	// Verify the pause was updated
+	isPaused, pauseBlock = batcher.IsPaused()
+	require.True(t, isPaused, "batcher should still be paused")
+	require.Equal(t, newPauseBlock, pauseBlock, "pause block should be updated")
+	sys.L2CL.Reached(types.LocalSafe, newPauseBlock, 10)
+	l.Info("Verified pause block was updated", "pauseBlock", pauseBlock)
+
+	// Test 4: Unpause
+	l.Info("Test 4: Unpausing batcher")
+	batcher.Unpause()
+
+	// Verify the batcher is no longer paused
+	isPaused, pauseBlock = batcher.IsPaused()
+	require.False(t, isPaused, "batcher should not be paused after unpause")
+	require.Equal(t, uint64(0), pauseBlock, "pause block should be 0 after unpause")
+	sys.L2CL.Advanced(types.LocalSafe, 1, 10)
+	l.Info("Verified batcher is not paused after unpause")
+}

--- a/op-devstack/dsl/l2_batcher.go
+++ b/op-devstack/dsl/l2_batcher.go
@@ -54,3 +54,36 @@ func (b *L2Batcher) Start() {
 	})
 	require.NoError(b.t, err, fmt.Sprintf("Expected to be able to call StartBatcher API on chain %s, but got error", b.inner.ID().ChainID()))
 }
+
+// PauseAtBlock pauses the batcher at the specified block number.
+// The batcher will process up to and including blockNum, but won't see any blocks beyond it.
+// Returns the highest block number the batcher will see.
+// This function is for integration test control only.
+// Only works if the underlying batcher implements PausableBatcher.
+func (b *L2Batcher) PauseAtBlock(blockNum uint64) uint64 {
+	pausable, ok := b.inner.(stack.PausableBatcher)
+	b.require.True(ok, "batcher does not implement PausableBatcher")
+	pauseBlock := pausable.PauseAtBlock(blockNum)
+	err := b.ActivityAPI().FlushBatcher(b.ctx)
+	b.require.NoError(err, "Failed to flush batcher")
+	return pauseBlock
+}
+
+// Unpause resumes normal batcher operation, allowing it to see all available blocks.
+// This function is for integration test control only.
+// Only works if the underlying batcher implements PausableBatcher.
+func (b *L2Batcher) Unpause() {
+	pausable, ok := b.inner.(stack.PausableBatcher)
+	b.require.True(ok, "batcher does not implement PausableBatcher")
+	pausable.Unpause()
+}
+
+// IsPaused returns true if the batcher is currently paused, and the block number it's paused at.
+// Returns (false, 0) if not paused.
+// This function is for integration test control only.
+// Only works if the underlying batcher implements PausableBatcher.
+func (b *L2Batcher) IsPaused() (bool, uint64) {
+	pausable, ok := b.inner.(stack.PausableBatcher)
+	b.require.True(ok, "batcher does not implement PausableBatcher")
+	return pausable.IsPaused()
+}

--- a/op-devstack/shim/l2_batcher.go
+++ b/op-devstack/shim/l2_batcher.go
@@ -7,16 +7,25 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/sources"
 )
 
+// pauseController is a minimal interface for pause control, avoiding circular dependencies
+type pauseController interface {
+	PauseAtBlock(blockNum uint64) uint64
+	Unpause()
+	IsPaused() (bool, uint64)
+}
+
 type L2BatcherConfig struct {
 	CommonConfig
-	ID     stack.L2BatcherID
-	Client client.RPC
+	ID      stack.L2BatcherID
+	Client  client.RPC
+	Backend pauseController // Optional: only set for sysgo backend with test control
 }
 
 type rpcL2Batcher struct {
 	commonImpl
-	id     stack.L2BatcherID
-	client *sources.BatcherAdminClient
+	id      stack.L2BatcherID
+	client  *sources.BatcherAdminClient
+	backend pauseController // Optional: for test control access
 }
 
 var _ stack.L2Batcher = (*rpcL2Batcher)(nil)
@@ -27,6 +36,7 @@ func NewL2Batcher(cfg L2BatcherConfig) stack.L2Batcher {
 		commonImpl: newCommon(cfg.CommonConfig),
 		id:         cfg.ID,
 		client:     sources.NewBatcherAdminClient(cfg.Client),
+		backend:    cfg.Backend,
 	}
 }
 
@@ -36,4 +46,26 @@ func (r *rpcL2Batcher) ID() stack.L2BatcherID {
 
 func (p *rpcL2Batcher) ActivityAPI() apis.BatcherActivity {
 	return p.client
+}
+
+// PausableBatcher implementation - delegates to backend if available
+
+func (r *rpcL2Batcher) PauseAtBlock(blockNum uint64) uint64 {
+	if r.backend != nil {
+		return r.backend.PauseAtBlock(blockNum)
+	}
+	return 0
+}
+
+func (r *rpcL2Batcher) Unpause() {
+	if r.backend != nil {
+		r.backend.Unpause()
+	}
+}
+
+func (r *rpcL2Batcher) IsPaused() (bool, uint64) {
+	if r.backend != nil {
+		return r.backend.IsPaused()
+	}
+	return false, 0
 }

--- a/op-devstack/stack/l2_batcher.go
+++ b/op-devstack/stack/l2_batcher.go
@@ -73,3 +73,24 @@ type L2Batcher interface {
 	ID() L2BatcherID
 	ActivityAPI() apis.BatcherActivity
 }
+
+// PausableBatcher extends L2Batcher with pause control for integration testing.
+// This interface is for integration test control only.
+type PausableBatcher interface {
+	L2Batcher
+
+	// PauseAtBlock pauses the batcher at the specified block number.
+	// The batcher will process up to and including blockNum, but won't see
+	// any blocks beyond it. Returns the highest block number the batcher will see.
+	// This function is for integration test control only.
+	PauseAtBlock(blockNum uint64) uint64
+
+	// Unpause resumes normal batcher operation, allowing it to see all available blocks.
+	// This function is for integration test control only.
+	Unpause()
+
+	// IsPaused returns true if the batcher is currently paused, and the block number it's paused at.
+	// Returns (false, 0) if not paused.
+	// This function is for integration test control only.
+	IsPaused() (bool, uint64)
+}

--- a/op-devstack/sysgo/l2_batcher.go
+++ b/op-devstack/sysgo/l2_batcher.go
@@ -2,6 +2,7 @@ package sysgo
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/ethereum/go-ethereum/crypto"
@@ -15,18 +16,20 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/setuputils"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/dial"
 	"github.com/ethereum-optimism/optimism/op-service/endpoint"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	oprpc "github.com/ethereum-optimism/optimism/op-service/rpc"
 )
 
 type L2Batcher struct {
-	id      stack.L2BatcherID
-	service *bss.BatcherService
-	rpc     string
-	l1RPC   string
-	l2CLRPC string
-	l2ELRPC string
+	id          stack.L2BatcherID
+	service     *bss.BatcherService
+	rpc         string
+	l1RPC       string
+	l2CLRPC     string
+	l2ELRPC     string
+	testControl *batcherTestControl
 }
 
 func (b *L2Batcher) hydrate(system stack.ExtensibleSystem) {
@@ -42,6 +45,49 @@ func (b *L2Batcher) hydrate(system stack.ExtensibleSystem) {
 	})
 	l2Net := system.L2Network(stack.L2NetworkID(b.id.ChainID()))
 	l2Net.(stack.ExtensibleL2Network).AddL2Batcher(bFrontend)
+}
+
+// proxyingEndpointProvider wraps an L2EndpointProvider and injects a rollup client proxy.
+type proxyingEndpointProvider struct {
+	inner      dial.L2EndpointProvider
+	proxy      *rollupClientProxy
+	realClient dial.RollupClientInterface
+	clientOnce sync.Once
+	clientErr  error
+}
+
+func (p *proxyingEndpointProvider) RollupClient(ctx context.Context) (dial.RollupClientInterface, error) {
+	// Create the real clients once and wrap them with the proxy
+	p.clientOnce.Do(func() {
+		p.realClient, p.clientErr = p.inner.RollupClient(ctx)
+		if p.clientErr != nil {
+			return
+		}
+		// Update the proxy's inner client to be the real rollup client
+		p.proxy.inner = p.realClient
+
+		// Also fetch the L2 eth client for the proxy
+		l2EthClient, err := p.inner.EthClient(ctx)
+		if err != nil {
+			p.clientErr = err
+			return
+		}
+		p.proxy.l2Client = l2EthClient
+	})
+	if p.clientErr != nil {
+		return nil, p.clientErr
+	}
+	return p.proxy, nil
+}
+
+func (p *proxyingEndpointProvider) EthClient(ctx context.Context) (dial.EthClientInterface, error) {
+	return p.inner.EthClient(ctx)
+}
+
+func (p *proxyingEndpointProvider) Close() {
+	if p.inner != nil {
+		p.inner.Close()
+	}
 }
 
 type BatcherOption func(id stack.L2BatcherID, cfg *bss.CLIConfig)
@@ -120,9 +166,36 @@ func WithBatcher(batcherID stack.L2BatcherID, l1ELID stack.L1ELNodeID, l2CLID st
 			p.Errorf("closeAppFn called, batcher hit a critical error: %v", cause)
 			cancelBatcherCtx()
 		}
+
+		// Variables to store proxy and test control
+		var rollupProxy *rollupClientProxy
+		var testControl *batcherTestControl
+
+		// Driver setup option that creates and injects the proxy
+		withProxyOption := func(setup *bss.DriverSetup) {
+			// Create rollup client proxy for test control
+			// The inner client and l2Client will be set lazily when RollupClient() is called
+			rollupProxy = &rollupClientProxy{}
+
+			// Create proxying endpoint provider that wraps the original
+			proxyingProvider := &proxyingEndpointProvider{
+				inner: setup.EndpointProvider,
+				proxy: rollupProxy,
+			}
+
+			// Replace the endpoint provider with our proxying version
+			setup.EndpointProvider = proxyingProvider
+
+			// Create test control
+			testControl = &batcherTestControl{
+				proxy: rollupProxy,
+				log:   logger,
+			}
+		}
+
 		batcher, err := bss.BatcherServiceFromCLIConfig(
 			batcherContext, closeAppFn, "0.0.1", batcherCLIConfig,
-			logger)
+			logger, withProxyOption)
 		require.NoError(err)
 		require.NoError(batcher.Start(p.Ctx()))
 		p.Cleanup(func() {
@@ -134,13 +207,42 @@ func WithBatcher(batcherID stack.L2BatcherID, l1ELID stack.L1ELNodeID, l2CLID st
 		})
 
 		b := &L2Batcher{
-			id:      batcherID,
-			service: batcher,
-			rpc:     batcher.HTTPEndpoint(),
-			l1RPC:   l1EL.UserRPC(),
-			l2CLRPC: l2CL.UserRPC(),
-			l2ELRPC: l2EL.UserRPC(),
+			id:          batcherID,
+			service:     batcher,
+			rpc:         batcher.HTTPEndpoint(),
+			l1RPC:       l1EL.UserRPC(),
+			l2CLRPC:     l2CL.UserRPC(),
+			l2ELRPC:     l2EL.UserRPC(),
+			testControl: testControl,
 		}
 		orch.batchers.Set(batcherID, b)
 	})
+}
+
+// batcherTestControl provides test control over the batcher by manipulating
+// the rollup client proxy to control what blocks the batcher sees.
+type batcherTestControl struct {
+	proxy *rollupClientProxy
+	log   log.Logger
+}
+
+// PauseAtBlock pauses the batcher at the specified block number.
+// The batcher will process up to and including blockNum, but won't see
+// any blocks beyond it. Returns the highest block number the batcher will see.
+func (tc *batcherTestControl) PauseAtBlock(blockNum uint64) uint64 {
+	tc.log.Info("pausing batcher at block", "blockNum", blockNum)
+
+	// Set the pause in the proxy
+	tc.proxy.setPauseAtBlock(blockNum)
+
+	// The batcher will naturally stop processing when it queries sync status
+	// and sees unsafe head capped at blockNum (inclusive)
+
+	return blockNum
+}
+
+// Unpause resumes normal batcher operation, allowing it to see all available blocks.
+func (tc *batcherTestControl) Unpause() {
+	tc.log.Info("unpausing batcher")
+	tc.proxy.clearPause()
 }

--- a/op-devstack/sysgo/l2_batcher.go
+++ b/op-devstack/sysgo/l2_batcher.go
@@ -23,13 +23,14 @@ import (
 )
 
 type L2Batcher struct {
-	id          stack.L2BatcherID
-	service     *bss.BatcherService
-	rpc         string
-	l1RPC       string
-	l2CLRPC     string
-	l2ELRPC     string
-	testControl *batcherTestControl
+	id      stack.L2BatcherID
+	service *bss.BatcherService
+	rpc     string
+	l1RPC   string
+	l2CLRPC string
+	l2ELRPC string
+	proxy   *rollupClientProxy
+	log     log.Logger
 }
 
 func (b *L2Batcher) hydrate(system stack.ExtensibleSystem) {
@@ -42,6 +43,7 @@ func (b *L2Batcher) hydrate(system stack.ExtensibleSystem) {
 		CommonConfig: shim.NewCommonConfig(system.T()),
 		ID:           b.id,
 		Client:       rpcCl,
+		Backend:      b, // Pass backend for test control access
 	})
 	l2Net := system.L2Network(stack.L2NetworkID(b.id.ChainID()))
 	l2Net.(stack.ExtensibleL2Network).AddL2Batcher(bFrontend)
@@ -167,9 +169,8 @@ func WithBatcher(batcherID stack.L2BatcherID, l1ELID stack.L1ELNodeID, l2CLID st
 			cancelBatcherCtx()
 		}
 
-		// Variables to store proxy and test control
+		// Variable to store proxy for test control
 		var rollupProxy *rollupClientProxy
-		var testControl *batcherTestControl
 
 		// Driver setup option that creates and injects the proxy
 		withProxyOption := func(setup *bss.DriverSetup) {
@@ -185,12 +186,6 @@ func WithBatcher(batcherID stack.L2BatcherID, l1ELID stack.L1ELNodeID, l2CLID st
 
 			// Replace the endpoint provider with our proxying version
 			setup.EndpointProvider = proxyingProvider
-
-			// Create test control
-			testControl = &batcherTestControl{
-				proxy: rollupProxy,
-				log:   logger,
-			}
 		}
 
 		batcher, err := bss.BatcherServiceFromCLIConfig(
@@ -207,33 +202,31 @@ func WithBatcher(batcherID stack.L2BatcherID, l1ELID stack.L1ELNodeID, l2CLID st
 		})
 
 		b := &L2Batcher{
-			id:          batcherID,
-			service:     batcher,
-			rpc:         batcher.HTTPEndpoint(),
-			l1RPC:       l1EL.UserRPC(),
-			l2CLRPC:     l2CL.UserRPC(),
-			l2ELRPC:     l2EL.UserRPC(),
-			testControl: testControl,
+			id:      batcherID,
+			service: batcher,
+			rpc:     batcher.HTTPEndpoint(),
+			l1RPC:   l1EL.UserRPC(),
+			l2CLRPC: l2CL.UserRPC(),
+			l2ELRPC: l2EL.UserRPC(),
+			proxy:   rollupProxy,
+			log:     logger,
 		}
 		orch.batchers.Set(batcherID, b)
 	})
 }
 
-// batcherTestControl provides test control over the batcher by manipulating
+// PausableBatcher interface implementation for L2Batcher
+// These methods provide pause functionality for integration testing by manipulating
 // the rollup client proxy to control what blocks the batcher sees.
-type batcherTestControl struct {
-	proxy *rollupClientProxy
-	log   log.Logger
-}
 
 // PauseAtBlock pauses the batcher at the specified block number.
 // The batcher will process up to and including blockNum, but won't see
 // any blocks beyond it. Returns the highest block number the batcher will see.
-func (tc *batcherTestControl) PauseAtBlock(blockNum uint64) uint64 {
-	tc.log.Info("pausing batcher at block", "blockNum", blockNum)
+func (b *L2Batcher) PauseAtBlock(blockNum uint64) uint64 {
+	b.log.Info("Pausing batcher at block", "blockNum", blockNum)
 
 	// Set the pause in the proxy
-	tc.proxy.setPauseAtBlock(blockNum)
+	b.proxy.setPauseAtBlock(blockNum)
 
 	// The batcher will naturally stop processing when it queries sync status
 	// and sees unsafe head capped at blockNum (inclusive)
@@ -242,7 +235,14 @@ func (tc *batcherTestControl) PauseAtBlock(blockNum uint64) uint64 {
 }
 
 // Unpause resumes normal batcher operation, allowing it to see all available blocks.
-func (tc *batcherTestControl) Unpause() {
-	tc.log.Info("unpausing batcher")
-	tc.proxy.clearPause()
+func (b *L2Batcher) Unpause() {
+	b.log.Info("Unpausing batcher")
+	b.proxy.clearPause()
+}
+
+// IsPaused returns true if the batcher is currently paused, and the block number it's paused at.
+// Returns (false, 0) if not paused.
+func (b *L2Batcher) IsPaused() (bool, uint64) {
+	pauseBlock := b.proxy.getPause()
+	return pauseBlock > 0, pauseBlock
 }

--- a/op-devstack/sysgo/l2_batcher_test_control_test.go
+++ b/op-devstack/sysgo/l2_batcher_test_control_test.go
@@ -1,0 +1,202 @@
+package sysgo
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+)
+
+func TestBatcherTestControl_PauseAtBlock(t *testing.T) {
+	logger := testlog.Logger(t, log.LevelInfo)
+
+	// Setup mock clients
+	blocks := make(map[uint64]*types.Block)
+	for i := uint64(1); i <= 100; i++ {
+		blocks[i] = newMockBlock(i)
+	}
+
+	mockRollup := &mockRollupClient{
+		syncStatus: &eth.SyncStatus{
+			UnsafeL2: eth.L2BlockRef{
+				Hash:   blocks[100].Hash(),
+				Number: 100,
+			},
+		},
+	}
+	mockL2 := &mockL2Client{blocks: blocks}
+
+	proxy := newRollupClientProxy(mockRollup, mockL2)
+	testControl := &batcherTestControl{
+		proxy: proxy,
+		log:   logger,
+	}
+
+	// Pause at block 50
+	result := testControl.PauseAtBlock(50)
+
+	// Should return 50 (the highest block the batcher will see)
+	require.Equal(t, uint64(50), result)
+
+	// Verify the proxy is actually paused at 50
+	require.Equal(t, uint64(50), proxy.getPause())
+
+	// Verify the proxy caps the unsafe head
+	ctx := context.Background()
+	status, err := proxy.SyncStatus(ctx)
+	require.NoError(t, err)
+	require.Equal(t, uint64(50), status.UnsafeL2.Number)
+}
+
+func TestBatcherTestControl_Unpause(t *testing.T) {
+	logger := testlog.Logger(t, log.LevelInfo)
+
+	// Setup mock clients
+	blocks := make(map[uint64]*types.Block)
+	for i := uint64(1); i <= 100; i++ {
+		blocks[i] = newMockBlock(i)
+	}
+
+	mockRollup := &mockRollupClient{
+		syncStatus: &eth.SyncStatus{
+			UnsafeL2: eth.L2BlockRef{
+				Hash:   blocks[100].Hash(),
+				Number: 100,
+			},
+		},
+	}
+	mockL2 := &mockL2Client{blocks: blocks}
+
+	proxy := newRollupClientProxy(mockRollup, mockL2)
+	testControl := &batcherTestControl{
+		proxy: proxy,
+		log:   logger,
+	}
+
+	// Pause at block 50
+	testControl.PauseAtBlock(50)
+	require.Equal(t, uint64(50), proxy.getPause())
+
+	// Unpause
+	testControl.Unpause()
+
+	// Verify the proxy is cleared
+	require.Equal(t, uint64(0), proxy.getPause())
+
+	// Verify the proxy no longer caps the unsafe head
+	ctx := context.Background()
+	status, err := proxy.SyncStatus(ctx)
+	require.NoError(t, err)
+	require.Equal(t, uint64(100), status.UnsafeL2.Number)
+}
+
+func TestBatcherTestControl_PauseAndUnpauseCycle(t *testing.T) {
+	logger := testlog.Logger(t, log.LevelInfo)
+
+	blocks := make(map[uint64]*types.Block)
+	for i := uint64(1); i <= 100; i++ {
+		blocks[i] = newMockBlock(i)
+	}
+
+	mockRollup := &mockRollupClient{
+		syncStatus: &eth.SyncStatus{
+			UnsafeL2: eth.L2BlockRef{
+				Hash:   blocks[100].Hash(),
+				Number: 100,
+			},
+		},
+	}
+	mockL2 := &mockL2Client{blocks: blocks}
+
+	proxy := newRollupClientProxy(mockRollup, mockL2)
+	testControl := &batcherTestControl{
+		proxy: proxy,
+		log:   logger,
+	}
+
+	ctx := context.Background()
+
+	// Initially unpaused
+	status, err := proxy.SyncStatus(ctx)
+	require.NoError(t, err)
+	require.Equal(t, uint64(100), status.UnsafeL2.Number)
+
+	// Pause at 30
+	result := testControl.PauseAtBlock(30)
+	require.Equal(t, uint64(30), result)
+
+	status, err = proxy.SyncStatus(ctx)
+	require.NoError(t, err)
+	require.Equal(t, uint64(30), status.UnsafeL2.Number)
+
+	// Pause at 60 (change pause point)
+	result = testControl.PauseAtBlock(60)
+	require.Equal(t, uint64(60), result)
+
+	status, err = proxy.SyncStatus(ctx)
+	require.NoError(t, err)
+	require.Equal(t, uint64(60), status.UnsafeL2.Number)
+
+	// Unpause
+	testControl.Unpause()
+
+	status, err = proxy.SyncStatus(ctx)
+	require.NoError(t, err)
+	require.Equal(t, uint64(100), status.UnsafeL2.Number)
+}
+
+func TestL2Batcher_TestControl(t *testing.T) {
+	logger := testlog.Logger(t, log.LevelInfo)
+
+	blocks := make(map[uint64]*types.Block)
+	for i := uint64(1); i <= 100; i++ {
+		blocks[i] = newMockBlock(i)
+	}
+
+	mockRollup := &mockRollupClient{
+		syncStatus: &eth.SyncStatus{
+			UnsafeL2: eth.L2BlockRef{
+				Hash:   blocks[100].Hash(),
+				Number: 100,
+			},
+		},
+	}
+	mockL2 := &mockL2Client{blocks: blocks}
+
+	proxy := newRollupClientProxy(mockRollup, mockL2)
+	testControl := &batcherTestControl{
+		proxy: proxy,
+		log:   logger,
+	}
+
+	// Create L2Batcher with test control
+	batcher := &L2Batcher{
+		testControl: testControl,
+	}
+
+	// Verify TestControl() returns the test control
+	tc := batcher.TestControl()
+	require.NotNil(t, tc)
+
+	// Verify it's the same instance
+	require.Equal(t, testControl, tc)
+
+	// Verify we can use it to pause/unpause
+	ctx := context.Background()
+	result := tc.PauseAtBlock(50)
+	require.Equal(t, uint64(50), result)
+
+	status, err := proxy.SyncStatus(ctx)
+	require.NoError(t, err)
+	require.Equal(t, uint64(50), status.UnsafeL2.Number)
+
+	tc.Unpause()
+	status, err = proxy.SyncStatus(ctx)
+	require.NoError(t, err)
+	require.Equal(t, uint64(100), status.UnsafeL2.Number)
+}

--- a/op-devstack/sysgo/l2_batcher_test_control_test.go
+++ b/op-devstack/sysgo/l2_batcher_test_control_test.go
@@ -32,13 +32,13 @@ func TestBatcherTestControl_PauseAtBlock(t *testing.T) {
 	mockL2 := &mockL2Client{blocks: blocks}
 
 	proxy := newRollupClientProxy(mockRollup, mockL2)
-	testControl := &batcherTestControl{
+	batcher := &L2Batcher{
 		proxy: proxy,
 		log:   logger,
 	}
 
 	// Pause at block 50
-	result := testControl.PauseAtBlock(50)
+	result := batcher.PauseAtBlock(50)
 
 	// Should return 50 (the highest block the batcher will see)
 	require.Equal(t, uint64(50), result)
@@ -73,17 +73,17 @@ func TestBatcherTestControl_Unpause(t *testing.T) {
 	mockL2 := &mockL2Client{blocks: blocks}
 
 	proxy := newRollupClientProxy(mockRollup, mockL2)
-	testControl := &batcherTestControl{
+	batcher := &L2Batcher{
 		proxy: proxy,
 		log:   logger,
 	}
 
 	// Pause at block 50
-	testControl.PauseAtBlock(50)
+	batcher.PauseAtBlock(50)
 	require.Equal(t, uint64(50), proxy.getPause())
 
 	// Unpause
-	testControl.Unpause()
+	batcher.Unpause()
 
 	// Verify the proxy is cleared
 	require.Equal(t, uint64(0), proxy.getPause())
@@ -114,7 +114,7 @@ func TestBatcherTestControl_PauseAndUnpauseCycle(t *testing.T) {
 	mockL2 := &mockL2Client{blocks: blocks}
 
 	proxy := newRollupClientProxy(mockRollup, mockL2)
-	testControl := &batcherTestControl{
+	batcher := &L2Batcher{
 		proxy: proxy,
 		log:   logger,
 	}
@@ -127,7 +127,7 @@ func TestBatcherTestControl_PauseAndUnpauseCycle(t *testing.T) {
 	require.Equal(t, uint64(100), status.UnsafeL2.Number)
 
 	// Pause at 30
-	result := testControl.PauseAtBlock(30)
+	result := batcher.PauseAtBlock(30)
 	require.Equal(t, uint64(30), result)
 
 	status, err = proxy.SyncStatus(ctx)
@@ -135,7 +135,7 @@ func TestBatcherTestControl_PauseAndUnpauseCycle(t *testing.T) {
 	require.Equal(t, uint64(30), status.UnsafeL2.Number)
 
 	// Pause at 60 (change pause point)
-	result = testControl.PauseAtBlock(60)
+	result = batcher.PauseAtBlock(60)
 	require.Equal(t, uint64(60), result)
 
 	status, err = proxy.SyncStatus(ctx)
@@ -143,14 +143,14 @@ func TestBatcherTestControl_PauseAndUnpauseCycle(t *testing.T) {
 	require.Equal(t, uint64(60), status.UnsafeL2.Number)
 
 	// Unpause
-	testControl.Unpause()
+	batcher.Unpause()
 
 	status, err = proxy.SyncStatus(ctx)
 	require.NoError(t, err)
 	require.Equal(t, uint64(100), status.UnsafeL2.Number)
 }
 
-func TestL2Batcher_TestControl(t *testing.T) {
+func TestL2Batcher_PausableBatcher(t *testing.T) {
 	logger := testlog.Logger(t, log.LevelInfo)
 
 	blocks := make(map[uint64]*types.Block)
@@ -169,33 +169,42 @@ func TestL2Batcher_TestControl(t *testing.T) {
 	mockL2 := &mockL2Client{blocks: blocks}
 
 	proxy := newRollupClientProxy(mockRollup, mockL2)
-	testControl := &batcherTestControl{
+
+	// Create L2Batcher with proxy
+	batcher := &L2Batcher{
 		proxy: proxy,
 		log:   logger,
 	}
 
-	// Create L2Batcher with test control
-	batcher := &L2Batcher{
-		testControl: testControl,
-	}
-
-	// Verify TestControl() returns the test control
-	tc := batcher.TestControl()
-	require.NotNil(t, tc)
-
-	// Verify it's the same instance
-	require.Equal(t, testControl, tc)
-
-	// Verify we can use it to pause/unpause
+	// Verify we can use the PausableBatcher methods directly on the batcher
 	ctx := context.Background()
-	result := tc.PauseAtBlock(50)
+
+	// Initially not paused
+	isPaused, pauseBlock := batcher.IsPaused()
+	require.False(t, isPaused)
+	require.Equal(t, uint64(0), pauseBlock)
+
+	// Pause at block 50
+	result := batcher.PauseAtBlock(50)
 	require.Equal(t, uint64(50), result)
+
+	// Verify pause state
+	isPaused, pauseBlock = batcher.IsPaused()
+	require.True(t, isPaused)
+	require.Equal(t, uint64(50), pauseBlock)
 
 	status, err := proxy.SyncStatus(ctx)
 	require.NoError(t, err)
 	require.Equal(t, uint64(50), status.UnsafeL2.Number)
 
-	tc.Unpause()
+	// Unpause
+	batcher.Unpause()
+
+	// Verify unpause state
+	isPaused, pauseBlock = batcher.IsPaused()
+	require.False(t, isPaused)
+	require.Equal(t, uint64(0), pauseBlock)
+
 	status, err = proxy.SyncStatus(ctx)
 	require.NoError(t, err)
 	require.Equal(t, uint64(100), status.UnsafeL2.Number)

--- a/op-devstack/sysgo/rollup_client_proxy.go
+++ b/op-devstack/sysgo/rollup_client_proxy.go
@@ -1,0 +1,171 @@
+package sysgo
+
+import (
+	"context"
+	"math/big"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/dial"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+// RollupClient is the interface we wrap. The proxy implements dial.RollupClientInterface
+// by wrapping a real client and only intercepting SyncStatus calls.
+type RollupClient interface {
+	dial.RollupClientInterface
+}
+
+// L2Client is the minimal interface needed to query L2 blocks.
+// This matches the interface defined in op-batcher/batcher/driver.go
+type L2Client interface {
+	BlockByNumber(ctx context.Context, number *big.Int) (*types.Block, error)
+}
+
+// rollupClientProxy wraps a RollupClient and allows test control over responses.
+// This is used to control what L2 blocks the batcher sees, enabling precise
+// pause control without modifying the batcher itself.
+//
+// When pauseAtBlockNum is set to a non-zero value, the proxy will cap the
+// UnsafeL2 head in SyncStatus responses to pauseAtBlockNum. This causes
+// the batcher to process up to and including pauseAtBlockNum, then stop
+// because it won't see any blocks beyond that point.
+type rollupClientProxy struct {
+	inner    RollupClient
+	l2Client L2Client // to query actual block data for hash consistency
+
+	mu              sync.RWMutex
+	pauseAtBlockNum uint64 // 0 = no pause
+}
+
+// newRollupClientProxy creates a new proxy wrapping the given rollup client.
+// The l2Client is used to query actual block data when capping the unsafe head,
+// ensuring the returned block hash matches the block number.
+func newRollupClientProxy(inner RollupClient, l2Client L2Client) *rollupClientProxy {
+	return &rollupClientProxy{
+		inner:    inner,
+		l2Client: l2Client,
+	}
+}
+
+// SyncStatus intercepts and potentially modifies the sync status response.
+// If a pause is active (pauseAtBlockNum > 0), it caps the UnsafeL2 head
+// to pauseAtBlockNum, allowing the batcher to process up to and including
+// that block, but preventing it from seeing any blocks beyond.
+func (p *rollupClientProxy) SyncStatus(ctx context.Context) (*eth.SyncStatus, error) {
+	status, err := p.inner.SyncStatus(ctx)
+	if err != nil || status == nil {
+		return status, err
+	}
+
+	p.mu.RLock()
+	pauseNum := p.pauseAtBlockNum
+	p.mu.RUnlock()
+
+	// If not paused or unsafe head is already at or below pause point, return as-is
+	if pauseNum == 0 || status.UnsafeL2.Number <= pauseNum {
+		return status, nil
+	}
+
+	// Make a copy of the status to avoid modifying the original
+	statusCopy := *status
+
+	// Cap the unsafe head at pauseNum (the last block the batcher should see)
+	cappedBlockNum := pauseNum
+
+	// Query the actual block to get the correct hash for consistency
+	block, err := p.l2Client.BlockByNumber(ctx, big.NewInt(int64(cappedBlockNum)))
+	if err != nil {
+		// If we can't query the block, return the error rather than
+		// returning inconsistent data
+		return nil, err
+	}
+
+	// Update the unsafe head to the capped value with correct hash
+	statusCopy.UnsafeL2 = eth.L2BlockRef{
+		Hash:           block.Hash(),
+		Number:         cappedBlockNum,
+		ParentHash:     block.ParentHash(),
+		Time:           block.Time(),
+		L1Origin:       status.UnsafeL2.L1Origin, // Keep original L1 origin
+		SequenceNumber: status.UnsafeL2.SequenceNumber,
+	}
+
+	// Also cap SafeL2 if it's somehow ahead (defensive)
+	if statusCopy.SafeL2.Number >= pauseNum {
+		statusCopy.SafeL2 = statusCopy.UnsafeL2
+	}
+
+	// And FinalizedL2 (also defensive)
+	if statusCopy.FinalizedL2.Number >= pauseNum {
+		statusCopy.FinalizedL2 = statusCopy.UnsafeL2
+	}
+
+	return &statusCopy, nil
+}
+
+// setPauseAtBlock sets the block number to pause at.
+// When the batcher queries sync status and the unsafe head is beyond
+// this block, the proxy will cap it to blockNum (inclusive).
+// The batcher will process up to and including blockNum, but won't see
+// any blocks after it. Set to 0 to clear the pause.
+func (p *rollupClientProxy) setPauseAtBlock(blockNum uint64) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.pauseAtBlockNum = blockNum
+}
+
+// clearPause removes any active pause, allowing the batcher to see
+// all available blocks again.
+func (p *rollupClientProxy) clearPause() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.pauseAtBlockNum = 0
+}
+
+// getPause returns the current pause block number (0 = no pause).
+func (p *rollupClientProxy) getPause() uint64 {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.pauseAtBlockNum
+}
+
+// Close is a no-op for the proxy since it doesn't own the underlying client.
+func (p *rollupClientProxy) Close() {
+	// No-op: we don't own the inner client
+}
+
+// OutputAtBlock forwards to the inner client.
+func (p *rollupClientProxy) OutputAtBlock(ctx context.Context, blockNum uint64) (*eth.OutputResponse, error) {
+	if p.inner == nil {
+		return nil, nil
+	}
+	return p.inner.OutputAtBlock(ctx, blockNum)
+}
+
+// RollupConfig forwards to the inner client.
+func (p *rollupClientProxy) RollupConfig(ctx context.Context) (*rollup.Config, error) {
+	if p.inner == nil {
+		return nil, nil
+	}
+	return p.inner.RollupConfig(ctx)
+}
+
+// StartSequencer forwards to the inner client.
+func (p *rollupClientProxy) StartSequencer(ctx context.Context, unsafeHead common.Hash) error {
+	if p.inner == nil {
+		return nil
+	}
+	return p.inner.StartSequencer(ctx, unsafeHead)
+}
+
+// SequencerActive forwards to the inner client.
+func (p *rollupClientProxy) SequencerActive(ctx context.Context) (bool, error) {
+	if p.inner == nil {
+		return false, nil
+	}
+	return p.inner.SequencerActive(ctx)
+}

--- a/op-devstack/sysgo/rollup_client_proxy_test.go
+++ b/op-devstack/sysgo/rollup_client_proxy_test.go
@@ -1,0 +1,420 @@
+package sysgo
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/trie"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+// mockRollupClient is a mock implementation of RollupClient for testing
+type mockRollupClient struct {
+	syncStatus *eth.SyncStatus
+	err        error
+}
+
+func (m *mockRollupClient) SyncStatus(ctx context.Context) (*eth.SyncStatus, error) {
+	return m.syncStatus, m.err
+}
+
+func (m *mockRollupClient) Close() {}
+
+func (m *mockRollupClient) OutputAtBlock(ctx context.Context, blockNum uint64) (*eth.OutputResponse, error) {
+	return nil, nil
+}
+
+func (m *mockRollupClient) RollupConfig(ctx context.Context) (*rollup.Config, error) {
+	return nil, nil
+}
+
+func (m *mockRollupClient) StartSequencer(ctx context.Context, unsafeHead common.Hash) error {
+	return nil
+}
+
+func (m *mockRollupClient) SequencerActive(ctx context.Context) (bool, error) {
+	return false, nil
+}
+
+// mockL2Client is a mock implementation of L2Client for testing
+type mockL2Client struct {
+	blocks map[uint64]*types.Block
+}
+
+func (m *mockL2Client) BlockByNumber(ctx context.Context, number *big.Int) (*types.Block, error) {
+	if number == nil {
+		return nil, nil
+	}
+	block, ok := m.blocks[bigs.Uint64Strict(number)]
+	if !ok {
+		return nil, nil
+	}
+	return block, nil
+}
+
+// newMockBlock creates a mock block for testing
+func newMockBlock(number uint64) *types.Block {
+	header := &types.Header{
+		Number: big.NewInt(int64(number)),
+		Time:   1000 + number,
+	}
+	// Set a deterministic hash based on block number
+	header.Extra = []byte{byte(number)}
+	return types.NewBlock(header, &types.Body{}, nil, trie.NewStackTrie(nil), types.DefaultBlockConfig)
+}
+
+func TestRollupClientProxy_Unpaused(t *testing.T) {
+	ctx := context.Background()
+
+	// Setup mock clients
+	mockRollup := &mockRollupClient{
+		syncStatus: &eth.SyncStatus{
+			UnsafeL2: eth.L2BlockRef{
+				Hash:   common.Hash{0x1},
+				Number: 100,
+			},
+			SafeL2: eth.L2BlockRef{
+				Hash:   common.Hash{0x2},
+				Number: 95,
+			},
+			FinalizedL2: eth.L2BlockRef{
+				Hash:   common.Hash{0x3},
+				Number: 90,
+			},
+		},
+	}
+	mockL2 := &mockL2Client{blocks: make(map[uint64]*types.Block)}
+
+	proxy := newRollupClientProxy(mockRollup, mockL2)
+
+	// When not paused, should pass through unchanged
+	status, err := proxy.SyncStatus(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, status)
+	require.Equal(t, uint64(100), status.UnsafeL2.Number)
+	require.Equal(t, uint64(95), status.SafeL2.Number)
+	require.Equal(t, uint64(90), status.FinalizedL2.Number)
+}
+
+func TestRollupClientProxy_PausedCapsUnsafeHead(t *testing.T) {
+	ctx := context.Background()
+
+	// Setup mock blocks
+	blocks := make(map[uint64]*types.Block)
+	for i := uint64(90); i <= 100; i++ {
+		blocks[i] = newMockBlock(i)
+	}
+
+	mockRollup := &mockRollupClient{
+		syncStatus: &eth.SyncStatus{
+			UnsafeL2: eth.L2BlockRef{
+				Hash:   blocks[100].Hash(),
+				Number: 100,
+			},
+			SafeL2: eth.L2BlockRef{
+				Hash:   blocks[95].Hash(),
+				Number: 95,
+			},
+			FinalizedL2: eth.L2BlockRef{
+				Hash:   blocks[90].Hash(),
+				Number: 90,
+			},
+		},
+	}
+	mockL2 := &mockL2Client{blocks: blocks}
+
+	proxy := newRollupClientProxy(mockRollup, mockL2)
+
+	// Pause at block 98 (batcher should see up to and including 98)
+	proxy.setPauseAtBlock(98)
+
+	// Should cap unsafe head at 98 (pauseNum, inclusive)
+	status, err := proxy.SyncStatus(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, status)
+	require.Equal(t, uint64(98), status.UnsafeL2.Number)
+	require.Equal(t, blocks[98].Hash(), status.UnsafeL2.Hash)
+	require.Equal(t, blocks[98].ParentHash(), status.UnsafeL2.ParentHash)
+	require.Equal(t, blocks[98].Time(), status.UnsafeL2.Time)
+
+	// Safe and finalized should be unchanged (they're below pause point)
+	require.Equal(t, uint64(95), status.SafeL2.Number)
+	require.Equal(t, uint64(90), status.FinalizedL2.Number)
+}
+
+func TestRollupClientProxy_PausedAtBlockStart(t *testing.T) {
+	ctx := context.Background()
+
+	// Setup mock blocks
+	blocks := make(map[uint64]*types.Block)
+	for i := uint64(1); i <= 10; i++ {
+		blocks[i] = newMockBlock(i)
+	}
+
+	mockRollup := &mockRollupClient{
+		syncStatus: &eth.SyncStatus{
+			UnsafeL2: eth.L2BlockRef{
+				Hash:   blocks[10].Hash(),
+				Number: 10,
+			},
+			SafeL2: eth.L2BlockRef{
+				Hash:   blocks[5].Hash(),
+				Number: 5,
+			},
+			FinalizedL2: eth.L2BlockRef{
+				Hash:   blocks[1].Hash(),
+				Number: 1,
+			},
+		},
+	}
+	mockL2 := &mockL2Client{blocks: blocks}
+
+	proxy := newRollupClientProxy(mockRollup, mockL2)
+
+	// Pause at block 8 (batcher should see up to and including 8)
+	proxy.setPauseAtBlock(8)
+
+	status, err := proxy.SyncStatus(ctx)
+	require.NoError(t, err)
+	require.Equal(t, uint64(8), status.UnsafeL2.Number)
+	require.Equal(t, blocks[8].Hash(), status.UnsafeL2.Hash)
+}
+
+func TestRollupClientProxy_UnsafeHeadAtOrBelowPause(t *testing.T) {
+	ctx := context.Background()
+
+	blocks := make(map[uint64]*types.Block)
+	for i := uint64(1); i <= 100; i++ {
+		blocks[i] = newMockBlock(i)
+	}
+
+	mockRollup := &mockRollupClient{
+		syncStatus: &eth.SyncStatus{
+			UnsafeL2: eth.L2BlockRef{
+				Hash:   blocks[50].Hash(),
+				Number: 50,
+			},
+			SafeL2: eth.L2BlockRef{
+				Hash:   blocks[45].Hash(),
+				Number: 45,
+			},
+			FinalizedL2: eth.L2BlockRef{
+				Hash:   blocks[40].Hash(),
+				Number: 40,
+			},
+		},
+	}
+	mockL2 := &mockL2Client{blocks: blocks}
+
+	proxy := newRollupClientProxy(mockRollup, mockL2)
+
+	// Pause at block 100 (well above current unsafe head)
+	proxy.setPauseAtBlock(100)
+
+	// Should pass through unchanged since unsafe head (50) <= pauseNum (100)
+	status, err := proxy.SyncStatus(ctx)
+	require.NoError(t, err)
+	require.Equal(t, uint64(50), status.UnsafeL2.Number)
+	require.Equal(t, blocks[50].Hash(), status.UnsafeL2.Hash)
+
+	// Also test when unsafe head exactly equals pause point
+	mockRollup.syncStatus.UnsafeL2.Hash = blocks[100].Hash()
+	mockRollup.syncStatus.UnsafeL2.Number = 100
+
+	status, err = proxy.SyncStatus(ctx)
+	require.NoError(t, err)
+	require.Equal(t, uint64(100), status.UnsafeL2.Number)
+	require.Equal(t, blocks[100].Hash(), status.UnsafeL2.Hash)
+}
+
+func TestRollupClientProxy_ClearPause(t *testing.T) {
+	ctx := context.Background()
+
+	blocks := make(map[uint64]*types.Block)
+	for i := uint64(1); i <= 100; i++ {
+		blocks[i] = newMockBlock(i)
+	}
+
+	mockRollup := &mockRollupClient{
+		syncStatus: &eth.SyncStatus{
+			UnsafeL2: eth.L2BlockRef{
+				Hash:   blocks[100].Hash(),
+				Number: 100,
+			},
+		},
+	}
+	mockL2 := &mockL2Client{blocks: blocks}
+
+	proxy := newRollupClientProxy(mockRollup, mockL2)
+
+	// Set pause at 50 (batcher should see up to and including 50)
+	proxy.setPauseAtBlock(50)
+	status, err := proxy.SyncStatus(ctx)
+	require.NoError(t, err)
+	require.Equal(t, uint64(50), status.UnsafeL2.Number)
+
+	// Clear pause
+	proxy.clearPause()
+	status, err = proxy.SyncStatus(ctx)
+	require.NoError(t, err)
+	require.Equal(t, uint64(100), status.UnsafeL2.Number)
+}
+
+func TestRollupClientProxy_GetPause(t *testing.T) {
+	mockRollup := &mockRollupClient{}
+	mockL2 := &mockL2Client{blocks: make(map[uint64]*types.Block)}
+
+	proxy := newRollupClientProxy(mockRollup, mockL2)
+
+	// Initially no pause
+	require.Equal(t, uint64(0), proxy.getPause())
+
+	// Set pause
+	proxy.setPauseAtBlock(42)
+	require.Equal(t, uint64(42), proxy.getPause())
+
+	// Clear pause
+	proxy.clearPause()
+	require.Equal(t, uint64(0), proxy.getPause())
+}
+
+func TestRollupClientProxy_SafeAndFinalizedCapping(t *testing.T) {
+	ctx := context.Background()
+
+	blocks := make(map[uint64]*types.Block)
+	for i := uint64(1); i <= 100; i++ {
+		blocks[i] = newMockBlock(i)
+	}
+
+	// Set up a scenario where safe and finalized are somehow ahead of pause
+	// (this shouldn't normally happen, but we're defensive)
+	mockRollup := &mockRollupClient{
+		syncStatus: &eth.SyncStatus{
+			UnsafeL2: eth.L2BlockRef{
+				Hash:   blocks[100].Hash(),
+				Number: 100,
+			},
+			SafeL2: eth.L2BlockRef{
+				Hash:   blocks[100].Hash(),
+				Number: 100,
+			},
+			FinalizedL2: eth.L2BlockRef{
+				Hash:   blocks[100].Hash(),
+				Number: 100,
+			},
+		},
+	}
+	mockL2 := &mockL2Client{blocks: blocks}
+
+	proxy := newRollupClientProxy(mockRollup, mockL2)
+	proxy.setPauseAtBlock(50)
+
+	status, err := proxy.SyncStatus(ctx)
+	require.NoError(t, err)
+
+	// All heads should be capped to 50 (inclusive)
+	require.Equal(t, uint64(50), status.UnsafeL2.Number)
+	require.Equal(t, uint64(50), status.SafeL2.Number)
+	require.Equal(t, uint64(50), status.FinalizedL2.Number)
+
+	// They should all have the same (correct) hash
+	require.Equal(t, blocks[50].Hash(), status.UnsafeL2.Hash)
+	require.Equal(t, blocks[50].Hash(), status.SafeL2.Hash)
+	require.Equal(t, blocks[50].Hash(), status.FinalizedL2.Hash)
+}
+
+func TestRollupClientProxy_ErrorPassthrough(t *testing.T) {
+	ctx := context.Background()
+
+	mockRollup := &mockRollupClient{
+		err: context.DeadlineExceeded,
+	}
+	mockL2 := &mockL2Client{blocks: make(map[uint64]*types.Block)}
+
+	proxy := newRollupClientProxy(mockRollup, mockL2)
+	proxy.setPauseAtBlock(50)
+
+	// Error should pass through unchanged
+	_, err := proxy.SyncStatus(ctx)
+	require.Error(t, err)
+	require.Equal(t, context.DeadlineExceeded, err)
+}
+
+func TestRollupClientProxy_NilStatusPassthrough(t *testing.T) {
+	ctx := context.Background()
+
+	mockRollup := &mockRollupClient{
+		syncStatus: nil,
+		err:        nil,
+	}
+	mockL2 := &mockL2Client{blocks: make(map[uint64]*types.Block)}
+
+	proxy := newRollupClientProxy(mockRollup, mockL2)
+	proxy.setPauseAtBlock(50)
+
+	// Nil status should pass through
+	status, err := proxy.SyncStatus(ctx)
+	require.NoError(t, err)
+	require.Nil(t, status)
+}
+
+func TestRollupClientProxy_ConcurrentAccess(t *testing.T) {
+	ctx := context.Background()
+
+	blocks := make(map[uint64]*types.Block)
+	for i := uint64(1); i <= 100; i++ {
+		blocks[i] = newMockBlock(i)
+	}
+
+	mockRollup := &mockRollupClient{
+		syncStatus: &eth.SyncStatus{
+			UnsafeL2: eth.L2BlockRef{
+				Hash:   blocks[100].Hash(),
+				Number: 100,
+			},
+		},
+	}
+	mockL2 := &mockL2Client{blocks: blocks}
+
+	proxy := newRollupClientProxy(mockRollup, mockL2)
+
+	// Test concurrent access doesn't panic
+	done := make(chan bool, 3)
+
+	// Goroutine 1: Set/clear pause
+	go func() {
+		for i := 0; i < 100; i++ {
+			proxy.setPauseAtBlock(50)
+			proxy.clearPause()
+		}
+		done <- true
+	}()
+
+	// Goroutine 2: Read pause
+	go func() {
+		for i := 0; i < 100; i++ {
+			_ = proxy.getPause()
+		}
+		done <- true
+	}()
+
+	// Goroutine 3: Call SyncStatus
+	go func() {
+		for i := 0; i < 100; i++ {
+			_, _ = proxy.SyncStatus(ctx)
+		}
+		done <- true
+	}()
+
+	// Wait for all goroutines
+	<-done
+	<-done
+	<-done
+}


### PR DESCRIPTION
**Description**

Inserts a proxy between the sysgo op-batcher and op-node to allow tests to restrict the batcher's view of the chain and thus pause submitting batches for blocks past a specific block number. This can then be used to provide fine grained control over batch submission.