### PR TITLE
chore(ci): add ci-base-clang image and register for factory builds

### DIFF
--- a/.github/docker-images.json
+++ b/.github/docker-images.json
@@ -129,6 +129,10 @@
       "type": "rust",
       "check": "none",
       "paths": ["rust/kona/docker/cannon/**"]
+    },
+    "ci-base-clang": {
+      "check": "none",
+      "paths": ["ops/docker/ci-base-clang/**"]
     }
   }
 }

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -396,3 +396,10 @@ target "cannon-builder" {
   platforms = split(",", PLATFORMS)
   tags = [for tag in split(",", IMAGE_TAGS) : "${REGISTRY}/${REPOSITORY}/cannon-builder:${tag}"]
 }
+
+target "ci-base-clang" {
+  dockerfile = "Dockerfile"
+  context = "ops/docker/ci-base-clang"
+  platforms = split(",", PLATFORMS)
+  tags = [for tag in split(",", IMAGE_TAGS) : "${REGISTRY}/${REPOSITORY}/ci-base-clang:${tag}"]
+}

--- a/ops/docker/ci-base-clang/Dockerfile
+++ b/ops/docker/ci-base-clang/Dockerfile
@@ -9,6 +9,7 @@ USER root
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
+ && apt-get upgrade -y \
  && apt-get install -y --no-install-recommends \
       clang \
       llvm-dev \

--- a/ops/docker/ci-base-clang/Dockerfile
+++ b/ops/docker/ci-base-clang/Dockerfile
@@ -1,0 +1,18 @@
+FROM cimg/base:2026.03
+
+LABEL org.opencontainers.image.title="optimism ci-base clang"
+LABEL org.opencontainers.image.description="CircleCI base image with clang, llvm-dev, and libclang-dev preinstalled for Rust bindgen jobs"
+LABEL org.opencontainers.image.source="https://github.com/ethereum-optimism/optimism"
+
+USER root
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      clang \
+      llvm-dev \
+      libclang-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+USER circleci


### PR DESCRIPTION
## Summary

- Add Dockerfile for `ci-base-clang` at `ops/docker/ci-base-clang/` (based on `cimg/base:2026.03` + clang, llvm-dev, libclang-dev)
- Add `ci-base-clang` target to `docker-bake.hcl`
- Add `ci-base-clang` entry to `.github/docker-images.json` for change detection

The factory workflow will build and publish the image to `us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-base-clang` with provenance attestation on every push to `develop`.

Rust CI jobs currently install clang at runtime via `apt-get`, adding ~9 minutes per build. Pre-baking these packages into a CI base image eliminates this overhead. A follow-up PR will update CircleCI config to use the image pinned by digest, with provenance verification before use.

Based on the Dockerfile from #20117.

Closes #20119

## Test plan

- [ ] Verify `docker-bake.hcl` parses correctly: `docker buildx bake --print ci-base-clang`
- [ ] CI builds the image successfully on both amd64 and arm64
- [ ] Image is available at `us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-base-clang:<sha>`
- [ ] Provenance attestation is attached: `gh attestation verify --bundle-from-oci -o ethereum-optimism oci://us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-base-clang:<sha>`