### PR TITLE
docs: fix typos and broken links in public-docs

### DIFF
--- a/docs/public-docs/app-developers/guides/interoperability/get-started.mdx
+++ b/docs/public-docs/app-developers/guides/interoperability/get-started.mdx
@@ -23,10 +23,10 @@ Choose your development environment to build, test, and quickly iterate on your 
 | Tool                                                                                       | Description                                                             |
 | ------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------- |
 | [Superchain Faucet](https://console.optimism.io/faucet?utm_source=op-docs&utm_medium=docs) | One-stop shop to grab testnet ETH for any OP Stack network.           |
-| [Supersim](/> app-developers/tools/development/supersim)                                                        | Local multi-chain testing environment for smart contracts.              |
+| [Supersim](/app-developers/tools/supersim)                                                        | Local multi-chain testing environment for smart contracts.              |
 | [Super CLI](https://github.com/ethereum-optimism/super-cli)                                | Command-line tool for seamless multichain app deployment and testing.   |
 | [Superchain Relayer](https://github.com/ethereum-optimism/superchain-relayer)              | UI for monitoring and managing cross-chain transactions.                |
-| [Interop Docs](/> op-stack/interop/explainer)                                                         | Comprehensive Interop information in the Optimism Docs.                 |
+| [Interop Docs](/op-stack/interop/explainer)                                                         | Comprehensive Interop information in the Optimism Docs.                 |
 | [Developer Console](https://console.optimism.io/?utm_source=op-docs&utm_medium=docs)  | Comprehensive tool to build, launch, and grow your app on OP Stack chains. |
 | [Developer Support GitHub](https://github.com/ethereum-optimism/developers/discussions)    | Quick and easy developer support.                                       |
 

--- a/docs/public-docs/app-developers/guides/transactions/flashblocks-and-gas-usage.mdx
+++ b/docs/public-docs/app-developers/guides/transactions/flashblocks-and-gas-usage.mdx
@@ -57,7 +57,7 @@ A transaction may be submitted with a gas limit lower than the total block gas l
 
 This happens because transaction acceptance and transaction inclusion are decided by different components.
 
-Genrally:
+Generally:
 - Incoming transactions first enter the Execution Layer txpool.
 - The EL checks whether `tx.gasLimit` exceeds the **full block gas limit**.
   - If it does, it rejects with `exceeds block gas limit`.

--- a/docs/public-docs/app-developers/tutorials/bridging/bridge-crosschain-eth.mdx
+++ b/docs/public-docs/app-developers/tutorials/bridging/bridge-crosschain-eth.mdx
@@ -16,7 +16,7 @@ description: Learn how to transfer ETH across the OP Stack interop cluster
 
 Crosschain ETH transfers across OP Stack chains are facilitated through the [SuperchainETHBridge](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/L2/SuperchainETHBridge.sol) contract.
 This tutorial walks through how to send ETH from one chain to another.
-You can do this on [Supersim](/> app-developers/tools/development/supersim) or production once it is released.
+You can do this on [Supersim](/app-developers/tools/supersim) or production once it is released.
 
 ### What you'll build
 
@@ -61,7 +61,7 @@ The tutorial uses these primary tools:
   </Step>
 
   <Step title="Configure the network">
-  You can run this tutorial either with [Supersim](/> app-developers/tools/development/supersim) running locally, or using the [Interop devnet](/app-developers/guides/building-apps).
+  You can run this tutorial either with [Supersim](/app-developers/tools/supersim) running locally, or using the [Interop devnet](/app-developers/guides/building-apps).
     Select the correct tab and follow the directions. 
   
   
@@ -381,5 +381,5 @@ The tutorial uses these primary tools:
 ## Next steps
 
 *   Check out the [SuperchainETHBridge guide](/op-stack/interop/superchain-eth-bridge) for more information.
-*   Review the [OP Stack interop explainer](/> op-stack/interop/explainer) for answers to common questions about interoperability.
+*   Review the [OP Stack interop explainer](/op-stack/interop/explainer) for answers to common questions about interoperability.
 

--- a/docs/public-docs/app-developers/tutorials/bridging/deposit-transactions.mdx
+++ b/docs/public-docs/app-developers/tutorials/bridging/deposit-transactions.mdx
@@ -90,5 +90,5 @@ We'll run through a sample deposit directly with the `OptimismPortal` using cast
 ## Next steps
 
 *   See the [transaction guides](/app-developers/guides/transactions) for more detailed information.
-*   Questions about Interop? Check out collection of [interop guides](/> op-stack/interop/explainer) or check out this [OP Stack interop design video walk-thru](https://www.youtube.com/watch?v=FKc5RgjtGes).
+*   Questions about Interop? Check out collection of [interop guides](/op-stack/interop/explainer) or check out this [OP Stack interop design video walk-thru](https://www.youtube.com/watch?v=FKc5RgjtGes).
 *   For more info about how OP Stack interoperability works under the hood, [check out the specs](https://specs.optimism.io/interop/overview.html?utm_source=op-docs&utm_medium=docs).

--- a/docs/public-docs/chain-operators/guides/features/blobs.mdx
+++ b/docs/public-docs/chain-operators/guides/features/blobs.mdx
@@ -4,7 +4,7 @@ description: Learn how to switch to using blobs for your chain.
 ---
 
 This guide walks you through how to switch to using blobs for your chain. 
-This feature was introduced in with the Ecotone network upgrade.
+This feature was introduced with the Ecotone network upgrade.
 
 ## Switch to using blobs
 

--- a/docs/public-docs/chain-operators/guides/features/custom-gas-token-guide.mdx
+++ b/docs/public-docs/chain-operators/guides/features/custom-gas-token-guide.mdx
@@ -137,7 +137,7 @@ Deploying a CGT chain follows the standard OP Stack deployment process with addi
       --deployment-target genesis
     ```
 
-    The genesis configuration is applied based on your `initent.toml`.
+    The genesis configuration is applied based on your `intent.toml`.
   </Step>
 
   <Step title="Start your chain services">


### PR DESCRIPTION
Fix a handful of prose errors and malformed markdown links found across the public-docs directory:

Typos / grammar:
- flashblocks-and-gas-usage.mdx: "Genrally" → "Generally"
- blobs.mdx: "introduced in with" → "introduced with" (duplicate word)
- custom-gas-token-guide.mdx: "initent.toml" → "intent.toml"

Broken markdown links (spurious `/> ` prefix breaking all href paths):
- get-started.mdx: fix Supersim and Interop Docs table links
- bridge-crosschain-eth.mdx: fix three Supersim / interop explainer links
- deposit-transactions.mdx: fix interop guides link

