### PR TITLE
docs: add fee vaults explainer and operations guide

### DIFF
--- a/docs/public-docs/chain-operators/guides/management/fee-vaults.mdx
+++ b/docs/public-docs/chain-operators/guides/management/fee-vaults.mdx
@@ -1,0 +1,121 @@
+---
+title: Fee vault operations
+description: How to configure, monitor, and withdraw from fee vaults on your OP Stack chain.
+---
+
+This guide covers the operational aspects of managing fee vaults on your OP Stack chain. For a conceptual overview of how fee vaults work, see [Fee vaults](/op-stack/transactions/fee-vaults).
+
+## Prerequisites
+
+- Access to the **ProxyAdminOwner** account (required for configuration changes)
+- An RPC endpoint for your L2 chain
+- `cast` CLI tool installed ([Foundry](https://book.getfoundry.sh/getting-started/installation))
+
+## Fee vault addresses
+
+| Vault | Address |
+|-------|---------|
+| `SequencerFeeVault` | `0x4200000000000000000000000000000000000011` |
+| `BaseFeeVault` | `0x4200000000000000000000000000000000000019` |
+| `L1FeeVault` | `0x420000000000000000000000000000000000001A` |
+| `OperatorFeeVault` | `0x420000000000000000000000000000000000001B` |
+
+## Checking vault state
+
+### View current balance
+
+```bash
+export L2_RPC=<L2_RPC>
+export VAULT=<VAULT_ADDRESS>
+
+cast balance $VAULT --rpc-url $L2_RPC
+```
+
+### View configuration
+
+```bash
+# Recipient address
+cast call $VAULT "recipient()" --rpc-url $L2_RPC
+
+# Minimum withdrawal amount (in wei)
+cast call $VAULT "minWithdrawalAmount()" --rpc-url $L2_RPC
+
+# Withdrawal network (0 = L1, 1 = L2)
+cast call $VAULT "withdrawalNetwork()" --rpc-url $L2_RPC
+
+# Total ETH withdrawn historically
+cast call $VAULT "totalProcessed()" --rpc-url $L2_RPC
+```
+
+## Updating configuration
+
+<Warning>
+  Configuration changes require the **ProxyAdminOwner** account. If your chain uses a multisig as the ProxyAdminOwner, these calls must be executed through the multisig.
+</Warning>
+
+### Set recipient
+
+```bash
+export L2_RPC=<L2_RPC>
+export VAULT=<VAULT_ADDRESS>
+export PK=<PROXY_ADMIN_OWNER_PRIVATE_KEY>
+
+cast send --rpc-url $L2_RPC --private-key $PK \
+  $VAULT "setRecipient(address)" <NEW_RECIPIENT_ADDRESS>
+```
+
+### Set minimum withdrawal amount
+
+```bash
+cast send --rpc-url $L2_RPC --private-key $PK \
+  $VAULT "setMinWithdrawalAmount(uint256)" <AMOUNT_IN_WEI>
+```
+
+### Set withdrawal network
+
+```bash
+# 0 = L1, 1 = L2
+cast send --rpc-url $L2_RPC --private-key $PK \
+  $VAULT "setWithdrawalNetwork(uint8)" <0_OR_1>
+```
+
+## Withdrawing fees
+
+Withdrawals are **permissionless** — anyone can trigger them once the vault balance meets the minimum threshold.
+
+### Trigger a withdrawal
+
+```bash
+cast send --rpc-url $L2_RPC --private-key $PK \
+  $VAULT "withdraw()"
+```
+
+This withdraws the **entire vault balance** to the configured recipient.
+
+### Withdrawal behavior by network
+
+- **L2 withdrawal (`withdrawalNetwork = 1`)**: Funds are transferred immediately to the recipient on L2. The transaction completes in a single step.
+- **L1 withdrawal (`withdrawalNetwork = 0`)**: An L2-to-L1 withdrawal is initiated via the `L2ToL1MessagePasser`. After calling `withdraw()`, you must still:
+  1. Wait for the withdrawal to be included in an L2 output root
+  2. Prove the withdrawal on L1
+  3. Wait for the finalization period
+  4. Finalize the withdrawal on L1
+
+  For details on completing L1 withdrawals, see [Withdrawal flow](/op-stack/bridging/withdrawal-flow).
+
+## Initial configuration during deployment
+
+Fee vault recipients, minimum withdrawal amounts, and withdrawal networks are configured during chain deployment with `op-deployer`. For details on setting these parameters, see the [op-deployer setup guide](/chain-operators/tutorials/create-l2-rollup/op-deployer-setup).
+
+## Monitoring
+
+It's good practice to monitor your fee vaults regularly:
+
+- **Vault balances**: Track balances to know when withdrawals can be triggered.
+- **`totalProcessed`**: Monitor cumulative withdrawals over time to understand revenue trends.
+
+## Next steps
+
+- Read the [fee vaults explainer](/op-stack/transactions/fee-vaults) to understand how vaults work at the protocol level.
+- See [Transaction Fees 101](/chain-operators/guides/management/transaction-fees-101) to learn how to tune fee parameters.
+- Review [fee components and formulas](/op-stack/transactions/fees) for detailed fee calculations.

--- a/docs/public-docs/chain-operators/guides/management/transaction-fees-101.mdx
+++ b/docs/public-docs/chain-operators/guides/management/transaction-fees-101.mdx
@@ -11,7 +11,7 @@ On an OP stack chain a transaction **Total Fee** is made of three main component
 
 `Total Fee = L2 Fee + L1 Fee + Operator Fee`
 
-Fees are gathered in dedicated contract vaults that collect the different fee components (for example `BaseFeeVault`, `SequencerFeeVault`, etc.).
+Fees are gathered in dedicated contract [fee vaults](/op-stack/transactions/fee-vaults) that collect the different fee components (for example `BaseFeeVault`, `SequencerFeeVault`, etc.). See the [fee vault operations guide](/chain-operators/guides/management/fee-vaults) for how to manage and withdraw from these vaults.
 
 ## 1. L2 Fee
 

--- a/docs/public-docs/chain-operators/tutorials/create-l2-rollup/op-deployer-setup.mdx
+++ b/docs/public-docs/chain-operators/tutorials/create-l2-rollup/op-deployer-setup.mdx
@@ -258,9 +258,10 @@ The intent file defines your chain's configuration.
 
   [[chains]]
     id = "0x000000000000000000000000000000000000000000000000000000000016de8d"
-    baseFeeVaultRecipient = "0x..."    # base_Fee_Vault_Recipient address
-    l1FeeVaultRecipient = "0x..."      # l1_Fee_Vault_Recipient address
-    sequencerFeeVaultRecipient = "0x..." # sequencer_Fee_Vault_Recipient address
+    baseFeeVaultRecipient = "0x..."       # receives base fees
+    l1FeeVaultRecipient = "0x..."         # receives L1 data fees
+    sequencerFeeVaultRecipient = "0x..."  # receives priority fees (tips)
+    operatorFeeVaultRecipient = "0x..."   # receives operator fees
     eip1559DenominatorCanyon = 250
     eip1559Denominator = 50
     eip1559Elasticity = 6
@@ -298,8 +299,17 @@ The intent file defines your chain's configuration.
     **Chain Configuration:**
 
     *   `id`: Unique identifier for your chain
-    *   `*FeeVaultRecipient`: Addresses receiving various protocol fees
+    *   `*FeeVaultRecipient`: Addresses receiving protocol fees (required — deployment fails if any are set to the zero address). See [fee vaults](/op-stack/transactions/fee-vaults) for details on each vault.
     *   `eip1559*`: Parameters for dynamic gas price calculation
+
+    **Fee Vault Optional Overrides:**
+
+    Each vault also supports optional parameters that can be set via deploy overrides. If not specified, the following defaults apply:
+
+    | Parameter | Default |
+    |-----------|---------|
+    | `*MinimumWithdrawalAmount` | 10 ETH |
+    | `*WithdrawalNetwork` | `local` (L2) |
 
     **Chain Roles:**
 

--- a/docs/public-docs/docs.json
+++ b/docs/public-docs/docs.json
@@ -1920,6 +1920,7 @@
                   "chain-operators/guides/management/key-management",
                   "chain-operators/guides/management/operations",
                   "chain-operators/guides/management/transaction-fees-101",
+                  "chain-operators/guides/management/fee-vaults",
                   "chain-operators/guides/management/troubleshooting"
                 ]
               }
@@ -2285,6 +2286,7 @@
             "group": "Transactions",
             "pages": [
               "/op-stack/transactions/fees",
+              "/op-stack/transactions/fee-vaults",
               "/op-stack/transactions/flashblocks",
               "/op-stack/transactions/forced-transaction",
               "/op-stack/transactions/transaction-finality",

--- a/docs/public-docs/op-stack/protocol/smart-contracts.mdx
+++ b/docs/public-docs/op-stack/protocol/smart-contracts.mdx
@@ -505,6 +505,7 @@ contract. If the ERC20 token is native to L1, it will be burnt.
 
 The `SequencerFeeVault` is the contract that holds any fees paid to the
 Sequencer during transaction processing and block production.
+See [fee vaults](/op-stack/transactions/fee-vaults) for details.
 
 *   **Address:** `0x4200000000000000000000000000000000000011`
 *   **Introduced:** Legacy
@@ -632,7 +633,8 @@ have the ability to upgrade any of the other predeploy contracts.
 
 The `BaseFeeVault` predeploy receives the base fees on L2. The base fee is not
 burnt on L2 like it is on L1. Once the contract has received a certain amount
-of fees, the ETH can be withdrawn to an immutable address on L1.
+of fees, the ETH can be withdrawn to a configured recipient.
+See [fee vaults](/op-stack/transactions/fee-vaults) for details.
 
 *   **Address:** `0x4200000000000000000000000000000000000019`
 *   **Introduced:** Bedrock
@@ -643,7 +645,8 @@ of fees, the ETH can be withdrawn to an immutable address on L1.
 
 The `L1FeeVault` predeploy receives the L1 portion of the transaction fees.
 Once the contract has received a certain amount of fees, the ETH can be
-withdrawn to an immutable address on L1.
+withdrawn to a configured recipient.
+See [fee vaults](/op-stack/transactions/fee-vaults) for details.
 
 *   **Address:** `0x420000000000000000000000000000000000001a`
 *   **Introduced:** Bedrock
@@ -654,7 +657,8 @@ withdrawn to an immutable address on L1.
 
 The `OperatorFeeVault` predeploy (introduced with the [Isthmus hardfork](https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/isthmus/predeploys.md#operatorfeevault)) receives the operator portion of the transaction fees.
 Once the contract has received a certain amount of fees, funds can be withdrawn to
-the BaseFeeVault on the L2 network.
+a configured recipient.
+See [fee vaults](/op-stack/transactions/fee-vaults) for details.
 
 *   **Address:** `0x420000000000000000000000000000000000001B`
 *   **Introduced:** Isthmus

--- a/docs/public-docs/op-stack/transactions/fee-vaults.mdx
+++ b/docs/public-docs/op-stack/transactions/fee-vaults.mdx
@@ -1,0 +1,69 @@
+---
+title: Fee vaults
+description: Learn how fee vaults work on OP Stack chains, where transaction fees are collected, and how the withdrawal mechanism operates.
+---
+
+Fee vaults are predeploy contracts on OP Stack L2 chains that collect and hold the different components of transaction fees. Unlike Ethereum where the base fee is burned, OP Stack chains route all fees into dedicated vault contracts, allowing chain operators to withdraw and manage collected revenue.
+
+## Overview
+
+Every OP Stack chain has four fee vaults, each collecting a specific fee component:
+
+| Vault | Address | Collects | Introduced |
+|-------|---------|----------|------------|
+| `SequencerFeeVault` | `0x4200000000000000000000000000000000000011` | Priority fees (tips) | Legacy |
+| `BaseFeeVault` | `0x4200000000000000000000000000000000000019` | Base fees (not burned on L2) | Bedrock |
+| `L1FeeVault` | `0x420000000000000000000000000000000000001A` | L1 data fees | Bedrock |
+| `OperatorFeeVault` | `0x420000000000000000000000000000000000001B` | Operator fees | Isthmus |
+
+### How fees flow into vaults
+
+When a transaction is executed on an OP Stack chain, the total fee is split across vaults based on the fee formula:
+
+```
+totalFee = gasUsed * (baseFee + priorityFee) + l1Fee + operatorFee
+```
+
+- **baseFee** portion goes to the `BaseFeeVault`
+- **priorityFee** portion goes to the `SequencerFeeVault`
+- **l1Fee** goes to the `L1FeeVault`
+- **operatorFee** goes to the `OperatorFeeVault`
+
+For a detailed breakdown of how each fee component is calculated, see [Transaction fees](/op-stack/transactions/fees).
+
+## Vault configuration
+
+Each fee vault has three configurable parameters:
+
+| Parameter | Description |
+|-----------|-------------|
+| **recipient** | The address that receives withdrawn funds |
+| **minWithdrawalAmount** | Minimum ETH balance required before a withdrawal can be triggered |
+| **withdrawalNetwork** | Whether funds are withdrawn to an L1 or L2 address |
+
+### Withdrawal network
+
+The `withdrawalNetwork` parameter determines how funds are routed when withdrawn:
+
+- **L1 (`0`)**: Funds are sent to the recipient on L1 via the `L2ToL1MessagePasser`. This initiates a standard L2-to-L1 withdrawal that must be proven and finalized on L1.
+- **L2 (`1`)**: Funds are sent directly to the recipient on L2 via a simple ETH transfer.
+
+## Withdrawal mechanism
+
+Fee vault withdrawals are **permissionless** — anyone can trigger a withdrawal by calling the `withdraw()` function on any vault. This design ensures that collected fees can always be moved to the configured recipient without relying on a specific operator.
+
+### How withdrawals work
+
+1. The caller invokes `withdraw()` on the vault contract.
+2. The vault checks that its balance meets the `minWithdrawalAmount` threshold.
+3. The entire vault balance is withdrawn (not a partial amount).
+4. The `totalProcessed` counter is incremented.
+5. Funds are routed based on `withdrawalNetwork`:
+   - **L2**: Direct ETH transfer to the recipient.
+   - **L1**: A withdrawal is initiated through the `L2ToL1MessagePasser` with a 400,000 gas limit. The withdrawal must then be [proven and finalized](/op-stack/bridging/withdrawal-flow) on L1.
+
+## Next steps
+
+- Learn how to [configure and withdraw from fee vaults](/chain-operators/guides/management/fee-vaults) as a chain operator.
+- Understand [transaction fee components](/op-stack/transactions/fees) in detail.
+- Review the [smart contracts reference](/op-stack/protocol/smart-contracts) for all predeploy addresses.

--- a/docs/public-docs/op-stack/transactions/fee-vaults.mdx
+++ b/docs/public-docs/op-stack/transactions/fee-vaults.mdx
@@ -18,18 +18,14 @@ Every OP Stack chain has four fee vaults, each collecting a specific fee compone
 
 ### How fees flow into vaults
 
-When a transaction is executed on an OP Stack chain, the total fee is split across vaults based on the fee formula:
+When a transaction is executed on an OP Stack chain, the total fee is split across vaults:
 
-```
-totalFee = gasUsed * (baseFee + priorityFee) + l1Fee + operatorFee
-```
+- **Base fee** (`gasUsed × baseFee`) goes to the `BaseFeeVault`
+- **Priority fee** (`gasUsed × priorityFee`) goes to the `SequencerFeeVault`
+- **L1 data fee** goes to the `L1FeeVault`
+- **Operator fee** (`operatorFeeScalar × gasUsed + operatorFeeConstant`) goes to the `OperatorFeeVault`
 
-- **baseFee** portion goes to the `BaseFeeVault`
-- **priorityFee** portion goes to the `SequencerFeeVault`
-- **l1Fee** goes to the `L1FeeVault`
-- **operatorFee** goes to the `OperatorFeeVault`
-
-For a detailed breakdown of how each fee component is calculated, see [Transaction fees](/op-stack/transactions/fees).
+Each component has its own formula. For the full breakdown, see [Transaction fees](/op-stack/transactions/fees).
 
 ## Vault configuration
 

--- a/docs/public-docs/op-stack/transactions/fees.mdx
+++ b/docs/public-docs/op-stack/transactions/fees.mdx
@@ -227,7 +227,7 @@ The Operator fee is a new fee component which enables more customizable fee stru
 
 ### Mechanism
 
-The Operator fee is automatically charged for any transaction that is included in a block after the Isthmus activation. This fee is deducted directly from the address that sent the transaction and follows the same semantics as existing fees charged in the EVM. The collected operator fees are sent to the **Operator Fee Vault**, a new vault similar to existing fee vaults.
+The Operator fee is automatically charged for any transaction that is included in a block after the Isthmus activation. This fee is deducted directly from the address that sent the transaction and follows the same semantics as existing fees charged in the EVM. The collected operator fees are sent to the **Operator Fee Vault**, a new vault similar to existing [fee vaults](/op-stack/transactions/fee-vaults).
 
 <Info>
   **Deposit transactions do not get charged operator fees.** For all deposit transactions, regardless of the operator fee parameter configuration, the operator fee is always zero.
@@ -279,25 +279,12 @@ The Operator fee follows standard EVM fee semantics:
 
 Transaction pools must account for the additional operator fee when validating transactions. Transactions without sufficient balance to cover the worst-case total cost (including operator fee) will be rejected.
 
-## Sequencer fee vault
+## Fee vaults
 
-The Sequencer fee vault collects and holds transaction fees paid to the sequencer during block production on OP Mainnet. These fees cover the cost of posting transaction data to L1, ensuring network sustainability and data availability.
-
-### Fee collection and distribution
-
-*   **Purpose**: The sequencer deposits collected fees into the Sequencer fee vault. These fees reimburse the sequencer for gas costs when submitting transaction batches to L1.
-*   **Vault address**: The Sequencer fee vault is predeployed at the address `0x4200000000000000000000000000000000000011` on the OP Mainnet.
-*   **Fee usage**: Stored fees are eventually transferred to a designated recipient address (e.g., a treasury or distribution contract).
-
-### How it works
-
-1.  **Fee collection**: During the processing of transactions, the sequencer collects fees from users as part of their transaction costs. These fees are primarily used to cover the gas expenses of posting transaction data to Ethereum L1.
-2.  **Storage**: Collected fees are deposited into the Sequencer fee vault contract.
-3.  **Distribution**: The fees are later distributed to the appropriate recipient, typically covering operational costs like L1 gas fees for data availability.
-
-This system ensures effective fee management, maintaining the security and operation of the Optimism network.
+Each fee component is routed to a dedicated [fee vault](/op-stack/transactions/fee-vaults) contract on L2. Unlike Ethereum where the base fee is burned, OP Stack chains collect all fees in these vaults, allowing chain operators to withdraw and manage collected revenue. See the [fee vaults](/op-stack/transactions/fee-vaults) page for details on how vaults work and the [fee vault operations guide](/chain-operators/guides/management/fee-vaults) for managing them.
 
 ## Next steps
 
+*   Learn how [fee vaults](/op-stack/transactions/fee-vaults) collect and distribute transaction fees.
 *   Read the [differences between Ethereum and OP Stack Chains](/op-stack/protocol/differences) guide.
 *   Read the [L2 to L1 Transactions](/app-developers/bridging/messaging#for-l1-to-l2-transactions) guide.


### PR DESCRIPTION
## Summary
- Add a fee vaults explainer page (`op-stack/transactions/fee-vaults`) covering what fee vaults are, how fees flow into them, configuration parameters, and the withdrawal mechanism.
- Add a fee vault operations guide (`chain-operators/guides/management/fee-vaults`) with practical instructions for checking vault state, updating configuration, and triggering withdrawals.
- Update existing docs (`fees.mdx`, `smart-contracts.mdx`, `transaction-fees-101.mdx`) with cross-links to the new pages.
- Add missing `operatorFeeVaultRecipient` to the op-deployer setup guide intent example, and document optional fee vault deployment parameters with their defaults.

## Test plan
- [x] Verify both new pages render correctly on the docs site
- [x] Verify all cross-links resolve correctly
- [x] Verify sidebar navigation shows the new pages in the right sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>