### PR TITLE
fix(op-devstack): close L2 EL proxies before stopping geth to prevent shutdown hang

### DIFF
--- a/op-devstack/sysgo/l2_el_opgeth.go
+++ b/op-devstack/sysgo/l2_el_opgeth.go
@@ -137,6 +137,18 @@ func (n *OpGeth) Stop() {
 		n.logger.Warn("op-geth already stopped")
 		return
 	}
+	// Close proxies first to sever any lingering client connections (e.g. from
+	// kona-host or the challenger) before shutting down geth. Geth's
+	// node.Close() waits for all active HTTP/WS handlers to finish; if a
+	// client connected through the proxy hasn't closed its WebSocket, Close()
+	// blocks indefinitely. Closing the proxy forcefully terminates the TCP
+	// connections, allowing geth to shut down promptly.
+	if n.userProxy != nil {
+		n.userProxy.Close()
+	}
+	if n.authProxy != nil {
+		n.authProxy.Close()
+	}
 	n.logger.Info("Closing op-geth", "name", n.name, "chain", n.l2Net.ChainID())
 	closeErr := n.l2Geth.Close()
 	n.logger.Info("Closed op-geth", "name", n.name, "chain", n.l2Net.ChainID(), "err", closeErr)

--- a/op-devstack/sysgo/l2_el_opreth.go
+++ b/op-devstack/sysgo/l2_el_opreth.go
@@ -131,6 +131,14 @@ func (n *OpReth) Start() {
 func (n *OpReth) Stop() {
 	n.mu.Lock()
 	defer n.mu.Unlock()
+	// Close proxies first to sever lingering client connections before
+	// stopping the subprocess. See OpGeth.Stop for full rationale.
+	if n.userProxy != nil {
+		n.userProxy.Close()
+	}
+	if n.authProxy != nil {
+		n.authProxy.Close()
+	}
 	err := n.sub.Stop(true)
 	n.p.Require().NoError(err, "Must stop")
 	n.sub = nil


### PR DESCRIPTION
## Summary

Fixes ethereum-optimism/optimism#19656

- **Root cause:** When L2 EL nodes (op-geth/op-reth) shut down during test cleanup, `geth.Node.Close()` waits for all active HTTP/WebSocket handlers to finish. If any client connected through the TCP proxy (e.g. the supernode's engine API connection, or kona-host's L2 node connection) hasn't cleanly closed its WebSocket, `Close()` blocks indefinitely. The TCP proxies are registered as separate `t.Cleanup()` entries that run *after* `l2EL.Stop()` in LIFO order, so the proxy connections stay alive while geth tries to shut down.

- **Why flaky (not always failing):** Whether WebSocket connections are cleanly closed before geth shutdown depends on goroutine scheduling during the cleanup sequence. The supernode's 5-second graceful stop timeout may or may not finish closing its engine API connections before `l2EL.Stop()` runs. Under CI resource contention (CPU pressure, many concurrent test packages), the supernode is more likely to exceed its shutdown timeout, leaving connections alive.

- **Fix:** Close the TCP proxies (user and auth) inside `OpGeth.Stop()` and `OpReth.Stop()` *before* closing the underlying node. This forcefully severs all TCP connections through the proxy, ensuring geth's `Close()` doesn't block waiting for lingering WebSocket handlers. The proxy `Close()` is idempotent, so the subsequent cleanup-registered `Close()` calls are safe no-ops.

- **Flake count:** 3 (via CircleCI Insights, 30-day window)

## Test plan
- [x] `go build ./op-devstack/sysgo/...` passes
- [x] `go vet ./op-devstack/sysgo/...` passes
- [x] `go build ./op-acceptance-tests/...` passes
- [ ] CI passes on this PR