### PR TITLE
contracts: remove unused dispute game and FFI test helpers

### DIFF
--- a/packages/contracts-bedrock/test/setup/DisputeGames.sol
+++ b/packages/contracts-bedrock/test/setup/DisputeGames.sol
@@ -68,11 +68,6 @@ library DisputeGames {
         return address(gameProxy);
     }
 
-    function isGamePermissioned(GameType _gameType) internal pure returns (bool) {
-        return _gameType.raw() == GameTypes.PERMISSIONED_CANNON.raw()
-            || _gameType.raw() == GameTypes.SUPER_PERMISSIONED_CANNON.raw();
-    }
-
     /// @notice Checks if the game type is a super game type
     function isSuperGame(GameType _gameType) internal pure returns (bool) {
         return GameTypes.isSuperGame(_gameType);
@@ -122,35 +117,6 @@ library DisputeGames {
             proposer_ = gameArgs.proposer;
         } else {
             proposer_ = IPermissionedDisputeGame(address(_dgf.gameImpls(gameType))).proposer();
-        }
-    }
-
-    /// @notice Gets the absolute prestate for a game type, handling both v1 and v2 dispute games.
-    ///         V1 games store the prestate on the game implementation, v2 games store it in gameArgs.
-    ///         Returns Claim.wrap(bytes32(0)) if no implementation exists for the game type.
-    /// @param _dgf The dispute game factory.
-    /// @param _gameType The game type to get the prestate for.
-    /// @return prestate_ The absolute prestate claim.
-    function getGameImplPrestate(
-        IDisputeGameFactory _dgf,
-        GameType _gameType
-    )
-        internal
-        view
-        returns (Claim prestate_)
-    {
-        // Return zero if no implementation exists for this game type
-        address gameImpl = address(_dgf.gameImpls(_gameType));
-        if (gameImpl == address(0)) {
-            return Claim.wrap(bytes32(0));
-        }
-
-        (bool gameArgsExist, bytes memory gameArgsData) = _getGameArgs(_dgf, _gameType);
-        if (gameArgsExist) {
-            LibGameArgs.GameArgs memory gameArgs = LibGameArgs.decode(gameArgsData);
-            prestate_ = Claim.wrap(gameArgs.absolutePrestate);
-        } else {
-            prestate_ = IFaultDisputeGame(gameImpl).absolutePrestate();
         }
     }
 

--- a/packages/contracts-bedrock/test/setup/FFIInterface.sol
+++ b/packages/contracts-bedrock/test/setup/FFIInterface.sol
@@ -293,52 +293,6 @@ contract FFIInterface {
         return (memRoot, proof);
     }
 
-    function getCannonMemoryProof2(
-        uint32 pc,
-        uint32 insn,
-        uint32 memAddr,
-        uint32 memVal,
-        uint32 memAddrForProof
-    )
-        external
-        returns (bytes32, bytes memory)
-    {
-        string[] memory cmds = new string[](8);
-        cmds[0] = "scripts/go-ffi/go-ffi";
-        cmds[1] = "diff";
-        cmds[2] = "cannonMemoryProof2";
-        cmds[3] = vm.toString(pc);
-        cmds[4] = vm.toString(insn);
-        cmds[5] = vm.toString(memAddr);
-        cmds[6] = vm.toString(memVal);
-        cmds[7] = vm.toString(memAddrForProof);
-        bytes memory result = Process.run(cmds);
-        (bytes32 memRoot, bytes memory proof) = abi.decode(result, (bytes32, bytes));
-        return (memRoot, proof);
-    }
-
-    function getCannonMemoryProofWrongLeaf(
-        uint32 pc,
-        uint32 insn,
-        uint32 memAddr,
-        uint32 memVal
-    )
-        external
-        returns (bytes32, bytes memory)
-    {
-        string[] memory cmds = new string[](7);
-        cmds[0] = "scripts/go-ffi/go-ffi";
-        cmds[1] = "diff";
-        cmds[2] = "cannonMemoryProofWrongLeaf";
-        cmds[3] = vm.toString(pc);
-        cmds[4] = vm.toString(insn);
-        cmds[5] = vm.toString(memAddr);
-        cmds[6] = vm.toString(memVal);
-        bytes memory result = Process.run(cmds);
-        (bytes32 memRoot, bytes memory proof) = abi.decode(result, (bytes32, bytes));
-        return (memRoot, proof);
-    }
-
     function getCannonMemory64Proof(uint64 addr, uint64 value) external returns (bytes32, bytes memory) {
         string[] memory cmds = new string[](5);
         cmds[0] = "scripts/go-ffi/go-ffi";


### PR DESCRIPTION
## Summary

- Remove `isGamePermissioned()` from `test/setup/DisputeGames.sol` — internal pure function, never called anywhere in the codebase
- Remove `getGameImplPrestate()` from `test/setup/DisputeGames.sol` — internal view function, never called anywhere in the codebase
- Remove `getCannonMemoryProof2()` from `test/setup/FFIInterface.sol` — external function, never called anywhere in the codebase
- Remove `getCannonMemoryProofWrongLeaf()` from `test/setup/FFIInterface.sol` — external function, never called anywhere in the codebase

All 4 functions were confirmed unused via grep across the entire monorepo. `forge build` passes cleanly after removal.

## Test plan

- [x] `forge build` compiles successfully with no warnings
- [ ] CI passes (no test references these functions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)