### PR TITLE
fix(op-e2e): fix nonce race in interop action tests

### DIFF
--- a/op-e2e/actions/interop/interop_msg_test.go
+++ b/op-e2e/actions/interop/interop_msg_test.go
@@ -413,7 +413,12 @@ func TestInitAndExecMsgSameTimestamp(gt *testing.T) {
 	actors.ChainA.Sequencer.ActL2StartBlock(t)
 
 	// chain A progressed single unsafe block
-	eventLoggerAddress := DeployEventLogger(t, optsA)
+	// Use a separate user for the deploy to avoid a nonce race: the deploy tx
+	// bypasses the tx pool (via IncludeTx), so PendingNonceAt may return a
+	// stale nonce for alice if the tx pool hasn't synced the new chain head yet.
+	deployer := setupUser(t, is, actors.ChainA, 1)
+	deployOpts, _ := DefaultTxOpts(t, deployer, actors.ChainA)
+	eventLoggerAddress := DeployEventLogger(t, deployOpts)
 	// Also match chain B
 	actors.ChainB.Sequencer.ActL2EmptyBlock(t)
 
@@ -487,7 +492,12 @@ func TestBreakTimestampInvariant(gt *testing.T) {
 	optsB, _ := DefaultTxOpts(t, bob, actors.ChainB)
 	actors.ChainA.Sequencer.ActL2StartBlock(t)
 	// chain A progressed single unsafe block
-	eventLoggerAddress := DeployEventLogger(t, optsA)
+	// Use a separate user for the deploy to avoid a nonce race: the deploy tx
+	// bypasses the tx pool (via IncludeTx), so PendingNonceAt may return a
+	// stale nonce for alice if the tx pool hasn't synced the new chain head yet.
+	deployer := setupUser(t, is, actors.ChainA, 1)
+	deployOpts, _ := DefaultTxOpts(t, deployer, actors.ChainA)
+	eventLoggerAddress := DeployEventLogger(t, deployOpts)
 
 	// Intent to initiate message(or emit event) on chain A
 	txA := txintent.NewIntent[*txintent.InitTrigger, *txintent.InteropOutput](optsA)
@@ -629,11 +639,15 @@ func TestExecMsgDifferTxIndex(gt *testing.T) {
 
 		// first, random or last tx of a single L2 block.
 		indexes := []int{0, 1 + rng.Intn(txCount-1), txCount - 1}
+		execNonce := uint64(0)
 		for blockNumDelta, index := range indexes {
 			actors.ChainB.Sequencer.ActL2StartBlock(t)
 
 			initTx := initTxs[index]
-			execTx := txintent.NewIntent[*txintent.ExecTrigger, *txintent.InteropOutput](optsB)
+			// Use explicit nonces to avoid a tx pool race: IncludeTx bypasses the
+			// tx pool, so PendingNonceAt may return a stale value.
+			execTx := txintent.NewIntent[*txintent.ExecTrigger, *txintent.InteropOutput](optsB, txplan.WithStaticNonce(execNonce))
+			execNonce++
 
 			// Single event in every tx so index is always 0
 			execTx.Content.Fn(txintent.ExecuteIndexed(predeploys.CrossL2InboxAddr, &initTx.Result, 0))
@@ -678,7 +692,12 @@ func TestExpiredMessage(gt *testing.T) {
 	optsB, _ := DefaultTxOpts(t, bob, actors.ChainB)
 	actors.ChainA.Sequencer.ActL2StartBlock(t)
 	// chain A progressed single unsafe block
-	eventLoggerAddress := DeployEventLogger(t, optsA)
+	// Use a separate user for the deploy to avoid a nonce race: the deploy tx
+	// bypasses the tx pool (via IncludeTx), so PendingNonceAt may return a
+	// stale nonce for alice if the tx pool hasn't synced the new chain head yet.
+	deployer := setupUser(t, is, actors.ChainA, 1)
+	deployOpts, _ := DefaultTxOpts(t, deployer, actors.ChainA)
+	eventLoggerAddress := DeployEventLogger(t, deployOpts)
 
 	// Intent to initiate message(or emit event) on chain A
 	txA := txintent.NewIntent[*txintent.InitTrigger, *txintent.InteropOutput](optsA)


### PR DESCRIPTION
## Summary

Fixes ethereum-optimism/optimism#19588 (TestExpiredMessage, 25 flakes)
Fixes ethereum-optimism/optimism#19589 (TestExecMsgDifferTxIndex, 23 flakes)
Related: ethereum-optimism/optimism#18137 (TestBreakTimestampInvariant, 27 flakes — nonce race component)

- **Root cause:** Four interop action tests flake with "nonce too low" because they deploy a contract via `IncludeTx` (which bypasses the geth tx pool) and then build a subsequent transaction for the same account using `PendingNonceAt`. Since the tx pool updates asynchronously on chain head changes, there's a race where the pool returns a stale nonce (0 instead of 1).
- **Why flaky (not always failing):** The tx pool's head-update goroutine may or may not have processed the new chain head by the time `PendingNonceAt` is called. Under CI load, goroutine scheduling delays make this more likely.
- **Fix:** Use separate deployer accounts (key index 1) so the primary user always starts at nonce 0, and use explicit nonces (`txplan.WithStaticNonce`) for multi-block exec tx loops.
- **Tests fixed:** TestExpiredMessage (25), TestBreakTimestampInvariant (27), TestInitAndExecMsgSameTimestamp (4), TestExecMsgDifferTxIndex (23)

## Test plan
- [x] `go build ./op-e2e/...` passes
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)