### PR TITLE
fix(op-batcher): fix flaky TestChannelManager_Memory

### DIFF
--- a/op-batcher/batcher/channel_manager_memory_test.go
+++ b/op-batcher/batcher/channel_manager_memory_test.go
@@ -89,13 +89,6 @@ func runMemoryTest(t *testing.T, batchType uint, compressorType string, compress
 	m := NewChannelManager(log, metrics.NoopMetrics, cfg, defaultTestRollupConfig)
 	m.Clear(eth.BlockID{})
 
-	// Measure initial memory using TotalAlloc which is monotonically increasing.
-	// Using Alloc (current heap) is flaky because GC can reclaim memory between
-	// the initial and final reads, causing uint64 underflow in the delta.
-	var initialMem runtime.MemStats
-	runtime.GC()
-	runtime.ReadMemStats(&initialMem)
-
 	// Create the first block (genesis)
 	var prevBlock *types.Block
 
@@ -138,27 +131,25 @@ func runMemoryTest(t *testing.T, batchType uint, compressorType string, compress
 	require.NoError(t, m.ensureChannelWithSpace(eth.BlockID{}))
 	require.NoError(t, m.processBlocks())
 
-	// Measure final memory using TotalAlloc (cumulative bytes allocated).
+	// Measure retained heap memory after forcing GC. Using HeapInuse as an
+	// absolute value avoids the uint64 underflow that made the original
+	// Alloc-delta approach flaky, while still catching retained-memory regressions.
 	var finalMem runtime.MemStats
 	runtime.GC()
 	runtime.ReadMemStats(&finalMem)
 
-	// TotalAlloc is monotonically increasing, so this subtraction is safe.
-	memAllocated := finalMem.TotalAlloc - initialMem.TotalAlloc
+	heapInuse := finalMem.HeapInuse
 
-	// Assert that total allocations don't exceed 1GB. TotalAlloc counts all
-	// allocations including those already freed, so the threshold is higher
-	// than a point-in-time heap limit.
-	const maxMemory = 1024 * 1024 * 1024 // 1GB in bytes
-	require.Less(t, memAllocated, uint64(maxMemory),
-		"Channel manager allocated %d bytes (%.2f MB), exceeding 1 GB limit",
-		memAllocated, float64(memAllocated)/1024/1024)
+	const maxMemory = 512 * 1024 * 1024 // 512MB in bytes
+	require.Less(t, heapInuse, uint64(maxMemory),
+		"Channel manager HeapInuse %d bytes (%.2f MB) exceeds 512 MB limit",
+		heapInuse, float64(heapInuse)/1024/1024)
 
 	// Log memory usage for debugging
 	t.Logf("Compressor: %s, Algorithm: %s, Batch Type: %d",
 		compressorType, compressionAlgo, batchType)
-	t.Logf("Channel manager total allocations: %d bytes (%.2f MB)",
-		memAllocated, float64(memAllocated)/1024/1024)
+	t.Logf("Channel manager HeapInuse: %d bytes (%.2f MB)",
+		heapInuse, float64(heapInuse)/1024/1024)
 	t.Logf("Number of channels in queue: %d", len(m.channelQueue))
 	t.Logf("Number of blocks processed: %d", len(m.blocks))
 

--- a/op-batcher/batcher/channel_manager_memory_test.go
+++ b/op-batcher/batcher/channel_manager_memory_test.go
@@ -89,7 +89,9 @@ func runMemoryTest(t *testing.T, batchType uint, compressorType string, compress
 	m := NewChannelManager(log, metrics.NoopMetrics, cfg, defaultTestRollupConfig)
 	m.Clear(eth.BlockID{})
 
-	// Measure initial memory
+	// Measure initial memory using TotalAlloc which is monotonically increasing.
+	// Using Alloc (current heap) is flaky because GC can reclaim memory between
+	// the initial and final reads, causing uint64 underflow in the delta.
 	var initialMem runtime.MemStats
 	runtime.GC()
 	runtime.ReadMemStats(&initialMem)
@@ -136,25 +138,27 @@ func runMemoryTest(t *testing.T, batchType uint, compressorType string, compress
 	require.NoError(t, m.ensureChannelWithSpace(eth.BlockID{}))
 	require.NoError(t, m.processBlocks())
 
-	// Measure final memory
+	// Measure final memory using TotalAlloc (cumulative bytes allocated).
 	var finalMem runtime.MemStats
 	runtime.GC()
 	runtime.ReadMemStats(&finalMem)
 
-	// Calculate memory used by the channel manager
-	memUsed := finalMem.Alloc - initialMem.Alloc
+	// TotalAlloc is monotonically increasing, so this subtraction is safe.
+	memAllocated := finalMem.TotalAlloc - initialMem.TotalAlloc
 
-	// Assert that memory usage doesn't exceed 512MB
-	const maxMemoryMB = 512 * 1024 * 1024 // 512MB in bytes
-	require.Less(t, memUsed, uint64(maxMemoryMB),
-		"Channel manager used %d bytes (%.2f MB), exceeding 512 MB limit",
-		memUsed, float64(memUsed)/1024/1024)
+	// Assert that total allocations don't exceed 1GB. TotalAlloc counts all
+	// allocations including those already freed, so the threshold is higher
+	// than a point-in-time heap limit.
+	const maxMemory = 1024 * 1024 * 1024 // 1GB in bytes
+	require.Less(t, memAllocated, uint64(maxMemory),
+		"Channel manager allocated %d bytes (%.2f MB), exceeding 1 GB limit",
+		memAllocated, float64(memAllocated)/1024/1024)
 
 	// Log memory usage for debugging
 	t.Logf("Compressor: %s, Algorithm: %s, Batch Type: %d",
 		compressorType, compressionAlgo, batchType)
-	t.Logf("Channel manager memory usage: %d bytes (%.2f MB)",
-		memUsed, float64(memUsed)/1024/1024)
+	t.Logf("Channel manager total allocations: %d bytes (%.2f MB)",
+		memAllocated, float64(memAllocated)/1024/1024)
 	t.Logf("Number of channels in queue: %d", len(m.channelQueue))
 	t.Logf("Number of blocks processed: %d", len(m.blocks))
 

--- a/op-batcher/batcher/channel_manager_memory_test.go
+++ b/op-batcher/batcher/channel_manager_memory_test.go
@@ -89,6 +89,11 @@ func runMemoryTest(t *testing.T, batchType uint, compressorType string, compress
 	m := NewChannelManager(log, metrics.NoopMetrics, cfg, defaultTestRollupConfig)
 	m.Clear(eth.BlockID{})
 
+	// Measure initial memory
+	var initialMem runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&initialMem)
+
 	// Create the first block (genesis)
 	var prevBlock *types.Block
 
@@ -131,25 +136,31 @@ func runMemoryTest(t *testing.T, batchType uint, compressorType string, compress
 	require.NoError(t, m.ensureChannelWithSpace(eth.BlockID{}))
 	require.NoError(t, m.processBlocks())
 
-	// Measure retained heap memory after forcing GC. Using HeapInuse as an
-	// absolute value avoids the uint64 underflow that made the original
-	// Alloc-delta approach flaky, while still catching retained-memory regressions.
+	// Measure final memory
 	var finalMem runtime.MemStats
 	runtime.GC()
 	runtime.ReadMemStats(&finalMem)
 
-	heapInuse := finalMem.HeapInuse
+	// Calculate memory used by the channel manager.
+	// Guard against uint64 underflow: GC between the two ReadMemStats calls can
+	// reclaim memory from other goroutines, making finalMem.Alloc < initialMem.Alloc.
+	// When that happens the delta is effectively zero — no leak detected.
+	var memUsed uint64
+	if finalMem.Alloc > initialMem.Alloc {
+		memUsed = finalMem.Alloc - initialMem.Alloc
+	}
 
-	const maxMemory = 512 * 1024 * 1024 // 512MB in bytes
-	require.Less(t, heapInuse, uint64(maxMemory),
-		"Channel manager HeapInuse %d bytes (%.2f MB) exceeds 512 MB limit",
-		heapInuse, float64(heapInuse)/1024/1024)
+	// Assert that memory usage doesn't exceed 512MB
+	const maxMemoryMB = 512 * 1024 * 1024 // 512MB in bytes
+	require.Less(t, memUsed, uint64(maxMemoryMB),
+		"Channel manager used %d bytes (%.2f MB), exceeding 512 MB limit",
+		memUsed, float64(memUsed)/1024/1024)
 
 	// Log memory usage for debugging
 	t.Logf("Compressor: %s, Algorithm: %s, Batch Type: %d",
 		compressorType, compressionAlgo, batchType)
-	t.Logf("Channel manager HeapInuse: %d bytes (%.2f MB)",
-		heapInuse, float64(heapInuse)/1024/1024)
+	t.Logf("Channel manager memory usage: %d bytes (%.2f MB)",
+		memUsed, float64(memUsed)/1024/1024)
 	t.Logf("Number of channels in queue: %d", len(m.channelQueue))
 	t.Logf("Number of blocks processed: %d", len(m.blocks))
 


### PR DESCRIPTION
## Summary

Fixes ethereum-optimism/optimism#19590

- **Root cause:** The test subtracts `initialMem.Alloc` from `finalMem.Alloc` to measure retained heap. Since `Alloc` can decrease when GC reclaims memory from other goroutines between the two `ReadMemStats` calls, the uint64 subtraction underflows to a massive value that fails the 512MB threshold.
- **Why flaky (not always failing):** GC timing is non-deterministic. The underflow only happens when GC runs between the two reads and reclaims enough to make `finalMem.Alloc < initialMem.Alloc`.
- **Fix:** Guard the subtraction — if `final < initial`, treat the delta as zero (GC reclaimed more than we allocated, so no leak). Preserves the original test semantics of bounding retained heap at 512MB.
- **Flake count:** 19 (via CircleCI Insights as of 2026-03-17)

## Test plan
- [x] `go build ./op-batcher/...` passes
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)