### PR TITLE
fix(op-supernode): add beacon fallback support for blob sidecar retrieval

### DIFF
--- a/op-supernode/config/config.go
+++ b/op-supernode/config/config.go
@@ -17,6 +17,7 @@ type CLIConfig struct {
 	DataDir                    string
 	L1NodeAddr                 string
 	L1BeaconAddr               string
+	L1BeaconFallbackAddrs      []string
 	RPCConfig                  oprpc.CLIConfig
 	LogConfig                  oplog.CLIConfig
 	MetricsConfig              opmetrics.CLIConfig
@@ -43,14 +44,15 @@ func (c *CLIConfig) Check() error {
 
 func NewConfig(ctx *cli.Context) *CLIConfig {
 	return &CLIConfig{
-		Chains:        ctx.Uint64Slice(flags.ChainsFlag.Name),
-		DataDir:       ctx.String(flags.DataDirFlag.Name),
-		L1NodeAddr:    ctx.String(flags.L1NodeAddr.Name),
-		L1BeaconAddr:  ctx.String(flags.L1BeaconAddr.Name),
-		RPCConfig:     oprpc.ReadCLIConfig(ctx),
-		LogConfig:     oplog.ReadCLIConfig(ctx),
-		MetricsConfig: opmetrics.ReadCLIConfig(ctx),
-		PprofConfig:   oppprof.ReadCLIConfig(ctx),
-		RawCtx:        ctx,
+		Chains:                ctx.Uint64Slice(flags.ChainsFlag.Name),
+		DataDir:               ctx.String(flags.DataDirFlag.Name),
+		L1NodeAddr:            ctx.String(flags.L1NodeAddr.Name),
+		L1BeaconAddr:          ctx.String(flags.L1BeaconAddr.Name),
+		L1BeaconFallbackAddrs: ctx.StringSlice(flags.L1BeaconFallbackAddrs.Name),
+		RPCConfig:             oprpc.ReadCLIConfig(ctx),
+		LogConfig:             oplog.ReadCLIConfig(ctx),
+		MetricsConfig:         opmetrics.ReadCLIConfig(ctx),
+		PprofConfig:           oppprof.ReadCLIConfig(ctx),
+		RawCtx:                ctx,
 	}
 }

--- a/op-supernode/flags/flags.go
+++ b/op-supernode/flags/flags.go
@@ -45,6 +45,12 @@ var (
 		EnvVars:  prefixEnvVars("L1_BEACON"),
 		Required: false,
 	}
+	L1BeaconFallbackAddrs = &cli.StringSliceFlag{
+		Name:    "l1.beacon-fallbacks",
+		Aliases: []string{"l1.beacon-archiver"},
+		Usage:   "Addresses of L1 Beacon-API compatible HTTP fallback endpoints. Used to fetch blob sidecars not available at the l1.beacon (e.g. expired blobs).",
+		EnvVars: append(prefixEnvVars("L1_BEACON_FALLBACKS"), prefixEnvVars("L1_BEACON_ARCHIVER")...),
+	}
 	DisableP2P = &cli.BoolFlag{
 		Name:     "disable-p2p",
 		Usage:    "Disable P2P for all chains. Affects configuration handed to virtual nodes.",
@@ -75,6 +81,7 @@ func RegisterActivityFlags(flags ...cli.Flag) {
 
 func init() {
 	optionalFlags = append(optionalFlags, L1BeaconAddr)
+	optionalFlags = append(optionalFlags, L1BeaconFallbackAddrs)
 	optionalFlags = append(optionalFlags, DataDirFlag)
 	optionalFlags = append(optionalFlags, oprpc.CLIFlags(EnvVarPrefix)...)
 	optionalFlags = append(optionalFlags, oplog.CLIFlags(EnvVarPrefix)...)

--- a/op-supernode/supernode/supernode.go
+++ b/op-supernode/supernode/supernode.go
@@ -10,6 +10,7 @@ import (
 
 	opnodecfg "github.com/ethereum-optimism/optimism/op-node/config"
 	rollupNode "github.com/ethereum-optimism/optimism/op-node/node"
+	"github.com/ethereum-optimism/optimism/op-service/apis"
 	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/httputil"
@@ -388,11 +389,18 @@ func (s *Supernode) initBeaconClient(ctx context.Context, cfg *config.CLIConfig)
 	basicClient := client.NewBasicHTTPClient(cfg.L1BeaconAddr, s.log)
 	beaconHTTPClient := sources.NewBeaconHTTPClient(basicClient)
 
+	// Create fallback beacon clients (e.g. blob archiver)
+	var fallbacks []apis.BeaconClient
+	for _, addr := range cfg.L1BeaconFallbackAddrs {
+		fb := client.NewBasicHTTPClient(addr, s.log)
+		fallbacks = append(fallbacks, sources.NewBeaconHTTPClient(fb))
+	}
+
 	// Create L1 Beacon client with default config
 	beaconCfg := sources.L1BeaconClientConfig{
 		FetchAllSidecars: false,
 	}
-	s.beaconClient = sources.NewL1BeaconClient(beaconHTTPClient, beaconCfg)
+	s.beaconClient = sources.NewL1BeaconClient(beaconHTTPClient, beaconCfg, fallbacks...)
 
 	s.log.Info("L1 Beacon client initialized successfully")
 	return nil


### PR DESCRIPTION
## Summary
- Adds `--l1.beacon-fallbacks` (aliased as `--l1.beacon-archiver`) flag to op-supernode, mirroring op-node's existing support
- The supernode's shared L1 beacon client was created without any fallback endpoints. When the primary beacon proxy returns errors (e.g. PeerDAS 400s for older blobs), derivation gets permanently stuck with no way to fall back to a blob archiver
- Fallback clients are passed to the existing `ClientPool` in `L1BeaconClient`, which already handles rotation on errors

## Context

Discovered while canary-testing a supernode upgrade on interop-v0. After the supernode restarted and derivation needed to re-derive from an earlier L1 block (near the interop activation timestamp), it hit L1 blocks containing blob transactions. The primary beacon proxy returned `400 BAD_REQUEST: Insufficient data columns to reconstruct blobs` (PeerDAS), and without a fallback the node was permanently stuck — even though a blob archiver with the data was configured at the VN level (`OP_SUPERNODE_VN_L1_BEACON_ARCHIVER`), the supernode's shared beacon client never used it.

The blob archiver successfully serves these blobs (confirmed via direct curl), so wiring it as a fallback resolves the issue.

## Test plan
- [x] Deployed to interop-v0 supernode-2 with `OP_SUPERNODE_L1_BEACON_FALLBACKS` set to blob archiver URL
- [x] Confirmed derivation progresses past L1 blocks with blob txs that the primary beacon proxy cannot serve
- [x] Verified no more "failed to fetch blobs" errors after deploying the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)