### PR TITLE
ci(op-acceptance): parallelize acceptance tests across CI nodes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,6 +86,9 @@ parameters:
   flake-shake-workers:
     type: integer
     default: 50
+  acceptance-test-parallelism:
+    type: integer
+    default: 4
   # go-cache-version can be used as a cache buster when making breaking changes to caching strategy
   go-cache-version:
     type: string
@@ -126,6 +129,7 @@ workflows:
             .* c-flake-shake-iterations << pipeline.parameters.flake-shake-iterations >> .circleci/continue/main.yml
             .* c-flake-shake-workers << pipeline.parameters.flake-shake-workers >> .circleci/continue/main.yml
             .* c-go-cache-version << pipeline.parameters.go-cache-version >> .circleci/continue/main.yml
+            .* c-acceptance-test-parallelism << pipeline.parameters.acceptance-test-parallelism >> .circleci/continue/main.yml
 
             rust/.* c-rust_ci_dispatch << pipeline.parameters.rust_ci_dispatch >> .circleci/continue/rust-ci.yml
             rust/.* c-default_docker_image << pipeline.parameters.default_docker_image >> .circleci/continue/rust-ci.yml

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -2289,9 +2289,9 @@ jobs:
                 path: ./op-acceptance-tests/logs
       # Persist logs for report consolidation job
       - persist_to_workspace:
-          root: op-acceptance-tests
+          root: .
           paths:
-            - logs/
+            - op-acceptance-tests/logs/
       - when:
           condition: on_fail
           steps:

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -74,6 +74,9 @@ parameters:
   c-flake-shake-workers:
     type: integer
     default: 50
+  c-acceptance-test-parallelism:
+    type: integer
+    default: 4
   # go-cache-version can be used as a cache buster when making breaking changes to caching strategy
   c-go-cache-version:
     type: string
@@ -2127,6 +2130,7 @@ jobs:
       - image: <<pipeline.parameters.c-default_docker_image>>
     circleci_ip_ranges: true
     resource_class: 2xlarge+
+    parallelism: << pipeline.parameters.c-acceptance-test-parallelism >>
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
@@ -2146,6 +2150,14 @@ jobs:
             echo "export RUST_BINARY_PATH_KONA_SUPERVISOR=$ROOT_DIR/rust/target/release/kona-supervisor" >> "$BASH_ENV"
             echo "export RUST_BINARY_PATH_OP_RBUILDER=$BIN_DIR/op-rbuilder" >> "$BASH_ENV"
             echo "export RUST_BINARY_PATH_ROLLUP_BOOST=$BIN_DIR/rollup-boost" >> "$BASH_ENV"
+      - run:
+          name: Configure CI test splitting
+          command: |
+            if [[ "${CIRCLE_NODE_TOTAL:-1}" -gt 1 ]]; then
+              echo "Splitting tests: node ${CIRCLE_NODE_INDEX} of ${CIRCLE_NODE_TOTAL}"
+              echo "export OP_ACCEPTOR_SPLIT_TOTAL=$CIRCLE_NODE_TOTAL" >> "$BASH_ENV"
+              echo "export OP_ACCEPTOR_SPLIT_INDEX=$CIRCLE_NODE_INDEX" >> "$BASH_ENV"
+            fi
       # Restore cached Go modules
       - restore_cache:
           keys:
@@ -2220,11 +2232,69 @@ jobs:
           steps:
             - store_artifacts:
                 path: ./op-acceptance-tests/logs
+      # Persist logs for report consolidation job
+      - persist_to_workspace:
+          root: op-acceptance-tests
+          paths:
+            - logs/
       - when:
           condition: on_fail
           steps:
             - notify-failures-on-develop:
                 mentions: "@protocol-devx-pod @changwan"
+
+  op-acceptance-tests-report:
+    docker:
+      - image: <<pipeline.parameters.c-default_docker_image>>
+    resource_class: medium
+    steps:
+      - utils/checkout-with-mise:
+          checkout-method: blobless
+          enable-mise-cache: true
+      - attach_workspace:
+          at: .
+      - restore_cache:
+          keys:
+            - go-mod-v1-{{ checksum "go.sum" }}
+            - go-mod-v1-
+      - run:
+          name: Build op-acceptor
+          working_directory: op-acceptance-tests
+          command: |
+            go mod download
+            just cmd-check
+      - run:
+          name: Merge test results from all parallel nodes
+          working_directory: op-acceptance-tests
+          command: |
+            mkdir -p results
+            # Merge all raw_go_events.log files from parallel nodes
+            find logs/ -name "raw_go_events.log" -exec cat {} + > merged_raw_events.log || true
+            # Generate consolidated JUnit XML
+            gotestsum --junitfile results/results.xml --raw-command cat merged_raw_events.log || true
+            # Generate consolidated summary
+            find logs/ -name "summary.log" -exec cat {} + > consolidated-summary.log || true
+      - run:
+          name: Generate consolidated HTML report
+          working_directory: op-acceptance-tests
+          command: |
+            if [ -s merged_raw_events.log ]; then
+              op-acceptor \
+                --report-from-events merged_raw_events.log \
+                --logdir ./consolidated-report \
+                --orchestrator sysgo
+              echo "Consolidated HTML report generated"
+            else
+              echo "No events to generate report from"
+            fi
+      - store_test_results:
+          path: ./op-acceptance-tests/results
+      - store_artifacts:
+          path: ./op-acceptance-tests/logs
+      - store_artifacts:
+          path: ./op-acceptance-tests/consolidated-report
+      - store_artifacts:
+          path: ./op-acceptance-tests/consolidated-summary.log
 
   op-acceptance-tests-flake-shake:
     parameters:
@@ -3279,6 +3349,9 @@ workflows:
             - cannon-kona-prestate
             - cannon-kona-host
             - rust-binaries-for-sysgo
+      - op-acceptance-tests-report:
+          requires:
+            - memory-all
       # Generate flaky test report
       - generate-flaky-report:
           name: generate-flaky-tests-report

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -2230,8 +2230,10 @@ jobs:
             fi
             # Use timing hints for balanced splitting if available
             if [ -f timing-hints.json ]; then
-              echo "Using timing hints for balanced CI splitting"
+              echo "Timing hints found — using timing-based bin-packing for balanced CI splitting"
               echo "export OP_ACCEPTOR_SPLIT_TIMING_FILE=$(pwd)/timing-hints.json" >> "$BASH_ENV"
+            else
+              echo "No timing hints found — using round-robin split (timing cache builds after first run)"
             fi
       # Restore cached Go modules (needed for go test runtime)
       - restore_cache:

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -2116,6 +2116,80 @@ jobs:
       - notify-failures-on-develop:
           mentions: "@changwan <@U08L5U8070U>" # @changwan @Anton Evangelatov
 
+  # Setup job: single node that does checkout, Rust build, Go mod download,
+  # test compilation, and persists everything to workspace. This avoids
+  # repeating ~8 min of setup on every parallel test node.
+  op-acceptance-tests-setup:
+    parameters:
+      gate:
+        description: The gate to run the acceptance tests against.
+        type: string
+        default: ""
+    docker:
+      - image: <<pipeline.parameters.c-default_docker_image>>
+    circleci_ip_ranges: true
+    resource_class: 2xlarge+
+    steps:
+      - utils/checkout-with-mise:
+          checkout-method: blobless
+          enable-mise-cache: true
+      - attach_workspace:
+          at: .
+      # Build kona-node for the acceptance tests. This automatically gets kona from the cache.
+      - rust-build:
+          directory: rust
+          profile: "release"
+      - run:
+          name: Configure Rust binary paths (sysgo)
+          command: |
+            ROOT_DIR="$(pwd)"
+            BIN_DIR="$ROOT_DIR/.circleci-cache/rust-binaries"
+            echo "export RUST_BINARY_PATH_KONA_NODE=$ROOT_DIR/rust/target/release/kona-node" >> "$BASH_ENV"
+            echo "export RUST_BINARY_PATH_KONA_SUPERVISOR=$ROOT_DIR/rust/target/release/kona-supervisor" >> "$BASH_ENV"
+            echo "export RUST_BINARY_PATH_OP_RBUILDER=$BIN_DIR/op-rbuilder" >> "$BASH_ENV"
+            echo "export RUST_BINARY_PATH_ROLLUP_BOOST=$BIN_DIR/rollup-boost" >> "$BASH_ENV"
+      # Restore cached Go modules
+      - restore_cache:
+          keys:
+            - go-mod-v1-{{ checksum "go.sum" }}
+            - go-mod-v1-
+      # Download Go dependencies
+      - run:
+          name: Download Go dependencies
+          working_directory: op-acceptance-tests
+          command: go mod download
+      - run:
+          name: Lint/Vet/Build op-acceptance-tests/cmd
+          working_directory: op-acceptance-tests
+          command: |
+            just cmd-check
+      # Prepare the test environment (compile tests to populate Go build cache)
+      - run:
+          name: Prepare test environment (compile tests and cache build results)
+          working_directory: op-acceptance-tests
+          command: go test -v -c -o /dev/null $(go list -f '{{if .TestGoFiles}}{{.ImportPath}}{{end}}' ./tests/...)
+      # Save the module cache for future runs
+      - save_cache:
+          key: go-mod-v1-{{ checksum "go.sum" }}
+          paths:
+            - "/go/pkg/mod"
+      # Restore timing hints from previous runs (for balanced CI splitting)
+      - restore_cache:
+          keys:
+            - acceptance-test-timings-v1
+      # Persist everything test nodes need to workspace
+      - persist_to_workspace:
+          root: .
+          paths:
+            # Go build cache (compiled test binaries)
+            - op-acceptance-tests/
+            # Rust binaries
+            - rust/target/release/kona-node
+            - rust/target/release/kona-supervisor
+            - .circleci-cache/rust-binaries/
+            # Timing hints for balanced splitting
+            - timing-hints.json
+
   op-acceptance-tests:
     parameters:
       gate:
@@ -2137,10 +2211,6 @@ jobs:
           enable-mise-cache: true
       - attach_workspace:
           at: .
-      # Build kona-node for the acceptance tests. This automatically gets kona from the cache.
-      - rust-build:
-          directory: rust
-          profile: "release"
       - run:
           name: Configure Rust binary paths (sysgo)
           command: |
@@ -2158,27 +2228,17 @@ jobs:
               echo "export OP_ACCEPTOR_SPLIT_TOTAL=$CIRCLE_NODE_TOTAL" >> "$BASH_ENV"
               echo "export OP_ACCEPTOR_SPLIT_INDEX=$CIRCLE_NODE_INDEX" >> "$BASH_ENV"
             fi
-      # Restore cached Go modules
+            # Use timing hints for balanced splitting if available
+            if [ -f timing-hints.json ]; then
+              echo "Using timing hints for balanced CI splitting"
+              echo "export OP_ACCEPTOR_SPLIT_TIMING_FILE=$(pwd)/timing-hints.json" >> "$BASH_ENV"
+            fi
+      # Restore cached Go modules (needed for go test runtime)
       - restore_cache:
           keys:
             - go-mod-v1-{{ checksum "go.sum" }}
             - go-mod-v1-
-      # Download Go dependencies
-      - run:
-          name: Download Go dependencies
-          working_directory: op-acceptance-tests
-          command: go mod download
-      - run:
-          name: Lint/Vet/Build op-acceptance-tests/cmd
-          working_directory: op-acceptance-tests
-          command: |
-            just cmd-check
-      # Prepare the test environment
-      - run:
-          name: Prepare test environment (compile tests and cache build results)
-          working_directory: op-acceptance-tests
-          command: go test -v -c -o /dev/null $(go list -f '{{if .TestGoFiles}}{{.ImportPath}}{{end}}' ./tests/...)
-      # Run the acceptance tests (if the devnet is running)
+      # Run the acceptance tests
       - run:
           name: Run acceptance tests (gate=<<parameters.gate>>)
           working_directory: op-acceptance-tests
@@ -2216,11 +2276,6 @@ jobs:
           command: |
             LOG_DIR=$(ls -td -- logs/* | head -1)
             gotestsum --junitfile results/results.xml --raw-command cat $LOG_DIR/raw_go_events.log || true
-      # Save the module cache for future runs
-      - save_cache:
-          key: go-mod-v1-{{ checksum "go.sum" }}
-          paths:
-            - "/go/pkg/mod"
       # Store test results and artifacts
       - when:
           condition: always
@@ -2275,15 +2330,16 @@ jobs:
             # Generate consolidated summary
             find logs/ -name "summary.log" -exec cat {} + > consolidated-summary.log || true
       - run:
-          name: Generate consolidated HTML report
+          name: Generate consolidated HTML report and timing data
           working_directory: op-acceptance-tests
           command: |
             if [ -s merged_raw_events.log ]; then
               op-acceptor \
                 --report-from-events merged_raw_events.log \
                 --logdir ./consolidated-report \
-                --orchestrator sysgo
-              echo "Consolidated HTML report generated"
+                --orchestrator sysgo \
+                --split-timing-output ../timing-hints.json
+              echo "Consolidated HTML report and timing data generated"
             else
               echo "No events to generate report from"
             fi
@@ -2295,6 +2351,11 @@ jobs:
           path: ./op-acceptance-tests/consolidated-report
       - store_artifacts:
           path: ./op-acceptance-tests/consolidated-summary.log
+      # Cache timing data for next run's balanced splitting
+      - save_cache:
+          key: acceptance-test-timings-v1-{{ epoch }}
+          paths:
+            - timing-hints.json
 
   op-acceptance-tests-flake-shake:
     parameters:
@@ -3335,6 +3396,17 @@ workflows:
             - rust-build-op-rbuilder
             - rust-build-rollup-boost
       # IN-MEMORY (all)
+      - op-acceptance-tests-setup:
+          name: memory-all-setup
+          gate: ""
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+          requires:
+            - contracts-bedrock-build
+            - cannon-prestate-quick
+            - cannon-kona-prestate
+            - cannon-kona-host
+            - rust-binaries-for-sysgo
       - op-acceptance-tests:
           name: memory-all
           gate: "" # Empty gate = gateless mode
@@ -3344,11 +3416,7 @@ workflows:
             - slack
             - discord
           requires:
-            - contracts-bedrock-build
-            - cannon-prestate-quick
-            - cannon-kona-prestate
-            - cannon-kona-host
-            - rust-binaries-for-sysgo
+            - memory-all-setup
       - op-acceptance-tests-report:
           requires:
             - memory-all

--- a/mise.toml
+++ b/mise.toml
@@ -40,7 +40,7 @@ anvil = "1.2.3"
 codecov-uploader = "0.8.0"
 goreleaser-pro = "2.11.2"
 kurtosis = "1.8.1"
-op-acceptor = "op-acceptor/v3.8.3"
+op-acceptor = "op-acceptor/v3.9.0-rc.1"
 git-cliff = "2.12.0"
 
 # Fake dependencies

--- a/mise.toml
+++ b/mise.toml
@@ -40,7 +40,7 @@ anvil = "1.2.3"
 codecov-uploader = "0.8.0"
 goreleaser-pro = "2.11.2"
 kurtosis = "1.8.1"
-op-acceptor = "op-acceptor/v3.9.0-rc.1"
+op-acceptor = "op-acceptor/v3.9.0-rc.2"
 git-cliff = "2.12.0"
 
 # Fake dependencies

--- a/mise.toml
+++ b/mise.toml
@@ -40,7 +40,7 @@ anvil = "1.2.3"
 codecov-uploader = "0.8.0"
 goreleaser-pro = "2.11.2"
 kurtosis = "1.8.1"
-op-acceptor = "op-acceptor/v3.9.0-rc.2"
+op-acceptor = "op-acceptor/v3.9.0-rc.3"
 git-cliff = "2.12.0"
 
 # Fake dependencies

--- a/op-acceptance-tests/justfile
+++ b/op-acceptance-tests/justfile
@@ -1,6 +1,6 @@
 REPO_ROOT := `realpath ..`  # path to the root of the optimism monorepo
 KURTOSIS_DIR := REPO_ROOT + "/kurtosis-devnet"
-ACCEPTOR_VERSION := env_var_or_default("ACCEPTOR_VERSION", "v3.9.0-rc.2")
+ACCEPTOR_VERSION := env_var_or_default("ACCEPTOR_VERSION", "v3.9.0-rc.3")
 DOCKER_REGISTRY := env_var_or_default("DOCKER_REGISTRY", "us-docker.pkg.dev/oplabs-tools-artifacts/images")
 ACCEPTOR_IMAGE := env_var_or_default("ACCEPTOR_IMAGE", DOCKER_REGISTRY + "/op-acceptor:" + ACCEPTOR_VERSION)
 

--- a/op-acceptance-tests/justfile
+++ b/op-acceptance-tests/justfile
@@ -1,6 +1,6 @@
 REPO_ROOT := `realpath ..`  # path to the root of the optimism monorepo
 KURTOSIS_DIR := REPO_ROOT + "/kurtosis-devnet"
-ACCEPTOR_VERSION := env_var_or_default("ACCEPTOR_VERSION", "v3.8.3")
+ACCEPTOR_VERSION := env_var_or_default("ACCEPTOR_VERSION", "v3.9.0-rc.1")
 DOCKER_REGISTRY := env_var_or_default("DOCKER_REGISTRY", "us-docker.pkg.dev/oplabs-tools-artifacts/images")
 ACCEPTOR_IMAGE := env_var_or_default("ACCEPTOR_IMAGE", DOCKER_REGISTRY + "/op-acceptor:" + ACCEPTOR_VERSION)
 

--- a/op-acceptance-tests/justfile
+++ b/op-acceptance-tests/justfile
@@ -1,6 +1,6 @@
 REPO_ROOT := `realpath ..`  # path to the root of the optimism monorepo
 KURTOSIS_DIR := REPO_ROOT + "/kurtosis-devnet"
-ACCEPTOR_VERSION := env_var_or_default("ACCEPTOR_VERSION", "v3.9.0-rc.1")
+ACCEPTOR_VERSION := env_var_or_default("ACCEPTOR_VERSION", "v3.9.0-rc.2")
 DOCKER_REGISTRY := env_var_or_default("DOCKER_REGISTRY", "us-docker.pkg.dev/oplabs-tools-artifacts/images")
 ACCEPTOR_IMAGE := env_var_or_default("ACCEPTOR_IMAGE", DOCKER_REGISTRY + "/op-acceptor:" + ACCEPTOR_VERSION)
 


### PR DESCRIPTION
## Summary

- Spread acceptance tests across 4 CircleCI nodes using the `parallelism` key, bridging `CIRCLE_NODE_TOTAL/INDEX` → `OP_ACCEPTOR_SPLIT_TOTAL/INDEX`
- Add a report consolidation job (`op-acceptance-tests-report`) that merges results from all nodes into a single JUnit XML + HTML report
- Bump op-acceptor to `v3.9.0-rc.1` which has the new `--split-total`, `--split-index`, and `--report-from-events` flags
- Parallelism default is 4, tunable via `acceptance-test-parallelism` pipeline parameter

Companion PR: https://github.com/ethereum-optimism/infra/pull/553

## Test plan

- [ ] Verify each parallel node runs a non-overlapping subset (check logs)
- [ ] Verify the report consolidation job produces a merged HTML report
- [ ] Sanity check with `parallelism: 1` to confirm no regressions