### PR TITLE
fix(ci): fix SIGPIPE in kona-build-release skip logic

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -616,7 +616,7 @@ commands:
               binary_dir="$CARGO_TARGET_DIR/<< parameters.profile >>"
               if [ -d "$binary_dir" ] && ls "$binary_dir"/* >/dev/null 2>&1; then
                 echo "No rust/ changes on feature branch — skipping cargo build"
-                ls -lh "$binary_dir"/ | head -20
+                ls -lh "$binary_dir"/ | head -20 || true
                 exit 0
               fi
               echo "WARNING: no cached binaries found, building from source"


### PR DESCRIPTION
## Summary

- Fixes `kona-build-release` CI failure (exit code 141) on PRs that don't touch Rust files
- The skip logic from #19459 works correctly but `ls -lh | head -20` triggers SIGPIPE when the directory listing exceeds 20 lines, and CircleCI's default `bash -eo pipefail` turns that into a fatal error
- Fix: append `|| true` to the diagnostic `ls | head` pipe

## Context

PR #19459 (`b894aa134c`) added path-filtering to skip cargo build on PRs without Rust changes. The skip logic itself is correct — it detects no changes and finds cached binaries — but the informational `ls` listing pipe breaks due to SIGPIPE.

Reproducible on any PR that doesn't touch `rust/` files (e.g. #19466).

## Test plan

- [ ] Verify `kona-build-release` passes on this PR (which doesn't touch Rust files)
- [ ] Verify `kona-build-release` still builds correctly on PRs that do touch Rust files

🤖 Generated with [Claude Code](https://claude.com/claude-code)