### PR TITLE
fix(op-node): handle reorged super authority heads gracefully

### DIFF
--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -264,7 +264,12 @@ func (e *EngineController) FinalizedHead() eth.L2BlockRef {
 		}
 		br, err := e.engine.L2BlockRefByHash(e.ctx, f.Hash)
 		if err != nil {
-			panic("superAuthority supplied an identifier for the finalized head which is not known to the engine")
+			// The super authority's finalized head may point to a block that was
+			// reorganized away. Fall back to the local finalized head until the
+			// super authority updates its state after the reorg.
+			e.log.Warn("super authority finalized head not found in engine, falling back to local finalized head",
+				"fid", f, "local_finalized", e.localFinalizedHead, "err", err)
+			return e.localFinalizedHead
 		}
 		return br
 	} else if e.supervisorEnabled || e.syncCfg.FollowSourceEnabled() {

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -226,7 +226,12 @@ func (e *EngineController) SafeL2Head() eth.L2BlockRef {
 		}
 		br, err := e.engine.L2BlockRefByHash(e.ctx, fvshid.Hash)
 		if err != nil {
-			panic("superAuthority supplied an identifier for the safe head which is not known to the engine")
+			// The super authority's verified safe head may point to a block that was
+			// reorganized away. Fall back to the local safe head until the super authority
+			// updates its state after the reorg.
+			e.log.Warn("super authority safe head not found in engine, falling back to local safe head",
+				"fvshid", fvshid, "local_safe", e.localSafeHead, "err", err)
+			return e.localSafeHead
 		}
 		return br
 	} else if e.supervisorEnabled || e.syncCfg.FollowSourceEnabled() {

--- a/op-node/rollup/engine/engine_controller_test.go
+++ b/op-node/rollup/engine/engine_controller_test.go
@@ -557,7 +557,7 @@ func TestEngineController_FinalizedHead(t *testing.T) {
 			expectResult: &eth.L2BlockRef{},
 		},
 		{
-			name: "panics when SuperAuthority block unknown to engine",
+			name: "falls back to local finalized when SuperAuthority block unknown to engine (reorg)",
 			setupSuperAuth: func() *mockSuperAuthority {
 				return &mockSuperAuthority{
 					finalizedL2Head: eth.BlockID{Hash: common.Hash{0x99}, Number: 50},
@@ -568,7 +568,7 @@ func TestEngineController_FinalizedHead(t *testing.T) {
 			setupEngine: func(m *testutils.MockEngine) {
 				m.ExpectL2BlockRefByHash(common.Hash{0x99}, eth.L2BlockRef{}, errors.New("block not found"))
 			},
-			expectPanic: "superAuthority supplied an identifier for the finalized head which is not known to the engine",
+			expectResult: &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
 		},
 	}
 

--- a/op-node/rollup/engine/engine_controller_test.go
+++ b/op-node/rollup/engine/engine_controller_test.go
@@ -278,7 +278,7 @@ func TestEngineController_SafeL2Head(t *testing.T) {
 			expectResult:   &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
 		},
 		{
-			name:              "panics when SuperAuthority block unknown to engine",
+			name:              "falls back to local safe when SuperAuthority block unknown to engine (reorg)",
 			supervisorEnabled: true,
 			setupSuperAuth: func() *mockSuperAuthority {
 				return &mockSuperAuthority{
@@ -289,7 +289,7 @@ func TestEngineController_SafeL2Head(t *testing.T) {
 			setupEngine: func(m *testutils.MockEngine) {
 				m.ExpectL2BlockRefByHash(common.Hash{0x99}, eth.L2BlockRef{}, errors.New("block not found"))
 			},
-			expectPanic: "superAuthority supplied an identifier for the safe head which is not known to the engine",
+			expectResult: &eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100},
 		},
 	}
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

During a reorg, both the safe head and finalized head held by the `SuperAuthority` can reference blocks that the local engine has reorganized away. The super authority updates asynchronously via `Reset()` calls from the rewinder, so there is always a transient window where its block IDs are stale.

`SafeL2Head()` already handled this correctly — when `L2BlockRefByHash` fails, it falls back to `localSafeHead` and logs a warning. `FinalizedHead()` had an identical code path but panicked instead, crashing the node.

Changes

**Commit 1** (`fix(op-node): handle reorged super authority safe head gracefully`)
Replaces the panic in `SafeL2Head()` with a warn log and fallback to `localSafeHead`.

**Commit 2** (`fix(op-node): handle reorged super authority finalized head gracefully`)
Applies the same fix to `FinalizedHead()`: replaces the panic with a warn log and fallback to `localFinalizedHead`.

Why the fallback is safe

`FinalizedHead()` already has a bounds check that caps the returned value at `localSafeHead.Number`. `localFinalizedHead` satisfies `Finalized ≤ Safe` by construction (set by local derivation), so returning it cannot violate that invariant. The node reports a slightly stale finalized head for the duration of the reorg window and self-corrects once the super authority calls `Reset()` with the post-reorg state.

**Tests** 

Both test cases previously asserting panic behavior (`expectPanic`) are updated to assert the fallback return value (`expectResult`). All existing cases in `TestEngineController_SafeL2Head` and `TestEngineController_FinalizedHead` pass.

```
go test ./op-node/rollup/engine/...
ok  github.com/ethereum-optimism/optimism/op-node/rollup/engine  0.015s
```

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
