### PR TITLE
fix(op-devstack): add 5m timeout to txs in GameHelper

### DIFF
--- a/op-devstack/dsl/proofs/game_helper.go
+++ b/op-devstack/dsl/proofs/game_helper.go
@@ -2,11 +2,13 @@ package proofs
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"math/big"
 	"os"
 	"path/filepath"
+	"time"
 
 	challengerTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
@@ -22,6 +24,13 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
 )
+
+// txTimeout is the maximum time to wait for a single transaction to be
+// estimated, submitted, and included. Without this, transactions inherit the
+// test's full context deadline (~2 hours in CI) and a hanging RPC call
+// (e.g. eth_estimateGas for an EIP-7702 delegated EOA) blocks silently
+// for the entire duration.
+const txTimeout = 5 * time.Minute
 
 type GameHelperMove struct {
 	ParentIdx *big.Int
@@ -60,7 +69,9 @@ func DeployGameHelper(t devtest.T, deployer *dsl.EOA, honestTraceProvider func(g
 	)
 
 	deployTx := txplan.NewPlannedTx(deployTxOpts)
-	receipt, err := deployTx.Included.Eval(t.Ctx())
+	deployCtx, deployCancel := context.WithTimeout(t.Ctx(), txTimeout)
+	defer deployCancel()
+	receipt, err := deployTx.Included.Eval(deployCtx)
 	req.NoError(err, "Failed to deploy GameHelper contract")
 
 	req.Equal(types.ReceiptStatusSuccessful, receipt.Status, "GameHelper deployment failed")
@@ -125,7 +136,9 @@ func getGameHelperArtifactPath(t devtest.T) string {
 
 func (gs *GameHelper) AuthEOA(eoa *dsl.EOA) *GameHelper {
 	tx := txplan.NewPlannedTx(eoa.PlanAuth(gs.contractAddr))
-	receipt, err := tx.Included.Eval(gs.t.Ctx())
+	authCtx, authCancel := context.WithTimeout(gs.t.Ctx(), txTimeout)
+	defer authCancel()
+	receipt, err := tx.Included.Eval(authCtx)
 	gs.require.NoError(err)
 	gs.require.Equal(types.ReceiptStatusSuccessful, receipt.Status)
 	return &GameHelper{
@@ -160,7 +173,9 @@ func (gs *GameHelper) CreateGameWithClaims(
 			txplan.WithData(data),
 		),
 	)
-	receipt, err := tx.Included.Eval(gs.t.Ctx())
+	createCtx, createCancel := context.WithTimeout(gs.t.Ctx(), txTimeout)
+	defer createCancel()
+	receipt, err := tx.Included.Eval(createCtx)
 	gs.require.NoError(err)
 	gs.require.Equal(types.ReceiptStatusSuccessful, receipt.Status)
 
@@ -307,7 +322,9 @@ func (gs *GameHelper) PerformMoves(eoa *dsl.EOA, game *FaultDisputeGame, moves [
 		),
 	)
 	preClaimCount := game.claimCount()
-	receipt, err := tx.Included.Eval(gs.t.Ctx())
+	moveCtx, moveCancel := context.WithTimeout(gs.t.Ctx(), txTimeout)
+	defer moveCancel()
+	receipt, err := tx.Included.Eval(moveCtx)
 	gs.require.NoError(err)
 	gs.require.Equal(types.ReceiptStatusSuccessful, receipt.Status)
 	postClaimCount := game.claimCount()

--- a/op-service/txplan/txplan.go
+++ b/op-service/txplan/txplan.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"time"
 
 	"github.com/ethereum-optimism/optimism/op-service/retry"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
@@ -233,7 +234,12 @@ func WithEstimator(cl Estimator, invalidateOnNewBlock bool) Option {
 				Data:       tx.Data.Value(),
 				AccessList: tx.AccessList.Value(),
 			}
-			gas, err := cl.EstimateGas(ctx, msg)
+			// Use a bounded context so a hanging eth_estimateGas call
+			// (e.g. for EIP-7702 delegated EOAs) doesn't block for the
+			// entire parent context lifetime.
+			estimateCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+			defer cancel()
+			gas, err := cl.EstimateGas(estimateCtx, msg)
 			if err != nil {
 				return 0, err
 			}

--- a/op-service/txplan/txplan.go
+++ b/op-service/txplan/txplan.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"time"
 
 	"github.com/ethereum-optimism/optimism/op-service/retry"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
@@ -234,12 +233,7 @@ func WithEstimator(cl Estimator, invalidateOnNewBlock bool) Option {
 				Data:       tx.Data.Value(),
 				AccessList: tx.AccessList.Value(),
 			}
-			// Use a bounded context so a hanging eth_estimateGas call
-			// (e.g. for EIP-7702 delegated EOAs) doesn't block for the
-			// entire parent context lifetime.
-			estimateCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-			defer cancel()
-			gas, err := cl.EstimateGas(estimateCtx, msg)
+			gas, err := cl.EstimateGas(ctx, msg)
 			if err != nil {
 				return 0, err
 			}


### PR DESCRIPTION
## Summary

- Add a 5-minute `context.WithTimeout` around each `Eval` call in `GameHelper` (deploy, AuthEOA, CreateGameWithClaims, PerformMoves)

## Motivation

`TestChallengerRespondsToMultipleInvalidClaimsEOA` hung for 2 hours in CI (the full Go binary timeout) on [PR #19525](https://github.com/ethereum-optimism/optimism/pull/19525). Investigation showed:

- The test's EOA variant uses EIP-7702 (`SetCodeTxType`) to delegate an EOA to a GameHelper contract
- All `Eval` calls in `GameHelper` pass `gs.t.Ctx()` which inherits the test's ~2-hour context deadline
- If any RPC call hangs (e.g. `eth_estimateGas` for a 7702-delegated EOA), it blocks silently for the entire duration
- Op-challenger's claim logic is claimant-agnostic (verified by tracing `ClaimID`, `shouldCounter`, `honestClaimTracker`) — the hang occurs in the tx lifecycle, not in game resolution

The 5-minute timeout bounds the entire tx lifecycle (estimation, signing, submission, inclusion) so any single hanging operation fails fast instead of consuming the full test budget.

## Test plan

- [ ] `go build ./op-devstack/dsl/proofs/...` compiles
- [ ] Existing acceptance tests pass
- [ ] Monitor CI for `TestChallengerRespondsToMultipleInvalidClaimsEOA` — should either pass or fail fast (not hang for 2 hours)

🤖 Generated with [Claude Code](https://claude.com/claude-code)