### PR TITLE
chore(op-acceptance-tests): add ELSync stalling tests to flake-shake

### DIFF
--- a/op-acceptance-tests/acceptance-tests.yaml
+++ b/op-acceptance-tests/acceptance-tests.yaml
@@ -61,6 +61,24 @@ gates:
        metadata:
          owner: "adrian sutton"
          target_gate: "supernode-interop"
+     - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/depreqres/reqressyncdisabled/elsync
+       name: TestUnsafeChainNotStalling_ELSync_Short
+       timeout: 10m
+       metadata:
+         owner: "anton evangelatov"
+         target_gate: "depreqres"
+     - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/depreqres/reqressyncdisabled/elsync
+       name: TestUnsafeChainNotStalling_ELSync_Long
+       timeout: 10m
+       metadata:
+         owner: "anton evangelatov"
+         target_gate: "depreqres"
+     - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/depreqres/reqressyncdisabled/elsync
+       name: TestUnsafeChainNotStalling_ELSync_RestartOpNode_Long
+       timeout: 10m
+       metadata:
+         owner: "anton evangelatov"
+         target_gate: "depreqres"
 
   - id: isthmus
     description: "Isthmus network tests."

--- a/op-acceptance-tests/acceptance-tests.yaml
+++ b/op-acceptance-tests/acceptance-tests.yaml
@@ -61,19 +61,19 @@ gates:
        metadata:
          owner: "adrian sutton"
          target_gate: "supernode-interop"
-     - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/depreqres/reqressyncdisabled/elsync
+     - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/depreqres/syncmodereqressync/elsync
        name: TestUnsafeChainNotStalling_ELSync_Short
        timeout: 10m
        metadata:
          owner: "anton evangelatov"
          target_gate: "depreqres"
-     - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/depreqres/reqressyncdisabled/elsync
+     - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/depreqres/syncmodereqressync/elsync
        name: TestUnsafeChainNotStalling_ELSync_Long
        timeout: 10m
        metadata:
          owner: "anton evangelatov"
          target_gate: "depreqres"
-     - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/depreqres/reqressyncdisabled/elsync
+     - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/depreqres/syncmodereqressync/elsync
        name: TestUnsafeChainNotStalling_ELSync_RestartOpNode_Long
        timeout: 10m
        metadata:


### PR DESCRIPTION
## Summary

`TestUnsafeChainNotStalling_ELSync_Short/Long/RestartOpNode_Long` have each failed 3× across 3 distinct branches in the past 7 days. All instances passed on rerun. Quarantining while the root cause is investigated.

## Failure pattern

These three tests always co-fail in the same job, never individually. They live in the same package (`depreqres/reqressyncdisabled/elsync`) and delegate to two shared helpers in the `common` package (`UnsafeChainNotStalling_Disconnect` and `_RestartOpNode`). Co-failure means the flake is in the shared setup/fixture, not in any one test's assertion logic.

Confirmed failing jobs:
- `theo/bump-op-reth` job 4470888 → passed on rerun 4474266
- `supernode/SameTimestampinterop` → passed on rerun
- `fix/audit-round2-feb-2026` job 4489682 → passed on rerun 4489145

## Note on effectiveness

These exclusions take effect in `memory-all` only after #19412 (op-acceptor v3.10.1 bump) merges. The current v3.9.0 has a bug where named-test flake-shake entries are silently ignored in gateless mode.

## Root cause investigation

In progress — looking at the `common` package shared fixture for timing issues.