### PR TITLE
fix(ci): install just via mise in GitHub Actions docker-build-prep

### DIFF
--- a/.github/actions/docker-build-prep/action.yml
+++ b/.github/actions/docker-build-prep/action.yml
@@ -12,6 +12,11 @@ outputs:
 runs:
   using: 'composite'
   steps:
+    - name: Install mise
+      uses: jdx/mise-action@c1ecc8f748cd28cdeabf76dab3cccde4ce692fe4 # v4.0.0
+      with:
+        install_args: just
+
     - name: Get date
       id: date
       shell: bash
@@ -23,7 +28,7 @@ runs:
       id: compute_versions
       shell: bash
       run: |
-        VERSIONS=$(GIT_COMMIT="${{ github.sha }}" make compute-git-versions)
+        VERSIONS=$(GIT_COMMIT="${{ github.sha }}" just compute-git-versions)
         echo "versions=$VERSIONS" >> $GITHUB_OUTPUT
         echo "Computed versions: $VERSIONS"
 

--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -12,6 +12,7 @@ on:
       - 'packages/contracts-bedrock/**'
       - 'docker-bake.hcl'
       - '.github/workflows/branches.yaml'
+      - '.github/actions/docker-build-prep/**'
       - 'ops/scripts/compute-git-versions.sh'
       - 'op-rbuilder/**'
       - 'rust/**'

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,3 @@
-DEPRECATED_TARGETS := help build build-go build-contracts build-customlint lint-go lint-go-fix check-op-geth-version golang-docker docker-builder-clean docker-builder cross-op-node contracts-bedrock-docker submodules op-node generate-mocks-op-node generate-mocks-op-service op-batcher op-proposer op-challenger op-dispute-mon op-supernode op-interop-filter op-program cannon reproducible-prestate-op-program reproducible-prestate-kona reproducible-prestate cannon-prestates mod-tidy clean nuke test-unit semgrep-ci op-program-client op-program-host make-pre-test go-tests go-tests-short go-tests-short-ci go-tests-ci go-tests-ci-kona-action go-tests-fraud-proofs-ci test update-op-geth
+DEPRECATED_TARGETS := help build build-go build-contracts build-customlint lint-go lint-go-fix check-op-geth-version golang-docker docker-builder-clean docker-builder cross-op-node contracts-bedrock-docker submodules op-node generate-mocks-op-node generate-mocks-op-service op-batcher op-proposer op-challenger op-dispute-mon op-supernode op-interop-filter op-program cannon reproducible-prestate-op-program reproducible-prestate-kona reproducible-prestate cannon-prestates mod-tidy clean nuke test-unit semgrep-ci op-program-client op-program-host make-pre-test go-tests go-tests-short go-tests-short-ci go-tests-ci go-tests-ci-kona-action go-tests-fraud-proofs-ci test update-op-geth compute-git-versions
 
 include ./justfiles/deprecated.mk
-
-# Called directly by GitHub Actions (no just dependency).
-.PHONY: compute-git-versions
-compute-git-versions:
-	@GIT_COMMIT="$${GIT_COMMIT:-$$(git rev-parse HEAD)}" ./ops/scripts/compute-git-versions.sh


### PR DESCRIPTION
## Summary

- Install `just` via `jdx/mise-action` (SHA-pinned v4.0.0) in the `docker-build-prep` composite action
- Switch from `make compute-git-versions` to `just compute-git-versions`
- Remove the #19523 workaround: delete native Make target and restore `compute-git-versions` to `DEPRECATED_TARGETS`
- Add `docker-build-prep` action path to `branches.yaml` PR trigger paths

Closes #19524