### PR TITLE
op-supernode: Fix/20191 pre interop safe stall

### DIFF
--- a/op-acceptance-tests/tests/interop/upgrade/pre_test.go
+++ b/op-acceptance-tests/tests/interop/upgrade/pre_test.go
@@ -68,20 +68,17 @@ func TestPreNoInbox(gt *testing.T) {
 
 	// Phase 2: Verify the derivation pipeline works pre-interop by checking
 	// that both chains advance their local-safe heads (batcher submits to L1,
-	// supernode derives from it).
-	//
-	// TODO(#20191): also assert CrossSafe and Finalized advance pre-interop.
-	// Currently the supernode stalls both heads at block 0 until interop
-	// activates, which would cause a chain-visible stall for any network
-	// with interop scheduled in the future. Once fixed, enable:
-	//
-	//   sys.L2ACL.AdvancedFn(types.CrossSafe, 5, 100),
-	//   sys.L2BCL.AdvancedFn(types.CrossSafe, 5, 100),
-	//   sys.L2ACL.AdvancedFn(types.Finalized, 1, 100),
-	//   sys.L2BCL.AdvancedFn(types.Finalized, 1, 100),
+	// supernode derives from it), and that CrossSafe and Finalized heads also
+	// advance. Pre-activation, the supernode must not gate these heads on the
+	// interop verifier and must instead fall through to local-safe /
+	// local-finalized. See issue #20191.
 	dsl.CheckAll(t,
 		sys.L2ACL.AdvancedFn(types.LocalSafe, 5, 100),
 		sys.L2BCL.AdvancedFn(types.LocalSafe, 5, 100),
+		sys.L2ACL.AdvancedFn(types.CrossSafe, 5, 100),
+		sys.L2BCL.AdvancedFn(types.CrossSafe, 5, 100),
+		sys.L2ACL.AdvancedFn(types.Finalized, 1, 100),
+		sys.L2BCL.AdvancedFn(types.Finalized, 1, 100),
 	)
 
 	// Phase 3: Try interop before the upgrade, confirm that messages do not get included

--- a/op-supernode/supernode/activity/activity.go
+++ b/op-supernode/supernode/activity/activity.go
@@ -45,6 +45,13 @@ type VerificationActivity interface {
 	// VerifiedAtTimestamp returns true if the activity has verified the data at the given timestamp.
 	VerifiedAtTimestamp(ts uint64) (bool, error)
 
+	// IsActiveAt reports whether this verification activity is responsible for
+	// verifying L2 content at the given timestamp. Activities that are scheduled
+	// (e.g. an interop activation in the future) return false for timestamps
+	// strictly before their activation point, signaling that callers may treat
+	// data at or before that timestamp as safe without consulting this activity.
+	IsActiveAt(ts uint64) bool
+
 	// LatestVerifiedL2Block returns the latest L2 block which has been verified,
 	// along with the timestamp at which it was verified.
 	LatestVerifiedL2Block(chainID eth.ChainID) (eth.BlockID, uint64)

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -787,6 +787,13 @@ func (i *Interop) VerifiedAtTimestamp(ts uint64) (bool, error) {
 	return i.verifiedDB.Has(ts)
 }
 
+// IsActiveAt reports whether the interop verifier is responsible for verifying
+// L2 content at the given timestamp. Returns false for timestamps strictly
+// before the configured activation timestamp.
+func (i *Interop) IsActiveAt(ts uint64) bool {
+	return ts >= i.activationTimestamp
+}
+
 // LatestVerifiedL2Block returns the latest L2 block which has been verified,
 // along with the timestamp at which it was verified.
 func (i *Interop) LatestVerifiedL2Block(chainID eth.ChainID) (eth.BlockID, uint64) {

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -801,6 +801,39 @@ func TestVerifiedAtTimestamp(t *testing.T) {
 }
 
 // =============================================================================
+// TestIsActiveAt
+// =============================================================================
+
+// TestIsActiveAt verifies that Interop.IsActiveAt reports the verifier as
+// inactive for timestamps strictly before the configured activation timestamp
+// and active at or after it. This is the per-verifier hook super_authority
+// consults to decide whether pre-interop L2 content can bypass the verifier
+// and fall back to local-safe / local-finalized.
+func TestIsActiveAt(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		activation uint64
+		ts         uint64
+		want       bool
+	}{
+		{"before activation returns false", 1000, 999, false},
+		{"well before activation returns false", 1000, 0, false},
+		{"at activation returns true", 1000, 1000, true},
+		{"after activation returns true", 1000, 9999, true},
+		{"activation zero always active", 0, 0, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newInteropTestHarness(t).WithActivation(tc.activation).Build()
+			require.Equal(t, tc.want, h.interop.IsActiveAt(tc.ts))
+		})
+	}
+}
+
+// =============================================================================
 // TestApplyResultCompat
 // =============================================================================
 

--- a/op-supernode/supernode/chain_container/chain_container_test.go
+++ b/op-supernode/supernode/chain_container/chain_container_test.go
@@ -45,6 +45,12 @@ type mockVirtualNode struct {
 	safeHeadL1  eth.BlockID
 	safeHeadL2  eth.BlockID
 	safeHeadErr error
+
+	// syncStatusOverride lets tests return a fully-formed eth.SyncStatus
+	// (e.g. populated LocalSafeL2.Time / LocalFinalizedL2 / FinalizedL1)
+	// instead of the synthesised default built from safeHeadL1/safeHeadL2.
+	// When nil, the default synthesis below is used.
+	syncStatusOverride func() (*eth.SyncStatus, error)
 }
 
 func newMockVirtualNode() *mockVirtualNode {
@@ -109,6 +115,9 @@ func (m *mockVirtualNode) LastL1(ctx context.Context) (eth.BlockID, error) {
 
 // SyncStatus implements virtual_node.VirtualNode SyncStatus
 func (m *mockVirtualNode) SyncStatus(ctx context.Context) (*eth.SyncStatus, error) {
+	if m.syncStatusOverride != nil {
+		return m.syncStatusOverride()
+	}
 	if m.safeHeadErr != nil {
 		return nil, m.safeHeadErr
 	}
@@ -181,6 +190,7 @@ func (m *mockVerificationActivity) Reset(chainID eth.ChainID, timestamp uint64, 
 func (m *mockVerificationActivity) VerifiedBlockAtL1(chainID eth.ChainID, l1BlockRef eth.L1BlockRef) (eth.BlockID, uint64) {
 	return eth.BlockID{}, 0
 }
+func (m *mockVerificationActivity) IsActiveAt(ts uint64) bool { return true }
 
 // Test helpers
 func createTestVNConfig() *opnodecfg.Config {

--- a/op-supernode/supernode/chain_container/super_authority.go
+++ b/op-supernode/supernode/chain_container/super_authority.go
@@ -13,13 +13,25 @@ import (
 
 // FullyVerifiedL2Head returns the fully verified L2 head block identifier.
 // The second return value indicates whether the caller should fall back to local-safe.
-// Returns (empty, true) only when no verifiers are registered.
-// Returns (empty, false) when verifiers are registered but haven't verified anything yet.
+// Returns (empty, true) when no verifiers are registered, or when every
+// registered verifier reports it is not yet active at the current local-safe
+// L2 timestamp (i.e. interop is scheduled but not yet activated).
+// Returns (empty, false) when verifiers are registered, at least one is active,
+// but none has verified anything yet.
 // Panics if verifiers disagree on the block hash for the same timestamp.
 func (c *simpleChainContainer) FullyVerifiedL2Head() (eth.BlockID, bool) {
 	// If no verifiers registered, signal fallback to local-safe
 	if len(c.verifiers) == 0 {
 		c.log.Debug("FullyVerifiedL2Head: no verifiers registered, signaling local-safe fallback")
+		return eth.BlockID{}, true
+	}
+
+	// If every registered verifier is still pre-activation at the current
+	// local-safe timestamp, fall back to local-safe. Pre-activation L2 content
+	// is verified by consensus alone; gating it on an interop verifier that
+	// has not started yet would stall the head at genesis (see #20191).
+	if activeTS, ok := c.localSafeTimestamp(); ok && c.allVerifiersPreActivationAt(activeTS) {
+		c.log.Debug("FullyVerifiedL2Head: all verifiers pre-activation, signaling local-safe fallback", "localSafeTime", activeTS)
 		return eth.BlockID{}, true
 	}
 
@@ -47,8 +59,12 @@ func (c *simpleChainContainer) FullyVerifiedL2Head() (eth.BlockID, bool) {
 
 // FinalizedL2Head returns the finalized L2 head block identifier.
 // The second return value indicates whether the caller should fall back to local-finalized.
-// Returns (empty, true) only when no verifiers are registered.
-// Returns (empty, false) when verifiers are registered but haven't finalized anything yet.
+// Returns (empty, true) when no verifiers are registered, or when every
+// registered verifier reports it is not yet active at the current local-safe
+// L2 timestamp (i.e. interop is scheduled but not yet activated; FinalizedL2
+// <= LocalSafeL2, so if local-safe is pre-activation, so is finalized).
+// Returns (empty, false) when verifiers are registered, at least one is active,
+// but none has finalized anything yet.
 // Panics if verifiers disagree on the block hash for the same timestamp.
 func (c *simpleChainContainer) FinalizedL2Head() (eth.BlockID, bool) {
 	// If no verifiers registered, signal fallback to local-finalized
@@ -62,6 +78,15 @@ func (c *simpleChainContainer) FinalizedL2Head() (eth.BlockID, bool) {
 		c.log.Error("FinalizedL2Head: failed to get sync status", "err", err)
 		return eth.BlockID{}, true
 	}
+
+	// If every registered verifier is still pre-activation at the current
+	// local-safe timestamp, fall back to local-finalized. See #20191 and the
+	// matching guard in FullyVerifiedL2Head.
+	if c.allVerifiersPreActivationAt(ss.LocalSafeL2.Time) {
+		c.log.Debug("FinalizedL2Head: all verifiers pre-activation, signaling local-finalized fallback", "localSafeTime", ss.LocalSafeL2.Time)
+		return eth.BlockID{}, true
+	}
+
 	timestamp := uint64(math.MaxUint64)
 	oldestFinalizedBlock := eth.BlockID{}
 	for _, v := range c.verifiers {
@@ -82,6 +107,33 @@ func (c *simpleChainContainer) FinalizedL2Head() (eth.BlockID, bool) {
 
 	c.log.Debug("FinalizedL2Head: returning finalized block", "block", oldestFinalizedBlock, "timestamp", timestamp)
 	return oldestFinalizedBlock, false
+}
+
+// localSafeTimestamp returns the timestamp of the current local-safe L2 head.
+// The bool is false if SyncStatus is unavailable, in which case callers should
+// not attempt the pre-activation short-circuit.
+func (c *simpleChainContainer) localSafeTimestamp() (uint64, bool) {
+	ss, err := c.SyncStatus(context.Background())
+	if err != nil {
+		c.log.Warn("localSafeTimestamp: failed to get sync status", "err", err)
+		return 0, false
+	}
+	return ss.LocalSafeL2.Time, true
+}
+
+// allVerifiersPreActivationAt reports whether every registered verifier is
+// still inactive at the given L2 timestamp. Returns false if there are no
+// verifiers; callers are expected to handle that case separately.
+func (c *simpleChainContainer) allVerifiersPreActivationAt(ts uint64) bool {
+	if len(c.verifiers) == 0 {
+		return false
+	}
+	for _, v := range c.verifiers {
+		if v.IsActiveAt(ts) {
+			return false
+		}
+	}
+	return true
 }
 
 // IsDenied checks if a block hash is on the deny list at the given height.

--- a/op-supernode/supernode/chain_container/super_authority_test.go
+++ b/op-supernode/supernode/chain_container/super_authority_test.go
@@ -17,6 +17,10 @@ type mockVerificationActivityForSuperAuthority struct {
 	latestVerifiedTS     uint64
 	latestFinalizedBlock eth.BlockID
 	latestFinalizedTS    uint64
+	// isActiveAtFn drives IsActiveAt for pre-activation fallback tests.
+	// When nil, IsActiveAt returns true (active for all timestamps), matching
+	// the default "always-active" semantics the existing tests assume.
+	isActiveAtFn func(ts uint64) bool
 }
 
 func (m *mockVerificationActivityForSuperAuthority) Start(ctx context.Context) error { return nil }
@@ -34,6 +38,12 @@ func (m *mockVerificationActivityForSuperAuthority) LatestVerifiedL2Block(chainI
 func (m *mockVerificationActivityForSuperAuthority) Reset(eth.ChainID, uint64, eth.BlockRef) {}
 func (m *mockVerificationActivityForSuperAuthority) VerifiedBlockAtL1(chainID eth.ChainID, l1BlockRef eth.L1BlockRef) (eth.BlockID, uint64) {
 	return m.latestFinalizedBlock, m.latestFinalizedTS
+}
+func (m *mockVerificationActivityForSuperAuthority) IsActiveAt(ts uint64) bool {
+	if m.isActiveAtFn != nil {
+		return m.isActiveAtFn(ts)
+	}
+	return true
 }
 
 var _ activity.VerificationActivity = (*mockVerificationActivityForSuperAuthority)(nil)
@@ -308,4 +318,231 @@ func TestChainContainer_FinalizedL2Head_AllUnfinalized(t *testing.T) {
 	result, useLocalFinalized := cc.FinalizedL2Head()
 	require.Equal(t, eth.BlockID{}, result, "should return empty BlockID when all verifiers are unfinalized")
 	require.False(t, useLocalFinalized, "should not signal fallback when verifiers exist but are unfinalized")
+}
+
+// =============================================================================
+// Pre-activation fallback tests (issue #20191)
+// =============================================================================
+//
+// These tests pin the contract that when every registered verifier reports
+// IsActiveAt(ss.LocalSafeL2.Time) == false (i.e. the supernode has interop
+// scheduled but the L1-derived local-safe head has not yet crossed the
+// activation timestamp), super_authority falls back to local-safe /
+// local-finalized rather than stalling the engine at genesis.
+//
+// Note: super_authority consults IsActiveAt(ss.LocalSafeL2.Time) for both the
+// safe and finalized head queries, since FinalizedL2 <= LocalSafeL2 always:
+// if local-safe is still pre-activation, finalized is too.
+
+// setSyncStatus configures the chain's mock virtual node to return the given
+// SyncStatus. The test-only mockVirtualNode always backs newTestChainContainer.
+func setSyncStatus(t *testing.T, cc *simpleChainContainer, ss *eth.SyncStatus) {
+	t.Helper()
+	mvn, ok := cc.vn.(*mockVirtualNode)
+	require.True(t, ok, "newTestChainContainer must install a *mockVirtualNode")
+	mvn.syncStatusOverride = func() (*eth.SyncStatus, error) { return ss, nil }
+}
+
+// preActivationFn returns an isActiveAtFn that reports inactive for all
+// timestamps strictly below activationTS.
+func preActivationFn(activationTS uint64) func(ts uint64) bool {
+	return func(ts uint64) bool { return ts >= activationTS }
+}
+
+// TestChainContainer_FullyVerifiedL2Head_PreActivation_FallsBackToLocalSafe
+// (case B1a) verifies that a single verifier reporting pre-activation for the
+// current LocalSafeL2 timestamp causes a fallback to local-safe.
+func TestChainContainer_FullyVerifiedL2Head_PreActivation_FallsBackToLocalSafe(t *testing.T) {
+	t.Parallel()
+
+	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
+	setSyncStatus(t, cc, &eth.SyncStatus{
+		LocalSafeL2: eth.L2BlockRef{Number: 50, Hash: [32]byte{0xaa}, Time: 999},
+	})
+
+	verifier := &mockVerificationActivityForSuperAuthority{
+		isActiveAtFn: preActivationFn(1000),
+	}
+	cc.verifiers = []activity.VerificationActivity{verifier}
+
+	result, useLocalSafe := cc.FullyVerifiedL2Head()
+	require.Equal(t, eth.BlockID{}, result, "pre-activation should return empty BlockID")
+	require.True(t, useLocalSafe, "pre-activation should signal fallback to local-safe")
+}
+
+// TestChainContainer_FullyVerifiedL2Head_PostActivation_EmptyVerifierNoFallback
+// (case B1b) verifies that once activation has been reached, the existing
+// "verifier present but nothing verified yet" behavior is preserved: no
+// fallback even though the verifier returns empty.
+func TestChainContainer_FullyVerifiedL2Head_PostActivation_EmptyVerifierNoFallback(t *testing.T) {
+	t.Parallel()
+
+	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
+	setSyncStatus(t, cc, &eth.SyncStatus{
+		LocalSafeL2: eth.L2BlockRef{Number: 600, Hash: [32]byte{0xbb}, Time: 1500},
+	})
+
+	verifier := &mockVerificationActivityForSuperAuthority{
+		isActiveAtFn: preActivationFn(1000),
+	}
+	cc.verifiers = []activity.VerificationActivity{verifier}
+
+	result, useLocalSafe := cc.FullyVerifiedL2Head()
+	require.Equal(t, eth.BlockID{}, result, "post-activation empty verifier returns empty")
+	require.False(t, useLocalSafe, "post-activation empty verifier must not signal fallback")
+}
+
+// TestChainContainer_FullyVerifiedL2Head_PostActivation_VerifiedBlockReturned
+// (case B1c) verifies that the existing "happy path" of returning the
+// verifier's LatestVerifiedL2Block is preserved after activation.
+func TestChainContainer_FullyVerifiedL2Head_PostActivation_VerifiedBlockReturned(t *testing.T) {
+	t.Parallel()
+
+	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
+	setSyncStatus(t, cc, &eth.SyncStatus{
+		LocalSafeL2: eth.L2BlockRef{Number: 600, Hash: [32]byte{0xbb}, Time: 1500},
+	})
+
+	verifiedBlock := eth.BlockID{Hash: [32]byte{0x11}, Number: 100}
+	verifier := &mockVerificationActivityForSuperAuthority{
+		latestVerifiedBlock: verifiedBlock,
+		latestVerifiedTS:    1500,
+		isActiveAtFn:        preActivationFn(1000),
+	}
+	cc.verifiers = []activity.VerificationActivity{verifier}
+
+	result, useLocalSafe := cc.FullyVerifiedL2Head()
+	require.Equal(t, verifiedBlock, result, "post-activation should return verified block")
+	require.False(t, useLocalSafe, "post-activation with a verified block must not signal fallback")
+}
+
+// TestChainContainer_FullyVerifiedL2Head_AllPreActivation_FallsBackToLocalSafe
+// (case B1d) verifies the multi-verifier case: when every verifier reports
+// pre-activation, fall back to local-safe.
+func TestChainContainer_FullyVerifiedL2Head_AllPreActivation_FallsBackToLocalSafe(t *testing.T) {
+	t.Parallel()
+
+	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
+	setSyncStatus(t, cc, &eth.SyncStatus{
+		LocalSafeL2: eth.L2BlockRef{Number: 50, Hash: [32]byte{0xaa}, Time: 999},
+	})
+
+	verifier1 := &mockVerificationActivityForSuperAuthority{isActiveAtFn: preActivationFn(1000)}
+	verifier2 := &mockVerificationActivityForSuperAuthority{isActiveAtFn: preActivationFn(2000)}
+	cc.verifiers = []activity.VerificationActivity{verifier1, verifier2}
+
+	result, useLocalSafe := cc.FullyVerifiedL2Head()
+	require.Equal(t, eth.BlockID{}, result, "all-pre-activation should return empty BlockID")
+	require.True(t, useLocalSafe, "all-pre-activation should signal fallback to local-safe")
+}
+
+// TestChainContainer_FullyVerifiedL2Head_MixedActiveAndPreActivation_NoFallback
+// (case B1e) verifies that a partial pre-activation state does NOT force
+// fallback: if at least one verifier is active but unverified, the existing
+// conservative behavior (empty, false) holds.
+func TestChainContainer_FullyVerifiedL2Head_MixedActiveAndPreActivation_NoFallback(t *testing.T) {
+	t.Parallel()
+
+	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
+	setSyncStatus(t, cc, &eth.SyncStatus{
+		LocalSafeL2: eth.L2BlockRef{Number: 600, Hash: [32]byte{0xbb}, Time: 1500},
+	})
+
+	active := &mockVerificationActivityForSuperAuthority{
+		isActiveAtFn: preActivationFn(1000), // active at 1500
+	}
+	preAct := &mockVerificationActivityForSuperAuthority{
+		isActiveAtFn: preActivationFn(2000), // still pre-activation at 1500
+	}
+	cc.verifiers = []activity.VerificationActivity{active, preAct}
+
+	result, useLocalSafe := cc.FullyVerifiedL2Head()
+	require.Equal(t, eth.BlockID{}, result, "mixed case should return empty BlockID")
+	require.False(t, useLocalSafe, "mixed case must not signal fallback; at least one verifier is active and unverified")
+}
+
+// TestChainContainer_FinalizedL2Head_PreActivation_FallsBackToLocalFinalized
+// (case B2a) mirrors B1a for the finalized head.
+func TestChainContainer_FinalizedL2Head_PreActivation_FallsBackToLocalFinalized(t *testing.T) {
+	t.Parallel()
+
+	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
+	setSyncStatus(t, cc, &eth.SyncStatus{
+		FinalizedL1: eth.L1BlockRef{Number: 40},
+		LocalSafeL2: eth.L2BlockRef{Number: 50, Hash: [32]byte{0xcc}, Time: 999},
+	})
+
+	verifier := &mockVerificationActivityForSuperAuthority{
+		isActiveAtFn: preActivationFn(1000),
+	}
+	cc.verifiers = []activity.VerificationActivity{verifier}
+
+	result, useLocalFinalized := cc.FinalizedL2Head()
+	require.Equal(t, eth.BlockID{}, result, "pre-activation should return empty BlockID")
+	require.True(t, useLocalFinalized, "pre-activation should signal fallback to local-finalized")
+}
+
+// TestChainContainer_FinalizedL2Head_PostActivation_EmptyVerifierNoFallback
+// (case B2b) — post-activation, verifier empty → empty, no fallback (unchanged).
+func TestChainContainer_FinalizedL2Head_PostActivation_EmptyVerifierNoFallback(t *testing.T) {
+	t.Parallel()
+
+	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
+	setSyncStatus(t, cc, &eth.SyncStatus{
+		FinalizedL1: eth.L1BlockRef{Number: 400},
+		LocalSafeL2: eth.L2BlockRef{Number: 600, Hash: [32]byte{0xdd}, Time: 1500},
+	})
+
+	verifier := &mockVerificationActivityForSuperAuthority{
+		isActiveAtFn: preActivationFn(1000),
+	}
+	cc.verifiers = []activity.VerificationActivity{verifier}
+
+	result, useLocalFinalized := cc.FinalizedL2Head()
+	require.Equal(t, eth.BlockID{}, result)
+	require.False(t, useLocalFinalized, "post-activation empty verifier must not signal fallback")
+}
+
+// TestChainContainer_FinalizedL2Head_PostActivation_FinalizedBlockReturned
+// (case B2c) — post-activation, verifier has a finalized block → returned (unchanged).
+func TestChainContainer_FinalizedL2Head_PostActivation_FinalizedBlockReturned(t *testing.T) {
+	t.Parallel()
+
+	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
+	setSyncStatus(t, cc, &eth.SyncStatus{
+		FinalizedL1: eth.L1BlockRef{Number: 400},
+		LocalSafeL2: eth.L2BlockRef{Number: 600, Hash: [32]byte{0xdd}, Time: 1500},
+	})
+
+	finalizedBlock := eth.BlockID{Hash: [32]byte{0x22}, Number: 100}
+	verifier := &mockVerificationActivityForSuperAuthority{
+		latestFinalizedBlock: finalizedBlock,
+		latestFinalizedTS:    1500,
+		isActiveAtFn:         preActivationFn(1000),
+	}
+	cc.verifiers = []activity.VerificationActivity{verifier}
+
+	result, useLocalFinalized := cc.FinalizedL2Head()
+	require.Equal(t, finalizedBlock, result, "post-activation should return finalized block")
+	require.False(t, useLocalFinalized)
+}
+
+// TestChainContainer_FinalizedL2Head_AllPreActivation_FallsBackToLocalFinalized
+// (case B2d) — multi-verifier all-pre-activation fallback.
+func TestChainContainer_FinalizedL2Head_AllPreActivation_FallsBackToLocalFinalized(t *testing.T) {
+	t.Parallel()
+
+	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
+	setSyncStatus(t, cc, &eth.SyncStatus{
+		FinalizedL1: eth.L1BlockRef{Number: 40},
+		LocalSafeL2: eth.L2BlockRef{Number: 50, Hash: [32]byte{0xcc}, Time: 999},
+	})
+
+	verifier1 := &mockVerificationActivityForSuperAuthority{isActiveAtFn: preActivationFn(1000)}
+	verifier2 := &mockVerificationActivityForSuperAuthority{isActiveAtFn: preActivationFn(2000)}
+	cc.verifiers = []activity.VerificationActivity{verifier1, verifier2}
+
+	result, useLocalFinalized := cc.FinalizedL2Head()
+	require.Equal(t, eth.BlockID{}, result)
+	require.True(t, useLocalFinalized, "all-pre-activation should signal fallback to local-finalized")
 }


### PR DESCRIPTION
Marking this as full review so it gets full CI. Work is in progress.


## Description

Fixes [#20191](https://github.com/ethereum-optimism/optimism/issues/20191).

When a supernode chain is configured with `InteropActivationTimestamp` scheduled in the future, `op-supernode` currently reports `SafeL2 = 0` and `FinalizedL2 = 0` via `optimism_syncStatus` (and the aggregated `supernode_syncStatus`) until activation. Both heads are pinned at genesis; `LocalSafeL2` advances correctly. Any network with interop scheduled but not yet live sees this as a chain-visible stall.

This PR:

1. Extends `activity.VerificationActivity` with a new method `IsActiveAt(ts uint64) bool`, implemented on `Interop` as `ts >= i.activationTimestamp`.
2. Teaches `chain_container/super_authority.go` to consult `IsActiveAt(ss.LocalSafeL2.Time)` before querying the verifier: when every registered verifier reports inactive at the current local-safe timestamp, `FullyVerifiedL2Head` and `FinalizedL2Head` return `(empty, useLocalSafe=true)` / `(empty, useLocalFinalized=true)`, so `op-node`'s `EngineController` falls back to local-safe / local-finalized rather than resolving to genesis.

Using `ss.LocalSafeL2.Time` for both heads is sound because `FinalizedL2 <= LocalSafeL2`: if local-safe is still pre-activation, finalized is too. `eth.SyncStatus` has no `LocalFinalizedL2` field, and `FinalizedL2` is circular post-interop (it is itself derived from super_authority), so `LocalSafeL2.Time` is the only non-circular activation-line check available.

## Root cause

`op-supernode` registers the `Interop` activity as a `VerificationActivity` on every chain container whenever `InteropActivationTimestamp != nil`. Pre-activation:

- `Interop.VerifiedAtTimestamp(ts)` already returns `true` for `ts < activationTimestamp` — it is aware of its own pre-activation state.
- `Interop.LatestVerifiedL2Block(chainID)` and `Interop.VerifiedBlockAtL1(chainID, l1)` both return `(BlockID{}, 0)` because `verifiedDB` is empty (the `observeRound` `DecisionWait` path does not commit).

`super_authority.go` treats `(empty, 0)` from a registered verifier as _"verifier is present but hasn't verified anything yet"_ and returns `(empty, false)`. `EngineController.SafeL2Head` / `FinalizedHead` then resolve `(empty, false)` to block 0. That is correct behaviour for _post_-activation genesis, but wrong pre-activation: pre-activation L2 content is verified by consensus alone and must be passed through as local-safe.

The asymmetry between `VerifiedAtTimestamp`'s pre-activation awareness and the other two methods is the root of the bug. This PR fixes it at the `super_authority` layer (via `IsActiveAt`) rather than at `Interop`, so the contract — _"when pre-activation, fall through to local"_ — is pinned at the seam where the fallback decision is actually made.

## Spec

When a chain is configured with an `InteropActivationTimestamp` scheduled in the future:

1. `SafeL2` MUST track `LocalSafeL2` while `LocalSafeL2.Time < InteropActivationTimestamp`.
2. `FinalizedL2` MUST track L1 finalization (equivalent to a non-interop chain) while `LocalSafeL2.Time < InteropActivationTimestamp`.
3. Once `LocalSafeL2.Time >= InteropActivationTimestamp`, existing behaviour resumes: `SafeL2` is gated by `LatestVerifiedL2Block`, `FinalizedL2` by `VerifiedBlockAtL1`.

## Changes

- `op-supernode/supernode/activity/activity.go` — add `IsActiveAt(ts uint64) bool` to `VerificationActivity`.
- `op-supernode/supernode/activity/interop/interop.go` — implement `IsActiveAt` on `Interop`.
- `op-supernode/supernode/chain_container/super_authority.go` — add `localSafeTimestamp()` + `allVerifiersPreActivationAt(ts)` helpers, consult them at the top of `FullyVerifiedL2Head` and `FinalizedL2Head`.
- Test-only mock updates to satisfy the interface (`mockVerificationActivity`, `mockVerificationActivityForSuperAuthority`), and a `syncStatusOverride` hook on `mockVirtualNode` so new tests can drive `LocalSafeL2.Time`.
- `op-acceptance-tests/tests/interop/upgrade/pre_test.go` — un-comments the pre-existing `TODO(#20191)` assertions in `TestPreNoInbox` so CI asserts the contract end-to-end.

## Test plan

The PR is structured as three commits — two RED test commits that encode the bug, followed by the fix that flips them to GREEN. Every new test and every existing test passes at `HEAD`.

### Unit tests

New `TestIsActiveAt` in `op-supernode/supernode/activity/interop/interop_test.go` (green at every commit):

| # | Case | Activation | ts | Expected |
|---|---|---|---|---|
| A1 | before activation returns false | 1000 | 999 | `false` |
| A2 | well before activation returns false | 1000 | 0 | `false` |
| A3 | at activation returns true | 1000 | 1000 | `true` |
| A4 | after activation returns true | 1000 | 9999 | `true` |
| A5 | activation zero always active | 0 | 0 | `true` |

New tests in `op-supernode/supernode/chain_container/super_authority_test.go`:

| # | Test | Pre-fix | Post-fix |
|---|---|---|---|
| B1a | `FullyVerifiedL2Head_PreActivation_FallsBackToLocalSafe` | FAIL | PASS |
| B1b | `FullyVerifiedL2Head_PostActivation_EmptyVerifierNoFallback` | PASS | PASS |
| B1c | `FullyVerifiedL2Head_PostActivation_VerifiedBlockReturned` | PASS | PASS |
| B1d | `FullyVerifiedL2Head_AllPreActivation_FallsBackToLocalSafe` | FAIL | PASS |
| B1e | `FullyVerifiedL2Head_MixedActiveAndPreActivation_NoFallback` | PASS | PASS |
| B2a | `FinalizedL2Head_PreActivation_FallsBackToLocalFinalized` | FAIL | PASS |
| B2b | `FinalizedL2Head_PostActivation_EmptyVerifierNoFallback` | PASS | PASS |
| B2c | `FinalizedL2Head_PostActivation_FinalizedBlockReturned` | PASS | PASS |
| B2d | `FinalizedL2Head_AllPreActivation_FallsBackToLocalFinalized` | FAIL | PASS |

- The four FAIL→PASS cases encode the bug; each asserts that the fallback boolean is `true` (i.e. the engine controller should read local-safe / local-finalized).
- The five PASS→PASS cases pin that existing behaviour is preserved:
  - B1c / B2c — verified block returned unchanged.
  - B1b / B2b — post-activation empty verifier still returns `(empty, false)` (no fallback; nothing verified yet).
  - B1e — mixed-state (at least one verifier active and unverified) does **not** force fallback; conservative "no fallback unless every verifier agrees it's unneeded" rule preserved.

Full `op-supernode/...` tree passes after the fix:
