### PR TITLE
fix(acceptance): remove flaky wall-clock assertion in TestFlashblocksTransfer

### DIFF
--- a/op-acceptance-tests/tests/flashblocks/flashblocks_transfer_test.go
+++ b/op-acceptance-tests/tests/flashblocks/flashblocks_transfer_test.go
@@ -22,10 +22,8 @@ import (
 //   - There must have been a Flashblock containing a new_account_balance corresponding to Bob's
 //     account. This flashblock would be representative of the flashblock including Alice-to-Bob
 //     transaction.
-//   - The flashblock's time (in seconds) must be less than or equal to the Transaction's block
-//     time (in seconds). (Can't check the block time beyond the granularity of seconds)
-//   - That Flashblock's time in nanoseconds must be before the approximated transaction
-//     confirmation time recorded previously.
+//   - Bob's balance reported in the flashblock must match the on-chain balance after confirmation.
+//   - The transaction's confirmed block number must match the flashblock's block number.
 func TestFlashblocksTransfer(gt *testing.T) {
 	t := devtest.ParallelT(gt)
 	// Example error with kona-node:
@@ -103,5 +101,5 @@ outer:
 	expectedBalance, err := sys.L2EL.EthClient().BalanceAt(t.Ctx(), bob.Address(), new(big.Int).SetUint64(txBlock.Number))
 	t.Require().NoError(err)
 	require.Equal(t, expectedBalance, observedBalance, "Bob's balance must be correct as per exactly what Alice transferred to them")
-	require.Equal(t, int(txBlock.Number), blockNumber, "the transaction's block number should be the same as the flashblock's parent block number")
+	require.Equal(t, int(txBlock.Number), blockNumber, "the transaction's block number should be the same as the flashblock's block number")
 }


### PR DESCRIPTION
## Summary

Removes a flaky time assertion in `TestFlashblocksTransfer` that compared `time.Now()` (wall-clock when the Go goroutine processed the flashblock) against `txBlock.Time` (sequencer block timestamp). Pipeline latency under CI load causes `time.Now()` to exceed the block timestamp by 1+ seconds.

The `Flashblock` struct has no timestamp field, so no reliable time comparison is possible. The remaining assertions (balance correctness, block number match) are the substantive checks.

Fixes #19934

## Test plan

- [x] `go vet` passes
- [ ] CI passes (the removed assertion was the sole source of flakiness)