### PR TITLE
chore(contracts-bedrock): suppress solc 0.8.31 deprecation warnings

### DIFF
--- a/packages/contracts-bedrock/foundry.toml
+++ b/packages/contracts-bedrock/foundry.toml
@@ -73,9 +73,11 @@ fs_permissions = [
   { access='read', path='./lib/superchain-registry/validation/standard/' },
 ]
 
-# 5159 error code is selfdestruct error code
-ignored_error_codes = ["transient-storage", "code-size", "init-code-size", "too-many-warnings", 5159]
-deny_warnings = true
+# 5159 = selfdestruct deprecation
+# 8429 = virtual modifiers deprecated (solc 0.8.31, triggered by solmate)
+# 2424 = natspec memory-safe-assembly comment deprecated (solc 0.8.31, triggered by forge-std)
+ignored_error_codes = ["transient-storage", "code-size", "init-code-size", "too-many-warnings", 5159, 8429, 2424]
+deny = "warnings"
 ffi = true
 
 # We set the gas limit to max int64 to avoid running out of gas during testing, since the default


### PR DESCRIPTION
Forge has begun downloading solc 0.8.31 for new installs on my machine. Because some of the libs we are pulling in have floating pragmas, it now compiles with that version, and it emits new deprecation warnings (added to 0.8.31 [here](https://github.com/argotorg/solidity/commit/f4173b2a7e4c975f0cda7ee665cab0b9404d985e)).

I suspect that the reason CI is not yet failing is because of mise install caching. If that cache is invalidated for any reason, I think that all smart contract CI jobs will begin to fail. 

This PR should prevent that.

- Add error codes 8429 (virtual modifiers deprecated) and 2424 (natspec memory-safe-assembly deprecated) to `ignored_error_codes` — both triggered by solc 0.8.31 via solmate and forge-std respectively
- Migrate `deny_warnings = true` to `deny = "warnings"` (updated Foundry config syntax)
- Document what each suppressed error code means