### PR TITLE
chore: add make to mise.toml

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -15,6 +15,7 @@ shellcheck = "0.10.0"
 shfmt = "3.11.0"
 direnv = "2.35.0"
 just = "1.37.0"
+make = "4.4.1"
 
 svm-rs = "0.5.19"
 


### PR DESCRIPTION
## Summary
- Adds `make = "4.4.1"` to `mise.toml` to pin the `make` version for consistent tooling across developer environments and CI.

## Test plan
- [ ] Verify `mise install` picks up the pinned `make` version

🤖 Generated with [Claude Code](https://claude.com/claude-code)