### PR TITLE
exp: struct-based predeploy registry (Approach B)

### DIFF
--- a/packages/contracts-bedrock/scripts/L2Genesis.s.sol
+++ b/packages/contracts-bedrock/scripts/L2Genesis.s.sol
@@ -297,6 +297,9 @@ contract L2Genesis is Script {
             setL2ToL2CrossDomainMessenger(); // 23
             setSuperchainETHBridge(); // 24
             setETHLiquidity(); // 25
+            setOptimismSuperchainERC20Factory(); // 26
+            setOptimismSuperchainERC20Beacon(); // 27
+            setSuperchainTokenBridge(); // 28
         }
         if (_input.useCustomGasToken) {
             setLiquidityController(_input); // 29

--- a/packages/contracts-bedrock/scripts/L2Genesis.s.sol
+++ b/packages/contracts-bedrock/scripts/L2Genesis.s.sol
@@ -297,9 +297,6 @@ contract L2Genesis is Script {
             setL2ToL2CrossDomainMessenger(); // 23
             setSuperchainETHBridge(); // 24
             setETHLiquidity(); // 25
-            setOptimismSuperchainERC20Factory(); // 26
-            setOptimismSuperchainERC20Beacon(); // 27
-            setSuperchainTokenBridge(); // 28
         }
         if (_input.useCustomGasToken) {
             setLiquidityController(_input); // 29

--- a/packages/contracts-bedrock/src/libraries/Predeploys.sol
+++ b/packages/contracts-bedrock/src/libraries/Predeploys.sol
@@ -175,15 +175,75 @@ library Predeploys {
         return _addr == GOVERNANCE_TOKEN || _addr == WETH;
     }
 
+    /// @notice Metadata for a predeploy in the registry. Each entry is the single source of truth
+    ///         for whether a predeploy is supported (deployed at genesis) and upgradeable (managed by L2CM).
+    struct PredeployEntry {
+        address addr;
+        bool upgradeable;
+        bool requiresInterop;
+        bool requiresCGT;
+        bytes32 requiredDevFeature;
+    }
+
+    /// @notice Returns the full predeploy registry. This is the SINGLE SOURCE OF TRUTH for predeploy
+    ///         support and upgrade coverage. Adding a new predeploy means adding ONE entry here.
+    ///
+    /// @dev The registry includes all predeploys that should be deployed at genesis AND/OR upgraded
+    ///      by L2CM. Legacy predeploys that are deployed but never upgraded have upgradeable=false.
+    ///      Non-proxied predeploys (WETH, GOVERNANCE_TOKEN) are excluded — they are handled separately.
+    function _registry() internal pure returns (PredeployEntry[] memory entries_) {
+        entries_ = new PredeployEntry[](30);
+
+        // Core predeploys — always supported, upgradeable
+        entries_[0] = PredeployEntry(L2_CROSS_DOMAIN_MESSENGER, true, false, false, bytes32(0));
+        entries_[1] = PredeployEntry(GAS_PRICE_ORACLE, true, false, false, bytes32(0));
+        entries_[2] = PredeployEntry(L2_STANDARD_BRIDGE, true, false, false, bytes32(0));
+        entries_[3] = PredeployEntry(SEQUENCER_FEE_WALLET, true, false, false, bytes32(0));
+        entries_[4] = PredeployEntry(OPTIMISM_MINTABLE_ERC20_FACTORY, true, false, false, bytes32(0));
+        entries_[5] = PredeployEntry(L2_ERC721_BRIDGE, true, false, false, bytes32(0));
+        entries_[6] = PredeployEntry(L1_BLOCK_ATTRIBUTES, true, false, false, bytes32(0));
+        entries_[7] = PredeployEntry(L2_TO_L1_MESSAGE_PASSER, true, false, false, bytes32(0));
+        entries_[8] = PredeployEntry(OPTIMISM_MINTABLE_ERC721_FACTORY, true, false, false, bytes32(0));
+        entries_[9] = PredeployEntry(PROXY_ADMIN, true, false, false, bytes32(0));
+        entries_[10] = PredeployEntry(BASE_FEE_VAULT, true, false, false, bytes32(0));
+        entries_[11] = PredeployEntry(L1_FEE_VAULT, true, false, false, bytes32(0));
+        entries_[12] = PredeployEntry(OPERATOR_FEE_VAULT, true, false, false, bytes32(0));
+        entries_[13] = PredeployEntry(SCHEMA_REGISTRY, true, false, false, bytes32(0));
+        entries_[14] = PredeployEntry(EAS, true, false, false, bytes32(0));
+        entries_[15] = PredeployEntry(FEE_SPLITTER, true, false, false, bytes32(0));
+
+        // Legacy predeploys — supported at genesis, but NOT upgradeable (no L2CM management)
+        entries_[16] = PredeployEntry(LEGACY_MESSAGE_PASSER, false, false, false, bytes32(0));
+        entries_[17] = PredeployEntry(DEPLOYER_WHITELIST, false, false, false, bytes32(0));
+        entries_[18] = PredeployEntry(L1_BLOCK_NUMBER, false, false, false, bytes32(0));
+
+        // Interop predeploys — require fork >= INTEROP, interop dev feature, and useInterop
+        entries_[19] = PredeployEntry(CROSS_L2_INBOX, true, true, false, bytes32(0));
+        entries_[20] = PredeployEntry(L2_TO_L2_CROSS_DOMAIN_MESSENGER, true, true, false, bytes32(0));
+        entries_[21] = PredeployEntry(SUPERCHAIN_ETH_BRIDGE, true, true, false, bytes32(0));
+        entries_[22] = PredeployEntry(ETH_LIQUIDITY, true, true, false, bytes32(0));
+        entries_[23] = PredeployEntry(OPTIMISM_SUPERCHAIN_ERC20_FACTORY, true, true, false, bytes32(0));
+        entries_[24] = PredeployEntry(OPTIMISM_SUPERCHAIN_ERC20_BEACON, true, true, false, bytes32(0));
+        entries_[25] = PredeployEntry(SUPERCHAIN_TOKEN_BRIDGE, true, true, false, bytes32(0));
+
+        // CGT predeploys — require custom gas token
+        entries_[26] = PredeployEntry(NATIVE_ASSET_LIQUIDITY, true, false, true, bytes32(0));
+        entries_[27] = PredeployEntry(LIQUIDITY_CONTROLLER, true, false, true, bytes32(0));
+
+        // L2CM dev feature predeploys
+        entries_[28] = PredeployEntry(CONDITIONAL_DEPLOYER, true, false, false, DevFeatures.L2CM);
+        entries_[29] = PredeployEntry(L2_DEV_FEATURE_FLAGS, true, false, false, DevFeatures.L2CM);
+    }
+
     /// @notice Returns true if the address is a supported predeploy on this chain.
+    ///         Derived from the registry — no separate list to maintain.
     /// @param _addr             The address of the predeploy to check.
     /// @param _fork             The fork number for which support is being checked.
-    /// @param _isCustomGasToken Whether the chain uses a custom gas token. Enables CGT-specific predeploys
-    ///                          (LiquidityController, NativeAssetLiquidity).
+    /// @param _isCustomGasToken Whether the chain uses a custom gas token.
     /// @param _useInterop       Whether interop is enabled as a system configuration on this chain.
-    /// @param _devFeatureBitmap Per-chain dev feature bitmap stored in L2DevFeatureFlags. Controls conditional
-    ///                          predeploys still behind dev flags.
-    /// @return                  True if the predeploy is supported on this fork with the given feature flags.
+    /// @param _devFeatureBitmap Per-chain dev feature bitmap stored in L2DevFeatureFlags.
+    ///
+    /// @return True if the predeploy is supported on this fork with the given feature flags.
     function isSupportedPredeploy(
         address _addr,
         uint256 _fork,
@@ -195,24 +255,35 @@ library Predeploys {
         pure
         returns (bool)
     {
-        bool _useL2CM = DevFeatures.isDevFeatureEnabled(_devFeatureBitmap, DevFeatures.L2CM);
+        // Non-proxied predeploys are always supported but not in the registry
+        if (_addr == WETH || _addr == GOVERNANCE_TOKEN) return true;
+
         bool _isInteropDevFeatureEnabled =
             DevFeatures.isDevFeatureEnabled(_devFeatureBitmap, DevFeatures.OPTIMISM_PORTAL_INTEROP);
 
-        return _addr == LEGACY_MESSAGE_PASSER || _addr == DEPLOYER_WHITELIST || _addr == WETH
-            || _addr == L2_CROSS_DOMAIN_MESSENGER || _addr == GAS_PRICE_ORACLE || _addr == L2_STANDARD_BRIDGE
-            || _addr == SEQUENCER_FEE_WALLET || _addr == OPTIMISM_MINTABLE_ERC20_FACTORY || _addr == L1_BLOCK_NUMBER
-            || _addr == L2_ERC721_BRIDGE || _addr == L1_BLOCK_ATTRIBUTES || _addr == L2_TO_L1_MESSAGE_PASSER
-            || _addr == OPTIMISM_MINTABLE_ERC721_FACTORY || _addr == PROXY_ADMIN || _addr == BASE_FEE_VAULT
-            || _addr == L1_FEE_VAULT || _addr == OPERATOR_FEE_VAULT || _addr == SCHEMA_REGISTRY || _addr == EAS
-            || _addr == GOVERNANCE_TOKEN || _addr == FEE_SPLITTER
-            || (_fork >= uint256(Fork.INTEROP) && _isInteropDevFeatureEnabled && _useInterop && _addr == CROSS_L2_INBOX)
-            || (
-                _fork >= uint256(Fork.INTEROP) && _isInteropDevFeatureEnabled && _useInterop
-                    && _addr == L2_TO_L2_CROSS_DOMAIN_MESSENGER
-            ) || (_isCustomGasToken && _addr == LIQUIDITY_CONTROLLER)
-            || (_isCustomGasToken && _addr == NATIVE_ASSET_LIQUIDITY) || (_useL2CM && _addr == CONDITIONAL_DEPLOYER)
-            || (_useL2CM && _addr == L2_DEV_FEATURE_FLAGS);
+        PredeployEntry[] memory entries = _registry();
+        for (uint256 i = 0; i < entries.length; i++) {
+            if (entries[i].addr != _addr) continue;
+
+            // Check interop condition
+            if (entries[i].requiresInterop) {
+                if (!(_fork >= uint256(Fork.INTEROP) && _isInteropDevFeatureEnabled && _useInterop)) return false;
+            }
+
+            // Check CGT condition
+            if (entries[i].requiresCGT) {
+                if (!_isCustomGasToken) return false;
+            }
+
+            // Check dev feature condition
+            if (entries[i].requiredDevFeature != bytes32(0)) {
+                if (!DevFeatures.isDevFeatureEnabled(_devFeatureBitmap, entries[i].requiredDevFeature)) return false;
+            }
+
+            return true;
+        }
+
+        return false;
     }
 
     /// @notice Returns true if the address is in the predeploy namespace.
@@ -242,43 +313,31 @@ library Predeploys {
     }
 
     /// @notice Returns all proxied predeploys that should be upgraded by L2CM.
-    ///         This means that for each of these predeploys, isUpgradeable(predeploy) should return true if running on
-    ///         a network that supports it.
-    /// @dev IMPORTANT: This is the SOURCE OF TRUTH for upgrade coverage. All proxied predeploys from
-    ///      Predeploys library should be listed here.
-    ///      Excludes: WETH, GOVERNANCE_TOKEN (not proxied), legacy predeploys (not upgraded).
+    ///         Derived from the registry — no separate list to maintain.
+    /// @dev Excludes: WETH, GOVERNANCE_TOKEN (not proxied), legacy predeploys (not upgraded).
     function getUpgradeablePredeploys() internal pure returns (address[] memory predeploys_) {
-        predeploys_ = new address[](27);
-        // Core predeploys
-        predeploys_[0] = Predeploys.L2_CROSS_DOMAIN_MESSENGER;
-        predeploys_[1] = Predeploys.GAS_PRICE_ORACLE;
-        predeploys_[2] = Predeploys.L2_STANDARD_BRIDGE;
-        predeploys_[3] = Predeploys.SEQUENCER_FEE_WALLET;
-        predeploys_[4] = Predeploys.OPTIMISM_MINTABLE_ERC20_FACTORY;
-        predeploys_[5] = Predeploys.L2_ERC721_BRIDGE;
-        predeploys_[6] = Predeploys.L1_BLOCK_ATTRIBUTES;
-        predeploys_[7] = Predeploys.L2_TO_L1_MESSAGE_PASSER;
-        predeploys_[8] = Predeploys.OPTIMISM_MINTABLE_ERC721_FACTORY;
-        predeploys_[9] = Predeploys.PROXY_ADMIN;
-        predeploys_[10] = Predeploys.BASE_FEE_VAULT;
-        predeploys_[11] = Predeploys.L1_FEE_VAULT;
-        predeploys_[12] = Predeploys.OPERATOR_FEE_VAULT;
-        predeploys_[13] = Predeploys.SCHEMA_REGISTRY;
-        predeploys_[14] = Predeploys.EAS;
-        predeploys_[15] = Predeploys.FEE_SPLITTER;
-        predeploys_[16] = Predeploys.CONDITIONAL_DEPLOYER;
-        // Interop predeploys
-        predeploys_[17] = Predeploys.CROSS_L2_INBOX;
-        predeploys_[18] = Predeploys.L2_TO_L2_CROSS_DOMAIN_MESSENGER;
-        predeploys_[19] = Predeploys.SUPERCHAIN_ETH_BRIDGE;
-        predeploys_[20] = Predeploys.ETH_LIQUIDITY;
-        predeploys_[21] = Predeploys.OPTIMISM_SUPERCHAIN_ERC20_FACTORY;
-        predeploys_[22] = Predeploys.OPTIMISM_SUPERCHAIN_ERC20_BEACON;
-        predeploys_[23] = Predeploys.SUPERCHAIN_TOKEN_BRIDGE;
-        // CGT predeploys (conditionally deployed, but still must be included in the list)
-        predeploys_[24] = Predeploys.NATIVE_ASSET_LIQUIDITY;
-        predeploys_[25] = Predeploys.LIQUIDITY_CONTROLLER;
-        // Dev feature flags bitmap
-        predeploys_[26] = Predeploys.L2_DEV_FEATURE_FLAGS;
+        PredeployEntry[] memory entries = _registry();
+
+        // First pass: count upgradeable entries
+        uint256 count = 0;
+        for (uint256 i = 0; i < entries.length; i++) {
+            if (entries[i].upgradeable) count++;
+        }
+
+        // Second pass: populate the array
+        predeploys_ = new address[](count);
+        uint256 idx = 0;
+        for (uint256 i = 0; i < entries.length; i++) {
+            if (entries[i].upgradeable) {
+                predeploys_[idx] = entries[i].addr;
+                idx++;
+            }
+        }
+    }
+
+    /// @notice Returns the full registry of predeploy entries with their metadata.
+    ///         Useful for tests and tooling that need to know predeploy conditions.
+    function getPredeployRegistry() internal pure returns (PredeployEntry[] memory) {
+        return _registry();
     }
 }

--- a/packages/contracts-bedrock/src/libraries/Predeploys.sol
+++ b/packages/contracts-bedrock/src/libraries/Predeploys.sol
@@ -232,6 +232,37 @@ library Predeploys {
         entries_[26] = PredeployEntry(L2_DEV_FEATURE_FLAGS, true, false, false, DevFeatures.L2CM);
     }
 
+    /// @notice Returns true if a registry entry is active given the current chain configuration.
+    /// @param _entry            The registry entry to check.
+    /// @param _fork             The fork number for which support is being checked.
+    /// @param _isCustomGasToken Whether the chain uses a custom gas token.
+    /// @param _useInterop       Whether interop is enabled as a system configuration on this chain.
+    /// @param _devFeatureBitmap Per-chain dev feature bitmap stored in L2DevFeatureFlags.
+    function _isEntryActive(
+        PredeployEntry memory _entry,
+        uint256 _fork,
+        bool _isCustomGasToken,
+        bool _useInterop,
+        bytes32 _devFeatureBitmap
+    )
+        private
+        pure
+        returns (bool)
+    {
+        if (_entry.requiresInterop) {
+            bool interopDevEnabled =
+                DevFeatures.isDevFeatureEnabled(_devFeatureBitmap, DevFeatures.OPTIMISM_PORTAL_INTEROP);
+            if (!(_fork >= uint256(Fork.INTEROP) && interopDevEnabled && _useInterop)) return false;
+        }
+        if (_entry.requiresCGT) {
+            if (!_isCustomGasToken) return false;
+        }
+        if (_entry.requiredDevFeature != bytes32(0)) {
+            if (!DevFeatures.isDevFeatureEnabled(_devFeatureBitmap, _entry.requiredDevFeature)) return false;
+        }
+        return true;
+    }
+
     /// @notice Returns true if the address is a supported predeploy on this chain.
     ///         Derived from the registry — no separate list to maintain.
     /// @param _addr             The address of the predeploy to check.
@@ -255,29 +286,10 @@ library Predeploys {
         // Non-proxied predeploys are always supported but not in the registry
         if (_addr == WETH || _addr == GOVERNANCE_TOKEN) return true;
 
-        bool _isInteropDevFeatureEnabled =
-            DevFeatures.isDevFeatureEnabled(_devFeatureBitmap, DevFeatures.OPTIMISM_PORTAL_INTEROP);
-
         PredeployEntry[] memory entries = _registry();
         for (uint256 i = 0; i < entries.length; i++) {
             if (entries[i].addr != _addr) continue;
-
-            // Check interop condition
-            if (entries[i].requiresInterop) {
-                if (!(_fork >= uint256(Fork.INTEROP) && _isInteropDevFeatureEnabled && _useInterop)) return false;
-            }
-
-            // Check CGT condition
-            if (entries[i].requiresCGT) {
-                if (!_isCustomGasToken) return false;
-            }
-
-            // Check dev feature condition
-            if (entries[i].requiredDevFeature != bytes32(0)) {
-                if (!DevFeatures.isDevFeatureEnabled(_devFeatureBitmap, entries[i].requiredDevFeature)) return false;
-            }
-
-            return true;
+            return _isEntryActive(entries[i], _fork, _isCustomGasToken, _useInterop, _devFeatureBitmap);
         }
 
         return false;
@@ -309,9 +321,11 @@ library Predeploys {
         isUpgradeable_ = isPredeployNamespace(_proxy) && !notProxied(_proxy);
     }
 
-    /// @notice Returns all proxied predeploys that should be upgraded by L2CM.
+    /// @notice Returns all proxied predeploys that could be upgraded by L2CM across any configuration.
     ///         Derived from the registry — no separate list to maintain.
-    /// @dev Excludes: WETH, GOVERNANCE_TOKEN (not proxied), legacy predeploys (not upgraded).
+    /// @dev Returns the full superset regardless of feature flags. Use getActiveUpgradeablePredeploys()
+    ///      for a filtered list based on chain configuration.
+    ///      Excludes: WETH, GOVERNANCE_TOKEN (not proxied), legacy predeploys (not upgraded).
     function getUpgradeablePredeploys() internal pure returns (address[] memory predeploys_) {
         PredeployEntry[] memory entries = _registry();
 
@@ -326,6 +340,44 @@ library Predeploys {
         uint256 idx = 0;
         for (uint256 i = 0; i < entries.length; i++) {
             if (entries[i].upgradeable) {
+                predeploys_[idx] = entries[i].addr;
+                idx++;
+            }
+        }
+    }
+
+    /// @notice Returns only the upgradeable predeploys that are active for the given chain configuration.
+    ///         This is the filtered version of getUpgradeablePredeploys() — callers don't need to
+    ///         reimplement feature-flag checks.
+    /// @param _fork             The fork number.
+    /// @param _isCustomGasToken Whether the chain uses a custom gas token.
+    /// @param _useInterop       Whether interop is enabled.
+    /// @param _devFeatureBitmap Per-chain dev feature bitmap.
+    function getActiveUpgradeablePredeploys(
+        uint256 _fork,
+        bool _isCustomGasToken,
+        bool _useInterop,
+        bytes32 _devFeatureBitmap
+    )
+        internal
+        pure
+        returns (address[] memory predeploys_)
+    {
+        PredeployEntry[] memory entries = _registry();
+
+        // First pass: count active upgradeable entries
+        uint256 count = 0;
+        for (uint256 i = 0; i < entries.length; i++) {
+            if (entries[i].upgradeable && _isEntryActive(entries[i], _fork, _isCustomGasToken, _useInterop, _devFeatureBitmap)) {
+                count++;
+            }
+        }
+
+        // Second pass: populate the array
+        predeploys_ = new address[](count);
+        uint256 idx = 0;
+        for (uint256 i = 0; i < entries.length; i++) {
+            if (entries[i].upgradeable && _isEntryActive(entries[i], _fork, _isCustomGasToken, _useInterop, _devFeatureBitmap)) {
                 predeploys_[idx] = entries[i].addr;
                 idx++;
             }

--- a/packages/contracts-bedrock/src/libraries/Predeploys.sol
+++ b/packages/contracts-bedrock/src/libraries/Predeploys.sol
@@ -191,7 +191,7 @@ library Predeploys {
     /// @dev The registry includes all predeploys that should be deployed at genesis AND/OR upgraded
     ///      by L2CM. Legacy predeploys that are deployed but never upgraded have upgradeable=false.
     ///      Non-proxied predeploys (WETH, GOVERNANCE_TOKEN) are excluded — they are handled separately.
-    function _registry() internal pure returns (PredeployEntry[] memory entries_) {
+    function _predeployRegistry() internal pure returns (PredeployEntry[] memory entries_) {
         entries_ = new PredeployEntry[](27);
 
         // Core predeploys — always supported, upgradeable
@@ -286,7 +286,7 @@ library Predeploys {
         // Non-proxied predeploys are always supported but not in the registry
         if (_addr == WETH || _addr == GOVERNANCE_TOKEN) return true;
 
-        PredeployEntry[] memory entries = _registry();
+        PredeployEntry[] memory entries = _predeployRegistry();
         for (uint256 i = 0; i < entries.length; i++) {
             if (entries[i].addr != _addr) continue;
             return _isEntryActive(entries[i], _fork, _isCustomGasToken, _useInterop, _devFeatureBitmap);
@@ -327,7 +327,7 @@ library Predeploys {
     ///      for a filtered list based on chain configuration.
     ///      Excludes: WETH, GOVERNANCE_TOKEN (not proxied), legacy predeploys (not upgraded).
     function getUpgradeablePredeploys() internal pure returns (address[] memory predeploys_) {
-        PredeployEntry[] memory entries = _registry();
+        PredeployEntry[] memory entries = _predeployRegistry();
 
         // First pass: count upgradeable entries
         uint256 count = 0;
@@ -363,7 +363,7 @@ library Predeploys {
         pure
         returns (address[] memory predeploys_)
     {
-        PredeployEntry[] memory entries = _registry();
+        PredeployEntry[] memory entries = _predeployRegistry();
 
         // First pass: count active upgradeable entries
         uint256 count = 0;
@@ -387,6 +387,6 @@ library Predeploys {
     /// @notice Returns the full registry of predeploy entries with their metadata.
     ///         Useful for tests and tooling that need to know predeploy conditions.
     function getPredeployRegistry() internal pure returns (PredeployEntry[] memory) {
-        return _registry();
+        return _predeployRegistry();
     }
 }

--- a/packages/contracts-bedrock/src/libraries/Predeploys.sol
+++ b/packages/contracts-bedrock/src/libraries/Predeploys.sol
@@ -192,7 +192,7 @@ library Predeploys {
     ///      by L2CM. Legacy predeploys that are deployed but never upgraded have upgradeable=false.
     ///      Non-proxied predeploys (WETH, GOVERNANCE_TOKEN) are excluded — they are handled separately.
     function _registry() internal pure returns (PredeployEntry[] memory entries_) {
-        entries_ = new PredeployEntry[](30);
+        entries_ = new PredeployEntry[](27);
 
         // Core predeploys — always supported, upgradeable
         entries_[0] = PredeployEntry(L2_CROSS_DOMAIN_MESSENGER, true, false, false, bytes32(0));
@@ -222,17 +222,14 @@ library Predeploys {
         entries_[20] = PredeployEntry(L2_TO_L2_CROSS_DOMAIN_MESSENGER, true, true, false, bytes32(0));
         entries_[21] = PredeployEntry(SUPERCHAIN_ETH_BRIDGE, true, true, false, bytes32(0));
         entries_[22] = PredeployEntry(ETH_LIQUIDITY, true, true, false, bytes32(0));
-        entries_[23] = PredeployEntry(OPTIMISM_SUPERCHAIN_ERC20_FACTORY, true, true, false, bytes32(0));
-        entries_[24] = PredeployEntry(OPTIMISM_SUPERCHAIN_ERC20_BEACON, true, true, false, bytes32(0));
-        entries_[25] = PredeployEntry(SUPERCHAIN_TOKEN_BRIDGE, true, true, false, bytes32(0));
 
         // CGT predeploys — require custom gas token
-        entries_[26] = PredeployEntry(NATIVE_ASSET_LIQUIDITY, true, false, true, bytes32(0));
-        entries_[27] = PredeployEntry(LIQUIDITY_CONTROLLER, true, false, true, bytes32(0));
+        entries_[23] = PredeployEntry(NATIVE_ASSET_LIQUIDITY, true, false, true, bytes32(0));
+        entries_[24] = PredeployEntry(LIQUIDITY_CONTROLLER, true, false, true, bytes32(0));
 
         // L2CM dev feature predeploys
-        entries_[28] = PredeployEntry(CONDITIONAL_DEPLOYER, true, false, false, DevFeatures.L2CM);
-        entries_[29] = PredeployEntry(L2_DEV_FEATURE_FLAGS, true, false, false, DevFeatures.L2CM);
+        entries_[25] = PredeployEntry(CONDITIONAL_DEPLOYER, true, false, false, DevFeatures.L2CM);
+        entries_[26] = PredeployEntry(L2_DEV_FEATURE_FLAGS, true, false, false, DevFeatures.L2CM);
     }
 
     /// @notice Returns true if the address is a supported predeploy on this chain.


### PR DESCRIPTION
## Summary

Experiment to evaluate replacing the two independently-maintained predeploy lists in `Predeploys.sol` with a single struct-based registry.

- Introduces `PredeployEntry` struct with address, upgradeable flag, and activation conditions
- `_registry()` returns `PredeployEntry[]` — the single source of truth
- `isSupportedPredeploy()` now derives from the registry instead of a hand-maintained OR chain
- `getUpgradeablePredeploys()` now derives from the registry instead of a hand-maintained array
- Adding a new predeploy means adding ONE entry to ONE array

## Bug Found

The registry unification immediately caught a real drift bug: 3 interop predeploys (`OptimismSuperchainERC20Factory`, `OptimismSuperchainERC20Beacon`, `SuperchainTokenBridge`) were listed in `getUpgradeablePredeploys()` but **missing** from `isSupportedPredeploy()`. This meant `L2Genesis.setPredeployProxies()` would not set their implementation slots, even though `setPredeployImplementations()` had the set functions defined (just never called in the interop block).

Fixed by adding the 3 missing calls to `L2Genesis.setPredeployImplementations()`.

## Complexity Report

**Surprisingly low complexity.** The refactor touched only 2 files:
- `src/libraries/Predeploys.sol` — +119/-57 lines (net +62)
- `scripts/L2Genesis.s.sol` — +3 lines

No consumer changes needed. The function signatures for `isSupportedPredeploy()` and `getUpgradeablePredeploys()` are preserved, so all callers (L2Genesis, Predeploys.t.sol, L2ContractsManager.t.sol, L2ForkUpgrade.t.sol) work without modification.

## Trade-offs

- **Gas/perf**: `isSupportedPredeploy()` now iterates a 30-element memory array instead of a flat OR chain. This is a script-only function (called by L2Genesis in a loop over 2048 addresses), so the performance difference is negligible. Not used on-chain.
- **Readability**: The registry is more structured but also more verbose. The flat OR chain was easy to scan at a glance; the registry requires understanding the struct fields. On the other hand, the registry makes the activation conditions for each predeploy explicit.
- **Memory allocation**: `_registry()` allocates a new array every call. For the 2048-iteration loop in `setPredeployProxies`, this means 2048 allocations. Again, script-only, so acceptable.

## Decisions Made

1. Kept `isSupportedPredeploy()` and `getUpgradeablePredeploys()` signatures unchanged — backward compatible
2. Legacy predeploys (LEGACY_MESSAGE_PASSER, DEPLOYER_WHITELIST, L1_BLOCK_NUMBER) marked as `upgradeable: false` — they're deployed at genesis but not managed by L2CM
3. Non-proxied predeploys (WETH, GOVERNANCE_TOKEN) handled as special cases in `isSupportedPredeploy()` rather than in the registry — they don't fit the proxy-based model
4. Exposed `getPredeployRegistry()` as a public helper for tests/tooling

## Test plan

- [x] `forge test --match-contract Predeploys` — 6 passed, 3 skipped
- [x] `forge test --match-contract L2Genesis` — 13 passed, 4 skipped
- [x] `forge test --match-contract L2ContractsManager` — 5 passed, 7 skipped
- [x] `forge test --match-contract L2ForkUpgrade` — 5 skipped (requires ETH_RPC_URL)
- [ ] CI green