### PR TITLE
fix(op-supernode): cap interop CurrentL1 at min of node CurrentL1s on advance

### DIFF
--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -522,6 +522,12 @@ func (i *Interop) applyPendingTransition(pending PendingTransition) (bool, error
 			return false, fmt.Errorf("clear pending transition: %w", err)
 		}
 		i.log.Info("committed verified result", "timestamp", pending.Result.Timestamp)
+		// L1Inclusion is the max L1 block used for derivation across all chains at this
+		// timestamp. It can exceed some chains' actual CurrentL1 — e.g. chain A derived
+		// from L1 1000 while chain B derived from L1 990. Chain B may then advance to
+		// the next timestamp (finding its batch at L1 995) without ever reaching L1 1000.
+		// Cap at the min of all nodes' CurrentL1 so this field is individually safe, not
+		// just safe when aggregated with chain CurrentL1s via syncstatus.Aggregate.
 		currentL1 := pending.Result.L1Inclusion
 		if localL1, err := i.collectCurrentL1(); err != nil {
 			i.log.Warn("failed to collect node CurrentL1 on advance, using L1Inclusion", "err", err)

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -522,8 +522,14 @@ func (i *Interop) applyPendingTransition(pending PendingTransition) (bool, error
 			return false, fmt.Errorf("clear pending transition: %w", err)
 		}
 		i.log.Info("committed verified result", "timestamp", pending.Result.Timestamp)
+		currentL1 := pending.Result.L1Inclusion
+		if localL1, err := i.collectCurrentL1(); err != nil {
+			i.log.Warn("failed to collect node CurrentL1 on advance, using L1Inclusion", "err", err)
+		} else if localL1.Number < currentL1.Number {
+			currentL1 = localL1
+		}
 		i.mu.Lock()
-		i.currentL1 = pending.Result.L1Inclusion
+		i.currentL1 = currentL1
 		i.mu.Unlock()
 		return true, nil
 	}

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -1043,6 +1043,36 @@ func TestProgressAndRecord(t *testing.T) {
 			},
 		},
 		{
+			name: "valid result caps L1 at min node CurrentL1 when L1Inclusion exceeds it",
+			setup: func(h *interopTestHarness) *interopTestHarness {
+				return h.WithChain(10, func(m *mockChainContainer) {
+					m.currentL1 = eth.BlockRef{Number: 1000, Hash: common.HexToHash("0xleading")}
+					m.blockAtTimestamp = eth.L2BlockRef{Number: 100, Hash: common.HexToHash("0xL2a")}
+				}).WithChain(8453, func(m *mockChainContainer) {
+					m.currentL1 = eth.BlockRef{Number: 990, Hash: common.HexToHash("0xlagging")}
+					m.blockAtTimestamp = eth.L2BlockRef{Number: 200, Hash: common.HexToHash("0xL2b")}
+				}).Build()
+			},
+			run: func(t *testing.T, h *interopTestHarness) {
+				// L1Inclusion is 1000 (from the leading chain) but chain 8453 is only at 990.
+				// interop.currentL1 must be capped at 990 so it never exceeds any node's CurrentL1.
+				h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID) (Result, error) {
+					return Result{
+						Timestamp:    ts,
+						L1Inclusion:  eth.BlockID{Number: 1000, Hash: common.HexToHash("0xleading")},
+						L2Heads:      blocks,
+					}, nil
+				}
+
+				madeProgress, err := h.interop.progressAndRecord()
+				require.NoError(t, err)
+				require.True(t, madeProgress)
+
+				require.Equal(t, uint64(990), h.interop.currentL1.Number)
+				require.Equal(t, common.HexToHash("0xlagging"), h.interop.currentL1.Hash)
+			},
+		},
+		{
 			name: "invalid result does not update L1",
 			setup: func(h *interopTestHarness) *interopTestHarness {
 				return h.WithChain(10, func(m *mockChainContainer) {

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -1058,9 +1058,9 @@ func TestProgressAndRecord(t *testing.T) {
 				// interop.currentL1 must be capped at 990 so it never exceeds any node's CurrentL1.
 				h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID) (Result, error) {
 					return Result{
-						Timestamp:    ts,
-						L1Inclusion:  eth.BlockID{Number: 1000, Hash: common.HexToHash("0xleading")},
-						L2Heads:      blocks,
+						Timestamp:   ts,
+						L1Inclusion: eth.BlockID{Number: 1000, Hash: common.HexToHash("0xleading")},
+						L2Heads:     blocks,
 					}, nil
 				}
 


### PR DESCRIPTION
## Summary

- When interop advances a timestamp, `L1Inclusion` is the **max** L1 block used for derivation across all chains. This can exceed some chains' actual `CurrentL1` — e.g. chain A derived T from L1 1000, chain B from L1 990, but chain B might find its T+1 batch at L1 995 without ever processing L1 1000. Interop would have reported `currentL1 = 1000` while chain B was still at 990.
- The external `syncstatus.Aggregate()` view was always safe (it takes `min(chains' CurrentL1, interop.CurrentL1())`), but the interop activity's `currentL1` field didn't satisfy the safety invariant individually.
- Fix: on advance, set `currentL1 = min(L1Inclusion, min(chains' CurrentL1))`, matching the conservative semantics already used by the wait path (`refreshCurrentL1OnWait`). Falls back to L1Inclusion with a warning if `collectCurrentL1` fails.

## Test plan

- [ ] Existing `valid result sets L1 to result L1Head` test still passes (chain at 200, L1Inclusion 150 → uses 150, the lower value)
- [ ] New `valid result caps L1 at min node CurrentL1 when L1Inclusion exceeds it` test: chain A at 1000, chain B at 990, L1Inclusion 1000 → `currentL1` is capped at 990

🤖 Generated with [Claude Code](https://claude.com/claude-code)