### PR TITLE
feat: split gotestsum logs into per-test files

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -952,7 +952,7 @@ jobs:
             if [ "$SKIP_SLOW_TESTS" = "false" ]; then
               TIMEOUT="45m"
             fi
-            gotestsum --format=testname --junitfile=../tmp/test-results/cannon-64.xml --jsonfile=../tmp/testlogs/log-64.json \
+            ../ops/scripts/gotestsum-split.sh --format=testname --junitfile=../tmp/test-results/cannon-64.xml --jsonfile=../tmp/testlogs/log-64.json \
             -- -timeout=$TIMEOUT -parallel=$(nproc) -coverpkg=github.com/ethereum-optimism/optimism/cannon/... -coverprofile=coverage-64.out ./...
           working_directory: cannon
       - codecov/upload:

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -1920,12 +1920,7 @@ jobs:
           path: ./tmp/test-results
       - run:
           name: Compress test logs
-          command: |
-            if [ -n "$CIRCLE_NODE_TOTAL" ] && [ "$CIRCLE_NODE_TOTAL" -gt 1 ]; then
-              tar -czf testlogs-${CIRCLE_NODE_INDEX}-of-${CIRCLE_NODE_TOTAL}.tar.gz -C ./tmp testlogs
-            else
-              tar -czf testlogs.tar.gz -C ./tmp testlogs
-            fi
+          command: tar -czf testlogs.tar.gz -C ./tmp testlogs
           when: always
       - run:
           name: Clean up op-deployer artifacts
@@ -1933,7 +1928,7 @@ jobs:
             rm -rf ~/.op-deployer/*
           when: always
       - store_artifacts:
-          path: testlogs*.tar.gz
+          path: testlogs.tar.gz
           when: always
       - when:
           condition: "<<parameters.notify>>"

--- a/justfile
+++ b/justfile
@@ -277,7 +277,7 @@ _go-tests-ci-internal go_test_flags="":
       PARALLEL_PACKAGES=$(echo "$ALL_PACKAGES" | tr ' ' '\n' | awk -v idx="$NODE_INDEX" -v total="$NODE_TOTAL" 'NR % total == idx' | tr '\n' ' ')
       if [ -n "$PARALLEL_PACKAGES" ]; then
           echo "Node $NODE_INDEX/$NODE_TOTAL running packages: $PARALLEL_PACKAGES"
-          gotestsum --format=testname \
+          ./ops/scripts/gotestsum-split.sh --format=testname \
               --junitfile=./tmp/test-results/results-"$NODE_INDEX".xml \
               --jsonfile=./tmp/testlogs/log-"$NODE_INDEX".json \
               --rerun-fails=3 \
@@ -289,7 +289,7 @@ _go-tests-ci-internal go_test_flags="":
           exit 1
       fi
   else
-      gotestsum --format=testname \
+      ./ops/scripts/gotestsum-split.sh --format=testname \
           --junitfile=./tmp/test-results/results.xml \
           --jsonfile=./tmp/testlogs/log.json \
           --rerun-fails=3 \
@@ -327,7 +327,7 @@ go-tests-fraud-proofs-ci:
   export MAINNET_RPC_URL="https://ci-mainnet-l1-archive.optimism.io"
   export NAT_INTEROP_LOADTEST_TARGET=10
   export NAT_INTEROP_LOADTEST_TIMEOUT=30s
-  gotestsum --format=testname \
+  ./ops/scripts/gotestsum-split.sh --format=testname \
       --junitfile=./tmp/test-results/results.xml \
       --jsonfile=./tmp/testlogs/log.json \
       --rerun-fails=3 \

--- a/op-e2e/justfile
+++ b/op-e2e/justfile
@@ -6,7 +6,7 @@ JUNIT_FILE := env('JUNIT_FILE', '')
 JSON_LOG_FILE := env('JSON_LOG_FILE', '')
 
 _go_test := if JUNIT_FILE != "" {
-    "OP_TESTLOG_DISABLE_COLOR=true OP_E2E_DISABLE_PARALLEL=false gotestsum --format=testname --junitfile=" + JUNIT_FILE + " --jsonfile=" + JSON_LOG_FILE + " -- -failfast"
+    "OP_TESTLOG_DISABLE_COLOR=true OP_E2E_DISABLE_PARALLEL=false ../ops/scripts/gotestsum-split.sh --format=testname --junitfile=" + JUNIT_FILE + " --jsonfile=" + JSON_LOG_FILE + " -- -failfast"
 } else {
     "go test"
 }

--- a/ops/scripts/gotestsum-split.sh
+++ b/ops/scripts/gotestsum-split.sh
@@ -42,5 +42,9 @@ gotestsum "$@"
 GOTESTSUM_EXIT=$?
 
 "$SCRIPT_DIR/split-test-logs.sh" "$json_file"
+SPLIT_EXIT=$?
 
+if [ $SPLIT_EXIT -ne 0 ]; then
+  exit $SPLIT_EXIT
+fi
 exit $GOTESTSUM_EXIT

--- a/ops/scripts/gotestsum-split.sh
+++ b/ops/scripts/gotestsum-split.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# gotestsum-split.sh — Drop-in gotestsum wrapper that splits JSON logs per test.
+#
+# Usage: gotestsum-split.sh [gotestsum args...]
+#
+# Drop-in replacement for gotestsum. Passes all arguments through, then splits
+# the --jsonfile output into per-test log files via split-test-logs.sh.
+#
+# If --jsonfile is not provided, the wrapper adds one automatically using a
+# default path (tmp/testlogs/log.json relative to cwd), ensuring per-test
+# logs are always generated.
+#
+# Preserves gotestsum's exit code so the split runs even on test failure
+# (when per-test logs are most useful for debugging).
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Scan args for --jsonfile.
+json_file=""
+next_is_jsonfile=false
+for arg in "$@"; do
+  if $next_is_jsonfile; then
+    json_file="$arg"
+    break
+  fi
+  case "$arg" in
+    --jsonfile=*) json_file="${arg#--jsonfile=}" ; break ;;
+    --jsonfile)   next_is_jsonfile=true ;;
+  esac
+done
+
+# If --jsonfile wasn't provided, add one automatically.
+if [ -z "$json_file" ]; then
+  json_file="tmp/testlogs/log.json"
+  mkdir -p "$(dirname "$json_file")"
+  set -- --jsonfile="$json_file" "$@"
+fi
+
+gotestsum "$@"
+GOTESTSUM_EXIT=$?
+
+"$SCRIPT_DIR/split-test-logs.sh" "$json_file"
+
+exit $GOTESTSUM_EXIT

--- a/ops/scripts/split-test-logs.sh
+++ b/ops/scripts/split-test-logs.sh
@@ -7,8 +7,7 @@
 # that test's output lines. Output goes to a "per-test" sibling directory next
 # to the JSON file, organized as <package>/<TestName>.log.
 #
-# Exits 0 on success or if the jsonfile doesn't exist (graceful no-op).
-# Skips silently if python3 is not available.
+# Fails if the jsonfile doesn't exist or python3 is not available.
 
 set -euo pipefail
 
@@ -20,11 +19,13 @@ fi
 json_file="$1"
 
 if [ ! -f "$json_file" ]; then
-  exit 0
+  echo "Error: JSON log file not found: $json_file" >&2
+  exit 1
 fi
 
 if ! command -v python3 &>/dev/null; then
-  exit 0
+  echo "Error: python3 is required but not found" >&2
+  exit 1
 fi
 
 output_dir="$(dirname "$json_file")/per-test"

--- a/ops/scripts/split-test-logs.sh
+++ b/ops/scripts/split-test-logs.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# split-test-logs.sh — Split a gotestsum JSON log file into per-test log files.
+#
+# Usage: split-test-logs.sh <jsonfile>
+#
+# Reads a gotestsum --jsonfile output and writes one file per test containing
+# that test's output lines. Output goes to a "per-test" sibling directory next
+# to the JSON file, organized as <package>/<TestName>.log.
+#
+# Exits 0 on success or if the jsonfile doesn't exist (graceful no-op).
+# Skips silently if python3 is not available.
+
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 <jsonfile>" >&2
+  exit 1
+fi
+
+json_file="$1"
+
+if [ ! -f "$json_file" ]; then
+  exit 0
+fi
+
+if ! command -v python3 &>/dev/null; then
+  exit 0
+fi
+
+output_dir="$(dirname "$json_file")/per-test"
+
+python3 - "$json_file" "$output_dir" <<'PYEOF'
+import json, os, sys, re
+
+json_file = sys.argv[1]
+output_dir = sys.argv[2]
+
+handles = {}
+
+def get_handle(path):
+    if path not in handles:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        handles[path] = open(path, "w")
+    return handles[path]
+
+def sanitize(name):
+    return re.sub(r'[<>:"|?*]', '_', name)
+
+count = 0
+with open(json_file) as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            ev = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+        test = ev.get("Test")
+        action = ev.get("Action")
+        output = ev.get("Output")
+        package = ev.get("Package", "")
+
+        if not test or action != "output" or output is None:
+            continue
+
+        pkg_dir = sanitize(package.replace("/", "."))
+        test_name = sanitize(test)
+        file_path = os.path.join(output_dir, pkg_dir, f"{test_name}.log")
+
+        fh = get_handle(file_path)
+        fh.write(output)
+        count += 1
+
+for fh in handles.values():
+    fh.close()
+
+print(f"Split {count} output lines across {len(handles)} test files in {output_dir}")
+PYEOF

--- a/rust/kona/tests/justfile
+++ b/rust/kona/tests/justfile
@@ -132,7 +132,7 @@ test-e2e-sysgo-run BINARY="node" GO_PKG_NAME="node/common" DEVNET="simple-kona" 
     # Run the test with count=1 to avoid caching the test results.
     cd {{SOURCE}}
     mkdir -p ./tmp/test-results ./tmp/testlogs
-    {{SOURCE}}/../../ops/scripts/gotestsum-split.sh --format=testname \
+    {{SOURCE}}/../../../ops/scripts/gotestsum-split.sh --format=testname \
         --junitfile=./tmp/test-results/results.xml \
         --jsonfile=./tmp/testlogs/log.json \
         -- -count=1 -timeout 40m ./$GO_PKG_NAME $FILTER
@@ -227,12 +227,12 @@ action-tests-single-run test_name='Test_ProgramAction' parallel="0" *args='':
       < /tmp/tests_shard.txt
     # xargs calls gotestsum multiple times appending to the same jsonfile,
     # so split once at the end rather than wrapping each call.
-    {{SOURCE}}/../../ops/scripts/split-test-logs.sh ./tmp/testlogs/log-$NODE_INDEX.json
+    {{SOURCE}}/../../../ops/scripts/split-test-logs.sh ./tmp/testlogs/log-$NODE_INDEX.json
 
     exit 0
   fi
 
-  {{SOURCE}}/../../ops/scripts/gotestsum-split.sh --format=testname \
+  {{SOURCE}}/../../../ops/scripts/gotestsum-split.sh --format=testname \
     --junitfile=./tmp/test-results/results.xml \
     --jsonfile=./tmp/testlogs/log.json \
     -- -count=1 -parallel=$PARALLEL -coverprofile=coverage.out -timeout=60m -run "{{test_name}}"
@@ -251,7 +251,7 @@ action-tests-interop-run test_name='TestInteropFaultProofs' *args='':
   # https://github.com/gotestyourself/gotestsum/blob/b4b13345fee56744d80016a20b760d3599c13504/testjson/format.go#L442-L444
   echo "Running action tests for the client program on the native target"
 
-  cd {{SOURCE}}/../../op-e2e/actions/interop && GITHUB_ACTIONS=false {{SOURCE}}/../../ops/scripts/gotestsum-split.sh --format=short-verbose -- -count=1 -timeout 60m -run "{{test_name}}" {{args}}
+  cd {{SOURCE}}/../../op-e2e/actions/interop && GITHUB_ACTIONS=false {{SOURCE}}/../../../ops/scripts/gotestsum-split.sh --format=short-verbose -- -count=1 -timeout 60m -run "{{test_name}}" {{args}}
 
 update-packages:
     #!/bin/bash

--- a/rust/kona/tests/justfile
+++ b/rust/kona/tests/justfile
@@ -132,7 +132,7 @@ test-e2e-sysgo-run BINARY="node" GO_PKG_NAME="node/common" DEVNET="simple-kona" 
     # Run the test with count=1 to avoid caching the test results.
     cd {{SOURCE}}
     mkdir -p ./tmp/test-results ./tmp/testlogs
-    gotestsum --format=testname \
+    {{SOURCE}}/../../ops/scripts/gotestsum-split.sh --format=testname \
         --junitfile=./tmp/test-results/results.xml \
         --jsonfile=./tmp/testlogs/log.json \
         -- -count=1 -timeout 40m ./$GO_PKG_NAME $FILTER
@@ -225,11 +225,14 @@ action-tests-single-run test_name='Test_ProgramAction' parallel="0" *args='':
       --jsonfile=./tmp/testlogs/log-$NODE_INDEX.json \
       -- -count=1 -parallel=$PARALLEL -coverprofile=coverage-$NODE_INDEX.out -timeout=60m -run '^{}$' \
       < /tmp/tests_shard.txt
+    # xargs calls gotestsum multiple times appending to the same jsonfile,
+    # so split once at the end rather than wrapping each call.
+    {{SOURCE}}/../../ops/scripts/split-test-logs.sh ./tmp/testlogs/log-$NODE_INDEX.json
 
     exit 0
   fi
 
-  gotestsum --format=testname \
+  {{SOURCE}}/../../ops/scripts/gotestsum-split.sh --format=testname \
     --junitfile=./tmp/test-results/results.xml \
     --jsonfile=./tmp/testlogs/log.json \
     -- -count=1 -parallel=$PARALLEL -coverprofile=coverage.out -timeout=60m -run "{{test_name}}"
@@ -248,7 +251,7 @@ action-tests-interop-run test_name='TestInteropFaultProofs' *args='':
   # https://github.com/gotestyourself/gotestsum/blob/b4b13345fee56744d80016a20b760d3599c13504/testjson/format.go#L442-L444
   echo "Running action tests for the client program on the native target"
 
-  cd {{SOURCE}}/../../op-e2e/actions/interop && GITHUB_ACTIONS=false gotestsum --format=short-verbose -- -count=1 -timeout 60m -run "{{test_name}}" {{args}}
+  cd {{SOURCE}}/../../op-e2e/actions/interop && GITHUB_ACTIONS=false {{SOURCE}}/../../ops/scripts/gotestsum-split.sh --format=short-verbose -- -count=1 -timeout 60m -run "{{test_name}}" {{args}}
 
 update-packages:
     #!/bin/bash

--- a/rust/op-reth/crates/tests/justfile
+++ b/rust/op-reth/crates/tests/justfile
@@ -72,4 +72,5 @@ test-e2e-sysgo: build unzip-contract-artifacts build-contracts
   export OP_RETH_EXEC_PATH="{{SOURCE_DIR}}/../../../target/debug/op-reth"
   export OP_DEVSTACK_PROOF_SEQUENCER_EL="{{OP_DEVSTACK_PROOF_SEQUENCER_EL}}"
   export OP_DEVSTACK_PROOF_VALIDATOR_EL="{{OP_DEVSTACK_PROOF_VALIDATOR_EL}}"
-  go test -count=1 -timeout 40m -v ./{{GO_PKG_NAME}}
+  {{SOURCE_DIR}}/../../../../ops/scripts/gotestsum-split.sh --format=testname \
+    -- -count=1 -timeout 40m ./{{GO_PKG_NAME}}

--- a/rust/op-reth/tests/justfile
+++ b/rust/op-reth/tests/justfile
@@ -42,7 +42,7 @@ test-e2e-sysgo: build-contracts
   export OP_RETH_EXEC_PATH="{{SOURCE_DIR}}/../../target/release/op-reth"
   export OP_DEVSTACK_PROOF_SEQUENCER_EL="{{OP_DEVSTACK_PROOF_SEQUENCER_EL}}"
   export OP_DEVSTACK_PROOF_VALIDATOR_EL="{{OP_DEVSTACK_PROOF_VALIDATOR_EL}}"
-  gotestsum --format=testname \
+  {{SOURCE_DIR}}/../../../ops/scripts/gotestsum-split.sh --format=testname \
     --junitfile=tmp/test-results/results.xml \
     --jsonfile=tmp/testlogs/log.json \
     -- -count=1 -timeout 40m ./{{GO_PKG_NAME}}


### PR DESCRIPTION
## Summary

Adds two scripts under `ops/scripts/`:

- **`split-test-logs.sh`** — takes a gotestsum JSON log file and splits it into one `.log` file per test, organized as `per-test/<package>/<TestName>.log` next to the source JSON file.
- **`gotestsum-split.sh`** — drop-in `gotestsum` wrapper that runs gotestsum, then calls `split-test-logs.sh`. Preserves gotestsum's exit code so splits happen even on test failure (when they're most useful). If `--jsonfile` isn't provided, adds one automatically (`tmp/testlogs/log.json`) so per-test logs are always generated.

All gotestsum invocations in justfiles and CI config now use the wrapper. The one exception is the xargs-based parallel sharding in kona action tests, which calls gotestsum directly (xargs invokes it multiple times appending to one jsonfile) then calls `split-test-logs.sh` once at the end.

Per-test logs land under `tmp/testlogs/per-test/` which is already captured by existing CircleCI `store_artifacts` steps.

Also migrates `rust/op-reth/crates/tests` from plain `go test` to gotestsum via the wrapper for consistency.

### Files touched

| File | Change |
|------|--------|
| `ops/scripts/split-test-logs.sh` | **New** — splits a JSON log file into per-test files |
| `ops/scripts/gotestsum-split.sh` | **New** — gotestsum wrapper that auto-splits |
| `justfile` | Use wrapper in `_go-tests-ci-internal` and `go-tests-fraud-proofs-ci` |
| `op-e2e/justfile` | Use wrapper in `_go_test` variable |
| `rust/kona/tests/justfile` | Use wrapper + direct split for xargs case |
| `rust/op-reth/tests/justfile` | Use wrapper in `test-e2e-sysgo` |
| `rust/op-reth/crates/tests/justfile` | Migrate to gotestsum via wrapper |
| `.circleci/continue/main.yml` | Use wrapper for cannon tests |

## Test plan

- [ ] Verify `split-test-logs.sh` correctly splits a gotestsum JSON file into per-test logs locally
- [ ] Verify `gotestsum-split.sh` auto-adds `--jsonfile` when not provided
- [ ] Verify CI jobs still pass (test results and artifacts captured)
- [ ] Verify per-test logs appear in CircleCI artifacts under `testlogs/per-test/`
- [ ] Verify the split runs on test failure (exit code preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)