### PR TITLE
supernode: Return whatever optimistic blocks are available

### DIFF
--- a/op-acceptance-tests/tests/interop/proofs/fpp/fpp_test.go
+++ b/op-acceptance-tests/tests/interop/proofs/fpp/fpp_test.go
@@ -22,8 +22,6 @@ func TestFPP(gt *testing.T) {
 
 func TestNextSuperRootNotFound(gt *testing.T) {
 	t := devtest.SerialT(gt)
-	// TODO(#19180): Unskip this once supernode is updated.
-	t.Skip("Supernode does not yet return optimistic blocks until blocks are fully validated")
 	sys := presets.NewSimpleInterop(t)
 	blockTime := sys.L2ChainA.Escape().RollupConfig().BlockTime
 

--- a/op-acceptance-tests/tests/interop/proofs/serial/interop_fault_proofs_test.go
+++ b/op-acceptance-tests/tests/interop/proofs/serial/interop_fault_proofs_test.go
@@ -10,8 +10,6 @@ import (
 
 func TestInteropFaultProofs(gt *testing.T) {
 	t := devtest.SerialT(gt)
-	// TODO(#19180): Unskip this once supernode is updated.
-	t.Skip("Supernode does not yet return optimistic blocks until blocks are fully validated")
 	sys := presets.NewSimpleInterop(t)
 	sfp.RunSuperFaultProofTest(t, sys)
 }

--- a/op-acceptance-tests/tests/superfaultproofs/singlechain.go
+++ b/op-acceptance-tests/tests/superfaultproofs/singlechain.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
@@ -34,7 +35,7 @@ func RunSingleChainSuperFaultProofSmokeTest(t devtest.T, sys *presets.SingleChai
 	// Stop batch submission so safe head stalls, then we have a known boundary.
 	c.Batcher.Stop()
 	t.Cleanup(c.Batcher.Start)
-	awaitSafeHeadsStalled(t, sys.L2CLA)
+	sys.L2CLA.Stalled(types.CrossSafe)
 
 	endTimestamp := nextTimestampAfterSafeHeads(t, chains)
 	startTimestamp := endTimestamp - 1
@@ -45,9 +46,7 @@ func RunSingleChainSuperFaultProofSmokeTest(t devtest.T, sys *presets.SingleChai
 	c.EL.Reached(eth.Unsafe, target, 60)
 
 	// L1 head where chain has no batch data at endTimestamp.
-	respBefore := awaitOptimisticPattern(t, sys.SuperRoots, endTimestamp,
-		nil, []eth.ChainID{c.ID})
-	l1HeadBefore := respBefore.CurrentL1
+	l1HeadBefore := l1BlockWhere(t, sys.L1EL, sys.SuperRoots, endTimestamp, nil, []eth.ChainID{c.ID})
 
 	// Resume batching so the chain's data at endTimestamp becomes available.
 	c.Batcher.Start()

--- a/op-acceptance-tests/tests/superfaultproofs/singlechain.go
+++ b/op-acceptance-tests/tests/superfaultproofs/singlechain.go
@@ -35,7 +35,7 @@ func RunSingleChainSuperFaultProofSmokeTest(t devtest.T, sys *presets.SingleChai
 	// Stop batch submission so safe head stalls, then we have a known boundary.
 	c.Batcher.Stop()
 	t.Cleanup(c.Batcher.Start)
-	sys.L2CLA.Stalled(types.CrossSafe)
+	sys.L2CLA.WaitForStall(types.CrossSafe)
 
 	endTimestamp := nextTimestampAfterSafeHeads(t, chains)
 	startTimestamp := endTimestamp - 1

--- a/op-acceptance-tests/tests/superfaultproofs/singlechain.go
+++ b/op-acceptance-tests/tests/superfaultproofs/singlechain.go
@@ -46,7 +46,7 @@ func RunSingleChainSuperFaultProofSmokeTest(t devtest.T, sys *presets.SingleChai
 	c.EL.Reached(eth.Unsafe, target, 60)
 
 	// L1 head where chain has no batch data at endTimestamp.
-	l1HeadBefore := l1BlockWhere(t, sys.L1EL, sys.SuperRoots, endTimestamp, nil, []eth.ChainID{c.ID})
+	l1HeadBefore := l1BlockWithLocalSafeBlocks(t, sys.L1EL, sys.SuperRoots, endTimestamp, nil, []eth.ChainID{c.ID})
 
 	// Resume batching so the chain's data at endTimestamp becomes available.
 	c.Batcher.Start()

--- a/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
+++ b/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
@@ -124,8 +124,8 @@ func latestRequiredL1(resp eth.SuperRootAtTimestampResponse) eth.BlockID {
 	return latest
 }
 
-// l1BlockWhere finds an L1 block where the specified chains either do or do not have safe blocks.
-func l1BlockWhere(t devtest.T, l1El *dsl.L1ELNode, sn *dsl.Supernode, timestamp uint64, hasSafe, notSafe []eth.ChainID) eth.BlockID {
+// l1BlockWithLocalSafeBlocks finds an L1 block where the specified chains either do or do not have safe blocks.
+func l1BlockWithLocalSafeBlocks(t devtest.T, l1El *dsl.L1ELNode, sn *dsl.Supernode, timestamp uint64, hasSafe, notSafe []eth.ChainID) eth.BlockID {
 	t.Logf("Finding L1 block where %v have safe blocks and %v do not", hasSafe, notSafe)
 	var l1Block eth.BlockID
 	t.Require().Eventually(func() bool {
@@ -583,11 +583,11 @@ func RunSuperFaultProofTest(t devtest.T, sys *presets.SimpleInterop) {
 	// -- Stage 2: Capture L1 heads at different batch-availability points --
 
 	// L1 head where neither chain has batch data at endTimestamp.
-	l1HeadBefore := l1BlockWhere(t, sys.L1EL, sys.SuperRoots, endTimestamp, nil, []eth.ChainID{chains[0].ID, chains[1].ID})
+	l1HeadBefore := l1BlockWithLocalSafeBlocks(t, sys.L1EL, sys.SuperRoots, endTimestamp, nil, []eth.ChainID{chains[0].ID, chains[1].ID})
 
 	// L1 head where only the first chain has batch data.
 	chains[0].Batcher.Start()
-	l1HeadAfterFirst := l1BlockWhere(t, sys.L1EL, sys.SuperRoots, endTimestamp, []eth.ChainID{chains[0].ID}, []eth.ChainID{chains[1].ID})
+	l1HeadAfterFirst := l1BlockWithLocalSafeBlocks(t, sys.L1EL, sys.SuperRoots, endTimestamp, []eth.ChainID{chains[0].ID}, []eth.ChainID{chains[1].ID})
 	chains[0].Batcher.Stop()
 
 	// L1 head where both chains have batch data (fully validated).

--- a/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
+++ b/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
@@ -2,6 +2,8 @@ package superfaultproofs
 
 import (
 	"context"
+	"encoding/json"
+	"math"
 	"math/big"
 	"math/rand"
 	"os"
@@ -144,25 +146,41 @@ func awaitSafeHeadsStalled(t devtest.T, nodes ...*dsl.L2CLNode) {
 	}, 2*time.Minute, 2*time.Second, "safe heads did not stall in time")
 }
 
-// awaitOptimisticPattern polls the supernode until every chain in mustHave has
-// optimistic data and every chain in mustMiss does not.
-func awaitOptimisticPattern(t devtest.T, sn *dsl.Supernode, timestamp uint64, mustHave, mustMiss []eth.ChainID) eth.SuperRootAtTimestampResponse {
-	var resp eth.SuperRootAtTimestampResponse
+// l1BlockWhere finds an L1 block where the specified chains either do or do not have safe blocks.
+func l1BlockWhere(t devtest.T, l1El *dsl.L1ELNode, sn *dsl.Supernode, timestamp uint64, hasSafe, notSafe []eth.ChainID) eth.BlockID {
+	t.Logf("Finding L1 block where %v have safe blocks and %v do not", hasSafe, notSafe)
+	var l1Block eth.BlockID
 	t.Require().Eventually(func() bool {
-		resp = sn.SuperRootAtTimestamp(timestamp)
-		for _, id := range mustHave {
-			if _, has := resp.OptimisticAtTimestamp[id]; !has {
+		resp := sn.SuperRootAtTimestamp(timestamp)
+		respJsonBytes, err := json.Marshal(resp)
+		t.Require().NoError(err)
+		respJson := string(respJsonBytes)
+		t.Logf("SuperRootAtTimestamp response: %s", respJson)
+		candidate := uint64(math.MaxUint64)
+		for _, id := range notSafe {
+			if optimistic, has := resp.OptimisticAtTimestamp[id]; has && optimistic.RequiredL1.Number <= candidate {
+				candidate = optimistic.RequiredL1.Number - 1 // We need this chain to not have a safe block, so L1 head must be the block before it.
+			}
+		}
+		// If we didn't have any notSafe chains, we can use the current L1 block.
+		if candidate == math.MaxUint64 {
+			candidate = resp.CurrentL1.Number
+		}
+		// Now verify that all the required chains have a safe block at the candidate L1 block.
+		for _, id := range hasSafe {
+			if optimistic, has := resp.OptimisticAtTimestamp[id]; !has {
+				t.Logf("Did not find safe block for chain %v in %v", id, respJson)
+				return false
+			} else if optimistic.RequiredL1.Number > candidate {
+				t.Logf("Required L1 block for chain %v is %v, but candidate is %v in %v", id, optimistic.RequiredL1.Number, candidate, respJson)
 				return false
 			}
 		}
-		for _, id := range mustMiss {
-			if _, has := resp.OptimisticAtTimestamp[id]; has {
-				return false
-			}
-		}
+
+		l1Block = l1El.BlockRefByNumber(candidate).ID()
 		return true
-	}, 2*time.Minute, 2*time.Second, "timed out waiting for optimistic pattern")
-	return resp
+	}, 2*time.Minute, 2*time.Second, "timed out waiting for l1 block")
+	return l1Block
 }
 
 // runKonaInteropProgram runs the kona interop fault proof program and checks the result.
@@ -591,15 +609,11 @@ func RunSuperFaultProofTest(t devtest.T, sys *presets.SimpleInterop) {
 	// -- Stage 2: Capture L1 heads at different batch-availability points --
 
 	// L1 head where neither chain has batch data at endTimestamp.
-	respBefore := awaitOptimisticPattern(t, sys.SuperRoots, endTimestamp,
-		nil, []eth.ChainID{chains[0].ID, chains[1].ID})
-	l1HeadBefore := respBefore.CurrentL1
+	l1HeadBefore := l1BlockWhere(t, sys.L1EL, sys.SuperRoots, endTimestamp, nil, []eth.ChainID{chains[0].ID, chains[1].ID})
 
 	// L1 head where only the first chain has batch data.
 	chains[0].Batcher.Start()
-	respAfterFirst := awaitOptimisticPattern(t, sys.SuperRoots, endTimestamp,
-		[]eth.ChainID{chains[0].ID}, []eth.ChainID{chains[1].ID})
-	l1HeadAfterFirst := respAfterFirst.CurrentL1
+	l1HeadAfterFirst := l1BlockWhere(t, sys.L1EL, sys.SuperRoots, endTimestamp, []eth.ChainID{chains[0].ID}, []eth.ChainID{chains[1].ID})
 	chains[0].Batcher.Stop()
 
 	// L1 head where both chains have batch data (fully validated).

--- a/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
+++ b/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
@@ -2,7 +2,6 @@ package superfaultproofs
 
 import (
 	"context"
-	"encoding/json"
 	"math"
 	"math/big"
 	"math/rand"
@@ -26,6 +25,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/apis"
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 )
@@ -124,38 +124,13 @@ func latestRequiredL1(resp eth.SuperRootAtTimestampResponse) eth.BlockID {
 	return latest
 }
 
-// awaitSafeHeadsStalled waits until every node's safe head has stopped advancing
-// for at least 10 seconds.
-func awaitSafeHeadsStalled(t devtest.T, nodes ...*dsl.L2CLNode) {
-	var last []eth.BlockID
-	var stableSince time.Time
-	t.Require().Eventually(func() bool {
-		cur := make([]eth.BlockID, len(nodes))
-		for i, n := range nodes {
-			cur[i] = n.SyncStatus().SafeL2.ID()
-		}
-		if slices.Equal(cur, last) {
-			if stableSince.IsZero() {
-				stableSince = time.Now()
-			}
-			return time.Since(stableSince) >= 10*time.Second
-		}
-		last = cur
-		stableSince = time.Time{}
-		return false
-	}, 2*time.Minute, 2*time.Second, "safe heads did not stall in time")
-}
-
 // l1BlockWhere finds an L1 block where the specified chains either do or do not have safe blocks.
 func l1BlockWhere(t devtest.T, l1El *dsl.L1ELNode, sn *dsl.Supernode, timestamp uint64, hasSafe, notSafe []eth.ChainID) eth.BlockID {
 	t.Logf("Finding L1 block where %v have safe blocks and %v do not", hasSafe, notSafe)
 	var l1Block eth.BlockID
 	t.Require().Eventually(func() bool {
 		resp := sn.SuperRootAtTimestamp(timestamp)
-		respJsonBytes, err := json.Marshal(resp)
-		t.Require().NoError(err)
-		respJson := string(respJsonBytes)
-		t.Logf("SuperRootAtTimestamp response: %s", respJson)
+
 		candidate := uint64(math.MaxUint64)
 		for _, id := range notSafe {
 			if optimistic, has := resp.OptimisticAtTimestamp[id]; has && optimistic.RequiredL1.Number <= candidate {
@@ -166,13 +141,12 @@ func l1BlockWhere(t devtest.T, l1El *dsl.L1ELNode, sn *dsl.Supernode, timestamp 
 		if candidate == math.MaxUint64 {
 			candidate = resp.CurrentL1.Number
 		}
+
 		// Now verify that all the required chains have a safe block at the candidate L1 block.
 		for _, id := range hasSafe {
 			if optimistic, has := resp.OptimisticAtTimestamp[id]; !has {
-				t.Logf("Did not find safe block for chain %v in %v", id, respJson)
 				return false
 			} else if optimistic.RequiredL1.Number > candidate {
-				t.Logf("Required L1 block for chain %v is %v, but candidate is %v in %v", id, optimistic.RequiredL1.Number, candidate, respJson)
 				return false
 			}
 		}
@@ -503,7 +477,7 @@ func RunUnsafeProposalTest(t devtest.T, sys *presets.SimpleInterop) {
 	//     that timestamp maps to a block at or below every chain's safe head.
 	chains[0].Batcher.Stop()
 	defer chains[0].Batcher.Start()
-	awaitSafeHeadsStalled(t, chains[0].CLNode)
+	chains[0].CLNode.Stalled(types.LocalSafe)
 
 	stalledStatus, err := chains[0].Rollup.SyncStatus(t.Ctx())
 	t.Require().NoError(err)
@@ -520,7 +494,7 @@ func RunUnsafeProposalTest(t devtest.T, sys *presets.SimpleInterop) {
 
 	chains[1].Batcher.Stop()
 	defer chains[1].Batcher.Start()
-	awaitSafeHeadsStalled(t, chains[1].CLNode)
+	chains[1].CLNode.Stalled(types.LocalSafe)
 
 	endTimestamp := chains[0].Cfg.TimestampForBlock(stalledSafeHead + 1)
 	agreedTimestamp := endTimestamp - 1
@@ -588,13 +562,13 @@ func RunSuperFaultProofTest(t devtest.T, sys *presets.SimpleInterop) {
 	t.Require().Len(chains, 2, "expected exactly 2 interop chains")
 
 	// -- Stage 1: Freeze batch submission ----------------------------------
+	chains[1].Batcher.Stop() // Stop chain 1 first and wait for chains[0] to have at least that local safe head.
+	t.Cleanup(chains[1].Batcher.Start)
+	// Wait for safe heads to stall (local safe will continue on chains[0] but interop validation can't progress because chains[1] local safe has stalled)
+	chains[1].CLNode.Stalled(types.CrossSafe)
 	chains[0].Batcher.Stop()
-	chains[1].Batcher.Stop()
-	t.Cleanup(func() {
-		chains[0].Batcher.Start()
-		chains[1].Batcher.Start()
-	})
-	awaitSafeHeadsStalled(t, sys.L2CLA, sys.L2CLB)
+	t.Cleanup(chains[0].Batcher.Start)
+	chains[0].CLNode.Stalled(types.LocalSafe) // Wait for chains[0] local safe head to stall
 
 	endTimestamp := nextTimestampAfterSafeHeads(t, chains)
 	startTimestamp := endTimestamp - 1

--- a/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
+++ b/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
@@ -477,7 +477,7 @@ func RunUnsafeProposalTest(t devtest.T, sys *presets.SimpleInterop) {
 	//     that timestamp maps to a block at or below every chain's safe head.
 	chains[0].Batcher.Stop()
 	defer chains[0].Batcher.Start()
-	chains[0].CLNode.Stalled(types.LocalSafe)
+	chains[0].CLNode.WaitForStall(types.LocalSafe)
 
 	stalledStatus, err := chains[0].Rollup.SyncStatus(t.Ctx())
 	t.Require().NoError(err)
@@ -494,7 +494,7 @@ func RunUnsafeProposalTest(t devtest.T, sys *presets.SimpleInterop) {
 
 	chains[1].Batcher.Stop()
 	defer chains[1].Batcher.Start()
-	chains[1].CLNode.Stalled(types.LocalSafe)
+	chains[1].CLNode.WaitForStall(types.LocalSafe)
 
 	endTimestamp := chains[0].Cfg.TimestampForBlock(stalledSafeHead + 1)
 	agreedTimestamp := endTimestamp - 1
@@ -565,10 +565,10 @@ func RunSuperFaultProofTest(t devtest.T, sys *presets.SimpleInterop) {
 	chains[1].Batcher.Stop() // Stop chain 1 first and wait for chains[0] to have at least that local safe head.
 	t.Cleanup(chains[1].Batcher.Start)
 	// Wait for safe heads to stall (local safe will continue on chains[0] but interop validation can't progress because chains[1] local safe has stalled)
-	chains[1].CLNode.Stalled(types.CrossSafe)
+	chains[1].CLNode.WaitForStall(types.CrossSafe)
 	chains[0].Batcher.Stop()
 	t.Cleanup(chains[0].Batcher.Start)
-	chains[0].CLNode.Stalled(types.LocalSafe) // Wait for chains[0] local safe head to stall
+	chains[0].CLNode.WaitForStall(types.LocalSafe) // Wait for chains[0] local safe head to stall
 
 	endTimestamp := nextTimestampAfterSafeHeads(t, chains)
 	startTimestamp := endTimestamp - 1

--- a/op-devstack/dsl/l2_cl.go
+++ b/op-devstack/dsl/l2_cl.go
@@ -170,7 +170,7 @@ func (cl *L2CLNode) NotAdvancedFn(lvl types.SafetyLevel, attempts int) CheckFunc
 
 // awaitSafeHeadsStalled waits until every node's safe head has stopped advancing
 // for at least 10 seconds.
-func (cl *L2CLNode) Stalled(lvl types.SafetyLevel) {
+func (cl *L2CLNode) WaitForStall(lvl types.SafetyLevel) {
 	var last eth.BlockID
 	var stableSince time.Time
 	cl.require.Eventuallyf(func() bool {

--- a/op-devstack/dsl/l2_cl.go
+++ b/op-devstack/dsl/l2_cl.go
@@ -168,6 +168,25 @@ func (cl *L2CLNode) NotAdvancedFn(lvl types.SafetyLevel, attempts int) CheckFunc
 	}
 }
 
+// awaitSafeHeadsStalled waits until every node's safe head has stopped advancing
+// for at least 10 seconds.
+func (cl *L2CLNode) Stalled(lvl types.SafetyLevel) {
+	var last eth.BlockID
+	var stableSince time.Time
+	cl.require.Eventuallyf(func() bool {
+		cur := cl.HeadBlockRef(lvl).ID()
+		if cur == last {
+			if stableSince.IsZero() {
+				stableSince = time.Now()
+			}
+			return time.Since(stableSince) >= 10*time.Second
+		}
+		last = cur
+		stableSince = time.Time{}
+		return false
+	}, 2*time.Minute, 2*time.Second, "expected %v head to stall", lvl)
+}
+
 // ReachedFn returns a lambda that checks the L2CL chain head with given safety level reaches the target block number
 // Composable with other lambdas to wait in parallel
 func (cl *L2CLNode) ReachedFn(lvl types.SafetyLevel, target uint64, attempts int) CheckFunc {

--- a/op-supernode/supernode/activity/superroot/superroot.go
+++ b/op-supernode/supernode/activity/superroot/superroot.go
@@ -105,30 +105,38 @@ func (s *Superroot) atTimestamp(ctx context.Context, timestamp uint64) (eth.Supe
 		verifiedL2, verifiedL1, err := chain.VerifiedAt(ctx, timestamp)
 		if errors.Is(err, ethereum.NotFound) {
 			notFound = true
-			continue // To allow other chains to populate unverified blocks
+			// Fall through to still collect optimistic data for this chain
 		} else if err != nil {
 			s.log.Warn("failed to get verified block", "chain_id", chainID.String(), "err", err)
 			return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("failed to get verified block: %w", err)
+		} else {
+			// Verified data is available: update min required L1 and collect the output root
+			if verifiedL1.Number < minVerifiedRequiredL1.Number || minVerifiedRequiredL1 == (eth.BlockID{}) {
+				minVerifiedRequiredL1 = verifiedL1
+			}
+			// Compute output root at or before timestamp using the verified L2 block number
+			outRoot, err := chain.OutputRootAtL2BlockNumber(ctx, verifiedL2.Number)
+			if err != nil {
+				s.log.Warn("failed to compute output root at L2 block", "chain_id", chainID.String(), "l2_number", verifiedL2.Number, "err", err)
+				return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("failed to compute output root at L2 block %d for chain ID %v: %w", verifiedL2.Number, chainID, err)
+			}
+			chainOutputs = append(chainOutputs, eth.ChainIDAndOutput{ChainID: chainID, Output: outRoot})
 		}
-		if verifiedL1.Number < minVerifiedRequiredL1.Number || minVerifiedRequiredL1 == (eth.BlockID{}) {
-			minVerifiedRequiredL1 = verifiedL1
-		}
-		// Compute output root at or before timestamp using the verified L2 block number
-		outRoot, err := chain.OutputRootAtL2BlockNumber(ctx, verifiedL2.Number)
-		if err != nil {
-			s.log.Warn("failed to compute output root at L2 block", "chain_id", chainID.String(), "l2_number", verifiedL2.Number, "err", err)
-			return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("failed to compute output root at L2 block %d for chain ID %v: %w", verifiedL2.Number, chainID, err)
-		}
-		chainOutputs = append(chainOutputs, eth.ChainIDAndOutput{ChainID: chainID, Output: outRoot})
-		// Optimistic output is the full output at the optimistic L2 block for the timestamp
+
+		// Collect optimistic data for this chain regardless of whether verified data is available.
+		// If optimistic data is also absent, the chain is simply excluded from OptimisticAtTimestamp.
 		optimisticOut, err := chain.OptimisticOutputAtTimestamp(ctx, timestamp)
-		if err != nil {
+		if errors.Is(err, ethereum.NotFound) {
+			continue
+		} else if err != nil {
 			s.log.Warn("failed to get optimistic block", "chain_id", chainID.String(), "err", err)
 			return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("failed to get optimistic block at timestamp %v for chain ID %v: %w", timestamp, chainID, err)
 		}
 		// Also include the source L1 for context
 		_, optimisticL1, err := chain.OptimisticAt(ctx, timestamp)
-		if err != nil {
+		if errors.Is(err, ethereum.NotFound) {
+			continue
+		} else if err != nil {
 			s.log.Warn("failed to get optimistic source L1", "chain_id", chainID.String(), "err", err)
 			return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("failed to get optimistic source L1 at timestamp %v for chain ID %v: %w", timestamp, chainID, err)
 		}

--- a/op-supernode/supernode/activity/superroot/superroot.go
+++ b/op-supernode/supernode/activity/superroot/superroot.go
@@ -98,35 +98,36 @@ func (s *Superroot) atTimestamp(ctx context.Context, timestamp uint64) (eth.Supe
 
 	notFound := false
 	chainIDs := make([]eth.ChainID, 0, len(s.chains))
-	// collect verified and optimistic L2 and L1 blocks at the given timestamp
+	// Collect verified L2 and L1 blocks at the given timestamp
 	for chainID, chain := range s.chains {
 		chainIDs = append(chainIDs, chainID)
 		// verifiedAt returns the L2 block which is fully verified at the given timestamp, and the minimum L1 block at which verification is possible
 		verifiedL2, verifiedL1, err := chain.VerifiedAt(ctx, timestamp)
 		if errors.Is(err, ethereum.NotFound) {
 			notFound = true
-			// Fall through to still collect optimistic data for this chain
+			continue
 		} else if err != nil {
 			s.log.Warn("failed to get verified block", "chain_id", chainID.String(), "err", err)
 			return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("failed to get verified block: %w", err)
-		} else {
-			// Verified data is available: update min required L1 and collect the output root
-			if verifiedL1.Number < minVerifiedRequiredL1.Number || minVerifiedRequiredL1 == (eth.BlockID{}) {
-				minVerifiedRequiredL1 = verifiedL1
-			}
-			// Compute output root at or before timestamp using the verified L2 block number
-			outRoot, err := chain.OutputRootAtL2BlockNumber(ctx, verifiedL2.Number)
-			if err != nil {
-				s.log.Warn("failed to compute output root at L2 block", "chain_id", chainID.String(), "l2_number", verifiedL2.Number, "err", err)
-				return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("failed to compute output root at L2 block %d for chain ID %v: %w", verifiedL2.Number, chainID, err)
-			}
-			chainOutputs = append(chainOutputs, eth.ChainIDAndOutput{ChainID: chainID, Output: outRoot})
 		}
+		// Verified data is available: update min required L1 and collect the output root
+		if verifiedL1.Number < minVerifiedRequiredL1.Number || minVerifiedRequiredL1 == (eth.BlockID{}) {
+			minVerifiedRequiredL1 = verifiedL1
+		}
+		// Compute output root at or before timestamp using the verified L2 block number
+		outRoot, err := chain.OutputRootAtL2BlockNumber(ctx, verifiedL2.Number)
+		if err != nil {
+			s.log.Warn("failed to compute output root at L2 block", "chain_id", chainID.String(), "l2_number", verifiedL2.Number, "err", err)
+			return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("failed to compute output root at L2 block %d for chain ID %v: %w", verifiedL2.Number, chainID, err)
+		}
+		chainOutputs = append(chainOutputs, eth.ChainIDAndOutput{ChainID: chainID, Output: outRoot})
+	}
 
-		// Collect optimistic data for this chain regardless of whether verified data is available.
-		// If optimistic data is also absent, the chain is simply excluded from OptimisticAtTimestamp.
+	// Collect optimistic data for all chains regardless of whether verified data is available.
+	for chainID, chain := range s.chains {
 		optimisticOut, err := chain.OptimisticOutputAtTimestamp(ctx, timestamp)
 		if errors.Is(err, ethereum.NotFound) {
+			// If optimistic data is also absent, the chain is simply excluded from OptimisticAtTimestamp.
 			continue
 		} else if err != nil {
 			s.log.Warn("failed to get optimistic block", "chain_id", chainID.String(), "err", err)

--- a/op-supernode/supernode/activity/superroot/superroot_test.go
+++ b/op-supernode/supernode/activity/superroot/superroot_test.go
@@ -218,6 +218,8 @@ func TestSuperroot_AtTimestamp_NotFoundOnVerifiedAt(t *testing.T) {
 	chains := map[eth.ChainID]cc.ChainContainer{
 		eth.ChainIDFromUInt64(10): &mockCC{
 			verifiedErr: fmt.Errorf("nope: %w", ethereum.NotFound),
+			optL2:       eth.BlockID{Number: 100},
+			optL1:       eth.BlockID{Number: 1000},
 		},
 		eth.ChainIDFromUInt64(11): &mockCC{
 			verL2:  eth.BlockID{Number: 200},
@@ -233,8 +235,49 @@ func TestSuperroot_AtTimestamp_NotFoundOnVerifiedAt(t *testing.T) {
 	actual, err := api.AtTimestamp(context.Background(), 123)
 	require.NoError(t, err)
 	require.Nil(t, actual.Data)
+	// Chain 10 has no verified data but optimistic data is available, so it should be present
+	require.Contains(t, actual.OptimisticAtTimestamp, eth.ChainIDFromUInt64(10))
+	require.Contains(t, actual.OptimisticAtTimestamp, eth.ChainIDFromUInt64(11))
+}
+
+func TestSuperroot_AtTimestamp_NotFoundOnVerifiedAtAndOptimisticAt(t *testing.T) {
+	t.Parallel()
+	chains := map[eth.ChainID]cc.ChainContainer{
+		eth.ChainIDFromUInt64(10): &mockCC{
+			verifiedErr:   fmt.Errorf("nope: %w", ethereum.NotFound),
+			optimisticErr: ethereum.NotFound,
+		},
+		eth.ChainIDFromUInt64(11): &mockCC{
+			verL2:  eth.BlockID{Number: 200},
+			verL1:  eth.BlockID{Number: 1100},
+			optL2:  eth.BlockID{Number: 200},
+			optL1:  eth.BlockID{Number: 1100},
+			output: eth.Bytes32{0x12},
+			status: &eth.SyncStatus{CurrentL1: eth.L1BlockRef{Number: 2100}},
+		},
+	}
+	s := New(gethlog.New(), chains)
+	api := &superrootAPI{s: s}
+	actual, err := api.AtTimestamp(context.Background(), 123)
+	require.NoError(t, err)
+	require.Nil(t, actual.Data)
+	// Chain 10 has neither verified nor optimistic data, so it should be absent
 	require.NotContains(t, actual.OptimisticAtTimestamp, eth.ChainIDFromUInt64(10))
 	require.Contains(t, actual.OptimisticAtTimestamp, eth.ChainIDFromUInt64(11))
+}
+
+func TestSuperroot_AtTimestamp_ErrorOnOptimisticAtWhenVerifiedNotFound(t *testing.T) {
+	t.Parallel()
+	chains := map[eth.ChainID]cc.ChainContainer{
+		eth.ChainIDFromUInt64(10): &mockCC{
+			verifiedErr:   fmt.Errorf("nope: %w", ethereum.NotFound),
+			optimisticErr: assertErr(),
+		},
+	}
+	s := New(gethlog.New(), chains)
+	api := &superrootAPI{s: s}
+	_, err := api.AtTimestamp(context.Background(), 123)
+	require.Error(t, err)
 }
 
 func TestSuperroot_AtTimestamp_ErrorOnOutputRoot(t *testing.T) {


### PR DESCRIPTION
**Description**

Include available optimistic blocks in superroot_atTimestamp response, even if not all blocks are available.

**Tests**

Unskips challenger tests that were affected by this.


**Metadata**

Part of #19180
