### PR TITLE
rename conflicting job name

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -2604,7 +2604,8 @@ workflows:
           context:
             - circleci-repo-readonly-authenticated-github-token
             - slack
-      - contracts-bedrock-checks-fast-feature-tests:
+      - contracts-bedrock-checks-fast:
+          name: contracts-bedrock-checks-fast-feature-tests
           context:
             - circleci-repo-readonly-authenticated-github-token
       - l2-chains-sync-check:

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -2604,7 +2604,7 @@ workflows:
           context:
             - circleci-repo-readonly-authenticated-github-token
             - slack
-      - contracts-bedrock-checks-fast:
+      - contracts-bedrock-checks-fast-feature-tests:
           context:
             - circleci-repo-readonly-authenticated-github-token
       - l2-chains-sync-check:
@@ -2860,7 +2860,7 @@ workflows:
             - contracts-bedrock-tests-heavy-fuzz-modified main: terminal
             - contracts-bedrock-tests-upgrade op-mainnet main: terminal
             - memory-all: terminal
-            - contracts-bedrock-checks-fast: terminal
+            - contracts-bedrock-checks-fast-feature-tests: terminal
           context:
             - circleci-api-token
           filters:

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -2605,7 +2605,6 @@ workflows:
             - circleci-repo-readonly-authenticated-github-token
             - slack
       - contracts-bedrock-checks-fast:
-          name: contracts-bedrock-checks-fast-feature-tests
           context:
             - circleci-repo-readonly-authenticated-github-token
       - l2-chains-sync-check:
@@ -2861,7 +2860,7 @@ workflows:
             - contracts-bedrock-tests-heavy-fuzz-modified main: terminal
             - contracts-bedrock-tests-upgrade op-mainnet main: terminal
             - memory-all: terminal
-            - contracts-bedrock-checks-fast-feature-tests: terminal
+            - contracts-bedrock-checks-fast: terminal
           context:
             - circleci-api-token
           filters:
@@ -3366,6 +3365,7 @@ workflows:
             - circleci-repo-readonly-authenticated-github-token
             - slack
       - contracts-bedrock-checks-fast:
+          name: contracts-bedrock-checks-fast-feature-tests
           context:
             - circleci-repo-readonly-authenticated-github-token
             - slack
@@ -3379,7 +3379,7 @@ workflows:
             - contracts-bedrock-tests-heavy-fuzz-modified main: terminal
             - contracts-bedrock-coverage main: terminal
             - contracts-bedrock-tests-upgrade op-mainnet main: terminal
-            - contracts-bedrock-checks-fast: terminal
+            - contracts-bedrock-checks-fast-feature-tests: terminal
           context:
             - circleci-api-token
 


### PR DESCRIPTION
This pull request updates the CircleCI workflow configuration to clarify and improve the naming of a specific job related to fast feature tests for contracts-bedrock. The changes ensure that the job is more clearly identified and referenced throughout the workflow.

Workflow configuration improvements:

* Renamed the job from `contracts-bedrock-checks-fast` to `contracts-bedrock-checks-fast-feature-tests` in both the job definition and its invocation, making it clearer what the job is responsible for. [[1]](diffhunk://#diff-f0efc20f2a9bb4e4f890362860f525c756a7b2662b088773e51c83c5b328c64cR3368) [[2]](diffhunk://#diff-f0efc20f2a9bb4e4f890362860f525c756a7b2662b088773e51c83c5b328c64cL3381-R3382)