### PR TITLE
fix(rust): Remove ignored warnings from deny.toml

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3031,7 +3031,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -12939,9 +12939,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -14539,7 +14539,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5f7c95348f20c1c913d72157b3c6dee6ea3e30b3d19502c5a7f6d3f160dacbf"
 dependencies = [
  "cc",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]

--- a/rust/alloy-op-hardforks/src/lib.rs
+++ b/rust/alloy-op-hardforks/src/lib.rs
@@ -365,8 +365,8 @@ impl Index<EthereumHardfork> for OpChainHardforks {
             // Dao Hardfork is not needed for OpChainHardforks
             Dao | Bpo1 | Bpo2 | Bpo3 | Bpo4 | Bpo5 | Amsterdam => &ForkCondition::Never,
             Berlin if self.is_op_mainnet() => &ForkCondition::Block(OP_MAINNET_BERLIN_BLOCK),
-            Frontier | Homestead | Tangerine | SpuriousDragon | Byzantium | Constantinople
-            | Petersburg | Istanbul | MuirGlacier | Berlin => &ForkCondition::ZERO_BLOCK,
+            Frontier | Homestead | Tangerine | SpuriousDragon | Byzantium | Constantinople |
+            Petersburg | Istanbul | MuirGlacier | Berlin => &ForkCondition::ZERO_BLOCK,
             London | ArrowGlacier | GrayGlacier => &self[Bedrock],
             Paris if self.is_op_mainnet() => &ForkCondition::TTD {
                 activation_block_number: OP_MAINNET_BEDROCK_BLOCK,

--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -10,8 +10,8 @@ feature-depth = 1
 [advisories]
 yanked = "warn"
 ignore = [
-  # https://rustsec.org/advisories/RUSTSEC-2024-0384 used by sse example
-  "RUSTSEC-2024-0384",
+  # paste crate is no longer maintained.
+  "RUSTSEC-2024-0436",
   # bincode is unmaintained but still functional; transitive dep from reth-nippy-jar and test-fuzz.
   "RUSTSEC-2025-0141",
 ]

--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -14,6 +14,8 @@ ignore = [
   "RUSTSEC-2024-0436",
   # bincode is unmaintained but still functional; transitive dep from reth-nippy-jar and test-fuzz.
   "RUSTSEC-2025-0141",
+  # rand is unsound with a custom logger using `rand::rng()`
+  "RUSTSEC-2026-0097",
 ]
 
 # This section is considered when running `cargo deny check bans`.

--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -10,11 +10,8 @@ feature-depth = 1
 [advisories]
 yanked = "warn"
 ignore = [
-  # paste crate is no longer maintained.
-  "RUSTSEC-2024-0436",
   # https://rustsec.org/advisories/RUSTSEC-2024-0384 used by sse example
   "RUSTSEC-2024-0384",
-  "RUSTSEC-2025-0012",
   # bincode is unmaintained but still functional; transitive dep from reth-nippy-jar and test-fuzz.
   "RUSTSEC-2025-0141",
 ]


### PR DESCRIPTION
These are causing [failures in CI](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/122688/workflows/08137625-06bd-41b2-bdab-8ae3b6861c07/jobs/4827189) because the deps emitting these warnings have been removed.