### PR TITLE
fix(op-supernode): Fix race condition in virtual node Stop/Start lifecycle

### DIFF
--- a/op-acceptance-tests/tests/supernode/interop/activation/activation_after_genesis_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/activation/activation_after_genesis_test.go
@@ -13,7 +13,6 @@ import (
 // AFTER genesis. This verifies that VerifiedAt (via superroot_atTimestamp) returns
 // verified data for timestamps both before and after the activation boundary.
 func TestSupernodeInteropActivationAfterGenesis(gt *testing.T) {
-	gt.Skip("this test is unstable")
 	t := devtest.ParallelT(gt)
 	sys := presets.NewTwoL2SupernodeInterop(t, InteropActivationDelay)
 

--- a/op-acceptance-tests/tests/supernode/interop/activation/activation_after_genesis_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/activation/activation_after_genesis_test.go
@@ -13,6 +13,7 @@ import (
 // AFTER genesis. This verifies that VerifiedAt (via superroot_atTimestamp) returns
 // verified data for timestamps both before and after the activation boundary.
 func TestSupernodeInteropActivationAfterGenesis(gt *testing.T) {
+	gt.Skip("this test is unstable")
 	t := devtest.ParallelT(gt)
 	sys := presets.NewTwoL2SupernodeInterop(t, InteropActivationDelay)
 

--- a/op-supernode/supernode/chain_container/virtual_node/virtual_node.go
+++ b/op-supernode/supernode/chain_container/virtual_node/virtual_node.go
@@ -72,9 +72,10 @@ type simpleVirtualNode struct {
 	initOverload     *rollupNode.InitializationOverrides // Shared resources which are overridden by the supernode
 	innerNodeFactory innerNodeFactory                    // Factory function to create inner node (overloadable for testing)
 
-	mu     sync.Mutex         // Protects state transitions
-	state  VNState            // Current lifecycle state
-	cancel context.CancelFunc // Cancels the running context
+	mu         sync.Mutex         // Protects state transitions
+	state      VNState            // Current lifecycle state
+	cancel     context.CancelFunc // Cancels the running context
+	preStopped bool               // Stop() was called before Start() ran; Start() exits immediately
 }
 
 func generateVirtualNodeID() string {
@@ -96,12 +97,19 @@ func NewVirtualNode(cfg *opnodecfg.Config, log gethlog.Logger, initOverload *rol
 }
 
 func (v *simpleVirtualNode) Start(ctx context.Context) error {
-	// Accquire lock while setting up inner node
+	// Acquire lock while setting up inner node
 	v.mu.Lock()
 	if v.state != VNStateNotStarted {
 		v.mu.Unlock()
 		v.log.Debug("virtual node not in a valid state to start", "state", v.state)
 		return ErrVirtualNodeCantStart
+	}
+	// Stop() was called before Start() had a chance to run.  Exit immediately so the
+	// chain-container restart loop can observe c.stop and break cleanly.
+	if v.preStopped {
+		v.state = VNStateStopped
+		v.mu.Unlock()
+		return nil
 	}
 	if v.cfg == nil {
 		v.mu.Unlock()
@@ -134,27 +142,39 @@ func (v *simpleVirtualNode) Start(ctx context.Context) error {
 	// Don't hold the lock while running or waiting for inner node to stop
 
 	// Run inner node in goroutine
-	// and await any signal to exit (Stop(), parent ctx, or inner error)
-	var innerErr error = nil
+	// and await any signal to exit (Stop(), parent ctx, or inner error).
+	// Use a buffered channel so the goroutine never blocks on send, and so
+	// the main goroutine can collect the error without a data race.
+	// Use n (captured above) rather than v.inner to avoid racing with the
+	// v.inner = nil write that happens after <-runCtx.Done().
+	innerErrCh := make(chan error, 1)
 	go func() {
-		innerErr = v.inner.Start(runCtx)
+		innerErrCh <- n.Start(runCtx)
 	}()
 	<-runCtx.Done()
 
-	// Clean up with lock to end of function
+	// Update state and capture inner under the lock, then release before blocking.
+	// Holding the mutex across inner.Stop() (up to 30 s) would freeze concurrent
+	// readers such as SyncStatus, SafeHeadAtL1, and L1AtSafeHead.
 	v.mu.Lock()
-	defer v.mu.Unlock()
 	v.state = VNStateStopped
 	v.cancel = nil
+	inner := v.inner
+	v.inner = nil // nil out now so readers see VNStateNotRunning immediately
+	v.mu.Unlock()
 
-	// Stop the inner node if it's still running
-	if v.inner != nil {
+	// Stop the inner node outside the lock
+	if inner != nil {
 		stopCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
-		if err := v.inner.Stop(stopCtx); err != nil {
+		if err := inner.Stop(stopCtx); err != nil {
 			v.log.Error("error stopping inner node", "err", err)
 		}
 	}
+
+	// Collect the inner goroutine's return value. inner.Stop() guarantees that
+	// n.Start() has returned, so this receive completes without blocking.
+	innerErr := <-innerErrCh
 
 	// Return inner error if that's what caused the cancellation, otherwise context error
 	if cancelErr != nil {
@@ -177,8 +197,12 @@ func (v *simpleVirtualNode) Stop(ctx context.Context) error {
 	v.mu.Lock()
 	defer v.mu.Unlock()
 
+	// Always mark as pre-stopped. If Start() hasn't run yet it will see this flag
+	// and exit immediately, closing the race window in the chain-container restart loop.
+	v.preStopped = true
+
 	if v.state != VNStateRunning {
-		return nil // Already stopped or not started
+		return nil // Already stopped, never started, or pre-stopped
 	}
 
 	// Cancel the run context to trigger shutdown

--- a/op-supernode/supernode/chain_container/virtual_node/virtual_node.go
+++ b/op-supernode/supernode/chain_container/virtual_node/virtual_node.go
@@ -57,9 +57,10 @@ type innerNodeFactory func(ctx context.Context, cfg *opnodecfg.Config, log gethl
 type VNState int
 
 const (
-	VNStateNotStarted VNState = iota
+	VNStateNotStarted  VNState = iota
 	VNStateRunning
 	VNStateStopped
+	VNStatePreStopped // Stop() called before Start() ran; Start() exits immediately
 )
 
 type simpleVirtualNode struct {
@@ -72,10 +73,9 @@ type simpleVirtualNode struct {
 	initOverload     *rollupNode.InitializationOverrides // Shared resources which are overridden by the supernode
 	innerNodeFactory innerNodeFactory                    // Factory function to create inner node (overloadable for testing)
 
-	mu         sync.Mutex         // Protects state transitions
-	state      VNState            // Current lifecycle state
-	cancel     context.CancelFunc // Cancels the running context
-	preStopped bool               // Stop() was called before Start() ran; Start() exits immediately
+	mu     sync.Mutex         // Protects state transitions
+	state  VNState            // Current lifecycle state
+	cancel context.CancelFunc // Cancels the running context
 }
 
 func generateVirtualNodeID() string {
@@ -99,17 +99,17 @@ func NewVirtualNode(cfg *opnodecfg.Config, log gethlog.Logger, initOverload *rol
 func (v *simpleVirtualNode) Start(ctx context.Context) error {
 	// Acquire lock while setting up inner node
 	v.mu.Lock()
+	// Stop() was called before Start() had a chance to run.  Exit immediately so the
+	// chain-container restart loop can observe c.stop and break cleanly.
+	if v.state == VNStatePreStopped {
+		v.state = VNStateStopped
+		v.mu.Unlock()
+		return nil
+	}
 	if v.state != VNStateNotStarted {
 		v.mu.Unlock()
 		v.log.Debug("virtual node not in a valid state to start", "state", v.state)
 		return ErrVirtualNodeCantStart
-	}
-	// Stop() was called before Start() had a chance to run.  Exit immediately so the
-	// chain-container restart loop can observe c.stop and break cleanly.
-	if v.preStopped {
-		v.state = VNStateStopped
-		v.mu.Unlock()
-		return nil
 	}
 	if v.cfg == nil {
 		v.mu.Unlock()
@@ -197,12 +197,15 @@ func (v *simpleVirtualNode) Stop(ctx context.Context) error {
 	v.mu.Lock()
 	defer v.mu.Unlock()
 
-	// Always mark as pre-stopped. If Start() hasn't run yet it will see this flag
-	// and exit immediately, closing the race window in the chain-container restart loop.
-	v.preStopped = true
+	// If not yet started, transition to PreStopped so Start() exits immediately,
+	// closing the race window in the chain-container restart loop.
+	if v.state == VNStateNotStarted {
+		v.state = VNStatePreStopped
+		return nil
+	}
 
 	if v.state != VNStateRunning {
-		return nil // Already stopped, never started, or pre-stopped
+		return nil // Already stopped or pre-stopped
 	}
 
 	// Cancel the run context to trigger shutdown

--- a/op-supernode/supernode/chain_container/virtual_node/virtual_node_test.go
+++ b/op-supernode/supernode/chain_container/virtual_node/virtual_node_test.go
@@ -312,7 +312,7 @@ func TestVirtualNode_Lifecycle(t *testing.T) {
 
 		// Call Stop() while still in NotStarted state
 		require.NoError(t, vn.Stop(context.Background()))
-		require.Equal(t, VNStateNotStarted, vn.State(), "state should still be NotStarted before Start is called")
+		require.Equal(t, VNStatePreStopped, vn.State(), "state should be PreStopped after Stop() before Start()")
 
 		startDone := make(chan error, 1)
 		go func() { startDone <- vn.Start(context.Background()) }()

--- a/op-supernode/supernode/chain_container/virtual_node/virtual_node_test.go
+++ b/op-supernode/supernode/chain_container/virtual_node/virtual_node_test.go
@@ -298,6 +298,64 @@ func TestVirtualNode_Lifecycle(t *testing.T) {
 		require.NoError(t, vn.Stop(ctx))
 	})
 
+	// TestVirtualNode_StopBeforeStart verifies the preStopped race fix:
+	// if Stop() is called before Start() has a chance to run, Start() must
+	// return immediately rather than hanging on <-runCtx.Done() forever.
+	t.Run("Stop before Start causes Start to return immediately", func(t *testing.T) {
+		mock := newMockInnerNode()
+		mock.startFunc = func(ctx context.Context) {
+			<-ctx.Done()
+		}
+
+		vn := NewVirtualNode(cfg, log, initOverload, appVersion)
+		vn.innerNodeFactory = createMockFactory(mock)
+
+		// Call Stop() while still in NotStarted state
+		require.NoError(t, vn.Stop(context.Background()))
+		require.Equal(t, VNStateNotStarted, vn.State(), "state should still be NotStarted before Start is called")
+
+		startDone := make(chan error, 1)
+		go func() { startDone <- vn.Start(context.Background()) }()
+
+		select {
+		case err := <-startDone:
+			require.NoError(t, err, "Start should return nil when preStopped")
+			require.Equal(t, VNStateStopped, vn.State())
+			require.False(t, mock.started, "inner node should never have been started")
+		case <-time.After(2 * time.Second):
+			t.Fatal("Start hung after Stop-before-Start — preStopped fix not working")
+		}
+	})
+
+	// TestVirtualNode_StopRacesWithStart stress-tests the preStopped fix by
+	// concurrently calling Stop() and Start() many times and verifying Start()
+	// always returns within a reasonable deadline (no permanent hang).
+	t.Run("Stop racing with Start never hangs", func(t *testing.T) {
+		const iterations = 50
+		for i := 0; i < iterations; i++ {
+			mock := newMockInnerNode()
+			mock.startFunc = func(ctx context.Context) {
+				<-ctx.Done()
+			}
+
+			vn := NewVirtualNode(cfg, log, initOverload, appVersion)
+			vn.innerNodeFactory = createMockFactory(mock)
+
+			startDone := make(chan error, 1)
+			go func() { startDone <- vn.Start(context.Background()) }()
+
+			// Stop immediately — may race before or after Start acquires the lock
+			_ = vn.Stop(context.Background())
+
+			select {
+			case <-startDone:
+				// Good — Start returned
+			case <-time.After(2 * time.Second):
+				t.Fatalf("iteration %d: Start hung — Stop-vs-Start race not handled", i)
+			}
+		}
+	})
+
 }
 
 // TestVirtualNode_InnerNodeIntegration tests interaction with inner node
@@ -326,7 +384,15 @@ func TestVirtualNode_InnerNodeIntegration(t *testing.T) {
 		}()
 
 		require.Eventually(t, func() bool {
-			return vn.State() == VNStateRunning && mock.started
+			if vn.State() != VNStateRunning {
+				return false
+			}
+			select {
+			case <-mock.startCh:
+				return true
+			default:
+				return false
+			}
 		}, 1*time.Second, 10*time.Millisecond)
 	})
 


### PR DESCRIPTION
Add preStopped flag to handle the case where Stop() is called before Start() has a chance to run. Without this fix, Start() would hang forever waiting on <-runCtx.Done() because the cancel function was never set.

Also fix mutex contention by releasing the lock before calling inner.Stop(), which can block for up to 30 seconds. This prevents freezing concurrent readers like SyncStatus.
