### PR TITLE
exp: require OPTIMISM_PORTAL_INTEROP for migrate (Finding 21)

### DIFF
--- a/packages/contracts-bedrock/interfaces/L1/opcm/IOPContractsManagerMigrator.sol
+++ b/packages/contracts-bedrock/interfaces/L1/opcm/IOPContractsManagerMigrator.sol
@@ -28,6 +28,9 @@ interface IOPContractsManagerMigrator {
     /// @notice Thrown when the starting respected game type is not a valid super game type.
     error OPContractsManagerMigrator_InvalidStartingRespectedGameType();
 
+    /// @notice Thrown when the OPTIMISM_PORTAL_INTEROP dev feature is not enabled.
+    error OPContractsManagerMigrator_InteropNotEnabled();
+
     /// @notice Returns the container of blueprint and implementation contract addresses.
     function contractsContainer() external view returns (IOPContractsManagerContainer);
 

--- a/packages/contracts-bedrock/snapshots/abi/OPContractsManagerMigrator.json
+++ b/packages/contracts-bedrock/snapshots/abi/OPContractsManagerMigrator.json
@@ -107,6 +107,11 @@
   },
   {
     "inputs": [],
+    "name": "OPContractsManagerMigrator_InteropNotEnabled",
+    "type": "error"
+  },
+  {
+    "inputs": [],
     "name": "OPContractsManagerMigrator_InvalidStartingRespectedGameType",
     "type": "error"
   },

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerMigrator.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerMigrator.sol
@@ -7,6 +7,7 @@ import { OPContractsManagerUtilsCaller } from "src/L1/opcm/OPContractsManagerUti
 // Libraries
 import { GameTypes } from "src/dispute/lib/Types.sol";
 import { Constants } from "src/libraries/Constants.sol";
+import { DevFeatures } from "src/libraries/DevFeatures.sol";
 import { Features } from "src/libraries/Features.sol";
 
 // Interfaces
@@ -46,6 +47,9 @@ contract OPContractsManagerMigrator is OPContractsManagerUtilsCaller {
     /// @notice Thrown when the starting respected game type is not a valid super game type.
     error OPContractsManagerMigrator_InvalidStartingRespectedGameType();
 
+    /// @notice Thrown when the OPTIMISM_PORTAL_INTEROP dev feature is not enabled.
+    error OPContractsManagerMigrator_InteropNotEnabled();
+
     /// @param _utils The utility functions for the OPContractsManager.
     constructor(IOPContractsManagerUtils _utils) OPContractsManagerUtilsCaller(_utils) { }
 
@@ -65,6 +69,12 @@ contract OPContractsManagerMigrator is OPContractsManagerUtilsCaller {
     ///      look or function like all of the other functions in OPCMv2.
     /// @param _input The input parameters for the migration.
     function migrate(MigrateInput calldata _input) public {
+        // Migration is only meaningful in an interop context. Revert if the OPTIMISM_PORTAL_INTEROP
+        // dev feature is not enabled to prevent misconfiguration.
+        if (!contractsContainer().isDevFeatureEnabled(DevFeatures.OPTIMISM_PORTAL_INTEROP)) {
+            revert OPContractsManagerMigrator_InteropNotEnabled();
+        }
+
         // Check that the starting respected game type is a valid super game type.
         if (
             _input.startingRespectedGameType.raw() != GameTypes.SUPER_CANNON.raw()

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
@@ -26,6 +26,7 @@ import { ISemver } from "interfaces/universal/ISemver.sol";
 import { IOPContractsManagerStandardValidator } from "interfaces/L1/IOPContractsManagerStandardValidator.sol";
 import { IOPContractsManagerV2 } from "interfaces/L1/opcm/IOPContractsManagerV2.sol";
 import { IOPContractsManagerUtils } from "interfaces/L1/opcm/IOPContractsManagerUtils.sol";
+import { IOPContractsManagerContainer } from "interfaces/L1/opcm/IOPContractsManagerContainer.sol";
 import { IOPContractsManagerMigrator } from "interfaces/L1/opcm/IOPContractsManagerMigrator.sol";
 import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
 import { IOptimismPortalInterop } from "interfaces/L1/IOptimismPortalInterop.sol";
@@ -1521,6 +1522,22 @@ contract OPContractsManagerV2_Migrate_Test is OPContractsManagerV2_TestInit {
         _doMigration(
             input, IOPContractsManagerMigrator.OPContractsManagerMigrator_InvalidStartingRespectedGameType.selector
         );
+    }
+
+    /// @notice Tests that the migration function reverts when the OPTIMISM_PORTAL_INTEROP dev
+    ///         feature is not enabled.
+    function test_migrate_interopNotEnabled_reverts() public {
+        IOPContractsManagerMigrator.MigrateInput memory input = _getDefaultMigrateInput();
+
+        // Mock the container to report interop as disabled.
+        vm.mockCall(
+            address(opcmV2.contractsContainer()),
+            abi.encodeCall(IOPContractsManagerContainer.isDevFeatureEnabled, (DevFeatures.OPTIMISM_PORTAL_INTEROP)),
+            abi.encode(false)
+        );
+
+        // Execute the migration, expect revert.
+        _doMigration(input, IOPContractsManagerMigrator.OPContractsManagerMigrator_InteropNotEnabled.selector);
     }
 }
 


### PR DESCRIPTION
## Summary

- Adds a revert at the top of `OPContractsManagerMigrator.migrate()` if the `OPTIMISM_PORTAL_INTEROP` dev feature is not enabled
- Migration is only meaningful in an interop context; allowing it without interop enabled is a misconfiguration risk
- Addresses audit finding 21 from the Feb 2026 audit

## What Changed

| File | Change |
|------|--------|
| `src/L1/opcm/OPContractsManagerMigrator.sol` | Added `DevFeatures` import, `InteropNotEnabled` error, interop check at top of `migrate()` |
| `interfaces/L1/opcm/IOPContractsManagerMigrator.sol` | Added `InteropNotEnabled` error to interface |
| `test/L1/opcm/OPContractsManagerV2.t.sol` | Added `test_migrate_interopNotEnabled_reverts` test using `vm.mockCall` to simulate disabled interop |
| `snapshots/abi/OPContractsManagerMigrator.json` | Auto-regenerated ABI snapshot |

## Decisions Made

1. **Error naming**: Used `OPContractsManagerMigrator_InteropNotEnabled` following the `ContractName_Description` pattern from the codebase
2. **Check placement**: Added at the very top of `migrate()` before any other validation, since there is no point validating inputs if interop is not enabled
3. **Test approach**: Used `vm.mockCall` on the container's `isDevFeatureEnabled` to simulate disabled interop within the existing test class (which requires interop enabled for setUp). This avoids needing a separate test contract
4. **No version bump needed**: `OPContractsManagerMigrator` does not implement `ISemver` and has no `version()` function. The `just pr` semver-diff check passed without changes

## Complexity Report

**Difficulty: Low.** This was a straightforward change.

- 4 files touched, 35 lines added
- No Go code changes needed: the `op-deployer` and `op-devstack` code that calls `migrate()` already operates in an interop-enabled context (the dev feature bitmap is set during deployment)
- No `op-e2e` changes needed: the Go bindings are auto-generated and the function signature is unchanged (only a new revert condition)
- No version bump needed: the Migrator contract has no `ISemver` interface
- `just pr` passed all 17 checks on first try
- All 5 migrate tests pass with interop enabled; tests correctly skip when interop is disabled

## Side Effects

- ABI snapshot updated (new error in ABI)
- No storage layout changes
- No semver-lock changes

## Test plan

- [x] `just build-dev` passes
- [x] `just test-dev` -- migrate tests pass with `DEV_FEATURE__OPCM_V2=true DEV_FEATURE__OPTIMISM_PORTAL_INTEROP=true`
- [x] Migrate tests skip correctly when interop is disabled
- [x] `just pr` passes all 17 checks
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)