### PR TITLE
feat(op-acceptance): add pre-genesis super dispute game coverage

### DIFF
--- a/op-acceptance-tests/tests/interop/proofs/challenger_test.go
+++ b/op-acceptance-tests/tests/interop/proofs/challenger_test.go
@@ -84,3 +84,22 @@ func TestChallengerRespondsToMultipleInvalidClaimsEOA(gt *testing.T) {
 		require.Equal(t, attacker.Address(), claim.Claimant())
 	}
 }
+
+func TestChallengerCountersPreGenesisGame(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewSimpleInteropSupernodeProofs(
+		t,
+		presets.WithChallengerCannonKonaEnabled(),
+		presets.WithPreGenesisSuperGame(
+			eth.Bytes32(common.HexToHash("0x1111000000000000000000000000000000000000000000000000000000000000")),
+			eth.Bytes32(common.HexToHash("0x2222000000000000000000000000000000000000000000000000000000000000")),
+		),
+	)
+
+	game := sys.DisputeGameFactory().SuperGameAtIndex(0)
+	genesisTime := sys.L2ChainA.Escape().RollupConfig().Genesis.L2Time
+	require.EqualValues(t, genesisTime, game.StartingL2SequenceNumber(), "pre-genesis game should anchor at rollup genesis")
+	require.Greater(t, game.L2SequenceNumber(), genesisTime, "pre-genesis game should dispute a post-genesis timestamp")
+
+	game.RootClaim().WaitForCounterClaim()
+}

--- a/op-devstack/dsl/proofs/claim.go
+++ b/op-devstack/dsl/proofs/claim.go
@@ -59,6 +59,10 @@ func (c *Claim) Claimant() common.Address {
 	return c.claim.Claimant
 }
 
+func (c *Claim) CounteredBy() common.Address {
+	return c.game.claimAtIndex(c.Index).CounteredBy
+}
+
 func (c *Claim) Depth() types.Depth {
 	return c.claim.Depth()
 }

--- a/op-devstack/dsl/proofs/dispute_game_factory.go
+++ b/op-devstack/dsl/proofs/dispute_game_factory.go
@@ -168,6 +168,21 @@ func (f *DisputeGameFactory) GameAtIndex(idx int64) *FaultDisputeGame {
 	return NewFaultDisputeGame(f.t, f.require, gameInfo.Proxy, f.getGameHelper, f.honestTraceForGame, game)
 }
 
+func (f *DisputeGameFactory) SuperGameAtIndex(idx int64) *SuperFaultDisputeGame {
+	gameInfo := contract.Read(f.dgf.GameAtIndex(big.NewInt(idx)))
+	gameType := gameTypes.GameType(gameInfo.GameType)
+	f.require.Truef(
+		gameType == gameTypes.SuperCannonGameType ||
+			gameType == gameTypes.SuperPermissionedGameType ||
+			gameType == gameTypes.SuperCannonKonaGameType,
+		"game at index %d is not a supported super game: %v",
+		idx,
+		gameType,
+	)
+	game := bindings.NewFaultDisputeGame(bindings.WithClient(f.ethClient), bindings.WithTo(gameInfo.Proxy), bindings.WithTest(f.t))
+	return NewSuperFaultDisputeGame(f.t, f.require, gameInfo.Proxy, f.getGameHelper, f.honestTraceForGame, game)
+}
+
 func (f *DisputeGameFactory) GameImpl(gameType gameTypes.GameType) *FaultDisputeGame {
 	implAddr := contract.Read(f.dgf.GameImpls(uint32(gameType)))
 	game := bindings.NewFaultDisputeGame(bindings.WithClient(f.ethClient), bindings.WithTo(implAddr), bindings.WithTest(f.t))

--- a/op-devstack/presets/interop.go
+++ b/op-devstack/presets/interop.go
@@ -111,7 +111,7 @@ func NewSimpleInteropSuperProofs(t devtest.T, opts ...Option) *SimpleInterop {
 // NewSimpleInteropSupernodeProofs creates a fresh SimpleInterop target for the current
 // test using the super-root proofs system backed by op-supernode.
 func NewSimpleInteropSupernodeProofs(t devtest.T, opts ...Option) *SimpleInterop {
-	presetCfg, _ := collectSupportedPresetConfig(t, "NewSimpleInteropSupernodeProofs", opts, supernodeProofsPresetSupportedOptionKinds)
+	presetCfg, _ := collectSupportedPresetConfig(t, "NewSimpleInteropSupernodeProofs", opts, twoL2SupernodeProofsPresetSupportedOptionKinds)
 	return simpleInteropFromSupernodeProofsRuntime(t, sysgo.NewTwoL2SupernodeProofsRuntimeWithConfig(t, true, presetCfg))
 }
 
@@ -125,7 +125,7 @@ func NewSingleChainInteropSupernodeProofs(t devtest.T, opts ...Option) *SingleCh
 // NewSimpleInteropIsthmusSuper creates a fresh SimpleInterop target for the current test
 // using the Isthmus super-root system backed by op-supernode.
 func NewSimpleInteropIsthmusSuper(t devtest.T, opts ...Option) *SimpleInterop {
-	presetCfg, _ := collectSupportedPresetConfig(t, "NewSimpleInteropIsthmusSuper", opts, supernodeProofsPresetSupportedOptionKinds)
+	presetCfg, _ := collectSupportedPresetConfig(t, "NewSimpleInteropIsthmusSuper", opts, twoL2SupernodeProofsPresetSupportedOptionKinds)
 	return simpleInteropFromSupernodeProofsRuntime(t, sysgo.NewTwoL2SupernodeProofsRuntimeWithConfig(t, false, presetCfg))
 }
 

--- a/op-devstack/presets/option_validation.go
+++ b/op-devstack/presets/option_validation.go
@@ -29,6 +29,7 @@ const (
 	optionKindMessageExpiryWindow
 	optionKindInteropLogBackfill
 	optionKindInteropFilter
+	optionKindPreGenesisSuperGame
 )
 
 const allOptionKinds = optionKindDeployer |
@@ -48,7 +49,8 @@ const allOptionKinds = optionKindDeployer |
 	optionKindProofValidation |
 	optionKindMessageExpiryWindow |
 	optionKindInteropLogBackfill |
-	optionKindInteropFilter
+	optionKindInteropFilter |
+	optionKindPreGenesisSuperGame
 
 var optionKindLabels = []struct {
 	kind  optionKinds
@@ -72,6 +74,7 @@ var optionKindLabels = []struct {
 	{kind: optionKindMessageExpiryWindow, label: "message expiry window"},
 	{kind: optionKindInteropLogBackfill, label: "interop log backfill depth"},
 	{kind: optionKindInteropFilter, label: "interop filter"},
+	{kind: optionKindPreGenesisSuperGame, label: "pre-genesis super game"},
 }
 
 func (k optionKinds) String() string {
@@ -163,6 +166,9 @@ const supernodeProofsPresetSupportedOptionKinds = optionKindDeployer |
 	optionKindTimeTravel |
 	optionKindMessageExpiryWindow
 
+const twoL2SupernodeProofsPresetSupportedOptionKinds = supernodeProofsPresetSupportedOptionKinds |
+	optionKindPreGenesisSuperGame
+
 const twoL2SupernodePresetSupportedOptionKinds = optionKindDeployer |
 	optionKindL1EL
 
@@ -171,7 +177,8 @@ const twoL2SupernodeInteropPresetSupportedOptionKinds = optionKindDeployer |
 	optionKindTimeTravel |
 	optionKindL1EL |
 	optionKindInteropLogBackfill |
-	optionKindInteropFilter
+	optionKindInteropFilter |
+	optionKindPreGenesisSuperGame
 
 const singleChainWithFlashblocksPresetSupportedOptionKinds = optionKindDeployer |
 	optionKindOPRBuilder

--- a/op-devstack/presets/options.go
+++ b/op-devstack/presets/options.go
@@ -323,3 +323,25 @@ func WithInteropLogBackfillDepth(d time.Duration) Option {
 		},
 	}
 }
+
+// WithPreGenesisSuperGame seeds one invalid super dispute game before the
+// rollup start block so tests can exercise supernode/challenger behaviour
+// when a game's L1 head predates rollup genesis. The claimed outputs follow
+// the preset chain order (`l2a`, `l2b` for two-chain presets).
+func WithPreGenesisSuperGame(claimedOutputs ...eth.Bytes32) Option {
+	var kinds optionKinds
+	if len(claimedOutputs) > 0 {
+		kinds = optionKindPreGenesisSuperGame
+	}
+	return option{
+		kinds: kinds,
+		applyFn: func(cfg *sysgo.PresetConfig) {
+			if len(claimedOutputs) == 0 {
+				return
+			}
+			cfg.PreGenesisSuperGame = &sysgo.PreGenesisSuperGameConfig{
+				ClaimedOutputs: append([]eth.Bytes32(nil), claimedOutputs...),
+			}
+		},
+	}
+}

--- a/op-devstack/presets/options_test.go
+++ b/op-devstack/presets/options_test.go
@@ -6,6 +6,7 @@ import (
 	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/stretchr/testify/require"
 )
 
@@ -46,6 +47,7 @@ func TestOptionKindsFromCompositeOptions(t *testing.T) {
 		require.Zero(t, WithGlobalSyncTesterELOption(nil).optionKinds())
 		require.Zero(t, WithProposerOption(nil).optionKinds())
 		require.Zero(t, WithOPRBuilderOption(nil).optionKinds())
+		require.Zero(t, WithPreGenesisSuperGame().optionKinds())
 		require.Zero(t, AfterBuild(nil).optionKinds())
 	})
 }
@@ -105,11 +107,22 @@ func TestUnsupportedPresetOptionKinds(t *testing.T) {
 			want: optionKindOPRBuilder | optionKindAfterBuild | optionKindProofValidation,
 		},
 		{
-			name:      "supernode proofs allow challenger and time travel toggles",
+			name:      "shared supernode proofs reject pre-genesis super game",
 			supported: supernodeProofsPresetSupportedOptionKinds,
 			opts: Combine(
 				WithChallengerCannonKonaEnabled(),
 				WithTimeTravelEnabled(),
+				WithPreGenesisSuperGame(eth.Bytes32{0x01}, eth.Bytes32{0x02}),
+			),
+			want: optionKindPreGenesisSuperGame,
+		},
+		{
+			name:      "two l2 supernode proofs accept pre-genesis super game",
+			supported: twoL2SupernodeProofsPresetSupportedOptionKinds,
+			opts: Combine(
+				WithChallengerCannonKonaEnabled(),
+				WithTimeTravelEnabled(),
+				WithPreGenesisSuperGame(eth.Bytes32{0x01}, eth.Bytes32{0x02}),
 			),
 			want: 0,
 		},
@@ -122,8 +135,11 @@ func TestUnsupportedPresetOptionKinds(t *testing.T) {
 		{
 			name:      "two l2 supernode interop accepts time travel",
 			supported: twoL2SupernodeInteropPresetSupportedOptionKinds,
-			opts:      WithTimeTravelEnabled(),
-			want:      0,
+			opts: Combine(
+				WithTimeTravelEnabled(),
+				WithPreGenesisSuperGame(eth.Bytes32{0x01}, eth.Bytes32{0x02}),
+			),
+			want: 0,
 		},
 		{
 			name:      "unsupported proof validation is called out separately from generic after build",

--- a/op-devstack/sysgo/multichain_proofs.go
+++ b/op-devstack/sysgo/multichain_proofs.go
@@ -116,8 +116,10 @@ func attachSupernodeSuperProofs(t devtest.T, runtime *MultiChainRuntime, cfg Pre
 	}
 
 	superrootTime := awaitSuperrootTime(t, cls...)
-	superRoot := getSupernodeSuperRoot(t, runtime.Supernode, superrootTime)
-	migrateSuperRoots(t, runtime.Keys, runtime.Migration, runtime.L1Network.ChainID(), runtime.L1EL, superRoot, superrootTime, proofChain.Network.ChainID())
+	if cfg.PreGenesisSuperGame == nil {
+		superRoot := getSupernodeSuperRoot(t, runtime.Supernode, superrootTime)
+		migrateSuperRoots(t, runtime.Keys, runtime.Migration, runtime.L1Network.ChainID(), runtime.L1EL, superRoot, superrootTime, proofChain.Network.ChainID())
+	}
 
 	challenger := startInteropChallenger(
 		t,

--- a/op-devstack/sysgo/multichain_supernode_runtime.go
+++ b/op-devstack/sysgo/multichain_supernode_runtime.go
@@ -214,6 +214,7 @@ func newTwoL2SupernodeRuntimeWithConfig(t devtest.T, enableInterop bool, delaySe
 	require.NoError(err, "failed to derive dev keys from mnemonic")
 
 	wb, l1Net, l2ANet, l2BNet := buildTwoL2RuntimeWorld(t, keys, enableInterop, delaySeconds, cfg.LocalContractArtifactsPath, cfg.DeployerOptions...)
+	migration := newInteropMigrationState(wb)
 	jwtPath, jwtSecret := writeJWTSecret(t)
 	l1Clock := clock.SystemClock
 	var timeTravelClock *clock.AdvancingClock
@@ -222,6 +223,9 @@ func newTwoL2SupernodeRuntimeWithConfig(t devtest.T, enableInterop bool, delaySe
 		l1Clock = timeTravelClock
 	}
 	l1EL, l1CL := startInProcessL1WithClockConfig(t, l1Net, jwtPath, l1Clock, cfg)
+	if cfg.PreGenesisSuperGame != nil {
+		preparePreGenesisSuperGame(t, keys, wb, l1Net, l1EL, migration, cfg.EnableCannonKonaForChall, cfg.PreGenesisSuperGame, l2ANet, l2BNet)
+	}
 
 	var l2AEL, l2BEL L2ELNode
 	var interopFilter *InteropFilter
@@ -320,7 +324,7 @@ func newTwoL2SupernodeRuntimeWithConfig(t devtest.T, enableInterop bool, delaySe
 
 	return &MultiChainRuntime{
 		Keys:          keys,
-		Migration:     newInteropMigrationState(wb),
+		Migration:     migration,
 		DependencySet: runtimeDepSet,
 		L1Network:     l1Net,
 		L1EL:          l1EL,

--- a/op-devstack/sysgo/pre_genesis_super_game.go
+++ b/op-devstack/sysgo/pre_genesis_super_game.go
@@ -1,0 +1,176 @@
+package sysgo
+
+import (
+	"math/big"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/state"
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
+	opclient "github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/retry"
+	"github.com/ethereum-optimism/optimism/op-service/sources"
+	"github.com/ethereum-optimism/optimism/op-service/txintent/bindings"
+	"github.com/ethereum-optimism/optimism/op-service/txintent/contractio"
+	"github.com/ethereum-optimism/optimism/op-service/txplan"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+const preGenesisRollupStartBlockDelay = uint64(6)
+
+var preGenesisStartingAnchorRoot = common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000042")
+
+func preparePreGenesisSuperGame(
+	t devtest.T,
+	keys devkeys.Keys,
+	wb *worldBuilder,
+	l1Net *L1Network,
+	l1EL *L1Geth,
+	migration *interopMigrationState,
+	enableCannonKona bool,
+	gameCfg *PreGenesisSuperGameConfig,
+	l2Nets ...*L2Network,
+) {
+	require := t.Require()
+	require.NotNil(gameCfg, "pre-genesis super game config is required")
+	require.NotEmpty(l2Nets, "at least one L2 network is required")
+	require.Len(gameCfg.ClaimedOutputs, len(l2Nets), "claimed outputs must match the number of L2 networks")
+
+	blockTime := l2Nets[0].RollupConfig().BlockTime
+	for _, l2Net := range l2Nets[1:] {
+		require.Equal(blockTime, l2Net.RollupConfig().BlockTime,
+			"pre-genesis super game only supports identical L2 block times")
+	}
+
+	rpcClient, err := rpc.DialContext(t.Ctx(), l1EL.UserRPC())
+	require.NoError(err, "failed to connect to L1 RPC")
+	defer rpcClient.Close()
+	client := ethclient.NewClient(rpcClient)
+	rpcWrapper := opclient.NewBaseRPCClient(rpcClient)
+	ethClient, err := sources.NewEthClient(rpcWrapper, t.Logger(), nil, sources.DefaultEthClientConfig(10))
+	require.NoError(err, "failed to create L1 eth client")
+
+	latestL1Header, err := client.HeaderByNumber(t.Ctx(), nil)
+	require.NoError(err, "failed to fetch latest L1 header")
+	require.NotNil(latestL1Header, "latest L1 header must be available")
+	require.NotNil(latestL1Header.Number, "latest L1 header must include a block number")
+
+	plannedRollupStartBlockNumber := bigs.Uint64Strict(latestL1Header.Number) + preGenesisRollupStartBlockDelay
+	plannedGenesisTime := latestL1Header.Time + preGenesisRollupStartBlockDelay*l1Net.blockTime
+	claimedTimestamp := plannedGenesisTime + blockTime
+
+	t.Logger().Info("preparing pre-genesis super game",
+		"current_l1_head", bigs.Uint64Strict(latestL1Header.Number),
+		"planned_rollup_start_block", plannedRollupStartBlockNumber,
+		"planned_genesis_time", plannedGenesisTime,
+		"claimed_timestamp", claimedTimestamp,
+	)
+
+	startingProposal := Proposal{
+		Root:             preGenesisStartingAnchorRoot,
+		L2SequenceNumber: new(big.Int).SetUint64(plannedGenesisTime),
+	}
+	sharedDGF := migrateSuperRootsWithProposal(
+		t,
+		keys,
+		migration,
+		l1Net.ChainID(),
+		l1EL,
+		startingProposal,
+		l2Nets[0].ChainID(),
+	)
+
+	gameType := superCannonGameType
+	if enableCannonKona {
+		gameType = superCannonKonaGameType
+	}
+
+	claimedChains := make([]eth.ChainIDAndOutput, 0, len(l2Nets))
+	for i, l2Net := range l2Nets {
+		claimedChains = append(claimedChains, eth.ChainIDAndOutput{
+			ChainID: l2Net.ChainID(),
+			Output:  gameCfg.ClaimedOutputs[i],
+		})
+	}
+	extraData := eth.NewSuperV1(claimedTimestamp, claimedChains...).Marshal()
+	rootClaim := crypto.Keccak256Hash(extraData)
+
+	gameCreatorKey, err := keys.Secret(devkeys.UserKey(funderMnemonicIndex))
+	require.NoError(err, "failed to derive pre-genesis game creator key")
+
+	txOpts := txplan.Combine(
+		txplan.WithChainID(client),
+		txplan.WithPrivateKey(gameCreatorKey),
+		txplan.WithPendingNonce(client),
+		txplan.WithAgainstLatestBlockEthClient(client),
+		txplan.WithEstimator(client, true),
+		txplan.WithRetrySubmission(client, 5, retry.Exponential()),
+		txplan.WithRetryInclusion(client, 5, retry.Exponential()),
+	)
+
+	dgf := bindings.NewBindings[bindings.DisputeGameFactory](
+		bindings.WithClient(ethClient),
+		bindings.WithTo(sharedDGF),
+		bindings.WithTest(t),
+	)
+	initBond, err := contractio.Read(dgf.InitBonds(uint32(gameType)), t.Ctx())
+	require.NoError(err, "failed to read dispute game init bond")
+	receipt, err := contractio.Write(
+		dgf.Create(uint32(gameType), rootClaim, extraData),
+		t.Ctx(),
+		txOpts,
+		txplan.WithValue(eth.WeiBig(initBond)),
+		txplan.WithGasRatio(2),
+	)
+	require.NoError(err, "failed to create pre-genesis dispute game")
+	require.EqualValues(types.ReceiptStatusSuccessful, receipt.Status, "pre-genesis dispute game creation failed")
+	require.NotNil(receipt.BlockNumber, "pre-genesis dispute game receipt must include a block number")
+	require.Lessf(bigs.Uint64Strict(receipt.BlockNumber), plannedRollupStartBlockNumber,
+		"pre-genesis dispute game must be created before the chosen rollup start block")
+
+	startBlockHeader := waitForL1Header(t, client, plannedRollupStartBlockNumber)
+	require.EqualValues(plannedRollupStartBlockNumber, bigs.Uint64Strict(startBlockHeader.Number), "unexpected planned rollup start block")
+	require.Greaterf(bigs.Uint64Strict(startBlockHeader.Number), bigs.Uint64Strict(receipt.BlockNumber),
+		"rollup start block must be strictly after the pre-genesis dispute game creation block")
+	require.EqualValues(plannedGenesisTime, startBlockHeader.Time, "unexpected planned rollup genesis time")
+
+	for _, chainState := range wb.output.Chains {
+		chainState.StartBlock = state.BlockRefJsonFromHeader(startBlockHeader)
+	}
+	wb.buildL2Genesis()
+	wb.buildFullConfigSet()
+	for _, l2Net := range l2Nets {
+		l2Net.genesis = wb.outL2Genesis[l2Net.ChainID()]
+		l2Net.rollupCfg = wb.outL2RollupCfg[l2Net.ChainID()]
+	}
+}
+
+func waitForL1Header(t devtest.T, client *ethclient.Client, blockNum uint64) *types.Header {
+	t.Helper()
+
+	var header *types.Header
+	t.Require().Eventuallyf(func() bool {
+		var err error
+		header, err = client.HeaderByNumber(t.Ctx(), new(big.Int).SetUint64(blockNum))
+		if err != nil {
+			return false
+		}
+		return header != nil
+	}, contextTimeout(t), 250*time.Millisecond, "waiting for L1 block %d", blockNum)
+	return header
+}
+
+func contextTimeout(t devtest.T) time.Duration {
+	if deadline, ok := t.Deadline(); ok {
+		if remaining := time.Until(deadline); remaining > 0 {
+			return remaining
+		}
+	}
+	return 2 * time.Minute
+}

--- a/op-devstack/sysgo/preset_config.go
+++ b/op-devstack/sysgo/preset_config.go
@@ -4,7 +4,12 @@ import (
 	"time"
 
 	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
+
+type PreGenesisSuperGameConfig struct {
+	ClaimedOutputs []eth.Bytes32
+}
 
 // PresetConfig captures preset constructor mutations.
 // It is independent from orchestrator lifecycle hooks.
@@ -29,6 +34,7 @@ type PresetConfig struct {
 	// InteropLogBackfillDepth, if non-zero, configures the supernode to backfill
 	// initiating-message logs backward from the tip by this duration at startup.
 	InteropLogBackfillDepth time.Duration
+	PreGenesisSuperGame     *PreGenesisSuperGameConfig
 }
 
 func NewPresetConfig() PresetConfig {

--- a/op-devstack/sysgo/superroot.go
+++ b/op-devstack/sysgo/superroot.go
@@ -199,6 +199,29 @@ func migrateSuperRoots(
 	superrootTime uint64,
 	primaryL2 eth.ChainID,
 ) common.Address {
+	return migrateSuperRootsWithProposal(
+		t,
+		keys,
+		migration,
+		l1ChainID,
+		l1EL,
+		Proposal{
+			Root:             common.Hash(superRoot),
+			L2SequenceNumber: new(big.Int).SetUint64(superrootTime),
+		},
+		primaryL2,
+	)
+}
+
+func migrateSuperRootsWithProposal(
+	t devtest.T,
+	keys devkeys.Keys,
+	migration *interopMigrationState,
+	l1ChainID eth.ChainID,
+	l1EL L1ELNode,
+	startingAnchorRoot Proposal,
+	primaryL2 eth.ChainID,
+) common.Address {
 	require := t.Require()
 	require.NotNil(migration, "interop migration state is required")
 	require.NotEmpty(migration.opcmImpl, "must have an OPCM implementation")
@@ -261,10 +284,7 @@ func migrateSuperRoots(
 				GameArgs: absoluteCannonKonaPrestate[:],
 			},
 		},
-		StartingAnchorRoot: Proposal{
-			Root:             common.Hash(superRoot),
-			L2SequenceNumber: big.NewInt(int64(superrootTime)),
-		},
+		StartingAnchorRoot:        startingAnchorRoot,
 		StartingRespectedGameType: superCannonGameType,
 	}
 	migrateCall := contract.Call("migrate", migrateInputV2)


### PR DESCRIPTION
Fixes #19115

## Summary

This adds coverage for super dispute games that are created before rollup L1 genesis in the supernode-backed interop proofs setup.

The change does three things:

- adds preset support to seed a pre-genesis super dispute game in the devstack runtime
- migrates super roots with a custom starting anchor and rebuilds the rollup configs from a later L1 start block
- adds an acceptance test that verifies the challenger counters the pre-genesis game

The setup is also hardened so the rollup start block is chosen relative to the current L1 head, and the runtime now asserts that the dispute game creation receipt lands strictly before the chosen rollup start block. That removes the earlier fixed-block assumption and makes the ordering explicit.

## Notes

- the new acceptance coverage uses a bounded wait for the challenger response instead of inheriting the DSL's longer default timeout
- the pre-genesis setup now explicitly checks `DG creation block < chosen rollup start block`
