### PR TITLE
fix(op-deployer): stabilize TestSuperchain flaky test

### DIFF
--- a/op-deployer/pkg/deployer/bootstrap/superchain_test.go
+++ b/op-deployer/pkg/deployer/bootstrap/superchain_test.go
@@ -32,8 +32,6 @@ func TestSuperchain(t *testing.T) {
 }
 
 func testSuperchain(t *testing.T, forkRPCURL string) {
-	t.Parallel()
-
 	if forkRPCURL == "" {
 		t.Skip("forkRPCURL not set")
 	}


### PR DESCRIPTION
## Summary

Fixes ethereum-optimism/optimism#19586

- **Root cause:** `testSuperchain` called `t.Parallel()`, causing mainnet and sepolia subtests to run concurrently. Each starts a RetryProxy + Anvil forking from an external RPC. Under CI load, this resource contention causes timeouts.
- **Fix:** Remove `t.Parallel()` — same fix applied to TestImplementations in #18019.
- **Flake count:** 45

## Test plan
- [x] `go build ./op-deployer/...` passes
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)