### PR TITLE
op-node: copy LocalSafeL2 in follow source mode

### DIFF
--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -493,8 +493,27 @@ func (s *Driver) followUpstream() {
 		return
 	}
 	s.log.Info("Follow Upstream", "eSafe", status.SafeL2, "eLocalSafe", status.LocalSafeL2, "eFinalized", status.FinalizedL2, "eCurrentL1", status.CurrentL1)
+	if status.SafeL2.Number > status.LocalSafeL2.Number {
+		s.log.Warn("Follow Upstream: Invalid external state, safe is ahead of local safe",
+			"safe", status.SafeL2.Number, "localSafe", status.LocalSafeL2.Number)
+		return
+	}
 	if status.FinalizedL2.Number > status.SafeL2.Number {
 		s.log.Warn("Follow Upstream: Invalid external state, finalized is ahead of safe", "safe", status.SafeL2.Number, "finalized", status.FinalizedL2.Number)
+		return
+	}
+
+	eLocalSafeL1Origin, err := s.upstreamFollowSource.L1BlockRefByNumber(s.driverCtx, status.LocalSafeL2.L1Origin.Number)
+	if err != nil {
+		s.log.Warn("Follow Upstream: Failed to look up L1 origin of external local safe head", "err", err)
+		return
+	}
+	if eLocalSafeL1Origin.Hash != status.LocalSafeL2.L1Origin.Hash {
+		s.log.Warn(
+			"Follow Upstream: Invalid external local safe: L1 origin of external local safe head mismatch",
+			"actual", eLocalSafeL1Origin,
+			"expected", status.LocalSafeL2.L1Origin,
+		)
 		return
 	}
 

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -492,7 +492,7 @@ func (s *Driver) followUpstream() {
 		s.log.Warn("Follow Upstream: Failed to fetch status", "err", err)
 		return
 	}
-	s.log.Info("Follow Upstream", "eSafe", status.SafeL2, "eFinalized", status.FinalizedL2, "eCurrentL1", status.CurrentL1)
+	s.log.Info("Follow Upstream", "eSafe", status.SafeL2, "eLocalSafe", status.LocalSafeL2, "eFinalized", status.FinalizedL2, "eCurrentL1", status.CurrentL1)
 	if status.FinalizedL2.Number > status.SafeL2.Number {
 		s.log.Warn("Follow Upstream: Invalid external state, finalized is ahead of safe", "safe", status.SafeL2.Number, "finalized", status.FinalizedL2.Number)
 		return
@@ -547,5 +547,5 @@ func (s *Driver) followUpstream() {
 		s.emitter.Emit(s.driverCtx, derive.DeriverL1StatusEvent{Origin: status.CurrentL1})
 	}
 	// Only reach this point if all L1 checks passed
-	s.SyncDeriver.Engine.FollowSource(status.SafeL2, status.FinalizedL2)
+	s.SyncDeriver.Engine.FollowSource(status.SafeL2, status.LocalSafeL2, status.FinalizedL2)
 }

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -1208,7 +1208,7 @@ func (e *EngineController) startPayload(ctx context.Context, fc eth.ForkchoiceSt
 	}
 }
 
-func (e *EngineController) FollowSource(eSafeBlockRef, eFinalizedRef eth.L2BlockRef) {
+func (e *EngineController) FollowSource(eSafeBlockRef, eLocalSafeRef, eFinalizedRef eth.L2BlockRef) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
@@ -1218,7 +1218,7 @@ func (e *EngineController) FollowSource(eSafeBlockRef, eFinalizedRef eth.L2Block
 			// May interrupt ongoing EL Sync to update the target, or trigger EL Sync
 			e.tryUpdateUnsafe(e.ctx, eSafeBlockRef)
 		}
-		e.tryUpdateLocalSafe(e.ctx, eSafeBlockRef, true, eth.L1BlockRef{})
+		e.tryUpdateLocalSafe(e.ctx, eLocalSafeRef, true, eth.L1BlockRef{})
 		// Directly update the Engine Controller state, bypassing finalizer
 		if e.FinalizedHead().Number <= eFinalizedRef.Number {
 			e.promoteFinalized(e.ctx, eFinalizedRef)
@@ -1229,6 +1229,7 @@ func (e *EngineController) FollowSource(eSafeBlockRef, eFinalizedRef eth.L2Block
 		"currentUnsafe", e.unsafeHead,
 		"currentSafe", e.SafeL2Head(),
 		"externalSafe", eSafeBlockRef,
+		"externalLocalSafe", eLocalSafeRef,
 		"externalFinalized", eFinalizedRef,
 	)
 

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -229,7 +229,7 @@ func (e *EngineController) SafeL2Head() eth.L2BlockRef {
 			panic("superAuthority supplied an identifier for the safe head which is not known to the engine")
 		}
 		return br
-	} else if e.supervisorEnabled {
+	} else if e.supervisorEnabled || e.syncCfg.FollowSourceEnabled() {
 		return e.deprecatedSafeHead
 	} else {
 		return e.localSafeHead
@@ -262,7 +262,7 @@ func (e *EngineController) FinalizedHead() eth.L2BlockRef {
 			panic("superAuthority supplied an identifier for the finalized head which is not known to the engine")
 		}
 		return br
-	} else if e.supervisorEnabled {
+	} else if e.supervisorEnabled || e.syncCfg.FollowSourceEnabled() {
 		return e.deprecatedFinalizedHead
 	} else {
 		return e.localFinalizedHead
@@ -787,7 +787,7 @@ func (e *EngineController) TryUpdateEngine(ctx context.Context) {
 
 func (e *EngineController) localSafeIsFullySafe(timestamp uint64) bool {
 	// pre-interop (or if supervisor disabled) everything that is local-safe is also immediately cross-safe.
-	return !e.rollupCfg.IsInterop(timestamp) || !e.supervisorEnabled
+	return !e.rollupCfg.IsInterop(timestamp) || (!e.supervisorEnabled && !e.syncCfg.FollowSourceEnabled())
 }
 
 func (e *EngineController) OnEvent(ctx context.Context, ev event.Event) bool {

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -1216,9 +1216,14 @@ func (e *EngineController) FollowSource(eSafeBlockRef, eLocalSafeRef, eFinalized
 		// Assume the sanity of external safe and finalized are checked
 		if updateUnsafe {
 			// May interrupt ongoing EL Sync to update the target, or trigger EL Sync
-			e.tryUpdateUnsafe(e.ctx, eSafeBlockRef)
+			e.tryUpdateUnsafe(e.ctx, eLocalSafeRef)
 		}
 		e.tryUpdateLocalSafe(e.ctx, eLocalSafeRef, true, eth.L1BlockRef{})
+		// Inject external cross-safe. Must happen before promoteFinalized
+		// (which rejects finalized > SafeL2Head).
+		if eSafeBlockRef.Number > e.deprecatedSafeHead.Number {
+			e.PromoteSafe(e.ctx, eSafeBlockRef, eth.L1BlockRef{})
+		}
 		// Directly update the Engine Controller state, bypassing finalizer
 		if e.FinalizedHead().Number <= eFinalizedRef.Number {
 			e.promoteFinalized(e.ctx, eFinalizedRef)
@@ -1235,14 +1240,14 @@ func (e *EngineController) FollowSource(eSafeBlockRef, eLocalSafeRef, eFinalized
 
 	logger.Info("Follow Source: Process external refs")
 
-	if e.unsafeHead.Number < eSafeBlockRef.Number {
+	if e.unsafeHead.Number < eLocalSafeRef.Number {
 		// EL Sync target may be updated
-		logger.Debug("Follow Source: EL Sync: External safe ahead of current unsafe")
+		logger.Debug("Follow Source: EL Sync: External local safe ahead of current unsafe")
 		followExternalRefs(true)
 		return
 	}
 
-	fetchedSafe, err := e.engine.L2BlockRefByNumber(e.ctx, eSafeBlockRef.Number)
+	fetchedSafe, err := e.engine.L2BlockRefByNumber(e.ctx, eLocalSafeRef.Number)
 	if errors.Is(err, ethereum.NotFound) {
 		// We queried a block before the EngineController unsafe head number,
 		// but it is not found. This indicates the underlying EL is still syncing.
@@ -1254,18 +1259,18 @@ func (e *EngineController) FollowSource(eSafeBlockRef, eLocalSafeRef, eFinalized
 		return
 	}
 	if err != nil {
-		logger.Debug("Follow Source: Failed to fetch external safe from local EL", "err", err)
+		logger.Debug("Follow Source: Failed to fetch external local safe from local EL", "err", err)
 		return
 	}
 
-	if fetchedSafe == eSafeBlockRef {
-		// External safe is found locally and matches.
+	if fetchedSafe == eLocalSafeRef {
+		// External local safe is found locally and matches.
 		logger.Debug("Follow Source: Consolidation")
 		followExternalRefs(false)
 		return
 	}
 
-	// External safe is found locally but they differ so trigger reorg.
+	// External local safe is found locally but they differ so trigger reorg.
 	// Reorging may trigger EL Sync, or updating the EL Sync target.
 	logger.Warn("Follow Source: Reorg. May Trigger EL sync")
 	followExternalRefs(true)

--- a/op-node/rollup/engine/engine_controller_test.go
+++ b/op-node/rollup/engine/engine_controller_test.go
@@ -7,6 +7,7 @@ import (
 	mrand "math/rand"
 	"testing"
 
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum-optimism/optimism/op-node/metrics"
@@ -396,6 +397,100 @@ func TestEngineController_ForkchoiceUpdateUsesSuperAuthority(t *testing.T) {
 }
 
 // SuperAuthority tests are in super_authority_deny_test.go
+
+// TestFollowSource_DivergentLocalSafeAndCrossSafe verifies that FollowSource correctly handles
+// the case where external cross-safe and local-safe values diverge. After the fix:
+//   - Consolidation/reorg checks use eLocalSafeRef (not eSafeBlockRef)
+//   - PromoteSafe injects the external cross-safe head
+//   - promoteFinalized succeeds because cross-safe is set before finalized is promoted
+func TestFollowSource_DivergentLocalSafeAndCrossSafe(t *testing.T) {
+	rng := mrand.New(mrand.NewSource(9999))
+
+	// Create block refs for a simple chain: block1 → block2 → block3 → block4 → block5
+	l1Origin := testutils.RandomBlockRef(rng)
+
+	block1 := eth.L2BlockRef{
+		Hash: testutils.RandomHash(rng), Number: 1,
+		ParentHash: testutils.RandomHash(rng), Time: l1Origin.Time + 1,
+		L1Origin: l1Origin.ID(), SequenceNumber: 1,
+	}
+	block2 := eth.L2BlockRef{
+		Hash: testutils.RandomHash(rng), Number: 2,
+		ParentHash: block1.Hash, Time: l1Origin.Time + 2,
+		L1Origin: l1Origin.ID(), SequenceNumber: 2,
+	}
+	block3 := eth.L2BlockRef{
+		Hash: testutils.RandomHash(rng), Number: 3,
+		ParentHash: block2.Hash, Time: l1Origin.Time + 3,
+		L1Origin: l1Origin.ID(), SequenceNumber: 3,
+	}
+	block4 := eth.L2BlockRef{
+		Hash: testutils.RandomHash(rng), Number: 4,
+		ParentHash: block3.Hash, Time: l1Origin.Time + 4,
+		L1Origin: l1Origin.ID(), SequenceNumber: 4,
+	}
+	block5 := eth.L2BlockRef{
+		Hash: testutils.RandomHash(rng), Number: 5,
+		ParentHash: block4.Hash, Time: l1Origin.Time + 5,
+		L1Origin: l1Origin.ID(), SequenceNumber: 5,
+	}
+
+	cfg := &rollup.Config{}
+	mockEngine := &testutils.MockEngine{}
+	emitter := &testutils.MockEmitter{}
+
+	// supervisorEnabled=true with no superAuthority:
+	//   SafeL2Head() returns deprecatedSafeHead (cross-safe)
+	//   FinalizedHead() returns deprecatedFinalizedHead
+	// This lets us observe cross-safe independently from local-safe.
+	ec := NewEngineController(context.Background(), mockEngine, testlog.Logger(t, 0),
+		metrics.NoopMetrics, cfg, &sync.Config{}, true, &testutils.MockL1Source{}, emitter, nil)
+
+	// Initial state: unsafe=block5, localSafe=block2, crossSafe=block2, finalized=block1
+	ec.unsafeHead = block5
+	ec.SetLocalSafeHead(block2)
+	ec.SetSafeHead(block2)      // deprecatedSafeHead = block2
+	ec.SetFinalizedHead(block1) // deprecatedFinalizedHead = block1
+	ec.needFCUCall = false      // reset after setup
+
+	// Mock expectations:
+	// Allow any events from the emitter (LocalSafeUpdateEvent, SafeDerivedEvent, etc.)
+	emitter.Mock.On("Emit", mock.Anything).Maybe()
+
+	// Consolidation lookup: after fix, uses eLocalSafeRef.Number (5)
+	mockEngine.ExpectL2BlockRefByNumber(5, block5, nil)
+
+	// FCU from PromoteSafe's tryUpdateEngine: safe=block4, finalized still block1
+	mockEngine.ExpectForkchoiceUpdate(
+		&eth.ForkchoiceState{
+			HeadBlockHash:      block5.Hash,
+			SafeBlockHash:      block4.Hash,
+			FinalizedBlockHash: block1.Hash,
+		}, nil,
+		&eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionValid}}, nil,
+	)
+	// FCU from promoteFinalized's tryUpdateEngine: finalized now block3
+	mockEngine.ExpectForkchoiceUpdate(
+		&eth.ForkchoiceState{
+			HeadBlockHash:      block5.Hash,
+			SafeBlockHash:      block4.Hash,
+			FinalizedBlockHash: block3.Hash,
+		}, nil,
+		&eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionValid}}, nil,
+	)
+
+	// Call FollowSource with divergent cross-safe (block4) and local-safe (block5)
+	ec.FollowSource(block4, block5, block3)
+
+	// Assert the final head state
+	require.Equal(t, block5, ec.localSafeHead, "localSafeHead should be updated to block5")
+	require.Equal(t, block4, ec.deprecatedSafeHead, "deprecatedSafeHead (cross-safe) should be updated to block4")
+	require.Equal(t, block3, ec.localFinalizedHead, "finalized should be updated to block3")
+
+	// Assert the invariant: cross-safe <= local-safe
+	require.LessOrEqual(t, ec.deprecatedSafeHead.Number, ec.localSafeHead.Number,
+		"invariant: cross-safe (deprecatedSafeHead) must not exceed local-safe")
+}
 
 // TestEngineController_FinalizedHead tests FinalizedHead behavior with various configurations
 func TestEngineController_FinalizedHead(t *testing.T) {

--- a/op-node/rollup/engine/engine_controller_test.go
+++ b/op-node/rollup/engine/engine_controller_test.go
@@ -435,16 +435,17 @@ func TestFollowSource_DivergentLocalSafeAndCrossSafe(t *testing.T) {
 		L1Origin: l1Origin.ID(), SequenceNumber: 5,
 	}
 
-	cfg := &rollup.Config{}
+	interopTime := uint64(0)
+	cfg := &rollup.Config{InteropTime: &interopTime}
 	mockEngine := &testutils.MockEngine{}
 	emitter := &testutils.MockEmitter{}
 
-	// supervisorEnabled=true with no superAuthority:
+	// FollowSourceEnabled=true with no superAuthority:
 	//   SafeL2Head() returns deprecatedSafeHead (cross-safe)
 	//   FinalizedHead() returns deprecatedFinalizedHead
 	// This lets us observe cross-safe independently from local-safe.
 	ec := NewEngineController(context.Background(), mockEngine, testlog.Logger(t, 0),
-		metrics.NoopMetrics, cfg, &sync.Config{}, true, &testutils.MockL1Source{}, emitter, nil)
+		metrics.NoopMetrics, cfg, &sync.Config{L2FollowSourceEndpoint: "http://localhost"}, false, &testutils.MockL1Source{}, emitter, nil)
 
 	// Initial state: unsafe=block5, localSafe=block2, crossSafe=block2, finalized=block1
 	ec.unsafeHead = block5
@@ -485,7 +486,7 @@ func TestFollowSource_DivergentLocalSafeAndCrossSafe(t *testing.T) {
 	// Assert the final head state
 	require.Equal(t, block5, ec.localSafeHead, "localSafeHead should be updated to block5")
 	require.Equal(t, block4, ec.deprecatedSafeHead, "deprecatedSafeHead (cross-safe) should be updated to block4")
-	require.Equal(t, block3, ec.localFinalizedHead, "finalized should be updated to block3")
+	require.Equal(t, block3, ec.deprecatedFinalizedHead, "deprecatedFinalizedHead (cross-finalized) should be updated to block3")
 
 	// Assert the invariant: cross-safe <= local-safe
 	require.LessOrEqual(t, ec.deprecatedSafeHead.Number, ec.localSafeHead.Number,

--- a/op-service/sources/follow_client.go
+++ b/op-service/sources/follow_client.go
@@ -14,6 +14,7 @@ type FollowClient struct {
 
 type FollowStatus struct {
 	SafeL2      eth.L2BlockRef
+	LocalSafeL2 eth.L2BlockRef
 	FinalizedL2 eth.L2BlockRef
 	CurrentL1   eth.L1BlockRef
 }
@@ -31,6 +32,7 @@ func (s *FollowClient) GetFollowStatus(ctx context.Context) (*FollowStatus, erro
 	return &FollowStatus{
 		FinalizedL2: status.FinalizedL2,
 		SafeL2:      status.SafeL2,
+		LocalSafeL2: status.LocalSafeL2,
 		CurrentL1:   status.CurrentL1,
 	}, nil
 }

--- a/op-service/sources/follow_client_test.go
+++ b/op-service/sources/follow_client_test.go
@@ -1,0 +1,74 @@
+package sources
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFollowClient_GetFollowStatus(t *testing.T) {
+	t.Run("CopiesLocalSafeL2", func(t *testing.T) {
+		ctx := context.Background()
+		rpc := new(mockRPC)
+		defer rpc.AssertExpectations(t)
+
+		client, err := NewFollowClient(rpc)
+		require.NoError(t, err)
+
+		// Create a mock sync status with distinct values for each field
+		// to ensure we're copying the right fields
+		mockSyncStatus := &eth.SyncStatus{
+			CurrentL1: eth.L1BlockRef{
+				Hash:   common.Hash{0x01},
+				Number: 100,
+			},
+			SafeL2: eth.L2BlockRef{
+				Hash:   common.Hash{0x02},
+				Number: 50,
+			},
+			LocalSafeL2: eth.L2BlockRef{
+				Hash:   common.Hash{0x03},
+				Number: 45, // LocalSafe can be different from (cross) Safe
+			},
+			FinalizedL2: eth.L2BlockRef{
+				Hash:   common.Hash{0x04},
+				Number: 40,
+			},
+		}
+
+		rpc.On("CallContext", ctx, mock.AnythingOfType("**eth.SyncStatus"),
+			"optimism_syncStatus", []any(nil)).Run(func(args mock.Arguments) {
+			// Set the result pointer to our mock sync status
+			*args[1].(**eth.SyncStatus) = mockSyncStatus
+		}).Return([]error{nil})
+
+		status, err := client.GetFollowStatus(ctx)
+		require.NoError(t, err)
+
+		// Verify all fields are correctly copied
+		require.Equal(t, mockSyncStatus.CurrentL1, status.CurrentL1, "CurrentL1 should be copied")
+		require.Equal(t, mockSyncStatus.SafeL2, status.SafeL2, "SafeL2 should be copied")
+		require.Equal(t, mockSyncStatus.FinalizedL2, status.FinalizedL2, "FinalizedL2 should be copied")
+		require.Equal(t, mockSyncStatus.LocalSafeL2, status.LocalSafeL2, "LocalSafeL2 should be copied")
+	})
+
+	t.Run("Error", func(t *testing.T) {
+		ctx := context.Background()
+		rpc := new(mockRPC)
+		defer rpc.AssertExpectations(t)
+
+		client, err := NewFollowClient(rpc)
+		require.NoError(t, err)
+
+		rpc.On("CallContext", ctx, mock.AnythingOfType("**eth.SyncStatus"),
+			"optimism_syncStatus", []any(nil)).Return([]error{context.DeadlineExceeded})
+
+		_, err = client.GetFollowStatus(ctx)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to fetch external syncStatus")
+	})
+}


### PR DESCRIPTION
# Tool Use Notice
Generated and Self Reviewed. May compact the testing.

# What

When op-node runs in light-node/follow-source mode, it follows an upstream node's sync status. Previously, FollowClient.GetFollowStatus() only copied SafeL2, FinalizedL2, and CurrentL1 - but not LocalSafeL2.

The FollowSource() function was incorrectly using SafeL2 (cross-safe) for updating the local-safe head, when it should use the upstream's LocalSafeL2 instead.

Changes:
- Add LocalSafeL2 field to FollowStatus struct
- Copy LocalSafeL2 from upstream sync status in GetFollowStatus()
- Update FollowSource() to accept separate LocalSafe parameter
- Pass LocalSafeL2 through followUpstream() to FollowSource()

# Tests
- Add test for FollowClient to verify LocalSafeL2 is copied. This also verifies _all_ fields are correctly copied.

