### PR TITLE
fix: various contracts-bedrock CI issues

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -1372,11 +1372,9 @@ jobs:
             FOUNDRY_PROFILE: ci
           working_directory: packages/contracts-bedrock
           when: on_fail
-      - when:
-          condition: always
-          steps:
-            - store_test_results:
-                path: packages/contracts-bedrock/results/results.xml
+      - store_test_results:
+          path: packages/contracts-bedrock/results
+          when: always
       - run:
           name: Lint forge test names
           command: just lint-forge-tests-check-no-build
@@ -1432,11 +1430,9 @@ jobs:
           key: golang-build-cache-contracts-bedrock-heavy-fuzz-{{ checksum "go.sum" }}
           paths:
             - "~/.cache/go-build"
-      - when:
-          condition: always
-          steps:
-            - store_test_results:
-                path: packages/contracts-bedrock/results/results.xml
+      - store_test_results:
+          path: packages/contracts-bedrock/results
+          when: always
       - notify-failures-on-develop
 
   # AI Contracts Test Maintenance System
@@ -1663,11 +1659,9 @@ jobs:
       - store_artifacts:
           path: packages/contracts-bedrock/failed-test-traces.log
           when: on_fail
-      - when:
-          condition: always
-          steps:
-            - store_test_results:
-                path: packages/contracts-bedrock/results/results.xml
+      - store_test_results:
+          path: packages/contracts-bedrock/results
+          when: always
       - notify-failures-on-develop:
           mentions: "@security-oncall"
 

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -1668,7 +1668,8 @@ jobs:
           steps:
             - store_test_results:
                 path: packages/contracts-bedrock/results/results.xml
-      - notify-failures-on-develop
+      - notify-failures-on-develop:
+          mentions: "@security-oncall"
 
   contracts-bedrock-upload:
     machine: true

--- a/packages/contracts-bedrock/interfaces/periphery/staking/IPolicyEngineStaking.sol
+++ b/packages/contracts-bedrock/interfaces/periphery/staking/IPolicyEngineStaking.sol
@@ -64,6 +64,8 @@ interface IPolicyEngineStaking is ISemver {
     /// @notice Thrown when trying to allowlist/disallow yourself.
     error PolicyEngineStaking_SelfAllowlist();
 
+    function __constructor__(address _ownerAddr, address _token) external;
+
     /// @notice Returns the contract owner.
     function owner() external view returns (address);
 

--- a/packages/contracts-bedrock/justfile
+++ b/packages/contracts-bedrock/justfile
@@ -119,8 +119,8 @@ prepare-upgrade-env *ARGS : build-go-ffi
   export FORK_BLOCK_NUMBER="${FORK_BLOCK_NUMBER:-$pinnedBlock}"
   echo "Running upgrade tests at block $FORK_BLOCK_NUMBER"
   export FORK_RPC_URL=$ETH_RPC_URL
-  export FORK_RETRIES=10
-  export FORK_BACKOFF=1000
+  export FOUNDRY_FORK_RETRIES=10
+  export FOUNDRY_FORK_RETRY_BACKOFF=1000
   export FORK_TEST=true
   {{ARGS}} \
   --match-path "test/{L1,dispute,cannon}/**"


### PR DESCRIPTION
## Summary                                                                                                                                                 
                                                                                                                                                             
  - Fixes `IPolicyEngineStaking.sol` to match the ABI generated by `PolicyEngineStaking.sol`. Public                                                         
    mapping getters auto-generate parameter names from the mapping key names (no `_` prefix) and return                                                      
    names from the struct field names (no `_` suffix). Adds the required `__constructor__` entry to match
    the implementation's constructor signature.
  - Adds `@security-oncall` mention to CircleCI notify step for `contracts-bedrock-checks` failures.
  - Fix `store_test_results` syntax: move `when: always` directly onto the step instead of wrapping in a `when: condition: always` block (`always` is not a valid pipeline expression, only a step attribute keyword). Also broadens path from `results/results.xml` to `results/` so CircleCI scans the directory for XML files rather than expecting a single hardcoded filename   
  - use correct Foundry env vars for fork RPC retries — The prepare-upgrade-env justfile recipe was exporting `FORK_RETRIES` and `FORK_BACKOFF`, but Foundry expects `FOUNDRY_FORK_RETRIES` and `FOUNDRY_FORK_RETRY_BACKOFF`. The old names were silently ignored, meaning fork tests had zero retry protection against RPC 429 rate limit errors. This was the root cause of the contracts-bedrock-tests-upgrade CI flakes on develop.

  ## How the interface mismatch got merged

  PR #19192 introduced `PolicyEngineStaking` with a mismatched interface (`_account` vs `account`,
  `effectiveStake_` vs `effectiveStake`, etc.) and all CI jobs reported `pass` with **0-second duration**.
  The 0-second duration indicates the `contracts-bedrock-checks` job was halted early by the
  `check-changed` step before `interfaces-check-no-build` ran.

  The `check-changed` script fetches `pr.base.sha` and `pr.head.sha` from the GitHub API and diffs them.
  The most likely cause is a stale SHA returned by the API (e.g., from a force-push or rebase race on the
  PR branch), producing an empty diff that caused the job to skip. Since `contracts-bedrock-build` has no
  `check-changed` guard, the build ran fine — but the checks job that would have caught the mismatch was
  silently skipped.