### PR TITLE
fix(cannon): install just from releases in Dockerfile.diff

### DIFF
--- a/cannon/Dockerfile.diff
+++ b/cannon/Dockerfile.diff
@@ -1,6 +1,10 @@
 FROM golang:1.24.10-alpine3.21 AS builder
 
-RUN apk add --no-cache bash just
+# Install just from GitHub releases to match the version pinned in mise.toml.
+# The Alpine package is too old and doesn't support the [script] attribute
+# used in testdata justfiles.
+RUN apk add --no-cache bash curl && \
+    curl -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin --tag 1.46.0
 
 COPY ./go.mod /app/go.mod
 COPY ./go.sum /app/go.sum


### PR DESCRIPTION
## Summary

- The `cannon-stf-verify` CI job fails because `cannon/Dockerfile.diff` installs `just` from Alpine packages (v1.37.0), but justfiles in the repo use the `[script('bash')]` attribute which requires `just >= 1.38.0`.
- Replace the Alpine `just` package with a direct install from GitHub releases, pinned to v1.46.0 to match `mise.toml`.
- Fixes the regression introduced in ethereum-optimism/optimism#19483.

## Test plan

- [ ] `cannon-stf-verify` CI job passes with the updated Dockerfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)