### PR TITLE
fix(op-node): emit ResetEvent instead of CriticalErrorEvent for deposits-only attributes failure

### DIFF
--- a/op-node/rollup/derive/deriver.go
+++ b/op-node/rollup/derive/deriver.go
@@ -179,7 +179,7 @@ func (d *PipelineDeriver) OnEvent(ctx context.Context, ev event.Event) bool {
 		d.pipeline.log.Warn("Deriving deposits-only attributes", "origin", d.pipeline.Origin())
 		attrib, err := d.pipeline.DepositsOnlyAttributes(x.Parent, x.DerivedFrom)
 		if err != nil {
-			d.emitter.Emit(ctx, rollup.CriticalErrorEvent{
+			d.emitter.Emit(ctx, rollup.ResetEvent{
 				Err: fmt.Errorf("deriving deposits-only attributes: %w", err),
 			})
 			return true


### PR DESCRIPTION
## Summary (by claude)

Changes `DepositsOnlyPayloadAttributesRequestEvent` error handling from `CriticalErrorEvent` (kills the node) to `ResetEvent` (resets the pipeline and retries).

### Problem

`DepositsOnlyAttributes()` has sanity checks that assume `lastAttribs` is always populated when called — this held for the original Holocene invalid-payload flow, where `DepositsOnlyPayloadAttributesRequestEvent` is only emitted immediately after `NextAttributes` set `lastAttribs`.

However, `DepositsOnlyPayloadAttributesRequestEvent` can also be emitted from `PayloadProcessEvent` via the SuperAuthority deny path (`payload_process.go`). In this path, a `ResetEvent` can be processed between the `BuildStartEvent` that initiated the payload and the `PayloadProcessEvent` that checks the deny list — because events are queued, not inline. When that happens, the pipeline reset clears `lastAttribs` to nil, and `DepositsOnlyAttributes()` fails with "no attributes generated yet".

With `CriticalErrorEvent`, this kills the node permanently. Since the deny list is persistent, every restart hits the same crash.

Discovered while working on #19346 (supernode interop reorg/eviction tests).

### Fix

Emit `ResetEvent` instead. The pipeline resets, re-derives from L1, re-populates `lastAttribs` via `NextAttributes`, and the deny check succeeds on retry.

This is consistent with how other transient state mismatches are handled in the derivation pipeline (e.g., `ProvideL1Traversal` emits `ResetEvent` for `ErrReset`). The original Holocene flow is unaffected — its invariants still hold.

### Supernode context

The supernode runs each chain inside a "chain container" that manages a virtual node (VN) — essentially an embedded op-node. When the interop verifier detects an invalid cross-chain executing message:

1. The block hash is added to a **persistent deny list** (bbolt DB on disk)
2. `RewindEngine` **destroys the current VN**, rewinds the EL to before the invalid block, then the container's `Start()` loop creates a **brand new VN** with a fresh derivation pipeline
3. The new VN re-derives from L1 against the rewound engine
4. When it re-derives the denied block, the SuperAuthority deny check fires and requests deposits-only attributes — this normally succeeds

The bug surfaces after multiple reorg cycles because the chain accumulates deposits-only blocks from prior cycles. When the new VN re-derives and encounters one of these prior deposits-only blocks, it derives attributes that include the invalid tx (from L1 batch data), but the on-chain block is deposits-only — a mismatch. Consolidation emits `BuildStartEvent`, which queues both `ForkchoiceUpdateEvent` and `BuildStartedEvent`. The FCU processing can trigger a `ResetEvent` (due to the head state changing from the reorg). Since events are queued, the processing order becomes:

1. `ForkchoiceUpdateEvent` → triggers `ResetEvent` (queued)
2. `ResetEvent` → pipeline reset, **`lastAttribs = nil`**
3. `BuildStartedEvent` → `BuildSealEvent` → `PayloadProcessEvent`
4. Deny check fires → `DepositsOnlyPayloadAttributesRequestEvent`
5. `DepositsOnlyAttributes()` → `lastAttribs == nil` → **crash**

Since the deny list persists across VN restarts, every new VN re-derives the same denied block and hits the same crash — an infinite crash loop that only `ResetEvent` (instead of `CriticalErrorEvent`) can break.

## Test plan
- Reproduced in supernode interop reorg acceptance tests: node crashed with `"deriving deposits-only attributes: no attributes generated yet"` after the SuperAuthority denied a block during re-derivation of a chain containing prior deposits-only blocks https://github.com/ethereum-optimism/optimism/pull/19346
- With this fix, the node resets and recovers

🤖 Generated with [Claude Code](https://claude.com/claude-code)