### PR TITLE
docs(nuts): document two-PR bundle flow and improve provenance error

### DIFF
--- a/op-core/nuts/README.md
+++ b/op-core/nuts/README.md
@@ -38,7 +38,7 @@ just nut-snapshot-for <fork>
 
 This copies `current-upgrade-bundle.json` to `op-core/nuts/bundles/<fork>_nut_bundle.json` and updates `fork_lock.toml` with the sha256 hash and the merge-base commit with `origin/develop`.
 
-**Why merge-base, not HEAD?** The recorded commit is the merge-base with `develop`, not HEAD, so the reference survives squash-merge. That only works if the contracts source that produced the bundle is already on `develop` — which is why PR 1 must land first.
+**Why merge-base, not HEAD?** The recorded commit is the [merge-base](https://git-scm.com/docs/git-merge-base) with `develop`. By ensuring that the recorded commit is a recent ancestor of `develop`, we can ensure that the reference will survives a squash-merge and persist in the history of the `develop` branch. This is why PR 1 must be merged first.
 
 ### Verifying a bundle
 

--- a/op-core/nuts/README.md
+++ b/op-core/nuts/README.md
@@ -11,14 +11,26 @@ Network Upgrade Transaction (NUT) bundles define the L2 deposit transactions tha
 
 ## Workflow
 
-### Generating a bundle
+Updating a fork's bundle is a **two-PR flow**:
+
+### PR 1 — Contracts change
+
+Change the Solidity source, then regenerate the in-repo snapshots:
 
 ```bash
 cd packages/contracts-bedrock
 just generate-nut-bundle
 ```
 
-### Snapshotting a bundle for a fork
+This updates:
+- `packages/contracts-bedrock/snapshots/semver-lock.json` (if any predeploy bytecode changed)
+- `packages/contracts-bedrock/snapshots/upgrades/current-upgrade-bundle.json` (the candidate bundle)
+
+Commit these alongside your contracts change. **Merge this PR to `develop` before proceeding.**
+
+### PR 2 — Snapshot the bundle for a fork
+
+From a branch based on the updated `develop`:
 
 ```bash
 just nut-snapshot-for <fork>
@@ -26,8 +38,7 @@ just nut-snapshot-for <fork>
 
 This copies `current-upgrade-bundle.json` to `op-core/nuts/bundles/<fork>_nut_bundle.json` and updates `fork_lock.toml` with the sha256 hash and the merge-base commit with `origin/develop`.
 
-**Important:** The recorded commit is the merge-base with develop, not HEAD. This ensures the commit survives squash-merge. Contract changes must be merged to develop in a separate PR *before* snapshotting the bundle.
-
+**Why merge-base, not HEAD?** The recorded commit is the merge-base with `develop`, not HEAD, so the reference survives squash-merge. That only works if the contracts source that produced the bundle is already on `develop` — which is why PR 1 must land first.
 
 ### Verifying a bundle
 
@@ -45,6 +56,17 @@ Requires `forge` for the provenance check (step 2).
 
 - **`check-nut-locks`** — Verifies all bundle hashes match their lock entries, all entries have a commit, and every `*_nut_bundle.json` file has a corresponding lock entry. Runs in CI on every PR.
 
+## Reading a bundle diff
+
+A single predeploy edit can cascade into multiple bundle entries. For example, a patch bump to `L1Block.sol` typically produces four diffs:
+
+1. **Deploy L1Block Implementation** — new bytecode (source changed).
+2. **Deploy L1BlockCGT Implementation** — new bytecode (inherits the new version string via `super.version()`).
+3. **Deploy L2ContractsManager Implementation** — new bytecode (hardcodes predeploy impl addresses, which shift when their bytecode changes).
+4. **L2ProxyAdmin Upgrade Predeploys** — new calldata (batch upgrade now points at the new impl addresses).
+
+When reviewing a bundle diff, check that every changed entry traces back to an intentional source change. Unexpected entries indicate a deeper impact than the diff suggests.
+
 ## fork_lock.toml schema
 
 ```toml
@@ -53,4 +75,12 @@ bundle = "op-core/nuts/bundles/<fork>_nut_bundle.json"  # repo-relative path
 hash = "sha256:<hex>"                                      # sha256 of bundle contents
 commit = "<full-sha>"                                      # commit that produced the bundle
 ```
+
+## Troubleshooting
+
+### `FAIL: provenance verification: regenerated bundle at commit <X> differs from committed bundle`
+
+The commit recorded in `fork_lock.toml` does not, when checked out, produce the bundle that is currently committed to the repo. The most common cause is running `just nut-snapshot-for <fork>` on a branch whose contracts source has not yet landed on `develop` — the merge-base with `origin/develop` resolves to a commit that predates the change being bundled.
+
+**Fix:** merge the contracts PR to `develop` first, then create a new branch from the updated `develop` and re-run `just nut-snapshot-for <fork>`.
 

--- a/op-core/nuts/README.md
+++ b/op-core/nuts/README.md
@@ -56,17 +56,6 @@ Requires `forge` for the provenance check (step 2).
 
 - **`check-nut-locks`** — Verifies all bundle hashes match their lock entries, all entries have a commit, and every `*_nut_bundle.json` file has a corresponding lock entry. Runs in CI on every PR.
 
-## Reading a bundle diff
-
-A single predeploy edit can cascade into multiple bundle entries. For example, a patch bump to `L1Block.sol` typically produces four diffs:
-
-1. **Deploy L1Block Implementation** — new bytecode (source changed).
-2. **Deploy L1BlockCGT Implementation** — new bytecode (inherits the new version string via `super.version()`).
-3. **Deploy L2ContractsManager Implementation** — new bytecode (hardcodes predeploy impl addresses, which shift when their bytecode changes).
-4. **L2ProxyAdmin Upgrade Predeploys** — new calldata (batch upgrade now points at the new impl addresses).
-
-When reviewing a bundle diff, check that every changed entry traces back to an intentional source change. Unexpected entries indicate a deeper impact than the diff suggests.
-
 ## fork_lock.toml schema
 
 ```toml
@@ -75,12 +64,3 @@ bundle = "op-core/nuts/bundles/<fork>_nut_bundle.json"  # repo-relative path
 hash = "sha256:<hex>"                                      # sha256 of bundle contents
 commit = "<full-sha>"                                      # commit that produced the bundle
 ```
-
-## Troubleshooting
-
-### `FAIL: provenance verification: regenerated bundle at commit <X> differs from committed bundle`
-
-The commit recorded in `fork_lock.toml` does not, when checked out, produce the bundle that is currently committed to the repo. The most common cause is running `just nut-snapshot-for <fork>` on a branch whose contracts source has not yet landed on `develop` — the merge-base with `origin/develop` resolves to a commit that predates the change being bundled.
-
-**Fix:** merge the contracts PR to `develop` first, then create a new branch from the updated `develop` and re-run `just nut-snapshot-for <fork>`.
-

--- a/ops/scripts/nut-provenance-verify/main.go
+++ b/ops/scripts/nut-provenance-verify/main.go
@@ -73,7 +73,7 @@ func run(fork forks.Name) error {
 	}
 
 	fmt.Printf("Verifying bundle provenance from commit %s...\n", entry.Commit[:12])
-	if err := verifyFromCommit(root, entry, func(contractsDir string) error {
+	if err := verifyFromCommit(root, fork, entry, func(contractsDir string) error {
 		cmd := exec.Command("just", "generate-nut-bundle")
 		cmd.Dir = contractsDir
 		cmd.Stdout = os.Stdout
@@ -89,7 +89,7 @@ func run(fork forks.Name) error {
 
 // verifyFromCommit creates a temporary worktree at the recorded commit,
 // regenerates the NUT bundle, and compares it against the locked bundle.
-func verifyFromCommit(root string, entry nuts.ForkLockEntry, generate bundleGenerator) error {
+func verifyFromCommit(root string, fork forks.Name, entry nuts.ForkLockEntry, generate bundleGenerator) error {
 	worktreeDir, err := os.MkdirTemp("", "verify-nuts-*")
 	if err != nil {
 		return fmt.Errorf("creating temp dir: %w", err)
@@ -130,8 +130,13 @@ func verifyFromCommit(root string, entry nuts.ForkLockEntry, generate bundleGene
 	}
 
 	if !bytes.Equal(regenContent, committedContent) {
-		return fmt.Errorf("regenerated bundle at commit %s differs from committed bundle %s",
-			entry.Commit[:12], entry.Bundle)
+		return fmt.Errorf(
+			"bundle regenerated from commit %s does not match committed bundle %s for fork %s. "+
+				"This usually means the recorded commit predates the contracts source being bundled. "+
+				"Merge the contracts PR to develop, then re-run 'just nut-snapshot-for %s' from "+
+				"a branch based on the updated develop. See op-core/nuts/README.md.",
+			entry.Commit[:12], entry.Bundle, fork, fork,
+		)
 	}
 
 	return nil

--- a/ops/scripts/nut-provenance-verify/main.go
+++ b/ops/scripts/nut-provenance-verify/main.go
@@ -131,10 +131,7 @@ func verifyFromCommit(root string, fork forks.Name, entry nuts.ForkLockEntry, ge
 
 	if !bytes.Equal(regenContent, committedContent) {
 		return fmt.Errorf(
-			"bundle regenerated from commit %s does not match committed bundle %s for fork %s. "+
-				"This usually means the recorded commit predates the contracts source being bundled. "+
-				"Merge the contracts PR to develop, then re-run 'just nut-snapshot-for %s' from "+
-				"a branch based on the updated develop. See op-core/nuts/README.md.",
+			"the bundle regenerated from commit %s does not match the committed bundle at %s for the %s fork . See op-core/nuts/README.md for details on how to lock a new bundle.",
 			entry.Commit[:12], entry.Bundle, fork, fork,
 		)
 	}

--- a/ops/scripts/nut-provenance-verify/main.go
+++ b/ops/scripts/nut-provenance-verify/main.go
@@ -132,7 +132,7 @@ func verifyFromCommit(root string, fork forks.Name, entry nuts.ForkLockEntry, ge
 	if !bytes.Equal(regenContent, committedContent) {
 		return fmt.Errorf(
 			"the bundle regenerated from commit %s does not match the committed bundle at %s for the %s fork . See op-core/nuts/README.md for details on how to lock a new bundle.",
-			entry.Commit[:12], entry.Bundle, fork, fork,
+			entry.Commit[:12], entry.Bundle, fork,
 		)
 	}
 

--- a/ops/scripts/nut-provenance-verify/main_test.go
+++ b/ops/scripts/nut-provenance-verify/main_test.go
@@ -82,7 +82,7 @@ func TestVerifyFromCommit_MatchingBundle(t *testing.T) {
 	// Generator is a no-op: the bundle file already exists at the commit.
 	noopGenerator := func(contractsDir string) error { return nil }
 
-	err := verifyFromCommit(root, entry, noopGenerator)
+	err := verifyFromCommit(root, "test-fork", entry, noopGenerator)
 	require.NoError(t, err)
 }
 
@@ -106,8 +106,8 @@ func TestVerifyFromCommit_MismatchedBundle(t *testing.T) {
 
 	noopGenerator := func(contractsDir string) error { return nil }
 
-	err := verifyFromCommit(root, entry, noopGenerator)
-	require.ErrorContains(t, err, "regenerated bundle at commit")
+	err := verifyFromCommit(root, "test-fork", entry, noopGenerator)
+	require.ErrorContains(t, err, "bundle regenerated from commit")
 }
 
 func TestVerifyFromCommit_GeneratorModifiesBundle(t *testing.T) {
@@ -136,6 +136,6 @@ func TestVerifyFromCommit_GeneratorModifiesBundle(t *testing.T) {
 		return os.WriteFile(outPath, regeneratedContent, 0644)
 	}
 
-	err := verifyFromCommit(root, entry, modifyingGenerator)
+	err := verifyFromCommit(root, "test-fork", entry, modifyingGenerator)
 	require.NoError(t, err)
 }


### PR DESCRIPTION
## Summary

- Restructure `op-core/nuts/README.md` workflow section as an explicit **two-PR flow** (contracts PR → snapshot PR), replacing the prose note that stated the rule without spelling out the steps.
- Add a *Reading a bundle diff* section explaining the cascade a single predeploy edit produces (L1Block → L1BlockCGT → L2ContractsManager → `L2ProxyAdmin Upgrade Predeploys`), so reviewers know what to expect.
- Add a *Troubleshooting* section keyed on the concrete error `nut-provenance-verify` emits.
- Rewrite that error in `ops/scripts/nut-provenance-verify/main.go` to name the likely cause and include the exact fix command, matching the style of sibling `check-nut-locks`. Thread `fork` through `verifyFromCommit` so the message can reference it.

The docs change and the error-message change are paired: the README's troubleshooting section and the new error text explain the same failure mode, and they should land together so a reviewer sees the full picture.

Fixes https://github.com/ethereum-optimism/optimism/issues/19307