### PR TITLE
chore(linter): migrate Makefile to justfile

### DIFF
--- a/justfiles/deprecated.mk
+++ b/justfiles/deprecated.mk
@@ -16,9 +16,9 @@ define make-deprecated-target
 $1:
 	@echo
 	@printf %s\\n '$(call banner-style,Deprecated make call: make $1 $(JUSTFLAGS))'
-	@printf %s\\n '$(call banner-style,Consider using just instead: just $(JUSTFLAGS) $1)'
+	@printf %s\\n '$(call banner-style,Consider using just instead: just $1)'
 	@echo
-	just $(JUSTFLAGS) $1
+	env $(JUSTFLAGS) just $1
 endef
 
 $(foreach element,$(DEPRECATED_TARGETS),$(eval $(call make-deprecated-target,$(element))))

--- a/justfiles/deprecated.mk
+++ b/justfiles/deprecated.mk
@@ -23,5 +23,4 @@ endef
 
 $(foreach element,$(DEPRECATED_TARGETS),$(eval $(call make-deprecated-target,$(element))))
 
-.PHONY:
-	$(DEPRECATED_TARGETS)
+.PHONY: $(DEPRECATED_TARGETS)

--- a/justfiles/uptodate.sh
+++ b/justfiles/uptodate.sh
@@ -33,6 +33,7 @@ fi
 
 for src in "$@"; do
     if [ ! -e "$src" ]; then
+        echo "warning: source '$src' does not exist, forcing rebuild" >&2
         exit 1
     elif [ -d "$src" ]; then
         newer=$(find "$src" -type f -newer "$target" -print -quit 2>/dev/null)

--- a/justfiles/uptodate.sh
+++ b/justfiles/uptodate.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Check if a target file is up to date relative to source files/directories.
+# Exits 0 (true) if the target exists and is newer than all sources.
+# Exits 1 (false) if the target needs rebuilding.
+#
+# Usage: uptodate.sh TARGET SOURCE [SOURCE...]
+#
+# SOURCE can be a file or a directory. Directories are searched recursively.
+#
+# Example in a justfile:
+#   build:
+#       #!/usr/bin/env bash
+#       set -euo pipefail
+#       if ../justfiles/uptodate.sh bin/mybinary src/ config.yml; then
+#           echo "bin/mybinary is up to date"
+#           exit 0
+#       fi
+#       go build -o bin/mybinary .
+
+set -euo pipefail
+
+if [ $# -lt 2 ]; then
+    echo "usage: uptodate.sh TARGET SOURCE [SOURCE...]" >&2
+    exit 1
+fi
+
+target="$1"
+shift
+
+if [ ! -f "$target" ]; then
+    exit 1
+fi
+
+for src in "$@"; do
+    if [ -d "$src" ]; then
+        newer=$(find "$src" -type f -newer "$target" -print -quit 2>/dev/null)
+        if [ -n "$newer" ]; then
+            exit 1
+        fi
+    elif [ -f "$src" ]; then
+        if [ "$src" -nt "$target" ]; then
+            exit 1
+        fi
+    fi
+done
+
+exit 0

--- a/justfiles/uptodate.sh
+++ b/justfiles/uptodate.sh
@@ -32,12 +32,14 @@ if [ ! -f "$target" ]; then
 fi
 
 for src in "$@"; do
-    if [ -d "$src" ]; then
+    if [ ! -e "$src" ]; then
+        exit 1
+    elif [ -d "$src" ]; then
         newer=$(find "$src" -type f -newer "$target" -print -quit 2>/dev/null)
         if [ -n "$newer" ]; then
             exit 1
         fi
-    elif [ -f "$src" ]; then
+    else
         if [ "$src" -nt "$target" ]; then
             exit 1
         fi

--- a/linter/Makefile
+++ b/linter/Makefile
@@ -1,15 +1,3 @@
-BIN := bin/op-golangci-lint
-SRC := $(shell find analyzers -type f)
+DEPRECATED_TARGETS := build test clean
 
-build: $(BIN)
-
-$(BIN): $(SRC) .custom-gcl.yml | bin
-	golangci-lint custom -v
-
-bin:
-	mkdir -p bin
-
-test:
-	go test ./...
-
-.PHONY: build test
+include ../justfiles/deprecated.mk

--- a/linter/justfile
+++ b/linter/justfile
@@ -7,12 +7,9 @@ build:
     #!/usr/bin/env bash
     set -euo pipefail
     mkdir -p bin
-    if [[ -f "{{BIN}}" ]]; then
-        newer=$(find analyzers -type f -newer "{{BIN}}" -print -quit 2>/dev/null)
-        if [[ -z "$newer" ]] && [[ "{{BIN}}" -nt .custom-gcl.yml ]]; then
-            echo "{{BIN}} is up to date"
-            exit 0
-        fi
+    if ../justfiles/uptodate.sh "{{BIN}}" analyzers .custom-gcl.yml; then
+        echo "{{BIN}} is up to date"
+        exit 0
     fi
     golangci-lint custom -v
 

--- a/linter/justfile
+++ b/linter/justfile
@@ -2,9 +2,18 @@ import '../justfiles/go.just'
 
 BIN := "bin/op-golangci-lint"
 
-# Build the custom linter
+# Build the custom linter (only if sources changed)
 build:
+    #!/usr/bin/env bash
+    set -euo pipefail
     mkdir -p bin
+    if [[ -f "{{BIN}}" ]]; then
+        newer=$(find analyzers -type f -newer "{{BIN}}" -print -quit 2>/dev/null)
+        if [[ -z "$newer" ]] && [[ "{{BIN}}" -nt .custom-gcl.yml ]]; then
+            echo "{{BIN}} is up to date"
+            exit 0
+        fi
+    fi
     golangci-lint custom -v
 
 # Run tests

--- a/linter/justfile
+++ b/linter/justfile
@@ -1,0 +1,15 @@
+import '../justfiles/go.just'
+
+BIN := "bin/op-golangci-lint"
+
+# Build the custom linter
+build:
+    mkdir -p bin
+    golangci-lint custom -v
+
+# Run tests
+test: (go_test "./...")
+
+# Clean build artifacts
+clean:
+    rm -rf bin


### PR DESCRIPTION
## Summary
- Migrates `linter/Makefile` build targets (`build`, `test`, `clean`) to a new `linter/justfile` using the shared `go.just` recipes
- Replaces the original Makefile with a deprecation shim (`justfiles/deprecated.mk`) that delegates to `just`, preserving backwards compatibility for existing `make` invocations
- Adds shared `justfiles/flags.mk` to extract Make variable assignments into `JUSTFLAGS` for forwarding to just as env vars
- Extracts the file-dependency freshness check into a reusable `justfiles/uptodate.sh` helper script, so other justfiles can use the same pattern to skip unnecessary rebuilds

## Stack
1. **This PR** — linter migration + shared infrastructure
2. optimism#19474 — cannon migration
3. optimism#19475 — op-e2e migration
4. optimism#19476 — op-program migration
5. optimism#19477 — root Makefile migration
6. optimism#19482 — CI config update
7. optimism#19483 — cannon testdata migration

## Test plan
- [x] `just build` in `linter/` builds the custom linter (skips if up to date)
- [x] `make build` in `linter/` delegates to `just build` with deprecation warning
- [x] `just test` runs `go test ./...` successfully
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)