### PR TITLE
docs: add default branch and build system info to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,9 @@ When this happens, offer to submit the improvement to the relevant file in `docs
 
 ## Repository Overview
 
+- **Default branch**: `develop` (not `main`)
+- **Build system**: migrating from Make to [Just](https://github.com/casey/just) — shared justfile infra lives in `justfiles/`
+
 This repository contains multiple components spanning different technologies:
 
 ### Go Services


### PR DESCRIPTION
## Summary
- Documents that the default branch is `develop` (not `main`) to prevent AI agents from failing on `git diff main..HEAD`
- Notes the ongoing Make → Just migration and the `justfiles/` shared infra directory

## Test plan
- [x] Content is accurate and concise

🤖 Generated with [Claude Code](https://claude.com/claude-code)