### PR TITLE
proofs: add interop FP trace extension action test to devstack

### DIFF
--- a/op-acceptance-tests/tests/isthmus/preinterop/interop_fault_proofs_test.go
+++ b/op-acceptance-tests/tests/isthmus/preinterop/interop_fault_proofs_test.go
@@ -13,3 +13,9 @@ func TestPreinteropFaultProofs(gt *testing.T) {
 	sys := presets.NewSimpleInterop(t)
 	sfp.RunSuperFaultProofTest(t, sys)
 }
+
+func TestPreinteropFaultProofs_TraceExtensionActivation(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewSimpleInterop(t)
+	sfp.RunTraceExtensionActivationTest(t, sys)
+}

--- a/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
+++ b/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
@@ -361,6 +361,110 @@ func buildTransitionTests(
 	}
 }
 
+// RunTraceExtensionActivationTest verifies that trace extension correctly
+// activates (or not) based on whether the claim timestamp has been reached.
+func RunTraceExtensionActivationTest(t devtest.T, sys *presets.SimpleInterop) {
+	t.Require().NotNil(sys.SuperRoots, "supernode is required for this test")
+
+	chains := orderedChains(sys)
+	t.Require().Len(chains, 2, "expected exactly 2 interop chains")
+
+	// -- Stage 1: Freeze batch submission, then validate endTimestamp --------
+	chains[0].Batcher.Stop()
+	chains[1].Batcher.Stop()
+	defer func() {
+		chains[0].Batcher.Start()
+		chains[1].Batcher.Start()
+	}()
+	awaitSafeHeadsStalled(t, sys.L2CLA, sys.L2CLB)
+
+	endTimestamp := nextTimestampAfterSafeHeads(t, chains)
+
+	// Ensure both chains have produced the target blocks as unsafe.
+	for _, c := range chains {
+		target, err := c.Cfg.TargetBlockNumber(endTimestamp)
+		t.Require().NoError(err)
+		c.EL.Reached(eth.Unsafe, target, 60)
+	}
+
+	// Submit batch data so endTimestamp becomes validated.
+	chains[0].Batcher.Start()
+	chains[1].Batcher.Start()
+	sys.SuperRoots.AwaitValidatedTimestamp(endTimestamp)
+	l1Head := latestRequiredL1(sys.SuperRoots.SuperRootAtTimestamp(endTimestamp))
+	chains[0].Batcher.Stop()
+	chains[1].Batcher.Stop()
+
+	// -- Stage 2: Build trace extension test claims --------------------------
+	startTimestamp := endTimestamp - 1
+	agreedSuperRoot := superRootAtTimestamp(t, chains, endTimestamp)
+	agreedClaim := agreedSuperRoot.Marshal()
+
+	// The disputed claim transitions to the next timestamp by including the
+	// first chain's optimistic block at endTimestamp+1.
+	firstOptimistic := optimisticBlockAtTimestamp(t, chains[0], endTimestamp+1)
+	disputedClaim := marshalTransition(agreedSuperRoot, 1, firstOptimistic)
+	disputedTraceIndex := int64(stepsPerTimestamp)
+
+	tests := []*transitionTest{
+		{
+			Name:               "CorrectlyDidNotActivate",
+			AgreedClaim:        agreedClaim,
+			DisputedClaim:      disputedClaim,
+			DisputedTraceIndex: disputedTraceIndex,
+			L1Head:             l1Head,
+			// Trace extension does not activate because we have not reached the proposal timestamp yet.
+			ClaimTimestamp: endTimestamp + 1,
+			ExpectValid:    true,
+		},
+		{
+			Name:               "IncorrectlyDidNotActivate",
+			AgreedClaim:        agreedClaim,
+			DisputedClaim:      disputedClaim,
+			DisputedTraceIndex: disputedTraceIndex,
+			L1Head:             l1Head,
+			// Trace extension should have activated because we have reached the proposal timestamp.
+			ClaimTimestamp: endTimestamp,
+			ExpectValid:    false,
+		},
+		{
+			Name:               "CorrectlyActivated",
+			AgreedClaim:        agreedClaim,
+			DisputedClaim:      agreedClaim,
+			DisputedTraceIndex: disputedTraceIndex,
+			L1Head:             l1Head,
+			// Trace extension activated at the proposal timestamp, claim stays the same.
+			ClaimTimestamp: endTimestamp,
+			ExpectValid:    true,
+		},
+		{
+			Name:               "IncorrectlyActivated",
+			AgreedClaim:        agreedClaim,
+			DisputedClaim:      agreedClaim,
+			DisputedTraceIndex: disputedTraceIndex,
+			L1Head:             l1Head,
+			// Trace extension should not have activated because we haven't reached the proposal timestamp.
+			ClaimTimestamp: endTimestamp + 1,
+			ExpectValid:    false,
+		},
+	}
+
+	// -- Stage 3: Run FPP and challenger tests --------------------------------
+	challengerCfg := sys.L2ChainA.Escape().L2Challengers()[0].Config()
+	gameDepth := sys.DisputeGameFactory().GameImpl(gameTypes.SuperCannonKonaGameType).SplitDepth()
+
+	for _, test := range tests {
+		t.Run(test.Name+"-fpp", func(t devtest.T) {
+			runKonaInteropProgram(t, challengerCfg.CannonKona, test.L1Head.Hash,
+				test.AgreedClaim, crypto.Keccak256Hash(test.DisputedClaim),
+				test.ClaimTimestamp, test.ExpectValid)
+		})
+		t.Run(test.Name+"-challenger", func(t devtest.T) {
+			runChallengerProviderTest(t, sys.SuperRoots.QueryAPI(), gameDepth, startTimestamp, test.ClaimTimestamp, test)
+		})
+	}
+}
+
 // RunSuperFaultProofTest encapsulates the basic super fault proof test flow.
 func RunSuperFaultProofTest(t devtest.T, sys *presets.SimpleInterop) {
 	t.Require().NotNil(sys.SuperRoots, "supernode is required for this test")

--- a/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
+++ b/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
@@ -369,33 +369,10 @@ func RunTraceExtensionActivationTest(t devtest.T, sys *presets.SimpleInterop) {
 	chains := orderedChains(sys)
 	t.Require().Len(chains, 2, "expected exactly 2 interop chains")
 
-	// -- Stage 1: Freeze batch submission, then validate endTimestamp --------
-	chains[0].Batcher.Stop()
-	chains[1].Batcher.Stop()
-	defer func() {
-		chains[0].Batcher.Start()
-		chains[1].Batcher.Start()
-	}()
-	awaitSafeHeadsStalled(t, sys.L2CLA, sys.L2CLB)
-
-	endTimestamp := nextTimestampAfterSafeHeads(t, chains)
-
-	// Ensure both chains have produced the target blocks as unsafe.
-	for _, c := range chains {
-		target, err := c.Cfg.TargetBlockNumber(endTimestamp)
-		t.Require().NoError(err)
-		c.EL.Reached(eth.Unsafe, target, 60)
-	}
-
-	// Submit batch data so endTimestamp becomes validated.
-	chains[0].Batcher.Start()
-	chains[1].Batcher.Start()
+	endTimestamp := uint64(time.Now().Unix())
 	sys.SuperRoots.AwaitValidatedTimestamp(endTimestamp)
-	l1Head := latestRequiredL1(sys.SuperRoots.SuperRootAtTimestamp(endTimestamp))
-	chains[0].Batcher.Stop()
-	chains[1].Batcher.Stop()
+	l1Head := latestRequiredL1(sys.SuperRoots.SuperRootAtTimestamp(endTimestamp + 1))
 
-	// -- Stage 2: Build trace extension test claims --------------------------
 	startTimestamp := endTimestamp - 1
 	agreedSuperRoot := superRootAtTimestamp(t, chains, endTimestamp)
 	agreedClaim := agreedSuperRoot.Marshal()
@@ -449,7 +426,6 @@ func RunTraceExtensionActivationTest(t devtest.T, sys *presets.SimpleInterop) {
 		},
 	}
 
-	// -- Stage 3: Run FPP and challenger tests --------------------------------
 	challengerCfg := sys.L2ChainA.Escape().L2Challengers()[0].Config()
 	gameDepth := sys.DisputeGameFactory().GameImpl(gameTypes.SuperCannonKonaGameType).SplitDepth()
 


### PR DESCRIPTION
This ports the [`TestinteropFaultProofs_TraceExtensionActivation`](https://github.com/ethereum-optimism/optimism/blob/d194274e861444b31db21b3aaec8c8f2581be6f2/op-e2e/actions/interop/proofs_test.go#L40) action test to a supernode pre-interop devstack setup.