### PR TITLE
test(contracts): fix testFuzz_params_validValues_succeeds rejection rate

### DIFF
--- a/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
+++ b/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
@@ -2628,68 +2628,86 @@ contract OptimismPortal2_Params_Test is CommonTest {
         // Get the set system gas limit
         uint64 gasLimit = systemConfig.gasLimit();
 
+        // Bind elasticity and denominator first since rounding and gas burn cap depend on them.
+        _elasticityMultiplier = uint8(bound(_elasticityMultiplier, 1, type(uint8).max));
+        _baseFeeMaxChangeDenominator = uint8(bound(_baseFeeMaxChangeDenominator, 2, type(uint8).max));
+
         // Bound resource config
         _systemTxMaxGas = uint32(bound(_systemTxMaxGas, 0, gasLimit - 21000));
         _maxResourceLimit = uint32(bound(_maxResourceLimit, 21000, MAX_GAS_LIMIT / 8));
         _maxResourceLimit = uint32(bound(_maxResourceLimit, 21000, gasLimit - _systemTxMaxGas));
+
+        // Round _maxResourceLimit down to nearest multiple of _elasticityMultiplier so it's
+        // divisible by construction, replacing the vm.assume that rejected ~97.6% of inputs.
+        _maxResourceLimit = uint32((_maxResourceLimit / _elasticityMultiplier) * _elasticityMultiplier);
+        vm.assume(_maxResourceLimit >= 21000);
+
         _maximumBaseFee = uint128(bound(_maximumBaseFee, 1, type(uint128).max));
         _minimumBaseFee = uint32(bound(_minimumBaseFee, 0, _maximumBaseFee - 1));
         _gasLimit = uint64(bound(_gasLimit, 21000, _maxResourceLimit));
         _gasLimit = uint64(bound(_gasLimit, 0, gasLimit));
-        _prevBaseFee = uint128(bound(_prevBaseFee, 0, 3 gwei));
         _prevBoughtGas = uint64(bound(_prevBoughtGas, 0, _maxResourceLimit - _gasLimit));
         _blockDiff = uint8(bound(_blockDiff, 0, 3));
-        _baseFeeMaxChangeDenominator = uint8(bound(_baseFeeMaxChangeDenominator, 2, type(uint8).max));
-        _elasticityMultiplier = uint8(bound(_elasticityMultiplier, 1, type(uint8).max));
 
         // Prevent values that would cause reverts
         vm.assume(uint256(_maxResourceLimit) + uint256(_systemTxMaxGas) <= gasLimit);
-        vm.assume(((_maxResourceLimit / _elasticityMultiplier) * _elasticityMultiplier) == _maxResourceLimit);
 
-        // Although we typically want to limit the usage of vm.assume, we've constructed the above
-        // bounds to satisfy the assumptions listed in this specific section. These assumptions
-        // serve only to act as an additional sanity check on top of the bounds and should not
-        // result in an unnecessary number of test rejections.
+        // These assumptions serve only to act as an additional sanity check on top of the bounds
+        // and should not result in an unnecessary number of test rejections.
         vm.assume(gasLimit >= _gasLimit);
         vm.assume(_minimumBaseFee < _maximumBaseFee);
 
-        // Base fee can increase quickly and mean that we can't buy the amount of gas we want.
-        // Here we add a VM assumption to bound the potential increase.
-        // Compute the maximum possible increase in base fee.
-        uint256 maxPercentIncrease = uint256(_elasticityMultiplier - 1) * 100 / uint256(_baseFeeMaxChangeDenominator);
-
-        // Assume that we have enough gas to burn.
-        // Compute the maximum amount of gas we'd need to burn.
-        // Assume we need 1/5 of our gas to do other stuff.
-        vm.assume(_prevBaseFee * maxPercentIncrease * _gasLimit / 100 < MAX_GAS_LIMIT * 4 / 5);
+        // Bound _prevBaseFee directly instead of filtering with vm.assume. Derivation:
+        //   Let m = maxPercentIncrease, g = _gasLimit, T = MAX_GAS_LIMIT * 4 / 5.
+        //   Original filter:  _prevBaseFee * m * g / 100 < T          (strict, integer division)
+        //   Multiply both sides by 100:  _prevBaseFee * m * g < T * 100
+        //   Divide both sides by (m * g):  _prevBaseFee < (T * 100) / (m * g)
+        //   Convert strict '<' to '<=':  _prevBaseFee <= (T * 100 - 1) / (m * g)
+        // When m * g == 0 the gas burn is always 0 < T, so no cap is needed.
+        {
+            // Original upper bound on _prevBaseFee before the gas burn constraint.
+            uint256 maxBaseFee = 3 gwei;
+            uint256 maxPercentIncrease =
+                uint256(_elasticityMultiplier - 1) * 100 / uint256(_baseFeeMaxChangeDenominator);
+            uint256 gasBurnDenom = maxPercentIncrease * uint256(_gasLimit);
+            // When gasBurnDenom == 0, gas burn is always 0 < T so the original cap suffices.
+            // Otherwise, take the min of the derived cap and the original cap.
+            uint256 gasBurnCap =
+                gasBurnDenom == 0 ? maxBaseFee : (uint256(MAX_GAS_LIMIT) * 4 / 5 * 100 - 1) / gasBurnDenom;
+            _prevBaseFee = uint128(bound(_prevBaseFee, 0, gasBurnCap < maxBaseFee ? gasBurnCap : maxBaseFee));
+        }
 
         // Pick a pseudorandom block number
         vm.roll(uint256(keccak256(abi.encode(_blockDiff))) % uint256(type(uint16).max) + uint256(_blockDiff));
 
-        // Create a resource config to mock the call to the system config with
-        IResourceMetering.ResourceConfig memory rcfg = IResourceMetering.ResourceConfig({
-            maxResourceLimit: _maxResourceLimit,
-            elasticityMultiplier: _elasticityMultiplier,
-            baseFeeMaxChangeDenominator: _baseFeeMaxChangeDenominator,
-            minimumBaseFee: _minimumBaseFee,
-            systemTxMaxGas: _systemTxMaxGas,
-            maximumBaseFee: _maximumBaseFee
-        });
-        vm.mockCall(address(systemConfig), abi.encodeCall(systemConfig.resourceConfig, ()), abi.encode(rcfg));
+        {
+            // Create a resource config to mock the call to the system config with
+            IResourceMetering.ResourceConfig memory rcfg = IResourceMetering.ResourceConfig({
+                maxResourceLimit: _maxResourceLimit,
+                elasticityMultiplier: _elasticityMultiplier,
+                baseFeeMaxChangeDenominator: _baseFeeMaxChangeDenominator,
+                minimumBaseFee: _minimumBaseFee,
+                systemTxMaxGas: _systemTxMaxGas,
+                maximumBaseFee: _maximumBaseFee
+            });
+            vm.mockCall(address(systemConfig), abi.encodeCall(systemConfig.resourceConfig, ()), abi.encode(rcfg));
+        }
 
-        // Set the resource params
-        uint256 _prevBlockNum = block.number - _blockDiff;
-        vm.store(
-            address(optimismPortal2),
-            bytes32(uint256(1)),
-            bytes32((_prevBlockNum << 192) | (uint256(_prevBoughtGas) << 128) | _prevBaseFee)
-        );
+        {
+            // Set the resource params
+            uint256 _prevBlockNum = block.number - _blockDiff;
+            vm.store(
+                address(optimismPortal2),
+                bytes32(uint256(1)),
+                bytes32((_prevBlockNum << 192) | (uint256(_prevBoughtGas) << 128) | _prevBaseFee)
+            );
 
-        // Ensure that the storage setting is correct
-        (uint128 prevBaseFee, uint64 prevBoughtGas, uint64 prevBlockNum) = optimismPortal2.params();
-        assertEq(prevBaseFee, _prevBaseFee);
-        assertEq(prevBoughtGas, _prevBoughtGas);
-        assertEq(prevBlockNum, _prevBlockNum);
+            // Ensure that the storage setting is correct
+            (uint128 prevBaseFee, uint64 prevBoughtGas, uint64 prevBlockNum) = optimismPortal2.params();
+            assertEq(prevBaseFee, _prevBaseFee);
+            assertEq(prevBoughtGas, _prevBoughtGas);
+            assertEq(prevBlockNum, _prevBlockNum);
+        }
 
         // Do a deposit, should not revert
         optimismPortal2.depositTransaction{ gas: MAX_GAS_LIMIT }({


### PR DESCRIPTION
## Summary

`testFuzz_params_validValues_succeeds` was exhausting Foundry's 65,536-rejection limit due to two `vm.assume` calls:

1. **Divisibility filter** (`vm.assume(r / e * e == r)`): with `_elasticityMultiplier` uniform in [1, 255], rejects ~97.6% of inputs.
2. **Gas burn filter** (`vm.assume(_prevBaseFee * maxPercentIncrease * _gasLimit / 100 < T)`): rejects a further slice depending on parameter ranges.

This PR replaces both with equivalent bound-based construction:

1. **Divisibility**: bind `_elasticityMultiplier` first, then round `_maxResourceLimit` down to the nearest multiple. Since `_gasLimit` and `_prevBoughtGas` are already bounded after `_maxResourceLimit` in the original code, they naturally use the rounded value with no re-bounding needed.
2. **Gas burn**: rearrange `p * m * g / 100 < T` to solve for the upper bound on `_prevBaseFee` (`<= (T * 100 - 1) / (m * g)`), then use `bound()` instead of `vm.assume`.

Scoping blocks are added for the `rcfg` struct, `vm.store`, and gas burn cap computation to avoid stack-too-deep under the lite (no-optimizer) profile.

## Comparison with #19410

This is an alternative to #19410 with a simpler diff. The core math is identical — same rounding for divisibility, same algebraic rearrangement for the gas burn cap. The differences:

- **No reordering of `_gasLimit`/`_prevBoughtGas` bounds**: in the original code these already come after `_maxResourceLimit`, so inserting the rounding between them means they naturally use the rounded value. No "re-bounding" step is needed.
- **Smaller diff**: the second half of the function (from `vm.roll` onward) only changes to add scoping blocks for stack-too-deep, not for logical reasons.
- **No Lean 4 proof**: the `naive_fix_not_sound` theorem in #19410's proof addresses a scenario (rounding after dependent bounds) that doesn't arise when rounding is inserted at the right point in the existing bound order.

## Test plan

- [ ] Run `testFuzz_params_validValues_succeeds` locally with `FOUNDRY_FUZZ_RUNS=10000` to confirm no rejections
- [ ] CI fuzz run passes