### PR TITLE
fix(ci): capture vm-compat findings JSON as CI artifact

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -2535,6 +2535,10 @@ jobs:
           command: |
             make run-vm-compat
           working_directory: op-program
+      - store_artifacts:
+          path: op-program/bin/vm-compat-output/vm-compat-findings.json
+          destination: vm-compat-findings.json
+          when: always
 
   op-program-compat:
     docker:

--- a/op-program/Dockerfile.vmcompat
+++ b/op-program/Dockerfile.vmcompat
@@ -26,7 +26,8 @@ RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache
 COPY . /app
 
 # Run the op-program analysis, capturing findings even on failure.
-# The exit code is saved so the caller can extract findings before failing.
+# The exit code is saved so the export stage can extract findings before the
+# check stage fails the build.
 WORKDIR /app/op-program
 ENV FINDINGS_OUTPUT_PATH=/app/op-program/vm-compat-findings.json
 RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build \
@@ -35,4 +36,6 @@ RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache
 
 FROM scratch AS export
 COPY --from=builder /app/op-program/vm-compat-findings.json .
-COPY --from=builder /app/op-program/vm-compat-exit-code .
+
+FROM builder AS check
+RUN exit $(cat /app/op-program/vm-compat-exit-code)

--- a/op-program/Dockerfile.vmcompat
+++ b/op-program/Dockerfile.vmcompat
@@ -34,8 +34,8 @@ RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache
   touch /app/op-program/vm-compat-findings.json && \
   make "analyze-op-program-client-${VM_TARGET}"; echo $? > /app/op-program/vm-compat-exit-code
 
-FROM scratch AS export
-COPY --from=builder /app/op-program/vm-compat-findings.json .
-
 FROM builder AS check
 RUN exit $(cat /app/op-program/vm-compat-exit-code)
+
+FROM scratch AS export
+COPY --from=check /app/op-program/vm-compat-findings.json .

--- a/op-program/Dockerfile.vmcompat
+++ b/op-program/Dockerfile.vmcompat
@@ -32,3 +32,7 @@ ENV FINDINGS_OUTPUT_PATH=/app/op-program/vm-compat-findings.json
 RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build \
   touch /app/op-program/vm-compat-findings.json && \
   make "analyze-op-program-client-${VM_TARGET}"; echo $? > /app/op-program/vm-compat-exit-code
+
+FROM scratch AS export
+COPY --from=builder /app/op-program/vm-compat-findings.json .
+COPY --from=builder /app/op-program/vm-compat-exit-code .

--- a/op-program/Dockerfile.vmcompat
+++ b/op-program/Dockerfile.vmcompat
@@ -30,9 +30,9 @@ COPY . /app
 WORKDIR /app/op-program
 ENV FINDINGS_OUTPUT_PATH=/app/op-program/vm-compat-findings.json
 RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build \
-  touch /app/op-program/vm-compat-findings.json && \
+  touch $FINDINGS_OUTPUT_PATH && \
   make "analyze-op-program-client-${VM_TARGET}"; echo $? > /app/op-program/vm-compat-exit-code
 
 FROM scratch AS export
-COPY --from=builder /app/op-program/vm-compat-findings.json .
+COPY --from=builder $FINDINGS_OUTPUT_PATH .
 COPY --from=builder /app/op-program/vm-compat-exit-code .

--- a/op-program/Dockerfile.vmcompat
+++ b/op-program/Dockerfile.vmcompat
@@ -34,5 +34,5 @@ RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache
   make "analyze-op-program-client-${VM_TARGET}"; echo $? > /app/op-program/vm-compat-exit-code
 
 FROM scratch AS export
-COPY --from=builder $FINDINGS_OUTPUT_PATH .
+COPY --from=builder /app/op-program/vm-compat-findings.json .
 COPY --from=builder /app/op-program/vm-compat-exit-code .

--- a/op-program/Dockerfile.vmcompat
+++ b/op-program/Dockerfile.vmcompat
@@ -26,16 +26,13 @@ RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache
 COPY . /app
 
 # Run the op-program analysis, capturing findings even on failure.
-# The exit code is saved so the export stage can extract findings before the
-# check stage fails the build.
+# The exit code is saved so the caller can extract findings before failing.
 WORKDIR /app/op-program
 ENV FINDINGS_OUTPUT_PATH=/app/op-program/vm-compat-findings.json
 RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build \
   touch /app/op-program/vm-compat-findings.json && \
   make "analyze-op-program-client-${VM_TARGET}"; echo $? > /app/op-program/vm-compat-exit-code
 
-FROM builder AS check
-RUN exit $(cat /app/op-program/vm-compat-exit-code)
-
 FROM scratch AS export
-COPY --from=check /app/op-program/vm-compat-findings.json .
+COPY --from=builder /app/op-program/vm-compat-findings.json .
+COPY --from=builder /app/op-program/vm-compat-exit-code .

--- a/op-program/Dockerfile.vmcompat
+++ b/op-program/Dockerfile.vmcompat
@@ -25,7 +25,10 @@ COPY ./go.mod ./go.sum ./
 RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build go mod download
 COPY . /app
 
-# Run the op-program analysis
+# Run the op-program analysis, capturing findings even on failure.
+# The exit code is saved so the caller can extract findings before failing.
 WORKDIR /app/op-program
+ENV FINDINGS_OUTPUT_PATH=/app/op-program/vm-compat-findings.json
 RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build \
-  make "analyze-op-program-client-${VM_TARGET}"
+  touch /app/op-program/vm-compat-findings.json && \
+  make "analyze-op-program-client-${VM_TARGET}"; echo $? > /app/op-program/vm-compat-exit-code

--- a/op-program/Makefile
+++ b/op-program/Makefile
@@ -154,18 +154,15 @@ run-vm-compat:
 		--build-arg GO_VERSION=1.24.10-alpine3.21 \
 		--build-arg VM_TARGET=current \
 		--progress plain \
+		--target export \
 		--output "$(VM_COMPAT_OUTPUT_DIR)" \
 		-f Dockerfile.vmcompat ../
-	@exit_code=$$(cat "$(VM_COMPAT_OUTPUT_DIR)/vm-compat-exit-code" 2>/dev/null || echo "1"); \
-	if [ "$$exit_code" != "0" ]; then \
-		echo "vm-compat analysis failed (exit code $$exit_code)"; \
-		if [ -s "$(VM_COMPAT_OUTPUT_DIR)/vm-compat-findings.json" ]; then \
-			echo "Findings saved to $(VM_COMPAT_OUTPUT_DIR)/vm-compat-findings.json"; \
-		fi; \
-		exit 1; \
-	fi
-	# TODO(#18334): Uncomment once vm-compat supports go1.25
-	#@docker build --build-arg GO_VERSION=1.25.4-alpine3.21 --build-arg VM_TARGET=next --progress plain --output "$(VM_COMPAT_OUTPUT_DIR)" -f Dockerfile.vmcompat ../
+	@docker build \
+		--build-arg GO_VERSION=1.24.10-alpine3.21 \
+		--build-arg VM_TARGET=current \
+		--progress plain \
+		--target check \
+		-f Dockerfile.vmcompat ../
 
 .PHONY: \
 	op-program \

--- a/op-program/Makefile
+++ b/op-program/Makefile
@@ -146,10 +146,31 @@ analyze-op-program-client-current:
 analyze-op-program-client-next:
 	./scripts/run-static-analysis.sh ./vm-profiles/cannon-multithreaded-64-next.yaml ./compatibility-test/baseline-cannon-multithreaded-64-next.json
 
+VM_COMPAT_OUTPUT_DIR := bin/vm-compat-output
+VM_COMPAT_IMAGE_TAG := op-program-vmcompat:latest
+
 run-vm-compat:
-	@docker build --build-arg GO_VERSION=1.24.10-alpine3.21 --build-arg VM_TARGET=current --progress plain -f Dockerfile.vmcompat ../
+	@rm -rf "$(VM_COMPAT_OUTPUT_DIR)" && mkdir -p "$(VM_COMPAT_OUTPUT_DIR)"
+	@docker build \
+		--build-arg GO_VERSION=1.24.10-alpine3.21 \
+		--build-arg VM_TARGET=current \
+		--progress plain \
+		-t "$(VM_COMPAT_IMAGE_TAG)" \
+		-f Dockerfile.vmcompat ../
+	@container_id=$$(docker create "$(VM_COMPAT_IMAGE_TAG)"); \
+	docker cp "$$container_id:/app/op-program/vm-compat-findings.json" "$(VM_COMPAT_OUTPUT_DIR)/vm-compat-findings.json" 2>/dev/null || true; \
+	docker cp "$$container_id:/app/op-program/vm-compat-exit-code" "$(VM_COMPAT_OUTPUT_DIR)/vm-compat-exit-code" 2>/dev/null || true; \
+	docker rm "$$container_id" > /dev/null; \
+	exit_code=$$(cat "$(VM_COMPAT_OUTPUT_DIR)/vm-compat-exit-code" 2>/dev/null || echo "1"); \
+	if [ "$$exit_code" != "0" ]; then \
+		echo "vm-compat analysis failed (exit code $$exit_code)"; \
+		if [ -s "$(VM_COMPAT_OUTPUT_DIR)/vm-compat-findings.json" ]; then \
+			echo "Findings saved to $(VM_COMPAT_OUTPUT_DIR)/vm-compat-findings.json"; \
+		fi; \
+		exit 1; \
+	fi
 	# TODO(#18334): Uncomment once vm-compat supports go1.25
-	#@docker build --build-arg GO_VERSION=1.25.4-alpine3.21 --build-arg VM_TARGET=next --progress plain -f Dockerfile.vmcompat ../
+	#@docker build --build-arg GO_VERSION=1.25.4-alpine3.21 --build-arg VM_TARGET=next --progress plain -t "$(VM_COMPAT_IMAGE_TAG)" -f Dockerfile.vmcompat ../
 
 .PHONY: \
 	op-program \

--- a/op-program/Makefile
+++ b/op-program/Makefile
@@ -147,7 +147,6 @@ analyze-op-program-client-next:
 	./scripts/run-static-analysis.sh ./vm-profiles/cannon-multithreaded-64-next.yaml ./compatibility-test/baseline-cannon-multithreaded-64-next.json
 
 VM_COMPAT_OUTPUT_DIR := bin/vm-compat-output
-VM_COMPAT_IMAGE_TAG := op-program-vmcompat:latest
 
 run-vm-compat:
 	@rm -rf "$(VM_COMPAT_OUTPUT_DIR)" && mkdir -p "$(VM_COMPAT_OUTPUT_DIR)"
@@ -155,13 +154,9 @@ run-vm-compat:
 		--build-arg GO_VERSION=1.24.10-alpine3.21 \
 		--build-arg VM_TARGET=current \
 		--progress plain \
-		-t "$(VM_COMPAT_IMAGE_TAG)" \
+		--output "$(VM_COMPAT_OUTPUT_DIR)" \
 		-f Dockerfile.vmcompat ../
-	@container_id=$$(docker create "$(VM_COMPAT_IMAGE_TAG)"); \
-	docker cp "$$container_id:/app/op-program/vm-compat-findings.json" "$(VM_COMPAT_OUTPUT_DIR)/vm-compat-findings.json" 2>/dev/null || true; \
-	docker cp "$$container_id:/app/op-program/vm-compat-exit-code" "$(VM_COMPAT_OUTPUT_DIR)/vm-compat-exit-code" 2>/dev/null || true; \
-	docker rm "$$container_id" > /dev/null; \
-	exit_code=$$(cat "$(VM_COMPAT_OUTPUT_DIR)/vm-compat-exit-code" 2>/dev/null || echo "1"); \
+	@exit_code=$$(cat "$(VM_COMPAT_OUTPUT_DIR)/vm-compat-exit-code" 2>/dev/null || echo "1"); \
 	if [ "$$exit_code" != "0" ]; then \
 		echo "vm-compat analysis failed (exit code $$exit_code)"; \
 		if [ -s "$(VM_COMPAT_OUTPUT_DIR)/vm-compat-findings.json" ]; then \
@@ -170,7 +165,7 @@ run-vm-compat:
 		exit 1; \
 	fi
 	# TODO(#18334): Uncomment once vm-compat supports go1.25
-	#@docker build --build-arg GO_VERSION=1.25.4-alpine3.21 --build-arg VM_TARGET=next --progress plain -t "$(VM_COMPAT_IMAGE_TAG)" -f Dockerfile.vmcompat ../
+	#@docker build --build-arg GO_VERSION=1.25.4-alpine3.21 --build-arg VM_TARGET=next --progress plain --output "$(VM_COMPAT_OUTPUT_DIR)" -f Dockerfile.vmcompat ../
 
 .PHONY: \
 	op-program \

--- a/op-program/Makefile
+++ b/op-program/Makefile
@@ -154,15 +154,10 @@ run-vm-compat:
 		--build-arg GO_VERSION=1.24.10-alpine3.21 \
 		--build-arg VM_TARGET=current \
 		--progress plain \
-		--target export \
 		--output "$(VM_COMPAT_OUTPUT_DIR)" \
 		-f Dockerfile.vmcompat ../
-	@docker build \
-		--build-arg GO_VERSION=1.24.10-alpine3.21 \
-		--build-arg VM_TARGET=current \
-		--progress plain \
-		--target check \
-		-f Dockerfile.vmcompat ../
+	# TODO(#18334): Uncomment once vm-compat supports go1.25
+	#@docker build --build-arg GO_VERSION=1.25.4-alpine3.21 --build-arg VM_TARGET=next --progress plain -f Dockerfile.vmcompat ../
 
 .PHONY: \
 	op-program \

--- a/op-program/Makefile
+++ b/op-program/Makefile
@@ -156,8 +156,9 @@ run-vm-compat:
 		--progress plain \
 		--output "$(VM_COMPAT_OUTPUT_DIR)" \
 		-f Dockerfile.vmcompat ../
+	@exit $$(cat "$(VM_COMPAT_OUTPUT_DIR)/vm-compat-exit-code")
 	# TODO(#18334): Uncomment once vm-compat supports go1.25
-	#@docker build --build-arg GO_VERSION=1.25.4-alpine3.21 --build-arg VM_TARGET=next --progress plain -f Dockerfile.vmcompat ../
+	#@docker build --build-arg GO_VERSION=1.25.4-alpine3.21 --build-arg VM_TARGET=next --progress plain --output "$(VM_COMPAT_OUTPUT_DIR)" -f Dockerfile.vmcompat ../
 
 .PHONY: \
 	op-program \

--- a/op-program/Makefile
+++ b/op-program/Makefile
@@ -159,6 +159,7 @@ run-vm-compat:
 	@exit $$(cat "$(VM_COMPAT_OUTPUT_DIR)/vm-compat-exit-code")
 	# TODO(#18334): Uncomment once vm-compat supports go1.25
 	#@docker build --build-arg GO_VERSION=1.25.4-alpine3.21 --build-arg VM_TARGET=next --progress plain --output "$(VM_COMPAT_OUTPUT_DIR)" -f Dockerfile.vmcompat ../
+	#@exit $$(cat "$(VM_COMPAT_OUTPUT_DIR)/vm-compat-exit-code")
 
 .PHONY: \
 	op-program \

--- a/op-program/scripts/run-static-analysis.sh
+++ b/op-program/scripts/run-static-analysis.sh
@@ -57,6 +57,10 @@ ISSUE_COUNT=$(jq 'length' "$OUTPUT_FILE")
 if [ "$ISSUE_COUNT" -gt 0 ]; then
   echo "❌ Analysis found $ISSUE_COUNT issues!"
   cat "$OUTPUT_FILE"
+  if [ -n "$FINDINGS_OUTPUT_PATH" ]; then
+    cp "$OUTPUT_FILE" "$FINDINGS_OUTPUT_PATH"
+    echo "Findings written to $FINDINGS_OUTPUT_PATH"
+  fi
   rm -f "$OUTPUT_FILE"
   exit 1
 else


### PR DESCRIPTION
## Summary
- When the `analyze-op-program-client` CI job fails, CircleCI truncates the Docker build log output, losing the beginning of the vm-compat findings JSON array
- This change captures the full findings JSON as a downloadable CI artifact so the complete output is always available for review
- The Docker build no longer fails on analysis errors; instead it captures the exit code, extracts findings via `docker cp`, then fails with the original exit code

## Changes
- **`op-program/scripts/run-static-analysis.sh`**: If `$FINDINGS_OUTPUT_PATH` is set, copy findings to that path before cleanup
- **`op-program/Dockerfile.vmcompat`**: Set `FINDINGS_OUTPUT_PATH` env var, capture analysis exit code instead of failing the build
- **`op-program/Makefile`** (`run-vm-compat`): Tag the built image, extract findings and exit code via `docker create`/`docker cp`, then check exit code
- **`.circleci/continue/main.yml`**: Add `store_artifacts` step (with `when: always`) to persist `vm-compat-findings.json`

## Test plan
- [ ] Verify the `analyze-op-program-client` CI job still passes when there are no findings
- [ ] Verify that when findings exist, the job fails AND the `vm-compat-findings.json` artifact is available in the CircleCI UI
- [ ] Verify running `make run-vm-compat` locally still works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)