### PR TITLE
op-supernode: fix - close interop activation gap in verified-head

### DIFF
--- a/op-acceptance-tests/tests/interop/upgrade/activation_gap_test.go
+++ b/op-acceptance-tests/tests/interop/upgrade/activation_gap_test.go
@@ -1,0 +1,85 @@
+//go:build !ci
+
+package upgrade
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-core/forks"
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	stypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+)
+
+// TestActivationGap asserts that SafeL2 (CrossSafe via optimism_syncStatus)
+// and FinalizedL2 never regress across the interop activation boundary on
+// either chain. Boots with activation 60s out, snapshots both heads
+// pre-activation, awaits activation, then polls optimism_syncStatus at 1Hz
+// for 60s asserting neither head drops below its snapshot on either chain.
+func TestActivationGap(gt *testing.T) {
+	t := devtest.ParallelT(gt)
+	sys := presets.NewTwoL2SupernodeInterop(t, 60)
+	require := t.Require()
+
+	interopTimeA := sys.L2A.Escape().ChainConfig().InteropTime
+	interopTimeB := sys.L2B.Escape().ChainConfig().InteropTime
+	require.NotNil(interopTimeA, "interop activation must be configured on chain A")
+	require.NotNil(interopTimeB, "interop activation must be configured on chain B")
+
+	upgradeTime := time.Unix(int64(*interopTimeA), 0)
+	if deadline, hasDeadline := t.Deadline(); hasDeadline {
+		t.Gate().True(upgradeTime.Add(90*time.Second).Before(deadline),
+			"test must have headroom past activation")
+	}
+
+	dsl.CheckAll(t,
+		sys.L2ACL.AdvancedFn(stypes.CrossSafe, 3, 60),
+		sys.L2BCL.AdvancedFn(stypes.CrossSafe, 3, 60),
+	)
+
+	preA := sys.L2ACL.SyncStatus()
+	preB := sys.L2BCL.SyncStatus()
+	require.Greater(preA.SafeL2.Number, uint64(0),
+		"chain A CrossSafe must be advancing pre-activation")
+	require.Greater(preB.SafeL2.Number, uint64(0),
+		"chain B CrossSafe must be advancing pre-activation")
+
+	t.Logger().Info("pre-activation snapshot",
+		"A.CrossSafe", preA.SafeL2.Number, "A.Finalized", preA.FinalizedL2.Number,
+		"B.CrossSafe", preB.SafeL2.Number, "B.Finalized", preB.FinalizedL2.Number)
+
+	activationA := sys.L2A.AwaitActivation(t, forks.Interop)
+	activationB := sys.L2B.AwaitActivation(t, forks.Interop)
+	t.Logger().Info("activation reached", "A", activationA, "B", activationB)
+
+	pollDeadline := time.Now().Add(60 * time.Second)
+	samples := 0
+	for time.Now().Before(pollDeadline) {
+		a := sys.L2ACL.SyncStatus()
+		b := sys.L2BCL.SyncStatus()
+
+		require.GreaterOrEqualf(a.SafeL2.Number, preA.SafeL2.Number,
+			"chain A CrossSafe regressed from %d to %d across activation",
+			preA.SafeL2.Number, a.SafeL2.Number)
+		require.GreaterOrEqualf(b.SafeL2.Number, preB.SafeL2.Number,
+			"chain B CrossSafe regressed from %d to %d across activation",
+			preB.SafeL2.Number, b.SafeL2.Number)
+		require.GreaterOrEqualf(a.FinalizedL2.Number, preA.FinalizedL2.Number,
+			"chain A Finalized regressed from %d to %d across activation",
+			preA.FinalizedL2.Number, a.FinalizedL2.Number)
+		require.GreaterOrEqualf(b.FinalizedL2.Number, preB.FinalizedL2.Number,
+			"chain B Finalized regressed from %d to %d across activation",
+			preB.FinalizedL2.Number, b.FinalizedL2.Number)
+
+		samples++
+		time.Sleep(1 * time.Second)
+	}
+	t.Logger().Info("monotonicity window completed", "samples", samples)
+
+	dsl.CheckAll(t,
+		sys.L2ACL.AdvancedFn(stypes.CrossSafe, 3, 60),
+		sys.L2BCL.AdvancedFn(stypes.CrossSafe, 3, 60),
+	)
+}

--- a/op-acceptance-tests/tests/interop/upgrade/pre_test.go
+++ b/op-acceptance-tests/tests/interop/upgrade/pre_test.go
@@ -68,20 +68,17 @@ func TestPreNoInbox(gt *testing.T) {
 
 	// Phase 2: Verify the derivation pipeline works pre-interop by checking
 	// that both chains advance their local-safe heads (batcher submits to L1,
-	// supernode derives from it).
-	//
-	// TODO(#20191): also assert CrossSafe and Finalized advance pre-interop.
-	// Currently the supernode stalls both heads at block 0 until interop
-	// activates, which would cause a chain-visible stall for any network
-	// with interop scheduled in the future. Once fixed, enable:
-	//
-	//   sys.L2ACL.AdvancedFn(types.CrossSafe, 5, 100),
-	//   sys.L2BCL.AdvancedFn(types.CrossSafe, 5, 100),
-	//   sys.L2ACL.AdvancedFn(types.Finalized, 1, 100),
-	//   sys.L2BCL.AdvancedFn(types.Finalized, 1, 100),
+	// supernode derives from it), and that CrossSafe and Finalized heads also
+	// advance. Pre-activation, the supernode must not gate these heads on the
+	// interop verifier and must instead fall through to local-safe /
+	// local-finalized. See issue #20191.
 	dsl.CheckAll(t,
 		sys.L2ACL.AdvancedFn(types.LocalSafe, 5, 100),
 		sys.L2BCL.AdvancedFn(types.LocalSafe, 5, 100),
+		sys.L2ACL.AdvancedFn(types.CrossSafe, 5, 100),
+		sys.L2BCL.AdvancedFn(types.CrossSafe, 5, 100),
+		sys.L2ACL.AdvancedFn(types.Finalized, 1, 100),
+		sys.L2BCL.AdvancedFn(types.Finalized, 1, 100),
 	)
 
 	// Phase 3: Try interop before the upgrade, confirm that messages do not get included

--- a/op-supernode/supernode/activity/activity.go
+++ b/op-supernode/supernode/activity/activity.go
@@ -45,6 +45,13 @@ type VerificationActivity interface {
 	// VerifiedAtTimestamp returns true if the activity has verified the data at the given timestamp.
 	VerifiedAtTimestamp(ts uint64) (bool, error)
 
+	// IsActiveAt reports whether this verification activity is responsible for
+	// verifying L2 content at the given timestamp. Activities that are scheduled
+	// (e.g. an interop activation in the future) return false for timestamps
+	// strictly before their activation point, signaling that callers may treat
+	// data at or before that timestamp as safe without consulting this activity.
+	IsActiveAt(ts uint64) bool
+
 	// LatestVerifiedL2Block returns the latest L2 block which has been verified,
 	// along with the timestamp at which it was verified.
 	LatestVerifiedL2Block(chainID eth.ChainID) (eth.BlockID, uint64)

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -787,6 +787,13 @@ func (i *Interop) VerifiedAtTimestamp(ts uint64) (bool, error) {
 	return i.verifiedDB.Has(ts)
 }
 
+// IsActiveAt reports whether the interop verifier is responsible for verifying
+// L2 content at the given timestamp. Returns false for timestamps strictly
+// before the configured activation timestamp.
+func (i *Interop) IsActiveAt(ts uint64) bool {
+	return ts >= i.activationTimestamp
+}
+
 // LatestVerifiedL2Block returns the latest L2 block which has been verified,
 // along with the timestamp at which it was verified.
 func (i *Interop) LatestVerifiedL2Block(chainID eth.ChainID) (eth.BlockID, uint64) {

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -794,13 +794,45 @@ func (i *Interop) IsActiveAt(ts uint64) bool {
 	return ts >= i.activationTimestamp
 }
 
+// preActivationBoundaryBlock returns the L2 block at activationTimestamp-1
+// for the given chain, along with the L1 block at which it became locally
+// safe. Pre-activation L2 content is verified by consensus, so this block
+// is treated as the implicit "verified" floor when verifiedDB has no entries.
+//
+// Returns ok=false when activation is zero, the chain is unknown, or the
+// engine has not yet reached the boundary timestamp.
+func (i *Interop) preActivationBoundaryBlock(chainID eth.ChainID) (l2 eth.BlockID, boundaryL1 eth.BlockID, boundaryTS uint64, ok bool) {
+	if i.activationTimestamp == 0 {
+		return eth.BlockID{}, eth.BlockID{}, 0, false
+	}
+	chain, known := i.chains[chainID]
+	if !known {
+		return eth.BlockID{}, eth.BlockID{}, 0, false
+	}
+	boundaryTS = i.activationTimestamp - 1
+	// context.Background(): these methods may be invoked from op-node's
+	// EngineController before Interop.Start has populated i.ctx.
+	l2, boundaryL1, err := chain.OptimisticAt(context.Background(), boundaryTS)
+	if err != nil {
+		return eth.BlockID{}, eth.BlockID{}, 0, false
+	}
+	return l2, boundaryL1, boundaryTS, true
+}
+
 // LatestVerifiedL2Block returns the latest L2 block which has been verified,
 // along with the timestamp at which it was verified.
+//
+// When verifiedDB is empty, falls through to the pre-activation boundary
+// block (verified by consensus).
 func (i *Interop) LatestVerifiedL2Block(chainID eth.ChainID) (eth.BlockID, uint64) {
 	emptyBlock := eth.BlockID{}
 	ts, ok := i.verifiedDB.LastTimestamp()
 	if !ok {
-		return emptyBlock, 0
+		l2, _, boundaryTS, ok := i.preActivationBoundaryBlock(chainID)
+		if !ok {
+			return emptyBlock, 0
+		}
+		return l2, boundaryTS
 	}
 	res, err := i.verifiedDB.Get(ts)
 	if err != nil {
@@ -816,6 +848,10 @@ func (i *Interop) LatestVerifiedL2Block(chainID eth.ChainID) (eth.BlockID, uint6
 // VerifiedBlockAtL1 returns the verified L2 block and timestamp
 // which guarantees that the verified data at that timestamp
 // originates from or before the supplied L1 block.
+//
+// When verifiedDB is empty, falls through to the pre-activation boundary
+// block iff its L1 inclusion is at or below l1Block; finalization remains
+// strictly L1-gated.
 func (i *Interop) VerifiedBlockAtL1(chainID eth.ChainID, l1Block eth.L1BlockRef) (eth.BlockID, uint64) {
 	// If L1 block is empty/zero (e.g. during startup before FinalizedL1 is set),
 	// no verified result can match, so return early.
@@ -826,7 +862,14 @@ func (i *Interop) VerifiedBlockAtL1(chainID eth.ChainID, l1Block eth.L1BlockRef)
 	// Get the last verified timestamp
 	lastTs, ok := i.verifiedDB.LastTimestamp()
 	if !ok {
-		return eth.BlockID{}, 0
+		l2, boundaryL1, boundaryTS, ok := i.preActivationBoundaryBlock(chainID)
+		if !ok {
+			return eth.BlockID{}, 0
+		}
+		if boundaryL1.Number > l1Block.Number {
+			return eth.BlockID{}, 0
+		}
+		return l2, boundaryTS
 	}
 
 	// Search backwards from the last timestamp to find the latest result

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -801,6 +801,39 @@ func TestVerifiedAtTimestamp(t *testing.T) {
 }
 
 // =============================================================================
+// TestIsActiveAt
+// =============================================================================
+
+// TestIsActiveAt verifies that Interop.IsActiveAt reports the verifier as
+// inactive for timestamps strictly before the configured activation timestamp
+// and active at or after it. This is the per-verifier hook super_authority
+// consults to decide whether pre-interop L2 content can bypass the verifier
+// and fall back to local-safe / local-finalized.
+func TestIsActiveAt(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		activation uint64
+		ts         uint64
+		want       bool
+	}{
+		{"before activation returns false", 1000, 999, false},
+		{"well before activation returns false", 1000, 0, false},
+		{"at activation returns true", 1000, 1000, true},
+		{"after activation returns true", 1000, 9999, true},
+		{"activation zero always active", 0, 0, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newInteropTestHarness(t).WithActivation(tc.activation).Build()
+			require.Equal(t, tc.want, h.interop.IsActiveAt(tc.ts))
+		})
+	}
+}
+
+// =============================================================================
 // TestApplyResultCompat
 // =============================================================================
 

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -2112,6 +2112,93 @@ func TestResetIsNoOp(t *testing.T) {
 }
 
 // =============================================================================
+// TestLatestVerifiedL2Block
+// =============================================================================
+
+// TestLatestVerifiedL2Block pins the contract that LatestVerifiedL2Block
+// falls through to the pre-activation boundary block when verifiedDB is
+// empty, and preserves verified-entry behaviour otherwise.
+func TestLatestVerifiedL2Block(t *testing.T) {
+	const activationTS = uint64(1000)
+	chainID := eth.ChainIDFromUInt64(10)
+
+	t.Run("empty DB, boundary lookup succeeds, returns boundary block", func(t *testing.T) {
+		boundaryL2 := eth.BlockID{Hash: common.HexToHash("0xBDY"), Number: 499}
+		boundaryL1 := eth.BlockID{Hash: common.HexToHash("0xL1BDY"), Number: 7777}
+		h := newInteropTestHarness(t).
+			WithActivation(activationTS).
+			WithChain(10, func(m *mockChainContainer) {
+				m.optimisticL2 = boundaryL2
+				m.optimisticL1 = boundaryL1
+			}).
+			Build()
+
+		blockID, ts := h.interop.LatestVerifiedL2Block(chainID)
+		require.Equal(t, boundaryL2, blockID, "must return pre-activation boundary block")
+		require.Equal(t, activationTS-1, ts, "timestamp must be activationTS-1")
+	})
+
+	t.Run("empty DB, boundary lookup fails, returns empty", func(t *testing.T) {
+		h := newInteropTestHarness(t).
+			WithActivation(activationTS).
+			WithChain(10, func(m *mockChainContainer) {
+				m.optimisticAtErr = errors.New("not ready")
+			}).
+			Build()
+
+		blockID, ts := h.interop.LatestVerifiedL2Block(chainID)
+		require.Equal(t, eth.BlockID{}, blockID, "lookup failure falls back to empty")
+		require.Equal(t, uint64(0), ts)
+	})
+
+	t.Run("empty DB, activation zero, returns empty", func(t *testing.T) {
+		boundaryL2 := eth.BlockID{Hash: common.HexToHash("0xBDY"), Number: 499}
+		h := newInteropTestHarness(t).
+			WithActivation(0).
+			WithChain(10, func(m *mockChainContainer) {
+				m.optimisticL2 = boundaryL2
+			}).
+			Build()
+
+		blockID, ts := h.interop.LatestVerifiedL2Block(chainID)
+		require.Equal(t, eth.BlockID{}, blockID, "activation=0 has no pre-activation range")
+		require.Equal(t, uint64(0), ts)
+	})
+
+	t.Run("empty DB, unknown chain, returns empty", func(t *testing.T) {
+		h := newInteropTestHarness(t).
+			WithActivation(activationTS).
+			WithChain(10, nil).
+			Build()
+
+		blockID, ts := h.interop.LatestVerifiedL2Block(eth.ChainIDFromUInt64(99))
+		require.Equal(t, eth.BlockID{}, blockID)
+		require.Equal(t, uint64(0), ts)
+	})
+
+	t.Run("non-empty DB, returns verified block (boundary not consulted)", func(t *testing.T) {
+		boundaryL2 := eth.BlockID{Hash: common.HexToHash("0xBDY"), Number: 499}
+		verifiedL2 := eth.BlockID{Hash: common.HexToHash("0xVER"), Number: 1050}
+		h := newInteropTestHarness(t).
+			WithActivation(activationTS).
+			WithChain(10, func(m *mockChainContainer) {
+				m.optimisticL2 = boundaryL2
+			}).
+			Build()
+
+		require.NoError(t, h.interop.verifiedDB.Commit(VerifiedResult{
+			Timestamp:   activationTS + 10,
+			L1Inclusion: eth.BlockID{Number: 20000},
+			L2Heads:     map[eth.ChainID]eth.BlockID{chainID: verifiedL2},
+		}))
+
+		blockID, ts := h.interop.LatestVerifiedL2Block(chainID)
+		require.Equal(t, verifiedL2, blockID, "must prefer actual verifiedDB entry")
+		require.Equal(t, activationTS+10, ts)
+	})
+}
+
+// =============================================================================
 // TestVerifiedBlockAtL1
 // =============================================================================
 
@@ -2167,14 +2254,71 @@ func TestVerifiedBlockAtL1(t *testing.T) {
 		require.Equal(t, uint64(1005), ts)
 	})
 
-	t.Run("empty DB returns empty", func(t *testing.T) {
+	t.Run("empty DB, boundary lookup fails, returns empty", func(t *testing.T) {
 		h := newInteropTestHarness(t).
-			WithChain(10, nil).
+			WithChain(10, func(m *mockChainContainer) {
+				m.optimisticAtErr = errors.New("not ready")
+			}).
 			Build()
 
 		l1Block := eth.L1BlockRef{Hash: common.Hash{0x01}, Number: 1000, Time: 999}
 		blockID, ts := h.interop.VerifiedBlockAtL1(h.Mock(10).id, l1Block)
-		require.Equal(t, eth.BlockID{}, blockID)
+		require.Equal(t, eth.BlockID{}, blockID, "lookup failure falls back to empty")
+		require.Equal(t, uint64(0), ts)
+	})
+
+	// Boundary-fallback cases: when verifiedDB is empty, VerifiedBlockAtL1
+	// returns the pre-activation boundary block iff its L1 inclusion is at
+	// or below l1Block. Finalization stays strictly L1-gated.
+
+	t.Run("empty DB, boundary L1 <= finalizedL1, returns boundary", func(t *testing.T) {
+		boundaryL2 := eth.BlockID{Hash: common.HexToHash("0xBDY"), Number: 499}
+		boundaryL1 := eth.BlockID{Hash: common.HexToHash("0xL1BDY"), Number: 7000}
+		h := newInteropTestHarness(t).
+			WithActivation(1000).
+			WithChain(10, func(m *mockChainContainer) {
+				m.optimisticL2 = boundaryL2
+				m.optimisticL1 = boundaryL1
+			}).
+			Build()
+
+		finalizedL1 := eth.L1BlockRef{Hash: common.Hash{0x01}, Number: 7500, Time: 999}
+		blockID, ts := h.interop.VerifiedBlockAtL1(h.Mock(10).id, finalizedL1)
+		require.Equal(t, boundaryL2, blockID, "boundary finalized by L1: returns boundary")
+		require.Equal(t, uint64(999), ts, "timestamp must be activationTS-1")
+	})
+
+	t.Run("empty DB, boundary L1 > finalizedL1, returns empty", func(t *testing.T) {
+		boundaryL2 := eth.BlockID{Hash: common.HexToHash("0xBDY"), Number: 499}
+		boundaryL1 := eth.BlockID{Hash: common.HexToHash("0xL1BDY"), Number: 9000}
+		h := newInteropTestHarness(t).
+			WithActivation(1000).
+			WithChain(10, func(m *mockChainContainer) {
+				m.optimisticL2 = boundaryL2
+				m.optimisticL1 = boundaryL1
+			}).
+			Build()
+
+		// finalizedL1.Number (7500) < boundaryL1.Number (9000): boundary is not
+		// yet L1-finalized, so finalized head must remain empty.
+		finalizedL1 := eth.L1BlockRef{Hash: common.Hash{0x01}, Number: 7500, Time: 999}
+		blockID, ts := h.interop.VerifiedBlockAtL1(h.Mock(10).id, finalizedL1)
+		require.Equal(t, eth.BlockID{}, blockID, "boundary not yet L1-finalized: empty")
+		require.Equal(t, uint64(0), ts)
+	})
+
+	t.Run("empty DB, activation zero, returns empty", func(t *testing.T) {
+		boundaryL2 := eth.BlockID{Hash: common.HexToHash("0xBDY"), Number: 499}
+		h := newInteropTestHarness(t).
+			WithActivation(0).
+			WithChain(10, func(m *mockChainContainer) {
+				m.optimisticL2 = boundaryL2
+			}).
+			Build()
+
+		finalizedL1 := eth.L1BlockRef{Hash: common.Hash{0x01}, Number: 1000, Time: 999}
+		blockID, ts := h.interop.VerifiedBlockAtL1(h.Mock(10).id, finalizedL1)
+		require.Equal(t, eth.BlockID{}, blockID, "activation=0 has no pre-activation range")
 		require.Equal(t, uint64(0), ts)
 	})
 }

--- a/op-supernode/supernode/chain_container/chain_container_test.go
+++ b/op-supernode/supernode/chain_container/chain_container_test.go
@@ -45,6 +45,12 @@ type mockVirtualNode struct {
 	safeHeadL1  eth.BlockID
 	safeHeadL2  eth.BlockID
 	safeHeadErr error
+
+	// syncStatusOverride lets tests return a fully-formed eth.SyncStatus
+	// (e.g. populated LocalSafeL2.Time / LocalFinalizedL2 / FinalizedL1)
+	// instead of the synthesised default built from safeHeadL1/safeHeadL2.
+	// When nil, the default synthesis below is used.
+	syncStatusOverride func() (*eth.SyncStatus, error)
 }
 
 func newMockVirtualNode() *mockVirtualNode {
@@ -109,6 +115,9 @@ func (m *mockVirtualNode) LastL1(ctx context.Context) (eth.BlockID, error) {
 
 // SyncStatus implements virtual_node.VirtualNode SyncStatus
 func (m *mockVirtualNode) SyncStatus(ctx context.Context) (*eth.SyncStatus, error) {
+	if m.syncStatusOverride != nil {
+		return m.syncStatusOverride()
+	}
 	if m.safeHeadErr != nil {
 		return nil, m.safeHeadErr
 	}
@@ -181,6 +190,7 @@ func (m *mockVerificationActivity) Reset(chainID eth.ChainID, timestamp uint64, 
 func (m *mockVerificationActivity) VerifiedBlockAtL1(chainID eth.ChainID, l1BlockRef eth.L1BlockRef) (eth.BlockID, uint64) {
 	return eth.BlockID{}, 0
 }
+func (m *mockVerificationActivity) IsActiveAt(ts uint64) bool { return true }
 
 // Test helpers
 func createTestVNConfig() *opnodecfg.Config {

--- a/op-supernode/supernode/chain_container/super_authority.go
+++ b/op-supernode/supernode/chain_container/super_authority.go
@@ -13,13 +13,25 @@ import (
 
 // FullyVerifiedL2Head returns the fully verified L2 head block identifier.
 // The second return value indicates whether the caller should fall back to local-safe.
-// Returns (empty, true) only when no verifiers are registered.
-// Returns (empty, false) when verifiers are registered but haven't verified anything yet.
+// Returns (empty, true) when no verifiers are registered, or when every
+// registered verifier reports it is not yet active at the current local-safe
+// L2 timestamp (i.e. interop is scheduled but not yet activated).
+// Returns (empty, false) when verifiers are registered, at least one is active,
+// but none has verified anything yet.
 // Panics if verifiers disagree on the block hash for the same timestamp.
 func (c *simpleChainContainer) FullyVerifiedL2Head() (eth.BlockID, bool) {
 	// If no verifiers registered, signal fallback to local-safe
 	if len(c.verifiers) == 0 {
 		c.log.Debug("FullyVerifiedL2Head: no verifiers registered, signaling local-safe fallback")
+		return eth.BlockID{}, true
+	}
+
+	// If every registered verifier is still pre-activation at the current
+	// local-safe timestamp, fall back to local-safe. Pre-activation L2 content
+	// is verified by consensus alone; gating it on an interop verifier that
+	// has not started yet would stall the head at genesis (see #20191).
+	if activeTS, ok := c.localSafeTimestamp(); ok && c.allVerifiersPreActivationAt(activeTS) {
+		c.log.Debug("FullyVerifiedL2Head: all verifiers pre-activation, signaling local-safe fallback", "localSafeTime", activeTS)
 		return eth.BlockID{}, true
 	}
 
@@ -47,8 +59,12 @@ func (c *simpleChainContainer) FullyVerifiedL2Head() (eth.BlockID, bool) {
 
 // FinalizedL2Head returns the finalized L2 head block identifier.
 // The second return value indicates whether the caller should fall back to local-finalized.
-// Returns (empty, true) only when no verifiers are registered.
-// Returns (empty, false) when verifiers are registered but haven't finalized anything yet.
+// Returns (empty, true) when no verifiers are registered, or when every
+// registered verifier reports it is not yet active at the current local-safe
+// L2 timestamp (i.e. interop is scheduled but not yet activated; FinalizedL2
+// <= LocalSafeL2, so if local-safe is pre-activation, so is finalized).
+// Returns (empty, false) when verifiers are registered, at least one is active,
+// but none has finalized anything yet.
 // Panics if verifiers disagree on the block hash for the same timestamp.
 func (c *simpleChainContainer) FinalizedL2Head() (eth.BlockID, bool) {
 	// If no verifiers registered, signal fallback to local-finalized
@@ -62,6 +78,15 @@ func (c *simpleChainContainer) FinalizedL2Head() (eth.BlockID, bool) {
 		c.log.Error("FinalizedL2Head: failed to get sync status", "err", err)
 		return eth.BlockID{}, true
 	}
+
+	// If every registered verifier is still pre-activation at the current
+	// local-safe timestamp, fall back to local-finalized. See #20191 and the
+	// matching guard in FullyVerifiedL2Head.
+	if c.allVerifiersPreActivationAt(ss.LocalSafeL2.Time) {
+		c.log.Debug("FinalizedL2Head: all verifiers pre-activation, signaling local-finalized fallback", "localSafeTime", ss.LocalSafeL2.Time)
+		return eth.BlockID{}, true
+	}
+
 	timestamp := uint64(math.MaxUint64)
 	oldestFinalizedBlock := eth.BlockID{}
 	for _, v := range c.verifiers {
@@ -82,6 +107,33 @@ func (c *simpleChainContainer) FinalizedL2Head() (eth.BlockID, bool) {
 
 	c.log.Debug("FinalizedL2Head: returning finalized block", "block", oldestFinalizedBlock, "timestamp", timestamp)
 	return oldestFinalizedBlock, false
+}
+
+// localSafeTimestamp returns the timestamp of the current local-safe L2 head.
+// The bool is false if SyncStatus is unavailable, in which case callers should
+// not attempt the pre-activation short-circuit.
+func (c *simpleChainContainer) localSafeTimestamp() (uint64, bool) {
+	ss, err := c.SyncStatus(context.Background())
+	if err != nil {
+		c.log.Warn("localSafeTimestamp: failed to get sync status", "err", err)
+		return 0, false
+	}
+	return ss.LocalSafeL2.Time, true
+}
+
+// allVerifiersPreActivationAt reports whether every registered verifier is
+// still inactive at the given L2 timestamp. Returns false if there are no
+// verifiers; callers are expected to handle that case separately.
+func (c *simpleChainContainer) allVerifiersPreActivationAt(ts uint64) bool {
+	if len(c.verifiers) == 0 {
+		return false
+	}
+	for _, v := range c.verifiers {
+		if v.IsActiveAt(ts) {
+			return false
+		}
+	}
+	return true
 }
 
 // IsDenied checks if a block hash is on the deny list at the given height.

--- a/op-supernode/supernode/chain_container/super_authority_test.go
+++ b/op-supernode/supernode/chain_container/super_authority_test.go
@@ -17,6 +17,10 @@ type mockVerificationActivityForSuperAuthority struct {
 	latestVerifiedTS     uint64
 	latestFinalizedBlock eth.BlockID
 	latestFinalizedTS    uint64
+	// isActiveAtFn drives IsActiveAt for pre-activation fallback tests.
+	// When nil, IsActiveAt returns true (active for all timestamps), matching
+	// the default "always-active" semantics the existing tests assume.
+	isActiveAtFn func(ts uint64) bool
 }
 
 func (m *mockVerificationActivityForSuperAuthority) Start(ctx context.Context) error { return nil }
@@ -34,6 +38,12 @@ func (m *mockVerificationActivityForSuperAuthority) LatestVerifiedL2Block(chainI
 func (m *mockVerificationActivityForSuperAuthority) Reset(eth.ChainID, uint64, eth.BlockRef) {}
 func (m *mockVerificationActivityForSuperAuthority) VerifiedBlockAtL1(chainID eth.ChainID, l1BlockRef eth.L1BlockRef) (eth.BlockID, uint64) {
 	return m.latestFinalizedBlock, m.latestFinalizedTS
+}
+func (m *mockVerificationActivityForSuperAuthority) IsActiveAt(ts uint64) bool {
+	if m.isActiveAtFn != nil {
+		return m.isActiveAtFn(ts)
+	}
+	return true
 }
 
 var _ activity.VerificationActivity = (*mockVerificationActivityForSuperAuthority)(nil)
@@ -308,4 +318,231 @@ func TestChainContainer_FinalizedL2Head_AllUnfinalized(t *testing.T) {
 	result, useLocalFinalized := cc.FinalizedL2Head()
 	require.Equal(t, eth.BlockID{}, result, "should return empty BlockID when all verifiers are unfinalized")
 	require.False(t, useLocalFinalized, "should not signal fallback when verifiers exist but are unfinalized")
+}
+
+// =============================================================================
+// Pre-activation fallback tests (issue #20191)
+// =============================================================================
+//
+// These tests pin the contract that when every registered verifier reports
+// IsActiveAt(ss.LocalSafeL2.Time) == false (i.e. the supernode has interop
+// scheduled but the L1-derived local-safe head has not yet crossed the
+// activation timestamp), super_authority falls back to local-safe /
+// local-finalized rather than stalling the engine at genesis.
+//
+// Note: super_authority consults IsActiveAt(ss.LocalSafeL2.Time) for both the
+// safe and finalized head queries, since FinalizedL2 <= LocalSafeL2 always:
+// if local-safe is still pre-activation, finalized is too.
+
+// setSyncStatus configures the chain's mock virtual node to return the given
+// SyncStatus. The test-only mockVirtualNode always backs newTestChainContainer.
+func setSyncStatus(t *testing.T, cc *simpleChainContainer, ss *eth.SyncStatus) {
+	t.Helper()
+	mvn, ok := cc.vn.(*mockVirtualNode)
+	require.True(t, ok, "newTestChainContainer must install a *mockVirtualNode")
+	mvn.syncStatusOverride = func() (*eth.SyncStatus, error) { return ss, nil }
+}
+
+// preActivationFn returns an isActiveAtFn that reports inactive for all
+// timestamps strictly below activationTS.
+func preActivationFn(activationTS uint64) func(ts uint64) bool {
+	return func(ts uint64) bool { return ts >= activationTS }
+}
+
+// TestChainContainer_FullyVerifiedL2Head_PreActivation_FallsBackToLocalSafe
+// (case B1a) verifies that a single verifier reporting pre-activation for the
+// current LocalSafeL2 timestamp causes a fallback to local-safe.
+func TestChainContainer_FullyVerifiedL2Head_PreActivation_FallsBackToLocalSafe(t *testing.T) {
+	t.Parallel()
+
+	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
+	setSyncStatus(t, cc, &eth.SyncStatus{
+		LocalSafeL2: eth.L2BlockRef{Number: 50, Hash: [32]byte{0xaa}, Time: 999},
+	})
+
+	verifier := &mockVerificationActivityForSuperAuthority{
+		isActiveAtFn: preActivationFn(1000),
+	}
+	cc.verifiers = []activity.VerificationActivity{verifier}
+
+	result, useLocalSafe := cc.FullyVerifiedL2Head()
+	require.Equal(t, eth.BlockID{}, result, "pre-activation should return empty BlockID")
+	require.True(t, useLocalSafe, "pre-activation should signal fallback to local-safe")
+}
+
+// TestChainContainer_FullyVerifiedL2Head_PostActivation_EmptyVerifierNoFallback
+// (case B1b) verifies that once activation has been reached, the existing
+// "verifier present but nothing verified yet" behavior is preserved: no
+// fallback even though the verifier returns empty.
+func TestChainContainer_FullyVerifiedL2Head_PostActivation_EmptyVerifierNoFallback(t *testing.T) {
+	t.Parallel()
+
+	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
+	setSyncStatus(t, cc, &eth.SyncStatus{
+		LocalSafeL2: eth.L2BlockRef{Number: 600, Hash: [32]byte{0xbb}, Time: 1500},
+	})
+
+	verifier := &mockVerificationActivityForSuperAuthority{
+		isActiveAtFn: preActivationFn(1000),
+	}
+	cc.verifiers = []activity.VerificationActivity{verifier}
+
+	result, useLocalSafe := cc.FullyVerifiedL2Head()
+	require.Equal(t, eth.BlockID{}, result, "post-activation empty verifier returns empty")
+	require.False(t, useLocalSafe, "post-activation empty verifier must not signal fallback")
+}
+
+// TestChainContainer_FullyVerifiedL2Head_PostActivation_VerifiedBlockReturned
+// (case B1c) verifies that the existing "happy path" of returning the
+// verifier's LatestVerifiedL2Block is preserved after activation.
+func TestChainContainer_FullyVerifiedL2Head_PostActivation_VerifiedBlockReturned(t *testing.T) {
+	t.Parallel()
+
+	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
+	setSyncStatus(t, cc, &eth.SyncStatus{
+		LocalSafeL2: eth.L2BlockRef{Number: 600, Hash: [32]byte{0xbb}, Time: 1500},
+	})
+
+	verifiedBlock := eth.BlockID{Hash: [32]byte{0x11}, Number: 100}
+	verifier := &mockVerificationActivityForSuperAuthority{
+		latestVerifiedBlock: verifiedBlock,
+		latestVerifiedTS:    1500,
+		isActiveAtFn:        preActivationFn(1000),
+	}
+	cc.verifiers = []activity.VerificationActivity{verifier}
+
+	result, useLocalSafe := cc.FullyVerifiedL2Head()
+	require.Equal(t, verifiedBlock, result, "post-activation should return verified block")
+	require.False(t, useLocalSafe, "post-activation with a verified block must not signal fallback")
+}
+
+// TestChainContainer_FullyVerifiedL2Head_AllPreActivation_FallsBackToLocalSafe
+// (case B1d) verifies the multi-verifier case: when every verifier reports
+// pre-activation, fall back to local-safe.
+func TestChainContainer_FullyVerifiedL2Head_AllPreActivation_FallsBackToLocalSafe(t *testing.T) {
+	t.Parallel()
+
+	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
+	setSyncStatus(t, cc, &eth.SyncStatus{
+		LocalSafeL2: eth.L2BlockRef{Number: 50, Hash: [32]byte{0xaa}, Time: 999},
+	})
+
+	verifier1 := &mockVerificationActivityForSuperAuthority{isActiveAtFn: preActivationFn(1000)}
+	verifier2 := &mockVerificationActivityForSuperAuthority{isActiveAtFn: preActivationFn(2000)}
+	cc.verifiers = []activity.VerificationActivity{verifier1, verifier2}
+
+	result, useLocalSafe := cc.FullyVerifiedL2Head()
+	require.Equal(t, eth.BlockID{}, result, "all-pre-activation should return empty BlockID")
+	require.True(t, useLocalSafe, "all-pre-activation should signal fallback to local-safe")
+}
+
+// TestChainContainer_FullyVerifiedL2Head_MixedActiveAndPreActivation_NoFallback
+// (case B1e) verifies that a partial pre-activation state does NOT force
+// fallback: if at least one verifier is active but unverified, the existing
+// conservative behavior (empty, false) holds.
+func TestChainContainer_FullyVerifiedL2Head_MixedActiveAndPreActivation_NoFallback(t *testing.T) {
+	t.Parallel()
+
+	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
+	setSyncStatus(t, cc, &eth.SyncStatus{
+		LocalSafeL2: eth.L2BlockRef{Number: 600, Hash: [32]byte{0xbb}, Time: 1500},
+	})
+
+	active := &mockVerificationActivityForSuperAuthority{
+		isActiveAtFn: preActivationFn(1000), // active at 1500
+	}
+	preAct := &mockVerificationActivityForSuperAuthority{
+		isActiveAtFn: preActivationFn(2000), // still pre-activation at 1500
+	}
+	cc.verifiers = []activity.VerificationActivity{active, preAct}
+
+	result, useLocalSafe := cc.FullyVerifiedL2Head()
+	require.Equal(t, eth.BlockID{}, result, "mixed case should return empty BlockID")
+	require.False(t, useLocalSafe, "mixed case must not signal fallback; at least one verifier is active and unverified")
+}
+
+// TestChainContainer_FinalizedL2Head_PreActivation_FallsBackToLocalFinalized
+// (case B2a) mirrors B1a for the finalized head.
+func TestChainContainer_FinalizedL2Head_PreActivation_FallsBackToLocalFinalized(t *testing.T) {
+	t.Parallel()
+
+	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
+	setSyncStatus(t, cc, &eth.SyncStatus{
+		FinalizedL1: eth.L1BlockRef{Number: 40},
+		LocalSafeL2: eth.L2BlockRef{Number: 50, Hash: [32]byte{0xcc}, Time: 999},
+	})
+
+	verifier := &mockVerificationActivityForSuperAuthority{
+		isActiveAtFn: preActivationFn(1000),
+	}
+	cc.verifiers = []activity.VerificationActivity{verifier}
+
+	result, useLocalFinalized := cc.FinalizedL2Head()
+	require.Equal(t, eth.BlockID{}, result, "pre-activation should return empty BlockID")
+	require.True(t, useLocalFinalized, "pre-activation should signal fallback to local-finalized")
+}
+
+// TestChainContainer_FinalizedL2Head_PostActivation_EmptyVerifierNoFallback
+// (case B2b) — post-activation, verifier empty → empty, no fallback (unchanged).
+func TestChainContainer_FinalizedL2Head_PostActivation_EmptyVerifierNoFallback(t *testing.T) {
+	t.Parallel()
+
+	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
+	setSyncStatus(t, cc, &eth.SyncStatus{
+		FinalizedL1: eth.L1BlockRef{Number: 400},
+		LocalSafeL2: eth.L2BlockRef{Number: 600, Hash: [32]byte{0xdd}, Time: 1500},
+	})
+
+	verifier := &mockVerificationActivityForSuperAuthority{
+		isActiveAtFn: preActivationFn(1000),
+	}
+	cc.verifiers = []activity.VerificationActivity{verifier}
+
+	result, useLocalFinalized := cc.FinalizedL2Head()
+	require.Equal(t, eth.BlockID{}, result)
+	require.False(t, useLocalFinalized, "post-activation empty verifier must not signal fallback")
+}
+
+// TestChainContainer_FinalizedL2Head_PostActivation_FinalizedBlockReturned
+// (case B2c) — post-activation, verifier has a finalized block → returned (unchanged).
+func TestChainContainer_FinalizedL2Head_PostActivation_FinalizedBlockReturned(t *testing.T) {
+	t.Parallel()
+
+	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
+	setSyncStatus(t, cc, &eth.SyncStatus{
+		FinalizedL1: eth.L1BlockRef{Number: 400},
+		LocalSafeL2: eth.L2BlockRef{Number: 600, Hash: [32]byte{0xdd}, Time: 1500},
+	})
+
+	finalizedBlock := eth.BlockID{Hash: [32]byte{0x22}, Number: 100}
+	verifier := &mockVerificationActivityForSuperAuthority{
+		latestFinalizedBlock: finalizedBlock,
+		latestFinalizedTS:    1500,
+		isActiveAtFn:         preActivationFn(1000),
+	}
+	cc.verifiers = []activity.VerificationActivity{verifier}
+
+	result, useLocalFinalized := cc.FinalizedL2Head()
+	require.Equal(t, finalizedBlock, result, "post-activation should return finalized block")
+	require.False(t, useLocalFinalized)
+}
+
+// TestChainContainer_FinalizedL2Head_AllPreActivation_FallsBackToLocalFinalized
+// (case B2d) — multi-verifier all-pre-activation fallback.
+func TestChainContainer_FinalizedL2Head_AllPreActivation_FallsBackToLocalFinalized(t *testing.T) {
+	t.Parallel()
+
+	cc := newTestChainContainer(t, eth.ChainIDFromUInt64(420))
+	setSyncStatus(t, cc, &eth.SyncStatus{
+		FinalizedL1: eth.L1BlockRef{Number: 40},
+		LocalSafeL2: eth.L2BlockRef{Number: 50, Hash: [32]byte{0xcc}, Time: 999},
+	})
+
+	verifier1 := &mockVerificationActivityForSuperAuthority{isActiveAtFn: preActivationFn(1000)}
+	verifier2 := &mockVerificationActivityForSuperAuthority{isActiveAtFn: preActivationFn(2000)}
+	cc.verifiers = []activity.VerificationActivity{verifier1, verifier2}
+
+	result, useLocalFinalized := cc.FinalizedL2Head()
+	require.Equal(t, eth.BlockID{}, result)
+	require.True(t, useLocalFinalized, "all-pre-activation should signal fallback to local-finalized")
 }


### PR DESCRIPTION
## Notices
Entirely generated.
Stacked on #20215 

## Description

Follow-up to #20215 addressing the activation-gap residual flagged in [wwared's review](https://github.com/ethereum-optimism/optimism/pull/20215#pullrequestreview-4149562593).

#20215 fixed the pre-interop stall by short-circuiting `super_authority` to local-safe whenever every registered verifier reports `!IsActiveAt(LocalSafeL2.Time)`. That leaves a transitional window once `LocalSafeL2.Time` crosses `activationTimestamp` but before the interop verifier commits its first `verifiedDB` entry: `IsActiveAt` is now `true`, the fast-path no longer triggers, `LatestVerifiedL2Block` / `VerifiedBlockAtL1` return `(empty, 0)`, and `EngineController` resolves that to genesis — briefly snapping `SafeL2` and `FinalizedL2` back to block 0 until the verifier catches up.

## Fix

Close the asymmetry at its root. `Interop.VerifiedAtTimestamp` is already pre-activation-aware; `LatestVerifiedL2Block` and `VerifiedBlockAtL1` now are too. Both fall through to the chain's **pre-activation boundary block** (L2 block at `activationTimestamp-1`, verified by consensus alone) whenever `verifiedDB` is empty. For the finalized head the boundary is only surfaced when its L1 inclusion is already `<= l1Block` — finalization stays strictly L1-gated.

Boundary lookup uses `ChainContainer.OptimisticAt(activationTs-1)`, recomputed per call (no caching). Lookup failures fall back to `(empty, 0)` so the existing pre-activation `IsActiveAt` fast-path in `super_authority` still guards the common case without an L2 RPC.

Rejected the alternative of loosening `EngineController`'s `(empty, false)` branch to fall through to `localSafeHead`: post-activation, `localSafeHead` contains blocks the verifier has not yet cross-verified and could still invalidate — that would overpromise safety.

## Behaviour across the activation spectrum

| State | `verifiedDB` | Boundary fallback | `SafeL2` resolves to |
|---|---|---|---|
| Pre-activation | empty | short-circuited by `IsActiveAt` fast-path in super_authority | `LocalSafe` (unchanged from #20215) |
| Activation gap | empty | returns boundary block | pre-activation boundary block |
| Steady state | non-empty | not consulted | verified block (unchanged) |

## Tests

**Unit** — `op-supernode/supernode/activity/interop/interop_test.go`:

- New `TestLatestVerifiedL2Block` (5 subtests): boundary returned on empty DB, lookup fails, `activation=0`, unknown chain, verifiedDB-non-empty preserved.
- Extended `TestVerifiedBlockAtL1` (4 new subtests): lookup fails, boundary L1 `<=` finalizedL1 (returns boundary), boundary L1 `>` finalizedL1 (stays empty), `activation=0`.

**Acceptance** — new `op-acceptance-tests/tests/interop/upgrade/activation_gap_test.go`:

- `TestActivationGap` boots `NewTwoL2SupernodeInterop(t, 60)`, snapshots `{SafeL2, FinalizedL2}` pre-activation, calls `AwaitActivation` on both chains, then polls `optimism_syncStatus` at 1 Hz for 60 s asserting neither head regresses below its pre-activation value on either chain. Direct end-to-end reproduction of the gap.

`super_authority_test.go` is intentionally unchanged: the contract at that layer is still pass-through, and the existing "empty verifier → no fallback" cases still hold there. The semantic shift lives inside the `Interop` verifier where the pre-activation asymmetry originated.


