### PR TITLE
chore: prebuild op-reth for acceptance tests

### DIFF
--- a/justfile
+++ b/justfile
@@ -344,7 +344,7 @@ update-op-geth:
 
 # Build all Rust binaries (release) for sysgo tests.
 build-rust-release:
-  cd rust && cargo build --release --bin kona-node --bin kona-host
+  cd rust && cargo build --release --bin kona-node --bin kona-host --bin op-reth
   cd op-rbuilder && cargo build --release -p op-rbuilder --bin op-rbuilder
   cd rollup-boost && cargo build --release -p rollup-boost --bin rollup-boost
 

--- a/op-acceptance-tests/justfile
+++ b/op-acceptance-tests/justfile
@@ -25,7 +25,7 @@ build-deps:
     cd {{REPO_ROOT}}
     just cannon-prestates
 
-    echo "Building Rust binaries (kona-node, op-rbuilder, rollup-boost)..."
+    echo "Building Rust binaries (kona-node, kona-host, op-reth, op-rbuilder, rollup-boost)..."
     cd {{REPO_ROOT}}
     just build-rust-release
 


### PR DESCRIPTION
Add `--bin op-reth` to the `build-rust-release` target so op-reth is built alongside kona-node and kona-host before acceptance tests run. Previously op-reth was built JIT when the first test that needed it started, which slowed test startup and could cause timeouts — op-rbuilder and rollup-boost are already built up front; this brings op-reth in line.

Note that this doesn't change how CI builds things - it uses separate jobs to pre-build rust in parallel with other work, but it makes running acceptance tests locally a lot more reliable. Previously the JIT op-reth build would cause long stalls in tests and often cause them to time out before the build finished.