### PR TITLE
chore(op-acceptance-tests): op-acceptor v3.10.2

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -41,7 +41,7 @@ anvil = "1.2.3"
 codecov-uploader = "0.8.0"
 goreleaser-pro = "2.11.2"
 kurtosis = "1.8.1"
-op-acceptor = "op-acceptor/v3.10.1"
+op-acceptor = "op-acceptor/v3.10.2"
 git-cliff = "2.12.0"
 
 # Fake dependencies

--- a/op-acceptance-tests/justfile
+++ b/op-acceptance-tests/justfile
@@ -1,6 +1,6 @@
 REPO_ROOT := `realpath ..`  # path to the root of the optimism monorepo
 KURTOSIS_DIR := REPO_ROOT + "/kurtosis-devnet"
-ACCEPTOR_VERSION := env_var_or_default("ACCEPTOR_VERSION", "v3.10.1")
+ACCEPTOR_VERSION := env_var_or_default("ACCEPTOR_VERSION", "v3.10.2")
 DOCKER_REGISTRY := env_var_or_default("DOCKER_REGISTRY", "us-docker.pkg.dev/oplabs-tools-artifacts/images")
 ACCEPTOR_IMAGE := env_var_or_default("ACCEPTOR_IMAGE", DOCKER_REGISTRY + "/op-acceptor:" + ACCEPTOR_VERSION)
 


### PR DESCRIPTION
## Summary
- Bump op-acceptor to v3.10.2 in mise.toml and op-acceptance-tests justfile

## Test plan
- [ ] CI passes with the updated op-acceptor version

🤖 Generated with [Claude Code](https://claude.com/claude-code)