### PR TITLE
ci(rust): downsize 7 Rust CI jobs from xlarge to medium

### DIFF
--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -433,7 +433,7 @@ jobs:
         default: "stable"
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
-    resource_class: xlarge
+    resource_class: medium
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
@@ -561,7 +561,7 @@ jobs:
         default: "just check-no-std"
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
-    resource_class: xlarge
+    resource_class: medium
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
@@ -590,7 +590,7 @@ jobs:
         default: "just lint-docs"
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
-    resource_class: xlarge
+    resource_class: medium
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
@@ -693,7 +693,7 @@ jobs:
         default: "just check-udeps"
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
-    resource_class: xlarge
+    resource_class: medium
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
@@ -732,7 +732,7 @@ jobs:
         default: "--workspace"
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
-    resource_class: xlarge
+    resource_class: medium
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
@@ -794,7 +794,7 @@ jobs:
   op-reth-compact-codec:
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
-    resource_class: xlarge
+    resource_class: medium
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
@@ -969,7 +969,7 @@ jobs:
   rust-docs-build:
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
-    resource_class: xlarge
+    resource_class: medium
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless

--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -590,7 +590,7 @@ jobs:
         default: "just lint-docs"
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
-    resource_class: medium
+    resource_class: xlarge
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless


### PR DESCRIPTION
## Summary

Reduce `resource_class` from `xlarge` (40 cr/min) to `medium` (10 cr/min) for 6 Docker-based Rust CI jobs. Saves ~613 credits per `rust-ci` workflow run (~71% reduction on affected jobs) with negligible wall-clock impact.

### Jobs changed

| Job | Develop avg (xlarge) | PR (medium) | Delta |
|-----|:---:|:---:|:---:|
| `rust-ci-clippy` | 2.9 min | 3.1 min | +0.2 min |
| `rust-ci-check-no-std` | 5.5 min | 6.2 min | +0.7 min |
| `rust-ci-udeps` | 2.7 min | 2.8 min | +0.1 min |
| `rust-ci-cargo-hack-build` (wasm-unknown) | 1.9 min | 2.1 min | +0.2 min |
| `rust-ci-cargo-hack-build` (wasm-wasi) | 1.9 min | 2.0 min | +0.1 min |
| `op-reth-compact-codec` | 4.4 min | 6.4 min | +2.0 min |
| `rust-docs-build` | 2.2 min | 2.2 min | +0.0 min |

### Not changed

| Job | Reason |
|-----|--------|
| `rust-ci-docs` | OOM killed on medium (SIGKILL) — needs xlarge memory |
| `kona-cargo-lint`, `kona-build-fpvm`, `kona-host-client-offline` | Machine executors (Docker-in-Docker + privileged access) |
| `rust-ci-cargo-hack`, `rust-ci-cargo-tests`, `rust-ci-doctest`, `rust-build-*` | Heavy compilation/test jobs that benefit from xlarge CPUs |

### Credit savings

| | xlarge (40 cr/min) | medium (10 cr/min) | Savings |
|---|---:|---:|---:|
| Affected jobs total | 861 cr | 248 cr | **613 cr/run** |

No impact on workflow wall-clock time — the critical path is `rust-cargo-hack` (25–34 min) and `rust-tests` (19–21 min), which are unchanged.

## Test plan

- [x] All 6 affected jobs pass on medium
- [x] `rust-ci-docs` confirmed OOM on medium, reverted to xlarge
- [x] Runtime comparison shows acceptable wall-clock increase (max +2 min on `op-reth-compact-codec`)
- [ ] Full CI green after revert of `rust-ci-docs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)