### PR TITLE
op-node: Drop Unsafe Payloads Denied by Superauthority

### DIFF
--- a/op-node/rollup/engine/payload_process.go
+++ b/op-node/rollup/engine/payload_process.go
@@ -39,11 +39,19 @@ func (e *EngineController) onPayloadProcess(ctx context.Context, ev PayloadProce
 				"err", err,
 			)
 		} else if denied {
-			e.log.Warn("Payload denied by SuperAuthority",
-				"blockNumber", payload.BlockNumber,
-				"blockHash", payload.BlockHash,
-			)
-			e.emitDepositsOnlyPayloadAttributesRequest(ctx, ev.Ref.ParentID(), ev.DerivedFrom)
+			if ev.DerivedFrom != (eth.L1BlockRef{}) {
+				e.log.Warn("Requesting deposits-only replacement for derived payload",
+					"blockNumber", payload.BlockNumber,
+					"blockHash", payload.BlockHash,
+					"derivedFrom", ev.DerivedFrom,
+				)
+				e.emitDepositsOnlyPayloadAttributesRequest(ctx, ev.Ref.ParentID(), ev.DerivedFrom)
+			} else {
+				e.log.Warn("Unsafe payload denied by SuperAuthority, dropping",
+					"blockNumber", payload.BlockNumber,
+					"blockHash", payload.BlockHash,
+				)
+			}
 			return
 		}
 	}

--- a/op-node/rollup/engine/super_authority_deny_test.go
+++ b/op-node/rollup/engine/super_authority_deny_test.go
@@ -26,15 +26,27 @@ type superAuthorityTestCase struct {
 func TestSuperAuthority(t *testing.T) {
 	tests := []superAuthorityTestCase{
 		{
-			name: "DeniedPayload_EmitsDepositsOnlyRequest",
+			name: "DeniedPayload_Safe_EmitsDepositsOnlyRequest",
 			setup: func(payload *eth.ExecutionPayloadEnvelope) (*testutils.MockEngine, rollup.SuperAuthority, eth.L1BlockRef) {
 				sa := newMockSuperAuthority()
 				sa.denyBlock(uint64(payload.ExecutionPayload.BlockNumber), payload.ExecutionPayload.BlockHash)
-				// Need DerivedFrom for Holocene path
+				// Safe payloads have a non-zero DerivedFrom
 				return nil, sa, eth.L1BlockRef{Number: 1}
 			},
 			expectations: func(emitter *testutils.MockEmitter, engine *testutils.MockEngine, payload *eth.ExecutionPayloadEnvelope) {
 				emitter.ExpectOnceType("DepositsOnlyPayloadAttributesRequestEvent")
+			},
+		},
+		{
+			name: "DeniedPayload_Unsafe_DropsPayload",
+			setup: func(payload *eth.ExecutionPayloadEnvelope) (*testutils.MockEngine, rollup.SuperAuthority, eth.L1BlockRef) {
+				sa := newMockSuperAuthority()
+				sa.denyBlock(uint64(payload.ExecutionPayload.BlockNumber), payload.ExecutionPayload.BlockHash)
+				// Unsafe payloads have zero DerivedFrom - should NOT emit DepositsOnlyRequest
+				return nil, sa, eth.L1BlockRef{}
+			},
+			expectations: func(emitter *testutils.MockEmitter, engine *testutils.MockEngine, payload *eth.ExecutionPayloadEnvelope) {
+				// No events expected - unsafe denied payloads are silently dropped
 			},
 		},
 		{


### PR DESCRIPTION
# What
When a payload is denied by the Superauthority, but has no `DerivedFrom` value, it is simply dropped.

# Why
Denial of payloads from Superauthority is meant to indicate post-derived (ie "LocalSafe") payloads should not be applied due to higher-order concerns from Verification Activities like Interop.

In extreme circumstances (ie testing), it is possible to identify a Local Safe payload as Invalid while it is still being gossiped around the network as an unsafe block. When the block is caught by the Superauthority, we can't make a replacement from it because it has no `DerivedFrom`.

## Why is Dropping Safe
Dropping is safe because in order to reach the `Denylist` in the Chain Container, the payload must have already been made Local Safe (ie published to L1), and then identified as Invalid. That means:
- This block "is Local Safe" even if we're being told about it in an unsafe context. But more importantly...
- This block is **NOT** actually Safe. If we saw this in the derived chain, we would remove it.

So, the solution used here is to await the correct payloads, and simply not apply Unsafe Payloads which we know wouldn't be valid.

# Testing

(Unit testing increased to show the difference in behavior when the L1 value is supplied.)

Tested using `TestInteropFaultProofs_InvalidBlock`. The test changes behavior with this commit:
- Without Commit: `Critical` error of replacement without Derived From
- With Commit: 3 instances of "dropping" the unsafe payload

The test STILL FAILS, and I am not sure why. But this at least corrects the behavior.

@ajsutton had other suggestions for how to solve this issue, which I will speak to him about additionally.