### PR TITLE
test(contracts): skip VerifyOPCM_Run_Test on coverage only, not unoptimized

### DIFF
--- a/packages/contracts-bedrock/scripts/deploy/VerifyOPCM.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/VerifyOPCM.s.sol
@@ -612,6 +612,20 @@ contract VerifyOPCM is Script {
             // If feature is enabled, continue with normal verification
         }
 
+        // Check if this is a ZK dispute game that should be skipped
+        if (_isZKDisputeGameImplementation(_target.name)) {
+            if (!_isZKDisputeGameEnabled(_opcm)) {
+                if (_target.addr == address(0)) {
+                    console.log("[SKIP] ZK dispute game not deployed (feature disabled)");
+                    return true; // Consider this "verified" when feature is off
+                } else {
+                    console.log("[FAIL] ERROR: ZK dispute game deployed but feature disabled");
+                    success = false;
+                }
+            }
+            // If feature is enabled, continue with normal verification
+        }
+
         // Load artifact information (bytecode, immutable refs) for detailed comparison
         ArtifactInfo memory artifact = _loadArtifactInfo(artifactPath);
 
@@ -750,6 +764,20 @@ contract VerifyOPCM is Script {
     function _isSuperDisputeGameImplementation(string memory _contractName) internal pure returns (bool) {
         return LibString.eq(_contractName, "SuperFaultDisputeGame")
             || LibString.eq(_contractName, "SuperPermissionedDisputeGame");
+    }
+
+    /// @notice Checks if the ZK dispute game feature is enabled in the dev feature bitmap.
+    /// @param _opcm The OPContractsManager to check.
+    /// @return True if the ZK dispute game feature is enabled.
+    function _isZKDisputeGameEnabled(IOPContractsManagerV2 _opcm) internal view returns (bool) {
+        return DevFeatures.isDevFeatureEnabled(_opcm.devFeatureBitmap(), DevFeatures.ZK_DISPUTE_GAME);
+    }
+
+    /// @notice Checks if a contract is a ZK dispute game implementation.
+    /// @param _contractName The name to check.
+    /// @return True if this is a ZK dispute game.
+    function _isZKDisputeGameImplementation(string memory _contractName) internal pure returns (bool) {
+        return LibString.eq(_contractName, "ZKDisputeGame");
     }
 
     /// @notice Verifies that the immutable variables in the OPCM contract match expected values.

--- a/packages/contracts-bedrock/test/scripts/VerifyOPCM.t.sol
+++ b/packages/contracts-bedrock/test/scripts/VerifyOPCM.t.sol
@@ -142,6 +142,10 @@ abstract contract VerifyOPCM_TestInit is CommonTest {
         return DevFeatures.isDevFeatureEnabled(bitmap, DevFeatures.OPTIMISM_PORTAL_INTEROP)
             || DevFeatures.isDevFeatureEnabled(bitmap, DevFeatures.SUPER_ROOT_GAMES_MIGRATION);
     }
+
+    function zkDisputeGameEnabled() internal view returns (bool) {
+        return DevFeatures.isDevFeatureEnabled(opcm.devFeatureBitmap(), DevFeatures.ZK_DISPUTE_GAME);
+    }
 }
 
 /// @title VerifyOPCM_Run_Test
@@ -171,6 +175,11 @@ contract VerifyOPCM_Run_Test is VerifyOPCM_TestInit {
 
                 // TODO(#17262): Remove this skip once Super dispute games are no longer behind a feature flag
                 if (_isSuperDisputeGameContractRef(ref)) {
+                    continue;
+                }
+
+                // TODO: Remove this skip once ZK dispute game is no longer behind a feature flag
+                if (_isZKDisputeGameContractRef(ref)) {
                     continue;
                 }
 
@@ -221,6 +230,11 @@ contract VerifyOPCM_Run_Test is VerifyOPCM_TestInit {
 
             // Skip super dispute games when feature disabled
             if (_isSuperDisputeGameContractRef(ref) && !superGamesEnabled()) {
+                continue;
+            }
+
+            // Skip ZK dispute game when feature disabled
+            if (_isZKDisputeGameContractRef(ref) && !zkDisputeGameEnabled()) {
                 continue;
             }
 
@@ -288,6 +302,11 @@ contract VerifyOPCM_Run_Test is VerifyOPCM_TestInit {
 
             // Skip super dispute games when feature disabled
             if (_isSuperDisputeGameContractRef(ref) && !superGamesEnabled()) {
+                continue;
+            }
+
+            // Skip ZK dispute game when feature disabled
+            if (_isZKDisputeGameContractRef(ref) && !zkDisputeGameEnabled()) {
                 continue;
             }
 
@@ -504,6 +523,10 @@ contract VerifyOPCM_Run_Test is VerifyOPCM_TestInit {
 
     function _isSuperDisputeGameContractRef(VerifyOPCM.OpcmContractRef memory ref) internal pure returns (bool) {
         return LibString.eq(ref.name, "SuperFaultDisputeGame") || LibString.eq(ref.name, "SuperPermissionedDisputeGame");
+    }
+
+    function _isZKDisputeGameContractRef(VerifyOPCM.OpcmContractRef memory ref) internal pure returns (bool) {
+        return LibString.eq(ref.name, "ZKDisputeGame");
     }
 
     /// @notice Utility function to mock the first OPCM component's contractsContainer address.

--- a/packages/contracts-bedrock/test/scripts/VerifyOPCM.t.sol
+++ b/packages/contracts-bedrock/test/scripts/VerifyOPCM.t.sol
@@ -157,7 +157,11 @@ contract VerifyOPCM_Run_Test is VerifyOPCM_TestInit {
 
     /// @notice Tests that the script succeeds when no changes are introduced.
     function test_run_succeeds() public {
-        skipIfUnoptimized();
+        // Coverage instrumentation would break the bytecode comparison because the artifact
+        // on disk is not instrumented. The optimizer setting does not matter: both the
+        // deployed code and the artifact come from the same local compile, so they move
+        // together under any Foundry profile.
+        skipIfCoverage();
 
         // Run the script.
         harness.run(address(opcm), true);
@@ -214,7 +218,8 @@ contract VerifyOPCM_Run_Test is VerifyOPCM_TestInit {
     ///         variables of implementation contracts. Fuzzing is too slow here, randomness is good
     ///         enough.
     function test_run_implementationDifferentInsideImmutable_succeeds() public {
-        skipIfUnoptimized();
+        // See test_run_succeeds for why this is coverage-only, not unoptimized-wide.
+        skipIfCoverage();
 
         // Skip security value checks since this test deliberately corrupts immutable values.
         harness.setSkipSecurityValueChecks(true);
@@ -286,7 +291,8 @@ contract VerifyOPCM_Run_Test is VerifyOPCM_TestInit {
     ///         implementation contracts that are not inside immutable references. Fuzzing is too
     ///         slow here, randomness is good enough.
     function test_run_implementationDifferentOutsideImmutable_reverts() public {
-        skipIfUnoptimized();
+        // See test_run_succeeds for why this is coverage-only, not unoptimized-wide.
+        skipIfCoverage();
 
         // Skip security value checks since corrupted bytecode may break contract queries.
         harness.setSkipSecurityValueChecks(true);

--- a/packages/contracts-bedrock/test/setup/Setup.sol
+++ b/packages/contracts-bedrock/test/setup/Setup.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.15;
 
 // Testing
 import { console2 as console } from "forge-std/console2.sol";
-import { Vm } from "forge-std/Vm.sol";
+import { Vm, VmSafe } from "forge-std/Vm.sol";
 import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 import { FeatureFlags } from "test/setup/FeatureFlags.sol";
 import { DisputeGames } from "test/setup/DisputeGames.sol";
@@ -240,6 +240,18 @@ abstract contract Setup is FeatureFlags {
     ///      bytecode verification tests, and any test sensitive to compiler output.
     function skipIfUnoptimized() public {
         if (Config.isUnoptimized()) {
+            vm.skip(true);
+        }
+    }
+
+    /// @dev Skips tests only under coverage mode, where Foundry injects instrumentation
+    ///      opcodes that change deployed bytecode relative to the compiled artifact.
+    ///      Prefer this over skipIfUnoptimized() for tests that compare locally-compiled
+    ///      bytecode to locally-compiled artifacts: both sides move together across
+    ///      optimized/unoptimized profiles, but coverage instrumentation breaks the
+    ///      comparison because the artifact on disk is not instrumented.
+    function skipIfCoverage() public {
+        if (vm.isContext(VmSafe.ForgeContext.Coverage)) {
             vm.skip(true);
         }
     }


### PR DESCRIPTION
## Summary

Narrows the skip condition on three \`VerifyOPCM_Run_Test\` tests from \`skipIfUnoptimized()\` to a new \`skipIfCoverage()\` helper. This lets the PR-level \`contracts-bedrock-tests\` run (which uses \`FOUNDRY_PROFILE=liteci\`) actually exercise \`VerifyOPCM\` instead of skipping it — closing the gap that let the \`ZKDisputeGame\` regression in #19685 sit red on develop for a day before anyone noticed (the symptom #20140 fixes).

**Stacked on [#20140](https://github.com/ethereum-optimism/optimism/pull/20140).** Merge that first — otherwise the un-skipped \`test_run_succeeds\` goes red on this PR's own \`liteci\` run for every non-ZK matrix cell.

## Why the current skip is wrong for these tests

These three tests compare a deployed address's code to a compiled artifact on disk. Both sides come from the same local compile, so the comparison holds under **any** optimizer setting — optimized or not. The only thing that genuinely breaks the comparison is **coverage mode**, which instruments the deployed code but not the artifact on disk.

That's how the original code read:

\`\`\`solidity
function test_run_succeeds() public {
    skipIfCoverage();
    ...
}
\`\`\`

PR #19332 introduced the \`liteci\` profile and unified all \`skipIfCoverage()\` into \`skipIfUnoptimized()\` via a mechanical rename across ~10 sites in this file. That rename is correct for gas-measurement tests and fork tests that depend on mainnet CREATE2 addresses — both of which genuinely differ under an unoptimized profile. But it's wrong for \`VerifyOPCM_Run_Test\`: nothing about these tests cares whether the optimizer ran.

Verified empirically by temporarily removing \`skipIfUnoptimized()\` from all three and running under \`FOUNDRY_PROFILE=liteci\` — every ref shows \`[OK] Exact Match\` and the suite passes.

## Changes

- \`test/setup/Setup.sol\`: add \`skipIfCoverage()\` back as a distinct helper (just wraps \`vm.isContext(VmSafe.ForgeContext.Coverage)\`). \`skipIfUnoptimized()\` is unchanged.
- \`test/scripts/VerifyOPCM.t.sol\`: swap \`skipIfUnoptimized()\` → \`skipIfCoverage()\` on \`test_run_succeeds\`, \`test_run_implementationDifferentInsideImmutable_succeeds\`, \`test_run_implementationDifferentOutsideImmutable_reverts\`, with a one-line comment at each site explaining why coverage is the only compiler-output dependency.

The other \`skipIfUnoptimized()\` calls in this file (and elsewhere) are left alone. Some of them genuinely depend on optimized bytecode (immutable-variable layout tests, preimage-oracle checks with fixed selectors). Worth auditing separately if/when anyone wants to widen the PR coverage further.

## Effect on CI

After this + #20140 land:

- \`contracts-bedrock-tests\` (PR, \`liteci\`) **will** exercise \`VerifyOPCM_Run_Test\`. A future feature-gated-ref miss like #19685 fails the PR, not develop.
- \`contracts-bedrock-tests-develop\` (\`ci\`) continues to do so at full fidelity.
- \`contracts-bedrock-coverage\` (\`cicoverage\`) continues to skip these tests via \`skipIfCoverage\`.

## Verification

- All 15 tests in \`VerifyOPCM_Run_Test\` pass locally under \`FOUNDRY_PROFILE=liteci\`, including the three now gated only by coverage.
- \`just pr\` (\`check-fast\`, 16 checks) green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)