### PR TITLE
proofs: Add missing consolidate step case in op-acceptance-tests

### DIFF
--- a/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
+++ b/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
@@ -366,6 +366,24 @@ func buildTransitionTests(
 			ClaimTimestamp:     endTimestamp,
 			ExpectValid:        true,
 		},
+		{
+			Name:               "ConsolidateStep",
+			AgreedClaim:        padding(consolidateStep),
+			DisputedClaim:      end.Marshal(),
+			DisputedTraceIndex: consolidateStep,
+			L1Head:             l1HeadCurrent,
+			ClaimTimestamp:     endTimestamp,
+			ExpectValid:        true,
+		},
+		{
+			Name:               "ConsolidateStep-InvalidNoChange",
+			AgreedClaim:        padding(consolidateStep),
+			DisputedClaim:      padding(consolidateStep),
+			DisputedTraceIndex: consolidateStep,
+			L1Head:             l1HeadCurrent,
+			ClaimTimestamp:     endTimestamp,
+			ExpectValid:        false,
+		},
 	}
 }
 


### PR DESCRIPTION
Adds the consolidation step (step 127) to `buildTransitionTests`, covering both the valid and invalid cases. This test case was missing from the `TestPreInteropFaultProofs` and `TestInteropFaultProofs` op-acceptance-tests.