### PR TITLE
op-node(p2p): reactive runtime config reload on signer mismatch

### DIFF
--- a/op-node/config/config.go
+++ b/op-node/config/config.go
@@ -65,6 +65,9 @@ type Config struct {
 	// but if log-events are not coming in (e.g. not syncing blocks) then the reload ensures the config stays accurate.
 	RuntimeConfigReloadInterval time.Duration
 
+	// ExpectUnsafeSignerChange enables reactive runtime config reloading on p2p signature mismatch.
+	ExpectUnsafeSignerChange bool
+
 	// Optional
 	Tracer tracer.Tracer
 

--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -306,6 +306,12 @@ var (
 		Value:    time.Minute * 10,
 		Category: L1RPCCategory,
 	}
+	ExpectUnsafeSignerChangeFlag = &cli.BoolFlag{
+		Name:     "p2p.expect-unsafe-signer-change",
+		Usage:    "Enable reactive runtime config reloading on p2p block signature mismatch. When enabled, a signature mismatch triggers an early reload of the unsafe block signer from L1 (rate-limited to every 2s) and uses ValidationIgnore instead of ValidationReject to avoid penalizing peers during signer rotations.",
+		EnvVars:  prefixEnvVars("P2P_EXPECT_UNSAFE_SIGNER_CHANGE"),
+		Category: P2PCategory,
+	}
 	SnapshotLog = &cli.StringFlag{
 		Name:     "snapshotlog.file",
 		Usage:    "Deprecated. This flag is ignored, but here for compatibility.",
@@ -496,6 +502,7 @@ var optionalFlags = []cli.Flag{
 	FinalityDelayFlag,
 	L1EpochPollIntervalFlag,
 	RuntimeConfigReloadIntervalFlag,
+	ExpectUnsafeSignerChangeFlag,
 	RPCAdminPersistence,
 	SnapshotLog,
 	HeartbeatEnabledFlag,

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -124,7 +124,8 @@ type OpNode struct {
 	p2pNode   *p2p.NodeP2P          // P2P node functionality
 	p2pMu     gosync.Mutex          // protects p2pNode
 	p2pSigner p2p.Signer            // p2p gossip application messages will be signed with this signer
-	runCfg    *runcfg.RuntimeConfig // runtime configurables
+	runCfg        *runcfg.RuntimeConfig // runtime configurables
+	reloadCfgCh   chan struct{}         // channel to trigger reactive runtime config reloads from p2p gossip
 
 	l2FollowSource *sources.FollowClient // (Optional) L2 Follow source when derivation disabled
 
@@ -404,6 +405,9 @@ func initRuntimeConfig(ctx context.Context, cfg *config.Config, node *OpNode) er
 	runCfg := runcfg.NewRuntimeConfig(node.log, node.l1Source, &cfg.Rollup)
 	// Set node.runCfg early so handleProtocolVersionsUpdate can access it during initialization
 	node.runCfg = runCfg
+	if cfg.ExpectUnsafeSignerChange {
+		node.reloadCfgCh = make(chan struct{}, 1)
+	}
 
 	confDepth := cfg.Driver.VerifierConfDepth
 	reload := func(ctx context.Context) (eth.L1BlockRef, error) {
@@ -459,6 +463,11 @@ func initRuntimeConfig(ctx context.Context, cfg *config.Config, node *OpNode) er
 		}
 		ticker := time.NewTicker(reloadInterval)
 		defer ticker.Stop()
+
+		// Rate limit reactive reloads triggered by signature mismatches in p2p gossip.
+		const reactiveReloadCooldown = 2 * time.Second
+		var lastReactiveReload time.Time
+
 		for {
 			select {
 			case <-ticker.C:
@@ -479,6 +488,18 @@ func initRuntimeConfig(ctx context.Context, cfg *config.Config, node *OpNode) er
 					}
 				} else {
 					node.log.Debug("reloaded runtime config", "l1_head", l1Head)
+				}
+			case <-node.reloadCfgCh:
+				if time.Since(lastReactiveReload) < reactiveReloadCooldown {
+					node.log.Debug("skipping reactive runtime config reload, cooldown not elapsed")
+					continue
+				}
+				lastReactiveReload = time.Now()
+				l1Head, err := reload(ctx)
+				if err != nil {
+					node.log.Warn("failed to reactively reload runtime config", "err", err)
+				} else {
+					node.log.Info("reactively reloaded runtime config", "l1_head", l1Head)
 				}
 			case <-ctx.Done():
 				return
@@ -742,7 +763,7 @@ func initP2P(cfg *config.Config, node *OpNode) (*p2p.NodeP2P, error) {
 		}
 		// embed syncDeriver and tracer(optional) to the blockReceiver to handle unsafe payloads via p2p
 		rec := p2p.NewBlockReceiver(node.log, node.metrics, node.l2Driver.SyncDeriver, node.cfg.Tracer)
-		p2pNode, err := p2p.NewNodeP2P(node.resourcesCtx, &cfg.Rollup, node.log, cfg.P2P, rec, node.l2Source, node.runCfg, node.metrics, node.clock)
+		p2pNode, err := p2p.NewNodeP2P(node.resourcesCtx, &cfg.Rollup, node.log, cfg.P2P, rec, node.l2Source, node.runCfg, node.reloadCfgCh, node.metrics, node.clock)
 		if err != nil {
 			return nil, err
 		}

--- a/op-node/p2p/gossip.go
+++ b/op-node/p2p/gossip.go
@@ -265,7 +265,7 @@ func (sb *seenBlocks) markSeen(h common.Hash) {
 	sb.blockHashes = append(sb.blockHashes, h)
 }
 
-func BuildBlocksValidator(log log.Logger, cfg *rollup.Config, runCfg GossipRuntimeConfig, blockVersion eth.BlockVersion, gossipConf GossipSetupConfigurables, clk clock.Clock) pubsub.ValidatorEx {
+func BuildBlocksValidator(log log.Logger, cfg *rollup.Config, runCfg GossipRuntimeConfig, reloadCfgCh chan<- struct{}, blockVersion eth.BlockVersion, gossipConf GossipSetupConfigurables, clk clock.Clock) pubsub.ValidatorEx {
 	// Seen block hashes per block height
 	// uint64 -> *seenBlocks
 	blockHeightLRU, err := lru.New[uint64, *seenBlocks](1000)
@@ -305,8 +305,11 @@ func BuildBlocksValidator(log log.Logger, cfg *rollup.Config, runCfg GossipRunti
 		signature := eth.Bytes65(data[:65])
 		payloadBytes := data[65:]
 
-		// [REJECT] if the signature by the sequencer is not valid
-		result := verifyBlockSignature(log, cfg, runCfg, id, signature, payloadBytes)
+		// [REJECT] if the signature by the sequencer is not valid.
+		// When reloadCfgCh is set (--p2p.expect-unsafe-signer-change), a signature mismatch instead
+		// triggers a reactive runtime config reload and returns Ignore to avoid penalizing peers
+		// during legitimate signer rotations.
+		result := verifyBlockSignature(log, cfg, runCfg, reloadCfgCh, id, signature, payloadBytes)
 		if result != pubsub.ValidationAccept {
 			return result
 		}
@@ -442,7 +445,7 @@ func BuildBlocksValidator(log log.Logger, cfg *rollup.Config, runCfg GossipRunti
 	}
 }
 
-func verifyBlockSignature(log log.Logger, cfg *rollup.Config, runCfg GossipRuntimeConfig, id peer.ID, signature eth.Bytes65, payloadBytes []byte) pubsub.ValidationResult {
+func verifyBlockSignature(log log.Logger, cfg *rollup.Config, runCfg GossipRuntimeConfig, reloadCfgCh chan<- struct{}, id peer.ID, signature eth.Bytes65, payloadBytes []byte) pubsub.ValidationResult {
 	authCtx := &opsigner.OPStackP2PBlockAuthV1{
 		Allowed: runCfg.P2PSequencerAddress(),
 		Chain:   eth.ChainIDFromBig(cfg.L2ChainID),
@@ -456,6 +459,15 @@ func verifyBlockSignature(log log.Logger, cfg *rollup.Config, runCfg GossipRunti
 		Signature: signature,
 	}
 	if err := block.VerifySignature(authCtx); err != nil {
+		if reloadCfgCh != nil {
+			log.Warn("invalid block signature, requesting runtime config reload", "err", err, "peer", id)
+			select {
+			case reloadCfgCh <- struct{}{}:
+			default:
+			}
+			// Use Ignore instead of Reject to avoid penalizing peers during legitimate signer rotations.
+			return pubsub.ValidationIgnore
+		}
 		log.Warn("invalid block signature", "err", err, "peer", id)
 		return pubsub.ValidationReject
 	}
@@ -634,11 +646,11 @@ func (p *publisher) Close() error {
 	return errors.Join(e1, e2)
 }
 
-func JoinGossip(self peer.ID, ps *pubsub.PubSub, log log.Logger, cfg *rollup.Config, runCfg GossipRuntimeConfig, gossipIn GossipIn, gossipConf GossipSetupConfigurables, clk clock.Clock) (GossipOut, error) {
+func JoinGossip(self peer.ID, ps *pubsub.PubSub, log log.Logger, cfg *rollup.Config, runCfg GossipRuntimeConfig, reloadCfgCh chan<- struct{}, gossipIn GossipIn, gossipConf GossipSetupConfigurables, clk clock.Clock) (GossipOut, error) {
 	p2pCtx, p2pCancel := context.WithCancel(context.Background())
 
 	v1Logger := log.New("topic", "blocksV1")
-	blocksV1Validator := guardGossipValidator(log, logValidationResult(self, "validated blockv1", v1Logger, BuildBlocksValidator(v1Logger, cfg, runCfg, eth.BlockV1, gossipConf, clk)))
+	blocksV1Validator := guardGossipValidator(log, logValidationResult(self, "validated blockv1", v1Logger, BuildBlocksValidator(v1Logger, cfg, runCfg, reloadCfgCh, eth.BlockV1, gossipConf, clk)))
 	blocksV1, err := newBlockTopic(p2pCtx, blocksTopicV1(cfg), ps, v1Logger, gossipIn, blocksV1Validator)
 	if err != nil {
 		p2pCancel()
@@ -646,7 +658,7 @@ func JoinGossip(self peer.ID, ps *pubsub.PubSub, log log.Logger, cfg *rollup.Con
 	}
 
 	v2Logger := log.New("topic", "blocksV2")
-	blocksV2Validator := guardGossipValidator(log, logValidationResult(self, "validated blockv2", v2Logger, BuildBlocksValidator(v2Logger, cfg, runCfg, eth.BlockV2, gossipConf, clk)))
+	blocksV2Validator := guardGossipValidator(log, logValidationResult(self, "validated blockv2", v2Logger, BuildBlocksValidator(v2Logger, cfg, runCfg, reloadCfgCh, eth.BlockV2, gossipConf, clk)))
 	blocksV2, err := newBlockTopic(p2pCtx, blocksTopicV2(cfg), ps, v2Logger, gossipIn, blocksV2Validator)
 	if err != nil {
 		p2pCancel()
@@ -654,7 +666,7 @@ func JoinGossip(self peer.ID, ps *pubsub.PubSub, log log.Logger, cfg *rollup.Con
 	}
 
 	v3Logger := log.New("topic", "blocksV3")
-	blocksV3Validator := guardGossipValidator(log, logValidationResult(self, "validated blockv3", v3Logger, BuildBlocksValidator(v3Logger, cfg, runCfg, eth.BlockV3, gossipConf, clk)))
+	blocksV3Validator := guardGossipValidator(log, logValidationResult(self, "validated blockv3", v3Logger, BuildBlocksValidator(v3Logger, cfg, runCfg, reloadCfgCh, eth.BlockV3, gossipConf, clk)))
 	blocksV3, err := newBlockTopic(p2pCtx, blocksTopicV3(cfg), ps, v3Logger, gossipIn, blocksV3Validator)
 	if err != nil {
 		p2pCancel()
@@ -662,7 +674,7 @@ func JoinGossip(self peer.ID, ps *pubsub.PubSub, log log.Logger, cfg *rollup.Con
 	}
 
 	v4Logger := log.New("topic", "blocksV4")
-	blocksV4Validator := guardGossipValidator(log, logValidationResult(self, "validated blockv4", v4Logger, BuildBlocksValidator(v4Logger, cfg, runCfg, eth.BlockV4, gossipConf, clk)))
+	blocksV4Validator := guardGossipValidator(log, logValidationResult(self, "validated blockv4", v4Logger, BuildBlocksValidator(v4Logger, cfg, runCfg, reloadCfgCh, eth.BlockV4, gossipConf, clk)))
 	blocksV4, err := newBlockTopic(p2pCtx, blocksTopicV4(cfg), ps, v4Logger, gossipIn, blocksV4Validator)
 	if err != nil {
 		p2pCancel()

--- a/op-node/p2p/gossip_test.go
+++ b/op-node/p2p/gossip_test.go
@@ -66,30 +66,42 @@ func TestVerifyBlockSignature(t *testing.T) {
 	secrets, err := crypto.GenerateKey()
 	require.NoError(t, err)
 	msg := []byte("any msg")
+	reloadCh := make(chan struct{}, 1)
 
 	t.Run("Valid", func(t *testing.T) {
 		runCfg := &testutils.MockRuntimeConfig{P2PSeqAddress: crypto.PubkeyToAddress(secrets.PublicKey)}
 		signer := &PreparedSigner{Signer: opsigner.NewLocalSigner(secrets)}
 		sig, err := signer.SignBlockV1(context.Background(), eth.ChainIDFromBig(cfg.L2ChainID), opsigner.PayloadHash(msg))
 		require.NoError(t, err)
-		result := verifyBlockSignature(logger, cfg, runCfg, peerId, sig, msg)
+		result := verifyBlockSignature(logger, cfg, runCfg, reloadCh, peerId, sig, msg)
 		require.Equal(t, pubsub.ValidationAccept, result)
 	})
 
 	t.Run("WrongSigner", func(t *testing.T) {
+		// Drain any previous signal
+		select {
+		case <-reloadCh:
+		default:
+		}
 		runCfg := &testutils.MockRuntimeConfig{P2PSeqAddress: common.HexToAddress("0x1234")}
 		signer := &PreparedSigner{Signer: opsigner.NewLocalSigner(secrets)}
 		sig, err := signer.SignBlockV1(context.Background(), eth.ChainIDFromBig(cfg.L2ChainID), opsigner.PayloadHash(msg))
 		require.NoError(t, err)
-		result := verifyBlockSignature(logger, cfg, runCfg, peerId, sig, msg)
-		require.Equal(t, pubsub.ValidationReject, result)
+		result := verifyBlockSignature(logger, cfg, runCfg, reloadCh, peerId, sig, msg)
+		require.Equal(t, pubsub.ValidationIgnore, result, "signature mismatch triggers Ignore to avoid penalizing peers during signer rotations")
+		// Verify that a reload was requested
+		select {
+		case <-reloadCh:
+		default:
+			t.Fatal("expected a runtime config reload signal on signature mismatch")
+		}
 	})
 
 	t.Run("InvalidSignature", func(t *testing.T) {
 		runCfg := &testutils.MockRuntimeConfig{P2PSeqAddress: crypto.PubkeyToAddress(secrets.PublicKey)}
 		sig := eth.Bytes65{}
-		result := verifyBlockSignature(logger, cfg, runCfg, peerId, sig, msg)
-		require.Equal(t, pubsub.ValidationReject, result)
+		result := verifyBlockSignature(logger, cfg, runCfg, reloadCh, peerId, sig, msg)
+		require.Equal(t, pubsub.ValidationIgnore, result, "invalid signature triggers Ignore and reload request")
 	})
 
 	t.Run("NoSequencer", func(t *testing.T) {
@@ -97,7 +109,7 @@ func TestVerifyBlockSignature(t *testing.T) {
 		signer := &PreparedSigner{Signer: opsigner.NewLocalSigner(secrets)}
 		sig, err := signer.SignBlockV1(context.Background(), eth.ChainIDFromBig(cfg.L2ChainID), opsigner.PayloadHash(msg))
 		require.NoError(t, err)
-		result := verifyBlockSignature(logger, cfg, runCfg, peerId, sig, msg)
+		result := verifyBlockSignature(logger, cfg, runCfg, reloadCh, peerId, sig, msg)
 		require.Equal(t, pubsub.ValidationIgnore, result)
 	})
 }
@@ -157,14 +169,14 @@ func TestBlockValidator(t *testing.T) {
 
 	// Create a mock gossip configuration for testing
 	mockGossipConf := &mockGossipSetupConfigurablesWithThreshold{threshold: 60 * time.Second}
-	v2Validator := BuildBlocksValidator(testlog.Logger(t, log.LevelCrit), cfg, runCfg, eth.BlockV2, mockGossipConf, clock.SystemClock)
-	v3Validator := BuildBlocksValidator(testlog.Logger(t, log.LevelCrit), cfg, runCfg, eth.BlockV3, mockGossipConf, clock.SystemClock)
-	v4Validator := BuildBlocksValidator(testlog.Logger(t, log.LevelDebug), cfg, runCfg, eth.BlockV4, mockGossipConf, clock.SystemClock)
+	v2Validator := BuildBlocksValidator(testlog.Logger(t, log.LevelCrit), cfg, runCfg, nil, eth.BlockV2, mockGossipConf, clock.SystemClock)
+	v3Validator := BuildBlocksValidator(testlog.Logger(t, log.LevelCrit), cfg, runCfg, nil, eth.BlockV3, mockGossipConf, clock.SystemClock)
+	v4Validator := BuildBlocksValidator(testlog.Logger(t, log.LevelDebug), cfg, runCfg, nil, eth.BlockV4, mockGossipConf, clock.SystemClock)
 	jovianCfg := &rollup.Config{
 		L2ChainID:  big.NewInt(100),
 		JovianTime: ptr.New(uint64(0)),
 	}
-	v4JovianValidator := BuildBlocksValidator(testlog.Logger(t, log.LevelCrit), jovianCfg, runCfg, eth.BlockV4, mockGossipConf, clock.SystemClock)
+	v4JovianValidator := BuildBlocksValidator(testlog.Logger(t, log.LevelCrit), jovianCfg, runCfg, nil, eth.BlockV4, mockGossipConf, clock.SystemClock)
 
 	zero, one := uint64(0), uint64(1)
 	beaconHash, withdrawalsRoot := common.HexToHash("0x1234"), common.HexToHash("0x9876")
@@ -264,7 +276,7 @@ func TestGossipTimestampThreshold(t *testing.T) {
 			mockConfig := &mockGossipSetupConfigurablesWithThreshold{threshold: tc.threshold}
 
 			// Create validator with the mock config
-			validator := BuildBlocksValidator(testlog.Logger(t, log.LevelCrit), cfg, runCfg, eth.BlockV2, mockConfig, clock.SystemClock)
+			validator := BuildBlocksValidator(testlog.Logger(t, log.LevelCrit), cfg, runCfg, nil, eth.BlockV2, mockConfig, clock.SystemClock)
 
 			// Create payload with the specific timestamp
 			payload := createExecutionPayload(types.Withdrawals{}, nil, nil, nil)

--- a/op-node/p2p/host_test.go
+++ b/op-node/p2p/host_test.go
@@ -121,7 +121,7 @@ func TestP2PFull(t *testing.T) {
 	runCfgB := &testutils.MockRuntimeConfig{P2PSeqAddress: common.Address{0x42}}
 
 	logA := testlog.Logger(t, log.LevelError).New("host", "A")
-	nodeA, err := NewNodeP2P(context.Background(), &rollup.Config{}, logA, &confA, &mockGossipIn{}, nil, runCfgA, metrics.NoopMetrics, clock.SystemClock)
+	nodeA, err := NewNodeP2P(context.Background(), &rollup.Config{}, logA, &confA, &mockGossipIn{}, nil, runCfgA, nil, metrics.NoopMetrics, clock.SystemClock)
 	require.NoError(t, err)
 	defer nodeA.Close()
 
@@ -150,7 +150,7 @@ func TestP2PFull(t *testing.T) {
 
 	logB := testlog.Logger(t, log.LevelError).New("host", "B")
 
-	nodeB, err := NewNodeP2P(context.Background(), &rollup.Config{}, logB, &confB, &mockGossipIn{}, nil, runCfgB, metrics.NoopMetrics, clock.SystemClock)
+	nodeB, err := NewNodeP2P(context.Background(), &rollup.Config{}, logB, &confB, &mockGossipIn{}, nil, runCfgB, nil, metrics.NoopMetrics, clock.SystemClock)
 	require.NoError(t, err)
 	defer nodeB.Close()
 	hostB := nodeB.Host()
@@ -322,7 +322,7 @@ func TestDiscovery(t *testing.T) {
 	resourcesCtx, resourcesCancel := context.WithCancel(context.Background())
 	defer resourcesCancel()
 
-	nodeA, err := NewNodeP2P(context.Background(), rollupCfg, logA, &confA, &mockGossipIn{}, nil, runCfgA, metrics.NoopMetrics, clock.SystemClock)
+	nodeA, err := NewNodeP2P(context.Background(), rollupCfg, logA, &confA, &mockGossipIn{}, nil, runCfgA, nil, metrics.NoopMetrics, clock.SystemClock)
 	require.NoError(t, err)
 	defer nodeA.Close()
 	hostA := nodeA.Host()
@@ -337,7 +337,7 @@ func TestDiscovery(t *testing.T) {
 	confB.DiscoveryDB = discDBC
 
 	// Start B
-	nodeB, err := NewNodeP2P(context.Background(), rollupCfg, logB, &confB, &mockGossipIn{}, nil, runCfgB, metrics.NoopMetrics, clock.SystemClock)
+	nodeB, err := NewNodeP2P(context.Background(), rollupCfg, logB, &confB, &mockGossipIn{}, nil, runCfgB, nil, metrics.NoopMetrics, clock.SystemClock)
 	require.NoError(t, err)
 	defer nodeB.Close()
 	hostB := nodeB.Host()
@@ -352,7 +352,7 @@ func TestDiscovery(t *testing.T) {
 		}})
 
 	// Start C
-	nodeC, err := NewNodeP2P(context.Background(), rollupCfg, logC, &confC, &mockGossipIn{}, nil, runCfgC, metrics.NoopMetrics, clock.SystemClock)
+	nodeC, err := NewNodeP2P(context.Background(), rollupCfg, logC, &confC, &mockGossipIn{}, nil, runCfgC, nil, metrics.NoopMetrics, clock.SystemClock)
 	require.NoError(t, err)
 	defer nodeC.Close()
 	hostC := nodeC.Host()

--- a/op-node/p2p/node.go
+++ b/op-node/p2p/node.go
@@ -60,6 +60,7 @@ func NewNodeP2P(
 	gossipIn GossipIn,
 	l2Chain L2Chain,
 	runCfg GossipRuntimeConfig,
+	reloadCfgCh chan<- struct{},
 	metrics metrics.Metricer,
 	clock clock.Clock,
 ) (*NodeP2P, error) {
@@ -70,7 +71,7 @@ func NewNodeP2P(
 		return nil, errors.New("SetupP2P.Disabled is true")
 	}
 	var n NodeP2P
-	if err := n.init(resourcesCtx, rollupCfg, log, setup, gossipIn, l2Chain, runCfg, metrics, clock); err != nil {
+	if err := n.init(resourcesCtx, rollupCfg, log, setup, gossipIn, l2Chain, runCfg, reloadCfgCh, metrics, clock); err != nil {
 		closeErr := n.Close()
 		if closeErr != nil {
 			log.Error("failed to close p2p after starting with err", "closeErr", closeErr, "err", err)
@@ -93,6 +94,7 @@ func (n *NodeP2P) init(
 	gossipIn GossipIn,
 	l2Chain L2Chain,
 	runCfg GossipRuntimeConfig,
+	reloadCfgCh chan<- struct{},
 	metrics metrics.Metricer,
 	clk clock.Clock,
 ) error {
@@ -164,7 +166,7 @@ func (n *NodeP2P) init(
 	if err != nil {
 		return fmt.Errorf("failed to start gossipsub router: %w", err)
 	}
-	n.gsOut, err = JoinGossip(n.host.ID(), n.gs, log, rollupCfg, runCfg, gossipIn, setup, clk)
+	n.gsOut, err = JoinGossip(n.host.ID(), n.gs, log, rollupCfg, runCfg, reloadCfgCh, gossipIn, setup, clk)
 	if err != nil {
 		return fmt.Errorf("failed to join blocks gossip topic: %w", err)
 	}

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -114,6 +114,7 @@ func NewConfig(ctx cliiface.Context, log log.Logger) (*config.Config, error) {
 		P2PSigner:                   p2pSignerSetup,
 		L1EpochPollInterval:         ctx.Duration(flags.L1EpochPollIntervalFlag.Name),
 		RuntimeConfigReloadInterval: ctx.Duration(flags.RuntimeConfigReloadIntervalFlag.Name),
+		ExpectUnsafeSignerChange:    ctx.Bool(flags.ExpectUnsafeSignerChangeFlag.Name),
 		ConfigPersistence:           configPersistence,
 		SafeDBPath:                  ctx.String(flags.SafeDBPath.Name),
 		Sync:                        *syncConfig,


### PR DESCRIPTION
## Summary

- Adds `--p2p.expect-unsafe-signer-change` flag that enables reactive runtime config reloading when a P2P block fails signature verification
- When enabled, signature mismatches trigger an early reload of the unsafe block signer from L1 (rate-limited to every 2s) and return `ValidationIgnore` instead of `ValidationReject` to avoid penalizing peers during signer rotations
- Without the flag, behavior is unchanged (`ValidationReject` on bad signatures)

Closes #19981

## Test plan

- [x] Existing gossip unit tests updated and passing
- [ ] Manual test: start verifier with `--p2p.expect-unsafe-signer-change`, rotate signer on L1, verify blocks from new signer are accepted within ~2s instead of waiting for the full reload interval
- [ ] Manual test: without the flag, verify existing behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)