### PR TITLE
ci: fix rust incremental compilation ICE in CI

### DIFF
--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -117,7 +117,7 @@ commands:
       version:
         description: "Version of the cache"
         type: string
-        default: "15"
+        default: "16"
       profile:
         description: "Profile to restore the cache for"
         type: string


### PR DESCRIPTION
Summary

- Bump the Rust CI build cache version from 15 to 16 to invalidate stale incremental compilation artifacts that are causing an internal compiler error (ICE) (https://github.com/rust-lang/rust/issues/84970)

Test plan

- Verify the failing CI job (example-exex-hello-world build) passes on a clean cache
- Confirm other Rust CI jobs (clippy, tests, etc.) are unaffected