### PR TITLE
op-supernode: Update Interop Activation Timestamp to Use Pointer

### DIFF
--- a/op-devstack/sysgo/l2_cl_supernode.go
+++ b/op-devstack/sysgo/l2_cl_supernode.go
@@ -219,8 +219,8 @@ type L2CLs struct {
 // SupernodeConfig holds configuration options for the shared supernode.
 type SupernodeConfig struct {
 	// InteropActivationTimestamp enables the interop activity at the given timestamp.
-	// Set to 0 to disable interop (default).
-	InteropActivationTimestamp uint64
+	// Set to nil to disable interop (default). Non-nil (including 0) enables interop.
+	InteropActivationTimestamp *uint64
 }
 
 // SupernodeOption is a functional option for configuring the supernode.
@@ -229,7 +229,8 @@ type SupernodeOption func(*SupernodeConfig)
 // WithSupernodeInterop enables the interop activity with the given activation timestamp.
 func WithSupernodeInterop(activationTimestamp uint64) SupernodeOption {
 	return func(cfg *SupernodeConfig) {
-		cfg.InteropActivationTimestamp = activationTimestamp
+		ts := activationTimestamp
+		cfg.InteropActivationTimestamp = &ts
 	}
 }
 
@@ -384,8 +385,8 @@ func withSharedSupernodeCLsImpl(orch *Orchestrator, supernodeID stack.SupernodeI
 		RPCConfig:                  oprpc.CLIConfig{ListenAddr: "127.0.0.1", ListenPort: 0, EnableAdmin: true},
 		InteropActivationTimestamp: snOpts.InteropActivationTimestamp,
 	}
-	if snOpts.InteropActivationTimestamp > 0 {
-		logger.Info("supernode interop enabled", "activation_timestamp", snOpts.InteropActivationTimestamp)
+	if snOpts.InteropActivationTimestamp != nil {
+		logger.Info("supernode interop enabled", "activation_timestamp", *snOpts.InteropActivationTimestamp)
 	}
 	ctx, cancel := context.WithCancel(p.Ctx())
 	exitFn := func(err error) { p.Require().NoError(err, "supernode critical error") }

--- a/op-supernode/cmd/main.go
+++ b/op-supernode/cmd/main.go
@@ -80,8 +80,12 @@ func main() {
 		}
 
 		// Populate config with interop activation timestamp from CLI context if set
+		// Only set the pointer if the flag is explicitly provided by the user
+		// If not set, leave as nil to disable interop
 		if cliCtx != nil && cliCtx.IsSet(interop.InteropActivationTimestampFlag.Name) {
-			cfg.InteropActivationTimestamp = cliCtx.Uint64(interop.InteropActivationTimestampFlag.Name)
+			ts := cliCtx.Uint64(interop.InteropActivationTimestampFlag.Name)
+			cfg.InteropActivationTimestamp = &ts
+			l.Info("interop activation timestamp set from CLI", "timestamp", ts)
 		}
 
 		// Create the supernode, supplying the logger, version, and close function

--- a/op-supernode/config/config.go
+++ b/op-supernode/config/config.go
@@ -22,7 +22,7 @@ type CLIConfig struct {
 	MetricsConfig              opmetrics.CLIConfig
 	PprofConfig                oppprof.CLIConfig
 	RawCtx                     *cli.Context
-	InteropActivationTimestamp uint64
+	InteropActivationTimestamp *uint64
 }
 
 func (c *CLIConfig) Check() error {

--- a/op-supernode/supernode/supernode.go
+++ b/op-supernode/supernode/supernode.go
@@ -92,9 +92,10 @@ func New(ctx context.Context, log gethlog.Logger, version string, requestStop co
 	}
 
 	log.Info("initializing interop activity? %v", cfg.RawCtx.IsSet(interop.InteropActivationTimestampFlag.Name))
-	// Initialize interop activity if the activation timestamp is set
-	if cfg.InteropActivationTimestamp > 0 {
-		interopActivity := interop.New(log.New("activity", "interop"), cfg.InteropActivationTimestamp, s.chains, cfg.DataDir)
+	// Initialize interop activity if the activation timestamp is set (non-nil)
+	// If it's nil, don't start interop. If it's non-nil (including 0), do start it.
+	if cfg.InteropActivationTimestamp != nil {
+		interopActivity := interop.New(log.New("activity", "interop"), *cfg.InteropActivationTimestamp, s.chains, cfg.DataDir)
 		s.activities = append(s.activities, interopActivity)
 		for _, chain := range s.chains {
 			chain.RegisterVerifier(interopActivity)


### PR DESCRIPTION
This allows the supernode to differentiate "interop active at genesis" from "interop not active at all" in the same way as is established in op-node/geth. 