### PR TITLE
fix(justfile): add kona-host to build-rust-release target

### DIFF
--- a/justfile
+++ b/justfile
@@ -344,7 +344,7 @@ update-op-geth:
 
 # Build all Rust binaries (release) for sysgo tests.
 build-rust-release:
-  cd rust && cargo build --release --bin kona-node
+  cd rust && cargo build --release --bin kona-node --bin kona-host
   cd op-rbuilder && cargo build --release -p op-rbuilder --bin op-rbuilder
   cd rollup-boost && cargo build --release -p rollup-boost --bin rollup-boost
 


### PR DESCRIPTION
## Summary

- Add `--bin kona-host` to the `build-rust-release` just target alongside the existing `kona-node` build

## Motivation

The `build-rust-release` target is invoked by `build-deps` as part of the acceptance test dependency chain. It builds `kona-node`, `op-rbuilder`, and `rollup-boost` but was missing `kona-host`.

Tests like `TestInteropFaultProofs_InvalidBlock` invoke `kona-host` as an external binary from `rust/target/release/kona-host`. Without it being part of `build-rust-release`, the binary can become stale (built before recent fixes land), causing test failures that are difficult to diagnose.

This is a one-line change: adding `--bin kona-host` to the existing `cd rust && cargo build --release` command, which already builds in the same Cargo workspace.

## Test plan

- [ ] Verify `just build-rust-release` builds both `kona-node` and `kona-host` in `rust/target/release/`
- [ ] Verify acceptance tests that depend on `kona-host` pass with a fresh build

🤖 Generated with [Claude Code](https://claude.com/claude-code)