### PR TITLE
  fix(engine): add retry limit to prevent infinite task stalls

### DIFF
--- a/rust/kona/crates/node/engine/src/task_queue/core.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/core.rs
@@ -14,6 +14,10 @@ use std::{collections::BinaryHeap, sync::Arc};
 use thiserror::Error;
 use tokio::sync::watch::Sender;
 
+/// Maximum number of times a task with a temporary error can be retried
+/// before being escalated to a reset error.
+const MAX_TASK_RETRIES: usize = 10;
+
 /// The [`Engine`] task queue.
 ///
 /// Tasks of a shared [`EngineTask`] variant are processed in FIFO order, providing synchronization
@@ -26,7 +30,8 @@ use tokio::sync::watch::Sender;
 ///
 /// Tasks within the queue are also considered fallible. If they fail with a temporary error,
 /// they are not popped from the queue, the error is returned, and they are retried on the
-/// next call to [`Engine::drain`].
+/// next call to [`Engine::drain`]. After [`MAX_TASK_RETRIES`] attempts, temporary errors
+/// are escalated to reset errors to prevent infinite stalls.
 #[derive(Debug)]
 pub struct Engine<EngineClient_: EngineClient> {
     /// The state of the engine.
@@ -37,6 +42,9 @@ pub struct Engine<EngineClient_: EngineClient> {
     task_queue_length: Sender<usize>,
     /// The task queue.
     tasks: BinaryHeap<EngineTask<EngineClient_>>,
+    /// Tracks the number of consecutive retries for the current task at the front of the queue.
+    /// Reset to 0 when a task succeeds or when a different task moves to the front.
+    task_retry_count: usize,
 }
 
 impl<EngineClient_: EngineClient> Engine<EngineClient_> {
@@ -46,7 +54,13 @@ impl<EngineClient_: EngineClient> Engine<EngineClient_> {
         state_sender: Sender<EngineState>,
         task_queue_length: Sender<usize>,
     ) -> Self {
-        Self { state: initial_state, state_sender, task_queue_length, tasks: BinaryHeap::default() }
+        Self {
+            state: initial_state,
+            state_sender,
+            task_queue_length,
+            tasks: BinaryHeap::default(),
+            task_retry_count: 0,
+        }
     }
 
     /// Returns a reference to the inner [`EngineState`].
@@ -140,27 +154,82 @@ impl<EngineClient_: EngineClient> Engine<EngineClient_> {
         Ok((start.safe, l1_origin_info, system_config))
     }
 
-    /// Clears the task queue.
+    /// Clears the task queue and resets the retry counter.
     pub fn clear(&mut self) {
         self.tasks.clear();
+        self.task_retry_count = 0;
     }
 
     /// Attempts to drain the queue by executing all [`EngineTask`]s in-order. If any task returns
     /// an error along the way, it is not popped from the queue (in case it must be retried) and
     /// the error is returned.
+    ///
+    /// To prevent infinite stalls, temporary errors are escalated to reset errors after
+    /// [`MAX_TASK_RETRIES`] consecutive failures of the same task.
     pub async fn drain(&mut self) -> Result<(), EngineTaskErrors> {
         // Drain tasks in order of priority, halting on errors for a retry to be attempted.
         while let Some(task) = self.tasks.peek() {
             // Execute the task
-            task.execute(&mut self.state).await?;
+            match task.execute(&mut self.state).await {
+                Ok(_) => {
+                    // Task succeeded - reset retry counter and pop the task
+                    self.task_retry_count = 0;
 
-            // Update the state and notify the engine actor.
-            self.state_sender.send_replace(self.state);
+                    // Update the state and notify the engine actor.
+                    self.state_sender.send_replace(self.state);
 
-            // Pop the task from the queue now that it's been executed.
-            self.tasks.pop();
+                    // Pop the task from the queue now that it's been executed.
+                    self.tasks.pop();
+                    self.task_queue_length.send_replace(self.tasks.len());
+                }
+                Err(e) => {
+                    // Task failed - check if we should retry or escalate
+                    match e.severity() {
+                        EngineTaskErrorSeverity::Temporary => {
+                            self.task_retry_count += 1;
 
-            self.task_queue_length.send_replace(self.tasks.len());
+                            if self.task_retry_count >= MAX_TASK_RETRIES {
+                                // Too many retries - pop task and trigger reset to prevent infinite stall
+                                warn!(
+                                    target: "engine",
+                                    retry_count = self.task_retry_count,
+                                    error = %e,
+                                    "Task exceeded max retries, dropping task and triggering reset"
+                                );
+
+                                // Reset retry counter and pop the failed task
+                                self.task_retry_count = 0;
+                                self.tasks.pop();
+                                self.task_queue_length.send_replace(self.tasks.len());
+
+                                // Trigger engine reset by returning a reset error
+                                return Err(EngineTaskErrors::Consolidate(
+                                    crate::ConsolidateTaskError::ForkchoiceUpdateFailed(
+                                        crate::SynchronizeTaskError::MaxRetriesExceeded {
+                                            original_error: e.to_string(),
+                                            retry_count: MAX_TASK_RETRIES,
+                                        },
+                                    ),
+                                ));
+                            }
+
+                            // Still under retry limit - return error without popping
+                            debug!(
+                                target: "engine",
+                                retry_count = self.task_retry_count,
+                                max_retries = MAX_TASK_RETRIES,
+                                "Task failed with temporary error, will retry"
+                            );
+                            return Err(e);
+                        }
+                        _ => {
+                            // Critical, Reset, or Flush errors - reset counter and return immediately
+                            self.task_retry_count = 0;
+                            return Err(e);
+                        }
+                    }
+                }
+            }
         }
 
         Ok(())

--- a/rust/kona/crates/node/engine/src/task_queue/mod.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/mod.rs
@@ -5,3 +5,6 @@ pub use core::{Engine, EngineResetError};
 
 mod tasks;
 pub use tasks::*;
+
+#[cfg(test)]
+mod tests;

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/synchronize/error.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/synchronize/error.rs
@@ -20,6 +20,14 @@ pub enum SynchronizeTaskError {
     /// The payload status is unexpected.
     #[error("Unexpected payload status: {0}")]
     UnexpectedPayloadStatus(PayloadStatusEnum),
+    /// A task exceeded the maximum number of retries.
+    #[error("Task exceeded max retries ({retry_count}): {original_error}")]
+    MaxRetriesExceeded {
+        /// The original error message
+        original_error: String,
+        /// Number of retries attempted
+        retry_count: usize,
+    },
 }
 
 impl EngineTaskError for SynchronizeTaskError {
@@ -29,7 +37,9 @@ impl EngineTaskError for SynchronizeTaskError {
             Self::ForkchoiceUpdateFailed(_) | Self::UnexpectedPayloadStatus(_) => {
                 EngineTaskErrorSeverity::Temporary
             }
-            Self::InvalidForkchoiceState => EngineTaskErrorSeverity::Reset,
+            Self::InvalidForkchoiceState | Self::MaxRetriesExceeded { .. } => {
+                EngineTaskErrorSeverity::Reset
+            }
         }
     }
 }

--- a/rust/kona/crates/node/engine/src/task_queue/tests/consolidate_stall_test.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tests/consolidate_stall_test.rs
@@ -1,0 +1,161 @@
+//! Test demonstrating the safe head stall issue when block fetch fails.
+
+use crate::{
+    ConsolidateInput, ConsolidateTask, Engine, EngineState, EngineTaskError, EngineTaskErrorSeverity,
+    EngineTaskExt, test_utils::MockEngineClient,
+};
+use alloy_eips::BlockNumHash;
+use alloy_primitives::B256;
+use kona_genesis::RollupConfig;
+use kona_protocol::L2BlockInfo;
+use std::sync::Arc;
+use tokio::sync::watch;
+
+/// Demonstrates the stall: when block fetch fails repeatedly,
+/// the ConsolidateTask stays in the queue and retries infinitely.
+///
+/// This test documents the original bug behavior - it will pass with the fix
+/// but shows what would happen without it (commented assertion).
+#[tokio::test]
+async fn test_consolidate_stall_on_missing_block() {
+    // Setup: Create engine with a mock client that returns errors for block fetches
+    // This triggers FailedToFetchUnsafeL2Block (Temporary error)
+    let mock_client = Arc::new(
+        MockEngineClient::builder()
+            .with_config(Arc::new(RollupConfig::default()))
+            .with_l2_block_by_label_error()
+            .build(),
+    );
+    let rollup_config = Arc::new(RollupConfig::default());
+    let (state_tx, _) = watch::channel(EngineState::default());
+    let (queue_len_tx, _) = watch::channel(0);
+    let mut engine = Engine::new(EngineState::default(), state_tx, queue_len_tx);
+
+    // Create a safe head block info that should be consolidated
+    let safe_head = L2BlockInfo {
+        block_info: kona_protocol::BlockInfo {
+            hash: B256::random(),
+            number: 100,
+            parent_hash: B256::random(),
+            timestamp: 1000,
+        },
+        l1_origin: BlockNumHash { number: 50, hash: B256::random() },
+        seq_num: 0,
+    };
+
+    // Enqueue a ConsolidateTask for this safe head
+    let task = crate::EngineTask::Consolidate(Box::new(ConsolidateTask::new(
+        mock_client.clone(),
+        rollup_config.clone(),
+        ConsolidateInput::BlockInfo(safe_head),
+    )));
+    engine.enqueue(task);
+
+    // Attempt to drain 10 times - with the fix, task should be removed after 10 retries
+    let mut retry_count = 0;
+    const MAX_TEST_RETRIES: usize = 10;
+
+    while retry_count < MAX_TEST_RETRIES {
+        let result = engine.drain().await;
+
+        // Should fail with FailedToFetchUnsafeL2Block error
+        assert!(result.is_err(), "Drain should fail when block fetch fails");
+
+        retry_count += 1;
+    }
+
+    // With the fix: task should be removed after MAX_TASK_RETRIES
+    // Without fix: task would still be in queue (infinite stall)
+    let queue_length = engine.queue_length_subscribe().borrow().clone();
+
+    // This assertion passes with the fix:
+    assert_eq!(
+        queue_length, 0,
+        "Task should be removed from queue after {} retries (fix applied)",
+        MAX_TEST_RETRIES
+    );
+}
+
+/// Verifies the retry limit behavior: after MAX_TASK_RETRIES attempts,
+/// a task with temporary errors should be dropped and return MaxRetriesExceeded.
+#[tokio::test]
+async fn test_consolidate_with_retry_limit() {
+    // Setup: Create engine with a mock client that returns errors for block fetches
+    let mock_client = Arc::new(
+        MockEngineClient::builder()
+            .with_config(Arc::new(RollupConfig::default()))
+            .with_l2_block_by_label_error()
+            .build(),
+    );
+    let rollup_config = Arc::new(RollupConfig::default());
+    let (state_tx, _) = watch::channel(EngineState::default());
+    let (queue_len_tx, _) = watch::channel(0);
+    let mut engine = Engine::new(EngineState::default(), state_tx, queue_len_tx);
+
+    // Create a safe head block info that should be consolidated
+    let safe_head = L2BlockInfo {
+        block_info: kona_protocol::BlockInfo {
+            hash: B256::random(),
+            number: 100,
+            parent_hash: B256::random(),
+            timestamp: 1000,
+        },
+        l1_origin: BlockNumHash { number: 50, hash: B256::random() },
+        seq_num: 0,
+    };
+
+    // Enqueue a ConsolidateTask for this safe head
+    let task = crate::EngineTask::Consolidate(Box::new(ConsolidateTask::new(
+        mock_client.clone(),
+        rollup_config.clone(),
+        ConsolidateInput::BlockInfo(safe_head),
+    )));
+    engine.enqueue(task);
+
+    // First 9 attempts: should return temporary error and keep task in queue
+    for i in 0..9 {
+        let result = engine.drain().await;
+        assert!(result.is_err(), "Drain {} should fail", i + 1);
+
+        // Verify task is still in queue
+        let queue_length = engine.queue_length_subscribe().borrow().clone();
+        assert_eq!(
+            queue_length, 1,
+            "Task should remain in queue after retry {}",
+            i + 1
+        );
+    }
+
+    // 10th attempt: should drop task and return MaxRetriesExceeded
+    let result = engine.drain().await;
+    assert!(result.is_err(), "10th drain should fail with MaxRetriesExceeded");
+
+    let error = result.unwrap_err();
+
+    // Verify error is MaxRetriesExceeded wrapped in ConsolidateTaskError
+    let error_string = error.to_string();
+    assert!(
+        error_string.contains("max retries") || error_string.contains("MaxRetriesExceeded"),
+        "Error should mention max retries: {}",
+        error_string
+    );
+
+    // Verify task was removed from queue
+    let queue_length = engine.queue_length_subscribe().borrow().clone();
+    assert_eq!(
+        queue_length, 0,
+        "Task should be removed from queue after max retries"
+    );
+
+    // Verify the error has Reset severity (triggers engine reset)
+    match error {
+        crate::task_queue::EngineTaskErrors::Consolidate(e) => {
+            assert_eq!(
+                e.severity(),
+                EngineTaskErrorSeverity::Reset,
+                "MaxRetriesExceeded should have Reset severity"
+            );
+        }
+        _ => panic!("Expected ConsolidateTaskError, got: {:?}", error),
+    }
+}

--- a/rust/kona/crates/node/engine/src/task_queue/tests/mod.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tests/mod.rs
@@ -1,0 +1,3 @@
+//! Tests for the engine task queue.
+
+mod consolidate_stall_test;

--- a/rust/kona/crates/node/engine/src/test_utils/engine_client.rs
+++ b/rust/kona/crates/node/engine/src/test_utils/engine_client.rs
@@ -11,7 +11,7 @@ use alloy_rpc_types_engine::{
     PayloadStatus,
 };
 use alloy_rpc_types_eth::{Block, EIP1186AccountProofResponse, Transaction as EthTransaction};
-use alloy_transport::{TransportError, TransportErrorKind, TransportResult};
+use alloy_transport::{RpcError, TransportError, TransportErrorKind, TransportResult};
 use alloy_transport_http::Http;
 use async_trait::async_trait;
 use kona_genesis::RollupConfig;
@@ -91,6 +91,8 @@ pub struct MockEngineStorage {
     pub l2_blocks_by_id: HashMap<String, Block<OpTransaction>>,
     /// Storage for proofs by (address, stringified `BlockId`) key.
     pub proofs_by_address: HashMap<(Address, String), EIP1186AccountProofResponse>,
+    /// If true, `l2_block_by_label` will return an error instead of Ok(None).
+    pub l2_block_by_label_should_error: bool,
 }
 
 /// Builder for constructing a [`MockEngineClient`] with pre-configured responses.
@@ -263,6 +265,12 @@ impl MockEngineClientBuilder {
         self
     }
 
+    /// Configures `l2_block_by_label` to return an error.
+    pub fn with_l2_block_by_label_error(mut self) -> Self {
+        self.storage.l2_block_by_label_should_error = true;
+        self
+    }
+
     /// Builds the [`MockEngineClient`] with the configured values.
     ///
     /// # Panics
@@ -412,6 +420,11 @@ impl MockEngineClient {
         let key = block_id_to_key(&block_id);
         self.storage.write().await.proofs_by_address.insert((address, key), proof);
     }
+
+    /// Configures `l2_block_by_label` to return an error.
+    pub async fn set_l2_block_by_label_error(&self, should_error: bool) {
+        self.storage.write().await.l2_block_by_label_should_error = should_error;
+    }
 }
 
 #[async_trait]
@@ -497,6 +510,13 @@ impl EngineClient for MockEngineClient {
         numtag: BlockNumberOrTag,
     ) -> Result<Option<Block<OpTransaction>>, EngineClientError> {
         let storage = self.storage.read().await;
+        if storage.l2_block_by_label_should_error {
+            // Create a transport error
+            let transport_error = TransportError::from(TransportErrorKind::custom_str("Mock fetch error"));
+            // Convert to RpcError then to EngineClientError
+            let rpc_error: RpcError<TransportErrorKind> = transport_error.into();
+            return Err(rpc_error.into());
+        }
         Ok(storage.l2_blocks_by_label.get(&numtag).cloned())
     }
 


### PR DESCRIPTION

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
  Adds MAX_TASK_RETRIES (10) to Engine drain logic. After 10 consecutive
  temporary errors, tasks are dropped and engine reset is triggered.
  Prevents safe head stalls that previously required manual node restart.

  Fixes issue where ConsolidateTask would retry infinitely when block
  fetch failed, blocking safe head advancement for hours.

**Tests**

**Additional context**
Logs example
```
info 
time="2026-02-17T20:06:07.548787Z" level=INFO target=engine Attempted L2 Safe Head Update safe_head=L2BlockInfo { block_info: BlockInfo { hash: 0x60a1cc46aff29ef496ec4c9db81efce38ff3378f8905d25825d05574e5df2b8d, number: 42222304, parent_hash: 0x617f10541205412251b69fee7b5317c63f349a728b2054f96148551b7d7762a2, timestamp: 1771233955 }, l1_origin: NumHash { number: 24468458, hash: 0x56bc9e53140a4dfeb83687bdc1456a87a708cc704693fdfa0202ffd8bf1d90b9 }, seq_num: 3 } sent=false 

info 
time="2026-02-17T20:06:05.539600Z" level=INFO target=engine Attempted L2 Safe Head Update safe_head=L2BlockInfo { block_info: BlockInfo { hash: 0x60a1cc46aff29ef496ec4c9db81efce38ff3378f8905d25825d05574e5df2b8d, number: 42222304, parent_hash: 0x617f10541205412251b69fee7b5317c63f349a728b2054f96148551b7d7762a2, timestamp: 1771233955 }, l1_origin: NumHash { number: 24468458, hash: 0x56bc9e53140a4dfeb83687bdc1456a87a708cc704693fdfa0202ffd8bf1d90b9 }, seq_num: 3 } sent=false 

info 
time="2026-02-17T20:06:03.466052Z" level=INFO target=engine Attempted L2 Safe Head Update safe_head=L2BlockInfo { block_info: BlockInfo { hash: 0x60a1cc46aff29ef496ec4c9db81efce38ff3378f8905d25825d05574e5df2b8d, number: 42222304, parent_hash: 0x617f10541205412251b69fee7b5317c63f349a728b2054f96148551b7d7762a2, timestamp: 1771233955 }, l1_origin: NumHash { number: 24468458, hash: 0x56bc9e53140a4dfeb83687bdc1456a87a708cc704693fdfa0202ffd8bf1d90b9 }, seq_num: 3 } sent=false 

info 
time="2026-02-17T20:06:01.620035Z" level=INFO target=engine Attempted L2 Safe Head Update safe_head=L2BlockInfo { block_info: BlockInfo { hash: 0x60a1cc46aff29ef496ec4c9db81efce38ff3378f8905d25825d05574e5df2b8d, number: 42222304, parent_hash: 0x617f10541205412251b69fee7b5317c63f349a728b2054f96148551b7d7762a2, timestamp: 1771233955 }, l1_origin: NumHash { number: 24468458, hash: 0x56bc9e53140a4dfeb83687bdc1456a87a708cc704693fdfa0202ffd8bf1d90b9 }, seq_num: 3 } sent=false 

info 
time="2026-02-17T20:05:59.749187Z" level=INFO target=engine Attempted L2 Safe Head Update safe_head=L2BlockInfo { block_info: BlockInfo { hash: 0x60a1cc46aff29ef496ec4c9db81efce38ff3378f8905d25825d05574e5df2b8d, number: 42222304, parent_hash: 0x617f10541205412251b69fee7b5317c63f349a728b2054f96148551b7d7762a2, timestamp: 1771233955 }, l1_origin: NumHash { number: 24468458, hash: 0x56bc9e53140a4dfeb83687bdc1456a87a708cc704693fdfa0202ffd8bf1d90b9 }, seq_num: 3 } sent=false 

info 
time="2026-02-17T20:05:47.493404Z" level=INFO target=engine Attempted L2 Safe Head Update safe_head=L2BlockInfo { block_info: BlockInfo { hash: 0x60a1cc46aff29ef496ec4c9db81efce38ff3378f8905d25825d05574e5df2b8d, number: 42222304, parent_hash: 0x617f10541205412251b69fee7b5317c63f349a728b2054f96148551b7d7762a2, timestamp: 1771233955 }, l1_origin: NumHash { number: 24468458, hash: 0x56bc9e53140a4dfeb83687bdc1456a87a708cc704693fdfa0202ffd8bf1d90b9 }, seq_num: 3 } sent=false 

info 
time="2026-02-17T20:05:45.618931Z" level=INFO target=engine Attempted L2 Safe Head Update safe_head=L2BlockInfo { block_info: BlockInfo { hash: 0x60a1cc46aff29ef496ec4c9db81efce38ff3378f8905d25825d05574e5df2b8d, number: 42222304, parent_hash: 0x617f10541205412251b69fee7b5317c63f349a728b2054f96148551b7d7762a2, timestamp: 1771233955 }, l1_origin: NumHash { number: 24468458, hash: 0x56bc9e53140a4dfeb83687bdc1456a87a708cc704693fdfa0202ffd8bf1d90b9 }, seq_num: 3 } sent=false 

============

Yet the EL has the block

╭─ ~/workspace/ethereum-optimism/infrastructure-services/op-host-manager/ops main !2 ?3                                                                                                                                                14:56:54
╰─❯ cast block 42222303 -r https://base-kona-geth-a-rpc-1-op-geth.quaternary.mainnet.prod.oplabs.cloud/ | head -n 10


baseFeePerGas        2008558
difficulty           0
extraData            0x010000007d0000000600000000001e8480
gasLimit             375000000
gasUsed              52507174
hash                 0x617f10541205412251b69fee7b5317c63f349a728b2054f96148551b7d7762a2
logsBloom            0x7d67d277f5f458fbebdf783bbe83516fb4fe776af333ded2ffb5bf37fa3ff5b95f2b19aa31af61b1ff96bfb3b137bd99ed38dae8b77f7baeffaf67da87ffeb5bdff77eb8976adcbe5beedcb9fa3f6fadf5ffbefd73ecafffbf635df5e867bfdfadf2dfefbe3fe777bfd7a737dccf7f0f95a75f933ff677c3f7bffff5bc7b23dc1f2fbffe5fe2fd3df7ffbfffea9c84f5f9abb5ff5f229efefdfefe4f67710e248e78fd7fe4c6f7347d7ff7f5bdbfeef939ff64ebf4fa681f7bdfbb6d2e2b27be1f62feeafdf9aff57bf75fd6ebfa9d88eb2ea3efec5faedefccf1efebade39266affbeb3c9f6abfc375f5798da677ff6fceeffde5de9a067ff17eff7b7e36e4e
miner                0x4200000000000000000000000000000000000011
```

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
