### PR TITLE
test(flashblocks): mark TestFlashblocksStream as flaky

### DIFF
--- a/op-acceptance-tests/tests/flashblocks/flashblocks_stream_test.go
+++ b/op-acceptance-tests/tests/flashblocks/flashblocks_stream_test.go
@@ -16,6 +16,8 @@ import (
 // rollup-boost and op-rbuilder streams.
 func TestFlashblocksStream(gt *testing.T) {
 	t := devtest.ParallelT(gt)
+	// TODO(ethereum-optimism/optimism#19883): investigate and unmark.
+	t.MarkFlaky("ethereum-optimism/optimism#19883")
 	// Example error with kona-node:
 	//
 	// assertions.go:387:             ERROR[03-30|22:44:52.250]


### PR DESCRIPTION
## Summary
- Adds `t.MarkFlaky("ethereum-optimism/optimism#19883")` to `TestFlashblocksStream` so the acceptance run downgrades its failures to skips while the flake is investigated.
- Leaves a `TODO` comment pointing at the tracking issue so the marker is easy to remove once the underlying port-conflict in `rollup-boost` is resolved.

Tracking: ethereum-optimism/optimism#19883

## Test plan
- [ ] CI: acceptance jobs pass (and any future `TestFlashblocksStream` failures are reported as skips, listed in `flaky-tests.txt`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)