### PR TITLE
fix(kona/derive): preserve error kind from chain provider in BlobSource

### DIFF
--- a/rust/kona/crates/protocol/derive/src/sources/blobs.rs
+++ b/rust/kona/crates/protocol/derive/src/sources/blobs.rs
@@ -4,7 +4,7 @@ use crate::{
     BlobData, BlobProvider, BlobProviderError, ChainProvider, DataAvailabilityProvider,
     PipelineError, PipelineErrorKind, PipelineResult,
 };
-use alloc::{boxed::Box, string::ToString, vec::Vec};
+use alloc::{boxed::Box, vec::Vec};
 use alloy_consensus::{
     Transaction, TxEip4844Variant, TxEnvelope, TxType, transaction::SignerRecoverable,
 };
@@ -116,10 +116,11 @@ where
             return Ok(());
         }
 
-        let info =
-            self.chain_provider.block_info_and_transactions_by_hash(block_ref.hash).await.map_err(
-                |e| -> PipelineErrorKind { BlobProviderError::Backend(e.to_string()).into() },
-            )?;
+        let info = self
+            .chain_provider
+            .block_info_and_transactions_by_hash(block_ref.hash)
+            .await
+            .map_err(Into::into)?;
 
         let (mut data, blob_hashes) = self.extract_blob_data(info.1, batcher_address);
 
@@ -403,6 +404,87 @@ pub(crate) mod tests {
         assert!(
             matches!(err, PipelineErrorKind::Reset(_)),
             "expected Reset for missed beacon slot, got {err:?}"
+        );
+    }
+
+    /// A minimal [`ChainProvider`] that always returns a "block not found" error which maps to
+    /// [`PipelineErrorKind::Reset`].  Used to verify that [`BlobSource::load_blobs`] preserves
+    /// the `Reset` kind when the underlying chain provider signals that a block is missing (e.g.
+    /// after an L1 reorg removes the block whose hash was referenced).
+    #[derive(Debug, Clone, Default)]
+    struct BlockNotFoundChainProvider;
+
+    /// Error type for [`BlockNotFoundChainProvider`] that converts to
+    /// [`PipelineErrorKind::Reset`], matching what `AlloyChainProvider` emits for 404 responses.
+    #[derive(Debug)]
+    struct BlockNotFoundError;
+
+    impl core::fmt::Display for BlockNotFoundError {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            write!(f, "block not found")
+        }
+    }
+
+    impl From<BlockNotFoundError> for PipelineErrorKind {
+        fn from(_: BlockNotFoundError) -> Self {
+            use crate::ResetError;
+            ResetError::BlockNotFound(alloy_primitives::B256::default().into()).reset()
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ChainProvider for BlockNotFoundChainProvider {
+        type Error = BlockNotFoundError;
+
+        async fn header_by_hash(
+            &mut self,
+            _: alloy_primitives::B256,
+        ) -> Result<alloy_consensus::Header, Self::Error> {
+            Err(BlockNotFoundError)
+        }
+
+        async fn block_info_by_number(
+            &mut self,
+            _: u64,
+        ) -> Result<kona_protocol::BlockInfo, Self::Error> {
+            Err(BlockNotFoundError)
+        }
+
+        async fn receipts_by_hash(
+            &mut self,
+            _: alloy_primitives::B256,
+        ) -> Result<alloc::vec::Vec<alloy_consensus::Receipt>, Self::Error> {
+            Err(BlockNotFoundError)
+        }
+
+        async fn block_info_and_transactions_by_hash(
+            &mut self,
+            _: alloy_primitives::B256,
+        ) -> Result<(kona_protocol::BlockInfo, alloc::vec::Vec<TxEnvelope>), Self::Error> {
+            Err(BlockNotFoundError)
+        }
+    }
+
+    /// Regression test: when `block_info_and_transactions_by_hash` returns an error that maps to
+    /// `PipelineErrorKind::Reset` (e.g. because an L1 reorg removed the block), `load_blobs`
+    /// must propagate the `Reset` kind unchanged.
+    ///
+    /// Before the fix, `BlobSource` wrapped every chain-provider error as
+    /// `BlobProviderError::Backend(e.to_string()).into()`, which unconditionally produces
+    /// `PipelineErrorKind::Temporary`.  The fix uses `.map_err(Into::into)` so the `Reset` kind
+    /// set by the underlying provider is preserved, allowing the pipeline to recover via reset
+    /// rather than spinning in a retry loop.
+    #[tokio::test]
+    async fn test_load_blobs_block_not_found_triggers_reset() {
+        let chain_provider = BlockNotFoundChainProvider;
+        let blob_fetcher = crate::test_utils::TestBlobProvider::default();
+        let mut source = BlobSource::new(chain_provider, blob_fetcher, Address::ZERO);
+
+        let err = source.load_blobs(&BlockInfo::default(), Address::ZERO).await.unwrap_err();
+        assert!(
+            matches!(err, PipelineErrorKind::Reset(_)),
+            "expected Reset when block_info_and_transactions_by_hash returns BlockNotFound, \
+             got {err:?}"
         );
     }
 }


### PR DESCRIPTION
## Summary

`BlobSource::load_blobs` was wrapping all errors from `chain_provider.block_info_and_transactions_by_hash` with `BlobProviderError::Backend(e.to_string()).into()`, which forced every error to `PipelineErrorKind::Temporary` regardless of the underlying error classification.

This is a regression: `AlloyChainProvider` was fixed in `ee4d492a87` to emit `PipelineErrorKind::Reset` for `BlockNotFound` errors (mapping via `AlloyChainProviderError::BlockNotFound` → `ResetError::BlockNotFound` → `Reset`). However, the `Backend` wrapping in `BlobSource` bypassed that fix entirely.

**Impact:** During an L1 reorg, when a blob-bearing L1 block hash disappears, kona's `BlobSource` spins retrying as `Temporary` instead of triggering a pipeline reset. This causes a liveness stall — the derivation pipeline cannot make progress.

The Go reference ([`blob_data_source.go:82-85`](https://github.com/ethereum-optimism/optimism/blob/9eaad92f7f2f8a5f9687b6a703d4afc3dad1d347/op-node/rollup/derive/blob_data_source.go#L82)) explicitly branches on `errors.Is(err, ethereum.NotFound)` → `NewResetError`, ensuring a pipeline reset is triggered.

## Fix

Change the `map_err` closure on the chain provider call from:

```rust
.map_err(|e| -> PipelineErrorKind { BlobProviderError::Backend(e.to_string()).into() })
```

to:

```rust
.map_err(Into::into)
```

This uses the `ChainProvider::Error`'s own `Into<PipelineErrorKind>` implementation to correctly route errors — exactly the pattern already used by `CalldataSource` (`calldata.rs:100`).

Also removes the now-unused `alloc::string::ToString` import.

## Testing

Existing tests continue to pass:
- `test_load_blobs_chain_provider_err`: still expects `Temporary` — `TestProviderError::BlockNotFound` maps to `Temporary` via its own `Into<PipelineErrorKind>` impl (not via `Backend`)
- `test_load_blobs_not_found_triggers_reset`: verifies that a missed beacon slot triggers `Reset`

Fixes https://github.com/ethereum-optimism/optimism/issues/19354