### PR TITLE
fix(contracts-bedrock): build contracts before generating NUT bundle

### DIFF
--- a/packages/contracts-bedrock/justfile
+++ b/packages/contracts-bedrock/justfile
@@ -236,7 +236,7 @@ genesis:
   forge script scripts/L2Genesis.s.sol:L2Genesis --sig 'runWithStateDump()'
 
 # Generates the Network Upgrade Transaction (NUT) bundle.
-generate-nut-bundle:
+generate-nut-bundle: build-no-tests
   @forge script scripts/upgrade/GenerateNUTBundle.s.sol:GenerateNUTBundle --sig 'run()' > /dev/null
 
 # Deploys the contracts.


### PR DESCRIPTION
## Summary
- Adds `build-no-tests` as a dependency to `generate-nut-bundle` so source contracts and scripts are compiled before the NUT bundle generation script runs.

## Test plan
- [ ] Run `just generate-nut-bundle` from a clean state (no prior build artifacts) and verify it succeeds