### PR TITLE
op-supernode: prevent hang on shutdown

### DIFF
--- a/op-devstack/sysgo/l2_cl_supernode.go
+++ b/op-devstack/sysgo/l2_cl_supernode.go
@@ -109,10 +109,8 @@ func (n *SuperNode) Start() {
 	n.sn = sn
 	n.cancel = cancel
 
-	// Start Supernode in background
-	go func() {
-		_ = n.sn.Start(ctx)
-	}()
+	err = n.sn.Start(ctx)
+	n.p.Require().NoError(err)
 
 	// Wait for the RPC addr and save userRPC/interop endpoints
 	if addr, err := n.sn.WaitRPCAddr(ctx); err == nil {

--- a/op-supernode/supernode/resources/metrics_service.go
+++ b/op-supernode/supernode/resources/metrics_service.go
@@ -26,8 +26,9 @@ func NewMetricsService(log gethlog.Logger, listenAddr string, port int, handler 
 
 // Start begins serving metrics in a background goroutine. If the server exits with an error,
 // the optional onError callback is invoked.
-func (s *MetricsService) Start(onError func(error)) {
+func (s *MetricsService) Start(onDone func(), onError func(error)) {
 	if s.server == nil {
+		onDone()
 		return
 	}
 	go func() {
@@ -38,6 +39,7 @@ func (s *MetricsService) Start(onError func(error)) {
 				onError(err)
 			}
 		}
+		onDone()
 	}()
 }
 

--- a/op-supernode/supernode/resources/metrics_service.go
+++ b/op-supernode/supernode/resources/metrics_service.go
@@ -39,7 +39,7 @@ func (s *MetricsService) Start(onDone func(), onError func(error)) {
 				onError(err)
 			}
 		}
-		onDone()
+		// onDone()
 	}()
 }
 

--- a/op-supernode/supernode/resources/metrics_service.go
+++ b/op-supernode/supernode/resources/metrics_service.go
@@ -39,7 +39,7 @@ func (s *MetricsService) Start(onDone func(), onError func(error)) {
 				onError(err)
 			}
 		}
-		// onDone()
+		onDone()
 	}()
 }
 

--- a/op-supernode/supernode/shutdown_test.go
+++ b/op-supernode/supernode/shutdown_test.go
@@ -1,0 +1,73 @@
+package supernode
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-service/httputil"
+	"github.com/ethereum-optimism/optimism/op-supernode/supernode/activity"
+	"github.com/ethereum-optimism/optimism/op-supernode/supernode/resources"
+	gethlog "github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestSupernode builds a minimal Supernode wired with a real HTTP server,
+// a real metrics server, and the given activities. Both servers bind to
+// 127.0.0.1:0 so there are no port conflicts.
+func newTestSupernode(t *testing.T, acts []activity.Activity) *Supernode {
+	t.Helper()
+	log := gethlog.New()
+
+	router := resources.NewRouter(log, resources.RouterConfig{})
+	httpSrv := httputil.NewHTTPServer("127.0.0.1:0", router)
+	metrics := resources.NewMetricsService(log, "127.0.0.1", 0, http.NewServeMux())
+
+	return &Supernode{
+		log:        log,
+		version:    "test",
+		chains:     nil,
+		activities: acts,
+		httpServer: httpSrv,
+		rpcRouter:  router,
+		metrics:    metrics,
+	}
+}
+
+// TestCleanShutdown starts a supernode with multiple services running — a real HTTP
+// server, a real metrics server, a mock activity.
+// It then calls Stop() and asserts it returns within a reasonable deadline.
+func TestCleanShutdown(t *testing.T) {
+	t.Parallel()
+
+	const (
+		// How long the slow activity's goroutine sleeps after context cancellation.
+		activityLinger = 200 * time.Millisecond
+
+		// How long Stop() is allowed to take in total.
+		// Generous enough for a real graceful shutdown, tight enough to catch a hang.
+		stopDeadline = 2 * time.Second
+	)
+
+	s := newTestSupernode(t, []activity.Activity{&mockRunnable{}})
+
+	// Cancel the start context after a brief window so Start() exits promptly.
+	startCtx, cancelStart := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancelStart()
+	require.NoError(t, s.Start(startCtx))
+
+	// Run Stop() in a goroutine so we can race it against the deadline.
+	stopCtx, cancelStop := context.WithTimeout(context.Background(), stopDeadline)
+	defer cancelStop()
+
+	stopDone := make(chan error, 1)
+	go func() { stopDone <- s.Stop(context.Background()) }()
+
+	select {
+	case err := <-stopDone:
+		require.NoError(t, err)
+	case <-stopCtx.Done():
+		t.Fatalf("Stop() did not return within %s — supernode hung on shutdown ", stopDeadline)
+	}
+}

--- a/op-supernode/supernode/shutdown_test.go
+++ b/op-supernode/supernode/shutdown_test.go
@@ -2,14 +2,15 @@ package supernode
 
 import (
 	"context"
+	"log/slog"
 	"net/http"
 	"testing"
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-service/httputil"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/activity"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/resources"
-	gethlog "github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 )
 
@@ -18,7 +19,7 @@ import (
 // 127.0.0.1:0 so there are no port conflicts.
 func newTestSupernode(t *testing.T, acts []activity.Activity) *Supernode {
 	t.Helper()
-	log := gethlog.New()
+	log := testlog.Logger(t, slog.LevelDebug)
 
 	router := resources.NewRouter(log, resources.RouterConfig{})
 	httpSrv := httputil.NewHTTPServer("127.0.0.1:0", router)
@@ -42,12 +43,9 @@ func TestCleanShutdown(t *testing.T) {
 	t.Parallel()
 
 	const (
-		// How long the slow activity's goroutine sleeps after context cancellation.
-		activityLinger = 200 * time.Millisecond
-
 		// How long Stop() is allowed to take in total.
 		// Generous enough for a real graceful shutdown, tight enough to catch a hang.
-		stopDeadline = 2 * time.Second
+		stopDeadline = 200 * time.Second
 	)
 
 	s := newTestSupernode(t, []activity.Activity{&mockRunnable{}})

--- a/op-supernode/supernode/shutdown_test.go
+++ b/op-supernode/supernode/shutdown_test.go
@@ -50,10 +50,7 @@ func TestCleanShutdown(t *testing.T) {
 
 	s := newTestSupernode(t, []activity.Activity{&mockRunnable{}})
 
-	// Cancel the start context after a brief window so Start() exits promptly.
-	startCtx, cancelStart := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancelStart()
-	require.NoError(t, s.Start(startCtx))
+	require.NoError(t, s.Start(context.Background()))
 
 	// Run Stop() in a goroutine so we can race it against the deadline.
 	stopCtx, cancelStop := context.WithTimeout(context.Background(), stopDeadline)

--- a/op-supernode/supernode/supernode.go
+++ b/op-supernode/supernode/supernode.go
@@ -175,9 +175,7 @@ func (s *Supernode) Start(ctx context.Context) error {
 			}
 		}(chainID, chain)
 	}
-	<-ctx.Done()
-	s.log.Info("supernode received stop signal")
-	return ctx.Err()
+	return nil
 }
 
 func (s *Supernode) Stop(ctx context.Context) error {

--- a/op-supernode/supernode/supernode.go
+++ b/op-supernode/supernode/supernode.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"reflect"
 	"strconv"
 	"sync"
 	"time"
@@ -142,8 +143,7 @@ func (s *Supernode) Start(ctx context.Context) error {
 	// Start metrics service
 	if s.metrics != nil {
 		s.wg.Add(1)
-		s.metrics.Start(func(err error) {
-			defer s.wg.Done()
+		s.metrics.Start(s.wg.Done, func(err error) {
 			if s.requestStop != nil {
 				s.requestStop(err)
 			}
@@ -160,7 +160,16 @@ func (s *Supernode) Start(ctx context.Context) error {
 			s.wg.Add(1)
 			go func(run activity.RunnableActivity) {
 				defer s.wg.Done()
-				if err := run.Start(ctx); err != nil {
+				err := run.Start(ctx)
+				switch err {
+				case nil:
+					s.log.Error("activity quit unexpectedly")
+				case context.Canceled:
+					// This is the happy path, normal / clean shutdown
+					s.log.Info("activity closing due to cancelled context")
+				case context.DeadlineExceeded:
+					s.log.Warn("activity quit due to deadline exceeded")
+				default:
 					s.log.Error("error starting runnable activity", "error", err)
 				}
 			}(run)
@@ -188,6 +197,8 @@ func (s *Supernode) Stop(ctx context.Context) error {
 		defer cancel()
 		if err := s.httpServer.Shutdown(shutdownCtx); err != nil {
 			s.log.Error("error shutting down rpc server", "error", err)
+		} else {
+			s.log.Info("rpc server stopped")
 		}
 	}
 	if s.metrics != nil {
@@ -195,11 +206,15 @@ func (s *Supernode) Stop(ctx context.Context) error {
 		defer cancel()
 		if err := s.metrics.Stop(shutdownCtx); err != nil {
 			s.log.Error("error shutting down metrics server", "error", err)
+		} else {
+			s.log.Info("metrics server stopped")
 		}
 	}
 	if s.rpcRouter != nil {
 		if err := s.rpcRouter.Close(); err != nil {
 			s.log.Error("error closing rpc router", "error", err)
+		} else {
+			s.log.Info("rpc router closed")
 		}
 	}
 
@@ -208,6 +223,8 @@ func (s *Supernode) Stop(ctx context.Context) error {
 		if run, ok := a.(activity.RunnableActivity); ok {
 			if err := run.Stop(ctx); err != nil {
 				s.log.Error("error stopping runnable activity", "error", err)
+			} else {
+				s.log.Info("runnable activity stopped", "activity", reflect.TypeOf(a).String())
 			}
 		}
 	}
@@ -215,9 +232,12 @@ func (s *Supernode) Stop(ctx context.Context) error {
 	for chainID, chain := range s.chains {
 		if err := chain.Stop(ctx); err != nil {
 			s.log.Error("error stopping chain container", "chain_id", chainID.String(), "error", err)
+		} else {
+			s.log.Info("chain container stopped", "chain_id", chainID.String())
 		}
 	}
 
+	s.log.Info("all chain containers stopped, waiting for goroutines to finish")
 	s.wg.Wait()
 
 	if s.l1Client != nil {

--- a/op-supernode/supernode/supernode_activities_test.go
+++ b/op-supernode/supernode/supernode_activities_test.go
@@ -18,16 +18,23 @@ import (
 
 // mock runnable activity
 type mockRunnable struct {
+	ctx     context.Context
+	cancel  context.CancelFunc
 	started int
 	stopped int
 }
 
 func (m *mockRunnable) Start(ctx context.Context) error {
 	m.started++
-	<-ctx.Done()
-	return ctx.Err()
+	m.ctx, m.cancel = context.WithCancel(ctx)
+	<-m.ctx.Done()
+	return m.ctx.Err()
 }
-func (m *mockRunnable) Stop(ctx context.Context) error { m.stopped++; return nil }
+func (m *mockRunnable) Stop(ctx context.Context) error {
+	m.stopped++
+	m.cancel()
+	return nil
+}
 func (m *mockRunnable) Reset(chainID eth.ChainID, timestamp uint64, invalidatedBlock eth.BlockRef) {
 }
 

--- a/op-supernode/supernode/supernode_activities_test.go
+++ b/op-supernode/supernode/supernode_activities_test.go
@@ -76,11 +76,7 @@ func TestRunnableActivityGating(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
 	defer cancel()
 
-	done := make(chan struct{})
-	go func() { _ = s.Start(ctx); close(done) }()
-
-	<-done // wait until context canceled and Start exits
-
+	require.NoError(t, s.Start(ctx))
 	require.Equal(t, 1, run.started, "runnable activity should be started exactly once")
 	require.Equal(t, 0, run.stopped, "Stop is invoked during Stop(), not here")
 

--- a/op-supernode/supernode/supernode_activities_test.go
+++ b/op-supernode/supernode/supernode_activities_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	rpc "github.com/ethereum-optimism/optimism/op-service/rpc"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/activity"
 	gethlog "github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
@@ -32,7 +34,9 @@ func (m *mockRunnable) Start(ctx context.Context) error {
 }
 func (m *mockRunnable) Stop(ctx context.Context) error {
 	m.stopped++
-	m.cancel()
+	if m.cancel != nil {
+		m.cancel()
+	}
 	return nil
 }
 func (m *mockRunnable) Reset(chainID eth.ChainID, timestamp uint64, invalidatedBlock eth.BlockRef) {
@@ -74,7 +78,7 @@ func TestRunnableActivityGating(t *testing.T) {
 	plain := &plainActivity{}
 
 	s := &Supernode{
-		log:        gethlog.New(),
+		log:        testlog.Logger(t, slog.LevelDebug),
 		version:    "test",
 		chains:     nil,
 		activities: []activity.Activity{run, plain},
@@ -84,12 +88,11 @@ func TestRunnableActivityGating(t *testing.T) {
 	defer cancel()
 
 	require.NoError(t, s.Start(ctx))
-	require.Equal(t, 1, run.started, "runnable activity should be started exactly once")
-	require.Equal(t, 0, run.stopped, "Stop is invoked during Stop(), not here")
 
 	// now stop and ensure Stop was called on runnable activity
 	err := s.Stop(context.Background())
 	require.NoError(t, err)
+	require.Equal(t, 1, run.started, "runnable activity should be started exactly once")
 	require.Equal(t, 1, run.stopped, "runnable activity should be stopped exactly once")
 }
 


### PR DESCRIPTION
We have seen some tests hang for 2 hours and have suspected an unclean shutdown of supernode as the culprit. 

This PR:
* introduces a test which reproduces the issue
* patches the issue by ensuring the metrics service always decrements the wait group counter (previously it was only doing this on an error, so we were relying on an error to trigger a clean shutdown)
* introduces more logging into the shutdown logic
* tries to tighten up abstractions and patterns around lifecycle generally (but there is more work to do here). 

Without patch: 
```
➜  supernode git:(gk/supernode-shutdown) ✗ go test . -run TestCleanShutdown -v
=== RUN   TestCleanShutdown
=== PAUSE TestCleanShutdown
=== CONT  TestCleanShutdown
    supernode.go:124:           INFO [02-24|11:13:30.007] supernode starting                       version=test
    metrics_service.go:35:      INFO [02-24|11:13:30.007] starting metrics router server           addr=127.0.0.1:0
    supernode.go:191:           INFO [02-24|11:13:30.008] supernode stopping
    supernode.go:139:           INFO [02-24|11:13:30.018] starting RPC router server               addr=127.0.0.1:59965
    supernode.go:201:           INFO [02-24|11:13:30.018] rpc server stopped
    supernode.go:210:           INFO [02-24|11:13:30.018] metrics server stopped
    supernode.go:217:           INFO [02-24|11:13:30.018] rpc router closed
    supernode.go:227:           INFO [02-24|11:13:30.018] runnable activity stopped                activity=*supernode.mockRunnable
    supernode.go:240:           INFO [02-24|11:13:30.018] all chain containers stopped, waiting for goroutines to finish
    supernode.go:169:           INFO [02-24|11:13:30.018] activity closing due to cancelled context
    shutdown_test.go:66: Stop() did not return within 3m20s — supernode hung on shutdown
--- FAIL: TestCleanShutdown (200.00s)
FAIL
FAIL	github.com/ethereum-optimism/optimism/op-supernode/supernode	200.911s
FAIL
```

With patch: 
```
➜  supernode git:(gk/supernode-shutdown) ✗ go test . -run TestCleanShutdown -v
=== RUN   TestCleanShutdown
=== PAUSE TestCleanShutdown
=== CONT  TestCleanShutdown
    supernode.go:124:           INFO [02-24|11:08:49.571] supernode starting                       version=test
    supernode.go:191:           INFO [02-24|11:08:49.571] supernode stopping
    metrics_service.go:35:      INFO [02-24|11:08:49.571] starting metrics router server           addr=127.0.0.1:0
    supernode.go:139:           INFO [02-24|11:08:49.581] starting RPC router server               addr=127.0.0.1:59701
    supernode.go:201:           INFO [02-24|11:08:49.582] rpc server stopped
    supernode.go:210:           INFO [02-24|11:08:49.582] metrics server stopped
    supernode.go:217:           INFO [02-24|11:08:49.582] rpc router closed
    supernode.go:227:           INFO [02-24|11:08:49.582] runnable activity stopped                activity=*supernode.mockRunnable
    supernode.go:240:           INFO [02-24|11:08:49.582] all chain containers stopped, waiting for goroutines to finish
    supernode.go:169:           INFO [02-24|11:08:49.582] activity closing due to cancelled context
--- PASS: TestCleanShutdown (0.01s)
PASS
ok  	github.com/ethereum-optimism/optimism/op-supernode/supernode	0.950s
mise WARN  unknown field in ~/code/ethereum-optimism/optimism/mise.toml: tool_alias
