### PR TITLE
docs(op-program): add deprecation notice to README

### DIFF
--- a/op-program/README.md
+++ b/op-program/README.md
@@ -1,5 +1,9 @@
 # op-program
 
+> **Deprecated:** op-program is deprecated and being replaced by [kona-client](../../rust/kona/).
+> Existing deployments will remain usable until the Karst hardfork, at which point migration to kona-client is required.
+> See the [end-of-support notice](https://docs.optimism.io/notices/op-geth-deprecation) for full details and migration guidance.
+
 Implements a fault proof program that runs through the rollup state-transition to verify an L2 output from L1 inputs.
 This verifiable output can then resolve a disputed output on L1.
 

--- a/op-program/README.md
+++ b/op-program/README.md
@@ -1,7 +1,7 @@
 # op-program
 
 > **Deprecated:** op-program is deprecated and being replaced by [kona-client](../../rust/kona/).
-> Existing deployments will remain usable until the Karst hardfork, at which point migration to kona-client is required.
+> Existing deployments will be supported until the Karst hardfork, at which point migration to kona-client is required.
 > See the [end-of-support notice](https://docs.optimism.io/notices/op-geth-deprecation) for full details and migration guidance.
 
 Implements a fault proof program that runs through the rollup state-transition to verify an L2 output from L1 inputs.


### PR DESCRIPTION
## Summary
- Adds a deprecation banner to the top of `op-program/README.md`
- Directs users to [kona-client](../../rust/kona/) as the replacement
- Links to the [end-of-support notice](https://docs.optimism.io/notices/op-geth-deprecation) for migration guidance

## Test plan
- [ ] Verify the banner renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)