### PR TITLE
op-interop-filter: add getBlockHashByNumber RPC

### DIFF
--- a/op-interop-filter/filter/backend.go
+++ b/op-interop-filter/filter/backend.go
@@ -185,29 +185,29 @@ func (b *Backend) CheckAccessList(ctx context.Context, inboxEntries []common.Has
 	return nil
 }
 
-// GetBlockByNumber returns the latest block or the block at a specific height for the given chain.
-func (b *Backend) GetBlockByNumber(chainID eth.ChainID, selector BlockSelector) (eth.BlockID, error) {
+// GetBlockHashByNumber returns the latest block hash or the block hash at a specific height for the given chain.
+func (b *Backend) GetBlockHashByNumber(chainID eth.ChainID, selector BlockSelector) (common.Hash, error) {
 	ingester, ok := b.chains[chainID]
 	if !ok {
-		return eth.BlockID{}, fmt.Errorf("chain %s: %w", chainID, types.ErrUnknownChain)
+		return common.Hash{}, fmt.Errorf("chain %s: %w", chainID, types.ErrUnknownChain)
 	}
 
 	if !b.Ready() {
-		return eth.BlockID{}, fmt.Errorf("block lookup unavailable for chain %s: %w", chainID, types.ErrUninitialized)
+		return common.Hash{}, fmt.Errorf("block hash lookup unavailable for chain %s: %w", chainID, types.ErrUninitialized)
 	}
 
 	if selector.Latest() {
 		block, ok := ingester.LatestBlock()
 		if !ok {
-			return eth.BlockID{}, fmt.Errorf("latest block for chain %s: %w", chainID, ethereum.NotFound)
+			return common.Hash{}, fmt.Errorf("latest block for chain %s: %w", chainID, ethereum.NotFound)
 		}
-		return block, nil
+		return block.Hash, nil
 	}
 
 	blockNum := selector.Number()
-	block, ok := ingester.BlockByNumber(blockNum)
+	blockHash, ok := ingester.BlockHashByNumber(blockNum)
 	if !ok {
-		return eth.BlockID{}, fmt.Errorf("block %d for chain %s: %w", blockNum, chainID, ethereum.NotFound)
+		return common.Hash{}, fmt.Errorf("block %d for chain %s: %w", blockNum, chainID, ethereum.NotFound)
 	}
-	return block, nil
+	return blockHash, nil
 }

--- a/op-interop-filter/filter/backend.go
+++ b/op-interop-filter/filter/backend.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sync/atomic"
 
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 
@@ -182,4 +183,31 @@ func (b *Backend) CheckAccessList(ctx context.Context, inboxEntries []common.Has
 
 	b.metrics.RecordCheckAccessList(true)
 	return nil
+}
+
+// GetBlockByNumber returns the latest block or the block at a specific height for the given chain.
+func (b *Backend) GetBlockByNumber(chainID eth.ChainID, selector BlockSelector) (eth.BlockID, error) {
+	ingester, ok := b.chains[chainID]
+	if !ok {
+		return eth.BlockID{}, fmt.Errorf("chain %s: %w", chainID, types.ErrUnknownChain)
+	}
+
+	if !b.Ready() {
+		return eth.BlockID{}, fmt.Errorf("block lookup unavailable for chain %s: %w", chainID, types.ErrUninitialized)
+	}
+
+	if selector.Latest() {
+		block, ok := ingester.LatestBlock()
+		if !ok {
+			return eth.BlockID{}, fmt.Errorf("latest block for chain %s: %w", chainID, ethereum.NotFound)
+		}
+		return block, nil
+	}
+
+	blockNum := selector.Number()
+	block, ok := ingester.BlockByNumber(blockNum)
+	if !ok {
+		return eth.BlockID{}, fmt.Errorf("block %d for chain %s: %w", blockNum, chainID, ethereum.NotFound)
+	}
+	return block, nil
 }

--- a/op-interop-filter/filter/backend.go
+++ b/op-interop-filter/filter/backend.go
@@ -192,10 +192,6 @@ func (b *Backend) GetBlockHashByNumber(chainID eth.ChainID, selector BlockSelect
 		return common.Hash{}, fmt.Errorf("chain %s: %w", chainID, types.ErrUnknownChain)
 	}
 
-	if !b.Ready() {
-		return common.Hash{}, fmt.Errorf("block hash lookup unavailable for chain %s: %w", chainID, types.ErrUninitialized)
-	}
-
 	if selector.Latest() {
 		block, ok := ingester.LatestBlock()
 		if !ok {

--- a/op-interop-filter/filter/backend_test.go
+++ b/op-interop-filter/filter/backend_test.go
@@ -251,13 +251,6 @@ func TestBackend_GetBlockHashByNumber(t *testing.T) {
 		require.ErrorIs(t, err, types.ErrUnknownChain)
 	})
 
-	t.Run("not ready", func(t *testing.T) {
-		mock.SetReady(false)
-		_, err := backend.GetBlockHashByNumber(eth.ChainIDFromUInt64(testChainA), BlockSelectorFromNumber(100))
-		require.ErrorIs(t, err, types.ErrUninitialized)
-		mock.SetReady(true)
-	})
-
 	t.Run("missing block", func(t *testing.T) {
 		_, err := backend.GetBlockHashByNumber(eth.ChainIDFromUInt64(testChainA), BlockSelectorFromNumber(999))
 		require.ErrorIs(t, err, ethereum.NotFound)

--- a/op-interop-filter/filter/backend_test.go
+++ b/op-interop-filter/filter/backend_test.go
@@ -227,7 +227,7 @@ func TestBackend_CheckAccessList(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestBackend_GetBlockByNumber(t *testing.T) {
+func TestBackend_GetBlockHashByNumber(t *testing.T) {
 	backend, mock := newTestBackendWithMockChain(testChainA)
 	latest := eth.BlockID{Hash: common.HexToHash("0xaa"), Number: 200}
 	at100 := eth.BlockID{Hash: common.HexToHash("0xbb"), Number: 100}
@@ -235,31 +235,31 @@ func TestBackend_GetBlockByNumber(t *testing.T) {
 	mock.AddBlock(latest)
 
 	t.Run("latest", func(t *testing.T) {
-		block, err := backend.GetBlockByNumber(eth.ChainIDFromUInt64(testChainA), LatestBlockSelector())
+		hash, err := backend.GetBlockHashByNumber(eth.ChainIDFromUInt64(testChainA), LatestBlockSelector())
 		require.NoError(t, err)
-		require.Equal(t, latest, block)
+		require.Equal(t, latest.Hash, hash)
 	})
 
 	t.Run("specific height", func(t *testing.T) {
-		block, err := backend.GetBlockByNumber(eth.ChainIDFromUInt64(testChainA), BlockSelectorFromNumber(100))
+		hash, err := backend.GetBlockHashByNumber(eth.ChainIDFromUInt64(testChainA), BlockSelectorFromNumber(100))
 		require.NoError(t, err)
-		require.Equal(t, at100, block)
+		require.Equal(t, at100.Hash, hash)
 	})
 
 	t.Run("unknown chain", func(t *testing.T) {
-		_, err := backend.GetBlockByNumber(eth.ChainIDFromUInt64(999), BlockSelectorFromNumber(100))
+		_, err := backend.GetBlockHashByNumber(eth.ChainIDFromUInt64(999), BlockSelectorFromNumber(100))
 		require.ErrorIs(t, err, types.ErrUnknownChain)
 	})
 
 	t.Run("not ready", func(t *testing.T) {
 		mock.SetReady(false)
-		_, err := backend.GetBlockByNumber(eth.ChainIDFromUInt64(testChainA), BlockSelectorFromNumber(100))
+		_, err := backend.GetBlockHashByNumber(eth.ChainIDFromUInt64(testChainA), BlockSelectorFromNumber(100))
 		require.ErrorIs(t, err, types.ErrUninitialized)
 		mock.SetReady(true)
 	})
 
 	t.Run("missing block", func(t *testing.T) {
-		_, err := backend.GetBlockByNumber(eth.ChainIDFromUInt64(testChainA), BlockSelectorFromNumber(999))
+		_, err := backend.GetBlockHashByNumber(eth.ChainIDFromUInt64(testChainA), BlockSelectorFromNumber(999))
 		require.ErrorIs(t, err, ethereum.NotFound)
 	})
 }

--- a/op-interop-filter/filter/backend_test.go
+++ b/op-interop-filter/filter/backend_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 
@@ -223,4 +225,41 @@ func TestBackend_CheckAccessList(t *testing.T) {
 	// LocalUnsafe with empty access list passes
 	err = backend.CheckAccessList(context.Background(), nil, types.LocalUnsafe, makeExecDescriptor(testChainA, 150, 0))
 	require.NoError(t, err)
+}
+
+func TestBackend_GetBlockByNumber(t *testing.T) {
+	backend, mock := newTestBackendWithMockChain(testChainA)
+	latest := eth.BlockID{Hash: common.HexToHash("0xaa"), Number: 200}
+	at100 := eth.BlockID{Hash: common.HexToHash("0xbb"), Number: 100}
+	mock.AddBlock(at100)
+	mock.AddBlock(latest)
+
+	t.Run("latest", func(t *testing.T) {
+		block, err := backend.GetBlockByNumber(eth.ChainIDFromUInt64(testChainA), LatestBlockSelector())
+		require.NoError(t, err)
+		require.Equal(t, latest, block)
+	})
+
+	t.Run("specific height", func(t *testing.T) {
+		block, err := backend.GetBlockByNumber(eth.ChainIDFromUInt64(testChainA), BlockSelectorFromNumber(100))
+		require.NoError(t, err)
+		require.Equal(t, at100, block)
+	})
+
+	t.Run("unknown chain", func(t *testing.T) {
+		_, err := backend.GetBlockByNumber(eth.ChainIDFromUInt64(999), BlockSelectorFromNumber(100))
+		require.ErrorIs(t, err, types.ErrUnknownChain)
+	})
+
+	t.Run("not ready", func(t *testing.T) {
+		mock.SetReady(false)
+		_, err := backend.GetBlockByNumber(eth.ChainIDFromUInt64(testChainA), BlockSelectorFromNumber(100))
+		require.ErrorIs(t, err, types.ErrUninitialized)
+		mock.SetReady(true)
+	})
+
+	t.Run("missing block", func(t *testing.T) {
+		_, err := backend.GetBlockByNumber(eth.ChainIDFromUInt64(testChainA), BlockSelectorFromNumber(999))
+		require.ErrorIs(t, err, ethereum.NotFound)
+	})
 }

--- a/op-interop-filter/filter/block_selector.go
+++ b/op-interop-filter/filter/block_selector.go
@@ -64,8 +64,6 @@ func parseQuotedBlockNumber(input string) (uint64, error) {
 	switch input {
 	case "":
 		return 0, fmt.Errorf("empty block selector")
-	case "earliest", "pending", "safe", "finalized":
-		return 0, fmt.Errorf("unsupported block tag %q: only \"latest\" and block numbers are supported", input)
 	}
 
 	if strings.HasPrefix(input, "0x") || strings.HasPrefix(input, "0X") {

--- a/op-interop-filter/filter/block_selector.go
+++ b/op-interop-filter/filter/block_selector.go
@@ -1,0 +1,84 @@
+package filter
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+)
+
+// BlockSelector selects either the latest block or a block at a specific height.
+// It accepts the JSON string "latest", a JSON number, or a quoted numeric string.
+type BlockSelector struct {
+	latest bool
+	number uint64
+}
+
+func LatestBlockSelector() BlockSelector {
+	return BlockSelector{latest: true}
+}
+
+func BlockSelectorFromNumber(number uint64) BlockSelector {
+	return BlockSelector{number: number}
+}
+
+func (s BlockSelector) Latest() bool {
+	return s.latest
+}
+
+func (s BlockSelector) Number() uint64 {
+	return s.number
+}
+
+func (s *BlockSelector) UnmarshalJSON(data []byte) error {
+	input := strings.TrimSpace(string(data))
+	if input == "" {
+		return fmt.Errorf("empty block selector")
+	}
+
+	if input == `"latest"` {
+		*s = LatestBlockSelector()
+		return nil
+	}
+
+	if len(input) >= 2 && input[0] == '"' && input[len(input)-1] == '"' {
+		number, err := parseQuotedBlockNumber(input[1 : len(input)-1])
+		if err != nil {
+			return err
+		}
+		*s = BlockSelectorFromNumber(number)
+		return nil
+	}
+
+	var number uint64
+	if err := json.Unmarshal(data, &number); err != nil {
+		return fmt.Errorf("invalid block selector %q: %w", input, err)
+	}
+	*s = BlockSelectorFromNumber(number)
+	return nil
+}
+
+func parseQuotedBlockNumber(input string) (uint64, error) {
+	switch input {
+	case "":
+		return 0, fmt.Errorf("empty block selector")
+	case "earliest", "pending", "safe", "finalized":
+		return 0, fmt.Errorf("unsupported block tag %q: only \"latest\" and block numbers are supported", input)
+	}
+
+	if strings.HasPrefix(input, "0x") || strings.HasPrefix(input, "0X") {
+		number, err := hexutil.DecodeUint64(input)
+		if err != nil {
+			return 0, fmt.Errorf("invalid hex block selector %q: %w", input, err)
+		}
+		return number, nil
+	}
+
+	number, err := strconv.ParseUint(input, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid block selector %q: %w", input, err)
+	}
+	return number, nil
+}

--- a/op-interop-filter/filter/frontend.go
+++ b/op-interop-filter/filter/frontend.go
@@ -30,9 +30,9 @@ func (f *QueryFrontend) CheckAccessList(ctx context.Context, inboxEntries []comm
 	return nil
 }
 
-// GetBlockByNumber returns the latest ingested block or the block at a specific height.
-func (f *QueryFrontend) GetBlockByNumber(ctx context.Context, chainID eth.ChainID, selector BlockSelector) (eth.BlockID, error) {
-	return f.backend.GetBlockByNumber(chainID, selector)
+// GetBlockHashByNumber returns the latest ingested block hash or the block hash at a specific height.
+func (f *QueryFrontend) GetBlockHashByNumber(ctx context.Context, chainID eth.ChainID, selector BlockSelector) (common.Hash, error) {
+	return f.backend.GetBlockHashByNumber(chainID, selector)
 }
 
 // PublicAdminFrontend exposes read-only admin methods on the public port.

--- a/op-interop-filter/filter/frontend.go
+++ b/op-interop-filter/filter/frontend.go
@@ -30,6 +30,11 @@ func (f *QueryFrontend) CheckAccessList(ctx context.Context, inboxEntries []comm
 	return nil
 }
 
+// GetBlockByNumber returns the latest ingested block or the block at a specific height.
+func (f *QueryFrontend) GetBlockByNumber(ctx context.Context, chainID eth.ChainID, selector BlockSelector) (eth.BlockID, error) {
+	return f.backend.GetBlockByNumber(chainID, selector)
+}
+
 // PublicAdminFrontend exposes read-only admin methods on the public port.
 type PublicAdminFrontend struct {
 	backend *Backend

--- a/op-interop-filter/filter/interfaces.go
+++ b/op-interop-filter/filter/interfaces.go
@@ -1,6 +1,8 @@
 package filter
 
 import (
+	"github.com/ethereum/go-ethereum/common"
+
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
@@ -31,8 +33,8 @@ type ChainIngester interface {
 	// LatestBlock returns the latest ingested block.
 	LatestBlock() (eth.BlockID, bool)
 
-	// BlockByNumber returns the ingested block at the given height.
-	BlockByNumber(number uint64) (eth.BlockID, bool)
+	// BlockHashByNumber returns the hash of the ingested block at the given height.
+	BlockHashByNumber(number uint64) (common.Hash, bool)
 
 	// LatestTimestamp returns the timestamp of the latest ingested block.
 	LatestTimestamp() (uint64, bool)

--- a/op-interop-filter/filter/interfaces.go
+++ b/op-interop-filter/filter/interfaces.go
@@ -31,6 +31,9 @@ type ChainIngester interface {
 	// LatestBlock returns the latest ingested block.
 	LatestBlock() (eth.BlockID, bool)
 
+	// BlockByNumber returns the ingested block at the given height.
+	BlockByNumber(number uint64) (eth.BlockID, bool)
+
 	// LatestTimestamp returns the timestamp of the latest ingested block.
 	LatestTimestamp() (uint64, bool)
 

--- a/op-interop-filter/filter/logsdb_chain_ingester.go
+++ b/op-interop-filter/filter/logsdb_chain_ingester.go
@@ -230,6 +230,15 @@ func (c *LogsDBChainIngester) LatestBlock() (eth.BlockID, bool) {
 	return c.logsDB.LatestSealedBlock()
 }
 
+// BlockByNumber returns the sealed block at the given height.
+func (c *LogsDBChainIngester) BlockByNumber(blockNum uint64) (eth.BlockID, bool) {
+	hash, ok := c.BlockHashAt(blockNum)
+	if !ok {
+		return eth.BlockID{}, false
+	}
+	return eth.BlockID{Hash: hash, Number: blockNum}, true
+}
+
 // BlockHashAt returns the hash of the sealed block at the given height.
 func (c *LogsDBChainIngester) BlockHashAt(blockNum uint64) (common.Hash, bool) {
 	c.mu.RLock()

--- a/op-interop-filter/filter/logsdb_chain_ingester.go
+++ b/op-interop-filter/filter/logsdb_chain_ingester.go
@@ -230,15 +230,6 @@ func (c *LogsDBChainIngester) LatestBlock() (eth.BlockID, bool) {
 	return c.logsDB.LatestSealedBlock()
 }
 
-// BlockByNumber returns the sealed block at the given height.
-func (c *LogsDBChainIngester) BlockByNumber(blockNum uint64) (eth.BlockID, bool) {
-	hash, ok := c.BlockHashAt(blockNum)
-	if !ok {
-		return eth.BlockID{}, false
-	}
-	return eth.BlockID{Hash: hash, Number: blockNum}, true
-}
-
 // BlockHashAt returns the hash of the sealed block at the given height.
 func (c *LogsDBChainIngester) BlockHashAt(blockNum uint64) (common.Hash, bool) {
 	c.mu.RLock()
@@ -254,6 +245,11 @@ func (c *LogsDBChainIngester) BlockHashAt(blockNum uint64) (common.Hash, bool) {
 	}
 
 	return seal.Hash, true
+}
+
+// BlockHashByNumber returns the sealed block hash at the given height.
+func (c *LogsDBChainIngester) BlockHashByNumber(blockNum uint64) (common.Hash, bool) {
+	return c.BlockHashAt(blockNum)
 }
 
 // LatestTimestamp returns the timestamp of the latest sealed block

--- a/op-interop-filter/filter/mock_test.go
+++ b/op-interop-filter/filter/mock_test.go
@@ -24,6 +24,9 @@ type mockChainIngester struct {
 	// Logs stored by their identifying query
 	logs map[logKey]types.BlockSeal
 
+	// Blocks keyed by block number
+	blocks map[uint64]eth.BlockID
+
 	// Executing messages with their inclusion context
 	execMsgs []IncludedMessage
 
@@ -47,6 +50,7 @@ type logKey struct {
 func newMockChainIngester() *mockChainIngester {
 	return &mockChainIngester{
 		logs:     make(map[logKey]types.BlockSeal),
+		blocks:   make(map[uint64]eth.BlockID),
 		execMsgs: make([]IncludedMessage, 0),
 		ready:    true, // Default to ready for simple tests
 	}
@@ -70,10 +74,11 @@ func (m *mockChainIngester) AddLog(timestamp, blockNum uint64, logIdx uint32, ch
 		Checksum:  checksum,
 	}
 	m.logs[key] = seal
+	m.blocks[blockNum] = eth.BlockID{Hash: seal.Hash, Number: blockNum}
 
 	// Update latest block/timestamp if needed
 	if blockNum > m.latestBlock.Number {
-		m.latestBlock = eth.BlockID{Number: blockNum}
+		m.latestBlock = eth.BlockID{Hash: seal.Hash, Number: blockNum}
 		m.latestTimestamp = timestamp
 	}
 	if m.earliestIngestedBlock == 0 || blockNum < m.earliestIngestedBlock {
@@ -95,6 +100,17 @@ func (m *mockChainIngester) AddExecMsg(msg IncludedMessage) {
 	}
 	if m.earliestIngestedBlock == 0 || msg.InclusionBlockNum < m.earliestIngestedBlock {
 		m.earliestIngestedBlock = msg.InclusionBlockNum
+	}
+}
+
+// AddBlock adds a block directly to the ingester.
+func (m *mockChainIngester) AddBlock(block eth.BlockID) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.blocks[block.Number] = block
+	if block.Number >= m.latestBlock.Number {
+		m.latestBlock = block
 	}
 }
 
@@ -133,6 +149,15 @@ func (m *mockChainIngester) LatestBlock() (eth.BlockID, bool) {
 		return eth.BlockID{}, false
 	}
 	return m.latestBlock, true
+}
+
+// BlockByNumber implements ChainIngester.
+func (m *mockChainIngester) BlockByNumber(number uint64) (eth.BlockID, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	block, ok := m.blocks[number]
+	return block, ok
 }
 
 // LatestTimestamp implements ChainIngester.

--- a/op-interop-filter/filter/mock_test.go
+++ b/op-interop-filter/filter/mock_test.go
@@ -151,13 +151,16 @@ func (m *mockChainIngester) LatestBlock() (eth.BlockID, bool) {
 	return m.latestBlock, true
 }
 
-// BlockByNumber implements ChainIngester.
-func (m *mockChainIngester) BlockByNumber(number uint64) (eth.BlockID, bool) {
+// BlockHashByNumber implements ChainIngester.
+func (m *mockChainIngester) BlockHashByNumber(number uint64) (common.Hash, bool) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
 	block, ok := m.blocks[number]
-	return block, ok
+	if !ok {
+		return common.Hash{}, false
+	}
+	return block.Hash, true
 }
 
 // LatestTimestamp implements ChainIngester.

--- a/op-interop-filter/filter/rpc_test.go
+++ b/op-interop-filter/filter/rpc_test.go
@@ -1,0 +1,105 @@
+package filter
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-interop-filter/metrics"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	oprpc "github.com/ethereum-optimism/optimism/op-service/rpc"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+)
+
+func TestBlockSelectorUnmarshalJSON(t *testing.T) {
+	t.Run("latest", func(t *testing.T) {
+		var selector BlockSelector
+		require.NoError(t, json.Unmarshal([]byte(`"latest"`), &selector))
+		require.True(t, selector.Latest())
+	})
+
+	t.Run("json number", func(t *testing.T) {
+		var selector BlockSelector
+		require.NoError(t, json.Unmarshal([]byte(`123`), &selector))
+		require.False(t, selector.Latest())
+		require.Equal(t, uint64(123), selector.Number())
+	})
+
+	t.Run("quoted decimal", func(t *testing.T) {
+		var selector BlockSelector
+		require.NoError(t, json.Unmarshal([]byte(`"123"`), &selector))
+		require.Equal(t, uint64(123), selector.Number())
+	})
+
+	t.Run("quoted hex", func(t *testing.T) {
+		var selector BlockSelector
+		require.NoError(t, json.Unmarshal([]byte(`"0x7b"`), &selector))
+		require.Equal(t, uint64(123), selector.Number())
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		var selector BlockSelector
+		require.Error(t, json.Unmarshal([]byte(`"safe"`), &selector))
+		require.ErrorContains(t, json.Unmarshal([]byte(`"safe"`), &selector), `unsupported block tag "safe"`)
+	})
+}
+
+func TestQueryFrontendGetBlockByNumberRPC(t *testing.T) {
+	logger := testlog.Logger(t, log.LevelInfo)
+	mock := newMockChainIngester()
+	mock.AddBlock(eth.BlockID{Hash: common.HexToHash("0x01"), Number: 100})
+	mock.AddBlock(eth.BlockID{Hash: common.HexToHash("0x02"), Number: 200})
+
+	backend := NewBackend(context.Background(), BackendParams{
+		Logger:         logger,
+		Metrics:        metrics.NoopMetrics,
+		Chains:         map[eth.ChainID]ChainIngester{eth.ChainIDFromUInt64(testChainA): mock},
+		CrossValidator: &mockCrossValidator{},
+	})
+
+	server := oprpc.NewServer(
+		"127.0.0.1",
+		0,
+		"test",
+		oprpc.WithLogger(logger),
+	)
+	server.AddAPI(rpc.API{
+		Namespace: "supervisor",
+		Service:   &QueryFrontend{backend: backend},
+	})
+
+	require.NoError(t, server.Start())
+	t.Cleanup(func() {
+		_ = server.Stop()
+	})
+
+	client, err := rpc.Dial("http://" + server.Endpoint())
+	require.NoError(t, err)
+	t.Cleanup(client.Close)
+
+	t.Run("latest selector", func(t *testing.T) {
+		var result eth.BlockID
+		err := client.Call(&result, "supervisor_getBlockByNumber", eth.ChainIDFromUInt64(testChainA), "latest")
+		require.NoError(t, err)
+		require.Equal(t, uint64(200), result.Number)
+		require.Equal(t, common.HexToHash("0x02"), result.Hash)
+	})
+
+	t.Run("numeric selector", func(t *testing.T) {
+		var result eth.BlockID
+		err := client.Call(&result, "supervisor_getBlockByNumber", eth.ChainIDFromUInt64(testChainA), uint64(100))
+		require.NoError(t, err)
+		require.Equal(t, eth.BlockID{Hash: common.HexToHash("0x01"), Number: 100}, result)
+	})
+
+	t.Run("missing block", func(t *testing.T) {
+		var result eth.BlockID
+		err := client.Call(&result, "supervisor_getBlockByNumber", eth.ChainIDFromUInt64(testChainA), uint64(999))
+		require.ErrorContains(t, err, "not found")
+	})
+}

--- a/op-interop-filter/filter/rpc_test.go
+++ b/op-interop-filter/filter/rpc_test.go
@@ -45,7 +45,6 @@ func TestBlockSelectorUnmarshalJSON(t *testing.T) {
 	t.Run("invalid", func(t *testing.T) {
 		var selector BlockSelector
 		require.Error(t, json.Unmarshal([]byte(`"safe"`), &selector))
-		require.ErrorContains(t, json.Unmarshal([]byte(`"safe"`), &selector), `unsupported block tag "safe"`)
 	})
 }
 

--- a/op-interop-filter/filter/rpc_test.go
+++ b/op-interop-filter/filter/rpc_test.go
@@ -49,7 +49,7 @@ func TestBlockSelectorUnmarshalJSON(t *testing.T) {
 	})
 }
 
-func TestQueryFrontendGetBlockByNumberRPC(t *testing.T) {
+func TestQueryFrontendGetBlockHashByNumberRPC(t *testing.T) {
 	logger := testlog.Logger(t, log.LevelInfo)
 	mock := newMockChainIngester()
 	mock.AddBlock(eth.BlockID{Hash: common.HexToHash("0x01"), Number: 100})
@@ -83,23 +83,22 @@ func TestQueryFrontendGetBlockByNumberRPC(t *testing.T) {
 	t.Cleanup(client.Close)
 
 	t.Run("latest selector", func(t *testing.T) {
-		var result eth.BlockID
-		err := client.Call(&result, "supervisor_getBlockByNumber", eth.ChainIDFromUInt64(testChainA), "latest")
+		var result common.Hash
+		err := client.Call(&result, "supervisor_getBlockHashByNumber", eth.ChainIDFromUInt64(testChainA), "latest")
 		require.NoError(t, err)
-		require.Equal(t, uint64(200), result.Number)
-		require.Equal(t, common.HexToHash("0x02"), result.Hash)
+		require.Equal(t, common.HexToHash("0x02"), result)
 	})
 
 	t.Run("numeric selector", func(t *testing.T) {
-		var result eth.BlockID
-		err := client.Call(&result, "supervisor_getBlockByNumber", eth.ChainIDFromUInt64(testChainA), uint64(100))
+		var result common.Hash
+		err := client.Call(&result, "supervisor_getBlockHashByNumber", eth.ChainIDFromUInt64(testChainA), uint64(100))
 		require.NoError(t, err)
-		require.Equal(t, eth.BlockID{Hash: common.HexToHash("0x01"), Number: 100}, result)
+		require.Equal(t, common.HexToHash("0x01"), result)
 	})
 
 	t.Run("missing block", func(t *testing.T) {
-		var result eth.BlockID
-		err := client.Call(&result, "supervisor_getBlockByNumber", eth.ChainIDFromUInt64(testChainA), uint64(999))
+		var result common.Hash
+		err := client.Call(&result, "supervisor_getBlockHashByNumber", eth.ChainIDFromUInt64(testChainA), uint64(999))
 		require.ErrorContains(t, err, "not found")
 	})
 }


### PR DESCRIPTION
## Summary
- add a public `supervisor_getBlockHashByNumber` RPC to op-interop-filter
- support `"latest"` and numeric block selectors for logs DB lookups
- return `ErrUninitialized` before readiness and add coverage for selector parsing and RPC behavior

## Testing
- go test ./op-interop-filter/filter ./op-interop-filter/...