### PR TITLE
fix(kona/derive): clear DAP on reset/activation signal in L1Retrieval

### DIFF
--- a/rust/kona/crates/protocol/derive/src/stages/l1_retrieval.rs
+++ b/rust/kona/crates/protocol/derive/src/stages/l1_retrieval.rs
@@ -244,44 +244,33 @@ mod tests {
         assert!(retrieval.next.is_none());
     }
 
-    /// Regression test: stale DAP data loaded before a reset must not be returned after the reset.
-    #[tokio::test]
-    async fn test_l1_retrieval_reset_clears_stale_data() {
+    async fn test_l1_retrieval_clears_stale_data(signal: Signal) {
         let traversal = TraversalTestHelper::new_populated();
-        // Pre-load a stale entry that should never be served after the reset.
+        // Pre-load a stale entry that should never be served after activation or reset.
         let dap = TestDAP { results: vec![Ok(Bytes::from_static(b"stale"))] };
         let mut retrieval = L1Retrieval::new(traversal, dap);
         retrieval.next = Some(BlockInfo::default());
-        retrieval
-            .signal(
-                ResetSignal { system_config: Some(Default::default()), ..Default::default() }
-                    .signal(),
-            )
-            .await
-            .unwrap();
+        retrieval.signal(signal).await.unwrap();
         // next_data must not return the stale bytes; the cleared provider yields EOF.
         let err = retrieval.next_data().await.unwrap_err();
         assert_eq!(err, PipelineError::Eof.temp());
     }
 
+    /// Regression test: stale DAP data loaded before a reset must not be returned after the reset.
+    #[tokio::test]
+    async fn test_l1_retrieval_reset_clears_stale_data() {
+        let reset_signal =
+            ResetSignal { system_config: Some(Default::default()), ..Default::default() }.signal();
+        test_l1_retrieval_clears_stale_data(reset_signal).await
+    }
+
     /// Regression test: stale DAP data loaded before an activation must not be returned after it.
     #[tokio::test]
     async fn test_l1_retrieval_activation_clears_stale_data() {
-        let traversal = TraversalTestHelper::new_populated();
-        // Pre-load a stale entry that should never be served after activation.
-        let dap = TestDAP { results: vec![Ok(Bytes::from_static(b"stale"))] };
-        let mut retrieval = L1Retrieval::new(traversal, dap);
-        retrieval.next = Some(BlockInfo::default());
-        retrieval
-            .signal(
-                ActivationSignal { system_config: Some(Default::default()), ..Default::default() }
-                    .signal(),
-            )
-            .await
-            .unwrap();
-        // next_data must not return the stale bytes; the cleared provider yields EOF.
-        let err = retrieval.next_data().await.unwrap_err();
-        assert_eq!(err, PipelineError::Eof.temp());
+        let activation_signal =
+            ActivationSignal { system_config: Some(Default::default()), ..Default::default() }
+                .signal();
+        test_l1_retrieval_clears_stale_data(activation_signal).await
     }
 
     #[tokio::test]

--- a/rust/kona/crates/protocol/derive/src/stages/l1_retrieval.rs
+++ b/rust/kona/crates/protocol/derive/src/stages/l1_retrieval.rs
@@ -125,6 +125,7 @@ where
         match signal {
             Signal::Reset(ResetSignal { l1_origin, .. }) |
             Signal::Activation(ActivationSignal { l1_origin, .. }) => {
+                self.provider.clear();
                 self.next = Some(l1_origin);
             }
             _ => {}
@@ -156,7 +157,7 @@ mod tests {
     #[tokio::test]
     async fn test_l1_retrieval_activation_signal() {
         let traversal = TraversalTestHelper::new_populated();
-        let dap = TestDAP { results: vec![] };
+        let dap = TestDAP { results: vec![Ok(Bytes::default())] };
         let mut retrieval = L1Retrieval::new(traversal, dap);
         retrieval.prev.block = None;
         assert!(retrieval.prev.block.is_none());
@@ -170,12 +171,14 @@ mod tests {
             .unwrap();
         assert!(retrieval.next.is_some());
         assert_eq!(retrieval.prev.block, Some(BlockInfo::default()));
+        // Provider must be cleared on activation to flush stale data.
+        assert!(retrieval.provider.results.is_empty());
     }
 
     #[tokio::test]
     async fn test_l1_retrieval_reset_signal() {
         let traversal = TraversalTestHelper::new_populated();
-        let dap = TestDAP { results: vec![] };
+        let dap = TestDAP { results: vec![Ok(Bytes::default())] };
         let mut retrieval = L1Retrieval::new(traversal, dap);
         retrieval.prev.block = None;
         assert!(retrieval.prev.block.is_none());
@@ -189,6 +192,8 @@ mod tests {
             .unwrap();
         assert!(retrieval.next.is_some());
         assert_eq!(retrieval.prev.block, Some(BlockInfo::default()));
+        // Provider must be cleared on reset to flush stale data.
+        assert!(retrieval.provider.results.is_empty());
     }
 
     #[tokio::test]

--- a/rust/kona/crates/protocol/derive/src/stages/l1_retrieval.rs
+++ b/rust/kona/crates/protocol/derive/src/stages/l1_retrieval.rs
@@ -244,6 +244,46 @@ mod tests {
         assert!(retrieval.next.is_none());
     }
 
+    /// Regression test: stale DAP data loaded before a reset must not be returned after the reset.
+    #[tokio::test]
+    async fn test_l1_retrieval_reset_clears_stale_data() {
+        let traversal = TraversalTestHelper::new_populated();
+        // Pre-load a stale entry that should never be served after the reset.
+        let dap = TestDAP { results: vec![Ok(Bytes::from_static(b"stale"))] };
+        let mut retrieval = L1Retrieval::new(traversal, dap);
+        retrieval.next = Some(BlockInfo::default());
+        retrieval
+            .signal(
+                ResetSignal { system_config: Some(Default::default()), ..Default::default() }
+                    .signal(),
+            )
+            .await
+            .unwrap();
+        // next_data must not return the stale bytes; the cleared provider yields EOF.
+        let err = retrieval.next_data().await.unwrap_err();
+        assert_eq!(err, PipelineError::Eof.temp());
+    }
+
+    /// Regression test: stale DAP data loaded before an activation must not be returned after it.
+    #[tokio::test]
+    async fn test_l1_retrieval_activation_clears_stale_data() {
+        let traversal = TraversalTestHelper::new_populated();
+        // Pre-load a stale entry that should never be served after activation.
+        let dap = TestDAP { results: vec![Ok(Bytes::from_static(b"stale"))] };
+        let mut retrieval = L1Retrieval::new(traversal, dap);
+        retrieval.next = Some(BlockInfo::default());
+        retrieval
+            .signal(
+                ActivationSignal { system_config: Some(Default::default()), ..Default::default() }
+                    .signal(),
+            )
+            .await
+            .unwrap();
+        // next_data must not return the stale bytes; the cleared provider yields EOF.
+        let err = retrieval.next_data().await.unwrap_err();
+        assert_eq!(err, PipelineError::Eof.temp());
+    }
+
     #[tokio::test]
     async fn test_l1_retrieval_existing_data_errors() {
         let traversal = TraversalTestHelper::new_populated();


### PR DESCRIPTION
On re-org, the reset signal was setting the next L1 origin but not clearing the data availability provider, leaving stale calldata or blobs in the pipeline. Call provider.clear() alongside the next-block reset so stale data cannot leak across a reorg boundary.

Edit: Added regression tests. Manually verified they fail without the fix.

Fixes https://github.com/ethereum-optimism/optimism-private/issues/469