### PR TITLE
fix(op-acceptance-tests): treat block removal as successful reorg detection

### DIFF
--- a/op-acceptance-tests/tests/supernode/interop/reorg/invalid_message_reorg_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/reorg/invalid_message_reorg_test.go
@@ -78,24 +78,26 @@ func TestSupernodeInteropInvalidMessageReplacement(gt *testing.T) {
 
 	// Resume interop and observe reorg
 	// Interop activity will proceed and invalidate the block, triggering a rewind, and building a replacement block
-	// We observe resets and replacements, but only proceed on replacement (we may miss reset if it happens quickly)
+	// The reorg is detected either by the block hash changing (replacement already built)
+	// or by the block disappearing (rewound, replacement not yet built).
+	// Both cases indicate the invalid block was successfully invalidated.
 	sys.Supernode.ResumeInterop()
 	require.Eventually(t, func() bool {
-		// Check if the block hash at the invalid block number changed or block doesn't exist
-		// Use the EthClient directly to handle errors (block may not exist after rewind)
 		currentBlock, err := sys.L2ELB.Escape().EthClient().BlockRefByNumber(ctx, invalidBlockNumber)
 		if err != nil {
 			if errors.Is(eth.MaybeAsNotFoundErr(err), ethereum.NotFound) {
 				t.Logger().Info("RESET DETECTED! Block no longer exists (rewound)",
 					"block_number", invalidBlockNumber,
 				)
-			} else {
-				t.Logger().Warn("unexpected error checking block",
-					"block_number", invalidBlockNumber,
-					"err", err,
-				)
+				return true
 			}
-		} else if currentBlock.Hash != invalidBlockHash {
+			t.Logger().Warn("unexpected error checking block",
+				"block_number", invalidBlockNumber,
+				"err", err,
+			)
+			return false
+		}
+		if currentBlock.Hash != invalidBlockHash {
 			t.Logger().Info("RESET DETECTED! Block hash changed",
 				"block_number", invalidBlockNumber,
 				"old_hash", invalidBlockHash,


### PR DESCRIPTION
## Summary

Fixes flaky test `TestSupernodeInteropInvalidMessageReplacement` by returning `true` from the reorg-detection polling loop when the block is `NotFound` (rewound), not just when the block hash changes.

**Root cause:** The `require.Eventually` callback logged "RESET DETECTED!" when the block disappeared but returned `false`, causing the 60s timeout to expire when the replacement block was slow to build under CI load. The subsequent `AwaitValidatedTimestamp` already waits (up to 150s) for the replacement block to be built and validated, so early detection of the rewind is safe.

**Why flaky:** Under CI resource contention, the replacement block takes longer to build after the chain rewinds. When it takes >60s, the polling loop times out despite correctly detecting the reorg on every tick.

**Flake count:** 3 (CircleCI Insights, `main` workflow, `memory-all-opn-op-geth` job)

Closes ethereum-optimism/optimism#19677

## Test plan

- [ ] Existing test `TestSupernodeInteropInvalidMessageReplacement` passes
- [ ] CI `memory-all-opn-op-geth` job no longer flakes on this test

🤖 Generated with [Claude Code](https://claude.com/claude-code)