### PR TITLE
fix(op-service/eth): use Blob label in UnmarshalFixedText

### DIFF
--- a/op-service/eth/blob.go
+++ b/op-service/eth/blob.go
@@ -43,7 +43,7 @@ func (b *Blob) UnmarshalJSON(text []byte) error {
 }
 
 func (b *Blob) UnmarshalText(text []byte) error {
-	return hexutil.UnmarshalFixedText("Bytes32", text, b[:])
+	return hexutil.UnmarshalFixedText("Blob", text, b[:])
 }
 
 func (b *Blob) MarshalText() ([]byte, error) {


### PR DESCRIPTION
Closes #19864

## Summary

Use `"Blob"` in `hexutil.UnmarshalFixedText` for `(*Blob).UnmarshalText` instead of the incorrect `"Bytes32"` label.

## Testing

- `go test ./op-service/eth/... -short`
