### PR TITLE
chore(rust): update thin-vec to patch RUSTSEC-2026-0103

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -13924,9 +13924,9 @@ dependencies = [
 
 [[package]]
 name = "thin-vec"
-version = "0.2.14"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144f754d318415ac792f9d69fc87abbbfc043ce2ef041c60f16ad828f638717d"
+checksum = "259cdf8ed4e4aca6f1e9d011e10bd53f524a2d0637d7b28450f6c64ac298c4c6"
 
 [[package]]
 name = "thiserror"


### PR DESCRIPTION
**Description**

Updates thin-vec to 0.2.16 to patch [RUSTSEC-2026-0103](https://rustsec.org/advisories/RUSTSEC-2026-0103) and fix the `rust-deny` CI job
