### PR TITLE
circleci: add go-binaries-for-sysgo as dep of go-tests-full

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -3126,6 +3126,7 @@ workflows:
           requires:
             - contracts-bedrock-build
             - cannon-prestate
+            - go-binaries-for-sysgo
           context:
             - circleci-repo-readonly-authenticated-github-token
             - slack


### PR DESCRIPTION
# Overview
Bug fix for `go-tests-full` post-merge ci job, which was failing ([example](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/116850/workflows/1036dbb7-9dfa-47d6-8b40-1293383c143f/jobs/4444683)) due to missing binary `op-program/bin/op-program`.

# Root cause
Commit 6af8caa8df split the old `cannon-prestate-quick` job into `cannon-prestate` + `go-binaries-for-sysgo`. The new `go-binaries-for-sysgo` job builds the op-program and cannon binaries needed by op-devstack sysgo tests. It was added as a dependency of `go-tests-short` (pr branches) but was missed for `go-tests-full` (develop branch only), so the bug slipped through ci.

# Fix
Added `go-binaries-for-sysgo` to the requires list of `go-tests-full`, matching what go-tests-short already has.   