### PR TITLE
fix(op-reth): fix flaky TestExecutePayloadSuccess

### DIFF
--- a/rust/op-reth/tests/proofs/core/execute_payload_test.go
+++ b/rust/op-reth/tests/proofs/core/execute_payload_test.go
@@ -17,6 +17,15 @@ func TestExecutePayloadSuccess(gt *testing.T) {
 	user := sys.FunderL2.NewFundedEOA(eth.OneHundredthEther)
 	opRethELNode := sys.RethWithProofL2ELNode()
 
+	// Wait for the validator to sync the blocks produced by the funder on the sequencer.
+	// Without this, the validator may report a block as its unsafe head before its state
+	// is fully available, causing PayloadExecutionWitness to fail with "no state found".
+	seqHead, err := sys.L2ELSequencerNode().Escape().L2EthClient().InfoByLabel(ctx, eth.Unsafe)
+	if err != nil {
+		gt.Fatal(err)
+	}
+	sys.L2ELValidatorNode().WaitForBlockNumber(seqHead.NumberU64())
+
 	plannedTxOption := user.PlanTransfer(user.Address(), eth.OneWei)
 	plannedTx := txplan.NewPlannedTx(plannedTxOption)
 	signedTx, err := plannedTx.Signed.Eval(ctx)
@@ -71,6 +80,13 @@ func TestExecutePayloadWithInvalidParentHash(gt *testing.T) {
 	sys := utils.NewMixedOpProofPreset(t)
 	user := sys.FunderL2.NewFundedEOA(eth.OneHundredthEther)
 	opRethELNode := sys.RethWithProofL2ELNode()
+
+	// Wait for the validator to fully sync the blocks produced by the funder.
+	seqHead, err := sys.L2ELSequencerNode().Escape().L2EthClient().InfoByLabel(ctx, eth.Unsafe)
+	if err != nil {
+		gt.Fatal(err)
+	}
+	sys.L2ELValidatorNode().WaitForBlockNumber(seqHead.NumberU64())
 
 	plannedTxOption := user.PlanTransfer(user.Address(), eth.OneWei)
 	plannedTx := txplan.NewPlannedTx(plannedTxOption)

--- a/rust/op-reth/tests/proofs/core/execute_payload_test.go
+++ b/rust/op-reth/tests/proofs/core/execute_payload_test.go
@@ -18,8 +18,8 @@ func TestExecutePayloadSuccess(gt *testing.T) {
 	opRethELNode := sys.RethWithProofL2ELNode()
 
 	// Wait for the validator to sync the blocks produced by the funder on the sequencer.
-	// Without this, the validator may report a block as its unsafe head before its state
-	// is fully available, causing PayloadExecutionWitness to fail with "no state found".
+	// Without this, the validator's proofs store (managed by an async ExEx) may not have
+	// indexed the block yet, causing PayloadExecutionWitness to fail with "no state found".
 	seqHead, err := sys.L2ELSequencerNode().Escape().L2EthClient().InfoByLabel(ctx, eth.Unsafe)
 	if err != nil {
 		gt.Fatal(err)
@@ -81,7 +81,9 @@ func TestExecutePayloadWithInvalidParentHash(gt *testing.T) {
 	user := sys.FunderL2.NewFundedEOA(eth.OneHundredthEther)
 	opRethELNode := sys.RethWithProofL2ELNode()
 
-	// Wait for the validator to fully sync the blocks produced by the funder.
+	// Wait for the validator to sync the blocks produced by the funder on the sequencer.
+	// Without this, the validator's proofs store (managed by an async ExEx) may not have
+	// indexed the block yet, causing PayloadExecutionWitness to fail with "no state found".
 	seqHead, err := sys.L2ELSequencerNode().Escape().L2EthClient().InfoByLabel(ctx, eth.Unsafe)
 	if err != nil {
 		gt.Fatal(err)


### PR DESCRIPTION
## Summary

Fixes flaky `TestExecutePayloadSuccess` (and `TestExecutePayloadWithInvalidParentHash`) by adding
`WaitForBlockNumber` synchronization between sequencer and validator — the same pattern used by
other non-flaky tests in the same package.

## Root Cause

The test sets up a 2-node L2 devnet (sequencer op-geth + validator op-reth). `NewFundedEOA` sends
a funding tx through the **sequencer**, which produces block 1. The test then immediately queries
the **validator** node's `PayloadExecutionWitness` RPC.

This RPC uses `OpStateProviderFactory`, which reads from a **proofs ExEx store** — an async
execution extension that processes `ChainCommitted` notifications after block commit. Under CI
resource pressure, the ExEx can lag behind the unsafe head update, so the proofs store hasn't
indexed block 1 yet → `"no state found for block number 1"`.

## Why Flaky (Not Always Failing)

The ExEx normally processes notifications in microseconds. Only under CI CPU/IO contention does
the gap widen enough for the test to query the proofs store before it's ready. CI logs show only
3ms between funder confirmation and the test failure.

## Fix

Added `WaitForBlockNumber` after `NewFundedEOA` to wait for the validator to sync the sequencer's
blocks before proceeding. This is the established pattern used by `TestDebugExecutionWitness`
(`execution_witness_test.go:52`) and `TestStorageProofUsingSimpleStorageContract`
(`simple_storage_test.go:24`), which don't flake.

## References

- Closes #19898

🤖 *Generated by Claude Code*