### PR TITLE
chore: add fix-rust-fmt Claude Code skill

### DIFF
--- a/.claude/skills/fix-rust-fmt/SKILL.md
+++ b/.claude/skills/fix-rust-fmt/SKILL.md
@@ -1,6 +1,6 @@
 # fix-rust-fmt
 
-Fix Rust formatting issues in the optimism monorepo which would case the `rust-fmt` CI job to fail.
+Fix Rust formatting issues in the optimism monorepo which would cause the `rust-fmt` CI job to fail.
 
 ## When to Use
 

--- a/.claude/skills/fix-rust-fmt/SKILL.md
+++ b/.claude/skills/fix-rust-fmt/SKILL.md
@@ -1,0 +1,57 @@
+# fix-rust-fmt
+
+Fix Rust formatting issues in the optimism monorepo. When the `rust-fmt` CI job
+fails, don't bother reading the errors — just run the formatter and commit
+whatever it changes.
+
+## When to Use
+
+Use this skill when the `rust-fmt` CI job fails on a PR that touches Rust code.
+
+### Trigger Phrases
+
+- "Fix rust formatting"
+- "rust-fmt is failing"
+- "Fix the rust-fmt CI job"
+
+## Prerequisites
+
+- `mise` must be trusted and installed for this repo (`mise trust && mise install`)
+
+## Workflow
+
+### Step 1: Ensure mise tools are installed
+
+From the repo root (or worktree root):
+
+```bash
+cd <REPO_ROOT> && mise install
+```
+
+This installs `rust`, `just`, and all other tools pinned in `mise.toml`.
+
+### Step 2: Install the nightly toolchain with rustfmt
+
+The justfile pins a specific nightly (see `NIGHTLY` variable in `rust/justfile`).
+Install it:
+
+```bash
+cd <REPO_ROOT>/rust && mise exec -- just install-nightly
+```
+
+### Step 3: Run the formatter
+
+```bash
+cd <REPO_ROOT>/rust && mise exec -- just fmt-fix
+```
+
+Any files that change are the reason the CI job failed. Stage and commit them.
+
+## Notes
+
+- `mise exec --` activates the mise environment so `cargo`, `just`, and
+  `rustup` resolve to the versions pinned in `mise.toml`.
+- The nightly toolchain is required because the workspace uses unstable
+  `rustfmt` options (see `rust/rustfmt.toml`).
+- There is no need to inspect `rust-fmt` CI errors — if the job failed, running
+  `just fmt-fix` and committing the result is the complete fix.

--- a/.claude/skills/fix-rust-fmt/SKILL.md
+++ b/.claude/skills/fix-rust-fmt/SKILL.md
@@ -1,8 +1,6 @@
 # fix-rust-fmt
 
-Fix Rust formatting issues in the optimism monorepo. When the `rust-fmt` CI job
-fails, don't bother reading the errors — just run the formatter and commit
-whatever it changes.
+Fix Rust formatting issues in the optimism monorepo which would case the `rust-fmt` CI job to fail.
 
 ## When to Use
 

--- a/docs/ai/rust-dev.md
+++ b/docs/ai/rust-dev.md
@@ -3,3 +3,7 @@
 This document provides guidance for AI agents working with Rust components in the OP Stack.
 
 <!-- TODO: Add detailed guidance for Rust development -->
+
+## Skills
+
+- **Fix Rust Formatting** ([`.claude/skills/fix-rust-fmt/SKILL.md`](../../.claude/skills/fix-rust-fmt/SKILL.md)): Fixes `rust-fmt` CI failures by installing the pinned nightly toolchain and running `just fmt-fix`. Invoke with `/fix-rust-fmt`.

--- a/rust/kona/CLAUDE.md
+++ b/rust/kona/CLAUDE.md
@@ -5,7 +5,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Build Commands
 - Build workspace: `just b` or `just build-native`
 - Lint: `just l` or `just lint-native`
-- Format: `just f` or `just fmt-native-fix`
+- Format: `just f` or `just fmt-native-fix` (if `rust-fmt` CI fails, use `/fix-rust-fmt`)
 - Run all tests: `just t` or `just tests`
 - Run specific test: `cargo nextest run --package [package-name] --test [test-name]`
 - Run single test: `cargo nextest run --package [package-name] --test [test-name] -- [test_function_name]`


### PR DESCRIPTION
## Summary

- Adds a `/fix-rust-fmt` Claude Code skill that fixes Rust formatting CI failures
- Runs `mise install` + `just install-nightly` + `just fmt-fix` with the correct pinned nightly toolchain
- No need to inspect CI errors — just run the formatter and commit whatever changes

## Test plan

- [ ] Invoke `/fix-rust-fmt` in a Claude Code session with a Rust formatting issue
- [ ] Verify it installs the correct nightly and runs `just fmt-fix`

🤖 Generated with [Claude Code](https://claude.com/claude-code)