### PR TITLE
fix(kona): correct target-c-int-width from 64 to 32 in MIPS64 target spec

### DIFF
--- a/rust/kona/docker/cannon/mips64-unknown-none.json
+++ b/rust/kona/docker/cannon/mips64-unknown-none.json
@@ -5,7 +5,7 @@
   "data-layout": "E-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128",
   "target-endian": "big",
   "target-pointer-width": 64,
-  "target-c-int-width": 64,
+  "target-c-int-width": 32,
   "os": "none",
   "llvm-abiname": "n64",
   "features": "+soft-float,+mips64",

--- a/rust/kona/docker/fpvm-prestates/cannon-repro.dockerfile
+++ b/rust/kona/docker/fpvm-prestates/cannon-repro.dockerfile
@@ -37,6 +37,9 @@ ENV KONA_CUSTOM_CONFIGS=$KONA_CUSTOM_CONFIGS
 ENV KONA_CUSTOM_CONFIGS_DIR=/usr/local/kona-custom-configs
 
 # Build kona-client
+# Override the target spec baked into the cannon-builder image (which has
+# target-c-int-width: 64) with the corrected one from the source tree.
+COPY kona/docker/cannon/mips64-unknown-none.json /mips64-unknown-none.json
 RUN cd kona && \
   cargo build -Zbuild-std=core,alloc -Zjson-target-spec -p kona-client --bin $CLIENT_BIN --locked --profile release-client-lto && \
   mv ./target/mips64-unknown-none/release-client-lto/$CLIENT_BIN /kona-client-elf


### PR DESCRIPTION
## Summary

- Fix incorrect `target-c-int-width: 64` → `32` in the custom `mips64-unknown-none.json` target spec
- Override the baked-in target spec in `cannon-builder:v1.0.0` by copying the corrected version into the prestate build

## Problem

The custom MIPS64 target spec had `target-c-int-width: 64`, but the MIPS64 n64 ABI specifies C `int` as 32 bits. This caused LLVM to miscompile `str` equality comparisons — the conditional branch on the `memcmp` return value was eliminated, making `str == str` always evaluate to `false`. This broke all string comparisons including serde field name matching, which caused the `Failed to read chain list: missing field 'name'` panic in kona proofs.

References:
- [MIPSpro 64-Bit Porting Guide](https://math-atlas.sourceforge.net/devel/assembly/mipsabi64.pdf) — "64-bit pointer and long and 32-bit int"
- [MIPSpro N32 ABI Handbook](https://math-atlas.sourceforge.net/devel/assembly/007-2816-005.pdf) — int is 32 bits in both n32 and n64

## Changes

1. `mips64-unknown-none.json`: `target-c-int-width` 64 → 32
2. `cannon-repro.dockerfile`: COPY the corrected target spec over the one baked into `cannon-builder:v1.0.0`

The COPY override is needed because the pre-built `cannon-builder:v1.0.0` Docker image has the old target spec baked in at `/mips64-unknown-none.json`. A follow-up PR will build the cannon-builder from source instead of using a pre-built image, eliminating this workaround.

## Test plan

- [x] Minimal reproducer confirms fix: https://github.com/ajsutton/rust-mips64-str-miscompile
- [x] Assembly output shows correct `beqz` branch after `memcmp` with `target-c-int-width: 32`
- [x] Prestate built with fix runs `str == str` comparison correctly in cannon (exit code 0)
- [ ] Full kona prestate builds and passes `TestChallengerPlaysGame` in CI

## Investigation

- Issue: ethereum-optimism/optimism#19654
- Investigation notes: [Notion](https://www.notion.so/oplabs/32cf153ee1628022b957d071781c793a)

🤖 Generated with [Claude Code](https://claude.com/claude-code)