### PR TITLE
chore(rust): remove stale RUSTSEC-2026-0002 ignore

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6955,9 +6955,9 @@ dependencies = [
 
 [[package]]
 name = "lz4_flex"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab6473172471198271ff72e9379150e9dfd70d8e533e0752a27e515b48dd375e"
+checksum = "98c23545df7ecf1b16c303910a69b079e8e251d60f7dd2cc9b4177f2afaf1746"
 
 [[package]]
 name = "mach2"

--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -17,8 +17,6 @@ ignore = [
   "RUSTSEC-2025-0012",
   # bincode is unmaintained but still functional; transitive dep from reth-nippy-jar and test-fuzz.
   "RUSTSEC-2025-0141",
-  # https://rustsec.org/advisories/RUSTSEC-2026-0002 lru unused directly: https://github.com/alloy-rs/alloy/pull/3460
-  "RUSTSEC-2026-0002",
 ]
 
 # This section is considered when running `cargo deny check bans`.


### PR DESCRIPTION
## Summary

- Remove the `RUSTSEC-2026-0002` ignore entry from `rust/deny.toml` — the advisory no longer matches any crate in the dependency tree, causing `cargo-deny` to fail with `"advisory was not encountered"`.
- The vulnerable `lru` versions (0.9.0–0.16.2) have been patched; `lru` 0.16.3 is already in `Cargo.lock`.
- This unblocks `rust-deny` CI for all open PRs (e.g. ethereum-optimism/optimism#19597).

## Test plan

- [ ] `rust-deny` CI job passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)