### PR TITLE
fix(op-validator): skip TestAddressValidDeployment in short mode

### DIFF
--- a/op-validator/pkg/validations/addresses_test.go
+++ b/op-validator/pkg/validations/addresses_test.go
@@ -74,6 +74,9 @@ func TestValidatorAddress(t *testing.T) {
 }
 
 func TestAddressValidDeployment(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test that requires external RPC endpoints")
+	}
 	t.Parallel()
 
 	for _, network := range []string{"mainnet", "sepolia"} {


### PR DESCRIPTION
## Summary

- **Skip `TestAddressValidDeployment` when `-short` flag is set** to fix a flaky test (14 flakes observed in `go-tests-short` CI job)
- Root cause: the test makes live RPC calls to public Ethereum endpoints (`publicnode.com`) for both mainnet and sepolia, iterating through 7 contract versions per network — these external dependencies cause intermittent timeouts and failures
- Other tests in the same package already use mock RPC servers and are unaffected

## Test plan

- [x] `go build ./op-validator/...` passes
- [x] `go vet ./op-validator/...` passes
- [x] `go test -short -run TestAddressValidDeployment -v ./op-validator/pkg/validations/` correctly skips
- [ ] CI `go-tests-short` job passes without this test flaking

🤖 Generated with [Claude Code](https://claude.com/claude-code)