### PR TITLE
ci: gate contract feature matrix jobs on path changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,8 @@ workflows:
             .* c-github-event-base64 << pipeline.parameters.github-event-base64 >> .circleci/continue/main.yml
             .* c-go-cache-version << pipeline.parameters.go-cache-version >> .circleci/continue/main.yml
             rust/.* c-rust_files_changed true .circleci/continue/main.yml
-            packages/contracts-bedrock/.* c-contracts_changed true .circleci/continue/main.yml
+            (packages/contracts-bedrock|\.circleci|\.github|ops/check-changed)/.* c-contracts_changed true .circleci/continue/main.yml
+            ^(package\.json|mise\.toml|go\.mod|go\.sum)$ c-contracts_changed true .circleci/continue/main.yml
             ^(?!docs/public-docs/).+ c-non_docs_changes true .circleci/continue/main.yml
 
             # Docs CI — trigger on docs/public-docs/ changes

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,7 @@ workflows:
             .* c-go-cache-version << pipeline.parameters.go-cache-version >> .circleci/continue/main.yml
             rust/.* c-rust_files_changed true .circleci/continue/main.yml
             (packages/contracts-bedrock|\.circleci|\.github|ops/check-changed)/.* c-contracts_changed true .circleci/continue/main.yml
-            ^(package\.json|mise\.toml|go\.mod|go\.sum)$ c-contracts_changed true .circleci/continue/main.yml
+            ^(package\.json|mise\.toml)$ c-contracts_changed true .circleci/continue/main.yml
             ^(?!docs/public-docs/).+ c-non_docs_changes true .circleci/continue/main.yml
 
             # Docs CI — trigger on docs/public-docs/ changes

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ workflows:
             .* c-github-event-base64 << pipeline.parameters.github-event-base64 >> .circleci/continue/main.yml
             .* c-go-cache-version << pipeline.parameters.go-cache-version >> .circleci/continue/main.yml
             rust/.* c-rust_files_changed true .circleci/continue/main.yml
-            (packages/contracts-bedrock|\.github|ops/check-changed)/.* c-contracts_changed true .circleci/continue/main.yml
+            (packages/contracts-bedrock|\.circleci|\.github|ops/check-changed)/.* c-contracts_changed true .circleci/continue/main.yml
             ^(package\.json|mise\.toml)$ c-contracts_changed true .circleci/continue/main.yml
             ^(?!docs/public-docs/).+ c-non_docs_changes true .circleci/continue/main.yml
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,6 +107,7 @@ workflows:
             .* c-github-event-base64 << pipeline.parameters.github-event-base64 >> .circleci/continue/main.yml
             .* c-go-cache-version << pipeline.parameters.go-cache-version >> .circleci/continue/main.yml
             rust/.* c-rust_files_changed true .circleci/continue/main.yml
+            (packages/contracts-bedrock|op-node)/.* c-contracts_changed true .circleci/continue/main.yml
             ^(?!docs/public-docs/).+ c-non_docs_changes true .circleci/continue/main.yml
 
             # Docs CI — trigger on docs/public-docs/ changes

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ workflows:
             .* c-github-event-base64 << pipeline.parameters.github-event-base64 >> .circleci/continue/main.yml
             .* c-go-cache-version << pipeline.parameters.go-cache-version >> .circleci/continue/main.yml
             rust/.* c-rust_files_changed true .circleci/continue/main.yml
-            (packages/contracts-bedrock|op-node)/.* c-contracts_changed true .circleci/continue/main.yml
+            packages/contracts-bedrock/.* c-contracts_changed true .circleci/continue/main.yml
             ^(?!docs/public-docs/).+ c-non_docs_changes true .circleci/continue/main.yml
 
             # Docs CI — trigger on docs/public-docs/ changes

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,12 @@ orbs:
 workflows:
   setup:
     when:
-      equal: ["", << pipeline.git.tag >>]
+      and:
+        - equal: ["", << pipeline.git.tag >>]
+        - not:
+            matches:
+              pattern: "^gh-readonly-queue/"
+              value: << pipeline.git.branch >>
     jobs:
       - path-filtering/filter: &path_filter
           base-revision: develop
@@ -114,6 +119,64 @@ workflows:
             # Docs CI — trigger on docs/public-docs/ changes
             .* c-default_docker_image << pipeline.parameters.default_docker_image >> .circleci/continue/docs-ci.yml
             docs/public-docs/.* c-docs_changes_detected true .circleci/continue/docs-ci.yml
+
+            # Rust CI — always include config, gate jobs via c-rust_changes_detected
+            .* c-default_docker_image << pipeline.parameters.default_docker_image >> .circleci/continue/rust-ci.yml
+            .* c-base_image << pipeline.parameters.base_image >> .circleci/continue/rust-ci.yml
+            .* c-go-cache-version << pipeline.parameters.go-cache-version >> .circleci/continue/rust-ci.yml
+            .* c-rust_ci_dispatch << pipeline.parameters.rust_ci_dispatch >> .circleci/continue/rust-ci.yml
+            (rust|\.circleci)/.* c-rust_changes_detected true .circleci/continue/rust-ci.yml
+            ^(?!docs/public-docs/).+ c-non_docs_changes true .circleci/continue/rust-ci.yml
+
+            # Rust E2E — always include config, gate jobs via c-rust_changes_detected
+            .* c-default_docker_image << pipeline.parameters.default_docker_image >> .circleci/continue/rust-e2e.yml
+            .* c-go-cache-version << pipeline.parameters.go-cache-version >> .circleci/continue/rust-e2e.yml
+            .* c-rust_e2e_dispatch << pipeline.parameters.rust_e2e_dispatch >> .circleci/continue/rust-e2e.yml
+            (rust|op-e2e|\.circleci)/.* c-rust_changes_detected true .circleci/continue/rust-e2e.yml
+            ^(?!docs/public-docs/).+ c-non_docs_changes true .circleci/continue/rust-e2e.yml
+
+  # Merge queue setup — identical to setup but passes c-is_merge_queue true.
+  # Runs exclusively for branches created by GitHub merge queue.
+  # IMPORTANT: keep mapping in sync with the setup workflow above.
+  setup-merge-queue:
+    when:
+      and:
+        - equal: ["", << pipeline.git.tag >>]
+        - matches:
+            pattern: "^gh-readonly-queue/"
+            value: << pipeline.git.branch >>
+    jobs:
+      - path-filtering/filter:
+          <<: *path_filter
+          mapping: |
+            # Merge queue flag — only lines unique to this workflow
+            .* c-is_merge_queue true .circleci/continue/main.yml
+            .* c-is_merge_queue true .circleci/continue/rust-ci.yml
+            .* c-is_merge_queue true .circleci/continue/rust-e2e.yml
+
+            # Everything below is identical to the setup workflow mapping.
+            .* c-default_docker_image << pipeline.parameters.default_docker_image >> .circleci/continue/main.yml
+            .* c-base_image << pipeline.parameters.base_image >> .circleci/continue/main.yml
+            .* c-main_dispatch << pipeline.parameters.main_dispatch >> .circleci/continue/main.yml
+            .* c-fault_proofs_dispatch << pipeline.parameters.fault_proofs_dispatch >> .circleci/continue/main.yml
+            .* c-reproducibility_dispatch << pipeline.parameters.reproducibility_dispatch >> .circleci/continue/main.yml
+            .* c-kontrol_dispatch << pipeline.parameters.kontrol_dispatch >> .circleci/continue/main.yml
+            .* c-cannon_full_test_dispatch << pipeline.parameters.cannon_full_test_dispatch >> .circleci/continue/main.yml
+            .* c-sdk_dispatch << pipeline.parameters.sdk_dispatch >> .circleci/continue/main.yml
+            .* c-publish_contract_artifacts_dispatch << pipeline.parameters.publish_contract_artifacts_dispatch >> .circleci/continue/main.yml
+            .* c-stale_check_dispatch << pipeline.parameters.stale_check_dispatch >> .circleci/continue/main.yml
+            .* c-contracts_coverage_dispatch << pipeline.parameters.contracts_coverage_dispatch >> .circleci/continue/main.yml
+            .* c-heavy_fuzz_dispatch << pipeline.parameters.heavy_fuzz_dispatch >> .circleci/continue/main.yml
+            .* c-ai_contracts_test_dispatch << pipeline.parameters.ai_contracts_test_dispatch >> .circleci/continue/main.yml
+            .* c-l2_fork_test_dispatch << pipeline.parameters.l2_fork_test_dispatch >> .circleci/continue/main.yml
+            .* c-github-event-type << pipeline.parameters.github-event-type >> .circleci/continue/main.yml
+            .* c-github-event-action << pipeline.parameters.github-event-action >> .circleci/continue/main.yml
+            .* c-github-event-base64 << pipeline.parameters.github-event-base64 >> .circleci/continue/main.yml
+            .* c-go-cache-version << pipeline.parameters.go-cache-version >> .circleci/continue/main.yml
+            rust/.* c-rust_files_changed true .circleci/continue/main.yml
+            (packages/contracts-bedrock|\.circleci|\.github|ops/check-changed)/.* c-contracts_changed true .circleci/continue/main.yml
+            ^(package\.json|mise\.toml)$ c-contracts_changed true .circleci/continue/main.yml
+            ^(?!docs/public-docs/).+ c-non_docs_changes true .circleci/continue/main.yml
 
             # Rust CI — always include config, gate jobs via c-rust_changes_detected
             .* c-default_docker_image << pipeline.parameters.default_docker_image >> .circleci/continue/rust-ci.yml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ workflows:
             .* c-github-event-base64 << pipeline.parameters.github-event-base64 >> .circleci/continue/main.yml
             .* c-go-cache-version << pipeline.parameters.go-cache-version >> .circleci/continue/main.yml
             rust/.* c-rust_files_changed true .circleci/continue/main.yml
-            (packages/contracts-bedrock|\.circleci|\.github|ops/check-changed)/.* c-contracts_changed true .circleci/continue/main.yml
+            (packages/contracts-bedrock|\.github|ops/check-changed)/.* c-contracts_changed true .circleci/continue/main.yml
             ^(package\.json|mise\.toml)$ c-contracts_changed true .circleci/continue/main.yml
             ^(?!docs/public-docs/).+ c-non_docs_changes true .circleci/continue/main.yml
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,12 +82,7 @@ orbs:
 workflows:
   setup:
     when:
-      and:
-        - equal: ["", << pipeline.git.tag >>]
-        - not:
-            matches:
-              pattern: "^gh-readonly-queue/"
-              value: << pipeline.git.branch >>
+      equal: ["", << pipeline.git.tag >>]
     jobs:
       - path-filtering/filter: &path_filter
           base-revision: develop
@@ -119,64 +114,6 @@ workflows:
             # Docs CI — trigger on docs/public-docs/ changes
             .* c-default_docker_image << pipeline.parameters.default_docker_image >> .circleci/continue/docs-ci.yml
             docs/public-docs/.* c-docs_changes_detected true .circleci/continue/docs-ci.yml
-
-            # Rust CI — always include config, gate jobs via c-rust_changes_detected
-            .* c-default_docker_image << pipeline.parameters.default_docker_image >> .circleci/continue/rust-ci.yml
-            .* c-base_image << pipeline.parameters.base_image >> .circleci/continue/rust-ci.yml
-            .* c-go-cache-version << pipeline.parameters.go-cache-version >> .circleci/continue/rust-ci.yml
-            .* c-rust_ci_dispatch << pipeline.parameters.rust_ci_dispatch >> .circleci/continue/rust-ci.yml
-            (rust|\.circleci)/.* c-rust_changes_detected true .circleci/continue/rust-ci.yml
-            ^(?!docs/public-docs/).+ c-non_docs_changes true .circleci/continue/rust-ci.yml
-
-            # Rust E2E — always include config, gate jobs via c-rust_changes_detected
-            .* c-default_docker_image << pipeline.parameters.default_docker_image >> .circleci/continue/rust-e2e.yml
-            .* c-go-cache-version << pipeline.parameters.go-cache-version >> .circleci/continue/rust-e2e.yml
-            .* c-rust_e2e_dispatch << pipeline.parameters.rust_e2e_dispatch >> .circleci/continue/rust-e2e.yml
-            (rust|op-e2e|\.circleci)/.* c-rust_changes_detected true .circleci/continue/rust-e2e.yml
-            ^(?!docs/public-docs/).+ c-non_docs_changes true .circleci/continue/rust-e2e.yml
-
-  # Merge queue setup — identical to setup but passes c-is_merge_queue true.
-  # Runs exclusively for branches created by GitHub merge queue.
-  # IMPORTANT: keep mapping in sync with the setup workflow above.
-  setup-merge-queue:
-    when:
-      and:
-        - equal: ["", << pipeline.git.tag >>]
-        - matches:
-            pattern: "^gh-readonly-queue/"
-            value: << pipeline.git.branch >>
-    jobs:
-      - path-filtering/filter:
-          <<: *path_filter
-          mapping: |
-            # Merge queue flag — only lines unique to this workflow
-            .* c-is_merge_queue true .circleci/continue/main.yml
-            .* c-is_merge_queue true .circleci/continue/rust-ci.yml
-            .* c-is_merge_queue true .circleci/continue/rust-e2e.yml
-
-            # Everything below is identical to the setup workflow mapping.
-            .* c-default_docker_image << pipeline.parameters.default_docker_image >> .circleci/continue/main.yml
-            .* c-base_image << pipeline.parameters.base_image >> .circleci/continue/main.yml
-            .* c-main_dispatch << pipeline.parameters.main_dispatch >> .circleci/continue/main.yml
-            .* c-fault_proofs_dispatch << pipeline.parameters.fault_proofs_dispatch >> .circleci/continue/main.yml
-            .* c-reproducibility_dispatch << pipeline.parameters.reproducibility_dispatch >> .circleci/continue/main.yml
-            .* c-kontrol_dispatch << pipeline.parameters.kontrol_dispatch >> .circleci/continue/main.yml
-            .* c-cannon_full_test_dispatch << pipeline.parameters.cannon_full_test_dispatch >> .circleci/continue/main.yml
-            .* c-sdk_dispatch << pipeline.parameters.sdk_dispatch >> .circleci/continue/main.yml
-            .* c-publish_contract_artifacts_dispatch << pipeline.parameters.publish_contract_artifacts_dispatch >> .circleci/continue/main.yml
-            .* c-stale_check_dispatch << pipeline.parameters.stale_check_dispatch >> .circleci/continue/main.yml
-            .* c-contracts_coverage_dispatch << pipeline.parameters.contracts_coverage_dispatch >> .circleci/continue/main.yml
-            .* c-heavy_fuzz_dispatch << pipeline.parameters.heavy_fuzz_dispatch >> .circleci/continue/main.yml
-            .* c-ai_contracts_test_dispatch << pipeline.parameters.ai_contracts_test_dispatch >> .circleci/continue/main.yml
-            .* c-l2_fork_test_dispatch << pipeline.parameters.l2_fork_test_dispatch >> .circleci/continue/main.yml
-            .* c-github-event-type << pipeline.parameters.github-event-type >> .circleci/continue/main.yml
-            .* c-github-event-action << pipeline.parameters.github-event-action >> .circleci/continue/main.yml
-            .* c-github-event-base64 << pipeline.parameters.github-event-base64 >> .circleci/continue/main.yml
-            .* c-go-cache-version << pipeline.parameters.go-cache-version >> .circleci/continue/main.yml
-            rust/.* c-rust_files_changed true .circleci/continue/main.yml
-            (packages/contracts-bedrock|\.circleci|\.github|ops/check-changed)/.* c-contracts_changed true .circleci/continue/main.yml
-            ^(package\.json|mise\.toml)$ c-contracts_changed true .circleci/continue/main.yml
-            ^(?!docs/public-docs/).+ c-non_docs_changes true .circleci/continue/main.yml
 
             # Rust CI — always include config, gate jobs via c-rust_changes_detected
             .* c-default_docker_image << pipeline.parameters.default_docker_image >> .circleci/continue/rust-ci.yml

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -1523,7 +1523,7 @@ jobs:
       - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: small
     steps:
-      - run: echo "Required contracts CI checks passed"
+      - utils/ci-gate
 
   contracts-bedrock-checks-fast:
     docker:

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -68,7 +68,7 @@ parameters:
   c-rust_files_changed:
     type: boolean
     default: false
-  # Set to true by path-filtering when files under packages/contracts-bedrock/ or op-node/ change.
+  # Set to true by path-filtering when files under packages/contracts-bedrock/ change.
   # When false, contract feature matrix jobs are skipped entirely.
   c-contracts_changed:
     type: boolean

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -158,7 +158,7 @@ parameters:
     default: "v0.0"
 
 orbs:
-  utils: ethereum-optimism/circleci-utils@1.0.25
+  utils: ethereum-optimism/circleci-utils@dev:conditional-ci-gate
   go: circleci/go@1.8.0
   gcp-cli: circleci/gcp-cli@3.0.1
   slack: circleci/slack@6.0.0
@@ -1526,8 +1526,14 @@ jobs:
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: small
+    parameters:
+      always-succed:
+        description: Force always succed
+        type: bool
+        default: false
     steps:
-      - utils/ci-gate
+      - utils/ci-gate:
+          enforce-only-in-merge-queue: << parameters.always-succed >>
 
   contracts-bedrock-checks-fast:
     docker:
@@ -3207,6 +3213,8 @@ workflows:
             - contracts-bedrock-coverage main: terminal
             - contracts-bedrock-tests-upgrade op-mainnet main: terminal
             - contracts-bedrock-checks-fast: terminal
+        context:
+          - circleci-repo-readonly-authenticated-github-token
 
   # ============================================================================
   # Required contracts CI gate (skip) — runs when no contract changes
@@ -3225,4 +3233,7 @@ workflows:
               pattern: "^gh-readonly-queue/"
               value: << pipeline.git.branch >>
     jobs:
-      - required-contracts-ci
+      - required-contracts-ci:
+          always-succed: true
+        context:
+          - circleci-repo-readonly-authenticated-github-token

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -68,7 +68,7 @@ parameters:
   c-rust_files_changed:
     type: boolean
     default: false
-  # Set to true by path-filtering when files under packages/contracts-bedrock/ change.
+  # Set to true by path-filtering when contracts or rebuild-all paths change.
   # When false, contract feature matrix jobs are skipped entirely.
   c-contracts_changed:
     type: boolean

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -154,7 +154,7 @@ parameters:
     default: "v0.0"
 
 orbs:
-  utils: ethereum-optimism/circleci-utils@dev:conditional-ci-gate
+  utils: ethereum-optimism/circleci-utils@1.0.26
   go: circleci/go@1.8.0
   gcp-cli: circleci/gcp-cli@3.0.1
   slack: circleci/slack@6.0.0

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -78,6 +78,10 @@ parameters:
   c-non_docs_changes:
     type: boolean
     default: false
+  # Set to true when the pipeline is triggered from a GitHub merge queue branch.
+  c-is_merge_queue:
+    type: boolean
+    default: false
   # go-cache-version can be used as a cache buster when making breaking changes to caching strategy
   c-go-cache-version:
     type: string

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -68,6 +68,11 @@ parameters:
   c-rust_files_changed:
     type: boolean
     default: false
+  # Set to true by path-filtering when files under packages/contracts-bedrock/ or op-node/ change.
+  # When false, contract feature matrix jobs are skipped entirely.
+  c-contracts_changed:
+    type: boolean
+    default: false
   # Set to true by path-filtering when files outside docs/public-docs/ change.
   # When false, the main workflow is skipped entirely (docs-only PR).
   c-non_docs_changes:
@@ -1513,6 +1518,13 @@ jobs:
           command: just update-selectors
           working_directory: packages/contracts-bedrock
 
+  required-contracts-ci:
+    docker:
+      - image: <<pipeline.parameters.c-default_docker_image>>
+    resource_class: small
+    steps:
+      - run: echo "Required contracts CI checks passed"
+
   contracts-bedrock-checks-fast:
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
@@ -2433,151 +2445,6 @@ workflows:
           context:
             - circleci-repo-readonly-authenticated-github-token
             - slack
-      - contracts-bedrock-tests:
-          # Heavily fuzz any fuzz tests within added or modified test files.
-          name: contracts-bedrock-tests-heavy-fuzz-modified <<matrix.features>>
-          test_list: git diff origin/develop...HEAD --name-only --diff-filter=AM -- './test/**/*.t.sol' | sed 's|packages/contracts-bedrock/||'
-          test_timeout: 1h
-          test_profile: ciheavy
-          features: <<matrix.features>>
-          matrix:
-            parameters:
-              features: &features_matrix
-                - main
-                - CUSTOM_GAS_TOKEN
-                - OPTIMISM_PORTAL_INTEROP
-                - OPCM_V2
-                - OPCM_V2,CUSTOM_GAS_TOKEN
-                - OPCM_V2,OPTIMISM_PORTAL_INTEROP
-                - OPCM_V2,ZK_DISPUTE_GAME
-                - OPCM_V2,CANNON_KONA
-                - OPCM_V2,SUPER_ROOT_GAMES_MIGRATION
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - slack
-      # On PRs, run tests with lite profile for better build times.
-      - contracts-bedrock-tests:
-          name: contracts-bedrock-tests <<matrix.features>>
-          test_list: find test -name "*.t.sol"
-          test_profile: liteci
-          features: <<matrix.features>>
-          matrix:
-            parameters:
-              features: *features_matrix
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - slack
-          check_changed_patterns: contracts-bedrock,op-node
-          filters:
-            branches:
-              ignore: develop
-      # On develop, run tests with ci profile to mirror production.
-      - contracts-bedrock-tests:
-          name: contracts-bedrock-tests-develop <<matrix.features>>
-          test_list: find test -name "*.t.sol"
-          test_profile: ci
-          features: <<matrix.features>>
-          matrix:
-            parameters:
-              features: *features_matrix
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - slack
-          check_changed_patterns: contracts-bedrock,op-node
-          filters:
-            branches:
-              only: develop
-      - contracts-bedrock-coverage:
-          # Generate coverage reports.
-          name: contracts-bedrock-coverage <<matrix.features>>
-          test_timeout: 1h
-          test_profile: cicoverage
-          features: <<matrix.features>>
-          matrix:
-            parameters:
-              features: *features_matrix
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - slack
-      # On PRs, run upgrade tests with lite profile for better build times.
-      - contracts-bedrock-tests-upgrade:
-          name: contracts-bedrock-tests-upgrade op-mainnet <<matrix.features>>
-          fork_op_chain: op
-          fork_base_chain: mainnet
-          fork_base_rpc: https://ci-mainnet-l1-archive.optimism.io
-          test_profile: liteci
-          features: <<matrix.features>>
-          matrix:
-            parameters:
-              features: *features_matrix
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - slack
-          filters:
-            branches:
-              ignore: develop
-      # On develop, run upgrade tests with ci profile to mirror production.
-      - contracts-bedrock-tests-upgrade:
-          name: contracts-bedrock-tests-upgrade-develop op-mainnet <<matrix.features>>
-          fork_op_chain: op
-          fork_base_chain: mainnet
-          fork_base_rpc: https://ci-mainnet-l1-archive.optimism.io
-          test_profile: ci
-          features: <<matrix.features>>
-          matrix:
-            parameters:
-              features: *features_matrix
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - slack
-          filters:
-            branches:
-              only: develop
-      # On PRs, run chain-specific upgrade tests with lite profile for better build times.
-      - contracts-bedrock-tests-upgrade:
-          name: contracts-bedrock-tests-upgrade <<matrix.fork_op_chain>>-mainnet
-          fork_op_chain: <<matrix.fork_op_chain>>
-          fork_base_chain: mainnet
-          fork_base_rpc: https://ci-mainnet-l1-archive.optimism.io
-          test_profile: liteci
-          matrix:
-            parameters:
-              fork_op_chain: ["op", "ink", "unichain"]
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - slack
-          filters:
-            branches:
-              ignore: develop
-      # On develop, run chain-specific upgrade tests with ci profile to mirror production.
-      - contracts-bedrock-tests-upgrade:
-          name: contracts-bedrock-tests-upgrade-develop <<matrix.fork_op_chain>>-mainnet
-          fork_op_chain: <<matrix.fork_op_chain>>
-          fork_base_chain: mainnet
-          fork_base_rpc: https://ci-mainnet-l1-archive.optimism.io
-          test_profile: ci
-          matrix:
-            parameters:
-              fork_op_chain: ["op", "ink", "unichain"]
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - slack
-          filters:
-            branches:
-              only: develop
-      # Always run L2 fork tests with ci profile
-      - contracts-bedrock-tests-l2-fork:
-          name: contracts-bedrock-tests-l2-fork op-mainnet
-          fork_op_chain: op-mainnet
-          l2_fork_rpc: https://op-mainnet-rpc.optimism.io/
-          l2_fork_block_number: latest
-          test_profile: ci
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - slack
-      - contracts-bedrock-checks-fast:
-          context:
-            - circleci-repo-readonly-authenticated-github-token
       - l2-chains-sync-check:
           context:
             - circleci-repo-readonly-authenticated-github-token
@@ -2825,12 +2692,7 @@ workflows:
             - go-lint: terminal
             - semgrep-scan-local: terminal
             - go-tests-short: terminal
-            - contracts-bedrock-coverage main: terminal
-            - contracts-bedrock-tests main: terminal
-            - contracts-bedrock-tests-heavy-fuzz-modified main: terminal
-            - contracts-bedrock-tests-upgrade op-mainnet main: terminal
             - memory-all: terminal
-            - contracts-bedrock-checks-fast: terminal
           context:
             - circleci-api-token
           filters:
@@ -3164,4 +3026,199 @@ workflows:
             - circleci-repo-readonly-authenticated-github-token
             - slack
 
+  contracts-feature-tests:
+    when:
+      or:
+        - and:
+            - equal: ["webhook", << pipeline.trigger_source >>]
+            - << pipeline.parameters.c-contracts_changed >>
+            - << pipeline.parameters.c-non_docs_changes >>
+        # Always run on develop (mirrors previous check-changed whitelist behavior)
+        - and:
+            - equal: ["webhook", << pipeline.trigger_source >>]
+            - equal: ["develop", << pipeline.git.branch >>]
+            - << pipeline.parameters.c-non_docs_changes >>
+        # Always run in merge queue
+        - and:
+            - equal: ["webhook", << pipeline.trigger_source >>]
+            - matches:
+                pattern: "^gh-readonly-queue/"
+                value: << pipeline.git.branch >>
+            - << pipeline.parameters.c-non_docs_changes >>
+        - and:
+            - equal: [true, <<pipeline.parameters.c-main_dispatch>>]
+            - equal: ["api", << pipeline.trigger_source >>]
+    jobs:
+      - contracts-bedrock-tests:
+          # Heavily fuzz any fuzz tests within added or modified test files.
+          name: contracts-bedrock-tests-heavy-fuzz-modified <<matrix.features>>
+          test_list: git diff origin/develop...HEAD --name-only --diff-filter=AM -- './test/**/*.t.sol' | sed 's|packages/contracts-bedrock/||'
+          test_timeout: 1h
+          test_profile: ciheavy
+          features: <<matrix.features>>
+          matrix:
+            parameters:
+              features: &features_matrix
+                - main
+                - CUSTOM_GAS_TOKEN
+                - OPTIMISM_PORTAL_INTEROP
+                - OPCM_V2
+                - OPCM_V2,CUSTOM_GAS_TOKEN
+                - OPCM_V2,OPTIMISM_PORTAL_INTEROP
+                - OPCM_V2,ZK_DISPUTE_GAME
+                - OPCM_V2,CANNON_KONA
+                - OPCM_V2,SUPER_ROOT_GAMES_MIGRATION
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+            - slack
+      # On PRs, run tests with lite profile for better build times.
+      - contracts-bedrock-tests:
+          name: contracts-bedrock-tests <<matrix.features>>
+          test_list: find test -name "*.t.sol"
+          test_profile: liteci
+          features: <<matrix.features>>
+          matrix:
+            parameters:
+              features: *features_matrix
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+            - slack
+          filters:
+            branches:
+              ignore: develop
+      # On develop, run tests with ci profile to mirror production.
+      - contracts-bedrock-tests:
+          name: contracts-bedrock-tests-develop <<matrix.features>>
+          test_list: find test -name "*.t.sol"
+          test_profile: ci
+          features: <<matrix.features>>
+          matrix:
+            parameters:
+              features: *features_matrix
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+            - slack
+          filters:
+            branches:
+              only: develop
+      - contracts-bedrock-coverage:
+          # Generate coverage reports.
+          name: contracts-bedrock-coverage <<matrix.features>>
+          test_timeout: 1h
+          test_profile: cicoverage
+          features: <<matrix.features>>
+          matrix:
+            parameters:
+              features: *features_matrix
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+            - slack
+      # On PRs, run upgrade tests with lite profile for better build times.
+      - contracts-bedrock-tests-upgrade:
+          name: contracts-bedrock-tests-upgrade op-mainnet <<matrix.features>>
+          fork_op_chain: op
+          fork_base_chain: mainnet
+          fork_base_rpc: https://ci-mainnet-l1-archive.optimism.io
+          test_profile: liteci
+          features: <<matrix.features>>
+          matrix:
+            parameters:
+              features: *features_matrix
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+            - slack
+          filters:
+            branches:
+              ignore: develop
+      # On develop, run upgrade tests with ci profile to mirror production.
+      - contracts-bedrock-tests-upgrade:
+          name: contracts-bedrock-tests-upgrade-develop op-mainnet <<matrix.features>>
+          fork_op_chain: op
+          fork_base_chain: mainnet
+          fork_base_rpc: https://ci-mainnet-l1-archive.optimism.io
+          test_profile: ci
+          features: <<matrix.features>>
+          matrix:
+            parameters:
+              features: *features_matrix
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+            - slack
+          filters:
+            branches:
+              only: develop
+      # On PRs, run chain-specific upgrade tests with lite profile for better build times.
+      - contracts-bedrock-tests-upgrade:
+          name: contracts-bedrock-tests-upgrade <<matrix.fork_op_chain>>-mainnet
+          fork_op_chain: <<matrix.fork_op_chain>>
+          fork_base_chain: mainnet
+          fork_base_rpc: https://ci-mainnet-l1-archive.optimism.io
+          test_profile: liteci
+          matrix:
+            parameters:
+              fork_op_chain: ["op", "ink", "unichain"]
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+            - slack
+          filters:
+            branches:
+              ignore: develop
+      # On develop, run chain-specific upgrade tests with ci profile to mirror production.
+      - contracts-bedrock-tests-upgrade:
+          name: contracts-bedrock-tests-upgrade-develop <<matrix.fork_op_chain>>-mainnet
+          fork_op_chain: <<matrix.fork_op_chain>>
+          fork_base_chain: mainnet
+          fork_base_rpc: https://ci-mainnet-l1-archive.optimism.io
+          test_profile: ci
+          matrix:
+            parameters:
+              fork_op_chain: ["op", "ink", "unichain"]
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+            - slack
+          filters:
+            branches:
+              only: develop
+      # Always run L2 fork tests with ci profile
+      - contracts-bedrock-tests-l2-fork:
+          name: contracts-bedrock-tests-l2-fork op-mainnet
+          fork_op_chain: op-mainnet
+          l2_fork_rpc: https://op-mainnet-rpc.optimism.io/
+          l2_fork_block_number: latest
+          test_profile: ci
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+            - slack
+      - contracts-bedrock-checks-fast:
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+            - slack
+      # -----------------------------------------------------------------------
+      # Required gate — fans in on required contract CI jobs
+      # -----------------------------------------------------------------------
+      - required-contracts-ci:
+          requires:
+            - contracts-bedrock-tests main: terminal
+            - contracts-bedrock-tests-heavy-fuzz-modified main: terminal
+            - contracts-bedrock-coverage main: terminal
+            - contracts-bedrock-tests-upgrade op-mainnet main: terminal
+            - contracts-bedrock-checks-fast: terminal
+
   # ============================================================================
+  # Required contracts CI gate (skip) — runs when no contract changes
+  # Produces the required-contracts-ci status so the merge queue doesn't hang.
+  # ============================================================================
+  contracts-feature-tests-short:
+    when:
+      and:
+        - equal: ["webhook", << pipeline.trigger_source >>]
+        - not: << pipeline.parameters.c-contracts_changed >>
+        - << pipeline.parameters.c-non_docs_changes >>
+        - not:
+            equal: ["develop", << pipeline.git.branch >>]
+        - not:
+            matches:
+              pattern: "^gh-readonly-queue/"
+              value: << pipeline.git.branch >>
+    jobs:
+      - required-contracts-ci

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -78,10 +78,6 @@ parameters:
   c-non_docs_changes:
     type: boolean
     default: false
-  # Set to true when the pipeline is triggered from a GitHub merge queue branch.
-  c-is_merge_queue:
-    type: boolean
-    default: false
   # go-cache-version can be used as a cache buster when making breaking changes to caching strategy
   c-go-cache-version:
     type: string

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -1529,11 +1529,11 @@ jobs:
     parameters:
       always-succed:
         description: Force always succed
-        type: bool
+        type: boolean
         default: false
     steps:
       - utils/ci-gate:
-          enforce-only-in-merge-queue: << parameters.always-succed >>
+          always-succeed: << parameters.always-succed >>
 
   contracts-bedrock-checks-fast:
     docker:

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -3213,8 +3213,8 @@ workflows:
             - contracts-bedrock-coverage main: terminal
             - contracts-bedrock-tests-upgrade op-mainnet main: terminal
             - contracts-bedrock-checks-fast: terminal
-        context:
-          - circleci-repo-readonly-authenticated-github-token
+          context:
+            - circleci-repo-readonly-authenticated-github-token
 
   # ============================================================================
   # Required contracts CI gate (skip) — runs when no contract changes
@@ -3235,5 +3235,5 @@ workflows:
     jobs:
       - required-contracts-ci:
           always-succed: true
-        context:
-          - circleci-repo-readonly-authenticated-github-token
+          context:
+            - circleci-repo-readonly-authenticated-github-token

--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -4,7 +4,7 @@ version: 2.1
 # This file contains all Rust CI commands, parameterized jobs, crate-specific jobs, and workflows.
 
 orbs:
-  utils: ethereum-optimism/circleci-utils@1.0.25
+  utils: ethereum-optimism/circleci-utils@dev:conditional-ci-gate
   gcp-cli: circleci/gcp-cli@3.0.1
   codecov: codecov/codecov@5.0.3
 

--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -27,9 +27,6 @@ parameters:
   c-non_docs_changes:
     type: boolean
     default: false
-  c-is_merge_queue:
-    type: boolean
-    default: false
   # Passthrough declarations for setup config parameters.
   # CircleCI forwards all explicitly-passed pipeline parameters to continuation configs.
   # Without these declarations, manually triggered pipelines fail with "Unexpected argument(s)".

--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -4,7 +4,7 @@ version: 2.1
 # This file contains all Rust CI commands, parameterized jobs, crate-specific jobs, and workflows.
 
 orbs:
-  utils: ethereum-optimism/circleci-utils@dev:conditional-ci-gate
+  utils: ethereum-optimism/circleci-utils@1.0.26
   gcp-cli: circleci/gcp-cli@3.0.1
   codecov: codecov/codecov@5.0.3
 

--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -27,6 +27,9 @@ parameters:
   c-non_docs_changes:
     type: boolean
     default: false
+  c-is_merge_queue:
+    type: boolean
+    default: false
   # Passthrough declarations for setup config parameters.
   # CircleCI forwards all explicitly-passed pipeline parameters to continuation configs.
   # Without these declarations, manually triggered pipelines fail with "Unexpected argument(s)".

--- a/.circleci/continue/rust-e2e.yml
+++ b/.circleci/continue/rust-e2e.yml
@@ -22,6 +22,9 @@ parameters:
   c-non_docs_changes:
     type: boolean
     default: false
+  c-is_merge_queue:
+    type: boolean
+    default: false
   # Passthrough declarations for setup config parameters.
   # CircleCI forwards all explicitly-passed pipeline parameters to continuation configs.
   # Without these declarations, manually triggered pipelines fail with "Unexpected argument(s)".

--- a/.circleci/continue/rust-e2e.yml
+++ b/.circleci/continue/rust-e2e.yml
@@ -22,9 +22,6 @@ parameters:
   c-non_docs_changes:
     type: boolean
     default: false
-  c-is_merge_queue:
-    type: boolean
-    default: false
   # Passthrough declarations for setup config parameters.
   # CircleCI forwards all explicitly-passed pipeline parameters to continuation configs.
   # Without these declarations, manually triggered pipelines fail with "Unexpected argument(s)".


### PR DESCRIPTION
## Summary

- Move ~35 contract feature matrix jobs into a dedicated `contracts-feature-tests` workflow gated on `c-contracts_changed` pipeline parameter
- Path-filtering sets `c-contracts_changed=true` only when `packages/contracts-bedrock/` or `op-node/` files change
- Non-contract PRs (docs, Rust, Go, etc.) no longer spin up 35 containers that each independently check-changed and halt
- Follows the established Rust CI two-workflow pattern (`contracts-feature-tests` + `contracts-feature-tests-short`) so `required-contracts-ci` always reports for the merge queue

## Motivation

Contract feature matrix jobs were running on every PR regardless of what changed. Each of the 8 feature combos × 4+ job types spun up a 2xlarge container, did a full checkout, then ran `check-changed` which called out to GitHub API — only to discover contracts weren't touched and halt. Example: [pipeline 120824](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/120824/workflows/b1e91d3b-b83c-45a0-9c6e-c2cf96d653d9) ran all contract matrix jobs on a Rust docs migration PR.

## What changed

| File | Change |
|------|--------|
| `config.yml` | Added `c-contracts_changed` path-filtering mapping |
| `continue/main.yml` | Added `c-contracts_changed` parameter, `required-contracts-ci` gate job, moved matrix jobs to `contracts-feature-tests` workflow, added `contracts-feature-tests-short` no-op workflow, removed contract refs from `ci-gate` |

## Required follow-up

- [ ] Add `required-contracts-ci` as a required status check in GitHub repo settings

## Test plan

- [ ] Verify a non-contract PR does NOT trigger the contract feature matrix workflow
- [ ] Verify a contract PR DOES trigger the full matrix and `required-contracts-ci` reports success
- [ ] Verify merge queue works with the new `required-contracts-ci` check
- [ ] Verify manual dispatch (`c-main_dispatch`) still triggers the full matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)