### PR TITLE
fix(ct): resolve correct target branch in merge queue

### DIFF
--- a/packages/contracts-bedrock/scripts/ops/get-target-branch.sh
+++ b/packages/contracts-bedrock/scripts/ops/get-target-branch.sh
@@ -8,7 +8,14 @@ fi
 
 # Fallbacks when not a PR or API did not return a branch
 if [ -z "$TARGET_BRANCH" ] || [ "$TARGET_BRANCH" = "null" ]; then
-  TARGET_BRANCH="${CIRCLE_BRANCH:-develop}"
+  # In merge queues, CIRCLE_BRANCH is gh-readonly-queue/<base>/pr-<n>-<sha>.
+  # Extract the base branch via regex; BASH_REMATCH[1] captures the first
+  # parenthesised group, i.e. the <base> segment between the slashes.
+  if [[ "${CIRCLE_BRANCH:-}" =~ ^gh-readonly-queue/([^/]+)/ ]]; then
+    TARGET_BRANCH="${BASH_REMATCH[1]}"
+  else
+    TARGET_BRANCH="${CIRCLE_BRANCH:-develop}"
+  fi
 fi
 
 echo "Resolved TARGET_BRANCH=$TARGET_BRANCH" >&2


### PR DESCRIPTION
## Summary

- In the merge queue, `CIRCLE_BRANCH` is set to `gh-readonly-queue/<base>/pr-<n>-<sha>`, which was being used as `TARGET_BRANCH` directly
- This caused `semver-diff-check` to diff against the merge queue branch instead of the actual base branch (e.g. `develop`), making it think no version bump occurred
- Fix: parse the base branch out of the `gh-readonly-queue/` pattern

## Test plan

- [x] Verified the regex extracts `develop` from `gh-readonly-queue/develop/pr-19797-8f8e581cf13bf524f721b963f149e9d53d84e653`
- [ ] Merge queue CI passes with this fix