### PR TITLE
fix(op-acceptance): align endTimestamp to block boundaries for all chains

### DIFF
--- a/op-acceptance-tests/tests/interop/proofs/serial/interop_fault_proofs_test.go
+++ b/op-acceptance-tests/tests/interop/proofs/serial/interop_fault_proofs_test.go
@@ -26,6 +26,9 @@ func TestInteropFaultProofs_ConsolidateValidCrossChainMessage(gt *testing.T) {
 
 func TestInteropFaultProofs_VariedBlockTimes(gt *testing.T) {
 	t := devtest.SerialT(gt)
+	// TODO(#19828): endTimestamp may align with a no-op transition for the slower chain,
+	// causing kona to skip the L1 data sufficiency check.
+	t.MarkFlaky("ethereum-optimism/optimism#19828")
 	sys := presets.NewSimpleInteropSupernodeProofs(
 		t,
 		presets.WithChallengerCannonKonaEnabled(),
@@ -39,6 +42,9 @@ func TestInteropFaultProofs_VariedBlockTimes(gt *testing.T) {
 
 func TestInteropFaultProofs_VariedBlockTimes_FasterChainB(gt *testing.T) {
 	t := devtest.SerialT(gt)
+	// TODO(#19828): endTimestamp may align with a no-op transition for the slower chain,
+	// causing kona to skip the L1 data sufficiency check.
+	t.MarkFlaky("ethereum-optimism/optimism#19828")
 	sys := presets.NewSimpleInteropSupernodeProofs(
 		t,
 		presets.WithChallengerCannonKonaEnabled(),

--- a/op-acceptance-tests/tests/isthmus/preinterop/interop_fault_proofs_test.go
+++ b/op-acceptance-tests/tests/isthmus/preinterop/interop_fault_proofs_test.go
@@ -30,6 +30,9 @@ func TestPreinteropFaultProofs_UnsafeProposal(gt *testing.T) {
 
 func TestPreinteropFaultProofs_VariedBlockTimes(gt *testing.T) {
 	t := devtest.SerialT(gt)
+	// TODO(#19828): endTimestamp may align with a no-op transition for the slower chain,
+	// causing kona to skip the L1 data sufficiency check.
+	t.MarkFlaky("ethereum-optimism/optimism#19828")
 	sys := presets.NewSimpleInteropIsthmusSuper(
 		t,
 		presets.WithChallengerCannonKonaEnabled(),
@@ -43,6 +46,9 @@ func TestPreinteropFaultProofs_VariedBlockTimes(gt *testing.T) {
 
 func TestPreinteropFaultProofs_VariedBlockTimes_FasterChainB(gt *testing.T) {
 	t := devtest.SerialT(gt)
+	// TODO(#19828): endTimestamp may align with a no-op transition for the slower chain,
+	// causing kona to skip the L1 data sufficiency check.
+	t.MarkFlaky("ethereum-optimism/optimism#19828")
 	sys := presets.NewSimpleInteropIsthmusSuper(
 		t,
 		presets.WithChallengerCannonKonaEnabled(),

--- a/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
+++ b/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
@@ -86,6 +86,29 @@ func nextTimestampAfterSafeHeads(t devtest.T, chains []*chain) uint64 {
 		}
 	}
 	t.Require().NotZero(ts, "end timestamp must be non-zero")
+
+	// Advance ts until every chain produces a new block at ts compared to ts-1.
+	// With varied block times (e.g. 1s and 2s), the initial ts may land on a
+	// no-op boundary for the slower chain. The L1-head-constrained subtests
+	// assume every chain has a real transition to validate, so we need all
+	// chains to have TargetBlockNumber(ts) > TargetBlockNumber(ts-1).
+	for {
+		allNew := true
+		for _, c := range chains {
+			curr, err := c.Cfg.TargetBlockNumber(ts)
+			t.Require().NoError(err)
+			prev, err := c.Cfg.TargetBlockNumber(ts - 1)
+			t.Require().NoError(err)
+			if curr <= prev {
+				allNew = false
+				break
+			}
+		}
+		if allNew {
+			break
+		}
+		ts++
+	}
 	return ts
 }
 


### PR DESCRIPTION
## Summary

- Fixes `nextTimestampAfterSafeHeads()` to advance `endTimestamp` until every chain produces a new block (not a no-op transition)
- With varied block times (1s + 2s), the initial timestamp can land on a no-op boundary for the slower chain, causing the `FirstChainReachesL1Head` and `SuperRootInvalidIfUnsupportedByL1Data` subtests to fail

## Root Cause

When `endTimestamp` doesn't align with the 2s chain's block time, `TargetBlockNumber(endTimestamp) == TargetBlockNumber(endTimestamp - 1)` for that chain. Kona correctly takes the no-op path (no block to derive, no L1 data needed), but the test expects `InvalidTransition`.

The fix advances `endTimestamp` until `TargetBlockNumber(ts) > TargetBlockNumber(ts - 1)` for all chains — O(max_block_time) iterations, so at most 1 extra second for the 1s+2s case.

## Stack

- Base: ethereum-optimism/optimism#19830 (marks tests as flaky)
- **This PR**: fixes the underlying issue

After this merges, the `MarkFlaky` calls from ethereum-optimism/optimism#19830 become no-ops (tests pass consistently) and can be removed in a follow-up.

ethereum-optimism/optimism#19828
ethereum-optimism/optimism#19829

## Test plan

- [ ] `TestInteropFaultProofs_VariedBlockTimes` passes consistently
- [ ] `TestInteropFaultProofs_VariedBlockTimes_FasterChainB` passes consistently
- [ ] `TestPreinteropFaultProofs_VariedBlockTimes` passes consistently
- [ ] `TestPreinteropFaultProofs_VariedBlockTimes_FasterChainB` passes consistently
- [ ] Non-varied-block-time tests unaffected (all chains have 1s block time, loop is a no-op)

🤖 Generated with [Claude Code](https://claude.com/claude-code)