### PR TITLE
fix(op-service): harden RetryProxy to stabilize TestImplementations

### DIFF
--- a/op-service/testutils/devnet/proxy.go
+++ b/op-service/testutils/devnet/proxy.go
@@ -46,7 +46,7 @@ func NewRetryProxy(lgr log.Logger, upstream string, opts ...Option) *RetryProxy 
 		upstream:   upstream,
 		client:     &http.Client{},
 		strategy:   strategy,
-		maxRetries: 5,
+		maxRetries: 10,
 	}
 
 	for _, opt := range opts {
@@ -57,28 +57,31 @@ func NewRetryProxy(lgr log.Logger, upstream string, opts ...Option) *RetryProxy 
 }
 
 func (p *RetryProxy) Start() error {
+	readyC := make(chan struct{}, 1)
 	errC := make(chan error, 1)
 
 	go func() {
 		ln, err := net.Listen("tcp", "127.0.0.1:0")
 		if err != nil {
 			errC <- fmt.Errorf("failed to listen: %w", err)
+			return
 		}
 
 		p.listenPort = ln.Addr().(*net.TCPAddr).Port
+		readyC <- struct{}{}
 
 		p.srv = &http.Server{
-			Addr:    "127.0.0.1:0",
 			Handler: p,
 		}
-		errC <- p.srv.Serve(ln)
+		if err := p.srv.Serve(ln); err != nil && err != http.ErrServerClosed {
+			p.lgr.Error("server exited with error", "err", err)
+		}
 	}()
 
-	timer := time.NewTimer(100 * time.Millisecond)
 	select {
 	case err := <-errC:
-		return fmt.Errorf("failed to start server: %w", err)
-	case <-timer.C:
+		return err
+	case <-readyC:
 		p.lgr.Info("server started", "port", p.listenPort)
 		return nil
 	}
@@ -114,7 +117,7 @@ func (p *RetryProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	//nolint:bodyClose
 	res, resBody, err := retry.Do2(r.Context(), p.maxRetries, p.strategy, func() (*http.Response, []byte, error) {
-		ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
 		defer cancel()
 		res, err := p.doProxyReq(ctx, reqBody)
 		if err != nil {


### PR DESCRIPTION
## Summary

Fixes ethereum-optimism/optimism#19583

- **Root cause:** `RetryProxy` had overly tight timeouts (5s per-request, 5 max retries) for CI conditions with 12 parallel nodes hitting external RPCs. Also had a race condition in `Start()` using a timer instead of a ready signal.
- **Why flaky (not always failing):** External RPC response times vary with CI load and rate limiting. Under light load, 5s is enough. Under heavy load (parallel test execution), requests timeout intermittently.
- **Fix:** Per-request timeout 5s→30s, max retries 5→10, channel-based ready signal, fixed missing return after listen failure.
- **Flake count:** 66 (highest after TestCleanShutdown)

## Test plan
- [x] `go build ./op-service/...` passes
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)