### PR TITLE
op-interop-filter: align progress logging with readiness

### DIFF
--- a/op-interop-filter/filter/lockstep_cross_validator.go
+++ b/op-interop-filter/filter/lockstep_cross_validator.go
@@ -291,6 +291,7 @@ func (v *LockstepCrossValidator) advanceValidation() {
 	if !v.crossValidatedOK.Load() {
 		v.crossValidatedTs.Store(v.startTimestamp)
 		v.crossValidatedOK.Store(true)
+		v.metrics.RecordCrossUnsafeValidatedTimestamp(v.startTimestamp)
 		v.log.Info("Cross-validator initialized", "startTimestamp", v.startTimestamp)
 		return
 	}
@@ -315,6 +316,7 @@ func (v *LockstepCrossValidator) advanceValidation() {
 
 		// Advance
 		v.crossValidatedTs.Store(nextTs)
+		v.metrics.RecordCrossUnsafeValidatedTimestamp(nextTs)
 		currentTs = nextTs
 
 		v.log.Debug("Advanced cross-validated timestamp", "timestamp", nextTs)

--- a/op-interop-filter/filter/logsdb_chain_ingester.go
+++ b/op-interop-filter/filter/logsdb_chain_ingester.go
@@ -402,6 +402,7 @@ func (c *LogsDBChainIngester) runIngestion() {
 
 	// Track progress for logging
 	lastLogTime := clock.SystemClock.Now()
+	blocksProcessedSinceLastLog := uint64(0)
 
 	// Use ticker for polling interval
 	ticker := time.NewTicker(c.pollInterval)
@@ -455,22 +456,37 @@ func (c *LogsDBChainIngester) runIngestion() {
 				break // Exit inner loop on error, wait for next tick to retry
 			}
 			nextBlock++
+			blocksProcessedSinceLastLog++
 
 			// Progress logging
-			if clock.SystemClock.Since(lastLogTime) > progressLogInterval {
+			elapsed := clock.SystemClock.Since(lastLogTime)
+			if elapsed > progressLogInterval {
+				headBlock := head.NumberU64()
+				currentBlock := nextBlock - 1
+				rate := float64(blocksProcessedSinceLastLog) / elapsed.Seconds()
+
 				startingBlock := c.calculateStartingBlock()
-				if nextBlock <= startingBlock {
-					progress := float64(nextBlock-c.earliestIngestedBlock.Load()) / float64(startingBlock-c.earliestIngestedBlock.Load()+1)
-					c.log.Info("Ingestion progress",
-						"block", nextBlock-1,
-						"target", startingBlock,
-						"progress", fmt.Sprintf("%.0f%%", progress*100))
+				if currentBlock <= startingBlock {
+					earliest := c.earliestIngestedBlock.Load()
+					totalRange := float64(startingBlock - earliest + 1)
+					pct := float64(currentBlock-earliest) / totalRange * 100
+					c.log.Info("Sync progress",
+						"block", currentBlock,
+						"head", headBlock,
+						"progress", fmt.Sprintf("%.1f%%", pct),
+						"blocks_per_sec", fmt.Sprintf("%.1f", rate))
 					chainIDUint64, _ := c.chainID.Uint64()
-					c.metrics.RecordBackfillProgress(chainIDUint64, progress)
+					c.metrics.RecordBackfillProgress(chainIDUint64, pct/100)
 				} else {
-					c.log.Debug("Ingestion progress", "block", nextBlock-1, "head", head.NumberU64())
+					pct := float64(currentBlock) / float64(headBlock) * 100
+					c.log.Info("Sync progress",
+						"block", currentBlock,
+						"head", headBlock,
+						"progress", fmt.Sprintf("%.1f%%", pct),
+						"blocks_per_sec", fmt.Sprintf("%.1f", rate))
 				}
 				lastLogTime = clock.SystemClock.Now()
+				blocksProcessedSinceLastLog = 0
 			}
 		}
 		// Caught up to head, will wait for next ticker tick

--- a/op-interop-filter/filter/logsdb_chain_ingester.go
+++ b/op-interop-filter/filter/logsdb_chain_ingester.go
@@ -402,7 +402,6 @@ func (c *LogsDBChainIngester) runIngestion() {
 
 	// Track progress for logging
 	lastLogTime := clock.SystemClock.Now()
-	blocksProcessedSinceLastLog := uint64(0)
 
 	// Use ticker for polling interval
 	ticker := time.NewTicker(c.pollInterval)
@@ -456,37 +455,22 @@ func (c *LogsDBChainIngester) runIngestion() {
 				break // Exit inner loop on error, wait for next tick to retry
 			}
 			nextBlock++
-			blocksProcessedSinceLastLog++
 
 			// Progress logging
-			elapsed := clock.SystemClock.Since(lastLogTime)
-			if elapsed > progressLogInterval {
-				headBlock := head.NumberU64()
-				currentBlock := nextBlock - 1
-				rate := float64(blocksProcessedSinceLastLog) / elapsed.Seconds()
-
+			if clock.SystemClock.Since(lastLogTime) > progressLogInterval {
 				startingBlock := c.calculateStartingBlock()
-				if currentBlock <= startingBlock {
-					earliest := c.earliestIngestedBlock.Load()
-					totalRange := float64(startingBlock - earliest + 1)
-					pct := float64(currentBlock-earliest) / totalRange * 100
-					c.log.Info("Sync progress",
-						"block", currentBlock,
-						"head", headBlock,
-						"progress", fmt.Sprintf("%.1f%%", pct),
-						"blocks_per_sec", fmt.Sprintf("%.1f", rate))
+				if nextBlock <= startingBlock {
+					progress := float64(nextBlock-c.earliestIngestedBlock.Load()) / float64(startingBlock-c.earliestIngestedBlock.Load()+1)
+					c.log.Info("Ingestion progress",
+						"block", nextBlock-1,
+						"target", startingBlock,
+						"progress", fmt.Sprintf("%.0f%%", progress*100))
 					chainIDUint64, _ := c.chainID.Uint64()
-					c.metrics.RecordBackfillProgress(chainIDUint64, pct/100)
+					c.metrics.RecordBackfillProgress(chainIDUint64, progress)
 				} else {
-					pct := float64(currentBlock) / float64(headBlock) * 100
-					c.log.Info("Sync progress",
-						"block", currentBlock,
-						"head", headBlock,
-						"progress", fmt.Sprintf("%.1f%%", pct),
-						"blocks_per_sec", fmt.Sprintf("%.1f", rate))
+					c.log.Info("Ingestion progress", "block", nextBlock-1, "head", head.NumberU64())
 				}
 				lastLogTime = clock.SystemClock.Now()
-				blocksProcessedSinceLastLog = 0
 			}
 		}
 		// Caught up to head, will wait for next ticker tick

--- a/op-interop-filter/filter/logsdb_chain_ingester.go
+++ b/op-interop-filter/filter/logsdb_chain_ingester.go
@@ -355,6 +355,16 @@ func (c *LogsDBChainIngester) calculateStartingBlock() uint64 {
 	return startingBlock
 }
 
+// calculateReadyBlock returns the block number the ingester must reach to report Ready().
+func (c *LogsDBChainIngester) calculateReadyBlock() uint64 {
+	readyBlock, err := c.rollupCfg.TargetBlockNumber(c.startTimestamp)
+	if err != nil {
+		// Timestamp is before genesis, start from genesis block
+		return c.rollupCfg.Genesis.L2.Number
+	}
+	return readyBlock
+}
+
 func (c *LogsDBChainIngester) initLogsDB() error {
 	var dbPath string
 	if c.dataDir != "" {
@@ -458,17 +468,17 @@ func (c *LogsDBChainIngester) runIngestion() {
 
 			// Progress logging
 			if clock.SystemClock.Since(lastLogTime) > progressLogInterval {
-				startingBlock := c.calculateStartingBlock()
-				if nextBlock <= startingBlock {
-					progress := float64(nextBlock-c.earliestIngestedBlock.Load()) / float64(startingBlock-c.earliestIngestedBlock.Load()+1)
+				readyBlock := c.calculateReadyBlock()
+				if nextBlock <= readyBlock {
+					progress := float64(nextBlock-c.earliestIngestedBlock.Load()) / float64(readyBlock-c.earliestIngestedBlock.Load()+1)
 					c.log.Info("Ingestion progress",
 						"block", nextBlock-1,
-						"target", startingBlock,
+						"target", readyBlock,
 						"progress", fmt.Sprintf("%.0f%%", progress*100))
 					chainIDUint64, _ := c.chainID.Uint64()
 					c.metrics.RecordBackfillProgress(chainIDUint64, progress)
 				} else {
-					c.log.Info("Ingestion progress", "block", nextBlock-1, "head", head.NumberU64())
+					c.log.Debug("Ingestion progress", "block", nextBlock-1, "head", head.NumberU64())
 				}
 				lastLogTime = clock.SystemClock.Now()
 			}

--- a/op-interop-filter/filter/logsdb_chain_ingester_test.go
+++ b/op-interop-filter/filter/logsdb_chain_ingester_test.go
@@ -661,6 +661,50 @@ func TestLogsDBChainIngester_CalculateStartingBlock_BackfillUnderflow(t *testing
 	require.Equal(t, l2StartBlock, startingBlock)
 }
 
+func TestLogsDBChainIngester_CalculateReadyBlock(t *testing.T) {
+	chainID := eth.ChainIDFromUInt64(901)
+	tempDir := t.TempDir()
+
+	mockClient := NewMockEthClient()
+
+	l2StartBlock := uint64(100)
+	l2StartTimestamp := uint64(1000)
+
+	ingester := newTestLogsDBChainIngester(t, testIngesterConfig{
+		chainID:   chainID,
+		dataDir:   tempDir,
+		ethClient: mockClient,
+		rollupCfg: testRollupConfig(901, l2StartBlock, l2StartTimestamp),
+	})
+
+	ingester.startTimestamp = 1100
+
+	readyBlock := ingester.calculateReadyBlock()
+	require.Equal(t, uint64(150), readyBlock)
+}
+
+func TestLogsDBChainIngester_CalculateReadyBlock_BeforeGenesis(t *testing.T) {
+	chainID := eth.ChainIDFromUInt64(901)
+	tempDir := t.TempDir()
+
+	mockClient := NewMockEthClient()
+
+	l2StartBlock := uint64(100)
+	l2StartTimestamp := uint64(1000)
+
+	ingester := newTestLogsDBChainIngester(t, testIngesterConfig{
+		chainID:   chainID,
+		dataDir:   tempDir,
+		ethClient: mockClient,
+		rollupCfg: testRollupConfig(901, l2StartBlock, l2StartTimestamp),
+	})
+
+	ingester.startTimestamp = 900
+
+	readyBlock := ingester.calculateReadyBlock()
+	require.Equal(t, l2StartBlock, readyBlock)
+}
+
 func TestLogsDBChainIngester_InitIngestion_ResumeFromExistingDB(t *testing.T) {
 	chainID := eth.ChainIDFromUInt64(901)
 	tempDir := t.TempDir()


### PR DESCRIPTION
## Summary
- compute progress against the block required for `Ready()` instead of the backfill start block
- keep the existing info-level progress log only while the ingester is still catching up to readiness
- restore post-readiness progress logging to debug level
- add focused tests for ready-block calculation

Supersedes #19782.