### PR TITLE
fix(ci): update CircleCI configuration to improve ci-gate job handling

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -727,15 +727,14 @@ jobs:
   ci-gate:
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
+    parameters:
+      always-succeed:
+        description: Force always succeed (skip API gate; for contracts-feature-tests-short)
+        type: boolean
+        default: false
     steps:
-      - utils/ci-gate
-
-  ci-gate-skip:
-    docker:
-      - image: <<pipeline.parameters.c-default_docker_image>>
-    resource_class: small
-    steps:
-      - run: echo "Skipped — docs-only change"
+      - utils/ci-gate:
+          always-succeed: << parameters.always-succeed >>
 
   # Build a single Rust binary from a workspace. Will cache the binary by default.
   rust-build-binary:
@@ -1560,13 +1559,13 @@ jobs:
       - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: small
     parameters:
-      always-succed:
+      always-succeed:
         description: Force always succeed (skip API gate; for contracts-feature-tests-short)
         type: boolean
         default: false
     steps:
       - utils/ci-gate:
-          always-succeed: << parameters.always-succed >>
+          always-succeed: << parameters.always-succeed >>
 
   contracts-bedrock-checks-fast:
     docker:
@@ -2731,12 +2730,6 @@ workflows:
             - cannon-prestate
             - rust-binaries-for-sysgo
             - go-binaries-for-sysgo
-      # Aggregator for all memory-all acceptance test variants
-      - memory-all:
-          requires:
-            - memory-all-opn-op-geth
-            - memory-all-opn-op-reth
-            - memory-all-kona-op-reth
       # Gate job - single stable job used as GitHub required status check for develop.
       # Uses terminal requires so it always runs (even when deps fail), giving the
       # merge queue an immediate failure signal instead of a timeout.
@@ -2748,7 +2741,9 @@ workflows:
             - go-lint: terminal
             - semgrep-scan-local: terminal
             - go-tests-short: terminal
-            - memory-all: terminal
+            - memory-all-opn-op-geth: terminal
+            - memory-all-opn-op-reth: terminal
+            - memory-all-kona-op-reth: terminal
           context:
             - circleci-api-token
           filters:
@@ -2769,7 +2764,7 @@ workflows:
         - not: << pipeline.parameters.c-non_docs_changes >>
     jobs:
       - ci-gate:
-          always-succed: true
+          always-succeed: true
           context:
             - circleci-api-token
 
@@ -3282,6 +3277,6 @@ workflows:
             - equal: ["api", << pipeline.trigger_source >>]
     jobs:
       - required-contracts-ci:
-          always-succed: true
+          always-succeed: true
           context:
             - circleci-api-token


### PR DESCRIPTION
This pull request makes several improvements and cleanups to the CircleCI configuration, mainly focused on fixing a parameter typo, simplifying job definitions, and updating workflow dependencies. The most important changes are summarized below:

**Parameter Naming and Consistency:**

* Fixed a typo in the `always-succeed` parameter (previously `always-succed`) across all relevant job and workflow definitions to ensure correct parameter usage and avoid misconfiguration. [[1]](diffhunk://#diff-f0efc20f2a9bb4e4f890362860f525c756a7b2662b088773e51c83c5b328c64cL1563-R1568) [[2]](diffhunk://#diff-f0efc20f2a9bb4e4f890362860f525c756a7b2662b088773e51c83c5b328c64cL2772-R2767) [[3]](diffhunk://#diff-f0efc20f2a9bb4e4f890362860f525c756a7b2662b088773e51c83c5b328c64cL3285-R3280)

**Job and Workflow Simplification:**

* Removed the redundant `ci-gate-skip` job and instead added an `always-succeed` parameter to the main `ci-gate` job, allowing it to be conditionally forced to succeed.
* Updated the usage of the `ci-gate` job in workflows to use the corrected `always-succeed` parameter. [[1]](diffhunk://#diff-f0efc20f2a9bb4e4f890362860f525c756a7b2662b088773e51c83c5b328c64cL2772-R2767) [[2]](diffhunk://#diff-f0efc20f2a9bb4e4f890362860f525c756a7b2662b088773e51c83c5b328c64cL3285-R3280)

**Workflow Dependency Updates:**

* Removed the aggregate `memory-all` job from workflow dependencies, and instead listed its individual component jobs (`memory-all-opn-op-geth`, `memory-all-opn-op-reth`, `memory-all-kona-op-reth`) directly as terminal jobs, clarifying workflow structure and improving job visibility. [[1]](diffhunk://#diff-f0efc20f2a9bb4e4f890362860f525c756a7b2662b088773e51c83c5b328c64cL2734-L2739) [[2]](diffhunk://#diff-f0efc20f2a9bb4e4f890362860f525c756a7b2662b088773e51c83c5b328c64cL2751-R2746)