### PR TITLE
ci: remove kona-client from cross-platform smoke test

### DIFF
--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -158,7 +158,6 @@ jobs:
           - op-rbuilder
           - kona-node
           - kona-host
-          - kona-client
           - op-reth
         runner:
           - ubuntu-24.04
@@ -168,7 +167,6 @@ jobs:
           - image_name: op-rbuilder
           - image_name: kona-node
           - image_name: kona-host
-          - image_name: kona-client
           - image_name: op-reth
     runs-on: ${{ matrix.runner }}
     env:
@@ -188,7 +186,6 @@ jobs:
           - op-rbuilder
           - kona-node
           - kona-host
-          - kona-client
           - op-reth
         runner:
           - ubuntu-24.04


### PR DESCRIPTION
## Summary

- Remove `kona-client` from the `check-cross-platform-rust` smoke test matrix
- `kona-client` is an FPVM guest program (`#![no_std]`, `#[client_entry]`) with no CLI argument handling, so `docker run $IMAGE --version` crashes with `OracleProviderError(Preimage(IOError(Closed)))`
- The image is still built and pushed; only the `--version` check is skipped

Fixes #19255