### PR TITLE
fix(op-acceptance-tests): Use WaitForStall in ELSync flaky tests

### DIFF
--- a/op-acceptance-tests/tests/depreqres/common/common.go
+++ b/op-acceptance-tests/tests/depreqres/common/common.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-service/testreq"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
@@ -71,22 +70,6 @@ func SyncModeReqRespSyncOpts(syncMode sync.Mode) []presets.Option {
 	}
 }
 
-// stableSyncStatus returns the sync status of node after any in-flight gossip messages
-// have been drained. DisconnectPeer closes the libp2p connection but a buffered gossip
-// payload can still arrive and be processed via AddUnsafePayload (SyncModeReqResp=true
-// routes CL gossip through the CLSync path even in ELSync mode). Polling until the
-// head is stable ensures the snapshot reflects a quiesced state.
-func stableSyncStatus(require *testreq.Assertions, node *dsl.L2CLNode) *eth.SyncStatus {
-	ss := node.SyncStatus()
-	require.Eventually(func() bool {
-		next := node.SyncStatus()
-		stable := next.UnsafeL2.Number == ss.UnsafeL2.Number
-		ss = next
-		return stable
-	}, 15*time.Second, 200*time.Millisecond, "L2CLB head should stabilize after disconnect")
-	return ss
-}
-
 func UnsafeChainNotStalling_Disconnect(gt *testing.T, syncMode sync.Mode, sleep time.Duration, opts ...presets.Option) {
 	t := devtest.SerialT(gt)
 	sys := presets.NewSingleChainMultiNodeWithoutCheck(t, opts...)
@@ -105,7 +88,8 @@ func UnsafeChainNotStalling_Disconnect(gt *testing.T, syncMode sync.Mode, sleep 
 	sys.L2CL.DisconnectPeer(sys.L2CLB)
 
 	ssA_before := sys.L2CL.SyncStatus()
-	ssB_before := stableSyncStatus(require, sys.L2CLB)
+	sys.L2CLB.WaitForStall(types.LocalUnsafe)
+	ssB_before := sys.L2CLB.SyncStatus()
 
 	l.Info("L2CL status before delay", "unsafeL2", ssA_before.UnsafeL2.ID(), "safeL2", ssA_before.SafeL2.ID())
 	l.Info("L2CLB status before delay", "unsafeL2", ssB_before.UnsafeL2.ID(), "safeL2", ssB_before.SafeL2.ID())
@@ -126,8 +110,8 @@ func UnsafeChainNotStalling_Disconnect(gt *testing.T, syncMode sync.Mode, sleep 
 	sys.L2CL.ConnectPeer(sys.L2CLB)
 
 	l.Info("Confirm that the unsafe chain for L2CLB is not stalled")
-	sys.L2CLB.Reached(types.LocalUnsafe, ssA_after.UnsafeL2.Number, 60)
-	sys.L2ELB.Reached(eth.Unsafe, ssA_after.UnsafeL2.Number, 60)
+	sys.L2CLB.Reached(types.LocalUnsafe, ssA_after.UnsafeL2.Number, 30)
+	sys.L2ELB.Reached(eth.Unsafe, ssA_after.UnsafeL2.Number, 30)
 }
 
 func UnsafeChainNotStalling_RestartOpNode(gt *testing.T, syncMode sync.Mode, sleep time.Duration, opts ...presets.Option) {
@@ -148,7 +132,8 @@ func UnsafeChainNotStalling_RestartOpNode(gt *testing.T, syncMode sync.Mode, sle
 	sys.L2CL.DisconnectPeer(sys.L2CLB)
 
 	ssA_before := sys.L2CL.SyncStatus()
-	ssB_before := stableSyncStatus(require, sys.L2CLB)
+	sys.L2CLB.WaitForStall(types.LocalUnsafe)
+	ssB_before := sys.L2CLB.SyncStatus()
 
 	l.Info("L2CL status before delay", "unsafeL2", ssA_before.UnsafeL2.ID(), "safeL2", ssA_before.SafeL2.ID())
 	l.Info("L2CLB status before delay", "unsafeL2", ssB_before.UnsafeL2.ID(), "safeL2", ssB_before.SafeL2.ID())
@@ -173,6 +158,6 @@ func UnsafeChainNotStalling_RestartOpNode(gt *testing.T, syncMode sync.Mode, sle
 	sys.L2CL.ConnectPeer(sys.L2CLB)
 
 	l.Info("Confirm that the unsafe chain for L2CLB is not stalled")
-	sys.L2CLB.Reached(types.LocalUnsafe, ssA_after.UnsafeL2.Number, 60)
-	sys.L2ELB.Reached(eth.Unsafe, ssA_after.UnsafeL2.Number, 60)
+	sys.L2CLB.Reached(types.LocalUnsafe, ssA_after.UnsafeL2.Number, 30)
+	sys.L2ELB.Reached(eth.Unsafe, ssA_after.UnsafeL2.Number, 30)
 }

--- a/op-acceptance-tests/tests/depreqres/common/common.go
+++ b/op-acceptance-tests/tests/depreqres/common/common.go
@@ -83,7 +83,7 @@ func stableSyncStatus(require *testreq.Assertions, node *dsl.L2CLNode) *eth.Sync
 		stable := next.UnsafeL2.Number == ss.UnsafeL2.Number
 		ss = next
 		return stable
-	}, 5*time.Second, 200*time.Millisecond, "L2CLB head should stabilize after disconnect")
+	}, 15*time.Second, 200*time.Millisecond, "L2CLB head should stabilize after disconnect")
 	return ss
 }
 
@@ -126,8 +126,8 @@ func UnsafeChainNotStalling_Disconnect(gt *testing.T, syncMode sync.Mode, sleep 
 	sys.L2CL.ConnectPeer(sys.L2CLB)
 
 	l.Info("Confirm that the unsafe chain for L2CLB is not stalled")
-	sys.L2CLB.Reached(types.LocalUnsafe, ssA_after.UnsafeL2.Number, 30)
-	sys.L2ELB.Reached(eth.Unsafe, ssA_after.UnsafeL2.Number, 30)
+	sys.L2CLB.Reached(types.LocalUnsafe, ssA_after.UnsafeL2.Number, 60)
+	sys.L2ELB.Reached(eth.Unsafe, ssA_after.UnsafeL2.Number, 60)
 }
 
 func UnsafeChainNotStalling_RestartOpNode(gt *testing.T, syncMode sync.Mode, sleep time.Duration, opts ...presets.Option) {
@@ -173,6 +173,6 @@ func UnsafeChainNotStalling_RestartOpNode(gt *testing.T, syncMode sync.Mode, sle
 	sys.L2CL.ConnectPeer(sys.L2CLB)
 
 	l.Info("Confirm that the unsafe chain for L2CLB is not stalled")
-	sys.L2CLB.Reached(types.LocalUnsafe, ssA_after.UnsafeL2.Number, 30)
-	sys.L2ELB.Reached(eth.Unsafe, ssA_after.UnsafeL2.Number, 30)
+	sys.L2CLB.Reached(types.LocalUnsafe, ssA_after.UnsafeL2.Number, 60)
+	sys.L2ELB.Reached(eth.Unsafe, ssA_after.UnsafeL2.Number, 60)
 }


### PR DESCRIPTION
## Summary

Fixes flaky `TestUnsafeChainNotStalling_ELSync_*` tests by replacing the custom `stableSyncStatus` helper with the existing `WaitForStall` DSL method.

**Replace `stableSyncStatus` with `WaitForStall`**
After peer disconnect, buffered gossip payloads can still arrive and be processed via `AddUnsafePayload`. The original `stableSyncStatus` helper polled every 200ms — mismatched with the 2s block production cadence — and only required two consecutive polls showing the same head to declare stability.

`L2CLNode.WaitForStall(types.LocalUnsafe)` is the DSL's purpose-built method for this: it polls every 2s (matching block times), requires 10 seconds of no movement, and has a 2-minute outer timeout. This is a more robust stability check that eliminates the flaky timing window.

Leaving this in flake-shake until it can prove itself stable.

#19611

🤖 Generated with [Claude Code](https://claude.com/claude-code)