### PR TITLE
feat(op-alloy): add post-exec transaction and receipt types

### DIFF
--- a/rust/alloy-op-evm/src/block/receipt_builder.rs
+++ b/rust/alloy-op-evm/src/block/receipt_builder.rs
@@ -58,6 +58,7 @@ impl OpReceiptBuilder for OpAlloyReceiptBuilder {
                     OpTxType::Eip2930 => OpReceiptEnvelope::Eip2930(receipt),
                     OpTxType::Eip1559 => OpReceiptEnvelope::Eip1559(receipt),
                     OpTxType::Eip7702 => OpReceiptEnvelope::Eip7702(receipt),
+                    OpTxType::PostExec => OpReceiptEnvelope::PostExec(receipt),
                     OpTxType::Deposit => unreachable!(),
                 })
             }

--- a/rust/alloy-op-evm/src/tx.rs
+++ b/rust/alloy-op-evm/src/tx.rs
@@ -2,13 +2,13 @@
 
 use crate::block::OpTxEnv;
 use alloy_consensus::{
-    Signed, TxEip1559, TxEip2930, TxEip4844, TxEip4844Variant, TxEip7702, TxLegacy,
+    Signed, Transaction, TxEip1559, TxEip2930, TxEip4844, TxEip4844Variant, TxEip7702, TxLegacy,
 };
 use alloy_eips::{Encodable2718, Typed2718, eip7594::Encodable7594};
 use alloy_evm::{FromRecoveredTx, FromTxWithEncoded, IntoTxEnv, TransactionEnvMut};
 use alloy_primitives::{Address, B256, Bytes, TxKind, U256};
 use core::ops::{Deref, DerefMut};
-use op_alloy::consensus::{OpTxEnvelope, TxDeposit};
+use op_alloy::consensus::{OpTxEnvelope, TxDeposit, TxPostExec};
 use op_revm::{OpTransaction, transaction::deposit::DepositTransactionParts};
 use revm::context::TxEnv;
 
@@ -133,6 +133,7 @@ impl FromTxWithEncoded<OpTxEnvelope> for OpTx {
             OpTxEnvelope::Eip2930(tx) => Self::from_encoded_tx(tx, caller, encoded),
             OpTxEnvelope::Eip7702(tx) => Self::from_encoded_tx(tx, caller, encoded),
             OpTxEnvelope::Deposit(tx) => Self::from_encoded_tx(tx.inner(), caller, encoded),
+            OpTxEnvelope::PostExec(tx) => Self::from_encoded_tx(tx.inner(), caller, encoded),
         }
     }
 }
@@ -213,6 +214,20 @@ impl FromTxWithEncoded<TxDeposit> for OpTx {
             is_system_transaction: tx.is_system_transaction,
         };
         Self(OpTransaction { base, enveloped_tx: Some(encoded), deposit })
+    }
+}
+
+impl FromRecoveredTx<TxPostExec> for OpTx {
+    fn from_recovered_tx(tx: &TxPostExec, _sender: Address) -> Self {
+        let encoded = tx.encoded_2718();
+        Self::from_encoded_tx(tx, Address::ZERO, encoded.into())
+    }
+}
+
+impl FromTxWithEncoded<TxPostExec> for OpTx {
+    fn from_encoded_tx(tx: &TxPostExec, caller: Address, encoded: Bytes) -> Self {
+        let base = TxEnv { tx_type: tx.ty(), caller, kind: tx.kind(), ..Default::default() };
+        Self(OpTransaction { base, enveloped_tx: Some(encoded), deposit: Default::default() })
     }
 }
 

--- a/rust/kona/bin/client/src/fpvm_evm/tx.rs
+++ b/rust/kona/bin/client/src/fpvm_evm/tx.rs
@@ -1,14 +1,14 @@
 //! [`FpvmOpTx`] newtype wrapper around [`OpTransaction<TxEnv>`].
 
 use alloy_consensus::{
-    Signed, TxEip1559, TxEip2930, TxEip4844, TxEip4844Variant, TxEip7702, TxLegacy,
+    Signed, Transaction, TxEip1559, TxEip2930, TxEip4844, TxEip4844Variant, TxEip7702, TxLegacy,
 };
 use alloy_eips::{Encodable2718, Typed2718, eip7594::Encodable7594};
 use alloy_evm::{FromRecoveredTx, FromTxWithEncoded, IntoTxEnv};
 use alloy_op_evm::block::OpTxEnv;
 use alloy_primitives::{Address, B256, Bytes, TxKind, U256};
 use core::ops::{Deref, DerefMut};
-use op_alloy_consensus::{OpTxEnvelope, TxDeposit};
+use op_alloy_consensus::{OpTxEnvelope, TxDeposit, TxPostExec};
 use op_revm::{OpTransaction, transaction::deposit::DepositTransactionParts};
 use revm::context::TxEnv;
 
@@ -136,6 +136,7 @@ impl FromTxWithEncoded<OpTxEnvelope> for FpvmOpTx {
             OpTxEnvelope::Eip2930(tx) => Self::from_encoded_tx(tx, caller, encoded),
             OpTxEnvelope::Eip7702(tx) => Self::from_encoded_tx(tx, caller, encoded),
             OpTxEnvelope::Deposit(tx) => Self::from_encoded_tx(tx.inner(), caller, encoded),
+            OpTxEnvelope::PostExec(tx) => Self::from_encoded_tx(tx.inner(), caller, encoded),
         }
     }
 }
@@ -213,5 +214,19 @@ impl FromTxWithEncoded<TxDeposit> for FpvmOpTx {
             is_system_transaction: tx.is_system_transaction,
         };
         Self(OpTransaction { base, enveloped_tx: Some(encoded), deposit })
+    }
+}
+
+impl FromRecoveredTx<TxPostExec> for FpvmOpTx {
+    fn from_recovered_tx(tx: &TxPostExec, _sender: Address) -> Self {
+        let encoded = tx.encoded_2718();
+        Self::from_encoded_tx(tx, Address::ZERO, encoded.into())
+    }
+}
+
+impl FromTxWithEncoded<TxPostExec> for FpvmOpTx {
+    fn from_encoded_tx(tx: &TxPostExec, caller: Address, encoded: Bytes) -> Self {
+        let base = TxEnv { tx_type: tx.ty(), caller, kind: tx.kind(), ..Default::default() };
+        Self(OpTransaction { base, enveloped_tx: Some(encoded), deposit: Default::default() })
     }
 }

--- a/rust/op-alloy/crates/consensus/src/lib.rs
+++ b/rust/op-alloy/crates/consensus/src/lib.rs
@@ -35,6 +35,9 @@ pub use eip1559::{
     decode_jovian_extra_data, encode_holocene_extra_data, encode_jovian_extra_data,
 };
 
+pub mod sdm;
+pub use sdm::*;
+
 mod source;
 pub use source::*;
 

--- a/rust/op-alloy/crates/consensus/src/receipts/envelope.rs
+++ b/rust/op-alloy/crates/consensus/src/receipts/envelope.rs
@@ -42,6 +42,9 @@ pub enum OpReceiptEnvelope<T = Log> {
     /// [EIP-7702]: https://eips.ethereum.org/EIPS/eip-7702
     #[cfg_attr(feature = "serde", serde(rename = "0x4", alias = "0x04"))]
     Eip7702(ReceiptWithBloom<Receipt<T>>),
+    /// Receipt envelope with type flag 125, containing a synthetic post-exec receipt.
+    #[cfg_attr(feature = "serde", serde(rename = "0x7d", alias = "0x7D"))]
+    PostExec(ReceiptWithBloom<Receipt<T>>),
     /// Receipt envelope with type flag 126, containing a [deposit] receipt.
     ///
     /// [deposit]: https://specs.optimism.io/protocol/deposits.html
@@ -76,6 +79,9 @@ impl OpReceiptEnvelope<Log> {
             OpTxType::Eip7702 => {
                 Self::Eip7702(ReceiptWithBloom { receipt: inner_receipt, logs_bloom })
             }
+            OpTxType::PostExec => {
+                Self::PostExec(ReceiptWithBloom { receipt: inner_receipt, logs_bloom })
+            }
             OpTxType::Deposit => {
                 let inner = OpDepositReceiptWithBloom {
                     receipt: OpDepositReceipt {
@@ -99,6 +105,7 @@ impl<T> OpReceiptEnvelope<T> {
             Self::Eip2930(_) => OpTxType::Eip2930,
             Self::Eip1559(_) => OpTxType::Eip1559,
             Self::Eip7702(_) => OpTxType::Eip7702,
+            Self::PostExec(_) => OpTxType::PostExec,
             Self::Deposit(_) => OpTxType::Deposit,
         }
     }
@@ -127,6 +134,7 @@ impl<T> OpReceiptEnvelope<T> {
             Self::Eip2930(r) => OpReceiptEnvelope::Eip2930(r.map_logs(f)),
             Self::Eip1559(r) => OpReceiptEnvelope::Eip1559(r.map_logs(f)),
             Self::Eip7702(r) => OpReceiptEnvelope::Eip7702(r.map_logs(f)),
+            Self::PostExec(r) => OpReceiptEnvelope::PostExec(r.map_logs(f)),
             Self::Deposit(r) => OpReceiptEnvelope::Deposit(r.map_receipt(|r| r.map_logs(f))),
         }
     }
@@ -144,9 +152,11 @@ impl<T> OpReceiptEnvelope<T> {
     /// Return the receipt's bloom.
     pub const fn logs_bloom(&self) -> &Bloom {
         match self {
-            Self::Legacy(t) | Self::Eip2930(t) | Self::Eip1559(t) | Self::Eip7702(t) => {
-                &t.logs_bloom
-            }
+            Self::Legacy(t) |
+            Self::Eip2930(t) |
+            Self::Eip1559(t) |
+            Self::Eip7702(t) |
+            Self::PostExec(t) => &t.logs_bloom,
             Self::Deposit(t) => &t.logs_bloom,
         }
     }
@@ -180,7 +190,11 @@ impl<T> OpReceiptEnvelope<T> {
     /// Consumes the type and returns the underlying [`Receipt`].
     pub fn into_receipt(self) -> Receipt<T> {
         match self {
-            Self::Legacy(t) | Self::Eip2930(t) | Self::Eip1559(t) | Self::Eip7702(t) => t.receipt,
+            Self::Legacy(t) |
+            Self::Eip2930(t) |
+            Self::Eip1559(t) |
+            Self::Eip7702(t) |
+            Self::PostExec(t) => t.receipt,
             Self::Deposit(t) => t.receipt.into_inner(),
         }
     }
@@ -189,9 +203,11 @@ impl<T> OpReceiptEnvelope<T> {
     /// receipt types may be added.
     pub const fn as_receipt(&self) -> Option<&Receipt<T>> {
         match self {
-            Self::Legacy(t) | Self::Eip2930(t) | Self::Eip1559(t) | Self::Eip7702(t) => {
-                Some(&t.receipt)
-            }
+            Self::Legacy(t) |
+            Self::Eip2930(t) |
+            Self::Eip1559(t) |
+            Self::Eip7702(t) |
+            Self::PostExec(t) => Some(&t.receipt),
             Self::Deposit(t) => Some(&t.receipt.inner),
         }
     }
@@ -201,7 +217,11 @@ impl OpReceiptEnvelope {
     /// Get the length of the inner receipt in the 2718 encoding.
     pub fn inner_length(&self) -> usize {
         match self {
-            Self::Legacy(t) | Self::Eip2930(t) | Self::Eip1559(t) | Self::Eip7702(t) => t.length(),
+            Self::Legacy(t) |
+            Self::Eip2930(t) |
+            Self::Eip1559(t) |
+            Self::Eip7702(t) |
+            Self::PostExec(t) => t.length(),
             Self::Deposit(t) => t.length(),
         }
     }
@@ -278,6 +298,7 @@ impl Typed2718 for OpReceiptEnvelope {
             Self::Eip2930(_) => OpTxType::Eip2930,
             Self::Eip1559(_) => OpTxType::Eip1559,
             Self::Eip7702(_) => OpTxType::Eip7702,
+            Self::PostExec(_) => OpTxType::PostExec,
             Self::Deposit(_) => OpTxType::Deposit,
         };
         ty as u8
@@ -302,9 +323,11 @@ impl Encodable2718 for OpReceiptEnvelope {
         }
         match self {
             Self::Deposit(t) => t.encode(out),
-            Self::Legacy(t) | Self::Eip2930(t) | Self::Eip1559(t) | Self::Eip7702(t) => {
-                t.encode(out)
-            }
+            Self::Legacy(t) |
+            Self::Eip2930(t) |
+            Self::Eip1559(t) |
+            Self::Eip7702(t) |
+            Self::PostExec(t) => t.encode(out),
         }
     }
 }
@@ -319,6 +342,7 @@ impl Decodable2718 for OpReceiptEnvelope {
             OpTxType::Eip1559 => Ok(Self::Eip1559(Decodable::decode(buf)?)),
             OpTxType::Eip7702 => Ok(Self::Eip7702(Decodable::decode(buf)?)),
             OpTxType::Eip2930 => Ok(Self::Eip2930(Decodable::decode(buf)?)),
+            OpTxType::PostExec => Ok(Self::PostExec(Decodable::decode(buf)?)),
             OpTxType::Deposit => Ok(Self::Deposit(Decodable::decode(buf)?)),
         }
     }
@@ -349,10 +373,12 @@ where
     T: arbitrary::Arbitrary<'a>,
 {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
-        match u.int_in_range(0..=4)? {
+        match u.int_in_range(0..=5)? {
             0 => Ok(Self::Legacy(ReceiptWithBloom::arbitrary(u)?)),
             1 => Ok(Self::Eip2930(ReceiptWithBloom::arbitrary(u)?)),
             2 => Ok(Self::Eip1559(ReceiptWithBloom::arbitrary(u)?)),
+            3 => Ok(Self::Eip7702(ReceiptWithBloom::arbitrary(u)?)),
+            4 => Ok(Self::PostExec(ReceiptWithBloom::arbitrary(u)?)),
             _ => Ok(Self::Deposit(OpDepositReceiptWithBloom::arbitrary(u)?)),
         }
     }
@@ -426,5 +452,16 @@ mod tests {
         assert_eq!(receipt.tx_type(), OpTxType::Deposit);
         assert_eq!(receipt.deposit_nonce(), Some(1));
         assert_eq!(receipt.deposit_receipt_version(), Some(2));
+    }
+
+    #[test]
+    fn post_exec_receipt_from_parts() {
+        let receipt =
+            OpReceiptEnvelope::from_parts(true, 100, vec![], OpTxType::PostExec, None, None);
+        assert!(receipt.status());
+        assert_eq!(receipt.cumulative_gas_used(), 100);
+        assert_eq!(receipt.logs().len(), 0);
+        assert_eq!(receipt.tx_type(), OpTxType::PostExec);
+        assert!(matches!(receipt, OpReceiptEnvelope::PostExec(_)));
     }
 }

--- a/rust/op-alloy/crates/consensus/src/receipts/receipt.rs
+++ b/rust/op-alloy/crates/consensus/src/receipts/receipt.rs
@@ -33,6 +33,9 @@ pub enum OpReceipt<T = Log> {
     /// EIP-7702 receipt
     #[cfg_attr(feature = "serde", serde(rename = "0x4", alias = "0x04"))]
     Eip7702(Receipt<T>),
+    /// Post-exec receipt
+    #[cfg_attr(feature = "serde", serde(rename = "0x7d", alias = "0x7D"))]
+    PostExec(Receipt<T>),
     /// Deposit receipt
     #[cfg_attr(feature = "serde", serde(rename = "0x7e", alias = "0x7E"))]
     Deposit(OpDepositReceipt<T>),
@@ -46,6 +49,7 @@ impl<T> OpReceipt<T> {
             Self::Eip2930(_) => OpTxType::Eip2930,
             Self::Eip1559(_) => OpTxType::Eip1559,
             Self::Eip7702(_) => OpTxType::Eip7702,
+            Self::PostExec(_) => OpTxType::PostExec,
             Self::Deposit(_) => OpTxType::Deposit,
         }
     }
@@ -56,7 +60,8 @@ impl<T> OpReceipt<T> {
             Self::Legacy(receipt) |
             Self::Eip2930(receipt) |
             Self::Eip1559(receipt) |
-            Self::Eip7702(receipt) => receipt,
+            Self::Eip7702(receipt) |
+            Self::PostExec(receipt) => receipt,
             Self::Deposit(receipt) => &receipt.inner,
         }
     }
@@ -67,7 +72,8 @@ impl<T> OpReceipt<T> {
             Self::Legacy(receipt) |
             Self::Eip2930(receipt) |
             Self::Eip1559(receipt) |
-            Self::Eip7702(receipt) => receipt,
+            Self::Eip7702(receipt) |
+            Self::PostExec(receipt) => receipt,
             Self::Deposit(receipt) => &mut receipt.inner,
         }
     }
@@ -78,7 +84,8 @@ impl<T> OpReceipt<T> {
             Self::Legacy(receipt) |
             Self::Eip2930(receipt) |
             Self::Eip1559(receipt) |
-            Self::Eip7702(receipt) => receipt,
+            Self::Eip7702(receipt) |
+            Self::PostExec(receipt) => receipt,
             Self::Deposit(receipt) => receipt.inner,
         }
     }
@@ -92,6 +99,7 @@ impl<T> OpReceipt<T> {
             Self::Eip2930(receipt) => OpReceipt::Eip2930(receipt.map_logs(f)),
             Self::Eip1559(receipt) => OpReceipt::Eip1559(receipt.map_logs(f)),
             Self::Eip7702(receipt) => OpReceipt::Eip7702(receipt.map_logs(f)),
+            Self::PostExec(receipt) => OpReceipt::PostExec(receipt.map_logs(f)),
             Self::Deposit(receipt) => OpReceipt::Deposit(receipt.map_logs(f)),
         }
     }
@@ -105,7 +113,8 @@ impl<T> OpReceipt<T> {
             Self::Legacy(receipt) |
             Self::Eip2930(receipt) |
             Self::Eip1559(receipt) |
-            Self::Eip7702(receipt) => receipt.rlp_encoded_fields_length_with_bloom(bloom),
+            Self::Eip7702(receipt) |
+            Self::PostExec(receipt) => receipt.rlp_encoded_fields_length_with_bloom(bloom),
             Self::Deposit(receipt) => receipt.rlp_encoded_fields_length_with_bloom(bloom),
         }
     }
@@ -119,7 +128,8 @@ impl<T> OpReceipt<T> {
             Self::Legacy(receipt) |
             Self::Eip2930(receipt) |
             Self::Eip1559(receipt) |
-            Self::Eip7702(receipt) => receipt.rlp_encode_fields_with_bloom(bloom, out),
+            Self::Eip7702(receipt) |
+            Self::PostExec(receipt) => receipt.rlp_encode_fields_with_bloom(bloom, out),
             Self::Deposit(receipt) => receipt.rlp_encode_fields_with_bloom(bloom, out),
         }
     }
@@ -170,6 +180,11 @@ impl<T> OpReceipt<T> {
                     RlpDecodableReceipt::rlp_decode_with_bloom(buf)?;
                 Ok(ReceiptWithBloom { receipt: Self::Eip7702(receipt), logs_bloom })
             }
+            OpTxType::PostExec => {
+                let ReceiptWithBloom { receipt, logs_bloom } =
+                    RlpDecodableReceipt::rlp_decode_with_bloom(buf)?;
+                Ok(ReceiptWithBloom { receipt: Self::PostExec(receipt), logs_bloom })
+            }
             OpTxType::Deposit => {
                 let ReceiptWithBloom { receipt, logs_bloom } =
                     RlpDecodableReceipt::rlp_decode_with_bloom(buf)?;
@@ -188,7 +203,8 @@ impl<T> OpReceipt<T> {
             Self::Legacy(receipt) |
             Self::Eip2930(receipt) |
             Self::Eip1559(receipt) |
-            Self::Eip7702(receipt) => {
+            Self::Eip7702(receipt) |
+            Self::PostExec(receipt) => {
                 receipt.status.encode(out);
                 receipt.cumulative_gas_used.encode(out);
                 receipt.logs.encode(out);
@@ -217,7 +233,8 @@ impl<T> OpReceipt<T> {
                 Self::Legacy(receipt) |
                 Self::Eip2930(receipt) |
                 Self::Eip1559(receipt) |
-                Self::Eip7702(receipt) => {
+                Self::Eip7702(receipt) |
+                Self::PostExec(receipt) => {
                     receipt.status.length() +
                         receipt.cumulative_gas_used.length() +
                         receipt.logs.length()
@@ -258,6 +275,7 @@ impl<T> OpReceipt<T> {
             OpTxType::Eip2930 => Ok(Self::Eip2930(Receipt { status, cumulative_gas_used, logs })),
             OpTxType::Eip1559 => Ok(Self::Eip1559(Receipt { status, cumulative_gas_used, logs })),
             OpTxType::Eip7702 => Ok(Self::Eip7702(Receipt { status, cumulative_gas_used, logs })),
+            OpTxType::PostExec => Ok(Self::PostExec(Receipt { status, cumulative_gas_used, logs })),
             OpTxType::Deposit => Ok(Self::Deposit(OpDepositReceipt {
                 inner: Receipt { status, cumulative_gas_used, logs },
                 deposit_nonce,
@@ -402,7 +420,8 @@ impl<T: Send + Sync + Clone + Debug + Eq + AsRef<Log>> TxReceipt for OpReceipt<T
             Self::Legacy(receipt) |
             Self::Eip2930(receipt) |
             Self::Eip1559(receipt) |
-            Self::Eip7702(receipt) => receipt.logs,
+            Self::Eip7702(receipt) |
+            Self::PostExec(receipt) => receipt.logs,
             Self::Deposit(receipt) => receipt.inner.logs,
         }
     }
@@ -443,6 +462,7 @@ impl From<super::OpReceiptEnvelope> for OpReceipt {
             super::OpReceiptEnvelope::Eip2930(receipt) => Self::Eip2930(receipt.receipt),
             super::OpReceiptEnvelope::Eip1559(receipt) => Self::Eip1559(receipt.receipt),
             super::OpReceiptEnvelope::Eip7702(receipt) => Self::Eip7702(receipt.receipt),
+            super::OpReceiptEnvelope::PostExec(receipt) => Self::PostExec(receipt.receipt),
             super::OpReceiptEnvelope::Deposit(receipt) => Self::Deposit(OpDepositReceipt {
                 deposit_nonce: receipt.receipt.deposit_nonce,
                 deposit_receipt_version: receipt.receipt.deposit_receipt_version,
@@ -460,6 +480,9 @@ impl<T> From<ReceiptWithBloom<OpReceipt<T>>> for OpReceiptEnvelope<T> {
             OpReceipt::Eip2930(receipt) => Self::Eip2930(ReceiptWithBloom { receipt, logs_bloom }),
             OpReceipt::Eip1559(receipt) => Self::Eip1559(ReceiptWithBloom { receipt, logs_bloom }),
             OpReceipt::Eip7702(receipt) => Self::Eip7702(ReceiptWithBloom { receipt, logs_bloom }),
+            OpReceipt::PostExec(receipt) => {
+                Self::PostExec(ReceiptWithBloom { receipt, logs_bloom })
+            }
             OpReceipt::Deposit(receipt) => Self::Deposit(ReceiptWithBloom { receipt, logs_bloom }),
         }
     }
@@ -496,6 +519,8 @@ pub(crate) mod serde_bincode_compat {
         Eip1559(alloy_consensus::serde_bincode_compat::Receipt<'a, alloy_primitives::Log>),
         /// EIP-7702 receipt
         Eip7702(alloy_consensus::serde_bincode_compat::Receipt<'a, alloy_primitives::Log>),
+        /// Post-exec receipt
+        PostExec(alloy_consensus::serde_bincode_compat::Receipt<'a, alloy_primitives::Log>),
         /// Deposit receipt
         Deposit(crate::serde_bincode_compat::OpDepositReceipt<'a, alloy_primitives::Log>),
     }
@@ -507,6 +532,7 @@ pub(crate) mod serde_bincode_compat {
                 super::OpReceipt::Eip2930(receipt) => Self::Eip2930(receipt.into()),
                 super::OpReceipt::Eip1559(receipt) => Self::Eip1559(receipt.into()),
                 super::OpReceipt::Eip7702(receipt) => Self::Eip7702(receipt.into()),
+                super::OpReceipt::PostExec(receipt) => Self::PostExec(receipt.into()),
                 super::OpReceipt::Deposit(receipt) => Self::Deposit(receipt.into()),
             }
         }
@@ -519,6 +545,7 @@ pub(crate) mod serde_bincode_compat {
                 OpReceipt::Eip2930(receipt) => Self::Eip2930(receipt.into()),
                 OpReceipt::Eip1559(receipt) => Self::Eip1559(receipt.into()),
                 OpReceipt::Eip7702(receipt) => Self::Eip7702(receipt.into()),
+                OpReceipt::PostExec(receipt) => Self::PostExec(receipt.into()),
                 OpReceipt::Deposit(receipt) => Self::Deposit(receipt.into()),
             }
         }
@@ -581,7 +608,7 @@ pub(crate) mod serde_bincode_compat {
 mod tests {
     use super::*;
     use alloc::vec;
-    use alloy_eips::Encodable2718;
+    use alloy_eips::{Decodable2718, Encodable2718};
     use alloy_primitives::{Bytes, address, b256, bytes, hex_literal::hex};
     use alloy_rlp::Encodable;
 
@@ -765,5 +792,23 @@ mod tests {
             legacy_receipt.encode_2718_len(),
             "Encoded length for legacy receipt should match the actual encoded data length"
         );
+    }
+
+    #[test]
+    fn post_exec_receipt_roundtrip() {
+        let receipt: ReceiptWithBloom<OpReceipt> = ReceiptWithBloom {
+            receipt: OpReceipt::PostExec(Receipt {
+                status: Eip658Value::Eip658(true),
+                cumulative_gas_used: 0,
+                logs: vec![],
+            }),
+            logs_bloom: Bloom::default(),
+        };
+
+        let encoded = receipt.encoded_2718();
+        let decoded = ReceiptWithBloom::<OpReceipt>::decode_2718(&mut encoded.as_ref()).unwrap();
+
+        assert_eq!(decoded, receipt);
+        assert_eq!(decoded.receipt.tx_type(), OpTxType::PostExec);
     }
 }

--- a/rust/op-alloy/crates/consensus/src/reth_codec.rs
+++ b/rust/op-alloy/crates/consensus/src/reth_codec.rs
@@ -11,10 +11,14 @@
 //! - `Compress`/`Decompress` impls for `OpTxEnvelope` and `OpReceipt` are added here since they
 //!   were previously provided by reth's in-tree codecs crate.
 
-use crate::{OpReceipt, OpTxEnvelope, OpTxType, OpTypedTransaction, TxDeposit};
+use crate::{
+    OpReceipt, OpTxEnvelope, OpTxType, OpTypedTransaction, POST_EXEC_TX_TYPE_ID, TxDeposit,
+    TxPostExec,
+};
 use alloc::vec::Vec;
-use alloy_consensus::{Receipt, Signed};
+use alloy_consensus::{Receipt, Signed, Transaction};
 use alloy_primitives::{Address, B256, Bytes, Log, Signature, TxKind, U256};
+use alloy_rlp::Decodable;
 use reth_codecs::{
     Compact,
     alloy::transaction::{CompactEnvelope, Envelope, FromTxCompact, ToTxCompact},
@@ -40,6 +44,10 @@ impl Compact for OpTxType {
                 buf.put_u8(crate::DEPOSIT_TX_TYPE_ID);
                 COMPACT_EXTENDED_IDENTIFIER_FLAG
             }
+            Self::PostExec => {
+                buf.put_u8(POST_EXEC_TX_TYPE_ID);
+                COMPACT_EXTENDED_IDENTIFIER_FLAG
+            }
         }
     }
 
@@ -54,6 +62,7 @@ impl Compact for OpTxType {
                 let ty = match extended_identifier {
                     alloy_consensus::constants::EIP7702_TX_TYPE_ID => Self::Eip7702,
                     crate::DEPOSIT_TX_TYPE_ID => Self::Deposit,
+                    POST_EXEC_TX_TYPE_ID => Self::PostExec,
                     _ => panic!("Unsupported OpTxType identifier: {extended_identifier}"),
                 };
                 (ty, buf)
@@ -126,6 +135,22 @@ impl Compact for TxDeposit {
     }
 }
 
+impl Compact for TxPostExec {
+    fn to_compact<B>(&self, buf: &mut B) -> usize
+    where
+        B: bytes::BufMut + AsMut<[u8]>,
+    {
+        self.input().to_compact(buf)
+    }
+
+    fn from_compact(buf: &[u8], len: usize) -> (Self, &[u8]) {
+        let (input, buf) = Bytes::from_compact(buf, len);
+        let mut slice = input.as_ref();
+        let tx = Self::decode(&mut slice).expect("valid compact post-exec tx");
+        (tx, buf)
+    }
+}
+
 // --- OpTypedTransaction ---
 
 impl Compact for OpTypedTransaction {
@@ -149,6 +174,9 @@ impl Compact for OpTypedTransaction {
                 tx.to_compact(buf);
             }
             Self::Deposit(tx) => {
+                tx.to_compact(buf);
+            }
+            Self::PostExec(tx) => {
                 tx.to_compact(buf);
             }
         }
@@ -178,6 +206,10 @@ impl Compact for OpTypedTransaction {
                 let (tx, buf) = TxDeposit::from_compact(buf, buf.len());
                 (Self::Deposit(tx), buf)
             }
+            OpTxType::PostExec => {
+                let (tx, buf) = TxPostExec::from_compact(buf, buf.len());
+                (Self::PostExec(tx), buf)
+            }
         }
     }
 }
@@ -191,7 +223,7 @@ impl Envelope for OpTxEnvelope {
             Self::Eip2930(tx) => tx.signature(),
             Self::Eip1559(tx) => tx.signature(),
             Self::Eip7702(tx) => tx.signature(),
-            Self::Deposit(_) => {
+            Self::Deposit(_) | Self::PostExec(_) => {
                 const DEPOSIT_SIG: Signature = Signature::new(U256::ZERO, U256::ZERO, false);
                 &DEPOSIT_SIG
             }
@@ -221,6 +253,9 @@ impl ToTxCompact for OpTxEnvelope {
                 tx.tx().to_compact(buf);
             }
             Self::Deposit(tx) => {
+                tx.inner().to_compact(buf);
+            }
+            Self::PostExec(tx) => {
                 tx.inner().to_compact(buf);
             }
         };
@@ -256,6 +291,10 @@ impl FromTxCompact for OpTxEnvelope {
             OpTxType::Deposit => {
                 let (tx, buf) = TxDeposit::from_compact(buf, buf.len());
                 (Self::Deposit(alloy_consensus::Sealed::new(tx)), buf)
+            }
+            OpTxType::PostExec => {
+                let (tx, buf) = TxPostExec::from_compact(buf, buf.len());
+                (Self::PostExec(alloy_consensus::Sealed::new(tx)), buf)
             }
         }
     }
@@ -337,6 +376,7 @@ impl From<CompactOpReceipt> for OpReceipt {
             OpTxType::Eip2930 => Self::Eip2930(receipt),
             OpTxType::Eip1559 => Self::Eip1559(receipt),
             OpTxType::Eip7702 => Self::Eip7702(receipt),
+            OpTxType::PostExec => Self::PostExec(receipt),
             OpTxType::Deposit => Self::Deposit(crate::OpDepositReceipt {
                 inner: receipt,
                 deposit_nonce: compact.deposit_nonce,

--- a/rust/op-alloy/crates/consensus/src/reth_core.rs
+++ b/rust/op-alloy/crates/consensus/src/reth_core.rs
@@ -41,7 +41,8 @@ impl InMemorySize for OpReceipt {
             Self::Legacy(receipt) |
             Self::Eip2930(receipt) |
             Self::Eip1559(receipt) |
-            Self::Eip7702(receipt) => receipt.size(),
+            Self::Eip7702(receipt) |
+            Self::PostExec(receipt) => receipt.size(),
             Self::Deposit(receipt) => receipt.size(),
         }
     }
@@ -55,6 +56,7 @@ impl InMemorySize for OpTypedTransaction {
             Self::Eip1559(tx) => tx.size(),
             Self::Eip7702(tx) => tx.size(),
             Self::Deposit(tx) => tx.size(),
+            Self::PostExec(tx) => tx.size(),
         }
     }
 }
@@ -78,6 +80,9 @@ impl InMemorySize for OpTxEnvelope {
             Self::Eip1559(tx) => tx.size(),
             Self::Eip7702(tx) => tx.size(),
             Self::Deposit(tx) => core::mem::size_of::<alloy_primitives::B256>() + tx.inner().size(),
+            Self::PostExec(tx) => {
+                core::mem::size_of::<alloy_primitives::B256>() + tx.inner().size()
+            }
         }
     }
 }

--- a/rust/op-alloy/crates/consensus/src/sdm.rs
+++ b/rust/op-alloy/crates/consensus/src/sdm.rs
@@ -1,0 +1,413 @@
+//! Post-execution transaction types.
+
+use alloc::vec::Vec;
+use alloy_consensus::{Sealable, Transaction, Typed2718, transaction::RlpEcdsaEncodableTx};
+use alloy_eips::{
+    eip2718::{Decodable2718, Eip2718Error, Eip2718Result, Encodable2718, IsTyped2718},
+    eip2930::AccessList,
+};
+use alloy_primitives::{B256, Bytes, ChainId, TxHash, TxKind, U256, keccak256};
+use alloy_rlp::{BufMut, Decodable, Encodable, Header};
+
+/// Type byte for the post-execution transaction.
+pub const POST_EXEC_TX_TYPE_ID: u8 = 0x7D;
+
+/// Per-transaction gas refund entry within a [`PostExecPayload`].
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct SDMGasEntry {
+    /// Transaction index within the block.
+    pub index: u64,
+    /// Gas refund from post-execution warming settlement.
+    pub gas_refund: u64,
+}
+
+impl Encodable for SDMGasEntry {
+    fn encode(&self, out: &mut dyn BufMut) {
+        let list_len = self.index.length() + self.gas_refund.length();
+        Header { list: true, payload_length: list_len }.encode(out);
+        self.index.encode(out);
+        self.gas_refund.encode(out);
+    }
+
+    fn length(&self) -> usize {
+        let list_len = self.index.length() + self.gas_refund.length();
+        Header { list: true, payload_length: list_len }.length() + list_len
+    }
+}
+
+impl Decodable for SDMGasEntry {
+    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        let header = Header::decode(buf)?;
+        if !header.list {
+            return Err(alloy_rlp::Error::UnexpectedString);
+        }
+        let remaining = buf.len();
+        let this = Self { index: Decodable::decode(buf)?, gas_refund: Decodable::decode(buf)? };
+        if buf.len() + header.payload_length != remaining {
+            return Err(alloy_rlp::Error::UnexpectedLength);
+        }
+        Ok(this)
+    }
+}
+
+/// Payload for the post-execution transaction.
+///
+/// Today this only carries the SDM gas refund data, but additional post-exec fields may
+/// be added in the future.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct PostExecPayload {
+    /// Format version.
+    pub version: u64,
+    /// L2 block number this synthetic payload is anchored to.
+    pub block_number: u64,
+    /// Initial SDM gas refund entries keyed by transaction index.
+    pub gas_refund_entries: Vec<SDMGasEntry>,
+}
+
+impl PostExecPayload {
+    /// Look up refund for a given tx index.
+    pub fn gas_refund_for_idx(&self, index: u64) -> Option<u64> {
+        self.gas_refund_entries.iter().find(|e| e.index == index).map(|e| e.gas_refund)
+    }
+
+    /// RLP-encode the payload into bytes.
+    pub fn to_rlp_bytes(&self) -> Bytes {
+        let mut buf = Vec::new();
+        self.encode(&mut buf);
+        buf.into()
+    }
+
+    /// Decode a payload from RLP bytes.
+    pub fn from_rlp_bytes(data: &[u8]) -> Option<Self> {
+        Self::decode(&mut &data[..]).ok()
+    }
+}
+
+impl Encodable for PostExecPayload {
+    fn encode(&self, out: &mut dyn BufMut) {
+        let list_len =
+            self.version.length() + self.block_number.length() + self.gas_refund_entries.length();
+        Header { list: true, payload_length: list_len }.encode(out);
+        self.version.encode(out);
+        self.block_number.encode(out);
+        self.gas_refund_entries.encode(out);
+    }
+
+    fn length(&self) -> usize {
+        let list_len =
+            self.version.length() + self.block_number.length() + self.gas_refund_entries.length();
+        Header { list: true, payload_length: list_len }.length() + list_len
+    }
+}
+
+impl Decodable for PostExecPayload {
+    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        let header = Header::decode(buf)?;
+        if !header.list {
+            return Err(alloy_rlp::Error::UnexpectedString);
+        }
+        let remaining = buf.len();
+        let this = Self {
+            version: Decodable::decode(buf)?,
+            block_number: Decodable::decode(buf)?,
+            gas_refund_entries: Decodable::decode(buf)?,
+        };
+        if buf.len() + header.payload_length != remaining {
+            return Err(alloy_rlp::Error::UnexpectedLength);
+        }
+        Ok(this)
+    }
+}
+
+/// Post-execution transaction carrying a [`PostExecPayload`].
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "serde",
+    serde(into = "TxPostExecSerdeHelper", try_from = "TxPostExecSerdeHelper")
+)]
+pub struct TxPostExec {
+    /// Decoded payload.
+    pub payload: PostExecPayload,
+    /// RLP-encoded payload bytes used as the transaction input.
+    pub input: Bytes,
+}
+
+#[cfg(feature = "arbitrary")]
+impl<'a> arbitrary::Arbitrary<'a> for TxPostExec {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(Self::new(PostExecPayload::arbitrary(u)?))
+    }
+}
+
+impl TxPostExec {
+    /// Construct a post-exec transaction from its decoded payload.
+    pub fn new(payload: PostExecPayload) -> Self {
+        let input = payload.to_rlp_bytes();
+        Self { payload, input }
+    }
+
+    /// Returns the canonical signature for post-exec transactions, which don't include a
+    /// signature.
+    pub const fn signature() -> alloy_primitives::Signature {
+        alloy_primitives::Signature::new(U256::ZERO, U256::ZERO, false)
+    }
+
+    /// Encoded length of the transaction body.
+    pub fn rlp_encoded_length(&self) -> usize {
+        self.input.len()
+    }
+
+    /// Encoded length including the type byte.
+    pub fn eip2718_encoded_length(&self) -> usize {
+        self.rlp_encoded_length() + 1
+    }
+
+    /// Calculates a heuristic for the in-memory size of the transaction.
+    pub fn size(&self) -> usize {
+        core::mem::size_of::<PostExecPayload>() +
+            self.input.len() +
+            self.payload.gas_refund_entries.len() * core::mem::size_of::<SDMGasEntry>()
+    }
+
+    /// Calculate the transaction hash.
+    pub fn tx_hash(&self) -> TxHash {
+        let mut buf = Vec::with_capacity(self.eip2718_encoded_length());
+        self.encode_2718(&mut buf);
+        keccak256(&buf)
+    }
+}
+
+impl Typed2718 for TxPostExec {
+    fn ty(&self) -> u8 {
+        POST_EXEC_TX_TYPE_ID
+    }
+}
+
+impl IsTyped2718 for TxPostExec {
+    fn is_type(ty: u8) -> bool {
+        ty == POST_EXEC_TX_TYPE_ID
+    }
+}
+
+impl RlpEcdsaEncodableTx for TxPostExec {
+    fn rlp_encoded_fields_length(&self) -> usize {
+        self.input.len()
+    }
+
+    fn rlp_encode_fields(&self, out: &mut dyn alloy_rlp::BufMut) {
+        out.put_slice(self.input.as_ref());
+    }
+}
+
+impl Transaction for TxPostExec {
+    fn chain_id(&self) -> Option<ChainId> {
+        None
+    }
+    fn nonce(&self) -> u64 {
+        0
+    }
+    fn gas_limit(&self) -> u64 {
+        0
+    }
+    fn gas_price(&self) -> Option<u128> {
+        None
+    }
+    fn max_fee_per_gas(&self) -> u128 {
+        0
+    }
+    fn max_priority_fee_per_gas(&self) -> Option<u128> {
+        None
+    }
+    fn max_fee_per_blob_gas(&self) -> Option<u128> {
+        None
+    }
+    fn priority_fee_or_price(&self) -> u128 {
+        0
+    }
+    fn effective_gas_price(&self, _: Option<u64>) -> u128 {
+        0
+    }
+    fn is_dynamic_fee(&self) -> bool {
+        false
+    }
+    fn kind(&self) -> TxKind {
+        TxKind::Call(Default::default())
+    }
+    fn is_create(&self) -> bool {
+        false
+    }
+    fn value(&self) -> U256 {
+        U256::ZERO
+    }
+    fn input(&self) -> &Bytes {
+        &self.input
+    }
+    fn access_list(&self) -> Option<&AccessList> {
+        None
+    }
+    fn blob_versioned_hashes(&self) -> Option<&[B256]> {
+        None
+    }
+    fn authorization_list(&self) -> Option<&[alloy_eips::eip7702::SignedAuthorization]> {
+        None
+    }
+}
+
+impl Encodable2718 for TxPostExec {
+    fn type_flag(&self) -> Option<u8> {
+        Some(POST_EXEC_TX_TYPE_ID)
+    }
+    fn encode_2718_len(&self) -> usize {
+        self.eip2718_encoded_length()
+    }
+    fn encode_2718(&self, out: &mut dyn alloy_rlp::BufMut) {
+        out.put_u8(POST_EXEC_TX_TYPE_ID);
+        out.put_slice(self.input.as_ref());
+    }
+}
+
+impl Decodable2718 for TxPostExec {
+    fn typed_decode(ty: u8, data: &mut &[u8]) -> Eip2718Result<Self> {
+        if ty != POST_EXEC_TX_TYPE_ID {
+            return Err(Eip2718Error::UnexpectedType(ty));
+        }
+        Ok(Self::new(PostExecPayload::decode(data)?))
+    }
+
+    fn fallback_decode(data: &mut &[u8]) -> Eip2718Result<Self> {
+        Ok(Self::new(PostExecPayload::decode(data)?))
+    }
+}
+
+impl Encodable for TxPostExec {
+    fn encode(&self, out: &mut dyn BufMut) {
+        out.put_slice(self.input.as_ref());
+    }
+
+    fn length(&self) -> usize {
+        self.rlp_encoded_length()
+    }
+}
+
+impl Decodable for TxPostExec {
+    fn decode(data: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        Ok(Self::new(PostExecPayload::decode(data)?))
+    }
+}
+
+impl Sealable for TxPostExec {
+    fn hash_slow(&self) -> B256 {
+        self.tx_hash()
+    }
+}
+
+#[cfg(feature = "serde")]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct TxPostExecSerdeHelper {
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
+    gas: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
+    value: Option<u128>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    input: Option<Bytes>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    payload: Option<PostExecPayload>,
+}
+
+#[cfg(feature = "serde")]
+impl From<TxPostExec> for TxPostExecSerdeHelper {
+    fn from(value: TxPostExec) -> Self {
+        Self { gas: Some(0), value: Some(0), input: Some(value.input), payload: None }
+    }
+}
+
+#[cfg(feature = "serde")]
+impl TryFrom<TxPostExecSerdeHelper> for TxPostExec {
+    type Error = &'static str;
+
+    fn try_from(value: TxPostExecSerdeHelper) -> Result<Self, Self::Error> {
+        if value.gas.is_some_and(|gas| gas != 0) {
+            return Err("post-exec transaction gas must be 0");
+        }
+        if value.value.is_some_and(|value| value != 0) {
+            return Err("post-exec transaction value must be 0");
+        }
+
+        let payload = if let Some(input) = value.input {
+            PostExecPayload::from_rlp_bytes(input.as_ref())
+                .ok_or("invalid post-exec transaction input")?
+        } else if let Some(payload) = value.payload {
+            payload
+        } else {
+            return Err("missing post-exec transaction input");
+        };
+
+        Ok(Self::new(payload))
+    }
+}
+
+#[cfg(feature = "alloy-compat")]
+impl From<TxPostExec> for alloy_rpc_types_eth::TransactionRequest {
+    fn from(tx: TxPostExec) -> Self {
+        Self {
+            from: Some(alloy_primitives::Address::ZERO),
+            transaction_type: Some(POST_EXEC_TX_TYPE_ID),
+            gas: Some(0),
+            nonce: Some(0),
+            value: Some(U256::ZERO),
+            input: tx.input.into(),
+            ..Default::default()
+        }
+    }
+}
+
+/// Build a post-execution transaction from a block number and refund entries.
+pub fn build_post_exec_tx(block_number: u64, gas_refund_entries: Vec<SDMGasEntry>) -> TxPostExec {
+    TxPostExec::new(PostExecPayload { version: 1, block_number, gas_refund_entries })
+}
+
+/// Check if a transaction type byte identifies a post-exec transaction.
+pub const fn is_post_exec_tx(ty: u8) -> bool {
+    ty == POST_EXEC_TX_TYPE_ID
+}
+
+/// Extract the payload from a post-exec transaction.
+pub fn extract_post_exec_payload_from_tx(tx: &TxPostExec) -> Option<PostExecPayload> {
+    Some(tx.payload.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn post_exec_payload_rlp_roundtrip_preserves_block_number() {
+        let payload = PostExecPayload {
+            version: 1,
+            block_number: 42,
+            gas_refund_entries: vec![SDMGasEntry { index: 3, gas_refund: 7 }],
+        };
+
+        let encoded = payload.to_rlp_bytes();
+        let decoded = PostExecPayload::from_rlp_bytes(encoded.as_ref()).expect("decode payload");
+
+        assert_eq!(decoded, payload);
+    }
+
+    #[test]
+    fn post_exec_tx_hash_depends_on_block_number() {
+        let entries = vec![SDMGasEntry { index: 3, gas_refund: 7 }];
+        let tx_a = build_post_exec_tx(42, entries.clone());
+        let tx_b = build_post_exec_tx(43, entries);
+
+        assert_ne!(tx_a.tx_hash(), tx_b.tx_hash());
+    }
+}

--- a/rust/op-alloy/crates/consensus/src/sdm.rs
+++ b/rust/op-alloy/crates/consensus/src/sdm.rs
@@ -344,6 +344,35 @@ mod tests {
         assert_ne!(tx_a.tx_hash(), tx_b.tx_hash());
     }
 
+    #[test]
+    fn post_exec_tx_eip2718_roundtrip() {
+        let tx = build_post_exec_tx(
+            99,
+            vec![
+                SDMGasEntry { index: 0, gas_refund: 100 },
+                SDMGasEntry { index: 5, gas_refund: 200 },
+            ],
+        );
+
+        let mut buf = Vec::new();
+        tx.encode_2718(&mut buf);
+
+        let decoded = TxPostExec::decode_2718(&mut buf.as_slice()).expect("decode 2718");
+        assert_eq!(decoded, tx);
+        assert_eq!(decoded.tx_hash(), tx.tx_hash());
+    }
+
+    #[test]
+    fn post_exec_tx_eip2718_roundtrip_empty_refunds() {
+        let tx = build_post_exec_tx(1, vec![]);
+
+        let mut buf = Vec::new();
+        tx.encode_2718(&mut buf);
+
+        let decoded = TxPostExec::decode_2718(&mut buf.as_slice()).expect("decode 2718");
+        assert_eq!(decoded, tx);
+    }
+
     #[cfg(feature = "serde")]
     #[test]
     fn post_exec_tx_serde_serializes_as_payload() {

--- a/rust/op-alloy/crates/consensus/src/sdm.rs
+++ b/rust/op-alloy/crates/consensus/src/sdm.rs
@@ -302,11 +302,6 @@ pub fn build_post_exec_tx(block_number: u64, gas_refund_entries: Vec<SDMGasEntry
     TxPostExec::new(PostExecPayload { version: 1, block_number, gas_refund_entries })
 }
 
-/// Check if a transaction type byte identifies a post-exec transaction.
-pub const fn is_post_exec_tx(ty: u8) -> bool {
-    ty == POST_EXEC_TX_TYPE_ID
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rust/op-alloy/crates/consensus/src/sdm.rs
+++ b/rust/op-alloy/crates/consensus/src/sdm.rs
@@ -1,21 +1,19 @@
 //! Post-execution transaction types.
 
 use alloc::vec::Vec;
-#[cfg(feature = "serde")]
-use alloc::{format, string::String};
 use alloy_consensus::{Sealable, Transaction, Typed2718, transaction::RlpEcdsaEncodableTx};
 use alloy_eips::{
     eip2718::{Decodable2718, Eip2718Error, Eip2718Result, Encodable2718, IsTyped2718},
     eip2930::AccessList,
 };
-use alloy_primitives::{B256, Bytes, ChainId, TxHash, TxKind, U256, keccak256};
-use alloy_rlp::{BufMut, Decodable, Encodable, Header};
+use alloy_primitives::{Address, B256, Bytes, ChainId, TxHash, TxKind, U256, keccak256};
+use alloy_rlp::{BufMut, Decodable, Encodable, Header, RlpDecodable, RlpEncodable};
 
 /// Type byte for the post-execution transaction.
 pub const POST_EXEC_TX_TYPE_ID: u8 = 0x7D;
 
 /// Per-transaction gas refund entry within a [`PostExecPayload`].
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default, RlpEncodable, RlpDecodable)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
@@ -26,40 +24,11 @@ pub struct SDMGasEntry {
     pub gas_refund: u64,
 }
 
-impl Encodable for SDMGasEntry {
-    fn encode(&self, out: &mut dyn BufMut) {
-        let list_len = self.index.length() + self.gas_refund.length();
-        Header { list: true, payload_length: list_len }.encode(out);
-        self.index.encode(out);
-        self.gas_refund.encode(out);
-    }
-
-    fn length(&self) -> usize {
-        let list_len = self.index.length() + self.gas_refund.length();
-        Header { list: true, payload_length: list_len }.length() + list_len
-    }
-}
-
-impl Decodable for SDMGasEntry {
-    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
-        let header = Header::decode(buf)?;
-        if !header.list {
-            return Err(alloy_rlp::Error::UnexpectedString);
-        }
-        let remaining = buf.len();
-        let this = Self { index: Decodable::decode(buf)?, gas_refund: Decodable::decode(buf)? };
-        if buf.len() + header.payload_length != remaining {
-            return Err(alloy_rlp::Error::UnexpectedLength);
-        }
-        Ok(this)
-    }
-}
-
 /// Payload for the post-execution transaction.
 ///
 /// Today this only carries the SDM gas refund data, but additional post-exec fields may
 /// be added in the future.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default, RlpEncodable, RlpDecodable)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
@@ -96,49 +65,10 @@ impl PostExecPayload {
     }
 }
 
-impl Encodable for PostExecPayload {
-    fn encode(&self, out: &mut dyn BufMut) {
-        let list_len =
-            self.version.length() + self.block_number.length() + self.gas_refund_entries.length();
-        Header { list: true, payload_length: list_len }.encode(out);
-        self.version.encode(out);
-        self.block_number.encode(out);
-        self.gas_refund_entries.encode(out);
-    }
-
-    fn length(&self) -> usize {
-        let list_len =
-            self.version.length() + self.block_number.length() + self.gas_refund_entries.length();
-        Header { list: true, payload_length: list_len }.length() + list_len
-    }
-}
-
-impl Decodable for PostExecPayload {
-    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
-        let header = Header::decode(buf)?;
-        if !header.list {
-            return Err(alloy_rlp::Error::UnexpectedString);
-        }
-        let remaining = buf.len();
-        let this = Self {
-            version: Decodable::decode(buf)?,
-            block_number: Decodable::decode(buf)?,
-            gas_refund_entries: Decodable::decode(buf)?,
-        };
-        if buf.len() + header.payload_length != remaining {
-            return Err(alloy_rlp::Error::UnexpectedLength);
-        }
-        Ok(this)
-    }
-}
-
 /// Post-execution transaction carrying a [`PostExecPayload`].
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    feature = "serde",
-    serde(into = "TxPostExecSerdeHelper", try_from = "TxPostExecSerdeHelper")
-)]
+#[cfg_attr(feature = "serde", serde(into = "PostExecPayload", from = "PostExecPayload"))]
 pub struct TxPostExec {
     /// Decoded payload.
     pub payload: PostExecPayload,
@@ -149,7 +79,20 @@ pub struct TxPostExec {
 #[cfg(feature = "arbitrary")]
 impl<'a> arbitrary::Arbitrary<'a> for TxPostExec {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        // Keep `payload` and the cached `input` bytes in sync for fuzzed values.
         Ok(Self::new(PostExecPayload::arbitrary(u)?))
+    }
+}
+
+impl From<PostExecPayload> for TxPostExec {
+    fn from(payload: PostExecPayload) -> Self {
+        Self::new(payload)
+    }
+}
+
+impl From<TxPostExec> for PostExecPayload {
+    fn from(tx: TxPostExec) -> Self {
+        tx.payload
     }
 }
 
@@ -164,6 +107,11 @@ impl TxPostExec {
     /// signature.
     pub const fn signature() -> alloy_primitives::Signature {
         alloy_primitives::Signature::new(U256::ZERO, U256::ZERO, false)
+    }
+
+    /// Returns the canonical signer address for post-exec transactions.
+    pub const fn signer_address(&self) -> Address {
+        Address::ZERO
     }
 
     /// Encoded length of the transaction body.
@@ -334,77 +282,11 @@ impl Sealable for TxPostExec {
     }
 }
 
-#[cfg(feature = "serde")]
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct TxPostExecSerdeHelper {
-    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
-    gas: Option<u64>,
-    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
-    value: Option<u128>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    input: Option<Bytes>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    payload: Option<PostExecPayload>,
-}
-
-#[cfg(feature = "serde")]
-impl From<TxPostExec> for TxPostExecSerdeHelper {
-    fn from(value: TxPostExec) -> Self {
-        // Emit both the canonical wire-format bytes and the decoded payload so JSON is both
-        // round-trippable and human-readable.
-        Self {
-            gas: Some(0),
-            value: Some(0),
-            input: Some(value.input),
-            payload: Some(value.payload),
-        }
-    }
-}
-
-#[cfg(feature = "serde")]
-impl TryFrom<TxPostExecSerdeHelper> for TxPostExec {
-    type Error = String;
-
-    fn try_from(value: TxPostExecSerdeHelper) -> Result<Self, Self::Error> {
-        if value.gas.is_some_and(|gas| gas != 0) {
-            return Err("post-exec transaction gas must be 0".into());
-        }
-        if value.value.is_some_and(|value| value != 0) {
-            return Err("post-exec transaction value must be 0".into());
-        }
-
-        // Accept either the raw input bytes or a decoded payload. If both are supplied, they must
-        // describe the same payload.
-        let input_payload = value
-            .input
-            .as_ref()
-            .map(|input| {
-                PostExecPayload::from_rlp_bytes(input.as_ref())
-                    .map_err(|err| format!("invalid post-exec transaction input: {err}"))
-            })
-            .transpose()?;
-
-        let payload = match (input_payload, value.payload) {
-            (Some(input_payload), Some(payload)) => {
-                if input_payload != payload {
-                    return Err("post-exec transaction input and payload mismatch".into());
-                }
-                input_payload
-            }
-            (Some(payload), None) | (None, Some(payload)) => payload,
-            (None, None) => return Err("missing post-exec transaction input or payload".into()),
-        };
-
-        Ok(Self::new(payload))
-    }
-}
-
 #[cfg(feature = "alloy-compat")]
 impl From<TxPostExec> for alloy_rpc_types_eth::TransactionRequest {
     fn from(tx: TxPostExec) -> Self {
         Self {
-            from: Some(alloy_primitives::Address::ZERO),
+            from: Some(tx.signer_address()),
             transaction_type: Some(POST_EXEC_TX_TYPE_ID),
             gas: Some(0),
             nonce: Some(0),
@@ -428,9 +310,6 @@ pub const fn is_post_exec_tx(ty: u8) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[cfg(feature = "serde")]
-    use serde_json::json;
 
     #[test]
     fn post_exec_payload_rlp_roundtrip_preserves_block_number() {
@@ -472,75 +351,21 @@ mod tests {
 
     #[cfg(feature = "serde")]
     #[test]
-    fn post_exec_tx_serde_emits_input_and_payload() {
+    fn post_exec_tx_serde_serializes_as_payload() {
         let tx = build_post_exec_tx(42, vec![SDMGasEntry { index: 3, gas_refund: 7 }]);
         let value = serde_json::to_value(&tx).expect("serialize tx");
 
-        assert!(value.get("input").is_some());
-        assert!(value.get("payload").is_some());
+        assert_eq!(value, serde_json::to_value(&tx.payload).expect("serialize payload"));
     }
 
     #[cfg(feature = "serde")]
     #[test]
-    fn post_exec_tx_serde_accepts_matching_input_and_payload() {
+    fn post_exec_tx_serde_roundtrip_preserves_cached_input() {
         let tx = build_post_exec_tx(42, vec![SDMGasEntry { index: 3, gas_refund: 7 }]);
         let value = serde_json::to_value(&tx).expect("serialize tx");
 
         let decoded: TxPostExec = serde_json::from_value(value).expect("deserialize tx");
         assert_eq!(decoded, tx);
-    }
-
-    #[cfg(feature = "serde")]
-    #[test]
-    fn post_exec_tx_serde_accepts_input_only() {
-        let tx = build_post_exec_tx(42, vec![SDMGasEntry { index: 3, gas_refund: 7 }]);
-        let mut value = serde_json::to_value(&tx).expect("serialize tx");
-        value.as_object_mut().expect("object").remove("payload");
-
-        let decoded: TxPostExec = serde_json::from_value(value).expect("deserialize tx");
-        assert_eq!(decoded, tx);
-    }
-
-    #[cfg(feature = "serde")]
-    #[test]
-    fn post_exec_tx_serde_accepts_payload_only() {
-        let tx = build_post_exec_tx(42, vec![SDMGasEntry { index: 3, gas_refund: 7 }]);
-        let mut value = serde_json::to_value(&tx).expect("serialize tx");
-        value.as_object_mut().expect("object").remove("input");
-
-        let decoded: TxPostExec = serde_json::from_value(value).expect("deserialize tx");
-        assert_eq!(decoded, tx);
-    }
-
-    #[cfg(feature = "serde")]
-    #[test]
-    fn post_exec_tx_serde_rejects_conflicting_input_and_payload() {
-        let tx = build_post_exec_tx(42, vec![SDMGasEntry { index: 3, gas_refund: 7 }]);
-        let value = json!({
-            "gas": "0x0",
-            "value": "0x0",
-            "input": tx.input,
-            "payload": {
-                "version": 1,
-                "blockNumber": 43,
-                "gasRefundEntries": [{ "index": 3, "gasRefund": 7 }]
-            }
-        });
-
-        let err = serde_json::from_value::<TxPostExec>(value).expect_err("reject mismatch");
-        assert!(err.to_string().contains("input and payload mismatch"));
-    }
-
-    #[cfg(feature = "serde")]
-    #[test]
-    fn post_exec_tx_serde_surfaces_input_decode_error() {
-        let value = json!({
-            "gas": "0x0",
-            "value": "0x0",
-            "input": "0xc0"
-        });
-
-        let err = serde_json::from_value::<TxPostExec>(value).expect_err("reject invalid input");
-        assert!(err.to_string().contains("invalid post-exec transaction input"));
+        assert_eq!(decoded.input, decoded.payload.to_rlp_bytes());
     }
 }

--- a/rust/op-alloy/crates/consensus/src/sdm.rs
+++ b/rust/op-alloy/crates/consensus/src/sdm.rs
@@ -1,6 +1,8 @@
 //! Post-execution transaction types.
 
 use alloc::vec::Vec;
+#[cfg(feature = "serde")]
+use alloc::{format, string::String};
 use alloy_consensus::{Sealable, Transaction, Typed2718, transaction::RlpEcdsaEncodableTx};
 use alloy_eips::{
     eip2718::{Decodable2718, Eip2718Error, Eip2718Result, Encodable2718, IsTyped2718},
@@ -84,8 +86,13 @@ impl PostExecPayload {
     }
 
     /// Decode a payload from RLP bytes.
-    pub fn from_rlp_bytes(data: &[u8]) -> Option<Self> {
-        Self::decode(&mut &data[..]).ok()
+    pub fn from_rlp_bytes(data: &[u8]) -> alloy_rlp::Result<Self> {
+        let mut buf = data;
+        let payload = Self::decode(&mut buf)?;
+        if !buf.is_empty() {
+            return Err(alloy_rlp::Error::UnexpectedLength);
+        }
+        Ok(payload)
     }
 }
 
@@ -169,6 +176,21 @@ impl TxPostExec {
         self.rlp_encoded_length() + 1
     }
 
+    fn network_header(&self) -> Header {
+        Header { list: false, payload_length: self.eip2718_encoded_length() }
+    }
+
+    /// Encoded length including the outer network RLP header.
+    pub fn network_encoded_length(&self) -> usize {
+        self.network_header().length_with_payload()
+    }
+
+    /// Network encode the transaction.
+    pub fn network_encode(&self, out: &mut dyn BufMut) {
+        self.network_header().encode(out);
+        self.encode_2718(out);
+    }
+
     /// Calculates a heuristic for the in-memory size of the transaction.
     pub fn size(&self) -> usize {
         core::mem::size_of::<PostExecPayload>() +
@@ -202,6 +224,8 @@ impl RlpEcdsaEncodableTx for TxPostExec {
     }
 
     fn rlp_encode_fields(&self, out: &mut dyn alloy_rlp::BufMut) {
+        // `input` already stores the canonical RLP-encoded payload, so the transaction fields are
+        // written as-is instead of being wrapped in an additional RLP list.
         out.put_slice(self.input.as_ref());
     }
 }
@@ -238,6 +262,8 @@ impl Transaction for TxPostExec {
         false
     }
     fn kind(&self) -> TxKind {
+        // Post-exec transactions do not carry a destination like deposits do, so expose them as a
+        // synthetic zero-address call placeholder.
         TxKind::Call(Default::default())
     }
     fn is_create(&self) -> bool {
@@ -325,29 +351,49 @@ struct TxPostExecSerdeHelper {
 #[cfg(feature = "serde")]
 impl From<TxPostExec> for TxPostExecSerdeHelper {
     fn from(value: TxPostExec) -> Self {
-        Self { gas: Some(0), value: Some(0), input: Some(value.input), payload: None }
+        // Emit both the canonical wire-format bytes and the decoded payload so JSON is both
+        // round-trippable and human-readable.
+        Self {
+            gas: Some(0),
+            value: Some(0),
+            input: Some(value.input),
+            payload: Some(value.payload),
+        }
     }
 }
 
 #[cfg(feature = "serde")]
 impl TryFrom<TxPostExecSerdeHelper> for TxPostExec {
-    type Error = &'static str;
+    type Error = String;
 
     fn try_from(value: TxPostExecSerdeHelper) -> Result<Self, Self::Error> {
         if value.gas.is_some_and(|gas| gas != 0) {
-            return Err("post-exec transaction gas must be 0");
+            return Err("post-exec transaction gas must be 0".into());
         }
         if value.value.is_some_and(|value| value != 0) {
-            return Err("post-exec transaction value must be 0");
+            return Err("post-exec transaction value must be 0".into());
         }
 
-        let payload = if let Some(input) = value.input {
-            PostExecPayload::from_rlp_bytes(input.as_ref())
-                .ok_or("invalid post-exec transaction input")?
-        } else if let Some(payload) = value.payload {
-            payload
-        } else {
-            return Err("missing post-exec transaction input");
+        // Accept either the raw input bytes or a decoded payload. If both are supplied, they must
+        // describe the same payload.
+        let input_payload = value
+            .input
+            .as_ref()
+            .map(|input| {
+                PostExecPayload::from_rlp_bytes(input.as_ref())
+                    .map_err(|err| format!("invalid post-exec transaction input: {err}"))
+            })
+            .transpose()?;
+
+        let payload = match (input_payload, value.payload) {
+            (Some(input_payload), Some(payload)) => {
+                if input_payload != payload {
+                    return Err("post-exec transaction input and payload mismatch".into());
+                }
+                input_payload
+            }
+            (Some(payload), None) | (None, Some(payload)) => payload,
+            (None, None) => return Err("missing post-exec transaction input or payload".into()),
         };
 
         Ok(Self::new(payload))
@@ -379,14 +425,12 @@ pub const fn is_post_exec_tx(ty: u8) -> bool {
     ty == POST_EXEC_TX_TYPE_ID
 }
 
-/// Extract the payload from a post-exec transaction.
-pub fn extract_post_exec_payload_from_tx(tx: &TxPostExec) -> Option<PostExecPayload> {
-    Some(tx.payload.clone())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(feature = "serde")]
+    use serde_json::json;
 
     #[test]
     fn post_exec_payload_rlp_roundtrip_preserves_block_number() {
@@ -403,11 +447,100 @@ mod tests {
     }
 
     #[test]
+    fn post_exec_payload_rlp_decode_rejects_trailing_bytes() {
+        let payload = PostExecPayload {
+            version: 1,
+            block_number: 42,
+            gas_refund_entries: vec![SDMGasEntry { index: 3, gas_refund: 7 }],
+        };
+
+        let mut encoded = payload.to_rlp_bytes().to_vec();
+        encoded.push(0);
+
+        let err = PostExecPayload::from_rlp_bytes(&encoded).expect_err("reject trailing bytes");
+        assert_eq!(err, alloy_rlp::Error::UnexpectedLength);
+    }
+
+    #[test]
     fn post_exec_tx_hash_depends_on_block_number() {
         let entries = vec![SDMGasEntry { index: 3, gas_refund: 7 }];
         let tx_a = build_post_exec_tx(42, entries.clone());
         let tx_b = build_post_exec_tx(43, entries);
 
         assert_ne!(tx_a.tx_hash(), tx_b.tx_hash());
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn post_exec_tx_serde_emits_input_and_payload() {
+        let tx = build_post_exec_tx(42, vec![SDMGasEntry { index: 3, gas_refund: 7 }]);
+        let value = serde_json::to_value(&tx).expect("serialize tx");
+
+        assert!(value.get("input").is_some());
+        assert!(value.get("payload").is_some());
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn post_exec_tx_serde_accepts_matching_input_and_payload() {
+        let tx = build_post_exec_tx(42, vec![SDMGasEntry { index: 3, gas_refund: 7 }]);
+        let value = serde_json::to_value(&tx).expect("serialize tx");
+
+        let decoded: TxPostExec = serde_json::from_value(value).expect("deserialize tx");
+        assert_eq!(decoded, tx);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn post_exec_tx_serde_accepts_input_only() {
+        let tx = build_post_exec_tx(42, vec![SDMGasEntry { index: 3, gas_refund: 7 }]);
+        let mut value = serde_json::to_value(&tx).expect("serialize tx");
+        value.as_object_mut().expect("object").remove("payload");
+
+        let decoded: TxPostExec = serde_json::from_value(value).expect("deserialize tx");
+        assert_eq!(decoded, tx);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn post_exec_tx_serde_accepts_payload_only() {
+        let tx = build_post_exec_tx(42, vec![SDMGasEntry { index: 3, gas_refund: 7 }]);
+        let mut value = serde_json::to_value(&tx).expect("serialize tx");
+        value.as_object_mut().expect("object").remove("input");
+
+        let decoded: TxPostExec = serde_json::from_value(value).expect("deserialize tx");
+        assert_eq!(decoded, tx);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn post_exec_tx_serde_rejects_conflicting_input_and_payload() {
+        let tx = build_post_exec_tx(42, vec![SDMGasEntry { index: 3, gas_refund: 7 }]);
+        let value = json!({
+            "gas": "0x0",
+            "value": "0x0",
+            "input": tx.input,
+            "payload": {
+                "version": 1,
+                "blockNumber": 43,
+                "gasRefundEntries": [{ "index": 3, "gasRefund": 7 }]
+            }
+        });
+
+        let err = serde_json::from_value::<TxPostExec>(value).expect_err("reject mismatch");
+        assert!(err.to_string().contains("input and payload mismatch"));
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn post_exec_tx_serde_surfaces_input_decode_error() {
+        let value = json!({
+            "gas": "0x0",
+            "value": "0x0",
+            "input": "0xc0"
+        });
+
+        let err = serde_json::from_value::<TxPostExec>(value).expect_err("reject invalid input");
+        assert!(err.to_string().contains("invalid post-exec transaction input"));
     }
 }

--- a/rust/op-alloy/crates/consensus/src/transaction/envelope.rs
+++ b/rust/op-alloy/crates/consensus/src/transaction/envelope.rs
@@ -1,5 +1,5 @@
 use crate::{
-    OpPooledTransaction, TxDeposit,
+    OpPooledTransaction, TxDeposit, TxPostExec,
     transaction::{OpDepositInfo, OpTransactionInfo},
 };
 use alloy_consensus::{
@@ -41,6 +41,9 @@ pub enum OpTxEnvelope {
     #[envelope(ty = 126)]
     #[serde(serialize_with = "crate::serde_deposit_tx_rpc")]
     Deposit(Sealed<TxDeposit>),
+    /// A [`TxPostExec`] tagged with type 0x7D.
+    #[envelope(ty = 125)]
+    PostExec(Sealed<TxPostExec>),
 }
 
 /// Represents an Optimism transaction envelope.
@@ -141,6 +144,7 @@ impl From<Signed<OpTypedTransaction>> for OpTxEnvelope {
                 Self::Eip7702(tx)
             }
             OpTypedTransaction::Deposit(tx) => Self::Deposit(Sealed::new_unchecked(tx, hash)),
+            OpTypedTransaction::PostExec(tx) => Self::PostExec(Sealed::new_unchecked(tx, hash)),
         }
     }
 }
@@ -154,6 +158,18 @@ impl From<(OpTypedTransaction, Signature)> for OpTxEnvelope {
 impl From<Sealed<TxDeposit>> for OpTxEnvelope {
     fn from(v: Sealed<TxDeposit>) -> Self {
         Self::Deposit(v)
+    }
+}
+
+impl From<TxPostExec> for OpTxEnvelope {
+    fn from(v: TxPostExec) -> Self {
+        v.seal_slow().into()
+    }
+}
+
+impl From<Sealed<TxPostExec>> for OpTxEnvelope {
+    fn from(v: Sealed<TxPostExec>) -> Self {
+        Self::PostExec(v)
     }
 }
 
@@ -187,6 +203,7 @@ impl From<OpTxEnvelope> for alloy_rpc_types_eth::TransactionRequest {
             OpTxEnvelope::Eip1559(tx) => tx.into_parts().0.into(),
             OpTxEnvelope::Eip7702(tx) => tx.into_parts().0.into(),
             OpTxEnvelope::Deposit(tx) => tx.into_inner().into(),
+            OpTxEnvelope::PostExec(tx) => tx.into_inner().into(),
             OpTxEnvelope::Legacy(tx) => tx.into_parts().0.into(),
         }
     }
@@ -242,15 +259,18 @@ impl OpTxEnvelope {
     /// Attempts to convert the envelope into the pooled variant.
     ///
     /// Returns an error if the envelope's variant is incompatible with the pooled format:
-    /// [`TxDeposit`].
+    /// [`TxDeposit`] and [`TxPostExec`].
     pub fn try_into_pooled(self) -> Result<OpPooledTransaction, ValueError<Self>> {
         match self {
             Self::Legacy(tx) => Ok(tx.into()),
             Self::Eip2930(tx) => Ok(tx.into()),
             Self::Eip1559(tx) => Ok(tx.into()),
             Self::Eip7702(tx) => Ok(tx.into()),
-            Self::Deposit(tx) => {
-                Err(ValueError::new(tx.into(), "Deposit transactions cannot be pooled"))
+            tx @ Self::Deposit(_) => {
+                Err(ValueError::new(tx, "Deposit transactions cannot be pooled"))
+            }
+            tx @ Self::PostExec(_) => {
+                Err(ValueError::new(tx, "PostExec transactions cannot be pooled"))
             }
         }
     }
@@ -258,7 +278,7 @@ impl OpTxEnvelope {
     /// Attempts to convert the envelope into the ethereum pooled variant.
     ///
     /// Returns an error if the envelope's variant is incompatible with the pooled format:
-    /// [`TxDeposit`].
+    /// [`TxDeposit`] and [`TxPostExec`].
     pub fn try_into_eth_pooled(
         self,
     ) -> Result<alloy_consensus::transaction::PooledTransaction, ValueError<Self>> {
@@ -277,6 +297,10 @@ impl OpTxEnvelope {
             tx @ Self::Deposit(_) => Err(ValueError::new(
                 tx,
                 "Deposit transactions cannot be converted to ethereum transaction",
+            )),
+            tx @ Self::PostExec(_) => Err(ValueError::new(
+                tx,
+                "PostExec transactions cannot be converted to ethereum transaction",
             )),
         }
     }
@@ -316,6 +340,10 @@ impl OpTxEnvelope {
     /// Returns mutable access to the input bytes.
     ///
     /// Caution: modifying this will cause side-effects on the hash.
+    ///
+    /// For [`TxPostExec`], this mutates the cached encoded payload bytes directly and may leave
+    /// them out of sync with [`TxPostExec::payload`]. Rebuild the transaction with
+    /// [`TxPostExec::new`] if you need to restore that invariant after mutating the input.
     #[doc(hidden)]
     pub const fn input_mut(&mut self) -> &mut Bytes {
         match self {
@@ -324,6 +352,7 @@ impl OpTxEnvelope {
             Self::Legacy(tx) => &mut tx.tx_mut().input,
             Self::Eip7702(tx) => &mut tx.tx_mut().input,
             Self::Deposit(tx) => &mut tx.inner_mut().input,
+            Self::PostExec(tx) => &mut tx.inner_mut().input,
         }
     }
 
@@ -357,6 +386,12 @@ impl OpTxEnvelope {
         matches!(self, Self::Deposit(_))
     }
 
+    /// Returns true if the transaction is a post-exec transaction.
+    #[inline]
+    pub const fn is_post_exec(&self) -> bool {
+        matches!(self, Self::PostExec(_))
+    }
+
     /// Returns the [`TxLegacy`] variant if the transaction is a legacy transaction.
     pub const fn as_legacy(&self) -> Option<&Signed<TxLegacy>> {
         match self {
@@ -381,7 +416,7 @@ impl OpTxEnvelope {
         }
     }
 
-    /// Returns the [`TxEip1559`] variant if the transaction is an EIP-1559 transaction.
+    /// Returns the [`TxDeposit`] variant if the transaction is a deposit transaction.
     pub const fn as_deposit(&self) -> Option<&Sealed<TxDeposit>> {
         match self {
             Self::Deposit(tx) => Some(tx),
@@ -391,14 +426,14 @@ impl OpTxEnvelope {
 
     /// Return the reference to signature.
     ///
-    /// Returns `None` if this is a deposit variant.
+    /// Returns `None` for unsigned variants: [`TxDeposit`] and [`TxPostExec`].
     pub const fn signature(&self) -> Option<&Signature> {
         match self {
             Self::Legacy(tx) => Some(tx.signature()),
             Self::Eip2930(tx) => Some(tx.signature()),
             Self::Eip1559(tx) => Some(tx.signature()),
             Self::Eip7702(tx) => Some(tx.signature()),
-            Self::Deposit(_) => None,
+            Self::Deposit(_) | Self::PostExec(_) => None,
         }
     }
 
@@ -410,6 +445,7 @@ impl OpTxEnvelope {
             Self::Eip1559(_) => OpTxType::Eip1559,
             Self::Eip7702(_) => OpTxType::Eip7702,
             Self::Deposit(_) => OpTxType::Deposit,
+            Self::PostExec(_) => OpTxType::PostExec,
         }
     }
 
@@ -421,6 +457,7 @@ impl OpTxEnvelope {
             Self::Eip2930(tx) => tx.hash(),
             Self::Eip7702(tx) => tx.hash(),
             Self::Deposit(tx) => tx.hash_ref(),
+            Self::PostExec(tx) => tx.hash_ref(),
         }
     }
 
@@ -437,6 +474,7 @@ impl OpTxEnvelope {
             Self::Eip1559(t) => t.eip2718_encoded_length(),
             Self::Eip7702(t) => t.eip2718_encoded_length(),
             Self::Deposit(t) => t.eip2718_encoded_length(),
+            Self::PostExec(t) => t.eip2718_encoded_length(),
         }
     }
 }
@@ -460,13 +498,16 @@ impl alloy_consensus::transaction::SignerRecoverable for OpTxEnvelope {
             // Optimism's Deposit transaction does not have a signature. Directly return the
             // `from` address.
             Self::Deposit(tx) => return Ok(tx.from),
+            Self::PostExec(_) => return Ok(alloy_primitives::Address::ZERO),
         };
         let signature = match self {
             Self::Legacy(tx) => tx.signature(),
             Self::Eip2930(tx) => tx.signature(),
             Self::Eip1559(tx) => tx.signature(),
             Self::Eip7702(tx) => tx.signature(),
-            Self::Deposit(_) => unreachable!("Deposit transactions should not be handled here"),
+            Self::Deposit(_) | Self::PostExec(_) => {
+                unreachable!("non-signed transactions should not be handled here")
+            }
         };
         alloy_consensus::crypto::secp256k1::recover_signer(signature, signature_hash)
     }
@@ -482,13 +523,16 @@ impl alloy_consensus::transaction::SignerRecoverable for OpTxEnvelope {
             // Optimism's Deposit transaction does not have a signature. Directly return the
             // `from` address.
             Self::Deposit(tx) => return Ok(tx.from),
+            Self::PostExec(_) => return Ok(alloy_primitives::Address::ZERO),
         };
         let signature = match self {
             Self::Legacy(tx) => tx.signature(),
             Self::Eip2930(tx) => tx.signature(),
             Self::Eip1559(tx) => tx.signature(),
             Self::Eip7702(tx) => tx.signature(),
-            Self::Deposit(_) => unreachable!("Deposit transactions should not be handled here"),
+            Self::Deposit(_) | Self::PostExec(_) => {
+                unreachable!("non-signed transactions should not be handled here")
+            }
         };
         alloy_consensus::crypto::secp256k1::recover_signer_unchecked(signature, signature_hash)
     }
@@ -511,6 +555,7 @@ impl alloy_consensus::transaction::SignerRecoverable for OpTxEnvelope {
                 alloy_consensus::transaction::SignerRecoverable::recover_unchecked_with_buf(tx, buf)
             }
             Self::Deposit(tx) => Ok(tx.from),
+            Self::PostExec(_) => Ok(alloy_primitives::Address::ZERO),
         }
     }
 }
@@ -518,7 +563,7 @@ impl alloy_consensus::transaction::SignerRecoverable for OpTxEnvelope {
 /// Bincode-compatible serde implementation for `OpTxEnvelope`.
 #[cfg(all(feature = "serde", feature = "serde-bincode-compat"))]
 pub mod serde_bincode_compat {
-    use crate::serde_bincode_compat::TxDeposit;
+    use crate::{TxPostExec, serde_bincode_compat::TxDeposit};
     use alloy_consensus::{
         Sealed, Signed,
         transaction::serde_bincode_compat::{TxEip1559, TxEip2930, TxEip7702, TxLegacy},
@@ -565,6 +610,13 @@ pub mod serde_bincode_compat {
             /// Borrowed deposit transaction data.
             transaction: TxDeposit<'a>,
         },
+        /// Post-exec variant.
+        PostExec {
+            /// Precomputed hash.
+            hash: B256,
+            /// Owned post-exec transaction data.
+            transaction: TxPostExec,
+        },
     }
 
     impl<'a> From<&'a super::OpTxEnvelope> for OpTxEnvelope<'a> {
@@ -590,6 +642,10 @@ pub mod serde_bincode_compat {
                     hash: sealed_deposit.seal(),
                     transaction: sealed_deposit.inner().into(),
                 },
+                super::OpTxEnvelope::PostExec(sealed_post_exec) => Self::PostExec {
+                    hash: sealed_post_exec.seal(),
+                    transaction: sealed_post_exec.inner().clone(),
+                },
             }
         }
     }
@@ -611,6 +667,9 @@ pub mod serde_bincode_compat {
                 }
                 OpTxEnvelope::Deposit { hash, transaction } => {
                     Self::Deposit(Sealed::new_unchecked(transaction.into(), hash))
+                }
+                OpTxEnvelope::PostExec { hash, transaction } => {
+                    Self::PostExec(Sealed::new_unchecked(transaction, hash))
                 }
             }
         }
@@ -639,10 +698,42 @@ pub mod serde_bincode_compat {
     #[cfg(test)]
     mod tests {
         use super::*;
+        use alloy_consensus::{Sealed, Signed, TxEip1559, TxEip2930, TxEip7702, TxLegacy};
         use arbitrary::Arbitrary;
         use rand::Rng;
         use serde::{Deserialize, Serialize};
         use serde_with::serde_as;
+
+        fn arbitrary_op_tx_envelope(
+            u: &mut arbitrary::Unstructured<'_>,
+        ) -> arbitrary::Result<super::super::OpTxEnvelope> {
+            Ok(match u.int_in_range(0..=5)? {
+                0 => super::super::OpTxEnvelope::Legacy(Signed::new_unhashed(
+                    TxLegacy::arbitrary(u)?,
+                    Signature::arbitrary(u)?,
+                )),
+                1 => super::super::OpTxEnvelope::Eip2930(Signed::new_unhashed(
+                    TxEip2930::arbitrary(u)?,
+                    Signature::arbitrary(u)?,
+                )),
+                2 => super::super::OpTxEnvelope::Eip1559(Signed::new_unhashed(
+                    TxEip1559::arbitrary(u)?,
+                    Signature::arbitrary(u)?,
+                )),
+                3 => super::super::OpTxEnvelope::Eip7702(Signed::new_unhashed(
+                    TxEip7702::arbitrary(u)?,
+                    Signature::arbitrary(u)?,
+                )),
+                4 => super::super::OpTxEnvelope::Deposit(Sealed::new_unchecked(
+                    crate::TxDeposit::arbitrary(u)?,
+                    B256::arbitrary(u)?,
+                )),
+                _ => super::super::OpTxEnvelope::PostExec(Sealed::new_unchecked(
+                    crate::TxPostExec::arbitrary(u)?,
+                    B256::arbitrary(u)?,
+                )),
+            })
+        }
 
         /// Tests a bincode round-trip for `OpTxEnvelope` using an arbitrary instance.
         #[test]
@@ -655,14 +746,16 @@ pub mod serde_bincode_compat {
                 envelope: super::super::OpTxEnvelope,
             }
 
-            let mut bytes = [0u8; 1024];
-            rand::rng().fill(bytes.as_mut_slice());
-            let data = Data {
-                envelope: super::super::OpTxEnvelope::arbitrary(&mut arbitrary::Unstructured::new(
-                    &bytes,
-                ))
-                .unwrap(),
-            };
+            let mut rng = rand::rng();
+            let data = (0..128)
+                .find_map(|_| {
+                    let mut bytes = [0u8; 4096];
+                    rng.fill(bytes.as_mut_slice());
+                    arbitrary_op_tx_envelope(&mut arbitrary::Unstructured::new(&bytes))
+                        .ok()
+                        .map(|envelope| Data { envelope })
+                })
+                .expect("failed to generate arbitrary OpTxEnvelope");
 
             let encoded = bincode::serde::encode_to_vec(&data, bincode::config::legacy()).unwrap();
             let (decoded, _) =

--- a/rust/op-alloy/crates/consensus/src/transaction/envelope.rs
+++ b/rust/op-alloy/crates/consensus/src/transaction/envelope.rs
@@ -48,13 +48,17 @@ pub enum OpTxEnvelope {
 
 /// Represents an Optimism transaction envelope.
 ///
-/// Compared to Ethereum it can tell whether the transaction is a deposit.
+/// Compared to Ethereum it can tell whether the transaction is a deposit or post-exec synthetic
+/// transaction.
 pub trait OpTransaction {
     /// Returns `true` if the transaction is a deposit.
     fn is_deposit(&self) -> bool;
 
     /// Returns `Some` if the transaction is a deposit.
     fn as_deposit(&self) -> Option<&Sealed<TxDeposit>>;
+
+    /// Returns `Some` if the transaction is a post-exec transaction.
+    fn as_post_exec(&self) -> Option<&Sealed<TxPostExec>>;
 }
 
 impl OpTransaction for OpTxEnvelope {
@@ -64,6 +68,10 @@ impl OpTransaction for OpTxEnvelope {
 
     fn as_deposit(&self) -> Option<&Sealed<TxDeposit>> {
         self.as_deposit()
+    }
+
+    fn as_post_exec(&self) -> Option<&Sealed<TxPostExec>> {
+        self.as_post_exec()
     }
 }
 
@@ -83,6 +91,13 @@ where
         match self {
             Self::BuiltIn(b) => b.as_deposit(),
             Self::Other(t) => t.as_deposit(),
+        }
+    }
+
+    fn as_post_exec(&self) -> Option<&Sealed<TxPostExec>> {
+        match self {
+            Self::BuiltIn(b) => b.as_post_exec(),
+            Self::Other(t) => t.as_post_exec(),
         }
     }
 }
@@ -424,6 +439,14 @@ impl OpTxEnvelope {
         }
     }
 
+    /// Returns the [`TxPostExec`] variant if the transaction is a post-exec transaction.
+    pub const fn as_post_exec(&self) -> Option<&Sealed<TxPostExec>> {
+        match self {
+            Self::PostExec(tx) => Some(tx),
+            _ => None,
+        }
+    }
+
     /// Return the reference to signature.
     ///
     /// Returns `None` for unsigned variants: [`TxDeposit`] and [`TxPostExec`].
@@ -498,6 +521,8 @@ impl alloy_consensus::transaction::SignerRecoverable for OpTxEnvelope {
             // Optimism's Deposit transaction does not have a signature. Directly return the
             // `from` address.
             Self::Deposit(tx) => return Ok(tx.from),
+            // Post-exec transactions are synthetic and unsigned, so use the canonical zero
+            // address placeholder.
             Self::PostExec(_) => return Ok(alloy_primitives::Address::ZERO),
         };
         let signature = match self {
@@ -523,6 +548,8 @@ impl alloy_consensus::transaction::SignerRecoverable for OpTxEnvelope {
             // Optimism's Deposit transaction does not have a signature. Directly return the
             // `from` address.
             Self::Deposit(tx) => return Ok(tx.from),
+            // Post-exec transactions are synthetic and unsigned, so use the canonical zero
+            // address placeholder.
             Self::PostExec(_) => return Ok(alloy_primitives::Address::ZERO),
         };
         let signature = match self {
@@ -555,6 +582,8 @@ impl alloy_consensus::transaction::SignerRecoverable for OpTxEnvelope {
                 alloy_consensus::transaction::SignerRecoverable::recover_unchecked_with_buf(tx, buf)
             }
             Self::Deposit(tx) => Ok(tx.from),
+            // Post-exec transactions are synthetic and unsigned, so use the canonical zero
+            // address placeholder.
             Self::PostExec(_) => Ok(alloy_primitives::Address::ZERO),
         }
     }

--- a/rust/op-alloy/crates/consensus/src/transaction/envelope.rs
+++ b/rust/op-alloy/crates/consensus/src/transaction/envelope.rs
@@ -521,9 +521,7 @@ impl alloy_consensus::transaction::SignerRecoverable for OpTxEnvelope {
             // Optimism's Deposit transaction does not have a signature. Directly return the
             // `from` address.
             Self::Deposit(tx) => return Ok(tx.from),
-            // Post-exec transactions are synthetic and unsigned, so use the canonical zero
-            // address placeholder.
-            Self::PostExec(_) => return Ok(alloy_primitives::Address::ZERO),
+            Self::PostExec(tx) => return Ok(tx.inner().signer_address()),
         };
         let signature = match self {
             Self::Legacy(tx) => tx.signature(),
@@ -548,9 +546,7 @@ impl alloy_consensus::transaction::SignerRecoverable for OpTxEnvelope {
             // Optimism's Deposit transaction does not have a signature. Directly return the
             // `from` address.
             Self::Deposit(tx) => return Ok(tx.from),
-            // Post-exec transactions are synthetic and unsigned, so use the canonical zero
-            // address placeholder.
-            Self::PostExec(_) => return Ok(alloy_primitives::Address::ZERO),
+            Self::PostExec(tx) => return Ok(tx.inner().signer_address()),
         };
         let signature = match self {
             Self::Legacy(tx) => tx.signature(),
@@ -582,9 +578,7 @@ impl alloy_consensus::transaction::SignerRecoverable for OpTxEnvelope {
                 alloy_consensus::transaction::SignerRecoverable::recover_unchecked_with_buf(tx, buf)
             }
             Self::Deposit(tx) => Ok(tx.from),
-            // Post-exec transactions are synthetic and unsigned, so use the canonical zero
-            // address placeholder.
-            Self::PostExec(_) => Ok(alloy_primitives::Address::ZERO),
+            Self::PostExec(tx) => Ok(tx.inner().signer_address()),
         }
     }
 }

--- a/rust/op-alloy/crates/consensus/src/transaction/envelope.rs
+++ b/rust/op-alloy/crates/consensus/src/transaction/envelope.rs
@@ -521,6 +521,8 @@ impl alloy_consensus::transaction::SignerRecoverable for OpTxEnvelope {
             // Optimism's Deposit transaction does not have a signature. Directly return the
             // `from` address.
             Self::Deposit(tx) => return Ok(tx.from),
+            // Post-exec transactions are unsigned synthetic system transactions. They use a
+            // canonical zero-address signer rather than a cryptographic signature.
             Self::PostExec(tx) => return Ok(tx.inner().signer_address()),
         };
         let signature = match self {
@@ -528,6 +530,7 @@ impl alloy_consensus::transaction::SignerRecoverable for OpTxEnvelope {
             Self::Eip2930(tx) => tx.signature(),
             Self::Eip1559(tx) => tx.signature(),
             Self::Eip7702(tx) => tx.signature(),
+            // Deposit and PostExec are unsigned and handled via early return above.
             Self::Deposit(_) | Self::PostExec(_) => {
                 unreachable!("non-signed transactions should not be handled here")
             }
@@ -546,6 +549,8 @@ impl alloy_consensus::transaction::SignerRecoverable for OpTxEnvelope {
             // Optimism's Deposit transaction does not have a signature. Directly return the
             // `from` address.
             Self::Deposit(tx) => return Ok(tx.from),
+            // Post-exec transactions are unsigned synthetic system transactions. They use a
+            // canonical zero-address signer rather than a cryptographic signature.
             Self::PostExec(tx) => return Ok(tx.inner().signer_address()),
         };
         let signature = match self {
@@ -553,9 +558,8 @@ impl alloy_consensus::transaction::SignerRecoverable for OpTxEnvelope {
             Self::Eip2930(tx) => tx.signature(),
             Self::Eip1559(tx) => tx.signature(),
             Self::Eip7702(tx) => tx.signature(),
-            Self::Deposit(_) | Self::PostExec(_) => {
-                unreachable!("non-signed transactions should not be handled here")
-            }
+            // Deposit and PostExec are unsigned and handled via early return above.
+            Self::Deposit(_) | Self::PostExec(_) => unreachable!(),
         };
         alloy_consensus::crypto::secp256k1::recover_signer_unchecked(signature, signature_hash)
     }
@@ -577,6 +581,7 @@ impl alloy_consensus::transaction::SignerRecoverable for OpTxEnvelope {
             Self::Eip7702(tx) => {
                 alloy_consensus::transaction::SignerRecoverable::recover_unchecked_with_buf(tx, buf)
             }
+            // Deposit and PostExec are unsigned; return their canonical signer directly.
             Self::Deposit(tx) => Ok(tx.from),
             Self::PostExec(tx) => Ok(tx.inner().signer_address()),
         }

--- a/rust/op-alloy/crates/consensus/src/transaction/tx_type.rs
+++ b/rust/op-alloy/crates/consensus/src/transaction/tx_type.rs
@@ -21,14 +21,15 @@ impl Display for OpTxType {
             Self::Eip1559 => write!(f, "eip1559"),
             Self::Eip7702 => write!(f, "eip7702"),
             Self::Deposit => write!(f, "deposit"),
+            Self::PostExec => write!(f, "post-exec"),
         }
     }
 }
 
 impl OpTxType {
     /// List of all variants.
-    pub const ALL: [Self; 5] =
-        [Self::Legacy, Self::Eip2930, Self::Eip1559, Self::Eip7702, Self::Deposit];
+    pub const ALL: [Self; 6] =
+        [Self::Legacy, Self::Eip2930, Self::Eip1559, Self::Eip7702, Self::Deposit, Self::PostExec];
 
     /// Returns `true` if the type is [`OpTxType::Deposit`].
     pub const fn is_deposit(&self) -> bool {
@@ -44,13 +45,14 @@ mod tests {
 
     #[test]
     fn test_all_tx_types() {
-        assert_eq!(OpTxType::ALL.len(), 5);
+        assert_eq!(OpTxType::ALL.len(), 6);
         let all = vec![
             OpTxType::Legacy,
             OpTxType::Eip2930,
             OpTxType::Eip1559,
             OpTxType::Eip7702,
             OpTxType::Deposit,
+            OpTxType::PostExec,
         ];
         assert_eq!(OpTxType::ALL.to_vec(), all);
     }

--- a/rust/op-alloy/crates/consensus/src/transaction/typed.rs
+++ b/rust/op-alloy/crates/consensus/src/transaction/typed.rs
@@ -100,6 +100,7 @@ impl OpTypedTransaction {
             Self::Eip2930(tx) => Some(tx.signature_hash()),
             Self::Eip1559(tx) => Some(tx.signature_hash()),
             Self::Eip7702(tx) => Some(tx.signature_hash()),
+            // Deposit and PostExec are unsigned synthetic transactions with no signature hash.
             Self::Deposit(_) | Self::PostExec(_) => None,
         }
     }

--- a/rust/op-alloy/crates/consensus/src/transaction/typed.rs
+++ b/rust/op-alloy/crates/consensus/src/transaction/typed.rs
@@ -256,7 +256,7 @@ impl RlpEcdsaEncodableTx for OpTypedTransaction {
             Self::Eip1559(tx) => tx.network_encode_with_type(signature, tx.ty(), out),
             Self::Eip7702(tx) => tx.network_encode_with_type(signature, tx.ty(), out),
             Self::Deposit(tx) => tx.network_encode(out),
-            Self::PostExec(tx) => Encodable2718::network_encode(tx, out),
+            Self::PostExec(tx) => tx.network_encode(out),
         }
     }
 
@@ -267,7 +267,7 @@ impl RlpEcdsaEncodableTx for OpTypedTransaction {
             Self::Eip1559(tx) => tx.network_encode(signature, out),
             Self::Eip7702(tx) => tx.network_encode(signature, out),
             Self::Deposit(tx) => tx.network_encode(out),
-            Self::PostExec(tx) => Encodable2718::network_encode(tx, out),
+            Self::PostExec(tx) => tx.network_encode(out),
         }
     }
 

--- a/rust/op-alloy/crates/consensus/src/transaction/typed.rs
+++ b/rust/op-alloy/crates/consensus/src/transaction/typed.rs
@@ -1,5 +1,5 @@
 pub use crate::transaction::envelope::OpTypedTransaction;
-use crate::{OpTxEnvelope, OpTxType, TxDeposit};
+use crate::{OpTxEnvelope, OpTxType, TxDeposit, TxPostExec};
 use alloy_consensus::{
     EthereumTypedTransaction, SignableTransaction, Signed, TxEip1559, TxEip2930, TxEip7702,
     TxLegacy, Typed2718, TypedTransaction, error::ValueError, transaction::RlpEcdsaEncodableTx,
@@ -37,6 +37,12 @@ impl From<TxDeposit> for OpTypedTransaction {
     }
 }
 
+impl From<TxPostExec> for OpTypedTransaction {
+    fn from(tx: TxPostExec) -> Self {
+        Self::PostExec(tx)
+    }
+}
+
 impl From<OpTxEnvelope> for OpTypedTransaction {
     fn from(envelope: OpTxEnvelope) -> Self {
         match envelope {
@@ -45,6 +51,7 @@ impl From<OpTxEnvelope> for OpTypedTransaction {
             OpTxEnvelope::Eip1559(tx) => Self::Eip1559(tx.strip_signature()),
             OpTxEnvelope::Eip7702(tx) => Self::Eip7702(tx.strip_signature()),
             OpTxEnvelope::Deposit(tx) => Self::Deposit(tx.into_inner()),
+            OpTxEnvelope::PostExec(tx) => Self::PostExec(tx.into_inner()),
         }
     }
 }
@@ -66,6 +73,7 @@ impl From<OpTypedTransaction> for alloy_rpc_types_eth::TransactionRequest {
             OpTypedTransaction::Eip1559(tx) => tx.into(),
             OpTypedTransaction::Eip7702(tx) => tx.into(),
             OpTypedTransaction::Deposit(tx) => tx.into(),
+            OpTypedTransaction::PostExec(tx) => tx.into(),
         }
     }
 }
@@ -79,19 +87,20 @@ impl OpTypedTransaction {
             Self::Eip1559(_) => OpTxType::Eip1559,
             Self::Eip7702(_) => OpTxType::Eip7702,
             Self::Deposit(_) => OpTxType::Deposit,
+            Self::PostExec(_) => OpTxType::PostExec,
         }
     }
 
     /// Calculates the signing hash for the transaction.
     ///
-    /// Returns `None` if the tx is a deposit transaction.
+    /// Returns `None` for unsigned transaction variants: [`TxDeposit`] and [`TxPostExec`].
     pub fn checked_signature_hash(&self) -> Option<B256> {
         match self {
             Self::Legacy(tx) => Some(tx.signature_hash()),
             Self::Eip2930(tx) => Some(tx.signature_hash()),
             Self::Eip1559(tx) => Some(tx.signature_hash()),
             Self::Eip7702(tx) => Some(tx.signature_hash()),
-            Self::Deposit(_) => None,
+            Self::Deposit(_) | Self::PostExec(_) => None,
         }
     }
 
@@ -127,6 +136,14 @@ impl OpTypedTransaction {
         }
     }
 
+    /// Return the inner post-exec transaction if it exists.
+    pub const fn post_exec(&self) -> Option<&TxPostExec> {
+        match self {
+            Self::PostExec(tx) => Some(tx),
+            _ => None,
+        }
+    }
+
     /// Returns `true` if transaction is deposit transaction.
     pub const fn is_deposit(&self) -> bool {
         matches!(self, Self::Deposit(_))
@@ -134,7 +151,8 @@ impl OpTypedTransaction {
 
     /// Calculate the transaction hash for the given signature.
     ///
-    /// Note: Returns the regular tx hash if this is a deposit variant
+    /// Note: returns the regular transaction hash for unsigned variants: [`TxDeposit`] and
+    /// [`TxPostExec`]. In those cases the provided signature is ignored.
     pub fn tx_hash(&self, signature: &Signature) -> TxHash {
         match self {
             Self::Legacy(tx) => tx.tx_hash(signature),
@@ -142,28 +160,30 @@ impl OpTypedTransaction {
             Self::Eip1559(tx) => tx.tx_hash(signature),
             Self::Eip7702(tx) => tx.tx_hash(signature),
             Self::Deposit(tx) => tx.tx_hash(),
+            Self::PostExec(tx) => tx.tx_hash(),
         }
     }
 
     /// Convenience function to convert this typed transaction into an [`OpTxEnvelope`].
     ///
-    /// Note: If this is a [`OpTypedTransaction::Deposit`] variant, the signature will be ignored.
+    /// Note: for unsigned variants ([`OpTypedTransaction::Deposit`] and
+    /// [`OpTypedTransaction::PostExec`]), the provided signature is ignored.
     pub fn into_envelope(self, signature: Signature) -> OpTxEnvelope {
         self.into_signed(signature).into()
     }
 
     /// Attempts to convert the optimism variant into an ethereum [`TypedTransaction`].
     ///
-    /// Returns the typed transaction as error if it is a variant unsupported on ethereum:
-    /// [`TxDeposit`]
+    /// Returns the typed transaction as an error if it is a variant unsupported on ethereum:
+    /// [`TxDeposit`] or [`TxPostExec`].
     pub fn try_into_eth(self) -> Result<TypedTransaction, ValueError<Self>> {
         self.try_into_eth_variant()
     }
 
     /// Attempts to convert the optimism variant into an ethereum [`TypedTransaction`].
     ///
-    /// Returns the typed transaction as error if it is a variant unsupported on ethereum:
-    /// [`TxDeposit`]
+    /// Returns the typed transaction as an error if it is a variant unsupported on ethereum:
+    /// [`TxDeposit`] or [`TxPostExec`].
     pub fn try_into_eth_variant<Eip4844>(
         self,
     ) -> Result<EthereumTypedTransaction<Eip4844>, ValueError<Self>> {
@@ -175,6 +195,10 @@ impl OpTypedTransaction {
             tx @ Self::Deposit(_) => Err(ValueError::new(
                 tx,
                 "Deposit transactions cannot be converted to ethereum transaction",
+            )),
+            tx @ Self::PostExec(_) => Err(ValueError::new(
+                tx,
+                "PostExec transactions cannot be converted to ethereum transaction",
             )),
         }
     }
@@ -188,6 +212,7 @@ impl RlpEcdsaEncodableTx for OpTypedTransaction {
             Self::Eip1559(tx) => tx.rlp_encoded_fields_length(),
             Self::Eip7702(tx) => tx.rlp_encoded_fields_length(),
             Self::Deposit(tx) => tx.rlp_encoded_fields_length(),
+            Self::PostExec(tx) => tx.rlp_encoded_fields_length(),
         }
     }
 
@@ -198,6 +223,7 @@ impl RlpEcdsaEncodableTx for OpTypedTransaction {
             Self::Eip1559(tx) => tx.rlp_encode_fields(out),
             Self::Eip7702(tx) => tx.rlp_encode_fields(out),
             Self::Deposit(tx) => tx.rlp_encode_fields(out),
+            Self::PostExec(tx) => tx.rlp_encode_fields(out),
         }
     }
 
@@ -208,6 +234,7 @@ impl RlpEcdsaEncodableTx for OpTypedTransaction {
             Self::Eip1559(tx) => tx.eip2718_encode_with_type(signature, tx.ty(), out),
             Self::Eip7702(tx) => tx.eip2718_encode_with_type(signature, tx.ty(), out),
             Self::Deposit(tx) => tx.encode_2718(out),
+            Self::PostExec(tx) => tx.encode_2718(out),
         }
     }
 
@@ -218,6 +245,7 @@ impl RlpEcdsaEncodableTx for OpTypedTransaction {
             Self::Eip1559(tx) => tx.eip2718_encode(signature, out),
             Self::Eip7702(tx) => tx.eip2718_encode(signature, out),
             Self::Deposit(tx) => tx.encode_2718(out),
+            Self::PostExec(tx) => tx.encode_2718(out),
         }
     }
 
@@ -228,6 +256,7 @@ impl RlpEcdsaEncodableTx for OpTypedTransaction {
             Self::Eip1559(tx) => tx.network_encode_with_type(signature, tx.ty(), out),
             Self::Eip7702(tx) => tx.network_encode_with_type(signature, tx.ty(), out),
             Self::Deposit(tx) => tx.network_encode(out),
+            Self::PostExec(tx) => Encodable2718::network_encode(tx, out),
         }
     }
 
@@ -238,6 +267,7 @@ impl RlpEcdsaEncodableTx for OpTypedTransaction {
             Self::Eip1559(tx) => tx.network_encode(signature, out),
             Self::Eip7702(tx) => tx.network_encode(signature, out),
             Self::Deposit(tx) => tx.network_encode(out),
+            Self::PostExec(tx) => Encodable2718::network_encode(tx, out),
         }
     }
 
@@ -248,6 +278,7 @@ impl RlpEcdsaEncodableTx for OpTypedTransaction {
             Self::Eip1559(tx) => tx.tx_hash_with_type(signature, tx.ty()),
             Self::Eip7702(tx) => tx.tx_hash_with_type(signature, tx.ty()),
             Self::Deposit(tx) => tx.tx_hash(),
+            Self::PostExec(tx) => tx.tx_hash(),
         }
     }
 
@@ -258,6 +289,7 @@ impl RlpEcdsaEncodableTx for OpTypedTransaction {
             Self::Eip1559(tx) => tx.tx_hash(signature),
             Self::Eip7702(tx) => tx.tx_hash(signature),
             Self::Deposit(tx) => tx.tx_hash(),
+            Self::PostExec(tx) => tx.tx_hash(),
         }
     }
 }
@@ -269,7 +301,7 @@ impl SignableTransaction<Signature> for OpTypedTransaction {
             Self::Eip2930(tx) => tx.set_chain_id(chain_id),
             Self::Eip1559(tx) => tx.set_chain_id(chain_id),
             Self::Eip7702(tx) => tx.set_chain_id(chain_id),
-            Self::Deposit(_) => {}
+            Self::Deposit(_) | Self::PostExec(_) => {}
         }
     }
 
@@ -279,7 +311,7 @@ impl SignableTransaction<Signature> for OpTypedTransaction {
             Self::Eip2930(tx) => tx.encode_for_signing(out),
             Self::Eip1559(tx) => tx.encode_for_signing(out),
             Self::Eip7702(tx) => tx.encode_for_signing(out),
-            Self::Deposit(_) => {}
+            Self::Deposit(_) | Self::PostExec(_) => {}
         }
     }
 
@@ -289,7 +321,7 @@ impl SignableTransaction<Signature> for OpTypedTransaction {
             Self::Eip2930(tx) => tx.payload_len_for_signature(),
             Self::Eip1559(tx) => tx.payload_len_for_signature(),
             Self::Eip7702(tx) => tx.payload_len_for_signature(),
-            Self::Deposit(_) => 0,
+            Self::Deposit(_) | Self::PostExec(_) => 0,
         }
     }
 

--- a/rust/op-alloy/crates/network/src/lib.rs
+++ b/rust/op-alloy/crates/network/src/lib.rs
@@ -143,6 +143,7 @@ impl TransactionBuilder<Optimism> for OpTransactionRequest {
     fn complete_type(&self, ty: OpTxType) -> Result<(), Vec<&'static str>> {
         match ty {
             OpTxType::Deposit => Err(vec!["not implemented for deposit tx"]),
+            OpTxType::PostExec => Err(vec!["not implemented for post-exec tx"]),
             _ => {
                 let ty = TxType::try_from(ty as u8).unwrap();
                 self.as_ref().complete_type(ty)

--- a/rust/op-alloy/crates/rpc-types/src/lib.rs
+++ b/rust/op-alloy/crates/rpc-types/src/lib.rs
@@ -9,6 +9,9 @@
 
 extern crate alloc;
 
+#[cfg(feature = "arbitrary")]
+use arbitrary as _;
+
 mod genesis;
 pub use genesis::{OpBaseFeeInfo, OpChainInfo, OpGenesisInfo};
 

--- a/rust/op-alloy/crates/rpc-types/src/receipt.rs
+++ b/rust/op-alloy/crates/rpc-types/src/receipt.rs
@@ -19,6 +19,9 @@ pub struct OpTransactionReceipt {
     /// L1 block info of the transaction.
     #[serde(flatten)]
     pub l1_block_info: L1BlockInfo,
+    /// Per-transaction gas refund from post-exec block-level warming.
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
+    pub op_gas_refund: Option<u64>,
 }
 
 impl alloy_network_primitives::ReceiptResponse for OpTransactionReceipt {
@@ -87,6 +90,9 @@ pub struct OpTransactionReceiptFields {
     /// L1 block info.
     #[serde(flatten)]
     pub l1_block_info: L1BlockInfo,
+    /// Per-transaction gas refund from post-exec block-level warming.
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
+    pub op_gas_refund: Option<u64>,
     /* --------------------------------------- Regolith --------------------------------------- */
     /// Deposit nonce for deposit transactions.
     ///
@@ -229,6 +235,9 @@ impl From<OpTransactionReceipt> for OpReceiptEnvelope<alloy_primitives::Log> {
             OpReceiptEnvelope::Eip2930(receipt) => Self::Eip2930(convert_standard_receipt(receipt)),
             OpReceiptEnvelope::Eip1559(receipt) => Self::Eip1559(convert_standard_receipt(receipt)),
             OpReceiptEnvelope::Eip7702(receipt) => Self::Eip7702(convert_standard_receipt(receipt)),
+            OpReceiptEnvelope::PostExec(receipt) => {
+                Self::PostExec(convert_standard_receipt(receipt))
+            }
             OpReceiptEnvelope::Deposit(OpDepositReceiptWithBloom { logs_bloom, receipt }) => {
                 let consensus_logs = receipt.inner.logs.into_iter().map(|log| log.inner).collect();
                 let consensus_receipt = OpDepositReceiptWithBloom {

--- a/rust/op-alloy/crates/rpc-types/src/transaction/request.rs
+++ b/rust/op-alloy/crates/rpc-types/src/transaction/request.rs
@@ -161,7 +161,7 @@ impl From<Sealed<TxDeposit>> for OpTransactionRequest {
 impl From<TxPostExec> for OpTransactionRequest {
     fn from(tx: TxPostExec) -> Self {
         Self(TransactionRequest {
-            from: Some(Address::ZERO),
+            from: Some(tx.signer_address()),
             transaction_type: Some(POST_EXEC_TX_TYPE_ID),
             gas: Some(0),
             nonce: Some(0),

--- a/rust/op-alloy/crates/rpc-types/src/transaction/request.rs
+++ b/rust/op-alloy/crates/rpc-types/src/transaction/request.rs
@@ -6,7 +6,9 @@ use alloy_eips::eip7702::SignedAuthorization;
 use alloy_network_primitives::TransactionBuilder7702;
 use alloy_primitives::{Address, Signature, TxKind, U256};
 use alloy_rpc_types_eth::{AccessList, TransactionInput, TransactionRequest};
-use op_alloy_consensus::{OpTxEnvelope, OpTypedTransaction, TxDeposit};
+use op_alloy_consensus::{
+    OpTxEnvelope, OpTypedTransaction, POST_EXEC_TX_TYPE_ID, TxDeposit, TxPostExec,
+};
 use serde::{Deserialize, Serialize};
 
 /// Builder for [`OpTypedTransaction`].
@@ -156,6 +158,20 @@ impl From<Sealed<TxDeposit>> for OpTransactionRequest {
     }
 }
 
+impl From<TxPostExec> for OpTransactionRequest {
+    fn from(tx: TxPostExec) -> Self {
+        Self(TransactionRequest {
+            from: Some(Address::ZERO),
+            transaction_type: Some(POST_EXEC_TX_TYPE_ID),
+            gas: Some(0),
+            nonce: Some(0),
+            value: Some(U256::ZERO),
+            input: tx.payload.to_rlp_bytes().into(),
+            ..Default::default()
+        })
+    }
+}
+
 impl<T> From<Signed<T, Signature>> for OpTransactionRequest
 where
     T: SignableTransaction<Signature> + Into<TransactionRequest>,
@@ -181,6 +197,7 @@ impl From<OpTypedTransaction> for OpTransactionRequest {
             OpTypedTransaction::Eip1559(tx) => Self(tx.into()),
             OpTypedTransaction::Eip7702(tx) => Self(tx.into()),
             OpTypedTransaction::Deposit(tx) => tx.into(),
+            OpTypedTransaction::PostExec(tx) => tx.into(),
         }
     }
 }
@@ -192,6 +209,7 @@ impl From<OpTxEnvelope> for OpTransactionRequest {
             OpTxEnvelope::Eip1559(tx) => tx.into(),
             OpTxEnvelope::Eip7702(tx) => tx.into(),
             OpTxEnvelope::Deposit(tx) => tx.into(),
+            OpTxEnvelope::PostExec(tx) => tx.into_inner().into(),
             _ => Default::default(),
         }
     }

--- a/rust/op-alloy/crates/rpc-types/src/transaction/request.rs
+++ b/rust/op-alloy/crates/rpc-types/src/transaction/request.rs
@@ -166,7 +166,7 @@ impl From<TxPostExec> for OpTransactionRequest {
             gas: Some(0),
             nonce: Some(0),
             value: Some(U256::ZERO),
-            input: tx.payload.to_rlp_bytes().into(),
+            input: tx.input.into(),
             ..Default::default()
         })
     }

--- a/rust/op-reth/crates/chainspec/Cargo.toml
+++ b/rust/op-reth/crates/chainspec/Cargo.toml
@@ -20,7 +20,7 @@ reth-network-peers.workspace = true
 
 # op-reth
 reth-optimism-forks.workspace = true
-reth-optimism-primitives.workspace = true
+reth-optimism-primitives = { workspace = true, features = ["serde", "reth-codec"] }
 
 # ethereum
 alloy-chains.workspace = true

--- a/rust/op-reth/crates/cli/src/ovm_file_codec.rs
+++ b/rust/op-reth/crates/cli/src/ovm_file_codec.rs
@@ -279,7 +279,7 @@ impl Decodable2718 for OvmTransactionSigned {
             )),
             OpTxType::PostExec => Ok(Self::from_transaction_and_signature(
                 OpTypedTransaction::PostExec(TxPostExec::decode_2718(buf)?),
-                Signature::new(Default::default(), Default::default(), false),
+                TxPostExec::signature(),
             )),
         }
     }

--- a/rust/op-reth/crates/cli/src/ovm_file_codec.rs
+++ b/rust/op-reth/crates/cli/src/ovm_file_codec.rs
@@ -14,7 +14,7 @@ use alloy_primitives::{
 };
 use alloy_rlp::{Decodable, Error as RlpError, RlpDecodable};
 use derive_more::{AsRef, Deref};
-use op_alloy_consensus::{OpTxType, OpTypedTransaction, TxDeposit};
+use op_alloy_consensus::{OpTxType, OpTypedTransaction, TxDeposit, TxPostExec};
 use reth_downloaders::file_client::FileClientError;
 use serde::{Deserialize, Serialize};
 use tokio_util::codec::Decoder;
@@ -248,6 +248,7 @@ impl Encodable2718 for OvmTransactionSigned {
                 set_code_tx.eip2718_encoded_length(&self.signature)
             }
             OpTypedTransaction::Deposit(deposit_tx) => deposit_tx.eip2718_encoded_length(),
+            OpTypedTransaction::PostExec(post_exec_tx) => post_exec_tx.eip2718_encoded_length(),
         }
     }
 
@@ -275,6 +276,10 @@ impl Decodable2718 for OvmTransactionSigned {
             OpTxType::Deposit => Ok(Self::from_transaction_and_signature(
                 OpTypedTransaction::Deposit(TxDeposit::rlp_decode(buf)?),
                 TxDeposit::signature(),
+            )),
+            OpTxType::PostExec => Ok(Self::from_transaction_and_signature(
+                OpTypedTransaction::PostExec(TxPostExec::decode_2718(buf)?),
+                Signature::new(Default::default(), Default::default(), false),
             )),
         }
     }

--- a/rust/op-reth/crates/cli/src/receipt_file_codec.rs
+++ b/rust/op-reth/crates/cli/src/receipt_file_codec.rs
@@ -108,6 +108,7 @@ impl TryFrom<OpGethReceipt> for OpReceipt {
             OpTxType::Legacy => Ok(Self::Legacy(receipt)),
             OpTxType::Eip2930 => Ok(Self::Eip2930(receipt)),
             OpTxType::Eip1559 => Ok(Self::Eip1559(receipt)),
+            OpTxType::PostExec => Ok(Self::PostExec(receipt)),
             OpTxType::Eip7702 => Ok(Self::Eip7702(receipt)),
             OpTxType::Deposit => Ok(Self::Deposit(OpDepositReceipt {
                 inner: receipt,

--- a/rust/op-reth/crates/evm/src/receipts.rs
+++ b/rust/op-reth/crates/evm/src/receipts.rs
@@ -35,6 +35,7 @@ impl OpReceiptBuilder for OpRethReceiptBuilder {
                     OpTxType::Eip1559 => OpReceipt::Eip1559(receipt),
                     OpTxType::Eip2930 => OpReceipt::Eip2930(receipt),
                     OpTxType::Eip7702 => OpReceipt::Eip7702(receipt),
+                    OpTxType::PostExec => OpReceipt::PostExec(receipt),
                     OpTxType::Deposit => unreachable!(),
                 })
             }

--- a/rust/op-reth/crates/primitives/src/receipt.rs
+++ b/rust/op-reth/crates/primitives/src/receipt.rs
@@ -67,6 +67,8 @@ pub(super) mod serde_bincode_compat {
         Eip1559(alloy_consensus::serde_bincode_compat::Receipt<'a, alloy_primitives::Log>),
         /// EIP-7702 receipt
         Eip7702(alloy_consensus::serde_bincode_compat::Receipt<'a, alloy_primitives::Log>),
+        /// Post-exec receipt
+        PostExec(alloy_consensus::serde_bincode_compat::Receipt<'a, alloy_primitives::Log>),
         /// Deposit receipt
         Deposit(
             op_alloy_consensus::serde_bincode_compat::OpDepositReceipt<'a, alloy_primitives::Log>,
@@ -80,6 +82,7 @@ pub(super) mod serde_bincode_compat {
                 super::OpReceipt::Eip2930(receipt) => Self::Eip2930(receipt.into()),
                 super::OpReceipt::Eip1559(receipt) => Self::Eip1559(receipt.into()),
                 super::OpReceipt::Eip7702(receipt) => Self::Eip7702(receipt.into()),
+                super::OpReceipt::PostExec(receipt) => Self::PostExec(receipt.into()),
                 super::OpReceipt::Deposit(receipt) => Self::Deposit(receipt.into()),
             }
         }
@@ -92,6 +95,7 @@ pub(super) mod serde_bincode_compat {
                 OpReceipt::Eip2930(receipt) => Self::Eip2930(receipt.into()),
                 OpReceipt::Eip1559(receipt) => Self::Eip1559(receipt.into()),
                 OpReceipt::Eip7702(receipt) => Self::Eip7702(receipt.into()),
+                OpReceipt::PostExec(receipt) => Self::PostExec(receipt.into()),
                 OpReceipt::Deposit(receipt) => Self::Deposit(receipt.into()),
             }
         }

--- a/rust/op-reth/crates/primitives/src/transaction/mod.rs
+++ b/rust/op-reth/crates/primitives/src/transaction/mod.rs
@@ -6,7 +6,11 @@ mod tx_type;
 #[cfg(test)]
 mod signed;
 
-pub use op_alloy_consensus::{OpTransaction, OpTxType, OpTypedTransaction};
+pub use op_alloy_consensus::{
+    OpTransaction, OpTxEnvelope, OpTxType, OpTypedTransaction, POST_EXEC_TX_TYPE_ID,
+    PostExecPayload, SDMGasEntry, TxPostExec, build_post_exec_tx,
+    extract_post_exec_payload_from_tx,
+};
 
 /// Signed transaction.
-pub type OpTransactionSigned = op_alloy_consensus::OpTxEnvelope;
+pub type OpTransactionSigned = OpTxEnvelope;

--- a/rust/op-reth/crates/primitives/src/transaction/mod.rs
+++ b/rust/op-reth/crates/primitives/src/transaction/mod.rs
@@ -9,7 +9,6 @@ mod signed;
 pub use op_alloy_consensus::{
     OpTransaction, OpTxEnvelope, OpTxType, OpTypedTransaction, POST_EXEC_TX_TYPE_ID,
     PostExecPayload, SDMGasEntry, TxPostExec, build_post_exec_tx,
-    extract_post_exec_payload_from_tx,
 };
 
 /// Signed transaction.

--- a/rust/op-reth/crates/primitives/src/transaction/signed.rs
+++ b/rust/op-reth/crates/primitives/src/transaction/signed.rs
@@ -110,9 +110,9 @@ impl SignerRecoverable for OpTransactionSigned {
     fn recover_signer(&self) -> Result<Address, RecoveryError> {
         // Optimism's Deposit transaction does not have a signature. Directly return the
         // `from` address.
-        match self.transaction {
-            OpTypedTransaction::Deposit(TxDeposit { from, .. }) => return Ok(from),
-            OpTypedTransaction::PostExec(_) => return Ok(Address::ZERO),
+        match &self.transaction {
+            OpTypedTransaction::Deposit(TxDeposit { from, .. }) => return Ok(*from),
+            OpTypedTransaction::PostExec(tx) => return Ok(tx.signer_address()),
             _ => {}
         }
 
@@ -126,7 +126,7 @@ impl SignerRecoverable for OpTransactionSigned {
         // `from` address.
         match &self.transaction {
             OpTypedTransaction::Deposit(TxDeposit { from, .. }) => return Ok(*from),
-            OpTypedTransaction::PostExec(_) => return Ok(Address::ZERO),
+            OpTypedTransaction::PostExec(tx) => return Ok(tx.signer_address()),
             _ => {}
         }
 
@@ -140,7 +140,7 @@ impl SignerRecoverable for OpTransactionSigned {
             // Optimism's Deposit transaction does not have a signature. Directly return the
             // `from` address.
             OpTypedTransaction::Deposit(tx) => return Ok(tx.from),
-            OpTypedTransaction::PostExec(_) => return Ok(Address::ZERO),
+            OpTypedTransaction::PostExec(tx) => return Ok(tx.signer_address()),
             OpTypedTransaction::Legacy(tx) => tx.encode_for_signing(buf),
             OpTypedTransaction::Eip2930(tx) => tx.encode_for_signing(buf),
             OpTypedTransaction::Eip1559(tx) => tx.encode_for_signing(buf),
@@ -200,11 +200,7 @@ impl From<Sealed<TxDeposit>> for OpTransactionSigned {
 impl From<Sealed<TxPostExec>> for OpTransactionSigned {
     fn from(value: Sealed<TxPostExec>) -> Self {
         let (tx, hash) = value.into_parts();
-        Self::new(
-            OpTypedTransaction::PostExec(tx),
-            Signature::new(Default::default(), Default::default(), false),
-            hash,
-        )
+        Self::new(OpTypedTransaction::PostExec(tx), TxPostExec::signature(), hash)
     }
 }
 
@@ -323,7 +319,7 @@ impl Decodable2718 for OpTransactionSigned {
             )),
             op_alloy_consensus::OpTxType::PostExec => Ok(Self::new_unhashed(
                 OpTypedTransaction::PostExec(TxPostExec::decode_2718(buf)?),
-                Signature::new(Default::default(), Default::default(), false),
+                TxPostExec::signature(),
             )),
         }
     }

--- a/rust/op-reth/crates/primitives/src/transaction/signed.rs
+++ b/rust/op-reth/crates/primitives/src/transaction/signed.rs
@@ -20,7 +20,9 @@ use core::{
     mem,
     ops::Deref,
 };
-use op_alloy_consensus::{OpPooledTransaction, OpTxEnvelope, OpTypedTransaction, TxDeposit};
+use op_alloy_consensus::{
+    OpPooledTransaction, OpTxEnvelope, OpTypedTransaction, TxDeposit, TxPostExec,
+};
 #[cfg(any(test, feature = "reth-codec"))]
 use reth_primitives_traits::{
     InMemorySize, SignedTransaction,
@@ -64,6 +66,7 @@ impl OpTransactionSigned {
             OpTypedTransaction::Eip1559(tx) => &mut tx.input,
             OpTypedTransaction::Eip7702(tx) => &mut tx.input,
             OpTypedTransaction::Deposit(tx) => &mut tx.input,
+            OpTypedTransaction::PostExec(tx) => &mut tx.input,
         }
     }
 
@@ -107,8 +110,10 @@ impl SignerRecoverable for OpTransactionSigned {
     fn recover_signer(&self) -> Result<Address, RecoveryError> {
         // Optimism's Deposit transaction does not have a signature. Directly return the
         // `from` address.
-        if let OpTypedTransaction::Deposit(TxDeposit { from, .. }) = self.transaction {
-            return Ok(from);
+        match self.transaction {
+            OpTypedTransaction::Deposit(TxDeposit { from, .. }) => return Ok(from),
+            OpTypedTransaction::PostExec(_) => return Ok(Address::ZERO),
+            _ => {}
         }
 
         let Self { transaction, signature, .. } = self;
@@ -119,8 +124,10 @@ impl SignerRecoverable for OpTransactionSigned {
     fn recover_signer_unchecked(&self) -> Result<Address, RecoveryError> {
         // Optimism's Deposit transaction does not have a signature. Directly return the
         // `from` address.
-        if let OpTypedTransaction::Deposit(TxDeposit { from, .. }) = &self.transaction {
-            return Ok(*from);
+        match &self.transaction {
+            OpTypedTransaction::Deposit(TxDeposit { from, .. }) => return Ok(*from),
+            OpTypedTransaction::PostExec(_) => return Ok(Address::ZERO),
+            _ => {}
         }
 
         let Self { transaction, signature, .. } = self;
@@ -133,6 +140,7 @@ impl SignerRecoverable for OpTransactionSigned {
             // Optimism's Deposit transaction does not have a signature. Directly return the
             // `from` address.
             OpTypedTransaction::Deposit(tx) => return Ok(tx.from),
+            OpTypedTransaction::PostExec(_) => return Ok(Address::ZERO),
             OpTypedTransaction::Legacy(tx) => tx.encode_for_signing(buf),
             OpTypedTransaction::Eip2930(tx) => tx.encode_for_signing(buf),
             OpTypedTransaction::Eip1559(tx) => tx.encode_for_signing(buf),
@@ -177,6 +185,7 @@ impl From<OpTxEnvelope> for OpTransactionSigned {
             OpTxEnvelope::Eip1559(tx) => tx.into(),
             OpTxEnvelope::Eip7702(tx) => tx.into(),
             OpTxEnvelope::Deposit(tx) => tx.into(),
+            OpTxEnvelope::PostExec(tx) => tx.into(),
         }
     }
 }
@@ -185,6 +194,17 @@ impl From<Sealed<TxDeposit>> for OpTransactionSigned {
     fn from(value: Sealed<TxDeposit>) -> Self {
         let (tx, hash) = value.into_parts();
         Self::new(OpTypedTransaction::Deposit(tx), TxDeposit::signature(), hash)
+    }
+}
+
+impl From<Sealed<TxPostExec>> for OpTransactionSigned {
+    fn from(value: Sealed<TxPostExec>) -> Self {
+        let (tx, hash) = value.into_parts();
+        Self::new(
+            OpTypedTransaction::PostExec(tx),
+            Signature::new(Default::default(), Default::default(), false),
+            hash,
+        )
     }
 }
 
@@ -197,6 +217,7 @@ impl From<OpTransactionSigned> for OpTxEnvelope {
             OpTypedTransaction::Eip1559(tx) => Signed::new_unchecked(tx, signature, hash).into(),
             OpTypedTransaction::Deposit(tx) => Sealed::new_unchecked(tx, hash).into(),
             OpTypedTransaction::Eip7702(tx) => Signed::new_unchecked(tx, signature, hash).into(),
+            OpTypedTransaction::PostExec(tx) => Sealed::new_unchecked(tx, hash).into(),
         }
     }
 }
@@ -249,6 +270,7 @@ impl Encodable2718 for OpTransactionSigned {
                 set_code_tx.eip2718_encoded_length(&self.signature)
             }
             OpTypedTransaction::Deposit(deposit_tx) => deposit_tx.eip2718_encoded_length(),
+            OpTypedTransaction::PostExec(post_exec_tx) => post_exec_tx.eip2718_encoded_length(),
         }
     }
 
@@ -268,6 +290,7 @@ impl Encodable2718 for OpTransactionSigned {
             }
             OpTypedTransaction::Eip7702(set_code_tx) => set_code_tx.eip2718_encode(signature, out),
             OpTypedTransaction::Deposit(deposit_tx) => deposit_tx.encode_2718(out),
+            OpTypedTransaction::PostExec(post_exec_tx) => post_exec_tx.encode_2718(out),
         }
     }
 }
@@ -297,6 +320,10 @@ impl Decodable2718 for OpTransactionSigned {
             op_alloy_consensus::OpTxType::Deposit => Ok(Self::new_unhashed(
                 OpTypedTransaction::Deposit(TxDeposit::rlp_decode(buf)?),
                 TxDeposit::signature(),
+            )),
+            op_alloy_consensus::OpTxType::PostExec => Ok(Self::new_unhashed(
+                OpTypedTransaction::PostExec(TxPostExec::decode_2718(buf)?),
+                Signature::new(Default::default(), Default::default(), false),
             )),
         }
     }
@@ -391,7 +418,18 @@ impl Typed2718 for OpTransactionSigned {
 
 impl PartialEq for OpTransactionSigned {
     fn eq(&self, other: &Self) -> bool {
-        self.signature == other.signature &&
+        let self_signature = match &self.transaction {
+            OpTypedTransaction::Deposit(_) => TxDeposit::signature(),
+            OpTypedTransaction::PostExec(_) => TxPostExec::signature(),
+            _ => self.signature,
+        };
+        let other_signature = match &other.transaction {
+            OpTypedTransaction::Deposit(_) => TxDeposit::signature(),
+            OpTypedTransaction::PostExec(_) => TxPostExec::signature(),
+            _ => other.signature,
+        };
+
+        self_signature == other_signature &&
             self.transaction == other.transaction &&
             self.tx_hash() == other.tx_hash()
     }
@@ -399,7 +437,11 @@ impl PartialEq for OpTransactionSigned {
 
 impl Hash for OpTransactionSigned {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.signature.hash(state);
+        match &self.transaction {
+            OpTypedTransaction::Deposit(_) => TxDeposit::signature().hash(state),
+            OpTypedTransaction::PostExec(_) => TxPostExec::signature().hash(state),
+            _ => self.signature.hash(state),
+        }
         self.transaction.hash(state);
     }
 }
@@ -416,7 +458,11 @@ impl reth_codecs::Compact for OpTransactionSigned {
         // The first byte uses 4 bits as flags: IsCompressed[1bit], TxType[2bits], Signature[1bit]
         buf.put_u8(0);
 
-        let sig_bit = self.signature.to_compact(buf) as u8;
+        let sig_bit = match &self.transaction {
+            OpTypedTransaction::Deposit(_) => TxDeposit::signature().to_compact(buf) as u8,
+            OpTypedTransaction::PostExec(_) => TxPostExec::signature().to_compact(buf) as u8,
+            _ => self.signature.to_compact(buf) as u8,
+        };
         let zstd_bit = self.transaction.input().len() >= 32;
 
         let tx_bits = if zstd_bit {
@@ -478,7 +524,11 @@ impl<'a> arbitrary::Arbitrary<'a> for OpTransactionSigned {
         )
         .unwrap();
 
-        let signature = if transaction.is_deposit() { TxDeposit::signature() } else { signature };
+        let signature = match &transaction {
+            OpTypedTransaction::Deposit(_) => TxDeposit::signature(),
+            OpTypedTransaction::PostExec(_) => TxPostExec::signature(),
+            _ => signature,
+        };
 
         Ok(Self::new_unhashed(transaction, signature))
     }
@@ -491,7 +541,7 @@ fn signature_hash(tx: &OpTypedTransaction) -> B256 {
         OpTypedTransaction::Eip2930(tx) => tx.signature_hash(),
         OpTypedTransaction::Eip1559(tx) => tx.signature_hash(),
         OpTypedTransaction::Eip7702(tx) => tx.signature_hash(),
-        OpTypedTransaction::Deposit(_) => B256::ZERO,
+        OpTypedTransaction::Deposit(_) | OpTypedTransaction::PostExec(_) => B256::ZERO,
     }
 }
 
@@ -501,6 +551,22 @@ mod tests {
     use proptest::proptest;
     use proptest_arbitrary_interop::arb;
     use reth_codecs::Compact;
+
+    fn make_input_large_enough_for_zstd(tx: &mut OpTransactionSigned) {
+        match &mut tx.transaction {
+            OpTypedTransaction::PostExec(post_exec) => {
+                *post_exec = TxPostExec::new(op_alloy_consensus::PostExecPayload {
+                    version: 1,
+                    block_number: 1,
+                    gas_refund_entries: (0..16)
+                        .map(|index| op_alloy_consensus::SDMGasEntry { index, gas_refund: 1 })
+                        .collect(),
+                });
+                assert!(post_exec.input.len() >= 33);
+            }
+            _ => *tx.input_mut() = vec![0; 33].into(),
+        }
+    }
 
     proptest! {
         #[test]
@@ -519,7 +585,7 @@ mod tests {
         #[test]
         fn test_roundtrip_compact_decode_envelope_zstd(mut reth_tx in arb::<OpTransactionSigned>()) {
                  // zstd only kicks in if the input is large enough
-            *reth_tx.input_mut() = vec![0;33].into();
+            make_input_large_enough_for_zstd(&mut reth_tx);
             let mut buf = Vec::<u8>::new();
             let len = reth_tx.to_compact(&mut buf);
 
@@ -532,7 +598,7 @@ mod tests {
         #[test]
         fn test_roundtrip_compact_encode_envelope_zstd(mut reth_tx in arb::<OpTransactionSigned>()) {
                  // zstd only kicks in if the input is large enough
-            *reth_tx.input_mut() = vec![0;33].into();
+            make_input_large_enough_for_zstd(&mut reth_tx);
             let mut expected_buf = Vec::<u8>::new();
             let expected_len = reth_tx.to_compact(&mut expected_buf);
 

--- a/rust/op-reth/crates/primitives/src/transaction/signed.rs
+++ b/rust/op-reth/crates/primitives/src/transaction/signed.rs
@@ -108,45 +108,62 @@ impl OpTransactionSigned {
 
 impl SignerRecoverable for OpTransactionSigned {
     fn recover_signer(&self) -> Result<Address, RecoveryError> {
-        // Optimism's Deposit transaction does not have a signature. Directly return the
-        // `from` address.
         match &self.transaction {
-            OpTypedTransaction::Deposit(TxDeposit { from, .. }) => return Ok(*from),
-            OpTypedTransaction::PostExec(tx) => return Ok(tx.signer_address()),
-            _ => {}
+            // Optimism's Deposit transaction does not have a signature. Directly return the
+            // `from` address.
+            OpTypedTransaction::Deposit(TxDeposit { from, .. }) => Ok(*from),
+            // Post-exec transactions are unsigned synthetic system transactions. They use a
+            // canonical zero-address signer rather than a cryptographic signature.
+            OpTypedTransaction::PostExec(tx) => Ok(tx.signer_address()),
+            _ => {
+                let Self { transaction, signature, .. } = self;
+                let signature_hash = signature_hash(transaction);
+                recover_signer(signature, signature_hash)
+            }
         }
-
-        let Self { transaction, signature, .. } = self;
-        let signature_hash = signature_hash(transaction);
-        recover_signer(signature, signature_hash)
     }
 
     fn recover_signer_unchecked(&self) -> Result<Address, RecoveryError> {
-        // Optimism's Deposit transaction does not have a signature. Directly return the
-        // `from` address.
         match &self.transaction {
-            OpTypedTransaction::Deposit(TxDeposit { from, .. }) => return Ok(*from),
-            OpTypedTransaction::PostExec(tx) => return Ok(tx.signer_address()),
-            _ => {}
+            // Optimism's Deposit transaction does not have a signature. Directly return the
+            // `from` address.
+            OpTypedTransaction::Deposit(TxDeposit { from, .. }) => Ok(*from),
+            // Post-exec transactions are unsigned synthetic system transactions. They use a
+            // canonical zero-address signer rather than a cryptographic signature.
+            OpTypedTransaction::PostExec(tx) => Ok(tx.signer_address()),
+            _ => {
+                let Self { transaction, signature, .. } = self;
+                let signature_hash = signature_hash(transaction);
+                recover_signer_unchecked(signature, signature_hash)
+            }
         }
-
-        let Self { transaction, signature, .. } = self;
-        let signature_hash = signature_hash(transaction);
-        recover_signer_unchecked(signature, signature_hash)
     }
 
     fn recover_unchecked_with_buf(&self, buf: &mut Vec<u8>) -> Result<Address, RecoveryError> {
         match &self.transaction {
             // Optimism's Deposit transaction does not have a signature. Directly return the
             // `from` address.
-            OpTypedTransaction::Deposit(tx) => return Ok(tx.from),
-            OpTypedTransaction::PostExec(tx) => return Ok(tx.signer_address()),
-            OpTypedTransaction::Legacy(tx) => tx.encode_for_signing(buf),
-            OpTypedTransaction::Eip2930(tx) => tx.encode_for_signing(buf),
-            OpTypedTransaction::Eip1559(tx) => tx.encode_for_signing(buf),
-            OpTypedTransaction::Eip7702(tx) => tx.encode_for_signing(buf),
-        };
-        recover_signer_unchecked(&self.signature, keccak256(buf))
+            OpTypedTransaction::Deposit(tx) => Ok(tx.from),
+            // Post-exec transactions are unsigned synthetic system transactions. They use a
+            // canonical zero-address signer rather than a cryptographic signature.
+            OpTypedTransaction::PostExec(tx) => Ok(tx.signer_address()),
+            OpTypedTransaction::Legacy(tx) => {
+                tx.encode_for_signing(buf);
+                recover_signer_unchecked(&self.signature, keccak256(buf))
+            }
+            OpTypedTransaction::Eip2930(tx) => {
+                tx.encode_for_signing(buf);
+                recover_signer_unchecked(&self.signature, keccak256(buf))
+            }
+            OpTypedTransaction::Eip1559(tx) => {
+                tx.encode_for_signing(buf);
+                recover_signer_unchecked(&self.signature, keccak256(buf))
+            }
+            OpTypedTransaction::Eip7702(tx) => {
+                tx.encode_for_signing(buf);
+                recover_signer_unchecked(&self.signature, keccak256(buf))
+            }
+        }
     }
 }
 

--- a/rust/op-reth/crates/primitives/src/transaction/tx_type.rs
+++ b/rust/op-reth/crates/primitives/src/transaction/tx_type.rs
@@ -3,7 +3,7 @@
 #[cfg(test)]
 mod tests {
     use alloy_consensus::constants::EIP7702_TX_TYPE_ID;
-    use op_alloy_consensus::{DEPOSIT_TX_TYPE_ID, OpTxType};
+    use op_alloy_consensus::{DEPOSIT_TX_TYPE_ID, OpTxType, POST_EXEC_TX_TYPE_ID};
     use reth_codecs::{Compact, txtype::*};
     use rstest::rstest;
 
@@ -13,6 +13,7 @@ mod tests {
     #[case(OpTxType::Eip1559, COMPACT_IDENTIFIER_EIP1559, vec![])]
     #[case(OpTxType::Eip7702, COMPACT_EXTENDED_IDENTIFIER_FLAG, vec![EIP7702_TX_TYPE_ID])]
     #[case(OpTxType::Deposit, COMPACT_EXTENDED_IDENTIFIER_FLAG, vec![DEPOSIT_TX_TYPE_ID])]
+    #[case(OpTxType::PostExec, COMPACT_EXTENDED_IDENTIFIER_FLAG, vec![POST_EXEC_TX_TYPE_ID])]
     fn test_txtype_to_compact(
         #[case] tx_type: OpTxType,
         #[case] expected_identifier: usize,
@@ -34,6 +35,7 @@ mod tests {
     #[case(OpTxType::Eip1559, COMPACT_IDENTIFIER_EIP1559, vec![])]
     #[case(OpTxType::Eip7702, COMPACT_EXTENDED_IDENTIFIER_FLAG, vec![EIP7702_TX_TYPE_ID])]
     #[case(OpTxType::Deposit, COMPACT_EXTENDED_IDENTIFIER_FLAG, vec![DEPOSIT_TX_TYPE_ID])]
+    #[case(OpTxType::PostExec, COMPACT_EXTENDED_IDENTIFIER_FLAG, vec![POST_EXEC_TX_TYPE_ID])]
     fn test_txtype_from_compact(
         #[case] expected_type: OpTxType,
         #[case] identifier: usize,

--- a/rust/op-reth/crates/rpc/src/eth/receipt.rs
+++ b/rust/op-reth/crates/rpc/src/eth/receipt.rs
@@ -2,7 +2,7 @@
 
 use crate::{OpEthApi, OpEthApiError, eth::RpcNodeCore};
 use alloy_consensus::{BlockHeader, Receipt, ReceiptWithBloom, TxReceipt};
-use alloy_eips::{Typed2718, eip2718::Encodable2718};
+use alloy_eips::eip2718::Encodable2718;
 use alloy_rpc_types_eth::{Log, TransactionReceipt};
 use op_alloy_consensus::{OpReceipt, OpTransaction};
 use op_alloy_rpc_types::{L1BlockInfo, OpTransactionReceipt, OpTransactionReceiptFields};
@@ -43,7 +43,7 @@ impl<Provider> OpReceiptConverter<Provider> {
 
 impl<Provider, N> ReceiptConverter<N> for OpReceiptConverter<Provider>
 where
-    N: NodePrimitives<SignedTx: OpTransaction + Typed2718 + Encodable2718, Receipt = OpReceipt>,
+    N: NodePrimitives<SignedTx: OpTransaction, Receipt = OpReceipt>,
     Provider:
         BlockReader<Block = N::Block> + ChainSpecProvider<ChainSpec: OpHardforks> + Debug + 'static,
 {

--- a/rust/op-reth/crates/rpc/src/eth/receipt.rs
+++ b/rust/op-reth/crates/rpc/src/eth/receipt.rs
@@ -2,16 +2,22 @@
 
 use crate::{OpEthApi, OpEthApiError, eth::RpcNodeCore};
 use alloy_consensus::{BlockHeader, Receipt, ReceiptWithBloom, TxReceipt};
-use alloy_eips::eip2718::Encodable2718;
+use alloy_eips::{
+    Typed2718,
+    eip2718::{Decodable2718, Encodable2718},
+};
 use alloy_rpc_types_eth::{Log, TransactionReceipt};
-use op_alloy_consensus::{OpReceipt, OpTransaction};
+use op_alloy_consensus::{
+    OpReceipt, OpTransaction, POST_EXEC_TX_TYPE_ID, PostExecPayload, TxPostExec,
+    extract_post_exec_payload_from_tx,
+};
 use op_alloy_rpc_types::{L1BlockInfo, OpTransactionReceipt, OpTransactionReceiptFields};
 use op_revm::estimate_tx_compressed_size;
 use reth_chainspec::{ChainSpecProvider, EthChainSpec};
 use reth_node_api::NodePrimitives;
 use reth_optimism_evm::RethL1BlockInfo;
 use reth_optimism_forks::OpHardforks;
-use reth_primitives_traits::SealedBlock;
+use reth_primitives_traits::{BlockBody, SealedBlock};
 use reth_rpc_eth_api::{
     RpcConvert,
     helpers::LoadReceipt,
@@ -43,7 +49,7 @@ impl<Provider> OpReceiptConverter<Provider> {
 
 impl<Provider, N> ReceiptConverter<N> for OpReceiptConverter<Provider>
 where
-    N: NodePrimitives<SignedTx: OpTransaction, Receipt = OpReceipt>,
+    N: NodePrimitives<SignedTx: OpTransaction + Typed2718 + Encodable2718, Receipt = OpReceipt>,
     Provider:
         BlockReader<Block = N::Block> + ChainSpecProvider<ChainSpec: OpHardforks> + Debug + 'static,
 {
@@ -86,6 +92,17 @@ where
         };
 
         let mut receipts = Vec::with_capacity(inputs.len());
+        let post_exec_payload: Option<PostExecPayload> =
+            block.body().transactions().iter().find_map(|tx| {
+                if tx.ty() != POST_EXEC_TX_TYPE_ID {
+                    return None;
+                }
+
+                let encoded = tx.encoded_2718();
+                let mut encoded_slice = encoded.as_ref();
+                let post_exec_tx = TxPostExec::decode_2718(&mut encoded_slice).ok()?;
+                extract_post_exec_payload_from_tx(&post_exec_tx)
+            });
 
         for input in inputs {
             // We must clear this cache as different L2 transactions can have different
@@ -93,9 +110,18 @@ where
             // new transaction input has changed, since otherwise the L1 cost wouldn't.
             l1_block_info.clear_tx_l1_cost();
 
+            let op_gas_refund = post_exec_payload
+                .as_ref()
+                .and_then(|payload| payload.gas_refund_for_idx(input.meta.index));
+
             receipts.push(
-                OpReceiptBuilder::new(&self.provider.chain_spec(), input, &mut l1_block_info)?
-                    .build(),
+                OpReceiptBuilder::new(
+                    &self.provider.chain_spec(),
+                    input,
+                    &mut l1_block_info,
+                    op_gas_refund,
+                )?
+                .build(),
             );
         }
 
@@ -120,6 +146,8 @@ pub struct OpReceiptFieldsBuilder {
     /* ---------------------------------------- Bedrock ---------------------------------------- */
     /// The base fee of the L1 origin block.
     pub l1_base_fee: Option<u128>,
+    /// Post-exec block-level warming refund for this transaction.
+    pub op_gas_refund: Option<u64>,
     /* --------------------------------------- Regolith ---------------------------------------- */
     /// Deposit nonce, if this is a deposit transaction.
     pub deposit_nonce: Option<u64>,
@@ -153,6 +181,7 @@ impl OpReceiptFieldsBuilder {
             l1_data_gas: None,
             l1_fee_scalar: None,
             l1_base_fee: None,
+            op_gas_refund: None,
             deposit_nonce: None,
             deposit_receipt_version: None,
             l1_base_fee_scalar: None,
@@ -217,6 +246,12 @@ impl OpReceiptFieldsBuilder {
         Ok(self)
     }
 
+    /// Applies post-exec block-level warming refund metadata.
+    pub const fn op_gas_refund(mut self, op_gas_refund: Option<u64>) -> Self {
+        self.op_gas_refund = op_gas_refund;
+        self
+    }
+
     /// Applies deposit transaction metadata: deposit nonce.
     pub const fn deposit_nonce(mut self, nonce: Option<u64>) -> Self {
         self.deposit_nonce = nonce;
@@ -238,6 +273,7 @@ impl OpReceiptFieldsBuilder {
             l1_data_gas: l1_gas_used,
             l1_fee_scalar,
             l1_base_fee: l1_gas_price,
+            op_gas_refund,
             deposit_nonce,
             deposit_receipt_version,
             l1_base_fee_scalar,
@@ -261,6 +297,7 @@ impl OpReceiptFieldsBuilder {
                 operator_fee_constant,
                 da_footprint_gas_scalar,
             },
+            op_gas_refund,
             deposit_nonce,
             deposit_receipt_version,
         }
@@ -282,6 +319,7 @@ impl OpReceiptBuilder {
         chain_spec: &impl OpHardforks,
         input: ConvertReceiptInput<'_, N>,
         l1_block_info: &mut op_revm::L1BlockInfo,
+        op_gas_refund: Option<u64>,
     ) -> Result<Self, OpEthApiError>
     where
         N: NodePrimitives<SignedTx: OpTransaction, Receipt = OpReceipt>,
@@ -300,6 +338,7 @@ impl OpReceiptBuilder {
                 OpReceipt::Eip2930(receipt) => OpReceipt::Eip2930(map_logs(receipt)),
                 OpReceipt::Eip1559(receipt) => OpReceipt::Eip1559(map_logs(receipt)),
                 OpReceipt::Eip7702(receipt) => OpReceipt::Eip7702(map_logs(receipt)),
+                OpReceipt::PostExec(receipt) => OpReceipt::PostExec(map_logs(receipt)),
                 OpReceipt::Deposit(receipt) => OpReceipt::Deposit(receipt.map_inner(map_logs)),
             };
             mapped_receipt.into_with_bloom()
@@ -322,6 +361,7 @@ impl OpReceiptBuilder {
 
         let op_receipt_fields = OpReceiptFieldsBuilder::new(timestamp, block_number)
             .l1_block_info(chain_spec, tx_signed, l1_block_info)?
+            .op_gas_refund(op_gas_refund)
             .build();
 
         Ok(Self { core_receipt, op_receipt_fields })
@@ -332,25 +372,33 @@ impl OpReceiptBuilder {
     pub fn build(self) -> OpTransactionReceipt {
         let Self { core_receipt: inner, op_receipt_fields } = self;
 
-        let OpTransactionReceiptFields { l1_block_info, .. } = op_receipt_fields;
+        let OpTransactionReceiptFields {
+            l1_block_info,
+            op_gas_refund,
+            deposit_nonce: _,
+            deposit_receipt_version: _,
+        } = op_receipt_fields;
 
-        OpTransactionReceipt { inner, l1_block_info }
+        OpTransactionReceipt { inner, l1_block_info, op_gas_refund }
     }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
-    use alloy_consensus::{Block, BlockBody, Eip658Value, TxEip7702, transaction::TransactionMeta};
+    use alloy_consensus::{
+        Block, BlockBody, Eip658Value, Header, Receipt, Sealable, SignableTransaction, TxEip7702,
+        transaction::TransactionMeta,
+    };
     use alloy_op_hardforks::{
         OP_MAINNET_ISTHMUS_TIMESTAMP, OP_MAINNET_JOVIAN_TIMESTAMP, OpChainHardforks,
     };
     use alloy_primitives::{Address, Bytes, Signature, U256, hex};
-    use op_alloy_consensus::OpTypedTransaction;
+    use op_alloy_consensus::{OpTypedTransaction, SDMGasEntry, build_post_exec_tx};
     use op_alloy_network::eip2718::Decodable2718;
     use reth_optimism_chainspec::{BASE_MAINNET, OP_MAINNET};
     use reth_optimism_primitives::{OpPrimitives, OpTransactionSigned};
-    use reth_primitives_traits::Recovered;
+    use reth_primitives_traits::{Recovered, SealedBlock};
 
     /// OP Mainnet transaction at index 0 in block 124665056.
     ///
@@ -388,6 +436,7 @@ mod test {
                 operator_fee_constant: None,
                 da_footprint_gas_scalar: None,
             },
+            op_gas_refund: None,
             deposit_nonce: None,
             deposit_receipt_version: None,
         };
@@ -479,6 +528,63 @@ mod test {
             TX_META_TX_1_OP_MAINNET_BLOCK_124665056.l1_block_info.da_footprint_gas_scalar,
             "incorrect da footprint gas scalar"
         );
+    }
+
+    #[test]
+    fn convert_receipts_extracts_post_exec_gas_refund_from_embedded_payload() {
+        let tx_0 = OpTransactionSigned::decode_2718(
+            &mut TX_SET_L1_BLOCK_OP_MAINNET_BLOCK_124665056.as_slice(),
+        )
+        .unwrap();
+        let tx_1 =
+            OpTransactionSigned::decode_2718(&mut TX_1_OP_MAINNET_BLOCK_124665056.as_slice())
+                .unwrap();
+        let post_exec = OpTransactionSigned::PostExec(
+            build_post_exec_tx(124665056, vec![SDMGasEntry { index: 1, gas_refund: 77 }])
+                .seal_slow(),
+        );
+
+        let block = SealedBlock::new_unhashed(Block::<OpTransactionSigned> {
+            header: Header {
+                number: 124665056,
+                timestamp: BLOCK_124665056_TIMESTAMP,
+                ..Default::default()
+            },
+            body: BlockBody {
+                transactions: vec![tx_0, tx_1.clone(), post_exec],
+                ..Default::default()
+            },
+        });
+
+        let converter = OpReceiptConverter::new(reth_storage_api::noop::NoopProvider::<
+            _,
+            OpPrimitives,
+        >::new(OP_MAINNET.clone()));
+        let receipts =
+            <OpReceiptConverter<_> as ReceiptConverter<OpPrimitives>>::convert_receipts_with_block(
+                &converter,
+                vec![ConvertReceiptInput::<OpPrimitives> {
+                    tx: Recovered::new_unchecked(&tx_1, Address::ZERO),
+                    receipt: OpReceipt::Eip1559(Receipt {
+                        status: Eip658Value::Eip658(true),
+                        cumulative_gas_used: 100,
+                        logs: vec![],
+                    }),
+                    gas_used: 100,
+                    next_log_index: 0,
+                    meta: TransactionMeta {
+                        index: 1,
+                        block_number: 124665056,
+                        timestamp: BLOCK_124665056_TIMESTAMP,
+                        ..Default::default()
+                    },
+                }],
+                &block,
+            )
+            .unwrap();
+
+        assert_eq!(receipts.len(), 1);
+        assert_eq!(receipts[0].op_gas_refund, Some(77));
     }
 
     #[test]
@@ -600,7 +706,7 @@ mod test {
 
         let signature = Signature::new(U256::default(), U256::default(), true);
 
-        let tx = OpTransactionSigned::new_unhashed(OpTypedTransaction::Eip7702(tx), signature);
+        let tx: OpTransactionSigned = OpTypedTransaction::Eip7702(tx).into_signed(signature).into();
 
         let mut l1_block_info = op_revm::L1BlockInfo {
             da_footprint_gas_scalar: Some(DA_FOOTPRINT_GAS_SCALAR),
@@ -635,7 +741,7 @@ mod test {
 
         let signature = Signature::new(U256::default(), U256::default(), true);
 
-        let tx = OpTransactionSigned::new_unhashed(OpTypedTransaction::Eip7702(tx), signature);
+        let tx: OpTransactionSigned = OpTypedTransaction::Eip7702(tx).into_signed(signature).into();
 
         let mut l1_block_info = op_revm::L1BlockInfo {
             da_footprint_gas_scalar: Some(DA_FOOTPRINT_GAS_SCALAR),
@@ -661,6 +767,7 @@ mod test {
                 },
             },
             &mut l1_block_info,
+            None,
         )
         .unwrap();
 
@@ -689,7 +796,7 @@ mod test {
 
         let signature = Signature::new(U256::default(), U256::default(), true);
 
-        let tx = OpTransactionSigned::new_unhashed(OpTypedTransaction::Eip7702(tx), signature);
+        let tx: OpTransactionSigned = OpTypedTransaction::Eip7702(tx).into_signed(signature).into();
 
         let mut l1_block_info = op_revm::L1BlockInfo {
             da_footprint_gas_scalar: Some(DA_FOOTPRINT_GAS_SCALAR),
@@ -715,6 +822,7 @@ mod test {
                 },
             },
             &mut l1_block_info,
+            None,
         )
         .unwrap();
 

--- a/rust/op-reth/crates/rpc/src/eth/receipt.rs
+++ b/rust/op-reth/crates/rpc/src/eth/receipt.rs
@@ -2,15 +2,9 @@
 
 use crate::{OpEthApi, OpEthApiError, eth::RpcNodeCore};
 use alloy_consensus::{BlockHeader, Receipt, ReceiptWithBloom, TxReceipt};
-use alloy_eips::{
-    Typed2718,
-    eip2718::{Decodable2718, Encodable2718},
-};
+use alloy_eips::{Typed2718, eip2718::Encodable2718};
 use alloy_rpc_types_eth::{Log, TransactionReceipt};
-use op_alloy_consensus::{
-    OpReceipt, OpTransaction, POST_EXEC_TX_TYPE_ID, PostExecPayload, TxPostExec,
-    extract_post_exec_payload_from_tx,
-};
+use op_alloy_consensus::{OpReceipt, OpTransaction};
 use op_alloy_rpc_types::{L1BlockInfo, OpTransactionReceipt, OpTransactionReceiptFields};
 use op_revm::estimate_tx_compressed_size;
 use reth_chainspec::{ChainSpecProvider, EthChainSpec};
@@ -92,17 +86,11 @@ where
         };
 
         let mut receipts = Vec::with_capacity(inputs.len());
-        let post_exec_payload: Option<PostExecPayload> =
-            block.body().transactions().iter().find_map(|tx| {
-                if tx.ty() != POST_EXEC_TX_TYPE_ID {
-                    return None;
-                }
-
-                let encoded = tx.encoded_2718();
-                let mut encoded_slice = encoded.as_ref();
-                let post_exec_tx = TxPostExec::decode_2718(&mut encoded_slice).ok()?;
-                extract_post_exec_payload_from_tx(&post_exec_tx)
-            });
+        let post_exec_payload = block
+            .body()
+            .transactions()
+            .iter()
+            .find_map(|tx| tx.as_post_exec().map(|tx| &tx.inner().payload));
 
         for input in inputs {
             // We must clear this cache as different L2 transactions can have different

--- a/rust/op-reth/examples/custom-node/src/pool.rs
+++ b/rust/op-reth/examples/custom-node/src/pool.rs
@@ -6,7 +6,7 @@ use alloy_consensus::{
     transaction::{SignerRecoverable, TxHashRef},
 };
 use alloy_primitives::{Address, B256, Sealed};
-use op_alloy_consensus::{OpPooledTransaction, OpTransaction, TxDeposit};
+use op_alloy_consensus::{OpPooledTransaction, OpTransaction, TxDeposit, TxPostExec};
 use reth_primitives_traits::InMemorySize;
 
 #[derive(Clone, Debug, TransactionEnvelope)]
@@ -48,6 +48,10 @@ impl OpTransaction for CustomPooledTransaction {
     }
 
     fn as_deposit(&self) -> Option<&Sealed<TxDeposit>> {
+        None
+    }
+
+    fn as_post_exec(&self) -> Option<&Sealed<TxPostExec>> {
         None
     }
 }

--- a/rust/op-reth/examples/custom-node/src/primitives/tx.rs
+++ b/rust/op-reth/examples/custom-node/src/primitives/tx.rs
@@ -7,7 +7,7 @@ use alloy_consensus::{
 use alloy_eips::Encodable2718;
 use alloy_primitives::{B256, Sealed, Signature};
 use alloy_rlp::BufMut;
-use op_alloy_consensus::{OpTxEnvelope, TxDeposit};
+use op_alloy_consensus::{OpTxEnvelope, TxDeposit, TxPostExec};
 use reth_codecs::{
     Compact,
     alloy::transaction::{CompactEnvelope, FromTxCompact, ToTxCompact},
@@ -100,6 +100,13 @@ impl OpTransaction for CustomTransaction {
     fn as_deposit(&self) -> Option<&Sealed<TxDeposit>> {
         match self {
             CustomTransaction::Op(op) => op.as_deposit(),
+            CustomTransaction::Payment(_) => None,
+        }
+    }
+
+    fn as_post_exec(&self) -> Option<&Sealed<TxPostExec>> {
+        match self {
+            CustomTransaction::Op(op) => op.as_post_exec(),
             CustomTransaction::Payment(_) => None,
         }
     }


### PR DESCRIPTION
Part of https://github.com/ethereum-optimism/protocol-team/issues/59

---

This PR introduces a new post-execution transaction type intended to carry SDM (Sequencer Defined Metering) metadata after normal block execution.

The new transaction uses type byte `0x7d` (`POST_EXEC_TX_TYPE_ID`) and is modeled as a first-class OP transaction. The payload currently carries a `version`, the target `block number`, and `per-transaction gas refund entries`. The result is a deterministic, block-unique post-exec transaction format that downstream code can encode, decode, hash, serialize, deserialize, and surface in receipts.

---

In future PRs, I'll be adding:
- node CLI / runtime feature flags
- EVM block-level warming logic
- execution-time refund generation
- payload builder injection of post-exec txs
- replay RPC / debug endpoints
- devstack / acceptance wiring