### PR TITLE
fix(op-acceptance-tests): increase CrossSafe sync timeout for EL Sync tests

### DIFF
--- a/op-acceptance-tests/tests/safeheaddb_elsync/safeheaddb_test.go
+++ b/op-acceptance-tests/tests/safeheaddb_elsync/safeheaddb_test.go
@@ -12,12 +12,22 @@ import (
 )
 
 func newSingleChainMultiNodeELSync(t devtest.T) *presets.SingleChainMultiNode {
-	return presets.NewSingleChainMultiNode(t,
+	// Use WithoutCheck because the default preset sync check uses 30 attempts
+	// (60s) for CrossSafe matching, which is insufficient for EL Sync mode.
+	// EL Sync must complete the initial sync phase before derivation can start,
+	// so CrossSafe takes longer to advance than in CL Sync mode.
+	sys := presets.NewSingleChainMultiNodeWithoutCheck(t,
 		presets.WithGlobalL2CLOption(sysgo.L2CLOptionFn(func(p devtest.T, _ sysgo.ComponentTarget, cfg *sysgo.L2CLConfig) {
 			cfg.VerifierSyncMode = sync.ELSync
 			cfg.SafeDBPath = p.TempDir()
 		})),
 	)
+	// Run the initial sync check with 60 attempts (120s) to accommodate EL Sync.
+	dsl.CheckAll(t,
+		sys.L2CLB.MatchedFn(sys.L2CL, types.CrossSafe, 60),
+		sys.L2CLB.MatchedFn(sys.L2CL, types.LocalUnsafe, 60),
+	)
+	return sys
 }
 
 func TestTruncateDatabaseOnELResync(gt *testing.T) {


### PR DESCRIPTION
## Summary

- Fix flaky `TestTruncateDatabaseOnELResync` and `TestNotTruncateDatabaseOnRestartWithExistingDatabase` by switching from `NewSingleChainMultiNode` (hardcoded 30-attempt/60s sync check) to `NewSingleChainMultiNodeWithoutCheck` + explicit 60-attempt (120s) sync check
- In EL Sync mode, derivation is blocked during the initial EL sync phase (`IsEngineInitialELSyncing` → `SyncStep` returns early), so CrossSafe takes longer to advance than in CL Sync mode
- Under CI resource contention, the three sequential phases (EL sync → derivation → supervisor confirmation) exceed the default 60s timeout

## Context

The default `NewSingleChainMultiNode` preset runs an initial sync check at `singlechain_from_runtime.go:51` with 30 attempts (60s). This is fine for CL Sync mode where derivation starts immediately, but insufficient for EL Sync mode. Every other EL Sync multi-node test already uses a `WithoutCheck` variant:

| Test | Preset | Sync Mode |
|------|--------|-----------|
| `depreqres/reqressyncdisabled/depreqres_test.go` | `NewSingleChainMultiNodeWithoutCheck` | EL Sync |
| `depreqres/reqressyncdisabled/divergence/divergence_test.go` | `NewSingleChainMultiNodeWithoutP2PWithoutCheck` | EL Sync |
| `depreqres/common/common.go` (×2) | `NewSingleChainMultiNodeWithoutCheck` | EL Sync |
| `sync/elsync/gap_elp2p/init_test.go` | `NewSingleChainMultiNodeWithoutP2PWithoutCheck` | EL Sync |
| `sync/elsync/gap_clp2p/init_test.go` | `NewSingleChainMultiNodeWithoutP2PWithoutCheck` | EL Sync |
| **`safeheaddb_elsync` (this PR)** | **`NewSingleChainMultiNodeWithoutCheck`** | **EL Sync** |

The only remaining caller of `NewSingleChainMultiNode` (with check) is `safeheaddb_clsync`, which uses CL Sync mode and is not affected.

## CI evidence

- [Job 4730402](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/121646/workflows/ce5a39a0-34f4-49e2-ac4d-73dfad0b8596/jobs/4730402) — `base=0 ref=29`, CrossSafe never advanced (Apr 2)
- [Job 4766480](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/122129/workflows/a709c1b8-d9be-4325-bbfb-77d0a0efea2d/jobs/4766480) — same pattern (Apr 8)

Closes #19897

## Test plan

- [x] Compiles cleanly (`go build ./op-acceptance-tests/tests/safeheaddb_elsync/...`)
- [x] Local run confirms the initial CrossSafe sync check passes with the increased timeout (matched at `ref=5` in ~8s)
- [x] CI acceptance tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)