### PR TITLE
feat(karst): reduce bn256Pairing input size limit to 300 pairs

### DIFF
--- a/rust/kona/bin/client/src/fpvm_evm/precompiles/bn128_pair.rs
+++ b/rust/kona/bin/client/src/fpvm_evm/precompiles/bn128_pair.rs
@@ -13,6 +13,7 @@ use revm::precompile::{
 
 const BN256_MAX_PAIRING_SIZE_GRANITE: usize = 112_687;
 const BN256_MAX_PAIRING_SIZE_JOVIAN: usize = 81_984;
+const BN256_MAX_PAIRING_SIZE_KARST: usize = 57_600;
 
 /// Runs the FPVM-accelerated `ecpairing` precompile call.
 pub(crate) fn fpvm_bn128_pair<H, O>(
@@ -80,6 +81,25 @@ where
     O: PreimageOracleClient + Send + Sync,
 {
     if input.len() > BN256_MAX_PAIRING_SIZE_JOVIAN {
+        return Err(PrecompileHalt::Bn254PairLength);
+    }
+
+    fpvm_bn128_pair(input, gas_limit, hint_writer, oracle_reader)
+}
+
+/// Runs the FPVM-accelerated `ecpairing` precompile call, with the input size limited by the
+/// Karst hardfork.
+pub(crate) fn fpvm_bn128_pair_karst<H, O>(
+    input: &[u8],
+    gas_limit: u64,
+    hint_writer: &H,
+    oracle_reader: &O,
+) -> EthPrecompileResult
+where
+    H: HintWriterClient + Send + Sync,
+    O: PreimageOracleClient + Send + Sync,
+{
+    if input.len() > BN256_MAX_PAIRING_SIZE_KARST {
         return Err(PrecompileHalt::Bn254PairLength);
     }
 
@@ -199,6 +219,38 @@ mod test {
             let input = [0u8; INPUT_SIZE];
             let accelerated_result =
                 fpvm_bn128_pair_jovian(&input, u64::MAX, hint_writer, oracle_reader).unwrap_err();
+
+            assert!(matches!(accelerated_result, PrecompileHalt::Bn254PairLength));
+        })
+        .await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_accelerated_bn128_pairing_karst() {
+        test_accelerated_precompile(|hint_writer, oracle_reader| {
+            let granite_result =
+                fpvm_bn128_pair_granite(TEST_INPUT.as_ref(), u64::MAX, hint_writer, oracle_reader)
+                    .unwrap();
+            let karst_result =
+                fpvm_bn128_pair_karst(TEST_INPUT.as_ref(), u64::MAX, hint_writer, oracle_reader)
+                    .unwrap();
+
+            assert_eq!(granite_result.bytes, karst_result.bytes);
+            assert_eq!(granite_result.gas_used, karst_result.gas_used);
+        })
+        .await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_accelerated_bn128_pairing_bad_input_len_karst() {
+        test_accelerated_precompile(|hint_writer, oracle_reader| {
+            // Calculate the next aligned size (multiple of PAIR_ELEMENT_LEN) that exceeds
+            // BN256_MAX_PAIRING_SIZE_KARST
+            const INPUT_SIZE: usize =
+                ((BN256_MAX_PAIRING_SIZE_KARST / PAIR_ELEMENT_LEN) + 1) * PAIR_ELEMENT_LEN;
+            let input = [0u8; INPUT_SIZE];
+            let accelerated_result =
+                fpvm_bn128_pair_karst(&input, u64::MAX, hint_writer, oracle_reader).unwrap_err();
 
             assert!(matches!(accelerated_result, PrecompileHalt::Bn254PairLength));
         })

--- a/rust/kona/bin/client/src/fpvm_evm/precompiles/provider.rs
+++ b/rust/kona/bin/client/src/fpvm_evm/precompiles/provider.rs
@@ -62,7 +62,8 @@ where
             OpSpecId::ECOTONE | OpSpecId::FJORD => accelerated_ecotone::<H, O>(),
             OpSpecId::GRANITE | OpSpecId::HOLOCENE => accelerated_granite::<H, O>(),
             OpSpecId::ISTHMUS => accelerated_isthmus::<H, O>(),
-            OpSpecId::JOVIAN | OpSpecId::KARST | OpSpecId::INTEROP => accelerated_jovian::<H, O>(),
+            OpSpecId::JOVIAN => accelerated_jovian::<H, O>(),
+            OpSpecId::KARST | OpSpecId::INTEROP => accelerated_karst::<H, O>(),
         };
 
         Self {
@@ -298,6 +299,24 @@ where
     base
 }
 
+/// The accelerated precompiles for the karst spec.
+fn accelerated_karst<H, O>() -> Vec<AcceleratedPrecompile<H, O>>
+where
+    H: HintWriterClient + Send + Sync,
+    O: PreimageOracleClient + Send + Sync,
+{
+    let mut base = accelerated_jovian::<H, O>();
+
+    // Replace the bn254 pair precompile with the Karst version (reduced input size limit).
+    base.retain(|p| p.address != bn254::pair::ADDRESS);
+    base.push(AcceleratedPrecompile::new(
+        bn254::pair::ADDRESS,
+        super::bn128_pair::fpvm_bn128_pair_karst::<H, O>,
+    ));
+
+    base
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -478,16 +497,12 @@ mod test {
         let isthmus_provider =
             OpFpvmPrecompiles::new_with_spec(OpSpecId::ISTHMUS, hint_writer, oracle_reader);
 
-        // Post-Jovian specs must have the same accelerated precompile addresses as Jovian.
+        // Each post-Jovian spec accelerates the same set of addresses as the previous fork.
+        // The dispatched function at a given address may still change (e.g. KARST swaps the
+        // bn254 pair function at 0x08 for a stricter input-size check).
         let jovian_addrs: Vec<_> = {
             let mut addrs: Vec<_> =
                 jovian_provider.accelerated_precompiles.keys().copied().collect();
-            addrs.sort();
-            addrs
-        };
-        let interop_addrs: Vec<_> = {
-            let mut addrs: Vec<_> =
-                interop_provider.accelerated_precompiles.keys().copied().collect();
             addrs.sort();
             addrs
         };
@@ -497,11 +512,20 @@ mod test {
             addrs.sort();
             addrs
         };
+        let interop_addrs: Vec<_> = {
+            let mut addrs: Vec<_> =
+                interop_provider.accelerated_precompiles.keys().copied().collect();
+            addrs.sort();
+            addrs
+        };
         assert_eq!(
-            jovian_addrs, interop_addrs,
-            "INTEROP should use Jovian accelerated precompiles"
+            jovian_addrs, karst_addrs,
+            "KARST should accelerate the same addresses as JOVIAN (functions may differ)"
         );
-        assert_eq!(jovian_addrs, karst_addrs, "KARST should use Jovian accelerated precompiles");
+        assert_eq!(
+            karst_addrs, interop_addrs,
+            "INTEROP should accelerate the same addresses as KARST (functions may differ)"
+        );
 
         // Verify the non-accelerated precompile sets point to the correct static instances.
         assert!(
@@ -520,6 +544,35 @@ mod test {
             core::ptr::eq(interop_provider.inner.precompiles, karst()),
             "INTEROP should use karst() precompiles"
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_karst_bn128_pair_enforces_karst_limit() {
+        use crate::fpvm_evm::precompiles::test_utils::test_accelerated_precompile;
+
+        test_accelerated_precompile(|hint_writer, oracle_reader| {
+            // 301 pairs × 192 bytes = 57_792 — aligned to PAIR_ELEMENT_LEN and one pair
+            // above BN256_MAX_PAIRING_SIZE_KARST (57_600).
+            const OVER_KARST_LIMIT: usize = 57_792;
+            let input = vec![0u8; OVER_KARST_LIMIT];
+
+            let karst_provider = OpFpvmPrecompiles::new_with_spec(
+                OpSpecId::KARST,
+                hint_writer.clone(),
+                oracle_reader.clone(),
+            );
+            let karst_fn = karst_provider
+                .accelerated_precompiles
+                .get(&bn254::pair::ADDRESS)
+                .copied()
+                .expect("KARST must have bn254 pair accelerated precompile");
+            let karst_res = karst_fn(&input, u64::MAX, hint_writer, oracle_reader);
+            assert!(
+                matches!(karst_res, Err(revm::precompile::PrecompileHalt::Bn254PairLength)),
+                "KARST should reject input > 57_600 bytes with Bn254PairLength"
+            );
+        })
+        .await;
     }
 
     #[test]

--- a/rust/op-revm/src/precompiles.rs
+++ b/rust/op-revm/src/precompiles.rs
@@ -94,11 +94,11 @@ pub fn karst() -> &'static Precompiles {
         let mut precompiles = jovian().clone();
 
         let mut to_remove = Precompiles::default();
-        to_remove.extend([modexp::BERLIN, secp256r1::P256VERIFY]);
+        to_remove.extend([modexp::BERLIN, secp256r1::P256VERIFY, bn254_pair::JOVIAN]);
 
         precompiles.difference(&to_remove);
 
-        precompiles.extend([modexp::OSAKA, secp256r1::P256VERIFY_OSAKA]);
+        precompiles.extend([modexp::OSAKA, secp256r1::P256VERIFY_OSAKA, bn254_pair::KARST]);
 
         precompiles
     })
@@ -218,6 +218,27 @@ pub mod bn254_pair {
     }
 
     eth_precompile_fn!(jovian_precompile, run_pair_jovian);
+
+    /// Max input size for the bn254 pair precompile after the Karst hardfork.
+    pub const KARST_MAX_INPUT_SIZE: usize = 57_600;
+    /// Bn254 pair precompile after the Karst hardfork.
+    pub const KARST: Precompile =
+        Precompile::new(PrecompileId::Bn254Pairing, bn254::pair::ADDRESS, karst_precompile);
+
+    /// Run the bn254 pair precompile with the Karst input size limit.
+    pub fn run_pair_karst(input: &[u8], gas_limit: u64) -> EthPrecompileResult {
+        if input.len() > KARST_MAX_INPUT_SIZE {
+            return Err(PrecompileHalt::Bn254PairLength);
+        }
+        bn254::run_pair(
+            input,
+            bn254::pair::ISTANBUL_PAIR_PER_POINT,
+            bn254::pair::ISTANBUL_PAIR_BASE,
+            gas_limit,
+        )
+    }
+
+    eth_precompile_fn!(karst_precompile, run_pair_karst);
 }
 
 /// `Bls12_381` precompile.
@@ -347,6 +368,15 @@ mod tests {
     };
     use std::vec;
 
+    /// Canonical bn256 pairing test vector (EIP-197): two pairs chosen so the
+    /// pairing product is the identity — a successful run returns `1` (32 bytes).
+    /// Shared by the Jovian and Karst accelerated-pairing tests.
+    const BN254_PAIR_IDENTITY_INPUT: [u8; 384] = hex!(
+        "2cf44499d5d27bb186308b7af7af02ac5bc9eeb6a3d147c186b21fb1b76e18da2c0f001f52110ccfe69108924926e45f0b0c868df0e7bde1fe16d3242dc715f61fb19bb476f6b9e44e2a32234da8212f61cd63919354bc06aef31e3cfaff3ebc22606845ff186793914e03e21df544c34ffe2f2f3504de8a79d9159eca2d98d92bd368e28381e8eccb5fa81fc26cf3f048eea9abfdd85d7ed3ab3698d63e4f902fe02e47887507adf0ff1743cbac6ba291e66f59be6bd763950bb16041a0a85e000000000000000000000000000000000000000000000000000000000000000130644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd451971ff0471b09fa93caaf13cbf443c1aede09cc4328f5a62aad45f40ec133eb4091058a3141822985733cbdddfed0fd8d6c104e9e9eff40bf5abfef9ab163bc72a23af9a5ce2ba2796c1f4e453a370eb0af8c212d9dc9acd8fc02c2e907baea223a8eb0b0996252cb548a4487da97b02422ebc0e834613f954de6c7e0afdc1fc"
+    );
+    const BN254_PAIR_IDENTITY_OUTPUT: [u8; 32] =
+        hex!("0000000000000000000000000000000000000000000000000000000000000001");
+
     #[test]
     fn test_bn254_pair() {
         let input = hex::decode(
@@ -397,14 +427,8 @@ mod tests {
 
     #[test]
     fn test_accelerated_bn254_pairing_jovian() {
-        const TEST_INPUT: [u8; 384] = hex!(
-            "2cf44499d5d27bb186308b7af7af02ac5bc9eeb6a3d147c186b21fb1b76e18da2c0f001f52110ccfe69108924926e45f0b0c868df0e7bde1fe16d3242dc715f61fb19bb476f6b9e44e2a32234da8212f61cd63919354bc06aef31e3cfaff3ebc22606845ff186793914e03e21df544c34ffe2f2f3504de8a79d9159eca2d98d92bd368e28381e8eccb5fa81fc26cf3f048eea9abfdd85d7ed3ab3698d63e4f902fe02e47887507adf0ff1743cbac6ba291e66f59be6bd763950bb16041a0a85e000000000000000000000000000000000000000000000000000000000000000130644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd451971ff0471b09fa93caaf13cbf443c1aede09cc4328f5a62aad45f40ec133eb4091058a3141822985733cbdddfed0fd8d6c104e9e9eff40bf5abfef9ab163bc72a23af9a5ce2ba2796c1f4e453a370eb0af8c212d9dc9acd8fc02c2e907baea223a8eb0b0996252cb548a4487da97b02422ebc0e834613f954de6c7e0afdc1fc"
-        );
-        const EXPECTED_OUTPUT: [u8; 32] =
-            hex!("0000000000000000000000000000000000000000000000000000000000000001");
-
-        let res = bn254_pair::run_pair_jovian(TEST_INPUT.as_ref(), u64::MAX);
-        assert!(matches!(res, Ok(outcome) if **outcome.bytes == EXPECTED_OUTPUT));
+        let res = bn254_pair::run_pair_jovian(BN254_PAIR_IDENTITY_INPUT.as_ref(), u64::MAX);
+        assert!(matches!(res, Ok(outcome) if **outcome.bytes == BN254_PAIR_IDENTITY_OUTPUT));
     }
 
     #[test]
@@ -412,6 +436,32 @@ mod tests {
         let input = [0u8; bn254_pair::JOVIAN_MAX_INPUT_SIZE + 1];
         let res = bn254_pair::run_pair_jovian(&input, u64::MAX);
         assert!(matches!(res, Err(PrecompileHalt::Bn254PairLength)));
+    }
+
+    #[test]
+    fn test_accelerated_bn254_pairing_karst() {
+        let res = bn254_pair::run_pair_karst(BN254_PAIR_IDENTITY_INPUT.as_ref(), u64::MAX);
+        assert!(matches!(res, Ok(outcome) if **outcome.bytes == BN254_PAIR_IDENTITY_OUTPUT));
+    }
+
+    #[test]
+    fn test_accelerated_bn254_pairing_bad_input_len_karst() {
+        let input = [0u8; bn254_pair::KARST_MAX_INPUT_SIZE + 1];
+        let res = bn254_pair::run_pair_karst(&input, u64::MAX);
+        assert!(matches!(res, Err(PrecompileHalt::Bn254PairLength)));
+    }
+
+    #[test]
+    fn test_get_karst_precompile_with_bad_input_len() {
+        let precompiles = OpPrecompiles::new_with_spec(OpSpecId::KARST);
+        let bn254_pair_precompile = precompiles.precompiles().get(&bn254::pair::ADDRESS).unwrap();
+
+        let bad_input_len = bn254_pair::KARST_MAX_INPUT_SIZE + 1;
+        assert!(bad_input_len < bn254_pair::JOVIAN_MAX_INPUT_SIZE);
+        let input = vec![0u8; bad_input_len];
+
+        let res = bn254_pair_precompile.execute(&input, u64::MAX, 0).unwrap();
+        assert!(matches!(res.status, PrecompileStatus::Halt(PrecompileHalt::Bn254PairLength)));
     }
 
     #[test]


### PR DESCRIPTION

Reduces the bn256Pairing (0x08) precompile max input size from 81,984 bytes (427 pairs) to 57,600 bytes (300 pairs) at the Karst hardfork. OpSpecId::KARST and OpSpecId::INTEROP pick up the new limit; OpSpecId::JOVIAN and earlier are unchanged.

Why

Jovian sized the bn256Pairing input cap so a worst-case loadPrecompilePreimagePart L1 transaction fits under EIP-7825's 16,777,216 gas cap, with ~503K of headroom at the current 34,000 gas-per-pair.

EIP-7904 (still in Draft) proposes raising the per-pair cost to 34,103 (+0.3%), reducing headroom to ~474K. At 427 pairs that's only ~1,110 extra gas per pair of tolerance before breaching the 16M cap (~3%). Client benchmarks in EIP-7904 show ±30–40% cross-client spread, so the final per-pair cost landing higher than the current draft is plausible.

Dropping to 300 pairs (57,600 bytes) adds more than Jovian-era headroom even at ~37,513 gas/pair. It's a one-time conservative reduction that avoids needing another input-size adjustment if EIP-7904/EIP-7825/EIP-2780/EIP-7976/EIP-8037 drafts shift before finalization.

Scope

- ✅ op-revm — add KARST_MAX_INPUT_SIZE, bn254_pair::KARST, run_pair_karst; the karst() precompile set swaps bn254_pair::JOVIAN for bn254_pair::KARST.
- ✅ kona FPVM — add BN256_MAX_PAIRING_SIZE_KARST, fpvm_bn128_pair_karst, accelerated_karst(); dispatch splits so JOVIAN => accelerated_jovian, KARST | INTEROP => accelerated_karst.
- ❌ op-geth / op-program — intentionally not updated. Both are being deprecated after Glamsterdam; op-revm (via op-reth) and kona are the only live execution/proving paths after Karst.
What's unchanged

- Jovian path: bn254_pair::JOVIAN, fpvm_bn128_pair_jovian, and OpSpecId::JOVIAN dispatch are not modified. Pre-Karst traffic keeps the 81,984-byte limit.
- All existing Jovian / Granite / Isthmus tests still pass.

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

Closes https://github.com/ethereum-optimism/optimism/issues/20195

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
