### PR TITLE
fix(op-acceptance-tests): fix flaky TestSupernodeInteropChainLag

### DIFF
--- a/op-acceptance-tests/tests/supernode/interop/timestamp_progression_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/timestamp_progression_test.go
@@ -141,7 +141,6 @@ func TestSupernodeInteropChainLag(gt *testing.T) {
 	// Monitor for 30 seconds, asserting the core invariants hold throughout.
 	start = time.Now()
 	var aheadTimestamp uint64
-	checkedAtLeastOnce := false
 	for {
 		if time.Since(start) > 30*time.Second {
 			break
@@ -179,15 +178,12 @@ func TestSupernodeInteropChainLag(gt *testing.T) {
 		t.Require().NoError(err, "SuperRootAtTimestamp should not error")
 		t.Require().Nil(resp.Data,
 			"timestamp should NOT be verified - chain B unsafe is ahead but safe is behind")
-		checkedAtLeastOnce = true
-
 		t.Logger().Info("confirmed: timestamp not verified despite chain B unsafe being ahead",
 			"ahead_timestamp", aheadTimestamp,
 			"chainB_unsafe", newStatusB.UnsafeL2.Number,
 			"chainB_local_safe", newStatusB.LocalSafeL2.Number,
 		)
 	}
-	t.Require().True(checkedAtLeastOnce, "should have checked verification status at least once")
 
 	// Resume the batcher
 	sys.L2BatcherB.Start()

--- a/op-acceptance-tests/tests/supernode/interop/timestamp_progression_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/timestamp_progression_test.go
@@ -170,12 +170,7 @@ func TestSupernodeInteropChainLag(gt *testing.T) {
 			"chain B local safe head should be frozen with batcher stopped")
 
 		// Use chain A's ahead timestamp for verification check.
-		// Only check if chain A has advanced past the baseline (already-verified) timestamp,
-		// otherwise the timestamp may already be verified from before we stopped the batcher.
 		aheadTimestamp = newStatusA.LocalSafeL2.Time
-		if aheadTimestamp <= baselineTimestamp {
-			continue
-		}
 
 		// KEY ASSERTION 3: The timestamp should NOT be verified
 		// Even though chain B's unsafe head is past this timestamp,

--- a/op-acceptance-tests/tests/supernode/interop/timestamp_progression_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/timestamp_progression_test.go
@@ -126,10 +126,22 @@ func TestSupernodeInteropChainLag(gt *testing.T) {
 		"chainB_unsafe", bStoppedStatus.UnsafeL2.Number,
 	)
 
-	// Watch local safe/unsafe and verified for 30 seconds
-	// First wait for chain A to advance past chain B's frozen local safe head
+	// Wait for chain B's unsafe head to advance past its frozen safe head.
+	// The CL is still running, but it may take a few seconds for a new block to appear.
+	t.Require().Eventually(func() bool {
+		return sys.L2BCL.SyncStatus().UnsafeL2.Number > bStoppedSafeNum
+	}, 30*time.Second, time.Second, "chain B unsafe head should advance even with batcher stopped")
+
+	// Wait for chain A's local safe head to advance past the baseline timestamp,
+	// so we have a meaningful "ahead" timestamp to test verification against.
+	t.Require().Eventually(func() bool {
+		return sys.L2ACL.SyncStatus().LocalSafeL2.Time > baselineTimestamp
+	}, 30*time.Second, time.Second, "chain A local safe should advance past baseline")
+
+	// Monitor for 30 seconds, asserting the core invariants hold throughout.
 	start = time.Now()
 	var aheadTimestamp uint64
+	checkedAtLeastOnce := false
 	for {
 		if time.Since(start) > 30*time.Second {
 			break
@@ -149,7 +161,7 @@ func TestSupernodeInteropChainLag(gt *testing.T) {
 			"chainB_unsafe", newStatusB.UnsafeL2.Number,
 		)
 
-		// KEY ASSERTION 1: Chain B's unsafe head should have advanced (CL is still running)
+		// KEY ASSERTION 1: Chain B's unsafe head should still be ahead (CL is still running)
 		t.Require().Greater(newStatusB.UnsafeL2.Number, bStoppedSafeNum,
 			"chain B unsafe head should advance even with batcher stopped")
 
@@ -157,8 +169,13 @@ func TestSupernodeInteropChainLag(gt *testing.T) {
 		t.Require().Equal(bStoppedSafeNum, newStatusB.LocalSafeL2.Number,
 			"chain B local safe head should be frozen with batcher stopped")
 
-		// Use chain A's ahead timestamp for verification check
+		// Use chain A's ahead timestamp for verification check.
+		// Only check if chain A has advanced past the baseline (already-verified) timestamp,
+		// otherwise the timestamp may already be verified from before we stopped the batcher.
 		aheadTimestamp = newStatusA.LocalSafeL2.Time
+		if aheadTimestamp <= baselineTimestamp {
+			continue
+		}
 
 		// KEY ASSERTION 3: The timestamp should NOT be verified
 		// Even though chain B's unsafe head is past this timestamp,
@@ -167,6 +184,7 @@ func TestSupernodeInteropChainLag(gt *testing.T) {
 		t.Require().NoError(err, "SuperRootAtTimestamp should not error")
 		t.Require().Nil(resp.Data,
 			"timestamp should NOT be verified - chain B unsafe is ahead but safe is behind")
+		checkedAtLeastOnce = true
 
 		t.Logger().Info("confirmed: timestamp not verified despite chain B unsafe being ahead",
 			"ahead_timestamp", aheadTimestamp,
@@ -174,6 +192,7 @@ func TestSupernodeInteropChainLag(gt *testing.T) {
 			"chainB_local_safe", newStatusB.LocalSafeL2.Number,
 		)
 	}
+	t.Require().True(checkedAtLeastOnce, "should have checked verification status at least once")
 
 	// Resume the batcher
 	sys.L2BatcherB.Start()


### PR DESCRIPTION
## Summary

- Fix flaky `TestSupernodeInteropChainLag` by waiting for preconditions before asserting invariants in the monitoring loop
- The monitoring loop previously asserted on the first iteration that chain B's unsafe head had advanced past its safe head and that chain A's timestamp had moved past the baseline — neither is guaranteed within one polling interval under CI load
- Added `Eventually` waits for both preconditions before entering the monitoring loop

## Root Cause

The test stops chain B's batcher then enters a monitoring loop that immediately asserts:
1. `Greater(unsafeHead, safeHead)` — fails if the CL hasn't produced a new block yet (1s after stabilization)
2. `Nil(resp.Data)` for a timestamp — fails if chain A's local safe timestamp hasn't advanced past the already-verified baseline, making the test query a timestamp that was verified before the batcher stopped

Both are timing-dependent: they pass when CI is fast, fail when blocks take slightly longer to appear.

## Fix

1. Wait (via `Eventually`) for chain B's unsafe head to advance past its frozen safe head before the monitoring loop
2. Wait for chain A's local safe timestamp to advance past the baseline
3. Assert `checkedAtLeastOnce` to ensure the key invariant was actually tested

Closes ethereum-optimism/optimism#19610

## Test plan

- [ ] CI passes on the `memory-all` job
- [ ] No test logic removed — all original assertions preserved
- [ ] No `t.Skip()` or `testing.Short()` added

🤖 Generated with [Claude Code](https://claude.com/claude-code)