### PR TITLE
fix(supernode): create synthetic payload without the risk of modifying the state root

### DIFF
--- a/op-supernode/supernode/chain_container/engine_controller/rewind.go
+++ b/op-supernode/supernode/chain_container/engine_controller/rewind.go
@@ -123,8 +123,19 @@ func (e *simpleEngineController) insertSyntheticPayload(ctx context.Context, blo
 	newPayload := *(envelope.ExecutionPayload)
 	newEnvelope.ExecutionPayload = &newPayload
 
-	// Modify the cloned payload to create a synthetic block with a different hash
-	newPayload.FeeRecipient = common.MaxAddress
+	// Modify ExtraData to produce a different block hash without affecting the state root.
+	// We must only change header fields that are not accessible via EVM opcodes. Fields
+	// that are EVM-accessible (e.g. coinbase, timestamp, prevrandao) influence execution
+	// and would cause the recomputed state root to diverge from the one in the payload,
+	// causing the engine to reject it. ExtraData has no EVM opcode and is safe to modify.
+	extra := make([]byte, len(newPayload.ExtraData))
+	copy(extra, newPayload.ExtraData)
+	if len(extra) == 0 {
+		extra = []byte{0x00}
+	} else {
+		extra[len(extra)-1] ^= 0xff
+	}
+	newPayload.ExtraData = extra
 	syntheticHash, _ := newEnvelope.CheckBlockHash() // ignore "ok" since we know it won't match
 	newPayload.BlockHash = syntheticHash
 

--- a/op-supernode/supernode/chain_container/engine_controller/rewind_test.go
+++ b/op-supernode/supernode/chain_container/engine_controller/rewind_test.go
@@ -221,8 +221,8 @@ func TestEngineController_RewindToTimestamp(t *testing.T) {
 				// Verify NewPayload was called (for synthetic block)
 				require.Equal(t, 1, l2.newPayloadCalls, "NewPayload should be called once for synthetic block")
 				require.NotNil(t, l2.lastNewPayload)
-				// The synthetic payload should have modified fee recipient
-				require.Equal(t, common.MaxAddress, l2.lastNewPayload.FeeRecipient, "Synthetic payload should have modified fee recipient")
+				// The synthetic payload should have modified ExtraData to change the block hash
+				require.NotEqual(t, payloadEnvelope.ExecutionPayload.ExtraData, l2.lastNewPayload.ExtraData, "Synthetic payload should have modified ExtraData")
 
 				// Verify ForkchoiceUpdate was called twice (once for synthetic, once for target)
 				require.Equal(t, 2, l2.fcuCalls, "ForkchoiceUpdate should be called twice")


### PR DESCRIPTION
Fixes an edge case where the synthetic payload by the supernode (when it tries to rewind an engine) would be rejected due to an incorrect state root. That would only happen if there were state changes in the original block (which the synthetic payload is constructed from) which depend on the `block.coinbase` (which has been mutated to make the synthetic payload).

We never ran into this yet because test blocks (or devnet blocks) typically don't have smart contracts which modify state based on `COINBASE`, but that is certainly something which can crop up on a realistic chain. Hence the need to fix this.

h/t to runtime verification and almanax for finding this!