### PR TITLE
Add unit tests for rollup derive package

### DIFF
--- a/op-node/rollup/derive/error_test.go
+++ b/op-node/rollup/derive/error_test.go
@@ -1,0 +1,106 @@
+package derive
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLevelString(t *testing.T) {
+	tests := []struct {
+		level    Level
+		expected string
+	}{
+		{LevelTemporary, "temp"},
+		{LevelReset, "reset"},
+		{LevelCritical, "crit"},
+		{Level(99), "unknown(99)"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.level.String())
+		})
+	}
+}
+
+func TestErrorError(t *testing.T) {
+	t.Run("with underlying error", func(t *testing.T) {
+		inner := errors.New("something broke")
+		err := NewTemporaryError(inner)
+		assert.Equal(t, "temp: something broke", err.Error())
+	})
+
+	t.Run("without underlying error", func(t *testing.T) {
+		err := NewTemporaryError(nil)
+		assert.Equal(t, "temp", err.Error())
+	})
+
+	t.Run("reset error message", func(t *testing.T) {
+		err := NewResetError(fmt.Errorf("bad state"))
+		assert.Equal(t, "reset: bad state", err.Error())
+	})
+
+	t.Run("critical error message", func(t *testing.T) {
+		err := NewCriticalError(fmt.Errorf("fatal"))
+		assert.Equal(t, "crit: fatal", err.Error())
+	})
+}
+
+func TestErrorUnwrap(t *testing.T) {
+	inner := errors.New("root cause")
+	err := NewTemporaryError(inner)
+	unwrapped := errors.Unwrap(err)
+	assert.Equal(t, inner, unwrapped)
+}
+
+func TestErrorIs(t *testing.T) {
+	t.Run("temporary matches temporary", func(t *testing.T) {
+		err := NewTemporaryError(errors.New("conn refused"))
+		require.True(t, errors.Is(err, ErrTemporary))
+		require.False(t, errors.Is(err, ErrReset))
+		require.False(t, errors.Is(err, ErrCritical))
+	})
+
+	t.Run("reset matches reset", func(t *testing.T) {
+		err := NewResetError(errors.New("reorg"))
+		require.True(t, errors.Is(err, ErrReset))
+		require.False(t, errors.Is(err, ErrTemporary))
+		require.False(t, errors.Is(err, ErrCritical))
+	})
+
+	t.Run("critical matches critical", func(t *testing.T) {
+		err := NewCriticalError(errors.New("panic"))
+		require.True(t, errors.Is(err, ErrCritical))
+		require.False(t, errors.Is(err, ErrTemporary))
+		require.False(t, errors.Is(err, ErrReset))
+	})
+
+	t.Run("does not match non-Error type", func(t *testing.T) {
+		err := NewTemporaryError(errors.New("x"))
+		require.False(t, errors.Is(err, errors.New("x")))
+	})
+
+	t.Run("nil comparison", func(t *testing.T) {
+		e := Error{err: nil, level: LevelTemporary}
+		assert.False(t, e.Is(nil))
+	})
+}
+
+func TestNewError(t *testing.T) {
+	err := NewError(errors.New("test"), LevelReset)
+	var deriveErr Error
+	require.True(t, errors.As(err, &deriveErr))
+	assert.Equal(t, LevelReset, deriveErr.level)
+}
+
+func TestWrappedErrorChain(t *testing.T) {
+	root := errors.New("connection timeout")
+	wrapped := fmt.Errorf("fetching block: %w", root)
+	err := NewTemporaryError(wrapped)
+
+	require.True(t, errors.Is(err, root))
+	require.True(t, errors.Is(err, ErrTemporary))
+}

--- a/op-node/rollup/derive/params_test.go
+++ b/op-node/rollup/derive/params_test.go
@@ -1,0 +1,90 @@
+package derive
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFrameSize(t *testing.T) {
+	t.Run("empty frame data", func(t *testing.T) {
+		f := Frame{Data: []byte{}}
+		assert.Equal(t, uint64(frameOverhead), frameSize(f))
+	})
+
+	t.Run("non-empty frame data", func(t *testing.T) {
+		data := make([]byte, 1000)
+		f := Frame{Data: data}
+		assert.Equal(t, uint64(1000+frameOverhead), frameSize(f))
+	})
+}
+
+func TestChannelIDString(t *testing.T) {
+	var id ChannelID
+	// All zeros
+	assert.Equal(t, "00000000000000000000000000000000", id.String())
+}
+
+func TestChannelIDTerminalString(t *testing.T) {
+	var id ChannelID
+	for i := range id {
+		id[i] = byte(i + 1)
+	}
+	s := id.TerminalString()
+	assert.Contains(t, s, "..")
+}
+
+func TestChannelIDMarshalText(t *testing.T) {
+	var id ChannelID
+	id[0] = 0xab
+	id[15] = 0xcd
+	text, err := id.MarshalText()
+	require.NoError(t, err)
+	assert.Equal(t, "ab0000000000000000000000000000cd", string(text))
+}
+
+func TestChannelIDUnmarshalText(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		var id ChannelID
+		err := id.UnmarshalText([]byte("ab0000000000000000000000000000cd"))
+		require.NoError(t, err)
+		assert.Equal(t, byte(0xab), id[0])
+		assert.Equal(t, byte(0xcd), id[15])
+	})
+
+	t.Run("invalid hex", func(t *testing.T) {
+		var id ChannelID
+		err := id.UnmarshalText([]byte("zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"))
+		require.Error(t, err)
+	})
+
+	t.Run("wrong length", func(t *testing.T) {
+		var id ChannelID
+		err := id.UnmarshalText([]byte("abcd"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid length")
+	})
+}
+
+func TestChannelIDRoundTrip(t *testing.T) {
+	var original ChannelID
+	for i := range original {
+		original[i] = byte(i * 17)
+	}
+	text, err := original.MarshalText()
+	require.NoError(t, err)
+
+	var decoded ChannelID
+	err = decoded.UnmarshalText(text)
+	require.NoError(t, err)
+	assert.Equal(t, original, decoded)
+}
+
+func TestDuplicateErr(t *testing.T) {
+	assert.EqualError(t, DuplicateErr, "duplicate frame")
+}
+
+func TestMaxSpanBatchElementCount(t *testing.T) {
+	assert.Equal(t, 10_000_000, MaxSpanBatchElementCount)
+}

--- a/op-node/rollup/derive/span_batch_util_test.go
+++ b/op-node/rollup/derive/span_batch_util_test.go
@@ -1,0 +1,126 @@
+package derive
+
+import (
+	"bytes"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodeSpanBatchBits(t *testing.T) {
+	t.Run("decode single byte aligned", func(t *testing.T) {
+		// 8 bits: 0b10101010 = 0xAA
+		r := bytes.NewReader([]byte{0xAA})
+		bits, err := decodeSpanBatchBits(r, 8)
+		require.NoError(t, err)
+		assert.Equal(t, big.NewInt(0xAA), bits)
+	})
+
+	t.Run("decode non-byte-aligned", func(t *testing.T) {
+		// 5 bits need 1 byte. 0b00010100 = 0x14, top 3 bits should be zero
+		r := bytes.NewReader([]byte{0x14})
+		bits, err := decodeSpanBatchBits(r, 5)
+		require.NoError(t, err)
+		assert.Equal(t, big.NewInt(0x14), bits)
+	})
+
+	t.Run("decode zero bits", func(t *testing.T) {
+		r := bytes.NewReader([]byte{})
+		bits, err := decodeSpanBatchBits(r, 0)
+		require.NoError(t, err)
+		assert.Equal(t, big.NewInt(0), bits)
+	})
+
+	t.Run("decode multi-byte", func(t *testing.T) {
+		// 16 bits
+		r := bytes.NewReader([]byte{0x01, 0x02})
+		bits, err := decodeSpanBatchBits(r, 16)
+		require.NoError(t, err)
+		assert.Equal(t, big.NewInt(0x0102), bits)
+	})
+
+	t.Run("error on insufficient data", func(t *testing.T) {
+		r := bytes.NewReader([]byte{0x01})
+		_, err := decodeSpanBatchBits(r, 16)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to read bits")
+	})
+
+	t.Run("error on trailing bits beyond bitLength", func(t *testing.T) {
+		// 3 bits max, but byte has bit 7 set (value 128 > 3 bits)
+		r := bytes.NewReader([]byte{0x80})
+		_, err := decodeSpanBatchBits(r, 3)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "bitfield has")
+	})
+}
+
+func TestEncodeSpanBatchBits(t *testing.T) {
+	t.Run("encode single byte aligned", func(t *testing.T) {
+		var buf bytes.Buffer
+		err := encodeSpanBatchBits(&buf, 8, big.NewInt(0xAA))
+		require.NoError(t, err)
+		assert.Equal(t, []byte{0xAA}, buf.Bytes())
+	})
+
+	t.Run("encode non-byte-aligned with padding", func(t *testing.T) {
+		var buf bytes.Buffer
+		// 5 bits, value 0b10101 = 21
+		err := encodeSpanBatchBits(&buf, 5, big.NewInt(21))
+		require.NoError(t, err)
+		// 1 byte, left-padded: 0b00010101 = 0x15
+		assert.Equal(t, []byte{0x15}, buf.Bytes())
+	})
+
+	t.Run("encode zero", func(t *testing.T) {
+		var buf bytes.Buffer
+		err := encodeSpanBatchBits(&buf, 8, big.NewInt(0))
+		require.NoError(t, err)
+		assert.Equal(t, []byte{0x00}, buf.Bytes())
+	})
+
+	t.Run("encode zero bitLength", func(t *testing.T) {
+		var buf bytes.Buffer
+		err := encodeSpanBatchBits(&buf, 0, big.NewInt(0))
+		require.NoError(t, err)
+		assert.Empty(t, buf.Bytes())
+	})
+
+	t.Run("error when bits exceed bitLength", func(t *testing.T) {
+		var buf bytes.Buffer
+		// 3 bits max, but value needs 8 bits
+		err := encodeSpanBatchBits(&buf, 3, big.NewInt(0xFF))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "bitfield is larger than bitLength")
+	})
+}
+
+func TestSpanBatchBitsRoundTrip(t *testing.T) {
+	testCases := []struct {
+		name      string
+		bitLength uint64
+		value     *big.Int
+	}{
+		{"8 bits", 8, big.NewInt(0xFF)},
+		{"16 bits", 16, big.NewInt(0xBEEF)},
+		{"1 bit set", 1, big.NewInt(1)},
+		{"1 bit zero", 1, big.NewInt(0)},
+		{"13 bits", 13, big.NewInt(0x1FFF)},
+		{"24 bits sparse", 24, big.NewInt(0x010001)},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			err := encodeSpanBatchBits(&buf, tc.bitLength, tc.value)
+			require.NoError(t, err)
+
+			r := bytes.NewReader(buf.Bytes())
+			decoded, err := decodeSpanBatchBits(r, tc.bitLength)
+			require.NoError(t, err)
+			assert.Equal(t, 0, tc.value.Cmp(decoded), "expected %s, got %s", tc.value, decoded)
+		})
+	}
+}


### PR DESCRIPTION
32 new Go tests for Error type, ChannelID params, and span batch bit encoding.