### PR TITLE
op-node: add RPC-based executing-message validator for unsafe blocks

### DIFF
--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -452,6 +452,22 @@ var (
 		TakesFile: true,
 		Category:  InteropCategory,
 	}
+	InteropRPCOverrides = &cli.StringFlag{
+		Name: "interop.rpc-overrides",
+		Usage: "Comma-separated chainID=URL pairs. When set, every newly-received unsafe block is validated " +
+			"by looking up each executing-message's initiating log via eth_getLogs on the configured remote chain's RPC. " +
+			"Intended for light-CL operators running without op-supervisor. Example: --interop.rpc-overrides=10=https://mainnet.optimism.io,8453=https://mainnet.base.org",
+		EnvVars:  prefixEnvVars("INTEROP_RPC_OVERRIDES"),
+		Value:    "",
+		Category: InteropCategory,
+	}
+	InteropRPCValidatorTimeout = &cli.DurationFlag{
+		Name:     "interop.rpc-validator.timeout",
+		Usage:    "Per-block budget for remote eth_getLogs validation. A block is rejected if not fully validated within this duration.",
+		EnvVars:  prefixEnvVars("INTEROP_RPC_VALIDATOR_TIMEOUT"),
+		Value:    60 * time.Second,
+		Category: InteropCategory,
+	}
 
 	IgnoreMissingPectraBlobSchedule = &cli.BoolFlag{
 		Name: "ignore-missing-pectra-blob-schedule",
@@ -525,6 +541,8 @@ var optionalFlags = []cli.Flag{
 	InteropRPCPort,
 	InteropJWTSecret,
 	InteropDependencySet,
+	InteropRPCOverrides,
+	InteropRPCValidatorTimeout,
 	IgnoreMissingPectraBlobSchedule,
 	ExperimentalOPStackAPI,
 }

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -620,6 +620,23 @@ func initL2(ctx context.Context, cfg *config.Config, node *OpNode) (*sources.Eng
 		}
 	}
 
+	// Wire the optional RPC-based executing-message validator into the engine
+	// controller so every newly-inserted unsafe block is vetted before FCU.
+	if interopCfg, ok := cfg.InteropConfig.(*interop.Config); ok {
+		validator, err := interop.NewRPCExecMsgValidator(
+			node.log, &cfg.Rollup, l2Source,
+			interopCfg.RPCOverrides, interopCfg.RPCValidatorTimeout,
+		)
+		if err != nil {
+			return nil, nil, nil, nil, fmt.Errorf("failed to setup executing-message RPC validator: %w", err)
+		}
+		if validator != nil {
+			l2Driver.SyncDeriver.Engine.SetUnsafeBlockValidator(validator)
+			node.log.Info("Executing-message RPC validator enabled",
+				"timeout", interopCfg.RPCValidatorTimeout)
+		}
+	}
+
 	return l2Source, sys, l2Driver, safeDB, nil
 }
 

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -164,6 +164,18 @@ type EngineController struct {
 	superAuthority rollup.SuperAuthority
 
 	unsafePayloads *PayloadsQueue // queue of unsafe payloads, ordered by ascending block number, may have gaps and duplicates
+
+	// unsafeBlockValidator, when non-nil, vets each new unsafe payload after
+	// NewPayload but before ForkchoiceUpdate. A non-nil error aborts promotion.
+	unsafeBlockValidator UnsafeBlockValidator
+}
+
+// UnsafeBlockValidator validates a newly-executed unsafe payload before it is
+// promoted to the unsafe head via forkchoiceUpdated. Implementations should be
+// self-contained (e.g. scan receipts, call out to remote RPCs, etc.) and bound
+// their own wall-time via ctx.
+type UnsafeBlockValidator interface {
+	Validate(ctx context.Context, envelope *eth.ExecutionPayloadEnvelope) error
 }
 
 var _ event.Deriver = (*EngineController)(nil)
@@ -570,6 +582,15 @@ func (e *EngineController) InsertUnsafePayload(ctx context.Context, envelope *et
 	return e.insertUnsafePayload(ctx, envelope, ref)
 }
 
+// SetUnsafeBlockValidator installs an optional hook that runs between
+// NewPayload and ForkchoiceUpdate on every inserted unsafe payload. Passing
+// nil disables the hook. Intended to be called once at node startup.
+func (e *EngineController) SetUnsafeBlockValidator(v UnsafeBlockValidator) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.unsafeBlockValidator = v
+}
+
 func (e *EngineController) insertUnsafePayload(ctx context.Context, envelope *eth.ExecutionPayloadEnvelope, ref eth.L2BlockRef) error {
 	// Check if there is a finalized head once when doing EL sync. If so, transition to CL sync
 	if e.syncStatus == syncStatusWillStartEL {
@@ -607,6 +628,18 @@ func (e *EngineController) insertUnsafePayload(ctx context.Context, envelope *et
 			payload.ID(), payload.ParentID(), eth.NewPayloadErr(payload, status)))
 	}
 	newPayloadFinish := time.Now()
+
+	validationStart := time.Now()
+	if e.unsafeBlockValidator != nil {
+		if err := e.unsafeBlockValidator.Validate(ctx, envelope); err != nil {
+			e.log.Warn("rejecting unsafe payload: executing-message validation failed",
+				"hash", envelope.ExecutionPayload.BlockHash,
+				"number", uint64(envelope.ExecutionPayload.BlockNumber),
+				"err", err)
+			return derive.NewTemporaryError(fmt.Errorf("executing-message validation failed: %w", err))
+		}
+	}
+	validationFinish := time.Now()
 
 	// Mark the new payload as valid
 	fc := eth.ForkchoiceState{
@@ -686,6 +719,7 @@ func (e *EngineController) insertUnsafePayload(ctx context.Context, envelope *et
 		"hash", envelope.ExecutionPayload.BlockHash,
 		"number", uint64(envelope.ExecutionPayload.BlockNumber),
 		"newpayload_time", common.PrettyDuration(newPayloadFinish.Sub(newPayloadStart)),
+		"validation_time", common.PrettyDuration(validationFinish.Sub(validationStart)),
 		"fcu2_time", common.PrettyDuration(fcu2Finish.Sub(fcu2Start)),
 		"total_time", common.PrettyDuration(totalTime),
 		"mgas", float64(envelope.ExecutionPayload.GasUsed)/1000000,

--- a/op-node/rollup/interop/config.go
+++ b/op-node/rollup/interop/config.go
@@ -3,6 +3,7 @@ package interop
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/ethereum/go-ethereum/log"
 
@@ -23,6 +24,13 @@ type Config struct {
 	RPCPort int
 	// RPCJwtSecretPath path of JWT secret file to apply authentication to the interop server address.
 	RPCJwtSecretPath string
+
+	// RPCOverrides is a raw comma-separated list of chainID=URL pairs used to
+	// validate executing messages against remote chains via eth_getLogs. Empty
+	// disables the RPC-based validator. Intended for light-CL operators.
+	RPCOverrides string
+	// RPCValidatorTimeout caps how long a single block's validation may take.
+	RPCValidatorTimeout time.Duration
 }
 
 func (cfg *Config) Check() error {

--- a/op-node/rollup/interop/rpc_validator.go
+++ b/op-node/rollup/interop/rpc_validator.go
@@ -1,0 +1,246 @@
+package interop
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"strings"
+	"time"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/log"
+	gethparams "github.com/ethereum/go-ethereum/params"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/ethereum-optimism/optimism/op-node/params"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	supervisortypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+)
+
+// DefaultRPCValidatorTimeout caps how long a single block's validation may take.
+// After this elapses, any outstanding remote RPC calls are cancelled and the
+// block is rejected. Operators can tune via --interop.rpc-validator.timeout.
+const DefaultRPCValidatorTimeout = 60 * time.Second
+
+// L2ReceiptsSource fetches receipts for a block from the local L2 execution engine.
+type L2ReceiptsSource interface {
+	FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Receipts, error)
+}
+
+// remoteClient is the subset of ethclient.Client used by the validator. It
+// exists so tests can substitute a fake without dialing real endpoints.
+type remoteClient interface {
+	FilterLogs(ctx context.Context, q ethereum.FilterQuery) ([]types.Log, error)
+	HeaderByHash(ctx context.Context, h common.Hash) (*types.Header, error)
+}
+
+// RPCExecMsgValidator verifies every executing message in a newly-inserted
+// unsafe block by consulting a configured remote chain's eth_getLogs endpoint.
+// It is intended for light-CL deployments where no op-supervisor is running.
+type RPCExecMsgValidator struct {
+	log        log.Logger
+	rollupCfg  *rollup.Config
+	l2         L2ReceiptsSource
+	clients    map[eth.ChainID]remoteClient
+	timeout    time.Duration
+	retryDelay time.Duration
+}
+
+// ParseRPCOverrides parses a comma-separated list of chainID=URL pairs.
+// Empty input yields an empty map (validator disabled).
+func ParseRPCOverrides(s string) (map[eth.ChainID]string, error) {
+	out := map[eth.ChainID]string{}
+	if strings.TrimSpace(s) == "" {
+		return out, nil
+	}
+	for _, pair := range strings.Split(s, ",") {
+		pair = strings.TrimSpace(pair)
+		eq := strings.IndexByte(pair, '=')
+		if eq < 0 {
+			return nil, fmt.Errorf("invalid rpc-override %q: expected chainID=URL", pair)
+		}
+		id, err := eth.ChainIDFromString(strings.TrimSpace(pair[:eq]))
+		if err != nil {
+			return nil, fmt.Errorf("invalid chainID in %q: %w", pair, err)
+		}
+		url := strings.TrimSpace(pair[eq+1:])
+		if url == "" {
+			return nil, fmt.Errorf("empty URL for chain %s", id)
+		}
+		if _, dup := out[id]; dup {
+			return nil, fmt.Errorf("duplicate chainID %s in overrides", id)
+		}
+		out[id] = url
+	}
+	return out, nil
+}
+
+// NewRPCExecMsgValidator parses overridesRaw, dials every configured remote
+// RPC up front, and returns the ready-to-use validator. Returns nil (no error)
+// if overridesRaw is empty — callers treat nil as "feature disabled" and skip
+// the hook entirely.
+func NewRPCExecMsgValidator(
+	logger log.Logger,
+	rollupCfg *rollup.Config,
+	l2 L2ReceiptsSource,
+	overridesRaw string,
+	timeout time.Duration,
+) (*RPCExecMsgValidator, error) {
+	overrides, err := ParseRPCOverrides(overridesRaw)
+	if err != nil {
+		return nil, err
+	}
+	if len(overrides) == 0 {
+		return nil, nil
+	}
+	if timeout <= 0 {
+		timeout = DefaultRPCValidatorTimeout
+	}
+	clients := make(map[eth.ChainID]remoteClient, len(overrides))
+	for id, url := range overrides {
+		c, err := ethclient.Dial(url)
+		if err != nil {
+			return nil, fmt.Errorf("dial %s (chain %s): %w", url, id, err)
+		}
+		clients[id] = c
+	}
+	return &RPCExecMsgValidator{
+		log:        logger,
+		rollupCfg:  rollupCfg,
+		l2:         l2,
+		clients:    clients,
+		timeout:    timeout,
+		retryDelay: 500 * time.Millisecond,
+	}, nil
+}
+
+// Validate scans the block's receipts for ExecutingMessage logs and verifies
+// each against the configured remote chain RPC. Returns nil if every exec
+// message validates, an error otherwise. Safe to call pre-interop (returns nil).
+func (v *RPCExecMsgValidator) Validate(ctx context.Context, envelope *eth.ExecutionPayloadEnvelope) error {
+	execTime := uint64(envelope.ExecutionPayload.Timestamp)
+	if !v.rollupCfg.IsInterop(execTime) {
+		return nil
+	}
+
+	blockHash := envelope.ExecutionPayload.BlockHash
+	_, receipts, err := v.l2.FetchReceipts(ctx, blockHash)
+	if err != nil {
+		return fmt.Errorf("fetch receipts for %s: %w", blockHash, err)
+	}
+
+	// Group executing messages by chainID so each chain's RPC is called
+	// sequentially within one goroutine but different chains run in parallel.
+	grouped := map[eth.ChainID][]supervisortypes.Message{}
+	for _, rcpt := range receipts {
+		for _, l := range rcpt.Logs {
+			if l.Address != gethparams.InteropCrossL2InboxAddress {
+				continue
+			}
+			if len(l.Topics) == 0 || l.Topics[0] != supervisortypes.ExecutingMessageEventTopic {
+				continue
+			}
+			var m supervisortypes.Message
+			if err := m.DecodeEvent(l.Topics, l.Data); err != nil {
+				return fmt.Errorf("decode executing-message log: %w", err)
+			}
+			grouped[m.Identifier.ChainID] = append(grouped[m.Identifier.ChainID], m)
+		}
+	}
+	if len(grouped) == 0 {
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, v.timeout)
+	defer cancel()
+
+	var g errgroup.Group
+	for chainID, msgs := range grouped {
+		chainID, msgs := chainID, msgs
+		g.Go(func() error { return v.validateChain(ctx, chainID, msgs, execTime) })
+	}
+	return g.Wait()
+}
+
+func (v *RPCExecMsgValidator) validateChain(ctx context.Context, chainID eth.ChainID, msgs []supervisortypes.Message, execTime uint64) error {
+	client, ok := v.clients[chainID]
+	if !ok {
+		return fmt.Errorf("no RPC configured for chain %s referenced by executing message", chainID)
+	}
+	for i := range msgs {
+		if err := v.validateOne(ctx, client, &msgs[i], execTime); err != nil {
+			return fmt.Errorf("chain %s: %w", chainID, err)
+		}
+	}
+	return nil
+}
+
+func (v *RPCExecMsgValidator) validateOne(ctx context.Context, client remoteClient, m *supervisortypes.Message, execTime uint64) error {
+	id := m.Identifier
+
+	// Temporal ordering: initiator must not be in the executor's future.
+	if id.Timestamp > execTime {
+		return fmt.Errorf("identifier timestamp %d exceeds exec block timestamp %d", id.Timestamp, execTime)
+	}
+	// Expiry window: use go-ethereum's shared interop constant.
+	if execTime-id.Timestamp > uint64(params.MessageExpiryTimeSecondsInterop) {
+		return fmt.Errorf("executing message expired (exec %d - init %d > %d)",
+			execTime, id.Timestamp, params.MessageExpiryTimeSecondsInterop)
+	}
+
+	remoteLog, remoteBlockTime, err := v.fetchRemoteLogWithRetry(ctx, client, id.Origin, id.BlockNumber, id.LogIndex)
+	if err != nil {
+		return err
+	}
+	if remoteLog == nil {
+		return fmt.Errorf("remote log not found at origin=%s block=%d logIndex=%d",
+			id.Origin, id.BlockNumber, id.LogIndex)
+	}
+	if remoteLog.Address != id.Origin {
+		return fmt.Errorf("origin mismatch: remote log address %s != identifier origin %s", remoteLog.Address, id.Origin)
+	}
+	if remoteBlockTime != id.Timestamp {
+		return fmt.Errorf("remote block timestamp %d != identifier timestamp %d", remoteBlockTime, id.Timestamp)
+	}
+	computed := crypto.Keccak256Hash(supervisortypes.LogToMessagePayload(remoteLog))
+	if computed != m.PayloadHash {
+		return fmt.Errorf("payload hash mismatch: computed=%s expected=%s", computed, m.PayloadHash)
+	}
+	return nil
+}
+
+func (v *RPCExecMsgValidator) fetchRemoteLogWithRetry(ctx context.Context, client remoteClient, origin common.Address, blockNum uint64, logIndex uint32) (*types.Log, uint64, error) {
+	bn := new(big.Int).SetUint64(blockNum)
+	q := ethereum.FilterQuery{FromBlock: bn, ToBlock: bn, Addresses: []common.Address{origin}}
+	for {
+		logs, err := client.FilterLogs(ctx, q)
+		if err == nil {
+			for i := range logs {
+				if logs[i].Index != uint(logIndex) {
+					continue
+				}
+				header, hErr := client.HeaderByHash(ctx, logs[i].BlockHash)
+				if hErr != nil {
+					err = hErr
+					break
+				}
+				return &logs[i], header.Time, nil
+			}
+			if err == nil {
+				// log not found — authoritative "no", not a retriable error
+				return nil, 0, nil
+			}
+		}
+		v.log.Warn("remote RPC error, retrying", "origin", origin, "block", blockNum, "err", err)
+		select {
+		case <-ctx.Done():
+			return nil, 0, fmt.Errorf("remote RPC exceeded validation budget: %w", ctx.Err())
+		case <-time.After(v.retryDelay):
+		}
+	}
+}

--- a/op-node/rollup/interop/rpc_validator_test.go
+++ b/op-node/rollup/interop/rpc_validator_test.go
@@ -1,0 +1,401 @@
+package interop
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"math/big"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/log"
+	gethparams "github.com/ethereum/go-ethereum/params"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	supervisortypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+)
+
+// ---- mocks ----
+
+type fakeL2 struct {
+	receipts types.Receipts
+	err      error
+}
+
+func (f *fakeL2) FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Receipts, error) {
+	return nil, f.receipts, f.err
+}
+
+type fakeRemote struct {
+	logs       []types.Log
+	headers    map[common.Hash]*types.Header
+	filterErr  error
+	failUntil  int32 // atomic: number of FilterLogs calls that should fail
+	callCount  int32
+	headerErr  error
+}
+
+func (f *fakeRemote) FilterLogs(ctx context.Context, q ethereum.FilterQuery) ([]types.Log, error) {
+	atomic.AddInt32(&f.callCount, 1)
+	if cur := atomic.LoadInt32(&f.failUntil); cur > 0 {
+		atomic.AddInt32(&f.failUntil, -1)
+		return nil, errors.New("transient rpc error")
+	}
+	if f.filterErr != nil {
+		return nil, f.filterErr
+	}
+	out := []types.Log{}
+	for _, l := range f.logs {
+		if q.FromBlock != nil && l.BlockNumber < q.FromBlock.Uint64() {
+			continue
+		}
+		if q.ToBlock != nil && l.BlockNumber > q.ToBlock.Uint64() {
+			continue
+		}
+		if len(q.Addresses) > 0 {
+			match := false
+			for _, a := range q.Addresses {
+				if l.Address == a {
+					match = true
+					break
+				}
+			}
+			if !match {
+				continue
+			}
+		}
+		out = append(out, l)
+	}
+	return out, nil
+}
+
+func (f *fakeRemote) HeaderByHash(ctx context.Context, h common.Hash) (*types.Header, error) {
+	if f.headerErr != nil {
+		return nil, f.headerErr
+	}
+	hdr, ok := f.headers[h]
+	if !ok {
+		return nil, errors.New("not found")
+	}
+	return hdr, nil
+}
+
+// ---- helpers ----
+
+// makeExecutingMessageLog builds a well-formed ExecutingMessage event log as
+// it would be emitted by CrossL2Inbox.validateMessage, pointing at the given
+// remote initiating log.
+func makeExecutingMessageLog(t *testing.T, initiating *types.Log, remoteChain eth.ChainID, blockTime uint64) *types.Log {
+	t.Helper()
+	payload := supervisortypes.LogToMessagePayload(initiating)
+	payloadHash := crypto.Keccak256Hash(payload)
+
+	// Identifier: origin (32b, left-padded), blockNumber (32b big-endian),
+	// logIndex (32b big-endian), timestamp (32b big-endian), chainID (32b).
+	data := make([]byte, 0, 32*5)
+	addrPad := make([]byte, 12)
+	data = append(data, addrPad...)
+	data = append(data, initiating.Address.Bytes()...)
+
+	bnPad := make([]byte, 24)
+	data = append(data, bnPad...)
+	data = binary.BigEndian.AppendUint64(data, initiating.BlockNumber)
+
+	liPad := make([]byte, 28)
+	data = append(data, liPad...)
+	data = binary.BigEndian.AppendUint32(data, uint32(initiating.Index))
+
+	tsPad := make([]byte, 24)
+	data = append(data, tsPad...)
+	data = binary.BigEndian.AppendUint64(data, blockTime)
+
+	chainIDBytes := remoteChain.Bytes32()
+	data = append(data, chainIDBytes[:]...)
+
+	return &types.Log{
+		Address: gethparams.InteropCrossL2InboxAddress,
+		Topics:  []common.Hash{supervisortypes.ExecutingMessageEventTopic, payloadHash},
+		Data:    data,
+	}
+}
+
+func newEnvelope(blockTime uint64) *eth.ExecutionPayloadEnvelope {
+	return &eth.ExecutionPayloadEnvelope{
+		ExecutionPayload: &eth.ExecutionPayload{
+			BlockHash: common.HexToHash("0xdead"),
+			Timestamp: eth.Uint64Quantity(blockTime),
+		},
+	}
+}
+
+func newValidator(t *testing.T, l2 L2ReceiptsSource, clients map[eth.ChainID]remoteClient) *RPCExecMsgValidator {
+	t.Helper()
+	interopTime := uint64(0)
+	cfg := &rollup.Config{InteropTime: &interopTime}
+	return &RPCExecMsgValidator{
+		log:        testlog.Logger(t, log.LvlDebug),
+		rollupCfg:  cfg,
+		l2:         l2,
+		clients:    clients,
+		timeout:    2 * time.Second,
+		retryDelay: 5 * time.Millisecond,
+	}
+}
+
+// ---- config parser tests ----
+
+func TestParseRPCOverrides(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		wantLen int
+		wantErr bool
+	}{
+		{"empty", "", 0, false},
+		{"whitespace", "   ", 0, false},
+		{"one", "10=https://a", 1, false},
+		{"two", "10=https://a,8453=https://b", 2, false},
+		{"spaces", " 10 = https://a , 8453 = https://b ", 2, false},
+		{"bad pair", "10", 0, true},
+		{"bad chainID", "abc=https://a", 0, true},
+		{"empty URL", "10=", 0, true},
+		{"dup chain", "10=a,10=b", 0, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			out, err := ParseRPCOverrides(c.in)
+			if c.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, out, c.wantLen)
+		})
+	}
+}
+
+// ---- validation tests ----
+
+func TestValidate_HappyPath(t *testing.T) {
+	remoteChain := eth.ChainIDFromUInt64(10)
+	remoteBlockTime := uint64(1000)
+	execBlockTime := remoteBlockTime + 5
+
+	initLog := &types.Log{
+		Address:     common.HexToAddress("0xabc"),
+		Topics:      []common.Hash{common.HexToHash("0x1")},
+		Data:        []byte("hello"),
+		BlockNumber: 42,
+		BlockHash:   common.HexToHash("0xbeef"),
+		Index:       7,
+	}
+	execLog := makeExecutingMessageLog(t, initLog, remoteChain, remoteBlockTime)
+
+	l2 := &fakeL2{receipts: types.Receipts{&types.Receipt{Logs: []*types.Log{execLog}}}}
+	rem := &fakeRemote{
+		logs:    []types.Log{*initLog},
+		headers: map[common.Hash]*types.Header{initLog.BlockHash: {Time: remoteBlockTime, Number: big.NewInt(42)}},
+	}
+	v := newValidator(t, l2, map[eth.ChainID]remoteClient{remoteChain: rem})
+
+	require.NoError(t, v.Validate(context.Background(), newEnvelope(execBlockTime)))
+}
+
+func TestValidate_NoExecutingMessages(t *testing.T) {
+	// Receipts with logs that don't match the Inbox or the topic: validator is a no-op.
+	unrelated := &types.Log{Address: common.HexToAddress("0xcafe"), Topics: []common.Hash{common.HexToHash("0xbeef")}}
+	l2 := &fakeL2{receipts: types.Receipts{&types.Receipt{Logs: []*types.Log{unrelated}}}}
+	rem := &fakeRemote{}
+	v := newValidator(t, l2, map[eth.ChainID]remoteClient{eth.ChainIDFromUInt64(10): rem})
+
+	require.NoError(t, v.Validate(context.Background(), newEnvelope(1000)))
+	require.EqualValues(t, 0, atomic.LoadInt32(&rem.callCount), "no RPC call expected on fast-path")
+}
+
+func TestValidate_PreInteropSkip(t *testing.T) {
+	// Interop activates at time 2000; block timestamp 1500 → skip entirely.
+	interopAt := uint64(2000)
+	cfg := &rollup.Config{InteropTime: &interopAt}
+	v := &RPCExecMsgValidator{
+		log:       testlog.Logger(t, log.LvlDebug),
+		rollupCfg: cfg,
+		// Deliberately nil l2 and clients: we must never touch them.
+		timeout: time.Second,
+	}
+	require.NoError(t, v.Validate(context.Background(), newEnvelope(1500)))
+}
+
+func TestValidate_MissingRemoteLog(t *testing.T) {
+	remoteChain := eth.ChainIDFromUInt64(10)
+	initLog := &types.Log{Address: common.HexToAddress("0xabc"), Topics: []common.Hash{common.HexToHash("0x1")}, BlockNumber: 42, Index: 7}
+	execLog := makeExecutingMessageLog(t, initLog, remoteChain, 1000)
+
+	l2 := &fakeL2{receipts: types.Receipts{&types.Receipt{Logs: []*types.Log{execLog}}}}
+	// Remote returns no matching logs at all.
+	rem := &fakeRemote{logs: nil}
+	v := newValidator(t, l2, map[eth.ChainID]remoteClient{remoteChain: rem})
+
+	err := v.Validate(context.Background(), newEnvelope(1005))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "remote log not found")
+}
+
+func TestValidate_UnknownChain(t *testing.T) {
+	remoteChain := eth.ChainIDFromUInt64(10)
+	initLog := &types.Log{Address: common.HexToAddress("0xabc"), Topics: []common.Hash{common.HexToHash("0x1")}, BlockNumber: 42, Index: 7}
+	execLog := makeExecutingMessageLog(t, initLog, remoteChain, 1000)
+
+	l2 := &fakeL2{receipts: types.Receipts{&types.Receipt{Logs: []*types.Log{execLog}}}}
+	// Configure a *different* chain's RPC than the one the message references.
+	rem := &fakeRemote{}
+	v := newValidator(t, l2, map[eth.ChainID]remoteClient{eth.ChainIDFromUInt64(8453): rem})
+
+	err := v.Validate(context.Background(), newEnvelope(1005))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no RPC configured")
+}
+
+func TestValidate_TimestampInversion(t *testing.T) {
+	remoteChain := eth.ChainIDFromUInt64(10)
+	// Initiator timestamp > executor block timestamp — invariant violation.
+	initiatorTime := uint64(2000)
+	execTime := uint64(1000)
+
+	initLog := &types.Log{Address: common.HexToAddress("0xabc"), Topics: []common.Hash{common.HexToHash("0x1")}, BlockNumber: 42, Index: 7}
+	execLog := makeExecutingMessageLog(t, initLog, remoteChain, initiatorTime)
+
+	l2 := &fakeL2{receipts: types.Receipts{&types.Receipt{Logs: []*types.Log{execLog}}}}
+	rem := &fakeRemote{}
+	v := newValidator(t, l2, map[eth.ChainID]remoteClient{remoteChain: rem})
+
+	err := v.Validate(context.Background(), newEnvelope(execTime))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exceeds exec block timestamp")
+	require.EqualValues(t, 0, atomic.LoadInt32(&rem.callCount), "remote RPC must not be called on obvious violations")
+}
+
+func TestValidate_Expired(t *testing.T) {
+	remoteChain := eth.ChainIDFromUInt64(10)
+	initiatorTime := uint64(1000)
+	// Way past the 7-day expiry window.
+	execTime := initiatorTime + 8*24*3600
+
+	initLog := &types.Log{Address: common.HexToAddress("0xabc"), Topics: []common.Hash{common.HexToHash("0x1")}, BlockNumber: 42, Index: 7}
+	execLog := makeExecutingMessageLog(t, initLog, remoteChain, initiatorTime)
+
+	l2 := &fakeL2{receipts: types.Receipts{&types.Receipt{Logs: []*types.Log{execLog}}}}
+	rem := &fakeRemote{}
+	v := newValidator(t, l2, map[eth.ChainID]remoteClient{remoteChain: rem})
+
+	err := v.Validate(context.Background(), newEnvelope(execTime))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "expired")
+}
+
+func TestValidate_PayloadHashMismatch(t *testing.T) {
+	remoteChain := eth.ChainIDFromUInt64(10)
+	remoteBlockTime := uint64(1000)
+
+	initLog := &types.Log{
+		Address:     common.HexToAddress("0xabc"),
+		Topics:      []common.Hash{common.HexToHash("0x1")},
+		Data:        []byte("hello"),
+		BlockNumber: 42, BlockHash: common.HexToHash("0xbeef"), Index: 7,
+	}
+	execLog := makeExecutingMessageLog(t, initLog, remoteChain, remoteBlockTime)
+
+	// Remote returns a *different* log at the same (origin, block, index).
+	tamperedLog := *initLog
+	tamperedLog.Data = []byte("tampered")
+
+	l2 := &fakeL2{receipts: types.Receipts{&types.Receipt{Logs: []*types.Log{execLog}}}}
+	rem := &fakeRemote{
+		logs:    []types.Log{tamperedLog},
+		headers: map[common.Hash]*types.Header{initLog.BlockHash: {Time: remoteBlockTime, Number: big.NewInt(42)}},
+	}
+	v := newValidator(t, l2, map[eth.ChainID]remoteClient{remoteChain: rem})
+
+	err := v.Validate(context.Background(), newEnvelope(remoteBlockTime+5))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "payload hash mismatch")
+}
+
+func TestValidate_RemoteBlockTimestampMismatch(t *testing.T) {
+	remoteChain := eth.ChainIDFromUInt64(10)
+	remoteBlockTime := uint64(1000)
+
+	initLog := &types.Log{Address: common.HexToAddress("0xabc"), Topics: []common.Hash{common.HexToHash("0x1")}, BlockNumber: 42, BlockHash: common.HexToHash("0xbeef"), Index: 7}
+	// Claim the identifier timestamp is remoteBlockTime, but the remote header returns a different time.
+	execLog := makeExecutingMessageLog(t, initLog, remoteChain, remoteBlockTime)
+
+	l2 := &fakeL2{receipts: types.Receipts{&types.Receipt{Logs: []*types.Log{execLog}}}}
+	rem := &fakeRemote{
+		logs:    []types.Log{*initLog},
+		headers: map[common.Hash]*types.Header{initLog.BlockHash: {Time: remoteBlockTime + 99, Number: big.NewInt(42)}},
+	}
+	v := newValidator(t, l2, map[eth.ChainID]remoteClient{remoteChain: rem})
+
+	err := v.Validate(context.Background(), newEnvelope(remoteBlockTime+5))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "remote block timestamp")
+}
+
+func TestValidate_RetryThenSucceed(t *testing.T) {
+	remoteChain := eth.ChainIDFromUInt64(10)
+	remoteBlockTime := uint64(1000)
+
+	initLog := &types.Log{Address: common.HexToAddress("0xabc"), Topics: []common.Hash{common.HexToHash("0x1")}, Data: []byte("hi"), BlockNumber: 42, BlockHash: common.HexToHash("0xbeef"), Index: 7}
+	execLog := makeExecutingMessageLog(t, initLog, remoteChain, remoteBlockTime)
+
+	l2 := &fakeL2{receipts: types.Receipts{&types.Receipt{Logs: []*types.Log{execLog}}}}
+	rem := &fakeRemote{
+		logs:    []types.Log{*initLog},
+		headers: map[common.Hash]*types.Header{initLog.BlockHash: {Time: remoteBlockTime, Number: big.NewInt(42)}},
+		// First 3 calls fail, 4th succeeds.
+		failUntil: 3,
+	}
+	v := newValidator(t, l2, map[eth.ChainID]remoteClient{remoteChain: rem})
+
+	require.NoError(t, v.Validate(context.Background(), newEnvelope(remoteBlockTime+5)))
+	require.GreaterOrEqual(t, atomic.LoadInt32(&rem.callCount), int32(4))
+}
+
+func TestValidate_TimeoutExceeded(t *testing.T) {
+	remoteChain := eth.ChainIDFromUInt64(10)
+	remoteBlockTime := uint64(1000)
+
+	initLog := &types.Log{Address: common.HexToAddress("0xabc"), Topics: []common.Hash{common.HexToHash("0x1")}, BlockNumber: 42, BlockHash: common.HexToHash("0xbeef"), Index: 7}
+	execLog := makeExecutingMessageLog(t, initLog, remoteChain, remoteBlockTime)
+
+	l2 := &fakeL2{receipts: types.Receipts{&types.Receipt{Logs: []*types.Log{execLog}}}}
+	// Remote permanently errors; validator should give up after timeout.
+	rem := &fakeRemote{filterErr: errors.New("permanent outage")}
+	v := newValidator(t, l2, map[eth.ChainID]remoteClient{remoteChain: rem})
+	v.timeout = 50 * time.Millisecond
+	v.retryDelay = 5 * time.Millisecond
+
+	start := time.Now()
+	err := v.Validate(context.Background(), newEnvelope(remoteBlockTime+5))
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "validation budget")
+	require.Less(t, elapsed, 500*time.Millisecond, "validator must bail once ctx times out")
+}
+
+func TestValidate_ReceiptsFetchError(t *testing.T) {
+	l2 := &fakeL2{err: errors.New("engine unavailable")}
+	v := newValidator(t, l2, map[eth.ChainID]remoteClient{eth.ChainIDFromUInt64(10): &fakeRemote{}})
+
+	err := v.Validate(context.Background(), newEnvelope(1000))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "fetch receipts")
+}

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -151,9 +151,11 @@ func NewConfig(ctx cliiface.Context, log log.Logger) (*config.Config, error) {
 
 func NewSupervisorEndpointConfig(ctx cliiface.Context) *interop.Config {
 	return &interop.Config{
-		RPCAddr:          ctx.String(flags.InteropRPCAddr.Name),
-		RPCPort:          ctx.Int(flags.InteropRPCPort.Name),
-		RPCJwtSecretPath: ctx.String(flags.InteropJWTSecret.Name),
+		RPCAddr:             ctx.String(flags.InteropRPCAddr.Name),
+		RPCPort:             ctx.Int(flags.InteropRPCPort.Name),
+		RPCJwtSecretPath:    ctx.String(flags.InteropJWTSecret.Name),
+		RPCOverrides:        ctx.String(flags.InteropRPCOverrides.Name),
+		RPCValidatorTimeout: ctx.Duration(flags.InteropRPCValidatorTimeout.Name),
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds an optional validator hook in `EngineController.insertUnsafePayload` between `NewPayload` and `ForkchoiceUpdate`. When `--interop.rpc-overrides=chainID=URL,...` is set, every `ExecutingMessage` log in a newly-inserted unsafe block is verified against the remote chain's `eth_getLogs`.
- Intended for light-CL operators running **without op-supervisor** — a lightweight alternative to full cross-chain verification.
- Validates: log existence at `(origin, block, logIndex)`, origin address, remote-block timestamp matches `Identifier.Timestamp`, `Identifier.Timestamp ≤ exec_block.Timestamp` (temporal ordering), message expiry window (≤ `MessageExpiryTimeSecondsInterop`), and `keccak(topics || data) == payloadHash`.
- Parallel per-chain via `errgroup`; per-block retry budget (default 60s, configurable via `--interop.rpc-validator.timeout`); rejected block does not call FCU (returns `TemporaryError` from `insertUnsafePayload`). `validation_time` logged alongside `newpayload_time` / `fcu2_time`.

## Config

```
--interop.rpc-overrides=10=https://mainnet.optimism.io,8453=https://mainnet.base.org
--interop.rpc-validator.timeout=60s   # optional
```

Empty `--interop.rpc-overrides` leaves the validator disabled (no behavior change).

## Trust model

A compliant remote full node returning a log at the claimed identifier is treated as evidence that some valid state transition produced that log. Remote chain reorgs are accepted — this validator only strengthens local soundness relative to "no cross-chain check at all." Not a substitute for cross-safety.

## Files

| File | Δ | Purpose |
|---|---|---|
| `op-node/rollup/interop/rpc_validator.go` | new (+246) | Validator, `remoteClient` interface, `ParseRPCOverrides`, retry loop |
| `op-node/rollup/engine/engine_controller.go` | +34 | `UnsafeBlockValidator` interface, field, setter, call site, metric |
| `op-node/flags/flags.go` | +18 | Two new flags in `InteropCategory` |
| `op-node/node/node.go` | +17 | Construct validator, wire into `EngineController` |
| `op-node/rollup/interop/config.go` | +8 | `RPCOverrides` / `RPCValidatorTimeout` fields |
| `op-node/service.go` | +5 | Copy flag values into `interop.Config` |
| `op-node/rollup/interop/rpc_validator_test.go` | new (+401) | 21 unit tests |

## Test plan

- [x] `go test ./op-node/rollup/interop/...` — 21/21 pass (happy path, missing log, wrong origin, bad payload hash, timestamp inversion, expired, unknown chain, retry-then-succeed, timeout exceeded, pre-interop skip, receipts fetch error, + 9 parser cases)
- [x] `go test ./op-node/rollup/engine/...` — no regressions
- [x] `go test ./op-node/node/...` — no regressions
- [x] `go build ./...` / `go vet ./op-node/...` — clean
- [ ] Live sync test against OP Mainnet + Base with real RPC overrides (TODO — run locally)
