### PR TITLE
op-node: reset SafeDB from local-safe head on engine reset

### DIFF
--- a/op-node/rollup/driver/sync_deriver.go
+++ b/op-node/rollup/driver/sync_deriver.go
@@ -158,8 +158,8 @@ func (s *SyncDeriver) onEngineConfirmedReset(ctx context.Context, x engine.Engin
 	// and don't confirm the engine-reset with the derivation pipeline.
 	// The pipeline will re-trigger a reset as necessary.
 	if s.SafeHeadNotifs != nil {
-		if err := s.SafeHeadNotifs.SafeHeadReset(x.CrossSafe); err != nil {
-			s.Log.Error("Failed to warn safe-head notifier of safe-head reset", "safe", x.CrossSafe)
+		if err := s.SafeHeadNotifs.SafeHeadReset(x.LocalSafe); err != nil {
+			s.Log.Error("Failed to warn safe-head notifier of safe-head reset", "safe", x.LocalSafe)
 			return
 		}
 		if s.SafeHeadNotifs.Enabled() && x.LocalSafe.ID() == s.Config.Genesis.L2 {


### PR DESCRIPTION
## Summary
This changes the SafeDB reset callback on `EngineResetConfirmedEvent` to use `LocalSafe` instead of `CrossSafe`.

## Issue
In the supernode/interop verifier path, `CrossSafe` can lag far behind `LocalSafe` during startup — particularly when the `VerifiedDB` is empty (fresh node or after a wipe), causing `SafeL2Head()` to fall back to genesis block 0.

The current reset wiring calls `SafeHeadReset(x.CrossSafe)`, which truncates SafeDB to the cross-safe head. When cross-safe is at genesis, `SafeHeadReset` deletes **all** entries because genesis is before the first SafeDB entry (see `SafeHeadReset` — the `hasPrevEntry` check fails, so nothing is re-written).

After the wipe, derivation continues from wherever the EL left off (e.g. L1 ~10,432,000) and only writes new SafeDB entries from that point forward. The historical entries from L1 genesis through the derivation resume point are permanently lost and never backfilled. The interop activity then fails when trying to walk back through SafeDB to find when earlier L2 blocks became safe:

```
L1AtSafeHead: walkback lookup failed, stopping
  chain_id=420120047  probe_l1=10432004  target=290754  err="not found"
failed to progress and record interop  activity=interop
  err="chain 420120047 not ready for timestamp 1772030700: not found"
```

### Root cause chain
1. `EngineResetConfirmedEvent` sets `CrossSafe: e.SafeL2Head()`
2. `SafeL2Head()` queries `superAuthority.FullyVerifiedL2Head()` → empty (no verified timestamps) → falls back to genesis block 0
3. `SyncDeriver.onEngineConfirmedReset` calls `SafeHeadReset(cross_safe=genesis)` → wipes entire SafeDB
4. Derivation continues from EL's current position, not from genesis → gap is never rebuilt
5. Interop activity starts from activation timestamp, needs SafeDB entries in the gap → permanently stuck

### Code path
- `engine_controller.go:991-996` — `CrossSafe: e.SafeL2Head()`
- `engine_controller.go:205-215` — `SafeL2Head()` genesis fallback when `FullyVerifiedL2Head()` is empty
- `sync_deriver.go:161` — `SafeHeadReset(x.CrossSafe)`
- `safedb.go:115-165` — `SafeHeadReset` deletes all entries when target is before first entry

## Fix
Use `x.LocalSafe` when notifying the SafeDB listener of an engine reset. This aligns SafeDB truncation with the derivation reset point, preserving historical entries that the interop activity needs for L1AtSafeHead walkback queries.

## Testing
- `go test ./op-node/rollup/driver`

## Validation
- [x] Reproduced the bug on interop-v0 `op-supernode-2` by upgrading to latest develop — interop activity stuck at activation timestamp with walkback "not found" errors
- [x] Confirmed SafeDB was wiped to genesis on startup (logs show `Resetting safe head db  l2=...block 0`)
- [x] Deployed fix to supernode-2 — SafeDB now reset to `local_safe` instead of genesis
- [x] Interop activity progresses past activation timestamp (verified timestamps advancing at ~264/min)
- [x] No recurrence of the "not found" walkback errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)