### PR TITLE
ci: Switch auth used to publish kona prestates.

### DIFF
--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -1283,4 +1283,4 @@ workflows:
               version: ["kona-client", "kona-client-int"]
           context:
             - circleci-repo-readonly-authenticated-github-token
-            - oplabs-gcr
+            - oplabs-network-optimism-io-bucket

--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -1275,6 +1275,7 @@ workflows:
     when:
       or:
         - equal: ["develop", <<pipeline.git.branch>>]
+        - equal: ["webhook", << pipeline.trigger_source >>] # Only trigger on push to develop, not scheduled runs
     jobs:
       - kona-publish-prestate-artifacts:
           name: kona-publish-<<matrix.version>>


### PR DESCRIPTION
**Description**

Switch the scope used to publish kona prestates to the same as the one used for cannon. I _think_ that should have access to publish (the current one does not and the job is failing).