### PR TITLE
revert: switch back from DHI to stock golang Docker images

### DIFF
--- a/cannon/Dockerfile.diff
+++ b/cannon/Dockerfile.diff
@@ -1,4 +1,4 @@
-FROM dhi.io/golang:1.24.13-alpine3.22-dev AS builder
+FROM golang:1.24.13-alpine3.22 AS builder
 
 # Install just from GitHub releases to match the version pinned in mise.toml.
 # The Alpine package is too old and doesn't support the [script] attribute

--- a/ops/docker/deployment-utils/Dockerfile
+++ b/ops/docker/deployment-utils/Dockerfile
@@ -1,4 +1,4 @@
-FROM dhi.io/golang:1.24.13-debian12-dev AS go-base
+FROM golang:1.24.13-bookworm AS go-base
 
 RUN go install github.com/tomwright/dasel/v2/cmd/dasel@master
 

--- a/ops/docker/op-stack-go/Dockerfile
+++ b/ops/docker/op-stack-go/Dockerfile
@@ -49,7 +49,7 @@ EOF
 RUN forge --version
 
 # We may be cross-building for another platform. Specify which platform we need as builder.
-FROM --platform=$BUILDPLATFORM dhi.io/golang:1.24.13-alpine3.22-dev AS builder
+FROM --platform=$BUILDPLATFORM golang:1.24.13-alpine3.22 AS builder
 
 RUN apk add --no-cache curl tar gzip make gcc musl-dev linux-headers git jq yq-go bash just
 
@@ -178,11 +178,9 @@ RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache
 
 # Compile contracts in a glibc-based image (solc requires glibc, crashes on Alpine musl).
 # Uses BUILDPLATFORM so it runs natively (no QEMU). Contract artifacts are platform-independent.
-FROM --platform=$BUILDPLATFORM dhi.io/golang:1.24.13-debian12-dev AS op-deployer-contracts
+FROM --platform=$BUILDPLATFORM golang:1.24.13-bookworm AS op-deployer-contracts
 ARG BUILDARCH
-RUN apt-get update && apt-get install -y --no-install-recommends curl jq git gzip coreutils \
-    && rm -rf /var/lib/apt/lists/* \
-    && mkdir -p /usr/local/bin
+RUN apt-get update && apt-get install -y --no-install-recommends curl jq git && rm -rf /var/lib/apt/lists/*
 COPY ./go.mod /app/go.mod
 COPY ./go.sum /app/go.sum
 WORKDIR /app


### PR DESCRIPTION
## Summary

The DHI builder images (`dhi.io/golang`) introduced in #19666 are causing failures in CircleCI. This reverts only the image switch while keeping the Go 1.24.13 toolchain bump.

Changes:
- `dhi.io/golang:1.24.13-alpine3.22-dev` -> `golang:1.24.13-alpine3.21`
- `dhi.io/golang:1.24.13-debian12-dev` -> `golang:1.24.13-bookworm`
- Remove extra `gzip coreutils` packages and `mkdir -p /usr/local/bin` that were only needed for DHI images

## Test plan

- CI passes (Docker builds succeed in CircleCI)