### PR TITLE
test(op-e2e): add proof test for batcher change within channel_timeout

### DIFF
--- a/op-e2e/actions/proofs/batcher_change_test.go
+++ b/op-e2e/actions/proofs/batcher_change_test.go
@@ -1,0 +1,64 @@
+package proofs_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	actionsHelpers "github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
+	"github.com/ethereum-optimism/optimism/op-e2e/actions/proofs/helpers"
+)
+
+// Test_ProgramAction_BatcherChangeWithinChannelTimeout verifies that after a
+// pipeline reset, the system config is loaded from the walked-back L2 block
+// (channel_timeout L1 blocks behind the safe head's L1 origin), not from the
+// safe head itself.
+//
+// Scenario:
+//  1. Batcher A submits a batch.
+//  2. The batcher address is changed from A to B on L1.
+//  3. Batcher B submits a batch.
+//  4. The fault proof program re-derives the chain from scratch. During reset,
+//     the pipeline walks back by channel_timeout and should find the old system
+//     config (batcher A). If it incorrectly uses the safe head's config
+//     (batcher B), it rejects batcher A's batch and derivation diverges.
+func Test_ProgramAction_BatcherChangeWithinChannelTimeout(gt *testing.T) {
+	matrix := helpers.NewMatrix[any]()
+	matrix.AddDefaultTestCases(
+		nil,
+		helpers.NewForkMatrix(helpers.Granite, helpers.Jovian),
+		testBatcherChangeWithinChannelTimeout,
+	)
+	matrix.Run(gt)
+}
+
+func testBatcherChangeWithinChannelTimeout(gt *testing.T, testCfg *helpers.TestCfg[any]) {
+	t := actionsHelpers.NewDefaultTesting(gt)
+	env := helpers.NewL2FaultProofEnv(t, testCfg, helpers.NewTestParams(), helpers.NewBatcherCfg())
+
+	miner := env.Miner
+	sequencer := env.Sequencer
+
+	// Step 1: Batcher A (default) submits a batch.
+	miner.ActEmptyBlock(t)
+	sequencer.ActL1HeadSignal(t)
+	sequencer.ActBuildToL1Head(t)
+	safeAfterA := env.BatchMineAndSync(t)
+	require.Greater(t, safeAfterA.Number, uint64(0), "safe head should advance after batcher A's batch")
+
+	// Step 2: Change batcher from A to B (Bob) on L1 and replace env.Batcher.
+	env.RotateBatcher(t, env.Dp.Secrets.Bob)
+
+	// Step 3: Build L2 blocks adopting the batcher change, submit with batcher B.
+	sequencer.ActL1HeadSignal(t)
+	sequencer.ActBuildToL1Head(t)
+	safeAfterB := env.BatchMineAndSync(t)
+	require.Greater(t, safeAfterB.Number, safeAfterA.Number, "safe head should advance after batcher B's batch")
+
+	// Step 4: Run the fault proof program. This re-derives the chain from
+	// scratch, triggering a pipeline reset. The pipeline must walk back by
+	// channel_timeout and use batcher A's system config for the initial
+	// derivation window. If it uses batcher B's config, batcher A's batch
+	// is rejected and derivation produces a different (shorter) safe chain.
+	env.RunFaultProofProgram(t, safeAfterB.Number, testCfg.CheckResult, testCfg.InputParams...)
+}

--- a/op-e2e/actions/proofs/helpers/env.go
+++ b/op-e2e/actions/proofs/helpers/env.go
@@ -1,26 +1,29 @@
 package helpers
 
 import (
+	"crypto/ecdsa"
 	"math/rand"
-
-	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
-	"github.com/ethereum-optimism/optimism/op-core/forks"
-	e2ecfg "github.com/ethereum-optimism/optimism/op-e2e/config"
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
-	"github.com/ethereum-optimism/optimism/op-program/client/boot"
-	"github.com/ethereum/go-ethereum/params"
 
 	altda "github.com/ethereum-optimism/optimism/op-alt-da"
 	batcherFlags "github.com/ethereum-optimism/optimism/op-batcher/flags"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
+	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
+	"github.com/ethereum-optimism/optimism/op-e2e/bindings"
+	e2ecfg "github.com/ethereum-optimism/optimism/op-e2e/config"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-program/client/boot"
 	"github.com/ethereum-optimism/optimism/op-program/host/config"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/stretchr/testify/require"
 )
 
@@ -236,12 +239,40 @@ func NewOpProgramCfg(
 	return dfault
 }
 
+const L1BlockTime = 12
+
+// RotateBatcher updates the on-chain batcher address in the SystemConfig contract and replaces
+// env.Batcher with a new one using the given key. The L1 transaction is mined in a new L1 block.
+func (env *L2FaultProofEnv) RotateBatcher(t helpers.Testing, newBatcherKey *ecdsa.PrivateKey) {
+	t.Helper()
+	newAddr := crypto.PubkeyToAddress(newBatcherKey.PublicKey)
+
+	sysCfgContract, err := bindings.NewSystemConfig(env.Sd.RollupCfg.L1SystemConfigAddress, env.Miner.EthClient())
+	require.NoError(t, err)
+	sysCfgOwner, err := bind.NewKeyedTransactorWithChainID(env.Dp.Secrets.Deployer, env.Sd.RollupCfg.L1ChainID)
+	require.NoError(t, err)
+	_, err = sysCfgContract.SetBatcherHash(sysCfgOwner, eth.AddressAsLeftPaddedHash(newAddr))
+	require.NoError(t, err)
+
+	env.Miner.ActL1StartBlock(L1BlockTime)(t)
+	env.Miner.ActL1IncludeTx(env.Dp.Addresses.Deployer)(t)
+	env.Miner.ActL1EndBlock(t)
+
+	batcherCfg := NewBatcherCfg()
+	batcherCfg.BatcherKey = newBatcherKey
+	env.Batcher = helpers.NewL2Batcher(
+		env.log, env.Sd.RollupCfg, batcherCfg,
+		env.Sequencer.RollupClient(), env.Miner.EthClient(),
+		env.Engine.EthClient(), env.engCl,
+	)
+}
+
 // BatchAndMine batches the current unsafe chain to L1 and mines the L1 block containing the
 // batcher transaction.
 func (env *L2FaultProofEnv) BatchAndMine(t helpers.Testing) {
 	t.Helper()
 	env.Batcher.ActSubmitAll(t)
-	env.Miner.ActL1StartBlock(12)(t)
+	env.Miner.ActL1StartBlock(L1BlockTime)(t)
 	env.Miner.ActL1IncludeTxByHash(env.Batcher.LastSubmitted.Hash())(t)
 	env.Miner.ActL1EndBlock(t)
 }


### PR DESCRIPTION
Adds an action test that verifies the fault proof program correctly handles a batcher address change within the channel_timeout window.

The test:
1. Batcher A submits a batch
2. Batcher address is changed from A to B on L1
3. Batcher B submits a batch
4. The fault proof program re-derives the chain from scratch

If the pipeline uses the wrong system config on reset (batcher B from the safe head instead of batcher A from the walked-back block), it rejects batcher A's batch and derivation diverges from op-node.

Follow up to https://github.com/ethereum-optimism/optimism/pull/19792