### PR TITLE
fix(op-devstack): stabilize flaky TestSupernodeSameTimestampInvalidTransitive

### DIFF
--- a/op-devstack/dsl/eoa.go
+++ b/op-devstack/dsl/eoa.go
@@ -34,6 +34,11 @@ type EOA struct {
 	// el is the execution-layer node that this user operates against.
 	// This may be a L1 or L2 EL node.
 	el ELNode
+
+	// sequencingNonce tracks the next nonce for direct-sequenced transactions.
+	// Initialized lazily on the first call to PlanForSequencing.
+	sequencingNonce    uint64
+	sequencingNonceSet bool
 }
 
 // InitMessage represents an initiating message that has been sent and included on chain.
@@ -149,6 +154,32 @@ func (u *EOA) Plan() txplan.Option {
 		txplan.WithRetrySubmission(elClient, 5, retry.Exponential()),
 		txplan.WithRetryInclusion(elClient, 5, retry.Exponential()),
 		txplan.WithBlockInclusionInfo(elClient),
+	)
+}
+
+// PlanForSequencing creates tx-planning options for transactions that will be
+// directly sequenced into blocks (bypassing the mempool). It uses a local nonce
+// counter instead of querying PendingNonceAt, avoiding races when multiple txs
+// from the same EOA are planned before any are included. It also omits
+// submission and inclusion retries since those are handled by the sequencer.
+func (u *EOA) PlanForSequencing() txplan.Option {
+	elClient := u.el.stackEL().EthClient()
+
+	if !u.sequencingNonceSet {
+		nonce, err := elClient.PendingNonceAt(u.ctx, u.Address())
+		u.require.NoError(err, "failed to get pending nonce for sequencing")
+		u.sequencingNonce = nonce
+		u.sequencingNonceSet = true
+	}
+	nonce := u.sequencingNonce
+	u.sequencingNonce++
+
+	return txplan.Combine(
+		txplan.WithChainID(elClient),
+		u.key.Plan(),
+		txplan.WithNonce(nonce),
+		txplan.WithAgainstLatestBlock(elClient),
+		txplan.WithEstimator(elClient, true),
 	)
 }
 
@@ -496,42 +527,41 @@ func (u *EOA) PrepareSameTimestampInit(
 	}
 }
 
-// SubmitInit submits the init message without waiting for inclusion.
-// Returns the planned tx which can be used to wait for inclusion later.
+// SubmitInit signs the init message for direct sequencing into a block.
+// Returns the planned tx whose Signed field can be evaluated to get the signed tx bytes.
 func (p *SameTimestampPair) SubmitInit() *txplan.PlannedTx {
-	tx := txintent.NewIntent[*txintent.InitTrigger, *txintent.InteropOutput](p.eoa.Plan())
+	tx := txintent.NewIntent[*txintent.InitTrigger, *txintent.InteropOutput](p.eoa.PlanForSequencing())
 	tx.Content.Set(p.Trigger)
-	_, err := tx.PlannedTx.Submitted.Eval(p.eoa.ctx)
-	p.eoa.require.NoError(err, "failed to submit init message")
+	_, err := tx.PlannedTx.Signed.Eval(p.eoa.ctx)
+	p.eoa.require.NoError(err, "failed to sign init message")
 	return tx.PlannedTx
 }
 
-// SubmitExecTo submits an exec message to the given EOA's chain, referencing this init.
-// The exec is submitted without waiting for inclusion.
-// Returns the planned tx which can be used to wait for inclusion later.
+// SubmitExecTo signs an exec message on the executor's chain, referencing this init.
+// Returns the planned tx whose Signed field can be evaluated to get the signed tx bytes.
 func (p *SameTimestampPair) SubmitExecTo(executor *EOA) *txplan.PlannedTx {
-	tx := txintent.NewIntent[*txintent.ExecTrigger, *txintent.InteropOutput](executor.Plan())
+	tx := txintent.NewIntent[*txintent.ExecTrigger, *txintent.InteropOutput](executor.PlanForSequencing())
 	tx.Content.Set(&txintent.ExecTrigger{
 		Executor: predeploys.CrossL2InboxAddr,
 		Msg:      p.Message,
 	})
-	_, err := tx.PlannedTx.Submitted.Eval(executor.ctx)
-	executor.require.NoError(err, "failed to submit exec message")
+	_, err := tx.PlannedTx.Signed.Eval(executor.ctx)
+	executor.require.NoError(err, "failed to sign exec message")
 	return tx.PlannedTx
 }
 
-// SubmitInvalidExecTo submits an exec message with an invalid log index.
+// SubmitInvalidExecTo signs an exec message with an invalid log index for direct sequencing.
 // This creates an exec that references a non-existent log, which should be detected as invalid.
-// Returns the planned tx which can be used to wait for inclusion later.
+// Returns the planned tx whose Signed field can be evaluated to get the signed tx bytes.
 func (p *SameTimestampPair) SubmitInvalidExecTo(executor *EOA) *txplan.PlannedTx {
 	invalidMsg := MakeInvalidLogIndex(p.Message)
 
-	tx := txintent.NewIntent[*txintent.ExecTrigger, *txintent.InteropOutput](executor.Plan())
+	tx := txintent.NewIntent[*txintent.ExecTrigger, *txintent.InteropOutput](executor.PlanForSequencing())
 	tx.Content.Set(&txintent.ExecTrigger{
 		Executor: predeploys.CrossL2InboxAddr,
 		Msg:      invalidMsg,
 	})
-	_, err := tx.PlannedTx.Submitted.Eval(executor.ctx)
-	executor.require.NoError(err, "failed to submit invalid exec message")
+	_, err := tx.PlannedTx.Signed.Eval(executor.ctx)
+	executor.require.NoError(err, "failed to sign invalid exec message")
 	return tx.PlannedTx
 }


### PR DESCRIPTION
## Summary

Fixes ethereum-optimism/optimism#19570

- **Root cause:** The same-timestamp test methods (`SubmitInit`, `SubmitExecTo`, `SubmitInvalidExecTo`) each call `EOA.Plan()` which independently queries `PendingNonceAt` from the EL node. When multiple txs from the same EOA are planned in quick succession (e.g. `pairA.SubmitInit()` followed by `pairB.SubmitExecTo(sys.Alice)` — both from Alice on chain A), the second query can return a stale nonce because the first tx hasn't reached the pending pool yet. This causes a nonce collision.
- **Why flaky (not always failing):** Whether `PendingNonceAt` sees the just-submitted tx depends on how fast the tx pool processes it. Under CI resource contention, the tx pool is slower, so the race is more likely. When the nonce collision happens, the retry logic fails with "replacement transaction underpriced" (failure mode 2). Even when submission succeeds, the duplicate nonce means one tx gets dropped, so `IncludeAndValidate` can't build the block and eventually times out at 150s (failure mode 1).
- **Fix:** Added `PlanForSequencing()` to `EOA` which fetches the pending nonce once and tracks it locally with an auto-incrementing counter. Sequential calls get sequential nonces without re-querying the node. The `Submit*` methods now only sign txs (via `Signed.Eval`) instead of submitting them to the mempool (via `Submitted.Eval`), since `IncludeAndValidate` bypasses the mempool entirely by directly sequencing signed tx bytes into blocks via `TestSequencer.SequenceBlockWithTxs`.
- **Flake count:** 4+ (via CircleCI Insights, job `memory-all-opn-op-geth`)

## Test plan
- [x] `go build ./op-devstack/...` passes
- [x] `go build ./op-acceptance-tests/tests/supernode/interop/same_timestamp_invalid/...` passes
- [x] `go vet ./op-devstack/...` passes
- [x] `go vet ./op-acceptance-tests/tests/supernode/interop/same_timestamp_invalid/...` passes
- [ ] CI passes on this PR