### PR TITLE
refactor(cannon-builder): reduce to apt-only MIPS64 cross-toolchain

### DIFF
--- a/rust/kona/docker/cannon/cannon.dockerfile
+++ b/rust/kona/docker/cannon/cannon.dockerfile
@@ -3,8 +3,9 @@ FROM ubuntu:22.04
 ENV SHELL=/bin/bash
 ENV DEBIAN_FRONTEND=noninteractive
 
-ENV RUST_VERSION=nightly-2026-02-20
-
+# MIPS64 cross-compilation toolchain — the only thing that must be frozen
+# in a Docker image because apt package versions are not deterministically pinnable.
+# Everything else (Rust, Go, mise, just) is installed on top from pinned version sources.
 RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
   ca-certificates \
   build-essential \
@@ -17,19 +18,3 @@ RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
   make \
   cmake \
   git
-
-# Install Rustup and Rust
-RUN curl https://sh.rustup.rs -sSf | bash -s -- -y --default-toolchain ${RUST_VERSION} --component rust-src
-ENV PATH="/root/.cargo/bin:${PATH}"
-
-# Add the special cannon build target
-COPY ./mips64-unknown-none.json .
-
-# Set up the env vars to instruct rustc to use the correct compiler and linker
-# and to build correctly to support the Cannon processor
-ENV CC_mips64_unknown_none=mips64-linux-gnuabi64-gcc \
-  CXX_mips64_unknown_none=mips64-linux-gnuabi64-g++ \
-  CARGO_TARGET_MIPS64_UNKNOWN_NONE_LINKER=mips64-linux-gnuabi64-gcc \
-  RUSTFLAGS="-Clink-arg=-e_start -Cllvm-args=-mno-check-zero-division" \
-  CARGO_BUILD_TARGET="/mips64-unknown-none.json" \
-  RUSTUP_TOOLCHAIN=${RUST_VERSION}


### PR DESCRIPTION
Reduces `cannon-builder` to its apt-only core: the MIPS64 cross-toolchain plus a handful of C/C++ build tools that can't be deterministically pinned outside a Docker image. Rust, target spec, and build env vars are dropped — consumers will install those on top from pinned sources (mise, `rust-toolchain.toml`, source tree) at build time.

Goal: decouple the base image from toolchain drift so it becomes a stable, long-lived artifact.

## Release

A new `cannon-builder/v2.0.0` tag must be cut after merge to publish the updated image. `cannon-builder:v1.0.0` remains immutable.

## Stack

ethereum-optimism/optimism#19889 is stacked on top; it updates consumers to install Rust on top of the apt-only image and supply their own `mips64-unknown-none.json`.