### PR TITLE
ci: Fix rust workflow references to prestate builds.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,14 +127,14 @@ workflows:
             .* c-flake-shake-workers << pipeline.parameters.flake-shake-workers >> .circleci/continue/main.yml
             .* c-go-cache-version << pipeline.parameters.go-cache-version >> .circleci/continue/main.yml
 
-            rust/.* c-rust_ci_dispatch << pipeline.parameters.rust_ci_dispatch >> .circleci/continue/rust-ci.yml
-            rust/.* c-default_docker_image << pipeline.parameters.default_docker_image >> .circleci/continue/rust-ci.yml
-            rust/.* c-base_image << pipeline.parameters.base_image >> .circleci/continue/rust-ci.yml
-            rust/.* c-go-cache-version << pipeline.parameters.go-cache-version >> .circleci/continue/rust-ci.yml
+            (rust|\.circleci)/.* c-rust_ci_dispatch << pipeline.parameters.rust_ci_dispatch >> .circleci/continue/rust-ci.yml
+            (rust|\.circleci)/.* c-default_docker_image << pipeline.parameters.default_docker_image >> .circleci/continue/rust-ci.yml
+            (rust|\.circleci)/.* c-base_image << pipeline.parameters.base_image >> .circleci/continue/rust-ci.yml
+            (rust|\.circleci)/.* c-go-cache-version << pipeline.parameters.go-cache-version >> .circleci/continue/rust-ci.yml
 
-            rust/.* c-rust_e2e_dispatch << pipeline.parameters.rust_e2e_dispatch >> .circleci/continue/rust-e2e.yml
-            rust/.* c-default_docker_image << pipeline.parameters.default_docker_image >> .circleci/continue/rust-e2e.yml
-            rust/.* c-go-cache-version << pipeline.parameters.go-cache-version >> .circleci/continue/rust-e2e.yml
+            (rust|\.circleci)/.* c-rust_e2e_dispatch << pipeline.parameters.rust_e2e_dispatch >> .circleci/continue/rust-e2e.yml
+            (rust|\.circleci)/.* c-default_docker_image << pipeline.parameters.default_docker_image >> .circleci/continue/rust-e2e.yml
+            (rust|\.circleci)/.* c-go-cache-version << pipeline.parameters.go-cache-version >> .circleci/continue/rust-e2e.yml
 
   setup-tag:
     when:

--- a/.circleci/continue/rust-e2e.yml
+++ b/.circleci/continue/rust-e2e.yml
@@ -202,11 +202,9 @@ workflows:
           build_args: --skip test
           context:
             - circleci-repo-readonly-authenticated-github-token
-      - cannon-prestate-quick: &rust-e2e-job-base
+      - cannon-prestate: &rust-e2e-job-base
           context:
             - circleci-repo-readonly-authenticated-github-token
-      - cannon-kona-prestate:
-          <<: *rust-e2e-job-base
       - rust-build-binary: &cannon-kona-host
           name: cannon-kona-host
           directory: rust
@@ -236,8 +234,7 @@ workflows:
             - circleci-repo-readonly-authenticated-github-token
           requires:
             - contracts-bedrock-build
-            - cannon-prestate-quick
-            - cannon-kona-prestate
+            - cannon-prestate
             - cannon-kona-host
             - kona-build-release
             - op-reth-build
@@ -246,8 +243,7 @@ workflows:
           <<: *rust-e2e-job-base
           requires:
             - contracts-bedrock-build
-            - cannon-prestate-quick
-            - cannon-kona-prestate
+            - cannon-prestate
             - cannon-kona-host
             - kona-build-release
       # Proof tests - single kind only, interop excluded per original config


### PR DESCRIPTION
**Description**

The rust workflow was referring to job definitions that had been removed from the main workflow and getting errors:
```
Error calling workflow: 'rust-e2e-ci'
Cannot find a definition for job named cannon-prestate-quick
```

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
