### PR TITLE
chore(ci): capture kona prestate debug artifacts

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -2093,11 +2093,7 @@ jobs:
             # chainList.json from the checkout (baked into the binary via include_str!)
             cp rust/kona/crates/protocol/registry/etc/chainList.json /tmp/prestate-debug/chainList.json
 
-            # Checksums of all built prestate artifacts
-            sha256sum rust/kona/prestate-artifacts-cannon/* > /tmp/prestate-debug/checksums-cannon.txt 2>/dev/null || true
-            sha256sum rust/kona/prestate-artifacts-cannon-interop/* > /tmp/prestate-debug/checksums-cannon-interop.txt 2>/dev/null || true
-
-            # The kona-client ELF binaries themselves (for offline inspection with strings/objdump)
+            # The kona-client ELF binaries (for offline inspection with strings/objdump)
             cp rust/kona/prestate-artifacts-cannon/kona-client-elf /tmp/prestate-debug/kona-client-elf-cannon 2>/dev/null || true
             cp rust/kona/prestate-artifacts-cannon-interop/kona-client-elf /tmp/prestate-debug/kona-client-elf-cannon-interop 2>/dev/null || true
       - store_artifacts:

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -2085,6 +2085,24 @@ jobs:
       - run:
           name: Build prestates
           command: just reproducible-prestate
+      - run:
+          name: Capture kona prestate debug artifacts
+          command: |
+            mkdir -p /tmp/prestate-debug
+
+            # chainList.json from the checkout (baked into the binary via include_str!)
+            cp rust/kona/crates/protocol/registry/etc/chainList.json /tmp/prestate-debug/chainList.json
+
+            # Checksums of all built prestate artifacts
+            sha256sum rust/kona/prestate-artifacts-cannon/* > /tmp/prestate-debug/checksums-cannon.txt 2>/dev/null || true
+            sha256sum rust/kona/prestate-artifacts-cannon-interop/* > /tmp/prestate-debug/checksums-cannon-interop.txt 2>/dev/null || true
+
+            # The kona-client ELF binaries themselves (for offline inspection with strings/objdump)
+            cp rust/kona/prestate-artifacts-cannon/kona-client-elf /tmp/prestate-debug/kona-client-elf-cannon 2>/dev/null || true
+            cp rust/kona/prestate-artifacts-cannon-interop/kona-client-elf /tmp/prestate-debug/kona-client-elf-cannon-interop 2>/dev/null || true
+      - store_artifacts:
+          path: /tmp/prestate-debug
+          destination: prestate-debug
       - persist_to_workspace:
           root: .
           paths:


### PR DESCRIPTION
## Summary

- Saves `chainList.json`, prestate artifact checksums, and the raw kona-client ELF binaries as CircleCI artifacts from the `cannon-prestate` job
- These artifacts allow offline debugging of ethereum-optimism/optimism#19654 where the kona guest panics with `missing field 'name'` during chainList.json deserialization, despite the checked-in file being valid
- Artifacts are stored under `prestate-debug/` in the job's artifact tab

## Context

The kona guest program panics during cannon VM execution:
```
Failed to read chain list: Error("missing field `name`", line: 23, column: 3)
```

The `chainList.json` is embedded at compile time via `include_str!()`. The file at the failing commit is valid (65 chains, all with `name`). We need to inspect the actual ELF binary to determine what JSON was embedded — this requires the artifacts to be preserved.

## Test plan

- [ ] Verify `cannon-prestate` job produces artifacts in the `prestate-debug/` directory
- [ ] Download and inspect the ELF with `strings` to extract the embedded chainList.json
- [ ] Remove this debug step once ethereum-optimism/optimism#19654 is resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)