### PR TITLE
contracts: remove unused test events

### DIFF
--- a/packages/contracts-bedrock/test/setup/Events.sol
+++ b/packages/contracts-bedrock/test/setup/Events.sol
@@ -46,14 +46,6 @@ abstract contract Events {
         bool isCreation,
         bytes data
     );
-    event WhatHappened(bool success, bytes returndata);
-
-    event OutputProposed(
-        bytes32 indexed outputRoot, uint256 indexed l2OutputIndex, uint256 indexed l2BlockNumber, uint256 l1Timestamp
-    );
-
-    event OutputsDeleted(uint256 indexed prevNextOutputIndex, uint256 indexed newNextOutputIndex);
-
     event Withdrawal(uint256 value, address to, address from);
     event Withdrawal(uint256 value, address to, address from, Types.WithdrawalNetwork withdrawalNetwork);
 
@@ -74,10 +66,6 @@ abstract contract Events {
     );
 
     event DepositFinalized(
-        address indexed l1Token, address indexed l2Token, address indexed from, address to, uint256 amount, bytes data
-    );
-
-    event DepositFailed(
         address indexed l1Token, address indexed l2Token, address indexed from, address to, uint256 amount, bytes data
     );
 


### PR DESCRIPTION
## Summary

- Remove 4 unused event declarations from `packages/contracts-bedrock/test/setup/Events.sol`
- Events removed: `WhatHappened`, `OutputProposed`, `OutputsDeleted`, `DepositFailed`
- These were leftovers from the removed L2OutputOracle system, confirmed unused via grep across the entire codebase

## Details

The following events were declared in the test `Events` helper contract but never emitted or referenced anywhere in the test suite:

| Event | Origin |
|-------|--------|
| `WhatHappened(bool, bytes)` | Generic debug event, unused |
| `OutputProposed(bytes32, uint256, uint256, uint256)` | L2OutputOracle (removed) |
| `OutputsDeleted(uint256, uint256)` | L2OutputOracle (removed) |
| `DepositFailed(address, address, address, address, uint256, bytes)` | Legacy bridge event, unused |

## Test plan

- [x] `forge build` compiles successfully with no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)