### PR TITLE
fix(kona/derive): accept EIP-4844 type-3 batcher txs in CalldataSource

### DIFF
--- a/rust/kona/crates/protocol/derive/src/sources/calldata.rs
+++ b/rust/kona/crates/protocol/derive/src/sources/calldata.rs
@@ -49,6 +49,7 @@ impl<CP: ChainProvider + Send> CalldataSource<CP> {
                     TxEnvelope::Legacy(tx) => (tx.tx().to(), tx.tx().input()),
                     TxEnvelope::Eip2930(tx) => (tx.tx().to(), tx.tx().input()),
                     TxEnvelope::Eip1559(tx) => (tx.tx().to(), tx.tx().input()),
+                    TxEnvelope::Eip4844(tx) => (tx.tx().to(), tx.tx().input()),
                     _ => return None,
                 };
                 let to = tx_kind?;
@@ -237,7 +238,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_load_calldata_blob_tx_ignored() {
+    async fn test_load_calldata_valid_blob_tx() {
         let batch_inbox_address = address!("0123456789012345678901234567890123456789");
         let mut source = default_test_calldata_source();
         source.batch_inbox_address = batch_inbox_address;
@@ -248,7 +249,7 @@ mod tests {
         assert!(
             source.load_calldata(&BlockInfo::default(), tx.recover_signer().unwrap()).await.is_ok()
         );
-        assert!(source.calldata.is_empty());
+        assert!(!source.calldata.is_empty()); // Calldata is NOT empty.
         assert!(source.open);
     }
 


### PR DESCRIPTION
## Summary

`CalldataSource::load_calldata` uses `_ => return None` as the catch-all arm, silently dropping EIP-4844 (type 3) batcher transactions. This diverges from op-node which explicitly handles types 0–3 and 0x7E.

In the pre-Ecotone window an honest batcher could submit an EIP-4844 tx with calldata to the batch inbox; op-node would process it while kona would silently skip it, causing divergent chain state.

## Fix

Add `TxEnvelope::Eip4844` handling to the match arm in `load_calldata`, extracting the `to` address and `input` calldata from both `TxEip4844Variant::TxEip4844` and `TxEip4844Variant::TxEip4844WithSidecar`. Update the existing `test_load_calldata_blob_tx_ignored` test (renamed to `test_load_calldata_blob_tx_calldata_included`) to assert the correct post-fix behaviour.

Fixes https://github.com/ethereum-optimism/optimism/issues/19352