### PR TITLE
refactor(kona/derive): rename index to expected_blobs in BlobData::fill

### DIFF
--- a/rust/kona/crates/protocol/derive/src/sources/blob_data.rs
+++ b/rust/kona/crates/protocol/derive/src/sources/blob_data.rs
@@ -145,22 +145,22 @@ impl BlobData {
     pub(crate) fn fill(
         &mut self,
         blobs: &[Box<Blob>],
-        index: usize,
+        expected_blobs: usize,
     ) -> Result<bool, BlobDecodingError> {
         // Do not fill if there is calldata here
         if self.calldata.is_some() {
             return Ok(false);
         }
 
-        if index >= blobs.len() {
+        if expected_blobs >= blobs.len() {
             return Err(BlobDecodingError::InvalidLength);
         }
 
-        if blobs[index].is_empty() {
+        if blobs[expected_blobs].is_empty() {
             return Err(BlobDecodingError::MissingData);
         }
 
-        self.data = Some(Bytes::from(*blobs[index]));
+        self.data = Some(Bytes::from(*blobs[expected_blobs]));
         Ok(true)
     }
 }


### PR DESCRIPTION
## Summary
- Renames the `index` parameter to `expected_blobs` in `BlobData::fill()` for better clarity about what the value represents
- Addresses review feedback from optimism#19362 ([comment](https://github.com/ethereum-optimism/optimism/pull/19362/files#r2914974799))

## Test plan
- [x] `cargo check` passes with no new warnings
- [x] Existing tests pass (positional args unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)