### PR TITLE
fix(op-node): pipeline reset to handle EL restarts gracefully

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -2035,6 +2035,7 @@ jobs:
             echo "export RUST_BINARY_PATH_KONA_SUPERVISOR=$ROOT_DIR/rust/target/release/kona-supervisor" >> "$BASH_ENV"
             echo "export RUST_BINARY_PATH_OP_RBUILDER=$BIN_DIR/op-rbuilder" >> "$BASH_ENV"
             echo "export RUST_BINARY_PATH_ROLLUP_BOOST=$BIN_DIR/rollup-boost" >> "$BASH_ENV"
+            echo "export OP_RETH_EXEC_PATH=$ROOT_DIR/rust/target/release/op-reth" >> "$BASH_ENV"
       # Restore cached Go modules
       - restore_cache:
           keys:

--- a/op-acceptance-tests/tests/sync/el_restart/el_restart_test.go
+++ b/op-acceptance-tests/tests/sync/el_restart/el_restart_test.go
@@ -1,0 +1,76 @@
+package el_restart
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+)
+
+// TestELRestartRecovery verifies that when an op-reth EL is restarted,
+// the op-node CL detects the state divergence (SYNCING response from FCU)
+// and triggers a reset to recover, catching up to the sequencer.
+//
+// This is a regression test for the bug where op-node unconditionally set
+// needFCUCall=false after any FCU response, causing a permanent stall when
+// the EL returned SYNCING after a restart.
+func TestELRestartRecovery(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewSingleChainMultiNodeWithoutCheck(t)
+
+	// 1. Wait for both nodes to be synced and advancing
+	dsl.CheckAll(t,
+		sys.L2CL.AdvancedFn(types.LocalUnsafe, 5, 30),
+		sys.L2CLB.AdvancedFn(types.LocalUnsafe, 5, 30),
+	)
+
+	// Record the verifier's state before stopping
+	verifierHeadBefore := sys.L2ELB.BlockRefByLabel(eth.Unsafe)
+	t.Logf("Verifier EL unsafe head before stop: %d (%s)", verifierHeadBefore.Number, verifierHeadBefore.Hash)
+
+	// 2. Stop the verifier EL (op-reth) — the CL stays running and will
+	//    get temporary errors until the EL comes back.
+	t.Logf("Stopping verifier EL (op-reth)")
+	sys.L2ELB.Stop()
+	t.Cleanup(func() {
+		// Ensure the EL is restarted even if the test fails, so cleanup works.
+		sys.L2ELB.Start()
+	})
+
+	// 3. Let the sequencer produce several more blocks while verifier EL is down.
+	//    This creates a gap between the CL's cached heads and the EL's actual state.
+	blocksToAdvance := uint64(10)
+	t.Logf("Waiting for sequencer to advance %d blocks while verifier EL is down", blocksToAdvance)
+	sys.L2CL.Advanced(types.LocalUnsafe, blocksToAdvance, 60)
+
+	seqHead := sys.L2EL.BlockRefByLabel(eth.Unsafe)
+	t.Logf("Sequencer EL unsafe head after gap: %d (%s)", seqHead.Number, seqHead.Hash)
+
+	// 4. Start the verifier EL back up.
+	//    op-reth restarts with persisted state, which may be behind the CL's cached heads.
+	//    When op-node sends FCU with its cached heads, op-reth returns SYNCING.
+	//    With the fix, op-node detects SYNCING in CL-sync mode and triggers a reset
+	//    via FindL2Heads to re-discover the EL's actual chain state.
+	t.Logf("Starting verifier EL (op-reth)")
+	sys.L2ELB.Start()
+
+	// Re-establish EL P2P peering so the verifier EL can sync blocks from the sequencer EL.
+	sys.L2ELB.PeerWith(sys.L2EL)
+
+	// 5. Wait for the verifier to recover and catch up.
+	//    Without the fix, the verifier would stall permanently here.
+	t.Logf("Waiting for verifier to recover and catch up to block %d", seqHead.Number)
+	dsl.CheckAll(t,
+		sys.L2ELB.ReachedFn(eth.Unsafe, seqHead.Number, 120),
+		sys.L2CLB.ReachedFn(types.LocalUnsafe, seqHead.Number, 120),
+	)
+
+	verifierHeadAfter := sys.L2ELB.BlockRefByLabel(eth.Unsafe)
+	t.Logf("Verifier EL recovered: unsafe head at %d (%s)", verifierHeadAfter.Number, verifierHeadAfter.Hash)
+
+	t.Require().GreaterOrEqual(verifierHeadAfter.Number, seqHead.Number,
+		"verifier should have caught up to sequencer's unsafe head")
+}

--- a/op-acceptance-tests/tests/sync/el_restart/el_restart_test.go
+++ b/op-acceptance-tests/tests/sync/el_restart/el_restart_test.go
@@ -57,8 +57,9 @@ func TestELRestartRecovery(gt *testing.T) {
 	t.Logf("Starting verifier EL (op-reth)")
 	sys.L2ELB.Start()
 
-	// Re-establish EL P2P peering so the verifier EL can sync blocks from the sequencer EL.
-	sys.L2ELB.PeerWith(sys.L2EL)
+	// No EL P2P re-peering needed: the verifier CL was never stopped, so it still
+	// receives blocks from the sequencer CL via CL P2P gossip and pushes them to
+	// the verifier EL via the Engine API.
 
 	// 5. Wait for the verifier to recover and catch up.
 	//    Without the fix, the verifier would stall permanently here.

--- a/op-acceptance-tests/tests/sync/el_restart/init_test.go
+++ b/op-acceptance-tests/tests/sync/el_restart/init_test.go
@@ -1,0 +1,50 @@
+package el_restart
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/compat"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+)
+
+func TestMain(m *testing.M) {
+	presets.DoMain(m,
+		WithOpNodeRethVerifier(),
+		presets.WithCompatibleTypes(compat.SysGo),
+	)
+}
+
+// WithOpNodeRethVerifier creates a single-chain multi-node system where:
+//   - Sequencer: op-geth EL + op-node CL
+//   - Verifier: op-reth EL + op-node CL
+//
+// This allows testing EL restart recovery when op-reth loses in-memory state.
+func WithOpNodeRethVerifier() stack.CommonOption {
+	var ids sysgo.DefaultSingleChainMultiNodeSystemIDs
+	return stack.MakeCommon(opNodeRethVerifierSystem(&ids))
+}
+
+func opNodeRethVerifierSystem(dest *sysgo.DefaultSingleChainMultiNodeSystemIDs) stack.Option[*sysgo.Orchestrator] {
+	ids := sysgo.NewDefaultSingleChainMultiNodeSystemIDs(sysgo.DefaultL1ID, sysgo.DefaultL2AID)
+
+	opt := stack.Combine[*sysgo.Orchestrator]()
+	// Sequencer system: op-geth + op-node + batcher + proposer
+	opt.Add(sysgo.DefaultMinimalSystem(&ids.DefaultMinimalSystemIDs))
+
+	// Verifier EL: use op-reth explicitly (instead of WithL2ELNode which defaults to op-geth)
+	opt.Add(sysgo.WithOpReth(ids.L2ELB))
+	// Verifier CL: op-node (default for WithL2CLNode)
+	opt.Add(sysgo.WithL2CLNode(ids.L2CLB, ids.L1CL, ids.L1EL, ids.L2ELB))
+
+	// P2P connections between sequencer and verifier
+	opt.Add(sysgo.WithL2CLP2PConnection(ids.L2CL, ids.L2CLB))
+	opt.Add(sysgo.WithL2ELP2PConnection(ids.L2EL, ids.L2ELB, false))
+
+	opt.Add(stack.Finally(func(orch *sysgo.Orchestrator) {
+		*dest = ids
+	}))
+
+	return opt
+}

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -546,6 +546,12 @@ func (e *EngineController) tryUpdateEngineInternal(ctx context.Context) error {
 			return derive.NewTemporaryError(fmt.Errorf("failed to sync forkchoice with engine: %w", err))
 		}
 	}
+	// Verify the FCU response status is acceptable. In CL-sync mode, only VALID is acceptable.
+	// If the EL returns SYNCING (e.g. after an EL restart where in-memory state was lost),
+	// trigger a reset to re-discover the EL's actual chain state via FindL2Heads.
+	if !e.checkForkchoiceUpdatedStatus(fcRes.PayloadStatus.Status) {
+		return derive.NewResetError(fmt.Errorf("forkchoice update returned unexpected status %s, need reset to re-sync with engine", fcRes.PayloadStatus.Status))
+	}
 	if fcRes.PayloadStatus.Status == eth.ExecutionValid {
 		e.requestForkchoiceUpdate(ctx)
 	}

--- a/op-node/rollup/engine/engine_controller_test.go
+++ b/op-node/rollup/engine/engine_controller_test.go
@@ -514,3 +514,102 @@ func TestEngineController_FinalizedHead(t *testing.T) {
 		})
 	}
 }
+
+// TestTryUpdateEngine_SyncingInCLModeTriggersReset tests that when the EL returns SYNCING
+// during a forkchoice update in CL-sync mode (e.g. after an EL restart), the engine controller
+// triggers a reset to re-discover the EL's actual chain state.
+func TestTryUpdateEngine_SyncingInCLModeTriggersReset(t *testing.T) {
+	cfg := &rollup.Config{
+		Genesis: rollup.Genesis{
+			L2Time: 1000,
+		},
+		BlockTime: 2,
+	}
+
+	mockEngine := &testutils.MockEngine{}
+	emitter := &testutils.MockEmitter{}
+	ec := NewEngineController(context.Background(), mockEngine, testlog.Logger(t, 0), metrics.NoopMetrics, cfg, &sync.Config{SyncMode: sync.CLSync}, false, &testutils.MockL1Source{}, emitter, nil)
+
+	// Set up valid internal state so initializeUnknowns succeeds
+	unsafeRef := eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100}
+	safeRef := eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 80}
+	finalRef := eth.L2BlockRef{Hash: common.Hash{0xcc}, Number: 50}
+
+	ec.unsafeHead = unsafeRef
+	ec.SetLocalSafeHead(safeRef)
+	ec.SetFinalizedHead(finalRef)
+	ec.needFCUCall = true
+
+	// Mock initializeUnknowns calls
+	mockEngine.ExpectL2BlockRefByLabel(eth.Unsafe, unsafeRef, nil)
+	mockEngine.ExpectL2BlockRefByLabel(eth.Safe, safeRef, nil)
+	mockEngine.ExpectL2BlockRefByLabel(eth.Finalized, finalRef, nil)
+
+	// Mock ForkchoiceUpdate to return SYNCING (simulating EL restart)
+	mockEngine.ExpectForkchoiceUpdate(
+		&eth.ForkchoiceState{
+			HeadBlockHash:      unsafeRef.Hash,
+			SafeBlockHash:      safeRef.Hash,
+			FinalizedBlockHash: finalRef.Hash,
+		},
+		nil,
+		&eth.ForkchoiceUpdatedResult{
+			PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionSyncing},
+		},
+		nil,
+	)
+
+	// Call tryUpdateEngineInternal - should return a reset error
+	err := ec.tryUpdateEngineInternal(context.Background())
+	require.Error(t, err)
+	require.True(t, errors.Is(err, derive.ErrReset), "expected reset error, got: %v", err)
+	require.Contains(t, err.Error(), "unexpected status")
+}
+
+// TestTryUpdateEngine_SyncingInELSyncModeIsAccepted tests that SYNCING is accepted
+// in EL-sync mode (existing behavior preserved).
+func TestTryUpdateEngine_SyncingInELSyncModeIsAccepted(t *testing.T) {
+	cfg := &rollup.Config{
+		Genesis: rollup.Genesis{
+			L2Time: 1000,
+		},
+		BlockTime: 2,
+	}
+
+	mockEngine := &testutils.MockEngine{}
+	emitter := &testutils.MockEmitter{}
+	ec := NewEngineController(context.Background(), mockEngine, testlog.Logger(t, 0), metrics.NoopMetrics, cfg, &sync.Config{SyncMode: sync.ELSync}, false, &testutils.MockL1Source{}, emitter, nil)
+
+	// Set up valid internal state
+	unsafeRef := eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100}
+	safeRef := eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 80}
+	finalRef := eth.L2BlockRef{Hash: common.Hash{0xcc}, Number: 50}
+
+	ec.unsafeHead = unsafeRef
+	ec.SetLocalSafeHead(safeRef)
+	ec.SetFinalizedHead(finalRef)
+	ec.needFCUCall = true
+
+	// Mock initializeUnknowns calls
+	mockEngine.ExpectL2BlockRefByLabel(eth.Unsafe, unsafeRef, nil)
+	mockEngine.ExpectL2BlockRefByLabel(eth.Safe, safeRef, nil)
+	mockEngine.ExpectL2BlockRefByLabel(eth.Finalized, finalRef, nil)
+
+	// Mock ForkchoiceUpdate to return SYNCING
+	mockEngine.ExpectForkchoiceUpdate(
+		&eth.ForkchoiceState{
+			HeadBlockHash:      unsafeRef.Hash,
+			SafeBlockHash:      safeRef.Hash,
+			FinalizedBlockHash: finalRef.Hash,
+		},
+		nil,
+		&eth.ForkchoiceUpdatedResult{
+			PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionSyncing},
+		},
+		nil,
+	)
+
+	// Call tryUpdateEngineInternal - should succeed in EL-sync mode
+	err := ec.tryUpdateEngineInternal(context.Background())
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Summary

- When `op-reth` is restarted, it loses in-memory chain state and returns `SYNCING` to forkchoice updates
- Previously, `tryUpdateEngineInternal` unconditionally set `needFCUCall=false` even for `SYNCING` responses, causing a permanent stall
- This fix validates the FCU response status using the existing `checkForkchoiceUpdatedStatus` method, triggering a pipeline reset in CL-sync mode when `SYNCING` is returned
- The reset runs `FindL2Heads` to re-discover the EL's actual chain state, resolving the stall in a single reset cycle
- EL-sync mode behavior is unchanged (SYNCING remains accepted)

## Root Cause

`tryUpdateEngineInternal` unconditionally set `needFCUCall = false` after any successful FCU RPC call, regardless of the payload status. When the EL returned `SYNCING` (which is not an RPC error), the flag was cleared, and since no new events set it back to `true`, op-node never retried the forkchoice update. This doesn't affect op-geth because geth persists the head block hash synchronously, so its head survives restarts. op-reth uses async persistence with an in-memory canonical state, so restarts can cause the head to revert.

## Tests Added

- unit tests: 
    - `TestTryUpdateEngine_SyncingInCLModeTriggersReset` verifies SYNCING triggers reset in CL-sync mode
    - `TestTryUpdateEngine_SyncingInELSyncModeIsAccepted` verifies SYNCING is still accepted in EL-sync mode
- integration tests:
    - op-acceptance-tests/tests/sync/el_restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)