### PR TITLE
fix(op-supernode): consolidate block-to-timestamp helpers and respect genesis offset

### DIFF
--- a/op-supernode/supernode/chain_container/chain_container.go
+++ b/op-supernode/supernode/chain_container/chain_container.go
@@ -336,10 +336,7 @@ func (c *simpleChainContainer) TimestampToBlockNumber(ctx context.Context, ts ui
 }
 
 func (c *simpleChainContainer) BlockNumberToTimestamp(ctx context.Context, blocknum uint64) (uint64, error) {
-	if c.vncfg == nil {
-		return 0, fmt.Errorf("rollup config not available")
-	}
-	return c.vncfg.Rollup.Genesis.L2Time + (blocknum * c.vncfg.Rollup.BlockTime), nil
+	return c.blockNumberToTimestamp(blocknum)
 }
 
 // LocalSafeBlockAtTimestamp returns the highest L2 block with timestamp <= ts using the L2 client,
@@ -627,9 +624,9 @@ func (c *simpleChainContainer) SetResetCallback(cb ResetCallback) {
 }
 
 // blockNumberToTimestamp converts a block number to its timestamp using rollup config.
-func (c *simpleChainContainer) blockNumberToTimestamp(blockNum uint64) uint64 {
+func (c *simpleChainContainer) blockNumberToTimestamp(blockNum uint64) (uint64, error) {
 	if c.vncfg == nil {
-		return 0
+		return 0, fmt.Errorf("rollup config not available")
 	}
-	return c.vncfg.Rollup.Genesis.L2Time + (blockNum * c.vncfg.Rollup.BlockTime)
+	return c.vncfg.Rollup.Genesis.L2Time + (blockNum * c.vncfg.Rollup.BlockTime), nil
 }

--- a/op-supernode/supernode/chain_container/chain_container.go
+++ b/op-supernode/supernode/chain_container/chain_container.go
@@ -628,5 +628,8 @@ func (c *simpleChainContainer) blockNumberToTimestamp(blockNum uint64) (uint64, 
 	if c.vncfg == nil {
 		return 0, fmt.Errorf("rollup config not available")
 	}
-	return c.vncfg.Rollup.Genesis.L2Time + (blockNum * c.vncfg.Rollup.BlockTime), nil
+	if blockNum < c.vncfg.Rollup.Genesis.L2.Number {
+		return 0, fmt.Errorf("block number %d before genesis %d", blockNum, c.vncfg.Rollup.Genesis.L2.Number)
+	}
+	return c.vncfg.Rollup.TimestampForBlock(blockNum), nil
 }

--- a/op-supernode/supernode/chain_container/chain_container_test.go
+++ b/op-supernode/supernode/chain_container/chain_container_test.go
@@ -1286,3 +1286,29 @@ func TestChainContainer_SyncStatus_UninitializedVirtualNode(t *testing.T) {
 	require.Nil(t, status)
 	require.ErrorIs(t, err, virtual_node.ErrVirtualNodeNotRunning)
 }
+
+func TestChainContainer_BlockNumberToTimestamp_RespectsGenesisBlockNumber(t *testing.T) {
+	t.Parallel()
+
+	chainID := eth.ChainIDFromUInt64(420)
+	log := createTestLogger(t)
+	cfg := createTestCLIConfig(t.TempDir())
+	initOverload := &rollupNode.InitializationOverrides{}
+
+	vncfg := createTestVNConfig()
+	vncfg.Rollup.Genesis.L2Time = 1000
+	vncfg.Rollup.Genesis.L2.Number = 100
+	vncfg.Rollup.BlockTime = 2
+
+	container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil)
+	impl, ok := container.(*simpleChainContainer)
+	require.True(t, ok)
+
+	timestamp, err := impl.BlockNumberToTimestamp(context.Background(), 104)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1008), timestamp)
+
+	_, err = impl.BlockNumberToTimestamp(context.Background(), 99)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "before genesis 100")
+}

--- a/op-supernode/supernode/chain_container/invalidation.go
+++ b/op-supernode/supernode/chain_container/invalidation.go
@@ -389,7 +389,10 @@ func (c *simpleChainContainer) InvalidateBlock(ctx context.Context, height uint6
 	invalidatedBlock := currentBlock.BlockRef()
 
 	// Rewind to the prior block's timestamp
-	priorTimestamp := c.blockNumberToTimestamp(height - 1)
+	priorTimestamp, err := c.blockNumberToTimestamp(height - 1)
+	if err != nil {
+		return false, fmt.Errorf("failed to compute rewind timestamp: %w", err)
+	}
 	if err := c.RewindEngine(ctx, priorTimestamp, invalidatedBlock); err != nil {
 		return false, fmt.Errorf("failed to rewind engine: %w", err)
 	}

--- a/op-supernode/supernode/chain_container/invalidation_test.go
+++ b/op-supernode/supernode/chain_container/invalidation_test.go
@@ -419,6 +419,34 @@ func TestInvalidateBlock(t *testing.T) {
 		require.False(t, found, "genesis block should not be added to denylist")
 	})
 
+	t.Run("missing rollup config returns error before rewind", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+
+		dl, err := OpenDenyList(filepath.Join(dir, "denylist"))
+		require.NoError(t, err)
+		defer dl.Close()
+
+		mockEng := &mockEngineForInvalidation{
+			blockRef: eth.L2BlockRef{Hash: common.HexToHash("0xdead")},
+		}
+
+		c := &simpleChainContainer{
+			denyList: dl,
+			log:      testLogger(),
+			engine:   mockEng,
+			vn:       &mockVNForInvalidation{},
+		}
+
+		rewound, err := c.InvalidateBlock(context.Background(), 5, common.HexToHash("0xdead"))
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to compute rewind timestamp")
+		require.Contains(t, err.Error(), "rollup config not available")
+		require.False(t, rewound)
+		require.False(t, mockEng.rewindCalled, "rewind should not be attempted without rollup config")
+	})
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()

--- a/op-supernode/supernode/chain_container/invalidation_test.go
+++ b/op-supernode/supernode/chain_container/invalidation_test.go
@@ -350,6 +350,7 @@ func TestInvalidateBlock(t *testing.T) {
 
 	tests := []struct {
 		name             string
+		genesisBlock     uint64
 		height           uint64
 		payloadHash      common.Hash
 		currentBlockHash common.Hash
@@ -359,6 +360,7 @@ func TestInvalidateBlock(t *testing.T) {
 	}{
 		{
 			name:             "current block matches triggers rewind",
+			genesisBlock:     0,
 			height:           5,
 			payloadHash:      common.HexToHash("0xdead"),
 			currentBlockHash: common.HexToHash("0xdead"), // Same hash
@@ -368,6 +370,7 @@ func TestInvalidateBlock(t *testing.T) {
 		},
 		{
 			name:             "current block differs no rewind",
+			genesisBlock:     0,
 			height:           5,
 			payloadHash:      common.HexToHash("0xdead"),
 			currentBlockHash: common.HexToHash("0xbeef"), // Different hash
@@ -376,6 +379,7 @@ func TestInvalidateBlock(t *testing.T) {
 		},
 		{
 			name:            "engine unavailable adds to denylist only",
+			genesisBlock:    0,
 			height:          5,
 			payloadHash:     common.HexToHash("0xdead"),
 			engineAvailable: false,
@@ -383,12 +387,23 @@ func TestInvalidateBlock(t *testing.T) {
 		},
 		{
 			name:             "rewind to height-1 timestamp calculated correctly",
+			genesisBlock:     0,
 			height:           10,
 			payloadHash:      common.HexToHash("0xabcd"),
 			currentBlockHash: common.HexToHash("0xabcd"),
 			engineAvailable:  true,
 			expectRewind:     true,
 			expectRewindTs:   genesisTime + (9 * blockTime), // height 9
+		},
+		{
+			name:             "rewind timestamp respects nonzero genesis block number",
+			genesisBlock:     100,
+			height:           105,
+			payloadHash:      common.HexToHash("0xcafe"),
+			currentBlockHash: common.HexToHash("0xcafe"),
+			engineAvailable:  true,
+			expectRewind:     true,
+			expectRewindTs:   genesisTime + (4 * blockTime), // block 104 relative to genesis block 100
 		},
 	}
 
@@ -470,6 +485,7 @@ func TestInvalidateBlock(t *testing.T) {
 				vn:       &mockVNForInvalidation{},
 			}
 			c.vncfg.Rollup.Genesis.L2Time = genesisTime
+			c.vncfg.Rollup.Genesis.L2.Number = tt.genesisBlock
 			c.vncfg.Rollup.BlockTime = blockTime
 
 			if tt.engineAvailable {

--- a/op-supernode/supernode/chain_container/invalidation_test.go
+++ b/op-supernode/supernode/chain_container/invalidation_test.go
@@ -453,7 +453,7 @@ func TestInvalidateBlock(t *testing.T) {
 			vn:       &mockVNForInvalidation{},
 		}
 
-		rewound, err := c.InvalidateBlock(context.Background(), 5, common.HexToHash("0xdead"), 0)
+		rewound, err := c.InvalidateBlock(context.Background(), 5, common.HexToHash("0xdead"), 0, eth.Bytes32{}, eth.Bytes32{})
 
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to compute rewind timestamp")

--- a/op-supernode/supernode/chain_container/invalidation_test.go
+++ b/op-supernode/supernode/chain_container/invalidation_test.go
@@ -453,7 +453,7 @@ func TestInvalidateBlock(t *testing.T) {
 			vn:       &mockVNForInvalidation{},
 		}
 
-		rewound, err := c.InvalidateBlock(context.Background(), 5, common.HexToHash("0xdead"))
+		rewound, err := c.InvalidateBlock(context.Background(), 5, common.HexToHash("0xdead"), 0)
 
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to compute rewind timestamp")


### PR DESCRIPTION
Closes #19539
Closes #19540

## Summary
- consolidate the duplicated block-number-to-timestamp conversion logic in `simpleChainContainer`
- remove the silent-zero private helper behavior and surface conversion failures as errors
- switch conversion to the canonical rollup timestamp mapping so nonzero `Genesis.L2.Number` is handled correctly
- make invalidation fail closed if rewind timestamp conversion cannot be computed
- add regressions for missing rollup config and nonzero genesis block number handling

## Testing
- `./linter/bin/op-golangci-lint run ./op-supernode/...`
- `go test ./op-supernode/...`