### PR TITLE
ci: skip rust gate and devnet workflows for docs-only PRs

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -3078,7 +3078,9 @@ workflows:
   devnet-metrics-collect:
     when:
       or:
-        - equal: [<< pipeline.trigger_source >>, "webhook"]
+        - and:
+            - equal: [<< pipeline.trigger_source >>, "webhook"]
+            - << pipeline.parameters.c-non_docs_changes >>
         - and:
             - equal: [true, << pipeline.parameters.c-devnet-metrics-collect >>]
             - equal: [<< pipeline.trigger_source >>, "api"]

--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -1289,6 +1289,7 @@ workflows:
       and:
         - equal: ["webhook", << pipeline.trigger_source >>]
         - not: << pipeline.parameters.c-rust_changes_detected >>
+        - << pipeline.parameters.c-non_docs_changes >>
     jobs:
       - rust-ci-cargo-tests:
           name: rust-tests

--- a/.circleci/continue/rust-e2e.yml
+++ b/.circleci/continue/rust-e2e.yml
@@ -386,6 +386,7 @@ workflows:
       and:
         - equal: ["webhook", << pipeline.trigger_source >>]
         - not: << pipeline.parameters.c-rust_changes_detected >>
+        - << pipeline.parameters.c-non_docs_changes >>
     jobs:
       - contracts-bedrock-build:
           build_args: --skip test


### PR DESCRIPTION
## Summary

The `rust-ci-gate-short`, `rust-e2e-gate-skip`, and `devnet-metrics-collect` workflows were not gated on the `c-non_docs_changes` parameter. This caused them to run on docs-only PRs:

- **rust-ci-gate-short / rust-e2e-gate-skip**: These fire when `c-rust_changes_detected` is false, which is true for docs-only PRs. They ran `rust-tests`, `op-reth-*`, `kona-build-*`, `contracts-bedrock-build`, and `kona-proof-action-single` unnecessarily.
- **devnet-metrics-collect**: Had no path filtering — ran on every webhook trigger.

Adds `c-non_docs_changes` to all three workflow conditions so they are skipped alongside the main workflow for docs-only changes. None of the jobs in these workflows are required status checks, so skipping them does not block merge.

## Test plan

- [ ] Verify this PR's own CI run — the gate-skip workflows should still fire since `.circleci/` is a non-docs path
- [ ] Push a docs-only change and confirm the rust gate-skip and devnet-metrics workflows no longer trigger


🤖 Generated with [Claude Code](https://claude.com/claude-code)