### PR TITLE
docs(op-node): document syncmode.req-resp and fix p2p.sync.req-resp wording

### DIFF
--- a/docs/public-docs/node-operators/reference/op-node-config.mdx
+++ b/docs/public-docs/node-operators/reference/op-node-config.mdx
@@ -286,6 +286,20 @@ Blockchain sync mode. Options are "consensus-layer" or "execution-layer". The de
   <Tab title="Environment variable">`OP_NODE_SYNCMODE=consensus-layer`</Tab>
 </Tabs>
 
+### syncmode.req-resp
+
+Enables the Req/Res CL P2P sync client path, used to close gaps against gossip. When disabled, `op-node` relies on the connected EL client to reach the chain tip. Default is `false`.
+
+<Tabs>
+  <Tab title="Syntax">`--syncmode.req-resp=[true|false]`</Tab>
+  <Tab title="Example">`--syncmode.req-resp=false`</Tab>
+  <Tab title="Environment variable">`OP_NODE_SYNCMODE_REQ_RESP=false`</Tab>
+</Tabs>
+
+<Warning>
+Deprecated in favor of execution-layer syncing; see the [Req/Res CL sync deprecation notice](/notices/req-resp-cl-sync-deprecation).
+</Warning>
+
 ## Fork overrides
 
 Manually override fork activation timestamps for testing or custom deployments.
@@ -821,13 +835,17 @@ Restricts `RequestL2Range` sync requests to static peers only. Useful for enforc
 
 ### p2p.sync.req-resp
 
-Enables P2P req-resp alternative sync method, on both server and client side. Default is `true`.
+Enables P2P req-resp sync, used to both serve block requests from peers and request missing blocks from peers. Default is `true`.
 
 <Tabs>
   <Tab title="Syntax">`--p2p.sync.req-resp=[true|false]`</Tab>
   <Tab title="Example">`--p2p.sync.req-resp=true`</Tab>
   <Tab title="Environment variable">`OP_NODE_P2P_SYNC_REQ_RESP=true`</Tab>
 </Tabs>
+
+<Warning>
+The Req/Res CL P2P sync client is deprecated in favor of execution-layer syncing; see the [Req/Res CL sync deprecation notice](/notices/req-resp-cl-sync-deprecation). The server path will remain temporarily but is also planned for removal.
+</Warning>
 
 ## Sequencer options
 


### PR DESCRIPTION
## Summary
- Add a new `### syncmode.req-resp` entry to the op-node config reference. The flag was previously undocumented, leaving operators with no way to discover it or its default from `--help` or the docs.
- Rewrite the `### p2p.sync.req-resp` description, which previously called it an *"alternative sync method, on both server and client side"* — wording that is both vague (alternative to what?) and misleading in light of the Req/Res CL sync deprecation, since the client and server paths are being deprecated on different timelines.
- Both entries include a compact Warning block pointing to the Req/Res CL sync deprecation notice.

## Dependencies
- **Blocked on #19998** (Req/Res CL sync deprecation notice). Both Warning blocks in this PR link to `/notices/req-resp-cl-sync-deprecation`, so this PR should only be merged **after** #19998 lands.

## Test plan
- [x] Verify the two updated sections render correctly on the docs site preview
- [ ] Verify the /notices/req-resp-cl-sync-deprecation links resolve (only after #19998 merges)
- [x] Verify sidebar/section anchors still work on the op-node config reference page

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>