### PR TITLE
fix(tests): use super_atTimestamp API for optimistic block output roots

### DIFF
--- a/op-acceptance-tests/tests/superfaultproofs/singlechain.go
+++ b/op-acceptance-tests/tests/superfaultproofs/singlechain.go
@@ -58,7 +58,7 @@ func RunSingleChainSuperFaultProofSmokeTest(t devtest.T, sys *presets.SingleChai
 	start := superRootAtTimestamp(t, chains, startTimestamp)
 	end := superRootAtTimestamp(t, chains, endTimestamp)
 
-	optimistic := optimisticBlockAtTimestamp(t, c, endTimestamp)
+	optimistic := optimisticBlockAtTimestamp(t, sys.SuperRoots.QueryAPI(), c.ID, endTimestamp)
 
 	// With one chain: step 0 = chain's optimistic block, steps 1..consolidateStep-1 = padding,
 	// consolidateStep = consolidation to next super root.

--- a/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
+++ b/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
@@ -96,12 +96,14 @@ func superRootAtTimestamp(t devtest.T, chains []*chain, timestamp uint64) eth.Su
 }
 
 // optimisticBlockAtTimestamp returns the optimistic block for a single chain at the given timestamp.
-func optimisticBlockAtTimestamp(t devtest.T, c *chain, timestamp uint64) interopTypes.OptimisticBlock {
-	blockNum, err := c.Cfg.TargetBlockNumber(timestamp)
+// It queries the supernode's super_atTimestamp API which returns the true optimistic output root,
+// even after an invalid block has been replaced during cross-safe validation.
+func optimisticBlockAtTimestamp(t devtest.T, queryAPI apis.SupernodeQueryAPI, chainID eth.ChainID, timestamp uint64) interopTypes.OptimisticBlock {
+	resp, err := queryAPI.SuperRootAtTimestamp(t.Ctx(), timestamp)
 	t.Require().NoError(err)
-	out, err := c.Rollup.OutputAtBlock(t.Ctx(), blockNum)
-	t.Require().NoError(err)
-	return interopTypes.OptimisticBlock{BlockHash: out.BlockRef.Hash, OutputRoot: out.OutputRoot}
+	out, ok := resp.OptimisticAtTimestamp[chainID]
+	t.Require().Truef(ok, "no optimistic output for chain %v at timestamp %d", chainID, timestamp)
+	return interopTypes.OptimisticBlock{BlockHash: out.Output.BlockRef.Hash, OutputRoot: out.Output.OutputRoot}
 }
 
 // marshalTransition serializes a transition state with the given super root, step, and progress.
@@ -404,7 +406,7 @@ func RunTraceExtensionActivationTest(t devtest.T, sys *presets.SimpleInterop) {
 
 	// The disputed claim transitions to the next timestamp by including the
 	// first chain's optimistic block at endTimestamp+1.
-	firstOptimistic := optimisticBlockAtTimestamp(t, chains[0], endTimestamp+1)
+	firstOptimistic := optimisticBlockAtTimestamp(t, sys.SuperRoots.QueryAPI(), chains[0].ID, endTimestamp+1)
 	disputedClaim := marshalTransition(agreedSuperRoot, 1, firstOptimistic)
 	disputedTraceIndex := int64(stepsPerTimestamp)
 
@@ -607,8 +609,8 @@ func RunSuperFaultProofTest(t devtest.T, sys *presets.SimpleInterop) {
 	start := superRootAtTimestamp(t, chains, startTimestamp)
 	end := superRootAtTimestamp(t, chains, endTimestamp)
 
-	firstOptimistic := optimisticBlockAtTimestamp(t, chains[0], endTimestamp)
-	secondOptimistic := optimisticBlockAtTimestamp(t, chains[1], endTimestamp)
+	firstOptimistic := optimisticBlockAtTimestamp(t, sys.SuperRoots.QueryAPI(), chains[0].ID, endTimestamp)
+	secondOptimistic := optimisticBlockAtTimestamp(t, sys.SuperRoots.QueryAPI(), chains[1].ID, endTimestamp)
 
 	step1 := marshalTransition(start, 1, firstOptimistic)
 	step2 := marshalTransition(start, 2, firstOptimistic, secondOptimistic)
@@ -686,8 +688,8 @@ func RunVariedBlockTimesTest(t devtest.T, sys *presets.SimpleInterop) {
 	start := superRootAtTimestamp(t, chains, startTimestamp)
 	end := superRootAtTimestamp(t, chains, endTimestamp)
 
-	firstOptimistic := optimisticBlockAtTimestamp(t, chains[0], endTimestamp)
-	secondOptimistic := optimisticBlockAtTimestamp(t, chains[1], endTimestamp)
+	firstOptimistic := optimisticBlockAtTimestamp(t, sys.SuperRoots.QueryAPI(), chains[0].ID, endTimestamp)
+	secondOptimistic := optimisticBlockAtTimestamp(t, sys.SuperRoots.QueryAPI(), chains[1].ID, endTimestamp)
 
 	step1 := marshalTransition(start, 1, firstOptimistic)
 	step2 := marshalTransition(start, 2, firstOptimistic, secondOptimistic)
@@ -738,8 +740,8 @@ func RunConsolidateValidCrossChainMessageTest(t devtest.T, sys *presets.SimpleIn
 	start := superRootAtTimestamp(t, chains, startTimestamp)
 	end := superRootAtTimestamp(t, chains, endTimestamp)
 
-	firstOptimistic := optimisticBlockAtTimestamp(t, chains[0], endTimestamp)
-	secondOptimistic := optimisticBlockAtTimestamp(t, chains[1], endTimestamp)
+	firstOptimistic := optimisticBlockAtTimestamp(t, sys.SuperRoots.QueryAPI(), chains[0].ID, endTimestamp)
+	secondOptimistic := optimisticBlockAtTimestamp(t, sys.SuperRoots.QueryAPI(), chains[1].ID, endTimestamp)
 	paddingStep := func(step uint64) []byte {
 		return marshalTransition(start, step, firstOptimistic, secondOptimistic)
 	}
@@ -809,8 +811,8 @@ func RunInvalidBlockTest(t devtest.T, sys *presets.SimpleInterop) {
 	start := superRootAtTimestamp(t, chains, startTimestamp)
 	crossSafeSuperRootEnd := superRootAtTimestamp(t, chains, endTimestamp)
 
-	firstOptimistic := optimisticBlockAtTimestamp(t, chains[0], endTimestamp)
-	secondOptimistic := optimisticBlockAtTimestamp(t, chains[1], endTimestamp)
+	firstOptimistic := optimisticBlockAtTimestamp(t, sys.SuperRoots.QueryAPI(), chains[0].ID, endTimestamp)
+	secondOptimistic := optimisticBlockAtTimestamp(t, sys.SuperRoots.QueryAPI(), chains[1].ID, endTimestamp)
 	paddingStep := func(step uint64) []byte {
 		return marshalTransition(start, step, firstOptimistic, secondOptimistic)
 	}


### PR DESCRIPTION
## Summary

- Changes `optimisticBlockAtTimestamp` in the super fault proof tests to query the supernode's `super_atTimestamp` API (`optimistic_at_timestamp` field) instead of calling `OutputAtBlock` directly on the rollup client.
- `OutputAtBlock` returns whatever block is currently canonical at a given number. After an invalid block is replaced during cross-safe validation, this returns the **replacement** block's output root, not the original optimistic block's output root.
- The `super_atTimestamp` API's `optimistic_at_timestamp` field is the intended source for optimistic output roots.

**Note:** The supernode's `OptimisticOutputAtTimestamp` (`chain_container.go:464`) also calls `OutputAtBlock` internally, so both paths currently return the same (wrong) value after replacement. Three `TestInteropFaultProofs_InvalidBlock` sub-tests still fail until the supernode is fixed to preserve the original optimistic output root:
- `SecondChainOptimisticBlock-fpp`
- `Consolidate-ExpectInvalidPendingBlock-fpp`
- `Consolidate-ExpectInvalidPendingBlock-challenger`

## Test plan

- [x] `TestInteropFaultProofs_ConsolidateValidCrossChainMessage` — all sub-tests pass
- [x] `TestInteropSingleChainFaultProofs` — all sub-tests pass
- [x] `TestInteropFaultProofs_InvalidBlock` — same 3 sub-tests fail as before (expected), all others pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)