### PR TITLE
fix supernode: Initial Block Seal

### DIFF
--- a/op-supernode/supernode/activity/interop/logdb.go
+++ b/op-supernode/supernode/activity/interop/logdb.go
@@ -199,18 +199,28 @@ func (i *Interop) verifyCanAddTimestamp(chainID eth.ChainID, db LogsDB, ts uint6
 
 // processBlockLogs processes the receipts for a block and stores the logs in the database.
 // If isFirstBlock is true, this is the first block being added to the logsDB (at activation timestamp),
-// and we treat it as genesis by using an empty parent block. This allows the logsDB to start at any
-// block number, not just genesis.
+// and we first seal a "virtual parent" block so that logs have a sealed block to reference.
+// This allows the logsDB to start at any block number, not just genesis.
 func (i *Interop) processBlockLogs(db LogsDB, blockInfo eth.BlockInfo, receipts gethTypes.Receipts, isFirstBlock bool) error {
 	blockNum := blockInfo.NumberU64()
 	blockID := eth.BlockID{Hash: blockInfo.Hash(), Number: blockNum}
 	parentHash := blockInfo.ParentHash()
 
-	// For the first block in the logsDB (activation block), use empty parent to treat it as genesis.
-	// This allows OpenBlock to work correctly even when we start at a non-genesis block.
 	parentBlock := eth.BlockID{Hash: parentHash, Number: blockNum - 1}
 	sealParentHash := parentHash
-	if blockNum == 0 || isFirstBlock {
+
+	// For the first block in the logsDB (activation block), we need to first seal
+	// a virtual parent block so that logs have a sealed block to reference.
+	// When the DB is empty, SealBlock allows any block to be added without parent validation.
+	if isFirstBlock && blockNum > 0 {
+		// Seal the parent as a "virtual genesis" - this works because DB is empty
+		if err := db.SealBlock(common.Hash{}, parentBlock, blockInfo.Time()); err != nil {
+			return fmt.Errorf("failed to seal virtual parent for first block: %w", err)
+		}
+		// parentBlock stays as-is (references the now-sealed parent)
+		// sealParentHash stays as parentHash
+	} else if blockNum == 0 {
+		// Actual genesis block - no parent, no logs allowed
 		parentBlock = eth.BlockID{}
 		sealParentHash = common.Hash{}
 	}
@@ -230,7 +240,6 @@ func (i *Interop) processBlockLogs(db LogsDB, blockInfo eth.BlockInfo, receipts 
 		}
 	}
 
-	// Seal the block - use empty parent hash for first block
 	if err := db.SealBlock(sealParentHash, blockID, blockInfo.Time()); err != nil {
 		return fmt.Errorf("failed to seal block: %w", err)
 	}

--- a/op-supernode/supernode/activity/interop/logdb_test.go
+++ b/op-supernode/supernode/activity/interop/logdb_test.go
@@ -557,13 +557,13 @@ func TestLoadLogs_ParentHashMismatch(t *testing.T) {
 // =============================================================================
 
 type mockLogsDB struct {
-	latestBlock   eth.BlockID
-	hasBlocks     bool
-	seal          suptypes.BlockSeal
-	findSealErr   error
-	addLogErr     error
-	sealBlockErr  error
-	addLogCalls   int
+	latestBlock    eth.BlockID
+	hasBlocks      bool
+	seal           suptypes.BlockSeal
+	findSealErr    error
+	addLogErr      error
+	sealBlockErr   error
+	addLogCalls    int
 	sealBlockCalls []*sealBlockCall // Track all SealBlock calls
 
 	firstSealedBlock    suptypes.BlockSeal

--- a/op-supernode/supernode/activity/interop/logdb_test.go
+++ b/op-supernode/supernode/activity/interop/logdb_test.go
@@ -284,10 +284,10 @@ func TestProcessBlockLogs(t *testing.T) {
 		err := interop.processBlockLogs(db, blockInfo, types.Receipts{}, false)
 
 		require.NoError(t, err)
-		require.NotNil(t, db.sealBlockCall)
-		require.Equal(t, common.Hash{0x01}, db.sealBlockCall.parentHash)
-		require.Equal(t, uint64(100), db.sealBlockCall.block.Number)
-		require.Equal(t, uint64(1000), db.sealBlockCall.timestamp)
+		require.Len(t, db.sealBlockCalls, 1)
+		require.Equal(t, common.Hash{0x01}, db.sealBlockCalls[0].parentHash)
+		require.Equal(t, uint64(100), db.sealBlockCalls[0].block.Number)
+		require.Equal(t, uint64(1000), db.sealBlockCalls[0].timestamp)
 		require.Equal(t, 0, db.addLogCalls)
 	})
 
@@ -321,7 +321,7 @@ func TestProcessBlockLogs(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Equal(t, 3, db.addLogCalls)
-		require.NotNil(t, db.sealBlockCall)
+		require.Len(t, db.sealBlockCalls, 1)
 	})
 
 	t.Run("genesis block handled correctly", func(t *testing.T) {
@@ -339,11 +339,11 @@ func TestProcessBlockLogs(t *testing.T) {
 		err := interop.processBlockLogs(db, blockInfo, types.Receipts{}, true)
 
 		require.NoError(t, err)
-		require.NotNil(t, db.sealBlockCall)
-		require.Equal(t, uint64(0), db.sealBlockCall.block.Number)
+		require.Len(t, db.sealBlockCalls, 1)
+		require.Equal(t, uint64(0), db.sealBlockCalls[0].block.Number)
 	})
 
-	t.Run("first block at non-zero number uses empty parent", func(t *testing.T) {
+	t.Run("first block at non-zero number seals virtual parent first", func(t *testing.T) {
 		t.Parallel()
 
 		interop := &Interop{log: gethlog.New()}
@@ -355,14 +355,95 @@ func TestProcessBlockLogs(t *testing.T) {
 			timestamp:  1000,
 		}
 
-		// isFirstBlock=true should use empty parent for both AddLog and SealBlock
-		// This allows the logsDB to treat this block as its genesis
+		// isFirstBlock=true should first seal a "virtual parent" block,
+		// then seal the actual block. This allows logs to reference a sealed parent.
 		err := interop.processBlockLogs(db, blockInfo, types.Receipts{}, true)
 
 		require.NoError(t, err)
-		require.NotNil(t, db.sealBlockCall)
-		// Both AddLog and SealBlock should use empty parent for first block
-		require.Equal(t, common.Hash{}, db.sealBlockCall.parentHash)
+		require.Len(t, db.sealBlockCalls, 2)
+
+		// First call: seal the virtual parent (block 9) with empty parent hash
+		require.Equal(t, common.Hash{}, db.sealBlockCalls[0].parentHash)
+		require.Equal(t, uint64(9), db.sealBlockCalls[0].block.Number)
+		require.Equal(t, common.Hash{0x01}, db.sealBlockCalls[0].block.Hash)
+
+		// Second call: seal the actual block (block 10) with real parent hash
+		require.Equal(t, common.Hash{0x01}, db.sealBlockCalls[1].parentHash)
+		require.Equal(t, uint64(10), db.sealBlockCalls[1].block.Number)
+		require.Equal(t, common.Hash{0x02}, db.sealBlockCalls[1].block.Hash)
+	})
+
+	t.Run("first block with logs succeeds", func(t *testing.T) {
+		t.Parallel()
+
+		interop := &Interop{log: gethlog.New()}
+		db := &mockLogsDB{}
+		blockInfo := &testBlockInfo{
+			hash:       common.Hash{0x02},
+			parentHash: common.Hash{0x01},
+			number:     100,
+			timestamp:  1000,
+		}
+
+		receipts := types.Receipts{
+			&types.Receipt{
+				Logs: []*types.Log{
+					{Address: common.Address{0xAA}, Data: []byte{0x01}},
+				},
+			},
+		}
+
+		// This is the key test: first block with logs should work because
+		// we seal the virtual parent first, allowing AddLog to reference it
+		err := interop.processBlockLogs(db, blockInfo, receipts, true)
+
+		require.NoError(t, err)
+		require.Len(t, db.sealBlockCalls, 2) // virtual parent + actual block
+		require.Equal(t, 1, db.addLogCalls)
+	})
+
+	t.Run("integration: first block with logs against real DB", func(t *testing.T) {
+		t.Parallel()
+
+		dataDir := t.TempDir()
+		chainID := eth.ChainIDFromUInt64(10)
+
+		db, err := openLogsDB(gethlog.New(), chainID, dataDir)
+		require.NoError(t, err)
+		defer db.Close()
+
+		interop := &Interop{log: gethlog.New()}
+		blockInfo := &testBlockInfo{
+			hash:       common.Hash{0x02},
+			parentHash: common.Hash{0x01},
+			number:     100,
+			timestamp:  1000,
+		}
+		receipts := types.Receipts{
+			&types.Receipt{
+				Logs: []*types.Log{
+					{Address: common.Address{0xAA}, Data: []byte{0x01}},
+					{Address: common.Address{0xBB}, Data: []byte{0x02}},
+				},
+			},
+		}
+
+		// This is the key integration test: first block with logs must work
+		// against the real logs.DB, not just the mock.
+		err = interop.processBlockLogs(db, blockInfo, receipts, true)
+		require.NoError(t, err)
+
+		// Verify data is correctly in the DB
+		latestBlock, ok := db.LatestSealedBlock()
+		require.True(t, ok)
+		require.Equal(t, uint64(100), latestBlock.Number)
+		require.Equal(t, common.Hash{0x02}, latestBlock.Hash)
+
+		// Verify we can open the block and see the logs
+		ref, logCount, _, err := db.OpenBlock(100)
+		require.NoError(t, err)
+		require.Equal(t, uint32(2), logCount)
+		require.Equal(t, common.Hash{0x01}, ref.ParentHash)
 	})
 
 	t.Run("AddLog error propagated", func(t *testing.T) {
@@ -483,7 +564,7 @@ type mockLogsDB struct {
 	addLogErr     error
 	sealBlockErr  error
 	addLogCalls   int
-	sealBlockCall *sealBlockCall
+	sealBlockCalls []*sealBlockCall // Track all SealBlock calls
 
 	firstSealedBlock    suptypes.BlockSeal
 	firstSealedBlockErr error
@@ -541,11 +622,11 @@ func (m *mockLogsDB) AddLog(logHash common.Hash, parentBlock eth.BlockID, logIdx
 }
 
 func (m *mockLogsDB) SealBlock(parentHash common.Hash, block eth.BlockID, timestamp uint64) error {
-	m.sealBlockCall = &sealBlockCall{
+	m.sealBlockCalls = append(m.sealBlockCalls, &sealBlockCall{
 		parentHash: parentHash,
 		block:      block,
 		timestamp:  timestamp,
-	}
+	})
 	return m.sealBlockErr
 }
 


### PR DESCRIPTION
Inserts an initial BlockSeal to allow the first block to build from the database without having to void its ParentHash (which was causing a failure to run in production).

Includes an integration test which shows (and resolves) the issue.