### PR TITLE
interop: add passthrough mode to interop filter

### DIFF
--- a/op-interop-filter/filter/backend.go
+++ b/op-interop-filter/filter/backend.go
@@ -29,6 +29,9 @@ type Backend struct {
 	// Manual failsafe override
 	manualFailsafe atomic.Bool
 
+	// Passthrough mode: all transactions pass without filtering
+	passthrough bool
+
 	cancel context.CancelFunc
 }
 
@@ -38,6 +41,7 @@ type BackendParams struct {
 	Metrics        metrics.Metricer
 	Chains         map[eth.ChainID]ChainIngester
 	CrossValidator CrossValidator
+	Passthrough    bool
 }
 
 // NewBackend creates a new Backend instance with the provided components.
@@ -49,6 +53,7 @@ func NewBackend(parentCtx context.Context, params BackendParams) *Backend {
 		metrics:        params.Metrics,
 		chains:         params.Chains,
 		crossValidator: params.CrossValidator,
+		passthrough:    params.Passthrough,
 		cancel:         cancel,
 	}
 }
@@ -132,6 +137,11 @@ func supportedSafetyLevel(level types.SafetyLevel) bool {
 // CheckAccessList validates the given access list entries.
 func (b *Backend) CheckAccessList(ctx context.Context, inboxEntries []common.Hash,
 	minSafety types.SafetyLevel, execDescriptor types.ExecutingDescriptor) error {
+
+	if b.passthrough {
+		b.metrics.RecordCheckAccessList(true)
+		return nil
+	}
 
 	if b.FailsafeEnabled() {
 		b.metrics.RecordCheckAccessList(false)

--- a/op-interop-filter/filter/config.go
+++ b/op-interop-filter/filter/config.go
@@ -36,6 +36,7 @@ type Config struct {
 	Version                     string
 	PollInterval                time.Duration // Interval for polling new blocks (default: 2s)
 	ValidationInterval          time.Duration // Interval for cross-chain validation (default: 500ms)
+	Passthrough                 bool          // If true, all transactions pass through without filtering
 
 	LogConfig     oplog.CLIConfig
 	MetricsConfig opmetrics.CLIConfig
@@ -132,6 +133,7 @@ func NewConfig(ctx *cli.Context, version string) (*Config, error) {
 		Version:                     version,
 		PollInterval:                pollInterval,
 		ValidationInterval:          validationInterval,
+		Passthrough:                 ctx.Bool(flags.DangerouslyEnablePassthroughFlag.Name),
 		LogConfig:                   oplog.ReadCLIConfig(ctx),
 		MetricsConfig:               opmetrics.ReadCLIConfig(ctx),
 		PprofConfig:                 oppprof.ReadCLIConfig(ctx),

--- a/op-interop-filter/filter/service.go
+++ b/op-interop-filter/filter/service.go
@@ -65,6 +65,10 @@ func Main(version string) cliapp.LifecycleAction {
 
 		l.Info("Initializing op-interop-filter", "version", version)
 
+		if cfg.Passthrough {
+			l.Warn("PASSTHROUGH MODE ENABLED: all transactions will bypass interop filtering")
+		}
+
 		if !cfg.MessageExpiryWindowExplicit {
 			l.Debug("Using default message expiry window", "window", DefaultMessageExpiryWindow)
 		} else {
@@ -219,6 +223,7 @@ func (s *Service) initBackend(ctx context.Context, cfg *Config) error {
 		Metrics:        s.metrics,
 		Chains:         chains,
 		CrossValidator: crossValidator,
+		Passthrough:    cfg.Passthrough,
 	})
 
 	s.log.Info("Created backend", "chains", len(chains))

--- a/op-interop-filter/flags/flags.go
+++ b/op-interop-filter/flags/flags.go
@@ -99,6 +99,11 @@ var (
 		EnvVars: prefixEnvVars("VALIDATION_INTERVAL"),
 		Value:   "500ms",
 	}
+	DangerouslyEnablePassthroughFlag = &cli.BoolFlag{
+		Name:    "dangerously-enable-passthrough",
+		Usage:   "Allow all transactions through without interop filtering. DANGEROUS: disables all executing message validation.",
+		EnvVars: prefixEnvVars("DANGEROUSLY_ENABLE_PASSTHROUGH"),
+	}
 )
 
 var requiredFlags = []cli.Flag{
@@ -118,6 +123,7 @@ var optionalFlags = []cli.Flag{
 	RPCPortFlag,
 	PollIntervalFlag,
 	ValidationIntervalFlag,
+	DangerouslyEnablePassthroughFlag,
 }
 
 func init() {


### PR DESCRIPTION
## Summary

- Adds `--dangerously-enable-passthrough` flag to op-interop-filter that bypasses all executing message validation
- When enabled, `CheckAccessList` immediately returns success without checking failsafe, readiness, or message validity
- Logs a loud warning on startup when passthrough mode is active

## Motivation

Needed to test invalid executing messages on the interop devnet. The filter currently blocks invalid messages before they reach the chain, making it impossible to test the invalidation/rewind paths end-to-end.

Closes #19565

## Test plan

- [x] Manual test: start op-interop-filter with `--dangerously-enable-passthrough` and verify all transactions pass through
- [x] Manual test: verify startup log includes passthrough warning
- [x] Manual test: submit invalid executing message on devnet and confirm it is not rejected by the filter