### PR TITLE
experiment: strip all CircleCI contexts

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -2435,24 +2435,24 @@ workflows:
       # to the contracts-feature-tests workflow below, which is gated on
       # c-contracts_changed. Keeping them here as well was duplicating every
       # contracts run on PRs that touch non-contract files.
-      - l2-chains-sync-check:
+      - l2-chains-sync-check
       - contracts-bedrock-upload:
           requires:
             - contracts-bedrock-build
       - diff-fetcher-forge-artifacts:
           requires:
             - contracts-bedrock-build
-      - op-deployer-forge-version:
+      - op-deployer-forge-version
       - semgrep-scan:
           name: semgrep-scan-local
           scan_command: semgrep scan --timeout=100 --config .semgrep/rules/ --error .
       - semgrep-scan:
           name: semgrep-test
           scan_command: semgrep scan --test --config .semgrep/rules/ .semgrep/tests/
-      - go-lint:
-      - check-op-geth-version:
-      - check-nut-locks:
-      - nut-provenance-verify:
+      - go-lint
+      - check-op-geth-version
+      - check-nut-locks
+      - nut-provenance-verify
       - fuzz-golang:
           name: fuzz-golang-<<matrix.package_name>>
           on_changes: <<matrix.package_name>>
@@ -2504,8 +2504,8 @@ workflows:
             - contracts-bedrock-build
             - cannon-prestate
             - go-binaries-for-sysgo
-      - analyze-op-program-client:
-      - op-program-compat:
+      - analyze-op-program-client
+      - op-program-compat
       - bedrock-go-tests:
           requires:
             - go-lint
@@ -2515,12 +2515,12 @@ workflows:
             - op-program-compat
             - go-tests-short
             - sanitize-op-program
-      - cannon-prestate:
+      - cannon-prestate
       - sanitize-op-program:
           requires:
             - cannon-prestate
-      - check-generated-mocks-op-node:
-      - check-generated-mocks-op-service:
+      - check-generated-mocks-op-node
+      - check-generated-mocks-op-service
       - cannon-go-lint-and-test:
           requires:
             - contracts-bedrock-build
@@ -2560,7 +2560,7 @@ workflows:
             - rust-workspace-binaries
             - rust-build-op-rbuilder
             - rust-build-rollup-boost
-      - go-binaries-for-sysgo:
+      - go-binaries-for-sysgo
       # IN-MEMORY (all) - op-node/op-geth
       - op-acceptance-tests:
           name: memory-all-opn-op-geth
@@ -2716,8 +2716,8 @@ workflows:
             - equal: [true, <<pipeline.parameters.c-fault_proofs_dispatch>>]
             - equal: ["api", << pipeline.trigger_source >>]
     jobs:
-      - cannon-prestate:
-      - cannon-stf-verify:
+      - cannon-prestate
+      - cannon-stf-verify
       - contracts-bedrock-build:
           build_args: --deny-warnings --skip test
       - rust-build-binary:
@@ -2753,7 +2753,7 @@ workflows:
             - equal: [true, <<pipeline.parameters.c-kontrol_dispatch>>]
             - equal: ["api", << pipeline.trigger_source >>]
     jobs:
-      - kontrol-tests:
+      - kontrol-tests
 
   scheduled-cannon-full-tests:
     when:
@@ -2777,7 +2777,7 @@ workflows:
         # Trigger on manual triggers if explicitly requested
         - equal: [true, << pipeline.parameters.c-reproducibility_dispatch >>]
     jobs:
-      - preimage-reproducibility:
+      - preimage-reproducibility
 
   scheduled-stale-check:
     when:
@@ -2786,7 +2786,7 @@ workflows:
           # Trigger on manual triggers if explicitly requested
         - equal: [true, << pipeline.parameters.c-stale_check_dispatch >>]
     jobs:
-      - stale-check:
+      - stale-check
 
   scheduled-heavy-fuzz-tests:
     when:
@@ -2794,7 +2794,7 @@ workflows:
         - equal: [build_daily, <<pipeline.schedule.name>>]
         - equal: [true, << pipeline.parameters.c-heavy_fuzz_dispatch >>]
     jobs:
-      - contracts-bedrock-heavy-fuzz-nightly:
+      - contracts-bedrock-heavy-fuzz-nightly
   close-issue-workflow:
     when:
       and:
@@ -2815,7 +2815,7 @@ workflows:
         - equal: [build_mon_thu, <<pipeline.schedule.name>>]
         - equal: [true, << pipeline.parameters.c-ai_contracts_test_dispatch >>]
     jobs:
-      - ai-contracts-test:
+      - ai-contracts-test
 
   l2-fork-test-workflow:
     when:

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -2428,59 +2428,31 @@ workflows:
           name: contracts-bedrock-build
           # Build with just core + script contracts.
           build_args: --deny-warnings --skip test
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - slack
       - check-kontrol-build:
           requires:
             - contracts-bedrock-build
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - slack
       # contracts-bedrock test/coverage/upgrade/l2-fork/checks-fast jobs have moved
       # to the contracts-feature-tests workflow below, which is gated on
       # c-contracts_changed. Keeping them here as well was duplicating every
       # contracts run on PRs that touch non-contract files.
       - l2-chains-sync-check:
-          context:
-            - circleci-repo-readonly-authenticated-github-token
       - contracts-bedrock-upload:
           requires:
             - contracts-bedrock-build
-          context:
-            - circleci-repo-readonly-authenticated-github-token
       - diff-fetcher-forge-artifacts:
-          context:
-            - circleci-repo-readonly-authenticated-github-token
           requires:
             - contracts-bedrock-build
       - op-deployer-forge-version:
-          context:
-            - circleci-repo-readonly-authenticated-github-token
       - semgrep-scan:
           name: semgrep-scan-local
           scan_command: semgrep scan --timeout=100 --config .semgrep/rules/ --error .
-          context:
-            - slack
-            - circleci-repo-readonly-authenticated-github-token
       - semgrep-scan:
           name: semgrep-test
           scan_command: semgrep scan --test --config .semgrep/rules/ .semgrep/tests/
-          context:
-            - slack
-            - circleci-repo-readonly-authenticated-github-token
       - go-lint:
-          context:
-            - circleci-repo-readonly-authenticated-github-token
       - check-op-geth-version:
-          context:
-            - circleci-repo-readonly-authenticated-github-token
       - check-nut-locks:
-          context:
-            - circleci-repo-readonly-authenticated-github-token
       - nut-provenance-verify:
-          context:
-            - circleci-repo-readonly-authenticated-github-token
       - fuzz-golang:
           name: fuzz-golang-<<matrix.package_name>>
           on_changes: <<matrix.package_name>>
@@ -2491,15 +2463,11 @@ workflows:
                 - op-node
                 - op-service
                 - op-chain-ops
-          context:
-            - circleci-repo-readonly-authenticated-github-token
       - fuzz-golang:
           name: cannon-fuzz
           package_name: cannon
           on_changes: cannon,packages/contracts-bedrock/src/cannon
           uses_artifacts: true
-          context:
-            - circleci-repo-readonly-authenticated-github-token
           requires:
             - contracts-bedrock-build
       - fuzz-golang:
@@ -2507,8 +2475,6 @@ workflows:
           package_name: op-e2e
           on_changes: op-e2e,packages/contracts-bedrock/src
           uses_artifacts: true
-          context:
-            - circleci-repo-readonly-authenticated-github-token
           requires:
             - contracts-bedrock-build
             - cannon-prestate
@@ -2521,8 +2487,6 @@ workflows:
             - contracts-bedrock-build
             - cannon-prestate
             - go-binaries-for-sysgo
-          context:
-            - circleci-repo-readonly-authenticated-github-token
           filters:
             branches:
               ignore: develop # Run on all branches EXCEPT develop (PR branches only)
@@ -2540,15 +2504,8 @@ workflows:
             - contracts-bedrock-build
             - cannon-prestate
             - go-binaries-for-sysgo
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - slack
       - analyze-op-program-client:
-          context:
-            - circleci-repo-readonly-authenticated-github-token
       - op-program-compat:
-          context:
-            - circleci-repo-readonly-authenticated-github-token
       - bedrock-go-tests:
           requires:
             - go-lint
@@ -2558,36 +2515,20 @@ workflows:
             - op-program-compat
             - go-tests-short
             - sanitize-op-program
-          context:
-            - circleci-repo-readonly-authenticated-github-tokens
       - cannon-prestate:
-          context:
-            - circleci-repo-readonly-authenticated-github-token
       - sanitize-op-program:
           requires:
             - cannon-prestate
-          context:
-            - circleci-repo-readonly-authenticated-github-token
       - check-generated-mocks-op-node:
-          context:
-            - circleci-repo-readonly-authenticated-github-token
       - check-generated-mocks-op-service:
-          context:
-            - circleci-repo-readonly-authenticated-github-token
       - cannon-go-lint-and-test:
           requires:
             - contracts-bedrock-build
           skip_slow_tests: true
           notify: true
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - slack
       - todo-issues:
           name: todo-issues-check
           check_closed: false
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - slack
       - shellcheck/check:
           name: shell-check
           # We don't need the `exclude` key as the orb detects the `.shellcheckrc`
@@ -2595,8 +2536,6 @@ workflows:
           ignore-dirs: |
             ./packages/contracts-bedrock/lib
             ./docs/public-docs
-          context:
-            - circleci-repo-readonly-authenticated-github-token
       # Acceptance test jobs (formerly in separate acceptance-tests workflow)
       - rust-build-binary:
           name: rust-workspace-binaries
@@ -2605,39 +2544,27 @@ workflows:
           save_cache: true
           persist_to_workspace: true
           rust_files_changed: << pipeline.parameters.c-rust_files_changed >>
-          context:
-            - circleci-repo-readonly-authenticated-github-token
       - rust-build-submodule: &rust-build-op-rbuilder
           name: rust-build-op-rbuilder
           directory: op-rbuilder
           binaries: "op-rbuilder"
           build_command: cargo build --release -p op-rbuilder --bin op-rbuilder
           needs_clang: true
-          context:
-            - circleci-repo-readonly-authenticated-github-token
       - rust-build-submodule: &rust-build-rollup-boost
           name: rust-build-rollup-boost
           directory: rollup-boost
           binaries: "rollup-boost"
           build_command: cargo build --release -p rollup-boost --bin rollup-boost
-          context:
-            - circleci-repo-readonly-authenticated-github-token
       - rust-binaries-for-sysgo:
           requires:
             - rust-workspace-binaries
             - rust-build-op-rbuilder
             - rust-build-rollup-boost
       - go-binaries-for-sysgo:
-          context:
-            - circleci-repo-readonly-authenticated-github-token
       # IN-MEMORY (all) - op-node/op-geth
       - op-acceptance-tests:
           name: memory-all-opn-op-geth
           no_output_timeout: 120m
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - slack
-            - discord
           requires:
             - contracts-bedrock-build
             - cannon-prestate
@@ -2648,10 +2575,6 @@ workflows:
           name: memory-all-opn-op-reth
           l2_el_kind: op-reth
           no_output_timeout: 120m
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - slack
-            - discord
           requires:
             - contracts-bedrock-build
             - cannon-prestate
@@ -2663,10 +2586,6 @@ workflows:
           l2_cl_kind: kona-node
           l2_el_kind: op-reth
           no_output_timeout: 120m
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - slack
-            - discord
           requires:
             - contracts-bedrock-build
             - cannon-prestate
@@ -2686,17 +2605,12 @@ workflows:
             - memory-all-opn-op-geth: terminal
             - memory-all-opn-op-reth: terminal
             - memory-all-kona-op-reth: terminal
-          context:
-            - circleci-api-token
           filters:
             branches:
               ignore: develop
       # Generate flaky test report
       - generate-flaky-report:
           name: generate-flaky-tests-report
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - circleci-api-token
 
   main-skip:
     when:
@@ -2707,8 +2621,6 @@ workflows:
     jobs:
       - ci-gate:
           always-succeed: true
-          context:
-            - circleci-api-token
 
   go-release-op-deployer:
     jobs:
@@ -2720,8 +2632,6 @@ workflows:
             branches:
               ignore: /.*/
           build_args: --skip test
-          context:
-            - circleci-repo-readonly-authenticated-github-token
       - go-release:
           filters:
             tags:
@@ -2729,9 +2639,6 @@ workflows:
             branches:
               ignore: /.*/
           module: op-deployer
-          context:
-            - oplabs-gcr-release
-            - circleci-repo-readonly-authenticated-github-token
           requires:
             - build-contracts-go-release-op-deployer
 
@@ -2745,8 +2652,6 @@ workflows:
             branches:
               ignore: /.*/
           build_args: --skip test
-          context:
-            - circleci-repo-readonly-authenticated-github-token
       - go-release:
           filters:
             tags:
@@ -2754,9 +2659,6 @@ workflows:
             branches:
               ignore: /.*/
           module: op-up
-          context:
-            - oplabs-gcr-release
-            - circleci-repo-readonly-authenticated-github-token
           requires:
             - build-contracts-go-release-op-up
 
@@ -2766,8 +2668,6 @@ workflows:
         equal: [scheduled_pipeline, << pipeline.trigger_source >>]
     jobs:
       - initialize:
-          context:
-            - circleci-repo-readonly-authenticated-github-token
           filters:
             tags:
               only: /^(da-server|cannon|ufm-[a-z0-9\-]*|op-[a-z0-9\-]*)\/v.*/
@@ -2779,15 +2679,9 @@ workflows:
               only: /^op-program\/v.*/
             branches:
               ignore: /.*/
-          context:
-            - circleci-repo-readonly-authenticated-github-token
           requires:
             - initialize
       - publish-cannon-prestates:
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - slack
-            - oplabs-network-optimism-io-bucket
           requires:
             - cannon-prestate
           filters:
@@ -2802,9 +2696,6 @@ workflows:
     jobs:
       - todo-issues:
           name: todo-issue-checks
-          context:
-            - slack
-            - circleci-repo-readonly-authenticated-github-token
 
   publish-contract-artifacts-on-tag:
     jobs:
@@ -2814,8 +2705,6 @@ workflows:
               only: /^op-contracts\/v.*/
             branches:
               ignore: /.*/
-          context:
-            - circleci-repo-readonly-authenticated-github-token
 
   develop-fault-proofs:
     when:
@@ -2828,17 +2717,9 @@ workflows:
             - equal: ["api", << pipeline.trigger_source >>]
     jobs:
       - cannon-prestate:
-          context:
-            - circleci-repo-readonly-authenticated-github-token
       - cannon-stf-verify:
-          context:
-            - slack
-            - circleci-repo-readonly-authenticated-github-token
       - contracts-bedrock-build:
           build_args: --deny-warnings --skip test
-          context:
-            - slack
-            - circleci-repo-readonly-authenticated-github-token
       - rust-build-binary:
           name: rust-workspace-binaries
           directory: rust
@@ -2846,8 +2727,6 @@ workflows:
           save_cache: true
           persist_to_workspace: true
           rust_files_changed: << pipeline.parameters.c-rust_files_changed >>
-          context:
-            - circleci-repo-readonly-authenticated-github-token
       - go-tests-with-fault-proof-deps:
           name: op-e2e-cannon-tests
           notify: true
@@ -2855,18 +2734,11 @@ workflows:
           no_output_timeout: 90m
           test_timeout: 480m
           resource_class: 2xlarge
-          context:
-            - slack
-            - circleci-repo-readonly-authenticated-github-token
           requires:
             - contracts-bedrock-build
             - cannon-prestate
             - rust-workspace-binaries
       - publish-cannon-prestates:
-          context:
-            - slack
-            - oplabs-network-optimism-io-bucket
-            - circleci-repo-readonly-authenticated-github-token
           requires:
             - cannon-prestate
             - op-e2e-cannon-tests
@@ -2882,10 +2754,6 @@ workflows:
             - equal: ["api", << pipeline.trigger_source >>]
     jobs:
       - kontrol-tests:
-          context:
-            - slack
-            - runtimeverification
-            - circleci-repo-readonly-authenticated-github-token
 
   scheduled-cannon-full-tests:
     when:
@@ -2895,17 +2763,12 @@ workflows:
     jobs:
       - contracts-bedrock-build:
           build_args: --deny-warnings --skip test
-          context:
-            - circleci-repo-readonly-authenticated-github-token
       - cannon-go-lint-and-test:
           requires:
             - contracts-bedrock-build
           skip_slow_tests: false
           no_output_timeout: 30m
           notify: true
-          context:
-            - slack
-            - circleci-repo-readonly-authenticated-github-token
 
   scheduled-preimage-reproducibility:
     when:
@@ -2915,9 +2778,6 @@ workflows:
         - equal: [true, << pipeline.parameters.c-reproducibility_dispatch >>]
     jobs:
       - preimage-reproducibility:
-          context:
-            - slack
-            - circleci-repo-readonly-authenticated-github-token
 
   scheduled-stale-check:
     when:
@@ -2927,8 +2787,6 @@ workflows:
         - equal: [true, << pipeline.parameters.c-stale_check_dispatch >>]
     jobs:
       - stale-check:
-          context:
-            - circleci-repo-optimism
 
   scheduled-heavy-fuzz-tests:
     when:
@@ -2937,9 +2795,6 @@ workflows:
         - equal: [true, << pipeline.parameters.c-heavy_fuzz_dispatch >>]
     jobs:
       - contracts-bedrock-heavy-fuzz-nightly:
-          context:
-            - slack
-            - circleci-repo-readonly-authenticated-github-token
   close-issue-workflow:
     when:
       and:
@@ -2953,8 +2808,6 @@ workflows:
             At this time, we are not accepting contributions that primarily fix spelling, stylistic, or grammatical errors in documentation, code, or elsewhere.
             Please check our [contribution guidelines](https://github.com/ethereum-optimism/optimism/blob/develop/CONTRIBUTING.md#contributions-related-to-spelling-and-grammar) for more information.
             This issue will be closed now."
-          context:
-            - circleci-repo-optimism
 
   ai-contracts-test-workflow:
     when:
@@ -2963,11 +2816,6 @@ workflows:
         - equal: [true, << pipeline.parameters.c-ai_contracts_test_dispatch >>]
     jobs:
       - ai-contracts-test:
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - circleci-api-token
-            - devin-api
-            - slack
 
   l2-fork-test-workflow:
     when:
@@ -2981,9 +2829,6 @@ workflows:
           l2_fork_rpc: https://op-mainnet-rpc.optimism.io/
           l2_fork_block_number: latest
           test_profile: ci
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - slack
 
   scheduled-weekly-tests:
     when:
@@ -3008,9 +2853,6 @@ workflows:
                 - base
                 - xlayer
           test_profile: ci
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - slack
 
   contracts-feature-tests:
     when:
@@ -3054,9 +2896,6 @@ workflows:
                 - L2CM
                 - L2CM,CUSTOM_GAS_TOKEN
                 - L2CM,OPTIMISM_PORTAL_INTEROP
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - slack
       # On PRs, run tests with lite profile for better build times.
       - contracts-bedrock-tests:
           name: contracts-bedrock-tests <<matrix.features>>
@@ -3066,9 +2905,6 @@ workflows:
           matrix:
             parameters:
               features: *features_matrix
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - slack
           filters:
             branches:
               ignore: develop
@@ -3081,9 +2917,6 @@ workflows:
           matrix:
             parameters:
               features: *features_matrix
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - slack
           filters:
             branches:
               only: develop
@@ -3096,9 +2929,6 @@ workflows:
           matrix:
             parameters:
               features: *features_matrix
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - slack
       # On PRs, run upgrade tests with lite profile for better build times.
       - contracts-bedrock-tests-upgrade:
           name: contracts-bedrock-tests-upgrade op-mainnet <<matrix.features>>
@@ -3110,9 +2940,6 @@ workflows:
           matrix:
             parameters:
               features: *features_matrix
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - slack
           filters:
             branches:
               ignore: develop
@@ -3127,9 +2954,6 @@ workflows:
           matrix:
             parameters:
               features: *features_matrix
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - slack
           filters:
             branches:
               only: develop
@@ -3143,9 +2967,6 @@ workflows:
           matrix:
             parameters:
               fork_op_chain: ["op", "ink", "unichain"]
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - slack
           filters:
             branches:
               ignore: develop
@@ -3159,9 +2980,6 @@ workflows:
           matrix:
             parameters:
               fork_op_chain: ["op", "ink", "unichain"]
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - slack
           filters:
             branches:
               only: develop
@@ -3172,14 +2990,8 @@ workflows:
           l2_fork_rpc: https://op-mainnet-rpc.optimism.io/
           l2_fork_block_number: latest
           test_profile: ci
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - slack
       - contracts-bedrock-checks-fast:
           name: contracts-bedrock-checks-fast-feature-tests
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - slack
       # -----------------------------------------------------------------------
       # required-contracts-ci: GitHub required status for this workflow. Terminal requires
       # keep this job scheduled even when upstream jobs fail; ci-gate then checks they passed.
@@ -3191,8 +3003,6 @@ workflows:
             - contracts-bedrock-coverage main: terminal
             - contracts-bedrock-tests-upgrade op-mainnet main: terminal
             - contracts-bedrock-checks-fast-feature-tests: terminal
-          context:
-            - circleci-api-token
 
   # ============================================================================
   # Required contracts CI gate (skip) — runs when no contract changes
@@ -3221,5 +3031,3 @@ workflows:
     jobs:
       - required-contracts-ci:
           always-succeed: true
-          context:
-            - circleci-api-token

--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -1027,7 +1027,7 @@ workflows:
       # -----------------------------------------------------------------------
       # OP-Reth crate-specific jobs
       # -----------------------------------------------------------------------
-      - op-reth-compact-codec:
+      - op-reth-compact-codec
 
       - rust-ci-cargo-tests:
           name: op-reth-integration-tests
@@ -1100,7 +1100,7 @@ workflows:
     when:
       equal: [build_weekly, <<pipeline.schedule.name>>]
     jobs:
-      - kona-link-checker:
+      - kona-link-checker
 
   # Kona publish prestate artifacts - on push to develop
   kona-publish-prestates:

--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -954,67 +954,54 @@ workflows:
       - rust-ci-fmt:
           name: rust-fmt
           directory: rust
-          context: &rust-ci-context
-            - circleci-repo-readonly-authenticated-github-token
 
       - rust-ci-clippy:
           name: rust-clippy
           directory: rust
           command: "cargo clippy --workspace --all-targets --all-features --locked"
-          context: *rust-ci-context
 
       - rust-ci-deny:
           name: rust-deny
           directory: rust
           command: "just deny"
-          context: *rust-ci-context
 
       - rust-ci-typos:
           name: rust-typos
           directory: rust
-          context: *rust-ci-context
 
       - rust-ci-zepter:
           name: rust-zepter
           directory: rust
-          context: *rust-ci-context
 
       - rust-ci-cargo-tests:
           name: rust-tests
           directory: rust
-          context: *rust-ci-context
 
       - rust-ci-doctest:
           name: rust-doctest
           directory: rust
           command: "cargo test --doc --workspace --all-features"
-          context: *rust-ci-context
 
       - rust-ci-docs:
           name: rust-docs
           directory: rust
-          context: *rust-ci-context
 
       - rust-ci-udeps:
           name: rust-udeps
           directory: rust
-          context: *rust-ci-context
 
       - rust-ci-cargo-hack:
           name: rust-cargo-hack
           parallelism: 6
-          context: *rust-ci-context
 
       - rust-build-binary:
           name: rust-build
           directory: rust
-          context: *rust-ci-context
 
       - rust-build-binary:
           name: rust-build-release
           directory: rust
           profile: release
-          context: *rust-ci-context
 
       # -----------------------------------------------------------------------
       # Unified cross-compilation jobs
@@ -1024,34 +1011,29 @@ workflows:
           directory: rust
           command: |
             just check-no-std
-          context: *rust-ci-context
 
       - rust-ci-cargo-hack-build:
           name: rust-wasm-unknown
           directory: rust
           target: wasm32-unknown-unknown
           flags: "-p op-alloy-consensus -p op-alloy-rpc-types -p op-alloy-rpc-types-engine -p alloy-op-evm --no-default-features"
-          context: *rust-ci-context
 
       - rust-ci-cargo-hack-build:
           name: rust-wasm-wasi
           directory: rust
           target: wasm32-wasip1
           flags: "-p op-alloy-consensus -p op-alloy-rpc-types-engine -p alloy-op-evm"
-          context: *rust-ci-context
 
       # -----------------------------------------------------------------------
       # OP-Reth crate-specific jobs
       # -----------------------------------------------------------------------
       - op-reth-compact-codec:
-          context: *rust-ci-context
 
       - rust-ci-cargo-tests:
           name: op-reth-integration-tests
           directory: rust
           command: "--justfile op-reth/justfile test-integration"
           cache_profile: debug
-          context: *rust-ci-context
 
       # -----------------------------------------------------------------------
       # Kona crate-specific jobs (lint, FPVM builds, benches, coverage)
@@ -1059,21 +1041,17 @@ workflows:
       - kona-cargo-lint:
           name: kona-lint-cannon
           target: "cannon"
-          context: *rust-ci-context
 
       - kona-build-fpvm:
           name: kona-build-fpvm-cannon-client
           target: "cannon-client"
-          context: *rust-ci-context
 
       - kona-coverage:
-          context: *rust-ci-context
           requires:
             - rust-tests
 
       - kona-host-client-offline:
           name: kona-host-client-offline-cannon
-          context: *rust-ci-context
 
       # -----------------------------------------------------------------------
       # Required gate — fans in on required Rust CI jobs
@@ -1098,19 +1076,16 @@ workflows:
       - rust-ci-cargo-tests:
           name: rust-tests
           directory: rust
-          context: *rust-ci-context
 
       - rust-ci-cargo-tests:
           name: op-reth-integration-tests
           directory: rust
           command: "--justfile op-reth/justfile test-integration"
           cache_profile: debug
-          context: *rust-ci-context
 
       - kona-build-fpvm:
           name: kona-build-fpvm-cannon-client
           target: "cannon-client"
-          context: *rust-ci-context
 
       - required-rust-ci:
           requires:
@@ -1126,8 +1101,6 @@ workflows:
       equal: [build_weekly, <<pipeline.schedule.name>>]
     jobs:
       - kona-link-checker:
-          context:
-            - circleci-repo-readonly-authenticated-github-token
 
   # Kona publish prestate artifacts - on push to develop
   kona-publish-prestates:
@@ -1142,6 +1115,3 @@ workflows:
           matrix:
             parameters:
               version: ["kona-client", "kona-client-int"]
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - oplabs-network-optimism-io-bucket

--- a/.circleci/continue/rust-e2e.yml
+++ b/.circleci/continue/rust-e2e.yml
@@ -311,38 +311,26 @@ workflows:
     jobs:
       - contracts-bedrock-build:
           build_args: --skip test
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-      - cannon-prestate: &rust-e2e-job-base
-          context:
-            - circleci-repo-readonly-authenticated-github-token
+      - cannon-prestate: &rust-e2e-job-base {}
       - rust-build-binary: &cannon-kona-host
           name: cannon-kona-host
           directory: rust
           profile: release
           binary: "kona-host"
-          context:
-            - circleci-repo-readonly-authenticated-github-token
       - rust-build-binary: &kona-build-release
           name: kona-build-release
           directory: rust
           profile: release
-          context:
-            - circleci-repo-readonly-authenticated-github-token
       - rust-build-binary:
           name: op-reth-build
           directory: rust
           profile: release
           binary: "op-reth"
-          context:
-            - circleci-repo-readonly-authenticated-github-token
       - rust-e2e-sysgo-tests:
           name: rust-e2e-<<matrix.devnet_config>>
           matrix:
             parameters:
               devnet_config: ["simple-kona", "simple-kona-geth", "simple-kona-sequencer"]
-          context:
-            - circleci-repo-readonly-authenticated-github-token
           requires:
             - contracts-bedrock-build
             - cannon-prestate
@@ -369,8 +357,6 @@ workflows:
           requires:
             - kona-build-release
             - contracts-bedrock-build
-          context:
-            - circleci-repo-readonly-authenticated-github-token
       # -----------------------------------------------------------------------
       # Required gate — fans in on all E2E test jobs
       # -----------------------------------------------------------------------
@@ -393,14 +379,10 @@ workflows:
     jobs:
       - contracts-bedrock-build:
           build_args: --skip test
-          context:
-            - circleci-repo-readonly-authenticated-github-token
       - rust-build-binary:
           name: kona-build-release
           directory: rust
           profile: release
-          context:
-            - circleci-repo-readonly-authenticated-github-token
       # Proof tests - single kind only, interop excluded per original config
       - kona-proof-action-tests:
           name: kona-proof-action-single
@@ -408,8 +390,6 @@ workflows:
           requires:
             - kona-build-release
             - contracts-bedrock-build
-          context:
-            - circleci-repo-readonly-authenticated-github-token
 
       - required-rust-e2e:
           requires:

--- a/.circleci/rust-nightly-bump.yml
+++ b/.circleci/rust-nightly-bump.yml
@@ -58,4 +58,4 @@ workflows:
               only:
                 - main
     jobs:
-      - bump-nightly:
+      - bump-nightly

--- a/.circleci/rust-nightly-bump.yml
+++ b/.circleci/rust-nightly-bump.yml
@@ -59,5 +59,3 @@ workflows:
                 - main
     jobs:
       - bump-nightly:
-          context:
-            - circleci-repo-optimism


### PR DESCRIPTION
## Summary

**⚠️ Do not merge.** Experiment only.

Removes every `context:` reference from the CircleCI config (111 occurrences across `main.yml`, `rust-ci.yml`, `rust-e2e.yml`, and `rust-nightly-bump.yml`). This simulates the environment a fork PR would run in if we enabled "Build forked pull requests" in CircleCI — no secrets injected, no contexts attached.

The purpose is to see **which jobs actually fail without their contexts** so we can scope the fork-PR-CI plan (see [design-docs#377](https://github.com/ethereum-optimism/design-docs/pull/377)) against real data instead of theory. Some jobs only reference contexts to avoid GitHub API rate limits (probably pass anyway on a warm cache); some genuinely need credentials (publish, release, Kontrol, Devin, notifications, etc.) and will fail.

## Notes on the diff

- Context blocks stripped via a small script; YAML validated with `js-yaml` post-strip — all configs parse.
- `&rust-e2e-job-base` anchor in `rust-e2e.yml` lost its only content (a context list), so it's been reset to an explicit empty mapping (`{}`) to keep the `<<:` merge references valid. No behavioural change beyond the removed contexts.
- Branch is based on latest `develop` (`496dd9cc41`).

## What I'll do with the results

- Tag every job that fails with the context-dependent reason it failed.
- Update the design doc's "jobs to gate with `when: not is_fork_pr`" list with the observed set, instead of the current inferred one.
- Close this PR without merging once the CI run is complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)