### PR TITLE
feat(op-alloy-evm): add `OpEvm::into_inner` method

### DIFF
--- a/rust/alloy-op-evm/src/lib.rs
+++ b/rust/alloy-op-evm/src/lib.rs
@@ -60,6 +60,13 @@ pub struct OpEvm<DB: Database, I, P = OpPrecompiles, Tx = OpTransaction<TxEnv>> 
 }
 
 impl<DB: Database, I, P, Tx> OpEvm<DB, I, P, Tx> {
+    /// Consumes self and return the inner EVM instance.
+    pub fn into_inner(
+        self,
+    ) -> op_revm::OpEvm<OpContext<DB>, I, EthInstructions<EthInterpreter, OpContext<DB>>, P> {
+        self.inner
+    }
+
     /// Provides a reference to the EVM context.
     pub const fn ctx(&self) -> &OpContext<DB> {
         &self.inner.0.ctx


### PR DESCRIPTION
**Description**

Add `TempoEvm::into_inner` method, like alloy_evm's [`EthEvm::into_inner`](https://docs.rs/alloy-evm/0.29.2/alloy_evm/eth/struct.EthEvm.html#method.into_inner).

**Tests**

This is just a getter.

**Additional context**

It will be useful in Foundry to access inner revm's EVM. See https://github.com/foundry-rs/foundry/pull/13908



