### PR TITLE
fix(op-e2e): reduce kona snapshot frequency to stabilize preimage tests

### DIFF
--- a/op-e2e/e2eutils/challenger/helper.go
+++ b/op-e2e/e2eutils/challenger/helper.go
@@ -219,6 +219,12 @@ func NewChallengerConfig(t *testing.T, sys EndpointProvider, l2NodeName string, 
 		// Limit concurrency to something more reasonable when there are also multiple tests executing in parallel
 		cfg.MaxConcurrency = 4
 	}
+	// Use a much lower snapshot frequency in tests so that kona creates intermediate snapshots.
+	// The default (1 billion) means no snapshots are created for typical test traces (~100K steps),
+	// forcing every kona invocation to start from the absolute prestate. With multiple kona runs
+	// per bisection level and parallel subtests, this causes severe CPU contention under CI load.
+	cfg.Cannon.SnapshotFreq = 10_000
+	cfg.CannonKona.SnapshotFreq = 10_000
 	cfg.MetricsConfig = metrics.CLIConfig{
 		Enabled:    true,
 		ListenAddr: "127.0.0.1",


### PR DESCRIPTION
## Summary

- Reduces kona snapshot frequency from 1 billion to 10,000 steps in test challenger config
- Fixes flaky `TestSuperCannonStepWithPreimage_nonExistingPreimage` subtests (`blob-mt-cannon-next`, `sha256-mt-cannon-next`) that timeout at ~31 min but pass on retry in ~11 min

## Root Cause

The default snapshot frequency of 1 billion steps means **no intermediate snapshots are created** for typical test traces (~100K steps). Every kona invocation during execution game bisection starts from the absolute prestate (step 0).

During `ChallengeToPreimageLoad`, multiple kona processes run concurrently:
- The test runs `FindStep` (kona from step 0 to preimage target)
- The test runs `GetStepData` (kona to generate proof)
- During bisection, both the test and challenger run kona for each claim
- Three subtests (blob, sha256, precompile) run in parallel, multiplying the load

With no intermediate snapshots, every kona invocation restarts from scratch. Under CI load with 6+ simultaneous kona processes, the challenger cannot compute and upload the preimage within the 20-minute `WaitForPreimageInOracle` timeout.

## Why Flaky (Not Always Failing)

The non-deterministic trigger is **CI CPU contention**. When the three preimage subtests run in parallel alongside other test jobs, the combined kona CPU pressure exceeds what the 20-minute timeout can accommodate. On retry, only failed subtests re-run (1-2 instead of 3), reducing contention enough for the challenger to complete within the timeout.

## Fix

Set `SnapshotFreq = 10_000` for both `Cannon` and `CannonKona` configs in `NewChallengerConfig`. This creates intermediate snapshots every 10K steps, allowing subsequent kona invocations to start from the nearest snapshot instead of from scratch. For a 100K-step trace, this means ~10 snapshots and a maximum of 10K steps per kona run instead of 100K.

## Test plan

- [ ] CI passes for `TestSuperCannonStepWithPreimage_nonExistingPreimage` subtests
- [ ] Other cannon-based faultproof tests still pass (they also benefit from lower snapshot frequency)
- [ ] No regressions in test runtime (snapshot creation overhead is negligible compared to kona re-execution savings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>