### PR TITLE
fix(op-reth): replace HashMap with sequential grouping in init store_entries

### DIFF
--- a/rust/op-reth/crates/cli/src/commands/op_proofs/init.rs
+++ b/rust/op-reth/crates/cli/src/commands/op_proofs/init.rs
@@ -8,7 +8,7 @@ use reth_node_core::version::version_metadata;
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_primitives::OpPrimitives;
 use reth_optimism_trie::{
-    InitializationJob, OpProofsStorage, OpProofsStore, db::MdbxProofsStorage,
+    InitializationJob, OpProofsStore, db::MdbxProofsStorage,
 };
 use reth_provider::{BlockNumReader, DBProvider, DatabaseProviderFactory};
 use std::{path::PathBuf, sync::Arc};
@@ -46,12 +46,14 @@ impl<C: ChainSpecParser<ChainSpec = OpChainSpec>> InitCommand<C> {
         // Initialize the environment with read-only access
         let Environment { provider_factory, .. } = self.env.init::<N>(AccessRights::RO)?;
 
-        // Create the proofs storage
-        let storage: OpProofsStorage<Arc<MdbxProofsStorage>> = Arc::new(
+        // Create the proofs storage without the metrics wrapper.
+        // During initialization we write billions of entries; the metrics layer's
+        // `AtomicBucket::push` (used by `Histogram::record_many`) is append-only and
+        // would accumulate ~19 bytes per observation, causing OOM on large chains.
+        let storage: Arc<MdbxProofsStorage> = Arc::new(
             MdbxProofsStorage::new(&self.storage_path)
                 .map_err(|e| eyre::eyre!("Failed to create MdbxProofsStorage: {e}"))?,
-        )
-        .into();
+        );
 
         // Check if already initialized
         if let Some((block_number, block_hash)) = storage.get_earliest_block_number()? {

--- a/rust/op-reth/crates/cli/src/commands/op_proofs/init.rs
+++ b/rust/op-reth/crates/cli/src/commands/op_proofs/init.rs
@@ -7,9 +7,7 @@ use reth_cli_commands::common::{AccessRights, CliNodeTypes, Environment, Environ
 use reth_node_core::version::version_metadata;
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_primitives::OpPrimitives;
-use reth_optimism_trie::{
-    InitializationJob, OpProofsStore, db::MdbxProofsStorage,
-};
+use reth_optimism_trie::{InitializationJob, OpProofsStore, db::MdbxProofsStorage};
 use reth_provider::{BlockNumReader, DBProvider, DatabaseProviderFactory};
 use std::{path::PathBuf, sync::Arc};
 use tracing::info;

--- a/rust/op-reth/crates/cli/src/commands/op_proofs/prune.rs
+++ b/rust/op-reth/crates/cli/src/commands/op_proofs/prune.rs
@@ -7,7 +7,7 @@ use reth_node_core::version::version_metadata;
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_primitives::OpPrimitives;
 use reth_optimism_trie::{
-    OpProofStoragePruner, OpProofsStorage, OpProofsStore, db::MdbxProofsStorage,
+    OpProofStoragePruner, OpProofsStore, db::MdbxProofsStorage,
 };
 use std::{path::PathBuf, sync::Arc};
 use tracing::info;
@@ -56,11 +56,10 @@ impl<C: ChainSpecParser<ChainSpec = OpChainSpec>> PruneCommand<C> {
         // Initialize the environment with read-only access
         let Environment { provider_factory, .. } = self.env.init::<N>(AccessRights::RO)?;
 
-        let storage: OpProofsStorage<Arc<MdbxProofsStorage>> = Arc::new(
+        let storage: Arc<MdbxProofsStorage> = Arc::new(
             MdbxProofsStorage::new(&self.storage_path)
                 .map_err(|e| eyre::eyre!("Failed to create MdbxProofsStorage: {e}"))?,
-        )
-        .into();
+        );
 
         let earliest_block = storage.get_earliest_block_number()?;
         let latest_block = storage.get_latest_block_number()?;

--- a/rust/op-reth/crates/cli/src/commands/op_proofs/prune.rs
+++ b/rust/op-reth/crates/cli/src/commands/op_proofs/prune.rs
@@ -6,9 +6,7 @@ use reth_cli_commands::common::{AccessRights, CliNodeTypes, Environment, Environ
 use reth_node_core::version::version_metadata;
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_primitives::OpPrimitives;
-use reth_optimism_trie::{
-    OpProofStoragePruner, OpProofsStore, db::MdbxProofsStorage,
-};
+use reth_optimism_trie::{OpProofStoragePruner, OpProofsStore, db::MdbxProofsStorage};
 use std::{path::PathBuf, sync::Arc};
 use tracing::info;
 

--- a/rust/op-reth/crates/cli/src/commands/op_proofs/unwind.rs
+++ b/rust/op-reth/crates/cli/src/commands/op_proofs/unwind.rs
@@ -36,10 +36,7 @@ pub struct UnwindCommand<C: ChainSpecParser> {
 
 impl<C: ChainSpecParser> UnwindCommand<C> {
     /// Validates that the target block number is within a valid range for unwinding.
-    fn validate_unwind_range<Store: OpProofsStore>(
-        &self,
-        storage: Store,
-    ) -> eyre::Result<bool> {
+    fn validate_unwind_range<Store: OpProofsStore>(&self, storage: Store) -> eyre::Result<bool> {
         let (Some((earliest, _)), Some((latest, _))) =
             (storage.get_earliest_block_number()?, storage.get_latest_block_number()?)
         else {

--- a/rust/op-reth/crates/cli/src/commands/op_proofs/unwind.rs
+++ b/rust/op-reth/crates/cli/src/commands/op_proofs/unwind.rs
@@ -6,7 +6,7 @@ use reth_cli_commands::common::{AccessRights, CliNodeTypes, Environment, Environ
 use reth_node_core::version::version_metadata;
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_primitives::OpPrimitives;
-use reth_optimism_trie::{OpProofsStorage, OpProofsStore, db::MdbxProofsStorage};
+use reth_optimism_trie::{OpProofsStore, db::MdbxProofsStorage};
 use reth_provider::{BlockReader, TransactionVariant};
 use std::{path::PathBuf, sync::Arc};
 use tracing::{info, warn};
@@ -38,7 +38,7 @@ impl<C: ChainSpecParser> UnwindCommand<C> {
     /// Validates that the target block number is within a valid range for unwinding.
     fn validate_unwind_range<Store: OpProofsStore>(
         &self,
-        storage: &OpProofsStorage<Store>,
+        storage: Store,
     ) -> eyre::Result<bool> {
         let (Some((earliest, _)), Some((latest, _))) =
             (storage.get_earliest_block_number()?, storage.get_latest_block_number()?)
@@ -73,14 +73,13 @@ impl<C: ChainSpecParser<ChainSpec = OpChainSpec>> UnwindCommand<C> {
         let Environment { provider_factory, .. } = self.env.init::<N>(AccessRights::RO)?;
 
         // Create the proofs storage
-        let storage: OpProofsStorage<Arc<MdbxProofsStorage>> = Arc::new(
+        let storage: Arc<MdbxProofsStorage> = Arc::new(
             MdbxProofsStorage::new(&self.storage_path)
                 .map_err(|e| eyre::eyre!("Failed to create MdbxProofsStorage: {e}"))?,
-        )
-        .into();
+        );
 
         // Validate that the target block is within a valid range for unwinding
-        if !self.validate_unwind_range(&storage)? {
+        if !self.validate_unwind_range(storage.clone())? {
             return Ok(());
         }
 

--- a/rust/op-reth/crates/trie/src/initialize.rs
+++ b/rust/op-reth/crates/trie/src/initialize.rs
@@ -19,7 +19,7 @@ use reth_primitives_traits::{Account, StorageEntry};
 use reth_trie_common::{
     BranchNodeCompact, Nibbles, StorageTrieEntry, StoredNibbles, StoredNibblesSubKey,
 };
-use std::{collections::HashMap, time::Instant};
+use std::time::Instant;
 use tracing::{debug, info};
 
 /// Batch size threshold for storing entries during initialization
@@ -394,21 +394,45 @@ impl<C> InitTable for HashedStoragesInit<C> {
     type Value = StorageEntry;
 
     /// Save mapping of hashed addresses to storage entries to storage.
+    ///
+    /// Entries must arrive in sorted order (address ASC, slot ASC) from the
+    /// source cursor. We group consecutively by address to preserve that
+    /// order for the backend's `append_dup` calls.
+    //
+    // # Why not HashMap?
+    //
+    // An earlier version grouped entries with `HashMap<B256, Vec<…>>`.
+    // HashMap randomised iteration order, which caused silent data loss
+    // when a batch contained multiple addresses and was only partially
+    // processed before a failure (e.g. OOM kill).
+    //
+    // Each `store_hashed_storages` call commits its own MDBX transaction,
+    // so if the HashMap happened to flush addresses B, D (committed) and
+    // then failed on A (e.g. OOM kill), the
+    // resume key would be set to D. On restart the source cursor seeks
+    // past D, permanently skipping A and C — producing a proof DB with
+    // missing entries and ultimately a trie root / hash mismatch.
     fn store_entries(
         store: &impl OpProofsInitialStateStore,
         entries: impl IntoIterator<Item = (Self::Key, Self::Value)>,
     ) -> Result<(), OpProofsStorageError> {
-        let entries_iter = entries.into_iter();
-        let mut by_address: HashMap<B256, Vec<(B256, U256)>> =
-            HashMap::with_capacity(entries_iter.size_hint().0);
+        let mut current_address: Option<B256> = None;
+        let mut current_slots: Vec<(B256, U256)> = Vec::new();
 
-        // Group entries by hashed address
-        for (address, entry) in entries_iter {
-            by_address.entry(address).or_default().push((entry.key, entry.value));
+        for (address, entry) in entries {
+            if current_address.as_ref() != Some(&address) {
+                // Flush previous address group
+                if let Some(addr) = current_address.take() {
+                    store.store_hashed_storages(addr, std::mem::take(&mut current_slots))?;
+                }
+                current_address = Some(address);
+            }
+            current_slots.push((entry.key, entry.value));
         }
-        // Store each address's storage entries
-        for (address, storages) in by_address {
-            store.store_hashed_storages(address, storages)?;
+
+        // Flush last group
+        if let Some(addr) = current_address {
+            store.store_hashed_storages(addr, current_slots)?;
         }
 
         Ok(())
@@ -437,24 +461,37 @@ impl<C> InitTable for StoragesTrieInit<C> {
     type Value = StorageTrieEntry;
 
     /// Save mapping of hashed addresses to storage trie entries to storage.
+    ///
+    /// Entries must arrive in sorted order (address ASC, nibbles ASC) from the
+    /// source cursor. We group consecutively by address to preserve that
+    /// order for the backend's `append_dup` calls.
+    ///
+    // See [`HashedStoragesInit::store_entries`] for why HashMap must not be
+    // used here — the same silent-data-loss-on-resume bug applies.
     fn store_entries(
         store: &impl OpProofsInitialStateStore,
         entries: impl IntoIterator<Item = (Self::Key, Self::Value)>,
     ) -> Result<(), OpProofsStorageError> {
-        let entries_iter = entries.into_iter();
-        let mut by_address: HashMap<B256, Vec<(Nibbles, Option<BranchNodeCompact>)>> =
-            HashMap::with_capacity(entries_iter.size_hint().0);
+        let mut current_address: Option<B256> = None;
+        let mut current_branches: Vec<(Nibbles, Option<BranchNodeCompact>)> = Vec::new();
 
-        // Group entries by hashed address
-        for (hashed_address, storage_entry) in entries_iter {
-            by_address
-                .entry(hashed_address)
-                .or_default()
-                .push((storage_entry.nibbles.0, Some(storage_entry.node)));
+        for (hashed_address, storage_entry) in entries {
+            if current_address.as_ref() != Some(&hashed_address) {
+                // Flush previous address group
+                if let Some(addr) = current_address.take() {
+                    store.store_storage_branches(
+                        addr,
+                        std::mem::take(&mut current_branches),
+                    )?;
+                }
+                current_address = Some(hashed_address);
+            }
+            current_branches.push((storage_entry.nibbles.0, Some(storage_entry.node)));
         }
-        // Store each address's storage trie branches
-        for (address, branches) in by_address {
-            store.store_storage_branches(address, branches)?;
+
+        // Flush last group
+        if let Some(addr) = current_address {
+            store.store_storage_branches(addr, current_branches)?;
         }
 
         Ok(())
@@ -1163,6 +1200,168 @@ mod tests {
                 got.push(path);
             }
             assert_eq!(got, vec![n2.0, n3.0]);
+        }
+    }
+
+    /// A recording spy that implements [`OpProofsInitialStateStore`] and captures
+    /// the order of addresses passed to `store_hashed_storages` and
+    /// `store_storage_branches`.
+    #[derive(Debug, Default)]
+    struct RecordingStore {
+        hashed_storage_addresses: std::sync::Mutex<Vec<B256>>,
+        storage_branch_addresses: std::sync::Mutex<Vec<B256>>,
+    }
+
+    impl OpProofsInitialStateStore for RecordingStore {
+        fn initial_state_anchor(&self) -> crate::OpProofsStorageResult<InitialStateAnchor> {
+            Ok(InitialStateAnchor::default())
+        }
+
+        fn set_initial_state_anchor(
+            &self,
+            _anchor: BlockNumHash,
+        ) -> crate::OpProofsStorageResult<()> {
+            Ok(())
+        }
+
+        fn store_account_branches(
+            &self,
+            _account_nodes: Vec<(Nibbles, Option<BranchNodeCompact>)>,
+        ) -> crate::OpProofsStorageResult<()> {
+            Ok(())
+        }
+
+        fn store_storage_branches(
+            &self,
+            hashed_address: B256,
+            _storage_nodes: Vec<(Nibbles, Option<BranchNodeCompact>)>,
+        ) -> crate::OpProofsStorageResult<()> {
+            self.storage_branch_addresses.lock().unwrap().push(hashed_address);
+            Ok(())
+        }
+
+        fn store_hashed_accounts(
+            &self,
+            _accounts: Vec<(B256, Option<Account>)>,
+        ) -> crate::OpProofsStorageResult<()> {
+            Ok(())
+        }
+
+        fn store_hashed_storages(
+            &self,
+            hashed_address: B256,
+            _storages: Vec<(B256, U256)>,
+        ) -> crate::OpProofsStorageResult<()> {
+            self.hashed_storage_addresses.lock().unwrap().push(hashed_address);
+            Ok(())
+        }
+
+        fn commit_initial_state(&self) -> crate::OpProofsStorageResult<BlockNumHash> {
+            Ok(BlockNumHash::default())
+        }
+    }
+
+    /// Verifies that `HashedStoragesInit::store_entries` calls
+    /// `store_hashed_storages` in strictly ascending address order.
+    ///
+    /// This is the regression test for the HashMap ordering bug: HashMap
+    /// randomised iteration order, caused silent data loss in case where
+    /// the batch contains multiple addresses and
+    /// the batch was partially processed before a failure.
+    #[test]
+    fn test_store_hashed_storages_preserves_sorted_address_order() {
+        let spy = RecordingStore::default();
+
+        // Build entries for 5 addresses in ascending order, each with 2 slots.
+        // These simulate what the source cursor yields in a single batch.
+        let addresses: Vec<B256> = (1u8..=5).map(|b| k(b)).collect();
+        let slot_a = k(0xAA);
+        let slot_b = k(0xBB);
+
+        let entries: Vec<(B256, StorageEntry)> = addresses
+            .iter()
+            .flat_map(|addr| {
+                vec![
+                    (*addr, StorageEntry { key: slot_a, value: U256::from(1) }),
+                    (*addr, StorageEntry { key: slot_b, value: U256::from(2) }),
+                ]
+            })
+            .collect();
+
+        HashedStoragesInit::<()>::store_entries(&spy, entries)
+            .expect("store_entries should succeed");
+
+        let recorded = spy.hashed_storage_addresses.lock().unwrap().clone();
+
+        // Must have been called exactly once per address
+        assert_eq!(recorded.len(), addresses.len(), "one call per address");
+
+        // Must be in the same (sorted) order as the input
+        assert_eq!(recorded, addresses, "addresses must be in ascending order");
+
+        // Strictly ascending — no duplicates, no out-of-order
+        for w in recorded.windows(2) {
+            assert!(
+                w[0] < w[1],
+                "addresses must be strictly ascending: {:?} >= {:?}",
+                w[0],
+                w[1]
+            );
+        }
+    }
+
+    /// Verifies that `StoragesTrieInit::store_entries` calls
+    /// `store_storage_branches` in strictly ascending address order.
+    #[test]
+    fn test_store_storage_branches_preserves_sorted_address_order() {
+        let spy = RecordingStore::default();
+
+        // Build entries for 5 addresses in ascending order, each with 2 trie paths.
+        let addresses: Vec<B256> = (1u8..=5).map(|b| k(b)).collect();
+        let path_a = Nibbles::from_nibbles_unchecked(vec![0x0A]);
+        let path_b = Nibbles::from_nibbles_unchecked(vec![0x0B]);
+
+        let entries: Vec<(B256, StorageTrieEntry)> = addresses
+            .iter()
+            .flat_map(|addr| {
+                vec![
+                    (
+                        *addr,
+                        StorageTrieEntry {
+                            nibbles: StoredNibblesSubKey(path_a.clone()),
+                            node: create_test_branch_node(),
+                        },
+                    ),
+                    (
+                        *addr,
+                        StorageTrieEntry {
+                            nibbles: StoredNibblesSubKey(path_b.clone()),
+                            node: create_test_branch_node(),
+                        },
+                    ),
+                ]
+            })
+            .collect();
+
+        StoragesTrieInit::<()>::store_entries(&spy, entries)
+            .expect("store_entries should succeed");
+
+        let recorded = spy.storage_branch_addresses.lock().unwrap().clone();
+
+        // Must have been called exactly once per address
+        assert_eq!(recorded.len(), addresses.len(), "one call per address");
+
+        // Must be in the same (sorted) order as the input
+        assert_eq!(recorded, addresses, "addresses must be in ascending order");
+
+        // Strictly ascending
+        for w in recorded.windows(2) {
+            assert!(
+                w[0] < w[1],
+                "addresses must be strictly ascending: {:?} >= {:?}",
+                w[0],
+                w[1]
+            );
         }
     }
 }

--- a/rust/op-reth/crates/trie/src/initialize.rs
+++ b/rust/op-reth/crates/trie/src/initialize.rs
@@ -465,7 +465,6 @@ impl<C> InitTable for StoragesTrieInit<C> {
     /// Entries must arrive in sorted order (address ASC, nibbles ASC) from the
     /// source cursor. We group consecutively by address to preserve that
     /// order for the backend's `append_dup` calls.
-    ///
     // See [`HashedStoragesInit::store_entries`] for why HashMap must not be
     // used here — the same silent-data-loss-on-resume bug applies.
     fn store_entries(
@@ -479,10 +478,7 @@ impl<C> InitTable for StoragesTrieInit<C> {
             if current_address.as_ref() != Some(&hashed_address) {
                 // Flush previous address group
                 if let Some(addr) = current_address.take() {
-                    store.store_storage_branches(
-                        addr,
-                        std::mem::take(&mut current_branches),
-                    )?;
+                    store.store_storage_branches(addr, std::mem::take(&mut current_branches))?;
                 }
                 current_address = Some(hashed_address);
             }
@@ -1264,7 +1260,7 @@ mod tests {
     /// Verifies that `HashedStoragesInit::store_entries` calls
     /// `store_hashed_storages` in strictly ascending address order.
     ///
-    /// This is the regression test for the HashMap ordering bug: HashMap
+    /// This is the regression test for the `HashMap` ordering bug: `HashMap`
     /// randomised iteration order, caused silent data loss in case where
     /// the batch contains multiple addresses and
     /// the batch was partially processed before a failure.
@@ -1274,7 +1270,7 @@ mod tests {
 
         // Build entries for 5 addresses in ascending order, each with 2 slots.
         // These simulate what the source cursor yields in a single batch.
-        let addresses: Vec<B256> = (1u8..=5).map(|b| k(b)).collect();
+        let addresses: Vec<B256> = (1u8..=5).map(k).collect();
         let slot_a = k(0xAA);
         let slot_b = k(0xBB);
 
@@ -1301,12 +1297,7 @@ mod tests {
 
         // Strictly ascending — no duplicates, no out-of-order
         for w in recorded.windows(2) {
-            assert!(
-                w[0] < w[1],
-                "addresses must be strictly ascending: {:?} >= {:?}",
-                w[0],
-                w[1]
-            );
+            assert!(w[0] < w[1], "addresses must be strictly ascending: {:?} >= {:?}", w[0], w[1]);
         }
     }
 
@@ -1317,7 +1308,7 @@ mod tests {
         let spy = RecordingStore::default();
 
         // Build entries for 5 addresses in ascending order, each with 2 trie paths.
-        let addresses: Vec<B256> = (1u8..=5).map(|b| k(b)).collect();
+        let addresses: Vec<B256> = (1u8..=5).map(k).collect();
         let path_a = Nibbles::from_nibbles_unchecked(vec![0x0A]);
         let path_b = Nibbles::from_nibbles_unchecked(vec![0x0B]);
 
@@ -1328,14 +1319,14 @@ mod tests {
                     (
                         *addr,
                         StorageTrieEntry {
-                            nibbles: StoredNibblesSubKey(path_a.clone()),
+                            nibbles: StoredNibblesSubKey(path_a),
                             node: create_test_branch_node(),
                         },
                     ),
                     (
                         *addr,
                         StorageTrieEntry {
-                            nibbles: StoredNibblesSubKey(path_b.clone()),
+                            nibbles: StoredNibblesSubKey(path_b),
                             node: create_test_branch_node(),
                         },
                     ),
@@ -1343,8 +1334,7 @@ mod tests {
             })
             .collect();
 
-        StoragesTrieInit::<()>::store_entries(&spy, entries)
-            .expect("store_entries should succeed");
+        StoragesTrieInit::<()>::store_entries(&spy, entries).expect("store_entries should succeed");
 
         let recorded = spy.storage_branch_addresses.lock().unwrap().clone();
 
@@ -1356,12 +1346,7 @@ mod tests {
 
         // Strictly ascending
         for w in recorded.windows(2) {
-            assert!(
-                w[0] < w[1],
-                "addresses must be strictly ascending: {:?} >= {:?}",
-                w[0],
-                w[1]
-            );
+            assert!(w[0] < w[1], "addresses must be strictly ascending: {:?} >= {:?}", w[0], w[1]);
         }
     }
 }

--- a/rust/op-reth/crates/trie/src/prune/pruner.rs
+++ b/rust/op-reth/crates/trie/src/prune/pruner.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "metrics")]
 use crate::prune::metrics::Metrics;
 use crate::{
-    OpProofsStorage, OpProofsStore,
+    OpProofsStore,
     prune::error::{OpProofStoragePrunerResult, PrunerError, PrunerOutput},
 };
 use alloy_eips::{BlockNumHash, eip1898::BlockWithParent};
@@ -14,7 +14,7 @@ use tracing::{error, info, trace};
 #[derive(Debug)]
 pub struct OpProofStoragePruner<P, H> {
     // Database provider for the prune
-    provider: OpProofsStorage<P>,
+    provider: P,
     /// Reader to fetch block hash by block number
     block_hash_reader: H,
     /// Keep at least these many recent blocks
@@ -30,7 +30,7 @@ pub struct OpProofStoragePruner<P, H> {
 impl<P, H> OpProofStoragePruner<P, H> {
     /// Create a new pruner.
     pub fn new(
-        provider: OpProofsStorage<P>,
+        provider: P,
         block_hash_reader: H,
         min_block_interval: u64,
         prune_batch_size: u64,
@@ -227,8 +227,8 @@ mod tests {
     async fn run_inner_and_and_verify_updated_state() {
         // --- env/store ---
         let dir = TempDir::new().unwrap();
-        let store: OpProofsStorage<Arc<MdbxProofsStorage>> =
-            OpProofsStorage::from(Arc::new(MdbxProofsStorage::new(dir.path()).expect("env")));
+        let store: Arc<MdbxProofsStorage> =
+            Arc::new(MdbxProofsStorage::new(dir.path()).expect("env"));
 
         store.set_earliest_block_number(0, B256::ZERO).expect("set earliest");
 
@@ -515,8 +515,8 @@ mod tests {
     #[tokio::test]
     async fn run_inner_where_latest_block_is_none() {
         let dir = TempDir::new().unwrap();
-        let store: OpProofsStorage<Arc<MdbxProofsStorage>> =
-            OpProofsStorage::from(Arc::new(MdbxProofsStorage::new(dir.path()).expect("env")));
+        let store: Arc<MdbxProofsStorage> =
+            Arc::new(MdbxProofsStorage::new(dir.path()).expect("env"));
 
         let earliest = store.get_earliest_block_number().unwrap();
         let latest = store.get_latest_block_number().unwrap();
@@ -536,8 +536,8 @@ mod tests {
         use crate::BlockStateDiff;
 
         let dir = TempDir::new().unwrap();
-        let store: OpProofsStorage<Arc<MdbxProofsStorage>> =
-            OpProofsStorage::from(Arc::new(MdbxProofsStorage::new(dir.path()).expect("env")));
+        let store: Arc<MdbxProofsStorage> =
+            Arc::new(MdbxProofsStorage::new(dir.path()).expect("env"));
 
         // Write a single block to set *latest* only.
         store
@@ -561,8 +561,8 @@ mod tests {
         use crate::BlockStateDiff;
 
         let dir = TempDir::new().unwrap();
-        let store: OpProofsStorage<Arc<MdbxProofsStorage>> =
-            OpProofsStorage::from(Arc::new(MdbxProofsStorage::new(dir.path()).expect("env")));
+        let store: Arc<MdbxProofsStorage> =
+            Arc::new(MdbxProofsStorage::new(dir.path()).expect("env"));
 
         // Set earliest=4 explicitly
         let earliest_num = 4u64;

--- a/rust/op-reth/crates/trie/src/prune/task.rs
+++ b/rust/op-reth/crates/trie/src/prune/task.rs
@@ -1,4 +1,4 @@
-use crate::{OpProofsStorage, OpProofsStore, prune::OpProofStoragePruner};
+use crate::{OpProofsStore, prune::OpProofStoragePruner};
 use reth_provider::BlockHashReader;
 use reth_tasks::shutdown::GracefulShutdown;
 use tokio::{
@@ -24,7 +24,7 @@ where
 {
     /// Initialize a new [`OpProofStoragePrunerTask`]
     pub fn new(
-        provider: OpProofsStorage<P>,
+        provider: P,
         hash_reader: H,
         min_block_interval: u64,
         task_run_interval: Duration,


### PR DESCRIPTION
# Description

## Problem

`HashedStoragesInit::store_entries` and `StoragesTrieInit::store_entries` grouped entries into a `HashMap<B256, Vec<…>>` before writing them to the proofs DB. The source cursor yields entries in sorted order `(address ASC, key ASC)`, but `HashMap` iteration randomises that order.

This caused silent data loss when the init process was killed(before processing the full batch) and restarted:

1.  A batch of 100K entries spans addresses A → E
2. HashMap iterates in random order, e.g. B, D, A, C, E
3. `store_hashed_storages(B, …)` → opens MDBX txn → commits
4. `store_hashed_storages(D, …)` → D → OK → commits
5. `store_hashed_storages(A, …)` → A → process dies (e.g. OOM)
6. On restart, `initial_state_anchor()` reads last key = D
7. Source cursor seeks past D, permanently skipping A and C
8. Init eventually completes, but the proof DB has missing entries
9. At query time → trie root / hash mismatch

## Fix
Replace `HashMap` grouping with sequential grouping that preserves the source cursor's sorted order. Consecutive entries with the same address are naturally grouped, and flushed in order. This guarantees on resume after partial commit, the last committed address is always the highest → no entries are skipped

# Tests

Added two regression tests using a `RecordingStore` spy that implements `OpProofsInitialStateStore` and captures the order of addresses passed to `store_hashed_storages` / `store_storage_branches`. Both tests assert:

1. Exactly one call per address
2. Calls arrive in strictly ascending address order

# Additional context

NA

# Metadata

Also contains code from https://github.com/ethereum-optimism/optimism/pull/19663 which fixes #19640 