### PR TITLE
op-program: add just target to regenerate vm-compat baseline

### DIFF
--- a/.claude/skills/vm-compat-triage/SKILL.md
+++ b/.claude/skills/vm-compat-triage/SKILL.md
@@ -17,8 +17,7 @@ Use when the `analyze-op-program-client` CI job fails on a PR. The job runs `vm-
 
 - `gh` CLI authenticated with GitHub
 - `jq` available
-- `vm-compat` binary (install: `mise use -g ubi:ChainSafe/vm-compat@1.1.0`, or download from GitHub releases — binary name is `analyzer-linux-arm64` / `analyzer-linux-amd64`)
-- `llvm-objdump` — **Linux only** (install: `sudo apt-get install -y llvm`). Not available on macOS. On macOS, use `just run-vm-compat` in the `op-program` directory which runs the analysis inside Docker.
+- Docker — required for `just run-vm-compat` and `just regenerate-vm-compat-baseline`. These targets build and run the analysis inside Docker, so no local `vm-compat` or `llvm-objdump` installation is needed. If Docker is not available, ask the user to run the just target.
 - The PR URL or number (ask the user if not provided)
 
 ## MIPS64 Syscall Reference
@@ -270,44 +269,29 @@ Only proceed if ALL findings are marked as either unreachable or acceptable (non
 
 **Do NOT manually add entries to the existing baseline.** The baseline must be regenerated from scratch so that stale entries (from code paths that no longer exist) are removed.
 
-To regenerate:
+To regenerate, use the `just regenerate-vm-compat-baseline` target from the `op-program` directory in the PR branch worktree. This requires Docker and handles everything end-to-end:
 
-1. Run vm-compat with **no baseline** to get the complete report for the current code:
-
-```bash
-cd op-program && vm-compat analyze \
-  --with-trace=true --skip-warnings=false --format=json \
-  --vm-profile-config vm-profiles/cannon-multithreaded-64.yaml \
-  --report-output-path /tmp/vm-compat-full-report.json \
-  ./client/cmd/main.go
-```
-
-2. Normalize the output by stripping `line`, `file`, and `absPath` fields (these are assembly positions, not Go source lines, and cause false positives when they change):
+1. Runs vm-compat with **no baseline** to get the complete report
+2. Normalizes the output by stripping assembly-level fields (`line`, `file`, `absPath`) that cause false positives when they change
+3. Overwrites the baseline JSON file
 
 ```bash
-cat /tmp/vm-compat-full-report.json | jq 'walk(
-  if type == "object" and has("line") then del(.line) else . end |
-  if type == "object" and has("absPath") then del(.absPath) else . end |
-  if type == "object" and has("file") then del(.file) else . end
-)' > op-program/compatibility-test/baseline-cannon-multithreaded-64.json
+cd op-program && just regenerate-vm-compat-baseline
 ```
 
-3. This replaces the entire baseline with the current state. The old baseline is not merged — it is replaced.
+If Docker is not available, ask the user to run this command.
+
+This replaces the entire baseline with the current state. The old baseline is not merged — it is replaced.
 
 ### Step 7: Verify
 
-After regenerating the baseline, re-run `vm-compat` with the new baseline to confirm zero new findings:
+After regenerating the baseline, re-run vm-compat with the new baseline to confirm zero new findings:
 
 ```bash
-cd op-program && vm-compat analyze \
-  --with-trace=true --skip-warnings=false --format=json \
-  --vm-profile-config vm-profiles/cannon-multithreaded-64.yaml \
-  --baseline-report compatibility-test/baseline-cannon-multithreaded-64.json \
-  --report-output-path /tmp/verify.json \
-  ./client/cmd/main.go
+cd op-program && just run-vm-compat
 ```
 
-If the output file contains an empty array `[]`, the baseline is complete.
+If it exits successfully with no findings, the baseline is complete. If Docker is not available, ask the user to run this command.
 
 ## Notes
 

--- a/op-program/Dockerfile.vmcompat
+++ b/op-program/Dockerfile.vmcompat
@@ -1,9 +1,11 @@
 ARG GO_VERSION=1.24.10-alpine3.21
 ARG VM_TARGET=current
+ARG VM_COMPAT_TASK=analyze-op-program-client
 FROM golang:${GO_VERSION} AS builder
 
-# Redeclare ARG to make it available in this build stage
+# Redeclare ARGs to make them available in this build stage
 ARG VM_TARGET
+ARG VM_COMPAT_TASK
 
 # Install dependencies
 RUN apk add --no-cache make git bash jq llvm just
@@ -31,8 +33,9 @@ WORKDIR /app/op-program
 ENV FINDINGS_OUTPUT_PATH=/app/op-program/vm-compat-findings.json
 RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build \
   touch $FINDINGS_OUTPUT_PATH && \
-  just "analyze-op-program-client-${VM_TARGET}"; echo $? > /app/op-program/vm-compat-exit-code
+  just "${VM_COMPAT_TASK}-${VM_TARGET}"; echo $? > /app/op-program/vm-compat-exit-code
 
 FROM scratch AS export
 COPY --from=builder /app/op-program/vm-compat-findings.json .
 COPY --from=builder /app/op-program/vm-compat-exit-code .
+COPY --from=builder /app/op-program/compatibility-test/baseline-cannon-multithreaded-64.json .

--- a/op-program/justfile
+++ b/op-program/justfile
@@ -164,6 +164,22 @@ verify-compat: verify-mainnet-genesis verify-sepolia-delta verify-sepolia-ecoton
 analyze-op-program-client-current:
     ./scripts/run-static-analysis.sh ./vm-profiles/cannon-multithreaded-64.yaml ./compatibility-test/baseline-cannon-multithreaded-64.json
 
+# Regenerate the current baseline (full report without baseline, then normalize)
+regenerate-baseline-current:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    FULL_REPORT=$(mktemp)
+    # Run without baseline — will exit 1 since all findings are "new", which is expected
+    FINDINGS_OUTPUT_PATH="$FULL_REPORT" ./scripts/run-static-analysis.sh ./vm-profiles/cannon-multithreaded-64.yaml || true
+    # Strip assembly-level fields that cause false positives when they change
+    jq 'walk(
+      if type == "object" and has("line") then del(.line) else . end |
+      if type == "object" and has("absPath") then del(.absPath) else . end |
+      if type == "object" and has("file") then del(.file) else . end
+    )' "$FULL_REPORT" > ./compatibility-test/baseline-cannon-multithreaded-64.json
+    rm -f "$FULL_REPORT"
+    echo "Baseline regenerated: ./compatibility-test/baseline-cannon-multithreaded-64.json ($(jq length ./compatibility-test/baseline-cannon-multithreaded-64.json) entries)"
+
 # Analyze next op-program client for VM compatibility
 analyze-op-program-client-next:
     ./scripts/run-static-analysis.sh ./vm-profiles/cannon-multithreaded-64-next.yaml ./compatibility-test/baseline-cannon-multithreaded-64-next.json
@@ -181,3 +197,16 @@ run-vm-compat:
     # TODO(#18334): Uncomment once vm-compat supports go1.25
     #@docker build --build-arg GO_VERSION=1.25.4-alpine3.21 --build-arg VM_TARGET=next --progress plain --output "{{VM_COMPAT_OUTPUT_DIR}}" -f Dockerfile.vmcompat ../
     #@exit $(cat "{{VM_COMPAT_OUTPUT_DIR}}/vm-compat-exit-code")
+
+# Regenerate the vm-compat baseline via Docker, then copy it back into the repo
+regenerate-vm-compat-baseline:
+    @rm -rf "{{VM_COMPAT_OUTPUT_DIR}}" && mkdir -p "{{VM_COMPAT_OUTPUT_DIR}}"
+    @docker build \
+        --build-arg GO_VERSION=1.24.10-alpine3.21 \
+        --build-arg VM_TARGET=current \
+        --build-arg VM_COMPAT_TASK=regenerate-baseline \
+        --progress plain \
+        --output "{{VM_COMPAT_OUTPUT_DIR}}" \
+        -f Dockerfile.vmcompat ../
+    @cp "{{VM_COMPAT_OUTPUT_DIR}}/baseline-cannon-multithreaded-64.json" ./compatibility-test/baseline-cannon-multithreaded-64.json
+    @echo "Baseline updated: ./compatibility-test/baseline-cannon-multithreaded-64.json ($(jq length ./compatibility-test/baseline-cannon-multithreaded-64.json) entries)"

--- a/op-program/scripts/run-static-analysis.sh
+++ b/op-program/scripts/run-static-analysis.sh
@@ -5,18 +5,19 @@ set -o pipefail # Ensure failures in pipelines are detected
 
 # Usage function
 usage() {
-  echo "Usage: $0 <vm-profile> <baseline-report>"
+  echo "Usage: $0 <vm-profile> [baseline-report]"
   echo "Valid profiles: cannon-singlethreaded-32, cannon-multithreaded-64"
+  echo "If baseline-report is omitted, outputs the full report (useful for regenerating baselines)."
   exit 1
 }
 
 # Validate input
-if [[ $# -ne 2 ]]; then
+if [[ $# -lt 1 || $# -gt 2 ]]; then
   usage
 fi
 
 VM_PROFILE_CONFIG=$1
-BASELINE_REPORT=$2
+BASELINE_REPORT=${2:-}
 
 ANALYZER_BIN="vm-compat"
 
@@ -45,11 +46,17 @@ fi
 echo "✅ vm-compat found at $(which vm-compat)"
 
 # Run the analyzer
-echo "Running analysis with VM profile: $VM_PROFILE_CONFIG using baseline report: $BASELINE_REPORT..."
 OUTPUT_FILE=$(mktemp)
 
-# Note: to output the full report, remove the `--baseline-report` option below
-"$ANALYZER_BIN" analyze --with-trace=true --skip-warnings=false --format=json --vm-profile-config "$VM_PROFILE_CONFIG" --baseline-report "$BASELINE_REPORT" --report-output-path "$OUTPUT_FILE" ./client/cmd/main.go
+BASELINE_ARGS=()
+if [ -n "$BASELINE_REPORT" ]; then
+  echo "Running analysis with VM profile: $VM_PROFILE_CONFIG using baseline report: $BASELINE_REPORT..."
+  BASELINE_ARGS=(--baseline-report "$BASELINE_REPORT")
+else
+  echo "Running analysis with VM profile: $VM_PROFILE_CONFIG (no baseline — full report)..."
+fi
+
+"$ANALYZER_BIN" analyze --with-trace=true --skip-warnings=false --format=json --vm-profile-config "$VM_PROFILE_CONFIG" "${BASELINE_ARGS[@]}" --report-output-path "$OUTPUT_FILE" ./client/cmd/main.go
 
 # Check if JSON output contains any issues
 ISSUE_COUNT=$(jq 'length' "$OUTPUT_FILE")


### PR DESCRIPTION
## Summary
- Adds `just regenerate-vm-compat-baseline` (Docker) and `just regenerate-baseline-current` (local) targets for one-command baseline regeneration
- Makes the baseline argument optional in `run-static-analysis.sh` — when omitted, produces the full report (no baseline filtering)
- Adds `VM_COMPAT_TASK` build arg to `Dockerfile.vmcompat` so the same image supports both analysis and regeneration
- Normalizes output by stripping assembly-level fields (`line`, `file`, `absPath`) that cause false positives across builds

Stacked on ethereum-optimism/optimism#19844.

## Test plan
- [x] `just regenerate-vm-compat-baseline` produces a valid baseline
- [x] `just run-vm-compat` passes with the regenerated baseline
- [ ] CI passes (default behavior unchanged — `VM_COMPAT_TASK` defaults to `analyze-op-program-client`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)