### PR TITLE
fix(op-supernode): prevent shutdown hang from Start/Stop race

### DIFF
--- a/op-supernode/supernode/supernode.go
+++ b/op-supernode/supernode/supernode.go
@@ -29,20 +29,20 @@ import (
 )
 
 type Supernode struct {
-	log          gethlog.Logger
-	version      string
-	requestStop  context.CancelCauseFunc
-	stopped      bool
-	cfg          *config.CLIConfig
-	chains       map[eth.ChainID]cc.ChainContainer
-	activities   []activity.Activity
+	log             gethlog.Logger
+	version         string
+	requestStop     context.CancelCauseFunc
+	stopped         bool
+	cfg             *config.CLIConfig
+	chains          map[eth.ChainID]cc.ChainContainer
+	activities      []activity.Activity
 	rootRPC         *oprpc.Handler
 	wg              sync.WaitGroup
-	lifecycleCancel context.CancelFunc
-	l1Client     *sources.L1Client
-	beaconClient *sources.L1BeaconClient
-	httpServer   *httputil.HTTPServer
-	rpcRouter    *resources.Router
+	lifecycleCancel context.CancelFunc // canceled in Stop() to unblock goroutines from Start()
+	l1Client        *sources.L1Client
+	beaconClient    *sources.L1BeaconClient
+	httpServer      *httputil.HTTPServer
+	rpcRouter       *resources.Router
 	// Metrics router/server for per-chain metrics
 	metrics      *resources.MetricsService
 	metricsFanIn *resources.MetricsFanIn

--- a/op-supernode/supernode/supernode.go
+++ b/op-supernode/supernode/supernode.go
@@ -36,8 +36,9 @@ type Supernode struct {
 	cfg          *config.CLIConfig
 	chains       map[eth.ChainID]cc.ChainContainer
 	activities   []activity.Activity
-	rootRPC      *oprpc.Handler
-	wg           sync.WaitGroup
+	rootRPC         *oprpc.Handler
+	wg              sync.WaitGroup
+	lifecycleCancel context.CancelFunc
 	l1Client     *sources.L1Client
 	beaconClient *sources.L1BeaconClient
 	httpServer   *httputil.HTTPServer
@@ -123,6 +124,15 @@ func New(ctx context.Context, log gethlog.Logger, version string, requestStop co
 
 func (s *Supernode) Start(ctx context.Context) error {
 	s.log.Info("supernode starting", "version", s.version)
+
+	// Create a lifecycle context that is canceled in Stop(). This ensures that
+	// goroutines spawned below will exit even if Stop() wins the race and runs
+	// before the goroutine has been scheduled. Without this, an activity's
+	// Start(ctx) could block forever if its Stop() was already called (and
+	// found cancel == nil) before Start() had a chance to initialize.
+	var lifecycleCtx context.Context
+	lifecycleCtx, s.lifecycleCancel = context.WithCancel(ctx)
+
 	if s.httpServer != nil {
 		s.wg.Add(1)
 		go func() {
@@ -161,7 +171,7 @@ func (s *Supernode) Start(ctx context.Context) error {
 			s.wg.Add(1)
 			go func(run activity.RunnableActivity) {
 				defer s.wg.Done()
-				err := run.Start(ctx)
+				err := run.Start(lifecycleCtx)
 				activityName := a.Name()
 				switch err {
 				case nil:
@@ -181,7 +191,7 @@ func (s *Supernode) Start(ctx context.Context) error {
 		s.wg.Add(1)
 		go func(chainID eth.ChainID, chain cc.ChainContainer) {
 			defer s.wg.Done()
-			if err := chain.Start(ctx); err != nil {
+			if err := chain.Start(lifecycleCtx); err != nil {
 				s.log.Error("error starting chain", "chain_id", chainID.String(), "error", err)
 			}
 		}(chainID, chain)
@@ -192,6 +202,15 @@ func (s *Supernode) Start(ctx context.Context) error {
 func (s *Supernode) Stop(ctx context.Context) error {
 	s.log.Info("supernode stopping")
 	s.stopped = true
+
+	// Cancel the lifecycle context before anything else. This guarantees that
+	// activity and chain goroutines will observe a canceled context even if
+	// they haven't been scheduled yet when the individual Stop() calls below
+	// execute. The individual Stop() calls are still made for orderly cleanup,
+	// but the lifecycle cancellation is the backstop that prevents hangs.
+	if s.lifecycleCancel != nil {
+		s.lifecycleCancel()
+	}
 
 	// Stop RPC server first, then close router resources
 	if s.httpServer != nil {

--- a/op-supernode/supernode/supernode_activities_test.go
+++ b/op-supernode/supernode/supernode_activities_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
@@ -20,23 +21,28 @@ import (
 
 // mock runnable activity
 type mockRunnable struct {
+	mu      sync.Mutex
 	ctx     context.Context
 	cancel  context.CancelFunc
 	started int
 	stopped int
 }
 
-func (mockRunnable) Name() string {
+func (*mockRunnable) Name() string {
 	return "mockRunnable"
 }
 
 func (m *mockRunnable) Start(ctx context.Context) error {
+	m.mu.Lock()
 	m.started++
 	m.ctx, m.cancel = context.WithCancel(ctx)
+	m.mu.Unlock()
 	<-m.ctx.Done()
 	return m.ctx.Err()
 }
 func (m *mockRunnable) Stop(ctx context.Context) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.stopped++
 	if m.cancel != nil {
 		m.cancel()


### PR DESCRIPTION
## Summary

- **Root cause**: `Supernode.Stop()` races with activity goroutines spawned by `Start()`. If `Stop()` runs before a goroutine is scheduled, `activity.Stop()` finds `cancel == nil` and silently does nothing. When the goroutine later executes, `Start()` blocks forever on `<-ctx.Done()` — the 143-flake `TestCleanShutdown` hang.
- **Fix**: Introduce a lifecycle context in `Start()`, canceled at the top of `Stop()`. Activities and chains receive this context instead of the caller's. Even if `Stop()` wins the race, the goroutine sees an already-canceled context and exits immediately.
- **Mock fix**: `mockRunnable.Name()` used a value receiver (copying the struct during concurrent writes) and `Start()`/`Stop()` accessed the `cancel` field without synchronization. Added mutex and pointer receiver.

## Context

`TestCleanShutdown` has been the #1 flaky test in CI with 177 total flakes (143 in `go-tests-short`, 34 in `go-tests-full`) over the last 14 days. Five prior PRs (#19179, #19213, #19293, #19337, #19365) addressed specific shutdown hangs in chain containers and the interop activity, but none addressed this orchestration-level race between `Start()` and `Stop()`.

The same race pattern exists in the real `heartbeat` and `interop` activities (they initialize `cancel` inside `Start()` and check it in `Stop()`). The lifecycle context fix at the `Supernode` level protects all of them.

## Test plan

- [x] `TestCleanShutdown` passes 10/10 iterations (`-count=10`)
- [x] `TestRunnableActivityGating` passes 10/10 iterations  
- [x] Full `op-supernode/supernode/` test suite passes with `-race` flag
- [x] `go build ./op-supernode/...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>