### PR TITLE
ci: add cannon-builder image to Docker CI builds

### DIFF
--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -69,6 +69,7 @@ jobs:
           - kona-client
           - kona-host
           - op-reth
+          - cannon-builder
     uses: ethereum-optimism/factory/.github/workflows/docker.yaml@f8f3cb4800e538003134fb5f50cc734c2c98d762
     with:
       mode: bake
@@ -116,6 +117,7 @@ jobs:
           - kona-client
           - kona-host
           - op-reth
+          - cannon-builder
     uses: ethereum-optimism/factory/.github/workflows/docker.yaml@f8f3cb4800e538003134fb5f50cc734c2c98d762
     with:
       mode: bake
@@ -168,6 +170,7 @@ jobs:
           - image_name: kona-node
           - image_name: kona-host
           - image_name: op-reth
+          - image_name: cannon-builder
     runs-on: ${{ matrix.runner }}
     env:
       IMAGE: ${{ needs.build-fork.result == 'success' && format('ttl.sh/{0}/{1}:24h', github.sha, matrix.image_name) || format('us-docker.pkg.dev/oplabs-tools-artifacts/images/{0}:{1}', matrix.image_name, github.sha) }}

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -389,3 +389,10 @@ target "op-reth" {
   platforms = split(",", PLATFORMS)
   tags = [for tag in split(",", IMAGE_TAGS) : "${REGISTRY}/${REPOSITORY}/op-reth:${tag}"]
 }
+
+target "cannon-builder" {
+  dockerfile = "cannon.dockerfile"
+  context = "rust/kona/docker/cannon"
+  platforms = split(",", PLATFORMS)
+  tags = [for tag in split(",", IMAGE_TAGS) : "${REGISTRY}/${REPOSITORY}/cannon-builder:${tag}"]
+}


### PR DESCRIPTION
## Summary
- Adds the kona `cannon-builder` (Rust MIPS64r1 toolchain) Docker image to the branch and tag CI build workflows
- Adds a `cannon-builder` target to the root `docker-bake.hcl` pointing at `rust/kona/docker/cannon/cannon.dockerfile`
- Excludes cannon-builder from cross-platform version checks since it's a toolchain image with no entrypoint

## Test plan
- [x] Verified `docker buildx bake --print cannon-builder` resolves correctly
- [x] Verified full image build completes locally with `docker buildx bake cannon-builder --load`

🤖 Generated with [Claude Code](https://claude.com/claude-code)