### PR TITLE
fix(op-service/eth): correct Bytes256 UnmarshalFixedText type name

### DIFF
--- a/op-service/eth/types.go
+++ b/op-service/eth/types.go
@@ -176,7 +176,7 @@ func (b *Bytes256) UnmarshalJSON(text []byte) error {
 }
 
 func (b *Bytes256) UnmarshalText(text []byte) error {
-	return hexutil.UnmarshalFixedText("Bytes32", text, b[:])
+	return hexutil.UnmarshalFixedText("Bytes256", text, b[:])
 }
 
 func (b Bytes256) MarshalText() ([]byte, error) {


### PR DESCRIPTION
Closes #19862

## Summary

Fix `(*Bytes256).UnmarshalText` to pass `"Bytes256"` to `hexutil.UnmarshalFixedText` instead of the mistaken `"Bytes32"` copy-paste label.

## Testing

- `go test ./op-service/eth/... -short`
