### PR TITLE
fix(ci): restore compute-git-versions as native make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,8 @@
-DEPRECATED_TARGETS := help build build-go build-contracts build-customlint lint-go lint-go-fix check-op-geth-version golang-docker docker-builder-clean docker-builder compute-git-versions cross-op-node contracts-bedrock-docker submodules op-node generate-mocks-op-node generate-mocks-op-service op-batcher op-proposer op-challenger op-dispute-mon op-supernode op-interop-filter op-program cannon reproducible-prestate-op-program reproducible-prestate-kona reproducible-prestate cannon-prestates mod-tidy clean nuke test-unit semgrep-ci op-program-client op-program-host make-pre-test go-tests go-tests-short go-tests-short-ci go-tests-ci go-tests-ci-kona-action go-tests-fraud-proofs-ci test update-op-geth
+DEPRECATED_TARGETS := help build build-go build-contracts build-customlint lint-go lint-go-fix check-op-geth-version golang-docker docker-builder-clean docker-builder cross-op-node contracts-bedrock-docker submodules op-node generate-mocks-op-node generate-mocks-op-service op-batcher op-proposer op-challenger op-dispute-mon op-supernode op-interop-filter op-program cannon reproducible-prestate-op-program reproducible-prestate-kona reproducible-prestate cannon-prestates mod-tidy clean nuke test-unit semgrep-ci op-program-client op-program-host make-pre-test go-tests go-tests-short go-tests-short-ci go-tests-ci go-tests-ci-kona-action go-tests-fraud-proofs-ci test update-op-geth
 
 include ./justfiles/deprecated.mk
+
+# Called directly by GitHub Actions (no just dependency).
+.PHONY: compute-git-versions
+compute-git-versions:
+	@GIT_COMMIT="$${GIT_COMMIT:-$$(git rev-parse HEAD)}" ./ops/scripts/compute-git-versions.sh


### PR DESCRIPTION
## Summary
- The `compute-git-versions` make target was moved to a deprecated shim that delegates to `just`, but the GitHub Actions `prep` job doesn't have `just` installed, causing `Error 127` on every PR
- Restores `compute-git-versions` as a native make target that calls `ops/scripts/compute-git-versions.sh` directly

## Test plan
- [x] `make compute-git-versions` works locally without `just`
- [ ] `prep` job passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)