### PR TITLE
Revert "ci: gate contract feature matrix jobs on path changes"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,8 +107,6 @@ workflows:
             .* c-github-event-base64 << pipeline.parameters.github-event-base64 >> .circleci/continue/main.yml
             .* c-go-cache-version << pipeline.parameters.go-cache-version >> .circleci/continue/main.yml
             rust/.* c-rust_files_changed true .circleci/continue/main.yml
-            (packages/contracts-bedrock|\.circleci|\.github|ops/check-changed)/.* c-contracts_changed true .circleci/continue/main.yml
-            ^(package\.json|mise\.toml)$ c-contracts_changed true .circleci/continue/main.yml
             ^(?!docs/public-docs/).+ c-non_docs_changes true .circleci/continue/main.yml
 
             # Docs CI — trigger on docs/public-docs/ changes

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -68,11 +68,6 @@ parameters:
   c-rust_files_changed:
     type: boolean
     default: false
-  # Set to true by path-filtering when contracts or rebuild-all paths change.
-  # When false, contract feature matrix jobs are skipped entirely.
-  c-contracts_changed:
-    type: boolean
-    default: false
   # Set to true by path-filtering when files outside docs/public-docs/ change.
   # When false, the main workflow is skipped entirely (docs-only PR).
   c-non_docs_changes:
@@ -154,7 +149,7 @@ parameters:
     default: "v0.0"
 
 orbs:
-  utils: ethereum-optimism/circleci-utils@1.0.26
+  utils: ethereum-optimism/circleci-utils@1.0.25
   go: circleci/go@1.8.0
   gcp-cli: circleci/gcp-cli@3.0.1
   slack: circleci/slack@6.0.0
@@ -1518,19 +1513,6 @@ jobs:
           command: just update-selectors
           working_directory: packages/contracts-bedrock
 
-  required-contracts-ci:
-    docker:
-      - image: <<pipeline.parameters.c-default_docker_image>>
-    resource_class: small
-    parameters:
-      always-succed:
-        description: Force always succed
-        type: boolean
-        default: false
-    steps:
-      - utils/ci-gate:
-          always-succeed: << parameters.always-succed >>
-
   contracts-bedrock-checks-fast:
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
@@ -2448,6 +2430,151 @@ workflows:
           context:
             - circleci-repo-readonly-authenticated-github-token
             - slack
+      - contracts-bedrock-tests:
+          # Heavily fuzz any fuzz tests within added or modified test files.
+          name: contracts-bedrock-tests-heavy-fuzz-modified <<matrix.features>>
+          test_list: git diff origin/develop...HEAD --name-only --diff-filter=AM -- './test/**/*.t.sol' | sed 's|packages/contracts-bedrock/||'
+          test_timeout: 1h
+          test_profile: ciheavy
+          features: <<matrix.features>>
+          matrix:
+            parameters:
+              features: &features_matrix
+                - main
+                - CUSTOM_GAS_TOKEN
+                - OPTIMISM_PORTAL_INTEROP
+                - OPCM_V2
+                - OPCM_V2,CUSTOM_GAS_TOKEN
+                - OPCM_V2,OPTIMISM_PORTAL_INTEROP
+                - OPCM_V2,ZK_DISPUTE_GAME
+                - OPCM_V2,CANNON_KONA
+                - OPCM_V2,SUPER_ROOT_GAMES_MIGRATION
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+            - slack
+      # On PRs, run tests with lite profile for better build times.
+      - contracts-bedrock-tests:
+          name: contracts-bedrock-tests <<matrix.features>>
+          test_list: find test -name "*.t.sol"
+          test_profile: liteci
+          features: <<matrix.features>>
+          matrix:
+            parameters:
+              features: *features_matrix
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+            - slack
+          check_changed_patterns: contracts-bedrock,op-node
+          filters:
+            branches:
+              ignore: develop
+      # On develop, run tests with ci profile to mirror production.
+      - contracts-bedrock-tests:
+          name: contracts-bedrock-tests-develop <<matrix.features>>
+          test_list: find test -name "*.t.sol"
+          test_profile: ci
+          features: <<matrix.features>>
+          matrix:
+            parameters:
+              features: *features_matrix
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+            - slack
+          check_changed_patterns: contracts-bedrock,op-node
+          filters:
+            branches:
+              only: develop
+      - contracts-bedrock-coverage:
+          # Generate coverage reports.
+          name: contracts-bedrock-coverage <<matrix.features>>
+          test_timeout: 1h
+          test_profile: cicoverage
+          features: <<matrix.features>>
+          matrix:
+            parameters:
+              features: *features_matrix
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+            - slack
+      # On PRs, run upgrade tests with lite profile for better build times.
+      - contracts-bedrock-tests-upgrade:
+          name: contracts-bedrock-tests-upgrade op-mainnet <<matrix.features>>
+          fork_op_chain: op
+          fork_base_chain: mainnet
+          fork_base_rpc: https://ci-mainnet-l1-archive.optimism.io
+          test_profile: liteci
+          features: <<matrix.features>>
+          matrix:
+            parameters:
+              features: *features_matrix
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+            - slack
+          filters:
+            branches:
+              ignore: develop
+      # On develop, run upgrade tests with ci profile to mirror production.
+      - contracts-bedrock-tests-upgrade:
+          name: contracts-bedrock-tests-upgrade-develop op-mainnet <<matrix.features>>
+          fork_op_chain: op
+          fork_base_chain: mainnet
+          fork_base_rpc: https://ci-mainnet-l1-archive.optimism.io
+          test_profile: ci
+          features: <<matrix.features>>
+          matrix:
+            parameters:
+              features: *features_matrix
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+            - slack
+          filters:
+            branches:
+              only: develop
+      # On PRs, run chain-specific upgrade tests with lite profile for better build times.
+      - contracts-bedrock-tests-upgrade:
+          name: contracts-bedrock-tests-upgrade <<matrix.fork_op_chain>>-mainnet
+          fork_op_chain: <<matrix.fork_op_chain>>
+          fork_base_chain: mainnet
+          fork_base_rpc: https://ci-mainnet-l1-archive.optimism.io
+          test_profile: liteci
+          matrix:
+            parameters:
+              fork_op_chain: ["op", "ink", "unichain"]
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+            - slack
+          filters:
+            branches:
+              ignore: develop
+      # On develop, run chain-specific upgrade tests with ci profile to mirror production.
+      - contracts-bedrock-tests-upgrade:
+          name: contracts-bedrock-tests-upgrade-develop <<matrix.fork_op_chain>>-mainnet
+          fork_op_chain: <<matrix.fork_op_chain>>
+          fork_base_chain: mainnet
+          fork_base_rpc: https://ci-mainnet-l1-archive.optimism.io
+          test_profile: ci
+          matrix:
+            parameters:
+              fork_op_chain: ["op", "ink", "unichain"]
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+            - slack
+          filters:
+            branches:
+              only: develop
+      # Always run L2 fork tests with ci profile
+      - contracts-bedrock-tests-l2-fork:
+          name: contracts-bedrock-tests-l2-fork op-mainnet
+          fork_op_chain: op-mainnet
+          l2_fork_rpc: https://op-mainnet-rpc.optimism.io/
+          l2_fork_block_number: latest
+          test_profile: ci
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+            - slack
+      - contracts-bedrock-checks-fast:
+          context:
+            - circleci-repo-readonly-authenticated-github-token
       - l2-chains-sync-check:
           context:
             - circleci-repo-readonly-authenticated-github-token
@@ -2693,7 +2820,12 @@ workflows:
             - go-lint: terminal
             - semgrep-scan-local: terminal
             - go-tests-short: terminal
+            - contracts-bedrock-coverage main: terminal
+            - contracts-bedrock-tests main: terminal
+            - contracts-bedrock-tests-heavy-fuzz-modified main: terminal
+            - contracts-bedrock-tests-upgrade op-mainnet main: terminal
             - memory-all: terminal
+            - contracts-bedrock-checks-fast: terminal
           context:
             - circleci-api-token
           filters:
@@ -3037,204 +3169,4 @@ workflows:
             - circleci-repo-readonly-authenticated-github-token
             - slack
 
-  contracts-feature-tests:
-    when:
-      or:
-        - and:
-            - equal: ["webhook", << pipeline.trigger_source >>]
-            - << pipeline.parameters.c-contracts_changed >>
-            - << pipeline.parameters.c-non_docs_changes >>
-        # Always run on develop (mirrors previous check-changed whitelist behavior)
-        - and:
-            - equal: ["webhook", << pipeline.trigger_source >>]
-            - equal: ["develop", << pipeline.git.branch >>]
-            - << pipeline.parameters.c-non_docs_changes >>
-        # Always run in merge queue
-        - and:
-            - equal: ["webhook", << pipeline.trigger_source >>]
-            - matches:
-                pattern: "^gh-readonly-queue/"
-                value: << pipeline.git.branch >>
-            - << pipeline.parameters.c-non_docs_changes >>
-        - and:
-            - equal: [true, <<pipeline.parameters.c-main_dispatch>>]
-            - equal: ["api", << pipeline.trigger_source >>]
-    jobs:
-      - contracts-bedrock-tests:
-          # Heavily fuzz any fuzz tests within added or modified test files.
-          name: contracts-bedrock-tests-heavy-fuzz-modified <<matrix.features>>
-          test_list: git diff origin/develop...HEAD --name-only --diff-filter=AM -- './test/**/*.t.sol' | sed 's|packages/contracts-bedrock/||'
-          test_timeout: 1h
-          test_profile: ciheavy
-          features: <<matrix.features>>
-          matrix:
-            parameters:
-              features: &features_matrix
-                - main
-                - CUSTOM_GAS_TOKEN
-                - OPTIMISM_PORTAL_INTEROP
-                - OPCM_V2
-                - OPCM_V2,CUSTOM_GAS_TOKEN
-                - OPCM_V2,OPTIMISM_PORTAL_INTEROP
-                - OPCM_V2,ZK_DISPUTE_GAME
-                - OPCM_V2,CANNON_KONA
-                - OPCM_V2,SUPER_ROOT_GAMES_MIGRATION
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - slack
-      # On PRs, run tests with lite profile for better build times.
-      - contracts-bedrock-tests:
-          name: contracts-bedrock-tests <<matrix.features>>
-          test_list: find test -name "*.t.sol"
-          test_profile: liteci
-          features: <<matrix.features>>
-          matrix:
-            parameters:
-              features: *features_matrix
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - slack
-          filters:
-            branches:
-              ignore: develop
-      # On develop, run tests with ci profile to mirror production.
-      - contracts-bedrock-tests:
-          name: contracts-bedrock-tests-develop <<matrix.features>>
-          test_list: find test -name "*.t.sol"
-          test_profile: ci
-          features: <<matrix.features>>
-          matrix:
-            parameters:
-              features: *features_matrix
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - slack
-          filters:
-            branches:
-              only: develop
-      - contracts-bedrock-coverage:
-          # Generate coverage reports.
-          name: contracts-bedrock-coverage <<matrix.features>>
-          test_timeout: 1h
-          test_profile: cicoverage
-          features: <<matrix.features>>
-          matrix:
-            parameters:
-              features: *features_matrix
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - slack
-      # On PRs, run upgrade tests with lite profile for better build times.
-      - contracts-bedrock-tests-upgrade:
-          name: contracts-bedrock-tests-upgrade op-mainnet <<matrix.features>>
-          fork_op_chain: op
-          fork_base_chain: mainnet
-          fork_base_rpc: https://ci-mainnet-l1-archive.optimism.io
-          test_profile: liteci
-          features: <<matrix.features>>
-          matrix:
-            parameters:
-              features: *features_matrix
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - slack
-          filters:
-            branches:
-              ignore: develop
-      # On develop, run upgrade tests with ci profile to mirror production.
-      - contracts-bedrock-tests-upgrade:
-          name: contracts-bedrock-tests-upgrade-develop op-mainnet <<matrix.features>>
-          fork_op_chain: op
-          fork_base_chain: mainnet
-          fork_base_rpc: https://ci-mainnet-l1-archive.optimism.io
-          test_profile: ci
-          features: <<matrix.features>>
-          matrix:
-            parameters:
-              features: *features_matrix
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - slack
-          filters:
-            branches:
-              only: develop
-      # On PRs, run chain-specific upgrade tests with lite profile for better build times.
-      - contracts-bedrock-tests-upgrade:
-          name: contracts-bedrock-tests-upgrade <<matrix.fork_op_chain>>-mainnet
-          fork_op_chain: <<matrix.fork_op_chain>>
-          fork_base_chain: mainnet
-          fork_base_rpc: https://ci-mainnet-l1-archive.optimism.io
-          test_profile: liteci
-          matrix:
-            parameters:
-              fork_op_chain: ["op", "ink", "unichain"]
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - slack
-          filters:
-            branches:
-              ignore: develop
-      # On develop, run chain-specific upgrade tests with ci profile to mirror production.
-      - contracts-bedrock-tests-upgrade:
-          name: contracts-bedrock-tests-upgrade-develop <<matrix.fork_op_chain>>-mainnet
-          fork_op_chain: <<matrix.fork_op_chain>>
-          fork_base_chain: mainnet
-          fork_base_rpc: https://ci-mainnet-l1-archive.optimism.io
-          test_profile: ci
-          matrix:
-            parameters:
-              fork_op_chain: ["op", "ink", "unichain"]
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - slack
-          filters:
-            branches:
-              only: develop
-      # Always run L2 fork tests with ci profile
-      - contracts-bedrock-tests-l2-fork:
-          name: contracts-bedrock-tests-l2-fork op-mainnet
-          fork_op_chain: op-mainnet
-          l2_fork_rpc: https://op-mainnet-rpc.optimism.io/
-          l2_fork_block_number: latest
-          test_profile: ci
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - slack
-      - contracts-bedrock-checks-fast:
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - slack
-      # -----------------------------------------------------------------------
-      # Required gate — fans in on required contract CI jobs
-      # -----------------------------------------------------------------------
-      - required-contracts-ci:
-          requires:
-            - contracts-bedrock-tests main: terminal
-            - contracts-bedrock-tests-heavy-fuzz-modified main: terminal
-            - contracts-bedrock-coverage main: terminal
-            - contracts-bedrock-tests-upgrade op-mainnet main: terminal
-            - contracts-bedrock-checks-fast: terminal
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-
   # ============================================================================
-  # Required contracts CI gate (skip) — runs when no contract changes
-  # Produces the required-contracts-ci status so the merge queue doesn't hang.
-  # ============================================================================
-  contracts-feature-tests-short:
-    when:
-      and:
-        - equal: ["webhook", << pipeline.trigger_source >>]
-        - not: << pipeline.parameters.c-contracts_changed >>
-        - << pipeline.parameters.c-non_docs_changes >>
-        - not:
-            equal: ["develop", << pipeline.git.branch >>]
-        - not:
-            matches:
-              pattern: "^gh-readonly-queue/"
-              value: << pipeline.git.branch >>
-    jobs:
-      - required-contracts-ci:
-          always-succed: true
-          context:
-            - circleci-repo-readonly-authenticated-github-token

--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -4,7 +4,7 @@ version: 2.1
 # This file contains all Rust CI commands, parameterized jobs, crate-specific jobs, and workflows.
 
 orbs:
-  utils: ethereum-optimism/circleci-utils@1.0.26
+  utils: ethereum-optimism/circleci-utils@1.0.25
   gcp-cli: circleci/gcp-cli@3.0.1
   codecov: codecov/codecov@5.0.3
 


### PR DESCRIPTION
Reverts ethereum-optimism/optimism#19780 temporarily

Some PRs that don't touch any contracts are expecting CI contract jobs as required checks that aren't currently being run. `required-contracts-ci` is also always failing (should be fixed by a follow up PR soon)

We can un-revert this afterwards, or feel free to close this PR if this is the wrong workaround