### PR TITLE
op-batcher: fix oldest L1 origin update in adding block

### DIFF
--- a/op-batcher/batcher/channel_builder.go
+++ b/op-batcher/batcher/channel_builder.go
@@ -189,7 +189,7 @@ func (c *ChannelBuilder) AddBlock(block SizedBlock) (*derive.L1BlockInfo, error)
 			Number: l1info.Number,
 		}
 	}
-	if c.oldestL1Origin.Number == 0 || l1info.Number < c.latestL1Origin.Number {
+	if c.oldestL1Origin.Number == 0 || l1info.Number < c.oldestL1Origin.Number {
 		c.oldestL1Origin = eth.BlockID{
 			Hash:   l1info.BlockHash,
 			Number: l1info.Number,


### PR DESCRIPTION
**Description**

During the process of updating oldestL1Origin in the AddBlock method, we should use the previous oldestL1Origin.Number for comparison, rather than c.latestL1Origin.Number
