### PR TITLE
fix(op-interop-filter): handle zero start timestamp in lockstep validator

### DIFF
--- a/op-interop-filter/filter/lockstep_cross_validator.go
+++ b/op-interop-filter/filter/lockstep_cross_validator.go
@@ -41,6 +41,7 @@ type LockstepCrossValidator struct {
 
 	// Single global cross-validated timestamp
 	crossValidatedTs atomic.Uint64
+	crossValidatedOK atomic.Bool
 
 	// Error state for validation failures
 	errMu sync.RWMutex
@@ -112,11 +113,10 @@ func (v *LockstepCrossValidator) setError(msg string) {
 
 // CrossValidatedTimestamp returns the global cross-validated timestamp.
 func (v *LockstepCrossValidator) CrossValidatedTimestamp() (uint64, bool) {
-	ts := v.crossValidatedTs.Load()
-	if ts == 0 {
+	if !v.crossValidatedOK.Load() {
 		return 0, false
 	}
-	return ts, true
+	return v.crossValidatedTs.Load(), true
 }
 
 // validateMessageTiming is a pure function that validates temporal constraints for cross-chain messages.
@@ -287,14 +287,15 @@ func (v *LockstepCrossValidator) advanceValidation() {
 		return
 	}
 
-	currentTs := v.crossValidatedTs.Load()
-
 	// Lazy initialization: start from the configured start timestamp
-	if currentTs == 0 {
+	if !v.crossValidatedOK.Load() {
 		v.crossValidatedTs.Store(v.startTimestamp)
+		v.crossValidatedOK.Store(true)
 		v.log.Info("Cross-validator initialized", "startTimestamp", v.startTimestamp)
 		return
 	}
+
+	currentTs := v.crossValidatedTs.Load()
 
 	// Try to advance one timestamp at a time until we catch up or hit an error
 	for {

--- a/op-interop-filter/filter/lockstep_cross_validator_test.go
+++ b/op-interop-filter/filter/lockstep_cross_validator_test.go
@@ -222,6 +222,30 @@ func TestCrossValidator_ValidationFailureSetsError(t *testing.T) {
 	require.Equal(t, uint64(101), ts, "cross-validated timestamp should not advance after failure")
 }
 
+func TestCrossValidator_StartTimestampZeroStillAdvances(t *testing.T) {
+	mock := newMockChainIngester()
+	mock.SetLatestTimestamp(1)
+
+	chains := map[eth.ChainID]ChainIngester{
+		eth.ChainIDFromUInt64(testChainA): mock,
+	}
+	cv := newTestCrossValidator(chains, testExpiryWindow, 0)
+
+	// First advancement initializes the validator at timestamp 0.
+	cv.advanceValidation()
+
+	ts, ok := cv.CrossValidatedTimestamp()
+	require.True(t, ok)
+	require.Equal(t, uint64(0), ts)
+
+	// Second advancement should move past 0 once chains have ingested timestamp 1.
+	cv.advanceValidation()
+
+	ts, ok = cv.CrossValidatedTimestamp()
+	require.True(t, ok)
+	require.Equal(t, uint64(1), ts)
+}
+
 // =============================================================================
 // ValidateAccessEntry Timestamp Ingestion Tests
 // =============================================================================


### PR DESCRIPTION
Closes #19537

## Summary
- replace the implicit `0 == uninitialized` sentinel with an explicit initialization flag for the lockstep cross-validator
- preserve support for `startTimestamp == 0` without wedging advancement
- add a regression test covering initialization at timestamp zero

## Testing
- `./linter/bin/op-golangci-lint run ./op-interop-filter/filter/...`
- `go test ./op-interop-filter/filter`