### PR TITLE
feat(op-node): execute NUT bundles at Karst fork activation

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -1874,6 +1874,19 @@ jobs:
           command: |
             make check-op-geth-version
 
+  check-nut-locks:
+    docker:
+      - image: <<pipeline.parameters.c-default_docker_image>>
+    resource_class: small
+    steps:
+      - utils/checkout-with-mise:
+          checkout-method: blobless
+          enable-mise-cache: true
+      - run:
+          name: check nut locks
+          command: |
+            make check-nut-locks
+
   go-tests:
     parameters:
       notify:
@@ -3066,6 +3079,9 @@ workflows:
           context:
             - circleci-repo-readonly-authenticated-github-token
       - check-op-geth-version:
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+      - check-nut-locks:
           context:
             - circleci-repo-readonly-authenticated-github-token
       - fuzz-golang:

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,10 @@ check-op-geth-version: ## Checks that op-geth version in go.mod is valid
 	go run ./ops/scripts/check-op-geth-version
 .PHONY: check-op-geth-version
 
+check-nut-locks: ## Checks that locked NUT bundles have not been modified
+	go run ./ops/scripts/check-nut-locks
+.PHONY: check-nut-locks
+
 golang-docker: ## Builds Docker images for Go components using buildx
 	# We don't use a buildx builder here, and just load directly into regular docker, for convenience.
 	GIT_COMMIT=$$(git rev-parse HEAD) \

--- a/op-core/nuts/fork_lock.toml
+++ b/op-core/nuts/fork_lock.toml
@@ -1,0 +1,6 @@
+# NUT Bundle Fork Lock
+# To update a locked bundle, update both the bundle file and this hash in the same PR.
+
+[karst]
+bundle = "op-node/rollup/derive/karst_nut_bundle.json"
+hash = "sha256:b9c610d09ca05ab24ef84ea38e4f563d71401f592f9eff13fa97dac879bee600"

--- a/op-node/rollup/derive/attributes.go
+++ b/op-node/rollup/derive/attributes.go
@@ -2,6 +2,7 @@ package derive
 
 import (
 	"context"
+	_ "embed"
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -9,10 +10,14 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
 
+	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum-optimism/optimism/op-core/predeploys"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
+
+//go:embed karst_nut_bundle.json
+var karstNUTBundleJSON []byte
 
 type DependencySet interface {
 	// Chains returns the number of chains in the dependency set
@@ -153,6 +158,20 @@ func (ba *FetchingAttributesBuilder) PreparePayloadAttributes(ctx context.Contex
 		upgradeTxs = append(upgradeTxs, jovian...)
 	}
 
+	// Starting with Karst, upgrade transactions are loaded from a NUT bundle and
+	// additional gas is allocated to the upgrade block so that upgrade transactions
+	// don't need to fit within the system tx gas limit.
+	var upgradeGas uint64
+	if ba.rollupCfg.IsKarstActivationBlock(nextL2Time) {
+		nutTxs, nutGas, err := UpgradeTransactionsFromNUTBundle(forks.Karst, karstNUTBundleJSON)
+		if err != nil {
+			return nil, NewCriticalError(fmt.Errorf("failed to build karst network upgrade txs: %w", err))
+		}
+		upgradeTxs = append(upgradeTxs, nutTxs...)
+		upgradeGas += nutGas
+	}
+
+	// TODO(#19239): migrate Interop to NUT bundle and add its gas to upgradeGas.
 	if ba.rollupCfg.IsInteropActivationBlock(nextL2Time) {
 		interop, err := InteropNetworkUpgradeTransactions()
 		if err != nil {
@@ -192,13 +211,15 @@ func (ba *FetchingAttributesBuilder) PreparePayloadAttributes(ctx context.Contex
 		}
 	}
 
+	gasLimit := sysConfig.GasLimit + upgradeGas
+
 	r := &eth.PayloadAttributes{
 		Timestamp:             hexutil.Uint64(nextL2Time),
 		PrevRandao:            eth.Bytes32(l1Info.MixDigest()),
 		SuggestedFeeRecipient: predeploys.SequencerFeeVaultAddr,
 		Transactions:          txs,
 		NoTxPool:              true,
-		GasLimit:              (*eth.Uint64Quantity)(&sysConfig.GasLimit),
+		GasLimit:              (*eth.Uint64Quantity)(&gasLimit),
 		Withdrawals:           withdrawals,
 		ParentBeaconBlockRoot: parentBeaconRoot,
 	}

--- a/op-node/rollup/derive/karst_nut_bundle.json
+++ b/op-node/rollup/derive/karst_nut_bundle.json
@@ -1,0 +1,6 @@
+{
+  "metadata": {
+    "version": "1.0.0"
+  },
+  "transactions": []
+}

--- a/op-node/rollup/derive/parse_upgrade_transactions.go
+++ b/op-node/rollup/derive/parse_upgrade_transactions.go
@@ -1,6 +1,7 @@
 package derive
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -47,6 +48,15 @@ func ReadNUTBundle(fork forks.Name, r io.Reader) (*NUTBundle, error) {
 	return &bundle, nil
 }
 
+// TotalGas returns the sum of gas limits across all transactions in the bundle.
+func (b *NUTBundle) TotalGas() uint64 {
+	var total uint64
+	for _, tx := range b.Transactions {
+		total += tx.GasLimit
+	}
+	return total
+}
+
 // ToDepositTransactions converts the bundle's transactions into serialized deposit transactions.
 func (b *NUTBundle) ToDepositTransactions() ([]hexutil.Bytes, error) {
 	txs := make([]hexutil.Bytes, 0, len(b.Transactions))
@@ -75,4 +85,20 @@ func (b *NUTBundle) ToDepositTransactions() ([]hexutil.Bytes, error) {
 		txs = append(txs, encoded)
 	}
 	return txs, nil
+}
+
+// UpgradeTransactionsFromNUTBundle parses an embedded NUT bundle JSON and returns
+// the deposit transactions along with the total gas required.
+func UpgradeTransactionsFromNUTBundle(fork forks.Name, bundleJSON []byte) ([]hexutil.Bytes, uint64, error) {
+	bundle, err := ReadNUTBundle(fork, bytes.NewReader(bundleJSON))
+	if err != nil {
+		return nil, 0, err
+	}
+
+	txs, err := bundle.ToDepositTransactions()
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return txs, bundle.TotalGas(), nil
 }

--- a/op-node/rollup/derive/parse_upgrade_transactions_test.go
+++ b/op-node/rollup/derive/parse_upgrade_transactions_test.go
@@ -99,6 +99,29 @@ func TestNUTBundleMissingIntent(t *testing.T) {
 	require.Contains(t, err.Error(), "missing intent")
 }
 
+func TestUpgradeTransactionsFromNUTBundle(t *testing.T) {
+	bundleJSON, err := os.ReadFile("testdata/test-nut.json")
+	require.NoError(t, err)
+
+	txs, totalGas, err := UpgradeTransactionsFromNUTBundle("Test", bundleJSON)
+	require.NoError(t, err)
+	require.Len(t, txs, 2)
+	require.Equal(t, uint64(1_000_000+5_000_000), totalGas)
+
+	// Verify gas matches sum of individual deposit tx gas limits
+	var sumGas uint64
+	for _, tx := range txs {
+		_, dep := toDepositTxn(t, tx)
+		sumGas += dep.Gas()
+	}
+	require.Equal(t, totalGas, sumGas)
+}
+
+func TestUpgradeTransactionsFromNUTBundleInvalidJSON(t *testing.T) {
+	_, _, err := UpgradeTransactionsFromNUTBundle("Test", []byte(`{invalid`))
+	require.Error(t, err)
+}
+
 // TestNUTBundleNullTo verifies that "to": null in JSON produces a contract creation (deploy) transaction.
 // Although NUTs are expected to use Arachnid's deterministic deployer, this sending to null
 // is how previous deployments have been handled and is useful to maintain going forward.

--- a/op-node/rollup/derive/testdata/test-nut.json
+++ b/op-node/rollup/derive/testdata/test-nut.json
@@ -1,21 +1,21 @@
 {
-  "metadata": {
-    "version": "1.0.0"
-  },
-  "transactions": [
-    {
-      "intent": "First Transaction",
-      "to": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-      "data": "0xabcdef",
-      "gasLimit": 1000000,
-      "from": "0x0000000000000000000000000000000000000000"
-    },
-    {
-      "intent": "Second Transaction",
-      "to": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-      "data": "0xabcdef",
-      "gasLimit": 5000000,
-      "from": "0x000000000000000000000000000000000000abba"
-    }
-  ]
+"metadata": {
+"version": "1.0.0"
+},
+"transactions": [
+{
+"intent": "First Transaction",
+"to": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+"data": "0xabcdef",
+"gasLimit": 1000000,
+"from": "0x0000000000000000000000000000000000000000"
+},
+{
+"intent": "Second Transaction",
+"to": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+"data": "0xabcdef",
+"gasLimit": 5000000,
+"from": "0x000000000000000000000000000000000000abba"
+}
+]
 }

--- a/op-node/rollup/sequencing/sequencer.go
+++ b/op-node/rollup/sequencing/sequencer.go
@@ -587,6 +587,12 @@ func (d *Sequencer) startBuildingBlock() {
 		d.log.Info("Sequencing Jovian upgrade block")
 	}
 
+	// For the Karst activation block we must not include any sequencer transactions.
+	if d.rollupCfg.IsKarstActivationBlock(uint64(attrs.Timestamp)) {
+		attrs.NoTxPool = true
+		d.log.Info("Sequencing Karst upgrade block")
+	}
+
 	// For the Interop activation block we must not include any sequencer transactions.
 	if d.rollupCfg.IsInteropActivationBlock(uint64(attrs.Timestamp)) {
 		attrs.NoTxPool = true

--- a/ops/scripts/check-nut-locks/main.go
+++ b/ops/scripts/check-nut-locks/main.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+
+	opservice "github.com/ethereum-optimism/optimism/op-service"
+)
+
+type forkLockEntry struct {
+	Bundle string `toml:"bundle"`
+	Hash   string `toml:"hash"`
+}
+
+func main() {
+	if err := run("."); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(dir string) error {
+	root, err := opservice.FindMonorepoRoot(dir)
+	if err != nil {
+		return fmt.Errorf("finding monorepo root: %w", err)
+	}
+
+	lockPath := filepath.Join(root, "op-core", "nuts", "fork_lock.toml")
+	var locks map[string]forkLockEntry
+	if _, err := toml.DecodeFile(lockPath, &locks); err != nil {
+		return fmt.Errorf("reading fork lock file: %w", err)
+	}
+
+	for fork, entry := range locks {
+		bundlePath := filepath.Join(root, entry.Bundle)
+		content, err := os.ReadFile(bundlePath)
+		if err != nil {
+			return fmt.Errorf("fork %s: reading bundle %s: %w", fork, entry.Bundle, err)
+		}
+
+		hash := sha256.Sum256(content)
+		actual := "sha256:" + hex.EncodeToString(hash[:])
+
+		locked := strings.TrimSpace(entry.Hash)
+		if actual != locked {
+			return fmt.Errorf(
+				"bundle hash mismatch for fork %s: locked=%s actual=%s. "+
+					"If this change is intentional, update the hash in op-core/nuts/fork_lock.toml",
+				fork, locked, actual,
+			)
+		}
+
+		fmt.Printf("fork %s: bundle hash OK\n", fork)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Add the Karst fork and wire NUT bundle execution into the derivation pipeline, with upgrade gas allocated to the block gas limit.
