### PR TITLE
chore: migrate docker images to oplabs GCP registry and fix prestate artifacts

### DIFF
--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -1054,7 +1054,7 @@ jobs:
           no_output_timeout: 60m
           command: |
             cd docker/fpvm-prestates
-            just "<<parameters.kind>>" "<<parameters.version>>" "../.."
+            just "<<parameters.kind>>" "<<parameters.version>>" "../../prestate-artifacts-<<parameters.kind>>"
       - run:
           name: Upload prestates to GCS
           working_directory: rust/kona

--- a/devnet-sdk/images/repository.go
+++ b/devnet-sdk/images/repository.go
@@ -9,7 +9,6 @@ type Repository struct {
 
 const (
 	opLabsToolsRegistry = "us-docker.pkg.dev/oplabs-tools-artifacts/images"
-	paradigmRegistry    = "ghcr.io/paradigmxyz"
 )
 
 // NewRepository creates a new Repository instance with predefined mappings
@@ -23,8 +22,7 @@ func NewRepository() *Repository {
 			"op-batcher":    opLabsToolsRegistry,
 			"op-proposer":   opLabsToolsRegistry,
 			"op-challenger": opLabsToolsRegistry,
-			// Paradigm images
-			"op-reth": paradigmRegistry,
+			"op-reth":       opLabsToolsRegistry,
 		},
 	}
 }

--- a/rust/docs/docs/pages/kona/node/install/docker.mdx
+++ b/rust/docs/docs/pages/kona/node/install/docker.mdx
@@ -19,21 +19,21 @@ Kona docker images are published with every release on GitHub Container Registry
 You can obtain the latest `kona-node` image with:
 
 ```bash
-docker pull ghcr.io/op-rs/kona/kona-node
+docker pull us-docker.pkg.dev/oplabs-tools-artifacts/images/kona-node
 ```
 
 <Callout type="note">
 Specify a specific version (e.g. v0.1.0) like so.
 
 ```bash
-docker pull ghcr.io/op-rs/kona/kona-node:v0.1.0
+docker pull us-docker.pkg.dev/oplabs-tools-artifacts/images/kona-node:v0.1.0
 ```
 </Callout>
 
 You can test the image with:
 
 ```bash
-docker run --rm ghcr.io/op-rs/kona/kona-node --version
+docker run --rm us-docker.pkg.dev/oplabs-tools-artifacts/images/kona-node --version
 ```
 
 If you can see the [latest release](https://github.com/ethereum-optimism/optimism/releases) version,

--- a/rust/docs/docs/pages/kona/node/run/docker.mdx
+++ b/rust/docs/docs/pages/kona/node/run/docker.mdx
@@ -50,8 +50,8 @@ For more detail into how Prometheus and Grafana work, head over to the
 
 The `docker-compose.yaml` uses published images from GitHub Container Registry:
 
-- **`op-reth`**: ghcr.io/paradigmxyz/op-reth:latest
-- **`kona-node`**: ghcr.io/op-rs/kona/kona-node:latest
+- **`op-reth`**: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-reth:develop
+- **`kona-node`**: us-docker.pkg.dev/oplabs-tools-artifacts/images/kona-node:develop
 
 ### Service Configuration
 

--- a/rust/docs/docs/pages/op-reth/run/opstack.mdx
+++ b/rust/docs/docs/pages/op-reth/run/opstack.mdx
@@ -108,7 +108,7 @@ Consider adding the `--l1.trustrpc` flag to improve performance, if the connecti
 [deposit-spec]: https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/deposits.md
 [derivation-spec]: https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/derivation.md
 [superchain-registry]: https://github.com/ethereum-optimism/superchain-registry
-[op-node-docker]: https://console.cloud.google.com/artifacts/docker/oplabs-tools-artifacts/us/images/op-node
+[op-node-docker]: https://console.cloud.google.com/artifacts/docker/us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node
 [reth]: https://github.com/paradigmxyz/reth
 [optimism]: https://github.com/ethereum-optimism/optimism
 [op-node]: https://github.com/ethereum-optimism/optimism/tree/develop/op-node

--- a/rust/kona/docker/README.md
+++ b/rust/kona/docker/README.md
@@ -56,12 +56,12 @@ Nightly Docker images are automatically built and published every day at 2 AM UT
 
 ```sh
 # Pull the latest nightly build (multi-platform: linux/amd64, linux/arm64)
-docker pull ghcr.io/op-rs/kona/kona-node:nightly
-docker pull ghcr.io/op-rs/kona/kona-host:nightly
-docker pull ghcr.io/op-rs/kona/kona-supervisor:nightly
+docker pull us-docker.pkg.dev/oplabs-tools-artifacts/images/kona-node:nightly
+docker pull us-docker.pkg.dev/oplabs-tools-artifacts/images/kona-host:nightly
+docker pull us-docker.pkg.dev/oplabs-tools-artifacts/images/kona-supervisor:nightly
 
 # Pull a specific date's nightly build
-docker pull ghcr.io/op-rs/kona/kona-node:nightly-2024-12-10
+docker pull us-docker.pkg.dev/oplabs-tools-artifacts/images/kona-node:nightly-2024-12-10
 ```
 
 ### Manual Trigger

--- a/rust/kona/docker/fpvm-prestates/justfile
+++ b/rust/kona/docker/fpvm-prestates/justfile
@@ -11,7 +11,11 @@ build-client-prestate-cannon-artifacts \
     out='./prestate-artifacts-cannon' \
     custom_config_dir='':
   #!/bin/bash
-  OUTPUT_DIR={{out}}
+  # Resolve output directory to an absolute path before changing directories
+  OUTPUT_DIR="{{out}}"
+  if [[ "$OUTPUT_DIR" != /* ]]; then
+    OUTPUT_DIR="$(pwd)/$OUTPUT_DIR"
+  fi
 
   # Docker bake env
   export CLIENT_BIN="{{kona_client_variant}}"

--- a/rust/kona/docker/recipes/kona-node-dev/op-reth/op-reth.dockerfile
+++ b/rust/kona/docker/recipes/kona-node-dev/op-reth/op-reth.dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/paradigmxyz/op-reth:nightly AS reth
+FROM us-docker.pkg.dev/oplabs-tools-artifacts/images/op-reth:nightly AS reth
 
 FROM ubuntu:latest
 

--- a/rust/kona/docker/recipes/kona-node-dev/publicnode.env
+++ b/rust/kona/docker/recipes/kona-node-dev/publicnode.env
@@ -18,7 +18,7 @@ KONA_NODE_METRICS_PORT=9002
 # (default: 5060)
 KONA_NODE_RPC_PORT=5060
 
-# (default: ghcr.io/op-rs/kona/kona-node:latest)
+# (default: us-docker.pkg.dev/oplabs-tools-artifacts/images/kona-node:develop)
 KONA_NODE_IMAGE=
 
 #################
@@ -34,7 +34,7 @@ OP_RETH_RPC_PORT=8545
 # (default: 8551)
 OP_RETH_ENGINE_PORT=8551
 
-# (default: ghcr.io/paradigmxyz/op-reth:latest)
+# (default: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-reth:develop)
 OP_RETH_IMAGE=
 
 #################

--- a/rust/kona/docker/recipes/kona-node/cfg.env
+++ b/rust/kona/docker/recipes/kona-node/cfg.env
@@ -18,7 +18,7 @@ KONA_NODE_METRICS_PORT=
 # (default: 5060)
 KONA_NODE_RPC_PORT=
 
-# (default: ghcr.io/op-rs/kona/kona-node:latest)
+# (default: us-docker.pkg.dev/oplabs-tools-artifacts/images/kona-node:develop)
 KONA_NODE_IMAGE=
 
 #################
@@ -34,7 +34,7 @@ OP_RETH_RPC_PORT=
 # (default: 8551)
 OP_RETH_ENGINE_PORT=
 
-# (default: ghcr.io/paradigmxyz/op-reth:latest)
+# (default: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-reth:develop)
 OP_RETH_IMAGE=
 
 #################

--- a/rust/kona/docker/recipes/kona-node/docker-compose.yaml
+++ b/rust/kona/docker/recipes/kona-node/docker-compose.yaml
@@ -33,7 +33,7 @@ services:
 
   op-reth:
     restart: unless-stopped
-    image: ${OP_RETH_NODE_IMAGE:-ghcr.io/paradigmxyz/op-reth:latest}
+    image: ${OP_RETH_NODE_IMAGE:-us-docker.pkg.dev/oplabs-tools-artifacts/images/op-reth:develop}
     depends_on:
       - prometheus
     ports:
@@ -58,7 +58,7 @@ services:
 
   kona-node:
     restart: unless-stopped
-    image: ${KONA_NODE_IMAGE:-ghcr.io/op-rs/kona/kona-node:latest}
+    image: ${KONA_NODE_IMAGE:-us-docker.pkg.dev/oplabs-tools-artifacts/images/kona-node:develop}
     depends_on:
       - prometheus
       - op-reth

--- a/rust/op-reth/Makefile
+++ b/rust/op-reth/Makefile
@@ -22,7 +22,7 @@ PROFILE ?= release
 CARGO_INSTALL_EXTRA_FLAGS ?=
 
 # The docker image name
-DOCKER_IMAGE_NAME ?= ghcr.io/paradigmxyz/op-reth
+DOCKER_IMAGE_NAME ?= us-docker.pkg.dev/oplabs-tools-artifacts/images/op-reth
 
 ##@ Help
 


### PR DESCRIPTION
## Summary
- Migrate all docker image references (kona-node, op-reth, kona-host, kona-supervisor) from `ghcr.io` (op-rs/kona, paradigmxyz) to the `oplabs-tools-artifacts` GCP registry
- Fix prestate build output directory in the justfile to resolve to an absolute path before changing directories
- Update CI to write prestate artifacts to a dedicated per-kind output directory

## Test plan
- [ ] Verify CI prestate builds produce artifacts in the correct output directory
- [ ] Verify docker-compose recipes pull from the new GCP registry
- [ ] Verify devnet-sdk uses the correct op-reth image source

🤖 Generated with [Claude Code](https://claude.com/claude-code)