### PR TITLE
fix(op-node,op-batcher): fix maxSafeLag stall, resume, and channel ti…

### DIFF
--- a/op-acceptance-tests/tests/sequencer/max_safe_lag_test.go
+++ b/op-acceptance-tests/tests/sequencer/max_safe_lag_test.go
@@ -11,16 +11,19 @@ import (
 )
 
 // TestMaxSafeLagStallAndResume verifies the sequencer.max-safe-lag behavior:
-// 1. The sequencer produces blocks normally when the safe head is caught up.
-// 2. When the batcher is stopped and the unsafe/safe gap exceeds maxSafeLag,
-//    the sequencer stalls (stops producing new blocks).
-// 3. When the batcher is restarted and the safe head advances past the stall
-//    point, the sequencer resumes producing blocks.
+//  1. The sequencer produces blocks normally when the safe head is caught up.
+//  2. When the batcher is stopped and the unsafe/safe gap exceeds maxSafeLag,
+//     the sequencer stalls (stops producing new blocks).
+//  3. When the batcher is restarted and the safe head advances past the stall
+//     point, the sequencer resumes producing blocks.
 //
 // This protects the feature introduced in ethereum-optimism/optimism#17936
 // against regression.
 func TestMaxSafeLagStallAndResume(gt *testing.T) {
 	t := devtest.ParallelT(gt)
+	// max-safe-lag is enforced inside op-node's Go sequencer; kona-node has its
+	// own sequencer implementation and is out of scope for this regression test.
+	sysgo.SkipOnKonaNode(t, "max-safe-lag is op-node only")
 	const maxSafeLag = uint64(20)
 	// This test does not need fault proofs; using the NoFaultProofs variant
 	// avoids requiring cannon prestate artifacts in local test runs.

--- a/op-acceptance-tests/tests/sequencer/max_safe_lag_test.go
+++ b/op-acceptance-tests/tests/sequencer/max_safe_lag_test.go
@@ -1,0 +1,93 @@
+package sequencer
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMaxSafeLagStallAndResume verifies the sequencer.max-safe-lag behavior:
+// 1. The sequencer produces blocks normally when the safe head is caught up.
+// 2. When the batcher is stopped and the unsafe/safe gap exceeds maxSafeLag,
+//    the sequencer stalls (stops producing new blocks).
+// 3. When the batcher is restarted and the safe head advances past the stall
+//    point, the sequencer resumes producing blocks.
+//
+// This protects the feature introduced in ethereum-optimism/optimism#17936
+// against regression.
+func TestMaxSafeLagStallAndResume(gt *testing.T) {
+	t := devtest.ParallelT(gt)
+	const maxSafeLag = uint64(20)
+	// This test does not need fault proofs; using the NoFaultProofs variant
+	// avoids requiring cannon prestate artifacts in local test runs.
+	sys := presets.NewMinimalNoFaultProofs(t,
+		presets.WithGlobalL2CLOption(sysgo.L2CLSequencerMaxSafeLag(maxSafeLag)))
+
+	blockTime := sys.L2Chain.Escape().RollupConfig().BlockTime
+
+	// Phase 1: confirm the chain is producing blocks and the safe head is keeping up.
+	startingUnsafe := sys.L2CL.SyncStatus().UnsafeL2.Number
+	require.Eventually(t, func() bool {
+		return sys.L2CL.SyncStatus().UnsafeL2.Number > startingUnsafe+5
+	}, time.Duration(blockTime*20)*time.Second, time.Second, "chain did not produce blocks at startup")
+
+	// Phase 2: stop the batcher so the safe head falls behind the unsafe head.
+	sys.L2Batcher.Stop()
+	t.Logger().Info("batcher stopped, waiting for sequencer to stall at maxSafeLag")
+
+	// Phase 3: wait until the unsafe head stops advancing for several consecutive
+	// block times while the gap exceeds maxSafeLag — that is the definitive signal
+	// that the sequencer is stalled. A simple "gap >= maxSafeLag then sleep" check
+	// would be racy: the batcher can still have in-flight L1 transactions that,
+	// once mined, deliver a batch of safe blocks, transiently shrink the gap, and
+	// let the sequencer produce a few more unsafe blocks before re-stalling.
+	//
+	// The confirmation window must be longer than the L1 block time (6s in
+	// devstack) so that any L1 tx broadcast by the batcher before Stop() has a
+	// chance to mine within the window rather than right after we accept stall.
+	const stableSamples = 10
+	stallTimeout := time.Duration(blockTime*(maxSafeLag*4+30)) * time.Second
+	var stalledUnsafe uint64
+	require.Eventually(t, func() bool {
+		status := sys.L2CL.SyncStatus()
+		gap := status.UnsafeL2.Number - status.SafeL2.Number
+		if gap < maxSafeLag {
+			stalledUnsafe = 0
+			return false
+		}
+		if stalledUnsafe == 0 || status.UnsafeL2.Number != stalledUnsafe {
+			// Either first sighting, or unsafe head advanced — reset the stability window.
+			stalledUnsafe = status.UnsafeL2.Number
+			return false
+		}
+		// Unsafe head unchanged since the previous sample with gap >= maxSafeLag.
+		// The for-loop below confirms the stall for additional samples.
+		return true
+	}, stallTimeout, time.Duration(blockTime)*time.Second, "sequencer did not stall after stopping batcher")
+
+	// Confirm the stall holds for enough samples to cover at least one L1 block.
+	for range stableSamples {
+		time.Sleep(time.Duration(blockTime) * time.Second)
+		status := sys.L2CL.SyncStatus()
+		require.Equal(t, stalledUnsafe, status.UnsafeL2.Number,
+			"sequencer was expected to stay stalled but unsafe head advanced: %d -> %d",
+			stalledUnsafe, status.UnsafeL2.Number)
+	}
+	t.Logger().Info("sequencer stalled as expected", "unsafe", stalledUnsafe, "safe", sys.L2CL.SyncStatus().SafeL2.Number)
+
+	// Phase 4: restart the batcher so the safe head can advance again.
+	sys.L2Batcher.Start()
+	t.Logger().Info("batcher restarted, waiting for sequencer to resume")
+
+	// Phase 5: the sequencer should resume producing blocks past the stalled head.
+	// 1 minute is a generous margin for CI jitter.
+	require.Eventually(t, func() bool {
+		return sys.L2CL.SyncStatus().UnsafeL2.Number > stalledUnsafe
+	}, time.Minute, time.Second,
+		"sequencer did not resume producing blocks after batcher restart")
+	t.Logger().Info("sequencer resumed", "unsafe", sys.L2CL.SyncStatus().UnsafeL2.Number)
+}

--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -311,8 +311,8 @@ func (s *channelManager) getReadyChannel(l1Head eth.BlockID, pi pubInfo) (*chann
 	}
 
 	// If there are pending blocks, add them to a channel.
-	toBeAddedBlocks := s.pendingBlocks() > 0
-	if toBeAddedBlocks {
+	havePendingBlocks := s.pendingBlocks() > 0
+	if havePendingBlocks {
 		if err := s.ensureChannelWithSpace(l1Head); err != nil {
 			return nil, err
 		}
@@ -330,7 +330,7 @@ func (s *channelManager) getReadyChannel(l1Head eth.BlockID, pi pubInfo) (*chann
 	// frames were already produced by a prior call (and drained by the earlier
 	// HasTxData check above). Skip re-running outputFrames on an already-closed
 	// channel-out, which would error.
-	if !toBeAddedBlocks && s.currentChannel.IsFull() {
+	if !havePendingBlocks && s.currentChannel.IsFull() {
 		return nil, io.EOF
 	}
 

--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -310,36 +310,28 @@ func (s *channelManager) getReadyChannel(l1Head eth.BlockID, pi pubInfo) (*chann
 		return firstWithTxData, nil
 	}
 
-	// No pending tx data, so we have to add new blocks to the channel
-	// If we have no saved blocks, we will not be able to create valid frames
-	if s.pendingBlocks() == 0 {
-		// Even without new blocks, check if an existing channel has timed out.
-		// Without this, the channel duration timeout is never re-evaluated once all
-		// pending blocks have been added, which can cause a deadlock when the
-		// sequencer stalls due to maxSafeLag: no new blocks → no timeout check →
-		// channel never closes → data never submitted → safe head stuck.
-		if s.currentChannel != nil && !s.currentChannel.IsFull() && !pi.ignoreMaxChannelDuration {
-			s.registerL1Block(l1Head)
-			if s.currentChannel.IsFull() {
-				s.log.Info("Channel timed out with no pending blocks, flushing",
-					"channel_id", s.currentChannel.ID(), "l1Head", l1Head)
-				if err := s.outputFrames(); err != nil {
-					return nil, err
-				}
-				if s.currentChannel.HasTxData() {
-					return s.currentChannel, nil
-				}
-			}
+	// If there are pending blocks, add them to a channel.
+	toBeAddedBlocks := s.pendingBlocks() > 0
+	if toBeAddedBlocks {
+		if err := s.ensureChannelWithSpace(l1Head); err != nil {
+			return nil, err
 		}
+		if err := s.processBlocks(); err != nil {
+			return nil, err
+		}
+	}
+
+	// Nothing to flush if there's no open channel.
+	if s.currentChannel == nil {
 		return nil, io.EOF
 	}
 
-	if err := s.ensureChannelWithSpace(l1Head); err != nil {
-		return nil, err
-	}
-
-	if err := s.processBlocks(); err != nil {
-		return nil, err
+	// If no blocks were added this call and the channel is already full, its
+	// frames were already produced by a prior call (and drained by the earlier
+	// HasTxData check above). Skip re-running outputFrames on an already-closed
+	// channel-out, which would error.
+	if !toBeAddedBlocks && s.currentChannel.IsFull() {
+		return nil, io.EOF
 	}
 
 	if !pi.ignoreMaxChannelDuration {

--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -313,6 +313,24 @@ func (s *channelManager) getReadyChannel(l1Head eth.BlockID, pi pubInfo) (*chann
 	// No pending tx data, so we have to add new blocks to the channel
 	// If we have no saved blocks, we will not be able to create valid frames
 	if s.pendingBlocks() == 0 {
+		// Even without new blocks, check if an existing channel has timed out.
+		// Without this, the channel duration timeout is never re-evaluated once all
+		// pending blocks have been added, which can cause a deadlock when the
+		// sequencer stalls due to maxSafeLag: no new blocks → no timeout check →
+		// channel never closes → data never submitted → safe head stuck.
+		if s.currentChannel != nil && !s.currentChannel.IsFull() && !pi.ignoreMaxChannelDuration {
+			s.registerL1Block(l1Head)
+			if s.currentChannel.IsFull() {
+				s.log.Info("Channel timed out with no pending blocks, flushing",
+					"channel_id", s.currentChannel.ID(), "l1Head", l1Head)
+				if err := s.outputFrames(); err != nil {
+					return nil, err
+				}
+				if s.currentChannel.HasTxData() {
+					return s.currentChannel, nil
+				}
+			}
+		}
 		return nil, io.EOF
 	}
 

--- a/op-devstack/presets/minimal_no_fault_proofs.go
+++ b/op-devstack/presets/minimal_no_fault_proofs.go
@@ -1,0 +1,21 @@
+package presets
+
+import (
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+)
+
+// NewMinimalNoFaultProofs is a Minimal preset that skips the proposer and
+// challenger. It is intended for tests that only exercise the sequencer +
+// batcher + derivation loop (e.g. sequencer control-plane features). Skipping
+// the challenger avoids requiring cannon prestate artifacts, which are
+// expensive to build locally.
+//
+// DisputeGameFactory() on the returned Minimal is not usable because the
+// challenger config is nil.
+func NewMinimalNoFaultProofs(t devtest.T, opts ...Option) *Minimal {
+	presetCfg, presetOpts := collectSupportedPresetConfig(t, "NewMinimalNoFaultProofs", opts, minimalPresetSupportedOptionKinds)
+	out := minimalFromRuntime(t, sysgo.NewMinimalNoFaultProofsRuntimeWithConfig(t, presetCfg))
+	presetOpts.applyPreset(out)
+	return out
+}

--- a/op-devstack/sysgo/l2_cl.go
+++ b/op-devstack/sysgo/l2_cl.go
@@ -40,6 +40,10 @@ type L2CLConfig struct {
 
 	// OffsetELSafe retracts safe and finalized from the EL-sync tip by floor(OffsetELSafe / L2BlockTime) blocks.
 	OffsetELSafe time.Duration
+
+	// SequencerMaxSafeLag caps the gap between unsafe and safe L2 heads;
+	// the sequencer stalls block production when the gap is exceeded. 0 disables.
+	SequencerMaxSafeLag uint64
 }
 
 func L2CLSequencer() L2CLOption {
@@ -57,6 +61,14 @@ func L2CLIndexing() L2CLOption {
 func L2CLFollowSource(source string) L2CLOption {
 	return L2CLOptionFn(func(p devtest.T, _ ComponentTarget, cfg *L2CLConfig) {
 		cfg.FollowSource = source
+	})
+}
+
+// L2CLSequencerMaxSafeLag sets the sequencer max-safe-lag. The sequencer stalls
+// block production when the unsafe/safe gap exceeds this value. 0 disables.
+func L2CLSequencerMaxSafeLag(maxSafeLag uint64) L2CLOption {
+	return L2CLOptionFn(func(p devtest.T, _ ComponentTarget, cfg *L2CLConfig) {
+		cfg.SequencerMaxSafeLag = maxSafeLag
 	})
 }
 

--- a/op-devstack/sysgo/singlechain_build.go
+++ b/op-devstack/sysgo/singlechain_build.go
@@ -392,8 +392,9 @@ func startL2CLNode(
 			BeaconAddr: l1CL.beaconHTTPAddr,
 		},
 		Driver: driver.Config{
-			SequencerEnabled:   cfg.IsSequencer,
-			SequencerConfDepth: 2,
+			SequencerEnabled:    cfg.IsSequencer,
+			SequencerConfDepth:  2,
+			SequencerMaxSafeLag: cfg.SequencerMaxSafeLag,
 		},
 		Rollup:            *l2Net.rollupCfg,
 		DependencySet:     startCfg.DependencySet,

--- a/op-devstack/sysgo/singlechain_runtime.go
+++ b/op-devstack/sysgo/singlechain_runtime.go
@@ -165,6 +165,21 @@ func NewMinimalRuntimeWithConfig(t devtest.T, cfg PresetConfig) *SingleChainRunt
 	})
 }
 
+// NewMinimalNoFaultProofsRuntimeWithConfig returns a minimal single-chain
+// runtime without the proposer or challenger. It is intended for tests that
+// only exercise the sequencer + batcher + derivation loop and do not need
+// fault proofs. Skipping the challenger also avoids requiring cannon prestate
+// artifacts, which are expensive to build locally.
+func NewMinimalNoFaultProofsRuntimeWithConfig(t devtest.T, cfg PresetConfig) *SingleChainRuntime {
+	return newSingleChainRuntimeWithConfig(t, cfg, singleChainRuntimeSpec{
+		BuildWorld:      newDefaultSingleChainWorld,
+		StartPrimary:    startDefaultSingleChainPrimary,
+		StartBatcher:    true,
+		StartProposer:   false,
+		StartChallenger: false,
+	})
+}
+
 func startMinimalBatcher(
 	t devtest.T,
 	keys devkeys.Keys,

--- a/op-node/rollup/sequencing/sequencer.go
+++ b/op-node/rollup/sequencing/sequencer.go
@@ -89,6 +89,11 @@ type Sequencer struct {
 
 	maxSafeLag atomic.Uint64
 
+	// stalledByMaxSafeLag tracks whether the sequencer was stalled specifically
+	// by the maxSafeLag check, to avoid incorrectly resuming when nextActionOK
+	// was set to false for unrelated reasons (e.g., pipeline reset, L1-derivation backoff).
+	stalledByMaxSafeLag bool
+
 	recoverMode atomic.Bool
 
 	// active identifies whether the sequencer is running.
@@ -431,6 +436,7 @@ func (d *Sequencer) onReset(x rollup.ResetEvent) {
 		d.emitter.Emit(d.ctx, engine.BuildCancelEvent{Info: d.latest.Info})
 	}
 	d.latest = BuildingState{}
+	d.stalledByMaxSafeLag = false
 	// no action to perform until we get a reset-confirmation
 	d.nextActionOK = false
 }
@@ -441,6 +447,8 @@ func (d *Sequencer) onEngineResetConfirmedEvent(engine.EngineResetConfirmedEvent
 	// assuming the execution-engine just churned through some work for the reset.
 	// This will also prevent any potential reset-loop from running too hot.
 	d.nextAction = d.timeNow().Add(time.Second * time.Duration(d.rollupCfg.BlockTime))
+	// Note: stalledByMaxSafeLag was cleared in onReset. If the lag condition still holds,
+	// the next ForkchoiceUpdateEvent will re-evaluate and re-stall the sequencer.
 	d.log.Info("Engine reset confirmed, sequencer may continue", "next", d.nextActionOK)
 }
 
@@ -450,13 +458,6 @@ func (d *Sequencer) onForkchoiceUpdate(x engine.ForkchoiceUpdateEvent) {
 	if !d.active.Load() {
 		d.setLatestHead(x.UnsafeL2Head)
 		return
-	}
-	// If the safe head has fallen behind by a significant number of blocks, delay creating new blocks
-	// until the safe lag is below SequencerMaxSafeLag.
-	if maxSafeLag := d.maxSafeLag.Load(); maxSafeLag > 0 && x.SafeL2Head.Number+maxSafeLag <= x.UnsafeL2Head.Number {
-		d.log.Warn("sequencer has fallen behind safe head by more than lag, stalling",
-			"head", x.UnsafeL2Head, "safe", x.SafeL2Head, "max_lag", maxSafeLag)
-		d.nextActionOK = false
 	}
 	// Drop stale block-building job if the chain has moved past it already.
 	if d.latest != (BuildingState{}) && d.latest.Onto.Number < x.UnsafeL2Head.Number {
@@ -478,6 +479,33 @@ func (d *Sequencer) onForkchoiceUpdate(x engine.ForkchoiceUpdateEvent) {
 			// otherwise start instantly
 			d.nextAction = now
 		}
+	}
+	// If the safe head has fallen behind by a significant number of blocks, delay creating new blocks
+	// until the safe lag is below SequencerMaxSafeLag.
+	// NOTE: This block must appear after the head-advancement block above. The head-advancement
+	// block unconditionally sets nextActionOK=true; the maxSafeLag check must be able to override it.
+	if maxSafeLag := d.maxSafeLag.Load(); maxSafeLag > 0 {
+		if x.SafeL2Head.Number+maxSafeLag <= x.UnsafeL2Head.Number {
+			d.log.Warn("sequencer has fallen behind safe head by more than lag, stalling",
+				"head", x.UnsafeL2Head, "safe", x.SafeL2Head, "max_lag", maxSafeLag)
+			d.nextActionOK = false
+			d.stalledByMaxSafeLag = true
+		} else if d.stalledByMaxSafeLag {
+			// Safe head has caught up after a maxSafeLag stall, resume sequencing.
+			// Only resume if we were stalled by maxSafeLag specifically, to avoid
+			// interfering with other nextActionOK=false states (reset, L1-derivation backoff, etc).
+			d.log.Info("safe head caught up, resuming sequencing",
+				"head", x.UnsafeL2Head, "safe", x.SafeL2Head, "max_lag", maxSafeLag)
+			d.stalledByMaxSafeLag = false
+			d.nextActionOK = d.active.Load()
+			d.nextAction = d.timeNow()
+		}
+	} else if d.stalledByMaxSafeLag {
+		// maxSafeLag was disabled at runtime (set to 0) while stalled; resume immediately.
+		d.log.Info("maxSafeLag disabled, resuming sequencing")
+		d.stalledByMaxSafeLag = false
+		d.nextActionOK = d.active.Load()
+		d.nextAction = d.timeNow()
 	}
 	d.setLatestHead(x.UnsafeL2Head)
 }
@@ -709,6 +737,7 @@ func (d *Sequencer) forceStart() error {
 	// clear the building state; interrupting any existing sequencing job (there should never be one)
 	d.latest = BuildingState{}
 	d.nextActionOK = true
+	d.stalledByMaxSafeLag = false
 	d.nextAction = d.timeNow()
 	d.active.Store(true)
 	d.metrics.SetSequencerState(true)
@@ -766,6 +795,7 @@ func (d *Sequencer) Stop(ctx context.Context) (common.Hash, error) {
 	d.latest = BuildingState{} // By wiping this state we cannot continue from it later.
 
 	d.nextActionOK = false
+	d.stalledByMaxSafeLag = false
 	d.active.Store(false)
 	d.metrics.SetSequencerState(false)
 	d.log.Info("Sequencer has been stopped")


### PR DESCRIPTION
## Description

Fixes a deterministic deadlock in `--sequencer.max-safe-lag` that permanently kills the sequencer once the gap is reached. Also fixes a batcher-side deadlock that prevents recovery even after the sequencer is fixed.

Fixes #17936

## Root Cause Analysis

The bug is a **deterministic deadlock**. Any deployment where the unsafe-safe gap reaches `maxSafeLag` will inevitably deadlock through a three-phase sequence:

### Phase 1 — Stall cannot take effect (issue #17936)

In `onForkchoiceUpdate()`, the maxSafeLag check runs **before** the head-advancement block:

```go
if maxSafeLag > 0 && gap >= maxSafeLag { nextActionOK = false }   // stall
if UnsafeL2Head > latestHead           { nextActionOK = true  }   // overridden
```

Every time the sequencer produces a block, the resulting `ForkchoiceUpdateEvent` has `UnsafeL2Head > latestHead`, which unconditionally overrides the stall. The sequencer logs `"stalling"` warnings but continues producing blocks (~110 more, gap grows from 200 to ~310).

### Phase 2 — Derivation catch-up triggers permanent stall

The derivation pipeline eventually begins catching up safe head. Each safe block advance triggers a `ForkchoiceUpdateEvent` where **`UnsafeL2Head` is unchanged** (no new blocks were produced in that event). Now:

- maxSafeLag check: gap >= 200 → `nextActionOK = false` ✓ (stall sticks)
- Head advancement: `UnsafeL2Head == latestHead` → **not executed** (no override)

The stall now takes real effect — the sequencer stops producing blocks.

### Phase 3 — Deadlock: no recovery path

When safe head finally catches up (gap < maxSafeLag):

- maxSafeLag `if` condition is false → **block not entered** (but also no `else` to resume)
- Head advancement: `UnsafeL2Head == latestHead` → **still false** (nothing changed)
- `nextActionOK` remains `false` permanently

This is a self-reinforcing deadlock:

```
nextActionOK = false → can't produce blocks → UnsafeL2Head never advances
       ↑                                                    |
       └── head advancement never fires ← UnsafeL2Head == latestHead
```

### Batcher deadlock (Bug 2)

Even if the sequencer is fixed to resume, the batcher creates a secondary deadlock. When the sequencer stalls, the batcher quickly consumes all pending blocks. With `pendingBlocks == 0`, `getReadyChannel()` returns `io.EOF` before calling `registerL1Block()` — the only place that checks channel duration timeout. The channel never times out, is never submitted to L1, safe head never advances, and the sequencer can never resume.

## Reproduction

**100% reproducible on devnet with fresh state:**

1. Configure `--sequencer.max-safe-lag=200`
2. Start devnet from genesis
3. Observe: gap grows at ~1 block/s, stall logs begin at gap=200 but sequencer continues
4. At gap ~310, derivation catches up → sequencer permanently stops
5. Safe head fully catches up (gap < 10), sequencer never resumes

This reproduces on every fresh start because the genesis-to-wallclock catch-up distance always exceeds maxSafeLag.

## Fix

### op-node: sequencer.go

1. **Move maxSafeLag check after head-advancement block** — so it can override `nextActionOK = true`, making the stall take immediate effect (fixes Phase 1).

2. **Add `stalledByMaxSafeLag` flag with explicit recovery** — when the flag is set and safe head catches up (gap < maxSafeLag), explicitly resume sequencing with `nextActionOK = true` (fixes Phase 3). The flag isolates maxSafeLag stalls from other `nextActionOK = false` states (pipeline reset, L1-derivation backoff, mid-seal wait).

3. **Edge cases handled:**
   - Runtime disable (`SetMaxSafeLag(0)` while stalled): detected and resumed immediately
   - Lifecycle transitions: flag cleared in `forceStart`, `onReset`, and `Stop`
   - Conductor failover: `forceStart` clears the flag for clean state

### op-batcher: channel_manager.go

When `pendingBlocks == 0` but a non-full channel exists, still call `registerL1Block()` to re-evaluate the channel duration timeout. If it times out, flush immediately.

## Testing

Devnet testing (single sequencer, no conductor, `max-safe-lag=200`):

| Scenario | Result |
|----------|--------|
| Gap reaches maxSafeLag | Sequencer stalls immediately (no ~110 block overshoot) |
| Safe head catches up | Sequencer auto-resumes (log: `"safe head caught up, resuming sequencing"`) |
| Batcher + stalled sequencer | Channel times out via batcher fix, data submitted, safe advances, sequencer resumes |
| Stop batcher → stall → restart batcher | Resumes in ~15s (new channel created) |
| Runtime `SetMaxSafeLag(0)` while stalled | Resumes immediately |
| Stall/resume log pairing | Equal counts confirmed (no leaked stalls) |