### PR TITLE
chore: replace deprecated deps with stdlib equivalents

### DIFF
--- a/cannon/mipsevm/memory/memory.go
+++ b/cannon/mipsevm/memory/memory.go
@@ -5,10 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"slices"
 	"sort"
-
-	"maps"
 
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/arch"
 )

--- a/cannon/mipsevm/memory/memory.go
+++ b/cannon/mipsevm/memory/memory.go
@@ -8,8 +8,9 @@ import (
 	"slices"
 	"sort"
 
+	"maps"
+
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/arch"
-	"golang.org/x/exp/maps"
 )
 
 // Note: 2**12 = 4 KiB, the min phys page size in the Go runtime.
@@ -334,7 +335,7 @@ func (m *Memory) Serialize(out io.Writer) error {
 	if err := binary.Write(out, binary.BigEndian, Word(m.PageCount())); err != nil {
 		return err
 	}
-	indexes := maps.Keys(m.pageTable)
+	indexes := slices.Collect(maps.Keys(m.pageTable))
 	// iterate sorted map keys for consistent serialization
 	slices.Sort(indexes)
 	for _, pageIndex := range indexes {

--- a/cannon/mipsevm/tests/evm_multithreaded64_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded64_test.go
@@ -4,10 +4,9 @@ package tests
 import (
 	"encoding/binary"
 	"fmt"
+	"maps"
 	"slices"
 	"testing"
-
-	"maps"
 
 	"github.com/stretchr/testify/require"
 

--- a/cannon/mipsevm/tests/evm_multithreaded64_test.go
+++ b/cannon/mipsevm/tests/evm_multithreaded64_test.go
@@ -7,8 +7,9 @@ import (
 	"slices"
 	"testing"
 
+	"maps"
+
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/maps"
 
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm"
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/arch"
@@ -651,7 +652,7 @@ func TestEVM_NoopSyscall64(t *testing.T) {
 
 func TestEVM_UnsupportedSyscall64(t *testing.T) {
 	t.Parallel()
-	noopSyscallNums := maps.Values(NoopSyscalls64)
+	noopSyscallNums := slices.Collect(maps.Values(NoopSyscalls64))
 	unsupportedSyscalls := make([]uint32, 0, 400)
 	for i := 5000; i < 5400; i++ {
 		candidate := uint32(i)

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,6 @@ require (
 	github.com/google/gofuzz v1.2.1-0.20220503160820-4a35382e8fc8
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
-	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/hashicorp/raft v1.7.3
 	github.com/hashicorp/raft-boltdb/v2 v2.3.1
@@ -49,7 +48,6 @@ require (
 	github.com/multiformats/go-multiaddr v0.14.0
 	github.com/multiformats/go-multiaddr-dns v0.4.1
 	github.com/olekukonko/tablewriter v0.0.5
-	github.com/pkg/errors v0.9.1
 	github.com/pkg/profile v1.7.0
 	github.com/prometheus/client_golang v1.22.0
 	github.com/prometheus/client_model v0.6.2
@@ -61,7 +59,6 @@ require (
 	go.opentelemetry.io/otel v1.40.0
 	go.opentelemetry.io/otel/trace v1.40.0
 	golang.org/x/crypto v0.46.0
-	golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c
 	golang.org/x/mod v0.30.0
 	golang.org/x/sync v0.19.0
 	golang.org/x/term v0.38.0
@@ -76,6 +73,8 @@ require (
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
 	github.com/grafana/pyroscope-go v1.2.7 // indirect
 	github.com/grafana/pyroscope-go/godeltaprof v0.1.9 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c // indirect
 	golang.org/x/telemetry v0.0.0-20251111182119-bc8e575c7b54 // indirect
 )
 
@@ -148,7 +147,6 @@ require (
 	github.com/google/gopacket v1.1.19 // indirect
 	github.com/google/pprof v0.0.0-20241009165004-a3522334989c // indirect
 	github.com/graph-gophers/graphql-go v1.3.0 // indirect
-	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-bexpr v0.1.11 // indirect
 	github.com/hashicorp/go-hclog v1.6.2 // indirect
 	github.com/hashicorp/go-immutable-radix v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -376,9 +376,6 @@ github.com/graph-gophers/graphql-go v1.3.0 h1:Eb9x/q6MFpCLz7jBCiP/WTxjSDrYLR1QY4
 github.com/graph-gophers/graphql-go v1.3.0/go.mod h1:9CQHMSxwO4MprSdzoIEobiHpoLtHm77vfxsvsIN5Vuc=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/grpc-gateway v1.5.0/go.mod h1:RSKVYQBd5MCa4OVpNdGskqpgL2+G+NZTnrVHpWWfpdw=
-github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
-github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
-github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-bexpr v0.1.11 h1:6DqdA/KBjurGby9yTY0bmkathya0lfwF2SeuubCI7dY=
 github.com/hashicorp/go-bexpr v0.1.11/go.mod h1:f03lAo0duBlDIUMGCuad8oLcgejw4m7U+N8T+6Kz1AE=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
@@ -393,8 +390,6 @@ github.com/hashicorp/go-msgpack v0.5.5 h1:i9R9JSrqIz0QVLz3sz+i3YJdT7TTSLcfLLzJi9
 github.com/hashicorp/go-msgpack v0.5.5/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-msgpack/v2 v2.1.2 h1:4Ee8FTp834e+ewB71RDrQ0VKpyFdrKOjvYtnQ/ltVj0=
 github.com/hashicorp/go-msgpack/v2 v2.1.2/go.mod h1:upybraOAblm4S7rx0+jeNy+CWWhzywQsSRV5033mMu4=
-github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
-github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-retryablehttp v0.5.3/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=
 github.com/hashicorp/go-uuid v1.0.0 h1:RS8zrF7PhGwyNPOtxSClXXj9HA8feRnJzgnI1RJCSnM=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=

--- a/op-batcher/compressor/compressors.go
+++ b/op-batcher/compressor/compressors.go
@@ -1,8 +1,10 @@
 package compressor
 
 import (
+	"maps"
+	"slices"
+
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
-	"golang.org/x/exp/maps"
 )
 
 type FactoryFunc func(Config) (derive.Compressor, error)
@@ -26,5 +28,5 @@ var Kinds = map[string]FactoryFunc{
 var KindKeys []string
 
 func init() {
-	KindKeys = maps.Keys(Kinds)
+	KindKeys = slices.Collect(maps.Keys(Kinds))
 }

--- a/op-chain-ops/cmd/check-prestate/main.go
+++ b/op-chain-ops/cmd/check-prestate/main.go
@@ -6,7 +6,10 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"slices"
 	"strings"
+
+	"maps"
 
 	"github.com/BurntSushi/toml"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/cmd/check-prestate/prestate"
@@ -18,7 +21,6 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/superchain"
 	"github.com/mattn/go-isatty"
-	"golang.org/x/exp/maps"
 )
 
 type FPProgramType interface {
@@ -65,7 +67,7 @@ func main() {
 		chainFilter = func(chainName string) bool {
 			return chains[chainName]
 		}
-		filteredChainNames = maps.Keys(chains)
+		filteredChainNames = slices.Collect(maps.Keys(chains))
 	}
 	prestateHash := common.HexToHash(prestateHashStr)
 	if prestateHash == (common.Hash{}) {
@@ -158,7 +160,7 @@ func main() {
 		ExecutionClient:    elCommitInfo,
 		SuperchainRegistry: commitInfo("superchain-registry", commit, "main", "superchain"),
 		UpToDateChains:     supportedChains,
-		OutdatedChains:     maps.Values(outdatedChains),
+		OutdatedChains:     slices.Collect(maps.Values(outdatedChains)),
 		MissingChains:      missingChains,
 	}
 	encoder := json.NewEncoder(os.Stdout)

--- a/op-chain-ops/cmd/check-prestate/main.go
+++ b/op-chain-ops/cmd/check-prestate/main.go
@@ -5,11 +5,10 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"maps"
 	"os"
 	"slices"
 	"strings"
-
-	"maps"
 
 	"github.com/BurntSushi/toml"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/cmd/check-prestate/prestate"

--- a/op-chain-ops/cmd/unclaimed-credits/main.go
+++ b/op-chain-ops/cmd/unclaimed-credits/main.go
@@ -6,7 +6,10 @@ import (
 	"fmt"
 	"math/big"
 	"os"
+	"slices"
 	"time"
+
+	"maps"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts/metrics"
@@ -20,7 +23,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/urfave/cli/v2"
-	"golang.org/x/exp/maps"
 )
 
 var (
@@ -130,7 +132,7 @@ func unclaimedCreditsForGame(ctx context.Context, game contracts.FaultDisputeGam
 			players[claim.CounteredBy] = true
 		}
 	}
-	playerList := maps.Keys(players)
+	playerList := slices.Collect(maps.Keys(players))
 	credits, err := game.GetCredits(ctx, rpcblock.Latest, playerList...)
 	if err != nil {
 		return fmt.Errorf("failed to retrieve credits: %w", err)

--- a/op-chain-ops/cmd/unclaimed-credits/main.go
+++ b/op-chain-ops/cmd/unclaimed-credits/main.go
@@ -4,12 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"math/big"
 	"os"
 	"slices"
 	"time"
-
-	"maps"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts/metrics"

--- a/op-chain-ops/foundry/sourcefs.go
+++ b/op-chain-ops/foundry/sourcefs.go
@@ -7,9 +7,10 @@ import (
 	"io/fs"
 	"path"
 	"path/filepath"
+	"slices"
 	"strings"
 
-	"golang.org/x/exp/maps"
+	"maps"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/srcmap"
 )
@@ -122,7 +123,7 @@ func (s *SourceMapFS) ReadSourceIDs(path string, contract string, compilerVersio
 			return nil, errors.New("no known build, unspecified compiler version")
 		}
 		if len(byCompilerVersion) > 1 {
-			return nil, fmt.Errorf("no compiler version specified, and more than one option: %s", strings.Join(maps.Keys(byCompilerVersion), ", "))
+			return nil, fmt.Errorf("no compiler version specified, and more than one option: %s", strings.Join(slices.Collect(maps.Keys(byCompilerVersion)), ", "))
 		}
 		// select the only remaining entry
 		for _, v := range byCompilerVersion {
@@ -140,7 +141,7 @@ func (s *SourceMapFS) ReadSourceIDs(path string, contract string, compilerVersio
 			return nil, errors.New("no known build, unspecified profile")
 		}
 		if len(byProfile) > 1 {
-			return nil, fmt.Errorf("no profile specified, and more than one option: %s", strings.Join(maps.Keys(byProfile), ", "))
+			return nil, fmt.Errorf("no profile specified, and more than one option: %s", strings.Join(slices.Collect(maps.Keys(byProfile)), ", "))
 		}
 		// select the only remaining entry
 		for _, v := range byProfile {

--- a/op-chain-ops/foundry/sourcefs.go
+++ b/op-chain-ops/foundry/sourcefs.go
@@ -5,12 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"maps"
 	"path"
 	"path/filepath"
 	"slices"
 	"strings"
-
-	"maps"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/srcmap"
 )

--- a/op-chain-ops/interopgen/deploy.go
+++ b/op-chain-ops/interopgen/deploy.go
@@ -3,11 +3,10 @@ package interopgen
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"math/big"
 	"slices"
 	"sort"
-
-	"maps"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"

--- a/op-chain-ops/interopgen/deploy.go
+++ b/op-chain-ops/interopgen/deploy.go
@@ -4,9 +4,10 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"slices"
 	"sort"
 
-	"golang.org/x/exp/maps"
+	"maps"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -271,7 +272,7 @@ func DeployL2ToL1(l1Host *script.Host, superCfg *SuperchainConfig, superDeployme
 func MigrateInterop(
 	l1Host *script.Host, l1GenesisTimestamp uint64, superCfg *SuperchainConfig, superDeployment *SuperchainDeployment, l2Cfgs map[string]*L2Config, l2Deployments map[string]*L2Deployment,
 ) (*InteropDeployment, error) {
-	l2ChainIDs := maps.Keys(l2Deployments)
+	l2ChainIDs := slices.Collect(maps.Keys(l2Deployments))
 	sort.Strings(l2ChainIDs)
 
 	// We don't have a super root at genesis. But stub the starting anchor root anyways to facilitate super DG testing.

--- a/op-chain-ops/script/cheatcodes_external.go
+++ b/op-chain-ops/script/cheatcodes_external.go
@@ -5,14 +5,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"math/big"
 	"path"
 	"slices"
 	"strconv"
 	"strings"
 	"time"
-
-	"maps"
 
 	"github.com/BurntSushi/toml"
 

--- a/op-chain-ops/script/cheatcodes_external.go
+++ b/op-chain-ops/script/cheatcodes_external.go
@@ -7,12 +7,14 @@ import (
 	"fmt"
 	"math/big"
 	"path"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
 
+	"maps"
+
 	"github.com/BurntSushi/toml"
-	"golang.org/x/exp/maps"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -388,7 +390,7 @@ func lookupKeys(v any, query string) ([]string, error) {
 	if query == "$" || query == "" {
 		switch x := v.(type) {
 		case map[string]any:
-			return maps.Keys(x), nil
+			return slices.Collect(maps.Keys(x)), nil
 		default:
 			return nil, fmt.Errorf("JSON value (Type %T) is not an object", x)
 		}
@@ -414,7 +416,7 @@ func lookupKeys(v any, query string) ([]string, error) {
 			if trailing != "" {
 				return nil, errors.New("cannot continue query after $ sign")
 			}
-			return maps.Keys(x), nil
+			return slices.Collect(maps.Keys(x)), nil
 		}
 		data, ok := x[stringKey]
 		if !ok {

--- a/op-challenger/cmd/credits.go
+++ b/op-challenger/cmd/credits.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+	"slices"
 	"time"
+
+	"maps"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/flags"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts"
@@ -17,7 +20,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/urfave/cli/v2"
-	"golang.org/x/exp/maps"
 )
 
 func ListCredits(ctx *cli.Context) error {
@@ -72,7 +74,7 @@ func listCredits(ctx context.Context, game contracts.FaultDisputeGameContract) e
 	if err != nil {
 		return fmt.Errorf("failed to get DelayedWETH info: %w", err)
 	}
-	claimants := maps.Keys(recipients)
+	claimants := slices.Collect(maps.Keys(recipients))
 	withdrawals, err := game.GetWithdrawals(ctx, rpcblock.Latest, claimants...)
 	if err != nil {
 		return fmt.Errorf("failed to get withdrawals: %w", err)

--- a/op-challenger/cmd/credits.go
+++ b/op-challenger/cmd/credits.go
@@ -3,11 +3,10 @@ package main
 import (
 	"context"
 	"fmt"
+	"maps"
 	"math/big"
 	"slices"
 	"time"
-
-	"maps"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/flags"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts"

--- a/op-challenger/game/registry/oracles.go
+++ b/op-challenger/game/registry/oracles.go
@@ -1,11 +1,13 @@
 package registry
 
 import (
+	"slices"
 	"sync"
+
+	"maps"
 
 	keccakTypes "github.com/ethereum-optimism/optimism/op-challenger/game/keccak/types"
 	"github.com/ethereum/go-ethereum/common"
-	"golang.org/x/exp/maps"
 )
 
 type OracleRegistry struct {
@@ -28,5 +30,5 @@ func (r *OracleRegistry) RegisterOracle(oracle keccakTypes.LargePreimageOracle) 
 func (r *OracleRegistry) Oracles() []keccakTypes.LargePreimageOracle {
 	r.l.Lock()
 	defer r.l.Unlock()
-	return maps.Values(r.oracles)
+	return slices.Collect(maps.Values(r.oracles))
 }

--- a/op-challenger/game/registry/oracles.go
+++ b/op-challenger/game/registry/oracles.go
@@ -1,10 +1,9 @@
 package registry
 
 import (
+	"maps"
 	"slices"
 	"sync"
-
-	"maps"
 
 	keccakTypes "github.com/ethereum-optimism/optimism/op-challenger/game/keccak/types"
 	"github.com/ethereum/go-ethereum/common"

--- a/op-challenger/sender/sender_test.go
+++ b/op-challenger/sender/sender_test.go
@@ -3,13 +3,12 @@ package sender
 import (
 	"context"
 	"fmt"
+	"maps"
 	"math/big"
 	"slices"
 	"sync"
 	"testing"
 	"time"
-
-	"maps"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"

--- a/op-challenger/sender/sender_test.go
+++ b/op-challenger/sender/sender_test.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+	"slices"
 	"sync"
 	"testing"
 	"time"
+
+	"maps"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
@@ -16,7 +19,6 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/maps"
 )
 
 func TestSendAndWaitQueueWithMaxPending(t *testing.T) {
@@ -163,7 +165,7 @@ func (s *stubTxMgr) txSuccess(candidate txmgr.TxCandidate) {
 	ch, ok := s.sending[candidate.TxData[0]]
 	if !ok {
 		// Shouldn't happen if tests are well written, but double check...
-		panic(fmt.Sprintf("Completing unknown transaction: %v Known: %v", candidate.TxData[0], maps.Keys(s.sending)))
+		panic(fmt.Sprintf("Completing unknown transaction: %v Known: %v", candidate.TxData[0], slices.Collect(maps.Keys(s.sending))))
 	}
 	ch <- &types.Receipt{Status: types.ReceiptStatusSuccessful}
 	close(ch)

--- a/op-conductor/conductor/config.go
+++ b/op-conductor/conductor/config.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/pkg/errors"
 	"github.com/urfave/cli/v2"
 
 	"github.com/ethereum-optimism/optimism/op-conductor/flags"
@@ -135,19 +134,19 @@ func (c *Config) Check() error {
 		return fmt.Errorf("missing rollup-boost next healthcheck URL")
 	}
 	if err := c.HealthCheck.Check(); err != nil {
-		return errors.Wrap(err, "invalid health check config")
+		return fmt.Errorf("invalid health check config: %w", err)
 	}
 	if err := c.RollupCfg.Check(); err != nil {
-		return errors.Wrap(err, "invalid rollup config")
+		return fmt.Errorf("invalid rollup config: %w", err)
 	}
 	if err := c.MetricsConfig.Check(); err != nil {
-		return errors.Wrap(err, "invalid metrics config")
+		return fmt.Errorf("invalid metrics config: %w", err)
 	}
 	if err := c.PprofConfig.Check(); err != nil {
-		return errors.Wrap(err, "invalid pprof config")
+		return fmt.Errorf("invalid pprof config: %w", err)
 	}
 	if err := c.RPC.Check(); err != nil {
-		return errors.Wrap(err, "invalid rpc config")
+		return fmt.Errorf("invalid rpc config: %w", err)
 	}
 	return nil
 }
@@ -155,12 +154,12 @@ func (c *Config) Check() error {
 // NewConfig parses the Config from the provided flags or environment variables.
 func NewConfig(ctx *cli.Context, log log.Logger) (*Config, error) {
 	if err := flags.CheckRequired(ctx); err != nil {
-		return nil, errors.Wrap(err, "missing required flags")
+		return nil, fmt.Errorf("missing required flags: %w", err)
 	}
 
 	rollupCfg, err := opnode.NewRollupConfigFromCLI(log, ctx)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to load rollup config")
+		return nil, fmt.Errorf("failed to load rollup config: %w", err)
 	}
 
 	executionP2pRpcUrl := ctx.String(flags.HealthcheckExecutionP2pRPCUrl.Name)

--- a/op-conductor/conductor/service.go
+++ b/op-conductor/conductor/service.go
@@ -2,6 +2,7 @@ package conductor
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/rand"
 	"net/http"
@@ -12,9 +13,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
-	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/raft"
-	"github.com/pkg/errors"
 
 	"github.com/ethereum-optimism/optimism/op-conductor/client"
 	"github.com/ethereum-optimism/optimism/op-conductor/consensus"
@@ -58,7 +57,7 @@ func NewOpConductor(
 	hmon health.HealthMonitor,
 ) (*OpConductor, error) {
 	if err := cfg.Check(); err != nil {
-		return nil, errors.Wrap(err, "invalid config")
+		return nil, fmt.Errorf("invalid config: %w", err)
 	}
 
 	oc := &OpConductor{
@@ -95,7 +94,7 @@ func NewOpConductor(
 		// ensure we always close the resources if we fail to initialize the conductor.
 		closeErr := oc.Stop(ctx)
 		if closeErr != nil {
-			err = multierror.Append(err, closeErr)
+			err = errors.Join(err, closeErr)
 		}
 		return nil, err
 	}
@@ -106,19 +105,19 @@ func NewOpConductor(
 func (c *OpConductor) init(ctx context.Context) error {
 	c.log.Info("initializing OpConductor", "version", c.version)
 	if err := c.initSequencerControl(ctx); err != nil {
-		return errors.Wrap(err, "failed to initialize sequencer control")
+		return fmt.Errorf("failed to initialize sequencer control: %w", err)
 	}
 	if err := c.initConsensus(ctx); err != nil {
-		return errors.Wrap(err, "failed to initialize consensus")
+		return fmt.Errorf("failed to initialize consensus: %w", err)
 	}
 	if err := c.initHealthMonitor(ctx); err != nil {
-		return errors.Wrap(err, "failed to initialize health monitor")
+		return fmt.Errorf("failed to initialize health monitor: %w", err)
 	}
 	if err := c.initRPCServer(ctx); err != nil {
-		return errors.Wrap(err, "failed to initialize rpc server")
+		return fmt.Errorf("failed to initialize rpc server: %w", err)
 	}
 	if err := c.initFlashblocksHandler(ctx); err != nil {
-		return errors.Wrap(err, "failed to initialize flashblocks handler")
+		return fmt.Errorf("failed to initialize flashblocks handler: %w", err)
 	}
 	return nil
 }
@@ -130,18 +129,18 @@ func (c *OpConductor) initSequencerControl(ctx context.Context) error {
 
 	ec, err := opclient.NewRPC(ctx, c.log, c.cfg.ExecutionRPC)
 	if err != nil {
-		return errors.Wrap(err, "failed to create geth rpc client")
+		return fmt.Errorf("failed to create geth rpc client: %w", err)
 	}
 	execCfg := sources.L2ClientDefaultConfig(&c.cfg.RollupCfg, true)
 	// TODO: Add metrics tracer here. tracked by https://github.com/ethereum-optimism/protocol-quest/issues/45
 	exec, err := sources.NewEthClient(ec, c.log, nil, &execCfg.EthClientConfig)
 	if err != nil {
-		return errors.Wrap(err, "failed to create geth client")
+		return fmt.Errorf("failed to create geth client: %w", err)
 	}
 
 	nc, err := opclient.NewRPC(ctx, c.log, c.cfg.NodeRPC)
 	if err != nil {
-		return errors.Wrap(err, "failed to create node rpc client")
+		return fmt.Errorf("failed to create node rpc client: %w", err)
 	}
 	node := sources.NewRollupClient(nc)
 	c.ctrl = client.NewSequencerControl(exec, node)
@@ -159,7 +158,7 @@ func (c *OpConductor) initSequencerControl(ctx context.Context) error {
 		return enabled, err
 	})
 	if err != nil {
-		return errors.Wrap(err, "failed to connect to sequencer")
+		return fmt.Errorf("failed to connect to sequencer: %w", err)
 	}
 	if !enabled {
 		return errors.New("conductor is not enabled on sequencer, exiting...")
@@ -191,7 +190,7 @@ func (c *OpConductor) initConsensus(ctx context.Context) error {
 	cons, err := consensus.NewRaftConsensus(c.log, raftConsensusConfig)
 	if err != nil {
 		if !errors.Is(err, raft.ErrCantBootstrap) {
-			return errors.Wrap(err, "failed to create raft consensus")
+			return fmt.Errorf("failed to create raft consensus: %w", err)
 		}
 	} else if c.cfg.RaftBootstrap {
 		c.log.Warn("Raft cluster bootstrapped, pausing conductor.")
@@ -209,7 +208,7 @@ func (c *OpConductor) initHealthMonitor(ctx context.Context) error {
 
 	nc, err := opclient.NewRPC(ctx, c.log, c.cfg.NodeRPC)
 	if err != nil {
-		return errors.Wrap(err, "failed to create node rpc client")
+		return fmt.Errorf("failed to create node rpc client: %w", err)
 	}
 	node := sources.NewRollupClient(nc)
 
@@ -229,7 +228,7 @@ func (c *OpConductor) initHealthMonitor(ctx context.Context) error {
 	if c.cfg.HealthCheck.ExecutionP2pEnabled {
 		execClient, err := dial.DialEthClientWithTimeout(ctx, 1*time.Minute, c.log, c.cfg.HealthCheck.ExecutionP2pRPCUrl)
 		if err != nil {
-			return errors.Wrap(err, "failed to create execution rpc client out of the el p2p rpc url: "+c.cfg.HealthCheck.ExecutionP2pRPCUrl)
+			return fmt.Errorf("failed to create execution rpc client out of the el p2p rpc url %s: %w", c.cfg.HealthCheck.ExecutionP2pRPCUrl, err)
 		}
 		switch c.cfg.HealthCheck.ExecutionP2pCheckApi {
 		case "net":
@@ -249,7 +248,7 @@ func (c *OpConductor) initHealthMonitor(ctx context.Context) error {
 	if c.cfg.SupervisorRPC != "" {
 		supervisor, err = dial.DialSupervisorClientWithTimeout(ctx, c.log, c.cfg.SupervisorRPC)
 		if err != nil {
-			return errors.Wrap(err, "failed to dial supervisor")
+			return fmt.Errorf("failed to dial supervisor: %w", err)
 		}
 	}
 
@@ -294,7 +293,7 @@ func (oc *OpConductor) initRPCServer(ctx context.Context) error {
 	if oc.cfg.RPCEnableProxy {
 		execClient, err := dial.DialEthClientWithTimeout(ctx, 1*time.Minute, oc.log, oc.cfg.ExecutionRPC)
 		if err != nil {
-			return errors.Wrap(err, "failed to create execution rpc client")
+			return fmt.Errorf("failed to create execution rpc client: %w", err)
 		}
 		executionProxy := conductorrpc.NewExecutionProxyBackend(oc.log, oc, execClient)
 		server.AddAPI(rpc.API{
@@ -309,7 +308,7 @@ func (oc *OpConductor) initRPCServer(ctx context.Context) error {
 
 		nodeClient, err := dial.DialRollupClientWithTimeout(ctx, oc.log, oc.cfg.NodeRPC)
 		if err != nil {
-			return errors.Wrap(err, "failed to create node rpc client")
+			return fmt.Errorf("failed to create node rpc client: %w", err)
 		}
 		nodeProxy := conductorrpc.NewNodeProxyBackend(oc.log, oc, nodeClient)
 		server.AddAPI(rpc.API{
@@ -344,7 +343,7 @@ func (c *OpConductor) initFlashblocksHandler(ctx context.Context) error {
 	}, c.metrics)
 
 	if err != nil {
-		return errors.Wrap(err, "failed to create flashblocks handler")
+		return fmt.Errorf("failed to create flashblocks handler: %w", err)
 	}
 
 	c.flashblocksHandler = handler
@@ -429,19 +428,19 @@ func (oc *OpConductor) Start(ctx context.Context) error {
 	oc.log.Info("starting OpConductor")
 
 	if err := oc.hmon.Start(ctx); err != nil {
-		return errors.Wrap(err, "failed to start health monitor")
+		return fmt.Errorf("failed to start health monitor: %w", err)
 	}
 
 	oc.log.Info("starting JSON-RPC server")
 	if err := oc.rpcServer.Start(); err != nil {
-		return errors.Wrap(err, "failed to start JSON-RPC server")
+		return fmt.Errorf("failed to start JSON-RPC server: %w", err)
 	}
 
 	// Start the flashblocks handler if it was initialized
 	if oc.flashblocksHandler != nil {
 		oc.log.Info("starting flashblocks handler")
 		if err := oc.flashblocksHandler.Start(ctx); err != nil {
-			return errors.Wrap(err, "failed to start flashblocks handler")
+			return fmt.Errorf("failed to start flashblocks handler: %w", err)
 		}
 	}
 
@@ -453,7 +452,7 @@ func (oc *OpConductor) Start(ctx context.Context) error {
 		}
 		metricsServer, err := opmetrics.StartServer(m.Registry(), oc.cfg.MetricsConfig.ListenAddr, oc.cfg.MetricsConfig.ListenPort)
 		if err != nil {
-			return errors.Wrap(err, "failed to start metrics server")
+			return fmt.Errorf("failed to start metrics server: %w", err)
 		}
 		oc.metricsServer = metricsServer
 	}
@@ -480,7 +479,7 @@ func (oc *OpConductor) Stop(ctx context.Context) error {
 	}
 
 	oc.log.Info("stopping OpConductor")
-	var result *multierror.Error
+	var result error
 
 	// close control loop
 	oc.shutdownCancel()
@@ -494,32 +493,32 @@ func (oc *OpConductor) Stop(ctx context.Context) error {
 
 	if oc.rpcServer != nil {
 		if err := oc.rpcServer.Stop(); err != nil {
-			result = multierror.Append(result, errors.Wrap(err, "failed to stop rpc server"))
+			result = errors.Join(result, fmt.Errorf("failed to stop rpc server: %w", err))
 		}
 	}
 
 	// stop health check
 	if oc.hmon != nil {
 		if err := oc.hmon.Stop(); err != nil {
-			result = multierror.Append(result, errors.Wrap(err, "failed to stop health monitor"))
+			result = errors.Join(result, fmt.Errorf("failed to stop health monitor: %w", err))
 		}
 	}
 
 	if oc.cons != nil {
 		if err := oc.cons.Shutdown(); err != nil {
-			result = multierror.Append(result, errors.Wrap(err, "failed to shutdown consensus"))
+			result = errors.Join(result, fmt.Errorf("failed to shutdown consensus: %w", err))
 		}
 	}
 
 	if oc.metricsServer != nil {
 		if err := oc.metricsServer.Shutdown(ctx); err != nil {
-			result = multierror.Append(result, errors.Wrap(err, "failed to stop metrics server"))
+			result = errors.Join(result, fmt.Errorf("failed to stop metrics server: %w", err))
 		}
 	}
 
-	if result.ErrorOrNil() != nil {
-		oc.log.Error("failed to stop OpConductor", "err", result.ErrorOrNil())
-		return result.ErrorOrNil()
+	if result != nil {
+		oc.log.Error("failed to stop OpConductor", "err", result)
+		return result
 	}
 
 	oc.stopped.Store(true)
@@ -548,7 +547,7 @@ func (oc *OpConductor) Pause(ctx context.Context) error {
 func (oc *OpConductor) Resume(ctx context.Context) error {
 	err := oc.updateSequencerActiveStatus()
 	if err != nil {
-		return errors.Wrap(err, "cannot resume because failed to get sequencer active status")
+		return fmt.Errorf("cannot resume because failed to get sequencer active status: %w", err)
 	}
 
 	select {
@@ -779,13 +778,13 @@ func (oc *OpConductor) action() {
 
 		// 2. we're here because an healthy leader became unhealthy itself
 		//    then we should try to stop sequencing locally and transfer leadership.
-		var result *multierror.Error
+		var result error
 		// Try to stop sequencer first, but since sequencer is not healthy, we may not be able to stop it.
 		// In this case, it's fine to continue to try to transfer leadership to another server. This is safe because
 		// 1. if leadership transfer succeeded, then we'll retry and enter case !status.leader && status.healthy && status.active, which will try to stop sequencer.
 		// 2. even if the retry continues to fail and current server stays in active sequencing mode, it would be safe because our hook in op-node will prevent it from committing any new blocks to the network via p2p (if it's not leader any more)
 		if e := oc.stopSequencer(); e != nil {
-			result = multierror.Append(result, e)
+			result = errors.Join(result, e)
 		}
 		// try to transfer leadership to another server despite if sequencer is stopped or not. There are 4 scenarios here:
 		// 1. [sequencer stopped, leadership transfer succeeded] which is the happy case and we handed over sequencing to another server.
@@ -793,9 +792,9 @@ func (oc *OpConductor) action() {
 		// 3. [sequencer active, leadership transfer succeeded] we'll enter into case !status.leader && status.healthy && status.active and retry stop sequencer.
 		// 4. [sequencer active, leadership transfer failed] we're in the same state and will retry here again.
 		if e := oc.transferLeader(); e != nil {
-			result = multierror.Append(result, e)
+			result = errors.Join(result, e)
 		}
-		err = result.ErrorOrNil()
+		err = result
 	case status.leader && status.healthy && !status.active:
 		// start sequencer
 		err = oc.startSequencer()
@@ -867,7 +866,7 @@ func (oc *OpConductor) stopSequencer() error {
 		if strings.Contains(err.Error(), driver.ErrSequencerAlreadyStopped.Error()) {
 			oc.log.Warn("sequencer already stopped", "err", err)
 		} else {
-			return errors.Wrap(err, "failed to stop sequencer")
+			return fmt.Errorf("failed to stop sequencer: %w", err)
 		}
 	}
 	oc.metrics.RecordStopSequencer(err == nil)
@@ -918,7 +917,7 @@ func (oc *OpConductor) startSequencer() error {
 func (oc *OpConductor) compareUnsafeHead(ctx context.Context) (*eth.ExecutionPayloadEnvelope, eth.BlockInfo, error) {
 	unsafeInCons, err := oc.cons.LatestUnsafePayload()
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "unable to retrieve unsafe head from consensus")
+		return nil, nil, fmt.Errorf("unable to retrieve unsafe head from consensus: %w", err)
 	}
 	if unsafeInCons == nil {
 		return nil, nil, ErrNoUnsafeHead
@@ -926,7 +925,7 @@ func (oc *OpConductor) compareUnsafeHead(ctx context.Context) (*eth.ExecutionPay
 
 	unsafeInNode, err := oc.ctrl.LatestUnsafeBlock(ctx)
 	if err != nil {
-		return unsafeInCons, nil, errors.Wrap(err, "failed to get latest unsafe block from EL during compareUnsafeHead phase")
+		return unsafeInCons, nil, fmt.Errorf("failed to get latest unsafe block from EL during compareUnsafeHead phase: %w", err)
 	}
 
 	oc.log.Debug("comparing unsafe head", "consensus", uint64(unsafeInCons.ExecutionPayload.BlockNumber), "node", unsafeInNode.NumberU64())
@@ -948,7 +947,7 @@ func (oc *OpConductor) compareUnsafeHead(ctx context.Context) (*eth.ExecutionPay
 func (oc *OpConductor) updateSequencerActiveStatus() error {
 	active, err := oc.ctrl.SequencerActive(oc.shutdownCtx)
 	if err != nil {
-		return errors.Wrap(err, "failed to get sequencer active status")
+		return fmt.Errorf("failed to get sequencer active status: %w", err)
 	}
 	oc.log.Info("sequencer active status updated", "active", active)
 	oc.seqActive.Store(active)

--- a/op-conductor/conductor/service_test.go
+++ b/op-conductor/conductor/service_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/hashicorp/go-multierror"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
@@ -876,8 +875,9 @@ func (s *OpConductorTestSuite) TestConductorRestart() {
 func (s *OpConductorTestSuite) TestHandleInitError() {
 	// This will cause an error in the init function, which should cause the conductor to stop successfully without issues.
 	_, err := New(s.ctx, &s.cfg, s.log, s.version)
-	_, ok := err.(*multierror.Error)
-	// error should not be a multierror, this means that init failed, but Stop() succeeded, which is what we expect.
+	// error should not be a joined error, this means that init failed, but Stop() succeeded, which is what we expect.
+	type multiUnwrap interface{ Unwrap() []error }
+	_, ok := err.(multiUnwrap)
 	s.False(ok)
 }
 

--- a/op-conductor/consensus/raft.go
+++ b/op-conductor/consensus/raft.go
@@ -2,6 +2,7 @@ package consensus
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -11,7 +12,6 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/hashicorp/raft"
 	boltdb "github.com/hashicorp/raft-boltdb/v2"
-	"github.com/pkg/errors"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -136,7 +136,7 @@ func NewRaftConsensus(log log.Logger, cfg *RaftConsensusConfig) (*RaftConsensus,
 	// When advertiseAddr == nil, the transport will use the local address that it is bound to.
 	transport, err := raft.NewTCPTransportWithLogger(bindAddr, advertiseAddr, maxConnPool, timeout, rc.Logger)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to create raft tcp transport")
+		return nil, fmt.Errorf("failed to create raft tcp transport: %w", err)
 	}
 	log.Info("Raft server network transport is up", "addr", transport.LocalAddr())
 
@@ -145,7 +145,7 @@ func NewRaftConsensus(log log.Logger, cfg *RaftConsensusConfig) (*RaftConsensus,
 	r, err := raft.NewRaft(rc, fsm, logStore, stableStore, snapshotStore, transport)
 	if err != nil {
 		log.Error("failed to create raft", "err", err)
-		return nil, errors.Wrap(err, "failed to create raft")
+		return nil, fmt.Errorf("failed to create raft: %w", err)
 	}
 
 	// If bootstrap = true, start raft in bootstrap mode, this will allow the current node to elect itself as leader when there's no other participants
@@ -175,7 +175,7 @@ func NewRaftConsensus(log log.Logger, cfg *RaftConsensusConfig) (*RaftConsensus,
 			if errors.Is(err, raft.ErrCantBootstrap) {
 				log.Warn("Raft cluster already exists, skipping bootstrap")
 			} else {
-				return nil, errors.Wrap(err, "failed to bootstrap raft cluster")
+				return nil, fmt.Errorf("failed to bootstrap raft cluster: %w", err)
 			}
 		}
 	}
@@ -307,12 +307,12 @@ func (rc *RaftConsensus) CommitUnsafePayload(payload *eth.ExecutionPayloadEnvelo
 
 	var buf bytes.Buffer
 	if _, err := payload.MarshalSSZ(&buf); err != nil {
-		return errors.Wrap(err, "failed to marshal payload envelope")
+		return fmt.Errorf("failed to marshal payload envelope: %w", err)
 	}
 
 	f := rc.r.Apply(buf.Bytes(), defaultTimeout)
 	if err := f.Error(); err != nil {
-		return errors.Wrap(err, "failed to apply payload envelope")
+		return fmt.Errorf("failed to apply payload envelope: %w", err)
 	}
 	rc.log.Debug("unsafe payload committed", "number", uint64(payload.ExecutionPayload.BlockNumber), "hash", payload.ExecutionPayload.BlockHash.Hex())
 
@@ -322,7 +322,7 @@ func (rc *RaftConsensus) CommitUnsafePayload(payload *eth.ExecutionPayloadEnvelo
 // LatestUnsafePayload implements Consensus, it returns the latest unsafe payload from FSM in a strongly consistent fashion.
 func (rc *RaftConsensus) LatestUnsafePayload() (*eth.ExecutionPayloadEnvelope, error) {
 	if err := rc.r.Barrier(defaultTimeout).Error(); err != nil {
-		return nil, errors.Wrap(err, "failed to apply barrier")
+		return nil, fmt.Errorf("failed to apply barrier: %w", err)
 	}
 
 	return rc.unsafeTracker.UnsafeHead(), nil

--- a/op-conductor/consensus/raft_fsm_test.go
+++ b/op-conductor/consensus/raft_fsm_test.go
@@ -2,6 +2,7 @@ package consensus
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"testing"
 
@@ -10,7 +11,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/hashicorp/raft"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -86,7 +86,7 @@ func NewMockReadCloser(data *eth.ExecutionPayloadEnvelope) (*mockReadCloser, err
 
 	var buf bytes.Buffer
 	if _, err := data.MarshalSSZ(&buf); err != nil {
-		return nil, errors.Wrap(err, "failed to unmarshal execution payload envelope")
+		return nil, fmt.Errorf("failed to unmarshal execution payload envelope: %w", err)
 	}
 	mrc.buffer = buf.Bytes()
 

--- a/op-deployer/pkg/deployer/broadcaster/keyed.go
+++ b/op-deployer/pkg/deployer/broadcaster/keyed.go
@@ -2,6 +2,7 @@ package broadcaster
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 	"sync"
@@ -19,7 +20,6 @@ import (
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/hashicorp/go-multierror"
 )
 
 const (
@@ -128,7 +128,7 @@ func (t *KeyedBroadcaster) Broadcast(ctx context.Context) ([]BroadcastResult, er
 		)
 	}
 
-	var txErr *multierror.Error
+	var txErr error
 	var completed int
 	for i, fut := range futures {
 		bcastRes := <-fut
@@ -143,7 +143,7 @@ func (t *KeyedBroadcaster) Broadcast(ctx context.Context) ([]BroadcastResult, er
 
 			if bcastRes.Receipt.Status == 0 {
 				failErr := fmt.Errorf("transaction failed: %s", outRes.Receipt.TxHash.String())
-				txErr = multierror.Append(txErr, failErr)
+				txErr = errors.Join(txErr, failErr)
 				outRes.Err = failErr
 				t.lgr.Error(
 					"transaction failed on chain",
@@ -165,7 +165,7 @@ func (t *KeyedBroadcaster) Broadcast(ctx context.Context) ([]BroadcastResult, er
 				)
 			}
 		} else {
-			txErr = multierror.Append(txErr, bcastRes.Err)
+			txErr = errors.Join(txErr, bcastRes.Err)
 			outRes.Err = bcastRes.Err
 			t.lgr.Error(
 				"transaction failed",
@@ -178,7 +178,7 @@ func (t *KeyedBroadcaster) Broadcast(ctx context.Context) ([]BroadcastResult, er
 
 		results[i] = outRes
 	}
-	return results, txErr.ErrorOrNil()
+	return results, txErr
 }
 
 func (t *KeyedBroadcaster) broadcast(ctx context.Context, bcast script.Broadcast, blockGasLimit uint64) (<-chan txmgr.SendResponse, common.Hash) {

--- a/op-dispute-mon/mon/extract/bond_enricher.go
+++ b/op-dispute-mon/mon/extract/bond_enricher.go
@@ -4,10 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"math/big"
 	"slices"
-
-	"maps"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	monTypes "github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"

--- a/op-dispute-mon/mon/extract/bond_enricher.go
+++ b/op-dispute-mon/mon/extract/bond_enricher.go
@@ -5,12 +5,14 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"slices"
+
+	"maps"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	monTypes "github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
 	"github.com/ethereum/go-ethereum/common"
-	"golang.org/x/exp/maps"
 )
 
 var _ Enricher = (*BondEnricher)(nil)
@@ -29,7 +31,7 @@ func NewBondEnricher() *BondEnricher {
 }
 
 func (b *BondEnricher) Enrich(ctx context.Context, block rpcblock.Block, caller GameCaller, game *monTypes.EnrichedGameData) error {
-	recipientAddrs := maps.Keys(game.Recipients)
+	recipientAddrs := slices.Collect(maps.Keys(game.Recipients))
 	credits, err := caller.GetCredits(ctx, block, recipientAddrs...)
 	if err != nil {
 		return err

--- a/op-dispute-mon/mon/extract/extractor.go
+++ b/op-dispute-mon/mon/extract/extractor.go
@@ -4,11 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"slices"
 	"sync"
 	"sync/atomic"
-
-	"maps"
 
 	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	monTypes "github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"

--- a/op-dispute-mon/mon/extract/extractor.go
+++ b/op-dispute-mon/mon/extract/extractor.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"sync"
 	"sync/atomic"
+
+	"maps"
 
 	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	monTypes "github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
@@ -13,7 +16,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
-	"golang.org/x/exp/maps"
 )
 
 var (
@@ -125,7 +127,7 @@ func (e *Extractor) enrichGames(ctx context.Context, blockHash common.Hash, game
 		updatedGameData[enrichedGame.Proxy] = enrichedGame
 	}
 	e.latestGameData = updatedGameData
-	return maps.Values(updatedGameData), int(ignored.Load()), int(failed.Load())
+	return slices.Collect(maps.Values(updatedGameData)), int(ignored.Load()), int(failed.Load())
 }
 
 func (e *Extractor) enrichGame(ctx context.Context, blockHash common.Hash, game gameTypes.GameMetadata) (*monTypes.EnrichedGameData, error) {

--- a/op-dispute-mon/mon/extract/withdrawals_enricher.go
+++ b/op-dispute-mon/mon/extract/withdrawals_enricher.go
@@ -4,9 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"slices"
-
 	"maps"
+	"slices"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts"
 	monTypes "github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"

--- a/op-dispute-mon/mon/extract/withdrawals_enricher.go
+++ b/op-dispute-mon/mon/extract/withdrawals_enricher.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
+
+	"maps"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts"
 	monTypes "github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
 	"github.com/ethereum/go-ethereum/common"
-	"golang.org/x/exp/maps"
 )
 
 var ErrIncorrectWithdrawalsCount = errors.New("incorrect withdrawals count")
@@ -23,7 +25,7 @@ func NewWithdrawalsEnricher() *WithdrawalsEnricher {
 }
 
 func (w *WithdrawalsEnricher) Enrich(ctx context.Context, block rpcblock.Block, caller GameCaller, game *monTypes.EnrichedGameData) error {
-	recipients := maps.Keys(game.Recipients)
+	recipients := slices.Collect(maps.Keys(game.Recipients))
 	withdrawals, err := caller.GetWithdrawals(ctx, block, recipients...)
 	if err != nil {
 		return fmt.Errorf("failed to fetch withdrawals: %w", err)

--- a/op-e2e/config/init.go
+++ b/op-e2e/config/init.go
@@ -12,6 +12,8 @@ import (
 	"sync"
 	"time"
 
+	"maps"
+
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/versions"
 	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer"
@@ -22,7 +24,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/state"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
-	"golang.org/x/exp/maps"
 
 	"github.com/ethereum-optimism/optimism/op-e2e/config/secrets"
 	"github.com/ethereum/go-ethereum/common/hexutil"

--- a/op-e2e/config/init.go
+++ b/op-e2e/config/init.go
@@ -5,14 +5,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"maps"
 	"math/big"
 	"os"
 	"path"
 	"slices"
 	"sync"
 	"time"
-
-	"maps"
 
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm/versions"
 	"github.com/ethereum-optimism/optimism/op-core/forks"

--- a/op-e2e/faultproofs/cannon_benchmark_test.go
+++ b/op-e2e/faultproofs/cannon_benchmark_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"encoding/json"
+	"fmt"
 	"math/big"
 	"os"
 	"path"
@@ -21,7 +22,6 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm"
@@ -142,12 +142,12 @@ func createBigContracts(ctx context.Context, t *testing.T, cfg e2esys.SystemConf
 			defer cancel()
 			err := client.SendTransaction(ctx, tx)
 			if err != nil {
-				results <- result{err: errors.Wrap(err, "Sending L2 tx")}
+				results <- result{err: fmt.Errorf("Sending L2 tx: %w", err)}
 				return
 			}
 			receipt, err := wait.ForReceiptOK(ctx, client, tx.Hash())
 			if err != nil {
-				results <- result{err: errors.Wrap(err, "Waiting for receipt")}
+				results <- result{err: fmt.Errorf("Waiting for receipt: %w", err)}
 				return
 			}
 			results <- result{addr: receipt.ContractAddress, err: nil}

--- a/op-e2e/system/e2esys/setup.go
+++ b/op-e2e/system/e2esys/setup.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"errors"
 	"fmt"
+	"maps"
 	"math/big"
 	"net"
 	"os"
@@ -16,8 +17,6 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
-
-	"maps"
 
 	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/stretchr/testify/require"

--- a/op-e2e/system/e2esys/setup.go
+++ b/op-e2e/system/e2esys/setup.go
@@ -10,15 +10,17 @@ import (
 	"net"
 	"os"
 	"path"
+	"slices"
 	"sort"
 	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"maps"
+
 	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/maps"
 
 	ds "github.com/ipfs/go-datastore"
 	dsSync "github.com/ipfs/go-datastore/sync"
@@ -871,7 +873,7 @@ func (cfg SystemConfig) Start(t *testing.T, startOpts ...StartOption) (*System, 
 	// Rollup nodes
 
 	// Ensure we are looping through the nodes in alphabetical order
-	ks := maps.Keys(cfg.Nodes)
+	ks := slices.Collect(maps.Keys(cfg.Nodes))
 	// Sort strings in ascending alphabetical order
 	sort.Strings(ks)
 

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -10,8 +10,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/hashicorp/go-multierror"
-
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -190,7 +188,7 @@ func NewWithOverride(ctx context.Context, cfg *config.Config, log log.Logger, ap
 		log.Error("Error initializing the rollup node", "err", err)
 		// ensure we always close the node resources if we fail to initialize the node.
 		if closeErr := n.Stop(ctx); closeErr != nil {
-			return nil, multierror.Append(err, closeErr)
+			return nil, errors.Join(err, closeErr)
 		}
 		return nil, err
 	}
@@ -858,11 +856,11 @@ func (n *OpNode) Stop(ctx context.Context) error {
 		return ErrAlreadyClosed
 	}
 
-	var result *multierror.Error
+	var result error
 
 	if n.server != nil {
 		if err := n.server.Stop(); err != nil {
-			result = multierror.Append(result, fmt.Errorf("failed to close RPC server: %w", err))
+			result = errors.Join(result, fmt.Errorf("failed to close RPC server: %w", err))
 		}
 	}
 
@@ -876,14 +874,14 @@ func (n *OpNode) Stop(ctx context.Context) error {
 		case err == nil:
 			n.log.Info("stopped sequencer", "latestHead", latestHead)
 		default:
-			result = multierror.Append(result, fmt.Errorf("error stopping sequencer: %w", err))
+			result = errors.Join(result, fmt.Errorf("error stopping sequencer: %w", err))
 		}
 	}
 
 	n.p2pMu.Lock()
 	if n.p2pNode != nil {
 		if err := n.p2pNode.Close(); err != nil {
-			result = multierror.Append(result, fmt.Errorf("failed to close p2p node: %w", err))
+			result = errors.Join(result, fmt.Errorf("failed to close p2p node: %w", err))
 		}
 		// Prevent further use of p2p.
 		n.p2pNode = nil
@@ -892,7 +890,7 @@ func (n *OpNode) Stop(ctx context.Context) error {
 
 	if n.p2pSigner != nil {
 		if err := n.p2pSigner.Close(); err != nil {
-			result = multierror.Append(result, fmt.Errorf("failed to close p2p signer: %w", err))
+			result = errors.Join(result, fmt.Errorf("failed to close p2p signer: %w", err))
 		}
 	}
 
@@ -916,14 +914,14 @@ func (n *OpNode) Stop(ctx context.Context) error {
 	// close L2 driver
 	if n.l2Driver != nil {
 		if err := n.l2Driver.Close(); err != nil {
-			result = multierror.Append(result, fmt.Errorf("failed to close L2 engine driver cleanly: %w", err))
+			result = errors.Join(result, fmt.Errorf("failed to close L2 engine driver cleanly: %w", err))
 		}
 	}
 
 	// close the interop sub system
 	if n.interopSys != nil {
 		if err := n.interopSys.Stop(ctx); err != nil {
-			result = multierror.Append(result, fmt.Errorf("failed to close interop sub-system: %w", err))
+			result = errors.Join(result, fmt.Errorf("failed to close interop sub-system: %w", err))
 		}
 	}
 
@@ -933,7 +931,7 @@ func (n *OpNode) Stop(ctx context.Context) error {
 
 	if n.safeDB != nil {
 		if err := n.safeDB.Close(); err != nil {
-			result = multierror.Append(result, fmt.Errorf("failed to close safe head db: %w", err))
+			result = errors.Join(result, fmt.Errorf("failed to close safe head db: %w", err))
 		}
 	}
 
@@ -970,16 +968,16 @@ func (n *OpNode) Stop(ctx context.Context) error {
 	// Close metrics and pprof only after we are done idling
 	if n.pprofService != nil {
 		if err := n.pprofService.Stop(ctx); err != nil {
-			result = multierror.Append(result, fmt.Errorf("failed to close pprof server: %w", err))
+			result = errors.Join(result, fmt.Errorf("failed to close pprof server: %w", err))
 		}
 	}
 	if n.metricsSrv != nil {
 		if err := n.metricsSrv.Stop(ctx); err != nil {
-			result = multierror.Append(result, fmt.Errorf("failed to close metrics server: %w", err))
+			result = errors.Join(result, fmt.Errorf("failed to close metrics server: %w", err))
 		}
 	}
 
-	return result.ErrorOrNil()
+	return result
 }
 
 func (n *OpNode) Stopped() bool {

--- a/op-node/p2p/node.go
+++ b/op-node/p2p/node.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/hashicorp/go-multierror"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/connmgr"
 	"github.com/libp2p/go-libp2p/core/host"
@@ -276,7 +275,7 @@ func (n *NodeP2P) BanIP(ip net.IP, expiration time.Time) error {
 }
 
 func (n *NodeP2P) Close() error {
-	var result *multierror.Error
+	var result error
 	if n.peerMonitor != nil {
 		n.peerMonitor.Stop()
 	}
@@ -285,23 +284,23 @@ func (n *NodeP2P) Close() error {
 	}
 	if n.gsOut != nil {
 		if err := n.gsOut.Close(); err != nil {
-			result = multierror.Append(result, fmt.Errorf("failed to close gossip cleanly: %w", err))
+			result = errors.Join(result, fmt.Errorf("failed to close gossip cleanly: %w", err))
 		}
 	}
 	if n.host != nil {
 		if err := n.host.Close(); err != nil {
-			result = multierror.Append(result, fmt.Errorf("failed to close p2p host cleanly: %w", err))
+			result = errors.Join(result, fmt.Errorf("failed to close p2p host cleanly: %w", err))
 		}
 		if n.syncCl != nil {
 			if err := n.syncCl.Close(); err != nil {
-				result = multierror.Append(result, fmt.Errorf("failed to close p2p sync client cleanly: %w", err))
+				result = errors.Join(result, fmt.Errorf("failed to close p2p sync client cleanly: %w", err))
 			}
 		}
 	}
 	if n.appScorer != nil {
 		n.appScorer.Stop()
 	}
-	return result.ErrorOrNil()
+	return result
 }
 
 func FindActiveTCPPort(h host.Host) (uint16, error) {

--- a/op-node/rollup/derive/batch_mux.go
+++ b/op-node/rollup/derive/batch_mux.go
@@ -3,12 +3,12 @@ package derive
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/log"
-	"golang.org/x/exp/slices"
 )
 
 // BatchMux multiplexes between different batch stages.

--- a/op-node/rollup/derive/deposits.go
+++ b/op-node/rollup/derive/deposits.go
@@ -1,9 +1,8 @@
 package derive
 
 import (
+	"errors"
 	"fmt"
-
-	"github.com/hashicorp/go-multierror"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -22,7 +21,7 @@ func UserDeposits(receipts []*types.Receipt, depositContractAddr common.Address)
 			if log.Address == depositContractAddr && len(log.Topics) > 0 && log.Topics[0] == DepositEventABIHash {
 				dep, err := UnmarshalDepositLogEvent(log)
 				if err != nil {
-					result = multierror.Append(result, fmt.Errorf("malformatted L1 deposit log in receipt %d, log %d: %w", i, j, err))
+					result = errors.Join(result, fmt.Errorf("malformatted L1 deposit log in receipt %d, log %d: %w", i, j, err))
 				} else {
 					out = append(out, dep)
 				}
@@ -36,13 +35,13 @@ func DeriveDeposits(receipts []*types.Receipt, depositContractAddr common.Addres
 	var result error
 	userDeposits, err := UserDeposits(receipts, depositContractAddr)
 	if err != nil {
-		result = multierror.Append(result, err)
+		result = errors.Join(result, err)
 	}
 	encodedTxs := make([]hexutil.Bytes, 0, len(userDeposits))
 	for i, tx := range userDeposits {
 		opaqueTx, err := types.NewTx(tx).MarshalBinary()
 		if err != nil {
-			result = multierror.Append(result, fmt.Errorf("failed to encode user tx %d", i))
+			result = errors.Join(result, fmt.Errorf("failed to encode user tx %d", i))
 		} else {
 			encodedTxs = append(encodedTxs, opaqueTx)
 		}

--- a/op-node/rollup/derive/system_config.go
+++ b/op-node/rollup/derive/system_config.go
@@ -9,7 +9,6 @@ import (
 	"github.com/ethereum/go-ethereum/consensus/misc/eip1559"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/hashicorp/go-multierror"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -41,7 +40,7 @@ var (
 
 // UpdateSystemConfigWithL1Receipts filters all L1 receipts to find config updates and applies the config updates to the given sysCfg
 // Updates are applied individually, and any malformed or invalid updates are ignored.
-// Any errors encountered during the update process are returned as a multierror.
+// Any errors encountered during the update process are returned as a joined error.
 func UpdateSystemConfigWithL1Receipts(sysCfg *eth.SystemConfig, receipts []*types.Receipt, cfg *rollup.Config, l1Time uint64) error {
 	var result error
 	for i, rec := range receipts {
@@ -58,7 +57,7 @@ func UpdateSystemConfigWithL1Receipts(sysCfg *eth.SystemConfig, receipts []*type
 					*sysCfg = updated
 				} else {
 					// or append the error to the result
-					result = multierror.Append(result, fmt.Errorf("malformatted L1 system sysCfg log in receipt %d, log %d: %w", i, j, err))
+					result = errors.Join(result, fmt.Errorf("malformatted L1 system sysCfg log in receipt %d, log %d: %w", i, j, err))
 				}
 			}
 		}

--- a/op-service/event/tracer_timing.go
+++ b/op-service/event/tracer_timing.go
@@ -2,11 +2,12 @@ package event
 
 import (
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 	"time"
 
-	"golang.org/x/exp/maps"
+	"maps"
 )
 
 // TimingTracer generates an HTML output with an SVG that shows,
@@ -131,7 +132,7 @@ func (st *TimingTracer) Output() string {
 	}
 
 	// sort the keys, to get deterministic diagram order
-	actors := maps.Keys(byActor)
+	actors := slices.Collect(maps.Keys(byActor))
 	sort.Strings(actors)
 
 	offsetY := float64(0)
@@ -142,7 +143,7 @@ func (st *TimingTracer) Output() string {
 	for _, actorName := range actors {
 
 		m := byActor[actorName]
-		derived := maps.Keys(m)
+		derived := slices.Collect(maps.Keys(m))
 		sort.Strings(derived)
 
 		for _, d := range derived {
@@ -189,7 +190,7 @@ func (st *TimingTracer) Output() string {
 	// draw lines between event-emissions and event-execution
 	for _, actorName := range actors {
 		m := byActor[actorName]
-		derived := maps.Keys(m)
+		derived := slices.Collect(maps.Keys(m))
 		sort.Strings(derived)
 		for _, d := range derived {
 			entries := m[d]

--- a/op-service/event/tracer_timing.go
+++ b/op-service/event/tracer_timing.go
@@ -2,12 +2,11 @@ package event
 
 import (
 	"fmt"
+	"maps"
 	"slices"
 	"sort"
 	"strings"
 	"time"
-
-	"maps"
 )
 
 // TimingTracer generates an HTML output with an SVG that shows,

--- a/op-service/safemath/safemath.go
+++ b/op-service/safemath/safemath.go
@@ -1,10 +1,14 @@
 package safemath
 
-import "golang.org/x/exp/constraints"
+// Unsigned is a constraint for unsigned integer types, including named types
+// whose underlying type is unsigned. Replaces golang.org/x/exp/Unsigned.
+type Unsigned interface {
+	~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr
+}
 
 // SaturatingAdd adds two unsigned integer values (of the same type),
 // and caps the result at the max value of the type.
-func SaturatingAdd[V constraints.Unsigned](a, b V) V {
+func SaturatingAdd[V Unsigned](a, b V) V {
 	out, overflow := SafeAdd(a, b)
 	if overflow {
 		return ^V(0) // max value
@@ -14,7 +18,7 @@ func SaturatingAdd[V constraints.Unsigned](a, b V) V {
 
 // SafeAdd adds two unsigned integer values (of the same type),
 // and allows integer overflows, and returns if it overflowed.
-func SafeAdd[V constraints.Unsigned](a, b V) (out V, overflow bool) {
+func SafeAdd[V Unsigned](a, b V) (out V, overflow bool) {
 	out = a + b
 	overflow = out < a
 	return
@@ -22,7 +26,7 @@ func SafeAdd[V constraints.Unsigned](a, b V) (out V, overflow bool) {
 
 // SaturatingSub subtracts two unsigned integer values (of the same type),
 // and floors the result at zero.
-func SaturatingSub[V constraints.Unsigned](a, b V) V {
+func SaturatingSub[V Unsigned](a, b V) V {
 	out, underflow := SafeSub(a, b)
 	if underflow {
 		return V(0) // min value
@@ -32,7 +36,7 @@ func SaturatingSub[V constraints.Unsigned](a, b V) V {
 
 // SafeSub subtracts two unsigned integer values (of the same type),
 // and allows integer underflows, and returns if it underflowed.
-func SafeSub[V constraints.Unsigned](a, b V) (out V, underflow bool) {
+func SafeSub[V Unsigned](a, b V) (out V, underflow bool) {
 	out = a - b
 	underflow = out > a
 	return

--- a/op-service/safemath/safemath_test.go
+++ b/op-service/safemath/safemath_test.go
@@ -5,8 +5,6 @@ import (
 	"math/big"
 	"testing"
 
-	"golang.org/x/exp/constraints"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
@@ -23,7 +21,7 @@ func TestAdd(t *testing.T) {
 	t.Run("uint", testAdd[uint])
 }
 
-func testAdd[V constraints.Unsigned](t *testing.T) {
+func testAdd[V Unsigned](t *testing.T) {
 	m := ^V(0)
 	require.Less(t, m+1, m, "sanity check max value does overflow")
 	vals := []V{
@@ -66,7 +64,7 @@ func TestSub(t *testing.T) {
 	t.Run("uint", testSub[uint])
 }
 
-func testSub[V constraints.Unsigned](t *testing.T) {
+func testSub[V Unsigned](t *testing.T) {
 	m := ^V(0)
 	require.Less(t, m+1, m, "sanity check min value does underflow")
 	vals := []V{

--- a/op-service/sources/batching/batching.go
+++ b/op-service/sources/batching/batching.go
@@ -8,8 +8,6 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/hashicorp/go-multierror"
-
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
@@ -149,7 +147,7 @@ func (ibc *IterativeBatchCall[K, V]) Fetch(ctx context.Context) error {
 	var result error
 	for _, elem := range batch {
 		if elem.Error != nil {
-			result = multierror.Append(result, elem.Error)
+			result = errors.Join(result, elem.Error)
 			elem.Error = nil // reset, we'll try this element again
 			ibc.scheduled <- elem
 			continue

--- a/op-service/sources/batching/batching_test.go
+++ b/op-service/sources/batching/batching_test.go
@@ -259,7 +259,7 @@ func TestFetchBatched(t *testing.T) {
 						{id: 0, err: false},
 						{id: 1, err: true},
 					},
-					err: "1 error occurred:",
+					err: "mockErr",
 				},
 				{
 					elems: []elemCall{
@@ -294,14 +294,14 @@ func TestFetchBatched(t *testing.T) {
 						{id: 0, err: true},
 						{id: 1, err: true},
 					},
-					err: "2 errors occurred:",
+					err: "mockErr",
 				},
 				{
 					elems: []elemCall{
 						{id: 0, err: false},
 						{id: 1, err: true},
 					},
-					err: "1 error occurred:",
+					err: "mockErr",
 				},
 				{
 					elems: []elemCall{


### PR DESCRIPTION
## Summary

Addresses the **High Priority** items from #19996 — replace three deprecated/superseded Go dependencies with stdlib equivalents:

- **`golang.org/x/exp` → stdlib** (20 files): `maps` → stdlib `maps` (wrapping `Keys`/`Values` with `slices.Collect`), `slices` → stdlib `slices`, `constraints` → local `Unsigned` interface
- **`github.com/pkg/errors` → `fmt.Errorf` + `%w`** (5 files): Replace `errors.Wrap(err, "msg")` with `fmt.Errorf("msg: %w", err)`
- **`github.com/hashicorp/go-multierror` → `errors.Join`** (8 files): Replace `multierror.Append` with `errors.Join`, `*multierror.Error` with `error`, `ErrorOrNil()` with direct return

### Results

- `go-multierror` fully removed from `go.mod`
- `x/exp` and `pkg/errors` move to indirect (still used by transitive deps)
- 35 files changed, 174 insertions(+), 160 deletions(-)
- `just lint-go` passes with zero issues
- All affected package tests pass

## Test plan

- [x] `go build ./...` — zero errors
- [x] `just lint-go` — zero issues, `go mod tidy` clean
- [x] `go test ./op-service/safemath/...` — constraints replacement verified
- [x] `go test ./op-node/rollup/derive/...` — slices, deposits, system_config verified
- [x] `go test ./op-conductor/...` — pkg/errors + multierror replacements verified, including `TestHandleInitError` type assertion update
- [x] `go test ./op-service/sources/batching/...` — multierror test expectations updated and verified
- [x] `go test` for all other affected packages (op-batcher, op-challenger, op-dispute-mon, op-chain-ops, cannon, op-service/event)

🤖 Generated with [Claude Code](https://claude.com/claude-code)