### PR TITLE
fix(op-e2e): fix flaky TestBreakTimestampInvariant

### DIFF
--- a/op-e2e/actions/interop/interop_msg_test.go
+++ b/op-e2e/actions/interop/interop_msg_test.go
@@ -562,6 +562,10 @@ func TestBreakTimestampInvariant(gt *testing.T) {
 	actors.ChainB.Sequencer.SyncSupervisor(t)
 	actors.Supervisor.ProcessFull(t)
 
+	// Propagate cross-safe/safe promotion back to op-node
+	actors.ChainB.Sequencer.SyncSupervisor(t)
+	actors.ChainB.Sequencer.ActL2PipelineFull(t)
+
 	// Make sure the replaced block has different blockhash
 	replacedBlock := actors.ChainB.Sequencer.SyncStatus().LocalSafeL2
 	require.NotEqual(t, reorgedOutBlock.Hash, replacedBlock.Hash)


### PR DESCRIPTION
## Summary

Fixes ethereum-optimism/optimism#18137

- **Root cause:** Missing sync round at end of test. After the supervisor processes the replacement block and promotes to cross-safe/safe, the op-node never received this promotion — no `SyncSupervisor` + `PipelineFull` was called before the final `assertHeads`.
- **Why flaky (not always failing):** The race is between the supervisor's internal promotion and the op-node's sync state. If the op-node happens to have already received the promotion via background sync, the test passes. If not, the assertion fails. Timing-dependent.
- **Fix:** Added `SyncSupervisor` + `PipelineFull` after the supervisor's `ProcessFull`, matching the pattern used by similar working tests.
- **Flake count:** 27

## Test plan
- [x] `go build ./op-e2e/...` passes
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)