### PR TITLE
op-supernode: Fix stuck pause state causing shutdown hang in chain container

### DIFF
--- a/op-supernode/supernode/chain_container/chain_container.go
+++ b/op-supernode/supernode/chain_container/chain_container.go
@@ -200,6 +200,13 @@ func (c *simpleChainContainer) Start(ctx context.Context) error {
 		// Pass in the chain container as a SuperAuthority
 		c.vn = c.virtualNodeFactory(c.vncfg, c.log, c.initOverload, c.appVersion, c)
 		if c.pause.Load() {
+			// Check for stop/cancellation even while paused, so teardown doesn't hang.
+			// Without this, a stuck pause (e.g. from RewindEngine exiting before Resume)
+			// causes this loop to spin forever, blocking wg.Wait() in Supernode.Stop().
+			if c.stop.Load() || ctx.Err() != nil {
+				c.log.Info("chain container stop requested while paused, stopping restart loop")
+				break
+			}
 			c.log.Info("chain container paused")
 			time.Sleep(1 * time.Second)
 			continue
@@ -490,6 +497,10 @@ func (c *simpleChainContainer) RewindEngine(ctx context.Context, timestamp uint6
 	if err != nil {
 		return err
 	}
+	// Always resume the container on return, even if we exit early due to context cancellation
+	// or an error mid-rewind. Without this, a cancelled ctx leaves pause=true permanently,
+	// causing the Start() loop to spin forever and block Supernode.Stop()'s wg.Wait().
+	defer c.Resume(context.Background()) //nolint:errcheck
 	c.log.Info("chain_container/RewindEngine: paused container")
 
 	// stop the vn

--- a/op-supernode/supernode/chain_container/chain_container_test.go
+++ b/op-supernode/supernode/chain_container/chain_container_test.go
@@ -660,8 +660,9 @@ func TestChainContainer_RewindEngine(t *testing.T) {
 		// Verify RewindToTimestamp was called multiple times (retry attempts)
 		require.Greater(t, mockEngine.rewindToTimestampCalled, 1, "RewindToTimestamp should be retried at least once")
 
-		// Container should still be paused since rewind failed
-		require.True(t, c.pause.Load(), "Container should remain paused after failed rewind")
+		// Container should be resumed even after a failed rewind, so the Start() loop
+		// can detect the stop flag and exit cleanly instead of spinning forever.
+		require.False(t, c.pause.Load(), "Container should be resumed (not stuck paused) after failed rewind")
 	})
 
 	t.Run("does not retry critical errors", func(t *testing.T) {


### PR DESCRIPTION
Continuing the campaign to reduce the flakiness of `TestSupernodeInteropActivationAfterGenesis`.

---

Add stop/cancellation check in Start() loop while paused to prevent infinite spinning when RewindEngine exits before Resume is called.

Add deferred Resume() call in RewindEngine to ensure the container is always unpaused on return, even on context cancellation or errors.


> Root Cause & Fix
> 
> **Root cause**: A race condition during teardown leaves `simpleChainContainer` paused permanently, blocking `Supernode.Stop()`'s `wg.Wait()` forever.
> 
> **Sequence of events** (in `chain_container.go`):
> 1. Interop activity calls `RewindEngine(i.ctx, ...)` → sets `c.pause = true`, stops the VN
> 2. Teardown begins: `n.cancel()` cancels the supernode context → `Interop.Stop()` cancels `i.ctx`
> 3. `RewindEngine` detects `ctx.Done()` in its retry loop and returns `ctx.Err()` — **without calling `Resume()`**
> 4. `c.pause` is stuck at `true` permanently
> 5. `simpleChainContainer.Stop()` sets `c.stop = true`, but `Start()`'s loop only checks `stop` *outside* the pause branch — it never sees it
> 6. The goroutine spins forever (creating leaked VN objects each second), never sends on `c.stopped`
> 7. `Supernode.Stop()` → `s.wg.Wait()` blocks indefinitely → 2-hour test timeout
> 
> **Fix 1** — `Start()`: check `stop`/`ctx` inside the `pause` branch so the loop can break during teardown even when paused (`chain_container.go:206-209`).
> 
> **Fix 2** — `RewindEngine()`: add `defer c.Resume(context.Background())` immediately after `Pause()` succeeds, ensuring `pause` is always cleared on exit regardless of how the function returns (`chain_container.go:500-503`). This is the defensive fix — it prevents `pause` from ever getting stuck.
> 
> The test `retries_transient_errors_and_eventually_fails` was updated to assert `pause=false` after a failed rewind (the new correct behavior), since "remain paused after failure" was precisely the bug.