### PR TITLE
fix(contracts): improve DelayedWETH loading for fork tests

### DIFF
--- a/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
@@ -390,11 +390,19 @@ contract OPContractsManager_Upgrade_Harness is CommonTest {
             vm.assertEq(blockhash(block.number - 1), game.l1Head().raw());
 
             if (gt.raw() == GameTypes.PERMISSIONED_CANNON.raw()) {
-                vm.assertEq(address(preUpgradeState.permissionedCannonWethProxy), address(game.weth()));
+                vm.assertEq(
+                    address(preUpgradeState.permissionedCannonWethProxy),
+                    address(game.weth()),
+                    "Incorrect permissioned WETH"
+                );
                 vm.assertEq(_challenger, game.challenger());
                 vm.assertEq(_proposer, game.proposer());
             } else {
-                vm.assertEq(address(preUpgradeState.permissionlessWethProxy), address(game.weth()));
+                vm.assertEq(
+                    address(preUpgradeState.permissionlessWethProxy),
+                    address(game.weth()),
+                    "Incorrect permissionless WETH"
+                );
             }
         }
 
@@ -1421,8 +1429,10 @@ contract OPContractsManager_Upgrade_Test is OPContractsManager_Upgrade_Harness {
                 disputeGameFactory, GameTypes.PERMISSIONED_CANNON
             ),
             cannonKonaAbsolutePrestate: DisputeGames.getGameImplPrestate(disputeGameFactory, GameTypes.CANNON_KONA),
-            permissionlessWethProxy: delayedWeth,
-            permissionedCannonWethProxy: delayedWETHPermissionedGameProxy
+            permissionlessWethProxy: DisputeGames.getGameImplDelayedWeth(disputeGameFactory, GameTypes.CANNON),
+            permissionedCannonWethProxy: DisputeGames.getGameImplDelayedWeth(
+                disputeGameFactory, GameTypes.PERMISSIONED_CANNON
+            )
         });
     }
 

--- a/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
@@ -167,18 +167,14 @@ contract OPContractsManager_Upgrade_Harness is CommonTest {
             IDelayedWETH(payable(artifacts.mustGetAddress("PermissionedDelayedWETHProxy")));
         permissionedDisputeGame = IPermissionedDisputeGame(address(artifacts.mustGetAddress("PermissionedDisputeGame")));
         IDisputeGameFactory dgf = IDisputeGameFactory(address(artifacts.mustGetAddress("DisputeGameFactoryProxy")));
-        faultDisputeGame = IFaultDisputeGame(address(dgf.gameImpls(GameTypes.CANNON)));
-        delayedWeth = faultDisputeGame.weth();
 
         // Grab the pre-upgrade state. Use getGameImplPrestate to handle both v1 and v2
         // dispute games (v1 stores prestate on game impl, v2 stores it in gameArgs).
         preUpgradeState = PreUpgradeState({
-            cannonAbsolutePrestate: DisputeGames.getGameImplPrestate(disputeGameFactory, GameTypes.CANNON),
-            permissionedAbsolutePrestate: DisputeGames.getGameImplPrestate(
-                disputeGameFactory, GameTypes.PERMISSIONED_CANNON
-            ),
-            cannonKonaAbsolutePrestate: DisputeGames.getGameImplPrestate(disputeGameFactory, GameTypes.CANNON_KONA),
-            permissionlessWethProxy: delayedWeth,
+            cannonAbsolutePrestate: DisputeGames.getGameImplPrestate(dgf, GameTypes.CANNON),
+            permissionedAbsolutePrestate: DisputeGames.getGameImplPrestate(dgf, GameTypes.PERMISSIONED_CANNON),
+            cannonKonaAbsolutePrestate: DisputeGames.getGameImplPrestate(dgf, GameTypes.CANNON_KONA),
+            permissionlessWethProxy: DisputeGames.getGameImplDelayedWeth(dgf, GameTypes.CANNON),
             permissionedCannonWethProxy: delayedWETHPermissionedGameProxy
         });
 

--- a/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
@@ -163,9 +163,6 @@ contract OPContractsManager_Upgrade_Harness is CommonTest {
         // Artifacts encoded as an address.
         l2ChainId = uint256(uint160(address(artifacts.mustGetAddress("L2ChainId"))));
 
-        delayedWETHPermissionedGameProxy =
-            IDelayedWETH(payable(artifacts.mustGetAddress("PermissionedDelayedWETHProxy")));
-        permissionedDisputeGame = IPermissionedDisputeGame(address(artifacts.mustGetAddress("PermissionedDisputeGame")));
         IDisputeGameFactory dgf = IDisputeGameFactory(address(artifacts.mustGetAddress("DisputeGameFactoryProxy")));
 
         // Grab the pre-upgrade state. Use getGameImplPrestate to handle both v1 and v2
@@ -175,7 +172,7 @@ contract OPContractsManager_Upgrade_Harness is CommonTest {
             permissionedAbsolutePrestate: DisputeGames.getGameImplPrestate(dgf, GameTypes.PERMISSIONED_CANNON),
             cannonKonaAbsolutePrestate: DisputeGames.getGameImplPrestate(dgf, GameTypes.CANNON_KONA),
             permissionlessWethProxy: DisputeGames.getGameImplDelayedWeth(dgf, GameTypes.CANNON),
-            permissionedCannonWethProxy: delayedWETHPermissionedGameProxy
+            permissionedCannonWethProxy: DisputeGames.getGameImplDelayedWeth(dgf, GameTypes.PERMISSIONED_CANNON)
         });
 
         // Since this superchainConfig is already at the expected reinitializer version...

--- a/packages/contracts-bedrock/test/setup/DisputeGames.sol
+++ b/packages/contracts-bedrock/test/setup/DisputeGames.sol
@@ -13,6 +13,7 @@ import { LibGameArgs } from "src/dispute/lib/LibGameArgs.sol";
 
 // Interfaces
 import "../../interfaces/dispute/IDisputeGame.sol";
+import "../../interfaces/dispute/IDelayedWETH.sol";
 import "../../interfaces/dispute/IDisputeGameFactory.sol";
 import { IFaultDisputeGame } from "../../interfaces/dispute/IFaultDisputeGame.sol";
 import { IPermissionedDisputeGame } from "../../interfaces/dispute/IPermissionedDisputeGame.sol";
@@ -151,6 +152,35 @@ library DisputeGames {
             prestate_ = Claim.wrap(gameArgs.absolutePrestate);
         } else {
             prestate_ = IFaultDisputeGame(gameImpl).absolutePrestate();
+        }
+    }
+
+    /// @notice Gets the DelayedWETH for a game type, handling both v1 and v2 dispute games.
+    ///         V1 games store the prestate on the game implementation, v2 games store it in gameArgs.
+    ///         Returns address(0) if no implementation exists for the game type.
+    /// @param _dgf The dispute game factory.
+    /// @param _gameType The game type to get the DelayedWETH for.
+    /// @return delayedWeth_ The delayedWETH address.
+    function getGameImplDelayedWeth(
+        IDisputeGameFactory _dgf,
+        GameType _gameType
+    )
+        internal
+        view
+        returns (IDelayedWETH delayedWeth_)
+    {
+        // Return zero if no implementation exists for this game type
+        address gameImpl = address(_dgf.gameImpls(_gameType));
+        if (gameImpl == address(0)) {
+            return IDelayedWETH(payable(address(0)));
+        }
+
+        (bool gameArgsExist, bytes memory gameArgsData) = _getGameArgs(_dgf, _gameType);
+        if (gameArgsExist) {
+            LibGameArgs.GameArgs memory gameArgs = LibGameArgs.decode(gameArgsData);
+            delayedWeth_ = IDelayedWETH(payable(gameArgs.weth));
+        } else {
+            delayedWeth_ = IFaultDisputeGame(gameImpl).weth();
         }
     }
 

--- a/packages/contracts-bedrock/test/setup/ForkLive.s.sol
+++ b/packages/contracts-bedrock/test/setup/ForkLive.s.sol
@@ -184,17 +184,26 @@ contract ForkLive is Deployer, StdAssertions, FeatureFlags {
         address permissionedGameImpl = address(disputeGameFactory.gameImpls(GameTypes.PERMISSIONED_CANNON));
         artifacts.save("PermissionedDisputeGame", permissionedGameImpl);
 
+        // Try to get DelayedWETH from gameArgs (v2), fallback to game impl (v1)
         IDelayedWETH delayedWeth;
+        bool useV1 = false;
+
+        // Try v2 structure first (gameArgs)
         try disputeGameFactory.gameArgs(GameTypes.PERMISSIONED_CANNON) returns (bytes memory gameArgsData_) {
             if (gameArgsData_.length > 0) {
-                // V2 structure: DelayedWETH is in gameArgs
+                // V2 structure: gameArgs exists and has data, decode it (must succeed)
                 delayedWeth = IDelayedWETH(payable(LibGameArgs.decode(gameArgsData_).weth));
             } else {
-                // V1 structure: DelayedWETH is on game impl
-                delayedWeth = IFaultDisputeGame(permissionedGameImpl).weth();
+                // V1 structure: gameArgs exists but returns empty
+                useV1 = true;
             }
         } catch {
-            // V1 structure (gameArgs() doesn't exist): DelayedWETH is on game impl
+            // V1 structure: gameArgs() doesn't exist
+            useV1 = true;
+        }
+
+        // Fallback to v1 structure (get weth from game impl)
+        if (useV1) {
             delayedWeth = IFaultDisputeGame(permissionedGameImpl).weth();
         }
 

--- a/packages/contracts-bedrock/test/setup/ForkLive.s.sol
+++ b/packages/contracts-bedrock/test/setup/ForkLive.s.sol
@@ -32,7 +32,6 @@ import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
 import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
 import { IOPContractsManager } from "interfaces/L1/IOPContractsManager.sol";
 import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.sol";
-import { IFaultDisputeGame } from "interfaces/dispute/IFaultDisputeGame.sol";
 import { IETHLockbox } from "interfaces/L1/IETHLockbox.sol";
 import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
 import { IOPContractsManagerUpgrader } from "interfaces/L1/IOPContractsManager.sol";
@@ -180,36 +179,21 @@ contract ForkLive is Deployer, StdAssertions, FeatureFlags {
 
         // The PermissionedDisputeGame and PermissionedDelayedWETHProxy are not listed in the registry for OP, so we
         // look it up onchain.
-        // Try gameArgs first (v2 structure), fall back to gameImpl.weth() (v1 structure).
         address permissionedGameImpl = address(disputeGameFactory.gameImpls(GameTypes.PERMISSIONED_CANNON));
         artifacts.save("PermissionedDisputeGame", permissionedGameImpl);
 
-        // Try to get DelayedWETH from gameArgs (v2), fallback to game impl (v1)
-        IDelayedWETH delayedWeth;
-        bool useV1 = false;
+        // Get DelayedWETH for PERMISSIONED games
+        IDelayedWETH permissionedDelayedWeth =
+            DisputeGames.getGameImplDelayedWeth(disputeGameFactory, GameTypes.PERMISSIONED_CANNON);
+        artifacts.save("PermissionedDelayedWETHProxy", address(permissionedDelayedWeth));
 
-        // Try v2 structure first (gameArgs)
-        try disputeGameFactory.gameArgs(GameTypes.PERMISSIONED_CANNON) returns (bytes memory gameArgsData_) {
-            if (gameArgsData_.length > 0) {
-                // V2 structure: gameArgs exists and has data, decode it (must succeed)
-                delayedWeth = IDelayedWETH(payable(LibGameArgs.decode(gameArgsData_).weth));
-            } else {
-                // V1 structure: gameArgs exists but returns empty
-                useV1 = true;
-            }
-        } catch {
-            // V1 structure: gameArgs() doesn't exist
-            useV1 = true;
-        }
+        // Get DelayedWETH for PERMISSIONLESS games (CANNON)
+        IDelayedWETH permissionlessDelayedWeth =
+            DisputeGames.getGameImplDelayedWeth(disputeGameFactory, GameTypes.PERMISSIONED_CANNON);
 
-        // Fallback to v1 structure (get weth from game impl)
-        if (useV1) {
-            delayedWeth = IFaultDisputeGame(permissionedGameImpl).weth();
-        }
-
-        artifacts.save("PermissionedDelayedWETHProxy", address(delayedWeth));
-        artifacts.save("DelayedWETHProxy", address(delayedWeth));
-        artifacts.save("DelayedWETHImpl", EIP1967Helper.getImplementation(address(delayedWeth)));
+        // The SR seems out-of-date, so pull the DelayedWETH addresses from the games.
+        artifacts.save("DelayedWETHProxy", address(permissionlessDelayedWeth));
+        artifacts.save("DelayedWETHImpl", EIP1967Helper.getImplementation(address(permissionlessDelayedWeth)));
     }
 
     /// @notice Calls to the Deploy.s.sol contract etched by Setup.sol to a deterministic address, sets up the

--- a/packages/contracts-bedrock/test/setup/ForkLive.s.sol
+++ b/packages/contracts-bedrock/test/setup/ForkLive.s.sol
@@ -189,7 +189,7 @@ contract ForkLive is Deployer, StdAssertions, FeatureFlags {
 
         // Get DelayedWETH for PERMISSIONLESS games (CANNON)
         IDelayedWETH permissionlessDelayedWeth =
-            DisputeGames.getGameImplDelayedWeth(disputeGameFactory, GameTypes.PERMISSIONED_CANNON);
+            DisputeGames.getGameImplDelayedWeth(disputeGameFactory, GameTypes.CANNON);
 
         // The SR seems out-of-date, so pull the DelayedWETH addresses from the games.
         artifacts.save("DelayedWETHProxy", address(permissionlessDelayedWeth));

--- a/packages/contracts-bedrock/test/setup/ForkLive.s.sol
+++ b/packages/contracts-bedrock/test/setup/ForkLive.s.sol
@@ -185,10 +185,10 @@ contract ForkLive is Deployer, StdAssertions, FeatureFlags {
         artifacts.save("PermissionedDisputeGame", permissionedGameImpl);
 
         IDelayedWETH delayedWeth;
-        try disputeGameFactory.gameArgs(GameTypes.PERMISSIONED_CANNON) returns (bytes memory gameArgsData) {
-            if (gameArgsData.length > 0) {
+        try disputeGameFactory.gameArgs(GameTypes.PERMISSIONED_CANNON) returns (bytes memory gameArgsData_) {
+            if (gameArgsData_.length > 0) {
                 // V2 structure: DelayedWETH is in gameArgs
-                delayedWeth = IDelayedWETH(payable(LibGameArgs.decode(gameArgsData).weth));
+                delayedWeth = IDelayedWETH(payable(LibGameArgs.decode(gameArgsData_).weth));
             } else {
                 // V1 structure: DelayedWETH is on game impl
                 delayedWeth = IFaultDisputeGame(permissionedGameImpl).weth();

--- a/packages/contracts-bedrock/test/setup/ForkLive.s.sol
+++ b/packages/contracts-bedrock/test/setup/ForkLive.s.sol
@@ -179,15 +179,28 @@ contract ForkLive is Deployer, StdAssertions, FeatureFlags {
             IDisputeGameFactory(artifacts.mustGetAddress("DisputeGameFactoryProxy"));
 
         // The PermissionedDisputeGame and PermissionedDelayedWETHProxy are not listed in the registry for OP, so we
-        // look it up onchain
-        IFaultDisputeGame permissionedDisputeGame =
-            IFaultDisputeGame(address(disputeGameFactory.gameImpls(GameTypes.PERMISSIONED_CANNON)));
-        artifacts.save("PermissionedDisputeGame", address(permissionedDisputeGame));
-        artifacts.save("PermissionedDelayedWETHProxy", address(permissionedDisputeGame.weth()));
+        // look it up onchain.
+        // Try gameArgs first (v2 structure), fall back to gameImpl.weth() (v1 structure).
+        address permissionedGameImpl = address(disputeGameFactory.gameImpls(GameTypes.PERMISSIONED_CANNON));
+        artifacts.save("PermissionedDisputeGame", permissionedGameImpl);
 
-        // The SR seems out-of-date, so pull the DelayedWETH addresses from the PermissionedDisputeGame.
-        artifacts.save("DelayedWETHProxy", address(permissionedDisputeGame.weth()));
-        artifacts.save("DelayedWETHImpl", EIP1967Helper.getImplementation(address(permissionedDisputeGame.weth())));
+        IDelayedWETH delayedWeth;
+        try disputeGameFactory.gameArgs(GameTypes.PERMISSIONED_CANNON) returns (bytes memory gameArgsData) {
+            if (gameArgsData.length > 0) {
+                // V2 structure: DelayedWETH is in gameArgs
+                delayedWeth = IDelayedWETH(payable(LibGameArgs.decode(gameArgsData).weth));
+            } else {
+                // V1 structure: DelayedWETH is on game impl
+                delayedWeth = IFaultDisputeGame(permissionedGameImpl).weth();
+            }
+        } catch {
+            // V1 structure (gameArgs() doesn't exist): DelayedWETH is on game impl
+            delayedWeth = IFaultDisputeGame(permissionedGameImpl).weth();
+        }
+
+        artifacts.save("PermissionedDelayedWETHProxy", address(delayedWeth));
+        artifacts.save("DelayedWETHProxy", address(delayedWeth));
+        artifacts.save("DelayedWETHImpl", EIP1967Helper.getImplementation(address(delayedWeth)));
     }
 
     /// @notice Calls to the Deploy.s.sol contract etched by Setup.sol to a deterministic address, sets up the


### PR DESCRIPTION
This PR fixes several issues with how DelayedWETH addresses are loaded during fork-based upgrade tests.

## Changes

### Load pre-upgrade state from on-chain queries
- Changed upgrade tests to fetch DelayedWETH addresses directly from on-chain state using `DisputeGames.getGameImplDelayedWeth()` instead of relying on artifacts
- This makes the tests more robust and ensures they work correctly regardless of whether artifacts were properly populated

### Fix v1/v2 OPCM structure handling
- Improved fallback logic in `ForkLive._readSuperchainRegistry()` to properly handle both v1 and v2 OPCM structures:
  - **V1 structure:** DelayedWETH accessed via `gameImpl.weth()`
  - **V2 structure:** DelayedWETH accessed via `gameArgs().weth`
- The code now attempts v2 first, then falls back to v1 if gameArgs don't exist or return empty bytes
- Ensures proper error propagation when gameArgs data is invalid

### Fix copy-paste bug in ForkLive
- Fixed bug where permissionless DelayedWETH was being fetched using `GameTypes.PERMISSIONED_CANNON` instead of `GameTypes.CANNON`
- This caused incorrect artifact addresses to be saved

### Improve test error messages
- Added descriptive error messages to WETH assertions to make test failures easier to diagnose

## Testing
- All upgrade tests now pass with these changes
- Tests work correctly across all feature variants including `CUSTOM_GAS_TOKEN`