### PR TITLE
fix(op-acceptance-tests): tolerate transient EL errors in Steady sampler

### DIFF
--- a/op-acceptance-tests/tests/interop/loadtest/schedule.go
+++ b/op-acceptance-tests/tests/interop/loadtest/schedule.go
@@ -270,7 +270,11 @@ func (s *Steady) Run(t devtest.T, spammer Spammer) {
 					if errors.Is(err, t.Ctx().Err()) {
 						return
 					}
-					t.Require().NoError(err)
+					// A transient sampling failure (e.g. dial timeout under load) is
+					// not a test failure. Log and try again next tick; leave the AIMD
+					// state unchanged so the current RPS is preserved.
+					t.Logger().Warn("Steady sampler failed to read unsafe head", "err", err)
+					continue
 				}
 				gasTarget := unsafe.GasLimit() / s.elasticityMultiplier
 				// Apply backpressure when we meet or exceed the gas target.


### PR DESCRIPTION
## Summary

Makes the `Steady.Run` backpressure sampler in the interop loadtest package resilient to transient EL errors. Fixes the flaky `TestRelayWithInvalidMessagesSteady` test (ethereum-optimism/optimism#20254).

## Root cause

`Steady.Run` (`op-acceptance-tests/tests/interop/loadtest/schedule.go:261-280`) spawns a goroutine that polls the unsafe head every `blockTime` to feed AIMD backpressure. The only non-fatal error path was `errors.Is(err, t.Ctx().Err())`, which catches only context cancellation / deadline errors. A `dial tcp 127.0.0.1:<proxy port>: i/o timeout` produced under load is a `*net.OpError` wrapping a syscall timeout — not a context error — so it bypassed the guard and hit `t.Require().NoError(err)` at line 273, failing the test.

`TestRelayWithInvalidMessagesSteady` concurrently spams ~1,000 invalid executing messages per block time at the same `l2B` `op-reth` EL via the same TCP proxy that the Steady sampler dials through. The proxy's accept backlog saturates intermittently under that load, producing dial timeouts. The spammer goroutines already treat these as non-fatal (via `logOnError` at `schedule.go:325-333` and `invalid_msg_test.go:77`); only the Steady sampler was fatal.

## Why flaky, not consistent

Dial timeouts on the proxy happen continuously under this workload (hundreds per run on the spammer side, all tolerated), but the Steady sampler dials only once per `blockTime`. Whether the sampler's single dial lands in a saturated window is the non-deterministic variable. Observed flake rate: 3 runs across pipelines 123082 / 123217 / 123327.

## Fix

Replace the fatal `Require().NoError(err)` in the sampler with a warn-and-continue, mirroring the existing tolerance pattern used by the other goroutines in the same test. AIMD state is preserved across the skip (rps is clamped `>= 1` in `Adjust`), so the next successful tick resumes backpressure updates.

```diff
-                    t.Require().NoError(err)
+                    // A transient sampling failure (e.g. dial timeout under load) is
+                    // not a test failure. Log and try again next tick; leave the AIMD
+                    // state unchanged so the current RPS is preserved.
+                    t.Logger().Warn("Steady sampler failed to read unsafe head", "err", err)
+                    continue
```

Closes ethereum-optimism/optimism#20254

## Test plan

- [x] `go build ./op-acceptance-tests/...` — clean
- [x] `go vet ./op-acceptance-tests/...` — clean
- [x] `just lint-go` — clean
- [ ] Watch the `memory-all-*-op-reth` acceptance jobs on CI for subsequent runs to confirm the flake is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)