### PR TITLE
test(op-acceptance-tests): unskip superroot proofs tests

### DIFF
--- a/op-acceptance-tests/tests/interop/proofs/fpp/fpp_test.go
+++ b/op-acceptance-tests/tests/interop/proofs/fpp/fpp_test.go
@@ -22,8 +22,6 @@ func TestFPP(gt *testing.T) {
 
 func TestNextSuperRootNotFound(gt *testing.T) {
 	t := devtest.ParallelT(gt)
-	// TODO(#19180): Unskip this once supernode is updated.
-	t.Skip("Supernode does not yet return optimistic blocks until blocks are fully validated")
 	sys := presets.NewSimpleInteropSupernodeProofs(t, presets.WithChallengerCannonKonaEnabled())
 	blockTime := sys.L2ChainA.Escape().RollupConfig().BlockTime
 

--- a/op-acceptance-tests/tests/interop/proofs/serial/interop_fault_proofs_test.go
+++ b/op-acceptance-tests/tests/interop/proofs/serial/interop_fault_proofs_test.go
@@ -12,8 +12,6 @@ import (
 
 func TestInteropFaultProofs(gt *testing.T) {
 	t := devtest.ParallelT(gt)
-	// TODO(#19180): Unskip this once supernode is updated.
-	t.Skip("Supernode does not yet return optimistic blocks until blocks are fully validated")
 	sys := presets.NewSimpleInteropSupernodeProofs(t, presets.WithChallengerCannonKonaEnabled())
 	sfp.RunSuperFaultProofTest(t, sys)
 }


### PR DESCRIPTION
The supernode now eagerly returns optimistic blocks and partial OptimisticAtTimestamp data, so the tests blocked on #19180 can run.

Part of #19010 