### PR TITLE
test: verify nut-bundle-check CI catches stale bundle

### DIFF
--- a/packages/contracts-bedrock/snapshots/upgrades/current-upgrade-bundle.json
+++ b/packages/contracts-bedrock/snapshots/upgrades/current-upgrade-bundle.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "version": "1.0.0"
+    "version": "1.0.0-test"
   },
   "transactions": [
     {


### PR DESCRIPTION
## Summary
Intentionally modifies the bundle version in `current-upgrade-bundle.json` to verify that the `nut-bundle-check` CI job catches stale bundles.

**Expected:** CI should fail on `nut-bundle-check-no-build`.

Will close after verifying.