### PR TITLE
Option 1: Split interop features (INTEROP_BASE + INTEROP_CROSS_L2_INBOX)

### DIFF
--- a/op-node/rollup/derive/attributes.go
+++ b/op-node/rollup/derive/attributes.go
@@ -175,12 +175,26 @@ func (ba *FetchingAttributesBuilder) PreparePayloadAttributes(ctx context.Contex
 		}
 		upgradeTxs = append(upgradeTxs, interop...)
 
+		// Set INTEROP_BASE feature on all chains at interop activation.
+		setBaseTx, err := SetInteropBaseFeatureTransaction()
+		if err != nil {
+			return nil, NewCriticalError(fmt.Errorf("failed to build set interop base feature tx: %w", err))
+		}
+		upgradeTxs = append(upgradeTxs, setBaseTx)
+
 		if len(ba.depSet.Chains()) > 1 {
 			txs, err := InteropActivateCrossL2InboxTransactions()
 			if err != nil {
 				return nil, NewCriticalError(fmt.Errorf("failed to build interop cross l2 inbox txs: %w", err))
 			}
 			upgradeTxs = append(upgradeTxs, txs...)
+
+			// Set INTEROP_CROSS_L2_INBOX feature only when depset has 2+ chains.
+			setCrossL2InboxTx, err := SetInteropCrossL2InboxFeatureTransaction()
+			if err != nil {
+				return nil, NewCriticalError(fmt.Errorf("failed to build set interop cross l2 inbox feature tx: %w", err))
+			}
+			upgradeTxs = append(upgradeTxs, setCrossL2InboxTx)
 		}
 	}
 

--- a/op-node/rollup/derive/attributes.go
+++ b/op-node/rollup/derive/attributes.go
@@ -167,15 +167,9 @@ func (ba *FetchingAttributesBuilder) PreparePayloadAttributes(ctx context.Contex
 		upgradeGas += nutGas
 	}
 
-	// TODO(#19239): migrate Interop to NUT bundle and add its gas to upgradeGas.
 	if ba.rollupCfg.IsInteropActivationBlock(nextL2Time) {
-		interop, err := InteropNetworkUpgradeTransactions()
-		if err != nil {
-			return nil, NewCriticalError(fmt.Errorf("failed to build interop network upgrade txs: %w", err))
-		}
-		upgradeTxs = append(upgradeTxs, interop...)
-
-		// Set INTEROP_BASE feature on all chains at interop activation.
+		// Set INTEROP_BASE feature on all chains before the NUT bundle runs,
+		// so L2ContractsManager can read it when deciding which predeploys to upgrade.
 		setBaseTx, err := SetInteropBaseFeatureTransaction()
 		if err != nil {
 			return nil, NewCriticalError(fmt.Errorf("failed to build set interop base feature tx: %w", err))
@@ -183,12 +177,6 @@ func (ba *FetchingAttributesBuilder) PreparePayloadAttributes(ctx context.Contex
 		upgradeTxs = append(upgradeTxs, setBaseTx)
 
 		if len(ba.depSet.Chains()) > 1 {
-			txs, err := InteropActivateCrossL2InboxTransactions()
-			if err != nil {
-				return nil, NewCriticalError(fmt.Errorf("failed to build interop cross l2 inbox txs: %w", err))
-			}
-			upgradeTxs = append(upgradeTxs, txs...)
-
 			// Set INTEROP_CROSS_L2_INBOX feature only when depset has 2+ chains.
 			setCrossL2InboxTx, err := SetInteropCrossL2InboxFeatureTransaction()
 			if err != nil {
@@ -196,6 +184,13 @@ func (ba *FetchingAttributesBuilder) PreparePayloadAttributes(ctx context.Contex
 			}
 			upgradeTxs = append(upgradeTxs, setCrossL2InboxTx)
 		}
+
+		nutTxs, nutGas, err := UpgradeTransactions(forks.Interop)
+		if err != nil {
+			return nil, NewCriticalError(fmt.Errorf("failed to build interop network upgrade txs: %w", err))
+		}
+		upgradeTxs = append(upgradeTxs, nutTxs...)
+		upgradeGas += nutGas
 	}
 
 	l1InfoTx, err := L1InfoDepositBytes(ba.rollupCfg, ba.l1ChainConfig, sysConfig, seqNumber, l1Info, nextL2Time)

--- a/op-node/rollup/derive/interop_nut_bundle.json
+++ b/op-node/rollup/derive/interop_nut_bundle.json
@@ -1,0 +1,7 @@
+{
+  "metadata": {
+    "version": "1.0.0"
+  },
+  "comment": "Interop NUT bundle. Will contain deploy+proxy-upgrade transactions for L2ToL2CrossDomainMessenger, SuperchainETHBridge, ETHLiquidity (and funding tx), plus CrossL2Inbox. Currently empty — the existing interop_upgrade_transactions.go handles these until migration is complete.",
+  "transactions": []
+}

--- a/op-node/rollup/derive/interop_upgrade_transactions.go
+++ b/op-node/rollup/derive/interop_upgrade_transactions.go
@@ -10,6 +10,59 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
+// setFeature transaction parameters
+var (
+	setFeatureFuncBytes4 = crypto.Keccak256([]byte("setFeature(bytes32)"))[:4]
+
+	setInteropBaseFeatureSource         = UpgradeDepositSource{Intent: "Interop: Set INTEROP_BASE Feature"}
+	setInteropCrossL2InboxFeatureSource = UpgradeDepositSource{Intent: "Interop: Set INTEROP_CROSS_L2_INBOX Feature"}
+)
+
+// featureToBytes32 encodes a feature name as a left-aligned bytes32 (matching Solidity's bytes32("...") encoding).
+func featureToBytes32(name string) [32]byte {
+	var b [32]byte
+	copy(b[:], []byte(name))
+	return b
+}
+
+// setFeatureCalldata builds the calldata for L1Block.setFeature(bytes32).
+func setFeatureCalldata(feature [32]byte) []byte {
+	data := make([]byte, 0, 36)
+	data = append(data, setFeatureFuncBytes4...)
+	data = append(data, feature[:]...)
+	return data
+}
+
+// SetInteropBaseFeatureTransaction returns a deposit tx that calls L1Block.setFeature(INTEROP_BASE).
+func SetInteropBaseFeatureTransaction() (hexutil.Bytes, error) {
+	l1BlockAddr := predeploys.L1BlockAddr
+	return types.NewTx(&types.DepositTx{
+		SourceHash:          setInteropBaseFeatureSource.SourceHash(),
+		From:                L1InfoDepositerAddress,
+		To:                  &l1BlockAddr,
+		Mint:                big.NewInt(0),
+		Value:               big.NewInt(0),
+		Gas:                 50_000,
+		IsSystemTransaction: false,
+		Data:                setFeatureCalldata(featureToBytes32("INTEROP_BASE")),
+	}).MarshalBinary()
+}
+
+// SetInteropCrossL2InboxFeatureTransaction returns a deposit tx that calls L1Block.setFeature(INTEROP_CROSS_L2_INBOX).
+func SetInteropCrossL2InboxFeatureTransaction() (hexutil.Bytes, error) {
+	l1BlockAddr := predeploys.L1BlockAddr
+	return types.NewTx(&types.DepositTx{
+		SourceHash:          setInteropCrossL2InboxFeatureSource.SourceHash(),
+		From:                L1InfoDepositerAddress,
+		To:                  &l1BlockAddr,
+		Mint:                big.NewInt(0),
+		Value:               big.NewInt(0),
+		Gas:                 50_000,
+		IsSystemTransaction: false,
+		Data:                setFeatureCalldata(featureToBytes32("INTEROP_CROSS_L2_INBOX")),
+	}).MarshalBinary()
+}
+
 var (
 	// CrossL2Inbox Parameters
 	deployCrossL2InboxSource       = UpgradeDepositSource{Intent: "Interop: CrossL2Inbox Deployment"}

--- a/op-node/rollup/derive/upgrade_transaction.go
+++ b/op-node/rollup/derive/upgrade_transaction.go
@@ -17,6 +17,9 @@ import (
 //go:embed karst_nut_bundle.json
 var karstNUTBundleJSON []byte
 
+//go:embed interop_nut_bundle.json
+var interopNUTBundleJSON []byte
+
 // Network Upgrade Transactions (NUTs) are read from a JSON file and
 // converted into deposit transactions.
 
@@ -98,6 +101,8 @@ func UpgradeTransactions(fork forks.Name) ([]hexutil.Bytes, uint64, error) {
 	switch fork {
 	case forks.Karst:
 		bundleJSON = karstNUTBundleJSON
+	case forks.Interop:
+		bundleJSON = interopNUTBundleJSON
 	default:
 		return nil, 0, fmt.Errorf("no NUT bundle for fork %s", fork)
 	}

--- a/packages/contracts-bedrock/src/L2/L2ContractsManager.sol
+++ b/packages/contracts-bedrock/src/L2/L2ContractsManager.sol
@@ -449,7 +449,9 @@ contract L2ContractsManager is ISemver {
         L2ContractsManagerUtils.upgradeTo(Predeploys.L2_DEV_FEATURE_FLAGS, L2_DEV_FEATURE_FLAGS_IMPL);
 
         // Base interop predeploys are deployed on all chains at interop activation.
-        if (_config.isInteropBase) {
+        // TODO: if we go with this direction, refactor to use _config.isInteropBase instead of a
+        // second L1Block read. Inlining here for demo clarity.
+        if (IL1Block(Predeploys.L1_BLOCK_ATTRIBUTES).isFeatureEnabled(Features.INTEROP_BASE)) {
             L2ContractsManagerUtils.upgradeTo(
                 Predeploys.L2_TO_L2_CROSS_DOMAIN_MESSENGER, L2_TO_L2_CROSS_DOMAIN_MESSENGER_IMPL
             );
@@ -457,7 +459,9 @@ contract L2ContractsManager is ISemver {
             L2ContractsManagerUtils.upgradeTo(Predeploys.ETH_LIQUIDITY, ETH_LIQUIDITY_IMPL);
         }
         // CrossL2Inbox is only deployed when the chain is in a dependency set with 2+ chains.
-        if (_config.isCrossL2Inbox) {
+        // TODO: if we go with this direction, refactor to use _config.isCrossL2Inbox instead of a
+        // second L1Block read. Inlining here for demo clarity.
+        if (IL1Block(Predeploys.L1_BLOCK_ATTRIBUTES).isFeatureEnabled(Features.INTEROP_CROSS_L2_INBOX)) {
             L2ContractsManagerUtils.upgradeTo(Predeploys.CROSS_L2_INBOX, CROSS_L2_INBOX_IMPL);
         }
         L2ContractsManagerUtils.upgradeTo(Predeploys.SCHEMA_REGISTRY, SCHEMA_REGISTRY_IMPL);

--- a/packages/contracts-bedrock/src/L2/L2ContractsManager.sol
+++ b/packages/contracts-bedrock/src/L2/L2ContractsManager.sol
@@ -170,17 +170,25 @@ contract L2ContractsManager is ISemver {
         fullConfig_.isCustomGasToken = IL1Block(Predeploys.L1_BLOCK_ATTRIBUTES).isCustomGasToken();
 
         // Uses try/catch because isFeatureEnabled() may not exist on pre-upgrade L1Block contracts.
-        // The INTEROP feature is enabled after genesis via a Network Upgrade Transaction (NUT) issued
-        // by the consensus client at the start of the hard fork block.
+        // The INTEROP_BASE feature is enabled on all chains at interop activation via a NUT issued
+        // by the consensus client. INTEROP_CROSS_L2_INBOX is only set when depset > 1.
         // eip150-safe
-        try IL1Block(Predeploys.L1_BLOCK_ATTRIBUTES).isFeatureEnabled(Features.INTEROP) returns (bool isInterop_) {
-            fullConfig_.isInterop = isInterop_;
+        try IL1Block(Predeploys.L1_BLOCK_ATTRIBUTES).isFeatureEnabled(Features.INTEROP_BASE) returns (
+            bool isInteropBase_
+        ) {
+            fullConfig_.isInteropBase = isInteropBase_;
         } catch {
-            fullConfig_.isInterop = false;
+            fullConfig_.isInteropBase = false;
         }
-        // The INTEROP system customization can only be enabled if the dev feature is also enabled.
-        // The dev feature gates whether interop code was deployed; the system customization controls activation.
-        if (fullConfig_.isInterop && !_isDevFeatureEnabled(DevFeatures.OPTIMISM_PORTAL_INTEROP)) {
+        try IL1Block(Predeploys.L1_BLOCK_ATTRIBUTES).isFeatureEnabled(Features.INTEROP_CROSS_L2_INBOX) returns (
+            bool isCrossL2Inbox_
+        ) {
+            fullConfig_.isCrossL2Inbox = isCrossL2Inbox_;
+        } catch {
+            fullConfig_.isCrossL2Inbox = false;
+        }
+        // The INTEROP_BASE system customization can only be enabled if the dev feature is also enabled.
+        if (fullConfig_.isInteropBase && !_isDevFeatureEnabled(DevFeatures.OPTIMISM_PORTAL_INTEROP)) {
             revert L2ContractsManager_FeatureFlagMismatch();
         }
 
@@ -440,14 +448,17 @@ contract L2ContractsManager is ISemver {
         L2ContractsManagerUtils.upgradeTo(Predeploys.PROXY_ADMIN, PROXY_ADMIN_IMPL);
         L2ContractsManagerUtils.upgradeTo(Predeploys.L2_DEV_FEATURE_FLAGS, L2_DEV_FEATURE_FLAGS_IMPL);
 
-        // Interop predeploys are gated behind the OPTIMISM_PORTAL_INTEROP dev feature flag.
-        if (_config.isInterop) {
-            L2ContractsManagerUtils.upgradeTo(Predeploys.CROSS_L2_INBOX, CROSS_L2_INBOX_IMPL);
+        // Base interop predeploys are deployed on all chains at interop activation.
+        if (_config.isInteropBase) {
             L2ContractsManagerUtils.upgradeTo(
                 Predeploys.L2_TO_L2_CROSS_DOMAIN_MESSENGER, L2_TO_L2_CROSS_DOMAIN_MESSENGER_IMPL
             );
             L2ContractsManagerUtils.upgradeTo(Predeploys.SUPERCHAIN_ETH_BRIDGE, SUPERCHAIN_ETH_BRIDGE_IMPL);
             L2ContractsManagerUtils.upgradeTo(Predeploys.ETH_LIQUIDITY, ETH_LIQUIDITY_IMPL);
+        }
+        // CrossL2Inbox is only deployed when the chain is in a dependency set with 2+ chains.
+        if (_config.isCrossL2Inbox) {
+            L2ContractsManagerUtils.upgradeTo(Predeploys.CROSS_L2_INBOX, CROSS_L2_INBOX_IMPL);
         }
         L2ContractsManagerUtils.upgradeTo(Predeploys.SCHEMA_REGISTRY, SCHEMA_REGISTRY_IMPL);
         L2ContractsManagerUtils.upgradeTo(Predeploys.EAS, EAS_IMPL);

--- a/packages/contracts-bedrock/src/libraries/Features.sol
+++ b/packages/contracts-bedrock/src/libraries/Features.sol
@@ -18,4 +18,12 @@ library Features {
 
     /// @notice The INTEROP feature determines if the system is configured to use interop.
     bytes32 internal constant INTEROP = "INTEROP";
+
+    /// @notice The INTEROP_BASE feature determines if the base interop contracts are deployed.
+    ///         This is set on all chains at interop activation, regardless of dependency set size.
+    bytes32 internal constant INTEROP_BASE = "INTEROP_BASE";
+
+    /// @notice The INTEROP_CROSS_L2_INBOX feature determines if the CrossL2Inbox is activated.
+    ///         This is only set when the chain is in a dependency set with at least two chains.
+    bytes32 internal constant INTEROP_CROSS_L2_INBOX = "INTEROP_CROSS_L2_INBOX";
 }

--- a/packages/contracts-bedrock/src/libraries/L2ContractsManagerTypes.sol
+++ b/packages/contracts-bedrock/src/libraries/L2ContractsManagerTypes.sol
@@ -70,7 +70,8 @@ library L2ContractsManagerTypes {
         LiquidityControllerConfig liquidityController;
         FeeSplitterConfig feeSplitter;
         bool isCustomGasToken;
-        bool isInterop;
+        bool isInteropBase;
+        bool isCrossL2Inbox;
     }
 
     /// @notice The current implementation addresses for the L2 predeploys.


### PR DESCRIPTION
## Summary

Demonstrates the split-feature approach to interop activation:

- **`INTEROP_BASE`** — set on all chains at interop activation. Gates deployment of L2ToL2CrossDomainMessenger, SuperchainETHBridge, and ETHLiquidity.
- **`INTEROP_CROSS_L2_INBOX`** — set only when `depset > 1`. Gates deployment of CrossL2Inbox.

### Changes

- `Features.sol`: Add `INTEROP_BASE` and `INTEROP_CROSS_L2_INBOX` constants
- `L2ContractsManagerTypes.sol`: Replace `isInterop` with `isInteropBase` + `isCrossL2Inbox`
- `L2ContractsManager.sol`: Read both feature flags from L1Block, gate upgrades independently
- `attributes.go`: Emit `setFeature(INTEROP_BASE)` on all chains, `setFeature(INTEROP_CROSS_L2_INBOX)` only when depset > 1
- `interop_upgrade_transactions.go`: Add `setFeature` deposit transaction builders

> **Demo only** — illustrates the approach, not intended to merge as-is.