### PR TITLE
test(oat): unmark TestPreinteropFaultProofs_VariedBlockTimes as flaky

### DIFF
--- a/op-acceptance-tests/tests/isthmus/preinterop/interop_fault_proofs_test.go
+++ b/op-acceptance-tests/tests/isthmus/preinterop/interop_fault_proofs_test.go
@@ -30,9 +30,6 @@ func TestPreinteropFaultProofs_UnsafeProposal(gt *testing.T) {
 
 func TestPreinteropFaultProofs_VariedBlockTimes(gt *testing.T) {
 	t := devtest.SerialT(gt)
-	// TODO(#19828): endTimestamp may align with a no-op transition for the slower chain,
-	// causing kona to skip the L1 data sufficiency check.
-	t.MarkFlaky("ethereum-optimism/optimism#19828")
 	sys := presets.NewSimpleInteropIsthmusSuper(
 		t,
 		presets.WithChallengerCannonKonaEnabled(),
@@ -46,9 +43,6 @@ func TestPreinteropFaultProofs_VariedBlockTimes(gt *testing.T) {
 
 func TestPreinteropFaultProofs_VariedBlockTimes_FasterChainB(gt *testing.T) {
 	t := devtest.SerialT(gt)
-	// TODO(#19828): endTimestamp may align with a no-op transition for the slower chain,
-	// causing kona to skip the L1 data sufficiency check.
-	t.MarkFlaky("ethereum-optimism/optimism#19828")
 	sys := presets.NewSimpleInteropIsthmusSuper(
 		t,
 		presets.WithChallengerCannonKonaEnabled(),


### PR DESCRIPTION
## Summary

Removes `MarkFlaky("ethereum-optimism/optimism#19828")` from:

- `TestPreinteropFaultProofs_VariedBlockTimes`
- `TestPreinteropFaultProofs_VariedBlockTimes_FasterChainB`

The associated TODO comment referencing the flaky condition is removed along with the `MarkFlaky` call.

## Test plan

- [x] Local 15x sweep of both tests — 15/15 passes each (30 total runs, 0 failures)
- [x] CI green (apart from the unrelated `prep` GHA job, which fails because mise cannot resolve `just v1.46.0` from GitHub releases — being investigated separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #19828 