### PR TITLE
chore(rust): bump revm to 38

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -289,9 +289,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.31.0"
+version = "0.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adcd754dd6733c3f2d44dd99ddecb7d844428a9b3cdbcafbe65570886bf24b20"
+checksum = "bd3e12b99b0c8f7298ffd3604c58310cba310203c5f6cd5e024f3b2bd9c3b09c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -404,7 +404,7 @@ dependencies = [
 
 [[package]]
 name = "alloy-op-evm"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -3038,7 +3038,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4666,6 +4666,7 @@ dependencies = [
  "hyper-util",
  "log",
  "rustls",
+ "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -7781,16 +7782,13 @@ dependencies = [
 
 [[package]]
 name = "op-revm"
-version = "17.0.0"
+version = "19.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c545fc4e916747afe36bcf36d6f8b46255b6a1b688f5ca8016e449f258e510"
 dependencies = [
- "alloy-primitives",
- "alloy-sol-types",
  "auto_impl",
  "revm",
- "rstest",
  "serde",
- "serde_json",
- "sha2",
 ]
 
 [[package]]
@@ -9020,16 +9018,22 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -9090,7 +9094,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9117,7 +9121,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9149,7 +9153,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9169,7 +9173,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -9182,7 +9186,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9270,7 +9274,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -9280,7 +9284,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -9300,9 +9304,9 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a29541038ab108b2e9d527c66b565e717e252e4eef6675377fc21f9ba587f792"
+checksum = "a79b3247ae4fbb1d4d35ce83a11fc596428a4c6ea836c98a75a55340192578a4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9321,9 +9325,9 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5646d4aff98bd51050fc920bc3ffdff209f2343def9ed31b56eea13c4245c4da"
+checksum = "df5dbae40c272b8a1b4fcc08ee2d4e77d3b0ccdb187c1313f412a73ff54ff2a2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9333,7 +9337,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -9349,7 +9353,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9362,7 +9366,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9375,7 +9379,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9401,7 +9405,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9429,7 +9433,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9455,7 +9459,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9485,7 +9489,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -9500,7 +9504,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9525,7 +9529,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9549,7 +9553,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9573,7 +9577,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9608,7 +9612,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9665,7 +9669,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9693,7 +9697,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9716,7 +9720,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9741,7 +9745,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9753,6 +9757,7 @@ dependencies = [
  "crossbeam-channel",
  "derive_more",
  "futures",
+ "indexmap 2.14.0",
  "metrics",
  "moka",
  "parking_lot",
@@ -9797,7 +9802,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9825,7 +9830,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -9840,7 +9845,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9856,7 +9861,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9878,7 +9883,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9889,7 +9894,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9918,10 +9923,11 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
+ "alloy-eip7928",
  "alloy-eips 2.0.0",
  "alloy-hardforks",
  "alloy-primitives",
@@ -9942,7 +9948,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9983,7 +9989,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "clap",
  "eyre",
@@ -10006,7 +10012,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10022,7 +10028,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -10038,7 +10044,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -10052,7 +10058,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10082,7 +10088,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10096,7 +10102,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -10106,7 +10112,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10130,7 +10136,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10150,7 +10156,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -10168,7 +10174,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -10181,7 +10187,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10200,7 +10206,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10238,7 +10244,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-test-utils"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-eips 2.0.0",
  "eyre",
@@ -10270,7 +10276,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -10284,7 +10290,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "serde",
  "serde_json",
@@ -10294,7 +10300,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10322,7 +10328,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "bytes",
  "futures",
@@ -10342,7 +10348,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -10359,7 +10365,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "bindgen",
  "cc",
@@ -10368,7 +10374,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "futures",
  "metrics",
@@ -10380,7 +10386,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -10389,7 +10395,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "futures-util",
  "if-addrs 0.14.0",
@@ -10403,7 +10409,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10460,7 +10466,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10485,7 +10491,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10508,7 +10514,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10523,7 +10529,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10537,7 +10543,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -10554,7 +10560,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10578,7 +10584,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10646,7 +10652,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10701,7 +10707,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-network",
@@ -10739,7 +10745,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10763,7 +10769,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -10787,7 +10793,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "bytes",
  "eyre",
@@ -10816,7 +10822,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -11393,7 +11399,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11417,7 +11423,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -11429,7 +11435,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -11453,7 +11459,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-util"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11463,7 +11469,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -11472,9 +11478,9 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e96ffdb2ce0cdcd814d39428dc1e9b660c85d85e0b75eb465a1ed0943a48c7bd"
+checksum = "cc759fd87c3f65440e5d3bfa3107fe8a13a61a6807cd485c62c49d63c7bf6717"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -11506,7 +11512,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -11552,7 +11558,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -11581,7 +11587,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11597,7 +11603,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11612,11 +11618,10 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
- "alloy-eip7928",
  "alloy-eips 2.0.0",
  "alloy-evm",
  "alloy-genesis",
@@ -11690,9 +11695,8 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
- "alloy-eip7928",
  "alloy-eips 2.0.0",
  "alloy-genesis",
  "alloy-json-rpc",
@@ -11721,7 +11725,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -11764,7 +11768,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11784,7 +11788,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -11815,7 +11819,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -11861,7 +11865,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -11909,7 +11913,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -11923,7 +11927,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -11938,9 +11942,9 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-traits"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c870f120b2e179e44906b7b288b0dea6577573010272adda8fff536e86fedd05"
+checksum = "b766da61ec7c46596386b4bc88d9b57d1939d3da2bc9e927567a8a23650e5ce9"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -11954,7 +11958,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -12006,7 +12010,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -12034,7 +12038,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -12048,7 +12052,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -12068,7 +12072,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -12083,7 +12087,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -12107,7 +12111,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-eips 2.0.0",
  "alloy-primitives",
@@ -12125,7 +12129,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -12146,7 +12150,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -12162,7 +12166,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -12172,7 +12176,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "clap",
  "eyre",
@@ -12191,7 +12195,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "clap",
  "eyre",
@@ -12209,7 +12213,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -12255,7 +12259,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.0",
@@ -12281,7 +12285,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -12308,7 +12312,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -12328,7 +12332,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-eip7928",
  "alloy-evm",
@@ -12356,7 +12360,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.0.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=552d896f9c4b75201def55969d3c23bcc990dd80#552d896f9c4b75201def55969d3c23bcc990dd80"
+source = "git+https://github.com/paradigmxyz/reth?rev=27bfddeada3953edc22759080a3659ccea62ca1f#27bfddeada3953edc22759080a3659ccea62ca1f"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -12377,18 +12381,18 @@ dependencies = [
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3882441cf1d51fe24dfc6df9919e6f17edfdb6b121050bd34348e925e61c7af1"
+checksum = "82fa54c341d926ec9b0f7fc0c87f831aa4959de699e69caab1a0bfd914326c09"
 dependencies = [
  "zstd",
 ]
 
 [[package]]
 name = "revm"
-version = "36.0.0"
+version = "38.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0abc15d09cd211e9e73410ada10134069c794d4bcdb787dfc16a1bf0939849c"
+checksum = "91202d39dbe8e8d10e9e8f2b76c30da68ecd1d25be69ba6d853ad0d03a3a398a"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -12405,9 +12409,9 @@ dependencies = [
 
 [[package]]
 name = "revm-bytecode"
-version = "9.0.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e86e468df3cf5cf59fa7ef71a3e9ccabb76bb336401ea2c0674f563104cf3c5e"
+checksum = "bdbb3a3d735efa94c91f2ef6bf20a35f99a77bc78f3e25bd758336901bdf9661"
 dependencies = [
  "bitvec",
  "phf",
@@ -12417,9 +12421,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "15.0.0"
+version = "16.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eb1f0a76b14d684a444fc52f7bf6b7564bf882599d91ee62e76d602e7a187c7"
+checksum = "c5f68d928d8b228e0faeb1c6ed75c4fde7d124f1ddf9119b67e7a0ad4041237d"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -12434,9 +12438,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "16.0.0"
+version = "17.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc256b27743e2912ca16899568e6652a372eb5d1d573e6edb16c7836b16cf487"
+checksum = "1f3758e6167c4ba7a59a689c519a047edaefcd4c37d74f279b93ed87bc8aece4"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -12450,9 +12454,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "12.0.0"
+version = "13.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c0a7d6da41061f2c50f99a2632571026b23684b5449ff319914151f4449b6c8"
+checksum = "c281a1f11d3bcb8c0bba1199ed6bcb001d1aeb3d4fb366819e14f88723989a4e"
 dependencies = [
  "alloy-eips 1.8.3",
  "revm-bytecode",
@@ -12464,9 +12468,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "10.0.0"
+version = "11.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd497a38a79057b94a049552cb1f925ad15078bc1a479c132aeeebd1d2ccc768"
+checksum = "d89efb9832a4e3742bb4ded5f7fe5bf905e8860e69427d4dfec153484fc6d304"
 dependencies = [
  "auto_impl",
  "either",
@@ -12478,9 +12482,9 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "17.0.0"
+version = "18.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1eed729ca9b228ae98688f352235871e9b8be3d568d488e4070f64c56e9d3d"
+checksum = "783e903d6922b7f5f9a940d1bb229530502d2924b1aed9d5ca5a94ebf065d460"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -12497,9 +12501,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "17.0.0"
+version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf5102391706513689f91cb3cb3d97b5f13a02e8647e6e9cb7620877ef84847"
+checksum = "8216ad58422090d0daa9eb430e0a081f7ad07e7fd30681dee71f8420c99624e0"
 dependencies = [
  "auto_impl",
  "either",
@@ -12515,9 +12519,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.37.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac49e53897c4cc59dbd7a7bb097386755a4dfa2bc7088b298f341b5dfcda6f2c"
+checksum = "731b682530a732ef9c189ef831589128e2ce34d4a306c956322ae2dffe009715"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -12535,9 +12539,9 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "34.0.0"
+version = "35.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf22f80612bb8f58fd1f578750281f2afadb6c93835b14ae6a4d6b75ca26f445"
+checksum = "1ece9f41b69658c15d748288a4dbdfc06a63f3ce93d983af440de3f1631dce6a"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -12548,9 +12552,9 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "32.1.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2ec11f45deec71e4945e1809736bb20d454285f9167ab53c5159dae1deb603f"
+checksum = "a346a8cc6c8c39bd65306641c692191299c0a7b63d38810e39e8fe9b92378660"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -12565,18 +12569,18 @@ dependencies = [
  "gmp-mpfr-sys",
  "k256",
  "p256",
+ "revm-context-interface",
  "revm-primitives",
  "ripemd",
  "secp256k1 0.31.1",
  "sha2",
- "substrate-bn",
 ]
 
 [[package]]
 name = "revm-primitives"
-version = "22.1.0"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcfb5ce6cf18b118932bcdb7da05cd9c250f2cb9f64131396b55f3fe3537c35"
+checksum = "0c99bda77d9661521ba0b4bc04558c6692074f01e65dd420fa3b893033d9b8a2"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -12586,9 +12590,9 @@ dependencies = [
 
 [[package]]
 name = "revm-state"
-version = "10.0.0"
+version = "11.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29404707763da607e5d6e4771cb203998c28159279c2f64cc32de08d2814651"
+checksum = "c32490ed687dba31c3c882beb8c20408bdd30ef96690d8f145b0ee9a87040bfe"
 dependencies = [
  "alloy-eip7928",
  "bitflags 2.11.1",
@@ -13713,19 +13717,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "substrate-bn"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b5bbfa79abbae15dd642ea8176a21a635ff3c00059961d1ea27ad04e5b441c"
-dependencies = [
- "byteorder",
- "crunchy",
- "lazy_static",
- "rand 0.8.6",
- "rustc-hex",
 ]
 
 [[package]]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -7783,12 +7783,15 @@ dependencies = [
 [[package]]
 name = "op-revm"
 version = "19.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c545fc4e916747afe36bcf36d6f8b46255b6a1b688f5ca8016e449f258e510"
 dependencies = [
+ "alloy-primitives",
+ "alloy-sol-types",
  "auto_impl",
  "revm",
+ "rstest",
  "serde",
+ "serde_json",
+ "sha2",
 ]
 
 [[package]]
@@ -12574,6 +12577,7 @@ dependencies = [
  "ripemd",
  "secp256k1 0.31.1",
  "sha2",
+ "substrate-bn",
 ]
 
 [[package]]
@@ -13717,6 +13721,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "substrate-bn"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b5bbfa79abbae15dd642ea8176a21a635ff3c00059961d1ea27ad04e5b441c"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "lazy_static",
+ "rand 0.8.6",
+ "rustc-hex",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -49,6 +49,9 @@ members = [
 
   # Alloy OP Hardforks
   "alloy-op-hardforks/",
+
+  # Op-Revm
+  "op-revm/",
 ]
 default-members = [
   "kona/bin/host",
@@ -386,7 +389,7 @@ revm-state = { version = "11.0.0", default-features = false }
 revm-primitives = { version = "23.0.0", default-features = false }
 revm-interpreter = { version = "35.0.0", default-features = false }
 revm-database-interface = { version = "11.0.0", default-features = false }
-op-revm = { version = "19.0.0", default-features = false }
+op-revm = { version = "19.0.0", path = "op-revm/", default-features = false }
 revm-inspectors = "0.39.0"
 
 # ==================== ALLOY ====================

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -49,9 +49,6 @@ members = [
 
   # Alloy OP Hardforks
   "alloy-op-hardforks/",
-
-  # Op-Revm
-  "op-revm/",
 ]
 default-members = [
   "kona/bin/host",
@@ -297,107 +294,107 @@ op-alloy-rpc-types-engine = { version = "0.24.0", path = "op-alloy/crates/rpc-ty
 op-alloy-rpc-jsonrpsee = { version = "0.24.0", path = "op-alloy/crates/rpc-jsonrpsee", default-features = false }
 
 # ==================== ALLOY-OP-EVM / ALLOY-OP-HARDFORKS ====================
-alloy-op-evm = { version = "0.30.0", path = "alloy-op-evm/", default-features = false }
+alloy-op-evm = { version = "0.31.0", path = "alloy-op-evm/", default-features = false }
 alloy-op-hardforks = { version = "0.4.7", path = "alloy-op-hardforks/", default-features = false }
 
 # ==================== RETH CRATES (crates.io) ====================
-reth-codecs = { version = "0.2.0", default-features = false, features = [
+reth-codecs = { version = "0.3.0", default-features = false, features = [
   "alloy",
 ] }
-reth-codecs-derive = "0.2.0"
-reth-primitives-traits = { version = "0.2.0", default-features = false }
-reth-rpc-traits = { version = "0.2.0", default-features = false }
-reth-zstd-compressors = { version = "0.2.0", default-features = false }
+reth-codecs-derive = "0.3.0"
+reth-primitives-traits = { version = "0.3.0", default-features = false }
+reth-rpc-traits = { version = "0.3.0", default-features = false }
+reth-zstd-compressors = { version = "0.3.0", default-features = false }
 
-# ==================== RETH CRATES (git @ 552d896f9c4b75201def55969d3c23bcc990dd80) ====================
-reth = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80" }
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80" }
-reth-chain-state = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80" }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80", default-features = false }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80", default-features = false }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80", default-features = false }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80" }
-reth-db-common = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80" }
-reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80", default-features = false }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80" }
-reth-eth-wire = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80" }
-reth-ethereum-forks = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80", default-features = false }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80", default-features = false }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80" }
-reth-exex = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80" }
-reth-exex-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80" }
-reth-execution-errors = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80", default-features = false }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80", default-features = false }
-reth-fs-util = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80" }
-reth-network = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80" }
-reth-node-events = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80" }
-reth-payload-builder-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80" }
-reth-payload-util = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80" }
-reth-payload-validator = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80" }
-reth-prune = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80", default-features = false }
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80", default-features = false }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80" }
-reth-rpc-engine-api = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80", default-features = false }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80" }
-reth-stages-types = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80", default-features = false }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80" }
-reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80", default-features = false }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80", default-features = false }
-reth-storage-errors = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80", default-features = false }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80", default-features = false }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80", default-features = false }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "552d896f9c4b75201def55969d3c23bcc990dd80" }
+# ==================== RETH CRATES (git @ 27bfddeada3953edc22759080a3659ccea62ca1f) ====================
+reth = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f" }
+reth-chain-state = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f", default-features = false }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f", default-features = false }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f", default-features = false }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f" }
+reth-db-common = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f" }
+reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f", default-features = false }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f" }
+reth-eth-wire = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f" }
+reth-ethereum-forks = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f", default-features = false }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f", default-features = false }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f" }
+reth-exex = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f" }
+reth-exex-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f" }
+reth-execution-errors = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f", default-features = false }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f", default-features = false }
+reth-fs-util = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f" }
+reth-network = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f" }
+reth-node-events = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f" }
+reth-payload-builder-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f" }
+reth-payload-util = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f" }
+reth-payload-validator = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f" }
+reth-prune = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f", default-features = false }
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f", default-features = false }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f" }
+reth-rpc-engine-api = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f", default-features = false }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f" }
+reth-stages-types = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f", default-features = false }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f" }
+reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f", default-features = false }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f", default-features = false }
+reth-storage-errors = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f", default-features = false }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f", default-features = false }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f", default-features = false }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "27bfddeada3953edc22759080a3659ccea62ca1f" }
 
 # ==================== REVM (latest: op-reth versions) ====================
-revm = { version = "36.0.0", default-features = false }
-revm-bytecode = { version = "9.0.0", default-features = false }
-revm-database = { version = "12.0.0", default-features = false }
-revm-state = { version = "10.0.0", default-features = false }
-revm-primitives = { version = "22.1.0", default-features = false }
-revm-interpreter = { version = "34.0.0", default-features = false }
-revm-database-interface = { version = "10.0.0", default-features = false }
-op-revm = { version = "17.0.0", path = "op-revm/", default-features = false }
-revm-inspectors = "0.37.0"
+revm = { version = "38.0.0", default-features = false }
+revm-bytecode = { version = "10.0.0", default-features = false }
+revm-database = { version = "13.0.0", default-features = false }
+revm-state = { version = "11.0.0", default-features = false }
+revm-primitives = { version = "23.0.0", default-features = false }
+revm-interpreter = { version = "35.0.0", default-features = false }
+revm-database-interface = { version = "11.0.0", default-features = false }
+op-revm = { version = "19.0.0", default-features = false }
+revm-inspectors = "0.39.0"
 
 # ==================== ALLOY ====================
 alloy-chains = { version = "0.2.33", default-features = false }
 alloy-dyn-abi = "1.5.6"
 alloy-eip2124 = { version = "0.2.0", default-features = false }
 alloy-eip7928 = { version = "0.3.3", default-features = false }
-alloy-evm = { version = "0.31.0", default-features = false }
+alloy-evm = { version = "0.33.0", default-features = false }
 alloy-primitives = { version = "1.5.6", default-features = false, features = [
   "map-foldhash",
 ] }

--- a/rust/alloy-op-evm/Cargo.toml
+++ b/rust/alloy-op-evm/Cargo.toml
@@ -2,7 +2,7 @@
 name = "alloy-op-evm"
 description = "OP EVM implementation"
 
-version = "0.30.0"
+version = "0.31.0"
 edition = "2021"
 rust-version = "1.94"
 authors = ["Alloy Contributors", "OpLabsPBC"]

--- a/rust/alloy-op-evm/src/block/mod.rs
+++ b/rust/alloy-op-evm/src/block/mod.rs
@@ -8,7 +8,7 @@ use alloy_evm::{
     Database, Evm, EvmFactory, FromRecoveredTx, FromTxWithEncoded, RecoveredTx,
     block::{
         BlockExecutionError, BlockExecutionResult, BlockExecutor, BlockExecutorFactory,
-        BlockExecutorFor, BlockValidationError, ExecutableTx, OnStateHook,
+        BlockExecutorFor, BlockValidationError, ExecutableTx, GasOutput, OnStateHook,
         StateChangePostBlockSource, StateChangeSource, StateDB, SystemCaller, TxResult,
         state_changes::{balance_increment_state, post_block_balance_increments},
     },
@@ -278,7 +278,10 @@ where
         })
     }
 
-    fn commit_transaction(&mut self, output: Self::Result) -> Result<u64, BlockExecutionError> {
+    fn commit_transaction(
+        &mut self,
+        output: Self::Result,
+    ) -> Result<GasOutput, BlockExecutionError> {
         let OpTxResult {
             inner: EthTxResult { result: ResultAndState { result, state }, blob_gas_used, tx_type },
             is_deposit,
@@ -296,7 +299,7 @@ where
 
         self.system_caller.on_state(StateChangeSource::Transaction(self.receipts.len()), &state);
 
-        let gas_used = result.gas_used();
+        let gas_used = result.tx_gas_used();
 
         // append gas used
         self.gas_used += gas_used;
@@ -347,7 +350,7 @@ where
 
         self.evm.db_mut().commit(state);
 
-        Ok(gas_used)
+        Ok(GasOutput::new(gas_used))
     }
 
     fn finish(
@@ -751,7 +754,8 @@ mod tests {
         let expected_da_footprint = executor.jovian_da_footprint_estimation(&tx_env, &tx).unwrap();
 
         // make sure we can use both `WithEncoded` and transaction itself as inputs.
-        let gas_used_tx = executor.execute_transaction(&tx).expect("failed to execute transaction");
+        let gas_used_tx =
+            executor.execute_transaction(&tx).expect("failed to execute transaction").tx_gas_used();
 
         // The gas used when executing the transaction should be the legacy value...
         assert!(gas_used_tx < expected_da_footprint);

--- a/rust/alloy-op-evm/src/env.rs
+++ b/rust/alloy-op-evm/src/env.rs
@@ -35,8 +35,8 @@ pub fn spec_by_timestamp_after_bedrock(chain_spec: impl OpHardforks, timestamp: 
         };
     }
     check_forks! {
+        is_karst_active_at_timestamp => OSAKA,
         is_interop_active_at_timestamp => INTEROP,
-        is_karst_active_at_timestamp => KARST,
         is_jovian_active_at_timestamp => JOVIAN,
         is_isthmus_active_at_timestamp => ISTHMUS,
         is_holocene_active_at_timestamp => HOLOCENE,
@@ -205,7 +205,6 @@ mod tests {
     fake_hardfork_constructors! {
         timestamp:
             interop => Interop,
-            karst => Karst,
             jovian => Jovian,
             isthmus => Isthmus,
             holocene => Holocene,
@@ -231,7 +230,6 @@ mod tests {
     }
 
     #[test_case::test_case(FakeHardfork::interop(), OpSpecId::INTEROP; "Interop")]
-    #[test_case::test_case(FakeHardfork::karst(), OpSpecId::KARST; "Karst")]
     #[test_case::test_case(FakeHardfork::jovian(), OpSpecId::JOVIAN; "Jovian")]
     #[test_case::test_case(FakeHardfork::isthmus(), OpSpecId::ISTHMUS; "Isthmus")]
     #[test_case::test_case(FakeHardfork::holocene(), OpSpecId::HOLOCENE; "Holocene")]

--- a/rust/alloy-op-evm/src/env.rs
+++ b/rust/alloy-op-evm/src/env.rs
@@ -35,7 +35,7 @@ pub fn spec_by_timestamp_after_bedrock(chain_spec: impl OpHardforks, timestamp: 
         };
     }
     check_forks! {
-        is_karst_active_at_timestamp => OSAKA,
+        is_karst_active_at_timestamp => KARST,
         is_interop_active_at_timestamp => INTEROP,
         is_jovian_active_at_timestamp => JOVIAN,
         is_isthmus_active_at_timestamp => ISTHMUS,
@@ -204,6 +204,7 @@ mod tests {
 
     fake_hardfork_constructors! {
         timestamp:
+            karst => Karst,
             interop => Interop,
             jovian => Jovian,
             isthmus => Isthmus,
@@ -229,6 +230,7 @@ mod tests {
         }
     }
 
+    #[test_case::test_case(FakeHardfork::karst(), OpSpecId::KARST; "Karst")]
     #[test_case::test_case(FakeHardfork::interop(), OpSpecId::INTEROP; "Interop")]
     #[test_case::test_case(FakeHardfork::jovian(), OpSpecId::JOVIAN; "Jovian")]
     #[test_case::test_case(FakeHardfork::isthmus(), OpSpecId::ISTHMUS; "Isthmus")]

--- a/rust/alloy-op-evm/src/error.rs
+++ b/rust/alloy-op-evm/src/error.rs
@@ -37,5 +37,6 @@ pub fn map_op_err<DB>(err: EVMError<DB, OpTransactionError>) -> EVMError<DB, OpT
         EVMError::Database(e) => EVMError::Database(e),
         EVMError::Header(e) => EVMError::Header(e),
         EVMError::Custom(e) => EVMError::Custom(e),
+        EVMError::CustomAny(e) => EVMError::CustomAny(e),
     }
 }

--- a/rust/alloy-op-evm/src/lib.rs
+++ b/rust/alloy-op-evm/src/lib.rs
@@ -137,6 +137,10 @@ where
         &self.block
     }
 
+    fn cfg_env(&self) -> &CfgEnv<OpSpecId> {
+        &self.cfg
+    }
+
     fn chain_id(&self) -> u64 {
         self.cfg.chain_id
     }
@@ -162,7 +166,7 @@ where
         self.inner.system_call_with_caller(caller, contract, data).map_err(map_op_err)
     }
 
-    fn finish(self) -> (Self::DB, EvmEnv<Self::Spec>) {
+    fn finish(self) -> (Self::DB, EvmEnv<Self::Spec, Self::BlockEnv>) {
         let Context { block: block_env, cfg: cfg_env, journaled_state, .. } = self.inner.0.ctx;
 
         (journaled_state.database, EvmEnv { block_env, cfg_env })
@@ -227,7 +231,7 @@ where
     fn create_evm<DB: Database>(
         &self,
         db: DB,
-        input: EvmEnv<OpSpecId>,
+        input: EvmEnv<OpSpecId, BlockEnv>,
     ) -> Self::Evm<DB, NoOpInspector> {
         let spec_id = input.cfg_env.spec;
         OpEvm {
@@ -250,7 +254,7 @@ where
     fn create_evm_with_inspector<DB: Database, I: Inspector<Self::Context<DB>>>(
         &self,
         db: DB,
-        input: EvmEnv<OpSpecId>,
+        input: EvmEnv<OpSpecId, BlockEnv>,
         inspector: I,
     ) -> Self::Evm<DB, I> {
         let spec_id = input.cfg_env.spec;
@@ -274,14 +278,14 @@ where
 
 #[cfg(test)]
 mod tests {
-    use alloc::{string::ToString, vec};
+    use alloc::vec;
     use alloy_evm::{
         EvmInternals,
         precompiles::{Precompile, PrecompileInput},
     };
     use alloy_primitives::U256;
     use op_revm::precompiles::{bls12_381, bn254_pair};
-    use revm::{context::CfgEnv, database::EmptyDB, precompile::PrecompileError};
+    use revm::{context::CfgEnv, database::EmptyDB, precompile::PrecompileHalt};
 
     use super::*;
 
@@ -295,64 +299,85 @@ mod tests {
         let (precompiles, ctx) = (&mut evm.inner.0.precompiles, &mut evm.inner.0.ctx);
 
         let jovian_precompile = precompiles.get(bn254_pair::JOVIAN.address()).unwrap();
-        let result = jovian_precompile.call(PrecompileInput {
-            data: &vec![0; bn254_pair::JOVIAN_MAX_INPUT_SIZE + 1],
-            gas: u64::MAX,
-            caller: Address::ZERO,
-            value: U256::ZERO,
-            is_static: false,
-            target_address: Address::ZERO,
-            bytecode_address: Address::ZERO,
-            internals: EvmInternals::from_context(ctx),
-        });
+        let result = jovian_precompile
+            .call(PrecompileInput {
+                data: &vec![0; bn254_pair::JOVIAN_MAX_INPUT_SIZE + 1],
+                gas: u64::MAX,
+                reservoir: 0,
+                caller: Address::ZERO,
+                value: U256::ZERO,
+                is_static: false,
+                target_address: Address::ZERO,
+                bytecode_address: Address::ZERO,
+                internals: EvmInternals::from_context(ctx),
+            })
+            .unwrap();
 
-        assert!(result.is_err());
-        assert!(matches!(result.unwrap_err(), PrecompileError::Bn254PairLength));
+        assert!(result.is_halt());
+        assert!(matches!(result.halt_reason(), Some(&PrecompileHalt::Bn254PairLength)));
 
         let jovian_precompile = precompiles.get(bls12_381::JOVIAN_G1_MSM.address()).unwrap();
-        let result = jovian_precompile.call(PrecompileInput {
-            data: &vec![0; bls12_381::JOVIAN_G1_MSM_MAX_INPUT_SIZE + 1],
-            gas: u64::MAX,
-            caller: Address::ZERO,
-            value: U256::ZERO,
-            is_static: false,
-            target_address: Address::ZERO,
-            bytecode_address: Address::ZERO,
-            internals: EvmInternals::from_context(ctx),
-        });
+        let result = jovian_precompile
+            .call(PrecompileInput {
+                data: &vec![0; bls12_381::JOVIAN_G1_MSM_MAX_INPUT_SIZE + 1],
+                gas: u64::MAX,
+                reservoir: 0,
+                caller: Address::ZERO,
+                value: U256::ZERO,
+                is_static: false,
+                target_address: Address::ZERO,
+                bytecode_address: Address::ZERO,
+                internals: EvmInternals::from_context(ctx),
+            })
+            .unwrap();
 
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("G1MSM input length too long"));
+        assert!(result.is_halt());
+        assert!(matches!(
+            result.halt_reason(),
+            Some(PrecompileHalt::Other(msg)) if msg.contains("G1MSM input length too long")
+        ));
 
         let jovian_precompile = precompiles.get(bls12_381::JOVIAN_G2_MSM.address()).unwrap();
-        let result = jovian_precompile.call(PrecompileInput {
-            data: &vec![0; bls12_381::JOVIAN_G2_MSM_MAX_INPUT_SIZE + 1],
-            gas: u64::MAX,
-            caller: Address::ZERO,
-            value: U256::ZERO,
-            is_static: false,
-            target_address: Address::ZERO,
-            bytecode_address: Address::ZERO,
-            internals: EvmInternals::from_context(ctx),
-        });
+        let result = jovian_precompile
+            .call(PrecompileInput {
+                data: &vec![0; bls12_381::JOVIAN_G2_MSM_MAX_INPUT_SIZE + 1],
+                gas: u64::MAX,
+                reservoir: 0,
+                caller: Address::ZERO,
+                value: U256::ZERO,
+                is_static: false,
+                target_address: Address::ZERO,
+                bytecode_address: Address::ZERO,
+                internals: EvmInternals::from_context(ctx),
+            })
+            .unwrap();
 
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("G2MSM input length too long"));
+        assert!(result.is_halt());
+        assert!(matches!(
+            result.halt_reason(),
+            Some(PrecompileHalt::Other(msg)) if msg.contains("G2MSM input length too long")
+        ));
 
         let jovian_precompile = precompiles.get(bls12_381::JOVIAN_PAIRING.address()).unwrap();
-        let result = jovian_precompile.call(PrecompileInput {
-            data: &vec![0; bls12_381::JOVIAN_PAIRING_MAX_INPUT_SIZE + 1],
-            gas: u64::MAX,
-            caller: Address::ZERO,
-            value: U256::ZERO,
-            is_static: false,
-            target_address: Address::ZERO,
-            bytecode_address: Address::ZERO,
-            internals: EvmInternals::from_context(ctx),
-        });
+        let result = jovian_precompile
+            .call(PrecompileInput {
+                data: &vec![0; bls12_381::JOVIAN_PAIRING_MAX_INPUT_SIZE + 1],
+                gas: u64::MAX,
+                reservoir: 0,
+                caller: Address::ZERO,
+                value: U256::ZERO,
+                is_static: false,
+                target_address: Address::ZERO,
+                bytecode_address: Address::ZERO,
+                internals: EvmInternals::from_context(ctx),
+            })
+            .unwrap();
 
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("Pairing input length too long"));
+        assert!(result.is_halt());
+        assert!(matches!(
+            result.halt_reason(),
+            Some(PrecompileHalt::Other(msg)) if msg.contains("Pairing input length too long")
+        ));
     }
 
     #[test]
@@ -366,6 +391,7 @@ mod tests {
         let result = jovian_precompile.call(PrecompileInput {
             data: &vec![0; bn254_pair::JOVIAN_MAX_INPUT_SIZE],
             gas: u64::MAX,
+            reservoir: 0,
             caller: Address::ZERO,
             value: U256::ZERO,
             is_static: false,
@@ -380,6 +406,7 @@ mod tests {
         let result = jovian_precompile.call(PrecompileInput {
             data: &vec![0; bls12_381::JOVIAN_G1_MSM_MAX_INPUT_SIZE],
             gas: u64::MAX,
+            reservoir: 0,
             caller: Address::ZERO,
             value: U256::ZERO,
             is_static: false,
@@ -394,6 +421,7 @@ mod tests {
         let result = jovian_precompile.call(PrecompileInput {
             data: &vec![0; bls12_381::JOVIAN_G2_MSM_MAX_INPUT_SIZE],
             gas: u64::MAX,
+            reservoir: 0,
             caller: Address::ZERO,
             value: U256::ZERO,
             is_static: false,
@@ -408,6 +436,7 @@ mod tests {
         let result = jovian_precompile.call(PrecompileInput {
             data: &vec![0; bls12_381::JOVIAN_PAIRING_MAX_INPUT_SIZE],
             gas: u64::MAX,
+            reservoir: 0,
             caller: Address::ZERO,
             value: U256::ZERO,
             is_static: false,

--- a/rust/justfile
+++ b/rust/justfile
@@ -121,9 +121,6 @@ check-no-std:
     op-alloy-consensus
     op-alloy-rpc-types
     op-alloy-rpc-types-engine
-
-    # op-revm
-    op-revm
   )
 
   # We need to install the riscv32imac-unknown-none-elf target before starting to build the no-std crates.

--- a/rust/kona/bin/client/src/fpvm_evm/precompiles/bls12_g1_add.rs
+++ b/rust/kona/bin/client/src/fpvm_evm/precompiles/bls12_g1_add.rs
@@ -10,7 +10,7 @@ use crate::fpvm_evm::precompiles::utils::precompile_run;
 use alloc::string::ToString;
 use kona_preimage::{HintWriterClient, PreimageOracleClient};
 use revm::precompile::{
-    PrecompileError, PrecompileOutput, PrecompileResult, bls12_381,
+    EthPrecompileOutput, EthPrecompileResult, PrecompileHalt, bls12_381,
     bls12_381_const::{G1_ADD_BASE_GAS_FEE, G1_ADD_INPUT_LENGTH},
 };
 
@@ -23,18 +23,18 @@ pub(crate) fn fpvm_bls12_g1_add<H, O>(
     gas_limit: u64,
     hint_writer: &H,
     oracle_reader: &O,
-) -> PrecompileResult
+) -> EthPrecompileResult
 where
     H: HintWriterClient + Send + Sync,
     O: PreimageOracleClient + Send + Sync,
 {
     if G1_ADD_BASE_GAS_FEE > gas_limit {
-        return Err(PrecompileError::OutOfGas);
+        return Err(PrecompileHalt::OutOfGas);
     }
 
     let input_len = input.len();
     if input_len != G1_ADD_INPUT_LENGTH {
-        return Err(PrecompileError::Other(
+        return Err(PrecompileHalt::Other(
             alloc::format!(
                 "G1 addition input length should be {G1_ADD_INPUT_LENGTH} bytes, was {input_len}"
             )
@@ -49,9 +49,9 @@ where
         oracle_reader,
         &[precompile.address().as_slice(), &G1_ADD_BASE_GAS_FEE.to_be_bytes(), input]
     })
-    .map_err(|e| PrecompileError::Other(e.to_string().into()))?;
+    .map_err(|e| PrecompileHalt::Other(e.to_string().into()))?;
 
-    Ok(PrecompileOutput::new(G1_ADD_BASE_GAS_FEE, result_data.into()))
+    Ok(EthPrecompileOutput::new(G1_ADD_BASE_GAS_FEE, result_data.into()))
 }
 
 #[cfg(test)]
@@ -86,7 +86,7 @@ mod test {
         test_accelerated_precompile(|hint_writer, oracle_reader| {
             let accelerated_result =
                 fpvm_bls12_g1_add(&[], u64::MAX, hint_writer, oracle_reader).unwrap_err();
-            assert!(matches!(accelerated_result, PrecompileError::Other(_)));
+            assert!(matches!(accelerated_result, PrecompileHalt::Other(_)));
         })
         .await;
     }
@@ -96,7 +96,7 @@ mod test {
         test_accelerated_precompile(|hint_writer, oracle_reader| {
             let accelerated_result =
                 fpvm_bls12_g1_add(&[], 0, hint_writer, oracle_reader).unwrap_err();
-            assert!(matches!(accelerated_result, PrecompileError::OutOfGas));
+            assert!(matches!(accelerated_result, PrecompileHalt::OutOfGas));
         })
         .await;
     }

--- a/rust/kona/bin/client/src/fpvm_evm/precompiles/bls12_g1_msm.rs
+++ b/rust/kona/bin/client/src/fpvm_evm/precompiles/bls12_g1_msm.rs
@@ -10,7 +10,7 @@ use crate::fpvm_evm::precompiles::utils::precompile_run;
 use alloc::string::ToString;
 use kona_preimage::{HintWriterClient, PreimageOracleClient};
 use revm::precompile::{
-    PrecompileError, PrecompileOutput, PrecompileResult, bls12_381,
+    EthPrecompileOutput, EthPrecompileResult, PrecompileHalt, bls12_381,
     bls12_381_const::{DISCOUNT_TABLE_G1_MSM, G1_MSM_BASE_GAS_FEE, G1_MSM_INPUT_LENGTH},
     bls12_381_utils::msm_required_gas,
 };
@@ -29,13 +29,13 @@ pub(crate) fn fpvm_bls12_g1_msm<H, O>(
     gas_limit: u64,
     hint_writer: &H,
     oracle_reader: &O,
-) -> PrecompileResult
+) -> EthPrecompileResult
 where
     H: HintWriterClient + Send + Sync,
     O: PreimageOracleClient + Send + Sync,
 {
     if input.len() > BLS12_MAX_G1_MSM_SIZE_ISTHMUS {
-        return Err(PrecompileError::Other(
+        return Err(PrecompileHalt::Other(
             alloc::format!("G1MSM input length must be at most {BLS12_MAX_G1_MSM_SIZE_ISTHMUS}")
                 .into(),
         ));
@@ -43,7 +43,7 @@ where
 
     let input_len = input.len();
     if input_len == 0 || !input_len.is_multiple_of(G1_MSM_INPUT_LENGTH) {
-        return Err(PrecompileError::Other(
+        return Err(PrecompileHalt::Other(
             alloc::format!(
                 "G1MSM input length should be multiple of {G1_MSM_INPUT_LENGTH}, was {input_len}"
             )
@@ -54,7 +54,7 @@ where
     let k = input_len / G1_MSM_INPUT_LENGTH;
     let required_gas = msm_required_gas(k, &DISCOUNT_TABLE_G1_MSM, G1_MSM_BASE_GAS_FEE);
     if required_gas > gas_limit {
-        return Err(PrecompileError::OutOfGas);
+        return Err(PrecompileHalt::OutOfGas);
     }
 
     let precompile = bls12_381::g1_msm::PRECOMPILE;
@@ -64,9 +64,9 @@ where
         oracle_reader,
         &[precompile.address().as_slice(), &required_gas.to_be_bytes(), input]
     })
-    .map_err(|e| PrecompileError::Other(e.to_string().into()))?;
+    .map_err(|e| PrecompileHalt::Other(e.to_string().into()))?;
 
-    Ok(PrecompileOutput::new(required_gas, result_data.into()))
+    Ok(EthPrecompileOutput::new(required_gas, result_data.into()))
 }
 
 /// Performs an FPVM-accelerated `bls12` g1 msm check precompile call after the Jovian Hardfork.
@@ -75,13 +75,13 @@ pub(crate) fn fpvm_bls12_g1_msm_jovian<H, O>(
     gas_limit: u64,
     hint_writer: &H,
     oracle_reader: &O,
-) -> PrecompileResult
+) -> EthPrecompileResult
 where
     H: HintWriterClient + Send + Sync,
     O: PreimageOracleClient + Send + Sync,
 {
     if input.len() > BLS12_MAX_G1_MSM_SIZE_JOVIAN {
-        return Err(PrecompileError::Other(
+        return Err(PrecompileHalt::Other(
             alloc::format!("G1MSM input length must be at most {BLS12_MAX_G1_MSM_SIZE_JOVIAN}")
                 .into(),
         ));
@@ -136,7 +136,7 @@ mod test {
                 oracle_reader,
             )
             .unwrap_err();
-            assert!(matches!(accelerated_result, PrecompileError::Other(_)));
+            assert!(matches!(accelerated_result, PrecompileHalt::Other(_)));
         })
         .await;
     }
@@ -146,7 +146,7 @@ mod test {
         test_accelerated_precompile(|hint_writer, oracle_reader| {
             let accelerated_result =
                 fpvm_bls12_g1_msm(&[], u64::MAX, hint_writer, oracle_reader).unwrap_err();
-            assert!(matches!(accelerated_result, PrecompileError::Other(_)));
+            assert!(matches!(accelerated_result, PrecompileHalt::Other(_)));
         })
         .await;
     }
@@ -161,7 +161,7 @@ mod test {
                 oracle_reader,
             )
             .unwrap_err();
-            assert!(matches!(accelerated_result, PrecompileError::Other(_)));
+            assert!(matches!(accelerated_result, PrecompileHalt::Other(_)));
         })
         .await;
     }
@@ -172,7 +172,7 @@ mod test {
             let accelerated_result =
                 fpvm_bls12_g1_msm(&[0u8; G1_MSM_INPUT_LENGTH], 0, hint_writer, oracle_reader)
                     .unwrap_err();
-            assert!(matches!(accelerated_result, PrecompileError::OutOfGas));
+            assert!(matches!(accelerated_result, PrecompileHalt::OutOfGas));
         })
         .await;
     }
@@ -202,7 +202,7 @@ mod test {
             let input = [0u8; INPUT_SIZE];
             let accelerated_result =
                 fpvm_bls12_g1_msm_jovian(&input, u64::MAX, hint_writer, oracle_reader).unwrap_err();
-            assert!(matches!(accelerated_result, PrecompileError::Other(_)));
+            assert!(matches!(accelerated_result, PrecompileHalt::Other(_)));
         })
         .await;
     }

--- a/rust/kona/bin/client/src/fpvm_evm/precompiles/bls12_g2_add.rs
+++ b/rust/kona/bin/client/src/fpvm_evm/precompiles/bls12_g2_add.rs
@@ -10,7 +10,7 @@ use crate::fpvm_evm::precompiles::utils::precompile_run;
 use alloc::string::ToString;
 use kona_preimage::{HintWriterClient, PreimageOracleClient};
 use revm::precompile::{
-    PrecompileError, PrecompileOutput, PrecompileResult, bls12_381,
+    EthPrecompileOutput, EthPrecompileResult, PrecompileHalt, bls12_381,
     bls12_381_const::{G2_ADD_BASE_GAS_FEE, G2_ADD_INPUT_LENGTH},
 };
 
@@ -23,18 +23,18 @@ pub(crate) fn fpvm_bls12_g2_add<H, O>(
     gas_limit: u64,
     hint_writer: &H,
     oracle_reader: &O,
-) -> PrecompileResult
+) -> EthPrecompileResult
 where
     H: HintWriterClient + Send + Sync,
     O: PreimageOracleClient + Send + Sync,
 {
     if G2_ADD_BASE_GAS_FEE > gas_limit {
-        return Err(PrecompileError::OutOfGas);
+        return Err(PrecompileHalt::OutOfGas);
     }
 
     let input_len = input.len();
     if input_len != G2_ADD_INPUT_LENGTH {
-        return Err(PrecompileError::Other(
+        return Err(PrecompileHalt::Other(
             alloc::format!(
                 "G2 addition input length should be {G2_ADD_INPUT_LENGTH} bytes, was {input_len}"
             )
@@ -49,9 +49,9 @@ where
         oracle_reader,
         &[precompile.address().as_slice(), &G2_ADD_BASE_GAS_FEE.to_be_bytes(), input]
     })
-    .map_err(|e| PrecompileError::Other(e.to_string().into()))?;
+    .map_err(|e| PrecompileHalt::Other(e.to_string().into()))?;
 
-    Ok(PrecompileOutput::new(G2_ADD_BASE_GAS_FEE, result_data.into()))
+    Ok(EthPrecompileOutput::new(G2_ADD_BASE_GAS_FEE, result_data.into()))
 }
 
 #[cfg(test)]
@@ -86,7 +86,7 @@ mod test {
         test_accelerated_precompile(|hint_writer, oracle_reader| {
             let accelerated_result =
                 fpvm_bls12_g2_add(&[], u64::MAX, hint_writer, oracle_reader).unwrap_err();
-            assert!(matches!(accelerated_result, PrecompileError::Other(_)));
+            assert!(matches!(accelerated_result, PrecompileHalt::Other(_)));
         })
         .await;
     }
@@ -96,7 +96,7 @@ mod test {
         test_accelerated_precompile(|hint_writer, oracle_reader| {
             let accelerated_result =
                 fpvm_bls12_g2_add(&[], 0, hint_writer, oracle_reader).unwrap_err();
-            assert!(matches!(accelerated_result, PrecompileError::OutOfGas));
+            assert!(matches!(accelerated_result, PrecompileHalt::OutOfGas));
         })
         .await;
     }

--- a/rust/kona/bin/client/src/fpvm_evm/precompiles/bls12_g2_msm.rs
+++ b/rust/kona/bin/client/src/fpvm_evm/precompiles/bls12_g2_msm.rs
@@ -10,7 +10,7 @@ use crate::fpvm_evm::precompiles::utils::precompile_run;
 use alloc::string::ToString;
 use kona_preimage::{HintWriterClient, PreimageOracleClient};
 use revm::precompile::{
-    PrecompileError, PrecompileOutput, PrecompileResult, bls12_381,
+    EthPrecompileOutput, EthPrecompileResult, PrecompileHalt, bls12_381,
     bls12_381_const::{DISCOUNT_TABLE_G2_MSM, G2_MSM_BASE_GAS_FEE, G2_MSM_INPUT_LENGTH},
     bls12_381_utils::msm_required_gas,
 };
@@ -29,7 +29,7 @@ pub(crate) fn fpvm_bls12_g2_msm<H, O>(
     gas_limit: u64,
     hint_writer: &H,
     oracle_reader: &O,
-) -> PrecompileResult
+) -> EthPrecompileResult
 where
     H: HintWriterClient + Send + Sync,
     O: PreimageOracleClient + Send + Sync,
@@ -37,14 +37,14 @@ where
     let input_len = input.len();
 
     if input_len > BLS12_MAX_G2_MSM_SIZE_ISTHMUS {
-        return Err(PrecompileError::Other(
+        return Err(PrecompileHalt::Other(
             alloc::format!("G2MSM input length must be at most {BLS12_MAX_G2_MSM_SIZE_ISTHMUS}")
                 .into(),
         ));
     }
 
     if input_len == 0 || !input_len.is_multiple_of(G2_MSM_INPUT_LENGTH) {
-        return Err(PrecompileError::Other(
+        return Err(PrecompileHalt::Other(
             alloc::format!(
                 "G2MSM input length should be multiple of {G2_MSM_INPUT_LENGTH}, was {input_len}"
             )
@@ -55,7 +55,7 @@ where
     let k = input_len / G2_MSM_INPUT_LENGTH;
     let required_gas = msm_required_gas(k, &DISCOUNT_TABLE_G2_MSM, G2_MSM_BASE_GAS_FEE);
     if required_gas > gas_limit {
-        return Err(PrecompileError::OutOfGas);
+        return Err(PrecompileHalt::OutOfGas);
     }
 
     let precompile = bls12_381::g2_msm::PRECOMPILE;
@@ -65,9 +65,9 @@ where
         oracle_reader,
         &[precompile.address().as_slice(), &required_gas.to_be_bytes(), input]
     })
-    .map_err(|e| PrecompileError::Other(e.to_string().into()))?;
+    .map_err(|e| PrecompileHalt::Other(e.to_string().into()))?;
 
-    Ok(PrecompileOutput::new(required_gas, result_data.into()))
+    Ok(EthPrecompileOutput::new(required_gas, result_data.into()))
 }
 
 /// Performs an FPVM-accelerated BLS12-381 G2 msm check after the Jovian Hardfork.
@@ -76,13 +76,13 @@ pub(crate) fn fpvm_bls12_g2_msm_jovian<H, O>(
     gas_limit: u64,
     hint_writer: &H,
     oracle_reader: &O,
-) -> PrecompileResult
+) -> EthPrecompileResult
 where
     H: HintWriterClient + Send + Sync,
     O: PreimageOracleClient + Send + Sync,
 {
     if input.len() > BLS12_MAX_G2_MSM_SIZE_JOVIAN {
-        return Err(PrecompileError::Other(
+        return Err(PrecompileHalt::Other(
             alloc::format!("G2MSM input length must be at most {BLS12_MAX_G2_MSM_SIZE_JOVIAN}")
                 .into(),
         ));
@@ -137,7 +137,7 @@ mod test {
                 oracle_reader,
             )
             .unwrap_err();
-            assert!(matches!(accelerated_result, PrecompileError::Other(_)));
+            assert!(matches!(accelerated_result, PrecompileHalt::Other(_)));
         })
         .await;
     }
@@ -147,7 +147,7 @@ mod test {
         test_accelerated_precompile(|hint_writer, oracle_reader| {
             let accelerated_result =
                 fpvm_bls12_g2_msm(&[], u64::MAX, hint_writer, oracle_reader).unwrap_err();
-            assert!(matches!(accelerated_result, PrecompileError::Other(_)));
+            assert!(matches!(accelerated_result, PrecompileHalt::Other(_)));
         })
         .await;
     }
@@ -158,7 +158,7 @@ mod test {
             let accelerated_result =
                 fpvm_bls12_g2_msm(&[0u8; G2_MSM_INPUT_LENGTH], 0, hint_writer, oracle_reader)
                     .unwrap_err();
-            assert!(matches!(accelerated_result, PrecompileError::OutOfGas));
+            assert!(matches!(accelerated_result, PrecompileHalt::OutOfGas));
         })
         .await;
     }
@@ -188,7 +188,7 @@ mod test {
             let input = [0u8; INPUT_SIZE];
             let accelerated_result =
                 fpvm_bls12_g2_msm_jovian(&input, u64::MAX, hint_writer, oracle_reader).unwrap_err();
-            assert!(matches!(accelerated_result, PrecompileError::Other(_)));
+            assert!(matches!(accelerated_result, PrecompileHalt::Other(_)));
         })
         .await;
     }

--- a/rust/kona/bin/client/src/fpvm_evm/precompiles/bls12_map_fp.rs
+++ b/rust/kona/bin/client/src/fpvm_evm/precompiles/bls12_map_fp.rs
@@ -10,7 +10,7 @@ use crate::fpvm_evm::precompiles::utils::precompile_run;
 use alloc::string::ToString;
 use kona_preimage::{HintWriterClient, PreimageOracleClient};
 use revm::precompile::{
-    PrecompileError, PrecompileOutput, PrecompileResult, bls12_381,
+    EthPrecompileOutput, EthPrecompileResult, PrecompileHalt, bls12_381,
     bls12_381_const::{MAP_FP_TO_G1_BASE_GAS_FEE, PADDED_FP_LENGTH},
 };
 
@@ -23,17 +23,17 @@ pub(crate) fn fpvm_bls12_map_fp<H, O>(
     gas_limit: u64,
     hint_writer: &H,
     oracle_reader: &O,
-) -> PrecompileResult
+) -> EthPrecompileResult
 where
     H: HintWriterClient + Send + Sync,
     O: PreimageOracleClient + Send + Sync,
 {
     if MAP_FP_TO_G1_BASE_GAS_FEE > gas_limit {
-        return Err(PrecompileError::OutOfGas);
+        return Err(PrecompileHalt::OutOfGas);
     }
 
     if input.len() != PADDED_FP_LENGTH {
-        return Err(PrecompileError::Other(
+        return Err(PrecompileHalt::Other(
             alloc::format!(
                 "MAP_FP_TO_G1 input should be {PADDED_FP_LENGTH} bytes, was {}",
                 input.len()
@@ -49,9 +49,9 @@ where
         oracle_reader,
         &[precompile.address().as_slice(), &MAP_FP_TO_G1_BASE_GAS_FEE.to_be_bytes(), input]
     })
-    .map_err(|e| PrecompileError::Other(e.to_string().into()))?;
+    .map_err(|e| PrecompileHalt::Other(e.to_string().into()))?;
 
-    Ok(PrecompileOutput::new(MAP_FP_TO_G1_BASE_GAS_FEE, result_data.into()))
+    Ok(EthPrecompileOutput::new(MAP_FP_TO_G1_BASE_GAS_FEE, result_data.into()))
 }
 
 #[cfg(test)]
@@ -85,7 +85,7 @@ mod test {
         test_accelerated_precompile(|hint_writer, oracle_reader| {
             let accelerated_result =
                 fpvm_bls12_map_fp(&[], 0, hint_writer, oracle_reader).unwrap_err();
-            assert!(matches!(accelerated_result, PrecompileError::OutOfGas));
+            assert!(matches!(accelerated_result, PrecompileHalt::OutOfGas));
         })
         .await;
     }
@@ -95,7 +95,7 @@ mod test {
         test_accelerated_precompile(|hint_writer, oracle_reader| {
             let accelerated_result =
                 fpvm_bls12_map_fp(&[], u64::MAX, hint_writer, oracle_reader).unwrap_err();
-            assert!(matches!(accelerated_result, PrecompileError::Other(_)));
+            assert!(matches!(accelerated_result, PrecompileHalt::Other(_)));
         })
         .await;
     }

--- a/rust/kona/bin/client/src/fpvm_evm/precompiles/bls12_map_fp2.rs
+++ b/rust/kona/bin/client/src/fpvm_evm/precompiles/bls12_map_fp2.rs
@@ -10,7 +10,7 @@ use crate::fpvm_evm::precompiles::utils::precompile_run;
 use alloc::string::ToString;
 use kona_preimage::{HintWriterClient, PreimageOracleClient};
 use revm::precompile::{
-    PrecompileError, PrecompileOutput, PrecompileResult, bls12_381,
+    EthPrecompileOutput, EthPrecompileResult, PrecompileHalt, bls12_381,
     bls12_381_const::{MAP_FP2_TO_G2_BASE_GAS_FEE, PADDED_FP2_LENGTH},
 };
 
@@ -23,17 +23,17 @@ pub(crate) fn fpvm_bls12_map_fp2<H, O>(
     gas_limit: u64,
     hint_writer: &H,
     oracle_reader: &O,
-) -> PrecompileResult
+) -> EthPrecompileResult
 where
     H: HintWriterClient + Send + Sync,
     O: PreimageOracleClient + Send + Sync,
 {
     if MAP_FP2_TO_G2_BASE_GAS_FEE > gas_limit {
-        return Err(PrecompileError::OutOfGas);
+        return Err(PrecompileHalt::OutOfGas);
     }
 
     if input.len() != PADDED_FP2_LENGTH {
-        return Err(PrecompileError::Other(
+        return Err(PrecompileHalt::Other(
             alloc::format!(
                 "MAP_FP2_TO_G2 input should be {PADDED_FP2_LENGTH} bytes, was {}",
                 input.len()
@@ -49,9 +49,9 @@ where
         oracle_reader,
         &[precompile.address().as_slice(), &MAP_FP2_TO_G2_BASE_GAS_FEE.to_be_bytes(), input]
     })
-    .map_err(|e| PrecompileError::Other(e.to_string().into()))?;
+    .map_err(|e| PrecompileHalt::Other(e.to_string().into()))?;
 
-    Ok(PrecompileOutput::new(MAP_FP2_TO_G2_BASE_GAS_FEE, result_data.into()))
+    Ok(EthPrecompileOutput::new(MAP_FP2_TO_G2_BASE_GAS_FEE, result_data.into()))
 }
 
 #[cfg(test)]
@@ -85,7 +85,7 @@ mod test {
         test_accelerated_precompile(|hint_writer, oracle_reader| {
             let accelerated_result =
                 fpvm_bls12_map_fp2(&[], 0, hint_writer, oracle_reader).unwrap_err();
-            assert!(matches!(accelerated_result, PrecompileError::OutOfGas));
+            assert!(matches!(accelerated_result, PrecompileHalt::OutOfGas));
         })
         .await;
     }
@@ -95,7 +95,7 @@ mod test {
         test_accelerated_precompile(|hint_writer, oracle_reader| {
             let accelerated_result =
                 fpvm_bls12_map_fp2(&[], u64::MAX, hint_writer, oracle_reader).unwrap_err();
-            assert!(matches!(accelerated_result, PrecompileError::Other(_)));
+            assert!(matches!(accelerated_result, PrecompileHalt::Other(_)));
         })
         .await;
     }

--- a/rust/kona/bin/client/src/fpvm_evm/precompiles/bls12_pair.rs
+++ b/rust/kona/bin/client/src/fpvm_evm/precompiles/bls12_pair.rs
@@ -10,7 +10,7 @@ use crate::fpvm_evm::precompiles::utils::precompile_run;
 use alloc::string::ToString;
 use kona_preimage::{HintWriterClient, PreimageOracleClient};
 use revm::precompile::{
-    PrecompileError, PrecompileOutput, PrecompileResult, bls12_381,
+    EthPrecompileOutput, EthPrecompileResult, PrecompileHalt, bls12_381,
     bls12_381_const::{PAIRING_INPUT_LENGTH, PAIRING_MULTIPLIER_BASE, PAIRING_OFFSET_BASE},
 };
 
@@ -26,7 +26,7 @@ pub(crate) fn fpvm_bls12_pairing<H, O>(
     gas_limit: u64,
     hint_writer: &H,
     oracle_reader: &O,
-) -> PrecompileResult
+) -> EthPrecompileResult
 where
     H: HintWriterClient + Send + Sync,
     O: PreimageOracleClient + Send + Sync,
@@ -34,14 +34,14 @@ where
     let input_len = input.len();
 
     if input_len > BLS12_MAX_PAIRING_SIZE_ISTHMUS {
-        return Err(PrecompileError::Other(
+        return Err(PrecompileHalt::Other(
             alloc::format!("Pairing input length must be at most {BLS12_MAX_PAIRING_SIZE_ISTHMUS}")
                 .into(),
         ));
     }
 
     if !input_len.is_multiple_of(PAIRING_INPUT_LENGTH) {
-        return Err(PrecompileError::Other(
+        return Err(PrecompileHalt::Other(
             alloc::format!(
                 "Pairing input length should be multiple of {PAIRING_INPUT_LENGTH}, was {input_len}"
             )
@@ -52,7 +52,7 @@ where
     let k = input_len / PAIRING_INPUT_LENGTH;
     let required_gas: u64 = PAIRING_MULTIPLIER_BASE * k as u64 + PAIRING_OFFSET_BASE;
     if required_gas > gas_limit {
-        return Err(PrecompileError::OutOfGas);
+        return Err(PrecompileHalt::OutOfGas);
     }
 
     let precompile = bls12_381::pairing::PRECOMPILE;
@@ -62,9 +62,9 @@ where
         oracle_reader,
         &[precompile.address().as_slice(), &required_gas.to_be_bytes(), input]
     })
-    .map_err(|e| PrecompileError::Other(e.to_string().into()))?;
+    .map_err(|e| PrecompileHalt::Other(e.to_string().into()))?;
 
-    Ok(PrecompileOutput::new(required_gas, result_data.into()))
+    Ok(EthPrecompileOutput::new(required_gas, result_data.into()))
 }
 
 /// Performs an FPVM-accelerated BLS12-381 pairing check after the Jovian Hardfork.
@@ -73,13 +73,13 @@ pub(crate) fn fpvm_bls12_pairing_jovian<H, O>(
     gas_limit: u64,
     hint_writer: &H,
     oracle_reader: &O,
-) -> PrecompileResult
+) -> EthPrecompileResult
 where
     H: HintWriterClient + Send + Sync,
     O: PreimageOracleClient + Send + Sync,
 {
     if input.len() > BLS12_MAX_PAIRING_SIZE_JOVIAN {
-        return Err(PrecompileError::Other(
+        return Err(PrecompileHalt::Other(
             alloc::format!("Pairing input length must be at most {BLS12_MAX_PAIRING_SIZE_JOVIAN}")
                 .into(),
         ));
@@ -132,7 +132,7 @@ mod test {
                 oracle_reader,
             )
             .unwrap_err();
-            assert!(matches!(accelerated_result, PrecompileError::Other(_)));
+            assert!(matches!(accelerated_result, PrecompileHalt::Other(_)));
         })
         .await;
     }
@@ -143,7 +143,7 @@ mod test {
             let accelerated_result =
                 fpvm_bls12_pairing(&[0u8; PAIRING_INPUT_LENGTH - 1], 0, hint_writer, oracle_reader)
                     .unwrap_err();
-            assert!(matches!(accelerated_result, PrecompileError::Other(_)));
+            assert!(matches!(accelerated_result, PrecompileHalt::Other(_)));
         })
         .await;
     }
@@ -154,7 +154,7 @@ mod test {
             let accelerated_result =
                 fpvm_bls12_pairing(&[0u8; PAIRING_INPUT_LENGTH], 0, hint_writer, oracle_reader)
                     .unwrap_err();
-            assert!(matches!(accelerated_result, PrecompileError::OutOfGas));
+            assert!(matches!(accelerated_result, PrecompileHalt::OutOfGas));
         })
         .await;
     }
@@ -185,7 +185,7 @@ mod test {
             let accelerated_result =
                 fpvm_bls12_pairing_jovian(&input, u64::MAX, hint_writer, oracle_reader)
                     .unwrap_err();
-            assert!(matches!(accelerated_result, PrecompileError::Other(_)));
+            assert!(matches!(accelerated_result, PrecompileHalt::Other(_)));
         })
         .await;
     }

--- a/rust/kona/bin/client/src/fpvm_evm/precompiles/bn128_pair.rs
+++ b/rust/kona/bin/client/src/fpvm_evm/precompiles/bn128_pair.rs
@@ -4,7 +4,7 @@ use crate::fpvm_evm::precompiles::utils::precompile_run;
 use alloc::string::ToString;
 use kona_preimage::{HintWriterClient, PreimageOracleClient};
 use revm::precompile::{
-    PrecompileError, PrecompileOutput, PrecompileResult,
+    EthPrecompileOutput, EthPrecompileResult, PrecompileHalt,
     bn254::{
         PAIR_ELEMENT_LEN,
         pair::{self, ISTANBUL_PAIR_BASE, ISTANBUL_PAIR_PER_POINT},
@@ -20,7 +20,7 @@ pub(crate) fn fpvm_bn128_pair<H, O>(
     gas_limit: u64,
     hint_writer: &H,
     oracle_reader: &O,
-) -> PrecompileResult
+) -> EthPrecompileResult
 where
     H: HintWriterClient + Send + Sync,
     O: PreimageOracleClient + Send + Sync,
@@ -29,11 +29,11 @@ where
         (input.len() / PAIR_ELEMENT_LEN) as u64 * ISTANBUL_PAIR_PER_POINT + ISTANBUL_PAIR_BASE;
 
     if gas_used > gas_limit {
-        return Err(PrecompileError::OutOfGas);
+        return Err(PrecompileHalt::OutOfGas);
     }
 
     if !input.len().is_multiple_of(PAIR_ELEMENT_LEN) {
-        return Err(PrecompileError::Bn254PairLength);
+        return Err(PrecompileHalt::Bn254PairLength);
     }
 
     let precompile = pair::ISTANBUL;
@@ -43,9 +43,9 @@ where
         oracle_reader,
         &[precompile.address().as_slice(), &gas_used.to_be_bytes(), input]
     })
-    .map_err(|e| PrecompileError::Other(e.to_string().into()))?;
+    .map_err(|e| PrecompileHalt::Other(e.to_string().into()))?;
 
-    Ok(PrecompileOutput::new(gas_used, result_data.into()))
+    Ok(EthPrecompileOutput::new(gas_used, result_data.into()))
 }
 
 /// Runs the FPVM-accelerated `ecpairing` precompile call, with the input size limited by the
@@ -55,13 +55,13 @@ pub(crate) fn fpvm_bn128_pair_granite<H, O>(
     gas_limit: u64,
     hint_writer: &H,
     oracle_reader: &O,
-) -> PrecompileResult
+) -> EthPrecompileResult
 where
     H: HintWriterClient + Send + Sync,
     O: PreimageOracleClient + Send + Sync,
 {
     if input.len() > BN256_MAX_PAIRING_SIZE_GRANITE {
-        return Err(PrecompileError::Bn254PairLength);
+        return Err(PrecompileHalt::Bn254PairLength);
     }
 
     fpvm_bn128_pair(input, gas_limit, hint_writer, oracle_reader)
@@ -74,13 +74,13 @@ pub(crate) fn fpvm_bn128_pair_jovian<H, O>(
     gas_limit: u64,
     hint_writer: &H,
     oracle_reader: &O,
-) -> PrecompileResult
+) -> EthPrecompileResult
 where
     H: HintWriterClient + Send + Sync,
     O: PreimageOracleClient + Send + Sync,
 {
     if input.len() > BN256_MAX_PAIRING_SIZE_JOVIAN {
-        return Err(PrecompileError::Bn254PairLength);
+        return Err(PrecompileHalt::Bn254PairLength);
     }
 
     fpvm_bn128_pair(input, gas_limit, hint_writer, oracle_reader)
@@ -140,7 +140,7 @@ mod test {
             let accelerated_result =
                 fpvm_bn128_pair(&input, 0, hint_writer, oracle_reader).unwrap_err();
 
-            assert!(matches!(accelerated_result, PrecompileError::OutOfGas));
+            assert!(matches!(accelerated_result, PrecompileHalt::OutOfGas));
         })
         .await;
     }
@@ -152,7 +152,7 @@ mod test {
             let accelerated_result =
                 fpvm_bn128_pair(&input, u64::MAX, hint_writer, oracle_reader).unwrap_err();
 
-            assert!(matches!(accelerated_result, PrecompileError::Bn254PairLength));
+            assert!(matches!(accelerated_result, PrecompileHalt::Bn254PairLength));
         })
         .await;
     }
@@ -168,7 +168,7 @@ mod test {
             let accelerated_result =
                 fpvm_bn128_pair_granite(&input, u64::MAX, hint_writer, oracle_reader).unwrap_err();
 
-            assert!(matches!(accelerated_result, PrecompileError::Bn254PairLength));
+            assert!(matches!(accelerated_result, PrecompileHalt::Bn254PairLength));
         })
         .await;
     }
@@ -200,7 +200,7 @@ mod test {
             let accelerated_result =
                 fpvm_bn128_pair_jovian(&input, u64::MAX, hint_writer, oracle_reader).unwrap_err();
 
-            assert!(matches!(accelerated_result, PrecompileError::Bn254PairLength));
+            assert!(matches!(accelerated_result, PrecompileHalt::Bn254PairLength));
         })
         .await;
     }

--- a/rust/kona/bin/client/src/fpvm_evm/precompiles/ecrecover.rs
+++ b/rust/kona/bin/client/src/fpvm_evm/precompiles/ecrecover.rs
@@ -4,7 +4,7 @@ use crate::fpvm_evm::precompiles::utils::precompile_run;
 use alloc::string::ToString;
 use alloy_primitives::Address;
 use kona_preimage::{HintWriterClient, PreimageOracleClient};
-use revm::precompile::{PrecompileError, PrecompileOutput, PrecompileResult};
+use revm::precompile::{EthPrecompileOutput, EthPrecompileResult, PrecompileHalt};
 
 /// Address of the `ecrecover` precompile.
 pub(crate) const ECRECOVER_ADDR: Address = revm::precompile::u64_to_address(1);
@@ -15,7 +15,7 @@ pub(crate) fn fpvm_ec_recover<H, O>(
     gas_limit: u64,
     hint_writer: &H,
     oracle_reader: &O,
-) -> PrecompileResult
+) -> EthPrecompileResult
 where
     H: HintWriterClient + Send + Sync,
     O: PreimageOracleClient + Send + Sync,
@@ -23,7 +23,7 @@ where
     const ECRECOVER_BASE: u64 = 3_000;
 
     if ECRECOVER_BASE > gas_limit {
-        return Err(PrecompileError::OutOfGas);
+        return Err(PrecompileHalt::OutOfGas);
     }
 
     let truncated_input = &input[..input.len().min(128)];
@@ -33,10 +33,10 @@ where
         oracle_reader,
         &[ECRECOVER_ADDR.as_slice(), &ECRECOVER_BASE.to_be_bytes(), truncated_input]
     })
-    .map_err(|e| PrecompileError::Other(e.to_string().into()))
+    .map_err(|e| PrecompileHalt::Other(e.to_string().into()))
     .unwrap_or_default();
 
-    Ok(PrecompileOutput::new(ECRECOVER_BASE, result_data.into()))
+    Ok(EthPrecompileOutput::new(ECRECOVER_BASE, result_data.into()))
 }
 
 #[cfg(test)]
@@ -74,7 +74,7 @@ mod test {
             let accelerated_result =
                 fpvm_ec_recover(&[], 0, hint_writer, oracle_reader).unwrap_err();
 
-            assert!(matches!(accelerated_result, PrecompileError::OutOfGas));
+            assert!(matches!(accelerated_result, PrecompileHalt::OutOfGas));
         })
         .await;
     }

--- a/rust/kona/bin/client/src/fpvm_evm/precompiles/kzg_point_eval.rs
+++ b/rust/kona/bin/client/src/fpvm_evm/precompiles/kzg_point_eval.rs
@@ -4,7 +4,7 @@ use crate::fpvm_evm::precompiles::utils::precompile_run;
 use alloc::string::ToString;
 use alloy_primitives::Address;
 use kona_preimage::{HintWriterClient, PreimageOracleClient};
-use revm::precompile::{PrecompileError, PrecompileOutput, PrecompileResult};
+use revm::precompile::{EthPrecompileOutput, EthPrecompileResult, PrecompileHalt};
 
 /// Address of the KZG point evaluation precompile.
 pub(crate) const KZG_POINT_EVAL_ADDR: Address = revm::precompile::u64_to_address(0x0A);
@@ -15,7 +15,7 @@ pub(crate) fn fpvm_kzg_point_eval<H, O>(
     gas_limit: u64,
     hint_writer: &H,
     oracle_reader: &O,
-) -> PrecompileResult
+) -> EthPrecompileResult
 where
     H: HintWriterClient + Send + Sync,
     O: PreimageOracleClient + Send + Sync,
@@ -23,11 +23,11 @@ where
     const GAS_COST: u64 = 50_000;
 
     if gas_limit < GAS_COST {
-        return Err(PrecompileError::OutOfGas);
+        return Err(PrecompileHalt::OutOfGas);
     }
 
     if input.len() != 192 {
-        return Err(PrecompileError::BlobInvalidInputLength);
+        return Err(PrecompileHalt::BlobInvalidInputLength);
     }
 
     let result_data = kona_proof::block_on(precompile_run! {
@@ -35,9 +35,9 @@ where
         oracle_reader,
         &[KZG_POINT_EVAL_ADDR.as_slice(), &GAS_COST.to_be_bytes(), input]
     })
-    .map_err(|e| PrecompileError::Other(e.to_string().into()))?;
+    .map_err(|e| PrecompileHalt::Other(e.to_string().into()))?;
 
-    Ok(PrecompileOutput::new(GAS_COST, result_data.into()))
+    Ok(EthPrecompileOutput::new(GAS_COST, result_data.into()))
 }
 
 #[cfg(test)]
@@ -79,7 +79,7 @@ mod test {
         test_accelerated_precompile(|hint_writer, oracle_reader| {
             let accelerated_result =
                 fpvm_kzg_point_eval(&[], 0, hint_writer, oracle_reader).unwrap_err();
-            assert!(matches!(accelerated_result, PrecompileError::OutOfGas));
+            assert!(matches!(accelerated_result, PrecompileHalt::OutOfGas));
         })
         .await;
     }
@@ -89,7 +89,7 @@ mod test {
         test_accelerated_precompile(|hint_writer, oracle_reader| {
             let accelerated_result =
                 fpvm_kzg_point_eval(&[], u64::MAX, hint_writer, oracle_reader).unwrap_err();
-            assert!(matches!(accelerated_result, PrecompileError::BlobInvalidInputLength));
+            assert!(matches!(accelerated_result, PrecompileHalt::BlobInvalidInputLength));
         })
         .await;
     }

--- a/rust/kona/bin/client/src/fpvm_evm/precompiles/provider.rs
+++ b/rust/kona/bin/client/src/fpvm_evm/precompiles/provider.rs
@@ -8,7 +8,7 @@ use alloy_primitives::{Address, Bytes};
 use kona_preimage::{HintWriterClient, PreimageOracleClient};
 use op_revm::{
     OpSpecId,
-    precompiles::{fjord, granite, isthmus, jovian},
+    precompiles::{fjord, granite, isthmus, jovian, karst},
 };
 use revm::{
     context::{Cfg, ContextTr},
@@ -51,7 +51,8 @@ where
             OpSpecId::FJORD => fjord(),
             OpSpecId::GRANITE | OpSpecId::HOLOCENE => granite(),
             OpSpecId::ISTHMUS => isthmus(),
-            OpSpecId::JOVIAN | OpSpecId::INTEROP | OpSpecId::OSAKA => jovian(),
+            OpSpecId::JOVIAN => jovian(),
+            OpSpecId::KARST | OpSpecId::INTEROP => karst(),
         };
 
         let accelerated_precompiles = match spec {
@@ -61,7 +62,7 @@ where
             OpSpecId::ECOTONE | OpSpecId::FJORD => accelerated_ecotone::<H, O>(),
             OpSpecId::GRANITE | OpSpecId::HOLOCENE => accelerated_granite::<H, O>(),
             OpSpecId::ISTHMUS => accelerated_isthmus::<H, O>(),
-            OpSpecId::JOVIAN | OpSpecId::INTEROP | OpSpecId::OSAKA => accelerated_jovian::<H, O>(),
+            OpSpecId::JOVIAN | OpSpecId::KARST | OpSpecId::INTEROP => accelerated_jovian::<H, O>(),
         };
 
         Self {
@@ -469,8 +470,8 @@ mod test {
             hint_writer.clone(),
             oracle_reader.clone(),
         );
-        let osaka_provider = OpFpvmPrecompiles::new_with_spec(
-            OpSpecId::OSAKA,
+        let karst_provider = OpFpvmPrecompiles::new_with_spec(
+            OpSpecId::KARST,
             hint_writer.clone(),
             oracle_reader.clone(),
         );
@@ -490,9 +491,9 @@ mod test {
             addrs.sort();
             addrs
         };
-        let osaka_addrs: Vec<_> = {
+        let karst_addrs: Vec<_> = {
             let mut addrs: Vec<_> =
-                osaka_provider.accelerated_precompiles.keys().copied().collect();
+                karst_provider.accelerated_precompiles.keys().copied().collect();
             addrs.sort();
             addrs
         };
@@ -500,7 +501,7 @@ mod test {
             jovian_addrs, interop_addrs,
             "INTEROP should use Jovian accelerated precompiles"
         );
-        assert_eq!(jovian_addrs, osaka_addrs, "OSAKA should use Jovian accelerated precompiles");
+        assert_eq!(jovian_addrs, karst_addrs, "KARST should use Jovian accelerated precompiles");
 
         // Verify the non-accelerated precompile sets point to the correct static instances.
         assert!(
@@ -512,12 +513,12 @@ mod test {
             "ISTHMUS should use isthmus() precompiles"
         );
         assert!(
-            core::ptr::eq(osaka_provider.inner.precompiles, jovian()),
-            "OSAKA should use jovian() precompiles"
+            core::ptr::eq(karst_provider.inner.precompiles, karst()),
+            "KARST should use karst() precompiles"
         );
         assert!(
-            core::ptr::eq(interop_provider.inner.precompiles, jovian()),
-            "INTEROP should use jovian() precompiles"
+            core::ptr::eq(interop_provider.inner.precompiles, karst()),
+            "INTEROP should use karst() precompiles"
         );
     }
 

--- a/rust/kona/bin/client/src/fpvm_evm/precompiles/provider.rs
+++ b/rust/kona/bin/client/src/fpvm_evm/precompiles/provider.rs
@@ -8,13 +8,15 @@ use alloy_primitives::{Address, Bytes};
 use kona_preimage::{HintWriterClient, PreimageOracleClient};
 use op_revm::{
     OpSpecId,
-    precompiles::{fjord, granite, isthmus, jovian, karst},
+    precompiles::{fjord, granite, isthmus, jovian},
 };
 use revm::{
     context::{Cfg, ContextTr},
     handler::{EthPrecompiles, PrecompileProvider},
     interpreter::{CallInputs, Gas, InstructionResult, InterpreterResult},
-    precompile::{PrecompileError, PrecompileResult, Precompiles, bls12_381_const, bn254},
+    precompile::{
+        EthPrecompileResult, PrecompileError, PrecompileOutput, Precompiles, bls12_381_const, bn254,
+    },
     primitives::{hardfork::SpecId, hash_map::HashMap},
 };
 
@@ -49,8 +51,7 @@ where
             OpSpecId::FJORD => fjord(),
             OpSpecId::GRANITE | OpSpecId::HOLOCENE => granite(),
             OpSpecId::ISTHMUS => isthmus(),
-            OpSpecId::JOVIAN => jovian(),
-            OpSpecId::KARST | OpSpecId::INTEROP => karst(),
+            OpSpecId::JOVIAN | OpSpecId::INTEROP | OpSpecId::OSAKA => jovian(),
         };
 
         let accelerated_precompiles = match spec {
@@ -60,7 +61,7 @@ where
             OpSpecId::ECOTONE | OpSpecId::FJORD => accelerated_ecotone::<H, O>(),
             OpSpecId::GRANITE | OpSpecId::HOLOCENE => accelerated_granite::<H, O>(),
             OpSpecId::ISTHMUS => accelerated_isthmus::<H, O>(),
-            OpSpecId::JOVIAN | OpSpecId::KARST | OpSpecId::INTEROP => accelerated_jovian::<H, O>(),
+            OpSpecId::JOVIAN | OpSpecId::INTEROP | OpSpecId::OSAKA => accelerated_jovian::<H, O>(),
         };
 
         Self {
@@ -121,28 +122,30 @@ where
         // 3. If the precompile is not found, return None.
         let output =
             if let Some(accelerated) = self.accelerated_precompiles.get(&inputs.bytecode_address) {
-                (accelerated)(&input, inputs.gas_limit, &self.hint_writer, &self.oracle_reader)
+                let eth_result =
+                    (accelerated)(&input, inputs.gas_limit, &self.hint_writer, &self.oracle_reader);
+                PrecompileOutput::from_eth_result(eth_result, inputs.reservoir)
             } else if let Some(precompile) = self.inner.precompiles.get(&inputs.bytecode_address) {
-                precompile.execute(&input, inputs.gas_limit)
+                match precompile.execute(&input, inputs.gas_limit, inputs.reservoir) {
+                    Ok(output) => output,
+                    Err(PrecompileError::Fatal(e)) => return Err(e),
+                    Err(PrecompileError::FatalAny(e)) => return Err(alloc::format!("{e:?}")),
+                }
             } else {
                 return Ok(None);
             };
 
-        match output {
-            Ok(output) => {
-                let underflow = result.gas.record_cost(output.gas_used);
-                assert!(underflow, "Gas underflow is not possible");
-                result.result = InstructionResult::Return;
-                result.output = output.bytes;
-            }
-            Err(PrecompileError::Fatal(e)) => return Err(e),
-            Err(e) => {
-                result.result = if e.is_oog() {
-                    InstructionResult::PrecompileOOG
-                } else {
-                    InstructionResult::PrecompileError
-                };
-            }
+        if output.is_halt() {
+            result.result = if output.halt_reason().is_some_and(|r| r.is_oog()) {
+                InstructionResult::PrecompileOOG
+            } else {
+                InstructionResult::PrecompileError
+            };
+        } else {
+            let underflow = result.gas.record_regular_cost(output.gas_used);
+            assert!(underflow, "Gas underflow is not possible");
+            result.result = InstructionResult::Return;
+            result.output = output.bytes;
         }
 
         Ok(Some(result))
@@ -160,7 +163,7 @@ where
 }
 
 /// A precompile function that can be accelerated by the FPVM.
-type AcceleratedPrecompileFn<H, O> = fn(&[u8], u64, &H, &O) -> PrecompileResult;
+type AcceleratedPrecompileFn<H, O> = fn(&[u8], u64, &H, &O) -> EthPrecompileResult;
 
 /// A tuple type for accelerated precompiles with an associated [`Address`].
 struct AcceleratedPrecompile<H, O> {
@@ -310,15 +313,16 @@ mod test {
     fn create_call_inputs(address: Address, input: Bytes, gas_limit: u64) -> CallInputs {
         CallInputs {
             input: CallInput::Bytes(input),
+            return_memory_offset: 0..0,
             gas_limit,
+            reservoir: 0,
             bytecode_address: address,
+            known_bytecode: (revm::primitives::KECCAK_EMPTY, revm::bytecode::Bytecode::new()),
             target_address: Address::ZERO,
             caller: Address::ZERO,
             value: revm::interpreter::CallValue::Transfer(alloy_primitives::U256::ZERO),
             scheme: revm::interpreter::CallScheme::Call,
             is_static: false,
-            return_memory_offset: 0..0,
-            known_bytecode: None,
         }
     }
 
@@ -336,12 +340,12 @@ mod test {
         gas_limit: u64,
         _hint_writer: &H,
         _oracle_reader: &O,
-    ) -> PrecompileResult
+    ) -> EthPrecompileResult
     where
         H: HintWriterClient + Send + Sync,
         O: PreimageOracleClient + Send + Sync,
     {
-        Ok(revm::precompile::PrecompileOutput::new(gas_limit / 2, Bytes::from_static(b"mock")))
+        Ok(revm::precompile::EthPrecompileOutput::new(gas_limit / 2, Bytes::from_static(b"mock")))
     }
 
     #[test]
@@ -465,8 +469,8 @@ mod test {
             hint_writer.clone(),
             oracle_reader.clone(),
         );
-        let karst_provider = OpFpvmPrecompiles::new_with_spec(
-            OpSpecId::KARST,
+        let osaka_provider = OpFpvmPrecompiles::new_with_spec(
+            OpSpecId::OSAKA,
             hint_writer.clone(),
             oracle_reader.clone(),
         );
@@ -488,7 +492,7 @@ mod test {
         };
         let osaka_addrs: Vec<_> = {
             let mut addrs: Vec<_> =
-                karst_provider.accelerated_precompiles.keys().copied().collect();
+                osaka_provider.accelerated_precompiles.keys().copied().collect();
             addrs.sort();
             addrs
         };
@@ -508,12 +512,12 @@ mod test {
             "ISTHMUS should use isthmus() precompiles"
         );
         assert!(
-            core::ptr::eq(karst_provider.inner.precompiles, karst()),
-            "KARST should use karst() precompiles"
+            core::ptr::eq(osaka_provider.inner.precompiles, jovian()),
+            "OSAKA should use jovian() precompiles"
         );
         assert!(
-            core::ptr::eq(interop_provider.inner.precompiles, karst()),
-            "INTEROP should use karst() precompiles"
+            core::ptr::eq(interop_provider.inner.precompiles, jovian()),
+            "INTEROP should use jovian() precompiles"
         );
     }
 
@@ -535,15 +539,16 @@ mod test {
         let sha256_addr = revm::precompile::u64_to_address(2);
         let call_inputs = CallInputs {
             input: CallInput::SharedBuffer(0..0),
+            return_memory_offset: 0..0,
             gas_limit: u64::MAX,
+            reservoir: 0,
             bytecode_address: sha256_addr,
+            known_bytecode: (revm::primitives::KECCAK_EMPTY, revm::bytecode::Bytecode::new()),
             target_address: Address::ZERO,
             caller: Address::ZERO,
             value: revm::interpreter::CallValue::Transfer(alloy_primitives::U256::ZERO),
             scheme: revm::interpreter::CallScheme::Call,
             is_static: false,
-            return_memory_offset: 0..0,
-            known_bytecode: None,
         };
 
         let result = precompiles.run(&mut ctx, &call_inputs).unwrap();

--- a/rust/kona/bin/client/src/fpvm_evm/precompiles/test_utils.rs
+++ b/rust/kona/bin/client/src/fpvm_evm/precompiles/test_utils.rs
@@ -48,7 +48,7 @@ pub(crate) fn execute_native_precompile<T: Into<Bytes>>(
     let Some(precompile) = precompiles.precompiles.get(&address) else {
         panic!("Precompile not found");
     };
-    precompile.execute(&input.into(), gas)
+    precompile.execute(&input.into(), gas, 0)
 }
 
 /// Starts a mock host thread that serves [`HintType::L1Precompile`] hints and preimages.
@@ -115,15 +115,15 @@ impl PreimageFetcher for PrecompilePreimageFetcher {
             let input = parsed_hint.data[28..].to_vec();
             let input_hash = keccak256(parsed_hint.data.as_ref());
 
-            let result = execute_native_precompile(address, input, gas).map_or_else(
-                |_| vec![0u8; 1],
-                |raw_res| {
+            let result = match execute_native_precompile(address, input, gas) {
+                Ok(raw_res) if raw_res.is_success() => {
                     let mut res = Vec::with_capacity(1 + raw_res.bytes.len());
                     res.push(0x01);
                     res.extend_from_slice(&raw_res.bytes);
                     res
-                },
-            );
+                }
+                _ => vec![0u8; 1],
+            };
 
             map_lock
                 .insert(PreimageKey::new(*input_hash, PreimageKeyType::Precompile), result.clone());

--- a/rust/kona/bin/host/src/eth/precompiles.rs
+++ b/rust/kona/bin/host/src/eth/precompiles.rs
@@ -24,8 +24,11 @@ pub(crate) fn execute<T: Into<Bytes>>(address: Address, input: T, gas: u64) -> R
     if let Some(precompile) =
         ACCELERATED_PRECOMPILES.iter().find(|precompile| *precompile.address() == address)
     {
-        let output = precompile.precompile()(&input.into(), gas)
-            .map_err(|e| HostError::PrecompileExecutionFailed(e.to_string()))?;
+        let output = precompile.execute(&input.into(), gas, 0).map_err(
+            |e: revm::precompile::PrecompileError| {
+                HostError::PrecompileExecutionFailed(e.to_string())
+            },
+        )?;
 
         Ok(output.bytes.into())
     } else {

--- a/rust/op-reth/crates/cli/src/commands/init_state.rs
+++ b/rust/op-reth/crates/cli/src/commands/init_state.rs
@@ -12,8 +12,7 @@ use reth_optimism_primitives::{
 };
 use reth_primitives_traits::{SealedHeader, header::HeaderMut};
 use reth_provider::{
-    BlockNumReader, DBProvider, DatabaseProviderFactory, StaticFileProviderFactory,
-    StaticFileWriter,
+    BlockNumReader, DatabaseProviderFactory, StaticFileProviderFactory, StaticFileWriter,
 };
 use std::{io::BufReader, sync::Arc};
 use tracing::info;
@@ -99,9 +98,7 @@ impl<C: ChainSpecParser<ChainSpec = OpChainSpec>> InitStateCommandOp<C> {
         info!(target: "reth::cli", "Initiating state dump");
 
         let reader = BufReader::new(reth_fs_util::open(self.init_state.state)?);
-        let hash = init_from_state_dump(reader, &provider_rw, config.stages.etl)?;
-
-        provider_rw.commit()?;
+        let hash = init_from_state_dump(reader, &provider_factory, config.stages.etl)?;
 
         info!(target: "reth::cli", hash = ?hash, "Genesis block written");
         Ok(())

--- a/rust/op-reth/crates/evm/src/lib.rs
+++ b/rust/op-reth/crates/evm/src/lib.rs
@@ -179,6 +179,7 @@ where
                 suggested_fee_recipient: attributes.suggested_fee_recipient,
                 prev_randao: attributes.prev_randao,
                 gas_limit: attributes.gas_limit,
+                slot_number: None,
             },
             self.chain_spec().next_block_base_fee(parent, attributes.timestamp).unwrap_or_default(),
             self.chain_spec(),

--- a/rust/op-reth/crates/node/src/engine.rs
+++ b/rust/op-reth/crates/node/src/engine.rs
@@ -280,7 +280,8 @@ pub fn validate_withdrawals_presence(
         EngineApiMessageVersion::V2 |
         EngineApiMessageVersion::V3 |
         EngineApiMessageVersion::V4 |
-        EngineApiMessageVersion::V5 => {
+        EngineApiMessageVersion::V5 |
+        EngineApiMessageVersion::V6 => {
             if is_shanghai && !has_withdrawals {
                 return Err(message_validation_kind
                     .to_error(VersionSpecificValidationError::NoWithdrawalsPostShanghai));

--- a/rust/op-reth/crates/node/src/node.rs
+++ b/rust/op-reth/crates/node/src/node.rs
@@ -941,6 +941,7 @@ impl<NetworkT, RpcMiddleware> OpAddOnsBuilder<NetworkT, RpcMiddleware> {
                 EB::default(),
                 EVB::default(),
                 rpc_middleware,
+                reth_node_builder::rpc::Identity::new(),
             )
             .with_tokio_runtime(tokio_runtime),
             da_config.unwrap_or_default(),

--- a/rust/op-reth/crates/node/tests/it/builder.rs
+++ b/rust/op-reth/crates/node/tests/it/builder.rs
@@ -72,7 +72,9 @@ fn test_setup_custom_precompiles() {
                 let precompile = Precompile::new(
                     PrecompileId::custom("custom"),
                     address!("0x0000000000000000000000000000000000756e69"),
-                    |_, _| PrecompileResult::Ok(PrecompileOutput::new(0, Bytes::new())),
+                    |_, _, reservoir| {
+                        PrecompileResult::Ok(PrecompileOutput::new(0, Bytes::new(), reservoir))
+                    },
                 );
                 precompiles.extend([precompile]);
                 precompiles

--- a/rust/op-reth/crates/payload/src/payload.rs
+++ b/rust/op-reth/crates/payload/src/payload.rs
@@ -82,8 +82,16 @@ impl reth_payload_primitives::ExecutionPayload for OpExecData {
         self.0.payload.as_v1().gas_used
     }
 
+    fn gas_limit(&self) -> u64 {
+        self.0.payload.as_v1().gas_limit
+    }
+
     fn transaction_count(&self) -> usize {
         self.0.payload.as_v1().transactions.len()
+    }
+
+    fn slot_number(&self) -> Option<u64> {
+        None
     }
 }
 
@@ -135,6 +143,10 @@ impl reth_payload_primitives::PayloadAttributes for OpPayloadAttrs {
 
     fn parent_beacon_block_root(&self) -> Option<B256> {
         self.0.payload_attributes.parent_beacon_block_root
+    }
+
+    fn slot_number(&self) -> Option<u64> {
+        None
     }
 }
 
@@ -228,6 +240,10 @@ impl<T: Decodable2718 + Send + Sync + Debug + Clone + Unpin + 'static>
 
     fn parent_beacon_block_root(&self) -> Option<B256> {
         self.parent_beacon_block_root
+    }
+
+    fn slot_number(&self) -> Option<u64> {
+        None
     }
 }
 

--- a/rust/op-reth/crates/rpc/src/error.rs
+++ b/rust/op-reth/crates/rpc/src/error.rs
@@ -188,6 +188,7 @@ where
             EVMError::Database(err) => Self::Eth(err.into()),
             EVMError::Header(err) => Self::Eth(err.into()),
             EVMError::Custom(err) => Self::Eth(EthApiError::EvmCustom(err)),
+            EVMError::CustomAny(err) => Self::Eth(EthApiError::EvmCustom(format!("{err:?}"))),
         }
     }
 }

--- a/rust/op-reth/examples/custom-node/src/engine.rs
+++ b/rust/op-reth/examples/custom-node/src/engine.rs
@@ -74,8 +74,16 @@ impl ExecutionPayload for CustomExecutionData {
         self.inner.payload.as_v1().gas_used
     }
 
+    fn gas_limit(&self) -> u64 {
+        self.inner.payload.as_v1().gas_limit
+    }
+
     fn transaction_count(&self) -> usize {
         self.inner.payload.as_v1().transactions.len()
+    }
+
+    fn slot_number(&self) -> Option<u64> {
+        None
     }
 }
 

--- a/rust/op-reth/examples/custom-node/src/evm/alloy.rs
+++ b/rust/op-reth/examples/custom-node/src/evm/alloy.rs
@@ -46,6 +46,10 @@ where
         self.inner.block()
     }
 
+    fn cfg_env(&self) -> &CfgEnv<OpSpecId> {
+        self.inner.cfg_env()
+    }
+
     fn chain_id(&self) -> u64 {
         self.inner.chain_id()
     }
@@ -69,7 +73,7 @@ where
         self.inner.transact_system_call(caller, contract, data)
     }
 
-    fn finish(self) -> (Self::DB, EvmEnv<Self::Spec>) {
+    fn finish(self) -> (Self::DB, EvmEnv<Self::Spec, Self::BlockEnv>) {
         self.inner.finish()
     }
 
@@ -108,7 +112,7 @@ impl EvmFactory for CustomEvmFactory {
     fn create_evm<DB: Database>(
         &self,
         db: DB,
-        input: EvmEnv<Self::Spec>,
+        input: EvmEnv<Self::Spec, Self::BlockEnv>,
     ) -> Self::Evm<DB, NoOpInspector> {
         CustomEvm::new(self.0.create_evm(db, input))
     }
@@ -116,7 +120,7 @@ impl EvmFactory for CustomEvmFactory {
     fn create_evm_with_inspector<DB: Database, I: Inspector<Self::Context<DB>>>(
         &self,
         db: DB,
-        input: EvmEnv<Self::Spec>,
+        input: EvmEnv<Self::Spec, Self::BlockEnv>,
         inspector: I,
     ) -> Self::Evm<DB, I> {
         CustomEvm::new(self.0.create_evm_with_inspector(db, input, inspector))

--- a/rust/op-reth/examples/custom-node/src/evm/executor.rs
+++ b/rust/op-reth/examples/custom-node/src/evm/executor.rs
@@ -10,7 +10,7 @@ use alloy_evm::{
     Evm, RecoveredTx,
     block::{
         BlockExecutionError, BlockExecutionResult, BlockExecutor, BlockExecutorFactory,
-        BlockExecutorFor, ExecutableTx, OnStateHook, StateDB,
+        BlockExecutorFor, ExecutableTx, GasOutput, OnStateHook, StateDB,
     },
     precompiles::PrecompilesMap,
 };
@@ -54,7 +54,10 @@ where
         }
     }
 
-    fn commit_transaction(&mut self, output: Self::Result) -> Result<u64, BlockExecutionError> {
+    fn commit_transaction(
+        &mut self,
+        output: Self::Result,
+    ) -> Result<GasOutput, BlockExecutionError> {
         self.inner.commit_transaction(output)
     }
 

--- a/rust/op-revm/Cargo.toml
+++ b/rust/op-revm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "op-revm"
 description = "Optimism variant of Revm"
-version = "17.0.0"
+version = "19.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true

--- a/rust/op-revm/src/handler.rs
+++ b/rust/op-revm/src/handler.rs
@@ -24,7 +24,9 @@ use revm::{
         pre_execution::{calculate_caller_fee, validate_account_nonce_and_code_with_components},
     },
     inspector::{Inspector, InspectorEvmTr, InspectorHandler},
-    interpreter::{Gas, interpreter::EthInterpreter, interpreter_action::FrameInit},
+    interpreter::{
+        Gas, InitialAndFloorGas, interpreter::EthInterpreter, interpreter_action::FrameInit,
+    },
     primitives::{U256, hardfork::SpecId},
 };
 use std::{boxed::Box, vec::Vec};
@@ -103,6 +105,7 @@ where
     fn validate_against_state_and_deduct_caller(
         &self,
         evm: &mut Self::Evm,
+        _init_and_floor_gas: &mut InitialAndFloorGas,
     ) -> Result<(), Self::Error> {
         let (block, tx, cfg, journal, chain, _) = evm.ctx().all_mut();
         let spec = cfg.spec();
@@ -194,6 +197,8 @@ where
         let gas = frame_result.gas_mut();
         let remaining = gas.remaining();
         let refunded = gas.refunded();
+        let reservoir = gas.reservoir();
+        let state_gas_spent = gas.state_gas_spent();
 
         // Spend the gas limit. Gas is reimbursed when the tx returns successfully.
         *gas = Gas::new_spent(tx_gas_limit);
@@ -238,6 +243,10 @@ where
                 gas.erase_cost(remaining);
             }
         }
+
+        gas.set_state_gas_spent(state_gas_spent);
+        gas.set_reservoir(reservoir);
+
         Ok(())
     }
 
@@ -305,16 +314,14 @@ where
         };
 
         let l1_cost = l1_block_info.calculate_tx_l1_cost(enveloped_tx, spec);
+        let effective_used =
+            frame_result.gas().used().saturating_sub(frame_result.gas().reservoir());
         let operator_fee_cost = if spec.is_enabled_in(OpSpecId::ISTHMUS) {
-            l1_block_info.operator_fee_charge(
-                enveloped_tx,
-                U256::from(frame_result.gas().used()),
-                spec,
-            )
+            l1_block_info.operator_fee_charge(enveloped_tx, U256::from(effective_used), spec)
         } else {
             U256::ZERO
         };
-        let base_fee_amount = U256::from(basefee.saturating_mul(frame_result.gas().used() as u128));
+        let base_fee_amount = U256::from(basefee.saturating_mul(effective_used as u128));
 
         // Send fees to their respective recipients
         for (recipient, amount) in [
@@ -407,7 +414,7 @@ where
             // clear the journal
             output = Ok(ExecutionResult::Halt {
                 reason: OpHaltReason::FailedDeposit,
-                gas: ResultGas::new(gas_limit, gas_used, 0, 0, 0),
+                gas: ResultGas::default().with_total_gas_spent(gas_used),
                 logs: Vec::new(),
             })
         }
@@ -487,7 +494,7 @@ mod tests {
 
         let gas = call_last_frame_return(ctx, InstructionResult::Revert, Gas::new(90));
         assert_eq!(gas.remaining(), 90);
-        assert_eq!(gas.spent(), 10);
+        assert_eq!(gas.total_gas_spent(), 10);
         assert_eq!(gas.refunded(), 0);
     }
 
@@ -499,7 +506,7 @@ mod tests {
 
         let gas = call_last_frame_return(ctx, InstructionResult::Stop, Gas::new(90));
         assert_eq!(gas.remaining(), 90);
-        assert_eq!(gas.spent(), 10);
+        assert_eq!(gas.total_gas_spent(), 10);
         assert_eq!(gas.refunded(), 0);
     }
 
@@ -519,12 +526,12 @@ mod tests {
 
         let gas = call_last_frame_return(ctx.clone(), InstructionResult::Stop, ret_gas);
         assert_eq!(gas.remaining(), 90);
-        assert_eq!(gas.spent(), 10);
+        assert_eq!(gas.total_gas_spent(), 10);
         assert_eq!(gas.refunded(), 2); // min(20, 10/5)
 
         let gas = call_last_frame_return(ctx, InstructionResult::Revert, ret_gas);
         assert_eq!(gas.remaining(), 90);
-        assert_eq!(gas.spent(), 10);
+        assert_eq!(gas.total_gas_spent(), 10);
         assert_eq!(gas.refunded(), 0);
     }
 
@@ -540,7 +547,7 @@ mod tests {
             .with_cfg(CfgEnv::new_with_spec(OpSpecId::BEDROCK));
         let gas = call_last_frame_return(ctx, InstructionResult::Stop, Gas::new(90));
         assert_eq!(gas.remaining(), 0);
-        assert_eq!(gas.spent(), 100);
+        assert_eq!(gas.total_gas_spent(), 100);
         assert_eq!(gas.refunded(), 0);
     }
 
@@ -557,7 +564,7 @@ mod tests {
             .with_cfg(CfgEnv::new_with_spec(OpSpecId::BEDROCK));
         let gas = call_last_frame_return(ctx, InstructionResult::Stop, Gas::new(90));
         assert_eq!(gas.remaining(), 100);
-        assert_eq!(gas.spent(), 0);
+        assert_eq!(gas.total_gas_spent(), 0);
         assert_eq!(gas.refunded(), 0);
     }
 
@@ -588,7 +595,9 @@ mod tests {
 
         let handler =
             OpHandler::<_, EVMError<_, OpTransactionError>, EthFrame<EthInterpreter>>::new();
-        handler.validate_against_state_and_deduct_caller(&mut evm).unwrap();
+        handler
+            .validate_against_state_and_deduct_caller(&mut evm, &mut Default::default())
+            .unwrap();
 
         // Check the account balance is updated.
         let account = evm.ctx().journal_mut().load_account(caller).unwrap();
@@ -629,7 +638,9 @@ mod tests {
 
         let handler =
             OpHandler::<_, EVMError<_, OpTransactionError>, EthFrame<EthInterpreter>>::new();
-        handler.validate_against_state_and_deduct_caller(&mut evm).unwrap();
+        handler
+            .validate_against_state_and_deduct_caller(&mut evm, &mut Default::default())
+            .unwrap();
 
         // Check the account balance is updated.
         let account = evm.ctx().journal_mut().load_account(caller).unwrap();
@@ -680,7 +691,9 @@ mod tests {
 
         let handler =
             OpHandler::<_, EVMError<_, OpTransactionError>, EthFrame<EthInterpreter>>::new();
-        handler.validate_against_state_and_deduct_caller(&mut evm).unwrap();
+        handler
+            .validate_against_state_and_deduct_caller(&mut evm, &mut Default::default())
+            .unwrap();
 
         assert_eq!(
             *evm.ctx().chain(),
@@ -759,7 +772,9 @@ mod tests {
 
         let handler =
             OpHandler::<_, EVMError<_, OpTransactionError>, EthFrame<EthInterpreter>>::new();
-        handler.validate_against_state_and_deduct_caller(&mut evm).unwrap();
+        handler
+            .validate_against_state_and_deduct_caller(&mut evm, &mut Default::default())
+            .unwrap();
 
         assert_eq!(
             *evm.ctx().chain(),
@@ -808,7 +823,9 @@ mod tests {
 
         let handler =
             OpHandler::<_, EVMError<_, OpTransactionError>, EthFrame<EthInterpreter>>::new();
-        handler.validate_against_state_and_deduct_caller(&mut evm).unwrap();
+        handler
+            .validate_against_state_and_deduct_caller(&mut evm, &mut Default::default())
+            .unwrap();
 
         assert_eq!(
             *evm.ctx().chain(),
@@ -857,7 +874,9 @@ mod tests {
 
         let handler =
             OpHandler::<_, EVMError<_, OpTransactionError>, EthFrame<EthInterpreter>>::new();
-        handler.validate_against_state_and_deduct_caller(&mut evm).unwrap();
+        handler
+            .validate_against_state_and_deduct_caller(&mut evm, &mut Default::default())
+            .unwrap();
 
         assert_eq!(
             *evm.ctx().chain(),
@@ -915,7 +934,9 @@ mod tests {
 
         let handler =
             OpHandler::<_, EVMError<_, OpTransactionError>, EthFrame<EthInterpreter>>::new();
-        handler.validate_against_state_and_deduct_caller(&mut evm).unwrap();
+        handler
+            .validate_against_state_and_deduct_caller(&mut evm, &mut Default::default())
+            .unwrap();
 
         assert_eq!(
             *evm.ctx().chain(),
@@ -967,7 +988,9 @@ mod tests {
             OpHandler::<_, EVMError<_, OpTransactionError>, EthFrame<EthInterpreter>>::new();
 
         // l1block cost is 1048 fee.
-        handler.validate_against_state_and_deduct_caller(&mut evm).unwrap();
+        handler
+            .validate_against_state_and_deduct_caller(&mut evm, &mut Default::default())
+            .unwrap();
 
         // Check the account balance is updated.
         let account = evm.ctx().journal_mut().load_account(caller).unwrap();
@@ -1004,7 +1027,9 @@ mod tests {
 
         // Under Isthmus the operator fee cost is operator_fee_scalar * gas_limit / 1e6 +
         // operator_fee_constant 10_000_000 * 10 / 1_000_000 + 50 = 150
-        handler.validate_against_state_and_deduct_caller(&mut evm).unwrap();
+        handler
+            .validate_against_state_and_deduct_caller(&mut evm, &mut Default::default())
+            .unwrap();
 
         // Check the account balance is updated.
         let account = evm.ctx().journal_mut().load_account(caller).unwrap();
@@ -1041,7 +1066,9 @@ mod tests {
 
         // Under Jovian the operator fee cost is operator_fee_scalar * gas_limit * 100 +
         // operator_fee_constant 2 * 10 * 100 + 50 = 2_050
-        handler.validate_against_state_and_deduct_caller(&mut evm).unwrap();
+        handler
+            .validate_against_state_and_deduct_caller(&mut evm, &mut Default::default())
+            .unwrap();
 
         let account = evm.ctx().journal_mut().load_account(caller).unwrap();
         assert_eq!(account.info.balance, U256::from(1));
@@ -1076,7 +1103,7 @@ mod tests {
 
         // l1block cost is 1048 fee.
         assert_eq!(
-            handler.validate_against_state_and_deduct_caller(&mut evm),
+            handler.validate_against_state_and_deduct_caller(&mut evm, &mut Default::default()),
             Err(EVMError::Transaction(
                 InvalidTransaction::LackOfFundForMaxFee {
                     fee: Box::new(U256::from(1048)),
@@ -1188,7 +1215,9 @@ mod tests {
         let handler =
             OpHandler::<_, EVMError<_, OpTransactionError>, EthFrame<EthInterpreter>>::new();
 
-        handler.validate_against_state_and_deduct_caller(&mut evm).unwrap();
+        handler
+            .validate_against_state_and_deduct_caller(&mut evm, &mut Default::default())
+            .unwrap();
 
         assert!(evm.0.ctx.journal_mut().load_account(Address::ZERO).unwrap().is_touched());
     }
@@ -1263,7 +1292,8 @@ mod tests {
         let handler =
             OpHandler::<_, EVMError<_, OpTransactionError>, EthFrame<EthInterpreter>>::new();
 
-        let result = handler.validate_against_state_and_deduct_caller(&mut evm);
+        let result =
+            handler.validate_against_state_and_deduct_caller(&mut evm, &mut Default::default());
 
         assert!(matches!(
             result.err().unwrap(),

--- a/rust/op-revm/src/precompiles.rs
+++ b/rust/op-revm/src/precompiles.rs
@@ -6,8 +6,8 @@ use revm::{
     handler::{EthPrecompiles, PrecompileProvider},
     interpreter::{CallInputs, InterpreterResult},
     precompile::{
-        self, Precompile, PrecompileError, PrecompileId, PrecompileResult, Precompiles, bn254,
-        modexp, secp256r1,
+        self, EthPrecompileResult, Precompile, PrecompileHalt, PrecompileId, Precompiles, bn254,
+        eth_precompile_fn, modexp, secp256r1,
     },
     primitives::{Address, OnceLock, hardfork::SpecId},
 };
@@ -181,12 +181,12 @@ pub mod bn254_pair {
     pub const GRANITE_MAX_INPUT_SIZE: usize = 112687;
     /// Bn254 pair precompile.
     pub const GRANITE: Precompile =
-        Precompile::new(PrecompileId::Bn254Pairing, bn254::pair::ADDRESS, run_pair_granite);
+        Precompile::new(PrecompileId::Bn254Pairing, bn254::pair::ADDRESS, granite_precompile);
 
     /// Run the bn254 pair precompile with Optimism input limit.
-    pub fn run_pair_granite(input: &[u8], gas_limit: u64) -> PrecompileResult {
+    pub fn run_pair_granite(input: &[u8], gas_limit: u64) -> EthPrecompileResult {
         if input.len() > GRANITE_MAX_INPUT_SIZE {
-            return Err(PrecompileError::Bn254PairLength);
+            return Err(PrecompileHalt::Bn254PairLength);
         }
         bn254::run_pair(
             input,
@@ -195,17 +195,19 @@ pub mod bn254_pair {
             gas_limit,
         )
     }
+
+    eth_precompile_fn!(granite_precompile, run_pair_granite);
 
     /// Max input size for the bn254 pair precompile.
     pub const JOVIAN_MAX_INPUT_SIZE: usize = 81_984;
     /// Bn254 pair precompile.
     pub const JOVIAN: Precompile =
-        Precompile::new(PrecompileId::Bn254Pairing, bn254::pair::ADDRESS, run_pair_jovian);
+        Precompile::new(PrecompileId::Bn254Pairing, bn254::pair::ADDRESS, jovian_precompile);
 
     /// Run the bn254 pair precompile with Optimism input limit.
-    pub fn run_pair_jovian(input: &[u8], gas_limit: u64) -> PrecompileResult {
+    pub fn run_pair_jovian(input: &[u8], gas_limit: u64) -> EthPrecompileResult {
         if input.len() > JOVIAN_MAX_INPUT_SIZE {
-            return Err(PrecompileError::Bn254PairLength);
+            return Err(PrecompileHalt::Bn254PairLength);
         }
         bn254::run_pair(
             input,
@@ -214,6 +216,8 @@ pub mod bn254_pair {
             gas_limit,
         )
     }
+
+    eth_precompile_fn!(jovian_precompile, run_pair_jovian);
 }
 
 /// `Bls12_381` precompile.
@@ -241,28 +245,35 @@ pub mod bls12_381 {
 
     /// G1 msm precompile.
     pub const ISTHMUS_G1_MSM: Precompile =
-        Precompile::new(PrecompileId::Bls12G1Msm, G1_MSM_ADDRESS, run_g1_msm_isthmus);
+        Precompile::new(PrecompileId::Bls12G1Msm, G1_MSM_ADDRESS, isthmus_g1_msm_precompile);
     /// G2 msm precompile.
     pub const ISTHMUS_G2_MSM: Precompile =
-        Precompile::new(PrecompileId::Bls12G2Msm, G2_MSM_ADDRESS, run_g2_msm_isthmus);
+        Precompile::new(PrecompileId::Bls12G2Msm, G2_MSM_ADDRESS, isthmus_g2_msm_precompile);
     /// Pairing precompile.
     pub const ISTHMUS_PAIRING: Precompile =
-        Precompile::new(PrecompileId::Bls12Pairing, PAIRING_ADDRESS, run_pair_isthmus);
+        Precompile::new(PrecompileId::Bls12Pairing, PAIRING_ADDRESS, isthmus_pairing_precompile);
 
     /// G1 msm precompile after the Jovian Hardfork.
     pub const JOVIAN_G1_MSM: Precompile =
-        Precompile::new(PrecompileId::Bls12G1Msm, G1_MSM_ADDRESS, run_g1_msm_jovian);
+        Precompile::new(PrecompileId::Bls12G1Msm, G1_MSM_ADDRESS, jovian_g1_msm_precompile);
     /// G2 msm precompile after the Jovian Hardfork.
     pub const JOVIAN_G2_MSM: Precompile =
-        Precompile::new(PrecompileId::Bls12G2Msm, G2_MSM_ADDRESS, run_g2_msm_jovian);
+        Precompile::new(PrecompileId::Bls12G2Msm, G2_MSM_ADDRESS, jovian_g2_msm_precompile);
     /// Pairing precompile after the Jovian Hardfork.
     pub const JOVIAN_PAIRING: Precompile =
-        Precompile::new(PrecompileId::Bls12Pairing, PAIRING_ADDRESS, run_pair_jovian);
+        Precompile::new(PrecompileId::Bls12Pairing, PAIRING_ADDRESS, jovian_pairing_precompile);
+
+    eth_precompile_fn!(isthmus_g1_msm_precompile, run_g1_msm_isthmus);
+    eth_precompile_fn!(isthmus_g2_msm_precompile, run_g2_msm_isthmus);
+    eth_precompile_fn!(isthmus_pairing_precompile, run_pair_isthmus);
+    eth_precompile_fn!(jovian_g1_msm_precompile, run_g1_msm_jovian);
+    eth_precompile_fn!(jovian_g2_msm_precompile, run_g2_msm_jovian);
+    eth_precompile_fn!(jovian_pairing_precompile, run_pair_jovian);
 
     /// Run the g1 msm precompile with Optimism input limit.
-    pub fn run_g1_msm_isthmus(input: &[u8], gas_limit: u64) -> PrecompileResult {
+    pub fn run_g1_msm_isthmus(input: &[u8], gas_limit: u64) -> EthPrecompileResult {
         if input.len() > ISTHMUS_G1_MSM_MAX_INPUT_SIZE {
-            return Err(PrecompileError::Other(
+            return Err(PrecompileHalt::Other(
                 "G1MSM input length too long for OP Stack input size limitation after the Isthmus Hardfork".into(),
             ));
         }
@@ -270,9 +281,9 @@ pub mod bls12_381 {
     }
 
     /// Run the g1 msm precompile with Optimism input limit.
-    pub fn run_g1_msm_jovian(input: &[u8], gas_limit: u64) -> PrecompileResult {
+    pub fn run_g1_msm_jovian(input: &[u8], gas_limit: u64) -> EthPrecompileResult {
         if input.len() > JOVIAN_G1_MSM_MAX_INPUT_SIZE {
-            return Err(PrecompileError::Other(
+            return Err(PrecompileHalt::Other(
                 "G1MSM input length too long for OP Stack input size limitation after the Jovian Hardfork".into(),
             ));
         }
@@ -280,9 +291,9 @@ pub mod bls12_381 {
     }
 
     /// Run the g2 msm precompile with Optimism input limit.
-    pub fn run_g2_msm_isthmus(input: &[u8], gas_limit: u64) -> PrecompileResult {
+    pub fn run_g2_msm_isthmus(input: &[u8], gas_limit: u64) -> EthPrecompileResult {
         if input.len() > ISTHMUS_G2_MSM_MAX_INPUT_SIZE {
-            return Err(PrecompileError::Other(
+            return Err(PrecompileHalt::Other(
                 "G2MSM input length too long for OP Stack input size limitation".into(),
             ));
         }
@@ -290,9 +301,9 @@ pub mod bls12_381 {
     }
 
     /// Run the g2 msm precompile with Optimism input limit after the Jovian Hardfork.
-    pub fn run_g2_msm_jovian(input: &[u8], gas_limit: u64) -> PrecompileResult {
+    pub fn run_g2_msm_jovian(input: &[u8], gas_limit: u64) -> EthPrecompileResult {
         if input.len() > JOVIAN_G2_MSM_MAX_INPUT_SIZE {
-            return Err(PrecompileError::Other(
+            return Err(PrecompileHalt::Other(
                 "G2MSM input length too long for OP Stack input size limitation after the Jovian Hardfork".into(),
             ));
         }
@@ -300,9 +311,9 @@ pub mod bls12_381 {
     }
 
     /// Run the pairing precompile with Optimism input limit.
-    pub fn run_pair_isthmus(input: &[u8], gas_limit: u64) -> PrecompileResult {
+    pub fn run_pair_isthmus(input: &[u8], gas_limit: u64) -> EthPrecompileResult {
         if input.len() > ISTHMUS_PAIRING_MAX_INPUT_SIZE {
-            return Err(PrecompileError::Other(
+            return Err(PrecompileHalt::Other(
                 "Pairing input length too long for OP Stack input size limitation".into(),
             ));
         }
@@ -310,9 +321,9 @@ pub mod bls12_381 {
     }
 
     /// Run the pairing precompile with Optimism input limit after the Jovian Hardfork.
-    pub fn run_pair_jovian(input: &[u8], gas_limit: u64) -> PrecompileResult {
+    pub fn run_pair_jovian(input: &[u8], gas_limit: u64) -> EthPrecompileResult {
         if input.len() > JOVIAN_PAIRING_MAX_INPUT_SIZE {
-            return Err(PrecompileError::Other(
+            return Err(PrecompileHalt::Other(
                 "Pairing input length too long for OP Stack input size limitation after the Jovian Hardfork".into(),
             ));
         }
@@ -331,7 +342,7 @@ mod tests {
 
     use super::*;
     use revm::{
-        precompile::{PrecompileError, bls12_381_const},
+        precompile::{PrecompileHalt, PrecompileStatus, bls12_381_const},
         primitives::{Bytes, hex},
     };
     use std::vec;
@@ -371,17 +382,17 @@ mod tests {
         .unwrap();
 
         let res = bn254_pair::run_pair_granite(&input, 260_000);
-        assert!(matches!(res, Err(PrecompileError::Bn254PairLength)));
+        assert!(matches!(res, Err(PrecompileHalt::Bn254PairLength)));
 
         // Valid input length shorter than 112687
         let input = vec![1u8; 586 * bn254::PAIR_ELEMENT_LEN];
         let res = bn254_pair::run_pair_granite(&input, 260_000);
-        assert!(matches!(res, Err(PrecompileError::OutOfGas)));
+        assert!(matches!(res, Err(PrecompileHalt::OutOfGas)));
 
         // Input length longer than 112687
         let input = vec![1u8; 587 * bn254::PAIR_ELEMENT_LEN];
         let res = bn254_pair::run_pair_granite(&input, 260_000);
-        assert!(matches!(res, Err(PrecompileError::Bn254PairLength)));
+        assert!(matches!(res, Err(PrecompileHalt::Bn254PairLength)));
     }
 
     #[test]
@@ -400,7 +411,7 @@ mod tests {
     fn test_accelerated_bn254_pairing_bad_input_len_jovian() {
         let input = [0u8; bn254_pair::JOVIAN_MAX_INPUT_SIZE + 1];
         let res = bn254_pair::run_pair_jovian(&input, u64::MAX);
-        assert!(matches!(res, Err(PrecompileError::Bn254PairLength)));
+        assert!(matches!(res, Err(PrecompileHalt::Bn254PairLength)));
     }
 
     #[test]
@@ -412,17 +423,17 @@ mod tests {
         assert!(bad_input_len < bn254_pair::GRANITE_MAX_INPUT_SIZE);
         let input = vec![0u8; bad_input_len];
 
-        let res = bn254_pair_precompile.execute(&input, u64::MAX);
-        assert!(matches!(res, Err(PrecompileError::Bn254PairLength)));
+        let res = bn254_pair_precompile.execute(&input, u64::MAX, 0).unwrap();
+        assert!(matches!(res.status, PrecompileStatus::Halt(PrecompileHalt::Bn254PairLength)));
 
         let bls12_381_g1_msm_precompile =
             precompiles.precompiles().get(&bls12_381_const::G1_MSM_ADDRESS).unwrap();
         bad_input_len = bls12_381::JOVIAN_G1_MSM_MAX_INPUT_SIZE + 1;
         assert!(bad_input_len < bls12_381::ISTHMUS_G1_MSM_MAX_INPUT_SIZE);
         let input = vec![0u8; bad_input_len];
-        let res = bls12_381_g1_msm_precompile.execute(&input, u64::MAX);
+        let res = bls12_381_g1_msm_precompile.execute(&input, u64::MAX, 0).unwrap();
         assert!(
-            matches!(res, Err(PrecompileError::Other(msg)) if msg.contains("input length too long"))
+            matches!(res.status, PrecompileStatus::Halt(PrecompileHalt::Other(msg)) if msg.contains("input length too long"))
         );
 
         let bls12_381_g2_msm_precompile =
@@ -430,9 +441,9 @@ mod tests {
         bad_input_len = bls12_381::JOVIAN_G2_MSM_MAX_INPUT_SIZE + 1;
         assert!(bad_input_len < bls12_381::ISTHMUS_G2_MSM_MAX_INPUT_SIZE);
         let input = vec![0u8; bad_input_len];
-        let res = bls12_381_g2_msm_precompile.execute(&input, u64::MAX);
+        let res = bls12_381_g2_msm_precompile.execute(&input, u64::MAX, 0).unwrap();
         assert!(
-            matches!(res, Err(PrecompileError::Other(msg)) if msg.contains("input length too long"))
+            matches!(res.status, PrecompileStatus::Halt(PrecompileHalt::Other(msg)) if msg.contains("input length too long"))
         );
 
         let bls12_381_pairing_precompile =
@@ -440,9 +451,9 @@ mod tests {
         bad_input_len = bls12_381::JOVIAN_PAIRING_MAX_INPUT_SIZE + 1;
         assert!(bad_input_len < bls12_381::ISTHMUS_PAIRING_MAX_INPUT_SIZE);
         let input = vec![0u8; bad_input_len];
-        let res = bls12_381_pairing_precompile.execute(&input, u64::MAX);
+        let res = bls12_381_pairing_precompile.execute(&input, u64::MAX, 0).unwrap();
         assert!(
-            matches!(res, Err(PrecompileError::Other(msg)) if msg.contains("input length too long"))
+            matches!(res.status, PrecompileStatus::Halt(PrecompileHalt::Other(msg)) if msg.contains("input length too long"))
         );
     }
 
@@ -510,7 +521,7 @@ mod tests {
         let res = run_g1_msm_isthmus(&input, 260_000);
 
         assert!(
-            matches!(res, Err(PrecompileError::Other(msg)) if msg.contains("input length too long"))
+            matches!(res, Err(PrecompileHalt::Other(msg)) if msg.contains("input length too long"))
         );
     }
 
@@ -522,7 +533,7 @@ mod tests {
         let res = run_g1_msm_jovian(&input, u64::MAX);
 
         assert!(
-            matches!(res, Err(PrecompileError::Other(msg)) if msg.contains("input length too long"))
+            matches!(res, Err(PrecompileHalt::Other(msg)) if msg.contains("input length too long"))
         );
     }
     #[test]
@@ -533,7 +544,7 @@ mod tests {
         let res = run_g2_msm_isthmus(&input, 260_000);
 
         assert!(
-            matches!(res, Err(PrecompileError::Other(msg)) if msg.contains("input length too long"))
+            matches!(res, Err(PrecompileHalt::Other(msg)) if msg.contains("input length too long"))
         );
     }
     #[test]
@@ -544,7 +555,7 @@ mod tests {
         let res = run_g2_msm_jovian(&input, u64::MAX);
 
         assert!(
-            matches!(res, Err(PrecompileError::Other(msg)) if msg.contains("input length too long"))
+            matches!(res, Err(PrecompileHalt::Other(msg)) if msg.contains("input length too long"))
         );
     }
     #[test]
@@ -555,7 +566,7 @@ mod tests {
         let res = bls12_381::run_pair_isthmus(&input, 260_000);
 
         assert!(
-            matches!(res, Err(PrecompileError::Other(msg)) if msg.contains("input length too long"))
+            matches!(res, Err(PrecompileHalt::Other(msg)) if msg.contains("input length too long"))
         );
     }
     #[test]
@@ -566,7 +577,7 @@ mod tests {
         let res = bls12_381::run_pair_jovian(&input, u64::MAX);
 
         assert!(
-            matches!(res, Err(PrecompileError::Other(msg)) if msg.contains("input length too long"))
+            matches!(res, Err(PrecompileHalt::Other(msg)) if msg.contains("input length too long"))
         );
     }
 }


### PR DESCRIPTION
## Summary
- bump the Rust OP stack to `revm 38`
- update related `alloy-evm`, `alloy-op-evm`, `op-revm`, `revm-inspectors`, and reth dependencies
- adapt `alloy-op-evm`, kona precompiles, and op-reth integration points to the new APIs

## Insights
- the FPVM precompile provider currently hardcodes a `0` reservoir when invoking precompiles; this branch compiles, but reservoir-aware gas accounting likely still needs a follow-up review under the revm 38 / EIP-8037 model