### PR TITLE
fix(kona): use L1 origin timestamp for brotli activation check

### DIFF
--- a/rust/kona/crates/protocol/derive/src/stages/batch/batch_queue.rs
+++ b/rust/kona/crates/protocol/derive/src/stages/batch/batch_queue.rs
@@ -484,7 +484,7 @@ mod tests {
         let file_contents = &(&*file_contents)[..file_contents.len() - 1];
         let data = alloy_primitives::hex::decode(file_contents).unwrap();
         let bytes: alloy_primitives::Bytes = data.into();
-        BatchReader::new(bytes, MAX_RLP_BYTES_PER_CHANNEL_FJORD as usize)
+        BatchReader::new(bytes, MAX_RLP_BYTES_PER_CHANNEL_FJORD as usize, 0)
     }
 
     #[test]

--- a/rust/kona/crates/protocol/derive/src/stages/channel/channel_reader.rs
+++ b/rust/kona/crates/protocol/derive/src/stages/channel/channel_reader.rs
@@ -68,8 +68,11 @@ where
                 MAX_RLP_BYTES_PER_CHANNEL_BEDROCK
             };
 
-            self.next_batch =
-                Some(BatchReader::new(&channel[..], max_rlp_bytes_per_channel as usize));
+            self.next_batch = Some(BatchReader::new(
+                &channel[..],
+                max_rlp_bytes_per_channel as usize,
+                origin.timestamp,
+            ));
             kona_macros::set!(gauge, crate::metrics::Metrics::PIPELINE_BATCH_READER_SET, 1);
         }
         Ok(())
@@ -227,6 +230,7 @@ mod test {
         reader.next_batch = Some(BatchReader::new(
             new_compressed_batch_data(),
             MAX_RLP_BYTES_PER_CHANNEL_FJORD as usize,
+            0,
         ));
         reader.flush_channel().await.unwrap();
         assert!(reader.next_batch.is_none());
@@ -239,6 +243,7 @@ mod test {
         reader.next_batch = Some(BatchReader::new(
             vec![0x00, 0x01, 0x02],
             MAX_RLP_BYTES_PER_CHANNEL_FJORD as usize,
+            0,
         ));
         assert!(!reader.prev.reset);
         reader.reset(BlockNumHash::default(), SystemConfig::default()).await.unwrap();

--- a/rust/kona/crates/protocol/protocol/src/batch/reader.rs
+++ b/rust/kona/crates/protocol/protocol/src/batch/reader.rs
@@ -25,7 +25,7 @@ pub enum DecompressionError {
 }
 
 /// Batch Reader provides a function that iteratively consumes batches from the reader.
-/// The `L1Inclusion` block is also provided at creation time.
+/// The L1 origin timestamp is provided at creation time and used for hardfork activation checks.
 /// Warning: the batch reader can read every batch-type.
 /// The caller of the batch-reader should filter the results.
 #[derive(Debug)]
@@ -40,6 +40,8 @@ pub struct BatchReader {
     pub max_rlp_bytes_per_channel: usize,
     /// Whether brotli decompression was used.
     pub brotli_used: bool,
+    /// The L1 origin block timestamp, used for hardfork activation checks.
+    pub origin_timestamp: u64,
 }
 
 impl BatchReader {
@@ -52,9 +54,9 @@ impl BatchReader {
     /// Brotli Compression Channel Version.
     pub const CHANNEL_VERSION_BROTLI: u8 = 1;
 
-    /// Creates a new [`BatchReader`] from the given data and max decompressed RLP bytes per
-    /// channel.
-    pub fn new<T>(data: T, max_rlp_bytes_per_channel: usize) -> Self
+    /// Creates a new [`BatchReader`] from the given data, max decompressed RLP bytes per
+    /// channel, and the L1 origin block timestamp (used for hardfork activation checks).
+    pub fn new<T>(data: T, max_rlp_bytes_per_channel: usize, origin_timestamp: u64) -> Self
     where
         T: Into<Vec<u8>>,
     {
@@ -64,6 +66,7 @@ impl BatchReader {
             cursor: 0,
             max_rlp_bytes_per_channel,
             brotli_used: false,
+            origin_timestamp,
         }
     }
 
@@ -133,8 +136,8 @@ impl BatchReader {
             return None;
         };
 
-        // Confirm that brotli decompression was performed *after* the Fjord hardfork.
-        if self.brotli_used && !cfg.is_fjord_active(batch.timestamp()) {
+        // Accept brotli only after Fjord activation (per L1 origin timestamp).
+        if self.brotli_used && !cfg.is_fjord_active(self.origin_timestamp) {
             return None;
         }
 
@@ -167,7 +170,7 @@ mod test {
     fn test_batch_reader() {
         let raw = new_compressed_batch_data();
         let decompressed_len = decompress_to_vec_zlib(&raw).unwrap().len();
-        let mut reader = BatchReader::new(raw, MAX_RLP_BYTES_PER_CHANNEL_BEDROCK as usize);
+        let mut reader = BatchReader::new(raw, MAX_RLP_BYTES_PER_CHANNEL_BEDROCK as usize, 0);
         reader.next_batch(&RollupConfig::default()).unwrap();
         assert_eq!(reader.cursor, decompressed_len);
     }
@@ -176,7 +179,7 @@ mod test {
     fn test_batch_reader_fjord() {
         let raw = new_compressed_batch_data();
         let decompressed_len = decompress_to_vec_zlib(&raw).unwrap().len();
-        let mut reader = BatchReader::new(raw, MAX_RLP_BYTES_PER_CHANNEL_FJORD as usize);
+        let mut reader = BatchReader::new(raw, MAX_RLP_BYTES_PER_CHANNEL_FJORD as usize, 0);
         reader
             .next_batch(&RollupConfig {
                 hardforks: HardForkConfig { fjord_time: Some(0), ..Default::default() },
@@ -208,7 +211,7 @@ mod test {
 
         // Set limit below decompressed size — should truncate, not error.
         let limit = decompressed_len / 2;
-        let mut reader = BatchReader::new(raw, limit);
+        let mut reader = BatchReader::new(raw, limit, 0);
         assert!(reader.decompress().is_ok());
         assert_eq!(reader.decompressed.len(), limit);
     }
@@ -220,7 +223,7 @@ mod test {
         let single_batch_len = full_len / n;
 
         // Full decompression should yield all n batches.
-        let mut reader = BatchReader::new(compressed.clone(), full_len);
+        let mut reader = BatchReader::new(compressed.clone(), full_len, 0);
         let mut count = 0;
         while reader.next_batch(&RollupConfig::default()).is_some() {
             count += 1;
@@ -229,7 +232,7 @@ mod test {
 
         // Truncate to just under the last batch — should yield n-1 batches.
         let limit = full_len - 1;
-        let mut reader = BatchReader::new(compressed, limit);
+        let mut reader = BatchReader::new(compressed, limit, 0);
         let mut count = 0;
         while reader.next_batch(&RollupConfig::default()).is_some() {
             count += 1;


### PR DESCRIPTION
## Summary

- `BatchReader` now stores the L1 origin timestamp at construction, using it for the Fjord brotli activation check instead of the untrusted batch timestamp
- Fixes a consensus deviation: a malicious batcher could craft a batch with a pre-Fjord timestamp inside a post-Fjord brotli channel, causing kona to reject the channel while op-node accepts it
- Also fixes the stale doc comment on `BatchReader` that claimed L1 inclusion was provided at creation time (now it actually is)

Fixes ethereum-optimism/optimism-private#485

## Test plan

- [x] All `kona-protocol` batch reader tests pass (4/4)
- [x] All `kona-derive` channel reader tests pass (7/7)
- [x] All `kona-derive` batch queue tests pass (20/20)
- [x] Clippy clean on `kona-protocol`, formatted with `just f`

🤖 Generated with [Claude Code](https://claude.com/claude-code)