### PR TITLE
op-node/derive: drop bad channel decompression as NotEnoughData

### DIFF
--- a/op-node/rollup/derive/channel_in_reader.go
+++ b/op-node/rollup/derive/channel_in_reader.go
@@ -59,7 +59,7 @@ func (cr *ChannelInReader) WriteChannel(data []byte) error {
 		cr.metrics.RecordChannelInputBytes(len(data))
 		return nil
 	} else {
-		cr.log.Error("Error creating batch reader from channel data", "err", err)
+		cr.log.Warn("Error creating batch reader from channel data", "err", err)
 		return err
 	}
 }
@@ -81,7 +81,8 @@ func (cr *ChannelInReader) NextBatch(ctx context.Context) (Batch, error) {
 			return nil, err
 		} else {
 			if err := cr.WriteChannel(data); err != nil {
-				return nil, NewTemporaryError(err)
+				cr.log.Warn("failed to create batch reader from channel data, dropping channel", "err", err)
+				return nil, NotEnoughData
 			}
 		}
 	}

--- a/op-node/rollup/derive/channel_in_reader.go
+++ b/op-node/rollup/derive/channel_in_reader.go
@@ -59,7 +59,6 @@ func (cr *ChannelInReader) WriteChannel(data []byte) error {
 		cr.metrics.RecordChannelInputBytes(len(data))
 		return nil
 	} else {
-		cr.log.Warn("Error creating batch reader from channel data", "err", err)
 		return err
 	}
 }
@@ -81,7 +80,7 @@ func (cr *ChannelInReader) NextBatch(ctx context.Context) (Batch, error) {
 			return nil, err
 		} else {
 			if err := cr.WriteChannel(data); err != nil {
-				cr.log.Warn("failed to create batch reader from channel data, dropping channel", "err", err)
+				cr.log.Warn("failed to create batch reader from channel data, dropping channel", "err", err, "origin", cr.Origin())
 				return nil, NotEnoughData
 			}
 		}


### PR DESCRIPTION
## Summary

- Fixes `WriteChannel` error classification in `ChannelInReader.NextBatch`: returns `NotEnoughData` (immediate continue, no backoff) instead of `NewTemporaryError` when channel data fails to decompress
- Downgrades the `log.Error` in `WriteChannel` to `log.Warn` since this is bad batcher data, not an infrastructure failure

The channel is already consumed from the `ChannelBank`/`ChannelAssembler` before `WriteChannel` is called, so a retry would not re-read the same channel. The `TemporaryError` caused one unnecessary backoff cycle and misleading `Error`-level logging.

Closes #19492. Part of #19491.

🤖 Generated by [Claude Code](https://claude.com/claude-code)