### PR TITLE
fix(op-reth): raise supervisor RPC timeout default from 100ms to 2s

### DIFF
--- a/rust/op-reth/crates/txpool/src/supervisor/client.rs
+++ b/rust/op-reth/crates/txpool/src/supervisor/client.rs
@@ -34,7 +34,7 @@ use tracing::trace;
 pub const DEFAULT_SUPERVISOR_URL: &str = "http://localhost:1337/";
 
 /// The default request timeout to use
-pub const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_millis(100);
+pub const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(2);
 
 /// Implementation of the supervisor trait for the interop.
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Fixes flaky `TestInteropFilter_IngressRejectsInvalid` — see #20291.

## Root cause

`SupervisorClient::DEFAULT_REQUEST_TIMEOUT` was 100 ms, applied via `tokio::time::timeout` to both `check_access_list` (ingress validation) and `query_failsafe` (background poller). Under CI load, localhost round trips to the Go-side interop filter can exceed 100 ms, so op-reth returns its own `InteropTxValidatorError::Timeout` instead of propagating the filter's real rejection string. The `"timeout: 0 secs"` seen in the error is a display artifact — `Duration::from_millis(100).as_secs()` truncates to `0`.

The only `SupervisorClient::builder(...)` call site never overrides the default, and there is no CLI flag, so the compile-time value is what ships.

## Fix

Raise the default to 2 s. This remains a protective ceiling against a genuinely hung upstream — the caller's context (7200 s for access-list checks, 10 s for this test) still bounds pathological cases — while giving ample headroom over realistic round-trip spikes. 100 ms was also indefensibly tight for any non-colocated supervisor in production.

Verified locally with `-count=20` on the target test: 20/20 pass. Full filter package `-count=2` also clean.

Closes #20291.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
