### PR TITLE
fix(op-acceptance-tests): stabilize TestUnsafeGapFillAfterUnsafeReorg_RestartL2CL

### DIFF
--- a/op-acceptance-tests/tests/sync/elsync/reorg/sync_test.go
+++ b/op-acceptance-tests/tests/sync/elsync/reorg/sync_test.go
@@ -163,6 +163,9 @@ func TestUnsafeGapFillAfterUnsafeReorg_RestartL2CL(gt *testing.T) {
 
 	// Stop Verifier CL
 	sys.L2CLB.Stop()
+	// Capture verifier's frozen unsafe head to use as a lower bound for what
+	// the sequencer must exceed after the reorg.
+	verUnsafeFrozen := sys.L2ELB.BlockRefByLabel(eth.Unsafe)
 
 	// Reorg L1 block which unsafe block L1 Origin points to
 	l1BlockBeforeReorg := sys.L1EL.BlockRefByNumber(l2BlockBeforeReorg.L1Origin.Number)
@@ -187,6 +190,12 @@ func TestUnsafeGapFillAfterUnsafeReorg_RestartL2CL(gt *testing.T) {
 	l2BlockAfterReorg := sys.L2EL.BlockRefByNumber(l2BlockBeforeReorg.Number)
 	require.NotEqual(l2BlockAfterReorg.Hash, l2BlockBeforeReorg.Hash)
 	logger.Info("Triggered L2 reorg", "l2", l2BlockAfterReorg)
+
+	// Wait for the sequencer to strictly exceed the verifier's frozen height
+	// before asserting seq > ver — ReorgTriggered only guarantees the block at
+	// l2BlockBeforeReorg.Number has been rewritten, not that the sequencer has
+	// rebuilt past the verifier.
+	sys.L2EL.Reached(eth.Unsafe, verUnsafeFrozen.Number+1, 30)
 
 	// Check the divergence before restarting verifier L2CLB
 	verUnsafe := sys.L2ELB.BlockRefByLabel(eth.Unsafe)

--- a/op-acceptance-tests/tests/sync/elsync/reorg/sync_test.go
+++ b/op-acceptance-tests/tests/sync/elsync/reorg/sync_test.go
@@ -151,7 +151,7 @@ func TestUnsafeGapFillAfterUnsafeReorg_RestartL2CL(gt *testing.T) {
 		return l2Unsafe.Number > 0 && l2Unsafe.L1Origin.Number > startL1Block.Number
 	}, 120*time.Second, 2*time.Second)
 
-	sys.L2ELB.Matched(sys.L2EL, types.LocalUnsafe, 5)
+	sys.L2ELB.Matched(sys.L2EL, types.LocalUnsafe, 30)
 
 	// Pick reorg block
 	l2BlockBeforeReorg := sys.L2EL.BlockRefByLabel(eth.Unsafe)
@@ -159,7 +159,7 @@ func TestUnsafeGapFillAfterUnsafeReorg_RestartL2CL(gt *testing.T) {
 
 	// Make few more unsafe blocks which will be reorged out
 	sys.L2EL.Advanced(eth.Unsafe, 4)
-	sys.L2ELB.Matched(sys.L2EL, types.LocalUnsafe, 5)
+	sys.L2ELB.Matched(sys.L2EL, types.LocalUnsafe, 30)
 
 	// Stop Verifier CL
 	sys.L2CLB.Stop()


### PR DESCRIPTION
**Claude:** Opened by Claude on behalf of @ajsutton. Closes ethereum-optimism/optimism#19936.

Fixes two independent races in `TestUnsafeGapFillAfterUnsafeReorg_RestartL2CL`. First, `ReorgTriggered` returns as soon as the reorg block is rewritten and does not wait for the sequencer to rebuild past the verifier's frozen unsafe head, so the immediately-following `seqUnsafe > verUnsafe` assertion could sample the sequencer mid-rebuild and fail (matching the CI evidence of `seq:18 ver:18`). Fixed by capturing the verifier's unsafe head right after `L2CLB.Stop()` and waiting on `Reached(eth.Unsafe, verUnsafeFrozen.Number+1, 30)` before the assertion, making the ordering structurally guaranteed.

Second, the two pre-reorg `Matched` calls used a 5-attempt (~10s) budget that assumed the verifier was in lockstep with the sequencer. Under cold-start contention (e.g. op-reth JIT compile) the sequencer can burst-produce 100+ blocks before the verifier begins syncing, and 10s isn't enough to close the gap. Bumped both budgets to 30 attempts (60s), consistent with the existing post-stop budget of 50.
