### PR TITLE
fix(op-acceptance): Avoid infinite hang if a subcommand doesn't close pipes when killed

### DIFF
--- a/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
+++ b/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
@@ -178,6 +178,12 @@ func runKonaInteropProgram(t devtest.T, cfg vm.Config, l1Head common.Hash, agree
 	cmd := exec.CommandContext(ctx, exePath, argv[1:]...)
 	cmd.Dir = tmpDir
 	cmd.Env = append(append(cmd.Env, os.Environ()...), "NO_COLOR=1")
+	// WaitDelay bounds how long CombinedOutput waits for I/O pipes to close
+	// after the process exits or the context is cancelled. Without this, if
+	// the context timeout fires and the process is killed, CombinedOutput
+	// can block indefinitely waiting for pipe EOF (e.g. if a child process
+	// or unclosed descriptor keeps the pipe open).
+	cmd.WaitDelay = 10 * time.Second
 
 	out, runErr := cmd.CombinedOutput()
 	if expectValid {

--- a/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
+++ b/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
@@ -183,7 +183,7 @@ func runKonaInteropProgram(t devtest.T, cfg vm.Config, l1Head common.Hash, agree
 	// the context timeout fires and the process is killed, CombinedOutput
 	// can block indefinitely waiting for pipe EOF (e.g. if a child process
 	// or unclosed descriptor keeps the pipe open).
-	cmd.WaitDelay = 10 * time.Second
+	cmd.WaitDelay = 60 * time.Second
 
 	out, runErr := cmd.CombinedOutput()
 	if expectValid {


### PR DESCRIPTION
## Summary

Will reduce the blast radius of ethereum-optimism/optimism#19656

- **Root cause:** `runKonaInteropProgram` uses `exec.CommandContext` with a 2-minute timeout and `cmd.CombinedOutput()`. In Go 1.20+, `WaitDelay` defaults to 0, which means when the context fires and the process is killed, `CombinedOutput` blocks indefinitely waiting for I/O pipes to reach EOF. If the killed kona process leaves any unclosed pipe descriptors (e.g. from in-flight RPC connections to the in-memory test system), this causes the entire test to hang.
- **Why flaky (not always failing):** The kona native binary connects to in-memory RPC endpoints for L1, L1 beacon, and L2 nodes. Under CI resource contention (32 concurrent test packages on a shared machine), these RPC calls can become slow. When the binary exceeds the 2-minute timeout and is killed, pipe cleanup depends on whether in-flight I/O completes promptly — a non-deterministic condition that depends on system load and goroutine scheduling.
- **Fix:** Set `cmd.WaitDelay = 10 * time.Second` to ensure Go force-closes pipes after at most 10 seconds post-cancellation, allowing the test to fail promptly rather than hanging for the full 2-hour test binary timeout.
- **Flake count:** 3 (via CircleCI Insights, 30-day window)

## Test plan
- [x] `go build ./op-acceptance-tests/tests/...` passes
- [x] `go vet ./op-acceptance-tests/tests/superfaultproofs/...` passes
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)