### PR TITLE
circleci: add readonly-github-token ctx where checkout-with-mise is used

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -3230,7 +3230,9 @@ workflows:
             - kona-build-release
             - rust-build-op-rbuilder
             - rust-build-rollup-boost
-      - go-binaries-for-sysgo
+      - go-binaries-for-sysgo:
+          context:
+            - circleci-repo-readonly-authenticated-github-token
       # IN-MEMORY (all)
       - op-acceptance-tests:
           name: memory-all
@@ -3343,6 +3345,7 @@ workflows:
               ignore: /.*/
           context:
             - oplabs-gcr-release
+            - circleci-repo-readonly-authenticated-github-token
           requires:
             - initialize
             - contracts-bedrock-build
@@ -3560,6 +3563,8 @@ workflows:
             - cannon-prestate
             - rust-binaries-for-sysgo
       - op-acceptance-tests-flake-shake-report:
+          context:
+            - circleci-repo-readonly-authenticated-github-token
           requires:
             - op-acceptance-tests-flake-shake
       - op-acceptance-tests-flake-shake-promote:


### PR DESCRIPTION
# Purpose
Fix github rate limiting failures within circelci.

# Fix
The `mise install` step in the install-mise orb command calls the github api unauthenticated to fetch releases, unless  an env var `GITHUB_TOKEN` or `MISE_GITHUB_TOKEN` is set. Unauthenticated GitHub API requests are limited to 60/hr per IP. Authenticated requests have a 5k/hr rate limit. This pr adds the `circleci-repo-readonly-authenticated-github-token` context to jobs that end up calling `mise install` via the `checkout-with-mise` step, which provides `MISE_GITHUB_TOKEN`.