### PR TITLE
fix(op-supernode): on invalid messages pause all chains before rewinding

### DIFF
--- a/op-supernode/supernode/activity/interop/algo_test.go
+++ b/op-supernode/supernode/activity/interop/algo_test.go
@@ -896,6 +896,7 @@ func (m *algoMockChain) Start(ctx context.Context) error                  { retu
 func (m *algoMockChain) Stop(ctx context.Context) error                   { return nil }
 func (m *algoMockChain) Pause(ctx context.Context) error                  { return nil }
 func (m *algoMockChain) Resume(ctx context.Context) error                 { return nil }
+func (m *algoMockChain) PauseAndStopVN(ctx context.Context) error         { return nil }
 func (m *algoMockChain) RegisterVerifier(v activity.VerificationActivity) {}
 func (m *algoMockChain) VerifierCurrentL1s() []eth.BlockID                { return nil }
 func (m *algoMockChain) LocalSafeBlockAtTimestamp(ctx context.Context, ts uint64) (eth.L2BlockRef, error) {

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -336,6 +336,20 @@ func (i *Interop) handleResult(result Result) error {
 	// if the result is invalid, invalidate the blocks and return
 	if !result.IsValid() {
 		i.log.Error("interop validation failed", "results", result)
+		// Freeze ALL invalid chains before rewinding any. Without this, rewinding chain A
+		// fires onReset which changes the interop supervisor state. Chain B's still-running
+		// VN sees the change and issues a ForkchoiceUpdate that advances its safe head,
+		// causing chain B's subsequent synthetic-payload rewind to be rejected as INVALID.
+		for chainID, invalidHead := range result.InvalidHeads {
+			chain, ok := i.chains[chainID]
+			if !ok {
+				i.log.Error("chain not found for pre-rewind freeze", "chainID", chainID)
+				continue
+			}
+			if err := chain.PauseAndStopVN(i.ctx); err != nil {
+				i.log.Error("failed to freeze chain before rewind", "chainID", chainID, "blockID", invalidHead, "err", err)
+			}
+		}
 		for chainID, invalidHead := range result.InvalidHeads {
 			if err := i.invalidateBlock(chainID, invalidHead); err != nil {
 				i.log.Error("failed to invalidate block", "chainID", chainID, "blockID", invalidHead, "err", err)

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -1256,6 +1256,7 @@ func (m *mockChainContainer) Start(ctx context.Context) error                  {
 func (m *mockChainContainer) Stop(ctx context.Context) error                   { return nil }
 func (m *mockChainContainer) Pause(ctx context.Context) error                  { return nil }
 func (m *mockChainContainer) Resume(ctx context.Context) error                 { return nil }
+func (m *mockChainContainer) PauseAndStopVN(ctx context.Context) error         { return nil }
 func (m *mockChainContainer) RegisterVerifier(v activity.VerificationActivity) {}
 func (m *mockChainContainer) VerifierCurrentL1s() []eth.BlockID                { return nil }
 func (m *mockChainContainer) LocalSafeBlockAtTimestamp(ctx context.Context, ts uint64) (eth.L2BlockRef, error) {

--- a/op-supernode/supernode/activity/interop/logdb_test.go
+++ b/op-supernode/supernode/activity/interop/logdb_test.go
@@ -648,6 +648,7 @@ func (m *statefulMockChainContainer) Start(ctx context.Context) error           
 func (m *statefulMockChainContainer) Stop(ctx context.Context) error                   { return nil }
 func (m *statefulMockChainContainer) Pause(ctx context.Context) error                  { return nil }
 func (m *statefulMockChainContainer) Resume(ctx context.Context) error                 { return nil }
+func (m *statefulMockChainContainer) PauseAndStopVN(ctx context.Context) error         { return nil }
 func (m *statefulMockChainContainer) RegisterVerifier(v activity.VerificationActivity) {}
 func (m *statefulMockChainContainer) VerifierCurrentL1s() []eth.BlockID                { return nil }
 func (m *statefulMockChainContainer) LocalSafeBlockAtTimestamp(ctx context.Context, ts uint64) (eth.L2BlockRef, error) {

--- a/op-supernode/supernode/activity/supernode/supernode_test.go
+++ b/op-supernode/supernode/activity/supernode/supernode_test.go
@@ -26,8 +26,9 @@ type mockCC struct {
 
 func (m *mockCC) Start(ctx context.Context) error  { return nil }
 func (m *mockCC) Stop(ctx context.Context) error   { return nil }
-func (m *mockCC) Pause(ctx context.Context) error  { return nil }
-func (m *mockCC) Resume(ctx context.Context) error { return nil }
+func (m *mockCC) Pause(ctx context.Context) error          { return nil }
+func (m *mockCC) Resume(ctx context.Context) error         { return nil }
+func (m *mockCC) PauseAndStopVN(ctx context.Context) error { return nil }
 
 func (m *mockCC) RegisterVerifier(v activity.VerificationActivity) {}
 func (m *mockCC) VerifierCurrentL1s() []eth.BlockID {

--- a/op-supernode/supernode/activity/supernode/supernode_test.go
+++ b/op-supernode/supernode/activity/supernode/supernode_test.go
@@ -24,8 +24,8 @@ type mockCC struct {
 	syncStatusErr error
 }
 
-func (m *mockCC) Start(ctx context.Context) error  { return nil }
-func (m *mockCC) Stop(ctx context.Context) error   { return nil }
+func (m *mockCC) Start(ctx context.Context) error          { return nil }
+func (m *mockCC) Stop(ctx context.Context) error           { return nil }
 func (m *mockCC) Pause(ctx context.Context) error          { return nil }
 func (m *mockCC) Resume(ctx context.Context) error         { return nil }
 func (m *mockCC) PauseAndStopVN(ctx context.Context) error { return nil }

--- a/op-supernode/supernode/activity/superroot/superroot_test.go
+++ b/op-supernode/supernode/activity/superroot/superroot_test.go
@@ -31,8 +31,8 @@ type mockCC struct {
 	syncStatusErr error
 }
 
-func (m *mockCC) Start(ctx context.Context) error  { return nil }
-func (m *mockCC) Stop(ctx context.Context) error   { return nil }
+func (m *mockCC) Start(ctx context.Context) error          { return nil }
+func (m *mockCC) Stop(ctx context.Context) error           { return nil }
 func (m *mockCC) Pause(ctx context.Context) error          { return nil }
 func (m *mockCC) Resume(ctx context.Context) error         { return nil }
 func (m *mockCC) PauseAndStopVN(ctx context.Context) error { return nil }

--- a/op-supernode/supernode/activity/superroot/superroot_test.go
+++ b/op-supernode/supernode/activity/superroot/superroot_test.go
@@ -33,8 +33,9 @@ type mockCC struct {
 
 func (m *mockCC) Start(ctx context.Context) error  { return nil }
 func (m *mockCC) Stop(ctx context.Context) error   { return nil }
-func (m *mockCC) Pause(ctx context.Context) error  { return nil }
-func (m *mockCC) Resume(ctx context.Context) error { return nil }
+func (m *mockCC) Pause(ctx context.Context) error          { return nil }
+func (m *mockCC) Resume(ctx context.Context) error         { return nil }
+func (m *mockCC) PauseAndStopVN(ctx context.Context) error { return nil }
 
 func (m *mockCC) RegisterVerifier(v activity.VerificationActivity) {}
 func (m *mockCC) VerifierCurrentL1s() []eth.BlockID {

--- a/op-supernode/supernode/chain_container/chain_container.go
+++ b/op-supernode/supernode/chain_container/chain_container.go
@@ -27,7 +27,13 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-const virtualNodeVersion = "0.1.0"
+const (
+	virtualNodeVersion = "0.1.0"
+	// maxRewindAttempts is the maximum number of times RewindEngine will retry a transient
+	// rewind error before giving up. Prevents infinite retry loops when the engine
+	// consistently rejects synthetic payloads or FCU calls.
+	maxRewindAttempts = 10
+)
 
 type ChainContainer interface {
 	Start(ctx context.Context) error
@@ -58,6 +64,10 @@ type ChainContainer interface {
 	// currently uses that block at the specified height.
 	// Returns true if a rewind was triggered, false otherwise.
 	InvalidateBlock(ctx context.Context, height uint64, payloadHash common.Hash) (bool, error)
+	// PauseAndStopVN pauses the chain container restart loop and stops the virtual node.
+	// This is used to freeze a chain's VN before a multi-chain rewind begins, preventing
+	// the VN from issuing forkchoice updates that race with the rewind of a peer chain.
+	PauseAndStopVN(ctx context.Context) error
 	// IsDenied checks if a block hash is on the deny list at the given height.
 	IsDenied(height uint64, payloadHash common.Hash) (bool, error)
 	// SetResetCallback sets a callback that is invoked when the chain resets.
@@ -522,20 +532,23 @@ func (c *simpleChainContainer) RewindEngine(ctx context.Context, timestamp uint6
 	c.log.Info("chain_container/RewindEngine: stopped vn")
 
 retryLoop:
-	for {
+	for attempt := 1; ; attempt++ {
 		err = c.engine.RewindToTimestamp(ctx, timestamp)
 		switch {
 		case errors.Is(err, context.DeadlineExceeded):
-			c.log.Error("chain_container/RewindEngine: timeout exceeded")
+			c.log.Error("chain_container/RewindEngine: timeout exceeded", "attempt", attempt, "timestamp", timestamp)
 			return err
 		case isCriticalRewindError(err):
-			c.log.Error("chain_container/RewindEngine: critical error", "err", err)
+			c.log.Error("chain_container/RewindEngine: critical error", "err", err, "attempt", attempt, "timestamp", timestamp)
 			return err
 		case err == nil:
-			c.log.Info("chain_container/RewindEngine: executed engine rewind")
+			c.log.Info("chain_container/RewindEngine: executed engine rewind", "attempts", attempt, "timestamp", timestamp)
 			break retryLoop
+		case attempt >= maxRewindAttempts:
+			c.log.Error("chain_container/RewindEngine: max retry attempts reached, giving up", "err", err, "attempt", attempt, "timestamp", timestamp)
+			return err
 		default:
-			c.log.Error("chain_container/RewindEngine: temporary error", "err", err)
+			c.log.Error("chain_container/RewindEngine: temporary error, retrying", "err", err, "attempt", attempt, "timestamp", timestamp)
 			select {
 			case <-ctx.Done():
 				return ctx.Err()
@@ -557,6 +570,20 @@ retryLoop:
 	c.log.Info("chain_container/RewindEngine: resumed container")
 
 	return nil
+}
+
+// PauseAndStopVN pauses the container restart loop and stops the running virtual node.
+// This must be called before a multi-chain rewind to prevent a peer chain's VN from
+// issuing forkchoice updates that race with the rewind operation.
+// RewindEngine's own Pause+Stop calls are idempotent when called after this.
+func (c *simpleChainContainer) PauseAndStopVN(ctx context.Context) error {
+	if err := c.Pause(ctx); err != nil {
+		return err
+	}
+	if c.vn == nil {
+		return nil
+	}
+	return c.vn.Stop(ctx)
 }
 
 // SetResetCallback sets a callback that is invoked when the chain resets.

--- a/op-supernode/supernode/chain_container/engine_controller/rewind.go
+++ b/op-supernode/supernode/chain_container/engine_controller/rewind.go
@@ -128,12 +128,18 @@ func (e *simpleEngineController) insertSyntheticPayload(ctx context.Context, blo
 	syntheticHash, _ := newEnvelope.CheckBlockHash() // ignore "ok" since we know it won't match
 	newPayload.BlockHash = syntheticHash
 
+	e.log.Info("inserting synthetic payload", "blockNumber", blockNumber, "parentHash", newPayload.ParentHash, "syntheticHash", syntheticHash)
 	status, err := e.l2.NewPayload(ctx, &newPayload, envelope.ParentBeaconBlockRoot)
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("%w: %w", ErrRewindInsertSyntheticFailed, err)
 	}
 	if status.Status != eth.ExecutionValid {
-		return common.Hash{}, fmt.Errorf("%w: status=%s", ErrRewindSyntheticPayloadRejected, status.Status)
+		validationErr := ""
+		if status.ValidationError != nil {
+			validationErr = *status.ValidationError
+		}
+		return common.Hash{}, fmt.Errorf("%w: status=%s validationError=%q blockNumber=%d parentHash=%s syntheticHash=%s",
+			ErrRewindSyntheticPayloadRejected, status.Status, validationErr, blockNumber, newPayload.ParentHash, syntheticHash)
 	}
 
 	return syntheticHash, nil
@@ -189,7 +195,12 @@ func (e *simpleEngineController) forkchoiceUpdate(ctx context.Context, head, saf
 		return err
 	}
 	if res.PayloadStatus.Status != eth.ExecutionValid {
-		return fmt.Errorf("%w: status=%s", ErrRewindFCURejected, res.PayloadStatus.Status)
+		validationErr := ""
+		if res.PayloadStatus.ValidationError != nil {
+			validationErr = *res.PayloadStatus.ValidationError
+		}
+		return fmt.Errorf("%w: status=%s validationError=%q head=%s safe=%s finalized=%s",
+			ErrRewindFCURejected, res.PayloadStatus.Status, validationErr, head, safe, finalized)
 	}
 	return nil
 }


### PR DESCRIPTION
Should hopefully fix at least one reason that `TestSupernodeSameTimestampCycle` can [flake. ](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/119496/workflows/a69e7897-5779-4346-9faf-ffbe69283dcf/jobs/4584483/tests)



Closes https://github.com/ethereum-optimism/optimism/issues/19559