### PR TITLE
fix(kona): enforce strict frame ordering in ChannelAssembler

### DIFF
--- a/rust/kona/crates/protocol/derive/src/stages/channel/channel_assembler.rs
+++ b/rust/kona/crates/protocol/derive/src/stages/channel/channel_assembler.rs
@@ -14,14 +14,13 @@ use core::fmt::Debug;
 use kona_genesis::{
     MAX_RLP_BYTES_PER_CHANNEL_BEDROCK, MAX_RLP_BYTES_PER_CHANNEL_FJORD, RollupConfig, SystemConfig,
 };
-use kona_protocol::{BlockInfo, Channel};
+use kona_protocol::{BlockInfo, OrderedChannel};
 
 /// The [`ChannelAssembler`] stage is responsible for assembling the [`Frame`]s from the
-/// [`FrameQueue`] stage into a raw compressed [`Channel`].
+/// [`FrameQueue`] stage into a raw compressed [`OrderedChannel`].
 ///
 /// [`Frame`]: kona_protocol::Frame
 /// [`FrameQueue`]: crate::stages::FrameQueue
-/// [`Channel`]: kona_protocol::Channel
 #[derive(Debug)]
 pub struct ChannelAssembler<P>
 where
@@ -31,8 +30,8 @@ where
     pub cfg: Arc<RollupConfig>,
     /// The previous stage of the derivation pipeline.
     pub prev: P,
-    /// The current [`Channel`] being assembled.
-    pub channel: Option<Channel>,
+    /// The current [`OrderedChannel`] being assembled.
+    pub channel: Option<OrderedChannel>,
 }
 
 impl<P> ChannelAssembler<P>
@@ -90,7 +89,7 @@ where
                 hex::encode(next_frame.id),
                 origin.number
             );
-            self.channel = Some(Channel::new(next_frame.id, origin));
+            self.channel = Some(OrderedChannel::new(next_frame.id, origin));
         }
 
         let _count = if self.channel.is_some() { 1 } else { 0 };

--- a/rust/kona/crates/protocol/derive/src/stages/channel/channel_assembler.rs
+++ b/rust/kona/crates/protocol/derive/src/stages/channel/channel_assembler.rs
@@ -147,7 +147,7 @@ where
             // If the channel is ready, forward the channel to the next stage.
             if channel.is_ready() {
                 let channel_bytes =
-                    channel.frame_data().ok_or(PipelineError::ChannelNotFound.crit())?;
+                    channel.data().map_err(|_| PipelineError::ChannelNotFound.crit())?;
 
                 info!(
                     target: "channel_assembler",

--- a/rust/kona/crates/protocol/protocol/src/channel.rs
+++ b/rust/kona/crates/protocol/protocol/src/channel.rs
@@ -34,6 +34,14 @@ pub enum ChannelError {
     /// The frame number is beyond the end frame.
     #[error("Frame number {0} is beyond end frame")]
     FrameBeyondEndFrame(usize),
+    /// The frame is out of order.
+    #[error("Frame out of order: expected {expected}, got {got}")]
+    FrameOutOfOrder {
+        /// The expected frame number.
+        expected: u16,
+        /// The actual frame number.
+        got: u16,
+    },
 }
 
 /// A Channel is a set of batches that are split into at least one, but possibly multiple frames.

--- a/rust/kona/crates/protocol/protocol/src/lib.rs
+++ b/rust/kona/crates/protocol/protocol/src/lib.rs
@@ -49,6 +49,9 @@ pub use channel::{
     MAX_RLP_BYTES_PER_CHANNEL,
 };
 
+mod ordered_channel;
+pub use ordered_channel::{OrderedChannel, OrderedChannelError};
+
 mod deposits;
 pub use deposits::{
     DEPOSIT_EVENT_ABI, DEPOSIT_EVENT_ABI_HASH, DEPOSIT_EVENT_VERSION_0, DepositError,

--- a/rust/kona/crates/protocol/protocol/src/lib.rs
+++ b/rust/kona/crates/protocol/protocol/src/lib.rs
@@ -50,7 +50,7 @@ pub use channel::{
 };
 
 mod ordered_channel;
-pub use ordered_channel::OrderedChannel;
+pub use ordered_channel::{OrderedChannel, ReadError};
 
 mod deposits;
 pub use deposits::{

--- a/rust/kona/crates/protocol/protocol/src/lib.rs
+++ b/rust/kona/crates/protocol/protocol/src/lib.rs
@@ -50,7 +50,7 @@ pub use channel::{
 };
 
 mod ordered_channel;
-pub use ordered_channel::{OrderedChannel, OrderedChannelError};
+pub use ordered_channel::OrderedChannel;
 
 mod deposits;
 pub use deposits::{

--- a/rust/kona/crates/protocol/protocol/src/ordered_channel.rs
+++ b/rust/kona/crates/protocol/protocol/src/ordered_channel.rs
@@ -110,8 +110,10 @@ impl OrderedChannel {
 
     /// Returns all of the channel's [`Frame`] data concatenated together.
     pub fn frame_data(&self) -> Option<Bytes> {
-        (!self.inputs.is_empty())
-            .then(|| self.inputs.iter().flat_map(|f| &f.data).copied().collect::<Vec<_>>().into())
+        if self.inputs.is_empty() {
+            return None;
+        }
+        Some(self.inputs.iter().flat_map(|f| &f.data).copied().collect::<Vec<_>>().into())
     }
 }
 

--- a/rust/kona/crates/protocol/protocol/src/ordered_channel.rs
+++ b/rust/kona/crates/protocol/protocol/src/ordered_channel.rs
@@ -1,0 +1,282 @@
+//! Ordered Channel Type
+//!
+//! An [`OrderedChannel`] enforces strict sequential frame ordering, rejecting any frame whose
+//! number does not match the expected next frame. This is the post-Holocene channel type, matching
+//! `op-node`'s `requireInOrder` behavior.
+
+use alloc::vec::Vec;
+use alloy_primitives::Bytes;
+
+use crate::{BlockInfo, ChannelId, Frame};
+
+/// An error returned when adding a frame to an [`OrderedChannel`].
+#[derive(Debug, thiserror::Error, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum OrderedChannelError {
+    /// The frame ID does not match the channel ID.
+    #[error("Frame id does not match channel id")]
+    FrameIdMismatch,
+    /// The channel is already closed.
+    #[error("Channel is closed")]
+    ChannelClosed,
+    /// The frame number is out of order.
+    #[error("Frame out of order: expected {expected}, got {got}")]
+    FrameOutOfOrder {
+        /// The expected frame number.
+        expected: u16,
+        /// The actual frame number.
+        got: u16,
+    },
+}
+
+/// An ordered channel that enforces strict sequential frame ingestion.
+///
+/// Unlike [`Channel`], which accepts frames out of order and checks contiguity at read time,
+/// `OrderedChannel` rejects any frame whose number does not equal the current frame count.
+/// This matches `op-node`'s Holocene behavior where `requireInOrder` is true.
+///
+/// [`Channel`]: crate::Channel
+#[derive(Debug, Clone)]
+pub struct OrderedChannel {
+    /// The unique identifier for this channel.
+    pub id: ChannelId,
+    /// The block that the channel was opened at.
+    pub open_block: BlockInfo,
+    /// Estimated memory size, used to drop the channel if we have too much data.
+    pub estimated_size: usize,
+    /// True if the last frame has been buffered.
+    pub closed: bool,
+    /// Frames stored in sequential order.
+    pub inputs: Vec<Frame>,
+    /// The highest L1 inclusion block that a frame was included in.
+    pub highest_l1_inclusion_block: BlockInfo,
+}
+
+impl OrderedChannel {
+    /// Create a new [`OrderedChannel`] with the given [`ChannelId`] and [`BlockInfo`].
+    pub fn new(id: ChannelId, open_block: BlockInfo) -> Self {
+        Self {
+            id,
+            open_block,
+            estimated_size: 0,
+            closed: false,
+            inputs: Vec::new(),
+            highest_l1_inclusion_block: BlockInfo::default(),
+        }
+    }
+
+    /// Returns the [`ChannelId`].
+    pub const fn id(&self) -> ChannelId {
+        self.id
+    }
+
+    /// Returns the number of frames ingested.
+    pub const fn len(&self) -> usize {
+        self.inputs.len()
+    }
+
+    /// Returns if the channel is empty.
+    pub const fn is_empty(&self) -> bool {
+        self.inputs.is_empty()
+    }
+
+    /// Returns the block number of the L1 block that contained the first [`Frame`].
+    pub const fn open_block_number(&self) -> u64 {
+        self.open_block.number
+    }
+
+    /// Returns the estimated size of the channel including [`Frame`] overhead.
+    pub const fn size(&self) -> usize {
+        self.estimated_size
+    }
+
+    /// Add a frame to the channel. The frame number must equal the current frame count
+    /// (strict sequential ordering).
+    pub fn add_frame(
+        &mut self,
+        frame: Frame,
+        l1_inclusion_block: BlockInfo,
+    ) -> Result<(), OrderedChannelError> {
+        if frame.id != self.id {
+            return Err(OrderedChannelError::FrameIdMismatch);
+        }
+        if self.closed {
+            return Err(OrderedChannelError::ChannelClosed);
+        }
+
+        let expected = self.inputs.len() as u16;
+        if frame.number != expected {
+            return Err(OrderedChannelError::FrameOutOfOrder { expected, got: frame.number });
+        }
+
+        if frame.is_last {
+            self.closed = true;
+        }
+
+        if self.highest_l1_inclusion_block.number < l1_inclusion_block.number {
+            self.highest_l1_inclusion_block = l1_inclusion_block;
+        }
+
+        self.estimated_size += frame.size();
+        self.inputs.push(frame);
+        Ok(())
+    }
+
+    /// Returns `true` if the channel is ready to be read.
+    /// Since frames are ingested in order, the channel is ready as soon as it is closed.
+    pub const fn is_ready(&self) -> bool {
+        self.closed
+    }
+
+    /// Returns all of the channel's [`Frame`] data concatenated together.
+    pub fn frame_data(&self) -> Option<Bytes> {
+        if self.inputs.is_empty() {
+            return None;
+        }
+        let mut data = Vec::with_capacity(self.estimated_size);
+        for frame in &self.inputs {
+            data.extend_from_slice(&frame.data);
+        }
+        Some(data.into())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use alloc::string::ToString;
+
+    fn test_id() -> ChannelId {
+        [0xFF; 16]
+    }
+
+    fn frame(id: ChannelId, number: u16, data: &[u8], is_last: bool) -> Frame {
+        Frame { id, number, data: data.to_vec(), is_last }
+    }
+
+    #[test]
+    fn test_ordered_channel_accessors() {
+        let id = test_id();
+        let block = BlockInfo { number: 42, timestamp: 0, ..Default::default() };
+        let channel = OrderedChannel::new(id, block);
+
+        assert_eq!(channel.id(), id);
+        assert_eq!(channel.open_block_number(), 42);
+        assert_eq!(channel.size(), 0);
+        assert_eq!(channel.len(), 0);
+        assert!(channel.is_empty());
+        assert!(!channel.is_ready());
+    }
+
+    #[test]
+    fn test_ordered_frames_accepted() {
+        let id = test_id();
+        let block = BlockInfo::default();
+        let mut channel = OrderedChannel::new(id, block);
+
+        assert!(channel.add_frame(frame(id, 0, b"hello", false), block).is_ok());
+        assert!(channel.add_frame(frame(id, 1, b"world", true), block).is_ok());
+        assert!(channel.is_ready());
+        assert_eq!(channel.len(), 2);
+        assert_eq!(channel.frame_data().unwrap().as_ref(), b"helloworld");
+    }
+
+    #[test]
+    fn test_wrong_channel_id_rejected() {
+        let id = test_id();
+        let block = BlockInfo::default();
+        let mut channel = OrderedChannel::new(id, block);
+
+        let err = channel.add_frame(frame([0xEE; 16], 0, b"bad", false), block).unwrap_err();
+        assert_eq!(err, OrderedChannelError::FrameIdMismatch);
+    }
+
+    #[test]
+    fn test_out_of_order_frame_rejected() {
+        let id = test_id();
+        let block = BlockInfo::default();
+        let mut channel = OrderedChannel::new(id, block);
+
+        // Frame 0 succeeds
+        assert!(channel.add_frame(frame(id, 0, b"first", false), block).is_ok());
+
+        // Frame 2 (skipping 1) is rejected
+        let err = channel.add_frame(frame(id, 2, b"skip", false), block).unwrap_err();
+        assert_eq!(err, OrderedChannelError::FrameOutOfOrder { expected: 1, got: 2 });
+        assert_eq!(channel.len(), 1);
+    }
+
+    #[test]
+    fn test_frame_after_close_rejected() {
+        let id = test_id();
+        let block = BlockInfo::default();
+        let mut channel = OrderedChannel::new(id, block);
+
+        assert!(channel.add_frame(frame(id, 0, b"only", true), block).is_ok());
+        assert!(channel.is_ready());
+
+        let err = channel.add_frame(frame(id, 1, b"extra", false), block).unwrap_err();
+        assert_eq!(err, OrderedChannelError::ChannelClosed);
+    }
+
+    #[test]
+    fn test_attack_scenario_cross_tx_out_of_order() {
+        // Attack from the finding: T1=[F0,F1,F2], T2=[F4,F5,F6(is_last)], T3=[F3]
+        // OrderedChannel should accept F0-F2 then reject F4 (expected F3).
+        let id = test_id();
+        let block = BlockInfo::default();
+        let mut channel = OrderedChannel::new(id, block);
+
+        // T1 frames arrive in order
+        assert!(channel.add_frame(frame(id, 0, b"f0", false), block).is_ok());
+        assert!(channel.add_frame(frame(id, 1, b"f1", false), block).is_ok());
+        assert!(channel.add_frame(frame(id, 2, b"f2", false), block).is_ok());
+
+        // T2 starts at frame 4 — out of order, rejected
+        let err = channel.add_frame(frame(id, 4, b"f4", false), block).unwrap_err();
+        assert_eq!(err, OrderedChannelError::FrameOutOfOrder { expected: 3, got: 4 });
+
+        // Channel is not ready and not closed
+        assert!(!channel.is_ready());
+        assert_eq!(channel.len(), 3);
+    }
+
+    #[test]
+    fn test_single_frame_channel() {
+        let id = test_id();
+        let block = BlockInfo::default();
+        let mut channel = OrderedChannel::new(id, block);
+
+        assert!(channel.add_frame(frame(id, 0, b"all", true), block).is_ok());
+        assert!(channel.is_ready());
+        assert_eq!(channel.frame_data().unwrap().as_ref(), b"all");
+    }
+
+    #[test]
+    fn test_empty_frame_data() {
+        let id = test_id();
+        let block = BlockInfo::default();
+        let channel = OrderedChannel::new(id, block);
+
+        assert_eq!(channel.frame_data(), None);
+    }
+
+    #[test]
+    fn test_l1_inclusion_block_tracking() {
+        let id = test_id();
+        let block1 = BlockInfo { number: 10, ..Default::default() };
+        let block2 = BlockInfo { number: 20, ..Default::default() };
+        let mut channel = OrderedChannel::new(id, block1);
+
+        assert!(channel.add_frame(frame(id, 0, b"a", false), block1).is_ok());
+        assert_eq!(channel.highest_l1_inclusion_block.number, 10);
+
+        assert!(channel.add_frame(frame(id, 1, b"b", true), block2).is_ok());
+        assert_eq!(channel.highest_l1_inclusion_block.number, 20);
+    }
+
+    #[test]
+    fn test_error_display() {
+        let err = OrderedChannelError::FrameOutOfOrder { expected: 3, got: 5 };
+        assert_eq!(err.to_string(), "Frame out of order: expected 3, got 5");
+    }
+}

--- a/rust/kona/crates/protocol/protocol/src/ordered_channel.rs
+++ b/rust/kona/crates/protocol/protocol/src/ordered_channel.rs
@@ -9,6 +9,17 @@ use alloy_primitives::Bytes;
 
 use crate::{BlockInfo, ChannelError, ChannelId, Frame};
 
+/// An error returned when reading data from an [`OrderedChannel`].
+#[derive(Debug, thiserror::Error, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ReadError {
+    /// The channel is not ready (not all frames have been received).
+    #[error("Channel is not ready")]
+    NotReady,
+    /// The channel has no frames.
+    #[error("Channel is empty")]
+    Empty,
+}
+
 /// An ordered channel that enforces strict sequential frame ingestion.
 ///
 /// Unlike [`Channel`], which accepts frames out of order and checks contiguity at read time,
@@ -109,11 +120,16 @@ impl OrderedChannel {
     }
 
     /// Returns all of the channel's [`Frame`] data concatenated together.
-    pub fn frame_data(&self) -> Option<Bytes> {
+    ///
+    /// Returns an error if the channel is empty or not yet ready.
+    pub fn data(&self) -> Result<Bytes, ReadError> {
         if self.inputs.is_empty() {
-            return None;
+            return Err(ReadError::Empty);
         }
-        Some(self.inputs.iter().flat_map(|f| &f.data).copied().collect::<Vec<_>>().into())
+        if !self.closed {
+            return Err(ReadError::NotReady);
+        }
+        Ok(self.inputs.iter().flat_map(|f| &f.data).copied().collect::<Vec<_>>().into())
     }
 }
 
@@ -154,7 +170,7 @@ mod test {
         assert!(channel.add_frame(frame(id, 1, b"world", true), block).is_ok());
         assert!(channel.is_ready());
         assert_eq!(channel.len(), 2);
-        assert_eq!(channel.frame_data().unwrap().as_ref(), b"helloworld");
+        assert_eq!(channel.data().unwrap().as_ref(), b"helloworld");
     }
 
     #[test]
@@ -225,16 +241,26 @@ mod test {
 
         assert!(channel.add_frame(frame(id, 0, b"all", true), block).is_ok());
         assert!(channel.is_ready());
-        assert_eq!(channel.frame_data().unwrap().as_ref(), b"all");
+        assert_eq!(channel.data().unwrap().as_ref(), b"all");
     }
 
     #[test]
-    fn test_empty_frame_data() {
+    fn test_data_empty_channel() {
         let id = test_id();
         let block = BlockInfo::default();
         let channel = OrderedChannel::new(id, block);
 
-        assert_eq!(channel.frame_data(), None);
+        assert_eq!(channel.data(), Err(ReadError::Empty));
+    }
+
+    #[test]
+    fn test_data_not_ready() {
+        let id = test_id();
+        let block = BlockInfo::default();
+        let mut channel = OrderedChannel::new(id, block);
+
+        assert!(channel.add_frame(frame(id, 0, b"partial", false), block).is_ok());
+        assert_eq!(channel.data(), Err(ReadError::NotReady));
     }
 
     #[test]

--- a/rust/kona/crates/protocol/protocol/src/ordered_channel.rs
+++ b/rust/kona/crates/protocol/protocol/src/ordered_channel.rs
@@ -7,26 +7,7 @@
 use alloc::vec::Vec;
 use alloy_primitives::Bytes;
 
-use crate::{BlockInfo, ChannelId, Frame};
-
-/// An error returned when adding a frame to an [`OrderedChannel`].
-#[derive(Debug, thiserror::Error, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum OrderedChannelError {
-    /// The frame ID does not match the channel ID.
-    #[error("Frame id does not match channel id")]
-    FrameIdMismatch,
-    /// The channel is already closed.
-    #[error("Channel is closed")]
-    ChannelClosed,
-    /// The frame number is out of order.
-    #[error("Frame out of order: expected {expected}, got {got}")]
-    FrameOutOfOrder {
-        /// The expected frame number.
-        expected: u16,
-        /// The actual frame number.
-        got: u16,
-    },
-}
+use crate::{BlockInfo, ChannelError, ChannelId, Frame};
 
 /// An ordered channel that enforces strict sequential frame ingestion.
 ///
@@ -95,17 +76,17 @@ impl OrderedChannel {
         &mut self,
         frame: Frame,
         l1_inclusion_block: BlockInfo,
-    ) -> Result<(), OrderedChannelError> {
+    ) -> Result<(), ChannelError> {
         if frame.id != self.id {
-            return Err(OrderedChannelError::FrameIdMismatch);
+            return Err(ChannelError::FrameIdMismatch);
         }
         if self.closed {
-            return Err(OrderedChannelError::ChannelClosed);
+            return Err(ChannelError::ChannelClosed);
         }
 
         let expected = self.inputs.len() as u16;
         if frame.number != expected {
-            return Err(OrderedChannelError::FrameOutOfOrder { expected, got: frame.number });
+            return Err(ChannelError::FrameOutOfOrder { expected, got: frame.number });
         }
 
         if frame.is_last {
@@ -129,14 +110,8 @@ impl OrderedChannel {
 
     /// Returns all of the channel's [`Frame`] data concatenated together.
     pub fn frame_data(&self) -> Option<Bytes> {
-        if self.inputs.is_empty() {
-            return None;
-        }
-        let mut data = Vec::with_capacity(self.estimated_size);
-        for frame in &self.inputs {
-            data.extend_from_slice(&frame.data);
-        }
-        Some(data.into())
+        (!self.inputs.is_empty())
+            .then(|| self.inputs.iter().flat_map(|f| &f.data).copied().collect::<Vec<_>>().into())
     }
 }
 
@@ -187,7 +162,7 @@ mod test {
         let mut channel = OrderedChannel::new(id, block);
 
         let err = channel.add_frame(frame([0xEE; 16], 0, b"bad", false), block).unwrap_err();
-        assert_eq!(err, OrderedChannelError::FrameIdMismatch);
+        assert_eq!(err, ChannelError::FrameIdMismatch);
     }
 
     #[test]
@@ -201,7 +176,7 @@ mod test {
 
         // Frame 2 (skipping 1) is rejected
         let err = channel.add_frame(frame(id, 2, b"skip", false), block).unwrap_err();
-        assert_eq!(err, OrderedChannelError::FrameOutOfOrder { expected: 1, got: 2 });
+        assert_eq!(err, ChannelError::FrameOutOfOrder { expected: 1, got: 2 });
         assert_eq!(channel.len(), 1);
     }
 
@@ -215,7 +190,7 @@ mod test {
         assert!(channel.is_ready());
 
         let err = channel.add_frame(frame(id, 1, b"extra", false), block).unwrap_err();
-        assert_eq!(err, OrderedChannelError::ChannelClosed);
+        assert_eq!(err, ChannelError::ChannelClosed);
     }
 
     #[test]
@@ -233,7 +208,7 @@ mod test {
 
         // T2 starts at frame 4 — out of order, rejected
         let err = channel.add_frame(frame(id, 4, b"f4", false), block).unwrap_err();
-        assert_eq!(err, OrderedChannelError::FrameOutOfOrder { expected: 3, got: 4 });
+        assert_eq!(err, ChannelError::FrameOutOfOrder { expected: 3, got: 4 });
 
         // Channel is not ready and not closed
         assert!(!channel.is_ready());
@@ -276,7 +251,7 @@ mod test {
 
     #[test]
     fn test_error_display() {
-        let err = OrderedChannelError::FrameOutOfOrder { expected: 3, got: 5 };
+        let err = ChannelError::FrameOutOfOrder { expected: 3, got: 5 };
         assert_eq!(err.to_string(), "Frame out of order: expected 3, got 5");
     }
 }


### PR DESCRIPTION
## Summary

- Add `OrderedChannel` — a simplified channel type that enforces strict sequential frame ordering (`frame.number == inputs.len()`), matching op-node's `requireInOrder` Holocene behavior
- `ChannelAssembler` (post-Holocene only) now uses `OrderedChannel` instead of `Channel`
- Existing `Channel` (out-of-order tolerant) stays in `ChannelBank` for pre-Holocene — independent types, no shared code, clean deprecation path
- `OrderedChannel` is simpler: `Vec<Frame>` instead of `HashMap`, no pruning, `is_ready()` is just `self.closed`

Fixes ethereum-optimism/optimism-private#482

## Test plan

- [x] 10 unit tests for `OrderedChannel`: ordered acceptance, out-of-order rejection, ID mismatch, double close, attack scenario (cross-tx out-of-order frames), single-frame channel, L1 inclusion tracking
- [x] All 5 existing `ChannelAssembler` tests pass unchanged
- [x] Clippy clean, formatted with `just f`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🧠 Note that I choose to create a new `OrderedChannel` type rather than add more logic to the existing channel because we want to deprecate pre-Holocene derivation soon and then we can just throw out the old `Channel` which allowed unordered frames. The ordered channel `add_frame` implementation is much simpler.