### PR TITLE
feat: add weekly l2 fork tests

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -3121,7 +3121,6 @@ workflows:
                 - soneium
                 - world-chain
                 - base
-                # - okx-xlayer
           test_profile: ci
           context:
             - circleci-repo-readonly-authenticated-github-token

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -50,6 +50,9 @@ parameters:
   c-l2_fork_test_dispatch:
     type: boolean
     default: false
+  c-l2_fork_weekly_dispatch:
+    type: boolean
+    default: false
   c-github-event-type:
     type: string
     default: "__not_set__"
@@ -121,6 +124,9 @@ parameters:
     type: boolean
     default: false
   l2_fork_test_dispatch:
+    type: boolean
+    default: false
+  l2_fork_weekly_dispatch:
     type: boolean
     default: false
   rust_ci_dispatch:
@@ -1382,8 +1388,9 @@ jobs:
         type: string
         default: "op-mainnet"
       l2_fork_rpc:
-        description: RPC URL for L2 fork
+        description: RPC URL for L2 fork. If empty, derived from fork_op_chain.
         type: string
+        default: ""
       l2_fork_block_number:
         description: Block number to fork from
         type: string
@@ -1415,10 +1422,19 @@ jobs:
           command: forge --version
           working_directory: packages/contracts-bedrock
       - run:
+          name: Resolve RPC URL
+          command: |
+            RPC="<<parameters.l2_fork_rpc>>"
+            if [ -z "$RPC" ]; then
+              RPC=$(jq -r '.["<<parameters.fork_op_chain>>"] // empty' .circleci/l2-rpcs.json)
+              [ -z "$RPC" ] && echo "Unknown chain '<<parameters.fork_op_chain>>' — add it to .circleci/l2-rpcs.json" && exit 1
+            fi
+            echo "export L2_FORK_RPC_URL=$RPC" >> $BASH_ENV
+      - run:
           name: Get latest block number if not specified
           command: |
             if [ "<<parameters.l2_fork_block_number>>" = "latest" ]; then
-              BLOCK_NUMBER=$(cast block-number --rpc-url <<parameters.l2_fork_rpc>>)
+              BLOCK_NUMBER=$(cast block-number --rpc-url "$L2_FORK_RPC_URL")
               echo "export L2_FORK_BLOCK_NUMBER=$BLOCK_NUMBER" >> $BASH_ENV
               echo "Using latest block number: $BLOCK_NUMBER"
               echo "$BLOCK_NUMBER" > ./l2ForkBlockNumber.txt
@@ -1444,7 +1460,6 @@ jobs:
             JUNIT_TEST_PATH=results/results.xml just test-l2-fork-upgrade
           environment:
             FOUNDRY_PROFILE: <<parameters.test_profile>>
-            L2_FORK_RPC_URL: <<parameters.l2_fork_rpc>>
           working_directory: packages/contracts-bedrock
           no_output_timeout: 20m
       - run:
@@ -1453,7 +1468,6 @@ jobs:
             just test-l2-fork-upgrade-rerun | tee failed-test-traces-l2-fork.log
           environment:
             FOUNDRY_PROFILE: <<parameters.test_profile>>
-            L2_FORK_RPC_URL: <<parameters.l2_fork_rpc>>
           working_directory: packages/contracts-bedrock
           when: on_fail
       - save_cache:
@@ -1511,6 +1525,16 @@ jobs:
           working_directory: packages/contracts-bedrock
       - notify-failures-on-develop:
           mentions: "@security-oncall"
+
+  l2-chains-sync-check:
+    docker:
+      - image: <<pipeline.parameters.c-default_docker_image>>
+    steps:
+      - utils/checkout-with-mise:
+          enable-mise-cache: false
+      - run:
+          name: Check l2-rpcs.json and weekly matrix are in sync
+          command: bash .circleci/scripts/check-l2-chains-sync.sh
 
   todo-issues:
     parameters:
@@ -2546,6 +2570,9 @@ workflows:
       - contracts-bedrock-checks-fast:
           context:
             - circleci-repo-readonly-authenticated-github-token
+      - l2-chains-sync-check:
+          context:
+            - circleci-repo-readonly-authenticated-github-token
       - contracts-bedrock-upload:
           requires:
             - contracts-bedrock-build
@@ -3068,6 +3095,33 @@ workflows:
           fork_op_chain: op-mainnet
           l2_fork_rpc: https://op-mainnet-rpc.optimism.io/
           l2_fork_block_number: latest
+          test_profile: ci
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+            - slack
+
+  scheduled-weekly-tests:
+    when:
+      or:
+        - equal: [build_weekly, <<pipeline.schedule.name>>]
+        - equal: [true, << pipeline.parameters.c-l2_fork_weekly_dispatch >>]
+    jobs:
+      - contracts-bedrock-tests-l2-fork:
+          matrix:
+            parameters:
+              fork_op_chain:
+                - op-mainnet
+                - zora
+                - ink
+                - mode
+                - metal
+                - arena-z
+                - swell
+                - unichain
+                - soneium
+                - world-chain
+                - base
+                # - okx-xlayer
           test_profile: ci
           context:
             - circleci-repo-readonly-authenticated-github-token

--- a/.circleci/l2-rpcs.json
+++ b/.circleci/l2-rpcs.json
@@ -1,0 +1,13 @@
+{
+  "op-mainnet": "https://mainnet.optimism.io",
+  "zora": "https://rpc.zora.energy",
+  "ink": "https://rpc-gel.inkonchain.com",
+  "mode": "https://mainnet.mode.network",
+  "metal": "https://rpc.metall2.com",
+  "arena-z": "https://rpc.arena-z.gg",
+  "swell": "https://swell-mainnet.alt.technology",
+  "unichain": "https://mainnet.unichain.org",
+  "soneium": "https://rpc.soneium.org",
+  "world-chain": "https://worldchain-mainnet.g.alchemy.com/public",
+  "base": "https://mainnet.base.org"
+}

--- a/.circleci/scripts/check-l2-chains-sync.sh
+++ b/.circleci/scripts/check-l2-chains-sync.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Checks that the chain names in the scheduled-weekly-tests matrix in
+# .circleci/continue/main.yml match the keys in ./circleci/l2-rpcs.json.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+L2_RPCS_FILE=".circleci/l2-rpcs.json"
+MAIN_YML_FILE=".circleci/continue/main.yml"
+L2_RPCS_PATH="$REPO_ROOT/$L2_RPCS_FILE"
+MAIN_YML_PATH="$REPO_ROOT/$MAIN_YML_FILE"
+
+json_chains=$(jq -r 'keys | sort | .[]' "$L2_RPCS_PATH")
+
+# Extract the fork_op_chain list from the scheduled-weekly-tests matrix block.
+# Relies on the block structure: the list appears after `fork_op_chain:` and
+# ends at the next non-list line (e.g. `test_profile:`).
+yaml_chains=$(awk '
+  /scheduled-weekly-tests/    { in_workflow=1 }
+  in_workflow && /fork_op_chain:/ { in_list=1; next }
+  in_workflow && in_list && /^[[:space:]]*- / {
+    sub(/^[[:space:]]*- /, ""); print; next
+  }
+  in_workflow && in_list      { exit }
+' "$MAIN_YML_PATH" | sort)
+
+if [ "$json_chains" = "$yaml_chains" ]; then
+  echo "OK: $L2_RPCS_FILE and scheduled-weekly-tests matrix are in sync."
+else
+  echo "ERROR: $L2_RPCS_FILE and the scheduled-weekly-tests matrix are out of sync."
+  echo ""
+  echo "  In l2-rpcs.json only:"
+  comm -23 <(echo "$json_chains") <(echo "$yaml_chains") | sed 's/^/    /'
+  echo "  In matrix only:"
+  comm -13 <(echo "$json_chains") <(echo "$yaml_chains") | sed 's/^/    /'
+  echo ""
+  echo "Update $L2_RPCS_FILE or the matrix in $MAIN_YML_FILE to match."
+  exit 1
+fi


### PR DESCRIPTION
**Description**

Adds a weekly CI job that runs L2 upgrade fork tests against all supported OP Stack chains.

Addresses [L-1]: chains running different contract versions may face unexpected reverts when using L2ContractsManager to perform upgrades.

**Changes**

**`.circleci/l2-rpcs.json`**
Single source of truth mapping each OP chain name to its public RPC endpoint.

**`.circleci/continue/main.yml`**
- `contracts-bedrock-tests-l2-fork` job: `l2_fork_rpc` is now optional. A new _Resolve RPC URL_ step derives the endpoint from `l2-rpcs.json` via `jq` when no explicit URL is passed, keeping existing callers (develop branch, manual dispatch) unaffected.
- New `scheduled-weekly-tests` workflow: triggers every week (`build_weekly` schedule) or on manual dispatch (`c-l2_fork_weekly_dispatch`). Uses a CircleCI matrix over `fork_op_chain` to run one parallel job per chain (11 total).
- New `l2-chains-sync-check` job wired into the main PR workflow.

**`.circleci/scripts/check-l2-chains-sync.sh`**
CI check that fails if the chain names in the `scheduled-weekly-tests` matrix and the keys in `l2-rpcs.json` diverge, preventing silent drift between the two.