### PR TITLE
op-acceptance-tests: Add PE MVP tests

### DIFF
--- a/op-acceptance-tests/tests/flashblocks/flashblocks_stream_test.go
+++ b/op-acceptance-tests/tests/flashblocks/flashblocks_stream_test.go
@@ -11,10 +11,8 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
-	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/log/logfilter"
 	"github.com/ethereum-optimism/optimism/op-service/logmods"
-	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 )
@@ -64,7 +62,7 @@ func TestFlashblocksStream(gt *testing.T) {
 	expectedChainID := sys.L2Chain.ChainID().ToBig()
 	require.Equal(t, oprbuilderNode.Escape().ChainID().ToBig(), expectedChainID, "flashblocks builder node chain id should match expected chain id")
 
-	driveViaTestSequencer(t, sys, 3)
+	DriveViaTestSequencer(t, sys, 3)
 
 	// Test the presence / absence of a flashblocks stream operating at a 250ms rate from a flashblocks-websocket-proxy node.
 	// Allow a generous window for first flashblocks to appear.
@@ -120,27 +118,6 @@ func TestFlashblocksStream(gt *testing.T) {
 	totalFlashblocksProduced := evaluateFlashblocksStream(t, logger, streamedMessages, failureTolerance)
 	require.Greater(t, totalFlashblocksProduced, 0, "expected to receive flashblocks from rollup-boost stream")
 	logger.Info("Flashblocks stream validation completed", "total_flashblocks_produced", totalFlashblocksProduced)
-}
-
-// driveViaTestSequencer explicitly builds a few blocks to ensure the builder/rollup-boost
-// have payloads to serve before we start listening for flashblocks.
-func driveViaTestSequencer(t devtest.T, sys *presets.SingleChainWithFlashblocks, count int) {
-	t.Helper()
-	ts := sys.TestSequencer.Escape().ControlAPI(sys.L2Chain.ChainID())
-	ctx := t.Ctx()
-
-	head := sys.L2EL.BlockRefByLabel(eth.Unsafe)
-	for i := 0; i < count; i++ {
-		require.NoError(t, ts.New(ctx, seqtypes.BuildOpts{Parent: head.Hash}))
-		require.NoError(t, ts.Next(ctx))
-		head = sys.L2EL.BlockRefByLabel(eth.Unsafe)
-	}
-	// Ensure the sequencer EL has produced at least one unsafe block before subscribing.
-	sys.L2EL.WaitForBlockNumber(1)
-
-	// Log the latest unsafe head and L1 origin to confirm block production before listening.
-	head = sys.L2EL.BlockRefByLabel(eth.Unsafe)
-	sys.Log.Info("Pre-listen unsafe head", "unsafe", head)
 }
 
 func evaluateFlashblocksStream(t devtest.T, logger log.Logger, streamedMessages []string, failureTolerance int) int {

--- a/op-acceptance-tests/tests/flashblocks/flashblocks_transfer_test.go
+++ b/op-acceptance-tests/tests/flashblocks/flashblocks_transfer_test.go
@@ -46,7 +46,7 @@ func TestFlashblocksTransfer(gt *testing.T) {
 	defer span.End()
 
 	// Drive a couple blocks on the test sequencer so the faucet L2 funding tx has a chance to land before we rely on it.
-	driveViaTestSequencer(t, sys, 2)
+	DriveViaTestSequencer(t, sys, 2)
 
 	alice := sys.FunderL2.NewFundedEOA(eth.ThreeHundredthsEther)
 	bob := sys.Wallet.NewEOA(sys.L2EL)

--- a/op-acceptance-tests/tests/flashblocks/utils.go
+++ b/op-acceptance-tests/tests/flashblocks/utils.go
@@ -3,6 +3,12 @@ package flashblocks
 import (
 	"encoding/json"
 	"strings"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
+	"github.com/stretchr/testify/require"
 )
 
 type Flashblock struct {
@@ -50,4 +56,25 @@ func (f *Flashblock) UnmarshalJSON(data []byte) error {
 	f.Metadata.NewAccountBalances = loweredBalances
 
 	return nil
+}
+
+// DriveViaTestSequencer explicitly builds a few blocks to ensure the builder/rollup-boost
+// have payloads to serve before we start listening for flashblocks.
+func DriveViaTestSequencer(t devtest.T, sys *presets.SingleChainWithFlashblocks, count int) {
+	t.Helper()
+	ts := sys.TestSequencer.Escape().ControlAPI(sys.L2Chain.ChainID())
+	ctx := t.Ctx()
+
+	head := sys.L2EL.BlockRefByLabel(eth.Unsafe)
+	for range count {
+		require.NoError(t, ts.New(ctx, seqtypes.BuildOpts{Parent: head.Hash}))
+		require.NoError(t, ts.Next(ctx))
+		head = sys.L2EL.BlockRefByLabel(eth.Unsafe)
+	}
+	// Ensure the sequencer EL has produced at least one unsafe block before subscribing.
+	sys.L2EL.WaitForBlockNumber(1)
+
+	// Log the latest unsafe head and L1 origin to confirm block production before listening.
+	head = sys.L2EL.BlockRefByLabel(eth.Unsafe)
+	sys.Log.Info("Pre-listen unsafe head", "unsafe", head)
 }

--- a/op-acceptance-tests/tests/rules/init_test.go
+++ b/op-acceptance-tests/tests/rules/init_test.go
@@ -1,0 +1,76 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// TestMain creates the test-setups against the shared backend
+func TestMain(m *testing.M) {
+	presets.DoMain(m, presets.WithSingleChainSystemWithFlashblocks(),
+		presets.WithOPRBuilderRules(TestRulesYAML, TestRefreshInterval),
+	)
+}
+
+// BoostedRecipient is the well-known address that receives boosted transactions in tests.
+// Transactions sent TO this address will be prioritized by the block builder when rules are enabled.
+var BoostedRecipient = common.HexToAddress("0x1111111111111111111111111111111111111111")
+
+// HighPriorityRecipient receives transactions with the highest boost (weight: 5000)
+var HighPriorityRecipient = common.HexToAddress("0x2222222222222222222222222222222222222222")
+
+// MediumPriorityRecipient receives transactions with medium boost (weight: 2000)
+var MediumPriorityRecipient = common.HexToAddress("0x3333333333333333333333333333333333333333")
+
+// LowPriorityRecipient receives transactions with low boost (weight: 500)
+var LowPriorityRecipient = common.HexToAddress("0x4444444444444444444444444444444444444444")
+
+const TestRefreshInterval = 5
+
+// TestRulesYAML is the rules configuration used for rule ordering tests.
+// It defines multiple boost levels to test priority ordering:
+// - High priority (weight 5000): transactions TO 0x2222...
+// - Medium priority (weight 2000): transactions TO 0x3333...
+// - Low priority (weight 500): transactions TO 0x4444...
+// - Legacy boost (weight 1000): transactions TO 0x1111... (BoostedRecipient)
+const TestRulesYAML = `version: 1
+
+aliases:
+  high_priority_recipients:
+    - "0x2222222222222222222222222222222222222222"
+  medium_priority_recipients:
+    - "0x3333333333333333333333333333333333333333"
+  low_priority_recipients:
+    - "0x4444444444444444444444444444444444444444"
+  boosted_recipients:
+    - "0x1111111111111111111111111111111111111111"
+
+rules:
+  boost:
+    - name: "High Priority Boost"
+      description: "Highest priority transactions"
+      type: to
+      aliases:
+        - "high_priority_recipients"
+      weight: 5000
+    - name: "Medium Priority Boost"
+      description: "Medium priority transactions"
+      type: to
+      aliases:
+        - "medium_priority_recipients"
+      weight: 2000
+    - name: "Low Priority Boost"
+      description: "Low priority transactions"
+      type: to
+      aliases:
+        - "low_priority_recipients"
+      weight: 500
+    - name: "Legacy Boosted Recipient"
+      description: "Boost transactions to test recipient address"
+      type: to
+      aliases:
+        - "boosted_recipients"
+      weight: 1000
+`

--- a/op-acceptance-tests/tests/rules/init_test.go
+++ b/op-acceptance-tests/tests/rules/init_test.go
@@ -1,17 +1,27 @@
 package rules
 
 import (
+	"os"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum/go-ethereum/common"
 )
 
+const RULES_TEST_ENABLE_ENV = "OP_RBUILDER_RULES_TEST"
+
+func rulesEnabled() bool {
+	return os.Getenv(RULES_TEST_ENABLE_ENV) == "1"
+}
+
 // TestMain creates the test-setups against the shared backend
 func TestMain(m *testing.M) {
-	presets.DoMain(m, presets.WithSingleChainSystemWithFlashblocks(),
-		presets.WithOPRBuilderRules(TestRulesYAML, TestRefreshInterval),
-	)
+	options := presets.WithSingleChainSystemWithFlashblocks()
+	if rulesEnabled() {
+		options = stack.Combine(options, presets.WithOPRBuilderRules(TestRulesYAML, TestRefreshInterval))
+	}
+	presets.DoMain(m, options)
 }
 
 // BoostedRecipient is the well-known address that receives boosted transactions in tests.

--- a/op-acceptance-tests/tests/rules/rules_test.go
+++ b/op-acceptance-tests/tests/rules/rules_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/retry"
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
@@ -332,16 +333,22 @@ func TestSameSenderNonceOrdering(gt *testing.T) {
 			"tx0 (nonce N) must have lower index than tx1 (nonce N+1) despite tx1 having higher boost")
 	} else {
 		// If in different blocks, tx0's block must be <= tx1's block
-		require.LessOrEqual(t, receipt0.BlockNumber.Uint64(), receipt1.BlockNumber.Uint64(),
-			"tx0 must be in same or earlier block than tx1")
+		require.LessOrEqual(t,
+			bigs.Uint64Strict(receipt0.BlockNumber),
+			bigs.Uint64Strict(receipt1.BlockNumber),
+			"tx0 must be in same or earlier block than tx1",
+		)
 	}
 
 	if receipt1.BlockNumber.Cmp(receipt2.BlockNumber) == 0 {
 		require.Less(t, receipt1.TransactionIndex, receipt2.TransactionIndex,
 			"tx1 (nonce N+1) must have lower index than tx2 (nonce N+2)")
 	} else {
-		require.LessOrEqual(t, receipt1.BlockNumber.Uint64(), receipt2.BlockNumber.Uint64(),
-			"tx1 must be in same or earlier block than tx2")
+		require.LessOrEqual(t,
+			bigs.Uint64Strict(receipt1.BlockNumber),
+			bigs.Uint64Strict(receipt2.BlockNumber),
+			"tx1 must be in same or earlier block than tx2",
+		)
 	}
 
 	logger.Info("Nonce ordering verified - boost rules do not break same-sender ordering")

--- a/op-acceptance-tests/tests/rules/rules_test.go
+++ b/op-acceptance-tests/tests/rules/rules_test.go
@@ -1,0 +1,685 @@
+package rules
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"math/rand"
+	"os"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/flashblocks"
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/retry"
+	"github.com/ethereum-optimism/optimism/op-service/txplan"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBoostPriorityOrdering validates that transactions to addresses with higher
+// boost weights appear earlier in blocks than transactions to lower-weight addresses.
+//
+// Rules configuration (from init_test.go):
+// - HighPriorityRecipient (0x2222...): weight 5000
+// - MediumPriorityRecipient (0x3333...): weight 2000
+// - LowPriorityRecipient (0x4444...): weight 500
+// - No boost for other addresses: weight 0
+//
+// Expected ordering: High (5000) > Medium (2000) > Low (500) > Normal (0)
+// We verify this by checking TransactionIndex in the block - lower index = earlier in block.
+func TestBoostPriorityOrdering(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	skipIfRulesNotEnabled(t)
+
+	logger := t.Logger()
+	tracer := t.Tracer()
+	ctx := t.Ctx()
+
+	sys := presets.NewSingleChainWithFlashblocks(t)
+
+	topLevelCtx, span := tracer.Start(ctx, "test boost priority ordering")
+	defer span.End()
+
+	ctx, cancel := context.WithTimeout(topLevelCtx, 90*time.Second)
+	defer cancel()
+
+	flashblocks.DriveViaTestSequencer(t, sys, 3)
+
+	const maxRetries = 3
+	err := retry.Do0(ctx, maxRetries, &retry.FixedStrategy{Dur: 0}, func() error {
+		fundAmount := eth.Ether(1)
+		senderHigh := sys.FunderL2.NewFundedEOA(fundAmount)
+		senderMedium := sys.FunderL2.NewFundedEOA(fundAmount)
+		senderLow := sys.FunderL2.NewFundedEOA(fundAmount)
+		senderNormal := sys.FunderL2.NewFundedEOA(fundAmount)
+
+		normalRecipient := sys.Wallet.NewEOA(sys.L2EL)
+		normalRecipientAddr := normalRecipient.Address()
+
+		sendAmount := eth.OneHundredthEther
+		var wg sync.WaitGroup
+		var txHigh, txMedium, txLow, txNormal *txplan.PlannedTx
+
+		wg.Add(4)
+		go func() {
+			defer wg.Done()
+			txHigh = senderHigh.Transact(
+				senderHigh.Plan(),
+				txplan.WithTo(&HighPriorityRecipient),
+				txplan.WithValue(sendAmount),
+			)
+		}()
+		go func() {
+			defer wg.Done()
+			txMedium = senderMedium.Transact(
+				senderMedium.Plan(),
+				txplan.WithTo(&MediumPriorityRecipient),
+				txplan.WithValue(sendAmount),
+			)
+		}()
+		go func() {
+			defer wg.Done()
+			txLow = senderLow.Transact(
+				senderLow.Plan(),
+				txplan.WithTo(&LowPriorityRecipient),
+				txplan.WithValue(sendAmount),
+			)
+		}()
+		go func() {
+			defer wg.Done()
+			txNormal = senderNormal.Transact(
+				senderNormal.Plan(),
+				txplan.WithTo(&normalRecipientAddr),
+				txplan.WithValue(sendAmount),
+			)
+		}()
+		wg.Wait()
+
+		receiptHigh, err := txHigh.Included.Eval(ctx)
+		if err != nil {
+			return fmt.Errorf("high priority tx inclusion: %w", err)
+		}
+		receiptMedium, err := txMedium.Included.Eval(ctx)
+		if err != nil {
+			return fmt.Errorf("medium priority tx inclusion: %w", err)
+		}
+		receiptLow, err := txLow.Included.Eval(ctx)
+		if err != nil {
+			return fmt.Errorf("low priority tx inclusion: %w", err)
+		}
+		receiptNormal, err := txNormal.Included.Eval(ctx)
+		if err != nil {
+			return fmt.Errorf("normal tx inclusion: %w", err)
+		}
+
+		logger.Info("All transactions confirmed",
+			"high_block", receiptHigh.BlockNumber, "high_index", receiptHigh.TransactionIndex,
+			"medium_block", receiptMedium.BlockNumber, "medium_index", receiptMedium.TransactionIndex,
+			"low_block", receiptLow.BlockNumber, "low_index", receiptLow.TransactionIndex,
+			"normal_block", receiptNormal.BlockNumber, "normal_index", receiptNormal.TransactionIndex,
+		)
+
+		sameBlock := receiptHigh.BlockNumber.Cmp(receiptMedium.BlockNumber) == 0 &&
+			receiptMedium.BlockNumber.Cmp(receiptLow.BlockNumber) == 0 &&
+			receiptLow.BlockNumber.Cmp(receiptNormal.BlockNumber) == 0
+
+		if !sameBlock {
+			return fmt.Errorf("transactions landed in different blocks: high=%d, medium=%d, low=%d, normal=%d",
+				receiptHigh.BlockNumber, receiptMedium.BlockNumber, receiptLow.BlockNumber, receiptNormal.BlockNumber)
+		}
+
+		require.Less(t, receiptHigh.TransactionIndex, receiptMedium.TransactionIndex,
+			"high priority (weight 5000) should have lower tx index than medium priority (weight 2000)")
+		require.Less(t, receiptMedium.TransactionIndex, receiptLow.TransactionIndex,
+			"medium priority (weight 2000) should have lower tx index than low priority (weight 500)")
+		require.Less(t, receiptLow.TransactionIndex, receiptNormal.TransactionIndex,
+			"low priority (weight 500) should have lower tx index than normal (no boost)")
+
+		logger.Info("Boost priority ordering verified successfully",
+			"order", fmt.Sprintf("high(idx=%d) < medium(idx=%d) < low(idx=%d) < normal(idx=%d)",
+				receiptHigh.TransactionIndex, receiptMedium.TransactionIndex,
+				receiptLow.TransactionIndex, receiptNormal.TransactionIndex),
+		)
+		return nil
+	})
+	require.NoError(t, err, "boost priority ordering verification failed")
+}
+
+// TestBoostedVsNonBoostedOrdering validates that a boosted transaction appears before
+// a non-boosted transaction even when the non-boosted transaction has a MUCH HIGHER
+// priority fee (gas tip). This proves that rule-based boost takes precedence over
+// economic incentives (EIP-1559 priority fees).
+//
+// Test setup:
+// - Boosted tx: to BoostedRecipient (weight 1000), LOW priority fee (1 gwei tip)
+// - Normal tx: to normal recipient (no boost), HIGH priority fee (100 gwei tip)
+//
+// Expected: Despite 100x higher gas tip, the normal tx should come AFTER the boosted tx.
+func TestBoostedVsNonBoostedOrdering(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	skipIfRulesNotEnabled(t)
+
+	logger := t.Logger()
+	tracer := t.Tracer()
+	ctx := t.Ctx()
+
+	sys := presets.NewSingleChainWithFlashblocks(t)
+
+	topLevelCtx, span := tracer.Start(ctx, "test boosted vs non-boosted ordering")
+	defer span.End()
+
+	ctx, cancel := context.WithTimeout(topLevelCtx, 90*time.Second)
+	defer cancel()
+
+	flashblocks.DriveViaTestSequencer(t, sys, 2)
+
+	lowGasTip := big.NewInt(1_000_000_000)
+	highGasTip := big.NewInt(100_000_000_000)
+	highGasFeeCap := big.NewInt(200_000_000_000)
+
+	const maxRetries = 3
+	err := retry.Do0(ctx, maxRetries, &retry.FixedStrategy{Dur: 0}, func() error {
+		fundAmount := eth.ThreeHundredthsEther
+		senderBoosted := sys.FunderL2.NewFundedEOA(fundAmount)
+		senderNormal := sys.FunderL2.NewFundedEOA(fundAmount)
+
+		normalRecipient := sys.Wallet.NewEOA(sys.L2EL)
+		normalRecipientAddr := normalRecipient.Address()
+
+		sendAmount := eth.OneHundredthEther
+		var wg sync.WaitGroup
+		var txBoosted, txNormal *txplan.PlannedTx
+
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			txBoosted = senderBoosted.Transact(
+				senderBoosted.Plan(),
+				txplan.WithTo(&BoostedRecipient),
+				txplan.WithValue(sendAmount),
+				txplan.WithGasTipCap(lowGasTip),
+			)
+		}()
+		go func() {
+			defer wg.Done()
+			txNormal = senderNormal.Transact(
+				senderNormal.Plan(),
+				txplan.WithTo(&normalRecipientAddr),
+				txplan.WithValue(sendAmount),
+				txplan.WithGasTipCap(highGasTip),
+				txplan.WithGasFeeCap(highGasFeeCap),
+			)
+		}()
+		wg.Wait()
+
+		receiptBoosted, err := txBoosted.Included.Eval(ctx)
+		if err != nil {
+			return fmt.Errorf("boosted tx inclusion: %w", err)
+		}
+		receiptNormal, err := txNormal.Included.Eval(ctx)
+		if err != nil {
+			return fmt.Errorf("normal tx inclusion: %w", err)
+		}
+
+		logger.Info("Transactions confirmed",
+			"boosted_block", receiptBoosted.BlockNumber,
+			"boosted_index", receiptBoosted.TransactionIndex,
+			"normal_block", receiptNormal.BlockNumber,
+			"normal_index", receiptNormal.TransactionIndex,
+		)
+
+		if receiptBoosted.BlockNumber.Cmp(receiptNormal.BlockNumber) != 0 {
+			return fmt.Errorf("transactions landed in different blocks: boosted=%d, normal=%d",
+				receiptBoosted.BlockNumber, receiptNormal.BlockNumber)
+		}
+
+		require.Less(t, receiptBoosted.TransactionIndex, receiptNormal.TransactionIndex,
+			"boosted transaction (weight 1000, 1 gwei tip) should have lower tx index than "+
+				"normal transaction (no boost, 100 gwei tip) - proving rules > gas priority")
+
+		logger.Info("Rule-based boost precedence over gas priority verified!",
+			"boosted_index", receiptBoosted.TransactionIndex,
+			"normal_index", receiptNormal.TransactionIndex,
+		)
+		return nil
+	})
+	require.NoError(t, err, "boosted vs non-boosted ordering verification failed")
+}
+
+// TestSameSenderNonceOrdering verifies that transactions from the same sender
+// maintain nonce ordering regardless of boost rules.
+func TestSameSenderNonceOrdering(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	skipIfRulesNotEnabled(t)
+
+	logger := t.Logger()
+	tracer := t.Tracer()
+	ctx := t.Ctx()
+
+	sys := presets.NewSingleChainWithFlashblocks(t)
+
+	topLevelCtx, span := tracer.Start(ctx, "test same sender nonce ordering")
+	defer span.End()
+
+	ctx, cancel := context.WithTimeout(topLevelCtx, 60*time.Second)
+	defer cancel()
+
+	// Drive initial blocks
+	flashblocks.DriveViaTestSequencer(t, sys, 2)
+
+	// Create a single funded sender
+	sender := sys.FunderL2.NewFundedEOA(eth.Ether(1))
+
+	// Create normal recipient
+	normalRecipient := sys.Wallet.NewEOA(sys.L2EL)
+	normalRecipientAddr := normalRecipient.Address()
+
+	logger.Info("Test sender created", "address", sender.Address().Hex())
+
+	sendAmount := eth.OneHundredthEther
+
+	// Send 3 sequential transactions from same sender to different recipients
+	// TX0 -> Normal recipient (no boost)
+	// TX1 -> HighPriorityRecipient (weight 5000)
+	// TX2 -> Normal recipient (no boost)
+	//
+	// Even though TX1 has the highest boost, it must come after TX0 due to nonce ordering
+
+	// TX0: to normal recipient
+	tx0 := sender.Transact(
+		sender.Plan(),
+		txplan.WithTo(&normalRecipientAddr),
+		txplan.WithValue(sendAmount),
+	)
+	receipt0, err := tx0.Included.Eval(ctx)
+	require.NoError(t, err, "tx0 should be included")
+
+	// TX1: to high priority recipient
+	tx1 := sender.Transact(
+		sender.Plan(),
+		txplan.WithTo(&HighPriorityRecipient),
+		txplan.WithValue(sendAmount),
+	)
+	receipt1, err := tx1.Included.Eval(ctx)
+	require.NoError(t, err, "tx1 should be included")
+
+	// TX2: to normal recipient
+	tx2 := sender.Transact(
+		sender.Plan(),
+		txplan.WithTo(&normalRecipientAddr),
+		txplan.WithValue(sendAmount),
+	)
+	receipt2, err := tx2.Included.Eval(ctx)
+	require.NoError(t, err, "tx2 should be included")
+
+	logger.Info("Sequential transactions confirmed",
+		"tx0_hash", receipt0.TxHash.Hex(), "tx0_block", receipt0.BlockNumber, "tx0_index", receipt0.TransactionIndex,
+		"tx1_hash", receipt1.TxHash.Hex(), "tx1_block", receipt1.BlockNumber, "tx1_index", receipt1.TransactionIndex,
+		"tx2_hash", receipt2.TxHash.Hex(), "tx2_block", receipt2.BlockNumber, "tx2_index", receipt2.TransactionIndex,
+	)
+
+	// Verify nonce ordering is preserved
+	// If transactions are in the same block, their indices must reflect nonce order
+	if receipt0.BlockNumber.Cmp(receipt1.BlockNumber) == 0 {
+		require.Less(t, receipt0.TransactionIndex, receipt1.TransactionIndex,
+			"tx0 (nonce N) must have lower index than tx1 (nonce N+1) despite tx1 having higher boost")
+	} else {
+		// If in different blocks, tx0's block must be <= tx1's block
+		require.LessOrEqual(t, receipt0.BlockNumber.Uint64(), receipt1.BlockNumber.Uint64(),
+			"tx0 must be in same or earlier block than tx1")
+	}
+
+	if receipt1.BlockNumber.Cmp(receipt2.BlockNumber) == 0 {
+		require.Less(t, receipt1.TransactionIndex, receipt2.TransactionIndex,
+			"tx1 (nonce N+1) must have lower index than tx2 (nonce N+2)")
+	} else {
+		require.LessOrEqual(t, receipt1.BlockNumber.Uint64(), receipt2.BlockNumber.Uint64(),
+			"tx1 must be in same or earlier block than tx2")
+	}
+
+	logger.Info("Nonce ordering verified - boost rules do not break same-sender ordering")
+}
+
+// TestMultipleSendersWithMixedPriorities tests a realistic scenario with multiple
+// senders sending to different priority recipients concurrently.
+func TestMultipleSendersWithMixedPriorities(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	skipIfRulesNotEnabled(t)
+
+	logger := t.Logger()
+	tracer := t.Tracer()
+	ctx := t.Ctx()
+
+	sys := presets.NewSingleChainWithFlashblocks(t)
+
+	topLevelCtx, span := tracer.Start(ctx, "test multiple senders mixed priorities")
+	defer span.End()
+
+	ctx, cancel := context.WithTimeout(topLevelCtx, 120*time.Second)
+	defer cancel()
+
+	flashblocks.DriveViaTestSequencer(t, sys, 2)
+
+	type senderConfig struct {
+		eoa       *dsl.EOA
+		priority  string
+		recipient common.Address
+		weight    int
+	}
+
+	type txResult struct {
+		receipt  *types.Receipt
+		priority string
+		weight   int
+	}
+
+	const maxRetries = 3
+	err := retry.Do0(ctx, maxRetries, &retry.FixedStrategy{Dur: 0}, func() error {
+		fundAmount := eth.ThreeHundredthsEther
+
+		normalRecipient := sys.Wallet.NewEOA(sys.L2EL)
+		normalRecipientAddr := normalRecipient.Address()
+
+		configs := []struct {
+			priority  string
+			recipient common.Address
+			weight    int
+		}{
+			{"high", HighPriorityRecipient, 5000},
+			{"medium", MediumPriorityRecipient, 2000},
+			{"low", LowPriorityRecipient, 500},
+			{"normal", normalRecipientAddr, 0},
+			{"high", HighPriorityRecipient, 5000},
+			{"normal", normalRecipientAddr, 0},
+		}
+
+		senders := make([]senderConfig, len(configs))
+		for i, cfg := range configs {
+			senders[i] = senderConfig{
+				eoa:       sys.FunderL2.NewFundedEOA(fundAmount),
+				priority:  cfg.priority,
+				recipient: cfg.recipient,
+				weight:    cfg.weight,
+			}
+		}
+
+		sendAmount := eth.OneHundredthEther
+		var wg sync.WaitGroup
+		plannedTxs := make([]*txplan.PlannedTx, len(senders))
+
+		for i := range senders {
+			wg.Add(1)
+			idx := i
+			go func() {
+				defer wg.Done()
+				recipient := senders[idx].recipient
+				plannedTxs[idx] = senders[idx].eoa.Transact(
+					senders[idx].eoa.Plan(),
+					txplan.WithTo(&recipient),
+					txplan.WithValue(sendAmount),
+				)
+			}()
+		}
+		wg.Wait()
+
+		results := make([]txResult, len(senders))
+		for i := range senders {
+			receipt, err := plannedTxs[i].Included.Eval(ctx)
+			if err != nil {
+				return fmt.Errorf("tx%d inclusion: %w", i, err)
+			}
+			results[i] = txResult{
+				receipt:  receipt,
+				priority: senders[i].priority,
+				weight:   senders[i].weight,
+			}
+			logger.Info("Transaction confirmed",
+				"index", i,
+				"priority", senders[i].priority,
+				"weight", senders[i].weight,
+				"block", receipt.BlockNumber,
+				"tx_index", receipt.TransactionIndex,
+			)
+		}
+
+		blockGroups := make(map[uint64][]txResult)
+		for _, r := range results {
+			blockNum := r.receipt.BlockNumber.Uint64()
+			blockGroups[blockNum] = append(blockGroups[blockNum], r)
+		}
+
+		if len(blockGroups) != 1 {
+			blockNumbers := make([]uint64, 0, len(blockGroups))
+			for blockNum := range blockGroups {
+				blockNumbers = append(blockNumbers, blockNum)
+			}
+			return fmt.Errorf("transactions landed in %d different blocks: %v", len(blockGroups), blockNumbers)
+		}
+
+		for blockNum, txs := range blockGroups {
+			logger.Info("Verifying ordering in block", "block", blockNum, "tx_count", len(txs))
+
+			for i := 0; i < len(txs); i++ {
+				for j := i + 1; j < len(txs); j++ {
+					if txs[i].weight > txs[j].weight {
+						require.Less(t, txs[i].receipt.TransactionIndex, txs[j].receipt.TransactionIndex,
+							"tx with weight %d should have lower index than tx with weight %d in block %d",
+							txs[i].weight, txs[j].weight, blockNum)
+					} else if txs[i].weight < txs[j].weight {
+						require.Greater(t, txs[i].receipt.TransactionIndex, txs[j].receipt.TransactionIndex,
+							"tx with weight %d should have higher index than tx with weight %d in block %d",
+							txs[i].weight, txs[j].weight, blockNum)
+					}
+				}
+			}
+		}
+
+		logger.Info("Multiple senders mixed priorities test completed successfully")
+		return nil
+	})
+	require.NoError(t, err, "multiple senders mixed priorities verification failed")
+}
+
+// TestSingleSenderRandomNonceOrderWithRandomScores sends 10 transactions from a single sender
+// with explicit nonces, random gas tips, and random boost recipients. The transactions are
+// submitted to the mempool in a shuffled nonce order to verify that op-rbuilder correctly
+// sorts by transaction score while still respecting nonce ordering for the same sender.
+//
+// Setup:
+//   - 1 sender, 10 transactions (nonces base+0 through base+9)
+//   - Each tx gets a random gas tip (1-50 gwei) AND a random recipient from
+//     {HighPriority, MediumPriority, LowPriority, Normal} for varied boost weights
+//   - Transactions are shuffled before submission so the mempool receives them out-of-order
+//
+// Expected: All 10 transactions are included with strict nonce ordering preserved,
+// i.e. within the same block tx with nonce N always has a lower TransactionIndex
+// than tx with nonce N+1, and across blocks lower nonces are in earlier blocks.
+func TestSingleSenderRandomNonceOrderWithRandomScores(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	skipIfRulesNotEnabled(t)
+
+	logger := t.Logger()
+	tracer := t.Tracer()
+	ctx := t.Ctx()
+
+	sys := presets.NewSingleChainWithFlashblocks(t)
+
+	topLevelCtx, span := tracer.Start(ctx, "test single sender random nonce order with random scores")
+	defer span.End()
+
+	ctx, cancel := context.WithTimeout(topLevelCtx, 120*time.Second)
+	defer cancel()
+
+	flashblocks.DriveViaTestSequencer(t, sys, 2)
+
+	const txCount = 10
+
+	type recipientInfo struct {
+		addr   common.Address
+		weight int
+	}
+	normalRecipient := sys.Wallet.NewEOA(sys.L2EL)
+	normalRecipientAddr := normalRecipient.Address()
+	recipients := []recipientInfo{
+		{HighPriorityRecipient, 5000},
+		{MediumPriorityRecipient, 2000},
+		{LowPriorityRecipient, 500},
+		{normalRecipientAddr, 0},
+	}
+
+	const maxRetries = 3
+	err := retry.Do0(ctx, maxRetries, &retry.FixedStrategy{Dur: 0}, func() error {
+		sender := sys.FunderL2.NewFundedEOA(eth.Ether(1))
+		baseNonce := sender.PendingNonce()
+
+		logger.Info("Test sender created",
+			"address", sender.Address().Hex(),
+			"baseNonce", baseNonce,
+		)
+
+		rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+		type txConfig struct {
+			nonce     uint64
+			tipGwei   int64
+			recipient recipientInfo
+		}
+		configs := make([]txConfig, txCount)
+		for i := 0; i < txCount; i++ {
+			tipGwei := int64(1 + rng.Intn(50))
+			recip := recipients[rng.Intn(len(recipients))]
+			configs[i] = txConfig{
+				nonce:     baseNonce + uint64(i),
+				tipGwei:   tipGwei,
+				recipient: recip,
+			}
+			logger.Info("Transaction config",
+				"index", i,
+				"nonce", configs[i].nonce,
+				"tipGwei", tipGwei,
+				"recipient", recip.addr.Hex(),
+				"boostWeight", recip.weight,
+			)
+		}
+
+		submitOrder := rng.Perm(txCount)
+		logger.Info("Shuffled submission order", "order", submitOrder)
+
+		sendAmount := eth.OneHundredthEther
+		highFeeCap := new(big.Int).Mul(big.NewInt(200), big.NewInt(1_000_000_000))
+
+		plannedTxs := make([]*txplan.PlannedTx, txCount)
+		var wg sync.WaitGroup
+		for _, idx := range submitOrder {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				cfg := configs[i]
+				tip := new(big.Int).Mul(big.NewInt(cfg.tipGwei), big.NewInt(1_000_000_000))
+				recipAddr := cfg.recipient.addr
+				plannedTxs[i] = sender.Transact(
+					sender.Plan(),
+					txplan.WithStaticNonce(cfg.nonce),
+					txplan.WithTo(&recipAddr),
+					txplan.WithValue(sendAmount),
+					txplan.WithGasTipCap(tip),
+					txplan.WithGasFeeCap(highFeeCap),
+				)
+			}(idx)
+		}
+		wg.Wait()
+
+		type txResult struct {
+			nonce   uint64
+			tipGwei int64
+			weight  int
+			receipt *types.Receipt
+		}
+		results := make([]txResult, txCount)
+		for i := 0; i < txCount; i++ {
+			receipt, err := plannedTxs[i].Included.Eval(ctx)
+			if err != nil {
+				return fmt.Errorf("tx%d (nonce %d) inclusion: %w", i, configs[i].nonce, err)
+			}
+			results[i] = txResult{
+				nonce:   configs[i].nonce,
+				tipGwei: configs[i].tipGwei,
+				weight:  configs[i].recipient.weight,
+				receipt: receipt,
+			}
+			logger.Info("Transaction confirmed",
+				"index", i,
+				"nonce", configs[i].nonce,
+				"tipGwei", configs[i].tipGwei,
+				"boostWeight", configs[i].recipient.weight,
+				"block", receipt.BlockNumber,
+				"txIndex", receipt.TransactionIndex,
+			)
+		}
+
+		sort.Slice(results, func(i, j int) bool {
+			return results[i].nonce < results[j].nonce
+		})
+
+		// Count how many transactions share a block with at least one other tx.
+		// If every tx lands in its own block, nonce ordering is trivially
+		// guaranteed by the protocol and the test does not exercise the builder's
+		// intra-block ordering logic.  Treat that as a retryable condition so the
+		// next attempt (with a fresh sender/nonces) hopefully lands more txs in
+		// the same block.
+		blockCounts := make(map[uint64]int)
+		for _, r := range results {
+			blockCounts[r.receipt.BlockNumber.Uint64()]++
+		}
+		maxPerBlock := 0
+		for _, c := range blockCounts {
+			if c > maxPerBlock {
+				maxPerBlock = c
+			}
+		}
+		if maxPerBlock < 2 {
+			return fmt.Errorf("all %d transactions landed in separate blocks (%d blocks); "+
+				"need at least 2 in the same block to validate intra-block nonce ordering",
+				txCount, len(blockCounts))
+		}
+
+		for i := 0; i < len(results)-1; i++ {
+			cur := results[i]
+			next := results[i+1]
+
+			if cur.receipt.BlockNumber.Cmp(next.receipt.BlockNumber) == 0 {
+				require.Less(t, cur.receipt.TransactionIndex, next.receipt.TransactionIndex,
+					"nonce %d (tip=%d gwei, boost=%d, txIdx=%d) must have lower tx index than nonce %d (tip=%d gwei, boost=%d, txIdx=%d) in block %d",
+					cur.nonce, cur.tipGwei, cur.weight, cur.receipt.TransactionIndex,
+					next.nonce, next.tipGwei, next.weight, next.receipt.TransactionIndex,
+					cur.receipt.BlockNumber)
+			} else {
+				require.Less(t, cur.receipt.BlockNumber.Uint64(), next.receipt.BlockNumber.Uint64(),
+					"nonce %d must be in an earlier block than nonce %d (got blocks %d and %d)",
+					cur.nonce, next.nonce, cur.receipt.BlockNumber, next.receipt.BlockNumber)
+			}
+		}
+
+		logger.Info("Single sender random nonce order test passed - nonce ordering preserved despite random scores and shuffled submission",
+			"txCount", txCount,
+			"blocksUsed", len(blockCounts),
+			"maxTxsInOneBlock", maxPerBlock,
+			"nonceRange", fmt.Sprintf("%d-%d", results[0].nonce, results[len(results)-1].nonce),
+		)
+		return nil
+	})
+	require.NoError(t, err, "single sender random nonce order with random scores verification failed")
+}
+
+func skipIfRulesNotEnabled(t devtest.T) {
+	if os.Getenv("OP_RBUILDER_RULES_TEST") != "1" {
+		t.Skip("Skipping rule ordering test")
+	}
+}

--- a/op-acceptance-tests/tests/rules/rules_test.go
+++ b/op-acceptance-tests/tests/rules/rules_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math/big"
 	"math/rand"
-	"os"
 	"sort"
 	"sync"
 	"testing"
@@ -690,7 +689,7 @@ func TestSingleSenderRandomNonceOrderWithRandomScores(gt *testing.T) {
 }
 
 func skipIfRulesNotEnabled(t devtest.T) {
-	if os.Getenv("OP_RBUILDER_RULES_TEST") != "1" {
+	if !rulesEnabled() {
 		t.Skip("Skipping rule ordering test")
 	}
 }

--- a/op-acceptance-tests/tests/rules/rules_test.go
+++ b/op-acceptance-tests/tests/rules/rules_test.go
@@ -458,7 +458,7 @@ func TestMultipleSendersWithMixedPriorities(gt *testing.T) {
 
 		blockGroups := make(map[uint64][]txResult)
 		for _, r := range results {
-			blockNum := r.receipt.BlockNumber.Uint64()
+			blockNum := bigs.Uint64Strict(r.receipt.BlockNumber)
 			blockGroups[blockNum] = append(blockGroups[blockNum], r)
 		}
 
@@ -643,7 +643,7 @@ func TestSingleSenderRandomNonceOrderWithRandomScores(gt *testing.T) {
 		// the same block.
 		blockCounts := make(map[uint64]int)
 		for _, r := range results {
-			blockCounts[r.receipt.BlockNumber.Uint64()]++
+			blockCounts[bigs.Uint64Strict(r.receipt.BlockNumber)]++
 		}
 		maxPerBlock := 0
 		for _, c := range blockCounts {
@@ -668,9 +668,13 @@ func TestSingleSenderRandomNonceOrderWithRandomScores(gt *testing.T) {
 					next.nonce, next.tipGwei, next.weight, next.receipt.TransactionIndex,
 					cur.receipt.BlockNumber)
 			} else {
-				require.Less(t, cur.receipt.BlockNumber.Uint64(), next.receipt.BlockNumber.Uint64(),
+				require.Less(
+					t,
+					bigs.Uint64Strict(cur.receipt.BlockNumber),
+					bigs.Uint64Strict(next.receipt.BlockNumber),
 					"nonce %d must be in an earlier block than nonce %d (got blocks %d and %d)",
-					cur.nonce, next.nonce, cur.receipt.BlockNumber, next.receipt.BlockNumber)
+					cur.nonce, next.nonce, cur.receipt.BlockNumber, next.receipt.BlockNumber,
+				)
 			}
 		}
 

--- a/op-devstack/dsl/fb_ws_client.go
+++ b/op-devstack/dsl/fb_ws_client.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"net"
 	"net/http"
 	"time"
 
@@ -112,9 +114,35 @@ func websocketListenFor(ctx context.Context, logger log.Logger, wsURL string, he
 				return nil
 			}
 
+			// Check for close errors first - these are normal termination
 			if websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway, websocket.CloseNoStatusReceived) {
 				logger.Info("WebSocket connection closed by peer", "total_messages", messageCount)
 				return nil
+			}
+
+			// Check if this is an unexpected close error (any close error not handled above)
+			var closeErr *websocket.CloseError
+			if errors.As(err, &closeErr) {
+				logger.Info("WebSocket connection closed unexpectedly", "code", closeErr.Code, "text", closeErr.Text, "total_messages", messageCount)
+				return nil
+			}
+
+			// Check for EOF errors - connection was closed
+			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+				logger.Info("WebSocket connection closed (EOF)", "total_messages", messageCount)
+				return nil
+			}
+
+			// Check for use of closed network connection
+			if errors.Is(err, net.ErrClosed) {
+				logger.Info("WebSocket connection closed (network)", "total_messages", messageCount)
+				return nil
+			}
+
+			// Timeout errors are recoverable - keep reading
+			var netErr net.Error
+			if errors.As(err, &netErr) && netErr.Timeout() {
+				continue
 			}
 
 			logger.Error("Error reading WebSocket message", "error", err, "message_count", messageCount)

--- a/op-devstack/presets/op_rbuilder_rules.go
+++ b/op-devstack/presets/op_rbuilder_rules.go
@@ -1,0 +1,43 @@
+package presets
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+)
+
+func WithOPRBuilderRules(ruleContent string, refreshInterval uint64) stack.CommonOption {
+	return stack.MakeCommon(
+		sysgo.WithGlobalOPRBuilderNodeOption(sysgo.OPRBuilderNodeOptionFn(
+			func(p devtest.P, id stack.OPRBuilderNodeID, cfg *sysgo.OPRBuilderNodeConfig) {
+				cfg.RulesEnabled = true
+				// Create a fixed directory for rules config
+				rulesDir := filepath.Join(os.TempDir(), "rules")
+				if err := os.MkdirAll(rulesDir, 0755); err != nil {
+					p.Errorf("Failed to create rules dir: %v", err)
+				}
+				// Write rules
+				rulesPath := filepath.Join(rulesDir, "ruleset.yaml")
+				if err := os.WriteFile(rulesPath, []byte(ruleContent), 0644); err != nil {
+					p.Errorf("Failed to create rules dir: %v", err)
+				}
+				// Write rule config pointing to rules file
+				rulesConfigContent := fmt.Sprintf(`
+file:
+  - path: %s
+    name: "Test Rules"
+    enabled: true
+
+refresh_interval: %d
+`, rulesPath, refreshInterval)
+				rulesConfigPath := filepath.Join(rulesDir, "rules_config.yaml")
+				if err := os.WriteFile(rulesConfigPath, []byte(rulesConfigContent), 0644); err != nil {
+					p.Errorf("Failed to write registry file: %v", err)
+				}
+				cfg.RulesConfigPath = rulesConfigPath
+			})))
+}

--- a/op-devstack/sysgo/op_rbuilder.go
+++ b/op-devstack/sysgo/op_rbuilder.go
@@ -92,6 +92,9 @@ type OPRBuilderNodeConfig struct {
 
 	Full bool
 
+	RulesEnabled    bool
+	RulesConfigPath string
+
 	// ExtraArgs are appended to the generated CLI allowing callers to override defaults
 	// if the binary respects "last flag wins".
 	ExtraArgs []string
@@ -126,6 +129,8 @@ func DefaultOPRbuilderNodeConfig() *OPRBuilderNodeConfig {
 		DataDir:           "",
 		ExtraArgs:         nil,
 		Env:               nil,
+		RulesEnabled:      false,
+		RulesConfigPath:   "",
 	}
 }
 
@@ -235,6 +240,11 @@ func (cfg *OPRBuilderNodeConfig) LaunchSpec(p devtest.P) (args []string, env []s
 		args = append(args, "--datadir="+cfg.DataDir)
 	}
 
+	if cfg.RulesEnabled {
+		args = append(args, "--rules.enabled")
+		args = append(args, "--rules.config-path="+cfg.RulesConfigPath)
+	}
+
 	args = append(args, cfg.ExtraArgs...)
 
 	return args, env
@@ -242,6 +252,12 @@ func (cfg *OPRBuilderNodeConfig) LaunchSpec(p devtest.P) (args []string, env []s
 
 type OPRBuilderNodeOption interface {
 	Apply(p devtest.P, id stack.OPRBuilderNodeID, cfg *OPRBuilderNodeConfig)
+}
+
+func WithGlobalOPRBuilderNodeOption(opt OPRBuilderNodeOption) stack.Option[*Orchestrator] {
+	return stack.BeforeDeploy(func(o *Orchestrator) {
+		o.oprbuilderNodeOptions = append(o.oprbuilderNodeOptions, opt)
+	})
 }
 
 type OPRBuilderNodeOptionFn func(p devtest.P, id stack.OPRBuilderNodeID, cfg *OPRBuilderNodeConfig)
@@ -481,7 +497,8 @@ func WithOPRBuilderNode(id stack.OPRBuilderNodeID, opts ...OPRBuilderNodeOption)
 		cfg := DefaultOPRbuilderNodeConfig()
 		cfg.AuthRPCJWTPath, _ = orch.writeDefaultJWT()
 		cfg.Chain = chainConfigPath
-		OPRBuilderNodeOptionBundle(opts).Apply(orch.P(), id, cfg)
+		orch.oprbuilderNodeOptions.Apply(p, id, cfg)              // apply global options
+		OPRBuilderNodeOptionBundle(opts).Apply(orch.P(), id, cfg) // apply specific options
 
 		rb := &OPRBuilderNode{
 			id:        id,

--- a/op-devstack/sysgo/orchestrator.go
+++ b/op-devstack/sysgo/orchestrator.go
@@ -32,6 +32,7 @@ type Orchestrator struct {
 	batcherOptions          []BatcherOption
 	proposerOptions         []ProposerOption
 	l2CLOptions             L2CLOptionBundle
+	oprbuilderNodeOptions   OPRBuilderNodeOptionBundle
 	l2ELOptions             L2ELOptionBundle
 	l2ChallengerOpts        l2ChallengerOpts
 	SyncTesterELOptions     SyncTesterELOptionBundle


### PR DESCRIPTION
Adds PE acceptance tests which are skipped by default.

These tests are not meant to be run at the monorepo.

Reviving https://github.com/ethereum-optimism/optimism/pull/18723 with addressing my own comments. 

Locally validated.
```
 Acceptance Testing Results (network: in-memory)                                                                                                     
 TYPE     ID                                                                                       DURATION   TESTS  PASSED  FAILED  SKIPPED  STATUS 
 Gate     rules                                                                                    1m51.278s      1       1       0        0  PASS   
 Package  └── github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/rules (package)      1m51.278s      1       1       0        0  PASS   
 Test         └── github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/rules (package)  1m51.278s      1       1       0        0  PASS   
 Subtest          ├── TestBoostPriorityOrdering                                                      20.662s      1       1       0        0  PASS   
                  ├── TestBoostedVsNonBoostedOrdering                                                14.008s      1       1       0        0  PASS   
                  ├── TestSameSenderNonceOrdering                                                    16.412s      1       1       0        0  PASS   
                  ├── TestMultipleSendersWithMixedPriorities                                         29.683s      1       1       0        0  PASS   
                  └── TestSingleSenderRandomNonceOrderWithRandomScores                               10.044s      1       1       0        0  PASS   
 TOTAL                                                                                             1M51.279S      5       5       0        0  PASS   
```

Example run cmd:
```sh
cd op-acceptance-tests
# tweak acceptance-tests.yaml, adding the `rules` gate
 RUST_BINARY_PATH_OP_RBUILDER=/Users/changwan/Documents/op-rbuilder/target/release/op-rbuilder  
OP_RBUILDER_RULES_TEST=1 just acceptance-test "" rules
```

Credits to @mininny for implementing the actual testing logic at `op-acceptance-tests/tests/rules/rules_test.go`