### PR TITLE
experiment: use op-reth for all interop acceptance tests

### DIFF
--- a/op-acceptance-tests/tests/interop/contract/init_test.go
+++ b/op-acceptance-tests/tests/interop/contract/init_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	presets.DoMain(m, presets.WithSimpleInterop())
+	presets.DoMain(m, presets.WithSimpleInterop(), presets.WithRethL2EL())
 }

--- a/op-acceptance-tests/tests/interop/message/init_test.go
+++ b/op-acceptance-tests/tests/interop/message/init_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	presets.DoMain(m, presets.WithSimpleInterop())
+	presets.DoMain(m, presets.WithSimpleInterop(), presets.WithRethL2EL())
 }

--- a/op-acceptance-tests/tests/interop/prep/init_test.go
+++ b/op-acceptance-tests/tests/interop/prep/init_test.go
@@ -10,5 +10,5 @@ func TestMain(m *testing.M) {
 	// Configure a system without interop activation.
 	// We just want to test if we can sync with a supervisor before interop is configured.
 	// The supervisor will not be indexing data yet before interop, and has to handle that interop is not scheduled.
-	presets.DoMain(m, presets.WithSimpleInterop(), presets.WithUnscheduledInterop())
+	presets.DoMain(m, presets.WithSimpleInterop(), presets.WithUnscheduledInterop(), presets.WithRethL2EL())
 }

--- a/op-acceptance-tests/tests/interop/proofs-singlechain/init_test.go
+++ b/op-acceptance-tests/tests/interop/proofs-singlechain/init_test.go
@@ -13,5 +13,6 @@ func TestMain(m *testing.M) {
 		presets.WithSingleChainSuperInteropSupernode(),
 		presets.WithL2NetworkCount(1),
 		stack.MakeCommon(sysgo.WithChallengerCannonKonaEnabled()),
+		presets.WithRethL2EL(),
 	)
 }

--- a/op-acceptance-tests/tests/interop/proofs/fpp/init_test.go
+++ b/op-acceptance-tests/tests/interop/proofs/fpp/init_test.go
@@ -12,5 +12,6 @@ func TestMain(m *testing.M) {
 	presets.DoMain(m,
 		presets.WithSuperInteropSupernode(),
 		stack.MakeCommon(sysgo.WithChallengerCannonKonaEnabled()),
+		presets.WithRethL2EL(),
 	)
 }

--- a/op-acceptance-tests/tests/interop/proofs/init_test.go
+++ b/op-acceptance-tests/tests/interop/proofs/init_test.go
@@ -12,5 +12,6 @@ func TestMain(m *testing.M) {
 	presets.DoMain(m,
 		presets.WithSuperInteropSupernode(),
 		stack.MakeCommon(sysgo.WithChallengerCannonKonaEnabled()),
+		presets.WithRethL2EL(),
 	)
 }

--- a/op-acceptance-tests/tests/interop/proofs/serial/init_test.go
+++ b/op-acceptance-tests/tests/interop/proofs/serial/init_test.go
@@ -12,5 +12,6 @@ func TestMain(m *testing.M) {
 	presets.DoMain(m,
 		presets.WithSuperInteropSupernode(),
 		stack.MakeCommon(sysgo.WithChallengerCannonKonaEnabled()),
+		presets.WithRethL2EL(),
 	)
 }

--- a/op-acceptance-tests/tests/interop/proofs/withdrawal/init_test.go
+++ b/op-acceptance-tests/tests/interop/proofs/withdrawal/init_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	presets.DoMain(m, presets.WithSuperInterop(), presets.WithTimeTravel())
+	presets.DoMain(m, presets.WithSuperInterop(), presets.WithTimeTravel(), presets.WithRethL2EL())
 }

--- a/op-acceptance-tests/tests/interop/reorgs/init_test.go
+++ b/op-acceptance-tests/tests/interop/reorgs/init_test.go
@@ -9,5 +9,5 @@ import (
 // TestMain creates the test-setups against the shared backend
 func TestMain(m *testing.M) {
 	// Other setups may be added here, hydrated from the same orchestrator
-	presets.DoMain(m, presets.WithSimpleInterop())
+	presets.DoMain(m, presets.WithSimpleInterop(), presets.WithRethL2EL())
 }

--- a/op-acceptance-tests/tests/interop/seqwindow/init_test.go
+++ b/op-acceptance-tests/tests/interop/seqwindow/init_test.go
@@ -22,5 +22,6 @@ func TestMain(m *testing.M) {
 			// in L1 block sync considerations in batcher stop or start.
 			// So we end up having to encode block by block, so the full batch data does not get dropped.
 			cfg.BatchType = derive.SingularBatchType
-		})))
+		})),
+		presets.WithRethL2EL())
 }

--- a/op-acceptance-tests/tests/interop/smoke/init_test.go
+++ b/op-acceptance-tests/tests/interop/smoke/init_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	presets.DoMain(m, presets.WithMinimal())
+	presets.DoMain(m, presets.WithMinimal(), presets.WithRethL2EL())
 }

--- a/op-acceptance-tests/tests/interop/sync/multisupervisor_interop/init_test.go
+++ b/op-acceptance-tests/tests/interop/sync/multisupervisor_interop/init_test.go
@@ -15,5 +15,6 @@ func TestMain(m *testing.M) {
 		presets.WithLogFilter(logfilter.DefaultMute(
 			stack.KindSelector(stack.SupervisorKind).And(logfilter.Level(log.LevelInfo)).Show(),
 			logfilter.Level(log.LevelError).Show(),
-		)))
+		)),
+		presets.WithRethL2EL())
 }

--- a/op-acceptance-tests/tests/interop/sync/simple_interop/init_test.go
+++ b/op-acceptance-tests/tests/interop/sync/simple_interop/init_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	presets.DoMain(m, presets.WithSimpleInterop())
+	presets.DoMain(m, presets.WithSimpleInterop(), presets.WithRethL2EL())
 }

--- a/op-acceptance-tests/tests/interop/upgrade-no-supervisor/init_test.go
+++ b/op-acceptance-tests/tests/interop/upgrade-no-supervisor/init_test.go
@@ -9,5 +9,6 @@ import (
 func TestMain(m *testing.M) {
 	presets.DoMain(m,
 		presets.WithMinimalInteropNoSupervisor(),
+		presets.WithRethL2EL(),
 	)
 }

--- a/op-acceptance-tests/tests/interop/upgrade-singlechain/init_test.go
+++ b/op-acceptance-tests/tests/interop/upgrade-singlechain/init_test.go
@@ -12,5 +12,6 @@ func TestMain(m *testing.M) {
 		presets.WithSuggestedInteropActivationOffset(30),
 		presets.WithInteropNotAtGenesis(),
 		presets.WithL2NetworkCount(1), // Specifically testing dependency set of 1 upgrade
+		presets.WithRethL2EL(),
 	)
 }

--- a/op-acceptance-tests/tests/interop/upgrade/init_test.go
+++ b/op-acceptance-tests/tests/interop/upgrade/init_test.go
@@ -10,5 +10,6 @@ func TestMain(m *testing.M) {
 	presets.DoMain(m,
 		presets.WithSimpleInterop(),
 		presets.WithSuggestedInteropActivationOffset(60),
-		presets.WithInteropNotAtGenesis())
+		presets.WithInteropNotAtGenesis(),
+		presets.WithRethL2EL())
 }

--- a/op-devstack/presets/interop.go
+++ b/op-devstack/presets/interop.go
@@ -271,6 +271,12 @@ func WithL2NetworkCount(count int) stack.CommonOption {
 	})
 }
 
+// WithRethL2EL forces all L2 EL nodes in this test suite to use op-reth instead of op-geth.
+// Requires OP_RETH_EXEC_PATH environment variable to be set.
+func WithRethL2EL() stack.CommonOption {
+	return stack.MakeCommon(sysgo.WithL2ELKind("op-reth"))
+}
+
 type MultiSupervisorInterop struct {
 	SimpleInterop
 

--- a/op-devstack/sysgo/l2_el.go
+++ b/op-devstack/sysgo/l2_el.go
@@ -91,16 +91,31 @@ func (l L2ELOptionBundle) Apply(p devtest.P, id stack.L2ELNodeID, cfg *L2ELConfi
 	}
 }
 
+// WithL2ELKind sets the kind of L2 EL node to use for all L2 EL nodes in this orchestrator.
+// Valid values: "op-reth", "op-geth" (default).
+// This overrides the DEVSTACK_L2EL_KIND environment variable.
+func WithL2ELKind(kind string) stack.Option[*Orchestrator] {
+	return stack.BeforeDeploy(func(o *Orchestrator) {
+		o.l2ELKind = kind
+	})
+}
+
 // WithL2ELNode adds the default type of L2 CL node.
-// The default can be configured with DEVSTACK_L2EL_KIND.
+// The default can be configured with DEVSTACK_L2EL_KIND env var or WithL2ELKind option.
 // Tests that depend on specific types can use options like WithKonaNode and WithOpNode directly.
 func WithL2ELNode(id stack.L2ELNodeID, opts ...L2ELOption) stack.Option[*Orchestrator] {
-	switch os.Getenv("DEVSTACK_L2EL_KIND") {
-	case "op-reth":
-		return WithOpReth(id, opts...)
-	default:
-		return WithOpGeth(id, opts...)
-	}
+	return stack.AfterDeploy(func(orch *Orchestrator) {
+		kind := orch.l2ELKind
+		if kind == "" {
+			kind = os.Getenv("DEVSTACK_L2EL_KIND")
+		}
+		switch kind {
+		case "op-reth":
+			WithOpReth(id, opts...).AfterDeploy(orch)
+		default:
+			WithOpGeth(id, opts...).AfterDeploy(orch)
+		}
+	})
 }
 
 func WithExtL2Node(id stack.L2ELNodeID, elRPCEndpoint string) stack.Option[*Orchestrator] {

--- a/op-devstack/sysgo/orchestrator.go
+++ b/op-devstack/sysgo/orchestrator.go
@@ -33,6 +33,7 @@ type Orchestrator struct {
 	proposerOptions         []ProposerOption
 	l2CLOptions             L2CLOptionBundle
 	l2ELOptions             L2ELOptionBundle
+	l2ELKind                string
 	l2ChallengerOpts        l2ChallengerOpts
 	SyncTesterELOptions     SyncTesterELOptionBundle
 	deployerPipelineOptions []DeployerPipelineOption


### PR DESCRIPTION
## Summary

Experiment to run all interop acceptance tests against op-reth instead of op-geth.

### Infrastructure changes

- `op-devstack/sysgo/orchestrator.go`: Add `l2ELKind string` field to `Orchestrator`
- `op-devstack/sysgo/l2_el.go`: Add `WithL2ELKind(kind string)` option; make `WithL2ELNode` lazy (defers geth/reth decision to `AfterDeploy` so it can be overridden via `BeforeDeploy` hooks)
- `op-devstack/presets/interop.go`: Add `WithRethL2EL()` common preset option

### Test changes

Add `presets.WithRethL2EL()` to all 16 `init_test.go` files under `op-acceptance-tests/tests/interop/`.

### Backwards compatibility

The existing `DEVSTACK_L2EL_KIND` env var continues to work. The orchestrator field takes precedence when set, otherwise falls back to the env var, then defaults to op-geth.

### Prerequisites

`OP_RETH_EXEC_PATH` must point to a valid op-reth binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)