### PR TITLE
fix(ci): report passing status checks for docs-only PRs

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -695,6 +695,13 @@ jobs:
     steps:
       - utils/ci-gate
 
+  ci-gate-skip:
+    docker:
+      - image: <<pipeline.parameters.c-default_docker_image>>
+    resource_class: small
+    steps:
+      - run: echo "Skipped — docs-only change"
+
   # Build a single Rust binary from a workspace. Will cache the binary by default.
   rust-build-binary:
     description: "Build a Rust workspace with target directory caching"
@@ -2834,6 +2841,36 @@ workflows:
           context:
             - circleci-repo-readonly-authenticated-github-token
             - circleci-api-token
+
+  main-skip:
+    when:
+      and:
+        - equal: ["", << pipeline.git.tag >>]
+        - equal: ["webhook", << pipeline.trigger_source >>]
+        - not: << pipeline.parameters.c-non_docs_changes >>
+    jobs:
+      - ci-gate-skip:
+          name: check-kontrol-build
+      - ci-gate-skip:
+          name: shell-check
+      - ci-gate-skip:
+          name: go-lint
+      - ci-gate-skip:
+          name: semgrep-scan-local
+      - ci-gate-skip:
+          name: go-tests-short
+      - ci-gate-skip:
+          name: contracts-bedrock-coverage main
+      - ci-gate-skip:
+          name: contracts-bedrock-tests main
+      - ci-gate-skip:
+          name: contracts-bedrock-tests-heavy-fuzz-modified main
+      - ci-gate-skip:
+          name: contracts-bedrock-tests-upgrade op-mainnet main
+      - ci-gate-skip:
+          name: memory-all
+      - ci-gate-skip:
+          name: contracts-bedrock-checks-fast
 
   go-release-op-deployer:
     jobs:


### PR DESCRIPTION
## Summary

- Adds a `main-skip` workflow that triggers when only `docs/public-docs/` files are changed
- Runs no-op jobs with names matching all 11 required GitHub status checks
- Prevents docs-only PRs from being permanently stuck at "Waiting for status to be reported"

## Problem

Prior PRs (#19739, #19780) correctly gated the main CI workflow behind `c-non_docs_changes`, so the full test suite no longer runs for docs-only changes. However, when the entire `main` workflow is skipped, GitHub branch protection never receives status reports for the required checks — leaving docs PRs like #19761 stuck indefinitely.

## Approach

Follows the same pattern already used by `rust-ci-gate-short` and `rust-e2e-gate-skip`: a lightweight skip workflow that runs a `ci-gate-skip` job (just `echo`) with the exact `name:` matching each required check. This satisfies GitHub's branch protection without running any real CI.

## Test plan

- [ ] Verify CI passes on this PR (since it touches `.circleci/`, the main workflow runs normally)
- [ ] After merge, verify a docs-only PR (e.g. #19761) gets all required checks reported as passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)