### PR TITLE
fix(op-batcher): update oldest L1 origin using oldest, not latest

### DIFF
--- a/op-batcher/batcher/channel_builder.go
+++ b/op-batcher/batcher/channel_builder.go
@@ -189,7 +189,7 @@ func (c *ChannelBuilder) AddBlock(block SizedBlock) (*derive.L1BlockInfo, error)
 			Number: l1info.Number,
 		}
 	}
-	if c.oldestL1Origin.Number == 0 || l1info.Number < c.latestL1Origin.Number {
+	if c.oldestL1Origin.Number == 0 || l1info.Number < c.oldestL1Origin.Number {
 		c.oldestL1Origin = eth.BlockID{
 			Hash:   l1info.BlockHash,
 			Number: l1info.Number,


### PR DESCRIPTION
Closes #19859

## Summary

Fixes `ChannelBuilder.AddBlock` so `oldestL1Origin` is updated when the new block's L1 origin number is **below the current oldest**, not when it is below `latestL1Origin`. The latter does not correctly track the minimum L1 block number across buffered blocks.

## Testing

- `go test ./op-batcher/batcher/... -short`
