### PR TITLE
fix(op-devstack): add per-call timeouts to contract.Read/ReadArray/Write

### DIFF
--- a/op-devstack/dsl/contract/call.go
+++ b/op-devstack/dsl/contract/call.go
@@ -1,8 +1,10 @@
 package contract
 
 import (
+	"context"
 	"fmt"
 	"math/big"
+	"time"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-service/errutil"
@@ -11,6 +13,14 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/txintent/contractio"
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
 	"github.com/ethereum/go-ethereum/core/types"
+)
+
+const (
+	// readTimeout bounds individual contract read calls to prevent tests from
+	// hanging when an in-memory geth node stalls under CI resource contention.
+	readTimeout = 60 * time.Second
+	// writeTimeout bounds contract write calls (transaction submission + mining).
+	writeTimeout = 5 * time.Minute
 )
 
 // TestCallView is used in devstack for wrapping errors
@@ -26,19 +36,24 @@ func checkTestable[O any](call bindings.TypedCall[O]) {
 	}
 }
 
-// Read executes a new message call without creating a transaction on the blockchain
+// Read executes a new message call without creating a transaction on the blockchain.
+// Each call is bounded by readTimeout to prevent hangs under CI resource contention.
 func Read[O any](call bindings.TypedCall[O], opts ...txplan.Option) O {
 	checkTestable(call)
-	o, err := contractio.Read(call, call.Test().Ctx(), opts...)
+	ctx, cancel := context.WithTimeout(call.Test().Ctx(), readTimeout)
+	defer cancel()
+	o, err := contractio.Read(call, ctx, opts...)
 	call.Test().Require().NoError(err)
 	return o
 }
 
-// ReadArray retrieves all data from an array in batches
+// ReadArray retrieves all data from an array in batches.
+// Each call is bounded by readTimeout to prevent hangs under CI resource contention.
 func ReadArray[T any](countCall bindings.TypedCall[*big.Int], elemCall func(i *big.Int) bindings.TypedCall[T]) []T {
 	checkTestable(countCall)
 	test := countCall.Test()
-	ctx := countCall.Test().Ctx()
+	ctx, cancel := context.WithTimeout(countCall.Test().Ctx(), readTimeout)
+	defer cancel()
 
 	caller := countCall.Client().NewMultiCaller(batching.DefaultBatchSize)
 
@@ -47,11 +62,14 @@ func ReadArray[T any](countCall bindings.TypedCall[*big.Int], elemCall func(i *b
 	return o
 }
 
-// Write makes a user to write a tx by using the planned contract bindings
+// Write makes a user to write a tx by using the planned contract bindings.
+// Each call is bounded by writeTimeout to prevent hangs under CI resource contention.
 func Write[O any](user *dsl.EOA, call bindings.TypedCall[O], opts ...txplan.Option) *types.Receipt {
 	checkTestable(call)
+	ctx, cancel := context.WithTimeout(call.Test().Ctx(), writeTimeout)
+	defer cancel()
 	finalOpts := txplan.Combine(user.Plan(), txplan.Combine(opts...))
-	o, err := contractio.Write(call, call.Test().Ctx(), finalOpts)
+	o, err := contractio.Write(call, ctx, finalOpts)
 	call.Test().Require().NoError(err, "contract write failed: %v", errutil.TryAddRevertReason(err))
 	return o
 }


### PR DESCRIPTION
## Summary

Fixes ethereum-optimism/optimism#19563

Add 60s timeout to `contract.Read`/`ReadArray` and 5m timeout to `contract.Write` in the DSL contract helpers. Previously these passed the base test context (up to 2h package timeout), so a single stalled RPC call to in-memory geth could hang a test for the full package timeout under CI resource contention.

This is the root cause of `TestChallengerRespondsToMultipleInvalidClaims` and `TestProposer` hanging in the `memory-all-opn-op-geth` CI job. Both tests use `contract.Read` in polling loops (`waitForClaim`, `WaitForGame`) that create their own timeout contexts — but the inner `Read` calls used the base 2h context, so a single blocked `eth_call` prevented the polling timeout from ever being checked.

The fix is one file (`op-devstack/dsl/contract/call.go`) and benefits all tests using the contract DSL.

## Test plan
- [x] `go build ./op-devstack/dsl/contract/...` passes
- [x] `go vet ./op-devstack/dsl/contract/...` passes
- [ ] CI passes — `memory-all-opn-op-geth` job no longer hangs

🤖 Generated with [Claude Code](https://claude.com/claude-code)