### PR TITLE
docs: add op-deployer upgrade/manage deprecation notice and update affected pages

### DIFF
--- a/docs/public-docs/chain-operators/tools/op-deployer/reference/custom-deployments.mdx
+++ b/docs/public-docs/chain-operators/tools/op-deployer/reference/custom-deployments.mdx
@@ -124,66 +124,8 @@ genesis and rollup config files.
 
 ## Upgrading
 
-You can upgrade between smart contract versions using the [`upgrade`](/chain-operators/tools/op-deployer/usage/upgrade) family of commands. As a prerequisite,
-you must deploy OPCMs for each version you want to upgrade between using the `bootstrap implementations` command.
-
-You will need to use the correct sub-command for the version you are upgrading from. For example, if you are
-upgrading from `v2.0.0` to `v3.0.0`, you will need to use the `upgrade v3.0.0` subcommand.
-
-Unlike the `bootstrap` and `apply` commands, the `upgrade` command does not interact with the chain directly. Instead,
-it generates calldata that you can use with `cast`, Gnosis SAFE, or whatever tooling you use to manage your L1.
-
-To run the upgrade command, use the following:
-
 <Warning>
-Upgrading between non-standard contract versions is not supported.
+The `op-deployer upgrade` command has been deprecated. For L1 contract upgrades, use
+[superchain-ops](/chain-operators/tutorials/l1-contract-upgrades/superchain-ops-guide) or interact with the
+OPCM directly. See the [deprecation notice](/notices/op-deployer-upgrade-deprecation) for details.
 </Warning>
-
-```shell
-op-deployer upgrade <version> \
-  --config <path to config JSON> \
-  --l1-rpc-url="<rpc url>"
-```
-
-The contents of your config JSON should look something like this:
-
-```json
-{
-  "prank": "<address of the contract that owns the chain - likely the same as the superchain owner>",
-  "opcm": "<address of new OPCM>",
-  "chainConfigs": [
-    {
-      "systemConfigProxy": "<address of the chain's system config proxy>",
-      "proxyAdmin": "<address of the chain's proxy admin>",
-      "absolutePrestate": "<32-byte hash of the chain's absolute prestate>"
-    }
-  ]
-}
-```
-
-You will get output that looks something like this:
-
-```json
-{
-  "to": "<maps to the prank address>",
-  "data": "<calldata>",
-  "value": "0x0"
-}
-```
-
-At this point, you will need to build a transaction that uses the calldata and calls the `upgrade()` method on the
-OPCM. The exact method you use to do this will depend on your tooling. As an example, you can craft a transaction
-for use with Gnosis SAFE CLI using the command below:
-
-<Info>
-The Gnosis SAFE UI does not support the `--delegate` flag, so the CLI is required if you're using a Gnosis SAFE.
-</Info>
-
-```shell
-safe-cli send-custom <owner SAFE address> <l1 rpc URL> <opcm address> 0 <calldata> --private-key <signer private key>
---delegate
-```
-
-Note that no matter which method you use to broadcast the calldata, the call to OPCM **must** come from the smart
-contract that owns the chain and the call must be via `DELEGATECALL`. If your upgrade command reverts, it is likely
-due to one of these conditions not being met.

--- a/docs/public-docs/chain-operators/tools/op-deployer/usage/upgrade.mdx
+++ b/docs/public-docs/chain-operators/tools/op-deployer/usage/upgrade.mdx
@@ -1,63 +1,10 @@
 ---
-title: Upgrade Command
-description: Learn how to upgrade a chain from one version to another.
+title: Upgrade Command (Deprecated)
+description: The op-deployer upgrade command has been deprecated.
 ---
 
-The `upgrade` command allows you to upgrade a chain from one version to another. It consists of several subcommands, one
-for each upgrade version. Think of it like a database migration: each upgrade command upgrades a chain from exactly
-one previous version to the next. A chain that is several versions behind can be upgrade to the latest version by
-running multiple `upgrade` commands in sequence.
-
-Unlike the `bootstrap` or `apply` commands, `upgrade` does not directly interact with the chain. Instead, it generates
-calldata. You can then use this calldata with `cast`, Gnosis SAFE, [`superchain-ops`](https://github.com/ethereum-optimism/superchain-ops), or whatever
-tooling you use to manage your L1.
-
 <Warning>
-Your chain **must** be owned by a smart contract for `upgrade` to work because the OPCM can only be called via
-`DELEGATECALL`.
+The `op-deployer upgrade` command has been deprecated and is no longer maintained. For L1 contract upgrades, use
+[superchain-ops](/chain-operators/tutorials/l1-contract-upgrades/superchain-ops-guide) or interact with the
+OPCM directly. See the [deprecation notice](/notices/op-deployer-upgrade-deprecation) for details.
 </Warning>
-
-## Usage
-
-Use the `upgrade` command like this:
-
-```shell
-op-deployer upgrade <version> \
-  --config <path to config JSON>
-```
-
-Version `version` must be one of `v2.0.0` or `v3.0.0`.
-
-You can also provide an optional `--override-artifacts-url` flag if you want to point to a different set of artifacts
-from the default. Setting this flag is not recommended.
-
-The config file should look like this:
-
-```json
-{
-  "prank": "<address of the contract that owns the chain>",
-  "opcm": "<address of the chain's OPCM>",
-  "chainConfigs": [
-    {
-      "systemConfigProxy": "<address of the chain's system config proxy>",
-      "proxyAdmin": "<address of the chain's proxy admin>",
-      "absolutePrestate": "<32-byte hash of the chain's absolute prestate>"
-    }
-  ]
-}
-```
-
-You can specify multiple chains in the `chainConfigs` array. The CLI will generate calldata for all chains you
-specify. Note that all of these chains must be upgradeable using the provided OPCM and `prank` address.
-
-The `upgrade` command will provide the following output:
-
-```json
-{
-  "to": "<maps to the prank address>",
-  "data": "<calldata>",
-  "value": "0x0"
-}
-```
-
-You can then use the `data` field in the `to` field as input to `cast` or other tools.

--- a/docs/public-docs/chain-operators/tutorials/l1-contract-upgrades/op-deployer-upgrade.mdx
+++ b/docs/public-docs/chain-operators/tutorials/l1-contract-upgrades/op-deployer-upgrade.mdx
@@ -1,70 +1,25 @@
 ---
-title: Upgrade L1 contracts using op-deployer
-description: Learn about how to upgrade smart contracts using op-deployer
+title: Upgrade L1 contracts using op-deployer (Deprecated)
+description: The op-deployer upgrade command has been deprecated. This page documents which versions it was available for.
 ---
 
-[`op-deployer`](/chain-operators/tools/op-deployer/overview) simplifies the process of deploying and upgrading the OP Stack. Using the `upgrade` command, you can upgrade a chain from one version to the next.
+<Warning>
+The `op-deployer upgrade` command has been deprecated and is no longer maintained. For L1 contract upgrades, use
+[superchain-ops](/chain-operators/tutorials/l1-contract-upgrades/superchain-ops-guide) or interact with the
+OPCM directly. See the [deprecation notice](/notices/op-deployer-upgrade-deprecation) for details.
+</Warning>
 
-It consists of several subcommands, one for each upgrade version. Think of it like a database migration: each upgrade command upgrades a chain from exactly one previous version to the next. A chain that is several versions behind can be upgraded to the latest version by running multiple upgrade commands in sequence.
+## Version availability
 
-Unlike the bootstrap or apply commands, upgrade does not directly interact with the chain. Instead, it generates calldata. You can then use this calldata with cast, Gnosis SAFE, or whatever tooling you use to manage your L1.
+The `op-deployer upgrade` command supported the following contract upgrade paths:
 
-## Limitations of `upgrade`
+| Upgrade path | op-deployer version | Status |
+|---|---|---|
+| op-contracts/v1.8.0 to op-contracts/v2.0.0 | v0.2.x | Deprecated |
+| op-contracts/v2.0.0 to op-contracts/v3.0.0 | v0.3.x | Deprecated |
 
-There are a few limitations to `upgrade`:
+Each minor version of `op-deployer` supported a single release of the governance-approved smart contracts. See the [releases guide](/chain-operators/tools/op-deployer/reference/releases) for more information on versioning.
 
-Using the standard OP Contracts Manager currently requires you to be using the standard shared SuperchainConfig contract. If you're not using this, you will need to utilize the `bootstrap` command to deploy your own Superchain target, including your own `opcm` instance.
+## Migration
 
-## Using `upgrade`
-
-<Steps>
-  <Step title="Install `op-deployer`">
-  [Install `op-deployer`](/operators/chain-operators/tools/op-deployer#installation) from source or pre-built binary.
-  </Step>
-
-  <Step title="Create a `config.json` file">
-  Create a `config.json` file using the following example:
-  
-    ```json
-    {
-      "prank": "<address of the contract of the L1 ProxyAdmin owner>",
-      "opcm": "<address of the chain's OPCM>",
-      "chainConfigs": [
-        {
-          "systemConfigProxy": "<address of the chain's system config proxy>",
-          "proxyAdmin": "<address of the chain's proxy admin>",
-          "absolutePrestate": "<32-byte hash of the chain's absolute prestate>"
-        }
-      ]
-    }
-    ```
-  
-    The standard OPCM instances (`opcm` in the example above) and absolute prestates (`absolutePrestate`) are found in the superchain registry:
-  
-    *   `opcm`: under `op_contracts_manager` for [Mainnet](https://github.com/ethereum-optimism/superchain-registry/blob/main/validation/standard/standard-versions-mainnet.toml) and [Sepolia](https://github.com/ethereum-optimism/superchain-registry/blob/main/validation/standard/standard-versions-sepolia.toml).
-    *   `absolutePrestate`: the `hash` under your [chosen upgrade](https://github.com/ethereum-optimism/superchain-registry/blob/main/validation/standard/standard-prestates.toml)
-  </Step>
-
-  <Step title="Generate calldata">
-  Run the following command:
-  
-    ```bash
-    op-deployer upgrade <version> \
-      --config <path to config JSON>
-    ```
-  
-    `version` must be either major release `2.0` or higher.
-  
-    The output should look like:
-  
-    ```json
-    {
-      "to": "<maps to the prank address>",
-      "data": "<calldata>",
-      "value": "0x0"
-    }
-    ```
-  
-    Now you have the calldata that can be executed onchain to perform the L1 contract upgrade. You should simulate this upgrade and make sure the changes are expected. You can reference the validation files of previously executed upgrade tasks in the [superchain-ops repo](https://github.com/ethereum-optimism/superchain-ops/blob/main/tasks/eth/022-holocene-fp-upgrade/NestedSignFromJson.s.sol) to see what the expected changes are. Once you're confident the state changes are expected, you can sign and execute the upgrade.
-  </Step>
-</Steps>
+For all future L1 contract upgrades, use [superchain-ops](/chain-operators/tutorials/l1-contract-upgrades/superchain-ops-guide). For non-Optimism governed chains, you can interact with the OPCM directly using your own tooling.

--- a/docs/public-docs/chain-operators/tutorials/l1-contract-upgrades/superchain-ops-guide.mdx
+++ b/docs/public-docs/chain-operators/tutorials/l1-contract-upgrades/superchain-ops-guide.mdx
@@ -5,9 +5,9 @@ description: Learn about using superchain-ops to upgrade your chain
 
 This guide outlines the process for upgrading Optimism chains using the `superchain-ops` repository. It's intended primarily for OP Stack chains managed by the Security Council, those with the Foundation or Security Council as signers, and/or chains requiring a highly secure process.
 
-For chains that don't require the enhanced security of superchain-ops or security council signing, you can instead use [op-deployer](/chain-operators/tutorials/l1-contract-upgrades/op-deployer-upgrade) to upgrade your chain.
+For chains that don't require the enhanced security of superchain-ops or security council signing, alternative upgrade tooling may be used. Note that the `op-deployer upgrade` command [has been deprecated](/notices/op-deployer-upgrade-deprecation).
 
-For non-Optimism governed chains, you can use [op-deployer](/chain-operators/tutorials/l1-contract-upgrades/op-deployer-upgrade) and your own tooling to upgrade your chain.
+For non-Optimism governed chains, you can use your own tooling to interact with the OPCM directly to upgrade your chain.
 
 `superchain-ops` is a highly secure service designed for Optimism chains. It provides a structured and security-focused approach to chain upgrades. The process involves creating tasks that use predefined templates to generate the necessary upgrade transactions.
 

--- a/docs/public-docs/docs.json
+++ b/docs/public-docs/docs.json
@@ -55,6 +55,10 @@
   },
   "redirects": [
     {
+      "source": "/chain-operators/tools/op-deployer/usage/upgrade",
+      "destination": "/notices/op-deployer-upgrade-deprecation"
+    },
+    {
       "source": "/pages/app-developers/get-started",
       "destination": "/interop/get-started"
     },
@@ -1970,8 +1974,7 @@
                       "chain-operators/tools/op-deployer/usage/bootstrap",
                       "chain-operators/tools/op-deployer/usage/init",
                       "chain-operators/tools/op-deployer/usage/apply",
-                      "chain-operators/tools/op-deployer/usage/verify",
-                      "chain-operators/tools/op-deployer/usage/upgrade"
+                      "chain-operators/tools/op-deployer/usage/verify"
                     ]
                   },
                   "chain-operators/tools/op-deployer/known-limitations",
@@ -2366,6 +2369,7 @@
             "group": "Notices",
             "pages": [
               "notices/op-geth-deprecation",
+              "notices/op-deployer-upgrade-deprecation",
               {
                 "group": "Archive",
                 "pages": [

--- a/docs/public-docs/notices/op-deployer-upgrade-deprecation.mdx
+++ b/docs/public-docs/notices/op-deployer-upgrade-deprecation.mdx
@@ -1,0 +1,33 @@
+---
+title: Deprecation of op-deployer upgrade and manage commands
+description: The op-deployer upgrade and manage commands are deprecated. Use superchain-ops or the OPCM directly for L1 contract upgrades.
+lang: en-US
+content_type: notice
+topic: op-deployer-upgrade-deprecation
+personas:
+  - chain-operator
+categories:
+  - infrastructure
+is_imported_content: 'false'
+---
+
+The `upgrade` and `manage` commands in `op-deployer` are deprecated and no longer maintained. OP Labs uses the OP Contracts Manager (OPCM) for upgrade and chain management operations, and will focus `op-deployer` on initial chain deployments only.
+
+## What this means
+
+*   The `op-deployer upgrade` and `op-deployer manage` subcommands are no longer supported and will not receive updates.
+*   `op-deployer` itself is **not** deprecated. It remains the recommended tool for initial chain deployments via the `bootstrap`, `init`, `apply`, and `inspect` commands.
+*   For L1 contract upgrades, use [superchain-ops](/chain-operators/tutorials/l1-contract-upgrades/superchain-ops-guide) or interact with the OPCM directly.
+
+## Action required
+
+If you are currently using `op-deployer upgrade` or `op-deployer manage` for L1 contract upgrades, migrate to one of the following approaches:
+
+1.  **[superchain-ops](/chain-operators/tutorials/l1-contract-upgrades/superchain-ops-guide)** — recommended for OP Stack chains managed by the Security Council, chains with the Foundation or Security Council as signers, and chains requiring a highly secure upgrade process.
+2.  **OPCM directly** — for non-Optimism governed chains, you can interact with the OP Contracts Manager directly using your own tooling.
+
+## Resources
+
+*   [superchain-ops upgrade guide](/chain-operators/tutorials/l1-contract-upgrades/superchain-ops-guide)
+*   [OP Contracts Manager reference](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/L1/OPContractsManager.sol)
+*   [OPCM design documentation](https://github.com/ethereum-optimism/design-docs/blob/main/protocol/op-contracts-manager-arch.md)


### PR DESCRIPTION
## Summary

- Adds a new deprecation notice page for the `op-deployer upgrade` and `op-deployer manage` commands
- Removes the `upgrade` command page from the Usage navigation and adds a redirect
- Updates the `op-deployer-upgrade` tutorial to show version availability instead of full usage docs
- Updates the `superchain-ops-guide` to remove references to `op-deployer` for upgrades
- Updates the `custom-deployments` reference to replace the Upgrading section with a deprecation warning
- Adds the deprecation notice to the Notices navigation section

This is a v2 of #19737 to retrigger CI checks after the docs-only CI fix was merged. Incorporates feedback from @soyboy:
- Fixed 404 on notice page (proper frontmatter + docs.json nav entry)
- Removed the usage/upgrade command page from navigation entirely
- Kept version availability info on the op-deployer-upgrade tutorial page
- Updated superchain-ops guide references to op-deployer
- Used `op-deployer` consistently (binary name)

## Test plan

- [ ] Verify the Mintlify preview deploys successfully
- [ ] Verify `/notices/op-deployer-upgrade-deprecation` resolves (no 404)
- [ ] Verify `/chain-operators/tools/op-deployer/usage/upgrade` redirects to the deprecation notice
- [ ] Verify the upgrade page is no longer in the Usage nav section
- [ ] Verify the deprecation notice appears in the Notices nav section
- [ ] Verify CI does NOT run non-docs checks on this docs-only PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)