### PR TITLE
fix(op-acceptance-tests): re-enable TestSupernodeInteropActivationAfterGenesis

### DIFF
--- a/op-acceptance-tests/acceptance-tests.yaml
+++ b/op-acceptance-tests/acceptance-tests.yaml
@@ -55,6 +55,12 @@ gates:
         metadata:
           owner: "anton evangelatov"
           target_gate: "depreqres"
+      - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/supernode/interop/activation
+        name: TestSupernodeInteropActivationAfterGenesis
+        timeout: 10m
+        metadata:
+          owner: "adrian sutton"
+          target_gate: "supernode-interop"
       - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/supernode/interop
         name: TestSupernodeInteropChainLag
         timeout: 15m

--- a/op-acceptance-tests/acceptance-tests.yaml
+++ b/op-acceptance-tests/acceptance-tests.yaml
@@ -55,12 +55,6 @@ gates:
         metadata:
           owner: "anton evangelatov"
           target_gate: "depreqres"
-      - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/supernode/interop/activation
-        name: TestSupernodeInteropActivationAfterGenesis
-        timeout: 10m
-        metadata:
-          owner: "adrian sutton"
-          target_gate: "supernode-interop"
       - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/supernode/interop
         name: TestSupernodeInteropChainLag
         timeout: 15m

--- a/op-acceptance-tests/tests/supernode/interop/activation/activation_after_genesis_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/activation/activation_after_genesis_test.go
@@ -18,7 +18,6 @@ const InteropActivationDelay = uint64(20)
 // verified data for timestamps both before and after the activation boundary.
 func TestSupernodeInteropActivationAfterGenesis(gt *testing.T) {
 	t := devtest.ParallelT(gt)
-	t.Skip("The TestMain setup code for this test is unstable")
 	sys := presets.NewTwoL2SupernodeInterop(t, InteropActivationDelay)
 
 	genesisTime := sys.GenesisTime


### PR DESCRIPTION
## Summary

- Re-enables `TestSupernodeInteropActivationAfterGenesis` by removing the `t.Skip` added in ethereum-optimism/optimism#19402
- The skip was added because `presets.WithTwoL2SupernodeInterop` with a nonzero interop activation delay caused supernode shutdown hangs
- The root cause (Start/Stop race condition) was fixed in ethereum-optimism/optimism#19576, which introduced a lifecycle context that prevents goroutine hangs during shutdown
- No test logic changes needed — the 300s Eventually timeout is sufficient for the 20-second activation delay

Closes ethereum-optimism/optimism#19403
Closes ethereum-optimism/optimism#19609

## Test plan

- [ ] CI passes with the test re-enabled (no longer skipped)
- [ ] `memory-all` job completes without shutdown hangs
- [ ] Run the test locally with `-count=5` to verify stability

🤖 Generated with [Claude Code](https://claude.com/claude-code)