### PR TITLE
exp: test freeze-all-then-resume ordering in interop invalidation

### DIFF
--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -1214,6 +1214,33 @@ func (m *mockBlockInfo) ID() eth.BlockID                                      { 
 
 var _ eth.BlockInfo = (*mockBlockInfo)(nil)
 
+// callLog records the order of method calls across multiple mock chain containers.
+// Tests use it to verify that operations happen in the expected sequence
+// (e.g., all freezes before any invalidation).
+type callLog struct {
+	mu      sync.Mutex
+	entries []callLogEntry
+}
+
+type callLogEntry struct {
+	chainID eth.ChainID
+	method  string
+}
+
+func (cl *callLog) record(chainID eth.ChainID, method string) {
+	cl.mu.Lock()
+	defer cl.mu.Unlock()
+	cl.entries = append(cl.entries, callLogEntry{chainID: chainID, method: method})
+}
+
+func (cl *callLog) snapshot() []callLogEntry {
+	cl.mu.Lock()
+	defer cl.mu.Unlock()
+	out := make([]callLogEntry, len(cl.entries))
+	copy(out, cl.entries)
+	return out
+}
+
 type mockChainContainer struct {
 	id eth.ChainID
 
@@ -1243,6 +1270,13 @@ type mockChainContainer struct {
 	optimisticL2    eth.BlockID
 	optimisticL1    eth.BlockID
 	optimisticAtErr error
+
+	// PauseAndStopVN / Resume tracking
+	pauseAndStopVNCalls int
+	pauseAndStopVNErr   error
+	resumeCalls         int
+	resumeErr           error
+	callLog             *callLog // shared ordered call log across mocks
 }
 
 type invalidateBlockCall struct {
@@ -1258,8 +1292,24 @@ func (m *mockChainContainer) ID() eth.ChainID                                  {
 func (m *mockChainContainer) Start(ctx context.Context) error                  { return nil }
 func (m *mockChainContainer) Stop(ctx context.Context) error                   { return nil }
 func (m *mockChainContainer) Pause(ctx context.Context) error                  { return nil }
-func (m *mockChainContainer) Resume(ctx context.Context) error                 { return nil }
-func (m *mockChainContainer) PauseAndStopVN(ctx context.Context) error         { return nil }
+func (m *mockChainContainer) Resume(ctx context.Context) error {
+	m.mu.Lock()
+	m.resumeCalls++
+	m.mu.Unlock()
+	if m.callLog != nil {
+		m.callLog.record(m.id, "Resume")
+	}
+	return m.resumeErr
+}
+func (m *mockChainContainer) PauseAndStopVN(ctx context.Context) error {
+	m.mu.Lock()
+	m.pauseAndStopVNCalls++
+	m.mu.Unlock()
+	if m.callLog != nil {
+		m.callLog.record(m.id, "PauseAndStopVN")
+	}
+	return m.pauseAndStopVNErr
+}
 func (m *mockChainContainer) RegisterVerifier(v activity.VerificationActivity) {}
 func (m *mockChainContainer) VerifierCurrentL1s() []eth.BlockID                { return nil }
 func (m *mockChainContainer) LocalSafeBlockAtTimestamp(ctx context.Context, ts uint64) (eth.L2BlockRef, error) {
@@ -1357,8 +1407,11 @@ func (m *mockChainContainer) RewindEngine(ctx context.Context, timestamp uint64,
 func (m *mockChainContainer) BlockTime() uint64 { return 1 }
 func (m *mockChainContainer) InvalidateBlock(ctx context.Context, height uint64, payloadHash common.Hash, decisionTimestamp uint64) (bool, error) {
 	m.mu.Lock()
-	defer m.mu.Unlock()
 	m.invalidateBlockCalls = append(m.invalidateBlockCalls, invalidateBlockCall{height: height, payloadHash: payloadHash})
+	m.mu.Unlock()
+	if m.callLog != nil {
+		m.callLog.record(m.id, "InvalidateBlock")
+	}
 	return m.invalidateBlockRet, m.invalidateBlockErr
 }
 func (m *mockChainContainer) PruneDeniedAtOrAfterTimestamp(timestamp uint64) (map[uint64][]common.Hash, error) {
@@ -1980,5 +2033,239 @@ func TestVerifiedBlockAtL1(t *testing.T) {
 		blockID, ts := h.interop.VerifiedBlockAtL1(h.Mock(10).id, l1Block)
 		require.Equal(t, eth.BlockID{}, blockID)
 		require.Equal(t, uint64(0), ts)
+	})
+}
+
+// =============================================================================
+// TestFreezeAllBeforeRewind
+// =============================================================================
+
+// TestFreezeAllBeforeRewind verifies the freeze-all-then-resume behavior
+// introduced in applyPendingTransition for DecisionInvalidate:
+//   - All chains (not just invalidated ones) are frozen via PauseAndStopVN
+//     before any invalidateBlock call
+//   - Only non-invalidated chains are resumed after the invalidation loop
+//   - Invalidated chains are NOT resumed (RewindEngine handles that internally)
+func TestFreezeAllBeforeRewind(t *testing.T) {
+	t.Parallel()
+
+	t.Run("all chains frozen before any invalidation", func(t *testing.T) {
+		cl := &callLog{}
+		h := newInteropTestHarness(t).
+			WithChain(10, func(m *mockChainContainer) {
+				m.blockAtTimestamp = eth.L2BlockRef{Number: 100, Hash: common.HexToHash("0x1")}
+				m.callLog = cl
+			}).
+			WithChain(8453, func(m *mockChainContainer) {
+				m.blockAtTimestamp = eth.L2BlockRef{Number: 200, Hash: common.HexToHash("0x2")}
+				m.callLog = cl
+			}).
+			WithChain(42, func(m *mockChainContainer) {
+				m.blockAtTimestamp = eth.L2BlockRef{Number: 300, Hash: common.HexToHash("0x3")}
+				m.callLog = cl
+			}).
+			Build()
+
+		chain10 := h.Mock(10).id
+		chain8453 := h.Mock(8453).id
+
+		// Only chain 10 is invalidated; chains 8453 and 42 are valid.
+		invalidResult := Result{
+			Timestamp:   1000,
+			L1Inclusion: eth.BlockID{Number: 100, Hash: common.HexToHash("0xL1")},
+			L2Heads: map[eth.ChainID]eth.BlockID{
+				chain10:   {Number: 500, Hash: common.HexToHash("0xL2-10")},
+				chain8453: {Number: 600, Hash: common.HexToHash("0xL2-8453")},
+			},
+			InvalidHeads: map[eth.ChainID]eth.BlockID{
+				chain10: {Number: 500, Hash: common.HexToHash("0xBAD")},
+			},
+		}
+
+		pending, err := h.interop.buildPendingTransition(
+			StepOutput{Decision: DecisionInvalidate, Result: invalidResult},
+			RoundObservation{},
+		)
+		require.NoError(t, err)
+		require.NoError(t, h.interop.verifiedDB.SetPendingTransition(pending))
+		_, err = h.interop.applyPendingTransition(pending)
+		require.NoError(t, err)
+
+		entries := cl.snapshot()
+
+		// All three chains must have PauseAndStopVN called.
+		require.Equal(t, 1, h.Mock(10).pauseAndStopVNCalls, "chain 10 should be frozen")
+		require.Equal(t, 1, h.Mock(8453).pauseAndStopVNCalls, "chain 8453 should be frozen")
+		require.Equal(t, 1, h.Mock(42).pauseAndStopVNCalls, "chain 42 should be frozen")
+
+		// Find the index of the first InvalidateBlock call.
+		firstInvalidateIdx := -1
+		for i, e := range entries {
+			if e.method == "InvalidateBlock" {
+				firstInvalidateIdx = i
+				break
+			}
+		}
+		require.NotEqual(t, -1, firstInvalidateIdx, "should have at least one InvalidateBlock call")
+
+		// Every PauseAndStopVN must come before the first InvalidateBlock.
+		for i, e := range entries {
+			if e.method == "PauseAndStopVN" {
+				require.Less(t, i, firstInvalidateIdx,
+					"PauseAndStopVN on chain %s (index %d) must precede first InvalidateBlock (index %d)",
+					e.chainID, i, firstInvalidateIdx)
+			}
+		}
+	})
+
+	t.Run("only non-invalidated chains are resumed", func(t *testing.T) {
+		cl := &callLog{}
+		h := newInteropTestHarness(t).
+			WithChain(10, func(m *mockChainContainer) {
+				m.blockAtTimestamp = eth.L2BlockRef{Number: 100, Hash: common.HexToHash("0x1")}
+				m.callLog = cl
+			}).
+			WithChain(8453, func(m *mockChainContainer) {
+				m.blockAtTimestamp = eth.L2BlockRef{Number: 200, Hash: common.HexToHash("0x2")}
+				m.callLog = cl
+			}).
+			WithChain(42, func(m *mockChainContainer) {
+				m.blockAtTimestamp = eth.L2BlockRef{Number: 300, Hash: common.HexToHash("0x3")}
+				m.callLog = cl
+			}).
+			Build()
+
+		chain10 := h.Mock(10).id
+		chain8453 := h.Mock(8453).id
+		chain42 := h.Mock(42).id
+
+		// Chains 10 and 8453 are invalidated; chain 42 is valid.
+		invalidResult := Result{
+			Timestamp:   1000,
+			L1Inclusion: eth.BlockID{Number: 100, Hash: common.HexToHash("0xL1")},
+			L2Heads: map[eth.ChainID]eth.BlockID{
+				chain10:   {Number: 500, Hash: common.HexToHash("0xL2-10")},
+				chain8453: {Number: 600, Hash: common.HexToHash("0xL2-8453")},
+				chain42:   {Number: 700, Hash: common.HexToHash("0xL2-42")},
+			},
+			InvalidHeads: map[eth.ChainID]eth.BlockID{
+				chain10:   {Number: 500, Hash: common.HexToHash("0xBAD10")},
+				chain8453: {Number: 600, Hash: common.HexToHash("0xBAD8453")},
+			},
+		}
+
+		pending, err := h.interop.buildPendingTransition(
+			StepOutput{Decision: DecisionInvalidate, Result: invalidResult},
+			RoundObservation{},
+		)
+		require.NoError(t, err)
+		require.NoError(t, h.interop.verifiedDB.SetPendingTransition(pending))
+		_, err = h.interop.applyPendingTransition(pending)
+		require.NoError(t, err)
+
+		// Only chain 42 (non-invalidated) should have Resume called.
+		require.Equal(t, 0, h.Mock(10).resumeCalls, "invalidated chain 10 should NOT be resumed")
+		require.Equal(t, 0, h.Mock(8453).resumeCalls, "invalidated chain 8453 should NOT be resumed")
+		require.Equal(t, 1, h.Mock(42).resumeCalls, "non-invalidated chain 42 should be resumed")
+	})
+
+	t.Run("resume happens after all invalidations", func(t *testing.T) {
+		cl := &callLog{}
+		h := newInteropTestHarness(t).
+			WithChain(10, func(m *mockChainContainer) {
+				m.blockAtTimestamp = eth.L2BlockRef{Number: 100, Hash: common.HexToHash("0x1")}
+				m.callLog = cl
+			}).
+			WithChain(8453, func(m *mockChainContainer) {
+				m.blockAtTimestamp = eth.L2BlockRef{Number: 200, Hash: common.HexToHash("0x2")}
+				m.callLog = cl
+			}).
+			Build()
+
+		chain10 := h.Mock(10).id
+		chain8453 := h.Mock(8453).id
+
+		// Only chain 10 is invalidated.
+		invalidResult := Result{
+			Timestamp:   1000,
+			L1Inclusion: eth.BlockID{Number: 100, Hash: common.HexToHash("0xL1")},
+			L2Heads: map[eth.ChainID]eth.BlockID{
+				chain10:   {Number: 500, Hash: common.HexToHash("0xL2-10")},
+				chain8453: {Number: 600, Hash: common.HexToHash("0xL2-8453")},
+			},
+			InvalidHeads: map[eth.ChainID]eth.BlockID{
+				chain10: {Number: 500, Hash: common.HexToHash("0xBAD")},
+			},
+		}
+
+		pending, err := h.interop.buildPendingTransition(
+			StepOutput{Decision: DecisionInvalidate, Result: invalidResult},
+			RoundObservation{},
+		)
+		require.NoError(t, err)
+		require.NoError(t, h.interop.verifiedDB.SetPendingTransition(pending))
+		_, err = h.interop.applyPendingTransition(pending)
+		require.NoError(t, err)
+
+		entries := cl.snapshot()
+
+		// Find the last InvalidateBlock index.
+		lastInvalidateIdx := -1
+		for i, e := range entries {
+			if e.method == "InvalidateBlock" {
+				lastInvalidateIdx = i
+			}
+		}
+		require.NotEqual(t, -1, lastInvalidateIdx)
+
+		// Every Resume must come after the last InvalidateBlock.
+		for i, e := range entries {
+			if e.method == "Resume" {
+				require.Greater(t, i, lastInvalidateIdx,
+					"Resume on chain %s (index %d) must follow last InvalidateBlock (index %d)",
+					e.chainID, i, lastInvalidateIdx)
+			}
+		}
+	})
+
+	t.Run("single chain invalidated freezes and does not resume", func(t *testing.T) {
+		cl := &callLog{}
+		h := newInteropTestHarness(t).
+			WithChain(10, func(m *mockChainContainer) {
+				m.blockAtTimestamp = eth.L2BlockRef{Number: 100, Hash: common.HexToHash("0x1")}
+				m.callLog = cl
+			}).
+			Build()
+
+		chain10 := h.Mock(10).id
+
+		// The only chain is invalidated — no chain should be resumed.
+		invalidResult := Result{
+			Timestamp:   1000,
+			L1Inclusion: eth.BlockID{Number: 100, Hash: common.HexToHash("0xL1")},
+			L2Heads: map[eth.ChainID]eth.BlockID{
+				chain10: {Number: 500, Hash: common.HexToHash("0xL2-10")},
+			},
+			InvalidHeads: map[eth.ChainID]eth.BlockID{
+				chain10: {Number: 500, Hash: common.HexToHash("0xBAD")},
+			},
+		}
+
+		pending, err := h.interop.buildPendingTransition(
+			StepOutput{Decision: DecisionInvalidate, Result: invalidResult},
+			RoundObservation{},
+		)
+		require.NoError(t, err)
+		require.NoError(t, h.interop.verifiedDB.SetPendingTransition(pending))
+		_, err = h.interop.applyPendingTransition(pending)
+		require.NoError(t, err)
+
+		require.Equal(t, 1, h.Mock(10).pauseAndStopVNCalls, "chain should be frozen")
+		require.Equal(t, 0, h.Mock(10).resumeCalls, "invalidated chain should NOT be resumed")
+
+		entries := cl.snapshot()
+		for _, e := range entries {
+			require.NotEqual(t, "Resume", e.method, "no Resume calls expected when all chains are invalidated")
+		}
 	})
 }


### PR DESCRIPTION
## Summary

- Adds `TestFreezeAllBeforeRewind` with 4 sub-tests verifying the call ordering of the freeze-all-chains step introduced in ethereum-optimism/optimism#19571
- Extends `mockChainContainer` with call tracking for `PauseAndStopVN`, `Resume`, and `InvalidateBlock`
- Introduces a shared `callLog` type for cross-mock call ordering assertions

## What's tested

1. **All chains frozen before any rewind** — `PauseAndStopVN` is called on every chain (including non-invalidated ones) before the first `InvalidateBlock` call
2. **Only non-invalidated chains resumed** — `Resume` is called only on chains NOT in `InvalidHeads`; invalidated chains are left for `RewindEngine` to resume
3. **Resume after all invalidations** — All `Resume` calls happen strictly after the last `InvalidateBlock`
4. **Single-chain edge case** — When the only chain is invalidated, no `Resume` calls are made at all

## Decisions Made

- Used a shared `callLog` with mutex-protected append for ordering assertions rather than timestamps (deterministic, no clock skew)
- Kept mock extensions minimal — only added fields actually needed by the new tests
- Tests operate directly on `applyPendingTransition` rather than going through the full `progressAndRecord` path, matching the existing test patterns for WAL/invalidation tests

## Test plan

- [x] `go test ./op-supernode/supernode/activity/interop/... -run TestFreezeAllBeforeRewind -v` — all 4 sub-tests pass
- [x] `go test ./op-supernode/supernode/activity/interop/...` — full suite passes (no regressions)
- [x] `go vet` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)