### PR TITLE
op-supernode: read interop activation timestamp from rollup config by default

### DIFF
--- a/op-supernode/cmd/main.go
+++ b/op-supernode/cmd/main.go
@@ -79,13 +79,12 @@ func main() {
 			return nil, fmt.Errorf("failed to create virtual node configs: %w", err)
 		}
 
-		// Populate config with interop activation timestamp from CLI context if set
-		// Only set the pointer if the flag is explicitly provided by the user
-		// If not set, leave as nil to disable interop
+		// Populate config with an explicit CLI or env override if one is set.
+		// Otherwise the supernode will derive interop activation from the loaded rollup configs.
 		if cliCtx != nil && cliCtx.IsSet(interop.InteropActivationTimestampFlag.Name) {
 			ts := cliCtx.Uint64(interop.InteropActivationTimestampFlag.Name)
 			cfg.InteropActivationTimestamp = &ts
-			l.Info("interop activation timestamp set from CLI", "timestamp", ts)
+			l.Info("interop activation timestamp override set", "timestamp", ts)
 		}
 
 		// Create the supernode, supplying the logger, version, and close function

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -30,7 +30,7 @@ var (
 // InteropActivationTimestampFlag is the CLI flag for the interop activation timestamp.
 var InteropActivationTimestampFlag = &cli.Uint64Flag{
 	Name:    "interop.activation-timestamp",
-	Usage:   "The timestamp at which interop should start",
+	Usage:   "Override the interop activation timestamp derived from rollup configs",
 	EnvVars: opservice.PrefixEnvVar(flags.EnvVarPrefix, "INTEROP_ACTIVATION_TIMESTAMP"),
 	Value:   0,
 }

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -9,6 +9,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	opservice "github.com/ethereum-optimism/optimism/op-service"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supernode/flags"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/activity"
@@ -28,9 +29,10 @@ var (
 
 // InteropActivationTimestampFlag is the CLI flag for the interop activation timestamp.
 var InteropActivationTimestampFlag = &cli.Uint64Flag{
-	Name:  "interop.activation-timestamp",
-	Usage: "The timestamp at which interop should start",
-	Value: 0,
+	Name:    "interop.activation-timestamp",
+	Usage:   "The timestamp at which interop should start",
+	EnvVars: opservice.PrefixEnvVar(flags.EnvVarPrefix, "INTEROP_ACTIVATION_TIMESTAMP"),
+	Value:   0,
 }
 
 func init() {

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -167,6 +167,12 @@ func TestNew(t *testing.T) {
 	}
 }
 
+func TestInteropActivationTimestampFlagEnvVar(t *testing.T) {
+	t.Parallel()
+
+	require.Contains(t, InteropActivationTimestampFlag.GetEnvVars(), "OP_SUPERNODE_INTEROP_ACTIVATION_TIMESTAMP")
+}
+
 // =============================================================================
 // TestStartStop
 // =============================================================================

--- a/op-supernode/supernode/interop_config_test.go
+++ b/op-supernode/supernode/interop_config_test.go
@@ -1,0 +1,82 @@
+package supernode
+
+import (
+	"testing"
+
+	opnodecfg "github.com/ethereum-optimism/optimism/op-node/config"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveInteropActivationTimestamp(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		override *uint64
+		vnCfgs   map[eth.ChainID]*opnodecfg.Config
+		want     *uint64
+		wantErr  string
+	}{
+		{
+			name:     "override wins over rollup configs",
+			override: uint64Ptr(42),
+			vnCfgs: map[eth.ChainID]*opnodecfg.Config{
+				eth.ChainIDFromUInt64(10):   {Rollup: rollup.Config{InteropTime: uint64Ptr(100)}},
+				eth.ChainIDFromUInt64(8453): {Rollup: rollup.Config{InteropTime: uint64Ptr(200)}},
+			},
+			want: uint64Ptr(42),
+		},
+		{
+			name: "derive from consistent rollup configs",
+			vnCfgs: map[eth.ChainID]*opnodecfg.Config{
+				eth.ChainIDFromUInt64(10):   {Rollup: rollup.Config{InteropTime: uint64Ptr(1234)}},
+				eth.ChainIDFromUInt64(8453): {Rollup: rollup.Config{InteropTime: uint64Ptr(1234)}},
+			},
+			want: uint64Ptr(1234),
+		},
+		{
+			name: "leave interop disabled when no rollup config enables it",
+			vnCfgs: map[eth.ChainID]*opnodecfg.Config{
+				eth.ChainIDFromUInt64(10):   {Rollup: rollup.Config{}},
+				eth.ChainIDFromUInt64(8453): {Rollup: rollup.Config{}},
+			},
+		},
+		{
+			name: "error on mixed nil and configured rollup timestamps",
+			vnCfgs: map[eth.ChainID]*opnodecfg.Config{
+				eth.ChainIDFromUInt64(10):   {Rollup: rollup.Config{}},
+				eth.ChainIDFromUInt64(8453): {Rollup: rollup.Config{InteropTime: uint64Ptr(1234)}},
+			},
+			wantErr: "has no interop activation timestamp",
+		},
+		{
+			name: "error on mismatched rollup timestamps",
+			vnCfgs: map[eth.ChainID]*opnodecfg.Config{
+				eth.ChainIDFromUInt64(10):   {Rollup: rollup.Config{InteropTime: uint64Ptr(100)}},
+				eth.ChainIDFromUInt64(8453): {Rollup: rollup.Config{InteropTime: uint64Ptr(200)}},
+			},
+			wantErr: "mismatched interop activation timestamps",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := resolveInteropActivationTimestamp(tt.override, tt.vnCfgs)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func uint64Ptr(v uint64) *uint64 {
+	return &v
+}

--- a/op-supernode/supernode/supernode.go
+++ b/op-supernode/supernode/supernode.go
@@ -95,11 +95,16 @@ func New(ctx context.Context, log gethlog.Logger, version string, requestStop co
 		superroot.New(log.New("activity", "superroot"), s.chains),
 	}
 
-	log.Info("initializing interop activity? %v", cfg.InteropActivationTimestamp != nil)
-	// Initialize interop activity if the activation timestamp is set (non-nil)
+	interopActivationTimestamp, err := resolveInteropActivationTimestamp(cfg.InteropActivationTimestamp, vnCfgs)
+	if err != nil {
+		return nil, fmt.Errorf("resolve interop activation timestamp: %w", err)
+	}
+
+	log.Info("initializing interop activity", "enabled", interopActivationTimestamp != nil)
+	// Initialize interop activity if the activation timestamp is known (non-nil).
 	// If it's nil, don't start interop. If it's non-nil (including 0), do start it.
-	if cfg.InteropActivationTimestamp != nil {
-		interopActivity := interop.New(log.New("activity", "interop"), *cfg.InteropActivationTimestamp, s.chains, cfg.DataDir, s.l1Client)
+	if interopActivationTimestamp != nil {
+		interopActivity := interop.New(log.New("activity", "interop"), *interopActivationTimestamp, s.chains, cfg.DataDir, s.l1Client)
 		s.activities = append(s.activities, interopActivity)
 		for _, chain := range s.chains {
 			chain.RegisterVerifier(interopActivity)
@@ -121,6 +126,50 @@ func New(ctx context.Context, log gethlog.Logger, version string, requestStop co
 		s.metrics = resources.NewMetricsService(log, cfg.MetricsConfig.ListenAddr, cfg.MetricsConfig.ListenPort, s.metricsFanIn)
 	}
 	return s, nil
+}
+
+func resolveInteropActivationTimestamp(override *uint64, vnCfgs map[eth.ChainID]*opnodecfg.Config) (*uint64, error) {
+	if override != nil {
+		return override, nil
+	}
+
+	var resolved *uint64
+	var resolvedChain eth.ChainID
+	var missingChain *eth.ChainID
+
+	for chainID, vnCfg := range vnCfgs {
+		if vnCfg == nil {
+			continue
+		}
+
+		if vnCfg.Rollup.InteropTime == nil {
+			if resolved != nil {
+				return nil, fmt.Errorf("chain %s has no interop activation timestamp, but chain %s is configured for timestamp %d", chainID, resolvedChain, *resolved)
+			}
+			if missingChain == nil {
+				missingChain = new(eth.ChainID)
+				*missingChain = chainID
+			}
+			continue
+		}
+
+		if missingChain != nil {
+			return nil, fmt.Errorf("chain %s is configured for interop activation timestamp %d, but chain %s has no interop activation timestamp", chainID, *vnCfg.Rollup.InteropTime, *missingChain)
+		}
+
+		if resolved == nil {
+			ts := *vnCfg.Rollup.InteropTime
+			resolved = &ts
+			resolvedChain = chainID
+			continue
+		}
+
+		if *resolved != *vnCfg.Rollup.InteropTime {
+			return nil, fmt.Errorf("mismatched interop activation timestamps: chain %s=%d, chain %s=%d", resolvedChain, *resolved, chainID, *vnCfg.Rollup.InteropTime)
+		}
+	}
+
+	return resolved, nil
 }
 
 func (s *Supernode) Start(ctx context.Context) error {


### PR DESCRIPTION
## Summary
- derive interop activation from loaded rollup configs by default
- keep `--interop.activation-timestamp` as an explicit CLI/env override via `OP_SUPERNODE_INTEROP_ACTIVATION_TIMESTAMP`
- fail fast if configured chains disagree on the interop activation timestamp
- add focused tests for override precedence, rollup-derived defaults, mismatch handling, and env-var registration

## Testing
- `go test ./op-supernode/cmd ./op-supernode/supernode ./op-supernode/supernode/activity/interop`
- `go build -o /tmp/op-supernode-issue19918 ./op-supernode/cmd`
- manually booted the built binary without `--interop.activation-timestamp` and confirmed startup enabled interop from rollup config

Closes #19918