### PR TITLE
feat(op-devstack): respect DEVSTACK_L2EL_KIND and DEVSTACK_L2CL_KIND in all single-chain runtimes

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -1803,7 +1803,7 @@ jobs:
         type: string
         default: ""
       l2_cl_kind:
-        description: "L2 consensus layer client (op-node or kona)"
+        description: "L2 consensus layer client (op-node or kona-node)"
         type: string
         default: "op-node"
       l2_el_kind:
@@ -2792,7 +2792,7 @@ workflows:
       - op-acceptance-tests:
           name: memory-all-kona-op-reth
           gate: "base"
-          l2_cl_kind: kona
+          l2_cl_kind: kona-node
           l2_el_kind: op-reth
           no_output_timeout: 120m
           context:

--- a/op-devstack/README.md
+++ b/op-devstack/README.md
@@ -104,7 +104,7 @@ and returns a typed output that the test then may use.
 - `DEVNET_EXPECT_PRECONDITIONS_MET`: This can be set of force test failures when their pre-conditions are not met, which would otherwise result in them being skipped. This is helpful in particular for runs that do intend to run specific tests (as opposed to whatever is available). `op-acceptor` does set that variable, for example.
 
 ### Rust stack env vars:
-- `DEVSTACK_L2CL_KIND=kona` to select kona as default L2 CL node
+- `DEVSTACK_L2CL_KIND=kona-node` to select kona-node as default L2 CL node
 - `DEVSTACK_L2EL_KIND=op-reth` to select op-reth as default L2 EL node
 - `KONA_NODE_EXEC_PATH=/home/USERHERE/projects/kona/target/debug/kona-node` to select the kona-node executable to run
 - `OP_RETH_EXEC_PATH=/home/USERHERE/projects/reth/target/release/op-reth` to select the op-reth executable to run

--- a/op-devstack/sysgo/mixed_runtime.go
+++ b/op-devstack/sysgo/mixed_runtime.go
@@ -64,6 +64,20 @@ const (
 	MixedL2CLKona   MixedL2CLKind = "kona-node"
 )
 
+// devstackL2ELKind returns the L2 EL kind requested via the DEVSTACK_L2EL_KIND
+// environment variable. Returns the empty string when the variable is unset,
+// meaning "use the runtime's default".
+func devstackL2ELKind() MixedL2ELKind {
+	return MixedL2ELKind(os.Getenv(DevstackL2ELKindEnvVar))
+}
+
+// devstackL2CLKind returns the L2 CL kind requested via the DEVSTACK_L2CL_KIND
+// environment variable. Returns the empty string when the variable is unset,
+// meaning "use the runtime's default".
+func devstackL2CLKind() MixedL2CLKind {
+	return MixedL2CLKind(os.Getenv("DEVSTACK_L2CL_KIND"))
+}
+
 type MixedSingleChainNodeSpec struct {
 	ELKey       string
 	CLKey       string

--- a/op-devstack/sysgo/multichain_supernode_runtime.go
+++ b/op-devstack/sysgo/multichain_supernode_runtime.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
-	"os"
 	"sort"
 	"strconv"
 	"time"
@@ -98,13 +97,10 @@ func NewTwoL2SupernodeRuntimeWithConfig(t devtest.T, cfg PresetConfig) *MultiCha
 	return runtime
 }
 
-// startSupernodeEL starts an L2 EL node for the supernode runtime.
-// It respects the DEVSTACK_L2EL_KIND env var: "op-geth" uses op-geth, otherwise op-reth is used.
+// startSupernodeEL starts an L2 EL node for the supernode runtime,
+// respecting DEVSTACK_L2EL_KIND (defaults to op-geth when unset).
 func startSupernodeEL(t devtest.T, l2Net *L2Network, jwtPath string, jwtSecret [32]byte) L2ELNode {
-	if MixedL2ELKind(os.Getenv(DevstackL2ELKindEnvVar)) == MixedL2ELOpGeth {
-		return startL2ELNode(t, l2Net, jwtPath, jwtSecret, "sequencer", NewELNodeIdentity(0))
-	}
-	return startMixedOpRethNode(t, l2Net, "sequencer", jwtPath, jwtSecret, nil)
+	return startL2ELForKey(t, l2Net, jwtPath, jwtSecret, "sequencer", NewELNodeIdentity(0))
 }
 
 func newSingleChainSupernodeRuntimeWithConfig(t devtest.T, interopAtGenesis bool, cfg PresetConfig) *MultiChainRuntime {

--- a/op-devstack/sysgo/singlechain_build.go
+++ b/op-devstack/sysgo/singlechain_build.go
@@ -150,8 +150,51 @@ func applyConfigPrefundedL2(t devtest.T, keys devkeys.Keys, l1ChainID, l2ChainID
 	l1Config.WithPrefundedAccount(addrFor(devkeys.SystemConfigOwner), *millionEth)
 }
 
-func startSequencerEL(t devtest.T, l2Net *L2Network, jwtPath string, jwtSecret [32]byte, identity *ELNodeIdentity) *OpGeth {
-	return startL2ELNode(t, l2Net, jwtPath, jwtSecret, "sequencer", identity)
+// startL2ELForKey starts an L2 EL node for the given key, respecting DEVSTACK_L2EL_KIND.
+// This is the single env-aware dispatch point for L2 EL selection.
+func startL2ELForKey(t devtest.T, l2Net *L2Network, jwtPath string, jwtSecret [32]byte, key string, identity *ELNodeIdentity) L2ELNode {
+	switch devstackL2ELKind() {
+	case MixedL2ELOpGeth:
+		return startL2ELNode(t, l2Net, jwtPath, jwtSecret, key, identity)
+	default: // op-reth
+		return startMixedOpRethNode(t, l2Net, key, jwtPath, jwtSecret, nil)
+	}
+}
+
+// startL2CLForKey starts an L2 CL node for the given key, respecting DEVSTACK_L2CL_KIND.
+// This is the single env-aware dispatch point for L2 CL selection.
+func startL2CLForKey(
+	t devtest.T,
+	keys devkeys.Keys,
+	l1Net *L1Network,
+	l2Net *L2Network,
+	l1EL L1ELNode,
+	l1CL *L1CLNode,
+	l2EL L2ELNode,
+	jwtSecret [32]byte,
+	clKey, elKey string,
+	isSequencer bool,
+	followSource string,
+	l2CLOpts []L2CLOption,
+) L2CLNode {
+	switch devstackL2CLKind() {
+	case MixedL2CLKona:
+		return startMixedKonaNode(t, keys, l1Net, l2Net, l1EL, l1CL, l2EL, clKey, elKey, isSequencer, nil)
+	default: // op-node
+		return startL2CLNode(t, keys, l1Net, l2Net, l1EL, l1CL, l2EL, jwtSecret, l2CLNodeStartConfig{
+			Key:            clKey,
+			IsSequencer:    isSequencer,
+			NoDiscovery:    true,
+			EnableReqResp:  true,
+			UseReqResp:     true,
+			L2FollowSource: followSource,
+			L2CLOptions:    l2CLOpts,
+		})
+	}
+}
+
+func startSequencerEL(t devtest.T, l2Net *L2Network, jwtPath string, jwtSecret [32]byte, identity *ELNodeIdentity) L2ELNode {
+	return startL2ELForKey(t, l2Net, jwtPath, jwtSecret, "sequencer", identity)
 }
 
 func startL2ELNode(
@@ -229,17 +272,8 @@ func startSequencerCL(
 	l2EL L2ELNode,
 	jwtSecret [32]byte,
 	l2CLOpts []L2CLOption,
-) *OpNode {
-	return startL2CLNode(t, keys, l1Net, l2Net, l1EL, l1CL, l2EL, jwtSecret, l2CLNodeStartConfig{
-		Key:            "sequencer",
-		IsSequencer:    true,
-		NoDiscovery:    true,
-		EnableReqResp:  true,
-		UseReqResp:     true,
-		IndexingMode:   false,
-		L2FollowSource: "",
-		L2CLOptions:    l2CLOpts,
-	})
+) L2CLNode {
+	return startL2CLForKey(t, keys, l1Net, l2Net, l1EL, l1CL, l2EL, jwtSecret, "sequencer", "sequencer", true, "", l2CLOpts)
 }
 
 type l2CLNodeStartConfig struct {

--- a/op-devstack/sysgo/singlechain_runtime.go
+++ b/op-devstack/sysgo/singlechain_runtime.go
@@ -77,8 +77,7 @@ func startDefaultSingleChainPrimary(
 	jwtSecret [32]byte,
 	cfg PresetConfig,
 ) singleChainPrimaryRuntime {
-	sequencerIdentity := NewELNodeIdentity(0)
-	l2EL := startSequencerEL(t, world.L2Network, jwtPath, jwtSecret, sequencerIdentity)
+	l2EL := startSequencerEL(t, world.L2Network, jwtPath, jwtSecret, NewELNodeIdentity(0))
 	l2CL := startSequencerCL(t, keys, world.L1Network, world.L2Network, l1EL, l1CL, l2EL, jwtSecret, cfg.GlobalL2CLOptions)
 	return singleChainPrimaryRuntime{
 		EL: l2EL,
@@ -123,9 +122,7 @@ func newSingleChainRuntimeWithConfig(t devtest.T, cfg PresetConfig, spec singleC
 
 	applyMinimalGameTypeOptions(t, keys, world.L1Network, world.L2Network, l1EL, cfg.AddedGameTypes, cfg.RespectedGameTypes)
 
-	sequencerCL, ok := primary.CL.(*OpNode)
-	require.True(ok, "single-chain runtime primary CL must be op-node for test sequencer")
-	testSequencer := startTestSequencer(t, keys, jwtPath, jwtSecret, world.L1Network, l1EL, l1CL, primary.EL, world.L2Network, sequencerCL)
+	testSequencer := startTestSequencerForRPCs(t, keys, "test-sequencer", jwtPath, jwtSecret, world.L1Network, l1EL, l1CL, world.L2Network.ChainID(), primary.EL.UserRPC(), primary.CL.UserRPC())
 	testSequencerRuntime := newTestSequencerRuntime(testSequencer, spec.TestSequencer)
 	faucetService := startFaucets(t, keys, world.L1Network.ChainID(), world.L2Network.ChainID(), l1EL.UserRPC(), primary.EL.UserRPC())
 

--- a/op-devstack/sysgo/singlechain_variants.go
+++ b/op-devstack/sysgo/singlechain_variants.go
@@ -166,17 +166,8 @@ func addSingleChainOpNode(
 ) *SingleChainNodeRuntime {
 	jwtPath := runtime.L2EL.JWTPath()
 	jwtSecret := readJWTSecretFromPath(t, jwtPath)
-	identity := NewELNodeIdentity(0)
-	l2EL := startL2ELNode(t, runtime.L2Network, jwtPath, jwtSecret, name, identity)
-	l2CL := startL2CLNode(t, runtime.Keys, runtime.L1Network, runtime.L2Network, runtime.L1EL, runtime.L1CL, l2EL, jwtSecret, l2CLNodeStartConfig{
-		Key:            name,
-		IsSequencer:    isSequencer,
-		NoDiscovery:    true,
-		EnableReqResp:  true,
-		UseReqResp:     true,
-		L2FollowSource: followSource,
-		L2CLOptions:    l2Opts,
-	})
+	l2EL := startL2ELForKey(t, runtime.L2Network, jwtPath, jwtSecret, name, NewELNodeIdentity(0))
+	l2CL := startL2CLForKey(t, runtime.Keys, runtime.L1Network, runtime.L2Network, runtime.L1EL, runtime.L1CL, l2EL, jwtSecret, name, name, isSequencer, followSource, l2Opts)
 	node := newSingleChainNodeRuntime(name, isSequencer, l2EL, l2CL)
 	runtime.Nodes[name] = node
 	return node

--- a/rust/kona/tests/justfile
+++ b/rust/kona/tests/justfile
@@ -21,9 +21,9 @@ build-kona PROFILE="release":
   #!/bin/bash
   cd {{SOURCE}}/.. && cargo build --bin kona-node --profile {{PROFILE}}
 
-acceptance-tests CL_TYPE="kona" EL_TYPE="op-reth" GATE="jovian":
+acceptance-tests CL_TYPE="kona-node" EL_TYPE="op-reth" GATE="jovian":
   #!/bin/bash
-  if [ "{{CL_TYPE}}" = "kona" ] ; then
+  if [ "{{CL_TYPE}}" = "kona-node" ] ; then
     echo "Building kona-node..."
     just build-kona
   fi
@@ -37,9 +37,9 @@ acceptance-tests CL_TYPE="kona" EL_TYPE="op-reth" GATE="jovian":
 
 # Run acceptance tests for the rust stack. By default runs the acceptance tests for kona-node with op-reth.
 # Uses the jovian gate by default.
-acceptance-tests-run CL_TYPE="kona" EL_TYPE="op-reth" GATE="jovian":
+acceptance-tests-run CL_TYPE="kona-node" EL_TYPE="op-reth" GATE="jovian":
   #!/bin/bash
-  if [ "{{CL_TYPE}}" = "kona" ] ; then
+  if [ "{{CL_TYPE}}" = "kona-node" ] ; then
     echo "Running acceptance tests for kona-node"
     export KONA_NODE_EXEC_PATH="{{SOURCE}}/../target/debug/kona-node"
   fi


### PR DESCRIPTION
Introduce two central env-aware dispatch functions, startL2ELForKey and startL2CLForKey, which read DEVSTACK_L2EL_KIND and DEVSTACK_L2CL_KIND respectively and start the appropriate implementation. All single-chain runtimes (minimal, flashblocks, interop-no-supervisor) and follower-node helpers now route through these functions, so setting the env vars affects every preset without any test changes required.

  DEVSTACK_L2EL_KIND=op-reth go test ./...   # use op-reth as L2 EL
  DEVSTACK_L2CL_KIND=kona-node go test ./...  # use kona-node as L2 CL

The sequencer EL/CL wrappers (startSequencerEL, startSequencerCL) and the verifier helper (addSingleChainOpNode) all delegate to the dispatch functions, replacing scattered direct calls to startL2ELNode / startL2CLNode. The supernode runtime's startSupernodeEL is unified with the same dispatch logic (default is now op-geth, matching every other runtime; previously it defaulted to op-reth).