### PR TITLE
fix(op-devstack): retry StartSequencer on stale unsafe head

### DIFF
--- a/op-devstack/dsl/l2_cl.go
+++ b/op-devstack/dsl/l2_cl.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
@@ -75,10 +76,32 @@ func (cl *L2CLNode) restoreManagedPeers() {
 }
 
 func (cl *L2CLNode) StartSequencer() {
-	unsafe := cl.HeadBlockRef(types.LocalUnsafe)
-	cl.log.Info("Continue sequencing with consensus node (op-node)", "chain", cl.ChainID(), "unsafe", unsafe)
-
-	err := cl.inner.RollupAPI().StartSequencer(cl.ctx, unsafe.Hash)
+	// The op-node Sequencer.Start RPC requires the caller to pass the hash of op-node's
+	// current unsafe head. Reading the head and issuing the start call are two separate
+	// RPCs, so any unsafe payload that op-node processes in between (e.g. blocks gossiped
+	// by another sequencer over p2p) invalidates the hash we just read. Retry on that
+	// specific mismatch error with a freshly-read head.
+	const maxAttempts = 10
+	var err error
+loop:
+	for range maxAttempts {
+		unsafe := cl.HeadBlockRef(types.LocalUnsafe)
+		cl.log.Info("Continue sequencing with consensus node (op-node)", "chain", cl.ChainID(), "unsafe", unsafe)
+		err = cl.inner.RollupAPI().StartSequencer(cl.ctx, unsafe.Hash)
+		if err == nil {
+			break
+		}
+		if !strings.Contains(err.Error(), "block hash does not match") {
+			break
+		}
+		cl.log.Info("Unsafe head advanced between read and StartSequencer; retrying", "chain", cl.ChainID(), "err", err)
+		select {
+		case <-cl.ctx.Done():
+			err = cl.ctx.Err()
+			break loop
+		case <-time.After(250 * time.Millisecond):
+		}
+	}
 	cl.require.NoError(err, fmt.Sprintf("Expected to be able to start sequencer on chain %d", cl.ChainID()))
 
 	// wait for the sequencer to become active


### PR DESCRIPTION
The DSL `StartSequencer` helper reads op-node's unsafe head via SyncStatus and then issues the Sequencer.Start RPC with that hash. op-node rejects the call if its latestHead advanced in between (e.g. a block gossiped over p2p by another sequencer), producing "block hash does not match". This surfaced as flakiness in `TestReorgInitExecMsg`, where `op-test-sequencer` publishes unsafe blocks concurrently with the handoff back to op-node. Retry on that specific error with a freshly-read head.

Flaky run at: https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/123094/workflows/58628e7d-eeaa-4b85-8898-5e2a3f6f00b5/jobs/4869894