### PR TITLE
fix(op-acceptance-tests): unskip TestInteropFaultProofs_InvalidBlock

### DIFF
--- a/op-acceptance-tests/tests/interop/proofs/serial/interop_fault_proofs_test.go
+++ b/op-acceptance-tests/tests/interop/proofs/serial/interop_fault_proofs_test.go
@@ -70,8 +70,6 @@ func TestInteropFaultProofs_VariedBlockTimes_FasterChainB(gt *testing.T) {
 
 func TestInteropFaultProofs_InvalidBlock(gt *testing.T) {
 	t := devtest.SerialT(gt)
-	// TODO(#19411): Re-enable once #19880 is merged.
-	t.Skip("Requires #19880 (supernode denylist output as optimistic)")
 	sys := presets.NewSimpleInteropSupernodeProofs(t, presets.WithChallengerCannonKonaEnabled())
 	sfp.RunInvalidBlockTest(t, sys)
 }


### PR DESCRIPTION
## Summary
- Unskips `TestInteropFaultProofs_InvalidBlock` now that all prerequisites are merged to develop
- All blocking PRs are merged: #19880 (supernode denylist output), #19850 (L2Transactions hint fix), #19890 (skip re-validating deposit-only blocks), #19894 (remove obsolete replacement deposit tx)
- Test passes locally — all subtests complete in ~56s

Closes #19411

## Test plan
- [x] Verified test passes locally with freshly built kona-host
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)