### PR TITLE
chore: add nut bundle check to just pr

### DIFF
--- a/packages/contracts-bedrock/checks.yaml
+++ b/packages/contracts-bedrock/checks.yaml
@@ -87,7 +87,7 @@ phases:
         command: go run ./scripts/checks/opcm-upgrade-checks/
       - name: nut-bundle-gen
         description: Generate the Network Upgrade Transaction bundle from the source
-        command: forge script ./scripts/upgrade/GenerateNUTBundle.s.sol:GenerateNUTBundle --sig 'run()' > /dev/null
+        command: forge script ./scripts/upgrade/GenerateNUTBundle.s.sol:GenerateNUTBundle --sig 'run()'
       - name: nut-bundle-check
         description: Check the generated Network Upgrade Transaction bundle is up to date
         command: go run ./scripts/checks/nut-bundle-check

--- a/packages/contracts-bedrock/checks.yaml
+++ b/packages/contracts-bedrock/checks.yaml
@@ -85,6 +85,9 @@ phases:
       - name: opcm-upgrade-checks
         description: Check OPCM upgrade methods
         command: go run ./scripts/checks/opcm-upgrade-checks/
+      - name: nut-bundle-check
+        description: Check the generated Network Upgrade Transaction bundle is up to date
+        command: go run ./scripts/checks/nut-bundle-check
 
   # Phase 4: Dev build checks - needs test artifacts
   - name: dev

--- a/packages/contracts-bedrock/checks.yaml
+++ b/packages/contracts-bedrock/checks.yaml
@@ -85,9 +85,14 @@ phases:
       - name: opcm-upgrade-checks
         description: Check OPCM upgrade methods
         command: go run ./scripts/checks/opcm-upgrade-checks/
+      - name: nut-bundle-gen
+        description: Generate the Network Upgrade Transaction bundle from the source
+        command: forge script ./scripts/upgrade/GenerateNUTBundle.s.sol:GenerateNUTBundle --sig 'run()' > /dev/null
       - name: nut-bundle-check
         description: Check the generated Network Upgrade Transaction bundle is up to date
         command: go run ./scripts/checks/nut-bundle-check
+        depends:
+          - nut-bundle-gen
 
   # Phase 4: Dev build checks - needs test artifacts
   - name: dev


### PR DESCRIPTION
## Overview

Wires up the `scripts/checks/nut-bundle-check` script to the `just pr` recipe. 

## Changes
- packages/contracts-bedrock/checks.yaml