### PR TITLE
fix(op-devstack): stabilize TestSubProcess flaky test

### DIFF
--- a/op-devstack/sysgo/subproc.go
+++ b/op-devstack/sysgo/subproc.go
@@ -79,8 +79,13 @@ func (sp *SubProcess) Stop(interrupt bool) error {
 		}
 	}
 
-	if _, err := sp.cmd.Process.Wait(); err != nil {
-		sp.p.Logger().Warn("Sub-process exited with error", "err", err)
+	// Use cmd.Wait() instead of cmd.Process.Wait() to ensure all stdout/stderr
+	// data is fully flushed before returning. Process.Wait() only waits for the
+	// process to exit but does not guarantee I/O completion, which causes races
+	// where log output hasn't been written to the LineBuffer yet.
+	waitErr := sp.cmd.Wait()
+	if waitErr != nil && !interrupt {
+		sp.p.Logger().Warn("Sub-process exited with error", "err", waitErr)
 	} else {
 		sp.p.Logger().Info("Sub-process gracefully exited")
 	}

--- a/op-devstack/sysgo/subproc.go
+++ b/op-devstack/sysgo/subproc.go
@@ -1,6 +1,7 @@
 package sysgo
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -84,8 +85,11 @@ func (sp *SubProcess) Stop(interrupt bool) error {
 	// process to exit but does not guarantee I/O completion, which causes races
 	// where log output hasn't been written to the LineBuffer yet.
 	waitErr := sp.cmd.Wait()
-	if waitErr != nil && !interrupt {
+	var exitErr *exec.ExitError
+	if waitErr != nil && !(interrupt && errors.As(waitErr, &exitErr)) {
 		sp.p.Logger().Warn("Sub-process exited with error", "err", waitErr)
+	} else if interrupt && waitErr != nil {
+		sp.p.Logger().Info("Sub-process stopped")
 	} else {
 		sp.p.Logger().Info("Sub-process gracefully exited")
 	}

--- a/op-devstack/sysgo/subproc_test.go
+++ b/op-devstack/sysgo/subproc_test.go
@@ -72,5 +72,5 @@ func testSleep(gt *testing.T, capt *testlog.CapturingHandler, sp *SubProcess) {
 		testlog.NewMessageFilter("Sending interrupt")))
 
 	require.NotNil(gt, capt.FindLog(
-		testlog.NewMessageFilter("Sub-process gracefully exited")))
+		testlog.NewMessageFilter("Sub-process stopped")))
 }


### PR DESCRIPTION
## Summary

Fixes ethereum-optimism/optimism#19587

- **Root cause:** `SubProcess.Stop()` used `cmd.Process.Wait()` (raw OS-level wait) instead of `cmd.Wait()`. The raw wait only blocks until the process exits but does not guarantee that stdout/stderr data has been fully written to the `LineBuffer` writers. This creates a race where `capt.FindLog()` assertions run before log messages have been flushed.
- **Fix:** Replaced `cmd.Process.Wait()` with `cmd.Wait()` to ensure I/O completion before returning. Handle exit errors from signal-killed processes (since `cmd.Wait()` returns `*exec.ExitError` for signal-killed processes, unlike `Process.Wait()` which returned nil).
- **Flake count:** 34 (via CircleCI Insights as of 2026-03-17)
- **Verification:** 50/50 test runs passed after the fix.

## Test plan
- [x] `go build ./op-devstack/...` passes
- [x] 50/50 test runs passed locally
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)