### PR TITLE
fix(op-e2e): restore cannon-kona game types in dispute game helper

### DIFF
--- a/op-e2e/e2eutils/disputegame/helper.go
+++ b/op-e2e/e2eutils/disputegame/helper.go
@@ -45,10 +45,10 @@ var (
 )
 
 const (
-	cannonGameType       uint32 = 0
-	permissionedGameType uint32 = 1
-	superCannonGameType  uint32 = 4
-	alphabetGameType     uint32 = 255
+	cannonKonaGameType      uint32 = 8
+	permissionedGameType    uint32 = 1
+	superCannonKonaGameType uint32 = 9
+	alphabetGameType        uint32 = 255
 )
 
 type GameCfg struct {
@@ -168,7 +168,7 @@ func (h *FactoryHelper) PreimageHelper(ctx context.Context) *preimage.Helper {
 	caller := batching.NewMultiCaller(h.Client.Client(), batching.DefaultBatchSize)
 	dgf, err := contracts.NewDisputeGameFactoryContract(ctx, metrics.NoopContractMetrics, h.FactoryAddr, caller)
 	h.Require.NoError(err)
-	vm, err := dgf.GetGameVm(ctx, gameTypes.GameType(cannonGameType))
+	vm, err := dgf.GetGameVm(ctx, gameTypes.GameType(cannonKonaGameType))
 	h.Require.NoError(err)
 	oracle, err := vm.Oracle(ctx)
 	h.Require.NoError(err)
@@ -192,7 +192,7 @@ func (h *FactoryHelper) StartOutputCannonGameWithCorrectRoot(ctx context.Context
 }
 
 func (h *FactoryHelper) StartOutputCannonGame(ctx context.Context, l2Node string, l2BlockNumber uint64, rootClaim common.Hash, opts ...GameOpt) *OutputCannonGameHelper {
-	return h.startOutputCannonGameOfType(ctx, l2Node, l2BlockNumber, rootClaim, cannonGameType, opts...)
+	return h.startOutputCannonGameOfType(ctx, l2Node, l2BlockNumber, rootClaim, cannonKonaGameType, opts...)
 }
 
 func (h *FactoryHelper) StartPermissionedGame(ctx context.Context, l2Node string, l2BlockNumber uint64, rootClaim common.Hash, opts ...GameOpt) *OutputCannonGameHelper {
@@ -245,13 +245,13 @@ func (h *FactoryHelper) StartSuperCannonGameWithCorrectRoot(ctx context.Context,
 	require.NoError(h.T, err)
 	l2Timestamp := b.Time()
 	h.WaitForSuperTimestamp(l2Timestamp, cfg)
-	return h.startSuperCannonGameOfType(ctx, l2Timestamp, superCannonGameType, opts...)
+	return h.startSuperCannonGameOfType(ctx, l2Timestamp, superCannonKonaGameType, opts...)
 }
 
 func (h *FactoryHelper) StartSuperCannonGameWithCorrectRootAtTimestamp(ctx context.Context, l2Timestamp uint64, opts ...GameOpt) *SuperCannonGameHelper {
 	cfg := NewGameCfg(opts...)
 	h.WaitForSuperTimestamp(l2Timestamp, cfg)
-	return h.startSuperCannonGameOfType(ctx, l2Timestamp, superCannonGameType, opts...)
+	return h.startSuperCannonGameOfType(ctx, l2Timestamp, superCannonKonaGameType, opts...)
 }
 
 func (h *FactoryHelper) StartSuperCannonGame(ctx context.Context, opts ...GameOpt) *SuperCannonGameHelper {
@@ -259,11 +259,11 @@ func (h *FactoryHelper) StartSuperCannonGame(ctx context.Context, opts ...GameOp
 	require.NoError(h.T, wait.ForBlock(ctx, h.Client, 1))
 	b, err := h.Client.BlockByNumber(ctx, nil)
 	require.NoError(h.T, err)
-	return h.startSuperCannonGameOfType(ctx, b.Time(), superCannonGameType, opts...)
+	return h.startSuperCannonGameOfType(ctx, b.Time(), superCannonKonaGameType, opts...)
 }
 
 func (h *FactoryHelper) StartSuperCannonGameAtTimestamp(ctx context.Context, timestamp uint64, opts ...GameOpt) *SuperCannonGameHelper {
-	return h.startSuperCannonGameOfType(ctx, timestamp, superCannonGameType, opts...)
+	return h.startSuperCannonGameOfType(ctx, timestamp, superCannonKonaGameType, opts...)
 }
 
 func (h *FactoryHelper) startSuperCannonGameOfType(ctx context.Context, timestamp uint64, gameType uint32, opts ...GameOpt) *SuperCannonGameHelper {


### PR DESCRIPTION
## Summary

- PR #19953 accidentally reverted the game type constants from #19791, changing them back to `CANNON` (0) / `SUPER_CANNON` (4) while the challenger is configured for `CANNON_KONA` (8) / `SUPER_CANNON_KONA` (9)
- This caused the challenger to reject all games with `"unsupported game type: 0"`, leading to **141/186 faultproof test failures** on develop ([failing job](https://app.circleci.com/jobs/github/ethereum-optimism/optimism/4771549))
- Restores the constants to match the `WithCannonKona` challenger configuration introduced in #19791

## Root cause

#19953 fixed a bond amount bug but was based on a stale branch — its diff reverted the game type constant changes from #19791 (`cannonKonaGameType=8` → `cannonGameType=0`, `superCannonKonaGameType=9` → `superCannonGameType=4`) while keeping the challenger configured for type 8/9 via `WithCannonKona`/`WithSuperCannonKona`.

## Test plan

- [x] Reproduced failure locally: `TestOutputCannonProposedOutputRootValid/mt-cannon` times out with 580 occurrences of `"unsupported game type: 0"` in challenger logs
- [x] After fix: same test passes in ~230s with zero `"unsupported game type"` errors
- [ ] CI `op-e2e-cannon-tests` passes in `develop-fault-proofs` workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)