### PR TITLE
feat(op-node): add --l1.beacon.slot-duration-override flag

### DIFF
--- a/op-node/config/beacon.go
+++ b/op-node/config/beacon.go
@@ -23,11 +23,12 @@ type L1BeaconEndpointSetup interface {
 }
 
 type L1BeaconEndpointConfig struct {
-	BeaconAddr             string   // Address of L1 User Beacon-API endpoint to use (beacon namespace required)
-	BeaconHeader           string   // Optional HTTP header for all requests to L1 Beacon
-	BeaconFallbackAddrs    []string // Addresses of L1 Beacon-API fallback endpoints (only for blob sidecars retrieval)
-	BeaconCheckIgnore      bool     // When false, halt startup if the beacon version endpoint fails
-	BeaconFetchAllSidecars bool     // Whether to fetch all blob sidecars and filter locally
+	BeaconAddr                 string   // Address of L1 User Beacon-API endpoint to use (beacon namespace required)
+	BeaconHeader               string   // Optional HTTP header for all requests to L1 Beacon
+	BeaconFallbackAddrs        []string // Addresses of L1 Beacon-API fallback endpoints (only for blob sidecars retrieval)
+	BeaconCheckIgnore          bool     // When false, halt startup if the beacon version endpoint fails
+	BeaconFetchAllSidecars     bool     // Whether to fetch all blob sidecars and filter locally
+	BeaconSlotDurationOverride uint64   // When non-zero, bypasses the beacon /eth/v1/config/spec fetch and uses this value as SECONDS_PER_SLOT
 }
 
 var _ L1BeaconEndpointSetup = (*L1BeaconEndpointConfig)(nil)
@@ -42,13 +43,18 @@ func (cfg *L1BeaconEndpointConfig) Setup(ctx context.Context, log log.Logger) (c
 		opts = append(opts, client.WithHeader(hdr))
 	}
 
+	var beaconOpts []sources.BeaconHTTPClientOption
+	if cfg.BeaconSlotDurationOverride != 0 {
+		beaconOpts = append(beaconOpts, sources.WithSlotDurationOverride(cfg.BeaconSlotDurationOverride))
+	}
+
 	for _, addr := range cfg.BeaconFallbackAddrs {
 		b := client.NewBasicHTTPClient(addr, log)
-		fb = append(fb, sources.NewBeaconHTTPClient(b))
+		fb = append(fb, sources.NewBeaconHTTPClient(b, beaconOpts...))
 	}
 
 	a := client.NewBasicHTTPClient(cfg.BeaconAddr, log, opts...)
-	return sources.NewBeaconHTTPClient(a), fb, nil
+	return sources.NewBeaconHTTPClient(a, beaconOpts...), fb, nil
 }
 
 func (cfg *L1BeaconEndpointConfig) Check() error {

--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -109,6 +109,14 @@ var (
 		EnvVars:  prefixEnvVars("L1_BEACON_FETCH_ALL_SIDECARS"),
 		Category: L1RPCCategory,
 	}
+	BeaconSlotDurationOverride = &cli.Uint64Flag{
+		Name:     "l1.beacon.slot-duration-override",
+		Usage:    "Duration in seconds of an L1 slot. When set (non-zero), bypasses the beacon /eth/v1/config/spec fetch and uses this value as SECONDS_PER_SLOT. Useful for devnets where the beacon spec endpoint is unavailable (e.g. anvil).",
+		Required: false,
+		Value:    0,
+		EnvVars:  prefixEnvVars("L1_BEACON_SLOT_DURATION_OVERRIDE"),
+		Category: L1RPCCategory,
+	}
 	SyncModeFlag = &cli.GenericFlag{
 		Name:     "syncmode",
 		Usage:    fmt.Sprintf("Blockchain sync mode (options: %s)", openum.EnumString(sync.ModeStrings)),
@@ -484,6 +492,7 @@ var optionalFlags = []cli.Flag{
 	BeaconFallbackAddrs,
 	BeaconCheckIgnore,
 	BeaconFetchAllSidecars,
+	BeaconSlotDurationOverride,
 	SyncModeFlag,
 	SyncModeReqRespFlag,
 	SyncModeOffsetELSafeFlag,

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -159,11 +159,12 @@ func NewSupervisorEndpointConfig(ctx cliiface.Context) *interop.Config {
 
 func NewBeaconEndpointConfig(ctx cliiface.Context) config.L1BeaconEndpointSetup {
 	return &config.L1BeaconEndpointConfig{
-		BeaconAddr:             ctx.String(flags.BeaconAddr.Name),
-		BeaconHeader:           ctx.String(flags.BeaconHeader.Name),
-		BeaconFallbackAddrs:    ctx.StringSlice(flags.BeaconFallbackAddrs.Name),
-		BeaconCheckIgnore:      ctx.Bool(flags.BeaconCheckIgnore.Name),
-		BeaconFetchAllSidecars: ctx.Bool(flags.BeaconFetchAllSidecars.Name),
+		BeaconAddr:                 ctx.String(flags.BeaconAddr.Name),
+		BeaconHeader:               ctx.String(flags.BeaconHeader.Name),
+		BeaconFallbackAddrs:        ctx.StringSlice(flags.BeaconFallbackAddrs.Name),
+		BeaconCheckIgnore:          ctx.Bool(flags.BeaconCheckIgnore.Name),
+		BeaconFetchAllSidecars:     ctx.Bool(flags.BeaconFetchAllSidecars.Name),
+		BeaconSlotDurationOverride: ctx.Uint64(flags.BeaconSlotDurationOverride.Name),
 	}
 }
 

--- a/op-service/sources/l1_beacon_client.go
+++ b/op-service/sources/l1_beacon_client.go
@@ -44,11 +44,28 @@ type L1BeaconClient struct {
 
 // BeaconHTTPClient implements BeaconClient. It provides golang types over the basic Beacon API.
 type BeaconHTTPClient struct {
-	cl client.HTTP
+	cl                   client.HTTP
+	slotDurationOverride uint64
 }
 
-func NewBeaconHTTPClient(cl client.HTTP) *BeaconHTTPClient {
-	return &BeaconHTTPClient{cl}
+type BeaconHTTPClientOption func(*BeaconHTTPClient)
+
+// WithSlotDurationOverride makes ConfigSpec return a synthesized response with
+// the given SECONDS_PER_SLOT value instead of issuing an HTTP request to the
+// beacon /eth/v1/config/spec endpoint. A value of 0 leaves the default
+// behavior unchanged.
+func WithSlotDurationOverride(slotDuration uint64) BeaconHTTPClientOption {
+	return func(c *BeaconHTTPClient) {
+		c.slotDurationOverride = slotDuration
+	}
+}
+
+func NewBeaconHTTPClient(cl client.HTTP, opts ...BeaconHTTPClientOption) *BeaconHTTPClient {
+	c := &BeaconHTTPClient{cl: cl}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
 }
 
 func (cl *BeaconHTTPClient) apiReq(ctx context.Context, dest any, reqPath string, reqQuery url.Values) error {
@@ -86,6 +103,13 @@ func (cl *BeaconHTTPClient) NodeVersion(ctx context.Context) (string, error) {
 }
 
 func (cl *BeaconHTTPClient) ConfigSpec(ctx context.Context) (eth.APIConfigResponse, error) {
+	if cl.slotDurationOverride != 0 {
+		return eth.APIConfigResponse{
+			Data: eth.ReducedConfigData{
+				SecondsPerSlot: eth.Uint64String(cl.slotDurationOverride),
+			},
+		}, nil
+	}
 	var configResp eth.APIConfigResponse
 	if err := cl.apiReq(ctx, &configResp, specMethod, nil); err != nil {
 		return eth.APIConfigResponse{}, err

--- a/op-service/sources/l1_beacon_client_test.go
+++ b/op-service/sources/l1_beacon_client_test.go
@@ -148,6 +148,18 @@ func TestBeaconHTTPClient(t *testing.T) {
 	require.Equal(t, err.Error(), fmt.Sprintf("#returned blobs(%d) != #requested blobs(%d)", 0, len(hashes)))
 }
 
+func TestBeaconHTTPClientConfigSpecOverride(t *testing.T) {
+	// With override set, ConfigSpec must return the synthesized value without
+	// touching the underlying HTTP client. client_mocks.NewHTTP sets up strict
+	// expectations, so an unexpected Get call would fail the test.
+	c := client_mocks.NewHTTP(t)
+	b := NewBeaconHTTPClient(c, WithSlotDurationOverride(7))
+
+	resp, err := b.ConfigSpec(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, eth.Uint64String(7), resp.Data.SecondsPerSlot)
+}
+
 func TestClientPoolSingle(t *testing.T) {
 	p := NewClientPool(1)
 	for i := 0; i < 10; i++ {


### PR DESCRIPTION
## Description

Mirrors kona PR op-rs/kona#3158. When set (non-zero), bypasses the beacon /eth/v1/config/spec fetch and uses the given value as SECONDS_PER_SLOT. Useful for devnets where the beacon spec endpoint is unavailable (e.g. anvil).