### PR TITLE
feat(mise): add nightly rust toolchain and cargo-nextest

### DIFF
--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -408,10 +408,6 @@ jobs:
           directory: <<parameters.directory>>
           prefix: <<parameters.directory>>-fmt
       - run:
-          name: Install nightly toolchain
-          working_directory: <<parameters.directory>>
-          command: just install-nightly
-      - run:
           name: Check formatting
           working_directory: <<parameters.directory>>
           command: <<parameters.command>>
@@ -599,10 +595,6 @@ jobs:
           prefix: <<parameters.directory>>-docs
           features: "all"
       - run:
-          name: Install nightly toolchain
-          working_directory: <<parameters.directory>>
-          command: just install-nightly
-      - run:
           name: Build documentation
           working_directory: <<parameters.directory>>
           no_output_timeout: 30m
@@ -701,10 +693,6 @@ jobs:
           directory: <<parameters.directory>>
           prefix: <<parameters.directory>>-udeps
           profile: "release"
-      - run:
-          name: Install nightly toolchain
-          working_directory: <<parameters.directory>>
-          command: just install-nightly
       - install-cargo-binstall
       - run:
           name: Install cargo-udeps

--- a/.claude/skills/fix-rust-fmt/SKILL.md
+++ b/.claude/skills/fix-rust-fmt/SKILL.md
@@ -28,16 +28,7 @@ cd <REPO_ROOT> && mise install
 
 This installs `rust`, `just`, and all other tools pinned in `mise.toml`.
 
-### Step 2: Install the nightly toolchain with rustfmt
-
-The justfile pins a specific nightly (see `NIGHTLY` variable in `rust/justfile`).
-Install it:
-
-```bash
-cd <REPO_ROOT>/rust && mise exec -- just install-nightly
-```
-
-### Step 3: Run the formatter
+### Step 2: Run the formatter
 
 ```bash
 cd <REPO_ROOT>/rust && mise exec -- just fmt-fix

--- a/docs/ai/rust-dev.md
+++ b/docs/ai/rust-dev.md
@@ -98,12 +98,7 @@ Lint configuration lives in `rust/Cargo.toml` (workspace lints section), `rust/c
 
 ### Formatting Requires Nightly
 
-Formatting uses a pinned nightly toolchain (defined as `NIGHTLY` in `rust/justfile`). If the nightly isn't installed:
-
-```bash
-cd rust
-just install-nightly
-```
+Formatting uses a pinned nightly toolchain (defined as `NIGHTLY` in `rust/justfile`). It is installed via mise.
 
 Then use `just fmt-fix` to auto-format, or `just fmt-check` to verify.
 

--- a/mise.toml
+++ b/mise.toml
@@ -6,7 +6,7 @@ go = "1.24.13"
 golangci-lint = "2.8.0"
 gotestsum = "1.12.3"
 mockery = "2.53.3"
-rust = "1.94.0"
+rust = ["1.94.0", { version = "nightly-2026-02-20", components = "rustfmt" }]
 python = "3.12.0"
 uv = "0.5.5"
 jq = "1.7.1"
@@ -18,6 +18,7 @@ just = "1.46.0"
 make = "4.4.1"
 
 svm-rs = "0.5.19"
+"github:nextest-rs/nextest" = { version = "0.9.132", version_prefix = "cargo-nextest-", bin = "cargo-nextest" }
 
 # Go dependencies
 "go:github.com/ethereum/go-ethereum/cmd/abigen" = "1.15.10"
@@ -61,7 +62,6 @@ gotestsum = "ubi:gotestyourself/gotestsum"
 kurtosis = "ubi:kurtosis-tech/kurtosis-cli-release-artifacts[exe=kurtosis]"
 mockery = "ubi:vektra/mockery"
 svm-rs = "ubi:alloy-rs/svm-rs[exe=svm]"
-
 # These are disabled, but latest mise versions error if they don't have a known
 # install source even though it won't ever actually use that source.
 kontrol = "ubi:ethereum-optimism/fake-kontrol"

--- a/rust/justfile
+++ b/rust/justfile
@@ -1,6 +1,6 @@
 set positional-arguments
 
-NIGHTLY := "nightly-2026-02-20"
+NIGHTLY := `grep -oE 'nightly-[0-9]{4}-[0-9]{2}-[0-9]{2}' ../mise.toml | head -1`
 
 # Aliases
 alias t := test


### PR DESCRIPTION
Install the pinned nightly toolchain and cargo-nextest automatically via mise instead of requiring manual setup. The nightly version pin in rust/justfile now reads from mise.toml to keep a single source of truth.

Remove the now-unnecessary install-nightly steps from CI, the fix-rust-fmt skill, and the rust-dev docs.