### PR TITLE
kona/derive: flush and continue on span batch extraction failure in BatchQueue

### DIFF
--- a/rust/kona/crates/protocol/derive/src/stages/batch/batch_queue.rs
+++ b/rust/kona/crates/protocol/derive/src/stages/batch/batch_queue.rs
@@ -2,7 +2,7 @@
 
 use super::NextBatchProvider;
 use crate::{
-    errors::{PipelineEncodingError, PipelineError, PipelineErrorKind, ResetError},
+    errors::{PipelineError, PipelineErrorKind, ResetError},
     traits::{AttributesProvider, L2ChainProvider, OriginAdvancer, OriginProvider, SignalReceiver},
     types::{PipelineResult, ResetSignal, Signal},
 };
@@ -385,12 +385,12 @@ where
         match batch {
             Batch::Single(sb) => Ok(sb),
             Batch::Span(sb) => {
-                let batches = match sb.get_singular_batches(&self.l1_blocks, parent).map_err(|e| {
-                    PipelineError::BadEncoding(PipelineEncodingError::SpanBatchError(e)).crit()
-                }) {
+                let batches = match sb.get_singular_batches(&self.l1_blocks, parent) {
                     Ok(b) => b,
                     Err(e) => {
-                        return Err(e);
+                        warn!(target: "batch_queue", "Failed to extract singular batches from span batch, flushing: {}", e);
+                        self.prev.flush();
+                        return Err(PipelineError::NotEnoughData.temp());
                     }
                 };
                 self.next_spans = batches;


### PR DESCRIPTION
## Summary

- Fixes `get_singular_batches` error handling in `BatchQueue::next_batch`: flushes and returns `NotEnoughData` (immediate retry, no halt) instead of `Critical`
- Matches the post-Holocene `BatchStream` behaviour, which already handles the same failure correctly

A malformed span batch that passes channel-level validation but fails at singular batch extraction would previously halt derivation entirely. Now it causes a channel flush and the pipeline continues.

Closes #19511. Part of #19510.

🤖 Generated by [Claude Code](https://claude.com/claude-code)