### PR TITLE
op-node/derive: CriticalError for missing beacon endpoint after Ecotone

### DIFF
--- a/op-node/rollup/derive/data_source.go
+++ b/op-node/rollup/derive/data_source.go
@@ -70,7 +70,7 @@ func (ds *DataSourceFactory) OpenData(ctx context.Context, ref eth.L1BlockRef, b
 	var src DataIter
 	if ds.ecotoneTime != nil && ref.Time >= *ds.ecotoneTime {
 		if ds.blobsFetcher == nil {
-			return nil, fmt.Errorf("ecotone upgrade active but beacon endpoint not configured")
+			return nil, NewCriticalError(fmt.Errorf("ecotone upgrade active but beacon endpoint not configured"))
 		}
 		src = NewBlobDataSource(ctx, ds.log, ds.dsCfg, ds.fetcher, ds.blobsFetcher, ref, batcherAddr)
 	} else {


### PR DESCRIPTION
## Summary

- Fixes misconfiguration handling in `DataSourceFactory.OpenData`: wraps the "beacon endpoint not configured" error with `NewCriticalError` so the node stops with a clear fatal error instead of retrying indefinitely

Running a post-Ecotone node without `--l1.beacon` is an unrecoverable operator misconfiguration. The previous unclassified error caused infinite backoff+retry with misleading `Error`-level logs instead of a clean node halt.

Closes #19495. Part of #19491.

🤖 Generated by [Claude Code](https://claude.com/claude-code)