### PR TITLE
fix(e2e): use confirmed nonce instead of pending nonce

### DIFF
--- a/op-acceptance-tests/tests/isthmus/isthmus_test_helpers.go
+++ b/op-acceptance-tests/tests/isthmus/isthmus_test_helpers.go
@@ -21,7 +21,7 @@ func DefaultTxSubmitOptions(w walletV2) txplan.Option {
 		txplan.WithPrivateKey(w.PrivateKey()),
 		txplan.WithChainID(w.Client()),
 		txplan.WithAgainstLatestBlock(w.Client()),
-		txplan.WithPendingNonce(w.Client()),
+		txplan.WithConfirmedNonce(w.Client()),
 		txplan.WithEstimator(w.Client(), false),
 		txplan.WithTransactionSubmitter(w.Client()),
 	)

--- a/op-devstack/dsl/eoa.go
+++ b/op-devstack/dsl/eoa.go
@@ -143,7 +143,7 @@ func (u *EOA) Plan() txplan.Option {
 	return txplan.Combine(
 		txplan.WithChainID(elClient),
 		u.key.Plan(),
-		txplan.WithPendingNonce(elClient),
+		txplan.WithConfirmedNonce(elClient),
 		txplan.WithAgainstLatestBlock(elClient),
 		txplan.WithEstimator(elClient, true),
 		txplan.WithRetrySubmission(elClient, 5, retry.Exponential()),

--- a/op-devstack/sysgo/add_game_type.go
+++ b/op-devstack/sysgo/add_game_type.go
@@ -68,7 +68,7 @@ func setRespectedGameTypeForRuntime(
 	txOpts := txplan.Combine(
 		txplan.WithChainID(client),
 		txplan.WithPrivateKey(guardianKey),
-		txplan.WithPendingNonce(client),
+		txplan.WithConfirmedNonce(client),
 		txplan.WithAgainstLatestBlockEthClient(client),
 		txplan.WithEstimator(client, true),
 		txplan.WithRetrySubmission(client, 5, retry.Exponential()),

--- a/op-e2e/actions/interop/interop_msg_test.go
+++ b/op-e2e/actions/interop/interop_msg_test.go
@@ -131,7 +131,7 @@ func DefaultTxOpts(t helpers.Testing, user *userWithKeys, chain *dsl.Chain) (txp
 		txplan.WithPrivateKey(user.secret),
 		txplan.WithChainID(sc),
 		txplan.WithAgainstLatestBlock(sc),
-		txplan.WithPendingNonce(sc),
+		txplan.WithConfirmedNonce(sc),
 		txplan.WithEstimator(sc, false),
 		txplan.WithTransactionSubmitter(builder),
 		txplan.WithAssumedInclusion(builder),

--- a/op-e2e/e2eutils/transactions/send.go
+++ b/op-e2e/e2eutils/transactions/send.go
@@ -62,8 +62,8 @@ func RequireSendTxs(t *testing.T, ctx context.Context, client *ethclient.Client,
 	cfg := makeSendTxCfg(opts...)
 	// First convert all the candidates to signed transactions so they are most likely to be included in the same block
 	// This still isn't guaranteed but minimises the delay between each transaction submission.
-	nonce, err := client.PendingNonceAt(ctx, crypto.PubkeyToAddress(privKey.PublicKey))
-	require.NoError(t, err, "Failed to get pending nonce")
+	nonce, err := client.NonceAt(ctx, crypto.PubkeyToAddress(privKey.PublicKey), nil)
+	require.NoError(t, err, "Failed to get nonce")
 	txs := make([]*types.Transaction, len(candidates))
 	for i, candidate := range candidates {
 		tx, err := createTx(ctx, client, candidate, privKey, nonce)
@@ -93,7 +93,11 @@ func RequireSendTxs(t *testing.T, ctx context.Context, client *ethclient.Client,
 
 func SendTx(ctx context.Context, client *ethclient.Client, candidate txmgr.TxCandidate, privKey *ecdsa.PrivateKey, opts ...SendTxOpt) (*types.Transaction, *types.Receipt, error) {
 	cfg := makeSendTxCfg(opts...)
-	nonce, err := client.PendingNonceAt(ctx, crypto.PubkeyToAddress(privKey.PublicKey))
+	// Use NonceAt (latest confirmed) rather than PendingNonceAt to avoid a race where the node's
+	// pending nonce hasn't updated yet after a recently confirmed transaction. Since SendTx always
+	// waits for a receipt before returning, the confirmed nonce is guaranteed to reflect all
+	// previously sent transactions.
+	nonce, err := client.NonceAt(ctx, crypto.PubkeyToAddress(privKey.PublicKey), nil)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get next nonce: %w", err)
 	}

--- a/op-service/txplan/txplan.go
+++ b/op-service/txplan/txplan.go
@@ -316,11 +316,30 @@ type PendingNonceAt interface {
 	PendingNonceAt(ctx context.Context, account common.Address) (uint64, error)
 }
 
+// Deprecated: WithPendingNonce uses the node's pending nonce which may be stale after a recently
+// confirmed transaction. Use WithConfirmedNonce instead when transactions are sent sequentially
+// and each waits for a receipt before the next is sent.
 func WithPendingNonce(cl PendingNonceAt) Option {
 	return func(tx *PlannedTx) {
 		tx.Nonce.DependOn(&tx.AgainstBlock, &tx.Sender)
 		tx.Nonce.Fn(func(ctx context.Context) (uint64, error) {
 			return cl.PendingNonceAt(ctx, tx.Sender.Value())
+		})
+	}
+}
+
+type ConfirmedNonceAt interface {
+	NonceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (uint64, error)
+}
+
+// WithConfirmedNonce resolves the nonce from the latest confirmed block rather than the pending
+// state. This avoids a race where the node's pending nonce hasn't updated yet after a recently
+// confirmed transaction.
+func WithConfirmedNonce(cl ConfirmedNonceAt) Option {
+	return func(tx *PlannedTx) {
+		tx.Nonce.DependOn(&tx.AgainstBlock, &tx.Sender)
+		tx.Nonce.Fn(func(ctx context.Context) (uint64, error) {
+			return cl.NonceAt(ctx, tx.Sender.Value(), nil)
 		})
 	}
 }

--- a/op-up/smoke.go
+++ b/op-up/smoke.go
@@ -124,7 +124,7 @@ func (u *remoteUser) plan() txplan.Option {
 	return txplan.Combine(
 		txplan.WithChainID(u.chain.ethClient),
 		txplan.WithPrivateKey(u.privKey),
-		txplan.WithPendingNonce(u.chain.ethClient),
+		txplan.WithConfirmedNonce(u.chain.ethClient),
 		txplan.WithAgainstLatestBlock(u.chain.ethClient),
 		txplan.WithEstimator(u.chain.ethClient, true),
 		txplan.WithRetrySubmission(u.chain.ethClient, 5, retry.Exponential()),


### PR DESCRIPTION
## Summary

- Switch `transactions.SendTx` and `txplan` callers from `PendingNonceAt` to `NonceAt` (latest confirmed block)
- Add `txplan.WithConfirmedNonce` as replacement for `WithPendingNonce` (now deprecated)

### Problem

`PendingNonceAt` can return a stale nonce after a recently confirmed transaction because the node's pending state update is asynchronous — it runs in a separate goroutine from block processing. This creates a race window where sequential `SendTx` calls (or any mix of `SendTx`/`bind.TransactOpts`/`txplan`) on the same EOA can get the same nonce, causing transaction replacement or revert.

This is the root cause of ethereum-optimism/optimism#19760 (`TestPreinteropFaultProofs_TraceExtensionActivation` flaking with "Ownable: caller is not the owner") and potentially other intermittent test failures.

### Fix

Since all test transaction helpers wait for a receipt before returning, the confirmed nonce (from `NonceAt` against the latest block) is guaranteed to reflect all previously sent transactions. This eliminates the race entirely.

`WithPendingNonce` is kept but deprecated — `WithConfirmedNonce` is the drop-in replacement. `RequireSendTxs` (the batching variant) also switches to `NonceAt` since it queries once and increments locally.

### Note

ethereum-optimism/optimism#19745 fixes the specific flake in ethereum-optimism/optimism#19760 by eliminating the multi-transaction ownership dance entirely via EIP-7702. This PR addresses the systemic issue so other sequential transaction patterns don't have the same problem.

## Test plan

- [ ] Existing tests pass (the change is semantically equivalent for the send-one-wait-send-next pattern used everywhere)
- [ ] Verify `TestPreinteropFaultProofs_TraceExtensionActivation` no longer flakes

🤖 Generated with [Claude Code](https://claude.com/claude-code)