### PR TITLE
fix(op-acceptance): remove MarkFlaky from stable tests

### DIFF
--- a/op-acceptance-tests/tests/depreqres/reqressyncdisabled/depreqres_test.go
+++ b/op-acceptance-tests/tests/depreqres/reqressyncdisabled/depreqres_test.go
@@ -12,11 +12,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
-const disabledReqRespSyncFlakyReason = "known flaky in the default acceptance run"
-
 func TestUnsafeChainNotStalling_DisabledReqRespSync(gt *testing.T) {
 	t := devtest.ParallelT(gt)
-	t.MarkFlaky(disabledReqRespSyncFlakyReason)
 	sys := presets.NewSingleChainMultiNodeWithoutCheck(t, common.ReqRespSyncDisabledOpts(sync.ELSync)...)
 	l := t.Logger()
 

--- a/op-acceptance-tests/tests/supernode/interop/timestamp_progression_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/timestamp_progression_test.go
@@ -7,8 +7,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 )
 
-const supernodeInteropFlakyReason = "known flaky in the default acceptance run"
-
 // TestSupernodeInteropVerifiedAt tests that the VerifiedAt endpoint returns
 // correct data after the interop activity has processed timestamps.
 func TestSupernodeInteropVerifiedAt(gt *testing.T) {
@@ -56,7 +54,6 @@ func TestSupernodeInteropVerifiedAt(gt *testing.T) {
 // This proves the supernode waits for all chains' local safe heads before verifying.
 func TestSupernodeInteropChainLag(gt *testing.T) {
 	t := devtest.ParallelT(gt)
-	t.MarkFlaky(supernodeInteropFlakyReason)
 	sys := newSupernodeInteropWithTimeTravel(t, 0)
 
 	blockTime := sys.L2A.Escape().RollupConfig().BlockTime


### PR DESCRIPTION
## Summary
- Remove `MarkFlaky` from `TestSupernodeInteropChainLag` and `TestUnsafeChainNotStalling_DisabledReqRespSync`
- CI stats show these tests have not been flaky recently
- Also removes the now-unused flaky reason constants

## Test plan
- [ ] CI passes with these tests running as non-flaky

🤖 Generated with [Claude Code](https://claude.com/claude-code)