### PR TITLE
docs(ai): add Go and Rust development guidance

### DIFF
--- a/docs/ai/dev-workflow.md
+++ b/docs/ai/dev-workflow.md
@@ -1,0 +1,31 @@
+# Development Workflow
+
+Common workflow guidance for AI agents working in the Optimism monorepo. Language-specific details are in [go-dev.md](go-dev.md) and [rust-dev.md](rust-dev.md).
+
+## Tool Versions
+
+All tool versions are pinned in `mise.toml` at the repo root. Always access tools through mise — never install or invoke system-global versions directly. Check `mise.toml` for current pinned versions when you need to know what's available.
+
+If mise reports the repo isn't trusted, ask the user to run `mise trust` — never trust it automatically.
+
+## Build System
+
+The repo uses [Just](https://github.com/casey/just) as its build system. Shared justfile infrastructure lives in `justfiles/`. Each component has its own justfile — run `just --list` in any directory to see available targets.
+
+## Before Every PR
+
+After running language-specific commit checks (lint, test):
+
+1. **Run affected tests broadly** — don't just test the package/crate you changed. Test packages that depend on it too.
+
+2. **Rebase on `develop`** — this is the default branch, not `main`:
+   ```bash
+   git fetch origin develop
+   git rebase origin/develop
+   ```
+
+3. **Follow PR guidelines** — see `docs/handbook/pr-guidelines.md`.
+
+## CI
+
+Some tests require CI-only environment variables and are skipped locally. Check the test code for environment variable guards if a test behaves differently than expected.

--- a/docs/ai/go-dev.md
+++ b/docs/ai/go-dev.md
@@ -1,5 +1,88 @@
 # Go Service Development
 
-This document provides guidance for AI agents working with Go services in the OP Stack.
+Guidance for AI agents working with Go code in the Optimism monorepo.
 
-<!-- TODO: Add detailed guidance for Go development -->
+## Tool Versions
+
+All tool versions are pinned in `mise.toml` at the repo root. Always access tools through mise — never install or invoke system-global versions directly. Check `mise.toml` for the current pinned versions when you need to know what's available.
+
+If mise reports the repo isn't trusted, ask the user to run `mise trust` — never trust it automatically.
+
+## Build System
+
+The repo uses [Just](https://github.com/casey/just) as its build system. Shared justfile infrastructure lives in `justfiles/`. Each Go service has its own justfile — run `just --list` in any service directory to see available targets.
+
+```bash
+# Build a single service (pattern: just ./<service>/<binary>)
+just ./op-node/op-node
+
+# Build all Go components
+just build-go
+```
+
+### Running Tests
+
+```bash
+# Test a single service
+cd <service> && just test
+
+# Test specific packages
+go test ./op-node/rollup/derive/...
+
+# Run the full test suite from the repo root
+just go-tests
+```
+
+### Generating Mocks
+
+Each service justfile has a `generate-mocks` target:
+
+```bash
+cd <service> && just generate-mocks
+```
+
+## Linting
+
+The repo uses a **custom golangci-lint build** with additional analyzer plugins. The standard `golangci-lint` binary will not catch all issues — always lint through `just`.
+
+```bash
+# Lint (also verifies compilation and module tidiness)
+just lint-go
+
+# Lint with auto-fix
+just lint-go-fix
+```
+
+The linter configuration is in `.golangci.yaml` — read it when you need specifics on which linters are enabled and how they're scoped.
+
+## Before Every Commit
+
+Run these checks before committing Go changes. Fix all issues — CI enforces zero warnings.
+
+1. **Lint** — this also verifies the code compiles and modules are tidy:
+   ```bash
+   just lint-go
+   ```
+
+2. **Test** — run tests for changed packages:
+   ```bash
+   cd <service> && just test
+   ```
+
+## Before Every PR
+
+Everything in "Before Every Commit" plus:
+
+1. **Run affected tests broadly** — don't just test the package you changed. Test packages that import it too. When in doubt, test the full service.
+
+2. **Rebase on `develop`** — this is the default branch, not `main`:
+   ```bash
+   git fetch origin develop
+   git rebase origin/develop
+   ```
+
+3. **Follow PR guidelines** — see `docs/handbook/pr-guidelines.md`.
+
+## CI
+
+Some tests require CI-only environment variables and are skipped locally. Check the test code for `os.Getenv` / `t.Skip` calls if a test behaves differently than expected.

--- a/docs/ai/go-dev.md
+++ b/docs/ai/go-dev.md
@@ -1,16 +1,10 @@
 # Go Service Development
 
-Guidance for AI agents working with Go code in the Optimism monorepo.
-
-## Tool Versions
-
-All tool versions are pinned in `mise.toml` at the repo root. Always access tools through mise — never install or invoke system-global versions directly. Check `mise.toml` for the current pinned versions when you need to know what's available.
-
-If mise reports the repo isn't trusted, ask the user to run `mise trust` — never trust it automatically.
+Guidance for AI agents working with Go code in the Optimism monorepo. See [dev-workflow.md](dev-workflow.md) for tool versions, PR workflow, and other cross-language guidance.
 
 ## Build System
 
-The repo uses [Just](https://github.com/casey/just) as its build system. Shared justfile infrastructure lives in `justfiles/`. Each Go service has its own justfile — run `just --list` in any service directory to see available targets.
+Each Go service has its own justfile — run `just --list` in any service directory to see available targets.
 
 ```bash
 # Build a single service (pattern: just ./<service>/<binary>)
@@ -68,21 +62,3 @@ Run these checks before committing Go changes. Fix all issues — CI enforces ze
    ```bash
    cd <service> && just test
    ```
-
-## Before Every PR
-
-Everything in "Before Every Commit" plus:
-
-1. **Run affected tests broadly** — don't just test the package you changed. Test packages that import it too. When in doubt, test the full service.
-
-2. **Rebase on `develop`** — this is the default branch, not `main`:
-   ```bash
-   git fetch origin develop
-   git rebase origin/develop
-   ```
-
-3. **Follow PR guidelines** — see `docs/handbook/pr-guidelines.md`.
-
-## CI
-
-Some tests require CI-only environment variables and are skipped locally. Check the test code for `os.Getenv` / `t.Skip` calls if a test behaves differently than expected.

--- a/docs/ai/rust-dev.md
+++ b/docs/ai/rust-dev.md
@@ -1,12 +1,6 @@
 # Rust Development
 
-Guidance for AI agents working with Rust code in the Optimism monorepo.
-
-## Tool Versions
-
-All tool versions are pinned in `mise.toml` at the repo root and `rust/rust-toolchain.toml` for the Rust toolchain. Always access tools through mise — never install or invoke system-global versions directly. Check these files for current pinned versions.
-
-If mise reports the repo isn't trusted, ask the user to run `mise trust` — never trust it automatically.
+Guidance for AI agents working with Rust code in the Optimism monorepo. See [dev-workflow.md](dev-workflow.md) for tool versions, PR workflow, and other cross-language guidance.
 
 ## Workspace Layout
 
@@ -16,11 +10,11 @@ All Rust code lives under `rust/`. This is a unified Cargo workspace — always 
 - **Op-Reth** — OP Stack execution client built on reth (`rust/op-reth/`)
 - **Op-Alloy / Alloy extensions** — OP Stack types and providers
 
-Check `rust/Cargo.toml` for the full workspace member list, dependency versions, and lint configuration.
+Check `rust/Cargo.toml` for the full workspace member list, dependency versions, and lint configuration. The Rust toolchain version is pinned in `rust/rust-toolchain.toml`.
 
 ## Build System
 
-Rust targets use Just. Run `just --list` in `rust/` to see all available targets. The key ones:
+Run `just --list` in `rust/` to see all available targets. The key ones:
 
 ```bash
 cd rust
@@ -123,25 +117,9 @@ Run these checks from `rust/`. Fix all issues — CI enforces zero warnings.
    just check-no-std
    ```
 
-## Before Every PR
-
-Everything in "Before Every Commit" plus:
-
-1. **Run affected tests broadly** — don't just test the crate you changed. Test crates that depend on it too.
-
-2. **Rebase on `develop`** — this is the default branch, not `main`:
-   ```bash
-   git fetch origin develop
-   git rebase origin/develop
-   ```
-
-3. **Follow PR guidelines** — see `docs/handbook/pr-guidelines.md`.
-
 ## CI
 
-Some tests require CI-only environment variables and are skipped locally. Check the test code for environment variable guards if a test behaves differently than expected.
-
-Build dependencies: op-reth requires `clang` / `libclang-dev` for reth-mdbx-sys bindgen. CI installs this automatically — if you see bindgen errors locally, install clang.
+Op-reth requires `clang` / `libclang-dev` for reth-mdbx-sys bindgen. CI installs this automatically — if you see bindgen errors locally, install clang.
 
 ## Skills
 

--- a/docs/ai/rust-dev.md
+++ b/docs/ai/rust-dev.md
@@ -1,8 +1,147 @@
 # Rust Development
 
-This document provides guidance for AI agents working with Rust components in the OP Stack.
+Guidance for AI agents working with Rust code in the Optimism monorepo.
 
-<!-- TODO: Add detailed guidance for Rust development -->
+## Tool Versions
+
+All tool versions are pinned in `mise.toml` at the repo root and `rust/rust-toolchain.toml` for the Rust toolchain. Always access tools through mise — never install or invoke system-global versions directly. Check these files for current pinned versions.
+
+If mise reports the repo isn't trusted, ask the user to run `mise trust` — never trust it automatically.
+
+## Workspace Layout
+
+All Rust code lives under `rust/`. This is a unified Cargo workspace — always run Rust commands from this directory. The workspace contains three main component groups:
+
+- **Kona** — Proof system and rollup node (`rust/kona/`)
+- **Op-Reth** — OP Stack execution client built on reth (`rust/op-reth/`)
+- **Op-Alloy / Alloy extensions** — OP Stack types and providers
+
+Check `rust/Cargo.toml` for the full workspace member list, dependency versions, and lint configuration.
+
+## Build System
+
+Rust targets use Just. Run `just --list` in `rust/` to see all available targets. The key ones:
+
+```bash
+cd rust
+
+# Build the workspace
+just build
+
+# Build in release mode
+just build-release
+
+# Build specific binaries
+just build-node      # kona-node
+just build-op-reth   # op-reth
+```
+
+### Running Tests
+
+Tests use `cargo-nextest` (not `cargo test`) for unit tests:
+
+```bash
+cd rust
+
+# Run all tests (unit + doc tests)
+just test
+
+# Unit tests only (excludes online tests)
+just test-unit
+
+# Doc tests only
+just test-docs
+```
+
+### Generating Prestates
+
+Kona prestates are built via Docker:
+
+```bash
+cd rust
+just build-kona-prestates
+```
+
+## Linting
+
+```bash
+cd rust
+
+# Run all lints (format check + clippy + doc lints)
+just lint
+
+# Individual lint steps
+just fmt-check      # formatting (requires nightly)
+just lint-clippy    # clippy with all features, -D warnings
+just lint-docs      # rustdoc warnings
+```
+
+Lint configuration lives in `rust/Cargo.toml` (workspace lints section), `rust/clippy.toml`, and `rust/rustfmt.toml`.
+
+### Formatting Requires Nightly
+
+Formatting uses a pinned nightly toolchain (defined as `NIGHTLY` in `rust/justfile`). If the nightly isn't installed:
+
+```bash
+cd rust
+just install-nightly
+```
+
+Then use `just fmt-fix` to auto-format, or `just fmt-check` to verify.
+
+### no_std Compatibility
+
+Many kona and alloy crates must compile without the standard library (for the fault proof VM). If you modify these crates, verify no_std builds:
+
+```bash
+cd rust
+just check-no-std
+```
+
+This builds affected crates for the `riscv32imac-unknown-none-elf` target.
+
+## Dependency Auditing
+
+The workspace uses `cargo-deny` for license, advisory, and dependency checks. Configuration is in `rust/deny.toml`.
+
+## Before Every Commit
+
+Run these checks from `rust/`. Fix all issues — CI enforces zero warnings.
+
+1. **Lint** — this checks formatting, clippy, and doc lints:
+   ```bash
+   just lint
+   ```
+
+2. **Test** — run tests for changed packages:
+   ```bash
+   just test-unit
+   ```
+
+3. **no_std** — if you changed any proof, protocol, or alloy crate:
+   ```bash
+   just check-no-std
+   ```
+
+## Before Every PR
+
+Everything in "Before Every Commit" plus:
+
+1. **Run affected tests broadly** — don't just test the crate you changed. Test crates that depend on it too.
+
+2. **Rebase on `develop`** — this is the default branch, not `main`:
+   ```bash
+   git fetch origin develop
+   git rebase origin/develop
+   ```
+
+3. **Follow PR guidelines** — see `docs/handbook/pr-guidelines.md`.
+
+## CI
+
+Some tests require CI-only environment variables and are skipped locally. Check the test code for environment variable guards if a test behaves differently than expected.
+
+Build dependencies: op-reth requires `clang` / `libclang-dev` for reth-mdbx-sys bindgen. CI installs this automatically — if you see bindgen errors locally, install clang.
 
 ## Skills
 


### PR DESCRIPTION
## Summary

- Replace placeholder `docs/ai/go-dev.md` with workflow guidance for AI agents: tool versions via mise, build/test/lint commands via just, and pre-commit/pre-PR checklists
- Replace placeholder `docs/ai/rust-dev.md` with the same: workspace layout, nightly formatting requirement, no_std compatibility checks, and pre-commit/pre-PR checklists

Both docs focus on non-obvious conventions and workflow (what an agent can't derive from reading source files). Linter configs, specific tool versions, and project structure are left to the source files themselves.

## Test plan

- [x] Verify `just lint-go`, `just lint-go-fix`, `just go-tests` targets exist after ethereum-optimism/optimism#19483 merges
- [x] Verify `just lint`, `just test`, `just fmt-fix` work from `rust/`
- [x] Review docs for accuracy against current repo state

🤖 Generated with [Claude Code](https://claude.com/claude-code)