### PR TITLE
fix(op-supernode): freeze all chains' VNs before any invalidation rewind

### DIFF
--- a/op-supernode/supernode/activity/interop/algo_test.go
+++ b/op-supernode/supernode/activity/interop/algo_test.go
@@ -896,6 +896,7 @@ func (m *algoMockChain) Start(ctx context.Context) error                  { retu
 func (m *algoMockChain) Stop(ctx context.Context) error                   { return nil }
 func (m *algoMockChain) Pause(ctx context.Context) error                  { return nil }
 func (m *algoMockChain) Resume(ctx context.Context) error                 { return nil }
+func (m *algoMockChain) PauseAndStopVN(ctx context.Context) error         { return nil }
 func (m *algoMockChain) RegisterVerifier(v activity.VerificationActivity) {}
 func (m *algoMockChain) VerifierCurrentL1s() []eth.BlockID                { return nil }
 func (m *algoMockChain) LocalSafeBlockAtTimestamp(ctx context.Context, ts uint64) (eth.L2BlockRef, error) {

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -467,12 +467,33 @@ func (i *Interop) applyPendingTransition(pending PendingTransition) (bool, error
 		sort.Slice(invalidations, func(i, j int) bool {
 			return invalidations[i].ChainID.Cmp(invalidations[j].ChainID) < 0
 		})
+		// Freeze ALL chains' VNs before rewinding any. Without this, a non-invalidated
+		// chain's still-running VN can observe the interop state change from onReset and
+		// issue a ForkchoiceUpdate that advances its safe head. If that chain is later
+		// invalidated (e.g. transitive invalidation across multiple rounds), its rewind
+		// will be rejected because the safe head was already advanced.
+		// This is broader than freezing only invalid chains because transitive invalidation
+		// requires multiple verification rounds — a chain valid in round N may become
+		// invalid in round N+1 after its dependency is replaced.
+		for chainID, chain := range i.chains {
+			if err := chain.PauseAndStopVN(i.ctx); err != nil {
+				i.log.Error("failed to freeze chain before rewind", "chainID", chainID, "err", err)
+			}
+		}
 		var failedAny bool
 		for _, p := range invalidations {
 			if err := i.invalidateBlock(p.ChainID, p.BlockID, p.Timestamp); err != nil {
 				i.log.Error("invalidation failed, transition preserved for retry on restart",
 					"chain", p.ChainID, "block", p.BlockID, "err", err)
 				failedAny = true
+			}
+		}
+		// Resume non-invalidated chains. Invalidated chains are resumed by RewindEngine.
+		for chainID, chain := range i.chains {
+			if _, isInvalid := pending.Result.InvalidHeads[chainID]; !isInvalid {
+				if err := chain.Resume(i.ctx); err != nil {
+					i.log.Error("failed to resume chain after rewind", "chainID", chainID, "err", err)
+				}
 			}
 		}
 		if failedAny {

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -1214,6 +1214,33 @@ func (m *mockBlockInfo) ID() eth.BlockID                                      { 
 
 var _ eth.BlockInfo = (*mockBlockInfo)(nil)
 
+// callLog records the order of method calls across multiple mock chain containers.
+// Tests use it to verify that operations happen in the expected sequence
+// (e.g., all freezes before any invalidation).
+type callLog struct {
+	mu      sync.Mutex
+	entries []callLogEntry
+}
+
+type callLogEntry struct {
+	chainID eth.ChainID
+	method  string
+}
+
+func (cl *callLog) record(chainID eth.ChainID, method string) {
+	cl.mu.Lock()
+	defer cl.mu.Unlock()
+	cl.entries = append(cl.entries, callLogEntry{chainID: chainID, method: method})
+}
+
+func (cl *callLog) snapshot() []callLogEntry {
+	cl.mu.Lock()
+	defer cl.mu.Unlock()
+	out := make([]callLogEntry, len(cl.entries))
+	copy(out, cl.entries)
+	return out
+}
+
 type mockChainContainer struct {
 	id eth.ChainID
 
@@ -1243,6 +1270,13 @@ type mockChainContainer struct {
 	optimisticL2    eth.BlockID
 	optimisticL1    eth.BlockID
 	optimisticAtErr error
+
+	// PauseAndStopVN / Resume tracking
+	pauseAndStopVNCalls int
+	pauseAndStopVNErr   error
+	resumeCalls         int
+	resumeErr           error
+	callLog             *callLog // shared ordered call log across mocks
 }
 
 type invalidateBlockCall struct {
@@ -1258,8 +1292,24 @@ func (m *mockChainContainer) ID() eth.ChainID                                  {
 func (m *mockChainContainer) Start(ctx context.Context) error                  { return nil }
 func (m *mockChainContainer) Stop(ctx context.Context) error                   { return nil }
 func (m *mockChainContainer) Pause(ctx context.Context) error                  { return nil }
-func (m *mockChainContainer) Resume(ctx context.Context) error                 { return nil }
-func (m *mockChainContainer) PauseAndStopVN(ctx context.Context) error         { return nil }
+func (m *mockChainContainer) Resume(ctx context.Context) error {
+	m.mu.Lock()
+	m.resumeCalls++
+	m.mu.Unlock()
+	if m.callLog != nil {
+		m.callLog.record(m.id, "Resume")
+	}
+	return m.resumeErr
+}
+func (m *mockChainContainer) PauseAndStopVN(ctx context.Context) error {
+	m.mu.Lock()
+	m.pauseAndStopVNCalls++
+	m.mu.Unlock()
+	if m.callLog != nil {
+		m.callLog.record(m.id, "PauseAndStopVN")
+	}
+	return m.pauseAndStopVNErr
+}
 func (m *mockChainContainer) RegisterVerifier(v activity.VerificationActivity) {}
 func (m *mockChainContainer) VerifierCurrentL1s() []eth.BlockID                { return nil }
 func (m *mockChainContainer) LocalSafeBlockAtTimestamp(ctx context.Context, ts uint64) (eth.L2BlockRef, error) {
@@ -1357,8 +1407,11 @@ func (m *mockChainContainer) RewindEngine(ctx context.Context, timestamp uint64,
 func (m *mockChainContainer) BlockTime() uint64 { return 1 }
 func (m *mockChainContainer) InvalidateBlock(ctx context.Context, height uint64, payloadHash common.Hash, decisionTimestamp uint64) (bool, error) {
 	m.mu.Lock()
-	defer m.mu.Unlock()
 	m.invalidateBlockCalls = append(m.invalidateBlockCalls, invalidateBlockCall{height: height, payloadHash: payloadHash})
+	m.mu.Unlock()
+	if m.callLog != nil {
+		m.callLog.record(m.id, "InvalidateBlock")
+	}
 	return m.invalidateBlockRet, m.invalidateBlockErr
 }
 func (m *mockChainContainer) PruneDeniedAtOrAfterTimestamp(timestamp uint64) (map[uint64][]common.Hash, error) {
@@ -1980,5 +2033,239 @@ func TestVerifiedBlockAtL1(t *testing.T) {
 		blockID, ts := h.interop.VerifiedBlockAtL1(h.Mock(10).id, l1Block)
 		require.Equal(t, eth.BlockID{}, blockID)
 		require.Equal(t, uint64(0), ts)
+	})
+}
+
+// =============================================================================
+// TestFreezeAllBeforeRewind
+// =============================================================================
+
+// TestFreezeAllBeforeRewind verifies the freeze-all-then-resume behavior
+// introduced in applyPendingTransition for DecisionInvalidate:
+//   - All chains (not just invalidated ones) are frozen via PauseAndStopVN
+//     before any invalidateBlock call
+//   - Only non-invalidated chains are resumed after the invalidation loop
+//   - Invalidated chains are NOT resumed (RewindEngine handles that internally)
+func TestFreezeAllBeforeRewind(t *testing.T) {
+	t.Parallel()
+
+	t.Run("all chains frozen before any invalidation", func(t *testing.T) {
+		cl := &callLog{}
+		h := newInteropTestHarness(t).
+			WithChain(10, func(m *mockChainContainer) {
+				m.blockAtTimestamp = eth.L2BlockRef{Number: 100, Hash: common.HexToHash("0x1")}
+				m.callLog = cl
+			}).
+			WithChain(8453, func(m *mockChainContainer) {
+				m.blockAtTimestamp = eth.L2BlockRef{Number: 200, Hash: common.HexToHash("0x2")}
+				m.callLog = cl
+			}).
+			WithChain(42, func(m *mockChainContainer) {
+				m.blockAtTimestamp = eth.L2BlockRef{Number: 300, Hash: common.HexToHash("0x3")}
+				m.callLog = cl
+			}).
+			Build()
+
+		chain10 := h.Mock(10).id
+		chain8453 := h.Mock(8453).id
+
+		// Only chain 10 is invalidated; chains 8453 and 42 are valid.
+		invalidResult := Result{
+			Timestamp:   1000,
+			L1Inclusion: eth.BlockID{Number: 100, Hash: common.HexToHash("0xL1")},
+			L2Heads: map[eth.ChainID]eth.BlockID{
+				chain10:   {Number: 500, Hash: common.HexToHash("0xL2-10")},
+				chain8453: {Number: 600, Hash: common.HexToHash("0xL2-8453")},
+			},
+			InvalidHeads: map[eth.ChainID]eth.BlockID{
+				chain10: {Number: 500, Hash: common.HexToHash("0xBAD")},
+			},
+		}
+
+		pending, err := h.interop.buildPendingTransition(
+			StepOutput{Decision: DecisionInvalidate, Result: invalidResult},
+			RoundObservation{},
+		)
+		require.NoError(t, err)
+		require.NoError(t, h.interop.verifiedDB.SetPendingTransition(pending))
+		_, err = h.interop.applyPendingTransition(pending)
+		require.NoError(t, err)
+
+		entries := cl.snapshot()
+
+		// All three chains must have PauseAndStopVN called.
+		require.Equal(t, 1, h.Mock(10).pauseAndStopVNCalls, "chain 10 should be frozen")
+		require.Equal(t, 1, h.Mock(8453).pauseAndStopVNCalls, "chain 8453 should be frozen")
+		require.Equal(t, 1, h.Mock(42).pauseAndStopVNCalls, "chain 42 should be frozen")
+
+		// Find the index of the first InvalidateBlock call.
+		firstInvalidateIdx := -1
+		for i, e := range entries {
+			if e.method == "InvalidateBlock" {
+				firstInvalidateIdx = i
+				break
+			}
+		}
+		require.NotEqual(t, -1, firstInvalidateIdx, "should have at least one InvalidateBlock call")
+
+		// Every PauseAndStopVN must come before the first InvalidateBlock.
+		for i, e := range entries {
+			if e.method == "PauseAndStopVN" {
+				require.Less(t, i, firstInvalidateIdx,
+					"PauseAndStopVN on chain %s (index %d) must precede first InvalidateBlock (index %d)",
+					e.chainID, i, firstInvalidateIdx)
+			}
+		}
+	})
+
+	t.Run("only non-invalidated chains are resumed", func(t *testing.T) {
+		cl := &callLog{}
+		h := newInteropTestHarness(t).
+			WithChain(10, func(m *mockChainContainer) {
+				m.blockAtTimestamp = eth.L2BlockRef{Number: 100, Hash: common.HexToHash("0x1")}
+				m.callLog = cl
+			}).
+			WithChain(8453, func(m *mockChainContainer) {
+				m.blockAtTimestamp = eth.L2BlockRef{Number: 200, Hash: common.HexToHash("0x2")}
+				m.callLog = cl
+			}).
+			WithChain(42, func(m *mockChainContainer) {
+				m.blockAtTimestamp = eth.L2BlockRef{Number: 300, Hash: common.HexToHash("0x3")}
+				m.callLog = cl
+			}).
+			Build()
+
+		chain10 := h.Mock(10).id
+		chain8453 := h.Mock(8453).id
+		chain42 := h.Mock(42).id
+
+		// Chains 10 and 8453 are invalidated; chain 42 is valid.
+		invalidResult := Result{
+			Timestamp:   1000,
+			L1Inclusion: eth.BlockID{Number: 100, Hash: common.HexToHash("0xL1")},
+			L2Heads: map[eth.ChainID]eth.BlockID{
+				chain10:   {Number: 500, Hash: common.HexToHash("0xL2-10")},
+				chain8453: {Number: 600, Hash: common.HexToHash("0xL2-8453")},
+				chain42:   {Number: 700, Hash: common.HexToHash("0xL2-42")},
+			},
+			InvalidHeads: map[eth.ChainID]eth.BlockID{
+				chain10:   {Number: 500, Hash: common.HexToHash("0xBAD10")},
+				chain8453: {Number: 600, Hash: common.HexToHash("0xBAD8453")},
+			},
+		}
+
+		pending, err := h.interop.buildPendingTransition(
+			StepOutput{Decision: DecisionInvalidate, Result: invalidResult},
+			RoundObservation{},
+		)
+		require.NoError(t, err)
+		require.NoError(t, h.interop.verifiedDB.SetPendingTransition(pending))
+		_, err = h.interop.applyPendingTransition(pending)
+		require.NoError(t, err)
+
+		// Only chain 42 (non-invalidated) should have Resume called.
+		require.Equal(t, 0, h.Mock(10).resumeCalls, "invalidated chain 10 should NOT be resumed")
+		require.Equal(t, 0, h.Mock(8453).resumeCalls, "invalidated chain 8453 should NOT be resumed")
+		require.Equal(t, 1, h.Mock(42).resumeCalls, "non-invalidated chain 42 should be resumed")
+	})
+
+	t.Run("resume happens after all invalidations", func(t *testing.T) {
+		cl := &callLog{}
+		h := newInteropTestHarness(t).
+			WithChain(10, func(m *mockChainContainer) {
+				m.blockAtTimestamp = eth.L2BlockRef{Number: 100, Hash: common.HexToHash("0x1")}
+				m.callLog = cl
+			}).
+			WithChain(8453, func(m *mockChainContainer) {
+				m.blockAtTimestamp = eth.L2BlockRef{Number: 200, Hash: common.HexToHash("0x2")}
+				m.callLog = cl
+			}).
+			Build()
+
+		chain10 := h.Mock(10).id
+		chain8453 := h.Mock(8453).id
+
+		// Only chain 10 is invalidated.
+		invalidResult := Result{
+			Timestamp:   1000,
+			L1Inclusion: eth.BlockID{Number: 100, Hash: common.HexToHash("0xL1")},
+			L2Heads: map[eth.ChainID]eth.BlockID{
+				chain10:   {Number: 500, Hash: common.HexToHash("0xL2-10")},
+				chain8453: {Number: 600, Hash: common.HexToHash("0xL2-8453")},
+			},
+			InvalidHeads: map[eth.ChainID]eth.BlockID{
+				chain10: {Number: 500, Hash: common.HexToHash("0xBAD")},
+			},
+		}
+
+		pending, err := h.interop.buildPendingTransition(
+			StepOutput{Decision: DecisionInvalidate, Result: invalidResult},
+			RoundObservation{},
+		)
+		require.NoError(t, err)
+		require.NoError(t, h.interop.verifiedDB.SetPendingTransition(pending))
+		_, err = h.interop.applyPendingTransition(pending)
+		require.NoError(t, err)
+
+		entries := cl.snapshot()
+
+		// Find the last InvalidateBlock index.
+		lastInvalidateIdx := -1
+		for i, e := range entries {
+			if e.method == "InvalidateBlock" {
+				lastInvalidateIdx = i
+			}
+		}
+		require.NotEqual(t, -1, lastInvalidateIdx)
+
+		// Every Resume must come after the last InvalidateBlock.
+		for i, e := range entries {
+			if e.method == "Resume" {
+				require.Greater(t, i, lastInvalidateIdx,
+					"Resume on chain %s (index %d) must follow last InvalidateBlock (index %d)",
+					e.chainID, i, lastInvalidateIdx)
+			}
+		}
+	})
+
+	t.Run("single chain invalidated freezes and does not resume", func(t *testing.T) {
+		cl := &callLog{}
+		h := newInteropTestHarness(t).
+			WithChain(10, func(m *mockChainContainer) {
+				m.blockAtTimestamp = eth.L2BlockRef{Number: 100, Hash: common.HexToHash("0x1")}
+				m.callLog = cl
+			}).
+			Build()
+
+		chain10 := h.Mock(10).id
+
+		// The only chain is invalidated — no chain should be resumed.
+		invalidResult := Result{
+			Timestamp:   1000,
+			L1Inclusion: eth.BlockID{Number: 100, Hash: common.HexToHash("0xL1")},
+			L2Heads: map[eth.ChainID]eth.BlockID{
+				chain10: {Number: 500, Hash: common.HexToHash("0xL2-10")},
+			},
+			InvalidHeads: map[eth.ChainID]eth.BlockID{
+				chain10: {Number: 500, Hash: common.HexToHash("0xBAD")},
+			},
+		}
+
+		pending, err := h.interop.buildPendingTransition(
+			StepOutput{Decision: DecisionInvalidate, Result: invalidResult},
+			RoundObservation{},
+		)
+		require.NoError(t, err)
+		require.NoError(t, h.interop.verifiedDB.SetPendingTransition(pending))
+		_, err = h.interop.applyPendingTransition(pending)
+		require.NoError(t, err)
+
+		require.Equal(t, 1, h.Mock(10).pauseAndStopVNCalls, "chain should be frozen")
+		require.Equal(t, 0, h.Mock(10).resumeCalls, "invalidated chain should NOT be resumed")
+
+		entries := cl.snapshot()
+		for _, e := range entries {
+			require.NotEqual(t, "Resume", e.method, "no Resume calls expected when all chains are invalidated")
+		}
 	})
 }

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -1259,6 +1259,7 @@ func (m *mockChainContainer) Start(ctx context.Context) error                  {
 func (m *mockChainContainer) Stop(ctx context.Context) error                   { return nil }
 func (m *mockChainContainer) Pause(ctx context.Context) error                  { return nil }
 func (m *mockChainContainer) Resume(ctx context.Context) error                 { return nil }
+func (m *mockChainContainer) PauseAndStopVN(ctx context.Context) error         { return nil }
 func (m *mockChainContainer) RegisterVerifier(v activity.VerificationActivity) {}
 func (m *mockChainContainer) VerifierCurrentL1s() []eth.BlockID                { return nil }
 func (m *mockChainContainer) LocalSafeBlockAtTimestamp(ctx context.Context, ts uint64) (eth.L2BlockRef, error) {

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -1288,10 +1288,10 @@ func newMockChainContainer(id uint64) *mockChainContainer {
 	return &mockChainContainer{id: eth.ChainIDFromUInt64(id)}
 }
 
-func (m *mockChainContainer) ID() eth.ChainID                                  { return m.id }
-func (m *mockChainContainer) Start(ctx context.Context) error                  { return nil }
-func (m *mockChainContainer) Stop(ctx context.Context) error                   { return nil }
-func (m *mockChainContainer) Pause(ctx context.Context) error                  { return nil }
+func (m *mockChainContainer) ID() eth.ChainID                 { return m.id }
+func (m *mockChainContainer) Start(ctx context.Context) error { return nil }
+func (m *mockChainContainer) Stop(ctx context.Context) error  { return nil }
+func (m *mockChainContainer) Pause(ctx context.Context) error { return nil }
 func (m *mockChainContainer) Resume(ctx context.Context) error {
 	m.mu.Lock()
 	m.resumeCalls++

--- a/op-supernode/supernode/activity/supernode/supernode_test.go
+++ b/op-supernode/supernode/activity/supernode/supernode_test.go
@@ -27,7 +27,8 @@ type mockCC struct {
 func (m *mockCC) Start(ctx context.Context) error  { return nil }
 func (m *mockCC) Stop(ctx context.Context) error   { return nil }
 func (m *mockCC) Pause(ctx context.Context) error  { return nil }
-func (m *mockCC) Resume(ctx context.Context) error { return nil }
+func (m *mockCC) Resume(ctx context.Context) error         { return nil }
+func (m *mockCC) PauseAndStopVN(ctx context.Context) error { return nil }
 
 func (m *mockCC) RegisterVerifier(v activity.VerificationActivity) {}
 func (m *mockCC) VerifierCurrentL1s() []eth.BlockID {

--- a/op-supernode/supernode/activity/supernode/supernode_test.go
+++ b/op-supernode/supernode/activity/supernode/supernode_test.go
@@ -24,9 +24,9 @@ type mockCC struct {
 	syncStatusErr error
 }
 
-func (m *mockCC) Start(ctx context.Context) error  { return nil }
-func (m *mockCC) Stop(ctx context.Context) error   { return nil }
-func (m *mockCC) Pause(ctx context.Context) error  { return nil }
+func (m *mockCC) Start(ctx context.Context) error          { return nil }
+func (m *mockCC) Stop(ctx context.Context) error           { return nil }
+func (m *mockCC) Pause(ctx context.Context) error          { return nil }
 func (m *mockCC) Resume(ctx context.Context) error         { return nil }
 func (m *mockCC) PauseAndStopVN(ctx context.Context) error { return nil }
 

--- a/op-supernode/supernode/activity/superroot/superroot_test.go
+++ b/op-supernode/supernode/activity/superroot/superroot_test.go
@@ -34,7 +34,8 @@ type mockCC struct {
 func (m *mockCC) Start(ctx context.Context) error  { return nil }
 func (m *mockCC) Stop(ctx context.Context) error   { return nil }
 func (m *mockCC) Pause(ctx context.Context) error  { return nil }
-func (m *mockCC) Resume(ctx context.Context) error { return nil }
+func (m *mockCC) Resume(ctx context.Context) error         { return nil }
+func (m *mockCC) PauseAndStopVN(ctx context.Context) error { return nil }
 
 func (m *mockCC) RegisterVerifier(v activity.VerificationActivity) {}
 func (m *mockCC) VerifierCurrentL1s() []eth.BlockID {

--- a/op-supernode/supernode/activity/superroot/superroot_test.go
+++ b/op-supernode/supernode/activity/superroot/superroot_test.go
@@ -31,9 +31,9 @@ type mockCC struct {
 	syncStatusErr error
 }
 
-func (m *mockCC) Start(ctx context.Context) error  { return nil }
-func (m *mockCC) Stop(ctx context.Context) error   { return nil }
-func (m *mockCC) Pause(ctx context.Context) error  { return nil }
+func (m *mockCC) Start(ctx context.Context) error          { return nil }
+func (m *mockCC) Stop(ctx context.Context) error           { return nil }
+func (m *mockCC) Pause(ctx context.Context) error          { return nil }
 func (m *mockCC) Resume(ctx context.Context) error         { return nil }
 func (m *mockCC) PauseAndStopVN(ctx context.Context) error { return nil }
 

--- a/op-supernode/supernode/chain_container/chain_container.go
+++ b/op-supernode/supernode/chain_container/chain_container.go
@@ -27,13 +27,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-const (
-	virtualNodeVersion = "0.1.0"
-	// maxRewindAttempts is the maximum number of times RewindEngine will retry a transient
-	// rewind error before giving up. Prevents infinite retry loops when the engine
-	// consistently rejects synthetic payloads or FCU calls.
-	maxRewindAttempts = 10
-)
+const virtualNodeVersion = "0.1.0"
 
 type ChainContainer interface {
 	Start(ctx context.Context) error
@@ -564,23 +558,20 @@ func (c *simpleChainContainer) RewindEngine(ctx context.Context, timestamp uint6
 	c.log.Info("chain_container/RewindEngine: stopped vn")
 
 retryLoop:
-	for attempt := 1; ; attempt++ {
+	for {
 		err = c.engine.RewindToTimestamp(ctx, timestamp)
 		switch {
 		case errors.Is(err, context.DeadlineExceeded):
-			c.log.Error("chain_container/RewindEngine: timeout exceeded", "attempt", attempt, "timestamp", timestamp)
+			c.log.Error("chain_container/RewindEngine: timeout exceeded")
 			return err
 		case isCriticalRewindError(err):
-			c.log.Error("chain_container/RewindEngine: critical error", "err", err, "attempt", attempt, "timestamp", timestamp)
+			c.log.Error("chain_container/RewindEngine: critical error", "err", err)
 			return err
 		case err == nil:
-			c.log.Info("chain_container/RewindEngine: executed engine rewind", "attempts", attempt, "timestamp", timestamp)
+			c.log.Info("chain_container/RewindEngine: executed engine rewind")
 			break retryLoop
-		case attempt >= maxRewindAttempts:
-			c.log.Error("chain_container/RewindEngine: max retry attempts reached, giving up", "err", err, "attempt", attempt, "timestamp", timestamp)
-			return err
 		default:
-			c.log.Error("chain_container/RewindEngine: temporary error, retrying", "err", err, "attempt", attempt, "timestamp", timestamp)
+			c.log.Error("chain_container/RewindEngine: temporary error", "err", err)
 			select {
 			case <-ctx.Done():
 				return ctx.Err()

--- a/op-supernode/supernode/chain_container/chain_container.go
+++ b/op-supernode/supernode/chain_container/chain_container.go
@@ -27,7 +27,13 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-const virtualNodeVersion = "0.1.0"
+const (
+	virtualNodeVersion = "0.1.0"
+	// maxRewindAttempts is the maximum number of times RewindEngine will retry a transient
+	// rewind error before giving up. Prevents infinite retry loops when the engine
+	// consistently rejects synthetic payloads or FCU calls.
+	maxRewindAttempts = 10
+)
 
 type ChainContainer interface {
 	Start(ctx context.Context) error
@@ -71,6 +77,10 @@ type ChainContainer interface {
 	// PruneDeniedAtOrAfterTimestamp removes deny-list entries with DecisionTimestamp >= timestamp.
 	// Returns map of removed hashes by height.
 	PruneDeniedAtOrAfterTimestamp(timestamp uint64) (map[uint64][]common.Hash, error)
+	// PauseAndStopVN pauses the chain container restart loop and stops the virtual node.
+	// This is used to freeze a chain's VN before a multi-chain rewind begins, preventing
+	// the VN from issuing forkchoice updates that race with the rewind of a peer chain.
+	PauseAndStopVN(ctx context.Context) error
 	// IsDenied checks if a block hash is on the deny list at the given height.
 	IsDenied(height uint64, payloadHash common.Hash) (bool, error)
 	// SetResetCallback sets a callback that is invoked when the chain resets.
@@ -554,20 +564,23 @@ func (c *simpleChainContainer) RewindEngine(ctx context.Context, timestamp uint6
 	c.log.Info("chain_container/RewindEngine: stopped vn")
 
 retryLoop:
-	for {
+	for attempt := 1; ; attempt++ {
 		err = c.engine.RewindToTimestamp(ctx, timestamp)
 		switch {
 		case errors.Is(err, context.DeadlineExceeded):
-			c.log.Error("chain_container/RewindEngine: timeout exceeded")
+			c.log.Error("chain_container/RewindEngine: timeout exceeded", "attempt", attempt, "timestamp", timestamp)
 			return err
 		case isCriticalRewindError(err):
-			c.log.Error("chain_container/RewindEngine: critical error", "err", err)
+			c.log.Error("chain_container/RewindEngine: critical error", "err", err, "attempt", attempt, "timestamp", timestamp)
 			return err
 		case err == nil:
-			c.log.Info("chain_container/RewindEngine: executed engine rewind")
+			c.log.Info("chain_container/RewindEngine: executed engine rewind", "attempts", attempt, "timestamp", timestamp)
 			break retryLoop
+		case attempt >= maxRewindAttempts:
+			c.log.Error("chain_container/RewindEngine: max retry attempts reached, giving up", "err", err, "attempt", attempt, "timestamp", timestamp)
+			return err
 		default:
-			c.log.Error("chain_container/RewindEngine: temporary error", "err", err)
+			c.log.Error("chain_container/RewindEngine: temporary error, retrying", "err", err, "attempt", attempt, "timestamp", timestamp)
 			select {
 			case <-ctx.Done():
 				return ctx.Err()
@@ -589,6 +602,20 @@ retryLoop:
 	c.log.Info("chain_container/RewindEngine: resumed container")
 
 	return nil
+}
+
+// PauseAndStopVN pauses the container restart loop and stops the running virtual node.
+// This must be called before a multi-chain rewind to prevent a peer chain's VN from
+// issuing forkchoice updates that race with the rewind operation.
+// RewindEngine's own Pause+Stop calls are idempotent when called after this.
+func (c *simpleChainContainer) PauseAndStopVN(ctx context.Context) error {
+	if err := c.Pause(ctx); err != nil {
+		return err
+	}
+	if c.vn == nil {
+		return nil
+	}
+	return c.vn.Stop(ctx)
 }
 
 // SetResetCallback sets a callback that is invoked when the chain resets.

--- a/op-supernode/supernode/chain_container/engine_controller/rewind.go
+++ b/op-supernode/supernode/chain_container/engine_controller/rewind.go
@@ -128,12 +128,18 @@ func (e *simpleEngineController) insertSyntheticPayload(ctx context.Context, blo
 	syntheticHash, _ := newEnvelope.CheckBlockHash() // ignore "ok" since we know it won't match
 	newPayload.BlockHash = syntheticHash
 
+	e.log.Info("inserting synthetic payload", "blockNumber", blockNumber, "parentHash", newPayload.ParentHash, "syntheticHash", syntheticHash)
 	status, err := e.l2.NewPayload(ctx, &newPayload, envelope.ParentBeaconBlockRoot)
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("%w: %w", ErrRewindInsertSyntheticFailed, err)
 	}
 	if status.Status != eth.ExecutionValid {
-		return common.Hash{}, fmt.Errorf("%w: status=%s", ErrRewindSyntheticPayloadRejected, status.Status)
+		validationErr := ""
+		if status.ValidationError != nil {
+			validationErr = *status.ValidationError
+		}
+		return common.Hash{}, fmt.Errorf("%w: status=%s validationError=%q blockNumber=%d parentHash=%s syntheticHash=%s",
+			ErrRewindSyntheticPayloadRejected, status.Status, validationErr, blockNumber, newPayload.ParentHash, syntheticHash)
 	}
 
 	return syntheticHash, nil
@@ -189,7 +195,12 @@ func (e *simpleEngineController) forkchoiceUpdate(ctx context.Context, head, saf
 		return err
 	}
 	if res.PayloadStatus.Status != eth.ExecutionValid {
-		return fmt.Errorf("%w: status=%s", ErrRewindFCURejected, res.PayloadStatus.Status)
+		validationErr := ""
+		if res.PayloadStatus.ValidationError != nil {
+			validationErr = *res.PayloadStatus.ValidationError
+		}
+		return fmt.Errorf("%w: status=%s validationError=%q head=%s safe=%s finalized=%s",
+			ErrRewindFCURejected, res.PayloadStatus.Status, validationErr, head, safe, finalized)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

- Freeze **all** chains' virtual nodes before executing any invalidation rewind, not just the ones being invalidated
- Prevents a race where a non-invalidated chain's VN reacts to the `onReset` state change and advances its safe head, causing its own later rewind to be rejected
- Adds `maxRewindAttempts` (10) to prevent infinite retry loops on persistent rewind failures
- Adds better error diagnostics in engine controller rewind (validation errors, block numbers, hashes)

## Problem

When the interop activity invalidates blocks, `RewindEngine`'s `onReset` callback modifies shared state (prunes verifiedDB, resets currentL1). A peer chain's still-running VN can observe this change and issue a ForkchoiceUpdate that advances its safe head. If that chain is later invalidated — in the same round (cycle) or a subsequent round (transitive) — its rewind is rejected as INVALID.

This particularly affects `TestSupernodeSameTimestampInvalidTransitive` where transitive invalidation requires multiple verification rounds:
1. **Round 1**: Chain B has invalid exec (bad log index) → B invalidated and rewound
2. Between rounds, chain A's VN reacts to B's reset state change
3. **Round 2**: Chain A's exec references B's now-replaced init → A invalidated
4. **A's rewind fails** because its safe head was already advanced by the VN's FCU in step 2

## Relationship to ethereum-optimism/optimism#19558

PR ethereum-optimism/optimism#19558 freezes only the **invalid** chains' VNs before rewinding. This fixes the cycle test (both chains invalid in one pass) but not the transitive test (only one chain invalid per pass — the other chain's VN is never frozen). This PR takes the broader approach of freezing all chains.

Closes ethereum-optimism/optimism#19570

## Test plan

- [x] `go build ./op-supernode/...` passes
- [x] `go test ./op-supernode/supernode/activity/interop/...` passes
- [x] `go test ./op-supernode/supernode/activity/supernode/...` passes
- [x] `go test ./op-supernode/supernode/activity/superroot/...` passes
- [x] `go test ./op-supernode/supernode/chain_container/...` passes
- [ ] CI: `memory-all-opn-op-geth` acceptance tests pass (TestSupernodeSameTimestampInvalidTransitive, TestSupernodeSameTimestampCycle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

closes #19558 