### PR TITLE
chore: bump Go toolchain to 1.25.8 and switch to DHI builder images

### DIFF
--- a/cannon/Dockerfile.diff
+++ b/cannon/Dockerfile.diff
@@ -1,4 +1,4 @@
-FROM golang:1.24.10-alpine3.21 AS builder
+FROM dhi.io/golang:1.25-alpine3.22-dev AS builder
 
 # Install just from GitHub releases to match the version pinned in mise.toml.
 # The Alpine package is too old and doesn't support the [script] attribute

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/ethereum-optimism/optimism
 
 go 1.24.0
 
-toolchain go1.24.10
+toolchain go1.25.8
 
 require (
 	github.com/BurntSushi/toml v1.5.0

--- a/mise.toml
+++ b/mise.toml
@@ -2,7 +2,7 @@
 
 # Core dependencies
 bun = "1.2.5"
-go = "1.24.10"
+go = "1.25.8"
 golangci-lint = "2.8.0"
 gotestsum = "1.12.3"
 mockery = "2.53.3"

--- a/ops/docker/deployment-utils/Dockerfile
+++ b/ops/docker/deployment-utils/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.10-bookworm AS go-base
+FROM dhi.io/golang:1.25-debian12-dev AS go-base
 
 RUN go install github.com/tomwright/dasel/v2/cmd/dasel@master
 

--- a/ops/docker/op-stack-go/Dockerfile
+++ b/ops/docker/op-stack-go/Dockerfile
@@ -49,7 +49,7 @@ EOF
 RUN forge --version
 
 # We may be cross-building for another platform. Specify which platform we need as builder.
-FROM --platform=$BUILDPLATFORM golang:1.24.10-alpine3.21 AS builder
+FROM --platform=$BUILDPLATFORM dhi.io/golang:1.25-alpine3.22-dev AS builder
 
 RUN apk add --no-cache curl tar gzip make gcc musl-dev linux-headers git jq yq-go bash just
 
@@ -178,9 +178,11 @@ RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache
 
 # Compile contracts in a glibc-based image (solc requires glibc, crashes on Alpine musl).
 # Uses BUILDPLATFORM so it runs natively (no QEMU). Contract artifacts are platform-independent.
-FROM --platform=$BUILDPLATFORM golang:1.24.10-bookworm AS op-deployer-contracts
+FROM --platform=$BUILDPLATFORM dhi.io/golang:1.25-debian12-dev AS op-deployer-contracts
 ARG BUILDARCH
-RUN apt-get update && apt-get install -y --no-install-recommends curl jq git && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends curl jq git gzip coreutils \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /usr/local/bin
 COPY ./go.mod /app/go.mod
 COPY ./go.sum /app/go.sum
 WORKDIR /app


### PR DESCRIPTION
## Summary

- Bump Go toolchain from 1.24.10 to 1.25.8. Go 1.24 reached end-of-life in February 2026 and is no longer receiving patches.
- Switch Docker builder images from stock `golang` to Docker Hardened Images (`dhi.io/golang`), which are rebuilt nightly with the latest patches.
- The `go.mod` `go` directive stays at `1.24.0` to preserve existing GODEBUG defaults and avoid behavioral changes (container-aware GOMAXPROCS, TLS SHA-1 rejection, stricter x509 parsing).
- Prestate builds (op-program) are intentionally not changed as they pin their own Go version for reproducibility.
- Create `/usr/local/bin` in the `op-deployer-contracts` stage since the DHI image doesn't include it (needed for forge extraction).

## Test plan

- [ ] CI passes (go build, go test)
- [ ] Docker image builds succeed (including op-deployer)
- [ ] Prestate builds are unaffected (pinned to Go 1.24.2)