### PR TITLE
chore: replace stale make calls with just

### DIFF
--- a/cannon/scripts/build-legacy-cannons.sh
+++ b/cannon/scripts/build-legacy-cannons.sh
@@ -34,7 +34,11 @@ function buildVersion() {
   git checkout "${TAG}" > "${LOG_FILE}" 2>&1
   git submodule update --init --recursive >> "${LOG_FILE}" 2>&1
   rm -rf "${BIN_DIR}/cannon-"*
-  make -C "${REPO_DIR}/cannon" cannon-embeds >> "${LOG_FILE}" 2>&1
+  if [ -f "${REPO_DIR}/cannon/justfile" ]; then
+    (cd "${REPO_DIR}/cannon" && just cannon-embeds >> "${LOG_FILE}" 2>&1)
+  else
+    make -C "${REPO_DIR}/cannon" cannon-embeds >> "${LOG_FILE}" 2>&1
+  fi
   cp "${BIN_DIR}/cannon-"* "${EMBEDS_DIR}/"
   echo "Built ${TAG} with versions:"
   (cd "${BIN_DIR}" && ls cannon-*)
@@ -52,7 +56,11 @@ done
 cd "${CANNON_DIR}"
 LOG_FILE="${LOGS_DIR}/build-current.txt"
 echo "Building current version of cannon Logs: ${LOG_FILE}"
-make cannon > "${LOG_FILE}" 2>&1
+if [ -f justfile ]; then
+  just cannon > "${LOG_FILE}" 2>&1
+else
+  make cannon > "${LOG_FILE}" 2>&1
+fi
 
 echo "All cannon versions successfully built and available in ${EMBEDS_DIR}"
 "${CANNON_DIR}/bin/cannon" list

--- a/cannon/scripts/build-legacy-cannons.sh
+++ b/cannon/scripts/build-legacy-cannons.sh
@@ -34,7 +34,7 @@ function buildVersion() {
   git checkout "${TAG}" > "${LOG_FILE}" 2>&1
   git submodule update --init --recursive >> "${LOG_FILE}" 2>&1
   rm -rf "${BIN_DIR}/cannon-"*
-  if [ -f "${REPO_DIR}/cannon/justfile" ]; then
+  if [ -f "${REPO_DIR}/cannon/justfile" ] && (cd "${REPO_DIR}/cannon" && just --show cannon-embeds &>/dev/null); then
     (cd "${REPO_DIR}/cannon" && just cannon-embeds >> "${LOG_FILE}" 2>&1)
   else
     make -C "${REPO_DIR}/cannon" cannon-embeds >> "${LOG_FILE}" 2>&1
@@ -56,7 +56,7 @@ done
 cd "${CANNON_DIR}"
 LOG_FILE="${LOGS_DIR}/build-current.txt"
 echo "Building current version of cannon Logs: ${LOG_FILE}"
-if [ -f justfile ]; then
+if [ -f justfile ] && just --show cannon &>/dev/null; then
   just cannon > "${LOG_FILE}" 2>&1
 else
   make cannon > "${LOG_FILE}" 2>&1

--- a/op-alt-da/Dockerfile
+++ b/op-alt-da/Dockerfile
@@ -1,6 +1,6 @@
 ARG OP_STACK_GO_BUILDER=us-docker.pkg.dev/oplabs-tools-artifacts/images/op-stack-go:latest
 FROM $OP_STACK_GO_BUILDER AS builder
-# See "make golang-docker" and /ops/docker/op-stack-go
+# See "just golang-docker" and /ops/docker/op-stack-go
 
 FROM alpine:3.20
 

--- a/op-dispute-mon/Dockerfile
+++ b/op-dispute-mon/Dockerfile
@@ -1,6 +1,6 @@
 ARG OP_STACK_GO_BUILDER=us-docker.pkg.dev/oplabs-tools-artifacts/images/op-stack-go:latest
 FROM $OP_STACK_GO_BUILDER AS builder
-# See "make golang-docker" and /ops/docker/op-stack-go
+# See "just golang-docker" and /ops/docker/op-stack-go
 
 FROM alpine:3.20
 

--- a/op-program/scripts/build-prestates.sh
+++ b/op-program/scripts/build-prestates.sh
@@ -106,7 +106,11 @@ EOF
 
   rm -rf "${BIN_DIR}"
   rm -rf rust/kona/prestate-artifacts-*
-  make reproducible-prestate >> "${log_file}" 2>&1
+  if [ -f justfile ]; then
+    just reproducible-prestate >> "${log_file}" 2>&1
+  else
+    make reproducible-prestate >> "${log_file}" 2>&1
+  fi
 
   if [[ "${version}" =~ ^op-program/v ]]; then
     if [ -f "${BIN_DIR}/prestate-proof.json" ]; then

--- a/op-program/scripts/build-prestates.sh
+++ b/op-program/scripts/build-prestates.sh
@@ -106,7 +106,7 @@ EOF
 
   rm -rf "${BIN_DIR}"
   rm -rf rust/kona/prestate-artifacts-*
-  if [ -f justfile ]; then
+  if [ -f justfile ] && just --show reproducible-prestate &>/dev/null; then
     just reproducible-prestate >> "${log_file}" 2>&1
   else
     make reproducible-prestate >> "${log_file}" 2>&1


### PR DESCRIPTION
## Summary

Audit and cleanup of remaining `make` references after the Make → Just migration (#19546).

- **`build-prestates.sh`** and **`build-legacy-cannons.sh`**: Use `just` when a justfile is present at the checked-out tag, fall back to `make` for older tags that predate the migration
- **`op-alt-da/Dockerfile`** and **`op-dispute-mon/Dockerfile`**: Update stale comments referencing `make golang-docker` → `just golang-docker`

Note: `rust/op-reth/tests/` was already handled by #19525.

## Test plan

- [ ] Verify `build-prestates.sh` still works for both old tags (no justfile → make) and new tags (justfile → just)
- [ ] Verify `build-legacy-cannons.sh` builds cannon embeds correctly across tag versions
- [ ] Confirm no other stale `make` references remain (audit checked CI configs, Dockerfiles, scripts, and docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)