### PR TITLE
feat(kona-host): add directory-based kv store compatible with op-program

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5859,6 +5859,7 @@ dependencies = [
  "rocksdb",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/rust/kona/bin/host/Cargo.toml
+++ b/rust/kona/bin/host/Cargo.toml
@@ -65,6 +65,7 @@ serde = { workspace = true, features = ["derive"] }
 clap = { workspace = true, features = ["derive", "env"] }
 tracing-subscriber = { workspace = true, features = ["fmt"] }
 thiserror.workspace = true
+tempfile.workspace = true
 
 # KZG
 ark-ff.workspace = true
@@ -72,7 +73,6 @@ ark-ff.workspace = true
 [dev-dependencies]
 alloy-json-rpc.workspace = true
 proptest.workspace = true
-tempfile.workspace = true
 
 [features]
 default = [ "interop", "single" ]

--- a/rust/kona/bin/host/Cargo.toml
+++ b/rust/kona/bin/host/Cargo.toml
@@ -72,6 +72,7 @@ ark-ff.workspace = true
 [dev-dependencies]
 alloy-json-rpc.workspace = true
 proptest.workspace = true
+tempfile.workspace = true
 
 [features]
 default = [ "interop", "single" ]

--- a/rust/kona/bin/host/src/interop/cfg.rs
+++ b/rust/kona/bin/host/src/interop/cfg.rs
@@ -2,9 +2,9 @@
 
 use super::{InteropHintHandler, InteropLocalInputs};
 use crate::{
-    DiskKeyValueStore, MemoryKeyValueStore, OfflineHostBackend, OnlineHostBackend,
-    OnlineHostBackendCfg, PreimageServer, SharedKeyValueStore, SplitKeyValueStore,
-    eth::rpc_provider, server::PreimageServerError,
+    DiskKeyValueStore, DirectoryKeyValueStore, MemoryKeyValueStore, OfflineHostBackend,
+    OnlineHostBackend, OnlineHostBackendCfg, PreimageServer, SharedKeyValueStore,
+    SplitKeyValueStore, eth::rpc_provider, kv::DataFormat, server::PreimageServerError,
 };
 use alloy_primitives::{B256, Bytes};
 use alloy_provider::{Provider, RootProvider};
@@ -79,6 +79,9 @@ pub struct InteropHost {
         env
     )]
     pub data_dir: Option<PathBuf>,
+    /// The format to use for preimage data storage on disk.
+    #[arg(long, default_value = "directory", env)]
+    pub data_format: DataFormat,
     /// Run the client program natively.
     #[arg(long, conflicts_with = "server", required_unless_present = "server")]
     pub native: bool,
@@ -256,9 +259,16 @@ impl InteropHost {
         let local_kv_store = InteropLocalInputs::new(self.clone());
 
         let kv_store: SharedKeyValueStore = if let Some(ref data_dir) = self.data_dir {
-            let disk_kv_store = DiskKeyValueStore::new(data_dir.clone());
-            let split_kv_store = SplitKeyValueStore::new(local_kv_store, disk_kv_store);
-            Arc::new(RwLock::new(split_kv_store))
+            match self.data_format {
+                DataFormat::Directory => {
+                    let dir_kv_store = DirectoryKeyValueStore::new(data_dir.clone());
+                    Arc::new(RwLock::new(SplitKeyValueStore::new(local_kv_store, dir_kv_store)))
+                }
+                DataFormat::Rocksdb => {
+                    let disk_kv_store = DiskKeyValueStore::new(data_dir.clone());
+                    Arc::new(RwLock::new(SplitKeyValueStore::new(local_kv_store, disk_kv_store)))
+                }
+            }
         } else {
             let mem_kv_store = MemoryKeyValueStore::new();
             let split_kv_store = SplitKeyValueStore::new(local_kv_store, mem_kv_store);

--- a/rust/kona/bin/host/src/interop/cfg.rs
+++ b/rust/kona/bin/host/src/interop/cfg.rs
@@ -260,7 +260,7 @@ impl InteropHost {
     /// ensure compatibility with existing data. Otherwise, `--data-format` is used as the default.
     fn create_key_value_store(&self) -> Result<SharedKeyValueStore, InteropHostError> {
         let local_kv_store = InteropLocalInputs::new(self.clone());
-        Ok(create_key_value_store(local_kv_store, self.data_dir.as_ref(), self.data_format))
+        Ok(create_key_value_store(local_kv_store, self.data_dir.as_deref(), self.data_format))
     }
 
     /// Creates the providers required for the preimage server backend.

--- a/rust/kona/bin/host/src/interop/cfg.rs
+++ b/rust/kona/bin/host/src/interop/cfg.rs
@@ -2,7 +2,7 @@
 
 use super::{InteropHintHandler, InteropLocalInputs};
 use crate::{
-    DiskKeyValueStore, DirectoryKeyValueStore, MemoryKeyValueStore, OfflineHostBackend,
+    DirectoryKeyValueStore, DiskKeyValueStore, MemoryKeyValueStore, OfflineHostBackend,
     OnlineHostBackend, OnlineHostBackendCfg, PreimageServer, SharedKeyValueStore,
     SplitKeyValueStore, eth::rpc_provider, kv::DataFormat, server::PreimageServerError,
 };

--- a/rust/kona/bin/host/src/interop/cfg.rs
+++ b/rust/kona/bin/host/src/interop/cfg.rs
@@ -216,10 +216,10 @@ impl InteropHost {
 
     /// Returns `true` if the host is running in offline mode.
     pub const fn is_offline(&self) -> bool {
-        self.l1_node_address.is_none()
-            && self.l2_node_addresses.is_none()
-            && self.l1_beacon_address.is_none()
-            && self.data_dir.is_some()
+        self.l1_node_address.is_none() &&
+            self.l2_node_addresses.is_none() &&
+            self.l1_beacon_address.is_none() &&
+            self.data_dir.is_some()
     }
 
     /// Reads the [`RollupConfig`]s from the file system and returns a map of L2 chain ID ->

--- a/rust/kona/bin/host/src/interop/cfg.rs
+++ b/rust/kona/bin/host/src/interop/cfg.rs
@@ -2,11 +2,10 @@
 
 use super::{InteropHintHandler, InteropLocalInputs};
 use crate::{
-    DirectoryKeyValueStore, DiskKeyValueStore, MemoryKeyValueStore, OfflineHostBackend,
-    OnlineHostBackend, OnlineHostBackendCfg, PreimageServer, SharedKeyValueStore,
-    SplitKeyValueStore,
+    OfflineHostBackend, OnlineHostBackend, OnlineHostBackendCfg, PreimageServer,
+    SharedKeyValueStore,
     eth::rpc_provider,
-    kv::{DataFormat, detect_data_format},
+    kv::{DataFormat, create_key_value_store},
     server::PreimageServerError,
 };
 use alloy_primitives::{B256, Bytes};
@@ -23,10 +22,7 @@ use kona_std_fpvm::{FileChannel, FileDescriptor};
 use op_alloy_network::Optimism;
 use serde::Serialize;
 use std::{collections::HashMap, path::PathBuf, str::FromStr, sync::Arc};
-use tokio::{
-    sync::RwLock,
-    task::{self, JoinHandle},
-};
+use tokio::task::{self, JoinHandle};
 
 /// The interop host application.
 #[derive(Default, Parser, Serialize, Clone, Debug)]
@@ -264,26 +260,7 @@ impl InteropHost {
     /// ensure compatibility with existing data. Otherwise, `--data-format` is used as the default.
     fn create_key_value_store(&self) -> Result<SharedKeyValueStore, InteropHostError> {
         let local_kv_store = InteropLocalInputs::new(self.clone());
-
-        let kv_store: SharedKeyValueStore = if let Some(ref data_dir) = self.data_dir {
-            let format = detect_data_format(data_dir, self.data_format);
-            match format {
-                DataFormat::Directory => {
-                    let dir_kv_store = DirectoryKeyValueStore::new(data_dir.clone());
-                    Arc::new(RwLock::new(SplitKeyValueStore::new(local_kv_store, dir_kv_store)))
-                }
-                DataFormat::Rocksdb => {
-                    let disk_kv_store = DiskKeyValueStore::new(data_dir.clone());
-                    Arc::new(RwLock::new(SplitKeyValueStore::new(local_kv_store, disk_kv_store)))
-                }
-            }
-        } else {
-            let mem_kv_store = MemoryKeyValueStore::new();
-            let split_kv_store = SplitKeyValueStore::new(local_kv_store, mem_kv_store);
-            Arc::new(RwLock::new(split_kv_store))
-        };
-
-        Ok(kv_store)
+        Ok(create_key_value_store(local_kv_store, self.data_dir.as_ref(), self.data_format))
     }
 
     /// Creates the providers required for the preimage server backend.

--- a/rust/kona/bin/host/src/interop/cfg.rs
+++ b/rust/kona/bin/host/src/interop/cfg.rs
@@ -4,7 +4,10 @@ use super::{InteropHintHandler, InteropLocalInputs};
 use crate::{
     DirectoryKeyValueStore, DiskKeyValueStore, MemoryKeyValueStore, OfflineHostBackend,
     OnlineHostBackend, OnlineHostBackendCfg, PreimageServer, SharedKeyValueStore,
-    SplitKeyValueStore, eth::rpc_provider, kv::DataFormat, server::PreimageServerError,
+    SplitKeyValueStore,
+    eth::rpc_provider,
+    kv::{DataFormat, detect_data_format},
+    server::PreimageServerError,
 };
 use alloy_primitives::{B256, Bytes};
 use alloy_provider::{Provider, RootProvider};
@@ -79,7 +82,8 @@ pub struct InteropHost {
         env
     )]
     pub data_dir: Option<PathBuf>,
-    /// The format to use for preimage data storage on disk.
+    /// The default format for preimage data storage on disk. If the data directory already
+    /// contains a `kvformat` marker file, that format is used instead of this value.
     #[arg(long, default_value = "directory", env)]
     pub data_format: DataFormat,
     /// Run the client program natively.
@@ -216,10 +220,10 @@ impl InteropHost {
 
     /// Returns `true` if the host is running in offline mode.
     pub const fn is_offline(&self) -> bool {
-        self.l1_node_address.is_none() &&
-            self.l2_node_addresses.is_none() &&
-            self.l1_beacon_address.is_none() &&
-            self.data_dir.is_some()
+        self.l1_node_address.is_none()
+            && self.l2_node_addresses.is_none()
+            && self.l1_beacon_address.is_none()
+            && self.data_dir.is_some()
     }
 
     /// Reads the [`RollupConfig`]s from the file system and returns a map of L2 chain ID ->
@@ -255,11 +259,15 @@ impl InteropHost {
     }
 
     /// Creates the key-value store for the host backend.
+    ///
+    /// If the data directory contains a `kvformat` marker file, the recorded format is used to
+    /// ensure compatibility with existing data. Otherwise, `--data-format` is used as the default.
     fn create_key_value_store(&self) -> Result<SharedKeyValueStore, InteropHostError> {
         let local_kv_store = InteropLocalInputs::new(self.clone());
 
         let kv_store: SharedKeyValueStore = if let Some(ref data_dir) = self.data_dir {
-            match self.data_format {
+            let format = detect_data_format(data_dir, self.data_format);
+            match format {
                 DataFormat::Directory => {
                     let dir_kv_store = DirectoryKeyValueStore::new(data_dir.clone());
                     Arc::new(RwLock::new(SplitKeyValueStore::new(local_kv_store, dir_kv_store)))

--- a/rust/kona/bin/host/src/kv/directory.rs
+++ b/rust/kona/bin/host/src/kv/directory.rs
@@ -4,7 +4,11 @@
 use super::{DataFormat, FORMAT_FILENAME, KeyValueStore};
 use crate::{HostError, Result};
 use alloy_primitives::{B256, hex};
-use std::{fs, path::PathBuf};
+use std::{
+    fs,
+    io::Write,
+    path::{Path, PathBuf},
+};
 
 /// A key-value store that writes preimages as hex-encoded files in subdirectories.
 ///
@@ -19,8 +23,8 @@ pub struct DirectoryKeyValueStore {
 
 impl DirectoryKeyValueStore {
     /// Create a new [`DirectoryKeyValueStore`] with the given data directory.
-    pub fn new(data_directory: PathBuf) -> Self {
-        fs::create_dir_all(&data_directory)
+    pub fn new(data_directory: &Path) -> Self {
+        fs::create_dir_all(data_directory)
             .unwrap_or_else(|e| panic!("Failed to create directory {data_directory:?}: {e}"));
 
         let format_path = data_directory.join(FORMAT_FILENAME);
@@ -29,7 +33,7 @@ impl DirectoryKeyValueStore {
                 .unwrap_or_else(|e| panic!("Failed to write kvformat marker: {e}"));
         }
 
-        Self { data_directory }
+        Self { data_directory: data_directory.to_path_buf() }
     }
 
     /// Returns the file path for the given key.
@@ -45,19 +49,38 @@ impl DirectoryKeyValueStore {
 
 impl KeyValueStore for DirectoryKeyValueStore {
     fn get(&self, key: B256) -> Option<Vec<u8>> {
-        let data = fs::read_to_string(self.key_path(key)).ok()?;
-        hex::decode(data).ok()
+        let path = self.key_path(key);
+        let data = fs::read_to_string(&path).ok()?;
+        match hex::decode(&data) {
+            Ok(value) => Some(value),
+            Err(e) => {
+                tracing::warn!(key = %key, path = %path.display(), error = %e, "Corrupt preimage file, ignoring");
+                None
+            }
+        }
     }
 
     fn set(&mut self, key: B256, value: Vec<u8>) -> Result<()> {
         let path = self.key_path(key);
-        if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent).map_err(|e| {
-                HostError::KeyValueSetFailed(format!("failed to create directory {parent:?}: {e}"))
-            })?;
-        }
-        fs::write(&path, hex::encode(&value))
-            .map_err(|e| HostError::KeyValueSetFailed(format!("failed to write {path:?}: {e}")))
+        let parent = path.parent().ok_or_else(|| {
+            HostError::KeyValueSetFailed(format!("no parent directory for {path:?}"))
+        })?;
+        fs::create_dir_all(parent).map_err(|e| {
+            HostError::KeyValueSetFailed(format!("failed to create directory {parent:?}: {e}"))
+        })?;
+
+        // Write to a temp file and rename for atomicity — a crash during fs::write could leave
+        // a partially written (corrupt) file, but rename is atomic on POSIX.
+        let mut tmp = tempfile::NamedTempFile::new_in(parent).map_err(|e| {
+            HostError::KeyValueSetFailed(format!("failed to create temp file in {parent:?}: {e}"))
+        })?;
+        tmp.write_all(hex::encode(&value).as_bytes()).map_err(|e| {
+            HostError::KeyValueSetFailed(format!("failed to write temp file: {e}"))
+        })?;
+        tmp.persist(&path).map_err(|e| {
+            HostError::KeyValueSetFailed(format!("failed to rename temp file to {path:?}: {e}"))
+        })?;
+        Ok(())
     }
 }
 
@@ -79,7 +102,7 @@ mod test {
         #[test]
         fn directory_kv_roundtrip(k_v in hash_map(any::<[u8; 32]>(), vec(any::<u8>(), 0..128), 1..128)) {
             let tempdir = tempfile::TempDir::new().unwrap();
-            let mut kv = DirectoryKeyValueStore::new(tempdir.path().to_path_buf());
+            let mut kv = DirectoryKeyValueStore::new(tempdir.path());
 
             for (k, v) in &k_v {
                 kv.set((*k).into(), v.clone()).unwrap();
@@ -95,7 +118,7 @@ mod test {
     #[test]
     fn writes_kvformat_marker() {
         let tempdir = tempfile::TempDir::new().unwrap();
-        let _kv = DirectoryKeyValueStore::new(tempdir.path().to_path_buf());
+        let _kv = DirectoryKeyValueStore::new(tempdir.path());
 
         let marker = std::fs::read_to_string(tempdir.path().join("kvformat")).unwrap();
         assert_eq!(marker, "directory");
@@ -104,14 +127,17 @@ mod test {
     #[test]
     fn key_path_layout() {
         let tempdir = tempfile::TempDir::new().unwrap();
-        let kv = DirectoryKeyValueStore::new(tempdir.path().to_path_buf());
+        let kv = DirectoryKeyValueStore::new(tempdir.path());
 
         let key = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
             .parse::<B256>()
             .unwrap();
         let path = kv.key_path(key);
 
-        assert!(path.to_str().unwrap().contains("0123"));
-        assert!(path.file_name().unwrap().to_str().unwrap().ends_with(".txt"));
+        let expected = tempdir
+            .path()
+            .join("0123")
+            .join("456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef.txt");
+        assert_eq!(path, expected);
     }
 }

--- a/rust/kona/bin/host/src/kv/directory.rs
+++ b/rust/kona/bin/host/src/kv/directory.rs
@@ -72,15 +72,14 @@ mod test {
         proptest,
         test_runner::Config,
     };
-    use std::env::temp_dir;
 
     proptest! {
         #![proptest_config(Config::with_cases(16))]
 
         #[test]
         fn directory_kv_roundtrip(k_v in hash_map(any::<[u8; 32]>(), vec(any::<u8>(), 0..128), 1..128)) {
-            let tempdir = temp_dir();
-            let mut kv = DirectoryKeyValueStore::new(tempdir);
+            let tempdir = tempfile::TempDir::new().unwrap();
+            let mut kv = DirectoryKeyValueStore::new(tempdir.path().to_path_buf());
 
             for (k, v) in &k_v {
                 kv.set((*k).into(), v.clone()).unwrap();
@@ -95,17 +94,17 @@ mod test {
 
     #[test]
     fn writes_kvformat_marker() {
-        let tempdir = temp_dir().join("kona_test_kvformat");
-        let _kv = DirectoryKeyValueStore::new(tempdir.clone());
+        let tempdir = tempfile::TempDir::new().unwrap();
+        let _kv = DirectoryKeyValueStore::new(tempdir.path().to_path_buf());
 
-        let marker = std::fs::read_to_string(tempdir.join("kvformat")).unwrap();
+        let marker = std::fs::read_to_string(tempdir.path().join("kvformat")).unwrap();
         assert_eq!(marker, "directory");
     }
 
     #[test]
     fn key_path_layout() {
-        let tempdir = temp_dir().join("kona_test_layout");
-        let kv = DirectoryKeyValueStore::new(tempdir);
+        let tempdir = tempfile::TempDir::new().unwrap();
+        let kv = DirectoryKeyValueStore::new(tempdir.path().to_path_buf());
 
         let key = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
             .parse::<B256>()

--- a/rust/kona/bin/host/src/kv/directory.rs
+++ b/rust/kona/bin/host/src/kv/directory.rs
@@ -1,20 +1,14 @@
 //! Contains a concrete implementation of the [`KeyValueStore`] trait that stores data on disk
-//! using a directory-based layout compatible with op-program's `DataFormatDirectory`.
+//! using a directory-based layout compatible with op-challenger's `DataFormatDirectory`.
 
-use super::KeyValueStore;
+use super::{DataFormat, FORMAT_FILENAME, KeyValueStore};
 use crate::{HostError, Result};
 use alloy_primitives::{B256, hex};
 use std::{fs, path::PathBuf};
 
-/// The filename used to record the storage format, matching op-program's convention.
-const FORMAT_FILENAME: &str = "kvformat";
-
-/// The format identifier written to the marker file, matching op-program's `DataFormatDirectory`.
-const FORMAT_VALUE: &str = "directory";
-
 /// A key-value store that writes preimages as hex-encoded files in subdirectories.
 ///
-/// Layout matches op-program's `directoryKV`:
+/// Layout is compatible with op-challenger's `directoryKV`:
 /// - Key `0x0123456789...abc` maps to `<dir>/0123/456789...abc.txt`
 /// - Values are hex-encoded on disk
 /// - A `kvformat` marker file containing `"directory"` is written for op-challenger compatibility
@@ -31,7 +25,7 @@ impl DirectoryKeyValueStore {
 
         let format_path = data_directory.join(FORMAT_FILENAME);
         if !format_path.exists() {
-            fs::write(&format_path, FORMAT_VALUE)
+            fs::write(&format_path, DataFormat::Directory.as_str())
                 .unwrap_or_else(|e| panic!("Failed to write kvformat marker: {e}"));
         }
 
@@ -40,8 +34,8 @@ impl DirectoryKeyValueStore {
 
     /// Returns the file path for the given key.
     ///
-    /// Matches op-program's `directoryKV.pathKey`: the hex key (without `0x` prefix) is split
-    /// into a 4-char directory prefix and the remainder as the filename with `.txt` extension.
+    /// The hex key (without `0x` prefix) is split into a 4-char directory prefix and the
+    /// remainder as the filename with `.txt` extension. This matches op-challenger's layout.
     fn key_path(&self, key: B256) -> PathBuf {
         let hex_key = format!("{key:x}");
         let (dir_part, file_part) = hex_key.split_at(4);

--- a/rust/kona/bin/host/src/kv/directory.rs
+++ b/rust/kona/bin/host/src/kv/directory.rs
@@ -74,9 +74,8 @@ impl KeyValueStore for DirectoryKeyValueStore {
         let mut tmp = tempfile::NamedTempFile::new_in(parent).map_err(|e| {
             HostError::KeyValueSetFailed(format!("failed to create temp file in {parent:?}: {e}"))
         })?;
-        tmp.write_all(hex::encode(&value).as_bytes()).map_err(|e| {
-            HostError::KeyValueSetFailed(format!("failed to write temp file: {e}"))
-        })?;
+        tmp.write_all(hex::encode(&value).as_bytes())
+            .map_err(|e| HostError::KeyValueSetFailed(format!("failed to write temp file: {e}")))?;
         tmp.persist(&path).map_err(|e| {
             HostError::KeyValueSetFailed(format!("failed to rename temp file to {path:?}: {e}"))
         })?;

--- a/rust/kona/bin/host/src/kv/directory.rs
+++ b/rust/kona/bin/host/src/kv/directory.rs
@@ -1,0 +1,132 @@
+//! Contains a concrete implementation of the [`KeyValueStore`] trait that stores data on disk
+//! using a directory-based layout compatible with op-program's `DataFormatDirectory`.
+
+use super::KeyValueStore;
+use crate::{HostError, Result};
+use alloy_primitives::{hex, B256};
+use std::{fs, path::PathBuf};
+
+/// The filename used to record the storage format, matching op-program's convention.
+const FORMAT_FILENAME: &str = "kvformat";
+
+/// The format identifier written to the marker file, matching op-program's `DataFormatDirectory`.
+const FORMAT_VALUE: &str = "directory";
+
+/// A key-value store that writes preimages as hex-encoded files in subdirectories.
+///
+/// Layout matches op-program's `directoryKV`:
+/// - Key `0x0123456789...abc` maps to `<dir>/0123/456789...abc.txt`
+/// - Values are hex-encoded on disk
+/// - A `kvformat` marker file containing `"directory"` is written for op-challenger compatibility
+#[derive(Debug)]
+pub struct DirectoryKeyValueStore {
+    data_directory: PathBuf,
+}
+
+impl DirectoryKeyValueStore {
+    /// Create a new [`DirectoryKeyValueStore`] with the given data directory.
+    pub fn new(data_directory: PathBuf) -> Self {
+        fs::create_dir_all(&data_directory)
+            .unwrap_or_else(|e| panic!("Failed to create directory {data_directory:?}: {e}"));
+
+        let format_path = data_directory.join(FORMAT_FILENAME);
+        if !format_path.exists() {
+            fs::write(&format_path, FORMAT_VALUE)
+                .unwrap_or_else(|e| panic!("Failed to write kvformat marker: {e}"));
+        }
+
+        Self { data_directory }
+    }
+
+    /// Returns the file path for the given key.
+    ///
+    /// Matches op-program's `directoryKV.pathKey`: the hex key (without `0x` prefix) is split
+    /// into a 4-char directory prefix and the remainder as the filename with `.txt` extension.
+    fn key_path(&self, key: B256) -> PathBuf {
+        let hex_key = format!("{key:x}");
+        let (dir_part, file_part) = hex_key.split_at(4);
+        self.data_directory.join(dir_part).join(format!("{file_part}.txt"))
+    }
+}
+
+impl KeyValueStore for DirectoryKeyValueStore {
+    fn get(&self, key: B256) -> Option<Vec<u8>> {
+        let data = fs::read_to_string(self.key_path(key)).ok()?;
+        hex::decode(data).ok()
+    }
+
+    fn set(&mut self, key: B256, value: Vec<u8>) -> Result<()> {
+        let path = self.key_path(key);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).map_err(|e| {
+                HostError::KeyValueSetFailed(format!(
+                    "failed to create directory {parent:?}: {e}"
+                ))
+            })?;
+        }
+        fs::write(&path, hex::encode(&value)).map_err(|e| {
+            HostError::KeyValueSetFailed(format!("failed to write {path:?}: {e}"))
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::DirectoryKeyValueStore;
+    use crate::kv::KeyValueStore;
+    use alloy_primitives::B256;
+    use proptest::{
+        arbitrary::any,
+        collection::{hash_map, vec},
+        proptest,
+        test_runner::Config,
+    };
+    use std::env::temp_dir;
+
+    proptest! {
+        #![proptest_config(Config::with_cases(16))]
+
+        #[test]
+        fn directory_kv_roundtrip(k_v in hash_map(any::<[u8; 32]>(), vec(any::<u8>(), 0..128), 1..128)) {
+            let tempdir = temp_dir();
+            let mut kv = DirectoryKeyValueStore::new(tempdir);
+
+            for (k, v) in &k_v {
+                kv.set((*k).into(), v.clone()).unwrap();
+            }
+
+            for (k, v) in &k_v {
+                let key: B256 = (*k).into();
+                assert_eq!(kv.get(key).unwrap(), *v);
+            }
+        }
+    }
+
+    #[test]
+    fn writes_kvformat_marker() {
+        let tempdir = temp_dir().join("kona_test_kvformat");
+        let _kv = DirectoryKeyValueStore::new(tempdir.clone());
+
+        let marker = std::fs::read_to_string(tempdir.join("kvformat")).unwrap();
+        assert_eq!(marker, "directory");
+    }
+
+    #[test]
+    fn key_path_layout() {
+        let tempdir = temp_dir().join("kona_test_layout");
+        let kv = DirectoryKeyValueStore::new(tempdir);
+
+        let key = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+            .parse::<B256>()
+            .unwrap();
+        let path = kv.key_path(key);
+
+        assert!(path.to_str().unwrap().contains("0123"));
+        assert!(path
+            .file_name()
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .ends_with(".txt"));
+    }
+}

--- a/rust/kona/bin/host/src/kv/directory.rs
+++ b/rust/kona/bin/host/src/kv/directory.rs
@@ -3,7 +3,7 @@
 
 use super::KeyValueStore;
 use crate::{HostError, Result};
-use alloy_primitives::{hex, B256};
+use alloy_primitives::{B256, hex};
 use std::{fs, path::PathBuf};
 
 /// The filename used to record the storage format, matching op-program's convention.

--- a/rust/kona/bin/host/src/kv/directory.rs
+++ b/rust/kona/bin/host/src/kv/directory.rs
@@ -59,14 +59,11 @@ impl KeyValueStore for DirectoryKeyValueStore {
         let path = self.key_path(key);
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent).map_err(|e| {
-                HostError::KeyValueSetFailed(format!(
-                    "failed to create directory {parent:?}: {e}"
-                ))
+                HostError::KeyValueSetFailed(format!("failed to create directory {parent:?}: {e}"))
             })?;
         }
-        fs::write(&path, hex::encode(&value)).map_err(|e| {
-            HostError::KeyValueSetFailed(format!("failed to write {path:?}: {e}"))
-        })
+        fs::write(&path, hex::encode(&value))
+            .map_err(|e| HostError::KeyValueSetFailed(format!("failed to write {path:?}: {e}")))
     }
 }
 
@@ -122,11 +119,6 @@ mod test {
         let path = kv.key_path(key);
 
         assert!(path.to_str().unwrap().contains("0123"));
-        assert!(path
-            .file_name()
-            .unwrap()
-            .to_str()
-            .unwrap()
-            .ends_with(".txt"));
+        assert!(path.file_name().unwrap().to_str().unwrap().ends_with(".txt"));
     }
 }

--- a/rust/kona/bin/host/src/kv/disk.rs
+++ b/rust/kona/bin/host/src/kv/disk.rs
@@ -84,16 +84,14 @@ mod test {
         proptest,
         test_runner::Config,
     };
-    use std::env::temp_dir;
-
     proptest! {
         #![proptest_config(Config::with_cases(16))]
 
         /// Test that converting from a [DiskKeyValueStore] to a [MemoryKeyValueStore] is lossless.
         #[test]
         fn convert_disk_kv_to_mem_kv(k_v in hash_map(any::<[u8; 32]>(), vec(any::<u8>(), 0..128), 1..128)) {
-            let tempdir = temp_dir();
-            let mut disk_kv = DiskKeyValueStore::new(tempdir);
+            let tempdir = tempfile::TempDir::new().unwrap();
+            let mut disk_kv = DiskKeyValueStore::new(tempdir.path().to_path_buf());
             for (k, v) in &k_v {
                 disk_kv.set(k.into(), v.clone()).unwrap();
             }

--- a/rust/kona/bin/host/src/kv/disk.rs
+++ b/rust/kona/bin/host/src/kv/disk.rs
@@ -20,6 +20,13 @@ impl DiskKeyValueStore {
         let db = DB::open(&Self::get_db_options(), data_directory.as_path())
             .unwrap_or_else(|e| panic!("Failed to open database at {data_directory:?}: {e}"));
 
+        // Write the kvformat marker file.
+        let format_path = data_directory.join("kvformat");
+        if !format_path.exists() {
+            std::fs::write(&format_path, "rocksdb")
+                .unwrap_or_else(|e| panic!("Failed to write kvformat marker: {e}"));
+        }
+
         Self { data_directory, db }
     }
 

--- a/rust/kona/bin/host/src/kv/disk.rs
+++ b/rust/kona/bin/host/src/kv/disk.rs
@@ -1,7 +1,7 @@
 //! Contains a concrete implementation of the [`KeyValueStore`] trait that stores data on disk
 //! using [rocksdb].
 
-use super::{KeyValueStore, MemoryKeyValueStore};
+use super::{DataFormat, FORMAT_FILENAME, KeyValueStore, MemoryKeyValueStore};
 use crate::{HostError, Result};
 use alloy_primitives::B256;
 use rocksdb::{DB, Options};
@@ -20,10 +20,10 @@ impl DiskKeyValueStore {
         let db = DB::open(&Self::get_db_options(), data_directory.as_path())
             .unwrap_or_else(|e| panic!("Failed to open database at {data_directory:?}: {e}"));
 
-        // Write the kvformat marker file.
-        let format_path = data_directory.join("kvformat");
+        // Write the kvformat marker file for op-challenger compatibility.
+        let format_path = data_directory.join(FORMAT_FILENAME);
         if !format_path.exists() {
-            std::fs::write(&format_path, "rocksdb")
+            std::fs::write(&format_path, DataFormat::Rocksdb.as_str())
                 .unwrap_or_else(|e| panic!("Failed to write kvformat marker: {e}"));
         }
 

--- a/rust/kona/bin/host/src/kv/mod.rs
+++ b/rust/kona/bin/host/src/kv/mod.rs
@@ -42,9 +42,10 @@ impl DataFormat {
 }
 
 /// Reads the `kvformat` marker file from the given directory. If the marker exists and contains
-/// a supported format, returns that format. Otherwise, returns `default_format` and writes the
-/// marker so that future opens (including by op-challenger) detect the format automatically.
-pub fn detect_data_format(data_dir: &Path, default_format: DataFormat) -> DataFormat {
+/// a supported format, returns that format. Otherwise, returns `default_format`. The marker file
+/// is written by the individual store implementations (`DirectoryKeyValueStore`, `DiskKeyValueStore`)
+/// when they initialize.
+pub(crate) fn detect_data_format(data_dir: &Path, default_format: DataFormat) -> DataFormat {
     let format_path = data_dir.join(FORMAT_FILENAME);
     std::fs::read_to_string(&format_path).map_or(default_format, |contents| {
         match contents.as_str() {
@@ -65,9 +66,9 @@ pub type SharedKeyValueStore = Arc<RwLock<dyn KeyValueStore + Send + Sync>>;
 ///
 /// If `data_dir` is provided, the format is auto-detected from any existing `kvformat` marker file,
 /// falling back to `default_format`. Otherwise a [`MemoryKeyValueStore`] is used.
-pub fn create_key_value_store<L>(
+pub(crate) fn create_key_value_store<L>(
     local_kv_store: L,
-    data_dir: Option<&std::path::PathBuf>,
+    data_dir: Option<&Path>,
     default_format: DataFormat,
 ) -> SharedKeyValueStore
 where
@@ -78,11 +79,11 @@ where
             let format = detect_data_format(data_dir, default_format);
             match format {
                 DataFormat::Directory => {
-                    let dir_kv_store = DirectoryKeyValueStore::new(data_dir.clone());
+                    let dir_kv_store = DirectoryKeyValueStore::new(data_dir);
                     Arc::new(RwLock::new(SplitKeyValueStore::new(local_kv_store, dir_kv_store)))
                 }
                 DataFormat::Rocksdb => {
-                    let disk_kv_store = DiskKeyValueStore::new(data_dir.clone());
+                    let disk_kv_store = DiskKeyValueStore::new(data_dir.to_path_buf());
                     Arc::new(RwLock::new(SplitKeyValueStore::new(local_kv_store, disk_kv_store)))
                 }
             }

--- a/rust/kona/bin/host/src/kv/mod.rs
+++ b/rust/kona/bin/host/src/kv/mod.rs
@@ -18,7 +18,7 @@ mod split;
 pub use split::SplitKeyValueStore;
 
 /// The storage format for on-disk preimage data.
-#[derive(Debug, Clone, Copy, Default, clap::ValueEnum)]
+#[derive(Debug, Clone, Copy, Default, clap::ValueEnum, serde::Serialize)]
 pub enum DataFormat {
     /// Files stored in subdirectories with hex-encoded values.
     /// Compatible with op-program's `DataFormatDirectory`.

--- a/rust/kona/bin/host/src/kv/mod.rs
+++ b/rust/kona/bin/host/src/kv/mod.rs
@@ -62,6 +62,39 @@ pub fn detect_data_format(data_dir: &Path, default_format: DataFormat) -> DataFo
 /// A type alias for a shared key-value store.
 pub type SharedKeyValueStore = Arc<RwLock<dyn KeyValueStore + Send + Sync>>;
 
+/// Creates a [`SharedKeyValueStore`] backed by disk or memory.
+///
+/// If `data_dir` is provided, the format is auto-detected from any existing `kvformat` marker file,
+/// falling back to `default_format`. Otherwise a [`MemoryKeyValueStore`] is used.
+pub fn create_key_value_store<L>(
+    local_kv_store: L,
+    data_dir: Option<&std::path::PathBuf>,
+    default_format: DataFormat,
+) -> SharedKeyValueStore
+where
+    L: KeyValueStore + Send + Sync + 'static,
+{
+    match data_dir {
+        Some(data_dir) => {
+            let format = detect_data_format(data_dir, default_format);
+            match format {
+                DataFormat::Directory => {
+                    let dir_kv_store = DirectoryKeyValueStore::new(data_dir.clone());
+                    Arc::new(RwLock::new(SplitKeyValueStore::new(local_kv_store, dir_kv_store)))
+                }
+                DataFormat::Rocksdb => {
+                    let disk_kv_store = DiskKeyValueStore::new(data_dir.clone());
+                    Arc::new(RwLock::new(SplitKeyValueStore::new(local_kv_store, disk_kv_store)))
+                }
+            }
+        }
+        None => {
+            let mem_kv_store = MemoryKeyValueStore::new();
+            Arc::new(RwLock::new(SplitKeyValueStore::new(local_kv_store, mem_kv_store)))
+        }
+    }
+}
+
 /// Describes the interface of a simple, synchronous key-value store.
 pub trait KeyValueStore {
     /// Get the value associated with the given key.
@@ -74,47 +107,40 @@ pub trait KeyValueStore {
 #[cfg(test)]
 mod test {
     use super::*;
-    use std::{env::temp_dir, fs};
-
-    fn test_dir(name: &str) -> std::path::PathBuf {
-        let dir = temp_dir().join(format!("kona_detect_format_{name}"));
-        let _ = fs::remove_dir_all(&dir);
-        fs::create_dir_all(&dir).unwrap();
-        dir
-    }
+    use std::fs;
 
     #[test]
     fn detect_reads_existing_directory_marker() {
-        let dir = test_dir("read_dir");
-        fs::write(dir.join("kvformat"), "directory").unwrap();
+        let dir = tempfile::TempDir::new().unwrap();
+        fs::write(dir.path().join("kvformat"), "directory").unwrap();
 
-        let format = detect_data_format(&dir, DataFormat::Rocksdb);
+        let format = detect_data_format(dir.path(), DataFormat::Rocksdb);
         assert_eq!(format, DataFormat::Directory);
     }
 
     #[test]
     fn detect_reads_existing_rocksdb_marker() {
-        let dir = test_dir("read_rocksdb");
-        fs::write(dir.join("kvformat"), "rocksdb").unwrap();
+        let dir = tempfile::TempDir::new().unwrap();
+        fs::write(dir.path().join("kvformat"), "rocksdb").unwrap();
 
-        let format = detect_data_format(&dir, DataFormat::Directory);
+        let format = detect_data_format(dir.path(), DataFormat::Directory);
         assert_eq!(format, DataFormat::Rocksdb);
     }
 
     #[test]
     fn detect_falls_back_to_default_when_no_marker() {
-        let dir = test_dir("no_marker");
+        let dir = tempfile::TempDir::new().unwrap();
 
-        assert_eq!(detect_data_format(&dir, DataFormat::Directory), DataFormat::Directory);
-        assert_eq!(detect_data_format(&dir, DataFormat::Rocksdb), DataFormat::Rocksdb);
+        assert_eq!(detect_data_format(dir.path(), DataFormat::Directory), DataFormat::Directory);
+        assert_eq!(detect_data_format(dir.path(), DataFormat::Rocksdb), DataFormat::Rocksdb);
     }
 
     #[test]
     fn detect_falls_back_to_default_for_unknown_format() {
-        let dir = test_dir("unknown");
-        fs::write(dir.join("kvformat"), "pebble").unwrap();
+        let dir = tempfile::TempDir::new().unwrap();
+        fs::write(dir.path().join("kvformat"), "pebble").unwrap();
 
-        let format = detect_data_format(&dir, DataFormat::Directory);
+        let format = detect_data_format(dir.path(), DataFormat::Directory);
         assert_eq!(format, DataFormat::Directory);
     }
 }

--- a/rust/kona/bin/host/src/kv/mod.rs
+++ b/rust/kona/bin/host/src/kv/mod.rs
@@ -2,7 +2,7 @@
 
 use crate::Result;
 use alloy_primitives::B256;
-use std::sync::Arc;
+use std::{path::Path, sync::Arc};
 use tokio::sync::RwLock;
 
 mod mem;
@@ -17,15 +17,46 @@ pub use directory::DirectoryKeyValueStore;
 mod split;
 pub use split::SplitKeyValueStore;
 
+/// The filename used to record the storage format, for compatibility with op-challenger.
+const FORMAT_FILENAME: &str = "kvformat";
+
 /// The storage format for on-disk preimage data.
-#[derive(Debug, Clone, Copy, Default, clap::ValueEnum, serde::Serialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, clap::ValueEnum, serde::Serialize)]
 pub enum DataFormat {
     /// Files stored in subdirectories with hex-encoded values.
-    /// Compatible with op-program's `DataFormatDirectory`.
+    /// Compatible with op-challenger's `DataFormatDirectory`.
     #[default]
     Directory,
     /// RocksDB-backed storage.
     Rocksdb,
+}
+
+impl DataFormat {
+    /// Returns the string identifier written to the `kvformat` marker file.
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Directory => "directory",
+            Self::Rocksdb => "rocksdb",
+        }
+    }
+}
+
+/// Reads the `kvformat` marker file from the given directory. If the marker exists and contains
+/// a supported format, returns that format. Otherwise, returns `default_format` and writes the
+/// marker so that future opens (including by op-challenger) detect the format automatically.
+pub fn detect_data_format(data_dir: &Path, default_format: DataFormat) -> DataFormat {
+    let format_path = data_dir.join(FORMAT_FILENAME);
+    match std::fs::read_to_string(&format_path) {
+        Ok(contents) => match contents.as_str() {
+            "directory" => DataFormat::Directory,
+            "rocksdb" => DataFormat::Rocksdb,
+            other => {
+                tracing::warn!(format = other, "Unknown kvformat marker, using CLI default");
+                default_format
+            }
+        },
+        Err(_) => default_format,
+    }
 }
 
 /// A type alias for a shared key-value store.
@@ -38,4 +69,52 @@ pub trait KeyValueStore {
 
     /// Set the value associated with the given key.
     fn set(&mut self, key: B256, value: Vec<u8>) -> Result<()>;
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::{env::temp_dir, fs};
+
+    fn test_dir(name: &str) -> std::path::PathBuf {
+        let dir = temp_dir().join(format!("kona_detect_format_{name}"));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn detect_reads_existing_directory_marker() {
+        let dir = test_dir("read_dir");
+        fs::write(dir.join("kvformat"), "directory").unwrap();
+
+        let format = detect_data_format(&dir, DataFormat::Rocksdb);
+        assert_eq!(format, DataFormat::Directory);
+    }
+
+    #[test]
+    fn detect_reads_existing_rocksdb_marker() {
+        let dir = test_dir("read_rocksdb");
+        fs::write(dir.join("kvformat"), "rocksdb").unwrap();
+
+        let format = detect_data_format(&dir, DataFormat::Directory);
+        assert_eq!(format, DataFormat::Rocksdb);
+    }
+
+    #[test]
+    fn detect_falls_back_to_default_when_no_marker() {
+        let dir = test_dir("no_marker");
+
+        assert_eq!(detect_data_format(&dir, DataFormat::Directory), DataFormat::Directory);
+        assert_eq!(detect_data_format(&dir, DataFormat::Rocksdb), DataFormat::Rocksdb);
+    }
+
+    #[test]
+    fn detect_falls_back_to_default_for_unknown_format() {
+        let dir = test_dir("unknown");
+        fs::write(dir.join("kvformat"), "pebble").unwrap();
+
+        let format = detect_data_format(&dir, DataFormat::Directory);
+        assert_eq!(format, DataFormat::Directory);
+    }
 }

--- a/rust/kona/bin/host/src/kv/mod.rs
+++ b/rust/kona/bin/host/src/kv/mod.rs
@@ -43,8 +43,8 @@ impl DataFormat {
 
 /// Reads the `kvformat` marker file from the given directory. If the marker exists and contains
 /// a supported format, returns that format. Otherwise, returns `default_format`. The marker file
-/// is written by the individual store implementations (`DirectoryKeyValueStore`, `DiskKeyValueStore`)
-/// when they initialize.
+/// is written by the individual store implementations (`DirectoryKeyValueStore`,
+/// `DiskKeyValueStore`) when they initialize.
 pub(crate) fn detect_data_format(data_dir: &Path, default_format: DataFormat) -> DataFormat {
     let format_path = data_dir.join(FORMAT_FILENAME);
     std::fs::read_to_string(&format_path).map_or(default_format, |contents| {

--- a/rust/kona/bin/host/src/kv/mod.rs
+++ b/rust/kona/bin/host/src/kv/mod.rs
@@ -46,17 +46,16 @@ impl DataFormat {
 /// marker so that future opens (including by op-challenger) detect the format automatically.
 pub fn detect_data_format(data_dir: &Path, default_format: DataFormat) -> DataFormat {
     let format_path = data_dir.join(FORMAT_FILENAME);
-    match std::fs::read_to_string(&format_path) {
-        Ok(contents) => match contents.as_str() {
+    std::fs::read_to_string(&format_path).map_or(default_format, |contents| {
+        match contents.as_str() {
             "directory" => DataFormat::Directory,
             "rocksdb" => DataFormat::Rocksdb,
             other => {
                 tracing::warn!(format = other, "Unknown kvformat marker, using CLI default");
                 default_format
             }
-        },
-        Err(_) => default_format,
-    }
+        }
+    })
 }
 
 /// A type alias for a shared key-value store.

--- a/rust/kona/bin/host/src/kv/mod.rs
+++ b/rust/kona/bin/host/src/kv/mod.rs
@@ -11,8 +11,22 @@ pub use mem::MemoryKeyValueStore;
 mod disk;
 pub use disk::DiskKeyValueStore;
 
+mod directory;
+pub use directory::DirectoryKeyValueStore;
+
 mod split;
 pub use split::SplitKeyValueStore;
+
+/// The storage format for on-disk preimage data.
+#[derive(Debug, Clone, Copy, Default, clap::ValueEnum)]
+pub enum DataFormat {
+    /// Files stored in subdirectories with hex-encoded values.
+    /// Compatible with op-program's `DataFormatDirectory`.
+    #[default]
+    Directory,
+    /// RocksDB-backed storage.
+    Rocksdb,
+}
 
 /// A type alias for a shared key-value store.
 pub type SharedKeyValueStore = Arc<RwLock<dyn KeyValueStore + Send + Sync>>;

--- a/rust/kona/bin/host/src/lib.rs
+++ b/rust/kona/bin/host/src/lib.rs
@@ -7,7 +7,7 @@ pub use error::{HostError, Result};
 mod server;
 pub use server::{PreimageServer, PreimageServerError};
 
-mod kv;
+pub mod kv;
 pub use kv::{
     DirectoryKeyValueStore, DiskKeyValueStore, KeyValueStore, MemoryKeyValueStore,
     SharedKeyValueStore, SplitKeyValueStore,

--- a/rust/kona/bin/host/src/lib.rs
+++ b/rust/kona/bin/host/src/lib.rs
@@ -7,9 +7,9 @@ pub use error::{HostError, Result};
 mod server;
 pub use server::{PreimageServer, PreimageServerError};
 
-pub mod kv;
+pub(crate) mod kv;
 pub use kv::{
-    DirectoryKeyValueStore, DiskKeyValueStore, KeyValueStore, MemoryKeyValueStore,
+    DataFormat, DirectoryKeyValueStore, DiskKeyValueStore, KeyValueStore, MemoryKeyValueStore,
     SharedKeyValueStore, SplitKeyValueStore,
 };
 

--- a/rust/kona/bin/host/src/lib.rs
+++ b/rust/kona/bin/host/src/lib.rs
@@ -9,7 +9,8 @@ pub use server::{PreimageServer, PreimageServerError};
 
 mod kv;
 pub use kv::{
-    DiskKeyValueStore, KeyValueStore, MemoryKeyValueStore, SharedKeyValueStore, SplitKeyValueStore,
+    DirectoryKeyValueStore, DiskKeyValueStore, KeyValueStore, MemoryKeyValueStore,
+    SharedKeyValueStore, SplitKeyValueStore,
 };
 
 mod backend;

--- a/rust/kona/bin/host/src/single/cfg.rs
+++ b/rust/kona/bin/host/src/single/cfg.rs
@@ -2,11 +2,10 @@
 
 use super::{SingleChainHintHandler, SingleChainLocalInputs};
 use crate::{
-    DirectoryKeyValueStore, DiskKeyValueStore, MemoryKeyValueStore, OfflineHostBackend,
-    OnlineHostBackend, OnlineHostBackendCfg, PreimageServer, SharedKeyValueStore,
-    SplitKeyValueStore,
+    OfflineHostBackend, OnlineHostBackend, OnlineHostBackendCfg, PreimageServer,
+    SharedKeyValueStore,
     eth::rpc_provider,
-    kv::{DataFormat, detect_data_format},
+    kv::{DataFormat, create_key_value_store},
     server::PreimageServerError,
 };
 use alloy_primitives::B256;
@@ -23,10 +22,7 @@ use kona_std_fpvm::{FileChannel, FileDescriptor};
 use op_alloy_network::Optimism;
 use serde::Serialize;
 use std::{path::PathBuf, sync::Arc};
-use tokio::{
-    sync::RwLock,
-    task::{self, JoinHandle},
-};
+use tokio::task::{self, JoinHandle};
 
 /// The host binary CLI application arguments.
 #[derive(Default, Parser, Serialize, Clone, Debug)]
@@ -265,26 +261,7 @@ impl SingleChainHost {
     /// ensure compatibility with existing data. Otherwise, `--data-format` is used as the default.
     pub fn create_key_value_store(&self) -> Result<SharedKeyValueStore, SingleChainHostError> {
         let local_kv_store = SingleChainLocalInputs::new(self.clone());
-
-        let kv_store: SharedKeyValueStore = if let Some(ref data_dir) = self.data_dir {
-            let format = detect_data_format(data_dir, self.data_format);
-            match format {
-                DataFormat::Directory => {
-                    let dir_kv_store = DirectoryKeyValueStore::new(data_dir.clone());
-                    Arc::new(RwLock::new(SplitKeyValueStore::new(local_kv_store, dir_kv_store)))
-                }
-                DataFormat::Rocksdb => {
-                    let disk_kv_store = DiskKeyValueStore::new(data_dir.clone());
-                    Arc::new(RwLock::new(SplitKeyValueStore::new(local_kv_store, disk_kv_store)))
-                }
-            }
-        } else {
-            let mem_kv_store = MemoryKeyValueStore::new();
-            let split_kv_store = SplitKeyValueStore::new(local_kv_store, mem_kv_store);
-            Arc::new(RwLock::new(split_kv_store))
-        };
-
-        Ok(kv_store)
+        Ok(create_key_value_store(local_kv_store, self.data_dir.as_ref(), self.data_format))
     }
 
     /// Creates the providers required for the host backend.

--- a/rust/kona/bin/host/src/single/cfg.rs
+++ b/rust/kona/bin/host/src/single/cfg.rs
@@ -2,9 +2,9 @@
 
 use super::{SingleChainHintHandler, SingleChainLocalInputs};
 use crate::{
-    DiskKeyValueStore, MemoryKeyValueStore, OfflineHostBackend, OnlineHostBackend,
-    OnlineHostBackendCfg, PreimageServer, SharedKeyValueStore, SplitKeyValueStore,
-    eth::rpc_provider, server::PreimageServerError,
+    DiskKeyValueStore, DirectoryKeyValueStore, MemoryKeyValueStore, OfflineHostBackend,
+    OnlineHostBackend, OnlineHostBackendCfg, PreimageServer, SharedKeyValueStore,
+    SplitKeyValueStore, eth::rpc_provider, kv::DataFormat, server::PreimageServerError,
 };
 use alloy_primitives::B256;
 use alloy_provider::RootProvider;
@@ -80,6 +80,9 @@ pub struct SingleChainHost {
         env
     )]
     pub data_dir: Option<PathBuf>,
+    /// The format to use for preimage data storage on disk.
+    #[arg(long, default_value = "directory", env)]
+    pub data_format: DataFormat,
     /// Run the client program natively.
     #[arg(long, conflicts_with = "server", required_unless_present = "server")]
     pub native: bool,
@@ -257,9 +260,16 @@ impl SingleChainHost {
         let local_kv_store = SingleChainLocalInputs::new(self.clone());
 
         let kv_store: SharedKeyValueStore = if let Some(ref data_dir) = self.data_dir {
-            let disk_kv_store = DiskKeyValueStore::new(data_dir.clone());
-            let split_kv_store = SplitKeyValueStore::new(local_kv_store, disk_kv_store);
-            Arc::new(RwLock::new(split_kv_store))
+            match self.data_format {
+                DataFormat::Directory => {
+                    let dir_kv_store = DirectoryKeyValueStore::new(data_dir.clone());
+                    Arc::new(RwLock::new(SplitKeyValueStore::new(local_kv_store, dir_kv_store)))
+                }
+                DataFormat::Rocksdb => {
+                    let disk_kv_store = DiskKeyValueStore::new(data_dir.clone());
+                    Arc::new(RwLock::new(SplitKeyValueStore::new(local_kv_store, disk_kv_store)))
+                }
+            }
         } else {
             let mem_kv_store = MemoryKeyValueStore::new();
             let split_kv_store = SplitKeyValueStore::new(local_kv_store, mem_kv_store);

--- a/rust/kona/bin/host/src/single/cfg.rs
+++ b/rust/kona/bin/host/src/single/cfg.rs
@@ -226,10 +226,10 @@ impl SingleChainHost {
 
     /// Returns `true` if the host is running in offline mode.
     pub const fn is_offline(&self) -> bool {
-        self.l1_node_address.is_none()
-            && self.l2_node_address.is_none()
-            && self.l1_beacon_address.is_none()
-            && self.data_dir.is_some()
+        self.l1_node_address.is_none() &&
+            self.l2_node_address.is_none() &&
+            self.l1_beacon_address.is_none() &&
+            self.data_dir.is_some()
     }
 
     /// Reads the [`RollupConfig`] from the file system and returns the deserialized configuration.

--- a/rust/kona/bin/host/src/single/cfg.rs
+++ b/rust/kona/bin/host/src/single/cfg.rs
@@ -261,7 +261,7 @@ impl SingleChainHost {
     /// ensure compatibility with existing data. Otherwise, `--data-format` is used as the default.
     pub fn create_key_value_store(&self) -> Result<SharedKeyValueStore, SingleChainHostError> {
         let local_kv_store = SingleChainLocalInputs::new(self.clone());
-        Ok(create_key_value_store(local_kv_store, self.data_dir.as_ref(), self.data_format))
+        Ok(create_key_value_store(local_kv_store, self.data_dir.as_deref(), self.data_format))
     }
 
     /// Creates the providers required for the host backend.

--- a/rust/kona/bin/host/src/single/cfg.rs
+++ b/rust/kona/bin/host/src/single/cfg.rs
@@ -4,7 +4,10 @@ use super::{SingleChainHintHandler, SingleChainLocalInputs};
 use crate::{
     DirectoryKeyValueStore, DiskKeyValueStore, MemoryKeyValueStore, OfflineHostBackend,
     OnlineHostBackend, OnlineHostBackendCfg, PreimageServer, SharedKeyValueStore,
-    SplitKeyValueStore, eth::rpc_provider, kv::DataFormat, server::PreimageServerError,
+    SplitKeyValueStore,
+    eth::rpc_provider,
+    kv::{DataFormat, detect_data_format},
+    server::PreimageServerError,
 };
 use alloy_primitives::B256;
 use alloy_provider::RootProvider;
@@ -80,7 +83,8 @@ pub struct SingleChainHost {
         env
     )]
     pub data_dir: Option<PathBuf>,
-    /// The format to use for preimage data storage on disk.
+    /// The default format for preimage data storage on disk. If the data directory already
+    /// contains a `kvformat` marker file, that format is used instead of this value.
     #[arg(long, default_value = "directory", env)]
     pub data_format: DataFormat,
     /// Run the client program natively.
@@ -226,10 +230,10 @@ impl SingleChainHost {
 
     /// Returns `true` if the host is running in offline mode.
     pub const fn is_offline(&self) -> bool {
-        self.l1_node_address.is_none() &&
-            self.l2_node_address.is_none() &&
-            self.l1_beacon_address.is_none() &&
-            self.data_dir.is_some()
+        self.l1_node_address.is_none()
+            && self.l2_node_address.is_none()
+            && self.l1_beacon_address.is_none()
+            && self.data_dir.is_some()
     }
 
     /// Reads the [`RollupConfig`] from the file system and returns the deserialized configuration.
@@ -256,11 +260,15 @@ impl SingleChainHost {
     }
 
     /// Creates the key-value store for the host backend.
+    ///
+    /// If the data directory contains a `kvformat` marker file, the recorded format is used to
+    /// ensure compatibility with existing data. Otherwise, `--data-format` is used as the default.
     pub fn create_key_value_store(&self) -> Result<SharedKeyValueStore, SingleChainHostError> {
         let local_kv_store = SingleChainLocalInputs::new(self.clone());
 
         let kv_store: SharedKeyValueStore = if let Some(ref data_dir) = self.data_dir {
-            match self.data_format {
+            let format = detect_data_format(data_dir, self.data_format);
+            match format {
                 DataFormat::Directory => {
                     let dir_kv_store = DirectoryKeyValueStore::new(data_dir.clone());
                     Arc::new(RwLock::new(SplitKeyValueStore::new(local_kv_store, dir_kv_store)))

--- a/rust/kona/bin/host/src/single/cfg.rs
+++ b/rust/kona/bin/host/src/single/cfg.rs
@@ -2,7 +2,7 @@
 
 use super::{SingleChainHintHandler, SingleChainLocalInputs};
 use crate::{
-    DiskKeyValueStore, DirectoryKeyValueStore, MemoryKeyValueStore, OfflineHostBackend,
+    DirectoryKeyValueStore, DiskKeyValueStore, MemoryKeyValueStore, OfflineHostBackend,
     OnlineHostBackend, OnlineHostBackendCfg, PreimageServer, SharedKeyValueStore,
     SplitKeyValueStore, eth::rpc_provider, kv::DataFormat, server::PreimageServerError,
 };


### PR DESCRIPTION
## Summary

- Add `DirectoryKeyValueStore` to kona-host that writes preimages in op-program's `DataFormatDirectory` layout
- Path layout: `<dir>/<first4hex>/<rest>.txt` with hex-encoded values, matching Go's `directoryKV`
- Writes `kvformat` marker file (`"directory"`) so op-challenger's existing autodetection works
- Add `--data-format` CLI option (default: `directory`, also supports `rocksdb`)
- RocksDB `DiskKeyValueStore` preserved as an option

## Motivation

kona-host uses RocksDB for preimage storage, but op-challenger reads preimages using op-program's flat-file format. Pebble (Go) cannot read RocksDB data (`pebble: corrupt manifest`). This format mismatch causes test failures when switching e2e tests from op-program to kona-host.

By defaulting to the same directory format as op-program, kona-host becomes a drop-in replacement for preimage storage.

## Test plan

- [x] `cargo check --package kona-host` compiles (no Rust errors)
- [x] Proptest roundtrip test for DirectoryKeyValueStore
- [x] kvformat marker file test
- [x] Key path layout test
- [ ] CI: kona-host Rust tests pass
- [ ] Integration: op-challenger can read preimages from kona-host directory format

🤖 Generated with [Claude Code](https://claude.com/claude-code)