### PR TITLE
feat(op-challenger): age run-trace game inputs by ~16/7 days

### DIFF
--- a/op-challenger/cmd/run_trace.go
+++ b/op-challenger/cmd/run_trace.go
@@ -45,11 +45,12 @@ func RunTrace(ctx *cli.Context, _ context.CancelCauseFunc) (cliapp.Lifecycle, er
 		}
 	}
 	vmTimeout := ctx.Duration(VMTimeoutFlag.Name)
-	return runner.NewRunner(logger, cfg, runConfigs, vmTimeout), nil
+	ageGameInputs := ctx.Bool(AgeGameInputsFlag.Name)
+	return runner.NewRunner(logger, cfg, runConfigs, vmTimeout, ageGameInputs), nil
 }
 
 func runTraceFlags() []cli.Flag {
-	return append(flags.Flags, RunTraceRunFlag, VMTimeoutFlag)
+	return append(flags.Flags, RunTraceRunFlag, VMTimeoutFlag, AgeGameInputsFlag)
 }
 
 var RunTraceCommand = &cli.Command{
@@ -78,6 +79,11 @@ var (
 		Usage:   fmt.Sprintf("Maximum duration for VM execution per run. Default is %s. Set to 0 to disable timeout.", DefaultVMTimeout),
 		EnvVars: opservice.PrefixEnvVar(flags.EnvVarPrefix, "VM_TIMEOUT"),
 		Value:   DefaultVMTimeout,
+	}
+	AgeGameInputsFlag = &cli.BoolFlag{
+		Name:    "age-game-inputs",
+		Usage:   "Hold the game L1 head ~16 days behind the chain head and derive the disputed L2 block from an L1 block another ~7 days earlier.",
+		EnvVars: opservice.PrefixEnvVar(flags.EnvVarPrefix, "AGE_GAME_INPUTS"),
 	}
 )
 

--- a/op-challenger/runner/game_inputs.go
+++ b/op-challenger/runner/game_inputs.go
@@ -28,7 +28,7 @@ const (
 	disputeL1OffsetBlocks = uint64(7 * 24 * 60 * 60 / 12)  // 50400
 )
 
-func createGameInputs(ctx context.Context, log log.Logger, rollupClient *sources.RollupClient, superNodeClient *sources.SuperNodeClient, l1Client *ethclient.Client, typeName string, gameType gameTypes.GameType) (utils.LocalGameInputs, error) {
+func createGameInputs(ctx context.Context, log log.Logger, rollupClient *sources.RollupClient, superNodeClient *sources.SuperNodeClient, l1Client *ethclient.Client, typeName string, gameType gameTypes.GameType, ageGameInputs bool) (utils.LocalGameInputs, error) {
 	switch gameType {
 	case gameTypes.SuperCannonGameType, gameTypes.SuperPermissionedGameType, gameTypes.SuperCannonKonaGameType:
 		if superNodeClient == nil {
@@ -39,11 +39,11 @@ func createGameInputs(ctx context.Context, log log.Logger, rollupClient *sources
 		if rollupClient == nil {
 			return utils.LocalGameInputs{}, fmt.Errorf("game type %s requires rollup rpc to be set", gameType)
 		}
-		return createGameInputsSingle(ctx, log, rollupClient, l1Client, typeName)
+		return createGameInputsSingle(ctx, log, rollupClient, l1Client, typeName, ageGameInputs)
 	}
 }
 
-func createGameInputsSingle(ctx context.Context, log log.Logger, client *sources.RollupClient, l1Client *ethclient.Client, typeName string) (utils.LocalGameInputs, error) {
+func createGameInputsSingle(ctx context.Context, log log.Logger, client *sources.RollupClient, l1Client *ethclient.Client, typeName string, ageGameInputs bool) (utils.LocalGameInputs, error) {
 	status, err := client.SyncStatus(ctx)
 	if err != nil {
 		return utils.LocalGameInputs{}, fmt.Errorf("failed to get rollup sync status: %w", err)
@@ -66,36 +66,28 @@ func createGameInputsSingle(ctx context.Context, log log.Logger, client *sources
 		return utils.LocalGameInputs{}, errors.New("l1 head is 0")
 	}
 
-	gameL1Num := saturatingSub(refHead.Number, gameL1HeadAgeBlocks)
-	if _, err := client.SafeHeadAtL1Block(ctx, gameL1Num); errors.Is(err, safedb.ErrNotFound) {
-		// Chain is younger than the 16-day target (or op-node's safe-head DB doesn't reach
-		// back that far). Fall back to the most recent valid head.
-		log.Info("Game L1 block is before earliest known safe head, falling back to reference head", "gameL1", gameL1Num, "refHead", refHead.Number, "type", typeName)
-		gameL1Num = refHead.Number
-	} else if err != nil {
-		return utils.LocalGameInputs{}, fmt.Errorf("failed to check safe head at game L1 block %v: %w", gameL1Num, err)
-	}
-
-	disputeL1Num := saturatingSub(gameL1Num, disputeL1OffsetBlocks)
-	if _, err := client.SafeHeadAtL1Block(ctx, disputeL1Num); errors.Is(err, safedb.ErrNotFound) {
-		// Chain can't give us a disputed block 7 days before the game head either.
-		// Dispute the safe head at the game L1 block itself.
-		log.Info("Dispute L1 block is before earliest known safe head, falling back to game L1 head", "disputeL1", disputeL1Num, "gameL1", gameL1Num, "type", typeName)
-		disputeL1Num = gameL1Num
-	} else if err != nil {
-		return utils.LocalGameInputs{}, fmt.Errorf("failed to check safe head at dispute L1 block %v: %w", disputeL1Num, err)
-	}
-
-	l1HeadHeader, err := l1Client.HeaderByNumber(ctx, new(big.Int).SetUint64(gameL1Num))
+	gameL1Num, disputeL1Num, err := selectGameAndDisputeL1Blocks(ctx, log, client, refHead.Number, typeName, ageGameInputs)
 	if err != nil {
-		return utils.LocalGameInputs{}, fmt.Errorf("failed to fetch l1 head at block %v: %w", gameL1Num, err)
+		return utils.LocalGameInputs{}, err
 	}
-	l1HeadHash := l1HeadHeader.Hash()
+
+	l1HeadHash := refHead.Hash
+	if gameL1Num != refHead.Number {
+		l1HeadHeader, err := l1Client.HeaderByNumber(ctx, new(big.Int).SetUint64(gameL1Num))
+		if err != nil {
+			return utils.LocalGameInputs{}, fmt.Errorf("failed to fetch l1 head at block %v: %w", gameL1Num, err)
+		}
+		l1HeadHash = l1HeadHeader.Hash()
+	}
 	log.Info("Using L1 head", "num", gameL1Num, "hash", l1HeadHash, "disputeL1", disputeL1Num, "type", typeName)
 
 	blockNumber, err := findL2BlockNumberToDispute(ctx, log, client, disputeL1Num)
 	if err != nil {
 		return utils.LocalGameInputs{}, fmt.Errorf("failed to find l2 block number to dispute: %w", err)
+	}
+	if blockNumber == 0 {
+		// L2 genesis can't be disputed (no parent block to use as the agreed prestate).
+		return utils.LocalGameInputs{}, errors.New("dispute l2 block is at or below genesis")
 	}
 	claimOutput, err := client.OutputAtBlock(ctx, blockNumber)
 	if err != nil {
@@ -115,11 +107,61 @@ func createGameInputsSingle(ctx context.Context, log log.Logger, client *sources
 	return localInputs, nil
 }
 
-func saturatingSub(a, b uint64) uint64 {
-	if a < b {
-		return 0
+// selectGameAndDisputeL1Blocks returns the L1 head used for the game and the L1 block whose
+// safe head bounds the disputed L2 block. A candidate is only accepted if the L2 safe head at
+// that block is non-zero, so we don't pick L1 blocks that predate the L2 chain's first batch.
+func selectGameAndDisputeL1Blocks(ctx context.Context, log log.Logger, client *sources.RollupClient, refHeadNum uint64, typeName string, ageGameInputs bool) (uint64, uint64, error) {
+	if !ageGameInputs {
+		return refHeadNum, refHeadNum, nil
 	}
-	return a - b
+
+	gameL1Num := refHeadNum
+	if refHeadNum >= gameL1HeadAgeBlocks {
+		candidate := refHeadNum - gameL1HeadAgeBlocks
+		ok, err := hasNonZeroSafeHead(ctx, client, candidate)
+		if err != nil {
+			return 0, 0, fmt.Errorf("failed to check safe head at game L1 block %v: %w", candidate, err)
+		}
+		if ok {
+			gameL1Num = candidate
+		} else {
+			log.Info("Game L1 block has no L2 safe head, falling back to reference head", "gameL1", candidate, "refHead", refHeadNum, "type", typeName)
+		}
+	} else {
+		log.Info("Reference head younger than game L1 age, falling back to reference head", "refHead", refHeadNum, "ageBlocks", gameL1HeadAgeBlocks, "type", typeName)
+	}
+
+	disputeL1Num := gameL1Num
+	if gameL1Num >= disputeL1OffsetBlocks {
+		candidate := gameL1Num - disputeL1OffsetBlocks
+		ok, err := hasNonZeroSafeHead(ctx, client, candidate)
+		if err != nil {
+			return 0, 0, fmt.Errorf("failed to check safe head at dispute L1 block %v: %w", candidate, err)
+		}
+		if ok {
+			disputeL1Num = candidate
+		} else {
+			log.Info("Dispute L1 block has no L2 safe head, falling back to game L1 head", "disputeL1", candidate, "gameL1", gameL1Num, "type", typeName)
+		}
+	} else {
+		log.Info("Game L1 block younger than dispute offset, falling back to game L1 head", "gameL1", gameL1Num, "offsetBlocks", disputeL1OffsetBlocks, "type", typeName)
+	}
+
+	return gameL1Num, disputeL1Num, nil
+}
+
+// hasNonZeroSafeHead reports whether op-node has a non-genesis L2 safe head at the given L1
+// block. Returns false if the safedb has no entry for the block, or if the recorded safe head
+// is L2 block 0 (the L1 block predates the L2 chain's first batch).
+func hasNonZeroSafeHead(ctx context.Context, client *sources.RollupClient, l1Num uint64) (bool, error) {
+	safeHead, err := client.SafeHeadAtL1Block(ctx, l1Num)
+	if errors.Is(err, safedb.ErrNotFound) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return safeHead.SafeHead.Number > 0, nil
 }
 
 func createGameInputsInterop(ctx context.Context, log log.Logger, client *sources.SuperNodeClient, typeName string) (utils.LocalGameInputs, error) {

--- a/op-challenger/runner/game_inputs.go
+++ b/op-challenger/runner/game_inputs.go
@@ -11,12 +11,24 @@ import (
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/utils"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum-optimism/optimism/op-node/node/safedb"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
 )
 
-func createGameInputs(ctx context.Context, log log.Logger, rollupClient *sources.RollupClient, superNodeClient *sources.SuperNodeClient, typeName string, gameType gameTypes.GameType) (utils.LocalGameInputs, error) {
+// Simulate a dispute game created roughly 16 days ago on a proposal that was ~7 days old
+// at creation time (just above the anchor state), then played out over the maximum ~16-day
+// duration with clock extensions. The L1 head in the game inputs therefore sits ~16 days
+// behind the current chain head, and the disputed L2 block is derived from an L1 block
+// another ~7 days earlier than that. Conversions assume a 12-second L1 block time.
+const (
+	gameL1HeadAgeBlocks   = uint64(16 * 24 * 60 * 60 / 12) // 115200
+	disputeL1OffsetBlocks = uint64(7 * 24 * 60 * 60 / 12)  // 50400
+)
+
+func createGameInputs(ctx context.Context, log log.Logger, rollupClient *sources.RollupClient, superNodeClient *sources.SuperNodeClient, l1Client *ethclient.Client, typeName string, gameType gameTypes.GameType) (utils.LocalGameInputs, error) {
 	switch gameType {
 	case gameTypes.SuperCannonGameType, gameTypes.SuperPermissionedGameType, gameTypes.SuperCannonKonaGameType:
 		if superNodeClient == nil {
@@ -27,34 +39,61 @@ func createGameInputs(ctx context.Context, log log.Logger, rollupClient *sources
 		if rollupClient == nil {
 			return utils.LocalGameInputs{}, fmt.Errorf("game type %s requires rollup rpc to be set", gameType)
 		}
-		return createGameInputsSingle(ctx, log, rollupClient, typeName)
+		return createGameInputsSingle(ctx, log, rollupClient, l1Client, typeName)
 	}
 }
 
-func createGameInputsSingle(ctx context.Context, log log.Logger, client *sources.RollupClient, typeName string) (utils.LocalGameInputs, error) {
+func createGameInputsSingle(ctx context.Context, log log.Logger, client *sources.RollupClient, l1Client *ethclient.Client, typeName string) (utils.LocalGameInputs, error) {
 	status, err := client.SyncStatus(ctx)
 	if err != nil {
 		return utils.LocalGameInputs{}, fmt.Errorf("failed to get rollup sync status: %w", err)
 	}
 	log.Info("Got sync status", "status", status, "type", typeName)
 
-	l1Head := status.FinalizedL1
+	refHead := status.FinalizedL1
 	if status.FinalizedL1.Number > status.CurrentL1.Number {
-		// Restrict the L1 head to a block that has actually been processed by op-node.
+		// Restrict the reference head to a block that has actually been processed by op-node.
 		// This only matters if op-node is behind and hasn't processed all finalized L1 blocks yet.
-		l1Head = status.CurrentL1
+		refHead = status.CurrentL1
 		log.Info("Node has not completed syncing finalized L1 block, using CurrentL1 instead", "type", typeName)
 	} else if status.FinalizedL1.Number == 0 {
 		// The node is resetting its pipeline and has set FinalizedL1 to 0, use the current L1 instead as it is the best
 		// hope of getting a non-zero L1 block
-		l1Head = status.CurrentL1
+		refHead = status.CurrentL1
 		log.Warn("Node has zero finalized L1 block, using CurrentL1 instead", "type", typeName)
 	}
-	log.Info("Using L1 head", "head", l1Head, "type", typeName)
-	if l1Head.Number == 0 {
+	if refHead.Number == 0 {
 		return utils.LocalGameInputs{}, errors.New("l1 head is 0")
 	}
-	blockNumber, err := findL2BlockNumberToDispute(ctx, log, client, l1Head.Number)
+
+	gameL1Num := saturatingSub(refHead.Number, gameL1HeadAgeBlocks)
+	if _, err := client.SafeHeadAtL1Block(ctx, gameL1Num); errors.Is(err, safedb.ErrNotFound) {
+		// Chain is younger than the 16-day target (or op-node's safe-head DB doesn't reach
+		// back that far). Fall back to the most recent valid head.
+		log.Info("Game L1 block is before earliest known safe head, falling back to reference head", "gameL1", gameL1Num, "refHead", refHead.Number, "type", typeName)
+		gameL1Num = refHead.Number
+	} else if err != nil {
+		return utils.LocalGameInputs{}, fmt.Errorf("failed to check safe head at game L1 block %v: %w", gameL1Num, err)
+	}
+
+	disputeL1Num := saturatingSub(gameL1Num, disputeL1OffsetBlocks)
+	if _, err := client.SafeHeadAtL1Block(ctx, disputeL1Num); errors.Is(err, safedb.ErrNotFound) {
+		// Chain can't give us a disputed block 7 days before the game head either.
+		// Dispute the safe head at the game L1 block itself.
+		log.Info("Dispute L1 block is before earliest known safe head, falling back to game L1 head", "disputeL1", disputeL1Num, "gameL1", gameL1Num, "type", typeName)
+		disputeL1Num = gameL1Num
+	} else if err != nil {
+		return utils.LocalGameInputs{}, fmt.Errorf("failed to check safe head at dispute L1 block %v: %w", disputeL1Num, err)
+	}
+
+	l1HeadHeader, err := l1Client.HeaderByNumber(ctx, new(big.Int).SetUint64(gameL1Num))
+	if err != nil {
+		return utils.LocalGameInputs{}, fmt.Errorf("failed to fetch l1 head at block %v: %w", gameL1Num, err)
+	}
+	l1HeadHash := l1HeadHeader.Hash()
+	log.Info("Using L1 head", "num", gameL1Num, "hash", l1HeadHash, "disputeL1", disputeL1Num, "type", typeName)
+
+	blockNumber, err := findL2BlockNumberToDispute(ctx, log, client, disputeL1Num)
 	if err != nil {
 		return utils.LocalGameInputs{}, fmt.Errorf("failed to find l2 block number to dispute: %w", err)
 	}
@@ -67,13 +106,20 @@ func createGameInputsSingle(ctx context.Context, log log.Logger, client *sources
 		return utils.LocalGameInputs{}, fmt.Errorf("failed to get claim output: %w", err)
 	}
 	localInputs := utils.LocalGameInputs{
-		L1Head:           l1Head.Hash,
+		L1Head:           l1HeadHash,
 		L2Head:           parentOutput.BlockRef.Hash,
 		L2OutputRoot:     common.Hash(parentOutput.OutputRoot),
 		L2Claim:          common.Hash(claimOutput.OutputRoot),
 		L2SequenceNumber: new(big.Int).SetUint64(blockNumber),
 	}
 	return localInputs, nil
+}
+
+func saturatingSub(a, b uint64) uint64 {
+	if a < b {
+		return 0
+	}
+	return a - b
 }
 
 func createGameInputsInterop(ctx context.Context, log log.Logger, client *sources.SuperNodeClient, typeName string) (utils.LocalGameInputs, error) {
@@ -142,27 +188,37 @@ func createGameInputsInterop(ctx context.Context, log log.Logger, client *source
 	return localInputs, nil
 }
 
-// findL2BlockNumberToDispute finds a safe l2 block number at different positions in a span batch
-func findL2BlockNumberToDispute(ctx context.Context, log log.Logger, client *sources.RollupClient, l1HeadNum uint64) (uint64, error) {
-	safeHead, err := client.SafeHeadAtL1Block(ctx, l1HeadNum)
+// findL2BlockNumberToDispute finds a safe l2 block number at different positions in a span batch.
+// disputeL1Num is the L1 block whose safe head is the upper bound on the L2 block we pick; the
+// function then walks further back in L1 to find a span batch boundary so that the selection
+// can land at random positions within (or either edge of) a span batch.
+func findL2BlockNumberToDispute(ctx context.Context, log log.Logger, client *sources.RollupClient, disputeL1Num uint64) (uint64, error) {
+	safeHead, err := client.SafeHeadAtL1Block(ctx, disputeL1Num)
 	if err != nil {
-		return 0, fmt.Errorf("failed to find safe head from l1 head %v: %w", l1HeadNum, err)
+		return 0, fmt.Errorf("failed to find safe head from l1 block %v: %w", disputeL1Num, err)
 	}
 	maxL2BlockNum := safeHead.SafeHead.Number
 
 	// Find a prior span batch boundary
 	// Limits how far back we search to 10 * 32 blocks
 	const skipSize = uint64(32)
+	l1Num := disputeL1Num
 	for i := 0; i < 10; i++ {
-		if l1HeadNum < skipSize {
+		if l1Num < skipSize {
 			// Too close to genesis, give up and just use the original block
 			log.Info("Failed to find prior batch.")
 			return maxL2BlockNum, nil
 		}
-		l1HeadNum -= skipSize
-		prevSafeHead, err := client.SafeHeadAtL1Block(ctx, l1HeadNum)
+		l1Num -= skipSize
+		prevSafeHead, err := client.SafeHeadAtL1Block(ctx, l1Num)
+		if errors.Is(err, safedb.ErrNotFound) {
+			// Walked back past the earliest known safe head (e.g. L2 genesis). Give up
+			// looking for an earlier boundary and just use what we have.
+			log.Info("Walked past earliest known safe head, using current max L2 block", "l2BlockNum", maxL2BlockNum)
+			return maxL2BlockNum, nil
+		}
 		if err != nil {
-			return 0, fmt.Errorf("failed to get prior safe head at L1 block %v: %w", l1HeadNum, err)
+			return 0, fmt.Errorf("failed to get prior safe head at L1 block %v: %w", l1Num, err)
 		}
 		if prevSafeHead.SafeHead.Number < maxL2BlockNum {
 			switch rand.IntN(3) {
@@ -181,6 +237,6 @@ func findL2BlockNumberToDispute(ctx context.Context, log log.Logger, client *sou
 			}
 		}
 	}
-	log.Warn("Failed to find prior batch", "l2BlockNum", maxL2BlockNum, "earliestCheckL1Block", l1HeadNum)
+	log.Warn("Failed to find prior batch", "l2BlockNum", maxL2BlockNum, "earliestCheckL1Block", l1Num)
 	return maxL2BlockNum, nil
 }

--- a/op-challenger/runner/runner.go
+++ b/op-challenger/runner/runner.go
@@ -74,6 +74,7 @@ type Runner struct {
 	runConfigs           []RunConfig
 	m                    Metricer
 	vmTimeout            time.Duration
+	ageGameInputs        bool
 	traceProviderCreator TraceProviderCreator
 
 	running    atomic.Bool
@@ -83,13 +84,14 @@ type Runner struct {
 	metricsSrv *httputil.HTTPServer
 }
 
-func NewRunner(logger log.Logger, cfg *config.Config, runConfigs []RunConfig, vmTimeout time.Duration) *Runner {
+func NewRunner(logger log.Logger, cfg *config.Config, runConfigs []RunConfig, vmTimeout time.Duration, ageGameInputs bool) *Runner {
 	return &Runner{
 		log:                  logger,
 		cfg:                  cfg,
 		runConfigs:           runConfigs,
 		m:                    NewMetrics(runConfigs),
 		vmTimeout:            vmTimeout,
+		ageGameInputs:        ageGameInputs,
 		traceProviderCreator: createTraceProvider,
 	}
 }
@@ -196,7 +198,7 @@ func (r *Runner) runAndRecordOnce(ctx context.Context, rlog log.Logger, runConfi
 		prestateSource = &HashPrestateFetcher{prestateHash: runConfig.Prestate}
 	}
 
-	localInputs, err := createGameInputs(ctx, rlog, rollupClient, superNodeClient, l1EthClient, runConfig.Name, runConfig.GameType)
+	localInputs, err := createGameInputs(ctx, rlog, rollupClient, superNodeClient, l1EthClient, runConfig.Name, runConfig.GameType, r.ageGameInputs)
 	if err != nil {
 		recordError(err, runConfig.Name, r.m, rlog)
 		return

--- a/op-challenger/runner/runner.go
+++ b/op-challenger/runner/runner.go
@@ -17,6 +17,7 @@ import (
 
 	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm"
@@ -128,23 +129,24 @@ func (r *Runner) Start(ctx context.Context) error {
 		return fmt.Errorf("failed to dial l1 client: %w", err)
 	}
 	caller := batching.NewMultiCaller(l1Client, batching.DefaultBatchSize)
+	l1EthClient := ethclient.NewClient(l1Client)
 
 	for _, runConfig := range r.runConfigs {
 		r.wg.Add(1)
-		go r.loop(ctx, runConfig, rollupClient, superNodeClient, caller)
+		go r.loop(ctx, runConfig, rollupClient, superNodeClient, l1EthClient, caller)
 	}
 
 	r.log.Info("Runners started", "num", len(r.runConfigs))
 	return nil
 }
 
-func (r *Runner) loop(ctx context.Context, runConfig RunConfig, rollupClient *sources.RollupClient, superNodeClient *sources.SuperNodeClient, caller *batching.MultiCaller) {
+func (r *Runner) loop(ctx context.Context, runConfig RunConfig, rollupClient *sources.RollupClient, superNodeClient *sources.SuperNodeClient, l1EthClient *ethclient.Client, caller *batching.MultiCaller) {
 	defer r.wg.Done()
 	t := time.NewTicker(1 * time.Minute)
 	defer t.Stop()
 	for {
 		baseLog := r.log.New("run_id", generateRunID())
-		r.runAndRecordOnce(ctx, baseLog, runConfig, rollupClient, superNodeClient, caller)
+		r.runAndRecordOnce(ctx, baseLog, runConfig, rollupClient, superNodeClient, l1EthClient, caller)
 		select {
 		case <-t.C:
 		case <-ctx.Done():
@@ -153,7 +155,7 @@ func (r *Runner) loop(ctx context.Context, runConfig RunConfig, rollupClient *so
 	}
 }
 
-func (r *Runner) runAndRecordOnce(ctx context.Context, rlog log.Logger, runConfig RunConfig, rollupClient *sources.RollupClient, superNodeClient *sources.SuperNodeClient, caller *batching.MultiCaller) {
+func (r *Runner) runAndRecordOnce(ctx context.Context, rlog log.Logger, runConfig RunConfig, rollupClient *sources.RollupClient, superNodeClient *sources.SuperNodeClient, l1EthClient *ethclient.Client, caller *batching.MultiCaller) {
 	recordError := func(err error, configName string, m Metricer, log log.Logger) {
 		if errors.Is(err, ErrUnexpectedStatusCode) {
 			log.Error("Incorrect status code", "type", runConfig.Name, "err", err)
@@ -194,7 +196,7 @@ func (r *Runner) runAndRecordOnce(ctx context.Context, rlog log.Logger, runConfi
 		prestateSource = &HashPrestateFetcher{prestateHash: runConfig.Prestate}
 	}
 
-	localInputs, err := createGameInputs(ctx, rlog, rollupClient, superNodeClient, runConfig.Name, runConfig.GameType)
+	localInputs, err := createGameInputs(ctx, rlog, rollupClient, superNodeClient, l1EthClient, runConfig.Name, runConfig.GameType)
 	if err != nil {
 		recordError(err, runConfig.Name, r.m, rlog)
 		return

--- a/op-challenger/runner/runner_test.go
+++ b/op-challenger/runner/runner_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestNewRunnerSetsTimeout(t *testing.T) {
 	timeout := 5 * time.Minute
-	r := NewRunner(nil, nil, nil, timeout)
+	r := NewRunner(nil, nil, nil, timeout, false)
 	require.Equal(t, timeout, r.vmTimeout)
 }
 


### PR DESCRIPTION
## Summary

`run-trace` now picks a game L1 head ~16 days behind the current chain head and a disputed L2 block derived from an L1 block a further ~7 days earlier. This simulates a dispute game created on a proposal just above the anchor state and played out over the maximum game duration with clock extensions — giving the trace runner coverage of the range of states real dispute games actually see. On young chains both offsets fall back via `safedb.ErrNotFound` so inputs are still produced. Interop (`createGameInputsInterop`) is deliberately left unchanged for now.

Partial progress on ethereum-optimism/optimism#19517 — further work required, this PR does not close the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)