### PR TITLE
chore(ci): move op-e2e-cannon-tests to Docker with test-level parallelism

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -1798,6 +1798,15 @@ jobs:
           name: build cannon
           command: just cannon
       - run:
+          name: verify kona-host binary
+          command: |
+            echo "=== kona-host binary ==="
+            ls -la rust/target/release/kona-host || echo "kona-host not found!"
+            echo "=== ldd output ==="
+            ldd rust/target/release/kona-host 2>&1 || echo "ldd failed"
+            echo "=== running kona-host --help ==="
+            rust/target/release/kona-host --help 2>&1 || echo "kona-host --help exited with $?"
+      - run:
           name: run tests
           no_output_timeout: <<parameters.no_output_timeout>>
           command: |

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -1798,14 +1798,10 @@ jobs:
           name: build cannon
           command: just cannon
       - run:
-          name: verify kona-host binary
+          name: build kona-host (native for machine executor)
           command: |
-            echo "=== kona-host binary ==="
-            ls -la rust/target/release/kona-host || echo "kona-host not found!"
-            echo "=== ldd output ==="
-            ldd rust/target/release/kona-host 2>&1 || echo "ldd failed"
-            echo "=== running kona-host --help ==="
-            rust/target/release/kona-host --help 2>&1 || echo "kona-host --help exited with $?"
+            cd rust && cargo build --release -p kona-host
+          no_output_timeout: 30m
       - run:
           name: run tests
           no_output_timeout: <<parameters.no_output_timeout>>

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -1798,11 +1798,6 @@ jobs:
           name: build cannon
           command: just cannon
       - run:
-          name: build kona-host (native for machine executor)
-          command: |
-            cd rust && cargo build --release -p kona-host
-          no_output_timeout: 30m
-      - run:
           name: run tests
           no_output_timeout: <<parameters.no_output_timeout>>
           command: |

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -1703,10 +1703,14 @@ jobs:
         description: Number machines to distribute the tests across
         type: integer
         default: 1
+      ip_ranges:
+        description: Whether to use CircleCI IP ranges (adds credit surcharge)
+        type: boolean
+        default: true
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: 2xlarge
-    circleci_ip_ranges: true
+    circleci_ip_ranges: <<parameters.ip_ranges>>
     parallelism: <<parameters.parallelism>>
     steps:
       - utils/checkout-with-mise:
@@ -1741,77 +1745,6 @@ jobs:
           name: Clean up op-deployer artifacts
           command: |
             rm -rf ~/.op-deployer/*
-          when: always
-      - store_artifacts:
-          path: testlogs.tar.gz
-          when: always
-      - when:
-          condition: "<<parameters.notify>>"
-          steps:
-            - notify-failures-on-develop:
-                mentions: "<<parameters.mentions>>"
-
-  go-tests-with-fault-proof-deps:
-    parameters:
-      notify:
-        description: Whether to notify on failure
-        type: boolean
-        default: false
-      mentions:
-        description: Slack user or group to mention when notifying of failures
-        type: string
-        default: ""
-      resource_class:
-        description: Machine resource class
-        type: string
-        default: 2xlarge
-      no_output_timeout:
-        description: Timeout for when CircleCI kills the job if there's no output
-        type: string
-        default: 60m
-      test_timeout:
-        description: Timeout for running tests
-        type: string
-        default: 10m
-      environment_overrides:
-        description: Environment overrides
-        type: string
-        default: ""
-    docker:
-      - image: <<pipeline.parameters.c-default_docker_image>>
-    resource_class: <<parameters.resource_class>>
-    steps:
-      - utils/checkout-with-mise:
-          checkout-method: blobless
-          enable-mise-cache: true
-      - attach_workspace:
-          at: .
-      - run:
-          name: build op-program-client
-          command: just op-program-client
-          working_directory: op-program
-      - run:
-          name: build op-program-host
-          command: just op-program-host
-          working_directory: op-program
-      - run:
-          name: build cannon
-          command: just cannon
-      - run:
-          name: run tests
-          no_output_timeout: <<parameters.no_output_timeout>>
-          command: |
-            <<parameters.environment_overrides>>
-            export TEST_TIMEOUT=<<parameters.test_timeout>>
-            just go-tests-fraud-proofs-ci
-      - codecov/upload:
-          disable_search: true
-          files: ./coverage.out
-      - store_test_results:
-          path: ./tmp/test-results
-      - run:
-          name: Compress test logs
-          command: tar -czf testlogs.tar.gz -C ./tmp testlogs
           when: always
       - store_artifacts:
           path: testlogs.tar.gz
@@ -3012,13 +2945,15 @@ workflows:
           rust_files_changed: << pipeline.parameters.c-rust_files_changed >>
           context:
             - circleci-repo-readonly-authenticated-github-token
-      - go-tests-with-fault-proof-deps:
+      - go-tests:
           name: op-e2e-cannon-tests
+          rule: go-tests-fraud-proofs-ci
+          parallelism: 4
+          ip_ranges: false
+          no_output_timeout: 45m
+          test_timeout: 120m
           notify: true
           mentions: "@proofs-team"
-          no_output_timeout: 90m
-          test_timeout: 480m
-          resource_class: 2xlarge
           context:
             - slack
             - circleci-repo-readonly-authenticated-github-token

--- a/justfile
+++ b/justfile
@@ -351,7 +351,7 @@ go-tests-fraud-proofs-ci:
       echo "Found $TOTAL_TESTS tests to split across $NODE_TOTAL nodes"
 
       # Split by timings (falls back to name-based if no timing data yet)
-      circleci tests split --split-by=timings --timings-type=name /tmp/tests.txt > /tmp/tests_shard.txt
+      circleci tests split --split-by=timings --timings-type=testname /tmp/tests.txt > /tmp/tests_shard.txt
 
       SHARD_COUNT=$(wc -l < /tmp/tests_shard.txt | tr -d ' ')
       echo "Node $NODE_INDEX/$NODE_TOTAL running $SHARD_COUNT tests:"

--- a/justfile
+++ b/justfile
@@ -351,7 +351,7 @@ go-tests-fraud-proofs-ci:
       echo "Found $TOTAL_TESTS tests to split across $NODE_TOTAL nodes"
 
       # Split by timings (falls back to name-based if no timing data yet)
-      circleci tests split --split-by=timings /tmp/tests.txt > /tmp/tests_shard.txt
+      circleci tests split --split-by=timings --timings-type=name /tmp/tests.txt > /tmp/tests_shard.txt
 
       SHARD_COUNT=$(wc -l < /tmp/tests_shard.txt | tr -d ' ')
       echo "Node $NODE_INDEX/$NODE_TOTAL running $SHARD_COUNT tests:"

--- a/justfile
+++ b/justfile
@@ -311,12 +311,20 @@ go-tests-ci-kona-action:
   just _go-tests-ci-internal "-count=1 -timeout 60m -run Test_ProgramAction"
 
 # Runs fraud proofs Go tests with gotestsum for CI.
+# Builds fraud proof dependencies, then runs tests with optional CircleCI test splitting.
 [script('bash')]
 go-tests-fraud-proofs-ci:
   set -euo pipefail
+
+  # Build fraud proof dependencies (each parallel node builds its own)
+  echo "Building fraud proof dependencies..."
+  (cd op-program && just op-program-client)
+  (cd op-program && just op-program-host)
+  just cannon
+
   echo "Setting up test directories..."
   mkdir -p ./tmp/test-results ./tmp/testlogs
-  echo "Running Go tests with gotestsum..."
+
   export ENABLE_KURTOSIS=true
   export OP_E2E_CANNON_ENABLED="true"
   export OP_E2E_USE_HTTP=true
@@ -327,13 +335,53 @@ go-tests-fraud-proofs-ci:
   export MAINNET_RPC_URL="https://ci-mainnet-l1-archive.optimism.io"
   export NAT_INTEROP_LOADTEST_TARGET=10
   export NAT_INTEROP_LOADTEST_TIMEOUT=30s
-  ./ops/scripts/gotestsum-split.sh --format=testname \
-      --junitfile=./tmp/test-results/results.xml \
-      --jsonfile=./tmp/testlogs/log.json \
-      --rerun-fails=3 \
-      --rerun-fails-max-failures=50 \
-      --packages="{{FRAUD_PROOF_TEST_PKGS}}" \
-      -- -parallel="$PARALLEL" -coverprofile=coverage.out -timeout={{TEST_TIMEOUT}}
+
+  if [ -n "${CIRCLE_NODE_TOTAL:-}" ] && [ "$CIRCLE_NODE_TOTAL" -gt 1 ]; then
+      NODE_INDEX=${CIRCLE_NODE_INDEX:-0}
+      NODE_TOTAL=${CIRCLE_NODE_TOTAL:-1}
+
+      # Enumerate top-level test functions
+      go test -list '^Test' ./op-e2e/faultproofs/... 2>/dev/null | grep -E '^Test' > /tmp/tests.txt
+
+      TOTAL_TESTS=$(wc -l < /tmp/tests.txt | tr -d ' ')
+      if [ "$TOTAL_TESTS" -eq 0 ]; then
+          echo "ERROR: no tests found in ./op-e2e/faultproofs/..."
+          exit 1
+      fi
+      echo "Found $TOTAL_TESTS tests to split across $NODE_TOTAL nodes"
+
+      # Split by timings (falls back to name-based if no timing data yet)
+      circleci tests split --split-by=timings /tmp/tests.txt > /tmp/tests_shard.txt
+
+      SHARD_COUNT=$(wc -l < /tmp/tests_shard.txt | tr -d ' ')
+      echo "Node $NODE_INDEX/$NODE_TOTAL running $SHARD_COUNT tests:"
+      cat /tmp/tests_shard.txt
+
+      if [ "$SHARD_COUNT" -eq 0 ]; then
+          echo "No tests assigned to this node, skipping."
+          exit 0
+      fi
+
+      # Build -run regex: ^(TestFoo|TestBar|TestBaz)$
+      RUN_REGEX="^($(paste -sd '|' /tmp/tests_shard.txt))$"
+
+      ./ops/scripts/gotestsum-split.sh --format=testname \
+          --junitfile=./tmp/test-results/results-"$NODE_INDEX".xml \
+          --jsonfile=./tmp/testlogs/log-"$NODE_INDEX".json \
+          --rerun-fails=3 \
+          --rerun-fails-max-failures=50 \
+          --packages="{{FRAUD_PROOF_TEST_PKGS}}" \
+          -- -parallel="$PARALLEL" -coverprofile=coverage-"$NODE_INDEX".out \
+             -run "$RUN_REGEX" -timeout={{TEST_TIMEOUT}} -tags="ci"
+  else
+      ./ops/scripts/gotestsum-split.sh --format=testname \
+          --junitfile=./tmp/test-results/results.xml \
+          --jsonfile=./tmp/testlogs/log.json \
+          --rerun-fails=3 \
+          --rerun-fails-max-failures=50 \
+          --packages="{{FRAUD_PROOF_TEST_PKGS}}" \
+          -- -parallel="$PARALLEL" -coverprofile=coverage.out -timeout={{TEST_TIMEOUT}}
+  fi
 
 # Runs comprehensive Go tests (alias for go-tests).
 test: go-tests


### PR DESCRIPTION
**Stacked on ethereum-optimism/optimism#19791** — review that PR first.

## Summary

- Migrate `op-e2e-cannon-tests` from machine executor to Docker (`go-tests` template) with `parallelism: 4`
- Add test-level splitting via `circleci tests split --split-by=timings` (63 tests across 4 nodes)
- Parameterize `circleci_ip_ranges` in `go-tests` template (new `ip_ranges` boolean, default `true`) — cannon tests opt out with `ip_ranges: false`
- Delete `go-tests-with-fault-proof-deps` job template (only had one user)
- Move fraud proof binary builds (op-program-client, op-program-host, cannon) into the justfile target

### Why

The machine executor was never needed — cannon e2e tests are pure Go, no Docker-in-Docker or privileged operations. Machine xlarge costs 100 credits/min vs Docker 2xlarge at 80 credits/min (without IP ranges surcharge).

### Expected impact

- Wall-clock time: ~4-8 hours → ~1-2 hours
- Credit cost: roughly neutral or lower
- Splitting improves automatically via CircleCI timing data after first run

### Intentional changes

- **Codecov upload dropped** — the `go-tests` template doesn't upload coverage; low value for e2e tests
- **Resource class changed** — xlarge machine (8 CPU) → 2xlarge Docker (16 CPU) per node
- **Build steps merged** — op-program-client/host/cannon builds now run inside the justfile target (each node builds its own, cached via go build cache)

## Test plan

- [ ] CI passes on this PR (the cannon tests themselves only run on develop, but config validation should pass)
- [ ] Verify `go-tests-with-fault-proof-deps` has no remaining references
- [ ] After merge to develop: verify all 4 parallel nodes start, each runs a subset of tests, job passes
- [ ] Verify JUnit XML stored per node (check CircleCI "Test" tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)