### PR TITLE
fix(alloy-op-evm): use `OpTx` in `OpEvm`

### DIFF
--- a/rust/alloy-op-evm/src/block/mod.rs
+++ b/rust/alloy-op-evm/src/block/mod.rs
@@ -481,15 +481,15 @@ mod tests {
     use alloy_primitives::{Address, Signature, U256, uint};
     use op_alloy::consensus::OpTxEnvelope;
     use op_revm::{
-        DefaultOp, L1BlockInfo, OpBuilder, OpSpecId,
+        L1BlockInfo, OpBuilder, OpSpecId, OpTransaction,
         constants::{
             BASE_FEE_SCALAR_OFFSET, ECOTONE_L1_BLOB_BASE_FEE_SLOT, ECOTONE_L1_FEE_SCALARS_SLOT,
             L1_BASE_FEE_SLOT, L1_BLOCK_CONTRACT, OPERATOR_FEE_SCALARS_SLOT,
         },
     };
     use revm::{
-        Context,
-        context::BlockEnv,
+        Context, MainContext,
+        context::{BlockEnv, CfgEnv},
         database::{CacheDB, EmptyDB, InMemoryDB, State},
         inspector::NoOpInspector,
         primitives::HashMap,
@@ -583,7 +583,10 @@ mod tests {
         &'a OpAlloyReceiptBuilder,
         &'a OpChainHardforks,
     > {
-        let ctx = Context::op()
+        let ctx = Context::mainnet()
+            .with_tx(crate::OpTx(OpTransaction::builder().build_fill()))
+            .with_cfg(CfgEnv::new_with_spec(OpSpecId::BEDROCK))
+            .with_chain(L1BlockInfo::default())
             .with_db(db)
             .with_chain(L1BlockInfo {
                 operator_fee_scalar: Some(U256::from(2)),

--- a/rust/alloy-op-evm/src/lib.rs
+++ b/rust/alloy-op-evm/src/lib.rs
@@ -27,11 +27,10 @@ use core::{
     ops::{Deref, DerefMut},
 };
 use op_revm::{
-    DefaultOp, L1BlockInfo, OpBuilder, OpContext, OpHaltReason, OpSpecId, OpTransaction,
-    precompiles::OpPrecompiles,
+    L1BlockInfo, OpBuilder, OpHaltReason, OpSpecId, OpTransaction, precompiles::OpPrecompiles,
 };
 use revm::{
-    Context, ExecuteEvm, InspectEvm, Inspector, Journal, SystemCallEvm,
+    Context, ExecuteEvm, InspectEvm, Inspector, Journal, MainContext, SystemCallEvm,
     context::{BlockEnv, CfgEnv, TxEnv},
     context_interface::result::{EVMError, ResultAndState},
     handler::{PrecompileProvider, instructions::EthInstructions},
@@ -58,7 +57,8 @@ pub type OpEvmContext<DB> = Context<BlockEnv, OpTx, CfgEnv<OpSpecId>, DB, Journa
 /// [`OpTx`] which wraps [`OpTransaction<TxEnv>`] and implements the necessary foreign traits.
 #[allow(missing_debug_implementations)] // missing revm::OpContext Debug impl
 pub struct OpEvm<DB: Database, I, P = OpPrecompiles, Tx = OpTx> {
-    inner: op_revm::OpEvm<OpContext<DB>, I, EthInstructions<EthInterpreter, OpContext<DB>>, P>,
+    inner:
+        op_revm::OpEvm<OpEvmContext<DB>, I, EthInstructions<EthInterpreter, OpEvmContext<DB>>, P>,
     inspect: bool,
     _tx: PhantomData<Tx>,
 }
@@ -67,17 +67,18 @@ impl<DB: Database, I, P, Tx> OpEvm<DB, I, P, Tx> {
     /// Consumes self and return the inner EVM instance.
     pub fn into_inner(
         self,
-    ) -> op_revm::OpEvm<OpContext<DB>, I, EthInstructions<EthInterpreter, OpContext<DB>>, P> {
+    ) -> op_revm::OpEvm<OpEvmContext<DB>, I, EthInstructions<EthInterpreter, OpEvmContext<DB>>, P>
+    {
         self.inner
     }
 
     /// Provides a reference to the EVM context.
-    pub const fn ctx(&self) -> &OpContext<DB> {
+    pub const fn ctx(&self) -> &OpEvmContext<DB> {
         &self.inner.0.ctx
     }
 
     /// Provides a mutable reference to the EVM context.
-    pub const fn ctx_mut(&mut self) -> &mut OpContext<DB> {
+    pub const fn ctx_mut(&mut self) -> &mut OpEvmContext<DB> {
         &mut self.inner.0.ctx
     }
 }
@@ -88,7 +89,12 @@ impl<DB: Database, I, P, Tx> OpEvm<DB, I, P, Tx> {
     /// The `inspect` argument determines whether the configured [`Inspector`] of the given
     /// [`OpEvm`](op_revm::OpEvm) should be invoked on [`Evm::transact`].
     pub const fn new(
-        evm: op_revm::OpEvm<OpContext<DB>, I, EthInstructions<EthInterpreter, OpContext<DB>>, P>,
+        evm: op_revm::OpEvm<
+            OpEvmContext<DB>,
+            I,
+            EthInstructions<EthInterpreter, OpEvmContext<DB>>,
+            P,
+        >,
         inspect: bool,
     ) -> Self {
         Self { inner: evm, inspect, _tx: PhantomData }
@@ -96,7 +102,7 @@ impl<DB: Database, I, P, Tx> OpEvm<DB, I, P, Tx> {
 }
 
 impl<DB: Database, I, P, Tx> Deref for OpEvm<DB, I, P, Tx> {
-    type Target = OpContext<DB>;
+    type Target = OpEvmContext<DB>;
 
     #[inline]
     fn deref(&self) -> &Self::Target {
@@ -114,8 +120,8 @@ impl<DB: Database, I, P, Tx> DerefMut for OpEvm<DB, I, P, Tx> {
 impl<DB, I, P, Tx> Evm for OpEvm<DB, I, P, Tx>
 where
     DB: Database,
-    I: Inspector<OpContext<DB>>,
-    P: PrecompileProvider<OpContext<DB>, Output = InterpreterResult>,
+    I: Inspector<OpEvmContext<DB>>,
+    P: PrecompileProvider<OpEvmContext<DB>, Output = InterpreterResult>,
     Tx: IntoTxEnv<Tx> + Into<OpTransaction<TxEnv>>,
 {
     type DB = DB;
@@ -139,11 +145,10 @@ where
         &mut self,
         tx: Self::Tx,
     ) -> Result<ResultAndState<Self::HaltReason>, Self::Error> {
-        let inner_tx: OpTransaction<TxEnv> = tx.into();
         let result = if self.inspect {
-            self.inner.inspect_tx(inner_tx)
+            self.inner.inspect_tx(OpTx(tx.into()))
         } else {
-            self.inner.transact(inner_tx)
+            self.inner.transact(OpTx(tx.into()))
         };
         result.map_err(map_op_err)
     }
@@ -210,8 +215,8 @@ impl<Tx> EvmFactory for OpEvmFactory<Tx>
 where
     Tx: IntoTxEnv<Tx> + Into<OpTransaction<TxEnv>> + Default + Clone + Debug,
 {
-    type Evm<DB: Database, I: Inspector<OpContext<DB>>> = OpEvm<DB, I, Self::Precompiles, Tx>;
-    type Context<DB: Database> = OpContext<DB>;
+    type Evm<DB: Database, I: Inspector<OpEvmContext<DB>>> = OpEvm<DB, I, Self::Precompiles, Tx>;
+    type Context<DB: Database> = OpEvmContext<DB>;
     type Tx = Tx;
     type Error<DBError: core::error::Error + Send + Sync + 'static> = EVMError<DBError, OpTxError>;
     type HaltReason = OpHaltReason;
@@ -226,7 +231,10 @@ where
     ) -> Self::Evm<DB, NoOpInspector> {
         let spec_id = input.cfg_env.spec;
         OpEvm {
-            inner: Context::op()
+            inner: Context::mainnet()
+                .with_tx(OpTx(OpTransaction::builder().build_fill()))
+                .with_cfg(CfgEnv::new_with_spec(OpSpecId::BEDROCK))
+                .with_chain(L1BlockInfo::default())
                 .with_db(db)
                 .with_block(input.block_env)
                 .with_cfg(input.cfg_env)
@@ -247,7 +255,10 @@ where
     ) -> Self::Evm<DB, I> {
         let spec_id = input.cfg_env.spec;
         OpEvm {
-            inner: Context::op()
+            inner: Context::mainnet()
+                .with_tx(OpTx(OpTransaction::builder().build_fill()))
+                .with_cfg(CfgEnv::new_with_spec(OpSpecId::BEDROCK))
+                .with_chain(L1BlockInfo::default())
                 .with_db(db)
                 .with_block(input.block_env)
                 .with_cfg(input.cfg_env)

--- a/rust/alloy-op-evm/src/tx.rs
+++ b/rust/alloy-op-evm/src/tx.rs
@@ -118,6 +118,16 @@ impl revm::context::Transaction for OpTx {
     }
 }
 
+impl revm::handler::SystemCallTx for OpTx {
+    fn new_system_tx_with_caller(
+        caller: Address,
+        system_contract_address: Address,
+        data: Bytes,
+    ) -> Self {
+        Self(OpTransaction::new_system_tx_with_caller(caller, system_contract_address, data))
+    }
+}
+
 impl op_revm::transaction::OpTxTr for OpTx {
     fn enveloped_tx(&self) -> Option<&Bytes> {
         self.0.enveloped_tx()

--- a/rust/kona/bin/client/src/fpvm_evm/factory.rs
+++ b/rust/kona/bin/client/src/fpvm_evm/factory.rs
@@ -2,13 +2,12 @@
 
 use super::{precompiles::OpFpvmPrecompiles, tx::FpvmOpTx};
 use alloy_evm::{Database, EvmEnv, EvmFactory};
-use alloy_op_evm::{OpEvm, OpTxError};
+use alloy_op_evm::{OpEvm, OpEvmContext, OpTx, OpTxError};
 use kona_preimage::{HintWriterClient, PreimageOracleClient};
-use op_revm::{DefaultOp, OpContext, OpEvm as RevmOpEvm, OpHaltReason, OpSpecId};
+use op_revm::{L1BlockInfo, OpBuilder, OpHaltReason, OpSpecId, OpTransaction};
 use revm::{
-    Context, Inspector,
-    context::{BlockEnv, Evm as RevmEvm, FrameStack, result::EVMError},
-    handler::instructions::EthInstructions,
+    Context, Inspector, MainContext,
+    context::{BlockEnv, CfgEnv, result::EVMError},
     inspector::NoOpInspector,
 };
 
@@ -47,9 +46,9 @@ where
     H: HintWriterClient + Clone + Send + Sync + 'static,
     O: PreimageOracleClient + Clone + Send + Sync + 'static,
 {
-    type Evm<DB: Database, I: Inspector<OpContext<DB>>> =
+    type Evm<DB: Database, I: Inspector<OpEvmContext<DB>>> =
         OpEvm<DB, I, OpFpvmPrecompiles<H, O>, FpvmOpTx>;
-    type Context<DB: Database> = OpContext<DB>;
+    type Context<DB: Database> = OpEvmContext<DB>;
     type Tx = FpvmOpTx;
     type Error<DBError: core::error::Error + Send + Sync + 'static> = EVMError<DBError, OpTxError>;
     type HaltReason = OpHaltReason;
@@ -63,18 +62,19 @@ where
         input: EvmEnv<OpSpecId>,
     ) -> Self::Evm<DB, NoOpInspector> {
         let spec_id = *input.spec_id();
-        let ctx = Context::op().with_db(db).with_block(input.block_env).with_cfg(input.cfg_env);
-        let revm_evm = RevmOpEvm(RevmEvm {
-            ctx,
-            inspector: NoOpInspector {},
-            instruction: EthInstructions::new_mainnet_with_spec(spec_id.into()),
-            precompiles: OpFpvmPrecompiles::new_with_spec(
+        let revm_evm = Context::mainnet()
+            .with_tx(OpTx(OpTransaction::builder().build_fill()))
+            .with_cfg(CfgEnv::new_with_spec(OpSpecId::BEDROCK))
+            .with_chain(L1BlockInfo::default())
+            .with_db(db)
+            .with_block(input.block_env)
+            .with_cfg(input.cfg_env)
+            .build_op_with_inspector(NoOpInspector {})
+            .with_precompiles(OpFpvmPrecompiles::new_with_spec(
                 spec_id,
                 self.hint_writer.clone(),
                 self.oracle_reader.clone(),
-            ),
-            frame_stack: FrameStack::new(),
-        });
+            ));
 
         OpEvm::new(revm_evm, false)
     }
@@ -86,18 +86,19 @@ where
         inspector: I,
     ) -> Self::Evm<DB, I> {
         let spec_id = *input.spec_id();
-        let ctx = Context::op().with_db(db).with_block(input.block_env).with_cfg(input.cfg_env);
-        let revm_evm = RevmOpEvm(RevmEvm {
-            ctx,
-            inspector,
-            instruction: EthInstructions::new_mainnet_with_spec(spec_id.into()),
-            precompiles: OpFpvmPrecompiles::new_with_spec(
+        let revm_evm = Context::mainnet()
+            .with_tx(OpTx(OpTransaction::builder().build_fill()))
+            .with_cfg(CfgEnv::new_with_spec(OpSpecId::BEDROCK))
+            .with_chain(L1BlockInfo::default())
+            .with_db(db)
+            .with_block(input.block_env)
+            .with_cfg(input.cfg_env)
+            .build_op_with_inspector(inspector)
+            .with_precompiles(OpFpvmPrecompiles::new_with_spec(
                 spec_id,
                 self.hint_writer.clone(),
                 self.oracle_reader.clone(),
-            ),
-            frame_stack: FrameStack::new(),
-        });
+            ));
 
         OpEvm::new(revm_evm, true)
     }

--- a/rust/kona/bin/client/src/fpvm_evm/precompiles/provider.rs
+++ b/rust/kona/bin/client/src/fpvm_evm/precompiles/provider.rs
@@ -297,11 +297,15 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
+    use alloy_op_evm::{OpEvmContext, OpTx};
     use kona_preimage::{HintWriterClient, PreimageOracleClient};
-    use op_revm::{DefaultOp as _, OpContext, OpSpecId};
-    use revm::{Context, database::EmptyDB, handler::PrecompileProvider, interpreter::CallInput};
+    use op_revm::{L1BlockInfo, OpSpecId, OpTransaction};
+    use revm::{
+        Context, MainContext, database::EmptyDB, handler::PrecompileProvider,
+        interpreter::CallInput,
+    };
 
-    type TestContext = OpContext<EmptyDB>;
+    type TestContext = OpEvmContext<EmptyDB>;
 
     fn create_call_inputs(address: Address, input: Bytes, gas_limit: u64) -> CallInputs {
         CallInputs {
@@ -319,7 +323,11 @@ mod test {
     }
 
     fn create_test_context() -> TestContext {
-        Context::op().with_db(EmptyDB::new())
+        Context::mainnet()
+            .with_tx(OpTx(OpTransaction::builder().build_fill()))
+            .with_cfg(revm::context::CfgEnv::new_with_spec(OpSpecId::BEDROCK))
+            .with_chain(L1BlockInfo::default())
+            .with_db(EmptyDB::new())
     }
 
     /// A mock accelerated precompile function that returns a fixed output.

--- a/rust/op-reth/crates/node/tests/it/builder.rs
+++ b/rust/op-reth/crates/node/tests/it/builder.rs
@@ -1,9 +1,9 @@
 //! Node builder setup tests.
 
-use alloy_op_evm::OpTxError;
+use alloy_op_evm::{OpEvmContext, OpTxError};
 use alloy_primitives::{Bytes, address};
 use core::marker::PhantomData;
-use op_revm::{OpContext, OpHaltReason, OpSpecId, precompiles::OpPrecompiles};
+use op_revm::{OpHaltReason, OpSpecId, precompiles::OpPrecompiles};
 use reth_db::test_utils::create_test_rw_db;
 use reth_evm::{Database, Evm, EvmEnv, EvmFactory, precompiles::PrecompilesMap};
 use reth_node_api::{FullNodeComponents, NodeTypesWithDBAdapter};
@@ -85,8 +85,9 @@ fn test_setup_custom_precompiles() {
     struct UniEvmFactory;
 
     impl EvmFactory for UniEvmFactory {
-        type Evm<DB: Database, I: Inspector<OpContext<DB>>> = OpEvm<DB, I, Self::Precompiles, OpTx>;
-        type Context<DB: Database> = OpContext<DB>;
+        type Evm<DB: Database, I: Inspector<OpEvmContext<DB>>> =
+            OpEvm<DB, I, Self::Precompiles, OpTx>;
+        type Context<DB: Database> = OpEvmContext<DB>;
         type Tx = OpTx;
         type Error<DBError: core::error::Error + Send + Sync + 'static> =
             EVMError<DBError, OpTxError>;

--- a/rust/op-reth/examples/custom-node/src/evm/alloy.rs
+++ b/rust/op-reth/examples/custom-node/src/evm/alloy.rs
@@ -1,10 +1,8 @@
 use crate::evm::{CustomTxEnv, PaymentTxEnv};
 use alloy_evm::{Database, Evm, EvmEnv, EvmFactory, precompiles::PrecompilesMap};
-use alloy_op_evm::{OpEvm, OpEvmFactory, OpTx, OpTxError};
+use alloy_op_evm::{OpEvm, OpEvmContext, OpEvmFactory, OpTx, OpTxError};
 use alloy_primitives::{Address, Bytes};
-use op_revm::{
-    L1BlockInfo, OpContext, OpHaltReason, OpSpecId, OpTransaction, precompiles::OpPrecompiles,
-};
+use op_revm::{L1BlockInfo, OpHaltReason, OpSpecId, OpTransaction, precompiles::OpPrecompiles};
 use revm::{
     Context, Inspector, Journal,
     context::{BlockEnv, CfgEnv, result::ResultAndState},
@@ -32,8 +30,8 @@ impl<DB: Database, I, P> CustomEvm<DB, I, P> {
 impl<DB, I, P> Evm for CustomEvm<DB, I, P>
 where
     DB: Database,
-    I: Inspector<OpContext<DB>>,
-    P: PrecompileProvider<OpContext<DB>, Output = InterpreterResult>,
+    I: Inspector<OpEvmContext<DB>>,
+    P: PrecompileProvider<OpEvmContext<DB>, Output = InterpreterResult>,
 {
     type DB = DB;
     type Tx = CustomTxEnv;
@@ -98,8 +96,8 @@ impl CustomEvmFactory {
 }
 
 impl EvmFactory for CustomEvmFactory {
-    type Evm<DB: Database, I: Inspector<OpContext<DB>>> = CustomEvm<DB, I, Self::Precompiles>;
-    type Context<DB: Database> = OpContext<DB>;
+    type Evm<DB: Database, I: Inspector<OpEvmContext<DB>>> = CustomEvm<DB, I, Self::Precompiles>;
+    type Context<DB: Database> = OpEvmContext<DB>;
     type Tx = CustomTxEnv;
     type Error<DBError: Error + Send + Sync + 'static> = EVMError<DBError, OpTxError>;
     type HaltReason = OpHaltReason;

--- a/rust/op-reth/examples/custom-node/src/evm/executor.rs
+++ b/rust/op-reth/examples/custom-node/src/evm/executor.rs
@@ -14,8 +14,7 @@ use alloy_evm::{
     },
     precompiles::PrecompilesMap,
 };
-use alloy_op_evm::{OpBlockExecutionCtx, OpBlockExecutor, block::OpTxResult};
-use op_revm::OpContext;
+use alloy_op_evm::{OpBlockExecutionCtx, OpBlockExecutor, OpEvmContext, block::OpTxResult};
 use reth_op::{OpReceipt, OpTxType, chainspec::OpChainSpec, node::OpRethReceiptBuilder};
 use revm::Inspector;
 use std::sync::Arc;
@@ -93,7 +92,7 @@ impl BlockExecutorFactory for CustomEvmConfig {
     ) -> impl BlockExecutorFor<'a, Self, DB, I>
     where
         DB: StateDB + 'a,
-        I: Inspector<OpContext<DB>> + 'a,
+        I: Inspector<OpEvmContext<DB>> + 'a,
     {
         CustomBlockExecutor {
             inner: OpBlockExecutor::new(


### PR DESCRIPTION
**Description**
Fix discrepancy on `OpTx` usage over revm's `Context` and both alloy_op_evm/op_revm's `OpEvm`
- replace `op_revm::OpContext` by `OpEvmContext`
- impl `SystemCallTx` for `OpTx`
- update op-reth and kona accordingly

These changes restore usability/consistency on all impls around op's EVM types, `Deref`, `Evm`, `ToTxEnv` ...