### PR TITLE
fix(op-node): pipeline reset to handle EL restarts gracefully

### DIFF
--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -535,6 +535,13 @@ func (e *EngineController) tryUpdateEngineInternal(ctx context.Context) error {
 			return derive.NewTemporaryError(fmt.Errorf("failed to sync forkchoice with engine: %w", err))
 		}
 	}
+	// Verify the FCU response status is acceptable. In CL-sync mode, only VALID is acceptable.
+	// If the EL returns SYNCING (e.g. after an EL restart where in-memory state was lost),
+	// trigger a reset to re-discover the EL's actual chain state via FindL2Heads. Done before
+	// recording lastForkchoice so a rejected FCU doesn't short-circuit the next retry.
+	if !e.checkForkchoiceUpdatedStatus(fcRes.PayloadStatus.Status) {
+		return derive.NewResetError(fmt.Errorf("forkchoice update returned unexpected status %s, need reset to re-sync with engine", fcRes.PayloadStatus.Status))
+	}
 	e.lastForkchoice = fc
 	if fcRes.PayloadStatus.Status == eth.ExecutionValid {
 		e.requestForkchoiceUpdate(ctx)

--- a/op-node/rollup/engine/engine_controller_test.go
+++ b/op-node/rollup/engine/engine_controller_test.go
@@ -694,3 +694,100 @@ func TestEngineController_FinalizedHead(t *testing.T) {
 		})
 	}
 }
+
+// TestTryUpdateEngine_SyncingInCLModeTriggersReset tests that when the EL returns SYNCING
+// during a forkchoice update in CL-sync mode (e.g. after an EL restart), the engine controller
+// triggers a reset to re-discover the EL's actual chain state.
+func TestTryUpdateEngine_SyncingInCLModeTriggersReset(t *testing.T) {
+	cfg := &rollup.Config{
+		Genesis: rollup.Genesis{
+			L2Time: 1000,
+		},
+		BlockTime: 2,
+	}
+
+	mockEngine := &testutils.MockEngine{}
+	emitter := &testutils.MockEmitter{}
+	ec := NewEngineController(context.Background(), mockEngine, testlog.Logger(t, 0), metrics.NoopMetrics, cfg, &sync.Config{SyncMode: sync.CLSync}, false, &testutils.MockL1Source{}, emitter, nil)
+
+	// Set up valid internal state so initializeUnknowns succeeds
+	unsafeRef := eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100}
+	safeRef := eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 80}
+	finalRef := eth.L2BlockRef{Hash: common.Hash{0xcc}, Number: 50}
+
+	ec.unsafeHead = unsafeRef
+	ec.SetLocalSafeHead(safeRef)
+	ec.SetFinalizedHead(finalRef)
+
+	// Mock initializeUnknowns calls
+	mockEngine.ExpectL2BlockRefByLabel(eth.Unsafe, unsafeRef, nil)
+	mockEngine.ExpectL2BlockRefByLabel(eth.Safe, safeRef, nil)
+	mockEngine.ExpectL2BlockRefByLabel(eth.Finalized, finalRef, nil)
+
+	// Mock ForkchoiceUpdate to return SYNCING (simulating EL restart)
+	mockEngine.ExpectForkchoiceUpdate(
+		&eth.ForkchoiceState{
+			HeadBlockHash:      unsafeRef.Hash,
+			SafeBlockHash:      safeRef.Hash,
+			FinalizedBlockHash: finalRef.Hash,
+		},
+		nil,
+		&eth.ForkchoiceUpdatedResult{
+			PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionSyncing},
+		},
+		nil,
+	)
+
+	// Call tryUpdateEngineInternal - should return a reset error
+	err := ec.tryUpdateEngineInternal(context.Background())
+	require.Error(t, err)
+	require.True(t, errors.Is(err, derive.ErrReset), "expected reset error, got: %v", err)
+	require.Contains(t, err.Error(), "unexpected status")
+}
+
+// TestTryUpdateEngine_SyncingInELSyncModeIsAccepted tests that SYNCING is accepted
+// in EL-sync mode (existing behavior preserved).
+func TestTryUpdateEngine_SyncingInELSyncModeIsAccepted(t *testing.T) {
+	cfg := &rollup.Config{
+		Genesis: rollup.Genesis{
+			L2Time: 1000,
+		},
+		BlockTime: 2,
+	}
+
+	mockEngine := &testutils.MockEngine{}
+	emitter := &testutils.MockEmitter{}
+	ec := NewEngineController(context.Background(), mockEngine, testlog.Logger(t, 0), metrics.NoopMetrics, cfg, &sync.Config{SyncMode: sync.ELSync}, false, &testutils.MockL1Source{}, emitter, nil)
+
+	// Set up valid internal state
+	unsafeRef := eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100}
+	safeRef := eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 80}
+	finalRef := eth.L2BlockRef{Hash: common.Hash{0xcc}, Number: 50}
+
+	ec.unsafeHead = unsafeRef
+	ec.SetLocalSafeHead(safeRef)
+	ec.SetFinalizedHead(finalRef)
+
+	// Mock initializeUnknowns calls
+	mockEngine.ExpectL2BlockRefByLabel(eth.Unsafe, unsafeRef, nil)
+	mockEngine.ExpectL2BlockRefByLabel(eth.Safe, safeRef, nil)
+	mockEngine.ExpectL2BlockRefByLabel(eth.Finalized, finalRef, nil)
+
+	// Mock ForkchoiceUpdate to return SYNCING
+	mockEngine.ExpectForkchoiceUpdate(
+		&eth.ForkchoiceState{
+			HeadBlockHash:      unsafeRef.Hash,
+			SafeBlockHash:      safeRef.Hash,
+			FinalizedBlockHash: finalRef.Hash,
+		},
+		nil,
+		&eth.ForkchoiceUpdatedResult{
+			PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionSyncing},
+		},
+		nil,
+	)
+
+	// Call tryUpdateEngineInternal - should succeed in EL-sync mode
+	err := ec.tryUpdateEngineInternal(context.Background())
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Summary

Replays #19384 on current \`develop\`. Original author: @bitwiseguy (Sam Stokes), credited as co-author below.

- When \`op-reth\` is restarted, it may lose its in-memory canonical chain state and return \`SYNCING\` to forkchoice updates.
- On current \`develop\` (after #19638), a \`SYNCING\` response is recorded as the last-accepted forkchoice via \`e.lastForkchoice = fc\`; the subsequent \`if fc == e.lastForkchoice { return nil }\` guard then suppresses all future FCU retries for that forkchoice, stalling op-node until restarted.
- This fix validates the FCU response status via the existing \`checkForkchoiceUpdatedStatus\` method *before* recording \`lastForkchoice\`. In CL-sync mode, \`SYNCING\` triggers a \`ResetError\`, so the pipeline runs \`FindL2Heads\` to re-discover the EL's actual chain state. In EL-sync mode, \`SYNCING\` remains accepted (existing behavior preserved).

## Evolution from #19384

A first iteration of this PR included an acceptance test \`TestELRestartRecovery\` that stopped the verifier op-reth, advanced the sequencer 10 blocks, restarted op-reth, and asserted the verifier caught up.

Empirical validation against current \`develop\` (ran the test with and without this commit's fix applied):

| Check | With fix | Without fix |
|---|---|---|
| \`TestTryUpdateEngine_SyncingInCLModeTriggersReset\` | PASS | **FAIL** — \`An error is expected but got nil\` |
| \`TestTryUpdateEngine_SyncingInELSyncModeIsAccepted\` | PASS | PASS (preserved behavior) |
| \`TestELRestartRecovery\` (acceptance) | PASS (~40s) | **PASS** (~41s) |

The unit tests are real regression guards. The acceptance test, as written, were not — they passes identically with or without the fix, because op-reth's persistence on clean shutdown appears sufficient that its canonical head survives the restart and FCU returns VALID rather than SYNCING. This ineffective acceptance test has therefore been dropped from an earlier iteration of PR; the fix ships with unit-test coverage only.

A follow-up issue tracks the need for a deterministic acceptance test that actually reproduces the SYNCING-after-restart condition: #20307.

## Merge conflicts resolved

- \`op-node/rollup/engine/engine_controller.go\` — ordered the new status check **before** \`e.lastForkchoice = fc\` (added on develop in #19638) so a rejected FCU doesn't get recorded as the last accepted forkchoice.
- \`op-node/rollup/engine/engine_controller_test.go\` — removed \`ec.needFCUCall = true\` from the two new tests; that field was deleted in #19638. Behavior is equivalent — the tests' initial \`lastForkchoice\` is the zero value, so the first FCU still fires.
- \`.circleci/continue/main.yml\` — the CI commit from the original PR (\`OP_RETH_EXEC_PATH\` export) is already present on develop in a dedicated "Configure L2 stack" step; no diff remained.

## Test plan

- [x] \`go build ./op-node/...\` — zero warnings
- [x] \`go vet ./op-node/rollup/engine/...\` — zero warnings
- [x] \`go test ./op-node/rollup/engine/\` — all pass, including the two new \`TestTryUpdateEngine_Syncing*\` tests
- [x] Unit tests empirically fail on a local revert of this commit — regression-guard proven
- [ ] CI green

Co-authors on the commit: Samuel Stokes (original author), Claude Opus 4.6 (original pairing).

🤖 *Generated by Claude Code*