### PR TITLE
refactor(op-alloy-consensus): deposit source hash builder

### DIFF
--- a/rust/kona/crates/protocol/hardforks/src/ecotone.rs
+++ b/rust/kona/crates/protocol/hardforks/src/ecotone.rs
@@ -1,10 +1,10 @@
 //! Module containing a [`TxDeposit`] builder for the Ecotone network upgrade transactions.
 
-use alloc::{string::String, vec::Vec};
+use alloc::vec::Vec;
 use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::{Address, B256, Bytes, TxKind, U256, address, hex};
 use kona_protocol::Predeploys;
-use op_alloy_consensus::{TxDeposit, UpgradeDepositSource};
+use op_alloy_consensus::{TxDeposit, upgrade_source_hash};
 
 use crate::Hardfork;
 
@@ -52,39 +52,32 @@ impl Ecotone {
 
     /// Returns the source hash for the deployment of the l1 block contract.
     pub fn deploy_l1_block_source() -> B256 {
-        UpgradeDepositSource { intent: String::from("Ecotone: L1 Block Deployment") }.source_hash()
+        upgrade_source_hash("Ecotone: L1 Block Deployment")
     }
 
     /// Returns the source hash for the deployment of the gas price oracle contract.
     pub fn deploy_gas_price_oracle_source() -> B256 {
-        UpgradeDepositSource { intent: String::from("Ecotone: Gas Price Oracle Deployment") }
-            .source_hash()
+        upgrade_source_hash("Ecotone: Gas Price Oracle Deployment")
     }
 
     /// Returns the source hash for the update of the l1 block proxy.
     pub fn update_l1_block_source() -> B256 {
-        UpgradeDepositSource { intent: String::from("Ecotone: L1 Block Proxy Update") }
-            .source_hash()
+        upgrade_source_hash("Ecotone: L1 Block Proxy Update")
     }
 
     /// Returns the source hash for the update of the gas price oracle proxy.
     pub fn update_gas_price_oracle_source() -> B256 {
-        UpgradeDepositSource { intent: String::from("Ecotone: Gas Price Oracle Proxy Update") }
-            .source_hash()
+        upgrade_source_hash("Ecotone: Gas Price Oracle Proxy Update")
     }
 
     /// Returns the source hash for the Ecotone Beacon Block Roots Contract deployment.
     pub fn beacon_roots_source() -> B256 {
-        UpgradeDepositSource {
-            intent: String::from("Ecotone: beacon block roots contract deployment"),
-        }
-        .source_hash()
+        upgrade_source_hash("Ecotone: beacon block roots contract deployment")
     }
 
     /// Returns the source hash for the Ecotone Gas Price Oracle activation.
     pub fn enable_ecotone_source() -> B256 {
-        UpgradeDepositSource { intent: String::from("Ecotone: Gas Price Oracle Set Ecotone") }
-            .source_hash()
+        upgrade_source_hash("Ecotone: Gas Price Oracle Set Ecotone")
     }
 
     /// Returns the EIP-4788 creation data.

--- a/rust/kona/crates/protocol/hardforks/src/fjord.rs
+++ b/rust/kona/crates/protocol/hardforks/src/fjord.rs
@@ -1,10 +1,10 @@
 //! Module containing a [`TxDeposit`] builder for the Fjord network upgrade transactions.
 
-use alloc::{string::String, vec::Vec};
+use alloc::vec::Vec;
 use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::{Address, B256, Bytes, TxKind, U256, address, hex};
 use kona_protocol::Predeploys;
-use op_alloy_consensus::{TxDeposit, UpgradeDepositSource};
+use op_alloy_consensus::{TxDeposit, upgrade_source_hash};
 
 use crate::Hardfork;
 
@@ -40,20 +40,17 @@ impl Fjord {
 
     /// Returns the source hash for the deployment of the Fjord Gas Price Oracle.
     pub fn deploy_fjord_gas_price_oracle_source() -> B256 {
-        UpgradeDepositSource { intent: String::from("Fjord: Gas Price Oracle Deployment") }
-            .source_hash()
+        upgrade_source_hash("Fjord: Gas Price Oracle Deployment")
     }
 
     /// Returns the source hash for the update of the Fjord Gas Price Oracle.
     pub fn update_fjord_gas_price_oracle_source() -> B256 {
-        UpgradeDepositSource { intent: String::from("Fjord: Gas Price Oracle Proxy Update") }
-            .source_hash()
+        upgrade_source_hash("Fjord: Gas Price Oracle Proxy Update")
     }
 
-    /// [`UpgradeDepositSource`] for setting the Fjord Gas Price Oracle.
+    /// Returns the source hash for the Fjord Gas Price Oracle activation.
     pub fn enable_fjord_source() -> B256 {
-        UpgradeDepositSource { intent: String::from("Fjord: Gas Price Oracle Set Fjord") }
-            .source_hash()
+        upgrade_source_hash("Fjord: Gas Price Oracle Set Fjord")
     }
 
     /// Returns the fjord gas price oracle deployment bytecode.

--- a/rust/kona/crates/protocol/hardforks/src/interop.rs
+++ b/rust/kona/crates/protocol/hardforks/src/interop.rs
@@ -4,11 +4,10 @@
 //!
 //! [specs]: https://specs.optimism.io/interop/derivation.html#network-upgrade-transactions
 
-use alloc::string::String;
 use alloy_eips::Encodable2718;
 use alloy_primitives::{Address, B256, Bytes, TxKind, U256, address, b256, hex};
 use kona_protocol::Predeploys;
-use op_alloy_consensus::{TxDeposit, UpgradeDepositSource};
+use op_alloy_consensus::{TxDeposit, upgrade_source_hash};
 
 use crate::Hardfork;
 
@@ -72,59 +71,47 @@ impl Interop {
 
     /// Returns the source hash for the `CrossL2Inbox` contract deployment transaction.
     pub fn deploy_cross_l2_inbox_source() -> B256 {
-        UpgradeDepositSource { intent: String::from("Interop: CrossL2Inbox Deployment") }
-            .source_hash()
+        upgrade_source_hash("Interop: CrossL2Inbox Deployment")
     }
 
     /// Returns the source hash for the `CrossL2Inbox` proxy upgrade transaction.
     pub fn upgrade_cross_l2_inbox_proxy_source() -> B256 {
-        UpgradeDepositSource { intent: String::from("Interop: CrossL2Inbox Proxy Update") }
-            .source_hash()
+        upgrade_source_hash("Interop: CrossL2Inbox Proxy Update")
     }
 
     /// Returns the source hash for the `L2ToL2CrossDomainMessenger` deployment transaction.
     pub fn deploy_l2_to_l2_xdm_source() -> B256 {
-        UpgradeDepositSource {
-            intent: String::from("Interop: L2ToL2CrossDomainMessenger Deployment"),
-        }
-        .source_hash()
+        upgrade_source_hash("Interop: L2ToL2CrossDomainMessenger Deployment")
     }
 
     /// Returns the source hash for the `L2ToL2CrossDomainMessenger` proxy upgrade transaction.
     pub fn upgrade_l2_to_l2_xdm_proxy_source() -> B256 {
-        UpgradeDepositSource {
-            intent: String::from("Interop: L2ToL2CrossDomainMessenger Proxy Update"),
-        }
-        .source_hash()
+        upgrade_source_hash("Interop: L2ToL2CrossDomainMessenger Proxy Update")
     }
 
     /// Returns the source hash for the `SuperchainETHBridge` deployment transaction.
     pub fn deploy_superchain_eth_bridge_source() -> B256 {
-        UpgradeDepositSource { intent: String::from("Interop: SuperchainETHBridge Deployment") }
-            .source_hash()
+        upgrade_source_hash("Interop: SuperchainETHBridge Deployment")
     }
 
     /// Returns the source hash for the `SuperchainETHBridge` proxy upgrade transaction.
     pub fn upgrade_superchain_eth_bridge_proxy_source() -> B256 {
-        UpgradeDepositSource { intent: String::from("Interop: SuperchainETHBridge Proxy Update") }
-            .source_hash()
+        upgrade_source_hash("Interop: SuperchainETHBridge Proxy Update")
     }
 
     /// Returns the source hash for the `ETHLiquidity` deployment transaction.
     pub fn deploy_eth_liquidity_source() -> B256 {
-        UpgradeDepositSource { intent: String::from("Interop: ETHLiquidity Deployment") }
-            .source_hash()
+        upgrade_source_hash("Interop: ETHLiquidity Deployment")
     }
 
     /// Returns the source hash for the `ETHLiquidity` proxy upgrade transaction.
     pub fn upgrade_eth_liquidity_proxy_source() -> B256 {
-        UpgradeDepositSource { intent: String::from("Interop: ETHLiquidity Proxy Update") }
-            .source_hash()
+        upgrade_source_hash("Interop: ETHLiquidity Proxy Update")
     }
 
     /// Returns the source hash for the `ETHLiquidity` funding transaction.
     pub fn fund_eth_liquidity_source() -> B256 {
-        UpgradeDepositSource { intent: String::from("Interop: ETHLiquidity Funding") }.source_hash()
+        upgrade_source_hash("Interop: ETHLiquidity Funding")
     }
 
     /// Returns the `CrossL2Inbox` deployment bytecode.

--- a/rust/kona/crates/protocol/hardforks/src/isthmus.rs
+++ b/rust/kona/crates/protocol/hardforks/src/isthmus.rs
@@ -4,11 +4,11 @@
 //!
 //! [specs]: https://specs.optimism.io/protocol/isthmus/derivation.html#network-upgrade-automation-transactions
 
-use alloc::{string::String, vec::Vec};
+use alloc::vec::Vec;
 use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::{Address, B256, Bytes, TxKind, U256, address, hex};
 use kona_protocol::Predeploys;
-use op_alloy_consensus::{TxDeposit, UpgradeDepositSource};
+use op_alloy_consensus::{TxDeposit, upgrade_source_hash};
 
 use crate::Hardfork;
 
@@ -72,49 +72,42 @@ impl Isthmus {
     );
     /// Returns the source hash for the Isthmus Gas Price Oracle activation.
     pub fn enable_isthmus_source() -> B256 {
-        UpgradeDepositSource { intent: String::from("Isthmus: Gas Price Oracle Set Isthmus") }
-            .source_hash()
+        upgrade_source_hash("Isthmus: Gas Price Oracle Set Isthmus")
     }
 
     /// Returns the source hash for the EIP-2935 block hash history contract deployment.
     pub fn block_hash_history_contract_source() -> B256 {
-        UpgradeDepositSource { intent: String::from("Isthmus: EIP-2935 Contract Deployment") }
-            .source_hash()
+        upgrade_source_hash("Isthmus: EIP-2935 Contract Deployment")
     }
 
     /// Returns the source hash for the deployment of the gas price oracle contract.
     pub fn deploy_gas_price_oracle_source() -> B256 {
-        UpgradeDepositSource { intent: String::from("Isthmus: Gas Price Oracle Deployment") }
-            .source_hash()
+        upgrade_source_hash("Isthmus: Gas Price Oracle Deployment")
     }
 
     /// Returns the source hash for the deployment of the l1 block contract.
     pub fn deploy_l1_block_source() -> B256 {
-        UpgradeDepositSource { intent: String::from("Isthmus: L1 Block Deployment") }.source_hash()
+        upgrade_source_hash("Isthmus: L1 Block Deployment")
     }
 
     /// Returns the source hash for the deployment of the operator fee vault contract.
     pub fn deploy_operator_fee_vault_source() -> B256 {
-        UpgradeDepositSource { intent: String::from("Isthmus: Operator Fee Vault Deployment") }
-            .source_hash()
+        upgrade_source_hash("Isthmus: Operator Fee Vault Deployment")
     }
 
     /// Returns the source hash for the update of the l1 block proxy.
     pub fn update_l1_block_source() -> B256 {
-        UpgradeDepositSource { intent: String::from("Isthmus: L1 Block Proxy Update") }
-            .source_hash()
+        upgrade_source_hash("Isthmus: L1 Block Proxy Update")
     }
 
     /// Returns the source hash for the update of the gas price oracle proxy.
     pub fn update_gas_price_oracle_source() -> B256 {
-        UpgradeDepositSource { intent: String::from("Isthmus: Gas Price Oracle Proxy Update") }
-            .source_hash()
+        upgrade_source_hash("Isthmus: Gas Price Oracle Proxy Update")
     }
 
     /// Returns the source hash for the update of the operator fee vault proxy.
     pub fn update_operator_fee_vault_source() -> B256 {
-        UpgradeDepositSource { intent: String::from("Isthmus: Operator Fee Vault Proxy Update") }
-            .source_hash()
+        upgrade_source_hash("Isthmus: Operator Fee Vault Proxy Update")
     }
 
     /// Returns the raw bytecode for the L1 Block deployment.

--- a/rust/kona/crates/protocol/hardforks/src/jovian.rs
+++ b/rust/kona/crates/protocol/hardforks/src/jovian.rs
@@ -4,11 +4,11 @@
 //!
 //! [specs]: https://specs.optimism.io/protocol/jovian/derivation.html#network-upgrade-automation-transactions
 
-use alloc::{string::String, vec::Vec};
+use alloc::vec::Vec;
 use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::{Address, B256, Bytes, TxKind, U256, address, hex, keccak256};
 use kona_protocol::Predeploys;
-use op_alloy_consensus::{TxDeposit, UpgradeDepositSource};
+use op_alloy_consensus::{TxDeposit, upgrade_source_hash};
 
 use crate::{Hardfork, upgrade_to_calldata};
 
@@ -32,24 +32,22 @@ impl Jovian {
 
     /// Returns the source hash for the deployment of the l1 block contract.
     pub fn deploy_l1_block_source() -> B256 {
-        UpgradeDepositSource { intent: String::from("Jovian: L1 Block Deployment") }.source_hash()
+        upgrade_source_hash("Jovian: L1 Block Deployment")
     }
 
     /// Returns the source hash for the deployment of the gas price oracle contract.
     pub fn l1_block_proxy_update() -> B256 {
-        UpgradeDepositSource { intent: String::from("Jovian: L1 Block Proxy Update") }.source_hash()
+        upgrade_source_hash("Jovian: L1 Block Proxy Update")
     }
 
     /// Returns the source hash for the deployment of the operator fee vault contract.
     pub fn gas_price_oracle() -> B256 {
-        UpgradeDepositSource { intent: String::from("Jovian: Gas Price Oracle Deployment") }
-            .source_hash()
+        upgrade_source_hash("Jovian: Gas Price Oracle Deployment")
     }
 
     /// Returns the source hash for the update of the l1 block proxy.
     pub fn gas_price_oracle_proxy_update() -> B256 {
-        UpgradeDepositSource { intent: String::from("Jovian: Gas Price Oracle Proxy Update") }
-            .source_hash()
+        upgrade_source_hash("Jovian: Gas Price Oracle Proxy Update")
     }
 
     /// The Jovian L1 Block Address
@@ -68,8 +66,7 @@ impl Jovian {
 
     /// Returns the source hash to the enable the gas price oracle for Jovian.
     pub fn gas_price_oracle_enable_jovian() -> B256 {
-        UpgradeDepositSource { intent: String::from("Jovian: Gas Price Oracle Set Jovian") }
-            .source_hash()
+        upgrade_source_hash("Jovian: Gas Price Oracle Set Jovian")
     }
 
     /// Returns the raw bytecode for the L1 Block deployment.

--- a/rust/kona/crates/protocol/protocol/src/deposits.rs
+++ b/rust/kona/crates/protocol/protocol/src/deposits.rs
@@ -3,7 +3,7 @@
 use alloc::vec::Vec;
 use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::{Address, B256, Bytes, Log, TxKind, U256, b256};
-use op_alloy_consensus::{TxDeposit, UserDepositSource};
+use op_alloy_consensus::{TxDeposit, user_deposit_source_hash};
 
 /// Deposit log event abi signature.
 pub const DEPOSIT_EVENT_ABI: &str = "TransactionDeposited(address,address,uint256,bytes)";
@@ -183,12 +183,10 @@ pub fn decode_deposit(block_hash: B256, index: usize, log: &Log) -> Result<Bytes
         )));
     }
 
-    let source = UserDepositSource::new(block_hash, index as u64);
-
     let mut deposit_tx = TxDeposit {
         from,
         is_system_transaction: false,
-        source_hash: source.source_hash(),
+        source_hash: user_deposit_source_hash(block_hash, index as u64),
         ..Default::default()
     };
 

--- a/rust/kona/crates/protocol/protocol/src/info/variant.rs
+++ b/rust/kona/crates/protocol/protocol/src/info/variant.rs
@@ -5,7 +5,7 @@ use alloy_consensus::Header;
 use alloy_eips::{BlockNumHash, eip7840::BlobParams};
 use alloy_primitives::{Address, B256, Bytes, Sealable, Sealed, TxKind, U256, address};
 use kona_genesis::{L1ChainConfig, RollupConfig, SystemConfig};
-use op_alloy_consensus::{DepositSourceDomain, L1InfoDepositSource, TxDeposit};
+use op_alloy_consensus::{TxDeposit, l1_info_deposit_source_hash};
 
 use crate::{
     BlockInfoError, DecodeError, L1BlockInfoBedrock, L1BlockInfoEcotone, L1BlockInfoIsthmus,
@@ -201,13 +201,8 @@ impl L1BlockInfoTx {
             l2_block_time,
         )?;
 
-        let source = DepositSourceDomain::L1Info(L1InfoDepositSource {
-            l1_block_hash: l1_info.block_hash(),
-            seq_number: sequence_number,
-        });
-
         let mut deposit_tx = TxDeposit {
-            source_hash: source.source_hash(),
+            source_hash: l1_info_deposit_source_hash(l1_info.block_hash(), sequence_number),
             from: L1_INFO_DEPOSITOR_ADDRESS,
             to: TxKind::Call(Predeploys::L1_BLOCK_INFO),
             mint: 0,

--- a/rust/op-alloy/crates/consensus/src/source.rs
+++ b/rust/op-alloy/crates/consensus/src/source.rs
@@ -1,7 +1,17 @@
-//! Classification of deposit transaction source
+//! Deposit transaction source hashing.
+//!
+//! Deposit transactions are identified by a `source_hash` derived from a domain identifier and
+//! domain-specific data. The shared pattern is:
+//!
+//! ```text
+//! source_hash = keccak256(pad32(domain_id) || keccak256(inner_data))
+//! ```
+//!
+//! [`DepositSourceHasher`] is an incremental builder for computing these hashes without heap
+//! allocation. Typed helper functions ([`upgrade_source_hash`], [`user_deposit_source_hash`], etc.)
+//! provide ergonomic shortcuts for each domain.
 
-use alloc::string::String;
-use alloy_primitives::{B256, keccak256};
+use alloy_primitives::{B256, Keccak256, keccak256};
 
 /// Source domain identifiers for deposit transactions.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Copy)]
@@ -17,148 +27,289 @@ pub enum DepositSourceDomainIdentifier {
     InteropBlockReplacement = 4,
 }
 
-/// Source domains for deposit transactions.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum DepositSourceDomain {
-    /// A user deposit source.
-    User(UserDepositSource),
-    /// A L1 info deposit source.
-    L1Info(L1InfoDepositSource),
-    /// An upgrade deposit source.
-    Upgrade(UpgradeDepositSource),
-    /// An interop block replacement deposit source.
-    InteropBlockReplacement(InteropBlockReplacementDepositSource),
+mod sealed {
+    #[allow(unnameable_types)]
+    pub trait Sealed {}
+
+    macro_rules! impl_sealed {
+        ($($t:ty),*) => { $( impl Sealed for $t {} )* };
+    }
+
+    impl_sealed!(u8, u16, u32, u64, u128, i8, i16, i32, i64, i128);
 }
 
-impl DepositSourceDomain {
-    /// Returns the source hash.
-    pub fn source_hash(&self) -> B256 {
-        match self {
-            Self::User(ds) => ds.source_hash(),
-            Self::L1Info(ds) => ds.source_hash(),
-            Self::Upgrade(ds) => ds.source_hash(),
-            Self::InteropBlockReplacement(ds) => ds.source_hash(),
+/// Trait for integer types that can be hashed as big-endian bytes.
+///
+/// Each type hashes at its native width (e.g., `u32` hashes 4 bytes, `u64` hashes 8 bytes).
+/// This is a sealed trait — only standard integer types implement it.
+///
+/// `usize`/`isize` are intentionally excluded because their width is platform-dependent,
+/// which would produce different hashes on different architectures.
+pub trait IntoBigEndianBytes: sealed::Sealed {
+    /// Write the big-endian representation of this integer into the hasher.
+    fn hash_into(self, hasher: &mut Keccak256);
+}
+
+macro_rules! impl_into_big_endian_bytes {
+    ($($t:ty),*) => {
+        $(
+            impl IntoBigEndianBytes for $t {
+                fn hash_into(self, hasher: &mut Keccak256) {
+                    hasher.update(&self.to_be_bytes());
+                }
+            }
+        )*
+    };
+}
+
+impl_into_big_endian_bytes!(u8, u16, u32, u64, u128, i8, i16, i32, i64, i128);
+
+/// Incremental builder for computing deposit source hashes.
+///
+/// Wraps an incremental keccak hasher and a domain identifier. Feed data in with the `hash_*`
+/// methods, then call [`finish`](Self::finish) to produce the final `source_hash`.
+///
+/// # Example
+///
+/// ```
+/// use op_alloy_consensus::{DepositSourceDomainIdentifier, deposit_source_hash};
+///
+/// let hash = deposit_source_hash(DepositSourceDomainIdentifier::Upgrade)
+///     .hash_str("Ecotone: L1 Block Deployment")
+///     .finish();
+/// ```
+pub struct DepositSourceHasher {
+    domain: DepositSourceDomainIdentifier,
+    inner: Keccak256,
+}
+
+impl core::fmt::Debug for DepositSourceHasher {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DepositSourceHasher").field("domain", &self.domain).finish_non_exhaustive()
+    }
+}
+
+impl DepositSourceHasher {
+    /// Creates a new hasher for the given domain.
+    pub fn new(domain: DepositSourceDomainIdentifier) -> Self {
+        Self { domain, inner: Keccak256::new() }
+    }
+
+    /// Feed raw bytes into the inner hash.
+    pub fn hash_bytes(mut self, data: &[u8]) -> Self {
+        self.inner.update(data);
+        self
+    }
+
+    /// Feed a string's UTF-8 bytes into the inner hash.
+    pub fn hash_str(self, data: &str) -> Self {
+        self.hash_bytes(data.as_bytes())
+    }
+
+    /// Feed a 32-byte value into the inner hash.
+    pub fn hash_b256(self, data: B256) -> Self {
+        self.hash_bytes(data.as_ref())
+    }
+
+    /// Feed an integer's big-endian bytes into the inner hash.
+    ///
+    /// The integer is hashed at its native width — `u32` produces 4 bytes, `u64` produces 8.
+    pub fn hash_int(mut self, value: impl IntoBigEndianBytes) -> Self {
+        value.hash_into(&mut self.inner);
+        self
+    }
+
+    /// Finalize the inner hash and compute the source hash.
+    ///
+    /// ```text
+    /// source_hash = keccak256(pad32(domain_id) || keccak256(accumulated_inner_data))
+    /// ```
+    pub fn finish(self) -> B256 {
+        let inner_hash = self.inner.finalize();
+        domain_hash(self.domain, inner_hash)
+    }
+}
+
+/// Creates a new [`DepositSourceHasher`] for the given domain.
+pub fn deposit_source_hash(domain: DepositSourceDomainIdentifier) -> DepositSourceHasher {
+    DepositSourceHasher::new(domain)
+}
+
+/// Compute a source hash from a domain identifier and a pre-computed inner value.
+///
+/// Use this when the inner 32 bytes are already known and should NOT be hashed again. This is
+/// the case for [`DepositSourceDomainIdentifier::InteropBlockReplacement`], where the inner
+/// value is the output root passed through directly.
+///
+/// ```text
+/// source_hash = keccak256(pad32(domain_id) || inner)
+/// ```
+pub fn deposit_source_hash_raw(domain: DepositSourceDomainIdentifier, inner: B256) -> B256 {
+    domain_hash(domain, inner)
+}
+
+/// Shared domain hash computation.
+fn domain_hash(domain: DepositSourceDomainIdentifier, inner: B256) -> B256 {
+    let mut buf = [0u8; 64];
+    buf[24..32].copy_from_slice(&(domain as u64).to_be_bytes());
+    buf[32..].copy_from_slice(inner.as_ref());
+    keccak256(buf)
+}
+
+/// Compute the source hash for an upgrade deposit transaction.
+///
+/// This is the primary API for the 31+ hardfork upgrade transactions that use string literal
+/// intents.
+pub fn upgrade_source_hash(intent: &str) -> B256 {
+    deposit_source_hash(DepositSourceDomainIdentifier::Upgrade).hash_str(intent).finish()
+}
+
+/// Compute the source hash for an upgrade deposit from its component parts.
+///
+/// Equivalent to `upgrade_source_hash(&format!("{fork} {index}: {intent}"))` but without the
+/// heap allocation — the index is formatted as decimal ASCII on the stack.
+pub fn upgrade_source_hash_parts(fork: &str, index: u64, intent: &str) -> B256 {
+    let mut buf = [0u8; 20]; // u64::MAX is 20 decimal digits
+    let ascii = format_u64_decimal(index, &mut buf);
+    deposit_source_hash(DepositSourceDomainIdentifier::Upgrade)
+        .hash_str(fork)
+        .hash_str(" ")
+        .hash_bytes(ascii)
+        .hash_str(": ")
+        .hash_str(intent)
+        .finish()
+}
+
+/// Format a u64 as decimal ASCII into a stack buffer, returning the written slice.
+fn format_u64_decimal(mut n: u64, buf: &mut [u8; 20]) -> &[u8] {
+    if n == 0 {
+        buf[19] = b'0';
+        return &buf[19..];
+    }
+    let mut i = 20;
+    while n > 0 {
+        i -= 1;
+        buf[i] = b'0' + (n % 10) as u8;
+        n /= 10;
+    }
+    &buf[i..]
+}
+
+/// Compute the source hash for a user deposit transaction.
+pub fn user_deposit_source_hash(l1_block_hash: B256, log_index: u64) -> B256 {
+    let mut input = [0u8; 64];
+    input[..32].copy_from_slice(l1_block_hash.as_ref());
+    input[56..].copy_from_slice(&log_index.to_be_bytes());
+    let inner = keccak256(input);
+    domain_hash(DepositSourceDomainIdentifier::User, inner)
+}
+
+/// Compute the source hash for an L1 info deposit transaction.
+pub fn l1_info_deposit_source_hash(l1_block_hash: B256, seq_number: u64) -> B256 {
+    let mut input = [0u8; 64];
+    input[..32].copy_from_slice(l1_block_hash.as_ref());
+    input[56..].copy_from_slice(&seq_number.to_be_bytes());
+    let inner = keccak256(input);
+    domain_hash(DepositSourceDomainIdentifier::L1Info, inner)
+}
+
+/// Compute the source hash for an interop block replacement deposit transaction.
+///
+/// Unlike other deposit sources, the output root is used directly as the inner value
+/// without an additional keccak hash.
+pub fn interop_block_replacement_source_hash(output_root: B256) -> B256 {
+    deposit_source_hash_raw(DepositSourceDomainIdentifier::InteropBlockReplacement, output_root)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::hex;
+
+    #[test]
+    fn upgrade_source_hash_ecotone() {
+        assert_eq!(
+            upgrade_source_hash("Ecotone: L1 Block Deployment"),
+            hex!("877a6077205782ea15a6dc8699fa5ebcec5e0f4389f09cb8eda09488231346f8"),
+        );
+    }
+
+    #[test]
+    fn user_deposit_source_hash_roundtrip() {
+        let block_hash = B256::repeat_byte(0xaa);
+        let log_index = 42u64;
+        let hash = user_deposit_source_hash(block_hash, log_index);
+        assert_ne!(hash, B256::ZERO);
+    }
+
+    #[test]
+    fn l1_info_deposit_source_hash_roundtrip() {
+        let block_hash = B256::repeat_byte(0xbb);
+        let seq_number = 7u64;
+        let hash = l1_info_deposit_source_hash(block_hash, seq_number);
+        assert_ne!(hash, B256::ZERO);
+    }
+
+    #[test]
+    fn interop_block_replacement_no_inner_hash() {
+        let output_root = B256::repeat_byte(0xcc);
+        let hash = interop_block_replacement_source_hash(output_root);
+        let expected = deposit_source_hash_raw(
+            DepositSourceDomainIdentifier::InteropBlockReplacement,
+            output_root,
+        );
+        assert_eq!(hash, expected);
+    }
+
+    #[test]
+    fn upgrade_source_hash_parts_matches_format() {
+        let formatted = alloc::format!("{} {}: {}", "Ecotone", 3, "L1 Block Deployment");
+        assert_eq!(
+            upgrade_source_hash_parts("Ecotone", 3, "L1 Block Deployment"),
+            upgrade_source_hash(&formatted),
+        );
+    }
+
+    #[test]
+    fn upgrade_source_hash_parts_zero_index() {
+        let formatted = alloc::format!("{} {}: {}", "Fjord", 0, "Deploy");
+        assert_eq!(
+            upgrade_source_hash_parts("Fjord", 0, "Deploy"),
+            upgrade_source_hash(&formatted),
+        );
+    }
+
+    #[test]
+    fn format_u64_decimal_edge_cases() {
+        let check = |n: u64| {
+            let expected = alloc::format!("{n}");
+            let mut buf = [0u8; 20];
+            let result = super::format_u64_decimal(n, &mut buf);
+            assert_eq!(
+                core::str::from_utf8(result).unwrap(),
+                expected,
+                "format_u64_decimal({n}) failed"
+            );
+        };
+
+        check(0);
+        check(u64::MAX);
+
+        // Cover every output length boundary: 9/10, 99/100, ..., up to 20 digits
+        let mut power = 1u64;
+        for _ in 0..19 {
+            check(power - 1);
+            check(power);
+            power = power.saturating_mul(10);
         }
     }
-}
 
-/// A deposit transaction source.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Copy)]
-pub struct UserDepositSource {
-    /// The L1 block hash.
-    pub l1_block_hash: B256,
-    /// The log index.
-    pub log_index: u64,
-}
-
-impl UserDepositSource {
-    /// Creates a new [`UserDepositSource`].
-    pub const fn new(l1_block_hash: B256, log_index: u64) -> Self {
-        Self { l1_block_hash, log_index }
-    }
-
-    /// Returns the source hash.
-    pub fn source_hash(&self) -> B256 {
-        let mut input = [0u8; 32 * 2];
-        input[..32].copy_from_slice(&self.l1_block_hash[..]);
-        input[32 * 2 - 8..].copy_from_slice(&self.log_index.to_be_bytes());
-        let deposit_id_hash = keccak256(input);
-        let mut domain_input = [0u8; 32 * 2];
-        let identifier_bytes: [u8; 8] = (DepositSourceDomainIdentifier::User as u64).to_be_bytes();
-        domain_input[32 - 8..32].copy_from_slice(&identifier_bytes);
-        domain_input[32..].copy_from_slice(&deposit_id_hash[..]);
-        keccak256(domain_input)
-    }
-}
-
-/// A L1 info deposit transaction source.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Copy)]
-pub struct L1InfoDepositSource {
-    /// The L1 block hash.
-    pub l1_block_hash: B256,
-    /// The sequence number.
-    pub seq_number: u64,
-}
-
-impl L1InfoDepositSource {
-    /// Creates a new [`L1InfoDepositSource`].
-    pub const fn new(l1_block_hash: B256, seq_number: u64) -> Self {
-        Self { l1_block_hash, seq_number }
-    }
-
-    /// Returns the source hash.
-    pub fn source_hash(&self) -> B256 {
-        let mut input = [0u8; 32 * 2];
-        input[..32].copy_from_slice(&self.l1_block_hash[..]);
-        input[32 * 2 - 8..].copy_from_slice(&self.seq_number.to_be_bytes());
-        let deposit_id_hash = keccak256(input);
-        let mut domain_input = [0u8; 32 * 2];
-        let identifier_bytes: [u8; 8] =
-            (DepositSourceDomainIdentifier::L1Info as u64).to_be_bytes();
-        domain_input[32 - 8..32].copy_from_slice(&identifier_bytes);
-        domain_input[32..].copy_from_slice(&deposit_id_hash[..]);
-        keccak256(domain_input)
-    }
-}
-
-/// An upgrade deposit transaction source.
-///
-/// This implements the translation of upgrade-tx identity information to a deposit source-hash,
-/// which makes the deposit uniquely identifiable.
-/// System-upgrade transactions have their own domain for source-hashes,
-/// to not conflict with user-deposits or deposited L1 information.
-/// The intent identifies the upgrade-tx uniquely, in a human-readable way.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct UpgradeDepositSource {
-    /// The intent.
-    pub intent: String,
-}
-
-impl UpgradeDepositSource {
-    /// Creates a new [`UpgradeDepositSource`].
-    pub const fn new(intent: String) -> Self {
-        Self { intent }
-    }
-
-    /// Returns the source hash.
-    pub fn source_hash(&self) -> B256 {
-        let intent_hash = keccak256(self.intent.as_bytes());
-        let mut domain_input = [0u8; 32 * 2];
-        let identifier_bytes: [u8; 8] =
-            (DepositSourceDomainIdentifier::Upgrade as u64).to_be_bytes();
-        domain_input[32 - 8..32].copy_from_slice(&identifier_bytes);
-        domain_input[32..].copy_from_slice(&intent_hash[..]);
-        keccak256(domain_input)
-    }
-}
-
-/// An interop block replacement deposit transaction source.
-///
-/// This implements the translation of the replaced output root information to a deposit
-/// source-hash, which makes the deposit uniquely identifiable.
-/// Interop block replacement transactions have their own domain for source-hashes,
-/// to not conflict with user-deposits, system upgrades, or L1 information updates.
-///
-/// The output root in the source is the output root of the block that was replaced.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct InteropBlockReplacementDepositSource {
-    /// The output root of the replaced block.
-    pub output_root: B256,
-}
-
-impl InteropBlockReplacementDepositSource {
-    /// Creates a new [`InteropBlockReplacementDepositSource`].
-    pub const fn new(output_root: B256) -> Self {
-        Self { output_root }
-    }
-
-    /// Returns the source hash.
-    pub fn source_hash(&self) -> B256 {
-        let mut domain_input = [0u8; 32 * 2];
-        let identifier_bytes: [u8; 8] =
-            (DepositSourceDomainIdentifier::InteropBlockReplacement as u64).to_be_bytes();
-        domain_input[32 - 8..32].copy_from_slice(&identifier_bytes);
-        domain_input[32..].copy_from_slice(&self.output_root[..]);
-        keccak256(domain_input)
+    #[test]
+    fn hash_int_native_width() {
+        let h32 =
+            deposit_source_hash(DepositSourceDomainIdentifier::Upgrade).hash_int(42u32).finish();
+        let h64 =
+            deposit_source_hash(DepositSourceDomainIdentifier::Upgrade).hash_int(42u64).finish();
+        assert_ne!(h32, h64, "u32 and u64 should hash different widths");
     }
 }


### PR DESCRIPTION
## Summary

- Replace the four struct-based deposit source types (`UpgradeDepositSource`, `UserDepositSource`, `L1InfoDepositSource`, `InteropBlockReplacementDepositSource`) with a zero-allocation `DepositSourceHasher` builder and typed helper functions
- Eliminates 31 heap allocations from `String::from("literal")` across 5 hardfork modules — bytes now feed directly into an incremental keccak hasher
- Provides ergonomic helpers (`upgrade_source_hash`, `user_deposit_source_hash`, etc.) as the primary API, with the raw builder available for custom patterns
- Includes `IntoBigEndianBytes` sealed trait for `hash_int()` with native-width encoding (no implicit widening)

## Test plan

- [x] All 54 `kona-hardforks` tests pass — these verify consensus-critical source hashes against hardcoded expected values
- [x] All 115 `op-alloy-consensus` tests pass including 8 new tests for the builder
- [x] New tests verify `upgrade_source_hash_parts` matches `format!` output exactly
- [x] Edge case coverage for `format_u64_decimal` across all digit lengths (0 through u64::MAX)
- [x] `kona-protocol` lib compiles clean
- [x] Clippy clean (`-D warnings`), rustfmt clean, `check-no-std` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)