### PR TITLE
chore(deps): upgrade Python 3.12.0 → 3.12.13 in mise.toml to fix failing `mise install`

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -7,7 +7,7 @@ golangci-lint = "2.8.0"
 gotestsum = "1.12.3"
 mockery = "2.53.3"
 rust = ["1.94.0", { version = "nightly-2026-02-20", components = "rustfmt" }]
-python = "3.12.0"
+python = "3.12.13"
 uv = "0.5.5"
 jq = "1.7.1"
 yq = "4.44.5"


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

- Bumps Python from 3.12.0 to 3.12.13 in mise.toml
- Fixes mise install failure caused by missing GitHub artifact attestations on Python 3.12.0 — that release predates the attestation feature (introduced May 2024), so verification always fails
- Avoids the workaround of disabling attestation verification, keeping the security check intact

**Tests**

`mise install works`. I didn't test the usage of python itself but this is only a patch version bump so it shouldn't have an effect.

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
