### PR TITLE
op-acceptance-tests: migrate TestInteropFaultProofs_MessageExpiry

### DIFF
--- a/op-acceptance-tests/tests/interop/proofs/serial/interop_fault_proofs_test.go
+++ b/op-acceptance-tests/tests/interop/proofs/serial/interop_fault_proofs_test.go
@@ -71,3 +71,13 @@ func TestInteropFaultProofs_InvalidBlock(gt *testing.T) {
 	sys := presets.NewSimpleInteropSupernodeProofs(t, presets.WithChallengerCannonKonaEnabled())
 	sfp.RunInvalidBlockTest(t, sys)
 }
+
+func TestInteropFaultProofs_MessageExpiry(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	const messageExpiryWindow = uint64(12) // 12 seconds for fast test
+	sys := presets.NewSimpleInteropSupernodeProofs(t,
+		presets.WithChallengerCannonKonaEnabled(),
+		presets.WithMessageExpiryWindow(messageExpiryWindow),
+	)
+	sfp.RunMessageExpiryTest(t, sys, messageExpiryWindow)
+}

--- a/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
+++ b/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
@@ -1055,6 +1055,146 @@ func RunInvalidBlockTest(t devtest.T, sys *presets.SimpleInterop) {
 	}
 }
 
+// RunMessageExpiryTest verifies that when a cross-chain message expires (the
+// executing message's block timestamp exceeds the init message timestamp plus
+// the message expiry window), the block containing the executing message is
+// replaced during consolidation. The system must be configured with a short
+// message expiry window via WithMessageExpiryWindow.
+//
+// msgExpiryWindow is the configured message expiry window in seconds; it must
+// match the value passed to WithMessageExpiryWindow when creating the system.
+func RunMessageExpiryTest(t devtest.T, sys *presets.SimpleInterop, msgExpiryWindow uint64) {
+	t.Require().NotNil(sys.SuperRoots, "supernode is required for this test")
+	rng := rand.New(rand.NewSource(1234))
+
+	chains := orderedChains(sys)
+	t.Require().Len(chains, 2, "expected exactly 2 interop chains")
+
+	aliceA := sys.FunderA.NewFundedEOA(eth.OneEther)
+	aliceB := aliceA.AsEL(sys.L2ELB)
+	sys.FunderB.Fund(aliceB, eth.OneEther)
+
+	// Send an initiating message on chain A.
+	eventLogger := aliceA.DeployEventLogger()
+	initMsg := aliceA.SendRandomInitMessage(rng, eventLogger, 2, 10)
+
+	// Record the init message's block timestamp.
+	initBlockNum := bigs.Uint64Strict(initMsg.BlockNumber())
+	initTimestamp := sys.L2ChainA.TimestampForBlockNum(initBlockNum)
+
+	// Calculate target block numbers past expiry for each chain independently.
+	// The message expires when: initTimestamp + expiryWindow < execTimestamp.
+	// Add extra blocks for safety margin.
+	blockTimeA := sys.L2ChainA.Escape().RollupConfig().BlockTime
+	blockTimeB := sys.L2ChainB.Escape().RollupConfig().BlockTime
+	t.Require().NotZero(blockTimeA, "block time A must be non-zero")
+	t.Require().NotZero(blockTimeB, "block time B must be non-zero")
+
+	currentBlockA := sys.L2ELA.BlockRefByLabel(eth.Unsafe)
+	currentBlockB := sys.L2ELB.BlockRefByLabel(eth.Unsafe)
+	blocksNeededA := (msgExpiryWindow / blockTimeA) + 2
+	blocksNeededB := (msgExpiryWindow / blockTimeB) + 2
+	targetBlockA := currentBlockA.Number + blocksNeededA
+	targetBlockB := currentBlockB.Number + blocksNeededB
+
+	// Wait for both chains to produce blocks past the expiry window.
+	sys.L2ELA.Reached(eth.Unsafe, targetBlockA, 60)
+	sys.L2ELB.Reached(eth.Unsafe, targetBlockB, 60)
+
+	// Stop batcher B so we control block production on chain B.
+	sys.L2BatcherB.Stop()
+
+	// Build the exec tx without submitting to the mempool.
+	// InteropMempoolFiltering would reject the expired message, so we
+	// bypass the mempool by injecting the raw tx via the test sequencer.
+	// This models a malicious sequencer force-including an invalid tx.
+	rawExecTx, execTxHash := aliceB.PrepareExecTx(initMsg)
+
+	// Inject the expired exec message into a block on chain B via test sequencer.
+	parentB := sys.L2ELB.BlockRefByLabel(eth.Unsafe)
+	chainBID := sys.L2ChainB.ChainID()
+	sys.TestSequencer.SequenceBlockWithTxs(t, chainBID, parentB.Hash, [][]byte{rawExecTx})
+
+	// Also advance chain A by one empty block to keep timestamps aligned.
+	parentA := sys.L2ELA.BlockRefByLabel(eth.Unsafe)
+	chainAID := sys.L2ChainA.ChainID()
+	sys.TestSequencer.SequenceBlock(t, chainAID, parentA.Hash)
+
+	// The injected block is the new unsafe head on chain B.
+	newHeadB := sys.L2ELB.BlockRefByLabel(eth.Unsafe)
+	execBlockNum := newHeadB.Number
+
+	// Verify the expired exec tx is actually in the injected block before consolidation.
+	sys.L2ELB.AssertTxInBlock(execBlockNum, execTxHash)
+
+	// Restart batcher B so batch data gets submitted to L1.
+	sys.L2BatcherB.Start()
+
+	endTimestamp := sys.L2ChainB.TimestampForBlockNum(execBlockNum)
+	t.Require().Greaterf(endTimestamp, initTimestamp+msgExpiryWindow,
+		"exec message timestamp %d should exceed init timestamp %d + expiry window %d",
+		endTimestamp, initTimestamp, msgExpiryWindow)
+	startTimestamp := endTimestamp - 1
+
+	// Wait for cross-safe validation, which should replace the invalid block.
+	sys.SuperRoots.AwaitValidatedTimestamp(endTimestamp)
+	sys.L2CLB.Reached(types.CrossSafe, execBlockNum, 30)
+
+	// Verify the expired exec tx was reorged out during consolidation.
+	sys.L2ELB.AssertTxNotInBlock(execBlockNum, execTxHash)
+
+	l1HeadCurrent := latestRequiredL1(sys.SuperRoots.SuperRootAtTimestamp(endTimestamp))
+
+	crossSafeSuperRootEnd := superRootAtTimestamp(t, chains, endTimestamp)
+
+	firstOptimistic := optimisticBlockAtTimestamp(t, sys.SuperRoots.QueryAPI(), chains[0].ID, endTimestamp)
+	secondOptimistic := optimisticBlockAtTimestamp(t, sys.SuperRoots.QueryAPI(), chains[1].ID, endTimestamp)
+
+	start := superRootAtTimestamp(t, chains, startTimestamp)
+	paddingStep := func(step uint64) []byte {
+		return marshalTransition(start, step, firstOptimistic, secondOptimistic)
+	}
+
+	preReplacementSuperRoot := eth.NewSuperV1(endTimestamp,
+		eth.ChainIDAndOutput{ChainID: chains[0].ID, Output: firstOptimistic.OutputRoot},
+		eth.ChainIDAndOutput{ChainID: chains[1].ID, Output: secondOptimistic.OutputRoot})
+
+	tests := []*transitionTest{
+		{
+			Name:               "Consolidate-ExpectInvalidPendingBlock",
+			AgreedClaim:        paddingStep(consolidateStep),
+			DisputedClaim:      preReplacementSuperRoot.Marshal(),
+			DisputedTraceIndex: consolidateStep,
+			ExpectValid:        false,
+			L1Head:             l1HeadCurrent,
+			ClaimTimestamp:     endTimestamp,
+		},
+		{
+			Name:               "Consolidate-ReplaceExpiredMessage",
+			AgreedClaim:        paddingStep(consolidateStep),
+			DisputedClaim:      crossSafeSuperRootEnd.Marshal(),
+			DisputedTraceIndex: consolidateStep,
+			ExpectValid:        true,
+			L1Head:             l1HeadCurrent,
+			ClaimTimestamp:     endTimestamp,
+		},
+	}
+
+	challengerCfg := sys.L2ChainA.Escape().L2Challengers()[0].Config()
+	gameDepth := sys.DisputeGameFactory().GameImpl(gameTypes.SuperCannonKonaGameType).SplitDepth()
+	for _, test := range tests {
+		t.Run(test.Name+"-fpp", func(t devtest.T) {
+			runKonaInteropProgram(t, challengerCfg.CannonKona, test.L1Head.Hash,
+				test.AgreedClaim, crypto.Keccak256Hash(test.DisputedClaim),
+				test.ClaimTimestamp, test.ExpectValid)
+		})
+
+		t.Run(test.Name+"-challenger", func(t devtest.T) {
+			runChallengerProviderTest(t, sys.SuperRoots.QueryAPI(), gameDepth, startTimestamp, test.ClaimTimestamp, test)
+		})
+	}
+}
+
 // RunDepositMessageTest verifies that the fault proof system correctly handles
 // consolidation when a cross-chain message is initiated via an L1 deposit transaction.
 func RunDepositMessageTest(t devtest.T, sys *presets.SimpleInterop) {

--- a/op-devstack/dsl/eoa.go
+++ b/op-devstack/dsl/eoa.go
@@ -337,6 +337,21 @@ func (u *EOA) SendExecMessage(initMsg *InitMessage, opts ...ExecMessageOpt) *Exe
 	}
 }
 
+// PrepareExecTx builds and signs an executing-message transaction referencing
+// the given init message, but does NOT submit it. Returns the raw signed
+// transaction bytes and tx hash. The raw bytes are suitable for injection via
+// TestSequencer.SequenceBlockWithTxs, bypassing mempool filtering.
+func (u *EOA) PrepareExecTx(initMsg *InitMessage) (rawTx []byte, txHash common.Hash) {
+	tx := txintent.NewIntent[*txintent.ExecTrigger, *txintent.InteropOutput](u.Plan())
+	tx.Content.DependOn(&initMsg.Tx.Result)
+	tx.Content.Fn(txintent.ExecuteIndexed(predeploys.CrossL2InboxAddr, &initMsg.Tx.Result, 0))
+	signedTx, err := tx.PlannedTx.Signed.Eval(u.ctx)
+	u.require.NoError(err, "failed to sign exec tx")
+	rawBytes, err := signedTx.MarshalBinary()
+	u.require.NoError(err, "failed to marshal exec tx")
+	return rawBytes, signedTx.Hash()
+}
+
 // SendInvalidExecMessage sends an executing message with an invalid identifier.
 // The log index is incremented to reference a non-existent log.
 func (u *EOA) SendInvalidExecMessage(initMsg *InitMessage) *ExecMessage {

--- a/op-devstack/presets/option_validation.go
+++ b/op-devstack/presets/option_validation.go
@@ -26,6 +26,7 @@ const (
 	optionKindRequireInteropNotAtGen
 	optionKindAfterBuild
 	optionKindProofValidation
+	optionKindMessageExpiryWindow
 )
 
 const allOptionKinds = optionKindDeployer |
@@ -42,7 +43,8 @@ const allOptionKinds = optionKindDeployer |
 	optionKindMaxSequencingWindow |
 	optionKindRequireInteropNotAtGen |
 	optionKindAfterBuild |
-	optionKindProofValidation
+	optionKindProofValidation |
+	optionKindMessageExpiryWindow
 
 var optionKindLabels = []struct {
 	kind  optionKinds
@@ -63,6 +65,7 @@ var optionKindLabels = []struct {
 	{kind: optionKindRequireInteropNotAtGen, label: "interop-not-at-genesis"},
 	{kind: optionKindAfterBuild, label: "after-build hooks"},
 	{kind: optionKindProofValidation, label: "proof-validation hooks"},
+	{kind: optionKindMessageExpiryWindow, label: "message expiry window"},
 }
 
 func (k optionKinds) String() string {
@@ -150,7 +153,8 @@ const simpleInteropSuperProofsPresetSupportedOptionKinds = optionKindDeployer |
 const supernodeProofsPresetSupportedOptionKinds = optionKindDeployer |
 	optionKindBatcher |
 	optionKindChallengerCannonKona |
-	optionKindL1EL
+	optionKindL1EL |
+	optionKindMessageExpiryWindow
 
 const twoL2SupernodePresetSupportedOptionKinds = optionKindDeployer |
 	optionKindL1EL

--- a/op-devstack/presets/options.go
+++ b/op-devstack/presets/options.go
@@ -275,6 +275,19 @@ func WithRequireInteropNotAtGenesis() Option {
 	}
 }
 
+// WithMessageExpiryWindow configures the message expiry window (in seconds)
+// used by the dependency set. This controls how long cross-chain messages
+// remain valid before they expire.
+func WithMessageExpiryWindow(window uint64) Option {
+	return option{
+		kinds: optionKindMessageExpiryWindow,
+		applyFn: func(cfg *sysgo.PresetConfig) {
+			v := window
+			cfg.MessageExpiryWindow = &v
+		},
+	}
+}
+
 // WithL2BlockTimes configures per-chain L2 block times via the deployer.
 // The blockTimes map keys are L2 chain IDs and values are the desired block
 // time in seconds for that chain.

--- a/op-devstack/sysgo/multichain_supernode_runtime.go
+++ b/op-devstack/sysgo/multichain_supernode_runtime.go
@@ -129,15 +129,30 @@ func newSingleChainSupernodeRuntimeWithConfig(t devtest.T, interopAtGenesis bool
 		depSetStatic = cast
 	}
 
+	if cfg.MessageExpiryWindow != nil && depSetStatic != nil {
+		var overrideErr error
+		depSetStatic, overrideErr = depset.NewStaticConfigDependencySetWithMessageExpiryOverride(
+			depSetStatic.Dependencies(), *cfg.MessageExpiryWindow)
+		require.NoError(overrideErr, "failed to override message expiry window")
+	}
+
 	supernode, l2CL := startSingleChainSharedSupernode(t, l1Net, l1EL, l1CL, l2Net, l2EL, depSetStatic, jwtSecret, interopAtGenesis)
 	l2Batcher := startMinimalBatcher(t, keys, l2Net, l1EL, l2CL, l2EL, cfg.BatcherOptions...)
 	l2Proposer := startMinimalProposer(t, keys, l2Net, l1EL, l2CL, cfg.ProposerOptions...)
 	faucetService := startFaucets(t, keys, l1Net.ChainID(), l2Net.ChainID(), l1EL.UserRPC(), l2EL.UserRPC())
 
+	// Use the potentially-overridden depSetStatic if available.
+	var runtimeDepSet depset.DependencySet
+	if depSetStatic != nil {
+		runtimeDepSet = depSetStatic
+	} else {
+		runtimeDepSet = depSet
+	}
+
 	return &MultiChainRuntime{
 		Keys:          keys,
 		Migration:     migration,
-		DependencySet: depSet,
+		DependencySet: runtimeDepSet,
 		L1Network:     l1Net,
 		L1EL:          l1EL,
 		L1CL:          l1CL,
@@ -190,6 +205,13 @@ func newTwoL2SupernodeRuntimeWithConfig(t devtest.T, enableInterop bool, delaySe
 		depSet = cast
 	}
 
+	if cfg.MessageExpiryWindow != nil && depSet != nil {
+		var err error
+		depSet, err = depset.NewStaticConfigDependencySetWithMessageExpiryOverride(
+			depSet.Dependencies(), *cfg.MessageExpiryWindow)
+		require.NoError(err, "failed to override message expiry window")
+	}
+
 	supernode, l2ACL, l2BCL := startTwoL2SharedSupernode(
 		t,
 		l1Net,
@@ -215,10 +237,19 @@ func newTwoL2SupernodeRuntimeWithConfig(t devtest.T, enableInterop bool, delaySe
 		l2BNet.ChainID(): l2BEL.UserRPC(),
 	})
 
+	// Use the potentially-overridden depSet (e.g. with custom message expiry window)
+	// if available; otherwise fall back to the original from the world builder.
+	var runtimeDepSet depset.DependencySet
+	if depSet != nil {
+		runtimeDepSet = depSet
+	} else {
+		runtimeDepSet = wb.outFullCfgSet.DependencySet
+	}
+
 	return &MultiChainRuntime{
 		Keys:          keys,
 		Migration:     newInteropMigrationState(wb),
-		DependencySet: wb.outFullCfgSet.DependencySet,
+		DependencySet: runtimeDepSet,
 		L1Network:     l1Net,
 		L1EL:          l1EL,
 		L1CL:          l1CL,

--- a/op-devstack/sysgo/preset_config.go
+++ b/op-devstack/sysgo/preset_config.go
@@ -20,6 +20,7 @@ type PresetConfig struct {
 	EnableTimeTravel           bool
 	MaxSequencingWindow        *uint64
 	RequireInteropNotAtGen     bool
+	MessageExpiryWindow        *uint64
 }
 
 func NewPresetConfig() PresetConfig {

--- a/op-supernode/supernode/activity/interop/algo.go
+++ b/op-supernode/supernode/activity/interop/algo.go
@@ -8,10 +8,10 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
-// ExpiryTime is the maximum age of an initiating message that can be executed.
-// Messages older than this are considered expired and invalid.
-// 7 days = 7 * 24 * 60 * 60 = 604800 seconds
-const ExpiryTime = 604800
+// defaultMessageExpiryWindow is the default maximum age of an initiating message
+// that can be executed. 7 days = 7 * 24 * 60 * 60 = 604800 seconds.
+// The actual value used is read from the dependency set at construction time.
+const defaultMessageExpiryWindow = 604800
 
 var (
 	// ErrUnknownChain is returned when an executing message references
@@ -23,7 +23,7 @@ var (
 	ErrTimestampViolation = errors.New("initiating message timestamp must not be greater than executing message timestamp")
 
 	// ErrMessageExpired is returned when an executing message references
-	// an initiating message that has expired (older than ExpiryTime).
+	// an initiating message that has expired (older than the message expiry window).
 	ErrMessageExpired = errors.New("initiating message has expired")
 )
 
@@ -58,7 +58,7 @@ func (i *Interop) l1Inclusion(ts uint64, blocksAtTimestamp blockPerChain) (eth.B
 // 2. For each executing message in the block:
 //   - Verify the initiating message exists in the source chain's logsDB
 //   - Verify the initiating message timestamp <= executing message timestamp
-//   - Verify the initiating message hasn't expired (within ExpiryTime)
+//   - Verify the initiating message hasn't expired (within message expiry window)
 func (i *Interop) verifyInteropMessages(ts uint64, blocksAtTimestamp blockPerChain) (Result, error) {
 	result := Result{
 		Timestamp:    ts,
@@ -171,7 +171,7 @@ func (i *Interop) verifyInteropMessages(ts uint64, blocksAtTimestamp blockPerCha
 // verifyExecutingMessage verifies a single executing message by checking:
 //  1. The initiating message exists in the source chain's database
 //  2. The initiating message's timestamp is not greater than the executing block's timestamp
-//  3. The initiating message hasn't expired (timestamp + ExpiryTime >= executing timestamp)
+//  3. The initiating message hasn't expired (timestamp + messageExpiryWindow >= executing timestamp)
 func (i *Interop) verifyExecutingMessage(executingChain eth.ChainID, executingTimestamp uint64, logIdx uint32, execMsg *types.ExecutingMessage) error {
 	// Get the source chain's logsDB
 	sourceDB, ok := i.logsDBs[execMsg.ChainID]
@@ -185,10 +185,10 @@ func (i *Interop) verifyExecutingMessage(executingChain eth.ChainID, executingTi
 			execMsg.Timestamp, executingTimestamp, ErrTimestampViolation)
 	}
 
-	// Verify the message hasn't expired: initiating timestamp + ExpiryTime must be >= executing timestamp
-	if execMsg.Timestamp+ExpiryTime < executingTimestamp {
+	// Verify the message hasn't expired: initiating timestamp + messageExpiryWindow must be >= executing timestamp
+	if execMsg.Timestamp+i.messageExpiryWindow < executingTimestamp {
 		return fmt.Errorf("initiating timestamp %d + expiry %d < executing timestamp %d: %w",
-			execMsg.Timestamp, ExpiryTime, executingTimestamp, ErrMessageExpired)
+			execMsg.Timestamp, i.messageExpiryWindow, executingTimestamp, ErrMessageExpired)
 	}
 
 	// Build the query for the initiating message

--- a/op-supernode/supernode/activity/interop/algo_test.go
+++ b/op-supernode/supernode/activity/interop/algo_test.go
@@ -84,6 +84,7 @@ func TestL1Inclusion(t *testing.T) {
 				l1Block := eth.BlockID{Number: 50, Hash: common.HexToHash("0xL1")}
 
 				interop := &Interop{
+					messageExpiryWindow: defaultMessageExpiryWindow,
 					log:     gethlog.New(),
 					logsDBs: map[eth.ChainID]LogsDB{},
 					chains:  map[eth.ChainID]cc.ChainContainer{chainID: &algoMockChain{id: chainID, optimisticL1: l1Block}},
@@ -105,6 +106,7 @@ func TestL1Inclusion(t *testing.T) {
 				// Chain 2 has L1 at 45 (earliest)
 				// Chain 3 has L1 at 50 (middle)
 				interop := &Interop{
+					messageExpiryWindow: defaultMessageExpiryWindow,
 					log:     gethlog.New(),
 					logsDBs: map[eth.ChainID]LogsDB{},
 					chains: map[eth.ChainID]cc.ChainContainer{
@@ -132,6 +134,7 @@ func TestL1Inclusion(t *testing.T) {
 				l1Block1 := eth.BlockID{Number: 50, Hash: common.HexToHash("0xL1_1")}
 
 				interop := &Interop{
+					messageExpiryWindow: defaultMessageExpiryWindow,
 					log:     gethlog.New(),
 					logsDBs: map[eth.ChainID]LogsDB{},
 					chains: map[eth.ChainID]cc.ChainContainer{
@@ -154,6 +157,7 @@ func TestL1Inclusion(t *testing.T) {
 				chainID := eth.ChainIDFromUInt64(10)
 
 				interop := &Interop{
+					messageExpiryWindow: defaultMessageExpiryWindow,
 					log:     gethlog.New(),
 					logsDBs: map[eth.ChainID]LogsDB{},
 					chains: map[eth.ChainID]cc.ChainContainer{
@@ -171,6 +175,7 @@ func TestL1Inclusion(t *testing.T) {
 			name: "NoChains_ReturnsEmpty",
 			setup: func() (*Interop, uint64, map[eth.ChainID]eth.BlockID) {
 				interop := &Interop{
+					messageExpiryWindow: defaultMessageExpiryWindow,
 					log:     gethlog.New(),
 					logsDBs: map[eth.ChainID]LogsDB{},
 					chains:  map[eth.ChainID]cc.ChainContainer{},
@@ -189,6 +194,7 @@ func TestL1Inclusion(t *testing.T) {
 				l1Block := eth.BlockID{Number: 0, Hash: common.HexToHash("0xGenesisL1")}
 
 				interop := &Interop{
+					messageExpiryWindow: defaultMessageExpiryWindow,
 					log:     gethlog.New(),
 					logsDBs: map[eth.ChainID]LogsDB{},
 					chains:  map[eth.ChainID]cc.ChainContainer{chainID: &algoMockChain{id: chainID, optimisticL1: l1Block}},
@@ -245,6 +251,7 @@ func TestVerifyInteropMessages(t *testing.T) {
 				}
 
 				interop := &Interop{
+					messageExpiryWindow: defaultMessageExpiryWindow,
 					log:     gethlog.New(),
 					logsDBs: map[eth.ChainID]LogsDB{chainID: mockDB},
 					chains:  map[eth.ChainID]cc.ChainContainer{chainID: newMockChainWithL1(chainID, l1Block)},
@@ -294,6 +301,7 @@ func TestVerifyInteropMessages(t *testing.T) {
 				}
 
 				interop := &Interop{
+					messageExpiryWindow: defaultMessageExpiryWindow,
 					log: gethlog.New(),
 					logsDBs: map[eth.ChainID]LogsDB{
 						sourceChainID: sourceDB,
@@ -326,7 +334,7 @@ func TestVerifyInteropMessages(t *testing.T) {
 
 				// Message is exactly at the expiry boundary (should pass)
 				execTimestamp := uint64(1000000)
-				initTimestamp := execTimestamp - ExpiryTime // Exactly at boundary
+				initTimestamp := execTimestamp - defaultMessageExpiryWindow // Exactly at boundary
 
 				sourceBlock := eth.BlockID{Number: 50, Hash: sourceBlockHash}
 				destBlock := eth.BlockID{Number: 100, Hash: destBlockHash}
@@ -353,6 +361,7 @@ func TestVerifyInteropMessages(t *testing.T) {
 				}
 
 				interop := &Interop{
+					messageExpiryWindow: defaultMessageExpiryWindow,
 					log: gethlog.New(),
 					logsDBs: map[eth.ChainID]LogsDB{
 						sourceChainID: sourceDB,
@@ -414,6 +423,7 @@ func TestVerifyInteropMessages(t *testing.T) {
 				l1Block := eth.BlockID{Number: 40, Hash: common.HexToHash("0xL1")}
 
 				interop := &Interop{
+					messageExpiryWindow: defaultMessageExpiryWindow,
 					log: gethlog.New(),
 					logsDBs: map[eth.ChainID]LogsDB{
 						sourceChainID: sourceDB,
@@ -451,6 +461,7 @@ func TestVerifyInteropMessages(t *testing.T) {
 				}
 
 				interop := &Interop{
+					messageExpiryWindow: defaultMessageExpiryWindow,
 					log:     gethlog.New(),
 					logsDBs: map[eth.ChainID]LogsDB{registeredChain: mockDB},
 					chains: map[eth.ChainID]cc.ChainContainer{
@@ -488,6 +499,7 @@ func TestVerifyInteropMessages(t *testing.T) {
 				}
 
 				interop := &Interop{
+					messageExpiryWindow: defaultMessageExpiryWindow,
 					log:     gethlog.New(),
 					logsDBs: map[eth.ChainID]LogsDB{chainID: mockDB},
 					chains:  map[eth.ChainID]cc.ChainContainer{chainID: newMockChainWithL1(chainID, l1Block, expectedBlock)},
@@ -532,6 +544,7 @@ func TestVerifyInteropMessages(t *testing.T) {
 				}
 
 				interop := &Interop{
+					messageExpiryWindow: defaultMessageExpiryWindow,
 					log: gethlog.New(),
 					logsDBs: map[eth.ChainID]LogsDB{
 						sourceChainID: sourceDB,
@@ -583,6 +596,7 @@ func TestVerifyInteropMessages(t *testing.T) {
 				}
 
 				interop := &Interop{
+					messageExpiryWindow: defaultMessageExpiryWindow,
 					log: gethlog.New(),
 					logsDBs: map[eth.ChainID]LogsDB{
 						sourceChainID: sourceDB,
@@ -627,6 +641,7 @@ func TestVerifyInteropMessages(t *testing.T) {
 				}
 
 				interop := &Interop{
+					messageExpiryWindow: defaultMessageExpiryWindow,
 					log: gethlog.New(),
 					logsDBs: map[eth.ChainID]LogsDB{
 						destChainID: destDB,
@@ -655,8 +670,8 @@ func TestVerifyInteropMessages(t *testing.T) {
 				destBlockHash := common.HexToHash("0xDest")
 				// Executing block is at timestamp 1000000 (well after expiry)
 				execTimestamp := uint64(1000000)
-				// Initiating message timestamp is more than ExpiryTime (604800) before executing timestamp
-				initTimestamp := execTimestamp - ExpiryTime - 1 // 1 second past expiry
+				// Initiating message timestamp is more than defaultMessageExpiryWindow (604800) before executing timestamp
+				initTimestamp := execTimestamp - defaultMessageExpiryWindow - 1 // 1 second past expiry
 
 				destBlock := eth.BlockID{Number: 100, Hash: destBlockHash}
 
@@ -680,6 +695,7 @@ func TestVerifyInteropMessages(t *testing.T) {
 				}
 
 				interop := &Interop{
+					messageExpiryWindow: defaultMessageExpiryWindow,
 					log: gethlog.New(),
 					logsDBs: map[eth.ChainID]LogsDB{
 						sourceChainID: sourceDB,
@@ -737,6 +753,7 @@ func TestVerifyInteropMessages(t *testing.T) {
 				}
 
 				interop := &Interop{
+					messageExpiryWindow: defaultMessageExpiryWindow,
 					log: gethlog.New(),
 					logsDBs: map[eth.ChainID]LogsDB{
 						sourceChainID:  sourceDB,
@@ -780,6 +797,7 @@ func TestVerifyInteropMessages(t *testing.T) {
 				}
 
 				interop := &Interop{
+					messageExpiryWindow: defaultMessageExpiryWindow,
 					log:     gethlog.New(),
 					logsDBs: map[eth.ChainID]LogsDB{chainID: mockDB},
 					chains:  map[eth.ChainID]cc.ChainContainer{chainID: newMockChainWithL1(chainID, l1Block)},

--- a/op-supernode/supernode/activity/interop/algo_test.go
+++ b/op-supernode/supernode/activity/interop/algo_test.go
@@ -85,9 +85,9 @@ func TestL1Inclusion(t *testing.T) {
 
 				interop := &Interop{
 					messageExpiryWindow: defaultMessageExpiryWindow,
-					log:     gethlog.New(),
-					logsDBs: map[eth.ChainID]LogsDB{},
-					chains:  map[eth.ChainID]cc.ChainContainer{chainID: &algoMockChain{id: chainID, optimisticL1: l1Block}},
+					log:                 gethlog.New(),
+					logsDBs:             map[eth.ChainID]LogsDB{},
+					chains:              map[eth.ChainID]cc.ChainContainer{chainID: &algoMockChain{id: chainID, optimisticL1: l1Block}},
 				}
 				return interop, 1000, map[eth.ChainID]eth.BlockID{chainID: expectedBlock}
 			},
@@ -107,8 +107,8 @@ func TestL1Inclusion(t *testing.T) {
 				// Chain 3 has L1 at 50 (middle)
 				interop := &Interop{
 					messageExpiryWindow: defaultMessageExpiryWindow,
-					log:     gethlog.New(),
-					logsDBs: map[eth.ChainID]LogsDB{},
+					log:                 gethlog.New(),
+					logsDBs:             map[eth.ChainID]LogsDB{},
 					chains: map[eth.ChainID]cc.ChainContainer{
 						chain1ID: &algoMockChain{id: chain1ID, optimisticL1: eth.BlockID{Number: 60, Hash: common.HexToHash("0xL1_1")}},
 						chain2ID: &algoMockChain{id: chain2ID, optimisticL1: eth.BlockID{Number: 45, Hash: common.HexToHash("0xL1_2")}},
@@ -135,8 +135,8 @@ func TestL1Inclusion(t *testing.T) {
 
 				interop := &Interop{
 					messageExpiryWindow: defaultMessageExpiryWindow,
-					log:     gethlog.New(),
-					logsDBs: map[eth.ChainID]LogsDB{},
+					log:                 gethlog.New(),
+					logsDBs:             map[eth.ChainID]LogsDB{},
 					chains: map[eth.ChainID]cc.ChainContainer{
 						chain1ID: &algoMockChain{id: chain1ID, optimisticL1: l1Block1},
 						// chain2ID NOT in chains map
@@ -158,8 +158,8 @@ func TestL1Inclusion(t *testing.T) {
 
 				interop := &Interop{
 					messageExpiryWindow: defaultMessageExpiryWindow,
-					log:     gethlog.New(),
-					logsDBs: map[eth.ChainID]LogsDB{},
+					log:                 gethlog.New(),
+					logsDBs:             map[eth.ChainID]LogsDB{},
 					chains: map[eth.ChainID]cc.ChainContainer{
 						chainID: &algoMockChain{id: chainID, optimisticAtErr: errors.New("optimistic at error")},
 					},
@@ -176,9 +176,9 @@ func TestL1Inclusion(t *testing.T) {
 			setup: func() (*Interop, uint64, map[eth.ChainID]eth.BlockID) {
 				interop := &Interop{
 					messageExpiryWindow: defaultMessageExpiryWindow,
-					log:     gethlog.New(),
-					logsDBs: map[eth.ChainID]LogsDB{},
-					chains:  map[eth.ChainID]cc.ChainContainer{},
+					log:                 gethlog.New(),
+					logsDBs:             map[eth.ChainID]LogsDB{},
+					chains:              map[eth.ChainID]cc.ChainContainer{},
 				}
 				return interop, 1000, map[eth.ChainID]eth.BlockID{}
 			},
@@ -195,9 +195,9 @@ func TestL1Inclusion(t *testing.T) {
 
 				interop := &Interop{
 					messageExpiryWindow: defaultMessageExpiryWindow,
-					log:     gethlog.New(),
-					logsDBs: map[eth.ChainID]LogsDB{},
-					chains:  map[eth.ChainID]cc.ChainContainer{chainID: &algoMockChain{id: chainID, optimisticL1: l1Block}},
+					log:                 gethlog.New(),
+					logsDBs:             map[eth.ChainID]LogsDB{},
+					chains:              map[eth.ChainID]cc.ChainContainer{chainID: &algoMockChain{id: chainID, optimisticL1: l1Block}},
 				}
 				return interop, 0, map[eth.ChainID]eth.BlockID{
 					chainID: {Number: 0, Hash: common.HexToHash("0x123")},
@@ -252,9 +252,9 @@ func TestVerifyInteropMessages(t *testing.T) {
 
 				interop := &Interop{
 					messageExpiryWindow: defaultMessageExpiryWindow,
-					log:     gethlog.New(),
-					logsDBs: map[eth.ChainID]LogsDB{chainID: mockDB},
-					chains:  map[eth.ChainID]cc.ChainContainer{chainID: newMockChainWithL1(chainID, l1Block)},
+					log:                 gethlog.New(),
+					logsDBs:             map[eth.ChainID]LogsDB{chainID: mockDB},
+					chains:              map[eth.ChainID]cc.ChainContainer{chainID: newMockChainWithL1(chainID, l1Block)},
 				}
 
 				return interop, 1000, map[eth.ChainID]eth.BlockID{chainID: expectedBlock}
@@ -302,7 +302,7 @@ func TestVerifyInteropMessages(t *testing.T) {
 
 				interop := &Interop{
 					messageExpiryWindow: defaultMessageExpiryWindow,
-					log: gethlog.New(),
+					log:                 gethlog.New(),
 					logsDBs: map[eth.ChainID]LogsDB{
 						sourceChainID: sourceDB,
 						destChainID:   destDB,
@@ -362,7 +362,7 @@ func TestVerifyInteropMessages(t *testing.T) {
 
 				interop := &Interop{
 					messageExpiryWindow: defaultMessageExpiryWindow,
-					log: gethlog.New(),
+					log:                 gethlog.New(),
 					logsDBs: map[eth.ChainID]LogsDB{
 						sourceChainID: sourceDB,
 						destChainID:   destDB,
@@ -424,7 +424,7 @@ func TestVerifyInteropMessages(t *testing.T) {
 
 				interop := &Interop{
 					messageExpiryWindow: defaultMessageExpiryWindow,
-					log: gethlog.New(),
+					log:                 gethlog.New(),
 					logsDBs: map[eth.ChainID]LogsDB{
 						sourceChainID: sourceDB,
 						destChainID:   destDB,
@@ -462,8 +462,8 @@ func TestVerifyInteropMessages(t *testing.T) {
 
 				interop := &Interop{
 					messageExpiryWindow: defaultMessageExpiryWindow,
-					log:     gethlog.New(),
-					logsDBs: map[eth.ChainID]LogsDB{registeredChain: mockDB},
+					log:                 gethlog.New(),
+					logsDBs:             map[eth.ChainID]LogsDB{registeredChain: mockDB},
 					chains: map[eth.ChainID]cc.ChainContainer{
 						registeredChain: newMockChainWithL1(registeredChain, eth.BlockID{Number: 40, Hash: common.HexToHash("0xL1")}),
 					},
@@ -500,9 +500,9 @@ func TestVerifyInteropMessages(t *testing.T) {
 
 				interop := &Interop{
 					messageExpiryWindow: defaultMessageExpiryWindow,
-					log:     gethlog.New(),
-					logsDBs: map[eth.ChainID]LogsDB{chainID: mockDB},
-					chains:  map[eth.ChainID]cc.ChainContainer{chainID: newMockChainWithL1(chainID, l1Block, expectedBlock)},
+					log:                 gethlog.New(),
+					logsDBs:             map[eth.ChainID]LogsDB{chainID: mockDB},
+					chains:              map[eth.ChainID]cc.ChainContainer{chainID: newMockChainWithL1(chainID, l1Block, expectedBlock)},
 				}
 
 				return interop, 1000, map[eth.ChainID]eth.BlockID{chainID: expectedBlock}
@@ -545,7 +545,7 @@ func TestVerifyInteropMessages(t *testing.T) {
 
 				interop := &Interop{
 					messageExpiryWindow: defaultMessageExpiryWindow,
-					log: gethlog.New(),
+					log:                 gethlog.New(),
 					logsDBs: map[eth.ChainID]LogsDB{
 						sourceChainID: sourceDB,
 						destChainID:   destDB,
@@ -597,7 +597,7 @@ func TestVerifyInteropMessages(t *testing.T) {
 
 				interop := &Interop{
 					messageExpiryWindow: defaultMessageExpiryWindow,
-					log: gethlog.New(),
+					log:                 gethlog.New(),
 					logsDBs: map[eth.ChainID]LogsDB{
 						sourceChainID: sourceDB,
 						destChainID:   destDB,
@@ -642,7 +642,7 @@ func TestVerifyInteropMessages(t *testing.T) {
 
 				interop := &Interop{
 					messageExpiryWindow: defaultMessageExpiryWindow,
-					log: gethlog.New(),
+					log:                 gethlog.New(),
 					logsDBs: map[eth.ChainID]LogsDB{
 						destChainID: destDB,
 						// Note: unknownSourceChain NOT in logsDBs
@@ -696,7 +696,7 @@ func TestVerifyInteropMessages(t *testing.T) {
 
 				interop := &Interop{
 					messageExpiryWindow: defaultMessageExpiryWindow,
-					log: gethlog.New(),
+					log:                 gethlog.New(),
 					logsDBs: map[eth.ChainID]LogsDB{
 						sourceChainID: sourceDB,
 						destChainID:   destDB,
@@ -754,7 +754,7 @@ func TestVerifyInteropMessages(t *testing.T) {
 
 				interop := &Interop{
 					messageExpiryWindow: defaultMessageExpiryWindow,
-					log: gethlog.New(),
+					log:                 gethlog.New(),
 					logsDBs: map[eth.ChainID]LogsDB{
 						sourceChainID:  sourceDB,
 						validChainID:   validDB,
@@ -798,9 +798,9 @@ func TestVerifyInteropMessages(t *testing.T) {
 
 				interop := &Interop{
 					messageExpiryWindow: defaultMessageExpiryWindow,
-					log:     gethlog.New(),
-					logsDBs: map[eth.ChainID]LogsDB{chainID: mockDB},
-					chains:  map[eth.ChainID]cc.ChainContainer{chainID: newMockChainWithL1(chainID, l1Block)},
+					log:                 gethlog.New(),
+					logsDBs:             map[eth.ChainID]LogsDB{chainID: mockDB},
+					chains:              map[eth.ChainID]cc.ChainContainer{chainID: newMockChainWithL1(chainID, l1Block)},
 				}
 
 				return interop, 1000, map[eth.ChainID]eth.BlockID{chainID: block}

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -81,6 +81,8 @@ type Interop struct {
 	activationTimestamp uint64
 	dataDir             string
 
+	messageExpiryWindow uint64
+
 	verifiedDB *VerifiedDB
 	logsDBs    map[eth.ChainID]LogsDB
 
@@ -115,6 +117,7 @@ func (i *Interop) Name() string {
 func New(
 	log log.Logger,
 	activationTimestamp uint64,
+	messageExpiryWindow uint64,
 	chains map[eth.ChainID]cc.ChainContainer,
 	dataDir string,
 	l1Source l1ByNumberSource,
@@ -141,6 +144,9 @@ func New(
 		logsDBs[chainID] = logsDB
 	}
 
+	if messageExpiryWindow == 0 {
+		messageExpiryWindow = defaultMessageExpiryWindow
+	}
 	i := &Interop{
 		log:                 log,
 		chains:              chains,
@@ -148,6 +154,7 @@ func New(
 		logsDBs:             logsDBs,
 		dataDir:             dataDir,
 		activationTimestamp: activationTimestamp,
+		messageExpiryWindow: messageExpiryWindow,
 	}
 	// default to using the verifyInteropMessages function
 	// (can be overridden by tests)

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -89,7 +89,7 @@ func (h *interopTestHarness) Build() *interopTestHarness {
 	for id, mock := range h.mocks {
 		chains[id] = mock
 	}
-	h.interop = New(testLogger(), h.activationTime, chains, h.dataDir, nil)
+	h.interop = New(testLogger(), h.activationTime, 0, chains, h.dataDir, nil)
 	if h.interop != nil {
 		h.interop.ctx = context.Background()
 		h.t.Cleanup(func() { _ = h.interop.Stop(context.Background()) })
@@ -129,7 +129,7 @@ func TestNew(t *testing.T) {
 				return h.WithChain(10, nil).WithChain(8453, nil).SkipBuild()
 			},
 			run: func(t *testing.T, h *interopTestHarness) {
-				interop := New(testLogger(), h.activationTime, h.Chains(), h.dataDir, nil)
+				interop := New(testLogger(), h.activationTime, 0, h.Chains(), h.dataDir, nil)
 				require.NotNil(t, interop)
 				t.Cleanup(func() { _ = interop.Stop(context.Background()) })
 
@@ -152,7 +152,7 @@ func TestNew(t *testing.T) {
 				return h.WithDataDir("/nonexistent/path").SkipBuild()
 			},
 			run: func(t *testing.T, h *interopTestHarness) {
-				interop := New(testLogger(), h.activationTime, h.Chains(), h.dataDir, nil)
+				interop := New(testLogger(), h.activationTime, 0, h.Chains(), h.dataDir, nil)
 				require.Nil(t, interop)
 			},
 		},
@@ -1145,7 +1145,7 @@ func TestInterop_FullCycle(t *testing.T) {
 	mock.blockAtTimestamp = eth.L2BlockRef{Number: 500, Hash: common.HexToHash("0xL2")}
 
 	chains := map[eth.ChainID]cc.ChainContainer{mock.id: mock}
-	interop := New(testLogger(), 100, chains, dataDir, nil)
+	interop := New(testLogger(), 100, 0, chains, dataDir, nil)
 	require.NotNil(t, interop)
 	interop.ctx = context.Background()
 

--- a/op-supernode/supernode/supernode.go
+++ b/op-supernode/supernode/supernode.go
@@ -104,7 +104,15 @@ func New(ctx context.Context, log gethlog.Logger, version string, requestStop co
 	// Initialize interop activity if the activation timestamp is known (non-nil).
 	// If it's nil, don't start interop. If it's non-nil (including 0), do start it.
 	if interopActivationTimestamp != nil {
-		interopActivity := interop.New(log.New("activity", "interop"), *interopActivationTimestamp, s.chains, cfg.DataDir, s.l1Client)
+		// Extract the message expiry window from the first virtual node's dependency set.
+		var msgExpiryWindow uint64
+		for _, vnCfg := range vnCfgs {
+			if vnCfg.DependencySet != nil {
+				msgExpiryWindow = vnCfg.DependencySet.MessageExpiryWindow()
+				break
+			}
+		}
+		interopActivity := interop.New(log.New("activity", "interop"), *interopActivationTimestamp, msgExpiryWindow, s.chains, cfg.DataDir, s.l1Client)
 		s.activities = append(s.activities, interopActivity)
 		for _, chain := range s.chains {
 			chain.RegisterVerifier(interopActivity)


### PR DESCRIPTION
## Summary

- Migrates `TestInteropFaultProofs_MessageExpiry` from `op-e2e/actions/interop/proofs_test.go` to `op-acceptance-tests` using the devstack DSL and supernode infrastructure
- Adds `WithMessageExpiryWindow` preset option to configure a short (12s) expiry window for testing (default 604800s is impractical with real services)
- Adds `PrepareExecTx` on `EOA` to build/sign an exec tx without submitting, for injection via `TestSequencer.SequenceBlockWithTxs` — bypassing `InteropMempoolFiltering` to model a malicious sequencer force-including an expired message
- Verifies block replacement during consolidation and runs FPP + challenger transition tests

Towards #19010

## Test plan

- [x] `TestInteropFaultProofs_MessageExpiry` passes locally with supernode proofs preset
- [x] Pre-consolidation assertion: expired exec tx is in the injected block
- [x] Post-consolidation assertion: expired exec tx is reorged out
- [x] FPP sub-tests: kona correctly identifies invalid (pre-replacement) and valid (post-replacement) claims
- [x] Challenger sub-tests: trace provider agrees with expected claim validity

🤖 Generated with [Claude Code](https://claude.com/claude-code)