### PR TITLE
fix(interopgen): use `InteropOffset` when setting Interop genesis flags

### DIFF
--- a/op-chain-ops/interopgen/deploy.go
+++ b/op-chain-ops/interopgen/deploy.go
@@ -369,8 +369,8 @@ func GenesisL2(l2Host *script.Host, cfg *L2Config, deployment *L2Deployment, mul
 		GasPayingTokenSymbol:                     cfg.GasPayingTokenSymbol,
 		NativeAssetLiquidityAmount:               cfg.NativeAssetLiquidityAmount.ToInt(),
 		LiquidityControllerOwner:                 cfg.LiquidityControllerOwner,
-		DevFeatureBitmap:                         devFeatureBitmapForL2Genesis(multichainDepSet), // TODO(#19102): add support for L2CM
-		UseInterop:                               multichainDepSet,
+		DevFeatureBitmap:                         devFeatureBitmapForL2Genesis(multichainDepSet && interopAtGenesis(cfg.L2GenesisInteropTimeOffset)), // TODO(#19102): add support for L2CM
+		UseInterop:                               multichainDepSet && interopAtGenesis(cfg.L2GenesisInteropTimeOffset),
 	}); err != nil {
 		return fmt.Errorf("failed L2 genesis: %w", err)
 	}
@@ -378,12 +378,18 @@ func GenesisL2(l2Host *script.Host, cfg *L2Config, deployment *L2Deployment, mul
 	return nil
 }
 
-// devFeatureBitmapForL2Genesis returns the dev feature bitmap for the L2 genesis based on the multichain deployment set.
-// If the multichain deployment set is true, the dev feature bitmap will be the OptimismPortalInteropDevFlag.
-func devFeatureBitmapForL2Genesis(multichainDepSet bool) common.Hash {
+// interopAtGenesis returns true if the Interop fork is scheduled to activate at genesis.
+// Using a nil offset means Interop is not scheduled at all.
+func interopAtGenesis(interopOffset *hexutil.Uint64) bool {
+	return interopOffset != nil && *interopOffset == 0
+}
+
+// devFeatureBitmapForL2Genesis returns the dev feature bitmap for the L2 genesis based on whether Interop should be
+// enabled or not.
+func devFeatureBitmapForL2Genesis(enableInterop bool) common.Hash {
 	// TODO(#19102): add support for L2CM
 	var bitmap common.Hash
-	if multichainDepSet {
+	if enableInterop {
 		bitmap = devfeatures.EnableDevFeature(bitmap, devfeatures.OptimismPortalInteropFlag)
 	}
 	return bitmap

--- a/op-chain-ops/interopgen/deploy_test.go
+++ b/op-chain-ops/interopgen/deploy_test.go
@@ -1,0 +1,38 @@
+package interopgen
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInteropAtGenesis(t *testing.T) {
+	zero := hexutil.Uint64(0)
+	nonzero := hexutil.Uint64(24)
+
+	tests := []struct {
+		name   string
+		offset *hexutil.Uint64
+		want   bool
+	}{
+		{"nil offset: Interop not scheduled", nil, false},
+		{"zero offset: Interop active at genesis", &zero, true},
+		{"non-zero offset: Interop delayed activation", &nonzero, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, interopAtGenesis(tt.offset))
+		})
+	}
+}
+
+// devFeatureBitmapForL2Genesis sets the OptimismPortalInteropFlag when interop is enabled.
+// Verify the bitmap differs between enabled and disabled states.
+func TestDevFeatureBitmapForL2Genesis(t *testing.T) {
+	enabled := devFeatureBitmapForL2Genesis(true)
+	disabled := devFeatureBitmapForL2Genesis(false)
+	require.NotEqual(t, enabled, disabled, "bitmap should differ when interop is enabled vs disabled")
+	require.True(t, disabled == (common.Hash{}), "disabled bitmap should be zero")
+}


### PR DESCRIPTION
## Summary
`GenesisL2` was enabling `UseInterop` and `OptimismPortalInteropFlag` based entirely on whether the world had more than one chain. This caused `L2Genesis.s.sol` to reject the configuration with `L2Genesis_InvalidInteropConfig` whenever `InteropOffset > 0`, because the fork number at genesis would be pre-Interop while both flags were set.

## Changes
- Gate both flags on `multichainDepSet && interopOffset == 0`. Interop will only be enabled at genesis if it's actually scheduled to activate.

Closes #20079 