### PR TITLE
fix(kona/proof): several fixes to kona-proof.

### DIFF
--- a/op-e2e/actions/proofs/end_of_source_test.go
+++ b/op-e2e/actions/proofs/end_of_source_test.go
@@ -1,0 +1,82 @@
+package proofs
+
+import (
+	"testing"
+
+	actionsHelpers "github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
+	"github.com/ethereum-optimism/optimism/op-e2e/actions/proofs/helpers"
+	"github.com/ethereum-optimism/optimism/op-program/client/claim"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+// runEndOfSourceOutputRootTest tests FPP behavior when the kona derivation pipeline hits EndOfSource
+// before deriving any blocks beyond the agreed prestate. The FPP should return the agreed prestate's
+// output root (i.e. the safe head output root), not a zero output root.
+func runEndOfSourceOutputRootTest(gt *testing.T, testCfg *helpers.TestCfg[any]) {
+	t := actionsHelpers.NewDefaultTesting(gt)
+	env := helpers.NewL2FaultProofEnv(t, testCfg, helpers.NewTestParams(), helpers.NewBatcherCfg())
+
+	// Build 1 L2 block, batch it to L1, and sync
+	env.Sequencer.ActL2StartBlock(t)
+	env.Sequencer.ActL2EndBlock(t)
+	env.BatchMineAndSync(t)
+
+	l2SafeHead := env.Engine.L2Chain().CurrentSafeBlock()
+	safeHeadNum := bigs.Uint64Strict(l2SafeHead.Number)
+	require.Equal(t, uint64(1), safeHeadNum)
+
+	// Get the output root at the safe head via the rollup client
+	rollupClient := env.Sequencer.RollupClient()
+	safeHeadOutput, err := rollupClient.OutputAtBlock(t.Ctx(), safeHeadNum)
+	require.NoError(t, err)
+
+	safeHeadOutputRoot := common.Hash(safeHeadOutput.OutputRoot)
+	safeHeadHash := safeHeadOutput.BlockRef.Hash
+
+	params := []helpers.FixtureInputParam{
+		func(f *helpers.FixtureInputs) {
+			f.L2OutputRoot = safeHeadOutputRoot
+		},
+		func(f *helpers.FixtureInputs) {
+			f.L2Head = safeHeadHash
+		},
+		helpers.WithL2BlockNumber(safeHeadNum + 1),
+		helpers.WithL2Claim(safeHeadOutputRoot),
+	}
+	params = append(params, testCfg.InputParams...)
+
+	env.RunFaultProofProgram(t, safeHeadNum, testCfg.CheckResult, params...)
+}
+
+// Test_ProgramAction_EndOfSourceOutputRoot verifies that the FPP correctly returns the agreed
+// prestate output root when EndOfSource is reached before deriving any new blocks.
+func Test_ProgramAction_EndOfSourceOutputRoot(gt *testing.T) {
+	matrix := helpers.NewMatrix[any]()
+	defer matrix.Run(gt)
+
+	matrix.AddTestCase(
+		"HonestClaim",
+		nil,
+		helpers.LatestForkOnly,
+		runEndOfSourceOutputRootTest,
+		helpers.ExpectNoError(),
+	)
+	matrix.AddTestCase(
+		"JunkClaim",
+		nil,
+		helpers.LatestForkOnly,
+		runEndOfSourceOutputRootTest,
+		helpers.ExpectError(claim.ErrClaimNotValid),
+		helpers.WithL2Claim(common.HexToHash("0xdeadbeef")),
+	)
+	matrix.AddTestCase(
+		"ZeroClaim",
+		nil,
+		helpers.LatestForkOnly,
+		runEndOfSourceOutputRootTest,
+		helpers.ExpectError(claim.ErrClaimNotValid),
+		helpers.WithL2Claim(common.Hash{}),
+	)
+}

--- a/op-e2e/actions/proofs/trace_extension_test.go
+++ b/op-e2e/actions/proofs/trace_extension_test.go
@@ -35,6 +35,67 @@ func runSafeHeadTraceExtensionTest(gt *testing.T, testCfg *helpers.TestCfg[any])
 	env.RunFaultProofProgram(t, bigs.Uint64Strict(l2SafeHead.Number), testCfg.CheckResult, params...)
 }
 
+func runTraceExtensionLeafTest(gt *testing.T, testCfg *helpers.TestCfg[any]) {
+	t := actionsHelpers.NewDefaultTesting(gt)
+	env := helpers.NewL2FaultProofEnv(t, testCfg, helpers.NewTestParams(), helpers.NewBatcherCfg())
+
+	// Build two empty blocks on L2.
+	// We want a transition where the agreed output root is at block N, but the claim targets block N+1,
+	// and maliciously repeats the output root from block N. This is invalid, and used to be accepted
+	// by kona due to faulty trace-extension short-circuiting based only on root equality.
+	env.Sequencer.ActL2StartBlock(t)
+	env.Sequencer.ActL2EndBlock(t)
+	env.Sequencer.ActL2StartBlock(t)
+	env.Sequencer.ActL2EndBlock(t)
+
+	env.BatchMineAndSync(t)
+
+	l1Head := env.Miner.L1Chain().CurrentBlock()
+	l2SafeHead := env.Engine.L2Chain().CurrentSafeBlock()
+
+	// Ensure there is only 1 block on L1.
+	require.Equal(t, uint64(1), bigs.Uint64Strict(l1Head.Number))
+	// Ensure the block is marked as safe before we attempt to fault prove it.
+	require.Equal(t, uint64(2), bigs.Uint64Strict(l2SafeHead.Number))
+
+	// Prove the transition 1 -> 2. This means the agreed output root is at block 1, and the claim
+	// targets block 2.
+	env.RunFaultProofProgram(t, 2, testCfg.CheckResult, testCfg.InputParams...)
+}
+
+func runTraceExtensionRepeatedRootAtNextBlockTest(gt *testing.T, testCfg *helpers.TestCfg[any]) {
+	t := actionsHelpers.NewDefaultTesting(gt)
+	env := helpers.NewL2FaultProofEnv(t, testCfg, helpers.NewTestParams(), helpers.NewBatcherCfg())
+
+	// Build two empty blocks on L2.
+	env.Sequencer.ActL2StartBlock(t)
+	env.Sequencer.ActL2EndBlock(t)
+	env.Sequencer.ActL2StartBlock(t)
+	env.Sequencer.ActL2EndBlock(t)
+
+	env.BatchMineAndSync(t)
+
+	l1Head := env.Miner.L1Chain().CurrentBlock()
+	l2SafeHead := env.Engine.L2Chain().CurrentSafeBlock()
+
+	// Ensure there is only 1 block on L1.
+	require.Equal(t, uint64(1), bigs.Uint64Strict(l1Head.Number))
+	// Ensure the block is marked as safe before we attempt to fault prove it.
+	require.Equal(t, uint64(2), bigs.Uint64Strict(l2SafeHead.Number))
+
+	rollupClient := env.Sequencer.L2Verifier.RollupClient()
+	out1, err := rollupClient.OutputAtBlock(t.Ctx(), 1)
+	require.NoError(t, err)
+
+	params := []helpers.FixtureInputParam{
+		helpers.WithL2Claim(common.Hash(out1.OutputRoot)),
+	}
+	params = append(params, testCfg.InputParams...)
+
+	// Prove the transition 1 -> 2, but maliciously repeat the output root from block 1 at block 2.
+	env.RunFaultProofProgram(t, 2, testCfg.CheckResult, params...)
+}
+
 // Test_ProgramAction_SafeHeadTraceExtension checks that op-program correctly handles the trace extension case where
 // the claimed l2 block number is after the safe head. The honest actor should repeat the output root from the safe head
 // and op-program should consider it valid even though the claimed l2 block number is not reached.
@@ -57,5 +118,27 @@ func Test_ProgramAction_SafeHeadTraceExtension(gt *testing.T) {
 		runSafeHeadTraceExtensionTest,
 		helpers.ExpectError(claim.ErrClaimNotValid),
 		helpers.WithL2Claim(common.HexToHash("0xdeadbeef")),
+	)
+}
+
+// Test_ProgramAction_TraceExtensionLeaf checks that both op-program and kona reject a claim that
+// maliciously repeats the agreed output root at a later (reachable) block number.
+func Test_ProgramAction_TraceExtensionLeaf(gt *testing.T) {
+	matrix := helpers.NewMatrix[any]()
+	defer matrix.Run(gt)
+
+	matrix.AddTestCase(
+		"HonestTransition",
+		nil,
+		helpers.LatestForkOnly,
+		runTraceExtensionLeafTest,
+		helpers.ExpectNoError(),
+	)
+	matrix.AddTestCase(
+		"RepeatedRootAtNextBlock",
+		nil,
+		helpers.LatestForkOnly,
+		runTraceExtensionRepeatedRootAtNextBlockTest,
+		helpers.ExpectError(claim.ErrClaimNotValid),
 	)
 }

--- a/rust/kona/bin/client/src/interop/transition.rs
+++ b/rust/kona/bin/client/src/interop/transition.rs
@@ -97,10 +97,17 @@ where
         );
     }
 
+    let agreed_l2_output_root = boot
+        .agreed_pre_state
+        .active_l2_output_root()
+        .ok_or(FaultProofProgramError::StateTransitionFailed)?
+        .output_root;
+
     // Create a new derivation driver with the given boot information and oracle.
     let cursor = new_oracle_pipeline_cursor(
         rollup_config.as_ref(),
         safe_head,
+        agreed_l2_output_root,
         &mut l1_provider,
         &mut l2_provider,
     )

--- a/rust/kona/bin/client/src/single.rs
+++ b/rust/kona/bin/client/src/single.rs
@@ -82,9 +82,26 @@ where
         ));
     }
 
-    // In the case where the agreed upon L2 output root is the same as the claimed L2 output root,
-    // trace extension is detected and we can skip the derivation and execution steps.
-    if boot.agreed_l2_output_root == boot.claimed_l2_output_root {
+    // If the claim targets the safe head block itself, then no derivation is required. This can
+    // happen at trace-extension leaves where the trace is capped at the root-claim block number.
+    //
+    // In this case, the only valid output root is the agreed output root (a zero-step transition).
+    if boot.claimed_l2_block_number == safe_head.number {
+        if boot.claimed_l2_output_root != boot.agreed_l2_output_root {
+            error!(
+                target: "client",
+                claimed = boot.claimed_l2_block_number,
+                safe = safe_head.number,
+                expected_output_root = ?boot.agreed_l2_output_root,
+                claimed_output_root = ?boot.claimed_l2_output_root,
+                "Claimed output root does not match agreed output root at safe head",
+            );
+            return Err(FaultProofProgramError::InvalidClaim(
+                boot.agreed_l2_output_root,
+                boot.claimed_l2_output_root,
+            ));
+        }
+
         info!(
             target: "client",
             "Trace extension detected. State transition is already agreed upon.",

--- a/rust/kona/bin/client/src/single.rs
+++ b/rust/kona/bin/client/src/single.rs
@@ -117,6 +117,7 @@ where
     let cursor = new_oracle_pipeline_cursor(
         rollup_config.as_ref(),
         safe_head,
+        boot.agreed_l2_output_root,
         &mut l1_provider,
         &mut l2_provider,
     )

--- a/rust/kona/bin/client/tests/trace_extension.rs
+++ b/rust/kona/bin/client/tests/trace_extension.rs
@@ -1,0 +1,159 @@
+use alloy_consensus::Header;
+use alloy_primitives::B256;
+use async_trait::async_trait;
+use kona_client::single::{FaultProofProgramError, run};
+use kona_preimage::{
+    HintWriterClient, PreimageKey, PreimageOracleClient,
+    errors::{PreimageOracleError, PreimageOracleResult},
+};
+use std::{collections::HashMap, sync::Arc};
+use tokio::sync::Mutex;
+
+#[derive(Clone, Debug, Default)]
+struct MockOracle {
+    preimages: Arc<Mutex<HashMap<PreimageKey, Vec<u8>>>>,
+}
+
+impl MockOracle {
+    fn from_preimages(preimages: HashMap<PreimageKey, Vec<u8>>) -> Self {
+        Self { preimages: Arc::new(Mutex::new(preimages)) }
+    }
+}
+
+#[async_trait]
+impl PreimageOracleClient for MockOracle {
+    async fn get(&self, key: PreimageKey) -> PreimageOracleResult<Vec<u8>> {
+        self.preimages
+            .lock()
+            .await
+            .get(&key)
+            .cloned()
+            .ok_or(PreimageOracleError::KeyNotFound)
+    }
+
+    async fn get_exact(&self, key: PreimageKey, buf: &mut [u8]) -> PreimageOracleResult<()> {
+        let data = self.get(key).await?;
+        if data.len() != buf.len() {
+            return Err(PreimageOracleError::BufferLengthMismatch(buf.len(), data.len()));
+        }
+        buf.copy_from_slice(&data);
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+struct MockHintWriter {
+    _hints: Arc<Mutex<Vec<String>>>,
+}
+
+#[async_trait]
+impl HintWriterClient for MockHintWriter {
+    async fn write(&self, hint: &str) -> PreimageOracleResult<()> {
+        self._hints.lock().await.push(hint.to_string());
+        Ok(())
+    }
+}
+
+fn b256(fill: u8) -> B256 {
+    B256::from([fill; 32])
+}
+
+fn setup_preimages(
+    agreed_root: B256,
+    claimed_root: B256,
+    claimed_block_number: u64,
+    safe_head_hash: B256,
+    safe_head_number: u64,
+) -> HashMap<PreimageKey, Vec<u8>> {
+    let mut preimages = HashMap::new();
+
+    // BootInfo local keys (see `kona_proof::boot`):
+    // 1: L1 head hash, 2: agreed output root, 3: claimed output root, 4: claimed block number,
+    // 5: chain id.
+    preimages.insert(PreimageKey::new_local(1), b256(0x11).as_slice().to_vec());
+    preimages.insert(PreimageKey::new_local(2), agreed_root.as_slice().to_vec());
+    preimages.insert(PreimageKey::new_local(3), claimed_root.as_slice().to_vec());
+    preimages.insert(PreimageKey::new_local(4), claimed_block_number.to_be_bytes().to_vec());
+    preimages.insert(PreimageKey::new_local(5), 10u64.to_be_bytes().to_vec());
+
+    // Output root preimage for `fetch_safe_head_hash(...)`. The safe head hash is read from
+    // bytes [96..128].
+    let mut output_root_preimage = [0u8; 128];
+    output_root_preimage[96..128].copy_from_slice(safe_head_hash.as_slice());
+    preimages.insert(
+        PreimageKey::new_keccak256(*agreed_root),
+        output_root_preimage.to_vec(),
+    );
+
+    // L2 safe head header.
+    let mut header = Header::default();
+    header.number = safe_head_number;
+    let header_rlp = alloy_rlp::encode(&header).to_vec();
+    preimages.insert(PreimageKey::new_keccak256(*safe_head_hash), header_rlp);
+
+    preimages
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn trace_extension_leaf_rejects_mismatched_output_root() {
+    let safe_head_number = 3;
+    let safe_head_hash = b256(0x22);
+    let agreed_root = b256(0xAA);
+    let claimed_root = b256(0xBB);
+
+    let oracle = MockOracle::from_preimages(setup_preimages(
+        agreed_root,
+        claimed_root,
+        safe_head_number,
+        safe_head_hash,
+        safe_head_number,
+    ));
+    let hints = MockHintWriter::default();
+
+    let err = run(oracle, hints).await.unwrap_err();
+    match err {
+        FaultProofProgramError::InvalidClaim(expected, actual) => {
+            assert_eq!(expected, agreed_root);
+            assert_eq!(actual, claimed_root);
+        }
+        other => panic!("unexpected error: {other:?}"),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn trace_extension_leaf_accepts_matching_output_root() {
+    let safe_head_number = 3;
+    let safe_head_hash = b256(0x22);
+    let agreed_root = b256(0xAA);
+
+    let oracle = MockOracle::from_preimages(setup_preimages(
+        agreed_root,
+        agreed_root,
+        safe_head_number,
+        safe_head_hash,
+        safe_head_number,
+    ));
+    let hints = MockHintWriter::default();
+
+    run(oracle, hints).await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn does_not_short_circuit_on_root_match_at_different_block() {
+    let safe_head_number = 3;
+    let safe_head_hash = b256(0x22);
+    let agreed_root = b256(0xAA);
+
+    // With the historical bug (checking only `agreed_root == claimed_root`), this would
+    // incorrectly return `Ok(())` without attempting derivation.
+    let oracle = MockOracle::from_preimages(setup_preimages(
+        agreed_root,
+        agreed_root,
+        safe_head_number + 1,
+        safe_head_hash,
+        safe_head_number,
+    ));
+    let hints = MockHintWriter::default();
+
+    assert!(run(oracle, hints).await.is_err());
+}

--- a/rust/kona/bin/client/tests/trace_extension.rs
+++ b/rust/kona/bin/client/tests/trace_extension.rs
@@ -23,12 +23,7 @@ impl MockOracle {
 #[async_trait]
 impl PreimageOracleClient for MockOracle {
     async fn get(&self, key: PreimageKey) -> PreimageOracleResult<Vec<u8>> {
-        self.preimages
-            .lock()
-            .await
-            .get(&key)
-            .cloned()
-            .ok_or(PreimageOracleError::KeyNotFound)
+        self.preimages.lock().await.get(&key).cloned().ok_or(PreimageOracleError::KeyNotFound)
     }
 
     async fn get_exact(&self, key: PreimageKey, buf: &mut [u8]) -> PreimageOracleResult<()> {
@@ -80,14 +75,10 @@ fn setup_preimages(
     // bytes [96..128].
     let mut output_root_preimage = [0u8; 128];
     output_root_preimage[96..128].copy_from_slice(safe_head_hash.as_slice());
-    preimages.insert(
-        PreimageKey::new_keccak256(*agreed_root),
-        output_root_preimage.to_vec(),
-    );
+    preimages.insert(PreimageKey::new_keccak256(*agreed_root), output_root_preimage.to_vec());
 
     // L2 safe head header.
-    let mut header = Header::default();
-    header.number = safe_head_number;
+    let header = Header { number: safe_head_number, ..Default::default() };
     let header_rlp = alloy_rlp::encode(&header).to_vec();
     preimages.insert(PreimageKey::new_keccak256(*safe_head_hash), header_rlp);
 

--- a/rust/kona/bin/host/src/interop/handler.rs
+++ b/rust/kona/bin/host/src/interop/handler.rs
@@ -536,9 +536,12 @@ impl HintHandler for InteropHintHandler {
                             .map(|header| Sealed::new_unchecked(header, agreed_block_hash))?;
                         let target_block = safe_head.number + 1;
 
+                        // The output root is unused in the host re-execution context,
+                        // which only collects preimages for witness generation.
                         let cursor = new_oracle_pipeline_cursor(
                             rollup_config.as_ref(),
                             safe_head,
+                            B256::ZERO,
                             &mut l1_provider,
                             &mut l2_provider,
                         )

--- a/rust/kona/crates/proof/proof/src/sync.rs
+++ b/rust/kona/crates/proof/proof/src/sync.rs
@@ -15,6 +15,7 @@ use spin::RwLock;
 pub async fn new_oracle_pipeline_cursor<L1, L2>(
     rollup_config: &RollupConfig,
     safe_header: Sealed<Header>,
+    agreed_l2_output_root: B256,
     chain_provider: &mut L1,
     l2_chain_provider: &mut L2,
 ) -> Result<Arc<RwLock<PipelineCursor>>, OracleProviderError>
@@ -38,7 +39,7 @@ where
 
     // Construct the cursor.
     let mut cursor = PipelineCursor::new(channel_timeout, origin);
-    let tip = TipCursor::new(safe_head_info, safe_header, B256::ZERO);
+    let tip = TipCursor::new(safe_head_info, safe_header, agreed_l2_output_root);
     cursor.advance(origin, tip);
 
     // Wrap the cursor in a shared read-write lock

--- a/rust/kona/crates/protocol/protocol/src/batch/reader.rs
+++ b/rust/kona/crates/protocol/protocol/src/batch/reader.rs
@@ -5,7 +5,7 @@ use alloc::vec::Vec;
 use alloy_primitives::Bytes;
 use alloy_rlp::Decodable;
 use kona_genesis::RollupConfig;
-use miniz_oxide::inflate::decompress_to_vec_zlib;
+use miniz_oxide::inflate::{TINFLStatus, decompress_to_vec_zlib_with_limit};
 
 /// Error type for decompression failures.
 #[derive(Debug, thiserror::Error)]
@@ -22,9 +22,6 @@ pub enum DecompressionError {
     /// A zlib decompression error.
     #[error("zlib decompression error")]
     ZlibError,
-    /// The RLP data is too large for the configured maximum.
-    #[error("the RLP data is too large: {0} bytes, maximum allowed: {1} bytes")]
-    RlpTooLarge(usize, usize),
 }
 
 /// Batch Reader provides a function that iteratively consumes batches from the reader.
@@ -71,34 +68,56 @@ impl BatchReader {
     }
 
     /// Helper method to decompress the data contained in the reader.
+    /// No-op if the data has already been decompressed.
     pub fn decompress(&mut self) -> Result<(), DecompressionError> {
-        if let Some(data) = self.data.take() {
-            // Peek at the data to determine the compression type.
-            if data.is_empty() {
-                return Err(DecompressionError::EmptyData);
-            }
-
-            let compression_type = data[0];
-            if (compression_type & 0x0F) == Self::ZLIB_DEFLATE_COMPRESSION_METHOD ||
-                (compression_type & 0x0F) == Self::ZLIB_RESERVED_COMPRESSION_METHOD
-            {
-                self.decompressed =
-                    decompress_to_vec_zlib(&data).map_err(|_| DecompressionError::ZlibError)?;
-
-                // Check the size of the decompressed channel RLP.
-                if self.decompressed.len() > self.max_rlp_bytes_per_channel {
-                    return Err(DecompressionError::RlpTooLarge(
-                        self.decompressed.len(),
-                        self.max_rlp_bytes_per_channel,
-                    ));
+        if !self.decompressed.is_empty() {
+            return Ok(());
+        }
+        match self.data.take() {
+            None => Err(DecompressionError::EmptyData),
+            Some(data) if data.is_empty() => Err(DecompressionError::EmptyData),
+            Some(data) => {
+                // Peek at the data to determine the compression type.
+                let compression_type = data[0];
+                if (compression_type & 0x0F) == Self::ZLIB_DEFLATE_COMPRESSION_METHOD ||
+                    (compression_type & 0x0F) == Self::ZLIB_RESERVED_COMPRESSION_METHOD
+                {
+                    self.decompress_zlib(data)
+                } else if compression_type == Self::CHANNEL_VERSION_BROTLI {
+                    self.decompress_brotli(data)
+                } else {
+                    Err(DecompressionError::UnsupportedType(compression_type))
                 }
-            } else if compression_type == Self::CHANNEL_VERSION_BROTLI {
-                self.brotli_used = true;
-                self.decompressed = decompress_brotli(&data[1..], self.max_rlp_bytes_per_channel)?;
-            } else {
-                return Err(DecompressionError::UnsupportedType(compression_type));
             }
         }
+    }
+
+    fn decompress_zlib(&mut self, data: Vec<u8>) -> Result<(), DecompressionError> {
+        // Decompress with a limit to prevent zip-bomb attacks.
+        // Per spec, if decompressed data exceeds the limit, the output is
+        // truncated to max_rlp_bytes_per_channel bytes (not rejected).
+        match decompress_to_vec_zlib_with_limit(&data, self.max_rlp_bytes_per_channel) {
+            Ok(decompressed) => {
+                self.decompressed = decompressed;
+            }
+            Err(e) if (e.status == TINFLStatus::HasMoreOutput || !e.output.is_empty()) => {
+                // Either: limit reached — truncate per spec and keep partial output.
+                // Or: decompression error with partial output — keep it so
+                // batches decoded before the error point are accepted.
+                self.decompressed = e.output;
+            }
+            Err(_) => {
+                return Err(DecompressionError::ZlibError);
+            }
+        }
+        Ok(())
+    }
+
+    fn decompress_brotli(&mut self, data: Vec<u8>) -> Result<(), DecompressionError> {
+        self.brotli_used = true;
+        // Note: the first byte of the channel data is the Brotli channel version but not part of
+        // the compressed data, so it's skipped here but not for zlib.
+        self.decompressed = decompress_brotli(&data[1..], self.max_rlp_bytes_per_channel)?;
         Ok(())
     }
 
@@ -131,6 +150,10 @@ mod test {
     use kona_genesis::{
         HardForkConfig, MAX_RLP_BYTES_PER_CHANNEL_BEDROCK, MAX_RLP_BYTES_PER_CHANNEL_FJORD,
     };
+    use miniz_oxide::{
+        deflate::{CompressionLevel, compress_to_vec_zlib},
+        inflate::decompress_to_vec_zlib,
+    };
 
     fn new_compressed_batch_data() -> Bytes {
         let file_contents =
@@ -161,5 +184,65 @@ mod test {
             })
             .unwrap();
         assert_eq!(reader.cursor, decompressed_len);
+    }
+
+    /// Builds zlib-compressed channel data containing `n` copies of the same
+    /// batch by duplicating the decompressed RLP content from the test fixture.
+    fn new_multi_batch_compressed_data(n: usize) -> (Bytes, usize) {
+        let raw = new_compressed_batch_data();
+        let single = decompress_to_vec_zlib(&raw).unwrap();
+
+        let mut multi = Vec::with_capacity(single.len() * n);
+        for _ in 0..n {
+            multi.extend_from_slice(&single);
+        }
+        let decompressed_len = multi.len();
+        (compress_to_vec_zlib(&multi, CompressionLevel::BestSpeed.into()).into(), decompressed_len)
+    }
+
+    #[test]
+    fn test_zlib_truncation_instead_of_rejection() {
+        let raw = new_compressed_batch_data();
+        let decompressed_len = decompress_to_vec_zlib(&raw).unwrap().len();
+        assert!(decompressed_len > 1, "test data must decompress to >1 byte");
+
+        // Set limit below decompressed size — should truncate, not error.
+        let limit = decompressed_len / 2;
+        let mut reader = BatchReader::new(raw, limit);
+        assert!(reader.decompress().is_ok());
+        assert_eq!(reader.decompressed.len(), limit);
+    }
+
+    #[test]
+    fn test_zlib_truncation_yields_decodable_batches() {
+        let n = 3;
+        let (compressed, full_len) = new_multi_batch_compressed_data(n);
+        let single_batch_len = full_len / n;
+
+        // Full decompression should yield all n batches.
+        let mut reader = BatchReader::new(compressed.clone(), full_len);
+        let mut count = 0;
+        while reader.next_batch(&RollupConfig::default()).is_some() {
+            count += 1;
+        }
+        assert_eq!(count, n, "should decode {n} batches from full channel");
+
+        // Truncate to just under the last batch — should yield n-1 batches.
+        let limit = full_len - 1;
+        let mut reader = BatchReader::new(compressed, limit);
+        let mut count = 0;
+        while reader.next_batch(&RollupConfig::default()).is_some() {
+            count += 1;
+        }
+        assert_eq!(
+            count,
+            n - 1,
+            "truncated channel should yield {exp} batches (cursor at {cursor}, \
+             single batch is {single_batch_len} bytes, limit {limit})",
+            exp = n - 1,
+            cursor = reader.cursor,
+        );
+        // First n-1 batches should have been fully consumed.
+        assert_eq!(reader.cursor, single_batch_len * (n - 1));
     }
 }

--- a/rust/kona/crates/protocol/protocol/src/brotli.rs
+++ b/rust/kona/crates/protocol/protocol/src/brotli.rs
@@ -2,17 +2,15 @@
 
 use alloc::{vec, vec::Vec};
 use alloc_no_stdlib::*;
-use brotli::*;
+use brotli::{BrotliResult, *};
 use core::ops;
 
-use crate::MAX_SPAN_BATCH_ELEMENTS;
-
-/// A frame decompression error.
-#[derive(thiserror::Error, Debug, PartialEq, Eq)]
+/// A brotli decompression error.
+#[derive(thiserror::Error, Debug)]
 pub enum BrotliDecompressionError {
-    /// The buffer exceeds the [`MAX_SPAN_BATCH_ELEMENTS`] protocol parameter.
-    #[error("The batch exceeds the maximum number of elements: {max_size}", max_size = MAX_SPAN_BATCH_ELEMENTS)]
-    BatchTooLarge,
+    /// Brotli decompression failed due to corrupt or invalid data.
+    #[error("brotli decompression failed: {0:?}")]
+    DecompressionFailed(BrotliResult),
 }
 
 /// Decompresses the given bytes data using the Brotli decompressor implemented
@@ -32,17 +30,21 @@ pub fn decompress_brotli(
     let hc_allocator = MemPool::<HuffmanCode>::new_allocator(&mut hc_buffer, bzero);
     let mut brotli_state = BrotliState::new(u8_allocator, u32_allocator, hc_allocator);
 
-    // Setup the decompressor inputs and outputs
-    let mut output = vec![0; data.len()];
+    // Setup the decompressor inputs and outputs.
+    // Cap initial buffer at the limit to prevent over-allocation.
+    let mut output = vec![0; core::cmp::min(data.len(), max_rlp_bytes_per_channel)];
     let mut available_in = data.len();
     let mut input_offset = 0;
     let mut available_out = output.len();
     let mut output_offset = 0;
     let mut written = 0;
 
-    // Decompress the data stream until success or failure
-    while matches!(
-        brotli::BrotliDecompressStream(
+    // Decompress the data stream until success or failure.
+    // The output buffer is grown as needed, capped at max_rlp_bytes_per_channel.
+    // Per spec, if decompressed data exceeds the limit, the output is truncated
+    // to max_rlp_bytes_per_channel bytes (not rejected).
+    loop {
+        let result = brotli::BrotliDecompressStream(
             &mut available_in,
             &mut input_offset,
             data,
@@ -51,25 +53,30 @@ pub fn decompress_brotli(
             &mut output,
             &mut written,
             &mut brotli_state,
-        ),
-        brotli::BrotliResult::NeedsMoreOutput
-    ) {
-        // Resize the output buffer to double the size, following standard
-        // practice for buffer resizing in streams.
+        );
         let old_len = output.len();
-        let new_len = old_len * 2;
 
-        if new_len > max_rlp_bytes_per_channel {
-            return Err(BrotliDecompressionError::BatchTooLarge);
+        match result {
+            // Buffer was already grown to the limit on a previous iteration, but the decompressor
+            // filled it and still has more to produce: stop per spec.
+            BrotliResult::NeedsMoreOutput if old_len >= max_rlp_bytes_per_channel => break,
+            // Enlarge output buffer to continue decompression.
+            BrotliResult::NeedsMoreOutput => {
+                let new_len = core::cmp::min((old_len * 2).max(1), max_rlp_bytes_per_channel);
+                output.resize(new_len, 0);
+                available_out += new_len - old_len;
+            }
+            // No output: error.
+            _ if written == 0 => {
+                return Err(BrotliDecompressionError::DecompressionFailed(result));
+            }
+            // Success, NeedsMoreInput or ResultFailure with some output written: return partial
+            // data.
+            _ => break,
         }
-
-        output.resize(new_len, 0);
-        available_out += old_len;
     }
 
-    // Truncate the output buffer to the written bytes
     output.truncate(written);
-
     Ok(output)
 }
 
@@ -101,5 +108,56 @@ mod test {
         let decompressed =
             decompress_brotli(&raw_batch, MAX_RLP_BYTES_PER_CHANNEL_FJORD as usize).unwrap();
         assert_eq!(decompressed, raw_batch_decompressed);
+    }
+
+    #[test]
+    fn test_brotli_truncation_instead_of_rejection() {
+        // Use the small test data to verify truncation behavior.
+        let expected = hex!("75ed184249e9bc19675e");
+        let compressed = hex!("8b048075ed184249e9bc19675e03");
+        let full_len = expected.len();
+
+        // Full limit — should decompress fully.
+        let decompressed = decompress_brotli(&compressed, full_len).unwrap();
+        assert_eq!(decompressed, expected);
+
+        // Limit smaller than data — should truncate, not error.
+        let limit = full_len / 2;
+        let decompressed = decompress_brotli(&compressed, limit).unwrap();
+        assert!(
+            decompressed.len() <= limit,
+            "truncated output ({}) should not exceed limit ({})",
+            decompressed.len(),
+            limit
+        );
+    }
+
+    #[test]
+    fn test_brotli_buffer_doubling_regression() {
+        // Regression test for the buffer-doubling bug: the old code doubled the
+        // output buffer and rejected if the doubled size exceeded the limit,
+        // even if the actual decompressed data fit within the limit.
+        //
+        // Example: 100 bytes of data, initial buffer = compressed.len() (small),
+        // buffer doubles past 100 -> old code returns BatchTooLarge.
+        let data = vec![0xAA; 100];
+        let compressed = {
+            let params = brotli::enc::BrotliEncoderParams::default();
+            let mut output = alloc::vec::Vec::new();
+            let mut input = &data[..];
+            brotli::BrotliCompress(&mut input, &mut output, &params).unwrap();
+            output
+        };
+
+        // Limit = exact decompressed size. The old code would error because
+        // internal buffer doubling would overshoot.
+        let result = decompress_brotli(&compressed, data.len());
+        assert!(result.is_ok(), "decompression at exact limit should succeed");
+        assert_eq!(result.unwrap(), data);
+
+        // Limit = data.len() + 1 — also succeeds.
+        let result = decompress_brotli(&compressed, data.len() + 1);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), data);
     }
 }


### PR DESCRIPTION
## Description

This PR contains several important fixes to kona-proof's derivation logic. In particular:
- c4950d67f560da88ae24ad4076c5034dac8e2868 fixes the trace-extension logic by preventing a malicious attacker from trivially challenging kona by sending a root anchored at a wrong height.
- 27fd483a0269dd0e79d5affcecee1166524efb4e ensures that the derivation's output root is non-trivial
- c390d771c65d783503f82fb76fb0b1d8628c605b fixes a potential OOM vulnerability for batch decompression