### PR TITLE
fix(kona/derive): add over-fill check in BlobSource::load_blobs

### DIFF
--- a/rust/kona/crates/protocol/derive/src/errors/pipeline.rs
+++ b/rust/kona/crates/protocol/derive/src/errors/pipeline.rs
@@ -356,6 +356,15 @@ pub enum ResetError {
     /// The blob provider returned fewer blobs than expected (under-fill).
     #[error("Blob provider under-fill: {0}")]
     BlobsUnderFill(BlobProviderError),
+    /// The blob provider returned more blobs than were requested (over-fill). The first argument
+    /// is the number of blob placeholders filled; the second is the total number of blobs
+    /// returned. This matches op-node's `fillBlobPointers` check at blob_data_source.go:162-163
+    /// which returns `fmt.Errorf("got too many blobs")` wrapped as `NewResetError`. Can occur
+    /// with buggy blob providers or in rare L1 reorg scenarios.
+    #[error(
+        "Blob provider over-fill: filled {0} blob placeholders but provider returned {1} blobs"
+    )]
+    BlobsOverFill(usize, usize),
 }
 
 impl ResetError {
@@ -449,6 +458,7 @@ mod tests {
                 expected: 0,
                 actual: 0,
             }),
+            ResetError::BlobsOverFill(0, 0),
         ];
         for error in reset_errors {
             let expected = PipelineErrorKind::Reset(error.clone());

--- a/rust/kona/crates/protocol/derive/src/errors/pipeline.rs
+++ b/rust/kona/crates/protocol/derive/src/errors/pipeline.rs
@@ -356,10 +356,8 @@ pub enum ResetError {
     /// The blob provider returned fewer blobs than expected (under-fill).
     #[error("Blob provider under-fill: {0}")]
     BlobsUnderFill(BlobProviderError),
-    /// The blob provider returned more blobs than were requested (over-fill). This matches the
-    /// check in `fillBlobPointers` in `blob_data_source.go` which returns
-    /// `fmt.Errorf("got too many blobs")` wrapped as `NewResetError`. Can occur with buggy blob
-    /// providers or in rare L1 reorg scenarios.
+    /// The blob provider returned more blobs than were requested (over-fill).
+    /// Can occur with buggy blob providers or in rare L1 reorg scenarios.
     #[error(
         "Blob provider over-fill: filled {filled} blob placeholders but provider returned {returned} blobs"
     )]

--- a/rust/kona/crates/protocol/derive/src/errors/pipeline.rs
+++ b/rust/kona/crates/protocol/derive/src/errors/pipeline.rs
@@ -356,15 +356,19 @@ pub enum ResetError {
     /// The blob provider returned fewer blobs than expected (under-fill).
     #[error("Blob provider under-fill: {0}")]
     BlobsUnderFill(BlobProviderError),
-    /// The blob provider returned more blobs than were requested (over-fill). The first argument
-    /// is the number of blob placeholders filled; the second is the total number of blobs
-    /// returned. This matches the check in `fillBlobPointers` in `blob_data_source.go`
-    /// which returns `fmt.Errorf("got too many blobs")` wrapped as `NewResetError`. Can occur
-    /// with buggy blob providers or in rare L1 reorg scenarios.
+    /// The blob provider returned more blobs than were requested (over-fill). This matches the
+    /// check in `fillBlobPointers` in `blob_data_source.go` which returns
+    /// `fmt.Errorf("got too many blobs")` wrapped as `NewResetError`. Can occur with buggy blob
+    /// providers or in rare L1 reorg scenarios.
     #[error(
-        "Blob provider over-fill: filled {0} blob placeholders but provider returned {1} blobs"
+        "Blob provider over-fill: filled {filled} blob placeholders but provider returned {returned} blobs"
     )]
-    BlobsOverFill(usize, usize),
+    BlobsOverFill {
+        /// The number of blob placeholders that were filled.
+        filled: usize,
+        /// The total number of blobs returned by the provider.
+        returned: usize,
+    },
 }
 
 impl ResetError {
@@ -458,7 +462,7 @@ mod tests {
                 expected: 0,
                 actual: 0,
             }),
-            ResetError::BlobsOverFill(0, 0),
+            ResetError::BlobsOverFill { filled: 0, returned: 0 },
         ];
         for error in reset_errors {
             let expected = PipelineErrorKind::Reset(error.clone());

--- a/rust/kona/crates/protocol/derive/src/errors/pipeline.rs
+++ b/rust/kona/crates/protocol/derive/src/errors/pipeline.rs
@@ -358,7 +358,7 @@ pub enum ResetError {
     BlobsUnderFill(BlobProviderError),
     /// The blob provider returned more blobs than were requested (over-fill). The first argument
     /// is the number of blob placeholders filled; the second is the total number of blobs
-    /// returned. This matches op-node's `fillBlobPointers` check at blob_data_source.go:162-163
+    /// returned. This matches the check in `fillBlobPointers` in `blob_data_source.go`
     /// which returns `fmt.Errorf("got too many blobs")` wrapped as `NewResetError`. Can occur
     /// with buggy blob providers or in rare L1 reorg scenarios.
     #[error(

--- a/rust/kona/crates/protocol/derive/src/sources/blobs.rs
+++ b/rust/kona/crates/protocol/derive/src/sources/blobs.rs
@@ -1,8 +1,8 @@
 //! Blob Data Source
 
 use crate::{
-    BlobData, BlobProvider, ChainProvider, DataAvailabilityProvider, PipelineError,
-    PipelineErrorKind, PipelineResult, ResetError,
+    BlobData, BlobProvider, BlobProviderError, ChainProvider, DataAvailabilityProvider,
+    PipelineError, PipelineErrorKind, PipelineResult, ResetError,
 };
 use alloc::{boxed::Box, vec::Vec};
 use alloy_consensus::{
@@ -163,11 +163,13 @@ where
             })?;
 
         // Fill the blob pointers.
-        let mut blob_index = 0;
+        let mut filled_blobs = 0;
         for blob in &mut data {
-            let should_increment = blob.fill(&blobs, blob_index)?;
+            let should_increment = blob
+                .fill(&blobs, filled_blobs)
+                .map_err(|e| -> PipelineErrorKind { BlobProviderError::from(e).into() })?;
             if should_increment {
-                blob_index += 1;
+                filled_blobs += 1;
             }
         }
 
@@ -176,9 +178,9 @@ where
         // from a clean state. Matches the check in `fillBlobPointers` in
         // blob_data_source.go which returns `fmt.Errorf("got too many blobs")`
         // wrapped as `NewResetError`.
-        if blob_index < blobs.len() {
+        if filled_blobs < blobs.len() {
             return Err(
-                ResetError::BlobsOverFill { filled: blob_index, returned: blobs.len() }.reset()
+                ResetError::BlobsOverFill { filled: filled_blobs, returned: blobs.len() }.reset()
             );
         }
 

--- a/rust/kona/crates/protocol/derive/src/sources/blobs.rs
+++ b/rust/kona/crates/protocol/derive/src/sources/blobs.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     BlobData, BlobProvider, ChainProvider, DataAvailabilityProvider, PipelineError,
-    PipelineErrorKind, PipelineResult,
+    PipelineErrorKind, PipelineResult, ResetError,
 };
 use alloc::{boxed::Box, vec::Vec};
 use alloy_consensus::{
@@ -169,6 +169,15 @@ where
             if should_increment {
                 blob_index += 1;
             }
+        }
+
+        // Post-loop over-fill check: if the provider returned more blobs than were
+        // requested, the pipeline state is inconsistent. Reset so the pipeline retries
+        // from a clean state. Matches op-node's `fillBlobPointers` check at
+        // blob_data_source.go:162-163 which returns `fmt.Errorf("got too many blobs")`
+        // wrapped as `NewResetError`.
+        if blob_index < blobs.len() {
+            return Err(ResetError::BlobsOverFill(blob_index, blobs.len()).reset());
         }
 
         self.open = true;
@@ -483,6 +492,54 @@ pub(crate) mod tests {
             matches!(err, PipelineErrorKind::Reset(_)),
             "expected Reset when block_info_and_transactions_by_hash returns BlockNotFound, \
              got {err:?}"
+        );
+    }
+
+    /// Regression test: when the blob provider returns more blobs than were requested
+    /// (over-fill), `load_blobs` must return `PipelineErrorKind::Reset` rather than
+    /// silently discarding the extra blobs. This matches op-node's `fillBlobPointers`
+    /// check at `blob_data_source.go:162-163` which returns `NewResetError("got too many
+    /// blobs")`. Over-fill can occur with buggy providers or in rare L1 reorg scenarios.
+    #[tokio::test]
+    async fn test_load_blobs_overfill_triggers_reset() {
+        use alloy_consensus::Blob;
+
+        let mut source = default_test_blob_source();
+        let block_info = BlockInfo::default();
+        let batcher_address =
+            alloy_primitives::address!("A83C816D4f9b2783761a22BA6FADB0eB0606D7B2");
+        source.batcher_address =
+            alloy_primitives::address!("11E9CA82A3a762b4B5bd264d4173a242e7a77064");
+        let txs = valid_blob_txs();
+        source.chain_provider.insert_block_with_transactions(1, block_info, txs);
+        // Insert blobs for all the real hashes so fill does not under-fill first.
+        let hashes = [
+            alloy_primitives::b256!(
+                "012ec3d6f66766bedb002a190126b3549fce0047de0d4c25cffce0dc1c57921a"
+            ),
+            alloy_primitives::b256!(
+                "0152d8e24762ff22b1cfd9f8c0683786a7ca63ba49973818b3d1e9512cd2cec4"
+            ),
+            alloy_primitives::b256!(
+                "013b98c6c83e066d5b14af2b85199e3d4fc7d1e778dd53130d180f5077e2d1c7"
+            ),
+            alloy_primitives::b256!(
+                "01148b495d6e859114e670ca54fb6e2657f0cbae5b08063605093a4b3dc9f8f1"
+            ),
+            alloy_primitives::b256!(
+                "011ac212f13c5dff2b2c6b600a79635103d6f580a4221079951181b25c7e6549"
+            ),
+        ];
+        for hash in hashes {
+            source.blob_fetcher.insert_blob(hash, Blob::with_last_byte(1u8));
+        }
+        // Instruct the mock provider to return one extra blob beyond what was requested.
+        source.blob_fetcher.should_return_extra_blob = true;
+
+        let err = source.load_blobs(&BlockInfo::default(), batcher_address).await.unwrap_err();
+        assert!(
+            matches!(err, PipelineErrorKind::Reset(_)),
+            "expected Reset for blob over-fill, got {err:?}"
         );
     }
 }

--- a/rust/kona/crates/protocol/derive/src/sources/blobs.rs
+++ b/rust/kona/crates/protocol/derive/src/sources/blobs.rs
@@ -1,8 +1,8 @@
 //! Blob Data Source
 
 use crate::{
-    BlobData, BlobProvider, BlobProviderError, ChainProvider, DataAvailabilityProvider,
-    PipelineError, PipelineErrorKind, PipelineResult, ResetError,
+    BlobData, BlobProvider, ChainProvider, DataAvailabilityProvider, PipelineError,
+    PipelineErrorKind, PipelineResult, ResetError,
 };
 use alloc::{boxed::Box, vec::Vec};
 use alloy_consensus::{
@@ -165,9 +165,7 @@ where
         // Fill the blob pointers.
         let mut filled_blobs = 0;
         for blob in &mut data {
-            let should_increment = blob
-                .fill(&blobs, filled_blobs)
-                .map_err(|e| -> PipelineErrorKind { BlobProviderError::from(e).into() })?;
+            let should_increment = blob.fill(&blobs, filled_blobs)?;
             if should_increment {
                 filled_blobs += 1;
             }

--- a/rust/kona/crates/protocol/derive/src/sources/blobs.rs
+++ b/rust/kona/crates/protocol/derive/src/sources/blobs.rs
@@ -177,7 +177,9 @@ where
         // blob_data_source.go which returns `fmt.Errorf("got too many blobs")`
         // wrapped as `NewResetError`.
         if blob_index < blobs.len() {
-            return Err(ResetError::BlobsOverFill(blob_index, blobs.len()).reset());
+            return Err(
+                ResetError::BlobsOverFill { filled: blob_index, returned: blobs.len() }.reset()
+            );
         }
 
         self.open = true;

--- a/rust/kona/crates/protocol/derive/src/sources/blobs.rs
+++ b/rust/kona/crates/protocol/derive/src/sources/blobs.rs
@@ -175,9 +175,7 @@ where
 
         // Post-loop over-fill check: if the provider returned more blobs than were
         // requested, the pipeline state is inconsistent. Reset so the pipeline retries
-        // from a clean state. Matches the check in `fillBlobPointers` in
-        // blob_data_source.go which returns `fmt.Errorf("got too many blobs")`
-        // wrapped as `NewResetError`.
+        // from a clean state.
         if filled_blobs < blobs.len() {
             return Err(
                 ResetError::BlobsOverFill { filled: filled_blobs, returned: blobs.len() }.reset()
@@ -501,8 +499,7 @@ pub(crate) mod tests {
 
     /// Regression test: when the blob provider returns more blobs than were requested
     /// (over-fill), `load_blobs` must return `PipelineErrorKind::Reset` rather than
-    /// silently discarding the extra blobs. This matches the check in `fillBlobPointers`
-    /// in `blob_data_source.go` which returns `NewResetError("got too many blobs")`.
+    /// silently discarding the extra blobs.
     /// Over-fill can occur with buggy providers or in rare L1 reorg scenarios.
     #[tokio::test]
     async fn test_load_blobs_overfill_triggers_reset() {

--- a/rust/kona/crates/protocol/derive/src/sources/blobs.rs
+++ b/rust/kona/crates/protocol/derive/src/sources/blobs.rs
@@ -173,8 +173,8 @@ where
 
         // Post-loop over-fill check: if the provider returned more blobs than were
         // requested, the pipeline state is inconsistent. Reset so the pipeline retries
-        // from a clean state. Matches op-node's `fillBlobPointers` check at
-        // blob_data_source.go:162-163 which returns `fmt.Errorf("got too many blobs")`
+        // from a clean state. Matches the check in `fillBlobPointers` in
+        // blob_data_source.go which returns `fmt.Errorf("got too many blobs")`
         // wrapped as `NewResetError`.
         if blob_index < blobs.len() {
             return Err(ResetError::BlobsOverFill(blob_index, blobs.len()).reset());
@@ -497,9 +497,9 @@ pub(crate) mod tests {
 
     /// Regression test: when the blob provider returns more blobs than were requested
     /// (over-fill), `load_blobs` must return `PipelineErrorKind::Reset` rather than
-    /// silently discarding the extra blobs. This matches op-node's `fillBlobPointers`
-    /// check at `blob_data_source.go:162-163` which returns `NewResetError("got too many
-    /// blobs")`. Over-fill can occur with buggy providers or in rare L1 reorg scenarios.
+    /// silently discarding the extra blobs. This matches the check in `fillBlobPointers`
+    /// in `blob_data_source.go` which returns `NewResetError("got too many blobs")`.
+    /// Over-fill can occur with buggy providers or in rare L1 reorg scenarios.
     #[tokio::test]
     async fn test_load_blobs_overfill_triggers_reset() {
         use alloy_consensus::Blob;

--- a/rust/kona/crates/protocol/derive/src/test_utils/blob_provider.rs
+++ b/rust/kona/crates/protocol/derive/src/test_utils/blob_provider.rs
@@ -17,6 +17,9 @@ pub struct TestBlobProvider {
     /// When `true`, `get_and_validate_blobs` returns `BlobProviderError::BlobNotFound`,
     /// simulating a missed/orphaned beacon slot (HTTP 404 from the beacon node).
     pub should_return_not_found: bool,
+    /// When `true`, `get_and_validate_blobs` appends one extra blob beyond those
+    /// requested, simulating a buggy provider that returns too many blobs (over-fill).
+    pub should_return_extra_blob: bool,
 }
 
 impl TestBlobProvider {
@@ -54,6 +57,9 @@ impl BlobProvider for TestBlobProvider {
             if let Some(data) = self.blobs.get(blob_hash) {
                 blobs.push(Box::new(*data));
             }
+        }
+        if self.should_return_extra_blob {
+            blobs.push(Box::new(Blob::default()));
         }
         Ok(blobs)
     }


### PR DESCRIPTION
## Summary

`BlobSource::load_blobs` was missing a post-loop over-fill check. After the blob-pointer fill loop completes, if `blob_index < blobs.len()` the blob provider returned more blobs than were requested. Previously kona silently discarded the extra blobs. This PR adds a guard that returns `ResetError::BlobsOverFill` (→ `PipelineErrorKind::Reset`) in that case, mirroring the op-node reference.

## Background

The Go op-node performs this check in `fillBlobPointers` in [`blob_data_source.go`](https://github.com/ethereum-optimism/optimism/blob/9eaad92f7f2f8a5f9687b6a703d4afc3dad1d347/op-node/rollup/derive/blob_data_source.go#L162):

```go
if blobIndex != len(blobs) {
    return fmt.Errorf("got too many blobs")
}
```

This error is wrapped as `NewResetError` at the call site, causing the pipeline to reset and retry from a clean state. Kona was missing the over-fill check; under-fill is handled separately via `BlobDecodingError::InvalidLength` in `BlobData::fill()`.

## When Over-fill Can Occur

- **Buggy L1 providers**: A beacon/blob provider that returns more blobs than requested (not spec-compliant but observed in practice with third-party providers).
- **Rare L1 reorg scenarios**: The set of blob transactions referenced by an L1 block can shift between the time the hashes are collected and the time the blobs are fetched, resulting in a count mismatch.

## Changes

- Add `ResetError::BlobsOverFill(usize, usize)` variant to `pipeline.rs` (addresses the over-fill case; under-fill is handled separately via `BlobDecodingError::InvalidLength` in `BlobData::fill()`).
- Import `ResetError` in `blobs.rs` and add the post-loop check after the fill loop.
- Add `should_return_extra_blob` flag to `TestBlobProvider` for testing.
- Add `test_load_blobs_overfill_triggers_reset` regression test.

## Testing

```
cargo test --package kona-derive sources::blobs
```

All 12 tests pass, including the new `test_load_blobs_overfill_triggers_reset`.

Fixes https://github.com/ethereum-optimism/optimism/issues/19363