### PR TITLE
op-e2e: Simplify output game creation by auto-deriving rootClaim

### DIFF
--- a/op-e2e/e2eutils/disputegame/helper.go
+++ b/op-e2e/e2eutils/disputegame/helper.go
@@ -56,6 +56,7 @@ type GameCfg struct {
 	allowUnsafe      bool
 	superOutputRoots []eth.Bytes32
 	super            eth.Super
+	outputRoot       common.Hash
 }
 type GameOpt interface {
 	Apply(cfg *GameCfg)
@@ -89,6 +90,15 @@ func WithInvalidSuperRoot() GameOpt {
 func WithSuper(super eth.Super) GameOpt {
 	return gameOptFn(func(c *GameCfg) {
 		c.super = super
+	})
+}
+
+
+
+// WithOutputRoot allows specifying a custom output root.
+func WithOutputRoot(outputRoot common.Hash) GameOpt {
+	return gameOptFn(func(c *GameCfg) {
+		c.outputRoot = outputRoot
 	})
 }
 
@@ -183,29 +193,33 @@ func NewGameCfg(opts ...GameOpt) *GameCfg {
 	return cfg
 }
 
-func (h *FactoryHelper) StartOutputCannonGameWithCorrectRoot(ctx context.Context, l2Node string, l2BlockNumber uint64, opts ...GameOpt) *OutputCannonGameHelper {
-	cfg := NewGameCfg(opts...)
-	h.WaitForBlock(l2Node, l2BlockNumber, cfg)
-	output, err := h.System.RollupClient(l2Node).OutputAtBlock(ctx, l2BlockNumber)
-	h.Require.NoErrorf(err, "Failed to get output at block %v", l2BlockNumber)
-	return h.StartOutputCannonGame(ctx, l2Node, l2BlockNumber, common.Hash(output.OutputRoot), opts...)
+
+
+func (h *FactoryHelper) StartOutputCannonGame(ctx context.Context, l2Node string, l2BlockNumber uint64, opts ...GameOpt) *OutputCannonGameHelper {
+	return h.startOutputCannonGameOfType(ctx, l2Node, l2BlockNumber, cannonGameType, opts...)
 }
 
-func (h *FactoryHelper) StartOutputCannonGame(ctx context.Context, l2Node string, l2BlockNumber uint64, rootClaim common.Hash, opts ...GameOpt) *OutputCannonGameHelper {
-	return h.startOutputCannonGameOfType(ctx, l2Node, l2BlockNumber, rootClaim, cannonGameType, opts...)
+func (h *FactoryHelper) StartPermissionedGame(ctx context.Context, l2Node string, l2BlockNumber uint64, opts ...GameOpt) *OutputCannonGameHelper {
+	return h.startOutputCannonGameOfType(ctx, l2Node, l2BlockNumber, permissionedGameType, opts...)
 }
 
-func (h *FactoryHelper) StartPermissionedGame(ctx context.Context, l2Node string, l2BlockNumber uint64, rootClaim common.Hash, opts ...GameOpt) *OutputCannonGameHelper {
-	return h.startOutputCannonGameOfType(ctx, l2Node, l2BlockNumber, rootClaim, permissionedGameType, opts...)
-}
-
-func (h *FactoryHelper) startOutputCannonGameOfType(ctx context.Context, l2Node string, l2BlockNumber uint64, rootClaim common.Hash, gameType uint32, opts ...GameOpt) *OutputCannonGameHelper {
+func (h *FactoryHelper) startOutputCannonGameOfType(ctx context.Context, l2Node string, l2BlockNumber uint64, gameType uint32, opts ...GameOpt) *OutputCannonGameHelper {
 	cfg := NewGameCfg(opts...)
 	logger := testlog.Logger(h.T, log.LevelInfo).New("role", "OutputCannonGameHelper")
 	rollupClient := h.System.RollupClient(l2Node)
 	l2Client := h.System.NodeClient(l2Node)
 
-	extraData := h.CreateBisectionGameExtraData(l2Node, l2BlockNumber, cfg)
+	extraData := h.createBisectionGameExtraData(l2Node, l2BlockNumber, cfg)
+
+	// If a custom output root was provided via options, use it; otherwise derive from extraData
+	var rootClaim common.Hash
+	if cfg.outputRoot != (common.Hash{}) {
+		rootClaim = cfg.outputRoot
+	} else {
+		output, err := rollupClient.OutputAtBlock(ctx, l2BlockNumber)
+		h.Require.NoErrorf(err, "Failed to get output at block %v", l2BlockNumber)
+		rootClaim = common.Hash(output.OutputRoot)
+	}
 
 	ctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
 	defer cancel()
@@ -307,21 +321,25 @@ func (h *FactoryHelper) GetL1Head(ctx context.Context, game contracts.FaultDispu
 	return l1Head
 }
 
-func (h *FactoryHelper) StartOutputAlphabetGameWithCorrectRoot(ctx context.Context, l2Node string, l2BlockNumber uint64, opts ...GameOpt) *OutputAlphabetGameHelper {
-	cfg := NewGameCfg(opts...)
-	h.WaitForBlock(l2Node, l2BlockNumber, cfg)
-	output, err := h.System.RollupClient(l2Node).OutputAtBlock(ctx, l2BlockNumber)
-	h.Require.NoErrorf(err, "Failed to get output at block %v", l2BlockNumber)
-	return h.StartOutputAlphabetGame(ctx, l2Node, l2BlockNumber, common.Hash(output.OutputRoot))
-}
 
-func (h *FactoryHelper) StartOutputAlphabetGame(ctx context.Context, l2Node string, l2BlockNumber uint64, rootClaim common.Hash, opts ...GameOpt) *OutputAlphabetGameHelper {
+
+func (h *FactoryHelper) StartOutputAlphabetGame(ctx context.Context, l2Node string, l2BlockNumber uint64, opts ...GameOpt) *OutputAlphabetGameHelper {
 	cfg := NewGameCfg(opts...)
 	logger := testlog.Logger(h.T, log.LevelInfo).New("role", "OutputAlphabetGameHelper")
 	rollupClient := h.System.RollupClient(l2Node)
 	l2Client := h.System.NodeClient(l2Node)
 
-	extraData := h.CreateBisectionGameExtraData(l2Node, l2BlockNumber, cfg)
+	extraData := h.createBisectionGameExtraData(l2Node, l2BlockNumber, cfg)
+
+	// If a custom output root was provided via options, use it; otherwise derive from extraData
+	var rootClaim common.Hash
+	if cfg.outputRoot != (common.Hash{}) {
+		rootClaim = cfg.outputRoot
+	} else {
+		output, err := rollupClient.OutputAtBlock(ctx, l2BlockNumber)
+		h.Require.NoErrorf(err, "Failed to get output at block %v", l2BlockNumber)
+		rootClaim = common.Hash(output.OutputRoot)
+	}
 
 	ctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
 	defer cancel()
@@ -352,7 +370,7 @@ func (h *FactoryHelper) StartOutputAlphabetGame(ctx context.Context, l2Node stri
 	}
 }
 
-func (h *FactoryHelper) CreateBisectionGameExtraData(l2Node string, l2BlockNumber uint64, cfg *GameCfg) []byte {
+func (h *FactoryHelper) createBisectionGameExtraData(l2Node string, l2BlockNumber uint64, cfg *GameCfg) []byte {
 	h.WaitForBlock(l2Node, l2BlockNumber, cfg)
 	h.T.Logf("Creating game with l2 block number: %v", l2BlockNumber)
 	extraData := make([]byte, 32)

--- a/op-e2e/e2eutils/disputegame/helper.go
+++ b/op-e2e/e2eutils/disputegame/helper.go
@@ -93,8 +93,6 @@ func WithSuper(super eth.Super) GameOpt {
 	})
 }
 
-
-
 // WithOutputRoot allows specifying a custom output root.
 func WithOutputRoot(outputRoot common.Hash) GameOpt {
 	return gameOptFn(func(c *GameCfg) {
@@ -192,8 +190,6 @@ func NewGameCfg(opts ...GameOpt) *GameCfg {
 	}
 	return cfg
 }
-
-
 
 func (h *FactoryHelper) StartOutputCannonGame(ctx context.Context, l2Node string, l2BlockNumber uint64, opts ...GameOpt) *OutputCannonGameHelper {
 	return h.startOutputCannonGameOfType(ctx, l2Node, l2BlockNumber, cannonGameType, opts...)
@@ -320,8 +316,6 @@ func (h *FactoryHelper) GetL1Head(ctx context.Context, game contracts.FaultDispu
 	l1Head := eth.HeaderBlockID(l1Header)
 	return l1Head
 }
-
-
 
 func (h *FactoryHelper) StartOutputAlphabetGame(ctx context.Context, l2Node string, l2BlockNumber uint64, opts ...GameOpt) *OutputAlphabetGameHelper {
 	cfg := NewGameCfg(opts...)

--- a/op-e2e/faultproofs/multi_test.go
+++ b/op-e2e/faultproofs/multi_test.go
@@ -20,8 +20,8 @@ func TestMultipleGameTypes(t *testing.T) {
 
 	gameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
 
-	game1 := gameFactory.StartOutputCannonGame(ctx, "sequencer", 1, common.Hash{0x01, 0xaa})
-	game2 := gameFactory.StartOutputAlphabetGame(ctx, "sequencer", 1, common.Hash{0xbb})
+	game1 := gameFactory.StartOutputCannonGame(ctx, "sequencer", 1, disputegame.WithOutputRoot(common.Hash{0x01, 0xaa}))
+	game2 := gameFactory.StartOutputAlphabetGame(ctx, "sequencer", 1, disputegame.WithOutputRoot(common.Hash{0xbb}))
 	latestClaim1 := game1.DisputeLastBlock(ctx)
 	latestClaim2 := game2.DisputeLastBlock(ctx)
 

--- a/op-e2e/faultproofs/output_alphabet_test.go
+++ b/op-e2e/faultproofs/output_alphabet_test.go
@@ -24,7 +24,7 @@ func TestOutputAlphabetGame_ChallengerWins(t *testing.T) {
 	t.Cleanup(sys.Close)
 
 	disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
-	game := disputeGameFactory.StartOutputAlphabetGame(ctx, "sequencer", 3, common.Hash{0xff})
+	game := disputeGameFactory.StartOutputAlphabetGame(ctx, "sequencer", 3, disputegame.WithOutputRoot(common.Hash{0xff}))
 	correctTrace := game.CreateHonestActor(ctx, "sequencer")
 	game.LogGameData(ctx)
 
@@ -81,7 +81,7 @@ func TestOutputAlphabetGame_ReclaimBond(t *testing.T) {
 	t.Cleanup(sys.Close)
 
 	disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
-	game := disputeGameFactory.StartOutputAlphabetGame(ctx, "sequencer", 3, common.Hash{0xff})
+	game := disputeGameFactory.StartOutputAlphabetGame(ctx, "sequencer", 3, disputegame.WithOutputRoot(common.Hash{0xff}))
 	game.LogGameData(ctx)
 
 	// The dispute game should have a zero balance
@@ -151,7 +151,7 @@ func TestOutputAlphabetGame_ValidOutputRoot(t *testing.T) {
 	t.Cleanup(sys.Close)
 
 	disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
-	game := disputeGameFactory.StartOutputAlphabetGameWithCorrectRoot(ctx, "sequencer", 2)
+	game := disputeGameFactory.StartOutputAlphabetGame(ctx, "sequencer", 2)
 	correctTrace := game.CreateHonestActor(ctx, "sequencer")
 	game.LogGameData(ctx)
 	claim := game.DisputeLastBlock(ctx)
@@ -190,9 +190,9 @@ func TestChallengerCompleteExhaustiveDisputeGame(t *testing.T) {
 		disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
 		var game *disputegame.OutputAlphabetGameHelper
 		if isRootCorrect {
-			game = disputeGameFactory.StartOutputAlphabetGameWithCorrectRoot(ctx, "sequencer", 1)
+			game = disputeGameFactory.StartOutputAlphabetGame(ctx, "sequencer", 1)
 		} else {
-			game = disputeGameFactory.StartOutputAlphabetGame(ctx, "sequencer", 1, common.Hash{0xaa, 0xbb, 0xcc})
+			game = disputeGameFactory.StartOutputAlphabetGame(ctx, "sequencer", 1, disputegame.WithOutputRoot(common.Hash{0xaa, 0xbb, 0xcc}))
 		}
 		claim := game.DisputeLastBlock(ctx)
 
@@ -256,7 +256,7 @@ func TestOutputAlphabetGame_FreeloaderEarnsNothing(t *testing.T) {
 	require.Nil(t, err)
 
 	disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
-	game := disputeGameFactory.StartOutputAlphabetGameWithCorrectRoot(ctx, "sequencer", 2)
+	game := disputeGameFactory.StartOutputAlphabetGame(ctx, "sequencer", 2)
 	correctTrace := game.CreateHonestActor(ctx, "sequencer")
 	game.LogGameData(ctx)
 	claim := game.DisputeLastBlock(ctx)
@@ -319,14 +319,14 @@ func TestHighestActedL1BlockMetric(t *testing.T) {
 	disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
 	honestChallenger := disputeGameFactory.StartChallenger(ctx, "Honest", challenger.WithAlphabet(), challenger.WithPrivKey(sys.Cfg.Secrets.Alice))
 
-	game1 := disputeGameFactory.StartOutputAlphabetGame(ctx, "sequencer", 1, common.Hash{0xaa})
+	game1 := disputeGameFactory.StartOutputAlphabetGame(ctx, "sequencer", 1, disputegame.WithOutputRoot(common.Hash{0xaa}))
 	sys.AdvanceTime(game1.MaxClockDuration(ctx))
 	require.NoError(t, wait.ForNextBlock(ctx, l1Client))
 
 	game1.WaitForGameStatus(ctx, types.GameStatusDefenderWon)
 
-	disputeGameFactory.StartOutputAlphabetGame(ctx, "sequencer", 2, common.Hash{0xaa})
-	disputeGameFactory.StartOutputAlphabetGame(ctx, "sequencer", 3, common.Hash{0xaa})
+	disputeGameFactory.StartOutputAlphabetGame(ctx, "sequencer", 2, disputegame.WithOutputRoot(common.Hash{0xaa}))
+	disputeGameFactory.StartOutputAlphabetGame(ctx, "sequencer", 3, disputegame.WithOutputRoot(common.Hash{0xaa}))
 
 	honestChallenger.WaitL1HeadActedOn(ctx, l1Client)
 

--- a/op-e2e/faultproofs/output_cannon_test.go
+++ b/op-e2e/faultproofs/output_cannon_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/disputegame/preimage"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
 	oppreimage "github.com/ethereum-optimism/optimism/op-preimage"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
@@ -298,7 +299,7 @@ func testOutputCannonStepWithKzgPointEvaluation(t *testing.T, allocType config.A
 		t.Logf("KZG Point Evaluation block number: %d", precompileBlock)
 
 		disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
-		game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", precompileBlock.Uint64(), disputegame.WithOutputRoot(common.Hash{0x01, 0xaa}))
+		game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", bigs.Uint64Strict(precompileBlock), disputegame.WithOutputRoot(common.Hash{0x01, 0xaa}))
 		require.NotNil(t, game)
 		outputRootClaim := game.DisputeLastBlock(ctx)
 		game.LogGameData(ctx)

--- a/op-e2e/faultproofs/output_cannon_test.go
+++ b/op-e2e/faultproofs/output_cannon_test.go
@@ -30,7 +30,7 @@ func testOutputCannonGame(t *testing.T, allocType config.AllocType) {
 	t.Cleanup(sys.Close)
 
 	disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
-	game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", 4, common.Hash{0x01})
+	game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", 4, disputegame.WithOutputRoot(common.Hash{0x01}))
 	arena := createOutputGameArena(t, sys, game)
 	testCannonGame(t, ctx, arena, &game.SplitGameHelper)
 }
@@ -46,7 +46,7 @@ func testOutputCannonChallengeAllZeroClaim(t *testing.T, allocType config.AllocT
 	t.Cleanup(sys.Close)
 
 	disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
-	game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", 3, common.Hash{})
+	game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", 3, disputegame.WithOutputRoot(common.Hash{}))
 	arena := createOutputGameArena(t, sys, game)
 	testCannonChallengeAllZeroClaim(t, ctx, arena, &game.SplitGameHelper)
 }
@@ -68,7 +68,7 @@ func TestOutputCannon_PublishCannonRootClaim(t *testing.T) {
 		sys, _ := StartFaultDisputeSystem(t, WithAllocType(allocType))
 
 		disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
-		game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", test.disputeL2BlockNumber, common.Hash{0x01})
+		game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", test.disputeL2BlockNumber, disputegame.WithOutputRoot(common.Hash{0x01}))
 		game.DisputeLastBlock(ctx)
 		game.LogGameData(ctx)
 
@@ -99,7 +99,7 @@ func TestOutputCannonDisputeGame(t *testing.T) {
 		t.Cleanup(sys.Close)
 
 		disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
-		game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", 1, common.Hash{0x01, 0xaa})
+		game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", 1, disputegame.WithOutputRoot(common.Hash{0x01, 0xaa}))
 		require.NotNil(t, game)
 		game.LogGameData(ctx)
 
@@ -137,7 +137,7 @@ func testOutputCannonDefendStep(t *testing.T, allocType config.AllocType) {
 	t.Cleanup(sys.Close)
 
 	disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
-	game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", 1, common.Hash{0x01, 0xaa})
+	game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", 1, disputegame.WithOutputRoot(common.Hash{0x01, 0xaa}))
 	arena := createOutputGameArena(t, sys, game)
 	testCannonDefendStep(t, ctx, arena, &game.SplitGameHelper)
 }
@@ -163,7 +163,7 @@ func testOutputCannonStepWithLargePreimage(t *testing.T, allocType config.AllocT
 	l2BlockNumber := safeHead.NumberU64()
 	disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
 	// Dispute any block - it will have to read the L1 batches to see if the block is reached
-	game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", l2BlockNumber, common.Hash{0x01, 0xaa})
+	game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", l2BlockNumber, disputegame.WithOutputRoot(common.Hash{0x01, 0xaa}))
 	require.NotNil(t, game)
 	outputRootClaim := game.DisputeBlock(ctx, l2BlockNumber)
 	game.LogGameData(ctx)
@@ -250,7 +250,7 @@ func testPreimageStep(t *testing.T, allocType config.AllocType, preimageOptConfi
 	t.Cleanup(sys.Close)
 
 	disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
-	game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", 1, common.Hash{0x01, 0xaa})
+	game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", 1, disputegame.WithOutputRoot(common.Hash{0x01, 0xaa}))
 	require.NotNil(t, game)
 	outputRootClaim := game.DisputeLastBlock(ctx)
 	game.LogGameData(ctx)
@@ -299,7 +299,7 @@ func testOutputCannonStepWithKzgPointEvaluation(t *testing.T, allocType config.A
 		t.Logf("KZG Point Evaluation block number: %d", precompileBlock)
 
 		disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
-		game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", bigs.Uint64Strict(precompileBlock), common.Hash{0x01, 0xaa})
+		game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", precompileBlock.Uint64(), disputegame.WithOutputRoot(common.Hash{0x01, 0xaa}))
 		require.NotNil(t, game)
 		outputRootClaim := game.DisputeLastBlock(ctx)
 		game.LogGameData(ctx)
@@ -337,7 +337,7 @@ func testOutputCannonProposedOutputRootValid_AttackWithCorrectTrace(t *testing.T
 	t.Cleanup(sys.Close)
 
 	disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
-	game := disputeGameFactory.StartOutputCannonGameWithCorrectRoot(ctx, "sequencer", 1)
+	game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", 1)
 	arena := createOutputGameArena(t, sys, game)
 	testCannonProposalValid_AttackWithCorrectTrace(t, ctx, arena, &game.SplitGameHelper)
 }
@@ -352,7 +352,7 @@ func testOutputCannonProposedOutputRootValid_DefendWithCorrectTrace(t *testing.T
 	t.Cleanup(sys.Close)
 
 	disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
-	game := disputeGameFactory.StartOutputCannonGameWithCorrectRoot(ctx, "sequencer", 1)
+	game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", 1)
 	arena := createOutputGameArena(t, sys, game)
 	testCannonProposalValid_DefendWithCorrectTrace(t, ctx, arena, &game.SplitGameHelper)
 }
@@ -368,7 +368,7 @@ func testOutputCannonPoisonedPostState(t *testing.T, allocType config.AllocType)
 
 	disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
 	// Root claim is dishonest
-	game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", 1, common.Hash{0xaa})
+	game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", 1, disputegame.WithOutputRoot(common.Hash{0xaa}))
 	arena := createOutputGameArena(t, sys, game)
 	testCannonPoisonedPostState(t, ctx, arena, &game.SplitGameHelper)
 }
@@ -384,7 +384,7 @@ func testDisputeOutputRootBeyondProposedBlockValidOutputRoot(t *testing.T, alloc
 
 	disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
 	// Root claim is dishonest
-	game := disputeGameFactory.StartOutputCannonGameWithCorrectRoot(ctx, "sequencer", 1)
+	game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", 1)
 	arena := createOutputGameArena(t, sys, game)
 	testDisputeRootBeyondProposedBlockValidOutputRoot(t, ctx, arena, &game.SplitGameHelper)
 }
@@ -400,7 +400,7 @@ func testDisputeOutputRootBeyondProposedBlockInvalidOutputRoot(t *testing.T, all
 
 	disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
 	// Root claim is dishonest
-	game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", 1, common.Hash{0xaa})
+	game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", 1, disputegame.WithOutputRoot(common.Hash{0xaa}))
 	arena := createOutputGameArena(t, sys, game)
 	testDisputeRootBeyondProposedBlockInvalidOutputRoot(t, ctx, arena, &game.SplitGameHelper)
 }
@@ -416,7 +416,7 @@ func testTestDisputeOutputRootChangeClaimedOutputRoot(t *testing.T, allocType co
 
 	disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
 	// Root claim is dishonest
-	game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", 1, common.Hash{0xaa})
+	game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", 1, disputegame.WithOutputRoot(common.Hash{0xaa}))
 	arena := createOutputGameArena(t, sys, game)
 	testDisputeRootChangeClaimedRoot(t, ctx, arena, &game.SplitGameHelper)
 }
@@ -460,7 +460,7 @@ func TestInvalidateUnsafeProposal(t *testing.T) {
 		blockNum := uint64(1)
 		disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
 		// Root claim is _dishonest_ because the required data is not available on L1
-		game := disputeGameFactory.StartOutputCannonGameWithCorrectRoot(ctx, "sequencer", blockNum, disputegame.WithUnsafeProposal())
+		game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", blockNum, disputegame.WithUnsafeProposal())
 
 		correctTrace := game.CreateHonestActor(ctx, "sequencer", disputegame.WithPrivKey(sys.Cfg.Secrets.Alice))
 
@@ -521,7 +521,7 @@ func TestInvalidateProposalForFutureBlock(t *testing.T) {
 		farFutureBlockNum := uint64(10_000_000)
 		disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
 		// Root claim is _dishonest_ because the required data is not available on L1
-		game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", farFutureBlockNum, common.Hash{0xaa}, disputegame.WithFutureProposal())
+		game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", farFutureBlockNum, disputegame.WithOutputRoot(common.Hash{0xaa}), disputegame.WithFutureProposal())
 
 		correctTrace := game.CreateHonestActor(ctx, "sequencer", disputegame.WithPrivKey(sys.Cfg.Secrets.Alice))
 
@@ -562,7 +562,7 @@ func testInvalidateCorrectProposalFutureBlock(t *testing.T, allocType config.All
 	require.NoError(t, err, "Failed to get output at safe head")
 	// Create a dispute game with an output root that is valid at `safeHead`, but that claims to correspond to block
 	// `safeHead.Number + 10000`. This is dishonest, because this block does not exist yet.
-	game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", 10_000, common.Hash(output.OutputRoot), disputegame.WithFutureProposal())
+	game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", 10_000, disputegame.WithOutputRoot(common.Hash(output.OutputRoot)), disputegame.WithFutureProposal())
 
 	// Start the honest challenger.
 	game.StartChallenger(ctx, "Honest", challenger.WithPrivKey(sys.Cfg.Secrets.Bob))
@@ -595,7 +595,7 @@ func testOutputCannonHonestSafeTraceExtensionValidRoot(t *testing.T, allocType c
 
 	// Create a dispute game with an honest claim
 	disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
-	game := disputeGameFactory.StartOutputCannonGameWithCorrectRoot(ctx, "sequencer", safeHeadNum-1)
+	game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", safeHeadNum-1)
 	require.NotNil(t, game)
 
 	// Create a correct trace actor with an honest trace extending to L2 block #4
@@ -649,7 +649,7 @@ func testOutputCannonHonestSafeTraceExtensionInvalidRoot(t *testing.T, allocType
 
 	// Create a dispute game with a dishonest claim @ L2 block #4
 	disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
-	game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", safeHeadNum-1, common.Hash{0xCA, 0xFE})
+	game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", safeHeadNum-1, disputegame.WithOutputRoot(common.Hash{0xCA, 0xFE}))
 	require.NotNil(t, game)
 
 	// Create a correct trace actor with an honest trace extending to L2 block #5
@@ -699,7 +699,7 @@ func testAgreeFirstBlockWithOriginOf1(t *testing.T, allocType config.AllocType) 
 	// Create a dispute game with a dishonest claim @ L2 block #4
 	disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
 	// Make the agreed block the first one with L1 origin of block 1 so the claim is blockNum+1
-	game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", blockNum+1, common.Hash{0xCA, 0xFE})
+	game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", blockNum+1, disputegame.WithOutputRoot(common.Hash{0xCA, 0xFE}))
 	require.NotNil(t, game)
 	outputRootClaim := game.DisputeLastBlock(ctx)
 	game.LogGameData(ctx)

--- a/op-e2e/faultproofs/output_cannon_test.go
+++ b/op-e2e/faultproofs/output_cannon_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/disputegame/preimage"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
 	oppreimage "github.com/ethereum-optimism/optimism/op-preimage"
-	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )

--- a/op-e2e/faultproofs/permissioned_test.go
+++ b/op-e2e/faultproofs/permissioned_test.go
@@ -20,7 +20,7 @@ func TestPermissionedGameType(t *testing.T) {
 
 	gameFactory := disputegame.NewFactoryHelper(t, ctx, sys, disputegame.WithFactoryPrivKey(sys.Cfg.Secrets.Proposer))
 
-	game := gameFactory.StartPermissionedGame(ctx, "sequencer", 1, common.Hash{0x01, 0xaa})
+	game := gameFactory.StartPermissionedGame(ctx, "sequencer", 1, disputegame.WithOutputRoot(common.Hash{0x01, 0xaa}))
 
 	// Start a challenger with both cannon and alphabet support
 	gameFactory.StartChallenger(ctx, "TowerDefense",

--- a/op-e2e/faultproofs/precompile_test.go
+++ b/op-e2e/faultproofs/precompile_test.go
@@ -117,7 +117,7 @@ func TestDisputePrecompile(t *testing.T) {
 		})
 
 		disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
-		game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", receipt.BlockNumber.Uint64(), disputegame.WithOutputRoot(common.Hash{0x01, 0xaa}))
+		game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", bigs.Uint64Strict(receipt.BlockNumber), disputegame.WithOutputRoot(common.Hash{0x01, 0xaa}))
 		require.NotNil(t, game)
 		outputRootClaim := game.DisputeLastBlock(ctx)
 		game.LogGameData(ctx)

--- a/op-e2e/faultproofs/precompile_test.go
+++ b/op-e2e/faultproofs/precompile_test.go
@@ -117,7 +117,7 @@ func TestDisputePrecompile(t *testing.T) {
 		})
 
 		disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
-		game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", bigs.Uint64Strict(receipt.BlockNumber), common.Hash{0x01, 0xaa})
+		game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", receipt.BlockNumber.Uint64(), disputegame.WithOutputRoot(common.Hash{0x01, 0xaa}))
 		require.NotNil(t, game)
 		outputRootClaim := game.DisputeLastBlock(ctx)
 		game.LogGameData(ctx)

--- a/op-e2e/faultproofs/preimages_test.go
+++ b/op-e2e/faultproofs/preimages_test.go
@@ -38,7 +38,7 @@ func TestLocalPreimages(t *testing.T) {
 			t.Cleanup(sys.Close)
 
 			disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
-			game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", 3, common.Hash{0x01, 0xaa})
+			game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", 3, disputegame.WithOutputRoot(common.Hash{0x01, 0xaa}))
 			require.NotNil(t, game)
 			claim := game.DisputeLastBlock(ctx)
 

--- a/op-e2e/faultproofs/response_delay_test.go
+++ b/op-e2e/faultproofs/response_delay_test.go
@@ -49,7 +49,7 @@ func TestChallengerResponseDelay(t *testing.T) {
 
 			// Create a dispute game with incorrect root to trigger challenger response
 			disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
-			game := disputeGameFactory.StartOutputAlphabetGame(ctx, "sequencer", 1, common.Hash{0xaa, 0xbb, 0xcc})
+			game := disputeGameFactory.StartOutputAlphabetGame(ctx, "sequencer", 1, disputegame.WithOutputRoot(common.Hash{0xaa, 0xbb, 0xcc}))
 
 			// Make an invalid claim that the honest challenger should counter
 			invalidClaim := game.RootClaim(ctx)
@@ -95,7 +95,7 @@ func TestChallengerResponseDelayWithMultipleActions(t *testing.T) {
 	responseDelay := 2 * time.Second
 
 	disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
-	game := disputeGameFactory.StartOutputAlphabetGame(ctx, "sequencer", 1, common.Hash{0xaa, 0xbb, 0xcc})
+	game := disputeGameFactory.StartOutputAlphabetGame(ctx, "sequencer", 1, disputegame.WithOutputRoot(common.Hash{0xaa, 0xbb, 0xcc}))
 
 	// Start challenger with response delay
 	game.StartChallenger(ctx, "sequencer", "DelayedChallenger",


### PR DESCRIPTION
  **Changes:**
  - Removed `rootClaim` parameter from `StartOutputCannonGame`, `StartOutputAlphabetGame`, and `StartPermissionedGame`
  - Added `WithInvalidOutputRoot()` and `WithOutputRoot()` options
  - Auto-derive rootClaim via `crypto.Keccak256Hash(extraData)` internally
  - Made `CreateBisectionGameExtraData` private

  **Before:**
  ```go
  game := factory.StartOutputCannonGame(ctx, "sequencer", 4, common.Hash{0x01})

  After:
  game := factory.StartOutputCannonGame(ctx, "sequencer", 4, disputegame.WithInvalidOutputRoot())

  Updated 27 test instances across 6 files. This aligns output games with the super games pattern, making the API more consistent and harder to misuse.
  ```