### PR TITLE
op-supernode: force virtual nodes to use consensus-layer sync

### DIFF
--- a/op-supernode/cmd/main.go
+++ b/op-supernode/cmd/main.go
@@ -15,6 +15,7 @@ import (
 	opnode "github.com/ethereum-optimism/optimism/op-node"
 	opnodecfg "github.com/ethereum-optimism/optimism/op-node/config"
 	opnodeflags "github.com/ethereum-optimism/optimism/op-node/flags"
+	opsync "github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 	"github.com/ethereum-optimism/optimism/op-service/cliapp"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
@@ -132,9 +133,20 @@ func createVirtualNodeConfigs(cliCtx *cli.Context, cfg *config.CLIConfig, l log.
 		if err != nil {
 			return nil, fmt.Errorf("failed to create virtual node config: %w", err)
 		}
+		normalizeVirtualNodeSyncConfig(chainID, cfg, l)
 		vnCfgs[eth.ChainIDFromUInt64(chainID)] = cfg
 	}
 	return vnCfgs, nil
+}
+
+func normalizeVirtualNodeSyncConfig(chainID uint64, cfg *opnodecfg.Config, l log.Logger) {
+	if cfg.Sync.SyncMode == opsync.CLSync {
+		return
+	}
+
+	l.Warn("execution-layer sync is unsupported for supernode virtual nodes, forcing consensus-layer sync", "chain", chainID, "configured_syncmode", cfg.Sync.SyncMode.String())
+	cfg.Sync.SyncMode = opsync.CLSync
+	cfg.Sync.SkipSyncStartCheck = false
 }
 
 func withNoP2P(vcli *flags.VirtualCLI) error {

--- a/op-supernode/cmd/main_test.go
+++ b/op-supernode/cmd/main_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"testing"
+
+	opnodecfg "github.com/ethereum-optimism/optimism/op-node/config"
+	opsync "github.com/ethereum-optimism/optimism/op-node/rollup/sync"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeVirtualNodeSyncConfigForcesCLSync(t *testing.T) {
+	t.Parallel()
+
+	cfg := &opnodecfg.Config{
+		Sync: opsync.Config{
+			SyncMode:           opsync.ELSync,
+			SkipSyncStartCheck: true,
+			SyncModeReqResp:    true,
+		},
+	}
+
+	normalizeVirtualNodeSyncConfig(10, cfg, log.New())
+
+	require.Equal(t, opsync.CLSync, cfg.Sync.SyncMode)
+	require.False(t, cfg.Sync.SkipSyncStartCheck)
+	require.True(t, cfg.Sync.SyncModeReqResp)
+}
+
+func TestNormalizeVirtualNodeSyncConfigLeavesCLSyncUntouched(t *testing.T) {
+	t.Parallel()
+
+	cfg := &opnodecfg.Config{
+		Sync: opsync.Config{
+			SyncMode:           opsync.CLSync,
+			SkipSyncStartCheck: true,
+			SyncModeReqResp:    true,
+		},
+	}
+
+	normalizeVirtualNodeSyncConfig(10, cfg, log.New())
+
+	require.Equal(t, opsync.CLSync, cfg.Sync.SyncMode)
+	require.True(t, cfg.Sync.SkipSyncStartCheck)
+	require.True(t, cfg.Sync.SyncModeReqResp)
+}


### PR DESCRIPTION
## Summary
- normalize supernode virtual-node configs back to consensus-layer sync after `opnode.NewConfig`
- disable `SkipSyncStartCheck` when EL sync would otherwise have been selected for a VN
- add focused unit tests for VN sync normalization

## Rationale
Execution-layer sync appears broken for supernode virtual nodes, so this keeps VN startup on the supported consensus-layer path automatically.

## Testing
- `go test ./op-supernode/cmd`
- `go build -o /tmp/op-supernode-clsync-vn ./op-supernode/cmd`