### PR TITLE
fix(op-reth): remove metrics wrapper from CLI commands to prevent OOM

### DIFF
--- a/rust/op-reth/crates/cli/src/commands/op_proofs/init.rs
+++ b/rust/op-reth/crates/cli/src/commands/op_proofs/init.rs
@@ -8,7 +8,7 @@ use reth_node_core::version::version_metadata;
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_primitives::OpPrimitives;
 use reth_optimism_trie::{
-    InitializationJob, OpProofsStorage, OpProofsStore, db::MdbxProofsStorage,
+    InitializationJob, OpProofsStore, db::MdbxProofsStorage,
 };
 use reth_provider::{BlockNumReader, DBProvider, DatabaseProviderFactory};
 use std::{path::PathBuf, sync::Arc};
@@ -46,12 +46,14 @@ impl<C: ChainSpecParser<ChainSpec = OpChainSpec>> InitCommand<C> {
         // Initialize the environment with read-only access
         let Environment { provider_factory, .. } = self.env.init::<N>(AccessRights::RO)?;
 
-        // Create the proofs storage
-        let storage: OpProofsStorage<Arc<MdbxProofsStorage>> = Arc::new(
+        // Create the proofs storage without the metrics wrapper.
+        // During initialization we write billions of entries; the metrics layer's
+        // `AtomicBucket::push` (used by `Histogram::record_many`) is append-only and
+        // would accumulate ~19 bytes per observation, causing OOM on large chains.
+        let storage: Arc<MdbxProofsStorage> = Arc::new(
             MdbxProofsStorage::new(&self.storage_path)
                 .map_err(|e| eyre::eyre!("Failed to create MdbxProofsStorage: {e}"))?,
-        )
-        .into();
+        );
 
         // Check if already initialized
         if let Some((block_number, block_hash)) = storage.get_earliest_block_number()? {

--- a/rust/op-reth/crates/cli/src/commands/op_proofs/init.rs
+++ b/rust/op-reth/crates/cli/src/commands/op_proofs/init.rs
@@ -7,9 +7,7 @@ use reth_cli_commands::common::{AccessRights, CliNodeTypes, Environment, Environ
 use reth_node_core::version::version_metadata;
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_primitives::OpPrimitives;
-use reth_optimism_trie::{
-    InitializationJob, OpProofsStore, db::MdbxProofsStorage,
-};
+use reth_optimism_trie::{InitializationJob, OpProofsStore, db::MdbxProofsStorage};
 use reth_provider::{BlockNumReader, DBProvider, DatabaseProviderFactory};
 use std::{path::PathBuf, sync::Arc};
 use tracing::info;

--- a/rust/op-reth/crates/cli/src/commands/op_proofs/prune.rs
+++ b/rust/op-reth/crates/cli/src/commands/op_proofs/prune.rs
@@ -7,7 +7,7 @@ use reth_node_core::version::version_metadata;
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_primitives::OpPrimitives;
 use reth_optimism_trie::{
-    OpProofStoragePruner, OpProofsStorage, OpProofsStore, db::MdbxProofsStorage,
+    OpProofStoragePruner, OpProofsStore, db::MdbxProofsStorage,
 };
 use std::{path::PathBuf, sync::Arc};
 use tracing::info;
@@ -56,11 +56,10 @@ impl<C: ChainSpecParser<ChainSpec = OpChainSpec>> PruneCommand<C> {
         // Initialize the environment with read-only access
         let Environment { provider_factory, .. } = self.env.init::<N>(AccessRights::RO)?;
 
-        let storage: OpProofsStorage<Arc<MdbxProofsStorage>> = Arc::new(
+        let storage: Arc<MdbxProofsStorage> = Arc::new(
             MdbxProofsStorage::new(&self.storage_path)
                 .map_err(|e| eyre::eyre!("Failed to create MdbxProofsStorage: {e}"))?,
-        )
-        .into();
+        );
 
         let earliest_block = storage.get_earliest_block_number()?;
         let latest_block = storage.get_latest_block_number()?;

--- a/rust/op-reth/crates/cli/src/commands/op_proofs/prune.rs
+++ b/rust/op-reth/crates/cli/src/commands/op_proofs/prune.rs
@@ -6,9 +6,7 @@ use reth_cli_commands::common::{AccessRights, CliNodeTypes, Environment, Environ
 use reth_node_core::version::version_metadata;
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_primitives::OpPrimitives;
-use reth_optimism_trie::{
-    OpProofStoragePruner, OpProofsStore, db::MdbxProofsStorage,
-};
+use reth_optimism_trie::{OpProofStoragePruner, OpProofsStore, db::MdbxProofsStorage};
 use std::{path::PathBuf, sync::Arc};
 use tracing::info;
 

--- a/rust/op-reth/crates/cli/src/commands/op_proofs/unwind.rs
+++ b/rust/op-reth/crates/cli/src/commands/op_proofs/unwind.rs
@@ -36,10 +36,7 @@ pub struct UnwindCommand<C: ChainSpecParser> {
 
 impl<C: ChainSpecParser> UnwindCommand<C> {
     /// Validates that the target block number is within a valid range for unwinding.
-    fn validate_unwind_range<Store: OpProofsStore>(
-        &self,
-        storage: Store,
-    ) -> eyre::Result<bool> {
+    fn validate_unwind_range<Store: OpProofsStore>(&self, storage: Store) -> eyre::Result<bool> {
         let (Some((earliest, _)), Some((latest, _))) =
             (storage.get_earliest_block_number()?, storage.get_latest_block_number()?)
         else {

--- a/rust/op-reth/crates/cli/src/commands/op_proofs/unwind.rs
+++ b/rust/op-reth/crates/cli/src/commands/op_proofs/unwind.rs
@@ -6,7 +6,7 @@ use reth_cli_commands::common::{AccessRights, CliNodeTypes, Environment, Environ
 use reth_node_core::version::version_metadata;
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_primitives::OpPrimitives;
-use reth_optimism_trie::{OpProofsStorage, OpProofsStore, db::MdbxProofsStorage};
+use reth_optimism_trie::{OpProofsStore, db::MdbxProofsStorage};
 use reth_provider::{BlockReader, TransactionVariant};
 use std::{path::PathBuf, sync::Arc};
 use tracing::{info, warn};
@@ -38,7 +38,7 @@ impl<C: ChainSpecParser> UnwindCommand<C> {
     /// Validates that the target block number is within a valid range for unwinding.
     fn validate_unwind_range<Store: OpProofsStore>(
         &self,
-        storage: &OpProofsStorage<Store>,
+        storage: Store,
     ) -> eyre::Result<bool> {
         let (Some((earliest, _)), Some((latest, _))) =
             (storage.get_earliest_block_number()?, storage.get_latest_block_number()?)
@@ -73,14 +73,13 @@ impl<C: ChainSpecParser<ChainSpec = OpChainSpec>> UnwindCommand<C> {
         let Environment { provider_factory, .. } = self.env.init::<N>(AccessRights::RO)?;
 
         // Create the proofs storage
-        let storage: OpProofsStorage<Arc<MdbxProofsStorage>> = Arc::new(
+        let storage: Arc<MdbxProofsStorage> = Arc::new(
             MdbxProofsStorage::new(&self.storage_path)
                 .map_err(|e| eyre::eyre!("Failed to create MdbxProofsStorage: {e}"))?,
-        )
-        .into();
+        );
 
         // Validate that the target block is within a valid range for unwinding
-        if !self.validate_unwind_range(&storage)? {
+        if !self.validate_unwind_range(storage.clone())? {
             return Ok(());
         }
 

--- a/rust/op-reth/crates/trie/src/prune/pruner.rs
+++ b/rust/op-reth/crates/trie/src/prune/pruner.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "metrics")]
 use crate::prune::metrics::Metrics;
 use crate::{
-    OpProofsStorage, OpProofsStore,
+    OpProofsStore,
     prune::error::{OpProofStoragePrunerResult, PrunerError, PrunerOutput},
 };
 use alloy_eips::{BlockNumHash, eip1898::BlockWithParent};
@@ -14,7 +14,7 @@ use tracing::{error, info, trace};
 #[derive(Debug)]
 pub struct OpProofStoragePruner<P, H> {
     // Database provider for the prune
-    provider: OpProofsStorage<P>,
+    provider: P,
     /// Reader to fetch block hash by block number
     block_hash_reader: H,
     /// Keep at least these many recent blocks
@@ -30,7 +30,7 @@ pub struct OpProofStoragePruner<P, H> {
 impl<P, H> OpProofStoragePruner<P, H> {
     /// Create a new pruner.
     pub fn new(
-        provider: OpProofsStorage<P>,
+        provider: P,
         block_hash_reader: H,
         min_block_interval: u64,
         prune_batch_size: u64,
@@ -227,8 +227,8 @@ mod tests {
     async fn run_inner_and_and_verify_updated_state() {
         // --- env/store ---
         let dir = TempDir::new().unwrap();
-        let store: OpProofsStorage<Arc<MdbxProofsStorage>> =
-            OpProofsStorage::from(Arc::new(MdbxProofsStorage::new(dir.path()).expect("env")));
+        let store: Arc<MdbxProofsStorage> =
+            Arc::new(MdbxProofsStorage::new(dir.path()).expect("env"));
 
         store.set_earliest_block_number(0, B256::ZERO).expect("set earliest");
 
@@ -515,8 +515,8 @@ mod tests {
     #[tokio::test]
     async fn run_inner_where_latest_block_is_none() {
         let dir = TempDir::new().unwrap();
-        let store: OpProofsStorage<Arc<MdbxProofsStorage>> =
-            OpProofsStorage::from(Arc::new(MdbxProofsStorage::new(dir.path()).expect("env")));
+        let store: Arc<MdbxProofsStorage> =
+            Arc::new(MdbxProofsStorage::new(dir.path()).expect("env"));
 
         let earliest = store.get_earliest_block_number().unwrap();
         let latest = store.get_latest_block_number().unwrap();
@@ -536,8 +536,8 @@ mod tests {
         use crate::BlockStateDiff;
 
         let dir = TempDir::new().unwrap();
-        let store: OpProofsStorage<Arc<MdbxProofsStorage>> =
-            OpProofsStorage::from(Arc::new(MdbxProofsStorage::new(dir.path()).expect("env")));
+        let store: Arc<MdbxProofsStorage> =
+            Arc::new(MdbxProofsStorage::new(dir.path()).expect("env"));
 
         // Write a single block to set *latest* only.
         store
@@ -561,8 +561,8 @@ mod tests {
         use crate::BlockStateDiff;
 
         let dir = TempDir::new().unwrap();
-        let store: OpProofsStorage<Arc<MdbxProofsStorage>> =
-            OpProofsStorage::from(Arc::new(MdbxProofsStorage::new(dir.path()).expect("env")));
+        let store: Arc<MdbxProofsStorage> =
+            Arc::new(MdbxProofsStorage::new(dir.path()).expect("env"));
 
         // Set earliest=4 explicitly
         let earliest_num = 4u64;

--- a/rust/op-reth/crates/trie/src/prune/task.rs
+++ b/rust/op-reth/crates/trie/src/prune/task.rs
@@ -1,4 +1,4 @@
-use crate::{OpProofsStorage, OpProofsStore, prune::OpProofStoragePruner};
+use crate::{OpProofsStore, prune::OpProofStoragePruner};
 use reth_provider::BlockHashReader;
 use reth_tasks::shutdown::GracefulShutdown;
 use tokio::{
@@ -24,7 +24,7 @@ where
 {
     /// Initialize a new [`OpProofStoragePrunerTask`]
     pub fn new(
-        provider: OpProofsStorage<P>,
+        provider: P,
         hash_reader: H,
         min_block_interval: u64,
         task_run_interval: Duration,


### PR DESCRIPTION
**Description**

Running `proofs init` on Base mainnet (~2.5B hashed storage entries) consistently
OOM-kills the process on a 64GB server at ~50-55GB RSS.

`OpProofsStorage<S>` is a type alias for `OpProofsStoreWithMetrics<S>`, which wraps
every storage operation with `metrics::Histogram` recording. The `store_hashed_storages`
path calls `record_duration_per_item` → `histogram.record_many()` for every batch,
which pushes into `metrics_util::AtomicBucket<T>` — an **append-only** data structure
that never releases memory until explicitly drained.

**Tests**

I have tested the fix on the base mainnet.

**Additional context**

NA

**Metadata**

- Fixes #19640 