### PR TITLE
chore(ci): consolidate Rust toolchain install into mise.toml

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -438,38 +438,6 @@ commands:
           key: go-<<parameters.namespace>>-<<parameters.version>>-<<parameters.module>>-{{ checksum "<<parameters.module>>/go.mod" }}-{{ checksum "<<parameters.module>>/go.sum" }}
 
   # --- Rust environment setup commands ---
-  rust-install-toolchain:
-    description: "Install Rust toolchain via rustup"
-    parameters:
-      channel:
-        description: The Rust channel release to use (stable, nightly, etc.)
-        type: string
-        default: "stable"
-      components:
-        description: Components to install (space or comma separated)
-        type: string
-        default: ""
-      toolchain_version:
-        description: The specific toolchain version for stable channel
-        type: string
-        default: "1.92.0"
-      target:
-        description: A custom target architecture to add to the toolchain
-        type: string
-        default: ""
-    steps:
-      - run:
-          name: Install Rust toolchain (<< parameters.channel >>)
-          command: |
-            rustup default << parameters.toolchain_version >>
-
-            if [ -n "<< parameters.components >>" ]; then
-              rustup component add << parameters.components >>
-            fi
-            if [ -n "<< parameters.target >>" ]; then
-              rustup target add << parameters.target >>
-            fi
-
   rust-setup-env:
     description: "Fix rust mise environment variables"
     steps:
@@ -642,10 +610,6 @@ commands:
         description: "Binary name to build. If not specified, all targets will be built."
         type: string
         default: ""
-      toolchain:
-        description: "Rust toolchain version to install before building (empty = use default)"
-        type: string
-        default: ""
       save_cache:
         description: "Whether to save the cache at the end of the build"
         type: boolean
@@ -663,11 +627,6 @@ commands:
           directory: << parameters.directory >>
           profile: << parameters.profile >>
           features: << parameters.features >>
-      - when:
-          condition: << parameters.toolchain >>
-          steps:
-            - rust-install-toolchain:
-                toolchain_version: << parameters.toolchain >>
       - run:
           name: Build << parameters.directory >>
           command: |
@@ -770,10 +729,6 @@ jobs:
         description: "Binary name to build. If not specified, all targets will be built."
         type: string
         default: ""
-      toolchain:
-        description: "Rust toolchain version to install before building (empty = use default)"
-        type: string
-        default: ""
       save_cache:
         description: "Whether to save the cache at the end of the build"
         type: boolean
@@ -795,7 +750,6 @@ jobs:
           features: << parameters.features >>
           package: << parameters.package >>
           binary: << parameters.binary >>
-          toolchain: << parameters.toolchain >>
           save_cache: << parameters.save_cache >>
           rust_files_changed: << parameters.rust_files_changed >>
       - when:

--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -697,7 +697,7 @@ jobs:
           name: Build for <<parameters.target>>
           working_directory: <<parameters.directory>>
           no_output_timeout: 40m
-          command: cargo hack build --target <<parameters.target>> <<parameters.flags>>
+          command: rustup target add <<parameters.target>> && cargo hack build --target <<parameters.target>> <<parameters.flags>>
       - rust-save-build-cache: *hack-build-cache-args
 
   # Shared cargo hack job

--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -142,41 +142,6 @@ commands:
             fi
             curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
 
-  rust-install-toolchain:
-    description: "Install Rust toolchain via rustup"
-    parameters:
-      channel:
-        description: The Rust channel release to use (stable, nightly, etc.)
-        type: string
-        default: "stable"
-      components:
-        description: Components to install (space or comma separated)
-        type: string
-        default: ""
-      toolchain_version:
-        description: The specific toolchain version for stable channel
-        type: string
-        default: "1.94.0"
-      target:
-        description: A custom target architecture to add to the toolchain
-        type: string
-        default: ""
-    steps:
-      - run:
-          name: Install Rust toolchain (<< parameters.channel >>)
-          command: |
-            TOOLCHAIN="<< parameters.toolchain_version >>"
-
-            rustup toolchain install "$TOOLCHAIN"
-            rustup default "$TOOLCHAIN"
-
-            if [ -n "<< parameters.components >>" ]; then
-              rustup component add << parameters.components >>
-            fi
-            if [ -n "<< parameters.target >>" ]; then
-              rustup target add << parameters.target >>
-            fi
-
   rust-setup-env:
     description: "Fix rust mise environment variables"
     steps:
@@ -306,10 +271,6 @@ commands:
         description: "Binary name to build. If not specified, all targets will be built."
         type: string
         default: ""
-      toolchain:
-        description: "Rust toolchain version to install before building (empty = use default)"
-        type: string
-        default: ""
       save_cache:
         description: "Whether to save the cache at the end of the build"
         type: boolean
@@ -323,11 +284,6 @@ commands:
           directory: << parameters.directory >>
           profile: << parameters.profile >>
           features: << parameters.features >>
-      - when:
-          condition: << parameters.toolchain >>
-          steps:
-            - rust-install-toolchain:
-                toolchain_version: << parameters.toolchain >>
       - run:
           name: Build << parameters.directory >>
           command: |
@@ -453,10 +409,6 @@ jobs:
         description: "Clippy command to run"
         type: string
         default: "cargo clippy --workspace --all-targets --all-features"
-      toolchain:
-        description: "Rust toolchain to use (stable or nightly)"
-        type: string
-        default: "stable"
     docker:
       - image: <<pipeline.parameters.c-rust_base_image>>
     resource_class: medium
@@ -467,10 +419,6 @@ jobs:
           directory: <<parameters.directory>>
           prefix: <<parameters.directory>>-clippy
           features: "all"
-      - rust-install-toolchain:
-          channel: <<parameters.toolchain>>
-          toolchain_version: <<parameters.toolchain>>
-          components: clippy
       - run:
           name: Run clippy
           working_directory: <<parameters.directory>>
@@ -573,14 +521,6 @@ jobs:
       directory:
         description: "Directory containing the Cargo workspace"
         type: string
-      target:
-        description: "Target architecture for no_std check"
-        type: string
-        default: "riscv32imac-unknown-none-elf"
-      toolchain:
-        description: "Rust toolchain version to use"
-        type: string
-        default: "stable"
       command:
         description: "Command to run for no_std check"
         type: string
@@ -594,9 +534,6 @@ jobs:
       - rust-prepare-and-restore-cache: &no-std-cache-args
           directory: <<parameters.directory>>
           prefix: <<parameters.directory>>-no-std
-      - rust-install-toolchain:
-          toolchain_version: <<parameters.toolchain>>
-          target: <<parameters.target>>
       - run:
           name: Check no_std compatibility
           working_directory: <<parameters.directory>>
@@ -671,10 +608,6 @@ jobs:
         description: "Flags passed to just command (e.g. --all-features, --no-default-features)"
         type: string
         default: ""
-      rust_version:
-        description: "Rust toolchain version to use"
-        type: string
-        default: "stable"
       cache_profile:
         description: "Build profile for caching"
         type: string
@@ -689,8 +622,6 @@ jobs:
           directory: <<parameters.directory>>
           prefix: <<parameters.directory>>-tests
           profile: <<parameters.cache_profile>>
-      - rust-install-toolchain:
-          toolchain_version: <<parameters.rust_version>>
       - install-cargo-binstall
       - run:
           name: Install nextest
@@ -766,7 +697,7 @@ jobs:
           name: Build for <<parameters.target>>
           working_directory: <<parameters.directory>>
           no_output_timeout: 40m
-          command: rustup target add <<parameters.target>> && cargo hack build --target <<parameters.target>> <<parameters.flags>>
+          command: cargo hack build --target <<parameters.target>> <<parameters.flags>>
       - rust-save-build-cache: *hack-build-cache-args
 
   # Shared cargo hack job
@@ -923,8 +854,6 @@ jobs:
       - rust-prepare-and-restore-cache:
           directory: rust
           features: "all"
-      - rust-install-toolchain:
-          components: rustfmt
       - run:
           name: Run fmt + lint for <<parameters.target>>
           working_directory: rust/kona
@@ -968,8 +897,6 @@ jobs:
           directory: rust
           prefix: kona-coverage
           version: "1"
-      - rust-install-toolchain:
-          components: llvm-tools-preview
       - install-cargo-binstall
       - run:
           name: Install cargo-llvm-cov and nextest
@@ -1029,8 +956,6 @@ jobs:
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
-      - rust-install-toolchain:
-          components: llvm-tools-preview
       - apt-install:
           packages: "clang llvm-dev libclang-dev"
           extra_flags: "--no-install-recommends"
@@ -1161,12 +1086,6 @@ workflows:
           profile: release
           context: *rust-ci-context
 
-      - rust-build-binary:
-          name: rust-msrv
-          directory: rust
-          toolchain: "1.94.0"
-          context: *rust-ci-context
-
       # -----------------------------------------------------------------------
       # Unified cross-compilation jobs
       # -----------------------------------------------------------------------
@@ -1175,7 +1094,6 @@ workflows:
           directory: rust
           command: |
             just check-no-std
-          toolchain: "1.94.0"
           context: *rust-ci-context
 
       - rust-ci-cargo-hack-build:

--- a/mise.toml
+++ b/mise.toml
@@ -6,7 +6,10 @@ go = "1.24.13"
 golangci-lint = "2.8.0"
 gotestsum = "1.12.3"
 mockery = "2.53.3"
-rust = ["1.94.0", { version = "nightly-2026-02-20", components = "rustfmt" }]
+rust = [
+  { version = "1.94.0", components = "clippy,rustfmt,llvm-tools-preview", targets = "riscv32imac-unknown-none-elf,wasm32-unknown-unknown,wasm32-wasip1" },
+  { version = "nightly-2026-02-20", components = "rustfmt" },
+]
 python = "3.12.13"
 uv = "0.5.5"
 jq = "1.7.1"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -13924,9 +13924,9 @@ dependencies = [
 
 [[package]]
 name = "thin-vec"
-version = "0.2.14"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144f754d318415ac792f9d69fc87abbbfc043ce2ef041c60f16ad828f638717d"
+checksum = "259cdf8ed4e4aca6f1e9d011e10bd53f524a2d0637d7b28450f6c64ac298c4c6"
 
 [[package]]
 name = "thiserror"


### PR DESCRIPTION
 - Move Rust components (`clippy`, `rustfmt`, `llvm-tools-preview`) and cross-compile targets (`riscv32imac-unknown-none-elf`, `wasm32-unknown-unknown`, `wasm32-wasip1`) into `mise.toml`
  so developers and CI share one source of truth for the toolchain.
  - Remove the `rust-install-toolchain` CircleCI command from `main.yml` and `rust-ci.yml` along with all 9 call sites — every invocation was re-installing the same 1.94.0 toolchain mise
  already provides; the only real work was adding the now-declared components/targets. Also drops the `rust-msrv` workflow entry (functionally identical to `rust-build` since MSRV equals
  the mise default).