### PR TITLE
kona/derive: ignore system config update errors in StatefulAttributesBuilder

### DIFF
--- a/rust/kona/crates/protocol/derive/src/attributes/stateful.rs
+++ b/rust/kona/crates/protocol/derive/src/attributes/stateful.rs
@@ -111,13 +111,13 @@ where
                 derive_deposits(epoch.hash, &receipts, self.rollup_cfg.deposit_contract_address)
                     .await
                     .map_err(|e| PipelineError::BadEncoding(e).crit())?;
-            sys_config
-                .update_with_receipts(
-                    &receipts,
-                    self.rollup_cfg.l1_system_config_address,
-                    self.rollup_cfg.is_ecotone_active(header.timestamp),
-                )
-                .map_err(|e| PipelineError::SystemConfigUpdate(e).crit())?;
+            if let Err(e) = sys_config.update_with_receipts(
+                &receipts,
+                self.rollup_cfg.l1_system_config_address,
+                self.rollup_cfg.is_ecotone_active(header.timestamp),
+            ) {
+                warn!(target: "attributes_builder", ?e, "Failed to update system config from L1 receipts, ignoring");
+            }
             l1_header = header;
             deposit_transactions = deposits;
             0


### PR DESCRIPTION
## Summary

- Fixes `update_with_receipts` error handling in `StatefulAttributesBuilder`: logs a warning and ignores the error instead of returning `Critical`
- Matches Go op-node behaviour, which intentionally ignores all system config update errors in the attributes builder

A single malformed `ConfigUpdate` log on L1 would previously halt kona derivation. The traversal stage already handles this correctly; this fixes the attributes builder to be consistent.

Closes #19512. Part of #19510.

🤖 Generated by [Claude Code](https://claude.com/claude-code)