### PR TITLE
chore: bump op-contracts release reference to v6.0.0-rc.2

### DIFF
--- a/packages/contracts-bedrock/test/setup/ForkLive.s.sol
+++ b/packages/contracts-bedrock/test/setup/ForkLive.s.sol
@@ -124,7 +124,7 @@ contract ForkLive is Deployer, StdAssertions, FeatureFlags {
         string memory standardVersionsToml =
             vm.readFile(string.concat(validationBasePath, "standard-versions-", baseChain(), ".toml"));
 
-        standardVersionsToml = standardVersionsToml.replace('"op-contracts/v2.0.0-rc.1"', "RELEASE");
+        standardVersionsToml = standardVersionsToml.replace('"op-contracts/v6.0.0-rc.2"', "RELEASE");
 
         // Read the extra addresses JSON file which contains addresses no longer in the chain TOML.
         string memory addressesJson = vm.readFile("./lib/superchain-registry/superchain/extra/addresses/addresses.json");


### PR DESCRIPTION
## Summary

Updates `ForkLive.s.sol` to reference `op-contracts/v6.0.0-rc.2` when parsing the standard versions TOML from the superchain-registry. This keeps the fork test setup aligned with the latest contracts release.

## Changes

- Bump the hardcoded release tag in `_readSuperchainRegistry()` from `v2.0.0-rc.1` to `v6.0.0-rc.2`