### PR TITLE
chore(ci): move cargo-* tools + lychee from CI installers to mise.toml

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -323,18 +323,6 @@ commands:
       - apt-install:
           packages: "zstd=1.4.8*"
 
-  install-cargo-binstall:
-    description: "Install cargo-binstall for fast binary installations"
-    steps:
-      - run:
-          name: Install cargo-binstall
-          command: |
-            if command -v cargo-binstall >/dev/null 2>&1; then
-              echo "cargo-binstall already installed"
-              exit 0
-            fi
-            curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
-
   get-target-branch:
     description: "Determine the PR target branch and export TARGET_BRANCH for subsequent steps"
     steps:

--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -130,18 +130,6 @@ commands:
             done
             sudo -E apt-get install -y << parameters.extra_flags >> << parameters.packages >>
 
-  install-cargo-binstall:
-    description: "Install cargo-binstall for fast binary installations"
-    steps:
-      - run:
-          name: Install cargo-binstall
-          command: |
-            if command -v cargo-binstall >/dev/null 2>&1; then
-              echo "cargo-binstall already installed"
-              exit 0
-            fi
-            curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
-
   rust-setup-env:
     description: "Fix rust mise environment variables"
     steps:
@@ -447,11 +435,6 @@ jobs:
       - rust-prepare-and-restore-cache: &deny-cache-args
           directory: <<parameters.directory>>
           prefix: <<parameters.directory>>-deny
-      - install-cargo-binstall
-      - run:
-          name: Install cargo-deny
-          command: |
-            command -v cargo-deny >/dev/null || cargo binstall --no-confirm cargo-deny
       - run:
           name: Run cargo deny
           working_directory: <<parameters.directory>>
@@ -477,12 +460,6 @@ jobs:
       - rust-prepare-and-restore-cache: &zepter-cache-args
           directory: <<parameters.directory>>
           prefix: <<parameters.directory>>-zepter
-      - install-cargo-binstall
-      - run:
-          name: Install zepter
-          command: |
-            command -v zepter >/dev/null || cargo binstall --no-confirm zepter
-            zepter --version
       - run:
           name: Check feature propagation
           working_directory: <<parameters.directory>>
@@ -504,11 +481,6 @@ jobs:
       - rust-prepare-and-restore-cache: &typos-cache-args
           directory: <<parameters.directory>>
           prefix: <<parameters.directory>>-typos
-      - install-cargo-binstall
-      - run:
-          name: Install typos-cli
-          command: |
-            command -v typos >/dev/null || cargo binstall --no-confirm typos-cli
       - run:
           name: Check for typos
           working_directory: <<parameters.directory>>
@@ -622,11 +594,6 @@ jobs:
           directory: <<parameters.directory>>
           prefix: <<parameters.directory>>-tests
           profile: <<parameters.cache_profile>>
-      - install-cargo-binstall
-      - run:
-          name: Install nextest
-          command: |
-            command -v cargo-nextest >/dev/null || cargo binstall --locked --no-confirm cargo-nextest
       - run:
           name: Run cargo tests
           working_directory: <<parameters.directory>>
@@ -654,11 +621,6 @@ jobs:
           directory: <<parameters.directory>>
           prefix: <<parameters.directory>>-udeps
           profile: "release"
-      - install-cargo-binstall
-      - run:
-          name: Install cargo-udeps
-          command: |
-            command -v cargo-udeps >/dev/null || cargo binstall --no-confirm cargo-udeps
       - run:
           name: Check unused dependencies
           working_directory: <<parameters.directory>>
@@ -688,11 +650,6 @@ jobs:
       - rust-prepare-and-restore-cache: &hack-build-cache-args
           directory: <<parameters.directory>>
           prefix: <<parameters.directory>>-hack-build
-      - install-cargo-binstall
-      - run:
-          name: Install cargo-hack
-          command: |
-            command -v cargo-hack >/dev/null || cargo binstall --no-confirm cargo-hack
       - run:
           name: Build for <<parameters.target>>
           working_directory: <<parameters.directory>>
@@ -718,11 +675,6 @@ jobs:
           directory: rust
           prefix: rust-hack
           features: "all"
-      - install-cargo-binstall
-      - run:
-          name: Install cargo-hack
-          command: |
-            command -v cargo-hack >/dev/null || cargo binstall --no-confirm cargo-hack
       - run:
           name: Run cargo hack
           working_directory: rust
@@ -794,11 +746,6 @@ jobs:
           packages: "clang llvm-dev libclang-dev"
           extra_flags: "--no-install-recommends"
       - rust-prepare
-      - install-cargo-binstall
-      - run:
-          name: Install cargo-llvm-cov
-          command: |
-            command -v cargo-llvm-cov >/dev/null || cargo binstall --no-confirm cargo-llvm-cov
       - run:
           name: Build cannon
           command: |
@@ -897,12 +844,6 @@ jobs:
           directory: rust
           prefix: kona-coverage
           version: "1"
-      - install-cargo-binstall
-      - run:
-          name: Install cargo-llvm-cov and nextest
-          command: |
-            command -v cargo-llvm-cov >/dev/null || cargo binstall --no-confirm cargo-llvm-cov
-            command -v cargo-nextest >/dev/null || cargo binstall --locked --no-confirm cargo-nextest
       - run:
           name: Generate lockfile if needed
           working_directory: rust
@@ -928,11 +869,6 @@ jobs:
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
-      - run:
-          name: Install lychee
-          command: |
-            curl -sSfL https://github.com/lycheeverse/lychee/releases/download/v0.15.1/lychee-v0.15.1-x86_64-unknown-linux-gnu.tar.gz | tar xz
-            sudo mv lychee /usr/local/bin/
       - run:
           name: Check links
           working_directory: rust/kona

--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -697,7 +697,7 @@ jobs:
           name: Build for <<parameters.target>>
           working_directory: <<parameters.directory>>
           no_output_timeout: 40m
-          command: cargo hack build --target <<parameters.target>> <<parameters.flags>>
+          command: rustup target add <<parameters.target>> && cargo hack build --target <<parameters.target>> <<parameters.flags>>
       - rust-save-build-cache: *hack-build-cache-args
 
   # Shared cargo hack job

--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -697,7 +697,7 @@ jobs:
           name: Build for <<parameters.target>>
           working_directory: <<parameters.directory>>
           no_output_timeout: 40m
-          command: rustup target add <<parameters.target>> && cargo hack build --target <<parameters.target>> <<parameters.flags>>
+          command: cargo hack build --target <<parameters.target>> <<parameters.flags>>
       - rust-save-build-cache: *hack-build-cache-args
 
   # Shared cargo hack job

--- a/mise.toml
+++ b/mise.toml
@@ -21,9 +21,9 @@ just = "1.46.0"
 make = "4.4.1"
 
 svm-rs = "0.5.19"
-"github:nextest-rs/nextest" = { version = "0.9.132", version_prefix = "cargo-nextest-", bin = "cargo-nextest" }
 
-# Rust tooling previously installed via `cargo binstall` in CI.
+# Rust tooling
+"github:nextest-rs/nextest" = { version = "0.9.132", version_prefix = "cargo-nextest-", bin = "cargo-nextest" }
 "github:EmbarkStudios/cargo-deny" = "0.19.4"
 "github:ggwpez/zepter" = { version = "1.88.0", version_prefix = "v" }
 "github:crate-ci/typos" = { version = "1.45.1", version_prefix = "v" }

--- a/mise.toml
+++ b/mise.toml
@@ -24,12 +24,12 @@ svm-rs = "0.5.19"
 "github:nextest-rs/nextest" = { version = "0.9.132", version_prefix = "cargo-nextest-", bin = "cargo-nextest" }
 
 # Rust tooling previously installed via `cargo binstall` in CI.
-"ubi:EmbarkStudios/cargo-deny" = "0.19.4"
-"ubi:ggwpez/zepter" = "1.88.0"
-"ubi:crate-ci/typos" = "1.45.1"
-"ubi:est31/cargo-udeps" = "0.1.60"
-"ubi:taiki-e/cargo-hack" = "0.6.44"
-"ubi:taiki-e/cargo-llvm-cov" = "0.8.5"
+"github:EmbarkStudios/cargo-deny" = "0.19.4"
+"github:ggwpez/zepter" = { version = "1.88.0", version_prefix = "v" }
+"github:crate-ci/typos" = { version = "1.45.1", version_prefix = "v" }
+"github:est31/cargo-udeps" = { version = "0.1.60", version_prefix = "v" }
+"github:taiki-e/cargo-hack" = { version = "0.6.44", version_prefix = "v" }
+"github:taiki-e/cargo-llvm-cov" = { version = "0.8.5", version_prefix = "v" }
 "github:lycheeverse/lychee" = { version = "0.23.0", version_prefix = "lychee-v", bin = "lychee" }
 
 # Go dependencies
@@ -53,7 +53,6 @@ anvil = "1.2.3"
 # Other dependencies
 codecov-uploader = "0.8.0"
 goreleaser-pro = "2.11.2"
-kurtosis = "1.8.1"
 git-cliff = "2.12.0"
 
 # Fake dependencies
@@ -64,20 +63,19 @@ kontrol = "1.0.90"
 binary_signer = "1.0.4"
 
 [tool_alias]
-forge = "ubi:foundry-rs/foundry[exe=forge]"
-cast = "ubi:foundry-rs/foundry[exe=cast]"
-anvil = "ubi:foundry-rs/foundry[exe=anvil]"
-just = "ubi:casey/just"
-codecov-uploader = "ubi:codecov/uploader"
-goreleaser-pro = "ubi:goreleaser/goreleaser-pro[exe=goreleaser]"
-gotestsum = "ubi:gotestyourself/gotestsum"
-kurtosis = "ubi:kurtosis-tech/kurtosis-cli-release-artifacts[exe=kurtosis]"
-mockery = "ubi:vektra/mockery"
-svm-rs = "ubi:alloy-rs/svm-rs[exe=svm]"
+forge = "github:foundry-rs/foundry[bin=forge,version_prefix=v]"
+cast = "github:foundry-rs/foundry[bin=cast,version_prefix=v]"
+anvil = "github:foundry-rs/foundry[bin=anvil,version_prefix=v]"
+just = "github:casey/just"
+codecov-uploader = "github:codecov/uploader[version_prefix=v]"
+goreleaser-pro = "github:goreleaser/goreleaser-pro[bin=goreleaser,version_prefix=v]"
+gotestsum = "github:gotestyourself/gotestsum[version_prefix=v]"
+mockery = "github:vektra/mockery[version_prefix=v]"
+svm-rs = "github:alloy-rs/svm-rs[bin=svm,version_prefix=v]"
 # These are disabled, but latest mise versions error if they don't have a known
 # install source even though it won't ever actually use that source.
-kontrol = "ubi:ethereum-optimism/fake-kontrol"
-binary_signer = "ubi:ethereum-optimism/fake-binary_signer"
+kontrol = "github:ethereum-optimism/fake-kontrol"
+binary_signer = "github:ethereum-optimism/fake-binary_signer"
 
 [settings]
 experimental = true

--- a/mise.toml
+++ b/mise.toml
@@ -23,6 +23,15 @@ make = "4.4.1"
 svm-rs = "0.5.19"
 "github:nextest-rs/nextest" = { version = "0.9.132", version_prefix = "cargo-nextest-", bin = "cargo-nextest" }
 
+# Rust tooling previously installed via `cargo binstall` in CI.
+"ubi:EmbarkStudios/cargo-deny" = "0.19.4"
+"ubi:ggwpez/zepter" = "1.88.0"
+"ubi:crate-ci/typos" = "1.45.1"
+"ubi:est31/cargo-udeps" = "0.1.60"
+"ubi:taiki-e/cargo-hack" = "0.6.44"
+"ubi:taiki-e/cargo-llvm-cov" = "0.8.5"
+"github:lycheeverse/lychee" = { version = "0.23.0", version_prefix = "lychee-v", bin = "lychee" }
+
 # Go dependencies
 "go:github.com/ethereum/go-ethereum/cmd/abigen" = "1.15.10"
 "go:github.com/ethereum/go-ethereum/cmd/geth" = "1.16.4" # Osaka testnet release.

--- a/op-program/scripts/run-static-analysis.sh
+++ b/op-program/scripts/run-static-analysis.sh
@@ -37,7 +37,7 @@ echo "✅ llvm-objdump found at $(which llvm-objdump)"
 if ! command -v vm-compat &> /dev/null; then
   echo "❌ Error: 'vm-compat' is required but not found in \$PATH"
   echo "Please install it using:"
-  echo "  mise use -g ubi:ChainSafe/vm-compat@1.1.0"
+  echo "  mise use -g github:ChainSafe/vm-compat@1.1.0"
   echo "Or manually download from:"
   echo "  https://github.com/ChainSafe/vm-compat/releases"
   exit 1

--- a/ops/book/src/ci/mise.md
+++ b/ops/book/src/ci/mise.md
@@ -22,7 +22,9 @@ However, some packages require some additional configuration.
 GitHub packages that expose multiple executables or where the executable name is different from the package name
 will require an alias to be defined in `mise.toml`. To do this:
 
-1. Add an alias named after the package to the `[alias]` stanza.
-2. Configure the alias to point to the package repository and specify the executable at the end 
-   as `[exe=<your-executable>]`, e.g.`ubi:goreleaser/goreleaser-pro[exe=goreleaser]`.
+1. Add an alias named after the package to the `[tool_alias]` stanza.
+2. Configure the alias to point to the package repository and specify the executable at the end
+   as `[bin=<your-executable>]`, e.g. `github:goreleaser/goreleaser-pro[bin=goreleaser,version_prefix=v]`.
+   Add `version_prefix=v` when the upstream release tags are v-prefixed (mise's `github:` backend
+   does not auto-strip prefixes).
 3. Add your package and its version to the list of tools in the `[tools]` stanza.


### PR DESCRIPTION
Follow up to: https://github.com/ethereum-optimism/optimism/pull/20207

---

TODO:
- [x] remove `ubi`
- [x] remove `kurtosis`
- [ ] add mise `lockfile` - in a follow-up PR.