### PR TITLE
fix(ctb): normalize underscore prefixes in ABI param names for interface check

### DIFF
--- a/packages/contracts-bedrock/scripts/checks/interfaces/main.go
+++ b/packages/contracts-bedrock/scripts/checks/interfaces/main.go
@@ -269,9 +269,6 @@ func normalizeABIItem(item map[string]interface{}) {
 			if key == "internalType" {
 				item[key] = normalizeInternalType(v)
 			}
-			if key == "name" && v != "__constructor__" {
-				item[key] = strings.Trim(v, "_")
-			}
 		case map[string]interface{}:
 			normalizeABIItem(v)
 		case []interface{}:
@@ -280,6 +277,11 @@ func normalizeABIItem(item map[string]interface{}) {
 					normalizeABIItem(elemMap)
 				}
 			}
+			// Trim underscores from parameter names in inputs/outputs only,
+			// not from top-level function/event names.
+			if key == "inputs" || key == "outputs" {
+				normalizeParamNames(v)
+			}
 		}
 	}
 
@@ -287,6 +289,19 @@ func normalizeABIItem(item map[string]interface{}) {
 		item["type"] = "constructor"
 		delete(item, "name")
 		delete(item, "outputs")
+	}
+}
+
+// normalizeParamNames trims leading/trailing underscores from parameter names
+// in an ABI inputs/outputs array. This ensures that naming conventions like
+// _account vs account or value_ vs value don't cause false ABI mismatches.
+func normalizeParamNames(params []interface{}) {
+	for _, param := range params {
+		if paramMap, ok := param.(map[string]interface{}); ok {
+			if name, ok := paramMap["name"].(string); ok {
+				paramMap["name"] = strings.Trim(name, "_")
+			}
+		}
 	}
 }
 

--- a/packages/contracts-bedrock/scripts/checks/interfaces/main.go
+++ b/packages/contracts-bedrock/scripts/checks/interfaces/main.go
@@ -269,6 +269,9 @@ func normalizeABIItem(item map[string]interface{}) {
 			if key == "internalType" {
 				item[key] = normalizeInternalType(v)
 			}
+			if key == "name" && v != "__constructor__" {
+				item[key] = strings.Trim(v, "_")
+			}
 		case map[string]interface{}:
 			normalizeABIItem(v)
 		case []interface{}:

--- a/packages/contracts-bedrock/scripts/checks/interfaces/main_test.go
+++ b/packages/contracts-bedrock/scripts/checks/interfaces/main_test.go
@@ -124,6 +124,21 @@ func TestNormalizeABI(t *testing.T) {
 			abi:  `[{"inputs":[{"internalType":"contract Test1","name":"test1","type":"address"},{"internalType":"contract ITest2","name":"test2","type":"address"}],"type":"function"}]`,
 			want: `[{"inputs":[{"internalType":"contract ITest1","name":"test1","type":"address"},{"internalType":"contract ITest2","name":"test2","type":"address"}],"type":"function"},{"inputs":[],"stateMutability":"nonpayable","type":"constructor"}]`,
 		},
+		{
+			name: "Trim leading underscores from input names",
+			abi:  `[{"inputs":[{"name":"_account","type":"address"}],"outputs":[],"type":"function","name":"test"}]`,
+			want: `[{"inputs":[{"name":"account","type":"address"}],"outputs":[],"type":"function","name":"test"},{"inputs":[],"stateMutability":"nonpayable","type":"constructor"}]`,
+		},
+		{
+			name: "Trim trailing underscores from output names",
+			abi:  `[{"inputs":[],"outputs":[{"name":"value_","type":"uint128"}],"type":"function","name":"test"}]`,
+			want: `[{"inputs":[],"outputs":[{"name":"value","type":"uint128"}],"type":"function","name":"test"},{"inputs":[],"stateMutability":"nonpayable","type":"constructor"}]`,
+		},
+		{
+			name: "Preserve __constructor__ name",
+			abi:  `[{"type":"function","name":"__constructor__","inputs":[],"stateMutability":"nonpayable","outputs":[]}]`,
+			want: `[{"type":"constructor","inputs":[],"stateMutability":"nonpayable"}]`,
+		},
 	}
 
 	for _, tt := range tests {
@@ -197,6 +212,48 @@ func TestCompareABIs(t *testing.T) {
 			}
 			if got != tt.want {
 				t.Errorf("compareABIs() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeAndCompareABIs(t *testing.T) {
+	tests := []struct {
+		name string
+		abi1 string
+		abi2 string
+		want bool
+	}{
+		{
+			name: "Underscore-prefixed input names match after normalization",
+			abi1: `[{"type":"function","name":"test","inputs":[{"name":"account","type":"address"}],"outputs":[]}]`,
+			abi2: `[{"type":"function","name":"test","inputs":[{"name":"_account","type":"address"}],"outputs":[]}]`,
+			want: true,
+		},
+		{
+			name: "Underscore-suffixed output names match after normalization",
+			abi1: `[{"type":"function","name":"test","inputs":[],"outputs":[{"name":"effectiveStake","type":"uint128"},{"name":"lastUpdate","type":"uint128"}]}]`,
+			abi2: `[{"type":"function","name":"test","inputs":[],"outputs":[{"name":"effectiveStake_","type":"uint128"},{"name":"lastUpdate_","type":"uint128"}]}]`,
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			norm1, err := normalizeABI(json.RawMessage(tt.abi1))
+			if err != nil {
+				t.Fatalf("normalizeABI(abi1) error = %v", err)
+			}
+			norm2, err := normalizeABI(json.RawMessage(tt.abi2))
+			if err != nil {
+				t.Fatalf("normalizeABI(abi2) error = %v", err)
+			}
+			got, err := compareABIs(norm1, norm2)
+			if err != nil {
+				t.Fatalf("compareABIs() error = %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("normalizeABI+compareABIs() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/packages/contracts-bedrock/scripts/checks/spacers/main.go
+++ b/packages/contracts-bedrock/scripts/checks/spacers/main.go
@@ -115,7 +115,7 @@ func processFile(path string) (*common.Void, []error) {
 func main() {
 	if _, err := common.ProcessFilesGlob(
 		[]string{"forge-artifacts/**/*.json"},
-		[]string{"forge-artifacts/**/CrossDomainMessengerLegacySpacer{0,1}.json"},
+		[]string{"forge-artifacts/**/CrossDomainMessengerLegacySpacer{0,1}*.json"},
 		processFile,
 	); err != nil {
 		fmt.Printf("Error: %v\n", err)

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -76,15 +76,15 @@
     "sourceCodeHash": "0xdc50fe7643d26950527dac75d69ddbdebf0b5c4f061fe2938eada849e179a217"
   },
   "src/L2/GasPriceOracle.sol:GasPriceOracle": {
-    "initCodeHash": "0xf72c23d9c3775afd7b645fde429d09800622d329116feb5ff9829634655123ca",
+    "initCodeHash": "0x5f726202df4824f90c7745856af504e3a96ced98c58e4cb4541729103eb10ab1",
     "sourceCodeHash": "0xb4d1bf3669ba87bbeaf4373145c7e1490478c4a05ba4838a524aa6f0ce7348a6"
   },
   "src/L2/L1Block.sol:L1Block": {
     "initCodeHash": "0xa6dd2668435fc510161fb2085e2fd77ef0cd6735d3e96a3f839b10c064f00317",
-    "sourceCodeHash": "0x6551be49dcb0e2a80e9c1042e7964dc41f70bcb08f9ceefd0c0156de9c14cf2d"
+    "sourceCodeHash": "0x3113cfebc9c815084cabc8fe617ada7b227118bb01f9dd82a405509c608d336f"
   },
   "src/L2/L1BlockCGT.sol:L1BlockCGT": {
-    "initCodeHash": "0x7eea0c398263b9f75b3a09039526e603f0cd5450f9d6056e6400ca215af042d5",
+    "initCodeHash": "0x8dffbf6c28be1420aae1d68ff1cd93ea0a5e8b2ae5d7fbad62cc36d6fa81a5e7",
     "sourceCodeHash": "0x97b84b125df97ca4ad6fb1bd5c05998115970f37e71d7bccb5b902144fb8f8de"
   },
   "src/L2/L1FeeVault.sol:L1FeeVault": {
@@ -96,15 +96,15 @@
     "sourceCodeHash": "0x7e438cbbe9a8248887b8c21f68c811f90a5cae4902cbbf7b0a1f6cd644dc42d9"
   },
   "src/L2/L2ContractsManager.sol:L2ContractsManager": {
-    "initCodeHash": "0xc6953fefa5142a37061fc6e96d0ec251a8ff8bcc2d09e8fdeb023e8677ff17c7",
-    "sourceCodeHash": "0xa4fba8f6dd5f7e1cfcba63ca8b9d0fbe621d1fe33aeb6147a185045fcded7c14"
+    "initCodeHash": "0x064e7fc27e27aa126cb3552f97b81fedda981003b1c3f25e0a983e75e4ddbd61",
+    "sourceCodeHash": "0x5d7dbdf6ac49af6ecdd23caac307a23ce5013e3a0ee2c9d319865b8610616a04"
   },
   "src/L2/L2CrossDomainMessenger.sol:L2CrossDomainMessenger": {
-    "initCodeHash": "0x3dcab7214430fdc9e8cf8a327ef0ff895a3d292613c17a03fec78fa7e93df820",
-    "sourceCodeHash": "0x12ea125038b87e259a0d203e119faa6e9726ab2bdbc30430f820ccd48fe87e14"
+    "initCodeHash": "0xb62e9cda20d4255c918a167aece9bd88ddbf204e2e519ba00b005a5b7a210b74",
+    "sourceCodeHash": "0xb59fd3fda52aa7290dba032615b81ed219fe2d66e17b8f4b383b36548225ac89"
   },
   "src/L2/L2ERC721Bridge.sol:L2ERC721Bridge": {
-    "initCodeHash": "0x863f0f5b410983f3e51cd97c60a3a42915141b7452864d0e176571d640002b81",
+    "initCodeHash": "0x1c2c08124badbabb78b848cca0bd8c44bb315fabce1dd224ae928f6b8e074a22",
     "sourceCodeHash": "0xc05bfcfadfd09a56cfea68e7c1853faa36d114d9a54cd307348be143e442c35a"
   },
   "src/L2/L2ProxyAdmin.sol:L2ProxyAdmin": {
@@ -132,8 +132,8 @@
     "sourceCodeHash": "0xbea4229c5c6988243dbc7cf5a086ddd412fe1f2903b8e20d56699fec8de0c2c9"
   },
   "src/L2/LiquidityController.sol:LiquidityController": {
-    "initCodeHash": "0xe492fe75e3c0a8a80ede7b50271263c42a2c7616a101861e892dba76f9771e34",
-    "sourceCodeHash": "0xef9cf289b4bf63808b6822fc2c588fe516abbbfb90479553e7d54d43de344e50"
+    "initCodeHash": "0xb41fb5ed5d60d9c0fcdc21e222567a48632544b99ef0a298735a56d15e06f327",
+    "sourceCodeHash": "0xdb07f5c447dc77959b1f662b28b76be91e422a5099ddcbe6e9cda21fa2743a24"
   },
   "src/L2/NativeAssetLiquidity.sol:NativeAssetLiquidity": {
     "initCodeHash": "0x04b176e5d484e54173a5644c833117c5fd9f055dce8678be9ec4cf07c0f01f00",
@@ -148,8 +148,8 @@
     "sourceCodeHash": "0xd93a8d5de6fd89ebf503976511065f0c2414814affdb908f26a867ffdd0f9fbe"
   },
   "src/L2/OptimismMintableERC721Factory.sol:OptimismMintableERC721Factory": {
-    "initCodeHash": "0xa692a3fc4a71eb3381a59d1ab655bbc02e8b507add7c3f560ee24b001d88ae6e",
-    "sourceCodeHash": "0xb0be3deac32956251adb37d3ca61f619ca4348a1355a41c856a3a95adde0e4ff"
+    "initCodeHash": "0xd3292dea542cfaa849d2187f3fe30afc7a1afa0da3a78585362585a13d4f75cc",
+    "sourceCodeHash": "0xd1857a59ef15214abc770ce54226db1e9b1205925fff920523911203978d93a5"
   },
   "src/L2/OptimismSuperchainERC20.sol:OptimismSuperchainERC20": {
     "initCodeHash": "0x1ad4b7c19d10f80559bad15063ac1fd420f36d76853eb6d846b0acd52fb93acb",
@@ -260,12 +260,12 @@
     "sourceCodeHash": "0xd6683fe9be4019d34249ada5a4de3e597f1bd9cd473a89f6eff8f749a0b0e978"
   },
   "src/universal/OptimismMintableERC20.sol:OptimismMintableERC20": {
-    "initCodeHash": "0xa26cd5b88cb1d4e5cef0422b98ff4c33a3bbfa33479ebd8632d095bb2c633ca7",
+    "initCodeHash": "0x3c85eed0d017dca8eda6396aa842ddc12492587b061e8c756a8d32c4610a9658",
     "sourceCodeHash": "0x7023665d461f173417d932b55010b8f6c34f2bbaf56cfe4e1b15862c08cbcaac"
   },
   "src/universal/OptimismMintableERC20Factory.sol:OptimismMintableERC20Factory": {
-    "initCodeHash": "0x747baf403205b900e1144038f2b807c84059229aedda8c91936798e1403eda39",
-    "sourceCodeHash": "0xf71e16aaad1ec2459040ab8c93b7188b2c04c671c21b4d43fba75cab80ed1b21"
+    "initCodeHash": "0x75f5f8dad139fce79a2fed9c80bf653184c73fb7dc319715cdd07392f32b007a",
+    "sourceCodeHash": "0xd2b644d1b13ce0aa6520412706e3c5aa7b30ef98ef7464ce6bc8e073879cd55b"
   },
   "src/universal/StorageSetter.sol:StorageSetter": {
     "initCodeHash": "0x1fd4b84add5c5ed80205cea0bbca9115e98d0efb416d9cedc12ce0cff9919bda",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -84,7 +84,7 @@
     "sourceCodeHash": "0x6551be49dcb0e2a80e9c1042e7964dc41f70bcb08f9ceefd0c0156de9c14cf2d"
   },
   "src/L2/L1BlockCGT.sol:L1BlockCGT": {
-    "initCodeHash": "0x98094c7af5b4a370cdf5cb5f1501f4c4e7f51e38379c9791a865f34232a75d37",
+    "initCodeHash": "0x7eea0c398263b9f75b3a09039526e603f0cd5450f9d6056e6400ca215af042d5",
     "sourceCodeHash": "0x97b84b125df97ca4ad6fb1bd5c05998115970f37e71d7bccb5b902144fb8f8de"
   },
   "src/L2/L1FeeVault.sol:L1FeeVault": {
@@ -100,7 +100,7 @@
     "sourceCodeHash": "0xa4fba8f6dd5f7e1cfcba63ca8b9d0fbe621d1fe33aeb6147a185045fcded7c14"
   },
   "src/L2/L2CrossDomainMessenger.sol:L2CrossDomainMessenger": {
-    "initCodeHash": "0xe160be403df12709c371c33195d1b9c3b5e9499e902e86bdabc8eed749c3fd61",
+    "initCodeHash": "0x3dcab7214430fdc9e8cf8a327ef0ff895a3d292613c17a03fec78fa7e93df820",
     "sourceCodeHash": "0x12ea125038b87e259a0d203e119faa6e9726ab2bdbc30430f820ccd48fe87e14"
   },
   "src/L2/L2ERC721Bridge.sol:L2ERC721Bridge": {
@@ -260,7 +260,7 @@
     "sourceCodeHash": "0xd6683fe9be4019d34249ada5a4de3e597f1bd9cd473a89f6eff8f749a0b0e978"
   },
   "src/universal/OptimismMintableERC20.sol:OptimismMintableERC20": {
-    "initCodeHash": "0x3c85eed0d017dca8eda6396aa842ddc12492587b061e8c756a8d32c4610a9658",
+    "initCodeHash": "0xa26cd5b88cb1d4e5cef0422b98ff4c33a3bbfa33479ebd8632d095bb2c633ca7",
     "sourceCodeHash": "0x7023665d461f173417d932b55010b8f6c34f2bbaf56cfe4e1b15862c08cbcaac"
   },
   "src/universal/OptimismMintableERC20Factory.sol:OptimismMintableERC20Factory": {

--- a/packages/contracts-bedrock/src/L2/L1Block.sol
+++ b/packages/contracts-bedrock/src/L2/L1Block.sol
@@ -64,9 +64,9 @@ contract L1Block is ISemver {
     /// @notice The DA footprint gas scalar.
     uint16 public daFootprintGasScalar;
 
-    /// @custom:semver 1.8.0
+    /// @custom:semver 1.8.1
     function version() public pure virtual returns (string memory) {
-        return "1.8.0";
+        return "1.8.1";
     }
 
     /// @notice Returns the gas paying token, its decimals, name and symbol.

--- a/packages/contracts-bedrock/src/L2/L2ContractsManager.sol
+++ b/packages/contracts-bedrock/src/L2/L2ContractsManager.sol
@@ -28,8 +28,8 @@ contract L2ContractsManager is ISemver {
     error L2ContractsManager_OnlyDelegatecall();
 
     /// @notice The semantic version of the L2ContractsManager contract.
-    /// @custom:semver 1.0.0
-    string public constant version = "1.0.0";
+    /// @custom:semver 1.0.1
+    string public constant version = "1.0.1";
 
     /// @notice The address of this contract. Used to enforce that the upgrade function is only
     ///         called via DELEGATECALL.

--- a/packages/contracts-bedrock/src/L2/L2CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/src/L2/L2CrossDomainMessenger.sol
@@ -19,8 +19,8 @@ import { IL2ToL1MessagePasser } from "interfaces/L2/IL2ToL1MessagePasser.sol";
 ///         L2 on the L2 side. Users are generally encouraged to use this contract instead of lower
 ///         level message passing contracts.
 contract L2CrossDomainMessenger is CrossDomainMessenger, ISemver {
-    /// @custom:semver 2.2.0
-    string public constant version = "2.2.0";
+    /// @custom:semver 2.2.1
+    string public constant version = "2.2.1";
 
     /// @notice Constructs the L2CrossDomainMessenger contract.
     constructor() {

--- a/packages/contracts-bedrock/src/L2/LiquidityController.sol
+++ b/packages/contracts-bedrock/src/L2/LiquidityController.sol
@@ -42,8 +42,8 @@ contract LiquidityController is ISemver, Initializable, OwnableUpgradeable {
     error LiquidityController_Unauthorized();
 
     /// @notice Semantic version.
-    /// @custom:semver 1.0.0
-    string public constant version = "1.0.0";
+    /// @custom:semver 1.0.1
+    string public constant version = "1.0.1";
 
     /// @notice Mapping of addresses authorized to control liquidity operations
     mapping(address => bool) public minters;

--- a/packages/contracts-bedrock/src/L2/OptimismMintableERC721Factory.sol
+++ b/packages/contracts-bedrock/src/L2/OptimismMintableERC721Factory.sol
@@ -30,8 +30,8 @@ contract OptimismMintableERC721Factory is ISemver {
     event OptimismMintableERC721Created(address indexed localToken, address indexed remoteToken, address deployer);
 
     /// @notice Semantic version.
-    /// @custom:semver 1.4.2
-    string public constant version = "1.4.2";
+    /// @custom:semver 1.4.3
+    string public constant version = "1.4.3";
 
     /// @notice The semver MUST be bumped any time that there is a change in
     ///         the OptimismMintableERC721 token contract since this contract

--- a/packages/contracts-bedrock/src/universal/OptimismMintableERC20Factory.sol
+++ b/packages/contracts-bedrock/src/universal/OptimismMintableERC20Factory.sol
@@ -51,8 +51,8 @@ contract OptimismMintableERC20Factory is ISemver, Initializable, IOptimismERC20F
     ///         the OptimismMintableERC20 token contract since this contract
     ///         is responsible for deploying OptimismMintableERC20 contracts.
     /// @notice Semantic version.
-    /// @custom:semver 1.10.2
-    string public constant version = "1.10.2";
+    /// @custom:semver 1.10.3
+    string public constant version = "1.10.3";
 
     /// @notice Constructs the OptimismMintableERC20Factory contract.
     constructor() {


### PR DESCRIPTION
The interface snapshot check was treating `_account` and `account` (and `value_` vs `value`) as different parameters, causing false mismatches between contracts and their interfaces. Trim leading/trailing underscores from parameter names during ABI normalization so naming conventions don't affect comparison.

This PR also fixes the failing `validate-spacers` check in CCI. The exclude glob CrossDomainMessengerLegacySpacer didn't cover .dispute.json variants, causing false failures. These spacer contract have correct slot positions in the deployed inheritance chain but are off-by-one when compiled in isolation (without Initializable).