### PR TITLE
fix broken justfile paths in op-reth tests after monorepo migration

### DIFF
--- a/rust/op-reth/crates/tests/Makefile
+++ b/rust/op-reth/crates/tests/Makefile
@@ -1,3 +1,3 @@
-DEPRECATED_TARGETS := all build build-docker build-docker-with-cov build-contracts unzip-contract-artifacts update-packages test-e2e-sysgo
+DEPRECATED_TARGETS := all build build-contracts build-bedrock-contracts test-e2e-sysgo
 
 include ../../../../justfiles/deprecated.mk

--- a/rust/op-reth/crates/tests/README.md
+++ b/rust/op-reth/crates/tests/README.md
@@ -9,7 +9,7 @@ This README documents common workflows and justfile recipes used to build artifa
 - Go (to run Go-based e2e tests)
 - Rust toolchain (to build `op-reth`)
 - Foundry (`forge`) for proof contract artifacts
-- Docker (optional, only for `just build-docker`)
+- Docker (optional, for container-based workflows)
 
 ## Commands
 
@@ -19,7 +19,7 @@ List all available recipes:
 just --list
 ```
 
-Build the local `op-reth` binary:
+Build the local `op-reth` binary (release):
 
 ```sh
 just build
@@ -35,16 +35,22 @@ just test-e2e-sysgo
 GO_PKG_NAME=path/to/pkg just test-e2e-sysgo
 ```
 
-Optional: build a local Docker image (`op-reth:local`):
+Build smart contract artifacts with Foundry:
 
 ```sh
-just build-docker
+just build-contracts
+```
+
+Build contracts-bedrock forge artifacts (required by sysgo deployer):
+
+```sh
+just build-bedrock-contracts
 ```
 
 ## Implementation notes
 
-- `just test-e2e-sysgo` depends on `build`, `unzip-contract-artifacts`, and `build-contracts`.
-- The test target sets `OP_RETH_EXEC_PATH` to `../../../target/debug/op-reth`.
+- `just test-e2e-sysgo` depends on `build-contracts` and runs automatically.
+- The test target sets `OP_RETH_EXEC_PATH` to `../../../target/release/op-reth`.
 - You can override proof EL kinds with:
   - `OP_DEVSTACK_PROOF_SEQUENCER_EL`
   - `OP_DEVSTACK_PROOF_VALIDATOR_EL`

--- a/rust/op-reth/crates/tests/justfile
+++ b/rust/op-reth/crates/tests/justfile
@@ -1,76 +1,48 @@
-DOCKER_IMAGE_NAME := "op-reth"
-DOCKER_TAG := "local"
-DOCKERFILE_PATH := "../../../DockerfileOpProof"
 GO_PKG_NAME := env("GO_PKG_NAME", "proofs/core")
 SOURCE_DIR := justfile_directory()
 OP_DEVSTACK_PROOF_SEQUENCER_EL := env("OP_DEVSTACK_PROOF_SEQUENCER_EL", "op-geth")
 OP_DEVSTACK_PROOF_VALIDATOR_EL := env("OP_DEVSTACK_PROOF_VALIDATOR_EL", "op-reth-with-proof")
 
 # default recipe
-default: all
+default:
+  @just --list
 
-# Run E2E tests (default target)
-all: test-e2e-sysgo
+# Build op-reth and run E2E tests
+all: build test-e2e-sysgo
 
-# Build op-reth
+# Build op-reth (release)
 build:
   @echo "Building op-reth binary..."
-  cd ../../../ && cargo build --bin op-reth --manifest-path crates/optimism/bin/op-reth/Cargo.toml
-
-# Build the op-reth Docker image
-build-docker:
-  #!/usr/bin/env bash
-  set -euo pipefail
-  echo "Building {{DOCKER_IMAGE_NAME}}:{{DOCKER_TAG}} Docker image..."
-  cd ../../../ && docker build -f "$(basename {{DOCKERFILE_PATH}})" -t {{DOCKER_IMAGE_NAME}}:{{DOCKER_TAG}} .
-
-# Build coverage-enabled op-reth Docker image
-build-docker-with-cov:
-  #!/usr/bin/env bash
-  set -euo pipefail
-  echo "Building coverage-enabled {{DOCKER_IMAGE_NAME}}:cov Docker image..."
-  cd ../../../ && docker build \
-    --build-arg RUSTFLAGS="-Cinstrument-coverage" \
-    --build-arg CARGO_INCREMENTAL=0 \
-    --build-arg LLVM_PROFILE_FILE="/coverage/%m-%p.profraw" \
-    -f "$(basename {{DOCKERFILE_PATH}})" \
-    -t {{DOCKER_IMAGE_NAME}}:{{DOCKER_TAG}} .
+  cd ../../../ && cargo build --release --bin op-reth
 
 # Build smart contract artifacts with Foundry
 build-contracts:
   #!/usr/bin/env bash
   set -euo pipefail
   echo "Building contracts with forge..."
-  cd "{{SOURCE_DIR}}/proofs/contracts" && forge build || { echo "forge build failed"; exit 1; }
+  cd "{{SOURCE_DIR}}/../../tests/proofs/contracts" && forge build || { echo "forge build failed"; exit 1; }
 
-# Unzip contract artifacts
-unzip-contract-artifacts:
+# Build contracts-bedrock forge artifacts (required by sysgo deployer)
+build-bedrock-contracts:
   #!/usr/bin/env bash
   set -euo pipefail
-  echo "Unzipping contract artifacts..."
-  mkdir -p "{{SOURCE_DIR}}/artifacts/src"
-  tar --zstd -xf "{{SOURCE_DIR}}/artifacts/compressed/artifacts.tzst" -C "{{SOURCE_DIR}}/artifacts/src"
-
-# Update contract artifacts from the optimism submodule
-update-packages:
-  #!/usr/bin/env bash
-  set -euo pipefail
-  echo "Updating contract artifacts from optimism submodule..."
-  cd "{{SOURCE_DIR}}/optimism/op-deployer" && just build-contracts copy-contract-artifacts
-  mkdir -p "{{SOURCE_DIR}}/artifacts/compressed"
-  cp "{{SOURCE_DIR}}/optimism/op-deployer/pkg/deployer/artifacts/forge-artifacts/artifacts.tzst" "{{SOURCE_DIR}}/artifacts/compressed/artifacts.tzst"
+  echo "Building contracts-bedrock forge artifacts..."
+  cd "{{SOURCE_DIR}}/../../../.." && cd packages/contracts-bedrock && just install && just build-no-tests
 
 # Run E2E tests using Sysgo
-test-e2e-sysgo: build unzip-contract-artifacts build-contracts
+test-e2e-sysgo: build-contracts
   #!/usr/bin/env bash
   set -euo pipefail
   echo "Running E2E tests with Sysgo"
-  export OP_DEPLOYER_ARTIFACTS="{{SOURCE_DIR}}/artifacts/src/forge-artifacts"
+  mkdir -p tmp/test-results tmp/testlogs
   export DISABLE_OP_E2E_LEGACY=true
+  export DEVSTACK_ORCHESTRATOR=sysgo
   export OP_RETH_ENABLE_PROOF_HISTORY=true
   export SKIP_P2P_CONNECTION_CHECK=true
-  export OP_RETH_EXEC_PATH="{{SOURCE_DIR}}/../../../target/debug/op-reth"
+  export OP_RETH_EXEC_PATH="{{SOURCE_DIR}}/../../../target/release/op-reth"
   export OP_DEVSTACK_PROOF_SEQUENCER_EL="{{OP_DEVSTACK_PROOF_SEQUENCER_EL}}"
   export OP_DEVSTACK_PROOF_VALIDATOR_EL="{{OP_DEVSTACK_PROOF_VALIDATOR_EL}}"
   {{SOURCE_DIR}}/../../../../ops/scripts/gotestsum-split.sh --format=testname \
+    --junitfile=tmp/test-results/results.xml \
+    --jsonfile=tmp/testlogs/log.json \
     -- -count=1 -timeout 40m ./{{GO_PKG_NAME}}


### PR DESCRIPTION
## summary
- fix broken path references in rust/op-reth/crates/tests/justfile after monorepo migration
- update README to reference just instead of make

## test plan
- verified just --list parses all recipes without errors

fixes #19569