### PR TITLE
docs: update README build commands from make to just

### DIFF
--- a/.claude/skills/vm-compat-triage/SKILL.md
+++ b/.claude/skills/vm-compat-triage/SKILL.md
@@ -18,7 +18,7 @@ Use when the `analyze-op-program-client` CI job fails on a PR. The job runs `vm-
 - `gh` CLI authenticated with GitHub
 - `jq` available
 - `vm-compat` binary (install: `mise use -g ubi:ChainSafe/vm-compat@1.1.0`, or download from GitHub releases — binary name is `analyzer-linux-arm64` / `analyzer-linux-amd64`)
-- `llvm-objdump` — **Linux only** (install: `sudo apt-get install -y llvm`). Not available on macOS. On macOS, use `make run-vm-compat` in the `op-program` directory which runs the analysis inside Docker.
+- `llvm-objdump` — **Linux only** (install: `sudo apt-get install -y llvm`). Not available on macOS. On macOS, use `just run-vm-compat` in the `op-program` directory which runs the analysis inside Docker.
 - The PR URL or number (ask the user if not provided)
 
 ## MIPS64 Syscall Reference
@@ -161,7 +161,7 @@ vm-compat analyze \
 **On macOS** (`llvm-objdump` is not available natively — use Docker):
 ```bash
 # From the op-program directory in the PR branch worktree:
-make run-vm-compat
+just run-vm-compat
 ```
 This builds and runs the analysis inside Docker. The findings JSON will be in the Docker build output (and as a CI artifact if the artifact capture PR is merged).
 

--- a/op-chain-ops/cmd/ecotone-scalar/README.md
+++ b/op-chain-ops/cmd/ecotone-scalar/README.md
@@ -7,9 +7,9 @@ configuring the base fee scalar and blob base fee scalars separately.
 
 #### Usage
 
-Build and run using the [Makefile](../../Makefile) `ecotone-scalar` target. Inside of `/op-chain-ops`, run:
+Build and run using the `ecotone-scalar` target. Inside of `/op-chain-ops`, run:
 ```sh
-make ecotone-scalar
+just ecotone-scalar
 ```
 to create a binary in [../../bin/ecotone-scalar](../../bin/ecotone-scalar) that can
 be executed, providing the `--scalar` and `--blob-scalar` flags to specify the base bee scalar and

--- a/op-challenger/README.md
+++ b/op-challenger/README.md
@@ -9,8 +9,7 @@ the [fault proof specs][proof-specs].
 
 ## Quickstart
 
-To build the `op-challenger`, run `make` (which executes the `make build`
-[Makefile](./Makefile) target). To view a list of available commands and
+To build the `op-challenger`, run `just op-challenger`. To view a list of available commands and
 options, run `./bin/op-challenger --help`.
 
 ## Usage
@@ -24,7 +23,7 @@ accessed by running `./op-challenger --help`.
 To run `op-challenger` against a local devnet, first start a local devnet
 that exposes the `simple-devnet` enclave.
 
-Then build the `op-challenger` with `make op-challenger`.
+Then build the `op-challenger` with `just op-challenger`.
 
 Run the `op-challenger` with:
 

--- a/op-dispute-mon/README.md
+++ b/op-dispute-mon/README.md
@@ -7,7 +7,7 @@ The `op-dispute-mon` is an off-chain service to monitor dispute games.
 Clone this repo. Then run:
 
 ```shell
-make op-dispute-mon
+just op-dispute-mon
 ```
 
 This will build the `op-dispute-mon` binary which can be run with

--- a/op-service/README.md
+++ b/op-service/README.md
@@ -61,9 +61,9 @@ Pull requests: [monorepo](https://github.com/ethereum-optimism/optimism/pulls?q=
 From `op-service` dir:
 ```bash
 # Run Go tests
-make test
+just test
 # Run Go fuzz tests
-make fuzz
+just fuzz
 ```
 
 ## Product

--- a/op-supervisor/README.md
+++ b/op-supervisor/README.md
@@ -23,7 +23,7 @@ The `op-supervisor` functions as a [superchain backend], implementing the [inter
 ## Quickstart
 
 ```bash
-make op-supervisor
+just op-supervisor
 
 # Key configurables:
 # datadir: where to store indexed interop data
@@ -43,7 +43,7 @@ make op-supervisor
 
 ```bash
 # from op-supervisor dir:
-make op-supervisor
+just op-supervisor
 ./bin/op-supervisor --help
 ```
 


### PR DESCRIPTION
## Summary
- Update build command references in `op-challenger`, `op-supervisor`, `op-dispute-mon`, and `ecotone-scalar` READMEs to use `just` instead of `make`
- Part of the ongoing build system migration from Make to Just (ref: ethereum-optimism/optimism#19546)

## Test plan
- [ ] Verify `just op-challenger`, `just op-supervisor`, `just op-dispute-mon`, and `just ecotone-scalar` targets exist and build successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)