### PR TITLE
feat(op-acceptance): port DepositMessage interop proof test

### DIFF
--- a/op-acceptance-tests/tests/interop/proofs/serial/interop_fault_proofs_test.go
+++ b/op-acceptance-tests/tests/interop/proofs/serial/interop_fault_proofs_test.go
@@ -24,6 +24,12 @@ func TestInteropFaultProofs_ConsolidateValidCrossChainMessage(gt *testing.T) {
 	sfp.RunConsolidateValidCrossChainMessageTest(t, sys)
 }
 
+func TestInteropFaultProofs_DepositMessage(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewSimpleInteropSupernodeProofs(t, presets.WithChallengerCannonKonaEnabled())
+	sfp.RunDepositMessageTest(t, sys)
+}
+
 func TestInteropFaultProofs_VariedBlockTimes(gt *testing.T) {
 	t := devtest.SerialT(gt)
 	// TODO(#19828): endTimestamp may align with a no-op transition for the slower chain,

--- a/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
+++ b/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
@@ -973,7 +973,7 @@ func RunDepositMessageTest(t devtest.T, sys *presets.SimpleInterop) {
 
 	eventLogger := aliceA.DeployEventLogger()
 	depositEOA := aliceA.ViaDepositTx(aliceL1, sys.L2ELA, sys.L2ChainA)
-	initMsg := depositEOA.SendRandomInitMessage(rng, eventLogger, 2, 10)
+	initMsg := depositEOA.SendRandomInitMessage(rng, eventLogger)
 	execMsg := aliceB.SendExecMessage(initMsg)
 
 	endTimestamp := sys.L2ChainB.TimestampForBlockNum(bigs.Uint64Strict(execMsg.BlockNumber()))

--- a/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
+++ b/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
@@ -16,17 +16,23 @@ import (
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/vm"
 	challengerTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum-optimism/optimism/op-core/predeploys"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl/contract"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-program/client/interop"
 	interopTypes "github.com/ethereum-optimism/optimism/op-program/client/interop/types"
 	"github.com/ethereum-optimism/optimism/op-service/apis"
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/txintent"
+	"github.com/ethereum-optimism/optimism/op-service/txintent/bindings"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 	"github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
@@ -954,4 +960,160 @@ func RunInvalidBlockTest(t devtest.T, sys *presets.SimpleInterop) {
 			runChallengerProviderTest(t, sys.SuperRoots.QueryAPI(), gameDepth, startTimestamp, test.ClaimTimestamp, test)
 		})
 	}
+}
+
+// RunDepositMessageTest verifies that the fault proof system correctly handles
+// consolidation when a cross-chain message is initiated via an L1 deposit transaction.
+func RunDepositMessageTest(t devtest.T, sys *presets.SimpleInterop) {
+	t.Require().NotNil(sys.SuperRoots, "supernode is required for this test")
+	rng := rand.New(rand.NewSource(5678))
+
+	chains := orderedChains(sys)
+	t.Require().Len(chains, 2, "expected exactly 2 interop chains")
+
+	// Fund users on L1, chain A, and chain B.
+	aliceA := sys.FunderA.NewFundedEOA(eth.OneEther)
+	aliceL1 := aliceA.AsEL(sys.L1EL)
+	sys.FunderL1.Fund(aliceL1, eth.OneEther)
+	aliceB := aliceA.AsEL(sys.L2ELB)
+	sys.FunderB.Fund(aliceB, eth.OneEther)
+
+	// Deploy EventLogger on chain A.
+	eventLogger := aliceA.DeployEventLogger()
+
+	// Build the emitLog calldata that will be executed via deposit.
+	topic1, topic2 := randomTopic(rng), randomTopic(rng)
+	initTrigger := &txintent.InitTrigger{
+		Emitter:    eventLogger,
+		Topics:     [][32]byte{topic1, topic2},
+		OpaqueData: randomBytes(rng, 10),
+	}
+	calldata, err := initTrigger.EncodeInput()
+	t.Require().NoError(err, "failed to encode emitLog calldata")
+
+	// Create the OptimismPortal2 binding on L1 for chain A.
+	portalAddr := sys.L2ChainA.DepositContractAddr()
+	portal := bindings.NewBindings[bindings.OptimismPortal2](
+		bindings.WithClient(sys.L1EL.EthClient()),
+		bindings.WithTo(portalAddr),
+		bindings.WithTest(t),
+	)
+
+	// Deposit the emitLog call via OptimismPortal2.
+	minGas := contract.Read(portal.MinimumGasLimit(uint64(len(calldata))))
+	depositCall := portal.DepositTransaction(eventLogger, eth.ZeroWei, max(100_000, minGas), false, calldata)
+	l1DepositReceipt := contract.Write(aliceL1, depositCall)
+	t.Require().Equal(ethtypes.ReceiptStatusSuccessful, l1DepositReceipt.Status, "L1 deposit tx failed")
+	t.Logf("Deposit tx included on L1 at block %d", l1DepositReceipt.BlockNumber)
+
+	// Derive the L2 deposit tx hash from the L1 receipt.
+	var l2DepositTx *ethtypes.DepositTx
+	for _, log := range l1DepositReceipt.Logs {
+		if l2DepositTx, err = derive.UnmarshalDepositLogEvent(log); err == nil {
+			break
+		}
+	}
+	t.Require().NotNil(l2DepositTx, "failed to find TransactionDeposited event in L1 receipt")
+	l2DepositTxHash := ethtypes.NewTx(l2DepositTx).Hash()
+
+	// Wait for chain A to derive past the deposit's L1 block, then fetch the L2 receipt.
+	l1BlockNum := bigs.Uint64Strict(l1DepositReceipt.BlockNumber)
+	sys.L2ELA.WaitL1OriginReached(eth.Unsafe, l1BlockNum, 120)
+	l2Receipt := sys.L2ELA.WaitForReceipt(l2DepositTxHash)
+	t.Require().Equal(ethtypes.ReceiptStatusSuccessful, l2Receipt.Status, "deposit tx failed on L2 chain A")
+	t.Require().NotZero(len(l2Receipt.Logs), "deposit tx emitted no logs on L2 chain A")
+
+	// Construct the interop message from the L2 receipt log.
+	initLog := l2Receipt.Logs[0]
+	initBlockNum := bigs.Uint64Strict(l2Receipt.BlockNumber)
+	initTimestamp := sys.L2ChainA.TimestampForBlockNum(initBlockNum)
+	payload := make([]byte, 0)
+	for _, topic := range initTrigger.Topics {
+		payload = append(payload, topic[:]...)
+	}
+	payload = append(payload, initTrigger.OpaqueData...)
+	msg := types.Message{
+		Identifier: types.Identifier{
+			Origin:      initLog.Address,
+			BlockNumber: initBlockNum,
+			LogIndex:    uint32(initLog.Index),
+			Timestamp:   initTimestamp,
+			ChainID:     sys.L2ChainA.ChainID(),
+		},
+		PayloadHash: crypto.Keccak256Hash(payload),
+	}
+
+	// Execute the cross-chain message on chain B.
+	execTx := txintent.NewIntent[*txintent.ExecTrigger, *txintent.InteropOutput](aliceB.Plan())
+	execTx.Content.Set(&txintent.ExecTrigger{
+		Executor: predeploys.CrossL2InboxAddr,
+		Msg:      msg,
+	})
+	execReceipt, err := execTx.PlannedTx.Included.Eval(t.Ctx())
+	t.Require().NoError(err, "exec message receipt not found on chain B")
+	t.Require().Equal(ethtypes.ReceiptStatusSuccessful, execReceipt.Status, "exec message failed on chain B")
+
+	endTimestamp := sys.L2ChainB.TimestampForBlockNum(bigs.Uint64Strict(execReceipt.BlockNumber))
+	startTimestamp := endTimestamp - 1
+
+	sys.SuperRoots.AwaitValidatedTimestamp(endTimestamp)
+	l1HeadCurrent := latestRequiredL1(sys.SuperRoots.SuperRootAtTimestamp(endTimestamp))
+
+	start := superRootAtTimestamp(t, chains, startTimestamp)
+	end := superRootAtTimestamp(t, chains, endTimestamp)
+
+	firstOptimistic := optimisticBlockAtTimestamp(t, sys.SuperRoots.QueryAPI(), chains[0].ID, endTimestamp)
+	secondOptimistic := optimisticBlockAtTimestamp(t, sys.SuperRoots.QueryAPI(), chains[1].ID, endTimestamp)
+	paddingStep := func(step uint64) []byte {
+		return marshalTransition(start, step, firstOptimistic, secondOptimistic)
+	}
+
+	tests := []*transitionTest{
+		{
+			Name:               "Consolidate",
+			AgreedClaim:        paddingStep(consolidateStep),
+			DisputedClaim:      end.Marshal(),
+			DisputedTraceIndex: consolidateStep,
+			ExpectValid:        true,
+			L1Head:             l1HeadCurrent,
+			ClaimTimestamp:     endTimestamp,
+		},
+		{
+			Name:               "Consolidate-InvalidNoChange",
+			AgreedClaim:        paddingStep(consolidateStep),
+			DisputedClaim:      paddingStep(consolidateStep),
+			DisputedTraceIndex: consolidateStep,
+			ExpectValid:        false,
+			L1Head:             l1HeadCurrent,
+			ClaimTimestamp:     endTimestamp,
+		},
+	}
+
+	challengerCfg := sys.L2ChainA.Escape().L2Challengers()[0].Config()
+	gameDepth := sys.DisputeGameFactory().GameImpl(gameTypes.SuperCannonKonaGameType).SplitDepth()
+	for _, test := range tests {
+		t.Run(test.Name+"-fpp", func(t devtest.T) {
+			runKonaInteropProgram(t, challengerCfg.CannonKona, test.L1Head.Hash,
+				test.AgreedClaim, crypto.Keccak256Hash(test.DisputedClaim),
+				test.ClaimTimestamp, test.ExpectValid)
+		})
+
+		t.Run(test.Name+"-challenger", func(t devtest.T) {
+			runChallengerProviderTest(t, sys.SuperRoots.QueryAPI(), gameDepth, startTimestamp, test.ClaimTimestamp, test)
+		})
+	}
+}
+
+// randomTopic generates a random 32-byte topic.
+func randomTopic(rng *rand.Rand) [32]byte {
+	var t [32]byte
+	rng.Read(t[:])
+	return t
+}
+
+// randomBytes generates n random bytes using the provided rng.
+func randomBytes(rng *rand.Rand, n int) []byte {
+	b := make([]byte, n)
+	rng.Read(b)
+	return b
 }

--- a/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
+++ b/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
@@ -16,23 +16,17 @@ import (
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/vm"
 	challengerTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
-	"github.com/ethereum-optimism/optimism/op-core/predeploys"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
-	"github.com/ethereum-optimism/optimism/op-devstack/dsl/contract"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
-	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-program/client/interop"
 	interopTypes "github.com/ethereum-optimism/optimism/op-program/client/interop/types"
 	"github.com/ethereum-optimism/optimism/op-service/apis"
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-service/txintent"
-	"github.com/ethereum-optimism/optimism/op-service/txintent/bindings"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 	"github.com/ethereum/go-ethereum/common"
-	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
@@ -971,89 +965,18 @@ func RunDepositMessageTest(t devtest.T, sys *presets.SimpleInterop) {
 	chains := orderedChains(sys)
 	t.Require().Len(chains, 2, "expected exactly 2 interop chains")
 
-	// Fund users on L1, chain A, and chain B.
 	aliceA := sys.FunderA.NewFundedEOA(eth.OneEther)
 	aliceL1 := aliceA.AsEL(sys.L1EL)
 	sys.FunderL1.Fund(aliceL1, eth.OneEther)
 	aliceB := aliceA.AsEL(sys.L2ELB)
 	sys.FunderB.Fund(aliceB, eth.OneEther)
 
-	// Deploy EventLogger on chain A.
 	eventLogger := aliceA.DeployEventLogger()
+	depositEOA := aliceA.ViaDepositTx(aliceL1, sys.L2ELA, sys.L2ChainA)
+	initMsg := depositEOA.SendRandomInitMessage(rng, eventLogger, 2, 10)
+	execMsg := aliceB.SendExecMessage(initMsg)
 
-	// Build the emitLog calldata that will be executed via deposit.
-	topic1, topic2 := randomTopic(rng), randomTopic(rng)
-	initTrigger := &txintent.InitTrigger{
-		Emitter:    eventLogger,
-		Topics:     [][32]byte{topic1, topic2},
-		OpaqueData: randomBytes(rng, 10),
-	}
-	calldata, err := initTrigger.EncodeInput()
-	t.Require().NoError(err, "failed to encode emitLog calldata")
-
-	// Create the OptimismPortal2 binding on L1 for chain A.
-	portalAddr := sys.L2ChainA.DepositContractAddr()
-	portal := bindings.NewBindings[bindings.OptimismPortal2](
-		bindings.WithClient(sys.L1EL.EthClient()),
-		bindings.WithTo(portalAddr),
-		bindings.WithTest(t),
-	)
-
-	// Deposit the emitLog call via OptimismPortal2.
-	minGas := contract.Read(portal.MinimumGasLimit(uint64(len(calldata))))
-	depositCall := portal.DepositTransaction(eventLogger, eth.ZeroWei, max(100_000, minGas), false, calldata)
-	l1DepositReceipt := contract.Write(aliceL1, depositCall)
-	t.Require().Equal(ethtypes.ReceiptStatusSuccessful, l1DepositReceipt.Status, "L1 deposit tx failed")
-	t.Logf("Deposit tx included on L1 at block %d", l1DepositReceipt.BlockNumber)
-
-	// Derive the L2 deposit tx hash from the L1 receipt.
-	var l2DepositTx *ethtypes.DepositTx
-	for _, log := range l1DepositReceipt.Logs {
-		if l2DepositTx, err = derive.UnmarshalDepositLogEvent(log); err == nil {
-			break
-		}
-	}
-	t.Require().NotNil(l2DepositTx, "failed to find TransactionDeposited event in L1 receipt")
-	l2DepositTxHash := ethtypes.NewTx(l2DepositTx).Hash()
-
-	// Wait for chain A to derive past the deposit's L1 block, then fetch the L2 receipt.
-	l1BlockNum := bigs.Uint64Strict(l1DepositReceipt.BlockNumber)
-	sys.L2ELA.WaitL1OriginReached(eth.Unsafe, l1BlockNum, 120)
-	l2Receipt := sys.L2ELA.WaitForReceipt(l2DepositTxHash)
-	t.Require().Equal(ethtypes.ReceiptStatusSuccessful, l2Receipt.Status, "deposit tx failed on L2 chain A")
-	t.Require().NotZero(len(l2Receipt.Logs), "deposit tx emitted no logs on L2 chain A")
-
-	// Construct the interop message from the L2 receipt log.
-	initLog := l2Receipt.Logs[0]
-	initBlockNum := bigs.Uint64Strict(l2Receipt.BlockNumber)
-	initTimestamp := sys.L2ChainA.TimestampForBlockNum(initBlockNum)
-	payload := make([]byte, 0)
-	for _, topic := range initTrigger.Topics {
-		payload = append(payload, topic[:]...)
-	}
-	payload = append(payload, initTrigger.OpaqueData...)
-	msg := types.Message{
-		Identifier: types.Identifier{
-			Origin:      initLog.Address,
-			BlockNumber: initBlockNum,
-			LogIndex:    uint32(initLog.Index),
-			Timestamp:   initTimestamp,
-			ChainID:     sys.L2ChainA.ChainID(),
-		},
-		PayloadHash: crypto.Keccak256Hash(payload),
-	}
-
-	// Execute the cross-chain message on chain B.
-	execTx := txintent.NewIntent[*txintent.ExecTrigger, *txintent.InteropOutput](aliceB.Plan())
-	execTx.Content.Set(&txintent.ExecTrigger{
-		Executor: predeploys.CrossL2InboxAddr,
-		Msg:      msg,
-	})
-	execReceipt, err := execTx.PlannedTx.Included.Eval(t.Ctx())
-	t.Require().NoError(err, "exec message receipt not found on chain B")
-	t.Require().Equal(ethtypes.ReceiptStatusSuccessful, execReceipt.Status, "exec message failed on chain B")
-
-	endTimestamp := sys.L2ChainB.TimestampForBlockNum(bigs.Uint64Strict(execReceipt.BlockNumber))
+	endTimestamp := sys.L2ChainB.TimestampForBlockNum(bigs.Uint64Strict(execMsg.BlockNumber()))
 	startTimestamp := endTimestamp - 1
 
 	sys.SuperRoots.AwaitValidatedTimestamp(endTimestamp)
@@ -1104,16 +1027,3 @@ func RunDepositMessageTest(t devtest.T, sys *presets.SimpleInterop) {
 	}
 }
 
-// randomTopic generates a random 32-byte topic.
-func randomTopic(rng *rand.Rand) [32]byte {
-	var t [32]byte
-	rng.Read(t[:])
-	return t
-}
-
-// randomBytes generates n random bytes using the provided rng.
-func randomBytes(rng *rand.Rand, n int) []byte {
-	b := make([]byte, n)
-	rng.Read(b)
-	return b
-}

--- a/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
+++ b/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
@@ -1026,4 +1026,3 @@ func RunDepositMessageTest(t devtest.T, sys *presets.SimpleInterop) {
 		})
 	}
 }
-

--- a/op-devstack/dsl/deposit_eoa.go
+++ b/op-devstack/dsl/deposit_eoa.go
@@ -1,0 +1,110 @@
+package dsl
+
+import (
+	"math/rand"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
+	"github.com/ethereum-optimism/optimism/op-service/txintent"
+	"github.com/ethereum-optimism/optimism/op-service/txintent/bindings"
+	"github.com/ethereum-optimism/optimism/op-service/txintent/contractio"
+	"github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+)
+
+// DepositEOA wraps an L2 EOA so that initiating messages are sent via L1 deposit
+// transactions rather than direct L2 transactions. The resulting InitMessage is
+// compatible with SendExecMessage on the receiving chain.
+type DepositEOA struct {
+	l2    *EOA       // the L2 identity (for chain ID, block refs, etc.)
+	l1    *EOA       // the L1 identity (for sending the deposit tx)
+	l2EL  *L2ELNode  // L2 EL node to wait for derivation and fetch receipts
+	l2Net *L2Network // L2 network for deposit contract address
+}
+
+// ViaDepositTx returns a DepositEOA that sends initiating messages through L1
+// deposit transactions. The caller must fund both the L1 and L2 identities.
+func (u *EOA) ViaDepositTx(l1 *EOA, l2EL *L2ELNode, l2Net *L2Network) *DepositEOA {
+	return &DepositEOA{l2: u, l1: l1, l2EL: l2EL, l2Net: l2Net}
+}
+
+// SendInitMessage sends an initiating message via an L1 deposit transaction.
+// It deposits a call to the EventLogger through OptimismPortal2, waits for L2
+// derivation, and returns an InitMessage with InteropOutput populated from the
+// L2 receipt — fully compatible with SendExecMessage.
+func (d *DepositEOA) SendInitMessage(trigger *txintent.InitTrigger) *InitMessage {
+	t := d.l2.t
+	ctx := d.l2.ctx
+
+	calldata, err := trigger.EncodeInput()
+	t.Require().NoError(err, "failed to encode InitTrigger calldata")
+
+	// Create OptimismPortal2 binding on L1.
+	portalAddr := d.l2Net.DepositContractAddr()
+	l1Client := d.l1.el.stackEL().EthClient()
+	portal := bindings.NewBindings[bindings.OptimismPortal2](
+		bindings.WithClient(l1Client),
+		bindings.WithTo(portalAddr),
+		bindings.WithTest(t),
+	)
+
+	// Read minimum gas and deposit the call.
+	minGas, err := contractio.Read(portal.MinimumGasLimit(uint64(len(calldata))), ctx)
+	t.Require().NoError(err, "failed to read MinimumGasLimit")
+	depositCall := portal.DepositTransaction(trigger.Emitter, eth.ZeroWei, max(100_000, minGas), false, calldata)
+	l1Receipt, err := contractio.Write(depositCall, ctx, d.l1.Plan())
+	t.Require().NoError(err, "L1 deposit tx failed")
+	t.Require().Equal(ethtypes.ReceiptStatusSuccessful, l1Receipt.Status, "L1 deposit tx reverted")
+
+	// Derive the L2 deposit tx hash from the L1 receipt.
+	var l2DepositTx *ethtypes.DepositTx
+	for _, log := range l1Receipt.Logs {
+		if l2DepositTx, err = derive.UnmarshalDepositLogEvent(log); err == nil {
+			break
+		}
+	}
+	t.Require().NotNil(l2DepositTx, "no TransactionDeposited event in L1 receipt")
+
+	// Wait for L2 to derive past the deposit's L1 block, then fetch the receipt.
+	d.l2EL.WaitL1OriginReached(eth.Unsafe, l1Receipt.BlockNumber.Uint64(), 120)
+	l2Receipt := d.l2EL.WaitForReceipt(ethtypes.NewTx(l2DepositTx).Hash())
+	t.Require().Equal(ethtypes.ReceiptStatusSuccessful, l2Receipt.Status, "deposit tx failed on L2")
+	t.Require().NotZero(len(l2Receipt.Logs), "deposit tx emitted no logs on L2")
+
+	// Build the InteropOutput from the L2 receipt so SendExecMessage works.
+	l2BlockRef := d.l2EL.BlockRefByNumber(l2Receipt.BlockNumber.Uint64())
+	var result txintent.InteropOutput
+	err = result.FromReceipt(ctx, l2Receipt, l2BlockRef.BlockRef(), d.l2.ChainID())
+	t.Require().NoError(err, "failed to build InteropOutput from L2 deposit receipt")
+
+	// Construct an InitMessage with a pre-resolved Result lazy.
+	tx := &txintent.IntentTx[*txintent.InitTrigger, *txintent.InteropOutput]{}
+	tx.Result.Set(&result)
+	return &InitMessage{Tx: tx, Receipt: l2Receipt}
+}
+
+// SendRandomInitMessage creates a random initiating message and sends it via L1 deposit.
+func (d *DepositEOA) SendRandomInitMessage(rng *rand.Rand, eventLoggerAddress common.Address, topicCount, dataLen int) *InitMessage {
+	if topicCount > 4 {
+		topicCount = 4
+	}
+	if topicCount < 1 {
+		topicCount = 1
+	}
+	if dataLen < 1 {
+		dataLen = 1
+	}
+
+	topics := make([][32]byte, topicCount)
+	for i := range topics {
+		copy(topics[i][:], testutils.RandomData(rng, 32))
+	}
+
+	trigger := &txintent.InitTrigger{
+		Emitter:    eventLoggerAddress,
+		Topics:     topics,
+		OpaqueData: testutils.RandomData(rng, dataLen),
+	}
+	return d.SendInitMessage(trigger)
+}

--- a/op-devstack/dsl/deposit_eoa.go
+++ b/op-devstack/dsl/deposit_eoa.go
@@ -4,6 +4,7 @@ import (
 	"math/rand"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
 	"github.com/ethereum-optimism/optimism/op-service/txintent"
@@ -57,7 +58,7 @@ func (d *DepositEOA) DepositTx(to common.Address, calldata []byte) *ethtypes.Rec
 	}
 	t.Require().NotNil(l2DepositTx, "no TransactionDeposited event in L1 receipt")
 
-	d.l2EL.WaitL1OriginReached(eth.Unsafe, l1Receipt.BlockNumber.Uint64(), 120)
+	d.l2EL.WaitL1OriginReached(eth.Unsafe, bigs.Uint64Strict(l1Receipt.BlockNumber), 120)
 	l2Receipt := d.l2EL.WaitForReceipt(ethtypes.NewTx(l2DepositTx).Hash())
 	t.Require().Equal(ethtypes.ReceiptStatusSuccessful, l2Receipt.Status, "deposit tx failed on L2")
 	return l2Receipt
@@ -75,7 +76,7 @@ func (d *DepositEOA) SendInitMessage(trigger *txintent.InitTrigger) *InitMessage
 	l2Receipt := d.DepositTx(trigger.Emitter, calldata)
 	t.Require().NotZero(len(l2Receipt.Logs), "deposit tx emitted no logs on L2")
 
-	l2BlockRef := d.l2EL.BlockRefByNumber(l2Receipt.BlockNumber.Uint64())
+	l2BlockRef := d.l2EL.BlockRefByNumber(bigs.Uint64Strict(l2Receipt.BlockNumber))
 	var result txintent.InteropOutput
 	err = result.FromReceipt(d.l2.ctx, l2Receipt, l2BlockRef.BlockRef(), d.l2.ChainID())
 	t.Require().NoError(err, "failed to build InteropOutput from L2 deposit receipt")

--- a/op-devstack/dsl/deposit_eoa.go
+++ b/op-devstack/dsl/deposit_eoa.go
@@ -13,9 +13,8 @@ import (
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 )
 
-// DepositEOA wraps an L2 EOA so that initiating messages are sent via L1 deposit
-// transactions rather than direct L2 transactions. The resulting InitMessage is
-// compatible with SendExecMessage on the receiving chain.
+// DepositEOA wraps an L2 EOA so that transactions are sent via L1 deposit
+// transactions rather than direct L2 transactions.
 type DepositEOA struct {
 	l2    *EOA       // the L2 identity (for chain ID, block refs, etc.)
 	l1    *EOA       // the L1 identity (for sending the deposit tx)
@@ -23,24 +22,18 @@ type DepositEOA struct {
 	l2Net *L2Network // L2 network for deposit contract address
 }
 
-// ViaDepositTx returns a DepositEOA that sends initiating messages through L1
+// ViaDepositTx returns a DepositEOA that sends transactions through L1
 // deposit transactions. The caller must fund both the L1 and L2 identities.
 func (u *EOA) ViaDepositTx(l1 *EOA, l2EL *L2ELNode, l2Net *L2Network) *DepositEOA {
 	return &DepositEOA{l2: u, l1: l1, l2EL: l2EL, l2Net: l2Net}
 }
 
-// SendInitMessage sends an initiating message via an L1 deposit transaction.
-// It deposits a call to the EventLogger through OptimismPortal2, waits for L2
-// derivation, and returns an InitMessage with InteropOutput populated from the
-// L2 receipt — fully compatible with SendExecMessage.
-func (d *DepositEOA) SendInitMessage(trigger *txintent.InitTrigger) *InitMessage {
+// DepositTx sends a transaction to the given address with the given calldata
+// via OptimismPortal2 on L1. It waits for L2 derivation and returns the L2 receipt.
+func (d *DepositEOA) DepositTx(to common.Address, calldata []byte) *ethtypes.Receipt {
 	t := d.l2.t
 	ctx := d.l2.ctx
 
-	calldata, err := trigger.EncodeInput()
-	t.Require().NoError(err, "failed to encode InitTrigger calldata")
-
-	// Create OptimismPortal2 binding on L1.
 	portalAddr := d.l2Net.DepositContractAddr()
 	l1Client := d.l1.el.stackEL().EthClient()
 	portal := bindings.NewBindings[bindings.OptimismPortal2](
@@ -49,15 +42,13 @@ func (d *DepositEOA) SendInitMessage(trigger *txintent.InitTrigger) *InitMessage
 		bindings.WithTest(t),
 	)
 
-	// Read minimum gas and deposit the call.
 	minGas, err := contractio.Read(portal.MinimumGasLimit(uint64(len(calldata))), ctx)
 	t.Require().NoError(err, "failed to read MinimumGasLimit")
-	depositCall := portal.DepositTransaction(trigger.Emitter, eth.ZeroWei, max(100_000, minGas), false, calldata)
+	depositCall := portal.DepositTransaction(to, eth.ZeroWei, max(100_000, minGas), false, calldata)
 	l1Receipt, err := contractio.Write(depositCall, ctx, d.l1.Plan())
 	t.Require().NoError(err, "L1 deposit tx failed")
 	t.Require().Equal(ethtypes.ReceiptStatusSuccessful, l1Receipt.Status, "L1 deposit tx reverted")
 
-	// Derive the L2 deposit tx hash from the L1 receipt.
 	var l2DepositTx *ethtypes.DepositTx
 	for _, log := range l1Receipt.Logs {
 		if l2DepositTx, err = derive.UnmarshalDepositLogEvent(log); err == nil {
@@ -66,45 +57,44 @@ func (d *DepositEOA) SendInitMessage(trigger *txintent.InitTrigger) *InitMessage
 	}
 	t.Require().NotNil(l2DepositTx, "no TransactionDeposited event in L1 receipt")
 
-	// Wait for L2 to derive past the deposit's L1 block, then fetch the receipt.
 	d.l2EL.WaitL1OriginReached(eth.Unsafe, l1Receipt.BlockNumber.Uint64(), 120)
 	l2Receipt := d.l2EL.WaitForReceipt(ethtypes.NewTx(l2DepositTx).Hash())
 	t.Require().Equal(ethtypes.ReceiptStatusSuccessful, l2Receipt.Status, "deposit tx failed on L2")
+	return l2Receipt
+}
+
+// SendInitMessage sends an initiating message via an L1 deposit transaction.
+// Returns an InitMessage with InteropOutput populated from the L2 receipt,
+// fully compatible with SendExecMessage on the receiving chain.
+func (d *DepositEOA) SendInitMessage(trigger *txintent.InitTrigger) *InitMessage {
+	t := d.l2.t
+
+	calldata, err := trigger.EncodeInput()
+	t.Require().NoError(err, "failed to encode InitTrigger calldata")
+
+	l2Receipt := d.DepositTx(trigger.Emitter, calldata)
 	t.Require().NotZero(len(l2Receipt.Logs), "deposit tx emitted no logs on L2")
 
-	// Build the InteropOutput from the L2 receipt so SendExecMessage works.
 	l2BlockRef := d.l2EL.BlockRefByNumber(l2Receipt.BlockNumber.Uint64())
 	var result txintent.InteropOutput
-	err = result.FromReceipt(ctx, l2Receipt, l2BlockRef.BlockRef(), d.l2.ChainID())
+	err = result.FromReceipt(d.l2.ctx, l2Receipt, l2BlockRef.BlockRef(), d.l2.ChainID())
 	t.Require().NoError(err, "failed to build InteropOutput from L2 deposit receipt")
 
-	// Construct an InitMessage with a pre-resolved Result lazy.
 	tx := &txintent.IntentTx[*txintent.InitTrigger, *txintent.InteropOutput]{}
 	tx.Result.Set(&result)
 	return &InitMessage{Tx: tx, Receipt: l2Receipt}
 }
 
 // SendRandomInitMessage creates a random initiating message and sends it via L1 deposit.
-func (d *DepositEOA) SendRandomInitMessage(rng *rand.Rand, eventLoggerAddress common.Address, topicCount, dataLen int) *InitMessage {
-	if topicCount > 4 {
-		topicCount = 4
-	}
-	if topicCount < 1 {
-		topicCount = 1
-	}
-	if dataLen < 1 {
-		dataLen = 1
-	}
-
-	topics := make([][32]byte, topicCount)
+func (d *DepositEOA) SendRandomInitMessage(rng *rand.Rand, eventLoggerAddress common.Address) *InitMessage {
+	topics := make([][32]byte, 2)
 	for i := range topics {
 		copy(topics[i][:], testutils.RandomData(rng, 32))
 	}
-
 	trigger := &txintent.InitTrigger{
 		Emitter:    eventLoggerAddress,
 		Topics:     topics,
-		OpaqueData: testutils.RandomData(rng, dataLen),
+		OpaqueData: testutils.RandomData(rng, 10),
 	}
 	return d.SendInitMessage(trigger)
 }

--- a/op-e2e/actions/interop/proofs_test.go
+++ b/op-e2e/actions/interop/proofs_test.go
@@ -1127,7 +1127,6 @@ func TestInteropFaultProofs_VariedBlockTimes_FasterChainB(gt *testing.T) {
 	runFppAndChallengerTests(gt, system, tests)
 }
 
-
 func TestInteropFaultProofs_DepositMessage_InvalidExecution(gt *testing.T) {
 	t := helpers.NewDefaultTesting(gt)
 

--- a/op-e2e/actions/interop/proofs_test.go
+++ b/op-e2e/actions/interop/proofs_test.go
@@ -1127,65 +1127,6 @@ func TestInteropFaultProofs_VariedBlockTimes_FasterChainB(gt *testing.T) {
 	runFppAndChallengerTests(gt, system, tests)
 }
 
-func TestInteropFaultProofs_DepositMessage(gt *testing.T) {
-	t := helpers.NewDefaultTesting(gt)
-
-	system := dsl.NewInteropDSL(t)
-	actors := system.Actors
-	emitter := system.DeployEmitterContracts()
-
-	// Advance L1 a couple times to avoid deposit gas metering issues near genesis
-	system.AdvanceL1()
-	system.AdvanceL1()
-
-	l1User := system.CreateUser()
-	depositMessage := dsl.NewMessage(system, actors.ChainA, emitter, "hello")
-	system.AdvanceL1(
-		dsl.WithActIncludeTx(
-			depositMessage.ActEmitDeposit(l1User)))
-
-	// As such, the next block timestamp across both chains will contain a user-deposit message and an executing message
-	system.AdvanceL2ToLastBlockOfOrigin(actors.ChainA, 2)
-	system.AdvanceL2ToLastBlockOfOrigin(actors.ChainB, 2)
-
-	actors.ChainA.Sequencer.ActL2StartBlock(t)
-	actors.ChainB.Sequencer.ActL2StartBlock(t)
-	// The pending block on chain A will contain the user deposit
-	depositMessage.ExecutePendingOn(actors.ChainB, actors.ChainA.Sequencer.L2Unsafe().Number+1)
-	actors.ChainA.Sequencer.ActL2EndBlock(t)
-	actors.ChainB.Sequencer.ActL2EndBlock(t)
-	system.SubmitBatchData(dsl.WithSkipCrossSafeUpdate())
-
-	endTimestamp := actors.ChainB.Sequencer.L2Unsafe().Time
-	startTimestamp := endTimestamp - 1
-	preConsolidation := system.Outputs.TransitionState(startTimestamp, consolidateStep,
-		system.Outputs.OptimisticBlockAtTimestamp(actors.ChainA, endTimestamp),
-		system.Outputs.OptimisticBlockAtTimestamp(actors.ChainB, endTimestamp),
-	).Marshal()
-
-	system.ProcessCrossSafe()
-	depositMessage.CheckExecuted()
-	assertUserDepositEmitted(t, system.Actors.ChainA, nil, emitter)
-	crossSafeEnd := system.Outputs.SuperRoot(endTimestamp)
-
-	tests := []*transitionTest{
-		{
-			name:               "Consolidate",
-			agreedClaim:        preConsolidation,
-			disputedClaim:      crossSafeEnd.Marshal(),
-			disputedTraceIndex: consolidateStep,
-			expectValid:        true,
-		},
-		{
-			name:               "Consolidate-InvalidNoChange",
-			agreedClaim:        preConsolidation,
-			disputedClaim:      preConsolidation,
-			disputedTraceIndex: consolidateStep,
-			expectValid:        false,
-		},
-	}
-	runFppAndChallengerTests(gt, system, tests)
-}
 
 func TestInteropFaultProofs_DepositMessage_InvalidExecution(gt *testing.T) {
 	t := helpers.NewDefaultTesting(gt)


### PR DESCRIPTION
## Summary

- Ports `TestInteropFaultProofs_DepositMessage` from op-e2e to the acceptance test framework
- Adds `RunDepositMessageTest` in `superfaultproofs.go` with 2 subtests (Consolidate-AllValid, Consolidate-AllValid-InvalidNoChange)
- Tests that deposit-initiated cross-chain messages are correctly handled by the super fault proof system
- Flow: fund L1 EOA → deposit via OptimismPortal2 → wait for L2 derivation → extract interop message → send exec message on chain B → verify consolidation

## Test plan

- [ ] CI: `TestInteropFaultProofs_DepositMessage` passes both FPP and challenger variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)