### PR TITLE
ci: publish junit results for rust and acceptance tests

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -1932,6 +1932,12 @@ jobs:
       - when:
           condition: always
           steps:
+            - store_artifacts:
+                path: ./op-acceptance-tests/results
+                destination: junit-results
+      - when:
+          condition: always
+          steps:
             - store_test_results:
                 path: ./op-acceptance-tests/results
       - when:

--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -675,10 +675,25 @@ jobs:
           command: |
             command -v cargo-nextest >/dev/null || cargo binstall --locked --no-confirm cargo-nextest
       - run:
+          name: Prepare test results directory
+          working_directory: <<parameters.directory>>
+          command: |
+            mkdir -p target/nextest/ci
+            rm -f target/nextest/ci/results.xml
+      - run:
           name: Run cargo tests
           working_directory: <<parameters.directory>>
           no_output_timeout: 40m
-          command: just <<parameters.command>> <<parameters.flags>>
+          command: |
+            export NEXTEST_PROFILE=ci
+            just <<parameters.command>> <<parameters.flags>>
+      - store_artifacts:
+          path: <<parameters.directory>>/target/nextest/ci
+          destination: junit-results
+          when: always
+      - store_test_results:
+          path: <<parameters.directory>>/target/nextest/ci
+          when: always
       - rust-save-build-cache: *tests-cache-args
 
   # Shared unused dependencies check job

--- a/rust/.config/nextest.toml
+++ b/rust/.config/nextest.toml
@@ -1,0 +1,2 @@
+[profile.ci.junit]
+path = "results.xml"


### PR DESCRIPTION
This PR publishes JUnit artifacts for `op-acceptance-tests` in CircleCI and updates the shared Rust CI test job to emit nextest JUnit XML.
It adds a repo-level `rust/.config/nextest.toml` `ci` profile so nextest writes `target/nextest/ci/results.xml`, then uploads that directory via both `store_artifacts` and `store_test_results`.
Validation in this workspace was limited to YAML and TOML parse checks.
