### PR TITLE
fix(op-acceptance): mark varied block time fault proof tests as flaky

### DIFF
--- a/op-acceptance-tests/tests/interop/proofs/serial/interop_fault_proofs_test.go
+++ b/op-acceptance-tests/tests/interop/proofs/serial/interop_fault_proofs_test.go
@@ -26,6 +26,9 @@ func TestInteropFaultProofs_ConsolidateValidCrossChainMessage(gt *testing.T) {
 
 func TestInteropFaultProofs_VariedBlockTimes(gt *testing.T) {
 	t := devtest.SerialT(gt)
+	// TODO(#19828): endTimestamp may align with a no-op transition for the slower chain,
+	// causing kona to skip the L1 data sufficiency check.
+	t.MarkFlaky("ethereum-optimism/optimism#19828")
 	sys := presets.NewSimpleInteropSupernodeProofs(
 		t,
 		presets.WithChallengerCannonKonaEnabled(),
@@ -39,6 +42,9 @@ func TestInteropFaultProofs_VariedBlockTimes(gt *testing.T) {
 
 func TestInteropFaultProofs_VariedBlockTimes_FasterChainB(gt *testing.T) {
 	t := devtest.SerialT(gt)
+	// TODO(#19828): endTimestamp may align with a no-op transition for the slower chain,
+	// causing kona to skip the L1 data sufficiency check.
+	t.MarkFlaky("ethereum-optimism/optimism#19828")
 	sys := presets.NewSimpleInteropSupernodeProofs(
 		t,
 		presets.WithChallengerCannonKonaEnabled(),

--- a/op-acceptance-tests/tests/isthmus/preinterop/interop_fault_proofs_test.go
+++ b/op-acceptance-tests/tests/isthmus/preinterop/interop_fault_proofs_test.go
@@ -30,6 +30,9 @@ func TestPreinteropFaultProofs_UnsafeProposal(gt *testing.T) {
 
 func TestPreinteropFaultProofs_VariedBlockTimes(gt *testing.T) {
 	t := devtest.SerialT(gt)
+	// TODO(#19828): endTimestamp may align with a no-op transition for the slower chain,
+	// causing kona to skip the L1 data sufficiency check.
+	t.MarkFlaky("ethereum-optimism/optimism#19828")
 	sys := presets.NewSimpleInteropIsthmusSuper(
 		t,
 		presets.WithChallengerCannonKonaEnabled(),
@@ -43,6 +46,9 @@ func TestPreinteropFaultProofs_VariedBlockTimes(gt *testing.T) {
 
 func TestPreinteropFaultProofs_VariedBlockTimes_FasterChainB(gt *testing.T) {
 	t := devtest.SerialT(gt)
+	// TODO(#19828): endTimestamp may align with a no-op transition for the slower chain,
+	// causing kona to skip the L1 data sufficiency check.
+	t.MarkFlaky("ethereum-optimism/optimism#19828")
 	sys := presets.NewSimpleInteropIsthmusSuper(
 		t,
 		presets.WithChallengerCannonKonaEnabled(),


### PR DESCRIPTION
## Summary

- Marks all 4 `VariedBlockTimes` fault proof tests (interop + preinterop) as flaky with `t.MarkFlaky()`, referencing tracking issues
- These tests were unskipped in ethereum-optimism/optimism#19805 but still fail intermittently

## Root Cause

When `endTimestamp` from `nextTimestampAfterSafeHeads()` falls on a no-op boundary for the slower chain (e.g. the 2s chain), kona correctly takes the no-op path — there's no block to derive, so no L1 data is needed. But the `FirstChainReachesL1Head` and `SuperRootInvalidIfUnsupportedByL1Data` subtests assume every chain has a real transition to validate and expect `InvalidTransition` when L1 data is missing.

The fix is to ensure `endTimestamp` aligns with a block timestamp for ALL chains, or to account for no-op transitions in the L1-head-constrained subtests.

## Tracking

- ethereum-optimism/optimism#19828 — `FirstChainReachesL1Head-fpp`
- ethereum-optimism/optimism#19829 — `SuperRootInvalidIfUnsupportedByL1Data-fpp`

## Test plan

- [ ] Verify the 4 tests are marked flaky (failures become skips in CI)
- [ ] No other test changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)