### PR TITLE
fix(op-e2e): make Holocene activation proof test non-trivial

### DIFF
--- a/op-e2e/actions/proofs/holocene_activation_test.go
+++ b/op-e2e/actions/proofs/holocene_activation_test.go
@@ -89,11 +89,9 @@ func Test_ProgramAction_HoloceneActivation(gt *testing.T) {
 		env.Sequencer.ActL2PipelineFull(t)
 
 		l2SafeHead := env.Sequencer.L2Safe()
-		t.Log(l2SafeHead.Time)
+		t.Log("Safe head", "time", l2SafeHead.Time)
 		require.EqualValues(t, uint64(0), l2SafeHead.Number) // channel should be dropped, so no safe head progression
-		if uint64(0) == l2SafeHead.Number {
-			t.Log("Safe head progressed as expected", "l2SafeHeadNumber", l2SafeHead.Number)
-		}
+		t.Log("Safe head progressed as expected", "number", l2SafeHead.Number)
 
 		// Log assertions
 		filters := []string{
@@ -106,7 +104,14 @@ func Test_ProgramAction_HoloceneActivation(gt *testing.T) {
 			recs := env.Logs.FindLogs(testlog.NewMessageContainsFilter(filter), testlog.NewAttributesFilter("role", "sequencer"))
 			require.Len(t, recs, 1, "searching for %d instances of '%s' in logs from role %s", 1, filter, "sequencer")
 		}
-		env.RunFaultProofProgramFromGenesis(t, l2SafeHead.Number, testCfg.CheckResult, testCfg.InputParams...)
+
+		// Now make sure the safe head progresses over the activation boundary so proofs tests aren't trivial over the genesis block.
+		env.BatchMineAndSync(t)
+		l2SafeHead = env.Sequencer.L2Safe()
+		t.Log("Safe head", "time", l2SafeHead.Time)
+		require.EqualValues(t, uint64(14), l2SafeHead.Number)
+		t.Log("Safe head progressed as expected", "number", l2SafeHead.Number)
+		env.RunFaultProofProgram(t, l2SafeHead.Number, testCfg.CheckResult, testCfg.InputParams...)
 	}
 
 	matrix := helpers.NewMatrix[any]()

--- a/op-e2e/actions/proofs/holocene_activation_test.go
+++ b/op-e2e/actions/proofs/holocene_activation_test.go
@@ -6,9 +6,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
 	actionsHelpers "github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/proofs/helpers"
-	"github.com/ethereum-optimism/optimism/op-program/client/claim"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/stretchr/testify/require"
 )
@@ -17,11 +15,11 @@ func Test_ProgramAction_HoloceneActivation(gt *testing.T) {
 
 	runHoloceneDerivationTest := func(gt *testing.T, testCfg *helpers.TestCfg[any]) {
 		t := actionsHelpers.NewDefaultTesting(gt)
+		const holoceneOffset = 14
 
 		// Define override to activate Holocene 14 seconds after genesis
 		var setHoloceneTime = func(dc *genesis.DeployConfig) {
-			fourteen := hexutil.Uint64(14)
-			dc.L2GenesisHoloceneTimeOffset = &fourteen
+			dc.L2GenesisHoloceneTimeOffset = ptr(hexutil.Uint64(holoceneOffset))
 		}
 
 		env := helpers.NewL2FaultProofEnv(t, testCfg, helpers.NewTestParams(), helpers.NewBatcherCfg(), setHoloceneTime)
@@ -109,27 +107,16 @@ func Test_ProgramAction_HoloceneActivation(gt *testing.T) {
 		env.BatchMineAndSync(t)
 		l2SafeHead = env.Sequencer.L2Safe()
 		t.Log("Safe head", "time", l2SafeHead.Time)
-		require.EqualValues(t, uint64(14), l2SafeHead.Number)
+		require.EqualValues(t, uint64(holoceneOffset), l2SafeHead.Number)
 		t.Log("Safe head progressed as expected", "number", l2SafeHead.Number)
 		env.RunFaultProofProgram(t, l2SafeHead.Number, testCfg.CheckResult, testCfg.InputParams...)
 	}
 
 	matrix := helpers.NewMatrix[any]()
-	defer matrix.Run(gt)
-
-	matrix.AddTestCase(
-		"HonestClaim-HoloceneActivation",
+	matrix.AddDefaultTestCases(
 		nil,
 		helpers.NewForkMatrix(helpers.Granite),
 		runHoloceneDerivationTest,
-		helpers.ExpectNoError(),
 	)
-	matrix.AddTestCase(
-		"JunkClaim-HoloceneActivation",
-		nil,
-		helpers.NewForkMatrix(helpers.Granite),
-		runHoloceneDerivationTest,
-		helpers.ExpectError(claim.ErrClaimNotValid),
-		helpers.WithL2Claim(common.HexToHash("0xdeadbeef")),
-	)
+	matrix.Run(gt)
 }

--- a/op-e2e/actions/proofs/holocene_batches_test.go
+++ b/op-e2e/actions/proofs/holocene_batches_test.go
@@ -130,7 +130,16 @@ func Test_ProgramAction_HoloceneBatches(gt *testing.T) {
 		testCfg.Custom.RequireExpectedProgressAndLogs(t, l2SafeHead, isHolocene, env.Engine, env.Logs)
 		t.Log("Safe head progressed as expected", "l2SafeHeadNumber", l2SafeHead.Number)
 
-		env.RunFaultProofProgramFromGenesis(t, l2SafeHead.Number, testCfg.CheckResult, testCfg.InputParams...)
+		// Ensure the safe head progresses so proofs tests aren't trivial over the genesis block.
+		// Build a new L2 block so the batcher has fresh data to submit (its buffer was consumed by the earlier manual batching).
+		if l2SafeHead.Number == 0 {
+			env.Sequencer.ActL2StartBlock(t)
+			env.Sequencer.ActL2EndBlock(t)
+			env.BatchMineAndSync(t)
+			l2SafeHead = env.Sequencer.L2Safe()
+			require.Greater(t, l2SafeHead.Number, uint64(0))
+		}
+		env.RunFaultProofProgram(t, l2SafeHead.Number, testCfg.CheckResult, testCfg.InputParams...)
 	}
 
 	matrix := helpers.NewMatrix[testCase]()

--- a/op-e2e/actions/proofs/holocene_batches_test.go
+++ b/op-e2e/actions/proofs/holocene_batches_test.go
@@ -130,16 +130,15 @@ func Test_ProgramAction_HoloceneBatches(gt *testing.T) {
 		testCfg.Custom.RequireExpectedProgressAndLogs(t, l2SafeHead, isHolocene, env.Engine, env.Logs)
 		t.Log("Safe head progressed as expected", "l2SafeHeadNumber", l2SafeHead.Number)
 
-		// Ensure the safe head progresses so proofs tests aren't trivial over the genesis block.
-		// Build a new L2 block so the batcher has fresh data to submit (its buffer was consumed by the earlier manual batching).
-		if l2SafeHead.Number == 0 {
-			env.Sequencer.ActL2StartBlock(t)
-			env.Sequencer.ActL2EndBlock(t)
-			env.BatchMineAndSync(t)
-			l2SafeHead = env.Sequencer.L2Safe()
-			require.Greater(t, l2SafeHead.Number, uint64(0))
+		// Run the fault proof program on a non-trivial block. When safe head is 0 because
+		// the derivation pipeline correctly dropped disordered batches, we skip the proof —
+		// rebatching would gloss over the problematic range and not test the drop behavior.
+		// TODO(#20050): run FPP over the genesis range and assert derivation produces no new blocks.
+		if l2SafeHead.Number > 0 {
+			env.RunFaultProofProgramFromGenesis(t, l2SafeHead.Number, testCfg.CheckResult, testCfg.InputParams...)
+		} else {
+			t.Log("Skipping fault proof program: safe head is at genesis due to dropped batches")
 		}
-		env.RunFaultProofProgram(t, l2SafeHead.Number, testCfg.CheckResult, testCfg.InputParams...)
 	}
 
 	matrix := helpers.NewMatrix[testCase]()

--- a/op-e2e/actions/proofs/holocene_frame_test.go
+++ b/op-e2e/actions/proofs/holocene_frame_test.go
@@ -113,16 +113,15 @@ func Test_ProgramAction_HoloceneFrames(gt *testing.T) {
 		testCfg.Custom.RequireExpectedProgressAndLogs(t, l2SafeHead, isHolocene, env.Engine, env.Logs)
 		t.Log("Safe head progressed as expected", "l2SafeHeadNumber", l2SafeHead.Number)
 
-		// Ensure the safe head progresses so proofs tests aren't trivial over the genesis block.
-		// Build a new L2 block so the batcher has fresh data to submit (its buffer was consumed by the earlier manual batching).
-		if l2SafeHead.Number == 0 {
-			env.Sequencer.ActL2StartBlock(t)
-			env.Sequencer.ActL2EndBlock(t)
-			env.BatchMineAndSync(t)
-			l2SafeHead = env.Sequencer.L2Safe()
-			require.Greater(t, l2SafeHead.Number, uint64(0))
+		// Run the fault proof program on a non-trivial block. When safe head is 0 because
+		// the derivation pipeline correctly dropped disordered frames, we skip the proof —
+		// rebatching would gloss over the problematic range and not test the drop behavior.
+		// TODO(#20050): run FPP over the genesis range and assert derivation produces no new blocks.
+		if l2SafeHead.Number > 0 {
+			env.RunFaultProofProgramFromGenesis(t, l2SafeHead.Number, testCfg.CheckResult, testCfg.InputParams...)
+		} else {
+			t.Log("Skipping fault proof program: safe head is at genesis due to dropped frames")
 		}
-		env.RunFaultProofProgram(t, l2SafeHead.Number, testCfg.CheckResult, testCfg.InputParams...)
 	}
 
 	matrix := helpers.NewMatrix[testCase]()

--- a/op-e2e/actions/proofs/holocene_frame_test.go
+++ b/op-e2e/actions/proofs/holocene_frame_test.go
@@ -113,7 +113,16 @@ func Test_ProgramAction_HoloceneFrames(gt *testing.T) {
 		testCfg.Custom.RequireExpectedProgressAndLogs(t, l2SafeHead, isHolocene, env.Engine, env.Logs)
 		t.Log("Safe head progressed as expected", "l2SafeHeadNumber", l2SafeHead.Number)
 
-		env.RunFaultProofProgramFromGenesis(t, l2SafeHead.Number, testCfg.CheckResult, testCfg.InputParams...)
+		// Ensure the safe head progresses so proofs tests aren't trivial over the genesis block.
+		// Build a new L2 block so the batcher has fresh data to submit (its buffer was consumed by the earlier manual batching).
+		if l2SafeHead.Number == 0 {
+			env.Sequencer.ActL2StartBlock(t)
+			env.Sequencer.ActL2EndBlock(t)
+			env.BatchMineAndSync(t)
+			l2SafeHead = env.Sequencer.L2Safe()
+			require.Greater(t, l2SafeHead.Number, uint64(0))
+		}
+		env.RunFaultProofProgram(t, l2SafeHead.Number, testCfg.CheckResult, testCfg.InputParams...)
 	}
 
 	matrix := helpers.NewMatrix[testCase]()

--- a/op-e2e/actions/proofs/holocene_invalid_batch_test.go
+++ b/op-e2e/actions/proofs/holocene_invalid_batch_test.go
@@ -239,8 +239,14 @@ func Test_ProgramAction_HoloceneInvalidBatch(gt *testing.T) {
 		testCfg.Custom.RequireExpectedProgressAndLogs(t, l2SafeHead, isHolocene, env.Engine, env.Logs)
 		t.Log("Safe head progressed as expected", "l2SafeHeadNumber", l2SafeHead.Number)
 
-		if safeHeadNumber := l2SafeHead.Number; safeHeadNumber > 0 {
-			env.RunFaultProofProgram(t, safeHeadNumber, testCfg.CheckResult, testCfg.InputParams...)
+		// Run the fault proof program on a non-trivial block. When safe head is 0 due to
+		// intentionally invalid block contents (e.g. over-advanced L1 origin, sequencer drift breach),
+		// rebatching produces the same invalid result, so skip the proof in those cases.
+		// The Holocene variants of these tests DO advance the safe head and run the proof.
+		if l2SafeHead.Number > 0 {
+			env.RunFaultProofProgram(t, l2SafeHead.Number, testCfg.CheckResult, testCfg.InputParams...)
+		} else {
+			t.Log("Skipping fault proof program: safe head is at genesis due to intentionally invalid block contents")
 		}
 	}
 


### PR DESCRIPTION
## Summary

Several Holocene proof action tests were running `RunFaultProofProgram` trivially on the genesis block (block 0), giving no real proof coverage:

- **`holocene_activation_test`**: `RunFaultProofProgramFromGenesis` called with safe head at 0. Now batch-mines past the activation boundary and runs `RunFaultProofProgram` on block 14 (the Holocene activation block).
- **`holocene_batches_test`**, **`holocene_frame_test`**, **`holocene_invalid_batch_test`**: when the derivation pipeline correctly drops invalid/disordered batches or frames, safe head stays at 0. These now skip the FPP with a log message rather than running a trivial proof. Rebatching was considered but rejected — it glosses over the problematic range and doesn't test the drop behavior.

Filed #20050 to track the proper fix: running the FPP over the genesis range and asserting derivation produces no new blocks.

## Test plan

- [x] `Test_ProgramAction_HoloceneActivation` — both subtests pass
- [x] `Test_ProgramAction_HoloceneBatches` — all subtests pass (20/20)
- [x] `Test_ProgramAction_HoloceneFrames` — all subtests pass (16/16)
- [x] `Test_ProgramAction_HoloceneInvalidBatch` — all subtests pass (24/24)

🤖 Generated with [Claude Code](https://claude.com/claude-code)