### PR TITLE
ci: store JUnit results as artifacts for test failure debugging

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -1409,6 +1409,12 @@ jobs:
           key: golang-build-cache-contracts-bedrock-heavy-fuzz-{{ checksum "go.sum" }}
           paths:
             - "~/.cache/go-build"
+      # Store raw JUnit XML as artifact for debugging when store_test_results
+      # shows 0 results (see ethereum-optimism/optimism#19577)
+      - store_artifacts:
+          path: packages/contracts-bedrock/results
+          destination: junit-results
+          when: always
       - store_test_results:
           path: packages/contracts-bedrock/results
           when: always
@@ -1637,6 +1643,12 @@ jobs:
       - store_artifacts:
           path: packages/contracts-bedrock/failed-test-traces.log
           when: on_fail
+      # Store raw JUnit XML as artifact for debugging when store_test_results
+      # shows 0 results (see ethereum-optimism/optimism#19577)
+      - store_artifacts:
+          path: packages/contracts-bedrock/results
+          destination: junit-results
+          when: always
       - store_test_results:
           path: packages/contracts-bedrock/results
           when: always


### PR DESCRIPTION
## Summary

- Store the raw `results/` directory (containing JUnit XML) as a CircleCI artifact on both `contracts-bedrock-tests-heavy-fuzz` and `contracts-bedrock-tests-upgrade` jobs
- Added `when: always` so the artifact is captured regardless of job outcome
- Added comments referencing the tracking issue

## Context

When forge fuzz tests fail via proptest (e.g. [job 4593745](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/119645/workflows/0f6b41b7-6134-4d96-a2e6-d03ab88a8145/jobs/4593745)), `store_test_results` captures 0 results despite forge normally writing valid JUnit XML on test failures. We verified experimentally that forge *does* write correct JUnit on standard assertion failures (983 results captured), so the proptest failure path behaves differently.

Without the raw artifact, we can't determine whether the file is empty, truncated, or malformed. This change ensures we have the file to inspect next time it happens.

Tracked in ethereum-optimism/optimism#19577.

## Test plan

- [x] Verified `store_artifacts` works correctly for JUnit results via a test branch with a deliberate failing test
- [x] Confirmed the artifact appears in CircleCI's artifacts tab as `junit-results/results.xml`
- [x] CI config YAML is syntactically valid (no structural changes, just added steps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)