### PR TITLE
op-interop-filter: add periodic sync progress logging

### DIFF
--- a/op-interop-filter/filter/logsdb_chain_ingester.go
+++ b/op-interop-filter/filter/logsdb_chain_ingester.go
@@ -402,6 +402,7 @@ func (c *LogsDBChainIngester) runIngestion() {
 
 	// Track progress for logging
 	lastLogTime := clock.SystemClock.Now()
+	blocksProcessedSinceLastLog := uint64(0)
 
 	// Use ticker for polling interval
 	ticker := time.NewTicker(c.pollInterval)
@@ -455,22 +456,37 @@ func (c *LogsDBChainIngester) runIngestion() {
 				break // Exit inner loop on error, wait for next tick to retry
 			}
 			nextBlock++
+			blocksProcessedSinceLastLog++
 
 			// Progress logging
-			if clock.SystemClock.Since(lastLogTime) > progressLogInterval {
+			elapsed := clock.SystemClock.Since(lastLogTime)
+			if elapsed > progressLogInterval {
+				headBlock := head.NumberU64()
+				currentBlock := nextBlock - 1
+				rate := float64(blocksProcessedSinceLastLog) / elapsed.Seconds()
+
 				startingBlock := c.calculateStartingBlock()
-				if nextBlock <= startingBlock {
-					progress := float64(nextBlock-c.earliestIngestedBlock.Load()) / float64(startingBlock-c.earliestIngestedBlock.Load()+1)
-					c.log.Info("Ingestion progress",
-						"block", nextBlock-1,
-						"target", startingBlock,
-						"progress", fmt.Sprintf("%.0f%%", progress*100))
+				if currentBlock <= startingBlock {
+					earliest := c.earliestIngestedBlock.Load()
+					totalRange := float64(startingBlock - earliest + 1)
+					pct := float64(currentBlock-earliest) / totalRange * 100
+					c.log.Info("Sync progress",
+						"block", currentBlock,
+						"head", headBlock,
+						"progress", fmt.Sprintf("%.1f%%", pct),
+						"blocks_per_sec", fmt.Sprintf("%.1f", rate))
 					chainIDUint64, _ := c.chainID.Uint64()
-					c.metrics.RecordBackfillProgress(chainIDUint64, progress)
+					c.metrics.RecordBackfillProgress(chainIDUint64, pct/100)
 				} else {
-					c.log.Debug("Ingestion progress", "block", nextBlock-1, "head", head.NumberU64())
+					pct := float64(currentBlock) / float64(headBlock) * 100
+					c.log.Info("Sync progress",
+						"block", currentBlock,
+						"head", headBlock,
+						"progress", fmt.Sprintf("%.1f%%", pct),
+						"blocks_per_sec", fmt.Sprintf("%.1f", rate))
 				}
 				lastLogTime = clock.SystemClock.Now()
+				blocksProcessedSinceLastLog = 0
 			}
 		}
 		// Caught up to head, will wait for next ticker tick


### PR DESCRIPTION
## Summary
- Adds info-level sync progress logging every 10 seconds during block ingestion in the interop filter
- Logs include current block, chain head, percentage complete, and blocks/sec throughput rate
- Previously, progress during backfill used info level but live sync only logged at debug level — now both paths log at info level with consistent format

## Motivation
When monitoring interop filter pods in production, it was difficult to tell how far along sync was without enabling debug logging or restarting the pod. This change surfaces progress at the default log level so operators can easily monitor ingestion status.

## Test plan
- [ ] Verify the op-interop-filter package compiles cleanly (`go build ./op-interop-filter/...`)
- [ ] Deploy to a dev cluster and confirm info-level "Sync progress" logs appear every ~10 seconds during backfill and live sync
- [ ] Verify log fields: `block`, `head`, `progress` (percentage), `blocks_per_sec` (rate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)