### PR TITLE
fix(kona): fix stale reth path references in kona tests justfile

### DIFF
--- a/rust/kona/tests/justfile
+++ b/rust/kona/tests/justfile
@@ -15,7 +15,7 @@ build-devnet BINARY:
 
 build-reth:
   #!/bin/bash
-  cd {{SOURCE}}/../../reth && cargo build --bin op-reth -p op-reth
+  cd {{SOURCE}}/../../op-reth && cargo build --bin op-reth -p op-reth
 
 build-kona PROFILE="release":
   #!/bin/bash
@@ -45,7 +45,7 @@ acceptance-tests-run CL_TYPE="kona-node" EL_TYPE="op-reth":
 
   if [ "{{EL_TYPE}}" = "op-reth" ] ; then
     echo "Running acceptance tests for op-reth"
-    export OP_RETH_EXEC_PATH="{{SOURCE}}/../../reth/target/debug/op-reth"
+    export OP_RETH_EXEC_PATH="{{SOURCE}}/../../target/debug/op-reth"
   fi
 
   echo "Running acceptance tests for {{CL_TYPE}} with {{EL_TYPE}}..."
@@ -82,7 +82,7 @@ test-e2e-sysgo-run BINARY="node" GO_PKG_NAME="node/common" DEVNET="simple-kona" 
           export KONA_NODE_EXEC_PATH="{{SOURCE}}/../target/debug/kona-node"
         fi
         if [ $OP_RETH_EXEC_PATH == "" ]; then
-          export OP_RETH_EXEC_PATH="{{SOURCE}}/../../reth/target/debug/op-reth"
+          export OP_RETH_EXEC_PATH="{{SOURCE}}/../../target/debug/op-reth"
         fi
     else
         echo "Invalid BINARY specified. Must be 'node'."
@@ -153,7 +153,7 @@ long-running-test FILTER="" OUTPUT_LOGS_DIR="":
     export OP_VALIDATOR_WITH_GETH=0
 
     export KONA_NODE_EXEC_PATH="{{SOURCE}}/../target/debug/kona-node"
-    export OP_RETH_EXEC_PATH="{{SOURCE}}/../../reth/target/debug/op-reth"
+    export OP_RETH_EXEC_PATH="{{SOURCE}}/../../target/debug/op-reth"
     export DEVSTACK_ORCHESTRATOR=sysgo
     echo "Building kona-node..."
     just build-kona


### PR DESCRIPTION
## Summary

- Fix 4 broken path references in `rust/kona/tests/justfile` left over from the workspace unification in #19034
- `build-reth` recipe: `cd ../../reth` → `cd ../../op-reth` (directory doesn't exist)
- `OP_RETH_EXEC_PATH` in 3 recipes: `../../reth/target/debug/op-reth` → `../../target/debug/op-reth` (unified workspace builds to `rust/target/`, not `rust/op-reth/target/`)

## Why CI wasn't failing

CI ([`rust-e2e.yml`](https://github.com/ethereum-optimism/optimism/blob/develop/.circleci/continue/rust-e2e.yml#L162)) pre-sets `OP_RETH_EXEC_PATH` to the correct `$WD/rust/target/release/op-reth` before calling `just test-e2e-sysgo-run`, so the fallback paths in the justfile are never triggered. CI also never calls `build-reth` directly — it builds op-reth as a separate `rust-build` step. The broken paths only affect **local development** workflows: `just build-reth`, `just acceptance-tests`, `just test-e2e-sysgo`, and `just long-running-test`.

No CI failure log exists for this bug since CI never exercises these code paths.

## Test plan

- [x] Ran `cd rust/kona && just build-reth` — successfully builds op-reth
- [x] Verified binary appears at `rust/target/debug/op-reth` (the path `OP_RETH_EXEC_PATH` now points to)
- [x] Confirmed no remaining `../../reth` references in the file

Related: #19569, #19929 (same class of bug in `rust/op-reth/crates/tests/justfile`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)