### PR TITLE
fix(op-supernode): error on uninitialized chain sync status

### DIFF
--- a/op-supernode/supernode/chain_container/chain_container.go
+++ b/op-supernode/supernode/chain_container/chain_container.go
@@ -350,7 +350,7 @@ func (c *simpleChainContainer) SyncStatus(ctx context.Context) (*eth.SyncStatus,
 		if c.log != nil {
 			c.log.Warn("SyncStatus: virtual node not initialized")
 		}
-		return &eth.SyncStatus{}, nil
+		return nil, virtual_node.ErrVirtualNodeNotRunning
 	}
 	st, err := c.vn.SyncStatus(ctx)
 	if err != nil {

--- a/op-supernode/supernode/chain_container/chain_container_test.go
+++ b/op-supernode/supernode/chain_container/chain_container_test.go
@@ -1098,3 +1098,18 @@ func TestChainContainer_LocalSafeBlockAtTimestamp(t *testing.T) {
 		})
 	}
 }
+
+func TestChainContainer_SyncStatus_UninitializedVirtualNode(t *testing.T) {
+	t.Parallel()
+
+	chainID := eth.ChainIDFromUInt64(420)
+	log := createTestLogger(t)
+	cfg := createTestCLIConfig(t.TempDir())
+	initOverload := &rollupNode.InitializationOverrides{}
+
+	container := NewChainContainer(chainID, createTestVNConfig(), log, cfg, initOverload, nil, nil, nil)
+
+	status, err := container.SyncStatus(context.Background())
+	require.Nil(t, status)
+	require.ErrorIs(t, err, virtual_node.ErrVirtualNodeNotRunning)
+}

--- a/op-supernode/supernode/chain_container/super_authority.go
+++ b/op-supernode/supernode/chain_container/super_authority.go
@@ -56,7 +56,7 @@ func (c *simpleChainContainer) FinalizedL2Head() (eth.BlockID, bool) {
 		return eth.BlockID{}, true
 	}
 
-	ss, err := c.vn.SyncStatus(context.Background())
+	ss, err := c.SyncStatus(context.Background())
 	if err != nil {
 		c.log.Error("FinalizedL2Head: failed to get sync status", "err", err)
 		return eth.BlockID{}, true


### PR DESCRIPTION
Closes #19538

## Summary
- return `virtual_node.ErrVirtualNodeNotRunning` when `ChainContainer.SyncStatus()` is called before the virtual node is initialized
- stop silently returning an empty `eth.SyncStatus` for an unready chain container
- add a regression test for the uninitialized virtual-node case

## Testing
- `./linter/bin/op-golangci-lint run ./op-supernode/...`
- `go test ./op-supernode/...`