### PR TITLE
op-reth: add chain_id to ExecutingDescriptor

### DIFF
--- a/rust/op-reth/crates/node/src/node.rs
+++ b/rust/op-reth/crates/node/src/node.rs
@@ -977,7 +977,7 @@ where
         // supervisor used for interop txpool validation
         let supervisor_client = if let Some(url) = self.supervisor_http.clone() {
             Some(
-                SupervisorClient::builder(url)
+                SupervisorClient::builder(url, ctx.chain_spec().chain_id())
                     .minimum_safety(self.supervisor_safety_level)
                     .build()
                     .await,

--- a/rust/op-reth/crates/txpool/src/supervisor/client.rs
+++ b/rust/op-reth/crates/txpool/src/supervisor/client.rs
@@ -42,7 +42,10 @@ pub struct SupervisorClient {
 
 impl SupervisorClient {
     /// Returns a new [`SupervisorClientBuilder`].
-    pub fn builder(supervisor_endpoint: impl Into<String>, chain_id: u64) -> SupervisorClientBuilder {
+    pub fn builder(
+        supervisor_endpoint: impl Into<String>,
+        chain_id: u64,
+    ) -> SupervisorClientBuilder {
         SupervisorClientBuilder::new(supervisor_endpoint, chain_id)
     }
 

--- a/rust/op-reth/crates/txpool/src/supervisor/client.rs
+++ b/rust/op-reth/crates/txpool/src/supervisor/client.rs
@@ -42,8 +42,8 @@ pub struct SupervisorClient {
 
 impl SupervisorClient {
     /// Returns a new [`SupervisorClientBuilder`].
-    pub fn builder(supervisor_endpoint: impl Into<String>) -> SupervisorClientBuilder {
-        SupervisorClientBuilder::new(supervisor_endpoint)
+    pub fn builder(supervisor_endpoint: impl Into<String>, chain_id: u64) -> SupervisorClientBuilder {
+        SupervisorClientBuilder::new(supervisor_endpoint, chain_id)
     }
 
     /// Returns configured timeout. See [`SupervisorClientInner`].
@@ -108,7 +108,7 @@ impl SupervisorClient {
         if let Err(err) = self
             .check_access_list(
                 inbox_entries.as_slice(),
-                ExecutingDescriptor::new(timestamp, timeout),
+                ExecutingDescriptor::new(self.inner.chain_id, timestamp, timeout),
             )
             .await
         {
@@ -166,6 +166,8 @@ impl SupervisorClient {
 #[derive(Debug, Clone)]
 pub struct SupervisorClientInner {
     client: ReqwestClient,
+    /// The chain ID of the executing chain
+    chain_id: u64,
     /// The default
     safety: SafetyLevel,
     /// The default request timeout
@@ -179,6 +181,8 @@ pub struct SupervisorClientInner {
 pub struct SupervisorClientBuilder {
     /// Supervisor server's socket.
     endpoint: String,
+    /// The chain ID of the executing chain.
+    chain_id: u64,
     /// Timeout for requests.
     ///
     /// NOTE: this timeout is only effective if it's shorter than the timeout configured for the
@@ -190,9 +194,10 @@ pub struct SupervisorClientBuilder {
 
 impl SupervisorClientBuilder {
     /// Creates a new builder.
-    pub fn new(supervisor_endpoint: impl Into<String>) -> Self {
+    pub fn new(supervisor_endpoint: impl Into<String>, chain_id: u64) -> Self {
         Self {
             endpoint: supervisor_endpoint.into(),
+            chain_id,
             timeout: DEFAULT_REQUEST_TIMEOUT,
             safety: SafetyLevel::CrossUnsafe,
         }
@@ -212,7 +217,7 @@ impl SupervisorClientBuilder {
 
     /// Creates a new supervisor validator.
     pub async fn build(self) -> SupervisorClient {
-        let Self { endpoint, timeout, safety } = self;
+        let Self { endpoint, chain_id, timeout, safety } = self;
 
         let client = ReqwestClient::builder()
             .connect(endpoint.as_str())
@@ -222,6 +227,7 @@ impl SupervisorClientBuilder {
         SupervisorClient {
             inner: Arc::new(SupervisorClientInner {
                 client,
+                chain_id,
                 safety,
                 timeout,
                 metrics: SupervisorMetrics::default(),

--- a/rust/op-reth/crates/txpool/src/supervisor/message.rs
+++ b/rust/op-reth/crates/txpool/src/supervisor/message.rs
@@ -19,10 +19,9 @@
 /// An [`ExecutingDescriptor`] is a part of the payload to `supervisor_checkAccessList`
 /// Spec: <https://github.com/ethereum-optimism/specs/blob/main/specs/interop/supervisor.md#executingdescriptor>
 #[derive(Default, Debug, PartialEq, Eq, Clone, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct ExecutingDescriptor {
     /// The chain ID of the executing chain.
-    #[serde(with = "alloy_serde::quantity")]
+    #[serde(rename = "chainID", with = "alloy_serde::quantity")]
     chain_id: u64,
     /// The timestamp used to enforce timestamp [invariant](https://github.com/ethereum-optimism/specs/blob/main/specs/interop/derivation.md#invariants)
     #[serde(with = "alloy_serde::quantity")]

--- a/rust/op-reth/crates/txpool/src/supervisor/message.rs
+++ b/rust/op-reth/crates/txpool/src/supervisor/message.rs
@@ -19,7 +19,11 @@
 /// An [`ExecutingDescriptor`] is a part of the payload to `supervisor_checkAccessList`
 /// Spec: <https://github.com/ethereum-optimism/specs/blob/main/specs/interop/supervisor.md#executingdescriptor>
 #[derive(Default, Debug, PartialEq, Eq, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ExecutingDescriptor {
+    /// The chain ID of the executing chain.
+    #[serde(with = "alloy_serde::quantity")]
+    chain_id: u64,
     /// The timestamp used to enforce timestamp [invariant](https://github.com/ethereum-optimism/specs/blob/main/specs/interop/derivation.md#invariants)
     #[serde(with = "alloy_serde::quantity")]
     timestamp: u64,
@@ -30,8 +34,8 @@ pub struct ExecutingDescriptor {
 }
 
 impl ExecutingDescriptor {
-    /// Create a new [`ExecutingDescriptor`] from the timestamp and timeout
-    pub const fn new(timestamp: u64, timeout: Option<u64>) -> Self {
-        Self { timestamp, timeout }
+    /// Create a new [`ExecutingDescriptor`] with chain ID, timestamp and timeout
+    pub const fn new(chain_id: u64, timestamp: u64, timeout: Option<u64>) -> Self {
+        Self { chain_id, timestamp, timeout }
     }
 }


### PR DESCRIPTION
## Summary
- Add `chain_id` field to op-reth's `ExecutingDescriptor` struct in the supervisor txpool validator
- Thread chain ID from `ChainSpec` through `SupervisorClientBuilder` -> `SupervisorClientInner` -> `ExecutingDescriptor`
- Include `chainId` in the serialized `supervisor_checkAccessList` RPC payload

## Problem
op-reth's `ExecutingDescriptor` was missing the `chainID` field that the Go-side interop filter expects. When op-reth called `supervisor_checkAccessList`, the filter deserialized `chainID` as 0, then rejected the tx with `"executing chain 0: unknown chain"`.

This broke all cross-chain relay transactions on devnets using op-reth + interop filter.

Closes https://github.com/ethereum-optimism/optimism/issues/19768

## Files changed
- `rust/op-reth/crates/txpool/src/supervisor/message.rs` — add `chain_id` field + `#[serde(rename_all = "camelCase")]`
- `rust/op-reth/crates/txpool/src/supervisor/client.rs` — store `chain_id` in inner, thread through builder
- `rust/op-reth/crates/node/src/node.rs` — pass `ctx.chain_spec().chain_id()` to builder
