### PR TITLE
op-acceptance-tests: disable `supernode/interop/activation` tests

### DIFF
--- a/op-acceptance-tests/tests/supernode/interop/activation/activation_after_genesis_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/activation/activation_after_genesis_test.go
@@ -14,6 +14,7 @@ import (
 // verified data for timestamps both before and after the activation boundary.
 func TestSupernodeInteropActivationAfterGenesis(gt *testing.T) {
 	t := devtest.ParallelT(gt)
+	t.Skip("The TestMain setup code for this test is unstable")
 	sys := presets.NewTwoL2SupernodeInterop(t, InteropActivationDelay)
 
 	genesisTime := sys.GenesisTime

--- a/op-acceptance-tests/tests/supernode/interop/activation/init_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/activation/init_test.go
@@ -15,7 +15,8 @@ const InteropActivationDelay = uint64(20)
 func TestMain(m *testing.M) {
 	// Set the L2CL kind to supernode for all tests in this package
 	_ = os.Setenv("DEVSTACK_L2CL_KIND", "supernode")
-	// TODO invoking presets.WithTwoL2SupernodeInterop with a nonzero interop activation delay
+	// TODO https://github.com/ethereum-optimism/optimism/issues/19403
+	// invoking presets.WithTwoL2SupernodeInterop with a nonzero interop activation delay
 	// results in an unstable test setup due to bugs in op-supernode (it will hang when shutting down)
 	// presets.DoMain(m, presets.WithTwoL2SupernodeInterop(InteropActivationDelay))
 }

--- a/op-acceptance-tests/tests/supernode/interop/activation/init_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/activation/init_test.go
@@ -3,8 +3,6 @@ package activation
 import (
 	"os"
 	"testing"
-
-	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 )
 
 // InteropActivationDelay is the delay in seconds from genesis to interop activation.
@@ -17,5 +15,7 @@ const InteropActivationDelay = uint64(20)
 func TestMain(m *testing.M) {
 	// Set the L2CL kind to supernode for all tests in this package
 	_ = os.Setenv("DEVSTACK_L2CL_KIND", "supernode")
-	presets.DoMain(m, presets.WithTwoL2SupernodeInterop(InteropActivationDelay))
+	// TODO invoking presets.WithTwoL2SupernodeInterop with a nonzero interop activation delay
+	// results in an unstable test setup due to bugs in op-supernode (it will hang when shutting down)
+	// presets.DoMain(m, presets.WithTwoL2SupernodeInterop(InteropActivationDelay))
 }


### PR DESCRIPTION
These have been causing enough pain that we should just rip them out and work on fixing them when they are out of the critical path of other PRs. 