### PR TITLE
fix(kona/genesis): continue past malformed logs in update_with_receipts

### DIFF
--- a/rust/kona/crates/protocol/derive/src/attributes/stateful.rs
+++ b/rust/kona/crates/protocol/derive/src/attributes/stateful.rs
@@ -111,14 +111,16 @@ where
                 derive_deposits(epoch.hash, &receipts, self.rollup_cfg.deposit_contract_address)
                     .await
                     .map_err(|e| PipelineError::BadEncoding(e).crit())?;
-            // Failure to update the system config is non-fatal: one or more receipts may
-            // contain malformed or invalid config update logs. Log a warning and continue.
-            if let Err(err) = sys_config.update_with_receipts(
+            let (updates, errors) = sys_config.update_with_receipts(
                 &receipts,
                 self.rollup_cfg.l1_system_config_address,
                 self.rollup_cfg.is_ecotone_active(header.timestamp),
-            ) {
-                warn!(target: "attributes", ?err, "Failed to update system config at epoch {} (non-fatal, continuing)", epoch.number);
+            );
+            for kind in &updates {
+                info!(target: "attributes", epoch = epoch.number, %kind, "Applied system config update");
+            }
+            for err in &errors {
+                warn!(target: "attributes", ?err, epoch = epoch.number, "Malformed system config update (skipped)");
             }
             l1_header = header;
             deposit_transactions = deposits;

--- a/rust/kona/crates/protocol/derive/src/stages/traversal/indexed.rs
+++ b/rust/kona/crates/protocol/derive/src/stages/traversal/indexed.rs
@@ -90,26 +90,13 @@ impl<F: ChainProvider> IndexedTraversal<F> {
         let receipts =
             self.data_source.receipts_by_hash(block_info.hash).await.map_err(Into::into)?;
 
-        let addr = self.rollup_config.l1_system_config_address;
-        let active = self.rollup_config.is_ecotone_active(block_info.timestamp);
-        match self.system_config.update_with_receipts(&receipts[..], addr, active) {
-            Ok(true) => {
-                let next = block_info.number as f64;
-                kona_macros::set!(gauge, crate::Metrics::PIPELINE_LATEST_SYS_CONFIG_UPDATE, next);
-                info!(target: "traversal", "System config updated at block {next}.");
-            }
-            Ok(false) => { /* Ignore, no update applied */ }
-            Err(err) => {
-                // Failure to update the system config is non-fatal: one or more receipts may be
-                // malformed or invalid. Log a warning and continue.
-                warn!(target: "traversal", ?err, "Failed to update system config at block {} (non-fatal, continuing)", block_info.number);
-                kona_macros::set!(
-                    gauge,
-                    crate::Metrics::PIPELINE_SYS_CONFIG_UPDATE_ERROR,
-                    block_info.number as f64
-                );
-            }
-        }
+        super::update_system_config_with_receipts(
+            &mut self.system_config,
+            &receipts,
+            self.rollup_config.l1_system_config_address,
+            self.rollup_config.is_ecotone_active(block_info.timestamp),
+            block_info.number,
+        );
 
         // Update the origin block.
         self.update_origin(block_info);

--- a/rust/kona/crates/protocol/derive/src/stages/traversal/mod.rs
+++ b/rust/kona/crates/protocol/derive/src/stages/traversal/mod.rs
@@ -9,6 +9,10 @@
 //! - [`PollingTraversal`]: An active traversal stage that polls for the next block through its
 //!   provider.
 
+use alloy_consensus::Receipt;
+use alloy_primitives::Address;
+use kona_genesis::SystemConfig;
+
 mod indexed;
 pub use indexed::IndexedTraversal;
 
@@ -22,4 +26,35 @@ pub enum TraversalStage {
     Managed,
     /// An active traversal stage that polls for the next block through its provider.
     Polling,
+}
+
+/// Updates the system config with receipts, logging each applied update and any errors,
+/// and setting the appropriate metrics gauges.
+fn update_system_config_with_receipts(
+    system_config: &mut SystemConfig,
+    receipts: &[Receipt],
+    l1_system_config_address: Address,
+    ecotone_active: bool,
+    block_number: u64,
+) {
+    let (updates, errors) =
+        system_config.update_with_receipts(receipts, l1_system_config_address, ecotone_active);
+    for kind in &updates {
+        info!(target: "traversal", %kind, block_number, "Applied system config update");
+    }
+    if !updates.is_empty() {
+        kona_macros::set!(
+            gauge,
+            crate::Metrics::PIPELINE_LATEST_SYS_CONFIG_UPDATE,
+            block_number as f64
+        );
+    }
+    for err in &errors {
+        warn!(target: "traversal", ?err, "Malformed system config update at block {block_number} (skipped)");
+        kona_macros::set!(
+            gauge,
+            crate::Metrics::PIPELINE_SYS_CONFIG_UPDATE_ERROR,
+            block_number as f64
+        );
+    }
 }

--- a/rust/kona/crates/protocol/derive/src/stages/traversal/polling.rs
+++ b/rust/kona/crates/protocol/derive/src/stages/traversal/polling.rs
@@ -98,26 +98,13 @@ impl<F: ChainProvider + Send> OriginAdvancer for PollingTraversal<F> {
         let receipts =
             self.data_source.receipts_by_hash(next_l1_origin.hash).await.map_err(Into::into)?;
 
-        let addr = self.rollup_config.l1_system_config_address;
-        let active = self.rollup_config.is_ecotone_active(next_l1_origin.timestamp);
-        match self.system_config.update_with_receipts(&receipts[..], addr, active) {
-            Ok(true) => {
-                let next = next_l1_origin.number as f64;
-                kona_macros::set!(gauge, crate::Metrics::PIPELINE_LATEST_SYS_CONFIG_UPDATE, next);
-                info!(target: "l1_traversal", "System config updated at block {next}.");
-            }
-            Ok(false) => { /* Ignore, no update applied */ }
-            Err(err) => {
-                // Failure to update the system config is non-fatal: one or more receipts may be
-                // malformed or invalid. Log a warning and continue.
-                warn!(target: "l1_traversal", ?err, "Failed to update system config at block {} (non-fatal, continuing)", next_l1_origin.number);
-                kona_macros::set!(
-                    gauge,
-                    crate::Metrics::PIPELINE_SYS_CONFIG_UPDATE_ERROR,
-                    next_l1_origin.number as f64
-                );
-            }
-        }
+        super::update_system_config_with_receipts(
+            &mut self.system_config,
+            &receipts,
+            self.rollup_config.l1_system_config_address,
+            self.rollup_config.is_ecotone_active(next_l1_origin.timestamp),
+            next_l1_origin.number,
+        );
 
         let prev_block_holocene = self.rollup_config.is_holocene_active(block.timestamp);
         let next_block_holocene = self.rollup_config.is_holocene_active(next_l1_origin.timestamp);

--- a/rust/kona/crates/protocol/genesis/src/system/config.rs
+++ b/rust/kona/crates/protocol/genesis/src/system/config.rs
@@ -4,6 +4,7 @@ use crate::{
     CONFIG_UPDATE_TOPIC, RollupConfig, SystemConfigLog, SystemConfigUpdateError,
     SystemConfigUpdateKind,
 };
+use alloc::vec::Vec;
 use alloy_consensus::{Eip658Value, Receipt};
 use alloy_primitives::{Address, B64, Log, U256};
 
@@ -118,33 +119,35 @@ impl<'a> serde::Deserialize<'a> for SystemConfig {
 impl SystemConfig {
     /// Filters all L1 receipts to find config updates and applies the config updates.
     ///
-    /// Returns `true` if any config updates were applied, `false` otherwise.
+    /// Each config update log is applied independently. Malformed or invalid updates are
+    /// skipped so that subsequent valid updates in the same block are still processed.
+    /// This matches the op-node reference behavior in `UpdateSystemConfigWithL1Receipts`.
+    ///
+    /// Returns the successfully applied update kinds and any errors encountered.
     pub fn update_with_receipts(
         &mut self,
         receipts: &[Receipt],
         l1_system_config_address: Address,
         ecotone_active: bool,
-    ) -> Result<bool, SystemConfigUpdateError> {
-        let mut updated = false;
-        for receipt in receipts {
-            if Eip658Value::Eip658(false) == receipt.status {
-                continue;
-            }
-
-            receipt.logs.iter().try_for_each(|log| {
+    ) -> (Vec<SystemConfigUpdateKind>, Vec<SystemConfigUpdateError>) {
+        receipts
+            .iter()
+            .filter(|r| r.status != Eip658Value::Eip658(false))
+            .flat_map(|r| &r.logs)
+            .filter(|log| {
                 let topics = log.topics();
-                if log.address == l1_system_config_address &&
+                log.address == l1_system_config_address &&
                     !topics.is_empty() &&
                     topics[0] == CONFIG_UPDATE_TOPIC
-                {
-                    // Safety: Error is bubbled up by the trailing `?`
-                    self.process_config_update_log(log, ecotone_active)?;
-                    updated = true;
+            })
+            .map(|log| self.process_config_update_log(log, ecotone_active))
+            .fold((Vec::new(), Vec::new()), |(mut updates, mut errors), result| {
+                match result {
+                    Ok(kind) => updates.push(kind),
+                    Err(e) => errors.push(e),
                 }
-                Ok::<(), SystemConfigUpdateError>(())
-            })?;
-        }
-        Ok(updated)
+                (updates, errors)
+            })
     }
 
     /// Returns the eip1559 parameters from a [`SystemConfig`] encoded as a [B64].
@@ -222,6 +225,17 @@ mod test {
     use crate::{CONFIG_UPDATE_EVENT_VERSION_0, HardForkConfig};
     use alloc::vec;
     use alloy_primitives::{B256, LogData, address, b256, hex};
+
+    const BATCHER_UPDATE_TYPE: B256 =
+        b256!("0000000000000000000000000000000000000000000000000000000000000000");
+    const GAS_CONFIG_UPDATE_TYPE: B256 =
+        b256!("0000000000000000000000000000000000000000000000000000000000000001");
+    const GAS_LIMIT_UPDATE_TYPE: B256 =
+        b256!("0000000000000000000000000000000000000000000000000000000000000002");
+    const EIP1559_UPDATE_TYPE: B256 =
+        b256!("0000000000000000000000000000000000000000000000000000000000000004");
+    const OPERATOR_FEE_UPDATE_TYPE: B256 =
+        b256!("0000000000000000000000000000000000000000000000000000000000000005");
 
     #[test]
     #[cfg(feature = "serde")]
@@ -382,18 +396,16 @@ mod test {
         let l1_system_config_address = Address::ZERO;
         let ecotone_active = false;
 
-        let updated = system_config
-            .update_with_receipts(&receipts, l1_system_config_address, ecotone_active)
-            .unwrap();
-        assert!(!updated);
+        let (updates, errors) =
+            system_config.update_with_receipts(&receipts, l1_system_config_address, ecotone_active);
+        assert!(updates.is_empty());
+        assert!(errors.is_empty());
 
         assert_eq!(system_config, SystemConfig::default());
     }
 
     #[test]
     fn test_system_config_update_with_receipts_batcher_address() {
-        const UPDATE_TYPE: B256 =
-            b256!("0000000000000000000000000000000000000000000000000000000000000000");
         let mut system_config = SystemConfig::default();
         let l1_system_config_address = Address::ZERO;
         let ecotone_active = false;
@@ -404,7 +416,7 @@ mod test {
                 vec![
                     CONFIG_UPDATE_TOPIC,
                     CONFIG_UPDATE_EVENT_VERSION_0,
-                    UPDATE_TYPE,
+                    BATCHER_UPDATE_TYPE,
                 ],
                 hex!("00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000beef").into()
             )
@@ -416,10 +428,13 @@ mod test {
             cumulative_gas_used: 0,
         };
 
-        let updated = system_config
-            .update_with_receipts(&[receipt], l1_system_config_address, ecotone_active)
-            .unwrap();
-        assert!(updated);
+        let (updates, errors) = system_config.update_with_receipts(
+            &[receipt],
+            l1_system_config_address,
+            ecotone_active,
+        );
+        assert_eq!(updates, vec![SystemConfigUpdateKind::Batcher]);
+        assert!(errors.is_empty());
 
         assert_eq!(
             system_config.batcher_address,
@@ -429,9 +444,6 @@ mod test {
 
     #[test]
     fn test_system_config_update_batcher_log() {
-        const UPDATE_TYPE: B256 =
-            b256!("0000000000000000000000000000000000000000000000000000000000000000");
-
         let mut system_config = SystemConfig::default();
 
         let update_log = Log {
@@ -440,7 +452,7 @@ mod test {
                 vec![
                     CONFIG_UPDATE_TOPIC,
                     CONFIG_UPDATE_EVENT_VERSION_0,
-                    UPDATE_TYPE,
+                    BATCHER_UPDATE_TYPE,
                 ],
                 hex!("00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000beef").into()
             )
@@ -457,9 +469,6 @@ mod test {
 
     #[test]
     fn test_system_config_update_gas_config_log() {
-        const UPDATE_TYPE: B256 =
-            b256!("0000000000000000000000000000000000000000000000000000000000000001");
-
         let mut system_config = SystemConfig::default();
 
         let update_log = Log {
@@ -468,13 +477,13 @@ mod test {
                 vec![
                     CONFIG_UPDATE_TOPIC,
                     CONFIG_UPDATE_EVENT_VERSION_0,
-                    UPDATE_TYPE,
+                    GAS_CONFIG_UPDATE_TYPE,
                 ],
                 hex!("00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000babe000000000000000000000000000000000000000000000000000000000000beef").into()
             )
         };
 
-        // Update the batcher address.
+        // Update the gas config.
         system_config.process_config_update_log(&update_log, false).unwrap();
 
         assert_eq!(system_config.overhead, U256::from(0xbabe));
@@ -483,9 +492,6 @@ mod test {
 
     #[test]
     fn test_system_config_update_gas_config_log_ecotone() {
-        const UPDATE_TYPE: B256 =
-            b256!("0000000000000000000000000000000000000000000000000000000000000001");
-
         let mut system_config = SystemConfig::default();
 
         let update_log = Log {
@@ -494,13 +500,13 @@ mod test {
                 vec![
                     CONFIG_UPDATE_TOPIC,
                     CONFIG_UPDATE_EVENT_VERSION_0,
-                    UPDATE_TYPE,
+                    GAS_CONFIG_UPDATE_TYPE,
                 ],
                 hex!("00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000babe000000000000000000000000000000000000000000000000000000000000beef").into()
             )
         };
 
-        // Update the gas limit.
+        // Update the gas config (ecotone).
         system_config.process_config_update_log(&update_log, true).unwrap();
 
         assert_eq!(system_config.overhead, U256::from(0));
@@ -509,9 +515,6 @@ mod test {
 
     #[test]
     fn test_system_config_update_gas_limit_log() {
-        const UPDATE_TYPE: B256 =
-            b256!("0000000000000000000000000000000000000000000000000000000000000002");
-
         let mut system_config = SystemConfig::default();
 
         let update_log = Log {
@@ -520,7 +523,7 @@ mod test {
                 vec![
                     CONFIG_UPDATE_TOPIC,
                     CONFIG_UPDATE_EVENT_VERSION_0,
-                    UPDATE_TYPE,
+                    GAS_LIMIT_UPDATE_TYPE,
                 ],
                 hex!("00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000beef").into()
             )
@@ -534,9 +537,6 @@ mod test {
 
     #[test]
     fn test_system_config_update_eip1559_params_log() {
-        const UPDATE_TYPE: B256 =
-            b256!("0000000000000000000000000000000000000000000000000000000000000004");
-
         let mut system_config = SystemConfig::default();
         let update_log = Log {
             address: Address::ZERO,
@@ -544,7 +544,7 @@ mod test {
                 vec![
                     CONFIG_UPDATE_TOPIC,
                     CONFIG_UPDATE_EVENT_VERSION_0,
-                    UPDATE_TYPE,
+                    EIP1559_UPDATE_TYPE,
                 ],
                 hex!("000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000babe0000beef").into()
             )
@@ -559,17 +559,14 @@ mod test {
 
     #[test]
     fn test_system_config_update_operator_fee_log() {
-        const UPDATE_TYPE: B256 =
-            b256!("0000000000000000000000000000000000000000000000000000000000000005");
-
         let mut system_config = SystemConfig::default();
-        let update_log  = Log {
+        let update_log = Log {
             address: Address::ZERO,
             data: LogData::new_unchecked(
                 vec![
                     CONFIG_UPDATE_TOPIC,
                     CONFIG_UPDATE_EVENT_VERSION_0,
-                    UPDATE_TYPE,
+                    OPERATOR_FEE_UPDATE_TYPE,
                 ],
                 hex!("0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000babe000000000000beef").into()
             )
@@ -580,5 +577,53 @@ mod test {
 
         assert_eq!(system_config.operator_fee_scalar, Some(0xbabe_u32));
         assert_eq!(system_config.operator_fee_constant, Some(0xbeef_u64));
+    }
+
+    #[test]
+    fn test_update_with_receipts_continues_past_malformed_log() {
+        let mut system_config = SystemConfig::default();
+        let l1_system_config_address = Address::ZERO;
+
+        // Malformed batcher update: non-zero upper 12 bytes in batcher hash
+        let malformed_log = Log {
+            address: Address::ZERO,
+            data: LogData::new_unchecked(
+                vec![
+                    CONFIG_UPDATE_TOPIC,
+                    CONFIG_UPDATE_EVENT_VERSION_0,
+                    BATCHER_UPDATE_TYPE,
+                ],
+                // ABI-encoded address with dirty upper bytes — will fail address decoding
+                hex!("00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000020dead00000000000000000000000000000000000000000000000000000000beef").into()
+            )
+        };
+
+        // Valid gas limit update (different type to prove the malformed one didn't apply)
+        let valid_log = Log {
+            address: Address::ZERO,
+            data: LogData::new_unchecked(
+                vec![
+                    CONFIG_UPDATE_TOPIC,
+                    CONFIG_UPDATE_EVENT_VERSION_0,
+                    GAS_LIMIT_UPDATE_TYPE,
+                ],
+                hex!("00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000beef").into()
+            )
+        };
+
+        let receipt = Receipt {
+            logs: vec![malformed_log, valid_log],
+            status: Eip658Value::Eip658(true),
+            cumulative_gas_used: 0,
+        };
+
+        let (updates, errors) =
+            system_config.update_with_receipts(&[receipt], l1_system_config_address, false);
+        assert_eq!(updates, vec![SystemConfigUpdateKind::GasLimit]);
+        assert_eq!(errors.len(), 1);
+        // Malformed batcher update was skipped — address unchanged.
+        assert_eq!(system_config.batcher_address, Address::ZERO);
+        // Valid gas limit update was still applied.
+        assert_eq!(system_config.gas_limit, 0xbeef_u64);
     }
 }

--- a/rust/kona/crates/protocol/genesis/src/system/kind.rs
+++ b/rust/kona/crates/protocol/genesis/src/system/kind.rs
@@ -1,7 +1,7 @@
 //! Contains the kind of system config update.
 
 /// Represents type of update to the system config.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, derive_more::TryFrom)]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, derive_more::Display, derive_more::TryFrom)]
 #[try_from(repr)]
 #[repr(u64)]
 pub enum SystemConfigUpdateKind {


### PR DESCRIPTION
## Summary

- `SystemConfig::update_with_receipts` used `try_for_each` which short-circuited on the first malformed config update log, silently dropping any subsequent valid updates in the same block
- Changed to process each log independently: valid updates are applied, malformed ones are skipped — matching the op-node reference in `UpdateSystemConfigWithL1Receipts` (`system_config.go:42-67`)
- Refactored return type from `Result<bool, SystemConfigUpdateError>` to `(Vec<SystemConfigUpdateKind>, Vec<SystemConfigUpdateError>)` so callers get full visibility into what succeeded and what failed
- Added `Display` derive to `SystemConfigUpdateKind` for human-readable log messages
- Deduplicated the two traversal callers into a shared `update_system_config_with_receipts` helper
- Updated the attributes caller to log individual updates/errors instead of a single blanket warning

Related: fixes remaining Issue 2 from https://github.com/ethereum-optimism/optimism-private/issues/507 . Issue 1 was already fixed by #19358 and #19503.

Fixes https://github.com/ethereum-optimism/optimism-private/issues/507

## Test plan

- [x] Added `test_update_with_receipts_continues_past_malformed_log` — sends a malformed batcher update followed by a valid gas limit update in the same receipt; asserts the malformed one is skipped (batcher address unchanged) and the valid one is applied (gas limit updated)
- [x] Red/green confirmed: test fails against the old `try_for_each` code, passes with the fix
- [x] All 20 `kona-genesis` config tests pass
- [x] All 6 `kona-derive` system config / syscfg tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)