### PR TITLE
chore(rust/op-reth): bump reth to v1.11.3

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -7838,7 +7838,7 @@ dependencies = [
 
 [[package]]
 name = "op-reth"
-version = "1.11.2"
+version = "1.11.3"
 dependencies = [
  "clap",
  "reth-cli-util",
@@ -9273,8 +9273,8 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9297,8 +9297,8 @@ dependencies = [
 
 [[package]]
 name = "reth-chain-state"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9329,8 +9329,8 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9349,8 +9349,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -9363,8 +9363,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-commands"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9449,8 +9449,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-runner"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -9459,8 +9459,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-util"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9479,8 +9479,8 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9499,8 +9499,8 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9509,8 +9509,8 @@ dependencies = [
 
 [[package]]
 name = "reth-config"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -9525,8 +9525,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9538,8 +9538,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9550,8 +9550,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-debug-client"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9576,8 +9576,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9603,8 +9603,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-api"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9632,8 +9632,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-common"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9662,8 +9662,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9677,8 +9677,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv4"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9702,8 +9702,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv5"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9726,8 +9726,8 @@ dependencies = [
 
 [[package]]
 name = "reth-dns-discovery"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9750,8 +9750,8 @@ dependencies = [
 
 [[package]]
 name = "reth-downloaders"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9785,8 +9785,8 @@ dependencies = [
 
 [[package]]
 name = "reth-e2e-test-utils"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9843,8 +9843,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9871,8 +9871,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-local"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9895,8 +9895,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9920,8 +9920,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-service"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "futures",
  "pin-project",
@@ -9942,8 +9942,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-tree"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9999,8 +9999,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-util"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10027,8 +10027,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10042,8 +10042,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era-downloader"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -10058,8 +10058,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era-utils"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10080,8 +10080,8 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -10091,8 +10091,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -10120,8 +10120,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire-types"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10144,8 +10144,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -10185,8 +10185,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-cli"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "clap",
  "eyre",
@@ -10208,8 +10208,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10224,8 +10224,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10242,8 +10242,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -10256,8 +10256,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-payload-builder"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10285,8 +10285,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10305,8 +10305,8 @@ dependencies = [
 
 [[package]]
 name = "reth-etl"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -10315,8 +10315,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10339,8 +10339,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10361,8 +10361,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -10374,8 +10374,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10392,8 +10392,8 @@ dependencies = [
 
 [[package]]
 name = "reth-exex"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10430,8 +10430,8 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-test-utils"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-eips",
  "eyre",
@@ -10462,8 +10462,8 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-types"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10476,8 +10476,8 @@ dependencies = [
 
 [[package]]
 name = "reth-fs-util"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "serde",
  "serde_json",
@@ -10486,8 +10486,8 @@ dependencies = [
 
 [[package]]
 name = "reth-invalid-block-hooks"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10514,8 +10514,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ipc"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "bytes",
  "futures",
@@ -10534,8 +10534,8 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "bitflags 2.11.0",
  "byteorder",
@@ -10550,8 +10550,8 @@ dependencies = [
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "bindgen",
  "cc",
@@ -10559,8 +10559,8 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "futures",
  "metrics",
@@ -10571,8 +10571,8 @@ dependencies = [
 
 [[package]]
 name = "reth-net-banlist"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -10580,8 +10580,8 @@ dependencies = [
 
 [[package]]
 name = "reth-net-nat"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "futures-util",
  "if-addrs 0.14.0",
@@ -10594,8 +10594,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10651,8 +10651,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10676,8 +10676,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-p2p"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10699,8 +10699,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10714,8 +10714,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-types"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10728,8 +10728,8 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -10745,8 +10745,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-api"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10769,8 +10769,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-builder"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10838,8 +10838,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-core"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10893,8 +10893,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethereum"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -10931,8 +10931,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethstats"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10955,8 +10955,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-events"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10979,8 +10979,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-metrics"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "bytes",
  "eyre",
@@ -11008,8 +11008,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-types"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -11020,7 +11020,7 @@ dependencies = [
 
 [[package]]
 name = "reth-op"
-version = "1.11.2"
+version = "1.11.3"
 dependencies = [
  "alloy-primitives",
  "reth-chainspec",
@@ -11061,7 +11061,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-chainspec"
-version = "1.11.2"
+version = "1.11.3"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -11089,7 +11089,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-cli"
-version = "1.11.2"
+version = "1.11.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11139,7 +11139,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-consensus"
-version = "1.11.2"
+version = "1.11.3"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -11170,7 +11170,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-evm"
-version = "1.11.2"
+version = "1.11.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11199,7 +11199,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-exex"
-version = "1.11.2"
+version = "1.11.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11226,7 +11226,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-flashblocks"
-version = "1.11.2"
+version = "1.11.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11271,7 +11271,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-forks"
-version = "1.11.2"
+version = "1.11.3"
 dependencies = [
  "alloy-op-hardforks",
  "alloy-primitives",
@@ -11281,7 +11281,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-node"
-version = "1.11.2"
+version = "1.11.3"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -11348,7 +11348,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-payload-builder"
-version = "1.11.2"
+version = "1.11.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11387,7 +11387,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-primitives"
-version = "1.11.2"
+version = "1.11.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11414,7 +11414,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-rpc"
-version = "1.11.2"
+version = "1.11.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11485,7 +11485,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-storage"
-version = "1.11.2"
+version = "1.11.3"
 dependencies = [
  "alloy-consensus",
  "reth-codecs",
@@ -11497,7 +11497,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-trie"
-version = "1.11.2"
+version = "1.11.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11542,7 +11542,7 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-txpool"
-version = "1.11.2"
+version = "1.11.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11580,8 +11580,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11601,8 +11601,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder-primitives"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -11613,8 +11613,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11636,8 +11636,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-util"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11646,8 +11646,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -11656,8 +11656,8 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-consensus",
  "once_cell",
@@ -11669,8 +11669,8 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11703,8 +11703,8 @@ dependencies = [
 
 [[package]]
 name = "reth-provider"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11748,8 +11748,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11777,8 +11777,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11793,8 +11793,8 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -11806,8 +11806,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -11883,8 +11883,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-eip7928",
  "alloy-eips",
@@ -11913,8 +11913,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-builder"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -11954,8 +11954,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-convert"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11978,8 +11978,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-engine-api"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -12008,8 +12008,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-api"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -12052,8 +12052,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-types"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12100,8 +12100,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-layer"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -12114,8 +12114,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-server-types"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -12130,8 +12130,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12180,8 +12180,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-api"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -12207,8 +12207,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -12221,8 +12221,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -12241,8 +12241,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -12256,8 +12256,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12280,8 +12280,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -12297,8 +12297,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tasks"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -12315,8 +12315,8 @@ dependencies = [
 
 [[package]]
 name = "reth-testing-utils"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12331,8 +12331,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -12341,8 +12341,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "clap",
  "eyre",
@@ -12360,8 +12360,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing-otlp"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "clap",
  "eyre",
@@ -12378,8 +12378,8 @@ dependencies = [
 
 [[package]]
 name = "reth-transaction-pool"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12424,8 +12424,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12450,8 +12450,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -12477,8 +12477,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-db"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -12497,8 +12497,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-parallel"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -12522,8 +12522,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -12541,8 +12541,8 @@ dependencies = [
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
 dependencies = [
  "zstd",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -296,79 +296,79 @@ op-alloy-rpc-jsonrpsee = { version = "0.23.1", path = "op-alloy/crates/rpc-jsonr
 alloy-op-evm = { version = "0.26.3", path = "alloy-op-evm/", default-features = false }
 alloy-op-hardforks = { version = "0.4.7", path = "alloy-op-hardforks/", default-features = false }
 
-# ==================== RETH CRATES (from git rev 564ffa58 / main) ====================
-reth = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
-reth-chain-state = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
-reth-codecs = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2", default-features = false }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2", default-features = false }
-reth-db = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2", default-features = false }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
-reth-db-common = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
-reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2", default-features = false }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
-reth-eth-wire = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
-reth-ethereum-forks = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2", default-features = false }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2", default-features = false }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
-reth-exex = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
-reth-exex-test-utils = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
-reth-execution-errors = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2", default-features = false }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2", default-features = false }
-reth-fs-util = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
-reth-network = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
-reth-node-events = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
-reth-payload-builder-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
-reth-payload-util = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
-reth-payload-validator = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
-reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2", default-features = false }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
-reth-prune = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2", default-features = false }
-reth-revm = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2", default-features = false }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
-reth-rpc-engine-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2", default-features = false }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
-reth-stages-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2", default-features = false }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
-reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2", default-features = false }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2", default-features = false }
-reth-storage-errors = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2", default-features = false }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2", default-features = false }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2", default-features = false }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2" }
-reth-zstd-compressors = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.2", default-features = false }
+# ==================== RETH CRATES (v1.11.3) ====================
+reth = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
+reth-chain-state = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
+reth-codecs = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false }
+reth-db = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
+reth-db-common = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
+reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
+reth-eth-wire = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
+reth-ethereum-forks = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
+reth-exex = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
+reth-exex-test-utils = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
+reth-execution-errors = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false }
+reth-fs-util = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
+reth-network = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
+reth-node-events = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
+reth-payload-builder-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
+reth-payload-util = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
+reth-payload-validator = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
+reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
+reth-prune = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false }
+reth-revm = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
+reth-rpc-engine-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
+reth-stages-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
+reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false }
+reth-storage-errors = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
+reth-zstd-compressors = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false }
 
 # ==================== REVM (latest: op-reth versions) ====================
 revm = { version = "34.0.0", default-features = false }

--- a/rust/op-reth/bin/Cargo.toml
+++ b/rust/op-reth/bin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "op-reth"
-version = "1.11.2"
+version = "1.11.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/rust/op-reth/crates/chainspec/Cargo.toml
+++ b/rust/op-reth/crates/chainspec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-optimism-chainspec"
-version = "1.11.2"
+version = "1.11.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/rust/op-reth/crates/cli/Cargo.toml
+++ b/rust/op-reth/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-optimism-cli"
-version = "1.11.2"
+version = "1.11.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/rust/op-reth/crates/consensus/Cargo.toml
+++ b/rust/op-reth/crates/consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-optimism-consensus"
-version = "1.11.2"
+version = "1.11.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/rust/op-reth/crates/evm/Cargo.toml
+++ b/rust/op-reth/crates/evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-optimism-evm"
-version = "1.11.2"
+version = "1.11.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/rust/op-reth/crates/exex/Cargo.toml
+++ b/rust/op-reth/crates/exex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-optimism-exex"
-version = "1.11.2"
+version = "1.11.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/rust/op-reth/crates/flashblocks/Cargo.toml
+++ b/rust/op-reth/crates/flashblocks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-optimism-flashblocks"
-version = "1.11.2"
+version = "1.11.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/rust/op-reth/crates/hardforks/Cargo.toml
+++ b/rust/op-reth/crates/hardforks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-optimism-forks"
-version = "1.11.2"
+version = "1.11.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/rust/op-reth/crates/node/Cargo.toml
+++ b/rust/op-reth/crates/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-optimism-node"
-version = "1.11.2"
+version = "1.11.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/rust/op-reth/crates/payload/Cargo.toml
+++ b/rust/op-reth/crates/payload/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-optimism-payload-builder"
-version = "1.11.2"
+version = "1.11.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/rust/op-reth/crates/primitives/Cargo.toml
+++ b/rust/op-reth/crates/primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-optimism-primitives"
-version = "1.11.2"
+version = "1.11.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/rust/op-reth/crates/reth/Cargo.toml
+++ b/rust/op-reth/crates/reth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-op"
-version = "1.11.2"
+version = "1.11.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/rust/op-reth/crates/rpc/Cargo.toml
+++ b/rust/op-reth/crates/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-optimism-rpc"
-version = "1.11.2"
+version = "1.11.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/rust/op-reth/crates/storage/Cargo.toml
+++ b/rust/op-reth/crates/storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-optimism-storage"
-version = "1.11.2"
+version = "1.11.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/rust/op-reth/crates/trie/Cargo.toml
+++ b/rust/op-reth/crates/trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-optimism-trie"
-version = "1.11.2"
+version = "1.11.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/rust/op-reth/crates/txpool/Cargo.toml
+++ b/rust/op-reth/crates/txpool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reth-optimism-txpool"
-version = "1.11.2"
+version = "1.11.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary
- Bump all reth dependencies from v1.11.2 to v1.11.3 in the rust workspace
- Update op-reth crate versions to 1.11.3
- Update Cargo.lock

## Test plan
- [x] `cargo check --workspace` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)