### PR TITLE
fix(op-reth): send chainID in supervisor_checkAccessList

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -11603,6 +11603,7 @@ dependencies = [
  "reth-storage-api",
  "reth-transaction-pool",
  "serde",
+ "serde_json",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/rust/op-reth/crates/node/src/node.rs
+++ b/rust/op-reth/crates/node/src/node.rs
@@ -977,7 +977,7 @@ where
         // supervisor used for interop txpool validation
         let supervisor_client = if let Some(url) = self.supervisor_http.clone() {
             Some(
-                SupervisorClient::builder(url)
+                SupervisorClient::builder(url, ctx.chain_spec().chain_id())
                     .minimum_safety(self.supervisor_safety_level)
                     .build()
                     .await,

--- a/rust/op-reth/crates/txpool/Cargo.toml
+++ b/rust/op-reth/crates/txpool/Cargo.toml
@@ -57,3 +57,4 @@ tokio = { workspace = true, features = ["time"] }
 [dev-dependencies]
 reth-optimism-chainspec.workspace = true
 reth-provider = { workspace = true, features = ["test-utils"] }
+serde_json.workspace = true

--- a/rust/op-reth/crates/txpool/src/supervisor/client.rs
+++ b/rust/op-reth/crates/txpool/src/supervisor/client.rs
@@ -42,7 +42,10 @@ pub struct SupervisorClient {
 
 impl SupervisorClient {
     /// Returns a new [`SupervisorClientBuilder`].
-    pub fn builder(supervisor_endpoint: impl Into<String>, chain_id: u64) -> SupervisorClientBuilder {
+    pub fn builder(
+        supervisor_endpoint: impl Into<String>,
+        chain_id: u64,
+    ) -> SupervisorClientBuilder {
         SupervisorClientBuilder::new(supervisor_endpoint, chain_id)
     }
 

--- a/rust/op-reth/crates/txpool/src/supervisor/client.rs
+++ b/rust/op-reth/crates/txpool/src/supervisor/client.rs
@@ -42,8 +42,8 @@ pub struct SupervisorClient {
 
 impl SupervisorClient {
     /// Returns a new [`SupervisorClientBuilder`].
-    pub fn builder(supervisor_endpoint: impl Into<String>) -> SupervisorClientBuilder {
-        SupervisorClientBuilder::new(supervisor_endpoint)
+    pub fn builder(supervisor_endpoint: impl Into<String>, chain_id: u64) -> SupervisorClientBuilder {
+        SupervisorClientBuilder::new(supervisor_endpoint, chain_id)
     }
 
     /// Returns configured timeout. See [`SupervisorClientInner`].
@@ -108,7 +108,7 @@ impl SupervisorClient {
         if let Err(err) = self
             .check_access_list(
                 inbox_entries.as_slice(),
-                ExecutingDescriptor::new(timestamp, timeout),
+                ExecutingDescriptor::new(self.inner.chain_id, timestamp, timeout),
             )
             .await
         {
@@ -166,6 +166,8 @@ impl SupervisorClient {
 #[derive(Debug, Clone)]
 pub struct SupervisorClientInner {
     client: ReqwestClient,
+    /// The chain ID of the executing chain
+    chain_id: u64,
     /// The default
     safety: SafetyLevel,
     /// The default request timeout
@@ -179,6 +181,8 @@ pub struct SupervisorClientInner {
 pub struct SupervisorClientBuilder {
     /// Supervisor server's socket.
     endpoint: String,
+    /// The chain ID of the executing chain.
+    chain_id: u64,
     /// Timeout for requests.
     ///
     /// NOTE: this timeout is only effective if it's shorter than the timeout configured for the
@@ -190,9 +194,10 @@ pub struct SupervisorClientBuilder {
 
 impl SupervisorClientBuilder {
     /// Creates a new builder.
-    pub fn new(supervisor_endpoint: impl Into<String>) -> Self {
+    pub fn new(supervisor_endpoint: impl Into<String>, chain_id: u64) -> Self {
         Self {
             endpoint: supervisor_endpoint.into(),
+            chain_id,
             timeout: DEFAULT_REQUEST_TIMEOUT,
             safety: SafetyLevel::CrossUnsafe,
         }
@@ -212,7 +217,7 @@ impl SupervisorClientBuilder {
 
     /// Creates a new supervisor validator.
     pub async fn build(self) -> SupervisorClient {
-        let Self { endpoint, timeout, safety } = self;
+        let Self { endpoint, chain_id, timeout, safety } = self;
 
         let client = ReqwestClient::builder()
             .connect(endpoint.as_str())
@@ -222,6 +227,7 @@ impl SupervisorClientBuilder {
         SupervisorClient {
             inner: Arc::new(SupervisorClientInner {
                 client,
+                chain_id,
                 safety,
                 timeout,
                 metrics: SupervisorMetrics::default(),

--- a/rust/op-reth/crates/txpool/src/supervisor/message.rs
+++ b/rust/op-reth/crates/txpool/src/supervisor/message.rs
@@ -19,10 +19,9 @@
 /// An [`ExecutingDescriptor`] is a part of the payload to `supervisor_checkAccessList`
 /// Spec: <https://github.com/ethereum-optimism/specs/blob/main/specs/interop/supervisor.md#executingdescriptor>
 #[derive(Default, Debug, PartialEq, Eq, Clone, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct ExecutingDescriptor {
     /// The chain ID of the executing chain.
-    #[serde(with = "alloy_serde::quantity")]
+    #[serde(rename = "chainID", with = "alloy_serde::quantity")]
     chain_id: u64,
     /// The timestamp used to enforce timestamp [invariant](https://github.com/ethereum-optimism/specs/blob/main/specs/interop/derivation.md#invariants)
     #[serde(with = "alloy_serde::quantity")]

--- a/rust/op-reth/crates/txpool/src/supervisor/message.rs
+++ b/rust/op-reth/crates/txpool/src/supervisor/message.rs
@@ -19,7 +19,11 @@
 /// An [`ExecutingDescriptor`] is a part of the payload to `supervisor_checkAccessList`
 /// Spec: <https://github.com/ethereum-optimism/specs/blob/main/specs/interop/supervisor.md#executingdescriptor>
 #[derive(Default, Debug, PartialEq, Eq, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ExecutingDescriptor {
+    /// The chain ID of the executing chain.
+    #[serde(with = "alloy_serde::quantity")]
+    chain_id: u64,
     /// The timestamp used to enforce timestamp [invariant](https://github.com/ethereum-optimism/specs/blob/main/specs/interop/derivation.md#invariants)
     #[serde(with = "alloy_serde::quantity")]
     timestamp: u64,
@@ -30,8 +34,8 @@ pub struct ExecutingDescriptor {
 }
 
 impl ExecutingDescriptor {
-    /// Create a new [`ExecutingDescriptor`] from the timestamp and timeout
-    pub const fn new(timestamp: u64, timeout: Option<u64>) -> Self {
-        Self { timestamp, timeout }
+    /// Create a new [`ExecutingDescriptor`] with chain ID, timestamp and timeout
+    pub const fn new(chain_id: u64, timestamp: u64, timeout: Option<u64>) -> Self {
+        Self { chain_id, timestamp, timeout }
     }
 }

--- a/rust/op-reth/crates/txpool/src/supervisor/message.rs
+++ b/rust/op-reth/crates/txpool/src/supervisor/message.rs
@@ -38,3 +38,26 @@ impl ExecutingDescriptor {
         Self { chain_id, timestamp, timeout }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::ExecutingDescriptor;
+
+    #[test]
+    fn serializes_executing_descriptor_with_chain_id_key() {
+        let descriptor = ExecutingDescriptor::new(1000, 1234567890, Some(3600));
+
+        let serialized = serde_json::to_string(&descriptor).unwrap();
+
+        assert_eq!(serialized, r#"{"chainID":"0x3e8","timestamp":"0x499602d2","timeout":"0xe10"}"#);
+    }
+
+    #[test]
+    fn deserializes_executing_descriptor_with_chain_id_key() {
+        let json = r#"{"chainID":"0x3e8","timestamp":"0x499602d2","timeout":"0xe10"}"#;
+
+        let deserialized: ExecutingDescriptor = serde_json::from_str(json).unwrap();
+
+        assert_eq!(deserialized, ExecutingDescriptor::new(1000, 1234567890, Some(3600)));
+    }
+}


### PR DESCRIPTION
## Summary

This updates the op-reth supervisor access-list validation payload so it includes the executing chain ID and matches the existing Go-side supervisor schema.

Changes in this branch:
- add `chain_id` to op-reth's local `ExecutingDescriptor`
- thread the chain ID from `ChainSpec` into the supervisor client
- serialize the field as `chainID` to match the Go supervisor and kona
- add a regression test covering `ExecutingDescriptor` serde for the exact `chainID` key

## Why

Without `chainID` in `supervisor_checkAccessList`, the supervisor sees chain ID `0` and rejects valid cross-chain relay transactions with an unknown-chain style failure.

## Testing

- `~/.cargo/bin/cargo test -p reth-optimism-txpool supervisor::message --quiet`
