### PR TITLE
fix(op-acceptance-tests): stabilize TestReorgUnsafeHead

### DIFF
--- a/op-acceptance-tests/tests/interop/reorgs/unsafe_head_test.go
+++ b/op-acceptance-tests/tests/interop/reorgs/unsafe_head_test.go
@@ -1,6 +1,7 @@
 package reorgs
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -93,12 +94,28 @@ func TestReorgUnsafeHead(gt *testing.T) {
 			L1Origin: nil,
 		})
 		require.NoError(t, err, "Expected to be able to create a new block job for sequencing on op-test-sequencer, but got error")
-		time.Sleep(2 * time.Second)
 
 		err = ia.Next(ctx)
 		require.NoError(t, err, "Expected to be able to call Next() after New() on op-test-sequencer, but got error")
-		time.Sleep(2 * time.Second)
 	}
+
+	// Before resuming op-node sequencing, wait until the CL's sync status reflects the
+	// test-sequencer's final committed block. The EL is updated synchronously by
+	// CommitBlock (via engine.NewPayload + forkchoice update), but the op-node's
+	// StatusTracker and Sequencer.latestHead are updated via asynchronous events.
+	// Without this wait, StartSequencer() can observe a stale local unsafe head, pass
+	// that stale hash to Sequencer.Start (which validates against its equally-stale
+	// latestHead), and then build on top of the original chain — silently reorging
+	// the EL back off the test-sequencer's conflicting fork.
+	expectedUnsafe := sys.L2ELA.BlockRefByLabel(eth.Unsafe)
+	l.Info("Waiting for op-node local-unsafe to match test-sequencer's committed head",
+		"number", expectedUnsafe.Number, "hash", expectedUnsafe.Hash)
+	waitCtx, waitCancel := context.WithTimeout(ctx, 30*time.Second)
+	err := wait.For(waitCtx, 100*time.Millisecond, func() (bool, error) {
+		return sys.L2ACL.SyncStatus().UnsafeL2.Hash == expectedUnsafe.Hash, nil
+	})
+	waitCancel()
+	require.NoError(t, err, "op-node never observed test-sequencer's committed unsafe head %s", expectedUnsafe.Hash)
 
 	// continue sequencing with consensus node (op-node)
 	sys.L2ACL.StartSequencer()


### PR DESCRIPTION
## Summary

Replace two `time.Sleep(2 * time.Second)` band-aids in `TestReorgUnsafeHead` with a deterministic poll on `SyncStatus().UnsafeL2.Hash` before re-enabling op-node sequencing.

Refs ethereum-optimism/optimism#20198.

## Root cause

`op-test-sequencer.CommitBlock` (via `opstack_commitBlockV1`) updates the EL synchronously (`engine_newPayload` + `engine_forkchoiceUpdated`) before returning, but the op-node's CL state — `StatusTracker.data.UnsafeL2` and `Sequencer.latestHead` — is updated asynchronously via the event executor draining `ForkchoiceUpdateEvent`.

Pre-fix, the test slept `2 * time.Second` twice. Under CI load the event loop could still be behind when `StartSequencer()` fired:

1. `L2CLNode.StartSequencer` reads `SyncStatus().UnsafeL2` → stale pre-stop original head.
2. Passes that stale hash to `Sequencer.Start` → validation `head == d.latestHead.Hash` passes because `latestHead` is equally stale.
3. `forceStart` activates the sequencer; `startBuildingBlock` uses the stale `latestHead` as parent and emits an FCU that reorgs the EL back onto the original chain.

Result: the assertion at `unsafe_head_test.go:114` reads the block at the divergence height and sees `originalRef_A.Hash`, which is precisely the observed symptom in https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/123078/workflows/4327c7d8-ab80-44a4-9508-0c99d5bc2fe0/jobs/4868463/tests (both log lines 111 and 112 printed the same hash).

## Why flaky, not consistent

Non-determinism is purely event-loop drain timing under Go goroutine scheduling. Under light load, 2 s is ample; under heavy CI load (four job variants running concurrently on acceptance-tests nodes) the drainer can be preempted long enough that the two-block pileup of `NewPayload → UnsafeUpdate → ForkchoiceUpdate` events hasn't finished processing when `StartSequencer` fires.

## Note on the CI job name

Despite the failing job being `memory-all-kona-op-reth`, this test runs against **op-node**, not kona-node:

- `NewTwoL2SupernodeInterop` → `multichain_supernode_runtime.go` hardcodes `opnodeconfig.Config`; `DEVSTACK_L2CL_KIND` is ignored by the supernode preset.
- The test-sequencer's committer requires `opstack_openBlockV1`/`opstack_commitBlockV1`, which only op-node implements (`op-node/node/api.go:186`); kona has no opstack RPC module.
- The failing job's logs show `component=supernode` with Go source references (`sequencer.go`, `driver.go`, `payload_success.go`, …).

## Fix

1. Snapshot the EL's unsafe head after the test-sequencer's second `ia.Next` — authoritative because `CommitBlock` is synchronous w.r.t. the EL.
2. Poll `sys.L2ACL.SyncStatus().UnsafeL2.Hash` every 100 ms (30 s timeout) until it equals the snapshot.
3. Only then call `StartSequencer()`.

Within a single `processEvent` dispatch the handlers run sequentially, so `StatusTracker` and `Sequencer.OnEvent` can complete out of order. But by the time `SyncStatus` reports the expected hash, either (a) the sequencer has already processed the same `ForkchoiceUpdateEvent`, or (b) when it does, `Sequencer.Start`'s internal mutex serialises `Start` against `OnEvent`, so `StartSequencer` either observes the fresh `latestHead` or fails fast with a visible `"block hash does not match"` error rather than silently reorging. Worst case the poll times out with an explicit `"op-node never observed test-sequencer's committed unsafe head <hash>"` — an explicit failure replacing a silent one.

## Test plan

- [x] `go build ./op-acceptance-tests/...`
- [x] `go vet ./op-acceptance-tests/...`
- [x] `op-golangci-lint run ./op-acceptance-tests/tests/interop/reorgs/...`
- [x] CI acceptance-tests job passes

---

_Authored by Claude Opus 4.7 (1M context) on behalf of @ajsutton; human review recommended before merge._