### PR TITLE
feat(op-deployer): add inspect l1-genesis command

### DIFF
--- a/op-deployer/pkg/deployer/inspect/flags.go
+++ b/op-deployer/pkg/deployer/inspect/flags.go
@@ -69,6 +69,12 @@ var Commands = []*cli.Command{
 		Action:    L2SemversCLI,
 		Flags:     Flags,
 	},
+	{
+		Name:   "l1-genesis",
+		Usage:  "outputs the L1 genesis for the deployment",
+		Action: L1GenesisCLI,
+		Flags:  Flags,
+	},
 }
 
 type cliConfig struct {

--- a/op-deployer/pkg/deployer/inspect/l1_genesis.go
+++ b/op-deployer/pkg/deployer/inspect/l1_genesis.go
@@ -1,0 +1,94 @@
+package inspect
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/pipeline"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/state"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/ioutil"
+	"github.com/ethereum-optimism/optimism/op-service/jsonutil"
+	"github.com/urfave/cli/v2"
+)
+
+// L1GenesisCLI is the CLI handler for `op-deployer inspect l1-genesis`.
+func L1GenesisCLI(cliCtx *cli.Context) error {
+	workdir := cliCtx.String(deployer.WorkdirFlagName)
+	if workdir == "" {
+		return fmt.Errorf("workdir flag is required")
+	}
+
+	outfile := cliCtx.String(OutfileFlagName)
+	if outfile == "" {
+		return fmt.Errorf("outfile flag is required")
+	}
+
+	globalState, err := pipeline.ReadState(workdir)
+	if err != nil {
+		return fmt.Errorf("failed to read state: %w", err)
+	}
+
+	l1Genesis, err := L1Genesis(globalState)
+	if err != nil {
+		return fmt.Errorf("failed to generate L1 genesis: %w", err)
+	}
+
+	if err := jsonutil.WriteJSON(l1Genesis, ioutil.ToStdOutOrFileOrNoop(outfile, 0o666)); err != nil {
+		return fmt.Errorf("failed to write L1 genesis: %w", err)
+	}
+
+	return nil
+}
+
+// L1Genesis reconstructs the full L1 genesis from deployment state.
+// It combines the L1StateDump allocs with the genesis template
+// rebuilt from AppliedIntent.L1DevGenesisParams, mirroring the logic
+// in SealL1DevGenesis.
+func L1Genesis(globalState *state.State) (*core.Genesis, error) {
+	if globalState.AppliedIntent == nil {
+		return nil, fmt.Errorf("chain state is not applied - run op-deployer apply")
+	}
+
+	if globalState.L1StateDump == nil {
+		return nil, fmt.Errorf("L1 state dump is missing from deployment state")
+	}
+
+	intent := globalState.AppliedIntent
+	l1DevParams := intent.L1DevGenesisParams
+	if l1DevParams == nil {
+		l1DevParams = &state.L1DevGenesisParams{}
+	}
+
+	bp := &l1DevParams.BlockParams
+	timestamp := bp.Timestamp
+	if timestamp == 0 {
+		timestamp = uint64(time.Now().Unix())
+	}
+	excessBlobGas := bp.ExcessBlobGas
+
+	// Reconstruct the genesis template using the same logic as SealL1DevGenesis.
+	genesisTemplate, err := genesis.NewL1GenesisMinimal(&genesis.DevL1DeployConfigMinimal{
+		DevL1DeployConfig: genesis.DevL1DeployConfig{
+			L1GenesisBlockTimestamp:     hexutil.Uint64(timestamp),
+			L1GenesisBlockGasLimit:      hexutil.Uint64(bp.GasLimit),
+			L1GenesisBlockExcessBlobGas: (*hexutil.Uint64)(&excessBlobGas),
+		},
+		L1ChainID:          eth.ChainIDFromUInt64(intent.L1ChainID),
+		L1PragueTimeOffset: l1DevParams.PragueTimeOffset,
+		L1OsakaTimeOffset:  l1DevParams.OsakaTimeOffset,
+		L1BPO1TimeOffset:   l1DevParams.BPO1TimeOffset,
+		BlobScheduleConfig: l1DevParams.BlobSchedule,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create L1 genesis template: %w", err)
+	}
+
+	genesisTemplate.Alloc = globalState.L1StateDump.Data.Accounts
+	return genesisTemplate, nil
+}

--- a/op-deployer/pkg/deployer/integration_test/l1_genesis_test.go
+++ b/op-deployer/pkg/deployer/integration_test/l1_genesis_test.go
@@ -1,0 +1,66 @@
+package integration_test
+
+import (
+	"context"
+	"testing"
+
+	"math/big"
+
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/inspect"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/state"
+	op_e2e "github.com/ethereum-optimism/optimism/op-e2e"
+	"github.com/stretchr/testify/require"
+)
+
+func TestL1Genesis(t *testing.T) {
+	op_e2e.InitParallel(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	customTimestamp := uint64(1700000000)
+	customGasLimit := uint64(42_000_000)
+	pragueOffset := uint64(0)
+
+	opts, intent, st := setupGenesisChain(t, 900)
+	intent.L1DevGenesisParams = &state.L1DevGenesisParams{
+		BlockParams: state.L1DevGenesisBlockParams{
+			Timestamp: customTimestamp,
+			GasLimit:  customGasLimit,
+		},
+		PragueTimeOffset: &pragueOffset,
+	}
+
+	require.NoError(t, deployer.ApplyPipeline(ctx, opts))
+
+	l1Genesis, err := inspect.L1Genesis(st)
+	require.NoError(t, err)
+
+	// Genesis allocs should contain deployed contracts.
+	require.NotEmpty(t, l1Genesis.Alloc)
+
+	// Chain ID should match intent.
+	require.Equal(t, new(big.Int).SetUint64(intent.L1ChainID), l1Genesis.Config.ChainID)
+
+	// Timestamp should match configured value.
+	require.EqualValues(t, customTimestamp, l1Genesis.Timestamp)
+
+	// Gas limit should match configured value.
+	require.EqualValues(t, customGasLimit, l1Genesis.GasLimit)
+
+	// Prague should be activated at genesis (offset 0).
+	require.NotNil(t, l1Genesis.Config.PragueTime)
+	require.EqualValues(t, customTimestamp, *l1Genesis.Config.PragueTime)
+
+	// ToBlock should produce a valid block with a non-zero state root.
+	block := l1Genesis.ToBlock()
+	require.NotZero(t, block.Root())
+	require.NotZero(t, block.Hash())
+
+	// The state root should match what SealL1DevGenesis computed.
+	require.NotNil(t, st.L1DevGenesis)
+	require.NotNil(t, st.L1DevGenesis.StateHash)
+	require.Equal(t, *st.L1DevGenesis.StateHash, block.Root(),
+		"inspect L1Genesis state root should match SealL1DevGenesis state root")
+}

--- a/op-devstack/sysgo/deployer.go
+++ b/op-devstack/sysgo/deployer.go
@@ -365,16 +365,9 @@ func WithCustomGasToken(name, symbol string, initialLiquidity *big.Int, liquidit
 }
 
 func (wb *worldBuilder) buildL1Genesis() {
-	wb.require.NotNil(wb.output.L1DevGenesis, "must have L1 genesis outer config")
-	wb.require.NotNil(wb.output.L1StateDump, "must have L1 genesis alloc")
-
-	genesisOuter := wb.output.L1DevGenesis
-	genesisAlloc := wb.output.L1StateDump.Data.Accounts
-	genesisCfg := *genesisOuter
-	genesisCfg.StateHash = nil
-	genesisCfg.Alloc = genesisAlloc
-
-	wb.outL1Genesis = &genesisCfg
+	l1Genesis, err := inspect.L1Genesis(wb.output)
+	wb.require.NoError(err, "need L1 genesis")
+	wb.outL1Genesis = l1Genesis
 }
 
 func (wb *worldBuilder) buildL2Genesis() {


### PR DESCRIPTION
## Summary

- Add `op-deployer inspect l1-genesis` CLI command and `inspect.L1Genesis()` public API function
- Reconstructs L1 genesis from deployment state (`L1StateDump` + `AppliedIntent.L1DevGenesisParams`) using the same `genesis.NewL1GenesisMinimal()` as `SealL1DevGenesis`
- Update op-devstack's `buildL1Genesis()` to call `inspect.L1Genesis()` instead of inline reconstruction, matching the pattern already used by `buildL2Genesis()` → `inspect.GenesisAndRollup()`

## Motivation

`State.L1DevGenesis` is tagged `json:"-"` — it's computed in-memory during the pipeline but not serialized to `state.json`. This means:
1. op-devstack reimplements L1 genesis reconstruction inline
2. External consumers need custom Go scripts to extract L1 genesis from state

Adding `inspect.L1Genesis()` closes this gap with a single, shared implementation.

## Test plan

- [x] `TestL1Genesis` — runs full deployment pipeline, calls `inspect.L1Genesis()`, verifies non-empty allocs, correct chain ID, timestamp, gas limit, Prague activation, and that the state root matches `SealL1DevGenesis`
- [x] `just lint-go` passes
- [x] `go build ./op-deployer/... ./op-devstack/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)