### PR TITLE
fix(op-supernode): early return in VerifiedBlockAtL1 for zero l1Block

### DIFF
--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -458,6 +458,12 @@ func (i *Interop) LatestVerifiedL2Block(chainID eth.ChainID) (eth.BlockID, uint6
 // which guarantees that the verified data at that pauseAtTimestamp
 // originates from or before the supplied L1 block.
 func (i *Interop) VerifiedBlockAtL1(chainID eth.ChainID, l1Block eth.L1BlockRef) (eth.BlockID, uint64) {
+	// If L1 block is empty/zero (e.g. during startup before FinalizedL1 is set),
+	// no verified result can match, so return early.
+	if l1Block == (eth.L1BlockRef{}) {
+		return eth.BlockID{}, 0
+	}
+
 	// Get the last verified timestamp
 	lastTs, ok := i.verifiedDB.LastTimestamp()
 	if !ok {

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -1535,3 +1535,70 @@ func TestReset(t *testing.T) {
 		})
 	}
 }
+
+// =============================================================================
+// TestVerifiedBlockAtL1
+// =============================================================================
+
+func TestVerifiedBlockAtL1(t *testing.T) {
+	t.Run("zero l1Block returns empty immediately", func(t *testing.T) {
+		h := newInteropTestHarness(t).
+			WithChain(10, nil).
+			Build()
+
+		// Commit some verified results so the DB is non-empty
+		for ts := uint64(100); ts <= 110; ts++ {
+			err := h.interop.verifiedDB.Commit(VerifiedResult{
+				Timestamp:   ts,
+				L1Inclusion: eth.BlockID{Number: ts + 1000},
+				L2Heads:     map[eth.ChainID]eth.BlockID{h.Mock(10).id: {Number: ts}},
+			})
+			require.NoError(t, err)
+		}
+
+		// Call with zero L1BlockRef — should return empty without scanning the DB
+		blockID, ts := h.interop.VerifiedBlockAtL1(h.Mock(10).id, eth.L1BlockRef{})
+		require.Equal(t, eth.BlockID{}, blockID)
+		require.Equal(t, uint64(0), ts)
+	})
+
+	t.Run("non-zero l1Block finds matching entry", func(t *testing.T) {
+		h := newInteropTestHarness(t).
+			WithChain(10, nil).
+			Build()
+
+		chainID := h.Mock(10).id
+		expectedL2 := eth.BlockID{Hash: common.Hash{0xaa}, Number: 105}
+
+		for ts := uint64(100); ts <= 110; ts++ {
+			l2Head := eth.BlockID{Hash: common.Hash{byte(ts)}, Number: ts}
+			if ts == 105 {
+				l2Head = expectedL2
+			}
+			err := h.interop.verifiedDB.Commit(VerifiedResult{
+				Timestamp:   ts,
+				L1Inclusion: eth.BlockID{Number: ts * 10}, // L1 inclusion grows with timestamp
+				L2Heads:     map[eth.ChainID]eth.BlockID{chainID: l2Head},
+			})
+			require.NoError(t, err)
+		}
+
+		// Query for L1 block 1059 — should match timestamp 105 (L1Inclusion.Number=1050 <= 1059)
+		// but not timestamp 106 (L1Inclusion.Number=1060 > 1059)
+		l1Block := eth.L1BlockRef{Hash: common.Hash{0x01}, Number: 1059, Time: 999}
+		blockID, ts := h.interop.VerifiedBlockAtL1(chainID, l1Block)
+		require.Equal(t, expectedL2, blockID)
+		require.Equal(t, uint64(105), ts)
+	})
+
+	t.Run("empty DB returns empty", func(t *testing.T) {
+		h := newInteropTestHarness(t).
+			WithChain(10, nil).
+			Build()
+
+		l1Block := eth.L1BlockRef{Hash: common.Hash{0x01}, Number: 1000, Time: 999}
+		blockID, ts := h.interop.VerifiedBlockAtL1(h.Mock(10).id, l1Block)
+		require.Equal(t, eth.BlockID{}, blockID)
+		require.Equal(t, uint64(0), ts)
+	})
+}


### PR DESCRIPTION
## Summary

- During startup, `FinalizedL1` is zero (no L1 finalization signal received yet)
- `VerifiedBlockAtL1` gets called with this zero value via `FinalizedL2Head()` → `super_authority`
- The function then iterates from `lastTimestamp` (~1.7B) down to 0, calling `VerifiedDB.Get()` for each value
- Since `l1Block.Number == 0`, no entry can ever match (`L1Inclusion.Number` is always > 0), so the loop never terminates
- This blocks the virtual node driver's event loop, preventing engine reset and all derivation

**Fix**: Early return when `l1Block` is the zero value `eth.L1BlockRef{}`. This is the "no information" case — the caller doesn't know what's finalized yet, so there's nothing to look up. The engine controller handles this correctly by falling back to genesis as the finalized head.

## Call trace
```
forceReset() → tryUpdateEngine() → initializeUnknowns() → FinalizedHead()
  → super_authority.FinalizedL2Head() → VerifiedBlockAtL1(chainID, ss.FinalizedL1)
```

## Why this is sufficient
- `FinalizedL1` is only zero before the first `OnL1Finalized` signal — once set, it's never zeroed (not even on `ResetEvent`)
- Only one production caller exists (`super_authority.go:67`)
- `(eth.L1BlockRef{})` cannot represent a real L1 block (real blocks have non-zero hashes), so no legitimate query is blocked
- For non-zero `l1Block`, the loop terminates quickly because the DB is sequential (no gaps) and L1 inclusion numbers are non-decreasing

## Test plan

- [x] Deployed to interop-v0 supernode-0 — virtual nodes derive and advance normally
- [x] Security review confirmed the fix is correct and covers all cases
- [x] Unit test for the zero l1Block case

🤖 Generated with [Claude Code](https://claude.com/claude-code)