### PR TITLE
fix(op-acceptance): eliminate race condition in super fault proof L1 head capture

### DIFF
--- a/op-acceptance-tests/tests/interop/proofs/serial/interop_fault_proofs_test.go
+++ b/op-acceptance-tests/tests/interop/proofs/serial/interop_fault_proofs_test.go
@@ -26,8 +26,6 @@ func TestInteropFaultProofs_ConsolidateValidCrossChainMessage(gt *testing.T) {
 
 func TestInteropFaultProofs_VariedBlockTimes(gt *testing.T) {
 	t := devtest.SerialT(gt)
-	// TODO(#19010): Unskip once varied block time fault proofs are stable.
-	t.Skip("Skipping flaky varied block time fault proof test")
 	sys := presets.NewSimpleInteropSupernodeProofs(
 		t,
 		presets.WithChallengerCannonKonaEnabled(),
@@ -41,8 +39,6 @@ func TestInteropFaultProofs_VariedBlockTimes(gt *testing.T) {
 
 func TestInteropFaultProofs_VariedBlockTimes_FasterChainB(gt *testing.T) {
 	t := devtest.SerialT(gt)
-	// TODO(#19010): Unskip once varied block time fault proofs are stable.
-	t.Skip("Skipping flaky varied block time fault proof test")
 	sys := presets.NewSimpleInteropSupernodeProofs(
 		t,
 		presets.WithChallengerCannonKonaEnabled(),

--- a/op-acceptance-tests/tests/isthmus/preinterop/interop_fault_proofs_test.go
+++ b/op-acceptance-tests/tests/isthmus/preinterop/interop_fault_proofs_test.go
@@ -30,8 +30,6 @@ func TestPreinteropFaultProofs_UnsafeProposal(gt *testing.T) {
 
 func TestPreinteropFaultProofs_VariedBlockTimes(gt *testing.T) {
 	t := devtest.SerialT(gt)
-	// TODO(#19010): Unskip once varied block time fault proofs are stable.
-	t.Skip("Skipping flaky varied block time fault proof test")
 	sys := presets.NewSimpleInteropIsthmusSuper(
 		t,
 		presets.WithChallengerCannonKonaEnabled(),
@@ -45,8 +43,6 @@ func TestPreinteropFaultProofs_VariedBlockTimes(gt *testing.T) {
 
 func TestPreinteropFaultProofs_VariedBlockTimes_FasterChainB(gt *testing.T) {
 	t := devtest.SerialT(gt)
-	// TODO(#19010): Unskip once varied block time fault proofs are stable.
-	t.Skip("Skipping flaky varied block time fault proof test")
 	sys := presets.NewSimpleInteropIsthmusSuper(
 		t,
 		presets.WithChallengerCannonKonaEnabled(),

--- a/op-acceptance-tests/tests/superfaultproofs/singlechain.go
+++ b/op-acceptance-tests/tests/superfaultproofs/singlechain.go
@@ -54,6 +54,9 @@ func RunSingleChainSuperFaultProofSmokeTest(t devtest.T, sys *presets.SingleChai
 	c.EL.Reached(eth.Safe, target, 60)
 	l1HeadCurrent := sys.L1EL.BlockRefByLabel(eth.Unsafe).ID()
 
+	// Stop batcher so the t.Cleanup(Start) call doesn't fail with "already running".
+	c.Batcher.Stop()
+
 	// Build expected transition states for a single chain.
 	start := superRootAtTimestamp(t, chains, startTimestamp)
 	end := superRootAtTimestamp(t, chains, endTimestamp)

--- a/op-acceptance-tests/tests/superfaultproofs/singlechain.go
+++ b/op-acceptance-tests/tests/superfaultproofs/singlechain.go
@@ -34,7 +34,6 @@ func RunSingleChainSuperFaultProofSmokeTest(t devtest.T, sys *presets.SingleChai
 
 	// Stop batch submission so safe head stalls, then we have a known boundary.
 	c.Batcher.Stop()
-	t.Cleanup(c.Batcher.Start)
 	sys.L2CLA.WaitForStall(types.CrossSafe)
 
 	endTimestamp := nextTimestampAfterSafeHeads(t, chains)
@@ -53,9 +52,6 @@ func RunSingleChainSuperFaultProofSmokeTest(t devtest.T, sys *presets.SingleChai
 	sys.SuperRoots.AwaitValidatedTimestamp(endTimestamp)
 	c.EL.Reached(eth.Safe, target, 60)
 	l1HeadCurrent := sys.L1EL.BlockRefByLabel(eth.Unsafe).ID()
-
-	// Stop batcher so the t.Cleanup(Start) call doesn't fail with "already running".
-	c.Batcher.Stop()
 
 	// Build expected transition states for a single chain.
 	start := superRootAtTimestamp(t, chains, startTimestamp)

--- a/op-acceptance-tests/tests/superfaultproofs/singlechain.go
+++ b/op-acceptance-tests/tests/superfaultproofs/singlechain.go
@@ -45,14 +45,14 @@ func RunSingleChainSuperFaultProofSmokeTest(t devtest.T, sys *presets.SingleChai
 	t.Require().NoError(err)
 	c.EL.Reached(eth.Unsafe, target, 60)
 
-	// L1 head where chain has no batch data at endTimestamp.
-	l1HeadBefore := l1BlockWithLocalSafeBlocks(t, sys.L1EL, sys.SuperRoots, endTimestamp, nil, []eth.ChainID{c.ID})
+	// Batcher is stopped, so no batch data for endTimestamp is on L1.
+	l1HeadBefore := sys.L1EL.BlockRefByLabel(eth.Unsafe).ID()
 
-	// Resume batching so the chain's data at endTimestamp becomes available.
+	// Resume batching and wait for the safe head to reach the target.
 	c.Batcher.Start()
 	sys.SuperRoots.AwaitValidatedTimestamp(endTimestamp)
-	l1HeadCurrent := latestRequiredL1(sys.SuperRoots.SuperRootAtTimestamp(endTimestamp))
-	c.Batcher.Stop()
+	c.EL.Reached(eth.Safe, target, 60)
+	l1HeadCurrent := sys.L1EL.BlockRefByLabel(eth.Unsafe).ID()
 
 	// Build expected transition states for a single chain.
 	start := superRootAtTimestamp(t, chains, startTimestamp)

--- a/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
+++ b/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
@@ -2,7 +2,6 @@ package superfaultproofs
 
 import (
 	"context"
-	"math"
 	"math/big"
 	"math/rand"
 	"os"
@@ -123,39 +122,6 @@ func latestRequiredL1(resp eth.SuperRootAtTimestampResponse) eth.BlockID {
 		}
 	}
 	return latest
-}
-
-// l1BlockWithLocalSafeBlocks finds an L1 block where the specified chains either do or do not have safe blocks.
-func l1BlockWithLocalSafeBlocks(t devtest.T, l1El *dsl.L1ELNode, sn *dsl.Supernode, timestamp uint64, hasSafe, notSafe []eth.ChainID) eth.BlockID {
-	t.Logf("Finding L1 block where %v have safe blocks and %v do not", hasSafe, notSafe)
-	var l1Block eth.BlockID
-	t.Require().Eventually(func() bool {
-		resp := sn.SuperRootAtTimestamp(timestamp)
-
-		candidate := uint64(math.MaxUint64)
-		for _, id := range notSafe {
-			if optimistic, has := resp.OptimisticAtTimestamp[id]; has && optimistic.RequiredL1.Number <= candidate {
-				candidate = optimistic.RequiredL1.Number - 1 // We need this chain to not have a safe block, so L1 head must be the block before it.
-			}
-		}
-		// If we didn't have any notSafe chains, we can use the current L1 block.
-		if candidate == math.MaxUint64 {
-			candidate = resp.CurrentL1.Number
-		}
-
-		// Now verify that all the required chains have a safe block at the candidate L1 block.
-		for _, id := range hasSafe {
-			if optimistic, has := resp.OptimisticAtTimestamp[id]; !has {
-				return false
-			} else if optimistic.RequiredL1.Number > candidate {
-				return false
-			}
-		}
-
-		l1Block = l1El.BlockRefByNumber(candidate).ID()
-		return true
-	}, 2*time.Minute, 2*time.Second, "timed out waiting for l1 block")
-	return l1Block
 }
 
 // runKonaInteropProgram runs the kona interop fault proof program and checks the result.
@@ -580,28 +546,32 @@ func RunSuperFaultProofTest(t devtest.T, sys *presets.SimpleInterop) {
 	endTimestamp := nextTimestampAfterSafeHeads(t, chains)
 	startTimestamp := endTimestamp - 1
 
-	// Ensure both chains have produced the target blocks as unsafe.
-	for _, c := range chains {
-		target, err := c.Cfg.TargetBlockNumber(endTimestamp)
-		t.Require().NoError(err)
-		c.EL.Reached(eth.Unsafe, target, 60)
-	}
+	// Wait for both chains to produce the target blocks as unsafe.
+	// Sequencers keep running freely — the L1 head invariants are maintained
+	// by which batchers are running, not by stopping sequencers.
+	target0, err := chains[0].Cfg.TargetBlockNumber(endTimestamp)
+	t.Require().NoError(err)
+	target1, err := chains[1].Cfg.TargetBlockNumber(endTimestamp)
+	t.Require().NoError(err)
+	chains[0].EL.Reached(eth.Unsafe, target0, 60)
+	chains[1].EL.Reached(eth.Unsafe, target1, 60)
 
-	// -- Stage 2: Capture L1 heads at different batch-availability points --
+	// -- Stage 2: Capture L1 heads via batcher choreography ----------------
+	// Batchers are stopped, so no batch data for endTimestamp is on L1.
+	l1HeadBefore := sys.L1EL.BlockRefByLabel(eth.Unsafe).ID()
 
-	// L1 head where neither chain has batch data at endTimestamp.
-	l1HeadBefore := l1BlockWithLocalSafeBlocks(t, sys.L1EL, sys.SuperRoots, endTimestamp, nil, []eth.ChainID{chains[0].ID, chains[1].ID})
-
-	// L1 head where only the first chain has batch data.
+	// Start chain[0]'s batcher and wait for its safe head to reach the target.
+	// Chain[1]'s batcher is still stopped, so only chain[0]'s data lands on L1.
 	chains[0].Batcher.Start()
-	l1HeadAfterFirst := l1BlockWithLocalSafeBlocks(t, sys.L1EL, sys.SuperRoots, endTimestamp, []eth.ChainID{chains[0].ID}, []eth.ChainID{chains[1].ID})
-	chains[0].Batcher.Stop()
+	chains[0].EL.Reached(eth.Safe, target0, 60)
+	l1HeadAfterFirst := sys.L1EL.BlockRefByLabel(eth.Unsafe).ID()
 
-	// L1 head where both chains have batch data (fully validated).
+	// Start chain[1]'s batcher and wait for the supernode to validate, then
+	// wait for chain[1]'s safe head to reach its target.
 	chains[1].Batcher.Start()
 	sys.SuperRoots.AwaitValidatedTimestamp(endTimestamp)
-	l1HeadCurrent := latestRequiredL1(sys.SuperRoots.SuperRootAtTimestamp(endTimestamp))
-	chains[1].Batcher.Stop()
+	chains[1].EL.Reached(eth.Safe, target1, 60)
+	l1HeadCurrent := sys.L1EL.BlockRefByLabel(eth.Unsafe).ID()
 
 	// --- Stage 3: Build expected transition states --------------------------
 	start := superRootAtTimestamp(t, chains, startTimestamp)

--- a/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
+++ b/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
@@ -72,7 +72,15 @@ func nextTimestampAfterSafeHeads(t devtest.T, chains []*chain) uint64 {
 	for _, c := range chains {
 		status, err := c.Rollup.SyncStatus(t.Ctx())
 		t.Require().NoError(err)
-		next := c.Cfg.TimestampForBlock(status.SafeL2.Number + 1)
+		// Use LocalSafeL2 when available, as it reflects the latest L1-derived
+		// head before interop cross-validation. SafeL2 (cross-safe) may lag far
+		// behind, causing endTimestamp to target blocks whose batch data is
+		// already on L1.
+		safeNum := status.SafeL2.Number
+		if status.LocalSafeL2.Number > safeNum {
+			safeNum = status.LocalSafeL2.Number
+		}
+		next := c.Cfg.TimestampForBlock(safeNum + 1)
 		if next > ts {
 			ts = next
 		}
@@ -535,10 +543,12 @@ func RunSuperFaultProofTest(t devtest.T, sys *presets.SimpleInterop) {
 	t.Require().Len(chains, 2, "expected exactly 2 interop chains")
 
 	// -- Stage 1: Freeze batch submission ----------------------------------
-	chains[1].Batcher.Stop()
-	chains[1].CLNode.WaitForStall(types.CrossSafe)
+	// Stop both batchers simultaneously, then wait for local-safe to stall on
+	// both chains. This ensures neither batcher submits data past the safe heads.
 	chains[0].Batcher.Stop()
+	chains[1].Batcher.Stop()
 	chains[0].CLNode.WaitForStall(types.LocalSafe)
+	chains[1].CLNode.WaitForStall(types.LocalSafe)
 
 	endTimestamp := nextTimestampAfterSafeHeads(t, chains)
 	startTimestamp := endTimestamp - 1
@@ -557,17 +567,19 @@ func RunSuperFaultProofTest(t devtest.T, sys *presets.SimpleInterop) {
 	// Batchers are stopped, so no batch data for endTimestamp is on L1.
 	l1HeadBefore := sys.L1EL.BlockRefByLabel(eth.Unsafe).ID()
 
-	// Start chain[0]'s batcher and wait for its safe head to reach the target.
+	// Start chain[0]'s batcher and wait for its local-safe head to reach the target.
 	// Chain[1]'s batcher is still stopped, so only chain[0]'s data lands on L1.
+	// We wait on the CL local-safe label because the EL safe label only advances
+	// after interop validation, which requires all chains to have batch data.
 	chains[0].Batcher.Start()
-	chains[0].EL.Reached(eth.Safe, target0, 60)
+	chains[0].CLNode.Reached(types.LocalSafe, target0, 60)
 	l1HeadAfterFirst := sys.L1EL.BlockRefByLabel(eth.Unsafe).ID()
 
 	// Start chain[1]'s batcher and wait for the supernode to validate, then
 	// wait for chain[1]'s safe head to reach its target.
 	chains[1].Batcher.Start()
 	sys.SuperRoots.AwaitValidatedTimestamp(endTimestamp)
-	chains[1].EL.Reached(eth.Safe, target1, 60)
+	chains[1].CLNode.Reached(types.LocalSafe, target1, 60)
 	l1HeadCurrent := sys.L1EL.BlockRefByLabel(eth.Unsafe).ID()
 
 	// --- Stage 3: Build expected transition states --------------------------
@@ -619,10 +631,12 @@ func RunVariedBlockTimesTest(t devtest.T, sys *presets.SimpleInterop) {
 		"this test requires chains with different block times")
 
 	// -- Stage 1: Setup — both batchers stopped -----------------------------
-	chains[1].Batcher.Stop()
-	chains[1].CLNode.WaitForStall(types.CrossSafe)
+	// Stop both batchers simultaneously, then wait for local-safe to stall on
+	// both chains. This ensures neither batcher submits data past the safe heads.
 	chains[0].Batcher.Stop()
+	chains[1].Batcher.Stop()
 	chains[0].CLNode.WaitForStall(types.LocalSafe)
+	chains[1].CLNode.WaitForStall(types.LocalSafe)
 
 	endTimestamp := nextTimestampAfterSafeHeads(t, chains)
 	startTimestamp := endTimestamp - 1
@@ -641,17 +655,19 @@ func RunVariedBlockTimesTest(t devtest.T, sys *presets.SimpleInterop) {
 	// Batchers are stopped, so no batch data for endTimestamp is on L1.
 	l1HeadBefore := sys.L1EL.BlockRefByLabel(eth.Unsafe).ID()
 
-	// Start chain[0]'s batcher and wait for its safe head to reach the target.
+	// Start chain[0]'s batcher and wait for its local-safe head to reach the target.
 	// Chain[1]'s batcher is still stopped, so only chain[0]'s data lands on L1.
+	// We wait on the CL local-safe label because the EL safe label only advances
+	// after interop validation, which requires all chains to have batch data.
 	chains[0].Batcher.Start()
-	chains[0].EL.Reached(eth.Safe, target0, 60)
+	chains[0].CLNode.Reached(types.LocalSafe, target0, 60)
 	l1HeadAfterFirst := sys.L1EL.BlockRefByLabel(eth.Unsafe).ID()
 
 	// Start chain[1]'s batcher and wait for the supernode to validate, then
 	// wait for chain[1]'s safe head to reach its target.
 	chains[1].Batcher.Start()
 	sys.SuperRoots.AwaitValidatedTimestamp(endTimestamp)
-	chains[1].EL.Reached(eth.Safe, target1, 60)
+	chains[1].CLNode.Reached(types.LocalSafe, target1, 60)
 	l1HeadCurrent := sys.L1EL.BlockRefByLabel(eth.Unsafe).ID()
 
 	// -- Stage 3: Build expected transition states --------------------------

--- a/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
+++ b/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
@@ -651,7 +651,7 @@ func RunVariedBlockTimesTest(t devtest.T, sys *presets.SimpleInterop) {
 	t.Require().NotEqual(chains[0].Cfg.BlockTime, chains[1].Cfg.BlockTime,
 		"this test requires chains with different block times")
 
-	// -- Stage 1: Freeze batch submission ----------------------------------
+	// -- Stage 1: Setup — both batchers stopped -----------------------------
 	chains[1].Batcher.Stop()
 	t.Cleanup(chains[1].Batcher.Start)
 	chains[1].CLNode.WaitForStall(types.CrossSafe)
@@ -662,25 +662,32 @@ func RunVariedBlockTimesTest(t devtest.T, sys *presets.SimpleInterop) {
 	endTimestamp := nextTimestampAfterSafeHeads(t, chains)
 	startTimestamp := endTimestamp - 1
 
-	// Ensure both chains have produced the target blocks as unsafe.
-	for _, c := range chains {
-		target, err := c.Cfg.TargetBlockNumber(endTimestamp)
-		t.Require().NoError(err)
-		c.EL.Reached(eth.Unsafe, target, 60)
-	}
+	// Wait for both chains to produce the target blocks as unsafe.
+	// Sequencers keep running freely — the L1 head invariants are maintained
+	// by which batchers are running, not by stopping sequencers.
+	target0, err := chains[0].Cfg.TargetBlockNumber(endTimestamp)
+	t.Require().NoError(err)
+	target1, err := chains[1].Cfg.TargetBlockNumber(endTimestamp)
+	t.Require().NoError(err)
+	chains[0].EL.Reached(eth.Unsafe, target0, 60)
+	chains[1].EL.Reached(eth.Unsafe, target1, 60)
 
-	// -- Stage 2: Capture L1 heads at different batch-availability points --
+	// -- Stage 2: Capture L1 heads via batcher choreography ----------------
+	// Batchers are stopped, so no batch data for endTimestamp is on L1.
+	l1HeadBefore := sys.L1EL.BlockRefByLabel(eth.Unsafe).ID()
 
-	l1HeadBefore := l1BlockWithLocalSafeBlocks(t, sys.L1EL, sys.SuperRoots, endTimestamp, nil, []eth.ChainID{chains[0].ID, chains[1].ID})
-
+	// Start chain[0]'s batcher and wait for its safe head to reach the target.
+	// Chain[1]'s batcher is still stopped, so only chain[0]'s data lands on L1.
 	chains[0].Batcher.Start()
-	l1HeadAfterFirst := l1BlockWithLocalSafeBlocks(t, sys.L1EL, sys.SuperRoots, endTimestamp, []eth.ChainID{chains[0].ID}, []eth.ChainID{chains[1].ID})
-	chains[0].Batcher.Stop()
+	chains[0].EL.Reached(eth.Safe, target0, 60)
+	l1HeadAfterFirst := sys.L1EL.BlockRefByLabel(eth.Unsafe).ID()
 
+	// Start chain[1]'s batcher and wait for the supernode to validate, then
+	// wait for chain[1]'s safe head to reach its target.
 	chains[1].Batcher.Start()
 	sys.SuperRoots.AwaitValidatedTimestamp(endTimestamp)
-	l1HeadCurrent := latestRequiredL1(sys.SuperRoots.SuperRootAtTimestamp(endTimestamp))
-	chains[1].Batcher.Stop()
+	chains[1].EL.Reached(eth.Safe, target1, 60)
+	l1HeadCurrent := sys.L1EL.BlockRefByLabel(eth.Unsafe).ID()
 
 	// -- Stage 3: Build expected transition states --------------------------
 	start := superRootAtTimestamp(t, chains, startTimestamp)

--- a/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
+++ b/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
@@ -535,13 +535,10 @@ func RunSuperFaultProofTest(t devtest.T, sys *presets.SimpleInterop) {
 	t.Require().Len(chains, 2, "expected exactly 2 interop chains")
 
 	// -- Stage 1: Freeze batch submission ----------------------------------
-	chains[1].Batcher.Stop() // Stop chain 1 first and wait for chains[0] to have at least that local safe head.
-	t.Cleanup(chains[1].Batcher.Start)
-	// Wait for safe heads to stall (local safe will continue on chains[0] but interop validation can't progress because chains[1] local safe has stalled)
+	chains[1].Batcher.Stop()
 	chains[1].CLNode.WaitForStall(types.CrossSafe)
 	chains[0].Batcher.Stop()
-	t.Cleanup(chains[0].Batcher.Start)
-	chains[0].CLNode.WaitForStall(types.LocalSafe) // Wait for chains[0] local safe head to stall
+	chains[0].CLNode.WaitForStall(types.LocalSafe)
 
 	endTimestamp := nextTimestampAfterSafeHeads(t, chains)
 	startTimestamp := endTimestamp - 1
@@ -572,10 +569,6 @@ func RunSuperFaultProofTest(t devtest.T, sys *presets.SimpleInterop) {
 	sys.SuperRoots.AwaitValidatedTimestamp(endTimestamp)
 	chains[1].EL.Reached(eth.Safe, target1, 60)
 	l1HeadCurrent := sys.L1EL.BlockRefByLabel(eth.Unsafe).ID()
-
-	// Stop batchers so the t.Cleanup(Start) calls don't fail with "already running".
-	chains[0].Batcher.Stop()
-	chains[1].Batcher.Stop()
 
 	// --- Stage 3: Build expected transition states --------------------------
 	start := superRootAtTimestamp(t, chains, startTimestamp)
@@ -627,10 +620,8 @@ func RunVariedBlockTimesTest(t devtest.T, sys *presets.SimpleInterop) {
 
 	// -- Stage 1: Setup — both batchers stopped -----------------------------
 	chains[1].Batcher.Stop()
-	t.Cleanup(chains[1].Batcher.Start)
 	chains[1].CLNode.WaitForStall(types.CrossSafe)
 	chains[0].Batcher.Stop()
-	t.Cleanup(chains[0].Batcher.Start)
 	chains[0].CLNode.WaitForStall(types.LocalSafe)
 
 	endTimestamp := nextTimestampAfterSafeHeads(t, chains)
@@ -662,10 +653,6 @@ func RunVariedBlockTimesTest(t devtest.T, sys *presets.SimpleInterop) {
 	sys.SuperRoots.AwaitValidatedTimestamp(endTimestamp)
 	chains[1].EL.Reached(eth.Safe, target1, 60)
 	l1HeadCurrent := sys.L1EL.BlockRefByLabel(eth.Unsafe).ID()
-
-	// Stop batchers so the t.Cleanup(Start) calls don't fail with "already running".
-	chains[0].Batcher.Stop()
-	chains[1].Batcher.Stop()
 
 	// -- Stage 3: Build expected transition states --------------------------
 	start := superRootAtTimestamp(t, chains, startTimestamp)

--- a/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
+++ b/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
@@ -573,6 +573,10 @@ func RunSuperFaultProofTest(t devtest.T, sys *presets.SimpleInterop) {
 	chains[1].EL.Reached(eth.Safe, target1, 60)
 	l1HeadCurrent := sys.L1EL.BlockRefByLabel(eth.Unsafe).ID()
 
+	// Stop batchers so the t.Cleanup(Start) calls don't fail with "already running".
+	chains[0].Batcher.Stop()
+	chains[1].Batcher.Stop()
+
 	// --- Stage 3: Build expected transition states --------------------------
 	start := superRootAtTimestamp(t, chains, startTimestamp)
 	end := superRootAtTimestamp(t, chains, endTimestamp)
@@ -658,6 +662,10 @@ func RunVariedBlockTimesTest(t devtest.T, sys *presets.SimpleInterop) {
 	sys.SuperRoots.AwaitValidatedTimestamp(endTimestamp)
 	chains[1].EL.Reached(eth.Safe, target1, 60)
 	l1HeadCurrent := sys.L1EL.BlockRefByLabel(eth.Unsafe).ID()
+
+	// Stop batchers so the t.Cleanup(Start) calls don't fail with "already running".
+	chains[0].Batcher.Stop()
+	chains[1].Batcher.Stop()
 
 	// -- Stage 3: Build expected transition states --------------------------
 	start := superRootAtTimestamp(t, chains, startTimestamp)

--- a/op-devstack/presets/option_validation.go
+++ b/op-devstack/presets/option_validation.go
@@ -148,7 +148,6 @@ const simpleInteropSuperProofsPresetSupportedOptionKinds = optionKindDeployer |
 	optionKindRequireInteropNotAtGen
 
 const supernodeProofsPresetSupportedOptionKinds = optionKindDeployer |
-	optionKindBatcher |
 	optionKindChallengerCannonKona |
 	optionKindL1EL
 

--- a/op-devstack/presets/option_validation.go
+++ b/op-devstack/presets/option_validation.go
@@ -147,7 +147,8 @@ const simpleInteropSuperProofsPresetSupportedOptionKinds = optionKindDeployer |
 	optionKindMaxSequencingWindow |
 	optionKindRequireInteropNotAtGen
 
-const supernodeProofsPresetSupportedOptionKinds = optionKindChallengerCannonKona |
+const supernodeProofsPresetSupportedOptionKinds = optionKindDeployer |
+	optionKindChallengerCannonKona |
 	optionKindL1EL
 
 const twoL2SupernodePresetSupportedOptionKinds = optionKindDeployer |

--- a/op-devstack/presets/option_validation.go
+++ b/op-devstack/presets/option_validation.go
@@ -148,6 +148,7 @@ const simpleInteropSuperProofsPresetSupportedOptionKinds = optionKindDeployer |
 	optionKindRequireInteropNotAtGen
 
 const supernodeProofsPresetSupportedOptionKinds = optionKindDeployer |
+	optionKindBatcher |
 	optionKindChallengerCannonKona |
 	optionKindL1EL
 

--- a/op-devstack/presets/options.go
+++ b/op-devstack/presets/options.go
@@ -1,6 +1,7 @@
 package presets
 
 import (
+	bss "github.com/ethereum-optimism/optimism/op-batcher/batcher"
 	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -236,6 +237,12 @@ func WithCannonKonaGameTypeAdded() Option {
 			cfg.AddedGameTypes = append(cfg.AddedGameTypes, gameTypes.CannonKonaGameType)
 		},
 	}
+}
+
+func WithBatcherStopped() Option {
+	return WithBatcherOption(func(_ sysgo.ComponentTarget, cfg *bss.CLIConfig) {
+		cfg.Stopped = true
+	})
 }
 
 func WithChallengerCannonKonaEnabled() Option {

--- a/op-devstack/presets/options.go
+++ b/op-devstack/presets/options.go
@@ -1,7 +1,6 @@
 package presets
 
 import (
-	bss "github.com/ethereum-optimism/optimism/op-batcher/batcher"
 	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -237,12 +236,6 @@ func WithCannonKonaGameTypeAdded() Option {
 			cfg.AddedGameTypes = append(cfg.AddedGameTypes, gameTypes.CannonKonaGameType)
 		},
 	}
-}
-
-func WithBatcherStopped() Option {
-	return WithBatcherOption(func(_ sysgo.ComponentTarget, cfg *bss.CLIConfig) {
-		cfg.Stopped = true
-	})
 }
 
 func WithChallengerCannonKonaEnabled() Option {

--- a/op-devstack/sysgo/multichain_supernode_runtime.go
+++ b/op-devstack/sysgo/multichain_supernode_runtime.go
@@ -204,9 +204,9 @@ func newTwoL2SupernodeRuntimeWithConfig(t devtest.T, enableInterop bool, delaySe
 		jwtSecret,
 	)
 
-	l2ABatcher := startMinimalBatcher(t, keys, l2ANet, l1EL, l2ACL, l2AEL)
+	l2ABatcher := startMinimalBatcher(t, keys, l2ANet, l1EL, l2ACL, l2AEL, cfg.BatcherOptions...)
 	l2AProposer := startMinimalProposer(t, keys, l2ANet, l1EL, l2ACL)
-	l2BBatcher := startMinimalBatcher(t, keys, l2BNet, l1EL, l2BCL, l2BEL)
+	l2BBatcher := startMinimalBatcher(t, keys, l2BNet, l1EL, l2BCL, l2BEL, cfg.BatcherOptions...)
 	l2BProposer := startMinimalProposer(t, keys, l2BNet, l1EL, l2BCL)
 
 	faucetService := startFaucetsForRPCs(t, keys, map[eth.ChainID]string{


### PR DESCRIPTION
## Summary

- Replace `l1BlockWithLocalSafeBlocks` (supernode `RequiredL1` polling) with direct L1 head reads at each stage of batcher choreography — the invariants (which chain's data is on L1) are now maintained by which batchers are running, not by timing
- Apply the same race-free pattern to `RunSuperFaultProofTest`, `RunVariedBlockTimesTest`, and `RunSingleChainSuperFaultProofSmokeTest`
- Remove the now-unused `l1BlockWithLocalSafeBlocks` helper and `math` import
- Unskip all four `VariedBlockTimes` test variants (preinterop + interop, both block time orderings)
- Fix interop-specific failures by using CL `LocalSafe` instead of EL `Safe` for batcher wait conditions and timestamp computation

## Root Cause

The original Stage 2 used `l1BlockWithLocalSafeBlocks()` to poll the supernode's `RequiredL1` values and search for L1 blocks satisfying per-chain conditions. This has an inherent TOCTOU race: continued sequencer block production causes batchers to submit extra data, shifting `RequiredL1` values between the poll and the L1 block read. With 1s block times (as in the `VariedBlockTimes` tests), the race window is wide enough to cause frequent flakes.

Additionally, the interop tests had two further issues:

1. **EL safe deadlock**: `EL.Reached(eth.Safe, ...)` never completes in interop mode because the EL safe label only advances after interop validation, which requires ALL chains to have batch data. When only one chain's batcher is running, EL safe never advances.

2. **Cross-safe vs local-safe mismatch**: `nextTimestampAfterSafeHeads` used `SafeL2` (cross-safe) to compute the end timestamp. In interop mode, cross-safe lags far behind local-safe, causing `endTimestamp` to target blocks whose batch data was already on L1 — breaking the `l1HeadBefore`/`l1HeadAfterFirst` invariants.

## Fix

Instead of polling the supernode for `RequiredL1`, read the L1 head directly from the L1 client at each stage of a batcher start/stop choreography:

1. Both batchers stopped simultaneously → `l1HeadBefore` (no batch data on L1)
2. Start chain[0]'s batcher → wait for `CLNode.Reached(types.LocalSafe, target)` → `l1HeadAfterFirst` (chain[0]'s data on L1, chain[1]'s batcher still stopped)
3. Start chain[1]'s batcher → `AwaitValidatedTimestamp` + `CLNode.Reached(types.LocalSafe, target)` → `l1HeadCurrent` (both chains' data on L1)

Key changes:
- Wait on **CL LocalSafe** instead of EL Safe — LocalSafe advances independently per-chain without requiring interop validation
- Use **`LocalSafeL2`** in `nextTimestampAfterSafeHeads` when available, so `endTimestamp` targets blocks past what's actually been batched
- Stop **both batchers simultaneously** to prevent one from submitting data past the safe heads while waiting for the other to stall
- Wire `BatcherOptions` through to the two-L2 supernode runtime and add `WithBatcherStopped()` preset option

The invariants are enforced by which batchers are running (binary state), not by timing windows.

## Test Plan

- [x] `TestPreinteropFaultProofs_VariedBlockTimes` passes (was skipped)
- [x] `TestPreinteropFaultProofs_VariedBlockTimes_FasterChainB` passes (was skipped)
- [x] `TestInteropFaultProofs_VariedBlockTimes` passes (was skipped)
- [x] `TestInteropFaultProofs_VariedBlockTimes_FasterChainB` passes (was skipped)
- [ ] `TestPreinteropFaultProofs` still passes (RunSuperFaultProofTest updated)
- [ ] `TestSingleChainSuperFaultProof` still passes (singlechain.go updated)
- [x] `go vet` and `golangci-lint` pass with zero issues

Fixes #19804

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context)