### PR TITLE
fix(op-reth): propagate MDBX errors in DupSort cursor iterators instead of silently swallowing them

### DIFF
--- a/rust/op-reth/crates/trie/src/initialize.rs
+++ b/rust/op-reth/crates/trie/src/initialize.rs
@@ -76,14 +76,16 @@ macro_rules! define_dup_cursor_iter {
                     return Some(res);
                 }
 
-                // If no more duplicates, find the next key with values
-                let Some(Ok((next_key, _))) = self.0.next_no_dup().transpose() else {
-                    // If no more entries, return None
-                    return None;
-                };
-
-                // If found, seek to the first duplicate for this key
-                return self.0.seek(next_key).transpose();
+                // If no more duplicates, find the next key with values.
+                // Use explicit match to propagate MDBX errors
+                match self.0.next_no_dup() {
+                    Ok(Some((next_key, _))) => {
+                        // Seek to the first duplicate for this key
+                        self.0.seek(next_key).transpose()
+                    }
+                    Ok(None) => None,
+                    Err(e) => Some(Err(e)),
+                }
             }
         }
     };


### PR DESCRIPTION
**Description**

Fixes a bug in `define_dup_cursor_iter` where MDBX errors from `next_no_dup()` are silently treated as end-of-table, potentially truncating data during initialization.

If a transient MDBX error occurs mid-iteration, the remaining entries in `HashedStorages` or `StoragesTrie` are silently skipped. The batch is committed, init may mark `Completed`, and the next block execution computes a different state root.

This could be potential root cause for intermittent hash mismatches observed after multi-step initialization (crash mid-init → restart → first block fails state root check). The intermittent nature aligns with transient I/O errors being position-dependent and rare.

**Tests**

Pending
