### PR TITLE
fix(op-acceptance-tests): fix flaky TestTruncateDatabaseOnELResync

### DIFF
--- a/op-acceptance-tests/tests/safeheaddb_elsync/safeheaddb_test.go
+++ b/op-acceptance-tests/tests/safeheaddb_elsync/safeheaddb_test.go
@@ -63,10 +63,17 @@ func TestTruncateDatabaseOnELResync(gt *testing.T) {
 
 	sys.L2ELB.Start()
 	sys.L2CLB.Start()
+	// Wait for the restarted EL to be ready to accept RPC/P2P connections
+	// before attempting to peer. Without this, PeerWith may waste its 30s
+	// timeout on a node whose P2P stack isn't fully initialized yet.
+	sys.L2ELB.WaitForOnline()
 	sys.L2ELB.PeerWith(sys.L2EL)
 
-	sys.L2CLB.Matched(sys.L2CL, types.LocalSafe, 60)
-	sys.L2CLB.Advanced(types.LocalSafe, 1, 60) // At least one safe head db update after resync
+	// EL Sync after a full database wipe requires more time than the initial sync:
+	// the EL must re-download all blocks via P2P before the CL can begin derivation,
+	// and node A keeps advancing LocalSafe in the meantime.
+	sys.L2CLB.Matched(sys.L2CL, types.LocalSafe, 90)
+	sys.L2CLB.Advanced(types.LocalSafe, 1, 90) // At least one safe head db update after resync
 
 	sys.L2CLB.VerifySafeHeadDatabaseMatches(sys.L2CL)
 }


### PR DESCRIPTION
TestTruncateDatabaseOnELResync was flaking in CI (job memory-all-opn-op-geth, build 4813600). After stopping and restarting node B with a wiped in-memory EL database, the test expects B to re-sync via EL Sync and catch up to node A.

Two issues contribute to the flakiness:

1. No readiness wait after Start(): PeerWith has a hard 30s timeout, but the restarted EL's RPC/P2P stack may not be fully initialized yet. Add WaitForOnline() between Start() and PeerWith() so the 30s peering window starts with a responsive node.

2. Insufficient retry budget: EL Sync after a full database wipe is slower than initial sync — the EL must re-download all blocks via P2P before CL derivation can even begin, while node A keeps advancing LocalSafe. Increase Matched and Advanced retry counts from 60 (120s) to 90 (180s) to give more headroom in resource-constrained CI.