### PR TITLE
fix(op-node): guard SafeDB methods against use after Close

### DIFF
--- a/op-node/node/safedb/safedb.go
+++ b/op-node/node/safedb/safedb.go
@@ -17,6 +17,7 @@ import (
 var (
 	ErrNotFound     = errors.New("not found")
 	ErrInvalidEntry = errors.New("invalid db entry")
+	ErrClosed       = errors.New("safe db closed")
 )
 
 const (
@@ -100,6 +101,9 @@ func (d *SafeDB) Enabled() bool {
 func (d *SafeDB) SafeHeadUpdated(safeHead eth.L2BlockRef, l1Head eth.BlockID) error {
 	d.m.Lock()
 	defer d.m.Unlock()
+	if d.closed {
+		return ErrClosed
+	}
 	d.log.Info("Record local safe head", "l2", safeHead.ID(), "l1", l1Head)
 	batch := d.db.NewBatch()
 	defer batch.Close()
@@ -115,6 +119,9 @@ func (d *SafeDB) SafeHeadUpdated(safeHead eth.L2BlockRef, l1Head eth.BlockID) er
 func (d *SafeDB) SafeHeadReset(safeHead eth.L2BlockRef) error {
 	d.m.Lock()
 	defer d.m.Unlock()
+	if d.closed {
+		return ErrClosed
+	}
 	d.log.Info("Resetting safe head db", "l2", safeHead.ID())
 	iter, err := d.db.NewIter(safeByL1BlockNumKey.IterRange())
 	if err != nil {
@@ -167,6 +174,10 @@ func (d *SafeDB) SafeHeadReset(safeHead eth.L2BlockRef) error {
 func (d *SafeDB) SafeHeadAtL1(ctx context.Context, l1BlockNum uint64) (l1Block eth.BlockID, safeHead eth.BlockID, err error) {
 	d.m.RLock()
 	defer d.m.RUnlock()
+	if d.closed {
+		err = ErrClosed
+		return
+	}
 	iter, err := d.db.NewIterWithContext(ctx, safeByL1BlockNumKey.IterRange())
 	if err != nil {
 		return


### PR DESCRIPTION
## Summary

Fixes a flaky test panic (`pebble: closed`) in `TestFollowSource_HeadsDivergeThenConverge` caused by a race condition during supernode shutdown.

### Root Cause

During `Supernode.Stop()`, activities are stopped non-blocking (`Interop.Stop()` calls `cancel()` but doesn't wait for the goroutine to exit), then chain containers are stopped (which closes SafeDB via `OpNode.Close()`). The interop goroutine can still be mid-`progressAndRecord()` when `SafeDB.Close()` runs, causing `SafeHeadAtL1()` to call `pebble.NewIterWithContext()` on a closed DB — panic.

### Why Flaky

The interop goroutine must be mid-iteration (specifically inside `SafeHeadAtL1`) at the exact moment the chain container's shutdown path closes the SafeDB. If it completes its iteration and checks `ctx.Done()` first, no panic occurs. Pure goroutine scheduling timing.

### Fix

Adds `ErrClosed` checks to all three SafeDB methods (`SafeHeadAtL1`, `SafeHeadUpdated`, `SafeHeadReset`) after acquiring their respective locks. The existing `closed` flag and `sync.RWMutex` provide proper synchronization — converts a panic into a graceful error return that the interop activity's error handling already handles.

Closes #19821

## Test plan

- [ ] Existing tests pass (the panic is eliminated)
- [ ] `TestFollowSource_HeadsDivergeThenConverge` no longer panics during shutdown races

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>