### PR TITLE
fix(op-node): update pending_safe in follow-source (light CL) mode

### DIFF
--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -492,7 +492,7 @@ func (s *Driver) followUpstream() {
 		s.log.Warn("Follow Upstream: Failed to fetch status", "err", err)
 		return
 	}
-	s.log.Info("Follow Upstream", "eSafe", status.SafeL2, "eLocalSafe", status.LocalSafeL2, "eFinalized", status.FinalizedL2, "eCurrentL1", status.CurrentL1)
+	s.log.Info("Follow Upstream", "eSafe", status.SafeL2, "eLocalSafe", status.LocalSafeL2, "ePendingSafe", status.PendingSafeL2, "eFinalized", status.FinalizedL2, "eCurrentL1", status.CurrentL1)
 	if status.SafeL2.Number > status.LocalSafeL2.Number {
 		s.log.Warn("Follow Upstream: Invalid external state, safe is ahead of local safe",
 			"safe", status.SafeL2.Number, "localSafe", status.LocalSafeL2.Number)
@@ -566,5 +566,5 @@ func (s *Driver) followUpstream() {
 		s.emitter.Emit(s.driverCtx, derive.DeriverL1StatusEvent{Origin: status.CurrentL1})
 	}
 	// Only reach this point if all L1 checks passed
-	s.SyncDeriver.Engine.FollowSource(status.SafeL2, status.LocalSafeL2, status.FinalizedL2)
+	s.SyncDeriver.Engine.FollowSource(status.SafeL2, status.LocalSafeL2, status.PendingSafeL2, status.FinalizedL2)
 }

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -1208,7 +1208,7 @@ func (e *EngineController) startPayload(ctx context.Context, fc eth.ForkchoiceSt
 	}
 }
 
-func (e *EngineController) FollowSource(eSafeBlockRef, eLocalSafeRef, eFinalizedRef eth.L2BlockRef) {
+func (e *EngineController) FollowSource(eSafeBlockRef, eLocalSafeRef, ePendingSafeRef, eFinalizedRef eth.L2BlockRef) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
@@ -1219,6 +1219,9 @@ func (e *EngineController) FollowSource(eSafeBlockRef, eLocalSafeRef, eFinalized
 			e.tryUpdateUnsafe(e.ctx, eLocalSafeRef)
 		}
 		e.tryUpdateLocalSafe(e.ctx, eLocalSafeRef, true, eth.L1BlockRef{})
+		// In follow-source mode, pending_safe should track the upstream's
+		// pending_safe since there is no local derivation pipeline.
+		e.tryUpdatePendingSafe(e.ctx, ePendingSafeRef, true, eth.L1BlockRef{})
 		// Inject external cross-safe. Must happen before promoteFinalized
 		// (which rejects finalized > SafeL2Head).
 		if eSafeBlockRef.Number > e.deprecatedSafeHead.Number {

--- a/op-node/rollup/engine/engine_controller_test.go
+++ b/op-node/rollup/engine/engine_controller_test.go
@@ -480,17 +480,98 @@ func TestFollowSource_DivergentLocalSafeAndCrossSafe(t *testing.T) {
 		&eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionValid}}, nil,
 	)
 
-	// Call FollowSource with divergent cross-safe (block4) and local-safe (block5)
-	ec.FollowSource(block4, block5, block3)
+	// Call FollowSource with divergent cross-safe (block4), local-safe (block5), pending-safe (block5), finalized (block3)
+	ec.FollowSource(block4, block5, block5, block3)
 
 	// Assert the final head state
 	require.Equal(t, block5, ec.localSafeHead, "localSafeHead should be updated to block5")
+	require.Equal(t, block5, ec.pendingSafeHead, "pendingSafeHead should track upstream pending_safe")
 	require.Equal(t, block4, ec.deprecatedSafeHead, "deprecatedSafeHead (cross-safe) should be updated to block4")
 	require.Equal(t, block3, ec.deprecatedFinalizedHead, "deprecatedFinalizedHead (cross-finalized) should be updated to block3")
 
 	// Assert the invariant: cross-safe <= local-safe
 	require.LessOrEqual(t, ec.deprecatedSafeHead.Number, ec.localSafeHead.Number,
 		"invariant: cross-safe (deprecatedSafeHead) must not exceed local-safe")
+}
+
+// TestFollowSource_PendingSafeTracksUpstream verifies that pending_safe advances
+// from genesis when FollowSource is called with a non-zero ePendingSafeRef.
+// This is a regression test for the bug where pending_safe stayed at genesis
+// in follow-source (light CL) mode.
+func TestFollowSource_PendingSafeTracksUpstream(t *testing.T) {
+	rng := mrand.New(mrand.NewSource(1234))
+
+	l1Origin := testutils.RandomBlockRef(rng)
+
+	genesis := eth.L2BlockRef{
+		Hash: testutils.RandomHash(rng), Number: 0,
+		ParentHash: common.Hash{}, Time: l1Origin.Time,
+		L1Origin: l1Origin.ID(), SequenceNumber: 0,
+	}
+	block100 := eth.L2BlockRef{
+		Hash: testutils.RandomHash(rng), Number: 100,
+		ParentHash: testutils.RandomHash(rng), Time: l1Origin.Time + 200,
+		L1Origin: l1Origin.ID(), SequenceNumber: 100,
+	}
+	block99 := eth.L2BlockRef{
+		Hash: testutils.RandomHash(rng), Number: 99,
+		ParentHash: testutils.RandomHash(rng), Time: l1Origin.Time + 198,
+		L1Origin: l1Origin.ID(), SequenceNumber: 99,
+	}
+	block90 := eth.L2BlockRef{
+		Hash: testutils.RandomHash(rng), Number: 90,
+		ParentHash: testutils.RandomHash(rng), Time: l1Origin.Time + 180,
+		L1Origin: l1Origin.ID(), SequenceNumber: 90,
+	}
+
+	interopTime := uint64(0)
+	cfg := &rollup.Config{InteropTime: &interopTime}
+	mockEngine := &testutils.MockEngine{}
+	emitter := &testutils.MockEmitter{}
+
+	ec := NewEngineController(context.Background(), mockEngine, testlog.Logger(t, 0),
+		metrics.NoopMetrics, cfg, &sync.Config{L2FollowSourceEndpoint: "http://localhost"}, false, &testutils.MockL1Source{}, emitter, nil)
+
+	// Initial state: simulates a fresh light node with pending_safe at genesis
+	ec.unsafeHead = block100
+	ec.pendingSafeHead = genesis
+	ec.SetLocalSafeHead(genesis)
+	ec.SetSafeHead(genesis)
+	ec.SetFinalizedHead(genesis)
+	ec.needFCUCall = false
+
+	emitter.Mock.On("Emit", mock.Anything).Maybe()
+
+	// Consolidation lookup for eLocalSafeRef
+	mockEngine.ExpectL2BlockRefByNumber(block99.Number, block99, nil)
+
+	// FCU from PromoteSafe (cross-safe = block90)
+	mockEngine.ExpectForkchoiceUpdate(
+		&eth.ForkchoiceState{
+			HeadBlockHash:      block100.Hash,
+			SafeBlockHash:      block90.Hash,
+			FinalizedBlockHash: genesis.Hash,
+		}, nil,
+		&eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionValid}}, nil,
+	)
+
+	// FCU from promoteFinalized (finalized stays at genesis since eFinalizedRef=genesis)
+	mockEngine.ExpectForkchoiceUpdate(
+		&eth.ForkchoiceState{
+			HeadBlockHash:      block100.Hash,
+			SafeBlockHash:      block90.Hash,
+			FinalizedBlockHash: genesis.Hash,
+		}, nil,
+		&eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionValid}}, nil,
+	)
+
+	// Call FollowSource: cross-safe=block90, local-safe=block99, pending-safe=block99, finalized=genesis
+	ec.FollowSource(block90, block99, block99, genesis)
+
+	// The key assertion: pending_safe should advance from genesis to block99
+	require.Equal(t, block99, ec.pendingSafeHead, "pendingSafeHead should advance from genesis to upstream pending_safe")
+	require.Equal(t, block99, ec.localSafeHead, "localSafeHead should be updated")
+	require.Equal(t, block90, ec.deprecatedSafeHead, "cross-safe should be updated")
 }
 
 // TestEngineController_FinalizedHead tests FinalizedHead behavior with various configurations

--- a/op-service/sources/follow_client.go
+++ b/op-service/sources/follow_client.go
@@ -13,10 +13,11 @@ type FollowClient struct {
 }
 
 type FollowStatus struct {
-	SafeL2      eth.L2BlockRef
-	LocalSafeL2 eth.L2BlockRef
-	FinalizedL2 eth.L2BlockRef
-	CurrentL1   eth.L1BlockRef
+	SafeL2        eth.L2BlockRef
+	LocalSafeL2   eth.L2BlockRef
+	PendingSafeL2 eth.L2BlockRef
+	FinalizedL2   eth.L2BlockRef
+	CurrentL1     eth.L1BlockRef
 }
 
 func NewFollowClient(client client.RPC) (*FollowClient, error) {
@@ -30,9 +31,10 @@ func (s *FollowClient) GetFollowStatus(ctx context.Context) (*FollowStatus, erro
 		return nil, fmt.Errorf("failed to fetch external syncStatus: %w", err)
 	}
 	return &FollowStatus{
-		FinalizedL2: status.FinalizedL2,
-		SafeL2:      status.SafeL2,
-		LocalSafeL2: status.LocalSafeL2,
-		CurrentL1:   status.CurrentL1,
+		FinalizedL2:   status.FinalizedL2,
+		SafeL2:        status.SafeL2,
+		LocalSafeL2:   status.LocalSafeL2,
+		PendingSafeL2: status.PendingSafeL2,
+		CurrentL1:     status.CurrentL1,
 	}, nil
 }

--- a/op-service/sources/follow_client_test.go
+++ b/op-service/sources/follow_client_test.go
@@ -34,6 +34,10 @@ func TestFollowClient_GetFollowStatus(t *testing.T) {
 				Hash:   common.Hash{0x03},
 				Number: 45, // LocalSafe can be different from (cross) Safe
 			},
+			PendingSafeL2: eth.L2BlockRef{
+				Hash:   common.Hash{0x05},
+				Number: 42,
+			},
 			FinalizedL2: eth.L2BlockRef{
 				Hash:   common.Hash{0x04},
 				Number: 40,
@@ -54,6 +58,7 @@ func TestFollowClient_GetFollowStatus(t *testing.T) {
 		require.Equal(t, mockSyncStatus.SafeL2, status.SafeL2, "SafeL2 should be copied")
 		require.Equal(t, mockSyncStatus.FinalizedL2, status.FinalizedL2, "FinalizedL2 should be copied")
 		require.Equal(t, mockSyncStatus.LocalSafeL2, status.LocalSafeL2, "LocalSafeL2 should be copied")
+		require.Equal(t, mockSyncStatus.PendingSafeL2, status.PendingSafeL2, "PendingSafeL2 should be copied")
 	})
 
 	t.Run("Error", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- In follow-source (light CL) mode, `pending_safe` stays stuck at genesis (block 0) while `safe` advances normally
- Root cause: `SyncStep()` returns early in follow-source mode and never reaches `RequestPendingSafeUpdate()`
- The `FollowSource()` / `followExternalRefs()` method updates `localSafe`, `safe`, and `finalized` but never touches `pendingSafe`
- Fix: add `tryUpdatePendingSafe()` call in `followExternalRefs()` so `pending_safe` tracks `local_safe`

## Impact
The batcher uses `pending_safe` (with `PREFER_LOCAL_SAFE_L2=true`) to determine what to batch. If the batcher connects to a light node sequencer with `pending_safe=0`, it thinks there's nothing to batch. This was observed on interop-v2 devnet where sequencer-2 (light node) had `pending_safe=0` while `safe=7637`.

## Test plan
- [ ] Verify light node sequencer's `pending_safe` advances with `safe` after this fix
- [ ] Verify batcher correctly batches when connected to a light node sequencer
- [ ] Run existing op-node tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)