### PR TITLE
fix(op-node/derive): subtract channel size only when pruning frames

### DIFF
--- a/op-node/rollup/derive/channel.go
+++ b/op-node/rollup/derive/channel.go
@@ -91,8 +91,8 @@ func (ch *Channel) AddFrame(frame Frame, l1InclusionBlock eth.L1BlockRef) error 
 		for idx, prunedFrame := range ch.inputs {
 			if idx >= uint64(ch.endFrameNumber) {
 				delete(ch.inputs, idx)
+				ch.size -= frameSize(prunedFrame)
 			}
-			ch.size -= frameSize(prunedFrame)
 		}
 		ch.highestFrameNumber = ch.endFrameNumber
 	}


### PR DESCRIPTION
Closes #19858

## Summary

Fixes channel `size` accounting when pruning frames after the closing frame: decrement `ch.size` only when a frame is actually deleted, not once per map entry during iteration.

## Testing

- `go test ./op-node/rollup/derive/...`
