### PR TITLE
proofs: Add single-chain interop and preinterop fault proof smoke tests

### DIFF
--- a/op-acceptance-tests/tests/interop/proofs-singlechain/init_test.go
+++ b/op-acceptance-tests/tests/interop/proofs-singlechain/init_test.go
@@ -1,0 +1,17 @@
+package proofs_singlechain
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+)
+
+func TestMain(m *testing.M) {
+	presets.DoMain(m,
+		presets.WithSingleChainSuperInteropSupernode(),
+		presets.WithL2NetworkCount(1),
+		stack.MakeCommon(sysgo.WithChallengerCannonKonaEnabled()),
+	)
+}

--- a/op-acceptance-tests/tests/interop/proofs-singlechain/interop_fault_proofs_test.go
+++ b/op-acceptance-tests/tests/interop/proofs-singlechain/interop_fault_proofs_test.go
@@ -1,0 +1,16 @@
+package proofs_singlechain
+
+import (
+	"testing"
+
+	sfp "github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/superfaultproofs"
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+)
+
+func TestInteropSingleChainFaultProofs(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewSingleChainInterop(t)
+	sfp.RunSingleChainSuperFaultProofSmokeTest(t, sys)
+}
+

--- a/op-acceptance-tests/tests/interop/proofs-singlechain/interop_fault_proofs_test.go
+++ b/op-acceptance-tests/tests/interop/proofs-singlechain/interop_fault_proofs_test.go
@@ -13,4 +13,3 @@ func TestInteropSingleChainFaultProofs(gt *testing.T) {
 	sys := presets.NewSingleChainInterop(t)
 	sfp.RunSingleChainSuperFaultProofSmokeTest(t, sys)
 }
-

--- a/op-acceptance-tests/tests/isthmus/preinterop-singlechain/init_test.go
+++ b/op-acceptance-tests/tests/isthmus/preinterop-singlechain/init_test.go
@@ -1,0 +1,17 @@
+package preinterop_singlechain
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+)
+
+func TestMain(m *testing.M) {
+	presets.DoMain(m,
+		presets.WithSingleChainIsthmusSuperSupernode(),
+		presets.WithL2NetworkCount(1),
+		stack.MakeCommon(sysgo.WithChallengerCannonKonaEnabled()),
+	)
+}

--- a/op-acceptance-tests/tests/isthmus/preinterop-singlechain/interop_fault_proofs_test.go
+++ b/op-acceptance-tests/tests/isthmus/preinterop-singlechain/interop_fault_proofs_test.go
@@ -1,0 +1,16 @@
+package preinterop_singlechain
+
+import (
+	"testing"
+
+	sfp "github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/superfaultproofs"
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+)
+
+func TestPreinteropSingleChainFaultProofs(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewSingleChainInterop(t)
+	sfp.RunSingleChainSuperFaultProofSmokeTest(t, sys)
+}
+

--- a/op-acceptance-tests/tests/isthmus/preinterop-singlechain/interop_fault_proofs_test.go
+++ b/op-acceptance-tests/tests/isthmus/preinterop-singlechain/interop_fault_proofs_test.go
@@ -13,4 +13,3 @@ func TestPreinteropSingleChainFaultProofs(gt *testing.T) {
 	sys := presets.NewSingleChainInterop(t)
 	sfp.RunSingleChainSuperFaultProofSmokeTest(t, sys)
 }
-

--- a/op-acceptance-tests/tests/superfaultproofs/singlechain.go
+++ b/op-acceptance-tests/tests/superfaultproofs/singlechain.go
@@ -33,7 +33,7 @@ func RunSingleChainSuperFaultProofSmokeTest(t devtest.T, sys *presets.SingleChai
 
 	// Stop batch submission so safe head stalls, then we have a known boundary.
 	c.Batcher.Stop()
-	defer c.Batcher.Start()
+	t.Cleanup(c.Batcher.Start)
 	awaitSafeHeadsStalled(t, sys.L2CLA)
 
 	endTimestamp := nextTimestampAfterSafeHeads(t, chains)

--- a/op-acceptance-tests/tests/superfaultproofs/singlechain.go
+++ b/op-acceptance-tests/tests/superfaultproofs/singlechain.go
@@ -157,4 +157,3 @@ func RunSingleChainSuperFaultProofSmokeTest(t devtest.T, sys *presets.SingleChai
 		})
 	}
 }
-

--- a/op-acceptance-tests/tests/superfaultproofs/singlechain.go
+++ b/op-acceptance-tests/tests/superfaultproofs/singlechain.go
@@ -1,0 +1,160 @@
+package superfaultproofs
+
+import (
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/super"
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+// singleChain bundles the DSL handles for the single L2 chain in a SingleChainInterop system.
+func singleChainFrom(sys *presets.SingleChainInterop) *chain {
+	return &chain{
+		ID:      sys.L2ChainA.ChainID(),
+		Cfg:     sys.L2ChainA.Escape().RollupConfig(),
+		Rollup:  sys.L2CLA.Escape().RollupAPI(),
+		EL:      sys.L2ELA,
+		CLNode:  sys.L2CLA,
+		Batcher: sys.L2BatcherA,
+	}
+}
+
+// RunSingleChainSuperFaultProofSmokeTest is a minimal smoke test for single-chain super fault proofs.
+// It verifies that the super-root transition works correctly when the dependency set has only one chain.
+// The test stops the batcher, waits for the safe head to stall, then resumes batching and verifies
+// a basic set of valid/invalid transitions through both the FPP and challenger trace provider.
+func RunSingleChainSuperFaultProofSmokeTest(t devtest.T, sys *presets.SingleChainInterop) {
+	t.Require().NotNil(sys.SuperRoots, "supernode is required for this test")
+
+	c := singleChainFrom(sys)
+	chains := []*chain{c}
+
+	// Stop batch submission so safe head stalls, then we have a known boundary.
+	c.Batcher.Stop()
+	defer c.Batcher.Start()
+	awaitSafeHeadsStalled(t, sys.L2CLA)
+
+	endTimestamp := nextTimestampAfterSafeHeads(t, chains)
+	startTimestamp := endTimestamp - 1
+
+	// Ensure the chain has produced the target block as unsafe.
+	target, err := c.Cfg.TargetBlockNumber(endTimestamp)
+	t.Require().NoError(err)
+	c.EL.Reached(eth.Unsafe, target, 60)
+
+	// L1 head where chain has no batch data at endTimestamp.
+	respBefore := awaitOptimisticPattern(t, sys.SuperRoots, endTimestamp,
+		nil, []eth.ChainID{c.ID})
+	l1HeadBefore := respBefore.CurrentL1
+
+	// Resume batching so the chain's data at endTimestamp becomes available.
+	c.Batcher.Start()
+	sys.SuperRoots.AwaitValidatedTimestamp(endTimestamp)
+	l1HeadCurrent := latestRequiredL1(sys.SuperRoots.SuperRootAtTimestamp(endTimestamp))
+	c.Batcher.Stop()
+
+	// Build expected transition states for a single chain.
+	start := superRootAtTimestamp(t, chains, startTimestamp)
+	end := superRootAtTimestamp(t, chains, endTimestamp)
+
+	optimistic := optimisticBlockAtTimestamp(t, c, endTimestamp)
+
+	// With one chain: step 0 = chain's optimistic block, steps 1..consolidateStep-1 = padding,
+	// consolidateStep = consolidation to next super root.
+	step1 := marshalTransition(start, 1, optimistic)
+	padding := func(step uint64) []byte {
+		return marshalTransition(start, step, optimistic)
+	}
+
+	tests := []*transitionTest{
+		{
+			Name:               "ClaimDirectToNextTimestamp",
+			AgreedClaim:        start.Marshal(),
+			DisputedClaim:      end.Marshal(),
+			DisputedTraceIndex: 0,
+			L1Head:             l1HeadCurrent,
+			ClaimTimestamp:     endTimestamp,
+			ExpectValid:        false,
+		},
+		{
+			Name:               "ChainOptimisticBlock",
+			AgreedClaim:        start.Marshal(),
+			DisputedClaim:      step1,
+			DisputedTraceIndex: 0,
+			L1Head:             l1HeadCurrent,
+			ClaimTimestamp:     endTimestamp,
+			ExpectValid:        true,
+		},
+		{
+			Name:               "ChainOptimisticBlock-InvalidNoChange",
+			AgreedClaim:        start.Marshal(),
+			DisputedClaim:      start.Marshal(),
+			DisputedTraceIndex: 0,
+			L1Head:             l1HeadCurrent,
+			ClaimTimestamp:     endTimestamp,
+			ExpectValid:        false,
+		},
+		{
+			Name:               "FirstPaddingStep",
+			AgreedClaim:        step1,
+			DisputedClaim:      padding(2),
+			DisputedTraceIndex: 1,
+			L1Head:             l1HeadCurrent,
+			ClaimTimestamp:     endTimestamp,
+			ExpectValid:        true,
+		},
+		{
+			Name:               "ConsolidateStep",
+			AgreedClaim:        padding(consolidateStep),
+			DisputedClaim:      end.Marshal(),
+			DisputedTraceIndex: consolidateStep,
+			L1Head:             l1HeadCurrent,
+			ClaimTimestamp:     endTimestamp,
+			ExpectValid:        true,
+		},
+		{
+			Name:               "ConsolidateStep-InvalidNoChange",
+			AgreedClaim:        padding(consolidateStep),
+			DisputedClaim:      padding(consolidateStep),
+			DisputedTraceIndex: consolidateStep,
+			L1Head:             l1HeadCurrent,
+			ClaimTimestamp:     endTimestamp,
+			ExpectValid:        false,
+		},
+		{
+			Name:               "ChainReachesL1Head",
+			AgreedClaim:        start.Marshal(),
+			DisputedClaim:      super.InvalidTransition,
+			DisputedTraceIndex: 0,
+			L1Head:             l1HeadBefore,
+			ClaimTimestamp:     endTimestamp,
+			ExpectValid:        true,
+		},
+		{
+			Name:               "SuperRootInvalidIfUnsupportedByL1Data",
+			AgreedClaim:        start.Marshal(),
+			DisputedClaim:      step1,
+			DisputedTraceIndex: 0,
+			L1Head:             l1HeadBefore,
+			ClaimTimestamp:     endTimestamp,
+			ExpectValid:        false,
+		},
+	}
+
+	challengerCfg := sys.L2ChainA.Escape().L2Challengers()[0].Config()
+	gameDepth := sys.DisputeGameFactory().GameImpl(gameTypes.SuperCannonKonaGameType).SplitDepth()
+
+	for _, test := range tests {
+		t.Run(test.Name+"-fpp", func(t devtest.T) {
+			runKonaInteropProgram(t, challengerCfg.CannonKona, test.L1Head.Hash,
+				test.AgreedClaim, crypto.Keccak256Hash(test.DisputedClaim),
+				test.ClaimTimestamp, test.ExpectValid)
+		})
+		t.Run(test.Name+"-challenger", func(t devtest.T) {
+			runChallengerProviderTest(t, sys.SuperRoots.QueryAPI(), gameDepth, startTimestamp, test.ClaimTimestamp, test)
+		})
+	}
+}
+

--- a/op-devstack/presets/interop.go
+++ b/op-devstack/presets/interop.go
@@ -108,6 +108,11 @@ func (s *SingleChainInterop) L2Networks() []*dsl.L2Network {
 	}
 }
 
+func (s *SingleChainInterop) DisputeGameFactory() *proofs.DisputeGameFactory {
+	supernode := s.system.Supernode(match.Assume(s.T, match.FirstSupernode))
+	return proofs.NewDisputeGameFactory(s.T, s.L1Network, s.L1EL.EthClient(), s.L2ChainA.DisputeGameFactoryProxyAddr(), nil, nil, supernode, s.challengerConfig)
+}
+
 func (s *SingleChainInterop) AdvanceTime(amount time.Duration) {
 	ttSys, ok := s.system.(stack.TimeTravelSystem)
 	s.T.Require().True(ok, "attempting to advance time on incompatible system")
@@ -168,6 +173,18 @@ func WithIsthmusSuperSupernode() stack.CommonOption {
 
 func WithIsthmusSuper() stack.CommonOption {
 	return stack.MakeCommon(sysgo.DefaultIsthmusSuperProofsSystem(&sysgo.DefaultInteropSystemIDs{}))
+}
+
+// WithSingleChainIsthmusSuperSupernode specifies a single-chain super root system
+// (for proofs) that sources super-roots via op-supernode, without interop at genesis.
+func WithSingleChainIsthmusSuperSupernode() stack.CommonOption {
+	return stack.MakeCommon(sysgo.DefaultSingleChainSupernodeIsthmusSuperProofsSystem(&sysgo.DefaultSingleChainSupernodeProofsSystemIDs{}))
+}
+
+// WithSingleChainSuperInteropSupernode specifies a single-chain super root system
+// (for proofs) that sources super-roots via op-supernode, with interop at genesis.
+func WithSingleChainSuperInteropSupernode() stack.CommonOption {
+	return stack.MakeCommon(sysgo.DefaultSingleChainSupernodeInteropProofsSystem(&sysgo.DefaultSingleChainSupernodeProofsSystemIDs{}))
 }
 
 // WithUnscheduledInterop adds a test-gate to not run the test if the interop upgrade is scheduled.

--- a/op-devstack/sysgo/system.go
+++ b/op-devstack/sysgo/system.go
@@ -632,6 +632,83 @@ func defaultSupernodeSuperProofsSystem(dest *DefaultSupernodeInteropProofsSystem
 	return opt
 }
 
+// DefaultSingleChainSupernodeProofsSystemIDs holds IDs for a single-chain supernode proof system.
+type DefaultSingleChainSupernodeProofsSystemIDs struct {
+	DefaultSingleChainInteropSystemIDs
+	Supernode stack.SupernodeID
+}
+
+func NewDefaultSingleChainSupernodeProofsSystemIDs(l1ID, l2AID eth.ChainID) DefaultSingleChainSupernodeProofsSystemIDs {
+	return DefaultSingleChainSupernodeProofsSystemIDs{
+		DefaultSingleChainInteropSystemIDs: NewDefaultSingleChainInteropSystemIDs(l1ID, l2AID),
+		Supernode:                          stack.NewSupernodeID("supernode-single-system-proofs", l2AID),
+	}
+}
+
+// DefaultSingleChainSupernodeIsthmusSuperProofsSystem creates a single-chain super-roots proofs
+// system using op-supernode without interop at genesis (preinterop).
+func DefaultSingleChainSupernodeIsthmusSuperProofsSystem(dest *DefaultSingleChainSupernodeProofsSystemIDs) stack.Option[*Orchestrator] {
+	return defaultSingleChainSupernodeSuperProofsSystem(dest)
+}
+
+// DefaultSingleChainSupernodeInteropProofsSystem creates a single-chain super-roots proofs
+// system using op-supernode with interop enabled at genesis.
+func DefaultSingleChainSupernodeInteropProofsSystem(dest *DefaultSingleChainSupernodeProofsSystemIDs) stack.Option[*Orchestrator] {
+	return defaultSingleChainSupernodeSuperProofsSystem(dest, WithInteropAtGenesis())
+}
+
+func defaultSingleChainSupernodeSuperProofsSystem(dest *DefaultSingleChainSupernodeProofsSystemIDs, deployerOpts ...DeployerOption) stack.CombinedOption[*Orchestrator] {
+	ids := NewDefaultSingleChainSupernodeProofsSystemIDs(DefaultL1ID, DefaultL2AID)
+	opt := stack.Combine[*Orchestrator]()
+
+	opt.Add(stack.BeforeDeploy(func(o *Orchestrator) {
+		o.P().Logger().Info("Setting up single-chain (supernode)")
+	}))
+
+	opt.Add(WithMnemonicKeys(devkeys.TestMnemonic))
+
+	opt.Add(WithDeployer(), WithDeployerOptions(
+		append([]DeployerOption{
+			WithLocalContractSources(),
+			WithCommons(ids.L1.ChainID()),
+			WithPrefundedL2(ids.L1.ChainID(), ids.L2A.ChainID()),
+			WithDevFeatureEnabled(deployer.OptimismPortalInteropDevFlag),
+		}, deployerOpts...)...,
+	))
+
+	opt.Add(WithL1Nodes(ids.L1EL, ids.L1CL))
+
+	opt.Add(WithL2ELNode(ids.L2AEL))
+
+	// Shared supernode for the single L2 chain
+	opt.Add(WithSharedSupernodeCLs(ids.Supernode, []L2CLs{{CLID: ids.L2ACL, ELID: ids.L2AEL}}, ids.L1CL, ids.L1EL))
+
+	opt.Add(WithTestSequencer(ids.TestSequencer, ids.L1CL, ids.L2ACL, ids.L1EL, ids.L2AEL))
+
+	opt.Add(WithBatcher(ids.L2ABatcher, ids.L1EL, ids.L2ACL, ids.L2AEL))
+
+	// Run super roots migration using supernode as super root source
+	opt.Add(WithSuperRootsFromSupernode(ids.L1.ChainID(), ids.L1EL, []stack.L2CLNodeID{ids.L2ACL}, ids.Supernode, ids.L2A.ChainID()))
+
+	// Start challenger after migration; use supernode RPCs as super-roots source.
+	opt.Add(WithSupernodeL2Challenger(ids.L2ChallengerA, ids.L1EL, ids.L1CL, &ids.Supernode, &ids.Cluster, []stack.L2ELNodeID{
+		ids.L2AEL,
+	}))
+
+	// Start proposer after migration; use supernode RPCs as proposal source.
+	opt.Add(WithSupernodeProposer(ids.L2AProposer, ids.L1EL, &ids.Supernode))
+
+	opt.Add(WithFaucets([]stack.L1ELNodeID{ids.L1EL}, []stack.L2ELNodeID{ids.L2AEL}))
+
+	opt.Add(WithL2MetricsDashboard())
+
+	opt.Add(stack.Finally(func(orch *Orchestrator) {
+		*dest = ids
+	}))
+
+	return opt
+}
+
 func defaultSuperProofsSystem(dest *DefaultInteropSystemIDs, deployerOpts ...DeployerOption) stack.CombinedOption[*Orchestrator] {
 	ids := NewDefaultInteropSystemIDs(DefaultL1ID, DefaultL2AID, DefaultL2BID)
 	opt := stack.Combine[*Orchestrator]()

--- a/op-devstack/sysgo/system.go
+++ b/op-devstack/sysgo/system.go
@@ -648,16 +648,18 @@ func NewDefaultSingleChainSupernodeProofsSystemIDs(l1ID, l2AID eth.ChainID) Defa
 // DefaultSingleChainSupernodeIsthmusSuperProofsSystem creates a single-chain super-roots proofs
 // system using op-supernode without interop at genesis (preinterop).
 func DefaultSingleChainSupernodeIsthmusSuperProofsSystem(dest *DefaultSingleChainSupernodeProofsSystemIDs) stack.Option[*Orchestrator] {
-	return defaultSingleChainSupernodeSuperProofsSystem(dest)
+	return defaultSingleChainSupernodeSuperProofsSystem(dest, nil)
 }
 
 // DefaultSingleChainSupernodeInteropProofsSystem creates a single-chain super-roots proofs
 // system using op-supernode with interop enabled at genesis.
 func DefaultSingleChainSupernodeInteropProofsSystem(dest *DefaultSingleChainSupernodeProofsSystemIDs) stack.Option[*Orchestrator] {
-	return defaultSingleChainSupernodeSuperProofsSystem(dest, WithInteropAtGenesis())
+	return defaultSingleChainSupernodeSuperProofsSystem(dest,
+		[]SupernodeOption{WithSupernodeInteropAtGenesis()},
+		WithInteropAtGenesis())
 }
 
-func defaultSingleChainSupernodeSuperProofsSystem(dest *DefaultSingleChainSupernodeProofsSystemIDs, deployerOpts ...DeployerOption) stack.CombinedOption[*Orchestrator] {
+func defaultSingleChainSupernodeSuperProofsSystem(dest *DefaultSingleChainSupernodeProofsSystemIDs, snOpts []SupernodeOption, deployerOpts ...DeployerOption) stack.CombinedOption[*Orchestrator] {
 	ids := NewDefaultSingleChainSupernodeProofsSystemIDs(DefaultL1ID, DefaultL2AID)
 	opt := stack.Combine[*Orchestrator]()
 
@@ -681,7 +683,9 @@ func defaultSingleChainSupernodeSuperProofsSystem(dest *DefaultSingleChainSupern
 	opt.Add(WithL2ELNode(ids.L2AEL))
 
 	// Shared supernode for the single L2 chain
-	opt.Add(WithSharedSupernodeCLs(ids.Supernode, []L2CLs{{CLID: ids.L2ACL, ELID: ids.L2AEL}}, ids.L1CL, ids.L1EL))
+	opt.Add(WithSharedSupernodeCLs(ids.Supernode,
+		[]L2CLs{{CLID: ids.L2ACL, ELID: ids.L2AEL}},
+		ids.L1CL, ids.L1EL, snOpts...))
 
 	opt.Add(WithTestSequencer(ids.TestSequencer, ids.L1CL, ids.L2ACL, ids.L1EL, ids.L2AEL))
 


### PR DESCRIPTION
Introduce smoke tests that sanity-check super fault proofs when the dependency set contains only one L2 chain. This covers both preinterop (super roots without interop activation) and interop (interop at genesis) scenarios using op-supernode.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>