### PR TITLE
fix(contracts-bedrock): skip auto-formatting in CI checks-fast

### DIFF
--- a/packages/contracts-bedrock/checks.yaml
+++ b/packages/contracts-bedrock/checks.yaml
@@ -23,8 +23,8 @@ phases:
     parallel: false
     checks:
       - name: lint-fix
-        description: Fix code formatting
-        command: forge fmt || true
+        description: Fix code formatting locally
+        command: '[ -n "${CI:-}" ] || forge fmt || true'
 
   # Phase 2: Pre-build checks - no compilation needed
   - name: pre-build


### PR DESCRIPTION
## Summary
- stop `check-fast` from mutating the workspace in CI before running `forge fmt --check`
- keep local `check-fast` behavior unchanged by still auto-formatting outside CI
- make the `lint` result in `contracts-bedrock-checks-fast-feature-tests` reflect whether the committed branch was already formatted

## Testing
- `CI=1 mise exec -- just check-fast -run lint`

## Context
Previously, `packages/contracts-bedrock/checks.yaml` ran `forge fmt || true` in the setup phase and then `forge fmt --check` in pre-build. That allowed CI to format the checkout first and then pass the formatting check on the mutated workspace.