### PR TITLE
op-acceptance-tests: remove race condition from flashblocks test

### DIFF
--- a/op-acceptance-tests/tests/flashblocks/flashblocks_transfer_test.go
+++ b/op-acceptance-tests/tests/flashblocks/flashblocks_transfer_test.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
@@ -73,7 +72,6 @@ func TestFlashblocksTransfer(gt *testing.T) {
 
 	var blockNumber int
 	var observedBalance *big.Int
-	var flashblockTime time.Time
 outer:
 	for {
 		select {
@@ -81,7 +79,6 @@ outer:
 			t.Require().True(ok, "client channel closed before we found the transaction")
 			balanceStr, found := fb.Metadata.NewAccountBalances[strings.ToLower(bob.Address().Hex())]
 			if found {
-				flashblockTime = time.Now()
 				blockNumber = fb.Metadata.BlockNumber
 				observedBalance, ok = new(big.Int).SetString(balanceStr[2:], 16)
 				t.Require().True(ok)
@@ -106,7 +103,5 @@ outer:
 	expectedBalance, err := sys.L2EL.EthClient().BalanceAt(t.Ctx(), bob.Address(), new(big.Int).SetUint64(txBlock.Number))
 	t.Require().NoError(err)
 	require.Equal(t, expectedBalance, observedBalance, "Bob's balance must be correct as per exactly what Alice transferred to them")
-
 	require.Equal(t, int(txBlock.Number), blockNumber, "the transaction's block number should be the same as the flashblock's parent block number")
-	require.LessOrEqual(t, flashblockTime.Unix(), int64(txBlock.Time), "the transaction's block time (in seconds) should be less than or equal to the flashblock's time (in seconds)")
 }

--- a/op-service/sources/flashblock_client.go
+++ b/op-service/sources/flashblock_client.go
@@ -80,7 +80,7 @@ func (c *FlashblockClient) Start(ctx context.Context) error {
 	for {
 		_, msg, err := c.ws.Read(ctx)
 		if err != nil {
-			if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+			if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) || ctx.Err() != nil {
 				c.logger.Info("FlashblockClient: read loop finished")
 				return nil
 			}


### PR DESCRIPTION
The flashblocks time is not guaranteed to be stored before the "native" block time.