### PR TITLE
fix(kona): send block hash instead of block number in L2 account proof hints

### DIFF
--- a/rust/kona/bin/host/src/interop/handler.rs
+++ b/rust/kona/bin/host/src/interop/handler.rs
@@ -369,25 +369,26 @@ impl HintHandler for InteropHintHandler {
                 kv_write_lock.set(PreimageKey::new_keccak256(*hash).into(), preimage.into())?;
             }
             HintType::L2AccountProof => {
-                // Backwards compatibility: accept both old (8+20+8=36 byte) and new
-                // (32+20+8=60 byte) formats. Old prestates send an 8-byte block number;
-                // new prestates send a 32-byte block hash. A single kona-host version
-                // serves all games.
+                // Backwards compatibility: old prestates send an 8-byte block number; new
+                // prestates send a 32-byte block hash. A single kona-host version serves all
+                // games.
+                const BLOCK_NUMBER_HINT_LEN: usize = 8 + 20 + 8;
+                const BLOCK_HASH_HINT_LEN: usize = 32 + 20 + 8;
                 let (block_id, address, chain_id) = match hint.data.len() {
-                    36 => {
+                    BLOCK_NUMBER_HINT_LEN => {
                         let block_number = u64::from_be_bytes(hint.data.as_ref()[..8].try_into()?);
                         let address = Address::from_slice(&hint.data.as_ref()[8..28]);
                         let chain_id = u64::from_be_bytes(hint.data.as_ref()[28..36].try_into()?);
                         (block_number.into(), address, chain_id)
                     }
-                    60 => {
+                    BLOCK_HASH_HINT_LEN => {
                         let block_hash = B256::from_slice(&hint.data.as_ref()[..32]);
                         let address = Address::from_slice(&hint.data.as_ref()[32..52]);
                         let chain_id = u64::from_be_bytes(hint.data.as_ref()[52..60].try_into()?);
                         (block_hash.into(), address, chain_id)
                     }
                     other => anyhow::bail!(
-                        "Invalid L2AccountProof hint length: expected 36 or 60, got {other}"
+                        "Invalid L2AccountProof hint length: expected {BLOCK_NUMBER_HINT_LEN} or {BLOCK_HASH_HINT_LEN}, got {other}"
                     ),
                 };
 
@@ -407,17 +408,20 @@ impl HintHandler for InteropHintHandler {
                 })?;
             }
             HintType::L2AccountStorageProof => {
-                // Backwards compatibility: accept both old (8+20+32+8=68 byte) and new
-                // (32+20+32+8=92 byte) formats. See L2AccountProof for details.
+                // Backwards compatibility: old prestates send an 8-byte block number; new
+                // prestates send a 32-byte block hash. A single kona-host version serves all
+                // games.
+                const BLOCK_NUMBER_HINT_LEN: usize = 8 + 20 + 32 + 8;
+                const BLOCK_HASH_HINT_LEN: usize = 32 + 20 + 32 + 8;
                 let (block_id, address, slot, chain_id) = match hint.data.len() {
-                    68 => {
+                    BLOCK_NUMBER_HINT_LEN => {
                         let block_number = u64::from_be_bytes(hint.data.as_ref()[..8].try_into()?);
                         let address = Address::from_slice(&hint.data.as_ref()[8..28]);
                         let slot = B256::from_slice(&hint.data.as_ref()[28..60]);
                         let chain_id = u64::from_be_bytes(hint.data.as_ref()[60..68].try_into()?);
                         (block_number.into(), address, slot, chain_id)
                     }
-                    92 => {
+                    BLOCK_HASH_HINT_LEN => {
                         let block_hash = B256::from_slice(&hint.data.as_ref()[..32]);
                         let address = Address::from_slice(&hint.data.as_ref()[32..52]);
                         let slot = B256::from_slice(&hint.data.as_ref()[52..84]);
@@ -425,7 +429,7 @@ impl HintHandler for InteropHintHandler {
                         (block_hash.into(), address, slot, chain_id)
                     }
                     other => anyhow::bail!(
-                        "Invalid L2AccountStorageProof hint length: expected 68 or 92, got {other}"
+                        "Invalid L2AccountStorageProof hint length: expected {BLOCK_NUMBER_HINT_LEN} or {BLOCK_HASH_HINT_LEN}, got {other}"
                     ),
                 };
 

--- a/rust/kona/bin/host/src/interop/handler.rs
+++ b/rust/kona/bin/host/src/interop/handler.rs
@@ -369,16 +369,32 @@ impl HintHandler for InteropHintHandler {
                 kv_write_lock.set(PreimageKey::new_keccak256(*hash).into(), preimage.into())?;
             }
             HintType::L2AccountProof => {
-                ensure!(hint.data.len() == 8 + 20 + 8, "Invalid hint data length");
-
-                let block_number = u64::from_be_bytes(hint.data.as_ref()[..8].try_into()?);
-                let address = Address::from_slice(&hint.data.as_ref()[8..28]);
-                let chain_id = u64::from_be_bytes(hint.data[28..].try_into()?);
+                // Backwards compatibility: accept both old (8+20+8=36 byte) and new
+                // (32+20+8=60 byte) formats. Old prestates send an 8-byte block number;
+                // new prestates send a 32-byte block hash. A single kona-host version
+                // serves all games.
+                let (block_id, address, chain_id) = match hint.data.len() {
+                    36 => {
+                        let block_number = u64::from_be_bytes(hint.data.as_ref()[..8].try_into()?);
+                        let address = Address::from_slice(&hint.data.as_ref()[8..28]);
+                        let chain_id = u64::from_be_bytes(hint.data.as_ref()[28..36].try_into()?);
+                        (block_number.into(), address, chain_id)
+                    }
+                    60 => {
+                        let block_hash = B256::from_slice(&hint.data.as_ref()[..32]);
+                        let address = Address::from_slice(&hint.data.as_ref()[32..52]);
+                        let chain_id = u64::from_be_bytes(hint.data.as_ref()[52..60].try_into()?);
+                        (block_hash.into(), address, chain_id)
+                    }
+                    other => anyhow::bail!(
+                        "Invalid L2AccountProof hint length: expected 36 or 60, got {other}"
+                    ),
+                };
 
                 let proof_response = providers
                     .l2(&chain_id)?
                     .get_proof(address, Default::default())
-                    .block_id(block_number.into())
+                    .block_id(block_id)
                     .await?;
 
                 // Write the account proof nodes to the key-value store.
@@ -391,17 +407,32 @@ impl HintHandler for InteropHintHandler {
                 })?;
             }
             HintType::L2AccountStorageProof => {
-                ensure!(hint.data.len() == 8 + 20 + 32 + 8, "Invalid hint data length");
-
-                let block_number = u64::from_be_bytes(hint.data.as_ref()[..8].try_into()?);
-                let address = Address::from_slice(&hint.data.as_ref()[8..28]);
-                let slot = B256::from_slice(&hint.data.as_ref()[28..60]);
-                let chain_id = u64::from_be_bytes(hint.data[60..].try_into()?);
+                // Backwards compatibility: accept both old (8+20+32+8=68 byte) and new
+                // (32+20+32+8=92 byte) formats. See L2AccountProof for details.
+                let (block_id, address, slot, chain_id) = match hint.data.len() {
+                    68 => {
+                        let block_number = u64::from_be_bytes(hint.data.as_ref()[..8].try_into()?);
+                        let address = Address::from_slice(&hint.data.as_ref()[8..28]);
+                        let slot = B256::from_slice(&hint.data.as_ref()[28..60]);
+                        let chain_id = u64::from_be_bytes(hint.data.as_ref()[60..68].try_into()?);
+                        (block_number.into(), address, slot, chain_id)
+                    }
+                    92 => {
+                        let block_hash = B256::from_slice(&hint.data.as_ref()[..32]);
+                        let address = Address::from_slice(&hint.data.as_ref()[32..52]);
+                        let slot = B256::from_slice(&hint.data.as_ref()[52..84]);
+                        let chain_id = u64::from_be_bytes(hint.data.as_ref()[84..92].try_into()?);
+                        (block_hash.into(), address, slot, chain_id)
+                    }
+                    other => anyhow::bail!(
+                        "Invalid L2AccountStorageProof hint length: expected 68 or 92, got {other}"
+                    ),
+                };
 
                 let mut proof_response = providers
                     .l2(&chain_id)?
                     .get_proof(address, vec![slot])
-                    .block_id(block_number.into())
+                    .block_id(block_id)
                     .await?;
 
                 let mut kv_lock = kv.write().await;

--- a/rust/kona/bin/host/src/single/handler.rs
+++ b/rust/kona/bin/host/src/single/handler.rs
@@ -316,15 +316,29 @@ impl HintHandler for SingleChainHintHandler {
                 kv_write_lock.set(PreimageKey::new_keccak256(*hash).into(), preimage.into())?;
             }
             HintType::L2AccountProof => {
-                ensure!(hint.data.len() == 8 + 20, "Invalid hint data length");
-
-                let block_number = u64::from_be_bytes(hint.data.as_ref()[..8].try_into()?);
-                let address = Address::from_slice(&hint.data.as_ref()[8..28]);
+                // Backwards compatibility: accept both old (8+20=28 byte) and new (32+20=52
+                // byte) formats. Old prestates send an 8-byte block number; new prestates
+                // send a 32-byte block hash. A single kona-host version serves all games.
+                let block_id = match hint.data.len() {
+                    28 => {
+                        let block_number = u64::from_be_bytes(hint.data.as_ref()[..8].try_into()?);
+                        let address = Address::from_slice(&hint.data.as_ref()[8..28]);
+                        (block_number.into(), address)
+                    }
+                    52 => {
+                        let block_hash = B256::from_slice(&hint.data.as_ref()[..32]);
+                        let address = Address::from_slice(&hint.data.as_ref()[32..52]);
+                        (block_hash.into(), address)
+                    }
+                    other => anyhow::bail!(
+                        "Invalid L2AccountProof hint length: expected 28 or 52, got {other}"
+                    ),
+                };
 
                 let proof_response = providers
                     .l2
-                    .get_proof(address, Default::default())
-                    .block_id(block_number.into())
+                    .get_proof(block_id.1, Default::default())
+                    .block_id(block_id.0)
                     .await?;
 
                 // Write the account proof nodes to the key-value store.
@@ -337,17 +351,28 @@ impl HintHandler for SingleChainHintHandler {
                 })?;
             }
             HintType::L2AccountStorageProof => {
-                ensure!(hint.data.len() == 8 + 20 + 32, "Invalid hint data length");
+                // Backwards compatibility: accept both old (8+20+32=60 byte) and new
+                // (32+20+32=84 byte) formats. See L2AccountProof for details.
+                let (block_id, address, slot) = match hint.data.len() {
+                    60 => {
+                        let block_number = u64::from_be_bytes(hint.data.as_ref()[..8].try_into()?);
+                        let address = Address::from_slice(&hint.data.as_ref()[8..28]);
+                        let slot = B256::from_slice(&hint.data.as_ref()[28..60]);
+                        (block_number.into(), address, slot)
+                    }
+                    84 => {
+                        let block_hash = B256::from_slice(&hint.data.as_ref()[..32]);
+                        let address = Address::from_slice(&hint.data.as_ref()[32..52]);
+                        let slot = B256::from_slice(&hint.data.as_ref()[52..84]);
+                        (block_hash.into(), address, slot)
+                    }
+                    other => anyhow::bail!(
+                        "Invalid L2AccountStorageProof hint length: expected 60 or 84, got {other}"
+                    ),
+                };
 
-                let block_number = u64::from_be_bytes(hint.data.as_ref()[..8].try_into()?);
-                let address = Address::from_slice(&hint.data.as_ref()[8..28]);
-                let slot = B256::from_slice(&hint.data.as_ref()[28..]);
-
-                let mut proof_response = providers
-                    .l2
-                    .get_proof(address, vec![slot])
-                    .block_id(block_number.into())
-                    .await?;
+                let mut proof_response =
+                    providers.l2.get_proof(address, vec![slot]).block_id(block_id).await?;
 
                 let mut kv_lock = kv.write().await;
 

--- a/rust/kona/bin/host/src/single/handler.rs
+++ b/rust/kona/bin/host/src/single/handler.rs
@@ -316,22 +316,24 @@ impl HintHandler for SingleChainHintHandler {
                 kv_write_lock.set(PreimageKey::new_keccak256(*hash).into(), preimage.into())?;
             }
             HintType::L2AccountProof => {
-                // Backwards compatibility: accept both old (8+20=28 byte) and new (32+20=52
-                // byte) formats. Old prestates send an 8-byte block number; new prestates
-                // send a 32-byte block hash. A single kona-host version serves all games.
+                // Backwards compatibility: old prestates send an 8-byte block number; new
+                // prestates send a 32-byte block hash. A single kona-host version serves all
+                // games.
+                const BLOCK_NUMBER_HINT_LEN: usize = 8 + 20;
+                const BLOCK_HASH_HINT_LEN: usize = 32 + 20;
                 let block_id = match hint.data.len() {
-                    28 => {
+                    BLOCK_NUMBER_HINT_LEN => {
                         let block_number = u64::from_be_bytes(hint.data.as_ref()[..8].try_into()?);
                         let address = Address::from_slice(&hint.data.as_ref()[8..28]);
                         (block_number.into(), address)
                     }
-                    52 => {
+                    BLOCK_HASH_HINT_LEN => {
                         let block_hash = B256::from_slice(&hint.data.as_ref()[..32]);
                         let address = Address::from_slice(&hint.data.as_ref()[32..52]);
                         (block_hash.into(), address)
                     }
                     other => anyhow::bail!(
-                        "Invalid L2AccountProof hint length: expected 28 or 52, got {other}"
+                        "Invalid L2AccountProof hint length: expected {BLOCK_NUMBER_HINT_LEN} or {BLOCK_HASH_HINT_LEN}, got {other}"
                     ),
                 };
 
@@ -351,23 +353,26 @@ impl HintHandler for SingleChainHintHandler {
                 })?;
             }
             HintType::L2AccountStorageProof => {
-                // Backwards compatibility: accept both old (8+20+32=60 byte) and new
-                // (32+20+32=84 byte) formats. See L2AccountProof for details.
+                // Backwards compatibility: old prestates send an 8-byte block number; new
+                // prestates send a 32-byte block hash. A single kona-host version serves all
+                // games.
+                const BLOCK_NUMBER_HINT_LEN: usize = 8 + 20 + 32;
+                const BLOCK_HASH_HINT_LEN: usize = 32 + 20 + 32;
                 let (block_id, address, slot) = match hint.data.len() {
-                    60 => {
+                    BLOCK_NUMBER_HINT_LEN => {
                         let block_number = u64::from_be_bytes(hint.data.as_ref()[..8].try_into()?);
                         let address = Address::from_slice(&hint.data.as_ref()[8..28]);
                         let slot = B256::from_slice(&hint.data.as_ref()[28..60]);
                         (block_number.into(), address, slot)
                     }
-                    84 => {
+                    BLOCK_HASH_HINT_LEN => {
                         let block_hash = B256::from_slice(&hint.data.as_ref()[..32]);
                         let address = Address::from_slice(&hint.data.as_ref()[32..52]);
                         let slot = B256::from_slice(&hint.data.as_ref()[52..84]);
                         (block_hash.into(), address, slot)
                     }
                     other => anyhow::bail!(
-                        "Invalid L2AccountStorageProof hint length: expected 60 or 84, got {other}"
+                        "Invalid L2AccountStorageProof hint length: expected {BLOCK_NUMBER_HINT_LEN} or {BLOCK_HASH_HINT_LEN}, got {other}"
                     ),
                 };
 

--- a/rust/kona/crates/proof/executor/src/builder/assemble.rs
+++ b/rust/kona/crates/proof/executor/src/builder/assemble.rs
@@ -48,7 +48,7 @@ where
         .root();
         let receipts_root = compute_receipts_root(&ex_result.receipts, self.config, timestamp);
         let withdrawals_root = if self.config.is_isthmus_active(timestamp) {
-            Some(self.message_passer_account(block_env.number.saturating_to::<u64>())?)
+            Some(self.message_passer_account()?)
         } else if self.config.is_canyon_active(timestamp) {
             Some(EMPTY_ROOT_HASH)
         } else {
@@ -133,7 +133,7 @@ where
             "Computing output root",
         );
 
-        let storage_root = self.message_passer_account(parent_number)?;
+        let storage_root = self.message_passer_account()?;
         let parent_header = self.trie_db.parent_block_header();
 
         // Construct the raw output and hash it.
@@ -153,12 +153,12 @@ where
     }
 
     /// Fetches the L2 to L1 message passer account from the cache or underlying trie.
-    fn message_passer_account(&mut self, block_number: u64) -> Result<B256, TrieDBError> {
+    fn message_passer_account(&mut self) -> Result<B256, TrieDBError> {
         match self.trie_db.storage_roots().get(&Predeploys::L2_TO_L1_MESSAGE_PASSER) {
             Some(storage_root) => Ok(storage_root.blind()),
             None => Ok(self
                 .trie_db
-                .get_trie_account(&Predeploys::L2_TO_L1_MESSAGE_PASSER, block_number)?
+                .get_trie_account(&Predeploys::L2_TO_L1_MESSAGE_PASSER)?
                 .ok_or(TrieDBError::MissingAccountInfo)?
                 .storage_root),
         }

--- a/rust/kona/crates/proof/executor/src/db/mod.rs
+++ b/rust/kona/crates/proof/executor/src/db/mod.rs
@@ -175,14 +175,10 @@ where
     /// - `Ok(Some(TrieAccount))`: The [`TrieAccount`] of the account.
     /// - `Ok(None)`: If the account does not exist in the trie.
     /// - `Err(_)`: If the account could not be fetched.
-    pub fn get_trie_account(
-        &mut self,
-        address: &Address,
-        block_number: u64,
-    ) -> TrieDBResult<Option<TrieAccount>> {
+    pub fn get_trie_account(&mut self, address: &Address) -> TrieDBResult<Option<TrieAccount>> {
         // Send a hint to the host to fetch the account proof.
         self.hinter
-            .hint_account_proof(*address, block_number)
+            .hint_account_proof(*address, self.parent_block_header.hash())
             .map_err(|e| TrieDBError::Provider(e.to_string()))?;
 
         // Fetch the account from the trie.
@@ -329,9 +325,7 @@ where
 
     fn basic(&mut self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
         // Fetch the account from the trie.
-        let Some(trie_account) =
-            self.get_trie_account(&address, self.parent_block_header.number)?
-        else {
+        let Some(trie_account) = self.get_trie_account(&address)? else {
             // If the account does not exist in the trie, return `Ok(None)`.
             return Ok(None);
         };
@@ -360,7 +354,7 @@ where
     fn storage(&mut self, address: Address, index: U256) -> Result<U256, Self::Error> {
         // Send a hint to the host to fetch the storage proof.
         self.hinter
-            .hint_storage_proof(address, index, self.parent_block_header.number)
+            .hint_storage_proof(address, index, self.parent_block_header.hash())
             .map_err(|e| TrieDBError::Provider(e.to_string()))?;
 
         // Fetch the account's storage root from the cache. If storage is being accessed, the

--- a/rust/kona/crates/proof/mpt/src/noop.rs
+++ b/rust/kona/crates/proof/mpt/src/noop.rs
@@ -29,7 +29,7 @@ impl TrieHinter for NoopTrieHinter {
         Ok(())
     }
 
-    fn hint_account_proof(&self, _address: Address, _block_number: u64) -> Result<(), Self::Error> {
+    fn hint_account_proof(&self, _address: Address, _block_hash: B256) -> Result<(), Self::Error> {
         Ok(())
     }
 
@@ -37,7 +37,7 @@ impl TrieHinter for NoopTrieHinter {
         &self,
         _address: Address,
         _slot: U256,
-        _block_number: u64,
+        _block_hash: B256,
     ) -> Result<(), Self::Error> {
         Ok(())
     }

--- a/rust/kona/crates/proof/mpt/src/traits.rs
+++ b/rust/kona/crates/proof/mpt/src/traits.rs
@@ -41,12 +41,12 @@ pub trait TrieHinter {
     ///
     /// ## Takes
     /// - `address` - The address of the contract whose trie node preimages are to be fetched.
-    /// - `block_number` - The block number at which the trie node preimages are to be fetched.
+    /// - `block_hash` - The block hash at which the trie node preimages are to be fetched.
     ///
     /// ## Returns
     /// - Ok(()): If the hint was successful.
     /// - `Err(Self::Error)`: If the hint was unsuccessful.
-    fn hint_account_proof(&self, address: Address, block_number: u64) -> Result<(), Self::Error>;
+    fn hint_account_proof(&self, address: Address, block_hash: B256) -> Result<(), Self::Error>;
 
     /// Hints the host to fetch the trie node preimages on the path to the storage slot within the
     /// given account's storage trie.
@@ -54,7 +54,7 @@ pub trait TrieHinter {
     /// ## Takes
     /// - `address` - The address of the contract whose trie node preimages are to be fetched.
     /// - `slot` - The storage slot whose trie node preimages are to be fetched.
-    /// - `block_number` - The block number at which the trie node preimages are to be fetched.
+    /// - `block_hash` - The block hash at which the trie node preimages are to be fetched.
     ///
     /// ## Returns
     /// - Ok(()): If the hint was successful.
@@ -63,7 +63,7 @@ pub trait TrieHinter {
         &self,
         address: Address,
         slot: U256,
-        block_number: u64,
+        block_hash: B256,
     ) -> Result<(), Self::Error>;
 
     /// Hints the host to fetch the execution witness for the [`OpPayloadAttributes`] applied on top

--- a/rust/kona/crates/proof/proof-interop/src/provider.rs
+++ b/rust/kona/crates/proof/proof-interop/src/provider.rs
@@ -128,11 +128,11 @@ where
 
     /// Fetch a [Header] by its number.
     async fn header_by_number(&self, chain_id: u64, number: u64) -> Result<Header, Self::Error> {
-        let Some(mut header) =
-            self.local_safe_heads.get(&chain_id).cloned().map(|h| h.into_inner())
-        else {
+        let Some(sealed) = self.local_safe_heads.get(&chain_id).cloned() else {
             return Err(PreimageOracleError::Other("Missing local safe header".to_string()).into());
         };
+        let mut current_hash = sealed.hash();
+        let mut header = sealed.into_inner();
 
         // Check if the block number is in range. If not, we can fail early.
         if number > header.number {
@@ -155,19 +155,29 @@ where
                 // If Isthmus is active, the EIP-2935 contract is used to perform leaping lookbacks
                 // through consulting the ring buffer within the contract. If this
                 // lookup fails for any reason, we fall back to linear walk back.
-                let block_hash = match eip_2935_history_lookup(&header, number, self, self).await {
+                let block_hash = match eip_2935_history_lookup(
+                    &header,
+                    number,
+                    current_hash,
+                    self,
+                    self,
+                )
+                .await
+                {
                     Ok(hash) => hash,
                     Err(_) => {
-                        // If the EIP-2935 lookup fails for any reason, attempt fallback to linear
-                        // walk back.
+                        // If the EIP-2935 lookup fails for any reason, attempt fallback to
+                        // linear walk back.
                         linear_fallback = true;
                         continue;
                     }
                 };
 
+                current_hash = block_hash;
                 header = self.header_by_hash(chain_id, block_hash).await?;
             } else {
                 // Walk back the block headers one-by-one until the desired block number is reached.
+                current_hash = header.parent_hash;
                 header = self.header_by_hash(chain_id, header.parent_hash).await?;
             }
         }
@@ -229,10 +239,10 @@ impl<C: CommsClient> TrieHinter for OracleInteropProvider<C> {
         })
     }
 
-    fn hint_account_proof(&self, address: Address, block_number: u64) -> Result<(), Self::Error> {
+    fn hint_account_proof(&self, address: Address, block_hash: B256) -> Result<(), Self::Error> {
         kona_proof::block_on(async move {
             HintType::L2AccountProof
-                .with_data(&[block_number.to_be_bytes().as_ref(), address.as_slice()])
+                .with_data(&[block_hash.as_slice(), address.as_slice()])
                 .with_data(
                     self.chain_id.read().map_or_else(Vec::new, |id| id.to_be_bytes().to_vec()),
                 )
@@ -245,12 +255,12 @@ impl<C: CommsClient> TrieHinter for OracleInteropProvider<C> {
         &self,
         address: alloy_primitives::Address,
         slot: alloy_primitives::U256,
-        block_number: u64,
+        block_hash: B256,
     ) -> Result<(), Self::Error> {
         kona_proof::block_on(async move {
             HintType::L2AccountStorageProof
                 .with_data(&[
-                    block_number.to_be_bytes().as_ref(),
+                    block_hash.as_slice(),
                     address.as_slice(),
                     slot.to_be_bytes::<32>().as_ref(),
                 ])

--- a/rust/kona/crates/proof/proof/src/eip2935.rs
+++ b/rust/kona/crates/proof/proof/src/eip2935.rs
@@ -23,6 +23,7 @@ const HISTORY_SERVE_WINDOW: u64 = 2u64.pow(13) - 1;
 pub async fn eip_2935_history_lookup<P, H>(
     header: &Header,
     block_number: u64,
+    block_hash: B256,
     provider: &P,
     hinter: &H,
 ) -> Result<B256, OracleProviderError>
@@ -42,7 +43,7 @@ where
 
     // Send a hint to fetch the storage slot proof prior to traversing the state / account tries.
     hinter
-        .hint_storage_proof(HISTORY_STORAGE_ADDRESS, U256::from(slot), header.number)
+        .hint_storage_proof(HISTORY_STORAGE_ADDRESS, U256::from(slot), block_hash)
         .map_err(|e| PreimageOracleError::Other(e.to_string()))?;
 
     // Fetch the trie account for the history accumulator.
@@ -158,10 +159,16 @@ mod tests {
             ..Default::default()
         };
 
-        let result =
-            eip_2935_history_lookup(&header, target_block_number, &provider, &NoopTrieHinter)
-                .await
-                .unwrap();
+        let block_hash = B256::from([0xAA; 32]);
+        let result = eip_2935_history_lookup(
+            &header,
+            target_block_number,
+            block_hash,
+            &provider,
+            &NoopTrieHinter,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(result, expected_hash);
     }

--- a/rust/kona/crates/proof/proof/src/l2/chain_provider.rs
+++ b/rust/kona/crates/proof/proof/src/l2/chain_provider.rs
@@ -62,7 +62,8 @@ impl<T: CommsClient> OracleL2ChainProvider<T> {
     /// L2 safe head.
     async fn header_by_number(&self, block_number: u64) -> Result<Header, OracleProviderError> {
         // Fetch the starting block header.
-        let mut header = self.header_by_hash(self.l2_safe_head().await?)?;
+        let mut current_hash = self.l2_safe_head().await?;
+        let mut header = self.header_by_hash(current_hash)?;
 
         // Check if the block number is in range. If not, we can fail early.
         if block_number > header.number {
@@ -76,7 +77,9 @@ impl<T: CommsClient> OracleL2ChainProvider<T> {
                 // through consulting the ring buffer within the contract. If this
                 // lookup fails for any reason, we fall back to linear walk back.
                 let block_hash =
-                    match eip_2935_history_lookup(&header, block_number, self, self).await {
+                    match eip_2935_history_lookup(&header, block_number, current_hash, self, self)
+                        .await
+                    {
                         Ok(hash) => hash,
                         Err(_) => {
                             // If the EIP-2935 lookup fails for any reason, attempt fallback to
@@ -86,9 +89,11 @@ impl<T: CommsClient> OracleL2ChainProvider<T> {
                         }
                     };
 
+                current_hash = block_hash;
                 header = self.header_by_hash(block_hash)?;
             } else {
                 // Walk back the block headers one-by-one until the desired block number is reached.
+                current_hash = header.parent_hash;
                 header = self.header_by_hash(header.parent_hash)?;
             }
         }
@@ -233,10 +238,10 @@ impl<T: CommsClient> TrieHinter for OracleL2ChainProvider<T> {
         })
     }
 
-    fn hint_account_proof(&self, address: Address, block_number: u64) -> Result<(), Self::Error> {
+    fn hint_account_proof(&self, address: Address, block_hash: B256) -> Result<(), Self::Error> {
         crate::block_on(async move {
             HintType::L2AccountProof
-                .with_data(&[block_number.to_be_bytes().as_ref(), address.as_slice()])
+                .with_data(&[block_hash.as_slice(), address.as_slice()])
                 .with_data(self.chain_id.map_or_else(Vec::new, |id| id.to_be_bytes().to_vec()))
                 .send(self.oracle.as_ref())
                 .await
@@ -247,12 +252,12 @@ impl<T: CommsClient> TrieHinter for OracleL2ChainProvider<T> {
         &self,
         address: alloy_primitives::Address,
         slot: alloy_primitives::U256,
-        block_number: u64,
+        block_hash: B256,
     ) -> Result<(), Self::Error> {
         crate::block_on(async move {
             HintType::L2AccountStorageProof
                 .with_data(&[
-                    block_number.to_be_bytes().as_ref(),
+                    block_hash.as_slice(),
                     address.as_slice(),
                     slot.to_be_bytes::<32>().as_ref(),
                 ])


### PR DESCRIPTION
## Summary

Fixes ethereum-optimism/optimism-private#492 (Cantina finding: incorrect L2AccountProof hinting sends block number instead of block hash). Originally reviewed in ethereum-optimism/optimism-private#525 — moved here for public landing.

- **`TrieHinter` trait**: Changed `hint_account_proof` and `hint_storage_proof` to take `B256` block hash instead of `u64` block number
- **Client implementations** (`kona-proof`, `kona-proof-interop`): Now send 32-byte block hash in hint data instead of 8-byte block number
- **Both kona hosts** (`single/handler.rs`, `interop/handler.rs`): Detect hint format by data length for backwards compatibility with existing prestates — a single host version serves all games
- **Callers** (`TrieDB`, `eip2935`, `assemble`): Updated to pass block hashes through the call chain

### Backwards Compatibility

The kona host must serve both old and new prestates simultaneously. Format detection by hint data length:

| Hint | Old format | New format |
|------|-----------|------------|
| L2AccountProof (single) | 8+20 = 28 bytes | 32+20 = 52 bytes |
| L2AccountProof (interop) | 8+20+8 = 36 bytes | 32+20+8 = 60 bytes |
| L2AccountStorageProof (single) | 8+20+32 = 60 bytes | 32+20+32 = 84 bytes |
| L2AccountStorageProof (interop) | 8+20+32+8 = 68 bytes | 32+20+32+8 = 92 bytes |

### Behavioral change in seal_block hint target

The previous code had an inconsistency in `BlockBuilder::seal_block` (`assemble.rs`): it passed `block_env.number` (the block being built, N) to `hint_account_proof`, while the trie had already been updated to block N's state via `state_root(&bundle)`. Meanwhile, `compute_output_root` correctly passed `parent_number` (N-1).

With this change, all hints consistently reference `parent_block_header.hash()` (block N-1). This is correct because:

1. **The hint is a prefetch mechanism, not a validation mechanism.** It tells the host which proof nodes to load into the KV store. The actual trie traversal is verified through hash-linked nodes from the root, independent of the hint.
2. **The `seal_block` path only reaches `get_trie_account` when the account was NOT modified** during block execution (the `None` branch of `message_passer_account` checks the storage_roots cache first). If the account wasn't modified, the proof nodes for blocks N-1 and N are identical.
3. **The old hint was arguably wrong** — it asked the host for state at block N while `get_trie_account` traverses from `self.root_node`, which only represents block N's state after `state_root()` has been called. Using `parent_block_header.hash()` is more consistent with the TrieDB's actual state lineage.

## Test plan

- [x] `cargo check -p kona-proof -p kona-proof-interop -p kona-host` passes
- [x] `cargo test -p kona-proof -p kona-proof-interop -p kona-host` — all tests pass
- [x] `cargo clippy` clean on changed crates (two pre-existing warnings in `kona-derive` are unrelated)
- [ ] CI validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)