### PR TITLE
feat(op-deployer): add configurable tx prepare retry interval

### DIFF
--- a/op-deployer/pkg/deployer/apply.go
+++ b/op-deployer/pkg/deployer/apply.go
@@ -38,15 +38,17 @@ import (
 )
 
 type ApplyConfig struct {
-	L1RPCUrl         string
-	Workdir          string
-	PrivateKey       string
-	DeploymentTarget DeploymentTarget
-	Logger           log.Logger
-	CacheDir         string
-	privateKeyECDSA  *ecdsa.PrivateKey
-	PreStateBuilder  pipeline.PreStateBuilder
-	UseForge         bool
+	L1RPCUrl               string
+	Workdir                string
+	PrivateKey             string
+	DeploymentTarget       DeploymentTarget
+	Logger                 log.Logger
+	CacheDir               string
+	privateKeyECDSA        *ecdsa.PrivateKey
+	PreStateBuilder        pipeline.PreStateBuilder
+	UseForge               bool
+	TxPrepareRetryInterval time.Duration
+	TxPrepareMaxAttempts   int
 }
 
 func (a *ApplyConfig) Check() error {
@@ -110,14 +112,16 @@ func ApplyCLI() func(cliCtx *cli.Context) error {
 		ctx := ctxinterrupt.WithCancelOnInterrupt(cliCtx.Context)
 
 		if err := Apply(ctx, ApplyConfig{
-			L1RPCUrl:         l1RPCUrl,
-			Workdir:          workdir,
-			PrivateKey:       privateKey,
-			DeploymentTarget: depTarget,
-			Logger:           l,
-			CacheDir:         cacheDir,
-			PreStateBuilder:  preStateBuilder,
-			UseForge:         cliCtx.Bool(UseForgeFlagName),
+			L1RPCUrl:               l1RPCUrl,
+			Workdir:                workdir,
+			PrivateKey:             privateKey,
+			DeploymentTarget:       depTarget,
+			Logger:                 l,
+			CacheDir:               cacheDir,
+			PreStateBuilder:        preStateBuilder,
+			UseForge:               cliCtx.Bool(UseForgeFlagName),
+			TxPrepareRetryInterval: cliCtx.Duration(TxPrepareRetryIntervalFlagName),
+			TxPrepareMaxAttempts:   cliCtx.Int(TxPrepareMaxAttemptsFlagName),
 		}); err != nil {
 			return err
 		}
@@ -256,18 +260,20 @@ func Apply(ctx context.Context, cfg ApplyConfig) error {
 	}
 
 	if err := ApplyPipeline(ctx, ApplyPipelineOpts{
-		L1RPCUrl:           cfg.L1RPCUrl,
-		DeploymentTarget:   cfg.DeploymentTarget,
-		DeployerPrivateKey: cfg.privateKeyECDSA,
-		Intent:             intent,
-		State:              st,
-		Logger:             cfg.Logger,
-		StateWriter:        pipeline.WorkdirStateWriter(cfg.Workdir),
-		CacheDir:           cfg.CacheDir,
-		PreStateBuilder:    cfg.PreStateBuilder,
-		UseForge:           cfg.UseForge,
-		PrivateKey:         cfg.PrivateKey,
-		Workdir:            cfg.Workdir,
+		L1RPCUrl:               cfg.L1RPCUrl,
+		DeploymentTarget:       cfg.DeploymentTarget,
+		DeployerPrivateKey:     cfg.privateKeyECDSA,
+		Intent:                 intent,
+		State:                  st,
+		Logger:                 cfg.Logger,
+		StateWriter:            pipeline.WorkdirStateWriter(cfg.Workdir),
+		CacheDir:               cfg.CacheDir,
+		PreStateBuilder:        cfg.PreStateBuilder,
+		UseForge:               cfg.UseForge,
+		PrivateKey:             cfg.PrivateKey,
+		Workdir:                cfg.Workdir,
+		TxPrepareRetryInterval: cfg.TxPrepareRetryInterval,
+		TxPrepareMaxAttempts:   cfg.TxPrepareMaxAttempts,
 	}); err != nil {
 		return err
 	}
@@ -281,18 +287,20 @@ type pipelineStage struct {
 }
 
 type ApplyPipelineOpts struct {
-	L1RPCUrl           string
-	DeploymentTarget   DeploymentTarget
-	DeployerPrivateKey *ecdsa.PrivateKey
-	Intent             *state.Intent
-	State              *state.State
-	Logger             log.Logger
-	StateWriter        pipeline.StateWriter
-	CacheDir           string
-	PreStateBuilder    pipeline.PreStateBuilder
-	UseForge           bool
-	PrivateKey         string
-	Workdir            string
+	L1RPCUrl               string
+	DeploymentTarget       DeploymentTarget
+	DeployerPrivateKey     *ecdsa.PrivateKey
+	Intent                 *state.Intent
+	State                  *state.State
+	Logger                 log.Logger
+	StateWriter            pipeline.StateWriter
+	CacheDir               string
+	PreStateBuilder        pipeline.PreStateBuilder
+	UseForge               bool
+	PrivateKey             string
+	Workdir                string
+	TxPrepareRetryInterval time.Duration
+	TxPrepareMaxAttempts   int
 }
 
 func ApplyPipeline(
@@ -385,11 +393,13 @@ func ApplyPipeline(
 		signer := opcrypto.SignerFnFromBind(opcrypto.PrivateKeySignerFn(opts.DeployerPrivateKey, chainID))
 
 		bcaster, err = broadcaster.NewKeyedBroadcaster(broadcaster.KeyedBroadcasterOpts{
-			Logger:  opts.Logger,
-			ChainID: new(big.Int).SetUint64(intent.L1ChainID),
-			Client:  l1Client,
-			Signer:  signer,
-			From:    deployer,
+			Logger:                 opts.Logger,
+			ChainID:                new(big.Int).SetUint64(intent.L1ChainID),
+			Client:                 l1Client,
+			Signer:                 signer,
+			From:                   deployer,
+			TxPrepareRetryInterval: opts.TxPrepareRetryInterval,
+			TxPrepareMaxAttempts:   opts.TxPrepareMaxAttempts,
 		})
 		if err != nil {
 			return fmt.Errorf("failed to create broadcaster: %w", err)

--- a/op-deployer/pkg/deployer/broadcaster/keyed.go
+++ b/op-deployer/pkg/deployer/broadcaster/keyed.go
@@ -35,11 +35,13 @@ type KeyedBroadcaster struct {
 }
 
 type KeyedBroadcasterOpts struct {
-	Logger  log.Logger
-	ChainID *big.Int
-	Client  *ethclient.Client
-	Signer  opcrypto.SignerFn
-	From    common.Address
+	Logger                 log.Logger
+	ChainID                *big.Int
+	Client                 *ethclient.Client
+	Signer                 opcrypto.SignerFn
+	From                   common.Address
+	TxPrepareRetryInterval time.Duration // 0 means default (2s)
+	TxPrepareMaxAttempts   int           // 0 means default (30)
 }
 
 func NewKeyedBroadcaster(cfg KeyedBroadcasterOpts) (*KeyedBroadcaster, error) {
@@ -55,6 +57,8 @@ func NewKeyedBroadcaster(cfg KeyedBroadcasterOpts) (*KeyedBroadcaster, error) {
 		Signer:                    cfg.Signer,
 		From:                      cfg.From,
 		GasPriceEstimatorFn:       DeployerGasPriceEstimator,
+		TxPrepareRetryInterval:    cfg.TxPrepareRetryInterval,
+		TxPrepareMaxAttempts:      cfg.TxPrepareMaxAttempts,
 	}
 
 	minTipCap, err := eth.GweiToWei(1.0)

--- a/op-deployer/pkg/deployer/flags.go
+++ b/op-deployer/pkg/deployer/flags.go
@@ -2,6 +2,7 @@ package deployer
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/artifacts"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/flags"
@@ -29,7 +30,9 @@ const (
 	ContractNameFlagName     = flags.ContractNameFlagName
 	VerifierTypeFlagName     = flags.VerifierTypeFlagName
 	VerifierUrlFlagName      = flags.VerifierUrlFlagName
-	UseForgeFlagName         = flags.UseForgeFlagName
+	UseForgeFlagName                = flags.UseForgeFlagName
+	TxPrepareRetryIntervalFlagName  = flags.TxPrepareRetryIntervalFlagName
+	TxPrepareMaxAttemptsFlagName    = flags.TxPrepareMaxAttemptsFlagName
 )
 
 var (
@@ -141,6 +144,18 @@ var (
 		EnvVars: PrefixEnvVar("USE_FORGE"),
 		Value:   false,
 	}
+	TxPrepareRetryIntervalFlag = &cli.DurationFlag{
+		Name:    TxPrepareRetryIntervalFlagName,
+		Usage:   "Interval between retries when transaction preparation fails (e.g. gas estimation). Lower values speed up deployment on local chains.",
+		EnvVars: PrefixEnvVar("TX_PREPARE_RETRY_INTERVAL"),
+		Value:   2 * time.Second,
+	}
+	TxPrepareMaxAttemptsFlag = &cli.IntFlag{
+		Name:    TxPrepareMaxAttemptsFlagName,
+		Usage:   "Maximum number of attempts when preparing transactions.",
+		EnvVars: PrefixEnvVar("TX_PREPARE_MAX_ATTEMPTS"),
+		Value:   30,
+	}
 	ValidateFlag = &cli.StringFlag{
 		Name:    "validate",
 		Usage:   "automatically validate deployment after apply. Specify validator version (e.g., v2.0.0) or 'auto' to auto-detect from state.json. If not specified, validation is skipped.",
@@ -169,6 +184,8 @@ var ApplyFlags = []cli.Flag{
 	VerifierFlag,
 	VerifierUrlFlag,
 	UseForgeFlag,
+	TxPrepareRetryIntervalFlag,
+	TxPrepareMaxAttemptsFlag,
 	ValidateFlag,
 }
 

--- a/op-deployer/pkg/deployer/flags/names.go
+++ b/op-deployer/pkg/deployer/flags/names.go
@@ -23,7 +23,9 @@ const (
 	ContractNameFlagName     = "contract-name"
 	VerifierTypeFlagName     = "verifier"
 	VerifierUrlFlagName      = "verifier-url"
-	UseForgeFlagName         = "use-forge"
+	UseForgeFlagName                = "use-forge"
+	TxPrepareRetryIntervalFlagName  = "tx-prepare-retry-interval"
+	TxPrepareMaxAttemptsFlagName    = "tx-prepare-max-attempts"
 )
 
 func DefaultCacheDir() string {

--- a/op-service/txmgr/cli.go
+++ b/op-service/txmgr/cli.go
@@ -640,6 +640,15 @@ type Config struct {
 	// gapped nonce error in the blob pool).
 	RetryInterval time.Duration
 
+	// TxPrepareRetryInterval is the interval between retries when preparing
+	// (crafting) a transaction fails, e.g. due to gas estimation failures.
+	// Defaults to 2 seconds if zero.
+	TxPrepareRetryInterval time.Duration
+
+	// TxPrepareMaxAttempts is the maximum number of attempts when preparing
+	// (crafting) a transaction. Defaults to 30 if zero.
+	TxPrepareMaxAttempts int
+
 	// MaxRetries is the maximum number of times to retry sending a
 	// transaction. This is used to limit the number of times we retry
 	// sending a transaction if it fails with a non-fatal error (e.g. the

--- a/op-service/txmgr/txmgr.go
+++ b/op-service/txmgr/txmgr.go
@@ -381,7 +381,15 @@ func (m *SimpleTxManager) SendAsync(ctx context.Context, candidate TxCandidate, 
 
 // prepare prepares the transaction for sending.
 func (m *SimpleTxManager) prepare(ctx context.Context, candidate TxCandidate) (*types.Transaction, error) {
-	tx, err := retry.Do(ctx, 30, retry.Fixed(2*time.Second), func() (*types.Transaction, error) {
+	prepareInterval := m.cfg.TxPrepareRetryInterval
+	if prepareInterval == 0 {
+		prepareInterval = 2 * time.Second
+	}
+	prepareMaxAttempts := m.cfg.TxPrepareMaxAttempts
+	if prepareMaxAttempts == 0 {
+		prepareMaxAttempts = 30
+	}
+	tx, err := retry.Do(ctx, prepareMaxAttempts, retry.Fixed(prepareInterval), func() (*types.Transaction, error) {
 		if m.closed.Load() {
 			return nil, ErrClosed
 		}


### PR DESCRIPTION
## Summary

- Add `--tx-prepare-retry-interval` and `--tx-prepare-max-attempts` CLI flags to `op-deployer apply`
- Thread these through `ApplyConfig` → `ApplyPipelineOpts` → `KeyedBroadcasterOpts` → `txmgr.Config`
- In `txmgr.SimpleTxManager.prepare()`, use config values instead of hardcoded `2s` / `30` attempts (defaults preserved when zero)
- On local Anvil chains, using `100ms` interval cuts the apply phase from ~25s to ~11s by avoiding wasted retries in `craftTx()`

## Test plan

- [x] `go build ./op-service/txmgr/... ./op-deployer/...` compiles
- [x] `go test ./op-service/txmgr/...` passes
- [x] `go test ./op-deployer/pkg/deployer/...` passes
- [x] `go test ./op-deployer/pkg/deployer/broadcaster/...` passes
- [ ] Integration test with kupcake passing `--tx-prepare-retry-interval 100ms --tx-prepare-max-attempts 100`

🤖 Generated with [Claude Code](https://claude.com/claude-code)