### PR TITLE
Improve EIP-7934 test to measure actual RLP block size

### DIFF
--- a/op-acceptance-tests/tests/osaka_on_l2_test.go
+++ b/op-acceptance-tests/tests/osaka_on_l2_test.go
@@ -8,9 +8,12 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/txplan"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
@@ -116,6 +119,57 @@ func TestEIP7883ModExpGasCostIncrease(gt *testing.T) {
 		Gas: 21_600,
 	}, rpc.BlockNumber(postForkBlockNum))
 	t.Require().NoError(err, "post-fork: modexp should succeed with 600 execution gas (floor is 500)")
+}
+
+func TestEIP7825TxGasLimitCap(gt *testing.T) {
+	t := devtest.ParallelT(gt)
+	sysgo.SkipOnOpGeth(t, "osaka is not supported in op-geth")
+
+	testCases := map[string]struct {
+		opt       sysgo.DeployerOption
+		expectErr bool
+	}{
+		"pre-karst": {
+			opt: sysgo.WithJovianAtGenesis,
+		},
+		"post-karst": {
+			opt:       sysgo.WithKarstAtGenesis,
+			expectErr: true,
+		},
+	}
+
+	// EIP-7825 caps transaction gas at 2^24 = 16,777,216.
+	// This is a tx validity rule enforced at the txpool/block level, not by the
+	// EVM, so eth_call and eth_simulateV1 don't enforce it. We must send a real
+	// transaction and verify the RPC rejects it.
+	for name, testCase := range testCases {
+		t.Run(name, func(t devtest.T) {
+			t.Parallel()
+			sys := presets.NewMinimal(t, presets.WithDeployerOptions(testCase.opt))
+
+			eoa := sys.FunderL2.NewFundedEOA(eth.OneEther)
+
+			planWithGasLimit := func(gas uint64) txplan.Option {
+				return txplan.Combine(
+					eoa.Plan(),
+					txplan.WithGasLimit(gas),
+					txplan.WithTo(&common.Address{}),
+				)
+			}
+
+			_, err := txplan.NewPlannedTx(planWithGasLimit(params.MaxTxGas)).Success.Eval(t.Ctx())
+			t.Require().NoError(err, "tx with gas at 2^24 should succeed")
+
+			tx := txplan.NewPlannedTx(planWithGasLimit(params.MaxTxGas + 1))
+			if testCase.expectErr {
+				_, err := tx.Included.Eval(t.Ctx())
+				t.Require().Error(err, "tx with gas above 2^24 should be rejected")
+			} else {
+				_, err := tx.Success.Eval(t.Ctx())
+				t.Require().NoError(err, "tx with gas above 2^24 should succeed")
+			}
+		})
+	}
 }
 
 func TestEIP7939CLZ(gt *testing.T) {

--- a/op-acceptance-tests/tests/osaka_on_l2_test.go
+++ b/op-acceptance-tests/tests/osaka_on_l2_test.go
@@ -18,6 +18,7 @@ import (
 )
 
 var modexpPrecompile = common.HexToAddress("0x0000000000000000000000000000000000000005")
+var p256VerifyPrecompile = common.HexToAddress("0x0000000000000000000000000000000000000100")
 
 // buildModExpInput constructs input data for the MODEXP precompile (address 0x05).
 // Format: <Bsize (32 bytes)> <Esize (32 bytes)> <Msize (32 bytes)> <B> <E> <M>
@@ -170,6 +171,50 @@ func TestEIP7825TxGasLimitCap(gt *testing.T) {
 			}
 		})
 	}
+}
+
+func TestEIP7951P256VerifyGasCostIncrease(gt *testing.T) {
+	t := devtest.ParallelT(gt)
+	sysgo.SkipOnOpGeth(t, "osaka is not supported in op-geth")
+
+	karstOffset := uint64(3)
+	sys := presets.NewMinimal(t, presets.WithDeployerOptions(sysgo.WithKarstAtOffset(&karstOffset)))
+
+	activationBlock := sys.L2Chain.AwaitActivation(t, forks.Karst)
+	t.Require().Greater(activationBlock.Number, uint64(0), "karst must not activate at genesis")
+	preForkBlockNum := activationBlock.Number - 1
+	postForkBlockNum := activationBlock.Number + 1
+	sys.L2EL.WaitForBlockNumber(postForkBlockNum)
+
+	l2Client := sys.L2EL.EthClient()
+
+	// Call P256VERIFY with empty calldata. The precompile charges its full gas
+	// cost regardless of input length, then returns empty (input != 160 bytes).
+	// Empty calldata avoids EIP-7623 calldata cost inflation, so intrinsic gas
+	// is just 21,000 and we can precisely control execution gas via gas limit.
+	//   RIP-7212 (pre-Karst):  P256VERIFY costs 3,450 gas
+	//   EIP-7951 (post-Karst): P256VERIFY costs 6,900 gas
+
+	// Pre-fork: 21,000 + 3,500 execution gas is enough for 3,450-gas precompile.
+	_, err := l2Client.Call(t.Ctx(), ethereum.CallMsg{
+		To:  &p256VerifyPrecompile,
+		Gas: 24_500,
+	}, rpc.BlockNumber(preForkBlockNum))
+	t.Require().NoError(err, "pre-fork: P256VERIFY should succeed with 3,500 execution gas (cost is 3,450)")
+
+	// Post-fork: 21,000 + 3,500 execution gas is NOT enough for 6,900-gas precompile.
+	_, err = l2Client.Call(t.Ctx(), ethereum.CallMsg{
+		To:  &p256VerifyPrecompile,
+		Gas: 24_500,
+	}, rpc.BlockNumber(postForkBlockNum))
+	t.Require().Error(err, "post-fork: P256VERIFY should fail with 3,500 execution gas (cost is 6,900)")
+
+	// Post-fork: 21,000 + 7,000 execution gas is enough for 6,900-gas precompile.
+	_, err = l2Client.Call(t.Ctx(), ethereum.CallMsg{
+		To:  &p256VerifyPrecompile,
+		Gas: 28_000,
+	}, rpc.BlockNumber(postForkBlockNum))
+	t.Require().NoError(err, "post-fork: P256VERIFY should succeed with 7,000 execution gas (cost is 6,900)")
 }
 
 func TestEIP7939CLZ(gt *testing.T) {

--- a/op-acceptance-tests/tests/osaka_on_l2_test.go
+++ b/op-acceptance-tests/tests/osaka_on_l2_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
@@ -71,4 +72,46 @@ func TestEIP7823UpperBoundModExp(gt *testing.T) {
 	}, rpc.BlockNumber(postForkBlockNum))
 	t.Require().NoError(err)
 	t.Require().Equal([]byte{3}, result, "2^3 mod 5 should equal 3")
+}
+
+func TestEIP7939CLZ(gt *testing.T) {
+	t := devtest.ParallelT(gt)
+	sysgo.SkipOnOpGeth(t, "osaka is not supported in op-geth")
+
+	karstOffset := uint64(3)
+	sys := presets.NewMinimal(t, presets.WithDeployerOptions(sysgo.WithKarstAtOffset(&karstOffset)))
+
+	activationBlock := sys.L2Chain.AwaitActivation(t, forks.Karst)
+	t.Require().Greater(activationBlock.Number, uint64(0), "karst must not activate at genesis")
+	preForkBlockNum := activationBlock.Number - 1
+	postForkBlockNum := activationBlock.Number + 1
+	sys.L2EL.WaitForBlockNumber(postForkBlockNum)
+
+	l2Client := sys.L2EL.EthClient()
+
+	// EVM init code that computes CLZ(1) and returns the 32-byte result.
+	// CLZ(1) = 255 because 1 has 255 leading zero bits in a uint256.
+	clzCode := []byte{
+		byte(vm.PUSH1), 1, // stack: [1]
+		byte(vm.CLZ),      // stack: [255] (1 has 255 leading zeros)
+		byte(vm.PUSH1), 0, // stack: [0, 255]
+		byte(vm.MSTORE),    // mem[0:32] = 255
+		byte(vm.PUSH1), 32, // stack: [32]
+		byte(vm.PUSH1), 0, // stack: [0, 32]
+		byte(vm.RETURN), // return mem[0:32]
+	}
+
+	// Pre-fork: CLZ opcode (0x1e) is not yet valid, so execution should fail.
+	_, err := l2Client.Call(t.Ctx(), ethereum.CallMsg{
+		Data: clzCode,
+	}, rpc.BlockNumber(preForkBlockNum))
+	t.Require().Error(err, "pre-fork: CLZ opcode should not be available")
+
+	// Post-fork: CLZ opcode is valid, execution should succeed.
+	result, err := l2Client.Call(t.Ctx(), ethereum.CallMsg{
+		Data: clzCode,
+	}, rpc.BlockNumber(postForkBlockNum))
+	t.Require().NoError(err, "post-fork: CLZ opcode should be available")
+	expected := common.LeftPadBytes([]byte{0xff}, 32) // 255 as uint256
+	t.Require().Equal(expected, result, "CLZ(1) should equal 255")
 }

--- a/op-acceptance-tests/tests/osaka_on_l2_test.go
+++ b/op-acceptance-tests/tests/osaka_on_l2_test.go
@@ -74,6 +74,50 @@ func TestEIP7823UpperBoundModExp(gt *testing.T) {
 	t.Require().Equal([]byte{3}, result, "2^3 mod 5 should equal 3")
 }
 
+func TestEIP7883ModExpGasCostIncrease(gt *testing.T) {
+	t := devtest.ParallelT(gt)
+	sysgo.SkipOnOpGeth(t, "osaka is not supported in op-geth")
+
+	karstOffset := uint64(3)
+	sys := presets.NewMinimal(t, presets.WithDeployerOptions(sysgo.WithKarstAtOffset(&karstOffset)))
+
+	activationBlock := sys.L2Chain.AwaitActivation(t, forks.Karst)
+	t.Require().Greater(activationBlock.Number, uint64(0), "karst must not activate at genesis")
+	preForkBlockNum := activationBlock.Number - 1
+	postForkBlockNum := activationBlock.Number + 1
+	sys.L2EL.WaitForBlockNumber(postForkBlockNum)
+
+	l2Client := sys.L2EL.EthClient()
+
+	// Call modexp with empty calldata. The precompile pads missing bytes with
+	// zeros, giving Bsize=0, Esize=0, Msize=0. This hits exactly the gas floor:
+	//   EIP-2565 (pre-Karst):  max(200, floor(0*0/3)) = 200 gas
+	//   EIP-7883 (post-Karst): max(500, floor(0*0))   = 500 gas
+	// Empty calldata also avoids EIP-7623 calldata cost inflation, so intrinsic
+	// gas is just 21,000 and we can precisely control execution gas via Gas limit.
+
+	// Pre-fork: 21,000 + 300 execution gas is enough for 200-gas floor.
+	_, err := l2Client.Call(t.Ctx(), ethereum.CallMsg{
+		To:  &modexpPrecompile,
+		Gas: 21_300,
+	}, rpc.BlockNumber(preForkBlockNum))
+	t.Require().NoError(err, "pre-fork: modexp should succeed with 300 execution gas (floor is 200)")
+
+	// Post-fork: 21,000 + 300 execution gas is NOT enough for 500-gas floor.
+	_, err = l2Client.Call(t.Ctx(), ethereum.CallMsg{
+		To:  &modexpPrecompile,
+		Gas: 21_300,
+	}, rpc.BlockNumber(postForkBlockNum))
+	t.Require().Error(err, "post-fork: modexp should fail with 300 execution gas (floor is 500)")
+
+	// Post-fork: 21,000 + 600 execution gas is enough for 500-gas floor.
+	_, err = l2Client.Call(t.Ctx(), ethereum.CallMsg{
+		To:  &modexpPrecompile,
+		Gas: 21_600,
+	}, rpc.BlockNumber(postForkBlockNum))
+	t.Require().NoError(err, "post-fork: modexp should succeed with 600 execution gas (floor is 500)")
+}
+
 func TestEIP7939CLZ(gt *testing.T) {
 	t := devtest.ParallelT(gt)
 	sysgo.SkipOnOpGeth(t, "osaka is not supported in op-geth")

--- a/op-acceptance-tests/tests/osaka_on_l2_test.go
+++ b/op-acceptance-tests/tests/osaka_on_l2_test.go
@@ -1,0 +1,74 @@
+package tests
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-core/forks"
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+var modexpPrecompile = common.HexToAddress("0x0000000000000000000000000000000000000005")
+
+// buildModExpInput constructs input data for the MODEXP precompile (address 0x05).
+// Format: <Bsize (32 bytes)> <Esize (32 bytes)> <Msize (32 bytes)> <B> <E> <M>
+func buildModExpInput(base, exp, mod []byte) []byte {
+	input := make([]byte, 0, 96+len(base)+len(exp)+len(mod))
+	input = append(input, common.LeftPadBytes(new(big.Int).SetInt64(int64(len(base))).Bytes(), 32)...)
+	input = append(input, common.LeftPadBytes(new(big.Int).SetInt64(int64(len(exp))).Bytes(), 32)...)
+	input = append(input, common.LeftPadBytes(new(big.Int).SetInt64(int64(len(mod))).Bytes(), 32)...)
+	input = append(input, base...)
+	input = append(input, exp...)
+	input = append(input, mod...)
+	return input
+}
+
+func TestEIP7823UpperBoundModExp(gt *testing.T) {
+	t := devtest.ParallelT(gt)
+	sysgo.SkipOnOpGeth(t, "osaka is not supported in op-geth")
+
+	karstOffset := uint64(3)
+	sys := presets.NewMinimal(t, presets.WithDeployerOptions(sysgo.WithKarstAtOffset(&karstOffset)))
+
+	activationBlock := sys.L2Chain.AwaitActivation(t, forks.Karst)
+	t.Require().Greater(activationBlock.Number, uint64(0), "karst must not activate at genesis")
+	preForkBlockNum := activationBlock.Number - 1
+	postForkBlockNum := activationBlock.Number + 1
+	sys.L2EL.WaitForBlockNumber(postForkBlockNum)
+
+	l2Client := sys.L2EL.EthClient()
+
+	// Modexp input exceeding EIP-7823 limits: modulus length is 1025 bytes (limit is 1024)
+	oversizeMod := make([]byte, 1025)
+	oversizeMod[1024] = 5
+	exceedingLimitInput := buildModExpInput([]byte{2}, []byte{3}, oversizeMod)
+
+	// Pre-fork: oversized modexp input should succeed (EIP-7823 not yet active)
+	result, err := l2Client.Call(t.Ctx(), ethereum.CallMsg{
+		To:   &modexpPrecompile,
+		Data: exceedingLimitInput,
+	}, rpc.BlockNumber(preForkBlockNum))
+	t.Require().NoError(err)
+	t.Require().Len(result, 1025, "pre-fork: modexp with oversized input should return 1025-byte result")
+
+	// Post-fork: oversized modexp input should fail (EIP-7823 enforced)
+	result, err = l2Client.Call(t.Ctx(), ethereum.CallMsg{
+		To:   &modexpPrecompile,
+		Data: exceedingLimitInput,
+	}, rpc.BlockNumber(postForkBlockNum))
+	t.Require().Error(err)
+	t.Require().Empty(result, "post-fork: modexp with oversized input should return empty result due to EIP-7823")
+
+	// Post-fork: within-limit modexp input should still succeed
+	result, err = l2Client.Call(t.Ctx(), ethereum.CallMsg{
+		To:   &modexpPrecompile,
+		Data: buildModExpInput([]byte{2}, []byte{3}, []byte{5}),
+	}, rpc.BlockNumber(postForkBlockNum))
+	t.Require().NoError(err)
+	t.Require().Equal([]byte{3}, result, "2^3 mod 5 should equal 3")
+}

--- a/op-acceptance-tests/tests/osaka_on_l2_test.go
+++ b/op-acceptance-tests/tests/osaka_on_l2_test.go
@@ -1,10 +1,15 @@
 package tests
 
 import (
+	"context"
 	"math/big"
+	"sync"
 	"testing"
+	"time"
 
+	"github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/interop/loadtest"
 	"github.com/ethereum-optimism/optimism/op-core/forks"
+	"github.com/ethereum-optimism/optimism/op-core/predeploys"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
@@ -257,4 +262,90 @@ func TestEIP7939CLZ(gt *testing.T) {
 	t.Require().NoError(err, "post-fork: CLZ opcode should be available")
 	expected := common.LeftPadBytes([]byte{0xff}, 32) // 255 as uint256
 	t.Require().Equal(expected, result, "CLZ(1) should equal 255")
+}
+
+func TestEIP7934BlockSizeLimitDisabled(gt *testing.T) {
+	t := devtest.ParallelT(gt)
+	sysgo.SkipOnOpGeth(t, "osaka is not supported in op-geth")
+
+	// Example error with kona-node:
+	//
+	// proxy.go:124:               ERROR[04-12|21:17:19.317] failed to proxy                          direction=upstream   err="writeto tcp 127.0.0.1:40991->127.0.0.1:34446: readfrom tcp 127.0.0.1:51850->127.0.0.1:38457: splice: connection reset by peer"
+	// proxy.go:124:               ERROR[04-12|21:17:19.317] failed to proxy                          direction=downstream err="writeto tcp 127.0.0.1:51850->127.0.0.1:38457: readfrom tcp 127.0.0.1:40991->127.0.0.1:34446: splice: broken pipe"
+	// driver.go:295:              WARN [04-12|21:17:19.317] Failed to load block into state          component=l2-batcher err="getting L2 block: websocket: read limit exceeded"
+	// driver.go:552:              WARN [04-12|21:17:19.317] error loading blocks, retrying on next tick component=l2-batcher err="getting L2 block: websocket: read limit exceeded"
+	// proxy.go:124:               ERROR[04-12|21:17:19.512] failed to proxy                          direction=downstream err="writeto tcp 127.0.0.1:44702->127.0.0.1:38457: readfrom tcp 127.0.0.1:40991->127.0.0.1:54452: splice: connection reset by peer"
+	// assertions.go:387:
+	//     	Error Trace:	/home/circleci/project/op-acceptance-tests/tests/osaka_on_l2_test.go:283
+	//     	Error:      	Received unexpected error:
+	//     	            	websocket: read limit exceeded
+	//     	Test:       	TestEIP7934BlockSizeLimitDisabled
+	sysgo.SkipOnKonaNode(t, "not supported")
+
+	// EIP-7934 limits RLP-encoded block size to 10 MiB on L1. OP Stack
+	// chains must NOT enforce this limit. We prove it by building a single
+	// block whose transaction data alone exceeds 10 MiB.
+	//
+	// EIP-7623 inflates zero-byte calldata cost to 10 gas/byte, so packing
+	// 12 MB into one block requires ~120M gas.
+	sys := presets.NewMinimal(t, presets.WithDeployerOptions(
+		sysgo.WithKarstAtGenesis,
+		sysgo.WithL2GasLimit(200_000_000),
+	))
+
+	spamTxs(sys)
+
+	// Find a block whose total transaction data exceeds 10 MiB.
+	l2Client := sys.L2EL.EthClient()
+	l2BlockTime := time.Duration(sys.L2Chain.Escape().RollupConfig().BlockTime) * time.Second
+	for {
+		select {
+		case <-time.After(l2BlockTime):
+			_, blockTxs, err := l2Client.InfoAndTxsByLabel(t.Ctx(), eth.Unsafe)
+			t.Require().NoError(err)
+
+			var totalTxSize int
+			for _, tx := range blockTxs {
+				bin, err := tx.MarshalBinary()
+				t.Require().NoError(err)
+				totalTxSize += len(bin)
+			}
+
+			if totalTxSize > 10_000_000 {
+				return
+			}
+		case <-t.Ctx().Done():
+			t.Require().NoError(t.Ctx().Err())
+		}
+	}
+}
+
+func spamTxs(sys *presets.Minimal) {
+	l2BlockTime := time.Duration(sys.L2Chain.Escape().RollupConfig().BlockTime) * time.Second
+	eoas := loadtest.FundEOAs(sys.T, eth.HundredEther, 50, l2BlockTime, sys.L2EL, sys.Wallet, sys.FaucetL2)
+	eoasRR := loadtest.NewRoundRobin(eoas)
+	spammer := loadtest.SpammerFunc(func(t devtest.T) error {
+		// Max tx size in op-geth and op-reth mempools is 128 kB per tx.
+		// We leave an 8 kB buffer for tx data outside the calldata.
+		const calldataSize = 120 * 1024
+		_, err := eoasRR.Get().Include(t,
+			txplan.WithTo(&predeploys.L1BlockAddr),
+			txplan.WithData(make([]byte, calldataSize)),
+			txplan.WithGasLimit(1_250_000),
+		)
+		return err
+	})
+	schedule := loadtest.NewBurst(l2BlockTime, loadtest.WithBaseRPS(50))
+
+	ctx, cancel := context.WithCancel(sys.T.Ctx())
+	var wg sync.WaitGroup
+	wg.Add(1)
+	sys.T.Cleanup(func() {
+		cancel()
+		wg.Wait()
+	})
+	go func() {
+		defer wg.Done()
+		schedule.Run(sys.T.WithCtx(ctx), spammer)
+	}()
 }

--- a/op-acceptance-tests/tests/osaka_on_l2_test.go
+++ b/op-acceptance-tests/tests/osaka_on_l2_test.go
@@ -17,9 +17,10 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
@@ -308,15 +309,18 @@ func TestEIP7934BlockSizeLimitDisabled(gt *testing.T) {
 	for {
 		select {
 		case <-time.After(l2BlockTime):
-			info, _, err := l2Client.InfoAndTxsByLabel(t.Ctx(), eth.Unsafe)
+			info, err := l2Client.InfoByLabel(t.Ctx(), eth.Unsafe)
 			t.Require().NoError(err)
 
-			// Use debug_getRawBlock to get the RLP-encoded block
-			var rawBlock hexutil.Bytes
-			err = l2Client.RPC().CallContext(t.Ctx(), &rawBlock, "debug_getRawBlock", rpc.BlockNumberOrHashWithNumber(rpc.BlockNumber(info.NumberU64())))
+			// Fetch the full block via eth_getBlockByNumber and RLP encode it
+			var block *types.Block
+			err = l2Client.RPC().CallContext(t.Ctx(), &block, "eth_getBlockByNumber", rpc.BlockNumber(info.NumberU64()).String(), true)
 			t.Require().NoError(err)
 
-			if len(rawBlock) > maxRLPBlockSize {
+			rlpBlock, err := rlp.EncodeToBytes(block)
+			t.Require().NoError(err)
+
+			if len(rlpBlock) > maxRLPBlockSize {
 				return
 			}
 		case <-t.Ctx().Done():

--- a/op-acceptance-tests/tests/osaka_on_l2_test.go
+++ b/op-acceptance-tests/tests/osaka_on_l2_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -266,7 +267,7 @@ func TestEIP7939CLZ(gt *testing.T) {
 
 func TestEIP7934BlockSizeLimitDisabled(gt *testing.T) {
 	t := devtest.ParallelT(gt)
-	sysgo.SkipOnOpGeth(t, "osaka is not supported in op-geth")
+	// sysgo.SkipOnOpGeth(t, "osaka is not supported in op-geth")
 
 	// Example error with kona-node:
 	//
@@ -282,12 +283,18 @@ func TestEIP7934BlockSizeLimitDisabled(gt *testing.T) {
 	//     	Test:       	TestEIP7934BlockSizeLimitDisabled
 	sysgo.SkipOnKonaNode(t, "not supported")
 
-	// EIP-7934 limits RLP-encoded block size to 10 MiB on L1. OP Stack
-	// chains must NOT enforce this limit. We prove it by building a single
-	// block whose transaction data alone exceeds 10 MiB.
+	// EIP-7934 limits RLP-encoded block size on L1:
+	//   MAX_BLOCK_SIZE = 10 MiB (10,485,760 bytes)
+	//   SAFETY_MARGIN = 2 MiB (2,097,152 bytes)
+	//   MAX_RLP_BLOCK_SIZE = MAX_BLOCK_SIZE - SAFETY_MARGIN = 8,388,608 bytes
+	//
+	// OP Stack chains must NOT enforce this limit. We prove it by building a
+	// single block whose RLP-encoded size exceeds MAX_RLP_BLOCK_SIZE.
 	//
 	// EIP-7623 inflates zero-byte calldata cost to 10 gas/byte, so packing
 	// 12 MB into one block requires ~120M gas.
+	const maxRLPBlockSize = 10_485_760 - 2_097_152 // 8,388,608 bytes
+
 	sys := presets.NewMinimal(t, presets.WithDeployerOptions(
 		sysgo.WithKarstAtGenesis,
 		sysgo.WithL2GasLimit(200_000_000),
@@ -295,23 +302,21 @@ func TestEIP7934BlockSizeLimitDisabled(gt *testing.T) {
 
 	spamTxs(sys)
 
-	// Find a block whose total transaction data exceeds 10 MiB.
+	// Find a block whose RLP-encoded size exceeds MAX_RLP_BLOCK_SIZE.
 	l2Client := sys.L2EL.EthClient()
 	l2BlockTime := time.Duration(sys.L2Chain.Escape().RollupConfig().BlockTime) * time.Second
 	for {
 		select {
 		case <-time.After(l2BlockTime):
-			_, blockTxs, err := l2Client.InfoAndTxsByLabel(t.Ctx(), eth.Unsafe)
+			info, _, err := l2Client.InfoAndTxsByLabel(t.Ctx(), eth.Unsafe)
 			t.Require().NoError(err)
 
-			var totalTxSize int
-			for _, tx := range blockTxs {
-				bin, err := tx.MarshalBinary()
-				t.Require().NoError(err)
-				totalTxSize += len(bin)
-			}
+			// Use debug_getRawBlock to get the RLP-encoded block
+			var rawBlock hexutil.Bytes
+			err = l2Client.RPC().CallContext(t.Ctx(), &rawBlock, "debug_getRawBlock", rpc.BlockNumberOrHashWithNumber(rpc.BlockNumber(info.NumberU64())))
+			t.Require().NoError(err)
 
-			if totalTxSize > 10_000_000 {
+			if len(rawBlock) > maxRLPBlockSize {
 				return
 			}
 		case <-t.Ctx().Done():

--- a/op-acceptance-tests/tests/osaka_on_l2_test.go
+++ b/op-acceptance-tests/tests/osaka_on_l2_test.go
@@ -267,7 +267,7 @@ func TestEIP7939CLZ(gt *testing.T) {
 
 func TestEIP7934BlockSizeLimitDisabled(gt *testing.T) {
 	t := devtest.ParallelT(gt)
-	// sysgo.SkipOnOpGeth(t, "osaka is not supported in op-geth")
+	sysgo.SkipOnOpGeth(t, "osaka is not supported in op-geth")
 
 	// Example error with kona-node:
 	//

--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -1175,6 +1175,7 @@ func (d *DeployConfig) RollupConfig(l1StartBlock *eth.BlockRef, l2GenesisBlockHa
 		PectraBlobScheduleTime:  d.PectraBlobScheduleTime(l1StartTime),
 		IsthmusTime:             d.IsthmusTime(l1StartTime),
 		JovianTime:              d.JovianTime(l1StartTime),
+		KarstTime:               d.KarstTime(l1StartTime),
 		InteropTime:             d.InteropTime(l1StartTime),
 		ProtocolVersionsAddress: d.ProtocolVersionsProxy,
 		AltDAConfig:             altDA,

--- a/op-devstack/sysgo/deployer.go
+++ b/op-devstack/sysgo/deployer.go
@@ -68,6 +68,12 @@ func WithKarstAtOffset(offset *uint64) DeployerOption {
 	}
 }
 
+func WithKarstAtGenesis(p devtest.T, _ devkeys.Keys, builder intentbuilder.Builder) {
+	for _, l2Cfg := range builder.L2s() {
+		l2Cfg.WithForkAtGenesis(opforks.Karst)
+	}
+}
+
 func WithJovianAtGenesis(p devtest.T, _ devkeys.Keys, builder intentbuilder.Builder) {
 	for _, l2Cfg := range builder.L2s() {
 		l2Cfg.WithForkAtGenesis(opforks.Jovian)

--- a/op-devstack/sysgo/deployer.go
+++ b/op-devstack/sysgo/deployer.go
@@ -60,6 +60,14 @@ func WithDefaultBPOBlobSchedule(_ devtest.T, _ devkeys.Keys, builder intentbuild
 	})
 }
 
+func WithKarstAtOffset(offset *uint64) DeployerOption {
+	return func(p devtest.T, _ devkeys.Keys, builder intentbuilder.Builder) {
+		for _, l2Cfg := range builder.L2s() {
+			l2Cfg.WithForkAtOffset(opforks.Karst, offset)
+		}
+	}
+}
+
 func WithJovianAtGenesis(p devtest.T, _ devkeys.Keys, builder intentbuilder.Builder) {
 	for _, l2Cfg := range builder.L2s() {
 		l2Cfg.WithForkAtGenesis(opforks.Jovian)

--- a/op-devstack/sysgo/deployer.go
+++ b/op-devstack/sysgo/deployer.go
@@ -80,6 +80,14 @@ func WithJovianAtGenesis(p devtest.T, _ devkeys.Keys, builder intentbuilder.Buil
 	}
 }
 
+func WithL2GasLimit(gasLimit uint64) DeployerOption {
+	return func(_ devtest.T, _ devkeys.Keys, builder intentbuilder.Builder) {
+		for _, l2Cfg := range builder.L2s() {
+			l2Cfg.WithGasLimit(gasLimit)
+		}
+	}
+}
+
 func WithEcotoneAtGenesis(p devtest.T, _ devkeys.Keys, builder intentbuilder.Builder) {
 	for _, l2Cfg := range builder.L2s() {
 		l2Cfg.WithForkAtGenesis(opforks.Ecotone)

--- a/op-devstack/sysgo/mixed_runtime.go
+++ b/op-devstack/sysgo/mixed_runtime.go
@@ -55,6 +55,13 @@ const (
 	MixedL2CLKona   MixedL2CLKind = "kona-node"
 )
 
+// SkipOnOpGeth skips the test when the L2 execution layer is op-geth
+func SkipOnOpGeth(t devtest.T, reason string) {
+	if devstackL2ELKind() == MixedL2ELOpGeth {
+		t.Skipf("skipping on op-geth: %s", reason)
+	}
+}
+
 // SkipOnOpReth skips the test when the L2 execution layer is op-reth
 func SkipOnOpReth(t devtest.T, reason string) {
 	if devstackL2ELKind() == MixedL2ELOpReth {

--- a/op-e2e/e2eutils/intentbuilder/builder.go
+++ b/op-e2e/e2eutils/intentbuilder/builder.go
@@ -63,6 +63,7 @@ type L2Configurator interface {
 	L2HardforkConfigurator
 	WithPrefundedAccount(addr common.Address, amount uint256.Int) L2Configurator
 	WithDAFootprintGasScalar(scalar uint16)
+	WithGasLimit(v uint64)
 }
 
 type ContractsConfigurator interface {
@@ -549,6 +550,10 @@ func (c *l2Configurator) initL2DevGenesisParams() *state.L2DevGenesisParams {
 func (c *l2Configurator) WithPrefundedAccount(addr common.Address, amount uint256.Int) L2Configurator {
 	c.initL2DevGenesisParams().Prefund[addr] = (*hexutil.U256)(&amount)
 	return c
+}
+
+func (c *l2Configurator) WithGasLimit(v uint64) {
+	c.builder.intent.Chains[c.chainIndex].GasLimit = v
 }
 
 func (c *l2Configurator) WithAdditionalDisputeGames(games []state.AdditionalDisputeGame) {

--- a/op-service/txmgr/txmgr.go
+++ b/op-service/txmgr/txmgr.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto/kzg4844"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/holiman/uint256"
 
@@ -489,6 +490,7 @@ func (m *SimpleTxManager) estimateOrValidateCandidateTxGas(ctx context.Context, 
 	}
 	// If the gas limit is set, we can use that as the gas
 	if candidate.GasLimit == 0 {
+		callMsg.Gas = params.MaxTxGas
 		gas, err := m.backend.EstimateGas(ctx, callMsg)
 		if err != nil {
 			return 0, fmt.Errorf("failed to estimate gas: %w", errutil.TryAddRevertReason(err))

--- a/op-service/txplan/txplan.go
+++ b/op-service/txplan/txplan.go
@@ -225,7 +225,7 @@ func WithEstimator(cl Estimator, invalidateOnNewBlock bool) Option {
 			msg := ethereum.CallMsg{
 				From:       tx.Sender.Value(),
 				To:         tx.To.Value(),
-				Gas:        0, // infinite gas, will be estimated
+				Gas:        params.MaxTxGas, // max gas, will be estimated
 				GasPrice:   nil,
 				GasFeeCap:  tx.GasFeeCap.Value(),
 				GasTipCap:  tx.GasTipCap.Value(),

--- a/rust/alloy-op-evm/src/env.rs
+++ b/rust/alloy-op-evm/src/env.rs
@@ -36,6 +36,7 @@ pub fn spec_by_timestamp_after_bedrock(chain_spec: impl OpHardforks, timestamp: 
     }
     check_forks! {
         is_interop_active_at_timestamp => INTEROP,
+        is_karst_active_at_timestamp => KARST,
         is_jovian_active_at_timestamp => JOVIAN,
         is_isthmus_active_at_timestamp => ISTHMUS,
         is_holocene_active_at_timestamp => HOLOCENE,
@@ -204,6 +205,7 @@ mod tests {
     fake_hardfork_constructors! {
         timestamp:
             interop => Interop,
+            karst => Karst,
             jovian => Jovian,
             isthmus => Isthmus,
             holocene => Holocene,
@@ -229,6 +231,7 @@ mod tests {
     }
 
     #[test_case::test_case(FakeHardfork::interop(), OpSpecId::INTEROP; "Interop")]
+    #[test_case::test_case(FakeHardfork::karst(), OpSpecId::KARST; "Karst")]
     #[test_case::test_case(FakeHardfork::jovian(), OpSpecId::JOVIAN; "Jovian")]
     #[test_case::test_case(FakeHardfork::isthmus(), OpSpecId::ISTHMUS; "Isthmus")]
     #[test_case::test_case(FakeHardfork::holocene(), OpSpecId::HOLOCENE; "Holocene")]

--- a/rust/alloy-op-hardforks/src/lib.rs
+++ b/rust/alloy-op-hardforks/src/lib.rs
@@ -167,7 +167,7 @@ impl OpHardfork {
     }
 
     /// Devnet list of hardforks.
-    pub const fn devnet() -> [(Self, ForkCondition); 9] {
+    pub const fn devnet() -> [(Self, ForkCondition); 10] {
         [
             (Self::Bedrock, ForkCondition::ZERO_BLOCK),
             (Self::Regolith, ForkCondition::ZERO_TIMESTAMP),
@@ -178,6 +178,7 @@ impl OpHardfork {
             (Self::Holocene, ForkCondition::ZERO_TIMESTAMP),
             (Self::Isthmus, ForkCondition::ZERO_TIMESTAMP),
             (Self::Jovian, ForkCondition::Timestamp(1762185600)),
+            (Self::Karst, ForkCondition::Never),
         ]
     }
 
@@ -316,8 +317,8 @@ impl OpChainHardforks {
 
 impl EthereumHardforks for OpChainHardforks {
     fn ethereum_fork_activation(&self, fork: EthereumHardfork) -> ForkCondition {
-        use EthereumHardfork::{Cancun, Prague, Shanghai};
-        use OpHardfork::{Canyon, Ecotone, Isthmus};
+        use EthereumHardfork::{Cancun, Osaka, Prague, Shanghai};
+        use OpHardfork::{Canyon, Ecotone, Isthmus, Karst};
 
         if self.forks.is_empty() {
             return ForkCondition::Never;
@@ -329,6 +330,7 @@ impl EthereumHardforks for OpChainHardforks {
             Shanghai if forks_len <= Canyon.idx() => ForkCondition::Never,
             Cancun if forks_len <= Ecotone.idx() => ForkCondition::Never,
             Prague if forks_len <= Isthmus.idx() => ForkCondition::Never,
+            Osaka if forks_len <= Karst.idx() => ForkCondition::Never,
             _ => self[fork],
         }
     }
@@ -378,11 +380,11 @@ impl Index<EthereumHardfork> for OpChainHardforks {
             Constantinople, Dao, Frontier, GrayGlacier, Homestead, Istanbul, London, MuirGlacier,
             Osaka, Paris, Petersburg, Prague, Shanghai, SpuriousDragon, Tangerine,
         };
-        use OpHardfork::{Bedrock, Canyon, Ecotone, Isthmus};
+        use OpHardfork::{Bedrock, Canyon, Ecotone, Isthmus, Karst};
 
         match hf {
             // Dao Hardfork is not needed for OpChainHardforks
-            Dao | Osaka | Bpo1 | Bpo2 | Bpo3 | Bpo4 | Bpo5 | Amsterdam => &ForkCondition::Never,
+            Dao | Bpo1 | Bpo2 | Bpo3 | Bpo4 | Bpo5 | Amsterdam => &ForkCondition::Never,
             Berlin if self.is_op_mainnet() => &ForkCondition::Block(OP_MAINNET_BERLIN_BLOCK),
             Frontier | Homestead | Tangerine | SpuriousDragon | Byzantium | Constantinople |
             Petersburg | Istanbul | MuirGlacier | Berlin => &ForkCondition::ZERO_BLOCK,
@@ -400,6 +402,7 @@ impl Index<EthereumHardfork> for OpChainHardforks {
             Shanghai => &self[Canyon],
             Cancun => &self[Ecotone],
             Prague => &self[Isthmus],
+            Osaka => &self[Karst],
             _ => unreachable!(),
         }
     }

--- a/rust/kona/bin/client/src/fpvm_evm/precompiles/provider.rs
+++ b/rust/kona/bin/client/src/fpvm_evm/precompiles/provider.rs
@@ -8,7 +8,7 @@ use alloy_primitives::{Address, Bytes};
 use kona_preimage::{HintWriterClient, PreimageOracleClient};
 use op_revm::{
     OpSpecId,
-    precompiles::{fjord, granite, isthmus, jovian},
+    precompiles::{fjord, granite, isthmus, jovian, karst},
 };
 use revm::{
     context::{Cfg, ContextTr},
@@ -49,7 +49,8 @@ where
             OpSpecId::FJORD => fjord(),
             OpSpecId::GRANITE | OpSpecId::HOLOCENE => granite(),
             OpSpecId::ISTHMUS => isthmus(),
-            OpSpecId::JOVIAN | OpSpecId::INTEROP | OpSpecId::OSAKA => jovian(),
+            OpSpecId::JOVIAN => jovian(),
+            OpSpecId::KARST | OpSpecId::INTEROP => karst(),
         };
 
         let accelerated_precompiles = match spec {
@@ -59,7 +60,7 @@ where
             OpSpecId::ECOTONE | OpSpecId::FJORD => accelerated_ecotone::<H, O>(),
             OpSpecId::GRANITE | OpSpecId::HOLOCENE => accelerated_granite::<H, O>(),
             OpSpecId::ISTHMUS => accelerated_isthmus::<H, O>(),
-            OpSpecId::JOVIAN | OpSpecId::INTEROP | OpSpecId::OSAKA => accelerated_jovian::<H, O>(),
+            OpSpecId::JOVIAN | OpSpecId::KARST | OpSpecId::INTEROP => accelerated_jovian::<H, O>(),
         };
 
         Self {
@@ -456,8 +457,8 @@ mod test {
             hint_writer.clone(),
             oracle_reader.clone(),
         );
-        let osaka_provider = OpFpvmPrecompiles::new_with_spec(
-            OpSpecId::OSAKA,
+        let karst_provider = OpFpvmPrecompiles::new_with_spec(
+            OpSpecId::KARST,
             hint_writer.clone(),
             oracle_reader.clone(),
         );
@@ -479,7 +480,7 @@ mod test {
         };
         let osaka_addrs: Vec<_> = {
             let mut addrs: Vec<_> =
-                osaka_provider.accelerated_precompiles.keys().copied().collect();
+                karst_provider.accelerated_precompiles.keys().copied().collect();
             addrs.sort();
             addrs
         };
@@ -495,16 +496,16 @@ mod test {
             "JOVIAN should use jovian() precompiles"
         );
         assert!(
-            core::ptr::eq(interop_provider.inner.precompiles, jovian()),
-            "INTEROP should use jovian() precompiles"
-        );
-        assert!(
-            core::ptr::eq(osaka_provider.inner.precompiles, jovian()),
-            "OSAKA should use jovian() precompiles"
-        );
-        assert!(
             core::ptr::eq(isthmus_provider.inner.precompiles, isthmus()),
             "ISTHMUS should use isthmus() precompiles"
+        );
+        assert!(
+            core::ptr::eq(karst_provider.inner.precompiles, karst()),
+            "KARST should use karst() precompiles"
+        );
+        assert!(
+            core::ptr::eq(interop_provider.inner.precompiles, karst()),
+            "INTEROP should use karst() precompiles"
         );
     }
 

--- a/rust/op-alloy/crates/rpc-types/src/genesis.rs
+++ b/rust/op-alloy/crates/rpc-types/src/genesis.rs
@@ -56,6 +56,8 @@ pub struct OpGenesisInfo {
     pub interop_time: Option<u64>,
     /// jovian hardfork timestamp
     pub jovian_time: Option<u64>,
+    /// karst hardfork timestamp
+    pub karst_time: Option<u64>,
 }
 
 impl OpGenesisInfo {
@@ -136,6 +138,7 @@ mod tests {
                 isthmus_time: None,
                 interop_time: None,
                 jovian_time: None,
+                karst_time: None,
             }
         );
     }
@@ -197,6 +200,7 @@ mod tests {
                     isthmus_time: None,
                     interop_time: None,
                     jovian_time: None,
+                    karst_time: None,
                 }),
                 base_fee_info: Some(OpBaseFeeInfo {
                     eip1559_elasticity: None,
@@ -222,6 +226,7 @@ mod tests {
                     isthmus_time: None,
                     interop_time: None,
                     jovian_time: None,
+                    karst_time: None,
                 }),
                 base_fee_info: Some(OpBaseFeeInfo {
                     eip1559_elasticity: None,
@@ -265,6 +270,7 @@ mod tests {
                     isthmus_time: Some(0),
                     interop_time: None,
                     jovian_time: Some(0),
+                    karst_time: None,
                 }),
                 base_fee_info: None,
             }

--- a/rust/op-reth/crates/chainspec/src/lib.rs
+++ b/rust/op-reth/crates/chainspec/src/lib.rs
@@ -200,9 +200,16 @@ impl OpChainSpecBuilder {
         self
     }
 
+    /// Enable Karst at genesis
+    pub fn karst_activated(mut self) -> Self {
+        self = self.jovian_activated();
+        self.inner = self.inner.with_fork(OpHardfork::Karst, ForkCondition::Timestamp(0));
+        self
+    }
+
     /// Enable Interop at genesis
     pub fn interop_activated(mut self) -> Self {
-        self = self.jovian_activated();
+        self = self.karst_activated();
         self.inner = self.inner.with_fork(OpHardfork::Interop, ForkCondition::Timestamp(0));
         self
     }
@@ -393,6 +400,7 @@ impl From<Genesis> for OpChainSpec {
             (OpHardfork::Holocene.boxed(), genesis_info.holocene_time),
             (OpHardfork::Isthmus.boxed(), genesis_info.isthmus_time),
             (OpHardfork::Jovian.boxed(), genesis_info.jovian_time),
+            (OpHardfork::Karst.boxed(), genesis_info.karst_time),
             (OpHardfork::Interop.boxed(), genesis_info.interop_time),
         ];
 

--- a/rust/op-reth/crates/chainspec/src/superchain/chain_metadata.rs
+++ b/rust/op-reth/crates/chainspec/src/superchain/chain_metadata.rs
@@ -27,6 +27,7 @@ pub(crate) struct HardforkConfig {
     pub holocene_time: Option<u64>,
     pub isthmus_time: Option<u64>,
     pub jovian_time: Option<u64>,
+    pub karst_time: Option<u64>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -60,6 +61,8 @@ pub(crate) struct ChainConfigExtraFields {
     pub isthmus_time: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub jovian_time: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub karst_time: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub optimism: Option<ChainConfigExtraFieldsOptimism>,
 }
@@ -108,7 +111,7 @@ pub(crate) fn to_genesis_chain_config(chain_config: &ChainMetadata) -> ChainConf
         shanghai_time: chain_config.hardforks.canyon_time, // Shanghai activates with Canyon
         cancun_time: chain_config.hardforks.ecotone_time,  // Cancun activates with Ecotone
         prague_time: chain_config.hardforks.isthmus_time,  // Prague activates with Isthmus
-        osaka_time: None,
+        osaka_time: chain_config.hardforks.karst_time,     // Osaka activates with Karst
         terminal_total_difficulty: Some(U256::ZERO),
         terminal_total_difficulty_passed: true,
         ethash: None,
@@ -141,6 +144,7 @@ pub(crate) fn to_genesis_chain_config(chain_config: &ChainMetadata) -> ChainConf
         holocene_time: chain_config.hardforks.holocene_time,
         isthmus_time: chain_config.hardforks.isthmus_time,
         jovian_time: chain_config.hardforks.jovian_time,
+        karst_time: chain_config.hardforks.karst_time,
         optimism: chain_config.optimism.as_ref().map(|o| o.into()),
     };
     res.extra_fields =
@@ -204,6 +208,7 @@ mod tests {
             holocene_time: Some(1736445601),
             isthmus_time: Some(1746806401),
             jovian_time: None,
+            karst_time: None,
             optimism: Option::from(ChainConfigExtraFieldsOptimism {
                 eip1559_elasticity: 6,
                 eip1559_denominator: 50,

--- a/rust/op-reth/crates/hardforks/src/lib.rs
+++ b/rust/op-reth/crates/hardforks/src/lib.rs
@@ -64,6 +64,7 @@ pub static DEV_HARDFORKS: LazyLock<ChainHardforks> = LazyLock::new(|| {
         (EthereumHardfork::Prague.boxed(), ForkCondition::Timestamp(0)),
         (OpHardfork::Isthmus.boxed(), ForkCondition::Timestamp(0)),
         (OpHardfork::Jovian.boxed(), ForkCondition::Timestamp(0)),
+        (OpHardfork::Karst.boxed(), ForkCondition::Timestamp(0)),
     ])
 });
 

--- a/rust/op-revm/src/precompiles.rs
+++ b/rust/op-revm/src/precompiles.rs
@@ -7,7 +7,7 @@ use revm::{
     interpreter::{CallInputs, InterpreterResult},
     precompile::{
         self, Precompile, PrecompileError, PrecompileId, PrecompileResult, Precompiles, bn254,
-        secp256r1,
+        modexp, secp256r1,
     },
     primitives::{Address, OnceLock, hardfork::SpecId},
 };
@@ -34,7 +34,8 @@ impl OpPrecompiles {
             OpSpecId::FJORD => fjord(),
             OpSpecId::GRANITE | OpSpecId::HOLOCENE => granite(),
             OpSpecId::ISTHMUS => isthmus(),
-            OpSpecId::INTEROP | OpSpecId::OSAKA | OpSpecId::JOVIAN => jovian(),
+            OpSpecId::JOVIAN => jovian(),
+            OpSpecId::KARST | OpSpecId::INTEROP => karst(),
         };
 
         Self { inner: EthPrecompiles { precompiles, spec: SpecId::default() }, spec }
@@ -82,6 +83,23 @@ pub fn isthmus() -> &'static Precompiles {
             bls12_381::ISTHMUS_G2_MSM,
             bls12_381::ISTHMUS_PAIRING,
         ]);
+        precompiles
+    })
+}
+
+/// Returns precompiles for karst spec.
+pub fn karst() -> &'static Precompiles {
+    static INSTANCE: OnceLock<Precompiles> = OnceLock::new();
+    INSTANCE.get_or_init(|| {
+        let mut precompiles = jovian().clone();
+
+        let mut to_remove = Precompiles::default();
+        to_remove.extend([modexp::BERLIN]);
+
+        precompiles.difference(&to_remove);
+
+        precompiles.extend([modexp::OSAKA]);
+
         precompiles
     })
 }

--- a/rust/op-revm/src/precompiles.rs
+++ b/rust/op-revm/src/precompiles.rs
@@ -94,11 +94,11 @@ pub fn karst() -> &'static Precompiles {
         let mut precompiles = jovian().clone();
 
         let mut to_remove = Precompiles::default();
-        to_remove.extend([modexp::BERLIN]);
+        to_remove.extend([modexp::BERLIN, secp256r1::P256VERIFY]);
 
         precompiles.difference(&to_remove);
 
-        precompiles.extend([modexp::OSAKA]);
+        precompiles.extend([modexp::OSAKA, secp256r1::P256VERIFY_OSAKA]);
 
         precompiles
     })

--- a/rust/op-revm/src/spec.rs
+++ b/rust/op-revm/src/spec.rs
@@ -1,6 +1,6 @@
 //! Contains the `[OpSpecId]` type and its implementation.
 use core::str::FromStr;
-use revm::primitives::hardfork::{SpecId, UnknownHardfork, name as eth_name};
+use revm::primitives::hardfork::{SpecId, UnknownHardfork};
 
 /// Optimism spec id.
 #[repr(u8)]
@@ -27,10 +27,10 @@ pub enum OpSpecId {
     /// Jovian spec id.
     #[default]
     JOVIAN,
+    /// Karst spec id.
+    KARST,
     /// Interop spec id.
     INTEROP,
-    /// Osaka spec id.
-    OSAKA,
 }
 
 impl OpSpecId {
@@ -41,7 +41,7 @@ impl OpSpecId {
             Self::CANYON => SpecId::SHANGHAI,
             Self::ECOTONE | Self::FJORD | Self::GRANITE | Self::HOLOCENE => SpecId::CANCUN,
             Self::ISTHMUS | Self::JOVIAN | Self::INTEROP => SpecId::PRAGUE,
-            Self::OSAKA => SpecId::OSAKA,
+            Self::KARST => SpecId::OSAKA,
         }
     }
 
@@ -71,8 +71,8 @@ impl FromStr for OpSpecId {
             name::HOLOCENE => Ok(Self::HOLOCENE),
             name::ISTHMUS => Ok(Self::ISTHMUS),
             name::JOVIAN => Ok(Self::JOVIAN),
+            name::KARST => Ok(Self::KARST),
             name::INTEROP => Ok(Self::INTEROP),
-            eth_name::OSAKA => Ok(Self::OSAKA),
             _ => Err(UnknownHardfork),
         }
     }
@@ -90,8 +90,8 @@ impl From<OpSpecId> for &'static str {
             OpSpecId::HOLOCENE => name::HOLOCENE,
             OpSpecId::ISTHMUS => name::ISTHMUS,
             OpSpecId::JOVIAN => name::JOVIAN,
+            OpSpecId::KARST => name::KARST,
             OpSpecId::INTEROP => name::INTEROP,
-            OpSpecId::OSAKA => eth_name::OSAKA,
         }
     }
 }
@@ -116,6 +116,8 @@ pub mod name {
     pub const ISTHMUS: &str = "Isthmus";
     /// Jovian spec name.
     pub const JOVIAN: &str = "Jovian";
+    /// Karst spec name.
+    pub const KARST: &str = "Karst";
     /// Interop spec name.
     pub const INTEROP: &str = "Interop";
 }


### PR DESCRIPTION
Use debug_getRawBlock to get the true RLP-encoded block size instead of summing transaction sizes. This accurately tests that OP Stack chains don't enforce the L1 MAX_RLP_BLOCK_SIZE limit (8,388,608 bytes).

Modifies #20069