### PR TITLE
fix(opcm): harden Initializable slot clearing during upgrades

### DIFF
--- a/packages/contracts-bedrock/interfaces/L1/opcm/IOPContractsManagerUtils.sol
+++ b/packages/contracts-bedrock/interfaces/L1/opcm/IOPContractsManagerUtils.sol
@@ -85,12 +85,20 @@ interface IOPContractsManagerUtils {
         pure
         returns (bool);
 
-    function isMatchingInstruction(ExtraInstruction memory _instruction, string memory _key, bytes memory _data)
+    function isMatchingInstruction(
+        ExtraInstruction memory _instruction,
+        string memory _key,
+        bytes memory _data
+    )
         external
         pure
         returns (bool);
 
-    function hasInstruction(ExtraInstruction[] memory _instructions, string memory _key, bytes memory _data)
+    function hasInstruction(
+        ExtraInstruction[] memory _instructions,
+        string memory _key,
+        bytes memory _data
+    )
         external
         pure
         returns (bool);
@@ -100,7 +108,12 @@ interface IOPContractsManagerUtils {
         pure
         returns (ExtraInstruction memory);
 
-    function loadBytes(address _source, bytes4 _selector, string memory _name, ExtraInstruction[] memory _instructions)
+    function loadBytes(
+        address _source,
+        bytes4 _selector,
+        string memory _name,
+        ExtraInstruction[] memory _instructions
+    )
         external
         view
         returns (bytes memory);

--- a/packages/contracts-bedrock/interfaces/L1/opcm/IOPContractsManagerUtils.sol
+++ b/packages/contracts-bedrock/interfaces/L1/opcm/IOPContractsManagerUtils.sol
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import { IOPContractsManagerContainer } from "interfaces/L1/opcm/IOPContractsManagerContainer.sol";
-import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
-import { IAddressManager } from "interfaces/legacy/IAddressManager.sol";
-import { IDisputeGame } from "interfaces/dispute/IDisputeGame.sol";
-import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.sol";
-import { IDelayedWETH } from "interfaces/dispute/IDelayedWETH.sol";
-import { IZKVerifier } from "interfaces/dispute/zk/IZKVerifier.sol";
-import { Claim, Duration, GameType } from "src/dispute/lib/Types.sol";
+import {IOPContractsManagerContainer} from "interfaces/L1/opcm/IOPContractsManagerContainer.sol";
+import {IProxyAdmin} from "interfaces/universal/IProxyAdmin.sol";
+import {IAddressManager} from "interfaces/legacy/IAddressManager.sol";
+import {IDisputeGame} from "interfaces/dispute/IDisputeGame.sol";
+import {IAnchorStateRegistry} from "interfaces/dispute/IAnchorStateRegistry.sol";
+import {IDelayedWETH} from "interfaces/dispute/IDelayedWETH.sol";
+import {IZKVerifier} from "interfaces/dispute/zk/IZKVerifier.sol";
+import {Claim, Duration, GameType} from "src/dispute/lib/Types.sol";
 
 interface IOPContractsManagerUtils {
     struct ProxyDeployArgs {
@@ -57,6 +57,8 @@ interface IOPContractsManagerUtils {
     error OPContractsManagerUtils_DowngradeNotAllowed(address _contract);
     error OPContractsManagerUtils_ExtraTagInProd(address _contract);
     error OPContractsManagerUtils_InitializingDuringUpgrade();
+    error OPContractsManagerUtils_InvalidInitializerOffset();
+    error OPContractsManagerUtils_InvalidV5Offset();
     error OPContractsManagerUtils_ConfigLoadFailed(string _name);
     error OPContractsManagerUtils_ProxyMustLoad(string _name);
     error OPContractsManagerUtils_UnsupportedGameType();
@@ -73,55 +75,32 @@ interface IOPContractsManagerUtils {
     function blueprints() external view returns (IOPContractsManagerContainer.Blueprints memory);
     function contractsContainer() external view returns (IOPContractsManagerContainer);
     function chainIdToBatchInboxAddress(uint256 _l2ChainId) external pure returns (address);
-    function computeSalt(
-        uint256 _l2ChainId,
-        string memory _saltMixer,
-        string memory _contractName
-    )
+    function computeSalt(uint256 _l2ChainId, string memory _saltMixer, string memory _contractName)
         external
         pure
         returns (bytes32);
 
-    function isMatchingInstructionByKey(
-        ExtraInstruction memory _instruction,
-        string memory _key
-    )
+    function isMatchingInstructionByKey(ExtraInstruction memory _instruction, string memory _key)
         external
         pure
         returns (bool);
 
-    function isMatchingInstruction(
-        ExtraInstruction memory _instruction,
-        string memory _key,
-        bytes memory _data
-    )
+    function isMatchingInstruction(ExtraInstruction memory _instruction, string memory _key, bytes memory _data)
         external
         pure
         returns (bool);
 
-    function hasInstruction(
-        ExtraInstruction[] memory _instructions,
-        string memory _key,
-        bytes memory _data
-    )
+    function hasInstruction(ExtraInstruction[] memory _instructions, string memory _key, bytes memory _data)
         external
         pure
         returns (bool);
 
-    function getInstructionByKey(
-        ExtraInstruction[] memory _instructions,
-        string memory _key
-    )
+    function getInstructionByKey(ExtraInstruction[] memory _instructions, string memory _key)
         external
         pure
         returns (ExtraInstruction memory);
 
-    function loadBytes(
-        address _source,
-        bytes4 _selector,
-        string memory _name,
-        ExtraInstruction[] memory _instructions
-    )
+    function loadBytes(address _source, bytes4 _selector, string memory _name, ExtraInstruction[] memory _instructions)
         external
         view
         returns (bytes memory);
@@ -132,9 +111,7 @@ interface IOPContractsManagerUtils {
         ProxyDeployArgs memory _args,
         string memory _contractName,
         ExtraInstruction[] memory _instructions
-    )
-        external
-        returns (address payable);
+    ) external returns (address payable);
 
     function upgrade(
         IProxyAdmin _proxyAdmin,
@@ -143,8 +120,17 @@ interface IOPContractsManagerUtils {
         bytes memory _data,
         bytes32 _slot,
         uint8 _offset
-    )
-        external;
+    ) external;
+
+    function upgrade(
+        IProxyAdmin _proxyAdmin,
+        address _target,
+        address _implementation,
+        bytes memory _data,
+        bytes32 _slot,
+        uint8 _offset,
+        bytes32 _ozV5Slot
+    ) external;
 
     function getGameImpl(GameType _gameType) external view returns (IDisputeGame);
 
@@ -153,10 +139,7 @@ interface IOPContractsManagerUtils {
         IAnchorStateRegistry _anchorStateRegistry,
         IDelayedWETH _delayedWETH,
         DisputeGameConfig memory _gcfg
-    )
-        external
-        view
-        returns (bytes memory);
+    ) external view returns (bytes memory);
 
     function __constructor__(IOPContractsManagerContainer _contractsContainer) external;
 }

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -40,8 +40,8 @@
     "sourceCodeHash": "0xb09cb2f7cbde8585fad5c5beb6811fa9044b156b4203da8005d3f6a7a68c30b2"
   },
   "src/L1/opcm/OPContractsManagerV2.sol:OPContractsManagerV2": {
-    "initCodeHash": "0x397abf0952ec7a694ec98964cc6fb4b09f2bf7176e31e7e3a9f59426f0bef4c3",
-    "sourceCodeHash": "0xe74c4ce2ebd584e69a24a13b18d43569e2996da415b2f44ed54e44159a95c5dd"
+    "initCodeHash": "0x87b27e4168960b7bfdb40e5cac3debe64e7ea1229ba18447806cad4d524900ee",
+    "sourceCodeHash": "0x29311a41e036ec2f30abc1a74ce56ea7f9816fb79f279f3bc5af6017f8bdeb5d"
   },
   "src/L2/BaseFeeVault.sol:BaseFeeVault": {
     "initCodeHash": "0xf1fb169c6dd4eceb5cec6ed6dfa3affc45970e5a01e00827d06af1f9e8df026d",

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerUtils.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerUtils.sol
@@ -20,7 +20,7 @@ import {IAnchorStateRegistry} from "interfaces/dispute/IAnchorStateRegistry.sol"
 import {IDelayedWETH} from "interfaces/dispute/IDelayedWETH.sol";
 
 /// @title OPContractsManagerUtils
-/// @notice OPContractsManagerUtils is a contract that provides utility functions for the OPContractsManager.
+/// @notice OPContractsManagerUtils provides utility functions for the OPContractsManager.
 contract OPContractsManagerUtils {
     /// @notice Default ERC-7201 Initializable slot used by OpenZeppelin v5.
     bytes32 internal constant DEFAULT_OZ_V5_INITIALIZABLE_SLOT =
@@ -316,6 +316,13 @@ contract OPContractsManagerUtils {
     }
 
     /// @notice Shared implementation for upgrade flows.
+    /// @param _proxyAdmin The proxy admin of the contract.
+    /// @param _target The target of the contract.
+    /// @param _implementation The implementation of the contract.
+    /// @param _data The data to call the initializer with.
+    /// @param _slot The slot where the initialized value is located.
+    /// @param _offset The offset of the initializer value in the slot.
+    /// @param _ozV5Slot The ERC-7201 Initializable slot for OZ v5 contracts.
     function _upgrade(
         IProxyAdmin _proxyAdmin,
         address _target,

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerUtils.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerUtils.sol
@@ -124,7 +124,11 @@ contract OPContractsManagerUtils {
     /// @param _key The key of the instruction to check for.
     /// @param _data The data of the instruction to check for.
     /// @return True if the instruction matches, false otherwise.
-    function isMatchingInstruction(ExtraInstruction memory _instruction, string memory _key, bytes memory _data)
+    function isMatchingInstruction(
+        ExtraInstruction memory _instruction,
+        string memory _key,
+        bytes memory _data
+    )
         public
         pure
         returns (bool)
@@ -138,7 +142,11 @@ contract OPContractsManagerUtils {
     /// @param _key The key of the instruction to check for.
     /// @param _data The data of the instruction to check for.
     /// @return True if the instruction is present, false otherwise.
-    function hasInstruction(ExtraInstruction[] memory _instructions, string memory _key, bytes memory _data)
+    function hasInstruction(
+        ExtraInstruction[] memory _instructions,
+        string memory _key,
+        bytes memory _data
+    )
         public
         pure
         returns (bool)
@@ -174,7 +182,12 @@ contract OPContractsManagerUtils {
     /// @param _name The name of the field to load.
     /// @param _instructions The extra upgrade instructions for the data load.
     /// @return Data retrieved from the source contract.
-    function loadBytes(address _source, bytes4 _selector, string memory _name, ExtraInstruction[] memory _instructions)
+    function loadBytes(
+        address _source,
+        bytes4 _selector,
+        string memory _name,
+        ExtraInstruction[] memory _instructions
+    )
         external
         view
         returns (bytes memory)

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerUtils.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerUtils.sol
@@ -2,26 +2,30 @@
 pragma solidity 0.8.15;
 
 // Libraries
-import { LibString } from "@solady/utils/LibString.sol";
-import { SemverComp } from "src/libraries/SemverComp.sol";
-import { Blueprint } from "src/libraries/Blueprint.sol";
-import { Constants } from "src/libraries/Constants.sol";
-import { GameType, GameTypes } from "src/dispute/lib/Types.sol";
+import {LibString} from "@solady/utils/LibString.sol";
+import {SemverComp} from "src/libraries/SemverComp.sol";
+import {Blueprint} from "src/libraries/Blueprint.sol";
+import {Constants} from "src/libraries/Constants.sol";
+import {GameType, GameTypes} from "src/dispute/lib/Types.sol";
 
 // Interfaces
-import { IOPContractsManagerContainer } from "interfaces/L1/opcm/IOPContractsManagerContainer.sol";
-import { IOPContractsManagerUtils } from "interfaces/L1/opcm/IOPContractsManagerUtils.sol";
-import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
-import { IAddressManager } from "interfaces/legacy/IAddressManager.sol";
-import { IStorageSetter } from "interfaces/universal/IStorageSetter.sol";
-import { ISemver } from "interfaces/universal/ISemver.sol";
-import { IDisputeGame } from "interfaces/dispute/IDisputeGame.sol";
-import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.sol";
-import { IDelayedWETH } from "interfaces/dispute/IDelayedWETH.sol";
+import {IOPContractsManagerContainer} from "interfaces/L1/opcm/IOPContractsManagerContainer.sol";
+import {IOPContractsManagerUtils} from "interfaces/L1/opcm/IOPContractsManagerUtils.sol";
+import {IProxyAdmin} from "interfaces/universal/IProxyAdmin.sol";
+import {IAddressManager} from "interfaces/legacy/IAddressManager.sol";
+import {IStorageSetter} from "interfaces/universal/IStorageSetter.sol";
+import {ISemver} from "interfaces/universal/ISemver.sol";
+import {IDisputeGame} from "interfaces/dispute/IDisputeGame.sol";
+import {IAnchorStateRegistry} from "interfaces/dispute/IAnchorStateRegistry.sol";
+import {IDelayedWETH} from "interfaces/dispute/IDelayedWETH.sol";
 
 /// @title OPContractsManagerUtils
 /// @notice OPContractsManagerUtils is a contract that provides utility functions for the OPContractsManager.
 contract OPContractsManagerUtils {
+    /// @notice Default ERC-7201 Initializable slot used by OpenZeppelin v5.
+    bytes32 internal constant DEFAULT_OZ_V5_INITIALIZABLE_SLOT =
+        bytes32(uint256(0xf0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a00));
+
     /// @notice Helper struct for deploying proxies, keeps code cleaner.
     struct ProxyDeployArgs {
         IProxyAdmin proxyAdmin;
@@ -53,6 +57,12 @@ contract OPContractsManagerUtils {
 
     /// @notice Thrown when a contract has `_initializing` as true during an upgrade.
     error OPContractsManagerUtils_InitializingDuringUpgrade();
+
+    /// @notice Thrown when the initializer offset is outside the bounds of a 32-byte slot.
+    error OPContractsManagerUtils_InvalidInitializerOffset();
+
+    /// @notice Thrown when a v5 Initializable slot is provided with a non-zero `_initialized` offset.
+    error OPContractsManagerUtils_InvalidV5Offset();
 
     /// @notice Thrown when a config load fails.
     /// @param _name The name of the config that failed to load.
@@ -89,11 +99,7 @@ contract OPContractsManagerUtils {
     /// @param _saltMixer The salt mixer to use for the deployment.
     /// @param _contractName The name of the contract to deploy.
     /// @return The computed salt.
-    function computeSalt(
-        uint256 _l2ChainId,
-        string memory _saltMixer,
-        string memory _contractName
-    )
+    function computeSalt(uint256 _l2ChainId, string memory _saltMixer, string memory _contractName)
         public
         pure
         returns (bytes32)
@@ -105,10 +111,7 @@ contract OPContractsManagerUtils {
     /// @param _instruction The instruction to check.
     /// @param _key The key of the instruction to check for.
     /// @return True if the instruction matches, false otherwise.
-    function isMatchingInstructionByKey(
-        ExtraInstruction memory _instruction,
-        string memory _key
-    )
+    function isMatchingInstructionByKey(ExtraInstruction memory _instruction, string memory _key)
         public
         pure
         returns (bool)
@@ -121,11 +124,7 @@ contract OPContractsManagerUtils {
     /// @param _key The key of the instruction to check for.
     /// @param _data The data of the instruction to check for.
     /// @return True if the instruction matches, false otherwise.
-    function isMatchingInstruction(
-        ExtraInstruction memory _instruction,
-        string memory _key,
-        bytes memory _data
-    )
+    function isMatchingInstruction(ExtraInstruction memory _instruction, string memory _key, bytes memory _data)
         public
         pure
         returns (bool)
@@ -139,11 +138,7 @@ contract OPContractsManagerUtils {
     /// @param _key The key of the instruction to check for.
     /// @param _data The data of the instruction to check for.
     /// @return True if the instruction is present, false otherwise.
-    function hasInstruction(
-        ExtraInstruction[] memory _instructions,
-        string memory _key,
-        bytes memory _data
-    )
+    function hasInstruction(ExtraInstruction[] memory _instructions, string memory _key, bytes memory _data)
         public
         pure
         returns (bool)
@@ -160,10 +155,7 @@ contract OPContractsManagerUtils {
     /// @param _instructions The list of extra upgrade instructions.
     /// @param _key The key of the instruction to get.
     /// @return The instruction, or an empty instruction if the instruction is not found.
-    function getInstructionByKey(
-        ExtraInstruction[] memory _instructions,
-        string memory _key
-    )
+    function getInstructionByKey(ExtraInstruction[] memory _instructions, string memory _key)
         public
         pure
         returns (ExtraInstruction memory)
@@ -173,7 +165,7 @@ contract OPContractsManagerUtils {
                 return _instructions[i];
             }
         }
-        return ExtraInstruction({ key: "", data: bytes("") });
+        return ExtraInstruction({key: "", data: bytes("")});
     }
 
     /// @notice Helper function to load data from a source contract as bytes.
@@ -182,12 +174,7 @@ contract OPContractsManagerUtils {
     /// @param _name The name of the field to load.
     /// @param _instructions The extra upgrade instructions for the data load.
     /// @return Data retrieved from the source contract.
-    function loadBytes(
-        address _source,
-        bytes4 _selector,
-        string memory _name,
-        ExtraInstruction[] memory _instructions
-    )
+    function loadBytes(address _source, bytes4 _selector, string memory _name, ExtraInstruction[] memory _instructions)
         external
         view
         returns (bytes memory)
@@ -230,10 +217,7 @@ contract OPContractsManagerUtils {
         ProxyDeployArgs memory _args,
         string memory _contractName,
         ExtraInstruction[] memory _instructions
-    )
-        external
-        returns (address payable)
-    {
+    ) external returns (address payable) {
         // Loads are allowed to fail ONLY if the user explicitly permitted it (or if this is a
         // deployment and the "ALL" permission is set).
         bool loadCanFail = hasInstruction(_instructions, Constants.PERMITTED_PROXY_DEPLOYMENT_KEY, bytes(_contractName))
@@ -307,9 +291,40 @@ contract OPContractsManagerUtils {
         bytes memory _data,
         bytes32 _slot,
         uint8 _offset
-    )
-        external
-    {
+    ) external {
+        _upgrade(_proxyAdmin, _target, _implementation, _data, _slot, _offset, DEFAULT_OZ_V5_INITIALIZABLE_SLOT);
+    }
+
+    /// @notice Upgrades a contract by resetting the initialized slot and calling the initializer.
+    /// @param _proxyAdmin The proxy admin of the contract.
+    /// @param _target The target of the contract.
+    /// @param _implementation The implementation of the contract.
+    /// @param _data The data to call the initializer with.
+    /// @param _slot The slot where the initialized value is located.
+    /// @param _offset The offset of the initializer value in the slot.
+    /// @param _ozV5Slot The ERC-7201 Initializable slot for OZ v5 contracts.
+    function upgrade(
+        IProxyAdmin _proxyAdmin,
+        address _target,
+        address _implementation,
+        bytes memory _data,
+        bytes32 _slot,
+        uint8 _offset,
+        bytes32 _ozV5Slot
+    ) external {
+        _upgrade(_proxyAdmin, _target, _implementation, _data, _slot, _offset, _ozV5Slot);
+    }
+
+    /// @notice Shared implementation for upgrade flows.
+    function _upgrade(
+        IProxyAdmin _proxyAdmin,
+        address _target,
+        address _implementation,
+        bytes memory _data,
+        bytes32 _slot,
+        uint8 _offset,
+        bytes32 _ozV5Slot
+    ) internal {
         // Check to make sure that we're not downgrading. Downgrades aren't inherently dangerous
         // but we also don't test for them so we don't really know if a specific downgrade will be
         // dangerous or not. It's easier to just revert instead.
@@ -333,25 +348,30 @@ contract OPContractsManagerUtils {
             revert OPContractsManagerUtils_ExtraTagInProd(_implementation);
         }
 
+        if (_offset >= 32) {
+            revert OPContractsManagerUtils_InvalidInitializerOffset();
+        }
+
+        if (_slot == _ozV5Slot && _offset != 0) {
+            revert OPContractsManagerUtils_InvalidV5Offset();
+        }
+
         // Upgrade to StorageSetter.
         _proxyAdmin.upgrade(payable(_target), address(implementations().storageSetterImpl));
 
         // We need to reset the initialized slot and call the initializer.
-        // Reset the initialized slot by zeroing the single byte at `_offset` (from the right).
-        bytes32 current = IStorageSetter(_target).getBytes32(_slot);
-        uint256 mask = ~(uint256(0xff) << (uint256(_offset) * 8));
-        IStorageSetter(_target).setBytes32(_slot, bytes32(uint256(current) & mask));
+        // Skip the generic one-byte clear when `_slot` is the OZ v5 slot because the v5
+        // `_initializing` flag shares that slot and must be checked before any writes occur.
+        if (_slot != _ozV5Slot) {
+            bytes32 current = IStorageSetter(_target).getBytes32(_slot);
+            uint256 mask = ~(uint256(0xff) << (uint256(_offset) * 8));
+            IStorageSetter(_target).setBytes32(_slot, bytes32(uint256(current) & mask));
+        }
 
         // Also clear the OZ v5 ERC-7201 Initializable slot. OZ v5 stores `_initialized` as
         // uint64 in the low 8 bytes and `_initializing` as bool at byte offset 8 of the
         // namespaced slot. For v4 contracts this slot is all zeros, making this a no-op.
-        // Slot derivation (ERC-7201):
-        //   keccak256(abi.encode(uint256(keccak256("openzeppelin.storage.Initializable")) - 1)) &
-        // ~bytes32(uint256(0xff))
-        // Ref:
-        // https://github.com/OpenZeppelin/openzeppelin-contracts/blob/6b55a93e/contracts/proxy/utils/Initializable.sol#L77
-        bytes32 ozV5Slot = bytes32(uint256(0xf0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a00));
-        bytes32 v5Current = IStorageSetter(_target).getBytes32(ozV5Slot);
+        bytes32 v5Current = IStorageSetter(_target).getBytes32(_ozV5Slot);
         uint256 v5Value = uint256(v5Current);
 
         // A contract should never be mid-initialization during an upgrade. The `_initializing`
@@ -362,7 +382,7 @@ contract OPContractsManagerUtils {
 
         // Zero the uint64 `_initialized` portion (low 8 bytes), preserving all upper bytes.
         uint256 v5Mask = ~uint256(0xFFFFFFFFFFFFFFFF);
-        IStorageSetter(_target).setBytes32(ozV5Slot, bytes32(v5Value & v5Mask));
+        IStorageSetter(_target).setBytes32(_ozV5Slot, bytes32(v5Value & v5Mask));
 
         // Upgrade to the implementation and call the initializer.
         _proxyAdmin.upgradeAndCall(payable(address(_target)), _implementation, _data);
@@ -415,11 +435,7 @@ contract OPContractsManagerUtils {
         IAnchorStateRegistry _anchorStateRegistry,
         IDelayedWETH _delayedWETH,
         IOPContractsManagerUtils.DisputeGameConfig memory _gcfg
-    )
-        public
-        view
-        returns (bytes memory)
-    {
+    ) public view returns (bytes memory) {
         IOPContractsManagerContainer.Implementations memory impls = implementations();
 
         // Super game types require l2ChainId=0 in game args because the chain ID is

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerUtilsCaller.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerUtilsCaller.sol
@@ -2,14 +2,14 @@
 pragma solidity ^0.8.0;
 
 // Libraries
-import { GameType } from "src/dispute/lib/Types.sol";
+import {GameType} from "src/dispute/lib/Types.sol";
 
 // Interfaces
-import { IOPContractsManagerUtils } from "interfaces/L1/opcm/IOPContractsManagerUtils.sol";
-import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
-import { IDisputeGame } from "interfaces/dispute/IDisputeGame.sol";
-import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.sol";
-import { IDelayedWETH } from "interfaces/dispute/IDelayedWETH.sol";
+import {IOPContractsManagerUtils} from "interfaces/L1/opcm/IOPContractsManagerUtils.sol";
+import {IProxyAdmin} from "interfaces/universal/IProxyAdmin.sol";
+import {IDisputeGame} from "interfaces/dispute/IDisputeGame.sol";
+import {IAnchorStateRegistry} from "interfaces/dispute/IAnchorStateRegistry.sol";
+import {IDelayedWETH} from "interfaces/dispute/IDelayedWETH.sol";
 
 /// @title OPContractsManagerUtilsCaller
 /// @notice OPContractsManagerUtilsCaller is an abstract contract that exists to hide all of the
@@ -46,11 +46,7 @@ abstract contract OPContractsManagerUtilsCaller {
     /// @param _saltMixer The salt mixer to use for the deployment.
     /// @param _contractName The name of the contract to deploy.
     /// @return The computed salt.
-    function _computeSalt(
-        uint256 _l2ChainId,
-        string memory _saltMixer,
-        string memory _contractName
-    )
+    function _computeSalt(uint256 _l2ChainId, string memory _saltMixer, string memory _contractName)
         internal
         view
         returns (bytes32)
@@ -68,11 +64,7 @@ abstract contract OPContractsManagerUtilsCaller {
     function _isMatchingInstructionByKey(
         IOPContractsManagerUtils.ExtraInstruction memory _instruction,
         string memory _key
-    )
-        internal
-        view
-        returns (bool)
-    {
+    ) internal view returns (bool) {
         return abi.decode(
             _staticcall(abi.encodeCall(IOPContractsManagerUtils.isMatchingInstructionByKey, (_instruction, _key))),
             (bool)
@@ -88,11 +80,7 @@ abstract contract OPContractsManagerUtilsCaller {
         IOPContractsManagerUtils.ExtraInstruction memory _instruction,
         string memory _key,
         bytes memory _data
-    )
-        internal
-        view
-        returns (bool)
-    {
+    ) internal view returns (bool) {
         return abi.decode(
             _staticcall(abi.encodeCall(IOPContractsManagerUtils.isMatchingInstruction, (_instruction, _key, _data))),
             (bool)
@@ -110,11 +98,7 @@ abstract contract OPContractsManagerUtilsCaller {
         bytes4 _selector,
         string memory _name,
         IOPContractsManagerUtils.ExtraInstruction[] memory _instructions
-    )
-        internal
-        view
-        returns (bytes memory)
-    {
+    ) internal view returns (bytes memory) {
         return abi.decode(
             _staticcall(abi.encodeCall(IOPContractsManagerUtils.loadBytes, (_source, _selector, _name, _instructions))),
             (bytes)
@@ -137,12 +121,8 @@ abstract contract OPContractsManagerUtilsCaller {
         IOPContractsManagerUtils.ProxyDeployArgs memory _args,
         string memory _contractName,
         IOPContractsManagerUtils.ExtraInstruction[] memory _instructions
-    )
-        internal
-        returns (address payable)
-    {
-        return payable(
-            abi.decode(
+    ) internal returns (address payable) {
+        return payable(abi.decode(
                 _delegatecall(
                     abi.encodeCall(
                         IOPContractsManagerUtils.loadOrDeployProxy,
@@ -150,8 +130,7 @@ abstract contract OPContractsManagerUtilsCaller {
                     )
                 ),
                 (address)
-            )
-        );
+            ));
     }
 
     /// @notice Upgrades a contract by resetting the initialized slot and calling the initializer.
@@ -177,12 +156,47 @@ abstract contract OPContractsManagerUtilsCaller {
         bytes memory _data,
         bytes32 _slot,
         uint8 _offset
-    )
-        internal
-    {
+    ) internal {
         _delegatecall(
-            abi.encodeCall(
-                IOPContractsManagerUtils.upgrade, (_proxyAdmin, _target, _implementation, _data, _slot, _offset)
+            abi.encodeWithSelector(
+                bytes4(keccak256("upgrade(address,address,address,bytes,bytes32,uint8)")),
+                _proxyAdmin,
+                _target,
+                _implementation,
+                _data,
+                _slot,
+                _offset
+            )
+        );
+    }
+
+    /// @notice Upgrades a contract by resetting the initialized slot and calling the initializer.
+    /// @param _proxyAdmin The proxy admin of the contract.
+    /// @param _target The target of the contract.
+    /// @param _implementation The implementation of the contract.
+    /// @param _data The data to call the initializer with.
+    /// @param _slot The slot where the initialized value is located.
+    /// @param _offset The offset of the initializer value in the slot.
+    /// @param _ozV5Slot The ERC-7201 Initializable slot for OZ v5 contracts.
+    function _upgrade(
+        IProxyAdmin _proxyAdmin,
+        address _target,
+        address _implementation,
+        bytes memory _data,
+        bytes32 _slot,
+        uint8 _offset,
+        bytes32 _ozV5Slot
+    ) internal {
+        _delegatecall(
+            abi.encodeWithSelector(
+                bytes4(keccak256("upgrade(address,address,address,bytes,bytes32,uint8,bytes32)")),
+                _proxyAdmin,
+                _target,
+                _implementation,
+                _data,
+                _slot,
+                _offset,
+                _ozV5Slot
             )
         );
     }
@@ -232,11 +246,7 @@ abstract contract OPContractsManagerUtilsCaller {
         IAnchorStateRegistry _anchorStateRegistry,
         IDelayedWETH _delayedWETH,
         IOPContractsManagerUtils.DisputeGameConfig memory _gcfg
-    )
-        internal
-        view
-        returns (bytes memory)
-    {
+    ) internal view returns (bytes memory) {
         return abi.decode(
             _staticcall(
                 abi.encodeCall(

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerUtilsCaller.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerUtilsCaller.sol
@@ -20,6 +20,14 @@ import {IDelayedWETH} from "interfaces/dispute/IDelayedWETH.sol";
 ///      identical to an "external library" contract. You could use a real external library, but
 ///      this is much easier for humans to read and for us to validate offchain.
 abstract contract OPContractsManagerUtilsCaller {
+    /// @notice Selector for `upgrade(address,address,address,bytes,bytes32,uint8)`.
+    bytes4 internal constant UPGRADE_SELECTOR =
+        bytes4(keccak256("upgrade(address,address,address,bytes,bytes32,uint8)"));
+
+    /// @notice Selector for `upgrade(address,address,address,bytes,bytes32,uint8,bytes32)`.
+    bytes4 internal constant UPGRADE_WITH_V5_SLOT_SELECTOR =
+        bytes4(keccak256("upgrade(address,address,address,bytes,bytes32,uint8,bytes32)"));
+
     /// @notice Address of the OPContractsManagerUtils contract.
     IOPContractsManagerUtils public immutable opcmUtils;
 
@@ -157,17 +165,9 @@ abstract contract OPContractsManagerUtilsCaller {
         bytes32 _slot,
         uint8 _offset
     ) internal {
-        _delegatecall(
-            abi.encodeWithSelector(
-                bytes4(keccak256("upgrade(address,address,address,bytes,bytes32,uint8)")),
-                _proxyAdmin,
-                _target,
-                _implementation,
-                _data,
-                _slot,
-                _offset
-            )
-        );
+        _delegatecall(bytes.concat(
+            UPGRADE_SELECTOR, abi.encode(_proxyAdmin, _target, _implementation, _data, _slot, _offset)
+        ));
     }
 
     /// @notice Upgrades a contract by resetting the initialized slot and calling the initializer.
@@ -187,18 +187,10 @@ abstract contract OPContractsManagerUtilsCaller {
         uint8 _offset,
         bytes32 _ozV5Slot
     ) internal {
-        _delegatecall(
-            abi.encodeWithSelector(
-                bytes4(keccak256("upgrade(address,address,address,bytes,bytes32,uint8,bytes32)")),
-                _proxyAdmin,
-                _target,
-                _implementation,
-                _data,
-                _slot,
-                _offset,
-                _ozV5Slot
-            )
-        );
+        _delegatecall(bytes.concat(
+            UPGRADE_WITH_V5_SLOT_SELECTOR,
+            abi.encode(_proxyAdmin, _target, _implementation, _data, _slot, _offset, _ozV5Slot)
+        ));
     }
 
     /// @notice Helper calling the utils contract (via delegatecall).

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
@@ -152,9 +152,9 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
     ///         - Major bump: New required sequential upgrade
     ///         - Minor bump: Replacement OPCM for same upgrade
     ///         - Patch bump: Development changes (expected for normal dev work)
-    /// @custom:semver 7.1.16
+    /// @custom:semver 7.1.17
     function version() public pure returns (string memory) {
-        return "7.1.16";
+        return "7.1.17";
     }
 
     /// @param _standardValidator The standard validator for this OPCM release.

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerUtils.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerUtils.t.sol
@@ -2,32 +2,32 @@
 pragma solidity 0.8.15;
 
 // Testing
-import { Test } from "test/setup/Test.sol";
-import { FeatureFlags } from "test/setup/FeatureFlags.sol";
-import { DevFeatures } from "src/libraries/DevFeatures.sol";
+import {Test} from "test/setup/Test.sol";
+import {FeatureFlags} from "test/setup/FeatureFlags.sol";
+import {DevFeatures} from "src/libraries/DevFeatures.sol";
 
 // Contracts
-import { OPContractsManagerUtils } from "src/L1/opcm/OPContractsManagerUtils.sol";
-import { OPContractsManagerContainer } from "src/L1/opcm/OPContractsManagerContainer.sol";
+import {OPContractsManagerUtils} from "src/L1/opcm/OPContractsManagerUtils.sol";
+import {OPContractsManagerContainer} from "src/L1/opcm/OPContractsManagerContainer.sol";
 
 // Libraries
-import { Constants } from "src/libraries/Constants.sol";
-import { Blueprint } from "src/libraries/Blueprint.sol";
-import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
+import {Constants} from "src/libraries/Constants.sol";
+import {Blueprint} from "src/libraries/Blueprint.sol";
+import {DeployUtils} from "scripts/libraries/DeployUtils.sol";
 
 // Interfaces
-import { IOPContractsManagerContainer } from "interfaces/L1/opcm/IOPContractsManagerContainer.sol";
-import { IOPContractsManagerUtils } from "interfaces/L1/opcm/IOPContractsManagerUtils.sol";
-import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
-import { IProxy } from "interfaces/universal/IProxy.sol";
-import { IAddressManager } from "interfaces/legacy/IAddressManager.sol";
-import { ISemver } from "interfaces/universal/ISemver.sol";
-import { IStorageSetter } from "interfaces/universal/IStorageSetter.sol";
-import { Claim, Duration } from "src/dispute/lib/LibUDT.sol";
-import { GameTypes } from "src/dispute/lib/Types.sol";
-import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.sol";
-import { IDelayedWETH } from "interfaces/dispute/IDelayedWETH.sol";
-import { IZKVerifier } from "interfaces/dispute/zk/IZKVerifier.sol";
+import {IOPContractsManagerContainer} from "interfaces/L1/opcm/IOPContractsManagerContainer.sol";
+import {IOPContractsManagerUtils} from "interfaces/L1/opcm/IOPContractsManagerUtils.sol";
+import {IProxyAdmin} from "interfaces/universal/IProxyAdmin.sol";
+import {IProxy} from "interfaces/universal/IProxy.sol";
+import {IAddressManager} from "interfaces/legacy/IAddressManager.sol";
+import {ISemver} from "interfaces/universal/ISemver.sol";
+import {IStorageSetter} from "interfaces/universal/IStorageSetter.sol";
+import {Claim, Duration} from "src/dispute/lib/LibUDT.sol";
+import {GameTypes} from "src/dispute/lib/Types.sol";
+import {IAnchorStateRegistry} from "interfaces/dispute/IAnchorStateRegistry.sol";
+import {IDelayedWETH} from "interfaces/dispute/IDelayedWETH.sol";
+import {IZKVerifier} from "interfaces/dispute/zk/IZKVerifier.sol";
 
 /// @title ImplV1_Harness
 /// @notice Implementation contract with version 1.0.0 for testing upgrades.
@@ -35,7 +35,7 @@ contract OPContractsManagerUtils_ImplV1_Harness is ISemver {
     /// @custom:semver 1.0.0
     string public constant version = "1.0.0";
 
-    function initialize() external { }
+    function initialize() external {}
 }
 
 /// @title ImplV1b_Harness
@@ -44,7 +44,7 @@ contract OPContractsManagerUtils_ImplV1b_Harness is ISemver {
     /// @custom:semver 1.0.0
     string public constant version = "1.0.0";
 
-    function initialize() external { }
+    function initialize() external {}
 }
 
 /// @title ImplV2_Harness
@@ -53,7 +53,7 @@ contract OPContractsManagerUtils_ImplV2_Harness is ISemver {
     /// @custom:semver 2.0.0
     string public constant version = "2.0.0";
 
-    function initialize() external { }
+    function initialize() external {}
 }
 
 /// @title ImplV2Beta_Harness
@@ -62,7 +62,7 @@ contract OPContractsManagerUtils_ImplV2Beta_Harness is ISemver {
     /// @custom:semver 2.0.0-beta.1
     string public constant version = "2.0.0-beta.1";
 
-    function initialize() external { }
+    function initialize() external {}
 }
 
 /// @title ImplV2Interop_Harness
@@ -71,7 +71,7 @@ contract OPContractsManagerUtils_ImplV2Interop_Harness is ISemver {
     /// @custom:semver 2.0.0+interop
     string public constant version = "2.0.0+interop";
 
-    function initialize() external { }
+    function initialize() external {}
 }
 
 /// @title OPContractsManagerUtils_TestInit
@@ -140,17 +140,14 @@ contract OPContractsManagerUtils_TestInit is Test, FeatureFlags {
     /// @param _key The key of the instruction.
     /// @param _data The data of the instruction.
     /// @return The array of extra instructions.
-    function _createInstructions(
-        string memory _key,
-        bytes memory _data
-    )
+    function _createInstructions(string memory _key, bytes memory _data)
         internal
         pure
         returns (OPContractsManagerUtils.ExtraInstruction[] memory)
     {
         OPContractsManagerUtils.ExtraInstruction[] memory instructions =
             new OPContractsManagerUtils.ExtraInstruction[](1);
-        instructions[0] = OPContractsManagerUtils.ExtraInstruction({ key: _key, data: _data });
+        instructions[0] = OPContractsManagerUtils.ExtraInstruction({key: _key, data: _data});
         return instructions;
     }
 
@@ -180,10 +177,7 @@ contract OPContractsManagerUtils_ChainIdToBatchInboxAddress_Test is OPContractsM
     /// @notice Tests that different chain IDs produce different batch inbox addresses.
     /// @param _chainId1 The first chain ID.
     /// @param _chainId2 The second chain ID.
-    function testFuzz_chainIdToBatchInboxAddress_differentInputs_succeeds(
-        uint256 _chainId1,
-        uint256 _chainId2
-    )
+    function testFuzz_chainIdToBatchInboxAddress_differentInputs_succeeds(uint256 _chainId1, uint256 _chainId2)
         public
         view
     {
@@ -203,11 +197,7 @@ contract OPContractsManagerUtils_ComputeSalt_Test is OPContractsManagerUtils_Tes
     /// @param _chainId The chain ID.
     /// @param _mixer The salt mixer.
     /// @param _name The contract name.
-    function testFuzz_computeSalt_succeeds(
-        uint256 _chainId,
-        string calldata _mixer,
-        string calldata _name
-    )
+    function testFuzz_computeSalt_succeeds(uint256 _chainId, string calldata _mixer, string calldata _name)
         public
         view
     {
@@ -237,7 +227,7 @@ contract OPContractsManagerUtils_HasInstruction_Test is OPContractsManagerUtils_
     function testFuzz_hasInstruction_exists_succeeds(string calldata _key, bytes calldata _data) public view {
         OPContractsManagerUtils.ExtraInstruction[] memory instructions =
             new OPContractsManagerUtils.ExtraInstruction[](1);
-        instructions[0] = OPContractsManagerUtils.ExtraInstruction({ key: _key, data: _data });
+        instructions[0] = OPContractsManagerUtils.ExtraInstruction({key: _key, data: _data});
 
         assertTrue(utils.hasInstruction(instructions, _key, _data), "Should find matching instruction");
         assertFalse(utils.hasInstruction(instructions, "nonexistent", _data), "Wrong key returns false");
@@ -248,9 +238,9 @@ contract OPContractsManagerUtils_HasInstruction_Test is OPContractsManagerUtils_
     function test_hasInstruction_multipleInstructions_succeeds() public view {
         OPContractsManagerUtils.ExtraInstruction[] memory instructions =
             new OPContractsManagerUtils.ExtraInstruction[](3);
-        instructions[0] = OPContractsManagerUtils.ExtraInstruction({ key: "Key1", data: bytes("Data1") });
-        instructions[1] = OPContractsManagerUtils.ExtraInstruction({ key: "Key2", data: bytes("Data2") });
-        instructions[2] = OPContractsManagerUtils.ExtraInstruction({ key: "Key3", data: bytes("Data3") });
+        instructions[0] = OPContractsManagerUtils.ExtraInstruction({key: "Key1", data: bytes("Data1")});
+        instructions[1] = OPContractsManagerUtils.ExtraInstruction({key: "Key2", data: bytes("Data2")});
+        instructions[2] = OPContractsManagerUtils.ExtraInstruction({key: "Key3", data: bytes("Data3")});
 
         assertTrue(utils.hasInstruction(instructions, "Key1", "Data1"), "First instruction should be found");
         assertTrue(utils.hasInstruction(instructions, "Key2", "Data2"), "Second instruction should be found");
@@ -278,7 +268,7 @@ contract OPContractsManagerUtils_GetInstructionByKey_Test is OPContractsManagerU
     function testFuzz_getInstructionByKey_succeeds(string calldata _key, bytes calldata _data) public view {
         OPContractsManagerUtils.ExtraInstruction[] memory instructions =
             new OPContractsManagerUtils.ExtraInstruction[](1);
-        instructions[0] = OPContractsManagerUtils.ExtraInstruction({ key: _key, data: _data });
+        instructions[0] = OPContractsManagerUtils.ExtraInstruction({key: _key, data: _data});
 
         // Should find the instruction.
         OPContractsManagerUtils.ExtraInstruction memory found = utils.getInstructionByKey(instructions, _key);
@@ -295,8 +285,8 @@ contract OPContractsManagerUtils_GetInstructionByKey_Test is OPContractsManagerU
     function test_getInstructionByKey_duplicateKeys_succeeds() public view {
         OPContractsManagerUtils.ExtraInstruction[] memory instructions =
             new OPContractsManagerUtils.ExtraInstruction[](2);
-        instructions[0] = OPContractsManagerUtils.ExtraInstruction({ key: "DupeKey", data: bytes("FirstData") });
-        instructions[1] = OPContractsManagerUtils.ExtraInstruction({ key: "DupeKey", data: bytes("SecondData") });
+        instructions[0] = OPContractsManagerUtils.ExtraInstruction({key: "DupeKey", data: bytes("FirstData")});
+        instructions[1] = OPContractsManagerUtils.ExtraInstruction({key: "DupeKey", data: bytes("SecondData")});
 
         OPContractsManagerUtils.ExtraInstruction memory result = utils.getInstructionByKey(instructions, "DupeKey");
 
@@ -417,10 +407,7 @@ contract OPContractsManagerUtils_LoadOrDeployProxy_Test is OPContractsManagerUti
         proxyAdmin.setAddressManager(addressManager);
 
         deployArgs = OPContractsManagerUtils.ProxyDeployArgs({
-            proxyAdmin: proxyAdmin,
-            addressManager: addressManager,
-            l2ChainId: 42,
-            saltMixer: "testMixer"
+            proxyAdmin: proxyAdmin, addressManager: addressManager, l2ChainId: 42, saltMixer: "testMixer"
         });
     }
 
@@ -690,9 +677,26 @@ contract OPContractsManagerUtils_Upgrade_Test is OPContractsManagerUtils_TestIni
         assertEq(proxyAdmin.getProxyImplementation(payable(address(proxy))), address(implBeta));
     }
 
+    /// @notice Tests that upgrade reverts when `_offset` points outside the 32-byte storage slot.
+    function test_upgrade_invalidInitializerOffset_reverts() public {
+        vm.expectRevert(IOPContractsManagerUtils.OPContractsManagerUtils_InvalidInitializerOffset.selector);
+        utils.upgrade(
+            proxyAdmin,
+            address(proxy),
+            address(implV1),
+            abi.encodeCall(OPContractsManagerUtils_ImplV1_Harness.initialize, ()),
+            TEST_SLOT,
+            32
+        );
+    }
+
     /// @notice ERC-7201 Initializable slot used by OZ v5.
     bytes32 internal constant OZ_V5_INITIALIZABLE_SLOT =
         bytes32(uint256(0xf0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a00));
+
+    /// @notice Custom ERC-7201 Initializable slot used to simulate `_initializableStorageSlot()` overrides.
+    bytes32 internal constant CUSTOM_OZ_V5_INITIALIZABLE_SLOT =
+        bytes32(uint256(0x111122223333444455556666777788889999AAAABBBBCCCCDDDDEEEEFFFF0000));
 
     /// @notice Tests that v4 contracts are unaffected by the v5 slot clearing logic. For v4
     ///         contracts the ERC-7201 slot is all zeros, so the new code is a no-op.
@@ -789,6 +793,21 @@ contract OPContractsManagerUtils_Upgrade_Test is OPContractsManagerUtils_TestIni
         );
     }
 
+    /// @notice Tests that using the v5 slot as the generic initializer slot with a non-zero
+    ///         offset reverts before any storage writes can mask `_initializing`.
+    function test_upgrade_v5SlotNonZeroOffset_reverts() public {
+        vm.expectRevert(IOPContractsManagerUtils.OPContractsManagerUtils_InvalidV5Offset.selector);
+        utils.upgrade(
+            proxyAdmin,
+            address(proxy),
+            address(implV2),
+            abi.encodeCall(OPContractsManagerUtils_ImplV2_Harness.initialize, ()),
+            OZ_V5_INITIALIZABLE_SLOT,
+            8,
+            OZ_V5_INITIALIZABLE_SLOT
+        );
+    }
+
     /// @notice Tests that the upper bytes of the ERC-7201 slot beyond the Initializable struct
     ///         are preserved when clearing the `_initialized` field.
     function test_upgrade_v5SlotPreservesUpperBytes_succeeds() public {
@@ -816,6 +835,31 @@ contract OPContractsManagerUtils_Upgrade_Test is OPContractsManagerUtils_TestIni
         assertEq(proxyAdmin.getProxyImplementation(payable(address(proxy))), address(implV2));
         // The upper bytes should be preserved, only the low 8 bytes should be zeroed.
         assertEq(vm.load(address(proxy), OZ_V5_INITIALIZABLE_SLOT), bytes32(upperData));
+    }
+
+    /// @notice Tests that callers can provide a custom OZ v5 Initializable slot instead of using
+    ///         the default ERC-7201 slot.
+    function test_upgrade_customV5SlotCleared_succeeds() public {
+        // Set v1 as current implementation.
+        vm.prank(address(utils));
+        proxyAdmin.upgrade(payable(address(proxy)), address(implV1));
+
+        vm.store(address(proxy), CUSTOM_OZ_V5_INITIALIZABLE_SLOT, bytes32(uint256(type(uint64).max)));
+        vm.store(address(proxy), OZ_V5_INITIALIZABLE_SLOT, bytes32(uint256(0xBEEF)));
+
+        utils.upgrade(
+            proxyAdmin,
+            address(proxy),
+            address(implV2),
+            abi.encodeCall(OPContractsManagerUtils_ImplV2_Harness.initialize, ()),
+            CUSTOM_OZ_V5_INITIALIZABLE_SLOT,
+            0,
+            CUSTOM_OZ_V5_INITIALIZABLE_SLOT
+        );
+
+        assertEq(proxyAdmin.getProxyImplementation(payable(address(proxy))), address(implV2));
+        assertEq(vm.load(address(proxy), CUSTOM_OZ_V5_INITIALIZABLE_SLOT), bytes32(0));
+        assertEq(vm.load(address(proxy), OZ_V5_INITIALIZABLE_SLOT), bytes32(uint256(0xBEEF)));
     }
 }
 
@@ -860,10 +904,7 @@ contract OPContractsManagerUtils_IsMatchingInstruction_Test is OPContractsManage
     /// @notice Tests that isMatchingInstruction returns false when the instruction does not match the key.
     function testFuzz_isMatchingInstruction_notMatchingKey_fails(
         OPContractsManagerUtils.ExtraInstruction memory _instruction
-    )
-        public
-        view
-    {
+    ) public view {
         // Create a key that is not the same as the instruction key.
         string memory _key = string.concat("not:", _instruction.key);
 
@@ -873,10 +914,7 @@ contract OPContractsManagerUtils_IsMatchingInstruction_Test is OPContractsManage
     /// @notice Tests that isMatchingInstruction returns false when the instruction does not match the data.
     function testFuzz_isMatchingInstruction_notMatchingData_fails(
         OPContractsManagerUtils.ExtraInstruction memory _instruction
-    )
-        public
-        view
-    {
+    ) public view {
         // Create a data that is not the same as the instruction data.
         bytes memory _data = bytes.concat("not:", _instruction.data);
 
@@ -898,10 +936,7 @@ contract OPContractsManagerUtils_IsMatchingInstructionByKey_Test is OPContractsM
     /// @notice Tests that isMatchingInstructionKey returns false when the instruction does not match the key.
     function testFuzz_isMatchingInstructionByKey_notMatchingKey_fails(
         OPContractsManagerUtils.ExtraInstruction memory _instruction
-    )
-        public
-        view
-    {
+    ) public view {
         // Create a key that is not the same as the instruction key.
         string memory _key = string.concat("not:", _instruction.key);
         assertFalse(utils.isMatchingInstructionByKey(_instruction, _key));
@@ -976,10 +1011,7 @@ contract OPContractsManagerUtils_MakeGameArgs_Test is OPContractsManagerUtils_Te
     /// @notice Tests that makeGameArgs reverts for an unsupported game type.
     function test_makeGameArgs_unsupportedType_reverts() public {
         IOPContractsManagerUtils.DisputeGameConfig memory cfg = IOPContractsManagerUtils.DisputeGameConfig({
-            enabled: true,
-            initBond: 0,
-            gameType: GameTypes.KAILUA,
-            gameArgs: bytes("")
+            enabled: true, initBond: 0, gameType: GameTypes.KAILUA, gameArgs: bytes("")
         });
         vm.expectRevert(IOPContractsManagerUtils.OPContractsManagerUtils_UnsupportedGameType.selector);
         utils.makeGameArgs(1, IAnchorStateRegistry(address(0)), IDelayedWETH(payable(address(0))), cfg);


### PR DESCRIPTION
## Summary
- harden `OPContractsManagerUtils.upgrade()` against invalid initializer offsets and avoid clobbering the OZ v5 `_initializing` byte before it is checked
- support custom OZ v5 Initializable slots and keep the overloaded utils upgrade calls CI-safe without `abi.encodeWithSelector`
- bump `OPContractsManagerV2` semver to `7.1.17` and refresh `packages/contracts-bedrock/snapshots/semver-lock.json`

## Testing
- `FOUNDRY_DENY=never forge test --match-path test/L1/opcm/OPContractsManagerUtils.t.sol --match-test "test.*upgrade.*|test.*Initializing.*|test.*Offset.*|test.*Custom.*V5.*"`
- `FOUNDRY_PROFILE=ci go run scripts/autogen/generate-semver-lock/main.go`

## Notes
- previous failing PR checks were blocked by the overloaded `upgrade(...)` encoding in `OPContractsManagerUtilsCaller.sol` and the missing `OPContractsManagerV2` semver/lock update; both are included in this revision