### PR TITLE
chore(op-acceptance-tests): allow overriding -count and -timeout in just test

### DIFF
--- a/op-acceptance-tests/justfile
+++ b/op-acceptance-tests/justfile
@@ -30,11 +30,26 @@ build-deps:
     just build-rust-release
 
 # Run specific acceptance tests. Builds dependencies first, then passes all arguments to go test.
+# Defaults `-count=1` and `-timeout 30m` are applied only when not already set in args,
+# so callers can override either (e.g. `just test -count=10 -run TestFoo ./...`).
 # Examples:
 #   just test ./op-acceptance-tests/tests/base/...
 #   just test -run TestMyTest ./op-acceptance-tests/tests/base/
+#   just test -count=10 -run TestMyTest ./op-acceptance-tests/tests/base/
 test *args: build-deps
-    cd {{REPO_ROOT}} && go test -count=1 -timeout 30m {{args}}
+    #!/usr/bin/env bash
+    set -euo pipefail
+    cd {{REPO_ROOT}}
+    flags=()
+    case " {{args}} " in
+        *" -count="*|*" -count "*) ;;
+        *) flags+=(-count=1) ;;
+    esac
+    case " {{args}} " in
+        *" -timeout="*|*" -timeout "*) ;;
+        *) flags+=(-timeout 30m) ;;
+    esac
+    exec go test "${flags[@]}" {{args}}
 
 # Run acceptance tests
 acceptance-test:


### PR DESCRIPTION
## Summary

The `just test` recipe in `op-acceptance-tests/justfile` hardcoded `-count=1 -timeout 30m`, which blocked callers from requesting e.g. repeated runs with `-count=10` for flake triage. With this change the defaults are applied only when the flag is absent from the forwarded args, so callers can override either.

```bash
just test -count=10 -run TestMyTest ./op-acceptance-tests/tests/base/
just test -timeout 1h ./op-acceptance-tests/tests/...
```

## Test plan

- [x] `just --show test` prints the updated recipe
- [ ] Verify the default path still applies `-count=1 -timeout 30m` when no args are passed
- [ ] Verify a `-count=N` override is respected

🤖 Generated with [Claude Code](https://claude.com/claude-code)