### PR TITLE
chore: bump just to 1.46.0

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -14,7 +14,7 @@ yq = "4.44.5"
 shellcheck = "0.10.0"
 shfmt = "3.11.0"
 direnv = "2.35.0"
-just = "1.37.0"
+just = "1.46.0"
 make = "4.4.1"
 
 svm-rs = "0.5.19"


### PR DESCRIPTION
## Summary
- Bumps `just` from 1.37.0 to 1.46.0 in `mise.toml`

## Test plan
- [ ] CI passes with the new version