### PR TITLE
fix(contracts-bedrock): correct minOwners require message in LivenessModule

### DIFF
--- a/packages/contracts-bedrock/src/safe/LivenessModule.sol
+++ b/packages/contracts-bedrock/src/safe/LivenessModule.sol
@@ -77,7 +77,7 @@ contract LivenessModule is ISemver {
         FALLBACK_OWNER = _fallbackOwner;
         MIN_OWNERS = _minOwners;
         address[] memory owners = _safe.getOwners();
-        require(_minOwners <= owners.length, "LivenessModule: minOwners must be less than the number of owners");
+        require(_minOwners <= owners.length, "LivenessModule: minOwners must be less than or equal to the number of owners");
         require(_thresholdPercentage > 0, "LivenessModule: thresholdPercentage must be greater than 0");
         require(_thresholdPercentage <= 100, "LivenessModule: thresholdPercentage must be less than or equal to 100");
     }


### PR DESCRIPTION
Closes #19866

## Summary

Align the `minOwners` constructor `require` revert string with the actual condition (`<=`): say "less than or equal to the number of owners" instead of strictly "less than".

## Testing

- String-only change; no logic change. Run contracts tests for this package if desired: `cd packages/contracts-bedrock && forge test --match-contract Liveness` (or full suite in CI).
