### PR TITLE
feat(op-reth): export calculate_receipt_root_optimism

### DIFF
--- a/op-reth/crates/consensus/src/lib.rs
+++ b/op-reth/crates/consensus/src/lib.rs
@@ -33,7 +33,7 @@ use reth_primitives_traits::{
 };
 
 mod proof;
-pub use proof::calculate_receipt_root_no_memo_optimism;
+pub use proof::{calculate_receipt_root_no_memo_optimism, calculate_receipt_root_optimism};
 
 pub mod validation;
 pub use validation::{canyon, isthmus, validate_block_post_execution};

--- a/op-reth/crates/consensus/src/proof.rs
+++ b/op-reth/crates/consensus/src/proof.rs
@@ -9,7 +9,7 @@ use reth_optimism_forks::OpHardforks;
 use reth_optimism_primitives::DepositReceipt;
 
 /// Calculates the receipt root for a header.
-pub(crate) fn calculate_receipt_root_optimism<R: DepositReceipt>(
+pub fn calculate_receipt_root_optimism<R: DepositReceipt>(
     receipts: &[ReceiptWithBloom<&R>],
     chain_spec: impl OpHardforks,
     timestamp: u64,


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Small PR to change `calculate_receipt_root_optimism` visibility so it can be used across other op stack's projects