### PR TITLE
test(contracts): reuse ProxyAdmin tests on L2ProxyAdmin for backwards compatibility

### DIFF
--- a/packages/contracts-bedrock/test/L2/L2ProxyAdmin.t.sol
+++ b/packages/contracts-bedrock/test/L2/L2ProxyAdmin.t.sol
@@ -3,6 +3,18 @@ pragma solidity 0.8.15;
 
 // Testing
 import { CommonTest } from "test/setup/CommonTest.sol";
+import {
+    ProxyAdmin_SetProxyType_Test,
+    ProxyAdmin_SetImplementationName_Test,
+    ProxyAdmin_SetAddressManager_Test,
+    ProxyAdmin_IsUpgrading_Test,
+    ProxyAdmin_GetProxyImplementation_Test,
+    ProxyAdmin_GetProxyAdmin_Test,
+    ProxyAdmin_ChangeProxyAdmin_Test,
+    ProxyAdmin_Upgrade_Test,
+    ProxyAdmin_UpgradeAndCall_Test,
+    ProxyAdmin_Uncategorized_Test
+} from "test/universal/ProxyAdmin.t.sol";
 
 // Libraries
 import { Constants } from "src/libraries/Constants.sol";
@@ -10,6 +22,7 @@ import { Predeploys } from "src/libraries/Predeploys.sol";
 
 // Interfaces
 import { IL2ProxyAdmin } from "interfaces/L2/IL2ProxyAdmin.sol";
+import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
 
 // Contracts
 import { L2ProxyAdmin } from "src/L2/L2ProxyAdmin.sol";
@@ -108,5 +121,95 @@ contract L2ProxyAdmin_UpgradePredeploys_Test is L2ProxyAdmin_TestInit {
         // Call upgradePredeploys with authorized caller
         vm.prank(Constants.DEPOSITOR_ACCOUNT);
         l2ProxyAdmin.upgradePredeploys(_l2ContractsManager);
+    }
+}
+
+// Backwards-compatibility: rerun all ProxyAdmin tests against L2ProxyAdmin
+// by overriding _createAdmin to deploy L2ProxyAdmin instead.
+
+/// @notice Deploys a new L2ProxyAdmin contract with the given owner address and returns it as IProxyAdmin.
+/// @param _owner The address to set as the owner of the deployed L2ProxyAdmin.
+/// @return The newly deployed L2ProxyAdmin as the IProxyAdmin interface.
+function _createL2ProxyAdmin(address _owner) returns (IProxyAdmin) {
+    return IProxyAdmin(address(new L2ProxyAdmin(_owner)));
+}
+
+/// @title L2ProxyAdmin_SetProxyType_Test
+/// @notice Tests the `setProxyType` function of the `L2ProxyAdmin` contract for backwards compatibility.
+contract L2ProxyAdmin_SetProxyType_Test is ProxyAdmin_SetProxyType_Test {
+    function _createAdmin(address _owner) internal override returns (IProxyAdmin) {
+        return _createL2ProxyAdmin(_owner);
+    }
+}
+
+/// @title L2ProxyAdmin_SetImplementationName_Test
+/// @notice Tests the `setImplementationName` function of the `L2ProxyAdmin` contract for backwards compatibility.
+contract L2ProxyAdmin_SetImplementationName_Test is ProxyAdmin_SetImplementationName_Test {
+    function _createAdmin(address _owner) internal override returns (IProxyAdmin) {
+        return _createL2ProxyAdmin(_owner);
+    }
+}
+
+/// @title L2ProxyAdmin_SetAddressManager_Test
+/// @notice Tests the `setAddressManager` function of the `L2ProxyAdmin` contract for backwards compatibility.
+contract L2ProxyAdmin_SetAddressManager_Test is ProxyAdmin_SetAddressManager_Test {
+    function _createAdmin(address _owner) internal override returns (IProxyAdmin) {
+        return _createL2ProxyAdmin(_owner);
+    }
+}
+
+/// @title L2ProxyAdmin_IsUpgrading_Test
+/// @notice Tests the `isUpgrading` function of the `L2ProxyAdmin` contract for backwards compatibility.
+contract L2ProxyAdmin_IsUpgrading_Test is ProxyAdmin_IsUpgrading_Test {
+    function _createAdmin(address _owner) internal override returns (IProxyAdmin) {
+        return _createL2ProxyAdmin(_owner);
+    }
+}
+
+/// @title L2ProxyAdmin_GetProxyImplementation_Test
+/// @notice Tests the `getProxyImplementation` function of the `L2ProxyAdmin` contract for backwards compatibility.
+contract L2ProxyAdmin_GetProxyImplementation_Test is ProxyAdmin_GetProxyImplementation_Test {
+    function _createAdmin(address _owner) internal override returns (IProxyAdmin) {
+        return _createL2ProxyAdmin(_owner);
+    }
+}
+
+/// @title L2ProxyAdmin_GetProxyAdmin_Test
+/// @notice Tests the `getProxyAdmin` function of the `L2ProxyAdmin` contract for backwards compatibility.
+contract L2ProxyAdmin_GetProxyAdmin_Test is ProxyAdmin_GetProxyAdmin_Test {
+    function _createAdmin(address _owner) internal override returns (IProxyAdmin) {
+        return _createL2ProxyAdmin(_owner);
+    }
+}
+
+/// @title L2ProxyAdmin_ChangeProxyAdmin_Test
+/// @notice Tests the `changeProxyAdmin` function of the `L2ProxyAdmin` contract for backwards compatibility.
+contract L2ProxyAdmin_ChangeProxyAdmin_Test is ProxyAdmin_ChangeProxyAdmin_Test {
+    function _createAdmin(address _owner) internal override returns (IProxyAdmin) {
+        return _createL2ProxyAdmin(_owner);
+    }
+}
+
+/// @title L2ProxyAdmin_Upgrade_Test
+/// @notice Tests the `upgrade` function of the `L2ProxyAdmin` contract for backwards compatibility.
+contract L2ProxyAdmin_Upgrade_Test is ProxyAdmin_Upgrade_Test {
+    function _createAdmin(address _owner) internal override returns (IProxyAdmin) {
+        return _createL2ProxyAdmin(_owner);
+    }
+}
+
+/// @title L2ProxyAdmin_UpgradeAndCall_Test
+/// @notice Tests the `upgradeAndCall` function of the `L2ProxyAdmin` contract for backwards compatibility.
+contract L2ProxyAdmin_UpgradeAndCall_Test is ProxyAdmin_UpgradeAndCall_Test {
+    function _createAdmin(address _owner) internal override returns (IProxyAdmin) {
+        return _createL2ProxyAdmin(_owner);
+    }
+}
+
+/// @title L2ProxyAdmin_Uncategorized_Test
+/// @notice General backwards-compatibility tests for the `L2ProxyAdmin` contract.
+contract L2ProxyAdmin_Uncategorized_Test is ProxyAdmin_Uncategorized_Test {
+    function _createAdmin(address _owner) internal override returns (IProxyAdmin) {
+        return _createL2ProxyAdmin(_owner);
     }
 }

--- a/packages/contracts-bedrock/test/L2/L2ProxyAdmin.t.sol
+++ b/packages/contracts-bedrock/test/L2/L2ProxyAdmin.t.sol
@@ -127,18 +127,11 @@ contract L2ProxyAdmin_UpgradePredeploys_Test is L2ProxyAdmin_TestInit {
 // Backwards-compatibility: rerun all ProxyAdmin tests against L2ProxyAdmin
 // by overriding _createAdmin to deploy L2ProxyAdmin instead.
 
-/// @notice Deploys a new L2ProxyAdmin contract with the given owner address and returns it as IProxyAdmin.
-/// @param _owner The address to set as the owner of the deployed L2ProxyAdmin.
-/// @return The newly deployed L2ProxyAdmin as the IProxyAdmin interface.
-function _createL2ProxyAdmin(address _owner) returns (IProxyAdmin) {
-    return IProxyAdmin(address(new L2ProxyAdmin(_owner)));
-}
-
 /// @title L2ProxyAdmin_SetProxyType_Test
 /// @notice Tests the `setProxyType` function of the `L2ProxyAdmin` contract for backwards compatibility.
 contract L2ProxyAdmin_SetProxyType_Test is ProxyAdmin_SetProxyType_Test {
     function _createAdmin(address _owner) internal override returns (IProxyAdmin) {
-        return _createL2ProxyAdmin(_owner);
+        return IProxyAdmin(address(new L2ProxyAdmin(_owner)));
     }
 }
 
@@ -146,7 +139,7 @@ contract L2ProxyAdmin_SetProxyType_Test is ProxyAdmin_SetProxyType_Test {
 /// @notice Tests the `setImplementationName` function of the `L2ProxyAdmin` contract for backwards compatibility.
 contract L2ProxyAdmin_SetImplementationName_Test is ProxyAdmin_SetImplementationName_Test {
     function _createAdmin(address _owner) internal override returns (IProxyAdmin) {
-        return _createL2ProxyAdmin(_owner);
+        return IProxyAdmin(address(new L2ProxyAdmin(_owner)));
     }
 }
 
@@ -154,7 +147,7 @@ contract L2ProxyAdmin_SetImplementationName_Test is ProxyAdmin_SetImplementation
 /// @notice Tests the `setAddressManager` function of the `L2ProxyAdmin` contract for backwards compatibility.
 contract L2ProxyAdmin_SetAddressManager_Test is ProxyAdmin_SetAddressManager_Test {
     function _createAdmin(address _owner) internal override returns (IProxyAdmin) {
-        return _createL2ProxyAdmin(_owner);
+        return IProxyAdmin(address(new L2ProxyAdmin(_owner)));
     }
 }
 
@@ -162,7 +155,7 @@ contract L2ProxyAdmin_SetAddressManager_Test is ProxyAdmin_SetAddressManager_Tes
 /// @notice Tests the `isUpgrading` function of the `L2ProxyAdmin` contract for backwards compatibility.
 contract L2ProxyAdmin_IsUpgrading_Test is ProxyAdmin_IsUpgrading_Test {
     function _createAdmin(address _owner) internal override returns (IProxyAdmin) {
-        return _createL2ProxyAdmin(_owner);
+        return IProxyAdmin(address(new L2ProxyAdmin(_owner)));
     }
 }
 
@@ -170,7 +163,7 @@ contract L2ProxyAdmin_IsUpgrading_Test is ProxyAdmin_IsUpgrading_Test {
 /// @notice Tests the `getProxyImplementation` function of the `L2ProxyAdmin` contract for backwards compatibility.
 contract L2ProxyAdmin_GetProxyImplementation_Test is ProxyAdmin_GetProxyImplementation_Test {
     function _createAdmin(address _owner) internal override returns (IProxyAdmin) {
-        return _createL2ProxyAdmin(_owner);
+        return IProxyAdmin(address(new L2ProxyAdmin(_owner)));
     }
 }
 
@@ -178,7 +171,7 @@ contract L2ProxyAdmin_GetProxyImplementation_Test is ProxyAdmin_GetProxyImplemen
 /// @notice Tests the `getProxyAdmin` function of the `L2ProxyAdmin` contract for backwards compatibility.
 contract L2ProxyAdmin_GetProxyAdmin_Test is ProxyAdmin_GetProxyAdmin_Test {
     function _createAdmin(address _owner) internal override returns (IProxyAdmin) {
-        return _createL2ProxyAdmin(_owner);
+        return IProxyAdmin(address(new L2ProxyAdmin(_owner)));
     }
 }
 
@@ -186,7 +179,7 @@ contract L2ProxyAdmin_GetProxyAdmin_Test is ProxyAdmin_GetProxyAdmin_Test {
 /// @notice Tests the `changeProxyAdmin` function of the `L2ProxyAdmin` contract for backwards compatibility.
 contract L2ProxyAdmin_ChangeProxyAdmin_Test is ProxyAdmin_ChangeProxyAdmin_Test {
     function _createAdmin(address _owner) internal override returns (IProxyAdmin) {
-        return _createL2ProxyAdmin(_owner);
+        return IProxyAdmin(address(new L2ProxyAdmin(_owner)));
     }
 }
 
@@ -194,7 +187,7 @@ contract L2ProxyAdmin_ChangeProxyAdmin_Test is ProxyAdmin_ChangeProxyAdmin_Test 
 /// @notice Tests the `upgrade` function of the `L2ProxyAdmin` contract for backwards compatibility.
 contract L2ProxyAdmin_Upgrade_Test is ProxyAdmin_Upgrade_Test {
     function _createAdmin(address _owner) internal override returns (IProxyAdmin) {
-        return _createL2ProxyAdmin(_owner);
+        return IProxyAdmin(address(new L2ProxyAdmin(_owner)));
     }
 }
 
@@ -202,7 +195,7 @@ contract L2ProxyAdmin_Upgrade_Test is ProxyAdmin_Upgrade_Test {
 /// @notice Tests the `upgradeAndCall` function of the `L2ProxyAdmin` contract for backwards compatibility.
 contract L2ProxyAdmin_UpgradeAndCall_Test is ProxyAdmin_UpgradeAndCall_Test {
     function _createAdmin(address _owner) internal override returns (IProxyAdmin) {
-        return _createL2ProxyAdmin(_owner);
+        return IProxyAdmin(address(new L2ProxyAdmin(_owner)));
     }
 }
 
@@ -210,6 +203,6 @@ contract L2ProxyAdmin_UpgradeAndCall_Test is ProxyAdmin_UpgradeAndCall_Test {
 /// @notice General backwards-compatibility tests for the `L2ProxyAdmin` contract.
 contract L2ProxyAdmin_Uncategorized_Test is ProxyAdmin_Uncategorized_Test {
     function _createAdmin(address _owner) internal override returns (IProxyAdmin) {
-        return _createL2ProxyAdmin(_owner);
+        return IProxyAdmin(address(new L2ProxyAdmin(_owner)));
     }
 }

--- a/packages/contracts-bedrock/test/universal/ProxyAdmin.t.sol
+++ b/packages/contracts-bedrock/test/universal/ProxyAdmin.t.sol
@@ -30,14 +30,17 @@ abstract contract ProxyAdmin_TestInit is Test {
 
     Proxy_SimpleStorage_Harness implementation;
 
-    function setUp() external {
-        // Deploy the proxy admin
-        admin = IProxyAdmin(
+    function _createAdmin(address _owner) internal virtual returns (IProxyAdmin) {
+        return IProxyAdmin(
             DeployUtils.create1({
                 _name: "ProxyAdmin",
-                _args: DeployUtils.encodeConstructor(abi.encodeCall(IProxyAdmin.__constructor__, (alice)))
+                _args: DeployUtils.encodeConstructor(abi.encodeCall(IProxyAdmin.__constructor__, (_owner)))
             })
         );
+    }
+
+    function setUp() public virtual {
+        admin = _createAdmin(alice);
 
         // Deploy the standard proxy
         proxy = IProxy(


### PR DESCRIPTION
This PR adds backwards-compatibility test coverage for the `L2ProxyAdmin` contract by rerunning all existing `ProxyAdmin` tests against it.

## Reason

`L2ProxyAdmin` replaces the existing `ProxyAdmin` predeploy. Other L2 contracts (`FeeVault`, `L1Withdrawer`, `FeeSplitter`) call `owner()` on it for access control. As an FMA follow-up ([FM3](https://github.com/ethereum-optimism/design-docs/blob/a937eab8e86a0479891e75ffcface87e508ae9fb/security/fma-l2cm.md?plain=1#L97-L123)), we need to verify that all existing `ProxyAdmin` functionality still works on `L2ProxyAdmin`. Rather than writing differential tests from scratch, reusing the existing `ProxyAdmin.t.sol` test paths proves backwards compatibility without duplicating test logic.

## Changes

- Extract a virtual `_createAdmin` hook in `ProxyAdmin_TestInit` so subclasses can override which admin contract gets deployed
- Make `ProxyAdmin_TestInit.setUp` `public virtual` (was `external`) to support test inheritance
- Add 10 backwards-compatibility test contracts in `L2ProxyAdmin.t.sol` that inherit from each `ProxyAdmin_*_Test` and override `_createAdmin` to deploy `L2ProxyAdmin`

Closes #19316