### PR TITLE
feat(op-supernode): add supernode-level prometheus metrics

### DIFF
--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -241,15 +241,15 @@ func New(
 		metrics = resources.NewSupernodeMetrics()
 	}
 	i := &Interop{
-		log:                        log,
-		chains:                     chains,
-		verifiedDB:                 verifiedDB,
-		logsDBs:                    logsDBs,
-		dataDir:                    dataDir,
-		activationTimestamp:        activationTimestamp,
-		messageExpiryWindow:        messageExpiryWindow,
-		logBackfillDepth:           logBackfillDepth,
-		metrics:                    metrics,
+		log:                 log,
+		chains:              chains,
+		verifiedDB:          verifiedDB,
+		logsDBs:             logsDBs,
+		dataDir:             dataDir,
+		activationTimestamp: activationTimestamp,
+		messageExpiryWindow: messageExpiryWindow,
+		logBackfillDepth:    logBackfillDepth,
+		metrics:             metrics,
 	}
 	// default to using the verifyInteropMessages function
 	// (can be overridden by tests)

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supernode/flags"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/activity"
 	cc "github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container"
+	"github.com/ethereum-optimism/optimism/op-supernode/supernode/resources"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/urfave/cli/v2"
@@ -178,6 +179,7 @@ type Interop struct {
 	l1Checker l1ConsistencyChecker
 
 	logBackfillDepth time.Duration
+	metrics          *resources.SupernodeMetrics
 }
 
 func (i *Interop) Name() string {
@@ -208,6 +210,7 @@ func New(
 	dataDir string,
 	l1Source l1ByNumberSource,
 	logBackfillDepth time.Duration,
+	metrics *resources.SupernodeMetrics,
 ) *Interop {
 	verifiedDB, err := OpenVerifiedDB(dataDir)
 	if err != nil {
@@ -234,15 +237,19 @@ func New(
 	if messageExpiryWindow == 0 {
 		messageExpiryWindow = defaultMessageExpiryWindow
 	}
+	if metrics == nil {
+		metrics = resources.NewSupernodeMetrics()
+	}
 	i := &Interop{
-		log:                 log,
-		chains:              chains,
-		verifiedDB:          verifiedDB,
-		logsDBs:             logsDBs,
-		dataDir:             dataDir,
-		activationTimestamp: activationTimestamp,
-		messageExpiryWindow: messageExpiryWindow,
-		logBackfillDepth:    logBackfillDepth,
+		log:                        log,
+		chains:                     chains,
+		verifiedDB:                 verifiedDB,
+		logsDBs:                    logsDBs,
+		dataDir:                    dataDir,
+		activationTimestamp:        activationTimestamp,
+		messageExpiryWindow:        messageExpiryWindow,
+		logBackfillDepth:           logBackfillDepth,
+		metrics:                    metrics,
 	}
 	// default to using the verifyInteropMessages function
 	// (can be overridden by tests)
@@ -368,6 +375,7 @@ func (i *Interop) progressAndRecord() (bool, error) {
 		return false, fmt.Errorf("get pending transition: %w", err)
 	}
 	if pending != nil {
+		i.metrics.InteropRoundDecisions.WithLabelValues(pending.Decision.String()).Inc()
 		return i.applyPendingTransition(*pending)
 	}
 
@@ -375,6 +383,7 @@ func (i *Interop) progressAndRecord() (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	i.metrics.InteropRoundDecisions.WithLabelValues(output.Decision.String()).Inc()
 	if output.Decision == DecisionWait {
 		return i.refreshCurrentL1OnWait()
 	}
@@ -565,6 +574,7 @@ func (i *Interop) applyPendingTransition(pending PendingTransition) (bool, error
 		if err := i.applyRewindPlan(*pending.Rewind); err != nil {
 			return false, fmt.Errorf("apply rewind plan: %w", err)
 		}
+		i.metrics.InteropRewinds.Inc()
 		if err := i.verifiedDB.ClearPendingTransition(); err != nil {
 			return false, fmt.Errorf("clear pending transition: %w", err)
 		}
@@ -609,6 +619,8 @@ func (i *Interop) applyPendingTransition(pending PendingTransition) (bool, error
 				i.log.Error("invalidation failed, transition preserved for retry on restart",
 					"chain", p.ChainID, "block", p.BlockID, "err", err)
 				failedAny = true
+			} else {
+				i.metrics.InteropInvalidations.WithLabelValues(p.ChainID.String()).Inc()
 			}
 		}
 		// Resume non-invalidated chains. Invalidated chains are resumed by RewindEngine.
@@ -645,6 +657,8 @@ func (i *Interop) applyPendingTransition(pending PendingTransition) (bool, error
 			return false, fmt.Errorf("clear pending transition: %w", err)
 		}
 		i.log.Info("committed verified result", "timestamp", pending.Result.Timestamp)
+		i.metrics.InteropTimestampsVerified.Inc()
+		i.metrics.InteropVerifiedTimestamp.Set(float64(pending.Result.Timestamp))
 		// L1Inclusion is the max L1 block used for derivation across all chains at this
 		// timestamp. It can exceed some chains' actual CurrentL1 — e.g. chain A derived
 		// from L1 1000 while chain B derived from L1 990. Chain B may then advance to

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -96,7 +96,7 @@ func (h *interopTestHarness) Build() *interopTestHarness {
 	for id, mock := range h.mocks {
 		chains[id] = mock
 	}
-	h.interop = New(testLogger(), h.activationTime, 0, chains, h.dataDir, nil, h.logBackfillDepth)
+	h.interop = New(testLogger(), h.activationTime, 0, chains, h.dataDir, nil, h.logBackfillDepth, nil)
 	if h.interop != nil {
 		h.interop.l1Checker = noopL1Checker{}
 		h.interop.ctx = context.Background()
@@ -137,7 +137,7 @@ func TestNew(t *testing.T) {
 				return h.WithChain(10, nil).WithChain(8453, nil).SkipBuild()
 			},
 			run: func(t *testing.T, h *interopTestHarness) {
-				interop := New(testLogger(), h.activationTime, 0, h.Chains(), h.dataDir, nil, 0)
+				interop := New(testLogger(), h.activationTime, 0, h.Chains(), h.dataDir, nil, 0, nil)
 				require.NotNil(t, interop)
 				interop.l1Checker = noopL1Checker{}
 				t.Cleanup(func() { _ = interop.Stop(context.Background()) })
@@ -161,7 +161,7 @@ func TestNew(t *testing.T) {
 				return h.WithDataDir("/nonexistent/path").SkipBuild()
 			},
 			run: func(t *testing.T, h *interopTestHarness) {
-				interop := New(testLogger(), h.activationTime, 0, h.Chains(), h.dataDir, nil, 0)
+				interop := New(testLogger(), h.activationTime, 0, h.Chains(), h.dataDir, nil, 0, nil)
 				require.Nil(t, interop)
 			},
 		},
@@ -1211,7 +1211,7 @@ func TestInterop_FullCycle(t *testing.T) {
 	mock.blockAtTimestamp = eth.L2BlockRef{Number: 500, Hash: common.HexToHash("0xL2")}
 
 	chains := map[eth.ChainID]cc.InteropChain{mock.id: mock}
-	interop := New(testLogger(), 100, 0, chains, dataDir, nil, 0)
+	interop := New(testLogger(), 100, 0, chains, dataDir, nil, 0, nil)
 	require.NotNil(t, interop)
 	interop.l1Checker = noopL1Checker{}
 	interop.ctx = context.Background()

--- a/op-supernode/supernode/chain_container/chain_container.go
+++ b/op-supernode/supernode/chain_container/chain_container.go
@@ -20,8 +20,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supernode/config"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/activity"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container/engine_controller"
-	"github.com/ethereum-optimism/optimism/op-supernode/supernode/resources"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container/virtual_node"
+	"github.com/ethereum-optimism/optimism/op-supernode/supernode/resources"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -122,8 +122,8 @@ type simpleChainContainer struct {
 	setHandler         func(chainID string, h http.Handler)    // Set the RPC handler on the router for the chain
 	addMetricsRegistry func(key string, g prometheus.Gatherer) // Set the metrics registry on the global metrics server
 	appVersion         string
-	virtualNodeFactory virtualNodeFactory          // Factory function to create virtual node (for testing)
-	rollupClient       *sources.RollupClient       // In-proc rollup RPC client bound to rpcHandler
+	virtualNodeFactory virtualNodeFactory    // Factory function to create virtual node (for testing)
+	rollupClient       *sources.RollupClient // In-proc rollup RPC client bound to rpcHandler
 	metrics            *resources.SupernodeMetrics
 
 	// verifiersMu guards writes and reads of the verifiers slice. Concurrent

--- a/op-supernode/supernode/chain_container/chain_container.go
+++ b/op-supernode/supernode/chain_container/chain_container.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supernode/config"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/activity"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container/engine_controller"
+	"github.com/ethereum-optimism/optimism/op-supernode/supernode/resources"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container/virtual_node"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
@@ -121,8 +122,9 @@ type simpleChainContainer struct {
 	setHandler         func(chainID string, h http.Handler)    // Set the RPC handler on the router for the chain
 	addMetricsRegistry func(key string, g prometheus.Gatherer) // Set the metrics registry on the global metrics server
 	appVersion         string
-	virtualNodeFactory virtualNodeFactory    // Factory function to create virtual node (for testing)
-	rollupClient       *sources.RollupClient // In-proc rollup RPC client bound to rpcHandler
+	virtualNodeFactory virtualNodeFactory          // Factory function to create virtual node (for testing)
+	rollupClient       *sources.RollupClient       // In-proc rollup RPC client bound to rpcHandler
+	metrics            *resources.SupernodeMetrics
 
 	// verifiersMu guards writes and reads of the verifiers slice. Concurrent
 	// readers (VerifiedAt, VerifierCurrentL1s) can race with the test-only
@@ -147,7 +149,11 @@ func NewChainContainer(
 	rpcHandler *oprpc.Handler,
 	setHandler func(chainID string, h http.Handler),
 	addMetricsRegistry func(key string, g prometheus.Gatherer),
+	metrics *resources.SupernodeMetrics,
 ) InteropChain {
+	if metrics == nil {
+		metrics = resources.NewSupernodeMetrics()
+	}
 	c := &simpleChainContainer{
 		vncfg:              vncfg,
 		cfg:                cfg,
@@ -160,6 +166,7 @@ func NewChainContainer(
 		addMetricsRegistry: addMetricsRegistry,
 		appVersion:         virtualNodeVersion,
 		virtualNodeFactory: defaultVirtualNodeFactory,
+		metrics:            metrics,
 	}
 	vncfg.SafeDBPath = c.subPath("safe_db")
 	vncfg.RPC = cfg.RPCConfig
@@ -314,6 +321,8 @@ func (c *simpleChainContainer) Start(ctx context.Context) error {
 			c.log.Info("chain container stop requested, stopping restart loop")
 			break
 		}
+
+		c.metrics.VNRestarts.WithLabelValues(c.chainID.String()).Inc()
 	}
 	c.log.Info("chain container exiting")
 	return nil

--- a/op-supernode/supernode/chain_container/chain_container_test.go
+++ b/op-supernode/supernode/chain_container/chain_container_test.go
@@ -20,11 +20,11 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container/engine_controller"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container/virtual_node"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/resources"
-	dto "github.com/prometheus/client_model/go"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	gethlog "github.com/ethereum/go-ethereum/log"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/require"
 )
 

--- a/op-supernode/supernode/chain_container/chain_container_test.go
+++ b/op-supernode/supernode/chain_container/chain_container_test.go
@@ -19,6 +19,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supernode/config"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container/engine_controller"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container/virtual_node"
+	"github.com/ethereum-optimism/optimism/op-supernode/supernode/resources"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -245,7 +247,7 @@ func TestChainContainer_Constructor(t *testing.T) {
 
 	t.Run("creates container with correct config", func(t *testing.T) {
 		cfg := createTestCLIConfig(t.TempDir())
-		container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil)
+		container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
 
 		require.NotNil(t, container)
 
@@ -265,7 +267,7 @@ func TestChainContainer_Constructor(t *testing.T) {
 		cfg := config.CLIConfig{
 			DataDir: dataDir,
 		}
-		container := NewChainContainer(eth.ChainIDFromUInt64(420), vncfg, log, cfg, initOverload, nil, nil, nil)
+		container := NewChainContainer(eth.ChainIDFromUInt64(420), vncfg, log, cfg, initOverload, nil, nil, nil, nil)
 
 		impl, ok := container.(*simpleChainContainer)
 		require.True(t, ok)
@@ -282,7 +284,7 @@ func TestChainContainer_Constructor(t *testing.T) {
 				ListenPort: 9545,
 			},
 		}
-		container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil)
+		container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
 
 		impl, ok := container.(*simpleChainContainer)
 		require.True(t, ok)
@@ -292,7 +294,7 @@ func TestChainContainer_Constructor(t *testing.T) {
 
 	t.Run("appVersion set correctly", func(t *testing.T) {
 		cfg := createTestCLIConfig(t.TempDir())
-		container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil)
+		container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
 		impl, ok := container.(*simpleChainContainer)
 		require.True(t, ok)
 
@@ -304,7 +306,7 @@ func TestChainContainer_Constructor(t *testing.T) {
 		cfg := config.CLIConfig{
 			DataDir: dataDir,
 		}
-		container := NewChainContainer(eth.ChainIDFromUInt64(420), vncfg, log, cfg, initOverload, nil, nil, nil)
+		container := NewChainContainer(eth.ChainIDFromUInt64(420), vncfg, log, cfg, initOverload, nil, nil, nil, nil)
 		impl, ok := container.(*simpleChainContainer)
 		require.True(t, ok)
 
@@ -329,7 +331,7 @@ func TestChainContainer_Constructor(t *testing.T) {
 		}
 
 		for _, tc := range testCases {
-			container := NewChainContainer(tc.chainID, vncfg, log, cfg, initOverload, nil, nil, nil)
+			container := NewChainContainer(tc.chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
 			impl, ok := container.(*simpleChainContainer)
 			require.True(t, ok)
 
@@ -351,7 +353,7 @@ func TestChainContainer_Lifecycle(t *testing.T) {
 	t.Run("Start respects stop flag", func(t *testing.T) {
 		log := createTestLogger(t)
 		cfg := createTestCLIConfig(t.TempDir())
-		container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil)
+		container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
 		impl, ok := container.(*simpleChainContainer)
 		require.True(t, ok)
 
@@ -378,7 +380,7 @@ func TestChainContainer_Lifecycle(t *testing.T) {
 	t.Run("Stop sets stop flag", func(t *testing.T) {
 		log := createTestLogger(t)
 		cfg := createTestCLIConfig(t.TempDir())
-		container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil)
+		container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
 		impl, ok := container.(*simpleChainContainer)
 		require.True(t, ok)
 
@@ -393,7 +395,7 @@ func TestChainContainer_Lifecycle(t *testing.T) {
 	t.Run("signals stopped channel on exit", func(t *testing.T) {
 		log := createTestLogger(t)
 		cfg := createTestCLIConfig(t.TempDir())
-		container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil)
+		container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
 		impl, ok := container.(*simpleChainContainer)
 		require.True(t, ok)
 
@@ -423,7 +425,7 @@ func TestChainContainer_Lifecycle(t *testing.T) {
 	t.Run("context cancellation stops restart loop", func(t *testing.T) {
 		log := createTestLogger(t)
 		cfg := createTestCLIConfig(t.TempDir())
-		container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil)
+		container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
 		impl, ok := container.(*simpleChainContainer)
 		require.True(t, ok)
 
@@ -464,7 +466,7 @@ func TestChainContainer_Lifecycle(t *testing.T) {
 	t.Run("Stop flag stops restart loop", func(t *testing.T) {
 		log := createTestLogger(t)
 		cfg := createTestCLIConfig(t.TempDir())
-		container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil)
+		container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
 		impl, ok := container.(*simpleChainContainer)
 		require.True(t, ok)
 
@@ -511,7 +513,7 @@ func TestChainContainer_PauseResume(t *testing.T) {
 	t.Run("Pause sets pause flag", func(t *testing.T) {
 		log := createTestLogger(t)
 		cfg := createTestCLIConfig(t.TempDir())
-		container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil)
+		container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
 		impl, ok := container.(*simpleChainContainer)
 		require.True(t, ok)
 
@@ -525,7 +527,7 @@ func TestChainContainer_PauseResume(t *testing.T) {
 	t.Run("Resume clears pause flag", func(t *testing.T) {
 		log := createTestLogger(t)
 		cfg := createTestCLIConfig(t.TempDir())
-		container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil)
+		container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
 		impl, ok := container.(*simpleChainContainer)
 		require.True(t, ok)
 
@@ -541,7 +543,7 @@ func TestChainContainer_PauseResume(t *testing.T) {
 	t.Run("paused container doesn't start VN, resumed does", func(t *testing.T) {
 		log := createTestLogger(t)
 		cfg := createTestCLIConfig(t.TempDir())
-		container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil)
+		container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
 		impl, ok := container.(*simpleChainContainer)
 		require.True(t, ok)
 
@@ -791,7 +793,7 @@ func TestChainContainer_VirtualNodeIntegration(t *testing.T) {
 	t.Run("Start creates and starts virtual node", func(t *testing.T) {
 		log := createTestLogger(t)
 		cfg := createTestCLIConfig(t.TempDir())
-		container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil)
+		container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
 		impl, ok := container.(*simpleChainContainer)
 		require.True(t, ok)
 
@@ -822,7 +824,7 @@ func TestChainContainer_VirtualNodeIntegration(t *testing.T) {
 	t.Run("auto-restart virtual node on exit", func(t *testing.T) {
 		log := createTestLogger(t)
 		cfg := createTestCLIConfig(t.TempDir())
-		container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil)
+		container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
 		impl, ok := container.(*simpleChainContainer)
 		require.True(t, ok)
 
@@ -856,10 +858,43 @@ func TestChainContainer_VirtualNodeIntegration(t *testing.T) {
 		}, 1*time.Second, 10*time.Millisecond)
 	})
 
+	t.Run("restart increments VNRestarts metric", func(t *testing.T) {
+		log := createTestLogger(t)
+		cfg := createTestCLIConfig(t.TempDir())
+		metrics := resources.NewSupernodeMetrics()
+		container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil, metrics)
+		impl, ok := container.(*simpleChainContainer)
+		require.True(t, ok)
+
+		restartCount := 0
+		mockVN := &mockVirtualNode{startSignal: make(chan struct{})}
+		mockVN.startFunc = func(ctx context.Context) error {
+			restartCount++
+			if restartCount < 3 {
+				return nil
+			}
+			<-ctx.Done()
+			return ctx.Err()
+		}
+		impl.virtualNodeFactory = func(cfg *opnodecfg.Config, log gethlog.Logger, initOverload *rollupNode.InitializationOverrides, appVersion string, superAuthority rollup.SuperAuthority) virtual_node.VirtualNode {
+			return mockVN
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+		defer cancel()
+		go func() { _ = container.Start(ctx) }()
+
+		require.Eventually(t, func() bool { return restartCount >= 3 }, 1*time.Second, 10*time.Millisecond)
+		// The first start is not a restart; restarts 2 and 3 should be counted.
+		var dto dto.Metric
+		require.NoError(t, metrics.VNRestarts.WithLabelValues(chainID.String()).Write(&dto))
+		require.Equal(t, float64(2), dto.GetCounter().GetValue())
+	})
+
 	t.Run("Stop calls virtual node Stop", func(t *testing.T) {
 		log := createTestLogger(t)
 		cfg := createTestCLIConfig(t.TempDir())
-		container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil)
+		container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
 		impl, ok := container.(*simpleChainContainer)
 		require.True(t, ok)
 
@@ -905,7 +940,7 @@ func TestChainContainer_VirtualNodeIntegration(t *testing.T) {
 
 		log := createTestLogger(t)
 		cfg := createTestCLIConfig(t.TempDir())
-		container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, setHandler, nil)
+		container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, setHandler, nil, nil)
 		impl, ok := container.(*simpleChainContainer)
 		require.True(t, ok)
 
@@ -948,7 +983,7 @@ func TestChainContainer_VerifiedAt(t *testing.T) {
 			verifiedAtTimestampErr:    nil,
 		}
 
-		container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil)
+		container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
 		impl, ok := container.(*simpleChainContainer)
 		require.True(t, ok)
 
@@ -995,7 +1030,7 @@ func TestChainContainer_OptimisticAt_ErrL1AtSafeHeadNotFound(t *testing.T) {
 	cfg := createTestCLIConfig(t.TempDir())
 	initOverload := &rollupNode.InitializationOverrides{}
 
-	container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil)
+	container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
 	impl, ok := container.(*simpleChainContainer)
 	require.True(t, ok)
 
@@ -1063,7 +1098,7 @@ func TestChainContainer_OptimisticAt_ErrL1AtSafeHeadUnavailable(t *testing.T) {
 	cfg := createTestCLIConfig(t.TempDir())
 	initOverload := &rollupNode.InitializationOverrides{}
 
-	container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil)
+	container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
 	impl, ok := container.(*simpleChainContainer)
 	require.True(t, ok)
 
@@ -1178,7 +1213,7 @@ func TestChainContainer_LocalSafeBlockAtTimestamp(t *testing.T) {
 		vncfg.Rollup.Genesis.L2Time = tc.genesisTime
 		vncfg.Rollup.BlockTime = tc.blockTime
 
-		container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil)
+		container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
 		impl, ok := container.(*simpleChainContainer)
 		require.True(t, ok)
 
@@ -1336,7 +1371,7 @@ func TestChainContainer_SyncStatus_UninitializedVirtualNode(t *testing.T) {
 	cfg := createTestCLIConfig(t.TempDir())
 	initOverload := &rollupNode.InitializationOverrides{}
 
-	container := NewChainContainer(chainID, createTestVNConfig(), log, cfg, initOverload, nil, nil, nil)
+	container := NewChainContainer(chainID, createTestVNConfig(), log, cfg, initOverload, nil, nil, nil, nil)
 
 	status, err := container.SyncStatus(context.Background())
 	require.Nil(t, status)
@@ -1356,7 +1391,7 @@ func TestChainContainer_BlockNumberToTimestamp_RespectsGenesisBlockNumber(t *tes
 	vncfg.Rollup.Genesis.L2.Number = 100
 	vncfg.Rollup.BlockTime = 2
 
-	container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil)
+	container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil, nil)
 	impl, ok := container.(*simpleChainContainer)
 	require.True(t, ok)
 

--- a/op-supernode/supernode/resources/metrics_fan_in.go
+++ b/op-supernode/supernode/resources/metrics_fan_in.go
@@ -21,6 +21,7 @@ type MetricsFanIn struct {
 	mu           sync.RWMutex
 	numGatherers int
 	gm           map[string]prometheus.Gatherer // keyed by decimal chain ID
+	extra        []prometheus.Gatherer          // additional gatherers (e.g. supernode-level metrics)
 	handler      http.Handler
 }
 
@@ -32,16 +33,31 @@ func NewMetricsFanIn(numGatherers int) *MetricsFanIn {
 		handler:      promhttp.HandlerFor(emptyRegistry, promhttp.HandlerOpts{})}
 }
 
+// AddGatherer registers an additional prometheus.Gatherer (e.g. SupernodeMetrics)
+// to be served alongside per-chain metrics. Nil gatherers are ignored.
+func (r *MetricsFanIn) AddGatherer(g prometheus.Gatherer) {
+	if g == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.extra = append(r.extra, g)
+	r.rebuildHandlerLocked()
+}
+
 func (r *MetricsFanIn) SetMetricsRegistry(key string, g prometheus.Gatherer) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.gm[key] = g
+	r.rebuildHandlerLocked()
+}
 
-	gs := make(prometheus.Gatherers, 0, r.numGatherers)
+func (r *MetricsFanIn) rebuildHandlerLocked() {
+	gs := make(prometheus.Gatherers, 0, r.numGatherers+len(r.extra))
 	for _, gr := range r.gm {
 		gs = append(gs, gr)
 	}
-
+	gs = append(gs, r.extra...)
 	r.handler = promhttp.HandlerFor(gs, promhttp.HandlerOpts{})
 }
 

--- a/op-supernode/supernode/resources/supernode_metrics.go
+++ b/op-supernode/supernode/resources/supernode_metrics.go
@@ -1,0 +1,71 @@
+package resources
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// SupernodeMetrics holds supernode-level metrics that outlive individual
+// virtual node restarts. Created once in supernode.New() and shared with
+// chain containers and activities. Callers that receive nil default to
+// NewSupernodeMetrics(), which creates functional counters not attached
+// to any scraped registry (safe for tests).
+type SupernodeMetrics struct {
+	VNRestarts                *prometheus.CounterVec
+	InteropTimestampsVerified prometheus.Counter
+	InteropInvalidations      *prometheus.CounterVec
+	InteropVerifiedTimestamp  prometheus.Gauge
+	InteropRoundDecisions     *prometheus.CounterVec
+	InteropRewinds            prometheus.Counter
+
+	registry *prometheus.Registry
+}
+
+// NewSupernodeMetrics creates a new SupernodeMetrics backed by a dedicated registry.
+func NewSupernodeMetrics() *SupernodeMetrics {
+	reg := prometheus.NewRegistry()
+	m := &SupernodeMetrics{
+		VNRestarts: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: "supernode",
+			Name:      "virtual_node_restarts_total",
+			Help:      "Total number of virtual node restarts.",
+		}, []string{"chain_id"}),
+		InteropTimestampsVerified: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: "supernode",
+			Name:      "interop_timestamps_verified_total",
+			Help:      "Total number of timestamps successfully verified by interop.",
+		}),
+		InteropInvalidations: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: "supernode",
+			Name:      "interop_invalidations_total",
+			Help:      "Total number of successful block invalidations triggered by interop.",
+		}, []string{"chain_id"}),
+		InteropVerifiedTimestamp: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: "supernode",
+			Name:      "interop_verified_timestamp",
+			Help:      "Latest L2 timestamp successfully verified by interop.",
+		}),
+		InteropRoundDecisions: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: "supernode",
+			Name:      "interop_round_decisions_total",
+			Help:      "Total number of interop round decisions by type.",
+		}, []string{"decision"}),
+		InteropRewinds: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: "supernode",
+			Name:      "interop_rewinds_total",
+			Help:      "Total number of interop rewinds due to L1 consistency failures.",
+		}),
+		registry: reg,
+	}
+	reg.MustRegister(
+		m.VNRestarts,
+		m.InteropTimestampsVerified,
+		m.InteropInvalidations,
+		m.InteropVerifiedTimestamp,
+		m.InteropRoundDecisions,
+		m.InteropRewinds,
+	)
+	return m
+}
+
+// Registry returns the prometheus gatherer for these metrics.
+func (m *SupernodeMetrics) Registry() prometheus.Gatherer {
+	return m.registry
+}

--- a/op-supernode/supernode/supernode.go
+++ b/op-supernode/supernode/supernode.go
@@ -50,8 +50,9 @@ type Supernode struct {
 	httpServer      *httputil.HTTPServer
 	rpcRouter       *resources.Router
 	// Metrics router/server for per-chain metrics
-	metrics      *resources.MetricsService
-	metricsFanIn *resources.MetricsFanIn
+	metrics          *resources.MetricsService
+	metricsFanIn     *resources.MetricsFanIn
+	supernodeMetrics *resources.SupernodeMetrics
 	// cached address when available
 	rpcAddr string
 
@@ -87,6 +88,8 @@ func New(ctx context.Context, log gethlog.Logger, version string, requestStop co
 	s.rpcRouter.SetRootHandler(s.rootRPC)
 	// Build metrics router; attach per-chain registries later
 	s.metricsFanIn = resources.NewMetricsFanIn(len(cfg.Chains))
+	s.supernodeMetrics = resources.NewSupernodeMetrics()
+	s.metricsFanIn.AddGatherer(s.supernodeMetrics.Registry())
 	for _, id := range cfg.Chains {
 		chainID := eth.ChainIDFromUInt64(id)
 		initOverrides := &rollupNode.InitializationOverrides{
@@ -98,7 +101,7 @@ func New(ctx context.Context, log gethlog.Logger, version string, requestStop co
 			log.Error("missing virtual node config for chain", "chain", id)
 			continue
 		}
-		container := cc.NewChainContainer(chainID, vnCfgs[chainID], log, *cfg, initOverrides, nil, s.rpcRouter.SetHandler, s.metricsFanIn.SetMetricsRegistry)
+		container := cc.NewChainContainer(chainID, vnCfgs[chainID], log, *cfg, initOverrides, nil, s.rpcRouter.SetHandler, s.metricsFanIn.SetMetricsRegistry, s.supernodeMetrics)
 		s.chains[chainID] = container
 	}
 
@@ -137,7 +140,7 @@ func New(ctx context.Context, log gethlog.Logger, version string, requestStop co
 				break
 			}
 		}
-		interopActivity := interop.New(log.New("activity", "interop"), *interopActivationTimestamp, msgExpiryWindow, s.chains, cfg.DataDir, s.l1Client, cfg.InteropLogBackfillDepth)
+		interopActivity := interop.New(log.New("activity", "interop"), *interopActivationTimestamp, msgExpiryWindow, s.chains, cfg.DataDir, s.l1Client, cfg.InteropLogBackfillDepth, s.supernodeMetrics)
 		s.activities = append(s.activities, interopActivity)
 		for _, chain := range s.chains {
 			chain.RegisterVerifier(interopActivity)

--- a/op-supernode/supernode/supernode_test_access.go
+++ b/op-supernode/supernode/supernode_test_access.go
@@ -92,6 +92,7 @@ func (s *Supernode) RestartInteropActivity(wipeLogsDBs bool) error {
 		s.cfg.DataDir,
 		s.l1Client,
 		s.cfg.InteropLogBackfillDepth,
+		s.supernodeMetrics,
 	)
 	if newIA == nil {
 		return fmt.Errorf("supernode: failed to construct replacement interop activity")


### PR DESCRIPTION


<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Introduces a SupernodeMetrics struct for metrics that outlive individual virtual node restarts, served alongside per-chain VN metrics via MetricsFanIn.AddGatherer.

Metrics added:
- supernode_virtual_node_restarts_total (counter, chain_id)
- supernode_interop_timestamps_verified_total (counter)
- supernode_interop_invalidations_total (counter, chain_id)
- supernode_interop_verified_timestamp (gauge)
- supernode_interop_round_decisions_total (counter, decision)
- supernode_interop_rewinds_total (counter)

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

```
--
# HELP supernode_interop_rewinds_total Total number of interop rewinds due to L1 consistency failures.
# TYPE supernode_interop_rewinds_total counter
supernode_interop_rewinds_total 0
# HELP supernode_interop_round_decisions_total Total number of interop round decisions by type.
# TYPE supernode_interop_round_decisions_total counter
supernode_interop_round_decisions_total{decision="wait"} 34
# HELP supernode_interop_timestamps_verified_total Total number of timestamps successfully verified by interop.
# TYPE supernode_interop_timestamps_verified_total counter
supernode_interop_timestamps_verified_total 0
# HELP supernode_interop_verified_timestamp Latest L2 timestamp successfully verified by interop.
# TYPE supernode_interop_verified_timestamp gauge
supernode_interop_verified_timestamp 0
```

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
