### PR TITLE
fix(op-service/sources): remove dead ToBlockID in FetchReceipts

### DIFF
--- a/op-service/sources/eth_client.go
+++ b/op-service/sources/eth_client.go
@@ -353,7 +353,7 @@ func (s *EthClient) FetchReceipts(ctx context.Context, blockHash common.Hash) (e
 		return nil, nil, fmt.Errorf("querying block: %w", err)
 	}
 
-	txHashes, _ := eth.TransactionsToHashes(txs), eth.ToBlockID(info)
+	txHashes := eth.TransactionsToHashes(txs)
 	receipts, err := s.recProvider.FetchReceipts(ctx, info, txHashes)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
Closes #19870

## Summary

Remove the unused `eth.ToBlockID(info)` evaluation in `EthClient.FetchReceipts`; only compute transaction hashes for the receipt fetch.

## Testing

- `go test ./op-service/sources/... -short`
