### PR TITLE
feat(alloy-op-evm): impl `OpTxTr` trait for `OpTx` + `OpEvmContext` alias

### DIFF
--- a/rust/alloy-op-evm/src/lib.rs
+++ b/rust/alloy-op-evm/src/lib.rs
@@ -27,12 +27,12 @@ use core::{
     ops::{Deref, DerefMut},
 };
 use op_revm::{
-    DefaultOp, OpBuilder, OpContext, OpHaltReason, OpSpecId, OpTransaction,
+    DefaultOp, L1BlockInfo, OpBuilder, OpContext, OpHaltReason, OpSpecId, OpTransaction,
     precompiles::OpPrecompiles,
 };
 use revm::{
-    Context, ExecuteEvm, InspectEvm, Inspector, SystemCallEvm,
-    context::{BlockEnv, TxEnv},
+    Context, ExecuteEvm, InspectEvm, Inspector, Journal, SystemCallEvm,
+    context::{BlockEnv, CfgEnv, TxEnv},
     context_interface::result::{EVMError, ResultAndState},
     handler::{PrecompileProvider, instructions::EthInstructions},
     inspector::NoOpInspector,
@@ -44,6 +44,9 @@ pub use tx::OpTx;
 
 pub mod block;
 pub use block::{OpBlockExecutionCtx, OpBlockExecutor, OpBlockExecutorFactory};
+
+/// The OP EVM context type.
+pub type OpEvmContext<DB> = Context<BlockEnv, OpTx, CfgEnv<OpSpecId>, DB, Journal<DB>, L1BlockInfo>;
 
 /// OP EVM implementation.
 ///

--- a/rust/alloy-op-evm/src/tx.rs
+++ b/rust/alloy-op-evm/src/tx.rs
@@ -118,6 +118,24 @@ impl revm::context::Transaction for OpTx {
     }
 }
 
+impl op_revm::transaction::OpTxTr for OpTx {
+    fn enveloped_tx(&self) -> Option<&Bytes> {
+        self.0.enveloped_tx()
+    }
+
+    fn source_hash(&self) -> Option<B256> {
+        self.0.source_hash()
+    }
+
+    fn mint(&self) -> Option<u128> {
+        self.0.mint()
+    }
+
+    fn is_system_transaction(&self) -> bool {
+        self.0.is_system_transaction()
+    }
+}
+
 impl FromRecoveredTx<OpTxEnvelope> for OpTx {
     fn from_recovered_tx(tx: &OpTxEnvelope, sender: Address) -> Self {
         let encoded = tx.encoded_2718();


### PR DESCRIPTION
**Description**

`alloy-op-evm` has wrapped revm's `OpTransaction<TxEnv>` into `OpTx`.

`alloy-op-evm` consumers like Foundry need to mutate evm's `Context`, while having `IntoTxEnv` bound (only available for `OpTx`, not for `OpTransaction<TxEnv>`). In this case, building a customized `OpEvm` with `ContextTr::Tx = OpTx` is impossible as `OpTx` doesn't implement `OpTxTr`.

To resolve the problem I added `OpTxTr` passthrough impl for `OpTx`, and a convenience `OpEvmContext<DB>` alias mirroring `alloy_evm::EthEvmContext<DB>`.


