### PR TITLE
fix(ci): bump rust-ci-cargo-tests to 2xlarge to avoid OOM

### DIFF
--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -659,7 +659,7 @@ jobs:
         default: "release"
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
-    resource_class: xlarge
+    resource_class: 2xlarge
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless


### PR DESCRIPTION
The `rust-ci-cargo-tests` job intermittently OOMs during the test-docs phase when compiling reth-optimism-node, causing flaky failures in the `rust-ci-gate-short` workflow on non-Rust PRs.

Fixes: https://github.com/ethereum-optimism/optimism/issues/19995

Another failure from 15.04.2026: https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/122652/workflows/da64627b-3864-40a3-9edd-979dd50ed8e6/jobs/4822798

Alternatively we could amend the `rust-ci-gate-short` to not compile test-docs.