### PR TITLE
supernode: Add 30s Context Deadline to Inner Node Shutdown

### DIFF
--- a/op-supernode/supernode/chain_container/virtual_node/virtual_node.go
+++ b/op-supernode/supernode/chain_container/virtual_node/virtual_node.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"math"
 	"sync"
+	"time"
 
 	opnodecfg "github.com/ethereum-optimism/optimism/op-node/config"
 	opmetrics "github.com/ethereum-optimism/optimism/op-node/metrics"
@@ -148,7 +149,8 @@ func (v *simpleVirtualNode) Start(ctx context.Context) error {
 
 	// Stop the inner node if it's still running
 	if v.inner != nil {
-		stopCtx := context.Background()
+		stopCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
 		if err := v.inner.Stop(stopCtx); err != nil {
 			v.log.Error("error stopping inner node", "err", err)
 		}


### PR DESCRIPTION
I suspect Supernode is partially responsible for the recent 2h test timeouts.

My current understanding is that a difference in CI test runner behavior is now exposing a failure to shutdown some applications. Proofs found one application which failed to notice closed context while waiting on a channel.

However, I also saw one instance of Supernode doing this, and from the appearance of the logs, the inner node was stuck running.

When the inner node is stopped, no deadline is used, and that's my current best explanation for what I saw.

In any case, seems like a good improvement to attach timeouts to closing signals so we aren't stuck waiting at close forever, and the test can actually end.