### PR TITLE
feat(op-reth): register eth_config RPC endpoint

### DIFF
--- a/rust/op-reth/crates/node/src/node.rs
+++ b/rust/op-reth/crates/node/src/node.rs
@@ -52,8 +52,12 @@ use reth_optimism_rpc::{
 };
 use reth_optimism_storage::OpStorage;
 use reth_optimism_txpool::{OpPool, OpPooledTx, supervisor::SupervisorClient};
+use reth_primitives_traits::header::HeaderMut;
 use reth_provider::{CanonStateSubscriptions, providers::ProviderFactoryBuilder};
-use reth_rpc_api::{DebugApiServer, L2EthApiExtServer, eth::RpcTypes};
+use reth_rpc_api::{
+    DebugApiServer, EthConfigApiServer, L2EthApiExtServer,
+    eth::{RpcTypes, helpers::config::EthConfigHandler},
+};
 use reth_rpc_server_types::RethRpcModule;
 use reth_tracing::tracing::{debug, info};
 use reth_transaction_pool::{
@@ -590,7 +594,10 @@ impl<N, EthB, PVB, EB, EVB, RpcMiddleware> NodeAddOns<N>
     for OpAddOns<N, EthB, PVB, EB, EVB, RpcMiddleware>
 where
     N: FullNodeComponents<
-            Types: NodeTypes<ChainSpec: OpHardforks, Primitives: OpPayloadPrimitives>,
+            Types: NodeTypes<
+                ChainSpec: OpHardforks + Hardforks,
+                Primitives: OpPayloadPrimitives<_Header: HeaderMut>,
+            >,
             Evm: ConfigureEvm<
                 NextBlockEnvCtx: BuildNextEnv<
                     OpPayloadBuilderAttributes<TxTy<N::Types>>,
@@ -622,6 +629,9 @@ where
             historical_rpc,
             ..
         } = self;
+
+        let eth_config =
+            EthConfigHandler::new(ctx.node.provider().clone(), ctx.node.evm_config().clone());
 
         let maybe_pre_bedrock_historical_rpc = historical_rpc
             .and_then(|historical_rpc| {
@@ -676,6 +686,8 @@ where
                 let reth_node_builder::rpc::RpcModuleContainer { modules, auth_module, registry } =
                     container;
 
+                modules.merge_if_module_configured(RethRpcModule::Eth, eth_config.into_rpc())?;
+
                 debug!(target: "reth::cli", "Installing debug payload witness rpc endpoint");
                 modules.merge_if_module_configured(RethRpcModule::Debug, debug_ext.into_rpc())?;
 
@@ -715,7 +727,10 @@ impl<N, EthB, PVB, EB, EVB, RpcMiddleware> RethRpcAddOns<N>
     for OpAddOns<N, EthB, PVB, EB, EVB, RpcMiddleware>
 where
     N: FullNodeComponents<
-            Types: NodeTypes<ChainSpec: OpHardforks, Primitives: OpPayloadPrimitives>,
+            Types: NodeTypes<
+                ChainSpec: OpHardforks + Hardforks,
+                Primitives: OpPayloadPrimitives<_Header: HeaderMut>,
+            >,
             Evm: ConfigureEvm<
                 NextBlockEnvCtx: BuildNextEnv<
                     OpPayloadBuilderAttributes<TxTy<N::Types>>,

--- a/rust/op-reth/crates/node/tests/it/rpc.rs
+++ b/rust/op-reth/crates/node/tests/it/rpc.rs
@@ -1,5 +1,6 @@
 //! RPC integration tests.
 
+use reth_chainspec::EthChainSpec;
 use reth_network::types::NatResolver;
 use reth_node_builder::{NodeBuilder, NodeHandle};
 use reth_node_core::{
@@ -8,7 +9,7 @@ use reth_node_core::{
 };
 use reth_optimism_chainspec::BASE_MAINNET;
 use reth_optimism_node::OpNode;
-use reth_rpc_api::servers::AdminApiServer;
+use reth_rpc_api::{EthConfigApiClient, servers::AdminApiServer};
 use reth_tasks::Runtime;
 
 // <https://github.com/paradigmxyz/reth/issues/19765>
@@ -38,6 +39,32 @@ async fn test_admin_external_ip() -> eyre::Result<()> {
     let info = api.node_info().await.unwrap();
 
     assert_eq!(info.ip, external_ip);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_eth_config_endpoint_exists() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let exec = Runtime::test();
+
+    // Node setup
+    let network = BASE_MAINNET.clone();
+    let mut network_args = NetworkArgs::default().with_unused_ports();
+    network_args.discovery.discv5_port = 0;
+    network_args.discovery.discv5_port_ipv6 = 0;
+    let node_config = NodeConfig::test()
+        .map_chain(network.clone())
+        .with_network(network_args)
+        .with_rpc(RpcServerArgs::default().with_unused_ports().with_http());
+
+    let NodeHandle { node, node_exit_future: _ } =
+        NodeBuilder::new(node_config).testing_node(exec).node(OpNode::default()).launch().await?;
+
+    let client = node.add_ons_handle.rpc_server_handles().rpc.http_client().unwrap();
+    let config = client.config().await?;
+    assert_eq!(config.current.chain_id, network.clone().chain_id());
 
     Ok(())
 }

--- a/rust/op-reth/examples/custom-node/src/primitives/header.rs
+++ b/rust/op-reth/examples/custom-node/src/primitives/header.rs
@@ -2,7 +2,7 @@ use alloy_consensus::Header;
 use alloy_primitives::{Address, B64, B256, BlockNumber, Bloom, Bytes, Sealable, U256};
 use alloy_rlp::{Encodable, RlpDecodable, RlpEncodable};
 use reth_codecs::Compact;
-use reth_primitives_traits::{BlockHeader, InMemorySize};
+use reth_primitives_traits::{BlockHeader, InMemorySize, header::HeaderMut};
 use revm_primitives::keccak256;
 use serde::{Deserialize, Serialize};
 
@@ -32,6 +32,28 @@ pub struct CustomHeader {
     pub inner: Header,
     /// The extended header
     pub extension: u64,
+}
+
+impl HeaderMut for CustomHeader {
+    fn set_parent_hash(&mut self, hash: alloy_primitives::BlockHash) {
+        self.inner.parent_hash = hash;
+    }
+
+    fn set_block_number(&mut self, number: BlockNumber) {
+        self.inner.number = number;
+    }
+
+    fn set_timestamp(&mut self, timestamp: u64) {
+        self.inner.timestamp = timestamp;
+    }
+
+    fn set_state_root(&mut self, state_root: B256) {
+        self.inner.state_root = state_root;
+    }
+
+    fn set_difficulty(&mut self, difficulty: U256) {
+        self.inner.difficulty = difficulty;
+    }
 }
 
 impl From<Header> for CustomHeader {


### PR DESCRIPTION
Wire EthConfigHandler into OpAddOns so the eth_config method (EIP-7910) is served on the eth namespace. Extend the generic bounds on the NodeAddOns and RethRpcAddOns impls to satisfy EthConfigHandler::new: ChainSpec must also implement Hardforks (OpHardforks only implies EthereumHardforks), and the primitives' header must implement HeaderMut so per-fork configs can be built by cloning and retiming the latest header.

Implement HeaderMut for the custom-node example's CustomHeader so the example keeps compiling.

Add an integration test in crates/node/tests/it/rpc.rs that launches an OpNode against BASE_MAINNET and calls eth_config via the jsonrpsee HTTP client, verifying the endpoint is wired up.