### PR TITLE
Raise TestSupernodeInteropActivationAfterGenesis timeout to 5min

### DIFF
--- a/op-acceptance-tests/tests/supernode/interop/activation/activation_after_genesis_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/activation/activation_after_genesis_test.go
@@ -68,7 +68,7 @@ func TestSupernodeInteropActivationAfterGenesis(gt *testing.T) {
 		)
 
 		return preVerified && postVerified
-	}, 90*time.Second, time.Second, "both pre and post activation timestamps should be verified")
+	}, 300*time.Second, time.Second, "both pre and post activation timestamps should be verified")
 
 	t.Logger().Info("activation boundary test complete",
 		"pre_activation_ts", preActivationTs,


### PR DESCRIPTION
This test is flaking in the merge queue regularly. Based on logs, I think it is jut very slow in CI. Raising timeouts from 1.5min to 5min.