### PR TITLE
chore: bump Go to 1.24.13 and switch to DHI builder images

### DIFF
--- a/cannon/Dockerfile.diff
+++ b/cannon/Dockerfile.diff
@@ -1,4 +1,4 @@
-FROM golang:1.24.10-alpine3.21 AS builder
+FROM dhi.io/golang:1.24.13-alpine3.22-dev AS builder
 
 # Install just from GitHub releases to match the version pinned in mise.toml.
 # The Alpine package is too old and doesn't support the [script] attribute

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/ethereum-optimism/optimism
 
 go 1.24.0
 
-toolchain go1.24.10
+toolchain go1.24.13
 
 require (
 	github.com/BurntSushi/toml v1.5.0

--- a/mise.toml
+++ b/mise.toml
@@ -2,7 +2,7 @@
 
 # Core dependencies
 bun = "1.2.5"
-go = "1.24.10"
+go = "1.24.13"
 golangci-lint = "2.8.0"
 gotestsum = "1.12.3"
 mockery = "2.53.3"

--- a/ops/docker/deployment-utils/Dockerfile
+++ b/ops/docker/deployment-utils/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.10-bookworm AS go-base
+FROM dhi.io/golang:1.24.13-debian12-dev AS go-base
 
 RUN go install github.com/tomwright/dasel/v2/cmd/dasel@master
 

--- a/ops/docker/op-stack-go/Dockerfile
+++ b/ops/docker/op-stack-go/Dockerfile
@@ -49,7 +49,7 @@ EOF
 RUN forge --version
 
 # We may be cross-building for another platform. Specify which platform we need as builder.
-FROM --platform=$BUILDPLATFORM golang:1.24.10-alpine3.21 AS builder
+FROM --platform=$BUILDPLATFORM dhi.io/golang:1.24.13-alpine3.22-dev AS builder
 
 RUN apk add --no-cache curl tar gzip make gcc musl-dev linux-headers git jq yq-go bash just
 
@@ -178,9 +178,11 @@ RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache
 
 # Compile contracts in a glibc-based image (solc requires glibc, crashes on Alpine musl).
 # Uses BUILDPLATFORM so it runs natively (no QEMU). Contract artifacts are platform-independent.
-FROM --platform=$BUILDPLATFORM golang:1.24.10-bookworm AS op-deployer-contracts
+FROM --platform=$BUILDPLATFORM dhi.io/golang:1.24.13-debian12-dev AS op-deployer-contracts
 ARG BUILDARCH
-RUN apt-get update && apt-get install -y --no-install-recommends curl jq git && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends curl jq git gzip coreutils \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /usr/local/bin
 COPY ./go.mod /app/go.mod
 COPY ./go.sum /app/go.sum
 WORKDIR /app


### PR DESCRIPTION
## Summary

- Bump Go toolchain from 1.24.10 to 1.24.13 to pick up security fixes for CVE-2025-68121 (critical, crypto/tls) and CVE-2025-61729 (high, crypto/x509).
- Switch Docker builder images from stock `golang` to Docker Hardened Images (`dhi.io/golang`), pinned to `1.24.13` to ensure the image ships the correct Go version (the floating `1.24` tag was behind at Go 1.24.5).
- The `go.mod` `go` directive stays at `1.24.0` to preserve existing GODEBUG defaults.
- Prestate builds (op-program) are unaffected as they pin their own Go version for reproducibility.
- Create `/usr/local/bin` in the `op-deployer-contracts` Docker stage since DHI images don't include it (needed for forge extraction).

Staying on Go 1.24 avoids Cannon compatibility issues with Go 1.25 (see #18334).

### Grype scan: CI-built images (develop vs this PR)

| Image | develop | this PR | delta | Critical | High | Medium |
|-------|:-------:|:-------:|:-----:|:--------:|:----:|:------:|
| op-node | 24 | 16 | **-8** | 1 → 0 | 6 → 2 | 16 → 13 |
| op-batcher | 18 | 10 | **-8** | 1 → 0 | 5 → 1 | 11 → 8 |
| op-proposer | 18 | 10 | **-8** | 1 → 0 | 5 → 1 | 11 → 8 |
| op-conductor | 24 | 16 | **-8** | 1 → 0 | 6 → 2 | 16 → 13 |
| op-challenger | 74 | 50 | **-24** | 3 → 0 | 15 → 3 | 26 → 17 |
| op-dispute-mon | 18 | 10 | **-8** | 1 → 0 | 5 → 1 | 11 → 8 |
| op-deployer | 17 | 9 | **-8** | 1 → 0 | 5 → 1 | 10 → 7 |

All critical findings eliminated. op-challenger sees the largest drop (-24) because its Ubuntu base image also benefits from the DHI switch.

**Go stdlib CVEs eliminated across all images:**
| CVE | Severity | Package |
|-----|----------|---------|
| CVE-2025-68121 | Critical | crypto/tls |
| CVE-2025-61729 | High | crypto/x509 |
| CVE-2025-61726 | High | go/stdlib |
| CVE-2025-61731 | High | go/stdlib |
| CVE-2025-61732 | High | go/stdlib |
| CVE-2025-61728 | Medium | go/stdlib |
| CVE-2025-61727 | Medium | crypto/x509 |
| CVE-2025-61730 | Medium | go/stdlib |

Remaining findings are Go dependency CVEs (quic-go, x/crypto, pion/dtls), OS packages (busybox, zlib), and 3 stdlib CVEs with fixes only in Go 1.25+/1.26+.

## Test plan

- [x] CI passes (go build, go test)
- [x] Docker image builds succeed (including op-deployer)
- [x] Prestate builds are unaffected (cannon-prestate, op-program-compat, sanitize-op-program all pass)