### PR TITLE
refactor(rust): replace #[ignore] with nextest binary filtering

### DIFF
--- a/rust/derivation-tests/README.md
+++ b/rust/derivation-tests/README.md
@@ -68,7 +68,7 @@ assert_ne!(root, alloy_primitives::B256::ZERO);
 
 1. Create a function that builds a `DerivationTest` with the desired chain structure.
 2. Assert the super root against a golden hash constant (see below).
-3. Optionally add an `#[ignore]` integration test that runs the scenario through op-program or kona-host.
+3. Optionally add the scenario to `tests/integration.rs` using the `run_all_programs!` macro to run it through op-program and kona-host.
 
 See `tests/simple.rs` for examples covering empty blocks, singular batches, blob batches, user transfers, multi-block epochs, and system config updates. Integration tests live in `tests/integration.rs` and server tests in `tests/server.rs`.
 
@@ -76,13 +76,13 @@ See `tests/simple.rs` for examples covering empty blocks, singular batches, blob
 
 Tests pin expected super root hashes as hardcoded constants in `tests/simple.rs`. This catches silent regressions in batch encoding, block execution, state root computation, or output root calculation -- a consistently wrong root would pass a pure determinism check.
 
-The golden values are framework-internal. Cross-implementation validation happens via the `#[ignore]` integration tests that run op-program and kona-host against the same chains.
+The golden values are framework-internal. Cross-implementation validation happens via the integration tests in `tests/integration.rs` that run op-program and kona-host against the same chains.
 
 ### Updating golden values
 
 When an intentional change modifies the derivation output (e.g. a new hardfork, changed genesis config, or updated deposit tx encoding):
 
-1. Run: `just test-derivation -- --nocapture 2>&1 | grep "super root"`
+1. Run: `just test-derivation -- --no-capture 2>&1 | grep "super root"`
 2. Each test prints its computed super root to stderr before asserting.
 3. Copy the new values into the `EXPECTED_*` constants in `tests/simple.rs`.
 4. Re-run `just test-derivation` to confirm all tests pass.
@@ -92,7 +92,7 @@ When an intentional change modifies the derivation output (e.g. a new hardfork, 
 ```
 tests/
 ├── simple.rs        Derivation correctness (golden hash assertions)
-├── integration.rs   op-program and kona-host end-to-end tests (#[ignore])
+├── integration.rs   op-program and kona-host end-to-end tests
 ├── server.rs        L1 RPC, L2 RPC, and Beacon API server tests
 └── helpers/         Shared test helpers (funded signer, etc.)
 

--- a/rust/derivation-tests/tests/helpers/mod.rs
+++ b/rust/derivation-tests/tests/helpers/mod.rs
@@ -12,16 +12,3 @@ pub(crate) fn default_test() -> DerivationTest {
 pub(crate) fn funded_signer() -> PrivateKeySigner {
     PrivateKeySigner::from_bytes(&PREFUNDED_ACCOUNT_KEY).expect("valid prefunded key")
 }
-
-/// Skip the current test if op-program or kona-host binaries are not available.
-///
-/// Prints a skip message and returns early when the required env vars are missing.
-#[macro_export]
-macro_rules! skip_without_programs {
-    () => {
-        if std::env::var("OP_PROGRAM_PATH").is_err() || std::env::var("KONA_HOST_PATH").is_err() {
-            eprintln!("SKIP: OP_PROGRAM_PATH and/or KONA_HOST_PATH not set, skipping program test");
-            return;
-        }
-    };
-}

--- a/rust/derivation-tests/tests/integration.rs
+++ b/rust/derivation-tests/tests/integration.rs
@@ -4,8 +4,9 @@
 //! generates one test per program implementation. To add a new program,
 //! update the macro — all scenarios get it for free.
 //!
-//! These tests require external binaries and are marked `#[ignore]`.
+//! These tests require external binaries and are excluded from `just test-derivation`.
 //! Run with: `just test-derivation-integration` (from rust/)
+//! Run a single program: `just test-derivation-op-program` or `just test-derivation-kona-host`
 
 mod helpers;
 
@@ -45,8 +46,10 @@ const KONA_HOST: Program = Program {
 
 async fn run_program(build: fn() -> DerivationTest, program: &Program) {
     if std::env::var(program.env_var).is_err() {
-        eprintln!("SKIP: {} not set.", program.env_var);
-        return;
+        panic!(
+            "{} not set. Build the binary first (see just test-derivation-integration).",
+            program.env_var
+        );
     }
 
     let test = build();
@@ -63,7 +66,7 @@ async fn run_program(build: fn() -> DerivationTest, program: &Program) {
     assert!(status.success(), "{} should exit 0, got: {status}", program.name,);
 }
 
-/// Generates one `#[tokio::test] #[ignore]` per program for a given scenario.
+/// Generates one `#[tokio::test]` per program for a given scenario.
 ///
 /// Adding a new program means adding one line here — every scenario gets it
 /// automatically.
@@ -71,13 +74,11 @@ macro_rules! run_all_programs {
     ($scenario:ident) => {
         paste::paste! {
             #[tokio::test]
-            #[ignore]
             async fn [<test_op_program_ $scenario>]() {
                 run_program($scenario, &OP_PROGRAM).await;
             }
 
             #[tokio::test]
-            #[ignore]
             async fn [<test_kona_host_ $scenario>]() {
                 run_program($scenario, &KONA_HOST).await;
             }

--- a/rust/justfile
+++ b/rust/justfile
@@ -41,8 +41,8 @@ build-op-reth:
 # Run all tests (unit + doc tests)
 test: test-unit test-docs
 
-# Run unit tests (excluding online tests)
-test-unit *args="-E '!test(test_online)'":
+# Run unit tests (excluding online tests and derivation-tests integration binary)
+test-unit *args="-E '!test(test_online) & !(package(derivation-tests) & binary(integration))'":
   cargo nextest run --workspace --all-features {{args}}
 
 # Run online tests only
@@ -57,25 +57,25 @@ test-docs:
 
 MONOREPO_ROOT := justfile_directory() / ".."
 
-# Run derivation-tests unit tests
+# Run derivation-tests unit tests (excludes integration tests that require external binaries)
 test-derivation *args='':
-  cargo test -p derivation-tests {{args}}
+  cargo nextest run -p derivation-tests -E '!binary(integration)' {{args}}
 
 # Run derivation-tests integration tests (builds op-program and kona-host first)
 test-derivation-integration: _build-op-program _build-kona-host
   OP_PROGRAM_PATH={{MONOREPO_ROOT}}/op-program/bin/op-program \
   KONA_HOST_PATH={{justfile_directory()}}/target/debug/kona-host \
-    cargo test -p derivation-tests -- --ignored
+    cargo nextest run -p derivation-tests -E 'binary(integration)'
 
 # Run derivation-tests integration tests against op-program only
 test-derivation-op-program: _build-op-program
   OP_PROGRAM_PATH={{MONOREPO_ROOT}}/op-program/bin/op-program \
-    cargo test -p derivation-tests -- --ignored test_op_program
+    cargo nextest run -p derivation-tests -E 'binary(integration) & test(test_op_program)'
 
 # Run derivation-tests integration tests against kona-host only
 test-derivation-kona-host: _build-kona-host
   KONA_HOST_PATH={{justfile_directory()}}/target/debug/kona-host \
-    cargo test -p derivation-tests -- --ignored test_kona_host
+    cargo nextest run -p derivation-tests -E 'binary(integration) & test(test_kona_host)'
 
 # Build op-program host binary
 _build-op-program:


### PR DESCRIPTION
## Summary

- Remove `#[ignore]` from derivation-tests integration tests
- Replace silent env-var skip with hard `panic!` when binaries are missing
- Switch all derivation test just targets from `cargo test` to `cargo nextest run` with binary-level filtering
- Scope `test-unit` exclusion to `package(derivation-tests) & binary(integration)` to avoid affecting other crates' `integration.rs` binaries
- Remove unused `skip_without_programs!` macro
- Update README: remove `#[ignore]` references, fix `--nocapture` → `--no-capture`

## Test plan

- [x] `just test-derivation` — 41 unit tests pass, integration binary skipped
- [x] Integration tests panic with clear message when env vars missing
- [x] `just fmt-check` passes
- [x] `cargo nextest list` confirms binary name `derivation-tests::integration`
- [x] Package-scoped filter correctly excludes only derivation-tests integration binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)