### PR TITLE
chore(contracts-bedrock): bump Solidity version to 0.8.25

### DIFF
--- a/packages/contracts-bedrock/scripts/L2Genesis.s.sol
+++ b/packages/contracts-bedrock/scripts/L2Genesis.s.sol
@@ -214,7 +214,7 @@ contract L2Genesis is Script {
     //          script didn't set the nonce and we didn't want to change that behavior when
     ///         migrating genesis generation to Solidity.
     function setPredeployProxies(Input memory _input) internal {
-        bytes memory code = vm.getDeployedCode("Proxy.sol:Proxy");
+        bytes memory code = vm.getDeployedCode("universal/Proxy.sol:Proxy");
         uint160 prefix = uint160(0x420) << 148;
 
         for (uint256 i = 0; i < Predeploys.PREDEPLOY_COUNT; i++) {

--- a/packages/contracts-bedrock/scripts/L2Genesis.s.sol
+++ b/packages/contracts-bedrock/scripts/L2Genesis.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";

--- a/packages/contracts-bedrock/scripts/SetPreinstalls.s.sol
+++ b/packages/contracts-bedrock/scripts/SetPreinstalls.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Script } from "forge-std/Script.sol";
 import { console2 as console } from "forge-std/console2.sol";

--- a/packages/contracts-bedrock/scripts/checks/strict-pragma/main.go
+++ b/packages/contracts-bedrock/scripts/checks/strict-pragma/main.go
@@ -72,7 +72,7 @@ func processFile(filePath string) (*common.Void, []error) {
 	}
 
 	if !isStrictPragma(pragma) {
-		return nil, []error{fmt.Errorf("non-strict pragma '%s' - contracts must use exact version (e.g., '0.8.15' not '^0.8.15')", pragma)}
+		return nil, []error{fmt.Errorf("non-strict pragma '%s' - contracts must use exact version (e.g., '0.8.25' not '^0.8.25')", pragma)}
 	}
 
 	return nil, nil

--- a/packages/contracts-bedrock/scripts/checks/strict-pragma/main_test.go
+++ b/packages/contracts-bedrock/scripts/checks/strict-pragma/main_test.go
@@ -15,7 +15,7 @@ func Test_hasConcreteContract(t *testing.T) {
 		{
 			name: "concrete contract",
 			content: `
-				pragma solidity 0.8.15;
+				pragma solidity 0.8.25;
 				contract MyContract {
 				}
 			`,
@@ -24,7 +24,7 @@ func Test_hasConcreteContract(t *testing.T) {
 		{
 			name: "abstract contract only",
 			content: `
-				pragma solidity 0.8.15;
+				pragma solidity 0.8.25;
 				abstract contract MyContract {
 				}
 			`,
@@ -33,7 +33,7 @@ func Test_hasConcreteContract(t *testing.T) {
 		{
 			name: "library only",
 			content: `
-				pragma solidity 0.8.15;
+				pragma solidity 0.8.25;
 				library MyLibrary {
 				}
 			`,
@@ -42,7 +42,7 @@ func Test_hasConcreteContract(t *testing.T) {
 		{
 			name: "interface only",
 			content: `
-				pragma solidity 0.8.15;
+				pragma solidity 0.8.25;
 				interface IMyInterface {
 				}
 			`,
@@ -51,7 +51,7 @@ func Test_hasConcreteContract(t *testing.T) {
 		{
 			name: "abstract and concrete contract",
 			content: `
-				pragma solidity 0.8.15;
+				pragma solidity 0.8.25;
 				abstract contract Base {
 				}
 				contract MyContract is Base {
@@ -62,7 +62,7 @@ func Test_hasConcreteContract(t *testing.T) {
 		{
 			name: "library and concrete contract",
 			content: `
-				pragma solidity 0.8.15;
+				pragma solidity 0.8.25;
 				library MyLibrary {
 				}
 				contract MyContract {
@@ -73,7 +73,7 @@ func Test_hasConcreteContract(t *testing.T) {
 		{
 			name: "contract in comment",
 			content: `
-				pragma solidity 0.8.15;
+				pragma solidity 0.8.25;
 				// contract NotReal {
 				// }
 				library MyLibrary {
@@ -84,7 +84,7 @@ func Test_hasConcreteContract(t *testing.T) {
 		{
 			name: "contract in multiline comment",
 			content: `
-				pragma solidity 0.8.15;
+				pragma solidity 0.8.25;
 				/*
 				contract NotReal {
 				}
@@ -118,10 +118,10 @@ func Test_extractPragma(t *testing.T) {
 		{
 			name: "strict pragma",
 			content: `
-				pragma solidity 0.8.15;
+				pragma solidity 0.8.25;
 				contract MyContract {}
 			`,
-			expected: "0.8.15",
+			expected: "0.8.25",
 		},
 		{
 			name: "caret pragma",
@@ -170,7 +170,7 @@ func Test_isStrictPragma(t *testing.T) {
 	}{
 		{
 			name:     "strict version",
-			pragma:   "0.8.15",
+			pragma:   "0.8.25",
 			expected: true,
 		},
 		{

--- a/packages/contracts-bedrock/scripts/deploy/AddGameType.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/AddGameType.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.25;
 
 // Forge
 import { Script } from "forge-std/Script.sol";

--- a/packages/contracts-bedrock/scripts/deploy/DeployAlphabetVM.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployAlphabetVM.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Script } from "forge-std/Script.sol";
 

--- a/packages/contracts-bedrock/scripts/deploy/DeployAltDA.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployAltDA.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { IDataAvailabilityChallenge } from "interfaces/L1/IDataAvailabilityChallenge.sol";
 import { IProxy } from "interfaces/universal/IProxy.sol";

--- a/packages/contracts-bedrock/scripts/deploy/DeployConfig.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployConfig.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Script } from "forge-std/Script.sol";
 import { console2 as console } from "forge-std/console2.sol";

--- a/packages/contracts-bedrock/scripts/deploy/DeployDisputeGame.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployDisputeGame.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Forge
 import { Script } from "forge-std/Script.sol";

--- a/packages/contracts-bedrock/scripts/deploy/DeployFeesDepositor.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployFeesDepositor.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Script } from "forge-std/Script.sol";
 import { console2 as console } from "forge-std/console2.sol";

--- a/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Script } from "forge-std/Script.sol";
 

--- a/packages/contracts-bedrock/scripts/deploy/DeployMIPS.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployMIPS.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Forge
 import { Script } from "forge-std/Script.sol";

--- a/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Script } from "forge-std/Script.sol";
 

--- a/packages/contracts-bedrock/scripts/deploy/DeploySaferSafes.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeploySaferSafes.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.25;
 
 // Forge
 import { Script } from "forge-std/Script.sol";

--- a/packages/contracts-bedrock/scripts/deploy/DeploySuperchain.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeploySuperchain.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Script } from "forge-std/Script.sol";
 

--- a/packages/contracts-bedrock/scripts/deploy/InteropMigration.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/InteropMigration.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Script } from "forge-std/Script.sol";
 import { BaseDeployIO } from "scripts/deploy/BaseDeployIO.sol";

--- a/packages/contracts-bedrock/scripts/deploy/ReadImplementationAddresses.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/ReadImplementationAddresses.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { IProxy } from "interfaces/universal/IProxy.sol";
 import { Script } from "forge-std/Script.sol";

--- a/packages/contracts-bedrock/scripts/deploy/ReadSuperchainDeployment.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/ReadSuperchainDeployment.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Script } from "forge-std/Script.sol";
 

--- a/packages/contracts-bedrock/scripts/deploy/SetDisputeGameImpl.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/SetDisputeGameImpl.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Script } from "forge-std/Script.sol";
 

--- a/packages/contracts-bedrock/scripts/deploy/StandardConstants.sol
+++ b/packages/contracts-bedrock/scripts/deploy/StandardConstants.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 library StandardConstants {
     uint256 public constant MIPS_VERSION = 8;

--- a/packages/contracts-bedrock/scripts/deploy/UpgradeSuperchainConfig.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/UpgradeSuperchainConfig.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Script } from "forge-std/Script.sol";
 import { IOPContractsManager } from "interfaces/L1/IOPContractsManager.sol";

--- a/packages/contracts-bedrock/scripts/deploy/VerifyOPCM.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/VerifyOPCM.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.25;
 
 // Foundry
 import { Script } from "forge-std/Script.sol";

--- a/packages/contracts-bedrock/scripts/libraries/StateDiff.sol
+++ b/packages/contracts-bedrock/scripts/libraries/StateDiff.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { stdJson } from "forge-std/StdJson.sol";
 import { VmSafe } from "forge-std/Vm.sol";

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -1,91 +1,91 @@
 {
   "src/L1/DataAvailabilityChallenge.sol:DataAvailabilityChallenge": {
-    "initCodeHash": "0xacbae98cc7c0f7ecbf36dc44bbf7cb0a011e6e6b781e28b9dbf947e31482b30d",
-    "sourceCodeHash": "0xe772f7db8033e4a738850cb28ac4849d3a454c93732135a8a10d4f7cb498088e"
+    "initCodeHash": "0xb2fb009daa758c03de24ac1d960bda8cc81c1a87120eb43943bdecf3e779f8c2",
+    "sourceCodeHash": "0x798fc65155e4031004bd600637b4915380d3b6061874c1e703057dcff108ad70"
   },
   "src/L1/ETHLockbox.sol:ETHLockbox": {
-    "initCodeHash": "0x65db3aa3c2e3221065752f66016fa02b66688a01cc5c3066533b27fe620619c8",
-    "sourceCodeHash": "0x6c9d3e2dee44c234d59ab93b6564536dfd807f1c4a02a82d5393bc53cb15b8b7"
+    "initCodeHash": "0xfc3f2102f8cd19e63b603b77a8f7b544090b9111d12427ddef05efa447f66926",
+    "sourceCodeHash": "0xb6de3cf280f386a147ea8b08ca1928aa29859599b725e394e7f465168dc50c96"
   },
   "src/L1/FeesDepositor.sol:FeesDepositor": {
-    "initCodeHash": "0xe52c51805cfd55967d037173159f18aaf4344e32e5c8ad41f8d5d0025b1d36a8",
-    "sourceCodeHash": "0xe5f2b1915a201c0b8a107f168f5b9bc8aec8e8e95f938082e42ba5b5c8ebbd11"
+    "initCodeHash": "0xec496f21fecb211dc7a327f3bdd427a733e206f988cc3bc89d9bd6872f8c76a7",
+    "sourceCodeHash": "0xde6ffc230586d838510b66e286edc3ebc54499d791a2740cfa435fcb7314e52f"
   },
   "src/L1/L1CrossDomainMessenger.sol:L1CrossDomainMessenger": {
-    "initCodeHash": "0x3dc659aafb03bd357f92abfc6794af89ee0ddd5212364551637422bf8d0b00f9",
-    "sourceCodeHash": "0xef3d366cd22eac2dfd22a658e003700c679bd9c38758d9c21befa7335bbd82ad"
+    "initCodeHash": "0xb6940024887a0e7acc63a23c43f1cf0293414a06916965342bce32cbe9288d3b",
+    "sourceCodeHash": "0xfead03c9f7ecfa5fd9bc40a76c2ca72661a4650741b9112342b75e1fd2bd0515"
   },
   "src/L1/L1ERC721Bridge.sol:L1ERC721Bridge": {
-    "initCodeHash": "0x6f586bf82f6e89b75c2cc707e16a71ac921a911acf00f1594659f82e5c819fcc",
-    "sourceCodeHash": "0x4d48a9cf80dd288d1c54c9576a1a8c12c1c5b9f1694246d0ebba60996f786b69"
+    "initCodeHash": "0xe838ac959eb698decefe5a4eef49b5d6621435dcd6b6678a74189d3ce12684f8",
+    "sourceCodeHash": "0xcedda41edde29fc4503c298f644c7ddd8d6cd45d7894dd6f3a9cd0909217fcf9"
   },
   "src/L1/L1StandardBridge.sol:L1StandardBridge": {
-    "initCodeHash": "0xadd7863f0d14360be0f0c575d07aa304457b190b64a91a8976770fb7c34b28a3",
-    "sourceCodeHash": "0xfca613b5d055ffc4c3cbccb0773ddb9030abedc1aa6508c9e2e7727cc0cd617b"
+    "initCodeHash": "0xb97101fc6112b94213414a928ccb176f1a7c4ec23c1b143f8d29cd268e3503e6",
+    "sourceCodeHash": "0x5e3086d23e664472a4d849aa5f9f6c6388303415f8fcdd84ffd9f9d4a15d93a1"
   },
   "src/L1/OPContractsManager.sol:OPContractsManager": {
-    "initCodeHash": "0xd4593c8b35e7a1d5371315011c48116594001b198168d416d5df6d43d49f97c8",
-    "sourceCodeHash": "0xf8900a57ff29a27f99f6f68b2978b7964629a5d4b8bb351394c10431cae0f617"
+    "initCodeHash": "0xd6e82f779194944f74122aacdc6868ff0348f7ab538f7919eb4bf761bab02548",
+    "sourceCodeHash": "0x3159e07d928b89a8925f6e51ba3d824ad85ddb523741fac4bb6ee9d80a68380b"
   },
   "src/L1/OPContractsManagerStandardValidator.sol:OPContractsManagerStandardValidator": {
-    "initCodeHash": "0xdec828fdb9f9bb7a35ca03d851b041fcd088681957642e949b5d320358d9b9a1",
-    "sourceCodeHash": "0x17231caf75773e159b91ad37d798c600ed9662b77c236143022456dc9eb83e47"
+    "initCodeHash": "0x2b421c32c3705f614b7908530082d7a6ee6e85fc5286f1ddfdde63af1cfc3541",
+    "sourceCodeHash": "0x4162d8907f06f166f8607255a1f6326df75076b877999477103f108712bc9608"
   },
   "src/L1/OptimismPortal2.sol:OptimismPortal2": {
-    "initCodeHash": "0x2c01bc6c0a55a1a27263224e05c1b28703ff85c61075bae7ab384b3043820ed2",
-    "sourceCodeHash": "0x16fb96f4d29a10d03b3b9c70edf56df51e97c2a1a3f0ba36aae79469b446ad5c"
+    "initCodeHash": "0xc8965815276312b9c11859a0c84a4d0715a1a99babc4400a3381e58b137c5b63",
+    "sourceCodeHash": "0x2490389fbc36ec2b475d96dff44a8cbdcf7e19a27f19899297e5c5105d4b41a9"
   },
   "src/L1/OptimismPortalInterop.sol:OptimismPortalInterop": {
-    "initCodeHash": "0xbe7924e1aef73d04bd058adf79666a0ce2172d7b18605f0c8296bd1dc75f9b03",
-    "sourceCodeHash": "0x3bf1ea77351cb79fb3fc34d6ad42524f2cba56191dbc0cba2c036cce6f570e80"
+    "initCodeHash": "0x387c3fdf6deddb5771bd13a49372be3b4a0f4829253211f61f446a39e490cbeb",
+    "sourceCodeHash": "0x1488487924393b287524993712dd6eea702c0a5df9f9e2163d611b213569b5fc"
   },
   "src/L1/ProtocolVersions.sol:ProtocolVersions": {
-    "initCodeHash": "0xcb59ad9a5ec2a0831b7f4daa74bdacba82ffa03035dafb499a732c641e017f4e",
-    "sourceCodeHash": "0x3b7b7a1023e6e87ce4680eee3cc4eebefc15b5ec80db3d39e824fbdd521762db"
+    "initCodeHash": "0x3c7ecf140c7861b0402ef9d4851e62f71dce8d0354dcd84f0b5566f2a9636a12",
+    "sourceCodeHash": "0x70794b37b2cdf395609cf434070a69497fec8ab4307d932ca4a9c6e2301d27a1"
   },
   "src/L1/SuperchainConfig.sol:SuperchainConfig": {
-    "initCodeHash": "0x7184a7d4ffb0e4624c8699d2573fa05eae028ca311e2f5bdd901e409cf6305ec",
-    "sourceCodeHash": "0x65c3a0c5d721408a6c8d66b817b4881820ea4119d6452796725fbf92ad9e3c8f"
+    "initCodeHash": "0x0836b6bd51cd71f10470b50e36f889a75c26c7235a8715db9c8d202c3bfb620b",
+    "sourceCodeHash": "0x77f0591ebb8fe1b8800a4277ddcd0b60ce93d047d55de2fa2fb4d85d9d48de2d"
   },
   "src/L1/SystemConfig.sol:SystemConfig": {
-    "initCodeHash": "0xd4ec112de4cf7173668374479b7405bab9c828e5b32c946ef8ab5cd021f9703b",
-    "sourceCodeHash": "0xb3184aa5d95a82109e7134d1f61941b30e25f655b9849a0e303d04bbce0cde0b"
+    "initCodeHash": "0xfc168fc0b68328d42b8330a74ffe4df4919fe0063589374c7b1d62c80dc71ea5",
+    "sourceCodeHash": "0xe52d89252cbf34c5cad404722793078d72263e02b6be034d5320bf404764e746"
   },
   "src/L1/opcm/OPContractsManagerV2.sol:OPContractsManagerV2": {
-    "initCodeHash": "0x5cbc998e57035d8658824e16dacaab8c702f9e18f482e16989b9420e5a7e8190",
-    "sourceCodeHash": "0x11678225efb1fb4593085febd8f438eeb4752c0ab3dfd2ee1c4fe47970dda953"
+    "initCodeHash": "0x668aba5fd1a33c178a6a40104b2fef12c2b4b72bd8f5feeb8f92889b0ef7e242",
+    "sourceCodeHash": "0xd0400c66286a0b37be2313a1f210bc1723eb027a54507cdb37b6d8040c076696"
   },
   "src/L2/BaseFeeVault.sol:BaseFeeVault": {
     "initCodeHash": "0x838bbd7f381e84e21887f72bd1da605bfc4588b3c39aed96cbce67c09335b3ee",
     "sourceCodeHash": "0xcb329746df0baddd3dc03c6c88da5d6bdc0f0a96d30e6dc78d0891bb1e935032"
   },
   "src/L2/ConditionalDeployer.sol:ConditionalDeployer": {
-    "initCodeHash": "0x580996fd149ac478b9363399eab8ba479ed55a324a215ea8e4841f9e9f033ac5",
-    "sourceCodeHash": "0x7c83a95f65cfd963af0caf90579e8f8544e3f883a48bc803720ec251c72aeffe"
+    "initCodeHash": "0x97a691cb4818111928fe01ecc047612bca86ab6e61f47839106903bae27c4b7d",
+    "sourceCodeHash": "0x0214ed6a92f8695b6a7aea731c60fd57f58971f58076a2abeb390eac3000d556"
   },
   "src/L2/CrossL2Inbox.sol:CrossL2Inbox": {
     "initCodeHash": "0x56f868e561c4abe539043f98b16aad9305479e68fd03ece2233249b0c73a24ea",
     "sourceCodeHash": "0x7c6d362a69a480a06a079542a7fd2ce48cb1dd80d6b9043fba60218569371349"
   },
   "src/L2/ETHLiquidity.sol:ETHLiquidity": {
-    "initCodeHash": "0xd4a8b5b95e29bdad905637c4007af161b28224f350f54508e66299f56cffcef0",
-    "sourceCodeHash": "0x6d137fef431d75a8bf818444915fc39c8b1d93434a9af9971d96fb3170bc72b7"
+    "initCodeHash": "0xeae7e29d1a49c256b40e5155fcca97e74729f77d4bfad55b6a97193150c4c87f",
+    "sourceCodeHash": "0xa64068ac8cfa94cf3a5f8846572ced00ac23b1dc166df934623bae4c152ab418"
   },
   "src/L2/FeeSplitter.sol:FeeSplitter": {
     "initCodeHash": "0xdaae3903628f760e36da47c8f8d75d20962d1811fb5129cb09eb01803e67c095",
     "sourceCodeHash": "0xdc50fe7643d26950527dac75d69ddbdebf0b5c4f061fe2938eada849e179a217"
   },
   "src/L2/GasPriceOracle.sol:GasPriceOracle": {
-    "initCodeHash": "0xf72c23d9c3775afd7b645fde429d09800622d329116feb5ff9829634655123ca",
-    "sourceCodeHash": "0xb4d1bf3669ba87bbeaf4373145c7e1490478c4a05ba4838a524aa6f0ce7348a6"
+    "initCodeHash": "0x018efa8caced0e69d82b16593d2b2fc059de041c78b19e7d348bcbb806522286",
+    "sourceCodeHash": "0x176a24155246f22a12f3760d482da0aee0ecb9f65a54bc37f537e8cc22a19bdc"
   },
   "src/L2/L1Block.sol:L1Block": {
-    "initCodeHash": "0xa6dd2668435fc510161fb2085e2fd77ef0cd6735d3e96a3f839b10c064f00317",
-    "sourceCodeHash": "0x6551be49dcb0e2a80e9c1042e7964dc41f70bcb08f9ceefd0c0156de9c14cf2d"
+    "initCodeHash": "0x6bca8a95500cdcf5faa28e930527a4a23aa6e6ba2f9c1920ea98a4a33a086f6b",
+    "sourceCodeHash": "0xeea9bbf845a2f36b830d1450ca91a2a3a672a9a9a2b296a4b0ae59359022f39a"
   },
   "src/L2/L1BlockCGT.sol:L1BlockCGT": {
-    "initCodeHash": "0x98094c7af5b4a370cdf5cb5f1501f4c4e7f51e38379c9791a865f34232a75d37",
-    "sourceCodeHash": "0x97b84b125df97ca4ad6fb1bd5c05998115970f37e71d7bccb5b902144fb8f8de"
+    "initCodeHash": "0x262bc9660a397f71e9ff79fc1ecc0919478e851006b1751c57251fe21195e89b",
+    "sourceCodeHash": "0x0ca17999e06c8deb5a6d4ba6afdbf8ddba1ba59ffc57a3ffd7d3cc60941f76ff"
   },
   "src/L2/L1FeeVault.sol:L1FeeVault": {
     "initCodeHash": "0x838bbd7f381e84e21887f72bd1da605bfc4588b3c39aed96cbce67c09335b3ee",
@@ -96,68 +96,68 @@
     "sourceCodeHash": "0x7e438cbbe9a8248887b8c21f68c811f90a5cae4902cbbf7b0a1f6cd644dc42d9"
   },
   "src/L2/L2ContractsManager.sol:L2ContractsManager": {
-    "initCodeHash": "0xc6953fefa5142a37061fc6e96d0ec251a8ff8bcc2d09e8fdeb023e8677ff17c7",
-    "sourceCodeHash": "0xa4fba8f6dd5f7e1cfcba63ca8b9d0fbe621d1fe33aeb6147a185045fcded7c14"
+    "initCodeHash": "0x1f4c4e5084ea97024f406ba87d44d1fc4db7ff8823e33d74833ead9b37015df4",
+    "sourceCodeHash": "0x820b95204466f68eb6c6ea108a9b21600583623408e34a85d7a60e646d3290fd"
   },
   "src/L2/L2CrossDomainMessenger.sol:L2CrossDomainMessenger": {
-    "initCodeHash": "0xe160be403df12709c371c33195d1b9c3b5e9499e902e86bdabc8eed749c3fd61",
-    "sourceCodeHash": "0x12ea125038b87e259a0d203e119faa6e9726ab2bdbc30430f820ccd48fe87e14"
+    "initCodeHash": "0xde10eeab8e468e6547195e76dfb488f34893340d55f1210d493ed190b69784dc",
+    "sourceCodeHash": "0xee1c544481c0283a8e7fb5b67c97eb5785f41ccd03df3516b0d72e5d7c2e3ffa"
   },
   "src/L2/L2ERC721Bridge.sol:L2ERC721Bridge": {
-    "initCodeHash": "0x863f0f5b410983f3e51cd97c60a3a42915141b7452864d0e176571d640002b81",
-    "sourceCodeHash": "0xc05bfcfadfd09a56cfea68e7c1853faa36d114d9a54cd307348be143e442c35a"
+    "initCodeHash": "0xd95a855e368b0de449591d971a2c0cea976af9bc9a1f94689588df50a7bb6d66",
+    "sourceCodeHash": "0x37326cc680f6aa22fc0b098b94a4db5b526a8eeadeeef903f8530c8c88d74300"
   },
   "src/L2/L2ProxyAdmin.sol:L2ProxyAdmin": {
-    "initCodeHash": "0x85b054c8105191d272014459858020a90fcf7db401ef0fb028999f967461d25a",
-    "sourceCodeHash": "0x0d402be0c35dcdd3f6642c2949932705dd09c8e2d08a06c328ccbf8ed6c65808"
+    "initCodeHash": "0xad0e30af5d4f470948cecc91232f7505b7aceda98b5bbdc52ef3fbfbebefb4d9",
+    "sourceCodeHash": "0xc69b7a0049af38e3c7ff4b47f2a75c056b2f0100319dcc898a3309e29f150322"
   },
   "src/L2/L2StandardBridge.sol:L2StandardBridge": {
-    "initCodeHash": "0xba5b288a396b34488ba7be68473305529c7da7c43e5f1cfc48d6a4aecd014103",
-    "sourceCodeHash": "0x9dd26676cd1276c807ffd4747236783c5170d0919c70693e70b7e4c4c2675429"
+    "initCodeHash": "0x491b7ef5515302b1886ef8d6174f7507884e41197879e822961a3da615d865b9",
+    "sourceCodeHash": "0xa695d54f8c7d0e2cf0e478ff9617387a45d7002f08907bd3de3bad1375f6f758"
   },
   "src/L2/L2StandardBridgeInterop.sol:L2StandardBridgeInterop": {
-    "initCodeHash": "0xa7a2e7efe8116ebb21f47ee06c1e62d3b2f5a046478094611a2ab4b714154030",
-    "sourceCodeHash": "0xde724da82ecf3c96b330c2876a7285b6e2b933ac599241eaa3174c443ebbe33a"
+    "initCodeHash": "0x85b8ff81dd3e9142244af8a9ef457034dc80b826b76346a634b7ef656a88997e",
+    "sourceCodeHash": "0x04dc817f3662f7ffed767f713df554ea860f66a8662bfb7adb9a57b22a6198ac"
   },
   "src/L2/L2ToL1MessagePasser.sol:L2ToL1MessagePasser": {
-    "initCodeHash": "0xe30675ea6623cd7390dd2cd1e9a523c92c66956dfab86d06e318eb410cd1989b",
-    "sourceCodeHash": "0xdc7bd63134eeab163a635950f2afd16b59f40f9cf1306f2ed33ad661cc7b4962"
+    "initCodeHash": "0xda5d79bc2892e79a352f77e270407af7fdd1635303fc676e48ec9f0f189a6308",
+    "sourceCodeHash": "0x3ae84831c9b4ad044b7d5548bd124e7239c3ece1e166ff1fabac8122f74bf1fe"
   },
   "src/L2/L2ToL1MessagePasserCGT.sol:L2ToL1MessagePasserCGT": {
-    "initCodeHash": "0xf36eab44c41249b4d8ea95a21b70f1eae55b1a555384870c2f4ca306fa9121b6",
-    "sourceCodeHash": "0xec1736e67134e22ad9ceb0b8b6c116fd169637aa6729c05d9f0f4b02547aaac0"
+    "initCodeHash": "0xf41a20a8f41d0a6c0838ee95f2e7544c2a98502a859077fb565843e92fe67c56",
+    "sourceCodeHash": "0x8067b0a2138a68f5730b3f5c676f494c093babe18af9ab1bf90045ec088f122a"
   },
   "src/L2/L2ToL2CrossDomainMessenger.sol:L2ToL2CrossDomainMessenger": {
     "initCodeHash": "0x975fd33a3a386310d54dbb01b56f3a6a8350f55a3b6bd7781e5ccc2166ddf2e6",
     "sourceCodeHash": "0xbea4229c5c6988243dbc7cf5a086ddd412fe1f2903b8e20d56699fec8de0c2c9"
   },
   "src/L2/LiquidityController.sol:LiquidityController": {
-    "initCodeHash": "0xe492fe75e3c0a8a80ede7b50271263c42a2c7616a101861e892dba76f9771e34",
-    "sourceCodeHash": "0xef9cf289b4bf63808b6822fc2c588fe516abbbfb90479553e7d54d43de344e50"
+    "initCodeHash": "0x621f6162f5f60fbac97d40aeb85a5e385bb789441a814ec8e064f3dc8797469f",
+    "sourceCodeHash": "0xe4f92953eb30667e7628e855ae925d8176ed4c9f79a99bb71a621ce735264274"
   },
   "src/L2/NativeAssetLiquidity.sol:NativeAssetLiquidity": {
-    "initCodeHash": "0x04b176e5d484e54173a5644c833117c5fd9f055dce8678be9ec4cf07c0f01f00",
-    "sourceCodeHash": "0x79289174e875ead5a6290df9af1951d6c0ff0dc6809601e1c7a80110ceb8e945"
+    "initCodeHash": "0x802e46c5e24c5b64c4acca5f2e9646d48859175d1c904826409f57bd950613bd",
+    "sourceCodeHash": "0x7dd1e4e17689a7fb202f92349e90e1c0c90ec2b04b6b61acde8c4e9641a8a631"
   },
   "src/L2/OperatorFeeVault.sol:OperatorFeeVault": {
     "initCodeHash": "0x2ebab6af089a714df25888a4dea81dadcb1fb57146be84d2e079041a9396a810",
     "sourceCodeHash": "0xd6e94bc9df025855916aa4184d0bc739b0fbe786dfd037b99dbb51d0d3e46918"
   },
   "src/L2/OptimismMintableERC721.sol:OptimismMintableERC721": {
-    "initCodeHash": "0x316c6d716358f5b5284cd5457ea9fca4b5ad4a37835d4b4b300413dafbfa2159",
-    "sourceCodeHash": "0xd93a8d5de6fd89ebf503976511065f0c2414814affdb908f26a867ffdd0f9fbe"
+    "initCodeHash": "0xf18cd1051da4b1c052753fb90f7672be57ed82a582a4b77dcf83730a543937b6",
+    "sourceCodeHash": "0x6f62a961eed09a6d8e1a9af599002c1943e4fa7e37c0f4c1ee40590129a18d86"
   },
   "src/L2/OptimismMintableERC721Factory.sol:OptimismMintableERC721Factory": {
-    "initCodeHash": "0xa692a3fc4a71eb3381a59d1ab655bbc02e8b507add7c3f560ee24b001d88ae6e",
-    "sourceCodeHash": "0xb0be3deac32956251adb37d3ca61f619ca4348a1355a41c856a3a95adde0e4ff"
+    "initCodeHash": "0xb38fff300840de77df55b4f91741ebc07643bc450b5e0a71498cc7304a4ca285",
+    "sourceCodeHash": "0xfda5c68d3de04ed3c1f7a3d1eb0bcba3d5e3f4903599e9a36ca5383c1c1def81"
   },
   "src/L2/OptimismSuperchainERC20.sol:OptimismSuperchainERC20": {
     "initCodeHash": "0x1ad4b7c19d10f80559bad15063ac1fd420f36d76853eb6d846b0acd52fb93acb",
     "sourceCodeHash": "0xa135241cee15274eb07045674106becf8e830ddc55412ebf5d608c5c3da6313e"
   },
   "src/L2/OptimismSuperchainERC20Beacon.sol:OptimismSuperchainERC20Beacon": {
-    "initCodeHash": "0x5d83dcdb91620e45fb32a32ad39ada98c5741e72d4ca668bb1a0933987098e59",
-    "sourceCodeHash": "0x4582c8b84fbe62e5b754ebf9683ae31217af3567398f7d3da196addaf8de2045"
+    "initCodeHash": "0xe8889970486fd207d5aa760e8c06977b869947f71eedafb8e3c356378f5e2886",
+    "sourceCodeHash": "0x2314dcbf4b55f06061719a38ab587f0e7068282fa77d098b298c3972cc126258"
   },
   "src/L2/OptimismSuperchainERC20Factory.sol:OptimismSuperchainERC20Factory": {
     "initCodeHash": "0xb7d37397a326f752d06f7f0cecc3f49f4397f91b4f4d9c4bd1a9fd127480e9d0",
@@ -172,8 +172,8 @@
     "sourceCodeHash": "0x76eb2c7617e9b0b8dcd6b88470797cc946798a9ac067e3f195fff971fcabdbf5"
   },
   "src/L2/SuperchainETHBridge.sol:SuperchainETHBridge": {
-    "initCodeHash": "0xa43665ad0f2b4f092ff04b12e38f24aa8d2cb34ae7a06fc037970743547bdf98",
-    "sourceCodeHash": "0x862b8a2e5dd5cafcda55e35df7713b0d0b7a93d4d6ce29ea9ca53e045bf63cb4"
+    "initCodeHash": "0x05c4986077d427853cb0bc40dbe403df5214409f8b9b205995fb45d2dc932f62",
+    "sourceCodeHash": "0xa35d76af73c7915a255018e3a4aaae109b476ecf68b3d56fbd01a9dae56cdc56"
   },
   "src/L2/SuperchainRevSharesCalculator.sol:SuperchainRevSharesCalculator": {
     "initCodeHash": "0xdfff95660d2d470e198054bb1717a30a45a806d2eaa3720fb43acaa3356c9a3e",
@@ -184,60 +184,60 @@
     "sourceCodeHash": "0x0ff7c1f0264d784fac5d69b792c6bc9d064d4a09701c1bafa808388685c8c4f1"
   },
   "src/L2/WETH.sol:WETH": {
-    "initCodeHash": "0xbc2cd025153720943e51b79822c2dc374d270a78b92cf47d49548c468e218e46",
-    "sourceCodeHash": "0x734a6b2aa6406bc145d848ad6071d3af1d40852aeb8f4b2f6f51beaad476e2d3"
+    "initCodeHash": "0xa45a0a4c3506ebe5942ef385aa83433d19c56485692a873c0d2c402ac6f3c81b",
+    "sourceCodeHash": "0xccebcd9eb88bc6ea544a26f86974b6df1e4138ae7f84cd6b7fdad8775cbc5c63"
   },
   "src/cannon/MIPS64.sol:MIPS64": {
-    "initCodeHash": "0x13196c1652a1f51cf0c16191f0092898f127eff036c773923c72b02a2823c7f4",
-    "sourceCodeHash": "0xd745aaf4ed265be7be7bff9bca1dd040e15dfe41e3a453906d72ca09a47f2c8b"
+    "initCodeHash": "0x2c142aed428c29d9c2e5a528bd97682633068452d1a45de4d079049320f82b58",
+    "sourceCodeHash": "0xc9fe64256613b2bf6cdf41043177bc3c076335be35d75d4459e423871e40dd17"
   },
   "src/cannon/PreimageOracle.sol:PreimageOracle": {
-    "initCodeHash": "0x6af5b0e83b455aab8d0946c160a4dc049a4e03be69f8a2a9e87b574f27b25a66",
-    "sourceCodeHash": "0x03c160168986ffc8d26a90c37366e7ad6da03f49d83449e1f8b3de0f4b590f6f"
+    "initCodeHash": "0x911778b4363efa32133ae2b287126fddedbb8e77e5367b61939b8f722dd09605",
+    "sourceCodeHash": "0x8f080a117cefd4fd27f3698404943e4ba48d13161c41ecf805d1d97fe56aaa88"
   },
   "src/dispute/AnchorStateRegistry.sol:AnchorStateRegistry": {
-    "initCodeHash": "0x7d85ca3f30f6526a62214a6ef876299dcf15e536afe4f5dd7b232a92120e170f",
-    "sourceCodeHash": "0x896011529b7fdb6623a0b3f72b099f38229168f54514e674c6b3aa7afc35e4fc"
+    "initCodeHash": "0xd307c5ff5f60e1ce27c33569bef1ac6482b55e126bac4522fd53a38a70c33331",
+    "sourceCodeHash": "0x6b863cc51709499699534761a533203732927af1825a65e9646bc17cb9ea1373"
   },
   "src/dispute/DelayedWETH.sol:DelayedWETH": {
-    "initCodeHash": "0xa8f60e142108b33675a8f6b6979c73b96eea247884842d796f9f878904c0a906",
-    "sourceCodeHash": "0xdebf2ab3af4d5549c40e9dd9db6b2458af286f323b6891f3b0c4e89f3c8928db"
+    "initCodeHash": "0x995b45ad4ed7dbf4bd5cdece2b759fa3fee9c23eec4c0718a229e2d1163795a9",
+    "sourceCodeHash": "0xabd9eb682752dd63b33998db4d371b8c8280eae18d1cf4b46f8b4766448216e3"
   },
   "src/dispute/DisputeGameFactory.sol:DisputeGameFactory": {
-    "initCodeHash": "0x534308ec135c86df2ea0d2f5f584e89b34f85dccb27349741bcba7e8d17bd8bc",
-    "sourceCodeHash": "0x7e68423e4c4ca7725a0c625aa3df9a3db0d7027eaddfdb2e7fa65329666b7a54"
+    "initCodeHash": "0x1a5fb7b970cae24dbd837836a3c7a1085a4aa9cacbe9c533b77798098e8df5aa",
+    "sourceCodeHash": "0x9d564f42b7a3f6b34e0d9dfbbc22cad887402eb0fa4c36d3095a40c06693b271"
   },
   "src/dispute/FaultDisputeGame.sol:FaultDisputeGame": {
-    "initCodeHash": "0x2493823ad9fb986a696e61ce8a8ef50c548c6a4e0affeeec63edd119ca206083",
-    "sourceCodeHash": "0xd6a17c76aed0e561d4b7293dc17157b9435173c0a61ec40dc4ff8e49e2c1e601"
+    "initCodeHash": "0x0d318f434c07be8e6614d8e77c8dfabf2b21558c784cf666b4168ad59f429b8b",
+    "sourceCodeHash": "0x9892497e43d38ae4231d477ee797948ff5d0804dcbbec6a954054a6c9f05069a"
   },
   "src/dispute/PermissionedDisputeGame.sol:PermissionedDisputeGame": {
-    "initCodeHash": "0x940289cf9018b6b22b532a90ee1e731427d435d7982e4e78ea44f25e1cb874a2",
-    "sourceCodeHash": "0x8302f265145ebccb05d1dfb123a1176bb0b29a06167817b0020eac104da8a841"
+    "initCodeHash": "0x814040359404a9889b63c3a412ebb510370e7babefcd3a495e5358c2671b0c9b",
+    "sourceCodeHash": "0x8054bea6812d83a04b2a81808290fb168e2ca90e1cbe1c2d2dafa947c9d6fc82"
   },
   "src/dispute/SuperFaultDisputeGame.sol:SuperFaultDisputeGame": {
-    "initCodeHash": "0xb5ce71bc56109055cd0dc71fc63015443bbdb29c5975e049802cd1b5188f06ca",
-    "sourceCodeHash": "0x3096a447574168528555f091a357a120b1dee6f35b50634b7d705ace1ef9c0ad"
+    "initCodeHash": "0x2c65f2f32d96b9b2e56e513d741c21774574a1a528c88c628681f0bb71518a26",
+    "sourceCodeHash": "0x1545015a1d63b45ec3bed825c42e5772db40e49da42b44a1cb56090cf3282a8b"
   },
   "src/dispute/SuperPermissionedDisputeGame.sol:SuperPermissionedDisputeGame": {
-    "initCodeHash": "0xa080730728e812e8b02d03b5857b23d16ade46f1656f26f22274835a3100edd7",
-    "sourceCodeHash": "0x314b6e0412f698ce3531e8176ce8e5b8a3976cc3fa9d7ecb1f3278612f90ed4e"
+    "initCodeHash": "0x4fda89e4e021d2e9c008069e1285838e1ac7824100108986f64ceeff8937d392",
+    "sourceCodeHash": "0x1d5894a07464a812aba4fed6178594dc91acdb6aad4c40897d96335bb996adc8"
   },
   "src/dispute/zk/OptimisticZkGame.sol:OptimisticZkGame": {
-    "initCodeHash": "0xffd6e4c9ab9cbbc40d972db32f87d547d5b13b0f122549f588ba39b7ae609311",
-    "sourceCodeHash": "0x276047949a0b0ff4e7057f341a4bf6af58c2e4e1c249dcb0fb1ca6e3feb3bf47"
+    "initCodeHash": "0x67ba520206340768e1738a71a0cc3b0b1504ea2aaccba2d3699144d72fbcd45c",
+    "sourceCodeHash": "0x6724a90e5312e503299d4766d96c4ef990b9b92eca86444535fde6837e5d2685"
   },
   "src/legacy/DeployerWhitelist.sol:DeployerWhitelist": {
-    "initCodeHash": "0x2e0ef4c341367eb59cc6c25190c64eff441d3fe130189da91d4d126f6bdbc9b5",
-    "sourceCodeHash": "0x99fb495ee1339f399d9e14cc56e4b3b128c67778ad9ca7bad1efbb49eda2ec4c"
+    "initCodeHash": "0x19ba38214742f7b7b9fbf6a40a5fa0e7c88f392b0a0fd3ad48614ce5703c136e",
+    "sourceCodeHash": "0x76695af9257573d727c2aa608e1da51676ffa2f365726fadb00a3997d4597d59"
   },
   "src/legacy/L1BlockNumber.sol:L1BlockNumber": {
-    "initCodeHash": "0x7549dcb63799c5f30b405c6f0c1264f55659e812ccab68bf1b36e8707f4ee198",
-    "sourceCodeHash": "0xf4b4cae7cc81a93d192ce8c54a7b543327458d53f3aaababacea843825bf3e1c"
+    "initCodeHash": "0xeb98fda161d877e2a4512abff44502a869c3503902286aa72fe4dea84f9dd933",
+    "sourceCodeHash": "0x72bf5cb8cc0fd6fdaf4112c14372a1522444a89bb09bf2c83abcce55be9bbbf9"
   },
   "src/legacy/LegacyMessagePasser.sol:LegacyMessagePasser": {
-    "initCodeHash": "0x3a82e248129d19764bb975bb79b48a982f077f33bb508480bf8d2ec1c0c9810d",
-    "sourceCodeHash": "0x955bd0c9b47e43219865e4e92abf28d916c96de20cbdf2f94c8ab14d02083759"
+    "initCodeHash": "0xe7c71f91165f0c1c8245c7f77e77a55751a8540f2fa2d37accc6ce1c1018294f",
+    "sourceCodeHash": "0x53412333bb4a2881b666d54aec0d94576e779c2da3f2c0c14b31fcabd46afae4"
   },
   "src/periphery/staking/PolicyEngineStaking.sol:PolicyEngineStaking": {
     "initCodeHash": "0xc0c04b0dddbf7831bf5abfccc6a569d92f9b7ab0ec53278f6d1cf7113041d59d",
@@ -248,35 +248,35 @@
     "sourceCodeHash": "0xd15f4bb43e81a10317902cd8e27394581a59df2656b130727eb67543c985c72e"
   },
   "src/safe/LivenessGuard.sol:LivenessGuard": {
-    "initCodeHash": "0x2c55a3800e8b4934c0e8eacd61e35c4210dcc659a9cf8e3e2792e1d822096656",
-    "sourceCodeHash": "0x62e1354f04f8de3edb58aa8517faf803cd69e6b5f1ce850ac83690bf6be0d25a"
+    "initCodeHash": "0x8b0fc1ef1d525ba449a9a484bfcc2fdc111e43c706dadb2e400e7027dfbb9692",
+    "sourceCodeHash": "0xa9ee08ae69d44a57d8160263c264e1befaf8977a6157f76d6fbfd082559cc0b7"
   },
   "src/safe/LivenessModule.sol:LivenessModule": {
-    "initCodeHash": "0x5e980d76c3eb8820b25e45142c68324a65e47b0fabbf171a6a4bef10476ec80e",
-    "sourceCodeHash": "0x7fc4789b082bc8ecd29c4c75a06058f0ff0b72f1c1028a42db6f1c35269c8865"
+    "initCodeHash": "0x09a9371fff8897901b859dc791b374ac4190467da7276b49a19c76814d619486",
+    "sourceCodeHash": "0xf832ffea713710ff11cb580d3e2d83ef9fd7174ab376e34808dfe87ac600b8fd"
   },
   "src/safe/SaferSafes.sol:SaferSafes": {
-    "initCodeHash": "0x0ad1f0f33517132b06a225b51e6eac48904d4ad691e0045eb70244d811d0d99d",
-    "sourceCodeHash": "0xd6683fe9be4019d34249ada5a4de3e597f1bd9cd473a89f6eff8f749a0b0e978"
+    "initCodeHash": "0x382547ee433608adb8ea14262aa51c757fb3b7c8c47b3171b92629547536779e",
+    "sourceCodeHash": "0x370bb9a2931419287fdcc1b47a1c26ad017ab882ac10be873a37384ba2be25e1"
   },
   "src/universal/OptimismMintableERC20.sol:OptimismMintableERC20": {
-    "initCodeHash": "0x3c85eed0d017dca8eda6396aa842ddc12492587b061e8c756a8d32c4610a9658",
-    "sourceCodeHash": "0x7023665d461f173417d932b55010b8f6c34f2bbaf56cfe4e1b15862c08cbcaac"
+    "initCodeHash": "0x36721d79519f41b7e46b24f9d1ba99780ab72f696a47522f60f5368fbed9e49f",
+    "sourceCodeHash": "0x04885d4b409e8b19a485b03c8bc711390e339af22997291d42997d442906948a"
   },
   "src/universal/OptimismMintableERC20Factory.sol:OptimismMintableERC20Factory": {
-    "initCodeHash": "0x747baf403205b900e1144038f2b807c84059229aedda8c91936798e1403eda39",
-    "sourceCodeHash": "0xf71e16aaad1ec2459040ab8c93b7188b2c04c671c21b4d43fba75cab80ed1b21"
+    "initCodeHash": "0x5b4afaba81702a77a4526a14ecc9b909a14ffd20efd7939a4d3ea6e69b804261",
+    "sourceCodeHash": "0x85a0d2b9828bdf6f48b6f9425c76f5c9f99e744cd4847eac089e3f506ced29d9"
   },
   "src/universal/StorageSetter.sol:StorageSetter": {
-    "initCodeHash": "0x1fd4b84add5c5ed80205cea0bbca9115e98d0efb416d9cedc12ce0cff9919bda",
-    "sourceCodeHash": "0xcfbaae5729ca367328ea546bbbe96194341586b2f4bfbd0cfa84acc09324d59b"
+    "initCodeHash": "0xac5c2c3c77df50a919227449c8be4fee6cff872d4825e944ee0ef21ae5063ef3",
+    "sourceCodeHash": "0xc15975ffcbe9531251dd3877ec6b3a390d061a9857da2baf33c5608b44f5de3d"
   },
   "src/vendor/eas/EAS.sol:EAS": {
-    "initCodeHash": "0xbd79d6fff128b3da3e09ead84b805b7540740190488f2791a6b4e5b7aabf9cff",
-    "sourceCodeHash": "0x3512c3a1b5871341346f6646a04c0895dd563e9824f2ab7ab965b6a81a41ad2e"
+    "initCodeHash": "0x176358143ca9802e339d4975e4a0902df89319a14a7a0a8a47795f891c5d501b",
+    "sourceCodeHash": "0x76e1648976d082340b49ca17237bafebf9c44a46a4089d506f678308bff80734"
   },
   "src/vendor/eas/SchemaRegistry.sol:SchemaRegistry": {
-    "initCodeHash": "0x2bfce526f82622288333d53ca3f43a0a94306ba1bab99241daa845f8f4b18bd4",
-    "sourceCodeHash": "0xf49d7b0187912a6bb67926a3222ae51121e9239495213c975b3b4b217ee57a1b"
+    "initCodeHash": "0xc2ee470d8e2e3acf091cc0a9021156ec4cedc70d47b3a8ea996240cb5c24214d",
+    "sourceCodeHash": "0x1b8ec755405b92428a1efd8741f385c9caa38394eb70067d29496fd23cbdf606"
   }
 }

--- a/packages/contracts-bedrock/src/L1/DataAvailabilityChallenge.sol
+++ b/packages/contracts-bedrock/src/L1/DataAvailabilityChallenge.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Contracts
 import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";

--- a/packages/contracts-bedrock/src/L1/DataAvailabilityChallenge.sol
+++ b/packages/contracts-bedrock/src/L1/DataAvailabilityChallenge.sol
@@ -95,8 +95,8 @@ contract DataAvailabilityChallenge is OwnableUpgradeable, ISemver {
     event BalanceChanged(address account, uint256 balance);
 
     /// @notice Semantic version.
-    /// @custom:semver 1.0.1
-    string public constant version = "1.0.1";
+    /// @custom:semver 1.0.2
+    string public constant version = "1.0.2";
 
     /// @notice The fixed cost of resolving a challenge.
     /// @dev The value is estimated by measuring the cost of resolving with `bytes(0)`

--- a/packages/contracts-bedrock/src/L1/ETHLockbox.sol
+++ b/packages/contracts-bedrock/src/L1/ETHLockbox.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Contracts
 import { Initializable } from "@openzeppelin/contracts/proxy/utils/Initializable.sol";

--- a/packages/contracts-bedrock/src/L1/ETHLockbox.sol
+++ b/packages/contracts-bedrock/src/L1/ETHLockbox.sol
@@ -73,9 +73,9 @@ contract ETHLockbox is ProxyAdminOwnedBase, Initializable, ReinitializableBase, 
     mapping(IETHLockbox => bool) public authorizedLockboxes;
 
     /// @notice Semantic version.
-    /// @custom:semver 1.2.0
+    /// @custom:semver 1.2.1
     function version() public view virtual returns (string memory) {
-        return "1.2.0";
+        return "1.2.1";
     }
 
     /// @notice Constructs the ETHLockbox contract.

--- a/packages/contracts-bedrock/src/L1/FeesDepositor.sol
+++ b/packages/contracts-bedrock/src/L1/FeesDepositor.sol
@@ -50,8 +50,8 @@ contract FeesDepositor is ProxyAdminOwnedBase, Initializable, ReinitializableBas
     event GasLimitUpdated(uint32 oldGasLimit, uint32 newGasLimit);
 
     /// @notice Semantic version.
-    /// @custom:semver 1.0.0
-    string public constant version = "1.0.0";
+    /// @custom:semver 1.0.1
+    string public constant version = "1.0.1";
 
     /// @notice Constructs the FeesDepositor contract.
     constructor() ReinitializableBase(1) {

--- a/packages/contracts-bedrock/src/L1/FeesDepositor.sol
+++ b/packages/contracts-bedrock/src/L1/FeesDepositor.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { IL1CrossDomainMessenger } from "interfaces/L1/IL1CrossDomainMessenger.sol";
 import { ProxyAdminOwnedBase } from "src/L1/ProxyAdminOwnedBase.sol";

--- a/packages/contracts-bedrock/src/L1/L1CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/src/L1/L1CrossDomainMessenger.sol
@@ -36,8 +36,8 @@ contract L1CrossDomainMessenger is CrossDomainMessenger, ProxyAdminOwnedBase, Re
     address private spacer_253_0_20;
 
     /// @notice Semantic version.
-    /// @custom:semver 2.11.0
-    string public constant version = "2.11.0";
+    /// @custom:semver 2.11.1
+    string public constant version = "2.11.1";
 
     /// @notice Contract of the SystemConfig.
     ISystemConfig public systemConfig;

--- a/packages/contracts-bedrock/src/L1/L1CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/src/L1/L1CrossDomainMessenger.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Contracts
 import { ProxyAdminOwnedBase } from "src/L1/ProxyAdminOwnedBase.sol";

--- a/packages/contracts-bedrock/src/L1/L1ERC721Bridge.sol
+++ b/packages/contracts-bedrock/src/L1/L1ERC721Bridge.sol
@@ -33,8 +33,8 @@ contract L1ERC721Bridge is ERC721Bridge, ProxyAdminOwnedBase, ReinitializableBas
     address private spacer_50_0_20;
 
     /// @notice Semantic version.
-    /// @custom:semver 2.9.0
-    string public constant version = "2.9.0";
+    /// @custom:semver 2.9.1
+    string public constant version = "2.9.1";
 
     /// @notice Address of the SystemConfig contract.
     ISystemConfig public systemConfig;

--- a/packages/contracts-bedrock/src/L1/L1ERC721Bridge.sol
+++ b/packages/contracts-bedrock/src/L1/L1ERC721Bridge.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Contracts
 import { ProxyAdminOwnedBase } from "src/L1/ProxyAdminOwnedBase.sol";

--- a/packages/contracts-bedrock/src/L1/L1StandardBridge.sol
+++ b/packages/contracts-bedrock/src/L1/L1StandardBridge.sol
@@ -77,8 +77,8 @@ contract L1StandardBridge is StandardBridge, ProxyAdminOwnedBase, Reinitializabl
     );
 
     /// @notice Semantic version.
-    /// @custom:semver 2.8.0
-    string public constant version = "2.8.0";
+    /// @custom:semver 2.8.1
+    string public constant version = "2.8.1";
 
     /// @custom:legacy
     /// @custom:spacer superchainConfig

--- a/packages/contracts-bedrock/src/L1/L1StandardBridge.sol
+++ b/packages/contracts-bedrock/src/L1/L1StandardBridge.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Contracts
 import { ProxyAdminOwnedBase } from "src/L1/ProxyAdminOwnedBase.sol";

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -1917,9 +1917,9 @@ contract OPContractsManager is ISemver {
     /// @dev This needs to stay at 6.x.x because the next release will ship OPCMv2. Since we are
     ///      not actually planning to release a 7.x.x of OPCMv1, it needs to stay at 6.x.x to avoid
     ///      errors in the versioning rules of OPCMv2.
-    /// @custom:semver 6.0.3
+    /// @custom:semver 6.0.4
     function version() public pure virtual returns (string memory) {
-        return "6.0.3";
+        return "6.0.4";
     }
 
     OPContractsManagerGameTypeAdder public immutable opcmGameTypeAdder;

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Contracts
 import { OPContractsManagerStandardValidator } from "src/L1/OPContractsManagerStandardValidator.sol";

--- a/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Libraries
 import { LibString } from "@solady/utils/LibString.sol";

--- a/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
@@ -40,8 +40,8 @@ import { IBigStepper } from "interfaces/dispute/IBigStepper.sol";
 /// before and after an upgrade.
 contract OPContractsManagerStandardValidator is ISemver {
     /// @notice The semantic version of the OPContractsManagerStandardValidator contract.
-    /// @custom:semver 2.3.0
-    string public constant version = "2.3.0";
+    /// @custom:semver 2.3.1
+    string public constant version = "2.3.1";
 
     /// @notice The SuperchainConfig contract.
     ISuperchainConfig public superchainConfig;

--- a/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
@@ -208,9 +208,9 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
     error OptimismPortal_InvalidLockboxState();
 
     /// @notice Semantic version.
-    /// @custom:semver 5.2.0
+    /// @custom:semver 5.2.1
     function version() public pure virtual returns (string memory) {
-        return "5.2.0";
+        return "5.2.1";
     }
 
     /// @param _proofMaturityDelaySeconds The proof maturity delay in seconds.

--- a/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Contracts
 import { ProxyAdminOwnedBase } from "src/L1/ProxyAdminOwnedBase.sol";

--- a/packages/contracts-bedrock/src/L1/OptimismPortalInterop.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortalInterop.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Contracts
 import { ProxyAdminOwnedBase } from "src/L1/ProxyAdminOwnedBase.sol";

--- a/packages/contracts-bedrock/src/L1/OptimismPortalInterop.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortalInterop.sol
@@ -217,9 +217,9 @@ contract OptimismPortalInterop is Initializable, ResourceMetering, Reinitializab
     error OptimismPortal_MigratingToSameRegistry();
 
     /// @notice Semantic version.
-    /// @custom:semver 5.3.0+interop
+    /// @custom:semver 5.3.1+interop
     function version() public pure virtual returns (string memory) {
-        return "5.3.0+interop";
+        return "5.3.1+interop";
     }
 
     /// @param _proofMaturityDelaySeconds The proof maturity delay in seconds.

--- a/packages/contracts-bedrock/src/L1/ProtocolVersions.sol
+++ b/packages/contracts-bedrock/src/L1/ProtocolVersions.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Contracts
 import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";

--- a/packages/contracts-bedrock/src/L1/ProtocolVersions.sol
+++ b/packages/contracts-bedrock/src/L1/ProtocolVersions.sol
@@ -41,8 +41,8 @@ contract ProtocolVersions is OwnableUpgradeable, ISemver {
     event ConfigUpdate(uint256 indexed version, UpdateType indexed updateType, bytes data);
 
     /// @notice Semantic version.
-    /// @custom:semver 1.1.1
-    string public constant version = "1.1.1";
+    /// @custom:semver 1.1.2
+    string public constant version = "1.1.2";
 
     /// @notice Constructs the ProtocolVersion contract.
     constructor() {

--- a/packages/contracts-bedrock/src/L1/ProxyAdminOwnedBase.sol
+++ b/packages/contracts-bedrock/src/L1/ProxyAdminOwnedBase.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.25;
 
 // Libraries
 import { Storage } from "src/libraries/Storage.sol";

--- a/packages/contracts-bedrock/src/L1/ResourceMetering.sol
+++ b/packages/contracts-bedrock/src/L1/ResourceMetering.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Contracts
 import { Initializable } from "@openzeppelin/contracts/proxy/utils/Initializable.sol";

--- a/packages/contracts-bedrock/src/L1/SuperchainConfig.sol
+++ b/packages/contracts-bedrock/src/L1/SuperchainConfig.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Contracts
 import { Initializable } from "@openzeppelin/contracts/proxy/utils/Initializable.sol";

--- a/packages/contracts-bedrock/src/L1/SuperchainConfig.sol
+++ b/packages/contracts-bedrock/src/L1/SuperchainConfig.sol
@@ -53,8 +53,8 @@ contract SuperchainConfig is ProxyAdminOwnedBase, Initializable, Reinitializable
     event ConfigUpdate(UpdateType indexed updateType, bytes data);
 
     /// @notice Semantic version.
-    /// @custom:semver 2.4.1
-    string public constant version = "2.4.1";
+    /// @custom:semver 2.4.2
+    string public constant version = "2.4.2";
 
     /// @notice Constructs the SuperchainConfig contract.
     constructor() ReinitializableBase(2) {

--- a/packages/contracts-bedrock/src/L1/SystemConfig.sol
+++ b/packages/contracts-bedrock/src/L1/SystemConfig.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Contracts
 import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";

--- a/packages/contracts-bedrock/src/L1/SystemConfig.sol
+++ b/packages/contracts-bedrock/src/L1/SystemConfig.sol
@@ -174,9 +174,9 @@ contract SystemConfig is ProxyAdminOwnedBase, OwnableUpgradeable, Reinitializabl
     error SystemConfig_InvalidFeatureState();
 
     /// @notice Semantic version.
-    /// @custom:semver 3.14.0
+    /// @custom:semver 3.14.1
     function version() public pure virtual returns (string memory) {
-        return "3.14.0";
+        return "3.14.1";
     }
 
     /// @notice Constructs the SystemConfig contract.

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerContainer.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerContainer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Libraries
 import { DevFeatures } from "src/libraries/DevFeatures.sol";

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerMigrator.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerMigrator.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Contracts
 import { OPContractsManagerUtilsCaller } from "src/L1/opcm/OPContractsManagerUtilsCaller.sol";

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerUtils.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerUtils.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Libraries
 import { LibString } from "@solady/utils/LibString.sol";

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Contracts
 import { OPContractsManagerUtilsCaller } from "src/L1/opcm/OPContractsManagerUtilsCaller.sol";

--- a/packages/contracts-bedrock/src/L2/ConditionalDeployer.sol
+++ b/packages/contracts-bedrock/src/L2/ConditionalDeployer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Interfaces
 import { ISemver } from "interfaces/universal/ISemver.sol";

--- a/packages/contracts-bedrock/src/L2/ConditionalDeployer.sol
+++ b/packages/contracts-bedrock/src/L2/ConditionalDeployer.sol
@@ -28,8 +28,8 @@ contract ConditionalDeployer is ISemver {
         payable(0x4e59b44847b379578588920cA78FbF26c0B4956C);
 
     /// @notice Semantic version.
-    /// @custom:semver 1.0.0
-    string public constant version = "1.0.0";
+    /// @custom:semver 1.0.1
+    string public constant version = "1.0.1";
 
     /// @notice Deploys an implementation using CREATE2 if it doesn't already exist.
     /// @dev Does not support deployments requiring ETH.

--- a/packages/contracts-bedrock/src/L2/ETHLiquidity.sol
+++ b/packages/contracts-bedrock/src/L2/ETHLiquidity.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Contracts
 import { SafeSend } from "src/universal/SafeSend.sol";

--- a/packages/contracts-bedrock/src/L2/ETHLiquidity.sol
+++ b/packages/contracts-bedrock/src/L2/ETHLiquidity.sol
@@ -31,8 +31,8 @@ contract ETHLiquidity is ISemver {
     event LiquidityFunded(address indexed funder, uint256 amount);
 
     /// @notice Semantic version.
-    /// @custom:semver 1.1.0
-    string public constant version = "1.1.0";
+    /// @custom:semver 1.1.1
+    string public constant version = "1.1.1";
 
     /// @notice Allows an address to lock ETH liquidity into this contract.
     function burn() external payable {

--- a/packages/contracts-bedrock/src/L2/GasPriceOracle.sol
+++ b/packages/contracts-bedrock/src/L2/GasPriceOracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Libraries
 import { LibZip } from "@solady/utils/LibZip.sol";

--- a/packages/contracts-bedrock/src/L2/GasPriceOracle.sol
+++ b/packages/contracts-bedrock/src/L2/GasPriceOracle.sol
@@ -30,8 +30,8 @@ contract GasPriceOracle is ISemver {
     uint256 public constant DECIMALS = 6;
 
     /// @notice Semantic version.
-    /// @custom:semver 1.6.0
-    string public constant version = "1.6.0";
+    /// @custom:semver 1.6.1
+    string public constant version = "1.6.1";
 
     /// @notice This is the intercept value for the linear regression used to estimate the final size of the
     ///         compressed transaction.

--- a/packages/contracts-bedrock/src/L2/L1Block.sol
+++ b/packages/contracts-bedrock/src/L2/L1Block.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Libraries
 import { Constants } from "src/libraries/Constants.sol";

--- a/packages/contracts-bedrock/src/L2/L1Block.sol
+++ b/packages/contracts-bedrock/src/L2/L1Block.sol
@@ -64,9 +64,9 @@ contract L1Block is ISemver {
     /// @notice The DA footprint gas scalar.
     uint16 public daFootprintGasScalar;
 
-    /// @custom:semver 1.8.0
+    /// @custom:semver 1.8.1
     function version() public pure virtual returns (string memory) {
-        return "1.8.0";
+        return "1.8.1";
     }
 
     /// @notice Returns the gas paying token, its decimals, name and symbol.

--- a/packages/contracts-bedrock/src/L2/L1BlockCGT.sol
+++ b/packages/contracts-bedrock/src/L2/L1BlockCGT.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Libraries
 import { Constants } from "src/libraries/Constants.sol";

--- a/packages/contracts-bedrock/src/L2/L2ContractsManager.sol
+++ b/packages/contracts-bedrock/src/L2/L2ContractsManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Interfaces
 import { ISemver } from "interfaces/universal/ISemver.sol";

--- a/packages/contracts-bedrock/src/L2/L2ContractsManager.sol
+++ b/packages/contracts-bedrock/src/L2/L2ContractsManager.sol
@@ -28,8 +28,8 @@ contract L2ContractsManager is ISemver {
     error L2ContractsManager_OnlyDelegatecall();
 
     /// @notice The semantic version of the L2ContractsManager contract.
-    /// @custom:semver 1.0.0
-    string public constant version = "1.0.0";
+    /// @custom:semver 1.0.1
+    string public constant version = "1.0.1";
 
     /// @notice The address of this contract. Used to enforce that the upgrade function is only
     ///         called via DELEGATECALL.

--- a/packages/contracts-bedrock/src/L2/L2CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/src/L2/L2CrossDomainMessenger.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Contracts
 import { CrossDomainMessenger } from "src/universal/CrossDomainMessenger.sol";

--- a/packages/contracts-bedrock/src/L2/L2CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/src/L2/L2CrossDomainMessenger.sol
@@ -19,8 +19,8 @@ import { IL2ToL1MessagePasser } from "interfaces/L2/IL2ToL1MessagePasser.sol";
 ///         L2 on the L2 side. Users are generally encouraged to use this contract instead of lower
 ///         level message passing contracts.
 contract L2CrossDomainMessenger is CrossDomainMessenger, ISemver {
-    /// @custom:semver 2.2.0
-    string public constant version = "2.2.0";
+    /// @custom:semver 2.2.1
+    string public constant version = "2.2.1";
 
     /// @notice Constructs the L2CrossDomainMessenger contract.
     constructor() {

--- a/packages/contracts-bedrock/src/L2/L2ERC721Bridge.sol
+++ b/packages/contracts-bedrock/src/L2/L2ERC721Bridge.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Contracts
 import { ERC721Bridge } from "src/universal/ERC721Bridge.sol";

--- a/packages/contracts-bedrock/src/L2/L2ERC721Bridge.sol
+++ b/packages/contracts-bedrock/src/L2/L2ERC721Bridge.sol
@@ -24,8 +24,8 @@ import { ISemver } from "interfaces/universal/ISemver.sol";
 ///         **WARNING**: Do not bridge an ERC721 that was originally deployed on Optimism. This
 ///         bridge ONLY supports ERC721s originally deployed on Ethereum.
 contract L2ERC721Bridge is ERC721Bridge, ISemver {
-    /// @custom:semver 1.10.0
-    string public constant version = "1.10.0";
+    /// @custom:semver 1.10.1
+    string public constant version = "1.10.1";
 
     /// @notice Constructs the L2ERC721Bridge contract.
     constructor() ERC721Bridge() {

--- a/packages/contracts-bedrock/src/L2/L2ProxyAdmin.sol
+++ b/packages/contracts-bedrock/src/L2/L2ProxyAdmin.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Interfaces
 import { IL2ContractsManager } from "interfaces/L2/IL2ContractsManager.sol";

--- a/packages/contracts-bedrock/src/L2/L2ProxyAdmin.sol
+++ b/packages/contracts-bedrock/src/L2/L2ProxyAdmin.sol
@@ -30,8 +30,8 @@ contract L2ProxyAdmin is ProxyAdmin, ISemver {
     error L2ProxyAdmin__UpgradeFailed(bytes data);
 
     /// @notice The semantic version of the contract.
-    /// @custom:semver 1.0.0
-    string public constant version = "1.0.0";
+    /// @custom:semver 1.0.1
+    string public constant version = "1.0.1";
 
     /// @notice The constructor for the L2ProxyAdmin contract.
     /// @param _owner Address of the initial owner of this contract.

--- a/packages/contracts-bedrock/src/L2/L2StandardBridge.sol
+++ b/packages/contracts-bedrock/src/L2/L2StandardBridge.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Contracts
 import { StandardBridge } from "src/universal/StandardBridge.sol";

--- a/packages/contracts-bedrock/src/L2/L2StandardBridge.sol
+++ b/packages/contracts-bedrock/src/L2/L2StandardBridge.sol
@@ -57,9 +57,9 @@ contract L2StandardBridge is StandardBridge, ISemver {
     );
 
     /// @notice Semantic version.
-    /// @custom:semver 1.13.0
+    /// @custom:semver 1.13.1
     function version() public pure virtual returns (string memory) {
-        return "1.13.0";
+        return "1.13.1";
     }
 
     /// @notice Constructs the L2StandardBridge contract.

--- a/packages/contracts-bedrock/src/L2/L2StandardBridgeInterop.sol
+++ b/packages/contracts-bedrock/src/L2/L2StandardBridgeInterop.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Contracts
 import { L2StandardBridge } from "src/L2/L2StandardBridge.sol";

--- a/packages/contracts-bedrock/src/L2/L2ToL1MessagePasser.sol
+++ b/packages/contracts-bedrock/src/L2/L2ToL1MessagePasser.sol
@@ -51,9 +51,9 @@ contract L2ToL1MessagePasser is ISemver {
     /// @param amount Amount of ETH that was burned.
     event WithdrawerBalanceBurnt(uint256 indexed amount);
 
-    /// @custom:semver 1.2.0
+    /// @custom:semver 1.2.1
     function version() public pure virtual returns (string memory) {
-        return "1.2.0";
+        return "1.2.1";
     }
 
     /// @notice Allows users to withdraw ETH by sending directly to this contract.

--- a/packages/contracts-bedrock/src/L2/L2ToL1MessagePasser.sol
+++ b/packages/contracts-bedrock/src/L2/L2ToL1MessagePasser.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Libraries
 import { Types } from "src/libraries/Types.sol";

--- a/packages/contracts-bedrock/src/L2/L2ToL1MessagePasserCGT.sol
+++ b/packages/contracts-bedrock/src/L2/L2ToL1MessagePasserCGT.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Libraries
 import { Predeploys } from "src/libraries/Predeploys.sol";

--- a/packages/contracts-bedrock/src/L2/LiquidityController.sol
+++ b/packages/contracts-bedrock/src/L2/LiquidityController.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Contracts
 import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";

--- a/packages/contracts-bedrock/src/L2/LiquidityController.sol
+++ b/packages/contracts-bedrock/src/L2/LiquidityController.sol
@@ -42,8 +42,8 @@ contract LiquidityController is ISemver, Initializable, OwnableUpgradeable {
     error LiquidityController_Unauthorized();
 
     /// @notice Semantic version.
-    /// @custom:semver 1.0.0
-    string public constant version = "1.0.0";
+    /// @custom:semver 1.0.1
+    string public constant version = "1.0.1";
 
     /// @notice Mapping of addresses authorized to control liquidity operations
     mapping(address => bool) public minters;

--- a/packages/contracts-bedrock/src/L2/NativeAssetLiquidity.sol
+++ b/packages/contracts-bedrock/src/L2/NativeAssetLiquidity.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Contracts
 import { SafeSend } from "src/universal/SafeSend.sol";

--- a/packages/contracts-bedrock/src/L2/NativeAssetLiquidity.sol
+++ b/packages/contracts-bedrock/src/L2/NativeAssetLiquidity.sol
@@ -27,8 +27,8 @@ contract NativeAssetLiquidity is ISemver {
     error NativeAssetLiquidity_Unauthorized();
 
     /// @notice Semantic version.
-    /// @custom:semver 1.0.0
-    string public constant version = "1.0.0";
+    /// @custom:semver 1.0.1
+    string public constant version = "1.0.1";
 
     /// @notice Allows an address to lock native asset liquidity into this contract.
     function deposit() external payable {

--- a/packages/contracts-bedrock/src/L2/OptimismMintableERC721.sol
+++ b/packages/contracts-bedrock/src/L2/OptimismMintableERC721.sol
@@ -46,8 +46,8 @@ contract OptimismMintableERC721 is ERC721Enumerable, ISemver {
     }
 
     /// @notice Semantic version.
-    /// @custom:semver 1.3.2
-    string public constant version = "1.3.2";
+    /// @custom:semver 1.3.3
+    string public constant version = "1.3.3";
 
     /// @param _bridge        Address of the bridge on this network.
     /// @param _remoteChainId Chain ID where the remote token is deployed.

--- a/packages/contracts-bedrock/src/L2/OptimismMintableERC721.sol
+++ b/packages/contracts-bedrock/src/L2/OptimismMintableERC721.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Contracts
 import { ERC721Enumerable } from "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";

--- a/packages/contracts-bedrock/src/L2/OptimismMintableERC721Factory.sol
+++ b/packages/contracts-bedrock/src/L2/OptimismMintableERC721Factory.sol
@@ -30,8 +30,8 @@ contract OptimismMintableERC721Factory is ISemver {
     event OptimismMintableERC721Created(address indexed localToken, address indexed remoteToken, address deployer);
 
     /// @notice Semantic version.
-    /// @custom:semver 1.4.2
-    string public constant version = "1.4.2";
+    /// @custom:semver 1.4.3
+    string public constant version = "1.4.3";
 
     /// @notice The semver MUST be bumped any time that there is a change in
     ///         the OptimismMintableERC721 token contract since this contract

--- a/packages/contracts-bedrock/src/L2/OptimismMintableERC721Factory.sol
+++ b/packages/contracts-bedrock/src/L2/OptimismMintableERC721Factory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Contracts
 import { OptimismMintableERC721 } from "src/L2/OptimismMintableERC721.sol";

--- a/packages/contracts-bedrock/src/L2/OptimismSuperchainERC20Beacon.sol
+++ b/packages/contracts-bedrock/src/L2/OptimismSuperchainERC20Beacon.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Libraries
 import { Predeploys } from "src/libraries/Predeploys.sol";

--- a/packages/contracts-bedrock/src/L2/OptimismSuperchainERC20Beacon.sol
+++ b/packages/contracts-bedrock/src/L2/OptimismSuperchainERC20Beacon.sol
@@ -14,8 +14,8 @@ import { ISemver } from "interfaces/universal/ISemver.sol";
 /// @notice OptimismSuperchainERC20Beacon is the beacon proxy for the OptimismSuperchainERC20 implementation.
 contract OptimismSuperchainERC20Beacon is IBeacon, ISemver {
     /// @notice Semantic version.
-    /// @custom:semver 1.0.1
-    string public constant version = "1.0.1";
+    /// @custom:semver 1.0.2
+    string public constant version = "1.0.2";
 
     /// @inheritdoc IBeacon
     function implementation() external pure override returns (address) {

--- a/packages/contracts-bedrock/src/L2/SuperchainETHBridge.sol
+++ b/packages/contracts-bedrock/src/L2/SuperchainETHBridge.sol
@@ -35,8 +35,8 @@ contract SuperchainETHBridge is ISemver {
     event RelayETH(address indexed from, address indexed to, uint256 amount, uint256 source);
 
     /// @notice Semantic version.
-    /// @custom:semver 1.0.1
-    string public constant version = "1.0.1";
+    /// @custom:semver 1.0.2
+    string public constant version = "1.0.2";
 
     /// @notice Sends ETH to some target address on another chain.
     /// @param _to       Address to send ETH to.

--- a/packages/contracts-bedrock/src/L2/SuperchainETHBridge.sol
+++ b/packages/contracts-bedrock/src/L2/SuperchainETHBridge.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Libraries
 import { Unauthorized, ZeroAddress } from "src/libraries/errors/CommonErrors.sol";

--- a/packages/contracts-bedrock/src/L2/WETH.sol
+++ b/packages/contracts-bedrock/src/L2/WETH.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Contracts
 import { WETH98 } from "src/universal/WETH98.sol";

--- a/packages/contracts-bedrock/src/L2/WETH.sol
+++ b/packages/contracts-bedrock/src/L2/WETH.sol
@@ -15,8 +15,8 @@ import { IL1Block } from "interfaces/L2/IL1Block.sol";
 ///        Allows for nice rendering of token names for chains using custom gas token.
 ///        This contract is not proxied and contains calls to the custom gas token methods.
 contract WETH is WETH98, ISemver {
-    /// @custom:semver 1.1.1
-    string public constant version = "1.1.1";
+    /// @custom:semver 1.1.2
+    string public constant version = "1.1.2";
 
     /// @notice Returns the name of the wrapped native asset. Will be "Wrapped Ether"
     ///         if the native asset is Ether.

--- a/packages/contracts-bedrock/src/cannon/MIPS64.sol
+++ b/packages/contracts-bedrock/src/cannon/MIPS64.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Libraries
 import {

--- a/packages/contracts-bedrock/src/cannon/MIPS64.sol
+++ b/packages/contracts-bedrock/src/cannon/MIPS64.sol
@@ -66,8 +66,8 @@ contract MIPS64 is ISemver {
     }
 
     /// @notice The semantic version of the MIPS64 contract.
-    /// @custom:semver 1.10.0
-    string public constant version = "1.10.0";
+    /// @custom:semver 1.10.1
+    string public constant version = "1.10.1";
 
     /// @notice The preimage oracle contract.
     IPreimageOracle internal immutable ORACLE;

--- a/packages/contracts-bedrock/src/cannon/PreimageKeyLib.sol
+++ b/packages/contracts-bedrock/src/cannon/PreimageKeyLib.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 /// @title PreimageKeyLib
 /// @notice Shared utilities for localizing local keys in the preimage oracle.

--- a/packages/contracts-bedrock/src/cannon/PreimageOracle.sol
+++ b/packages/contracts-bedrock/src/cannon/PreimageOracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Libraries
 import { LibKeccak } from "@lib-keccak/LibKeccak.sol";

--- a/packages/contracts-bedrock/src/cannon/PreimageOracle.sol
+++ b/packages/contracts-bedrock/src/cannon/PreimageOracle.sol
@@ -50,8 +50,8 @@ contract PreimageOracle is ISemver {
     uint256 public constant PRECOMPILE_CALL_RESERVED_GAS = 100_000;
 
     /// @notice The semantic version of the Preimage Oracle contract.
-    /// @custom:semver 1.1.4
-    string public constant version = "1.1.4";
+    /// @custom:semver 1.1.5
+    string public constant version = "1.1.5";
 
     ////////////////////////////////////////////////////////////////
     //                 Authorized Preimage Parts                  //

--- a/packages/contracts-bedrock/src/dispute/AnchorStateRegistry.sol
+++ b/packages/contracts-bedrock/src/dispute/AnchorStateRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Contracts
 import { Initializable } from "@openzeppelin/contracts/proxy/utils/Initializable.sol";

--- a/packages/contracts-bedrock/src/dispute/AnchorStateRegistry.sol
+++ b/packages/contracts-bedrock/src/dispute/AnchorStateRegistry.sol
@@ -24,8 +24,8 @@ import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 ///         be initialized with a more recent starting state which reduces the amount of required offchain computation.
 contract AnchorStateRegistry is ProxyAdminOwnedBase, Initializable, ReinitializableBase, ISemver {
     /// @notice Semantic version.
-    /// @custom:semver 3.8.0
-    string public constant version = "3.8.0";
+    /// @custom:semver 3.8.1
+    string public constant version = "3.8.1";
 
     /// @notice The dispute game finality delay in seconds.
     uint256 internal immutable DISPUTE_GAME_FINALITY_DELAY_SECONDS;

--- a/packages/contracts-bedrock/src/dispute/DelayedWETH.sol
+++ b/packages/contracts-bedrock/src/dispute/DelayedWETH.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Contracts
 import { Initializable } from "@openzeppelin/contracts/proxy/utils/Initializable.sol";

--- a/packages/contracts-bedrock/src/dispute/DelayedWETH.sol
+++ b/packages/contracts-bedrock/src/dispute/DelayedWETH.sol
@@ -30,8 +30,8 @@ contract DelayedWETH is Initializable, ProxyAdminOwnedBase, ReinitializableBase,
     }
 
     /// @notice Semantic version.
-    /// @custom:semver 1.5.0
-    string public constant version = "1.5.0";
+    /// @custom:semver 1.5.1
+    string public constant version = "1.5.1";
 
     /// @notice Returns a withdrawal request for the given address.
     mapping(address => mapping(address => WithdrawalRequest)) public withdrawals;

--- a/packages/contracts-bedrock/src/dispute/DisputeGameFactory.sol
+++ b/packages/contracts-bedrock/src/dispute/DisputeGameFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Contracts
 import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";

--- a/packages/contracts-bedrock/src/dispute/DisputeGameFactory.sol
+++ b/packages/contracts-bedrock/src/dispute/DisputeGameFactory.sol
@@ -56,8 +56,8 @@ contract DisputeGameFactory is ProxyAdminOwnedBase, ReinitializableBase, Ownable
     }
 
     /// @notice Semantic version.
-    /// @custom:semver 1.6.0
-    string public constant version = "1.6.0";
+    /// @custom:semver 1.6.1
+    string public constant version = "1.6.1";
 
     /// @notice `gameImpls` is a mapping that maps `GameType`s to their respective
     ///         `IDisputeGame` implementations.

--- a/packages/contracts-bedrock/src/dispute/FaultDisputeGame.sol
+++ b/packages/contracts-bedrock/src/dispute/FaultDisputeGame.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Libraries
 import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";

--- a/packages/contracts-bedrock/src/dispute/FaultDisputeGame.sol
+++ b/packages/contracts-bedrock/src/dispute/FaultDisputeGame.sol
@@ -147,9 +147,9 @@ contract FaultDisputeGame is Clone, ISemver {
     uint256 internal constant HEADER_BLOCK_NUMBER_INDEX = 8;
 
     /// @notice Semantic version.
-    /// @custom:semver 2.4.0
+    /// @custom:semver 2.4.1
     function version() public pure virtual returns (string memory) {
-        return "2.4.0";
+        return "2.4.1";
     }
 
     /// @notice The starting timestamp of the game

--- a/packages/contracts-bedrock/src/dispute/PermissionedDisputeGame.sol
+++ b/packages/contracts-bedrock/src/dispute/PermissionedDisputeGame.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Contracts
 import { FaultDisputeGame } from "src/dispute/FaultDisputeGame.sol";

--- a/packages/contracts-bedrock/src/dispute/PermissionedDisputeGame.sol
+++ b/packages/contracts-bedrock/src/dispute/PermissionedDisputeGame.sol
@@ -26,9 +26,9 @@ contract PermissionedDisputeGame is FaultDisputeGame {
     }
 
     /// @notice Semantic version.
-    /// @custom:semver 2.4.0
+    /// @custom:semver 2.4.1
     function version() public pure override returns (string memory) {
-        return "2.4.0";
+        return "2.4.1";
     }
 
     /// @param _params Parameters for creating a new FaultDisputeGame.

--- a/packages/contracts-bedrock/src/dispute/SuperFaultDisputeGame.sol
+++ b/packages/contracts-bedrock/src/dispute/SuperFaultDisputeGame.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Libraries
 import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";

--- a/packages/contracts-bedrock/src/dispute/SuperFaultDisputeGame.sol
+++ b/packages/contracts-bedrock/src/dispute/SuperFaultDisputeGame.sol
@@ -146,9 +146,9 @@ contract SuperFaultDisputeGame is Clone, ISemver {
     Position internal constant ROOT_POSITION = Position.wrap(1);
 
     /// @notice Semantic version.
-    /// @custom:semver 0.7.0
+    /// @custom:semver 0.7.1
     function version() public pure virtual returns (string memory) {
-        return "0.7.0";
+        return "0.7.1";
     }
 
     /// @notice The starting timestamp of the game

--- a/packages/contracts-bedrock/src/dispute/SuperPermissionedDisputeGame.sol
+++ b/packages/contracts-bedrock/src/dispute/SuperPermissionedDisputeGame.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Contracts
 import { SuperFaultDisputeGame } from "src/dispute/SuperFaultDisputeGame.sol";

--- a/packages/contracts-bedrock/src/dispute/SuperPermissionedDisputeGame.sol
+++ b/packages/contracts-bedrock/src/dispute/SuperPermissionedDisputeGame.sol
@@ -27,9 +27,9 @@ contract SuperPermissionedDisputeGame is SuperFaultDisputeGame {
     }
 
     /// @notice Semantic version.
-    /// @custom:semver 0.7.0
+    /// @custom:semver 0.7.1
     function version() public pure override returns (string memory) {
-        return "0.7.0";
+        return "0.7.1";
     }
 
     /// @param _params Parameters for creating a new FaultDisputeGame.

--- a/packages/contracts-bedrock/src/dispute/lib/Errors.sol
+++ b/packages/contracts-bedrock/src/dispute/lib/Errors.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.25;
 
 // Libraries
 import { GameType, Hash, Claim } from "src/dispute/lib/LibUDT.sol";

--- a/packages/contracts-bedrock/src/dispute/lib/LibGameArgs.sol
+++ b/packages/contracts-bedrock/src/dispute/lib/LibGameArgs.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.25;
 
 import { InvalidGameArgsLength } from "src/dispute/lib/Errors.sol";
 

--- a/packages/contracts-bedrock/src/dispute/lib/LibPosition.sol
+++ b/packages/contracts-bedrock/src/dispute/lib/LibPosition.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.25;
 
 using LibPosition for Position global;
 

--- a/packages/contracts-bedrock/src/dispute/lib/LibUDT.sol
+++ b/packages/contracts-bedrock/src/dispute/lib/LibUDT.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.25;
 
 // Libraries
 import { Position } from "src/dispute/lib/LibPosition.sol";

--- a/packages/contracts-bedrock/src/dispute/lib/Types.sol
+++ b/packages/contracts-bedrock/src/dispute/lib/Types.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.25;
 
 // Libraries
 import {

--- a/packages/contracts-bedrock/src/dispute/zk/AccessManager.sol
+++ b/packages/contracts-bedrock/src/dispute/zk/AccessManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 import { IDisputeGameFactory } from "interfaces/dispute/IDisputeGameFactory.sol";

--- a/packages/contracts-bedrock/src/dispute/zk/OptimisticZkGame.sol
+++ b/packages/contracts-bedrock/src/dispute/zk/OptimisticZkGame.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Libraries
 import { Clone } from "@solady/utils/Clone.sol";

--- a/packages/contracts-bedrock/src/dispute/zk/OptimisticZkGame.sol
+++ b/packages/contracts-bedrock/src/dispute/zk/OptimisticZkGame.sol
@@ -146,8 +146,8 @@ contract OptimisticZkGame is Clone, ISemver, IDisputeGame {
     AccessManager internal immutable ACCESS_MANAGER;
 
     /// @notice Semantic version.
-    /// @custom:semver 0.2.0
-    string public constant version = "0.2.0";
+    /// @custom:semver 0.2.1
+    string public constant version = "0.2.1";
 
     /// @notice The starting timestamp of the game.
     Timestamp public createdAt;

--- a/packages/contracts-bedrock/src/governance/GovernanceToken.sol
+++ b/packages/contracts-bedrock/src/governance/GovernanceToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Contracts
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";

--- a/packages/contracts-bedrock/src/governance/MintManager.sol
+++ b/packages/contracts-bedrock/src/governance/MintManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Contracts
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";

--- a/packages/contracts-bedrock/src/legacy/AddressManager.sol
+++ b/packages/contracts-bedrock/src/legacy/AddressManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Contracts
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";

--- a/packages/contracts-bedrock/src/legacy/DeployerWhitelist.sol
+++ b/packages/contracts-bedrock/src/legacy/DeployerWhitelist.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Interfaces
 import { ISemver } from "interfaces/universal/ISemver.sol";

--- a/packages/contracts-bedrock/src/legacy/DeployerWhitelist.sol
+++ b/packages/contracts-bedrock/src/legacy/DeployerWhitelist.sol
@@ -42,8 +42,8 @@ contract DeployerWhitelist is ISemver {
     }
 
     /// @notice Semantic version.
-    /// @custom:semver 1.1.2
-    string public constant version = "1.1.2";
+    /// @custom:semver 1.1.3
+    string public constant version = "1.1.3";
 
     /// @notice Adds or removes an address from the deployment whitelist.
     /// @param _deployer      Address to update permissions for.

--- a/packages/contracts-bedrock/src/legacy/L1BlockNumber.sol
+++ b/packages/contracts-bedrock/src/legacy/L1BlockNumber.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Libraries
 import { Predeploys } from "src/libraries/Predeploys.sol";

--- a/packages/contracts-bedrock/src/legacy/L1BlockNumber.sol
+++ b/packages/contracts-bedrock/src/legacy/L1BlockNumber.sol
@@ -18,8 +18,8 @@ import { IL1Block } from "interfaces/L2/IL1Block.sol";
 ///        contract instead.
 contract L1BlockNumber is ISemver {
     /// @notice Semantic version.
-    /// @custom:semver 1.1.2
-    string public constant version = "1.1.2";
+    /// @custom:semver 1.1.3
+    string public constant version = "1.1.3";
 
     /// @notice Returns the L1 block number.
     receive() external payable {

--- a/packages/contracts-bedrock/src/legacy/L1ChugSplashProxy.sol
+++ b/packages/contracts-bedrock/src/legacy/L1ChugSplashProxy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Libraries
 import { Constants } from "src/libraries/Constants.sol";

--- a/packages/contracts-bedrock/src/legacy/LegacyMessagePasser.sol
+++ b/packages/contracts-bedrock/src/legacy/LegacyMessagePasser.sol
@@ -15,8 +15,8 @@ contract LegacyMessagePasser is ISemver {
     mapping(bytes32 => bool) public sentMessages;
 
     /// @notice Semantic version.
-    /// @custom:semver 1.1.2
-    string public constant version = "1.1.2";
+    /// @custom:semver 1.1.3
+    string public constant version = "1.1.3";
 
     /// @notice Passes a message to L1.
     /// @param _message Message to pass to L1.

--- a/packages/contracts-bedrock/src/legacy/LegacyMessagePasser.sol
+++ b/packages/contracts-bedrock/src/legacy/LegacyMessagePasser.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Interfaces
 import { ISemver } from "interfaces/universal/ISemver.sol";

--- a/packages/contracts-bedrock/src/legacy/LegacyMintableERC20.sol
+++ b/packages/contracts-bedrock/src/legacy/LegacyMintableERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Contracts
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";

--- a/packages/contracts-bedrock/src/legacy/ResolvedDelegateProxy.sol
+++ b/packages/contracts-bedrock/src/legacy/ResolvedDelegateProxy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Contracts
 import { AddressManager } from "src/legacy/AddressManager.sol";

--- a/packages/contracts-bedrock/src/libraries/Burn.sol
+++ b/packages/contracts-bedrock/src/libraries/Burn.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 /// @title Burn
 /// @notice Utilities for burning stuff.

--- a/packages/contracts-bedrock/src/periphery/TransferOnion.sol
+++ b/packages/contracts-bedrock/src/periphery/TransferOnion.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Contracts
 import { ReentrancyGuard } from "@openzeppelin/contracts/security/ReentrancyGuard.sol";

--- a/packages/contracts-bedrock/src/periphery/drippie/Drippie.sol
+++ b/packages/contracts-bedrock/src/periphery/drippie/Drippie.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Contracts
 import { AssetReceiver } from "src/periphery/AssetReceiver.sol";

--- a/packages/contracts-bedrock/src/periphery/drippie/dripchecks/CheckBalanceLow.sol
+++ b/packages/contracts-bedrock/src/periphery/drippie/dripchecks/CheckBalanceLow.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Interfaces
 import { IDripCheck } from "src/periphery/drippie/IDripCheck.sol";

--- a/packages/contracts-bedrock/src/periphery/drippie/dripchecks/CheckSecrets.sol
+++ b/packages/contracts-bedrock/src/periphery/drippie/dripchecks/CheckSecrets.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Interfaces
 import { IDripCheck } from "src/periphery/drippie/IDripCheck.sol";

--- a/packages/contracts-bedrock/src/periphery/drippie/dripchecks/CheckTrue.sol
+++ b/packages/contracts-bedrock/src/periphery/drippie/dripchecks/CheckTrue.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Interfaces
 import { IDripCheck } from "src/periphery/drippie/IDripCheck.sol";

--- a/packages/contracts-bedrock/src/periphery/faucet/Faucet.sol
+++ b/packages/contracts-bedrock/src/periphery/faucet/Faucet.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Contracts
 import { SafeSend } from "src/universal/SafeSend.sol";

--- a/packages/contracts-bedrock/src/periphery/faucet/authmodules/AdminFaucetAuthModule.sol
+++ b/packages/contracts-bedrock/src/periphery/faucet/authmodules/AdminFaucetAuthModule.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Contracts
 import { EIP712 } from "@openzeppelin/contracts/utils/cryptography/draft-EIP712.sol";

--- a/packages/contracts-bedrock/src/periphery/monitoring/DisputeMonitorHelper.sol
+++ b/packages/contracts-bedrock/src/periphery/monitoring/DisputeMonitorHelper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.25;
 
 // Libraries
 import { LibString } from "@solady/utils/LibString.sol";

--- a/packages/contracts-bedrock/src/safe/LivenessGuard.sol
+++ b/packages/contracts-bedrock/src/safe/LivenessGuard.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Safe
 import { Safe } from "safe-contracts/Safe.sol";

--- a/packages/contracts-bedrock/src/safe/LivenessGuard.sol
+++ b/packages/contracts-bedrock/src/safe/LivenessGuard.sol
@@ -30,8 +30,8 @@ contract LivenessGuard is ISemver, BaseGuard {
     event OwnerRecorded(address owner);
 
     /// @notice Semantic version.
-    /// @custom:semver 1.1.0
-    string public constant version = "1.1.0";
+    /// @custom:semver 1.1.1
+    string public constant version = "1.1.1";
 
     /// @notice The safe account for which this contract will be the guard.
     Safe internal immutable SAFE;

--- a/packages/contracts-bedrock/src/safe/LivenessModule.sol
+++ b/packages/contracts-bedrock/src/safe/LivenessModule.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Safe
 import { Safe } from "safe-contracts/Safe.sol";

--- a/packages/contracts-bedrock/src/safe/LivenessModule.sol
+++ b/packages/contracts-bedrock/src/safe/LivenessModule.sol
@@ -58,8 +58,8 @@ contract LivenessModule is ISemver {
     uint256 internal constant GUARD_STORAGE_SLOT = 0x4a204f620c8c5ccdca3fd54d003badd85ba500436a431f0cbda4f558c93c34c8;
 
     /// @notice Semantic version.
-    /// @custom:semver 1.3.0
-    string public constant version = "1.3.0";
+    /// @custom:semver 1.3.1
+    string public constant version = "1.3.1";
 
     // Constructor to initialize the Safe and baseModule instances
     constructor(

--- a/packages/contracts-bedrock/src/safe/LivenessModule2.sol
+++ b/packages/contracts-bedrock/src/safe/LivenessModule2.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Safe
 import { Safe } from "safe-contracts/Safe.sol";

--- a/packages/contracts-bedrock/src/safe/SaferSafes.sol
+++ b/packages/contracts-bedrock/src/safe/SaferSafes.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Safe
 import { Safe } from "safe-contracts/Safe.sol";

--- a/packages/contracts-bedrock/src/safe/SaferSafes.sol
+++ b/packages/contracts-bedrock/src/safe/SaferSafes.sol
@@ -26,8 +26,8 @@ import { ISemver } from "interfaces/universal/ISemver.sol";
 ///      compatibility restrictions in the LivenessModule2 and TimelockGuard contracts.
 contract SaferSafes is LivenessModule2, TimelockGuard, ISemver {
     /// @notice Semantic version.
-    /// @custom:semver 1.10.1
-    string public constant version = "1.10.1";
+    /// @custom:semver 1.10.2
+    string public constant version = "1.10.2";
 
     /// @notice Error for when the liveness response period is insufficient.
     error SaferSafes_InsufficientLivenessResponsePeriod();

--- a/packages/contracts-bedrock/src/safe/TimelockGuard.sol
+++ b/packages/contracts-bedrock/src/safe/TimelockGuard.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Safe
 import { Safe } from "safe-contracts/Safe.sol";

--- a/packages/contracts-bedrock/src/universal/CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/src/universal/CrossDomainMessenger.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Libraries
 import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";

--- a/packages/contracts-bedrock/src/universal/ERC721Bridge.sol
+++ b/packages/contracts-bedrock/src/universal/ERC721Bridge.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Contracts
 import { Initializable } from "@openzeppelin/contracts/proxy/utils/Initializable.sol";

--- a/packages/contracts-bedrock/src/universal/OptimismMintableERC20.sol
+++ b/packages/contracts-bedrock/src/universal/OptimismMintableERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Contracts
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";

--- a/packages/contracts-bedrock/src/universal/OptimismMintableERC20.sol
+++ b/packages/contracts-bedrock/src/universal/OptimismMintableERC20.sol
@@ -47,8 +47,8 @@ contract OptimismMintableERC20 is ERC20Permit, ISemver {
     }
 
     /// @notice Semantic version.
-    /// @custom:semver 1.4.1
-    string public constant version = "1.4.1";
+    /// @custom:semver 1.4.2
+    string public constant version = "1.4.2";
 
     /// @notice Getter function for the permit2 address. It deterministically deployed
     ///         so it will always be at the same address. It is also included as a preinstall,

--- a/packages/contracts-bedrock/src/universal/OptimismMintableERC20Factory.sol
+++ b/packages/contracts-bedrock/src/universal/OptimismMintableERC20Factory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Contracts
 import { Initializable } from "@openzeppelin/contracts/proxy/utils/Initializable.sol";

--- a/packages/contracts-bedrock/src/universal/OptimismMintableERC20Factory.sol
+++ b/packages/contracts-bedrock/src/universal/OptimismMintableERC20Factory.sol
@@ -51,8 +51,8 @@ contract OptimismMintableERC20Factory is ISemver, Initializable, IOptimismERC20F
     ///         the OptimismMintableERC20 token contract since this contract
     ///         is responsible for deploying OptimismMintableERC20 contracts.
     /// @notice Semantic version.
-    /// @custom:semver 1.10.2
-    string public constant version = "1.10.2";
+    /// @custom:semver 1.10.3
+    string public constant version = "1.10.3";
 
     /// @notice Constructs the OptimismMintableERC20Factory contract.
     constructor() {

--- a/packages/contracts-bedrock/src/universal/Proxy.sol
+++ b/packages/contracts-bedrock/src/universal/Proxy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Libraries
 import { Constants } from "src/libraries/Constants.sol";

--- a/packages/contracts-bedrock/src/universal/ProxyAdmin.sol
+++ b/packages/contracts-bedrock/src/universal/ProxyAdmin.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Contracts
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";

--- a/packages/contracts-bedrock/src/universal/ReinitializableBase.sol
+++ b/packages/contracts-bedrock/src/universal/ReinitializableBase.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 /// @title ReinitializableBase
 /// @notice A base contract for reinitializable contracts that exposes a version number.

--- a/packages/contracts-bedrock/src/universal/StandardBridge.sol
+++ b/packages/contracts-bedrock/src/universal/StandardBridge.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Contracts
 import { Initializable } from "@openzeppelin/contracts/proxy/utils/Initializable.sol";

--- a/packages/contracts-bedrock/src/universal/StorageSetter.sol
+++ b/packages/contracts-bedrock/src/universal/StorageSetter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Libraries
 import { Storage } from "src/libraries/Storage.sol";

--- a/packages/contracts-bedrock/src/universal/StorageSetter.sol
+++ b/packages/contracts-bedrock/src/universal/StorageSetter.sol
@@ -19,8 +19,8 @@ contract StorageSetter is ISemver {
     }
 
     /// @notice Semantic version.
-    /// @custom:semver 1.2.2
-    string public constant version = "1.2.2";
+    /// @custom:semver 1.2.3
+    string public constant version = "1.2.3";
 
     /// @notice Stores a bytes32 `_value` at `_slot`. Any storage slots that
     ///         are packed should be set through this interface.

--- a/packages/contracts-bedrock/src/universal/WETH98.sol
+++ b/packages/contracts-bedrock/src/universal/WETH98.sol
@@ -17,7 +17,7 @@
 // Based on WETH9 by Dapphub.
 // Modified by OP Labs.
 
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 /// @title WETH98
 /// @notice WETH98 is a version of WETH9 upgraded for Solidity 0.8.x.

--- a/packages/contracts-bedrock/src/vendor/eas/EAS.sol
+++ b/packages/contracts-bedrock/src/vendor/eas/EAS.sol
@@ -79,8 +79,8 @@ contract EAS is IEAS, ISemver, EIP1271Verifier {
     uint256[MAX_GAP - 3] private __gap;
 
     /// @notice Semantic version.
-    /// @custom:semver 1.4.1-beta.3
-    string public constant version = "1.4.1-beta.3";
+    /// @custom:semver 1.4.2-beta.3
+    string public constant version = "1.4.2-beta.3";
 
     /// @dev Creates a new EAS instance.
     constructor() EIP1271Verifier("EAS", "1.3.0") { }

--- a/packages/contracts-bedrock/src/vendor/eas/EAS.sol
+++ b/packages/contracts-bedrock/src/vendor/eas/EAS.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.19;
+pragma solidity 0.8.25;
 
 import { Address } from "@openzeppelin/contracts/utils/Address.sol";
 import { ISemver } from "interfaces/universal/ISemver.sol";

--- a/packages/contracts-bedrock/src/vendor/eas/SchemaRegistry.sol
+++ b/packages/contracts-bedrock/src/vendor/eas/SchemaRegistry.sol
@@ -20,8 +20,8 @@ contract SchemaRegistry is ISchemaRegistry, ISemver {
     uint256[MAX_GAP - 1] private __gap;
 
     /// @notice Semantic version.
-    /// @custom:semver 1.3.1-beta.2
-    string public constant version = "1.3.1-beta.2";
+    /// @custom:semver 1.3.2-beta.2
+    string public constant version = "1.3.2-beta.2";
 
     /// @inheritdoc ISchemaRegistry
     function register(string calldata schema, ISchemaResolver resolver, bool revocable) external returns (bytes32) {

--- a/packages/contracts-bedrock/src/vendor/eas/SchemaRegistry.sol
+++ b/packages/contracts-bedrock/src/vendor/eas/SchemaRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.19;
+pragma solidity 0.8.25;
 
 import { ISemver } from "interfaces/universal/ISemver.sol";
 import { ISchemaResolver } from "src/vendor/eas/resolver/ISchemaResolver.sol";

--- a/packages/contracts-bedrock/src/vendor/eas/eip1271/EIP1271Verifier.sol
+++ b/packages/contracts-bedrock/src/vendor/eas/eip1271/EIP1271Verifier.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.19;
+pragma solidity 0.8.25;
 
 import { EIP712 } from "@openzeppelin/contracts/utils/cryptography/draft-EIP712.sol";
 import { SignatureChecker } from "@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol";

--- a/packages/contracts-bedrock/src/vendor/eas/resolver/SchemaResolver.sol
+++ b/packages/contracts-bedrock/src/vendor/eas/resolver/SchemaResolver.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.19;
+pragma solidity 0.8.25;
 
 import { IEAS, Attestation } from "src/vendor/eas/IEAS.sol";
 import { AccessDenied, InvalidEAS, InvalidLength, uncheckedInc } from "src/vendor/eas/Common.sol";

--- a/packages/contracts-bedrock/test/L1/DataAvailabilityChallenge.t.sol
+++ b/packages/contracts-bedrock/test/L1/DataAvailabilityChallenge.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import {
     IDataAvailabilityChallenge,

--- a/packages/contracts-bedrock/test/L1/ETHLockbox.t.sol
+++ b/packages/contracts-bedrock/test/L1/ETHLockbox.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { CommonTest } from "test/setup/CommonTest.sol";

--- a/packages/contracts-bedrock/test/L1/FeesDepositor.t.sol
+++ b/packages/contracts-bedrock/test/L1/FeesDepositor.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { CommonTest } from "test/setup/CommonTest.sol";
 import { ICrossDomainMessenger } from "interfaces/universal/ICrossDomainMessenger.sol";

--- a/packages/contracts-bedrock/test/L1/L1CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/L1/L1CrossDomainMessenger.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing utilities
 import { CommonTest } from "test/setup/CommonTest.sol";

--- a/packages/contracts-bedrock/test/L1/L1ERC721Bridge.t.sol
+++ b/packages/contracts-bedrock/test/L1/L1ERC721Bridge.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { CommonTest } from "test/setup/CommonTest.sol";

--- a/packages/contracts-bedrock/test/L1/L1StandardBridge.t.sol
+++ b/packages/contracts-bedrock/test/L1/L1StandardBridge.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { stdStorage, StdStorage } from "forge-std/StdStorage.sol";

--- a/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { Test } from "test/setup/Test.sol";

--- a/packages/contracts-bedrock/test/L1/OPContractsManagerContractsContainer.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManagerContractsContainer.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { OPContractsManager_TestInit } from "test/L1/OPContractsManager.t.sol";

--- a/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { CommonTest } from "test/setup/CommonTest.sol";

--- a/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
+++ b/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Forge
 import { VmSafe } from "forge-std/Vm.sol";

--- a/packages/contracts-bedrock/test/L1/ProtocolVersions.t.sol
+++ b/packages/contracts-bedrock/test/L1/ProtocolVersions.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { CommonTest } from "test/setup/CommonTest.sol";

--- a/packages/contracts-bedrock/test/L1/ProxyAdminOwnedBase.t.sol
+++ b/packages/contracts-bedrock/test/L1/ProxyAdminOwnedBase.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { CommonTest } from "test/setup/CommonTest.sol";

--- a/packages/contracts-bedrock/test/L1/ResourceMetering.t.sol
+++ b/packages/contracts-bedrock/test/L1/ResourceMetering.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { Test } from "test/setup/Test.sol";

--- a/packages/contracts-bedrock/test/L1/SuperchainConfig.t.sol
+++ b/packages/contracts-bedrock/test/L1/SuperchainConfig.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { CommonTest } from "test/setup/CommonTest.sol";

--- a/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
+++ b/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { CommonTest } from "test/setup/CommonTest.sol";

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerContainer.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerContainer.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { Test } from "test/setup/Test.sol";

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerUtils.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerUtils.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { Test } from "test/setup/Test.sol";

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { VmSafe } from "forge-std/Vm.sol";

--- a/packages/contracts-bedrock/test/L1/opcm/helpers/BatchUpgrader.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/helpers/BatchUpgrader.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { IOPContractsManagerV2 } from "interfaces/L1/opcm/IOPContractsManagerV2.sol";
 import { LibString } from "@solady/utils/LibString.sol";

--- a/packages/contracts-bedrock/test/L2/BaseFeeVault.t.sol
+++ b/packages/contracts-bedrock/test/L2/BaseFeeVault.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Interfaces
 import { IFeeVault } from "interfaces/L2/IFeeVault.sol";

--- a/packages/contracts-bedrock/test/L2/ConditionalDeployer.t.sol
+++ b/packages/contracts-bedrock/test/L2/ConditionalDeployer.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { CommonTest } from "test/setup/CommonTest.sol";

--- a/packages/contracts-bedrock/test/L2/CrossDomainOwnable.t.sol
+++ b/packages/contracts-bedrock/test/L2/CrossDomainOwnable.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { Test } from "test/setup/Test.sol";

--- a/packages/contracts-bedrock/test/L2/CrossDomainOwnable2.t.sol
+++ b/packages/contracts-bedrock/test/L2/CrossDomainOwnable2.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing utilities
 import { CommonTest } from "test/setup/CommonTest.sol";

--- a/packages/contracts-bedrock/test/L2/CrossDomainOwnable3.t.sol
+++ b/packages/contracts-bedrock/test/L2/CrossDomainOwnable3.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing utilities
 import { CommonTest } from "test/setup/CommonTest.sol";

--- a/packages/contracts-bedrock/test/L2/CrossL2Inbox.t.sol
+++ b/packages/contracts-bedrock/test/L2/CrossL2Inbox.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { Test } from "test/setup/Test.sol";

--- a/packages/contracts-bedrock/test/L2/ETHLiquidity.t.sol
+++ b/packages/contracts-bedrock/test/L2/ETHLiquidity.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing utilities
 import { CommonTest } from "test/setup/CommonTest.sol";

--- a/packages/contracts-bedrock/test/L2/FeeSplitter.t.sol
+++ b/packages/contracts-bedrock/test/L2/FeeSplitter.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { CommonTest } from "test/setup/CommonTest.sol";

--- a/packages/contracts-bedrock/test/L2/FeeVault.t.sol
+++ b/packages/contracts-bedrock/test/L2/FeeVault.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { CommonTest } from "test/setup/CommonTest.sol";

--- a/packages/contracts-bedrock/test/L2/GasPriceOracle.t.sol
+++ b/packages/contracts-bedrock/test/L2/GasPriceOracle.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { CommonTest } from "test/setup/CommonTest.sol";

--- a/packages/contracts-bedrock/test/L2/L1Block.t.sol
+++ b/packages/contracts-bedrock/test/L2/L1Block.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { CommonTest } from "test/setup/CommonTest.sol";

--- a/packages/contracts-bedrock/test/L2/L1FeeVault.t.sol
+++ b/packages/contracts-bedrock/test/L2/L1FeeVault.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Interfaces
 import { IFeeVault } from "interfaces/L2/IFeeVault.sol";

--- a/packages/contracts-bedrock/test/L2/L1Withdrawer.t.sol
+++ b/packages/contracts-bedrock/test/L2/L1Withdrawer.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { CommonTest } from "test/setup/CommonTest.sol";
 import { ICrossDomainMessenger } from "interfaces/universal/ICrossDomainMessenger.sol";

--- a/packages/contracts-bedrock/test/L2/L2ContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L2/L2ContractsManager.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Libraries
 import { Predeploys } from "src/libraries/Predeploys.sol";

--- a/packages/contracts-bedrock/test/L2/L2CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/L2/L2CrossDomainMessenger.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { CommonTest } from "test/setup/CommonTest.sol";

--- a/packages/contracts-bedrock/test/L2/L2ERC721Bridge.t.sol
+++ b/packages/contracts-bedrock/test/L2/L2ERC721Bridge.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { CommonTest } from "test/setup/CommonTest.sol";

--- a/packages/contracts-bedrock/test/L2/L2ProxyAdmin.t.sol
+++ b/packages/contracts-bedrock/test/L2/L2ProxyAdmin.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { CommonTest } from "test/setup/CommonTest.sol";

--- a/packages/contracts-bedrock/test/L2/L2StandardBridge.t.sol
+++ b/packages/contracts-bedrock/test/L2/L2StandardBridge.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { stdStorage, StdStorage } from "forge-std/StdStorage.sol";

--- a/packages/contracts-bedrock/test/L2/L2StandardBridgeInterop.t.sol
+++ b/packages/contracts-bedrock/test/L2/L2StandardBridgeInterop.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { CommonTest } from "test/setup/CommonTest.sol";

--- a/packages/contracts-bedrock/test/L2/L2ToL1MessagePasser.t.sol
+++ b/packages/contracts-bedrock/test/L2/L2ToL1MessagePasser.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing utilities
 import { CommonTest } from "test/setup/CommonTest.sol";

--- a/packages/contracts-bedrock/test/L2/LegacyFeeSplitter.t.sol
+++ b/packages/contracts-bedrock/test/L2/LegacyFeeSplitter.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { FeeSplitter_TestInit } from "test/L2/FeeSplitter.t.sol";
 import { LegacyFeeSplitter } from "test/mocks/LegacyFeeSplitter.sol";

--- a/packages/contracts-bedrock/test/L2/LiquidityController.t.sol
+++ b/packages/contracts-bedrock/test/L2/LiquidityController.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { CommonTest } from "test/setup/CommonTest.sol";

--- a/packages/contracts-bedrock/test/L2/NativeAssetLiquidity.t.sol
+++ b/packages/contracts-bedrock/test/L2/NativeAssetLiquidity.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing utilities
 import { CommonTest } from "test/setup/CommonTest.sol";

--- a/packages/contracts-bedrock/test/L2/OperatorFeeVault.t.sol
+++ b/packages/contracts-bedrock/test/L2/OperatorFeeVault.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Interfaces
 import { IFeeVault } from "interfaces/L2/IFeeVault.sol";

--- a/packages/contracts-bedrock/test/L2/OptimismMintableERC721.t.sol
+++ b/packages/contracts-bedrock/test/L2/OptimismMintableERC721.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { ERC721, IERC721 } from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import { IERC721Enumerable } from "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";

--- a/packages/contracts-bedrock/test/L2/OptimismMintableERC721Factory.t.sol
+++ b/packages/contracts-bedrock/test/L2/OptimismMintableERC721Factory.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { CommonTest } from "test/setup/CommonTest.sol";
 import { OptimismMintableERC721 } from "src/L2/OptimismMintableERC721.sol";

--- a/packages/contracts-bedrock/test/L2/OptimismSuperchainERC20Beacon.t.sol
+++ b/packages/contracts-bedrock/test/L2/OptimismSuperchainERC20Beacon.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing utilities
 import { CommonTest } from "test/setup/CommonTest.sol";

--- a/packages/contracts-bedrock/test/L2/OptimismSuperchainERC20Factory.t.sol
+++ b/packages/contracts-bedrock/test/L2/OptimismSuperchainERC20Factory.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing utilities
 import { CommonTest } from "test/setup/CommonTest.sol";

--- a/packages/contracts-bedrock/test/L2/RevenueSharingIntegration.t.sol
+++ b/packages/contracts-bedrock/test/L2/RevenueSharingIntegration.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { CommonTest } from "test/setup/CommonTest.sol";
 import { ISharesCalculator } from "interfaces/L2/ISharesCalculator.sol";

--- a/packages/contracts-bedrock/test/L2/SequencerFeeVault.t.sol
+++ b/packages/contracts-bedrock/test/L2/SequencerFeeVault.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Interfaces
 import { IFeeVault } from "interfaces/L2/IFeeVault.sol";

--- a/packages/contracts-bedrock/test/L2/SuperchainETHBridge.t.sol
+++ b/packages/contracts-bedrock/test/L2/SuperchainETHBridge.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { CommonTest } from "test/setup/CommonTest.sol";

--- a/packages/contracts-bedrock/test/L2/SuperchainRevSharesCalculator.t.sol
+++ b/packages/contracts-bedrock/test/L2/SuperchainRevSharesCalculator.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { CommonTest } from "test/setup/CommonTest.sol";

--- a/packages/contracts-bedrock/test/L2/WETH.t.sol
+++ b/packages/contracts-bedrock/test/L2/WETH.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing utilities
 import { CommonTest } from "test/setup/CommonTest.sol";

--- a/packages/contracts-bedrock/test/actors/FaultDisputeActors.sol
+++ b/packages/contracts-bedrock/test/actors/FaultDisputeActors.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.25;
 
 // Testing
 import { CommonBase } from "forge-std/Base.sol";

--- a/packages/contracts-bedrock/test/cannon/MIPS64.t.sol
+++ b/packages/contracts-bedrock/test/cannon/MIPS64.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { Test } from "test/setup/Test.sol";

--- a/packages/contracts-bedrock/test/cannon/MIPS64Memory.t.sol
+++ b/packages/contracts-bedrock/test/cannon/MIPS64Memory.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { CommonTest } from "test/setup/CommonTest.sol";
 import { MIPS64Memory } from "src/cannon/libraries/MIPS64Memory.sol";

--- a/packages/contracts-bedrock/test/cannon/PreimageOracle.t.sol
+++ b/packages/contracts-bedrock/test/cannon/PreimageOracle.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { Test } from "test/setup/Test.sol";

--- a/packages/contracts-bedrock/test/dispute/AnchorStateRegistry.t.sol
+++ b/packages/contracts-bedrock/test/dispute/AnchorStateRegistry.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.25;
 
 // Testing
 import { BaseFaultDisputeGame_TestInit, _changeClaimStatus } from "test/dispute/FaultDisputeGame.t.sol";

--- a/packages/contracts-bedrock/test/dispute/DelayedWETH.t.sol
+++ b/packages/contracts-bedrock/test/dispute/DelayedWETH.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.25;
 
 // Testing
 import { CommonTest } from "test/setup/CommonTest.sol";

--- a/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
+++ b/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.25;
 
 // Testing
 import { CommonTest } from "test/setup/CommonTest.sol";

--- a/packages/contracts-bedrock/test/dispute/FaultDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/dispute/FaultDisputeGame.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.25;
 
 // Testing
 import { Vm } from "forge-std/Vm.sol";

--- a/packages/contracts-bedrock/test/dispute/PermissionedDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/dispute/PermissionedDisputeGame.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.25;
 
 // Testing
 import { DisputeGameFactory_TestInit } from "test/dispute/DisputeGameFactory.t.sol";

--- a/packages/contracts-bedrock/test/dispute/SuperFaultDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/dispute/SuperFaultDisputeGame.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.25;
 
 // Testing
 import { Vm } from "forge-std/Vm.sol";

--- a/packages/contracts-bedrock/test/dispute/SuperPermissionedDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/dispute/SuperPermissionedDisputeGame.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.25;
 
 // Testing
 import { DisputeGameFactory_TestInit } from "test/dispute/DisputeGameFactory.t.sol";

--- a/packages/contracts-bedrock/test/dispute/lib/LibClock.t.sol
+++ b/packages/contracts-bedrock/test/dispute/lib/LibClock.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.25;
 
 // Testing
 import { Test } from "test/setup/Test.sol";

--- a/packages/contracts-bedrock/test/dispute/lib/LibGameArgs.t.sol
+++ b/packages/contracts-bedrock/test/dispute/lib/LibGameArgs.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.25;
 
 // Testing
 import { Test } from "test/setup/Test.sol";

--- a/packages/contracts-bedrock/test/dispute/lib/LibGameId.t.sol
+++ b/packages/contracts-bedrock/test/dispute/lib/LibGameId.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.25;
 
 // Testing
 import { Test } from "test/setup/Test.sol";

--- a/packages/contracts-bedrock/test/dispute/lib/LibPosition.t.sol
+++ b/packages/contracts-bedrock/test/dispute/lib/LibPosition.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.25;
 
 // Testing
 import { Test } from "test/setup/Test.sol";

--- a/packages/contracts-bedrock/test/dispute/zk/OptimisticZkGame.t.sol
+++ b/packages/contracts-bedrock/test/dispute/zk/OptimisticZkGame.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { DisputeGameFactory_TestInit } from "test/dispute/DisputeGameFactory.t.sol";

--- a/packages/contracts-bedrock/test/dispute/zk/mocks/SP1MockVerifier.sol
+++ b/packages/contracts-bedrock/test/dispute/zk/mocks/SP1MockVerifier.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { ISP1Verifier } from "src/dispute/zk/ISP1Verifier.sol";
 

--- a/packages/contracts-bedrock/test/governance/GovernanceToken.t.sol
+++ b/packages/contracts-bedrock/test/governance/GovernanceToken.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing utilities
 import { CommonTest } from "test/setup/CommonTest.sol";

--- a/packages/contracts-bedrock/test/governance/MintManager.t.sol
+++ b/packages/contracts-bedrock/test/governance/MintManager.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { CommonTest } from "test/setup/CommonTest.sol";

--- a/packages/contracts-bedrock/test/integration/ExecutingMessageEmitted.t.sol
+++ b/packages/contracts-bedrock/test/integration/ExecutingMessageEmitted.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing utilities
 import { CommonTest } from "test/setup/CommonTest.sol";

--- a/packages/contracts-bedrock/test/invariants/AddressAliasHelper.t.sol
+++ b/packages/contracts-bedrock/test/invariants/AddressAliasHelper.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { StdInvariant } from "forge-std/StdInvariant.sol";
 import { AddressAliasHelper } from "src/vendor/AddressAliasHelper.sol";

--- a/packages/contracts-bedrock/test/invariants/Burn.Eth.t.sol
+++ b/packages/contracts-bedrock/test/invariants/Burn.Eth.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { StdUtils } from "forge-std/StdUtils.sol";
 import { Vm } from "forge-std/Vm.sol";

--- a/packages/contracts-bedrock/test/invariants/Burn.Gas.t.sol
+++ b/packages/contracts-bedrock/test/invariants/Burn.Gas.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { StdUtils } from "forge-std/StdUtils.sol";
 import { Vm } from "forge-std/Vm.sol";

--- a/packages/contracts-bedrock/test/invariants/CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/invariants/CrossDomainMessenger.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { StdUtils } from "forge-std/StdUtils.sol";
 import { Vm } from "forge-std/Vm.sol";

--- a/packages/contracts-bedrock/test/invariants/CustomGasToken.t.sol
+++ b/packages/contracts-bedrock/test/invariants/CustomGasToken.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { StdUtils } from "forge-std/StdUtils.sol";

--- a/packages/contracts-bedrock/test/invariants/ETHLiquidity.t.sol
+++ b/packages/contracts-bedrock/test/invariants/ETHLiquidity.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { StdUtils } from "forge-std/StdUtils.sol";

--- a/packages/contracts-bedrock/test/invariants/Encoding.t.sol
+++ b/packages/contracts-bedrock/test/invariants/Encoding.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { StdInvariant } from "forge-std/StdInvariant.sol";
 import { Encoding } from "src/libraries/Encoding.sol";

--- a/packages/contracts-bedrock/test/invariants/FaultDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/invariants/FaultDisputeGame.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { Vm } from "forge-std/Vm.sol";

--- a/packages/contracts-bedrock/test/invariants/FeeSplit.t.sol
+++ b/packages/contracts-bedrock/test/invariants/FeeSplit.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.25;
 
 import { StdUtils } from "forge-std/StdUtils.sol";
 import { Vm } from "forge-std/Vm.sol";

--- a/packages/contracts-bedrock/test/invariants/Hashing.t.sol
+++ b/packages/contracts-bedrock/test/invariants/Hashing.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { StdInvariant } from "forge-std/StdInvariant.sol";
 import { Encoding } from "src/libraries/Encoding.sol";

--- a/packages/contracts-bedrock/test/invariants/InvariantTest.sol
+++ b/packages/contracts-bedrock/test/invariants/InvariantTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { Test } from "test/setup/Test.sol";

--- a/packages/contracts-bedrock/test/invariants/OptimismPortal2.t.sol
+++ b/packages/contracts-bedrock/test/invariants/OptimismPortal2.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { StdUtils } from "forge-std/StdUtils.sol";

--- a/packages/contracts-bedrock/test/invariants/ResourceMetering.t.sol
+++ b/packages/contracts-bedrock/test/invariants/ResourceMetering.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { StdUtils } from "forge-std/StdUtils.sol";
 import { StdInvariant } from "forge-std/StdInvariant.sol";

--- a/packages/contracts-bedrock/test/invariants/SafeCall.t.sol
+++ b/packages/contracts-bedrock/test/invariants/SafeCall.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { StdUtils } from "forge-std/StdUtils.sol";
 import { Vm } from "forge-std/Vm.sol";

--- a/packages/contracts-bedrock/test/invariants/SuperFaultDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/invariants/SuperFaultDisputeGame.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { BaseSuperFaultDisputeGame_TestInit } from "test/dispute/SuperFaultDisputeGame.t.sol";

--- a/packages/contracts-bedrock/test/invariants/SystemConfig.t.sol
+++ b/packages/contracts-bedrock/test/invariants/SystemConfig.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { Test } from "test/setup/Test.sol";

--- a/packages/contracts-bedrock/test/kontrol/proofs/utils/KontrolUtils.sol
+++ b/packages/contracts-bedrock/test/kontrol/proofs/utils/KontrolUtils.sol
@@ -10,7 +10,7 @@
 // need for the `copy_memory_to_memory` function and its summary, and thus this workaround.
 // For more information refer to the `copy_memory_to_memory` summary section of `pausability-lemmas.md`.
 
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Vm } from "forge-std/Vm.sol";
 import { KontrolCheats } from "kontrol-cheatcodes/KontrolCheats.sol";

--- a/packages/contracts-bedrock/test/legacy/DeployerWhitelist.t.sol
+++ b/packages/contracts-bedrock/test/legacy/DeployerWhitelist.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { Test } from "test/setup/Test.sol";

--- a/packages/contracts-bedrock/test/legacy/L1BlockNumber.t.sol
+++ b/packages/contracts-bedrock/test/legacy/L1BlockNumber.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { Test } from "test/setup/Test.sol";

--- a/packages/contracts-bedrock/test/legacy/L1ChugSplashProxy.t.sol
+++ b/packages/contracts-bedrock/test/legacy/L1ChugSplashProxy.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { Test } from "test/setup/Test.sol";

--- a/packages/contracts-bedrock/test/legacy/LegacyMessagePasser.t.sol
+++ b/packages/contracts-bedrock/test/legacy/LegacyMessagePasser.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing utilities
 import { CommonTest } from "test/setup/CommonTest.sol";

--- a/packages/contracts-bedrock/test/legacy/LegacyMintableERC20.t.sol
+++ b/packages/contracts-bedrock/test/legacy/LegacyMintableERC20.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing utilities
 import { CommonTest } from "test/setup/CommonTest.sol";

--- a/packages/contracts-bedrock/test/legacy/ResolvedDelegateProxy.t.sol
+++ b/packages/contracts-bedrock/test/legacy/ResolvedDelegateProxy.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { Test } from "test/setup/Test.sol";

--- a/packages/contracts-bedrock/test/libraries/Blueprint.t.sol
+++ b/packages/contracts-bedrock/test/libraries/Blueprint.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { Test } from "test/setup/Test.sol";

--- a/packages/contracts-bedrock/test/libraries/Bytes.t.sol
+++ b/packages/contracts-bedrock/test/libraries/Bytes.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { Test } from "test/setup/Test.sol";

--- a/packages/contracts-bedrock/test/libraries/Constants.t.sol
+++ b/packages/contracts-bedrock/test/libraries/Constants.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { Test } from "test/setup/Test.sol";

--- a/packages/contracts-bedrock/test/libraries/DeployUtils.t.sol
+++ b/packages/contracts-bedrock/test/libraries/DeployUtils.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { Test } from "test/setup/Test.sol";

--- a/packages/contracts-bedrock/test/libraries/DevFeatures.t.sol
+++ b/packages/contracts-bedrock/test/libraries/DevFeatures.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { Test } from "test/setup/Test.sol";

--- a/packages/contracts-bedrock/test/libraries/EOA.t.sol
+++ b/packages/contracts-bedrock/test/libraries/EOA.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { Test } from "test/setup/Test.sol";

--- a/packages/contracts-bedrock/test/libraries/Encoding.t.sol
+++ b/packages/contracts-bedrock/test/libraries/Encoding.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { CommonTest } from "test/setup/CommonTest.sol";

--- a/packages/contracts-bedrock/test/libraries/GasPayingToken.t.sol
+++ b/packages/contracts-bedrock/test/libraries/GasPayingToken.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { Test } from "test/setup/Test.sol";

--- a/packages/contracts-bedrock/test/libraries/Hashing.t.sol
+++ b/packages/contracts-bedrock/test/libraries/Hashing.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing utilities
 import { CommonTest } from "test/setup/CommonTest.sol";

--- a/packages/contracts-bedrock/test/libraries/L2ContractsManagerUtils.t.sol
+++ b/packages/contracts-bedrock/test/libraries/L2ContractsManagerUtils.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Libraries
 import { L2ContractsManagerUtils } from "src/libraries/L2ContractsManagerUtils.sol";

--- a/packages/contracts-bedrock/test/libraries/Predeploys.t.sol
+++ b/packages/contracts-bedrock/test/libraries/Predeploys.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { CommonTest } from "test/setup/CommonTest.sol";

--- a/packages/contracts-bedrock/test/libraries/Predeploys.t.sol
+++ b/packages/contracts-bedrock/test/libraries/Predeploys.t.sol
@@ -62,7 +62,7 @@ abstract contract Predeploys_TestInit is CommonTest {
         uint256 count = 2048;
         uint160 prefix = uint160(0x420) << 148;
 
-        bytes memory proxyCode = vm.getDeployedCode("Proxy.sol:Proxy");
+        bytes memory proxyCode = vm.getDeployedCode("universal/Proxy.sol:Proxy");
 
         for (uint256 i = 0; i < count; i++) {
             address addr = address(prefix | uint160(i));

--- a/packages/contracts-bedrock/test/libraries/Preinstalls.t.sol
+++ b/packages/contracts-bedrock/test/libraries/Preinstalls.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { CommonTest } from "test/setup/CommonTest.sol";
 import { Preinstalls } from "src/libraries/Preinstalls.sol";

--- a/packages/contracts-bedrock/test/libraries/SafeCall.t.sol
+++ b/packages/contracts-bedrock/test/libraries/SafeCall.t.sol
@@ -168,11 +168,11 @@ contract SafeCall_CallWithMinGas_Test is SafeCall_TestInit {
             // run before testing this with forge test or forge snapshot, forge clean should be run
             // first so that it recompiles the contracts using the foundry.toml optimizer settings.
             if (Config.isUnoptimized()) {
-                // 66_290 is the exact amount of gas required with the optimizer disabled.
-                expected = 66_290;
+                // 66_273 is the exact amount of gas required with the optimizer disabled.
+                expected = 66_273;
             } else {
-                // 65_922 is the exact amount of gas required with optimizer enabled.
-                expected = 65_922;
+                // 65_914 is the exact amount of gas required with optimizer enabled.
+                expected = 65_914;
             }
 
             if (i < expected) {
@@ -205,11 +205,11 @@ contract SafeCall_CallWithMinGas_Test is SafeCall_TestInit {
             // run before testing this with forge test or forge snapshot, forge clean should be run
             // first so that it recompiles the contracts using the foundry.toml optimizer settings.
             if (Config.isUnoptimized()) {
-                // 15_278_989 is the exact amount of gas required with the optimizer disabled.
-                expected = 15_278_989;
+                // 15_278_972 is the exact amount of gas required with the optimizer disabled.
+                expected = 15_278_972;
             } else {
-                // 15_278_621 is the exact amount of gas required with optimizer enabled.
-                expected = 15_278_621;
+                // 15_278_613 is the exact amount of gas required with optimizer enabled.
+                expected = 15_278_613;
             }
 
             if (i < expected) {

--- a/packages/contracts-bedrock/test/libraries/SafeCall.t.sol
+++ b/packages/contracts-bedrock/test/libraries/SafeCall.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { Test } from "test/setup/Test.sol";

--- a/packages/contracts-bedrock/test/libraries/SemverComp.t.sol
+++ b/packages/contracts-bedrock/test/libraries/SemverComp.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { Test } from "test/setup/Test.sol";

--- a/packages/contracts-bedrock/test/libraries/StaticConfig.t.sol
+++ b/packages/contracts-bedrock/test/libraries/StaticConfig.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { Test } from "test/setup/Test.sol";

--- a/packages/contracts-bedrock/test/libraries/Storage.t.sol
+++ b/packages/contracts-bedrock/test/libraries/Storage.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { Test } from "test/setup/Test.sol";

--- a/packages/contracts-bedrock/test/libraries/rlp/RLPReader.t.sol
+++ b/packages/contracts-bedrock/test/libraries/rlp/RLPReader.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { Test } from "test/setup/Test.sol";

--- a/packages/contracts-bedrock/test/libraries/rlp/RLPWriter.t.sol
+++ b/packages/contracts-bedrock/test/libraries/rlp/RLPWriter.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { Test } from "test/setup/Test.sol";

--- a/packages/contracts-bedrock/test/libraries/trie/MerkleTrie.t.sol
+++ b/packages/contracts-bedrock/test/libraries/trie/MerkleTrie.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { Test } from "test/setup/Test.sol";

--- a/packages/contracts-bedrock/test/mocks/AlphabetVM.sol
+++ b/packages/contracts-bedrock/test/mocks/AlphabetVM.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.25;
 
 // Libraries
 import { PreimageKeyLib } from "src/cannon/PreimageKeyLib.sol";

--- a/packages/contracts-bedrock/test/mocks/DummyGuard.sol
+++ b/packages/contracts-bedrock/test/mocks/DummyGuard.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { BaseGuard } from "safe-contracts/base/GuardManager.sol";
 import { Enum } from "safe-contracts/common/Enum.sol";

--- a/packages/contracts-bedrock/test/mocks/MaliciousMockFeeVault.sol
+++ b/packages/contracts-bedrock/test/mocks/MaliciousMockFeeVault.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Types } from "src/libraries/Types.sol";
 

--- a/packages/contracts-bedrock/test/mocks/MockFeeVault.sol
+++ b/packages/contracts-bedrock/test/mocks/MockFeeVault.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Types } from "src/libraries/Types.sol";
 

--- a/packages/contracts-bedrock/test/mocks/NextImpl.sol
+++ b/packages/contracts-bedrock/test/mocks/NextImpl.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 

--- a/packages/contracts-bedrock/test/mocks/ReentrantMockFeeVault.sol
+++ b/packages/contracts-bedrock/test/mocks/ReentrantMockFeeVault.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Types } from "src/libraries/Types.sol";
 import { IFeeVault } from "interfaces/L2/IFeeVault.sol";

--- a/packages/contracts-bedrock/test/mocks/RevertingRecipient.sol
+++ b/packages/contracts-bedrock/test/mocks/RevertingRecipient.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 /// @notice Helper recipient that always reverts on receiving ETH
 contract RevertingRecipient {

--- a/packages/contracts-bedrock/test/opcm/DeployAltDA.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployAltDA.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { Test } from "test/setup/Test.sol";

--- a/packages/contracts-bedrock/test/opcm/DeployDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployDisputeGame.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { Test } from "test/setup/Test.sol";

--- a/packages/contracts-bedrock/test/opcm/DeployFeesDepositor.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployFeesDepositor.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { Test } from "test/setup/Test.sol";

--- a/packages/contracts-bedrock/test/opcm/DeployImplementations.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployImplementations.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { Test } from "test/setup/Test.sol";

--- a/packages/contracts-bedrock/test/opcm/DeployMIPS.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployMIPS.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { Test } from "test/setup/Test.sol";

--- a/packages/contracts-bedrock/test/opcm/DeployOPChain.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployOPChain.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { Test } from "test/setup/Test.sol";

--- a/packages/contracts-bedrock/test/opcm/DeploySaferSafes.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeploySaferSafes.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { Test } from "test/setup/Test.sol";

--- a/packages/contracts-bedrock/test/opcm/DeploySuperchain.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeploySuperchain.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { Test } from "test/setup/Test.sol";

--- a/packages/contracts-bedrock/test/opcm/InteropMigration.t.sol
+++ b/packages/contracts-bedrock/test/opcm/InteropMigration.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { Test } from "test/setup/Test.sol";

--- a/packages/contracts-bedrock/test/opcm/UpgradeOPChain.t.sol
+++ b/packages/contracts-bedrock/test/opcm/UpgradeOPChain.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { Test } from "test/setup/Test.sol";

--- a/packages/contracts-bedrock/test/opcm/UpgradeSuperchainConfig.t.sol
+++ b/packages/contracts-bedrock/test/opcm/UpgradeSuperchainConfig.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { Test } from "test/setup/Test.sol";

--- a/packages/contracts-bedrock/test/periphery/AssetReceiver.t.sol
+++ b/packages/contracts-bedrock/test/periphery/AssetReceiver.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { Test } from "test/setup/Test.sol";

--- a/packages/contracts-bedrock/test/periphery/Transactor.t.sol
+++ b/packages/contracts-bedrock/test/periphery/Transactor.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { Test } from "test/setup/Test.sol";

--- a/packages/contracts-bedrock/test/periphery/TransferOnion.t.sol
+++ b/packages/contracts-bedrock/test/periphery/TransferOnion.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { Test } from "test/setup/Test.sol";

--- a/packages/contracts-bedrock/test/periphery/drippie/Drippie.t.sol
+++ b/packages/contracts-bedrock/test/periphery/drippie/Drippie.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { Test } from "test/setup/Test.sol";

--- a/packages/contracts-bedrock/test/periphery/drippie/dripchecks/CheckBalanceLow.t.sol
+++ b/packages/contracts-bedrock/test/periphery/drippie/dripchecks/CheckBalanceLow.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { Test } from "test/setup/Test.sol";

--- a/packages/contracts-bedrock/test/periphery/drippie/dripchecks/CheckSecrets.t.sol
+++ b/packages/contracts-bedrock/test/periphery/drippie/dripchecks/CheckSecrets.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { Test } from "test/setup/Test.sol";

--- a/packages/contracts-bedrock/test/periphery/drippie/dripchecks/CheckTrue.t.sol
+++ b/packages/contracts-bedrock/test/periphery/drippie/dripchecks/CheckTrue.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { Test } from "test/setup/Test.sol";

--- a/packages/contracts-bedrock/test/periphery/faucet/Faucet.t.sol
+++ b/packages/contracts-bedrock/test/periphery/faucet/Faucet.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { Test } from "test/setup/Test.sol";

--- a/packages/contracts-bedrock/test/periphery/faucet/authmodules/AdminFaucetAuthModule.t.sol
+++ b/packages/contracts-bedrock/test/periphery/faucet/authmodules/AdminFaucetAuthModule.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { Test } from "test/setup/Test.sol";

--- a/packages/contracts-bedrock/test/periphery/monitoring/DisputeMonitorHelper.t.sol
+++ b/packages/contracts-bedrock/test/periphery/monitoring/DisputeMonitorHelper.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { DisputeGameFactory_TestInit } from "test/dispute/DisputeGameFactory.t.sol";

--- a/packages/contracts-bedrock/test/periphery/staking/PolicyEngineStaking.t.sol
+++ b/packages/contracts-bedrock/test/periphery/staking/PolicyEngineStaking.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing utilities
 import { CommonTest } from "test/setup/CommonTest.sol";

--- a/packages/contracts-bedrock/test/safe/DeputyPauseModule.t.sol
+++ b/packages/contracts-bedrock/test/safe/DeputyPauseModule.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { CommonTest } from "test/setup/CommonTest.sol";

--- a/packages/contracts-bedrock/test/safe/LivenessGuard.t.sol
+++ b/packages/contracts-bedrock/test/safe/LivenessGuard.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { Test } from "test/setup/Test.sol";

--- a/packages/contracts-bedrock/test/safe/LivenessModule.t.sol
+++ b/packages/contracts-bedrock/test/safe/LivenessModule.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { Test } from "test/setup/Test.sol";

--- a/packages/contracts-bedrock/test/safe/LivenessModule2.t.sol
+++ b/packages/contracts-bedrock/test/safe/LivenessModule2.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { Test } from "test/setup/Test.sol";

--- a/packages/contracts-bedrock/test/safe/SafeSigners.t.sol
+++ b/packages/contracts-bedrock/test/safe/SafeSigners.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { Test } from "test/setup/Test.sol";

--- a/packages/contracts-bedrock/test/safe/SaferSafes.t.sol
+++ b/packages/contracts-bedrock/test/safe/SaferSafes.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Enum } from "safe-contracts/common/Enum.sol";
 import { Safe } from "safe-contracts/Safe.sol";

--- a/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
+++ b/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import "test/safe-tools/SafeTestTools.sol";

--- a/packages/contracts-bedrock/test/scripts/DeployOwnership.t.sol
+++ b/packages/contracts-bedrock/test/scripts/DeployOwnership.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Forge
 import { StdCheatsSafe } from "forge-std/StdCheats.sol";

--- a/packages/contracts-bedrock/test/scripts/L2Genesis.t.sol
+++ b/packages/contracts-bedrock/test/scripts/L2Genesis.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { Test } from "test/setup/Test.sol";

--- a/packages/contracts-bedrock/test/scripts/ReadImplementationAddresses.t.sol
+++ b/packages/contracts-bedrock/test/scripts/ReadImplementationAddresses.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { CommonTest } from "test/setup/CommonTest.sol";

--- a/packages/contracts-bedrock/test/scripts/ReadSuperchainDeployment.t.sol
+++ b/packages/contracts-bedrock/test/scripts/ReadSuperchainDeployment.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { Test } from "test/setup/Test.sol";

--- a/packages/contracts-bedrock/test/scripts/VerifyOPCM.t.sol
+++ b/packages/contracts-bedrock/test/scripts/VerifyOPCM.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Libraries
 import { LibString } from "@solady/utils/LibString.sol";

--- a/packages/contracts-bedrock/test/setup/ByteUtils.sol
+++ b/packages/contracts-bedrock/test/setup/ByteUtils.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 library ByteUtils {
     /// @notice Overwrite bytes in-place at a specific offset.

--- a/packages/contracts-bedrock/test/setup/DeployVariations.t.sol
+++ b/packages/contracts-bedrock/test/setup/DeployVariations.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing utilities
 import { CommonTest } from "test/setup/CommonTest.sol";

--- a/packages/contracts-bedrock/test/setup/DisputeGames.sol
+++ b/packages/contracts-bedrock/test/setup/DisputeGames.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { ByteUtils } from "./ByteUtils.sol";

--- a/packages/contracts-bedrock/test/setup/FFIInterface.sol
+++ b/packages/contracts-bedrock/test/setup/FFIInterface.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Types } from "src/libraries/Types.sol";
 import { Vm } from "forge-std/Vm.sol";
@@ -8,7 +8,7 @@ import { Process } from "scripts/libraries/Process.sol";
 
 /// @title FFIInterface
 /// @notice This contract is set into state using `etch` and therefore must not have constructor logic.
-///         It also MUST be compiled with `0.8.15` because `vm.getDeployedCode` will break if there
+///         It also MUST be compiled with `0.8.25` because `vm.getDeployedCode` will break if there
 ///         are multiple artifacts for different compiler versions.
 contract FFIInterface {
     Vm internal constant vm = Vm(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);

--- a/packages/contracts-bedrock/test/setup/FeatureFlags.sol
+++ b/packages/contracts-bedrock/test/setup/FeatureFlags.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { console2 as console } from "forge-std/console2.sol";

--- a/packages/contracts-bedrock/test/setup/Setup.sol
+++ b/packages/contracts-bedrock/test/setup/Setup.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { console2 as console } from "forge-std/console2.sol";

--- a/packages/contracts-bedrock/test/universal/BenchmarkTest.t.sol
+++ b/packages/contracts-bedrock/test/universal/BenchmarkTest.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Forge
 import { Vm } from "forge-std/Vm.sol";

--- a/packages/contracts-bedrock/test/universal/CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/universal/CrossDomainMessenger.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { Test } from "test/setup/Test.sol";

--- a/packages/contracts-bedrock/test/universal/ExtendedPause.t.sol
+++ b/packages/contracts-bedrock/test/universal/ExtendedPause.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { CommonTest } from "test/setup/CommonTest.sol";
 

--- a/packages/contracts-bedrock/test/universal/OptimismMintableERC20.t.sol
+++ b/packages/contracts-bedrock/test/universal/OptimismMintableERC20.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { CommonTest } from "test/setup/CommonTest.sol";
 import { IOptimismMintableERC20 } from "interfaces/universal/IOptimismMintableERC20.sol";

--- a/packages/contracts-bedrock/test/universal/OptimismMintableERC20Factory.t.sol
+++ b/packages/contracts-bedrock/test/universal/OptimismMintableERC20Factory.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { CommonTest } from "test/setup/CommonTest.sol";

--- a/packages/contracts-bedrock/test/universal/Proxy.t.sol
+++ b/packages/contracts-bedrock/test/universal/Proxy.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { Test } from "test/setup/Test.sol";

--- a/packages/contracts-bedrock/test/universal/ProxyAdmin.t.sol
+++ b/packages/contracts-bedrock/test/universal/ProxyAdmin.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { Test } from "test/setup/Test.sol";

--- a/packages/contracts-bedrock/test/universal/ReinitializableBase.t.sol
+++ b/packages/contracts-bedrock/test/universal/ReinitializableBase.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { Test } from "test/setup/Test.sol";

--- a/packages/contracts-bedrock/test/universal/SafeSend.t.sol
+++ b/packages/contracts-bedrock/test/universal/SafeSend.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { SafeSend } from "src/universal/SafeSend.sol";
 import { CommonTest } from "test/setup/CommonTest.sol";

--- a/packages/contracts-bedrock/test/universal/StandardBridge.t.sol
+++ b/packages/contracts-bedrock/test/universal/StandardBridge.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { StandardBridge } from "src/universal/StandardBridge.sol";
 import { CommonTest } from "test/setup/CommonTest.sol";

--- a/packages/contracts-bedrock/test/universal/WETH98.t.sol
+++ b/packages/contracts-bedrock/test/universal/WETH98.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { Test } from "test/setup/Test.sol";

--- a/packages/contracts-bedrock/test/vendor/AddressAliasHelper.t.sol
+++ b/packages/contracts-bedrock/test/vendor/AddressAliasHelper.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { Test } from "test/setup/Test.sol";

--- a/packages/contracts-bedrock/test/vendor/Initializable.t.sol
+++ b/packages/contracts-bedrock/test/vendor/Initializable.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 // Testing
 import { CommonTest } from "test/setup/CommonTest.sol";


### PR DESCRIPTION
## Summary

Experimental PR to bump the Solidity compiler version in `packages/contracts-bedrock/` from 0.8.15 to 0.8.25.

- Updated 290 Solidity files across `src/`, `test/`, and `scripts/`
- Updated vendor EAS files from 0.8.19 to 0.8.25
- Updated `^0.8.15` floating pragmas to `^0.8.25`
- Left `^0.8.0`, `^0.8.8`, `^0.8.9`, `^0.8.13`, `^0.8.24`, and range pragmas unchanged (already compatible)
- Patch-bumped 54 contracts that showed bytecode changes
- Updated all hardcoded version expectations in validators and deploy scripts

## What Changed

| Category | Files | Details |
|----------|-------|---------|
| Pragma updates | 290 | `0.8.15` -> `0.8.25`, `0.8.19` -> `0.8.25`, `^0.8.15` -> `^0.8.25` |
| Version bumps | 54 | Patch bump all contracts with bytecode changes |
| Artifact disambiguation | 2 | `vm.getDeployedCode` path-qualified for `Proxy.sol` |
| Gas boundary tests | 1 | `SafeCall.t.sol` threshold adjustments |
| Hardcoded versions | 3 | `OPContractsManagerStandardValidator`, `DeploySaferSafes` script + test |
| Check scripts | 2 | `strict-pragma` test data, `semver-diff` exclusions |

## Decisions Made

1. **Vendor EAS files bumped to 0.8.25** -- Kept everything on a single compiler version to avoid artifact collisions.

2. **Left `^0.8.0` and other float pragmas alone** -- Libraries, interfaces, and utility files use floating pragmas that are already compatible.

3. **Path-qualified `vm.getDeployedCode` calls** -- With all contracts compiling under 0.8.25, some contracts sharing names with OpenZeppelin dependencies (e.g., `Proxy.sol`) produced ambiguous artifacts. Fixed by using path-qualified names.

4. **Updated gas boundary test constants** -- 0.8.25 generates slightly more efficient bytecode (PUSH0 opcode), reducing gas thresholds by 8-17 gas units in SafeCall tests.

5. **Excluded inheriting-version contracts from semver-diff** -- L1BlockCGT, L2StandardBridgeInterop, L2ToL1MessagePasserCGT use `string.concat(super.version(), suffix)` which the semver-diff check cannot parse. Added them to the exclusion list since parent versions are already validated.

6. **Updated OPContractsManagerStandardValidator** -- Hardcoded `preimageOracleVersion()` from 1.1.4 to 1.1.5 to match the bumped PreimageOracle.

## Complexity Report

**Moderate complexity, but highly mechanical.** Summary:

1. **Artifact name collisions** (key finding): When contracts-bedrock used 0.8.15 and OZ v5 used `^0.8.20`, Foundry compiled them with different compiler versions and could disambiguate artifacts. With both at 0.8.25, contracts with the same file name (e.g., `Proxy.sol`) collide. This is the most architecturally significant issue.

2. **54 version bumps needed** (mechanical): Every contract's bytecode changes with a new compiler, requiring patch bumps. This is the bulk of the diff.

3. **Gas boundary tests** (expected): Exact gas thresholds changed by 8-17 units.

4. **No breaking language changes**: Zero compilation errors despite 10 minor versions. `selfdestruct` deprecation already suppressed. No `block.difficulty` usage.

5. **Validator expectations**: The `OPContractsManagerStandardValidator` hardcodes expected contract versions, requiring updates when versions change.

## Side Effects

- **All 290 files** show pragma changes
- **54 contracts** have patch version bumps
- **semver-lock.json** regenerated (all bytecode hashes changed)
- Gas constants changed in SafeCall.t.sol
- `vm.getDeployedCode` paths changed in L2Genesis.s.sol and Predeploys.t.sol
- `check-semver-diff.sh` now excludes 3 inheriting-version contracts
- **No ABI changes** -- all changes are bytecode-only

## Test Results

- Build: passing (645 files compiled with single Solc 0.8.25)
- Tests: 2210 passed, 0 failed, 108 skipped
- `check-fast`: 17/17 checks passing

## Key Solidity changes available with 0.8.25

- 0.8.18: `block.prevrandao` (replaces `block.difficulty`)
- 0.8.20: Default EVM target changed to Shanghai (PUSH0 opcode)
- 0.8.22: Deprecation warnings for various features
- 0.8.24: Transient storage (`tstore`/`tload`), `mcopy`
- 0.8.25: Bug fixes and stability improvements

## Test plan

- [x] `just build-dev` passes (zero warnings)
- [x] `just test-dev` passes (2210/2210 tests, 108 skipped)
- [x] `just check-fast` passes (17/17 checks)
- [ ] CI checks (watching)

Generated with [Claude Code](https://claude.com/claude-code)