### PR TITLE
fix(ci): add passthrough params to fix manual pipeline dispatch

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -81,6 +81,82 @@ parameters:
   c-go-cache-version:
     type: string
     default: "v0.0"
+  # Passthrough declarations for setup config parameters.
+  # CircleCI forwards all explicitly-passed pipeline parameters to continuation configs.
+  # Without these declarations, manually triggered pipelines fail with "Unexpected argument(s)".
+  # These are not referenced by any job — the c- prefixed versions above are used instead.
+  default_docker_image:
+    type: string
+    default: cimg/base:2026.03
+  base_image:
+    type: string
+    default: default
+  main_dispatch:
+    type: boolean
+    default: true
+  fault_proofs_dispatch:
+    type: boolean
+    default: false
+  reproducibility_dispatch:
+    type: boolean
+    default: false
+  kontrol_dispatch:
+    type: boolean
+    default: false
+  cannon_full_test_dispatch:
+    type: boolean
+    default: false
+  sdk_dispatch:
+    type: boolean
+    default: false
+  docker_publish_dispatch:
+    type: boolean
+    default: false
+  stale_check_dispatch:
+    type: boolean
+    default: false
+  contracts_coverage_dispatch:
+    type: boolean
+    default: false
+  heavy_fuzz_dispatch:
+    type: boolean
+    default: false
+  sync_test_op_node_dispatch:
+    type: boolean
+    default: false
+  ai_contracts_test_dispatch:
+    type: boolean
+    default: false
+  rust_ci_dispatch:
+    type: boolean
+    default: false
+  rust_e2e_dispatch:
+    type: boolean
+    default: false
+  github-event-type:
+    type: string
+    default: "__not_set__"
+  github-event-action:
+    type: string
+    default: "__not_set__"
+  github-event-base64:
+    type: string
+    default: "__not_set__"
+  devnet-metrics-collect:
+    type: boolean
+    default: false
+  flake-shake-dispatch:
+    type: boolean
+    default: false
+  flake-shake-iterations:
+    type: integer
+    default: 300
+  flake-shake-workers:
+    type: integer
+    default: 50
+  go-cache-version:
+    type: string
+    default: "v0.0"
 
 orbs:
   go: circleci/go@1.8.0

--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -24,6 +24,82 @@ parameters:
   c-rust_changes_detected:
     type: boolean
     default: false
+  # Passthrough declarations for setup config parameters.
+  # CircleCI forwards all explicitly-passed pipeline parameters to continuation configs.
+  # Without these declarations, manually triggered pipelines fail with "Unexpected argument(s)".
+  # These are not referenced by any job — the c- prefixed versions above are used instead.
+  default_docker_image:
+    type: string
+    default: cimg/base:2026.03
+  base_image:
+    type: string
+    default: default
+  main_dispatch:
+    type: boolean
+    default: true
+  fault_proofs_dispatch:
+    type: boolean
+    default: false
+  reproducibility_dispatch:
+    type: boolean
+    default: false
+  kontrol_dispatch:
+    type: boolean
+    default: false
+  cannon_full_test_dispatch:
+    type: boolean
+    default: false
+  sdk_dispatch:
+    type: boolean
+    default: false
+  docker_publish_dispatch:
+    type: boolean
+    default: false
+  stale_check_dispatch:
+    type: boolean
+    default: false
+  contracts_coverage_dispatch:
+    type: boolean
+    default: false
+  heavy_fuzz_dispatch:
+    type: boolean
+    default: false
+  sync_test_op_node_dispatch:
+    type: boolean
+    default: false
+  ai_contracts_test_dispatch:
+    type: boolean
+    default: false
+  rust_ci_dispatch:
+    type: boolean
+    default: false
+  rust_e2e_dispatch:
+    type: boolean
+    default: false
+  github-event-type:
+    type: string
+    default: "__not_set__"
+  github-event-action:
+    type: string
+    default: "__not_set__"
+  github-event-base64:
+    type: string
+    default: "__not_set__"
+  devnet-metrics-collect:
+    type: boolean
+    default: false
+  flake-shake-dispatch:
+    type: boolean
+    default: false
+  flake-shake-iterations:
+    type: integer
+    default: 300
+  flake-shake-workers:
+    type: integer
+    default: 50
+  go-cache-version:
+    type: string
+    default: "v0.0"
 
 # ============================================================================
 # COMMANDS

--- a/.circleci/continue/rust-e2e.yml
+++ b/.circleci/continue/rust-e2e.yml
@@ -19,6 +19,82 @@ parameters:
   c-rust_changes_detected:
     type: boolean
     default: false
+  # Passthrough declarations for setup config parameters.
+  # CircleCI forwards all explicitly-passed pipeline parameters to continuation configs.
+  # Without these declarations, manually triggered pipelines fail with "Unexpected argument(s)".
+  # These are not referenced by any job — the c- prefixed versions above are used instead.
+  default_docker_image:
+    type: string
+    default: cimg/base:2026.03
+  base_image:
+    type: string
+    default: default
+  main_dispatch:
+    type: boolean
+    default: true
+  fault_proofs_dispatch:
+    type: boolean
+    default: false
+  reproducibility_dispatch:
+    type: boolean
+    default: false
+  kontrol_dispatch:
+    type: boolean
+    default: false
+  cannon_full_test_dispatch:
+    type: boolean
+    default: false
+  sdk_dispatch:
+    type: boolean
+    default: false
+  docker_publish_dispatch:
+    type: boolean
+    default: false
+  stale_check_dispatch:
+    type: boolean
+    default: false
+  contracts_coverage_dispatch:
+    type: boolean
+    default: false
+  heavy_fuzz_dispatch:
+    type: boolean
+    default: false
+  sync_test_op_node_dispatch:
+    type: boolean
+    default: false
+  ai_contracts_test_dispatch:
+    type: boolean
+    default: false
+  rust_ci_dispatch:
+    type: boolean
+    default: false
+  rust_e2e_dispatch:
+    type: boolean
+    default: false
+  github-event-type:
+    type: string
+    default: "__not_set__"
+  github-event-action:
+    type: string
+    default: "__not_set__"
+  github-event-base64:
+    type: string
+    default: "__not_set__"
+  devnet-metrics-collect:
+    type: boolean
+    default: false
+  flake-shake-dispatch:
+    type: boolean
+    default: false
+  flake-shake-iterations:
+    type: integer
+    default: 300
+  flake-shake-workers:
+    type: integer
+    default: 50
+  go-cache-version:
+    type: string
+    default: "v0.0"
 
 # Commands used by rust-e2e jobs
 commands:


### PR DESCRIPTION
## Summary

Fixes manual pipeline dispatch (both UI and API) which has been broken since #19142 introduced the `c-` prefix for continuation config parameters.

**Root cause:** CircleCI forwards all explicitly-passed pipeline parameters to continuation configs during dynamic config (`setup: true`). When you trigger a pipeline with e.g. `fault_proofs_dispatch=true`, CircleCI:
1. Accepts it in the setup config (where it's declared) ✅
2. Runs path-filtering which maps it to `c-fault_proofs_dispatch` for continuation ✅
3. Also forwards the original `fault_proofs_dispatch` to the continuation config ❌
4. Continuation only declares `c-fault_proofs_dispatch`, rejects `fault_proofs_dispatch` as "Unexpected argument(s)" ❌

This is a [known CircleCI limitation](https://discuss.circleci.com/t/unexpected-argument-error-when-calling-continuation-pipeline/42355) with dynamic configuration.

**Fix:** Add all setup config parameters as passthrough declarations in each continuation config (`main.yml`, `rust-ci.yml`, `rust-e2e.yml`). These are not referenced by any job — the `c-` prefixed versions remain in use. They exist solely to accept the forwarded parameters without error.

## Test plan

- [ ] Verify normal webhook-triggered CI still passes (parameters at defaults, no change in behavior)
- [ ] Verify manual dispatch via API works: `curl -X POST "https://circleci.com/api/v2/project/gh/ethereum-optimism/optimism/pipeline" -H "Content-Type: application/json" -H "Circle-Token: $CITOKEN" -d '{"branch": "aj/fix-ci-dispatch-params", "parameters": {"fault_proofs_dispatch": true}}'`
- [ ] Verify manual dispatch via CircleCI UI "Trigger Pipeline" works

🤖 Generated with [Claude Code](https://claude.com/claude-code)