### PR TITLE
ci: bump factory workflow to node24-compatible version

### DIFF
--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -255,7 +255,7 @@ jobs:
       fail-fast: false
       matrix:
         image_name: ${{ fromJson(needs.detect-changes.outputs.images_json) }}
-    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@4a6713dc9a56712c9150a8007aa1d33eba6f38ea
+    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@cc1794a8e99695971560f5354076fbe2ddca9f2e
     with:
       mode: bake
       image_name: ${{ matrix.image_name }}
@@ -282,7 +282,7 @@ jobs:
       fail-fast: false
       matrix:
         image_name: ${{ fromJson(needs.detect-changes.outputs.images_json) }}
-    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@4a6713dc9a56712c9150a8007aa1d33eba6f38ea
+    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@cc1794a8e99695971560f5354076fbe2ddca9f2e
     with:
       mode: bake
       image_name: ${{ matrix.image_name }}

--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -255,7 +255,7 @@ jobs:
       fail-fast: false
       matrix:
         image_name: ${{ fromJson(needs.detect-changes.outputs.images_json) }}
-    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@cc1794a8e99695971560f5354076fbe2ddca9f2e
+    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@0df70b9f043d552377e641951fe72ca292086e85
     with:
       mode: bake
       image_name: ${{ matrix.image_name }}
@@ -282,7 +282,7 @@ jobs:
       fail-fast: false
       matrix:
         image_name: ${{ fromJson(needs.detect-changes.outputs.images_json) }}
-    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@cc1794a8e99695971560f5354076fbe2ddca9f2e
+    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@0df70b9f043d552377e641951fe72ca292086e85
     with:
       mode: bake
       image_name: ${{ matrix.image_name }}

--- a/.github/workflows/tags.yaml
+++ b/.github/workflows/tags.yaml
@@ -26,12 +26,12 @@ jobs:
       - uses: ./.github/actions/docker-build-prep
         id: prep
       - name: Parse tag
-        uses: ethereum-optimism/factory/actions/parse-tag@240b16167a5f5aa789270fa9c0efbfa9f010b7e7
+        uses: ethereum-optimism/factory/actions/parse-tag@cc1794a8e99695971560f5354076fbe2ddca9f2e
         id: parse-tag
 
   release:
     needs: prep
-    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@4a6713dc9a56712c9150a8007aa1d33eba6f38ea
+    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@cc1794a8e99695971560f5354076fbe2ddca9f2e
     with:
       mode: bake
       image_name: ${{ needs.prep.outputs.image_name }}

--- a/.github/workflows/tags.yaml
+++ b/.github/workflows/tags.yaml
@@ -26,12 +26,12 @@ jobs:
       - uses: ./.github/actions/docker-build-prep
         id: prep
       - name: Parse tag
-        uses: ethereum-optimism/factory/actions/parse-tag@cc1794a8e99695971560f5354076fbe2ddca9f2e
+        uses: ethereum-optimism/factory/actions/parse-tag@0df70b9f043d552377e641951fe72ca292086e85
         id: parse-tag
 
   release:
     needs: prep
-    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@cc1794a8e99695971560f5354076fbe2ddca9f2e
+    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@0df70b9f043d552377e641951fe72ca292086e85
     with:
       mode: bake
       image_name: ${{ needs.prep.outputs.image_name }}


### PR DESCRIPTION
## Summary

- Bumps all `ethereum-optimism/factory` workflow and action references to `cc1794a8e99695971560f5354076fbe2ddca9f2e`
- This version picks up Node.js 24 compatibility updates for GitHub Actions ahead of the June 2 deprecation deadline for Node.js 16/20 runners

## Changes

- `.github/workflows/branches.yaml`: Updated 2 factory docker workflow references
- `.github/workflows/tags.yaml`: Updated 1 factory docker workflow reference and 1 parse-tag action reference