### PR TITLE
fix(kona): return error instead of panic on unknown batch type

### DIFF
--- a/rust/kona/crates/protocol/protocol/src/batch/core.rs
+++ b/rust/kona/crates/protocol/protocol/src/batch/core.rs
@@ -42,8 +42,7 @@ impl Batch {
         }
 
         // Read the batch type
-        let batch_type =
-            BatchType::try_from(r[0]).map_err(BatchDecodingError::UnknownBatchType)?;
+        let batch_type = BatchType::try_from(r[0]).map_err(BatchDecodingError::UnknownBatchType)?;
         r.advance(1);
 
         match batch_type {

--- a/rust/kona/crates/protocol/protocol/src/batch/core.rs
+++ b/rust/kona/crates/protocol/protocol/src/batch/core.rs
@@ -42,7 +42,8 @@ impl Batch {
         }
 
         // Read the batch type
-        let batch_type = BatchType::from(r[0]);
+        let batch_type =
+            BatchType::try_from(r[0]).map_err(BatchDecodingError::UnknownBatchType)?;
         r.advance(1);
 
         match batch_type {
@@ -129,6 +130,13 @@ mod tests {
             txs: SpanBatchTransactions::default(),
             ..Default::default()
         }), decoded);
+    }
+
+    #[test]
+    fn test_unknown_batch_type_returns_error() {
+        let data = [0xFF, 0x00]; // unknown batch type 0xFF followed by dummy data
+        let result = Batch::decode(&mut data.as_slice(), &RollupConfig::default());
+        assert_eq!(result, Err(BatchDecodingError::UnknownBatchType(0xFF)));
     }
 
     #[test]

--- a/rust/kona/crates/protocol/protocol/src/batch/errors.rs
+++ b/rust/kona/crates/protocol/protocol/src/batch/errors.rs
@@ -40,6 +40,9 @@ pub enum BatchDecodingError {
     /// Empty buffer
     #[error("Empty buffer")]
     EmptyBuffer,
+    /// Unknown batch type
+    #[error("Unknown batch type: {0}")]
+    UnknownBatchType(u8),
     /// Error decoding an Alloy RLP
     #[error("Error decoding an Alloy RLP: {0}")]
     AlloyRlpError(alloy_rlp::Error),

--- a/rust/kona/crates/protocol/protocol/src/batch/type.rs
+++ b/rust/kona/crates/protocol/protocol/src/batch/type.rs
@@ -28,12 +28,14 @@ pub enum BatchType {
     Span = SPAN_BATCH_TYPE,
 }
 
-impl From<u8> for BatchType {
-    fn from(val: u8) -> Self {
+impl TryFrom<u8> for BatchType {
+    type Error = u8;
+
+    fn try_from(val: u8) -> Result<Self, Self::Error> {
         match val {
-            SINGLE_BATCH_TYPE => Self::Single,
-            SPAN_BATCH_TYPE => Self::Span,
-            _ => panic!("Invalid batch type: {val}"),
+            SINGLE_BATCH_TYPE => Ok(Self::Single),
+            SPAN_BATCH_TYPE => Ok(Self::Span),
+            _ => Err(val),
         }
     }
 }
@@ -51,7 +53,7 @@ impl Encodable for BatchType {
 impl Decodable for BatchType {
     fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
         let val = u8::decode(buf)?;
-        Ok(Self::from(val))
+        Self::try_from(val).map_err(|_| alloy_rlp::Error::Custom("invalid batch type"))
     }
 }
 
@@ -67,5 +69,26 @@ mod test {
         batch_type.encode(&mut buf);
         let decoded = BatchType::decode(&mut buf.as_slice()).unwrap();
         assert_eq!(batch_type, decoded);
+    }
+
+    #[test]
+    fn test_try_from_valid_types() {
+        assert_eq!(BatchType::try_from(SINGLE_BATCH_TYPE), Ok(BatchType::Single));
+        assert_eq!(BatchType::try_from(SPAN_BATCH_TYPE), Ok(BatchType::Span));
+    }
+
+    #[test]
+    fn test_try_from_unknown_type_returns_error() {
+        assert_eq!(BatchType::try_from(0xFF), Err(0xFF));
+        assert_eq!(BatchType::try_from(0x02), Err(0x02));
+    }
+
+    #[test]
+    fn test_rlp_decode_unknown_type_returns_error() {
+        let mut buf = Vec::new();
+        // RLP-encode an invalid batch type byte
+        0xFFu8.encode(&mut buf);
+        let result = BatchType::decode(&mut buf.as_slice());
+        assert!(result.is_err());
     }
 }


### PR DESCRIPTION
## Summary

- Replace `BatchType::From<u8>` (which panics on unknown values) with `TryFrom<u8>` that returns an error
- Add `BatchDecodingError::UnknownBatchType(u8)` variant and propagate in `Batch::decode`
- Matches the OP spec and `op-node` behavior: unknown batch versions are invalid and must be ignored, not cause a panic

Fixes ethereum-optimism/optimism-private#484

## Test plan

- [x] `BatchType::try_from` returns `Ok` for valid types, `Err` for unknown
- [x] RLP decode of unknown batch type returns error (not panic)
- [x] `Batch::decode` with unknown type byte returns `BatchDecodingError::UnknownBatchType`
- [x] All existing `kona-protocol` tests pass
- [x] Clippy clean, formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)