### PR TITLE
fix(depreqres): stabilize L2CLB snapshot after disconnect to fix ELSync triple-failure flake

### DIFF
--- a/op-acceptance-tests/tests/depreqres/common/common.go
+++ b/op-acceptance-tests/tests/depreqres/common/common.go
@@ -9,8 +9,25 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testreq"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
+
+// stableSyncStatus returns the sync status of node after any in-flight gossip messages
+// have been drained. DisconnectPeer closes the libp2p connection but a buffered gossip
+// payload can still arrive and be processed via AddUnsafePayload (SyncModeReqResp=true
+// routes CL gossip through the CLSync path even in ELSync mode). Polling until the
+// head is stable ensures the snapshot reflects a quiesced state.
+func stableSyncStatus(require *testreq.Assertions, node *dsl.L2CLNode) *eth.SyncStatus {
+	ss := node.SyncStatus()
+	require.Eventually(func() bool {
+		next := node.SyncStatus()
+		stable := next.UnsafeL2.Number == ss.UnsafeL2.Number
+		ss = next
+		return stable
+	}, 5*time.Second, 200*time.Millisecond, "L2CLB head should stabilize after disconnect")
+	return ss
+}
 
 func UnsafeChainNotStalling_Disconnect(gt *testing.T, syncMode sync.Mode, sleep time.Duration) {
 	t := devtest.SerialT(gt)
@@ -30,19 +47,7 @@ func UnsafeChainNotStalling_Disconnect(gt *testing.T, syncMode sync.Mode, sleep 
 	sys.L2CL.DisconnectPeer(sys.L2CLB)
 
 	ssA_before := sys.L2CL.SyncStatus()
-
-	// Drain any in-flight gossip messages before recording the L2CLB baseline.
-	// DisconnectPeer closes the libp2p connection but a buffered gossip payload can
-	// still arrive and be processed via AddUnsafePayload (SyncModeReqResp=true routes
-	// CL gossip through the CLSync path even in ELSync mode). Polling until the head
-	// is stable ensures the snapshot reflects a quiesced state.
-	ssB_before := sys.L2CLB.SyncStatus()
-	require.Eventually(func() bool {
-		next := sys.L2CLB.SyncStatus()
-		stable := next.UnsafeL2.Number == ssB_before.UnsafeL2.Number
-		ssB_before = next
-		return stable
-	}, 5*time.Second, 200*time.Millisecond, "L2CLB head should stabilize after disconnect")
+	ssB_before := stableSyncStatus(require, sys.L2CLB)
 
 	l.Info("L2CL status before delay", "unsafeL2", ssA_before.UnsafeL2.ID(), "safeL2", ssA_before.SafeL2.ID())
 	l.Info("L2CLB status before delay", "unsafeL2", ssB_before.UnsafeL2.ID(), "safeL2", ssB_before.SafeL2.ID())
@@ -85,16 +90,7 @@ func UnsafeChainNotStalling_RestartOpNode(gt *testing.T, syncMode sync.Mode, sle
 	sys.L2CL.DisconnectPeer(sys.L2CLB)
 
 	ssA_before := sys.L2CL.SyncStatus()
-
-	// Drain any in-flight gossip messages before recording the L2CLB baseline.
-	// See UnsafeChainNotStalling_Disconnect for full explanation.
-	ssB_before := sys.L2CLB.SyncStatus()
-	require.Eventually(func() bool {
-		next := sys.L2CLB.SyncStatus()
-		stable := next.UnsafeL2.Number == ssB_before.UnsafeL2.Number
-		ssB_before = next
-		return stable
-	}, 5*time.Second, 200*time.Millisecond, "L2CLB head should stabilize after disconnect")
+	ssB_before := stableSyncStatus(require, sys.L2CLB)
 
 	l.Info("L2CL status before delay", "unsafeL2", ssA_before.UnsafeL2.ID(), "safeL2", ssA_before.SafeL2.ID())
 	l.Info("L2CLB status before delay", "unsafeL2", ssB_before.UnsafeL2.ID(), "safeL2", ssB_before.SafeL2.ID())

--- a/op-acceptance-tests/tests/depreqres/common/common.go
+++ b/op-acceptance-tests/tests/depreqres/common/common.go
@@ -30,7 +30,19 @@ func UnsafeChainNotStalling_Disconnect(gt *testing.T, syncMode sync.Mode, sleep 
 	sys.L2CL.DisconnectPeer(sys.L2CLB)
 
 	ssA_before := sys.L2CL.SyncStatus()
+
+	// Drain any in-flight gossip messages before recording the L2CLB baseline.
+	// DisconnectPeer closes the libp2p connection but a buffered gossip payload can
+	// still arrive and be processed via AddUnsafePayload (SyncModeReqResp=true routes
+	// CL gossip through the CLSync path even in ELSync mode). Polling until the head
+	// is stable ensures the snapshot reflects a quiesced state.
 	ssB_before := sys.L2CLB.SyncStatus()
+	require.Eventually(func() bool {
+		next := sys.L2CLB.SyncStatus()
+		stable := next.UnsafeL2.Number == ssB_before.UnsafeL2.Number
+		ssB_before = next
+		return stable
+	}, 5*time.Second, 200*time.Millisecond, "L2CLB head should stabilize after disconnect")
 
 	l.Info("L2CL status before delay", "unsafeL2", ssA_before.UnsafeL2.ID(), "safeL2", ssA_before.SafeL2.ID())
 	l.Info("L2CLB status before delay", "unsafeL2", ssB_before.UnsafeL2.ID(), "safeL2", ssB_before.SafeL2.ID())
@@ -73,7 +85,16 @@ func UnsafeChainNotStalling_RestartOpNode(gt *testing.T, syncMode sync.Mode, sle
 	sys.L2CL.DisconnectPeer(sys.L2CLB)
 
 	ssA_before := sys.L2CL.SyncStatus()
+
+	// Drain any in-flight gossip messages before recording the L2CLB baseline.
+	// See UnsafeChainNotStalling_Disconnect for full explanation.
 	ssB_before := sys.L2CLB.SyncStatus()
+	require.Eventually(func() bool {
+		next := sys.L2CLB.SyncStatus()
+		stable := next.UnsafeL2.Number == ssB_before.UnsafeL2.Number
+		ssB_before = next
+		return stable
+	}, 5*time.Second, 200*time.Millisecond, "L2CLB head should stabilize after disconnect")
 
 	l.Info("L2CL status before delay", "unsafeL2", ssA_before.UnsafeL2.ID(), "safeL2", ssA_before.SafeL2.ID())
 	l.Info("L2CLB status before delay", "unsafeL2", ssB_before.UnsafeL2.ID(), "safeL2", ssB_before.SafeL2.ID())


### PR DESCRIPTION
## Root Cause

Three tests in `syncmodereqressync/elsync` always co-fail in CI with the pattern:

```
ssB_before=3, ssB_after=4
require.Equal(ssB_after.UnsafeL2.Number, ssB_before.UnsafeL2.Number) → FAIL
```

**Why they fail:**

`init_test.go` for `syncmodereqressync/elsync` uses `WithSyncModeReqRespSync()` which sets `cfg.SyncModeReqResp = true`. In `sync_deriver.go:109`:

```go
if s.SyncCfg.SyncMode == sync.CLSync || (!s.Engine.IsEngineInitialELSyncing() && s.SyncCfg.SyncModeReqResp) {
    s.Engine.AddUnsafePayload(ctx, envelope)  // CLSync path
    return
}
```

When `SyncModeReqResp=true` and not in initial EL sync, gossip payloads are processed via the CLSync path even in ELSync mode. `DisconnectPeer` closes the libp2p connection but a gossip message for block 4 already in transit can still arrive. The window between `DisconnectPeer` returning and `ssB_before` being recorded is wide enough for this message to be delivered and advance L2CLB's head from 3→4 — making `ssB_before=3` stale immediately.

**Why only `syncmodereqressync` (not `reqressyncdisabled`):** The `reqressyncdisabled` variant uses `WithReqRespSyncDisabled()` which sets `UseReqRespSync=false`, keeping all ELSync mode traffic on the EL path. The in-flight gossip is ignored.

**Why triple-failure:** The three tests share a sequential devnet. Short's L2CLB is left at block 4 when it should be at 3, so Long's initial `CheckAll` (expecting to advance from 4 to 7) fails within its 30-attempt window, and `RestartOpNode_Long` cascades similarly.

## Fix

After `DisconnectPeer`, poll `ssB` until two consecutive reads agree before recording the baseline snapshot. This drains any in-flight gossip messages before the "before" state is captured. The drain window is milliseconds; the 5s timeout is a safety margin.

## Evidence

Before fix (count=1, CI job 4489682 pattern reproduced locally):
```
FAIL  github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/depreqres/syncmodereqressync/elsync
```

After fix (count=5, all pass):
```
--- PASS: TestUnsafeChainNotStalling_ELSync_Short (28.22s)
--- PASS: TestUnsafeChainNotStalling_ELSync_Short (30.22s)
--- PASS: TestUnsafeChainNotStalling_ELSync_Short (30.21s)
--- PASS: TestUnsafeChainNotStalling_ELSync_Short (30.22s)
--- PASS: TestUnsafeChainNotStalling_ELSync_Short (30.22s)
ok  github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/depreqres/syncmodereqressync/elsync  152.651s
```

## Related

- PR #19415: adds these three tests to flake-shake gate (pending)
- This PR is the actual fix; #19415 can be closed once this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)