### PR TITLE
fix(op-interop-filter): prevent uint64 underflow in calculateStartingBlock

### DIFF
--- a/op-interop-filter/filter/logsdb_chain_ingester.go
+++ b/op-interop-filter/filter/logsdb_chain_ingester.go
@@ -340,7 +340,12 @@ func (c *LogsDBChainIngester) findAndSetEarliestBlock(latestBlock uint64) {
 // calculateStartingBlock returns the block number where ingestion should start,
 // calculated from startTimestamp and backfillDuration.
 func (c *LogsDBChainIngester) calculateStartingBlock() uint64 {
-	backfillTimestamp := c.startTimestamp - uint64(c.backfillDuration.Seconds())
+	backfillSeconds := uint64(c.backfillDuration.Seconds())
+	if c.startTimestamp < backfillSeconds {
+		// Backfill reaches before epoch 0; start from genesis
+		return c.rollupCfg.Genesis.L2.Number
+	}
+	backfillTimestamp := c.startTimestamp - backfillSeconds
 
 	startingBlock, err := c.rollupCfg.TargetBlockNumber(backfillTimestamp)
 	if err != nil {

--- a/op-interop-filter/filter/logsdb_chain_ingester_test.go
+++ b/op-interop-filter/filter/logsdb_chain_ingester_test.go
@@ -633,6 +633,34 @@ func TestLogsDBChainIngester_InitIngestion_FreshStart(t *testing.T) {
 	require.Equal(t, startingBlock, nextBlock)
 }
 
+func TestLogsDBChainIngester_CalculateStartingBlock_BackfillUnderflow(t *testing.T) {
+	chainID := eth.ChainIDFromUInt64(901)
+	tempDir := t.TempDir()
+
+	mockClient := NewMockEthClient()
+
+	l2StartBlock := uint64(100)
+	l2StartTimestamp := uint64(1000)
+
+	headBlock := createTestBlock(200, 1200, common.Hash{0x99})
+	mockClient.AddBlock(headBlock, nil)
+	mockClient.SetHeadBlock(headBlock)
+
+	ingester := newTestLogsDBChainIngester(t, testIngesterConfig{
+		chainID:   chainID,
+		dataDir:   tempDir,
+		ethClient: mockClient,
+		rollupCfg: testRollupConfig(901, l2StartBlock, l2StartTimestamp),
+	})
+
+	// startTimestamp=50, backfillDuration=200s would underflow without the guard
+	ingester.startTimestamp = 50
+	ingester.backfillDuration = 200 * time.Second
+
+	startingBlock := ingester.calculateStartingBlock()
+	require.Equal(t, l2StartBlock, startingBlock)
+}
+
 func TestLogsDBChainIngester_InitIngestion_ResumeFromExistingDB(t *testing.T) {
 	chainID := eth.ChainIDFromUInt64(901)
 	tempDir := t.TempDir()


### PR DESCRIPTION
## Summary

- Guard against uint64 underflow in `calculateStartingBlock` when `startTimestamp < backfillDuration.Seconds()`
- Falls back to L2 genesis block instead of wrapping to a huge timestamp
- Adds test covering the underflow case

Fixes runtimeverification/_audits_Ethereum-optimism_optimism_interopv2#37

## Test plan

- [x] New test `TestLogsDBChainIngester_CalculateStartingBlock_BackfillUnderflow` covers the underflow case
- [x] Existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)