### PR TITLE
fix(op-devstack): stabilize flaky TestChallengerRespondsToMultipleInvalidClaims

### DIFF
--- a/op-devstack/dsl/proofs/claim.go
+++ b/op-devstack/dsl/proofs/claim.go
@@ -91,8 +91,9 @@ func (c *Claim) WaitForCounterClaim(ignoreClaims ...*Claim) *Claim {
 func (c *Claim) WaitForCountered() {
 	timedCtx, cancel := context.WithTimeout(c.t.Ctx(), defaultTimeout)
 	defer cancel()
+	timedGame := c.game.withContext(timedCtx)
 	err := wait.For(timedCtx, time.Second, func() (bool, error) {
-		claim := c.game.claimAtIndex(c.Index)
+		claim := timedGame.claimAtIndex(c.Index)
 		return claim.CounteredBy != common.Address{}, nil
 	})
 	if err != nil { // Avoid waiting time capturing game data when there's no error

--- a/op-devstack/dsl/proofs/dispute_game_factory.go
+++ b/op-devstack/dsl/proofs/dispute_game_factory.go
@@ -164,13 +164,13 @@ func (f *DisputeGameFactory) GameCount() int64 {
 func (f *DisputeGameFactory) GameAtIndex(idx int64) *FaultDisputeGame {
 	gameInfo := contract.Read(f.dgf.GameAtIndex(big.NewInt(idx)))
 	game := bindings.NewFaultDisputeGame(bindings.WithClient(f.ethClient), bindings.WithTo(gameInfo.Proxy), bindings.WithTest(f.t))
-	return NewFaultDisputeGame(f.t, f.require, gameInfo.Proxy, f.getGameHelper, f.honestTraceForGame, game)
+	return NewFaultDisputeGame(f.t, f.require, gameInfo.Proxy, f.ethClient, f.getGameHelper, f.honestTraceForGame, game)
 }
 
 func (f *DisputeGameFactory) GameImpl(gameType gameTypes.GameType) *FaultDisputeGame {
 	implAddr := contract.Read(f.dgf.GameImpls(uint32(gameType)))
 	game := bindings.NewFaultDisputeGame(bindings.WithClient(f.ethClient), bindings.WithTo(implAddr), bindings.WithTest(f.t))
-	return NewFaultDisputeGame(f.t, f.require, implAddr, f.getGameHelper, f.honestTraceForGame, game)
+	return NewFaultDisputeGame(f.t, f.require, implAddr, f.ethClient, f.getGameHelper, f.honestTraceForGame, game)
 }
 
 func (f *DisputeGameFactory) GameArgs(gameType gameTypes.GameType) []byte {
@@ -212,7 +212,7 @@ func (f *DisputeGameFactory) startSuperGameOfType(eoa *dsl.EOA, gameType gameTyp
 	}
 	game, addr := f.createNewGame(eoa, gameType, rootClaim, extraData)
 
-	return NewSuperFaultDisputeGame(f.t, f.require, addr, f.getGameHelper, f.honestTraceForGame, game)
+	return NewSuperFaultDisputeGame(f.t, f.require, addr, f.ethClient, f.getGameHelper, f.honestTraceForGame, game)
 }
 
 func (f *DisputeGameFactory) createSuperGameExtraData(timestamp uint64, cfg *GameCfg) []byte {
@@ -400,7 +400,7 @@ func (f *DisputeGameFactory) startOutputRootGameOfType(
 		rootClaim = common.Hash(response.OutputRoot)
 	}
 	game, addr := f.createNewGame(eoa, gameType, rootClaim, extraData)
-	return NewFaultDisputeGame(f.t, f.require, addr, f.getGameHelper, honestTraceProvider, game)
+	return NewFaultDisputeGame(f.t, f.require, addr, f.ethClient, f.getGameHelper, honestTraceProvider, game)
 }
 
 func (f *DisputeGameFactory) createOutputGameExtraData(blockNum uint64, cfg *GameCfg) []byte {

--- a/op-devstack/dsl/proofs/fault_dispute_game.go
+++ b/op-devstack/dsl/proofs/fault_dispute_game.go
@@ -17,7 +17,9 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl/contract"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
+	"github.com/ethereum-optimism/optimism/op-service/apis"
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
+	"github.com/ethereum-optimism/optimism/op-service/testreq"
 	"github.com/ethereum-optimism/optimism/op-service/txintent/bindings"
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
 )
@@ -28,6 +30,7 @@ type FaultDisputeGame struct {
 	t                   devtest.T
 	require             *require.Assertions
 	game                *bindings.FaultDisputeGame
+	ethClient           apis.EthClient
 	Address             common.Address
 	helperProvider      gameHelperProvider
 	honestTraceProvider func() challengerTypes.TraceAccessor
@@ -37,6 +40,7 @@ func NewFaultDisputeGame(
 	t devtest.T,
 	require *require.Assertions,
 	addr common.Address,
+	ethClient apis.EthClient,
 	helperProvider gameHelperProvider,
 	honestTrace func(game *FaultDisputeGame) challengerTypes.TraceAccessor,
 	game *bindings.FaultDisputeGame,
@@ -45,6 +49,7 @@ func NewFaultDisputeGame(
 		t:              t,
 		require:        require,
 		game:           game,
+		ethClient:      ethClient,
 		Address:        addr,
 		helperProvider: helperProvider,
 	}
@@ -53,6 +58,37 @@ func NewFaultDisputeGame(
 	}
 	return fdg
 }
+
+// withContext returns a FaultDisputeGame whose contract-binding RPC calls
+// use the supplied context.  The returned value shares the same on-chain
+// address and helpers but is only suitable for read-only operations (it
+// should not be used to send transactions).
+func (g *FaultDisputeGame) withContext(ctx context.Context) *FaultDisputeGame {
+	ctxTest := &baseTestCtx{ctx: ctx, t: g.t}
+	game := bindings.NewFaultDisputeGame(
+		bindings.WithClient(g.ethClient),
+		bindings.WithTo(g.Address),
+		bindings.WithTest(ctxTest),
+	)
+	return &FaultDisputeGame{
+		t:              g.t,
+		require:        g.require,
+		game:           game,
+		ethClient:      g.ethClient,
+		Address:        g.Address,
+		helperProvider: g.helperProvider,
+	}
+}
+
+// baseTestCtx is a minimal bindings.BaseTest that provides a custom context
+// while delegating assertion handling to the underlying devtest.T.
+type baseTestCtx struct {
+	ctx context.Context
+	t   devtest.T
+}
+
+func (b *baseTestCtx) Ctx() context.Context            { return b.ctx }
+func (b *baseTestCtx) Require() *testreq.Assertions    { return b.t.Require() }
 
 func (g *FaultDisputeGame) GameType() gameTypes.GameType {
 	return gameTypes.GameType(contract.Read(g.game.GameType()))
@@ -166,10 +202,18 @@ func (g *FaultDisputeGame) claimCount() uint64 {
 func (g *FaultDisputeGame) waitForClaim(timeout time.Duration, errorMsg string, predicate func(claimIdx uint64, claim bindings.Claim) bool) (uint64, bindings.Claim) {
 	timedCtx, cancel := context.WithTimeout(g.t.Ctx(), timeout)
 	defer cancel()
+
+	// Create a game binding that uses timedCtx for RPC calls.
+	// Without this, allClaims() uses the base test context (which may have a
+	// much longer deadline, e.g. the 2-hour package timeout), so a single
+	// hung RPC call would block the entire polling loop and bypass the
+	// per-wait timeout above.
+	timedGame := g.withContext(timedCtx)
+
 	var matchedClaim bindings.Claim
 	var matchClaimIdx uint64
 	err := wait.For(timedCtx, time.Second, func() (bool, error) {
-		claims := g.allClaims()
+		claims := timedGame.allClaims()
 		// Search backwards because the new claims are at the end and more likely the ones we want.
 		for i := len(claims) - 1; i >= 0; i-- {
 			claim := claims[i]

--- a/op-devstack/dsl/proofs/super_fault_dispute_game.go
+++ b/op-devstack/dsl/proofs/super_fault_dispute_game.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-service/apis"
 	"github.com/ethereum-optimism/optimism/op-service/txintent/bindings"
 )
 
@@ -18,11 +19,12 @@ func NewSuperFaultDisputeGame(
 	t devtest.T,
 	require *require.Assertions,
 	addr common.Address,
+	ethClient apis.EthClient,
 	helperProvider gameHelperProvider,
 	honestTrace func(game *FaultDisputeGame) types.TraceAccessor,
 	game *bindings.FaultDisputeGame,
 ) *SuperFaultDisputeGame {
-	fdg := NewFaultDisputeGame(t, require, addr, helperProvider, honestTrace, game)
+	fdg := NewFaultDisputeGame(t, require, addr, ethClient, helperProvider, honestTrace, game)
 	return &SuperFaultDisputeGame{
 		FaultDisputeGame: fdg,
 	}


### PR DESCRIPTION
## Summary

Fixes ethereum-optimism/optimism#19563

- **Root cause:** The `waitForClaim` and `WaitForCountered` polling loops create a timeout context (20 minutes) but the RPC calls inside the loop (`allClaims()`, `claimAtIndex()`) use the base test context, which has a 2-hour deadline (the package timeout). When an individual RPC call to the in-memory L1 geth hangs due to CI resource contention, the polling loop blocks indefinitely -- `wait.For` only checks context cancellation *between* poll iterations, not *during* them.
- **Why flaky (not always failing):** The RPC calls only hang when the L1 geth instance experiences resource contention under CI load (4 parallel test systems each running their own L1/L2/supernode/challenger). When CI resources are plentiful, the calls return promptly and the test passes.
- **Fix:** Create a context-bound copy of the `FaultDisputeGame` binding for use inside polling loops, so that RPC calls respect the per-wait timeout instead of the base test context. This bounds the hang duration to the 20-minute `defaultTimeout` rather than the 2-hour package timeout.
- **Flake count:** 2 (via CircleCI Insights)

## Test plan
- [x] `go build ./op-devstack/...` passes
- [x] `go build ./op-acceptance-tests/...` passes
- [x] `go vet ./op-devstack/dsl/proofs/...` passes
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)