### PR TITLE
ci: route PR docker builds to tmp registry

### DIFF
--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -262,7 +262,7 @@ jobs:
       bake_file: docker-bake.hcl
       target: ${{ matrix.image_name }}
       gcp_project_id: ${{ vars.GCP_PROJECT_ID_OPLABS_TOOLS_ARTIFACTS }}
-      registry: us-docker.pkg.dev/oplabs-tools-artifacts/images
+      registry: ${{ github.event_name == 'pull_request' && 'us-docker.pkg.dev/oplabs-tools-artifacts/tmp' || 'us-docker.pkg.dev/oplabs-tools-artifacts/images' }}
       env: |
         GIT_VERSION=${{ fromJson(needs.prep.outputs.versions)[matrix.image_name] }}
       set: |
@@ -313,7 +313,7 @@ jobs:
           - ubuntu-24.04-arm
     runs-on: ${{ matrix.runner }}
     env:
-      IMAGE: ${{ needs.build-fork.result == 'success' && format('ttl.sh/{0}/{1}:24h', github.sha, matrix.image_name) || format('us-docker.pkg.dev/oplabs-tools-artifacts/images/{0}:{1}', matrix.image_name, github.sha) }}
+      IMAGE: ${{ needs.build-fork.result == 'success' && format('ttl.sh/{0}/{1}:24h', github.sha, matrix.image_name) || (github.event_name == 'pull_request' && format('us-docker.pkg.dev/oplabs-tools-artifacts/tmp/{0}:{1}', matrix.image_name, github.sha) || format('us-docker.pkg.dev/oplabs-tools-artifacts/images/{0}:{1}', matrix.image_name, github.sha)) }}
     steps:
       - name: Run image
         env:
@@ -336,7 +336,7 @@ jobs:
           - ubuntu-24.04-arm
     runs-on: ${{ matrix.runner }}
     env:
-      IMAGE: ${{ needs.build-fork.result == 'success' && format('ttl.sh/{0}/{1}:24h', github.sha, matrix.image_name) || format('us-docker.pkg.dev/oplabs-tools-artifacts/images/{0}:{1}', matrix.image_name, github.sha) }}
+      IMAGE: ${{ needs.build-fork.result == 'success' && format('ttl.sh/{0}/{1}:24h', github.sha, matrix.image_name) || (github.event_name == 'pull_request' && format('us-docker.pkg.dev/oplabs-tools-artifacts/tmp/{0}:{1}', matrix.image_name, github.sha) || format('us-docker.pkg.dev/oplabs-tools-artifacts/images/{0}:{1}', matrix.image_name, github.sha)) }}
     steps:
       - name: Run image
         run: docker run "$IMAGE" --version


### PR DESCRIPTION
## Summary

Route pull-request docker builds to a new ephemeral `tmp` Artifact Registry instead of the production `images` registry. Push-to-develop and scheduled builds still target `images`; tag/release builds (in `tags.yaml`) are unchanged.

## Test plan

- [x] Open this PR; confirm the build job pushes to `us-docker.pkg.dev/oplabs-tools-artifacts/tmp/<image>:<sha>`
- [x] Pull one of the built images and run `--version`
- [ ] After merge, confirm a `develop` push still targets `us-docker.pkg.dev/oplabs-tools-artifacts/images`

Closes #20137
