### PR TITLE
supernode: store full OutputV0 in denylist

### DIFF
--- a/op-supernode/supernode/activity/interop/algo_test.go
+++ b/op-supernode/supernode/activity/interop/algo_test.go
@@ -883,6 +883,9 @@ func (m *algoMockChain) OptimisticAt(ctx context.Context, ts uint64) (eth.BlockI
 func (m *algoMockChain) OutputRootAtL2BlockNumber(ctx context.Context, l2BlockNum uint64) (eth.Bytes32, error) {
 	return eth.Bytes32{}, nil
 }
+func (m *algoMockChain) OutputV0AtL2BlockNumber(ctx context.Context, l2BlockNum uint64) (*eth.OutputV0, error) {
+	return &eth.OutputV0{}, nil
+}
 func (m *algoMockChain) OptimisticOutputAtTimestamp(ctx context.Context, ts uint64) (*eth.OutputResponse, error) {
 	return nil, nil
 }
@@ -896,7 +899,7 @@ func (m *algoMockChain) RewindEngine(ctx context.Context, timestamp uint64, inva
 	return nil
 }
 func (m *algoMockChain) BlockTime() uint64 { return 1 }
-func (m *algoMockChain) InvalidateBlock(ctx context.Context, height uint64, payloadHash common.Hash) (bool, error) {
+func (m *algoMockChain) InvalidateBlock(ctx context.Context, height uint64, payloadHash common.Hash, output *eth.OutputV0) (bool, error) {
 	return false, nil
 }
 func (m *algoMockChain) IsDenied(height uint64, payloadHash common.Hash) (bool, error) {

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -337,7 +337,14 @@ func (i *Interop) invalidateBlock(chainID eth.ChainID, blockID eth.BlockID) erro
 	if !ok {
 		return fmt.Errorf("chain %s not found", chainID)
 	}
-	_, err := chain.InvalidateBlock(i.ctx, blockID.Number, blockID.Hash)
+
+	// Fetch the full OutputV0 for the invalid block
+	output, err := chain.OutputV0AtL2BlockNumber(i.ctx, blockID.Number)
+	if err != nil {
+		return fmt.Errorf("failed to get output for block %d: %w", blockID.Number, err)
+	}
+
+	_, err = chain.InvalidateBlock(i.ctx, blockID.Number, blockID.Hash, output)
 	return err
 }
 

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -1062,6 +1062,7 @@ type mockChainContainer struct {
 type invalidateBlockCall struct {
 	height      uint64
 	payloadHash common.Hash
+	output      *eth.OutputV0
 }
 
 func newMockChainContainer(id uint64) *mockChainContainer {
@@ -1105,6 +1106,13 @@ func (m *mockChainContainer) OptimisticAt(ctx context.Context, ts uint64) (eth.B
 func (m *mockChainContainer) OutputRootAtL2BlockNumber(ctx context.Context, l2BlockNum uint64) (eth.Bytes32, error) {
 	return eth.Bytes32{}, nil
 }
+func (m *mockChainContainer) OutputV0AtL2BlockNumber(ctx context.Context, l2BlockNum uint64) (*eth.OutputV0, error) {
+	return &eth.OutputV0{
+		StateRoot:                eth.Bytes32{0x01},
+		MessagePasserStorageRoot: eth.Bytes32{0x02},
+		BlockHash:                common.BigToHash(big.NewInt(int64(l2BlockNum))),
+	}, nil
+}
 func (m *mockChainContainer) OptimisticOutputAtTimestamp(ctx context.Context, ts uint64) (*eth.OutputResponse, error) {
 	return nil, nil
 }
@@ -1136,10 +1144,10 @@ func (m *mockChainContainer) RewindEngine(ctx context.Context, timestamp uint64,
 	return nil
 }
 func (m *mockChainContainer) BlockTime() uint64 { return 1 }
-func (m *mockChainContainer) InvalidateBlock(ctx context.Context, height uint64, payloadHash common.Hash) (bool, error) {
+func (m *mockChainContainer) InvalidateBlock(ctx context.Context, height uint64, payloadHash common.Hash, output *eth.OutputV0) (bool, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.invalidateBlockCalls = append(m.invalidateBlockCalls, invalidateBlockCall{height: height, payloadHash: payloadHash})
+	m.invalidateBlockCalls = append(m.invalidateBlockCalls, invalidateBlockCall{height: height, payloadHash: payloadHash, output: output})
 	return m.invalidateBlockRet, m.invalidateBlockErr
 }
 func (m *mockChainContainer) IsDenied(height uint64, payloadHash common.Hash) (bool, error) {

--- a/op-supernode/supernode/activity/interop/logdb_test.go
+++ b/op-supernode/supernode/activity/interop/logdb_test.go
@@ -584,6 +584,9 @@ func (m *statefulMockChainContainer) OptimisticAt(ctx context.Context, ts uint64
 func (m *statefulMockChainContainer) OutputRootAtL2BlockNumber(ctx context.Context, l2BlockNum uint64) (eth.Bytes32, error) {
 	return eth.Bytes32{}, nil
 }
+func (m *statefulMockChainContainer) OutputV0AtL2BlockNumber(ctx context.Context, l2BlockNum uint64) (*eth.OutputV0, error) {
+	return &eth.OutputV0{}, nil
+}
 func (m *statefulMockChainContainer) OptimisticOutputAtTimestamp(ctx context.Context, ts uint64) (*eth.OutputResponse, error) {
 	return nil, nil
 }
@@ -597,7 +600,7 @@ func (m *statefulMockChainContainer) BlockTime() uint64 { return 1 }
 func (m *statefulMockChainContainer) RewindEngine(ctx context.Context, timestamp uint64, invalidatedBlock eth.BlockRef) error {
 	return nil
 }
-func (m *statefulMockChainContainer) InvalidateBlock(ctx context.Context, height uint64, payloadHash common.Hash) (bool, error) {
+func (m *statefulMockChainContainer) InvalidateBlock(ctx context.Context, height uint64, payloadHash common.Hash, output *eth.OutputV0) (bool, error) {
 	return false, nil
 }
 func (m *statefulMockChainContainer) IsDenied(height uint64, payloadHash common.Hash) (bool, error) {

--- a/op-supernode/supernode/activity/superroot/superroot_test.go
+++ b/op-supernode/supernode/activity/superroot/superroot_test.go
@@ -74,6 +74,12 @@ func (m *mockCC) OutputRootAtL2BlockNumber(ctx context.Context, l2BlockNum uint6
 	}
 	return m.output, nil
 }
+func (m *mockCC) OutputV0AtL2BlockNumber(ctx context.Context, l2BlockNum uint64) (*eth.OutputV0, error) {
+	if m.outputErr != nil {
+		return nil, m.outputErr
+	}
+	return &eth.OutputV0{}, nil
+}
 func (m *mockCC) OptimisticOutputAtTimestamp(ctx context.Context, ts uint64) (*eth.OutputResponse, error) {
 	if m.optimisticErr != nil {
 		return nil, m.optimisticErr
@@ -98,7 +104,7 @@ func (m *mockCC) ID() eth.ChainID {
 }
 
 func (m *mockCC) BlockTime() uint64 { return 1 }
-func (m *mockCC) InvalidateBlock(ctx context.Context, height uint64, payloadHash common.Hash) (bool, error) {
+func (m *mockCC) InvalidateBlock(ctx context.Context, height uint64, payloadHash common.Hash, output *eth.OutputV0) (bool, error) {
 	return false, nil
 }
 func (m *mockCC) IsDenied(height uint64, payloadHash common.Hash) (bool, error) {

--- a/op-supernode/supernode/chain_container/chain_container.go
+++ b/op-supernode/supernode/chain_container/chain_container.go
@@ -41,6 +41,7 @@ type ChainContainer interface {
 	VerifiedAt(ctx context.Context, ts uint64) (l2, l1 eth.BlockID, err error)
 	OptimisticAt(ctx context.Context, ts uint64) (l2, l1 eth.BlockID, err error)
 	OutputRootAtL2BlockNumber(ctx context.Context, l2BlockNum uint64) (eth.Bytes32, error)
+	OutputV0AtL2BlockNumber(ctx context.Context, l2BlockNum uint64) (*eth.OutputV0, error)
 	OptimisticOutputAtTimestamp(ctx context.Context, ts uint64) (*eth.OutputResponse, error)
 	// RewindEngine rewinds the engine to the highest block with timestamp less than or equal to the given timestamp.
 	// invalidatedBlock is the block that triggered the rewind and is passed to reset callbacks.
@@ -53,8 +54,9 @@ type ChainContainer interface {
 	BlockTime() uint64
 	// InvalidateBlock adds a block to the deny list and triggers a rewind if the chain
 	// currently uses that block at the specified height.
+	// The output parameter contains the full OutputV0 structure for the invalidated block.
 	// Returns true if a rewind was triggered, false otherwise.
-	InvalidateBlock(ctx context.Context, height uint64, payloadHash common.Hash) (bool, error)
+	InvalidateBlock(ctx context.Context, height uint64, payloadHash common.Hash, output *eth.OutputV0) (bool, error)
 	// IsDenied checks if a block hash is on the deny list at the given height.
 	IsDenied(height uint64, payloadHash common.Hash) (bool, error)
 	// SetResetCallback sets a callback that is invoked when the chain resets.
@@ -351,6 +353,14 @@ func (c *simpleChainContainer) OutputRootAtL2BlockNumber(ctx context.Context, l2
 		return eth.Bytes32{}, err
 	}
 	return eth.OutputRoot(out), nil
+}
+
+// OutputV0AtL2BlockNumber returns the full OutputV0 structure for the specified L2 block number.
+func (c *simpleChainContainer) OutputV0AtL2BlockNumber(ctx context.Context, l2BlockNum uint64) (*eth.OutputV0, error) {
+	if c.engine == nil {
+		return nil, engine_controller.ErrNoEngineClient
+	}
+	return c.engine.OutputV0AtBlockNumber(ctx, l2BlockNum)
 }
 
 // safeDBAtL2 delegates to the virtual node to resolve the earliest L1 at which the L2 became safe.

--- a/op-supernode/supernode/chain_container/invalidation.go
+++ b/op-supernode/supernode/chain_container/invalidation.go
@@ -8,12 +8,15 @@ import (
 	"path/filepath"
 	"sync"
 
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
 	bolt "go.etcd.io/bbolt"
 )
 
 const (
 	denyListDBName = "denylist"
+	// denyListEntrySize is the size of each entry: payloadHash (32) + StateRoot (32) + MessagePasserStorageRoot (32)
+	denyListEntrySize = common.HashLength + 32 + 32 // 96 bytes
 )
 
 // denyListBucketName is the name of the bbolt bucket used to store denied block hashes.
@@ -58,9 +61,10 @@ func heightToKey(height uint64) []byte {
 	return key
 }
 
-// Add adds a payload hash to the deny list at the given block height.
-// Multiple hashes can be denied at the same height.
-func (d *DenyList) Add(height uint64, payloadHash common.Hash) error {
+// Add adds a payload hash and its associated output to the deny list at the given block height.
+// Multiple entries can be denied at the same height.
+// The output contains StateRoot, MessagePasserStorageRoot, and BlockHash (which should match payloadHash).
+func (d *DenyList) Add(height uint64, payloadHash common.Hash, output *eth.OutputV0) error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
@@ -69,24 +73,26 @@ func (d *DenyList) Add(height uint64, payloadHash common.Hash) error {
 	return d.db.Update(func(tx *bolt.Tx) error {
 		b := tx.Bucket(denyListBucketName)
 
-		// Get existing hashes at this height
+		// Get existing entries at this height
 		existing := b.Get(key)
-		var hashes []byte
+		var entries []byte
 		if existing != nil {
 			// Check if hash already exists
-			for i := 0; i+common.HashLength <= len(existing); i += common.HashLength {
+			for i := 0; i+denyListEntrySize <= len(existing); i += denyListEntrySize {
 				if common.BytesToHash(existing[i:i+common.HashLength]) == payloadHash {
 					// Already denied
 					return nil
 				}
 			}
-			hashes = make([]byte, len(existing), len(existing)+common.HashLength)
-			copy(hashes, existing)
+			entries = make([]byte, len(existing), len(existing)+denyListEntrySize)
+			copy(entries, existing)
 		}
 
-		// Append the new hash
-		hashes = append(hashes, payloadHash.Bytes()...)
-		return b.Put(key, hashes)
+		// Append the new entry: payloadHash (32) + StateRoot (32) + MessagePasserStorageRoot (32)
+		entries = append(entries, payloadHash.Bytes()...)
+		entries = append(entries, output.StateRoot[:]...)
+		entries = append(entries, output.MessagePasserStorageRoot[:]...)
+		return b.Put(key, entries)
 	})
 }
 
@@ -105,8 +111,8 @@ func (d *DenyList) Contains(height uint64, payloadHash common.Hash) (bool, error
 			return nil
 		}
 
-		// Search for the hash in the list
-		for i := 0; i+common.HashLength <= len(existing); i += common.HashLength {
+		// Search for the hash in the entries
+		for i := 0; i+denyListEntrySize <= len(existing); i += denyListEntrySize {
 			if common.BytesToHash(existing[i:i+common.HashLength]) == payloadHash {
 				found = true
 				return nil
@@ -133,13 +139,48 @@ func (d *DenyList) GetDeniedHashes(height uint64) ([]common.Hash, error) {
 			return nil
 		}
 
-		for i := 0; i+common.HashLength <= len(existing); i += common.HashLength {
+		for i := 0; i+denyListEntrySize <= len(existing); i += denyListEntrySize {
 			hashes = append(hashes, common.BytesToHash(existing[i:i+common.HashLength]))
 		}
 		return nil
 	})
 
 	return hashes, err
+}
+
+// GetOutput returns the OutputV0 associated with a denied payload hash at the given height.
+// Returns the output, whether it was found, and any error.
+func (d *DenyList) GetOutput(height uint64, payloadHash common.Hash) (*eth.OutputV0, bool, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	key := heightToKey(height)
+	var output *eth.OutputV0
+	var found bool
+
+	err := d.db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket(denyListBucketName)
+		existing := b.Get(key)
+		if existing == nil {
+			return nil
+		}
+
+		// Search for the hash in the entries
+		for i := 0; i+denyListEntrySize <= len(existing); i += denyListEntrySize {
+			if common.BytesToHash(existing[i:i+common.HashLength]) == payloadHash {
+				found = true
+				output = &eth.OutputV0{
+					BlockHash: payloadHash,
+				}
+				copy(output.StateRoot[:], existing[i+common.HashLength:i+common.HashLength+32])
+				copy(output.MessagePasserStorageRoot[:], existing[i+common.HashLength+32:i+denyListEntrySize])
+				return nil
+			}
+		}
+		return nil
+	})
+
+	return output, found, err
 }
 
 // Close closes the database.
@@ -151,7 +192,7 @@ func (d *DenyList) Close() error {
 // currently uses that block at the specified height.
 // Returns true if a rewind was triggered, false otherwise.
 // Note: Genesis block (height=0) cannot be invalidated as there is no prior block to rewind to.
-func (c *simpleChainContainer) InvalidateBlock(ctx context.Context, height uint64, payloadHash common.Hash) (bool, error) {
+func (c *simpleChainContainer) InvalidateBlock(ctx context.Context, height uint64, payloadHash common.Hash, output *eth.OutputV0) (bool, error) {
 	if c.denyList == nil {
 		return false, fmt.Errorf("deny list not initialized")
 	}
@@ -162,13 +203,14 @@ func (c *simpleChainContainer) InvalidateBlock(ctx context.Context, height uint6
 	}
 
 	// Add to deny list first
-	if err := c.denyList.Add(height, payloadHash); err != nil {
+	if err := c.denyList.Add(height, payloadHash, output); err != nil {
 		return false, fmt.Errorf("failed to add block to deny list: %w", err)
 	}
 
 	c.log.Info("added block to deny list",
 		"height", height,
 		"payloadHash", payloadHash,
+		"outputRoot", eth.OutputRoot(output),
 	)
 
 	// Check if the current chain uses this block at this height

--- a/op-supernode/supernode/chain_container/invalidation_test.go
+++ b/op-supernode/supernode/chain_container/invalidation_test.go
@@ -27,7 +27,7 @@ func TestDenyList_AddAndContains(t *testing.T) {
 			name: "single hash at height",
 			setup: func(t *testing.T, dl *DenyList) {
 				hash := common.HexToHash("0x1111111111111111111111111111111111111111111111111111111111111111")
-				require.NoError(t, dl.Add(100, hash))
+				require.NoError(t, dl.Add(100, hash, testOutput(hash)))
 			},
 			check: func(t *testing.T, dl *DenyList) {
 				hash := common.HexToHash("0x1111111111111111111111111111111111111111111111111111111111111111")
@@ -45,7 +45,7 @@ func TestDenyList_AddAndContains(t *testing.T) {
 					common.HexToHash("0xcccc"),
 				}
 				for _, h := range hashes {
-					require.NoError(t, dl.Add(50, h))
+					require.NoError(t, dl.Add(50, h, testOutput(h)))
 				}
 			},
 			check: func(t *testing.T, dl *DenyList) {
@@ -65,7 +65,7 @@ func TestDenyList_AddAndContains(t *testing.T) {
 			name: "hash at wrong height returns false",
 			setup: func(t *testing.T, dl *DenyList) {
 				hash := common.HexToHash("0xdddd")
-				require.NoError(t, dl.Add(10, hash))
+				require.NoError(t, dl.Add(10, hash, testOutput(hash)))
 			},
 			check: func(t *testing.T, dl *DenyList) {
 				hash := common.HexToHash("0xdddd")
@@ -84,9 +84,9 @@ func TestDenyList_AddAndContains(t *testing.T) {
 			name: "duplicate add is idempotent",
 			setup: func(t *testing.T, dl *DenyList) {
 				hash := common.HexToHash("0xeeee")
-				require.NoError(t, dl.Add(200, hash))
-				require.NoError(t, dl.Add(200, hash)) // Add again
-				require.NoError(t, dl.Add(200, hash)) // And again
+				require.NoError(t, dl.Add(200, hash, testOutput(hash)))
+				require.NoError(t, dl.Add(200, hash, testOutput(hash))) // Add again
+				require.NoError(t, dl.Add(200, hash, testOutput(hash))) // And again
 			},
 			check: func(t *testing.T, dl *DenyList) {
 				hash := common.HexToHash("0xeeee")
@@ -136,7 +136,7 @@ func TestDenyList_Persistence(t *testing.T) {
 					{300, common.HexToHash("0x4444")},
 				}
 				for _, h := range hashes {
-					require.NoError(t, dl.Add(h.height, h.hash))
+					require.NoError(t, dl.Add(h.height, h.hash, testOutput(h.hash)))
 				}
 
 				require.NoError(t, dl.Close())
@@ -218,7 +218,7 @@ func TestDenyList_GetDeniedHashes(t *testing.T) {
 			setup: func(t *testing.T, dl *DenyList) {
 				for i := 0; i < 5; i++ {
 					hash := common.BigToHash(common.Big1.Add(common.Big1, common.Big0.SetInt64(int64(i))))
-					require.NoError(t, dl.Add(100, hash))
+					require.NoError(t, dl.Add(100, hash, testOutput(hash)))
 				}
 			},
 			check: func(t *testing.T, dl *DenyList) {
@@ -231,8 +231,8 @@ func TestDenyList_GetDeniedHashes(t *testing.T) {
 			name: "empty for clean height",
 			setup: func(t *testing.T, dl *DenyList) {
 				// Add hashes at other heights
-				require.NoError(t, dl.Add(10, common.HexToHash("0xaaaa")))
-				require.NoError(t, dl.Add(30, common.HexToHash("0xbbbb")))
+				require.NoError(t, dl.Add(10, common.HexToHash("0xaaaa"), testOutput(common.HexToHash("0xaaaa"))))
+				require.NoError(t, dl.Add(30, common.HexToHash("0xbbbb"), testOutput(common.HexToHash("0xbbbb"))))
 			},
 			check: func(t *testing.T, dl *DenyList) {
 				hashes, err := dl.GetDeniedHashes(20)
@@ -244,12 +244,12 @@ func TestDenyList_GetDeniedHashes(t *testing.T) {
 			name: "isolated by height",
 			setup: func(t *testing.T, dl *DenyList) {
 				// Add different hashes at different heights
-				require.NoError(t, dl.Add(10, common.HexToHash("0x1010")))
-				require.NoError(t, dl.Add(10, common.HexToHash("0x1011")))
-				require.NoError(t, dl.Add(20, common.HexToHash("0x2020")))
-				require.NoError(t, dl.Add(20, common.HexToHash("0x2021")))
-				require.NoError(t, dl.Add(20, common.HexToHash("0x2022")))
-				require.NoError(t, dl.Add(30, common.HexToHash("0x3030")))
+				require.NoError(t, dl.Add(10, common.HexToHash("0x1010"), testOutput(common.HexToHash("0x1010"))))
+				require.NoError(t, dl.Add(10, common.HexToHash("0x1011"), testOutput(common.HexToHash("0x1011"))))
+				require.NoError(t, dl.Add(20, common.HexToHash("0x2020"), testOutput(common.HexToHash("0x2020"))))
+				require.NoError(t, dl.Add(20, common.HexToHash("0x2021"), testOutput(common.HexToHash("0x2021"))))
+				require.NoError(t, dl.Add(20, common.HexToHash("0x2022"), testOutput(common.HexToHash("0x2022"))))
+				require.NoError(t, dl.Add(30, common.HexToHash("0x3030"), testOutput(common.HexToHash("0x3030"))))
 			},
 			check: func(t *testing.T, dl *DenyList) {
 				hashes10, err := dl.GetDeniedHashes(10)
@@ -407,14 +407,15 @@ func TestInvalidateBlock(t *testing.T) {
 		}
 
 		ctx := context.Background()
-		rewound, err := c.InvalidateBlock(ctx, 0, common.HexToHash("0xgenesis"))
+		genesisHash := common.HexToHash("0xgenesis")
+		rewound, err := c.InvalidateBlock(ctx, 0, genesisHash, testOutput(genesisHash))
 
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "cannot invalidate genesis block")
 		require.False(t, rewound)
 
 		// Genesis hash should NOT be added to denylist
-		found, err := dl.Contains(0, common.HexToHash("0xgenesis"))
+		found, err := dl.Contains(0, genesisHash)
 		require.NoError(t, err)
 		require.False(t, found, "genesis block should not be added to denylist")
 	})
@@ -450,7 +451,7 @@ func TestInvalidateBlock(t *testing.T) {
 
 			// Call InvalidateBlock
 			ctx := context.Background()
-			rewound, err := c.InvalidateBlock(ctx, tt.height, tt.payloadHash)
+			rewound, err := c.InvalidateBlock(ctx, tt.height, tt.payloadHash, testOutput(tt.payloadHash))
 			require.NoError(t, err)
 
 			// Verify rewind behavior
@@ -516,7 +517,7 @@ func TestIsDenied(t *testing.T) {
 			defer dl.Close()
 
 			// Setup
-			require.NoError(t, dl.Add(tt.setupHeight, tt.setupHash))
+			require.NoError(t, dl.Add(tt.setupHeight, tt.setupHash, testOutput(tt.setupHash)))
 
 			// Create container
 			c := &simpleChainContainer{
@@ -534,6 +535,115 @@ func TestIsDenied(t *testing.T) {
 
 func testLogger() gethlog.Logger {
 	return gethlog.New()
+}
+
+// testOutput creates a test OutputV0 with the given hash as BlockHash.
+func testOutput(hash common.Hash) *eth.OutputV0 {
+	return &eth.OutputV0{
+		StateRoot:                eth.Bytes32{0x01, 0x02, 0x03},
+		MessagePasserStorageRoot: eth.Bytes32{0x04, 0x05, 0x06},
+		BlockHash:                hash,
+	}
+}
+
+// testOutputWithRoots creates a test OutputV0 with specific state and message passer roots.
+func testOutputWithRoots(hash common.Hash, stateRoot, msgPasserRoot eth.Bytes32) *eth.OutputV0 {
+	return &eth.OutputV0{
+		StateRoot:                stateRoot,
+		MessagePasserStorageRoot: msgPasserRoot,
+		BlockHash:                hash,
+	}
+}
+
+func TestDenyList_GetOutput(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		setup func(t *testing.T, dl *DenyList)
+		check func(t *testing.T, dl *DenyList)
+	}{
+		{
+			name: "returns output for existing entry",
+			setup: func(t *testing.T, dl *DenyList) {
+				hash := common.HexToHash("0x1234")
+				stateRoot := eth.Bytes32{0xaa, 0xbb, 0xcc}
+				msgPasserRoot := eth.Bytes32{0xdd, 0xee, 0xff}
+				require.NoError(t, dl.Add(100, hash, testOutputWithRoots(hash, stateRoot, msgPasserRoot)))
+			},
+			check: func(t *testing.T, dl *DenyList) {
+				hash := common.HexToHash("0x1234")
+				output, found, err := dl.GetOutput(100, hash)
+				require.NoError(t, err)
+				require.True(t, found)
+				require.NotNil(t, output)
+				require.Equal(t, hash, output.BlockHash)
+				require.Equal(t, eth.Bytes32{0xaa, 0xbb, 0xcc}, output.StateRoot)
+				require.Equal(t, eth.Bytes32{0xdd, 0xee, 0xff}, output.MessagePasserStorageRoot)
+			},
+		},
+		{
+			name: "returns not found for non-existent hash",
+			setup: func(t *testing.T, dl *DenyList) {
+				hash := common.HexToHash("0x1234")
+				require.NoError(t, dl.Add(100, hash, testOutput(hash)))
+			},
+			check: func(t *testing.T, dl *DenyList) {
+				differentHash := common.HexToHash("0x5678")
+				output, found, err := dl.GetOutput(100, differentHash)
+				require.NoError(t, err)
+				require.False(t, found)
+				require.Nil(t, output)
+			},
+		},
+		{
+			name: "returns not found for wrong height",
+			setup: func(t *testing.T, dl *DenyList) {
+				hash := common.HexToHash("0x1234")
+				require.NoError(t, dl.Add(100, hash, testOutput(hash)))
+			},
+			check: func(t *testing.T, dl *DenyList) {
+				hash := common.HexToHash("0x1234")
+				output, found, err := dl.GetOutput(200, hash)
+				require.NoError(t, err)
+				require.False(t, found)
+				require.Nil(t, output)
+			},
+		},
+		{
+			name: "returns correct output from multiple entries at same height",
+			setup: func(t *testing.T, dl *DenyList) {
+				hash1 := common.HexToHash("0x1111")
+				hash2 := common.HexToHash("0x2222")
+				hash3 := common.HexToHash("0x3333")
+				require.NoError(t, dl.Add(100, hash1, testOutputWithRoots(hash1, eth.Bytes32{0x11}, eth.Bytes32{0x11})))
+				require.NoError(t, dl.Add(100, hash2, testOutputWithRoots(hash2, eth.Bytes32{0x22}, eth.Bytes32{0x22})))
+				require.NoError(t, dl.Add(100, hash3, testOutputWithRoots(hash3, eth.Bytes32{0x33}, eth.Bytes32{0x33})))
+			},
+			check: func(t *testing.T, dl *DenyList) {
+				hash2 := common.HexToHash("0x2222")
+				output, found, err := dl.GetOutput(100, hash2)
+				require.NoError(t, err)
+				require.True(t, found)
+				require.Equal(t, hash2, output.BlockHash)
+				require.Equal(t, eth.Bytes32{0x22}, output.StateRoot)
+				require.Equal(t, eth.Bytes32{0x22}, output.MessagePasserStorageRoot)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			dl, err := OpenDenyList(dir)
+			require.NoError(t, err)
+			defer dl.Close()
+
+			tt.setup(t, dl)
+			tt.check(t, dl)
+		})
+	}
 }
 
 // TestDenyList_ConcurrentAccess verifies the DenyList is safe for concurrent use.
@@ -573,7 +683,7 @@ func TestDenyList_ConcurrentAccess(t *testing.T) {
 				hash := makeHash(accessorID, j)
 
 				// Write
-				err := dl.Add(height, hash)
+				err := dl.Add(height, hash, testOutput(hash))
 				require.NoError(t, err)
 
 				// Read own write


### PR DESCRIPTION
# Tool Use Notice
Entirely Generated. This PR just changes one data type for another (superset) data type, and corrects the related integrations.

# What
Update the DenyList to store the complete eth.OutputV0 structure instead of just the block hash. This enables retrieval of the StateRoot and MessagePasserStorageRoot for invalidated blocks, as well as the calculation of the Output Root of any invalidated blocks we no longer have access to.

Changes:
- DenyList.Add() now accepts *eth.OutputV0 parameter
- Added DenyList.GetOutput() to retrieve full OutputV0 for denied blocks
- Storage format: 96 bytes per entry (hash + StateRoot + MsgPasserRoot)
- ChainContainer.InvalidateBlock() now requires *eth.OutputV0
- Added ChainContainer.OutputV0AtL2BlockNumber() to fetch full output
- Interop activity fetches OutputV0 before invalidating blocks
- Updated all mock implementations and tests