### PR TITLE
ci: enable SBOM attestation with Rust crate visibility

### DIFF
--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -255,7 +255,7 @@ jobs:
       fail-fast: false
       matrix:
         image_name: ${{ fromJson(needs.detect-changes.outputs.images_json) }}
-    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@f8f3cb4800e538003134fb5f50cc734c2c98d762
+    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@fe0972b97492cd3feee1e6d733636d69b1041a47
     with:
       mode: bake
       image_name: ${{ matrix.image_name }}
@@ -263,6 +263,7 @@ jobs:
       target: ${{ matrix.image_name }}
       gcp_project_id: ${{ vars.GCP_PROJECT_ID_OPLABS_TOOLS_ARTIFACTS }}
       registry: us-docker.pkg.dev/oplabs-tools-artifacts/images
+      sbom: true
       env: |
         GIT_VERSION=${{ fromJson(needs.prep.outputs.versions)[matrix.image_name] }}
       set: |
@@ -282,7 +283,7 @@ jobs:
       fail-fast: false
       matrix:
         image_name: ${{ fromJson(needs.detect-changes.outputs.images_json) }}
-    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@f8f3cb4800e538003134fb5f50cc734c2c98d762
+    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@fe0972b97492cd3feee1e6d733636d69b1041a47
     with:
       mode: bake
       image_name: ${{ matrix.image_name }}
@@ -290,6 +291,7 @@ jobs:
       target: ${{ matrix.image_name }}
       tag: 24h
       registry: ttl.sh/${{ github.sha }}
+      sbom: true
       env: |
         GIT_VERSION=${{ fromJson(needs.prep.outputs.versions)[matrix.image_name] }}
       set: |

--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -255,7 +255,7 @@ jobs:
       fail-fast: false
       matrix:
         image_name: ${{ fromJson(needs.detect-changes.outputs.images_json) }}
-    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@fe0972b97492cd3feee1e6d733636d69b1041a47
+    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@f114f40489bad0c8d187fa49f042b53335d9e431
     with:
       mode: bake
       image_name: ${{ matrix.image_name }}
@@ -263,7 +263,6 @@ jobs:
       target: ${{ matrix.image_name }}
       gcp_project_id: ${{ vars.GCP_PROJECT_ID_OPLABS_TOOLS_ARTIFACTS }}
       registry: us-docker.pkg.dev/oplabs-tools-artifacts/images
-      sbom: true
       env: |
         GIT_VERSION=${{ fromJson(needs.prep.outputs.versions)[matrix.image_name] }}
       set: |
@@ -283,7 +282,7 @@ jobs:
       fail-fast: false
       matrix:
         image_name: ${{ fromJson(needs.detect-changes.outputs.images_json) }}
-    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@fe0972b97492cd3feee1e6d733636d69b1041a47
+    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@f114f40489bad0c8d187fa49f042b53335d9e431
     with:
       mode: bake
       image_name: ${{ matrix.image_name }}
@@ -291,7 +290,6 @@ jobs:
       target: ${{ matrix.image_name }}
       tag: 24h
       registry: ttl.sh/${{ github.sha }}
-      sbom: true
       env: |
         GIT_VERSION=${{ fromJson(needs.prep.outputs.versions)[matrix.image_name] }}
       set: |

--- a/.github/workflows/tags.yaml
+++ b/.github/workflows/tags.yaml
@@ -31,7 +31,7 @@ jobs:
 
   release:
     needs: prep
-    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@fe0972b97492cd3feee1e6d733636d69b1041a47
+    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@f114f40489bad0c8d187fa49f042b53335d9e431
     with:
       mode: bake
       image_name: ${{ needs.prep.outputs.image_name }}
@@ -40,7 +40,6 @@ jobs:
       tag: ${{ needs.prep.outputs.version }}
       gcp_project_id: ${{ vars.GCP_PROJECT_ID_OPLABS_TOOLS_ARTIFACTS }}
       registry: us-docker.pkg.dev/oplabs-tools-artifacts/images
-      sbom: true
       env: |
         GIT_VERSION=${{ fromJson(needs.prep.outputs.versions)[needs.prep.outputs.image_name] }}
       set: |

--- a/.github/workflows/tags.yaml
+++ b/.github/workflows/tags.yaml
@@ -31,7 +31,7 @@ jobs:
 
   release:
     needs: prep
-    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@f8f3cb4800e538003134fb5f50cc734c2c98d762
+    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@fe0972b97492cd3feee1e6d733636d69b1041a47
     with:
       mode: bake
       image_name: ${{ needs.prep.outputs.image_name }}
@@ -40,6 +40,7 @@ jobs:
       tag: ${{ needs.prep.outputs.version }}
       gcp_project_id: ${{ vars.GCP_PROJECT_ID_OPLABS_TOOLS_ARTIFACTS }}
       registry: us-docker.pkg.dev/oplabs-tools-artifacts/images
+      sbom: true
       env: |
         GIT_VERSION=${{ fromJson(needs.prep.outputs.versions)[needs.prep.outputs.image_name] }}
       set: |

--- a/rust/kona/docker/apps/kona_app_generic.dockerfile
+++ b/rust/kona/docker/apps/kona_app_generic.dockerfile
@@ -25,7 +25,7 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 # Install cargo-binstall
 RUN curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
 
-RUN cargo binstall cargo-chef -y
+RUN cargo binstall cargo-chef cargo-auditable -y
 
 ################################
 #    Local Repo Setup Stage    #
@@ -79,7 +79,7 @@ RUN RUSTFLAGS="-C target-cpu=generic" cargo chef cook --bin "${BIN_TARGET}" --pr
 COPY --from=app-setup /workspace .
 # Build the application binary on the selected tag. Since we build the external dependencies in the previous step,
 # this step will reuse the target directory from the previous step.
-RUN RUSTFLAGS="-C target-cpu=generic" cargo build --bin "${BIN_TARGET}" --profile "${BUILD_PROFILE}"
+RUN RUSTFLAGS="-C target-cpu=generic" cargo auditable build --bin "${BIN_TARGET}" --profile "${BUILD_PROFILE}"
 
 # Export stage
 FROM ubuntu:22.04 AS export-stage

--- a/rust/op-reth/DockerfileOp
+++ b/rust/op-reth/DockerfileOp
@@ -5,6 +5,7 @@ LABEL org.opencontainers.image.source=https://github.com/paradigmxyz/reth
 LABEL org.opencontainers.image.licenses="MIT OR Apache-2.0"
 
 RUN apt-get update && apt-get -y upgrade && apt-get install -y libclang-dev pkg-config
+RUN cargo install cargo-auditable
 
 # Builds a cargo-chef plan
 FROM chef AS planner
@@ -26,7 +27,7 @@ ENV FEATURES=$FEATURES
 RUN cargo chef cook --profile $BUILD_PROFILE --features "$FEATURES" --recipe-path recipe.json --manifest-path /app/op-reth/bin/Cargo.toml
 
 COPY . .
-RUN cargo build --profile $BUILD_PROFILE --features "$FEATURES" --bin op-reth --manifest-path /app/op-reth/bin/Cargo.toml
+RUN cargo auditable build --profile $BUILD_PROFILE --features "$FEATURES" --bin op-reth --manifest-path /app/op-reth/bin/Cargo.toml
 
 RUN ls -la /app/target/$BUILD_PROFILE/op-reth
 RUN cp /app/target/$BUILD_PROFILE/op-reth /app/op-reth


### PR DESCRIPTION
## Summary
- Bump factory workflow ref to `f114f40` which adds an `sbom` input defaulting to `true`, so all Docker builds get SPDX SBOM attestations automatically
- Use `cargo auditable build` instead of `cargo build` in op-reth and kona Dockerfiles, embedding the full crate dependency tree into the compiled binaries so SBOM scanners can see Rust dependencies (not just OS packages)
- `op-rbuilder` is a submodule and needs a separate change in its own repo

## Test plan
- [x] Verified SBOM attestation present on `op-reth` (both amd64 and arm64) from an earlier push
- [ ] Verify CI builds succeed with cargo-auditable
- [ ] Inspect a rebuilt Rust image SBOM to confirm crate-level packages appear