### PR TITLE
fix(ci): prevent merge queue name collision for docs-only PRs

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -3217,9 +3217,13 @@ workflows:
             - equal: ["develop", << pipeline.git.branch >>]
             - << pipeline.parameters.c-non_docs_changes >>
         # Merge queue (merge gate). Match checkout branch.
-        - matches:
-            pattern: "^gh-readonly-queue/.*"
-            value: << pipeline.git.branch >>
+        # Also require non-docs changes so docs-only PRs take the skip path
+        # (contracts-feature-tests-short) and produce the correct check name.
+        - and:
+            - matches:
+                pattern: "^gh-readonly-queue/.*"
+                value: << pipeline.git.branch >>
+            - << pipeline.parameters.c-non_docs_changes >>
         - and:
             - equal: [true, <<pipeline.parameters.c-main_dispatch>>]
             - equal: ["api", << pipeline.trigger_source >>]
@@ -3400,9 +3404,13 @@ workflows:
               - equal: ["develop", << pipeline.git.branch >>]
               - << pipeline.parameters.c-non_docs_changes >>
           # Merge queue (merge gate). Match checkout branch.
-          - matches:
-              pattern: "^gh-readonly-queue/.*"
-              value: << pipeline.git.branch >>
+          # Also require non-docs changes so docs-only PRs take the skip path
+          # and produce the correct check name.
+          - and:
+              - matches:
+                  pattern: "^gh-readonly-queue/.*"
+                  value: << pipeline.git.branch >>
+              - << pipeline.parameters.c-non_docs_changes >>
           - and:
             - equal: [true, <<pipeline.parameters.c-main_dispatch>>]
             - equal: ["api", << pipeline.trigger_source >>]


### PR DESCRIPTION
Docs-only PRs are being removed from the merge queue with "no response for status checks." The root cause is a CircleCI job name collision: when a docs-only PR enters the merge queue, the gh-readonly-queue/* branch pattern unconditionally triggers the contracts-feature-tests workflow (full suite) alongside main-skip. Both workflows contain a contracts-bedrock-checks-fast job, so CircleCI disambiguates them by appending -1 and -2 suffixes. The merge queue requires the exact name contracts-bedrock-checks-fast (no suffix), which never appears, causing a timeout and dequeue.

The fix adds a c-non_docs_changes guard to the merge queue branch match in both contracts-feature-tests and contracts-feature-tests-short. This ensures docs-only PRs in the merge queue take the skip path (contracts-feature-tests-short only), producing a single contracts-bedrock-checks-fast job with no suffix collision.
