### PR TITLE
op-acceptance-tests: Add tests for L2 light CL follow source mode interop

### DIFF
--- a/op-acceptance-tests/tests/supernode/interop/follow_l2/init_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/follow_l2/init_test.go
@@ -1,0 +1,18 @@
+package follow_l2
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/compat"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+)
+
+func TestMain(m *testing.M) {
+	presets.DoMain(
+		m,
+		presets.WithTwoL2SupernodeFollowL2(0),
+		presets.WithReqRespSyncDisabled(),
+		presets.WithNoDiscovery(),
+		presets.WithCompatibleTypes(compat.SysGo),
+	)
+}

--- a/op-acceptance-tests/tests/supernode/interop/follow_l2/sync_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/follow_l2/sync_test.go
@@ -1,0 +1,97 @@
+package follow_l2
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+)
+
+func TestFollowSource_LocalSafeDivergesThenConverges(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	require := t.Require()
+	sys := presets.NewTwoL2SupernodeFollowL2(t, 0)
+
+	type chainPair struct {
+		name     string
+		source   *dsl.L2CLNode
+		follower *dsl.L2CLNode
+	}
+
+	chains := []chainPair{
+		{name: "A", source: sys.L2ACL, follower: sys.L2AFollowCL},
+		{name: "B", source: sys.L2BCL, follower: sys.L2BFollowCL},
+	}
+
+	// Initial sanity: followers are aligned with upstream on both local-safe and cross-safe.
+	initialChecks := make([]dsl.CheckFunc, 0, len(chains)*2)
+	for _, chain := range chains {
+		initialChecks = append(initialChecks,
+			chain.follower.MatchedFn(chain.source, types.LocalSafe, 20),
+			chain.follower.MatchedFn(chain.source, types.CrossSafe, 20),
+		)
+	}
+	dsl.CheckAll(t, initialChecks...)
+
+	pausedAt := sys.Supernode.EnsureInteropPaused(sys.L2ACL, sys.L2BCL, 10)
+	t.Logger().Info("interop paused", "timestamp", pausedAt)
+
+	// While interop is paused, local-safe should continue to advance and lead cross-safe.
+	require.Eventually(func() bool {
+		for _, chain := range chains {
+			sourceStatus := chain.source.SyncStatus()
+			followerStatus := chain.follower.SyncStatus()
+
+			if sourceStatus.LocalSafeL2.Number <= sourceStatus.SafeL2.Number+1 {
+				return false
+			}
+			if followerStatus.LocalSafeL2.Number <= followerStatus.SafeL2.Number+1 {
+				return false
+			}
+		}
+		return true
+	}, 2*time.Minute, 2*time.Second, "expected local-safe to lead cross-safe on source and follower")
+
+	// Core follow-source checks: follower must match source local-safe and cross-safe independently.
+	divergenceChecks := make([]dsl.CheckFunc, 0, len(chains)*2)
+	for _, chain := range chains {
+		divergenceChecks = append(divergenceChecks,
+			chain.follower.MatchedFn(chain.source, types.LocalSafe, 20),
+			chain.follower.MatchedFn(chain.source, types.CrossSafe, 20),
+		)
+	}
+	dsl.CheckAll(t, divergenceChecks...)
+
+	// Freeze new block production so interop can catch cross-safe up to local-safe.
+	sys.L2ACL.StopSequencer()
+	sys.L2BCL.StopSequencer()
+	t.Cleanup(func() {
+		sys.L2ACL.StartSequencer()
+		sys.L2BCL.StartSequencer()
+	})
+
+	sys.Supernode.ResumeInterop()
+
+	require.Eventually(func() bool {
+		for _, chain := range chains {
+			status := chain.follower.SyncStatus()
+			if status.LocalSafeL2.Hash != status.SafeL2.Hash || status.LocalSafeL2.Number != status.SafeL2.Number {
+				return false
+			}
+		}
+		return true
+	}, 3*time.Minute, 2*time.Second, "expected local-safe and cross-safe to converge on followers")
+
+	// Final sanity: follower and source converge to the same local-safe and cross-safe heads.
+	finalChecks := make([]dsl.CheckFunc, 0, len(chains)*2)
+	for _, chain := range chains {
+		finalChecks = append(finalChecks,
+			chain.follower.MatchedFn(chain.source, types.LocalSafe, 20),
+			chain.follower.MatchedFn(chain.source, types.CrossSafe, 20),
+		)
+	}
+	dsl.CheckAll(t, finalChecks...)
+}

--- a/op-devstack/presets/twol2_follow_l2.go
+++ b/op-devstack/presets/twol2_follow_l2.go
@@ -1,0 +1,53 @@
+package presets
+
+import (
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack/match"
+	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+)
+
+// TwoL2SupernodeFollowL2 extends TwoL2SupernodeInterop with one follow-source
+// verifier per chain.
+type TwoL2SupernodeFollowL2 struct {
+	TwoL2SupernodeInterop
+
+	L2AFollowCL *dsl.L2CLNode
+	L2BFollowCL *dsl.L2CLNode
+}
+
+// WithTwoL2SupernodeFollowL2 specifies a two-L2 system using a shared supernode
+// with interop enabled and one follow-source verifier per chain.
+// Use delaySeconds=0 for interop at genesis, or a positive value to test the transition from
+// normal safety to interop-verified safety.
+func WithTwoL2SupernodeFollowL2(delaySeconds uint64) stack.CommonOption {
+	return stack.MakeCommon(sysgo.DefaultTwoL2SupernodeFollowL2System(&sysgo.DefaultTwoL2SupernodeFollowL2SystemIDs{}, delaySeconds))
+}
+
+// NewTwoL2SupernodeFollowL2 creates a TwoL2SupernodeFollowL2 preset for acceptance tests.
+// Use delaySeconds=0 for interop at genesis, or a positive value to test the transition.
+// The delaySeconds must match what was passed to WithTwoL2SupernodeFollowL2 in TestMain.
+func NewTwoL2SupernodeFollowL2(t devtest.T, delaySeconds uint64) *TwoL2SupernodeFollowL2 {
+	base := NewTwoL2SupernodeInterop(t, delaySeconds)
+
+	l2a := base.system.L2Network(match.L2ChainA)
+	l2b := base.system.L2Network(match.L2ChainB)
+
+	followerCLAID := stack.NewL2CLNodeID("follower", l2a.ID().ChainID())
+	followerCLBID := stack.NewL2CLNodeID("follower", l2b.ID().ChainID())
+
+	followerCLA := l2a.L2CLNode(match.MatchElemFn[stack.L2CLNodeID, stack.L2CLNode](func(elem stack.L2CLNode) bool {
+		return elem.ID() == followerCLAID
+	}))
+
+	followerCLB := l2b.L2CLNode(match.MatchElemFn[stack.L2CLNodeID, stack.L2CLNode](func(elem stack.L2CLNode) bool {
+		return elem.ID() == followerCLBID
+	}))
+
+	return &TwoL2SupernodeFollowL2{
+		TwoL2SupernodeInterop: *base,
+		L2AFollowCL:           dsl.NewL2CLNode(followerCLA, base.ControlPlane),
+		L2BFollowCL:           dsl.NewL2CLNode(followerCLB, base.ControlPlane),
+	}
+}

--- a/op-devstack/presets/twol2_follow_l2.go
+++ b/op-devstack/presets/twol2_follow_l2.go
@@ -13,7 +13,9 @@ import (
 type TwoL2SupernodeFollowL2 struct {
 	TwoL2SupernodeInterop
 
+	L2AFollowEL *dsl.L2ELNode
 	L2AFollowCL *dsl.L2CLNode
+	L2BFollowEL *dsl.L2ELNode
 	L2BFollowCL *dsl.L2CLNode
 }
 
@@ -34,20 +36,30 @@ func NewTwoL2SupernodeFollowL2(t devtest.T, delaySeconds uint64) *TwoL2Supernode
 	l2a := base.system.L2Network(match.L2ChainA)
 	l2b := base.system.L2Network(match.L2ChainB)
 
+	followerELAID := stack.NewL2ELNodeID("follower", l2a.ID().ChainID())
 	followerCLAID := stack.NewL2CLNodeID("follower", l2a.ID().ChainID())
+	followerELBID := stack.NewL2ELNodeID("follower", l2b.ID().ChainID())
 	followerCLBID := stack.NewL2CLNodeID("follower", l2b.ID().ChainID())
 
+	followerELA := l2a.L2ELNode(match.MatchElemFn[stack.L2ELNodeID, stack.L2ELNode](func(elem stack.L2ELNode) bool {
+		return elem.ID() == followerELAID
+	}))
 	followerCLA := l2a.L2CLNode(match.MatchElemFn[stack.L2CLNodeID, stack.L2CLNode](func(elem stack.L2CLNode) bool {
 		return elem.ID() == followerCLAID
 	}))
 
+	followerELB := l2b.L2ELNode(match.MatchElemFn[stack.L2ELNodeID, stack.L2ELNode](func(elem stack.L2ELNode) bool {
+		return elem.ID() == followerELBID
+	}))
 	followerCLB := l2b.L2CLNode(match.MatchElemFn[stack.L2CLNodeID, stack.L2CLNode](func(elem stack.L2CLNode) bool {
 		return elem.ID() == followerCLBID
 	}))
 
 	return &TwoL2SupernodeFollowL2{
 		TwoL2SupernodeInterop: *base,
+		L2AFollowEL:           dsl.NewL2ELNode(followerELA, base.ControlPlane),
 		L2AFollowCL:           dsl.NewL2CLNode(followerCLA, base.ControlPlane),
+		L2BFollowEL:           dsl.NewL2ELNode(followerELB, base.ControlPlane),
 		L2BFollowCL:           dsl.NewL2CLNode(followerCLB, base.ControlPlane),
 	}
 }

--- a/op-devstack/sysgo/system_two_l2_follow_l2.go
+++ b/op-devstack/sysgo/system_two_l2_follow_l2.go
@@ -1,0 +1,61 @@
+package sysgo
+
+import (
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+// DefaultTwoL2SupernodeFollowL2SystemIDs defines a two-L2 interop+supernode setup
+// with one additional follow-source verifier per chain.
+type DefaultTwoL2SupernodeFollowL2SystemIDs struct {
+	DefaultTwoL2SystemIDs
+
+	L2AFollowerCL stack.L2CLNodeID
+	L2AFollowerEL stack.L2ELNodeID
+	L2BFollowerCL stack.L2CLNodeID
+	L2BFollowerEL stack.L2ELNodeID
+}
+
+func NewDefaultTwoL2SupernodeFollowL2SystemIDs(l1ID, l2AID, l2BID eth.ChainID) DefaultTwoL2SupernodeFollowL2SystemIDs {
+	return DefaultTwoL2SupernodeFollowL2SystemIDs{
+		DefaultTwoL2SystemIDs: NewDefaultTwoL2SystemIDs(l1ID, l2AID, l2BID),
+		L2AFollowerCL:         stack.NewL2CLNodeID("follower", l2AID),
+		L2AFollowerEL:         stack.NewL2ELNodeID("follower", l2AID),
+		L2BFollowerCL:         stack.NewL2CLNodeID("follower", l2BID),
+		L2BFollowerEL:         stack.NewL2ELNodeID("follower", l2BID),
+	}
+}
+
+// DefaultTwoL2SupernodeFollowL2System runs two L2 chains with:
+//   - shared supernode CL (interop enabled with configurable delay),
+//   - one follow-source verifier per chain in op-node light-CL mode.
+//
+// The follower for each chain tracks that chain's supernode CL proxy.
+func DefaultTwoL2SupernodeFollowL2System(dest *DefaultTwoL2SupernodeFollowL2SystemIDs, delaySeconds uint64) stack.Option[*Orchestrator] {
+	ids := NewDefaultTwoL2SupernodeFollowL2SystemIDs(DefaultL1ID, DefaultL2AID, DefaultL2BID)
+
+	var baseIDs DefaultTwoL2SystemIDs
+	opt := stack.Combine[*Orchestrator]()
+
+	// Build on top of the existing interop+supernode two-L2 topology.
+	opt.Add(DefaultSupernodeInteropTwoL2System(&baseIDs, delaySeconds))
+
+	// Chain A follower
+	opt.Add(WithL2ELNode(ids.L2AFollowerEL))
+	opt.Add(WithOpNodeFollowL2(ids.L2AFollowerCL, ids.L1CL, ids.L1EL, ids.L2AFollowerEL, ids.L2ACL))
+	// The chain source is a supernode proxy CL, which does not implement opp2p_* RPCs.
+	// Skip CL P2P wiring and rely on follow-source + EL P2P for data availability.
+	opt.Add(WithL2ELP2PConnection(ids.L2AEL, ids.L2AFollowerEL, false))
+
+	// Chain B follower
+	opt.Add(WithL2ELNode(ids.L2BFollowerEL))
+	opt.Add(WithOpNodeFollowL2(ids.L2BFollowerCL, ids.L1CL, ids.L1EL, ids.L2BFollowerEL, ids.L2BCL))
+	opt.Add(WithL2ELP2PConnection(ids.L2BEL, ids.L2BFollowerEL, false))
+
+	opt.Add(stack.Finally(func(orch *Orchestrator) {
+		ids.DefaultTwoL2SystemIDs = baseIDs
+		*dest = ids
+	}))
+
+	return opt
+}

--- a/op-devstack/sysgo/system_two_l2_follow_l2.go
+++ b/op-devstack/sysgo/system_two_l2_follow_l2.go
@@ -43,8 +43,9 @@ func DefaultTwoL2SupernodeFollowL2System(dest *DefaultTwoL2SupernodeFollowL2Syst
 	// Chain A follower
 	opt.Add(WithL2ELNode(ids.L2AFollowerEL))
 	opt.Add(WithOpNodeFollowL2(ids.L2AFollowerCL, ids.L1CL, ids.L1EL, ids.L2AFollowerEL, ids.L2ACL))
-	// The chain source is a supernode proxy CL, which does not implement opp2p_* RPCs.
+	// TODO(#19379): The chain source is a supernode proxy CL, which does not implement opp2p_* RPCs.
 	// Skip CL P2P wiring and rely on follow-source + EL P2P for data availability.
+	// opt.Add(WithL2CLP2PConnection(ids.L2ACL, ids.L2AFollowerCL))
 	opt.Add(WithL2ELP2PConnection(ids.L2AEL, ids.L2AFollowerEL, false))
 
 	// Chain B follower


### PR DESCRIPTION
**Description**

This adds a new preset for a network with two L2 light CLs, and an acceptance test that checks the logic added in #19330.

The test fails as expected if I run it on current `develop` HEAD and passes by running on top of `lightnode/localSafe`.

**Tests**

Adds `TestFollowSource_LocalSafeDivergesThenConverges`, which is under `op-acceptance-tests/tests/supernode/interop/` and should thus already be part of the `interop` gate.

**Additional context**

See #19330 and #19331

**Metadata**

- Fixes #19331