### PR TITLE
fix: wire --txpool.nolocals config

### DIFF
--- a/rust/op-reth/crates/node/src/node.rs
+++ b/rust/op-reth/crates/node/src/node.rs
@@ -1000,6 +1000,7 @@ where
                 .set_tx_fee_cap(ctx.config().rpc.rpc_tx_fee_cap)
                 .with_max_tx_gas_limit(ctx.config().txpool.max_tx_gas_limit)
                 .with_minimum_priority_fee(ctx.config().txpool.minimum_priority_fee)
+                .with_local_transactions_config(ctx.pool_config().local_transactions_config.clone())
                 .with_additional_tasks(
                     pool_config_overrides
                         .additional_validation_tasks


### PR DESCRIPTION
## Description                                                                                                                                                                               
                                                                                                                                                                                             
  Fix `--txpool.nolocals` being silently ignored by the transaction validator, causing `--txpool.minimum-priority-fee` to have no effect on RPC-submitted transactions.                        
                                                                                                                                                                                               
  `OpPoolBuilder::build_pool()` wires several txpool config fields into `EthTransactionValidatorBuilder` — `max_tx_input_bytes`, `max_tx_gas_limit`, `minimum_priority_fee` — but was missing  
  `local_transactions_config`. The builder defaults to `LocalTransactionConfig { no_exemptions: false }`, meaning transactions submitted via `eth_sendRawTransaction` are always treated as  
  local (`TransactionOrigin::Local`), bypassing the `minimum_priority_fee` check regardless of `--txpool.nolocals`.                                                                            
                                                                                                                                                                                             
  Fix: call `.with_local_transactions_config(ctx.pool_config().local_transactions_config.clone())` in the validator builder chain so `--txpool.nolocals` is respected by the validator.

  ## Tests

  Manually verified with `cast send --priority-gas-price 1gwei` against a node configured with `--txpool.nolocals --txpool.minimum-priority-fee=20000000000`. Before fix: transaction included.
   After fix: transaction rejected with `PriorityFeeBelowMinimum`.
                                                                                                                                                                                               
  ## Additional context                                                                                                                                                                      

  `local_transactions_config` is already correctly applied to `PoolConfig` (used for pool ordering/subpool logic) via `ctx.pool_config()` — the missing wiring was only on the validator side.

  ## Metadata

  - Affected flags: `--txpool.nolocals`, `--txpool.minimum-priority-fee`                                                                                                                       
  - Root cause: `local_transactions_config` not propagated to `EthTransactionValidatorBuilder` in `OpPoolBuilder::build_pool()`