### PR TITLE
test(op-acceptance-tests): SuperPermissionedDisputeGame at initial deployment

### DIFF
--- a/op-acceptance-tests/tests/base/withdrawal/withdrawal_test_helper.go
+++ b/op-acceptance-tests/tests/base/withdrawal/withdrawal_test_helper.go
@@ -40,10 +40,9 @@ func newSystem(t devtest.T, gameType gameTypes.GameType) *presets.Minimal {
 func TestWithdrawal(gt *testing.T, gameType gameTypes.GameType) {
 	t := devtest.ParallelT(gt)
 	sys := newSystem(t, gameType)
-	require := sys.T.Require()
 
 	bridge := sys.StandardBridge()
-	require.EqualValuesf(gameType, bridge.RespectedGameType(), "Respected game type must be %s", gameType)
+	bridge.VerifyRespectedGameType(gameType)
 
 	initialL1Balance := eth.OneThirdEther
 

--- a/op-acceptance-tests/tests/interop/super-at-genesis/super_dispute_game_at_initial_deployment_test.go
+++ b/op-acceptance-tests/tests/interop/super-at-genesis/super_dispute_game_at_initial_deployment_test.go
@@ -1,0 +1,25 @@
+package super_at_genesis
+
+import (
+	"testing"
+
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+)
+
+// TestSuperPermissionedDisputeGameInstalledAtInitialDeployment verifies that
+// when a chain is deployed via op-deployer with the SuperRootGamesMigration
+// dev feature flag set, SuperPermissionedDisputeGame is installed in the
+// permissioned slot as part of the initial op-deployer apply - no post-deploy
+// OPCMv2 migration is required.
+//
+// Tracks ethereum-optimism/optimism#18729.
+func TestSuperPermissionedDisputeGameInstalledAtInitialDeployment(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewSingleChainInteropSuperRootAtGenesis(t)
+
+	sys.StandardBridge(sys.L2ChainA).VerifyRespectedGameType(gameTypes.SuperPermissionedGameType)
+	sys.DisputeGameFactory().VerifyGameImplPresent(gameTypes.SuperPermissionedGameType)
+	sys.DisputeGameFactory().VerifyGameImplAbsent(gameTypes.PermissionedGameType)
+}

--- a/op-acceptance-tests/tests/interop/super-at-genesis/super_dispute_game_at_initial_deployment_test.go
+++ b/op-acceptance-tests/tests/interop/super-at-genesis/super_dispute_game_at_initial_deployment_test.go
@@ -9,12 +9,9 @@ import (
 )
 
 // TestSuperPermissionedDisputeGameInstalledAtInitialDeployment verifies that
-// when a chain is deployed via op-deployer with the SuperRootGamesMigration
-// dev feature flag set, SuperPermissionedDisputeGame is installed in the
-// permissioned slot as part of the initial op-deployer apply - no post-deploy
-// OPCMv2 migration is required.
-//
-// Tracks ethereum-optimism/optimism#18729.
+// a chain deployed with the SuperRootGamesMigration dev feature flag has
+// SuperPermissionedDisputeGame in the permissioned slot at initial deploy,
+// without requiring a post-deploy OPCMv2 migration.
 func TestSuperPermissionedDisputeGameInstalledAtInitialDeployment(gt *testing.T) {
 	t := devtest.SerialT(gt)
 	sys := presets.NewSingleChainInteropSuperRootAtGenesis(t)

--- a/op-acceptance-tests/tests/proofs/cannon/smoke_test.go
+++ b/op-acceptance-tests/tests/proofs/cannon/smoke_test.go
@@ -24,8 +24,6 @@ func TestSmoke(gt *testing.T) {
 	_, err = gameargs.Parse(gameArgs)
 	require.NoError(err, "Permissionless game args invalid")
 
-	permissionedGame := dgf.GameImpl(gameTypes.PermissionedGameType)
-	require.NotEmpty(permissionedGame.Address, "permissioned game impl must be set")
-	cannonGame := dgf.GameImpl(gameTypes.CannonGameType)
-	require.NotEmpty(cannonGame.Address, "cannon game impl must be set")
+	dgf.VerifyGameImplPresent(gameTypes.PermissionedGameType)
+	dgf.VerifyGameImplPresent(gameTypes.CannonGameType)
 }

--- a/op-devstack/dsl/bridge.go
+++ b/op-devstack/dsl/bridge.go
@@ -121,8 +121,6 @@ func (b *StandardBridge) RespectedGameType() uint32 {
 	return gameType
 }
 
-// VerifyRespectedGameType asserts that the OptimismPortal's
-// AnchorStateRegistry reports the expected respected game type.
 func (b *StandardBridge) VerifyRespectedGameType(expected gameTypes.GameType) {
 	actual := gameTypes.GameType(b.RespectedGameType())
 	b.require.Equalf(expected, actual,

--- a/op-devstack/dsl/bridge.go
+++ b/op-devstack/dsl/bridge.go
@@ -121,6 +121,15 @@ func (b *StandardBridge) RespectedGameType() uint32 {
 	return gameType
 }
 
+// VerifyRespectedGameType asserts that the OptimismPortal's
+// AnchorStateRegistry reports the expected respected game type.
+func (b *StandardBridge) VerifyRespectedGameType(expected gameTypes.GameType) {
+	actual := gameTypes.GameType(b.RespectedGameType())
+	b.require.Equalf(expected, actual,
+		"respected game type mismatch: expected %s (%d), got %s (%d)",
+		expected, uint32(expected), actual, uint32(actual))
+}
+
 func (b *StandardBridge) PortalVersion() string {
 	version, err := contractio.Read(b.l1Portal.Version(), b.ctx)
 	b.require.NoError(err, "Failed to read portal version")

--- a/op-devstack/dsl/proofs/dispute_game_factory.go
+++ b/op-devstack/dsl/proofs/dispute_game_factory.go
@@ -174,16 +174,12 @@ func (f *DisputeGameFactory) GameImpl(gameType gameTypes.GameType) *FaultDispute
 	return NewFaultDisputeGame(f.t, f.require, implAddr, f.getGameHelper, f.honestTraceForGame, game)
 }
 
-// VerifyGameImplPresent asserts the DisputeGameFactory has a non-zero
-// implementation registered for the given game type.
 func (f *DisputeGameFactory) VerifyGameImplPresent(gameType gameTypes.GameType) {
 	implAddr := contract.Read(f.dgf.GameImpls(uint32(gameType)))
 	f.require.NotEqualf(common.Address{}, implAddr,
 		"expected DisputeGameFactory to have an implementation for %s (%d)", gameType, uint32(gameType))
 }
 
-// VerifyGameImplAbsent asserts the DisputeGameFactory has no implementation
-// registered for the given game type (the slot is address(0)).
 func (f *DisputeGameFactory) VerifyGameImplAbsent(gameType gameTypes.GameType) {
 	implAddr := contract.Read(f.dgf.GameImpls(uint32(gameType)))
 	f.require.Equalf(common.Address{}, implAddr,

--- a/op-devstack/dsl/proofs/dispute_game_factory.go
+++ b/op-devstack/dsl/proofs/dispute_game_factory.go
@@ -174,6 +174,22 @@ func (f *DisputeGameFactory) GameImpl(gameType gameTypes.GameType) *FaultDispute
 	return NewFaultDisputeGame(f.t, f.require, implAddr, f.getGameHelper, f.honestTraceForGame, game)
 }
 
+// VerifyGameImplPresent asserts the DisputeGameFactory has a non-zero
+// implementation registered for the given game type.
+func (f *DisputeGameFactory) VerifyGameImplPresent(gameType gameTypes.GameType) {
+	implAddr := contract.Read(f.dgf.GameImpls(uint32(gameType)))
+	f.require.NotEqualf(common.Address{}, implAddr,
+		"expected DisputeGameFactory to have an implementation for %s (%d)", gameType, uint32(gameType))
+}
+
+// VerifyGameImplAbsent asserts the DisputeGameFactory has no implementation
+// registered for the given game type (the slot is address(0)).
+func (f *DisputeGameFactory) VerifyGameImplAbsent(gameType gameTypes.GameType) {
+	implAddr := contract.Read(f.dgf.GameImpls(uint32(gameType)))
+	f.require.Equalf(common.Address{}, implAddr,
+		"expected DisputeGameFactory to have no implementation for %s (%d), got %s", gameType, uint32(gameType), implAddr)
+}
+
 func (f *DisputeGameFactory) GameArgs(gameType gameTypes.GameType) []byte {
 	return contract.Read(f.dgf.GameArgs(uint32(gameType)))
 }

--- a/op-devstack/presets/interop.go
+++ b/op-devstack/presets/interop.go
@@ -136,6 +136,16 @@ func NewSingleChainInteropIsthmusSuper(t devtest.T, opts ...Option) *SingleChain
 	return singleChainInteropFromSupernodeProofsRuntime(t, sysgo.NewSingleChainSupernodeProofsRuntimeWithConfig(t, false, presetCfg))
 }
 
+// NewSingleChainInteropSuperRootAtGenesis creates a fresh SingleChainInterop
+// target where SuperPermissionedDisputeGame is installed in the permissioned
+// slot as part of the initial op-deployer apply - no post-deploy OPCMv2
+// migration runs. This exercises the initial-deploy path for super-root
+// dispute games tracked by ethereum-optimism/optimism#18729.
+func NewSingleChainInteropSuperRootAtGenesis(t devtest.T, opts ...Option) *SingleChainInterop {
+	presetCfg, _ := collectSupportedPresetConfig(t, "NewSingleChainInteropSuperRootAtGenesis", opts, supernodeProofsPresetSupportedOptionKinds)
+	return singleChainInteropFromSupernodeProofsRuntime(t, sysgo.NewSingleChainSuperRootAtGenesisRuntimeWithConfig(t, presetCfg))
+}
+
 // NewSimpleInterop creates a fresh SimpleInterop target for the current test.
 //
 // The target is created from the interop runtime plus any additional preset options.

--- a/op-devstack/sysgo/multichain_proofs.go
+++ b/op-devstack/sysgo/multichain_proofs.go
@@ -189,7 +189,9 @@ func NewTwoL2SupernodeProofsRuntimeWithConfig(t devtest.T, interopAtGenesis bool
 
 func NewSingleChainSupernodeProofsRuntimeWithConfig(t devtest.T, interopAtGenesis bool, cfg PresetConfig) *MultiChainRuntime {
 	cfg = withSuperProofsDeployerFeature(cfg)
-	runtime := newSingleChainSupernodeRuntimeWithConfig(t, interopAtGenesis, true, cfg)
+	runtime := newSingleChainSupernodeRuntimeWithConfig(t, interopAtGenesis, cfg)
+	chain := runtime.Chains["l2a"]
+	chain.Proposer = startMinimalProposer(t, runtime.Keys, chain.Network, runtime.L1EL, chain.CL, cfg.ProposerOptions...)
 	attachTestSequencerToRuntime(t, runtime, "dev")
 	return attachSupernodeSuperProofs(t, runtime, cfg)
 }

--- a/op-devstack/sysgo/multichain_proofs.go
+++ b/op-devstack/sysgo/multichain_proofs.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
 	opchallenger "github.com/ethereum-optimism/optimism/op-challenger"
 	challengermetrics "github.com/ethereum-optimism/optimism/op-challenger/metrics"
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-core/devfeatures"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	sharedchallenger "github.com/ethereum-optimism/optimism/op-devstack/shared/challenger"
@@ -106,18 +107,45 @@ func attachSupernodeSuperProofs(t devtest.T, runtime *MultiChainRuntime, cfg Pre
 
 	proofChain := chains[0]
 	cls := make([]L2CLNode, 0, len(chains))
-	nets := make([]*L2Network, 0, len(chains))
-	els := make([]L2ELNode, 0, len(chains))
 	for _, chain := range chains {
 		t.Require().NotNil(chain, "runtime chain entry must not be nil")
 		cls = append(cls, chain.CL)
-		nets = append(nets, chain.Network)
-		els = append(els, chain.EL)
 	}
 
 	superrootTime := awaitSuperrootTime(t, cls...)
 	superRoot := getSupernodeSuperRoot(t, runtime.Supernode, superrootTime)
 	migrateSuperRoots(t, runtime.Keys, runtime.Migration, runtime.L1Network.ChainID(), runtime.L1EL, superRoot, superrootTime, proofChain.Network.ChainID())
+
+	// After migration all three super types are enabled; the proposer
+	// defaults to SUPER_CANNON (matching the migrated StartingRespectedGameType).
+	attachSuperChallengerAndProposer(t, runtime, cfg, gameTypes.SuperCannonGameType)
+	return runtime
+}
+
+// attachSuperChallengerAndProposer wires a shared interop challenger and a
+// super proposer into a supernode-backed runtime. proposerGameType selects
+// which super game type the proposer creates: SUPER_CANNON for post-migration
+// chains (all three super types enabled) or SUPER_PERMISSIONED_CANNON for
+// initial-deploy super chains where only the permissioned super slot is
+// active.
+func attachSuperChallengerAndProposer(
+	t devtest.T,
+	runtime *MultiChainRuntime,
+	cfg PresetConfig,
+	proposerGameType gameTypes.GameType,
+) {
+	chains := orderedRuntimeChains(runtime)
+	t.Require().NotEmpty(chains, "runtime must contain at least one chain")
+	t.Require().NotNil(runtime.Supernode, "runtime must provide a supernode")
+
+	proofChain := chains[0]
+	nets := make([]*L2Network, 0, len(chains))
+	els := make([]L2ELNode, 0, len(chains))
+	for _, chain := range chains {
+		t.Require().NotNil(chain, "runtime chain entry must not be nil")
+		nets = append(nets, chain.Network)
+		els = append(els, chain.EL)
+	}
 
 	challenger := startInteropChallenger(
 		t,
@@ -134,6 +162,12 @@ func attachSupernodeSuperProofs(t devtest.T, runtime *MultiChainRuntime, cfg Pre
 	)
 	runtime.L2ChallengerConfig = challenger.Config()
 
+	proposerOpts := append([]ProposerOption{
+		func(_ ComponentTarget, c *ps.CLIConfig) {
+			c.DisputeGameType = uint32(proposerGameType)
+		},
+	}, cfg.ProposerOptions...)
+
 	_ = startSuperProposer(
 		t,
 		runtime.Keys,
@@ -143,10 +177,8 @@ func attachSupernodeSuperProofs(t devtest.T, runtime *MultiChainRuntime, cfg Pre
 		proofChain.Network,
 		"",
 		runtime.Supernode.UserRPC(),
-		cfg.ProposerOptions...,
+		proposerOpts...,
 	)
-
-	return runtime
 }
 
 func NewSimpleInteropSuperProofsRuntimeWithConfig(t devtest.T, cfg PresetConfig) *MultiChainRuntime {
@@ -163,7 +195,7 @@ func NewTwoL2SupernodeProofsRuntimeWithConfig(t devtest.T, interopAtGenesis bool
 
 func NewSingleChainSupernodeProofsRuntimeWithConfig(t devtest.T, interopAtGenesis bool, cfg PresetConfig) *MultiChainRuntime {
 	cfg = withSuperProofsDeployerFeature(cfg)
-	runtime := newSingleChainSupernodeRuntimeWithConfig(t, interopAtGenesis, cfg)
+	runtime := newSingleChainSupernodeRuntimeWithConfig(t, interopAtGenesis, true, cfg)
 	attachTestSequencerToRuntime(t, runtime, "dev")
 	return attachSupernodeSuperProofs(t, runtime, cfg)
 }

--- a/op-devstack/sysgo/multichain_proofs.go
+++ b/op-devstack/sysgo/multichain_proofs.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
 	opchallenger "github.com/ethereum-optimism/optimism/op-challenger"
-	challengermetrics "github.com/ethereum-optimism/optimism/op-challenger/metrics"
 	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	challengermetrics "github.com/ethereum-optimism/optimism/op-challenger/metrics"
 	"github.com/ethereum-optimism/optimism/op-core/devfeatures"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	sharedchallenger "github.com/ethereum-optimism/optimism/op-devstack/shared/challenger"
@@ -116,18 +116,12 @@ func attachSupernodeSuperProofs(t devtest.T, runtime *MultiChainRuntime, cfg Pre
 	superRoot := getSupernodeSuperRoot(t, runtime.Supernode, superrootTime)
 	migrateSuperRoots(t, runtime.Keys, runtime.Migration, runtime.L1Network.ChainID(), runtime.L1EL, superRoot, superrootTime, proofChain.Network.ChainID())
 
-	// After migration all three super types are enabled; the proposer
-	// defaults to SUPER_CANNON (matching the migrated StartingRespectedGameType).
 	attachSuperChallengerAndProposer(t, runtime, cfg, gameTypes.SuperCannonGameType)
 	return runtime
 }
 
-// attachSuperChallengerAndProposer wires a shared interop challenger and a
-// super proposer into a supernode-backed runtime. proposerGameType selects
-// which super game type the proposer creates: SUPER_CANNON for post-migration
-// chains (all three super types enabled) or SUPER_PERMISSIONED_CANNON for
-// initial-deploy super chains where only the permissioned super slot is
-// active.
+// attachSuperChallengerAndProposer wires an interop challenger and a super
+// proposer for proposerGameType into a supernode-backed runtime.
 func attachSuperChallengerAndProposer(
 	t devtest.T,
 	runtime *MultiChainRuntime,

--- a/op-devstack/sysgo/multichain_super_at_genesis.go
+++ b/op-devstack/sysgo/multichain_super_at_genesis.go
@@ -1,0 +1,36 @@
+package sysgo
+
+import (
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum-optimism/optimism/op-core/devfeatures"
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+)
+
+// withSuperRootGamesAtGenesisDeployerFeatures enables both the OptimismPortal
+// interop flag and the SuperRootGamesMigration dev flag in the deploy intent.
+// With both bits set, DeployImplementations.s.sol deploys the super dispute
+// game impls and DeployOPChain.s.sol wires SUPER_PERMISSIONED_CANNON into the
+// permissioned slot and sets it as the respected game type, instead of
+// PERMISSIONED_CANNON. No post-deploy OPCMv2 migration is needed.
+func withSuperRootGamesAtGenesisDeployerFeatures(cfg PresetConfig) PresetConfig {
+	cfg.DeployerOptions = append([]DeployerOption{
+		WithDevFeatureEnabled(devfeatures.OptimismPortalInteropFlag),
+		WithDevFeatureEnabled(devfeatures.SuperRootGamesMigrationFlag),
+	}, cfg.DeployerOptions...)
+	return cfg
+}
+
+// NewSingleChainSuperRootAtGenesisRuntimeWithConfig builds a single-chain
+// supernode runtime that has SuperPermissionedDisputeGame installed in the
+// permissioned slot as part of the initial op-deployer apply. Only
+// SUPER_PERMISSIONED_CANNON (game type 5) is active on-chain, so the runtime
+// skips the standard permissioned-cannon proposer (which would have no
+// implementation to target) and runs a super proposer against game type 5
+// directly.
+func NewSingleChainSuperRootAtGenesisRuntimeWithConfig(t devtest.T, cfg PresetConfig) *MultiChainRuntime {
+	cfg = withSuperRootGamesAtGenesisDeployerFeatures(cfg)
+	runtime := newSingleChainSupernodeRuntimeWithConfig(t, true, false, cfg)
+	attachTestSequencerToRuntime(t, runtime, "dev")
+	attachSuperChallengerAndProposer(t, runtime, cfg, gameTypes.SuperPermissionedGameType)
+	return runtime
+}

--- a/op-devstack/sysgo/multichain_super_at_genesis.go
+++ b/op-devstack/sysgo/multichain_super_at_genesis.go
@@ -19,7 +19,7 @@ func withSuperRootGamesAtGenesisDeployerFeatures(cfg PresetConfig) PresetConfig 
 // permissioned slot at initial deploy.
 func NewSingleChainSuperRootAtGenesisRuntimeWithConfig(t devtest.T, cfg PresetConfig) *MultiChainRuntime {
 	cfg = withSuperRootGamesAtGenesisDeployerFeatures(cfg)
-	runtime := newSingleChainSupernodeRuntimeWithConfig(t, true, false, cfg)
+	runtime := newSingleChainSupernodeRuntimeWithConfig(t, true, cfg)
 	attachTestSequencerToRuntime(t, runtime, "dev")
 	attachSuperChallengerAndProposer(t, runtime, cfg, gameTypes.SuperPermissionedGameType)
 	return runtime

--- a/op-devstack/sysgo/multichain_super_at_genesis.go
+++ b/op-devstack/sysgo/multichain_super_at_genesis.go
@@ -6,12 +6,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 )
 
-// withSuperRootGamesAtGenesisDeployerFeatures enables both the OptimismPortal
-// interop flag and the SuperRootGamesMigration dev flag in the deploy intent.
-// With both bits set, DeployImplementations.s.sol deploys the super dispute
-// game impls and DeployOPChain.s.sol wires SUPER_PERMISSIONED_CANNON into the
-// permissioned slot and sets it as the respected game type, instead of
-// PERMISSIONED_CANNON. No post-deploy OPCMv2 migration is needed.
 func withSuperRootGamesAtGenesisDeployerFeatures(cfg PresetConfig) PresetConfig {
 	cfg.DeployerOptions = append([]DeployerOption{
 		WithDevFeatureEnabled(devfeatures.OptimismPortalInteropFlag),
@@ -21,12 +15,8 @@ func withSuperRootGamesAtGenesisDeployerFeatures(cfg PresetConfig) PresetConfig 
 }
 
 // NewSingleChainSuperRootAtGenesisRuntimeWithConfig builds a single-chain
-// supernode runtime that has SuperPermissionedDisputeGame installed in the
-// permissioned slot as part of the initial op-deployer apply. Only
-// SUPER_PERMISSIONED_CANNON (game type 5) is active on-chain, so the runtime
-// skips the standard permissioned-cannon proposer (which would have no
-// implementation to target) and runs a super proposer against game type 5
-// directly.
+// supernode runtime with SUPER_PERMISSIONED_CANNON installed in the
+// permissioned slot at initial deploy.
 func NewSingleChainSuperRootAtGenesisRuntimeWithConfig(t devtest.T, cfg PresetConfig) *MultiChainRuntime {
 	cfg = withSuperRootGamesAtGenesisDeployerFeatures(cfg)
 	runtime := newSingleChainSupernodeRuntimeWithConfig(t, true, false, cfg)

--- a/op-devstack/sysgo/multichain_supernode_runtime.go
+++ b/op-devstack/sysgo/multichain_supernode_runtime.go
@@ -138,7 +138,12 @@ func startSupernodeELWithSupervisorURL(
 	}
 }
 
-func newSingleChainSupernodeRuntimeWithConfig(t devtest.T, interopAtGenesis bool, cfg PresetConfig) *MultiChainRuntime {
+// newSingleChainSupernodeRuntimeWithConfig builds a single-chain runtime with
+// an op-supernode attached. If startMinimalProposer is true, a standard
+// permissioned-cannon proposer (game type 1) is started alongside the
+// batcher. Callers that install super dispute games at initial deploy
+// should pass false and start a super proposer separately.
+func newSingleChainSupernodeRuntimeWithConfig(t devtest.T, interopAtGenesis bool, startMinimalProposerDaemon bool, cfg PresetConfig) *MultiChainRuntime {
 	require := t.Require()
 
 	keys, err := devkeys.NewMnemonicDevKeys(devkeys.TestMnemonic)
@@ -173,7 +178,10 @@ func newSingleChainSupernodeRuntimeWithConfig(t devtest.T, interopAtGenesis bool
 
 	supernode, l2CL := startSingleChainSharedSupernode(t, l1Net, l1EL, l1CL, l2Net, l2EL, depSetStatic, jwtSecret, interopAtGenesis)
 	l2Batcher := startMinimalBatcher(t, keys, l2Net, l1EL, l2CL, l2EL, cfg.BatcherOptions...)
-	l2Proposer := startMinimalProposer(t, keys, l2Net, l1EL, l2CL, cfg.ProposerOptions...)
+	var l2Proposer *L2Proposer
+	if startMinimalProposerDaemon {
+		l2Proposer = startMinimalProposer(t, keys, l2Net, l1EL, l2CL, cfg.ProposerOptions...)
+	}
 	faucetService := startFaucets(t, keys, l1Net.ChainID(), l2Net.ChainID(), l1EL.UserRPC(), l2EL.UserRPC())
 
 	// Use the potentially-overridden depSetStatic if available.

--- a/op-devstack/sysgo/multichain_supernode_runtime.go
+++ b/op-devstack/sysgo/multichain_supernode_runtime.go
@@ -138,11 +138,6 @@ func startSupernodeELWithSupervisorURL(
 	}
 }
 
-// newSingleChainSupernodeRuntimeWithConfig builds a single-chain runtime with
-// an op-supernode attached. If startMinimalProposer is true, a standard
-// permissioned-cannon proposer (game type 1) is started alongside the
-// batcher. Callers that install super dispute games at initial deploy
-// should pass false and start a super proposer separately.
 func newSingleChainSupernodeRuntimeWithConfig(t devtest.T, interopAtGenesis bool, startMinimalProposerDaemon bool, cfg PresetConfig) *MultiChainRuntime {
 	require := t.Require()
 

--- a/op-devstack/sysgo/multichain_supernode_runtime.go
+++ b/op-devstack/sysgo/multichain_supernode_runtime.go
@@ -138,7 +138,7 @@ func startSupernodeELWithSupervisorURL(
 	}
 }
 
-func newSingleChainSupernodeRuntimeWithConfig(t devtest.T, interopAtGenesis bool, startMinimalProposerDaemon bool, cfg PresetConfig) *MultiChainRuntime {
+func newSingleChainSupernodeRuntimeWithConfig(t devtest.T, interopAtGenesis bool, cfg PresetConfig) *MultiChainRuntime {
 	require := t.Require()
 
 	keys, err := devkeys.NewMnemonicDevKeys(devkeys.TestMnemonic)
@@ -173,10 +173,6 @@ func newSingleChainSupernodeRuntimeWithConfig(t devtest.T, interopAtGenesis bool
 
 	supernode, l2CL := startSingleChainSharedSupernode(t, l1Net, l1EL, l1CL, l2Net, l2EL, depSetStatic, jwtSecret, interopAtGenesis)
 	l2Batcher := startMinimalBatcher(t, keys, l2Net, l1EL, l2CL, l2EL, cfg.BatcherOptions...)
-	var l2Proposer *L2Proposer
-	if startMinimalProposerDaemon {
-		l2Proposer = startMinimalProposer(t, keys, l2Net, l1EL, l2CL, cfg.ProposerOptions...)
-	}
 	faucetService := startFaucets(t, keys, l1Net.ChainID(), l2Net.ChainID(), l1EL.UserRPC(), l2EL.UserRPC())
 
 	// Use the potentially-overridden depSetStatic if available.
@@ -196,12 +192,11 @@ func newSingleChainSupernodeRuntimeWithConfig(t devtest.T, interopAtGenesis bool
 		L1CL:          l1CL,
 		Chains: map[string]*MultiChainNodeRuntime{
 			"l2a": {
-				Name:     "l2a",
-				Network:  l2Net,
-				EL:       l2EL,
-				CL:       l2CL,
-				Batcher:  l2Batcher,
-				Proposer: l2Proposer,
+				Name:    "l2a",
+				Network: l2Net,
+				EL:      l2EL,
+				CL:      l2CL,
+				Batcher: l2Batcher,
 			},
 		},
 		Supernode:     supernode,


### PR DESCRIPTION
## Summary

Adds an acceptance test that verifies a chain can be deployed with `SuperPermissionedDisputeGame` installed in the permissioned slot as part of the initial `op-deployer apply` — no post-deploy OPCMv2 migration. This is driven by setting both `OptimismPortalInteropFlag` and `SuperRootGamesMigrationFlag` in the deploy intent's `devFeatureBitmap`; the Solidity deploy scripts already do the slot swap and `startingRespectedGameType` wiring based on that flag. A new `NewSingleChainInteropSuperRootAtGenesis` preset exposes this to devstack tests, sharing its challenger + proposer setup with the existing migration path via a new `attachSuperChallengerAndProposer` helper.

Along the way: small DSL additions (`StandardBridge.VerifyRespectedGameType`, `DisputeGameFactory.VerifyGameImplPresent/Absent`) with two pre-existing tests switched over to them. 

Fixes ethereum-optimism/optimism#18729.