### PR TITLE
fix(kona-proof-interop): only print missing chain IDs in rollup config warning

### DIFF
--- a/rust/kona/crates/proof/proof-interop/src/boot.rs
+++ b/rust/kona/crates/proof/proof-interop/src/boot.rs
@@ -127,10 +127,12 @@ impl BootInfo {
         {
             chain_ids.iter().map(|id| (*id, ROLLUP_CONFIGS[id].clone())).collect()
         } else {
+            let missing_ids: Vec<u64> =
+                chain_ids.into_iter().filter(|id| !ROLLUP_CONFIGS.contains_key(id)).collect();
             warn!(
                 target: "boot_loader",
                 "No rollup config found for chain IDs {:?}, falling back to preimage oracle. This is insecure in production without additional validation!",
-                chain_ids
+                missing_ids
             );
             let ser_cfg = oracle
                 .get(PreimageKey::new_local(L2_ROLLUP_CONFIG_KEY.to()))


### PR DESCRIPTION
Previously the warning logged all `chain_ids` when some were missing from `ROLLUP_CONFIG`. Now only the chain IDs not found in `ROLLUP_CONFIG` are printed.

resolves: https://github.com/ethereum-optimism/optimism-private/issues/437?issue=ethereum-optimism%7Coptimism-private%7C503