### PR TITLE
ci: add per-image change detection to Docker build workflow

### DIFF
--- a/.github/actions/docker-build-prep/action.yml
+++ b/.github/actions/docker-build-prep/action.yml
@@ -27,8 +27,10 @@ runs:
     - name: Compute GIT_VERSION for all images
       id: compute_versions
       shell: bash
+      env:
+        GIT_COMMIT: ${{ github.sha }}
       run: |
-        VERSIONS=$(GIT_COMMIT="${{ github.sha }}" just compute-git-versions)
+        VERSIONS=$(just compute-git-versions)
         echo "versions=$VERSIONS" >> $GITHUB_OUTPUT
         echo "Computed versions: $VERSIONS"
 

--- a/.github/docker-images.json
+++ b/.github/docker-images.json
@@ -1,0 +1,129 @@
+{
+  "shared_paths": [
+    "docker-bake.hcl",
+    ".github/workflows/branches.yaml",
+    ".github/docker-images.json",
+    ".github/actions/docker-build-prep/**",
+    "ops/scripts/compute-git-versions.sh"
+  ],
+  "shared_go_paths": [
+    "go.mod",
+    "go.sum",
+    "ops/docker/op-stack-go/**",
+    "op-service/**",
+    "op-core/**",
+    "op-chain-ops/**"
+  ],
+  "images": {
+    "op-node": {
+      "type": "go",
+      "check": "go",
+      "paths": ["op-node/**"]
+    },
+    "op-batcher": {
+      "type": "go",
+      "check": "go",
+      "paths": ["op-batcher/**"]
+    },
+    "op-faucet": {
+      "type": "go",
+      "check": "go",
+      "paths": ["op-faucet/**"]
+    },
+    "op-program": {
+      "type": "go",
+      "check": "go",
+      "paths": ["op-program/**", "op-preimage/**"]
+    },
+    "op-proposer": {
+      "type": "go",
+      "check": "go",
+      "paths": ["op-proposer/**"]
+    },
+    "op-challenger": {
+      "type": "go",
+      "check": "go",
+      "paths": ["op-challenger/**", "op-program/**", "cannon/**", "op-preimage/**", "rust/kona/**"]
+    },
+    "op-dispute-mon": {
+      "type": "go",
+      "check": "go",
+      "paths": ["op-dispute-mon/**"]
+    },
+    "op-conductor": {
+      "type": "go",
+      "check": "go",
+      "paths": ["op-conductor/**", "op-node/**"]
+    },
+    "da-server": {
+      "type": "go",
+      "check": "go",
+      "paths": ["op-alt-da/**"]
+    },
+    "op-supervisor": {
+      "type": "go",
+      "check": "go",
+      "paths": ["op-supervisor/**"]
+    },
+    "op-supernode": {
+      "type": "go",
+      "check": "go",
+      "paths": ["op-supernode/**", "op-node/**"]
+    },
+    "op-test-sequencer": {
+      "type": "go",
+      "check": "go",
+      "paths": ["op-test-sequencer/**"]
+    },
+    "cannon": {
+      "type": "go",
+      "check": "go",
+      "paths": ["cannon/**", "op-preimage/**"]
+    },
+    "op-dripper": {
+      "type": "go",
+      "check": "go",
+      "paths": ["op-dripper/**"]
+    },
+    "op-interop-mon": {
+      "type": "go",
+      "check": "go",
+      "paths": ["op-interop-mon/**"]
+    },
+    "op-interop-filter": {
+      "type": "go",
+      "check": "go",
+      "paths": ["op-interop-filter/**"]
+    },
+    "op-rbuilder": {
+      "type": "rust",
+      "check": "rust",
+      "paths": ["op-rbuilder/**"]
+    },
+    "kona-node": {
+      "type": "rust",
+      "check": "rust",
+      "paths": ["rust/**"]
+    },
+    "kona-client": {
+      "type": "rust",
+      "check": "none",
+      "paths": ["rust/**"]
+    },
+    "kona-host": {
+      "type": "rust",
+      "check": "rust",
+      "paths": ["rust/**"]
+    },
+    "op-reth": {
+      "type": "rust",
+      "check": "rust",
+      "paths": ["rust/**"]
+    },
+    "cannon-builder": {
+      "type": "rust",
+      "check": "none",
+      "paths": ["rust/kona/docker/cannon/**"]
+    }
+  }
+}

--- a/.github/docker-images.json
+++ b/.github/docker-images.json
@@ -80,6 +80,11 @@
       "check": "go",
       "paths": ["cannon/**", "op-preimage/**"]
     },
+    "op-deployer": {
+      "type": "go",
+      "check": "go",
+      "paths": ["op-deployer/**", "packages/contracts-bedrock/**"]
+    },
     "op-dripper": {
       "type": "go",
       "check": "go",

--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -316,7 +316,9 @@ jobs:
       IMAGE: ${{ needs.build-fork.result == 'success' && format('ttl.sh/{0}/{1}:24h', github.sha, matrix.image_name) || format('us-docker.pkg.dev/oplabs-tools-artifacts/images/{0}:{1}', matrix.image_name, github.sha) }}
     steps:
       - name: Run image
-        run: docker run $IMAGE ${{ matrix.image_name }} --version
+        env:
+          IMAGE_NAME: ${{ matrix.image_name }}
+        run: docker run "$IMAGE" "$IMAGE_NAME" --version
 
   # Separate cross-platform check for Rust images (they use ENTRYPOINT instead of CMD)
   check-cross-platform-rust:
@@ -337,7 +339,7 @@ jobs:
       IMAGE: ${{ needs.build-fork.result == 'success' && format('ttl.sh/{0}/{1}:24h', github.sha, matrix.image_name) || format('us-docker.pkg.dev/oplabs-tools-artifacts/images/{0}:{1}', matrix.image_name, github.sha) }}
     steps:
       - name: Run image
-        run: docker run $IMAGE --version
+        run: docker run "$IMAGE" --version
 
   # Gate job for branch protection — provides a stable check name regardless of dynamic matrix contents
   docker-build-result:
@@ -346,42 +348,52 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check results
+        env:
+          DETECT_RESULT: ${{ needs.detect-changes.result }}
+          HAS_IMAGES: ${{ needs.detect-changes.outputs.has_images }}
+          IS_FORK: ${{ needs.detect-changes.outputs.is_fork }}
+          BUILD_RESULT: ${{ needs.build.result }}
+          BUILD_FORK_RESULT: ${{ needs.build-fork.result }}
+          HAS_GO: ${{ needs.detect-changes.outputs.has_go_check_images }}
+          HAS_RUST: ${{ needs.detect-changes.outputs.has_rust_check_images }}
+          GO_CHECK_RESULT: ${{ needs.check-cross-platform.result }}
+          RUST_CHECK_RESULT: ${{ needs.check-cross-platform-rust.result }}
         run: |
           # Fail if detect-changes itself failed (otherwise empty outputs silently pass)
-          if [[ "${{ needs.detect-changes.result }}" != "success" ]]; then
-            echo "detect-changes failed: ${{ needs.detect-changes.result }}"
+          if [[ "$DETECT_RESULT" != "success" ]]; then
+            echo "detect-changes failed: $DETECT_RESULT"
             exit 1
           fi
 
           # If no images needed building, that's a success
-          if [[ "${{ needs.detect-changes.outputs.has_images }}" != "true" ]]; then
+          if [[ "$HAS_IMAGES" != "true" ]]; then
             echo "No images needed building — success"
             exit 0
           fi
 
           # Check that the applicable build job succeeded
-          if [[ "${{ needs.detect-changes.outputs.is_fork }}" == "true" ]]; then
-            BUILD_RESULT="${{ needs.build-fork.result }}"
+          if [[ "$IS_FORK" == "true" ]]; then
+            RESULT="$BUILD_FORK_RESULT"
           else
-            BUILD_RESULT="${{ needs.build.result }}"
+            RESULT="$BUILD_RESULT"
           fi
 
-          if [[ "$BUILD_RESULT" != "success" ]]; then
-            echo "Build failed with result: $BUILD_RESULT"
+          if [[ "$RESULT" != "success" ]]; then
+            echo "Build failed with result: $RESULT"
             exit 1
           fi
 
           # Check cross-platform results (they use always() so check explicitly)
-          if [[ "${{ needs.detect-changes.outputs.has_go_check_images }}" == "true" ]]; then
-            if [[ "${{ needs.check-cross-platform.result }}" != "success" ]]; then
-              echo "Go cross-platform check failed: ${{ needs.check-cross-platform.result }}"
+          if [[ "$HAS_GO" == "true" ]]; then
+            if [[ "$GO_CHECK_RESULT" != "success" ]]; then
+              echo "Go cross-platform check failed: $GO_CHECK_RESULT"
               exit 1
             fi
           fi
 
-          if [[ "${{ needs.detect-changes.outputs.has_rust_check_images }}" == "true" ]]; then
-            if [[ "${{ needs.check-cross-platform-rust.result }}" != "success" ]]; then
-              echo "Rust cross-platform check failed: ${{ needs.check-cross-platform-rust.result }}"
+          if [[ "$HAS_RUST" == "true" ]]; then
+            if [[ "$RUST_CHECK_RESULT" != "success" ]]; then
+              echo "Rust cross-platform check failed: $RUST_CHECK_RESULT"
               exit 1
             fi
           fi

--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -48,6 +48,12 @@ jobs:
           ref: ${{ github.event_name == 'schedule' && 'develop' || '' }}
       - name: Detect affected images
         id: detect
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          THIS_REPO: ${{ github.repository }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
 
@@ -55,16 +61,16 @@ jobs:
 
           # Determine if this is a fork PR
           IS_FORK="false"
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            if [[ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]]; then
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            if [[ "$HEAD_REPO" != "$THIS_REPO" ]]; then
               IS_FORK="true"
             fi
           fi
           echo "is_fork=$IS_FORK" >> "$GITHUB_OUTPUT"
 
           # For push to develop or scheduled builds, build all images
-          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
-            echo "Non-PR event (${{ github.event_name }}): building all images"
+          if [[ "$EVENT_NAME" != "pull_request" ]]; then
+            echo "Non-PR event ($EVENT_NAME): building all images"
             ALL_IMAGES=$(jq -c '[.images | keys[]]' "$CONFIG")
             GO_CHECK=$(jq -c '[.images | to_entries[] | select(.value.check == "go") | .key]' "$CONFIG")
             RUST_CHECK=$(jq -c '[.images | to_entries[] | select(.value.check == "rust") | .key]' "$CONFIG")
@@ -79,7 +85,7 @@ jobs:
           fi
 
           # For PRs, detect which files changed (three-dot diff = only the PR's changes)
-          CHANGED_FILES=$(git diff --name-only "${{ github.event.pull_request.base.sha }}"..."${{ github.event.pull_request.head.sha }}" 2>/dev/null || true)
+          CHANGED_FILES=$(git diff --name-only "${BASE_SHA}...${HEAD_SHA}" 2>/dev/null || true)
 
           if [[ -z "$CHANGED_FILES" ]]; then
             echo "WARNING: Could not detect changed files — building all images as fallback"

--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -8,19 +8,217 @@ on:
     branches:
       - 'develop'
     paths:
-      - 'ops/docker/**'
-      - 'packages/contracts-bedrock/**'
-      - 'docker-bake.hcl'
-      - '.github/workflows/branches.yaml'
-      - '.github/actions/docker-build-prep/**'
-      - 'ops/scripts/compute-git-versions.sh'
-      - 'op-rbuilder/**'
+      - 'op-*/**'
+      - 'cannon/**'
       - 'rust/**'
+      - 'ops/docker/**'
+      - 'ops/scripts/compute-git-versions.sh'
+      - 'docker-bake.hcl'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/branches.yaml'
+      - '.github/docker-images.json'
+      - '.github/actions/docker-build-prep/**'
   schedule:
     # Daily builds at 2 AM UTC (matches CircleCI schedule)
     - cron: '0 2 * * *'
 
 jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      images_json: ${{ steps.detect.outputs.images_json }}
+      go_check_images_json: ${{ steps.detect.outputs.go_check_images_json }}
+      rust_check_images_json: ${{ steps.detect.outputs.rust_check_images_json }}
+      has_images: ${{ steps.detect.outputs.has_images }}
+      has_go_check_images: ${{ steps.detect.outputs.has_go_check_images }}
+      has_rust_check_images: ${{ steps.detect.outputs.has_rust_check_images }}
+      is_fork: ${{ steps.detect.outputs.is_fork }}
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2
+        with:
+          egress-policy: audit
+      - name: Checkout
+        uses: actions/checkout@71cf2267d89c5cb81562390fa70a37fa40b1305e # v6
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'schedule' && 'develop' || '' }}
+      - name: Detect affected images
+        id: detect
+        run: |
+          set -euo pipefail
+
+          CONFIG=".github/docker-images.json"
+
+          # Determine if this is a fork PR
+          IS_FORK="false"
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            if [[ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]]; then
+              IS_FORK="true"
+            fi
+          fi
+          echo "is_fork=$IS_FORK" >> "$GITHUB_OUTPUT"
+
+          # For push to develop or scheduled builds, build all images
+          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+            echo "Non-PR event (${{ github.event_name }}): building all images"
+            ALL_IMAGES=$(jq -c '[.images | keys[]]' "$CONFIG")
+            GO_CHECK=$(jq -c '[.images | to_entries[] | select(.value.check == "go") | .key]' "$CONFIG")
+            RUST_CHECK=$(jq -c '[.images | to_entries[] | select(.value.check == "rust") | .key]' "$CONFIG")
+
+            echo "images_json=$ALL_IMAGES" >> "$GITHUB_OUTPUT"
+            echo "go_check_images_json=$GO_CHECK" >> "$GITHUB_OUTPUT"
+            echo "rust_check_images_json=$RUST_CHECK" >> "$GITHUB_OUTPUT"
+            echo "has_images=true" >> "$GITHUB_OUTPUT"
+            echo "has_go_check_images=true" >> "$GITHUB_OUTPUT"
+            echo "has_rust_check_images=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # For PRs, detect which files changed (three-dot diff = only the PR's changes)
+          CHANGED_FILES=$(git diff --name-only "${{ github.event.pull_request.base.sha }}"..."${{ github.event.pull_request.head.sha }}" 2>/dev/null || true)
+
+          if [[ -z "$CHANGED_FILES" ]]; then
+            echo "WARNING: Could not detect changed files — building all images as fallback"
+            ALL_IMAGES=$(jq -c '[.images | keys[]]' "$CONFIG")
+            GO_CHECK=$(jq -c '[.images | to_entries[] | select(.value.check == "go") | .key]' "$CONFIG")
+            RUST_CHECK=$(jq -c '[.images | to_entries[] | select(.value.check == "rust") | .key]' "$CONFIG")
+
+            echo "images_json=$ALL_IMAGES" >> "$GITHUB_OUTPUT"
+            echo "go_check_images_json=$GO_CHECK" >> "$GITHUB_OUTPUT"
+            echo "rust_check_images_json=$RUST_CHECK" >> "$GITHUB_OUTPUT"
+            echo "has_images=true" >> "$GITHUB_OUTPUT"
+            echo "has_go_check_images=true" >> "$GITHUB_OUTPUT"
+            echo "has_rust_check_images=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Changed files:"
+          echo "$CHANGED_FILES" | head -50
+          TOTAL=$(echo "$CHANGED_FILES" | wc -l)
+          echo "($TOTAL files total)"
+
+          # matches_pattern checks if a file matches a path pattern
+          # "foo/**" matches any file under foo/
+          # "foo" matches the exact file foo
+          matches_pattern() {
+            local file="$1"
+            local pattern="$2"
+            if [[ "$pattern" == *"/**" ]]; then
+              local prefix="${pattern%/**}"
+              [[ "$file" == "$prefix/"* ]] && return 0
+            else
+              [[ "$file" == "$pattern" ]] && return 0
+            fi
+            return 1
+          }
+
+          BUILD_ALL=false
+          BUILD_ALL_GO=false
+
+          # Check shared paths (trigger all images)
+          SHARED_PATHS=$(jq -r '.shared_paths[]' "$CONFIG")
+          while IFS= read -r pattern; do
+            while IFS= read -r file; do
+              if matches_pattern "$file" "$pattern"; then
+                echo "Shared path match: $file matches $pattern → building all images"
+                BUILD_ALL=true
+                break 2
+              fi
+            done <<< "$CHANGED_FILES"
+          done <<< "$SHARED_PATHS"
+
+          # Check shared Go paths (trigger all Go images)
+          if [[ "$BUILD_ALL" != "true" ]]; then
+            SHARED_GO_PATHS=$(jq -r '.shared_go_paths[]' "$CONFIG")
+            while IFS= read -r pattern; do
+              while IFS= read -r file; do
+                if matches_pattern "$file" "$pattern"; then
+                  echo "Shared Go path match: $file matches $pattern → building all Go images"
+                  BUILD_ALL_GO=true
+                  break 2
+                fi
+              done <<< "$CHANGED_FILES"
+            done <<< "$SHARED_GO_PATHS"
+          fi
+
+          # Collect affected images
+          declare -A AFFECTED
+
+          if [[ "$BUILD_ALL" == "true" ]]; then
+            # All images affected
+            while IFS= read -r name; do
+              AFFECTED["$name"]=1
+            done < <(jq -r '.images | keys[]' "$CONFIG")
+          else
+            if [[ "$BUILD_ALL_GO" == "true" ]]; then
+              # All Go images affected
+              while IFS= read -r name; do
+                AFFECTED["$name"]=1
+              done < <(jq -r '.images | to_entries[] | select(.value.type == "go") | .key' "$CONFIG")
+            fi
+
+            # Check per-image paths for remaining images
+            while IFS= read -r entry; do
+              name=$(echo "$entry" | jq -r '.key')
+              # Skip if already affected
+              [[ -n "${AFFECTED[$name]+x}" ]] && continue
+
+              paths=$(echo "$entry" | jq -r '.value.paths[]')
+              while IFS= read -r pattern; do
+                while IFS= read -r file; do
+                  if matches_pattern "$file" "$pattern"; then
+                    echo "Image path match: $file matches $pattern → building $name"
+                    AFFECTED["$name"]=1
+                    break 2
+                  fi
+                done <<< "$CHANGED_FILES"
+              done <<< "$paths"
+            done < <(jq -c '.images | to_entries[]' "$CONFIG")
+          fi
+
+          # Build output arrays
+          AFFECTED_LIST=$(printf '%s\n' "${!AFFECTED[@]}" | sort)
+
+          IMAGES_JSON="[]"
+          GO_CHECK_JSON="[]"
+          RUST_CHECK_JSON="[]"
+
+          if [[ -n "$AFFECTED_LIST" ]]; then
+            IMAGES_JSON=$(echo "$AFFECTED_LIST" | jq -R -s -c 'split("\n") | map(select(length > 0))')
+
+            GO_CHECK_JSON=$(echo "$AFFECTED_LIST" | while IFS= read -r name; do
+              [[ -z "$name" ]] && continue
+              check=$(jq -r --arg n "$name" '.images[$n].check' "$CONFIG")
+              if [[ "$check" == "go" ]]; then echo "$name"; fi
+            done | jq -R -s -c 'split("\n") | map(select(length > 0))')
+
+            RUST_CHECK_JSON=$(echo "$AFFECTED_LIST" | while IFS= read -r name; do
+              [[ -z "$name" ]] && continue
+              check=$(jq -r --arg n "$name" '.images[$n].check' "$CONFIG")
+              if [[ "$check" == "rust" ]]; then echo "$name"; fi
+            done | jq -R -s -c 'split("\n") | map(select(length > 0))')
+          fi
+
+          echo "Affected images: $IMAGES_JSON"
+          echo "Go check images: $GO_CHECK_JSON"
+          echo "Rust check images: $RUST_CHECK_JSON"
+
+          echo "images_json=$IMAGES_JSON" >> "$GITHUB_OUTPUT"
+          echo "go_check_images_json=$GO_CHECK_JSON" >> "$GITHUB_OUTPUT"
+          echo "rust_check_images_json=$RUST_CHECK_JSON" >> "$GITHUB_OUTPUT"
+
+          HAS_IMAGES=$( [[ $(echo "$IMAGES_JSON" | jq 'length') -gt 0 ]] && echo "true" || echo "false" )
+          HAS_GO=$( [[ $(echo "$GO_CHECK_JSON" | jq 'length') -gt 0 ]] && echo "true" || echo "false" )
+          HAS_RUST=$( [[ $(echo "$RUST_CHECK_JSON" | jq 'length') -gt 0 ]] && echo "true" || echo "false" )
+
+          echo "has_images=$HAS_IMAGES" >> "$GITHUB_OUTPUT"
+          echo "has_go_check_images=$HAS_GO" >> "$GITHUB_OUTPUT"
+          echo "has_rust_check_images=$HAS_RUST" >> "$GITHUB_OUTPUT"
+
   prep:
     runs-on: ubuntu-latest
     permissions:
@@ -42,36 +240,14 @@ jobs:
         id: prep
 
   build:
-    needs: prep
-    # only build if push to develop, scheduled run, or PR from a local branch (not a fork)
-    if: github.event_name == 'push' || github.event_name == 'schedule' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+    needs: [prep, detect-changes]
+    if: |
+      needs.detect-changes.outputs.is_fork == 'false'
+      && needs.detect-changes.outputs.has_images == 'true'
     strategy:
       fail-fast: false
       matrix:
-        image_name:
-          - op-node
-          - op-batcher
-          - op-faucet
-          - op-program
-          - op-proposer
-          - op-challenger
-          - op-dispute-mon
-          - op-conductor
-          - da-server
-          - op-supervisor
-          - op-supernode
-          - op-test-sequencer
-          - cannon
-          - op-deployer
-          - op-dripper
-          - op-interop-mon
-          - op-interop-filter
-          - op-rbuilder
-          - kona-node
-          - kona-client
-          - kona-host
-          - op-reth
-          - cannon-builder
+        image_name: ${{ fromJson(needs.detect-changes.outputs.images_json) }}
     uses: ethereum-optimism/factory/.github/workflows/docker.yaml@f8f3cb4800e538003134fb5f50cc734c2c98d762
     with:
       mode: bake
@@ -91,36 +267,14 @@ jobs:
       attestations: write
 
   build-fork:
-    needs: prep
-    # only build if PR from a fork
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+    needs: [prep, detect-changes]
+    if: |
+      needs.detect-changes.outputs.is_fork == 'true'
+      && needs.detect-changes.outputs.has_images == 'true'
     strategy:
       fail-fast: false
       matrix:
-        image_name:
-          - op-node
-          - op-batcher
-          - op-faucet
-          - op-program
-          - op-proposer
-          - op-challenger
-          - op-dispute-mon
-          - op-conductor
-          - da-server
-          - op-supervisor
-          - op-supernode
-          - op-test-sequencer
-          - cannon
-          - op-deployer
-          - op-dripper
-          - op-interop-mon
-          - op-interop-filter
-          - op-rbuilder
-          - kona-node
-          - kona-client
-          - kona-host
-          - op-reth
-          - cannon-builder
+        image_name: ${{ fromJson(needs.detect-changes.outputs.images_json) }}
     uses: ethereum-optimism/factory/.github/workflows/docker.yaml@f8f3cb4800e538003134fb5f50cc734c2c98d762
     with:
       mode: bake
@@ -138,43 +292,18 @@ jobs:
       contents: read
 
   check-cross-platform:
-    needs: [build, build-fork]
-    if: always() && (needs.build.result == 'success' || needs.build-fork.result == 'success')
+    needs: [build, build-fork, detect-changes]
+    if: |
+      always()
+      && needs.detect-changes.outputs.has_go_check_images == 'true'
+      && (needs.build.result == 'success' || needs.build-fork.result == 'success')
     strategy:
       fail-fast: false
       matrix:
-        image_name:
-          - op-node
-          - op-batcher
-          - op-faucet
-          - op-program
-          - op-proposer
-          - op-challenger
-          - op-dispute-mon
-          - op-conductor
-          - da-server
-          - op-supervisor
-          - op-supernode
-          - op-test-sequencer
-          - cannon
-          - op-deployer
-          - op-dripper
-          - op-interop-mon
-          - op-interop-filter
-          - op-rbuilder
-          - kona-node
-          - kona-host
-          - op-reth
+        image_name: ${{ fromJson(needs.detect-changes.outputs.go_check_images_json) }}
         runner:
           - ubuntu-24.04
           - ubuntu-24.04-arm
-        exclude:
-          # Rust images use ENTRYPOINT, so the version check command differs
-          - image_name: op-rbuilder
-          - image_name: kona-node
-          - image_name: kona-host
-          - image_name: op-reth
-          - image_name: cannon-builder
     runs-on: ${{ matrix.runner }}
     env:
       IMAGE: ${{ needs.build-fork.result == 'success' && format('ttl.sh/{0}/{1}:24h', github.sha, matrix.image_name) || format('us-docker.pkg.dev/oplabs-tools-artifacts/images/{0}:{1}', matrix.image_name, github.sha) }}
@@ -184,16 +313,15 @@ jobs:
 
   # Separate cross-platform check for Rust images (they use ENTRYPOINT instead of CMD)
   check-cross-platform-rust:
-    needs: [build, build-fork]
-    if: always() && (needs.build.result == 'success' || needs.build-fork.result == 'success')
+    needs: [build, build-fork, detect-changes]
+    if: |
+      always()
+      && needs.detect-changes.outputs.has_rust_check_images == 'true'
+      && (needs.build.result == 'success' || needs.build-fork.result == 'success')
     strategy:
       fail-fast: false
       matrix:
-        image_name:
-          - op-rbuilder
-          - kona-node
-          - kona-host
-          - op-reth
+        image_name: ${{ fromJson(needs.detect-changes.outputs.rust_check_images_json) }}
         runner:
           - ubuntu-24.04
           - ubuntu-24.04-arm
@@ -203,3 +331,52 @@ jobs:
     steps:
       - name: Run image
         run: docker run $IMAGE --version
+
+  # Gate job for branch protection — provides a stable check name regardless of dynamic matrix contents
+  docker-build-result:
+    needs: [detect-changes, build, build-fork, check-cross-platform, check-cross-platform-rust]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check results
+        run: |
+          # Fail if detect-changes itself failed (otherwise empty outputs silently pass)
+          if [[ "${{ needs.detect-changes.result }}" != "success" ]]; then
+            echo "detect-changes failed: ${{ needs.detect-changes.result }}"
+            exit 1
+          fi
+
+          # If no images needed building, that's a success
+          if [[ "${{ needs.detect-changes.outputs.has_images }}" != "true" ]]; then
+            echo "No images needed building — success"
+            exit 0
+          fi
+
+          # Check that the applicable build job succeeded
+          if [[ "${{ needs.detect-changes.outputs.is_fork }}" == "true" ]]; then
+            BUILD_RESULT="${{ needs.build-fork.result }}"
+          else
+            BUILD_RESULT="${{ needs.build.result }}"
+          fi
+
+          if [[ "$BUILD_RESULT" != "success" ]]; then
+            echo "Build failed with result: $BUILD_RESULT"
+            exit 1
+          fi
+
+          # Check cross-platform results (they use always() so check explicitly)
+          if [[ "${{ needs.detect-changes.outputs.has_go_check_images }}" == "true" ]]; then
+            if [[ "${{ needs.check-cross-platform.result }}" != "success" ]]; then
+              echo "Go cross-platform check failed: ${{ needs.check-cross-platform.result }}"
+              exit 1
+            fi
+          fi
+
+          if [[ "${{ needs.detect-changes.outputs.has_rust_check_images }}" == "true" ]]; then
+            if [[ "${{ needs.check-cross-platform-rust.result }}" != "success" ]]; then
+              echo "Rust cross-platform check failed: ${{ needs.check-cross-platform-rust.result }}"
+              exit 1
+            fi
+          fi
+
+          echo "All builds and checks passed"

--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -10,6 +10,7 @@ on:
     paths:
       - 'op-*/**'
       - 'cannon/**'
+      - 'packages/contracts-bedrock/**'
       - 'rust/**'
       - 'ops/docker/**'
       - 'ops/scripts/compute-git-versions.sh'

--- a/ops/scripts/compute-git-versions.sh
+++ b/ops/scripts/compute-git-versions.sh
@@ -13,28 +13,17 @@ set -euo pipefail
 
 GIT_COMMIT="${GIT_COMMIT:-$(git rev-parse HEAD)}"
 
-IMAGES=(
-  "op-node"
-  "op-batcher"
-  "op-deployer"
-  "op-faucet"
-  "op-program"
-  "op-proposer"
-  "op-challenger"
-  "op-dispute-mon"
-  "op-conductor"
-  "da-server"
-  "op-supervisor"
-  "op-supernode"
-  "op-test-sequencer"
-  "cannon"
-  "op-dripper"
-  "op-interop-mon"
-  "op-reth"
-  "kona-node"
-  "kona-host"
-  "kona-client"
-)
+# Read image list from the single source of truth
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+IMAGES_JSON="$REPO_ROOT/.github/docker-images.json"
+
+if [ ! -f "$IMAGES_JSON" ]; then
+  echo "Error: $IMAGES_JSON not found" >&2
+  exit 1
+fi
+
+mapfile -t IMAGES < <(jq -r '.images | keys[]' "$IMAGES_JSON" | sort)
 
 echo "Checking git tags pointing at $GIT_COMMIT:" >&2
 tags_at_commit=$(git tag --points-at "$GIT_COMMIT" || true)

--- a/ops/scripts/compute-git-versions.sh
+++ b/ops/scripts/compute-git-versions.sh
@@ -32,14 +32,27 @@ echo "Tags at commit: $tags_at_commit" >&2
 declare -A VERSIONS
 
 for IMAGE_NAME in "${IMAGES[@]}"; do
-  # Replicate CircleCI logic exactly: filter tags by image name prefix
-  filtered_tags=$(echo "$tags_at_commit" | grep "^${IMAGE_NAME}/" || true)
+  # Filter tags by exact image name prefix (use bash matching, not regex, to avoid injection)
+  filtered_tags=""
+  while IFS= read -r tag; do
+    [[ -z "$tag" ]] && continue
+    if [[ "$tag" == "${IMAGE_NAME}/"* ]]; then
+      filtered_tags+="$tag"$'\n'
+    fi
+  done <<< "$tags_at_commit"
+  filtered_tags="${filtered_tags%$'\n'}"
   echo "Filtered tags for ${IMAGE_NAME}: $filtered_tags" >&2
 
   if [ -z "$filtered_tags" ]; then
     VERSIONS["$IMAGE_NAME"]="untagged"
   else
-    sorted_tags=$(echo "$filtered_tags" | sed "s|${IMAGE_NAME}/||" | sort -V)
+    # Strip image name prefix using parameter expansion (not sed) to avoid metacharacter issues
+    sorted_tags=""
+    while IFS= read -r tag; do
+      [[ -z "$tag" ]] && continue
+      sorted_tags+="${tag#"${IMAGE_NAME}/"}"$'\n'
+    done <<< "$filtered_tags"
+    sorted_tags=$(echo "$sorted_tags" | sort -V)
     echo "Sorted tags for ${IMAGE_NAME}: $sorted_tags" >&2
 
     # prefer full release tag over "-rc" release candidate tag if both exist
@@ -54,19 +67,12 @@ for IMAGE_NAME in "${IMAGES[@]}"; do
   echo "GIT_VERSION for ${IMAGE_NAME}: ${VERSIONS[$IMAGE_NAME]}" >&2
 done
 
-# Output as JSON
-JSON="{"
-FIRST=true
+# Output as JSON (use jq to safely encode keys/values)
+JSON="{}"
 for IMAGE_NAME in "${IMAGES[@]}"; do
-  if [ "$FIRST" = true ]; then
-    FIRST=false
-  else
-    JSON="${JSON},"
-  fi
   VERSION="${VERSIONS[$IMAGE_NAME]}"
-  JSON="${JSON}\"${IMAGE_NAME}\":\"${VERSION}\""
+  JSON=$(echo "$JSON" | jq -c --arg k "$IMAGE_NAME" --arg v "$VERSION" '. + {($k): $v}')
 done
-JSON="${JSON}}"
 
 echo "$JSON"
 


### PR DESCRIPTION
Closes #19209

- New `.github/docker-images.json` as single source of truth for all 22 Docker images, their types, cross-platform check styles, and source paths
- `branches.yaml` rewritten with a `detect-changes` job that computes affected images via three-dot git diff, outputting dynamic JSON matrices consumed by all downstream jobs
- `compute-git-versions.sh` now reads its image list from `docker-images.json` instead of a hardcoded array (which was already out of sync)

## What changed

**Per-image change detection**: PRs now only build images whose source paths were touched. The detection has three tiers:
1. **Shared paths** (docker-bake.hcl, workflow files, etc.) ->  build all 22 images
2. **Shared Go paths** (go.mod, go.sum, op-service/, op-core/, op-chain-ops/, op-stack-go Dockerfile) → build all 16 Go images
3. **Per-image paths** (e.g. op-node/ triggers op-node, op-conductor, op-supernode) → build only affected images

Push-to-develop and scheduled builds continue building everything.

**Dynamic matrices** — all four downstream jobs (build, build-fork, check-cross-platform, check-cross-platform-rust) use `fromJson()` on the detect-changes outputs instead of hardcoded lists. Adding/removing an image is now a one-line change to `docker-images.json`.

**Gate job** — `docker-build-result` provides a stable check name for branch protection regardless of which images were in the matrix. Explicitly checks for detect-changes failure to avoid silent false-passes.

## Acceptance Criteria

- [ ] PRs that only affect a single service build only that service's image (plus any images affected by shared code changes).
- [ ] Contributors don't see skipped jobs for the other build path (fork vs. local).
- [ ] The image list is defined in a single location within the workflow configuration.
- [ ] Scheduled builds continue to build all images.
- [ ] The existing security model is preserved: fork PRs never push images to the registry.
- [ ] Builds continue to use the reusable factory docker workflow.
