### PR TITLE
fix(ai-test): pass structured_output_schema to Devin API for structured output

### DIFF
--- a/ops/ai-eng/contracts-test-maintenance/components/devin-api/devin_client.py
+++ b/ops/ai-eng/contracts-test-maintenance/components/devin-api/devin_client.py
@@ -135,7 +135,31 @@ def create_session(prompt):
 
     print(f"Creating session at: {base_url}/sessions")
     headers = _create_headers(api_key, "application/json")
-    data = json.dumps({"prompt": prompt}).encode("utf-8")
+
+    # JSON Schema (Draft 7) so Devin populates the structured_output API field.
+    structured_output_schema = {
+        "type": "object",
+        "properties": {
+            "analysis_complete": {
+                "type": "boolean",
+                "description": "Set to true after completing Phases 1-2 analysis"
+            },
+            "changes_needed": {
+                "type": "boolean",
+                "description": "True if tests will be created/modified, false if no changes needed"
+            },
+            "reason": {
+                "type": "string",
+                "description": "Brief explanation of why changes are or aren't needed"
+            }
+        },
+        "required": ["analysis_complete", "changes_needed", "reason"]
+    }
+
+    data = json.dumps({
+        "prompt": prompt,
+        "structured_output_schema": structured_output_schema
+    }).encode("utf-8")
 
     retry_delay = 60
     while True:
@@ -218,9 +242,9 @@ def monitor_session(session_id):
                         continue
 
                     # Check structured output and PR (both should be populated when blocked)
-                    # Note: Devin API nests structured_output twice: {structured_output: {structured_output: {...}}}
-                    # The outer structured_output can be null, so we use `or {}` to handle that case
-                    structured = (api_response.get("structured_output") or {}).get("structured_output") or {}
+                    # The structured_output_schema passed at session creation tells Devin
+                    # to populate this field; it can be null if Devin hasn't finished analysis
+                    structured = api_response.get("structured_output") or {}
                     analysis_complete = structured.get("analysis_complete", False)
                     changes_needed = structured.get("changes_needed")
 


### PR DESCRIPTION
This PR fixes the Devin client timing out on every run by ensuring the `structured_output` field is properly populated in the Devin API response.

## Reason

The Devin API introduced a `structured_output_schema` parameter for session creation that must be passed for the `structured_output` field to be populated in API responses. Without it, Devin treats the prompt's structured output instructions as internal reasoning only and never writes to the API field. As a result, `structured_output` was always `null`, both completion checks failed, and the monitor timed out after 300 seconds on every run, despite Devin having opened a PR successfully.

## Changes

- Pass `structured_output_schema` (JSON Schema Draft 7) at session creation so Devin populates the `structured_output` API response field
- Fix incorrect double-nested extraction of `structured_output` that always resolved to an empty dict