### PR TITLE
fix(kona/derive): return Reset instead of Critical on blob under-fill in BlobData::fill

### DIFF
--- a/rust/kona/crates/protocol/derive/src/errors/pipeline.rs
+++ b/rust/kona/crates/protocol/derive/src/errors/pipeline.rs
@@ -1,6 +1,6 @@
 //! This module contains derivation errors thrown within the pipeline.
 
-use crate::BuilderError;
+use crate::{BlobProviderError, BuilderError};
 use alloc::string::String;
 use alloy_eips::BlockId;
 use alloy_primitives::B256;
@@ -354,8 +354,8 @@ pub enum ResetError {
     #[error("Block not found: {0}")]
     BlockNotFound(BlockId),
     /// The blob provider returned fewer blobs than expected (under-fill).
-    #[error("Blob provider under-fill: expected blob at index {0} but only {1} blobs returned")]
-    BlobsUnderFill(usize, usize),
+    #[error("Blob provider under-fill: {0}")]
+    BlobsUnderFill(BlobProviderError),
 }
 
 impl ResetError {
@@ -445,7 +445,10 @@ mod tests {
             ResetError::HoloceneActivation,
             ResetError::BlobsUnavailable(0),
             ResetError::BlockNotFound(B256::default().into()),
-            ResetError::BlobsUnderFill(0, 0),
+            ResetError::BlobsUnderFill(BlobProviderError::NotEnoughBlobs {
+                expected: 0,
+                actual: 0,
+            }),
         ];
         for error in reset_errors {
             let expected = PipelineErrorKind::Reset(error.clone());

--- a/rust/kona/crates/protocol/derive/src/errors/pipeline.rs
+++ b/rust/kona/crates/protocol/derive/src/errors/pipeline.rs
@@ -353,6 +353,9 @@ pub enum ResetError {
     /// typically because an L1 reorg removed it. The pipeline must reset to recover.
     #[error("Block not found: {0}")]
     BlockNotFound(BlockId),
+    /// The blob provider returned fewer blobs than expected (under-fill).
+    #[error("Blob provider under-fill: expected blob at index {0} but only {1} blobs returned")]
+    BlobsUnderFill(usize, usize),
 }
 
 impl ResetError {
@@ -442,6 +445,7 @@ mod tests {
             ResetError::HoloceneActivation,
             ResetError::BlobsUnavailable(0),
             ResetError::BlockNotFound(B256::default().into()),
+            ResetError::BlobsUnderFill(0, 0),
         ];
         for error in reset_errors {
             let expected = PipelineErrorKind::Reset(error.clone());

--- a/rust/kona/crates/protocol/derive/src/errors/sources.rs
+++ b/rust/kona/crates/protocol/derive/src/errors/sources.rs
@@ -33,6 +33,9 @@ pub enum BlobProviderError {
     /// Blob decoding error.
     #[error("Blob decoding error: {0}")]
     BlobDecoding(#[from] BlobDecodingError),
+    /// The blob provider returned fewer blobs than requested (under-fill).
+    #[error("Not enough blobs: expected blob at index {0} but provider returned only {1} blobs")]
+    NotEnoughBlobs(usize, usize),
     /// The beacon node returned a 404 for the requested slot, indicating the slot was missed or
     /// orphaned. Blobs for missed/orphaned slots will never become available, so the pipeline
     /// must reset to move past the L1 block that referenced them.
@@ -54,6 +57,9 @@ impl From<BlobProviderError> for PipelineErrorKind {
             BlobProviderError::SidecarLengthMismatch(_, _) |
             BlobProviderError::SlotDerivation |
             BlobProviderError::BlobDecoding(_) => PipelineError::Provider(val.to_string()).crit(),
+            BlobProviderError::NotEnoughBlobs(index, count) => {
+                ResetError::BlobsUnderFill(index, count).reset()
+            }
             BlobProviderError::BlobNotFound { slot, .. } => {
                 ResetError::BlobsUnavailable(slot).reset()
             }
@@ -97,5 +103,8 @@ mod tests {
             matches!(err, PipelineErrorKind::Reset(_)),
             "BlobNotFound must map to Reset so the pipeline moves past the missed slot"
         );
+
+        let err: PipelineErrorKind = BlobProviderError::NotEnoughBlobs(2, 1).into();
+        assert!(matches!(err, PipelineErrorKind::Reset(_)));
     }
 }

--- a/rust/kona/crates/protocol/derive/src/errors/sources.rs
+++ b/rust/kona/crates/protocol/derive/src/errors/sources.rs
@@ -5,7 +5,7 @@ use alloc::string::{String, ToString};
 use thiserror::Error;
 
 /// Blob Decoding Error
-#[derive(Error, Debug, PartialEq, Eq)]
+#[derive(Error, Clone, Debug, PartialEq, Eq)]
 pub enum BlobDecodingError {
     /// Invalid field element
     #[error("Invalid field element")]
@@ -22,7 +22,7 @@ pub enum BlobDecodingError {
 }
 
 /// An error returned by the [`BlobProviderError`].
-#[derive(Error, Debug, PartialEq, Eq)]
+#[derive(Error, Clone, Debug, PartialEq, Eq)]
 pub enum BlobProviderError {
     /// The number of specified blob hashes did not match the number of returned sidecars.
     #[error("Blob sidecar length mismatch: expected {0}, got {1}")]
@@ -34,8 +34,15 @@ pub enum BlobProviderError {
     #[error("Blob decoding error: {0}")]
     BlobDecoding(#[from] BlobDecodingError),
     /// The blob provider returned fewer blobs than requested (under-fill).
-    #[error("Not enough blobs: expected blob at index {0} but provider returned only {1} blobs")]
-    NotEnoughBlobs(usize, usize),
+    #[error(
+        "Not enough blobs: expected blob at index {expected} but provider returned only {actual} blobs"
+    )]
+    NotEnoughBlobs {
+        /// The blob index that was expected.
+        expected: usize,
+        /// The actual number of blobs returned by the provider.
+        actual: usize,
+    },
     /// The beacon node returned a 404 for the requested slot, indicating the slot was missed or
     /// orphaned. Blobs for missed/orphaned slots will never become available, so the pipeline
     /// must reset to move past the L1 block that referenced them.
@@ -57,9 +64,7 @@ impl From<BlobProviderError> for PipelineErrorKind {
             BlobProviderError::SidecarLengthMismatch(_, _) |
             BlobProviderError::SlotDerivation |
             BlobProviderError::BlobDecoding(_) => PipelineError::Provider(val.to_string()).crit(),
-            BlobProviderError::NotEnoughBlobs(index, count) => {
-                ResetError::BlobsUnderFill(index, count).reset()
-            }
+            BlobProviderError::NotEnoughBlobs { .. } => ResetError::BlobsUnderFill(val).reset(),
             BlobProviderError::BlobNotFound { slot, .. } => {
                 ResetError::BlobsUnavailable(slot).reset()
             }
@@ -104,7 +109,8 @@ mod tests {
             "BlobNotFound must map to Reset so the pipeline moves past the missed slot"
         );
 
-        let err: PipelineErrorKind = BlobProviderError::NotEnoughBlobs(2, 1).into();
+        let err: PipelineErrorKind =
+            BlobProviderError::NotEnoughBlobs { expected: 2, actual: 1 }.into();
         assert!(matches!(err, PipelineErrorKind::Reset(_)));
     }
 }

--- a/rust/kona/crates/protocol/derive/src/sources/blob_data.rs
+++ b/rust/kona/crates/protocol/derive/src/sources/blob_data.rs
@@ -1,6 +1,6 @@
 //! Contains the `BlobData` struct.
 
-use crate::BlobDecodingError;
+use crate::{BlobDecodingError, BlobProviderError};
 use alloc::{boxed::Box, vec};
 use alloy_eips::eip4844::{BYTES_PER_BLOB, Blob, VERSIONED_HASH_VERSION_KZG};
 use alloy_primitives::Bytes;
@@ -146,18 +146,18 @@ impl BlobData {
         &mut self,
         blobs: &[Box<Blob>],
         index: usize,
-    ) -> Result<bool, BlobDecodingError> {
+    ) -> Result<bool, BlobProviderError> {
         // Do not fill if there is calldata here
         if self.calldata.is_some() {
             return Ok(false);
         }
 
         if index >= blobs.len() {
-            return Err(BlobDecodingError::InvalidLength);
+            return Err(BlobProviderError::NotEnoughBlobs(index, blobs.len()));
         }
 
         if blobs[index].is_empty() {
-            return Err(BlobDecodingError::MissingData);
+            return Err(BlobDecodingError::MissingData.into());
         }
 
         self.data = Some(Bytes::from(*blobs[index]));
@@ -190,7 +190,7 @@ mod tests {
     fn test_fill_oob_index() {
         let mut blob_data = BlobData::default();
         let blobs = vec![Box::new(Blob::with_last_byte(1u8))];
-        assert_eq!(blob_data.fill(&blobs, 1), Err(BlobDecodingError::InvalidLength));
+        assert_eq!(blob_data.fill(&blobs, 1), Err(BlobProviderError::NotEnoughBlobs(1, 1)));
     }
 
     #[test]

--- a/rust/kona/crates/protocol/derive/src/sources/blob_data.rs
+++ b/rust/kona/crates/protocol/derive/src/sources/blob_data.rs
@@ -153,7 +153,7 @@ impl BlobData {
         }
 
         if index >= blobs.len() {
-            return Err(BlobProviderError::NotEnoughBlobs(index, blobs.len()));
+            return Err(BlobProviderError::NotEnoughBlobs { expected: index, actual: blobs.len() });
         }
 
         if blobs[index].is_empty() {
@@ -190,7 +190,10 @@ mod tests {
     fn test_fill_oob_index() {
         let mut blob_data = BlobData::default();
         let blobs = vec![Box::new(Blob::with_last_byte(1u8))];
-        assert_eq!(blob_data.fill(&blobs, 1), Err(BlobProviderError::NotEnoughBlobs(1, 1)));
+        assert_eq!(
+            blob_data.fill(&blobs, 1),
+            Err(BlobProviderError::NotEnoughBlobs { expected: 1, actual: 1 })
+        );
     }
 
     #[test]

--- a/rust/kona/crates/protocol/derive/src/sources/blobs.rs
+++ b/rust/kona/crates/protocol/derive/src/sources/blobs.rs
@@ -165,8 +165,7 @@ where
         // Fill the blob pointers.
         let mut blob_index = 0;
         for blob in &mut data {
-            let should_increment =
-                blob.fill(&blobs, blob_index).map_err(Into::<PipelineErrorKind>::into)?;
+            let should_increment = blob.fill(&blobs, blob_index)?;
             if should_increment {
                 blob_index += 1;
             }

--- a/rust/kona/crates/protocol/derive/src/sources/blobs.rs
+++ b/rust/kona/crates/protocol/derive/src/sources/blobs.rs
@@ -165,9 +165,8 @@ where
         // Fill the blob pointers.
         let mut blob_index = 0;
         for blob in &mut data {
-            let should_increment = blob
-                .fill(&blobs, blob_index)
-                .map_err(|e| -> PipelineErrorKind { BlobProviderError::from(e).into() })?;
+            let should_increment =
+                blob.fill(&blobs, blob_index).map_err(Into::<PipelineErrorKind>::into)?;
             if should_increment {
                 blob_index += 1;
             }

--- a/rust/kona/crates/protocol/derive/src/sources/blobs.rs
+++ b/rust/kona/crates/protocol/derive/src/sources/blobs.rs
@@ -1,7 +1,7 @@
 //! Blob Data Source
 
 use crate::{
-    BlobData, BlobProvider, BlobProviderError, ChainProvider, DataAvailabilityProvider,
+    BlobData, BlobProvider, ChainProvider, DataAvailabilityProvider,
     PipelineError, PipelineErrorKind, PipelineResult,
 };
 use alloc::{boxed::Box, vec::Vec};

--- a/rust/kona/crates/protocol/derive/src/sources/blobs.rs
+++ b/rust/kona/crates/protocol/derive/src/sources/blobs.rs
@@ -1,8 +1,8 @@
 //! Blob Data Source
 
 use crate::{
-    BlobData, BlobProvider, ChainProvider, DataAvailabilityProvider,
-    PipelineError, PipelineErrorKind, PipelineResult,
+    BlobData, BlobProvider, ChainProvider, DataAvailabilityProvider, PipelineError,
+    PipelineErrorKind, PipelineResult,
 };
 use alloc::{boxed::Box, vec::Vec};
 use alloy_consensus::{


### PR DESCRIPTION
## Summary

When a blob provider returns fewer blobs than there are blob-hash placeholders (under-fill), `BlobData::fill` currently returns `BlobDecodingError::InvalidLength` which maps to `PipelineErrorKind::Critical` — permanently terminating the derivation pipeline.

This is wrong. Under-fill is a **transient, recoverable condition**:
- The provider may not have all blobs cached/synced yet for a newly confirmed L1 block
- The L1 block may have been reorged out, causing the provider to return fewer blobs

In both cases the pipeline should **reset and retry** from the last safe L1 block. This is exactly what op-node does: `fillBlobPointers` wraps the same under-fill error as `NewResetError` at [`blob_data_source.go:110`](https://github.com/ethereum-optimism/optimism/blob/9eaad92f7f2f8a5f9687b6a703d4afc3dad1d347/op-node/rollup/derive/blob_data_source.go#L108-L111), giving automatic recovery.

Without this fix, any blob under-fill in kona causes permanent pipeline halt requiring operator restart.

## Changes

- `errors/pipeline.rs`: Add `ResetError::BlobsUnderFill(usize, usize)` — a named reset error for this condition
- `errors/sources.rs`: Add `BlobProviderError::NotEnoughBlobs(usize, usize)` mapped to `ResetError::BlobsUnderFill.reset()` in `From<BlobProviderError> for PipelineErrorKind`
- `sources/blob_data.rs`: Change `BlobData::fill` return type from `Result<bool, BlobDecodingError>` to `Result<bool, BlobProviderError>`, returning `NotEnoughBlobs` on under-fill
- `sources/blobs.rs`: Simplify the `fill` error conversion to `.into()` (now that `fill` directly returns `BlobProviderError`)
- Tests updated to assert under-fill produces `Reset` not `Critical`

## Testing

```
cargo test --package kona-derive --lib test_fill_oob_index
cargo test --package kona-derive --lib test_from_blob_provider_error
cargo test --package kona-derive --lib test_reset_error_kinds
```

All pass. No new test failures introduced (the one pre-existing failure is a `tracing-subscriber` global state conflict unrelated to this change).

## Related

Fixes https://github.com/ethereum-optimism/optimism/issues/19359

Found during conformance review `kona-node-vs-op-node`.