### PR TITLE
op-devstack: add DerivationReady hook and de-flake TestCLELDivergence

### DIFF
--- a/op-acceptance-tests/tests/depreqres/reqressyncdisabled/divergence/divergence_test.go
+++ b/op-acceptance-tests/tests/depreqres/reqressyncdisabled/divergence/divergence_test.go
@@ -22,6 +22,8 @@ func TestCLELDivergence(gt *testing.T) {
 
 	sys.L2CL.Advanced(types.LocalUnsafe, 8, 30)
 
+	sys.L2CL.WaitForDerivationReady()
+
 	// batcher down so safe not advanced
 	require.Equal(uint64(0), sys.L2CL.HeadBlockRef(types.LocalSafe).Number)
 	require.Equal(uint64(0), sys.L2CLB.HeadBlockRef(types.LocalSafe).Number)
@@ -43,9 +45,6 @@ func TestCLELDivergence(gt *testing.T) {
 		// Canonical unsafe head never advances because of the gap
 		require.Equal(startNum+1, sys.L2ELB.BlockRefByLabel(eth.Unsafe).Number)
 
-		// EL-sync can quickly reset the status tracker after exposing the posted
-		// unsafe head, so poll tightly and without extra RPCs between the post and
-		// the SyncStatus check.
 		var ss *eth.SyncStatus
 		require.Eventually(func() bool {
 			ss = sys.L2CLB.SyncStatus()

--- a/op-devstack/dsl/l2_cl.go
+++ b/op-devstack/dsl/l2_cl.go
@@ -120,6 +120,23 @@ func (cl *L2CLNode) SyncStatus() *eth.SyncStatus {
 	return syncStatus
 }
 
+func (cl *L2CLNode) DerivationReady() bool {
+	ctx, cancel := context.WithTimeout(cl.ctx, DefaultTimeout)
+	defer cancel()
+	ready, err := cl.inner.RollupAPI().DerivationReady(ctx)
+	cl.require.NoError(err)
+	return ready
+}
+
+func (cl *L2CLNode) WaitForDerivationReady() {
+	ctx, cancel := context.WithTimeout(cl.ctx, DefaultTimeout)
+	defer cancel()
+	err := wait.For(ctx, 100*time.Millisecond, func() (bool, error) {
+		return cl.inner.RollupAPI().DerivationReady(ctx)
+	})
+	cl.require.NoError(err, "derivation did not become ready")
+}
+
 // HeadBlockRef fetches L2CL sync status and returns block ref with given safety level
 func (cl *L2CLNode) HeadBlockRef(lvl types.SafetyLevel) eth.L2BlockRef {
 	syncStatus := cl.SyncStatus()

--- a/op-e2e/actions/helpers/l2_verifier.go
+++ b/op-e2e/actions/helpers/l2_verifier.go
@@ -289,6 +289,10 @@ func (s *l2VerifierBackend) ResetDerivationPipeline(ctx context.Context) error {
 	return nil
 }
 
+func (s *l2VerifierBackend) DerivationReady(ctx context.Context) (bool, error) {
+	return s.verifier.derivation.DerivationReady(), nil
+}
+
 func (s *l2VerifierBackend) StartSequencer(ctx context.Context, blockHash common.Hash) error {
 	return nil
 }

--- a/op-node/node/api.go
+++ b/op-node/node/api.go
@@ -33,6 +33,7 @@ type driverClient interface {
 	SyncStatus(ctx context.Context) (*eth.SyncStatus, error)
 	BlockRefWithStatus(ctx context.Context, num uint64) (eth.L2BlockRef, *eth.SyncStatus, error)
 	ResetDerivationPipeline(context.Context) error
+	DerivationReady(context.Context) (bool, error)
 	StartSequencer(ctx context.Context, blockHash common.Hash) error
 	StopSequencer(context.Context) (common.Hash, error)
 	SequencerActive(context.Context) (bool, error)
@@ -62,6 +63,10 @@ func NewAdminAPI(dr driverClient, log log.Logger) *adminAPI {
 
 func (n *adminAPI) ResetDerivationPipeline(ctx context.Context) error {
 	return n.dr.ResetDerivationPipeline(ctx)
+}
+
+func (n *adminAPI) DerivationReady(ctx context.Context) (bool, error) {
+	return n.dr.DerivationReady(ctx)
 }
 
 func (n *adminAPI) StartSequencer(ctx context.Context, blockHash common.Hash) error {

--- a/op-node/node/server_test.go
+++ b/op-node/node/server_test.go
@@ -303,6 +303,10 @@ func (c *mockDriverClient) ResetDerivationPipeline(ctx context.Context) error {
 	return c.Mock.MethodCalled("ResetDerivationPipeline").Get(0).(error)
 }
 
+func (c *mockDriverClient) DerivationReady(ctx context.Context) (bool, error) {
+	return c.Mock.MethodCalled("DerivationReady").Get(0).(bool), nil
+}
+
 func (c *mockDriverClient) StartSequencer(ctx context.Context, blockHash common.Hash) error {
 	return c.Mock.MethodCalled("StartSequencer").Get(0).(error)
 }

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -408,6 +408,19 @@ func (s *Driver) SetRecoverMode(ctx context.Context, mode bool) error {
 	return nil
 }
 
+// DerivationReady blocks the driver event loop and captures whether derivation is ready.
+func (s *Driver) DerivationReady(ctx context.Context) (bool, error) {
+	wait := make(chan struct{})
+	select {
+	case s.stateReq <- wait:
+		ready := s.SyncDeriver.Derivation.DerivationReady()
+		<-wait
+		return ready, nil
+	case <-ctx.Done():
+		return false, ctx.Err()
+	}
+}
+
 // SyncStatus blocks the driver event loop and captures the syncing status.
 func (s *Driver) SyncStatus(ctx context.Context) (*eth.SyncStatus, error) {
 	return s.StatusTracker.SyncStatus(), nil

--- a/op-service/apis/rollup.go
+++ b/op-service/apis/rollup.go
@@ -58,12 +58,17 @@ type RecoverMode interface {
 	SetRecoverMode(ctx context.Context, mode bool) error
 }
 
+type DerivationReadiness interface {
+	DerivationReady(ctx context.Context) (bool, error)
+}
+
 type RollupAdminClient interface {
 	CommonAdminClient
 	SequencerActivity
 	UnsignedPayloadPoster
 	RollupConductor
 	RecoverMode
+	DerivationReadiness
 }
 
 type RollupAdminServer interface {
@@ -72,6 +77,7 @@ type RollupAdminServer interface {
 	UnsignedPayloadPoster
 	RollupConductor
 	RecoverMode
+	DerivationReadiness
 }
 
 type RollupNodeClient interface {

--- a/op-service/sources/rollupclient.go
+++ b/op-service/sources/rollupclient.go
@@ -103,6 +103,12 @@ func (r *RollupClient) SetRecoverMode(ctx context.Context, mode bool) error {
 	return r.rpc.CallContext(ctx, nil, "admin_setRecoverMode", mode)
 }
 
+func (r *RollupClient) DerivationReady(ctx context.Context) (bool, error) {
+	var result bool
+	err := r.rpc.CallContext(ctx, &result, "admin_derivationReady")
+	return result, err
+}
+
 func (r *RollupClient) Close() {
 	r.rpc.Close()
 }

--- a/op-service/testutils/mock_rollup_client.go
+++ b/op-service/testutils/mock_rollup_client.go
@@ -58,6 +58,15 @@ func (m *MockRollupClient) ExpectSequencerActive(active bool, err error) {
 	m.Mock.On("SequencerActive").Once().Return(active, err)
 }
 
+func (m *MockRollupClient) DerivationReady(ctx context.Context) (bool, error) {
+	out := m.Mock.Called()
+	return out.Bool(0), out.Error(1)
+}
+
+func (m *MockRollupClient) ExpectDerivationReady(ready bool, err error) {
+	m.Mock.On("DerivationReady").Once().Return(ready, err)
+}
+
 func (m *MockRollupClient) ExpectClose() {
 	m.Mock.On("Close").Once()
 }


### PR DESCRIPTION
This PR is adding a `DerivationReady` admin RPC, so that op-acceptance-tests can test if the initial derviation pipeline initialization has been done.

This should de-flake the `TestCLELDivergence` test.

Related: https://github.com/ethereum-optimism/optimism/issues/19681#issuecomment-4109757146