### PR TITLE
docs: remove revenue sharing config references

### DIFF
--- a/docs/public-docs/chain-operators/guides/features/custom-gas-token-guide.mdx
+++ b/docs/public-docs/chain-operators/guides/features/custom-gas-token-guide.mdx
@@ -71,7 +71,6 @@ Deploying a CGT chain follows the standard OP Stack deployment process with addi
       gasLimit = 60000000
       operatorFeeScalar = 0
       operatorFeeConstant = 0
-      chainFeesRecipient = "0x0000000000000000000000000000000000000000"
       minBaseFee = 0
       daFootprintGasScalar = 0
 

--- a/docs/public-docs/chain-operators/tools/op-deployer/usage/init.mdx
+++ b/docs/public-docs/chain-operators/tools/op-deployer/usage/init.mdx
@@ -56,10 +56,6 @@ l2ContractsLocator = "tag://op-contracts/v1.7.0-beta.1+l2-contracts"
   eip1559Denominator = 50
   eip1559Elasticity = 6
 
-  # Revenue Sharing Configuration
-  useRevenueShare = true
-  chainFeesRecipient = "0x0000000000000000000000000000000000000000"
-
   [chains.roles]
     l1ProxyAdminOwner = "0x0000000000000000000000000000000000000000"
     l2ProxyAdminOwner = "0x0000000000000000000000000000000000000000"
@@ -74,23 +70,6 @@ l2ContractsLocator = "tag://op-contracts/v1.7.0-beta.1+l2-contracts"
 Before you can use your intent file for a deployment, you will need to update all zero values to whatever is
 appropriate for your chain. For dev environments, it is ok to use all EOAs/hot-wallets.
 </Warning>
-
-## Revenue Sharing Configuration
-
-The `useRevenueShare` field controls whether your chain enables the revenue sharing system feature:
-
-*   **`useRevenueShare = true`** (default for standard configurations): `FeeVault`s are upgraded and configured to use the `FeeSplitter` contract as the recipient, L2 as withdrawal network and `0` as the minimum withdrawal amount. The split logic is calculated using the `SuperchainRevSharesCalculator` contract. The `L1Withdrawer` contract is set to withdraw the OP portion of fees automatically.
-
-*   **`useRevenueShare = false`**: `FeeSplitter` is deployed but initialized with zero address for the `sharesCalculator` field. No deployment is made for the `SuperchainRevSharesCalculator` and `L1Withdrawer` contracts. `FeeVault`s are upgraded but initialized using the custom configuration you provide.
-
-### Configuration Fields
-
-*   `useRevenueShare` (optional): Enables or disables the revenue sharing system. Defaults to `true` for standard configurations, `false` for custom.
-*   `chainFeesRecipient` (required when `useRevenueShare = true`): Address that receives the chain operator's portion of fee revenue on L2. Must be able to receive ETH.
-
-<Info>
-Since `useRevenueShare` defaults to `true` for standard configurations, you must either provide a `chainFeesRecipient` address OR explicitly set `useRevenueShare = false` to opt out. The deployment will fail validation if revenue sharing is enabled without a recipient.
-</Info>
 
 ## Production Setup
 

--- a/docs/public-docs/create-l2-rollup-example/scripts/setup-rollup.sh
+++ b/docs/public-docs/create-l2-rollup-example/scripts/setup-rollup.sh
@@ -73,7 +73,7 @@ generate_addresses() {
     log_info "Changed to directory: $(pwd)"
 
     # Generate addresses for different roles using openssl
-    for role in admin base_fee_vault_recipient l1_fee_vault_recipient sequencer_fee_vault_recipient system_config unsafe_block_signer operator_fee_vault_recipient chain_fees_fee_recipient batcher proposer challenger ; do
+    for role in admin base_fee_vault_recipient l1_fee_vault_recipient sequencer_fee_vault_recipient system_config unsafe_block_signer operator_fee_vault_recipient batcher proposer challenger ; do
         # Generate a random 32-byte private key, ensuring it's not zero
         private_key=""
         while [ -z "$private_key" ] || [ "$private_key" = "0000000000000000000000000000000000000000000000000000000000000000" ]; do
@@ -131,7 +131,6 @@ update_intent() {
     PROPOSER_ADDR=$(cat addresses/proposer_address.txt)
     CHALLENGER_ADDR=$(cat addresses/challenger_address.txt)
     OPERATOR_FEE_VAULT_ADDR=$(cat addresses/operator_fee_vault_recipient_address.txt)
-    CHAIN_FEES_RECIPIENT_ADDR=$(cat addresses/chain_fees_fee_recipient_address.txt)
 
     # Keep the default contract locators and opcmAddress from op-deployer init
 
@@ -148,7 +147,6 @@ update_intent() {
     sed -i.bak "s|challenger = .*|challenger = \"$CHALLENGER_ADDR\"|" .deployer/intent.toml
     sed -i.bak "s|fundDevAccounts = .*|fundDevAccounts = true|" .deployer/intent.toml
     sed -i.bak "s|operatorFeeVaultRecipient = .*|operatorFeeVaultRecipient = \"$OPERATOR_FEE_VAULT_ADDR\"|" .deployer/intent.toml
-    sed -i.bak "s|chainFeesRecipient = .*|chainFeesRecipient = \"$CHAIN_FEES_RECIPIENT_ADDR\"|" .deployer/intent.toml
     log_success "Intent configuration updated"
 }
 


### PR DESCRIPTION
> ⚠️ **DO NOT MERGE** until [#19750 (refactor: revenue share cleanup)](https://github.com/ethereum-optimism/optimism/pull/19750) lands on `develop`. This docs PR depends on that schema change being live — merging first would leave the docs out of sync with `op-deployer init` output.

## Summary
- Drops `useRevenueShare` / `chainFeesRecipient` from the op-deployer init and custom gas token intent examples.
- Removes the Revenue Sharing Configuration section from `init.mdx`.
- Cleans the `chain_fees_fee_recipient` role out of `create-l2-rollup-example/scripts/setup-rollup.sh`.
- Follows the monorepo-wide removal of `FeeSplitter`, `L1Withdrawer`, `SuperchainRevSharesCalculator`, and `FeesDepositor` tracked in #19750.

## Test plan
- [x] Mintlify structure intact (headings, frontmatter, code fences, `<Warning>` / `<Info>` tags balance).
- [ ] **After #19750 merges:** run `op-deployer init` from a fresh develop build and confirm `chainFeesRecipient` is no longer emitted in the generated `intent.toml`.
- [ ] _(Optional)_ **After #19750 merges:** run `setup-rollup.sh` end-to-end (`make init && make setup && make up`) against Sepolia and verify the rollup deploys and produces blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)