### PR TITLE
fix(op-reth): wait for proofs ExEx store before debug_executePayload

### DIFF
--- a/docs/ai/rust-dev.md
+++ b/docs/ai/rust-dev.md
@@ -47,6 +47,30 @@ just test-unit
 just test-docs
 ```
 
+### Running op-reth E2E Tests
+
+The op-reth E2E tests (`rust/op-reth/tests/proofs/`) run a full devnet with op-geth (sequencer) and op-reth (validator). They require two build prerequisites:
+
+1. **Forge artifacts** — the devnet deploys contracts from compiled artifacts:
+   ```bash
+   cd packages/contracts-bedrock
+   mise exec -- just build-no-tests
+   ```
+
+2. **op-reth release binary** — the test harness (`op-devstack/sysgo/rust_binary.go`) only searches `target/release/`, not `target/debug/`. Options:
+   ```bash
+   # Option A: let the test build it (slow first run, cached after)
+   RUST_JIT_BUILD=1 go test -v -run TestName ./rust/op-reth/tests/proofs/core/
+
+   # Option B: pre-build the binary
+   cd rust && just build-op-reth
+   ```
+
+Run from the monorepo root:
+```bash
+mise exec -- go test -v -run TestExecutePayloadSuccess -count=1 ./rust/op-reth/tests/proofs/core/
+```
+
 ### Generating Prestates
 
 Kona prestates are built via Docker:

--- a/rust/op-reth/tests/proofs/core/execute_payload_test.go
+++ b/rust/op-reth/tests/proofs/core/execute_payload_test.go
@@ -17,9 +17,7 @@ func TestExecutePayloadSuccess(gt *testing.T) {
 	user := sys.FunderL2.NewFundedEOA(eth.OneHundredthEther)
 	opRethELNode := sys.RethWithProofL2ELNode()
 
-	// Wait for the validator to sync the blocks produced by the funder on the sequencer.
-	// Without this, the validator's proofs store (managed by an async ExEx) may not have
-	// indexed the block yet, causing PayloadExecutionWitness to fail with "no state found".
+	// Wait for the validator's EL head to reach the sequencer's head.
 	seqHead, err := sys.L2ELSequencerNode().Escape().L2EthClient().InfoByLabel(ctx, eth.Unsafe)
 	if err != nil {
 		gt.Fatal(err)
@@ -42,6 +40,12 @@ func TestExecutePayloadSuccess(gt *testing.T) {
 	if err != nil {
 		gt.Fatal(err)
 	}
+
+	// Wait for the proofs ExEx store to index the parent block. The ExEx processes
+	// ChainCommitted notifications asynchronously, so the EL head can advance before
+	// the store is ready. debug_executePayload reads from the ExEx store and will
+	// fail with "no state found" if it hasn't caught up yet.
+	utils.WaitForProofsStoreBlock(t, opRethELNode.Escape().L2EthClient(), lastBlock.NumberU64())
 
 	blockTime := lastBlock.Time() + 1
 	gasLimit := eth.Uint64Quantity(lastBlock.GasLimit())
@@ -81,9 +85,7 @@ func TestExecutePayloadWithInvalidParentHash(gt *testing.T) {
 	user := sys.FunderL2.NewFundedEOA(eth.OneHundredthEther)
 	opRethELNode := sys.RethWithProofL2ELNode()
 
-	// Wait for the validator to sync the blocks produced by the funder on the sequencer.
-	// Without this, the validator's proofs store (managed by an async ExEx) may not have
-	// indexed the block yet, causing PayloadExecutionWitness to fail with "no state found".
+	// Wait for the validator's EL head to reach the sequencer's head.
 	seqHead, err := sys.L2ELSequencerNode().Escape().L2EthClient().InfoByLabel(ctx, eth.Unsafe)
 	if err != nil {
 		gt.Fatal(err)
@@ -106,6 +108,9 @@ func TestExecutePayloadWithInvalidParentHash(gt *testing.T) {
 	if err != nil {
 		gt.Fatal(err)
 	}
+
+	// Wait for the proofs ExEx store to index the parent block (same race as TestExecutePayloadSuccess).
+	utils.WaitForProofsStoreBlock(t, opRethELNode.Escape().L2EthClient(), lastBlock.NumberU64())
 
 	blockTime := lastBlock.Time() + 1
 	gasLimit := eth.Uint64Quantity(lastBlock.GasLimit())

--- a/rust/op-reth/tests/proofs/utils/utils.go
+++ b/rust/op-reth/tests/proofs/utils/utils.go
@@ -4,9 +4,11 @@ import (
 	"encoding/json"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-service/apis"
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
@@ -47,6 +49,33 @@ func LoadArtifact(t devtest.T, artifactPath string) (abi.ABI, []byte) {
 	}
 
 	return parsedABI, common.FromHex(binHex)
+}
+
+// WaitForProofsStoreBlock polls the op-reth debug_proofsSyncStatus RPC until the
+// proofs ExEx store has indexed at least up to targetBlock. The ExEx processes
+// ChainCommitted notifications asynchronously, so the EL head can advance before
+// the proofs store has caught up. Any RPC that depends on OpStateProviderFactory
+// (e.g. debug_executePayload) will fail with "no state found" if called before
+// the store is ready.
+func WaitForProofsStoreBlock(t devtest.T, client apis.EthClient, targetBlock uint64) {
+	type syncStatus struct {
+		Earliest *uint64 `json:"earliest"`
+		Latest   *uint64 `json:"latest"`
+	}
+	require.Eventually(t, func() bool {
+		var status syncStatus
+		err := client.RPC().CallContext(t.Ctx(), &status, "debug_proofsSyncStatus")
+		if err != nil {
+			t.Logf("debug_proofsSyncStatus call failed (retrying): %v", err)
+			return false
+		}
+		if status.Latest == nil {
+			t.Logf("proofs store not yet initialized, waiting...")
+			return false
+		}
+		t.Logf("proofs store status: latest=%d target=%d", *status.Latest, targetBlock)
+		return *status.Latest >= targetBlock
+	}, 30*time.Second, 200*time.Millisecond, "proofs store did not index block %d in time", targetBlock)
 }
 
 // DeployContract deploys the contract creation bytecode from the given artifact.


### PR DESCRIPTION
## Summary

Fixes the recurring flake in `TestExecutePayloadSuccess` (and `TestExecutePayloadWithInvalidParentHash`).

PR #19899 added `WaitForBlockNumber` synchronization, but that only waits for the validator's **EL head** to advance. The `debug_executePayload` RPC reads from the **proofs ExEx store** (`OpStateProviderFactory`), which is populated asynchronously via `ChainCommitted` notifications. Under CI resource pressure, the ExEx lags behind the EL head, causing `"no state found for block number 1"`.

## Root Cause

The proofs ExEx (`OpProofsExEx`) processes `ChainCommitted` notifications in its own async loop. When the validator imports a block, the EL head advances immediately, but the ExEx store may not have indexed it yet. `WaitForBlockNumber` returns as soon as the EL head advances — it doesn't check the ExEx store. The subsequent `debug_executePayload` call then hits `OpStateProviderFactory::state_provider`, which returns `StateForNumberNotFound` because the store is empty/stale.

CI evidence confirms: block reached at `02:09:14.715`, test failed at `02:09:14.721` — 6ms gap.

## Fix

Added `utils.WaitForProofsStoreBlock` — polls `debug_proofsSyncStatus` (an existing RPC that reads from the same `Arc<MdbxProofsStorage>` backing `OpStateProviderFactory`) until the store's `latest` block >= the target. This follows the established pattern from the prune tests (`prune_test.go`).

The race is **completely eliminated**: once the poll succeeds, `state_provider` is guaranteed to find the data (the store doesn't prune `latest` backward).

## Why Flaky (Not Always Failing)

The ExEx normally processes notifications in microseconds. Only under CI CPU/IO contention does the gap widen enough for the test to query the store before it's ready.

## Flake Count

4 flakes recorded in CircleCI Insights.

Fixes https://github.com/ethereum-optimism/optimism/issues/19898

🤖 *Generated by Claude Code*