### PR TITLE
fix(kona/derive): make syscfg update failure non-fatal in L1Traversal

### DIFF
--- a/rust/kona/crates/protocol/derive/src/stages/traversal/indexed.rs
+++ b/rust/kona/crates/protocol/derive/src/stages/traversal/indexed.rs
@@ -100,13 +100,15 @@ impl<F: ChainProvider> IndexedTraversal<F> {
             }
             Ok(false) => { /* Ignore, no update applied */ }
             Err(err) => {
-                error!(target: "traversal", ?err, "Failed to update system config at block {}", block_info.number);
+                // Failure to update the system config is non-fatal: one or more receipts may be
+                // malformed or invalid. Log a warning and continue, matching op-node behaviour
+                // (l1_traversal.go:78-82: "failure to apply is just informational").
+                warn!(target: "traversal", ?err, "Failed to update system config at block {} (non-fatal, continuing)", block_info.number);
                 kona_macros::set!(
                     gauge,
                     crate::Metrics::PIPELINE_SYS_CONFIG_UPDATE_ERROR,
                     block_info.number as f64
                 );
-                return Err(PipelineError::SystemConfigUpdate(err).crit());
             }
         }
 
@@ -315,15 +317,18 @@ mod tests {
         let first = b256!("3333333333333333333333333333333333333333333333333333333333333333");
         let second = b256!("4444444444444444444444444444444444444444444444444444444444444444");
         let block1 = BlockInfo { hash: first, ..BlockInfo::default() };
-        let block2 = BlockInfo { number: 1, hash: second, ..BlockInfo::default() };
+        let block2 = BlockInfo { number: 1, hash: second, parent_hash: first, ..BlockInfo::default() };
         let blocks = vec![block1, block2];
         let receipts = new_receipts();
         let mut traversal = new_test_managed(blocks, receipts);
         traversal.block = Some(block1);
         assert_eq!(traversal.next_l1_block().await.unwrap(), Some(block1));
-        // provide_next_block will fail due to system config update error
-        let err = traversal.provide_next_block(block2).await.unwrap_err();
-        matches!(err, PipelineErrorKind::Critical(PipelineError::SystemConfigUpdate(_)));
+        // A system config update error is now non-fatal (matches op-node behaviour):
+        // provide_next_block returns Ok(()) and origin advances to block2.
+        assert!(
+            traversal.provide_next_block(block2).await.is_ok(),
+            "system config update failure should be non-fatal (warn + continue)"
+        );
     }
 
     #[tokio::test]

--- a/rust/kona/crates/protocol/derive/src/stages/traversal/indexed.rs
+++ b/rust/kona/crates/protocol/derive/src/stages/traversal/indexed.rs
@@ -101,8 +101,7 @@ impl<F: ChainProvider> IndexedTraversal<F> {
             Ok(false) => { /* Ignore, no update applied */ }
             Err(err) => {
                 // Failure to update the system config is non-fatal: one or more receipts may be
-                // malformed or invalid. Log a warning and continue, matching op-node behaviour
-                // (l1_traversal.go:78-82: "failure to apply is just informational").
+                // malformed or invalid. Log a warning and continue.
                 warn!(target: "traversal", ?err, "Failed to update system config at block {} (non-fatal, continuing)", block_info.number);
                 kona_macros::set!(
                     gauge,
@@ -317,7 +316,8 @@ mod tests {
         let first = b256!("3333333333333333333333333333333333333333333333333333333333333333");
         let second = b256!("4444444444444444444444444444444444444444444444444444444444444444");
         let block1 = BlockInfo { hash: first, ..BlockInfo::default() };
-        let block2 = BlockInfo { number: 1, hash: second, parent_hash: first, ..BlockInfo::default() };
+        let block2 =
+            BlockInfo { number: 1, hash: second, parent_hash: first, ..BlockInfo::default() };
         let blocks = vec![block1, block2];
         let receipts = new_receipts();
         let mut traversal = new_test_managed(blocks, receipts);

--- a/rust/kona/crates/protocol/derive/src/stages/traversal/polling.rs
+++ b/rust/kona/crates/protocol/derive/src/stages/traversal/polling.rs
@@ -109,8 +109,7 @@ impl<F: ChainProvider + Send> OriginAdvancer for PollingTraversal<F> {
             Ok(false) => { /* Ignore, no update applied */ }
             Err(err) => {
                 // Failure to update the system config is non-fatal: one or more receipts may be
-                // malformed or invalid. Log a warning and continue, matching op-node behaviour
-                // (l1_traversal.go:78-82: "failure to apply is just informational").
+                // malformed or invalid. Log a warning and continue.
                 warn!(target: "l1_traversal", ?err, "Failed to update system config at block {} (non-fatal, continuing)", next_l1_origin.number);
                 kona_macros::set!(
                     gauge,
@@ -177,9 +176,14 @@ impl<F: ChainProvider + Send> SignalReceiver for PollingTraversal<F> {
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
-    use crate::{errors::PipelineErrorKind, test_utils::TraversalTestHelper};
+    use crate::{
+        errors::PipelineErrorKind,
+        test_utils::{TestChainProvider, TraversalTestHelper},
+    };
     use alloc::vec;
-    use alloy_primitives::{address, b256};
+    use alloy_consensus::Receipt;
+    use alloy_primitives::{Bytes, Log, LogData, address, b256};
+    use kona_genesis::CONFIG_UPDATE_TOPIC;
 
     #[test]
     fn test_l1_traversal_batcher_address() {
@@ -287,16 +291,47 @@ pub(crate) mod tests {
 
     #[tokio::test]
     async fn test_l1_traversal_system_config_update_fails() {
+        // Build a 3-node chain: genesis (hash=0x0) → block1 → block2.
+        // block2 has a receipt with a log from L1_SYS_CONFIG_ADDR that has only
+        // 1 topic instead of the required >= 3, triggering a syscfg update error.
+        // The fix under test makes this error non-fatal: advance_origin warns and
+        // continues (matching op-node's l1_traversal.go:78-82 behaviour).
         let first = b256!("3333333333333333333333333333333333333333333333333333333333333333");
         let second = b256!("4444444444444444444444444444444444444444444444444444444444444444");
-        let block1 = BlockInfo { hash: first, ..BlockInfo::default() };
-        let block2 = BlockInfo { hash: second, ..BlockInfo::default() };
-        let blocks = vec![block1, block2];
-        let receipts = TraversalTestHelper::new_receipts();
-        let mut traversal = TraversalTestHelper::new_from_blocks(blocks, receipts);
+        // block1: child of genesis (parent_hash = 0x0 = genesis.hash)
+        let block1 = BlockInfo { number: 1, hash: first, ..BlockInfo::default() };
+        // block2: child of block1, with a receipt that triggers syscfg update failure
+        let block2 =
+            BlockInfo { number: 2, hash: second, parent_hash: first, ..BlockInfo::default() };
+
+        let mut provider = TestChainProvider::default();
+        let rollup_config = RollupConfig {
+            l1_system_config_address: TraversalTestHelper::L1_SYS_CONFIG_ADDR,
+            ..RollupConfig::default()
+        };
+        provider.insert_block(1, block1);
+        provider.insert_block(2, block2);
+        // block1 gets an empty receipt (no syscfg updates).
+        provider.insert_receipts(first, vec![Receipt::default()]);
+        // block2 gets a malformed log from L1_SYS_CONFIG_ADDR (only 1 topic instead of 3).
+        // update_with_receipts returns Err(InvalidTopicLen(1)) → non-fatal with the fix.
+        let bad_log = Log {
+            address: TraversalTestHelper::L1_SYS_CONFIG_ADDR,
+            data: LogData::new_unchecked(vec![CONFIG_UPDATE_TOPIC], Bytes::default()),
+        };
+        let bad_receipt = Receipt {
+            status: alloy_consensus::Eip658Value::Eip658(true),
+            logs: vec![bad_log],
+            ..Receipt::default()
+        };
+        provider.insert_receipts(second, vec![bad_receipt]);
+
+        let mut traversal = PollingTraversal::new(provider, Arc::new(rollup_config));
+
+        // First advance_origin: genesis → block1 (empty receipt, no syscfg update)
         assert!(traversal.advance_origin().await.is_ok());
-        // A system config update error is now non-fatal (matches op-node behaviour):
-        // advance_origin returns Ok(()) and the pipeline continues.
+        // Second advance_origin: block1 → block2 (bad receipt triggers syscfg update
+        // error, but it is now non-fatal: warn + continue = Ok(())).
         assert!(
             traversal.advance_origin().await.is_ok(),
             "system config update failure should be non-fatal (warn + continue)"

--- a/rust/kona/crates/protocol/derive/src/stages/traversal/polling.rs
+++ b/rust/kona/crates/protocol/derive/src/stages/traversal/polling.rs
@@ -108,13 +108,15 @@ impl<F: ChainProvider + Send> OriginAdvancer for PollingTraversal<F> {
             }
             Ok(false) => { /* Ignore, no update applied */ }
             Err(err) => {
-                error!(target: "l1_traversal", ?err, "Failed to update system config at block {}", next_l1_origin.number);
+                // Failure to update the system config is non-fatal: one or more receipts may be
+                // malformed or invalid. Log a warning and continue, matching op-node behaviour
+                // (l1_traversal.go:78-82: "failure to apply is just informational").
+                warn!(target: "l1_traversal", ?err, "Failed to update system config at block {} (non-fatal, continuing)", next_l1_origin.number);
                 kona_macros::set!(
                     gauge,
                     crate::Metrics::PIPELINE_SYS_CONFIG_UPDATE_ERROR,
                     next_l1_origin.number as f64
                 );
-                return Err(PipelineError::SystemConfigUpdate(err).crit());
             }
         }
 
@@ -293,10 +295,12 @@ pub(crate) mod tests {
         let receipts = TraversalTestHelper::new_receipts();
         let mut traversal = TraversalTestHelper::new_from_blocks(blocks, receipts);
         assert!(traversal.advance_origin().await.is_ok());
-        // Only the second block should fail since the second receipt
-        // contains invalid logs that will error for a system config update.
-        let err = traversal.advance_origin().await.unwrap_err();
-        matches!(err, PipelineErrorKind::Critical(PipelineError::SystemConfigUpdate(_)));
+        // A system config update error is now non-fatal (matches op-node behaviour):
+        // advance_origin returns Ok(()) and the pipeline continues.
+        assert!(
+            traversal.advance_origin().await.is_ok(),
+            "system config update failure should be non-fatal (warn + continue)"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Fixes https://github.com/ethereum-optimism/optimism/issues/19353

When `update_with_receipts` fails to apply system config changes from L1 receipts (e.g. due to malformed logs), both `PollingTraversal::advance_origin` and `IndexedTraversal::provide_next_block` were returning `PipelineError::SystemConfigUpdate(err).crit()`, permanently halting the pipeline.

op-node's reference implementation ([`l1_traversal.go:78-82`](https://github.com/ethereum-optimism/optimism/blob/9eaad92f7f2f8a5f9687b6a703d4afc3dad1d347/op-node/rollup/derive/l1_traversal.go#L78)) treats this as explicitly non-fatal:

> "if UpdateSystemConfigWithL1Receipts returns an error, it is because one or more of the receipts are malformed or invalid — failure to apply is just informational, so we just log the error and continue"

## Changes

- **`rust/kona/crates/protocol/derive/src/stages/traversal/polling.rs`** — `PollingTraversal::advance_origin`: change `Err` arm from `return Err(...crit())` to `warn!` + continue
- **`rust/kona/crates/protocol/derive/src/stages/traversal/indexed.rs`** — `IndexedTraversal::provide_next_block`: same change
- Update existing tests to expect non-fatal behaviour (the existing tests were asserting the old broken critical-error path)

## Testing

Existing test `test_l1_traversal_system_config_update_fails` (polling) and `test_managed_traversal_system_config_update_fails` (indexed) have been updated to assert `is_ok()` rather than an unwrap of the critical error.