### PR TITLE
chore(contracts): add non-idempotent initializer review rules

### DIFF
--- a/docs/ai/contract-dev.md
+++ b/docs/ai/contract-dev.md
@@ -20,7 +20,7 @@ Proxied contracts in the OP Stack can be re-initialized during upgrades (via `re
 - Operations that depend on prior state (e.g., "add 10 to balance" vs "set balance to 10")
 
 
-### Other Reasons an Initializer my be Unsafe to Re-Run
+### Other Reasons an Initializer may be Unsafe to Re-Run
 
 - Emitting events that trigger off-chain actions (e.g., indexers that process each event exactly once)
 - Overwriting a variable that other contracts or off-chain systems already depend on (e.g., resetting a registry address that live contracts are pointing to, or changing a config value that should be immutable after first init)

--- a/docs/ai/contract-dev.md
+++ b/docs/ai/contract-dev.md
@@ -2,4 +2,36 @@
 
 This document provides guidance for AI agents working with smart contracts in the OP Stack.
 
-<!-- TODO: Add detailed guidance for contract development -->
+## Non-Idempotent Initializers
+
+When reviewing `initialize()` or `reinitializer` functions, check whether the function is **idempotent** — calling it multiple times with the same arguments should produce the same end state as calling it once.
+
+### The Risk
+
+Proxied contracts in the OP Stack can be re-initialized during upgrades (via `reinitializer(version)`). Orchestrators like `OPContractsManagerV2._apply()` call `initialize()` on contracts that may already hold state from a previous initialization. If the initializer is not idempotent, re-initialization can corrupt state.
+
+**Example**: `ETHLockbox.initialize()` calls `_authorizePortal()` for each portal passed in. Currently safe because `_authorizePortal()` is idempotent — setting `authorizedPortals[portal] = true` twice has the same effect as once. But if someone later added a portal count that increments on each authorization, re-initialization would double-count portals.
+
+### What Makes an Initializer Non-Idempotent or Unsafe to Re-Run
+
+- Incrementing counters or nonces
+- Appending to arrays (creates duplicates on re-init)
+- External calls with lasting side-effects (e.g., minting tokens, sending ETH)
+- Operations that depend on prior state (e.g., "add 10 to balance" vs "set balance to 10")
+- Emitting events that trigger off-chain actions (e.g., indexers that process each event exactly once)
+- Overwriting a variable that other contracts or off-chain systems already depend on (e.g., resetting a registry address that live contracts are pointing to, or changing a config value that should be immutable after first init)
+
+### Rule
+
+Non-idempotent or unsafe-to-rerun behavior in `initialize()` / `reinitializer` functions is **disallowed** unless the consequences are explicitly acknowledged in a `@notice` comment on the function. The comment must explain why the non-idempotent behavior is safe given how callers use the function.
+
+Without this comment, the code must not be approved.
+
+### Review Checklist
+
+When reviewing changes to `initialize()` or its callers:
+
+1. **Is every operation in this initializer idempotent?** Assigning a variable to a fixed value is idempotent. Incrementing, appending, or calling external contracts may not be.
+2. **Could overwriting any variable be unsafe?** Some values should only be set once — overwriting them during re-initialization could break other contracts or systems that depend on the original value.
+3. **Can this contract be re-initialized?** Check for `reinitializer` modifier. If it only uses `initializer` (one-shot), the risk does not apply.
+4. **If non-idempotent or unsafe behavior exists, is there a `@notice` comment acknowledging it?** The comment must explain why it's safe. If the comment is missing, flag it as a blocking issue.

--- a/docs/ai/contract-dev.md
+++ b/docs/ai/contract-dev.md
@@ -12,12 +12,16 @@ Proxied contracts in the OP Stack can be re-initialized during upgrades (via `re
 
 **Example**: `ETHLockbox.initialize()` calls `_authorizePortal()` for each portal passed in. Currently safe because `_authorizePortal()` is idempotent — setting `authorizedPortals[portal] = true` twice has the same effect as once. But if someone later added a portal count that increments on each authorization, re-initialization would double-count portals.
 
-### What Makes an Initializer Non-Idempotent or Unsafe to Re-Run
+### What Makes an Initializer Non-Idempotent
 
 - Incrementing counters or nonces
 - Appending to arrays (creates duplicates on re-init)
 - External calls with lasting side-effects (e.g., minting tokens, sending ETH)
 - Operations that depend on prior state (e.g., "add 10 to balance" vs "set balance to 10")
+
+
+### Other Reasons an Initializer my be Unsafe to Re-Run
+
 - Emitting events that trigger off-chain actions (e.g., indexers that process each event exactly once)
 - Overwriting a variable that other contracts or off-chain systems already depend on (e.g., resetting a registry address that live contracts are pointing to, or changing a config value that should be immutable after first init)
 

--- a/ops/ai-eng/graphite/rules.md
+++ b/ops/ai-eng/graphite/rules.md
@@ -76,6 +76,28 @@ If the PR changes the Foundry dependency versions, i.e the `forge`, `cast`, and 
 >
 > For more information on the Foundry version upgrade process, please see the [Foundry version upgrade policy](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/book/src/policies/foundry-upgrades.md).
 
+### Non-Idempotent Initializers
+
+When reviewing changes to `initialize()` or `reinitializer` functions, check whether the function is **idempotent** — calling it multiple times with the same arguments should produce the same end state as calling it once. Proxied contracts can be re-initialized during upgrades, so non-idempotent initializers risk corrupting state.
+
+**When to flag:**
+- An `initialize()` function increments counters, appends to arrays, or performs any operation where repeating it changes the outcome
+- An `initialize()` function makes external calls with lasting side-effects (minting, transferring, authorizing in ways that aren't simple overwrites)
+- An `initialize()` function overwrites a variable that other contracts or off-chain systems may already depend on
+- A change to an existing `initialize()` function introduces non-idempotent or unsafe-to-rerun behavior that wasn't there before
+
+Non-idempotent or unsafe-to-rerun behavior in initializers is **disallowed** unless explicitly acknowledged with a `@notice` comment explaining why it's safe. If you detect non-idempotent behavior without such a comment, you MUST leave a blocking comment:
+
+> **Non-Idempotent Initializer — Acknowledgment Required**
+>
+> This `initialize()` function contains operations that are not idempotent (not safe to call multiple times with the same arguments). Since proxied contracts can be re-initialized during upgrades, this is disallowed unless explicitly acknowledged.
+>
+> Please either:
+> 1. Make the operation idempotent, or
+> 2. Add a `@notice` comment on the function explaining why the non-idempotent behavior is safe given how callers use it
+>
+> See `docs/ai/contract-dev.md` for detailed guidance.
+
 ### Storage Layout Mutation Warnings
 
 If a PR modifies files in `packages/contracts-bedrock/snapshots/storageLayout/`, you MUST analyze the diff to determine if storage slots are being **mutated** (as opposed to purely added or deleted along with the contract).


### PR DESCRIPTION
## Summary

- Populates the empty `docs/ai/contract-dev.md` with a "Non-Idempotent Initializers" review guideline for AI agents
- Adds a matching rule to the Graphite/Diamond code review rules (`ops/ai-eng/graphite/rules.md`)

Addresses audit finding #20: potential footgun when re-initializing `ETHLockbox` with only its own `OptimismPortal`. The triage decision was to add review rules (not contract code changes) to catch this class of issue — `initialize()` functions that are not safe to re-run because they increment counters, append to arrays, make non-idempotent external calls, or overwrite variables that other systems depend on.

## Test plan

- [x] Verify `docs/ai/contract-dev.md` replaces the TODO with actionable review guidance
- [x] Verify `ops/ai-eng/graphite/rules.md` includes the new rule section with warning template
- [ ] Confirm Diamond picks up the new rule on future PRs touching `initialize()` functions

🤖 Generated with [Claude Code](https://claude.com/claude-code)