### PR TITLE
Update op-deployer upgrade command details

### DIFF
--- a/docs/public-docs/chain-operators/tools/op-deployer/reference/custom-deployments.mdx
+++ b/docs/public-docs/chain-operators/tools/op-deployer/reference/custom-deployments.mdx
@@ -125,7 +125,8 @@ genesis and rollup config files.
 ## Upgrading
 
 <Warning>
-The `op-deployer upgrade` command has been deprecated. For L1 contract upgrades, use
+The `op-deployer upgrade` command supports upgrades up to `op-contracts/v5.0.0` only. It does **not** support
+upgrading from `op-contracts/v5.0.0` to `op-contracts/v6.0.0`. For upgrades beyond v5.0.0, use
 [superchain-ops](/chain-operators/tutorials/l1-contract-upgrades/superchain-ops-guide) or interact with the
-OPCM directly. See the [deprecation notice](/notices/op-deployer-upgrade-deprecation) for details.
+OPCM directly. See the [notice](/notices/op-deployer-upgrade-deprecation) for details.
 </Warning>

--- a/docs/public-docs/chain-operators/tools/op-deployer/usage/upgrade.mdx
+++ b/docs/public-docs/chain-operators/tools/op-deployer/usage/upgrade.mdx
@@ -1,10 +1,11 @@
 ---
-title: Upgrade Command (Deprecated)
-description: The op-deployer upgrade command has been deprecated.
+title: Upgrade Command
+description: The op-deployer upgrade command supports upgrades up to op-contracts/v5.0.0.
 ---
 
 <Warning>
-The `op-deployer upgrade` command has been deprecated and is no longer maintained. For L1 contract upgrades, use
+The `op-deployer upgrade` command can be used for upgrades up to `op-contracts/v5.0.0`. It does **not** support
+upgrading from `op-contracts/v5.0.0` to `op-contracts/v6.0.0`. For upgrades beyond v5.0.0, use
 [superchain-ops](/chain-operators/tutorials/l1-contract-upgrades/superchain-ops-guide) or interact with the
-OPCM directly. See the [deprecation notice](/notices/op-deployer-upgrade-deprecation) for details.
+OPCM directly. See the [notice](/notices/op-deployer-upgrade-deprecation) for details.
 </Warning>

--- a/docs/public-docs/chain-operators/tutorials/l1-contract-upgrades/op-deployer-upgrade.mdx
+++ b/docs/public-docs/chain-operators/tutorials/l1-contract-upgrades/op-deployer-upgrade.mdx
@@ -1,25 +1,28 @@
 ---
-title: Upgrade L1 contracts using op-deployer (Deprecated)
-description: The op-deployer upgrade command has been deprecated. This page documents which versions it was available for.
+title: Upgrade L1 contracts using op-deployer
+description: Learn how to use the op-deployer upgrade command to upgrade L1 contracts up to op-contracts/v5.0.0.
 ---
 
 <Warning>
-The `op-deployer upgrade` command has been deprecated and is no longer maintained. For L1 contract upgrades, use
+The `op-deployer upgrade` command can be used for upgrades up to `op-contracts/v5.0.0`. It does **not** support
+upgrading from `op-contracts/v5.0.0` to `op-contracts/v6.0.0`. For upgrades beyond v5.0.0, use
 [superchain-ops](/chain-operators/tutorials/l1-contract-upgrades/superchain-ops-guide) or interact with the
 OPCM directly. See the [deprecation notice](/notices/op-deployer-upgrade-deprecation) for details.
 </Warning>
 
 ## Version availability
 
-The `op-deployer upgrade` command supported the following contract upgrade paths:
+The `op-deployer upgrade` command supports the following contract upgrade paths (upgrades must be performed in steps):
 
 | Upgrade path | op-deployer version | Status |
 |---|---|---|
-| op-contracts/v1.8.0 to op-contracts/v2.0.0 | v0.2.x | Deprecated |
-| op-contracts/v2.0.0 to op-contracts/v3.0.0 | v0.3.x | Deprecated |
+| op-contracts/v1.8.0 to op-contracts/v2.0.0 | v0.2.x | Available |
+| op-contracts/v2.0.0 to op-contracts/v3.0.0 | v0.3.x | Available |
+| op-contracts/v3.0.0 to op-contracts/v4.0.0 | v0.4.x | Available |
+| op-contracts/v4.0.0 to op-contracts/v5.0.0 | v0.5.x | Available |
 
 Each minor version of `op-deployer` supported a single release of the governance-approved smart contracts. See the [releases guide](/chain-operators/tools/op-deployer/reference/releases) for more information on versioning.
 
 ## Migration
 
-For all future L1 contract upgrades, use [superchain-ops](/chain-operators/tutorials/l1-contract-upgrades/superchain-ops-guide). For non-Optimism governed chains, you can interact with the OPCM directly using your own tooling.
+For L1 contract upgrades beyond `op-contracts/v5.0.0`, use [superchain-ops](/chain-operators/tutorials/l1-contract-upgrades/superchain-ops-guide). For non-Optimism governed chains, you can interact with the OPCM directly using your own tooling.

--- a/docs/public-docs/chain-operators/tutorials/l1-contract-upgrades/superchain-ops-guide.mdx
+++ b/docs/public-docs/chain-operators/tutorials/l1-contract-upgrades/superchain-ops-guide.mdx
@@ -5,7 +5,7 @@ description: Learn about using superchain-ops to upgrade your chain
 
 This guide outlines the process for upgrading Optimism chains using the `superchain-ops` repository. It's intended primarily for OP Stack chains managed by the Security Council, those with the Foundation or Security Council as signers, and/or chains requiring a highly secure process.
 
-For chains that don't require the enhanced security of superchain-ops or security council signing, alternative upgrade tooling may be used. Note that the `op-deployer upgrade` command [has been deprecated](/notices/op-deployer-upgrade-deprecation).
+For chains that don't require the enhanced security of superchain-ops or security council signing, alternative upgrade tooling may be used. Note that the `op-deployer upgrade` command only supports upgrades [up to `op-contracts/v5.0.0`](/notices/op-deployer-upgrade-deprecation).
 
 For non-Optimism governed chains, you can use your own tooling to interact with the OPCM directly to upgrade your chain.
 

--- a/docs/public-docs/notices/op-deployer-upgrade-deprecation.mdx
+++ b/docs/public-docs/notices/op-deployer-upgrade-deprecation.mdx
@@ -11,17 +11,18 @@ categories:
 is_imported_content: 'false'
 ---
 
-The `upgrade` and `manage` commands in `op-deployer` are deprecated and no longer maintained. OP Labs uses the OP Contracts Manager (OPCM) for upgrade and chain management operations, and will focus `op-deployer` on initial chain deployments only.
+The `manage` command in `op-deployer` is deprecated and no longer maintained. The `upgrade` command can still be used for upgrades up to `op-contracts/v5.0.0` but does **not** support upgrading from `op-contracts/v5.0.0` to `op-contracts/v6.0.0`. For upgrades beyond v5.0.0, use the OPCM directly or superchain-ops.
 
 ## What this means
 
-*   The `op-deployer upgrade` and `op-deployer manage` subcommands are no longer supported and will not receive updates.
+*   The `op-deployer manage` subcommand is no longer supported and will not receive updates.
+*   The `op-deployer upgrade` command can be used for the upgrade path from `op-contracts/v1.8.0` up to `op-contracts/v5.0.0` (in steps: v1.8.0 → v2.0.0 → v3.0.0 → v4.0.0 → v5.0.0). It does **not** support upgrading from `op-contracts/v5.0.0` to `op-contracts/v6.0.0`.
 *   `op-deployer` itself is **not** deprecated. It remains the recommended tool for initial chain deployments via the `bootstrap`, `init`, `apply`, and `inspect` commands.
-*   For L1 contract upgrades, use [superchain-ops](/chain-operators/tutorials/l1-contract-upgrades/superchain-ops-guide) or interact with the OPCM directly.
+*   For L1 contract upgrades beyond `op-contracts/v5.0.0`, use [superchain-ops](/chain-operators/tutorials/l1-contract-upgrades/superchain-ops-guide) or interact with the OPCM directly.
 
 ## Action required
 
-If you are currently using `op-deployer upgrade` or `op-deployer manage` for L1 contract upgrades, migrate to one of the following approaches:
+If you need to upgrade beyond `op-contracts/v5.0.0`, migrate to one of the following approaches:
 
 1.  **[superchain-ops](/chain-operators/tutorials/l1-contract-upgrades/superchain-ops-guide)** — recommended for OP Stack chains managed by the Security Council, chains with the Foundation or Security Council as signers, and chains requiring a highly secure upgrade process.
 2.  **OPCM directly** — for non-Optimism governed chains, you can interact with the OP Contracts Manager directly using your own tooling.


### PR DESCRIPTION
Edit mentions of op-deployer upgrade command deprecation, specifying that it can still be used up to v5.0.0. 