### PR TITLE
fix: mask rs to 32 bits before clz/clo count loop on MIPS64

### DIFF
--- a/cannon/mipsevm/exec/mips_instructions.go
+++ b/cannon/mipsevm/exec/mips_instructions.go
@@ -591,12 +591,13 @@ func HandleHiLo(cpu *mipsevm.CpuScalars, registers *[32]Word, fun uint32, rs Wor
 		hi, lo := bits.Mul64(absA, absB)
 		if negative {
 			// Two's complement negation: flip all bits and add 1
+			// Must increment lo first, then carry to hi if lo overflows to 0
 			hi = ^hi
 			lo = ^lo
-			if lo == 0xFFFFFFFFFFFFFFFF {
+			lo++
+			if lo == 0 {
 				hi++
 			}
-			lo++
 		}
 		cpu.HI = Word(hi)
 		cpu.LO = Word(lo)

--- a/cannon/mipsevm/exec/mips_instructions.go
+++ b/cannon/mipsevm/exec/mips_instructions.go
@@ -345,6 +345,8 @@ func ExecuteMipsInstruction(insn uint32, opcode uint32, fun uint32, rs, rt, mem 
 				if fun == 0x20 {
 					rs = ^rs
 				}
+				// Mask to 32 bits to prevent upper bits of 64-bit Word from affecting the count
+				rs = rs & 0xFFFFFFFF
 				i := uint32(0)
 				for ; rs&0x80000000 != 0; i++ {
 					rs <<= 1


### PR DESCRIPTION
On MIPS64 builds where Word is uint64, the 32-bit clz (count leading zeros) and clo (count leading ones) instructions operate on the full 64-bit rs value without masking to 32 bits before the counting loop.

For clz (fun 0x20): rs = ^rs inverts all 64 bits. When the original value is zero-extended from 32 bits (upper 32 bits = 0), inversion sets all upper bits to 1. The loop then counts through these upper bits first, producing counts exceeding 32 - an impossible result for a 32-bit CLZ instruction per the MIPS ISA specification.

For clo (fun 0x21): if rs is sign-extended from a negative 32-bit value (upper 32 bits all 1s), the loop shifts through all 64 set bits before reaching the 32-bit boundary.

This patch adds rs = rs & 0xFFFFFFFF after the optional bit inversion but before the counting loop, isolating the lower 32 bits. The 64-bit variants dclz/dclo (fun 0x24/0x25) are unaffected as they correctly use uint64(rs)&0x80000000_00000000 to check bit 63.

If the off-chain cannon VM and on-chain MIPS implementation produce different results for clz/clo on values with non-zero upper bits, a fault proof could be constructed where the two disagree on the resulting program state.

