### PR TITLE
chore(rust/op-reth): bump op-reth to 1.11.2

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -7838,7 +7838,7 @@ dependencies = [
 
 [[package]]
 name = "op-reth"
-version = "1.11.1"
+version = "1.11.2"
 dependencies = [
  "clap",
  "reth-cli-util",
@@ -9274,7 +9274,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9298,7 +9298,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9330,7 +9330,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9350,7 +9350,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -9364,7 +9364,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9450,7 +9450,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -9460,7 +9460,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9480,7 +9480,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9500,7 +9500,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9510,7 +9510,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -9526,7 +9526,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9539,7 +9539,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9551,7 +9551,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9577,7 +9577,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9604,7 +9604,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9633,7 +9633,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9663,7 +9663,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9678,7 +9678,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9703,7 +9703,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9727,7 +9727,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9751,7 +9751,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9786,7 +9786,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9844,7 +9844,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9872,7 +9872,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9896,7 +9896,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9921,7 +9921,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-service"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "futures",
  "pin-project",
@@ -9943,7 +9943,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10000,7 +10000,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10028,7 +10028,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10043,7 +10043,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -10059,7 +10059,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10081,7 +10081,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -10092,7 +10092,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -10121,7 +10121,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10145,7 +10145,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -10186,7 +10186,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "clap",
  "eyre",
@@ -10209,7 +10209,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10225,7 +10225,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10243,7 +10243,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -10257,7 +10257,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10286,7 +10286,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10306,7 +10306,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -10316,7 +10316,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10340,7 +10340,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10362,7 +10362,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -10375,7 +10375,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10393,7 +10393,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10431,7 +10431,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-test-utils"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-eips",
  "eyre",
@@ -10463,7 +10463,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10477,7 +10477,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "serde",
  "serde_json",
@@ -10487,7 +10487,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10515,7 +10515,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "bytes",
  "futures",
@@ -10535,7 +10535,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "bitflags 2.11.0",
  "byteorder",
@@ -10551,7 +10551,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "bindgen",
  "cc",
@@ -10560,7 +10560,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "futures",
  "metrics",
@@ -10572,7 +10572,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -10581,7 +10581,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "futures-util",
  "if-addrs 0.14.0",
@@ -10595,7 +10595,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10652,7 +10652,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10677,7 +10677,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10700,7 +10700,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10715,7 +10715,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10729,7 +10729,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -10746,7 +10746,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10770,7 +10770,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10839,7 +10839,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10894,7 +10894,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -10932,7 +10932,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10956,7 +10956,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10980,7 +10980,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "bytes",
  "eyre",
@@ -11009,7 +11009,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -11020,7 +11020,7 @@ dependencies = [
 
 [[package]]
 name = "reth-op"
-version = "1.11.1"
+version = "1.11.2"
 dependencies = [
  "alloy-primitives",
  "reth-chainspec",
@@ -11061,7 +11061,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-chainspec"
-version = "1.11.1"
+version = "1.11.2"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -11089,7 +11089,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-cli"
-version = "1.11.1"
+version = "1.11.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11139,7 +11139,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-consensus"
-version = "1.11.1"
+version = "1.11.2"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -11170,7 +11170,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-evm"
-version = "1.11.1"
+version = "1.11.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11199,7 +11199,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-exex"
-version = "1.11.1"
+version = "1.11.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11226,7 +11226,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-flashblocks"
-version = "1.11.1"
+version = "1.11.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11271,7 +11271,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-forks"
-version = "1.11.1"
+version = "1.11.2"
 dependencies = [
  "alloy-op-hardforks",
  "alloy-primitives",
@@ -11281,7 +11281,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-node"
-version = "1.11.1"
+version = "1.11.2"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -11348,7 +11348,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-payload-builder"
-version = "1.11.1"
+version = "1.11.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11387,7 +11387,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-primitives"
-version = "1.11.1"
+version = "1.11.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11414,7 +11414,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-rpc"
-version = "1.11.1"
+version = "1.11.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11485,7 +11485,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-storage"
-version = "1.11.1"
+version = "1.11.2"
 dependencies = [
  "alloy-consensus",
  "reth-codecs",
@@ -11497,7 +11497,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-trie"
-version = "1.11.1"
+version = "1.11.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11542,7 +11542,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-txpool"
-version = "1.11.1"
+version = "1.11.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11581,7 +11581,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11602,7 +11602,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -11614,7 +11614,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11637,7 +11637,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-util"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11647,7 +11647,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -11657,7 +11657,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-consensus",
  "once_cell",
@@ -11670,7 +11670,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11704,7 +11704,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11749,7 +11749,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11778,7 +11778,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11794,7 +11794,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -11807,7 +11807,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -11884,7 +11884,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-eip7928",
  "alloy-eips",
@@ -11914,7 +11914,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -11955,7 +11955,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11979,7 +11979,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -12009,7 +12009,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -12053,7 +12053,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12101,7 +12101,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -12115,7 +12115,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -12131,7 +12131,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12181,7 +12181,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -12208,7 +12208,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -12222,7 +12222,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -12242,7 +12242,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -12257,7 +12257,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12281,7 +12281,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -12298,7 +12298,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -12316,7 +12316,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12332,7 +12332,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -12342,7 +12342,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "clap",
  "eyre",
@@ -12361,7 +12361,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "clap",
  "eyre",
@@ -12379,7 +12379,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12425,7 +12425,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12451,7 +12451,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -12478,7 +12478,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -12498,7 +12498,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -12523,7 +12523,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -12542,7 +12542,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
 dependencies = [
  "zstd",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -297,78 +297,78 @@ alloy-op-evm = { version = "0.26.3", path = "alloy-op-evm/", default-features = 
 alloy-op-hardforks = { version = "0.4.7", path = "alloy-op-hardforks/", default-features = false }
 
 # ==================== RETH CRATES (from git rev 564ffa58 / main) ====================
-reth = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-chain-state = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-codecs = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1", default-features = false }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1", default-features = false }
-reth-db = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1", default-features = false }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-db-common = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1", default-features = false }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-eth-wire = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-ethereum-forks = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1", default-features = false }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1", default-features = false }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-exex = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-exex-test-utils = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-execution-errors = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1", default-features = false }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1", default-features = false }
-reth-fs-util = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-network = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-node-events = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-payload-builder-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-payload-util = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-payload-validator = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1", default-features = false }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-prune = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1", default-features = false }
-reth-revm = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1", default-features = false }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-rpc-engine-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1", default-features = false }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-stages-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1", default-features = false }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1", default-features = false }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1", default-features = false }
-reth-storage-errors = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1", default-features = false }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1", default-features = false }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1", default-features = false }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-zstd-compressors = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1", default-features = false }
+reth = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
+reth-chain-state = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
+reth-codecs = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2", default-features = false }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2", default-features = false }
+reth-db = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2", default-features = false }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
+reth-db-common = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
+reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2", default-features = false }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
+reth-eth-wire = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
+reth-ethereum-forks = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2", default-features = false }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2", default-features = false }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
+reth-exex = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
+reth-exex-test-utils = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
+reth-execution-errors = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2", default-features = false }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2", default-features = false }
+reth-fs-util = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
+reth-network = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
+reth-node-events = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
+reth-payload-builder-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
+reth-payload-util = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
+reth-payload-validator = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
+reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2", default-features = false }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
+reth-prune = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2", default-features = false }
+reth-revm = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2", default-features = false }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
+reth-rpc-engine-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2", default-features = false }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
+reth-stages-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2", default-features = false }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
+reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2", default-features = false }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2", default-features = false }
+reth-storage-errors = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2", default-features = false }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2", default-features = false }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2", default-features = false }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
+reth-zstd-compressors = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2", default-features = false }
 
 # ==================== REVM (latest: op-reth versions) ====================
 revm = { version = "34.0.0", default-features = false }

--- a/rust/op-reth/bin/Cargo.toml
+++ b/rust/op-reth/bin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "op-reth"
-version = "1.11.1"
+version = "1.11.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/rust/op-reth/crates/chainspec/Cargo.toml
+++ b/rust/op-reth/crates/chainspec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-optimism-chainspec"
-version = "1.11.1"
+version = "1.11.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/rust/op-reth/crates/cli/Cargo.toml
+++ b/rust/op-reth/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-optimism-cli"
-version = "1.11.1"
+version = "1.11.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/rust/op-reth/crates/consensus/Cargo.toml
+++ b/rust/op-reth/crates/consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-optimism-consensus"
-version = "1.11.1"
+version = "1.11.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/rust/op-reth/crates/evm/Cargo.toml
+++ b/rust/op-reth/crates/evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-optimism-evm"
-version = "1.11.1"
+version = "1.11.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/rust/op-reth/crates/exex/Cargo.toml
+++ b/rust/op-reth/crates/exex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-optimism-exex"
-version = "1.11.1"
+version = "1.11.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/rust/op-reth/crates/flashblocks/Cargo.toml
+++ b/rust/op-reth/crates/flashblocks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-optimism-flashblocks"
-version = "1.11.1"
+version = "1.11.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/rust/op-reth/crates/hardforks/Cargo.toml
+++ b/rust/op-reth/crates/hardforks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-optimism-forks"
-version = "1.11.1"
+version = "1.11.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/rust/op-reth/crates/node/Cargo.toml
+++ b/rust/op-reth/crates/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-optimism-node"
-version = "1.11.1"
+version = "1.11.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/rust/op-reth/crates/payload/Cargo.toml
+++ b/rust/op-reth/crates/payload/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-optimism-payload-builder"
-version = "1.11.1"
+version = "1.11.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/rust/op-reth/crates/primitives/Cargo.toml
+++ b/rust/op-reth/crates/primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-optimism-primitives"
-version = "1.11.1"
+version = "1.11.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/rust/op-reth/crates/reth/Cargo.toml
+++ b/rust/op-reth/crates/reth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-op"
-version = "1.11.1"
+version = "1.11.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/rust/op-reth/crates/rpc/Cargo.toml
+++ b/rust/op-reth/crates/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-optimism-rpc"
-version = "1.11.1"
+version = "1.11.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/rust/op-reth/crates/storage/Cargo.toml
+++ b/rust/op-reth/crates/storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-optimism-storage"
-version = "1.11.1"
+version = "1.11.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/rust/op-reth/crates/trie/Cargo.toml
+++ b/rust/op-reth/crates/trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-optimism-trie"
-version = "1.11.1"
+version = "1.11.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/rust/op-reth/crates/txpool/Cargo.toml
+++ b/rust/op-reth/crates/txpool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-optimism-txpool"
-version = "1.11.1"
+version = "1.11.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Description

This PR bumps the reth dependency to version 1.11.2 after they released an important security patch. See https://github.com/paradigmxyz/reth/releases/tag/v1.11.2

Bump op-reth to version 1.11.2. 