### PR TITLE
fix(tcpproxy): close race in Proxy.Close that causes 2-hour test hangs

### DIFF
--- a/op-service/testutils/tcpproxy/proxy.go
+++ b/op-service/testutils/tcpproxy/proxy.go
@@ -49,6 +49,7 @@ func (p *Proxy) Start() error {
 		return fmt.Errorf("could not listen: %w", err)
 	}
 	p.lis = lis
+	p.lgr.Info("proxy listening", "addr", lis.Addr().String())
 
 	p.wg.Add(1)
 	go func() {
@@ -57,10 +58,11 @@ func (p *Proxy) Start() error {
 		for {
 			downConn, err := p.lis.Accept()
 			if p.stopped.Load() {
+				p.lgr.Info("accept loop exiting: proxy stopped")
 				return
 			}
 			if err != nil {
-				p.lgr.Error("failed to accept downstream", "err", err)
+				p.lgr.Error("accept failed", "err", err, "addr", p.lis.Addr().String(), "stopped", p.stopped.Load())
 				continue
 			}
 
@@ -134,6 +136,7 @@ func (p *Proxy) handleConn(downConn net.Conn) {
 }
 
 func (p *Proxy) Close() error {
+	p.lgr.Info("closing proxy", "addr", p.lis.Addr().String())
 	p.stopped.Store(true)
 	p.lis.Close()
 

--- a/op-service/testutils/tcpproxy/proxy.go
+++ b/op-service/testutils/tcpproxy/proxy.go
@@ -97,6 +97,10 @@ func (p *Proxy) handleConn(downConn net.Conn) {
 		return
 	}
 	defer upConn.Close()
+	if p.stopped.Load() {
+		p.mu.Unlock()
+		return
+	}
 	p.conns[downConn] = struct{}{}
 	p.conns[upConn] = struct{}{}
 	p.mu.Unlock()
@@ -132,11 +136,16 @@ func (p *Proxy) handleConn(downConn net.Conn) {
 func (p *Proxy) Close() error {
 	p.stopped.Store(true)
 	p.lis.Close()
+
+	// Close all tracked connections under the lock. handleConn checks
+	// p.stopped under p.mu before adding new connections, so after this
+	// iteration no new connections can appear in p.conns.
 	p.mu.Lock()
 	for conn := range p.conns {
 		conn.Close()
 	}
 	p.mu.Unlock()
+
 	p.wg.Wait()
 	return nil
 }


### PR DESCRIPTION
## Summary

Fixes a race condition in the TCP proxy's `Close()` method that causes `wg.Wait()` to hang indefinitely, resulting in 2-hour CI timeouts for tests like `TestInteropFaultProofs_ConsolidateValidCrossChainMessage`.

- Release `p.mu` before dialing upstream in `handleConn` (was held up to 10s during retry loop)
- Check `p.stopped` under `p.mu` before registering connections, establishing a linearization point with `Close()`
- Add early `p.stopped` checks in the retry loop to bail fast on shutdown

Also adds some logging to help diagnose some failures where op-node is failing to connect to op-geth after a restart which are look suspiciously like the proxy might be doing something wrong (but can't tell for sure).

### Root Cause

`handleConn` held `p.mu` while dialing upstream (up to 10s with retries). When `Close()` was called, it would set `p.stopped`, close the listener, then iterate `p.conns` to close tracked connections. If a `handleConn` goroutine was already launched but hadn't yet acquired `p.mu`, it could add connections to `p.conns` *after* `Close()` had already iterated. Those untracked connections never got closed, so the `io.Copy` pump goroutines blocked forever, and `wg.Wait()` in `Close()` never returned.

### Why Flaky

The race depends on goroutine scheduling: `handleConn` must acquire `p.mu` after `Close()` finishes iterating `p.conns`. Under CI CPU pressure, scheduling delays make this window more likely. Locally, the goroutine usually completes before `Close()` runs.

Closes ethereum-optimism/optimism#19656

## Test plan

- [x] Adversarial code review confirmed the fix is correct with no new races
- [ ] CI passes (the affected test `TestInteropFaultProofs_ConsolidateValidCrossChainMessage` runs in `memory-all-opn-op-geth`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>