### PR TITLE
fix(contracts): skip ZKDisputeGame in VerifyOPCM when feature disabled

### DIFF
--- a/packages/contracts-bedrock/scripts/deploy/VerifyOPCM.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/VerifyOPCM.s.sol
@@ -612,6 +612,20 @@ contract VerifyOPCM is Script {
             // If feature is enabled, continue with normal verification
         }
 
+        // Check if this is a ZK dispute game that should be skipped
+        if (_isZKDisputeGameImplementation(_target.name)) {
+            if (!_isZKDisputeGameEnabled(_opcm)) {
+                if (_target.addr == address(0)) {
+                    console.log("[SKIP] ZK dispute game not deployed (feature disabled)");
+                    return true; // Consider this "verified" when feature is off
+                } else {
+                    console.log("[FAIL] ERROR: ZK dispute game deployed but feature disabled");
+                    success = false;
+                }
+            }
+            // If feature is enabled, continue with normal verification
+        }
+
         // Load artifact information (bytecode, immutable refs) for detailed comparison
         ArtifactInfo memory artifact = _loadArtifactInfo(artifactPath);
 
@@ -750,6 +764,20 @@ contract VerifyOPCM is Script {
     function _isSuperDisputeGameImplementation(string memory _contractName) internal pure returns (bool) {
         return LibString.eq(_contractName, "SuperFaultDisputeGame")
             || LibString.eq(_contractName, "SuperPermissionedDisputeGame");
+    }
+
+    /// @notice Checks if the ZK dispute game feature is enabled in the dev feature bitmap.
+    /// @param _opcm The OPContractsManager to check.
+    /// @return True if the ZK dispute game feature is enabled.
+    function _isZKDisputeGameEnabled(IOPContractsManagerV2 _opcm) internal view returns (bool) {
+        return DevFeatures.isDevFeatureEnabled(_opcm.devFeatureBitmap(), DevFeatures.ZK_DISPUTE_GAME);
+    }
+
+    /// @notice Checks if a contract is a ZK dispute game implementation.
+    /// @param _contractName The name to check.
+    /// @return True if this is a ZK dispute game.
+    function _isZKDisputeGameImplementation(string memory _contractName) internal pure returns (bool) {
+        return LibString.eq(_contractName, "ZKDisputeGame");
     }
 
     /// @notice Verifies that the immutable variables in the OPCM contract match expected values.

--- a/packages/contracts-bedrock/test/scripts/VerifyOPCM.t.sol
+++ b/packages/contracts-bedrock/test/scripts/VerifyOPCM.t.sol
@@ -142,6 +142,10 @@ abstract contract VerifyOPCM_TestInit is CommonTest {
         return DevFeatures.isDevFeatureEnabled(bitmap, DevFeatures.OPTIMISM_PORTAL_INTEROP)
             || DevFeatures.isDevFeatureEnabled(bitmap, DevFeatures.SUPER_ROOT_GAMES_MIGRATION);
     }
+
+    function zkDisputeGameEnabled() internal view returns (bool) {
+        return DevFeatures.isDevFeatureEnabled(opcm.devFeatureBitmap(), DevFeatures.ZK_DISPUTE_GAME);
+    }
 }
 
 /// @title VerifyOPCM_Run_Test
@@ -171,6 +175,11 @@ contract VerifyOPCM_Run_Test is VerifyOPCM_TestInit {
 
                 // TODO(#17262): Remove this skip once Super dispute games are no longer behind a feature flag
                 if (_isSuperDisputeGameContractRef(ref)) {
+                    continue;
+                }
+
+                // TODO: Remove this skip once ZK dispute game is no longer behind a feature flag
+                if (_isZKDisputeGameContractRef(ref)) {
                     continue;
                 }
 
@@ -221,6 +230,11 @@ contract VerifyOPCM_Run_Test is VerifyOPCM_TestInit {
 
             // Skip super dispute games when feature disabled
             if (_isSuperDisputeGameContractRef(ref) && !superGamesEnabled()) {
+                continue;
+            }
+
+            // Skip ZK dispute game when feature disabled
+            if (_isZKDisputeGameContractRef(ref) && !zkDisputeGameEnabled()) {
                 continue;
             }
 
@@ -288,6 +302,11 @@ contract VerifyOPCM_Run_Test is VerifyOPCM_TestInit {
 
             // Skip super dispute games when feature disabled
             if (_isSuperDisputeGameContractRef(ref) && !superGamesEnabled()) {
+                continue;
+            }
+
+            // Skip ZK dispute game when feature disabled
+            if (_isZKDisputeGameContractRef(ref) && !zkDisputeGameEnabled()) {
                 continue;
             }
 
@@ -504,6 +523,10 @@ contract VerifyOPCM_Run_Test is VerifyOPCM_TestInit {
 
     function _isSuperDisputeGameContractRef(VerifyOPCM.OpcmContractRef memory ref) internal pure returns (bool) {
         return LibString.eq(ref.name, "SuperFaultDisputeGame") || LibString.eq(ref.name, "SuperPermissionedDisputeGame");
+    }
+
+    function _isZKDisputeGameContractRef(VerifyOPCM.OpcmContractRef memory ref) internal pure returns (bool) {
+        return LibString.eq(ref.name, "ZKDisputeGame");
     }
 
     /// @notice Utility function to mock the first OPCM component's contractsContainer address.


### PR DESCRIPTION
## Summary

\`contracts-bedrock-tests-develop\` has been silently red on develop since #19685 (merged 2026-04-16) for 11 of 12 matrix cells. The bug surfaced as 3 failing tests in \`test/scripts/VerifyOPCM.t.sol\`:

- \`test_run_succeeds\` — \`VerifyOPCM_Failed()\`
- \`test_run_implementationDifferentInsideImmutable_succeeds\` — \`VerifyOPCM_Failed()\`
- \`test_run_implementationDifferentOutsideImmutable_reverts\` — \`panic: arithmetic underflow or overflow (0x11)\`

Reference failure: [job 4850658](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/122879/workflows/19455be2-516b-4ec3-81c3-a7f630c67ac4/jobs/4850658) (\`L2CM,CUSTOM_GAS_TOKEN\`, but same failure on any matrix cell that doesn't enable \`ZK_DISPUTE_GAME\`).

## Root cause

#19685 added \`zkDisputeGameImpl\` to \`VerifyOPCM\`'s \`fieldNameOverrides\` and \`validatorGetterChecks\` maps but forgot the corresponding skip path. When \`DEV_FEATURE__ZK_DISPUTE_GAME\` is off, OPCM returns \`zkDisputeGameImpl = address(0)\`, and \`_verifyOpcmContractRef\` treats the 0-byte deployed code vs ~13.5KB expected artifact as a verification failure. The existing \`SuperFaultDisputeGame\` / \`SuperPermissionedDisputeGame\` path has exactly this skip already.

\`test_run_implementationDifferentOutsideImmutable_reverts\` fails with \`panic 0x11\` specifically because \`vm.randomUint(0, implCode.length - 1)\` underflows when \`implCode\` for the ZK ref is empty.

## Why it wasn't caught at merge time

\`contracts-bedrock-tests-develop\` runs only on develop (post-merge) and is not part of the \`required-contracts-ci\` gate. The merge-queue-gated \`contracts-bedrock-tests\` (PR variant) uses the \`liteci\` profile which exercises a reduced matrix — not the same set this fails in.

## Fix

Two-part, mirrors the existing \`SuperDisputeGame\` skip pattern:

1. **\`scripts/deploy/VerifyOPCM.s.sol\`** — adds a ZK skip branch in \`_verifyOpcmContractRef\` plus \`_isZKDisputeGameEnabled(_opcm)\` / \`_isZKDisputeGameImplementation(name)\` helpers.
2. **\`test/scripts/VerifyOPCM.t.sol\`** — adds \`zkDisputeGameEnabled()\` + \`_isZKDisputeGameContractRef()\` and:
   - Skips the ZK ref in both random-byte loops when the feature is off (so \`implCode.length == 0\` doesn't underflow).
   - Unconditionally skips ZK in \`test_runSingle_succeeds\` (matches the existing \`TODO(#17262)\` super-games skip — \`runSingle\` passes \`address(0)\` as opcm, which would make the feature-bitmap call revert).

## Verification

Ran the full \`VerifyOPCM_Run_Test\` suite (15 tests) locally against four matrix cells before the fix would fail and after it:

| Env | Before | After |
|---|---|---|
| \`main\` | 3 FAIL / 12 PASS | 15 PASS |
| \`L2CM,CUSTOM_GAS_TOKEN\` | 3 FAIL / 12 PASS | 15 PASS |
| \`OPCM_V2,OPTIMISM_PORTAL_INTEROP\` (super games enabled) | 3 FAIL / 12 PASS | 15 PASS |
| \`OPCM_V2,ZK_DISPUTE_GAME\` | 15 PASS | 15 PASS |

\`just pr\` (\`check-fast\`) passes locally — all 16 checks.

## Test plan

- [ ] CI green on this PR, including \`contracts-bedrock-tests\` across the matrix.
- [ ] After merge: confirm \`contracts-bedrock-tests-develop\` is green on develop for non-ZK matrix cells.
- [ ] Follow-up worth considering: add \`required-contracts-ci\` terminal-require on at least one \`-develop\` matrix cell (or a dedicated smoke) so this class of regression can't silently live on develop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)