### PR TITLE
kona/protocol/derive: handle "blob not found" correctly

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6210,6 +6210,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tower 0.5.3",
+ "tracing",
 ]
 
 [[package]]

--- a/rust/kona/crates/protocol/derive/src/errors/pipeline.rs
+++ b/rust/kona/crates/protocol/derive/src/errors/pipeline.rs
@@ -344,6 +344,10 @@ pub enum ResetError {
     /// The next l1 block provided to the managed traversal stage is not the expected one.
     #[error("Next L1 block hash mismatch: expected {0}, got {1}")]
     NextL1BlockHashMismatch(B256, B256),
+    /// Blobs referenced by an L1 block are permanently unavailable (e.g. missed beacon slot).
+    /// The pipeline must reset to move past the offending L1 block.
+    #[error("Blobs unavailable: beacon node returned 404 for slot")]
+    BlobsUnavailable,
 }
 
 impl ResetError {

--- a/rust/kona/crates/protocol/derive/src/errors/pipeline.rs
+++ b/rust/kona/crates/protocol/derive/src/errors/pipeline.rs
@@ -346,8 +346,8 @@ pub enum ResetError {
     NextL1BlockHashMismatch(B256, B256),
     /// Blobs referenced by an L1 block are permanently unavailable (e.g. missed beacon slot).
     /// The pipeline must reset to move past the offending L1 block.
-    #[error("Blobs unavailable: beacon node returned 404 for slot")]
-    BlobsUnavailable,
+    #[error("Blobs unavailable: beacon node returned 404 for slot {0}")]
+    BlobsUnavailable(u64),
 }
 
 impl ResetError {
@@ -435,6 +435,7 @@ mod tests {
                 Default::default(),
             )),
             ResetError::HoloceneActivation,
+            ResetError::BlobsUnavailable(0),
         ];
         for error in reset_errors {
             let expected = PipelineErrorKind::Reset(error.clone());

--- a/rust/kona/crates/protocol/derive/src/errors/sources.rs
+++ b/rust/kona/crates/protocol/derive/src/errors/sources.rs
@@ -90,11 +90,9 @@ mod tests {
 
         // A 404 from the beacon node (missed/orphaned slot) must trigger a pipeline reset,
         // not a temporary retry. Without this, the safe head stalls indefinitely.
-        let err: PipelineErrorKind = BlobProviderError::BlobNotFound {
-            slot: 13779552,
-            reason: "slot not found".into(),
-        }
-        .into();
+        let err: PipelineErrorKind =
+            BlobProviderError::BlobNotFound { slot: 13779552, reason: "slot not found".into() }
+                .into();
         assert!(
             matches!(err, PipelineErrorKind::Reset(_)),
             "BlobNotFound must map to Reset so the pipeline moves past the missed slot"

--- a/rust/kona/crates/protocol/derive/src/errors/sources.rs
+++ b/rust/kona/crates/protocol/derive/src/errors/sources.rs
@@ -36,8 +36,13 @@ pub enum BlobProviderError {
     /// The beacon node returned a 404 for the requested slot, indicating the slot was missed or
     /// orphaned. Blobs for missed/orphaned slots will never become available, so the pipeline
     /// must reset to move past the L1 block that referenced them.
-    #[error("Blob not found at slot {0}: {1}")]
-    BlobNotFound(u64, String),
+    #[error("Blob not found at slot {slot}: {reason}")]
+    BlobNotFound {
+        /// The beacon slot that returned 404.
+        slot: u64,
+        /// The underlying error message from the beacon client.
+        reason: String,
+    },
     /// Error pertaining to the backend transport.
     #[error("{0}")]
     Backend(String),
@@ -49,7 +54,9 @@ impl From<BlobProviderError> for PipelineErrorKind {
             BlobProviderError::SidecarLengthMismatch(_, _) |
             BlobProviderError::SlotDerivation |
             BlobProviderError::BlobDecoding(_) => PipelineError::Provider(val.to_string()).crit(),
-            BlobProviderError::BlobNotFound(slot, _) => ResetError::BlobsUnavailable(slot).reset(),
+            BlobProviderError::BlobNotFound { slot, .. } => {
+                ResetError::BlobsUnavailable(slot).reset()
+            }
             BlobProviderError::Backend(_) => PipelineError::Provider(val.to_string()).temp(),
         }
     }
@@ -83,8 +90,11 @@ mod tests {
 
         // A 404 from the beacon node (missed/orphaned slot) must trigger a pipeline reset,
         // not a temporary retry. Without this, the safe head stalls indefinitely.
-        let err: PipelineErrorKind =
-            BlobProviderError::BlobNotFound(13779552, "slot not found".into()).into();
+        let err: PipelineErrorKind = BlobProviderError::BlobNotFound {
+            slot: 13779552,
+            reason: "slot not found".into(),
+        }
+        .into();
         assert!(
             matches!(err, PipelineErrorKind::Reset(_)),
             "BlobNotFound must map to Reset so the pipeline moves past the missed slot"

--- a/rust/kona/crates/protocol/derive/src/errors/sources.rs
+++ b/rust/kona/crates/protocol/derive/src/errors/sources.rs
@@ -46,12 +46,10 @@ pub enum BlobProviderError {
 impl From<BlobProviderError> for PipelineErrorKind {
     fn from(val: BlobProviderError) -> Self {
         match val {
-            BlobProviderError::SidecarLengthMismatch(_, _) |
-            BlobProviderError::SlotDerivation |
-            BlobProviderError::BlobDecoding(_) => PipelineError::Provider(val.to_string()).crit(),
-            BlobProviderError::BlobNotFound(_, _) => {
-                ResetError::BlobsUnavailable.reset()
-            }
+            BlobProviderError::SidecarLengthMismatch(_, _)
+            | BlobProviderError::SlotDerivation
+            | BlobProviderError::BlobDecoding(_) => PipelineError::Provider(val.to_string()).crit(),
+            BlobProviderError::BlobNotFound(_, _) => ResetError::BlobsUnavailable.reset(),
             BlobProviderError::Backend(_) => PipelineError::Provider(val.to_string()).temp(),
         }
     }
@@ -80,8 +78,7 @@ mod tests {
             BlobProviderError::BlobDecoding(BlobDecodingError::InvalidFieldElement).into();
         assert!(matches!(err, PipelineErrorKind::Critical(_)));
 
-        let err: PipelineErrorKind =
-            BlobProviderError::Backend("transport error".into()).into();
+        let err: PipelineErrorKind = BlobProviderError::Backend("transport error".into()).into();
         assert!(matches!(err, PipelineErrorKind::Temporary(_)));
 
         // A 404 from the beacon node (missed/orphaned slot) must trigger a pipeline reset,

--- a/rust/kona/crates/protocol/derive/src/errors/sources.rs
+++ b/rust/kona/crates/protocol/derive/src/errors/sources.rs
@@ -46,9 +46,9 @@ pub enum BlobProviderError {
 impl From<BlobProviderError> for PipelineErrorKind {
     fn from(val: BlobProviderError) -> Self {
         match val {
-            BlobProviderError::SidecarLengthMismatch(_, _)
-            | BlobProviderError::SlotDerivation
-            | BlobProviderError::BlobDecoding(_) => PipelineError::Provider(val.to_string()).crit(),
+            BlobProviderError::SidecarLengthMismatch(_, _) |
+            BlobProviderError::SlotDerivation |
+            BlobProviderError::BlobDecoding(_) => PipelineError::Provider(val.to_string()).crit(),
             BlobProviderError::BlobNotFound(_, _) => ResetError::BlobsUnavailable.reset(),
             BlobProviderError::Backend(_) => PipelineError::Provider(val.to_string()).temp(),
         }

--- a/rust/kona/crates/protocol/derive/src/errors/sources.rs
+++ b/rust/kona/crates/protocol/derive/src/errors/sources.rs
@@ -49,7 +49,7 @@ impl From<BlobProviderError> for PipelineErrorKind {
             BlobProviderError::SidecarLengthMismatch(_, _) |
             BlobProviderError::SlotDerivation |
             BlobProviderError::BlobDecoding(_) => PipelineError::Provider(val.to_string()).crit(),
-            BlobProviderError::BlobNotFound(_, _) => ResetError::BlobsUnavailable.reset(),
+            BlobProviderError::BlobNotFound(slot, _) => ResetError::BlobsUnavailable(slot).reset(),
             BlobProviderError::Backend(_) => PipelineError::Provider(val.to_string()).temp(),
         }
     }

--- a/rust/kona/crates/protocol/derive/src/errors/sources.rs
+++ b/rust/kona/crates/protocol/derive/src/errors/sources.rs
@@ -1,6 +1,6 @@
 //! Error types for sources.
 
-use crate::{PipelineError, PipelineErrorKind};
+use crate::{PipelineError, PipelineErrorKind, ResetError};
 use alloc::string::{String, ToString};
 use thiserror::Error;
 
@@ -33,6 +33,11 @@ pub enum BlobProviderError {
     /// Blob decoding error.
     #[error("Blob decoding error: {0}")]
     BlobDecoding(#[from] BlobDecodingError),
+    /// The beacon node returned a 404 for the requested slot, indicating the slot was missed or
+    /// orphaned. Blobs for missed/orphaned slots will never become available, so the pipeline
+    /// must reset to move past the L1 block that referenced them.
+    #[error("Blob not found at slot {0}: {1}")]
+    BlobNotFound(u64, String),
     /// Error pertaining to the backend transport.
     #[error("{0}")]
     Backend(String),
@@ -44,6 +49,9 @@ impl From<BlobProviderError> for PipelineErrorKind {
             BlobProviderError::SidecarLengthMismatch(_, _) |
             BlobProviderError::SlotDerivation |
             BlobProviderError::BlobDecoding(_) => PipelineError::Provider(val.to_string()).crit(),
+            BlobProviderError::BlobNotFound(_, _) => {
+                ResetError::BlobsUnavailable.reset()
+            }
             BlobProviderError::Backend(_) => PipelineError::Provider(val.to_string()).temp(),
         }
     }
@@ -71,5 +79,18 @@ mod tests {
         let err: PipelineErrorKind =
             BlobProviderError::BlobDecoding(BlobDecodingError::InvalidFieldElement).into();
         assert!(matches!(err, PipelineErrorKind::Critical(_)));
+
+        let err: PipelineErrorKind =
+            BlobProviderError::Backend("transport error".into()).into();
+        assert!(matches!(err, PipelineErrorKind::Temporary(_)));
+
+        // A 404 from the beacon node (missed/orphaned slot) must trigger a pipeline reset,
+        // not a temporary retry. Without this, the safe head stalls indefinitely.
+        let err: PipelineErrorKind =
+            BlobProviderError::BlobNotFound(13779552, "slot not found".into()).into();
+        assert!(
+            matches!(err, PipelineErrorKind::Reset(_)),
+            "BlobNotFound must map to Reset so the pipeline moves past the missed slot"
+        );
     }
 }

--- a/rust/kona/crates/protocol/derive/src/sources/blobs.rs
+++ b/rust/kona/crates/protocol/derive/src/sources/blobs.rs
@@ -116,13 +116,10 @@ where
             return Ok(());
         }
 
-        let info = self
-            .chain_provider
-            .block_info_and_transactions_by_hash(block_ref.hash)
-            .await
-            .map_err(|e| -> PipelineErrorKind {
-                BlobProviderError::Backend(e.to_string()).into()
-            })?;
+        let info =
+            self.chain_provider.block_info_and_transactions_by_hash(block_ref.hash).await.map_err(
+                |e| -> PipelineErrorKind { BlobProviderError::Backend(e.to_string()).into() },
+            )?;
 
         let (mut data, blob_hashes) = self.extract_blob_data(info.1, batcher_address);
 

--- a/rust/kona/crates/protocol/derive/src/sources/blobs.rs
+++ b/rust/kona/crates/protocol/derive/src/sources/blobs.rs
@@ -133,39 +133,38 @@ where
             return Ok(());
         }
 
-        let blobs = self
-            .blob_fetcher
-            .get_and_validate_blobs(block_ref, &blob_hashes)
-            .await
-            .map_err(|e| {
-                // Convert via Into<PipelineErrorKind> which routes:
-                //   BlobNotFound  -> PipelineErrorKind::Reset   (missed/orphaned slot)
-                //   Backend       -> PipelineErrorKind::Temporary (transient, retry)
-                //   others        -> PipelineErrorKind::Critical
-                let kind: PipelineErrorKind = e.into();
-                match &kind {
-                    PipelineErrorKind::Reset(_) => {
-                        warn!(
-                            target: "blob_source",
-                            block_hash = %block_ref.hash,
-                            block_number = block_ref.number,
-                            timestamp = block_ref.timestamp,
-                            "Blobs permanently unavailable (missed/orphaned beacon slot); \
-                             triggering pipeline reset"
-                        );
+        let blobs =
+            self.blob_fetcher.get_and_validate_blobs(block_ref, &blob_hashes).await.map_err(
+                |e| {
+                    // Convert via Into<PipelineErrorKind> which routes:
+                    //   BlobNotFound  -> PipelineErrorKind::Reset   (missed/orphaned slot)
+                    //   Backend       -> PipelineErrorKind::Temporary (transient, retry)
+                    //   others        -> PipelineErrorKind::Critical
+                    let kind: PipelineErrorKind = e.into();
+                    match &kind {
+                        PipelineErrorKind::Reset(_) => {
+                            warn!(
+                                target: "blob_source",
+                                block_hash = %block_ref.hash,
+                                block_number = block_ref.number,
+                                timestamp = block_ref.timestamp,
+                                "Blobs permanently unavailable (missed/orphaned beacon slot); \
+                                 triggering pipeline reset"
+                            );
+                        }
+                        _ => {
+                            warn!(
+                                target: "blob_source",
+                                block_hash = %block_ref.hash,
+                                block_number = block_ref.number,
+                                timestamp = block_ref.timestamp,
+                                "Failed to fetch blobs: {kind}"
+                            );
+                        }
                     }
-                    _ => {
-                        warn!(
-                            target: "blob_source",
-                            block_hash = %block_ref.hash,
-                            block_number = block_ref.number,
-                            timestamp = block_ref.timestamp,
-                            "Failed to fetch blobs: {kind}"
-                        );
-                    }
-                }
-                kind
-            })?;
+                    kind
+                },
+            )?;
 
         // Fill the blob pointers.
         let mut blob_index = 0;

--- a/rust/kona/crates/protocol/derive/src/sources/blobs.rs
+++ b/rust/kona/crates/protocol/derive/src/sources/blobs.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     BlobData, BlobProvider, BlobProviderError, ChainProvider, DataAvailabilityProvider,
-    PipelineError, PipelineResult,
+    PipelineError, PipelineErrorKind, PipelineResult,
 };
 use alloc::{boxed::Box, string::ToString, vec::Vec};
 use alloy_consensus::{
@@ -111,7 +111,7 @@ where
         &mut self,
         block_ref: &BlockInfo,
         batcher_address: Address,
-    ) -> Result<(), BlobProviderError> {
+    ) -> Result<(), PipelineErrorKind> {
         if self.open {
             return Ok(());
         }
@@ -120,7 +120,9 @@ where
             .chain_provider
             .block_info_and_transactions_by_hash(block_ref.hash)
             .await
-            .map_err(|e| BlobProviderError::Backend(e.to_string()))?;
+            .map_err(|e| -> PipelineErrorKind {
+                BlobProviderError::Backend(e.to_string()).into()
+            })?;
 
         let (mut data, blob_hashes) = self.extract_blob_data(info.1, batcher_address);
 
@@ -131,13 +133,39 @@ where
             return Ok(());
         }
 
-        let blobs =
-            self.blob_fetcher.get_and_validate_blobs(block_ref, &blob_hashes).await.map_err(
-                |e| {
-                    warn!(target: "blob_source", "Failed to fetch blobs: {e}");
-                    BlobProviderError::Backend(e.to_string())
-                },
-            )?;
+        let blobs = self
+            .blob_fetcher
+            .get_and_validate_blobs(block_ref, &blob_hashes)
+            .await
+            .map_err(|e| {
+                // Convert via Into<PipelineErrorKind> which routes:
+                //   BlobNotFound  -> PipelineErrorKind::Reset   (missed/orphaned slot)
+                //   Backend       -> PipelineErrorKind::Temporary (transient, retry)
+                //   others        -> PipelineErrorKind::Critical
+                let kind: PipelineErrorKind = e.into();
+                match &kind {
+                    PipelineErrorKind::Reset(_) => {
+                        warn!(
+                            target: "blob_source",
+                            block_hash = %block_ref.hash,
+                            block_number = block_ref.number,
+                            timestamp = block_ref.timestamp,
+                            "Blobs permanently unavailable (missed/orphaned beacon slot); \
+                             triggering pipeline reset"
+                        );
+                    }
+                    _ => {
+                        warn!(
+                            target: "blob_source",
+                            block_hash = %block_ref.hash,
+                            block_number = block_ref.number,
+                            timestamp = block_ref.timestamp,
+                            "Failed to fetch blobs: {kind}"
+                        );
+                    }
+                }
+                kind
+            })?;
 
         // Fill the blob pointers.
         let mut blob_index = 0;
@@ -149,7 +177,8 @@ where
                     }
                 }
                 Err(e) => {
-                    return Err(e.into());
+                    let err: BlobProviderError = e.into();
+                    return Err(err.into());
                 }
             }
         }
@@ -242,7 +271,7 @@ pub(crate) mod tests {
         let mut source = default_test_blob_source();
         assert!(matches!(
             source.load_blobs(&BlockInfo::default(), Address::ZERO).await,
-            Err(BlobProviderError::Backend(_))
+            Err(PipelineErrorKind::Temporary(_))
         ));
     }
 
@@ -270,7 +299,7 @@ pub(crate) mod tests {
         source.chain_provider.insert_block_with_transactions(1, block_info, txs);
         assert!(matches!(
             source.load_blobs(&BlockInfo::default(), batcher_address).await,
-            Err(BlobProviderError::Backend(_))
+            Err(PipelineErrorKind::Critical(_))
         ));
     }
 
@@ -345,5 +374,46 @@ pub(crate) mod tests {
         let mut source = default_test_blob_source();
         let err = source.next(&BlockInfo::default(), Address::ZERO).await.unwrap_err();
         assert!(matches!(err, PipelineErrorKind::Temporary(PipelineError::Provider(_))));
+    }
+
+    /// Regression test: a beacon node 404 (missed/orphaned slot) must propagate through
+    /// `load_blobs` as `PipelineErrorKind::Reset`, not as a temporary retryable error.
+    #[tokio::test]
+    async fn test_load_blobs_not_found_triggers_reset() {
+        let mut source = default_test_blob_source();
+        let block_info = BlockInfo::default();
+        let batcher_address =
+            alloy_primitives::address!("A83C816D4f9b2783761a22BA6FADB0eB0606D7B2");
+        source.batcher_address =
+            alloy_primitives::address!("11E9CA82A3a762b4B5bd264d4173a242e7a77064");
+        source.chain_provider.insert_block_with_transactions(1, block_info, valid_blob_txs());
+        source.blob_fetcher.should_return_not_found = true;
+
+        let err = source.load_blobs(&BlockInfo::default(), batcher_address).await.unwrap_err();
+        assert!(
+            matches!(err, PipelineErrorKind::Reset(_)),
+            "expected Reset for missed beacon slot, got {err:?}"
+        );
+    }
+
+    /// Regression test: `BlobProviderError::BlobNotFound` from the blob fetcher must surface
+    /// through `next()` as `PipelineErrorKind::Reset`, triggering a pipeline reset.
+    /// Without this, a missed beacon slot causes an infinite retry loop and safe head stall.
+    #[tokio::test]
+    async fn test_missed_beacon_slot_triggers_pipeline_reset() {
+        let mut source = default_test_blob_source();
+        let block_info = BlockInfo::default();
+        let batcher_address =
+            alloy_primitives::address!("A83C816D4f9b2783761a22BA6FADB0eB0606D7B2");
+        source.batcher_address =
+            alloy_primitives::address!("11E9CA82A3a762b4B5bd264d4173a242e7a77064");
+        source.chain_provider.insert_block_with_transactions(1, block_info, valid_blob_txs());
+        source.blob_fetcher.should_return_not_found = true;
+
+        let err = source.next(&BlockInfo::default(), batcher_address).await.unwrap_err();
+        assert!(
+            matches!(err, PipelineErrorKind::Reset(_)),
+            "expected Reset for missed beacon slot, got {err:?}"
+        );
     }
 }

--- a/rust/kona/crates/protocol/derive/src/sources/blobs.rs
+++ b/rust/kona/crates/protocol/derive/src/sources/blobs.rs
@@ -164,16 +164,11 @@ where
         // Fill the blob pointers.
         let mut blob_index = 0;
         for blob in &mut data {
-            match blob.fill(&blobs, blob_index) {
-                Ok(should_increment) => {
-                    if should_increment {
-                        blob_index += 1;
-                    }
-                }
-                Err(e) => {
-                    let err: BlobProviderError = e.into();
-                    return Err(err.into());
-                }
+            let should_increment = blob
+                .fill(&blobs, blob_index)
+                .map_err(|e| -> PipelineErrorKind { BlobProviderError::from(e).into() })?;
+            if should_increment {
+                blob_index += 1;
             }
         }
 

--- a/rust/kona/crates/protocol/derive/src/sources/blobs.rs
+++ b/rust/kona/crates/protocol/derive/src/sources/blobs.rs
@@ -130,38 +130,36 @@ where
             return Ok(());
         }
 
-        let blobs =
-            self.blob_fetcher.get_and_validate_blobs(block_ref, &blob_hashes).await.map_err(
-                |e| {
-                    // Convert via Into<PipelineErrorKind> which routes:
-                    //   BlobNotFound  -> PipelineErrorKind::Reset   (missed/orphaned slot)
-                    //   Backend       -> PipelineErrorKind::Temporary (transient, retry)
-                    //   others        -> PipelineErrorKind::Critical
-                    let kind: PipelineErrorKind = e.into();
-                    match &kind {
-                        PipelineErrorKind::Reset(_) => {
-                            warn!(
-                                target: "blob_source",
-                                block_hash = %block_ref.hash,
-                                block_number = block_ref.number,
-                                timestamp = block_ref.timestamp,
-                                "Blobs permanently unavailable (missed/orphaned beacon slot); \
-                                 triggering pipeline reset"
-                            );
-                        }
-                        _ => {
-                            warn!(
-                                target: "blob_source",
-                                block_hash = %block_ref.hash,
-                                block_number = block_ref.number,
-                                timestamp = block_ref.timestamp,
-                                "Failed to fetch blobs: {kind}"
-                            );
-                        }
-                    }
-                    kind
-                },
-            )?;
+        // Convert via Into<PipelineErrorKind> which routes:
+        //   BlobNotFound  -> PipelineErrorKind::Reset   (missed/orphaned slot)
+        //   Backend       -> PipelineErrorKind::Temporary (transient, retry)
+        //   others        -> PipelineErrorKind::Critical
+        let blobs = self
+            .blob_fetcher
+            .get_and_validate_blobs(block_ref, &blob_hashes)
+            .await
+            .map_err(Into::<PipelineErrorKind>::into)
+            .inspect_err(|kind| match kind {
+                PipelineErrorKind::Reset(_) => {
+                    warn!(
+                        target: "blob_source",
+                        block_hash = %block_ref.hash,
+                        block_number = block_ref.number,
+                        timestamp = block_ref.timestamp,
+                        "Blobs permanently unavailable (missed/orphaned beacon slot); \
+                         triggering pipeline reset"
+                    );
+                }
+                _ => {
+                    warn!(
+                        target: "blob_source",
+                        block_hash = %block_ref.hash,
+                        block_number = block_ref.number,
+                        timestamp = block_ref.timestamp,
+                        "Failed to fetch blobs: {kind}"
+                    );
+                }
+            })?;
 
         // Fill the blob pointers.
         let mut blob_index = 0;

--- a/rust/kona/crates/protocol/derive/src/test_utils/blob_provider.rs
+++ b/rust/kona/crates/protocol/derive/src/test_utils/blob_provider.rs
@@ -44,7 +44,10 @@ impl BlobProvider for TestBlobProvider {
             return Err(BlobProviderError::SlotDerivation);
         }
         if self.should_return_not_found {
-            return Err(BlobProviderError::BlobNotFound(0, "mock: slot not found".into()));
+            return Err(BlobProviderError::BlobNotFound {
+                slot: 0,
+                reason: "mock: slot not found".into(),
+            });
         }
         let mut blobs = Vec::new();
         for blob_hash in blob_hashes {

--- a/rust/kona/crates/protocol/derive/src/test_utils/blob_provider.rs
+++ b/rust/kona/crates/protocol/derive/src/test_utils/blob_provider.rs
@@ -12,8 +12,11 @@ use kona_protocol::BlockInfo;
 pub struct TestBlobProvider {
     /// Maps block hashes to blob data.
     pub blobs: HashMap<B256, Blob>,
-    /// whether the blob provider should return an error.
+    /// Whether the blob provider should return a generic backend error.
     pub should_error: bool,
+    /// When `true`, `get_and_validate_blobs` returns `BlobProviderError::BlobNotFound`,
+    /// simulating a missed/orphaned beacon slot (HTTP 404 from the beacon node).
+    pub should_return_not_found: bool,
 }
 
 impl TestBlobProvider {
@@ -39,6 +42,9 @@ impl BlobProvider for TestBlobProvider {
     ) -> Result<Vec<Box<Blob>>, Self::Error> {
         if self.should_error {
             return Err(BlobProviderError::SlotDerivation);
+        }
+        if self.should_return_not_found {
+            return Err(BlobProviderError::BlobNotFound(0, "mock: slot not found".into()));
         }
         let mut blobs = Vec::new();
         for blob_hash in blob_hashes {

--- a/rust/kona/crates/providers/providers-alloy/Cargo.toml
+++ b/rust/kona/crates/providers/providers-alloy/Cargo.toml
@@ -47,6 +47,7 @@ tower.workspace = true
 http-body-util.workspace = true
 
 c-kzg.workspace = true
+tracing.workspace = true
 
 # `metrics` feature
 metrics = { workspace = true, optional = true }

--- a/rust/kona/crates/providers/providers-alloy/src/beacon_client.rs
+++ b/rust/kona/crates/providers/providers-alloy/src/beacon_client.rs
@@ -73,6 +73,13 @@ pub trait BeaconClient {
     /// The error type for [`BeaconClient`] implementations.
     type Error: core::fmt::Display;
 
+    /// Returns the slot number if this error represents a beacon slot not found (HTTP 404).
+    ///
+    /// Returns `None` for all other error kinds. This allows the blob provider to distinguish
+    /// permanently-unavailable slots (missed/orphaned beacon blocks) from transient errors,
+    /// and trigger a pipeline reset instead of retrying indefinitely.
+    fn slot_not_found(err: &Self::Error) -> Option<u64>;
+
     /// Returns the slot interval in seconds.
     async fn slot_interval(&self) -> Result<APIConfigResponse, Self::Error>;
 
@@ -104,6 +111,11 @@ pub enum BeaconClientError {
     /// HTTP request failed.
     #[error("HTTP request failed: {0}")]
     Http(#[from] reqwest::Error),
+
+    /// The beacon node returned HTTP 404 for the requested slot. This means the slot was missed
+    /// or orphaned and the blobs will never be available.
+    #[error("Beacon slot not found (HTTP 404) for slot {0}")]
+    SlotNotFound(u64),
 
     /// Blob hash not found in beacon response.
     #[error("Blob hash not found in beacon response: {0}")]
@@ -162,8 +174,16 @@ impl OnlineBeaconClient {
             .get(format!("{}/{}/{}", self.base, BLOBS_METHOD_PREFIX, slot))
             .query(&[("versioned_hashes", &params.join(","))])
             .send()
-            .await?
-            .error_for_status()?;
+            .await?;
+
+        // A 404 means the beacon slot was missed or orphaned. Blobs for such slots will never
+        // become available, so surface this as a distinct error rather than a generic HTTP error
+        // so that callers can trigger a pipeline reset instead of retrying indefinitely.
+        if response.status() == reqwest::StatusCode::NOT_FOUND {
+            return Err(BeaconClientError::SlotNotFound(slot));
+        }
+
+        let response = response.error_for_status()?;
         let bundle = response.json::<GetBlobsResponse>().await?;
 
         let returned_blobs_mapped_by_hash = bundle
@@ -193,6 +213,10 @@ impl OnlineBeaconClient {
 #[async_trait]
 impl BeaconClient for OnlineBeaconClient {
     type Error = BeaconClientError;
+
+    fn slot_not_found(err: &Self::Error) -> Option<u64> {
+        if let BeaconClientError::SlotNotFound(slot) = err { Some(*slot) } else { None }
+    }
 
     async fn slot_interval(&self) -> Result<APIConfigResponse, Self::Error> {
         kona_macros::inc!(gauge, Metrics::BEACON_CLIENT_REQUESTS, "method" => "spec");
@@ -330,5 +354,31 @@ mod tests {
             }
             blobs_mock.delete();
         }
+    }
+
+    /// Regression test: a beacon node HTTP 404 for a given slot must return
+    /// `BeaconClientError::SlotNotFound` rather than a generic `Http` error.
+    /// This allows the blob provider layer to map it to `BlobProviderError::BlobNotFound`
+    /// and the pipeline to issue a reset rather than retrying indefinitely.
+    #[tokio::test]
+    async fn test_filtered_beacon_blobs_404_returns_slot_not_found() {
+        let slot = 13779552u64; // slot from the real-world missed-slot incident
+        let test_blob_hash: FixedBytes<32> = FixedBytes::from_hex(TEST_BLOB_HASH_HEX).unwrap();
+        let requested_blob_hashes: Vec<B256> = vec![test_blob_hash];
+
+        let server = MockServer::start();
+        let mut blobs_mock = server.mock(|when, then| {
+            when.method(GET).path(format!("/eth/v1/beacon/blobs/{slot}"));
+            then.status(404).body(r#"{"code":404,"message":"Block not found"}"#);
+        });
+
+        let client = OnlineBeaconClient::new_http(server.base_url());
+        let response = client.filtered_beacon_blobs(slot, &requested_blob_hashes).await;
+        blobs_mock.assert();
+
+        assert!(
+            matches!(response, Err(BeaconClientError::SlotNotFound(s)) if s == slot),
+            "expected SlotNotFound({slot}), got {response:?}"
+        );
     }
 }

--- a/rust/kona/crates/providers/providers-alloy/src/beacon_client.rs
+++ b/rust/kona/crates/providers/providers-alloy/src/beacon_client.rs
@@ -367,7 +367,7 @@ mod tests {
         let requested_blob_hashes: Vec<B256> = vec![test_blob_hash];
 
         let server = MockServer::start();
-        let mut blobs_mock = server.mock(|when, then| {
+        let blobs_mock = server.mock(|when, then| {
             when.method(GET).path(format!("/eth/v1/beacon/blobs/{slot}"));
             then.status(404).body(r#"{"code":404,"message":"Block not found"}"#);
         });

--- a/rust/kona/crates/providers/providers-alloy/src/blobs.rs
+++ b/rust/kona/crates/providers/providers-alloy/src/blobs.rs
@@ -90,24 +90,19 @@ impl<B: BeaconClient> OnlineBlobProvider<B> {
 
         let result =
             self.beacon_client.filtered_beacon_blobs(slot, blob_hashes).await.map_err(|e| {
-                B::slot_not_found(&e).map_or_else(
-                    || BlobProviderError::Backend(e.to_string()),
-                    |missing_slot| {
-                        // The beacon node returned 404 for this slot. The slot was missed or
-                        // orphaned; its blobs will never be available. Map to BlobNotFound so
-                        // the pipeline issues a reset rather than retrying indefinitely.
-                        warn!(
-                            target: "blob_provider",
-                            slot = missing_slot,
-                            "Beacon slot not found (404); slot may be missed or orphaned. \
-                             Triggering pipeline reset."
-                        );
-                        BlobProviderError::BlobNotFound {
-                            slot: missing_slot,
-                            reason: e.to_string(),
-                        }
-                    },
-                )
+                // The beacon node returned 404 for this slot. The slot was missed or
+                // orphaned; its blobs will never be available. Map to BlobNotFound so
+                // the pipeline issues a reset rather than retrying indefinitely.
+                let Some(missing_slot) = B::slot_not_found(&e) else {
+                    return BlobProviderError::Backend(e.to_string());
+                };
+                warn!(
+                    target: "blob_provider",
+                    slot = missing_slot,
+                    "Beacon slot not found (404); slot may be missed or orphaned. \
+                     Triggering pipeline reset."
+                );
+                BlobProviderError::BlobNotFound { slot: missing_slot, reason: e.to_string() }
             });
 
         #[cfg(feature = "metrics")]

--- a/rust/kona/crates/providers/providers-alloy/src/blobs.rs
+++ b/rust/kona/crates/providers/providers-alloy/src/blobs.rs
@@ -102,7 +102,10 @@ impl<B: BeaconClient> OnlineBlobProvider<B> {
                             "Beacon slot not found (404); slot may be missed or orphaned. \
                              Triggering pipeline reset."
                         );
-                        BlobProviderError::BlobNotFound(missing_slot, e.to_string())
+                        BlobProviderError::BlobNotFound {
+                            slot: missing_slot,
+                            reason: e.to_string(),
+                        }
                     },
                 )
             });

--- a/rust/kona/crates/providers/providers-alloy/src/blobs.rs
+++ b/rust/kona/crates/providers/providers-alloy/src/blobs.rs
@@ -9,6 +9,7 @@ use async_trait::async_trait;
 use kona_derive::{BlobProvider, BlobProviderError};
 use kona_protocol::BlockInfo;
 use std::{boxed::Box, string::ToString, vec::Vec};
+use tracing::warn;
 
 /// A boxed blob.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -91,7 +92,22 @@ impl<B: BeaconClient> OnlineBlobProvider<B> {
             .beacon_client
             .filtered_beacon_blobs(slot, blob_hashes)
             .await
-            .map_err(|e| BlobProviderError::Backend(e.to_string()));
+            .map_err(|e| {
+                if let Some(missing_slot) = B::slot_not_found(&e) {
+                    // The beacon node returned 404 for this slot. The slot was missed or
+                    // orphaned; its blobs will never be available. Map to BlobNotFound so
+                    // the pipeline issues a reset rather than retrying indefinitely.
+                    warn!(
+                        target: "blob_provider",
+                        slot = missing_slot,
+                        "Beacon slot not found (404); slot may be missed or orphaned. \
+                         Triggering pipeline reset."
+                    );
+                    BlobProviderError::BlobNotFound(missing_slot, e.to_string())
+                } else {
+                    BlobProviderError::Backend(e.to_string())
+                }
+            });
 
         #[cfg(feature = "metrics")]
         if result.is_err() {

--- a/rust/kona/crates/providers/providers-alloy/src/blobs.rs
+++ b/rust/kona/crates/providers/providers-alloy/src/blobs.rs
@@ -88,25 +88,23 @@ impl<B: BeaconClient> OnlineBlobProvider<B> {
     ) -> Result<Vec<BoxedBlob>, BlobProviderError> {
         kona_macros::inc!(gauge, Metrics::BLOB_FETCHES);
 
-        let result = self
-            .beacon_client
-            .filtered_beacon_blobs(slot, blob_hashes)
-            .await
-            .map_err(|e| {
-                if let Some(missing_slot) = B::slot_not_found(&e) {
-                    // The beacon node returned 404 for this slot. The slot was missed or
-                    // orphaned; its blobs will never be available. Map to BlobNotFound so
-                    // the pipeline issues a reset rather than retrying indefinitely.
-                    warn!(
-                        target: "blob_provider",
-                        slot = missing_slot,
-                        "Beacon slot not found (404); slot may be missed or orphaned. \
-                         Triggering pipeline reset."
-                    );
-                    BlobProviderError::BlobNotFound(missing_slot, e.to_string())
-                } else {
-                    BlobProviderError::Backend(e.to_string())
-                }
+        let result =
+            self.beacon_client.filtered_beacon_blobs(slot, blob_hashes).await.map_err(|e| {
+                B::slot_not_found(&e).map_or_else(
+                    || BlobProviderError::Backend(e.to_string()),
+                    |missing_slot| {
+                        // The beacon node returned 404 for this slot. The slot was missed or
+                        // orphaned; its blobs will never be available. Map to BlobNotFound so
+                        // the pipeline issues a reset rather than retrying indefinitely.
+                        warn!(
+                            target: "blob_provider",
+                            slot = missing_slot,
+                            "Beacon slot not found (404); slot may be missed or orphaned. \
+                             Triggering pipeline reset."
+                        );
+                        BlobProviderError::BlobNotFound(missing_slot, e.to_string())
+                    },
+                )
             });
 
         #[cfg(feature = "metrics")]


### PR DESCRIPTION
Generated by Claude.

We are seeing safe head stalls from some kona nodes and traced it to a missing beacon slot and kona stuck trying to pull blobs. The aim of this PR is to make kona-node behave more like op-node in such a scenario. 

Closes https://github.com/ethereum-optimism/optimism/issues/18716