### PR TITLE
fix(contracts-bedrock): dedupe unoptimized profile mock logic into Setup

### DIFF
--- a/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
@@ -28,8 +28,6 @@ import { DevFeatures } from "src/libraries/DevFeatures.sol";
 import { Types as LibTypes } from "src/libraries/Types.sol";
 import { Encoding } from "src/libraries/Encoding.sol";
 import { Hashing } from "src/libraries/Hashing.sol";
-import { LibString } from "@solady/utils/LibString.sol";
-
 // Interfaces
 import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.sol";
 import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
@@ -270,55 +268,15 @@ contract OPContractsManager_Upgrade_Harness is CommonTest {
         // try to apply to this function call instead.
         IOPContractsManagerStandardValidator validator = _opcm.opcmStandardValidator();
 
-        // When running fork tests with an unoptimized Foundry profile (e.g., liteci),
-        // implementation contracts deployed via CREATE2 get different addresses because
-        // unoptimized bytecode differs from production builds. Most proxies are re-pointed
-        // to new implementations during the OPCM upgrade, so their getProxyImplementation
-        // checks pass regardless of optimizer settings. However, DelayedWETH and ETHLockbox
-        // proxies are NOT re-pointed during the upgrade — they retain the mainnet
-        // implementations. With optimized builds the CREATE2 addresses match mainnet, but
-        // with unoptimized builds they diverge. Mock getProxyImplementation for these
-        // proxies so the validator sees the expected implementation addresses.
-        {
-            string memory _profile = Config.foundryProfile();
-            bool _isOptimizedProfile = LibString.eq(_profile, "default") || LibString.eq(_profile, "ci");
-            if (!_isOptimizedProfile) {
-                IDelayedWETH _cannonWeth = DisputeGames.getGameImplDelayedWeth(disputeGameFactory, GameTypes.CANNON);
-                if (address(_cannonWeth) != address(0)) {
-                    vm.mockCall(
-                        address(proxyAdmin),
-                        abi.encodeCall(IProxyAdmin.getProxyImplementation, (address(_cannonWeth))),
-                        abi.encode(validator.delayedWETHImpl())
-                    );
-                }
-                IDelayedWETH _permissionedWeth =
-                    DisputeGames.getGameImplDelayedWeth(disputeGameFactory, GameTypes.PERMISSIONED_CANNON);
-                if (address(_permissionedWeth) != address(0)) {
-                    vm.mockCall(
-                        address(proxyAdmin),
-                        abi.encodeCall(IProxyAdmin.getProxyImplementation, (address(_permissionedWeth))),
-                        abi.encode(validator.delayedWETHImpl())
-                    );
-                }
-                IDelayedWETH _cannonKonaWeth =
-                    DisputeGames.getGameImplDelayedWeth(disputeGameFactory, GameTypes.CANNON_KONA);
-                if (address(_cannonKonaWeth) != address(0)) {
-                    vm.mockCall(
-                        address(proxyAdmin),
-                        abi.encodeCall(IProxyAdmin.getProxyImplementation, (address(_cannonKonaWeth))),
-                        abi.encode(validator.delayedWETHImpl())
-                    );
-                }
-                IETHLockbox _lockbox = optimismPortal2.ethLockbox();
-                if (address(_lockbox) != address(0)) {
-                    vm.mockCall(
-                        address(proxyAdmin),
-                        abi.encodeCall(IProxyAdmin.getProxyImplementation, (address(_lockbox))),
-                        abi.encode(validator.ethLockboxImpl())
-                    );
-                }
-            }
-        }
+        // Mock getProxyImplementation for DelayedWETH and ETHLockbox proxies when running
+        // with an unoptimized Foundry profile. See Setup.mockUnoptimizedProxyImplementations.
+        mockUnoptimizedProxyImplementations(
+            disputeGameFactory,
+            proxyAdmin,
+            address(optimismPortal2.ethLockbox()),
+            validator.delayedWETHImpl(),
+            validator.ethLockboxImpl()
+        );
 
         // If the absolute prestate is zero, we will always get a PDDG-40,PLDG-40 error here in the
         // standard validator. This happens because an absolute prestate of zero means that the

--- a/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
@@ -5,10 +5,7 @@ pragma solidity 0.8.15;
 import { CommonTest } from "test/setup/CommonTest.sol";
 import { StandardConstants } from "scripts/deploy/StandardConstants.sol";
 import { DisputeGames } from "../setup/DisputeGames.sol";
-import { Config } from "scripts/libraries/Config.sol";
-
 // Libraries
-import { LibString } from "@solady/utils/LibString.sol";
 import { GameType, Hash } from "src/dispute/lib/LibUDT.sol";
 import { GameTypes, Duration, Claim } from "src/dispute/lib/Types.sol";
 import { ForgeArtifacts } from "scripts/libraries/ForgeArtifacts.sol";
@@ -191,53 +188,15 @@ abstract contract OPContractsManagerStandardValidator_TestInit is CommonTest {
                 abi.encode(standardValidator.optimismMintableERC20FactoryImpl())
             );
 
-            // When running fork tests with an unoptimized Foundry profile (e.g., liteci),
-            // implementation contracts deployed via CREATE2 get different addresses because
-            // unoptimized bytecode differs from production builds. Most proxies are re-pointed
-            // to new implementations during the OPCM upgrade, so their getProxyImplementation
-            // checks pass regardless of optimizer settings. However, DelayedWETH and ETHLockbox
-            // proxies are NOT re-pointed during the upgrade — they retain the mainnet
-            // implementations. With optimized builds the CREATE2 addresses match mainnet, but
-            // with unoptimized builds they diverge. Mock getProxyImplementation for these
-            // proxies so the validator sees the expected implementation addresses.
-            {
-                string memory _profile = Config.foundryProfile();
-                bool _isOptimizedProfile = LibString.eq(_profile, "default") || LibString.eq(_profile, "ci");
-                if (!_isOptimizedProfile) {
-                    IDelayedWETH _cannonWeth = DisputeGames.getGameImplDelayedWeth(dgf, GameTypes.CANNON);
-                    if (address(_cannonWeth) != address(0)) {
-                        vm.mockCall(
-                            address(proxyAdmin),
-                            abi.encodeCall(IProxyAdmin.getProxyImplementation, (address(_cannonWeth))),
-                            abi.encode(standardValidator.delayedWETHImpl())
-                        );
-                    }
-                    IDelayedWETH _permissionedWeth =
-                        DisputeGames.getGameImplDelayedWeth(dgf, GameTypes.PERMISSIONED_CANNON);
-                    if (address(_permissionedWeth) != address(0)) {
-                        vm.mockCall(
-                            address(proxyAdmin),
-                            abi.encodeCall(IProxyAdmin.getProxyImplementation, (address(_permissionedWeth))),
-                            abi.encode(standardValidator.delayedWETHImpl())
-                        );
-                    }
-                    IDelayedWETH _cannonKonaWeth = DisputeGames.getGameImplDelayedWeth(dgf, GameTypes.CANNON_KONA);
-                    if (address(_cannonKonaWeth) != address(0)) {
-                        vm.mockCall(
-                            address(proxyAdmin),
-                            abi.encodeCall(IProxyAdmin.getProxyImplementation, (address(_cannonKonaWeth))),
-                            abi.encode(standardValidator.delayedWETHImpl())
-                        );
-                    }
-                    if (address(ethLockbox) != address(0)) {
-                        vm.mockCall(
-                            address(proxyAdmin),
-                            abi.encodeCall(IProxyAdmin.getProxyImplementation, (address(ethLockbox))),
-                            abi.encode(standardValidator.ethLockboxImpl())
-                        );
-                    }
-                }
-            }
+            // Mock getProxyImplementation for DelayedWETH and ETHLockbox proxies when running
+            // with an unoptimized Foundry profile. See Setup.mockUnoptimizedProxyImplementations.
+            mockUnoptimizedProxyImplementations(
+                dgf,
+                proxyAdmin,
+                address(ethLockbox),
+                standardValidator.delayedWETHImpl(),
+                standardValidator.ethLockboxImpl()
+            );
 
             DisputeGames.mockGameImplChallenger(
                 disputeGameFactory, GameTypes.PERMISSIONED_CANNON, standardValidator.challenger()

--- a/packages/contracts-bedrock/test/setup/Setup.sol
+++ b/packages/contracts-bedrock/test/setup/Setup.sol
@@ -6,6 +6,7 @@ import { console2 as console } from "forge-std/console2.sol";
 import { Vm } from "forge-std/Vm.sol";
 import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 import { FeatureFlags } from "test/setup/FeatureFlags.sol";
+import { DisputeGames } from "test/setup/DisputeGames.sol";
 
 // Scripts
 import { Deploy } from "scripts/deploy/Deploy.s.sol";
@@ -18,6 +19,8 @@ import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 import { Config } from "scripts/libraries/Config.sol";
 
 // Libraries
+import { GameType } from "src/dispute/lib/LibUDT.sol";
+import { GameTypes } from "src/dispute/lib/Types.sol";
 import { Predeploys } from "src/libraries/Predeploys.sol";
 import { Preinstalls } from "src/libraries/Preinstalls.sol";
 import { AddressAliasHelper } from "src/vendor/AddressAliasHelper.sol";
@@ -224,6 +227,42 @@ abstract contract Setup is FeatureFlags {
     function skipIfUnoptimized() public {
         if (Config.isUnoptimized()) {
             vm.skip(true);
+        }
+    }
+
+    /// @dev Mocks getProxyImplementation for DelayedWETH and ETHLockbox proxies when running
+    ///      with an unoptimized Foundry profile. These proxies are not re-pointed during OPCM
+    ///      upgrades, so their CREATE2 implementation addresses diverge from mainnet when
+    ///      bytecode differs (unoptimized vs optimized). No-op for optimized profiles.
+    function mockUnoptimizedProxyImplementations(
+        IDisputeGameFactory _dgf,
+        IProxyAdmin _proxyAdmin,
+        address _ethLockbox,
+        address _delayedWETHImpl,
+        address _ethLockboxImpl
+    )
+        internal
+    {
+        if (!Config.isUnoptimized()) return;
+
+        GameType[3] memory gameTypes = [GameTypes.CANNON, GameTypes.PERMISSIONED_CANNON, GameTypes.CANNON_KONA];
+        for (uint256 i = 0; i < gameTypes.length; i++) {
+            IDelayedWETH delayedWETHProxy = DisputeGames.getGameImplDelayedWeth(_dgf, gameTypes[i]);
+            if (address(delayedWETHProxy) != address(0)) {
+                vm.mockCall(
+                    address(_proxyAdmin),
+                    abi.encodeCall(IProxyAdmin.getProxyImplementation, (address(delayedWETHProxy))),
+                    abi.encode(_delayedWETHImpl)
+                );
+            }
+        }
+
+        if (_ethLockbox != address(0)) {
+            vm.mockCall(
+                address(_proxyAdmin),
+                abi.encodeCall(IProxyAdmin.getProxyImplementation, (_ethLockbox)),
+                abi.encode(_ethLockboxImpl)
+            );
         }
     }
 


### PR DESCRIPTION
## Summary

Extracts duplicated mock logic for DelayedWETH and ETHLockbox proxy implementations into a shared `Setup.mockUnoptimizedProxyImplementations()` helper, replacing identical ~40-line blocks in both `OPContractsManager.t.sol` and `OPContractsManagerStandardValidator.t.sol`.

Follow-up from review feedback on #19332.

## Test plan

- [ ] CI passes (no behavioral change, just deduplication)

🤖 Generated with [Claude Code](https://claude.com/claude-code)