### PR TITLE
fix(op-service/sources): release receipts fetch lock on inner error

### DIFF
--- a/op-service/sources/receipts_caching.go
+++ b/op-service/sources/receipts_caching.go
@@ -72,6 +72,7 @@ func (p *CachingReceiptsProvider) FetchReceipts(ctx context.Context, blockInfo e
 
 	r, err := p.inner.FetchReceipts(ctx, blockInfo, txHashes)
 	if err != nil {
+		p.deleteFetchingLock(block.Hash)
 		return nil, err
 	}
 


### PR DESCRIPTION
Closes #19875

## Summary

Call `deleteFetchingLock` when `inner.FetchReceipts` fails so the per-block entry is not left in `fetching` forever.

## Testing

- `go test ./op-service/sources/... -short`
