### PR TITLE
refactor(op-supernode): remove unused CurrentL1 tracking from interop activity

### DIFF
--- a/op-supernode/supernode/activity/activity.go
+++ b/op-supernode/supernode/activity/activity.go
@@ -39,9 +39,6 @@ type VerificationActivity interface {
 	// Reset resets the activity's state.
 	Reset(chainID eth.ChainID, timestamp uint64, invalidatedBlock eth.BlockRef)
 
-	// CurrentL1 returns the current L1 block ID.
-	CurrentL1() eth.BlockID
-
 	// VerifiedAtTimestamp returns true if the activity has verified the data at the given timestamp.
 	VerifiedAtTimestamp(ts uint64) (bool, error)
 

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -51,8 +51,6 @@ type Interop struct {
 	cancel  context.CancelFunc
 	started bool
 
-	currentL1 eth.BlockID
-
 	verifyFn func(ts uint64, blocksAtTimestamp map[eth.ChainID]eth.BlockID) (Result, error)
 
 	// cycleVerifyFn handles same-timestamp cycle verification.
@@ -186,13 +184,6 @@ func (i *Interop) Resume() {
 // progressAndRecord attempts to progress interop and record the result.
 // Returns (madeProgress, error) where madeProgress indicates if we advanced the verified timestamp.
 func (i *Interop) progressAndRecord() (bool, error) {
-	// Check the L1s of each chain prior to performing interop
-	localCurrentL1, err := i.collectCurrentL1()
-	if err != nil {
-		i.log.Error("failed to collect current L1", "err", err)
-		return false, err
-	}
-
 	// Perform the interop evaluation
 	result, err := i.progressInterop()
 	if err != nil {
@@ -219,35 +210,7 @@ func (i *Interop) progressAndRecord() (bool, error) {
 	// - if interop ran and advanced the verified timestamp, the L1Inclusion is the L1 inclusion at the verified timestamp
 	// this is because the individual chains may advance their CurrentL1, and if progress is being made, we might not be done using the collected L1s.
 	verifiedAdvanced := !result.IsEmpty()
-	i.mu.Lock()
-	if verifiedAdvanced {
-		// the new CurrentL1 is the L1 inclusion at the verified timestamp
-		i.currentL1 = result.L1Inclusion
-	} else {
-		// the new CurrentL1 is the lowest CurrentL1 from the collected chains
-		i.currentL1 = localCurrentL1
-	}
-	i.mu.Unlock()
 	return verifiedAdvanced, nil
-}
-
-// collectCurrentL1 collects the current L1 head of all chains,
-// which is the minimum L1 head of all the derivation pipelines in Chain Containers
-func (i *Interop) collectCurrentL1() (eth.BlockID, error) {
-	var currentL1 eth.BlockID
-	first := true
-	for _, chain := range i.chains {
-		status, err := chain.SyncStatus(i.ctx)
-		if err != nil {
-			return eth.BlockID{}, fmt.Errorf("chain %s not ready: %w", chain.ID(), err)
-		}
-		block := status.CurrentL1
-		if first || block.Number < currentL1.Number {
-			currentL1 = block.ID()
-			first = false
-		}
-	}
-	return currentL1, nil
 }
 
 func (i *Interop) progressInterop() (Result, error) {
@@ -414,14 +377,6 @@ func (i *Interop) commitVerifiedResult(timestamp uint64, verifiedResult Verified
 	return i.verifiedDB.Commit(verifiedResult)
 }
 
-// CurrentL1 returns the L1 block which has been fully considered for interop,
-// whether or not it advanced the verified timestamp.
-func (i *Interop) CurrentL1() eth.BlockID {
-	i.mu.RLock()
-	defer i.mu.RUnlock()
-	return i.currentL1
-}
-
 // VerifiedAtTimestamp returns whether the data is verified at the given timestamp.
 // For timestamps before the activation timestamp, this returns true since interop
 // wasn't active yet and verification proceeds automatically.
@@ -509,9 +464,6 @@ func (i *Interop) Reset(chainID eth.ChainID, timestamp uint64, invalidatedBlock 
 
 	i.resetLogsDB(chainID, db, invalidatedBlock)
 	i.resetVerifiedDB(timestamp)
-
-	// Reset the currentL1 to force re-evaluation
-	i.currentL1 = eth.BlockID{}
 }
 
 // resetLogsDB rewinds or clears the logsDB for a chain to the block before the invalidated block.

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -197,18 +197,7 @@ func (i *Interop) progressAndRecord() (bool, error) {
 		i.log.Error("failed to handle result", "err", err)
 		return false, err
 	}
-	// if the result is invalid, exit without updating the current L1s
-	if !result.IsEmpty() && !result.IsValid() {
-		i.log.Warn("result is invalid, skipping current L1 update", "results", result)
-		return false, nil
-	}
 
-	// Once interop is complete and recorded, update the current L1s
-	// the current L1s being considered by the Activity right now depend on what progress was made:
-	// - if interop failed to run, the current L1s are not updated
-	// - if interop ran but did not advance the verified timestamp, the CurrentL1 values collected are used directly
-	// - if interop ran and advanced the verified timestamp, the L1Inclusion is the L1 inclusion at the verified timestamp
-	// this is because the individual chains may advance their CurrentL1, and if progress is being made, we might not be done using the collected L1s.
 	verifiedAdvanced := !result.IsEmpty()
 	return verifiedAdvanced, nil
 }

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -198,7 +198,7 @@ func (i *Interop) progressAndRecord() (bool, error) {
 		return false, err
 	}
 
-	verifiedAdvanced := !result.IsEmpty()
+	verifiedAdvanced := !result.IsEmpty() && result.IsValid()
 	return verifiedAdvanced, nil
 }
 

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -285,70 +285,6 @@ func TestStartStop(t *testing.T) {
 }
 
 // =============================================================================
-// TestCollectCurrentL1
-// =============================================================================
-
-func TestCollectCurrentL1(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name   string
-		setup  func(h *interopTestHarness) *interopTestHarness
-		assert func(t *testing.T, l1 eth.BlockID, err error)
-	}{
-		{
-			name: "returns minimum L1 across multiple chains",
-			setup: func(h *interopTestHarness) *interopTestHarness {
-				return h.WithChain(10, func(m *mockChainContainer) {
-					m.currentL1 = eth.BlockRef{Number: 200, Hash: common.HexToHash("0x2")}
-				}).WithChain(8453, func(m *mockChainContainer) {
-					m.currentL1 = eth.BlockRef{Number: 100, Hash: common.HexToHash("0x1")} // minimum
-				}).Build()
-			},
-			assert: func(t *testing.T, l1 eth.BlockID, err error) {
-				require.NoError(t, err)
-				require.Equal(t, uint64(100), l1.Number)
-				require.Equal(t, common.HexToHash("0x1"), l1.Hash)
-			},
-		},
-		{
-			name: "single chain returns its L1",
-			setup: func(h *interopTestHarness) *interopTestHarness {
-				return h.WithChain(10, func(m *mockChainContainer) {
-					m.currentL1 = eth.BlockRef{Number: 500, Hash: common.HexToHash("0x5")}
-				}).Build()
-			},
-			assert: func(t *testing.T, l1 eth.BlockID, err error) {
-				require.NoError(t, err)
-				require.Equal(t, uint64(500), l1.Number)
-			},
-		},
-		{
-			name: "chain error propagated",
-			setup: func(h *interopTestHarness) *interopTestHarness {
-				return h.WithChain(10, func(m *mockChainContainer) {
-					m.currentL1Err = errors.New("chain not synced")
-				}).Build()
-			},
-			assert: func(t *testing.T, l1 eth.BlockID, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "not ready")
-				require.Equal(t, eth.BlockID{}, l1)
-			},
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			h := newInteropTestHarness(t)
-			tc.setup(h)
-			l1, err := h.interop.collectCurrentL1()
-			tc.assert(t, l1, err)
-		})
-	}
-}
-
-// =============================================================================
 // TestCheckChainsReady
 // =============================================================================
 
@@ -1010,14 +946,9 @@ func TestProgressAndRecord(t *testing.T) {
 				}).Build()
 			},
 			run: func(t *testing.T, h *interopTestHarness) {
-				require.Equal(t, eth.BlockID{}, h.interop.currentL1)
-
 				madeProgress, err := h.interop.progressAndRecord()
 				require.NoError(t, err)
 				require.False(t, madeProgress, "empty result should not advance verified timestamp")
-
-				require.Equal(t, uint64(100), h.interop.currentL1.Number)
-				require.Equal(t, common.HexToHash("0x1"), h.interop.currentL1.Hash)
 			},
 		},
 		{
@@ -1037,9 +968,6 @@ func TestProgressAndRecord(t *testing.T) {
 				madeProgress, err := h.interop.progressAndRecord()
 				require.NoError(t, err)
 				require.True(t, madeProgress, "valid result should advance verified timestamp")
-
-				require.Equal(t, expectedL1Inclusion.Number, h.interop.currentL1.Number)
-				require.Equal(t, expectedL1Inclusion.Hash, h.interop.currentL1.Hash)
 			},
 		},
 		{
@@ -1052,9 +980,6 @@ func TestProgressAndRecord(t *testing.T) {
 			},
 			run: func(t *testing.T, h *interopTestHarness) {
 				mock := h.Mock(10)
-				initialL1 := eth.BlockID{Number: 50, Hash: common.HexToHash("0x50")}
-				h.interop.currentL1 = initialL1
-
 				h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID) (Result, error) {
 					return Result{
 						Timestamp:    ts,
@@ -1067,22 +992,6 @@ func TestProgressAndRecord(t *testing.T) {
 				madeProgress, err := h.interop.progressAndRecord()
 				require.NoError(t, err)
 				require.False(t, madeProgress, "invalid result should not advance verified timestamp")
-
-				require.Equal(t, initialL1.Number, h.interop.currentL1.Number)
-				require.Equal(t, initialL1.Hash, h.interop.currentL1.Hash)
-			},
-		},
-		{
-			name: "errors propagated",
-			setup: func(h *interopTestHarness) *interopTestHarness {
-				return h.WithChain(10, func(m *mockChainContainer) {
-					m.currentL1Err = errors.New("L1 sync error")
-				}).Build()
-			},
-			run: func(t *testing.T, h *interopTestHarness) {
-				madeProgress, err := h.interop.progressAndRecord()
-				require.Error(t, err)
-				require.False(t, madeProgress, "error should not advance verified timestamp")
 			},
 		},
 	}
@@ -1124,10 +1033,6 @@ func TestInterop_FullCycle(t *testing.T) {
 
 	// Run 3 cycles
 	for i := 0; i < 3; i++ {
-		l1, err := interop.collectCurrentL1()
-		require.NoError(t, err)
-		require.Equal(t, uint64(1000), l1.Number)
-
 		result, err := interop.progressInterop()
 		require.NoError(t, err)
 		require.False(t, result.IsEmpty())
@@ -1490,25 +1395,6 @@ func TestReset(t *testing.T) {
 				require.False(t, has)
 				has, _ = h.interop.verifiedDB.Has(102)
 				require.False(t, has)
-			},
-		},
-		{
-			name: "resets currentL1",
-			setup: func(h *interopTestHarness) (*interopTestHarness, *mockLogsDBForInterop) {
-				h.WithChain(10, func(m *mockChainContainer) {
-					m.blockAtTimestamp = eth.L2BlockRef{Number: 99}
-				}).Build()
-				mockLogsDB := &mockLogsDBForInterop{}
-				h.interop.logsDBs[h.Mock(10).id] = mockLogsDB
-				return h, mockLogsDB
-			},
-			run: func(t *testing.T, h *interopTestHarness, mockLogsDB *mockLogsDBForInterop) {
-				h.interop.currentL1 = eth.BlockID{Number: 500, Hash: common.HexToHash("0xL1")}
-
-				invalidatedBlock := eth.BlockRef{Number: 100, ParentHash: common.Hash{}}
-				h.interop.Reset(h.Mock(10).id, 100, invalidatedBlock)
-
-				require.Equal(t, eth.BlockID{}, h.interop.currentL1)
 			},
 		},
 		{


### PR DESCRIPTION
The currentL1 field and related methods were not being used externally and added unnecessary complexity to the interop verification flow.
