### PR TITLE
feat(op-supernode): derive interop activation from rollup config

### DIFF
--- a/op-supernode/cmd/main.go
+++ b/op-supernode/cmd/main.go
@@ -21,7 +21,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supernode/config"
 	"github.com/ethereum-optimism/optimism/op-supernode/flags"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode"
-	"github.com/ethereum-optimism/optimism/op-supernode/supernode/activity/interop"
 	"github.com/ethereum/go-ethereum/log"
 )
 
@@ -77,15 +76,6 @@ func main() {
 		vnCfgs, err := createVirtualNodeConfigs(cliCtx, cfg, l)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create virtual node configs: %w", err)
-		}
-
-		// Populate config with interop activation timestamp from CLI context if set
-		// Only set the pointer if the flag is explicitly provided by the user
-		// If not set, leave as nil to disable interop
-		if cliCtx != nil && cliCtx.IsSet(interop.InteropActivationTimestampFlag.Name) {
-			ts := cliCtx.Uint64(interop.InteropActivationTimestampFlag.Name)
-			cfg.InteropActivationTimestamp = &ts
-			l.Info("interop activation timestamp set from CLI", "timestamp", ts)
 		}
 
 		// Create the supernode, supplying the logger, version, and close function

--- a/op-supernode/config/config.go
+++ b/op-supernode/config/config.go
@@ -22,8 +22,7 @@ type CLIConfig struct {
 	LogConfig                  oplog.CLIConfig
 	MetricsConfig              opmetrics.CLIConfig
 	PprofConfig                oppprof.CLIConfig
-	RawCtx                     *cli.Context
-	InteropActivationTimestamp *uint64
+	RawCtx *cli.Context
 }
 
 func (c *CLIConfig) Check() error {

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -10,12 +10,10 @@ import (
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-supernode/flags"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/activity"
 	cc "github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/urfave/cli/v2"
 )
 
 // Compile-time interface conformance assertions.
@@ -26,16 +24,6 @@ var (
 	errorBackoffPeriod                               = 2 * time.Second // backoff on errors
 )
 
-// InteropActivationTimestampFlag is the CLI flag for the interop activation timestamp.
-var InteropActivationTimestampFlag = &cli.Uint64Flag{
-	Name:  "interop.activation-timestamp",
-	Usage: "The timestamp at which interop should start",
-	Value: 0,
-}
-
-func init() {
-	flags.RegisterActivityFlags(InteropActivationTimestampFlag)
-}
 
 // chainsReadyResult holds the parallel query results from checkChainsReady.
 type chainsReadyResult struct {

--- a/op-supernode/supernode/supernode.go
+++ b/op-supernode/supernode/supernode.go
@@ -95,11 +95,23 @@ func New(ctx context.Context, log gethlog.Logger, version string, requestStop co
 		superroot.New(log.New("activity", "superroot"), s.chains),
 	}
 
-	log.Info("initializing interop activity? %v", cfg.InteropActivationTimestamp != nil)
-	// Initialize interop activity if the activation timestamp is set (non-nil)
+	// Derive interop activation timestamp from rollup configs.
+	// All chains in an interop set should have the same interop activation time.
+	var interopActivationTS *uint64
+	for chainID, vnCfg := range vnCfgs {
+		if vnCfg != nil && vnCfg.Rollup.InteropTime != nil {
+			ts := *vnCfg.Rollup.InteropTime
+			interopActivationTS = &ts
+			log.Info("Derived interop activation timestamp from rollup config", "chain", chainID, "timestamp", ts)
+			break
+		}
+	}
+
+	log.Info("initializing interop activity?", "enabled", interopActivationTS != nil)
+	// Initialize interop activity if the activation timestamp is known (non-nil).
 	// If it's nil, don't start interop. If it's non-nil (including 0), do start it.
-	if cfg.InteropActivationTimestamp != nil {
-		interopActivity := interop.New(log.New("activity", "interop"), *cfg.InteropActivationTimestamp, s.chains, cfg.DataDir, s.l1Client)
+	if interopActivationTS != nil {
+		interopActivity := interop.New(log.New("activity", "interop"), *interopActivationTS, s.chains, cfg.DataDir, s.l1Client)
 		s.activities = append(s.activities, interopActivity)
 		for _, chain := range s.chains {
 			chain.RegisterVerifier(interopActivity)


### PR DESCRIPTION
## Summary
- Remove the `--interop.activation-timestamp` CLI flag from the supernode
- Instead, derive the interop activation timestamp from the rollup configs of the configured virtual nodes
- The rollup config already contains `interop_time` which is the source of truth

This eliminates a manual configuration step when deploying interop supernodes. Currently, operators must manually set `--interop.activation-timestamp` on the supernode even though the same information is already in the rollup config that the supernode loads. Without this flag, interop cross-chain verification silently doesn't start.

## Test plan
- [ ] Verify supernode starts interop activity without `--interop.activation-timestamp` flag when rollup config has `interop_time` set
- [ ] Verify supernode still works when `interop_time` is not set in rollup config (interop disabled)
- [ ] Run existing supernode tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)