### PR TITLE
chore(ci): add op to chain-specific upgrade test matrix, remove base

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -2938,7 +2938,7 @@ workflows:
           test_profile: liteci
           matrix:
             parameters:
-              fork_op_chain: ["base", "ink", "unichain"]
+              fork_op_chain: ["op", "ink", "unichain"]
           context:
             - circleci-repo-readonly-authenticated-github-token
             - slack
@@ -2954,7 +2954,7 @@ workflows:
           test_profile: ci
           matrix:
             parameters:
-              fork_op_chain: ["base", "ink", "unichain"]
+              fork_op_chain: ["op", "ink", "unichain"]
           context:
             - circleci-repo-readonly-authenticated-github-token
             - slack
@@ -3550,10 +3550,8 @@ workflows:
               network_preset:
                 [
                   "op-sepolia",
-                  "base-sepolia",
                   "unichain-sepolia",
                   "op-mainnet",
-                  "base-mainnet",
                 ]
               l2_cl_syncmode: ["consensus-layer", "execution-layer"]
 


### PR DESCRIPTION
## Summary

- Add `"op"` to the `fork_op_chain` matrix for chain-specific upgrade tests (PR + develop jobs)
- Remove `"base"` from upgrade test matrix and `"base-mainnet"`/`"base-sepolia"` from sync test matrix
- Supersedes #19447 — this PR combines both the Base removal and the OP addition

## Test plan

- [x] YAML validated
- [x] No remaining `"base"` chain variant references
- [x] `"op"` now appears in chain-specific matrix alongside `"ink"` and `"unichain"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)