### PR TITLE
fix(kona-engine): reset on SYNCING FCU response after EL sync completed

### DIFF
--- a/rust/kona/crates/node/engine/src/task_queue/tasks/synchronize/task.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/synchronize/task.rs
@@ -65,9 +65,18 @@ impl<EngineClient_: EngineClient> SynchronizeTask<EngineClient_> {
                 Ok(())
             }
             PayloadStatusEnum::Syncing => {
-                // If we're not building a new payload, we're driving EL sync.
-                debug!(target: "engine", "Attempting to update forkchoice state while EL syncing");
-                Ok(())
+                if state.el_sync_finished {
+                    // EL was previously synced but is now returning SYNCING,
+                    // indicating state divergence (e.g. after EL restart where
+                    // in-memory state was lost). Trigger a reset to re-discover
+                    // the EL's actual chain state.
+                    warn!(target: "engine", "EL returned SYNCING after sync was previously completed, triggering reset");
+                    Err(SynchronizeTaskError::InvalidForkchoiceState)
+                } else {
+                    // EL sync still in progress, SYNCING is expected.
+                    debug!(target: "engine", "Attempting to update forkchoice state while EL syncing");
+                    Ok(())
+                }
             }
             s => {
                 // Other codes are not expected.


### PR DESCRIPTION
## Summary

- When an EL (e.g. op-reth) is restarted, it may lose in-memory chain state and return `SYNCING` to forkchoice updates
- Previously, `SynchronizeTask::check_forkchoice_updated_status` treated `SYNCING` as `Ok(())` unconditionally, causing kona-node's internal state to advance while the EL is still catching up
- This fix checks `state.el_sync_finished`: if the EL was previously synced but now returns `SYNCING`, it returns `InvalidForkchoiceState` (which has `Reset` severity), triggering `find_starting_forkchoice` to re-query the EL's actual heads
- During initial EL sync (`el_sync_finished=false`), `SYNCING` remains accepted (existing behavior preserved)

## Root Cause

`SynchronizeTask::check_forkchoice_updated_status` returns `Ok(())` for `PayloadStatusEnum::Syncing` unconditionally. After the task returns `Ok`, the internal state is updated at line 143 (`state.sync_state = new_sync_state`). Since `InsertTask` delegates FCU to `SynchronizeTask`, new P2P payloads keep "successfully" advancing the CL's view of the chain while the EL is still syncing back to its persisted state.

This is the kona-engine counterpart to the same bug in op-node's `tryUpdateEngineInternal`.

## Test plan

- [x] `cargo check -p kona-engine` compiles successfully
- [x] `cargo test -p kona-engine` — all 56 tests pass
- [ ] Manual test: restart op-reth while kona-node is running and verify kona-node recovers without restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)