### PR TITLE
fix(op-challenger): pass depset config to kona super executor

### DIFF
--- a/op-challenger/game/fault/trace/vm/kona_super_server_executor.go
+++ b/op-challenger/game/fault/trace/vm/kona_super_server_executor.go
@@ -54,6 +54,10 @@ func (s *KonaSuperExecutor) OracleCommand(cfg Config, dataDir string, inputs uti
 		args = append(args, "--l1-config-path", cfg.L1GenesisPath)
 	}
 
+	if cfg.DepsetConfigPath != "" {
+		args = append(args, "--depset-cfg", cfg.DepsetConfigPath)
+	}
+
 	if cfg.EnableExperimentalWitnessEndpoint {
 		args = append(args, "--enable-experimental-witness-endpoint")
 	}

--- a/op-challenger/game/fault/trace/vm/kona_super_server_executor_test.go
+++ b/op-challenger/game/fault/trace/vm/kona_super_server_executor_test.go
@@ -32,6 +32,51 @@ func TestKonaSuperExecutorWithWitnessEndpoint(t *testing.T) {
 	require.True(t, slices.Contains(args, "--enable-experimental-witness-endpoint"))
 }
 
+func TestKonaSuperExecutorWithDepsetConfig(t *testing.T) {
+	t.Parallel()
+	executor := NewKonaSuperExecutor()
+	cfg := Config{
+		Server:           "/path/to/kona",
+		L1:               "http://l1",
+		L1Beacon:         "http://beacon",
+		L2s:              []string{"http://l2a", "http://l2b"},
+		DepsetConfigPath: "/path/to/depset.json",
+	}
+	inputs := utils.LocalGameInputs{
+		L1Head:           common.Hash{0x11},
+		AgreedPreState:   []byte{0x01, 0x02},
+		L2Claim:          common.Hash{0x44},
+		L2SequenceNumber: big.NewInt(100),
+	}
+
+	args, err := executor.OracleCommand(cfg, "/data", inputs)
+	require.NoError(t, err)
+	require.True(t, slices.Contains(args, "--depset-cfg"))
+	idx := slices.Index(args, "--depset-cfg")
+	require.Equal(t, "/path/to/depset.json", args[idx+1])
+}
+
+func TestKonaSuperExecutorWithoutDepsetConfig(t *testing.T) {
+	t.Parallel()
+	executor := NewKonaSuperExecutor()
+	cfg := Config{
+		Server:   "/path/to/kona",
+		L1:       "http://l1",
+		L1Beacon: "http://beacon",
+		L2s:      []string{"http://l2a", "http://l2b"},
+	}
+	inputs := utils.LocalGameInputs{
+		L1Head:           common.Hash{0x11},
+		AgreedPreState:   []byte{0x01, 0x02},
+		L2Claim:          common.Hash{0x44},
+		L2SequenceNumber: big.NewInt(100),
+	}
+
+	args, err := executor.OracleCommand(cfg, "/data", inputs)
+	require.NoError(t, err)
+	require.False(t, slices.Contains(args, "--depset-cfg"))
+}
+
 func TestKonaSuperExecutorWithoutWitnessEndpoint(t *testing.T) {
 	t.Parallel()
 	executor := NewKonaSuperExecutor()


### PR DESCRIPTION
## Summary
- Pass `--depset-cfg` flag to kona-host in `KonaSuperExecutor.OracleCommand` when `DepsetConfigPath` is configured
- The dependency set config contains the message expiry window override needed for kona to detect expired messages. Without this flag, kona falls back to the hardcoded 7-day default.

## Test plan
- [x] Added `TestKonaSuperExecutorWithDepsetConfig` — verifies `--depset-cfg` flag and value are present
- [x] Added `TestKonaSuperExecutorWithoutDepsetConfig` — verifies flag is absent when config is empty
- [x] All existing tests pass (`go test ./op-challenger/game/fault/trace/vm/ -run TestKonaSuperExecutor -v`)
- [x] `go vet` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>