### PR TITLE
hotfix: limit event drain to avoid sequencer starvation during derivation

### DIFF
--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -2,7 +2,9 @@ package driver
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -349,7 +351,16 @@ func (s *Driver) eventLoop() {
 			s.metrics.RecordPipelineReset()
 			close(respCh)
 		case <-s.drain.Await():
-			if err := s.drain.Drain(); err != nil {
+			const maxDrainEvents = 20
+			drained := 0
+			err := s.drain.DrainUntil(func(ev event.Event) bool {
+				drained++
+				return drained >= maxDrainEvents
+			}, true)
+			if drained >= maxDrainEvents {
+				s.log.Info("event drain capped to avoid starving sequencer", "cap", maxDrainEvents)
+			}
+			if err != nil && !errors.Is(err, io.EOF) {
 				if s.driverCtx.Err() != nil {
 					return
 				} else {

--- a/op-node/rollup/driver/interfaces.go
+++ b/op-node/rollup/driver/interfaces.go
@@ -127,5 +127,6 @@ type SequencerStateListener interface {
 
 type Drain interface {
 	Drain() error
+	DrainUntil(fn func(ev event.Event) bool, excl bool) error
 	Await() <-chan struct{}
 }

--- a/op-node/rollup/engine/build_start.go
+++ b/op-node/rollup/engine/build_start.go
@@ -19,8 +19,21 @@ func (ev BuildStartEvent) String() string {
 }
 
 func (e *EngineController) onBuildStart(ctx context.Context, ev BuildStartEvent) {
+	eventReceivedTime := time.Now()
 	rpcCtx, cancel := context.WithTimeout(e.ctx, buildStartTimeout)
 	defer cancel()
+
+	// Calculate slot delay: how late are we compared to when we should start building?
+	// We should start building at (block_timestamp - block_time)
+	// slot_delay_ms = actual_start - expected_start
+	// Positive = late, Negative = early, ~0 = on time
+	blockTimestamp := time.Unix(int64(ev.Attributes.Attributes.Timestamp), 0)
+	expectedStart := blockTimestamp.Add(-time.Duration(e.rollupCfg.BlockTime) * time.Second)
+	slotDelayMs := eventReceivedTime.Sub(expectedStart).Milliseconds()
+
+	e.log.Info("BuildStartEvent received",
+		"block_number", ev.Attributes.Parent.Number+1,
+		"slot_delay_ms", slotDelayMs)
 
 	if ev.Attributes.DerivedFrom != (eth.L1BlockRef{}) &&
 		e.pendingSafeHead.Hash != ev.Attributes.Parent.Hash {


### PR DESCRIPTION
Hotfix for https://github.com/ethereum-optimism/optimism/issues/19263 (doesn't fix it)

This hotfix caps how many events the driver drains per wake‑up. Under heavy derivation load, the driver would drain the entire queue before checking the sequencer timer, which delayed BuildStartEvent. We now drain a bounded number of events per cycle to ensure the driver can service sequencer actions promptly.

Hardcoded to a cap of draining 20 events.

Tested locally via builder-playground.