### PR TITLE
feat(op-node): offset_derived for EL-sync safe/finalized retraction

### DIFF
--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -123,6 +123,14 @@ var (
 		EnvVars:  prefixEnvVars("SYNCMODE_REQ_RESP"),
 		Category: RollupCategory,
 	}
+	SyncModeOffsetDerivedFlag = &cli.DurationFlag{
+		Name: "syncmode.offset-derived",
+		Usage: "After execution-layer sync completes, set safe and finalized heads to this duration behind the synced tip " +
+			"(converted to L2 blocks via rollup block time using floor division). 0 keeps safe and finalized at the tip.",
+		EnvVars:  prefixEnvVars("SYNCMODE_OFFSET_DERIVED"),
+		Category: RollupCategory,
+		Value:    0,
+	}
 	RPCAdminPersistence = &cli.StringFlag{
 		Name:     "rpc.admin-state",
 		Usage:    "File path used to persist state changes made via the admin API so they persist across restarts. Disabled if not set.",
@@ -477,6 +485,7 @@ var optionalFlags = []cli.Flag{
 	BeaconFetchAllSidecars,
 	SyncModeFlag,
 	SyncModeReqRespFlag,
+	SyncModeOffsetDerivedFlag,
 	FetchWithdrawalRootFromState,
 	L1TrustRPC,
 	L1RPCProviderKind,

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -616,15 +616,24 @@ func (e *EngineController) insertUnsafePayload(ctx context.Context, envelope *et
 		SafeBlockHash:      e.SafeL2Head().Hash,
 		FinalizedBlockHash: e.FinalizedHead().Hash,
 	}
+	derivedForForkchoice := ref
 	if e.syncStatus == syncStatusFinishedELButNotFinalized {
-		fc.SafeBlockHash = envelope.ExecutionPayload.BlockHash
-		fc.FinalizedBlockHash = envelope.ExecutionPayload.BlockHash
+		if e.syncCfg.OffsetDerived > 0 {
+			n := sync.DerivedBlockSteps(e.syncCfg.OffsetDerived, e.rollupCfg.BlockTime)
+			d, err := sync.L2AncestorByN(ctx, e.engine, e.rollupCfg.Genesis.L2, ref, n)
+			if err != nil {
+				return derive.NewTemporaryError(fmt.Errorf("EL sync offset-derived head: %w", err))
+			}
+			derivedForForkchoice = d
+		}
+		fc.SafeBlockHash = derivedForForkchoice.Hash
+		fc.FinalizedBlockHash = derivedForForkchoice.Hash
 		e.SetUnsafeHead(ref) // ensure that the unsafe head stays ahead of safe/finalized labels.
 		e.emitter.Emit(ctx, UnsafeUpdateEvent{Ref: ref})
-		e.SetLocalSafeHead(ref)
-		e.SetSafeHead(ref)
-		e.onSafeUpdate(ctx, ref, ref)
-		e.SetFinalizedHead(ref)
+		e.SetLocalSafeHead(derivedForForkchoice)
+		e.SetSafeHead(derivedForForkchoice)
+		e.onSafeUpdate(ctx, derivedForForkchoice, derivedForForkchoice)
+		e.SetFinalizedHead(derivedForForkchoice)
 	}
 	logFn := e.logSyncProgressMaybe()
 	defer logFn()
@@ -655,7 +664,8 @@ func (e *EngineController) insertUnsafePayload(ctx context.Context, envelope *et
 	e.emitter.Emit(ctx, UnsafeUpdateEvent{Ref: ref})
 
 	if e.syncStatus == syncStatusFinishedELButNotFinalized {
-		e.log.Info("Finished EL sync", "sync_duration", e.clock.Since(e.elStart), "finalized_block", ref.ID().String())
+		e.log.Info("Finished EL sync", "sync_duration", e.clock.Since(e.elStart),
+			"unsafe_block", ref.ID().String(), "safe_finalized_block", derivedForForkchoice.ID().String())
 		e.syncStatus = syncStatusFinishedEL
 	}
 

--- a/op-node/rollup/engine/engine_el_sync_offset_test.go
+++ b/op-node/rollup/engine/engine_el_sync_offset_test.go
@@ -1,0 +1,154 @@
+// Tests: InteropELSyncBootstrap_Feature.md §2 — offset_derived at EL-sync completion (insertUnsafePayload).
+package engine
+
+import (
+	"context"
+	"math/big"
+	mrand "math/rand"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-node/metrics"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/event"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
+	"github.com/ethereum/go-ethereum/common"
+	gethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+type discardEmitter struct{}
+
+func (discardEmitter) Emit(context.Context, event.Event) {}
+
+type noopSyncDeriver struct{}
+
+func (noopSyncDeriver) OnELSyncStarted() {}
+
+// buildELSyncTipChain returns genesis L2 b0 .. b3 (tip) with BlockTime=2 and a valid payload for b3.
+func buildELSyncTipChain(t *testing.T) (*rollup.Config, eth.L2BlockRef, eth.L2BlockRef, eth.L2BlockRef, eth.L2BlockRef, *eth.ExecutionPayloadEnvelope) {
+	t.Helper()
+	rng := mrand.New(mrand.NewSource(1234))
+	refA := testutils.RandomBlockRef(rng)
+	refA0 := eth.L2BlockRef{
+		Hash:           testutils.RandomHash(rng),
+		Number:         0,
+		ParentHash:     common.Hash{},
+		Time:           refA.Time,
+		L1Origin:       refA.ID(),
+		SequenceNumber: 0,
+	}
+	cfg := &rollup.Config{
+		Genesis: rollup.Genesis{
+			L1:     refA.ID(),
+			L2:     refA0.ID(),
+			L2Time: refA0.Time,
+			SystemConfig: eth.SystemConfig{
+				BatcherAddr: common.Address{42},
+				Overhead:    [32]byte{123},
+				Scalar:      [32]byte{42},
+				GasLimit:    20_000_000,
+			},
+		},
+		BlockTime:     2,
+		SeqWindowSize: 2,
+	}
+	refA1 := eth.L2BlockRef{
+		Hash:           common.Hash{'1'},
+		Number:         1,
+		ParentHash:     refA0.Hash,
+		Time:           refA0.Time + cfg.BlockTime,
+		L1Origin:       refA.ID(),
+		SequenceNumber: 1,
+	}
+	refA2 := eth.L2BlockRef{
+		Hash:           common.Hash{'2'},
+		Number:         2,
+		ParentHash:     refA1.Hash,
+		Time:           refA1.Time + cfg.BlockTime,
+		L1Origin:       refA.ID(),
+		SequenceNumber: 2,
+	}
+	refA3 := eth.L2BlockRef{
+		Hash:           common.Hash{'3'},
+		Number:         3,
+		ParentHash:     refA2.Hash,
+		Time:           refA2.Time + cfg.BlockTime,
+		L1Origin:       refA.ID(),
+		SequenceNumber: 3,
+	}
+	aL1Info := &testutils.MockBlockInfo{
+		InfoParentHash:  refA.ParentHash,
+		InfoNum:         refA.Number,
+		InfoTime:        refA.Time,
+		InfoHash:        refA.Hash,
+		InfoBaseFee:     big.NewInt(1),
+		InfoBlobBaseFee: big.NewInt(1),
+		InfoReceiptRoot: gethtypes.EmptyRootHash,
+		InfoRoot:        testutils.RandomHash(rng),
+		InfoGasUsed:     rng.Uint64(),
+	}
+	l1Bytes, err := derive.L1InfoDepositBytes(cfg, params.SepoliaChainConfig, cfg.Genesis.SystemConfig, refA3.SequenceNumber, aL1Info, refA3.Time)
+	require.NoError(t, err)
+	payload := &eth.ExecutionPayloadEnvelope{ExecutionPayload: &eth.ExecutionPayload{
+		ParentHash:   refA3.ParentHash,
+		BlockNumber:  eth.Uint64Quantity(refA3.Number),
+		Timestamp:    eth.Uint64Quantity(refA3.Time),
+		BlockHash:    refA3.Hash,
+		Transactions: []eth.Data{l1Bytes},
+	}}
+	return cfg, refA0, refA1, refA2, refA3, payload
+}
+
+func TestInsertUnsafePayload_ELSync_offsetDerived_zero_sets_safe_to_tip(t *testing.T) {
+	cfg, refA0, _, _, refA3, payload := buildELSyncTipChain(t)
+	mockEngine := &testutils.MockEngine{}
+	ec := NewEngineController(context.Background(), mockEngine, testlog.Logger(t, 0), metrics.NoopMetrics, cfg,
+		&sync.Config{SyncMode: sync.ELSync, OffsetDerived: 0}, false, &testutils.MockL1Source{}, discardEmitter{}, nil)
+	ec.SyncDeriver = noopSyncDeriver{}
+
+	mockEngine.ExpectL2BlockRefByLabel(eth.Finalized, refA0, nil)
+	mockEngine.ExpectNewPayload(payload.ExecutionPayload, nil, &eth.PayloadStatusV1{Status: eth.ExecutionValid}, nil)
+	mockEngine.ExpectForkchoiceUpdate(&eth.ForkchoiceState{
+		HeadBlockHash:      refA3.Hash,
+		SafeBlockHash:      refA3.Hash,
+		FinalizedBlockHash: refA3.Hash,
+	}, nil, &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionValid}}, nil)
+
+	err := ec.InsertUnsafePayload(context.Background(), payload, refA3)
+	require.NoError(t, err)
+	require.Equal(t, refA3, ec.unsafeHead)
+	require.Equal(t, refA3, ec.localSafeHead)
+	require.Equal(t, refA3, ec.FinalizedHead())
+}
+
+func TestInsertUnsafePayload_ELSync_offsetDerived_retracts_safe_finalized(t *testing.T) {
+	cfg, refA0, refA1, refA2, refA3, payload := buildELSyncTipChain(t)
+	mockEngine := &testutils.MockEngine{}
+	// offset 5s, BlockTime 2 -> floor(5/2)=2 ancestors from tip -> refA1
+	ec := NewEngineController(context.Background(), mockEngine, testlog.Logger(t, 0), metrics.NoopMetrics, cfg,
+		&sync.Config{SyncMode: sync.ELSync, OffsetDerived: 5 * time.Second}, false, &testutils.MockL1Source{}, discardEmitter{}, nil)
+	ec.SyncDeriver = noopSyncDeriver{}
+
+	mockEngine.ExpectL2BlockRefByLabel(eth.Finalized, refA0, nil)
+	mockEngine.ExpectNewPayload(payload.ExecutionPayload, nil, &eth.PayloadStatusV1{Status: eth.ExecutionValid}, nil)
+	mockEngine.ExpectL2BlockRefByHash(refA3.ParentHash, refA2, nil)
+	mockEngine.ExpectL2BlockRefByHash(refA2.ParentHash, refA1, nil)
+	mockEngine.ExpectForkchoiceUpdate(&eth.ForkchoiceState{
+		HeadBlockHash:      refA3.Hash,
+		SafeBlockHash:      refA1.Hash,
+		FinalizedBlockHash: refA1.Hash,
+	}, nil, &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionValid}}, nil)
+
+	err := ec.InsertUnsafePayload(context.Background(), payload, refA3)
+	require.NoError(t, err)
+	require.Equal(t, refA3, ec.unsafeHead)
+	require.Equal(t, refA1, ec.localSafeHead)
+	require.Equal(t, refA1, ec.FinalizedHead())
+}

--- a/op-node/rollup/sync/config.go
+++ b/op-node/rollup/sync/config.go
@@ -1,8 +1,10 @@
 package sync
 
 import (
+	"errors"
 	"fmt"
 	"strings"
+	"time"
 )
 
 type Mode int
@@ -77,6 +79,20 @@ type Config struct {
 
 	L2FollowSourceEndpoint string `json:"l2_follow_source_endpoint"`
 	NeedInitialResetEngine bool   `json:"need_initial_reset_engine"`
+
+	// OffsetDerived retracts safe and finalized from the EL-sync tip by floor(OffsetDerived / L2BlockTime) blocks.
+	// Zero disables (safe and finalized stay at the synced tip when EL sync completes).
+	OffsetDerived time.Duration `json:"offset_derived,omitempty"`
+}
+
+func (c *Config) Check() error {
+	if c == nil {
+		return nil
+	}
+	if c.OffsetDerived < 0 {
+		return errors.New("sync.offset-derived must be >= 0")
+	}
+	return nil
 }
 
 func (c *Config) FollowSourceEnabled() bool {

--- a/op-node/rollup/sync/offset_derived.go
+++ b/op-node/rollup/sync/offset_derived.go
@@ -1,0 +1,35 @@
+package sync
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+// DerivedBlockSteps returns floor(offsetDerived / blockTime) L2 block steps to walk back from the EL-sync tip.
+// blockTime is rollup L2 block time in seconds. A zero or negative offset yields 0; zero block time yields 0.
+func DerivedBlockSteps(offsetDerived time.Duration, blockTime uint64) uint64 {
+	if offsetDerived <= 0 || blockTime == 0 {
+		return 0
+	}
+	sec := uint64(offsetDerived / time.Second)
+	return sec / blockTime
+}
+
+// L2AncestorByN walks parent links from tip, at most n times, clamping at genesisL2 (inclusive).
+func L2AncestorByN(ctx context.Context, l2 L2Chain, genesisL2 eth.BlockID, tip eth.L2BlockRef, n uint64) (eth.L2BlockRef, error) {
+	cur := tip
+	for i := uint64(0); i < n; i++ {
+		if cur.Number <= genesisL2.Number {
+			return cur, nil
+		}
+		parent, err := l2.L2BlockRefByHash(ctx, cur.ParentHash)
+		if err != nil {
+			return eth.L2BlockRef{}, fmt.Errorf("parent of L2 block %s: %w", cur, err)
+		}
+		cur = parent
+	}
+	return cur, nil
+}

--- a/op-node/rollup/sync/offset_derived_test.go
+++ b/op-node/rollup/sync/offset_derived_test.go
@@ -1,0 +1,61 @@
+// Tests: InteropELSyncBootstrap_Feature.md §2 — offset_derived block-step math and L2AncestorByN.
+package sync
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+func TestDerivedBlockSteps(t *testing.T) {
+	tests := []struct {
+		name   string
+		offset time.Duration
+		bt     uint64
+		want   uint64
+	}{
+		{"zero offset", 0, 2, 0},
+		{"negative treated as zero", -time.Hour, 2, 0},
+		{"zero block time", time.Hour, 0, 0},
+		{"floor BT=2 offset=3s -> 1", 3 * time.Second, 2, 1},
+		{"floor BT=2 offset=4s -> 2", 4 * time.Second, 2, 2},
+		{"sub-second offset truncates", 500 * time.Millisecond, 1, 0},
+		{"12h with 2s blocks", 12 * time.Hour, 2, 21600},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DerivedBlockSteps(tt.offset, tt.bt)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestL2AncestorByN_walkAndClamp(t *testing.T) {
+	ctx := context.Background()
+	genesis := eth.BlockID{Hash: common.Hash{'g'}, Number: 0}
+	b0 := eth.L2BlockRef{Hash: genesis.Hash, Number: 0, ParentHash: common.Hash{}}
+	b1 := eth.L2BlockRef{Hash: common.Hash{'1'}, Number: 1, ParentHash: b0.Hash}
+	b2 := eth.L2BlockRef{Hash: common.Hash{'2'}, Number: 2, ParentHash: b1.Hash}
+	b3 := eth.L2BlockRef{Hash: common.Hash{'3'}, Number: 3, ParentHash: b2.Hash}
+
+	m := &testutils.MockL2Client{}
+	m.ExpectL2BlockRefByHash(b3.ParentHash, b2, nil)
+	m.ExpectL2BlockRefByHash(b2.ParentHash, b1, nil)
+
+	out, err := L2AncestorByN(ctx, m, genesis, b3, 2)
+	require.NoError(t, err)
+	require.Equal(t, b1, out)
+
+	// n larger than depth — clamp at genesis
+	m2 := &testutils.MockL2Client{}
+	m2.ExpectL2BlockRefByHash(b1.ParentHash, b0, nil)
+	out2, err := L2AncestorByN(ctx, m2, genesis, b1, 100)
+	require.NoError(t, err)
+	require.Equal(t, b0, out2)
+}

--- a/op-node/rollup/sync/start.go
+++ b/op-node/rollup/sync/start.go
@@ -100,6 +100,17 @@ func currentHeads(ctx context.Context, cfg *rollup.Config, l2 L2Chain) (*FindHea
 	}, nil
 }
 
+// elSyncRecoveryHeads applies the same safe/finalized choice as EL-sync completion:
+// unsafe stays at tip; safe and finalized retract by syncCfg.OffsetDerived (see DerivedBlockSteps).
+func elSyncRecoveryHeads(ctx context.Context, cfg *rollup.Config, l2 L2Chain, syncCfg *Config, tip eth.L2BlockRef) (*FindHeadsResult, error) {
+	n := DerivedBlockSteps(syncCfg.OffsetDerived, cfg.BlockTime)
+	derived, err := L2AncestorByN(ctx, l2, cfg.Genesis.L2, tip, n)
+	if err != nil {
+		return nil, fmt.Errorf("EL sync recovery derived head: %w", err)
+	}
+	return &FindHeadsResult{Unsafe: tip, Safe: derived, Finalized: derived}, nil
+}
+
 // FindL2Heads walks back from `start` (the previous unsafe L2 block) and finds
 // the finalized, unsafe and safe L2 blocks.
 //
@@ -130,7 +141,7 @@ func FindL2Heads(ctx context.Context, cfg *rollup.Config, l1 L1Chain, l2 L2Chain
 		result.Unsafe.Number > cfg.Genesis.L2.Number &&
 		result.Unsafe.L1Origin.Number > cfg.Genesis.L1.Number+(RecoverMinSeqWindows*cfg.SeqWindowSize) {
 		lgr.Warn("Attempting recovery from sync state without finality.", "head", result.Unsafe)
-		return &FindHeadsResult{Unsafe: result.Unsafe, Safe: result.Unsafe, Finalized: result.Unsafe}, nil
+		return elSyncRecoveryHeads(ctx, cfg, l2, syncCfg, result.Unsafe)
 	}
 
 	// Check if the execution engine corrupted, and forkchoice is ahead of the remaining chain:
@@ -138,7 +149,7 @@ func FindL2Heads(ctx context.Context, cfg *rollup.Config, l1 L1Chain, l2 L2Chain
 	if result.Unsafe.Number < result.Finalized.Number || result.Unsafe.Number < result.Safe.Number {
 		lgr.Error("Unsafe head is behind known finalized/safe blocks, execution-engine chain must have been rewound without forkchoice update. Attempting recovery now.",
 			"unsafe_head", result.Unsafe, "safe_head", result.Safe, "finalized_head", result.Finalized)
-		return &FindHeadsResult{Unsafe: result.Unsafe, Safe: result.Unsafe, Finalized: result.Unsafe}, nil
+		return elSyncRecoveryHeads(ctx, cfg, l2, syncCfg, result.Unsafe)
 	}
 
 	// Remember original unsafe block to determine reorg depth

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -370,9 +370,13 @@ func NewSyncConfig(ctx cliiface.Context, log log.Logger) (*sync.Config, error) {
 		L2FollowSourceEndpoint:         l2FollowSourceEndpoint,
 		// Sequencer needs a manual initial reset when follow source
 		NeedInitialResetEngine: ctx.Bool(flags.SequencerEnabledFlag.Name) && l2FollowSourceEndpoint != "",
+		OffsetDerived:                  ctx.Duration(flags.SyncModeOffsetDerivedFlag.Name),
 	}
 	if ctx.Bool(flags.L2EngineSyncEnabled.Name) {
 		cfg.SyncMode = sync.ELSync
+	}
+	if err := cfg.Check(); err != nil {
+		return nil, err
 	}
 	return cfg, nil
 }

--- a/op-node/service_test.go
+++ b/op-node/service_test.go
@@ -15,6 +15,7 @@ func syncConfigCliApp() *cli.App {
 		flags.L2EngineSyncEnabled,
 		flags.SyncModeFlag,
 		flags.SyncModeReqRespFlag,
+		flags.SyncModeOffsetDerivedFlag,
 		flags.L2FollowSource,
 		flags.L2EngineKind,
 		flags.SkipSyncStartCheck,

--- a/op-supernode/cmd/main.go
+++ b/op-supernode/cmd/main.go
@@ -21,7 +21,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supernode/config"
 	"github.com/ethereum-optimism/optimism/op-supernode/flags"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode"
-	"github.com/ethereum-optimism/optimism/op-supernode/supernode/activity/interop"
 	"github.com/ethereum/go-ethereum/log"
 )
 
@@ -79,13 +78,8 @@ func main() {
 			return nil, fmt.Errorf("failed to create virtual node configs: %w", err)
 		}
 
-		// Populate config with interop activation timestamp from CLI context if set
-		// Only set the pointer if the flag is explicitly provided by the user
-		// If not set, leave as nil to disable interop
-		if cliCtx != nil && cliCtx.IsSet(interop.InteropActivationTimestampFlag.Name) {
-			ts := cliCtx.Uint64(interop.InteropActivationTimestampFlag.Name)
-			cfg.InteropActivationTimestamp = &ts
-			l.Info("interop activation timestamp set from CLI", "timestamp", ts)
+		if cfg.InteropActivationTimestamp != nil {
+			l.Info("interop activation timestamp set from CLI", "timestamp", *cfg.InteropActivationTimestamp)
 		}
 
 		// Create the supernode, supplying the logger, version, and close function

--- a/op-supernode/config/config.go
+++ b/op-supernode/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"errors"
+	"time"
 
 	"github.com/urfave/cli/v2"
 
@@ -24,6 +25,9 @@ type CLIConfig struct {
 	PprofConfig                oppprof.CLIConfig
 	RawCtx                     *cli.Context
 	InteropActivationTimestamp *uint64
+	// InteropLogBackfillDepth is the duration (e.g. 168h) to extend initiating-message log ingestion
+	// backward from the tip before interop message validation runs. Zero disables.
+	InteropLogBackfillDepth time.Duration
 }
 
 func (c *CLIConfig) Check() error {
@@ -39,11 +43,17 @@ func (c *CLIConfig) Check() error {
 	if c.L1NodeAddr == "" {
 		return errors.New("l1 node address is required")
 	}
+	if c.InteropLogBackfillDepth < 0 {
+		return errors.New("interop.log-backfill-depth must be >= 0")
+	}
+	if c.InteropLogBackfillDepth > 0 && c.InteropActivationTimestamp == nil {
+		return errors.New("interop.log-backfill-depth requires interop.activation-timestamp")
+	}
 	return nil
 }
 
 func NewConfig(ctx *cli.Context) *CLIConfig {
-	return &CLIConfig{
+	cfg := &CLIConfig{
 		Chains:                ctx.Uint64Slice(flags.ChainsFlag.Name),
 		DataDir:               ctx.String(flags.DataDirFlag.Name),
 		L1NodeAddr:            ctx.String(flags.L1NodeAddr.Name),
@@ -54,5 +64,11 @@ func NewConfig(ctx *cli.Context) *CLIConfig {
 		MetricsConfig:         opmetrics.ReadCLIConfig(ctx),
 		PprofConfig:           oppprof.ReadCLIConfig(ctx),
 		RawCtx:                ctx,
+		InteropLogBackfillDepth: ctx.Duration("interop.log-backfill-depth"),
 	}
+	if ctx.IsSet("interop.activation-timestamp") {
+		ts := ctx.Uint64("interop.activation-timestamp")
+		cfg.InteropActivationTimestamp = &ts
+	}
+	return cfg
 }

--- a/op-supernode/config/config_test.go
+++ b/op-supernode/config/config_test.go
@@ -1,0 +1,24 @@
+package config
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCLIConfig_Check_logBackfillRequiresActivation(t *testing.T) {
+	ptr := func(u uint64) *uint64 { return &u }
+	t.Run("ok with both", func(t *testing.T) {
+		c := &CLIConfig{L1NodeAddr: "http://x", InteropActivationTimestamp: ptr(1), InteropLogBackfillDepth: time.Hour}
+		require.NoError(t, c.Check())
+	})
+	t.Run("backfill without activation", func(t *testing.T) {
+		c := &CLIConfig{L1NodeAddr: "http://x", InteropLogBackfillDepth: time.Hour}
+		require.ErrorContains(t, c.Check(), "interop.log-backfill-depth requires interop.activation-timestamp")
+	})
+	t.Run("negative depth", func(t *testing.T) {
+		c := &CLIConfig{L1NodeAddr: "http://x", InteropActivationTimestamp: ptr(1), InteropLogBackfillDepth: -time.Second}
+		require.ErrorContains(t, c.Check(), "interop.log-backfill-depth must be >= 0")
+	})
+}

--- a/op-supernode/supernode/activity/interop/algo_test.go
+++ b/op-supernode/supernode/activity/interop/algo_test.go
@@ -932,6 +932,9 @@ func (m *algoMockChain) FetchReceipts(ctx context.Context, blockID eth.BlockID) 
 func (m *algoMockChain) SyncStatus(ctx context.Context) (*eth.SyncStatus, error) {
 	return &eth.SyncStatus{}, nil
 }
+func (m *algoMockChain) TimestampToBlockNumber(ctx context.Context, ts uint64) (uint64, error) {
+	return ts, nil
+}
 func (m *algoMockChain) RewindEngine(ctx context.Context, timestamp uint64, invalidatedBlock eth.BlockRef) error {
 	return nil
 }

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -33,8 +33,15 @@ var InteropActivationTimestampFlag = &cli.Uint64Flag{
 	Value: 0,
 }
 
+// InteropLogBackfillDepthFlag extends initiating-message log ingestion backward from the L2 tip by this duration (clamped to activation). Validation still starts only beyond the local safe head.
+var InteropLogBackfillDepthFlag = &cli.DurationFlag{
+	Name:  "interop.log-backfill-depth",
+	Usage: "Duration to pre-ingest logs behind the tip before interop validation (e.g. 168h). Never loads logs before interop.activation-timestamp. Requires interop.activation-timestamp.",
+	Value: 0,
+}
+
 func init() {
-	flags.RegisterActivityFlags(InteropActivationTimestampFlag)
+	flags.RegisterActivityFlags(InteropActivationTimestampFlag, InteropLogBackfillDepthFlag)
 }
 
 // chainsReadyResult holds the parallel query results from checkChainsReady.
@@ -103,6 +110,17 @@ type Interop struct {
 
 	l1Checker    *byNumberConsistencyChecker
 	frontierView *frontierVerificationView
+
+	// logBackfillDepth enables pre-validation log ingestion (InteropELSyncBootstrap_Feature.md §3).
+	logBackfillDepth time.Duration
+
+	backfillMu          sync.Mutex
+	logBackfillComplete bool
+	backfillProgress    map[eth.ChainID]*chainBackfillProgress
+	// postBackfillLocalSafeCeiling is set when log backfill finishes: per-chain LocalSafeL2.Number
+	// at that moment. Rounds with frontier block number <= this ceiling skip full verify (logs already ingested).
+	postBackfillLocalSafeCeiling map[eth.ChainID]uint64
+	inLogBackfill                atomic.Bool
 }
 
 func (i *Interop) Name() string {
@@ -116,6 +134,7 @@ func New(
 	chains map[eth.ChainID]cc.ChainContainer,
 	dataDir string,
 	l1Source l1ByNumberSource,
+	logBackfillDepth time.Duration,
 ) *Interop {
 	verifiedDB, err := OpenVerifiedDB(dataDir)
 	if err != nil {
@@ -146,6 +165,7 @@ func New(
 		logsDBs:             logsDBs,
 		dataDir:             dataDir,
 		activationTimestamp: activationTimestamp,
+		logBackfillDepth:    logBackfillDepth,
 	}
 	// default to using the verifyInteropMessages function
 	// (can be overridden by tests)
@@ -166,6 +186,10 @@ func (i *Interop) Start(ctx context.Context) error {
 	i.ctx, i.cancel = context.WithCancel(ctx)
 	i.started = true
 	i.mu.Unlock()
+
+	if i.logBackfillDepth > 0 {
+		i.log.Info("interop log backfill depth configured", "duration", i.logBackfillDepth.String())
+	}
 
 	for {
 		select {
@@ -266,6 +290,16 @@ func (i *Interop) progressAndRecord() (bool, error) {
 		return i.applyPendingTransition(*pending)
 	}
 
+	if i.logBackfillDepth > 0 && !i.logBackfillComplete {
+		sealed, err := i.runLogBackfillStep()
+		if err != nil {
+			return false, err
+		}
+		if sealed {
+			return false, nil
+		}
+	}
+
 	output, obs, err := i.progressInterop()
 	if err != nil {
 		return false, err
@@ -311,6 +345,16 @@ func (i *Interop) progressInterop() (StepOutput, RoundObservation, error) {
 
 	if early := checkPreconditions(obs); early != nil {
 		return *early, obs, nil
+	}
+
+	if i.shouldSkipValidationUsingBackfillCeiling(obs.BlocksAtTS) {
+		skipResult := Result{
+			Timestamp:               obs.NextTimestamp,
+			L2Heads:                 cloneBlockIDMap(obs.BlocksAtTS),
+			L1Inclusion:             maxL1Inclusion(obs.L1Heads),
+			SkipPersistFrontierLogs: true,
+		}
+		return decideVerifiedResult(obs, skipResult), obs, nil
 	}
 
 	result, err := i.verify(obs.NextTimestamp, obs.BlocksAtTS)
@@ -536,8 +580,10 @@ func (i *Interop) applyPendingTransition(pending PendingTransition) (bool, error
 			}
 			return false, nil
 		}
-		if err := i.persistFrontierLogs(pending.Result.Timestamp, pending.Result.L2Heads); err != nil {
-			return false, fmt.Errorf("persist frontier logs: %w", err)
+		if !pending.Result.SkipPersistFrontierLogs {
+			if err := i.persistFrontierLogs(pending.Result.Timestamp, pending.Result.L2Heads); err != nil {
+				return false, fmt.Errorf("persist frontier logs: %w", err)
+			}
 		}
 
 		if err := i.commitVerifiedResult(pending.Result.Timestamp, pending.Result.ToVerifiedResult()); err != nil {

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -30,12 +30,13 @@ import (
 // It reduces boilerplate by handling common setup: temp directories, mock chains,
 // interop creation, context assignment, and cleanup.
 type interopTestHarness struct {
-	t              *testing.T
-	interop        *Interop
-	mocks          map[eth.ChainID]*mockChainContainer
-	activationTime uint64
-	dataDir        string
-	skipBuild      bool // for tests that need custom construction
+	t                *testing.T
+	interop          *Interop
+	mocks            map[eth.ChainID]*mockChainContainer
+	activationTime   uint64
+	logBackfillDepth time.Duration
+	dataDir          string
+	skipBuild        bool // for tests that need custom construction
 }
 
 // newInteropTestHarness creates a new test harness with sensible defaults.
@@ -53,6 +54,12 @@ func newInteropTestHarness(t *testing.T) *interopTestHarness {
 // WithActivation sets the interop activation timestamp.
 func (h *interopTestHarness) WithActivation(ts uint64) *interopTestHarness {
 	h.activationTime = ts
+	return h
+}
+
+// WithLogBackfillDepth sets op-supernode's --interop.log-backfill-depth for the built Interop.
+func (h *interopTestHarness) WithLogBackfillDepth(d time.Duration) *interopTestHarness {
+	h.logBackfillDepth = d
 	return h
 }
 
@@ -89,7 +96,7 @@ func (h *interopTestHarness) Build() *interopTestHarness {
 	for id, mock := range h.mocks {
 		chains[id] = mock
 	}
-	h.interop = New(testLogger(), h.activationTime, chains, h.dataDir, nil)
+	h.interop = New(testLogger(), h.activationTime, chains, h.dataDir, nil, h.logBackfillDepth)
 	if h.interop != nil {
 		h.interop.ctx = context.Background()
 		h.t.Cleanup(func() { _ = h.interop.Stop(context.Background()) })
@@ -129,7 +136,7 @@ func TestNew(t *testing.T) {
 				return h.WithChain(10, nil).WithChain(8453, nil).SkipBuild()
 			},
 			run: func(t *testing.T, h *interopTestHarness) {
-				interop := New(testLogger(), h.activationTime, h.Chains(), h.dataDir, nil)
+				interop := New(testLogger(), h.activationTime, h.Chains(), h.dataDir, nil, 0)
 				require.NotNil(t, interop)
 				t.Cleanup(func() { _ = interop.Stop(context.Background()) })
 
@@ -152,7 +159,7 @@ func TestNew(t *testing.T) {
 				return h.WithDataDir("/nonexistent/path").SkipBuild()
 			},
 			run: func(t *testing.T, h *interopTestHarness) {
-				interop := New(testLogger(), h.activationTime, h.Chains(), h.dataDir, nil)
+				interop := New(testLogger(), h.activationTime, h.Chains(), h.dataDir, nil, 0)
 				require.Nil(t, interop)
 			},
 		},
@@ -1127,6 +1134,68 @@ func TestProgressAndRecord(t *testing.T) {
 }
 
 // =============================================================================
+// TestLogBackfill_SealsAndSkipsVerifyUntilBeyondCeiling
+// =============================================================================
+
+func TestLogBackfill_SealsAndSkipsVerifyUntilBeyondCeiling(t *testing.T) {
+	const act = uint64(108)
+	depth := time.Second // tip time 110 -> T_lo 109; seals blocks 109..110; ceiling LocalSafe = 110
+
+	h := newInteropTestHarness(t).
+		WithActivation(act).
+		WithLogBackfillDepth(depth).
+		WithChain(10, func(m *mockChainContainer) {
+			m.currentL1 = eth.BlockRef{Number: 1, Hash: common.HexToHash("0xL1")}
+			m.syncStatusFull = &eth.SyncStatus{
+				CurrentL1:   eth.L1BlockRef{Number: 1, Hash: common.HexToHash("0xL1")},
+				UnsafeL2:    eth.L2BlockRef{Number: 110, Time: 110},
+				LocalSafeL2: eth.L2BlockRef{Number: 110, Time: 110},
+			}
+		}).
+		Build()
+
+	var verifyCalls atomic.Int32
+	h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID) (Result, error) {
+		verifyCalls.Add(1)
+		return Result{
+			Timestamp:   ts,
+			L1Inclusion: eth.BlockID{Number: 1, Hash: common.HexToHash("0xL1")},
+			L2Heads:     blocks,
+		}, nil
+	}
+	h.interop.ctx = context.Background()
+
+	for range 30 {
+		if h.interop.logBackfillComplete {
+			break
+		}
+		_, err := h.interop.progressAndRecord()
+		require.NoError(t, err)
+	}
+	require.True(t, h.interop.logBackfillComplete, "backfill should finish sealing through local safe")
+
+	chain10 := h.Mock(10)
+	latest, has := h.interop.logsDBs[chain10.id].LatestSealedBlock()
+	require.True(t, has)
+	require.Equal(t, uint64(110), latest.Number)
+
+	require.Zero(t, verifyCalls.Load())
+
+	for range 40 {
+		lastTS, ok := h.interop.verifiedDB.LastTimestamp()
+		if ok && lastTS >= 111 {
+			break
+		}
+		_, err := h.interop.progressAndRecord()
+		require.NoError(t, err)
+	}
+	lastTS, ok := h.interop.verifiedDB.LastTimestamp()
+	require.True(t, ok)
+	require.GreaterOrEqual(t, lastTS, uint64(111))
+	require.Equal(t, int32(1), verifyCalls.Load())
+}
+
+// =============================================================================
 // TestInterop_FullCycle
 // =============================================================================
 
@@ -1139,7 +1208,7 @@ func TestInterop_FullCycle(t *testing.T) {
 	mock.blockAtTimestamp = eth.L2BlockRef{Number: 500, Hash: common.HexToHash("0xL2")}
 
 	chains := map[eth.ChainID]cc.ChainContainer{mock.id: mock}
-	interop := New(testLogger(), 100, chains, dataDir, nil)
+	interop := New(testLogger(), 100, chains, dataDir, nil, 0)
 	require.NotNil(t, interop)
 	interop.ctx = context.Background()
 
@@ -1301,6 +1370,9 @@ type mockChainContainer struct {
 	optimisticL1    eth.BlockID
 	optimisticAtErr error
 
+	// If set, SyncStatus returns this instead of synthesizing from currentL1 only.
+	syncStatusFull *eth.SyncStatus
+
 	// PauseAndStopVN / Resume tracking
 	pauseAndStopVNCalls int
 	pauseAndStopVNErr   error
@@ -1409,7 +1481,10 @@ func (m *mockChainContainer) OptimisticOutputAtTimestamp(ctx context.Context, ts
 func (m *mockChainContainer) FetchReceipts(ctx context.Context, blockID eth.BlockID) (eth.BlockInfo, types.Receipts, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	ts := m.lastRequestedTimestamp
+	ts := blockID.Number
+	if ts == 0 {
+		ts = m.lastRequestedTimestamp
+	}
 	var parentHash common.Hash
 	if ts > 0 {
 		parentHash = common.BigToHash(big.NewInt(int64(ts - 1)))
@@ -1428,7 +1503,13 @@ func (m *mockChainContainer) SyncStatus(ctx context.Context) (*eth.SyncStatus, e
 	if m.currentL1Err != nil {
 		return nil, m.currentL1Err
 	}
+	if m.syncStatusFull != nil {
+		return m.syncStatusFull, nil
+	}
 	return &eth.SyncStatus{CurrentL1: m.currentL1}, nil
+}
+func (m *mockChainContainer) TimestampToBlockNumber(ctx context.Context, ts uint64) (uint64, error) {
+	return ts, nil
 }
 func (m *mockChainContainer) RewindEngine(ctx context.Context, timestamp uint64, invalidatedBlock eth.BlockRef) error {
 	m.mu.Lock()

--- a/op-supernode/supernode/activity/interop/log_backfill_bounds.go
+++ b/op-supernode/supernode/activity/interop/log_backfill_bounds.go
@@ -1,0 +1,22 @@
+package interop
+
+import "time"
+
+// LogBackfillLowerBound returns T_lo = max(T_act, T_tip - D_log) in unix seconds (L2).
+// Spec: InteropELSyncBootstrap_Feature.md §3 — never ingest logs for timestamps before activation.
+func LogBackfillLowerBound(tipTimestampUnix, activationTimestampUnix uint64, logBackfillDepth time.Duration) uint64 {
+	if logBackfillDepth <= 0 {
+		return tipTimestampUnix
+	}
+	sub := uint64(logBackfillDepth / time.Second)
+	var raw uint64
+	if tipTimestampUnix >= sub {
+		raw = tipTimestampUnix - sub
+	} else {
+		raw = 0
+	}
+	if raw < activationTimestampUnix {
+		return activationTimestampUnix
+	}
+	return raw
+}

--- a/op-supernode/supernode/activity/interop/log_backfill_bounds_test.go
+++ b/op-supernode/supernode/activity/interop/log_backfill_bounds_test.go
@@ -1,0 +1,30 @@
+// Tests: InteropELSyncBootstrap_Feature.md §3 — T_lo = max(T_act, T_tip - D_log).
+package interop
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogBackfillLowerBound(t *testing.T) {
+	t.Run("zero depth returns tip", func(t *testing.T) {
+		got := LogBackfillLowerBound(1000, 100, 0)
+		require.Equal(t, uint64(1000), got)
+	})
+	t.Run("clamps to activation when raw before activation", func(t *testing.T) {
+		// tip 200, depth 500s -> raw 0, max(100,0)=100
+		got := LogBackfillLowerBound(200, 100, 500*time.Second)
+		require.Equal(t, uint64(100), got)
+	})
+	t.Run("uses raw when above activation", func(t *testing.T) {
+		// tip 1000, depth 100s -> raw 900, max(100,900)=900
+		got := LogBackfillLowerBound(1000, 100, 100*time.Second)
+		require.Equal(t, uint64(900), got)
+	})
+	t.Run("tip below depth underflows to zero then clamps to activation", func(t *testing.T) {
+		got := LogBackfillLowerBound(50, 40, 100*time.Second)
+		require.Equal(t, uint64(40), got)
+	})
+}

--- a/op-supernode/supernode/activity/interop/log_backfill_run.go
+++ b/op-supernode/supernode/activity/interop/log_backfill_run.go
@@ -1,0 +1,207 @@
+package interop
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	cc "github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container"
+)
+
+// chainBackfillProgress tracks per-chain sequential log sealing for --interop.log-backfill-depth.
+type chainBackfillProgress struct {
+	done      bool
+	nextBlock uint64 // next L2 block number to seal; 0 = not yet computed for this chain
+}
+
+func sortedChainIDs(chains map[eth.ChainID]cc.ChainContainer) []eth.ChainID {
+	out := make([]eth.ChainID, 0, len(chains))
+	for id := range chains {
+		out = append(out, id)
+	}
+	sort.Slice(out, func(a, b int) bool { return out[a].Cmp(out[b]) < 0 })
+	return out
+}
+
+// runLogBackfillStep seals at most one L2 block across all chains (round-robin by sorted ID).
+// Returns (true, nil) if a block was sealed; (false, nil) if backfill is finished or nothing to do.
+func (i *Interop) runLogBackfillStep() (bool, error) {
+	if i.logBackfillDepth <= 0 {
+		return false, nil
+	}
+
+	i.backfillMu.Lock()
+	if i.logBackfillComplete {
+		i.backfillMu.Unlock()
+		return false, nil
+	}
+	if i.backfillProgress == nil {
+		i.backfillProgress = make(map[eth.ChainID]*chainBackfillProgress)
+	}
+	i.backfillMu.Unlock()
+
+	ctx := i.ctx
+	for _, cid := range sortedChainIDs(i.chains) {
+		sealed, err := i.trySealNextBackfillBlock(ctx, cid)
+		if err != nil {
+			return false, err
+		}
+		if sealed {
+			return true, nil
+		}
+	}
+
+	i.backfillMu.Lock()
+	allDone := true
+	for _, cid := range sortedChainIDs(i.chains) {
+		p := i.backfillProgress[cid]
+		if p == nil || !p.done {
+			allDone = false
+			break
+		}
+	}
+	i.backfillMu.Unlock()
+	if !allDone {
+		i.log.Warn("log backfill inconsistent state")
+		return false, nil
+	}
+
+	ceiling := make(map[eth.ChainID]uint64, len(i.chains))
+	for _, cid := range sortedChainIDs(i.chains) {
+		ss, err := i.chains[cid].SyncStatus(ctx)
+		if err != nil {
+			return false, fmt.Errorf("chain %s: sync status for backfill ceiling: %w", cid, err)
+		}
+		ceiling[cid] = ss.LocalSafeL2.Number
+	}
+
+	i.backfillMu.Lock()
+	i.logBackfillComplete = true
+	i.postBackfillLocalSafeCeiling = ceiling
+	i.backfillMu.Unlock()
+	i.log.Info("interop log backfill complete")
+	return false, nil
+}
+
+func (i *Interop) trySealNextBackfillBlock(ctx context.Context, cid eth.ChainID) (bool, error) {
+	chain := i.chains[cid]
+
+	i.backfillMu.Lock()
+	p := i.backfillProgress[cid]
+	if p != nil && p.done {
+		i.backfillMu.Unlock()
+		return false, nil
+	}
+	i.backfillMu.Unlock()
+
+	ss, err := chain.SyncStatus(ctx)
+	if err != nil {
+		return false, fmt.Errorf("chain %s: sync status: %w", cid, err)
+	}
+	tipTs := ss.UnsafeL2.Time
+	safeNum := ss.LocalSafeL2.Number
+
+	Tlo := LogBackfillLowerBound(tipTs, i.activationTimestamp, i.logBackfillDepth)
+	startNum, err := chain.TimestampToBlockNumber(ctx, Tlo)
+	if err != nil {
+		startNum = 0
+	}
+	if startNum > safeNum {
+		i.backfillMu.Lock()
+		if i.backfillProgress[cid] == nil {
+			i.backfillProgress[cid] = &chainBackfillProgress{done: true}
+		} else {
+			i.backfillProgress[cid].done = true
+		}
+		i.backfillMu.Unlock()
+		return false, nil
+	}
+
+	i.backfillMu.Lock()
+	p = i.backfillProgress[cid]
+	if p == nil {
+		p = &chainBackfillProgress{nextBlock: startNum}
+		i.backfillProgress[cid] = p
+	}
+	if p.done {
+		i.backfillMu.Unlock()
+		return false, nil
+	}
+	next := p.nextBlock
+	if next == 0 {
+		next = startNum
+		p.nextBlock = next
+	}
+	if next > safeNum {
+		p.done = true
+		i.backfillMu.Unlock()
+		return false, nil
+	}
+	i.backfillMu.Unlock()
+
+	out, err := chain.OutputV0AtBlockNumber(ctx, next)
+	if err != nil {
+		return false, fmt.Errorf("chain %s: output at block %d: %w", cid, next, err)
+	}
+	bid := eth.BlockID{Hash: out.BlockHash, Number: next}
+	blockInfo, receipts, err := chain.FetchReceipts(ctx, bid)
+	if err != nil {
+		return false, fmt.Errorf("chain %s: fetch receipts %d: %w", cid, next, err)
+	}
+
+	i.inLogBackfill.Store(true)
+	err = i.sealBlockDataIntoLogsDB(cid, bid, blockInfo, receipts, blockInfo.Time())
+	i.inLogBackfill.Store(false)
+	if err != nil {
+		return false, err
+	}
+
+	i.backfillMu.Lock()
+	p = i.backfillProgress[cid]
+	p.nextBlock = next + 1
+	if p.nextBlock > safeNum {
+		p.done = true
+	}
+	i.backfillMu.Unlock()
+	return true, nil
+}
+
+func (i *Interop) shouldSkipValidationUsingBackfillCeiling(blocks map[eth.ChainID]eth.BlockID) bool {
+	i.backfillMu.Lock()
+	ceiling := i.postBackfillLocalSafeCeiling
+	i.backfillMu.Unlock()
+	if ceiling == nil || len(blocks) == 0 {
+		return false
+	}
+	for cid, bid := range blocks {
+		lim, ok := ceiling[cid]
+		if !ok || bid.Number > lim {
+			return false
+		}
+	}
+	return true
+}
+
+func maxL1Inclusion(heads map[eth.ChainID]eth.BlockID) eth.BlockID {
+	var max eth.BlockID
+	first := true
+	for _, h := range heads {
+		if first || h.Number > max.Number {
+			max = h
+			first = false
+		}
+	}
+	return max
+}
+
+func cloneBlockIDMap(m map[eth.ChainID]eth.BlockID) map[eth.ChainID]eth.BlockID {
+	if m == nil {
+		return nil
+	}
+	out := make(map[eth.ChainID]eth.BlockID, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}

--- a/op-supernode/supernode/activity/interop/logdb.go
+++ b/op-supernode/supernode/activity/interop/logdb.go
@@ -101,51 +101,67 @@ var (
 // transition apply — verification itself is read-only.
 func (i *Interop) persistFrontierLogs(ts uint64, blocksAtTS map[eth.ChainID]eth.BlockID) error {
 	for chainID, blockID := range blocksAtTS {
-		chain, ok := i.chains[chainID]
-		if !ok {
-			continue
-		}
-		db := i.logsDBs[chainID]
-
-		latestBlock, hasBlocks, err := i.verifyCanAddTimestamp(chainID, db, ts, chain.BlockTime())
-		if err != nil {
+		if err := i.sealFetchedBlockIntoLogsDB(chainID, blockID, ts); err != nil {
 			return err
 		}
+	}
+	return nil
+}
 
-		blockInfo, receipts, err := chain.FetchReceipts(i.ctx, blockID)
-		if err != nil {
-			return fmt.Errorf("chain %s: failed to fetch receipts for block %v: %w", chainID, blockID, err)
+// sealFetchedBlockIntoLogsDB fetches receipts for blockID and seals logs using ts for monotonicity checks
+// (typically the interop round timestamp, or the block timestamp during backfill).
+func (i *Interop) sealFetchedBlockIntoLogsDB(chainID eth.ChainID, blockID eth.BlockID, ts uint64) error {
+	chain, ok := i.chains[chainID]
+	if !ok {
+		return nil
+	}
+	blockInfo, receipts, err := chain.FetchReceipts(i.ctx, blockID)
+	if err != nil {
+		return fmt.Errorf("chain %s: failed to fetch receipts for block %v: %w", chainID, blockID, err)
+	}
+	return i.sealBlockDataIntoLogsDB(chainID, blockID, blockInfo, receipts, ts)
+}
+
+// sealBlockDataIntoLogsDB seals logs for an already-fetched block using ts for verifyCanAddTimestamp.
+func (i *Interop) sealBlockDataIntoLogsDB(chainID eth.ChainID, blockID eth.BlockID, blockInfo eth.BlockInfo, receipts gethTypes.Receipts, ts uint64) error {
+	chain, ok := i.chains[chainID]
+	if !ok {
+		return nil
+	}
+	db := i.logsDBs[chainID]
+
+	latestBlock, hasBlocks, err := i.verifyCanAddTimestamp(chainID, db, ts, chain.BlockTime())
+	if err != nil {
+		return err
+	}
+
+	if hasBlocks {
+		if latestBlock.Number > blockID.Number {
+			seal, err := db.FindSealedBlock(blockID.Number)
+			if err == nil && seal.Hash == blockID.Hash {
+				return nil
+			}
+			return fmt.Errorf("chain %s: logsDB has stale data at height %d: %w",
+				chainID, blockID.Number, ErrStaleLogsDB)
+		}
+		if latestBlock.Number == blockID.Number {
+			if latestBlock.Hash == blockID.Hash {
+				return nil
+			}
+			return fmt.Errorf("chain %s: logsDB has block %s at height %d, expected %s: %w",
+				chainID, latestBlock.Hash, latestBlock.Number, blockID.Hash, ErrStaleLogsDB)
 		}
 
-		if hasBlocks {
-			if latestBlock.Number > blockID.Number {
-				seal, err := db.FindSealedBlock(blockID.Number)
-				if err == nil && seal.Hash == blockID.Hash {
-					continue
-				}
-				return fmt.Errorf("chain %s: logsDB has stale data at height %d: %w",
-					chainID, blockID.Number, ErrStaleLogsDB)
-			}
-			if latestBlock.Number == blockID.Number {
-				if latestBlock.Hash == blockID.Hash {
-					continue
-				}
-				return fmt.Errorf("chain %s: logsDB has block %s at height %d, expected %s: %w",
-					chainID, latestBlock.Hash, latestBlock.Number, blockID.Hash, ErrStaleLogsDB)
-			}
-
-			if blockInfo.ParentHash() != latestBlock.Hash {
-				return fmt.Errorf("chain %s: block %d parent hash %s does not match logsDB last sealed block hash %s: %w",
-					chainID, blockID.Number, blockInfo.ParentHash(), latestBlock.Hash, ErrParentHashMismatch)
-			}
-		}
-
-		isFirstBlock := !hasBlocks
-		if err := i.processBlockLogs(db, blockInfo, receipts, isFirstBlock); err != nil {
-			return fmt.Errorf("chain %s: failed to process block logs for block %d: %w", chainID, blockID.Number, err)
+		if blockInfo.ParentHash() != latestBlock.Hash {
+			return fmt.Errorf("chain %s: block %d parent hash %s does not match logsDB last sealed block hash %s: %w",
+				chainID, blockID.Number, blockInfo.ParentHash(), latestBlock.Hash, ErrParentHashMismatch)
 		}
 	}
 
+	isFirstBlock := !hasBlocks
+	if err := i.processBlockLogs(db, blockInfo, receipts, isFirstBlock); err != nil {
+		return fmt.Errorf("chain %s: failed to process block logs for block %d: %w", chainID, blockID.Number, err)
+	}
 	return nil
 }
 
@@ -154,9 +170,10 @@ func (i *Interop) verifyCanAddTimestamp(chainID eth.ChainID, db LogsDB, ts uint6
 
 	// If no blocks in DB:
 	// - At activation timestamp: OK, proceed to load the first block
-	// - Not at activation timestamp: ERROR, we're missing data
+	// - During log backfill (inLogBackfill): allow first seal at any ts >= activation
+	// - Otherwise: ERROR, we're missing data
 	if !hasBlocks {
-		if ts == i.activationTimestamp {
+		if ts == i.activationTimestamp || (i.inLogBackfill.Load() && ts >= i.activationTimestamp) {
 			return eth.BlockID{}, hasBlocks, nil
 		}
 		return eth.BlockID{}, hasBlocks, fmt.Errorf("chain %s: logsDB is empty but expected blocks before timestamp %d: %w",

--- a/op-supernode/supernode/activity/interop/types.go
+++ b/op-supernode/supernode/activity/interop/types.go
@@ -29,6 +29,8 @@ type Result struct {
 	L1Inclusion  eth.BlockID                 `json:"l1Inclusion"`
 	L2Heads      map[eth.ChainID]eth.BlockID `json:"l2Heads"`
 	InvalidHeads map[eth.ChainID]InvalidHead `json:"invalidHeads"`
+	// SkipPersistFrontierLogs skips sealing frontier logs on advance (already ingested, e.g. log backfill).
+	SkipPersistFrontierLogs bool `json:"-"`
 }
 
 // PendingTransition is the generic write-ahead-log entry for an effectful

--- a/op-supernode/supernode/activity/supernode/supernode_test.go
+++ b/op-supernode/supernode/activity/supernode/supernode_test.go
@@ -117,6 +117,10 @@ func (m *mockCC) PruneDeniedAtOrAfterTimestamp(timestamp uint64) (map[uint64][]c
 
 func (m *mockCC) SetResetCallback(cb cc.ResetCallback) {}
 
+func (m *mockCC) TimestampToBlockNumber(ctx context.Context, ts uint64) (uint64, error) {
+	return ts, nil
+}
+
 var _ cc.ChainContainer = (*mockCC)(nil)
 
 func TestSupernode_SyncStatus_Succeeds(t *testing.T) {

--- a/op-supernode/supernode/activity/superroot/superroot_test.go
+++ b/op-supernode/supernode/activity/superroot/superroot_test.go
@@ -118,6 +118,10 @@ func (m *mockCC) IsDenied(height uint64, payloadHash common.Hash) (bool, error) 
 }
 func (m *mockCC) SetResetCallback(cb cc.ResetCallback) {}
 
+func (m *mockCC) TimestampToBlockNumber(ctx context.Context, ts uint64) (uint64, error) {
+	return ts, nil
+}
+
 var _ cc.ChainContainer = (*mockCC)(nil)
 
 func TestSuperroot_AtTimestamp_Succeeds(t *testing.T) {

--- a/op-supernode/supernode/chain_container/chain_container.go
+++ b/op-supernode/supernode/chain_container/chain_container.go
@@ -37,6 +37,8 @@ type ChainContainer interface {
 
 	ID() eth.ChainID
 	LocalSafeBlockAtTimestamp(ctx context.Context, ts uint64) (eth.L2BlockRef, error)
+	// TimestampToBlockNumber maps an L2 unix timestamp to the L2 block number (rollup derivation).
+	TimestampToBlockNumber(ctx context.Context, ts uint64) (uint64, error)
 	SyncStatus(ctx context.Context) (*eth.SyncStatus, error)
 	VerifiedAt(ctx context.Context, ts uint64) (l2, l1 eth.BlockID, err error)
 	OptimisticAt(ctx context.Context, ts uint64) (l2, l1 eth.BlockID, err error)

--- a/op-supernode/supernode/supernode.go
+++ b/op-supernode/supernode/supernode.go
@@ -99,7 +99,7 @@ func New(ctx context.Context, log gethlog.Logger, version string, requestStop co
 	// Initialize interop activity if the activation timestamp is set (non-nil)
 	// If it's nil, don't start interop. If it's non-nil (including 0), do start it.
 	if cfg.InteropActivationTimestamp != nil {
-		interopActivity := interop.New(log.New("activity", "interop"), *cfg.InteropActivationTimestamp, s.chains, cfg.DataDir, s.l1Client)
+		interopActivity := interop.New(log.New("activity", "interop"), *cfg.InteropActivationTimestamp, s.chains, cfg.DataDir, s.l1Client, cfg.InteropLogBackfillDepth)
 		s.activities = append(s.activities, interopActivity)
 		for _, chain := range s.chains {
 			chain.RegisterVerifier(interopActivity)


### PR DESCRIPTION
# Tool Use Notice
Generated via Optimisim+Custom TDD Feature development.

Current Status: Author Self-Review.

## Summary
Two related pieces for EL-sync / interop bootstrap:
1. **op-node — `offset_derived`:** After EL sync completes, retract **safe**, **finalized**, and **local safe** from the unsafe tip by `floor(offset_derived / L2 block time)` parent steps. **Unsafe** stays on the tip. Same offset logic is used on `FindL2Heads` recovery when recovering EL-sync heads.
2. **op-supernode — interop log backfill:** Optional `--interop.log-backfill-depth` pre-ingests initiating logs from `max(interop activation, tip − depth)` through each chain’s **local safe**, never before activation. **Full message validation** (and cycle checks) is skipped only while every chain’s frontier block at the round is still at or below a **snapshot** of `LocalSafeL2.Number` taken when backfill finishes—so a moving, far-ahead local safe does not incorrectly skip validation during timestamp catch-up. Advances in that phase use `SkipPersistFrontierLogs` and skip `persistFrontierLogs` on apply.
## Config / CLI
- **op-node:** `--syncmode.offset-derived` / `OP_NODE_SYNCMODE_OFFSET_DERIVED` (duration; parsed like other duration flags).
- **op-supernode:** `--interop.log-backfill-depth` (requires interop activation timestamp); validated in config tests.
## Implementation notes
- **op-node:** `rollup/sync/offset_derived.go` (`DerivedBlockSteps`, `L2AncestorByN`), `sync.Config`, engine FCU path, `rollup/sync/start.go` recovery, tests in `offset_derived_test.go` and `engine_el_sync_offset_test.go`.
- **op-supernode:** `ChainContainer.TimestampToBlockNumber`, `log_backfill_bounds.go`, `log_backfill_run.go`, `logdb.go` sealing helpers + backfill timestamp rules, `interop.go` gating + `applyPendingTransition` skip for frontier log persist.
## Testing
- `go test ./op-node/rollup/sync/... ./op-node/rollup/engine/...` (as appropriate for touched packages)
- `go test ./op-supernode/...`
## Related
- op-node EL-sync UX / correctness (e.g. ethereum-optimism/optimism#17631 context, if applicable).
