### PR TITLE
fix(kona): pass block timestamp to is_interop_active instead of block number

### DIFF
--- a/rust/kona/crates/proof/driver/src/core.rs
+++ b/rust/kona/crates/proof/driver/src/core.rs
@@ -240,7 +240,8 @@ where
 
                     // If we are in interop mode, this error must be handled by the caller.
                     // Otherwise, we continue the loop to halt derivation on the next iteration.
-                    if cfg.is_interop_active(self.cursor.read().l2_safe_head().block_info.number) {
+                    if cfg.is_interop_active(self.cursor.read().l2_safe_head().block_info.timestamp)
+                    {
                         return Err(PipelineError::EndOfSource.crit().into());
                     }
                     continue;


### PR DESCRIPTION
## Summary

- Fix incorrect argument passed to `is_interop_active()` in kona proof driver — was passing `block_info.number` (block number) instead of `block_info.timestamp`
- Since block numbers are always smaller than timestamps, interop was never detected as active, causing `EndOfSource` errors to be silently swallowed instead of propagated

## Context

Fixes ethereum-optimism/optimism-private#490. The only other call site (`actor.rs`) already correctly uses `.timestamp`.

Moved from ethereum-optimism/optimism-private#522 to the public repo and rebased on latest develop.

## Test plan

- [x] `cargo check -p kona-driver` compiles cleanly
- [x] `cargo test -p kona-driver` passes
- [ ] Needs integration test that activates interop after genesis with a proposal unsupported by batch data on L1

🤖 Generated with [Claude Code](https://claude.com/claude-code)