### PR TITLE
fix(kona): remove obsolete replacement deposit tx from consolidation

### DIFF
--- a/op-acceptance-tests/tests/interop/proofs/serial/interop_fault_proofs_test.go
+++ b/op-acceptance-tests/tests/interop/proofs/serial/interop_fault_proofs_test.go
@@ -64,6 +64,8 @@ func TestInteropFaultProofs_VariedBlockTimes_FasterChainB(gt *testing.T) {
 
 func TestInteropFaultProofs_InvalidBlock(gt *testing.T) {
 	t := devtest.SerialT(gt)
+	// TODO(#19411): Re-enable once #19880 is merged.
+	t.Skip("Requires #19880 (supernode denylist output as optimistic)")
 	sys := presets.NewSimpleInteropSupernodeProofs(t, presets.WithChallengerCannonKonaEnabled())
 	sfp.RunInvalidBlockTest(t, sys)
 }

--- a/op-acceptance-tests/tests/interop/proofs/serial/interop_fault_proofs_test.go
+++ b/op-acceptance-tests/tests/interop/proofs/serial/interop_fault_proofs_test.go
@@ -64,9 +64,6 @@ func TestInteropFaultProofs_VariedBlockTimes_FasterChainB(gt *testing.T) {
 
 func TestInteropFaultProofs_InvalidBlock(gt *testing.T) {
 	t := devtest.SerialT(gt)
-	// TODO(#19411): Re-enable once the invalid-block supernode proof expectations match the
-	// native Kona FPP and challenger provider behavior again.
-	t.Skip("Temporarily skipped while investigating invalid-block supernode proof mismatches")
 	sys := presets.NewSimpleInteropSupernodeProofs(t, presets.WithChallengerCannonKonaEnabled())
 	sfp.RunInvalidBlockTest(t, sys)
 }

--- a/rust/kona/crates/proof/proof-interop/src/consolidation.rs
+++ b/rust/kona/crates/proof/proof-interop/src/consolidation.rs
@@ -3,10 +3,9 @@
 use crate::{BootInfo, OptimisticBlock, OracleInteropProvider, PreState};
 use alloc::{collections::BTreeSet, vec::Vec};
 use alloy_consensus::{Header, Sealed};
-use alloy_eips::Encodable2718;
 use alloy_evm::{EvmFactory, FromRecoveredTx, FromTxWithEncoded};
 use alloy_op_evm::block::OpTxEnv;
-use alloy_primitives::{Address, B256, Bytes, Sealable, TxKind, U256, address};
+use alloy_primitives::Sealable;
 use alloy_rpc_types_engine::PayloadAttributes;
 use core::fmt::Debug;
 use kona_executor::{Eip1559ValidationError, ExecutorError, StatelessL2Builder};
@@ -14,9 +13,8 @@ use kona_interop::{MessageGraph, MessageGraphError};
 use kona_mpt::OrderedListWalker;
 use kona_preimage::CommsClient;
 use kona_proof::{errors::OracleProviderError, l2::OracleL2ChainProvider};
-use kona_protocol::OutputRoot;
 use kona_registry::{HashMap, ROLLUP_CONFIGS};
-use op_alloy_consensus::{InteropBlockReplacementDepositSource, OpTxEnvelope, OpTxType, TxDeposit};
+use op_alloy_consensus::{OpTxEnvelope, OpTxType};
 use op_alloy_rpc_types_engine::OpPayloadAttributes;
 use op_revm::OpSpecId;
 use revm::context::BlockEnv;
@@ -186,17 +184,11 @@ where
                 .find(|block| block.block_hash == header.hash())
                 .ok_or(MessageGraphError::EmptyDependencySet)?;
 
-            // Filter out all transactions that are not deposits to start.
-            let mut transactions = transactions
+            // Filter out all transactions that are not deposits.
+            let transactions = transactions
                 .into_iter()
                 .filter(|t| !t.is_empty() && t[0] == OpTxType::Deposit)
                 .collect::<Vec<_>>();
-
-            // Add the deposit replacement system transaction at the end of the list.
-            transactions.push(Self::craft_replacement_transaction(
-                &header,
-                original_optimistic_block.output_root,
-            ));
 
             // Re-craft the execution payload, trimming off all non-deposit transactions.
             let deposit_only_payload = OpPayloadAttributes {
@@ -263,37 +255,6 @@ where
         }
 
         Ok(())
-    }
-
-    /// Forms the replacement transaction inserted into a deposit-only block in the event that a
-    /// block is reduced due to invalid messages.
-    ///
-    /// <https://specs.optimism.io/interop/derivation.html#optimistic-block-deposited-transaction>
-    fn craft_replacement_transaction(old_header: &Sealed<Header>, old_output_root: B256) -> Bytes {
-        const REPLACEMENT_SENDER: Address = address!("deaddeaddeaddeaddeaddeaddeaddeaddead0002");
-        const REPLACEMENT_GAS: u64 = 36000;
-
-        let source = InteropBlockReplacementDepositSource::new(old_output_root);
-        let output_root = OutputRoot::from_parts(
-            old_header.state_root,
-            old_header.withdrawals_root.unwrap_or_default(),
-            old_header.hash(),
-        );
-        let replacement_tx = OpTxEnvelope::Deposit(
-            TxDeposit {
-                source_hash: source.source_hash(),
-                from: REPLACEMENT_SENDER,
-                to: TxKind::Call(Address::ZERO),
-                mint: 0,
-                value: U256::ZERO,
-                gas_limit: REPLACEMENT_GAS,
-                is_system_transaction: false,
-                input: output_root.encode().into(),
-            }
-            .seal(),
-        );
-
-        replacement_tx.encoded_2718().into()
     }
 }
 


### PR DESCRIPTION
## Summary

- Remove the obsolete "optimistic block deposited transaction" from Kona's deposit-only replacement block construction during interop consolidation
- Remove the dead `craft_replacement_transaction` method and unused imports
- Keep test skipped until ethereum-optimism/optimism#19880 is merged

## Context

The interop spec no longer includes an additional replacement deposit tx in deposit-only blocks. The supernode already builds replacement blocks with only the original deposit transactions (the L1Info tx), but Kona was still appending an extra deposit tx encoding the original block's output root via `craft_replacement_transaction`.

This caused a state root mismatch between the supernode's replacement block (1 tx, gas_used ~54k) and Kona's (2 txs, gas_used ~80k), which cascaded into different output roots and a different super root — failing the `Consolidate-ReplaceInvalidBlock-fpp` subtest.

Removing the extra tx also resolves the `Rlp(InputTooShort)` error that occurred during the second consolidation pass — with only deposit txs in the replacement block, the message graph derivation finds no executing messages and succeeds cleanly, so ethereum-optimism/optimism#19890 is not required.

## Dependencies

The test (`TestInteropFaultProofs_InvalidBlock`) requires:

- ethereum-optimism/optimism#19880 — supernode returns denied block output as optimistic
- This PR — remove the obsolete replacement deposit tx from Kona

The L2Transactions hint fix (ethereum-optimism/optimism#19850) is already merged to develop. The test remains skipped until ethereum-optimism/optimism#19880 is merged.

Closes ethereum-optimism/optimism#19411

## Test plan

- [x] `cargo check -p kona-proof-interop` passes
- [x] `cargo clippy -p kona-proof-interop` — no warnings
- [x] `cargo +nightly fmt -p kona-proof-interop -- --check` — clean
- [x] `TestInteropFaultProofs_InvalidBlock` passes locally with develop + ethereum-optimism/optimism#19880 (without ethereum-optimism/optimism#19890)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)