### PR TITLE
chore(ci): skip kona-build-release on PRs that don't touch Rust

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,6 +123,7 @@ workflows:
             .* c-flake-shake-iterations << pipeline.parameters.flake-shake-iterations >> .circleci/continue/main.yml
             .* c-flake-shake-workers << pipeline.parameters.flake-shake-workers >> .circleci/continue/main.yml
             .* c-go-cache-version << pipeline.parameters.go-cache-version >> .circleci/continue/main.yml
+            rust/.* c-rust_files_changed true .circleci/continue/main.yml
 
             (rust|\.circleci)/.* c-rust_ci_dispatch << pipeline.parameters.rust_ci_dispatch >> .circleci/continue/rust-ci.yml
             (rust|\.circleci)/.* c-default_docker_image << pipeline.parameters.default_docker_image >> .circleci/continue/rust-ci.yml

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -71,6 +71,12 @@ parameters:
   c-flake-shake-workers:
     type: integer
     default: 50
+  # Set to true by path-filtering when files under rust/ change.
+  # When false on feature branches, kona-build-release skips cargo build and
+  # reuses cached binaries — saving ~9 minutes on PRs that don't touch Rust.
+  c-rust_files_changed:
+    type: boolean
+    default: false
   # go-cache-version can be used as a cache buster when making breaking changes to caching strategy
   c-go-cache-version:
     type: string
@@ -576,6 +582,10 @@ commands:
         description: "Whether to save the cache at the end of the build"
         type: boolean
         default: false
+      rust_files_changed:
+        description: "Set to false to skip cargo build and reuse cached binaries (feature branches only)."
+        type: boolean
+        default: true
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
@@ -596,6 +606,22 @@ commands:
             PWD=$(pwd)
             export CARGO_TARGET_DIR="$PWD/<< parameters.directory >>/target"
             echo "CARGO_TARGET_DIR: $CARGO_TARGET_DIR"
+
+            # On feature branches where rust/ hasn't changed, reuse binaries from
+            # the restored target cache instead of running cargo build (~9 min saving).
+            # Always build on develop/main as a safety backstop.
+            if [ "<< parameters.rust_files_changed >>" = "false" ] \
+                && [ "$CIRCLE_BRANCH" != "develop" ] \
+                && [ "$CIRCLE_BRANCH" != "main" ]; then
+              binary_dir="$CARGO_TARGET_DIR/<< parameters.profile >>"
+              if [ -d "$binary_dir" ] && ls "$binary_dir"/* >/dev/null 2>&1; then
+                echo "No rust/ changes on feature branch — skipping cargo build"
+                ls -lh "$binary_dir"/ | head -20
+                exit 0
+              fi
+              echo "WARNING: no cached binaries found, building from source"
+            fi
+
             export PROFILE="--profile << parameters.profile >>"
 
             # Debug profile is specified as "debug" in the config/target, but cargo build expects "dev"
@@ -676,6 +702,10 @@ jobs:
         description: "Whether to persist the built binaries to the CircleCI workspace"
         type: boolean
         default: false
+      rust_files_changed:
+        description: "Set to false to skip cargo build and reuse cached binaries (feature branches only)."
+        type: boolean
+        default: true
     steps:
       - rust-build:
           directory: << parameters.directory >>
@@ -687,6 +717,7 @@ jobs:
           binary: << parameters.binary >>
           toolchain: << parameters.toolchain >>
           save_cache: << parameters.save_cache >>
+          rust_files_changed: << parameters.rust_files_changed >>
       - when:
           condition: << parameters.persist_to_workspace >>
           steps:
@@ -3136,6 +3167,7 @@ workflows:
           features: "default"
           save_cache: true
           persist_to_workspace: true
+          rust_files_changed: << pipeline.parameters.c-rust_files_changed >>
           context:
             - circleci-repo-readonly-authenticated-github-token
       - rust-build-submodule: &rust-build-op-rbuilder


### PR DESCRIPTION
## Summary

- `kona-build-release` takes ~9 minutes on every PR, even when no Rust files changed — cargo rebuilds from scratch because fresh checkouts defeat mtime-based fingerprinting
- Uses CircleCI path-filtering to detect `rust/` changes and passes `c-rust_files_changed` to `main.yml`
- When `false` on a feature branch, the build step checks for cached binaries in the restored target cache and exits early

## Safety backstops

- **develop/main**: always build fresh, never skip
- **Cache miss**: falls through to full cargo build with a warning
- **Default is safe**: `rust_files_changed` defaults to `true` — all invocations that don't explicitly opt in always build
- **Flake-shake**: unaffected (doesn't pass the parameter)

## Expected impact

~9 minutes saved on the critical path for every PR that doesn't touch `rust/`.

## Test plan

- [ ] This PR itself doesn't touch `rust/`, so its own CI run should exercise the skip path — check the "Build rust" step in `kona-build-release` for the early exit message
- [ ] Verify acceptance test shards still pass (binaries come from cache)
- [ ] Verify a PR that *does* touch `rust/` still builds normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)