### PR TITLE
fix(kona): use BTreeMap for deterministic JSON serialization in interop host

### DIFF
--- a/rust/kona/bin/host/src/interop/cfg.rs
+++ b/rust/kona/bin/host/src/interop/cfg.rs
@@ -22,7 +22,12 @@ use kona_providers_alloy::{OnlineBeaconClient, OnlineBlobProvider};
 use kona_std_fpvm::{FileChannel, FileDescriptor};
 use op_alloy_network::Optimism;
 use serde::Serialize;
-use std::{collections::{BTreeMap, HashMap}, path::PathBuf, str::FromStr, sync::Arc};
+use std::{
+    collections::{BTreeMap, HashMap},
+    path::PathBuf,
+    str::FromStr,
+    sync::Arc,
+};
 use tokio::task::{self, JoinHandle};
 
 /// The interop host application.

--- a/rust/kona/bin/host/src/interop/cfg.rs
+++ b/rust/kona/bin/host/src/interop/cfg.rs
@@ -22,7 +22,7 @@ use kona_providers_alloy::{OnlineBeaconClient, OnlineBlobProvider};
 use kona_std_fpvm::{FileChannel, FileDescriptor};
 use op_alloy_network::Optimism;
 use serde::Serialize;
-use std::{collections::HashMap, path::PathBuf, str::FromStr, sync::Arc};
+use std::{collections::{BTreeMap, HashMap}, path::PathBuf, str::FromStr, sync::Arc};
 use tokio::task::{self, JoinHandle};
 
 /// The interop host application.
@@ -228,13 +228,14 @@ impl InteropHost {
     }
 
     /// Reads the [`RollupConfig`]s from the file system and returns a map of L2 chain ID ->
-    /// [`RollupConfig`]s.
+    /// [`RollupConfig`]s. Uses `BTreeMap` to ensure deterministic JSON serialization order when
+    /// these configs are served as preimages to the cannon VM.
     pub fn read_rollup_configs(
         &self,
-    ) -> Option<Result<HashMap<u64, RollupConfig>, InteropHostError>> {
+    ) -> Option<Result<BTreeMap<u64, RollupConfig>, InteropHostError>> {
         let rollup_config_paths = self.rollup_config_paths.as_ref()?;
 
-        Some(rollup_config_paths.iter().try_fold(HashMap::default(), |mut acc, path| {
+        Some(rollup_config_paths.iter().try_fold(BTreeMap::default(), |mut acc, path| {
             // Read the serialized config from the file system.
             let ser_config = std::fs::read_to_string(path)?;
 

--- a/rust/kona/crates/protocol/interop/src/depset.rs
+++ b/rust/kona/crates/protocol/interop/src/depset.rs
@@ -1,5 +1,5 @@
-use alloc::collections::BTreeMap;
 use crate::MESSAGE_EXPIRY_WINDOW;
+use alloc::collections::BTreeMap;
 use alloy_primitives::ChainId;
 
 /// Configuration for a dependency of a chain

--- a/rust/kona/crates/protocol/interop/src/depset.rs
+++ b/rust/kona/crates/protocol/interop/src/depset.rs
@@ -1,6 +1,6 @@
+use alloc::collections::BTreeMap;
 use crate::MESSAGE_EXPIRY_WINDOW;
 use alloy_primitives::ChainId;
-use kona_registry::HashMap;
 
 /// Configuration for a dependency of a chain
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -15,7 +15,7 @@ pub struct ChainDependency {}
 #[allow(clippy::zero_sized_map_values)]
 pub struct DependencySet {
     /// Dependencies information per chain.
-    pub dependencies: HashMap<ChainId, ChainDependency>,
+    pub dependencies: BTreeMap<ChainId, ChainDependency>,
 
     /// Override message expiry window to use for this dependency set.
     pub override_message_expiry_window: Option<u64>,
@@ -35,11 +35,11 @@ impl DependencySet {
 #[allow(clippy::zero_sized_map_values)]
 mod tests {
     use super::*;
+    use alloc::collections::BTreeMap;
     use alloy_primitives::ChainId;
-    use kona_registry::HashMap;
 
     const fn create_dependency_set(
-        dependencies: HashMap<ChainId, ChainDependency>,
+        dependencies: BTreeMap<ChainId, ChainDependency>,
         override_expiry: u64,
     ) -> DependencySet {
         DependencySet { dependencies, override_message_expiry_window: Some(override_expiry) }
@@ -47,7 +47,7 @@ mod tests {
 
     #[test]
     fn test_get_message_expiry_window_default() {
-        let deps = HashMap::default();
+        let deps = BTreeMap::default();
         // override_message_expiry_window is 0, so default should be used
         let ds = create_dependency_set(deps, 0);
         assert_eq!(
@@ -59,7 +59,7 @@ mod tests {
 
     #[test]
     fn test_get_message_expiry_window_override() {
-        let deps = HashMap::default();
+        let deps = BTreeMap::default();
         let override_value = 12345;
         let ds = create_dependency_set(deps, override_value);
         assert_eq!(


### PR DESCRIPTION
## Summary

- Replace `HashMap` with `BTreeMap` for `DependencySet.dependencies` and `read_rollup_configs` return type in kona's interop host
- Fixes non-deterministic JSON serialization that caused cannon VM state divergence between test helper and challenger processes

## Root Cause

Rust's `HashMap` iteration order is randomized per-process via hash seeds. When kona-host serializes `DependencySet` and rollup configs as JSON preimages for the cannon VM, two separate kona-host processes (test helper vs challenger) can produce different byte sequences for the same logical data:

```
Process A: {"900200":{},"900201":{}}
Process B: {"900201":{},"900200":{}}
```

These different bytes get read into MIPS memory inside the cannon VM, producing different state hashes from that point forward. This causes the challenger to disagree with the test's claims, attack instead of defend, and step at a trace index that has no preimage data — so the preimage never gets uploaded to the oracle, and `WaitForPreimageInOracle` times out.

## Evidence

- Binary diff of cannon VM snapshots at step 10M showed divergence at exactly the byte where chain ID order differs in serialized JSON (offset 6,827,040: `dencies":{"90020` → one has `0":{},"900201"` and the other has `1":{},"900200"`)
- Step 0 snapshots are identical (both from the same absolute prestate)
- The fix was verified with **68+ consecutive local test passes** (still running, previously failed on the first run without the fix)

## Test plan

- [x] Reproduced locally — test failed on first run without fix
- [x] Applied fix, rebuilt kona-host, ran 68+ consecutive passes (100-run verification still in progress)
- [ ] CI `develop-fault-proofs` workflow passes

Fixes ethereum-optimism/optimism#19892

🤖 Generated with [Claude Code](https://claude.com/claude-code)