### PR TITLE
fix(kona): cache replacement block receipts during consolidation

### DIFF
--- a/rust/kona/crates/proof/proof-interop/src/consolidation.rs
+++ b/rust/kona/crates/proof/proof-interop/src/consolidation.rs
@@ -122,12 +122,14 @@ where
         chain_ids: &[u64],
     ) -> Result<(), ConsolidationError> {
         for chain_id in chain_ids {
-            // Find the optimistic block header for the chain ID.
+            // Find the optimistic block header for the chain ID. Clone to release the borrow
+            // on `self.interop_provider` so we can call `cache_receipts` later.
             let header = self
                 .interop_provider
                 .local_safe_heads()
                 .get(chain_id)
-                .ok_or(MessageGraphError::EmptyDependencySet)?;
+                .ok_or(MessageGraphError::EmptyDependencySet)?
+                .clone();
 
             // Look up the parent header for the block.
             let parent_header =
@@ -177,7 +179,7 @@ where
 
             // Add the deposit replacement system transaction at the end of the list.
             transactions.push(Self::craft_replacement_transaction(
-                header,
+                &header,
                 original_optimistic_block.output_root,
             ));
 
@@ -234,8 +236,25 @@ where
 
             // Execute the block and take the new header. At this point, the block is guaranteed to
             // be canonical.
-            let new_header = executor.build_block(deposit_only_payload)?.header;
+            let outcome = executor.build_block(deposit_only_payload)?;
+            let new_header = outcome.header;
+
+            // Cache the receipts for the replacement block. The next consolidation loop will
+            // need to derive the message graph from this block's receipts, but the block only
+            // exists in-memory — it can't be fetched from the L2 node.
+            self.interop_provider
+                .cache_receipts(new_header.hash(), outcome.execution_result.receipts);
+
             let new_output_root = executor.compute_output_root()?;
+
+            info!(
+                target: "superchain_consolidator",
+                chain_id = *chain_id,
+                old_hash = ?header.hash(),
+                new_hash = ?new_header.hash(),
+                new_output_root = ?new_output_root,
+                "Replaced invalid block with deposit-only block"
+            );
 
             // Replace the original optimistic block with the deposit only block.
             *original_optimistic_block = OptimisticBlock::new(new_header.hash(), new_output_root);

--- a/rust/kona/crates/proof/proof-interop/src/provider.rs
+++ b/rust/kona/crates/proof/proof-interop/src/provider.rs
@@ -24,6 +24,9 @@ pub struct OracleInteropProvider<C> {
     boot: BootInfo,
     /// The local safe head block header cache.
     local_safe_heads: HashMap<u64, Sealed<Header>>,
+    /// Cached receipts for replacement blocks built during consolidation.
+    /// These blocks only exist in-memory and can't be fetched from the L2 node.
+    cached_receipts: HashMap<B256, Vec<OpReceiptEnvelope>>,
     /// The chain ID for the current call context. Used to declare the chain ID for the trie hints.
     chain_id: Arc<RwLock<Option<u64>>>,
 }
@@ -42,6 +45,7 @@ where
             oracle,
             boot,
             local_safe_heads: local_safe_headers,
+            cached_receipts: HashMap::default(),
             chain_id: Arc::new(RwLock::new(None)),
         }
     }
@@ -49,6 +53,12 @@ where
     /// Returns a reference to the local safe heads map.
     pub const fn local_safe_heads(&self) -> &HashMap<u64, Sealed<Header>> {
         &self.local_safe_heads
+    }
+
+    /// Caches receipts for a replacement block that was built in-memory during consolidation.
+    /// These blocks don't exist on the L2 node, so receipts must be served from this cache.
+    pub fn cache_receipts(&mut self, block_hash: B256, receipts: Vec<OpReceiptEnvelope>) {
+        self.cached_receipts.insert(block_hash, receipts);
     }
 
     /// Replaces a local safe head with the given header.
@@ -178,6 +188,10 @@ where
         chain_id: u64,
         block_hash: B256,
     ) -> Result<Vec<OpReceiptEnvelope>, Self::Error> {
+        // Check the cache first for replacement blocks built during consolidation.
+        if let Some(receipts) = self.cached_receipts.get(&block_hash) {
+            return Ok(receipts.clone());
+        }
         let header = self.header_by_hash(chain_id, block_hash).await?;
         self.derive_receipts(chain_id, block_hash, &header).await
     }
@@ -520,5 +534,28 @@ mod tests {
 
         assert_eq!(header.hash_slow(), expected_hash);
         assert_eq!(header.number, fixture.target_block_number);
+    }
+
+    #[test]
+    fn test_cached_receipts_served_from_cache() {
+        use alloc::vec;
+        use alloy_primitives::B256;
+        use op_alloy_consensus::OpReceiptEnvelope;
+
+        let (client, fixture) = load_fixture();
+        let mut provider = build_provider(client, &fixture);
+
+        let fake_hash = B256::from([0x42u8; 32]);
+        let receipts: Vec<OpReceiptEnvelope> = vec![];
+
+        // Cache empty receipts for a fake block
+        provider.cache_receipts(fake_hash, receipts.clone());
+
+        // Verify the cache is hit
+        let result = kona_proof::block_on(async {
+            provider.receipts_by_hash(fixture.chain_id, fake_hash).await
+        });
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().len(), 0);
     }
 }

--- a/rust/kona/crates/proof/proof-interop/src/provider.rs
+++ b/rust/kona/crates/proof/proof-interop/src/provider.rs
@@ -549,7 +549,7 @@ mod tests {
         let receipts: Vec<OpReceiptEnvelope> = vec![];
 
         // Cache empty receipts for a fake block
-        provider.cache_receipts(fake_hash, receipts.clone());
+        provider.cache_receipts(fake_hash, receipts);
 
         // Verify the cache is hit
         let result = kona_proof::block_on(async {


### PR DESCRIPTION
## Summary

- Cache replacement block receipts in `OracleInteropProvider` so the second consolidation loop can read them without hitting the L2 node oracle
- After `SuperchainConsolidator::re_execute_deposit_only` builds a deposit-only replacement block, store its receipts keyed by block hash in a new `cached_receipts` field
- `receipts_by_hash` checks the cache first, falling back to the oracle only for blocks that exist on-chain

## Context

When the `SuperchainConsolidator` replaces an invalid block with a deposit-only block, the replacement exists only in memory. On the next consolidation iteration, `MessageGraph::derive` calls `receipts_by_hash` for the replacement block's hash. Because the block was never persisted to the L2 node, the oracle returns invalid data, causing an RLP decode error and failing the proof.

## Test plan

- [x] `cargo check -p kona-proof-interop` passes
- [x] `cargo clippy -p kona-proof-interop --release` has no errors
- [x] `cargo test -p kona-proof-interop test_cached_receipts` passes — unit test verifies cache hit bypasses oracle

🤖 Generated with [Claude Code](https://claude.com/claude-code)