### PR TITLE
refactor(op-devstack): move rust binary tooling to shared/rustbin, use it for kona-host

### DIFF
--- a/op-devstack/shared/challenger/challenger.go
+++ b/op-devstack/shared/challenger/challenger.go
@@ -1,6 +1,7 @@
 package challenger
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"encoding/json"
 	"errors"
@@ -12,6 +13,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-challenger/config"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/vm"
 	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum-optimism/optimism/op-devstack/shared/rustbin"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/crypto"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
@@ -79,7 +81,15 @@ func applyCannonKonaConfig(c *config.Config, rollupCfgs []*rollup.Config, l1Gene
 	if err := applyVmConfig(root, &c.CannonKona, c.Datadir, rollupCfgs, l1Genesis, l2Geneses); err != nil {
 		return err
 	}
-	c.CannonKona.Server = root + "rust/target/release/kona-host"
+	konaHostBin, err := rustbin.EnsureExists(context.Background(), nil, rustbin.Spec{
+		SrcDir:  "rust/kona",
+		Package: "kona-host",
+		Binary:  "kona-host",
+	})
+	if err != nil {
+		return fmt.Errorf("kona-host binary: %w", err)
+	}
+	c.CannonKona.Server = konaHostBin
 	if interop {
 		c.CannonKonaAbsolutePreState = root + "rust/kona/prestate-artifacts-cannon-interop/prestate.bin.gz"
 	} else {

--- a/op-devstack/shared/challenger/challenger.go
+++ b/op-devstack/shared/challenger/challenger.go
@@ -31,10 +31,10 @@ const (
 	InteropVariantNext  PrestateVariant = "interopNext"
 )
 
-type Option func(cfg *config.Config) error
+type Option func(ctx context.Context, cfg *config.Config) error
 
 func WithDepset(ds *depset.StaticConfigDependencySet) Option {
-	return func(c *config.Config) error {
+	return func(_ context.Context, c *config.Config) error {
 		b, err := ds.MarshalJSON()
 		if err != nil {
 			return fmt.Errorf("failed to marshal dependency set config: %w", err)
@@ -51,7 +51,7 @@ func WithDepset(ds *depset.StaticConfigDependencySet) Option {
 }
 
 func WithPrivKey(key *ecdsa.PrivateKey) Option {
-	return func(c *config.Config) error {
+	return func(_ context.Context, c *config.Config) error {
 		c.TxMgrConfig.PrivateKey = crypto.EncodePrivKeyToString(key)
 		return nil
 	}
@@ -74,7 +74,7 @@ func applyCannonConfig(c *config.Config, rollupCfgs []*rollup.Config, l1Genesis 
 	return nil
 }
 
-func applyCannonKonaConfig(c *config.Config, rollupCfgs []*rollup.Config, l1Genesis *core.Genesis, l2Geneses []*core.Genesis, interop bool) error {
+func applyCannonKonaConfig(ctx context.Context, c *config.Config, rollupCfgs []*rollup.Config, l1Genesis *core.Genesis, l2Geneses []*core.Genesis, interop bool) error {
 	root, err := findMonorepoRoot()
 	if err != nil {
 		return err
@@ -86,7 +86,7 @@ func applyCannonKonaConfig(c *config.Config, rollupCfgs []*rollup.Config, l1Gene
 		SrcDir:  "rust/kona",
 		Package: "kona-host",
 		Binary:  "kona-host",
-	}.EnsureExists(context.Background(), log.NewLogger(log.DiscardHandler()))
+	}.EnsureExists(ctx, log.NewLogger(log.DiscardHandler()))
 	if err != nil {
 		return fmt.Errorf("kona-host binary: %w", err)
 	}
@@ -143,74 +143,74 @@ func applyVmConfig(root string, c *vm.Config, dataDir string, rollupCfgs []*roll
 }
 
 func WithFactoryAddress(addr common.Address) Option {
-	return func(c *config.Config) error {
+	return func(_ context.Context, c *config.Config) error {
 		c.GameFactoryAddress = addr
 		return nil
 	}
 }
 
 func WithCannonConfig(rollupCfgs []*rollup.Config, l1Genesis *core.Genesis, l2Geneses []*core.Genesis, prestateVariant PrestateVariant) Option {
-	return func(c *config.Config) error {
+	return func(_ context.Context, c *config.Config) error {
 		return applyCannonConfig(c, rollupCfgs, l1Genesis, l2Geneses, prestateVariant)
 	}
 }
 
 func WithCannonKonaConfig(rollupCfgs []*rollup.Config, l1Genesis *core.Genesis, l2Geneses []*core.Genesis) Option {
-	return func(c *config.Config) error {
-		return applyCannonKonaConfig(c, rollupCfgs, l1Genesis, l2Geneses, false)
+	return func(ctx context.Context, c *config.Config) error {
+		return applyCannonKonaConfig(ctx, c, rollupCfgs, l1Genesis, l2Geneses, false)
 	}
 }
 
 func WithCannonKonaInteropConfig(rollupCfgs []*rollup.Config, l1Genesis *core.Genesis, l2Geneses []*core.Genesis) Option {
-	return func(c *config.Config) error {
-		return applyCannonKonaConfig(c, rollupCfgs, l1Genesis, l2Geneses, true)
+	return func(ctx context.Context, c *config.Config) error {
+		return applyCannonKonaConfig(ctx, c, rollupCfgs, l1Genesis, l2Geneses, true)
 	}
 }
 
 func WithCannonGameType() Option {
-	return func(c *config.Config) error {
+	return func(_ context.Context, c *config.Config) error {
 		c.GameTypes = append(c.GameTypes, gameTypes.CannonGameType)
 		return nil
 	}
 }
 
 func WithCannonKonaGameType() Option {
-	return func(c *config.Config) error {
+	return func(_ context.Context, c *config.Config) error {
 		c.GameTypes = append(c.GameTypes, gameTypes.CannonKonaGameType)
 		return nil
 	}
 }
 
 func WithPermissionedGameType() Option {
-	return func(c *config.Config) error {
+	return func(_ context.Context, c *config.Config) error {
 		c.GameTypes = append(c.GameTypes, gameTypes.PermissionedGameType)
 		return nil
 	}
 }
 
 func WithSuperCannonGameType() Option {
-	return func(c *config.Config) error {
+	return func(_ context.Context, c *config.Config) error {
 		c.GameTypes = append(c.GameTypes, gameTypes.SuperCannonGameType)
 		return nil
 	}
 }
 
 func WithSuperCannonKonaGameType() Option {
-	return func(c *config.Config) error {
+	return func(_ context.Context, c *config.Config) error {
 		c.GameTypes = append(c.GameTypes, gameTypes.SuperCannonKonaGameType)
 		return nil
 	}
 }
 
 func WithSuperPermissionedGameType() Option {
-	return func(c *config.Config) error {
+	return func(_ context.Context, c *config.Config) error {
 		c.GameTypes = append(c.GameTypes, gameTypes.SuperPermissionedGameType)
 		return nil
 	}
 }
 
 func WithFastGames() Option {
-	return func(c *config.Config) error {
+	return func(_ context.Context, c *config.Config) error {
 		c.GameTypes = append(c.GameTypes, gameTypes.FastGameType)
 		return nil
 	}
@@ -221,29 +221,29 @@ func WithFastGames() Option {
 // time by avoiding full block re-derivation and re-execution.
 // Requires op-reth or execution client with debug_executePayload support.
 func WithExperimentalWitnessEndpoint() Option {
-	return func(c *config.Config) error {
+	return func(_ context.Context, c *config.Config) error {
 		c.CannonKona.EnableExperimentalWitnessEndpoint = true
 		return nil
 	}
 }
 
-func NewInteropChallengerConfig(dir string, l1Endpoint string, l1Beacon string, supervisorEndpoint string, l2Endpoints []string, options ...Option) (*config.Config, error) {
+func NewInteropChallengerConfig(ctx context.Context, dir string, l1Endpoint string, l1Beacon string, supervisorEndpoint string, l2Endpoints []string, options ...Option) (*config.Config, error) {
 	cfg := config.NewInteropConfig(common.Address{}, l1Endpoint, l1Beacon, supervisorEndpoint, l2Endpoints, dir)
-	if err := applyCommonChallengerOpts(&cfg, options...); err != nil {
+	if err := applyCommonChallengerOpts(ctx, &cfg, options...); err != nil {
 		return nil, err
 	}
 	return &cfg, nil
 }
 
-func NewPreInteropChallengerConfig(dir string, l1Endpoint string, l1Beacon string, rollupEndpoint string, l2Endpoint string, options ...Option) (*config.Config, error) {
+func NewPreInteropChallengerConfig(ctx context.Context, dir string, l1Endpoint string, l1Beacon string, rollupEndpoint string, l2Endpoint string, options ...Option) (*config.Config, error) {
 	cfg := config.NewConfig(common.Address{}, l1Endpoint, l1Beacon, rollupEndpoint, l2Endpoint, dir)
-	if err := applyCommonChallengerOpts(&cfg, options...); err != nil {
+	if err := applyCommonChallengerOpts(ctx, &cfg, options...); err != nil {
 		return nil, err
 	}
 	return &cfg, nil
 }
 
-func applyCommonChallengerOpts(cfg *config.Config, options ...Option) error {
+func applyCommonChallengerOpts(ctx context.Context, cfg *config.Config, options ...Option) error {
 	cfg.Cannon.L2Custom = true
 	cfg.CannonKona.L2Custom = true
 	// The devnet can't set the absolute prestate output root because the contracts are deployed in L1 genesis
@@ -258,7 +258,7 @@ func applyCommonChallengerOpts(cfg *config.Config, options ...Option) error {
 	cfg.MetricsConfig.Enabled = false
 	cfg.PollInterval = time.Second
 	for _, option := range options {
-		if err := option(cfg); err != nil {
+		if err := option(ctx, cfg); err != nil {
 			return err
 		}
 	}

--- a/op-devstack/shared/challenger/challenger.go
+++ b/op-devstack/shared/challenger/challenger.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/log"
 )
 
 type PrestateVariant string
@@ -85,7 +86,7 @@ func applyCannonKonaConfig(c *config.Config, rollupCfgs []*rollup.Config, l1Gene
 		SrcDir:  "rust/kona",
 		Package: "kona-host",
 		Binary:  "kona-host",
-	}.EnsureExists(context.Background(), nil)
+	}.EnsureExists(context.Background(), log.NewLogger(log.DiscardHandler()))
 	if err != nil {
 		return fmt.Errorf("kona-host binary: %w", err)
 	}

--- a/op-devstack/shared/challenger/challenger.go
+++ b/op-devstack/shared/challenger/challenger.go
@@ -81,11 +81,11 @@ func applyCannonKonaConfig(c *config.Config, rollupCfgs []*rollup.Config, l1Gene
 	if err := applyVmConfig(root, &c.CannonKona, c.Datadir, rollupCfgs, l1Genesis, l2Geneses); err != nil {
 		return err
 	}
-	konaHostBin, err := rustbin.EnsureExists(context.Background(), nil, rustbin.Spec{
+	konaHostBin, err := rustbin.Spec{
 		SrcDir:  "rust/kona",
 		Package: "kona-host",
 		Binary:  "kona-host",
-	})
+	}.EnsureExists(context.Background(), nil)
 	if err != nil {
 		return fmt.Errorf("kona-host binary: %w", err)
 	}

--- a/op-devstack/shared/rustbin/rust_binary.go
+++ b/op-devstack/shared/rustbin/rust_binary.go
@@ -1,4 +1,4 @@
-package sysgo
+package rustbin
 
 import (
 	"context"
@@ -10,18 +10,19 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum/go-ethereum/log"
+
 	opservice "github.com/ethereum-optimism/optimism/op-service"
 )
 
-// RustBinarySpec describes a Rust binary to be built and located.
-type RustBinarySpec struct {
+// Spec describes a Rust binary to be built and located.
+type Spec struct {
 	SrcDir  string // directory name relative to monorepo root, e.g. "rollup-boost"
 	Package string // cargo package name, e.g. "rollup-boost"
 	Binary  string // binary name, e.g. "rollup-boost"
 }
 
-// EnsureRustBinary locates or builds a Rust binary as needed.
+// EnsureExists locates or builds a Rust binary as needed.
 //
 // Env var overrides (suffix derived from binary name, e.g. "rollup-boost" -> "ROLLUP_BOOST"):
 //   - RUST_BINARY_PATH_<BINARY>: absolute path to pre-built binary (skips build, must exist)
@@ -30,7 +31,9 @@ type RustBinarySpec struct {
 // Build behavior:
 //   - RUST_JIT_BUILD=1: runs cargo build in debug mode (letting cargo handle rebuild detection)
 //   - Otherwise: only checks binary exists, errors if missing
-func EnsureRustBinary(p devtest.CommonT, spec RustBinarySpec) (string, error) {
+//
+// logger may be nil, in which case informational messages are skipped.
+func EnsureExists(ctx context.Context, logger log.Logger, spec Spec) (string, error) {
 	envSuffix := toEnvVarSuffix(spec.Binary)
 
 	// Check for explicit binary path override
@@ -38,7 +41,9 @@ func EnsureRustBinary(p devtest.CommonT, spec RustBinarySpec) (string, error) {
 		if _, err := os.Stat(pathOverride); os.IsNotExist(err) {
 			return "", fmt.Errorf("%s binary not found at overridden path %s", spec.Binary, pathOverride)
 		}
-		p.Logger().Info("Using overridden binary path", "binary", spec.Binary, "path", pathOverride)
+		if logger != nil {
+			logger.Info("Using overridden binary path", "binary", spec.Binary, "path", pathOverride)
+		}
 		return pathOverride, nil
 	}
 
@@ -51,8 +56,10 @@ func EnsureRustBinary(p devtest.CommonT, spec RustBinarySpec) (string, error) {
 	jitBuild := os.Getenv("RUST_JIT_BUILD") != ""
 
 	if jitBuild {
-		p.Logger().Info("Building Rust binary (JIT)", "binary", spec.Binary, "dir", srcRoot)
-		if err := buildRustBinary(p.Ctx(), srcRoot, spec.Package, spec.Binary); err != nil {
+		if logger != nil {
+			logger.Info("Building Rust binary (JIT)", "binary", spec.Binary, "dir", srcRoot)
+		}
+		if err := buildRustBinary(ctx, srcRoot, spec.Package, spec.Binary); err != nil {
 			return "", err
 		}
 	}

--- a/op-devstack/shared/rustbin/rust_binary.go
+++ b/op-devstack/shared/rustbin/rust_binary.go
@@ -33,22 +33,22 @@ type Spec struct {
 //   - Otherwise: only checks binary exists, errors if missing
 //
 // logger may be nil, in which case informational messages are skipped.
-func EnsureExists(ctx context.Context, logger log.Logger, spec Spec) (string, error) {
-	envSuffix := toEnvVarSuffix(spec.Binary)
+func (s Spec) EnsureExists(ctx context.Context, logger log.Logger) (string, error) {
+	envSuffix := toEnvVarSuffix(s.Binary)
 
 	// Check for explicit binary path override
 	if pathOverride := os.Getenv("RUST_BINARY_PATH_" + envSuffix); pathOverride != "" {
 		if _, err := os.Stat(pathOverride); os.IsNotExist(err) {
-			return "", fmt.Errorf("%s binary not found at overridden path %s", spec.Binary, pathOverride)
+			return "", fmt.Errorf("%s binary not found at overridden path %s", s.Binary, pathOverride)
 		}
 		if logger != nil {
-			logger.Info("Using overridden binary path", "binary", spec.Binary, "path", pathOverride)
+			logger.Info("Using overridden binary path", "binary", s.Binary, "path", pathOverride)
 		}
 		return pathOverride, nil
 	}
 
 	// Determine source root
-	srcRoot, err := resolveSrcRoot(spec.SrcDir, envSuffix)
+	srcRoot, err := resolveSrcRoot(s.SrcDir, envSuffix)
 	if err != nil {
 		return "", err
 	}
@@ -57,17 +57,17 @@ func EnsureExists(ctx context.Context, logger log.Logger, spec Spec) (string, er
 
 	if jitBuild {
 		if logger != nil {
-			logger.Info("Building Rust binary (JIT)", "binary", spec.Binary, "dir", srcRoot)
+			logger.Info("Building Rust binary (JIT)", "binary", s.Binary, "dir", srcRoot)
 		}
-		if err := buildRustBinary(ctx, srcRoot, spec.Package, spec.Binary); err != nil {
+		if err := buildRustBinary(ctx, srcRoot, s.Package, s.Binary); err != nil {
 			return "", err
 		}
 	}
 
-	binaryPath, err := resolveBuiltRustBinaryPath(srcRoot, spec.Binary)
+	binaryPath, err := resolveBuiltRustBinaryPath(srcRoot, s.Binary)
 	if err != nil {
 		return "", fmt.Errorf("%s binary not found; run 'cd %s && just build-%s-debug' (or just build-%s for release) or set RUST_JIT_BUILD=1: %w",
-			spec.Binary, spec.SrcDir, spec.Binary, spec.Binary, err)
+			s.Binary, s.SrcDir, s.Binary, s.Binary, err)
 	}
 	return binaryPath, nil
 }

--- a/op-devstack/shared/rustbin/rust_binary.go
+++ b/op-devstack/shared/rustbin/rust_binary.go
@@ -31,8 +31,6 @@ type Spec struct {
 // Build behavior:
 //   - RUST_JIT_BUILD=1: runs cargo build in debug mode (letting cargo handle rebuild detection)
 //   - Otherwise: only checks binary exists, errors if missing
-//
-// logger may be nil, in which case informational messages are skipped.
 func (s Spec) EnsureExists(ctx context.Context, logger log.Logger) (string, error) {
 	envSuffix := toEnvVarSuffix(s.Binary)
 
@@ -41,9 +39,7 @@ func (s Spec) EnsureExists(ctx context.Context, logger log.Logger) (string, erro
 		if _, err := os.Stat(pathOverride); os.IsNotExist(err) {
 			return "", fmt.Errorf("%s binary not found at overridden path %s", s.Binary, pathOverride)
 		}
-		if logger != nil {
-			logger.Info("Using overridden binary path", "binary", s.Binary, "path", pathOverride)
-		}
+		logger.Info("Using overridden binary path", "binary", s.Binary, "path", pathOverride)
 		return pathOverride, nil
 	}
 
@@ -56,9 +52,7 @@ func (s Spec) EnsureExists(ctx context.Context, logger log.Logger) (string, erro
 	jitBuild := os.Getenv("RUST_JIT_BUILD") != ""
 
 	if jitBuild {
-		if logger != nil {
-			logger.Info("Building Rust binary (JIT)", "binary", s.Binary, "dir", srcRoot)
-		}
+		logger.Info("Building Rust binary (JIT)", "binary", s.Binary, "dir", srcRoot)
 		if err := buildRustBinary(ctx, srcRoot, s.Package, s.Binary); err != nil {
 			return "", err
 		}

--- a/op-devstack/sysgo/mixed_runtime.go
+++ b/op-devstack/sysgo/mixed_runtime.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/shared/rustbin"
 	"github.com/ethereum-optimism/optimism/op-faucet/faucet"
 	"github.com/ethereum-optimism/optimism/op-service/endpoint"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -287,7 +288,7 @@ func startMixedOpRethNode(
 
 	tempP2PPath := filepath.Join(tempDir, "p2pkey.txt")
 
-	execPath, err := EnsureRustBinary(t, RustBinarySpec{
+	execPath, err := rustbin.EnsureExists(t.Ctx(), t.Logger(), rustbin.Spec{
 		SrcDir:  "rust",
 		Package: "op-reth",
 		Binary:  "op-reth",
@@ -448,7 +449,7 @@ func startMixedKonaNode(
 		envVars = append(envVars, "KONA_NODE_MODE=Validator")
 	}
 
-	execPath, err := EnsureRustBinary(t, RustBinarySpec{
+	execPath, err := rustbin.EnsureExists(t.Ctx(), t.Logger(), rustbin.Spec{
 		SrcDir:  "rust/kona",
 		Package: "kona-node",
 		Binary:  "kona-node",

--- a/op-devstack/sysgo/mixed_runtime.go
+++ b/op-devstack/sysgo/mixed_runtime.go
@@ -288,11 +288,11 @@ func startMixedOpRethNode(
 
 	tempP2PPath := filepath.Join(tempDir, "p2pkey.txt")
 
-	execPath, err := rustbin.EnsureExists(t.Ctx(), t.Logger(), rustbin.Spec{
+	execPath, err := rustbin.Spec{
 		SrcDir:  "rust",
 		Package: "op-reth",
 		Binary:  "op-reth",
-	})
+	}.EnsureExists(t.Ctx(), t.Logger())
 	t.Require().NoError(err, "op-reth binary not available (build with 'just build-rust-release' or set RUST_JIT_BUILD=1)")
 
 	args := []string{
@@ -449,11 +449,11 @@ func startMixedKonaNode(
 		envVars = append(envVars, "KONA_NODE_MODE=Validator")
 	}
 
-	execPath, err := rustbin.EnsureExists(t.Ctx(), t.Logger(), rustbin.Spec{
+	execPath, err := rustbin.Spec{
 		SrcDir:  "rust/kona",
 		Package: "kona-node",
 		Binary:  "kona-node",
-	})
+	}.EnsureExists(t.Ctx(), t.Logger())
 	t.Require().NoError(err, "prepare kona-node binary")
 	t.Require().NotEmpty(execPath, "kona-node binary path resolved")
 

--- a/op-devstack/sysgo/multichain_proofs.go
+++ b/op-devstack/sysgo/multichain_proofs.go
@@ -289,6 +289,7 @@ func startInteropChallenger(
 		)
 	}
 	cfg, err := sharedchallenger.NewInteropChallengerConfig(
+		t.Ctx(),
 		t.TempDir(),
 		l1EL.UserRPC(),
 		l1CL.beaconHTTPAddr,

--- a/op-devstack/sysgo/multichain_supervisor_runtime.go
+++ b/op-devstack/sysgo/multichain_supervisor_runtime.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
 	"github.com/ethereum-optimism/optimism/op-core/devfeatures"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/shared/rustbin"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/clock"
@@ -381,7 +382,7 @@ func startKonaSupervisor(
 		require.NoError(os.WriteFile(filePath, rollupData, 0o644))
 	}
 
-	execPath, err := EnsureRustBinary(t, RustBinarySpec{
+	execPath, err := rustbin.EnsureExists(t.Ctx(), t.Logger(), rustbin.Spec{
 		SrcDir:  "rust/kona",
 		Package: "kona-supervisor",
 		Binary:  "kona-supervisor",

--- a/op-devstack/sysgo/multichain_supervisor_runtime.go
+++ b/op-devstack/sysgo/multichain_supervisor_runtime.go
@@ -382,11 +382,11 @@ func startKonaSupervisor(
 		require.NoError(os.WriteFile(filePath, rollupData, 0o644))
 	}
 
-	execPath, err := rustbin.EnsureExists(t.Ctx(), t.Logger(), rustbin.Spec{
+	execPath, err := rustbin.Spec{
 		SrcDir:  "rust/kona",
 		Package: "kona-supervisor",
 		Binary:  "kona-supervisor",
-	})
+	}.EnsureExists(t.Ctx(), t.Logger())
 	require.NoError(err, "prepare kona-supervisor binary")
 	require.NotEmpty(execPath, "kona-supervisor binary path resolved")
 

--- a/op-devstack/sysgo/op_rbuilder.go
+++ b/op-devstack/sysgo/op_rbuilder.go
@@ -409,11 +409,11 @@ func (b *OPRBuilderNode) Start() {
 
 	b.sub = NewSubProcess(b.p, stdOut, stdErr)
 
-	execPath, err := rustbin.EnsureExists(b.p.Ctx(), b.p.Logger(), rustbin.Spec{
+	execPath, err := rustbin.Spec{
 		SrcDir:  "op-rbuilder",
 		Package: "op-rbuilder",
 		Binary:  "op-rbuilder",
-	})
+	}.EnsureExists(b.p.Ctx(), b.p.Logger())
 	b.p.Require().NoError(err, "prepare op-rbuilder binary")
 	b.p.Require().NotEmpty(execPath, "op-rbuilder binary path resolved")
 

--- a/op-devstack/sysgo/op_rbuilder.go
+++ b/op-devstack/sysgo/op_rbuilder.go
@@ -15,6 +15,7 @@ import (
 	yaml "gopkg.in/yaml.v3"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/shared/rustbin"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -408,7 +409,7 @@ func (b *OPRBuilderNode) Start() {
 
 	b.sub = NewSubProcess(b.p, stdOut, stdErr)
 
-	execPath, err := EnsureRustBinary(b.p, RustBinarySpec{
+	execPath, err := rustbin.EnsureExists(b.p.Ctx(), b.p.Logger(), rustbin.Spec{
 		SrcDir:  "op-rbuilder",
 		Package: "op-rbuilder",
 		Binary:  "op-rbuilder",

--- a/op-devstack/sysgo/rollup_boost.go
+++ b/op-devstack/sysgo/rollup_boost.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/shared/rustbin"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/logpipe"
@@ -104,7 +105,7 @@ func (r *RollupBoostNode) Start() {
 
 	r.sub = NewSubProcess(r.p, stdOut, stdErr)
 
-	execPath, err := EnsureRustBinary(r.p, RustBinarySpec{
+	execPath, err := rustbin.EnsureExists(r.p.Ctx(), r.p.Logger(), rustbin.Spec{
 		SrcDir:  "rollup-boost",
 		Package: "rollup-boost",
 		Binary:  "rollup-boost",

--- a/op-devstack/sysgo/rollup_boost.go
+++ b/op-devstack/sysgo/rollup_boost.go
@@ -105,11 +105,11 @@ func (r *RollupBoostNode) Start() {
 
 	r.sub = NewSubProcess(r.p, stdOut, stdErr)
 
-	execPath, err := rustbin.EnsureExists(r.p.Ctx(), r.p.Logger(), rustbin.Spec{
+	execPath, err := rustbin.Spec{
 		SrcDir:  "rollup-boost",
 		Package: "rollup-boost",
 		Binary:  "rollup-boost",
-	})
+	}.EnsureExists(r.p.Ctx(), r.p.Logger())
 	r.p.Require().NoError(err, "prepare rollup-boost binary")
 	r.p.Require().NotEmpty(execPath, "rollup-boost binary path resolved")
 

--- a/op-devstack/sysgo/singlechain_runtime.go
+++ b/op-devstack/sysgo/singlechain_runtime.go
@@ -348,6 +348,7 @@ func startMinimalChallenger(
 		)
 	}
 	cfg, err := sharedchallenger.NewPreInteropChallengerConfig(
+		t.Ctx(),
 		t.TempDir(),
 		l1EL.UserRPC(),
 		l1CL.beaconHTTPAddr,

--- a/op-e2e/e2eutils/challenger/helper.go
+++ b/op-e2e/e2eutils/challenger/helper.go
@@ -129,7 +129,7 @@ type MinimalT interface {
 
 func handleOptError(t *testing.T, opt shared.Option) Option {
 	return func(c *config.Config) {
-		require.NoError(t, opt(c))
+		require.NoError(t, opt(t.Context(), c))
 	}
 }
 func WithCannon(t *testing.T, system System) Option {


### PR DESCRIPTION
The shared/challenger package hardcoded kona-host to rust/target/release/kona-host, bypassing the JIT build, env var overrides, and debug/release discovery that other Rust binaries already had via EnsureRustBinary in sysgo.

Move the rust binary resolution logic from sysgo into shared/rustbin so it can be used by shared/challenger directly. Decouple from devtest.CommonT by accepting context.Context and log.Logger (nil-safe) instead. Update shared/challenger to resolve kona-host through rustbin.EnsureExists, giving it the same RUST_JIT_BUILD, RUST_BINARY_PATH_KONA_HOST, and multi-profile search support that op-reth, kona-node, and other Rust binaries already have.