### PR TITLE
fix(op-deployer): remove t.Parallel() from TestSuperchain to prevent CI flakes

### DIFF
--- a/op-deployer/pkg/deployer/bootstrap/superchain_test.go
+++ b/op-deployer/pkg/deployer/bootstrap/superchain_test.go
@@ -32,8 +32,6 @@ func TestSuperchain(t *testing.T) {
 }
 
 func testSuperchain(t *testing.T, forkRPCURL string) {
-	t.Parallel()
-
 	if forkRPCURL == "" {
 		t.Skip("forkRPCURL not set")
 	}


### PR DESCRIPTION
## Summary

- Remove `t.Parallel()` from `testSuperchain` to eliminate resource contention between parallel Anvil+RetryProxy instances under CI load
- Same fix pattern proven effective for `TestImplementations` in #18019

## Root Cause

`testSuperchain` called `t.Parallel()`, causing `mainnet` and `sepolia` subtests to run concurrently. Each subtest creates a RetryProxy + Anvil instance forking from an external RPC. Under CI load, the combined resource pressure (CPU, network, RPC rate limits) causes timeouts and connection failures.

The RetryProxy hardening in #19593 (longer timeouts, more retries) helped but was insufficient — `TestSuperchain` continued to flake (45 times per the tracking issue).

## Why Flaky (Not Always Failing)

CI node load varies per run. Under light load, both subtests complete within their 5-minute timeout. Under heavy load, resource contention causes one or both to fail.

## Test Plan

- [x] Verified `testImplementations` already has `t.Parallel()` removed (#18019)
- [x] Verified both functions use identical `devnet.NewForked()` pattern
- [x] Adversarial review passed with 95% confidence

Closes ethereum-optimism/optimism#19586

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>