### PR TITLE
op-reth(consensus): make calculate_receipt_root_optimism pub

### DIFF
--- a/rust/op-reth/crates/consensus/src/lib.rs
+++ b/rust/op-reth/crates/consensus/src/lib.rs
@@ -33,7 +33,7 @@ use reth_primitives_traits::{
 };
 
 mod proof;
-pub use proof::calculate_receipt_root_no_memo_optimism;
+pub use proof::{calculate_receipt_root_no_memo_optimism, calculate_receipt_root_optimism};
 
 pub mod validation;
 pub use validation::{canyon, isthmus, validate_block_post_execution};

--- a/rust/op-reth/crates/consensus/src/proof.rs
+++ b/rust/op-reth/crates/consensus/src/proof.rs
@@ -9,7 +9,7 @@ use reth_optimism_forks::OpHardforks;
 use reth_optimism_primitives::DepositReceipt;
 
 /// Calculates the receipt root for a header.
-pub(crate) fn calculate_receipt_root_optimism<R: DepositReceipt>(
+pub fn calculate_receipt_root_optimism<R: DepositReceipt>(
     receipts: &[ReceiptWithBloom<&R>],
     chain_spec: impl OpHardforks,
     timestamp: u64,


### PR DESCRIPTION
`calculate_receipt_root_optimism` can be useful when we have memoized `ReceiptWithBloom`