### PR TITLE
test(op-acceptance-tests): add EIP-7934 block size limit disabled test

### DIFF
--- a/op-acceptance-tests/tests/osaka_on_l2_test.go
+++ b/op-acceptance-tests/tests/osaka_on_l2_test.go
@@ -1,10 +1,15 @@
 package tests
 
 import (
+	"context"
 	"math/big"
+	"sync"
 	"testing"
+	"time"
 
+	"github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/interop/loadtest"
 	"github.com/ethereum-optimism/optimism/op-core/forks"
+	"github.com/ethereum-optimism/optimism/op-core/predeploys"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
@@ -257,4 +262,78 @@ func TestEIP7939CLZ(gt *testing.T) {
 	t.Require().NoError(err, "post-fork: CLZ opcode should be available")
 	expected := common.LeftPadBytes([]byte{0xff}, 32) // 255 as uint256
 	t.Require().Equal(expected, result, "CLZ(1) should equal 255")
+}
+
+// TestEIP7934BlockSizeLimitDisabled proves that EIP-7934 is disabled by building a single block
+// whose transaction data alone exceeds the max block size.
+func TestEIP7934BlockSizeLimitDisabled(gt *testing.T) {
+	t := devtest.ParallelT(gt)
+	sysgo.SkipOnOpGeth(t, "osaka is not supported in op-geth")
+
+	// EIP-7623 inflates zero-byte calldata cost to 10 gas/byte, so packing
+	// 12 MB into one block requires ~120M gas.
+	sys := presets.NewMinimal(t, presets.WithDeployerOptions(
+		sysgo.WithKarstAtGenesis,
+		sysgo.WithL2GasLimit(120_000_000),
+	))
+
+	spamTxs(sys)
+
+	// Find a block whose total transaction data exceeds 10 MiB.
+	l2Client := sys.L2EL.EthClient()
+	l2BlockTime := time.Duration(sys.L2Chain.Escape().RollupConfig().BlockTime) * time.Second
+	for {
+		select {
+		case <-time.After(l2BlockTime):
+			info, blockTxs, err := l2Client.InfoAndTxsByLabel(t.Ctx(), eth.Unsafe)
+			t.Require().NoError(err)
+
+			var totalTxSize int
+			for _, tx := range blockTxs {
+				bin, err := tx.MarshalBinary()
+				t.Require().NoError(err)
+				totalTxSize += len(bin)
+			}
+
+			t.Logger().Info("Checking L2 block...", "number", info.NumberU64(), "size", totalTxSize, "gasUsed", info.GasUsed())
+
+			// We use tx data size instead of the total block size since we don't have a client
+			// capable of deserializing block responses.
+			if totalTxSize > params.MaxBlockSize {
+				return
+			}
+		case <-t.Ctx().Done():
+			t.Require().NoError(t.Ctx().Err())
+		}
+	}
+}
+
+func spamTxs(sys *presets.Minimal) {
+	l2BlockTime := time.Duration(sys.L2Chain.Escape().RollupConfig().BlockTime) * time.Second
+	eoas := loadtest.FundEOAs(sys.T, eth.HundredEther, 50, l2BlockTime, sys.L2EL, sys.Wallet, sys.FaucetL2)
+	eoasRR := loadtest.NewRoundRobin(eoas)
+	spammer := loadtest.SpammerFunc(func(t devtest.T) error {
+		// Max tx size in op-geth and op-reth mempools is 128 kB per tx.
+		// We leave an 8 kB buffer for tx data outside the calldata.
+		const calldataSize = 120 * 1024
+		_, err := eoasRR.Get().Include(t,
+			txplan.WithTo(&predeploys.L1BlockAddr),
+			txplan.WithData(make([]byte, calldataSize)),
+			txplan.WithGasLimit(1_250_000),
+		)
+		return err
+	})
+	schedule := loadtest.NewBurst(l2BlockTime, loadtest.WithBaseRPS(50))
+
+	ctx, cancel := context.WithCancel(sys.T.Ctx())
+	var wg sync.WaitGroup
+	wg.Add(1)
+	sys.T.Cleanup(func() {
+		cancel()
+		wg.Wait()
+	})
+	go func() {
+		defer wg.Done()
+		schedule.Run(sys.T.WithCtx(ctx), spammer)
+	}()
 }

--- a/op-devstack/sysgo/deployer.go
+++ b/op-devstack/sysgo/deployer.go
@@ -80,6 +80,14 @@ func WithJovianAtGenesis(p devtest.T, _ devkeys.Keys, builder intentbuilder.Buil
 	}
 }
 
+func WithL2GasLimit(gasLimit uint64) DeployerOption {
+	return func(_ devtest.T, _ devkeys.Keys, builder intentbuilder.Builder) {
+		for _, l2Cfg := range builder.L2s() {
+			l2Cfg.WithGasLimit(gasLimit)
+		}
+	}
+}
+
 func WithEcotoneAtGenesis(p devtest.T, _ devkeys.Keys, builder intentbuilder.Builder) {
 	for _, l2Cfg := range builder.L2s() {
 		l2Cfg.WithForkAtGenesis(opforks.Ecotone)

--- a/op-e2e/e2eutils/intentbuilder/builder.go
+++ b/op-e2e/e2eutils/intentbuilder/builder.go
@@ -62,6 +62,7 @@ type L2Configurator interface {
 	L2HardforkConfigurator
 	WithPrefundedAccount(addr common.Address, amount uint256.Int) L2Configurator
 	WithDAFootprintGasScalar(scalar uint16)
+	WithGasLimit(v uint64)
 }
 
 type ContractsConfigurator interface {
@@ -543,6 +544,10 @@ func (c *l2Configurator) initL2DevGenesisParams() *state.L2DevGenesisParams {
 func (c *l2Configurator) WithPrefundedAccount(addr common.Address, amount uint256.Int) L2Configurator {
 	c.initL2DevGenesisParams().Prefund[addr] = (*hexutil.U256)(&amount)
 	return c
+}
+
+func (c *l2Configurator) WithGasLimit(v uint64) {
+	c.builder.intent.Chains[c.chainIndex].GasLimit = v
 }
 
 func (c *l2Configurator) WithAdditionalDisputeGames(games []state.AdditionalDisputeGame) {


### PR DESCRIPTION
Assert that OP Stack chains can build blocks exceeding the EIP-7934 10 MiB RLP block size limit. Submits many transactions with large calldata under a 200M gas limit and verifies a single block exceeds 10 MiB in total transaction data.

Also adds WithGasLimit to L2Configurator and WithL2GasLimit deployer option to support custom L2 block gas limits in tests.

Stacked on #20068

---
For reference https://github.com/ethereum-optimism/design-docs/blob/main/protocol/fusaka-on-l2.md 