### PR TITLE
Update git.just to read components version from env

### DIFF
--- a/justfiles/git.just
+++ b/justfiles/git.just
@@ -15,12 +15,14 @@ _PREFERRED_TAG := shell("echo $1 | tr ' ' '\n' | grep -v -- '-rc' | tail -n 1", 
 _LAST_TAG := shell("echo $1 | tr ' ' '\n' | tail -n 1", _PROJECT_TAGS)
 
 # Find version tag, prioritizing non-rc release tags
-VERSION := if _PREFERRED_TAG != "" {
+_COMPUTED_VERSION := if _PREFERRED_TAG != "" {
     _PREFERRED_TAG
 } else if _LAST_TAG != "" {
     _LAST_TAG
 } else {
     "untagged"
 }
+
+VERSION := env('VERSION', _COMPUTED_VERSION)
 
 VERSION_META := ""


### PR DESCRIPTION
After switching from make to just [here](https://github.com/ethereum-optimism/optimism/commit/fdf9103cab4cbcc89270f962a42ca58e983dc321) the components version is not picked up correctly when building docker image and it's set to untagged. This PR updates VERSION in [git.just](https://github.com/ethereum-optimism/optimism/blob/develop/justfiles/git.just#L18-L24) so it is also read from env like GITCOMMIT and GITDATE