### PR TITLE
ci: retry apt-get update on transient mirror sync failures

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -299,7 +299,13 @@ commands:
           command: |
             export NEEDRESTART_MODE=a
             for i in 1 2 3; do
-              sudo -E apt-get -o Acquire::Retries=5 update && break
+              if sudo -E apt-get -o Acquire::Retries=5 update; then
+                break
+              fi
+              if [ "$i" = "3" ]; then
+                echo "apt-get update failed after 3 attempts" >&2
+                exit 1
+              fi
               echo "apt-get update failed (attempt $i), retrying in 10s..." >&2
               sleep 10
             done
@@ -865,7 +871,13 @@ jobs:
 
             if [ "<< parameters.needs_clang >>" = "true" ]; then
               for i in 1 2 3; do
-                sudo apt-get -o Acquire::Retries=5 update && break
+                if sudo apt-get -o Acquire::Retries=5 update; then
+                  break
+                fi
+                if [ "$i" = "3" ]; then
+                  echo "apt-get update failed after 3 attempts" >&2
+                  exit 1
+                fi
                 echo "apt-get update failed (attempt $i), retrying in 10s..." >&2
                 sleep 10
               done

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -283,12 +283,33 @@ commands:
           branch_pattern: develop
           mentions: "<< parameters.mentions >>"
 
+  apt-install:
+    description: "apt-get update + install, with retries to tolerate transient Ubuntu mirror sync failures."
+    parameters:
+      packages:
+        description: "Space-separated list of apt packages to install."
+        type: string
+      extra_flags:
+        description: "Extra flags to pass to apt-get install (e.g. '--no-install-recommends')."
+        type: string
+        default: ""
+    steps:
+      - run:
+          name: "apt install << parameters.packages >>"
+          command: |
+            export NEEDRESTART_MODE=a
+            for i in 1 2 3; do
+              sudo -E apt-get -o Acquire::Retries=5 update && break
+              echo "apt-get update failed (attempt $i), retrying in 10s..." >&2
+              sleep 10
+            done
+            sudo -E apt-get install -y << parameters.extra_flags >> << parameters.packages >>
+
   install-zstd:
     description: "Install zstd compression utility"
     steps:
-      - run:
-          name: Install zstd
-          command: sudo apt-get update && sudo apt-get install -y zstd=1.4.8*
+      - apt-install:
+          packages: "zstd=1.4.8*"
 
   install-cargo-binstall:
     description: "Install cargo-binstall for fast binary installations"
@@ -468,12 +489,9 @@ commands:
       - when:
           condition: << parameters.needs_clang >>
           steps:
-            - run:
-                name: Install clang
-                command: |
-                  export NEEDRESTART_MODE=a
-                  sudo -E apt-get update --yes
-                  sudo -E apt-get install -y --no-install-recommends clang llvm-dev libclang-dev
+            - apt-install:
+                packages: "clang llvm-dev libclang-dev"
+                extra_flags: "--no-install-recommends"
 
   rust-restore-build-cache:
     description: "Restore the target directory cache for a Rust workspace"
@@ -846,7 +864,11 @@ jobs:
             git submodule update --init --recursive --depth 1 -j 8 --single-branch << parameters.directory >>
 
             if [ "<< parameters.needs_clang >>" = "true" ]; then
-              sudo apt-get update
+              for i in 1 2 3; do
+                sudo apt-get -o Acquire::Retries=5 update && break
+                echo "apt-get update failed (attempt $i), retrying in 10s..." >&2
+                sleep 10
+              done
               sudo apt-get install -y --no-install-recommends clang
             fi
 
@@ -1227,11 +1249,8 @@ jobs:
           name: Print forge version
           command: forge --version
           working_directory: packages/contracts-bedrock
-      - run:
-          name: Install lcov
-          command: |
-            sudo apt-get update
-            sudo apt-get install -y lcov
+      - apt-install:
+          packages: "lcov"
       - run:
           name: Write pinned block number for cache key
           command: |
@@ -1963,11 +1982,8 @@ jobs:
       - utils/checkout-with-mise:
           checkout-method: blobless
           enable-mise-cache: true
-      - run:
-          name: Install tools
-          command: |
-            sudo apt-get update
-            sudo apt-get install -y binutils-mips-linux-gnu
+      - apt-install:
+          packages: "binutils-mips-linux-gnu"
       - run:
           name: Build cannon
           command: just cannon

--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -96,6 +96,28 @@ parameters:
 # COMMANDS
 # ============================================================================
 commands:
+  apt-install:
+    description: "apt-get update + install, with retries to tolerate transient Ubuntu mirror sync failures."
+    parameters:
+      packages:
+        description: "Space-separated list of apt packages to install."
+        type: string
+      extra_flags:
+        description: "Extra flags to pass to apt-get install (e.g. '--no-install-recommends')."
+        type: string
+        default: ""
+    steps:
+      - run:
+          name: "apt install << parameters.packages >>"
+          command: |
+            export NEEDRESTART_MODE=a
+            for i in 1 2 3; do
+              sudo -E apt-get -o Acquire::Retries=5 update && break
+              echo "apt-get update failed (attempt $i), retrying in 10s..." >&2
+              sleep 10
+            done
+            sudo -E apt-get install -y << parameters.extra_flags >> << parameters.packages >>
+
   install-cargo-binstall:
     description: "Install cargo-binstall for fast binary installations"
     steps:
@@ -174,12 +196,9 @@ commands:
       - when:
           condition: << parameters.needs_clang >>
           steps:
-            - run:
-                name: Install clang
-                command: |
-                  export NEEDRESTART_MODE=a
-                  sudo -E apt-get update --yes
-                  sudo -E apt-get install -y --no-install-recommends clang llvm-dev libclang-dev
+            - apt-install:
+                packages: "clang llvm-dev libclang-dev"
+                extra_flags: "--no-install-recommends"
 
   rust-restore-build-cache:
     description: "Restore the target directory cache for a Rust workspace"
@@ -339,9 +358,8 @@ commands:
   install-zstd:
     description: "Install zstd compression utility"
     steps:
-      - run:
-          name: Install zstd
-          command: sudo apt-get update && sudo apt-get install -y zstd=1.4.8*
+      - apt-install:
+          packages: "zstd=1.4.8*"
 
   gcp-oidc-authenticate:
     description: "Authenticate with GCP using a CircleCI OIDC token."

--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -112,7 +112,13 @@ commands:
           command: |
             export NEEDRESTART_MODE=a
             for i in 1 2 3; do
-              sudo -E apt-get -o Acquire::Retries=5 update && break
+              if sudo -E apt-get -o Acquire::Retries=5 update; then
+                break
+              fi
+              if [ "$i" = "3" ]; then
+                echo "apt-get update failed after 3 attempts" >&2
+                exit 1
+              fi
               echo "apt-get update failed (attempt $i), retrying in 10s..." >&2
               sleep 10
             done


### PR DESCRIPTION
## Summary

`archive.ubuntu.com` periodically serves a stale `Packages.gz` during mirror sync, failing `apt-get update` with:

```
E: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/noble-updates/main/binary-amd64/Packages.gz  File has unexpected size (2401605 != 2401619). Mirror sync in progress? [IP: 91.189.92.23 80]
E: Some index files failed to download.
Exited with code exit status 100
```

This is a recurring source of CI flakes — most recently hit in [`contracts-bedrock-coverage`](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/122779/workflows/9512a240-fcb4-4edb-9e9d-a611b311a338/jobs/4839063) on the `Install lcov` step, but the same mode has killed `clang`, `zstd`, `binutils-mips-linux-gnu`, etc.

## Fix

Add a shared `apt-install` CircleCI command that:

- passes `-o Acquire::Retries=5` so `apt` retries each individual file fetch (handles the common case where only one file is mid-sync)
- wraps the whole `update` in a 3-attempt loop with 10s backoff (handles the rare case where a whole snapshot is bad)
- plumbs `--no-install-recommends` via an optional parameter

Replaced every `apt-get update && apt-get install …` call site in `main.yml` and `rust-ci.yml` with this command. The one inline call buried inside a larger shell script (`rust-build-binary`) gets the same retry loop inline.

## Not touched

- `sudo apt-get install -y ripgrep` in `main.yml` — does not call `apt-get update`, so not affected by this failure mode.
- `docs-ci.yml` node install — uses NodeSource's `setup_24.x` which manages its own apt config.

## Test plan

- [ ] Green CI on this PR exercises the new command across `contracts-bedrock-coverage`, cannon build, rust clang installs, and zstd installs.
- [ ] Manual check: no `sudo apt-get update` without retries remains (`rg 'apt-get (update|install)' .circleci/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)