### PR TITLE
op-supernode: review fixes for #19973 (race, Stop safety, backfill edges)

### DIFF
--- a/op-acceptance-tests/tests/supernode/interop/backfill/happy/happy_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/backfill/happy/happy_test.go
@@ -1,6 +1,6 @@
 // Package happy contains the happy-path acceptance test for interop log
-// backfill. It lives in its own package (rather than a single file) so it
-// runs in its own test binary, isolated from the retry-path test.
+// backfill. It lives in its own package so it runs in its own test binary,
+// isolated from any other acceptance packages that share global preset state.
 package happy
 
 import (

--- a/op-acceptance-tests/tests/supernode/interop/backfill/testutil.go
+++ b/op-acceptance-tests/tests/supernode/interop/backfill/testutil.go
@@ -1,7 +1,6 @@
-// Package backfillutil contains shared helpers used by the interop log-backfill
-// acceptance tests. The individual test cases live in sibling packages
-// (backfill/happy) so that each runs in its own test binary and shares no
-// in-process state.
+// Package backfill contains shared helpers used by the interop log-backfill
+// acceptance tests. The individual test cases live in the sibling backfill/happy
+// package so each runs in its own test binary and shares no in-process state.
 package backfill
 
 import (

--- a/op-supernode/config/config.go
+++ b/op-supernode/config/config.go
@@ -50,6 +50,15 @@ func (c *CLIConfig) Check() error {
 	if c.InteropLogBackfillDepth < 0 {
 		return errors.New("interop.log-backfill-depth must be >= 0")
 	}
+	// Reject sub-second positive durations: LogBackfillLowerBound divides by
+	// time.Second (floor) to derive the seconds offset for T_lo. Anything
+	// less than a second truncates to 0 — the depth silently becomes a no-op
+	// even though the > 0 checks downstream think backfill is enabled.
+	// Fail loud at config time so operators see it instead of wondering why
+	// backfill didn't run.
+	if c.InteropLogBackfillDepth > 0 && c.InteropLogBackfillDepth < time.Second {
+		return errors.New("interop.log-backfill-depth must be >= 1s when non-zero (sub-second values truncate to 0 and silently disable backfill)")
+	}
 	// Note: InteropLogBackfillDepth > 0 also requires a resolved interop
 	// activation timestamp, but that can be satisfied either by the CLI
 	// override (InteropActivationTimestamp) or by rollup configs loaded

--- a/op-supernode/config/config_test.go
+++ b/op-supernode/config/config_test.go
@@ -30,6 +30,29 @@ func TestCLIConfig_Check_interopLogBackfill(t *testing.T) {
 			cfg:     &CLIConfig{L1NodeAddr: "http://x", InteropActivationTimestamp: ptr(1), InteropLogBackfillDepth: -time.Second},
 			wantErr: "interop.log-backfill-depth must be >= 0",
 		},
+		{
+			// Zero is the documented "disables backfill" value. Must stay
+			// accepted by Check() — a regression here would make every
+			// operator who doesn't explicitly configure depth fail startup.
+			name: "zero depth disables backfill and passes Check",
+			cfg:  &CLIConfig{L1NodeAddr: "http://x"},
+		},
+		{
+			// Sub-second positive durations truncate to zero inside
+			// LogBackfillLowerBound (see log_backfill.go), so accepting
+			// them would silently no-op backfill. Check() should reject
+			// at config time so operators see the problem immediately.
+			name:    "sub-second positive depth rejected",
+			cfg:     &CLIConfig{L1NodeAddr: "http://x", InteropActivationTimestamp: ptr(1), InteropLogBackfillDepth: 500 * time.Millisecond},
+			wantErr: "must be >= 1s when non-zero",
+		},
+		{
+			// Exactly 1s is the smallest non-zero depth that survives the
+			// seconds-floor conversion. Pin it so future refactors don't
+			// accidentally tighten the bound past what operators can set.
+			name: "one-second depth is the minimum accepted positive value",
+			cfg:  &CLIConfig{L1NodeAddr: "http://x", InteropActivationTimestamp: ptr(1), InteropLogBackfillDepth: time.Second},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	opservice "github.com/ethereum-optimism/optimism/op-service"
+	"github.com/ethereum-optimism/optimism/op-service/clock"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supernode/flags"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/activity"
@@ -245,11 +246,18 @@ func (i *Interop) Start(ctx context.Context) error {
 			if err == nil {
 				break
 			}
+			// ErrChainBehindBackfillLowerBound is terminal: its only operator
+			// remediation (per the error's docstring) is to clear the data
+			// directory and restart. Retrying in place just drowns logs and
+			// hides the real action item.
+			if errors.Is(err, ErrChainBehindBackfillLowerBound) {
+				return fmt.Errorf("log backfill aborted: %w (operator: clear the supernode data directory and restart)", err)
+			}
 			i.log.Warn("log backfill failed, retrying (virtual nodes may not be ready yet)", "err", err)
-			select {
-			case <-i.ctx.Done():
-				return fmt.Errorf("log backfill interrupted: %w", i.ctx.Err())
-			case <-time.After(i.errorBackoffPeriod):
+			// SleepCtx instead of time.After so ctx cancel is observed
+			// immediately and no timer is abandoned.
+			if err := clock.SystemClock.SleepCtx(i.ctx, i.errorBackoffPeriod); err != nil {
+				return fmt.Errorf("log backfill interrupted: %w", err)
 			}
 		}
 	}
@@ -262,14 +270,20 @@ func (i *Interop) Start(ctx context.Context) error {
 		default:
 			madeProgress, err := i.progressAndRecord()
 			if err != nil {
-				// Error: back off before next attempt
+				// Error: back off before next attempt. SleepCtx so ctx cancel
+				// stops the loop immediately instead of sleeping out the full
+				// backoff.
 				i.log.Error("failed to progress and record interop", "err", err)
-				time.Sleep(i.errorBackoffPeriod)
+				if sleepErr := clock.SystemClock.SleepCtx(i.ctx, i.errorBackoffPeriod); sleepErr != nil {
+					return sleepErr
+				}
 				continue
 			}
 			if !madeProgress {
-				// Chains not ready, back off before next attempt
-				time.Sleep(i.backoffPeriod)
+				// Chains not ready, back off before next attempt.
+				if sleepErr := clock.SystemClock.SleepCtx(i.ctx, i.backoffPeriod); sleepErr != nil {
+					return sleepErr
+				}
 			}
 			// Otherwise: immediately ready for next iteration (aggressive catch-up)
 		}

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -21,10 +21,17 @@ import (
 
 // Compile-time interface conformance assertions.
 var (
-	_                  activity.RunnableActivity     = (*Interop)(nil)
-	_                  activity.VerificationActivity = (*Interop)(nil)
-	backoffPeriod                                    = 1 * time.Second // backoff when chains aren't ready
-	errorBackoffPeriod                               = 2 * time.Second // backoff on errors
+	_ activity.RunnableActivity     = (*Interop)(nil)
+	_ activity.VerificationActivity = (*Interop)(nil)
+)
+
+// Default backoff durations used by Start. Seeded into i.backoffPeriod /
+// i.errorBackoffPeriod in New so tests can override them per-instance
+// without racing — two parallel tests each spawning Start on their own
+// Interop used to fight over package-level vars.
+const (
+	defaultBackoffPeriod      = 1 * time.Second // backoff when chains aren't ready
+	defaultErrorBackoffPeriod = 2 * time.Second // backoff on errors
 )
 
 // InteropActivationTimestampFlag is the CLI flag for the interop activation timestamp.
@@ -92,7 +99,11 @@ type Interop struct {
 	// and is advanced past the backfilled range after log backfill completes.
 	// Protocol-facing queries (VerifiedAtTimestamp, VerifiedBlockAtL1, etc.)
 	// always use the original activationTimestamp.
-	runtimeActivationTimestamp uint64
+	//
+	// Atomic so test accessors (RuntimeActivationTimestamp) can read it
+	// from a different goroutine than the one that advances it in
+	// runLogBackfill without tripping the race detector.
+	runtimeActivationTimestamp atomic.Uint64
 
 	dataDir string
 
@@ -105,6 +116,16 @@ type Interop struct {
 	ctx     context.Context
 	cancel  context.CancelFunc
 	started bool
+	// done is closed by Start when it returns. Stop waits on done before
+	// closing logsDBs/verifiedDB so any in-flight backfill or frontier-seal
+	// writes finish before the underlying store files close. Without this,
+	// chain.FetchReceipts returning mid-cancel leaves sealBlockDataIntoLogsDB
+	// mid-SealBlock, racing with db.Close() (which does not hold db.rwLock).
+	done chan struct{}
+	// closeOnce makes Stop idempotent. Before this guard, a second Stop
+	// re-invoked logs.DB.Close() / verifiedDB.Close() on already-closed
+	// handles, which was a latent panic risk.
+	closeOnce sync.Once
 
 	currentL1 eth.BlockID
 
@@ -131,6 +152,13 @@ type Interop struct {
 	frontierView *frontierVerificationView
 
 	logBackfillDepth time.Duration
+
+	// backoffPeriod / errorBackoffPeriod are the Start loop's retry delays.
+	// Instance fields (not package vars) so each test can tune its own
+	// Interop without data-racing another test that happens to run in
+	// parallel. Seeded from defaultBackoffPeriod / defaultErrorBackoffPeriod.
+	backoffPeriod      time.Duration
+	errorBackoffPeriod time.Duration
 }
 
 func (i *Interop) Name() string {
@@ -173,16 +201,18 @@ func New(
 		messageExpiryWindow = defaultMessageExpiryWindow
 	}
 	i := &Interop{
-		log:                        log,
-		chains:                     chains,
-		verifiedDB:                 verifiedDB,
-		logsDBs:                    logsDBs,
-		dataDir:                    dataDir,
-		activationTimestamp:        activationTimestamp,
-		runtimeActivationTimestamp: activationTimestamp,
-		messageExpiryWindow:        messageExpiryWindow,
-		logBackfillDepth:           logBackfillDepth,
+		log:                 log,
+		chains:              chains,
+		verifiedDB:          verifiedDB,
+		logsDBs:             logsDBs,
+		dataDir:             dataDir,
+		activationTimestamp: activationTimestamp,
+		messageExpiryWindow: messageExpiryWindow,
+		logBackfillDepth:    logBackfillDepth,
+		backoffPeriod:       defaultBackoffPeriod,
+		errorBackoffPeriod:  defaultErrorBackoffPeriod,
 	}
+	i.runtimeActivationTimestamp.Store(activationTimestamp)
 	// default to using the verifyInteropMessages function
 	// (can be overridden by tests)
 	i.verifyFn = i.verifyInteropMessages
@@ -201,7 +231,11 @@ func (i *Interop) Start(ctx context.Context) error {
 	}
 	i.ctx, i.cancel = context.WithCancel(ctx)
 	i.started = true
+	i.done = make(chan struct{})
 	i.mu.Unlock()
+	// Signal Stop that all DB writes driven by this Start have drained.
+	// Must fire even on panic so Stop doesn't block forever waiting on it.
+	defer close(i.done)
 
 	if i.logBackfillDepth > 0 {
 		i.log.Info("interop log backfill depth configured", "duration", i.logBackfillDepth.String())
@@ -215,7 +249,7 @@ func (i *Interop) Start(ctx context.Context) error {
 			select {
 			case <-i.ctx.Done():
 				return fmt.Errorf("log backfill interrupted: %w", i.ctx.Err())
-			case <-time.After(errorBackoffPeriod):
+			case <-time.After(i.errorBackoffPeriod):
 			}
 		}
 	}
@@ -230,12 +264,12 @@ func (i *Interop) Start(ctx context.Context) error {
 			if err != nil {
 				// Error: back off before next attempt
 				i.log.Error("failed to progress and record interop", "err", err)
-				time.Sleep(errorBackoffPeriod)
+				time.Sleep(i.errorBackoffPeriod)
 				continue
 			}
 			if !madeProgress {
 				// Chains not ready, back off before next attempt
-				time.Sleep(backoffPeriod)
+				time.Sleep(i.backoffPeriod)
 			}
 			// Otherwise: immediately ready for next iteration (aggressive catch-up)
 		}
@@ -243,22 +277,51 @@ func (i *Interop) Start(ctx context.Context) error {
 }
 
 // Stop stops the Interop activity.
+//
+// Ordering:
+//  1. Cancel i.ctx so backfill / main loop observe the cancel through the
+//     chain RPC calls they make.
+//  2. Wait on i.done (closed by Start's defer) so any in-flight DB writes
+//     finish before we touch the underlying stores. logs.DB.Close does not
+//     take db.rwLock, so closing while SealBlock / AddLog is running would
+//     race on the underlying append-only store. Bounded by ctx so Stop
+//     cannot deadlock a caller with its own timeout.
+//  3. Close the DBs exactly once (idempotent for repeat Stop calls).
 func (i *Interop) Stop(ctx context.Context) error {
 	i.mu.Lock()
-	defer i.mu.Unlock()
+	started := i.started
+	done := i.done
 	if i.cancel != nil {
 		i.cancel()
 	}
-	// Close all logsDBs
-	for chainID, db := range i.logsDBs {
-		if err := db.Close(); err != nil {
-			i.log.Error("failed to close logs DB", "chainID", chainID, "err", err)
+	i.mu.Unlock()
+
+	if started && done != nil {
+		select {
+		case <-done:
+		case <-ctx.Done():
+			i.log.Warn("stop timed out waiting for Start to return; closing DBs anyway",
+				"err", ctx.Err())
 		}
 	}
-	if i.verifiedDB != nil {
-		return i.verifiedDB.Close()
-	}
-	return nil
+
+	var firstErr error
+	i.closeOnce.Do(func() {
+		for chainID, db := range i.logsDBs {
+			if err := db.Close(); err != nil {
+				i.log.Error("failed to close logs DB", "chainID", chainID, "err", err)
+				if firstErr == nil {
+					firstErr = err
+				}
+			}
+		}
+		if i.verifiedDB != nil {
+			if err := i.verifiedDB.Close(); err != nil && firstErr == nil {
+				firstErr = err
+			}
+		}
+	})
+	return firstErr
 }
 
 // checkPreconditions determines whether observation alone already implies an
@@ -374,7 +437,7 @@ func (i *Interop) observeRound() (RoundObservation, error) {
 		obs.LastVerified = &result
 		obs.NextTimestamp = lastTS + 1
 	} else {
-		obs.NextTimestamp = i.runtimeActivationTimestamp
+		obs.NextTimestamp = i.runtimeActivationTimestamp.Load()
 	}
 
 	if pauseTS := i.pauseAtTimestamp.Load(); pauseTS != 0 && obs.NextTimestamp >= pauseTS {
@@ -610,7 +673,7 @@ func (i *Interop) buildRewindPlan(lastTS uint64) (RewindPlan, error) {
 		RewindAtOrAfter: lastTS,
 	}
 
-	if lastTS <= i.runtimeActivationTimestamp {
+	if lastTS <= i.runtimeActivationTimestamp.Load() {
 		return plan, nil
 	}
 

--- a/op-supernode/supernode/activity/interop/interop_test_access.go
+++ b/op-supernode/supernode/activity/interop/interop_test_access.go
@@ -66,7 +66,7 @@ func (i *Interop) ActivationTimestamp() uint64 {
 // by the main loop and backfill. It starts equal to ActivationTimestamp and
 // may be advanced past the backfilled range once backfill finishes.
 func (i *Interop) RuntimeActivationTimestamp() uint64 {
-	return i.runtimeActivationTimestamp
+	return i.runtimeActivationTimestamp.Load()
 }
 
 // ---------------------------------------------------------------------------

--- a/op-supernode/supernode/activity/interop/log_backfill.go
+++ b/op-supernode/supernode/activity/interop/log_backfill.go
@@ -87,7 +87,7 @@ func (i *Interop) runLogBackfill() error {
 		}
 	}
 
-	Tlo := LogBackfillLowerBound(minCrossSafeTime, i.runtimeActivationTimestamp, i.logBackfillDepth)
+	Tlo := LogBackfillLowerBound(minCrossSafeTime, i.runtimeActivationTimestamp.Load(), i.logBackfillDepth)
 	// Debug-level because this fires on every retry while VNs are coming up.
 	// The summary "interop log backfill complete" line at the end is the
 	// user-visible signal that backfill finished.
@@ -134,12 +134,12 @@ func (i *Interop) runLogBackfill() error {
 		}
 	}
 
-	if !firstLocal && minLocalSafeTime+1 > i.runtimeActivationTimestamp {
+	if !firstLocal && minLocalSafeTime+1 > i.runtimeActivationTimestamp.Load() {
 		i.log.Info("advancing runtime activation past backfilled range",
-			"oldActivation", i.runtimeActivationTimestamp, "newActivation", minLocalSafeTime+1)
-		i.runtimeActivationTimestamp = minLocalSafeTime + 1
+			"oldActivation", i.runtimeActivationTimestamp.Load(), "newActivation", minLocalSafeTime+1)
+		i.runtimeActivationTimestamp.Store(minLocalSafeTime + 1)
 	}
-	i.log.Info("interop log backfill complete", "runtimeActivationTimestamp", i.runtimeActivationTimestamp)
+	i.log.Info("interop log backfill complete", "runtimeActivationTimestamp", i.runtimeActivationTimestamp.Load())
 	return nil
 }
 

--- a/op-supernode/supernode/activity/interop/log_backfill.go
+++ b/op-supernode/supernode/activity/interop/log_backfill.go
@@ -146,6 +146,23 @@ func (i *Interop) runLogBackfill() error {
 func (i *Interop) backfillChain(ctx context.Context, cid eth.ChainID, chain cc.ChainContainer, startNum, endNum uint64) error {
 	db := i.logsDBs[cid]
 	if latest, has := db.LatestSealedBlock(); has {
+		// Detect a coverage gap at the front of the DB. processBlockLogs
+		// seals a virtual parent at startNum-1 before the real first block,
+		// so after a clean backfill FirstSealedBlock is the requested
+		// startNum-1. If it is higher than that, the existing DB was
+		// populated by an earlier run whose T_lo was larger — e.g. operator
+		// increased logBackfillDepth across restarts. logs.DB is append-only
+		// so we cannot retroactively fill [requestedStart, existingFirst)
+		// without clearing; warn loudly so the gap is visible instead of
+		// silent.
+		if first, err := db.FirstSealedBlock(); err == nil && startNum > 0 && first.Number > startNum {
+			i.log.Warn("log backfill: logsDB starts above requested T_lo; coverage gap will remain",
+				"chain", cid,
+				"firstSealed", first.Number,
+				"requestedStart", startNum,
+				"gapBlocks", first.Number-startNum,
+				"hint", "clear the supernode data directory to get full coverage for the new depth")
+		}
 		startNum = latest.Number + 1
 	}
 	for num := startNum; num <= endNum; num++ {

--- a/op-supernode/supernode/activity/interop/log_backfill_test.go
+++ b/op-supernode/supernode/activity/interop/log_backfill_test.go
@@ -183,8 +183,12 @@ func TestLogBackfill_RetriesStopOnContextCancel(t *testing.T) {
 	done := make(chan error, 1)
 	go func() { done <- h.interop.Start(ctx) }()
 
-	// Let it retry a few times, then cancel.
-	time.Sleep(100 * time.Millisecond)
+	// Wait for at least two attempts so we're actually exercising the retry
+	// path before cancelling — previously a raw time.Sleep(100ms) was flaky
+	// on loaded CI and the test could pass without the retry loop running.
+	require.Eventually(t, func() bool {
+		return h.interop.backfillAttempts.Load() >= 2
+	}, 5*time.Second, 5*time.Millisecond, "backfill should attempt at least twice before cancel")
 	cancel()
 
 	select {

--- a/op-supernode/supernode/activity/interop/log_backfill_test.go
+++ b/op-supernode/supernode/activity/interop/log_backfill_test.go
@@ -93,7 +93,7 @@ func TestLogBackfill_ResumesAfterInterruption(t *testing.T) {
 	}
 
 	require.NoError(t, h.interop.runLogBackfill())
-	require.Equal(t, uint64(111), h.interop.runtimeActivationTimestamp)
+	require.Equal(t, uint64(111), h.interop.runtimeActivationTimestamp.Load())
 	require.Equal(t, act, h.interop.activationTimestamp, "protocol activation must not change")
 
 	latest, has = h.interop.logsDBs[chain10.id].LatestSealedBlock()
@@ -139,10 +139,9 @@ func TestLogBackfill_RetriesWhenVirtualNodesNotReady(t *testing.T) {
 		}).
 		Build()
 
-	// Use a shorter backoff for tests.
-	origBackoff := errorBackoffPeriod
-	errorBackoffPeriod = 10 * time.Millisecond
-	t.Cleanup(func() { errorBackoffPeriod = origBackoff })
+	// Shorter retry delay for tests. Instance-field, so no race with a
+	// sibling test also tuning its own Interop.
+	h.interop.errorBackoffPeriod = 10 * time.Millisecond
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -152,12 +151,12 @@ func TestLogBackfill_RetriesWhenVirtualNodesNotReady(t *testing.T) {
 
 	// Wait for backfill to complete: runtime activation should advance past 110.
 	require.Eventually(t, func() bool {
-		return h.interop.runtimeActivationTimestamp > act
+		return h.interop.runtimeActivationTimestamp.Load() > act
 	}, 5*time.Second, 20*time.Millisecond, "backfill should eventually succeed after retries")
 
 	require.GreaterOrEqual(t, syncStatusCalls.Load(), failUntil,
 		"SyncStatus should have been called at least %d times (the failing ones)", failUntil)
-	require.Equal(t, uint64(111), h.interop.runtimeActivationTimestamp)
+	require.Equal(t, uint64(111), h.interop.runtimeActivationTimestamp.Load())
 	require.Equal(t, act, h.interop.activationTimestamp, "protocol activation must not change")
 
 	cancel()
@@ -177,9 +176,7 @@ func TestLogBackfill_RetriesStopOnContextCancel(t *testing.T) {
 		}).
 		Build()
 
-	origBackoff := errorBackoffPeriod
-	errorBackoffPeriod = 10 * time.Millisecond
-	t.Cleanup(func() { errorBackoffPeriod = origBackoff })
+	h.interop.errorBackoffPeriod = 10 * time.Millisecond
 
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -264,7 +261,7 @@ func TestLogBackfill_AsymmetricMultiChain(t *testing.T) {
 
 	require.NoError(t, h.interop.runLogBackfill())
 	require.Equal(t, act, h.interop.activationTimestamp, "protocol activation must not change")
-	require.Equal(t, uint64(111), h.interop.runtimeActivationTimestamp,
+	require.Equal(t, uint64(111), h.interop.runtimeActivationTimestamp.Load(),
 		"runtime activation must advance to min(localSafe)+1 across all chains")
 
 	chain10 := h.Mock(10)
@@ -335,7 +332,7 @@ func TestLogBackfill_FailsWhenChainBehindLowerBound(t *testing.T) {
 	err := h.interop.runLogBackfill()
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrChainBehindBackfillLowerBound)
-	require.Equal(t, act, h.interop.runtimeActivationTimestamp,
+	require.Equal(t, act, h.interop.runtimeActivationTimestamp.Load(),
 		"runtime activation must not advance when backfill fails")
 }
 
@@ -386,7 +383,7 @@ func TestLogBackfill_MisalignedActivation(t *testing.T) {
 
 	require.NoError(t, h.interop.runLogBackfill())
 	require.Equal(t, act, h.interop.activationTimestamp, "protocol activation must not change")
-	require.Equal(t, localSafeTs+1, h.interop.runtimeActivationTimestamp)
+	require.Equal(t, localSafeTs+1, h.interop.runtimeActivationTimestamp.Load())
 
 	chain10 := h.Mock(10)
 	db := h.interop.logsDBs[chain10.id]
@@ -444,7 +441,7 @@ func TestLogBackfill_AdvancesActivationAndStartsVerifyAfterCeiling(t *testing.T)
 	h.interop.ctx = context.Background()
 
 	require.NoError(t, h.interop.runLogBackfill())
-	require.Equal(t, uint64(111), h.interop.runtimeActivationTimestamp)
+	require.Equal(t, uint64(111), h.interop.runtimeActivationTimestamp.Load())
 	require.Equal(t, act, h.interop.activationTimestamp, "protocol activation must not change")
 
 	chain10 := h.Mock(10)

--- a/op-supernode/supernode/activity/interop/logdb.go
+++ b/op-supernode/supernode/activity/interop/logdb.go
@@ -123,7 +123,10 @@ func (i *Interop) sealFetchedBlockIntoLogsDB(chainID eth.ChainID, blockID eth.Bl
 }
 
 // sealBlockDataIntoLogsDB seals logs for an already-fetched block using ts for verifyCanAddTimestamp.
-// isBackfill relaxes the first-seal check to allow any ts >= activation (not just ts == activation).
+// isBackfill relaxes the empty-DB first-seal check: instead of requiring
+// ts == runtimeActivationTimestamp, the anchor block may sit up to one
+// blockTime before activation (the "pre-activation pairing anchor" branch
+// in verifyCanAddTimestamp).
 func (i *Interop) sealBlockDataIntoLogsDB(chainID eth.ChainID, blockID eth.BlockID, blockInfo eth.BlockInfo, receipts gethTypes.Receipts, ts uint64, isBackfill bool) error {
 	chain, ok := i.chains[chainID]
 	if !ok {
@@ -233,9 +236,11 @@ func (i *Interop) verifyCanAddTimestamp(chainID eth.ChainID, db LogsDB, ts uint6
 }
 
 // processBlockLogs processes the receipts for a block and stores the logs in the database.
-// If isFirstBlock is true, this is the first block being added to the logsDB (at activation timestamp),
-// and we first seal a "virtual parent" block so that logs have a sealed block to reference.
-// This allows the logsDB to start at any block number, not just genesis.
+// If isFirstBlock is true, this is the first block being added to the logsDB
+// (at runtimeActivationTimestamp for the main loop, or within one blockTime
+// of activationTimestamp for backfill), and we first seal a "virtual parent"
+// block so logs have a sealed block to reference. This allows the logsDB
+// to start at any block number, not just genesis.
 func (i *Interop) processBlockLogs(db LogsDB, blockInfo eth.BlockInfo, receipts gethTypes.Receipts, isFirstBlock bool) error {
 	blockNum := blockInfo.NumberU64()
 	blockID := eth.BlockID{Hash: blockInfo.Hash(), Number: blockNum}

--- a/op-supernode/supernode/activity/interop/logdb.go
+++ b/op-supernode/supernode/activity/interop/logdb.go
@@ -173,7 +173,7 @@ func (i *Interop) verifyCanAddTimestamp(chainID eth.ChainID, db LogsDB, ts uint6
 		// The main loop starts at runtimeActivationTimestamp (which may have been
 		// advanced past the protocol activation by backfill). If the DB is empty,
 		// this is the only timestamp the main loop would legitimately seal first.
-		if ts == i.runtimeActivationTimestamp {
+		if ts == i.runtimeActivationTimestamp.Load() {
 			return eth.BlockID{}, hasBlocks, nil
 		}
 		// Backfill's first block is TargetBlockNumber(T_lo), which floors the

--- a/op-supernode/supernode/activity/interop/logdb_test.go
+++ b/op-supernode/supernode/activity/interop/logdb_test.go
@@ -260,6 +260,75 @@ func TestVerifyPreviousTimestampSealed(t *testing.T) {
 	}
 }
 
+// TestVerifyCanAddTimestamp_RuntimeVsProtocolActivation pins the two semantic
+// splits that were added with log backfill but not exercised in the original
+// table-driven test: (1) main-loop empty-DB seals must match
+// runtimeActivationTimestamp (not activationTimestamp), and (2) backfill
+// empty-DB seals may sit within one blockTime before activationTimestamp
+// (the pre-activation pairing anchor).
+//
+// Without these cases the existing test accepts both ts == activation and
+// ts == runtimeActivation interchangeably because every row initialises
+// them to the same value, so a regression that swapped the two fields
+// would silently pass.
+func TestVerifyCanAddTimestamp_RuntimeVsProtocolActivation(t *testing.T) {
+	t.Parallel()
+
+	const (
+		protocolAct uint64 = 1000
+		runtimeAct  uint64 = 1200 // advanced past backfilled range
+		blockTime   uint64 = 3
+	)
+	chainID := eth.ChainIDFromUInt64(10)
+
+	newInterop := func() *Interop {
+		i := &Interop{log: gethlog.New(), activationTimestamp: protocolAct}
+		i.runtimeActivationTimestamp.Store(runtimeAct)
+		return i
+	}
+	emptyDB := func() *mockLogsDB { return &mockLogsDB{hasBlocks: false} }
+
+	t.Run("main-loop empty DB at runtimeActivation succeeds", func(t *testing.T) {
+		t.Parallel()
+		_, has, err := newInterop().verifyCanAddTimestamp(chainID, emptyDB(), runtimeAct, blockTime, false)
+		require.NoError(t, err)
+		require.False(t, has)
+	})
+
+	t.Run("main-loop empty DB at protocolActivation errors (not runtimeActivation)", func(t *testing.T) {
+		t.Parallel()
+		_, _, err := newInterop().verifyCanAddTimestamp(chainID, emptyDB(), protocolAct, blockTime, false)
+		require.ErrorIs(t, err, ErrPreviousTimestampNotSealed,
+			"main loop must compare to runtimeActivationTimestamp; a regression that used activationTimestamp would wrongly accept %d here", protocolAct)
+	})
+
+	t.Run("backfill empty DB at anchor (activation - blockTime + 1) succeeds", func(t *testing.T) {
+		t.Parallel()
+		// TargetBlockNumber(activation) floors to a block up to blockTime-1
+		// earlier than activation; accepting that block is the whole point
+		// of the backfill branch.
+		ts := protocolAct - blockTime + 1
+		_, _, err := newInterop().verifyCanAddTimestamp(chainID, emptyDB(), ts, blockTime, true)
+		require.NoError(t, err, "ts=%d should be accepted as the pre-activation pairing anchor", ts)
+	})
+
+	t.Run("backfill empty DB at activation succeeds", func(t *testing.T) {
+		t.Parallel()
+		_, _, err := newInterop().verifyCanAddTimestamp(chainID, emptyDB(), protocolAct, blockTime, true)
+		require.NoError(t, err)
+	})
+
+	t.Run("backfill empty DB strictly more than one blockTime before activation errors", func(t *testing.T) {
+		t.Parallel()
+		// ts + blockTime == activation is the boundary: the check is
+		// strict >, so this must fail. Prevents the anchor window from
+		// silently widening if the operator is wrong.
+		ts := protocolAct - blockTime
+		_, _, err := newInterop().verifyCanAddTimestamp(chainID, emptyDB(), ts, blockTime, true)
+		require.ErrorIs(t, err, ErrPreviousTimestampNotSealed)
+	})
+}
+
 // =============================================================================
 // TestProcessBlockLogs
 // =============================================================================

--- a/op-supernode/supernode/activity/interop/logdb_test.go
+++ b/op-supernode/supernode/activity/interop/logdb_test.go
@@ -222,10 +222,10 @@ func TestVerifyPreviousTimestampSealed(t *testing.T) {
 			t.Parallel()
 
 			interop := &Interop{
-				log:                        gethlog.New(),
-				activationTimestamp:        tt.activationTS,
-				runtimeActivationTimestamp: tt.activationTS,
+				log:                 gethlog.New(),
+				activationTimestamp: tt.activationTS,
 			}
+			interop.runtimeActivationTimestamp.Store(tt.activationTS)
 			chainID := eth.ChainIDFromUInt64(10)
 			expectedHash := common.Hash{0x01}
 			db := &mockLogsDB{


### PR DESCRIPTION
Three commits against `feat/op-supernode-interop-log-backfill` covering the
must-fix / should-fix / nit items surfaced while reviewing #19973.

Every commit message has the full why/what/trade-off writeup; this PR
description is just an index.

## Must-fix — `a2b09d8` — race, Stop/backfill races, double-close, test-var race

- `runtimeActivationTimestamp` promoted to `atomic.Uint64` — the field
  was plain `uint64`, read from `RuntimeActivationTimestamp()` (test
  accessor), `observeRound`, `buildRewindPlan`, and
  `verifyCanAddTimestamp` while written only by `runLogBackfill`.
  Siblings (`backfillAttempts`, `backfillCompleted`, `pauseAtTimestamp`)
  were already atomic; this one was missed and tripped `-race`.
- `Stop` now waits on `i.done` (closed by `Start`'s `defer`) before
  closing logsDBs/verifiedDB. Previously `Stop` cancelled `i.ctx` and
  immediately called `db.Close()`, but the backfill hot path does
  not check ctx between `FetchReceipts` and the subsequent
  `SealBlock` / `AddLog`, and `logs.DB.Close` does not take
  `db.rwLock` — so a Stop arriving between "receipts fetched" and
  "seal flushed" could close the append-only store out from under a
  live writer.
- `Stop` is now idempotent via `sync.Once`. The pre-existing code
  only closed `verifiedDB`; this PR expanded it to close every
  `logs.DB`, making a repeat `Stop` call re-invoke `Close` on
  already-closed stores.
- `errorBackoffPeriod` / `backoffPeriod` moved from package vars to
  instance fields on `Interop`. The two retry-path tests mutated the
  package vars in parallel and raced each other (pre-existing — in
  this PR, not upstream). Per-instance durations remove the shared
  state entirely and drop the `t.Cleanup` restore dance.

Verified with `go test ./op-supernode/supernode/activity/interop/
-race -count=3` — clean.

## Should-fix — `d785b83` — terminal error, coverage gap, sub-second depth, SleepCtx, stale comments

- `ErrChainBehindBackfillLowerBound` now terminates the retry loop
  with an inline operator remediation hint. Previously it looped
  forever behind a misleading "virtual nodes may not be ready" warn.
- Resume with a larger `logBackfillDepth` across restarts now logs
  a `Warn` naming the chain, first-sealed block, requested start, and
  gap size. logs.DB is append-only so we can't retroactively fill the
  range; the fix surfaces the gap instead of silencing it.
- Sub-second `logBackfillDepth` (truncates to zero inside
  `LogBackfillLowerBound`) is rejected at `CLIConfig.Check` time.
  Previously `depth < 1s` silently disabled backfill while the
  downstream `> 0` checks reported it as active.
- `time.After(d)` in the retry `select` and both `time.Sleep` calls
  in the main loop replaced with `clock.SystemClock.SleepCtx(ctx, d)`
  — no abandoned timers, and a ctx cancel during a backoff returns
  immediately instead of sleeping out the full duration.
- Stale comments updated: `logdb.go:126` / `logdb.go:236` (old
  "`ts >= activation`" and "at activation timestamp" phrasings
  predate the `ts+blockTime > activation` misalignment fix in
  1f813c4d7c), `acceptance/.../testutil.go` + `happy_test.go`
  (referenced the retry-path sibling package deleted in 4c7f8e9764).

## Nits — `9d4edfa` — test coverage

- Config test gains zero-depth / sub-second / 1s-boundary rows — the
  previous table missed every non-trivial non-negative case.
- `TestLogBackfill_RetriesStopOnContextCancel` swaps raw `time.Sleep
  (100ms)` for `require.Eventually` gated on `backfillAttempts >= 2`,
  so the test actually exercises the retry path before cancel
  (previously the test could pass without a retry happening).
- New `TestVerifyCanAddTimestamp_RuntimeVsProtocolActivation` pins
  the `activationTimestamp` vs `runtimeActivationTimestamp` split
  with five cases (main-loop at runtime succeeds, main-loop at
  protocol errors, backfill pairing anchor succeeds at both the
  inner and outer edges, backfill rejects strictly more than one
  blockTime before activation). A regression that swapped the two
  fields would have passed the existing suite.

## Test plan

- [x] `go test ./op-supernode/supernode/activity/interop/ ./op-supernode/config/... -race -count=3` (clean)
- [ ] CI green on the PR
- [ ] Review from @axelKingsley / optimism maintainers

🤖 Generated with [Claude Code](https://claude.com/claude-code)