### PR TITLE
feat(ci): add required gate jobs for Rust CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,14 +125,18 @@ workflows:
             .* c-go-cache-version << pipeline.parameters.go-cache-version >> .circleci/continue/main.yml
             rust/.* c-rust_files_changed true .circleci/continue/main.yml
 
-            (rust|\.circleci)/.* c-rust_ci_dispatch << pipeline.parameters.rust_ci_dispatch >> .circleci/continue/rust-ci.yml
-            (rust|\.circleci)/.* c-default_docker_image << pipeline.parameters.default_docker_image >> .circleci/continue/rust-ci.yml
-            (rust|\.circleci)/.* c-base_image << pipeline.parameters.base_image >> .circleci/continue/rust-ci.yml
-            (rust|\.circleci)/.* c-go-cache-version << pipeline.parameters.go-cache-version >> .circleci/continue/rust-ci.yml
+            # Rust CI — always include config, gate jobs via c-rust_changes_detected
+            .* c-default_docker_image << pipeline.parameters.default_docker_image >> .circleci/continue/rust-ci.yml
+            .* c-base_image << pipeline.parameters.base_image >> .circleci/continue/rust-ci.yml
+            .* c-go-cache-version << pipeline.parameters.go-cache-version >> .circleci/continue/rust-ci.yml
+            .* c-rust_ci_dispatch << pipeline.parameters.rust_ci_dispatch >> .circleci/continue/rust-ci.yml
+            (rust|\.circleci)/.* c-rust_changes_detected true .circleci/continue/rust-ci.yml
 
-            (rust|op-e2e|\.circleci)/.* c-rust_e2e_dispatch << pipeline.parameters.rust_e2e_dispatch >> .circleci/continue/rust-e2e.yml
-            (rust|op-e2e|\.circleci)/.* c-default_docker_image << pipeline.parameters.default_docker_image >> .circleci/continue/rust-e2e.yml
-            (rust|op-e2e|\.circleci)/.* c-go-cache-version << pipeline.parameters.go-cache-version >> .circleci/continue/rust-e2e.yml
+            # Rust E2E — always include config, gate jobs via c-rust_changes_detected
+            .* c-default_docker_image << pipeline.parameters.default_docker_image >> .circleci/continue/rust-e2e.yml
+            .* c-go-cache-version << pipeline.parameters.go-cache-version >> .circleci/continue/rust-e2e.yml
+            .* c-rust_e2e_dispatch << pipeline.parameters.rust_e2e_dispatch >> .circleci/continue/rust-e2e.yml
+            (rust|op-e2e|\.circleci)/.* c-rust_changes_detected true .circleci/continue/rust-e2e.yml
 
   setup-tag:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,13 +130,13 @@ workflows:
             .* c-base_image << pipeline.parameters.base_image >> .circleci/continue/rust-ci.yml
             .* c-go-cache-version << pipeline.parameters.go-cache-version >> .circleci/continue/rust-ci.yml
             .* c-rust_ci_dispatch << pipeline.parameters.rust_ci_dispatch >> .circleci/continue/rust-ci.yml
-            rust/.* c-rust_changes_detected true .circleci/continue/rust-ci.yml
+            (rust|\.circleci)/.* c-rust_changes_detected true .circleci/continue/rust-ci.yml
 
             # Rust E2E — always include config, gate jobs via c-rust_changes_detected
             .* c-default_docker_image << pipeline.parameters.default_docker_image >> .circleci/continue/rust-e2e.yml
             .* c-go-cache-version << pipeline.parameters.go-cache-version >> .circleci/continue/rust-e2e.yml
             .* c-rust_e2e_dispatch << pipeline.parameters.rust_e2e_dispatch >> .circleci/continue/rust-e2e.yml
-            (rust|op-e2e)/.* c-rust_changes_detected true .circleci/continue/rust-e2e.yml
+            (rust|op-e2e|\.circleci)/.* c-rust_changes_detected true .circleci/continue/rust-e2e.yml
 
   setup-tag:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,13 +130,13 @@ workflows:
             .* c-base_image << pipeline.parameters.base_image >> .circleci/continue/rust-ci.yml
             .* c-go-cache-version << pipeline.parameters.go-cache-version >> .circleci/continue/rust-ci.yml
             .* c-rust_ci_dispatch << pipeline.parameters.rust_ci_dispatch >> .circleci/continue/rust-ci.yml
-            (rust|\.circleci)/.* c-rust_changes_detected true .circleci/continue/rust-ci.yml
+            rust/.* c-rust_changes_detected true .circleci/continue/rust-ci.yml
 
             # Rust E2E — always include config, gate jobs via c-rust_changes_detected
             .* c-default_docker_image << pipeline.parameters.default_docker_image >> .circleci/continue/rust-e2e.yml
             .* c-go-cache-version << pipeline.parameters.go-cache-version >> .circleci/continue/rust-e2e.yml
             .* c-rust_e2e_dispatch << pipeline.parameters.rust_e2e_dispatch >> .circleci/continue/rust-e2e.yml
-            (rust|op-e2e|\.circleci)/.* c-rust_changes_detected true .circleci/continue/rust-e2e.yml
+            (rust|op-e2e)/.* c-rust_changes_detected true .circleci/continue/rust-e2e.yml
 
   setup-tag:
     when:

--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -1042,12 +1042,14 @@ jobs:
 workflows:
   # ==========================================================================
   # Unified Rust CI workflow
-  # Runs on any rust/.* change or manual dispatch with rust_ci_dispatch=true
+  # Runs on rust path changes or manual dispatch with rust_ci_dispatch=true
   # ==========================================================================
   rust-ci:
     when:
       or:
-        - equal: ["webhook", << pipeline.trigger_source >>]
+        - and:
+            - equal: ["webhook", << pipeline.trigger_source >>]
+            - << pipeline.parameters.c-rust_changes_detected >>
         - and:
             - equal: [true, <<pipeline.parameters.c-rust_ci_dispatch>>]
             - equal: ["api", << pipeline.trigger_source >>]
@@ -1058,10 +1060,6 @@ workflows:
       - rust-ci-fmt:
           name: rust-fmt
           directory: rust
-          when:
-            or:
-              - << pipeline.parameters.c-rust_changes_detected >>
-              - << pipeline.parameters.c-rust_ci_dispatch >>
           context: &rust-ci-context
             - circleci-repo-readonly-authenticated-github-token
 
@@ -1069,122 +1067,70 @@ workflows:
           name: rust-clippy
           directory: rust
           command: "cargo clippy --workspace --all-targets --all-features --locked"
-          when:
-            or:
-              - << pipeline.parameters.c-rust_changes_detected >>
-              - << pipeline.parameters.c-rust_ci_dispatch >>
           context: *rust-ci-context
 
       - rust-ci-deny:
           name: rust-deny
           directory: rust
           command: "cargo deny --all-features check all"
-          when:
-            or:
-              - << pipeline.parameters.c-rust_changes_detected >>
-              - << pipeline.parameters.c-rust_ci_dispatch >>
           context: *rust-ci-context
 
       - rust-ci-typos:
           name: rust-typos
           directory: rust
-          when:
-            or:
-              - << pipeline.parameters.c-rust_changes_detected >>
-              - << pipeline.parameters.c-rust_ci_dispatch >>
           context: *rust-ci-context
 
       - rust-ci-zepter:
           name: rust-zepter
           directory: rust
-          when:
-            or:
-              - << pipeline.parameters.c-rust_changes_detected >>
-              - << pipeline.parameters.c-rust_ci_dispatch >>
           context: *rust-ci-context
 
       - rust-ci-cargo-tests:
           name: rust-tests
           directory: rust
-          when:
-            or:
-              - << pipeline.parameters.c-rust_changes_detected >>
-              - << pipeline.parameters.c-rust_ci_dispatch >>
           context: *rust-ci-context
 
       - rust-ci-doctest:
           name: rust-doctest
           directory: rust
           command: "cargo test --doc --workspace --all-features"
-          when:
-            or:
-              - << pipeline.parameters.c-rust_changes_detected >>
-              - << pipeline.parameters.c-rust_ci_dispatch >>
           context: *rust-ci-context
 
       - rust-ci-docs:
           name: rust-docs
           directory: rust
-          when:
-            or:
-              - << pipeline.parameters.c-rust_changes_detected >>
-              - << pipeline.parameters.c-rust_ci_dispatch >>
           context: *rust-ci-context
 
       # Docs build
       - rust-docs-build:
-          when:
-            or:
-              - << pipeline.parameters.c-rust_changes_detected >>
-              - << pipeline.parameters.c-rust_ci_dispatch >>
           context:
             - circleci-repo-readonly-authenticated-github-token
 
       - rust-ci-udeps:
           name: rust-udeps
           directory: rust
-          when:
-            or:
-              - << pipeline.parameters.c-rust_changes_detected >>
-              - << pipeline.parameters.c-rust_ci_dispatch >>
           context: *rust-ci-context
 
       - rust-ci-cargo-hack:
           name: rust-cargo-hack
           parallelism: 6
-          when:
-            or:
-              - << pipeline.parameters.c-rust_changes_detected >>
-              - << pipeline.parameters.c-rust_ci_dispatch >>
           context: *rust-ci-context
 
       - rust-build-binary:
           name: rust-build
           directory: rust
-          when:
-            or:
-              - << pipeline.parameters.c-rust_changes_detected >>
-              - << pipeline.parameters.c-rust_ci_dispatch >>
           context: *rust-ci-context
 
       - rust-build-binary:
           name: rust-build-release
           directory: rust
           profile: release
-          when:
-            or:
-              - << pipeline.parameters.c-rust_changes_detected >>
-              - << pipeline.parameters.c-rust_ci_dispatch >>
           context: *rust-ci-context
 
       - rust-build-binary:
           name: rust-msrv
           directory: rust
           toolchain: "1.92.0"
-          when:
-            or:
-              - << pipeline.parameters.c-rust_changes_detected >>
-              - << pipeline.parameters.c-rust_ci_dispatch >>
           context: *rust-ci-context
 
       # -----------------------------------------------------------------------
@@ -1196,10 +1142,6 @@ workflows:
           command: |
             just check-no-std
           toolchain: "1.92.0"
-          when:
-            or:
-              - << pipeline.parameters.c-rust_changes_detected >>
-              - << pipeline.parameters.c-rust_ci_dispatch >>
           context: *rust-ci-context
 
       - rust-ci-cargo-hack-build:
@@ -1207,10 +1149,6 @@ workflows:
           directory: rust
           target: wasm32-unknown-unknown
           flags: "-p op-alloy-consensus -p op-alloy-rpc-types -p op-alloy-rpc-types-engine -p alloy-op-evm --no-default-features"
-          when:
-            or:
-              - << pipeline.parameters.c-rust_changes_detected >>
-              - << pipeline.parameters.c-rust_ci_dispatch >>
           context: *rust-ci-context
 
       - rust-ci-cargo-hack-build:
@@ -1218,20 +1156,12 @@ workflows:
           directory: rust
           target: wasm32-wasip1
           flags: "-p op-alloy-consensus -p op-alloy-rpc-types-engine -p alloy-op-evm"
-          when:
-            or:
-              - << pipeline.parameters.c-rust_changes_detected >>
-              - << pipeline.parameters.c-rust_ci_dispatch >>
           context: *rust-ci-context
 
       # -----------------------------------------------------------------------
       # OP-Reth crate-specific jobs
       # -----------------------------------------------------------------------
       - op-reth-compact-codec:
-          when:
-            or:
-              - << pipeline.parameters.c-rust_changes_detected >>
-              - << pipeline.parameters.c-rust_ci_dispatch >>
           context: *rust-ci-context
 
       - rust-ci-cargo-tests:
@@ -1239,10 +1169,6 @@ workflows:
           directory: rust
           command: "--justfile op-reth/justfile test-integration"
           cache_profile: debug
-          when:
-            or:
-              - << pipeline.parameters.c-rust_changes_detected >>
-              - << pipeline.parameters.c-rust_ci_dispatch >>
           context: *rust-ci-context
 
       - rust-ci-cargo-tests:
@@ -1251,10 +1177,6 @@ workflows:
           command: "--justfile op-reth/justfile test"
           flags: "edge"
           cache_profile: debug
-          when:
-            or:
-              - << pipeline.parameters.c-rust_changes_detected >>
-              - << pipeline.parameters.c-rust_ci_dispatch >>
           context: *rust-ci-context
 
       # -----------------------------------------------------------------------
@@ -1265,10 +1187,6 @@ workflows:
           matrix:
             parameters:
               target: ["cannon"]
-          when:
-            or:
-              - << pipeline.parameters.c-rust_changes_detected >>
-              - << pipeline.parameters.c-rust_ci_dispatch >>
           context: *rust-ci-context
 
       - kona-build-fpvm:
@@ -1276,38 +1194,37 @@ workflows:
           matrix:
             parameters:
               target: ["cannon-client"]
-          when:
-            or:
-              - << pipeline.parameters.c-rust_changes_detected >>
-              - << pipeline.parameters.c-rust_ci_dispatch >>
           context: *rust-ci-context
 
       - kona-coverage:
-          when:
-            or:
-              - << pipeline.parameters.c-rust_changes_detected >>
-              - << pipeline.parameters.c-rust_ci_dispatch >>
           context: *rust-ci-context
           requires:
             - rust-tests
 
       - kona-host-client-offline:
           name: kona-host-client-offline-cannon
-          when:
-            or:
-              - << pipeline.parameters.c-rust_changes_detected >>
-              - << pipeline.parameters.c-rust_ci_dispatch >>
           context: *rust-ci-context
 
       # -----------------------------------------------------------------------
-      # Required gate — always runs, fans in on required Rust CI jobs
-      # When rust jobs are skipped (no changes), requirements are auto-satisfied
+      # Required gate — fans in on required Rust CI jobs
       # -----------------------------------------------------------------------
       - required-rust-ci:
           requires:
             - rust-tests
             - rust-clippy
             - rust-docs
+
+  # ==========================================================================
+  # Required Rust CI gate (skip) — runs when no rust changes and no dispatch
+  # Immediately passes the required-rust-ci check so GitHub is satisfied
+  # ==========================================================================
+  rust-ci-gate-skip:
+    when:
+      and:
+        - equal: ["webhook", << pipeline.trigger_source >>]
+        - not: << pipeline.parameters.c-rust_changes_detected >>
+    jobs:
+      - required-rust-ci
 
   # ==========================================================================
   # Kona scheduled workflows

--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -1183,17 +1183,13 @@ workflows:
       # Kona crate-specific jobs (lint, FPVM builds, benches, coverage)
       # -----------------------------------------------------------------------
       - kona-cargo-lint:
-          name: kona-lint-<<matrix.target>>
-          matrix:
-            parameters:
-              target: ["cannon"]
+          name: kona-lint-cannon
+          target: "cannon"
           context: *rust-ci-context
 
       - kona-build-fpvm:
-          name: kona-build-fpvm-<<matrix.target>>
-          matrix:
-            parameters:
-              target: ["cannon-client"]
+          name: kona-build-fpvm-cannon-client
+          target: "cannon-client"
           context: *rust-ci-context
 
       - kona-coverage:
@@ -1216,15 +1212,46 @@ workflows:
 
   # ==========================================================================
   # Required Rust CI gate (skip) — runs when no rust changes and no dispatch
-  # Immediately passes the required-rust-ci check so GitHub is satisfied
+  # Just runs the rust cargo tests for the different packages in the repo and try to build the fpvm-prestates
   # ==========================================================================
-  rust-ci-gate-skip:
+  rust-ci-gate-short:
     when:
       and:
         - equal: ["webhook", << pipeline.trigger_source >>]
         - not: << pipeline.parameters.c-rust_changes_detected >>
     jobs:
-      - required-rust-ci
+      - rust-ci-cargo-tests:
+          name: rust-tests
+          directory: rust
+          context: *rust-ci-context
+
+      - rust-ci-cargo-tests:
+          name: op-reth-integration-tests
+          directory: rust
+          command: "--justfile op-reth/justfile test-integration"
+          cache_profile: debug
+          context: *rust-ci-context
+
+      - rust-ci-cargo-tests:
+          name: op-reth-tests-edge
+          directory: rust
+          command: "--justfile op-reth/justfile test"
+          flags: "edge"
+          cache_profile: debug
+          context: *rust-ci-context
+
+      - kona-build-fpvm:
+          name: kona-build-fpvm-cannon-client
+          target: "cannon-client"
+          context: *rust-ci-context
+
+      - required-rust-ci:
+          requires:
+            - rust-tests
+            - op-reth-integration-tests
+            - op-reth-tests-edge
+            - kona-build-fpvm-cannon-client
+
 
   # ==========================================================================
   # Kona scheduled workflows

--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -21,6 +21,9 @@ parameters:
   c-go-cache-version:
     type: string
     default: "v0.0"
+  c-rust_changes_detected:
+    type: boolean
+    default: false
 
 # ============================================================================
 # COMMANDS
@@ -1026,6 +1029,13 @@ jobs:
             echo "Successfully published prestates artifacts to GCS"
       - rust-save-build-cache: *kona-publish-prestate-cache
 
+  required-rust-ci:
+    docker:
+      - image: <<pipeline.parameters.c-default_docker_image>>
+    resource_class: small
+    steps:
+      - run: echo "Required Rust CI checks passed"
+
 # ============================================================================
 # WORKFLOWS
 # ============================================================================
@@ -1048,6 +1058,10 @@ workflows:
       - rust-ci-fmt:
           name: rust-fmt
           directory: rust
+          when:
+            or:
+              - << pipeline.parameters.c-rust_changes_detected >>
+              - << pipeline.parameters.c-rust_ci_dispatch >>
           context: &rust-ci-context
             - circleci-repo-readonly-authenticated-github-token
 
@@ -1055,70 +1069,122 @@ workflows:
           name: rust-clippy
           directory: rust
           command: "cargo clippy --workspace --all-targets --all-features --locked"
+          when:
+            or:
+              - << pipeline.parameters.c-rust_changes_detected >>
+              - << pipeline.parameters.c-rust_ci_dispatch >>
           context: *rust-ci-context
 
       - rust-ci-deny:
           name: rust-deny
           directory: rust
           command: "cargo deny --all-features check all"
+          when:
+            or:
+              - << pipeline.parameters.c-rust_changes_detected >>
+              - << pipeline.parameters.c-rust_ci_dispatch >>
           context: *rust-ci-context
 
       - rust-ci-typos:
           name: rust-typos
           directory: rust
+          when:
+            or:
+              - << pipeline.parameters.c-rust_changes_detected >>
+              - << pipeline.parameters.c-rust_ci_dispatch >>
           context: *rust-ci-context
 
       - rust-ci-zepter:
           name: rust-zepter
           directory: rust
+          when:
+            or:
+              - << pipeline.parameters.c-rust_changes_detected >>
+              - << pipeline.parameters.c-rust_ci_dispatch >>
           context: *rust-ci-context
 
       - rust-ci-cargo-tests:
           name: rust-tests
           directory: rust
+          when:
+            or:
+              - << pipeline.parameters.c-rust_changes_detected >>
+              - << pipeline.parameters.c-rust_ci_dispatch >>
           context: *rust-ci-context
 
       - rust-ci-doctest:
           name: rust-doctest
           directory: rust
           command: "cargo test --doc --workspace --all-features"
+          when:
+            or:
+              - << pipeline.parameters.c-rust_changes_detected >>
+              - << pipeline.parameters.c-rust_ci_dispatch >>
           context: *rust-ci-context
 
       - rust-ci-docs:
           name: rust-docs
           directory: rust
+          when:
+            or:
+              - << pipeline.parameters.c-rust_changes_detected >>
+              - << pipeline.parameters.c-rust_ci_dispatch >>
           context: *rust-ci-context
 
       # Docs build
       - rust-docs-build:
+          when:
+            or:
+              - << pipeline.parameters.c-rust_changes_detected >>
+              - << pipeline.parameters.c-rust_ci_dispatch >>
           context:
             - circleci-repo-readonly-authenticated-github-token
 
       - rust-ci-udeps:
           name: rust-udeps
           directory: rust
+          when:
+            or:
+              - << pipeline.parameters.c-rust_changes_detected >>
+              - << pipeline.parameters.c-rust_ci_dispatch >>
           context: *rust-ci-context
 
       - rust-ci-cargo-hack:
           name: rust-cargo-hack
           parallelism: 6
+          when:
+            or:
+              - << pipeline.parameters.c-rust_changes_detected >>
+              - << pipeline.parameters.c-rust_ci_dispatch >>
           context: *rust-ci-context
 
       - rust-build-binary:
           name: rust-build
           directory: rust
+          when:
+            or:
+              - << pipeline.parameters.c-rust_changes_detected >>
+              - << pipeline.parameters.c-rust_ci_dispatch >>
           context: *rust-ci-context
 
       - rust-build-binary:
           name: rust-build-release
           directory: rust
           profile: release
+          when:
+            or:
+              - << pipeline.parameters.c-rust_changes_detected >>
+              - << pipeline.parameters.c-rust_ci_dispatch >>
           context: *rust-ci-context
 
       - rust-build-binary:
           name: rust-msrv
           directory: rust
           toolchain: "1.92.0"
+          when:
+            or:
+              - << pipeline.parameters.c-rust_changes_detected >>
+              - << pipeline.parameters.c-rust_ci_dispatch >>
           context: *rust-ci-context
 
       # -----------------------------------------------------------------------
@@ -1130,6 +1196,10 @@ workflows:
           command: |
             just check-no-std
           toolchain: "1.92.0"
+          when:
+            or:
+              - << pipeline.parameters.c-rust_changes_detected >>
+              - << pipeline.parameters.c-rust_ci_dispatch >>
           context: *rust-ci-context
 
       - rust-ci-cargo-hack-build:
@@ -1137,6 +1207,10 @@ workflows:
           directory: rust
           target: wasm32-unknown-unknown
           flags: "-p op-alloy-consensus -p op-alloy-rpc-types -p op-alloy-rpc-types-engine -p alloy-op-evm --no-default-features"
+          when:
+            or:
+              - << pipeline.parameters.c-rust_changes_detected >>
+              - << pipeline.parameters.c-rust_ci_dispatch >>
           context: *rust-ci-context
 
       - rust-ci-cargo-hack-build:
@@ -1144,12 +1218,20 @@ workflows:
           directory: rust
           target: wasm32-wasip1
           flags: "-p op-alloy-consensus -p op-alloy-rpc-types-engine -p alloy-op-evm"
+          when:
+            or:
+              - << pipeline.parameters.c-rust_changes_detected >>
+              - << pipeline.parameters.c-rust_ci_dispatch >>
           context: *rust-ci-context
 
       # -----------------------------------------------------------------------
       # OP-Reth crate-specific jobs
       # -----------------------------------------------------------------------
       - op-reth-compact-codec:
+          when:
+            or:
+              - << pipeline.parameters.c-rust_changes_detected >>
+              - << pipeline.parameters.c-rust_ci_dispatch >>
           context: *rust-ci-context
 
       - rust-ci-cargo-tests:
@@ -1157,6 +1239,10 @@ workflows:
           directory: rust
           command: "--justfile op-reth/justfile test-integration"
           cache_profile: debug
+          when:
+            or:
+              - << pipeline.parameters.c-rust_changes_detected >>
+              - << pipeline.parameters.c-rust_ci_dispatch >>
           context: *rust-ci-context
 
       - rust-ci-cargo-tests:
@@ -1165,6 +1251,10 @@ workflows:
           command: "--justfile op-reth/justfile test"
           flags: "edge"
           cache_profile: debug
+          when:
+            or:
+              - << pipeline.parameters.c-rust_changes_detected >>
+              - << pipeline.parameters.c-rust_ci_dispatch >>
           context: *rust-ci-context
 
       # -----------------------------------------------------------------------
@@ -1175,6 +1265,10 @@ workflows:
           matrix:
             parameters:
               target: ["cannon"]
+          when:
+            or:
+              - << pipeline.parameters.c-rust_changes_detected >>
+              - << pipeline.parameters.c-rust_ci_dispatch >>
           context: *rust-ci-context
 
       - kona-build-fpvm:
@@ -1182,17 +1276,38 @@ workflows:
           matrix:
             parameters:
               target: ["cannon-client"]
+          when:
+            or:
+              - << pipeline.parameters.c-rust_changes_detected >>
+              - << pipeline.parameters.c-rust_ci_dispatch >>
           context: *rust-ci-context
 
       - kona-coverage:
+          when:
+            or:
+              - << pipeline.parameters.c-rust_changes_detected >>
+              - << pipeline.parameters.c-rust_ci_dispatch >>
           context: *rust-ci-context
           requires:
             - rust-tests
 
       - kona-host-client-offline:
           name: kona-host-client-offline-cannon
+          when:
+            or:
+              - << pipeline.parameters.c-rust_changes_detected >>
+              - << pipeline.parameters.c-rust_ci_dispatch >>
           context: *rust-ci-context
 
+      # -----------------------------------------------------------------------
+      # Required gate — always runs, fans in on required Rust CI jobs
+      # When rust jobs are skipped (no changes), requirements are auto-satisfied
+      # -----------------------------------------------------------------------
+      - required-rust-ci:
+          requires:
+            - rust-tests
+            - rust-clippy
+            - rust-docs
 
   # ==========================================================================
   # Kona scheduled workflows
@@ -1211,6 +1326,7 @@ workflows:
       and:
         - equal: ["develop", <<pipeline.git.branch>>]
         - equal: ["webhook", << pipeline.trigger_source >>] # Only trigger on push to develop, not scheduled runs
+        - << pipeline.parameters.c-rust_changes_detected >>  # Only publish when rust paths changed
     jobs:
       - kona-publish-prestate-artifacts:
           name: kona-publish-<<matrix.version>>

--- a/.circleci/continue/rust-e2e.yml
+++ b/.circleci/continue/rust-e2e.yml
@@ -16,6 +16,9 @@ parameters:
   c-go-cache-version:
     type: string
     default: "v0.0"
+  c-rust_changes_detected:
+    type: boolean
+    default: false
 
 # Commands used by rust-e2e jobs
 commands:
@@ -164,6 +167,13 @@ jobs:
       - go-save-cache:
           namespace: kona-ci
 
+  required-rust-e2e:
+    docker:
+      - image: <<pipeline.parameters.c-default_docker_image>>
+    resource_class: small
+    steps:
+      - run: echo "Required Rust E2E checks passed"
+
 # ============================================================================
 # RUST E2E WORKFLOWS
 # ============================================================================
@@ -178,9 +188,17 @@ workflows:
     jobs:
       - contracts-bedrock-build:
           build_args: --skip test
+          when:
+            or:
+              - << pipeline.parameters.c-rust_changes_detected >>
+              - << pipeline.parameters.c-rust_e2e_dispatch >>
           context:
             - circleci-repo-readonly-authenticated-github-token
       - cannon-prestate: &rust-e2e-job-base
+          when:
+            or:
+              - << pipeline.parameters.c-rust_changes_detected >>
+              - << pipeline.parameters.c-rust_e2e_dispatch >>
           context:
             - circleci-repo-readonly-authenticated-github-token
       - rust-build-binary: &cannon-kona-host
@@ -188,12 +206,20 @@ workflows:
           directory: rust
           profile: release
           binary: "kona-host"
+          when:
+            or:
+              - << pipeline.parameters.c-rust_changes_detected >>
+              - << pipeline.parameters.c-rust_e2e_dispatch >>
           context:
             - circleci-repo-readonly-authenticated-github-token
       - rust-build-binary: &kona-build-release
           name: kona-build-release
           directory: rust
           profile: release
+          when:
+            or:
+              - << pipeline.parameters.c-rust_changes_detected >>
+              - << pipeline.parameters.c-rust_e2e_dispatch >>
           context:
             - circleci-repo-readonly-authenticated-github-token
       - rust-build-binary:
@@ -201,6 +227,10 @@ workflows:
           directory: rust
           profile: release
           binary: "op-reth"
+          when:
+            or:
+              - << pipeline.parameters.c-rust_changes_detected >>
+              - << pipeline.parameters.c-rust_e2e_dispatch >>
           context:
             - circleci-repo-readonly-authenticated-github-token
       - rust-e2e-sysgo-tests:
@@ -208,6 +238,10 @@ workflows:
           matrix:
             parameters:
               devnet_config: ["simple-kona", "simple-kona-geth", "simple-kona-sequencer", "large-kona-sequencer"]
+          when:
+            or:
+              - << pipeline.parameters.c-rust_changes_detected >>
+              - << pipeline.parameters.c-rust_e2e_dispatch >>
           context:
             - circleci-repo-readonly-authenticated-github-token
           requires:
@@ -219,6 +253,10 @@ workflows:
       - rust-restart-sysgo-tests:
           name: rust-e2e-restart
           <<: *rust-e2e-job-base
+          when:
+            or:
+              - << pipeline.parameters.c-rust_changes_detected >>
+              - << pipeline.parameters.c-rust_e2e_dispatch >>
           requires:
             - contracts-bedrock-build
             - cannon-prestate
@@ -228,9 +266,24 @@ workflows:
       - kona-proof-action-tests:
           name: kona-proof-action-single
           kind: single
+          when:
+            or:
+              - << pipeline.parameters.c-rust_changes_detected >>
+              - << pipeline.parameters.c-rust_e2e_dispatch >>
           requires:
             - kona-build-release
             - contracts-bedrock-build
           context:
             - circleci-repo-readonly-authenticated-github-token
+      # -----------------------------------------------------------------------
+      # Required gate — always runs, fans in on all E2E test jobs
+      # -----------------------------------------------------------------------
+      - required-rust-e2e:
+          requires:
+            - rust-e2e-simple-kona
+            - rust-e2e-simple-kona-geth
+            - rust-e2e-simple-kona-sequencer
+            - rust-e2e-large-kona-sequencer
+            - rust-e2e-restart
+            - kona-proof-action-single
 

--- a/.circleci/continue/rust-e2e.yml
+++ b/.circleci/continue/rust-e2e.yml
@@ -259,12 +259,35 @@ workflows:
             - kona-proof-action-single
 
   # Required Rust E2E gate (skip) — runs when no rust changes and no dispatch
-  # Immediately passes the required-rust-e2e check so GitHub is satisfied
+  # Just runs action tests
   rust-e2e-gate-skip:
     when:
       and:
         - equal: ["webhook", << pipeline.trigger_source >>]
         - not: << pipeline.parameters.c-rust_changes_detected >>
     jobs:
-      - required-rust-e2e
+      - contracts-bedrock-build:
+          build_args: --skip test
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+      - rust-build-binary:
+          name: kona-build-release
+          directory: rust
+          profile: release
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+      # Proof tests - single kind only, interop excluded per original config
+      - kona-proof-action-tests:
+          name: kona-proof-action-single
+          kind: single
+          requires:
+            - kona-build-release
+            - contracts-bedrock-build
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+
+      - required-rust-e2e:
+          requires:
+            - kona-proof-action-single
+
 

--- a/.circleci/continue/rust-e2e.yml
+++ b/.circleci/continue/rust-e2e.yml
@@ -178,27 +178,22 @@ jobs:
 # RUST E2E WORKFLOWS
 # ============================================================================
 workflows:
+  # Rust E2E CI — runs on rust path changes or manual dispatch
   rust-e2e-ci:
     when:
       or:
-        - equal: ["webhook", << pipeline.trigger_source >>]
+        - and:
+            - equal: ["webhook", << pipeline.trigger_source >>]
+            - << pipeline.parameters.c-rust_changes_detected >>
         - and:
             - equal: [true, <<pipeline.parameters.c-rust_e2e_dispatch>>]
             - equal: ["api", << pipeline.trigger_source >>]
     jobs:
       - contracts-bedrock-build:
           build_args: --skip test
-          when:
-            or:
-              - << pipeline.parameters.c-rust_changes_detected >>
-              - << pipeline.parameters.c-rust_e2e_dispatch >>
           context:
             - circleci-repo-readonly-authenticated-github-token
       - cannon-prestate: &rust-e2e-job-base
-          when:
-            or:
-              - << pipeline.parameters.c-rust_changes_detected >>
-              - << pipeline.parameters.c-rust_e2e_dispatch >>
           context:
             - circleci-repo-readonly-authenticated-github-token
       - rust-build-binary: &cannon-kona-host
@@ -206,20 +201,12 @@ workflows:
           directory: rust
           profile: release
           binary: "kona-host"
-          when:
-            or:
-              - << pipeline.parameters.c-rust_changes_detected >>
-              - << pipeline.parameters.c-rust_e2e_dispatch >>
           context:
             - circleci-repo-readonly-authenticated-github-token
       - rust-build-binary: &kona-build-release
           name: kona-build-release
           directory: rust
           profile: release
-          when:
-            or:
-              - << pipeline.parameters.c-rust_changes_detected >>
-              - << pipeline.parameters.c-rust_e2e_dispatch >>
           context:
             - circleci-repo-readonly-authenticated-github-token
       - rust-build-binary:
@@ -227,10 +214,6 @@ workflows:
           directory: rust
           profile: release
           binary: "op-reth"
-          when:
-            or:
-              - << pipeline.parameters.c-rust_changes_detected >>
-              - << pipeline.parameters.c-rust_e2e_dispatch >>
           context:
             - circleci-repo-readonly-authenticated-github-token
       - rust-e2e-sysgo-tests:
@@ -238,10 +221,6 @@ workflows:
           matrix:
             parameters:
               devnet_config: ["simple-kona", "simple-kona-geth", "simple-kona-sequencer", "large-kona-sequencer"]
-          when:
-            or:
-              - << pipeline.parameters.c-rust_changes_detected >>
-              - << pipeline.parameters.c-rust_e2e_dispatch >>
           context:
             - circleci-repo-readonly-authenticated-github-token
           requires:
@@ -253,10 +232,6 @@ workflows:
       - rust-restart-sysgo-tests:
           name: rust-e2e-restart
           <<: *rust-e2e-job-base
-          when:
-            or:
-              - << pipeline.parameters.c-rust_changes_detected >>
-              - << pipeline.parameters.c-rust_e2e_dispatch >>
           requires:
             - contracts-bedrock-build
             - cannon-prestate
@@ -266,17 +241,13 @@ workflows:
       - kona-proof-action-tests:
           name: kona-proof-action-single
           kind: single
-          when:
-            or:
-              - << pipeline.parameters.c-rust_changes_detected >>
-              - << pipeline.parameters.c-rust_e2e_dispatch >>
           requires:
             - kona-build-release
             - contracts-bedrock-build
           context:
             - circleci-repo-readonly-authenticated-github-token
       # -----------------------------------------------------------------------
-      # Required gate — always runs, fans in on all E2E test jobs
+      # Required gate — fans in on all E2E test jobs
       # -----------------------------------------------------------------------
       - required-rust-e2e:
           requires:
@@ -286,4 +257,14 @@ workflows:
             - rust-e2e-large-kona-sequencer
             - rust-e2e-restart
             - kona-proof-action-single
+
+  # Required Rust E2E gate (skip) — runs when no rust changes and no dispatch
+  # Immediately passes the required-rust-e2e check so GitHub is satisfied
+  rust-e2e-gate-skip:
+    when:
+      and:
+        - equal: ["webhook", << pipeline.trigger_source >>]
+        - not: << pipeline.parameters.c-rust_changes_detected >>
+    jobs:
+      - required-rust-e2e
 


### PR DESCRIPTION
## Summary

- Always include `rust-ci.yml` and `rust-e2e.yml` in the continuation pipeline (changed path-filtering from conditional inclusion to always-include)
- Add `c-rust_changes_detected` boolean parameter, set to `true` only when `(rust|\.circleci)/.*` paths change
- Gate all Rust CI and E2E jobs behind `when: or: [c-rust_changes_detected, dispatch]` so they skip on non-Rust PRs
- Add `required-rust-ci` gate job (requires: `rust-tests`, `rust-clippy`, `rust-docs`) and `required-rust-e2e` gate job (requires all terminal E2E test jobs)
- Gate jobs always run — pass immediately when Rust jobs are skipped, wait for Rust jobs when they run
- Gate `kona-publish-prestates` with `c-rust_changes_detected` to preserve current behavior

## How it works

CircleCI's documented behavior: when a job is skipped via `when: false`, downstream `requires` are treated as satisfied. So the gate jobs pass immediately on non-Rust PRs.

## Post-merge

After this merges and the gate jobs appear in CI, add `required-rust-ci` and `required-rust-e2e` as required status checks in GitHub branch protection settings.

## Test plan

- [ ] This PR changes `.circleci/` paths, so `c-rust_changes_detected=true` — verify all Rust jobs run and gate jobs wait for them
- [ ] After merge, verify a non-Rust PR shows `required-rust-ci` and `required-rust-e2e` passing immediately
- [ ] Verify `scheduled-kona-link-checker` and `kona-publish-prestates` are unaffected
- [ ] Verify manual dispatch (`rust_ci_dispatch`, `rust_e2e_dispatch`) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)