### PR TITLE
chore(rust): add just target for cargo-deny

### DIFF
--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -1148,7 +1148,7 @@ workflows:
       - rust-ci-deny:
           name: rust-deny
           directory: rust
-          command: "cargo deny --all-features check all"
+          command: "just deny"
           context: *rust-ci-context
 
       - rust-ci-typos:

--- a/docs/ai/rust-dev.md
+++ b/docs/ai/rust-dev.md
@@ -98,6 +98,11 @@ This builds affected crates for the `riscv32imac-unknown-none-elf` target.
 
 The workspace uses `cargo-deny` for license, advisory, and dependency checks. Configuration is in `rust/deny.toml`.
 
+```bash
+cd rust
+just deny
+```
+
 ## Before Every Commit
 
 Run these checks from `rust/`. Fix all issues — CI enforces zero warnings.

--- a/rust/justfile
+++ b/rust/justfile
@@ -130,6 +130,10 @@ bench:
 
 ########################## Misc tools ###############################
 
+# Audit dependencies for licenses, advisories, and bans
+deny:
+  cargo deny --all-features check all
+
 # Check for unused dependencies (requires nightly + cargo-udeps)
 check-udeps:
   cargo +{{NIGHTLY}} udeps --release --workspace --all-features --all-targets


### PR DESCRIPTION
## Summary

- Add a `deny` just target to `rust/justfile` that runs `cargo deny --all-features check all`
- Update CI (`rust-ci.yml`) to use `just deny` instead of invoking cargo deny directly
- Update `docs/ai/rust-dev.md` to reference the new target

Stacked on ethereum-optimism/optimism#19518.

## Test plan

- [ ] Run `cd rust && just deny` locally — should produce same output as `cargo deny --all-features check all`
- [ ] Verify CI `rust-deny` job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)