### PR TITLE
ci: bump factory workflow to enable SBOM attestation by default

### DIFF
--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -255,7 +255,7 @@ jobs:
       fail-fast: false
       matrix:
         image_name: ${{ fromJson(needs.detect-changes.outputs.images_json) }}
-    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@f8f3cb4800e538003134fb5f50cc734c2c98d762
+    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@4a6713dc9a56712c9150a8007aa1d33eba6f38ea
     with:
       mode: bake
       image_name: ${{ matrix.image_name }}
@@ -282,7 +282,7 @@ jobs:
       fail-fast: false
       matrix:
         image_name: ${{ fromJson(needs.detect-changes.outputs.images_json) }}
-    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@f8f3cb4800e538003134fb5f50cc734c2c98d762
+    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@4a6713dc9a56712c9150a8007aa1d33eba6f38ea
     with:
       mode: bake
       image_name: ${{ matrix.image_name }}

--- a/.github/workflows/tags.yaml
+++ b/.github/workflows/tags.yaml
@@ -31,7 +31,7 @@ jobs:
 
   release:
     needs: prep
-    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@f8f3cb4800e538003134fb5f50cc734c2c98d762
+    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@4a6713dc9a56712c9150a8007aa1d33eba6f38ea
     with:
       mode: bake
       image_name: ${{ needs.prep.outputs.image_name }}


### PR DESCRIPTION
## Summary
- Bump factory workflow ref to `4a6713d` which adds SBOM generation (defaulting to on) for all Docker image builds
- All images will now have SPDX 2.3 SBOM attestations attached automatically

## Test plan
- [x] Verified SBOM attestation on `op-reth` in #19762