### PR TITLE
fix(op-e2e): set init bond when creating dispute games in e2e tests

### DIFF
--- a/op-e2e/e2eutils/disputegame/helper.go
+++ b/op-e2e/e2eutils/disputegame/helper.go
@@ -210,6 +210,7 @@ func (h *FactoryHelper) startOutputCannonGameOfType(ctx context.Context, l2Node 
 	ctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
 	defer cancel()
 
+	h.setInitBond(gameType)
 	tx, err := transactions.PadGasEstimate(h.Opts, 2, func(opts *bind.TransactOpts) (*types.Transaction, error) {
 		return h.Factory.Create(opts, gameType, rootClaim, extraData)
 	})
@@ -272,6 +273,7 @@ func (h *FactoryHelper) startSuperCannonGameOfType(ctx context.Context, timestam
 	ctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
 	defer cancel()
 
+	h.setInitBond(gameType)
 	tx, err := transactions.PadGasEstimate(h.Opts, 2, func(opts *bind.TransactOpts) (*types.Transaction, error) {
 		return h.Factory.Create(opts, gameType, rootClaim, extraData)
 	})
@@ -326,6 +328,7 @@ func (h *FactoryHelper) StartOutputAlphabetGame(ctx context.Context, l2Node stri
 	ctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
 	defer cancel()
 
+	h.setInitBond(alphabetGameType)
 	tx, err := transactions.PadGasEstimate(h.Opts, 2, func(opts *bind.TransactOpts) (*types.Transaction, error) {
 		return h.Factory.Create(opts, alphabetGameType, rootClaim, extraData)
 	})
@@ -350,6 +353,12 @@ func (h *FactoryHelper) StartOutputAlphabetGame(ctx context.Context, l2Node stri
 	return &OutputAlphabetGameHelper{
 		OutputGameHelper: *NewOutputGameHelper(h.T, h.Require, h.Client, h.Opts, h.PrivKey, game, h.FactoryAddr, createdEvent.DisputeProxy, provider, h.System),
 	}
+}
+
+func (h *FactoryHelper) setInitBond(gameType uint32) {
+	bond, err := h.Factory.InitBonds(&bind.CallOpts{}, gameType)
+	h.Require.NoError(err, "Failed to get init bond")
+	h.Opts.Value = bond
 }
 
 func (h *FactoryHelper) CreateBisectionGameExtraData(l2Node string, l2BlockNumber uint64, cfg *GameCfg) []byte {


### PR DESCRIPTION
## Summary

- Fix `TestPermissionedGameType` (and all other dispute game e2e tests) failing with `IncorrectBondAmount` revert since Apr 3
- Query `DisputeGameFactory.initBonds(gameType)` and set `opts.Value` before calling `Factory.Create` in the test helper

## Root Cause

PR #19795 removed OPCMv1, so e2e tests now deploy through OPCMv2 which sets `initBonds[PERMISSIONED_CANNON] = 0.08 ether`. Previously, OPCMv1's `_registerPermissionedGame()` only called `setDGFImplementation()` and never called `setInitBond()`, leaving the default at 0.

The test helper (`FactoryHelper`) creates `TransactOpts` via `bind.NewKeyedTransactorWithChainID()` which leaves `Value = nil` (msg.value = 0). When `initBonds` was 0 this worked; now that it's 0.08 ether, the factory's `create()` reverts.

## Fix

Added a `setInitBond` helper that queries the factory for the required bond and sets `opts.Value` before every `Factory.Create` call. Applied to all three game creation paths:
- `startOutputCannonGameOfType` (cannon/permissioned games)
- `startSuperCannonGameOfType` (super cannon games)
- `StartOutputAlphabetGame` (alphabet games)

## Test plan

- [x] Reproduced failure locally: `TestPermissionedGameType` fails with `IncorrectBondAmount` (0x8620aa19) before fix
- [x] Verified fix locally: `TestPermissionedGameType` passes after fix
- [x] Confirmed this is the same error seen in 17+ consecutive CI failures on `develop` since Apr 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)