### PR TITLE
feat(op-devstack): use EIP-7702 SetCode for OPCM migration delegatecalls

### DIFF
--- a/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
+++ b/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
@@ -395,7 +395,7 @@ func RunTraceExtensionActivationTest(t devtest.T, sys *presets.SimpleInterop) {
 	t.Require().Len(chains, 2, "expected exactly 2 interop chains")
 
 	endTimestamp := uint64(time.Now().Unix())
-	sys.SuperRoots.AwaitValidatedTimestamp(endTimestamp)
+	sys.SuperRoots.AwaitValidatedTimestamp(endTimestamp + 1)
 	l1Head := latestRequiredL1(sys.SuperRoots.SuperRootAtTimestamp(endTimestamp + 1))
 
 	startTimestamp := endTimestamp - 1

--- a/op-devstack/sysgo/add_game_type.go
+++ b/op-devstack/sysgo/add_game_type.go
@@ -12,7 +12,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/artifacts"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/manage"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
-	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
 	op_service "github.com/ethereum-optimism/optimism/op-service"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/retry"
@@ -124,8 +123,6 @@ func addGameTypeForRuntime(
 		SaltMixer:               fmt.Sprintf("devstack-%s-%s", l2Net.ChainID(), absolutePrestate.Hex()),
 	}
 
-	opChainProxyAdmin := l2Net.deployment.ProxyAdminAddr()
-
 	_, addGameTypeCalldata, err := manage.AddGameType(t.Ctx(), cfg)
 	require.NoError(err, "failed to create add game type calldata")
 	require.Len(addGameTypeCalldata, 1, "calldata must contain one entry")
@@ -133,26 +130,9 @@ func addGameTypeForRuntime(
 	chainOps := devkeys.ChainOperatorKeys(l1ChainID.ToBig())
 	l1PAOKey, err := keys.Secret(chainOps(devkeys.L1ProxyAdminOwnerRole))
 	require.NoError(err, "failed to get l1 proxy admin owner key")
-	transactOpts, err := bind.NewKeyedTransactorWithChainID(l1PAOKey, l1ChainID.ToBig())
-	require.NoError(err, "must have transact opts")
-	transactOpts.Context = t.Ctx()
 
-	t.Log("Deploying delegate call proxy contract")
-	delegateCallProxy, proxyContract := deployDelegateCallProxy(t, transactOpts, client, l1PAO)
-	// transfer ownership to the proxy so that we can delegatecall the opcm
-	transferOwnership(t, l1PAOKey, client, opChainProxyAdmin, delegateCallProxy)
-	dgf := l2Net.deployment.DisputeGameFactoryProxyAddr()
-	transferOwnership(t, l1PAOKey, client, dgf, delegateCallProxy)
-
-	t.Log("sending opcm.addGameType transaction")
-	tx, err := proxyContract.ExecuteDelegateCall(transactOpts, l2Net.opcmImpl, addGameTypeCalldata[0].Data)
-	require.NoError(err, "failed to send add game type tx")
-	_, err = wait.ForReceiptOK(t.Ctx(), client, tx.Hash())
-	require.NoError(err, "failed to wait for add game type receipt")
-
-	// reset ProxyAdmin ownership transfers
-	transferOwnershipForDelegateCallProxy(t, l1ChainID.ToBig(), l1PAOKey, client, delegateCallProxy, opChainProxyAdmin, l1PAO)
-	transferOwnershipForDelegateCallProxy(t, l1ChainID.ToBig(), l1PAOKey, client, delegateCallProxy, dgf, l1PAO)
+	t.Log("Executing opcm.addGameType via SetCode delegatecall")
+	delegateCallWithSetCode(t, l1PAOKey, client, l2Net.opcmImpl, addGameTypeCalldata[0].Data)
 }
 
 func PrestateForGameType(t devtest.CommonT, gameType gameTypes.GameType) common.Hash {

--- a/op-devstack/sysgo/superroot.go
+++ b/op-devstack/sysgo/superroot.go
@@ -10,23 +10,23 @@ import (
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
-	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts/gameargs"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-e2e/bindings"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/contracts/bindings/delegatecallproxy"
-	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/transactions"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
 	"github.com/ethereum-optimism/optimism/op-service/dial"
-	"github.com/ethereum-optimism/optimism/op-service/errutil"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/retry"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
-	"github.com/ethereum-optimism/optimism/op-service/txmgr"
+	"github.com/ethereum-optimism/optimism/op-service/txplan"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/lmittmann/w3"
 	w3eth "github.com/lmittmann/w3/module/eth"
@@ -54,6 +54,63 @@ func deployDelegateCallProxy(t devtest.CommonT, transactOpts *bind.TransactOpts,
 	_, err = wait.ForReceiptOK(t.Ctx(), client, tx.Hash())
 	t.Require().NoError(err, "DelegateCallProxy deployment tx was not included successfully")
 	return deployAddress, proxyContract
+}
+
+// delegateCallWithSetCode executes a delegatecall to target with the given data
+// by delegating the sender's code to a DelegateCallProxy via EIP-7702 SetCode.
+// The sender EOA temporarily gets DelegateCallProxy code, calls executeDelegateCall
+// on itself, and the target runs via delegatecall in the sender's context.
+// This avoids transferring ownership of contracts to a temporary proxy.
+//
+// Uses txplan for nonce management, gas pricing, signing, and retry — the same
+// infrastructure that dsl.EOA.PlanAuth uses, without requiring a dsl.EOA.
+func delegateCallWithSetCode(
+	t devtest.CommonT,
+	privateKey *ecdsa.PrivateKey,
+	client *ethclient.Client,
+	target common.Address,
+	data []byte,
+) {
+	require := t.Require()
+	ctx := t.Ctx()
+	sender := crypto.PubkeyToAddress(privateKey.PublicKey)
+
+	// Deploy DelegateCallProxy as code reference for SetCode delegation
+	chainID, err := client.ChainID(ctx)
+	require.NoError(err)
+	transactOpts, err := bind.NewKeyedTransactorWithChainID(privateKey, chainID)
+	require.NoError(err)
+	transactOpts.Context = ctx
+	proxyAddr, _ := deployDelegateCallProxy(t, transactOpts, client, sender)
+
+	// Encode executeDelegateCall(target, data) calldata
+	proxyABI, err := delegatecallproxy.DelegatecallproxyMetaData.GetAbi()
+	require.NoError(err)
+	calldata, err := proxyABI.Pack("executeDelegateCall", target, data)
+	require.NoError(err)
+
+	// Build a SetCode tx using txplan — same options PlanAuth uses,
+	// plus the delegatecall payload as tx data.
+	toAddr := sender
+	tx := txplan.NewPlannedTx(
+		txplan.WithChainID(client),
+		txplan.WithPrivateKey(privateKey),
+		txplan.WithPendingNonce(client),
+		txplan.WithAgainstLatestBlockEthClient(client),
+		txplan.WithType(types.SetCodeTxType),
+		txplan.WithTo(&toAddr),
+		txplan.WithAuthorizationTo(proxyAddr),
+		txplan.WithData(calldata),
+		// Fixed gas limit because eth_estimateGas doesn't handle EIP-7702 authorizations.
+		// Use the EIP-7825 max transaction gas limit to give the migration maximum room.
+		txplan.WithGasLimit(params.MaxTxGas),
+		txplan.WithRetrySubmission(client, 5, retry.Exponential()),
+		txplan.WithRetryInclusion(client, 5, retry.Exponential()),
+	)
+
+	receipt, err := tx.Included.Eval(ctx)
+	require.NoError(err)
+	require.Equal(types.ReceiptStatusSuccessful, receipt.Status, "delegatecall via SetCode failed")
 }
 
 func awaitSuperrootTime(t devtest.T, cls ...L2CLNode) uint64 {
@@ -146,12 +203,6 @@ func migrateSuperRoots(
 	client := ethclient.NewClient(rpcClient)
 	w3Client := w3.NewClient(rpcClient)
 
-	l1pao, err := keys.Address(devkeys.ChainOperatorKeys(l1ChainID.ToBig())(devkeys.L1ProxyAdminOwnerRole))
-	require.NoError(err, "must have L1 proxy admin owner private key")
-
-	superchainProxyAdmin := getProxyAdmin(t, w3Client, migration.superchainConfigAddr)
-	require.NotEmpty(superchainProxyAdmin, "superchain proxy admin address is empty")
-
 	useV2 := isOPCMV2(t, w3Client, migration.opcmImpl)
 	absoluteCannonPrestate := getInteropCannonAbsolutePrestate(t)
 	absoluteCannonKonaPrestate := getInteropCannonKonaAbsolutePrestate(t)
@@ -163,9 +214,7 @@ func migrateSuperRoots(
 	require.NoError(err, "must have configured challenger")
 
 	var opChainConfigs []bindings.OPContractsManagerOpChainConfig
-	var l2ChainIDs []eth.ChainID
-	for l2ChainID, l2Deployment := range migration.l2Deployments {
-		l2ChainIDs = append(l2ChainIDs, l2ChainID)
+	for _, l2Deployment := range migration.l2Deployments {
 		opChainConfigs = append(opChainConfigs, bindings.OPContractsManagerOpChainConfig{
 			SystemConfigProxy:  l2Deployment.SystemConfigProxyAddr(),
 			CannonPrestate:     absoluteCannonPrestate,
@@ -227,32 +276,9 @@ func migrateSuperRoots(
 
 	l1PAOKey, err := keys.Secret(devkeys.ChainOperatorKeys(l1ChainID.ToBig())(devkeys.L1ProxyAdminOwnerRole))
 	require.NoError(err, "must have configured L1 proxy admin owner")
-	transactOpts, err := bind.NewKeyedTransactorWithChainID(l1PAOKey, l1ChainID.ToBig())
-	require.NoError(err, "must have transact opts")
-	transactOpts.Context = t.Ctx()
 
-	t.Log("Deploying delegate call proxy contract")
-	delegateCallProxy, proxyContract := deployDelegateCallProxy(t, transactOpts, client, l1pao)
-	oldSuperchainProxyAdminOwner := getOwner(t, w3Client, superchainProxyAdmin)
-	transferOwnership(t, l1PAOKey, client, superchainProxyAdmin, delegateCallProxy)
-
-	oldDisputeGameFactories := make(map[eth.ChainID]common.Address)
-	for i, opChainConfig := range opChainConfigs {
-		var portal common.Address
-		require.NoError(w3Client.Call(w3eth.CallFunc(opChainConfig.SystemConfigProxy, optimismPortalFn).Returns(&portal)))
-		portalProxyAdmin := getProxyAdmin(t, w3Client, portal)
-		transferOwnership(t, l1PAOKey, client, portalProxyAdmin, delegateCallProxy)
-
-		dgf := getDisputeGameFactory(t, w3Client, portal)
-		transferOwnership(t, l1PAOKey, client, dgf, delegateCallProxy)
-		oldDisputeGameFactories[l2ChainIDs[i]] = dgf
-	}
-
-	t.Log("Executing delegate call")
-	migrateTx, err := proxyContract.ExecuteDelegateCall(transactOpts, migration.opcmImpl, migrateCallData)
-	require.NoErrorf(err, "migrate delegatecall failed: %v", errutil.TryAddRevertReason(err))
-	_, err = wait.ForReceiptOK(t.Ctx(), client, migrateTx.Hash())
-	require.NoError(err)
+	t.Log("Executing OPCM migration via SetCode delegatecall")
+	delegateCallWithSetCode(t, l1PAOKey, client, migration.opcmImpl, migrateCallData)
 
 	var sharedDGF common.Address
 	for _, l2Deployment := range migration.l2Deployments {
@@ -265,30 +291,6 @@ func migrateSuperRoots(
 		}
 	}
 	require.NotEmpty(getSuperGameImpl(t, w3Client, sharedDGF))
-
-	resetOwnershipAfterMigration(
-		t,
-		keys,
-		l1ChainID.ToBig(),
-		l1PAOKey,
-		w3Client,
-		client,
-		delegateCallProxy,
-		opChainConfigs,
-	)
-	resetOldDisputeGameFactoriesAfterMigration(
-		t,
-		keys,
-		l1ChainID.ToBig(),
-		l1PAOKey,
-		client,
-		delegateCallProxy,
-		oldDisputeGameFactories,
-	)
-	transferOwnershipForDelegateCallProxy(t, l1ChainID.ToBig(), l1PAOKey, client, delegateCallProxy, superchainProxyAdmin, oldSuperchainProxyAdminOwner)
-
-	superchainProxyAdminOwner := getOwner(t, w3Client, superchainProxyAdmin)
-	require.Equal(oldSuperchainProxyAdminOwner, superchainProxyAdminOwner, "superchain proxy admin owner is not the L1PAO")
 
 	for chainID, l2Deployment := range migration.l2Deployments {
 		l2Deployment.disputeGameFactoryProxy = sharedDGF
@@ -325,23 +327,14 @@ func getAbsolutePrestate(t devtest.CommonT, prestatePath string) common.Hash {
 }
 
 const (
-	superCannonGameType       = 4
-	superPermissionedGameType = 5
+	superCannonGameType = 4
 )
 
 var (
-	optimismPortalFn      = w3.MustNewFunc("optimismPortal()", "address")
-	disputeGameFactoryFn  = w3.MustNewFunc("disputeGameFactory()", "address")
-	gameImplsFn           = w3.MustNewFunc("gameImpls(uint32)", "address")
-	gameArgsFn            = w3.MustNewFunc("gameArgs(uint32)", "bytes")
-	ownerFn               = w3.MustNewFunc("owner()", "address")
-	proxyAdminFn          = w3.MustNewFunc("proxyAdmin()", "address")
-	adminFn               = w3.MustNewFunc("admin()", "address")
-	proxyAdminOwnerFn     = w3.MustNewFunc("proxyAdminOwner()", "address")
-	ethLockboxFn          = w3.MustNewFunc("ethLockbox()", "address")
-	anchorStateRegistryFn = w3.MustNewFunc("anchorStateRegistry()", "address")
-	transferOwnershipFn   = w3.MustNewFunc("transferOwnership(address)", "")
-	versionFn             = w3.MustNewFunc("version()", "string")
+	optimismPortalFn     = w3.MustNewFunc("optimismPortal()", "address")
+	disputeGameFactoryFn = w3.MustNewFunc("disputeGameFactory()", "address")
+	gameImplsFn          = w3.MustNewFunc("gameImpls(uint32)", "address")
+	versionFn            = w3.MustNewFunc("version()", "string")
 )
 
 // isOPCMV2 is a helper function that checks the OPCM version and returns true if it is at least 7.0.0
@@ -376,172 +369,4 @@ func getSuperGameImpl(t devtest.CommonT, client *w3.Client, dgf common.Address) 
 	return addr
 }
 
-func getOwner(t devtest.CommonT, client *w3.Client, addr common.Address) common.Address {
-	var owner common.Address
-	err := client.Call(w3eth.CallFunc(addr, ownerFn).Returns(&owner))
-	t.Require().NoError(err)
-	return owner
-}
 
-func getAdmin(t devtest.CommonT, client *w3.Client, addr common.Address) common.Address {
-	var admin common.Address
-	err := client.Call(w3eth.CallFunc(addr, adminFn).Returns(&admin))
-	t.Require().NoError(err)
-	return admin
-}
-
-func getProxyAdminOwner(t devtest.CommonT, client *w3.Client, addr common.Address) common.Address {
-	var proxyAdminOwner common.Address
-	err := client.Call(w3eth.CallFunc(addr, proxyAdminOwnerFn).Returns(&proxyAdminOwner))
-	t.Require().NoError(err)
-	return proxyAdminOwner
-}
-
-func getProxyAdmin(t devtest.CommonT, client *w3.Client, addr common.Address) common.Address {
-	var proxyAdmin common.Address
-	err := client.Call(w3eth.CallFunc(addr, proxyAdminFn).Returns(&proxyAdmin))
-	t.Require().NoError(err)
-	return proxyAdmin
-}
-
-func transferOwnership(t devtest.CommonT, privateKey *ecdsa.PrivateKey, client *ethclient.Client, l1ProxyAdmin common.Address, newOwner common.Address) {
-	data, err := transferOwnershipFn.EncodeArgs(newOwner)
-	t.Require().NoError(err)
-
-	candidate := txmgr.TxCandidate{
-		To:       &l1ProxyAdmin,
-		TxData:   data,
-		GasLimit: 1_000_000,
-	}
-	_, receipt, err := transactions.SendTx(t.Ctx(), client, candidate, privateKey)
-	t.Require().NoErrorf(err, "transferOwnership failed: %v", errutil.TryAddRevertReason(err))
-	t.Require().Equal(receipt.Status, types.ReceiptStatusSuccessful, "transferOwnership failed")
-}
-
-func transferOwnershipForDelegateCallProxy(
-	t devtest.CommonT,
-	transactChainID *big.Int,
-	privateKey *ecdsa.PrivateKey,
-	client *ethclient.Client,
-	delegateCallProxy common.Address,
-	proxyAdminOwned common.Address,
-	newOwner common.Address,
-) {
-	transactOpts, err := bind.NewKeyedTransactorWithChainID(privateKey, transactChainID)
-	t.Require().NoError(err, "must have transact opts")
-	transactOpts.Context = t.Ctx()
-
-	abi, err := delegatecallproxy.DelegatecallproxyMetaData.GetAbi()
-	t.Require().NoError(err, "failed to get abi")
-	contract := batching.NewBoundContract(abi, delegateCallProxy)
-	call := contract.Call("transferOwnership", proxyAdminOwned, newOwner)
-	data, err := call.Pack()
-	t.Require().NoError(err)
-
-	candidate := txmgr.TxCandidate{
-		To:       &delegateCallProxy,
-		TxData:   data,
-		GasLimit: 1_000_000,
-	}
-	_, receipt, err := transactions.SendTx(t.Ctx(), client, candidate, privateKey)
-	t.Require().NoErrorf(err, "transferOwnership failed: %v", errutil.TryAddRevertReason(err))
-	t.Require().Equal(receipt.Status, types.ReceiptStatusSuccessful, "transferOwnership failed")
-}
-
-func resetOwnershipAfterMigration(
-	t devtest.CommonT,
-	keys devkeys.Keys,
-	l1ChainID *big.Int,
-	ownerPrivateKey *ecdsa.PrivateKey,
-	w3Client *w3.Client,
-	client *ethclient.Client,
-	delegateCallProxy common.Address,
-	opChainConfigs []bindings.OPContractsManagerOpChainConfig,
-) {
-	l1PAO, err := keys.Address(devkeys.ChainOperatorKeys(l1ChainID)(devkeys.L1ProxyAdminOwnerRole))
-	t.Require().NoError(err, "must have L1 proxy admin owner private key")
-
-	portal0 := getOptimismPortal(t, w3Client, opChainConfigs[0].SystemConfigProxy)
-	sharedDGF := getDisputeGameFactory(t, w3Client, portal0)
-	transferOwnershipForDelegateCallProxy(
-		t,
-		l1ChainID,
-		ownerPrivateKey,
-		client,
-		delegateCallProxy,
-		sharedDGF,
-		l1PAO,
-	)
-
-	var sharedEthLockboxProxy common.Address
-	err = w3Client.Call(w3eth.CallFunc(portal0, ethLockboxFn).Returns(&sharedEthLockboxProxy))
-	t.Require().NoError(err)
-	proxyAdmin := getAdmin(t, w3Client, sharedEthLockboxProxy)
-	transferOwnershipForDelegateCallProxy(
-		t,
-		l1ChainID,
-		ownerPrivateKey,
-		client,
-		delegateCallProxy,
-		proxyAdmin,
-		l1PAO,
-	)
-
-	for _, cfg := range opChainConfigs {
-		portal := getOptimismPortal(t, w3Client, cfg.SystemConfigProxy)
-		portalProxyAdmin := getProxyAdmin(t, w3Client, portal)
-		if getOwner(t, w3Client, portalProxyAdmin) == delegateCallProxy {
-			transferOwnershipForDelegateCallProxy(
-				t,
-				l1ChainID,
-				ownerPrivateKey,
-				client,
-				delegateCallProxy,
-				portalProxyAdmin,
-				l1PAO,
-			)
-		}
-	}
-
-	var sharedAnchorStateRegistryProxy common.Address
-	err = w3Client.Call(w3eth.CallFunc(portal0, anchorStateRegistryFn).Returns(&sharedAnchorStateRegistryProxy))
-	t.Require().NoError(err)
-	asrAAdminOwner := getProxyAdminOwner(t, w3Client, sharedAnchorStateRegistryProxy)
-	t.Require().Equal(l1PAO, asrAAdminOwner, "sharedAnchorStateRegistryProxy proxy admin owner is not the L1PAO")
-
-	gameTypes := []uint32{superPermissionedGameType, superCannonGameType}
-	for _, gameType := range gameTypes {
-		var gameArgsBytes []byte
-		err = w3Client.Call(w3eth.CallFunc(sharedDGF, gameArgsFn, gameType).Returns(&gameArgsBytes))
-		t.Require().NoError(err)
-		gameArgs, err := gameargs.Parse(gameArgsBytes)
-		t.Require().NoErrorf(err, "invalid game args for gameType %d", gameType)
-		wethAdminOwner := getProxyAdminOwner(t, w3Client, gameArgs.Weth)
-		t.Require().Equal(l1PAO, wethAdminOwner, "wethProxy proxy admin owner is not the L1PAO")
-	}
-}
-
-func resetOldDisputeGameFactoriesAfterMigration(
-	t devtest.CommonT,
-	keys devkeys.Keys,
-	l1ChainID *big.Int,
-	ownerPrivateKey *ecdsa.PrivateKey,
-	client *ethclient.Client,
-	delegateCallProxy common.Address,
-	oldDisputeGameFactories map[eth.ChainID]common.Address,
-) {
-	for l2ChainID, oldDGF := range oldDisputeGameFactories {
-		chainOpsForL2 := devkeys.ChainOperatorKeys(l2ChainID.ToBig())
-		l1PAOForL2, err := keys.Address(chainOpsForL2(devkeys.L1ProxyAdminOwnerRole))
-		t.Require().NoError(err, "must have configured L1 proxy admin owner private key")
-		transferOwnershipForDelegateCallProxy(
-			t,
-			l1ChainID,
-			ownerPrivateKey,
-			client,
-			delegateCallProxy,
-			oldDGF,
-			l1PAOForL2,
-		)
-	}
-}

--- a/op-devstack/sysgo/superroot.go
+++ b/op-devstack/sysgo/superroot.go
@@ -368,5 +368,3 @@ func getSuperGameImpl(t devtest.CommonT, client *w3.Client, dgf common.Address) 
 	t.Require().NoError(err)
 	return addr
 }
-
-


### PR DESCRIPTION
## Summary

- Replace DelegateCallProxy deploy-transfer-execute-restore pattern with EIP-7702 SetCode in `migrateSuperRoots` and `addGameTypeForRuntime`
- The L1PAO EOA temporarily adopts DelegateCallProxy code via SetCode, calls `executeDelegateCall` on itself — no ownership transfers needed
- Reduces transaction count from ~5+5N to 2 per invocation (1 deploy + 1 SetCode tx)
- Deletes 7 functions, 7 w3 variables, 4 imports (~195 lines of ownership transfer/restoration code)
- New `delegateCallWithSetCode` helper uses `txplan` for nonce, gas, signing, and retry (same infra as `dsl.EOA.PlanAuth`)

## Test plan

- [ ] `go build ./op-devstack/...` passes clean ✅
- [ ] `go vet ./op-devstack/...` passes clean ✅
- [ ] `TestInteropFaultProofs_InvalidBlock` and other interop proof tests pass (exercises `migrateSuperRoots`)
- [ ] Tests exercising `addGameTypeForRuntime` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

fixes https://github.com/ethereum-optimism/optimism/issues/19760