### PR TITLE
feat(op-node): add L2CM feature toggle for Karst NUT bundle

### DIFF
--- a/op-node/rollup/derive/attributes.go
+++ b/op-node/rollup/derive/attributes.go
@@ -158,7 +158,7 @@ func (ba *FetchingAttributesBuilder) PreparePayloadAttributes(ctx context.Contex
 	// additional gas is allocated to the upgrade block so that upgrade transactions
 	// don't need to fit within the system tx gas limit.
 	var upgradeGas uint64
-	if ba.rollupCfg.IsKarstActivationBlock(nextL2Time) {
+	if ba.rollupCfg.IsL2CMActivationBlock(nextL2Time) {
 		nutTxs, nutGas, err := UpgradeTransactions(forks.Karst)
 		if err != nil {
 			return nil, NewCriticalError(fmt.Errorf("failed to build karst network upgrade txs: %w", err))

--- a/op-node/rollup/toggles.go
+++ b/op-node/rollup/toggles.go
@@ -8,3 +8,17 @@ package rollup
 // func (c *Config) IsMinBaseFee(time uint64) bool {
 // 	return c.IsJovian(time) // Replace with return false to disable
 // }
+
+// IsL2CM gates the L2 Contracts Manager upgrade transactions at the Karst fork.
+// Replace with return false to disable NUT bundle execution during development.
+func (c *Config) IsL2CM(time uint64) bool {
+	return c.IsKarst(time)
+}
+
+// IsL2CMActivationBlock returns true only at the exact activation block.
+func (c *Config) IsL2CMActivationBlock(l2BlockTime uint64) bool {
+	if !c.IsL2CM(l2BlockTime) {
+		return false
+	}
+	return c.IsKarstActivationBlock(l2BlockTime)
+}


### PR DESCRIPTION
## Summary
- Adds `IsL2CM` / `IsL2CMActivationBlock` toggle to `op-node/rollup/toggles.go`
- Gates Karst NUT bundle execution in `attributes.go` behind the toggle
- Toggle delegates to `IsKarst` — set to `return false` to disable during development

## Test plan
- [x] `go build ./op-node/rollup/...` passes
- [x] `go test ./op-node/rollup/derive/...` passes