### PR TITLE
op-devstack: add explicit local contract artifacts override

### DIFF
--- a/op-devstack/presets/option_validation.go
+++ b/op-devstack/presets/option_validation.go
@@ -147,4 +147,5 @@ const twoL2SupernodePresetSupportedOptionKinds = optionKindDeployer
 const twoL2SupernodeInteropPresetSupportedOptionKinds = optionKindDeployer |
 	optionKindTimeTravel
 
-const singleChainWithFlashblocksPresetSupportedOptionKinds = optionKindOPRBuilder
+const singleChainWithFlashblocksPresetSupportedOptionKinds = optionKindDeployer |
+	optionKindOPRBuilder

--- a/op-devstack/presets/options.go
+++ b/op-devstack/presets/options.go
@@ -100,6 +100,25 @@ func WithDeployerOptions(opts ...sysgo.DeployerOption) Option {
 	}
 }
 
+// WithLocalContractSourcesAt configures a preset to load local contracts-bedrock
+// artifacts from the supplied directory instead of resolving them relative to
+// the process working directory.
+func WithLocalContractSourcesAt(path string) Option {
+	var kinds optionKinds
+	if path != "" {
+		kinds = optionKindDeployer
+	}
+	return option{
+		kinds: kinds,
+		applyFn: func(cfg *sysgo.PresetConfig) {
+			if path == "" {
+				return
+			}
+			cfg.LocalContractArtifactsPath = path
+		},
+	}
+}
+
 func WithBatcherOption(opt sysgo.BatcherOption) Option {
 	var kinds optionKinds
 	if opt != nil {

--- a/op-devstack/presets/options_test.go
+++ b/op-devstack/presets/options_test.go
@@ -33,6 +33,7 @@ func TestOptionKindsFromCompositeOptions(t *testing.T) {
 
 	t.Run("nil adapters do not claim support kinds", func(t *testing.T) {
 		require.Zero(t, WithDeployerOptions(nil).optionKinds())
+		require.Zero(t, WithLocalContractSourcesAt("").optionKinds())
 		require.Zero(t, WithBatcherOption(nil).optionKinds())
 		require.Zero(t, WithGlobalL2CLOption(nil).optionKinds())
 		require.Zero(t, WithGlobalSyncTesterELOption(nil).optionKinds())
@@ -40,6 +41,11 @@ func TestOptionKindsFromCompositeOptions(t *testing.T) {
 		require.Zero(t, WithOPRBuilderOption(nil).optionKinds())
 		require.Zero(t, AfterBuild(nil).optionKinds())
 	})
+}
+
+func TestWithLocalContractSourcesAt(t *testing.T) {
+	cfg, _ := collectPresetConfig([]Option{WithLocalContractSourcesAt("/tmp/contracts-bedrock")})
+	require.Equal(t, "/tmp/contracts-bedrock", cfg.LocalContractArtifactsPath)
 }
 
 func TestUnsupportedPresetOptionKinds(t *testing.T) {
@@ -67,9 +73,10 @@ func TestUnsupportedPresetOptionKinds(t *testing.T) {
 			want:      optionKindChallengerCannonKona,
 		},
 		{
-			name:      "flashblocks only allows builder adapters",
+			name:      "flashblocks allows builder and deployer adapters",
 			supported: singleChainWithFlashblocksPresetSupportedOptionKinds,
 			opts: Combine(
+				WithLocalContractSourcesAt("/tmp/contracts-bedrock"),
 				WithOPRBuilderOption(builderOpt),
 				WithTimeTravelEnabled(),
 			),

--- a/op-devstack/sysgo/deployer.go
+++ b/op-devstack/sysgo/deployer.go
@@ -2,7 +2,6 @@ package sysgo
 
 import (
 	"math/big"
-	"os"
 	"path/filepath"
 	"slices"
 	"time"
@@ -147,23 +146,49 @@ var (
 
 func WithEmbeddedContractSources() DeployerOption {
 	return func(_ devtest.T, _ devkeys.Keys, builder intentbuilder.Builder) {
-		builder.WithL1ContractsLocator(artifacts.EmbeddedLocator)
-		builder.WithL2ContractsLocator(artifacts.EmbeddedLocator)
+		setContractLocators(builder, artifacts.EmbeddedLocator)
+	}
+}
+
+func localContractSourcesLocator(artifactsPath string) (*artifacts.Locator, error) {
+	if artifactsPath == "" {
+		paths, err := contractPaths()
+		if err != nil {
+			return nil, err
+		}
+		artifactsPath = paths.FoundryArtifacts
+	}
+	absPath, err := filepath.Abs(artifactsPath)
+	if err != nil {
+		return nil, err
+	}
+	if err := ensureDir(absPath); err != nil {
+		return nil, err
+	}
+	return artifacts.NewFileLocator(absPath)
+}
+
+func setContractLocators(builder intentbuilder.Builder, contractArtifacts *artifacts.Locator) {
+	builder.WithL1ContractsLocator(contractArtifacts)
+	builder.WithL2ContractsLocator(contractArtifacts)
+}
+
+// WithLocalContractSourcesAt configures the deployer to load both L1 and L2
+// contract artifacts from the given local contracts-bedrock checkout or
+// forge-artifacts directory.
+func WithLocalContractSourcesAt(artifactsPath string) DeployerOption {
+	return func(p devtest.T, _ devkeys.Keys, builder intentbuilder.Builder) {
+		contractArtifacts, err := localContractSourcesLocator(artifactsPath)
+		p.Require().NoError(err)
+		setContractLocators(builder, contractArtifacts)
 	}
 }
 
 func WithLocalContractSources() DeployerOption {
-	return func(p devtest.T, keys devkeys.Keys, builder intentbuilder.Builder) {
-		paths, err := contractPaths()
+	return func(p devtest.T, _ devkeys.Keys, builder intentbuilder.Builder) {
+		contractArtifacts, err := localContractSourcesLocator("")
 		p.Require().NoError(err)
-		wd, err := os.Getwd()
-		p.Require().NoError(err)
-		artifactsPath := filepath.Join(wd, paths.FoundryArtifacts)
-		p.Require().NoError(ensureDir(artifactsPath))
-		contractArtifacts, err := artifacts.NewFileLocator(artifactsPath)
-		p.Require().NoError(err)
-		builder.WithL1ContractsLocator(contractArtifacts)
-		builder.WithL2ContractsLocator(contractArtifacts)
+		setContractLocators(builder, contractArtifacts)
 	}
 }
 

--- a/op-devstack/sysgo/deployer_test.go
+++ b/op-devstack/sysgo/deployer_test.go
@@ -1,0 +1,96 @@
+package sysgo
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/artifacts"
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/intentbuilder"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+func TestLocalContractSourcesLocator(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid dir", func(t *testing.T) {
+		t.Parallel()
+
+		artifactsDir := filepath.Join(t.TempDir(), "forge-artifacts")
+		require.NoError(t, os.Mkdir(artifactsDir, 0o755))
+
+		loc, err := localContractSourcesLocator(artifactsDir)
+		require.NoError(t, err)
+
+		require.True(t, artifacts.MustNewFileLocator(artifactsDir).Equal(loc))
+	})
+
+	t.Run("missing dir", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := localContractSourcesLocator(filepath.Join(t.TempDir(), "missing"))
+		require.Error(t, err)
+	})
+}
+
+func TestLocalContractSourcesLocatorAcceptsContractsBedrockRoot(t *testing.T) {
+	t.Parallel()
+
+	contractsDir := filepath.Join(t.TempDir(), "packages", "contracts-bedrock")
+	require.NoError(t, os.MkdirAll(filepath.Join(contractsDir, "forge-artifacts"), 0o755))
+
+	loc, err := localContractSourcesLocator(contractsDir)
+	require.NoError(t, err)
+
+	require.True(t, artifacts.MustNewFileLocator(contractsDir).Equal(loc))
+}
+
+func TestWithLocalContractSourcesAt(t *testing.T) {
+	t.Parallel()
+
+	artifactsDir := filepath.Join(t.TempDir(), "forge-artifacts")
+	require.NoError(t, os.Mkdir(artifactsDir, 0o755))
+
+	builder := newValidIntentBuilder()
+	dt := devtest.SerialT(t)
+
+	WithLocalContractSourcesAt(artifactsDir)(dt, nil, builder)
+
+	intent, err := builder.Build()
+	require.NoError(t, err)
+
+	expected := artifacts.MustNewFileLocator(artifactsDir)
+	require.True(t, expected.Equal(intent.L1ContractsLocator))
+	require.True(t, expected.Equal(intent.L2ContractsLocator))
+}
+
+func newValidIntentBuilder() intentbuilder.Builder {
+	builder := intentbuilder.New()
+
+	_, superchain := builder.WithSuperchain()
+	superchain.WithProxyAdminOwner(common.HexToAddress("0x1"))
+	superchain.WithGuardian(common.HexToAddress("0x2"))
+	superchain.WithProtocolVersionsOwner(common.HexToAddress("0x3"))
+	superchain.WithChallenger(common.HexToAddress("0x4"))
+
+	builder, _ = builder.WithL1(eth.ChainIDFromUInt64(1))
+	_, l2 := builder.WithL2(eth.ChainIDFromUInt64(10))
+	l2.WithBaseFeeVaultRecipient(common.HexToAddress("0x5"))
+	l2.WithSequencerFeeVaultRecipient(common.HexToAddress("0x6"))
+	l2.WithL1FeeVaultRecipient(common.HexToAddress("0x7"))
+	l2.WithOperatorFeeVaultRecipient(common.HexToAddress("0x8"))
+	l2.WithL1ProxyAdminOwner(common.HexToAddress("0x9"))
+	l2.WithL2ProxyAdminOwner(common.HexToAddress("0xa"))
+	l2.WithSystemConfigOwner(common.HexToAddress("0xb"))
+	l2.WithUnsafeBlockSigner(common.HexToAddress("0xc"))
+	l2.WithBatcher(common.HexToAddress("0xd"))
+	l2.WithProposer(common.HexToAddress("0xe"))
+	l2.WithChallenger(common.HexToAddress("0xf"))
+
+	return builder
+}

--- a/op-devstack/sysgo/mixed_runtime.go
+++ b/op-devstack/sysgo/mixed_runtime.go
@@ -64,10 +64,11 @@ type MixedSingleChainNodeSpec struct {
 }
 
 type MixedSingleChainPresetConfig struct {
-	NodeSpecs         []MixedSingleChainNodeSpec
-	WithTestSequencer bool
-	TestSequencerName string
-	DeployerOptions   []DeployerOption
+	NodeSpecs                  []MixedSingleChainNodeSpec
+	WithTestSequencer          bool
+	TestSequencerName          string
+	LocalContractArtifactsPath string
+	DeployerOptions            []DeployerOption
 }
 
 type mixedSingleChainNode struct {
@@ -105,7 +106,7 @@ func NewMixedSingleChainRuntime(t devtest.T, cfg MixedSingleChainPresetConfig) *
 	keys, err := devkeys.NewMnemonicDevKeys(devkeys.TestMnemonic)
 	require.NoError(err, "failed to derive dev keys from mnemonic")
 
-	l1Net, l2Net := buildSingleChainWorld(t, keys, cfg.DeployerOptions...)
+	l1Net, l2Net := buildSingleChainWorld(t, keys, cfg.LocalContractArtifactsPath, cfg.DeployerOptions...)
 	jwtPath, jwtSecret := writeJWTSecret(t)
 	l1EL, l1CL := startInProcessL1(t, l1Net, jwtPath)
 

--- a/op-devstack/sysgo/multichain_supernode_runtime.go
+++ b/op-devstack/sysgo/multichain_supernode_runtime.go
@@ -102,7 +102,7 @@ func newSingleChainSupernodeRuntimeWithConfig(t devtest.T, interopAtGenesis bool
 	keys, err := devkeys.NewMnemonicDevKeys(devkeys.TestMnemonic)
 	require.NoError(err, "failed to derive dev keys from mnemonic")
 
-	migration, l1Net, l2Net, depSet, _ := buildSingleChainWorldWithInteropAndState(t, keys, interopAtGenesis, cfg.DeployerOptions...)
+	migration, l1Net, l2Net, depSet, _ := buildSingleChainWorldWithInteropAndState(t, keys, interopAtGenesis, cfg.LocalContractArtifactsPath, cfg.DeployerOptions...)
 	validateSimpleInteropPresetConfig(t, cfg, l2Net)
 
 	jwtPath, jwtSecret := writeJWTSecret(t)
@@ -156,7 +156,7 @@ func newTwoL2SupernodeRuntimeWithConfig(t devtest.T, enableInterop bool, delaySe
 	keys, err := devkeys.NewMnemonicDevKeys(devkeys.TestMnemonic)
 	require.NoError(err, "failed to derive dev keys from mnemonic")
 
-	wb, l1Net, l2ANet, l2BNet := buildTwoL2RuntimeWorld(t, keys, enableInterop, cfg.DeployerOptions...)
+	wb, l1Net, l2ANet, l2BNet := buildTwoL2RuntimeWorld(t, keys, enableInterop, cfg.LocalContractArtifactsPath, cfg.DeployerOptions...)
 	jwtPath, jwtSecret := writeJWTSecret(t)
 	l1Clock := clock.SystemClock
 	var timeTravelClock *clock.AdvancingClock
@@ -241,7 +241,7 @@ func newTwoL2SupernodeRuntimeWithConfig(t devtest.T, enableInterop bool, delaySe
 	}, activationTime
 }
 
-func buildTwoL2RuntimeWorld(t devtest.T, keys devkeys.Keys, enableInterop bool, deployerOpts ...DeployerOption) (*worldBuilder, *L1Network, *L2Network, *L2Network) {
+func buildTwoL2RuntimeWorld(t devtest.T, keys devkeys.Keys, enableInterop bool, localContractArtifactsPath string, deployerOpts ...DeployerOption) (*worldBuilder, *L1Network, *L2Network, *L2Network) {
 	wb := &worldBuilder{
 		p:       t,
 		logger:  t.Logger(),
@@ -250,7 +250,7 @@ func buildTwoL2RuntimeWorld(t devtest.T, keys devkeys.Keys, enableInterop bool, 
 		builder: intentbuilder.New(),
 	}
 
-	applyConfigLocalContractSources(t, keys, wb.builder)
+	applyConfigLocalContractSources(t, keys, wb.builder, localContractArtifactsPath)
 	applyConfigCommons(t, keys, DefaultL1ID, wb.builder)
 	applyConfigPrefundedL2(t, keys, DefaultL1ID, DefaultL2AID, wb.builder)
 	applyConfigPrefundedL2(t, keys, DefaultL1ID, DefaultL2BID, wb.builder)

--- a/op-devstack/sysgo/multichain_supervisor_runtime.go
+++ b/op-devstack/sysgo/multichain_supervisor_runtime.go
@@ -37,7 +37,7 @@ func NewSingleChainInteropRuntimeWithConfig(t devtest.T, cfg PresetConfig) *Mult
 	keys, err := devkeys.NewMnemonicDevKeys(devkeys.TestMnemonic)
 	require.NoError(err, "failed to derive dev keys from mnemonic")
 
-	migration, l1Net, l2Net, depSet, fullCfgSet := buildSingleChainWorldWithInteropAndState(t, keys, true, cfg.DeployerOptions...)
+	migration, l1Net, l2Net, depSet, fullCfgSet := buildSingleChainWorldWithInteropAndState(t, keys, true, cfg.LocalContractArtifactsPath, cfg.DeployerOptions...)
 	validateSimpleInteropPresetConfig(t, cfg, l2Net)
 
 	jwtPath, jwtSecret := writeJWTSecret(t)
@@ -107,7 +107,7 @@ func NewSimpleInteropRuntimeWithConfig(t devtest.T, cfg PresetConfig) *MultiChai
 	keys, err := devkeys.NewMnemonicDevKeys(devkeys.TestMnemonic)
 	require.NoError(err, "failed to derive dev keys from mnemonic")
 
-	migration, l1Net, l2ANet, l2BNet, fullCfgSet := buildTwoL2WorldWithState(t, keys, true, cfg.DeployerOptions...)
+	migration, l1Net, l2ANet, l2BNet, fullCfgSet := buildTwoL2WorldWithState(t, keys, true, cfg.LocalContractArtifactsPath, cfg.DeployerOptions...)
 	validateSimpleInteropPresetConfig(t, cfg, l2ANet, l2BNet)
 	depSet := fullCfgSet.DependencySet
 

--- a/op-devstack/sysgo/preset_config.go
+++ b/op-devstack/sysgo/preset_config.go
@@ -5,18 +5,19 @@ import gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types
 // PresetConfig captures preset constructor mutations.
 // It is independent from orchestrator lifecycle hooks.
 type PresetConfig struct {
-	DeployerOptions           []DeployerOption
-	BatcherOptions            []BatcherOption
-	ProposerOptions           []ProposerOption
-	OPRBuilderOptions         []OPRBuilderNodeOption
-	GlobalL2CLOptions         []L2CLOption
-	GlobalSyncTesterELOptions []SyncTesterELOption
-	AddedGameTypes            []gameTypes.GameType
-	RespectedGameTypes        []gameTypes.GameType
-	EnableCannonKonaForChall  bool
-	EnableTimeTravel          bool
-	MaxSequencingWindow       *uint64
-	RequireInteropNotAtGen    bool
+	LocalContractArtifactsPath string
+	DeployerOptions            []DeployerOption
+	BatcherOptions             []BatcherOption
+	ProposerOptions            []ProposerOption
+	OPRBuilderOptions          []OPRBuilderNodeOption
+	GlobalL2CLOptions          []L2CLOption
+	GlobalSyncTesterELOptions  []SyncTesterELOption
+	AddedGameTypes             []gameTypes.GameType
+	RespectedGameTypes         []gameTypes.GameType
+	EnableCannonKonaForChall   bool
+	EnableTimeTravel           bool
+	MaxSequencingWindow        *uint64
+	RequireInteropNotAtGen     bool
 }
 
 type PresetOption interface {

--- a/op-devstack/sysgo/singlechain_build.go
+++ b/op-devstack/sysgo/singlechain_build.go
@@ -5,8 +5,6 @@ import (
 	"encoding/hex"
 	"flag"
 	"fmt"
-	"os"
-	"path/filepath"
 	"time"
 
 	"github.com/urfave/cli/v2"
@@ -19,7 +17,6 @@ import (
 	"github.com/ethereum/go-ethereum/params/forks"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
-	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/artifacts"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/intentbuilder"
 	faucetConfig "github.com/ethereum-optimism/optimism/op-faucet/config"
@@ -69,7 +66,7 @@ type testSequencer struct {
 	service    *sequencer.Service
 }
 
-func buildSingleChainWorld(t devtest.T, keys devkeys.Keys, deployerOpts ...DeployerOption) (*L1Network, *L2Network) {
+func buildSingleChainWorld(t devtest.T, keys devkeys.Keys, localContractArtifactsPath string, deployerOpts ...DeployerOption) (*L1Network, *L2Network) {
 	wb := &worldBuilder{
 		p:       t,
 		logger:  t.Logger(),
@@ -78,7 +75,7 @@ func buildSingleChainWorld(t devtest.T, keys devkeys.Keys, deployerOpts ...Deplo
 		builder: intentbuilder.New(),
 	}
 
-	applyConfigLocalContractSources(t, keys, wb.builder)
+	applyConfigLocalContractSources(t, keys, wb.builder, localContractArtifactsPath)
 	applyConfigCommons(t, keys, DefaultL1ID, wb.builder)
 	applyConfigPrefundedL2(t, keys, DefaultL1ID, DefaultL2AID, wb.builder)
 	applyConfigDeployerOptions(t, keys, wb.builder, deployerOpts)
@@ -108,14 +105,8 @@ func buildSingleChainWorld(t devtest.T, keys devkeys.Keys, deployerOpts ...Deplo
 	return l1Net, l2Net
 }
 
-func applyConfigLocalContractSources(t devtest.T, _ devkeys.Keys, builder intentbuilder.Builder) {
-	paths, err := contractPaths()
-	t.Require().NoError(err)
-	wd, err := os.Getwd()
-	t.Require().NoError(err)
-	artifactsPath := filepath.Join(wd, paths.FoundryArtifacts)
-	t.Require().NoError(ensureDir(artifactsPath))
-	contractArtifacts, err := artifacts.NewFileLocator(artifactsPath)
+func applyConfigLocalContractSources(t devtest.T, _ devkeys.Keys, builder intentbuilder.Builder, artifactsPath string) {
+	contractArtifacts, err := localContractSourcesLocator(artifactsPath)
 	t.Require().NoError(err)
 	builder.WithL1ContractsLocator(contractArtifacts)
 	builder.WithL2ContractsLocator(contractArtifacts)

--- a/op-devstack/sysgo/singlechain_interop.go
+++ b/op-devstack/sysgo/singlechain_interop.go
@@ -6,7 +6,7 @@ import (
 )
 
 func newSingleChainInteropWorldNoSupervisor(t devtest.T, keys devkeys.Keys, cfg PresetConfig) singleChainRuntimeWorld {
-	l1Net, l2Net, depSet, fullCfgSet := buildSingleChainWorldWithInterop(t, keys, true, cfg.DeployerOptions...)
+	l1Net, l2Net, depSet, fullCfgSet := buildSingleChainWorldWithInterop(t, keys, true, cfg.LocalContractArtifactsPath, cfg.DeployerOptions...)
 	return singleChainRuntimeWorld{
 		L1Network: l1Net,
 		L2Network: l2Net,

--- a/op-devstack/sysgo/singlechain_runtime.go
+++ b/op-devstack/sysgo/singlechain_runtime.go
@@ -60,7 +60,7 @@ func newSingleChainNodeRuntime(name string, isSequencer bool, el L2ELNode, cl L2
 }
 
 func newDefaultSingleChainWorld(t devtest.T, keys devkeys.Keys, cfg PresetConfig) singleChainRuntimeWorld {
-	l1Net, l2Net := buildSingleChainWorld(t, keys, cfg.DeployerOptions...)
+	l1Net, l2Net := buildSingleChainWorld(t, keys, cfg.LocalContractArtifactsPath, cfg.DeployerOptions...)
 	return singleChainRuntimeWorld{
 		L1Network: l1Net,
 		L2Network: l2Net,

--- a/op-devstack/sysgo/world.go
+++ b/op-devstack/sysgo/world.go
@@ -39,8 +39,8 @@ func applyConfigDeployerOptions(t devtest.T, keys devkeys.Keys, builder intentbu
 	}
 }
 
-func buildSingleChainWorldWithInterop(t devtest.T, keys devkeys.Keys, interopAtGenesis bool, deployerOpts ...DeployerOption) (*L1Network, *L2Network, depset.DependencySet, depset.FullConfigSetMerged) {
-	_, l1Net, l2Net, depSet, fullCfgSet := buildSingleChainWorldWithInteropAndState(t, keys, interopAtGenesis, deployerOpts...)
+func buildSingleChainWorldWithInterop(t devtest.T, keys devkeys.Keys, interopAtGenesis bool, localContractArtifactsPath string, deployerOpts ...DeployerOption) (*L1Network, *L2Network, depset.DependencySet, depset.FullConfigSetMerged) {
+	_, l1Net, l2Net, depSet, fullCfgSet := buildSingleChainWorldWithInteropAndState(t, keys, interopAtGenesis, localContractArtifactsPath, deployerOpts...)
 	return l1Net, l2Net, depSet, fullCfgSet
 }
 
@@ -65,9 +65,9 @@ func newInteropMigrationState(wb *worldBuilder) *interopMigrationState {
 	return state
 }
 
-func buildSingleChainWorldWithInteropAndState(t devtest.T, keys devkeys.Keys, interopAtGenesis bool, deployerOpts ...DeployerOption) (*interopMigrationState, *L1Network, *L2Network, depset.DependencySet, depset.FullConfigSetMerged) {
+func buildSingleChainWorldWithInteropAndState(t devtest.T, keys devkeys.Keys, interopAtGenesis bool, localContractArtifactsPath string, deployerOpts ...DeployerOption) (*interopMigrationState, *L1Network, *L2Network, depset.DependencySet, depset.FullConfigSetMerged) {
 	wb := newWorldBuilder(t, keys)
-	applyConfigLocalContractSources(t, keys, wb.builder)
+	applyConfigLocalContractSources(t, keys, wb.builder, localContractArtifactsPath)
 	applyConfigCommons(t, keys, DefaultL1ID, wb.builder)
 	applyConfigPrefundedL2(t, keys, DefaultL1ID, DefaultL2AID, wb.builder)
 	if interopAtGenesis {
@@ -104,9 +104,9 @@ func buildSingleChainWorldWithInteropAndState(t devtest.T, keys devkeys.Keys, in
 	return newInteropMigrationState(wb), l1Net, l2Net, depSet, wb.outFullCfgSet
 }
 
-func buildTwoL2WorldWithState(t devtest.T, keys devkeys.Keys, interopAtGenesis bool, deployerOpts ...DeployerOption) (*interopMigrationState, *L1Network, *L2Network, *L2Network, depset.FullConfigSetMerged) {
+func buildTwoL2WorldWithState(t devtest.T, keys devkeys.Keys, interopAtGenesis bool, localContractArtifactsPath string, deployerOpts ...DeployerOption) (*interopMigrationState, *L1Network, *L2Network, *L2Network, depset.FullConfigSetMerged) {
 	wb := newWorldBuilder(t, keys)
-	applyConfigLocalContractSources(t, keys, wb.builder)
+	applyConfigLocalContractSources(t, keys, wb.builder, localContractArtifactsPath)
 	applyConfigCommons(t, keys, DefaultL1ID, wb.builder)
 	applyConfigPrefundedL2(t, keys, DefaultL1ID, DefaultL2AID, wb.builder)
 	applyConfigPrefundedL2(t, keys, DefaultL1ID, DefaultL2BID, wb.builder)


### PR DESCRIPTION
## Summary
- add `WithLocalContractSourcesAt` so callers can provide an explicit local `forge-artifacts` path
- refactor the existing local contract source setup to reuse the same locator helper
- add focused unit tests for the locator helper and explicit override path

## Testing
- go test ./op-devstack/sysgo -run 'Test(LocalContractSourcesLocator|WithLocalContractSourcesAt)$'
- go vet ./op-devstack/sysgo