### PR TITLE
fix(kona/derive): copy origin field during Holocene BatchQueue→BatchValidator transition

### DIFF
--- a/rust/kona/crates/protocol/derive/src/stages/batch/batch_provider.rs
+++ b/rust/kona/crates/protocol/derive/src/stages/batch/batch_provider.rs
@@ -18,7 +18,7 @@ use kona_protocol::{BlockInfo, L2BlockInfo, SingleBatch};
 /// When Holocene is active, the [`BatchValidator`] is used.
 ///
 /// When transitioning between the two stages, the mux will reset the active stage, but
-/// retain `l1_blocks`.
+/// retain `l1_blocks` and `origin`.
 #[derive(Debug)]
 pub struct BatchProvider<P, F>
 where
@@ -74,6 +74,7 @@ where
             let batch_queue = self.batch_queue.take().expect("Must have batch queue");
             let mut bv = BatchValidator::new(self.cfg.clone(), batch_queue.prev);
             bv.l1_blocks = batch_queue.l1_blocks;
+            bv.origin = batch_queue.origin;
             self.batch_validator = Some(bv);
         } else if self.batch_validator.is_some() && !self.cfg.is_holocene_active(origin.timestamp) {
             // If the batch validator is active, and Holocene is not active, it indicates an L1
@@ -305,5 +306,61 @@ mod test {
             panic!("Expected BatchValidator");
         };
         assert!(bv.l1_blocks.len() == 1);
+    }
+
+    // BQ-12 fix: On Holocene activation, BatchProvider.attempt_update() must copy BOTH l1_blocks
+    // AND origin from the old BatchQueue to the new BatchValidator, matching Go's
+    // BatchMux.TransformHolocene() which copies both bs.l1Blocks and bs.origin (batch_mux.go:67-68).
+    //
+    // Without copying origin, BatchValidator.origin starts as None. The first
+    // update_origins() call always enters the `self.origin != self.prev.origin()` branch
+    // (None != Some(...)), causing either duplicate l1_block insertion (normal case) or
+    // l1_blocks.clear() followed by MissingOrigin.crit() halt (lagging case).
+    #[test]
+    fn test_spec_batch_provider_holocene_transition_origin_not_transferred() {
+        let provider = TestNextBatchProvider::new(vec![]);
+        let l2_provider = TestL2ChainProvider::default();
+        // Holocene activates at timestamp 2.
+        let cfg = Arc::new(RollupConfig {
+            hardforks: HardForkConfig { holocene_time: Some(2), ..Default::default() },
+            ..Default::default()
+        });
+        let mut batch_provider = BatchProvider::new(cfg, provider, l2_provider);
+
+        // Initialize with BatchQueue (Holocene not yet active at timestamp 0).
+        batch_provider.attempt_update().unwrap();
+        assert!(batch_provider.batch_queue.is_some(), "Expected BatchQueue pre-Holocene");
+
+        // Seed BatchQueue.l1_blocks with two blocks (as would happen during normal derivation).
+        let block_a = BlockInfo { number: 1, timestamp: 0, ..Default::default() };
+        let block_b = BlockInfo { number: 2, timestamp: 2, ..Default::default() };
+        {
+            let bq = batch_provider.batch_queue.as_mut().unwrap();
+            bq.l1_blocks.push(block_a);
+            bq.l1_blocks.push(block_b);
+            bq.origin = Some(block_b); // BatchQueue.origin set to the current L1 head
+            // Advance the mock prev origin to Holocene activation timestamp.
+            bq.prev.origin = Some(block_b);
+        }
+
+        // Trigger Holocene transition via attempt_update().
+        batch_provider.attempt_update().unwrap();
+        assert!(batch_provider.batch_queue.is_none(), "BatchQueue should be gone post-Holocene");
+        assert!(batch_provider.batch_validator.is_some(), "Expected BatchValidator post-Holocene");
+
+        let bv = batch_provider.batch_validator.as_ref().unwrap();
+
+        // Verify l1_blocks were transferred.
+        assert_eq!(bv.l1_blocks.len(), 2, "l1_blocks must be transferred from BatchQueue");
+        assert_eq!(bv.l1_blocks[0], block_a);
+        assert_eq!(bv.l1_blocks[1], block_b);
+
+        // Verify origin was transferred (BQ-12 fix): BatchValidator.origin must equal the
+        // origin from the old BatchQueue, matching Go's TransformHolocene (batch_mux.go:68).
+        assert_eq!(
+            bv.origin,
+            Some(block_b),
+            "BatchValidator.origin must be copied from BatchQueue on Holocene transition"
+        );
     }
 }

--- a/rust/kona/crates/protocol/derive/src/stages/batch/batch_provider.rs
+++ b/rust/kona/crates/protocol/derive/src/stages/batch/batch_provider.rs
@@ -354,7 +354,7 @@ mod test {
         assert_eq!(bv.l1_blocks[0], block_a);
         assert_eq!(bv.l1_blocks[1], block_b);
 
-        // Verify origin was transferred (BQ-12 fix): BatchValidator.origin must equal the
+        // Verify origin was transferred: BatchValidator.origin must equal the
         // origin from the old BatchQueue, matching Go's TransformHolocene (batch_mux.go:68).
         assert_eq!(
             bv.origin,

--- a/rust/kona/crates/protocol/derive/src/stages/batch/batch_provider.rs
+++ b/rust/kona/crates/protocol/derive/src/stages/batch/batch_provider.rs
@@ -316,7 +316,7 @@ mod test {
     // (None != Some(...)), causing either duplicate l1_block insertion (normal case) or
     // l1_blocks.clear() followed by MissingOrigin.crit() halt (lagging case).
     #[test]
-    fn test_spec_batch_provider_holocene_transition_origin_not_transferred() {
+    fn test_spec_batch_provider_holocene_transition_origin_transferred() {
         let provider = TestNextBatchProvider::new(vec![]);
         let l2_provider = TestL2ChainProvider::default();
         // Holocene activates at timestamp 2.

--- a/rust/kona/crates/protocol/derive/src/stages/batch/batch_provider.rs
+++ b/rust/kona/crates/protocol/derive/src/stages/batch/batch_provider.rs
@@ -308,9 +308,8 @@ mod test {
         assert!(bv.l1_blocks.len() == 1);
     }
 
-    // BQ-12 fix: On Holocene activation, BatchProvider.attempt_update() must copy BOTH l1_blocks
-    // AND origin from the old BatchQueue to the new BatchValidator, matching Go's
-    // BatchMux.TransformHolocene() which copies both bs.l1Blocks and bs.origin (batch_mux.go:67-68).
+    // On Holocene activation, BatchProvider.attempt_update() must copy BOTH l1_blocks
+    // AND origin from the old BatchQueue to the new BatchValidator.
     //
     // Without copying origin, BatchValidator.origin starts as None. The first
     // update_origins() call always enters the `self.origin != self.prev.origin()` branch


### PR DESCRIPTION
## Description

When kona's derivation pipeline transitions from `BatchQueue` to `BatchValidator` at Holocene activation, `BatchProvider::attempt_update()` copies `l1_blocks` from the old `BatchQueue` but does **not** copy the `origin` field.

Go's `BatchMux.TransformHolocene()` copies both fields ([batch_mux.go#L67-L68](https://github.com/ethereum-optimism/optimism/blob/9eaad92f7f2f8a5f9687b6a703d4afc3dad1d347/op-node/rollup/derive/batch_mux.go#L67)):

```go
bs.l1Blocks = slices.Clone(bp.l1Blocks)
bs.origin = bp.origin         // ← this line was missing in Rust
```

The Rust code before this fix ([batch_provider.rs#L74-L77](https://github.com/ethereum-optimism/optimism/blob/9eaad92f7f2f8a5f9687b6a703d4afc3dad1d347/rust/kona/crates/protocol/derive/src/stages/batch/batch_provider.rs#L74)):

```rust
let batch_queue = self.batch_queue.take().expect("Must have batch queue");
let mut bv = BatchValidator::new(self.cfg.clone(), batch_queue.prev);
bv.l1_blocks = batch_queue.l1_blocks;
// bv.origin was not set — starts as None
self.batch_validator = Some(bv);
```

### Failure modes

Because `BatchValidator::new()` initialises `origin` to `None`, the very first call to `update_origins()` after the Holocene transition always enters the `self.origin != self.prev.origin()` branch (`None != Some(...)`):

**1. Normal-case duplicate insertion (affects every transitioning node)**

When `origin_behind` is `false` (the common case where the pipeline is caught up with L1), `update_origins()` pushes the current L1 block onto `l1_blocks` again. If `l1_blocks` was `[block_a, block_b]` after the transfer, it becomes `[block_a, block_b, block_b]`. After epoch pruning fires, this leaves two identical entries `[block_b, block_b]`, corrupting the two-slot epoch window relied on by `try_derive_empty_batch` and epoch-advancement logic.

**2. Lagging/startup case — l1_blocks cleared, derivation halts**

When `origin_behind` is `true` (`prev.origin().number < parent.l1_origin.number`), `update_origins()` calls `self.l1_blocks.clear()`, discarding all L1 history transferred from `BatchQueue`. The next `next_batch()` call returns `MissingOrigin.crit()`, permanently halting the derivation pipeline.

Go is immune to both because `bs.origin = bp.origin` is set before the first `NextBatch` call, making `bs.origin == bs.prev.Origin()` and causing `update_origins()` to skip the update branch entirely.

### Current impact

Holocene is already active on all supported chains, so new nodes start with Holocene already active and take the direct-initialisation path in `attempt_update()` — meaning there is **no current impact in production**. The bug would surface again if a new hardfork resets the mux or if a future chain activates Holocene after initial deployment.

## Fix

Copy `batch_queue.origin` into `bv.origin` alongside `l1_blocks`:

```rust
let batch_queue = self.batch_queue.take().expect("Must have batch queue");
let mut bv = BatchValidator::new(self.cfg.clone(), batch_queue.prev);
bv.l1_blocks = batch_queue.l1_blocks;
bv.origin = batch_queue.origin;   // ← new line
self.batch_validator = Some(bv);
```

A regression test `test_spec_batch_provider_holocene_transition_origin_not_transferred` is included that verifies both `l1_blocks` and `origin` are correctly transferred after the Holocene transition.

Fixes https://github.com/ethereum-optimism/optimism/issues/19356