### PR TITLE
fix(ci): retry L1 archive RPC call in print-pinned-block-number

### DIFF
--- a/packages/contracts-bedrock/justfile
+++ b/packages/contracts-bedrock/justfile
@@ -94,6 +94,7 @@ test-dev *ARGS: build-go-ffi
 
 # Calculates and prints the pinned block number for the current ETH_RPC_URL.
 # Uses the most recent Sunday at 00:00 UTC as the target timestamp.
+# Retries up to 3 times with a 5-second delay to handle transient RPC failures.
 print-pinned-block-number:
   #!/usr/bin/env bash
   set -euo pipefail
@@ -103,7 +104,17 @@ print-pinned-block-number:
   h=$(date -u +%H); m=$(date -u +%M); s=$(date -u +%S)
   secs_since_midnight=$(( 10#$h * 3600 + 10#$m * 60 + 10#$s ))
   sunday_midnight=$(( now - secs_since_midnight - dow * 86400 ))
-  cast find-block "$sunday_midnight" --rpc-url $ETH_RPC_URL
+  for attempt in 1 2 3; do
+    if cast find-block "$sunday_midnight" --rpc-url $ETH_RPC_URL; then
+      exit 0
+    fi
+    if [ "$attempt" -lt 3 ]; then
+      echo "Attempt $attempt failed, retrying in 5s..." >&2
+      sleep 5
+    fi
+  done
+  echo "All attempts to fetch pinned block number failed" >&2
+  exit 1
 
 # Prepares the environment for upgrade path variant of contract tests and coverage.
 # Env Vars:

--- a/packages/contracts-bedrock/justfile
+++ b/packages/contracts-bedrock/justfile
@@ -104,13 +104,15 @@ print-pinned-block-number:
   h=$(date -u +%H); m=$(date -u +%M); s=$(date -u +%S)
   secs_since_midnight=$(( 10#$h * 3600 + 10#$m * 60 + 10#$s ))
   sunday_midnight=$(( now - secs_since_midnight - dow * 86400 ))
+  delay=5
   for attempt in 1 2 3; do
     if cast find-block "$sunday_midnight" --rpc-url $ETH_RPC_URL; then
       exit 0
     fi
     if [ "$attempt" -lt 3 ]; then
-      echo "Attempt $attempt failed, retrying in 5s..." >&2
-      sleep 5
+      echo "Attempt $attempt failed, retrying in ${delay}s..." >&2
+      sleep "$delay"
+      delay=$(( delay * 2 ))
     fi
   done
   echo "All attempts to fetch pinned block number failed" >&2


### PR DESCRIPTION
## Problem

`ci-mainnet-l1-archive.optimism.io` returns transient 5xx errors (Cloudflare 502) occasionally. When this happens, the `print-pinned-block-number` step fails immediately, killing **all** `contracts-bedrock-coverage` and `contracts-bedrock-tests-upgrade` job variants simultaneously — 5+ jobs fail from a single brief RPC outage with zero test signal produced.

Confirmed incident: 2026-03-04 ~18:57 UTC on PR #19272, all 5 coverage variants killed.

## Fix

Add 3 retries with 5s delay to `print-pinned-block-number` in `packages/contracts-bedrock/justfile`. The change is localized to this one recipe and covers all callers (both coverage and upgrade test jobs in CI).

```
Attempt 1: cast find-block ... → 502
Attempt 1 failed, retrying in 5s...
Attempt 2: cast find-block ... → success
```

Maximum added latency on a 3-fail scenario: 10s (2×5s sleep). Typical transient outages resolve within 30–60s so 3 attempts covers the common case.

## Test plan

- [ ] Verified `just print-pinned-block-number` still works with a live RPC URL
- [ ] CI passes (no justfile syntax issues — the recipe uses `#!/usr/bin/env bash` shebang so standard bash retry loop is valid)

🤖 Generated with [Claude Code](https://claude.com/claude-code)