### PR TITLE
fix(op-supernode): distinguish transient vs permanent SafeDB gaps in errors

### DIFF
--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -228,7 +228,12 @@ func (i *Interop) Start(ctx context.Context) error {
 		default:
 			madeProgress, err := i.progressAndRecord()
 			if err != nil {
-				// Error: back off before next attempt
+				// Permanent SafeDB gap: log once and halt — retrying cannot fix it.
+				if errors.Is(err, cc.ErrHistoryUnavailable) {
+					i.log.Error("interop activity halted: SafeDB history unavailable on this node", "err", err,
+						"remediation", "reseed data dir, advance interop.activation-timestamp past the gap, or rederive from L1")
+					return fmt.Errorf("interop halted due to unavailable history: %w", err)
+				}
 				i.log.Error("failed to progress and record interop", "err", err)
 				time.Sleep(errorBackoffPeriod)
 				continue

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -286,6 +286,30 @@ func TestStartStop(t *testing.T) {
 				require.Error(t, err)
 			},
 		},
+		{
+			// Permanent SafeDB gap must halt Start cleanly (no retry loop).
+			name: "Start halts when a chain reports ErrHistoryUnavailable",
+			setup: func(h *interopTestHarness) *interopTestHarness {
+				return h.WithChain(10, func(m *mockChainContainer) {
+					m.currentL1 = eth.BlockRef{Number: 100, Hash: common.HexToHash("0x1")}
+					m.blockAtTimestamp = eth.L2BlockRef{Number: 50}
+					m.optimisticAtErr = cc.ErrHistoryUnavailable
+				}).Build()
+			},
+			run: func(t *testing.T, h *interopTestHarness) {
+				done := make(chan error, 1)
+				go func() { done <- h.interop.Start(context.Background()) }()
+
+				// Must halt well under one errorBackoffPeriod (2s).
+				var err error
+				select {
+				case err = <-done:
+				case <-time.After(5 * time.Second):
+					t.Fatal("Start did not halt within 5s after ErrHistoryUnavailable")
+				}
+				require.ErrorIs(t, err, cc.ErrHistoryUnavailable)
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/op-supernode/supernode/chain_container/chain_container.go
+++ b/op-supernode/supernode/chain_container/chain_container.go
@@ -30,6 +30,12 @@ import (
 
 const virtualNodeVersion = "0.1.0"
 
+// ErrHistoryUnavailable is the permanent counterpart of ethereum.NotFound:
+// SafeDB on this node cannot and will not contain the requested history
+// (e.g. snap/CL-sync bootstrap gap). Interop halts on this rather than
+// retrying; recovery requires operator intervention.
+var ErrHistoryUnavailable = errors.New("safedb history unavailable on this node")
+
 type ChainContainer interface {
 	Start(ctx context.Context) error
 	Stop(ctx context.Context) error
@@ -435,7 +441,11 @@ func (c *simpleChainContainer) safeDBAtL2(ctx context.Context, l2 eth.BlockID) (
 	c.log.Debug("safeDBAtL2", "l2", l2, "currentL1", currentL1, "err", err)
 	l1, err := c.vn.L1AtSafeHead(ctx, l2)
 	if err != nil {
-		// Map L1AtSafeHeadNotFound to ethereum.NotFound so callers treat chain lag as "not ready"
+		// Permanent history gap -> ErrHistoryUnavailable (interop halts).
+		// Transient lag -> ethereum.NotFound (callers back off and retry).
+		if errors.Is(err, virtual_node.ErrL1AtSafeHeadUnavailable) {
+			return eth.BlockID{}, fmt.Errorf("L1 at safe head unavailable for L2 %s: %w", l2, ErrHistoryUnavailable)
+		}
 		if errors.Is(err, virtual_node.ErrL1AtSafeHeadNotFound) {
 			return eth.BlockID{}, fmt.Errorf("L1 at safe head not available for L2 %s: %w", l2, ethereum.NotFound)
 		}

--- a/op-supernode/supernode/chain_container/chain_container_test.go
+++ b/op-supernode/supernode/chain_container/chain_container_test.go
@@ -1049,6 +1049,52 @@ func (m *mockVNForL1AtSafeHeadError) SyncStatus(ctx context.Context) (*eth.SyncS
 
 var _ virtual_node.VirtualNode = (*mockVNForL1AtSafeHeadError)(nil)
 
+// ErrL1AtSafeHeadUnavailable from the VN must map to ErrHistoryUnavailable
+// (and NOT to ethereum.NotFound) so interop halts instead of treating it as
+// transient chain lag.
+func TestChainContainer_OptimisticAt_ErrL1AtSafeHeadUnavailable(t *testing.T) {
+	t.Parallel()
+
+	chainID := eth.ChainIDFromUInt64(420)
+	vncfg := createTestVNConfig()
+	vncfg.Rollup.Genesis.L2Time = 1000
+	vncfg.Rollup.BlockTime = 2
+	log := createTestLogger(t)
+	cfg := createTestCLIConfig(t.TempDir())
+	initOverload := &rollupNode.InitializationOverrides{}
+
+	container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil)
+	impl, ok := container.(*simpleChainContainer)
+	require.True(t, ok)
+
+	mockEngine := &mockEngineController{
+		l2BlockRefByNumberResult: eth.L2BlockRef{
+			Hash:   common.Hash{0x01},
+			Number: 5,
+			Time:   1010,
+		},
+	}
+	impl.engine = mockEngine
+
+	mockVN := &mockVNForL1AtSafeHeadError{
+		syncStatusResult: &eth.SyncStatus{
+			CurrentL1:   eth.L1BlockRef{Hash: common.Hash{0x10}, Number: 50},
+			LocalSafeL2: eth.L2BlockRef{Hash: common.Hash{0x20}, Number: 100},
+		},
+		l1AtSafeHeadErr: virtual_node.ErrL1AtSafeHeadUnavailable,
+	}
+	impl.vn = mockVN
+
+	ctx := context.Background()
+	_, _, err := container.OptimisticAt(ctx, 1010)
+
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrHistoryUnavailable),
+		"ErrL1AtSafeHeadUnavailable should be mapped to ErrHistoryUnavailable, got: %v", err)
+	require.False(t, errors.Is(err, ethereum.NotFound),
+		"ErrL1AtSafeHeadUnavailable must NOT be mapped to ethereum.NotFound — that would make it look transient. got: %v", err)
+}
+
 // TestChainContainer_LocalSafeBlockAtTimestamp tests the LocalSafeBlockAtTimestamp method
 func TestChainContainer_LocalSafeBlockAtTimestamp(t *testing.T) {
 	t.Parallel()

--- a/op-supernode/supernode/chain_container/virtual_node/virtual_node.go
+++ b/op-supernode/supernode/chain_container/virtual_node/virtual_node.go
@@ -10,6 +10,7 @@ import (
 	opnodecfg "github.com/ethereum-optimism/optimism/op-node/config"
 	opmetrics "github.com/ethereum-optimism/optimism/op-node/metrics"
 	rollupNode "github.com/ethereum-optimism/optimism/op-node/node"
+	"github.com/ethereum-optimism/optimism/op-node/node/safedb"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	gethlog "github.com/ethereum/go-ethereum/log"
 	"github.com/google/uuid"
@@ -211,7 +212,14 @@ func (v *simpleVirtualNode) SafeHeadAtL1(ctx context.Context, l1BlockNum uint64)
 	return db.SafeHeadAtL1(ctx, l1BlockNum)
 }
 
+// ErrL1AtSafeHeadNotFound: transient — SafeDB hasn't observed the answer yet
+// (target ahead of latest, or DB empty at startup). Retry.
 var ErrL1AtSafeHeadNotFound = errors.New("l1 at safe head not found")
+
+// ErrL1AtSafeHeadUnavailable: permanent on this node — the crossing happened
+// before SafeDB started recording (snap/CL-sync bootstrap), or the walkback
+// reached the genesis bound. Retrying won't help; operator must intervene.
+var ErrL1AtSafeHeadUnavailable = errors.New("l1 at safe head history unavailable")
 
 // L1AtSafeHead finds the earliest L1 block at which the provided L2 block became local safe,
 // using the monotonicity of SafeDB (L2 safe head number is non-decreasing over L1).
@@ -239,6 +247,12 @@ func (v *simpleVirtualNode) L1AtSafeHead(ctx context.Context, target eth.BlockID
 	// Get the latest entry to start the walkback
 	latestL1, latestL2, err := db.SafeHeadAtL1(ctx, math.MaxUint64-1)
 	if err != nil {
+		// Empty DB on startup is transient; anything else is a real failure.
+		if errors.Is(err, safedb.ErrNotFound) {
+			v.log.Debug("L1AtSafeHead: SafeDB empty, no entries yet",
+				"target_l2_num", target.Number, "target_l2_hash", target.Hash)
+			return eth.BlockID{}, ErrL1AtSafeHeadNotFound
+		}
 		v.log.Debug("L1AtSafeHead: latest lookup failed", "err", err)
 		return eth.BlockID{}, err
 	}
@@ -248,27 +262,49 @@ func (v *simpleVirtualNode) L1AtSafeHead(ctx context.Context, target eth.BlockID
 		return eth.BlockID{}, ErrL1AtSafeHeadNotFound
 	}
 	v.log.Debug("L1AtSafeHead: target within latest", "latest_l2", latestL2.Number, "target", target.Number)
-	// Walk back until the cursor would drop below the target
+	// Walk back until the cursor would drop below the target. cursor tracks
+	// the earliest entry we've successfully resolved; on failure it is the
+	// first (earliest) recorded SafeDB entry, which is the most useful piece
+	// of diagnostic context for the operator.
 	cursor := latestL1
+	cursorL2 := latestL2
 	genesisL1 := v.cfg.Rollup.Genesis.L1.Number
 	steps := 0
 	for {
 		steps++
 		if cursor.Number <= 0 || cursor.Number <= genesisL1 {
-			// if we made it all the way back to genesis, it is likely the SafeDB is not stable enough for use
-			// safer to simply return an error for now.
-			v.log.Warn("L1AtSafeHead: reached genesis bound", "genesis_l1", genesisL1, "earliest_l1", cursor.Number)
-			return eth.BlockID{}, ErrL1AtSafeHeadNotFound
+			// Walkback crossed the genesis bound without ever dropping below
+			// target: the crossing is older than anything we have. Permanent.
+			v.log.Warn("L1AtSafeHead: reached genesis bound without crossing target",
+				"target_l2_num", target.Number, "target_l2_hash", target.Hash,
+				"earliest_l1", cursor.Number, "earliest_l2", cursorL2.Number,
+				"genesis_l1", genesisL1)
+			return eth.BlockID{}, ErrL1AtSafeHeadUnavailable
 		}
 		prev := cursor.Number - 1
 		l1Prev, l2Prev, err := db.SafeHeadAtL1(ctx, prev)
 		if err != nil {
-			v.log.Error("L1AtSafeHead: walkback lookup failed, stopping", "probe_l1", prev, "target", target.Number, "err", err)
+			// Probed below the earliest SafeDB entry: snap/CL-sync bootstrap
+			// gap. Permanent on this node; retrying won't backfill history.
+			// cursor is the earliest entry in the DB (nothing exists at
+			// or below cursor.Number - 1, which is what we just probed).
+			if errors.Is(err, safedb.ErrNotFound) {
+				v.log.Warn("L1AtSafeHead: walkback ran past earliest SafeDB entry",
+					"target_l2_num", target.Number, "target_l2_hash", target.Hash,
+					"earliest_l1", cursor.Number, "earliest_l2", cursorL2.Number,
+					"probe_l1", prev, "genesis_l1", genesisL1)
+				return eth.BlockID{}, ErrL1AtSafeHeadUnavailable
+			}
+			v.log.Error("L1AtSafeHead: walkback lookup failed, stopping",
+				"target_l2_num", target.Number, "target_l2_hash", target.Hash,
+				"earliest_l1", cursor.Number, "earliest_l2", cursorL2.Number,
+				"probe_l1", prev, "err", err)
 			return eth.BlockID{}, err
 		}
 		if l2Prev.Number >= target.Number {
 			// Still meets or exceeds target; continue walking back
 			cursor = l1Prev
+			cursorL2 = l2Prev
 			continue
 		}
 		// Dropped below target; current cursor is the first that meets/exceeds

--- a/op-supernode/supernode/chain_container/virtual_node/virtual_node_test.go
+++ b/op-supernode/supernode/chain_container/virtual_node/virtual_node_test.go
@@ -11,6 +11,7 @@ import (
 	opnodecfg "github.com/ethereum-optimism/optimism/op-node/config"
 	opmetrics "github.com/ethereum-optimism/optimism/op-node/metrics"
 	rollupNode "github.com/ethereum-optimism/optimism/op-node/node"
+	"github.com/ethereum-optimism/optimism/op-node/node/safedb"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	gethlog "github.com/ethereum/go-ethereum/log"
@@ -104,7 +105,7 @@ func (m *mockSafeDBReader) SafeHeadAtL1(ctx context.Context, l1BlockNum uint64) 
 		}
 	}
 	if !found {
-		return eth.BlockID{}, eth.BlockID{}, errors.New("no entry found")
+		return eth.BlockID{}, eth.BlockID{}, safedb.ErrNotFound
 	}
 	entry := m.entries[best]
 	return entry.l1, entry.l2, nil
@@ -492,8 +493,7 @@ func TestVirtualNode_L1AtSafeHead(t *testing.T) {
 		// Should NOT match genesis since both number AND hash must match
 		target := eth.BlockID{Number: genesisL2.Number, Hash: [32]byte{0xff}}
 		_, err := vn.L1AtSafeHead(context.Background(), target)
-		// Returns error because mockDB is empty and walkback fails
-		require.Error(t, err)
+		require.ErrorIs(t, err, ErrL1AtSafeHeadNotFound)
 	})
 
 	t.Run("non-genesis target uses walkback to find earliest L1", func(t *testing.T) {
@@ -542,6 +542,71 @@ func TestVirtualNode_L1AtSafeHead(t *testing.T) {
 
 		// Query for L2 block 100 - beyond latest L2 safe head (5)
 		target := eth.BlockID{Number: 100, Hash: [32]byte{}}
+		_, err := vn.L1AtSafeHead(context.Background(), target)
+		require.ErrorIs(t, err, ErrL1AtSafeHeadNotFound)
+	})
+
+	// CL/snap-sync bootstrap: SafeDB starts above genesisL1, so the walkback
+	// runs off the end of recorded history. That is permanent on this node.
+	t.Run("walkback past earliest SafeDB entry returns Unavailable", func(t *testing.T) {
+		cfg := createConfigWithGenesis()
+		log := createTestLogger()
+		vn := NewVirtualNode(cfg, log, nil, "test")
+
+		mockDB := newMockSafeDBReader()
+		mockDB.addEntry(500, [32]byte{0x10}, [32]byte{0x11}, 100)
+		mockDB.addEntry(501, [32]byte{0x12}, [32]byte{0x13}, 110)
+		mockDB.addEntry(502, [32]byte{0x14}, [32]byte{0x15}, 120)
+
+		mock := newMockInnerNode()
+		mock.db = mockDB
+		vn.inner = mock
+		vn.state = VNStateRunning
+
+		// target within latest L2 (100 <= 120) so we enter walkback; prev=499
+		// is below the earliest entry (500) but above genesisL1 (100), so the
+		// safedb.ErrNotFound from that probe is what triggers the sentinel.
+		target := eth.BlockID{Number: 100, Hash: [32]byte{0x11}}
+		_, err := vn.L1AtSafeHead(context.Background(), target)
+		require.ErrorIs(t, err, ErrL1AtSafeHeadUnavailable)
+	})
+
+	// Walkback reaches the genesis bound without ever dropping below target:
+	// also permanent (SafeDB near genesis is not considered stable).
+	t.Run("walkback reaches genesis bound returns Unavailable", func(t *testing.T) {
+		cfg := createConfigWithGenesis()
+		log := createTestLogger()
+		vn := NewVirtualNode(cfg, log, nil, "test")
+
+		mockDB := newMockSafeDBReader()
+		// genesisL1=100; both entries have L2 >= target=10, so walkback from
+		// L1=150 descends to cursor=100 which trips the genesis guard.
+		mockDB.addEntry(100, [32]byte{0x01}, [32]byte{0x02}, 50)
+		mockDB.addEntry(150, [32]byte{0x03}, [32]byte{0x04}, 60)
+
+		mock := newMockInnerNode()
+		mock.db = mockDB
+		vn.inner = mock
+		vn.state = VNStateRunning
+
+		target := eth.BlockID{Number: 10, Hash: [32]byte{0x02}}
+		_, err := vn.L1AtSafeHead(context.Background(), target)
+		require.ErrorIs(t, err, ErrL1AtSafeHeadUnavailable)
+	})
+
+	// Empty SafeDB on startup: transient NotFound, not the permanent sentinel.
+	t.Run("empty SafeDB returns NotFound on latest lookup", func(t *testing.T) {
+		cfg := createConfigWithGenesis()
+		log := createTestLogger()
+		vn := NewVirtualNode(cfg, log, nil, "test")
+
+		mockDB := newMockSafeDBReader()
+		mock := newMockInnerNode()
+		mock.db = mockDB
+		vn.inner = mock
+		vn.state = VNStateRunning
+
+		target := eth.BlockID{Number: 50, Hash: [32]byte{0xaa}}
 		_, err := vn.L1AtSafeHead(context.Background(), target)
 		require.ErrorIs(t, err, ErrL1AtSafeHeadNotFound)
 	})


### PR DESCRIPTION
# Tool Use Notice
Generated.

## Summary

Split up the error from the l1ForL2 SafeDB function so that if a block won't _ever_ be in the db (is prior to the first item), a more obvious, non-retrying error is returned.

## Behavior change

| Scenario | Before | After |
|---|---|---|
| Chain lagging (target beyond latest) | Silent retry (`NotFound`) | Silent retry (unchanged) |
| Empty DB at startup | Error-loop every 2s until first advance | Silent retry (`NotFound`, 1s) |
| Walkback past earliest SafeDB entry | Loud error every `errorBackoffPeriod`, infinite retry | One `Error` log with remediation + context, activity halts |
| Walkback reaches genesis bound | Silent retry (previously mapped to `NotFound`) | One `Error` log with remediation + context, activity halts |

## Scope 

This PR changes how the permanent-gap condition is **surfaced and
handled**, not whether it's recoverable:

## Files

- `op-supernode/supernode/chain_container/virtual_node/virtual_node.go` —
  two sentinels; translate `safedb.ErrNotFound` at the initial lookup
  (transient) and at the walkback probe (permanent); genesis-bound guard
  returns Unavailable; logs carry `target_l2_*`, `earliest_l1`,
  `earliest_l2`, `probe_l1`, `genesis_l1`.
- `op-supernode/supernode/chain_container/chain_container.go` — new
  `ErrHistoryUnavailable`; `safeDBAtL2` maps Unavailable →
  `ErrHistoryUnavailable` and NotFound → `ethereum.NotFound`.
- `op-supernode/supernode/activity/interop/interop.go` — `Start` loop
  catches `cc.ErrHistoryUnavailable`, logs once at `Error` with a
  `remediation` hint, and returns instead of retrying.

## Test plan

- [x] `virtual_node_test.go`
  - [x] walkback past earliest SafeDB entry → `ErrL1AtSafeHeadUnavailable`
  - [x] walkback reaches genesis bound → `ErrL1AtSafeHeadUnavailable`
  - [x] empty SafeDB on initial lookup → `ErrL1AtSafeHeadNotFound`
  - [x] target beyond latest → `ErrL1AtSafeHeadNotFound` (unchanged)
  - [x] mock `SafeDBReader` returns `safedb.ErrNotFound` to match the real DB
- [x] `chain_container_test.go`
  - [x] `ErrL1AtSafeHeadUnavailable` → `ErrHistoryUnavailable` and
        explicitly NOT `ethereum.NotFound` (the invariant interop relies on)
  - [x] `ErrL1AtSafeHeadNotFound` → `ethereum.NotFound` (unchanged)
- [x] `interop_test.go`
  - [x] `Start` returns within 5s (well under `errorBackoffPeriod`) with an
        error wrapping `cc.ErrHistoryUnavailable` when a chain reports
        permanent history loss