### PR TITLE
feat(op-acceptance-tests): add EIP-7825 tx gas limit cap test

### DIFF
--- a/op-acceptance-tests/tests/osaka_on_l2_test.go
+++ b/op-acceptance-tests/tests/osaka_on_l2_test.go
@@ -8,9 +8,12 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/txplan"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
@@ -116,6 +119,57 @@ func TestEIP7883ModExpGasCostIncrease(gt *testing.T) {
 		Gas: 21_600,
 	}, rpc.BlockNumber(postForkBlockNum))
 	t.Require().NoError(err, "post-fork: modexp should succeed with 600 execution gas (floor is 500)")
+}
+
+func TestEIP7825TxGasLimitCap(gt *testing.T) {
+	t := devtest.ParallelT(gt)
+	sysgo.SkipOnOpGeth(t, "osaka is not supported in op-geth")
+
+	testCases := map[string]struct {
+		opt       sysgo.DeployerOption
+		expectErr bool
+	}{
+		"pre-karst": {
+			opt: sysgo.WithJovianAtGenesis,
+		},
+		"post-karst": {
+			opt:       sysgo.WithKarstAtGenesis,
+			expectErr: true,
+		},
+	}
+
+	// EIP-7825 caps transaction gas at 2^24 = 16,777,216.
+	// This is a tx validity rule enforced at the txpool/block level, not by the
+	// EVM, so eth_call and eth_simulateV1 don't enforce it. We must send a real
+	// transaction and verify the RPC rejects it.
+	for name, testCase := range testCases {
+		t.Run(name, func(t devtest.T) {
+			t.Parallel()
+			sys := presets.NewMinimal(t, presets.WithDeployerOptions(testCase.opt))
+
+			eoa := sys.FunderL2.NewFundedEOA(eth.OneEther)
+
+			planWithGasLimit := func(gas uint64) txplan.Option {
+				return txplan.Combine(
+					eoa.Plan(),
+					txplan.WithGasLimit(gas),
+					txplan.WithTo(&common.Address{}),
+				)
+			}
+
+			_, err := txplan.NewPlannedTx(planWithGasLimit(params.MaxTxGas)).Success.Eval(t.Ctx())
+			t.Require().NoError(err, "tx with gas at 2^24 should succeed")
+
+			tx := txplan.NewPlannedTx(planWithGasLimit(params.MaxTxGas + 1))
+			if testCase.expectErr {
+				_, err := tx.Included.Eval(t.Ctx())
+				t.Require().Error(err, "tx with gas above 2^24 should be rejected")
+			} else {
+				_, err := tx.Success.Eval(t.Ctx())
+				t.Require().NoError(err, "tx with gas above 2^24 should succeed")
+			}
+		})
+	}
 }
 
 func TestEIP7939CLZ(gt *testing.T) {

--- a/op-devstack/sysgo/deployer.go
+++ b/op-devstack/sysgo/deployer.go
@@ -68,6 +68,12 @@ func WithKarstAtOffset(offset *uint64) DeployerOption {
 	}
 }
 
+func WithKarstAtGenesis(p devtest.T, _ devkeys.Keys, builder intentbuilder.Builder) {
+	for _, l2Cfg := range builder.L2s() {
+		l2Cfg.WithForkAtGenesis(opforks.Karst)
+	}
+}
+
 func WithJovianAtGenesis(p devtest.T, _ devkeys.Keys, builder intentbuilder.Builder) {
 	for _, l2Cfg := range builder.L2s() {
 		l2Cfg.WithForkAtGenesis(opforks.Jovian)


### PR DESCRIPTION
Add TestEIP7825TxGasLimitCap to verify the 2^24 transaction gas limit cap is enforced after Karst. Uses txplan to send real transactions since EIP-7825 is a tx validity rule not enforced by eth_call or eth_simulateV1. Tests both pre-karst (gas above cap allowed) and post-karst (gas above cap rejected, gas at cap succeeds).

Also adds WithKarstAtGenesis deployer option and fixes the tx manager gas estimator to set callMsg.Gas to params.MaxTxGas before calling EstimateGas, which is required post-Osaka.

Stacked on #20069

---
For reference https://github.com/ethereum-optimism/design-docs/blob/main/protocol/fusaka-on-l2.md 