### PR TITLE
supernode: Record full Output bytes with denied heads

### DIFF
--- a/op-supernode/supernode/activity/interop/algo.go
+++ b/op-supernode/supernode/activity/interop/algo.go
@@ -63,7 +63,7 @@ func (i *Interop) verifyInteropMessages(ts uint64, blocksAtTimestamp blockPerCha
 	result := Result{
 		Timestamp:    ts,
 		L2Heads:      make(blockPerChain),
-		InvalidHeads: make(blockPerChain),
+		InvalidHeads: make(map[eth.ChainID]InvalidHead),
 	}
 
 	if l1Inclusion, err := i.l1Inclusion(ts, blocksAtTimestamp); err != nil {
@@ -108,7 +108,11 @@ func (i *Interop) verifyInteropMessages(ts uint64, blocksAtTimestamp blockPerCha
 								"expected", expectedBlock.Hash,
 								"got", firstBlock.Hash,
 							)
-							result.InvalidHeads[chainID] = expectedBlock
+							invalid, err := i.newInvalidHead(chainID, expectedBlock)
+							if err != nil {
+								return Result{}, fmt.Errorf("chain %s: %w", chainID, err)
+							}
+							result.InvalidHeads[chainID] = invalid
 						}
 						result.L2Heads[chainID] = expectedBlock
 						continue
@@ -125,7 +129,11 @@ func (i *Interop) verifyInteropMessages(ts uint64, blocksAtTimestamp blockPerCha
 				"expected", expectedBlock.Hash,
 				"got", blockRef.Hash,
 			)
-			result.InvalidHeads[chainID] = expectedBlock
+			invalid, err := i.newInvalidHead(chainID, expectedBlock)
+			if err != nil {
+				return Result{}, fmt.Errorf("chain %s: %w", chainID, err)
+			}
+			result.InvalidHeads[chainID] = invalid
 			result.L2Heads[chainID] = expectedBlock
 			continue
 		}
@@ -149,7 +157,11 @@ func (i *Interop) verifyInteropMessages(ts uint64, blocksAtTimestamp blockPerCha
 
 		result.L2Heads[chainID] = expectedBlock
 		if !blockValid {
-			result.InvalidHeads[chainID] = expectedBlock
+			invalid, err := i.newInvalidHead(chainID, expectedBlock)
+			if err != nil {
+				return Result{}, fmt.Errorf("chain %s: %w", chainID, err)
+			}
+			result.InvalidHeads[chainID] = invalid
 		}
 	}
 

--- a/op-supernode/supernode/activity/interop/algo_test.go
+++ b/op-supernode/supernode/activity/interop/algo_test.go
@@ -495,7 +495,7 @@ func TestVerifyInteropMessages(t *testing.T) {
 				expectedBlock := eth.BlockID{Number: 100, Hash: common.HexToHash("0xExpected")}
 				require.False(t, result.IsValid())
 				require.Contains(t, result.InvalidHeads, chainID)
-				require.Equal(t, expectedBlock, result.InvalidHeads[chainID])
+				require.Equal(t, expectedBlock, result.InvalidHeads[chainID].BlockID)
 			},
 		},
 		{
@@ -930,8 +930,14 @@ func (m *algoMockChain) RewindEngine(ctx context.Context, timestamp uint64, inva
 	return nil
 }
 func (m *algoMockChain) BlockTime() uint64 { return 1 }
-func (m *algoMockChain) InvalidateBlock(ctx context.Context, height uint64, payloadHash common.Hash, decisionTimestamp uint64) (bool, error) {
+func (m *algoMockChain) InvalidateBlock(ctx context.Context, height uint64, payloadHash common.Hash, decisionTimestamp uint64, stateRoot, messagePasserStorageRoot eth.Bytes32) (bool, error) {
 	return false, nil
+}
+func (m *algoMockChain) OutputV0AtBlockNumber(ctx context.Context, l2BlockNum uint64) (*eth.OutputV0, error) {
+	return &eth.OutputV0{}, nil
+}
+func (m *algoMockChain) GetDeniedOutput(height uint64, payloadHash common.Hash) (*eth.OutputV0, error) {
+	return nil, nil
 }
 func (m *algoMockChain) PruneDeniedAtOrAfterTimestamp(timestamp uint64) (map[uint64][]common.Hash, error) {
 	return nil, nil

--- a/op-supernode/supernode/activity/interop/algo_test.go
+++ b/op-supernode/supernode/activity/interop/algo_test.go
@@ -24,10 +24,15 @@ import (
 // =============================================================================
 
 // newMockChainWithL1 creates a mock chain with the specified L1 block for OptimisticAt
-func newMockChainWithL1(chainID eth.ChainID, l1Block eth.BlockID) *algoMockChain {
+func newMockChainWithL1(chainID eth.ChainID, l1Block eth.BlockID, blocks ...eth.BlockID) *algoMockChain {
+	hashes := make(map[uint64]common.Hash, len(blocks))
+	for _, b := range blocks {
+		hashes[b.Number] = b.Hash
+	}
 	return &algoMockChain{
 		id:           chainID,
 		optimisticL1: l1Block,
+		blockHashes:  hashes,
 	}
 }
 
@@ -485,7 +490,7 @@ func TestVerifyInteropMessages(t *testing.T) {
 				interop := &Interop{
 					log:     gethlog.New(),
 					logsDBs: map[eth.ChainID]LogsDB{chainID: mockDB},
-					chains:  map[eth.ChainID]cc.ChainContainer{chainID: newMockChainWithL1(chainID, l1Block)},
+					chains:  map[eth.ChainID]cc.ChainContainer{chainID: newMockChainWithL1(chainID, l1Block, expectedBlock)},
 				}
 
 				return interop, 1000, map[eth.ChainID]eth.BlockID{chainID: expectedBlock}
@@ -534,7 +539,7 @@ func TestVerifyInteropMessages(t *testing.T) {
 					},
 					chains: map[eth.ChainID]cc.ChainContainer{
 						sourceChainID: newMockChainWithL1(sourceChainID, eth.BlockID{Number: 40, Hash: common.HexToHash("0xL1")}),
-						destChainID:   newMockChainWithL1(destChainID, eth.BlockID{Number: 40, Hash: common.HexToHash("0xL1")}),
+						destChainID:   newMockChainWithL1(destChainID, eth.BlockID{Number: 40, Hash: common.HexToHash("0xL1")}, destBlock),
 					},
 				}
 
@@ -585,7 +590,7 @@ func TestVerifyInteropMessages(t *testing.T) {
 					},
 					chains: map[eth.ChainID]cc.ChainContainer{
 						sourceChainID: newMockChainWithL1(sourceChainID, eth.BlockID{Number: 40, Hash: common.HexToHash("0xL1")}),
-						destChainID:   newMockChainWithL1(destChainID, eth.BlockID{Number: 40, Hash: common.HexToHash("0xL1")}),
+						destChainID:   newMockChainWithL1(destChainID, eth.BlockID{Number: 40, Hash: common.HexToHash("0xL1")}, destBlock),
 					},
 				}
 
@@ -629,7 +634,7 @@ func TestVerifyInteropMessages(t *testing.T) {
 					},
 					chains: map[eth.ChainID]cc.ChainContainer{
 						unknownSourceChain: newMockChainWithL1(unknownSourceChain, eth.BlockID{Number: 40, Hash: common.HexToHash("0xL1")}),
-						destChainID:        newMockChainWithL1(destChainID, eth.BlockID{Number: 40, Hash: common.HexToHash("0xL1")}),
+						destChainID:        newMockChainWithL1(destChainID, eth.BlockID{Number: 40, Hash: common.HexToHash("0xL1")}, destBlock),
 					},
 				}
 
@@ -682,7 +687,7 @@ func TestVerifyInteropMessages(t *testing.T) {
 					},
 					chains: map[eth.ChainID]cc.ChainContainer{
 						sourceChainID: newMockChainWithL1(sourceChainID, eth.BlockID{Number: 40, Hash: common.HexToHash("0xL1")}),
-						destChainID:   newMockChainWithL1(destChainID, eth.BlockID{Number: 40, Hash: common.HexToHash("0xL1")}),
+						destChainID:   newMockChainWithL1(destChainID, eth.BlockID{Number: 40, Hash: common.HexToHash("0xL1")}, destBlock),
 					},
 				}
 
@@ -739,7 +744,7 @@ func TestVerifyInteropMessages(t *testing.T) {
 						invalidChainID: invalidDB,
 					},
 					chains: map[eth.ChainID]cc.ChainContainer{
-						invalidChainID: newMockChainWithL1(invalidChainID, eth.BlockID{Number: 40, Hash: common.HexToHash("0xL1")}),
+						invalidChainID: newMockChainWithL1(invalidChainID, eth.BlockID{Number: 40, Hash: common.HexToHash("0xL1")}, invalidBlock),
 						sourceChainID:  newMockChainWithL1(sourceChainID, eth.BlockID{Number: 40, Hash: common.HexToHash("0xL1")}),
 						validChainID:   newMockChainWithL1(validChainID, eth.BlockID{Number: 40, Hash: common.HexToHash("0xL1")}),
 					},
@@ -889,6 +894,7 @@ type algoMockChain struct {
 	optimisticL2    eth.BlockID
 	optimisticL1    eth.BlockID
 	optimisticAtErr error
+	blockHashes     map[uint64]common.Hash
 }
 
 func (m *algoMockChain) ID() eth.ChainID                                  { return m.id }
@@ -934,7 +940,11 @@ func (m *algoMockChain) InvalidateBlock(ctx context.Context, height uint64, payl
 	return false, nil
 }
 func (m *algoMockChain) OutputV0AtBlockNumber(ctx context.Context, l2BlockNum uint64) (*eth.OutputV0, error) {
-	return &eth.OutputV0{}, nil
+	out := &eth.OutputV0{}
+	if m.blockHashes != nil {
+		out.BlockHash = m.blockHashes[l2BlockNum]
+	}
+	return out, nil
 }
 func (m *algoMockChain) GetDeniedOutput(height uint64, payloadHash common.Hash) (*eth.OutputV0, error) {
 	return nil, nil

--- a/op-supernode/supernode/activity/interop/cycle.go
+++ b/op-supernode/supernode/activity/interop/cycle.go
@@ -3,6 +3,7 @@ package interop
 import (
 	"cmp"
 	"errors"
+	"fmt"
 	"slices"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -210,9 +211,13 @@ func (i *Interop) verifyCycleMessages(ts uint64, blocksAtTimestamp map[eth.Chain
 		// (bystander chains that have same-ts EMs but aren't part of the cycle are spared)
 		cycleChains := collectCycleParticipants(graph)
 		if len(cycleChains) > 0 {
-			result.InvalidHeads = make(map[eth.ChainID]eth.BlockID)
+			result.InvalidHeads = make(map[eth.ChainID]InvalidHead)
 			for chainID := range cycleChains {
-				result.InvalidHeads[chainID] = blocksAtTimestamp[chainID]
+				invalid, err := i.newInvalidHead(chainID, blocksAtTimestamp[chainID])
+				if err != nil {
+					return Result{}, fmt.Errorf("chain %s: %w", chainID, err)
+				}
+				result.InvalidHeads[chainID] = invalid
 			}
 		}
 	}

--- a/op-supernode/supernode/activity/interop/decide_test.go
+++ b/op-supernode/supernode/activity/interop/decide_test.go
@@ -81,8 +81,8 @@ func TestDecideVerifiedResult(t *testing.T) {
 		L2Heads: map[eth.ChainID]eth.BlockID{
 			eth.ChainIDFromUInt64(1): {Hash: common.HexToHash("0xa"), Number: 100},
 		},
-		InvalidHeads: map[eth.ChainID]eth.BlockID{
-			eth.ChainIDFromUInt64(2): {Hash: common.HexToHash("0xbad"), Number: 200},
+		InvalidHeads: map[eth.ChainID]InvalidHead{
+			eth.ChainIDFromUInt64(2): {BlockID: eth.BlockID{Hash: common.HexToHash("0xbad"), Number: 200}},
 		},
 	}
 

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -400,7 +400,7 @@ func (i *Interop) verify(ts uint64, blocksAtTS map[eth.ChainID]eth.BlockID) (Res
 
 	if len(cycleResult.InvalidHeads) > 0 {
 		if result.InvalidHeads == nil {
-			result.InvalidHeads = make(map[eth.ChainID]eth.BlockID)
+			result.InvalidHeads = make(map[eth.ChainID]InvalidHead)
 		}
 		for chainID, invalidBlock := range cycleResult.InvalidHeads {
 			result.InvalidHeads[chainID] = invalidBlock
@@ -408,6 +408,25 @@ func (i *Interop) verify(ts uint64, blocksAtTS map[eth.ChainID]eth.BlockID) (Res
 	}
 
 	return result, nil
+}
+
+// newInvalidHead constructs a fully-formed InvalidHead with the output preimage
+// fields already attached. Returns an error if the output cannot be computed —
+// at verification time the engine should always have the block, so failure
+// indicates a transient RPC issue or a serious invariant violation.
+func (i *Interop) newInvalidHead(chainID eth.ChainID, blockID eth.BlockID) (InvalidHead, error) {
+	head := InvalidHead{BlockID: blockID}
+	chain, ok := i.chains[chainID]
+	if !ok {
+		return head, fmt.Errorf("chain %s not found", chainID)
+	}
+	outputV0, err := chain.OutputV0AtBlockNumber(i.ctx, blockID.Number)
+	if err != nil {
+		return head, fmt.Errorf("chain %s: failed to compute OutputV0 for block %d: %w", chainID, blockID.Number, err)
+	}
+	head.StateRoot = outputV0.StateRoot
+	head.MessagePasserStorageRoot = outputV0.MessagePasserStorageRoot
+	return head, nil
 }
 
 func (i *Interop) buildPendingTransition(output StepOutput, obs RoundObservation) (PendingTransition, error) {
@@ -457,11 +476,13 @@ func (i *Interop) applyPendingTransition(pending PendingTransition) (bool, error
 			return false, nil
 		}
 		invalidations := make([]PendingInvalidation, 0, len(pending.Result.InvalidHeads))
-		for chainID, blockID := range pending.Result.InvalidHeads {
+		for chainID, invalidHead := range pending.Result.InvalidHeads {
 			invalidations = append(invalidations, PendingInvalidation{
-				ChainID:   chainID,
-				BlockID:   blockID,
-				Timestamp: pending.Result.Timestamp,
+				ChainID:                  chainID,
+				BlockID:                  invalidHead.BlockID,
+				Timestamp:                pending.Result.Timestamp,
+				StateRoot:                invalidHead.StateRoot,
+				MessagePasserStorageRoot: invalidHead.MessagePasserStorageRoot,
 			})
 		}
 		sort.Slice(invalidations, func(i, j int) bool {
@@ -482,7 +503,7 @@ func (i *Interop) applyPendingTransition(pending PendingTransition) (bool, error
 		}
 		var failedAny bool
 		for _, p := range invalidations {
-			if err := i.invalidateBlock(p.ChainID, p.BlockID, p.Timestamp); err != nil {
+			if err := i.invalidateBlock(p.ChainID, p.BlockID, p.Timestamp, p.StateRoot, p.MessagePasserStorageRoot); err != nil {
 				i.log.Error("invalidation failed, transition preserved for retry on restart",
 					"chain", p.ChainID, "block", p.BlockID, "err", err)
 				failedAny = true
@@ -795,11 +816,11 @@ func (i *Interop) Reset(chainID eth.ChainID, timestamp uint64, invalidatedBlock 
 
 // invalidateBlock notifies the chain container to add the block to the denylist
 // and potentially rewind if the chain is currently using that block.
-func (i *Interop) invalidateBlock(chainID eth.ChainID, blockID eth.BlockID, decisionTimestamp uint64) error {
+func (i *Interop) invalidateBlock(chainID eth.ChainID, blockID eth.BlockID, decisionTimestamp uint64, stateRoot, messagePasserStorageRoot eth.Bytes32) error {
 	chain, ok := i.chains[chainID]
 	if !ok {
 		return fmt.Errorf("chain %s not found", chainID)
 	}
-	_, err := chain.InvalidateBlock(i.ctx, blockID.Number, blockID.Hash, decisionTimestamp)
+	_, err := chain.InvalidateBlock(i.ctx, blockID.Number, blockID.Hash, decisionTimestamp, stateRoot, messagePasserStorageRoot)
 	return err
 }

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -424,6 +424,10 @@ func (i *Interop) newInvalidHead(chainID eth.ChainID, blockID eth.BlockID) (Inva
 	if err != nil {
 		return head, fmt.Errorf("chain %s: failed to compute OutputV0 for block %d: %w", chainID, blockID.Number, err)
 	}
+	if outputV0.BlockHash != blockID.Hash {
+		return head, fmt.Errorf("chain %s: block %d hash changed (expected %s, got %s): possible reorg",
+			chainID, blockID.Number, blockID.Hash, outputV0.BlockHash)
+	}
 	head.StateRoot = outputV0.StateRoot
 	head.MessagePasserStorageRoot = outputV0.MessagePasserStorageRoot
 	return head, nil

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -621,8 +621,8 @@ func TestProgressInteropWithCycleVerify(t *testing.T) {
 					return Result{
 						Timestamp: ts,
 						L2Heads:   blocks,
-						InvalidHeads: map[eth.ChainID]eth.BlockID{
-							chain8453: blocks[chain8453],
+						InvalidHeads: map[eth.ChainID]InvalidHead{
+							chain8453: {BlockID: blocks[chain8453]},
 						},
 					}, nil
 				}
@@ -675,8 +675,8 @@ func TestProgressInteropWithCycleVerify(t *testing.T) {
 					return Result{
 						Timestamp: ts,
 						L2Heads:   blocks,
-						InvalidHeads: map[eth.ChainID]eth.BlockID{
-							chain10: blocks[chain10],
+						InvalidHeads: map[eth.ChainID]InvalidHead{
+							chain10: {BlockID: blocks[chain10]},
 						},
 					}, nil
 				}
@@ -686,8 +686,8 @@ func TestProgressInteropWithCycleVerify(t *testing.T) {
 					return Result{
 						Timestamp: ts,
 						L2Heads:   blocks,
-						InvalidHeads: map[eth.ChainID]eth.BlockID{
-							chain8453: blocks[chain8453],
+						InvalidHeads: map[eth.ChainID]InvalidHead{
+							chain8453: {BlockID: blocks[chain8453]},
 						},
 					}, nil
 				}
@@ -855,8 +855,8 @@ func TestApplyResultCompat(t *testing.T) {
 					L2Heads: map[eth.ChainID]eth.BlockID{
 						mock.id: {Number: 500, Hash: common.HexToHash("0xL2")},
 					},
-					InvalidHeads: map[eth.ChainID]eth.BlockID{
-						mock.id: {Number: 500, Hash: common.HexToHash("0xBAD")},
+					InvalidHeads: map[eth.ChainID]InvalidHead{
+						mock.id: {BlockID: eth.BlockID{Number: 500, Hash: common.HexToHash("0xBAD")}},
 					},
 				}
 
@@ -901,7 +901,7 @@ func TestInvalidateBlock(t *testing.T) {
 			run: func(t *testing.T, h *interopTestHarness) {
 				mock := h.Mock(10)
 				blockID := eth.BlockID{Number: 500, Hash: common.HexToHash("0xBAD")}
-				err := h.interop.invalidateBlock(mock.id, blockID, 0)
+				err := h.interop.invalidateBlock(mock.id, blockID, 0, eth.Bytes32{}, eth.Bytes32{})
 				require.NoError(t, err)
 
 				require.Len(t, mock.invalidateBlockCalls, 1)
@@ -918,7 +918,7 @@ func TestInvalidateBlock(t *testing.T) {
 				mock := h.Mock(10)
 				unknownChain := eth.ChainIDFromUInt64(999)
 				blockID := eth.BlockID{Number: 500, Hash: common.HexToHash("0xBAD")}
-				err := h.interop.invalidateBlock(unknownChain, blockID, 0)
+				err := h.interop.invalidateBlock(unknownChain, blockID, 0, eth.Bytes32{}, eth.Bytes32{})
 
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "not found")
@@ -935,7 +935,7 @@ func TestInvalidateBlock(t *testing.T) {
 			run: func(t *testing.T, h *interopTestHarness) {
 				mock := h.Mock(10)
 				blockID := eth.BlockID{Number: 500, Hash: common.HexToHash("0xBAD")}
-				err := h.interop.invalidateBlock(mock.id, blockID, 0)
+				err := h.interop.invalidateBlock(mock.id, blockID, 0, eth.Bytes32{}, eth.Bytes32{})
 
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "engine failure")
@@ -957,9 +957,9 @@ func TestInvalidateBlock(t *testing.T) {
 						mock1.id: {Number: 500, Hash: common.HexToHash("0xL2-1")},
 						mock2.id: {Number: 600, Hash: common.HexToHash("0xL2-2")},
 					},
-					InvalidHeads: map[eth.ChainID]eth.BlockID{
-						mock1.id: {Number: 500, Hash: common.HexToHash("0xBAD1")},
-						mock2.id: {Number: 600, Hash: common.HexToHash("0xBAD2")},
+					InvalidHeads: map[eth.ChainID]InvalidHead{
+						mock1.id: {BlockID: eth.BlockID{Number: 500, Hash: common.HexToHash("0xBAD1")}},
+						mock2.id: {BlockID: eth.BlockID{Number: 600, Hash: common.HexToHash("0xBAD2")}},
 					},
 				}
 
@@ -1090,7 +1090,7 @@ func TestProgressAndRecord(t *testing.T) {
 						Timestamp:    ts,
 						L1Inclusion:  eth.BlockID{Number: 999, Hash: common.HexToHash("0xShouldNotBeUsed")},
 						L2Heads:      blocks,
-						InvalidHeads: map[eth.ChainID]eth.BlockID{mock.id: {Number: 100}},
+						InvalidHeads: map[eth.ChainID]InvalidHead{mock.id: {BlockID: eth.BlockID{Number: 100}}},
 					}, nil
 				}
 
@@ -1201,7 +1201,7 @@ func TestResult_IsEmpty(t *testing.T) {
 		{"only timestamp", Result{Timestamp: 1000}, true},
 		{"with L1Head", Result{Timestamp: 1000, L1Inclusion: eth.BlockID{Number: 100}}, false},
 		{"with L2Heads", Result{Timestamp: 1000, L2Heads: map[eth.ChainID]eth.BlockID{eth.ChainIDFromUInt64(10): {Number: 50}}}, false},
-		{"with InvalidHeads", Result{Timestamp: 1000, InvalidHeads: map[eth.ChainID]eth.BlockID{eth.ChainIDFromUInt64(10): {Number: 50}}}, false},
+		{"with InvalidHeads", Result{Timestamp: 1000, InvalidHeads: map[eth.ChainID]InvalidHead{eth.ChainIDFromUInt64(10): {BlockID: eth.BlockID{Number: 50}}}}, false},
 	}
 
 	for _, tt := range tests {
@@ -1310,8 +1310,10 @@ type mockChainContainer struct {
 }
 
 type invalidateBlockCall struct {
-	height      uint64
-	payloadHash common.Hash
+	height                   uint64
+	payloadHash              common.Hash
+	stateRoot                eth.Bytes32
+	messagePasserStorageRoot eth.Bytes32
 }
 
 func newMockChainContainer(id uint64) *mockChainContainer {
@@ -1435,14 +1437,26 @@ func (m *mockChainContainer) RewindEngine(ctx context.Context, timestamp uint64,
 	return m.rewindEngineErr
 }
 func (m *mockChainContainer) BlockTime() uint64 { return 1 }
-func (m *mockChainContainer) InvalidateBlock(ctx context.Context, height uint64, payloadHash common.Hash, decisionTimestamp uint64) (bool, error) {
+func (m *mockChainContainer) InvalidateBlock(ctx context.Context, height uint64, payloadHash common.Hash, decisionTimestamp uint64, stateRoot, messagePasserStorageRoot eth.Bytes32) (bool, error) {
 	m.mu.Lock()
-	m.invalidateBlockCalls = append(m.invalidateBlockCalls, invalidateBlockCall{height: height, payloadHash: payloadHash})
+	m.invalidateBlockCalls = append(m.invalidateBlockCalls, invalidateBlockCall{
+		height: height, payloadHash: payloadHash, stateRoot: stateRoot, messagePasserStorageRoot: messagePasserStorageRoot,
+	})
 	m.mu.Unlock()
 	if m.callLog != nil {
 		m.callLog.record(m.id, "InvalidateBlock")
 	}
 	return m.invalidateBlockRet, m.invalidateBlockErr
+}
+func (m *mockChainContainer) OutputV0AtBlockNumber(ctx context.Context, l2BlockNum uint64) (*eth.OutputV0, error) {
+	return &eth.OutputV0{
+		StateRoot:                eth.Bytes32(common.HexToHash("0xmockstate")),
+		MessagePasserStorageRoot: eth.Bytes32(common.HexToHash("0xmockmsg")),
+		BlockHash:                common.BigToHash(common.Big0.SetUint64(l2BlockNum)),
+	}, nil
+}
+func (m *mockChainContainer) GetDeniedOutput(height uint64, payloadHash common.Hash) (*eth.OutputV0, error) {
+	return nil, nil
 }
 func (m *mockChainContainer) PruneDeniedAtOrAfterTimestamp(timestamp uint64) (map[uint64][]common.Hash, error) {
 	if m.pruneDeniedResult != nil {
@@ -1484,8 +1498,8 @@ func TestWAL_PreservedOnInvalidationFailure(t *testing.T) {
 		L2Heads: map[eth.ChainID]eth.BlockID{
 			mock.id: {Number: 500, Hash: common.HexToHash("0xL2")},
 		},
-		InvalidHeads: map[eth.ChainID]eth.BlockID{
-			mock.id: {Number: 500, Hash: common.HexToHash("0xBAD")},
+		InvalidHeads: map[eth.ChainID]InvalidHead{
+			mock.id: {BlockID: eth.BlockID{Number: 500, Hash: common.HexToHash("0xBAD")}},
 		},
 	}
 
@@ -1533,8 +1547,8 @@ func TestPendingTransition_RecoverInvalidatePreservedOnFailure(t *testing.T) {
 		Result: &Result{
 			Timestamp:   1000,
 			L1Inclusion: eth.BlockID{Hash: common.HexToHash("0xL1"), Number: 100},
-			InvalidHeads: map[eth.ChainID]eth.BlockID{
-				mock.id: {Hash: common.HexToHash("0xBAD"), Number: 500},
+			InvalidHeads: map[eth.ChainID]InvalidHead{
+				mock.id: {BlockID: eth.BlockID{Hash: common.HexToHash("0xBAD"), Number: 500}},
 			},
 		},
 	}
@@ -2107,8 +2121,8 @@ func TestFreezeAllBeforeRewind(t *testing.T) {
 				chain10:   {Number: 500, Hash: common.HexToHash("0xL2-10")},
 				chain8453: {Number: 600, Hash: common.HexToHash("0xL2-8453")},
 			},
-			InvalidHeads: map[eth.ChainID]eth.BlockID{
-				chain10: {Number: 500, Hash: common.HexToHash("0xBAD")},
+			InvalidHeads: map[eth.ChainID]InvalidHead{
+				chain10: {BlockID: eth.BlockID{Number: 500, Hash: common.HexToHash("0xBAD")}},
 			},
 		}
 
@@ -2178,9 +2192,9 @@ func TestFreezeAllBeforeRewind(t *testing.T) {
 				chain8453: {Number: 600, Hash: common.HexToHash("0xL2-8453")},
 				chain42:   {Number: 700, Hash: common.HexToHash("0xL2-42")},
 			},
-			InvalidHeads: map[eth.ChainID]eth.BlockID{
-				chain10:   {Number: 500, Hash: common.HexToHash("0xBAD10")},
-				chain8453: {Number: 600, Hash: common.HexToHash("0xBAD8453")},
+			InvalidHeads: map[eth.ChainID]InvalidHead{
+				chain10:   {BlockID: eth.BlockID{Number: 500, Hash: common.HexToHash("0xBAD10")}},
+				chain8453: {BlockID: eth.BlockID{Number: 600, Hash: common.HexToHash("0xBAD8453")}},
 			},
 		}
 
@@ -2223,8 +2237,8 @@ func TestFreezeAllBeforeRewind(t *testing.T) {
 				chain10:   {Number: 500, Hash: common.HexToHash("0xL2-10")},
 				chain8453: {Number: 600, Hash: common.HexToHash("0xL2-8453")},
 			},
-			InvalidHeads: map[eth.ChainID]eth.BlockID{
-				chain10: {Number: 500, Hash: common.HexToHash("0xBAD")},
+			InvalidHeads: map[eth.ChainID]InvalidHead{
+				chain10: {BlockID: eth.BlockID{Number: 500, Hash: common.HexToHash("0xBAD")}},
 			},
 		}
 
@@ -2276,8 +2290,8 @@ func TestFreezeAllBeforeRewind(t *testing.T) {
 			L2Heads: map[eth.ChainID]eth.BlockID{
 				chain10: {Number: 500, Hash: common.HexToHash("0xL2-10")},
 			},
-			InvalidHeads: map[eth.ChainID]eth.BlockID{
-				chain10: {Number: 500, Hash: common.HexToHash("0xBAD")},
+			InvalidHeads: map[eth.ChainID]InvalidHead{
+				chain10: {BlockID: eth.BlockID{Number: 500, Hash: common.HexToHash("0xBAD")}},
 			},
 		}
 

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -1452,7 +1452,7 @@ func (m *mockChainContainer) OutputV0AtBlockNumber(ctx context.Context, l2BlockN
 	return &eth.OutputV0{
 		StateRoot:                eth.Bytes32(common.HexToHash("0xmockstate")),
 		MessagePasserStorageRoot: eth.Bytes32(common.HexToHash("0xmockmsg")),
-		BlockHash:                common.BigToHash(common.Big0.SetUint64(l2BlockNum)),
+		BlockHash:                common.BigToHash(new(big.Int).SetUint64(l2BlockNum)),
 	}, nil
 }
 func (m *mockChainContainer) GetDeniedOutput(height uint64, payloadHash common.Hash) (*eth.OutputV0, error) {

--- a/op-supernode/supernode/activity/interop/types.go
+++ b/op-supernode/supernode/activity/interop/types.go
@@ -13,13 +13,31 @@ type VerifiedResult struct {
 	L2Heads     map[eth.ChainID]eth.BlockID `json:"l2Heads"`
 }
 
+// InvalidHead pairs a block identifier with the output preimage fields needed
+// for optimistic root computation in the superroot API. The full OutputV0 can
+// be reconstructed on demand via OutputV0() since BlockHash is already in BlockID.
+type InvalidHead struct {
+	eth.BlockID
+	StateRoot                eth.Bytes32 `json:"stateRoot"`
+	MessagePasserStorageRoot eth.Bytes32 `json:"messagePasserStorageRoot"`
+}
+
+// OutputV0 reconstructs the full output from the stored preimage fields.
+func (h InvalidHead) OutputV0() *eth.OutputV0 {
+	return &eth.OutputV0{
+		StateRoot:                h.StateRoot,
+		MessagePasserStorageRoot: h.MessagePasserStorageRoot,
+		BlockHash:                h.Hash,
+	}
+}
+
 // Result represents the result of interop validation at a specific timestamp given current data.
 // it contains all the same information as VerifiedResult, but also contains a list of invalid heads.
 type Result struct {
 	Timestamp    uint64                      `json:"timestamp"`
 	L1Inclusion  eth.BlockID                 `json:"l1Inclusion"`
 	L2Heads      map[eth.ChainID]eth.BlockID `json:"l2Heads"`
-	InvalidHeads map[eth.ChainID]eth.BlockID `json:"invalidHeads"`
+	InvalidHeads map[eth.ChainID]InvalidHead `json:"invalidHeads"`
 }
 
 // PendingTransition is the generic write-ahead-log entry for an effectful

--- a/op-supernode/supernode/activity/interop/types.go
+++ b/op-supernode/supernode/activity/interop/types.go
@@ -22,15 +22,6 @@ type InvalidHead struct {
 	MessagePasserStorageRoot eth.Bytes32 `json:"messagePasserStorageRoot"`
 }
 
-// OutputV0 reconstructs the full output from the stored preimage fields.
-func (h InvalidHead) OutputV0() *eth.OutputV0 {
-	return &eth.OutputV0{
-		StateRoot:                h.StateRoot,
-		MessagePasserStorageRoot: h.MessagePasserStorageRoot,
-		BlockHash:                h.Hash,
-	}
-}
-
 // Result represents the result of interop validation at a specific timestamp given current data.
 // it contains all the same information as VerifiedResult, but also contains a list of invalid heads.
 type Result struct {

--- a/op-supernode/supernode/activity/interop/types_test.go
+++ b/op-supernode/supernode/activity/interop/types_test.go
@@ -1,6 +1,7 @@
 package interop
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -26,7 +27,7 @@ func TestResult_IsValid(t *testing.T) {
 			Timestamp:    100,
 			L1Inclusion:  eth.BlockID{Number: 1},
 			L2Heads:      map[eth.ChainID]eth.BlockID{eth.ChainIDFromUInt64(10): {Number: 100}},
-			InvalidHeads: map[eth.ChainID]eth.BlockID{},
+			InvalidHeads: map[eth.ChainID]InvalidHead{},
 		}
 		require.True(t, r.IsValid())
 	})
@@ -36,8 +37,8 @@ func TestResult_IsValid(t *testing.T) {
 			Timestamp:   100,
 			L1Inclusion: eth.BlockID{Number: 1},
 			L2Heads:     map[eth.ChainID]eth.BlockID{eth.ChainIDFromUInt64(10): {Number: 100}},
-			InvalidHeads: map[eth.ChainID]eth.BlockID{
-				eth.ChainIDFromUInt64(10): {Number: 100, Hash: common.HexToHash("0xbad")},
+			InvalidHeads: map[eth.ChainID]InvalidHead{
+				eth.ChainIDFromUInt64(10): {BlockID: eth.BlockID{Number: 100, Hash: common.HexToHash("0xbad")}},
 			},
 		}
 		require.False(t, r.IsValid())
@@ -46,9 +47,9 @@ func TestResult_IsValid(t *testing.T) {
 	t.Run("returns false with multiple invalid heads", func(t *testing.T) {
 		r := Result{
 			Timestamp: 100,
-			InvalidHeads: map[eth.ChainID]eth.BlockID{
-				eth.ChainIDFromUInt64(10):   {Number: 100},
-				eth.ChainIDFromUInt64(8453): {Number: 200},
+			InvalidHeads: map[eth.ChainID]InvalidHead{
+				eth.ChainIDFromUInt64(10):   {BlockID: eth.BlockID{Number: 100}},
+				eth.ChainIDFromUInt64(8453): {BlockID: eth.BlockID{Number: 200}},
 			},
 		}
 		require.False(t, r.IsValid())
@@ -72,8 +73,8 @@ func TestResult_ToVerifiedResult(t *testing.T) {
 				chainID1: {Hash: common.HexToHash("0x2222"), Number: 200},
 				chainID2: {Hash: common.HexToHash("0x3333"), Number: 300},
 			},
-			InvalidHeads: map[eth.ChainID]eth.BlockID{
-				chainID1: {Hash: common.HexToHash("0xbad"), Number: 199},
+			InvalidHeads: map[eth.ChainID]InvalidHead{
+				chainID1: {BlockID: eth.BlockID{Hash: common.HexToHash("0xbad"), Number: 199}},
 			},
 		}
 
@@ -117,8 +118,8 @@ func TestResult_ToVerifiedResult(t *testing.T) {
 			L2Heads: map[eth.ChainID]eth.BlockID{
 				chainID: {Number: 200},
 			},
-			InvalidHeads: map[eth.ChainID]eth.BlockID{
-				chainID: {Number: 199},
+			InvalidHeads: map[eth.ChainID]InvalidHead{
+				chainID: {BlockID: eth.BlockID{Number: 199}},
 			},
 		}
 
@@ -127,4 +128,74 @@ func TestResult_ToVerifiedResult(t *testing.T) {
 		// Original should still have InvalidHeads
 		require.Len(t, r.InvalidHeads, 1)
 	})
+}
+
+func TestInvalidHead_JSONRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	original := InvalidHead{
+		BlockID: eth.BlockID{
+			Hash:   common.HexToHash("0xdead"),
+			Number: 500,
+		},
+		StateRoot:                eth.Bytes32(common.HexToHash("0xstate")),
+		MessagePasserStorageRoot: eth.Bytes32(common.HexToHash("0xmsgpasser")),
+	}
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var decoded InvalidHead
+	require.NoError(t, json.Unmarshal(data, &decoded))
+
+	require.Equal(t, original.BlockID, decoded.BlockID)
+	require.Equal(t, original.StateRoot, decoded.StateRoot)
+	require.Equal(t, original.MessagePasserStorageRoot, decoded.MessagePasserStorageRoot)
+}
+
+func TestInvalidHead_JSONRoundTrip_ZeroRoots(t *testing.T) {
+	t.Parallel()
+
+	original := InvalidHead{
+		BlockID: eth.BlockID{
+			Hash:   common.HexToHash("0xbeef"),
+			Number: 42,
+		},
+		StateRoot:                eth.Bytes32{},
+		MessagePasserStorageRoot: eth.Bytes32{},
+	}
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var decoded InvalidHead
+	require.NoError(t, json.Unmarshal(data, &decoded))
+
+	require.Equal(t, original.BlockID, decoded.BlockID)
+	require.Equal(t, original.StateRoot, decoded.StateRoot)
+	require.Equal(t, original.MessagePasserStorageRoot, decoded.MessagePasserStorageRoot)
+}
+
+func TestPendingInvalidation_JSONRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	original := PendingInvalidation{
+		ChainID:                  eth.ChainIDFromUInt64(10),
+		BlockID:                  eth.BlockID{Hash: common.HexToHash("0xbad"), Number: 100},
+		Timestamp:                42,
+		StateRoot:                eth.Bytes32(common.HexToHash("0xstate")),
+		MessagePasserStorageRoot: eth.Bytes32(common.HexToHash("0xmsgpasser")),
+	}
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var decoded PendingInvalidation
+	require.NoError(t, json.Unmarshal(data, &decoded))
+
+	require.Equal(t, original.ChainID, decoded.ChainID)
+	require.Equal(t, original.BlockID, decoded.BlockID)
+	require.Equal(t, original.Timestamp, decoded.Timestamp)
+	require.Equal(t, original.StateRoot, decoded.StateRoot)
+	require.Equal(t, original.MessagePasserStorageRoot, decoded.MessagePasserStorageRoot)
 }

--- a/op-supernode/supernode/activity/interop/verified_db.go
+++ b/op-supernode/supernode/activity/interop/verified_db.go
@@ -33,9 +33,11 @@ var pendingTransitionKey = []byte("pending")
 
 // PendingInvalidation records a chain invalidation that needs to be executed.
 type PendingInvalidation struct {
-	ChainID   eth.ChainID `json:"chainID"`
-	BlockID   eth.BlockID `json:"blockID"`
-	Timestamp uint64      `json:"timestamp"` // the interop decision timestamp
+	ChainID                  eth.ChainID `json:"chainID"`
+	BlockID                  eth.BlockID `json:"blockID"`
+	Timestamp                uint64      `json:"timestamp"` // the interop decision timestamp
+	StateRoot                eth.Bytes32 `json:"stateRoot"`
+	MessagePasserStorageRoot eth.Bytes32 `json:"messagePasserStorageRoot"`
 }
 
 // VerifiedDB provides persistence for verified timestamps using bbolt.

--- a/op-supernode/supernode/activity/interop/verified_db_test.go
+++ b/op-supernode/supernode/activity/interop/verified_db_test.go
@@ -354,9 +354,17 @@ func TestVerifiedDB_PendingTransition(t *testing.T) {
 			Result: &Result{
 				Timestamp:   42,
 				L1Inclusion: eth.BlockID{Hash: common.HexToHash("0x1111"), Number: 42},
-				InvalidHeads: map[eth.ChainID]eth.BlockID{
-					eth.ChainIDFromUInt64(1): {Hash: common.HexToHash("0xaaaa"), Number: 100},
-					eth.ChainIDFromUInt64(2): {Hash: common.HexToHash("0xbbbb"), Number: 200},
+				InvalidHeads: map[eth.ChainID]InvalidHead{
+					eth.ChainIDFromUInt64(1): {
+						BlockID:                  eth.BlockID{Hash: common.HexToHash("0xaaaa"), Number: 100},
+						StateRoot:                eth.Bytes32(common.HexToHash("0xstate1")),
+						MessagePasserStorageRoot: eth.Bytes32(common.HexToHash("0xmsg1")),
+					},
+					eth.ChainIDFromUInt64(2): {
+						BlockID:                  eth.BlockID{Hash: common.HexToHash("0xbbbb"), Number: 200},
+						StateRoot:                eth.Bytes32(common.HexToHash("0xstate2")),
+						MessagePasserStorageRoot: eth.Bytes32(common.HexToHash("0xmsg2")),
+					},
 				},
 			},
 		}

--- a/op-supernode/supernode/activity/supernode/supernode_test.go
+++ b/op-supernode/supernode/activity/supernode/supernode_test.go
@@ -97,8 +97,14 @@ func (m *mockCC) ID() eth.ChainID {
 
 func (m *mockCC) BlockTime() uint64 { return 1 }
 
-func (m *mockCC) InvalidateBlock(ctx context.Context, height uint64, payloadHash common.Hash, decisionTimestamp uint64) (bool, error) {
+func (m *mockCC) InvalidateBlock(ctx context.Context, height uint64, payloadHash common.Hash, decisionTimestamp uint64, stateRoot, messagePasserStorageRoot eth.Bytes32) (bool, error) {
 	return false, nil
+}
+func (m *mockCC) OutputV0AtBlockNumber(ctx context.Context, l2BlockNum uint64) (*eth.OutputV0, error) {
+	return &eth.OutputV0{}, nil
+}
+func (m *mockCC) GetDeniedOutput(height uint64, payloadHash common.Hash) (*eth.OutputV0, error) {
+	return nil, nil
 }
 
 func (m *mockCC) IsDenied(height uint64, payloadHash common.Hash) (bool, error) {

--- a/op-supernode/supernode/activity/superroot/superroot_test.go
+++ b/op-supernode/supernode/activity/superroot/superroot_test.go
@@ -102,8 +102,14 @@ func (m *mockCC) ID() eth.ChainID {
 }
 
 func (m *mockCC) BlockTime() uint64 { return 1 }
-func (m *mockCC) InvalidateBlock(ctx context.Context, height uint64, payloadHash common.Hash, decisionTimestamp uint64) (bool, error) {
+func (m *mockCC) InvalidateBlock(ctx context.Context, height uint64, payloadHash common.Hash, decisionTimestamp uint64, stateRoot, messagePasserStorageRoot eth.Bytes32) (bool, error) {
 	return false, nil
+}
+func (m *mockCC) OutputV0AtBlockNumber(ctx context.Context, l2BlockNum uint64) (*eth.OutputV0, error) {
+	return &eth.OutputV0{}, nil
+}
+func (m *mockCC) GetDeniedOutput(height uint64, payloadHash common.Hash) (*eth.OutputV0, error) {
+	return nil, nil
 }
 func (m *mockCC) PruneDeniedAtOrAfterTimestamp(timestamp uint64) (map[uint64][]common.Hash, error) {
 	return nil, nil

--- a/op-supernode/supernode/chain_container/chain_container.go
+++ b/op-supernode/supernode/chain_container/chain_container.go
@@ -61,13 +61,14 @@ type ChainContainer interface {
 	BlockTime() uint64
 	// InvalidateBlock adds a block to the deny list and triggers a rewind if the chain
 	// currently uses that block at the specified height.
+	// output is the marshaled eth.Output preimage for optimistic root computation.
 	// WARNING: this is a dangerous stateful operation and is intended to be called only
 	// by interop transition application. Other callers should not use it until the
 	// interface is refactored to make that ownership explicit.
 	// TODO(#19561): remove this footgun by moving reorg-triggering operations behind a
 	// smaller interop-owned interface.
 	// Returns true if a rewind was triggered, false otherwise.
-	InvalidateBlock(ctx context.Context, height uint64, payloadHash common.Hash, decisionTimestamp uint64) (bool, error)
+	InvalidateBlock(ctx context.Context, height uint64, payloadHash common.Hash, decisionTimestamp uint64, stateRoot, messagePasserStorageRoot eth.Bytes32) (bool, error)
 	// PruneDeniedAtOrAfterTimestamp removes deny-list entries with DecisionTimestamp >= timestamp.
 	// Returns map of removed hashes by height.
 	PruneDeniedAtOrAfterTimestamp(timestamp uint64) (map[uint64][]common.Hash, error)
@@ -77,6 +78,11 @@ type ChainContainer interface {
 	PauseAndStopVN(ctx context.Context) error
 	// IsDenied checks if a block hash is on the deny list at the given height.
 	IsDenied(height uint64, payloadHash common.Hash) (bool, error)
+	// GetDeniedOutput returns the reconstructed OutputV0 for a denied block.
+	// Returns nil if the block is not denied at that height.
+	GetDeniedOutput(height uint64, payloadHash common.Hash) (*eth.OutputV0, error)
+	// OutputV0AtBlockNumber returns the full OutputV0 for the block at the given number.
+	OutputV0AtBlockNumber(ctx context.Context, l2BlockNum uint64) (*eth.OutputV0, error)
 	// SetResetCallback sets a callback that is invoked when the chain resets.
 	// The supernode uses this to notify activities about chain resets.
 	SetResetCallback(cb ResetCallback)

--- a/op-supernode/supernode/chain_container/invalidation.go
+++ b/op-supernode/supernode/chain_container/invalidation.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"sync"
 
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
 	bolt "go.etcd.io/bbolt"
 )
@@ -27,10 +28,13 @@ type DenyList struct {
 	mu sync.RWMutex
 }
 
-// DenyRecord stores a denied payload hash along with decision provenance.
+// DenyRecord stores a denied payload hash along with decision provenance
+// and the output preimage fields for optimistic root computation.
 type DenyRecord struct {
-	PayloadHash       common.Hash `json:"payloadHash"`
-	DecisionTimestamp uint64      `json:"decisionTimestamp"`
+	PayloadHash              common.Hash `json:"payloadHash"`
+	DecisionTimestamp        uint64      `json:"decisionTimestamp"`
+	StateRoot                eth.Bytes32 `json:"stateRoot"`
+	MessagePasserStorageRoot eth.Bytes32 `json:"messagePasserStorageRoot"`
 }
 
 func encodeDenyRecords(records []DenyRecord) ([]byte, error) {
@@ -42,24 +46,8 @@ func decodeDenyRecords(raw []byte) ([]DenyRecord, error) {
 		return nil, nil
 	}
 	var records []DenyRecord
-	if err := json.Unmarshal(raw, &records); err == nil {
-		return records, nil
-	}
-	// Backward compatibility: legacy format is concatenated 32-byte hashes.
-	// Legacy entries get DecisionTimestamp: 0, which means they are never
-	// removed by PruneAtOrAfterTimestamp (since rewind timestamps are always
-	// well above 0). This is the safe default — deny decisions from before
-	// provenance tracking was added should be preserved rather than silently
-	// dropped.
-	if len(raw)%common.HashLength != 0 {
-		return nil, fmt.Errorf("invalid denylist record payload length %d", len(raw))
-	}
-	records = make([]DenyRecord, 0, len(raw)/common.HashLength)
-	for i := 0; i+common.HashLength <= len(raw); i += common.HashLength {
-		records = append(records, DenyRecord{
-			PayloadHash:       common.BytesToHash(raw[i : i+common.HashLength]),
-			DecisionTimestamp: 0,
-		})
+	if err := json.Unmarshal(raw, &records); err != nil {
+		return nil, fmt.Errorf("failed to decode denylist records: %w", err)
 	}
 	return records, nil
 }
@@ -97,8 +85,9 @@ func heightToKey(height uint64) []byte {
 }
 
 // Add adds a payload hash to the deny list at the given block height.
+// stateRoot and messagePasserStorageRoot are the output preimage fields for optimistic root computation.
 // Multiple hashes can be denied at the same height.
-func (d *DenyList) Add(height uint64, payloadHash common.Hash, decisionTimestamp uint64) error {
+func (d *DenyList) Add(height uint64, payloadHash common.Hash, decisionTimestamp uint64, stateRoot, messagePasserStorageRoot eth.Bytes32) error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
@@ -113,7 +102,6 @@ func (d *DenyList) Add(height uint64, payloadHash common.Hash, decisionTimestamp
 			return err
 		}
 
-		// Check if hash already exists
 		for _, r := range records {
 			if r.PayloadHash == payloadHash {
 				return nil
@@ -121,8 +109,10 @@ func (d *DenyList) Add(height uint64, payloadHash common.Hash, decisionTimestamp
 		}
 
 		records = append(records, DenyRecord{
-			PayloadHash:       payloadHash,
-			DecisionTimestamp: decisionTimestamp,
+			PayloadHash:              payloadHash,
+			DecisionTimestamp:        decisionTimestamp,
+			StateRoot:                stateRoot,
+			MessagePasserStorageRoot: messagePasserStorageRoot,
 		})
 
 		encoded, err := encodeDenyRecords(records)
@@ -131,6 +121,42 @@ func (d *DenyList) Add(height uint64, payloadHash common.Hash, decisionTimestamp
 		}
 		return b.Put(key, encoded)
 	})
+}
+
+// GetOutputV0 reconstructs and returns the full OutputV0 for a denied block.
+// Returns nil if the hash is not denied at that height.
+func (d *DenyList) GetOutputV0(height uint64, payloadHash common.Hash) (*eth.OutputV0, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	key := heightToKey(height)
+	var result *eth.OutputV0
+
+	err := d.db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket(denyListBucketName)
+		existing := b.Get(key)
+		if existing == nil {
+			return nil
+		}
+
+		records, err := decodeDenyRecords(existing)
+		if err != nil {
+			return err
+		}
+		for _, r := range records {
+			if r.PayloadHash == payloadHash {
+				result = &eth.OutputV0{
+					StateRoot:                r.StateRoot,
+					MessagePasserStorageRoot: r.MessagePasserStorageRoot,
+					BlockHash:                payloadHash,
+				}
+				return nil
+			}
+		}
+		return nil
+	})
+
+	return result, err
 }
 
 // Contains checks if a payload hash is denied at the given block height.
@@ -278,7 +304,7 @@ func (d *DenyList) Close() error {
 // smaller interop-owned interface.
 // Returns true if a rewind was triggered, false otherwise.
 // Note: Genesis block (height=0) cannot be invalidated as there is no prior block to rewind to.
-func (c *simpleChainContainer) InvalidateBlock(ctx context.Context, height uint64, payloadHash common.Hash, decisionTimestamp uint64) (bool, error) {
+func (c *simpleChainContainer) InvalidateBlock(ctx context.Context, height uint64, payloadHash common.Hash, decisionTimestamp uint64, stateRoot, messagePasserStorageRoot eth.Bytes32) (bool, error) {
 	if c.denyList == nil {
 		return false, fmt.Errorf("deny list not initialized")
 	}
@@ -288,8 +314,8 @@ func (c *simpleChainContainer) InvalidateBlock(ctx context.Context, height uint6
 		return false, fmt.Errorf("cannot invalidate genesis block (height=0)")
 	}
 
-	// Add to deny list first
-	if err := c.denyList.Add(height, payloadHash, decisionTimestamp); err != nil {
+	// Add to deny list with the output preimage fields
+	if err := c.denyList.Add(height, payloadHash, decisionTimestamp, stateRoot, messagePasserStorageRoot); err != nil {
 		return false, fmt.Errorf("failed to add block to deny list: %w", err)
 	}
 

--- a/op-supernode/supernode/chain_container/invalidation_test.go
+++ b/op-supernode/supernode/chain_container/invalidation_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	gethlog "github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
-	bolt "go.etcd.io/bbolt"
 )
 
 func TestDenyList_AddAndContains(t *testing.T) {
@@ -28,7 +27,7 @@ func TestDenyList_AddAndContains(t *testing.T) {
 			name: "single hash at height",
 			setup: func(t *testing.T, dl *DenyList) {
 				hash := common.HexToHash("0x1111111111111111111111111111111111111111111111111111111111111111")
-				require.NoError(t, dl.Add(100, hash, 0))
+				require.NoError(t, dl.Add(100, hash, 0, eth.Bytes32{}, eth.Bytes32{}))
 			},
 			check: func(t *testing.T, dl *DenyList) {
 				hash := common.HexToHash("0x1111111111111111111111111111111111111111111111111111111111111111")
@@ -46,7 +45,7 @@ func TestDenyList_AddAndContains(t *testing.T) {
 					common.HexToHash("0xcccc"),
 				}
 				for _, h := range hashes {
-					require.NoError(t, dl.Add(50, h, 0))
+					require.NoError(t, dl.Add(50, h, 0, eth.Bytes32{}, eth.Bytes32{}))
 				}
 			},
 			check: func(t *testing.T, dl *DenyList) {
@@ -66,7 +65,7 @@ func TestDenyList_AddAndContains(t *testing.T) {
 			name: "hash at wrong height returns false",
 			setup: func(t *testing.T, dl *DenyList) {
 				hash := common.HexToHash("0xdddd")
-				require.NoError(t, dl.Add(10, hash, 0))
+				require.NoError(t, dl.Add(10, hash, 0, eth.Bytes32{}, eth.Bytes32{}))
 			},
 			check: func(t *testing.T, dl *DenyList) {
 				hash := common.HexToHash("0xdddd")
@@ -85,9 +84,9 @@ func TestDenyList_AddAndContains(t *testing.T) {
 			name: "duplicate add is idempotent",
 			setup: func(t *testing.T, dl *DenyList) {
 				hash := common.HexToHash("0xeeee")
-				require.NoError(t, dl.Add(200, hash, 0))
-				require.NoError(t, dl.Add(200, hash, 0)) // Add again
-				require.NoError(t, dl.Add(200, hash, 0)) // And again
+				require.NoError(t, dl.Add(200, hash, 0, eth.Bytes32{}, eth.Bytes32{}))
+				require.NoError(t, dl.Add(200, hash, 0, eth.Bytes32{}, eth.Bytes32{})) // Add again
+				require.NoError(t, dl.Add(200, hash, 0, eth.Bytes32{}, eth.Bytes32{})) // And again
 			},
 			check: func(t *testing.T, dl *DenyList) {
 				hash := common.HexToHash("0xeeee")
@@ -137,7 +136,7 @@ func TestDenyList_Persistence(t *testing.T) {
 					{300, common.HexToHash("0x4444")},
 				}
 				for _, h := range hashes {
-					require.NoError(t, dl.Add(h.height, h.hash, 0))
+					require.NoError(t, dl.Add(h.height, h.hash, 0, eth.Bytes32{}, eth.Bytes32{}))
 				}
 
 				require.NoError(t, dl.Close())
@@ -219,7 +218,7 @@ func TestDenyList_GetDeniedHashes(t *testing.T) {
 			setup: func(t *testing.T, dl *DenyList) {
 				for i := 0; i < 5; i++ {
 					hash := common.BigToHash(common.Big1.Add(common.Big1, common.Big0.SetInt64(int64(i))))
-					require.NoError(t, dl.Add(100, hash, 0))
+					require.NoError(t, dl.Add(100, hash, 0, eth.Bytes32{}, eth.Bytes32{}))
 				}
 			},
 			check: func(t *testing.T, dl *DenyList) {
@@ -232,8 +231,8 @@ func TestDenyList_GetDeniedHashes(t *testing.T) {
 			name: "empty for clean height",
 			setup: func(t *testing.T, dl *DenyList) {
 				// Add hashes at other heights
-				require.NoError(t, dl.Add(10, common.HexToHash("0xaaaa"), 0))
-				require.NoError(t, dl.Add(30, common.HexToHash("0xbbbb"), 0))
+				require.NoError(t, dl.Add(10, common.HexToHash("0xaaaa"), 0, eth.Bytes32{}, eth.Bytes32{}))
+				require.NoError(t, dl.Add(30, common.HexToHash("0xbbbb"), 0, eth.Bytes32{}, eth.Bytes32{}))
 			},
 			check: func(t *testing.T, dl *DenyList) {
 				hashes, err := dl.GetDeniedHashes(20)
@@ -245,12 +244,12 @@ func TestDenyList_GetDeniedHashes(t *testing.T) {
 			name: "isolated by height",
 			setup: func(t *testing.T, dl *DenyList) {
 				// Add different hashes at different heights
-				require.NoError(t, dl.Add(10, common.HexToHash("0x1010"), 0))
-				require.NoError(t, dl.Add(10, common.HexToHash("0x1011"), 0))
-				require.NoError(t, dl.Add(20, common.HexToHash("0x2020"), 0))
-				require.NoError(t, dl.Add(20, common.HexToHash("0x2021"), 0))
-				require.NoError(t, dl.Add(20, common.HexToHash("0x2022"), 0))
-				require.NoError(t, dl.Add(30, common.HexToHash("0x3030"), 0))
+				require.NoError(t, dl.Add(10, common.HexToHash("0x1010"), 0, eth.Bytes32{}, eth.Bytes32{}))
+				require.NoError(t, dl.Add(10, common.HexToHash("0x1011"), 0, eth.Bytes32{}, eth.Bytes32{}))
+				require.NoError(t, dl.Add(20, common.HexToHash("0x2020"), 0, eth.Bytes32{}, eth.Bytes32{}))
+				require.NoError(t, dl.Add(20, common.HexToHash("0x2021"), 0, eth.Bytes32{}, eth.Bytes32{}))
+				require.NoError(t, dl.Add(20, common.HexToHash("0x2022"), 0, eth.Bytes32{}, eth.Bytes32{}))
+				require.NoError(t, dl.Add(30, common.HexToHash("0x3030"), 0, eth.Bytes32{}, eth.Bytes32{}))
 			},
 			check: func(t *testing.T, dl *DenyList) {
 				hashes10, err := dl.GetDeniedHashes(10)
@@ -408,7 +407,7 @@ func TestInvalidateBlock(t *testing.T) {
 		}
 
 		ctx := context.Background()
-		rewound, err := c.InvalidateBlock(ctx, 0, common.HexToHash("0xgenesis"), 0)
+		rewound, err := c.InvalidateBlock(ctx, 0, common.HexToHash("0xgenesis"), 0, eth.Bytes32{}, eth.Bytes32{})
 
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "cannot invalidate genesis block")
@@ -449,9 +448,16 @@ func TestInvalidateBlock(t *testing.T) {
 				c.engine = mockEng
 			}
 
-			// Call InvalidateBlock
+			testStateRoot := eth.Bytes32(common.HexToHash("0xstate"))
+			testMsgPasserRoot := eth.Bytes32(common.HexToHash("0xmsgpasser"))
+			testOut := &eth.OutputV0{
+				StateRoot:                testStateRoot,
+				MessagePasserStorageRoot: testMsgPasserRoot,
+				BlockHash:                tt.payloadHash,
+			}
+
 			ctx := context.Background()
-			rewound, err := c.InvalidateBlock(ctx, tt.height, tt.payloadHash, 0)
+			rewound, err := c.InvalidateBlock(ctx, tt.height, tt.payloadHash, 0, testStateRoot, testMsgPasserRoot)
 			require.NoError(t, err)
 
 			// Verify rewind behavior
@@ -466,8 +472,57 @@ func TestInvalidateBlock(t *testing.T) {
 			found, err := dl.Contains(tt.height, tt.payloadHash)
 			require.NoError(t, err)
 			require.True(t, found, "hash should be in denylist after InvalidateBlock")
+
+			storedOutput, err := dl.GetOutputV0(tt.height, tt.payloadHash)
+			require.NoError(t, err)
+			require.Equal(t, testOut, storedOutput, "OutputV0 should be stored in denylist after InvalidateBlock")
 		})
 	}
+}
+
+func TestGetDeniedOutput(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	dl, err := OpenDenyList(filepath.Join(dir, "denylist"))
+	require.NoError(t, err)
+	defer dl.Close()
+
+	testStateRoot := eth.Bytes32(common.HexToHash("0xstate"))
+	testMsgPasserRoot := eth.Bytes32(common.HexToHash("0xmsgpasser"))
+	hash := common.HexToHash("0xdead")
+
+	c := &simpleChainContainer{
+		denyList: dl,
+		log:      testLogger(),
+	}
+
+	t.Run("returns output after InvalidateBlock", func(t *testing.T) {
+		require.NoError(t, dl.Add(100, hash, 0, testStateRoot, testMsgPasserRoot))
+
+		got, err := c.GetDeniedOutput(100, hash)
+		require.NoError(t, err)
+		want := &eth.OutputV0{
+			StateRoot:                testStateRoot,
+			MessagePasserStorageRoot: testMsgPasserRoot,
+			BlockHash:                hash,
+		}
+		require.Equal(t, want, got)
+	})
+
+	t.Run("returns nil for non-denied block", func(t *testing.T) {
+		got, err := c.GetDeniedOutput(999, common.HexToHash("0xunknown"))
+		require.NoError(t, err)
+		require.Nil(t, got)
+	})
+
+	t.Run("returns error when denylist not initialized", func(t *testing.T) {
+		noDenyList := &simpleChainContainer{
+			log: testLogger(),
+		}
+		_, err := noDenyList.GetDeniedOutput(100, hash)
+		require.Error(t, err)
+	})
 }
 
 func TestIsDenied(t *testing.T) {
@@ -517,7 +572,7 @@ func TestIsDenied(t *testing.T) {
 			defer dl.Close()
 
 			// Setup
-			require.NoError(t, dl.Add(tt.setupHeight, tt.setupHash, 0))
+			require.NoError(t, dl.Add(tt.setupHeight, tt.setupHash, 0, eth.Bytes32{}, eth.Bytes32{}))
 
 			// Create container
 			c := &simpleChainContainer{
@@ -574,7 +629,7 @@ func TestDenyList_ConcurrentAccess(t *testing.T) {
 				hash := makeHash(accessorID, j)
 
 				// Write
-				err := dl.Add(height, hash, 0)
+				err := dl.Add(height, hash, 0, eth.Bytes32{}, eth.Bytes32{})
 				require.NoError(t, err)
 
 				// Read own write
@@ -617,9 +672,9 @@ func TestDenyList_PruneAtOrAfterTimestamp(t *testing.T) {
 	hashA := common.HexToHash("0xaaaa")
 	hashB := common.HexToHash("0xbbbb")
 	hashC := common.HexToHash("0xcccc")
-	require.NoError(t, dl.Add(100, hashA, 10))
-	require.NoError(t, dl.Add(100, hashB, 11))
-	require.NoError(t, dl.Add(200, hashC, 12))
+	require.NoError(t, dl.Add(100, hashA, 10, eth.Bytes32{}, eth.Bytes32{}))
+	require.NoError(t, dl.Add(100, hashB, 11, eth.Bytes32{}, eth.Bytes32{}))
+	require.NoError(t, dl.Add(200, hashC, 12, eth.Bytes32{}, eth.Bytes32{}))
 
 	removed, err := dl.PruneAtOrAfterTimestamp(11)
 	require.NoError(t, err)
@@ -641,32 +696,154 @@ func TestDenyList_PruneAtOrAfterTimestamp(t *testing.T) {
 	require.Empty(t, records200)
 }
 
-func TestDenyList_DecodesLegacyHashOnlyFormat(t *testing.T) {
+func TestDenyList_GetOutputV0(t *testing.T) {
 	t.Parallel()
+
 	dir := t.TempDir()
 	dl, err := OpenDenyList(dir)
 	require.NoError(t, err)
 	defer dl.Close()
 
-	hashA := common.HexToHash("0xaaaa")
-	hashB := common.HexToHash("0xbbbb")
-	raw := append(hashA.Bytes(), hashB.Bytes()...)
+	out := &eth.OutputV0{
+		StateRoot:                eth.Bytes32(common.HexToHash("0xstate")),
+		MessagePasserStorageRoot: eth.Bytes32(common.HexToHash("0xmsgpasser")),
+		BlockHash:                common.HexToHash("0xblock"),
+	}
+	hash := common.HexToHash("0x1111")
+	require.NoError(t, dl.Add(100, hash, 0, out.StateRoot, out.MessagePasserStorageRoot))
 
-	// Write legacy format directly to bbolt
-	dl.mu.Lock()
-	err = dl.db.Update(func(tx *bolt.Tx) error {
-		return tx.Bucket(denyListBucketName).Put(heightToKey(100), raw)
+	want := &eth.OutputV0{
+		StateRoot:                out.StateRoot,
+		MessagePasserStorageRoot: out.MessagePasserStorageRoot,
+		BlockHash:                hash,
+	}
+
+	t.Run("returns stored OutputV0 for matching hash and height", func(t *testing.T) {
+		got, err := dl.GetOutputV0(100, hash)
+		require.NoError(t, err)
+		require.Equal(t, want, got)
 	})
-	dl.mu.Unlock()
+
+	t.Run("returns nil for wrong hash at same height", func(t *testing.T) {
+		got, err := dl.GetOutputV0(100, common.HexToHash("0x9999"))
+		require.NoError(t, err)
+		require.Nil(t, got)
+	})
+
+	t.Run("returns nil for correct hash at wrong height", func(t *testing.T) {
+		got, err := dl.GetOutputV0(200, hash)
+		require.NoError(t, err)
+		require.Nil(t, got)
+	})
+
+	t.Run("returns nil for empty height", func(t *testing.T) {
+		got, err := dl.GetOutputV0(999, common.HexToHash("0xabcd"))
+		require.NoError(t, err)
+		require.Nil(t, got)
+	})
+
+	t.Run("isolates outputs per hash at same height", func(t *testing.T) {
+		out2 := &eth.OutputV0{
+			StateRoot:                eth.Bytes32(common.HexToHash("0xstate2")),
+			MessagePasserStorageRoot: eth.Bytes32(common.HexToHash("0xmsgpasser2")),
+			BlockHash:                common.HexToHash("0xblock2"),
+		}
+		hash2 := common.HexToHash("0x2222")
+		require.NoError(t, dl.Add(100, hash2, 0, out2.StateRoot, out2.MessagePasserStorageRoot))
+
+		got1, err := dl.GetOutputV0(100, hash)
+		require.NoError(t, err)
+		require.Equal(t, want, got1)
+
+		want2 := &eth.OutputV0{
+			StateRoot:                out2.StateRoot,
+			MessagePasserStorageRoot: out2.MessagePasserStorageRoot,
+			BlockHash:                hash2,
+		}
+		got2, err := dl.GetOutputV0(100, hash2)
+		require.NoError(t, err)
+		require.Equal(t, want2, got2)
+	})
+}
+
+func TestDenyList_OutputPersistence(t *testing.T) {
+	t.Parallel()
+
+	dir := filepath.Join(t.TempDir(), "denylist")
+
+	out := &eth.OutputV0{
+		StateRoot:                eth.Bytes32(common.HexToHash("0xpersist_state")),
+		MessagePasserStorageRoot: eth.Bytes32(common.HexToHash("0xpersist_msgpasser")),
+		BlockHash:                common.HexToHash("0xpersist_block"),
+	}
+	hash := common.HexToHash("0xdead")
+	want := &eth.OutputV0{
+		StateRoot:                out.StateRoot,
+		MessagePasserStorageRoot: out.MessagePasserStorageRoot,
+		BlockHash:                hash,
+	}
+
+	// Write and close
+	dl, err := OpenDenyList(dir)
 	require.NoError(t, err)
+	require.NoError(t, dl.Add(100, hash, 42, out.StateRoot, out.MessagePasserStorageRoot))
+	require.NoError(t, dl.Close())
+
+	// Reopen and verify output persisted
+	dl2, err := OpenDenyList(dir)
+	require.NoError(t, err)
+	defer dl2.Close()
+
+	got, err := dl2.GetOutputV0(100, hash)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+
+	records, err := dl2.GetDeniedRecords(100)
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+	require.Equal(t, hash, records[0].PayloadHash)
+	require.Equal(t, uint64(42), records[0].DecisionTimestamp)
+	require.Equal(t, out.StateRoot, records[0].StateRoot)
+	require.Equal(t, out.MessagePasserStorageRoot, records[0].MessagePasserStorageRoot)
+}
+
+func TestDenyList_GetDeniedRecords_IncludesRoots(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	dl, err := OpenDenyList(dir)
+	require.NoError(t, err)
+	defer dl.Close()
+
+	out1 := &eth.OutputV0{
+		StateRoot:                eth.Bytes32(common.HexToHash("0xstate1")),
+		MessagePasserStorageRoot: eth.Bytes32(common.HexToHash("0xmsg1")),
+		BlockHash:                common.HexToHash("0xblock1"),
+	}
+	out2 := &eth.OutputV0{
+		StateRoot:                eth.Bytes32(common.HexToHash("0xstate2")),
+		MessagePasserStorageRoot: eth.Bytes32(common.HexToHash("0xmsg2")),
+		BlockHash:                common.HexToHash("0xblock2"),
+	}
+	hash1 := common.HexToHash("0xaaaa")
+	hash2 := common.HexToHash("0xbbbb")
+
+	require.NoError(t, dl.Add(100, hash1, 10, out1.StateRoot, out1.MessagePasserStorageRoot))
+	require.NoError(t, dl.Add(100, hash2, 11, out2.StateRoot, out2.MessagePasserStorageRoot))
 
 	records, err := dl.GetDeniedRecords(100)
 	require.NoError(t, err)
 	require.Len(t, records, 2)
-	require.Equal(t, DenyRecord{PayloadHash: hashA, DecisionTimestamp: 0}, records[0])
-	require.Equal(t, DenyRecord{PayloadHash: hashB, DecisionTimestamp: 0}, records[1])
 
-	found, err := dl.Contains(100, hashA)
-	require.NoError(t, err)
-	require.True(t, found)
+	recordMap := make(map[common.Hash]DenyRecord)
+	for _, r := range records {
+		recordMap[r.PayloadHash] = r
+	}
+
+	require.Equal(t, out1.StateRoot, recordMap[hash1].StateRoot)
+	require.Equal(t, out1.MessagePasserStorageRoot, recordMap[hash1].MessagePasserStorageRoot)
+	require.Equal(t, uint64(10), recordMap[hash1].DecisionTimestamp)
+	require.Equal(t, out2.StateRoot, recordMap[hash2].StateRoot)
+	require.Equal(t, out2.MessagePasserStorageRoot, recordMap[hash2].MessagePasserStorageRoot)
+	require.Equal(t, uint64(11), recordMap[hash2].DecisionTimestamp)
 }

--- a/op-supernode/supernode/chain_container/super_authority.go
+++ b/op-supernode/supernode/chain_container/super_authority.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container/engine_controller"
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -89,6 +90,22 @@ func (c *simpleChainContainer) IsDenied(height uint64, payloadHash common.Hash) 
 		return false, fmt.Errorf("deny list not initialized")
 	}
 	return c.denyList.Contains(height, payloadHash)
+}
+
+// GetDeniedOutput returns the reconstructed OutputV0 for a denied block.
+func (c *simpleChainContainer) GetDeniedOutput(height uint64, payloadHash common.Hash) (*eth.OutputV0, error) {
+	if c.denyList == nil {
+		return nil, fmt.Errorf("deny list not initialized")
+	}
+	return c.denyList.GetOutputV0(height, payloadHash)
+}
+
+// OutputV0AtBlockNumber returns the full OutputV0 for the block at the given number.
+func (c *simpleChainContainer) OutputV0AtBlockNumber(ctx context.Context, l2BlockNum uint64) (*eth.OutputV0, error) {
+	if c.engine == nil {
+		return nil, engine_controller.ErrNoEngineClient
+	}
+	return c.engine.OutputV0AtBlockNumber(ctx, l2BlockNum)
 }
 
 // Interface satisfaction static check


### PR DESCRIPTION
# Tool Use Notice
Fully generated using repo and custom guidance. TDD, followed by two self-review rounds.

Current Status: Ready for peer review.

# What
Augments the current Denylist recording structure with additional output fields such that an OutputV0 can be constructed for the replaced blocks.

# Why 
Proofs needs to see both the pre-replacement and post-replacement outputs for every chain in order to correctly understand the roots being proposed and therefore correctly challenge games. We had been recording the block hashes, which allowed us to see that an optimistic root would differ from the validated one, but until now we haven't actually recorded these values.

# Related Work
This may not single-handedly address the SLA requests of superroot API for the Proofs team, but it's a known gap that factors into it.

# How

This PR stores the two non-redundant preimage fields (`StateRoot`, `MessagePasserStorageRoot`) as typed `eth.Bytes32` values alongside each denied block entry. `BlockHash` is already carried in the `BlockID`, so the full `OutputV0` can be reconstructed on demand without storing redundant data.

### Design decisions
- **Typed fields**: The preimage is stored as two `eth.Bytes32` fields. This makes JSON human-readable, prevents "wrong bytes" bugs, and avoids storing the redundant `BlockHash` and constant `Version` that would be inside the baked Output bytes.
- **Reconstruct on demand**: `InvalidHead.OutputV0()` and `DenyList.GetOutputV0()` reconstruct the full `*eth.OutputV0` from the stored fields + `BlockHash`. No serialization in the pipeline.
- **`newInvalidHead` returns error**: Where the Algo and Cycle functions had previously attached an Invalid Head, they now first call `newInvalidHead` which will gather all the output fields, and may return an error. 

### Files changed (9 production, 8 test)
| File | Change |
|------|--------|
| `chain_container/invalidation.go` | `DenyRecord` gains `StateRoot` + `MessagePasserStorageRoot`; `Add()` accepts two `eth.Bytes32`; `GetOutputV0()` reconstructs `*eth.OutputV0`; legacy decode removed |
| `chain_container/chain_container.go` | Interface: `InvalidateBlock(stateRoot, messagePasserStorageRoot)`, `GetDeniedOutput() *eth.OutputV0`, new `OutputV0AtBlockNumber` |
| `chain_container/super_authority.go` | `GetDeniedOutput` + `OutputV0AtBlockNumber` implementations |
| `activity/interop/types.go` | `InvalidHead` type with `StateRoot` + `MessagePasserStorageRoot` fields and `OutputV0()` reconstruction method |
| `activity/interop/verified_db.go` | `PendingInvalidation` gains `StateRoot` + `MessagePasserStorageRoot` |
| `activity/interop/interop.go` | `newInvalidHead` helper (returns error); `invalidateBlock` passes preimage fields; `applyPendingTransition` wiring |
| `activity/interop/algo.go` | All `InvalidHeads` assignments use `newInvalidHead`, propagate errors |
| `activity/interop/cycle.go` | Cycle participants use `newInvalidHead`, propagate errors |

## Tests
### DenyList storage (`invalidation_test.go`)
- existing `dl.Add()` calls updated for two `eth.Bytes32` params
- **`TestDenyList_GetOutputV0`** — 5 sub-tests:
  - returns reconstructed `*eth.OutputV0` for denied block
  - returns nil for non-denied height
  - returns nil for non-denied hash at valid height
  - isolates multiple records at same height
- **`TestDenyList_OutputPersistence`** — output fields survive close/reopen
- **`TestDenyList_GetDeniedRecords_IncludesRoots`** — `StateRoot` + `MessagePasserStorageRoot` present in record list
### ChainContainer interface (`invalidation_test.go`)
- `TestInvalidateBlock` updated to pass `StateRoot`/`MessagePasserStorageRoot` and assert via `GetOutputV0`
- **`TestGetDeniedOutput`** — 3 sub-tests:
  - returns `*eth.OutputV0` after invalidation
  - returns nil for non-denied block
  - returns error when denylist uninitialized
### Interop types (`types_test.go`, `verified_db_test.go`)
- `TestResult_IsValid` — 4 sub-tests updated for `InvalidHead`
- `TestResult_ToVerifiedResult` — 2 sub-tests updated for `InvalidHead`
- **`TestInvalidHead_JSONRoundTrip`** — marshal/unmarshal with `StateRoot` + `MessagePasserStorageRoot`
- **`TestInvalidHead_JSONRoundTrip_ZeroRoots`** — zero-value field behavior
- **`TestPendingInvalidation_JSONRoundTrip`** — with preimage fields
- `TestVerifiedDB_PendingTransition` — WAL round-trip with preimage fields
### Interop wiring (`interop_test.go`, `algo_test.go`, `decide_test.go`)
- `invalidateBlockCall` struct carries `stateRoot` + `messagePasserStorageRoot`
- `mockChainContainer.InvalidateBlock` records both fields
- `mockChainContainer.OutputV0AtBlockNumber` + `GetDeniedOutput` stubs added
- `InvalidHeads` map constructions updated to `map[eth.ChainID]InvalidHead{...}`
- `result.InvalidHeads[chainID]` assertions updated to `.BlockID`
- `algoMockChain` updated with new method signatures + stubs
- 3 direct `invalidateBlock` test calls updated
