### PR TITLE
feat(kona): add lightweight follow node mode

### DIFF
--- a/rust/kona/bin/node/src/cli.rs
+++ b/rust/kona/bin/node/src/cli.rs
@@ -1,7 +1,9 @@
 //! Contains the node CLI.
 
 use crate::{
-    commands::{BootstoreCommand, InfoCommand, NetCommand, NodeCommand, RegistryCommand},
+    commands::{
+        BootstoreCommand, FollowCommand, InfoCommand, NetCommand, NodeCommand, RegistryCommand,
+    },
     flags::{GlobalArgs, init_unified_metrics},
     version,
 };
@@ -17,6 +19,9 @@ pub enum Commands {
     /// Runs the consensus node.
     #[command(alias = "n")]
     Node(NodeCommand),
+    /// Runs a lightweight follow node that tracks a source L2 CL.
+    #[command(alias = "f")]
+    Follow(FollowCommand),
     /// Runs the networking stack for the node.
     #[command(alias = "p2p", alias = "network")]
     Net(NetCommand),
@@ -55,6 +60,7 @@ impl Cli {
         // Initialize telemetry - allow subcommands to customize the filter.
         match self.subcommand {
             Commands::Node(ref node) => node.init_logs(&self.global)?,
+            Commands::Follow(ref follow) => follow.init_logs(&self.global)?,
             Commands::Net(ref net) => net.init_logs(&self.global)?,
             Commands::Registry(ref registry) => registry.init_logs(&self.global)?,
             Commands::Bootstore(ref bootstore) => bootstore.init_logs(&self.global)?,
@@ -75,6 +81,7 @@ impl Cli {
         // Run the subcommand.
         match self.subcommand {
             Commands::Node(node) => Self::run_until_ctrl_c(node.run(&self.global)),
+            Commands::Follow(follow) => Self::run_until_ctrl_c(follow.run(&self.global)),
             Commands::Net(net) => Self::run_until_ctrl_c(net.run(&self.global)),
             Commands::Registry(registry) => registry.run(&self.global),
             Commands::Bootstore(bootstore) => bootstore.run(&self.global),
@@ -122,6 +129,8 @@ mod tests {
     #[case::bootstore_subcommand_short(Commands::Bootstore(Default::default()), "b")]
     #[case::bootstore_subcommand_long(Commands::Bootstore(Default::default()), "boot")]
     #[case::bootstore_subcommand_long2(Commands::Bootstore(Default::default()), "store")]
+    #[case::follow_subcommand_long(Commands::Follow(Default::default()), "follow")]
+    #[case::follow_subcommand_short(Commands::Follow(Default::default()), "f")]
     #[case::info_subcommand(Commands::Info(Default::default()), "info")]
     fn test_parse_cli(#[case] subcommand: Commands, #[case] subcommand_alias: &str) {
         let args = vec!["kona-node", subcommand_alias, "--help"];

--- a/rust/kona/bin/node/src/commands/follow.rs
+++ b/rust/kona/bin/node/src/commands/follow.rs
@@ -1,0 +1,113 @@
+//! Follow Subcommand — lightweight node mode that follows a source L2 CL node.
+
+use crate::flags::{
+    DerivationDelegateArgs, GlobalArgs, L1ClientArgs, L2ClientArgs, RollupBoostFlags, RpcArgs,
+};
+use anyhow::{Result, bail};
+use clap::Parser;
+use kona_cli::LogConfig;
+use kona_node_service::{EngineConfig, FollowNodeBuilder, L1ConfigBuilder, NodeMode};
+use std::{path::PathBuf, sync::Arc, time::Duration};
+use tracing::{error, info};
+
+use super::node::NodeCommand;
+
+/// Command-line interface for running a lightweight follow node.
+///
+/// The follow node polls a source L2 CL node for sync status and drives the local engine,
+/// bypassing full derivation and P2P networking. This is useful for nodes that want to follow
+/// an existing CL without the overhead of running their own derivation pipeline or P2P stack.
+#[derive(Parser, Debug, Clone, Default)]
+#[command(about = "Runs a lightweight follow node that tracks a source L2 CL")]
+pub struct FollowCommand {
+    /// L1 RPC CLI arguments.
+    #[clap(flatten)]
+    pub l1_rpc_args: L1ClientArgs,
+
+    /// L2 engine CLI arguments.
+    #[clap(flatten)]
+    pub l2_client_args: L2ClientArgs,
+
+    /// Source L2 CL to follow (required).
+    #[clap(flatten)]
+    pub derivation_delegate_args: DerivationDelegateArgs,
+
+    /// RPC CLI arguments (optional).
+    #[command(flatten)]
+    pub rpc_flags: RpcArgs,
+
+    /// Path to a custom L2 rollup configuration file
+    /// (overrides the default rollup configuration from the registry)
+    #[arg(long, visible_alias = "rollup-cfg", env = "KONA_NODE_ROLLUP_CONFIG")]
+    pub l2_config_file: Option<PathBuf>,
+
+    /// Path to a custom L1 rollup configuration file
+    /// (overrides the default rollup configuration from the registry)
+    #[arg(long, visible_alias = "rollup-l1-cfg", env = "KONA_NODE_L1_CHAIN_CONFIG")]
+    pub l1_config_file: Option<PathBuf>,
+}
+
+impl FollowCommand {
+    /// Initializes the logging system based on global arguments.
+    pub fn init_logs(&self, args: &GlobalArgs) -> anyhow::Result<()> {
+        LogConfig::new(args.log_args.clone()).init_tracing_subscriber(None)?;
+        Ok(())
+    }
+
+    /// Run the Follow subcommand.
+    pub async fn run(self, args: &GlobalArgs) -> Result<()> {
+        let cfg = NodeCommand::get_l2_config_from(&self.l2_config_file, args)?;
+
+        info!(
+            target: "follow_node",
+            chain_id = cfg.l2_chain_id.id(),
+            "Starting follow node services"
+        );
+
+        let l1_config = L1ConfigBuilder {
+            chain_config: NodeCommand::get_l1_config_from(&self.l1_config_file, cfg.l1_chain_id)?,
+            trust_rpc: self.l1_rpc_args.l1_trust_rpc,
+            beacon: self.l1_rpc_args.l1_beacon.clone(),
+            rpc_url: self.l1_rpc_args.l1_eth_rpc.clone(),
+            slot_duration_override: self.l1_rpc_args.l1_slot_duration_override,
+        };
+
+        let Some(derivation_delegate_config) = self.derivation_delegate_args.config() else {
+            bail!("Follow mode requires --l2.follow.source to specify the source L2 CL node");
+        };
+
+        let jwt_secret = NodeCommand::validate_jwt_with(&self.l2_client_args).await?;
+
+        let engine_config = EngineConfig {
+            config: Arc::new(cfg.clone()),
+            builder_url: self.l2_client_args.l2_engine_rpc.clone(),
+            builder_jwt_secret: jwt_secret,
+            builder_timeout: Duration::from_millis(self.l2_client_args.l2_engine_timeout),
+            l2_url: self.l2_client_args.l2_engine_rpc.clone(),
+            l2_jwt_secret: jwt_secret,
+            l2_timeout: Duration::from_millis(self.l2_client_args.l2_engine_timeout),
+            l1_url: self.l1_rpc_args.l1_eth_rpc.clone(),
+            mode: NodeMode::Validator,
+            rollup_boost: RollupBoostFlags::default().as_rollup_boost_args(),
+        };
+
+        let rpc_config = self.rpc_flags.into();
+
+        FollowNodeBuilder::new(
+            cfg,
+            l1_config,
+            engine_config,
+            rpc_config,
+            derivation_delegate_config,
+        )
+        .build()
+        .start()
+        .await
+        .map_err(|e| {
+            error!(target: "follow_node", "Failed to start follow node service: {e}");
+            anyhow::anyhow!("{e}")
+        })?;
+
+        Ok(())
+    }
+}

--- a/rust/kona/bin/node/src/commands/mod.rs
+++ b/rust/kona/bin/node/src/commands/mod.rs
@@ -1,5 +1,8 @@
 //! Contains subcommands for the kona node.
 
+mod follow;
+pub use follow::FollowCommand;
+
 mod info;
 pub use info::InfoCommand;
 

--- a/rust/kona/bin/node/src/commands/node.rs
+++ b/rust/kona/bin/node/src/commands/node.rs
@@ -226,6 +226,50 @@ impl NodeCommand {
         Self::is_jwt_signature_error(error.as_ref() as &dyn std::error::Error)
     }
 
+    /// Validate the jwt secret for a given set of L2 client args.
+    pub async fn validate_jwt_with(l2_client_args: &L2ClientArgs) -> anyhow::Result<JwtSecret> {
+        let jwt_secret = Self::l2_jwt_secret_from(l2_client_args)?;
+
+        let engine = OpEngineClient::<RootProvider, RootProvider<Optimism>>::rpc_client::<Optimism>(
+            l2_client_args.l2_engine_rpc.clone(),
+            jwt_secret,
+        );
+
+        let exchange = || async {
+            match <RootProvider<Optimism> as OpEngineApi<
+                Optimism,
+                Http<HyperAuthClient>,
+            >>::exchange_capabilities(&engine, vec![])
+            .await
+            {
+                Ok(_) => {
+                    debug!("Successfully exchanged capabilities with engine");
+                    Ok(jwt_secret)
+                }
+                Err(e) => {
+                    if Self::is_jwt_signature_error(&e) {
+                        error!(
+                            "Engine API JWT secret differs from the one specified by --l2.jwt-secret/--l2.jwt-secret-encoded"
+                        );
+                        error!(
+                            "Ensure that the JWT secret file specified is correct (by default it is `jwt.hex` in the current directory)"
+                        );
+                        return Err(JwtValidationError::InvalidSignature.into());
+                    }
+                    Err(JwtValidationError::CapabilityExchange(e.to_string()).into())
+                }
+            }
+        };
+
+        exchange
+            .retry(ExponentialBuilder::default())
+            .when(|e| !Self::is_jwt_signature_error_from_anyhow(e))
+            .notify(|_, duration| {
+                debug!("Retrying engine capability handshake after {duration:?}");
+            })
+            .await
+    }
+
     /// Validate the jwt secret if specified by exchanging capabilities with the engine.
     /// Since the engine client will fail if the jwt token is invalid, this allows to ensure
     /// that the jwt token passed as a cli arg is correct.
@@ -342,7 +386,15 @@ impl NodeCommand {
 
     /// Get the L1 config, either from a file or the known chains.
     pub fn get_l1_config(&self, l1_chain_id: u64) -> Result<L1ChainConfig> {
-        match &self.l1_config_file {
+        Self::get_l1_config_from(&self.l1_config_file, l1_chain_id)
+    }
+
+    /// Get the L1 config from an optional file path or the known chains.
+    pub fn get_l1_config_from(
+        l1_config_file: &Option<PathBuf>,
+        l1_chain_id: u64,
+    ) -> Result<L1ChainConfig> {
+        match l1_config_file {
             Some(path) => {
                 debug!("Loading l1 config from file: {:?}", path);
                 let file = File::open(path)
@@ -361,7 +413,15 @@ impl NodeCommand {
 
     /// Get the L2 rollup config, either from a file or the superchain registry.
     pub fn get_l2_config(&self, args: &GlobalArgs) -> Result<RollupConfig> {
-        match &self.l2_config_file {
+        Self::get_l2_config_from(&self.l2_config_file, args)
+    }
+
+    /// Get the L2 rollup config from an optional file path or the superchain registry.
+    pub fn get_l2_config_from(
+        l2_config_file: &Option<PathBuf>,
+        args: &GlobalArgs,
+    ) -> Result<RollupConfig> {
+        match l2_config_file {
             Some(path) => {
                 debug!("Loading l2 config from file: {:?}", path);
                 let file = File::open(path)
@@ -378,22 +438,27 @@ impl NodeCommand {
         }
     }
 
-    /// Returns the L2 JWT secret for the engine API
-    /// using the provided [`PathBuf`]. If the file is not found,
-    /// it will return the default JWT secret.
-    pub fn l2_jwt_secret(&self) -> anyhow::Result<JwtSecret> {
-        if let Some(path) = &self.l2_client_args.l2_engine_jwt_secret &&
+    /// Returns the L2 JWT secret for the engine API from a set of L2 client args.
+    pub fn l2_jwt_secret_from(l2_client_args: &L2ClientArgs) -> anyhow::Result<JwtSecret> {
+        if let Some(path) = &l2_client_args.l2_engine_jwt_secret &&
             let Ok(secret) = std::fs::read_to_string(path)
         {
             return JwtSecret::from_hex(secret)
                 .map_err(|e| anyhow::anyhow!("Failed to parse JWT secret: {e}"));
         }
 
-        if let Some(secret) = &self.l2_client_args.l2_engine_jwt_encoded {
+        if let Some(secret) = &l2_client_args.l2_engine_jwt_encoded {
             return Ok(*secret);
         }
 
         Self::default_jwt_secret("l2_jwt.hex")
+    }
+
+    /// Returns the L2 JWT secret for the engine API
+    /// using the provided [`PathBuf`]. If the file is not found,
+    /// it will return the default JWT secret.
+    pub fn l2_jwt_secret(&self) -> anyhow::Result<JwtSecret> {
+        Self::l2_jwt_secret_from(&self.l2_client_args)
     }
 
     /// Returns the builder JWT secret for the engine API

--- a/rust/kona/crates/node/service/src/actors/l1_watcher/actor.rs
+++ b/rust/kona/crates/node/service/src/actors/l1_watcher/actor.rs
@@ -44,8 +44,8 @@ where
     latest_head: watch::Sender<Option<BlockInfo>>,
     /// Client used to interact with the [`crate::DerivationActor`].
     derivation_client: L1WatcherDerivationClient_,
-    /// The block signer sender.
-    block_signer_sender: mpsc::Sender<Address>,
+    /// The block signer sender. Optional to support modes without P2P networking.
+    block_signer_sender: Option<mpsc::Sender<Address>>,
     /// The cancellation token, shared between all tasks.
     cancellation: CancellationToken,
     /// A stream over the latest head.
@@ -68,7 +68,7 @@ where
         l1_query_rx: mpsc::Receiver<L1WatcherQueries>,
         l1_head_updates_tx: watch::Sender<Option<BlockInfo>>,
         derivation_client: L1WatcherDerivationClient_,
-        signer: mpsc::Sender<Address>,
+        signer: Option<mpsc::Sender<Address>>,
         cancellation: CancellationToken,
         head_stream: BlockStream,
         finalized_stream: BlockStream,
@@ -140,7 +140,9 @@ where
                                     target: "l1_watcher",
                                     "Unsafe block signer update: {unsafe_block_signer}"
                                 );
-                                if let Err(e) = self.block_signer_sender.send(unsafe_block_signer).await {
+                                if let Some(ref sender) = self.block_signer_sender
+                                    && let Err(e) = sender.send(unsafe_block_signer).await
+                                {
                                     error!(
                                         target: "l1_watcher",
                                         "Error sending unsafe block signer update: {e}"

--- a/rust/kona/crates/node/service/src/actors/rpc/actor.rs
+++ b/rust/kona/crates/node/service/src/actors/rpc/actor.rs
@@ -43,10 +43,10 @@ pub struct RpcActor<
 /// The communication context used by the RPC actor.
 #[derive(Debug)]
 pub struct RpcContext {
-    /// The network p2p rpc sender.
-    pub p2p_network: mpsc::Sender<P2pRpcRequest>,
-    /// The network admin rpc sender.
-    pub network_admin: mpsc::Sender<NetworkAdminQuery>,
+    /// The network p2p rpc sender. Optional to support modes without P2P networking.
+    pub p2p_network: Option<mpsc::Sender<P2pRpcRequest>>,
+    /// The network admin rpc sender. Optional to support modes without P2P networking.
+    pub network_admin: Option<mpsc::Sender<NetworkAdminQuery>>,
     /// The l1 watcher queries sender.
     pub l1_watcher_queries: mpsc::Sender<L1WatcherQueries>,
     /// The cancellation token, shared between all tasks.
@@ -123,18 +123,22 @@ where
         modules
             .merge(RollupBoostHealthzApiServer::into_rpc(self.rollup_boost_health_rpc_client))?;
 
-        // Build the p2p rpc module.
-        modules.merge(P2pRpc::new(p2p_network).into_rpc())?;
+        // Build the p2p rpc module if P2P networking is enabled.
+        if let Some(p2p_network) = p2p_network {
+            modules.merge(P2pRpc::new(p2p_network).into_rpc())?;
+        }
 
-        // Build the admin rpc module.
-        modules.merge(
-            AdminRpc::new(
-                self.sequencer_admin_rpc_client,
-                network_admin,
-                Some(self.rollup_boost_admin_rpc_client),
-            )
-            .into_rpc(),
-        )?;
+        // Build the admin rpc module if network admin is available.
+        if let Some(network_admin) = network_admin {
+            modules.merge(
+                AdminRpc::new(
+                    self.sequencer_admin_rpc_client,
+                    network_admin,
+                    Some(self.rollup_boost_admin_rpc_client),
+                )
+                .into_rpc(),
+            )?;
+        }
 
         // Create context for communication between actors.
         let rollup_rpc = RollupRpc::new(self.engine_rpc_client.clone(), l1_watcher_queries);

--- a/rust/kona/crates/node/service/src/lib.rs
+++ b/rust/kona/crates/node/service/src/lib.rs
@@ -11,8 +11,8 @@ extern crate tracing;
 
 mod service;
 pub use service::{
-    DerivationDelegateConfig, InteropMode, L1Config, L1ConfigBuilder, NodeMode, RollupNode,
-    RollupNodeBuilder,
+    DerivationDelegateConfig, FollowNode, FollowNodeBuilder, InteropMode, L1Config,
+    L1ConfigBuilder, NodeMode, RollupNode, RollupNodeBuilder,
 };
 
 mod actors;

--- a/rust/kona/crates/node/service/src/service/follow.rs
+++ b/rust/kona/crates/node/service/src/service/follow.rs
@@ -1,0 +1,200 @@
+//! Contains the [`FollowNode`] implementation — a lightweight node mode that polls a source L2
+//! node and drives the local engine, bypassing full derivation and P2P networking.
+
+use super::builder::{DerivationDelegateConfig, L1ConfigBuilder};
+use crate::{
+    DelegateDerivationActor, DerivationDelegateClient, EngineConfig, L1WatcherActor, NodeActor,
+    QueuedDerivationEngineClient, QueuedEngineDerivationClient, QueuedEngineRpcClient,
+    QueuedL1WatcherDerivationClient, QueuedSequencerAdminAPIClient, RollupBoostAdminApiClient,
+    RollupBoostHealthRpcClient, RpcActor, RpcContext,
+    actors::BlockStream,
+    service::node::{L1Config, create_engine_actor},
+};
+use alloy_eips::BlockNumberOrTag;
+use alloy_provider::RootProvider;
+use kona_genesis::RollupConfig;
+use kona_protocol::L2BlockInfo;
+use kona_providers_alloy::{AlloyChainProvider, OnlineBeaconClient};
+use kona_rpc::RpcBuilder;
+use std::{sync::Arc, time::Duration};
+use tokio::sync::{mpsc, watch};
+use tokio_util::sync::CancellationToken;
+
+const DERIVATION_PROVIDER_CACHE_SIZE: usize = 1024;
+const HEAD_STREAM_POLL_INTERVAL: u64 = 4;
+const FINALIZED_STREAM_POLL_INTERVAL: u64 = 60;
+
+/// A lightweight node that follows a source L2 CL node via delegated derivation.
+///
+/// Unlike [`super::RollupNode`], this node does not run P2P networking, sequencing, or full
+/// derivation. It spawns only:
+/// - [`EngineActor`] — drives the local execution engine
+/// - [`DelegateDerivationActor`] — polls `optimism_syncStatus` from the source CL
+/// - [`L1WatcherActor`] — watches the L1 chain for system config updates
+/// - [`RpcActor`] (optional) — serves RPC without P2P or admin endpoints
+#[derive(Debug)]
+pub struct FollowNode {
+    /// The rollup configuration.
+    config: Arc<RollupConfig>,
+    /// The [`EngineConfig`] for the node.
+    engine_config: EngineConfig,
+    /// The derivation delegate client.
+    derivation_delegate_provider: DerivationDelegateClient,
+    /// The optional [`RpcBuilder`] for the node.
+    rpc_builder: Option<RpcBuilder>,
+    /// The L1 configuration.
+    l1_config: L1Config,
+}
+
+impl FollowNode {
+    /// Starts the follow node service.
+    pub async fn start(&self) -> Result<(), String> {
+        let cancellation = CancellationToken::new();
+
+        let (derivation_actor_request_tx, derivation_actor_request_rx) = mpsc::channel(1024);
+        let (engine_actor_request_tx, engine_actor_request_rx) = mpsc::channel(1024);
+        let (unsafe_head_tx, _unsafe_head_rx) = watch::channel(L2BlockInfo::default());
+
+        let engine_actor = create_engine_actor(
+            &self.engine_config,
+            self.config.clone(),
+            false, // follow mode is never a sequencer
+            cancellation.clone(),
+            engine_actor_request_rx,
+            QueuedEngineDerivationClient::new(derivation_actor_request_tx.clone()),
+            unsafe_head_tx,
+        )?;
+
+        // L1 Provider for sanity checking Derivation Delegation
+        let l1_provider = AlloyChainProvider::new(
+            self.l1_config.engine_provider.clone(),
+            DERIVATION_PROVIDER_CACHE_SIZE,
+        );
+
+        let derivation = DelegateDerivationActor::<_>::new(
+            QueuedDerivationEngineClient {
+                engine_actor_request_tx: engine_actor_request_tx.clone(),
+            },
+            cancellation.clone(),
+            derivation_actor_request_rx,
+            self.derivation_delegate_provider.clone(),
+            l1_provider,
+        );
+
+        // Create the L1 Watcher actor
+        let (l1_query_tx, l1_query_rx) = mpsc::channel(1024);
+        let (l1_head_updates_tx, _l1_head_updates_rx) = watch::channel(None);
+
+        let head_stream = BlockStream::new_as_stream(
+            self.l1_config.engine_provider.clone(),
+            BlockNumberOrTag::Latest,
+            Duration::from_secs(HEAD_STREAM_POLL_INTERVAL),
+        )?;
+        let finalized_stream = BlockStream::new_as_stream(
+            self.l1_config.engine_provider.clone(),
+            BlockNumberOrTag::Finalized,
+            Duration::from_secs(FINALIZED_STREAM_POLL_INTERVAL),
+        )?;
+
+        let l1_watcher = L1WatcherActor::new(
+            self.config.clone(),
+            self.l1_config.engine_provider.clone(),
+            l1_query_rx,
+            l1_head_updates_tx,
+            QueuedL1WatcherDerivationClient { derivation_actor_request_tx },
+            None, // No block signer sender — no network actor in follow mode
+            cancellation.clone(),
+            head_stream,
+            finalized_stream,
+        );
+
+        // Create the RPC server actor (optional, no P2P or admin endpoints).
+        let rpc = self.rpc_builder.clone().map(|b| {
+            RpcActor::new(
+                b,
+                QueuedEngineRpcClient::new(engine_actor_request_tx.clone()),
+                RollupBoostAdminApiClient {
+                    engine_actor_request_tx: engine_actor_request_tx.clone(),
+                },
+                RollupBoostHealthRpcClient {
+                    engine_actor_request_tx: engine_actor_request_tx.clone(),
+                },
+                None::<QueuedSequencerAdminAPIClient>, // No sequencer admin client
+            )
+        });
+
+        crate::service::spawn_and_wait!(
+            cancellation,
+            actors = [
+                rpc.map(|r| (
+                    r,
+                    RpcContext {
+                        cancellation: cancellation.clone(),
+                        p2p_network: None,
+                        network_admin: None,
+                        l1_watcher_queries: l1_query_tx,
+                    }
+                )),
+                Some((l1_watcher, ())),
+                Some((derivation, ())),
+                Some((engine_actor, ())),
+            ]
+        );
+        Ok(())
+    }
+}
+
+/// Builder for the [`FollowNode`].
+#[derive(Debug)]
+pub struct FollowNodeBuilder {
+    /// The rollup configuration.
+    pub config: RollupConfig,
+    /// The L1 chain configuration builder.
+    pub l1_config_builder: L1ConfigBuilder,
+    /// Engine builder configuration.
+    pub engine_config: EngineConfig,
+    /// An optional RPC Configuration.
+    pub rpc_config: Option<RpcBuilder>,
+    /// Configuration for Derivation Delegate mode (required for follow).
+    pub derivation_delegate_config: DerivationDelegateConfig,
+}
+
+impl FollowNodeBuilder {
+    /// Creates a new [`FollowNodeBuilder`].
+    pub const fn new(
+        config: RollupConfig,
+        l1_config_builder: L1ConfigBuilder,
+        engine_config: EngineConfig,
+        rpc_config: Option<RpcBuilder>,
+        derivation_delegate_config: DerivationDelegateConfig,
+    ) -> Self {
+        Self { config, l1_config_builder, engine_config, rpc_config, derivation_delegate_config }
+    }
+
+    /// Assembles the [`FollowNode`] service.
+    pub fn build(self) -> FollowNode {
+        let mut l1_beacon = OnlineBeaconClient::new_http(self.l1_config_builder.beacon.to_string());
+        if let Some(l1_slot_duration) = self.l1_config_builder.slot_duration_override {
+            l1_beacon = l1_beacon.with_l1_slot_duration_override(l1_slot_duration);
+        }
+
+        let l1_config = L1Config {
+            chain_config: Arc::new(self.l1_config_builder.chain_config),
+            trust_rpc: self.l1_config_builder.trust_rpc,
+            beacon_client: l1_beacon,
+            engine_provider: RootProvider::new_http(self.l1_config_builder.rpc_url.clone()),
+        };
+
+        let derivation_delegate_provider =
+            DerivationDelegateClient::new(self.derivation_delegate_config.l2_cl_url.clone())
+                .expect("Failed to create Derivation Delegate provider");
+
+        FollowNode {
+            config: Arc::new(self.config),
+            engine_config: self.engine_config,
+            derivation_delegate_provider,
+            rpc_builder: self.rpc_config,
+            l1_config,
+        }
+    }
+}

--- a/rust/kona/crates/node/service/src/service/mod.rs
+++ b/rust/kona/crates/node/service/src/service/mod.rs
@@ -9,6 +9,9 @@ pub use builder::{DerivationDelegateConfig, L1ConfigBuilder, RollupNodeBuilder};
 mod mode;
 pub use mode::{InteropMode, NodeMode};
 
+mod follow;
+pub use follow::{FollowNode, FollowNodeBuilder};
+
 mod node;
 pub use node::{L1Config, RollupNode};
 

--- a/rust/kona/crates/node/service/src/service/node.rs
+++ b/rust/kona/crates/node/service/src/service/node.rs
@@ -198,38 +198,15 @@ impl RollupNode {
         >,
         String,
     > {
-        let engine_state = EngineState::default();
-        let (engine_state_tx, engine_state_rx) = watch::channel(engine_state);
-        let (engine_queue_length_tx, engine_queue_length_rx) = watch::channel(0);
-        let engine = Engine::new(engine_state, engine_state_tx, engine_queue_length_tx);
-
-        let engine_client = Arc::new(self.engine_config().build_engine_client().map_err(|e| {
-            error!(target: "service", error = ?e, "engine client build failed");
-            format!("Engine client build failed: {e:?}")
-        })?);
-
-        let engine_processor = EngineProcessor::new(
-            engine_client.clone(),
+        create_engine_actor(
+            &self.engine_config(),
             self.config.clone(),
-            derivation_client,
-            engine,
-            self.mode().is_sequencer().then_some(unsafe_head_tx),
-        );
-
-        let engine_rpc_processor = EngineRpcProcessor::new(
-            engine_client.clone(),
-            engine_client.rollup_boost.clone(),
-            self.config.clone(),
-            engine_state_rx,
-            engine_queue_length_rx,
-        );
-
-        Ok(EngineActor::new(
+            self.mode().is_sequencer(),
             cancellation_token,
             engine_request_rx,
-            engine_processor,
-            engine_rpc_processor,
-        ))
+            derivation_client,
+            unsafe_head_tx,
+        )
     }
 
     /// Starts the rollup node service.
@@ -349,7 +326,7 @@ impl RollupNode {
             l1_query_rx,
             l1_head_updates_tx.clone(),
             QueuedL1WatcherDerivationClient { derivation_actor_request_tx },
-            signer,
+            Some(signer),
             cancellation.clone(),
             head_stream,
             finalized_stream,
@@ -408,8 +385,8 @@ impl RollupNode {
                     r,
                     RpcContext {
                         cancellation: cancellation.clone(),
-                        p2p_network: network_rpc,
-                        network_admin: net_admin_rpc,
+                        p2p_network: Some(network_rpc),
+                        network_admin: Some(net_admin_rpc),
                         l1_watcher_queries: l1_query_tx,
                     }
                 )),
@@ -422,4 +399,59 @@ impl RollupNode {
         );
         Ok(())
     }
+}
+
+/// Shared helper to assemble an [`EngineActor`]. Used by both [`RollupNode`] and
+/// [`super::FollowNode`].
+#[allow(clippy::type_complexity)]
+pub(crate) fn create_engine_actor(
+    engine_config: &EngineConfig,
+    config: Arc<RollupConfig>,
+    is_sequencer: bool,
+    cancellation_token: CancellationToken,
+    engine_request_rx: mpsc::Receiver<EngineActorRequest>,
+    derivation_client: QueuedEngineDerivationClient,
+    unsafe_head_tx: watch::Sender<L2BlockInfo>,
+) -> Result<
+    EngineActor<
+        EngineProcessor<
+            OpEngineClient<RootProvider, RootProvider<Optimism>>,
+            QueuedEngineDerivationClient,
+        >,
+        EngineRpcProcessor<OpEngineClient<RootProvider, RootProvider<Optimism>>>,
+    >,
+    String,
+> {
+    let engine_state = EngineState::default();
+    let (engine_state_tx, engine_state_rx) = watch::channel(engine_state);
+    let (engine_queue_length_tx, engine_queue_length_rx) = watch::channel(0);
+    let engine = Engine::new(engine_state, engine_state_tx, engine_queue_length_tx);
+
+    let engine_client = Arc::new(engine_config.clone().build_engine_client().map_err(|e| {
+        error!(target: "service", error = ?e, "engine client build failed");
+        format!("Engine client build failed: {e:?}")
+    })?);
+
+    let engine_processor = EngineProcessor::new(
+        engine_client.clone(),
+        config.clone(),
+        derivation_client,
+        engine,
+        is_sequencer.then_some(unsafe_head_tx),
+    );
+
+    let engine_rpc_processor = EngineRpcProcessor::new(
+        engine_client.clone(),
+        engine_client.rollup_boost.clone(),
+        config,
+        engine_state_rx,
+        engine_queue_length_rx,
+    );
+
+    Ok(EngineActor::new(
+        cancellation_token,
+        engine_request_rx,
+        engine_processor,
+        engine_rpc_processor,
+    ))
 }

--- a/rust/op-reth/crates/exex/src/lib.rs
+++ b/rust/op-reth/crates/exex/src/lib.rs
@@ -220,6 +220,19 @@ where
         self.ensure_initialized()?;
         let sync_target_tx = self.spawn_sync_task();
 
+        // Start sync immediately if we're behind the best block
+        let latest_stored = self.storage.get_latest_block_number()?.map(|(n, _)| n).unwrap_or(0);
+        let best_block = self.ctx.provider().best_block_number()?;
+        if latest_stored < best_block {
+            info!(
+                target: "optimism::exex",
+                latest_stored,
+                best_block,
+                "Starting immediate sync to catch up"
+            );
+            sync_target_tx.send(best_block)?;
+        }
+
         let prune_task = OpProofStoragePrunerTask::new(
             self.storage.clone(),
             self.ctx.provider().clone(),
@@ -458,7 +471,7 @@ where
             // Process each block from latest_stored + 1 to tip
             let start = latest_stored.saturating_add(1);
             for block_number in start..=new.tip().number() {
-                self.process_block(block_number, &new, collector)?;
+                self.process_block(block_number, Some(&*new), collector)?;
             }
         } else {
             debug!(
@@ -482,7 +495,7 @@ where
     fn process_block(
         &self,
         block_number: u64,
-        chain: &Chain<Primitives>,
+        chain: Option<&Chain<Primitives>>,
         collector: &LiveTrieCollector<'_, Node::Evm, Node::Provider, Storage>,
     ) -> eyre::Result<()> {
         // Check if this block should be verified via full execution
@@ -491,13 +504,15 @@ where
 
         // Try to get block data from the chain first
         // 1. Fast Path: Try to use pre-computed state from the notification
-        if let Some(block) = chain.blocks().get(&block_number) {
+        if let Some(block) = chain.and_then(|c| c.blocks().get(&block_number)) {
             // Check if we have BOTH trie updates and hashed state.
             // If either is missing, we fall back to execution to ensure data integrity.
-            if let Some((trie_updates, hashed_state)) = chain.trie_data_at(block_number).map(|d| {
-                let SortedTrieData { hashed_state, trie_updates } = d.get();
-                (trie_updates, hashed_state)
-            }) {
+            if let Some((trie_updates, hashed_state)) =
+                chain.and_then(|c| c.trie_data_at(block_number)).map(|d| {
+                    let SortedTrieData { hashed_state, trie_updates } = d.get();
+                    (trie_updates, hashed_state)
+                })
+            {
                 // Use fast path only if we're not scheduled to verify this block
                 if !should_verify {
                     debug!(


### PR DESCRIPTION
## Summary

Ports the follow node concept from [base/base](https://github.com/base/base) PRs #1042, #1048, and #1178 to kona and op-reth.

- **Follow node**: A lightweight node mode that polls a source L2 CL node via delegated derivation and drives the local engine, bypassing full derivation and P2P networking. Usage: `kona-node follow --l2.follow.source <URL> ...`
- **Optional P2P/admin RPC**: `RpcContext.p2p_network` and `network_admin` are now `Option` to support modes without P2P networking
- **Optional block signer**: `L1WatcherActor.block_signer_sender` is now `Option` since follow mode has no network actor
- **Shared engine helper**: Extracted `create_engine_actor` as a free function reused by both `RollupNode` and `FollowNode`
- **CLI subcommand**: Added `follow` (alias `f`) subcommand with required `--l2.follow.source` flag
- **Shared config helpers**: Extracted `get_l1_config_from`, `get_l2_config_from`, `validate_jwt_with`, `l2_jwt_secret_from` as static methods on `NodeCommand` for reuse by `FollowCommand`
- **(op-reth)** `process_block` now accepts `Option<&Chain>` and proofs sync starts immediately on startup if behind

### New files
- `rust/kona/crates/node/service/src/service/follow.rs` — `FollowNode` + `FollowNodeBuilder`
- `rust/kona/bin/node/src/commands/follow.rs` — `FollowCommand` CLI

## Test plan

- [x] `cargo check -p kona-node-service -p kona-node` — compiles cleanly
- [x] `cargo clippy -p kona-node-service -p kona-node -- -D warnings` — no warnings
- [x] `cargo nextest run --package kona-node` — 78/78 tests pass
- [x] `cargo nextest run --package kona-node-service` — all unit tests pass (network integration tests have pre-existing port-binding failures)
- [x] `cargo run -p kona-node -- follow --help` — CLI smoke test passes
- [x] `cargo check -p reth-optimism-exex` — compiles cleanly
- [ ] Integration test with a live source L2 CL node

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>