### PR TITLE
refactor(dsl): introduce InitMessage and ExecMessage structs

### DIFF
--- a/op-acceptance-tests/tests/interop/message/interop_happy_tx_test.go
+++ b/op-acceptance-tests/tests/interop/message/interop_happy_tx_test.go
@@ -11,8 +11,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-
-	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	stypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
@@ -45,16 +43,12 @@ func TestInteropHappyTx(gt *testing.T) {
 
 	// confirm that the cross-safe safety passed init and exec receipts and that blocks were not reorged
 	dsl.CheckAll(t,
-		sys.L2CLA.ReachedRefFn(stypes.CrossSafe, eth.BlockID{
-			Number: bigs.Uint64Strict(initMsg.BlockNumber()),
-			Hash:   initMsg.BlockHash(),
+		sys.L2CLA.ReachedRefFn(stypes.CrossSafe, initMsg.BlockID(),
 			// TODO(#16598): Make this relative to the block time
-		}, 500),
-		sys.L2CLB.ReachedRefFn(stypes.CrossSafe, eth.BlockID{
-			Number: bigs.Uint64Strict(execMsg.BlockNumber()),
-			Hash:   execMsg.BlockHash(),
+			500),
+		sys.L2CLB.ReachedRefFn(stypes.CrossSafe, execMsg.BlockID(),
 			// TODO(#16598): Make this relative to the block time
-		}, 500),
+			500),
 	)
 
 	orch := presets.Orchestrator()

--- a/op-acceptance-tests/tests/interop/message/interop_happy_tx_test.go
+++ b/op-acceptance-tests/tests/interop/message/interop_happy_tx_test.go
@@ -41,7 +41,7 @@ func TestInteropHappyTx(gt *testing.T) {
 	sys.L2ChainB.WaitForBlock()
 
 	// send executing message on chain B
-	_, execReceipt := bob.SendExecMessage(initMsg.Tx, 0)
+	_, execReceipt := bob.SendExecMessage(initMsg)
 
 	// confirm that the cross-safe safety passed init and exec receipts and that blocks were not reorged
 	dsl.CheckAll(t,

--- a/op-acceptance-tests/tests/interop/message/interop_happy_tx_test.go
+++ b/op-acceptance-tests/tests/interop/message/interop_happy_tx_test.go
@@ -46,8 +46,8 @@ func TestInteropHappyTx(gt *testing.T) {
 	// confirm that the cross-safe safety passed init and exec receipts and that blocks were not reorged
 	dsl.CheckAll(t,
 		sys.L2CLA.ReachedRefFn(stypes.CrossSafe, eth.BlockID{
-			Number: bigs.Uint64Strict(initMsg.Receipt.BlockNumber),
-			Hash:   initMsg.Receipt.BlockHash,
+			Number: bigs.Uint64Strict(initMsg.BlockNumber()),
+			Hash:   initMsg.BlockHash(),
 			// TODO(#16598): Make this relative to the block time
 		}, 500),
 		sys.L2CLB.ReachedRefFn(stypes.CrossSafe, eth.BlockID{

--- a/op-acceptance-tests/tests/interop/message/interop_happy_tx_test.go
+++ b/op-acceptance-tests/tests/interop/message/interop_happy_tx_test.go
@@ -41,7 +41,7 @@ func TestInteropHappyTx(gt *testing.T) {
 	sys.L2ChainB.WaitForBlock()
 
 	// send executing message on chain B
-	_, execReceipt := bob.SendExecMessage(initMsg)
+	execMsg := bob.SendExecMessage(initMsg)
 
 	// confirm that the cross-safe safety passed init and exec receipts and that blocks were not reorged
 	dsl.CheckAll(t,
@@ -51,8 +51,8 @@ func TestInteropHappyTx(gt *testing.T) {
 			// TODO(#16598): Make this relative to the block time
 		}, 500),
 		sys.L2CLB.ReachedRefFn(stypes.CrossSafe, eth.BlockID{
-			Number: bigs.Uint64Strict(execReceipt.BlockNumber),
-			Hash:   execReceipt.BlockHash,
+			Number: bigs.Uint64Strict(execMsg.BlockNumber()),
+			Hash:   execMsg.BlockHash(),
 			// TODO(#16598): Make this relative to the block time
 		}, 500),
 	)

--- a/op-acceptance-tests/tests/interop/message/interop_happy_tx_test.go
+++ b/op-acceptance-tests/tests/interop/message/interop_happy_tx_test.go
@@ -35,19 +35,19 @@ func TestInteropHappyTx(gt *testing.T) {
 
 	// send initiating message on chain A
 	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
-	initTx, initReceipt := alice.SendInitMessage(interop.RandomInitTrigger(rng, eventLoggerAddress, rng.Intn(3), rng.Intn(10)))
+	initMsg := alice.SendInitMessage(interop.RandomInitTrigger(rng, eventLoggerAddress, rng.Intn(3), rng.Intn(10)))
 
 	// at least one block between the init tx on chain A and the exec tx on chain B
 	sys.L2ChainB.WaitForBlock()
 
 	// send executing message on chain B
-	_, execReceipt := bob.SendExecMessage(initTx, 0)
+	_, execReceipt := bob.SendExecMessage(initMsg.Tx, 0)
 
 	// confirm that the cross-safe safety passed init and exec receipts and that blocks were not reorged
 	dsl.CheckAll(t,
 		sys.L2CLA.ReachedRefFn(stypes.CrossSafe, eth.BlockID{
-			Number: bigs.Uint64Strict(initReceipt.BlockNumber),
-			Hash:   initReceipt.BlockHash,
+			Number: bigs.Uint64Strict(initMsg.Receipt.BlockNumber),
+			Hash:   initMsg.Receipt.BlockHash,
 			// TODO(#16598): Make this relative to the block time
 		}, 500),
 		sys.L2CLB.ReachedRefFn(stypes.CrossSafe, eth.BlockID{

--- a/op-acceptance-tests/tests/interop/message/interop_mon_test.go
+++ b/op-acceptance-tests/tests/interop/message/interop_mon_test.go
@@ -49,7 +49,7 @@ func TestInteropMon(gt *testing.T) {
 	initMsg := alice.SendInitMessage(interop.RandomInitTrigger(rng, eventLoggerAddress, rng.Intn(3), rng.Intn(10)))
 
 	// send executing message on chain B
-	_, _ = bob.SendExecMessage(initMsg.Tx, 0)
+	_, _ = bob.SendExecMessage(initMsg)
 
 	// Ensure the metrics are generated
 	require.EventuallyWithT(func(t *assert.CollectT) {

--- a/op-acceptance-tests/tests/interop/message/interop_mon_test.go
+++ b/op-acceptance-tests/tests/interop/message/interop_mon_test.go
@@ -49,7 +49,7 @@ func TestInteropMon(gt *testing.T) {
 	initMsg := alice.SendInitMessage(interop.RandomInitTrigger(rng, eventLoggerAddress, rng.Intn(3), rng.Intn(10)))
 
 	// send executing message on chain B
-	_, _ = bob.SendExecMessage(initMsg)
+	_ = bob.SendExecMessage(initMsg)
 
 	// Ensure the metrics are generated
 	require.EventuallyWithT(func(t *assert.CollectT) {

--- a/op-acceptance-tests/tests/interop/message/interop_mon_test.go
+++ b/op-acceptance-tests/tests/interop/message/interop_mon_test.go
@@ -46,10 +46,10 @@ func TestInteropMon(gt *testing.T) {
 
 	// send initiating message on chain A
 	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
-	initTx, _ := alice.SendInitMessage(interop.RandomInitTrigger(rng, eventLoggerAddress, rng.Intn(3), rng.Intn(10)))
+	initMsg := alice.SendInitMessage(interop.RandomInitTrigger(rng, eventLoggerAddress, rng.Intn(3), rng.Intn(10)))
 
 	// send executing message on chain B
-	_, _ = bob.SendExecMessage(initTx, 0)
+	_, _ = bob.SendExecMessage(initMsg.Tx, 0)
 
 	// Ensure the metrics are generated
 	require.EventuallyWithT(func(t *assert.CollectT) {

--- a/op-acceptance-tests/tests/interop/message/interop_msg_test.go
+++ b/op-acceptance-tests/tests/interop/message/interop_msg_test.go
@@ -45,7 +45,7 @@ func TestInitExecMsg(gt *testing.T) {
 	// Make sure supervisor indexes block which includes init message
 	sys.Supervisor.WaitForUnsafeHeadToAdvance(alice.ChainID(), 2)
 	// Single event in tx so index is 0
-	bob.SendExecMessage(initMsg.Tx, 0)
+	bob.SendExecMessage(initMsg)
 }
 
 // TestInitExecMsgWithDSL tests basic interop messaging with contract DSL

--- a/op-acceptance-tests/tests/interop/message/interop_msg_test.go
+++ b/op-acceptance-tests/tests/interop/message/interop_msg_test.go
@@ -41,11 +41,11 @@ func TestInitExecMsg(gt *testing.T) {
 
 	eventLoggerAddress := alice.DeployEventLogger()
 	// Trigger random init message at chain A
-	initIntent, _ := alice.SendInitMessage(interop.RandomInitTrigger(rng, eventLoggerAddress, rng.Intn(5), rng.Intn(30)))
+	initMsg := alice.SendInitMessage(interop.RandomInitTrigger(rng, eventLoggerAddress, rng.Intn(5), rng.Intn(30)))
 	// Make sure supervisor indexes block which includes init message
 	sys.Supervisor.WaitForUnsafeHeadToAdvance(alice.ChainID(), 2)
 	// Single event in tx so index is 0
-	bob.SendExecMessage(initIntent, 0)
+	bob.SendExecMessage(initMsg.Tx, 0)
 }
 
 // TestInitExecMsgWithDSL tests basic interop messaging with contract DSL

--- a/op-acceptance-tests/tests/interop/upgrade/post_test.go
+++ b/op-acceptance-tests/tests/interop/upgrade/post_test.go
@@ -142,16 +142,16 @@ func testInteropMessageInclusion(t devtest.T, sys *presets.SimpleInterop) {
 
 	// Phase 2: Send init message on chain A
 	rng := rand.New(rand.NewSource(1234))
-	initIntent, initReceipt := alice.SendInitMessage(interop.RandomInitTrigger(rng, eventLoggerAddress, rng.Intn(5), rng.Intn(30)))
+	initMsg := alice.SendInitMessage(interop.RandomInitTrigger(rng, eventLoggerAddress, rng.Intn(5), rng.Intn(30)))
 
 	// Make sure supervisor indexes block which includes init message
 	sys.Supervisor.WaitForUnsafeHeadToAdvance(alice.ChainID(), 2)
 
 	// Single event in tx so index is 0
-	_, execReceipt := bob.SendExecMessage(initIntent, 0)
+	_, execReceipt := bob.SendExecMessage(initMsg.Tx, 0)
 
 	// Phase 5: Verify cross-safe progression
-	verifyInteropMessagesProgression(t, sys, initReceipt, execReceipt)
+	verifyInteropMessagesProgression(t, sys, initMsg.Receipt, execReceipt)
 
 	logger.Info("Interop message inclusion test completed successfully")
 }

--- a/op-acceptance-tests/tests/interop/upgrade/post_test.go
+++ b/op-acceptance-tests/tests/interop/upgrade/post_test.go
@@ -148,7 +148,7 @@ func testInteropMessageInclusion(t devtest.T, sys *presets.SimpleInterop) {
 	sys.Supervisor.WaitForUnsafeHeadToAdvance(alice.ChainID(), 2)
 
 	// Single event in tx so index is 0
-	_, execReceipt := bob.SendExecMessage(initMsg.Tx, 0)
+	_, execReceipt := bob.SendExecMessage(initMsg)
 
 	// Phase 5: Verify cross-safe progression
 	verifyInteropMessagesProgression(t, sys, initMsg.Receipt, execReceipt)

--- a/op-acceptance-tests/tests/interop/upgrade/post_test.go
+++ b/op-acceptance-tests/tests/interop/upgrade/post_test.go
@@ -17,8 +17,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/stack/match"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	stypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
-
-	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -177,14 +175,8 @@ func verifyInteropMessagesProgression(t devtest.T, sys *presets.SimpleInterop, i
 
 	// Verify cross-safe progression for both messages
 	dsl.CheckAll(t,
-		sys.L2CLA.ReachedRefFn(stypes.CrossSafe, eth.BlockID{
-			Number: bigs.Uint64Strict(initMsg.BlockNumber()),
-			Hash:   initMsg.BlockHash(),
-		}, 60),
-		sys.L2CLB.ReachedRefFn(stypes.CrossSafe, eth.BlockID{
-			Number: bigs.Uint64Strict(execMsg.BlockNumber()),
-			Hash:   execMsg.BlockHash(),
-		}, 60),
+		sys.L2CLA.ReachedRefFn(stypes.CrossSafe, initMsg.BlockID(), 60),
+		sys.L2CLB.ReachedRefFn(stypes.CrossSafe, execMsg.BlockID(), 60),
 	)
 
 	logger.Info("Cross-safe progression verified for both init and exec messages")

--- a/op-acceptance-tests/tests/interop/upgrade/post_test.go
+++ b/op-acceptance-tests/tests/interop/upgrade/post_test.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 )
 
 func TestPostInbox(gt *testing.T) {
@@ -148,10 +147,10 @@ func testInteropMessageInclusion(t devtest.T, sys *presets.SimpleInterop) {
 	sys.Supervisor.WaitForUnsafeHeadToAdvance(alice.ChainID(), 2)
 
 	// Single event in tx so index is 0
-	_, execReceipt := bob.SendExecMessage(initMsg)
+	execMsg := bob.SendExecMessage(initMsg)
 
 	// Phase 5: Verify cross-safe progression
-	verifyInteropMessagesProgression(t, sys, initMsg.Receipt, execReceipt)
+	verifyInteropMessagesProgression(t, sys, initMsg, execMsg)
 
 	logger.Info("Interop message inclusion test completed successfully")
 }
@@ -173,18 +172,18 @@ func setupInteropTestEnvironment(sys *presets.SimpleInterop) (alice, bob *dsl.EO
 }
 
 // verifyInteropMessagesProgression verifies cross-safe progression for both init and exec messages
-func verifyInteropMessagesProgression(t devtest.T, sys *presets.SimpleInterop, initReceipt, execReceipt *types.Receipt) {
+func verifyInteropMessagesProgression(t devtest.T, sys *presets.SimpleInterop, initMsg *dsl.InitMessage, execMsg *dsl.ExecMessage) {
 	logger := t.Logger()
 
 	// Verify cross-safe progression for both messages
 	dsl.CheckAll(t,
 		sys.L2CLA.ReachedRefFn(stypes.CrossSafe, eth.BlockID{
-			Number: bigs.Uint64Strict(initReceipt.BlockNumber),
-			Hash:   initReceipt.BlockHash,
+			Number: bigs.Uint64Strict(initMsg.BlockNumber()),
+			Hash:   initMsg.BlockHash(),
 		}, 60),
 		sys.L2CLB.ReachedRefFn(stypes.CrossSafe, eth.BlockID{
-			Number: bigs.Uint64Strict(execReceipt.BlockNumber),
-			Hash:   execReceipt.BlockHash,
+			Number: bigs.Uint64Strict(execMsg.BlockNumber()),
+			Hash:   execMsg.BlockHash(),
 		}, 60),
 	)
 

--- a/op-acceptance-tests/tests/interop/upgrade/pre_test.go
+++ b/op-acceptance-tests/tests/interop/upgrade/pre_test.go
@@ -89,7 +89,7 @@ func TestPreNoInbox(gt *testing.T) {
 		require.ErrorContains(err, "implementation not initialized", "error did not contain expected string")
 		require.Nil(execReceipt)
 
-		t.Logger().Info("initReceipt", "blocknum", initMsg.Receipt.BlockNumber, "txhash", initMsg.Receipt.TxHash)
+		t.Logger().Info("initReceipt", "blocknum", initMsg.BlockNumber(), "txhash", initMsg.TxHash())
 
 		// confirm we are still pre-interop
 		require.False(sys.L2ChainA.IsActivated(*interopTimeA))

--- a/op-acceptance-tests/tests/interop/upgrade/pre_test.go
+++ b/op-acceptance-tests/tests/interop/upgrade/pre_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/ethereum-optimism/optimism/devnet-sdk/contracts/constants"
 	"github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/interop"
@@ -60,8 +59,7 @@ func TestPreNoInbox(gt *testing.T) {
 		t.Logger().Info("Timestamps", "interopTime", *interopTime, "now", time.Now().Unix())
 	})
 
-	var initReceipt *types.Receipt
-	var initTx *txintent.IntentTx[*txintent.InitTrigger, *txintent.InteropOutput]
+	var initMsg *dsl.InitMessage
 	// try interop before the upgrade, confirm that messages do not get included
 	{
 		// two EOAs for triggering the init and exec interop txs
@@ -78,20 +76,20 @@ func TestPreNoInbox(gt *testing.T) {
 
 		// send initiating message on chain A
 		rng := rand.New(rand.NewSource(time.Now().UnixNano()))
-		initTx, initReceipt = alice.SendInitMessage(interop.RandomInitTrigger(rng, eventLoggerAddress, rng.Intn(3), rng.Intn(10)))
+		initMsg = alice.SendInitMessage(interop.RandomInitTrigger(rng, eventLoggerAddress, rng.Intn(3), rng.Intn(10)))
 
 		// at least one block between the init tx on chain A and the exec tx on chain B
 		sys.L2ChainB.WaitForBlock()
 
 		// send executing message on chain B and confirm we got an error
 		execTx := txintent.NewIntent[*txintent.ExecTrigger, *txintent.InteropOutput](bob.Plan())
-		execTx.Content.DependOn(&initTx.Result)
-		execTx.Content.Fn(txintent.ExecuteIndexed(constants.CrossL2Inbox, &initTx.Result, 0))
+		execTx.Content.DependOn(&initMsg.Tx.Result)
+		execTx.Content.Fn(txintent.ExecuteIndexed(constants.CrossL2Inbox, &initMsg.Tx.Result, 0))
 		execReceipt, err := execTx.PlannedTx.Included.Eval(sys.T.Ctx())
 		require.ErrorContains(err, "implementation not initialized", "error did not contain expected string")
 		require.Nil(execReceipt)
 
-		t.Logger().Info("initReceipt", "blocknum", initReceipt.BlockNumber, "txhash", initReceipt.TxHash)
+		t.Logger().Info("initReceipt", "blocknum", initMsg.Receipt.BlockNumber, "txhash", initMsg.Receipt.TxHash)
 
 		// confirm we are still pre-interop
 		require.False(sys.L2ChainA.IsActivated(*interopTimeA))
@@ -103,7 +101,7 @@ func TestPreNoInbox(gt *testing.T) {
 	{
 		ctx := sys.T.Ctx()
 
-		execTrigger, err := txintent.ExecuteIndexed(constants.CrossL2Inbox, &initTx.Result, 0)(ctx)
+		execTrigger, err := txintent.ExecuteIndexed(constants.CrossL2Inbox, &initMsg.Tx.Result, 0)(ctx)
 		require.NoError(err)
 
 		ed := stypes.ExecutingDescriptor{Timestamp: uint64(time.Now().Unix())}

--- a/op-acceptance-tests/tests/interop/upgrade/pre_test.go
+++ b/op-acceptance-tests/tests/interop/upgrade/pre_test.go
@@ -89,7 +89,7 @@ func TestPreNoInbox(gt *testing.T) {
 		require.ErrorContains(err, "implementation not initialized", "error did not contain expected string")
 		require.Nil(execReceipt)
 
-		t.Logger().Info("initReceipt", "blocknum", initMsg.BlockNumber(), "txhash", initMsg.TxHash())
+		t.Logger().Info("initReceipt", "msg", initMsg)
 
 		// confirm we are still pre-interop
 		require.False(sys.L2ChainA.IsActivated(*interopTimeA))

--- a/op-acceptance-tests/tests/supernode/interop/cross_message_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/cross_message_test.go
@@ -5,15 +5,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/stretchr/testify/assert"
-
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-service/testutils"
-	"github.com/ethereum-optimism/optimism/op-service/txintent"
 )
 
 // TestSupernodeInteropBidirectionalMessages tests sending messages in both directions
@@ -38,24 +33,22 @@ func TestSupernodeInteropBidirectionalMessages(gt *testing.T) {
 	rng := rand.New(rand.NewSource(54321))
 
 	// Send A -> B message
-	initTriggerAtoB := randomInitTrigger(rng, eventLoggerA, 2, 10)
-	initTxAtoB, initReceiptAtoB := alice.SendInitMessage(initTriggerAtoB)
+	initMsgAtoB := alice.SendRandomInitMessage(rng, eventLoggerA, 2, 10)
 	sys.L2B.WaitForBlock()
-	_, execReceiptAtoB := bob.SendExecMessage(initTxAtoB, 0)
+	_, execReceiptAtoB := bob.SendExecMessage(initMsgAtoB.Tx, 0)
 
 	t.Logger().Info("A->B message sent",
-		"init_block", initReceiptAtoB.BlockNumber,
+		"init_block", initMsgAtoB.Receipt.BlockNumber,
 		"exec_block", execReceiptAtoB.BlockNumber,
 	)
 
 	// Send B -> A message
-	initTriggerBtoA := randomInitTrigger(rng, eventLoggerB, 2, 10)
-	initTxBtoA, initReceiptBtoA := bob.SendInitMessage(initTriggerBtoA)
+	initMsgBtoA := bob.SendRandomInitMessage(rng, eventLoggerB, 2, 10)
 	sys.L2A.WaitForBlock()
-	_, execReceiptBtoA := alice.SendExecMessage(initTxBtoA, 0)
+	_, execReceiptBtoA := alice.SendExecMessage(initMsgBtoA.Tx, 0)
 
 	t.Logger().Info("B->A message sent",
-		"init_block", initReceiptBtoA.BlockNumber,
+		"init_block", initMsgBtoA.Receipt.BlockNumber,
 		"exec_block", execReceiptBtoA.BlockNumber,
 	)
 
@@ -68,44 +61,19 @@ func TestSupernodeInteropBidirectionalMessages(gt *testing.T) {
 		statusB := sys.L2BCL.SyncStatus()
 
 		// All blocks should be safe
-		return statusA.SafeL2.Number > bigs.Uint64Strict(initReceiptAtoB.BlockNumber) &&
+		return statusA.SafeL2.Number > bigs.Uint64Strict(initMsgAtoB.Receipt.BlockNumber) &&
 			statusA.SafeL2.Number > bigs.Uint64Strict(execReceiptBtoA.BlockNumber) &&
 			statusB.SafeL2.Number > bigs.Uint64Strict(execReceiptAtoB.BlockNumber) &&
-			statusB.SafeL2.Number > bigs.Uint64Strict(initReceiptBtoA.BlockNumber)
+			statusB.SafeL2.Number > bigs.Uint64Strict(initMsgBtoA.Receipt.BlockNumber)
 	}, timeout, time.Second, "bidirectional messages should become safe")
 
 	t.Logger().Info("bidirectional messages processed successfully")
-
 	finalStatusA := sys.L2ACL.SyncStatus()
 	finalStatusB := sys.L2BCL.SyncStatus()
 	for _, s := range []eth.L2BlockRef{finalStatusA.SafeL2, finalStatusB.SafeL2} {
-		assert.NotZero(t, s.Time, "SafeL2.Time was zero")
-		assert.NotZero(t, s.L1Origin, "SafeL2.L1Origin was zero")
-		assert.NotZero(t, s.ParentHash, "SafeL2.ParentHash was zero")
-		assert.NotZero(t, s.Hash, "SafeL2.Hash was zero")
-	}
-}
-
-// randomInitTrigger creates a random init trigger for testing.
-func randomInitTrigger(rng *rand.Rand, eventLoggerAddress common.Address, topicCount, dataLen int) *txintent.InitTrigger {
-	if topicCount > 4 {
-		topicCount = 4 // Max 4 topics in EVM logs
-	}
-	if topicCount < 1 {
-		topicCount = 1
-	}
-	if dataLen < 1 {
-		dataLen = 1
-	}
-
-	topics := make([][32]byte, topicCount)
-	for i := range topics {
-		copy(topics[i][:], testutils.RandomData(rng, 32))
-	}
-
-	return &txintent.InitTrigger{
-		Emitter:    eventLoggerAddress,
-		Topics:     topics,
-		OpaqueData: testutils.RandomData(rng, dataLen),
+		t.Require().NotZero(t, s.Time, "SafeL2.Time was zero")
+		t.Require().NotZero(t, s.L1Origin, "SafeL2.L1Origin was zero")
+		t.Require().NotZero(t, s.ParentHash, "SafeL2.ParentHash was zero")
+		t.Require().NotZero(t, s.Hash, "SafeL2.Hash was zero")
 	}
 }

--- a/op-acceptance-tests/tests/supernode/interop/cross_message_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/cross_message_test.go
@@ -37,20 +37,14 @@ func TestSupernodeInteropBidirectionalMessages(gt *testing.T) {
 	sys.L2B.WaitForBlock()
 	execMsgAtoB := bob.SendExecMessage(initMsgAtoB)
 
-	t.Logger().Info("A->B message sent",
-		"init_block", initMsgAtoB.BlockNumber(),
-		"exec_block", execMsgAtoB.BlockNumber(),
-	)
+	t.Logger().Info("A->B message sent", "msg", execMsgAtoB)
 
 	// Send B -> A message
 	initMsgBtoA := bob.SendRandomInitMessage(rng, eventLoggerB, 2, 10)
 	sys.L2A.WaitForBlock()
 	execMsgBtoA := alice.SendExecMessage(initMsgBtoA)
 
-	t.Logger().Info("B->A message sent",
-		"init_block", initMsgBtoA.BlockNumber(),
-		"exec_block", execMsgBtoA.BlockNumber(),
-	)
+	t.Logger().Info("B->A message sent", "msg", execMsgBtoA)
 
 	// Wait for all messages to become safe
 	blockTime := sys.L2A.Escape().RollupConfig().BlockTime

--- a/op-acceptance-tests/tests/supernode/interop/cross_message_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/cross_message_test.go
@@ -35,7 +35,7 @@ func TestSupernodeInteropBidirectionalMessages(gt *testing.T) {
 	// Send A -> B message
 	initMsgAtoB := alice.SendRandomInitMessage(rng, eventLoggerA, 2, 10)
 	sys.L2B.WaitForBlock()
-	_, execReceiptAtoB := bob.SendExecMessage(initMsgAtoB.Tx, 0)
+	_, execReceiptAtoB := bob.SendExecMessage(initMsgAtoB)
 
 	t.Logger().Info("A->B message sent",
 		"init_block", initMsgAtoB.BlockNumber(),
@@ -45,7 +45,7 @@ func TestSupernodeInteropBidirectionalMessages(gt *testing.T) {
 	// Send B -> A message
 	initMsgBtoA := bob.SendRandomInitMessage(rng, eventLoggerB, 2, 10)
 	sys.L2A.WaitForBlock()
-	_, execReceiptBtoA := alice.SendExecMessage(initMsgBtoA.Tx, 0)
+	_, execReceiptBtoA := alice.SendExecMessage(initMsgBtoA)
 
 	t.Logger().Info("B->A message sent",
 		"init_block", initMsgBtoA.BlockNumber(),

--- a/op-acceptance-tests/tests/supernode/interop/cross_message_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/cross_message_test.go
@@ -38,7 +38,7 @@ func TestSupernodeInteropBidirectionalMessages(gt *testing.T) {
 	_, execReceiptAtoB := bob.SendExecMessage(initMsgAtoB.Tx, 0)
 
 	t.Logger().Info("A->B message sent",
-		"init_block", initMsgAtoB.Receipt.BlockNumber,
+		"init_block", initMsgAtoB.BlockNumber(),
 		"exec_block", execReceiptAtoB.BlockNumber,
 	)
 
@@ -48,7 +48,7 @@ func TestSupernodeInteropBidirectionalMessages(gt *testing.T) {
 	_, execReceiptBtoA := alice.SendExecMessage(initMsgBtoA.Tx, 0)
 
 	t.Logger().Info("B->A message sent",
-		"init_block", initMsgBtoA.Receipt.BlockNumber,
+		"init_block", initMsgBtoA.BlockNumber(),
 		"exec_block", execReceiptBtoA.BlockNumber,
 	)
 
@@ -61,10 +61,10 @@ func TestSupernodeInteropBidirectionalMessages(gt *testing.T) {
 		statusB := sys.L2BCL.SyncStatus()
 
 		// All blocks should be safe
-		return statusA.SafeL2.Number > bigs.Uint64Strict(initMsgAtoB.Receipt.BlockNumber) &&
+		return statusA.SafeL2.Number > bigs.Uint64Strict(initMsgAtoB.BlockNumber()) &&
 			statusA.SafeL2.Number > bigs.Uint64Strict(execReceiptBtoA.BlockNumber) &&
 			statusB.SafeL2.Number > bigs.Uint64Strict(execReceiptAtoB.BlockNumber) &&
-			statusB.SafeL2.Number > bigs.Uint64Strict(initMsgBtoA.Receipt.BlockNumber)
+			statusB.SafeL2.Number > bigs.Uint64Strict(initMsgBtoA.BlockNumber())
 	}, timeout, time.Second, "bidirectional messages should become safe")
 
 	t.Logger().Info("bidirectional messages processed successfully")

--- a/op-acceptance-tests/tests/supernode/interop/cross_message_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/cross_message_test.go
@@ -35,21 +35,21 @@ func TestSupernodeInteropBidirectionalMessages(gt *testing.T) {
 	// Send A -> B message
 	initMsgAtoB := alice.SendRandomInitMessage(rng, eventLoggerA, 2, 10)
 	sys.L2B.WaitForBlock()
-	_, execReceiptAtoB := bob.SendExecMessage(initMsgAtoB)
+	execMsgAtoB := bob.SendExecMessage(initMsgAtoB)
 
 	t.Logger().Info("A->B message sent",
 		"init_block", initMsgAtoB.BlockNumber(),
-		"exec_block", execReceiptAtoB.BlockNumber,
+		"exec_block", execMsgAtoB.BlockNumber(),
 	)
 
 	// Send B -> A message
 	initMsgBtoA := bob.SendRandomInitMessage(rng, eventLoggerB, 2, 10)
 	sys.L2A.WaitForBlock()
-	_, execReceiptBtoA := alice.SendExecMessage(initMsgBtoA)
+	execMsgBtoA := alice.SendExecMessage(initMsgBtoA)
 
 	t.Logger().Info("B->A message sent",
 		"init_block", initMsgBtoA.BlockNumber(),
-		"exec_block", execReceiptBtoA.BlockNumber,
+		"exec_block", execMsgBtoA.BlockNumber(),
 	)
 
 	// Wait for all messages to become safe
@@ -62,8 +62,8 @@ func TestSupernodeInteropBidirectionalMessages(gt *testing.T) {
 
 		// All blocks should be safe
 		return statusA.SafeL2.Number > bigs.Uint64Strict(initMsgAtoB.BlockNumber()) &&
-			statusA.SafeL2.Number > bigs.Uint64Strict(execReceiptBtoA.BlockNumber) &&
-			statusB.SafeL2.Number > bigs.Uint64Strict(execReceiptAtoB.BlockNumber) &&
+			statusA.SafeL2.Number > bigs.Uint64Strict(execMsgBtoA.BlockNumber()) &&
+			statusB.SafeL2.Number > bigs.Uint64Strict(execMsgAtoB.BlockNumber()) &&
 			statusB.SafeL2.Number > bigs.Uint64Strict(initMsgBtoA.BlockNumber())
 	}, timeout, time.Second, "bidirectional messages should become safe")
 

--- a/op-acceptance-tests/tests/supernode/interop/reorg/invalid_message_reorg_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/reorg/invalid_message_reorg_test.go
@@ -60,7 +60,7 @@ func TestSupernodeInteropInvalidMessageReplacement(gt *testing.T) {
 	sys.L2B.WaitForBlock()
 
 	// Send an INVALID executing message on chain B
-	_, invalidExecReceipt := bob.SendInvalidExecMessage(initMsg.Tx, 0)
+	_, invalidExecReceipt := bob.SendInvalidExecMessage(initMsg)
 	invalidBlockNumber := bigs.Uint64Strict(invalidExecReceipt.BlockNumber)
 	invalidBlockHash := invalidExecReceipt.BlockHash
 	invalidBlockTimestamp := sys.L2B.TimestampForBlockNum(invalidBlockNumber)

--- a/op-acceptance-tests/tests/supernode/interop/reorg/invalid_message_reorg_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/reorg/invalid_message_reorg_test.go
@@ -49,18 +49,18 @@ func TestSupernodeInteropInvalidMessageReplacement(gt *testing.T) {
 	rng := rand.New(rand.NewSource(12345))
 
 	// Send an initiating message on chain A
-	initTx, initReceipt := alice.SendRandomInitMessage(rng, eventLoggerA, 2, 10)
+	initMsg := alice.SendRandomInitMessage(rng, eventLoggerA, 2, 10)
 
 	t.Logger().Info("initiating message sent on chain A",
-		"block", initReceipt.BlockNumber,
-		"hash", initReceipt.BlockHash,
+		"block", initMsg.Receipt.BlockNumber,
+		"hash", initMsg.Receipt.BlockHash,
 	)
 
 	// Wait for chain B to catch up
 	sys.L2B.WaitForBlock()
 
 	// Send an INVALID executing message on chain B
-	_, invalidExecReceipt := bob.SendInvalidExecMessage(initTx, 0)
+	_, invalidExecReceipt := bob.SendInvalidExecMessage(initMsg.Tx, 0)
 	invalidBlockNumber := bigs.Uint64Strict(invalidExecReceipt.BlockNumber)
 	invalidBlockHash := invalidExecReceipt.BlockHash
 	invalidBlockTimestamp := sys.L2B.TimestampForBlockNum(invalidBlockNumber)

--- a/op-acceptance-tests/tests/supernode/interop/reorg/invalid_message_reorg_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/reorg/invalid_message_reorg_test.go
@@ -52,8 +52,8 @@ func TestSupernodeInteropInvalidMessageReplacement(gt *testing.T) {
 	initMsg := alice.SendRandomInitMessage(rng, eventLoggerA, 2, 10)
 
 	t.Logger().Info("initiating message sent on chain A",
-		"block", initMsg.Receipt.BlockNumber,
-		"hash", initMsg.Receipt.BlockHash,
+		"block", initMsg.BlockNumber(),
+		"hash", initMsg.BlockHash(),
 	)
 
 	// Wait for chain B to catch up

--- a/op-acceptance-tests/tests/supernode/interop/reorg/invalid_message_reorg_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/reorg/invalid_message_reorg_test.go
@@ -60,9 +60,9 @@ func TestSupernodeInteropInvalidMessageReplacement(gt *testing.T) {
 	sys.L2B.WaitForBlock()
 
 	// Send an INVALID executing message on chain B
-	_, invalidExecReceipt := bob.SendInvalidExecMessage(initMsg)
-	invalidBlockNumber := bigs.Uint64Strict(invalidExecReceipt.BlockNumber)
-	invalidBlockHash := invalidExecReceipt.BlockHash
+	execMsg := bob.SendInvalidExecMessage(initMsg)
+	invalidBlockNumber := bigs.Uint64Strict(execMsg.BlockNumber())
+	invalidBlockHash := execMsg.BlockHash()
 	invalidBlockTimestamp := sys.L2B.TimestampForBlockNum(invalidBlockNumber)
 	t.Logger().Info("invalid executing message sent on chain B",
 		"block", invalidBlockNumber,
@@ -111,7 +111,7 @@ func TestSupernodeInteropInvalidMessageReplacement(gt *testing.T) {
 
 	// ASSERTION: The invalid transaction no longer exists in the chain
 	// The invalid exec message transaction should NOT be in the replacement block
-	sys.L2ELB.AssertTxNotInBlock(invalidBlockNumber, invalidExecReceipt.TxHash)
+	sys.L2ELB.AssertTxNotInBlock(invalidBlockNumber, execMsg.Receipt.TxHash)
 
 	t.Logger().Info("test complete: invalid block was replaced and verified",
 		"invalid_block_number", invalidBlockNumber,

--- a/op-devstack/dsl/eoa.go
+++ b/op-devstack/dsl/eoa.go
@@ -34,6 +34,12 @@ type EOA struct {
 	el ELNode
 }
 
+// InitMessage represents an initiating message that has been sent and included on chain.
+type InitMessage struct {
+	Tx      *txintent.IntentTx[*txintent.InitTrigger, *txintent.InteropOutput]
+	Receipt *types.Receipt
+}
+
 func NewEOA(key *Key, el ELNode) *EOA {
 	return &EOA{
 		commonImpl: commonFromT(key.t),
@@ -179,13 +185,13 @@ func (u *EOA) DeployWETH() common.Address {
 	return wethAddress
 }
 
-func (u *EOA) SendInitMessage(trigger *txintent.InitTrigger) (*txintent.IntentTx[*txintent.InitTrigger, *txintent.InteropOutput], *types.Receipt) {
+func (u *EOA) SendInitMessage(trigger *txintent.InitTrigger) *InitMessage {
 	tx := txintent.NewIntent[*txintent.InitTrigger, *txintent.InteropOutput](u.Plan())
 	tx.Content.Set(trigger)
 	receipt, err := tx.PlannedTx.Included.Eval(u.ctx)
 	u.t.Require().NoError(err, "init msg receipt not found")
 	u.log.Info("init message included", "chain", u.ChainID(), "block", receipt.BlockNumber)
-	return tx, receipt
+	return &InitMessage{Tx: tx, Receipt: receipt}
 }
 
 // SendRandomInitMessage creates and sends a random initiating message using the given event logger.

--- a/op-devstack/dsl/eoa.go
+++ b/op-devstack/dsl/eoa.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ethereum-optimism/optimism/devnet-sdk/contracts/constants"
 	"github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/interop"
 	e2eBindings "github.com/ethereum-optimism/optimism/op-e2e/bindings"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/retry"
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
@@ -55,6 +56,14 @@ func (m *InitMessage) BlockHash() common.Hash {
 	return m.Receipt.BlockHash
 }
 
+// BlockID returns the block ID from the receipt.
+func (m *InitMessage) BlockID() eth.BlockID {
+	return eth.BlockID{
+		Number: bigs.Uint64Strict(m.Receipt.BlockNumber),
+		Hash:   m.Receipt.BlockHash,
+	}
+}
+
 // ExecMessage represents an executing message that has been sent and included on chain.
 type ExecMessage struct {
 	Tx      *txintent.IntentTx[*txintent.ExecTrigger, *txintent.InteropOutput]
@@ -74,6 +83,14 @@ func (m *ExecMessage) TxHash() common.Hash {
 // BlockHash returns the block hash from the receipt.
 func (m *ExecMessage) BlockHash() common.Hash {
 	return m.Receipt.BlockHash
+}
+
+// BlockID returns the block ID from the receipt.
+func (m *ExecMessage) BlockID() eth.BlockID {
+	return eth.BlockID{
+		Number: bigs.Uint64Strict(m.Receipt.BlockNumber),
+		Hash:   m.Receipt.BlockHash,
+	}
 }
 
 func NewEOA(key *Key, el ELNode) *EOA {

--- a/op-devstack/dsl/eoa.go
+++ b/op-devstack/dsl/eoa.go
@@ -196,7 +196,7 @@ func (u *EOA) SendInitMessage(trigger *txintent.InitTrigger) *InitMessage {
 
 // SendRandomInitMessage creates and sends a random initiating message using the given event logger.
 // topicCount specifies the number of topics (clamped to 1-4), dataLen specifies the opaque data length (minimum 1).
-func (u *EOA) SendRandomInitMessage(rng *rand.Rand, eventLoggerAddress common.Address, topicCount, dataLen int) (*txintent.IntentTx[*txintent.InitTrigger, *txintent.InteropOutput], *types.Receipt) {
+func (u *EOA) SendRandomInitMessage(rng *rand.Rand, eventLoggerAddress common.Address, topicCount, dataLen int) *InitMessage {
 	// Clamp topicCount to valid range [1, 4]
 	if topicCount > 4 {
 		topicCount = 4

--- a/op-devstack/dsl/eoa.go
+++ b/op-devstack/dsl/eoa.go
@@ -55,6 +55,27 @@ func (m *InitMessage) BlockHash() common.Hash {
 	return m.Receipt.BlockHash
 }
 
+// ExecMessage represents an executing message that has been sent and included on chain.
+type ExecMessage struct {
+	Tx      *txintent.IntentTx[*txintent.ExecTrigger, *txintent.InteropOutput]
+	Receipt *types.Receipt
+}
+
+// BlockNumber returns the block number from the receipt.
+func (m *ExecMessage) BlockNumber() *big.Int {
+	return m.Receipt.BlockNumber
+}
+
+// TxHash returns the transaction hash from the receipt.
+func (m *ExecMessage) TxHash() common.Hash {
+	return m.Receipt.TxHash
+}
+
+// BlockHash returns the block hash from the receipt.
+func (m *ExecMessage) BlockHash() common.Hash {
+	return m.Receipt.BlockHash
+}
+
 func NewEOA(key *Key, el ELNode) *EOA {
 	return &EOA{
 		commonImpl: commonFromT(key.t),
@@ -238,7 +259,7 @@ func (u *EOA) SendRandomInitMessage(rng *rand.Rand, eventLoggerAddress common.Ad
 	return u.SendInitMessage(trigger)
 }
 
-func (u *EOA) SendExecMessage(initMsg *InitMessage) (*txintent.IntentTx[*txintent.ExecTrigger, *txintent.InteropOutput], *types.Receipt) {
+func (u *EOA) SendExecMessage(initMsg *InitMessage) *ExecMessage {
 	tx := txintent.NewIntent[*txintent.ExecTrigger, *txintent.InteropOutput](u.Plan())
 	tx.Content.DependOn(&initMsg.Tx.Result)
 	tx.Content.Fn(txintent.ExecuteIndexed(constants.CrossL2Inbox, &initMsg.Tx.Result, 0))
@@ -247,12 +268,15 @@ func (u *EOA) SendExecMessage(initMsg *InitMessage) (*txintent.IntentTx[*txinten
 	u.log.Info("exec message included", "chain", u.ChainID(), "block", receipt.BlockNumber)
 	// Check single ExecutingMessage triggered
 	u.t.Require().Equal(1, len(receipt.Logs))
-	return tx, receipt
+	return &ExecMessage{
+		Tx:      tx,
+		Receipt: receipt,
+	}
 }
 
 // SendInvalidExecMessage sends an executing message with an invalid identifier.
 // The log index is incremented to reference a non-existent log.
-func (u *EOA) SendInvalidExecMessage(initMsg *InitMessage) (*txintent.IntentTx[*txintent.ExecTrigger, *txintent.InteropOutput], *types.Receipt) {
+func (u *EOA) SendInvalidExecMessage(initMsg *InitMessage) *ExecMessage {
 	result, err := initMsg.Tx.Result.Eval(u.ctx)
 	u.t.Require().NoError(err, "failed to evaluate init result")
 	u.t.Require().Greater(len(result.Entries), 0, "event index out of range")
@@ -277,7 +301,10 @@ func (u *EOA) SendInvalidExecMessage(initMsg *InitMessage) (*txintent.IntentTx[*
 	receipt, err := tx.PlannedTx.Included.Eval(u.ctx)
 	u.t.Require().NoError(err, "invalid exec msg receipt not found")
 	u.log.Info("invalid exec message included", "chain", u.ChainID(), "block", receipt.BlockNumber)
-	return tx, receipt
+	return &ExecMessage{
+		Tx:      tx,
+		Receipt: receipt,
+	}
 }
 
 // SendPackedRandomInitMessages batches random messages and initiates them via a single multicall

--- a/op-devstack/dsl/eoa.go
+++ b/op-devstack/dsl/eoa.go
@@ -238,10 +238,10 @@ func (u *EOA) SendRandomInitMessage(rng *rand.Rand, eventLoggerAddress common.Ad
 	return u.SendInitMessage(trigger)
 }
 
-func (u *EOA) SendExecMessage(initIntent *txintent.IntentTx[*txintent.InitTrigger, *txintent.InteropOutput], eventIdx int) (*txintent.IntentTx[*txintent.ExecTrigger, *txintent.InteropOutput], *types.Receipt) {
+func (u *EOA) SendExecMessage(initMsg *InitMessage) (*txintent.IntentTx[*txintent.ExecTrigger, *txintent.InteropOutput], *types.Receipt) {
 	tx := txintent.NewIntent[*txintent.ExecTrigger, *txintent.InteropOutput](u.Plan())
-	tx.Content.DependOn(&initIntent.Result)
-	tx.Content.Fn(txintent.ExecuteIndexed(constants.CrossL2Inbox, &initIntent.Result, eventIdx))
+	tx.Content.DependOn(&initMsg.Tx.Result)
+	tx.Content.Fn(txintent.ExecuteIndexed(constants.CrossL2Inbox, &initMsg.Tx.Result, 0))
 	receipt, err := tx.PlannedTx.Included.Eval(u.ctx)
 	u.t.Require().NoError(err, "exec msg receipt not found")
 	u.log.Info("exec message included", "chain", u.ChainID(), "block", receipt.BlockNumber)
@@ -252,16 +252,13 @@ func (u *EOA) SendExecMessage(initIntent *txintent.IntentTx[*txintent.InitTrigge
 
 // SendInvalidExecMessage sends an executing message with an invalid identifier.
 // The log index is incremented to reference a non-existent log.
-func (u *EOA) SendInvalidExecMessage(
-	initIntent *txintent.IntentTx[*txintent.InitTrigger, *txintent.InteropOutput],
-	eventIdx int,
-) (*txintent.IntentTx[*txintent.ExecTrigger, *txintent.InteropOutput], *types.Receipt) {
-	result, err := initIntent.Result.Eval(u.ctx)
+func (u *EOA) SendInvalidExecMessage(initMsg *InitMessage) (*txintent.IntentTx[*txintent.ExecTrigger, *txintent.InteropOutput], *types.Receipt) {
+	result, err := initMsg.Tx.Result.Eval(u.ctx)
 	u.t.Require().NoError(err, "failed to evaluate init result")
-	u.t.Require().Greater(len(result.Entries), eventIdx, "event index out of range")
+	u.t.Require().Greater(len(result.Entries), 0, "event index out of range")
 
 	// Get the message and modify it to be invalid by incrementing the log index
-	msg := result.Entries[eventIdx]
+	msg := result.Entries[0]
 	msg.Identifier.LogIndex++
 
 	// Create the exec trigger with the invalid message
@@ -272,7 +269,7 @@ func (u *EOA) SendInvalidExecMessage(
 
 	// The Fn just returns the pre-built trigger
 	tx := txintent.NewIntent[*txintent.ExecTrigger, *txintent.InteropOutput](u.Plan())
-	tx.Content.DependOn(&initIntent.Result)
+	tx.Content.DependOn(&initMsg.Tx.Result)
 	tx.Content.Fn(func(ctx context.Context) (*txintent.ExecTrigger, error) {
 		return execTrigger, nil
 	})

--- a/op-devstack/dsl/eoa.go
+++ b/op-devstack/dsl/eoa.go
@@ -64,8 +64,14 @@ func (m *InitMessage) BlockID() eth.BlockID {
 	}
 }
 
+// String returns a human-readable representation of the InitMessage.
+func (m *InitMessage) String() string {
+	return fmt.Sprintf("InitMessage(block=%d, blockHash=%s, txHash=%s)", m.Receipt.BlockNumber, m.Receipt.BlockHash, m.Receipt.TxHash)
+}
+
 // ExecMessage represents an executing message that has been sent and included on chain.
 type ExecMessage struct {
+	Init    *InitMessage
 	Tx      *txintent.IntentTx[*txintent.ExecTrigger, *txintent.InteropOutput]
 	Receipt *types.Receipt
 }
@@ -91,6 +97,11 @@ func (m *ExecMessage) BlockID() eth.BlockID {
 		Number: bigs.Uint64Strict(m.Receipt.BlockNumber),
 		Hash:   m.Receipt.BlockHash,
 	}
+}
+
+// String returns a human-readable representation of the ExecMessage.
+func (m *ExecMessage) String() string {
+	return fmt.Sprintf("ExecMessage(init=%s, block=%d, blockHash=%s, txHash=%s)", m.Init, m.Receipt.BlockNumber, m.Receipt.BlockHash, m.Receipt.TxHash)
 }
 
 func NewEOA(key *Key, el ELNode) *EOA {
@@ -286,6 +297,7 @@ func (u *EOA) SendExecMessage(initMsg *InitMessage) *ExecMessage {
 	// Check single ExecutingMessage triggered
 	u.t.Require().Equal(1, len(receipt.Logs))
 	return &ExecMessage{
+		Init:    initMsg,
 		Tx:      tx,
 		Receipt: receipt,
 	}
@@ -319,6 +331,7 @@ func (u *EOA) SendInvalidExecMessage(initMsg *InitMessage) *ExecMessage {
 	u.t.Require().NoError(err, "invalid exec msg receipt not found")
 	u.log.Info("invalid exec message included", "chain", u.ChainID(), "block", receipt.BlockNumber)
 	return &ExecMessage{
+		Init:    initMsg,
 		Tx:      tx,
 		Receipt: receipt,
 	}

--- a/op-devstack/dsl/eoa.go
+++ b/op-devstack/dsl/eoa.go
@@ -40,6 +40,21 @@ type InitMessage struct {
 	Receipt *types.Receipt
 }
 
+// BlockNumber returns the block number from the receipt.
+func (m *InitMessage) BlockNumber() *big.Int {
+	return m.Receipt.BlockNumber
+}
+
+// TxHash returns the transaction hash from the receipt.
+func (m *InitMessage) TxHash() common.Hash {
+	return m.Receipt.TxHash
+}
+
+// BlockHash returns the block hash from the receipt.
+func (m *InitMessage) BlockHash() common.Hash {
+	return m.Receipt.BlockHash
+}
+
 func NewEOA(key *Key, el ELNode) *EOA {
 	return &EOA{
 		commonImpl: commonFromT(key.t),

--- a/rust/kona/tests/supervisor/message/interop_happy_tx_test.go
+++ b/rust/kona/tests/supervisor/message/interop_happy_tx_test.go
@@ -42,7 +42,7 @@ func TestInteropHappyTx(gt *testing.T) {
 	sys.L2ChainB.WaitForBlock()
 
 	// send executing message on chain B
-	_, execReceipt := bob.SendExecMessage(initMsg)
+	execMsg := bob.SendExecMessage(initMsg)
 
 	// confirm that the cross-safe safety passed init and exec receipts and that blocks were not reorged
 	dsl.CheckAll(t,
@@ -51,8 +51,8 @@ func TestInteropHappyTx(gt *testing.T) {
 			Hash:   initMsg.BlockHash(),
 		}, 500),
 		sys.L2CLB.ReachedRefFn(stypes.CrossSafe, eth.BlockID{
-			Number: bigs.Uint64Strict(execReceipt.BlockNumber),
-			Hash:   execReceipt.BlockHash,
+			Number: bigs.Uint64Strict(execMsg.BlockNumber()),
+			Hash:   execMsg.BlockHash(),
 		}, 500),
 	)
 }

--- a/rust/kona/tests/supervisor/message/interop_happy_tx_test.go
+++ b/rust/kona/tests/supervisor/message/interop_happy_tx_test.go
@@ -10,8 +10,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-
-	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	stypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
@@ -46,13 +44,7 @@ func TestInteropHappyTx(gt *testing.T) {
 
 	// confirm that the cross-safe safety passed init and exec receipts and that blocks were not reorged
 	dsl.CheckAll(t,
-		sys.L2CLA.ReachedRefFn(stypes.CrossSafe, eth.BlockID{
-			Number: bigs.Uint64Strict(initMsg.BlockNumber()),
-			Hash:   initMsg.BlockHash(),
-		}, 500),
-		sys.L2CLB.ReachedRefFn(stypes.CrossSafe, eth.BlockID{
-			Number: bigs.Uint64Strict(execMsg.BlockNumber()),
-			Hash:   execMsg.BlockHash(),
-		}, 500),
+		sys.L2CLA.ReachedRefFn(stypes.CrossSafe, initMsg.BlockID(), 500),
+		sys.L2CLB.ReachedRefFn(stypes.CrossSafe, execMsg.BlockID(), 500),
 	)
 }

--- a/rust/kona/tests/supervisor/message/interop_happy_tx_test.go
+++ b/rust/kona/tests/supervisor/message/interop_happy_tx_test.go
@@ -42,13 +42,13 @@ func TestInteropHappyTx(gt *testing.T) {
 	sys.L2ChainB.WaitForBlock()
 
 	// send executing message on chain B
-	_, execReceipt := bob.SendExecMessage(initMsg.Tx, 0)
+	_, execReceipt := bob.SendExecMessage(initMsg)
 
 	// confirm that the cross-safe safety passed init and exec receipts and that blocks were not reorged
 	dsl.CheckAll(t,
 		sys.L2CLA.ReachedRefFn(stypes.CrossSafe, eth.BlockID{
-			Number: bigs.Uint64Strict(initMsg.Receipt.BlockNumber),
-			Hash:   initMsg.Receipt.BlockHash,
+			Number: bigs.Uint64Strict(initMsg.BlockNumber()),
+			Hash:   initMsg.BlockHash(),
 		}, 500),
 		sys.L2CLB.ReachedRefFn(stypes.CrossSafe, eth.BlockID{
 			Number: bigs.Uint64Strict(execReceipt.BlockNumber),

--- a/rust/kona/tests/supervisor/message/interop_happy_tx_test.go
+++ b/rust/kona/tests/supervisor/message/interop_happy_tx_test.go
@@ -36,19 +36,19 @@ func TestInteropHappyTx(gt *testing.T) {
 
 	// send initiating message on chain A
 	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
-	initTx, initReceipt := alice.SendInitMessage(interop.RandomInitTrigger(rng, eventLoggerAddress, rng.Intn(3), rng.Intn(10)))
+	initMsg := alice.SendInitMessage(interop.RandomInitTrigger(rng, eventLoggerAddress, rng.Intn(3), rng.Intn(10)))
 
 	// at least one block between the init tx on chain A and the exec tx on chain B
 	sys.L2ChainB.WaitForBlock()
 
 	// send executing message on chain B
-	_, execReceipt := bob.SendExecMessage(initTx, 0)
+	_, execReceipt := bob.SendExecMessage(initMsg.Tx, 0)
 
 	// confirm that the cross-safe safety passed init and exec receipts and that blocks were not reorged
 	dsl.CheckAll(t,
 		sys.L2CLA.ReachedRefFn(stypes.CrossSafe, eth.BlockID{
-			Number: bigs.Uint64Strict(initReceipt.BlockNumber),
-			Hash:   initReceipt.BlockHash,
+			Number: bigs.Uint64Strict(initMsg.Receipt.BlockNumber),
+			Hash:   initMsg.Receipt.BlockHash,
 		}, 500),
 		sys.L2CLB.ReachedRefFn(stypes.CrossSafe, eth.BlockID{
 			Number: bigs.Uint64Strict(execReceipt.BlockNumber),

--- a/rust/kona/tests/supervisor/message/interop_msg_test.go
+++ b/rust/kona/tests/supervisor/message/interop_msg_test.go
@@ -43,11 +43,11 @@ func TestInitExecMsg(gt *testing.T) {
 
 	eventLoggerAddress := alice.DeployEventLogger()
 	// Trigger random init message at chain A
-	initIntent, _ := alice.SendInitMessage(interop.RandomInitTrigger(rng, eventLoggerAddress, rng.Intn(5), rng.Intn(30)))
+	initMsg := alice.SendInitMessage(interop.RandomInitTrigger(rng, eventLoggerAddress, rng.Intn(5), rng.Intn(30)))
 	// Make sure supervisor indexes block which includes init message
 	sys.Supervisor.WaitForUnsafeHeadToAdvance(alice.ChainID(), 2)
 	// Single event in tx so index is 0
-	bob.SendExecMessage(initIntent, 0)
+	bob.SendExecMessage(initMsg.Tx, 0)
 }
 
 // TestInitExecMsgWithDSL tests basic interop messaging with contract DSL

--- a/rust/kona/tests/supervisor/message/interop_msg_test.go
+++ b/rust/kona/tests/supervisor/message/interop_msg_test.go
@@ -47,7 +47,7 @@ func TestInitExecMsg(gt *testing.T) {
 	// Make sure supervisor indexes block which includes init message
 	sys.Supervisor.WaitForUnsafeHeadToAdvance(alice.ChainID(), 2)
 	// Single event in tx so index is 0
-	bob.SendExecMessage(initMsg.Tx, 0)
+	bob.SendExecMessage(initMsg)
 }
 
 // TestInitExecMsgWithDSL tests basic interop messaging with contract DSL

--- a/rust/kona/tests/supervisor/pre_interop/post_test.go
+++ b/rust/kona/tests/supervisor/pre_interop/post_test.go
@@ -173,7 +173,7 @@ func testInteropMessageInclusion(t devtest.T, sys *presets.SimpleInterop) {
 	sys.Supervisor.WaitForUnsafeHeadToAdvance(alice.ChainID(), 2)
 
 	// Single event in tx so index is 0
-	_, execReceipt := bob.SendExecMessage(initMsg.Tx, 0)
+	_, execReceipt := bob.SendExecMessage(initMsg)
 
 	// Phase 5: Verify cross-safe progression
 	verifyInteropMessagesProgression(t, sys, initMsg.Receipt, execReceipt)

--- a/rust/kona/tests/supervisor/pre_interop/post_test.go
+++ b/rust/kona/tests/supervisor/pre_interop/post_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	stypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 )
 
 func testSupervisorActivationBlock(t devtest.T, sys *presets.SimpleInterop, net *dsl.L2Network, activationBlock eth.BlockID) {
@@ -173,10 +172,10 @@ func testInteropMessageInclusion(t devtest.T, sys *presets.SimpleInterop) {
 	sys.Supervisor.WaitForUnsafeHeadToAdvance(alice.ChainID(), 2)
 
 	// Single event in tx so index is 0
-	_, execReceipt := bob.SendExecMessage(initMsg)
+	execMsg := bob.SendExecMessage(initMsg)
 
 	// Phase 5: Verify cross-safe progression
-	verifyInteropMessagesProgression(t, sys, initMsg.Receipt, execReceipt)
+	verifyInteropMessagesProgression(t, sys, initMsg, execMsg)
 
 	logger.Info("Interop message inclusion test completed successfully")
 }
@@ -198,18 +197,18 @@ func setupInteropTestEnvironment(sys *presets.SimpleInterop) (alice, bob *dsl.EO
 }
 
 // verifyInteropMessagesProgression verifies cross-safe progression for both init and exec messages
-func verifyInteropMessagesProgression(t devtest.T, sys *presets.SimpleInterop, initReceipt, execReceipt *types.Receipt) {
+func verifyInteropMessagesProgression(t devtest.T, sys *presets.SimpleInterop, initMsg *dsl.InitMessage, execMsg *dsl.ExecMessage) {
 	logger := t.Logger()
 
 	// Verify cross-safe progression for both messages
 	dsl.CheckAll(t,
 		sys.L2CLA.ReachedRefFn(stypes.CrossSafe, eth.BlockID{
-			Number: bigs.Uint64Strict(initReceipt.BlockNumber),
-			Hash:   initReceipt.BlockHash,
+			Number: bigs.Uint64Strict(initMsg.BlockNumber()),
+			Hash:   initMsg.BlockHash(),
 		}, 60),
 		sys.L2CLB.ReachedRefFn(stypes.CrossSafe, eth.BlockID{
-			Number: bigs.Uint64Strict(execReceipt.BlockNumber),
-			Hash:   execReceipt.BlockHash,
+			Number: bigs.Uint64Strict(execMsg.BlockNumber()),
+			Hash:   execMsg.BlockHash(),
 		}, 60),
 	)
 

--- a/rust/kona/tests/supervisor/pre_interop/post_test.go
+++ b/rust/kona/tests/supervisor/pre_interop/post_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack/match"
-	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	stypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 	"github.com/ethereum/go-ethereum/common"
@@ -202,14 +201,8 @@ func verifyInteropMessagesProgression(t devtest.T, sys *presets.SimpleInterop, i
 
 	// Verify cross-safe progression for both messages
 	dsl.CheckAll(t,
-		sys.L2CLA.ReachedRefFn(stypes.CrossSafe, eth.BlockID{
-			Number: bigs.Uint64Strict(initMsg.BlockNumber()),
-			Hash:   initMsg.BlockHash(),
-		}, 60),
-		sys.L2CLB.ReachedRefFn(stypes.CrossSafe, eth.BlockID{
-			Number: bigs.Uint64Strict(execMsg.BlockNumber()),
-			Hash:   execMsg.BlockHash(),
-		}, 60),
+		sys.L2CLA.ReachedRefFn(stypes.CrossSafe, initMsg.BlockID(), 60),
+		sys.L2CLB.ReachedRefFn(stypes.CrossSafe, execMsg.BlockID(), 60),
 	)
 
 	logger.Info("Cross-safe progression verified for both init and exec messages")

--- a/rust/kona/tests/supervisor/pre_interop/post_test.go
+++ b/rust/kona/tests/supervisor/pre_interop/post_test.go
@@ -167,16 +167,16 @@ func testInteropMessageInclusion(t devtest.T, sys *presets.SimpleInterop) {
 
 	// Phase 2: Send init message on chain A
 	rng := rand.New(rand.NewSource(1234))
-	initIntent, initReceipt := alice.SendInitMessage(interop.RandomInitTrigger(rng, eventLoggerAddress, rng.Intn(5), rng.Intn(30)))
+	initMsg := alice.SendInitMessage(interop.RandomInitTrigger(rng, eventLoggerAddress, rng.Intn(5), rng.Intn(30)))
 
 	// Make sure supervisor indexes block which includes init message
 	sys.Supervisor.WaitForUnsafeHeadToAdvance(alice.ChainID(), 2)
 
 	// Single event in tx so index is 0
-	_, execReceipt := bob.SendExecMessage(initIntent, 0)
+	_, execReceipt := bob.SendExecMessage(initMsg.Tx, 0)
 
 	// Phase 5: Verify cross-safe progression
-	verifyInteropMessagesProgression(t, sys, initReceipt, execReceipt)
+	verifyInteropMessagesProgression(t, sys, initMsg.Receipt, execReceipt)
 
 	logger.Info("Interop message inclusion test completed successfully")
 }

--- a/rust/kona/tests/supervisor/pre_interop/pre_test.go
+++ b/rust/kona/tests/supervisor/pre_interop/pre_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/txintent"
 	stypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
-	"github.com/ethereum/go-ethereum/core/types"
 )
 
 // Acceptance Test: https://github.com/ethereum-optimism/optimism/blob/develop/op-acceptance-tests/tests/interop/upgrade/pre_test.go
@@ -56,8 +55,7 @@ func TestPreNoInbox(gt *testing.T) {
 		t.Logger().Info("Timestamps", "interopTime", *interopTime, "now", time.Now().Unix())
 	})
 
-	var initReceipt *types.Receipt
-	var initTx *txintent.IntentTx[*txintent.InitTrigger, *txintent.InteropOutput]
+	var initMsg *dsl.InitMessage
 	// try interop before the upgrade, confirm that messages do not get included
 	{
 		// two EOAs for triggering the init and exec interop txs
@@ -74,20 +72,20 @@ func TestPreNoInbox(gt *testing.T) {
 
 		// send initiating message on chain A
 		rng := rand.New(rand.NewSource(time.Now().UnixNano()))
-		initTx, initReceipt = alice.SendInitMessage(interop.RandomInitTrigger(rng, eventLoggerAddress, rng.Intn(3), rng.Intn(10)))
+		initMsg = alice.SendInitMessage(interop.RandomInitTrigger(rng, eventLoggerAddress, rng.Intn(3), rng.Intn(10)))
 
 		// at least one block between the init tx on chain A and the exec tx on chain B
 		sys.L2ChainB.WaitForBlock()
 
 		// send executing message on chain B and confirm we got an error
 		execTx := txintent.NewIntent[*txintent.ExecTrigger, *txintent.InteropOutput](bob.Plan())
-		execTx.Content.DependOn(&initTx.Result)
-		execTx.Content.Fn(txintent.ExecuteIndexed(constants.CrossL2Inbox, &initTx.Result, 0))
+		execTx.Content.DependOn(&initMsg.Tx.Result)
+		execTx.Content.Fn(txintent.ExecuteIndexed(constants.CrossL2Inbox, &initMsg.Tx.Result, 0))
 		execReceipt, err := execTx.PlannedTx.Included.Eval(sys.T.Ctx())
 		require.ErrorContains(err, "implementation not initialized", "error did not contain expected string")
 		require.Nil(execReceipt)
 
-		t.Logger().Info("initReceipt", "blocknum", initReceipt.BlockNumber, "txhash", initReceipt.TxHash)
+		t.Logger().Info("initReceipt", "blocknum", initMsg.Receipt.BlockNumber, "txhash", initMsg.Receipt.TxHash)
 
 		// confirm we are still pre-interop
 		require.False(sys.L2ChainA.IsActivated(*interopTimeA))
@@ -99,7 +97,7 @@ func TestPreNoInbox(gt *testing.T) {
 	{
 		ctx := sys.T.Ctx()
 
-		execTrigger, err := txintent.ExecuteIndexed(constants.CrossL2Inbox, &initTx.Result, 0)(ctx)
+		execTrigger, err := txintent.ExecuteIndexed(constants.CrossL2Inbox, &initMsg.Tx.Result, 0)(ctx)
 		require.NoError(err)
 
 		ed := stypes.ExecutingDescriptor{Timestamp: uint64(time.Now().Unix())}

--- a/rust/kona/tests/supervisor/rpc/rpc_test.go
+++ b/rust/kona/tests/supervisor/rpc/rpc_test.go
@@ -203,9 +203,10 @@ func TestRPCCheckAccessList(gt *testing.T) {
 	sys.L2ChainB.CatchUpTo(sys.L2ChainA)
 
 	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
-	_, initReceipt := alice.SendInitMessage(
+	initMsg := alice.SendInitMessage(
 		interop.RandomInitTrigger(rng, eventLoggerAddress, rng.Intn(3), rng.Intn(10)),
 	)
+	initReceipt := initMsg.Receipt
 
 	logToAccess := func(chainID eth.ChainID, log *gethTypes.Log, timestamp uint64) types.Access {
 		msgPayload := make([]byte, 0)


### PR DESCRIPTION
## Summary

Refactors interop message handling in the DSL to use dedicated struct types instead of returning tuples, improving API ergonomics and type safety.

### Changes

- **Introduced `InitMessage` struct**: Encapsulates the `IntentTx` and `Receipt` returned by `SendInitMessage` and `SendRandomInitMessage`
- **Introduced `ExecMessage` struct**: Encapsulates the `IntentTx` and `Receipt` returned by `SendExecMessage` and `SendInvalidExecMessage`
- **Added convenience accessors**: Both structs expose `BlockNumber()`, `TxHash()`, `BlockHash()`, and `BlockID()` methods for easier access to receipt data
- **Simplified API**: `SendExecMessage` and `SendInvalidExecMessage` now accept `InitMessage` directly instead of `IntentTx` + `eventIdx` (always 0)
- **Updated all call sites**: Migrated 8+ test files across `op-acceptance-tests` and `rust/kona/tests` to use the new API

### Benefits

1. **Better encapsulation**: Related values (transaction intent + receipt) are bundled together
2. **Cleaner call sites**: No more tuple unpacking, direct access via methods
3. **Type safety**: Compiler enforces correct message types
4. **Reduced boilerplate**: `BlockID()` method eliminates repeated `eth.BlockID` construction

### Testing

- ✅ All acceptance tests passing
- ✅ `make lint-go` passes (0 issues)
- ✅ All affected test files updated and verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)