### PR TITLE
op-node/derive: drop pre-Delta span batch as NotEnoughData

### DIFF
--- a/op-node/rollup/derive/channel_in_reader.go
+++ b/op-node/rollup/derive/channel_in_reader.go
@@ -110,10 +110,8 @@ func (cr *ChannelInReader) NextBatch(ctx context.Context) (Batch, error) {
 		return batch, nil
 	case SpanBatchType:
 		if origin := cr.Origin(); !cr.cfg.IsDelta(origin.Time) {
-			// Check hard fork activation with the L1 inclusion block time instead of the L1 origin block time.
-			// Therefore, even if the batch passed this rule, it can be dropped in the batch queue.
-			// This is just for early dropping invalid batches as soon as possible.
-			return nil, NewTemporaryError(fmt.Errorf("cannot accept span batch in L1 block %s at time %d", origin, origin.Time))
+			cr.log.Warn("dropping span batch before Delta activation", "origin", origin)
+			return nil, NotEnoughData
 		}
 		batch.Batch, err = DeriveSpanBatch(batchData, cr.cfg.BlockTime, cr.cfg.Genesis.L2Time, cr.cfg.L2ChainID)
 		if err != nil {


### PR DESCRIPTION
## Summary

- Fixes pre-Delta span batch handling in `ChannelInReader.NextBatch`: returns `NotEnoughData` (immediate continue, no backoff) instead of `NewTemporaryError`
- A channel with N span batches in a pre-Delta block previously required N backoff cycles to drain; now it drains immediately

The comment in the old code said "early dropping invalid batches as soon as possible", but `NewTemporaryError` did the opposite — it triggered backoff+retry, leaving `cr.nextBatchFn` set so each retry consumed the next bad batch.

Closes #19493. Part of #19491.

🤖 Generated by [Claude Code](https://claude.com/claude-code)