### PR TITLE
feat(op-reth): activate EIP-7823 modexp upper bounds on Karst fork

### DIFF
--- a/op-acceptance-tests/tests/osaka_on_l2_test.go
+++ b/op-acceptance-tests/tests/osaka_on_l2_test.go
@@ -1,0 +1,74 @@
+package tests
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-core/forks"
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+var modexpPrecompile = common.HexToAddress("0x0000000000000000000000000000000000000005")
+
+// buildModExpInput constructs input data for the MODEXP precompile (address 0x05).
+// Format: <Bsize (32 bytes)> <Esize (32 bytes)> <Msize (32 bytes)> <B> <E> <M>
+func buildModExpInput(base, exp, mod []byte) []byte {
+	input := make([]byte, 0, 96+len(base)+len(exp)+len(mod))
+	input = append(input, common.LeftPadBytes(new(big.Int).SetInt64(int64(len(base))).Bytes(), 32)...)
+	input = append(input, common.LeftPadBytes(new(big.Int).SetInt64(int64(len(exp))).Bytes(), 32)...)
+	input = append(input, common.LeftPadBytes(new(big.Int).SetInt64(int64(len(mod))).Bytes(), 32)...)
+	input = append(input, base...)
+	input = append(input, exp...)
+	input = append(input, mod...)
+	return input
+}
+
+func TestEIP7823UpperBoundModExp(gt *testing.T) {
+	t := devtest.ParallelT(gt)
+	sysgo.SkipOnOpGeth(t, "osaka is not supported in op-geth")
+
+	karstOffset := uint64(3)
+	sys := presets.NewMinimal(t, presets.WithDeployerOptions(sysgo.WithKarstAtOffset(&karstOffset)))
+
+	activationBlock := sys.L2Chain.AwaitActivation(t, forks.Karst)
+	t.Require().Greater(activationBlock.Number, uint64(0), "karst must not activate at genesis")
+	preForkBlockNum := activationBlock.Number - 1
+	postForkBlockNum := activationBlock.Number + 1
+	sys.L2EL.WaitForBlockNumber(postForkBlockNum)
+
+	l2Client := sys.L2EL.EthClient()
+
+	// Modexp input exceeding EIP-7823 limits: modulus length is 1025 bytes (limit is 1024)
+	oversizeMod := make([]byte, 1025)
+	oversizeMod[1024] = 5
+	exceedingLimitInput := buildModExpInput([]byte{2}, []byte{3}, oversizeMod)
+
+	// Pre-fork: oversized modexp input should succeed (EIP-7823 not yet active)
+	result, err := l2Client.Call(t.Ctx(), ethereum.CallMsg{
+		To:   &modexpPrecompile,
+		Data: exceedingLimitInput,
+	}, rpc.BlockNumber(preForkBlockNum))
+	t.Require().NoError(err)
+	t.Require().Len(result, 1025, "pre-fork: modexp with oversized input should return 1025-byte result")
+
+	// Post-fork: oversized modexp input should fail (EIP-7823 enforced)
+	result, err = l2Client.Call(t.Ctx(), ethereum.CallMsg{
+		To:   &modexpPrecompile,
+		Data: exceedingLimitInput,
+	}, rpc.BlockNumber(postForkBlockNum))
+	t.Require().Error(err)
+	t.Require().Empty(result, "post-fork: modexp with oversized input should return empty result due to EIP-7823")
+
+	// Post-fork: within-limit modexp input should still succeed
+	result, err = l2Client.Call(t.Ctx(), ethereum.CallMsg{
+		To:   &modexpPrecompile,
+		Data: buildModExpInput([]byte{2}, []byte{3}, []byte{5}),
+	}, rpc.BlockNumber(postForkBlockNum))
+	t.Require().NoError(err)
+	t.Require().Equal([]byte{3}, result, "2^3 mod 5 should equal 3")
+}

--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -1175,6 +1175,7 @@ func (d *DeployConfig) RollupConfig(l1StartBlock *eth.BlockRef, l2GenesisBlockHa
 		PectraBlobScheduleTime:  d.PectraBlobScheduleTime(l1StartTime),
 		IsthmusTime:             d.IsthmusTime(l1StartTime),
 		JovianTime:              d.JovianTime(l1StartTime),
+		KarstTime:               d.KarstTime(l1StartTime),
 		InteropTime:             d.InteropTime(l1StartTime),
 		ProtocolVersionsAddress: d.ProtocolVersionsProxy,
 		AltDAConfig:             altDA,

--- a/op-devstack/sysgo/deployer.go
+++ b/op-devstack/sysgo/deployer.go
@@ -60,6 +60,14 @@ func WithDefaultBPOBlobSchedule(_ devtest.T, _ devkeys.Keys, builder intentbuild
 	})
 }
 
+func WithKarstAtOffset(offset *uint64) DeployerOption {
+	return func(p devtest.T, _ devkeys.Keys, builder intentbuilder.Builder) {
+		for _, l2Cfg := range builder.L2s() {
+			l2Cfg.WithForkAtOffset(opforks.Karst, offset)
+		}
+	}
+}
+
 func WithJovianAtGenesis(p devtest.T, _ devkeys.Keys, builder intentbuilder.Builder) {
 	for _, l2Cfg := range builder.L2s() {
 		l2Cfg.WithForkAtGenesis(opforks.Jovian)

--- a/op-devstack/sysgo/mixed_runtime.go
+++ b/op-devstack/sysgo/mixed_runtime.go
@@ -55,6 +55,13 @@ const (
 	MixedL2CLKona   MixedL2CLKind = "kona-node"
 )
 
+// SkipOnOpGeth skips the test when the L2 execution layer is op-geth
+func SkipOnOpGeth(t devtest.T, reason string) {
+	if devstackL2ELKind() == MixedL2ELOpGeth {
+		t.Skipf("skipping on op-geth: %s", reason)
+	}
+}
+
 // SkipOnOpReth skips the test when the L2 execution layer is op-reth
 func SkipOnOpReth(t devtest.T, reason string) {
 	if devstackL2ELKind() == MixedL2ELOpReth {

--- a/op-service/txmgr/txmgr.go
+++ b/op-service/txmgr/txmgr.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto/kzg4844"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/holiman/uint256"
 
@@ -489,6 +490,7 @@ func (m *SimpleTxManager) estimateOrValidateCandidateTxGas(ctx context.Context, 
 	}
 	// If the gas limit is set, we can use that as the gas
 	if candidate.GasLimit == 0 {
+		callMsg.Gas = params.MaxTxGas
 		gas, err := m.backend.EstimateGas(ctx, callMsg)
 		if err != nil {
 			return 0, fmt.Errorf("failed to estimate gas: %w", errutil.TryAddRevertReason(err))

--- a/op-service/txplan/txplan.go
+++ b/op-service/txplan/txplan.go
@@ -225,7 +225,7 @@ func WithEstimator(cl Estimator, invalidateOnNewBlock bool) Option {
 			msg := ethereum.CallMsg{
 				From:       tx.Sender.Value(),
 				To:         tx.To.Value(),
-				Gas:        0, // infinite gas, will be estimated
+				Gas:        params.MaxTxGas, // max gas, will be estimated
 				GasPrice:   nil,
 				GasFeeCap:  tx.GasFeeCap.Value(),
 				GasTipCap:  tx.GasTipCap.Value(),

--- a/rust/alloy-op-evm/src/env.rs
+++ b/rust/alloy-op-evm/src/env.rs
@@ -36,6 +36,7 @@ pub fn spec_by_timestamp_after_bedrock(chain_spec: impl OpHardforks, timestamp: 
     }
     check_forks! {
         is_interop_active_at_timestamp => INTEROP,
+        is_karst_active_at_timestamp => KARST,
         is_jovian_active_at_timestamp => JOVIAN,
         is_isthmus_active_at_timestamp => ISTHMUS,
         is_holocene_active_at_timestamp => HOLOCENE,
@@ -204,6 +205,7 @@ mod tests {
     fake_hardfork_constructors! {
         timestamp:
             interop => Interop,
+            karst => Karst,
             jovian => Jovian,
             isthmus => Isthmus,
             holocene => Holocene,
@@ -229,6 +231,7 @@ mod tests {
     }
 
     #[test_case::test_case(FakeHardfork::interop(), OpSpecId::INTEROP; "Interop")]
+    #[test_case::test_case(FakeHardfork::karst(), OpSpecId::KARST; "Karst")]
     #[test_case::test_case(FakeHardfork::jovian(), OpSpecId::JOVIAN; "Jovian")]
     #[test_case::test_case(FakeHardfork::isthmus(), OpSpecId::ISTHMUS; "Isthmus")]
     #[test_case::test_case(FakeHardfork::holocene(), OpSpecId::HOLOCENE; "Holocene")]

--- a/rust/alloy-op-hardforks/src/lib.rs
+++ b/rust/alloy-op-hardforks/src/lib.rs
@@ -166,22 +166,6 @@ impl OpHardfork {
         ]
     }
 
-    /// Devnet list of hardforks.
-    pub const fn devnet() -> [(Self, ForkCondition); 10] {
-        [
-            (Self::Bedrock, ForkCondition::ZERO_BLOCK),
-            (Self::Regolith, ForkCondition::ZERO_TIMESTAMP),
-            (Self::Canyon, ForkCondition::ZERO_TIMESTAMP),
-            (Self::Ecotone, ForkCondition::ZERO_TIMESTAMP),
-            (Self::Fjord, ForkCondition::ZERO_TIMESTAMP),
-            (Self::Granite, ForkCondition::ZERO_TIMESTAMP),
-            (Self::Holocene, ForkCondition::ZERO_TIMESTAMP),
-            (Self::Isthmus, ForkCondition::ZERO_TIMESTAMP),
-            (Self::Jovian, ForkCondition::Timestamp(1762185600)),
-            (Self::Karst, ForkCondition::Never),
-        ]
-    }
-
     /// Returns index of `self` in sorted canonical array.
     pub const fn idx(&self) -> usize {
         *self as usize
@@ -304,11 +288,6 @@ impl OpChainHardforks {
         Self::new(OpHardfork::base_sepolia())
     }
 
-    /// Creates a new [`OpChainHardforks`] with devnet configuration.
-    pub fn devnet() -> Self {
-        Self::new(OpHardfork::devnet())
-    }
-
     /// Returns `true` if this is an OP mainnet instance.
     pub fn is_op_mainnet(&self) -> bool {
         self[OpHardfork::Bedrock] == ForkCondition::Block(OP_MAINNET_BEDROCK_BLOCK)
@@ -386,8 +365,8 @@ impl Index<EthereumHardfork> for OpChainHardforks {
             // Dao Hardfork is not needed for OpChainHardforks
             Dao | Bpo1 | Bpo2 | Bpo3 | Bpo4 | Bpo5 | Amsterdam => &ForkCondition::Never,
             Berlin if self.is_op_mainnet() => &ForkCondition::Block(OP_MAINNET_BERLIN_BLOCK),
-            Frontier | Homestead | Tangerine | SpuriousDragon | Byzantium | Constantinople |
-            Petersburg | Istanbul | MuirGlacier | Berlin => &ForkCondition::ZERO_BLOCK,
+            Frontier | Homestead | Tangerine | SpuriousDragon | Byzantium | Constantinople
+            | Petersburg | Istanbul | MuirGlacier | Berlin => &ForkCondition::ZERO_BLOCK,
             London | ArrowGlacier | GrayGlacier => &self[Bedrock],
             Paris if self.is_op_mainnet() => &ForkCondition::TTD {
                 activation_block_number: OP_MAINNET_BEDROCK_BLOCK,

--- a/rust/alloy-op-hardforks/src/lib.rs
+++ b/rust/alloy-op-hardforks/src/lib.rs
@@ -167,7 +167,7 @@ impl OpHardfork {
     }
 
     /// Devnet list of hardforks.
-    pub const fn devnet() -> [(Self, ForkCondition); 9] {
+    pub const fn devnet() -> [(Self, ForkCondition); 10] {
         [
             (Self::Bedrock, ForkCondition::ZERO_BLOCK),
             (Self::Regolith, ForkCondition::ZERO_TIMESTAMP),
@@ -178,6 +178,7 @@ impl OpHardfork {
             (Self::Holocene, ForkCondition::ZERO_TIMESTAMP),
             (Self::Isthmus, ForkCondition::ZERO_TIMESTAMP),
             (Self::Jovian, ForkCondition::Timestamp(1762185600)),
+            (Self::Karst, ForkCondition::Never),
         ]
     }
 
@@ -316,8 +317,8 @@ impl OpChainHardforks {
 
 impl EthereumHardforks for OpChainHardforks {
     fn ethereum_fork_activation(&self, fork: EthereumHardfork) -> ForkCondition {
-        use EthereumHardfork::{Cancun, Prague, Shanghai};
-        use OpHardfork::{Canyon, Ecotone, Isthmus};
+        use EthereumHardfork::{Cancun, Osaka, Prague, Shanghai};
+        use OpHardfork::{Canyon, Ecotone, Isthmus, Karst};
 
         if self.forks.is_empty() {
             return ForkCondition::Never;
@@ -329,6 +330,7 @@ impl EthereumHardforks for OpChainHardforks {
             Shanghai if forks_len <= Canyon.idx() => ForkCondition::Never,
             Cancun if forks_len <= Ecotone.idx() => ForkCondition::Never,
             Prague if forks_len <= Isthmus.idx() => ForkCondition::Never,
+            Osaka if forks_len <= Karst.idx() => ForkCondition::Never,
             _ => self[fork],
         }
     }
@@ -378,11 +380,11 @@ impl Index<EthereumHardfork> for OpChainHardforks {
             Constantinople, Dao, Frontier, GrayGlacier, Homestead, Istanbul, London, MuirGlacier,
             Osaka, Paris, Petersburg, Prague, Shanghai, SpuriousDragon, Tangerine,
         };
-        use OpHardfork::{Bedrock, Canyon, Ecotone, Isthmus};
+        use OpHardfork::{Bedrock, Canyon, Ecotone, Isthmus, Karst};
 
         match hf {
             // Dao Hardfork is not needed for OpChainHardforks
-            Dao | Osaka | Bpo1 | Bpo2 | Bpo3 | Bpo4 | Bpo5 | Amsterdam => &ForkCondition::Never,
+            Dao | Bpo1 | Bpo2 | Bpo3 | Bpo4 | Bpo5 | Amsterdam => &ForkCondition::Never,
             Berlin if self.is_op_mainnet() => &ForkCondition::Block(OP_MAINNET_BERLIN_BLOCK),
             Frontier | Homestead | Tangerine | SpuriousDragon | Byzantium | Constantinople |
             Petersburg | Istanbul | MuirGlacier | Berlin => &ForkCondition::ZERO_BLOCK,
@@ -400,6 +402,7 @@ impl Index<EthereumHardfork> for OpChainHardforks {
             Shanghai => &self[Canyon],
             Cancun => &self[Ecotone],
             Prague => &self[Isthmus],
+            Osaka => &self[Karst],
             _ => unreachable!(),
         }
     }

--- a/rust/kona/bin/client/src/fpvm_evm/precompiles/provider.rs
+++ b/rust/kona/bin/client/src/fpvm_evm/precompiles/provider.rs
@@ -8,7 +8,7 @@ use alloy_primitives::{Address, Bytes};
 use kona_preimage::{HintWriterClient, PreimageOracleClient};
 use op_revm::{
     OpSpecId,
-    precompiles::{fjord, granite, isthmus, jovian},
+    precompiles::{fjord, granite, isthmus, jovian, karst},
 };
 use revm::{
     context::{Cfg, ContextTr},
@@ -49,7 +49,8 @@ where
             OpSpecId::FJORD => fjord(),
             OpSpecId::GRANITE | OpSpecId::HOLOCENE => granite(),
             OpSpecId::ISTHMUS => isthmus(),
-            OpSpecId::JOVIAN | OpSpecId::INTEROP | OpSpecId::OSAKA => jovian(),
+            OpSpecId::JOVIAN => jovian(),
+            OpSpecId::KARST | OpSpecId::INTEROP => karst(),
         };
 
         let accelerated_precompiles = match spec {
@@ -59,7 +60,7 @@ where
             OpSpecId::ECOTONE | OpSpecId::FJORD => accelerated_ecotone::<H, O>(),
             OpSpecId::GRANITE | OpSpecId::HOLOCENE => accelerated_granite::<H, O>(),
             OpSpecId::ISTHMUS => accelerated_isthmus::<H, O>(),
-            OpSpecId::JOVIAN | OpSpecId::INTEROP | OpSpecId::OSAKA => accelerated_jovian::<H, O>(),
+            OpSpecId::JOVIAN | OpSpecId::KARST | OpSpecId::INTEROP => accelerated_jovian::<H, O>(),
         };
 
         Self {
@@ -456,8 +457,8 @@ mod test {
             hint_writer.clone(),
             oracle_reader.clone(),
         );
-        let osaka_provider = OpFpvmPrecompiles::new_with_spec(
-            OpSpecId::OSAKA,
+        let karst_provider = OpFpvmPrecompiles::new_with_spec(
+            OpSpecId::KARST,
             hint_writer.clone(),
             oracle_reader.clone(),
         );
@@ -479,7 +480,7 @@ mod test {
         };
         let osaka_addrs: Vec<_> = {
             let mut addrs: Vec<_> =
-                osaka_provider.accelerated_precompiles.keys().copied().collect();
+                karst_provider.accelerated_precompiles.keys().copied().collect();
             addrs.sort();
             addrs
         };
@@ -495,16 +496,16 @@ mod test {
             "JOVIAN should use jovian() precompiles"
         );
         assert!(
-            core::ptr::eq(interop_provider.inner.precompiles, jovian()),
-            "INTEROP should use jovian() precompiles"
-        );
-        assert!(
-            core::ptr::eq(osaka_provider.inner.precompiles, jovian()),
-            "OSAKA should use jovian() precompiles"
-        );
-        assert!(
             core::ptr::eq(isthmus_provider.inner.precompiles, isthmus()),
             "ISTHMUS should use isthmus() precompiles"
+        );
+        assert!(
+            core::ptr::eq(karst_provider.inner.precompiles, karst()),
+            "KARST should use karst() precompiles"
+        );
+        assert!(
+            core::ptr::eq(interop_provider.inner.precompiles, karst()),
+            "INTEROP should use karst() precompiles"
         );
     }
 

--- a/rust/op-alloy/crates/rpc-types/src/genesis.rs
+++ b/rust/op-alloy/crates/rpc-types/src/genesis.rs
@@ -56,6 +56,8 @@ pub struct OpGenesisInfo {
     pub interop_time: Option<u64>,
     /// jovian hardfork timestamp
     pub jovian_time: Option<u64>,
+    /// karst hardfork timestamp
+    pub karst_time: Option<u64>,
 }
 
 impl OpGenesisInfo {
@@ -136,6 +138,7 @@ mod tests {
                 isthmus_time: None,
                 interop_time: None,
                 jovian_time: None,
+                karst_time: None,
             }
         );
     }
@@ -197,6 +200,7 @@ mod tests {
                     isthmus_time: None,
                     interop_time: None,
                     jovian_time: None,
+                    karst_time: None,
                 }),
                 base_fee_info: Some(OpBaseFeeInfo {
                     eip1559_elasticity: None,
@@ -222,6 +226,7 @@ mod tests {
                     isthmus_time: None,
                     interop_time: None,
                     jovian_time: None,
+                    karst_time: None,
                 }),
                 base_fee_info: Some(OpBaseFeeInfo {
                     eip1559_elasticity: None,
@@ -265,6 +270,7 @@ mod tests {
                     isthmus_time: Some(0),
                     interop_time: None,
                     jovian_time: Some(0),
+                    karst_time: None,
                 }),
                 base_fee_info: None,
             }

--- a/rust/op-reth/crates/chainspec/src/lib.rs
+++ b/rust/op-reth/crates/chainspec/src/lib.rs
@@ -200,9 +200,16 @@ impl OpChainSpecBuilder {
         self
     }
 
+    /// Enable Karst at genesis
+    pub fn karst_activated(mut self) -> Self {
+        self = self.jovian_activated();
+        self.inner = self.inner.with_fork(OpHardfork::Karst, ForkCondition::Timestamp(0));
+        self
+    }
+
     /// Enable Interop at genesis
     pub fn interop_activated(mut self) -> Self {
-        self = self.jovian_activated();
+        self = self.karst_activated();
         self.inner = self.inner.with_fork(OpHardfork::Interop, ForkCondition::Timestamp(0));
         self
     }
@@ -393,6 +400,7 @@ impl From<Genesis> for OpChainSpec {
             (OpHardfork::Holocene.boxed(), genesis_info.holocene_time),
             (OpHardfork::Isthmus.boxed(), genesis_info.isthmus_time),
             (OpHardfork::Jovian.boxed(), genesis_info.jovian_time),
+            (OpHardfork::Karst.boxed(), genesis_info.karst_time),
             (OpHardfork::Interop.boxed(), genesis_info.interop_time),
         ];
 

--- a/rust/op-reth/crates/chainspec/src/superchain/chain_metadata.rs
+++ b/rust/op-reth/crates/chainspec/src/superchain/chain_metadata.rs
@@ -207,7 +207,7 @@ mod tests {
             granite_time: Some(1726070401),
             holocene_time: Some(1736445601),
             isthmus_time: Some(1746806401),
-            jovian_time: None,
+            jovian_time: Some(1764691201),
             karst_time: None,
             optimism: Option::from(ChainConfigExtraFieldsOptimism {
                 eip1559_elasticity: 6,
@@ -225,7 +225,8 @@ mod tests {
         assert_eq!(value.get("graniteTime").unwrap(), 1726070401);
         assert_eq!(value.get("holoceneTime").unwrap(), 1736445601);
         assert_eq!(value.get("isthmusTime").unwrap(), 1746806401);
-        assert_eq!(value.get("jovianTime"), None);
+        assert_eq!(value.get("jovianTime").unwrap(), 1764691201);
+        assert_eq!(value.get("karstTime"), None);
         let optimism = value.get("optimism").unwrap();
         assert_eq!(optimism.get("eip1559Elasticity").unwrap(), 6);
         assert_eq!(optimism.get("eip1559Denominator").unwrap(), 50);

--- a/rust/op-reth/crates/chainspec/src/superchain/chain_metadata.rs
+++ b/rust/op-reth/crates/chainspec/src/superchain/chain_metadata.rs
@@ -27,6 +27,7 @@ pub(crate) struct HardforkConfig {
     pub holocene_time: Option<u64>,
     pub isthmus_time: Option<u64>,
     pub jovian_time: Option<u64>,
+    pub karst_time: Option<u64>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -60,6 +61,8 @@ pub(crate) struct ChainConfigExtraFields {
     pub isthmus_time: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub jovian_time: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub karst_time: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub optimism: Option<ChainConfigExtraFieldsOptimism>,
 }
@@ -108,7 +111,7 @@ pub(crate) fn to_genesis_chain_config(chain_config: &ChainMetadata) -> ChainConf
         shanghai_time: chain_config.hardforks.canyon_time, // Shanghai activates with Canyon
         cancun_time: chain_config.hardforks.ecotone_time,  // Cancun activates with Ecotone
         prague_time: chain_config.hardforks.isthmus_time,  // Prague activates with Isthmus
-        osaka_time: None,
+        osaka_time: chain_config.hardforks.karst_time,     // Osaka activates with Karst
         terminal_total_difficulty: Some(U256::ZERO),
         terminal_total_difficulty_passed: true,
         ethash: None,
@@ -141,6 +144,7 @@ pub(crate) fn to_genesis_chain_config(chain_config: &ChainMetadata) -> ChainConf
         holocene_time: chain_config.hardforks.holocene_time,
         isthmus_time: chain_config.hardforks.isthmus_time,
         jovian_time: chain_config.hardforks.jovian_time,
+        karst_time: chain_config.hardforks.karst_time,
         optimism: chain_config.optimism.as_ref().map(|o| o.into()),
     };
     res.extra_fields =
@@ -204,6 +208,7 @@ mod tests {
             holocene_time: Some(1736445601),
             isthmus_time: Some(1746806401),
             jovian_time: None,
+            karst_time: None,
             optimism: Option::from(ChainConfigExtraFieldsOptimism {
                 eip1559_elasticity: 6,
                 eip1559_denominator: 50,

--- a/rust/op-reth/crates/hardforks/src/lib.rs
+++ b/rust/op-reth/crates/hardforks/src/lib.rs
@@ -64,6 +64,7 @@ pub static DEV_HARDFORKS: LazyLock<ChainHardforks> = LazyLock::new(|| {
         (EthereumHardfork::Prague.boxed(), ForkCondition::Timestamp(0)),
         (OpHardfork::Isthmus.boxed(), ForkCondition::Timestamp(0)),
         (OpHardfork::Jovian.boxed(), ForkCondition::Timestamp(0)),
+        (OpHardfork::Karst.boxed(), ForkCondition::Timestamp(0)),
     ])
 });
 

--- a/rust/op-revm/src/precompiles.rs
+++ b/rust/op-revm/src/precompiles.rs
@@ -7,7 +7,7 @@ use revm::{
     interpreter::{CallInputs, InterpreterResult},
     precompile::{
         self, Precompile, PrecompileError, PrecompileId, PrecompileResult, Precompiles, bn254,
-        secp256r1,
+        modexp, secp256r1,
     },
     primitives::{Address, OnceLock, hardfork::SpecId},
 };
@@ -34,7 +34,8 @@ impl OpPrecompiles {
             OpSpecId::FJORD => fjord(),
             OpSpecId::GRANITE | OpSpecId::HOLOCENE => granite(),
             OpSpecId::ISTHMUS => isthmus(),
-            OpSpecId::INTEROP | OpSpecId::OSAKA | OpSpecId::JOVIAN => jovian(),
+            OpSpecId::JOVIAN => jovian(),
+            OpSpecId::KARST | OpSpecId::INTEROP => karst(),
         };
 
         Self { inner: EthPrecompiles { precompiles, spec: SpecId::default() }, spec }
@@ -82,6 +83,23 @@ pub fn isthmus() -> &'static Precompiles {
             bls12_381::ISTHMUS_G2_MSM,
             bls12_381::ISTHMUS_PAIRING,
         ]);
+        precompiles
+    })
+}
+
+/// Returns precompiles for karst spec.
+pub fn karst() -> &'static Precompiles {
+    static INSTANCE: OnceLock<Precompiles> = OnceLock::new();
+    INSTANCE.get_or_init(|| {
+        let mut precompiles = jovian().clone();
+
+        let mut to_remove = Precompiles::default();
+        to_remove.extend([modexp::BERLIN]);
+
+        precompiles.difference(&to_remove);
+
+        precompiles.extend([modexp::OSAKA]);
+
         precompiles
     })
 }

--- a/rust/op-revm/src/spec.rs
+++ b/rust/op-revm/src/spec.rs
@@ -1,6 +1,6 @@
 //! Contains the `[OpSpecId]` type and its implementation.
 use core::str::FromStr;
-use revm::primitives::hardfork::{SpecId, UnknownHardfork, name as eth_name};
+use revm::primitives::hardfork::{SpecId, UnknownHardfork};
 
 /// Optimism spec id.
 #[repr(u8)]
@@ -27,10 +27,10 @@ pub enum OpSpecId {
     /// Jovian spec id.
     #[default]
     JOVIAN,
+    /// Karst spec id.
+    KARST,
     /// Interop spec id.
     INTEROP,
-    /// Osaka spec id.
-    OSAKA,
 }
 
 impl OpSpecId {
@@ -41,7 +41,7 @@ impl OpSpecId {
             Self::CANYON => SpecId::SHANGHAI,
             Self::ECOTONE | Self::FJORD | Self::GRANITE | Self::HOLOCENE => SpecId::CANCUN,
             Self::ISTHMUS | Self::JOVIAN | Self::INTEROP => SpecId::PRAGUE,
-            Self::OSAKA => SpecId::OSAKA,
+            Self::KARST => SpecId::OSAKA,
         }
     }
 
@@ -71,8 +71,8 @@ impl FromStr for OpSpecId {
             name::HOLOCENE => Ok(Self::HOLOCENE),
             name::ISTHMUS => Ok(Self::ISTHMUS),
             name::JOVIAN => Ok(Self::JOVIAN),
+            name::KARST => Ok(Self::KARST),
             name::INTEROP => Ok(Self::INTEROP),
-            eth_name::OSAKA => Ok(Self::OSAKA),
             _ => Err(UnknownHardfork),
         }
     }
@@ -90,8 +90,8 @@ impl From<OpSpecId> for &'static str {
             OpSpecId::HOLOCENE => name::HOLOCENE,
             OpSpecId::ISTHMUS => name::ISTHMUS,
             OpSpecId::JOVIAN => name::JOVIAN,
+            OpSpecId::KARST => name::KARST,
             OpSpecId::INTEROP => name::INTEROP,
-            OpSpecId::OSAKA => eth_name::OSAKA,
         }
     }
 }
@@ -116,6 +116,8 @@ pub mod name {
     pub const ISTHMUS: &str = "Isthmus";
     /// Jovian spec name.
     pub const JOVIAN: &str = "Jovian";
+    /// Karst spec name.
+    pub const KARST: &str = "Karst";
     /// Interop spec name.
     pub const INTEROP: &str = "Interop";
 }


### PR DESCRIPTION
Wire up the Karst OP fork through the Rust EL stack so that EIP-7823 (modexp precompile input upper bounds of 1024 bytes) takes effect when Karst activates. Karst remains at SpecId::PRAGUE to avoid unsupported fork errors in reth v2.0.0; the modexp limit is enforced via a custom karst() precompile set that swaps modexp::BERLIN for modexp::OSAKA.

Changes:
- Add OpSpecId::KARST variant mapped to SpecId::PRAGUE
- Add karst() precompile set with modexp::OSAKA (EIP-7823 limits)
- Add karst_time to OpGenesisInfo, HardforkConfig, ChainConfigExtraFields
- Wire is_karst_active_at_timestamp into spec_by_timestamp_after_bedrock
- Register OpHardfork::Karst in chainspec From<Genesis>, DEV_HARDFORKS, devnet config, and OpChainSpecBuilder
- Add KarstTime to Go RollupConfig() output (was missing)
- Add acceptance test TestEIP7823UpperBoundModExp verifying pre/post fork behavior

Stacked on #20067 

---
For reference https://github.com/ethereum-optimism/design-docs/blob/main/protocol/fusaka-on-l2.md 