### PR TITLE
chore(op-acceptance): skip flaky VariedBlockTimes fault proof tests

### DIFF
--- a/op-acceptance-tests/tests/interop/proofs/serial/interop_fault_proofs_test.go
+++ b/op-acceptance-tests/tests/interop/proofs/serial/interop_fault_proofs_test.go
@@ -26,6 +26,8 @@ func TestInteropFaultProofs_ConsolidateValidCrossChainMessage(gt *testing.T) {
 
 func TestInteropFaultProofs_VariedBlockTimes(gt *testing.T) {
 	t := devtest.SerialT(gt)
+	// TODO(#19010): Unskip once varied block time fault proofs are stable.
+	t.Skip("Skipping flaky varied block time fault proof test")
 	sys := presets.NewSimpleInteropSupernodeProofs(
 		t,
 		presets.WithChallengerCannonKonaEnabled(),
@@ -39,6 +41,8 @@ func TestInteropFaultProofs_VariedBlockTimes(gt *testing.T) {
 
 func TestInteropFaultProofs_VariedBlockTimes_FasterChainB(gt *testing.T) {
 	t := devtest.SerialT(gt)
+	// TODO(#19010): Unskip once varied block time fault proofs are stable.
+	t.Skip("Skipping flaky varied block time fault proof test")
 	sys := presets.NewSimpleInteropSupernodeProofs(
 		t,
 		presets.WithChallengerCannonKonaEnabled(),

--- a/op-acceptance-tests/tests/isthmus/preinterop/interop_fault_proofs_test.go
+++ b/op-acceptance-tests/tests/isthmus/preinterop/interop_fault_proofs_test.go
@@ -30,6 +30,8 @@ func TestPreinteropFaultProofs_UnsafeProposal(gt *testing.T) {
 
 func TestPreinteropFaultProofs_VariedBlockTimes(gt *testing.T) {
 	t := devtest.SerialT(gt)
+	// TODO(#19010): Unskip once varied block time fault proofs are stable.
+	t.Skip("Skipping flaky varied block time fault proof test")
 	sys := presets.NewSimpleInteropIsthmusSuper(
 		t,
 		presets.WithChallengerCannonKonaEnabled(),
@@ -43,6 +45,8 @@ func TestPreinteropFaultProofs_VariedBlockTimes(gt *testing.T) {
 
 func TestPreinteropFaultProofs_VariedBlockTimes_FasterChainB(gt *testing.T) {
 	t := devtest.SerialT(gt)
+	// TODO(#19010): Unskip once varied block time fault proofs are stable.
+	t.Skip("Skipping flaky varied block time fault proof test")
 	sys := presets.NewSimpleInteropIsthmusSuper(
 		t,
 		presets.WithChallengerCannonKonaEnabled(),


### PR DESCRIPTION
## Summary
- Skip `TestPreinteropFaultProofs_VariedBlockTimes` and `TestPreinteropFaultProofs_VariedBlockTimes_FasterChainB` (preinterop)
- Skip `TestInteropFaultProofs_VariedBlockTimes` and `TestInteropFaultProofs_VariedBlockTimes_FasterChainB` (interop)
- These tests are new and flaky — need more careful review before re-enabling
- Tracked by ethereum-optimism/optimism#19010

## Test plan
- [x] Verify the 4 tests have `t.Skip` added
- [ ] CI passes without these tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)