### PR TITLE
kona-proofs: Fix interop header_by_number lookup for blocks within the current history window

### DIFF
--- a/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
+++ b/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
@@ -501,17 +501,13 @@ func RunConsolidateValidCrossChainMessageTest(t devtest.T, sys *presets.SimpleIn
 	gameDepth := sys.DisputeGameFactory().GameImpl(gameTypes.SuperCannonKonaGameType).SplitDepth()
 	for _, test := range tests {
 		t.Run(test.Name+"-fpp", func(t devtest.T) {
-			// TODO(#18288): Re-enable test when Kona is fixed
-			t.Skip("Kona currently hangs when looking up init messages")
 			runKonaInteropProgram(t, challengerCfg.CannonKona, test.L1Head.Hash,
 				test.AgreedClaim, crypto.Keccak256Hash(test.DisputedClaim),
 				test.ClaimTimestamp, test.ExpectValid)
-			t.Log("Test complete")
 		})
 
 		t.Run(test.Name+"-challenger", func(t devtest.T) {
 			runChallengerProviderTest(t, sys.SuperRoots.QueryAPI(), gameDepth, startTimestamp, test.ClaimTimestamp, test)
 		})
 	}
-	t.Log("All tests complete")
 }

--- a/rust/kona/crates/proof/proof-interop/src/provider.rs
+++ b/rust/kona/crates/proof/proof-interop/src/provider.rs
@@ -142,7 +142,7 @@ where
                 // If Isthmus is active, the EIP-2935 contract is used to perform leaping lookbacks
                 // through consulting the ring buffer within the contract. If this
                 // lookup fails for any reason, we fall back to linear walk back.
-                let block_hash = match eip_2935_history_lookup(&header, 0, self, self).await {
+                let block_hash = match eip_2935_history_lookup(&header, number, self, self).await {
                     Ok(hash) => hash,
                     Err(_) => {
                         // If the EIP-2935 lookup fails for any reason, attempt fallback to linear


### PR DESCRIPTION
**Description**

Ensure the block number being looked up is right. This makes it work for blocks within a history window but the code is still pretty smelly for anything prior to that. It's worth fixing the easy case now so we can get interop tests enabled but not closing the issue yet until we have a better understanding of the issue and are sure it works for blocks prior to the history window too.


**Tests**

Enabled the test that was getting stuck forever and now passes.

Builds on https://github.com/ethereum-optimism/optimism/pull/19229

**Metadata**

Part of https://github.com/ethereum-optimism/optimism/issues/18288