### PR TITLE
chore(rust): add release recipe for subdir crate releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,8 @@ packages/contracts-bedrock/deployments/anvil
 
 .devnet*
 
+.claude/worktrees
+
 # Ignore local fuzzing results
 **/testdata/fuzz/
 

--- a/mise.toml
+++ b/mise.toml
@@ -23,6 +23,8 @@ make = "4.4.1"
 svm-rs = "0.5.19"
 
 # Rust tooling
+"github:crate-ci/cargo-release" = { version = "1.1.2" }
+
 "github:nextest-rs/nextest" = { version = "0.9.132", version_prefix = "cargo-nextest-", bin = "cargo-nextest" }
 "github:EmbarkStudios/cargo-deny" = "0.19.4"
 "github:ggwpez/zepter" = { version = "1.88.0", version_prefix = "v" }
@@ -34,7 +36,7 @@ svm-rs = "0.5.19"
 
 # Go dependencies
 "go:github.com/ethereum/go-ethereum/cmd/abigen" = "1.15.10"
-"go:github.com/ethereum/go-ethereum/cmd/geth" = "1.16.4" # Osaka testnet release.
+"go:github.com/ethereum/go-ethereum/cmd/geth" = "1.16.4"    # Osaka testnet release.
 
 # Python dependencies
 "pipx:slither-analyzer" = "0.10.2"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -7694,7 +7694,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "op-alloy"
-version = "0.24.0"
+version = "2.0.0"
 dependencies = [
  "op-alloy-consensus",
  "op-alloy-network",
@@ -7706,7 +7706,7 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-consensus"
-version = "0.24.0"
+version = "2.0.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -7739,7 +7739,7 @@ checksum = "a79f352fc3893dcd670172e615afef993a41798a1d3fc0db88a3e60ef2e70ecc"
 
 [[package]]
 name = "op-alloy-network"
-version = "0.24.0"
+version = "2.0.0"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -7751,7 +7751,7 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-provider"
-version = "0.24.0"
+version = "2.0.0"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -7764,7 +7764,7 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-rpc-jsonrpsee"
-version = "0.24.0"
+version = "2.0.0"
 dependencies = [
  "alloy-primitives",
  "jsonrpsee",
@@ -7772,7 +7772,7 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-rpc-types"
-version = "0.24.0"
+version = "2.0.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
@@ -7796,7 +7796,7 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-rpc-types-engine"
-version = "0.24.0"
+version = "2.0.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -7855,7 +7855,7 @@ dependencies = [
 
 [[package]]
 name = "op-revm"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "alloy-op-hardforks"
-version = "0.4.7"
+version = "0.5.0"
 dependencies = [
  "alloy-chains",
  "alloy-hardforks",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -405,7 +405,7 @@ dependencies = [
 
 [[package]]
 name = "alloy-op-evm"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -306,7 +306,7 @@ op-alloy-rpc-types-engine = { version = "2.0.0", path = "op-alloy/crates/rpc-typ
 op-alloy-rpc-jsonrpsee = { version = "2.0.0", path = "op-alloy/crates/rpc-jsonrpsee", default-features = false }
 
 # ==================== ALLOY-OP-EVM / ALLOY-OP-HARDFORKS ====================
-alloy-op-evm = { version = "0.31.0", path = "alloy-op-evm/", default-features = false }
+alloy-op-evm = { version = "0.32.0", path = "alloy-op-evm/", default-features = false }
 alloy-op-hardforks = { version = "0.5.0", path = "alloy-op-hardforks/", default-features = false }
 
 # ==================== RETH CRATES (crates.io) ====================

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -398,7 +398,7 @@ revm-state = { version = "11.0.0", default-features = false }
 revm-primitives = { version = "23.0.0", default-features = false }
 revm-interpreter = { version = "35.0.0", default-features = false }
 revm-database-interface = { version = "11.0.0", default-features = false }
-op-revm = { version = "19.0.0", path = "op-revm/", default-features = false }
+op-revm = { version = "20.0.0", path = "op-revm/", default-features = false }
 revm-inspectors = "0.39.0"
 
 # ==================== ALLOY ====================

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -298,12 +298,12 @@ reth-optimism-trie = { path = "op-reth/crates/trie/" }
 reth-optimism-txpool = { path = "op-reth/crates/txpool/" }
 
 # ==================== OP-ALLOY INTERNAL CRATES ====================
-op-alloy-consensus = { version = "0.24.0", path = "op-alloy/crates/consensus", default-features = false }
-op-alloy-network = { version = "0.24.0", path = "op-alloy/crates/network", default-features = false }
-op-alloy-provider = { version = "0.24.0", path = "op-alloy/crates/provider", default-features = false }
-op-alloy-rpc-types = { version = "0.24.0", path = "op-alloy/crates/rpc-types", default-features = false }
-op-alloy-rpc-types-engine = { version = "0.24.0", path = "op-alloy/crates/rpc-types-engine", default-features = false }
-op-alloy-rpc-jsonrpsee = { version = "0.24.0", path = "op-alloy/crates/rpc-jsonrpsee", default-features = false }
+op-alloy-consensus = { version = "2.0.0", path = "op-alloy/crates/consensus", default-features = false }
+op-alloy-network = { version = "2.0.0", path = "op-alloy/crates/network", default-features = false }
+op-alloy-provider = { version = "2.0.0", path = "op-alloy/crates/provider", default-features = false }
+op-alloy-rpc-types = { version = "2.0.0", path = "op-alloy/crates/rpc-types", default-features = false }
+op-alloy-rpc-types-engine = { version = "2.0.0", path = "op-alloy/crates/rpc-types-engine", default-features = false }
+op-alloy-rpc-jsonrpsee = { version = "2.0.0", path = "op-alloy/crates/rpc-jsonrpsee", default-features = false }
 
 # ==================== ALLOY-OP-EVM / ALLOY-OP-HARDFORKS ====================
 alloy-op-evm = { version = "0.31.0", path = "alloy-op-evm/", default-features = false }
@@ -456,7 +456,7 @@ alloy-transport-ipc = { version = "2.0.4", default-features = false }
 alloy-transport-ws = { version = "2.0.4", default-features = false }
 
 # ==================== OP-ALLOY (from crates.io) ====================
-op-alloy = { version = "0.24.0", path = "op-alloy/crates/op-alloy", default-features = false }
+op-alloy = { version = "2.0.0", path = "op-alloy/crates/op-alloy", default-features = false }
 op-alloy-flz = { version = "0.13.1", default-features = false }
 
 # ==================== ASYNC ====================

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -307,7 +307,7 @@ op-alloy-rpc-jsonrpsee = { version = "2.0.0", path = "op-alloy/crates/rpc-jsonrp
 
 # ==================== ALLOY-OP-EVM / ALLOY-OP-HARDFORKS ====================
 alloy-op-evm = { version = "0.31.0", path = "alloy-op-evm/", default-features = false }
-alloy-op-hardforks = { version = "0.4.7", path = "alloy-op-hardforks/", default-features = false }
+alloy-op-hardforks = { version = "0.5.0", path = "alloy-op-hardforks/", default-features = false }
 
 # ==================== RETH CRATES (crates.io) ====================
 reth-codecs = { version = "0.3.1", default-features = false, features = [

--- a/rust/alloy-op-evm/Cargo.toml
+++ b/rust/alloy-op-evm/Cargo.toml
@@ -2,7 +2,7 @@
 name = "alloy-op-evm"
 description = "OP EVM implementation"
 
-version = "0.31.0"
+version = "0.32.0"
 edition = "2021"
 rust-version = "1.94"
 authors = ["Alloy Contributors", "OpLabsPBC"]

--- a/rust/alloy-op-evm/release.toml
+++ b/rust/alloy-op-evm/release.toml
@@ -7,5 +7,5 @@ sign-tag = true
 shared-version = true
 pre-release-commit-message = "chore: release {{version}}"
 tag-prefix = "" # tag only once instead of per every crate
-pre-release-hook = ["sh", "-c", "$WORKSPACE_ROOT/scripts/changelog.sh --tag {{version}}"]
+pre-release-hook = ["sh", "-c", "$WORKSPACE_ROOT/alloy-op-evm/scripts/changelog.sh --tag {{version}}"]
 owners = ["github:alloy-rs:core"]

--- a/rust/alloy-op-evm/release.toml
+++ b/rust/alloy-op-evm/release.toml
@@ -1,11 +1,10 @@
 # Configuration file for [`cargo-release`](https://github.com/crate-ci/cargo-release)
 # See: https://github.com/crate-ci/cargo-release/blob/master/docs/reference.md
 
-allow-branch = ["main"]
+allow-branch = ["develop"]
 sign-commit = true
 sign-tag = true
 shared-version = true
 pre-release-commit-message = "chore: release {{version}}"
-tag-prefix = "" # tag only once instead of per every crate
-pre-release-hook = ["sh", "-c", "$WORKSPACE_ROOT/alloy-op-evm/scripts/changelog.sh --tag {{version}}"]
+tag-prefix = ""                                           # tag only once instead of per every crate
 owners = ["github:alloy-rs:core"]

--- a/rust/alloy-op-evm/release.toml
+++ b/rust/alloy-op-evm/release.toml
@@ -4,7 +4,5 @@
 allow-branch = ["develop"]
 sign-commit = true
 sign-tag = true
-shared-version = true
-pre-release-commit-message = "chore: release {{version}}"
-tag-prefix = ""                                           # tag only once instead of per every crate
-owners = ["github:alloy-rs:core"]
+pre-release-commit-message = "chore(alloy-op-evm): release {{version}}"
+tag-prefix = ""                                                         # tag only once instead of per every crate

--- a/rust/alloy-op-hardforks/Cargo.toml
+++ b/rust/alloy-op-hardforks/Cargo.toml
@@ -2,7 +2,7 @@
 name = "alloy-op-hardforks"
 description = "Bindings for named OP hardforks"
 
-version = "0.4.7"
+version = "0.5.0"
 edition = "2024"
 rust-version = "1.94"
 authors = ["Alloy Contributors", "OpLabsPBC"]

--- a/rust/justfile
+++ b/rust/justfile
@@ -195,13 +195,18 @@ hack partition="" shuffle="false" seed="default":
 
 ########################### Release #################################
 
-# Release all workspace crates at the given version, excluding crates under rust/op-reth/.
+# Release crates at the given version.
+# target: either "workspace" (releases every subdir under rust/ except op-reth,
+#         in dependency order) or one of the subdir names (op-alloy,
+#         alloy-op-hardforks, alloy-op-evm, op-revm, kona).
 # mode: "dry" (default, prints changes without applying) or "execute"
 # Extra args are forwarded to `cargo release`.
-# Example: just release 1.0.0
-# Example: just release 1.0.0 execute
-# Example: just release 1.0.0 execute --no-confirm --no-publish
-release VERSION MODE="dry" *ARGS="":
+# kona is split into two topologically-ordered batches to stay under the
+# crates.io "existing crates" rate limit of 30.
+# Example: just release workspace 1.0.0
+# Example: just release kona 1.0.0 execute
+# Example: just release op-alloy 1.0.0 execute --no-confirm
+release TARGET VERSION MODE="dry" *ARGS="":
     #!/usr/bin/env bash
     set -euo pipefail
 
@@ -216,20 +221,76 @@ release VERSION MODE="dry" *ARGS="":
       *) echo "error: mode must be 'dry' or 'execute', got '{{MODE}}'" >&2; exit 1 ;;
     esac
 
-    PKGS=$(cargo metadata --format-version=1 --no-deps \
-      | jq -r '.packages[] | select(.manifest_path | contains("/rust/op-reth/") | not) | .name' \
-      | sort -u | sed 's/^/-p /' | tr '\n' ' ')
+    METADATA=$(cargo metadata --format-version=1 --no-deps)
 
-    if [[ -z "$PKGS" ]]; then
-      echo "error: no workspace crates found to release" >&2
+    # Hardcoded split for kona: 32 crates exceeds crates.io's "existing crates"
+    # rate limit of 30, so we publish in two topologically-ordered batches.
+    # When adding a new crate under rust/kona/, append it to whichever batch
+    # leaves both <= 30 (preserving topo order: deps before dependents).
+    KONA_BATCH_1="kona-genesis kona-macros kona-mpt kona-preimage kona-serde kona-sources kona-registry kona-std-fpvm kona-cli kona-peers kona-protocol kona-std-fpvm-proc kona-disc kona-engine kona-executor kona-hardforks"
+    KONA_BATCH_2="kona-interop example-discovery kona-gossip execution-fixture kona-derive kona-rpc kona-driver kona-providers-alloy kona-providers-local kona-proof kona-node-service kona-proof-interop example-gossip kona-node kona-client kona-host"
+
+    ACTUAL_KONA=$(echo "$METADATA" | jq -r '.packages[] | select(.manifest_path | contains("/rust/kona/")) | .name' | sort -u)
+    EXPECTED_KONA=$(echo "$KONA_BATCH_1 $KONA_BATCH_2" | tr ' ' '\n' | sort -u)
+    if [[ "$ACTUAL_KONA" != "$EXPECTED_KONA" ]]; then
+      echo "error: hardcoded kona batches don't match actual kona crates." >&2
+      echo "  diff (actual vs expected):" >&2
+      diff <(echo "$ACTUAL_KONA") <(echo "$EXPECTED_KONA") >&2 || true
+      echo "  Update KONA_BATCH_1/KONA_BATCH_2 in rust/justfile." >&2
       exit 1
     fi
 
-    echo "Packages to release at version {{VERSION}} (mode: {{MODE}}):"
-    echo "$PKGS" | tr ' ' '\n' | sed '/^$/d'
-    echo
+    # Release order is dependency-driven: foundational crates first, kona last.
+    ALL_SUBDIRS="op-alloy alloy-op-hardforks alloy-op-evm op-revm kona"
 
-    exec cargo release {{VERSION}} $PKGS $EXTRA {{ARGS}}
+    EXPECTED_SUBDIRS=$(echo "$ALL_SUBDIRS" | tr ' ' '\n' | sort -u)
+    ACTUAL_SUBDIRS=$(echo "$METADATA" \
+      | jq -r '.packages[].manifest_path' \
+      | sed -nE 's|.*/rust/([^/]+)/.*|\1|p' \
+      | grep -vx 'op-reth' \
+      | sort -u)
+    if [[ "$EXPECTED_SUBDIRS" != "$ACTUAL_SUBDIRS" ]]; then
+      echo "error: hardcoded ALL_SUBDIRS list doesn't match actual subdirs under rust/." >&2
+      echo "  diff (expected vs actual):" >&2
+      diff <(echo "$EXPECTED_SUBDIRS") <(echo "$ACTUAL_SUBDIRS") >&2 || true
+      echo "  Update ALL_SUBDIRS in rust/justfile." >&2
+      exit 1
+    fi
+
+    case "{{TARGET}}" in
+      workspace) SUBDIRS="$ALL_SUBDIRS" ;;
+      *)
+        if ! echo " $ALL_SUBDIRS " | grep -q " {{TARGET}} "; then
+          echo "error: unknown target '{{TARGET}}'. Must be 'workspace' or one of: $ALL_SUBDIRS" >&2
+          exit 1
+        fi
+        SUBDIRS="{{TARGET}}"
+        ;;
+    esac
+
+    run_release() {
+      local label="$1"; shift
+      local pkgs
+      pkgs=$(printf -- '-p %s ' "$@")
+      echo "=== $label → version {{VERSION}} (mode: {{MODE}}) ==="
+      printf '%s\n' "$@"
+      echo
+      cargo release {{VERSION}} $pkgs $EXTRA {{ARGS}}
+    }
+
+    for subdir in $SUBDIRS; do
+      if [[ "$subdir" == "kona" ]]; then
+        run_release "rust/kona/ batch 1/2" $KONA_BATCH_1
+        run_release "rust/kona/ batch 2/2" $KONA_BATCH_2
+      else
+        PKGS_LIST=$(echo "$METADATA" \
+          | jq -r --arg dir "/rust/$subdir/" \
+              '.packages[] | select(.manifest_path | contains($dir)) | .name' \
+          | sort -u)
+        [[ -z "$PKGS_LIST" ]] && continue
+        run_release "rust/$subdir/" $PKGS_LIST
+      fi
+    done
 
 ######################### Documentation ################################
 

--- a/rust/justfile
+++ b/rust/justfile
@@ -195,11 +195,13 @@ hack partition="" shuffle="false" seed="default":
 
 ########################### Release #################################
 
-# Release crates under a subdirectory plus their transitive workspace deps.
+# Release all workspace crates at the given version, excluding crates under rust/op-reth/.
 # mode: "dry" (default, prints changes without applying) or "execute"
-# Example: just release op-alloy 1.0.0
-# Example: just release op-alloy 1.0.0 execute
-release SUBDIR VERSION MODE="dry":
+# Extra args are forwarded to `cargo release`.
+# Example: just release 1.0.0
+# Example: just release 1.0.0 execute
+# Example: just release 1.0.0 execute --no-confirm --no-publish
+release VERSION MODE="dry" *ARGS="":
     #!/usr/bin/env bash
     set -euo pipefail
 
@@ -214,29 +216,20 @@ release SUBDIR VERSION MODE="dry":
       *) echo "error: mode must be 'dry' or 'execute', got '{{MODE}}'" >&2; exit 1 ;;
     esac
 
-    WS_NAMES=$(cargo metadata --format-version=1 --no-deps \
-      | jq -r '.packages[].name' | sort -u)
+    PKGS=$(cargo metadata --format-version=1 --no-deps \
+      | jq -r '.packages[] | select(.manifest_path | contains("/rust/op-reth/") | not) | .name' \
+      | sort -u | sed 's/^/-p /' | tr '\n' ' ')
 
-    SEED=$(cargo metadata --format-version=1 --no-deps \
-      | jq -r --arg dir "/rust/{{SUBDIR}}/" \
-          '.packages[] | select(.manifest_path | contains($dir)) | .name')
-
-    if [[ -z "$SEED" ]]; then
-      echo "error: no workspace crates found under rust/{{SUBDIR}}/" >&2
+    if [[ -z "$PKGS" ]]; then
+      echo "error: no workspace crates found to release" >&2
       exit 1
     fi
-
-    DEPS=$(for pkg in $SEED; do
-      cargo tree -p "$pkg" -e normal,build --prefix none 2>/dev/null | awk '{print $1}'
-    done | sort -u)
-
-    PKGS=$(comm -12 <(echo "$DEPS") <(echo "$WS_NAMES") | sed 's/^/-p /' | tr '\n' ' ')
 
     echo "Packages to release at version {{VERSION}} (mode: {{MODE}}):"
     echo "$PKGS" | tr ' ' '\n' | sed '/^$/d'
     echo
 
-    exec cargo release {{VERSION}} $PKGS $EXTRA
+    exec cargo release {{VERSION}} $PKGS $EXTRA {{ARGS}}
 
 ######################### Documentation ################################
 

--- a/rust/justfile
+++ b/rust/justfile
@@ -193,6 +193,51 @@ hack partition="" shuffle="false" seed="default":
 
   cargo hack check --each-feature --no-dev-deps $PKG_FLAGS {{ if partition != "" { "--partition " + partition } else { "" } }}
 
+########################### Release #################################
+
+# Release crates under a subdirectory plus their transitive workspace deps.
+# mode: "dry" (default, prints changes without applying) or "execute"
+# Example: just release op-alloy 1.0.0
+# Example: just release op-alloy 1.0.0 execute
+release SUBDIR VERSION MODE="dry":
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    if ! command -v cargo-release >/dev/null 2>&1; then
+      echo "cargo-release not found, installing..."
+      cargo install cargo-release
+    fi
+
+    case "{{MODE}}" in
+      dry)     EXTRA="" ;;
+      execute) EXTRA="--execute" ;;
+      *) echo "error: mode must be 'dry' or 'execute', got '{{MODE}}'" >&2; exit 1 ;;
+    esac
+
+    WS_NAMES=$(cargo metadata --format-version=1 --no-deps \
+      | jq -r '.packages[].name' | sort -u)
+
+    SEED=$(cargo metadata --format-version=1 --no-deps \
+      | jq -r --arg dir "/rust/{{SUBDIR}}/" \
+          '.packages[] | select(.manifest_path | contains($dir)) | .name')
+
+    if [[ -z "$SEED" ]]; then
+      echo "error: no workspace crates found under rust/{{SUBDIR}}/" >&2
+      exit 1
+    fi
+
+    DEPS=$(for pkg in $SEED; do
+      cargo tree -p "$pkg" -e normal,build --prefix none 2>/dev/null | awk '{print $1}'
+    done | sort -u)
+
+    PKGS=$(comm -12 <(echo "$DEPS") <(echo "$WS_NAMES") | sed 's/^/-p /' | tr '\n' ' ')
+
+    echo "Packages to release at version {{VERSION}} (mode: {{MODE}}):"
+    echo "$PKGS" | tr ' ' '\n' | sed '/^$/d'
+    echo
+
+    exec cargo release {{VERSION}} $PKGS $EXTRA
+
 ######################### Documentation ################################
 
 DOCS_DIR := justfile_directory() / "docs"

--- a/rust/kona/release.toml
+++ b/rust/kona/release.toml
@@ -7,4 +7,4 @@ sign-tag = true
 shared-version = true
 pre-release-commit-message = "chore: release {{version}}"
 tag-prefix = "" # tag only once instead of per every crate
-pre-release-hook = ["sh", "-c", "$WORKSPACE_ROOT/.config/changelog.sh --tag {{version}}"]
+pre-release-hook = ["sh", "-c", "$WORKSPACE_ROOT/kona/.config/changelog.sh --tag {{version}}"]

--- a/rust/op-alloy/crates/consensus/Cargo.toml
+++ b/rust/op-alloy/crates/consensus/Cargo.toml
@@ -2,7 +2,7 @@
 name = "op-alloy-consensus"
 description = "Optimism alloy consensus types"
 
-version = "0.24.0"
+version = "2.0.0"
 edition.workspace = true
 rust-version.workspace = true
 authors = ["Alloy Contributors"]

--- a/rust/op-alloy/crates/network/Cargo.toml
+++ b/rust/op-alloy/crates/network/Cargo.toml
@@ -2,7 +2,7 @@
 name = "op-alloy-network"
 description = "Optimism blockchain RPC behavior abstraction"
 
-version = "0.24.0"
+version = "2.0.0"
 edition.workspace = true
 rust-version.workspace = true
 authors = ["Alloy Contributors"]

--- a/rust/op-alloy/crates/op-alloy/Cargo.toml
+++ b/rust/op-alloy/crates/op-alloy/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "op-alloy"
 description = "Connect applications to the OP Stack"
-version = "0.24.0"
+version = "2.0.0"
 edition.workspace = true
 rust-version.workspace = true
 authors = ["Alloy Contributors"]

--- a/rust/op-alloy/crates/provider/Cargo.toml
+++ b/rust/op-alloy/crates/provider/Cargo.toml
@@ -2,7 +2,7 @@
 name = "op-alloy-provider"
 description = "Interface with an OP Stack blockchain"
 
-version = "0.24.0"
+version = "2.0.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/rust/op-alloy/crates/rpc-jsonrpsee/Cargo.toml
+++ b/rust/op-alloy/crates/rpc-jsonrpsee/Cargo.toml
@@ -2,7 +2,7 @@
 name = "op-alloy-rpc-jsonrpsee"
 description = "Optimism RPC Client"
 
-version = "0.24.0"
+version = "2.0.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/rust/op-alloy/crates/rpc-types-engine/Cargo.toml
+++ b/rust/op-alloy/crates/rpc-types-engine/Cargo.toml
@@ -2,7 +2,7 @@
 name = "op-alloy-rpc-types-engine"
 description = "Optimism RPC types for the `engine` namespace"
 
-version = "0.24.0"
+version = "2.0.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/rust/op-alloy/crates/rpc-types/Cargo.toml
+++ b/rust/op-alloy/crates/rpc-types/Cargo.toml
@@ -2,7 +2,7 @@
 name = "op-alloy-rpc-types"
 description = "Optimism RPC types"
 
-version = "0.24.0"
+version = "2.0.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/rust/op-alloy/release.toml
+++ b/rust/op-alloy/release.toml
@@ -7,4 +7,4 @@ sign-tag = true
 shared-version = true
 pre-release-commit-message = "chore: release {{version}}"
 tag-prefix = "" # tag only once instead of per every crate
-pre-release-hook = ["sh", "-c", "$WORKSPACE_ROOT/scripts/changelog.sh --tag {{version}}"]
+pre-release-hook = ["sh", "-c", "$WORKSPACE_ROOT/op-alloy/scripts/changelog.sh --tag {{version}}"]

--- a/rust/op-revm/Cargo.toml
+++ b/rust/op-revm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "op-revm"
 description = "Optimism variant of Revm"
-version = "19.0.0"
+version = "20.0.0"
 authors.workspace = true
 edition.workspace = true
 keywords.workspace = true


### PR DESCRIPTION
## Summary

- Adds a `release` recipe to `rust/justfile` that publishes the crates under a given subdirectory (e.g. `rust/op-alloy`) together with their transitive workspace dependencies.
- Supports a `dry` (default) / `execute` mode so the computed package set can be inspected before anything is actually released.

## Usage

```bash
just release op-alloy 1.0.0          # dry run — prints the set of packages that would be released
just release op-alloy 1.0.0 execute  # actually release
```

## Test plan

- [ ] `just release op-alloy 1.0.0` prints the expected package set without touching anything
- [ ] `just release <subdir-with-no-crates> 1.0.0` fails fast with a clear error
- [ ] `just release op-alloy 1.0.0 bogus` fails fast with the mode-validation error