### PR TITLE
feat(devtest): add FLAKY_FAIL/FLAKY_PASS annotations for flaky test tracking

### DIFF
--- a/op-devstack/devtest/testing.go
+++ b/op-devstack/devtest/testing.go
@@ -120,10 +120,11 @@ func (t *testingT) shouldSkipFlakyFailure() bool {
 func (t *testingT) skipFlakyFailure(msg string) {
 	if t.reason != "" {
 		t.logger.Warn("Ignoring failure in flaky test", "reason", t.reason, "failure", msg)
+		t.t.Skip(fmt.Sprintf("FLAKY_FAIL: %s: %s", t.reason, msg))
 	} else {
 		t.logger.Warn("Ignoring failure in flaky test", "failure", msg)
+		t.t.Skip(fmt.Sprintf("FLAKY_FAIL: %s", msg))
 	}
-	t.t.SkipNow()
 }
 
 func (t *testingT) Error(args ...any) {
@@ -252,6 +253,15 @@ func (t *testingT) MarkFlaky(reason string) {
 	if reason != "" {
 		t.reason = reason
 	}
+	t.t.Cleanup(func() {
+		if !t.t.Failed() && !t.t.Skipped() && !mustFailFlakyTests() {
+			if t.reason != "" {
+				t.t.Skip(fmt.Sprintf("FLAKY_PASS: %s", t.reason))
+			} else {
+				t.t.Skip("FLAKY_PASS")
+			}
+		}
+	})
 }
 
 func (t *testingT) Run(name string, fn func(T)) {
@@ -280,6 +290,17 @@ func (t *testingT) Run(name string, fn func(T)) {
 		}
 		subT.req = testreq.New(subT)
 		subT.gate = testreq.New(&gateAdapter{subT})
+		if subT.flaky {
+			subGoT.Cleanup(func() {
+				if !subGoT.Failed() && !subGoT.Skipped() && !mustFailFlakyTests() {
+					if subT.reason != "" {
+						subGoT.Skip(fmt.Sprintf("FLAKY_PASS: %s", subT.reason))
+					} else {
+						subGoT.Skip("FLAKY_PASS")
+					}
+				}
+			})
+		}
 		fn(subT)
 	})
 }

--- a/op-devstack/devtest/testing.go
+++ b/op-devstack/devtest/testing.go
@@ -120,10 +120,10 @@ func (t *testingT) shouldSkipFlakyFailure() bool {
 func (t *testingT) skipFlakyFailure(msg string) {
 	if t.reason != "" {
 		t.logger.Warn("Ignoring failure in flaky test", "reason", t.reason, "failure", msg)
-		t.t.Skip(fmt.Sprintf("FLAKY_FAIL: %s: %s", t.reason, msg))
+		t.t.Skipf("FLAKY_FAIL: %s: %s", t.reason, msg)
 	} else {
 		t.logger.Warn("Ignoring failure in flaky test", "failure", msg)
-		t.t.Skip(fmt.Sprintf("FLAKY_FAIL: %s", msg))
+		t.t.Skipf("FLAKY_FAIL: %s", msg)
 	}
 }
 
@@ -256,7 +256,7 @@ func (t *testingT) MarkFlaky(reason string) {
 	t.t.Cleanup(func() {
 		if !t.t.Failed() && !t.t.Skipped() && !mustFailFlakyTests() {
 			if t.reason != "" {
-				t.t.Skip(fmt.Sprintf("FLAKY_PASS: %s", t.reason))
+				t.t.Skipf("FLAKY_PASS: %s", t.reason)
 			} else {
 				t.t.Skip("FLAKY_PASS")
 			}
@@ -294,7 +294,7 @@ func (t *testingT) Run(name string, fn func(T)) {
 			subGoT.Cleanup(func() {
 				if !subGoT.Failed() && !subGoT.Skipped() && !mustFailFlakyTests() {
 					if subT.reason != "" {
-						subGoT.Skip(fmt.Sprintf("FLAKY_PASS: %s", subT.reason))
+						subGoT.Skipf("FLAKY_PASS: %s", subT.reason)
 					} else {
 						subGoT.Skip("FLAKY_PASS")
 					}

--- a/op-devstack/devtest/testing_test.go
+++ b/op-devstack/devtest/testing_test.go
@@ -42,3 +42,67 @@ func TestMarkFlakyPropagatesToSubtests(t *testing.T) {
 		t.Fatal("expected flaky child subtest to be skipped instead of failed")
 	}
 }
+
+func TestMarkFlakyFailProducesAnnotatedSkip(t *testing.T) {
+	t.Setenv(FailFlakyTests, "false")
+	ok := t.Run("flaky", func(gt *testing.T) {
+		dt := SerialT(gt)
+		dt.MarkFlaky("test-reason")
+		dt.Require().Equal("expected", "actual")
+		gt.Fatal("should not reach here")
+	})
+	if !ok {
+		t.Fatal("expected flaky subtest to be skipped instead of failed")
+	}
+}
+
+func TestMarkFlakyPassProducesAnnotatedSkip(t *testing.T) {
+	t.Setenv(FailFlakyTests, "false")
+	ok := t.Run("flaky-pass", func(gt *testing.T) {
+		dt := SerialT(gt)
+		dt.MarkFlaky("test-reason")
+		// Test passes — no assertions fail
+	})
+	if !ok {
+		t.Fatal("expected flaky passing subtest to be skipped (not failed)")
+	}
+}
+
+func TestMarkFlakyAnnotationsDisabledWhenForceFail(t *testing.T) {
+	t.Setenv(FailFlakyTests, "true")
+	// Verify that mustFailFlakyTests returns true, which means
+	// shouldSkipFlakyFailure returns false and FailNow will not be
+	// converted to a skip.  We cannot call FailNow in a subtest here
+	// because Go propagates subtest failures to the parent, which would
+	// cause this test to fail unconditionally.
+	if !mustFailFlakyTests() {
+		t.Fatal("expected mustFailFlakyTests to return true when DEVNET_FAIL_FLAKY_TESTS=true")
+	}
+}
+
+func TestMarkFlakyPassNoAnnotationWhenForceFail(t *testing.T) {
+	t.Setenv(FailFlakyTests, "true")
+	ok := t.Run("flaky-pass-forced", func(gt *testing.T) {
+		dt := SerialT(gt)
+		dt.MarkFlaky("test-reason")
+		// Test passes — no assertions fail
+		// Should NOT be skipped when DEVNET_FAIL_FLAKY_TESTS=true
+	})
+	if !ok {
+		t.Fatal("expected passing test to pass normally when DEVNET_FAIL_FLAKY_TESTS=true")
+	}
+}
+
+func TestMarkFlakySubtestPassProducesAnnotatedSkip(t *testing.T) {
+	t.Setenv(FailFlakyTests, "false")
+	ok := t.Run("flaky-parent", func(gt *testing.T) {
+		dt := SerialT(gt)
+		dt.MarkFlaky("test-reason")
+		dt.Run("passing-child", func(dt T) {
+			// Child passes — should be skipped with FLAKY_PASS
+		})
+	})
+	if !ok {
+		t.Fatal("expected flaky passing subtest to be skipped (not failed)")
+	}
+}


### PR DESCRIPTION
## Summary

- `skipFlakyFailure()` now emits `t.t.Skipf("FLAKY_FAIL: reason: failure")` instead of bare `t.t.SkipNow()`, so flaky test failures carry a structured marker in JUnit XML skip messages
- `MarkFlaky()` registers a cleanup that emits `FLAKY_PASS: reason` when a flaky-marked test passes, making passing flaky tests distinguishable from normal passes
- `Run()` registers the same FLAKY_PASS cleanup on subtests that inherit the flaky flag

This enables downstream systems (cci-stats) to parse the skip messages and record flaky test outcomes persistently, so teams can track which flaky tests are still failing and which have stabilized enough to unmark.

Companion PR: ethereum-optimism/infra#576 — cci-stats changes to parse these markers.

## Test plan

- [x] New tests: `TestMarkFlakyFailProducesAnnotatedSkip`, `TestMarkFlakyPassProducesAnnotatedSkip`, `TestMarkFlakyAnnotationsDisabledWhenForceFail`, `TestMarkFlakyPassNoAnnotationWhenForceFail`, `TestMarkFlakySubtestPassProducesAnnotatedSkip`
- [x] All existing devtest tests pass unchanged
- [x] `go vet` clean
- [ ] Verify FLAKY_FAIL/FLAKY_PASS markers appear in CircleCI test metadata after CI run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>