### PR TITLE
op-acceptance-tests: make some spamming tests work against op-reth

### DIFF
--- a/op-acceptance-tests/tests/batcher/throttling/throttling_test.go
+++ b/op-acceptance-tests/tests/batcher/throttling/throttling_test.go
@@ -11,12 +11,10 @@ import (
 	batcherConfig "github.com/ethereum-optimism/optimism/op-batcher/config"
 	"github.com/ethereum-optimism/optimism/op-core/predeploys"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
-	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-service/txinclude"
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
 )
 
@@ -39,9 +37,7 @@ func TestDABlockThrottling(gt *testing.T) {
 		cfg.PollInterval = 500 * time.Millisecond // Fast poll for quicker test feedback.
 	}))
 
-	spamCtx, cancelSpam := context.WithCancel(t.Ctx())
-	defer cancelSpam()
-	spamTxs(spamCtx, sys)
+	spamTxs(sys)
 
 	const minFullSize = blockSizeLimit * 95 / 100
 
@@ -77,37 +73,9 @@ func TestDABlockThrottling(gt *testing.T) {
 	}
 }
 
-func spamTxs(ctx context.Context, sys *presets.Minimal) {
+func spamTxs(sys *presets.Minimal) {
 	l2BlockTime := time.Duration(sys.L2Chain.Escape().RollupConfig().BlockTime) * time.Second
-
-	// Fund a lot of spammer EOAs. The funder provided by the devstack isn't very reliable when
-	// funding lots of different accounts. We fund one account from the faucet and then use that
-	// account to fund all the others.
-	const numAccounts = 50
-	totalETH := eth.OneEther.Mul(numAccounts)
-	spammerELClient := txinclude.NewReliableEL(sys.L2EL.Escape().EthClient(), l2BlockTime)
-	funder := newSyncEOA(sys.FunderL2.NewFundedEOA(totalETH), spammerELClient)
-	totalETH = totalETH.Sub(totalETH.Div(50)) // Reserve 2% of the balance for gas.
-	ethPerAccount := totalETH.Div(numAccounts)
-	var eoas []*loadtest.SyncEOA
-	var mu sync.Mutex
-	var wgEOA sync.WaitGroup
-	for range numAccounts {
-		wgEOA.Add(1)
-		go func() {
-			defer wgEOA.Done()
-			eoa := sys.Wallet.NewEOA(sys.L2EL)
-			addr := eoa.Address()
-			_, err := funder.Include(sys.T, txplan.WithTo(&addr), txplan.WithValue(ethPerAccount))
-			sys.T.Require().NoError(err)
-
-			mu.Lock()
-			defer mu.Unlock()
-			eoas = append(eoas, newSyncEOA(eoa, spammerELClient))
-		}()
-	}
-	wgEOA.Wait()
-
+	eoas := loadtest.FundEOAs(sys.T, eth.HundredEther, 50, l2BlockTime, sys.L2EL, sys.Wallet, sys.FaucetL2)
 	eoasRR := loadtest.NewRoundRobin(eoas)
 	spammer := loadtest.SpammerFunc(func(t devtest.T) error {
 		_, err := eoasRR.Get().Include(t, txplan.WithTo(&predeploys.L1BlockAddr), txplan.WithData(make([]byte, 0)), txplan.WithGasLimit(70_000))
@@ -115,19 +83,15 @@ func spamTxs(ctx context.Context, sys *presets.Minimal) {
 	})
 	schedule := loadtest.NewBurst(l2BlockTime, loadtest.WithBaseRPS(50))
 
+	ctx, cancel := context.WithCancel(sys.T.Ctx())
 	var wg sync.WaitGroup
 	wg.Add(1)
 	sys.T.Cleanup(func() {
+		cancel()
 		wg.Wait()
 	})
 	go func() {
 		defer wg.Done()
 		schedule.Run(sys.T.WithCtx(ctx), spammer)
 	}()
-}
-
-func newSyncEOA(eoa *dsl.EOA, el txinclude.EL) *loadtest.SyncEOA {
-	signer := txinclude.NewPkSigner(eoa.Key().Priv(), eoa.ChainID().ToBig())
-	const maxConcurrentTxs = 16 // Reth's mempool limits the number of txs per account to 16.
-	return loadtest.NewSyncEOA(txinclude.NewLimit(txinclude.NewPersistent(signer, el), maxConcurrentTxs), eoa.Plan())
 }

--- a/op-acceptance-tests/tests/interop/loadtest/l2.go
+++ b/op-acceptance-tests/tests/interop/loadtest/l2.go
@@ -1,11 +1,13 @@
 package loadtest
 
 import (
+	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/txinclude"
 	"github.com/ethereum-optimism/optimism/op-service/txintent/bindings"
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
@@ -75,4 +77,43 @@ func (l2 *L2) Include(t devtest.T, opts ...txplan.Option) (*txinclude.IncludedTx
 	}
 	t.Require().Equal(ethtypes.ReceiptStatusSuccessful, includedTx.Receipt.Status)
 	return includedTx, nil
+}
+
+func FundEOAs(t devtest.T, budget eth.ETH, numAccounts uint64, blockTime time.Duration, el *dsl.L2ELNode, wallet *dsl.HDWallet, faucet *dsl.Faucet) []*SyncEOA {
+	t.Require().Equal(faucet.Escape().ChainID(), el.ChainID())
+
+	// Fund a lot of spammer EOAs. The funder provided by the devstack isn't very reliable when
+	// funding lots of different accounts. We fund one account from the faucet and then use that
+	// account to fund all the others.
+	spammerELClient := txinclude.NewReliableEL(el.Escape().EthClient(), blockTime)
+	funderEOA := newSyncEOA(dsl.NewFunder(wallet, faucet, el).NewFundedEOA(budget), spammerELClient)
+	budget = budget.Sub(budget.Div(50)) // Reserve 2% of the balance for gas.
+	ethPerAccount := budget.Div(numAccounts)
+	var eoas []*SyncEOA
+	var mu sync.Mutex
+	var wgEOA sync.WaitGroup
+	for range numAccounts {
+		wgEOA.Add(1)
+		go func() {
+			defer wgEOA.Done()
+
+			eoa := wallet.NewEOA(el)
+			addr := eoa.Address()
+			_, err := funderEOA.Include(t, txplan.WithTo(&addr), txplan.WithValue(ethPerAccount))
+			t.Require().NoError(err)
+
+			mu.Lock()
+			defer mu.Unlock()
+			eoas = append(eoas, newSyncEOA(eoa, spammerELClient))
+		}()
+	}
+	wgEOA.Wait()
+
+	return eoas
+}
+
+func newSyncEOA(eoa *dsl.EOA, el txinclude.EL) *SyncEOA {
+	signer := txinclude.NewPkSigner(eoa.Key().Priv(), eoa.ChainID().ToBig())
+	const maxConcurrentTxs = 16 // Reth's mempool limits the number of txs per account to 16.
+	return NewSyncEOA(txinclude.NewLimit(txinclude.NewPersistent(signer, el), maxConcurrentTxs), eoa.Plan())
 }

--- a/op-acceptance-tests/tests/jovian/bpo2/joviantest/cases.go
+++ b/op-acceptance-tests/tests/jovian/bpo2/joviantest/cases.go
@@ -1,15 +1,12 @@
 package joviantest
 
 import (
-	"context"
-	"crypto/rand"
 	"encoding/binary"
 	"math/big"
-	"sync"
 	"testing"
 	"time"
 
-	"github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/interop/loadtest"
+	"github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/jovian"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
 	opforks "github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
@@ -18,10 +15,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-service/txinclude"
 	"github.com/ethereum-optimism/optimism/op-service/txintent/bindings"
 	"github.com/ethereum-optimism/optimism/op-service/txintent/contractio"
-	"github.com/ethereum-optimism/optimism/op-service/txplan"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus/misc/eip1559"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -29,24 +24,6 @@ import (
 )
 
 type SetupFn func(t devtest.T) *presets.Minimal
-
-type calldataSpammer struct {
-	eoa *loadtest.SyncEOA
-}
-
-func newCalldataSpammer(eoa *loadtest.SyncEOA) *calldataSpammer {
-	return &calldataSpammer{
-		eoa: eoa,
-	}
-}
-
-func (s *calldataSpammer) Spam(t devtest.T) error {
-	data := make([]byte, 50_000)
-	_, err := rand.Read(data)
-	t.Require().NoError(err)
-	_, err = s.eoa.Include(t, txplan.WithTo(&common.Address{}), txplan.WithData(data))
-	return err
-}
 
 type daFootprintSystemConfig struct {
 	SetDAFootprintGasScalar func(scalar uint16) bindings.TypedCall[any] `sol:"setDAFootprintGasScalar"`
@@ -264,26 +241,7 @@ func RunDAFootprint(gt *testing.T, setup SetupFn) {
 			}
 			env.expectL1BlockDAFootprintGasScalar(t, tc.expected)
 
-			var wg sync.WaitGroup
-			defer wg.Wait()
-
-			ctx, cancel := context.WithTimeout(t.Ctx(), time.Minute)
-			defer cancel()
-			t = t.WithCtx(ctx)
-
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				eoa := sys.FunderL2.NewFundedEOA(eth.OneTenthEther)
-				includer := txinclude.NewPersistent(txinclude.NewPkSigner(eoa.Key().Priv(), eoa.ChainID().ToBig()), struct {
-					*txinclude.Resubmitter
-					*txinclude.Monitor
-				}{
-					txinclude.NewResubmitter(ethClient, l2BlockTime),
-					txinclude.NewMonitor(ethClient, l2BlockTime),
-				})
-				loadtest.NewBurst(l2BlockTime).Run(t, newCalldataSpammer(loadtest.NewSyncEOA(includer, eoa.Plan())))
-			}()
+			jovian.SpamCalldata(t, l2BlockTime, sys.L2EL, sys.Wallet, sys.FaucetL2)
 
 			rollupCfg := sys.L2Chain.Escape().RollupConfig()
 			gasTarget := rollupCfg.Genesis.SystemConfig.GasLimit / rollupCfg.ChainOpConfig.EIP1559Elasticity

--- a/op-acceptance-tests/tests/jovian/da_footprint.go
+++ b/op-acceptance-tests/tests/jovian/da_footprint.go
@@ -16,7 +16,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-service/txinclude"
 	"github.com/ethereum-optimism/optimism/op-service/txintent/bindings"
 	"github.com/ethereum-optimism/optimism/op-service/txintent/contractio"
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
@@ -26,22 +25,27 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
-type CalldataSpammer struct {
-	eoa *loadtest.SyncEOA
-}
+func SpamCalldata(t devtest.T, l2BlockTime time.Duration, el *dsl.L2ELNode, wallet *dsl.HDWallet, faucet *dsl.Faucet) {
+	eoas := loadtest.FundEOAs(t, eth.HundredEther, 25, l2BlockTime, el, wallet, faucet)
+	rr := loadtest.NewRoundRobin(eoas)
 
-func NewCalldataSpammer(eoa *loadtest.SyncEOA) *CalldataSpammer {
-	return &CalldataSpammer{
-		eoa: eoa,
-	}
-}
-
-func (s *CalldataSpammer) Spam(t devtest.T) error {
-	data := make([]byte, 50_000)
-	_, err := rand.Read(data)
-	t.Require().NoError(err)
-	_, err = s.eoa.Include(t, txplan.WithTo(&common.Address{}), txplan.WithData(data))
-	return err
+	ctx, cancel := context.WithCancel(t.Ctx())
+	var wg sync.WaitGroup
+	t.Cleanup(func() {
+		cancel()
+		wg.Wait()
+	})
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		loadtest.NewBurst(l2BlockTime).Run(t.WithCtx(ctx), loadtest.SpammerFunc(func(t devtest.T) error {
+			data := make([]byte, 50_000)
+			_, err := rand.Read(data)
+			t.Require().NoError(err)
+			_, err = rr.Get().Include(t, txplan.WithTo(&common.Address{}), txplan.WithData(data))
+			return err
+		}))
+	}()
 }
 
 type daFootprintSystemConfig struct {
@@ -164,26 +168,7 @@ func TestDAFootprint(gt *testing.T) {
 			}
 			env.expectL1BlockDAFootprintGasScalar(t, tc.expected)
 
-			var wg sync.WaitGroup
-			defer wg.Wait()
-
-			ctx, cancel := context.WithTimeout(t.Ctx(), time.Minute)
-			defer cancel()
-			t = t.WithCtx(ctx)
-
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				eoa := sys.FunderL2.NewFundedEOA(eth.OneTenthEther)
-				includer := txinclude.NewPersistent(txinclude.NewPkSigner(eoa.Key().Priv(), eoa.ChainID().ToBig()), struct {
-					*txinclude.Resubmitter
-					*txinclude.Monitor
-				}{
-					txinclude.NewResubmitter(ethClient, l2BlockTime),
-					txinclude.NewMonitor(ethClient, l2BlockTime),
-				})
-				loadtest.NewBurst(l2BlockTime).Run(t, NewCalldataSpammer(loadtest.NewSyncEOA(includer, eoa.Plan())))
-			}()
+			SpamCalldata(t, l2BlockTime, sys.L2EL, sys.Wallet, sys.FaucetL2)
 
 			rollupCfg := sys.L2Chain.Escape().RollupConfig()
 			gasTarget := rollupCfg.Genesis.SystemConfig.GasLimit / rollupCfg.ChainOpConfig.EIP1559Elasticity


### PR DESCRIPTION
Reth's mempool has different policies from geth that make it harder to spam artificial traffic. Fortunately, we already dealt with this problem in an existing test (a batcher throttling test).

This commit extracts the relevant logic from the batcher throttling test into the existing `loadtest` package and reuses it in some tests that spam transactions.