### PR TITLE
fix(kona/protocol): add TxGases span decode error for gas varints

### DIFF
--- a/rust/kona/crates/protocol/protocol/src/batch/errors.rs
+++ b/rust/kona/crates/protocol/protocol/src/batch/errors.rs
@@ -75,6 +75,9 @@ pub enum SpanDecodingError {
     /// Failed to decode transaction nonces
     #[error("Failed to decode transaction nonces")]
     TxNonces,
+    /// Failed to decode transaction gas limits
+    #[error("Failed to decode transaction gas limits")]
+    TxGases,
     /// Mismatch in length between the transaction type and signature arrays in a span batch
     /// transaction payload.
     #[error("Mismatch in length between the transaction type and signature arrays")]

--- a/rust/kona/crates/protocol/protocol/src/batch/errors.rs
+++ b/rust/kona/crates/protocol/protocol/src/batch/errors.rs
@@ -72,6 +72,9 @@ pub enum SpanDecodingError {
     /// Failed to decode transaction nonces
     #[error("Failed to decode transaction nonces")]
     TxNonces,
+    /// Failed to decode transaction gas limits
+    #[error("Failed to decode transaction gas limits")]
+    TxGases,
     /// Mismatch in length between the transaction type and signature arrays in a span batch
     /// transaction payload.
     #[error("Mismatch in length between the transaction type and signature arrays")]

--- a/rust/kona/crates/protocol/protocol/src/batch/transactions.rs
+++ b/rust/kona/crates/protocol/protocol/src/batch/transactions.rs
@@ -185,7 +185,7 @@ impl SpanBatchTransactions {
         let mut gases = Vec::with_capacity(self.total_block_tx_count as usize);
         for _ in 0..self.total_block_tx_count {
             let (gas, remaining) = unsigned_varint::decode::u64(r)
-                .map_err(|_| SpanBatchError::Decoding(SpanDecodingError::TxNonces))?;
+                .map_err(|_| SpanBatchError::Decoding(SpanDecodingError::TxGases))?;
             gases.push(gas);
             *r = remaining;
         }
@@ -404,6 +404,13 @@ mod tests {
             result,
             Err(SpanBatchError::Decoding(SpanDecodingError::InvalidTransactionData))
         );
+    }
+
+    #[test]
+    fn test_decode_tx_gases_truncated() {
+        let mut txs = SpanBatchTransactions { total_block_tx_count: 1, ..Default::default() };
+        let result = txs.decode_tx_gases(&mut [].as_slice());
+        assert_eq!(result, Err(SpanBatchError::Decoding(SpanDecodingError::TxGases)));
     }
 
     #[test]

--- a/rust/kona/crates/protocol/protocol/src/batch/transactions.rs
+++ b/rust/kona/crates/protocol/protocol/src/batch/transactions.rs
@@ -185,7 +185,7 @@ impl SpanBatchTransactions {
         let mut gases = Vec::with_capacity(self.total_block_tx_count as usize);
         for _ in 0..self.total_block_tx_count {
             let (gas, remaining) = unsigned_varint::decode::u64(r)
-                .map_err(|_| SpanBatchError::Decoding(SpanDecodingError::TxNonces))?;
+                .map_err(|_| SpanBatchError::Decoding(SpanDecodingError::TxGases))?;
             gases.push(gas);
             *r = remaining;
         }


### PR DESCRIPTION
Closes #19873

## Summary

- Add `SpanDecodingError::TxGases` with a clear error message for gas-limit varint decode failures.
- Map `decode_tx_gases` failures to `TxGases` instead of incorrectly using `TxNonces`.

## Testing

- `cd rust/kona && cargo check -p kona-protocol --lib`
