### PR TITLE
op-devstack: do not use the structured logger for test failures

### DIFF
--- a/op-devstack/devtest/testing.go
+++ b/op-devstack/devtest/testing.go
@@ -133,10 +133,10 @@ func (t *testingT) Error(args ...any) {
 		t.skipFlakyFailure(fmt.Sprintln(args...))
 		return
 	}
-	// Note: the test-logger catches panics when the test is logged to after test-end.
-	// Note: we do not use t.Error directly, to keep the log-formatting more consistent.
-	t.logger.Error(fmt.Sprintln(args...))
-	t.Fail()
+	// Write directly to testing.T, not the structured logger. The structured logger's
+	// terminal handler quotes messages containing '=' (via escapeMessage/strconv.Quote),
+	// which escapes all \n and \t, making testify's multi-line assertion diffs unreadable.
+	t.t.Error(args...)
 }
 
 func (t *testingT) Errorf(format string, args ...any) {
@@ -145,10 +145,10 @@ func (t *testingT) Errorf(format string, args ...any) {
 		t.skipFlakyFailure(fmt.Sprintf(format, args...))
 		return
 	}
-	// Note: the test-logger catches panics when the test is logged to after test-end.
-	// Note: we do not use t.Errorf directly, to keep the log-formatting more consistent.
-	t.logger.Error(fmt.Sprintf(format, args...))
-	t.Fail()
+	// Write directly to testing.T, not the structured logger. The structured logger's
+	// terminal handler quotes messages containing '=' (via escapeMessage/strconv.Quote),
+	// which escapes all \n and \t, making testify's multi-line assertion diffs unreadable.
+	t.t.Errorf(format, args...)
 }
 
 func (t *testingT) Fail() {


### PR DESCRIPTION
Before this commit, `TestDemoFail1` would not emit a human-readable message. This is due to the structured logger escaping all ascii codes when certain special characters are present (like `=`).

The fix is to not use the structured logger to print test errors.

```go
package pkg

import (
	"testing"

	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
)

func TestDemoFail1(gt *testing.T) {
	t := devtest.ParallelT(gt)
	t.Require().Equal(
		map[string]int{"a": 1, "b": 2, "c": 3},
		map[string]int{"a": 1, "b": 99, "c": 3},
	)
}

func TestDemoFail2(gt *testing.T) {
	t := devtest.ParallelT(gt)
	t.Require().Equal(1, 2)
}
```

