### PR TITLE
fix(ci): quarantine flaky TestSupernodeSameTimestampCycle

### DIFF
--- a/op-acceptance-tests/acceptance-tests.yaml
+++ b/op-acceptance-tests/acceptance-tests.yaml
@@ -85,6 +85,12 @@ gates:
         metadata:
           owner: "anton evangelatov"
           target_gate: "depreqres"
+      - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/supernode/interop/same_timestamp_invalid
+        name: TestSupernodeSameTimestampCycle
+        timeout: 15m
+        metadata:
+          owner: "axel kingsley"
+          target_gate: "supernode-interop"
 
   - id: jovian
     description: "Jovian network tests."


### PR DESCRIPTION
## Summary

- Moves `TestSupernodeSameTimestampCycle` to the `flake-shake` quarantine gate in `acceptance-tests.yaml`
- The test intermittently fails with a context deadline timeout under CI load, producing a bare `--- FAIL` with no assertion message
- Fixes flaky `TestSupernodeSameTimestampCycle` observed on ethereum-optimism/optimism#19526 (which only changes `make->just` in Dockerfiles — no test code changes)

## Root cause analysis

The test sets up a two-L2 supernode interop environment, stops the sequencers, builds deterministic-timestamp blocks via `TestSequencer`, then resumes interop validation. Under CI load, the chain synchronization and interop validation steps can take longer than expected, causing the test context deadline (set 3 seconds before the Go test timeout) to fire. When this happens, the test teardown runs but no assertion message is printed — just `--- FAIL: TestSupernodeSameTimestampCycle (30.62s)`.

The `flake-shake` gate will run this test repeatedly to determine if the flakiness is a timing issue that can be fixed or if it needs a longer timeout.

## Test plan

- [ ] Verify the YAML is valid and op-acceptor picks up the new entry
- [ ] Confirm the test is skipped from the `supernode-interop` gate (op-acceptor auto-skips flake-shake tests)
- [ ] Monitor flake-shake runs for stability data

🤖 Generated with [Claude Code](https://claude.com/claude-code)