### PR TITLE
fix(kona/protocol): add TxGases span decode error for gas varints

### DIFF
--- a/rust/kona/crates/protocol/protocol/src/batch/errors.rs
+++ b/rust/kona/crates/protocol/protocol/src/batch/errors.rs
@@ -72,6 +72,9 @@ pub enum SpanDecodingError {
     /// Failed to decode transaction nonces
     #[error("Failed to decode transaction nonces")]
     TxNonces,
+    /// Failed to decode transaction gas limits
+    #[error("Failed to decode transaction gas limits")]
+    TxGases,
     /// Mismatch in length between the transaction type and signature arrays in a span batch
     /// transaction payload.
     #[error("Mismatch in length between the transaction type and signature arrays")]

--- a/rust/kona/crates/protocol/protocol/src/batch/transactions.rs
+++ b/rust/kona/crates/protocol/protocol/src/batch/transactions.rs
@@ -185,7 +185,7 @@ impl SpanBatchTransactions {
         let mut gases = Vec::with_capacity(self.total_block_tx_count as usize);
         for _ in 0..self.total_block_tx_count {
             let (gas, remaining) = unsigned_varint::decode::u64(r)
-                .map_err(|_| SpanBatchError::Decoding(SpanDecodingError::TxNonces))?;
+                .map_err(|_| SpanBatchError::Decoding(SpanDecodingError::TxGases))?;
             gases.push(gas);
             *r = remaining;
         }


### PR DESCRIPTION
## Summary

Rebase of #19874 onto current `develop` to fix CI failures.

Original PR by @cuiweixie: Adds a `TxGases` variant to `SpanDecodingError` and fixes the gas varint decoding to use it instead of incorrectly reporting `TxNonces`.

- Cherry-picked the original commit onto current develop HEAD
- No code changes from the original PR

## Test plan

- [x] CI passes (original PR was behind develop)