### PR TITLE
feat(op-alt-da): allow Keccak256 commitments without DAChallengeAddress

### DIFF
--- a/op-alt-da/damgr.go
+++ b/op-alt-da/damgr.go
@@ -50,7 +50,7 @@ type HeadSignalFn func(eth.L1BlockRef)
 
 // Config is the relevant subset of rollup config for AltDA.
 type Config struct {
-	// Required for filtering contract events
+	// DAChallengeContractAddress filters challenge contract events. Zero means no challenge contract.
 	DAChallengeContractAddress common.Address
 	// Allowed CommitmentType
 	CommitmentType CommitmentType
@@ -406,7 +406,7 @@ func (d *DA) loadChallengeEvents(ctx context.Context, l1 L1Fetcher, block eth.Bl
 func (d *DA) fetchChallengeLogs(ctx context.Context, l1 L1Fetcher, block eth.BlockID) ([]*types.Log, error) {
 	var logs []*types.Log
 	// Don't look at the challenge contract if there is no challenge contract.
-	if d.cfg.CommitmentType == GenericCommitmentType {
+	if d.cfg.DAChallengeContractAddress == (common.Address{}) {
 		return logs, nil
 	}
 	//cached with deposits events call so not expensive

--- a/op-alt-da/damgr_test.go
+++ b/op-alt-da/damgr_test.go
@@ -444,3 +444,37 @@ func TestAdvanceChallengeOrigin(t *testing.T) {
 	_, has = state.GetChallenge(comm, 14)
 	require.False(t, has)
 }
+
+// TestFetchChallengeLogsNoChallengeContract verifies that when DAChallengeContractAddress is zero
+// (no on-chain challenge contract), fetchChallengeLogs skips receipt scanning entirely.
+// This supports Keccak256 commitments without a challenge contract (e.g., permissioned Validium with ZK proofs).
+func TestFetchChallengeLogsNoChallengeContract(t *testing.T) {
+	logger := testlog.Logger(t, log.LevelWarn)
+	ctx := context.Background()
+
+	l1F := &mockL1Fetcher{}
+	defer l1F.AssertExpectations(t)
+
+	storage := NewMockDAClient(logger)
+
+	// Keccak256 commitment type with no challenge contract
+	pcfg := Config{
+		ChallengeWindow: 90,
+		ResolveWindow:   90,
+		CommitmentType:  Keccak256CommitmentType,
+	}
+
+	state := NewState(logger, &NoopMetrics{}, pcfg)
+	da := NewAltDAWithState(logger, pcfg, storage, &NoopMetrics{}, state)
+
+	bhash := common.HexToHash("0xd438144ffab918b1349e7cd06889c26800c26d8edc34d64f750e3e097166a09c")
+	bn := uint64(19)
+	id := eth.BlockID{Number: bn, Hash: bhash}
+
+	// No FetchReceipts expectation set — if fetchChallengeLogs tries to call it, the mock will fail.
+	err := da.AdvanceChallengeOrigin(ctx, l1F, id)
+	require.NoError(t, err)
+
+	// Verify the challenge origin was still advanced
+	require.Equal(t, bn, da.challengeOrigin.Number)
+}

--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -995,9 +995,7 @@ func (d *L1DependenciesConfig) CheckAddresses(dependencyContext DependencyContex
 		return fmt.Errorf("%w: OptimismPortalProxy cannot be address(0)", ErrInvalidDeployConfig)
 	}
 
-	if dependencyContext.UseAltDA && dependencyContext.DACommitmentType == altda.KeccakCommitmentString && d.DAChallengeProxy == (common.Address{}) {
-		return fmt.Errorf("%w: DAChallengeContract cannot be address(0) when using alt-da mode", ErrInvalidDeployConfig)
-	} else if dependencyContext.UseAltDA && dependencyContext.DACommitmentType == altda.GenericCommitmentString && d.DAChallengeProxy != (common.Address{}) {
+	if dependencyContext.UseAltDA && dependencyContext.DACommitmentType == altda.GenericCommitmentString && d.DAChallengeProxy != (common.Address{}) {
 		return fmt.Errorf("%w: DAChallengeContract must be address(0) when using generic commitments in alt-da mode", ErrInvalidDeployConfig)
 	}
 	return nil

--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -54,7 +54,8 @@ type Genesis struct {
 }
 
 type AltDAConfig struct {
-	// L1 DataAvailabilityChallenge contract proxy address
+	// L1 DataAvailabilityChallenge contract proxy address.
+	// Optional for Keccak256 commitments; must be zero for GenericCommitment.
 	DAChallengeAddress common.Address `json:"da_challenge_contract_address,omitempty"`
 	// CommitmentType specifies which commitment type can be used. Defaults to Keccak (type 0) if not present
 	CommitmentType string `json:"da_commitment_type"`
@@ -399,16 +400,14 @@ func (cfg *Config) ProbablyMissingPectraBlobSchedule() bool {
 	return pragueTime >= cfg.Genesis.L2Time
 }
 
-// validateAltDAConfig checks the two approaches to configuring alt-da mode.
-// If the legacy values are set, they are copied to the new location. If both are set, they are check for consistency.
+// validateAltDAConfig checks that the AltDA configuration is internally consistent.
+// GenericCommitment must not have a DAChallengeAddress set; Keccak256 may optionally have one.
 func validateAltDAConfig(cfg *Config) error {
 	if cfg.AltDAConfig != nil {
 		if !(cfg.AltDAConfig.CommitmentType == altda.KeccakCommitmentString || cfg.AltDAConfig.CommitmentType == altda.GenericCommitmentString) {
 			return fmt.Errorf("invalid commitment type: %v", cfg.AltDAConfig.CommitmentType)
 		}
-		if cfg.AltDAConfig.CommitmentType == altda.KeccakCommitmentString && cfg.AltDAConfig.DAChallengeAddress == (common.Address{}) {
-			return errors.New("Must set da_challenge_contract_address for keccak commitments")
-		} else if cfg.AltDAConfig.CommitmentType == altda.GenericCommitmentString && cfg.AltDAConfig.DAChallengeAddress != (common.Address{}) {
+		if cfg.AltDAConfig.CommitmentType == altda.GenericCommitmentString && cfg.AltDAConfig.DAChallengeAddress != (common.Address{}) {
 			return errors.New("Must set empty da_challenge_contract_address for generic commitments")
 		}
 	}

--- a/op-node/rollup/types_test.go
+++ b/op-node/rollup/types_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 
+	altda "github.com/ethereum-optimism/optimism/op-alt-da"
 	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/ptr"
@@ -1089,4 +1090,63 @@ func TestConfig_ActivateAtGenesis(t *testing.T) {
 		}
 		require.Zero(t, cfg)
 	})
+}
+
+func TestValidateAltDAConfig(t *testing.T) {
+	tests := []struct {
+		name      string
+		altDA     *AltDAConfig
+		expectErr string
+	}{
+		{
+			name:  "nil config is valid",
+			altDA: nil,
+		},
+		{
+			name: "keccak with challenge address",
+			altDA: &AltDAConfig{
+				CommitmentType:     altda.KeccakCommitmentString,
+				DAChallengeAddress: common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678"),
+			},
+		},
+		{
+			name: "keccak without challenge address",
+			altDA: &AltDAConfig{
+				CommitmentType: altda.KeccakCommitmentString,
+			},
+		},
+		{
+			name: "generic without challenge address",
+			altDA: &AltDAConfig{
+				CommitmentType: altda.GenericCommitmentString,
+			},
+		},
+		{
+			name: "generic with challenge address is invalid",
+			altDA: &AltDAConfig{
+				CommitmentType:     altda.GenericCommitmentString,
+				DAChallengeAddress: common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678"),
+			},
+			expectErr: "Must set empty da_challenge_contract_address for generic commitments",
+		},
+		{
+			name: "invalid commitment type",
+			altDA: &AltDAConfig{
+				CommitmentType: "InvalidType",
+			},
+			expectErr: "invalid commitment type: InvalidType",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{AltDAConfig: tt.altDA}
+			err := validateAltDAConfig(cfg)
+			if tt.expectErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tt.expectErr)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary

- Make the DA challenge contract optional for Keccak256 commitments, supporting permissioned Validium chains where ZK proofs (e.g., op-succinct/SP1) provide cryptographic data integrity without on-chain challenges
- Previously, `validateAltDAConfig` required `DAChallengeAddress != address(0)` for Keccak256, forcing users to pass a dummy address as a workaround
- Change `fetchChallengeLogs` guard from commitment-type-based to address-based, which is semantically correct ("skip if no challenge contract")

## Motivation

In a permissioned Validium model, the chain operator runs the DA server and ZK proofs verify `keccak256(data) == commitment` inside the zkVM. The on-chain challenge mechanism is redundant because there is no untrusted party to challenge and data integrity is already proven cryptographically.

## Test plan

- [x] `TestValidateAltDAConfig` — 6 table-driven cases covering all commitment type + address combinations
- [x] `TestFetchChallengeLogsNoChallengeContract` — verifies Keccak256 + zero address skips receipt scanning
- [x] Existing `TestConfig_Check`, `TestAdvanceChallengeOrigin`, and genesis config tests still pass