### PR TITLE
refactor(ci): update CI gate jobs in CircleCI configuration

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -2768,18 +2768,10 @@ workflows:
         - equal: ["webhook", << pipeline.trigger_source >>]
         - not: << pipeline.parameters.c-non_docs_changes >>
     jobs:
-      - ci-gate-skip:
-          name: check-kontrol-build
-      - ci-gate-skip:
-          name: shell-check
-      - ci-gate-skip:
-          name: go-lint
-      - ci-gate-skip:
-          name: semgrep-scan-local
-      - ci-gate-skip:
-          name: go-tests-short
-      - ci-gate-skip:
-          name: memory-all
+      - ci-gate:
+          always-succed: true
+          context:
+            - circleci-api-token
 
   go-release-op-deployer:
     jobs:


### PR DESCRIPTION
This pull request makes a change to the workflow configuration in `.circleci/continue/main.yml` to simplify job handling. The main update is replacing multiple individual `ci-gate-skip` jobs with a single `ci-gate` job that always succeeds.

Workflow simplification:

* Replaced several `ci-gate-skip` jobs (`check-kontrol-build`, `shell-check`, `go-lint`, `semgrep-scan-local`, `go-tests-short`, `memory-all`) with a single `ci-gate` job configured to always succeed and use the `circleci-api-token` context.