### PR TITLE
fix: remove duplicated nut bundle check in l2 fork ci test

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -1434,10 +1434,6 @@ jobs:
       - setup-features:
           features: <<parameters.features>>
       - run:
-          name: Check NUT bundle is up-to-date
-          command: just nut-bundle-check-no-build
-          working_directory: packages/contracts-bedrock
-      - run:
           name: Run L2 fork tests
           command: |
             mkdir -p results


### PR DESCRIPTION
**Description**
Removes duplicated nut bundle check in l2 fork test job.

This validation is already performed in [`packages/contracts-bedrock/checks.yaml`](https://github.com/ethereum-optimism/optimism/blob/75d7d012e7d60ac7b872ed666f759fb46798d28a/packages/contracts-bedrock/checks.yaml#L85).