### PR TITLE
refactor: move OP EVM code into alloy-op-evm newtypes

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -106,9 +106,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy-chains"
-version = "0.2.30"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f374d3c6d729268bbe2d0e0ff992bb97898b2df756691a62ee1d5f0506bc39"
+checksum = "6d9d22005bf31b018f31ef9ecadb5d2c39cf4f6acc8db0456f72c815f3d7f757"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -227,9 +227,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7928"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3231de68d5d6e75332b7489cfcc7f4dfabeba94d990a10e4b923af0e6623540"
+checksum = "f8222b1d88f9a6d03be84b0f5e76bb60cd83991b43ad8ab6477f0e4a7809b98d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -267,9 +267,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.27.2"
+version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ccfe6d724ceabd5518350cfb34f17dd3a6c3cc33579eee94d98101d3a511ff"
+checksum = "b991c370ce44e70a3a9e474087e3d65e42e66f967644ad729dc4cec09a21fd09"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -395,7 +395,9 @@ dependencies = [
  "auto_impl",
  "op-alloy",
  "op-revm",
+ "reth-evm",
  "revm",
+ "test-case",
  "thiserror 2.0.18",
 ]
 
@@ -424,7 +426,7 @@ dependencies = [
  "derive_more",
  "fixed-cache",
  "foldhash 0.2.0",
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "hashbrown 0.16.1",
  "indexmap 2.13.0",
  "itoa",
@@ -922,14 +924,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-trie"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d7fd448ab0a017de542de1dcca7a58e7019fe0e7a34ed3f9543ebddf6aceffa"
+checksum = "3f14b5d9b2c2173980202c6ff470d96e7c5e202c65a9f67884ad565226df7fbb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "arbitrary",
- "arrayvec",
  "derive_arbitrary",
  "derive_more",
  "nybbles",
@@ -982,9 +983,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -1003,9 +1004,9 @@ checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -1442,9 +1443,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.40"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d67d43201f4d20c78bcda740c142ca52482d81da80681533d33bf3f0596c8e2"
+checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -1595,9 +1596,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.0"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9a7b350e3bb1767102698302bc37256cbd48422809984b98d292c40e2579aa9"
+checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -1605,9 +1606,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.37.1"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b092fe214090261288111db7a2b2c2118e5a7f30dc2569f1732c4069a6840549"
+checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
 dependencies = [
  "cc",
  "cmake",
@@ -2222,9 +2223,9 @@ dependencies = [
 
 [[package]]
 name = "c-kzg"
-version = "2.1.5"
+version = "2.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e00bf4b112b07b505472dbefd19e37e53307e2bfed5a79e0cc161d58ccd0e687"
+checksum = "6648ed1e4ea8e8a1a4a2c78e1cda29a3fd500bc622899c340d8525ea9a76b24a"
 dependencies = [
  "arbitrary",
  "blst",
@@ -2412,9 +2413,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -2422,9 +2423,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2434,9 +2435,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2446,9 +2447,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmake"
@@ -2664,9 +2665,9 @@ dependencies = [
 
 [[package]]
 name = "const-hex"
-version = "1.17.0"
+version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bb320cac8a0750d7f25280aa97b09c26edfe161164238ecbbb31092b079e735"
+checksum = "531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -3734,7 +3735,7 @@ dependencies = [
  "kona-disc",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -3778,7 +3779,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -3799,7 +3800,7 @@ dependencies = [
  "kona-executor",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
  "url",
 ]
 
@@ -4192,7 +4193,7 @@ dependencies = [
  "log",
  "rustversion",
  "windows-link",
- "windows-result 0.4.1",
+ "windows-result",
 ]
 
 [[package]]
@@ -4228,20 +4229,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -4781,8 +4782,8 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.2",
- "system-configuration 0.7.0",
+ "socket2 0.6.3",
+ "system-configuration",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -4802,7 +4803,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -4938,16 +4939,6 @@ dependencies = [
 
 [[package]]
 name = "if-addrs"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cabb0019d51a643781ff15c9c8a3e5dedc365c47211270f4e8f82812fedd8f0a"
-dependencies = [
- "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "if-addrs"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf39cc0423ee66021dc5eccface85580e4a001e0c5288bae8bea7ecb69225e90"
@@ -4957,16 +4948,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "if-watch"
-version = "3.2.1"
+name = "if-addrs"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdf9d64cfcf380606e64f9a0bcf493616b65331199f984151a6fa11a7b3cde38"
+checksum = "c0a05c691e1fae256cf7013d99dad472dc52d5543322761f83ec8d47eab40d2b"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "if-watch"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71c02a5161c313f0cbdbadc511611893584a10a7b6153cb554bdf83ddce99ec2"
 dependencies = [
  "async-io",
  "core-foundation 0.9.4",
  "fnv",
  "futures",
- "if-addrs 0.10.2",
+ "if-addrs 0.15.0",
  "ipnet",
  "log",
  "netlink-packet-core",
@@ -4974,9 +4975,9 @@ dependencies = [
  "netlink-proto",
  "netlink-sys",
  "rtnetlink",
- "system-configuration 0.6.1",
+ "system-configuration",
  "tokio",
- "windows 0.53.0",
+ "windows",
 ]
 
 [[package]]
@@ -5081,9 +5082,9 @@ dependencies = [
 
 [[package]]
 name = "inotify"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
+checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
 dependencies = [
  "bitflags 2.11.0",
  "inotify-sys",
@@ -5169,9 +5170,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 dependencies = [
  "serde",
 ]
@@ -5287,9 +5288,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.88"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7e709f3e3d22866f9c25b3aff01af289b18422cc8b4262fb19103ee80fe513d"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -5545,7 +5546,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
  "tracing-appender",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -5613,7 +5614,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -5859,7 +5860,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -5964,7 +5965,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tracing",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
  "url",
  "vergen",
  "vergen-git2",
@@ -6164,7 +6165,7 @@ dependencies = [
  "derive_more",
  "kona-genesis",
  "kona-registry",
- "miniz_oxide 0.9.0",
+ "miniz_oxide 0.9.1",
  "op-alloy-consensus",
  "op-alloy-rpc-types",
  "op-alloy-rpc-types-engine",
@@ -6177,7 +6178,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
  "unsigned-varint 0.8.0",
 ]
 
@@ -6378,9 +6379,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libgit2-sys"
@@ -6508,9 +6509,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-gossipsub"
-version = "0.49.2"
+version = "0.49.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f58e37d8d6848e5c4c9e3c35c6f61133235bff2960c9c00a663b0849301221"
+checksum = "4cef64c3bdfaee9561319a289d778e9f8c56bd8e10f5d1059289ebb085ef09d7"
 dependencies = [
  "async-channel",
  "asynchronous-codec",
@@ -6733,7 +6734,7 @@ dependencies = [
  "if-watch",
  "libc",
  "libp2p-core",
- "socket2 0.6.2",
+ "socket2 0.6.3",
  "tokio",
  "tracing",
 ]
@@ -6784,7 +6785,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
  "yamux 0.12.1",
- "yamux 0.13.8",
+ "yamux 0.13.10",
 ]
 
 [[package]]
@@ -6800,13 +6801,14 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.12"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
- "redox_syscall 0.7.1",
+ "plain",
+ "redox_syscall 0.7.3",
 ]
 
 [[package]]
@@ -6827,9 +6829,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.23"
+version = "1.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15d118bbf3771060e7311cc7bb0545b01d08a8b4a7de949198dec1fa0ca1c0f7"
+checksum = "d52f4c29e2a68ac30c9087e1b772dc9f44a2b66ed44edf2266cf2be9b03dafc1"
 dependencies = [
  "cc",
  "libc",
@@ -6906,7 +6908,7 @@ dependencies = [
  "generator",
  "scoped-tls",
  "tracing",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -7122,7 +7124,7 @@ dependencies = [
  "once_cell",
  "procfs",
  "rlimit",
- "windows 0.62.2",
+ "windows",
 ]
 
 [[package]]
@@ -7195,9 +7197,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5faa9f23e86bd5768d76def086192ff5f869fb088da12a976ea21e9796b975f6"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
 dependencies = [
  "adler2",
  "serde",
@@ -7264,9 +7266,9 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.12.13"
+version = "0.12.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac832c50ced444ef6be0767a008b02c106a909ba79d1d830501e94b96f6b7e"
+checksum = "85f8024e1c8e71c778968af91d43700ce1d11b219d127d79fb2934153b82b42b"
 dependencies = [
  "async-lock",
  "crossbeam-channel",
@@ -7382,46 +7384,30 @@ dependencies = [
 
 [[package]]
 name = "netlink-packet-core"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72724faf704479d67b388da142b186f916188505e7e0b26719019c525882eda4"
+checksum = "3463cbb78394cb0141e2c926b93fc2197e473394b761986eca3b9da2c63ae0f4"
 dependencies = [
- "anyhow",
- "byteorder",
- "netlink-packet-utils",
+ "paste",
 ]
 
 [[package]]
 name = "netlink-packet-route"
-version = "0.17.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053998cea5a306971f88580d0829e90f270f940befd7cf928da179d4187a5a66"
+checksum = "4ce3636fa715e988114552619582b530481fd5ef176a1e5c1bf024077c2c9445"
 dependencies = [
- "anyhow",
- "bitflags 1.3.2",
- "byteorder",
+ "bitflags 2.11.0",
  "libc",
+ "log",
  "netlink-packet-core",
- "netlink-packet-utils",
-]
-
-[[package]]
-name = "netlink-packet-utils"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ede8a08c71ad5a95cdd0e4e52facd37190977039a4704eb82a283f713747d34"
-dependencies = [
- "anyhow",
- "byteorder",
- "paste",
- "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "netlink-proto"
-version = "0.11.5"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72452e012c2f8d612410d89eea01e2d9b56205274abb35d53f60200b2ec41d60"
+checksum = "b65d130ee111430e47eed7896ea43ca693c387f097dd97376bffafbf25812128"
 dependencies = [
  "bytes",
  "futures",
@@ -7455,12 +7441,13 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.26.4"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.11.0",
  "cfg-if",
+ "cfg_aliases",
  "libc",
 ]
 
@@ -7664,18 +7651,18 @@ dependencies = [
 
 [[package]]
 name = "objc2-core-foundation"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.11.0",
 ]
 
 [[package]]
 name = "objc2-io-kit"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c1c64d6120e51cd86033f67176b1cb66780c2efe34dec55176f77befd93c0a"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
 dependencies = [
  "libc",
  "objc2-core-foundation",
@@ -7701,9 +7688,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 dependencies = [
  "critical-section",
  "portable-atomic",
@@ -7896,9 +7883,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.75"
+version = "0.10.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if",
@@ -7937,9 +7924,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.111"
+version = "0.9.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
 dependencies = [
  "cc",
  "libc",
@@ -7985,7 +7972,7 @@ dependencies = [
  "opentelemetry 0.31.0",
  "tracing",
  "tracing-core",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -8339,18 +8326,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8359,9 +8346,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pin-utils"
@@ -8384,6 +8371,12 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plain_hasher"
@@ -8571,9 +8564,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
  "toml_edit",
 ]
@@ -8819,7 +8812,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.2",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -8828,9 +8821,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
@@ -8856,16 +8849,16 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.2",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -8875,6 +8868,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "radium"
@@ -9113,9 +9112,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.1"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35985aa610addc02e24fc232012c86fd11f14111180f902b67e2d5331f8ebf2b"
+checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
  "bitflags 2.11.0",
 ]
@@ -9187,9 +9186,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "regress"
@@ -11096,7 +11095,7 @@ dependencies = [
  "alloy-op-hardforks",
  "alloy-primitives",
  "derive_more",
- "miniz_oxide 0.9.0",
+ "miniz_oxide 0.9.1",
  "op-alloy-consensus",
  "op-alloy-rpc-types",
  "paste",
@@ -11444,6 +11443,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-json-rpc",
+ "alloy-op-evm",
  "alloy-op-hardforks",
  "alloy-primitives",
  "alloy-rlp",
@@ -12378,7 +12378,7 @@ dependencies = [
  "tracing-journald",
  "tracing-logfmt",
  "tracing-samply",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
  "tracing-tracy",
  "tracy-client",
 ]
@@ -12397,7 +12397,7 @@ dependencies = [
  "opentelemetry_sdk 0.31.0",
  "tracing",
  "tracing-opentelemetry 0.32.1",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
  "url",
 ]
 
@@ -12736,9 +12736,9 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "32.0.0"
+version = "32.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50c1285c848d240678bf69cb0f6179ff5a4aee6fc8e921d89708087197a0aff3"
+checksum = "e2ec11f45deec71e4945e1809736bb20d454285f9167ab53c5159dae1deb603f"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -12761,9 +12761,9 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
-version = "22.0.0"
+version = "22.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba580c56a8ec824a64f8a1683577876c2e1dbe5247044199e9b881421ad5dcf9"
+checksum = "4bcfb5ce6cf18b118932bcdb7da05cd9c250f2cb9f64131396b55f3fe3537c35"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -12972,7 +12972,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-opentelemetry 0.29.0",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
  "url",
  "uuid",
  "vergen",
@@ -13038,15 +13038,15 @@ dependencies = [
 
 [[package]]
 name = "rtnetlink"
-version = "0.13.1"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a552eb82d19f38c3beed3f786bd23aa434ceb9ac43ab44419ca6d67a7e186c0"
+checksum = "4b960d5d873a75b5be9761b1e73b146f52dddcd27bac75263f40fba686d4d7b5"
 dependencies = [
- "futures",
+ "futures-channel",
+ "futures-util",
  "log",
  "netlink-packet-core",
  "netlink-packet-route",
- "netlink-packet-utils",
  "netlink-proto",
  "netlink-sys",
  "nix",
@@ -13161,9 +13161,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.36"
+version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -13297,9 +13297,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -13579,9 +13579,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.16.1"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
+checksum = "381b283ce7bc6b476d903296fb59d0d36633652b633b27f64db4fb46dcbfc3b9"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -13598,9 +13598,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.16.1"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
+checksum = "a6d4e30573c8cb306ed6ab1dca8423eec9a463ea0e155f45399455e0368b27e0"
 dependencies = [
  "darling 0.21.3",
  "proc-macro2",
@@ -13804,9 +13804,9 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "sketches-ddsketch"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e9a774a6c28142ac54bb25d25562e6bcf957493a184f15ad4eebccb23e410a"
+checksum = "0c6f73aeb92d671e0cc4dca167e59b2deb6387c375391bc99ee743f326994a2b"
 
 [[package]]
 name = "slab"
@@ -13868,12 +13868,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -14024,27 +14024,16 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.38.2"
+version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efc19935b4b66baa6f654ac7924c192f55b175c00a7ab72410fc24284dacda8"
+checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
 dependencies = [
  "libc",
  "memchr",
  "ntapi",
  "objc2-core-foundation",
  "objc2-io-kit",
- "windows 0.62.2",
-]
-
-[[package]]
-name = "system-configuration"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
-dependencies = [
- "bitflags 2.11.0",
- "core-foundation 0.9.4",
- "system-configuration-sys",
+ "windows",
 ]
 
 [[package]]
@@ -14143,12 +14132,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.25.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -14369,9 +14358,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
@@ -14379,16 +14368,16 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.2",
+ "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -14481,7 +14470,7 @@ dependencies = [
  "indexmap 2.13.0",
  "serde_core",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
  "winnow",
@@ -14497,13 +14486,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_edit"
-version = "0.23.10+spec-1.0.0"
+name = "toml_datetime"
+version = "1.0.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.4+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7193cbd0ce53dc966037f54351dbbcf0d5a642c7f0038c382ef9e677ce8c13f2"
 dependencies = [
  "indexmap 2.13.0",
- "toml_datetime",
+ "toml_datetime 1.0.0+spec-1.1.0",
  "toml_parser",
  "winnow",
 ]
@@ -14694,7 +14692,7 @@ dependencies = [
  "crossbeam-channel",
  "thiserror 2.0.18",
  "time",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -14736,7 +14734,7 @@ checksum = "2d3a81ed245bfb62592b1e2bc153e77656d94ee6a0497683a65a12ccaf2438d0"
 dependencies = [
  "libc",
  "tracing-core",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -14759,7 +14757,7 @@ dependencies = [
  "time",
  "tracing",
  "tracing-core",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -14776,7 +14774,7 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
  "web-time",
 ]
 
@@ -14792,7 +14790,7 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
  "web-time",
 ]
 
@@ -14809,7 +14807,7 @@ dependencies = [
  "memmap2",
  "smallvec",
  "tracing-core",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -14833,9 +14831,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -14859,7 +14857,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eaa1852afa96e0fe9e44caa53dc0bd2d9d05e0f2611ce09f97f8677af56e4ba"
 dependencies = [
  "tracing-core",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
  "tracy-client",
 ]
 
@@ -15125,11 +15123,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.21.0"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
+checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -15264,9 +15262,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.111"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec1adf1535672f5b7824f817792b1afd731d7e843d2d04ec8f27e8cb51edd8ac"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -15277,9 +15275,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.61"
+version = "0.4.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe88540d1c934c4ec8e6db0afa536876c5441289d7f9f9123d4f065ac1250a6b"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -15291,9 +15289,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.111"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e638317c08b21663aed4d2b9a2091450548954695ff4efa75bff5fa546b3b1"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -15301,9 +15299,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.111"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c64760850114d03d5f65457e96fc988f11f01d38fbaa51b254e4ab5809102af"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -15314,9 +15312,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.111"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60eecd4fe26177cfa3339eb00b4a36445889ba3ad37080c2429879718e20ca41"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
@@ -15384,9 +15382,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.88"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6bb20ed2d9572df8584f6dc81d68a41a625cadc6f15999d649a70ce7e3597a"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -15477,22 +15475,12 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efc5cf48f83140dcaab716eeaea345f9e93d0018fb81162753a3f76c3397b538"
-dependencies = [
- "windows-core 0.53.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
  "windows-collections",
- "windows-core 0.62.2",
+ "windows-core",
  "windows-future",
  "windows-numerics",
 ]
@@ -15503,17 +15491,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core 0.62.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcc5b895a6377f1ab9fa55acedab1fd5ac0db66ad1e6c7f47e28a22e446a5dd"
-dependencies = [
- "windows-result 0.1.2",
- "windows-targets 0.52.6",
+ "windows-core",
 ]
 
 [[package]]
@@ -15525,7 +15503,7 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link",
- "windows-result 0.4.1",
+ "windows-result",
  "windows-strings",
 ]
 
@@ -15535,7 +15513,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core 0.62.2",
+ "windows-core",
  "windows-link",
  "windows-threading",
 ]
@@ -15574,7 +15552,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core 0.62.2",
+ "windows-core",
  "windows-link",
 ]
 
@@ -15585,17 +15563,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
  "windows-link",
- "windows-result 0.4.1",
+ "windows-result",
  "windows-strings",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
-dependencies = [
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -15924,9 +15893,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
@@ -16146,9 +16115,9 @@ dependencies = [
 
 [[package]]
 name = "yamux"
-version = "0.13.8"
+version = "0.13.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deab71f2e20691b4728b349c6cee8fc7223880fa67b6b4f92225ec32225447e5"
+checksum = "1991f6690292030e31b0144d73f5e8368936c58e45e7068254f7138b23b00672"
 dependencies = [
  "futures",
  "log",
@@ -16200,18 +16169,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.39"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
+checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.39"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
+checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rust/alloy-op-evm/Cargo.toml
+++ b/rust/alloy-op-evm/Cargo.toml
@@ -14,7 +14,7 @@ repository = "https://github.com/ethereum-optimism/optimism"
 workspace = true
 
 [dependencies]
-alloy-evm = { workspace = true, features = ["op"] }
+alloy-evm.workspace = true
 
 alloy-eips = { workspace = true }
 alloy-consensus = { workspace = true }
@@ -30,8 +30,11 @@ thiserror = { workspace = true }
 
 auto_impl = { workspace = true }
 
+reth-evm = { workspace = true, optional = true }
+
 [dev-dependencies]
 alloy-hardforks = { workspace = true }
+test-case.workspace = true
 
 [features]
 default = ["std"]
@@ -46,4 +49,7 @@ std = [
 	"thiserror/std"
 ]
 gmp = ["alloy-evm/gmp"]
+engine = ["op-alloy/rpc-types-engine"]
+reth = ["reth-evm"]
+rpc = ["alloy-evm/rpc", "op-alloy/rpc-types"]
 asm-keccak = ["alloy-evm/asm-keccak", "alloy-primitives/asm-keccak", "revm/asm-keccak"]

--- a/rust/alloy-op-evm/src/env.rs
+++ b/rust/alloy-op-evm/src/env.rs
@@ -1,0 +1,269 @@
+//! OP EVM environment configuration.
+//!
+//! Provides spec ID mapping and `EvmEnv` constructors for Optimism.
+
+use alloy_consensus::BlockHeader;
+use alloy_evm::{eth::NextEvmEnvAttributes, EvmEnv};
+use alloy_op_hardforks::OpHardforks;
+use alloy_primitives::{Address, BlockNumber, BlockTimestamp, ChainId, B256, U256};
+use op_revm::OpSpecId;
+use revm::{
+    context::{BlockEnv, CfgEnv},
+    context_interface::block::BlobExcessGasAndPrice,
+    primitives::hardfork::SpecId,
+};
+
+/// Map the latest active hardfork at the given header to a revm [`OpSpecId`].
+pub fn spec(chain_spec: impl OpHardforks, header: impl BlockHeader) -> OpSpecId {
+    spec_by_timestamp_after_bedrock(chain_spec, header.timestamp())
+}
+
+/// Returns the revm [`OpSpecId`] at the given timestamp.
+///
+/// # Note
+///
+/// This is only intended to be used after the Bedrock, when hardforks are activated by
+/// timestamp.
+pub fn spec_by_timestamp_after_bedrock(chain_spec: impl OpHardforks, timestamp: u64) -> OpSpecId {
+    macro_rules! check_forks {
+        ($($check:ident => $spec:ident),+ $(,)?) => {
+            $(
+                if chain_spec.$check(timestamp) {
+                    return OpSpecId::$spec;
+                }
+            )+
+        };
+    }
+    check_forks! {
+        is_interop_active_at_timestamp => INTEROP,
+        is_jovian_active_at_timestamp => JOVIAN,
+        is_isthmus_active_at_timestamp => ISTHMUS,
+        is_holocene_active_at_timestamp => HOLOCENE,
+        is_granite_active_at_timestamp => GRANITE,
+        is_fjord_active_at_timestamp => FJORD,
+        is_ecotone_active_at_timestamp => ECOTONE,
+        is_canyon_active_at_timestamp => CANYON,
+        is_regolith_active_at_timestamp => REGOLITH,
+    }
+    OpSpecId::BEDROCK
+}
+
+/// Internal helper for constructing EVM environment from block header fields.
+struct EvmEnvInput {
+    timestamp: BlockTimestamp,
+    number: BlockNumber,
+    beneficiary: Address,
+    mix_hash: Option<B256>,
+    difficulty: U256,
+    gas_limit: u64,
+    base_fee_per_gas: u64,
+}
+
+impl EvmEnvInput {
+    fn from_block_header(header: impl BlockHeader) -> Self {
+        Self {
+            timestamp: header.timestamp(),
+            number: header.number(),
+            beneficiary: header.beneficiary(),
+            mix_hash: header.mix_hash(),
+            difficulty: header.difficulty(),
+            gas_limit: header.gas_limit(),
+            base_fee_per_gas: header.base_fee_per_gas().unwrap_or_default(),
+        }
+    }
+
+    fn for_next(
+        parent: impl BlockHeader,
+        attributes: NextEvmEnvAttributes,
+        base_fee_per_gas: u64,
+    ) -> Self {
+        Self {
+            timestamp: attributes.timestamp,
+            number: parent.number() + 1,
+            beneficiary: attributes.suggested_fee_recipient,
+            mix_hash: Some(attributes.prev_randao),
+            difficulty: U256::ZERO,
+            gas_limit: attributes.gas_limit,
+            base_fee_per_gas,
+        }
+    }
+}
+
+/// Create a new `EvmEnv` with [`OpSpecId`] from a block `header`, `chain_id` and `chain_spec`.
+pub fn evm_env_for_op_block(
+    header: impl BlockHeader,
+    chain_spec: impl OpHardforks,
+    chain_id: ChainId,
+) -> EvmEnv<OpSpecId> {
+    evm_env_for_op(EvmEnvInput::from_block_header(header), chain_spec, chain_id)
+}
+
+/// Create a new `EvmEnv` with [`OpSpecId`] from a parent block `header`, `chain_id` and
+/// `chain_spec`.
+pub fn evm_env_for_op_next_block(
+    header: impl BlockHeader,
+    attributes: NextEvmEnvAttributes,
+    base_fee_per_gas: u64,
+    chain_spec: impl OpHardforks,
+    chain_id: ChainId,
+) -> EvmEnv<OpSpecId> {
+    evm_env_for_op(
+        EvmEnvInput::for_next(header, attributes, base_fee_per_gas),
+        chain_spec,
+        chain_id,
+    )
+}
+
+fn evm_env_for_op(
+    input: EvmEnvInput,
+    chain_spec: impl OpHardforks,
+    chain_id: ChainId,
+) -> EvmEnv<OpSpecId> {
+    let spec = spec_by_timestamp_after_bedrock(&chain_spec, input.timestamp);
+    let cfg_env = CfgEnv::new().with_chain_id(chain_id).with_spec_and_mainnet_gas_params(spec);
+
+    let blob_excess_gas_and_price = spec
+        .into_eth_spec()
+        .is_enabled_in(SpecId::CANCUN)
+        .then_some(BlobExcessGasAndPrice { excess_blob_gas: 0, blob_gasprice: 1 });
+
+    let is_merge_active = spec.into_eth_spec() >= SpecId::MERGE;
+
+    let block_env = BlockEnv {
+        number: U256::from(input.number),
+        beneficiary: input.beneficiary,
+        timestamp: U256::from(input.timestamp),
+        difficulty: if is_merge_active { U256::ZERO } else { input.difficulty },
+        prevrandao: if is_merge_active { input.mix_hash } else { None },
+        gas_limit: input.gas_limit,
+        basefee: input.base_fee_per_gas,
+        // EIP-4844 excess blob gas of this block, introduced in Cancun
+        blob_excess_gas_and_price,
+    };
+
+    EvmEnv::new(cfg_env, block_env)
+}
+
+#[cfg(feature = "engine")]
+mod payload {
+    use super::*;
+    use op_alloy::rpc_types_engine::OpExecutionPayload;
+
+    /// Create a new `EvmEnv` with [`OpSpecId`] from a `payload`, `chain_id` and `chain_spec`.
+    pub fn evm_env_for_op_payload(
+        payload: &OpExecutionPayload,
+        chain_spec: impl OpHardforks,
+        chain_id: ChainId,
+    ) -> EvmEnv<OpSpecId> {
+        let input = EvmEnvInput {
+            timestamp: payload.timestamp(),
+            number: payload.block_number(),
+            beneficiary: payload.as_v1().fee_recipient,
+            mix_hash: Some(payload.as_v1().prev_randao),
+            difficulty: payload.as_v1().prev_randao.into(),
+            gas_limit: payload.as_v1().gas_limit,
+            base_fee_per_gas: payload.as_v1().base_fee_per_gas.saturating_to(),
+        };
+        super::evm_env_for_op(input, chain_spec, chain_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_consensus::Header;
+    use alloy_hardforks::EthereumHardfork;
+    use alloy_op_hardforks::{
+        EthereumHardforks, ForkCondition, OpChainHardforks, OpHardfork,
+        OP_MAINNET_CANYON_TIMESTAMP, OP_MAINNET_ECOTONE_TIMESTAMP, OP_MAINNET_FJORD_TIMESTAMP,
+        OP_MAINNET_GRANITE_TIMESTAMP, OP_MAINNET_HOLOCENE_TIMESTAMP, OP_MAINNET_ISTHMUS_TIMESTAMP,
+        OP_MAINNET_JOVIAN_TIMESTAMP, OP_MAINNET_REGOLITH_TIMESTAMP,
+    };
+    use alloy_primitives::BlockTimestamp;
+
+    struct FakeHardfork {
+        fork: OpHardfork,
+        cond: ForkCondition,
+    }
+
+    macro_rules! fake_hardfork_constructors {
+        (timestamp: $($ts_name:ident => $ts_fork:ident),+ $(,)?; block: $($blk_name:ident => $blk_fork:ident),+ $(,)?) => {
+            impl FakeHardfork {
+                $(
+                    fn $ts_name() -> Self {
+                        Self { fork: OpHardfork::$ts_fork, cond: ForkCondition::Timestamp(0) }
+                    }
+                )+
+                $(
+                    fn $blk_name() -> Self {
+                        Self { fork: OpHardfork::$blk_fork, cond: ForkCondition::Block(0) }
+                    }
+                )+
+            }
+        };
+    }
+
+    fake_hardfork_constructors! {
+        timestamp:
+            interop => Interop,
+            jovian => Jovian,
+            isthmus => Isthmus,
+            holocene => Holocene,
+            granite => Granite,
+            fjord => Fjord,
+            ecotone => Ecotone,
+            canyon => Canyon,
+            regolith => Regolith;
+        block:
+            bedrock => Bedrock,
+    }
+
+    impl EthereumHardforks for FakeHardfork {
+        fn ethereum_fork_activation(&self, _: EthereumHardfork) -> ForkCondition {
+            unimplemented!()
+        }
+    }
+
+    impl OpHardforks for FakeHardfork {
+        fn op_fork_activation(&self, fork: OpHardfork) -> ForkCondition {
+            if fork == self.fork {
+                self.cond
+            } else {
+                ForkCondition::Never
+            }
+        }
+    }
+
+    #[test_case::test_case(FakeHardfork::interop(), OpSpecId::INTEROP; "Interop")]
+    #[test_case::test_case(FakeHardfork::jovian(), OpSpecId::JOVIAN; "Jovian")]
+    #[test_case::test_case(FakeHardfork::isthmus(), OpSpecId::ISTHMUS; "Isthmus")]
+    #[test_case::test_case(FakeHardfork::holocene(), OpSpecId::HOLOCENE; "Holocene")]
+    #[test_case::test_case(FakeHardfork::granite(), OpSpecId::GRANITE; "Granite")]
+    #[test_case::test_case(FakeHardfork::fjord(), OpSpecId::FJORD; "Fjord")]
+    #[test_case::test_case(FakeHardfork::ecotone(), OpSpecId::ECOTONE; "Ecotone")]
+    #[test_case::test_case(FakeHardfork::canyon(), OpSpecId::CANYON; "Canyon")]
+    #[test_case::test_case(FakeHardfork::regolith(), OpSpecId::REGOLITH; "Regolith")]
+    #[test_case::test_case(FakeHardfork::bedrock(), OpSpecId::BEDROCK; "Bedrock")]
+    fn test_spec_maps_hardfork_successfully(fork: impl OpHardforks, expected_spec: OpSpecId) {
+        let header = Header::default();
+        let actual_spec = spec(fork, &header);
+
+        assert_eq!(actual_spec, expected_spec);
+    }
+
+    #[test_case::test_case(OP_MAINNET_JOVIAN_TIMESTAMP, OpSpecId::JOVIAN; "Jovian")]
+    #[test_case::test_case(OP_MAINNET_ISTHMUS_TIMESTAMP, OpSpecId::ISTHMUS; "Isthmus")]
+    #[test_case::test_case(OP_MAINNET_HOLOCENE_TIMESTAMP, OpSpecId::HOLOCENE; "Holocene")]
+    #[test_case::test_case(OP_MAINNET_GRANITE_TIMESTAMP, OpSpecId::GRANITE; "Granite")]
+    #[test_case::test_case(OP_MAINNET_FJORD_TIMESTAMP, OpSpecId::FJORD; "Fjord")]
+    #[test_case::test_case(OP_MAINNET_ECOTONE_TIMESTAMP, OpSpecId::ECOTONE; "Ecotone")]
+    #[test_case::test_case(OP_MAINNET_CANYON_TIMESTAMP, OpSpecId::CANYON; "Canyon")]
+    #[test_case::test_case(OP_MAINNET_REGOLITH_TIMESTAMP, OpSpecId::REGOLITH; "Regolith")]
+    fn test_op_spec_maps_hardfork_successfully(timestamp: BlockTimestamp, expected_spec: OpSpecId) {
+        let fork = OpChainHardforks::op_mainnet();
+        let header = Header { timestamp, ..Default::default() };
+        let actual_spec = spec(&fork, &header);
+
+        assert_eq!(actual_spec, expected_spec);
+    }
+}

--- a/rust/alloy-op-evm/src/error.rs
+++ b/rust/alloy-op-evm/src/error.rs
@@ -1,0 +1,41 @@
+//! Error types for OP EVM execution.
+
+use alloy_evm::InvalidTxError;
+use core::fmt;
+use op_revm::OpTransactionError;
+use revm::context_interface::result::{EVMError, InvalidTransaction};
+
+/// Newtype wrapper around [`OpTransactionError`] that allows implementing foreign traits.
+#[derive(Debug)]
+pub struct OpTxError(pub OpTransactionError);
+
+impl fmt::Display for OpTxError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl core::error::Error for OpTxError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        self.0.source()
+    }
+}
+
+impl InvalidTxError for OpTxError {
+    fn as_invalid_tx_err(&self) -> Option<&InvalidTransaction> {
+        match &self.0 {
+            OpTransactionError::Base(tx) => Some(tx),
+            _ => None,
+        }
+    }
+}
+
+/// Maps an [`EVMError<DB, OpTransactionError>`] to [`EVMError<DB, OpTxError>`].
+pub fn map_op_err<DB>(err: EVMError<DB, OpTransactionError>) -> EVMError<DB, OpTxError> {
+    match err {
+        EVMError::Transaction(e) => EVMError::Transaction(OpTxError(e)),
+        EVMError::Database(e) => EVMError::Database(e),
+        EVMError::Header(e) => EVMError::Header(e),
+        EVMError::Custom(e) => EVMError::Custom(e),
+    }
+}

--- a/rust/alloy-op-evm/src/lib.rs
+++ b/rust/alloy-op-evm/src/lib.rs
@@ -9,7 +9,17 @@
 
 extern crate alloc;
 
-pub use alloy_evm::op::{spec, spec_by_timestamp_after_bedrock};
+pub mod env;
+pub use env::{evm_env_for_op_block, evm_env_for_op_next_block, spec, spec_by_timestamp_after_bedrock};
+
+pub mod error;
+pub use error::{OpTxError, map_op_err};
+
+pub mod tx;
+pub use tx::OpTx;
+
+#[cfg(feature = "rpc")]
+pub mod rpc;
 
 use alloy_evm::{Database, Evm, EvmEnv, EvmFactory, precompiles::PrecompilesMap};
 use alloy_primitives::{Address, Bytes};
@@ -18,12 +28,12 @@ use core::{
     ops::{Deref, DerefMut},
 };
 use op_revm::{
-    DefaultOp, OpBuilder, OpContext, OpHaltReason, OpSpecId, OpTransaction, OpTransactionError,
+    DefaultOp, OpBuilder, OpContext, OpHaltReason, OpSpecId,
     precompiles::OpPrecompiles,
 };
 use revm::{
     Context, ExecuteEvm, InspectEvm, Inspector, SystemCallEvm,
-    context::{BlockEnv, TxEnv},
+    context::BlockEnv,
     context_interface::result::{EVMError, ResultAndState},
     handler::{PrecompileProvider, instructions::EthInstructions},
     inspector::NoOpInspector,
@@ -92,8 +102,8 @@ where
     P: PrecompileProvider<OpContext<DB>, Output = InterpreterResult>,
 {
     type DB = DB;
-    type Tx = OpTransaction<TxEnv>;
-    type Error = EVMError<DB::Error, OpTransactionError>;
+    type Tx = OpTx;
+    type Error = EVMError<DB::Error, OpTxError>;
     type HaltReason = OpHaltReason;
     type Spec = OpSpecId;
     type BlockEnv = BlockEnv;
@@ -112,7 +122,12 @@ where
         &mut self,
         tx: Self::Tx,
     ) -> Result<ResultAndState<Self::HaltReason>, Self::Error> {
-        if self.inspect { self.inner.inspect_tx(tx) } else { self.inner.transact(tx) }
+        let result = if self.inspect {
+            self.inner.inspect_tx(tx.0)
+        } else {
+            self.inner.transact(tx.0)
+        };
+        result.map_err(map_op_err)
     }
 
     fn transact_system_call(
@@ -121,7 +136,7 @@ where
         contract: Address,
         data: Bytes,
     ) -> Result<ResultAndState<Self::HaltReason>, Self::Error> {
-        self.inner.system_call_with_caller(caller, contract, data)
+        self.inner.system_call_with_caller(caller, contract, data).map_err(map_op_err)
     }
 
     fn finish(self) -> (Self::DB, EvmEnv<Self::Spec>) {
@@ -159,9 +174,9 @@ pub struct OpEvmFactory;
 impl EvmFactory for OpEvmFactory {
     type Evm<DB: Database, I: Inspector<OpContext<DB>>> = OpEvm<DB, I, Self::Precompiles>;
     type Context<DB: Database> = OpContext<DB>;
-    type Tx = OpTransaction<TxEnv>;
+    type Tx = OpTx;
     type Error<DBError: core::error::Error + Send + Sync + 'static> =
-        EVMError<DBError, OpTransactionError>;
+        EVMError<DBError, OpTxError>;
     type HaltReason = OpHaltReason;
     type Spec = OpSpecId;
     type BlockEnv = BlockEnv;

--- a/rust/alloy-op-evm/src/rpc.rs
+++ b/rust/alloy-op-evm/src/rpc.rs
@@ -1,0 +1,26 @@
+//! RPC transaction conversion for OP types.
+
+use crate::OpTx;
+use alloy_evm::{
+    EvmEnv,
+    env::BlockEnvironment,
+    rpc::{EthTxEnvError, TryIntoTxEnv},
+};
+use alloy_primitives::Bytes;
+use op_alloy::rpc_types::OpTransactionRequest;
+use op_revm::OpTransaction;
+
+impl<Block: BlockEnvironment> TryIntoTxEnv<OpTx, Block> for OpTransactionRequest {
+    type Err = EthTxEnvError;
+
+    fn try_into_tx_env<Spec>(
+        self,
+        evm_env: &EvmEnv<Spec, Block>,
+    ) -> Result<OpTx, Self::Err> {
+        Ok(OpTx(OpTransaction {
+            base: self.as_ref().clone().try_into_tx_env(evm_env)?,
+            enveloped_tx: Some(Bytes::new()),
+            deposit: Default::default(),
+        }))
+    }
+}

--- a/rust/alloy-op-evm/src/tx.rs
+++ b/rust/alloy-op-evm/src/tx.rs
@@ -1,0 +1,231 @@
+//! [`OpTx`] newtype wrapper around [`OpTransaction<TxEnv>`].
+
+use alloy_consensus::{
+    Signed, TxEip1559, TxEip2930, TxEip4844, TxEip4844Variant, TxEip7702, TxLegacy,
+};
+use alloy_eips::{eip7594::Encodable7594, Encodable2718, Typed2718};
+use alloy_evm::{FromRecoveredTx, FromTxWithEncoded, IntoTxEnv};
+use alloy_primitives::{Address, B256, Bytes, TxKind, U256};
+use core::ops::{Deref, DerefMut};
+use op_alloy::consensus::{OpTxEnvelope, TxDeposit};
+use op_revm::{transaction::deposit::DepositTransactionParts, OpTransaction};
+use revm::context::TxEnv;
+
+use crate::block::OpTxEnv;
+
+/// Helper to convert a deposit transaction into a [`TxEnv`].
+fn deposit_tx_env(tx: &TxDeposit, caller: Address) -> TxEnv {
+    TxEnv {
+        tx_type: tx.ty(),
+        caller,
+        gas_limit: tx.gas_limit,
+        kind: tx.to,
+        value: tx.value,
+        data: tx.input.clone(),
+        ..Default::default()
+    }
+}
+
+/// Newtype wrapper around [`OpTransaction<TxEnv>`] that allows implementing foreign traits.
+#[derive(Clone, Debug, Default)]
+pub struct OpTx(pub OpTransaction<TxEnv>);
+
+impl Deref for OpTx {
+    type Target = OpTransaction<TxEnv>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for OpTx {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl IntoTxEnv<Self> for OpTx {
+    fn into_tx_env(self) -> Self {
+        self
+    }
+}
+
+impl OpTxEnv for OpTx {
+    fn encoded_bytes(&self) -> Option<&Bytes> {
+        self.0.enveloped_tx.as_ref()
+    }
+}
+
+impl revm::context::Transaction for OpTx {
+    type AccessListItem<'a>
+        = <OpTransaction<TxEnv> as revm::context::Transaction>::AccessListItem<'a>
+    where
+        Self: 'a;
+    type Authorization<'a>
+        = <OpTransaction<TxEnv> as revm::context::Transaction>::Authorization<'a>
+    where
+        Self: 'a;
+
+    fn tx_type(&self) -> u8 {
+        self.0.tx_type()
+    }
+    fn caller(&self) -> Address {
+        self.0.caller()
+    }
+    fn gas_limit(&self) -> u64 {
+        self.0.gas_limit()
+    }
+    fn value(&self) -> U256 {
+        self.0.value()
+    }
+    fn input(&self) -> &Bytes {
+        self.0.input()
+    }
+    fn nonce(&self) -> u64 {
+        revm::context::Transaction::nonce(&self.0)
+    }
+    fn kind(&self) -> TxKind {
+        self.0.kind()
+    }
+    fn chain_id(&self) -> Option<u64> {
+        self.0.chain_id()
+    }
+    fn gas_price(&self) -> u128 {
+        self.0.gas_price()
+    }
+    fn access_list(&self) -> Option<impl Iterator<Item = Self::AccessListItem<'_>>> {
+        self.0.access_list()
+    }
+    fn blob_versioned_hashes(&self) -> &[B256] {
+        self.0.blob_versioned_hashes()
+    }
+    fn max_fee_per_blob_gas(&self) -> u128 {
+        self.0.max_fee_per_blob_gas()
+    }
+    fn authorization_list_len(&self) -> usize {
+        self.0.authorization_list_len()
+    }
+    fn authorization_list(&self) -> impl Iterator<Item = Self::Authorization<'_>> {
+        self.0.authorization_list()
+    }
+    fn max_priority_fee_per_gas(&self) -> Option<u128> {
+        self.0.max_priority_fee_per_gas()
+    }
+}
+
+impl FromRecoveredTx<OpTxEnvelope> for OpTx {
+    fn from_recovered_tx(tx: &OpTxEnvelope, sender: Address) -> Self {
+        let encoded = tx.encoded_2718();
+        Self::from_encoded_tx(tx, sender, encoded.into())
+    }
+}
+
+impl FromTxWithEncoded<OpTxEnvelope> for OpTx {
+    fn from_encoded_tx(tx: &OpTxEnvelope, caller: Address, encoded: Bytes) -> Self {
+        match tx {
+            OpTxEnvelope::Legacy(tx) => Self::from_encoded_tx(tx, caller, encoded),
+            OpTxEnvelope::Eip1559(tx) => Self::from_encoded_tx(tx, caller, encoded),
+            OpTxEnvelope::Eip2930(tx) => Self::from_encoded_tx(tx, caller, encoded),
+            OpTxEnvelope::Eip7702(tx) => Self::from_encoded_tx(tx, caller, encoded),
+            OpTxEnvelope::Deposit(tx) => Self::from_encoded_tx(tx.inner(), caller, encoded),
+        }
+    }
+}
+
+/// Generates [`FromRecoveredTx`] and [`FromTxWithEncoded`] impls for [`OpTx`] from a
+/// `Signed<$tx>` and bare `$tx` type. The bare type conversion creates the [`TxEnv`] via
+/// [`FromRecoveredTx`] and wraps it in an [`OpTransaction`].
+macro_rules! impl_from_tx {
+    ($($tx:ty),+ $(,)?) => {
+        $(
+            impl FromRecoveredTx<Signed<$tx>> for OpTx {
+                fn from_recovered_tx(tx: &Signed<$tx>, sender: Address) -> Self {
+                    let encoded = tx.encoded_2718();
+                    Self::from_encoded_tx(tx, sender, encoded.into())
+                }
+            }
+
+            impl FromTxWithEncoded<Signed<$tx>> for OpTx {
+                fn from_encoded_tx(tx: &Signed<$tx>, caller: Address, encoded: Bytes) -> Self {
+                    Self::from_encoded_tx(tx.tx(), caller, encoded)
+                }
+            }
+
+            impl FromTxWithEncoded<$tx> for OpTx {
+                fn from_encoded_tx(tx: &$tx, caller: Address, encoded: Bytes) -> Self {
+                    let base = TxEnv::from_recovered_tx(tx, caller);
+                    Self(OpTransaction {
+                        base,
+                        enveloped_tx: Some(encoded),
+                        deposit: Default::default(),
+                    })
+                }
+            }
+        )+
+    };
+}
+
+impl_from_tx!(TxLegacy, TxEip2930, TxEip1559, TxEip4844, TxEip7702);
+
+/// `TxEip4844Variant<T>` conversion is not necessary for `OpTx`, but it's useful
+/// sugar for Foundry.
+impl<T> FromRecoveredTx<Signed<TxEip4844Variant<T>>> for OpTx
+where
+    T: Encodable7594 + Send + Sync,
+{
+    fn from_recovered_tx(tx: &Signed<TxEip4844Variant<T>>, sender: Address) -> Self {
+        let encoded = tx.encoded_2718();
+        Self::from_encoded_tx(tx, sender, encoded.into())
+    }
+}
+
+impl<T> FromTxWithEncoded<Signed<TxEip4844Variant<T>>> for OpTx {
+    fn from_encoded_tx(tx: &Signed<TxEip4844Variant<T>>, caller: Address, encoded: Bytes) -> Self {
+        Self::from_encoded_tx(tx.tx(), caller, encoded)
+    }
+}
+
+impl<T> FromTxWithEncoded<TxEip4844Variant<T>> for OpTx {
+    fn from_encoded_tx(tx: &TxEip4844Variant<T>, caller: Address, encoded: Bytes) -> Self {
+        let base = TxEnv::from_recovered_tx(tx, caller);
+        Self(OpTransaction { base, enveloped_tx: Some(encoded), deposit: Default::default() })
+    }
+}
+
+impl FromRecoveredTx<TxDeposit> for OpTx {
+    fn from_recovered_tx(tx: &TxDeposit, sender: Address) -> Self {
+        let encoded = tx.encoded_2718();
+        Self::from_encoded_tx(tx, sender, encoded.into())
+    }
+}
+
+impl FromTxWithEncoded<TxDeposit> for OpTx {
+    fn from_encoded_tx(tx: &TxDeposit, caller: Address, encoded: Bytes) -> Self {
+        let base = deposit_tx_env(tx, caller);
+        let deposit = DepositTransactionParts {
+            source_hash: tx.source_hash,
+            mint: Some(tx.mint),
+            is_system_transaction: tx.is_system_transaction,
+        };
+        Self(OpTransaction { base, enveloped_tx: Some(encoded), deposit })
+    }
+}
+
+#[cfg(feature = "reth")]
+impl reth_evm::TransactionEnv for OpTx {
+    fn set_gas_limit(&mut self, gas_limit: u64) {
+        self.0.base.gas_limit = gas_limit;
+    }
+
+    fn nonce(&self) -> u64 {
+        self.0.base.nonce
+    }
+
+    fn set_nonce(&mut self, nonce: u64) {
+        self.0.base.nonce = nonce;
+    }
+
+    fn set_access_list(&mut self, access_list: alloy_eips::eip2930::AccessList) {
+        self.0.base.access_list = access_list;
+    }
+}

--- a/rust/kona/bin/client/Cargo.toml
+++ b/rust/kona/bin/client/Cargo.toml
@@ -41,7 +41,7 @@ op-alloy-rpc-types-engine = { workspace = true, features = ["serde"] }
 revm.workspace = true
 op-revm.workspace = true
 alloy-op-evm.workspace = true
-alloy-evm = { workspace = true, features = ["op"] }
+alloy-evm = { workspace = true }
 
 # General
 lru.workspace = true

--- a/rust/kona/bin/client/src/fpvm_evm/factory.rs
+++ b/rust/kona/bin/client/src/fpvm_evm/factory.rs
@@ -2,15 +2,14 @@
 
 use super::precompiles::OpFpvmPrecompiles;
 use alloy_evm::{Database, EvmEnv, EvmFactory};
-use alloy_op_evm::OpEvm;
+use alloy_op_evm::{OpEvm, OpTx, OpTxError};
 use kona_preimage::{HintWriterClient, PreimageOracleClient};
 use op_revm::{
-    DefaultOp, OpContext, OpEvm as RevmOpEvm, OpHaltReason, OpSpecId, OpTransaction,
-    OpTransactionError,
+    DefaultOp, OpContext, OpEvm as RevmOpEvm, OpHaltReason, OpSpecId,
 };
 use revm::{
     Context, Inspector,
-    context::{BlockEnv, Evm as RevmEvm, FrameStack, TxEnv, result::EVMError},
+    context::{BlockEnv, Evm as RevmEvm, FrameStack, result::EVMError},
     handler::instructions::EthInstructions,
     inspector::NoOpInspector,
 };
@@ -52,9 +51,9 @@ where
 {
     type Evm<DB: Database, I: Inspector<OpContext<DB>>> = OpEvm<DB, I, OpFpvmPrecompiles<H, O>>;
     type Context<DB: Database> = OpContext<DB>;
-    type Tx = OpTransaction<TxEnv>;
+    type Tx = OpTx;
     type Error<DBError: core::error::Error + Send + Sync + 'static> =
-        EVMError<DBError, OpTransactionError>;
+        EVMError<DBError, OpTxError>;
     type HaltReason = OpHaltReason;
     type Spec = OpSpecId;
     type Precompiles = OpFpvmPrecompiles<H, O>;

--- a/rust/kona/crates/proof/driver/Cargo.toml
+++ b/rust/kona/crates/proof/driver/Cargo.toml
@@ -22,7 +22,7 @@ kona-protocol.workspace = true
 alloy-rlp.workspace = true
 alloy-consensus.workspace = true
 alloy-primitives.workspace = true
-alloy-evm = { workspace = true, features = ["op"] }
+alloy-evm = { workspace = true }
 
 # OP Alloy
 op-alloy-consensus.workspace = true

--- a/rust/kona/crates/proof/executor/Cargo.toml
+++ b/rust/kona/crates/proof/executor/Cargo.toml
@@ -35,7 +35,7 @@ revm.workspace = true
 
 # alloy-evm
 alloy-op-evm.workspace = true
-alloy-evm = { workspace = true, features = ["op"] }
+alloy-evm = { workspace = true }
 
 # General
 thiserror.workspace = true

--- a/rust/kona/crates/proof/proof-interop/Cargo.toml
+++ b/rust/kona/crates/proof/proof-interop/Cargo.toml
@@ -28,7 +28,7 @@ alloy-eips.workspace = true
 alloy-primitives.workspace = true
 alloy-consensus.workspace = true
 alloy-rpc-types-engine.workspace = true
-alloy-evm = { workspace = true, features = ["op"] }
+alloy-evm = { workspace = true }
 
 # OP Alloy
 op-alloy-consensus.workspace = true

--- a/rust/kona/crates/proof/proof/Cargo.toml
+++ b/rust/kona/crates/proof/proof/Cargo.toml
@@ -36,7 +36,7 @@ op-alloy-rpc-types-engine = { workspace = true, features = ["serde"] }
 # Execution
 op-revm.workspace = true
 alloy-op-evm.workspace = true
-alloy-evm = { workspace = true, features = ["op"] }
+alloy-evm = { workspace = true }
 
 # General
 lru.workspace = true

--- a/rust/op-reth/crates/evm/Cargo.toml
+++ b/rust/op-reth/crates/evm/Cargo.toml
@@ -25,7 +25,7 @@ reth-rpc-eth-api = { workspace = true, optional = true }
 alloy-eips.workspace = true
 alloy-evm.workspace = true
 alloy-primitives.workspace = true
-alloy-op-evm.workspace = true
+alloy-op-evm = { workspace = true, features = ["reth"] }
 op-alloy-consensus.workspace = true
 op-alloy-rpc-types-engine.workspace = true
 alloy-consensus.workspace = true
@@ -80,4 +80,4 @@ portable = [
     "op-revm/portable",
     "revm/portable",
 ]
-rpc = ["reth-rpc-eth-api", "reth-optimism-primitives/serde", "reth-optimism-primitives/reth-codec", "alloy-evm/rpc"]
+rpc = ["reth-rpc-eth-api", "reth-optimism-primitives/serde", "reth-optimism-primitives/reth-codec", "alloy-evm/rpc", "alloy-op-evm/rpc"]

--- a/rust/op-reth/crates/evm/src/lib.rs
+++ b/rust/op-reth/crates/evm/src/lib.rs
@@ -14,10 +14,10 @@ extern crate alloc;
 use alloc::sync::Arc;
 use alloy_consensus::{BlockHeader, Header};
 use alloy_evm::{EvmFactory, FromRecoveredTx, FromTxWithEncoded};
-use alloy_op_evm::block::{OpTxEnv, receipt_builder::OpReceiptBuilder};
+use alloy_op_evm::{OpTx, evm_env_for_op_block, evm_env_for_op_next_block, block::{OpTxEnv, receipt_builder::OpReceiptBuilder}};
 use core::fmt::Debug;
 use op_alloy_consensus::EIP1559ParamError;
-use op_revm::{OpSpecId, OpTransaction};
+use op_revm::OpSpecId;
 use reth_chainspec::EthChainSpec;
 use reth_evm::{
     ConfigureEvm, EvmEnv, TransactionEnv, eth::NextEvmEnvAttributes, precompiles::PrecompilesMap,
@@ -26,7 +26,7 @@ use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_forks::OpHardforks;
 use reth_optimism_primitives::{DepositReceipt, OpPrimitives};
 use reth_primitives_traits::{NodePrimitives, SealedBlock, SealedHeader, SignedTransaction};
-use revm::context::{BlockEnv, TxEnv};
+use revm::context::BlockEnv;
 
 #[allow(unused_imports)]
 use {
@@ -132,7 +132,7 @@ where
             BlockBody = alloy_consensus::BlockBody<R::Transaction>,
             Block = alloy_consensus::Block<R::Transaction>,
         >,
-    OpTransaction<TxEnv>: FromRecoveredTx<N::SignedTx> + FromTxWithEncoded<N::SignedTx>,
+    OpTx: FromRecoveredTx<N::SignedTx> + FromTxWithEncoded<N::SignedTx>,
     R: OpReceiptBuilder<Receipt: DepositReceipt, Transaction: SignedTransaction>,
     EvmF: EvmFactory<
             Tx: FromRecoveredTx<R::Transaction>
@@ -160,7 +160,7 @@ where
     }
 
     fn evm_env(&self, header: &Header) -> Result<EvmEnv<OpSpecId>, Self::Error> {
-        Ok(EvmEnv::for_op_block(header, self.chain_spec(), self.chain_spec().chain().id()))
+        Ok(evm_env_for_op_block(header, self.chain_spec(), self.chain_spec().chain().id()))
     }
 
     fn next_evm_env(
@@ -168,7 +168,7 @@ where
         parent: &Header,
         attributes: &Self::NextBlockEnvCtx,
     ) -> Result<EvmEnv<OpSpecId>, Self::Error> {
-        Ok(EvmEnv::for_op_next_block(
+        Ok(evm_env_for_op_next_block(
             parent,
             NextEvmEnvAttributes {
                 timestamp: attributes.timestamp,
@@ -217,7 +217,7 @@ where
             BlockBody = alloy_consensus::BlockBody<R::Transaction>,
             Block = alloy_consensus::Block<R::Transaction>,
         >,
-    OpTransaction<TxEnv>: FromRecoveredTx<N::SignedTx> + FromTxWithEncoded<N::SignedTx>,
+    OpTx: FromRecoveredTx<N::SignedTx> + FromTxWithEncoded<N::SignedTx>,
     R: OpReceiptBuilder<Receipt: DepositReceipt, Transaction: SignedTransaction>,
     Self: Send + Sync + Unpin + Clone + 'static,
 {

--- a/rust/op-reth/crates/node/tests/it/builder.rs
+++ b/rust/op-reth/crates/node/tests/it/builder.rs
@@ -2,8 +2,9 @@
 
 use alloy_primitives::{Bytes, address};
 use core::marker::PhantomData;
+use alloy_op_evm::{OpTx, OpTxError};
 use op_revm::{
-    OpContext, OpHaltReason, OpSpecId, OpTransaction, OpTransactionError,
+    OpContext, OpHaltReason, OpSpecId,
     precompiles::OpPrecompiles,
 };
 use reth_db::test_utils::create_test_rw_db;
@@ -89,9 +90,9 @@ fn test_setup_custom_precompiles() {
     impl EvmFactory for UniEvmFactory {
         type Evm<DB: Database, I: Inspector<OpContext<DB>>> = OpEvm<DB, I, Self::Precompiles>;
         type Context<DB: Database> = OpContext<DB>;
-        type Tx = OpTransaction<TxEnv>;
+        type Tx = OpTx;
         type Error<DBError: core::error::Error + Send + Sync + 'static> =
-            EVMError<DBError, OpTransactionError>;
+            EVMError<DBError, OpTxError>;
         type HaltReason = OpHaltReason;
         type Spec = OpSpecId;
         type BlockEnv = BlockEnv;

--- a/rust/op-reth/crates/rpc/Cargo.toml
+++ b/rust/op-reth/crates/rpc/Cargo.toml
@@ -61,6 +61,7 @@ op-alloy-rpc-types.workspace = true
 op-alloy-rpc-types-engine.workspace = true
 op-alloy-rpc-jsonrpsee.workspace = true
 op-alloy-consensus.workspace = true
+alloy-op-evm.workspace = true
 revm.workspace = true
 op-revm.workspace = true
 

--- a/rust/op-reth/crates/rpc/src/error.rs
+++ b/rust/op-reth/crates/rpc/src/error.rs
@@ -5,7 +5,8 @@ use alloy_primitives::Bytes;
 use alloy_rpc_types_eth::{BlockError, error::EthRpcErrorCode};
 use alloy_transport::{RpcError, TransportErrorKind};
 use jsonrpsee_types::error::{INTERNAL_ERROR_CODE, INVALID_PARAMS_CODE};
-use op_revm::{OpHaltReason, OpTransactionError};
+use alloy_op_evm::OpTxError;
+use op_revm::OpHaltReason;
 use reth_evm::execute::ProviderError;
 use reth_optimism_evm::OpBlockExecutionError;
 use reth_rpc_eth_api::{AsEthApiError, EthTxEnvError, TransactionConversionError};
@@ -92,11 +93,12 @@ impl From<OpInvalidTransactionError> for jsonrpsee_types::error::ErrorObject<'st
     }
 }
 
-impl TryFrom<OpTransactionError> for OpInvalidTransactionError {
+impl TryFrom<OpTxError> for OpInvalidTransactionError {
     type Error = InvalidTransaction;
 
-    fn try_from(err: OpTransactionError) -> Result<Self, Self::Error> {
-        match err {
+    fn try_from(err: OpTxError) -> Result<Self, Self::Error> {
+        use op_revm::OpTransactionError;
+        match err.0 {
             OpTransactionError::DepositSystemTxPostRegolith => {
                 Ok(Self::DepositSystemTxPostRegolith)
             }
@@ -170,15 +172,18 @@ impl From<SequencerClientError> for jsonrpsee_types::error::ErrorObject<'static>
     }
 }
 
-impl<T> From<EVMError<T, OpTransactionError>> for OpEthApiError
+impl<T> From<EVMError<T, OpTxError>> for OpEthApiError
 where
     T: Into<EthApiError>,
 {
-    fn from(error: EVMError<T, OpTransactionError>) -> Self {
+    fn from(error: EVMError<T, OpTxError>) -> Self {
         match error {
             EVMError::Transaction(err) => match err.try_into() {
                 Ok(err) => Self::InvalidTransaction(err),
-                Err(err) => Self::Eth(EthApiError::InvalidTransaction(err.into())),
+                Err(err) => {
+                    let err: InvalidTransaction = err;
+                    Self::Eth(EthApiError::InvalidTransaction(err.into()))
+                }
             },
             EVMError::Database(err) => Self::Eth(err.into()),
             EVMError::Header(err) => Self::Eth(err.into()),

--- a/rust/op-reth/examples/custom-node/Cargo.toml
+++ b/rust/op-reth/examples/custom-node/Cargo.toml
@@ -29,7 +29,7 @@ alloy-consensus = { workspace = true, features = ["serde"] }
 alloy-eips.workspace = true
 alloy-evm.workspace = true
 alloy-genesis.workspace = true
-alloy-op-evm.workspace = true
+alloy-op-evm = { workspace = true, features = ["reth"] }
 alloy-primitives.workspace = true
 alloy-rlp.workspace = true
 alloy-serde.workspace = true

--- a/rust/op-reth/examples/custom-node/src/evm/alloy.rs
+++ b/rust/op-reth/examples/custom-node/src/evm/alloy.rs
@@ -1,9 +1,9 @@
 use crate::evm::{CustomTxEnv, PaymentTxEnv};
 use alloy_evm::{Database, Evm, EvmEnv, EvmFactory, precompiles::PrecompilesMap};
-use alloy_op_evm::{OpEvm, OpEvmFactory};
+use alloy_op_evm::{OpEvm, OpEvmFactory, OpTx, OpTxError};
 use alloy_primitives::{Address, Bytes};
 use op_revm::{
-    L1BlockInfo, OpContext, OpHaltReason, OpSpecId, OpTransaction, OpTransactionError,
+    L1BlockInfo, OpContext, OpHaltReason, OpSpecId, OpTransaction,
     precompiles::OpPrecompiles,
 };
 use reth_ethereum::evm::revm::{
@@ -37,7 +37,7 @@ where
 {
     type DB = DB;
     type Tx = CustomTxEnv;
-    type Error = EVMError<DB::Error, OpTransactionError>;
+    type Error = EVMError<DB::Error, OpTxError>;
     type HaltReason = OpHaltReason;
     type Spec = OpSpecId;
     type BlockEnv = BlockEnv;
@@ -101,7 +101,7 @@ impl EvmFactory for CustomEvmFactory {
     type Evm<DB: Database, I: Inspector<OpContext<DB>>> = CustomEvm<DB, I, Self::Precompiles>;
     type Context<DB: Database> = OpContext<DB>;
     type Tx = CustomTxEnv;
-    type Error<DBError: Error + Send + Sync + 'static> = EVMError<DBError, OpTransactionError>;
+    type Error<DBError: Error + Send + Sync + 'static> = EVMError<DBError, OpTxError>;
     type HaltReason = OpHaltReason;
     type Spec = OpSpecId;
     type BlockEnv = BlockEnv;

--- a/rust/op-reth/examples/custom-node/src/evm/env.rs
+++ b/rust/op-reth/examples/custom-node/src/evm/env.rs
@@ -3,8 +3,8 @@ use alloy_eips::{Typed2718, eip2930::AccessList};
 use alloy_evm::{FromRecoveredTx, FromTxWithEncoded, IntoTxEnv};
 use alloy_op_evm::block::OpTxEnv;
 use alloy_primitives::{Address, B256, Bytes, TxKind, U256};
+use alloy_op_evm::OpTx;
 use op_alloy_consensus::OpTxEnvelope;
-use op_revm::OpTransaction;
 use reth_ethereum::evm::{primitives::TransactionEnv, revm::context::TxEnv};
 
 /// An Optimism transaction extended by [`PaymentTxEnv`] that can be fed to [`Evm`].
@@ -12,7 +12,7 @@ use reth_ethereum::evm::{primitives::TransactionEnv, revm::context::TxEnv};
 /// [`Evm`]: alloy_evm::Evm
 #[derive(Clone, Debug)]
 pub enum CustomTxEnv {
-    Op(OpTransaction<TxEnv>),
+    Op(alloy_op_evm::OpTx),
     Payment(PaymentTxEnv),
 }
 
@@ -292,13 +292,13 @@ impl FromTxWithEncoded<TxPayment> for TxEnv {
 
 impl FromRecoveredTx<OpTxEnvelope> for CustomTxEnv {
     fn from_recovered_tx(tx: &OpTxEnvelope, sender: Address) -> Self {
-        Self::Op(OpTransaction::from_recovered_tx(tx, sender))
+        Self::Op(OpTx::from_recovered_tx(tx, sender))
     }
 }
 
 impl FromTxWithEncoded<OpTxEnvelope> for CustomTxEnv {
     fn from_encoded_tx(tx: &OpTxEnvelope, sender: Address, encoded: Bytes) -> Self {
-        Self::Op(OpTransaction::from_encoded_tx(tx, sender, encoded))
+        Self::Op(OpTx::from_encoded_tx(tx, sender, encoded))
     }
 }
 

--- a/rust/op-reth/examples/custom-node/src/rpc.rs
+++ b/rust/op-reth/examples/custom-node/src/rpc.rs
@@ -37,7 +37,7 @@ impl TryIntoTxEnv<CustomTxEnv> for OpTransactionRequest {
         self,
         evm_env: &EvmEnv<Spec, BlockEnv>,
     ) -> Result<CustomTxEnv, Self::Err> {
-        Ok(CustomTxEnv::Op(self.try_into_tx_env(evm_env)?))
+        Ok(CustomTxEnv::Op(alloy_op_evm::OpTx(self.try_into_tx_env(evm_env)?)))
     }
 }
 


### PR DESCRIPTION
## Summary
- Introduce `OpTx` and `OpTxError` newtype wrappers in alloy-op-evm to hold all OP-specific EVM implementations previously in alloy-evm's `op` module
- Move spec ID mapping and `EvmEnv` constructors as free functions (`evm_env_for_op_block`, `evm_env_for_op_next_block`)
- Add `TryIntoTxEnv<OpTx>` for `OpTransactionRequest` behind `rpc` feature
- Add `TransactionEnv` impl for `OpTx` behind `reth` feature
- Update op-reth, kona, and custom-node example to use new types
- Remove `alloy-evm` `op` feature usage from kona crates

This is the companion PR to https://github.com/alloy-rs/evm/pull/312 which removes the OP-specific code from alloy-evm. Together they decouple alloy-evm from Optimism, using newtype wrappers to satisfy Rust's orphan rule.

## Test plan
- [x] `cargo clippy` passes with no warnings
- [x] `cargo test -p alloy-op-evm` — 24 tests pass
- [x] Full workspace `cargo check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)