### PR TITLE
docs: add op-deployer upgrade/manage deprecation notice and update af…

### DIFF
--- a/docs/public-docs/chain-operators/tools/op-deployer/reference/custom-deployments.mdx
+++ b/docs/public-docs/chain-operators/tools/op-deployer/reference/custom-deployments.mdx
@@ -124,66 +124,12 @@ genesis and rollup config files.
 
 ## Upgrading
 
-You can upgrade between smart contract versions using the [`upgrade`](/chain-operators/tools/op-deployer/usage/upgrade) family of commands. As a prerequisite,
-you must deploy OPCMs for each version you want to upgrade between using the `bootstrap implementations` command.
-
-You will need to use the correct sub-command for the version you are upgrading from. For example, if you are
-upgrading from `v2.0.0` to `v3.0.0`, you will need to use the `upgrade v3.0.0` subcommand.
-
-Unlike the `bootstrap` and `apply` commands, the `upgrade` command does not interact with the chain directly. Instead,
-it generates calldata that you can use with `cast`, Gnosis SAFE, or whatever tooling you use to manage your L1.
-
-To run the upgrade command, use the following:
-
 <Warning>
-Upgrading between non-standard contract versions is not supported.
+The `upgrade` command in `op-deployer` is no longer maintained or supported. See the [deprecation notice](/notices/op-deployer-upgrade-deprecation) for details and migration guidance.
 </Warning>
 
-```shell
-op-deployer upgrade <version> \
-  --config <path to config JSON> \
-  --l1-rpc-url="<rpc url>"
-```
+The `upgrade` command in `op-deployer` has been deprecated. Migrate to the **OPCM upgrade interface** directly for managing chain upgrades. For documentation and guidance, see:
 
-The contents of your config JSON should look something like this:
-
-```json
-{
-  "prank": "<address of the contract that owns the chain - likely the same as the superchain owner>",
-  "opcm": "<address of new OPCM>",
-  "chainConfigs": [
-    {
-      "systemConfigProxy": "<address of the chain's system config proxy>",
-      "proxyAdmin": "<address of the chain's proxy admin>",
-      "absolutePrestate": "<32-byte hash of the chain's absolute prestate>"
-    }
-  ]
-}
-```
-
-You will get output that looks something like this:
-
-```json
-{
-  "to": "<maps to the prank address>",
-  "data": "<calldata>",
-  "value": "0x0"
-}
-```
-
-At this point, you will need to build a transaction that uses the calldata and calls the `upgrade()` method on the
-OPCM. The exact method you use to do this will depend on your tooling. As an example, you can craft a transaction
-for use with Gnosis SAFE CLI using the command below:
-
-<Info>
-The Gnosis SAFE UI does not support the `--delegate` flag, so the CLI is required if you're using a Gnosis SAFE.
-</Info>
-
-```shell
-safe-cli send-custom <owner SAFE address> <l1 rpc URL> <opcm address> 0 <calldata> --private-key <signer private key>
---delegate
-```
-
-Note that no matter which method you use to broadcast the calldata, the call to OPCM **must** come from the smart
-contract that owns the chain and the call must be via `DELEGATECALL`. If your upgrade command reverts, it is likely
-due to one of these conditions not being met.
+- [Deprecation notice](/notices/op-deployer-upgrade-deprecation) — full details on what's changing and who is affected
+- [OP Contracts Manager](/chain-operators/reference/opcm) — reference documentation
+- [OPCM specs](https://specs.optimism.io/experimental/op-contracts-manager.html) — technical specification

--- a/docs/public-docs/chain-operators/tools/op-deployer/usage/upgrade.mdx
+++ b/docs/public-docs/chain-operators/tools/op-deployer/usage/upgrade.mdx
@@ -1,63 +1,21 @@
 ---
 title: Upgrade Command
-description: Learn how to upgrade a chain from one version to another.
+description: The op-deployer upgrade command is deprecated. Use the OPCM upgrade interface directly.
 ---
 
-The `upgrade` command allows you to upgrade a chain from one version to another. It consists of several subcommands, one
-for each upgrade version. Think of it like a database migration: each upgrade command upgrades a chain from exactly
-one previous version to the next. A chain that is several versions behind can be upgrade to the latest version by
-running multiple `upgrade` commands in sequence.
-
-Unlike the `bootstrap` or `apply` commands, `upgrade` does not directly interact with the chain. Instead, it generates
-calldata. You can then use this calldata with `cast`, Gnosis SAFE, [`superchain-ops`](https://github.com/ethereum-optimism/superchain-ops), or whatever
-tooling you use to manage your L1.
-
 <Warning>
-Your chain **must** be owned by a smart contract for `upgrade` to work because the OPCM can only be called via
-`DELEGATECALL`.
+  The `upgrade` command in `op-deployer` is no longer maintained or supported. Do not rely on it for chain upgrades.
+  See the [deprecation notice](/notices/op-deployer-upgrade-deprecation) for details and migration guidance.
 </Warning>
 
-## Usage
+The `upgrade` command in `op-deployer` has been deprecated. OP Labs now uses the OPCM (OP Contracts Manager) directly for upgrade operations and will no longer develop this functionality within `op-deployer`.
 
-Use the `upgrade` command like this:
+`op-deployer` continues to be supported for **initial chain deployments only**.
 
-```shell
-op-deployer upgrade <version> \
-  --config <path to config JSON>
-```
+## What you should do
 
-Version `version` must be one of `v2.0.0` or `v3.0.0`.
+Migrate to the **OPCM upgrade interface** directly for managing your chain upgrades. For documentation and guidance, see:
 
-You can also provide an optional `--override-artifacts-url` flag if you want to point to a different set of artifacts
-from the default. Setting this flag is not recommended.
-
-The config file should look like this:
-
-```json
-{
-  "prank": "<address of the contract that owns the chain>",
-  "opcm": "<address of the chain's OPCM>",
-  "chainConfigs": [
-    {
-      "systemConfigProxy": "<address of the chain's system config proxy>",
-      "proxyAdmin": "<address of the chain's proxy admin>",
-      "absolutePrestate": "<32-byte hash of the chain's absolute prestate>"
-    }
-  ]
-}
-```
-
-You can specify multiple chains in the `chainConfigs` array. The CLI will generate calldata for all chains you
-specify. Note that all of these chains must be upgradeable using the provided OPCM and `prank` address.
-
-The `upgrade` command will provide the following output:
-
-```json
-{
-  "to": "<maps to the prank address>",
-  "data": "<calldata>",
-  "value": "0x0"
-}
-```
-
-You can then use the `data` field in the `to` field as input to `cast` or other tools.
+- [Deprecation notice](/notices/op-deployer-upgrade-deprecation) — full details on what's changing and who is affected
+- [OP Contracts Manager](/chain-operators/reference/opcm) — reference documentation
+- [OPCM specs](https://specs.optimism.io/experimental/op-contracts-manager.html) — technical specification

--- a/docs/public-docs/chain-operators/tutorials/l1-contract-upgrades/op-deployer-upgrade.mdx
+++ b/docs/public-docs/chain-operators/tutorials/l1-contract-upgrades/op-deployer-upgrade.mdx
@@ -1,70 +1,21 @@
 ---
 title: Upgrade L1 contracts using op-deployer
-description: Learn about how to upgrade smart contracts using op-deployer
+description: The op-deployer upgrade command is deprecated. Use the OPCM upgrade interface directly.
 ---
 
-[`op-deployer`](/chain-operators/tools/op-deployer/overview) simplifies the process of deploying and upgrading the OP Stack. Using the `upgrade` command, you can upgrade a chain from one version to the next.
+<Warning>
+  The `upgrade` command in `op-deployer` is no longer maintained or supported. This tutorial is outdated.
+  See the [deprecation notice](/notices/op-deployer-upgrade-deprecation) for details and migration guidance.
+</Warning>
 
-It consists of several subcommands, one for each upgrade version. Think of it like a database migration: each upgrade command upgrades a chain from exactly one previous version to the next. A chain that is several versions behind can be upgraded to the latest version by running multiple upgrade commands in sequence.
+The `upgrade` command in `op-deployer` has been deprecated. OP Labs now uses the OPCM (OP Contracts Manager) directly for upgrade operations and will no longer develop this functionality within `op-deployer`.
 
-Unlike the bootstrap or apply commands, upgrade does not directly interact with the chain. Instead, it generates calldata. You can then use this calldata with cast, Gnosis SAFE, or whatever tooling you use to manage your L1.
+`op-deployer` continues to be supported for **initial chain deployments only**.
 
-## Limitations of `upgrade`
+## What you should do
 
-There are a few limitations to `upgrade`:
+Migrate to the **OPCM upgrade interface** directly for managing your chain upgrades. For documentation and guidance, see:
 
-Using the standard OP Contracts Manager currently requires you to be using the standard shared SuperchainConfig contract. If you're not using this, you will need to utilize the `bootstrap` command to deploy your own Superchain target, including your own `opcm` instance.
-
-## Using `upgrade`
-
-<Steps>
-  <Step title="Install `op-deployer`">
-  [Install `op-deployer`](/operators/chain-operators/tools/op-deployer#installation) from source or pre-built binary.
-  </Step>
-
-  <Step title="Create a `config.json` file">
-  Create a `config.json` file using the following example:
-  
-    ```json
-    {
-      "prank": "<address of the contract of the L1 ProxyAdmin owner>",
-      "opcm": "<address of the chain's OPCM>",
-      "chainConfigs": [
-        {
-          "systemConfigProxy": "<address of the chain's system config proxy>",
-          "proxyAdmin": "<address of the chain's proxy admin>",
-          "absolutePrestate": "<32-byte hash of the chain's absolute prestate>"
-        }
-      ]
-    }
-    ```
-  
-    The standard OPCM instances (`opcm` in the example above) and absolute prestates (`absolutePrestate`) are found in the superchain registry:
-  
-    *   `opcm`: under `op_contracts_manager` for [Mainnet](https://github.com/ethereum-optimism/superchain-registry/blob/main/validation/standard/standard-versions-mainnet.toml) and [Sepolia](https://github.com/ethereum-optimism/superchain-registry/blob/main/validation/standard/standard-versions-sepolia.toml).
-    *   `absolutePrestate`: the `hash` under your [chosen upgrade](https://github.com/ethereum-optimism/superchain-registry/blob/main/validation/standard/standard-prestates.toml)
-  </Step>
-
-  <Step title="Generate calldata">
-  Run the following command:
-  
-    ```bash
-    op-deployer upgrade <version> \
-      --config <path to config JSON>
-    ```
-  
-    `version` must be either major release `2.0` or higher.
-  
-    The output should look like:
-  
-    ```json
-    {
-      "to": "<maps to the prank address>",
-      "data": "<calldata>",
-      "value": "0x0"
-    }
-    ```
-  
-    Now you have the calldata that can be executed onchain to perform the L1 contract upgrade. You should simulate this upgrade and make sure the changes are expected. You can reference the validation files of previously executed upgrade tasks in the [superchain-ops repo](https://github.com/ethereum-optimism/superchain-ops/blob/main/tasks/eth/022-holocene-fp-upgrade/NestedSignFromJson.s.sol) to see what the expected changes are. Once you're confident the state changes are expected, you can sign and execute the upgrade.
-  </Step>
-</Steps>
+- [Deprecation notice](/notices/op-deployer-upgrade-deprecation) — full details on what's changing and who is affected
+- [OP Contracts Manager](/chain-operators/reference/opcm) — reference documentation
+- [OPCM specs](https://specs.optimism.io/experimental/op-contracts-manager.html) — technical specification

--- a/docs/public-docs/docs.json
+++ b/docs/public-docs/docs.json
@@ -2366,6 +2366,7 @@
             "group": "Notices",
             "pages": [
               "notices/op-geth-deprecation",
+              "notices/op-deployer-upgrade-deprecation",
               {
                 "group": "Archive",
                 "pages": [

--- a/docs/public-docs/notices/op-deployer-upgrade-deprecation.mdx
+++ b/docs/public-docs/notices/op-deployer-upgrade-deprecation.mdx
@@ -1,0 +1,46 @@
+---
+title: Deprecation Notice: op-deployer upgrade and manage functionality
+description: The upgrade and manage commands in op-deployer are no longer maintained. Use the OPCM upgrade interface directly to manage chain upgrades.
+lang: en-US
+content_type: notice
+topic: op-deployer-upgrade-deprecation
+personas:
+  - chain-operator
+categories:
+  - infrastructure
+is_imported_content: 'false'
+---
+
+We are deprecating the `upgrade` and `manage` commands in `op-deployer`. These commands will no longer be maintained or supported.
+
+## What's changing
+
+OP Labs uses the OPCM (OP Contracts Manager) for upgrade and chain management operations, and will no longer be developing this functionality within `op-deployer`.
+
+`op-deployer` will continue to be supported for **initial chain deployments only**. The `upgrade` and `manage` commands are no longer under active development and will not receive further updates or support.
+
+## Who is affected
+
+RaaS providers and any operators currently using `op-deployer` for upgrades or chain management.
+
+## What you should do
+
+Migrate to the **OPCM upgrade interface** directly for managing your chain upgrades.
+
+OPCM is a contract that deploys and upgrades the L1 contracts for an OP Stack chain. As of [Upgrade 13](https://gov.optimism.io/t/upgrade-proposal-13-opcm-and-incident-response-improvements/9739), OPCM instances support upgrading existing OP Stack chains.
+
+<Warning>
+  The `upgrade` and `manage` commands in `op-deployer` are no longer maintained. Do not rely on them for future chain upgrades or chain management.
+</Warning>
+
+For documentation and guidance on using OPCM directly, see:
+
+- [OP Contracts Manager](/chain-operators/reference/opcm) — reference documentation
+- [OPCM specs](https://specs.optimism.io/experimental/op-contracts-manager.html) — technical specification
+- [OPCM design document](https://github.com/ethereum-optimism/design-docs/blob/main/protocol/op-contracts-manager-arch.md) — architecture and design
+
+## Resources
+
+- [OP Contracts Manager reference](/chain-operators/reference/opcm)
+- [OPCM specs](https://specs.optimism.io/experimental/op-contracts-manager.html)
+- [op-deployer overview](/chain-operators/tools/op-deployer/overview)


### PR DESCRIPTION
Adds a new notice page announcing that the `upgrade` and `manage` commands in op-deployer are deprecated and no longer maintained. Updates all pages that previously documented these commands to redirect users to the deprecation notice and OPCM upgrade interface.