### PR TITLE
op-reth: serialize proofs-history ExEx writes to fix flaky TestSequencingWindowExpiry

### DIFF
--- a/rust/op-reth/crates/exex/src/lib.rs
+++ b/rust/op-reth/crates/exex/src/lib.rs
@@ -20,7 +20,10 @@ use reth_optimism_trie::{
 };
 use reth_provider::{BlockNumReader, BlockReader, TransactionVariant};
 use reth_trie::{HashedPostStateSorted, SortedTrieData, updates::TrieUpdatesSorted};
-use std::{sync::Arc, time::Duration};
+use std::{
+    sync::{Arc, Mutex},
+    time::Duration,
+};
 use tokio::{sync::watch, task, time};
 use tracing::{debug, error, info};
 
@@ -101,6 +104,7 @@ where
             proofs_history_window: self.proofs_history_window,
             proofs_history_prune_interval: self.proofs_history_prune_interval,
             verification_interval: self.verification_interval,
+            write_lock: Arc::new(Mutex::new(())),
         }
     }
 }
@@ -190,6 +194,14 @@ where
     /// If 0, verification is disabled (always use fast path when available).
     /// If 1, verification is always enabled (always execute blocks).
     verification_interval: u64,
+    /// Serializes write critical sections between the main notification loop and the background
+    /// sync task. Both writers must hold this lock while reading the current `latest_stored`
+    /// block and committing new updates so their decisions cannot be invalidated by an
+    /// interleaved write from the other task. Without it, both writers can independently snapshot
+    /// the same `latest_stored`, decide to append the next block, and the second commit fails the
+    /// storage layer's append-only parent-hash check, which previously crashed the ExEx and the
+    /// node along with it.
+    write_lock: Arc<Mutex<()>>,
 }
 
 impl<Node, Storage> OpProofsExEx<Node, Storage>
@@ -304,6 +316,7 @@ where
         let task_storage = self.storage.clone();
         let task_provider = self.ctx.provider().clone();
         let task_evm_config = self.ctx.evm_config().clone();
+        let task_write_lock = self.write_lock.clone();
 
         self.ctx.task_executor().spawn_critical_task(
             "optimism::exex::proofs_storage_sync_loop",
@@ -311,7 +324,14 @@ where
                 let storage = task_storage.clone();
                 let task_collector =
                     LiveTrieCollector::new(task_evm_config, task_provider.clone(), &storage);
-                Self::sync_loop(sync_target_rx, task_storage, task_provider, &task_collector).await;
+                Self::sync_loop(
+                    sync_target_rx,
+                    task_storage,
+                    task_provider,
+                    &task_collector,
+                    task_write_lock,
+                )
+                .await;
             },
         );
 
@@ -324,11 +344,16 @@ where
         storage: OpProofsStorage<Storage>,
         provider: Node::Provider,
         collector: &LiveTrieCollector<'_, Node::Evm, Node::Provider, Storage>,
+        write_lock: Arc<Mutex<()>>,
     ) {
         debug!(target: "optimism::exex", "Starting proofs storage sync loop");
 
         loop {
             let target = *sync_target_rx.borrow_and_update();
+
+            // Snapshot `latest` outside the write lock — the lock is reacquired per-block inside
+            // `process_batch` to keep each block's read-and-write atomic against the main task
+            // without holding the lock for the entire batch.
             let latest = match storage.provider_ro().and_then(|p| p.get_latest_block_number()) {
                 Ok(Some((n, _))) => n,
                 Ok(None) => {
@@ -347,9 +372,14 @@ where
             }
 
             // Process one batch
-            if let Err(e) =
-                Self::process_batch(latest, target, &provider, collector, SYNC_BLOCKS_BATCH_SIZE)
-            {
+            if let Err(e) = Self::process_batch(
+                latest,
+                target,
+                &provider,
+                collector,
+                SYNC_BLOCKS_BATCH_SIZE,
+                &write_lock,
+            ) {
                 error!(target: "optimism::exex", error = ?e, "Batch processing failed");
             }
 
@@ -359,13 +389,17 @@ where
         }
     }
 
-    /// Process a batch of blocks from start to target (up to `batch_size`)
+    /// Process a batch of blocks from start to target (up to `batch_size`).
+    ///
+    /// `write_lock` is acquired around each block's execute-and-store so the main notification
+    /// task can interleave between blocks without observing or producing a torn state.
     fn process_batch(
         start: u64,
         target: u64,
         provider: &Node::Provider,
         collector: &LiveTrieCollector<'_, Node::Evm, Node::Provider, Storage>,
         batch_size: usize,
+        write_lock: &Mutex<()>,
     ) -> eyre::Result<()> {
         let end = (start + batch_size as u64).min(target);
         debug!(
@@ -380,6 +414,10 @@ where
                 .recovered_block(block_num.into(), TransactionVariant::NoHash)?
                 .ok_or_else(|| eyre::eyre!("Missing block {}", block_num))?;
 
+            let _guard = match write_lock.lock() {
+                Ok(g) => g,
+                Err(poisoned) => poisoned.into_inner(),
+            };
             collector.execute_and_store_block_updates(&block)?;
         }
 
@@ -392,6 +430,17 @@ where
         collector: &LiveTrieCollector<'_, Node::Evm, Node::Provider, Storage>,
         sync_target_tx: &watch::Sender<u64>,
     ) -> eyre::Result<()> {
+        // Hold the write lock for the entire read-and-write critical section: the
+        // `latest_stored` snapshot we read here drives every storage decision in the handlers
+        // below, and the storage layer's append-only check uses the same value at commit time.
+        // Without the lock, the background sync task can interleave writes between this read and
+        // our commit, causing the append-only check to reject our write with `OutOfOrder` —
+        // which previously crashed the ExEx and brought the node down.
+        let _write_guard = match self.write_lock.lock() {
+            Ok(g) => g,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+
         let latest_stored = match self.storage.provider_ro()?.get_latest_block_number()? {
             Some((n, _)) => n,
             None => {


### PR DESCRIPTION
Fixes ethereum-optimism/optimism#20212

## Summary

`TestSequencingWindowExpiry` (acceptance test, `memory-all-kona-op-reth` job) was failing with `expiry_test.go:125 Condition never satisfied — expecting CL to sync cross-safe data`. The Go assertion is a downstream symptom; the real bug is in the op-reth `proofs-history` ExEx, which panicked mid-test, took down the sequencer, and prevented the supernode from making cross-safe progress.

Failing CI run: https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/123106/workflows/a439de60-69c4-431d-86a3-254d3e93abae/jobs/4871228/tests

## Root cause

Two tasks in `OpProofsExEx` write to the same MDBX storage concurrently:

1. **Main notification task** — `handle_notification` reads `latest_stored` via a read-only tx, then opens a fresh write tx inside `store_block_updates` (`rust/op-reth/crates/trie/src/live.rs:134`).
2. **Background `sync_loop`** — `process_batch` reads its own `latest` snapshot and calls `execute_and_store_block_updates` per block.

The only cross-writer serialization was the MDBX append-only check in `store_trie_updates_append_only_inner` (`rust/op-reth/crates/trie/src/db/store.rs:526–541`), which returns `OutOfOrder` when `latest_block_hash != parent`. Between a writer's read-tx snapshot and its write-tx acquisition, MDBX serializes writers — so the other task can commit blocks and invalidate the snapshot.

When `TestSequencingWindowExpiry` triggers a window-expiry reorg at block 33, `sync_target_tx` still points at the old high-water mark. `sync_loop` drains toward it while new sequential `ChainCommitted` notifications arrive. The race:

- Main task enters `handle_notification`, snapshots `latest_stored = hash(35)`, decides to append block 36, blocks on MDBX write-tx acquisition.
- `sync_loop` commits 36, 37, 38 in the interim.
- Main task finally acquires the write tx; append-only check sees `latest_block_hash = hash(38)` vs `parent = hash(35)` and returns `OutOfOrder`.
- On the main-task path this error propagates through `run()`, which the ExEx framework turns into a fatal `Critical task \`exex\` panicked`. Sequencer shuts down. Supernode logs `error determining l2 block at given timestamp ... not found`. `Eventually` at `expiry_test.go:125` times out.

CI log smoking gun: at `10:51:29.259` `sync_loop` already hit a **non-fatal** \`Batch processing failed: Block 35 is out of order\` (logged at `exex/src/lib.rs:383`), confirming the two writers were actively racing. ~250ms later the ordering flipped and the main-task path hit the fatal panic.

Hashes from the log:
- `0x8475…347a6a` = block 35
- `0x2cdd…2154bd` = block 38
- Panic: \`Block 36, parent=0x8475 (35), latest stored=0x2cdd (38)\` — i.e. stored state raced 2 blocks ahead of what the main task was about to write.

## Why flaky, not consistent

The race requires a specific interleaving: a gap-triggering `ChainCommitted` spawns sync via `sync_target_tx`, followed by sequential `ChainCommitted`s while `sync_loop` is mid-batch. Depends on tokio task scheduling. `TestSequencingWindowExpiry` reliably produces the notification storm (window-expiry reorg + recovery-mode block extension), but the interleaving is timing-sensitive — CircleCI Insights reports \`times_flaked=1\`.

## Fix

Add `write_lock: Arc<std::sync::Mutex<()>>` to `OpProofsExEx`, plumbed through `spawn_sync_task` → `sync_loop` → `process_batch`. Acquire it:

- In `handle_notification` **over the entire handler** — held across the `latest_stored` read AND all downstream writes. This makes the fatal main-task race structurally impossible.
- In `process_batch` **per block** inside the loop — preserves `sync_loop`'s existing error-and-continue behavior on `OutOfOrder` (non-fatal, logged, retried next pass).

`std::sync::Mutex` is correct: no `.await` inside the locked region. No lock-ordering or re-entrancy paths found. The existing MDBX-level append-only check remains as a correctness backstop.

## Files changed

- `rust/op-reth/crates/exex/src/lib.rs` — add `write_lock`, thread through sync spawn path, acquire in `handle_notification` and `process_batch` (+55 / -6).

## Verification

- \`cargo check -p reth-optimism-exex -p reth-optimism-trie -p op-reth\` — clean
- \`cargo clippy -p reth-optimism-exex\` — zero warnings
- \`cargo test -p reth-optimism-exex --lib\` — 11/11 existing unit tests pass
- \`go vet ./op-acceptance-tests/tests/interop/seqwindow/\` — clean
- \`TestSequencingWindowExpiry\` end-to-end **not** reproduced locally — requires full devstack + built op-reth binary. The acceptance test itself exercises the patched path in CI.

## Known caveats / follow-ups

- **No regression test added.** The race is hard to unit-test (two tokio tasks + MDBX). A coarse threaded test exercising sequential-commit vs. batch-catch-up on a shared `OpProofsExEx` would lock the invariant in against future refactors. Worth doing as a follow-up.
- **State-machine smell (out of scope for this fix):** `sync_target_tx` is never reset on reorg/revert. Post-reorg, `sync_loop` races forward against new sequential `ChainCommitted` notifications — the lock makes that safe but doesn't stop the wasted work or the non-fatal `OutOfOrder` logs. A cleaner design would clamp or reset the sync target on `ChainReorged` / `ChainReverted`.
- **Lock hold time:** `handle_notification` holds the lock across `execute_and_store_block_updates`, which runs full EVM execution. Net latency is similar to pre-fix (MDBX already serialized writers); net behavior is correct.

## Test plan

- [ ] CI green, especially \`memory-all-kona-op-reth\`
- [ ] \`cargo test -p reth-optimism-exex --lib\` passes
- [ ] Watch for reappearance of \`proofs-history crashed: Block N is out of order\` on the main-task path (should be eliminated) vs. the non-fatal \`Batch processing failed\` on the sync-loop path (acceptable, already logged)

🤖 *Generated by Claude Code*