### PR TITLE
l1 retrieval: clear provider on reset

### DIFF
--- a/rust/kona/crates/protocol/derive/src/stages/l1_retrieval.rs
+++ b/rust/kona/crates/protocol/derive/src/stages/l1_retrieval.rs
@@ -125,6 +125,7 @@ where
         match signal {
             Signal::Reset(ResetSignal { l1_origin, .. }) |
             Signal::Activation(ActivationSignal { l1_origin, .. }) => {
+                self.provider.clear();
                 self.next = Some(l1_origin);
             }
             _ => {}
@@ -156,7 +157,7 @@ mod tests {
     #[tokio::test]
     async fn test_l1_retrieval_activation_signal() {
         let traversal = TraversalTestHelper::new_populated();
-        let dap = TestDAP { results: vec![] };
+        let dap = TestDAP { results: vec![Ok(Bytes::default())] };
         let mut retrieval = L1Retrieval::new(traversal, dap);
         retrieval.prev.block = None;
         assert!(retrieval.prev.block.is_none());
@@ -170,12 +171,13 @@ mod tests {
             .unwrap();
         assert!(retrieval.next.is_some());
         assert_eq!(retrieval.prev.block, Some(BlockInfo::default()));
+        assert!(retrieval.provider.results.is_empty(), "provider must be cleared on activation");
     }
 
     #[tokio::test]
     async fn test_l1_retrieval_reset_signal() {
         let traversal = TraversalTestHelper::new_populated();
-        let dap = TestDAP { results: vec![] };
+        let dap = TestDAP { results: vec![Ok(Bytes::default())] };
         let mut retrieval = L1Retrieval::new(traversal, dap);
         retrieval.prev.block = None;
         assert!(retrieval.prev.block.is_none());
@@ -189,6 +191,7 @@ mod tests {
             .unwrap();
         assert!(retrieval.next.is_some());
         assert_eq!(retrieval.prev.block, Some(BlockInfo::default()));
+        assert!(retrieval.provider.results.is_empty(), "provider must be cleared on reset");
     }
 
     #[tokio::test]


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
