### PR TITLE
chore(ci): remove Base from upgrade and sync test matrices

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -2938,7 +2938,7 @@ workflows:
           test_profile: liteci
           matrix:
             parameters:
-              fork_op_chain: ["base", "ink", "unichain"]
+              fork_op_chain: ["ink", "unichain"]
           context:
             - circleci-repo-readonly-authenticated-github-token
             - slack
@@ -2954,7 +2954,7 @@ workflows:
           test_profile: ci
           matrix:
             parameters:
-              fork_op_chain: ["base", "ink", "unichain"]
+              fork_op_chain: ["ink", "unichain"]
           context:
             - circleci-repo-readonly-authenticated-github-token
             - slack
@@ -3550,10 +3550,8 @@ workflows:
               network_preset:
                 [
                   "op-sepolia",
-                  "base-sepolia",
                   "unichain-sepolia",
                   "op-mainnet",
-                  "base-mainnet",
                 ]
               l2_cl_syncmode: ["consensus-layer", "execution-layer"]
 


### PR DESCRIPTION
## Summary

- Remove `"base"` from the `fork_op_chain` matrix in both PR and develop upgrade test jobs
- Remove `"base-mainnet"` and `"base-sepolia"` from the sync test `network_preset` matrix
- Fixes the failing `contracts-bedrock-tests-upgrade-develop base-mainnet` job ([CircleCI #4512715](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/118610/workflows/14907dd4-f231-42dd-9ce4-28ad68e8ae69/jobs/4512715))

Base's on-chain contract state has diverged from the standard OP Stack upgrade path, causing `testFuzz_isGameClaimValid_isRetired_succeeds` to revert with `AnchorStateRegistry_Unauthorized()` on Base Mainnet forks.

## Test plan

- [x] YAML validated with `python3 -c "import yaml; yaml.safe_load(...)"`
- [x] No remaining `"base"`, `base-mainnet`, or `base-sepolia` chain variant references in CI config
- [x] Remaining chains (op, ink, unichain) unaffected — matrix entries unchanged
- [x] No Solidity code modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)