### PR TITLE
fix(ci): pin mise to 2026.2.2 in docker-build-prep action

### DIFF
--- a/.github/actions/docker-build-prep/action.yml
+++ b/.github/actions/docker-build-prep/action.yml
@@ -15,6 +15,7 @@ runs:
     - name: Install mise
       uses: jdx/mise-action@c1ecc8f748cd28cdeabf76dab3cccde4ce692fe4 # v4.0.0
       with:
+        version: 2026.2.2
         install_args: just
 
     - name: Get date


### PR DESCRIPTION
## Summary

The branch build `prep` job (`.github/workflows/branches.yaml` → `docker-build-prep`) was failing to install `just` via `jdx/mise-action`. Example failing run: https://github.com/ethereum-optimism/optimism/actions/runs/24638787954/job/72039357234

### Root cause

`jdx/mise-action` defaults to installing the latest mise release (`2026.4.18` at the time of failure). That release [changed](https://github.com/jdx/mise/pull/9245) the `ubi` backend to skip the `mise-versions.jdx.dev` cache and query GitHub's API directly. The `ubi` backend's tag-resolution logic prepends a `v` to the requested version, so for `just = "1.46.0"` (aliased to `ubi:casey/just` in `mise.toml`) it hits:

```
https://api.github.com/repos/casey/just/releases/tags/v1.46.0
```

`casey/just` publishes releases with a non-`v` prefix (the tag is `1.46.0`), so the above 404s and the install step fails.

The CircleCI side is unaffected because the `ethereum-optimism/circleci-utils` orb pins mise to `v2026.2.2`, which still uses the versions host and resolves the correct tag.

### Fix

Pin the mise version in `.github/actions/docker-build-prep/action.yml` to `2026.2.2` to match CircleCI.

## Test plan

- [ ] `branch build / prep` job succeeds on this PR
- [ ] Downstream `build` / `build-fork` jobs receive a populated `versions` output from prep