### PR TITLE
fix(op-service): increase Anvil startup timeout 5s → 30s

### DIFF
--- a/op-service/testutils/devnet/anvil.go
+++ b/op-service/testutils/devnet/anvil.go
@@ -114,7 +114,7 @@ func (r *Anvil) Start() error {
 	go r.outputStream(r.stdout)
 	go r.outputStream(r.stderr)
 
-	timeoutC := time.NewTimer(5 * time.Second)
+	timeoutC := time.NewTimer(30 * time.Second)
 
 	select {
 	case <-r.startedCh:


### PR DESCRIPTION
## Summary

- Increases the Anvil startup timeout in `op-service/testutils/devnet/anvil.go` from **5 seconds to 30 seconds**
- Fixes `TestImplementations` and `TestSuperchain` in `op-deployer/pkg/deployer/bootstrap` — the **#2 and #3 most frequent flakes** in the repo over the last 7 days (67 and 46 incidences respectively)

## Root Cause

`Anvil.Start()` waits for Anvil to print `"Listening on 127.0.0.1"` before returning. With a 5s timeout, this races against CI load: when 12 parallel nodes share a `2xlarge` box, Anvil occasionally takes >5s to initialize, producing:

```
failed to start Anvil: anvil did not start in time
```

The test retries usually recover (job passes), but about 1 in N runs exhausts retries and the job fails hard — as seen in job [#4491716](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/118123/workflows/e130e358-cde0-471f-beb6-8a3fb7e1a41e/jobs/4491716).

## Verification

Reproduced locally by setting timeout to 1ms → confirmed `anvil did not start in time`. With 30s → Anvil starts successfully every time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)