### PR TITLE
ci: use cargo-auditable for Rust image builds

### DIFF
--- a/rust/kona/docker/apps/kona_app_generic.dockerfile
+++ b/rust/kona/docker/apps/kona_app_generic.dockerfile
@@ -25,7 +25,7 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 # Install cargo-binstall
 RUN curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
 
-RUN cargo binstall cargo-chef -y
+RUN cargo binstall cargo-chef cargo-auditable -y
 
 ################################
 #    Local Repo Setup Stage    #
@@ -79,7 +79,7 @@ RUN RUSTFLAGS="-C target-cpu=generic" cargo chef cook --bin "${BIN_TARGET}" --pr
 COPY --from=app-setup /workspace .
 # Build the application binary on the selected tag. Since we build the external dependencies in the previous step,
 # this step will reuse the target directory from the previous step.
-RUN RUSTFLAGS="-C target-cpu=generic" cargo build --bin "${BIN_TARGET}" --profile "${BUILD_PROFILE}"
+RUN RUSTFLAGS="-C target-cpu=generic" cargo auditable build --bin "${BIN_TARGET}" --profile "${BUILD_PROFILE}"
 
 # Export stage
 FROM ubuntu:22.04 AS export-stage

--- a/rust/op-reth/DockerfileOp
+++ b/rust/op-reth/DockerfileOp
@@ -5,6 +5,7 @@ LABEL org.opencontainers.image.source=https://github.com/paradigmxyz/reth
 LABEL org.opencontainers.image.licenses="MIT OR Apache-2.0"
 
 RUN apt-get update && apt-get -y upgrade && apt-get install -y libclang-dev pkg-config
+RUN cargo install cargo-auditable
 
 # Builds a cargo-chef plan
 FROM chef AS planner
@@ -26,7 +27,7 @@ ENV FEATURES=$FEATURES
 RUN cargo chef cook --profile $BUILD_PROFILE --features "$FEATURES" --recipe-path recipe.json --manifest-path /app/op-reth/bin/Cargo.toml
 
 COPY . .
-RUN cargo build --profile $BUILD_PROFILE --features "$FEATURES" --bin op-reth --manifest-path /app/op-reth/bin/Cargo.toml
+RUN cargo auditable build --profile $BUILD_PROFILE --features "$FEATURES" --bin op-reth --manifest-path /app/op-reth/bin/Cargo.toml
 
 RUN ls -la /app/target/$BUILD_PROFILE/op-reth
 RUN cp /app/target/$BUILD_PROFILE/op-reth /app/op-reth


### PR DESCRIPTION
## Summary
- Install `cargo-auditable` in op-reth and kona Dockerfiles
- Use `cargo auditable build` instead of `cargo build` for the final binary step
- This embeds the full crate dependency tree (from `Cargo.lock`) into the compiled binary as a `.dep-v0` ELF section, making all Rust dependencies visible to SBOM scanners and vulnerability tools like trivy and syft
- Without this, SBOM attestations for Rust images only contain OS-level packages (apt/dpkg); with it, they include all Rust crates (e.g., 885 packages for op-reth vs 102 before)
- `op-rbuilder` is a submodule and needs a separate change in its own repo

## Test plan
- [x] Verified in #19762: op-reth SBOM went from 102 packages (OS only) to 885 packages (OS + all Rust crates)
- [x] Verify CI builds succeed