### PR TITLE
chore(ci): add test-level parallelism to memory-all-opn-op-geth

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -2771,7 +2771,7 @@ workflows:
       # IN-MEMORY (all) - op-node/op-geth
       - op-acceptance-tests:
           name: memory-all-opn-op-geth
-          parallelism: 2
+          parallelism: 3
           no_output_timeout: 120m
           context:
             - circleci-repo-readonly-authenticated-github-token

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -2771,7 +2771,7 @@ workflows:
       # IN-MEMORY (all) - op-node/op-geth
       - op-acceptance-tests:
           name: memory-all-opn-op-geth
-          parallelism: 3
+          parallelism: 2
           no_output_timeout: 120m
           context:
             - circleci-repo-readonly-authenticated-github-token

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -1839,10 +1839,15 @@ jobs:
         description: Timeout for when CircleCI kills the job if there's no output
         type: string
         default: 30m
+      parallelism:
+        description: Number of machines to distribute the tests across
+        type: integer
+        default: 1
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
     circleci_ip_ranges: true
     resource_class: 2xlarge+
+    parallelism: <<parameters.parallelism>>
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
@@ -2766,6 +2771,7 @@ workflows:
       # IN-MEMORY (all) - op-node/op-geth
       - op-acceptance-tests:
           name: memory-all-opn-op-geth
+          parallelism: 2
           no_output_timeout: 120m
           context:
             - circleci-repo-readonly-authenticated-github-token

--- a/op-acceptance-tests/justfile
+++ b/op-acceptance-tests/justfile
@@ -112,16 +112,50 @@ acceptance-test gate="":
         TEST_PACKAGES=("./op-acceptance-tests/tests/...")
     fi
 
+    # CircleCI test-level splitting
+    RUN_FLAG=""
+    JUNIT_FILE="$RESULTS_DIR/results.xml"
+    JSON_FILE="$LOG_DIR/raw_go_events.log"
+    if [ -n "${CIRCLE_NODE_TOTAL:-}" ] && [ "$CIRCLE_NODE_TOTAL" -gt 1 ]; then
+        NODE_INDEX=${CIRCLE_NODE_INDEX:-0}
+        NODE_TOTAL=${CIRCLE_NODE_TOTAL:-1}
+
+        go test -list '^Test' "${TEST_PACKAGES[@]}" 2>/dev/null | grep -E '^Test' > /tmp/tests.txt
+
+        TOTAL_TESTS=$(wc -l < /tmp/tests.txt | tr -d ' ')
+        if [ "$TOTAL_TESTS" -eq 0 ]; then
+            echo "ERROR: no tests found in packages: ${TEST_PACKAGES[*]}"
+            exit 1
+        fi
+        echo "Found $TOTAL_TESTS tests to split across $NODE_TOTAL nodes"
+
+        circleci tests split --split-by=timings /tmp/tests.txt > /tmp/tests_shard.txt
+
+        SHARD_COUNT=$(wc -l < /tmp/tests_shard.txt | tr -d ' ')
+        echo "Node $NODE_INDEX/$NODE_TOTAL running $SHARD_COUNT tests:"
+        cat /tmp/tests_shard.txt
+
+        if [ "$SHARD_COUNT" -eq 0 ]; then
+            echo "No tests assigned to this node, skipping."
+            exit 0
+        fi
+
+        RUN_FLAG="-run=^($(paste -sd '|' /tmp/tests_shard.txt))$"
+        JUNIT_FILE="$RESULTS_DIR/results-${NODE_INDEX}.xml"
+        JSON_FILE="$LOG_DIR/raw_go_events-${NODE_INDEX}.log"
+    fi
+
     set +e
     LOG_LEVEL="${LOG_LEVEL}" {{REPO_ROOT}}/ops/scripts/gotestsum-split.sh \
         --format testname \
-        --junitfile "$RESULTS_DIR/results.xml" \
-        --jsonfile "$LOG_DIR/raw_go_events.log" \
+        --junitfile "$JUNIT_FILE" \
+        --jsonfile "$JSON_FILE" \
         -- \
         -count=1 \
         -p "${JOBS}" \
         -parallel "${TEST_PARALLEL}" \
         -timeout "${TEST_TIMEOUT}" \
+        ${RUN_FLAG:+"$RUN_FLAG"} \
         "${TEST_PACKAGES[@]}" \
         2>&1 | tee "$LOG_DIR/all.log"
     TEST_STATUS=${PIPESTATUS[0]}

--- a/op-acceptance-tests/justfile
+++ b/op-acceptance-tests/justfile
@@ -129,7 +129,7 @@ acceptance-test gate="":
         fi
         echo "Found $TOTAL_TESTS tests to split across $NODE_TOTAL nodes"
 
-        circleci tests split --split-by=timings /tmp/tests.txt > /tmp/tests_shard.txt
+        circleci tests split --split-by=timings --timings-type=name /tmp/tests.txt > /tmp/tests_shard.txt
 
         SHARD_COUNT=$(wc -l < /tmp/tests_shard.txt | tr -d ' ')
         echo "Node $NODE_INDEX/$NODE_TOTAL running $SHARD_COUNT tests:"

--- a/op-acceptance-tests/justfile
+++ b/op-acceptance-tests/justfile
@@ -129,7 +129,7 @@ acceptance-test gate="":
         fi
         echo "Found $TOTAL_TESTS tests to split across $NODE_TOTAL nodes"
 
-        circleci tests split --split-by=timings --timings-type=name /tmp/tests.txt > /tmp/tests_shard.txt
+        circleci tests split --split-by=timings --timings-type=testname /tmp/tests.txt > /tmp/tests_shard.txt
 
         SHARD_COUNT=$(wc -l < /tmp/tests_shard.txt | tr -d ' ')
         echo "Node $NODE_INDEX/$NODE_TOTAL running $SHARD_COUNT tests:"


### PR DESCRIPTION
## Summary

- Add CircleCI test-level splitting to the acceptance test runner (`op-acceptance-tests/justfile`)
- When `CIRCLE_NODE_TOTAL > 1`: enumerate tests via `go test -list`, split with `circleci tests split --split-by=timings`, build `-run` regex
- Add `parallelism` parameter to `op-acceptance-tests` job template (default 1 — existing callers unchanged)
- Set `parallelism: 2` on `memory-all-opn-op-geth` only — the variant that runs all tests and is on the PR merge critical path

### Why

`memory-all-opn-op-geth` runs all ~153 acceptance tests on a single node in ~12 minutes. It's on the critical path for every PR merge via `ci-gate`. Splitting across 2 nodes should reduce wall-clock time to ~7 minutes.

### What's unchanged

- Gated variants (`memory-all-opn-op-reth`, `memory-all-kona-op-reth`) stay at parallelism=1 — they already finish in ~3 min
- Local runs (no `CIRCLE_NODE_TOTAL`) behave identically to today
- `memory-all` aggregator and `ci-gate` dependency chain unaffected

## Test plan

- [ ] CI passes on this PR
- [ ] After merge to develop: verify `memory-all-opn-op-geth` starts 2 parallel nodes
- [ ] Verify both nodes run a subset of tests and the job passes
- [ ] Verify gated variants still run with parallelism=1 (single node)
- [ ] Verify total test count across both nodes matches previous single-node runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)