### PR TITLE
op-devstack: Add P2P config for supernode follow mode CLs

### DIFF
--- a/op-acceptance-tests/tests/supernode/interop/follow_l2/sync_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/follow_l2/sync_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
-func TestFollowSource_LocalSafeDivergesThenConverges(gt *testing.T) {
+func TestFollowSource_HeadsDivergeThenConverge(gt *testing.T) {
 	t := devtest.SerialT(gt)
 	require := t.Require()
 	sys := presets.NewTwoL2SupernodeFollowL2(t, 0)
@@ -19,6 +19,15 @@ func TestFollowSource_LocalSafeDivergesThenConverges(gt *testing.T) {
 		name     string
 		source   *dsl.L2CLNode
 		follower *dsl.L2CLNode
+	}
+
+	type headSnapshot struct {
+		sourceUnsafe      uint64
+		sourceLocalSafe   uint64
+		sourceCrossSafe   uint64
+		followerUnsafe    uint64
+		followerLocalSafe uint64
+		followerCrossSafe uint64
 	}
 
 	chains := []chainPair{
@@ -39,26 +48,66 @@ func TestFollowSource_LocalSafeDivergesThenConverges(gt *testing.T) {
 	pausedAt := sys.Supernode.EnsureInteropPaused(sys.L2ACL, sys.L2BCL, 10)
 	t.Logger().Info("interop paused", "timestamp", pausedAt)
 
-	// While interop is paused, local-safe should continue to advance and lead cross-safe.
+	baselines := make(map[string]headSnapshot, len(chains))
+	for _, chain := range chains {
+		sourceStatus := chain.source.SyncStatus()
+		followerStatus := chain.follower.SyncStatus()
+		baselines[chain.name] = headSnapshot{
+			sourceUnsafe:      sourceStatus.UnsafeL2.Number,
+			sourceLocalSafe:   sourceStatus.LocalSafeL2.Number,
+			sourceCrossSafe:   sourceStatus.SafeL2.Number,
+			followerUnsafe:    followerStatus.UnsafeL2.Number,
+			followerLocalSafe: followerStatus.LocalSafeL2.Number,
+			followerCrossSafe: followerStatus.SafeL2.Number,
+		}
+	}
+
+	// While interop is paused, unsafe should advance independently ahead of local-safe, and local-safe ahead of cross-safe.
 	require.Eventually(func() bool {
 		for _, chain := range chains {
+			baseline := baselines[chain.name]
 			sourceStatus := chain.source.SyncStatus()
 			followerStatus := chain.follower.SyncStatus()
 
-			if sourceStatus.LocalSafeL2.Number <= sourceStatus.SafeL2.Number+1 {
+			if sourceStatus.UnsafeL2.Number <= baseline.sourceUnsafe {
 				return false
 			}
-			if followerStatus.LocalSafeL2.Number <= followerStatus.SafeL2.Number+1 {
+			if followerStatus.UnsafeL2.Number <= baseline.followerUnsafe {
+				return false
+			}
+			if sourceStatus.UnsafeL2.Number <= sourceStatus.LocalSafeL2.Number {
+				return false
+			}
+			if followerStatus.UnsafeL2.Number <= followerStatus.LocalSafeL2.Number {
+				return false
+			}
+			if sourceStatus.LocalSafeL2.Number <= sourceStatus.SafeL2.Number {
+				return false
+			}
+			if followerStatus.LocalSafeL2.Number <= followerStatus.SafeL2.Number {
+				return false
+			}
+			if sourceStatus.LocalSafeL2.Number <= baseline.sourceLocalSafe {
+				return false
+			}
+			if followerStatus.LocalSafeL2.Number <= baseline.followerLocalSafe {
+				return false
+			}
+			if sourceStatus.SafeL2.Number < baseline.sourceCrossSafe {
+				return false
+			}
+			if followerStatus.SafeL2.Number < baseline.followerCrossSafe {
 				return false
 			}
 		}
 		return true
-	}, 2*time.Minute, 2*time.Second, "expected local-safe to lead cross-safe on source and follower")
+	}, 2*time.Minute, 2*time.Second, "expected unsafe > local-safe > cross-safe with unsafe advancing on source and follower")
 
-	// Core follow-source checks: follower must match source local-safe and cross-safe independently.
-	divergenceChecks := make([]dsl.CheckFunc, 0, len(chains)*2)
+	// Core follow-source checks: follower must match source unsafe, local-safe, and cross-safe independently.
+	divergenceChecks := make([]dsl.CheckFunc, 0, len(chains)*3)
 	for _, chain := range chains {
 		divergenceChecks = append(divergenceChecks,
+			chain.follower.MatchedFn(chain.source, types.LocalUnsafe, 20),
 			chain.follower.MatchedFn(chain.source, types.LocalSafe, 20),
 			chain.follower.MatchedFn(chain.source, types.CrossSafe, 20),
 		)
@@ -85,10 +134,11 @@ func TestFollowSource_LocalSafeDivergesThenConverges(gt *testing.T) {
 		return true
 	}, 3*time.Minute, 2*time.Second, "expected local-safe and cross-safe to converge on followers")
 
-	// Final sanity: follower and source converge to the same local-safe and cross-safe heads.
-	finalChecks := make([]dsl.CheckFunc, 0, len(chains)*2)
+	// Final sanity: follower and source converge to the same unsafe, local-safe, and cross-safe heads.
+	finalChecks := make([]dsl.CheckFunc, 0, len(chains)*3)
 	for _, chain := range chains {
 		finalChecks = append(finalChecks,
+			chain.follower.MatchedFn(chain.source, types.LocalUnsafe, 20),
 			chain.follower.MatchedFn(chain.source, types.LocalSafe, 20),
 			chain.follower.MatchedFn(chain.source, types.CrossSafe, 20),
 		)

--- a/op-devstack/sysgo/l2_cl_opnode.go
+++ b/op-devstack/sysgo/l2_cl_opnode.go
@@ -3,12 +3,9 @@ package sysgo
 import (
 	"context"
 	"encoding/hex"
-	"flag"
 	"fmt"
 	"sync"
 	"time"
-
-	"github.com/urfave/cli/v2"
 
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
@@ -21,9 +18,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/stack/match"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/opnode"
 	"github.com/ethereum-optimism/optimism/op-node/config"
-	opNodeFlags "github.com/ethereum-optimism/optimism/op-node/flags"
-	"github.com/ethereum-optimism/optimism/op-node/p2p"
-	p2pcli "github.com/ethereum-optimism/optimism/op-node/p2p/cli"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/driver"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/interop"
 	nodeSync "github.com/ethereum-optimism/optimism/op-node/rollup/sync"
@@ -224,48 +218,20 @@ func withOpNode(l2CLID stack.ComponentID, l1CLID stack.ComponentID, l1ELID stack
 
 		logger := p.Logger()
 
-		var p2pSignerSetup p2p.SignerSetup
-		var p2pConfig *p2p.Config
-		// code block for P2P setup
-		{
-			// make a dummy flagset since p2p config initialization helpers only input cli context
-			fs := flag.NewFlagSet("", flag.ContinueOnError)
-			// use default flags
-			for _, f := range opNodeFlags.P2PFlags(opNodeFlags.EnvVarPrefix) {
-				require.NoError(f.Apply(fs))
-			}
-			// mandatory P2P flags
-			require.NoError(fs.Set(opNodeFlags.AdvertiseIPName, "127.0.0.1"))
-			require.NoError(fs.Set(opNodeFlags.AdvertiseTCPPortName, "0"))
-			require.NoError(fs.Set(opNodeFlags.AdvertiseUDPPortName, "0"))
-			require.NoError(fs.Set(opNodeFlags.ListenIPName, "127.0.0.1"))
-			require.NoError(fs.Set(opNodeFlags.ListenTCPPortName, "0"))
-			require.NoError(fs.Set(opNodeFlags.ListenUDPPortName, "0"))
-			// avoid resource unavailable error by using memorydb
-			require.NoError(fs.Set(opNodeFlags.DiscoveryPathName, "memory"))
-			require.NoError(fs.Set(opNodeFlags.PeerstorePathName, "memory"))
-			// For peer ID
-			networkPrivKey, err := crypto.GenerateKey()
-			require.NoError(err)
-			networkPrivKeyHex := hex.EncodeToString(crypto.FromECDSA(networkPrivKey))
-			require.NoError(fs.Set(opNodeFlags.P2PPrivRawName, networkPrivKeyHex))
-			// Explicitly set to empty; do not default to resolving DNS of external bootnodes
-			require.NoError(fs.Set(opNodeFlags.BootnodesName, ""))
-
-			cliCtx := cli.NewContext(&cli.App{}, fs, nil)
-			if cfg.IsSequencer {
-				p2pKey, err := orch.keys.Secret(devkeys.SequencerP2PRole.Key(l2CLID.ChainID().ToBig()))
-				require.NoError(err, "need p2p key for sequencer")
-				p2pKeyHex := hex.EncodeToString(crypto.FromECDSA(p2pKey))
-				require.NoError(fs.Set(opNodeFlags.SequencerP2PKeyName, p2pKeyHex))
-				p2pSignerSetup, err = p2pcli.LoadSignerSetup(cliCtx, logger)
-				require.NoError(err, "failed to load p2p signer")
-				logger.Info("Sequencer key acquired")
-			}
-			p2pConfig, err = p2pcli.NewConfig(cliCtx, l2Net.rollupCfg.BlockTime)
-			require.NoError(err, "failed to load p2p config")
-			p2pConfig.NoDiscovery = cfg.NoDiscovery
+		sequencerP2PKeyHex := ""
+		if cfg.IsSequencer {
+			p2pKey, err := orch.keys.Secret(devkeys.SequencerP2PRole.Key(l2CLID.ChainID().ToBig()))
+			require.NoError(err, "need p2p key for sequencer")
+			sequencerP2PKeyHex = hex.EncodeToString(crypto.FromECDSA(p2pKey))
 		}
+		p2pConfig, p2pSignerSetup := newDevstackP2PConfig(
+			p,
+			logger,
+			l2Net.rollupCfg.BlockTime,
+			cfg.NoDiscovery,
+			cfg.EnableReqRespSync,
+			sequencerP2PKeyHex,
+		)
 
 		// specify interop config, but do not configure anything, to disable indexing mode
 		interopCfg := &interop.Config{}
@@ -279,9 +245,6 @@ func withOpNode(l2CLID stack.ComponentID, l1CLID stack.ComponentID, l1ELID stack
 				RPCJwtSecretPath: jwtPath,
 			}
 		}
-
-		// Set the req-resp sync flag as per config
-		p2pConfig.EnableReqRespSync = cfg.EnableReqRespSync
 
 		nodeCfg := &config.Config{
 			L1: &config.L1EndpointConfig{

--- a/op-devstack/sysgo/l2_cl_p2p_config.go
+++ b/op-devstack/sysgo/l2_cl_p2p_config.go
@@ -1,0 +1,74 @@
+package sysgo
+
+import (
+	"encoding/hex"
+	"flag"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	opNodeFlags "github.com/ethereum-optimism/optimism/op-node/flags"
+	"github.com/ethereum-optimism/optimism/op-node/p2p"
+	p2pcli "github.com/ethereum-optimism/optimism/op-node/p2p/cli"
+)
+
+func newDevstackP2PConfig(
+	p devtest.P,
+	logger log.Logger,
+	blockTime uint64,
+	noDiscovery bool,
+	enableReqRespSync bool,
+	sequencerP2PKeyHex string,
+) (*p2p.Config, p2p.SignerSetup) {
+	require := p.Require()
+
+	// make a dummy flagset since p2p config initialization helpers only input cli context
+	fs := flag.NewFlagSet("", flag.ContinueOnError)
+	// use default flags
+	for _, f := range opNodeFlags.P2PFlags(opNodeFlags.EnvVarPrefix) {
+		require.NoError(f.Apply(fs))
+	}
+	// mandatory P2P flags
+	require.NoError(fs.Set(opNodeFlags.AdvertiseIPName, "127.0.0.1"))
+	require.NoError(fs.Set(opNodeFlags.AdvertiseTCPPortName, "0"))
+	require.NoError(fs.Set(opNodeFlags.AdvertiseUDPPortName, "0"))
+	require.NoError(fs.Set(opNodeFlags.ListenIPName, "127.0.0.1"))
+	require.NoError(fs.Set(opNodeFlags.ListenTCPPortName, "0"))
+	require.NoError(fs.Set(opNodeFlags.ListenUDPPortName, "0"))
+	// avoid resource unavailable error by using memorydb
+	require.NoError(fs.Set(opNodeFlags.DiscoveryPathName, "memory"))
+	require.NoError(fs.Set(opNodeFlags.PeerstorePathName, "memory"))
+	// Explicitly set to empty; do not default to resolving DNS of external bootnodes
+	require.NoError(fs.Set(opNodeFlags.BootnodesName, ""))
+	// For peer ID
+	networkPrivKey, err := crypto.GenerateKey()
+	networkPrivKeyHex := hex.EncodeToString(crypto.FromECDSA(networkPrivKey))
+	require.NoError(err)
+	require.NoError(fs.Set(opNodeFlags.P2PPrivRawName, networkPrivKeyHex))
+	if noDiscovery {
+		require.NoError(fs.Set(opNodeFlags.NoDiscoveryName, "true"))
+	}
+	if enableReqRespSync {
+		require.NoError(fs.Set(opNodeFlags.SyncReqRespName, "true"))
+	}
+
+	cliCtx := cli.NewContext(&cli.App{}, fs, nil)
+
+	var p2pSignerSetup p2p.SignerSetup
+	if sequencerP2PKeyHex != "" {
+		require.NoError(fs.Set(opNodeFlags.SequencerP2PKeyName, sequencerP2PKeyHex))
+		p2pSignerSetup, err = p2pcli.LoadSignerSetup(cliCtx, logger)
+		require.NoError(err, "failed to load p2p signer")
+		logger.Info("Sequencer key acquired")
+	}
+
+	p2pConfig, err := p2pcli.NewConfig(cliCtx, blockTime)
+	require.NoError(err, "failed to load p2p config")
+	p2pConfig.NoDiscovery = noDiscovery
+	p2pConfig.EnableReqRespSync = enableReqRespSync
+
+	return p2pConfig, p2pSignerSetup
+}

--- a/op-devstack/sysgo/l2_cl_supernode.go
+++ b/op-devstack/sysgo/l2_cl_supernode.go
@@ -2,15 +2,18 @@ package sysgo
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
 	"sort"
 	"strconv"
 	"sync"
 	"time"
 
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
 
 	altda "github.com/ethereum-optimism/optimism/op-alt-da"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/shim"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
@@ -315,6 +318,20 @@ func withSharedSupernodeCLsImpl(orch *Orchestrator, supernodeID stack.SupernodeI
 		if cluster, ok := orch.ClusterForL2(l2ChainID); ok {
 			depSet = cluster.DepSet()
 		}
+		sequencerP2PKeyHex := ""
+		if isSequencer {
+			p2pKey, err := orch.keys.Secret(devkeys.SequencerP2PRole.Key(l2ChainID.ToBig()))
+			require.NoError(err, "need p2p key for supernode virtual sequencer")
+			sequencerP2PKeyHex = hex.EncodeToString(crypto.FromECDSA(p2pKey))
+		}
+		p2pConfig, p2pSignerSetup := newDevstackP2PConfig(
+			p,
+			logger.New("chain_id", l2ChainID.String(), "component", "supernode-p2p"),
+			l2Net.rollupCfg.BlockTime,
+			false,
+			true,
+			sequencerP2PKeyHex,
+		)
 		return &config.Config{
 			L1: &config.L1EndpointConfig{
 				L1NodeAddr:       l1EL.UserRPC(),
@@ -335,12 +352,13 @@ func withSharedSupernodeCLsImpl(orch *Orchestrator, supernodeID stack.SupernodeI
 			Beacon:                          &config.L1BeaconEndpointConfig{BeaconAddr: l1CL.beaconHTTPAddr},
 			Driver:                          driver.Config{SequencerEnabled: isSequencer, SequencerConfDepth: 2},
 			Rollup:                          *l2Net.rollupCfg,
+			P2PSigner:                       p2pSignerSetup,
 			RPC:                             oprpc.CLIConfig{ListenAddr: "127.0.0.1", ListenPort: 0, EnableAdmin: true},
 			InteropConfig:                   interopCfg,
-			P2P:                             nil,
+			P2P:                             p2pConfig,
 			L1EpochPollInterval:             2 * time.Second,
 			RuntimeConfigReloadInterval:     0,
-			Sync:                            nodeSync.Config{SyncMode: nodeSync.CLSync},
+			Sync:                            nodeSync.Config{SyncMode: nodeSync.CLSync, SyncModeReqResp: true},
 			ConfigPersistence:               config.DisabledConfigPersistence{},
 			Metrics:                         opmetrics.CLIConfig{},
 			Pprof:                           oppprof.CLIConfig{},

--- a/op-devstack/sysgo/system_two_l2_follow_l2.go
+++ b/op-devstack/sysgo/system_two_l2_follow_l2.go
@@ -43,14 +43,13 @@ func DefaultTwoL2SupernodeFollowL2System(dest *DefaultTwoL2SupernodeFollowL2Syst
 	// Chain A follower
 	opt.Add(WithL2ELNode(ids.L2AFollowerEL))
 	opt.Add(WithOpNodeFollowL2(ids.L2AFollowerCL, ids.L1CL, ids.L1EL, ids.L2AFollowerEL, ids.L2ACL))
-	// TODO(#19379): The chain source is a supernode proxy CL, which does not implement opp2p_* RPCs.
-	// Skip CL P2P wiring and rely on follow-source + EL P2P for data availability.
-	// opt.Add(WithL2CLP2PConnection(ids.L2ACL, ids.L2AFollowerCL))
+	opt.Add(WithL2CLP2PConnection(ids.L2ACL, ids.L2AFollowerCL))
 	opt.Add(WithL2ELP2PConnection(ids.L2AEL, ids.L2AFollowerEL, false))
 
 	// Chain B follower
 	opt.Add(WithL2ELNode(ids.L2BFollowerEL))
 	opt.Add(WithOpNodeFollowL2(ids.L2BFollowerCL, ids.L1CL, ids.L1EL, ids.L2BFollowerEL, ids.L2BCL))
+	opt.Add(WithL2CLP2PConnection(ids.L2BCL, ids.L2BFollowerCL))
 	opt.Add(WithL2ELP2PConnection(ids.L2BEL, ids.L2BFollowerEL, false))
 
 	opt.Add(stack.Finally(func(orch *Orchestrator) {


### PR DESCRIPTION
**Description**

Factors out the P2P config to a common devstack helper, and uses the same config function for both cases.

**Tests**

Modifies the test added in #19378 to also check that the unsafe head is advancing correctly and that CL P2P gossip is working as expected. I've double checked that this modified test fails without the `opt.Add(WithL2CLP2PConnection(ids.L2ACL, ids.L2AFollowerCL))` lines and passes with them.

**Additional context**

#19379 and https://github.com/ethereum-optimism/optimism/pull/19378#pullrequestreview-3886694766

**Metadata**

- Fixes #19379 