### PR TITLE
Delete .circleci/Untitled

### DIFF
--- a/.circleci/Untitled
+++ b/.circleci/Untitled
@@ -1,1 +1,0 @@
-c-contracts_changed


### PR DESCRIPTION
This pull request makes a minor update by removing the line `c-contracts_changed` from the `.circleci/Untitled` file. 
This file is not needed.