### PR TITLE
docs(opcm): acknowledge Initializable upgrade limitations

### DIFF
--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerUtils.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerUtils.sol
@@ -337,6 +337,10 @@ contract OPContractsManagerUtils {
         _proxyAdmin.upgrade(payable(_target), address(implementations().storageSetterImpl));
 
         // We need to reset the initialized slot and call the initializer.
+        // NOTE: This reset path still assumes `_offset` is a byte offset within a single
+        // storage slot, the generic one-byte clear can clobber OZ v5 `_initializing` if `_slot`
+        // matches the namespaced Initializable slot, and the hardcoded ERC-7201 slot only covers
+        // the default OZ v5 `_initializableStorageSlot()` layout.
         // Reset the initialized slot by zeroing the single byte at `_offset` (from the right).
         bytes32 current = IStorageSetter(_target).getBytes32(_slot);
         uint256 mask = ~(uint256(0xff) << (uint256(_offset) * 8));


### PR DESCRIPTION
## Summary
- add an in-code note in `OPContractsManagerUtils.upgrade()` documenting the current Initializable reset assumptions and edge cases
- explicitly acknowledge the `_offset` single-slot assumption, the `_slot == ozV5Slot` clobber risk, and the hardcoded default OZ v5 slot assumption
- supersede #20244 with a comment-only change instead of changing upgrade behavior in this round

## Testing
- `cd packages/contracts-bedrock && mise exec -- forge fmt --check src/L1/opcm/OPContractsManagerUtils.sol`

## Notes
- this is intentionally non-functional and just records the known limitation in the codepath
