### PR TITLE
op-node/derive: drop malformed span batch tx data as NotEnoughData

### DIFF
--- a/op-node/rollup/derive/channel_in_reader.go
+++ b/op-node/rollup/derive/channel_in_reader.go
@@ -3,6 +3,7 @@ package derive
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 
@@ -117,7 +118,11 @@ func (cr *ChannelInReader) NextBatch(ctx context.Context) (Batch, error) {
 		}
 		batch.Batch, err = DeriveSpanBatch(batchData, cr.cfg.BlockTime, cr.cfg.Genesis.L2Time, cr.cfg.L2ChainID)
 		if err != nil {
-			return nil, err
+			if errors.Is(err, ErrCritical) {
+				return nil, err
+			}
+			cr.log.Warn("dropping malformed span batch", "err", err)
+			return nil, NotEnoughData
 		}
 		batch.LogContext(cr.log).Info("decoded span batch from channel", "stage_origin", cr.Origin())
 		cr.metrics.RecordDerivedBatches("span")


### PR DESCRIPTION
## Summary

- Fixes unclassified error propagation from `DeriveSpanBatch` in `ChannelInReader.NextBatch`
- Malformed span batch data (bad tx type, invalid encoding) now returns `NotEnoughData` for immediate drop instead of triggering O(N×backoff) drain
- Critical errors (logic errors) from `DeriveSpanBatch` still propagate as-is

Closes #19494. Part of #19491.

🤖 Generated by [Claude Code](https://claude.com/claude-code)