### PR TITLE
ci: pin ci-base-clang image for Rust jobs and skip runtime apt-install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,11 @@ parameters:
   default_docker_image:
     type: string
     default: cimg/base:2026.03
+  # Pinned ci-base-clang image (cimg/base + clang/llvm-dev/libclang-dev) for Rust jobs.
+  # Provenance is verified by .github/workflows/verify-ci-base-clang-attestation.yml.
+  rust_base_image:
+    type: string
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-base-clang@sha256:852cb2dcd64eb5c039abf857a2217f341351eb7e4ef1a989ba9eefb86f158105
   base_image:
     type: string
     default: default
@@ -89,6 +94,7 @@ workflows:
           config-path: .circleci/continue/main.yml
           mapping: |
             .* c-default_docker_image << pipeline.parameters.default_docker_image >> .circleci/continue/main.yml
+            .* c-rust_base_image << pipeline.parameters.rust_base_image >> .circleci/continue/main.yml
             .* c-base_image << pipeline.parameters.base_image >> .circleci/continue/main.yml
             .* c-main_dispatch << pipeline.parameters.main_dispatch >> .circleci/continue/main.yml
             .* c-fault_proofs_dispatch << pipeline.parameters.fault_proofs_dispatch >> .circleci/continue/main.yml
@@ -117,6 +123,7 @@ workflows:
 
             # Rust CI — always include config, gate jobs via c-rust_changes_detected
             .* c-default_docker_image << pipeline.parameters.default_docker_image >> .circleci/continue/rust-ci.yml
+            .* c-rust_base_image << pipeline.parameters.rust_base_image >> .circleci/continue/rust-ci.yml
             .* c-base_image << pipeline.parameters.base_image >> .circleci/continue/rust-ci.yml
             .* c-go-cache-version << pipeline.parameters.go-cache-version >> .circleci/continue/rust-ci.yml
             .* c-rust_ci_dispatch << pipeline.parameters.rust_ci_dispatch >> .circleci/continue/rust-ci.yml
@@ -125,6 +132,7 @@ workflows:
 
             # Rust E2E — always include config, gate jobs via c-rust_changes_detected
             .* c-default_docker_image << pipeline.parameters.default_docker_image >> .circleci/continue/rust-e2e.yml
+            .* c-rust_base_image << pipeline.parameters.rust_base_image >> .circleci/continue/rust-e2e.yml
             .* c-go-cache-version << pipeline.parameters.go-cache-version >> .circleci/continue/rust-e2e.yml
             .* c-rust_e2e_dispatch << pipeline.parameters.rust_e2e_dispatch >> .circleci/continue/rust-e2e.yml
             (rust|op-e2e|\.circleci)/.* c-rust_changes_detected true .circleci/continue/rust-e2e.yml

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -502,8 +502,15 @@ commands:
           condition: << parameters.needs_clang >>
           steps:
             - run:
-                name: Verify clang available (baked into c-rust_base_image)
-                command: command -v clang >/dev/null && command -v llvm-config >/dev/null
+                name: Ensure clang available
+                # Docker jobs use c-rust_base_image with clang pre-baked, so this is a no-op.
+                # Machine jobs run on bare Ubuntu VMs where clang must still be installed.
+                command: |
+                  if command -v clang >/dev/null; then
+                    exit 0
+                  fi
+                  sudo -E apt-get update --yes
+                  sudo -E apt-get install -y --no-install-recommends clang llvm-dev libclang-dev
 
   rust-restore-build-cache:
     description: "Restore the target directory cache for a Rust workspace"
@@ -875,8 +882,9 @@ jobs:
             # restore cannot make the submodule path non-empty (which breaks `git submodule update --init`).
             git submodule update --init --recursive --depth 1 -j 8 --single-branch << parameters.directory >>
 
-            if [ "<< parameters.needs_clang >>" = "true" ]; then
-              command -v clang >/dev/null
+            if [ "<< parameters.needs_clang >>" = "true" ] && ! command -v clang >/dev/null; then
+              sudo -E apt-get update --yes
+              sudo -E apt-get install -y --no-install-recommends clang
             fi
 
             cd << parameters.directory >> && << parameters.build_command >>

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -4,6 +4,9 @@ parameters:
   c-default_docker_image:
     type: string
     default: cimg/base:2026.03
+  c-rust_base_image:
+    type: string
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-base-clang@sha256:852cb2dcd64eb5c039abf857a2217f341351eb7e4ef1a989ba9eefb86f158105
   c-base_image:
     type: string
     default: default
@@ -89,6 +92,9 @@ parameters:
   default_docker_image:
     type: string
     default: cimg/base:2026.03
+  rust_base_image:
+    type: string
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-base-clang@sha256:852cb2dcd64eb5c039abf857a2217f341351eb7e4ef1a989ba9eefb86f158105
   base_image:
     type: string
     default: default
@@ -495,9 +501,9 @@ commands:
       - when:
           condition: << parameters.needs_clang >>
           steps:
-            - apt-install:
-                packages: "clang llvm-dev libclang-dev"
-                extra_flags: "--no-install-recommends"
+            - run:
+                name: Verify clang available (baked into c-rust_base_image)
+                command: command -v clang >/dev/null && command -v llvm-config >/dev/null
 
   rust-restore-build-cache:
     description: "Restore the target directory cache for a Rust workspace"
@@ -735,7 +741,7 @@ jobs:
   rust-build-binary:
     description: "Build a Rust workspace with target directory caching"
     docker:
-      - image: <<pipeline.parameters.c-default_docker_image>>
+      - image: <<pipeline.parameters.c-rust_base_image>>
     resource_class: xlarge
     parameters:
       directory:
@@ -806,7 +812,7 @@ jobs:
   # Build a single Rust binary from a submodule.
   rust-build-submodule:
     docker:
-      - image: <<pipeline.parameters.c-default_docker_image>>
+      - image: <<pipeline.parameters.c-rust_base_image>>
     resource_class: xlarge
     parameters:
       directory:
@@ -870,18 +876,7 @@ jobs:
             git submodule update --init --recursive --depth 1 -j 8 --single-branch << parameters.directory >>
 
             if [ "<< parameters.needs_clang >>" = "true" ]; then
-              for i in 1 2 3; do
-                if sudo apt-get -o Acquire::Retries=5 update; then
-                  break
-                fi
-                if [ "$i" = "3" ]; then
-                  echo "apt-get update failed after 3 attempts" >&2
-                  exit 1
-                fi
-                echo "apt-get update failed (attempt $i), retrying in 10s..." >&2
-                sleep 10
-              done
-              sudo apt-get install -y --no-install-recommends clang
+              command -v clang >/dev/null
             fi
 
             cd << parameters.directory >> && << parameters.build_command >>

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -503,25 +503,7 @@ commands:
           steps:
             - run:
                 name: Ensure clang available
-                # Docker jobs use c-rust_base_image with clang pre-baked, so this is a no-op.
-                # Machine jobs run on bare Ubuntu VMs where clang must still be installed.
-                command: |
-                  if command -v clang >/dev/null; then
-                    exit 0
-                  fi
-                  export NEEDRESTART_MODE=a
-                  for i in 1 2 3; do
-                    if sudo -E apt-get -o Acquire::Retries=5 update; then
-                      break
-                    fi
-                    if [ "$i" = "3" ]; then
-                      echo "apt-get update failed after 3 attempts" >&2
-                      exit 1
-                    fi
-                    echo "apt-get update failed (attempt $i), retrying in 10s..." >&2
-                    sleep 10
-                  done
-                  sudo -E apt-get install -y --no-install-recommends clang llvm-dev libclang-dev
+                command: command -v clang >/dev/null 2>&1 || { echo "ERROR: clang is required but was not found in PATH" >&2; exit 1; }
 
   rust-restore-build-cache:
     description: "Restore the target directory cache for a Rust workspace"

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -509,7 +509,18 @@ commands:
                   if command -v clang >/dev/null; then
                     exit 0
                   fi
-                  sudo -E apt-get update --yes
+                  export NEEDRESTART_MODE=a
+                  for i in 1 2 3; do
+                    if sudo -E apt-get -o Acquire::Retries=5 update; then
+                      break
+                    fi
+                    if [ "$i" = "3" ]; then
+                      echo "apt-get update failed after 3 attempts" >&2
+                      exit 1
+                    fi
+                    echo "apt-get update failed (attempt $i), retrying in 10s..." >&2
+                    sleep 10
+                  done
                   sudo -E apt-get install -y --no-install-recommends clang llvm-dev libclang-dev
 
   rust-restore-build-cache:
@@ -883,8 +894,18 @@ jobs:
             git submodule update --init --recursive --depth 1 -j 8 --single-branch << parameters.directory >>
 
             if [ "<< parameters.needs_clang >>" = "true" ] && ! command -v clang >/dev/null; then
-              sudo -E apt-get update --yes
-              sudo -E apt-get install -y --no-install-recommends clang
+              for i in 1 2 3; do
+                if sudo apt-get -o Acquire::Retries=5 update; then
+                  break
+                fi
+                if [ "$i" = "3" ]; then
+                  echo "apt-get update failed after 3 attempts" >&2
+                  exit 1
+                fi
+                echo "apt-get update failed (attempt $i), retrying in 10s..." >&2
+                sleep 10
+              done
+              sudo apt-get install -y --no-install-recommends clang
             fi
 
             cd << parameters.directory >> && << parameters.build_command >>

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -503,7 +503,7 @@ commands:
           steps:
             - run:
                 name: Ensure clang available
-                command: command -v clang >/dev/null 2>&1 || { echo "ERROR: clang is required but was not found in PATH" >&2; exit 1; }
+                command: 'command -v clang >/dev/null 2>&1 || { echo "ERROR: clang is required but was not found in PATH" >&2; exit 1; }'
 
   rust-restore-build-cache:
     description: "Restore the target directory cache for a Rust workspace"

--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -209,8 +209,15 @@ commands:
           condition: << parameters.needs_clang >>
           steps:
             - run:
-                name: Verify clang available (baked into c-rust_base_image)
-                command: command -v clang >/dev/null && command -v llvm-config >/dev/null
+                name: Ensure clang available
+                # Docker jobs use c-rust_base_image with clang pre-baked, so this is a no-op.
+                # Machine jobs run on bare Ubuntu VMs where clang must still be installed.
+                command: |
+                  if command -v clang >/dev/null; then
+                    exit 0
+                  fi
+                  sudo -E apt-get update --yes
+                  sudo -E apt-get install -y --no-install-recommends clang llvm-dev libclang-dev
 
   rust-restore-build-cache:
     description: "Restore the target directory cache for a Rust workspace"

--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -216,7 +216,18 @@ commands:
                   if command -v clang >/dev/null; then
                     exit 0
                   fi
-                  sudo -E apt-get update --yes
+                  export NEEDRESTART_MODE=a
+                  for i in 1 2 3; do
+                    if sudo -E apt-get -o Acquire::Retries=5 update; then
+                      break
+                    fi
+                    if [ "$i" = "3" ]; then
+                      echo "apt-get update failed after 3 attempts" >&2
+                      exit 1
+                    fi
+                    echo "apt-get update failed (attempt $i), retrying in 10s..." >&2
+                    sleep 10
+                  done
                   sudo -E apt-get install -y --no-install-recommends clang llvm-dev libclang-dev
 
   rust-restore-build-cache:

--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -210,25 +210,7 @@ commands:
           steps:
             - run:
                 name: Ensure clang available
-                # Docker jobs use c-rust_base_image with clang pre-baked, so this is a no-op.
-                # Machine jobs run on bare Ubuntu VMs where clang must still be installed.
-                command: |
-                  if command -v clang >/dev/null; then
-                    exit 0
-                  fi
-                  export NEEDRESTART_MODE=a
-                  for i in 1 2 3; do
-                    if sudo -E apt-get -o Acquire::Retries=5 update; then
-                      break
-                    fi
-                    if [ "$i" = "3" ]; then
-                      echo "apt-get update failed after 3 attempts" >&2
-                      exit 1
-                    fi
-                    echo "apt-get update failed (attempt $i), retrying in 10s..." >&2
-                    sleep 10
-                  done
-                  sudo -E apt-get install -y --no-install-recommends clang llvm-dev libclang-dev
+                command: command -v clang >/dev/null 2>&1 || { echo "ERROR: clang is required but was not found in PATH" >&2; exit 1; }
 
   rust-restore-build-cache:
     description: "Restore the target directory cache for a Rust workspace"
@@ -877,6 +859,9 @@ jobs:
       - utils/checkout-with-mise:
           checkout-method: blobless
       - install-zstd
+      - apt-install:
+          packages: "clang llvm-dev libclang-dev"
+          extra_flags: "--no-install-recommends"
       - rust-prepare
       - install-cargo-binstall
       - run:
@@ -932,6 +917,9 @@ jobs:
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
+      - apt-install:
+          packages: "clang llvm-dev libclang-dev"
+          extra_flags: "--no-install-recommends"
       - rust-prepare-and-restore-cache:
           directory: rust
           features: "all"
@@ -957,6 +945,9 @@ jobs:
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
+      - apt-install:
+          packages: "clang llvm-dev libclang-dev"
+          extra_flags: "--no-install-recommends"
       - rust-prepare
       - run:
           name: Build <<parameters.target>>
@@ -1040,6 +1031,9 @@ jobs:
           checkout-method: blobless
       - rust-install-toolchain:
           components: llvm-tools-preview
+      - apt-install:
+          packages: "clang llvm-dev libclang-dev"
+          extra_flags: "--no-install-recommends"
       - rust-prepare-and-restore-cache: &kona-publish-prestate-cache
           directory: rust
           profile: release

--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -210,7 +210,7 @@ commands:
           steps:
             - run:
                 name: Ensure clang available
-                command: command -v clang >/dev/null 2>&1 || { echo "ERROR: clang is required but was not found in PATH" >&2; exit 1; }
+                command: 'command -v clang >/dev/null 2>&1 || { echo "ERROR: clang is required but was not found in PATH" >&2; exit 1; }'
 
   rust-restore-build-cache:
     description: "Restore the target directory cache for a Rust workspace"

--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -12,6 +12,9 @@ parameters:
   c-default_docker_image:
     type: string
     default: cimg/base:2026.03
+  c-rust_base_image:
+    type: string
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-base-clang@sha256:852cb2dcd64eb5c039abf857a2217f341351eb7e4ef1a989ba9eefb86f158105
   c-base_image:
     type: string
     default: default
@@ -34,6 +37,9 @@ parameters:
   default_docker_image:
     type: string
     default: cimg/base:2026.03
+  rust_base_image:
+    type: string
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-base-clang@sha256:852cb2dcd64eb5c039abf857a2217f341351eb7e4ef1a989ba9eefb86f158105
   base_image:
     type: string
     default: default
@@ -202,9 +208,9 @@ commands:
       - when:
           condition: << parameters.needs_clang >>
           steps:
-            - apt-install:
-                packages: "clang llvm-dev libclang-dev"
-                extra_flags: "--no-install-recommends"
+            - run:
+                name: Verify clang available (baked into c-rust_base_image)
+                command: command -v clang >/dev/null && command -v llvm-config >/dev/null
 
   rust-restore-build-cache:
     description: "Restore the target directory cache for a Rust workspace"
@@ -423,7 +429,7 @@ jobs:
         type: string
         default: "just fmt-check"
     docker:
-      - image: <<pipeline.parameters.c-default_docker_image>>
+      - image: <<pipeline.parameters.c-rust_base_image>>
     resource_class: medium
     steps:
       - utils/checkout-with-mise:
@@ -452,7 +458,7 @@ jobs:
         type: string
         default: "stable"
     docker:
-      - image: <<pipeline.parameters.c-default_docker_image>>
+      - image: <<pipeline.parameters.c-rust_base_image>>
     resource_class: medium
     steps:
       - utils/checkout-with-mise:
@@ -485,7 +491,7 @@ jobs:
         type: string
         default: "cargo deny check"
     docker:
-      - image: <<pipeline.parameters.c-default_docker_image>>
+      - image: <<pipeline.parameters.c-rust_base_image>>
     resource_class: medium
     steps:
       - utils/checkout-with-mise:
@@ -515,7 +521,7 @@ jobs:
         type: string
         default: "zepter run check"
     docker:
-      - image: <<pipeline.parameters.c-default_docker_image>>
+      - image: <<pipeline.parameters.c-rust_base_image>>
     resource_class: medium
     steps:
       - utils/checkout-with-mise:
@@ -542,7 +548,7 @@ jobs:
         description: "Directory containing the Cargo workspace"
         type: string
     docker:
-      - image: <<pipeline.parameters.c-default_docker_image>>
+      - image: <<pipeline.parameters.c-rust_base_image>>
     resource_class: medium
     steps:
       - utils/checkout-with-mise:
@@ -580,7 +586,7 @@ jobs:
         type: string
         default: "just check-no-std"
     docker:
-      - image: <<pipeline.parameters.c-default_docker_image>>
+      - image: <<pipeline.parameters.c-rust_base_image>>
     resource_class: medium
     steps:
       - utils/checkout-with-mise:
@@ -609,7 +615,7 @@ jobs:
         type: string
         default: "just lint-docs"
     docker:
-      - image: <<pipeline.parameters.c-default_docker_image>>
+      - image: <<pipeline.parameters.c-rust_base_image>>
     resource_class: xlarge
     steps:
       - utils/checkout-with-mise:
@@ -636,7 +642,7 @@ jobs:
         type: string
         default: "cargo test --workspace --doc"
     docker:
-      - image: <<pipeline.parameters.c-default_docker_image>>
+      - image: <<pipeline.parameters.c-rust_base_image>>
     resource_class: xlarge
     steps:
       - utils/checkout-with-mise:
@@ -674,7 +680,7 @@ jobs:
         type: string
         default: "release"
     docker:
-      - image: <<pipeline.parameters.c-default_docker_image>>
+      - image: <<pipeline.parameters.c-rust_base_image>>
     resource_class: 2xlarge
     steps:
       - utils/checkout-with-mise:
@@ -708,7 +714,7 @@ jobs:
         type: string
         default: "just check-udeps"
     docker:
-      - image: <<pipeline.parameters.c-default_docker_image>>
+      - image: <<pipeline.parameters.c-rust_base_image>>
     resource_class: medium
     steps:
       - utils/checkout-with-mise:
@@ -743,7 +749,7 @@ jobs:
         type: string
         default: "--workspace"
     docker:
-      - image: <<pipeline.parameters.c-default_docker_image>>
+      - image: <<pipeline.parameters.c-rust_base_image>>
     resource_class: medium
     steps:
       - utils/checkout-with-mise:
@@ -771,7 +777,7 @@ jobs:
         type: integer
         default: 1
     docker:
-      - image: <<pipeline.parameters.c-default_docker_image>>
+      - image: <<pipeline.parameters.c-rust_base_image>>
     resource_class: xlarge
     parallelism: <<parameters.parallelism>>
     steps:
@@ -805,7 +811,7 @@ jobs:
   # OP-Reth compact codec backwards compatibility
   op-reth-compact-codec:
     docker:
-      - image: <<pipeline.parameters.c-default_docker_image>>
+      - image: <<pipeline.parameters.c-rust_base_image>>
     # This job frequently gets killed for smaller resource_class
     resource_class: xlarge
     steps:
@@ -944,7 +950,7 @@ jobs:
   # Kona Coverage
   kona-coverage:
     docker:
-      - image: <<pipeline.parameters.c-default_docker_image>>
+      - image: <<pipeline.parameters.c-rust_base_image>>
     resource_class: xlarge
     steps:
       - utils/checkout-with-mise:
@@ -981,7 +987,7 @@ jobs:
   # Kona Link Checker
   kona-link-checker:
     docker:
-      - image: <<pipeline.parameters.c-default_docker_image>>
+      - image: <<pipeline.parameters.c-rust_base_image>>
     resource_class: medium
     steps:
       - utils/checkout-with-mise:
@@ -1051,7 +1057,7 @@ jobs:
 
   required-rust-ci:
     docker:
-      - image: <<pipeline.parameters.c-default_docker_image>>
+      - image: <<pipeline.parameters.c-rust_base_image>>
     resource_class: small
     steps:
       - run: echo "Required Rust CI checks passed"

--- a/.circleci/continue/rust-e2e.yml
+++ b/.circleci/continue/rust-e2e.yml
@@ -10,6 +10,9 @@ parameters:
   c-default_docker_image:
     type: string
     default: cimg/base:2026.03
+  c-rust_base_image:
+    type: string
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-base-clang@sha256:852cb2dcd64eb5c039abf857a2217f341351eb7e4ef1a989ba9eefb86f158105
   c-rust_e2e_dispatch:
     type: boolean
     default: false
@@ -29,6 +32,9 @@ parameters:
   default_docker_image:
     type: string
     default: cimg/base:2026.03
+  rust_base_image:
+    type: string
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-base-clang@sha256:852cb2dcd64eb5c039abf857a2217f341351eb7e4ef1a989ba9eefb86f158105
   base_image:
     type: string
     default: default
@@ -140,7 +146,7 @@ jobs:
         type: boolean
         default: false
     docker:
-      - image: <<pipeline.parameters.c-default_docker_image>>
+      - image: <<pipeline.parameters.c-rust_base_image>>
     resource_class: xlarge
     steps:
       - utils/checkout-with-mise:
@@ -186,7 +192,7 @@ jobs:
   # Kona Node Restart Tests (from node_e2e_sysgo_tests.yaml)
   rust-restart-sysgo-tests:
     docker:
-      - image: <<pipeline.parameters.c-default_docker_image>>
+      - image: <<pipeline.parameters.c-rust_base_image>>
     resource_class: xlarge
     steps:
       - utils/checkout-with-mise:
@@ -216,7 +222,7 @@ jobs:
   # op-reth E2E Sysgo Tests
   op-reth-e2e-sysgo-tests:
     docker:
-      - image: <<pipeline.parameters.c-default_docker_image>>
+      - image: <<pipeline.parameters.c-rust_base_image>>
     resource_class: xlarge
     steps:
       - utils/checkout-with-mise:
@@ -251,7 +257,7 @@ jobs:
         description: The kind of action test (single or interop)
         type: string
     docker:
-      - image: <<pipeline.parameters.c-default_docker_image>>
+      - image: <<pipeline.parameters.c-rust_base_image>>
     resource_class: xlarge
     parallelism: 4
     steps:
@@ -282,7 +288,7 @@ jobs:
 
   required-rust-e2e:
     docker:
-      - image: <<pipeline.parameters.c-default_docker_image>>
+      - image: <<pipeline.parameters.c-rust_base_image>>
     resource_class: small
     steps:
       - run: echo "Required Rust E2E checks passed"


### PR DESCRIPTION
## Summary

- Adds a new pipeline parameter \`rust_base_image\` pinned by digest to the factory-built \`ci-base-clang\` image (\`cimg/base\` + \`clang\`/\`llvm-dev\`/\`libclang-dev\`).
- Switches Rust job executors in \`main.yml\`, \`rust-ci.yml\`, and \`rust-e2e.yml\` to use this image.
- Replaces the runtime \`apt-install clang\` step (~9 min) with a fast \`command -v clang\` verification.
- Provenance of the pinned digest will be verified by a follow-up GitHub Actions workflow (sub-issue #20122).

The \`needs_clang\` parameter is preserved everywhere, so call sites and downstream commands are unchanged. The conditional \`Verify clang\` step now substitutes for the previous install step.

## Test plan

- [ ] Wait for CircleCI to pull \`ci-base-clang@sha256:852cb2d...\` and run all Rust jobs successfully.
- [ ] Verify rust-build-binary, rust-build-submodule, rust-ci-* and rust-e2e-* jobs pass.
- [ ] Confirm \`Verify clang available\` step replaces the \`Install clang\` step in job logs.

Closes #20120