### PR TITLE
fix(proofs-exex): error if state unavailable instead of falling back to historical provider

### DIFF
--- a/rust/op-reth/crates/rpc/src/state.rs
+++ b/rust/op-reth/crates/rpc/src/state.rs
@@ -46,12 +46,12 @@ where
                 .get_earliest_block_number()
                 .map_err(|e| ProviderError::Database(e.into()))?,
         ) else {
-            // if no earliest block, db is empty - use historical provider
-            return Ok(historical_provider);
+            // if no earliest block, db is empty, return error
+            return Err(ProviderError::StateForNumberNotFound(block_number));
         };
 
         if block_number < earliest_block_number || block_number > latest_block_number {
-            return Ok(historical_provider);
+            return Err(ProviderError::StateForNumberNotFound(block_number));
         }
 
         let external_overlay_provider =


### PR DESCRIPTION
**Description**

This PR updates the proofs ExEx state provider logic to return an error if the requested block is outside the available proofs window, instead of falling back to the historical provider. Using the historical provider for state root-related methods can cause excessive memory usage and OOMs.

**Tests**

e2e tests

**Additional context**

NA

**Metadata**

Ref: https://github.com/base/base/pull/1840
