### PR TITLE
fix(op-deployer): increase timeouts for TestCLIMigrate tests

### DIFF
--- a/op-deployer/pkg/deployer/integration_test/cli/cli_runner.go
+++ b/op-deployer/pkg/deployer/integration_test/cli/cli_runner.go
@@ -179,7 +179,7 @@ func (r *CLITestRunner) RunWithNetwork(ctx context.Context, args []string, env m
 // ExpectSuccess runs a command expecting it to succeed
 func (r *CLITestRunner) ExpectSuccess(t *testing.T, args []string, env map[string]string) string {
 	r.lgr.Info("Running cli command, expecting success")
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
 	output, err := r.Run(ctx, args, env)
@@ -190,7 +190,7 @@ func (r *CLITestRunner) ExpectSuccess(t *testing.T, args []string, env map[strin
 // ExpectSuccessWithNetwork runs a command with network parameters expecting it to succeed
 func (r *CLITestRunner) ExpectSuccessWithNetwork(t *testing.T, args []string, env map[string]string) string {
 	r.lgr.Info("Running cli command with network, expecting success")
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
 	output, err := r.RunWithNetwork(ctx, args, env)
@@ -201,7 +201,7 @@ func (r *CLITestRunner) ExpectSuccessWithNetwork(t *testing.T, args []string, en
 // ExpectErrorContains runs a command expecting it to fail with specific error text
 func (r *CLITestRunner) ExpectErrorContains(t *testing.T, args []string, env map[string]string, contains string) string {
 	r.lgr.Info("Running cli command, expecting error")
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
 	output, err := r.Run(ctx, args, env)

--- a/op-deployer/pkg/deployer/integration_test/cli/migrate_test.go
+++ b/op-deployer/pkg/deployer/integration_test/cli/migrate_test.go
@@ -101,7 +101,7 @@ func TestCLIMigrateV1(t *testing.T) {
 
 	testCacheDir := testutils.IsolatedTestDirWithAutoCleanup(t)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
 
 	pkHex, _, _ := shared.DefaultPrivkey(t)
@@ -241,7 +241,9 @@ func TestCLIMigrateV1(t *testing.T) {
 	// Apply deployment
 	// Note: Validation will run automatically but may find expected errors for migration test deployments
 	// (e.g., custom dev features, non-standard configurations). We verify deployment succeeded despite validation errors.
-	output, runErr := runner.RunWithNetwork(context.Background(), []string{
+	applyCtx, applyCancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer applyCancel()
+	output, runErr := runner.RunWithNetwork(applyCtx, []string{
 		"apply",
 		"--deployment-target", "live",
 		"--workdir", workDir,
@@ -315,7 +317,7 @@ func TestCLIMigrateV2(t *testing.T) {
 
 	testCacheDir := testutils.IsolatedTestDirWithAutoCleanup(t)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
 
 	pkHex, _, _ := shared.DefaultPrivkey(t)
@@ -475,7 +477,9 @@ func TestCLIMigrateV2(t *testing.T) {
 	// Apply deployment
 	// Note: Validation will run automatically but may find expected errors for migration test deployments
 	// (e.g., custom dev features, non-standard configurations). We verify deployment succeeded despite validation errors.
-	output, runErr := runner.RunWithNetwork(context.Background(), []string{
+	applyCtx, applyCancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer applyCancel()
+	output, runErr := runner.RunWithNetwork(applyCtx, []string{
 		"apply",
 		"--deployment-target", "live",
 		"--workdir", workDir,


### PR DESCRIPTION
## Summary

Fixes timeout-induced flakiness in `TestCLIMigrateV1`, `TestCLIMigrateV2`, and `TestCLIBootstrapForge` by increasing timeouts for external-RPC-dependent operations.

Closes ethereum-optimism/optimism#19624
Closes ethereum-optimism/optimism#19627

## Root Cause

The tests deploy many contracts (superchain, implementations, chain contracts, migration) over a forked Sepolia RPC via `RetryProxy`. Three timeout issues combined to cause the 20-minute binary timeout to fire:

1. **Bootstrap context too tight (5 min):** The `Superchain()` and `Implementations()` deployments shared a single 5-minute context. Each deploys many contracts over an external RPC — under load this is not enough.

2. **Apply command had no timeout:** `runner.RunWithNetwork(context.Background(), ...)` meant the `apply` step could run unbounded until the binary timeout killed it.

3. **CLI runner helper timeouts too tight (60s):** `ExpectSuccess`, `ExpectSuccessWithNetwork`, and `ExpectErrorContains` all hardcoded a 60-second timeout. This is too tight for any caller that deploys contracts over an external RPC — and there are 30+ call sites across the CLI integration tests, including all `TestCLIBootstrapForge` subtests.

## Why Flaky (Not Consistent)

External Sepolia RPC latency varies with CI load, time of day, and network conditions. With 12 parallel CI nodes hitting the same RPC endpoint, latency spikes are common but not guaranteed. When latency is low, all operations complete within the original timeouts. When latency spikes, the cumulative time exceeds the 20-minute binary timeout.

## What the Fix Does

- **cli_runner.go:** Increased timeout from 60s to 5 min in `ExpectSuccess`, `ExpectSuccessWithNetwork`, and `ExpectErrorContains`. Benefits all 30+ call sites, including `TestCLIBootstrapForge` (13 flakes) and `TestCLIMigrate` tests.
- **migrate_test.go:** Increased bootstrap context from 5 min to 10 min (both V1 and V2 tests). Added 5-minute timeout to the `apply` commands that previously used unbounded `context.Background()`.