### PR TITLE
fix(devstack): prevent indefinite hang in interop proofs tests

### DIFF
--- a/op-acceptance-tests/tests/interop/proofs/proposer/proposer_test.go
+++ b/op-acceptance-tests/tests/interop/proofs/proposer/proposer_test.go
@@ -1,4 +1,4 @@
-package proofs
+package proposer
 
 import (
 	"testing"

--- a/op-devstack/dsl/contract/call.go
+++ b/op-devstack/dsl/contract/call.go
@@ -16,9 +16,9 @@ import (
 )
 
 const (
-	// readTimeout bounds individual contract read calls to prevent tests from
+	// ReadTimeout bounds individual contract read calls to prevent tests from
 	// hanging when an in-memory geth node stalls under CI resource contention.
-	readTimeout = 60 * time.Second
+	ReadTimeout = 60 * time.Second
 	// writeTimeout bounds contract write calls (transaction submission + mining).
 	writeTimeout = 5 * time.Minute
 )
@@ -37,10 +37,10 @@ func checkTestable[O any](call bindings.TypedCall[O]) {
 }
 
 // Read executes a new message call without creating a transaction on the blockchain.
-// Each call is bounded by readTimeout to prevent hangs under CI resource contention.
+// Each call is bounded by ReadTimeout to prevent hangs under CI resource contention.
 func Read[O any](call bindings.TypedCall[O], opts ...txplan.Option) O {
 	checkTestable(call)
-	ctx, cancel := context.WithTimeout(call.Test().Ctx(), readTimeout)
+	ctx, cancel := context.WithTimeout(call.Test().Ctx(), ReadTimeout)
 	defer cancel()
 	o, err := contractio.Read(call, ctx, opts...)
 	call.Test().Require().NoError(err)
@@ -48,11 +48,11 @@ func Read[O any](call bindings.TypedCall[O], opts ...txplan.Option) O {
 }
 
 // ReadArray retrieves all data from an array in batches.
-// Each call is bounded by readTimeout to prevent hangs under CI resource contention.
+// Each call is bounded by ReadTimeout to prevent hangs under CI resource contention.
 func ReadArray[T any](countCall bindings.TypedCall[*big.Int], elemCall func(i *big.Int) bindings.TypedCall[T]) []T {
 	checkTestable(countCall)
 	test := countCall.Test()
-	ctx, cancel := context.WithTimeout(countCall.Test().Ctx(), readTimeout)
+	ctx, cancel := context.WithTimeout(countCall.Test().Ctx(), ReadTimeout)
 	defer cancel()
 
 	caller := countCall.Client().NewMultiCaller(batching.DefaultBatchSize)

--- a/op-devstack/dsl/proofs/dispute_game_factory.go
+++ b/op-devstack/dsl/proofs/dispute_game_factory.go
@@ -35,6 +35,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/apis"
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/txintent/bindings"
+	"github.com/ethereum-optimism/optimism/op-service/txintent/contractio"
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
 )
 
@@ -180,13 +181,34 @@ func (f *DisputeGameFactory) GameArgs(gameType gameTypes.GameType) []byte {
 func (f *DisputeGameFactory) WaitForGame() *FaultDisputeGame {
 	initialCount := f.GameCount()
 	f.t.Require().Eventually(func() bool {
-		gameCount := f.GameCount()
+		// Use gameCountOrError to avoid calling FailNow inside Eventually's goroutine.
+		// testify's Eventually runs the condition in a separate goroutine; if FailNow
+		// (runtime.Goexit) fires there, the goroutine silently dies and Eventually
+		// blocks forever because it never receives from the result channel.
+		gameCount, err := f.gameCountOrError()
+		if err != nil {
+			f.t.Logf("transient error reading game count (will retry): %v", err)
+			return false
+		}
 		check := gameCount > initialCount
 		f.t.Logf("waiting for new game. current=%d new=%d", initialCount, gameCount)
 		return check
 	}, time.Minute*10, time.Second*5)
 
 	return f.GameAtIndex(initialCount)
+}
+
+// gameCountOrError returns the game count or an error, without calling FailNow.
+// This is safe to use inside Eventually conditions where FailNow would kill
+// the goroutine and cause the test to hang indefinitely.
+func (f *DisputeGameFactory) gameCountOrError() (int64, error) {
+	ctx, cancel := context.WithTimeout(f.t.Ctx(), contract.ReadTimeout)
+	defer cancel()
+	result, err := contractio.Read(f.dgf.GameCount(), ctx)
+	if err != nil {
+		return 0, err
+	}
+	return result.Int64(), nil
 }
 
 func (f *DisputeGameFactory) StartSuperCannonKonaGame(eoa *dsl.EOA, opts ...GameOpt) *SuperFaultDisputeGame {
@@ -238,7 +260,10 @@ func (f *DisputeGameFactory) createSuperGameExtraData(timestamp uint64, cfg *Gam
 func (f *DisputeGameFactory) awaitMinVerifiedTimestamp(timestamp uint64) {
 	f.t.Require().Eventually(func() bool {
 		resp, err := f.superNode.QueryAPI().SuperRootAtTimestamp(f.t.Ctx(), timestamp)
-		f.require.NoError(err, "Failed to fetch supernode status (superroot_atTimestamp)")
+		if err != nil {
+			f.t.Logf("transient error fetching supernode status (will retry): %v", err)
+			return false
+		}
 		return resp.Data != nil
 	}, 2*time.Minute, 1*time.Second)
 }


### PR DESCRIPTION
## Summary

Fixes `TestProposer` and `TestChallengerPlaysGame` hanging indefinitely in the `memory-all-opn-op-geth` CI job (5 flakes each in CircleCI Insights).

### Root Cause

Two separate issues contribute to these test failures:

**1. System setup stalls under resource contention (primary cause of 2h timeout)**

Both tests use `devtest.ParallelT` and each creates a full interop system (L1 + 2xL2 + supernode + proposer + challenger + batcher). Running two such systems simultaneously under CI resource contention causes system setup to stall indefinitely. TestProposer's system never completes setup — no test-specific log output is ever produced. When the 2h subtest timeout fires, both tests in the package are killed.

**Fix:** Move `TestProposer` to its own sub-package (`proofs/proposer/`) so the two heavy systems don't share a package-level timeout. This follows the existing pattern (`proofs/fpp/`, `proofs/serial/`, `proofs/withdrawal/`).

**2. `FailNow` inside `testify.Eventually` goroutines (secondary bug)**

`WaitForGame()` and `awaitMinVerifiedTimestamp()` call `contract.Read` (which calls `FailNow` on error) inside `testify/require.Eventually` condition functions. Testify runs conditions in separate goroutines. When `FailNow` fires (via `runtime.Goexit()`), the goroutine dies silently. `Eventually`'s 10-minute timer still fires, so this produces a ~10-minute hang (not the 2h timeout), but it's still a real bug that should be fixed.

`runtime.Goexit()` is not catchable by `recover()` — the `testreq.wrapCondition` panic guard provides no protection against this.

**Fix:** Replace fatal assertions inside `Eventually` conditions with error-returning variants that log transient errors and return `false` to let `Eventually` retry normally.

### Note

The same `FailNow`-inside-`Eventually` pattern also exists in `bridge.go` (~lines 387, 530). Those are separate tests and out of scope for this PR.

Fixes ethereum-optimism/optimism#19672
Fixes ethereum-optimism/optimism#19673
Related: ethereum-optimism/optimism#19563

## Test plan

- [ ] CI passes — `memory-all-opn-op-geth` job completes without hanging
- [ ] `TestProposer` and `TestChallengerPlaysGame` both pass independently in their isolated packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)