### PR TITLE
ci: Fix kona-prestate metadata file name

### DIFF
--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -1091,7 +1091,7 @@ jobs:
               echo "Publishing commit hash data"
               INFO_FILE=$(mktemp)
               (echo "Commit=<< pipeline.git.revision >>" && echo "Prestate: ${PRESTATE_HASH}") > "${INFO_FILE}"
-              gsutil cp "${INFO_FILE}" "gs://oplabs-network-data/proofs/kona/<<parameters.kind>>/${BRANCH_NAME}-<<parameters.version>>-prestate.bin.gz.txt"
+              gsutil cp "${INFO_FILE}" "gs://oplabs-network-data/proofs/kona/<<parameters.kind>>/${BRANCH_NAME}-<<parameters.version>>.bin.gz.txt"
               rm "${INFO_FILE}"
               PRESTATE_HASH="${BRANCH_NAME}-<<parameters.version>>"
             fi


### PR DESCRIPTION
**Description**

The metadata file when publishing prestates from branches should have the same name as the prestate with `.txt` appended but kona's upload was adding an extra `-prestate` so it wasn't being picked up by vm-runner.
