### PR TITLE
fix(kona-host): use tempfile for test isolation, deduplicate kv store creation

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5859,6 +5859,7 @@ dependencies = [
  "rocksdb",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/rust/kona/bin/host/Cargo.toml
+++ b/rust/kona/bin/host/Cargo.toml
@@ -72,6 +72,7 @@ ark-ff.workspace = true
 [dev-dependencies]
 alloy-json-rpc.workspace = true
 proptest.workspace = true
+tempfile.workspace = true
 
 [features]
 default = [ "interop", "single" ]

--- a/rust/kona/bin/host/src/interop/cfg.rs
+++ b/rust/kona/bin/host/src/interop/cfg.rs
@@ -2,11 +2,10 @@
 
 use super::{InteropHintHandler, InteropLocalInputs};
 use crate::{
-    DirectoryKeyValueStore, DiskKeyValueStore, MemoryKeyValueStore, OfflineHostBackend,
-    OnlineHostBackend, OnlineHostBackendCfg, PreimageServer, SharedKeyValueStore,
-    SplitKeyValueStore,
+    OfflineHostBackend, OnlineHostBackend, OnlineHostBackendCfg, PreimageServer,
+    SharedKeyValueStore,
     eth::rpc_provider,
-    kv::{DataFormat, detect_data_format},
+    kv::{DataFormat, create_key_value_store},
     server::PreimageServerError,
 };
 use alloy_primitives::{B256, Bytes};
@@ -23,10 +22,7 @@ use kona_std_fpvm::{FileChannel, FileDescriptor};
 use op_alloy_network::Optimism;
 use serde::Serialize;
 use std::{collections::HashMap, path::PathBuf, str::FromStr, sync::Arc};
-use tokio::{
-    sync::RwLock,
-    task::{self, JoinHandle},
-};
+use tokio::task::{self, JoinHandle};
 
 /// The interop host application.
 #[derive(Default, Parser, Serialize, Clone, Debug)]
@@ -264,26 +260,7 @@ impl InteropHost {
     /// ensure compatibility with existing data. Otherwise, `--data-format` is used as the default.
     fn create_key_value_store(&self) -> Result<SharedKeyValueStore, InteropHostError> {
         let local_kv_store = InteropLocalInputs::new(self.clone());
-
-        let kv_store: SharedKeyValueStore = if let Some(ref data_dir) = self.data_dir {
-            let format = detect_data_format(data_dir, self.data_format);
-            match format {
-                DataFormat::Directory => {
-                    let dir_kv_store = DirectoryKeyValueStore::new(data_dir.clone());
-                    Arc::new(RwLock::new(SplitKeyValueStore::new(local_kv_store, dir_kv_store)))
-                }
-                DataFormat::Rocksdb => {
-                    let disk_kv_store = DiskKeyValueStore::new(data_dir.clone());
-                    Arc::new(RwLock::new(SplitKeyValueStore::new(local_kv_store, disk_kv_store)))
-                }
-            }
-        } else {
-            let mem_kv_store = MemoryKeyValueStore::new();
-            let split_kv_store = SplitKeyValueStore::new(local_kv_store, mem_kv_store);
-            Arc::new(RwLock::new(split_kv_store))
-        };
-
-        Ok(kv_store)
+        Ok(create_key_value_store(local_kv_store, self.data_dir.as_ref(), self.data_format))
     }
 
     /// Creates the providers required for the preimage server backend.

--- a/rust/kona/bin/host/src/kv/directory.rs
+++ b/rust/kona/bin/host/src/kv/directory.rs
@@ -72,15 +72,14 @@ mod test {
         proptest,
         test_runner::Config,
     };
-    use std::env::temp_dir;
 
     proptest! {
         #![proptest_config(Config::with_cases(16))]
 
         #[test]
         fn directory_kv_roundtrip(k_v in hash_map(any::<[u8; 32]>(), vec(any::<u8>(), 0..128), 1..128)) {
-            let tempdir = temp_dir();
-            let mut kv = DirectoryKeyValueStore::new(tempdir);
+            let tempdir = tempfile::TempDir::new().unwrap();
+            let mut kv = DirectoryKeyValueStore::new(tempdir.path().to_path_buf());
 
             for (k, v) in &k_v {
                 kv.set((*k).into(), v.clone()).unwrap();
@@ -95,17 +94,17 @@ mod test {
 
     #[test]
     fn writes_kvformat_marker() {
-        let tempdir = temp_dir().join("kona_test_kvformat");
-        let _kv = DirectoryKeyValueStore::new(tempdir.clone());
+        let tempdir = tempfile::TempDir::new().unwrap();
+        let _kv = DirectoryKeyValueStore::new(tempdir.path().to_path_buf());
 
-        let marker = std::fs::read_to_string(tempdir.join("kvformat")).unwrap();
+        let marker = std::fs::read_to_string(tempdir.path().join("kvformat")).unwrap();
         assert_eq!(marker, "directory");
     }
 
     #[test]
     fn key_path_layout() {
-        let tempdir = temp_dir().join("kona_test_layout");
-        let kv = DirectoryKeyValueStore::new(tempdir);
+        let tempdir = tempfile::TempDir::new().unwrap();
+        let kv = DirectoryKeyValueStore::new(tempdir.path().to_path_buf());
 
         let key = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
             .parse::<B256>()

--- a/rust/kona/bin/host/src/kv/disk.rs
+++ b/rust/kona/bin/host/src/kv/disk.rs
@@ -84,16 +84,14 @@ mod test {
         proptest,
         test_runner::Config,
     };
-    use std::env::temp_dir;
-
     proptest! {
         #![proptest_config(Config::with_cases(16))]
 
         /// Test that converting from a [DiskKeyValueStore] to a [MemoryKeyValueStore] is lossless.
         #[test]
         fn convert_disk_kv_to_mem_kv(k_v in hash_map(any::<[u8; 32]>(), vec(any::<u8>(), 0..128), 1..128)) {
-            let tempdir = temp_dir();
-            let mut disk_kv = DiskKeyValueStore::new(tempdir);
+            let tempdir = tempfile::TempDir::new().unwrap();
+            let mut disk_kv = DiskKeyValueStore::new(tempdir.path().to_path_buf());
             for (k, v) in &k_v {
                 disk_kv.set(k.into(), v.clone()).unwrap();
             }

--- a/rust/kona/bin/host/src/kv/mod.rs
+++ b/rust/kona/bin/host/src/kv/mod.rs
@@ -62,6 +62,39 @@ pub fn detect_data_format(data_dir: &Path, default_format: DataFormat) -> DataFo
 /// A type alias for a shared key-value store.
 pub type SharedKeyValueStore = Arc<RwLock<dyn KeyValueStore + Send + Sync>>;
 
+/// Creates a [`SharedKeyValueStore`] backed by disk or memory.
+///
+/// If `data_dir` is provided, the format is auto-detected from any existing `kvformat` marker file,
+/// falling back to `default_format`. Otherwise a [`MemoryKeyValueStore`] is used.
+pub fn create_key_value_store<L>(
+    local_kv_store: L,
+    data_dir: Option<&std::path::PathBuf>,
+    default_format: DataFormat,
+) -> SharedKeyValueStore
+where
+    L: KeyValueStore + Send + Sync + 'static,
+{
+    match data_dir {
+        Some(data_dir) => {
+            let format = detect_data_format(data_dir, default_format);
+            match format {
+                DataFormat::Directory => {
+                    let dir_kv_store = DirectoryKeyValueStore::new(data_dir.clone());
+                    Arc::new(RwLock::new(SplitKeyValueStore::new(local_kv_store, dir_kv_store)))
+                }
+                DataFormat::Rocksdb => {
+                    let disk_kv_store = DiskKeyValueStore::new(data_dir.clone());
+                    Arc::new(RwLock::new(SplitKeyValueStore::new(local_kv_store, disk_kv_store)))
+                }
+            }
+        }
+        None => {
+            let mem_kv_store = MemoryKeyValueStore::new();
+            Arc::new(RwLock::new(SplitKeyValueStore::new(local_kv_store, mem_kv_store)))
+        }
+    }
+}
+
 /// Describes the interface of a simple, synchronous key-value store.
 pub trait KeyValueStore {
     /// Get the value associated with the given key.
@@ -74,47 +107,40 @@ pub trait KeyValueStore {
 #[cfg(test)]
 mod test {
     use super::*;
-    use std::{env::temp_dir, fs};
-
-    fn test_dir(name: &str) -> std::path::PathBuf {
-        let dir = temp_dir().join(format!("kona_detect_format_{name}"));
-        let _ = fs::remove_dir_all(&dir);
-        fs::create_dir_all(&dir).unwrap();
-        dir
-    }
+    use std::fs;
 
     #[test]
     fn detect_reads_existing_directory_marker() {
-        let dir = test_dir("read_dir");
-        fs::write(dir.join("kvformat"), "directory").unwrap();
+        let dir = tempfile::TempDir::new().unwrap();
+        fs::write(dir.path().join("kvformat"), "directory").unwrap();
 
-        let format = detect_data_format(&dir, DataFormat::Rocksdb);
+        let format = detect_data_format(dir.path(), DataFormat::Rocksdb);
         assert_eq!(format, DataFormat::Directory);
     }
 
     #[test]
     fn detect_reads_existing_rocksdb_marker() {
-        let dir = test_dir("read_rocksdb");
-        fs::write(dir.join("kvformat"), "rocksdb").unwrap();
+        let dir = tempfile::TempDir::new().unwrap();
+        fs::write(dir.path().join("kvformat"), "rocksdb").unwrap();
 
-        let format = detect_data_format(&dir, DataFormat::Directory);
+        let format = detect_data_format(dir.path(), DataFormat::Directory);
         assert_eq!(format, DataFormat::Rocksdb);
     }
 
     #[test]
     fn detect_falls_back_to_default_when_no_marker() {
-        let dir = test_dir("no_marker");
+        let dir = tempfile::TempDir::new().unwrap();
 
-        assert_eq!(detect_data_format(&dir, DataFormat::Directory), DataFormat::Directory);
-        assert_eq!(detect_data_format(&dir, DataFormat::Rocksdb), DataFormat::Rocksdb);
+        assert_eq!(detect_data_format(dir.path(), DataFormat::Directory), DataFormat::Directory);
+        assert_eq!(detect_data_format(dir.path(), DataFormat::Rocksdb), DataFormat::Rocksdb);
     }
 
     #[test]
     fn detect_falls_back_to_default_for_unknown_format() {
-        let dir = test_dir("unknown");
-        fs::write(dir.join("kvformat"), "pebble").unwrap();
+        let dir = tempfile::TempDir::new().unwrap();
+        fs::write(dir.path().join("kvformat"), "pebble").unwrap();
 
-        let format = detect_data_format(&dir, DataFormat::Directory);
+        let format = detect_data_format(dir.path(), DataFormat::Directory);
         assert_eq!(format, DataFormat::Directory);
     }
 }

--- a/rust/kona/bin/host/src/single/cfg.rs
+++ b/rust/kona/bin/host/src/single/cfg.rs
@@ -2,11 +2,10 @@
 
 use super::{SingleChainHintHandler, SingleChainLocalInputs};
 use crate::{
-    DirectoryKeyValueStore, DiskKeyValueStore, MemoryKeyValueStore, OfflineHostBackend,
-    OnlineHostBackend, OnlineHostBackendCfg, PreimageServer, SharedKeyValueStore,
-    SplitKeyValueStore,
+    OfflineHostBackend, OnlineHostBackend, OnlineHostBackendCfg, PreimageServer,
+    SharedKeyValueStore,
     eth::rpc_provider,
-    kv::{DataFormat, detect_data_format},
+    kv::{DataFormat, create_key_value_store},
     server::PreimageServerError,
 };
 use alloy_primitives::B256;
@@ -23,10 +22,7 @@ use kona_std_fpvm::{FileChannel, FileDescriptor};
 use op_alloy_network::Optimism;
 use serde::Serialize;
 use std::{path::PathBuf, sync::Arc};
-use tokio::{
-    sync::RwLock,
-    task::{self, JoinHandle},
-};
+use tokio::task::{self, JoinHandle};
 
 /// The host binary CLI application arguments.
 #[derive(Default, Parser, Serialize, Clone, Debug)]
@@ -265,26 +261,7 @@ impl SingleChainHost {
     /// ensure compatibility with existing data. Otherwise, `--data-format` is used as the default.
     pub fn create_key_value_store(&self) -> Result<SharedKeyValueStore, SingleChainHostError> {
         let local_kv_store = SingleChainLocalInputs::new(self.clone());
-
-        let kv_store: SharedKeyValueStore = if let Some(ref data_dir) = self.data_dir {
-            let format = detect_data_format(data_dir, self.data_format);
-            match format {
-                DataFormat::Directory => {
-                    let dir_kv_store = DirectoryKeyValueStore::new(data_dir.clone());
-                    Arc::new(RwLock::new(SplitKeyValueStore::new(local_kv_store, dir_kv_store)))
-                }
-                DataFormat::Rocksdb => {
-                    let disk_kv_store = DiskKeyValueStore::new(data_dir.clone());
-                    Arc::new(RwLock::new(SplitKeyValueStore::new(local_kv_store, disk_kv_store)))
-                }
-            }
-        } else {
-            let mem_kv_store = MemoryKeyValueStore::new();
-            let split_kv_store = SplitKeyValueStore::new(local_kv_store, mem_kv_store);
-            Arc::new(RwLock::new(split_kv_store))
-        };
-
-        Ok(kv_store)
+        Ok(create_key_value_store(local_kv_store, self.data_dir.as_ref(), self.data_format))
     }
 
     /// Creates the providers required for the host backend.


### PR DESCRIPTION
## Summary

- Replace `temp_dir()` with `tempfile::TempDir` in all kona-host tests to prevent test interference and race conditions across proptest cases and parallel runs ([review comment](https://github.com/ethereum-optimism/optimism/pull/19803#discussion_r3007279752))
- Extract duplicated kv store creation logic from `single/cfg.rs` and `interop/cfg.rs` into a shared `create_key_value_store` helper in the `kv` module

## Test plan

- [x] All 22 kona-host tests pass
- [x] `cargo fmt` clean
- [x] `cargo clippy` — no new warnings (removed unused `RwLock` imports)

🤖 Generated with [Claude Code](https://claude.com/claude-code)