### PR TITLE
[codex] Guard KONTROL defaults and fix getting-started output path

### DIFF
--- a/packages/contracts-bedrock/scripts/deploy/Deployer.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deployer.sol
@@ -32,9 +32,17 @@ abstract contract Deployer is Script {
 
         DeployUtils.etchLabelAndAllowCheatcodes({ _etchTo: address(cfg), _cname: "DeployConfig" });
 
+        bool isKontrolContext = Config.isKontrolContext();
+        require(
+            !(isKontrolContext
+                    && (vm.isContext(VmSafe.ForgeContext.ScriptBroadcast)
+                        || vm.isContext(VmSafe.ForgeContext.ScriptResume))),
+            "Deployer: KONTROL_CONTEXT cannot be used during broadcast/resume"
+        );
+
         // In test context or kontrol context, use hardcoded defaults by calling read() with empty path.
         // In non-test context, read from the config file.
-        if (vm.isContext(VmSafe.ForgeContext.TestGroup) || Config.isKontrolContext()) {
+        if (vm.isContext(VmSafe.ForgeContext.TestGroup) || isKontrolContext) {
             cfg.read("");
         } else {
             cfg.read(Config.deployConfigPath());

--- a/packages/contracts-bedrock/scripts/getting-started/config.sh
+++ b/packages/contracts-bedrock/scripts/getting-started/config.sh
@@ -149,5 +149,8 @@ cat << EOL >> tmp_config.json
 }
 EOL
 
-# Write the final config file
-mv tmp_config.json "$CONTRACTS_BASE/deploy-config/getting-started.json"
+# Write the final config file outside of the deleted deploy-config/ directory.
+GETTING_STARTED_CONFIG_PATH="${GETTING_STARTED_CONFIG_PATH:-$CONTRACTS_BASE/getting-started.json}"
+mkdir -p "$(dirname "$GETTING_STARTED_CONFIG_PATH")"
+mv tmp_config.json "$GETTING_STARTED_CONFIG_PATH"
+echo "Wrote config to $GETTING_STARTED_CONFIG_PATH"


### PR DESCRIPTION
## Summary
- reject `KONTROL_CONTEXT=true` during `forge script --broadcast` and `--resume` so broadcast deploys cannot fall back to hardcoded dev defaults
- move the getting-started config output out of the deleted `deploy-config/` directory and make the output path configurable

## Why
PR #18922 makes `KONTROL_CONTEXT` opt into `_initDefaults()` in `Deployer.setUp()`. That is correct for Kontrol runs, but without a broadcast/resume guard the same env var can also affect real `forge script` deploy flows.

The PR also deletes `packages/contracts-bedrock/deploy-config/`, but `scripts/getting-started/config.sh` still writes to that directory.

## Validation
- `bash -n packages/contracts-bedrock/scripts/getting-started/config.sh`
- `forge fmt --check packages/contracts-bedrock/scripts/deploy/Deployer.sol`
