### PR TITLE
fix(ci): upgrade rust-e2e-large-kona-sequencer to 2xlarge resource class

### DIFF
--- a/.circleci/continue/rust-e2e.yml
+++ b/.circleci/continue/rust-e2e.yml
@@ -148,9 +148,13 @@ jobs:
         description: Whether to run reorg tests
         type: boolean
         default: false
+      resource_class:
+        description: "CircleCI resource class (large devnets need 2xlarge for memory)"
+        type: string
+        default: xlarge
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
-    resource_class: xlarge
+    resource_class: <<parameters.resource_class>>
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
@@ -322,7 +326,21 @@ workflows:
           name: rust-e2e-<<matrix.devnet_config>>
           matrix:
             parameters:
-              devnet_config: ["simple-kona", "simple-kona-geth", "simple-kona-sequencer", "large-kona-sequencer"]
+              devnet_config: ["simple-kona", "simple-kona-geth", "simple-kona-sequencer"]
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+          requires:
+            - contracts-bedrock-build
+            - cannon-prestate
+            - cannon-kona-host
+            - kona-build-release
+            - op-reth-build
+      # large-kona-sequencer needs 2xlarge: it runs 9 nodes (1 sequencer +
+      # 4 reth validators + 4 geth validators) which exceeds xlarge memory.
+      - rust-e2e-sysgo-tests:
+          name: rust-e2e-large-kona-sequencer
+          devnet_config: large-kona-sequencer
+          resource_class: 2xlarge
           context:
             - circleci-repo-readonly-authenticated-github-token
           requires:


### PR DESCRIPTION
## Summary

Upgrade the `rust-e2e-large-kona-sequencer` CI job from `xlarge` (8 vCPU, 16GB) to `2xlarge` (16 vCPU, 32GB) to fix a flaky `TestSyncSafe` failure.

### Root Cause

The `large-kona-sequencer` devnet config spins up ~20+ processes: 9 L2 CL nodes (1 kona sequencer + 4 kona-reth validators + 4 kona-geth validators), 9 L2 EL nodes, plus L1, batcher, and supervisor. On `xlarge`, resource contention causes kona-node engine API calls to time out:

```
ERROR component=kona-node error="Request timeout"
ERROR component=kona-node error="ErrorObject { code: ServerError(13), message: \"Request timeout\", data: None }"
WARN  Failed to insert new payload: server returned an error response: error code 13: Request timeout
```

When payload insertions fail, the safe head can't advance, and `TestSyncSafe` exhausts its retry budget (80 attempts * 2s = 160s) with:
```
operation failed permanently after 80 attempts: expected head to advance: local-safe
```

This failure was previously invisible at the test level because the rust-e2e jobs didn't report JUnit XML results to CircleCI. It showed up only as a job-level failure. ethereum-optimism/optimism#19548 adds `store_test_results` to make these visible.

### Change

Added a `resource_class` parameter to `rust-e2e-sysgo-tests` (defaults to `xlarge` so existing variants are unchanged) and split `large-kona-sequencer` out of the matrix with `resource_class: 2xlarge`.

## Test plan

- [ ] `rust-e2e-large-kona-sequencer` passes on 2xlarge
- [ ] Other rust-e2e variants unaffected (still xlarge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)