### PR TITLE
feat: L2CM authoritative registry

### DIFF
--- a/packages/contracts-bedrock/src/libraries/Predeploys.sol
+++ b/packages/contracts-bedrock/src/libraries/Predeploys.sol
@@ -145,17 +145,13 @@ library Predeploys {
     }
 
     /// @notice Returns the name of the predeploy at the given address.
+    ///         Always returns the primary, non-variant, record name for a given proxy address.
+    ///         e.g. getName(L1_BLOCK_ATTRIBUTES) always returns "L1Block", not "L1BlockCGT".
     function getName(address _addr) internal pure returns (string memory out_) {
         require(isPredeployNamespace(_addr), "Predeploys: address must be a predeploy");
-
-        // Get default name for CGT variants
-        if (_addr == L1_BLOCK_ATTRIBUTES) return "L1Block";
-        if (_addr == L2_TO_L1_MESSAGE_PASSER) return "L2ToL1MessagePasser";
-
-        // Get name from record
         PredeployRecord[] memory records = getAllRecords();
         for (uint256 i = 0; i < records.length; i++) {
-            if (records[i].proxy == _addr) {
+            if (records[i].proxy == _addr && !records[i].isVariant) {
                 return records[i].name;
             }
         }

--- a/packages/contracts-bedrock/src/libraries/Predeploys.sol
+++ b/packages/contracts-bedrock/src/libraries/Predeploys.sol
@@ -164,7 +164,13 @@ library Predeploys {
 
     /// @notice Returns true if the predeploy is not proxied.
     function notProxied(address _addr) internal pure returns (bool) {
-        return _addr == GOVERNANCE_TOKEN || _addr == WETH;
+        PredeployRecord[] memory records = getAllRecords();
+        for (uint256 i = 0; i < records.length; i++) {
+            if (records[i].proxy == _addr) {
+                return !records[i].isProxied;
+            }
+        }
+        return false;
     }
 
     /// @notice Returns true if the address is in the predeploy namespace.

--- a/packages/contracts-bedrock/test/libraries/Predeploys.t.sol
+++ b/packages/contracts-bedrock/test/libraries/Predeploys.t.sol
@@ -20,15 +20,13 @@ abstract contract Predeploys_TestInit is CommonTest {
     //////////////////////////////////////////////////////
 
     /// @notice Returns true if the address is a predeploy that has a different code in the
-    ///         interop mode.
-    function _interopCodeDiffer(address _addr) internal pure returns (bool) {
-        return _addr == Predeploys.L1_BLOCK_ATTRIBUTES || _addr == Predeploys.L2_STANDARD_BRIDGE;
-    }
-
-    /// @notice Returns true if the address is a predeploy that has a different code in the
-    ///         custom gas token mode.
+    ///         custom gas token mode, derived from the registry from `isVariant` && `isCustomGasToken`.
     function _customGasTokenCodeDiffer(address _addr) internal pure returns (bool) {
-        return _addr == Predeploys.L1_BLOCK_ATTRIBUTES || _addr == Predeploys.L2_TO_L1_MESSAGE_PASSER;
+        Predeploys.PredeployRecord[] memory records = Predeploys.getAllRecords();
+        for (uint256 i = 0; i < records.length; i++) {
+            if (records[i].proxy == _addr && records[i].isVariant && records[i].isCustomGasToken) return true;
+        }
+        return false;
     }
 
     /// @notice Returns true if the account is not meant to be in the L2 genesis anymore.
@@ -130,7 +128,7 @@ abstract contract Predeploys_TestInit is CommonTest {
                 string.concat("Implementation mismatch for ", vm.toString(addr))
             );
             assertNotEq(implAddr.code.length, 0, "predeploy implementation account must have code");
-            if (!_usesImmutables(addr) && !_interopCodeDiffer(addr) && !_customGasTokenCodeDiffer(addr)) {
+            if (!_usesImmutables(addr) && !_customGasTokenCodeDiffer(addr)) {
                 // can't check bytecode if it's modified with immutables in genesis.
                 assertEq(implAddr.code, supposedCode, "proxy implementation contract should match contract source");
             }

--- a/packages/contracts-bedrock/test/libraries/Predeploys.t.sol
+++ b/packages/contracts-bedrock/test/libraries/Predeploys.t.sol
@@ -173,6 +173,17 @@ contract Predeploys_PredeployToCodeNamespace_Test is Predeploys_TestInit {
     }
 }
 
+/// @title Predeploys_GetName_Test
+/// @notice Tests the `getName` function of the `Predeploys` library.
+contract Predeploys_GetName_Test is Predeploys_TestInit {
+    /// @notice Tests that for addresses with CGT variants which share their proxy address with a primary
+    ///         record getName always return the primary name.
+    function test_getName_forVariantProxy_succeeds() external pure {
+        assertEq(Predeploys.getName(Predeploys.L1_BLOCK_ATTRIBUTES), "L1Block");
+        assertEq(Predeploys.getName(Predeploys.L2_TO_L1_MESSAGE_PASSER), "L2ToL1MessagePasser");
+    }
+}
+
 /// @title Predeploys_Uncategorized_Test
 /// @notice General tests that are not testing any function directly of the `Predeploys` contract
 ///         or are testing multiple functions at once.


### PR DESCRIPTION
## Summary
Reduces the number of locations that require manual updates when a new Predeploy is added.

## Changes
- `notProxied()`: replaced hardcoded `GOVERNANCE_TOKEN || WETH` check with a loop over `getAllRecords()`, returning `!record.isProxied`.
- `getName()`: removed hardcoded CGT variant address overrides.                                                                   
- test helpers:
    - `_customGasTokenCodeDiffer`: replaced hardcoded addresses with a registry driven loop over `isVariant` && `isCustomGasToken` records.
    - `_interopCodeDiffer` removed entirely as it was returning stale exemptions for `L1Block` and `L2StandardBridge`.