### PR TITLE
supernode: rewrite interop log backfill around backfillEndTimestamp

### DIFF
--- a/op-devstack/dsl/supernode.go
+++ b/op-devstack/dsl/supernode.go
@@ -170,7 +170,7 @@ func (s *Supernode) AwaitBackfillCompleted() {
 //     (the first seal is at most one block before activation; when activation
 //     is not aligned to a block boundary, the block representing the chain
 //     state as of activation is the correct pairing anchor and is sealed).
-//  2. firstSealed.Timestamp <  RuntimeActivationTimestamp
+//  2. firstSealed.Timestamp <  FirstVerifiableTimestamp
 //     (the main loop's handoff happens strictly after the backfilled range)
 //  3. firstSealed.Timestamp <= max(ActivationTimestamp, latestSealed.Timestamp - depth)
 //     + blockTime                         (backfill reached ~depth back,
@@ -184,7 +184,7 @@ func (s *Supernode) AssertBackfillCovers(depth time.Duration, blockTime uint64, 
 	ia := s.interopActivity()
 
 	activation := ia.ActivationTimestamp()
-	runtimeActivation := ia.RuntimeActivationTimestamp()
+	firstVerifiable := ia.FirstVerifiableTimestamp()
 	depthSec := uint64(depth / time.Second)
 
 	for _, chainID := range chains {
@@ -198,9 +198,9 @@ func (s *Supernode) AssertBackfillCovers(depth time.Duration, blockTime uint64, 
 			"chain %s: first seal ts %d must be within one block time (%d) of activation ts %d",
 			chainID, first.Timestamp, blockTime, activation)
 
-		s.require.Lessf(first.Timestamp, runtimeActivation,
-			"chain %s: first seal ts %d must be < runtime activation ts %d (backfill must hand off strictly before main loop)",
-			chainID, first.Timestamp, runtimeActivation)
+		s.require.Lessf(first.Timestamp, firstVerifiable,
+			"chain %s: first seal ts %d must be < first-verifiable ts %d (backfill must hand off strictly before main loop)",
+			chainID, first.Timestamp, firstVerifiable)
 
 		expectedLowerBound := activation
 		if latest.Timestamp > activation+depthSec {
@@ -218,7 +218,7 @@ func (s *Supernode) AssertBackfillCovers(depth time.Duration, blockTime uint64, 
 			"chain", chainID,
 			"first_num", first.Number, "first_ts", first.Timestamp,
 			"latest_num", latest.Number, "latest_ts", latest.Timestamp,
-			"activation", activation, "runtime_activation", runtimeActivation,
+			"activation", activation, "first_verifiable", firstVerifiable,
 			"depth_sec", depthSec)
 	}
 }

--- a/op-devstack/stack/supernode.go
+++ b/op-devstack/stack/supernode.go
@@ -15,7 +15,8 @@ type Supernode interface {
 // InteropActivity; see op-supernode/supernode/activity/interop for the
 // methods available on the returned pointer (PauseAt, Resume,
 // BackfillAttempts, BackfillCompleted, ActivationTimestamp,
-// RuntimeActivationTimestamp, FirstSealedBlock, LatestSealedBlock, ...).
+// BackfillEndTimestamp, FirstVerifiableTimestamp, FirstSealedBlock,
+// LatestSealedBlock, ...).
 type InteropTestControl interface {
 	// InteropActivity returns the current interop activity, or nil if the
 	// supernode is not running or interop is not configured. Callers must

--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -207,6 +207,9 @@ func (cfg *Config) TimestampForBlock(blockNumber uint64) uint64 {
 	return cfg.Genesis.L2Time + ((blockNumber - cfg.Genesis.L2.Number) * cfg.BlockTime)
 }
 
+// TargetBlockNumber returns the L2 block number for the given timestamp.
+// If the timestamp is before the genesis time, it returns an error.
+// All other cases should return a valid block number.
 func (cfg *Config) TargetBlockNumber(timestamp uint64) (num uint64, err error) {
 	// subtract genesis time from timestamp to get the time elapsed since genesis, and then divide that
 	// difference by the block time to get the expected L2 block number at the current time. If the

--- a/op-supernode/supernode/activity/interop/algo_test.go
+++ b/op-supernode/supernode/activity/interop/algo_test.go
@@ -838,6 +838,9 @@ type algoMockLogsDB struct {
 	containsErr  error
 }
 
+func (m *algoMockLogsDB) BlockNumberToTimestamp(ctx context.Context, blocknum uint64) (uint64, error) {
+	return 0, nil
+}
 func (m *algoMockLogsDB) LatestSealedBlock() (eth.BlockID, bool) { return eth.BlockID{}, false }
 func (m *algoMockLogsDB) FirstSealedBlock() (suptypes.BlockSeal, error) {
 	if m.firstSealedBlockErr != nil {
@@ -915,6 +918,9 @@ type algoMockChain struct {
 	blockHashes     map[uint64]common.Hash
 }
 
+func (m *algoMockChain) BlockNumberToTimestamp(ctx context.Context, blocknum uint64) (uint64, error) {
+	return 0, nil
+}
 func (m *algoMockChain) ID() eth.ChainID                                  { return m.id }
 func (m *algoMockChain) Start(ctx context.Context) error                  { return nil }
 func (m *algoMockChain) Stop(ctx context.Context) error                   { return nil }

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -87,13 +87,10 @@ type Interop struct {
 	chains              map[eth.ChainID]cc.ChainContainer
 	activationTimestamp uint64 // immutable protocol activation timestamp
 
-	// backfillEndTimestamp is the (inclusive) last timestamp whose logs
-	// were sealed by runLogBackfill. Zero means backfill has not yet run
-	// (or was skipped because logBackfillDepth <= 0). The main loop reads
-	// this via firstVerifiableTimestamp() so it starts verification at
-	// backfillEndTimestamp+1 — the first timestamp not already covered
-	// by pre-ingested logs. Protocol-facing queries (VerifiedAtTimestamp,
-	// VerifiedBlockAtL1, etc.) always use activationTimestamp.
+	// backfillEndTimestamp represents the end of the range of timestamps that were sealed by runLogBackfill.
+	// this is used for loop handoff from log backfill to main processing.
+	// firstVerifiableTimestamp is used to determine the start of the main processing loop, which is backfillEndTimestamp + 1,
+	// or activationTimestamp if backfill was not used.
 	backfillEndTimestamp uint64
 
 	dataDir string

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -87,12 +87,14 @@ type Interop struct {
 	chains              map[eth.ChainID]cc.ChainContainer
 	activationTimestamp uint64 // immutable protocol activation timestamp
 
-	// runtimeActivationTimestamp is the effective activation timestamp used
-	// by the main loop and backfill. It starts equal to activationTimestamp
-	// and is advanced past the backfilled range after log backfill completes.
-	// Protocol-facing queries (VerifiedAtTimestamp, VerifiedBlockAtL1, etc.)
-	// always use the original activationTimestamp.
-	runtimeActivationTimestamp uint64
+	// backfillEndTimestamp is the (inclusive) last timestamp whose logs
+	// were sealed by runLogBackfill. Zero means backfill has not yet run
+	// (or was skipped because logBackfillDepth <= 0). The main loop reads
+	// this via firstVerifiableTimestamp() so it starts verification at
+	// backfillEndTimestamp+1 — the first timestamp not already covered
+	// by pre-ingested logs. Protocol-facing queries (VerifiedAtTimestamp,
+	// VerifiedBlockAtL1, etc.) always use activationTimestamp.
+	backfillEndTimestamp uint64
 
 	dataDir string
 
@@ -137,6 +139,21 @@ func (i *Interop) Name() string {
 	return "interop"
 }
 
+// firstVerifiableTimestamp is the earliest timestamp the main loop will
+// attempt to verify. It is activationTimestamp when backfill did not run,
+// or backfillEndTimestamp+1 when it did (clamped so it never falls below
+// activation, though by construction backfillEndTimestamp >= activation).
+func (i *Interop) firstVerifiableTimestamp() uint64 {
+	if i.backfillEndTimestamp == 0 {
+		return i.activationTimestamp
+	}
+	next := i.backfillEndTimestamp + 1
+	if next < i.activationTimestamp {
+		return i.activationTimestamp
+	}
+	return next
+}
+
 // New constructs a new Interop activity.
 func New(
 	log log.Logger,
@@ -173,15 +190,14 @@ func New(
 		messageExpiryWindow = defaultMessageExpiryWindow
 	}
 	i := &Interop{
-		log:                        log,
-		chains:                     chains,
-		verifiedDB:                 verifiedDB,
-		logsDBs:                    logsDBs,
-		dataDir:                    dataDir,
-		activationTimestamp:        activationTimestamp,
-		runtimeActivationTimestamp: activationTimestamp,
-		messageExpiryWindow:        messageExpiryWindow,
-		logBackfillDepth:           logBackfillDepth,
+		log:                 log,
+		chains:              chains,
+		verifiedDB:          verifiedDB,
+		logsDBs:             logsDBs,
+		dataDir:             dataDir,
+		activationTimestamp: activationTimestamp,
+		messageExpiryWindow: messageExpiryWindow,
+		logBackfillDepth:    logBackfillDepth,
 	}
 	// default to using the verifyInteropMessages function
 	// (can be overridden by tests)
@@ -207,8 +223,9 @@ func (i *Interop) Start(ctx context.Context) error {
 		i.log.Info("interop log backfill depth configured", "duration", i.logBackfillDepth.String())
 		for {
 			i.backfillAttempts.Add(1)
-			err := i.runLogBackfill()
+			end, err := i.runLogBackfill()
 			if err == nil {
+				i.backfillEndTimestamp = end
 				break
 			}
 			i.log.Warn("log backfill failed, retrying (virtual nodes may not be ready yet)", "err", err)
@@ -220,6 +237,7 @@ func (i *Interop) Start(ctx context.Context) error {
 		}
 	}
 	i.backfillCompleted.Store(true)
+	i.log.Info("log backfill complete", "backfillEndTimestamp", i.backfillEndTimestamp)
 
 	for {
 		select {
@@ -379,7 +397,7 @@ func (i *Interop) observeRound() (RoundObservation, error) {
 		obs.LastVerified = &result
 		obs.NextTimestamp = lastTS + 1
 	} else {
-		obs.NextTimestamp = i.runtimeActivationTimestamp
+		obs.NextTimestamp = i.firstVerifiableTimestamp()
 	}
 
 	if pauseTS := i.pauseAtTimestamp.Load(); pauseTS != 0 && obs.NextTimestamp >= pauseTS {
@@ -615,7 +633,7 @@ func (i *Interop) buildRewindPlan(lastTS uint64) (RewindPlan, error) {
 		RewindAtOrAfter: lastTS,
 	}
 
-	if lastTS <= i.runtimeActivationTimestamp {
+	if lastTS <= i.firstVerifiableTimestamp() {
 		return plan, nil
 	}
 

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -1400,6 +1400,11 @@ type mockChainContainer struct {
 	// together with timestampToBlockNumberOverride to simulate a chain with
 	// a blockTime > 1 and genesis-offset scheduling.
 	blockInfoTimeFn func(blockNum uint64) uint64
+
+	// blockNumberToTimestampOverride lets tests report a non-trivial genesis
+	// time (and per-block timestamps) through BlockNumberToTimestamp. Used
+	// by tests that exercise the genesis-clamp path in runLogBackfill.
+	blockNumberToTimestampOverride func(ctx context.Context, blocknum uint64) (uint64, error)
 }
 
 type invalidateBlockCall struct {
@@ -1425,6 +1430,13 @@ func (m *mockChainContainer) Resume(ctx context.Context) error {
 		m.callLog.record(m.id, "Resume")
 	}
 	return m.resumeErr
+}
+
+func (m *mockChainContainer) BlockNumberToTimestamp(ctx context.Context, blocknum uint64) (uint64, error) {
+	if m.blockNumberToTimestampOverride != nil {
+		return m.blockNumberToTimestampOverride(ctx, blocknum)
+	}
+	return 0, nil
 }
 func (m *mockChainContainer) PauseAndStopVN(ctx context.Context) error {
 	m.mu.Lock()

--- a/op-supernode/supernode/activity/interop/interop_test_access.go
+++ b/op-supernode/supernode/activity/interop/interop_test_access.go
@@ -62,11 +62,19 @@ func (i *Interop) ActivationTimestamp() uint64 {
 	return i.activationTimestamp
 }
 
-// RuntimeActivationTimestamp returns the mutable activation timestamp used
-// by the main loop and backfill. It starts equal to ActivationTimestamp and
-// may be advanced past the backfilled range once backfill finishes.
-func (i *Interop) RuntimeActivationTimestamp() uint64 {
-	return i.runtimeActivationTimestamp
+// BackfillEndTimestamp returns the inclusive last timestamp whose logs were
+// sealed by runLogBackfill, or 0 if backfill has not run. The main loop
+// starts verification at BackfillEndTimestamp()+1 (or ActivationTimestamp()
+// when backfill was skipped).
+func (i *Interop) BackfillEndTimestamp() uint64 {
+	return i.backfillEndTimestamp
+}
+
+// FirstVerifiableTimestamp returns the timestamp at which the main loop
+// begins verification: ActivationTimestamp() when backfill did not run,
+// or BackfillEndTimestamp()+1 when it did.
+func (i *Interop) FirstVerifiableTimestamp() uint64 {
+	return i.firstVerifiableTimestamp()
 }
 
 // ---------------------------------------------------------------------------

--- a/op-supernode/supernode/activity/interop/log_backfill.go
+++ b/op-supernode/supernode/activity/interop/log_backfill.go
@@ -2,145 +2,83 @@ package interop
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"time"
+	"math"
+	"sync"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	cc "github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container"
 )
 
-// ErrChainBehindBackfillLowerBound is returned when a chain's LocalSafeL2
-// block number is earlier than the block that TimestampToBlockNumber maps
-// T_lo to. Under a consistent SyncStatus we should always have
-// LocalSafeL2.Time >= minCrossSafeTime >= T_lo, so this indicates the
-// chain container is reporting inconsistent state (e.g. mid-rewind, a
-// fresh VN whose LocalSafe hasn't caught up to cross-safe, or a bad
-// TimestampToBlockNumber implementation). Silently skipping such a
-// chain would cause the main loop to wedge on ErrStaleLogsDB once it
-// hands off below the first sealed block of chains that did backfill,
-// so we fail the whole attempt instead. Operator remediation is to
-// clear the logs DBs and restart.
-var ErrChainBehindBackfillLowerBound = errors.New("chain localSafe is behind backfill lower bound; clear data dir")
-
-// LogBackfillLowerBound returns T_lo = max(T_act, crossSafeTs - D_log) in unix seconds (L2).
-// crossSafeTs is the minimum cross-safe timestamp across all chains — the
-// earliest point where cross-validation will resume after startup.
-// Never ingest logs for timestamps before activation.
-func LogBackfillLowerBound(crossSafeTs, activationTimestampUnix uint64, logBackfillDepth time.Duration) uint64 {
-	if logBackfillDepth <= 0 {
-		return crossSafeTs
-	}
-	sub := uint64(logBackfillDepth / time.Second)
-	var raw uint64
-	if crossSafeTs >= sub {
-		raw = crossSafeTs - sub
-	} else {
-		raw = 0
-	}
-	if raw < activationTimestampUnix {
-		return activationTimestampUnix
-	}
-	return raw
-}
-
-// runLogBackfill seals logs for each chain from T_lo through LocalSafe and
-// advances activationTimestamp past the backfilled range so the main loop
-// starts verification after the pre-ingested data.
-//
-// T_lo is computed from the minimum cross-safe (SafeL2) timestamp across all
-// chains, since that is the earliest point where cross-validation will resume.
-func (i *Interop) runLogBackfill() error {
+func (i *Interop) runLogBackfill() (uint64, error) {
 	if i.logBackfillDepth <= 0 {
-		return nil
+		return 0, nil
 	}
 	if len(i.chains) == 0 {
-		return nil
+		return 0, nil
 	}
 
-	ctx := i.ctx
-
-	// First pass: gather the minimum cross-safe timestamp across all chains.
-	// SafeL2 is the cross-safe head post-interop.
-	type chainInfo struct {
-		crossSafeTime uint64
-		localSafeNum  uint64
-		localSafeTime uint64
-	}
-	info := make(map[eth.ChainID]chainInfo, len(i.chains))
-	var minCrossSafeTime uint64
-	first := true
-	for cid, chain := range i.chains {
-		ss, err := chain.SyncStatus(ctx)
+	// identify the minimum cross-safe time across all chains
+	minCrossSafeTime := uint64(math.MaxUint64)
+	for _, chain := range i.chains {
+		syncStatus, err := chain.SyncStatus(i.ctx)
 		if err != nil {
-			return fmt.Errorf("chain %s: sync status: %w", cid, err)
+			return 0, fmt.Errorf("chain %s: sync status: %w", chain.ID(), err)
 		}
-		ci := chainInfo{
-			crossSafeTime: ss.SafeL2.Time,
-			localSafeNum:  ss.LocalSafeL2.Number,
-			localSafeTime: ss.LocalSafeL2.Time,
-		}
-		info[cid] = ci
-		if first || ci.crossSafeTime < minCrossSafeTime {
-			minCrossSafeTime = ci.crossSafeTime
-			first = false
-		}
+		i.log.Debug("log backfill: sync status",
+			"chain", chain.ID(), "safe", syncStatus.SafeL2, "localSafe", syncStatus.LocalSafeL2)
+		minCrossSafeTime = min(minCrossSafeTime, syncStatus.SafeL2.Time)
 	}
 
-	Tlo := LogBackfillLowerBound(minCrossSafeTime, i.runtimeActivationTimestamp, i.logBackfillDepth)
-	// Debug-level because this fires on every retry while VNs are coming up.
-	// The summary "interop log backfill complete" line at the end is the
-	// user-visible signal that backfill finished.
-	i.log.Debug("log backfill: computed lower bound",
-		"minCrossSafeTime", minCrossSafeTime, "T_lo", Tlo, "depth", i.logBackfillDepth)
-
-	// Second pass: backfill each chain from T_lo to its LocalSafe. Fold
-	// localSafeTime into minLocalSafeTime only after the consistency check
-	// passes, so runtimeActivation is clamped to the earliest backfilled
-	// head — any chain that can't satisfy the round aborts before
-	// contributing, which keeps minLocalSafeTime reflective of the set of
-	// chains whose logs DB is populated up to T_lo.
-	var minLocalSafeTime uint64
-	firstLocal := true
-	for cid, chain := range i.chains {
-		ci := info[cid]
-
-		startNum, err := chain.TimestampToBlockNumber(ctx, Tlo)
-		if err != nil {
-			return fmt.Errorf("chain %s: timestamp to block number for T_lo %d: %w", cid, Tlo, err)
-		}
-		// Under a consistent SyncStatus this is unreachable: T_lo is clamped
-		// to min(crossSafe) across chains, and localSafe >= crossSafe on every
-		// chain, so localSafeNum >= TimestampToBlockNumber(T_lo). If it fires,
-		// the chain container is reporting inconsistent state and continuing
-		// would leave this chain's logs DB empty while other chains seal from
-		// T_lo forward, which wedges the main loop's first seal attempt on
-		// ErrStaleLogsDB.
-		if startNum > ci.localSafeNum {
-			return fmt.Errorf("chain %s: startNum %d > localSafeNum %d at T_lo %d (localSafeTime %d, minCrossSafeTime %d): %w",
-				cid, startNum, ci.localSafeNum, Tlo, ci.localSafeTime, minCrossSafeTime, ErrChainBehindBackfillLowerBound)
-		}
-
-		if firstLocal || ci.localSafeTime < minLocalSafeTime {
-			minLocalSafeTime = ci.localSafeTime
-			firstLocal = false
-		}
-
-		i.log.Info("log backfill: sealing logs",
-			"chain", cid, "from", startNum, "to", ci.localSafeNum)
-
-		if err := i.backfillChain(ctx, cid, chain, startNum, ci.localSafeNum); err != nil {
-			return err
-		}
+	// naively, end minus depth is the ideal backfill start.
+	// guard the subtraction so a young chain (crossSafe < depth) doesn't wrap.
+	depthSec := uint64(i.logBackfillDepth.Seconds())
+	var idealStart uint64
+	if minCrossSafeTime >= depthSec {
+		idealStart = minCrossSafeTime - depthSec
 	}
+	// clamp to the activation timestamp: never backfill before activation.
+	startTime := max(idealStart, i.activationTimestamp)
 
-	if !firstLocal && minLocalSafeTime+1 > i.runtimeActivationTimestamp {
-		i.log.Info("advancing runtime activation past backfilled range",
-			"oldActivation", i.runtimeActivationTimestamp, "newActivation", minLocalSafeTime+1)
-		i.runtimeActivationTimestamp = minLocalSafeTime + 1
+	// backfill every chain in parallel over [startTime, endTime]
+	errCh := make(chan error, len(i.chains))
+	wg := sync.WaitGroup{}
+	wg.Add(len(i.chains))
+	for _, chain := range i.chains {
+		go func(chain cc.ChainContainer) {
+			defer wg.Done()
+			// if activation falls after the backfill range end, don't backfill
+			if i.activationTimestamp > minCrossSafeTime {
+				i.log.Info("log backfill: activation timestamp falls after backfill range end, skipping backfill",
+					"activationTimestamp", i.activationTimestamp, "minCrossSafeTime", minCrossSafeTime)
+				return
+			}
+			startNum, err := chain.TimestampToBlockNumber(i.ctx, startTime)
+			if err != nil {
+				errCh <- fmt.Errorf("chain %s: timestamp to block number for start %d: %w", chain.ID(), startTime, err)
+				i.log.Error("log backfill: timestamp to block number for start", "chain", chain.ID(), "err", err)
+				return
+			}
+			endNum, err := chain.TimestampToBlockNumber(i.ctx, minCrossSafeTime)
+			if err != nil {
+				errCh <- fmt.Errorf("chain %s: timestamp to block number for end %d: %w", chain.ID(), minCrossSafeTime, err)
+				i.log.Error("log backfill: timestamp to block number for end", "chain", chain.ID(), "err", err)
+				return
+			}
+			i.log.Info("log backfill: sealing logs",
+				"chain", chain.ID(), "from", startNum, "to", endNum)
+			if err := i.backfillChain(i.ctx, chain.ID(), chain, startNum, endNum); err != nil {
+				errCh <- fmt.Errorf("chain %s: backfill: %w", chain.ID(), err)
+				return
+			}
+		}(chain)
 	}
-	i.log.Info("interop log backfill complete", "runtimeActivationTimestamp", i.runtimeActivationTimestamp)
-	return nil
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		return 0, err
+	}
+	return minCrossSafeTime, nil
 }
 
 func (i *Interop) backfillChain(ctx context.Context, cid eth.ChainID, chain cc.ChainContainer, startNum, endNum uint64) error {

--- a/op-supernode/supernode/activity/interop/log_backfill.go
+++ b/op-supernode/supernode/activity/interop/log_backfill.go
@@ -25,9 +25,19 @@ func (i *Interop) runLogBackfill() (uint64, error) {
 		if err != nil {
 			return 0, fmt.Errorf("chain %s: sync status: %w", chain.ID(), err)
 		}
+		if syncStatus.SafeL2.Number == 0 {
+			return 0, fmt.Errorf("chain %s: safe L2 number is 0", chain.ID())
+		}
 		i.log.Debug("log backfill: sync status",
 			"chain", chain.ID(), "safe", syncStatus.SafeL2, "localSafe", syncStatus.LocalSafeL2)
 		minCrossSafeTime = min(minCrossSafeTime, syncStatus.SafeL2.Time)
+	}
+
+	// if activation falls after the backfill range end, don't backfill
+	if i.activationTimestamp > minCrossSafeTime {
+		i.log.Info("log backfill: activation timestamp falls after backfill range end, skipping backfill",
+			"activationTimestamp", i.activationTimestamp, "minCrossSafeTime", minCrossSafeTime)
+		return 0, nil
 	}
 
 	// naively, end minus depth is the ideal backfill start.
@@ -47,13 +57,14 @@ func (i *Interop) runLogBackfill() (uint64, error) {
 	for _, chain := range i.chains {
 		go func(chain cc.ChainContainer) {
 			defer wg.Done()
-			// if activation falls after the backfill range end, don't backfill
-			if i.activationTimestamp > minCrossSafeTime {
-				i.log.Info("log backfill: activation timestamp falls after backfill range end, skipping backfill",
-					"activationTimestamp", i.activationTimestamp, "minCrossSafeTime", minCrossSafeTime)
-				return
+			chainStartTime := startTime
+			// if we can identify the genesis time, use it to clamp the start time
+			// if we can't, we'd either fail now or later when trying to use the value
+			if genesisTime, err := chain.BlockNumberToTimestamp(i.ctx, 0); err == nil &&
+				genesisTime > startTime {
+				chainStartTime = genesisTime
 			}
-			startNum, err := chain.TimestampToBlockNumber(i.ctx, startTime)
+			startNum, err := chain.TimestampToBlockNumber(i.ctx, chainStartTime)
 			if err != nil {
 				errCh <- fmt.Errorf("chain %s: timestamp to block number for start %d: %w", chain.ID(), startTime, err)
 				i.log.Error("log backfill: timestamp to block number for start", "chain", chain.ID(), "err", err)

--- a/op-supernode/supernode/activity/interop/log_backfill.go
+++ b/op-supernode/supernode/activity/interop/log_backfill.go
@@ -25,8 +25,10 @@ func (i *Interop) runLogBackfill() (uint64, error) {
 		if err != nil {
 			return 0, fmt.Errorf("chain %s: sync status: %w", chain.ID(), err)
 		}
-		if syncStatus.SafeL2.Number == 0 {
-			return 0, fmt.Errorf("chain %s: safe L2 number is 0", chain.ID())
+		// watch that local safe advances to become non-zero
+		// local safe should advance even if cross safe has nothing to work from
+		if syncStatus.LocalSafeL2.Number == 0 {
+			return 0, fmt.Errorf("chain %s: local safe L2 number is 0", chain.ID())
 		}
 		i.log.Debug("log backfill: sync status",
 			"chain", chain.ID(), "safe", syncStatus.SafeL2, "localSafe", syncStatus.LocalSafeL2)

--- a/op-supernode/supernode/activity/interop/log_backfill_test.go
+++ b/op-supernode/supernode/activity/interop/log_backfill_test.go
@@ -498,13 +498,13 @@ func TestLogBackfill_NoOpWhenNoChains(t *testing.T) {
 }
 
 // TestLogBackfill_ActivationInFuture asserts the edge case where the
-// configured activation is ahead of every chain's cross-safe tip. The
-// window start clamps to activationTimestamp, producing startTime >
-// minCrossSafeTime (i.e. startNum > endNum). runLogBackfill must still
-// return minCrossSafeTime without error; the per-chain backfill loop is
-// a no-op because startNum > endNum. Operationally this means the main
-// loop will wait for the chain to advance past activation before doing
-// any verification work — no blocks get sealed eagerly.
+// configured activation is ahead of every chain's cross-safe tip.
+// runLogBackfill must short-circuit with (0, nil) — the "backfill did
+// not run" convention — rather than claiming minCrossSafeTime was
+// sealed when nothing was. This keeps backfillEndTimestamp honest for
+// external observers (devstack/integration assertions) and routes the
+// main loop through the activationTimestamp path of
+// firstVerifiableTimestamp().
 func TestLogBackfill_ActivationInFuture(t *testing.T) {
 	const act = uint64(2000)
 	depth := 100 * time.Second
@@ -536,15 +536,85 @@ func TestLogBackfill_ActivationInFuture(t *testing.T) {
 
 	end, err := h.interop.runLogBackfill()
 	require.NoError(t, err)
-	require.Equal(t, uint64(1000), end,
-		"return value is still minCrossSafeTime even when activation is in the future")
+	require.Zero(t, end,
+		"activation-in-future must short-circuit with end=0 (backfill did not run)")
 	require.Zero(t, outputCalls.Load(),
-		"no blocks fetched: startNum > endNum when activation is ahead of cross-safe")
+		"no blocks fetched: backfill is skipped when activation is ahead of cross-safe")
 
 	chain10 := h.Mock(10)
 	_, has := h.interop.logsDBs[chain10.id].LatestSealedBlock()
-	require.False(t, has, "logs DB must remain empty when the window is inverted")
+	require.False(t, has, "logs DB must remain empty when backfill is skipped")
 
 	require.Equal(t, act, h.interop.activationTimestamp,
 		"protocol activation must not change")
+
+	// With end==0 the main loop falls through to activationTimestamp,
+	// which is the correct handoff when activation is still in the future.
+	h.interop.backfillEndTimestamp = end
+	require.Equal(t, act, h.interop.firstVerifiableTimestamp(),
+		"main loop resumes at activationTimestamp when backfill is skipped")
+}
+
+// TestLogBackfill_ClampsStartToGenesis asserts that when a chain's genesis
+// timestamp is later than the computed backfill startTime, the per-chain
+// start is clamped up to genesis. Without this clamp, runLogBackfill would
+// ask TimestampToBlockNumber for a pre-genesis timestamp and then try to
+// seal blocks before the chain existed.
+//
+// Setup: activation=50, depth=50s, crossSafe=110 → idealStart=60,
+// startTime=max(60, 50)=60. Chain's genesis time is 100, which is > 60,
+// so the clamp fires and the chain should backfill [100..110] (11 blocks)
+// instead of [60..110] (51 blocks).
+func TestLogBackfill_ClampsStartToGenesis(t *testing.T) {
+	const (
+		act          uint64 = 50
+		genesisTime  uint64 = 100
+		crossSafeTip uint64 = 110
+	)
+	depth := 50 * time.Second // idealStart = 110-50 = 60; clamps up to genesisTime=100
+
+	var outputCalls atomic.Int32
+
+	h := newInteropTestHarness(t).
+		WithActivation(act).
+		WithLogBackfillDepth(depth).
+		WithChain(10, func(m *mockChainContainer) {
+			m.syncStatusFull = &eth.SyncStatus{
+				CurrentL1:   eth.L1BlockRef{Number: 1, Hash: common.HexToHash("0xL1")},
+				UnsafeL2:    eth.L2BlockRef{Number: crossSafeTip, Time: crossSafeTip},
+				SafeL2:      eth.L2BlockRef{Number: crossSafeTip, Time: crossSafeTip},
+				LocalSafeL2: eth.L2BlockRef{Number: crossSafeTip, Time: crossSafeTip},
+			}
+			// Report genesis time strictly ahead of the pre-clamp startTime.
+			m.blockNumberToTimestampOverride = func(ctx context.Context, blocknum uint64) (uint64, error) {
+				if blocknum == 0 {
+					return genesisTime, nil
+				}
+				return blocknum, nil
+			}
+			m.outputV0Override = func(ctx context.Context, num uint64) (*eth.OutputV0, error) {
+				outputCalls.Add(1)
+				return &eth.OutputV0{
+					StateRoot:                eth.Bytes32(common.HexToHash("0xmockstate")),
+					MessagePasserStorageRoot: eth.Bytes32(common.HexToHash("0xmockmsg")),
+					BlockHash:                common.BigToHash(new(big.Int).SetUint64(num)),
+				}, nil
+			}
+		}).
+		Build()
+	h.interop.ctx = context.Background()
+
+	end, err := h.interop.runLogBackfill()
+	require.NoError(t, err)
+	require.Equal(t, crossSafeTip, end,
+		"return value is still minCrossSafeTime regardless of the genesis clamp")
+
+	chain10 := h.Mock(10)
+	latest, has := h.interop.logsDBs[chain10.id].LatestSealedBlock()
+	require.True(t, has)
+	require.Equal(t, crossSafeTip, latest.Number)
+
+	// 11 = blocks 100..110 (clamped at genesis=100), NOT 51 = blocks 60..110.
+	require.Equal(t, int32(11), outputCalls.Load(),
+		"backfill must start at genesis (%d), not the pre-clamp startTime (60)", genesisTime)
 }

--- a/op-supernode/supernode/activity/interop/log_backfill_test.go
+++ b/op-supernode/supernode/activity/interop/log_backfill_test.go
@@ -13,26 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestLogBackfillLowerBound(t *testing.T) {
-	tests := []struct {
-		name           string
-		crossSafe, act uint64
-		depth          time.Duration
-		wantTlo        uint64
-	}{
-		{"zero depth returns crossSafe", 1000, 100, 0, 1000},
-		{"clamp when raw before activation", 200, 100, 500 * time.Second, 100},
-		{"raw above activation", 1000, 100, 100 * time.Second, 900},
-		{"crossSafe below depth underflow then clamp", 50, 40, 100 * time.Second, 40},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := LogBackfillLowerBound(tt.crossSafe, tt.act, tt.depth)
-			require.Equal(t, tt.wantTlo, got)
-		})
-	}
-}
-
 // progressInteropUntil calls progressAndRecord up to maxIters times until cond() is true.
 func progressInteropUntil(t *testing.T, i *Interop, maxIters int, cond func() bool) {
 	t.Helper()
@@ -92,8 +72,13 @@ func TestLogBackfill_ResumesAfterInterruption(t *testing.T) {
 		}, nil
 	}
 
-	require.NoError(t, h.interop.runLogBackfill())
-	require.Equal(t, uint64(111), h.interop.runtimeActivationTimestamp)
+	end, err := h.interop.runLogBackfill()
+	require.NoError(t, err)
+	h.interop.backfillEndTimestamp = end
+	require.Equal(t, uint64(110), end,
+		"runLogBackfill must return minCrossSafeTime as the end of the sealed range")
+	require.Equal(t, uint64(111), h.interop.firstVerifiableTimestamp(),
+		"main loop resumes at backfillEndTimestamp+1")
 	require.Equal(t, act, h.interop.activationTimestamp, "protocol activation must not change")
 
 	latest, has = h.interop.logsDBs[chain10.id].LatestSealedBlock()
@@ -150,14 +135,16 @@ func TestLogBackfill_RetriesWhenVirtualNodesNotReady(t *testing.T) {
 	done := make(chan error, 1)
 	go func() { done <- h.interop.Start(ctx) }()
 
-	// Wait for backfill to complete: runtime activation should advance past 110.
+	// Wait for backfill to complete: backfillEndTimestamp should be set
+	// to the end of the sealed range (110).
 	require.Eventually(t, func() bool {
-		return h.interop.runtimeActivationTimestamp > act
+		return h.interop.backfillEndTimestamp > 0
 	}, 5*time.Second, 20*time.Millisecond, "backfill should eventually succeed after retries")
 
 	require.GreaterOrEqual(t, syncStatusCalls.Load(), failUntil,
 		"SyncStatus should have been called at least %d times (the failing ones)", failUntil)
-	require.Equal(t, uint64(111), h.interop.runtimeActivationTimestamp)
+	require.Equal(t, uint64(110), h.interop.backfillEndTimestamp)
+	require.Equal(t, uint64(111), h.interop.firstVerifiableTimestamp())
 	require.Equal(t, act, h.interop.activationTimestamp, "protocol activation must not change")
 
 	cancel()
@@ -198,25 +185,27 @@ func TestLogBackfill_RetriesStopOnContextCancel(t *testing.T) {
 	}
 }
 
-// TestLogBackfill_AsymmetricMultiChain exercises the two cross-chain minima
-// that runLogBackfill computes with three chains at different sync tips:
+// TestLogBackfill_AsymmetricMultiChain asserts that every chain is backfilled
+// over the same [T_lo, minCrossSafeTime] window regardless of how far
+// individual chains' LocalSafe heads have advanced. This keeps the system
+// symmetric at startup — every chain has logs sealed up to the same
+// timestamp, matching the invariant the main loop observes during normal
+// operation. Chains whose local-safe head is beyond minCrossSafeTime catch
+// up through the main loop, not eagerly during backfill.
 //
 //   - T_lo is derived from min(SafeL2.Time) across chains (cross-safe).
-//   - runtimeActivationTimestamp is derived from min(LocalSafeL2.Time) across
-//     chains and must advance to that minimum + 1.
-//
-// All chains participate in backfill, and each chain's LocalSafe is at or
-// beyond T_lo in both time and block number — the consistent case that
-// runLogBackfill is required to support.
+//   - End of backfill for every chain is TimestampToBlockNumber(minCrossSafeTime).
+//   - backfillEndTimestamp is set to minCrossSafeTime; the main loop
+//     resumes at backfillEndTimestamp+1.
 func TestLogBackfill_AsymmetricMultiChain(t *testing.T) {
 	const act = uint64(50)
 	depth := 10 * time.Second // min crossSafe 100 -> T_lo 90
 
-	// Chain 10: crossSafe/localSafe tip at 120. Backfill range 90..120.
-	// Chain 20: crossSafe 200, localSafe tip at 130. Backfill range 90..130.
-	// Chain 30: crossSafe 100 (the min, so it pins T_lo), localSafe tip at
-	// 110 (smallest localSafe, so it pins runtimeActivation). Backfill
-	// range 90..110.
+	// Chain 10: crossSafe/localSafe tip at 120.
+	// Chain 20: crossSafe 200, localSafe tip at 130.
+	// Chain 30: crossSafe 100 (the min, pinning T_lo), localSafe tip at 110.
+	// Every chain backfills 90..100 (the shared shape), so each seals 11
+	// blocks regardless of how far its local tip is.
 	h := newInteropTestHarness(t).
 		WithActivation(act).
 		WithLogBackfillDepth(depth).
@@ -262,81 +251,38 @@ func TestLogBackfill_AsymmetricMultiChain(t *testing.T) {
 		}
 	}
 
-	require.NoError(t, h.interop.runLogBackfill())
+	end, err := h.interop.runLogBackfill()
+	require.NoError(t, err)
+	h.interop.backfillEndTimestamp = end
 	require.Equal(t, act, h.interop.activationTimestamp, "protocol activation must not change")
-	require.Equal(t, uint64(111), h.interop.runtimeActivationTimestamp,
-		"runtime activation must advance to min(localSafe)+1 across all chains")
+	require.Equal(t, uint64(100), end,
+		"runLogBackfill must return minCrossSafeTime as the end of the sealed range")
+	require.Equal(t, uint64(101), h.interop.firstVerifiableTimestamp(),
+		"main loop resumes at backfillEndTimestamp+1")
 
 	chain10 := h.Mock(10)
 	chain20 := h.Mock(20)
 	chain30 := h.Mock(30)
 
-	require.Equal(t, int32(31), fetchCount[chain10.id].Load(),
-		"chain 10 should backfill blocks 90..120 (31 blocks)")
-	require.Equal(t, int32(41), fetchCount[chain20.id].Load(),
-		"chain 20 should backfill blocks 90..130 (41 blocks)")
-	require.Equal(t, int32(21), fetchCount[chain30.id].Load(),
-		"chain 30 should backfill blocks 90..110 (21 blocks)")
+	// Every chain backfills the same 90..100 window (11 blocks each).
+	require.Equal(t, int32(11), fetchCount[chain10.id].Load(),
+		"chain 10 should backfill blocks 90..100 (11 blocks)")
+	require.Equal(t, int32(11), fetchCount[chain20.id].Load(),
+		"chain 20 should backfill blocks 90..100 (11 blocks)")
+	require.Equal(t, int32(11), fetchCount[chain30.id].Load(),
+		"chain 30 should backfill blocks 90..100 (11 blocks)")
 
 	latest10, has10 := h.interop.logsDBs[chain10.id].LatestSealedBlock()
 	require.True(t, has10)
-	require.Equal(t, uint64(120), latest10.Number)
+	require.Equal(t, uint64(100), latest10.Number)
 
 	latest20, has20 := h.interop.logsDBs[chain20.id].LatestSealedBlock()
 	require.True(t, has20)
-	require.Equal(t, uint64(130), latest20.Number)
+	require.Equal(t, uint64(100), latest20.Number)
 
 	latest30, has30 := h.interop.logsDBs[chain30.id].LatestSealedBlock()
 	require.True(t, has30)
-	require.Equal(t, uint64(110), latest30.Number)
-}
-
-// TestLogBackfill_FailsWhenChainBehindLowerBound asserts that runLogBackfill
-// refuses to proceed if TimestampToBlockNumber(T_lo) for any chain lands past
-// that chain's LocalSafeL2 block number. This condition is unreachable under
-// a consistent SyncStatus (localSafe >= crossSafe >= minCrossSafeTime >= T_lo),
-// so if it fires, the chain container is reporting inconsistent state.
-// Silently skipping such a chain would leave its logs DB empty while other
-// chains seal from T_lo forward, wedging the main loop's first seal attempt
-// on ErrStaleLogsDB. Failing the attempt surfaces the problem to the
-// operator; remediation is to clear the data dir and restart.
-func TestLogBackfill_FailsWhenChainBehindLowerBound(t *testing.T) {
-	const act = uint64(50)
-	depth := 10 * time.Second // min crossSafe 100 -> T_lo 90
-
-	h := newInteropTestHarness(t).
-		WithActivation(act).
-		WithLogBackfillDepth(depth).
-		WithChain(10, func(m *mockChainContainer) {
-			m.syncStatusFull = &eth.SyncStatus{
-				CurrentL1:   eth.L1BlockRef{Number: 1, Hash: common.HexToHash("0xL1")},
-				UnsafeL2:    eth.L2BlockRef{Number: 120, Time: 120},
-				SafeL2:      eth.L2BlockRef{Number: 100, Time: 100},
-				LocalSafeL2: eth.L2BlockRef{Number: 120, Time: 120},
-			}
-		}).
-		// Chain 20 reports a consistent-looking SyncStatus but a bogus
-		// TimestampToBlockNumber that maps T_lo to a block well past
-		// LocalSafeL2. This is the inconsistency the guard catches.
-		WithChain(20, func(m *mockChainContainer) {
-			m.syncStatusFull = &eth.SyncStatus{
-				CurrentL1:   eth.L1BlockRef{Number: 1, Hash: common.HexToHash("0xL1")},
-				UnsafeL2:    eth.L2BlockRef{Number: 95, Time: 95},
-				SafeL2:      eth.L2BlockRef{Number: 500, Time: 500},
-				LocalSafeL2: eth.L2BlockRef{Number: 95, Time: 95},
-			}
-			m.timestampToBlockNumberOverride = func(ctx context.Context, ts uint64) (uint64, error) {
-				return 200, nil
-			}
-		}).
-		Build()
-	h.interop.ctx = context.Background()
-
-	err := h.interop.runLogBackfill()
-	require.Error(t, err)
-	require.ErrorIs(t, err, ErrChainBehindBackfillLowerBound)
-	require.Equal(t, act, h.interop.runtimeActivationTimestamp,
-		"runtime activation must not advance when backfill fails")
+	require.Equal(t, uint64(100), latest30.Number)
 }
 
 // TestLogBackfill_MisalignedActivation asserts that backfill succeeds when
@@ -352,7 +298,8 @@ func TestLogBackfill_FailsWhenChainBehindLowerBound(t *testing.T) {
 // Concrete setup: blockTime=3, genesis=0, activation=1000. Block 333 has
 // Time()=999 (the pairing anchor); block 334 is at 1002; LocalSafe is at
 // block 340, Time=1020. T_lo clamps to activation so backfill must seal
-// blocks 333..340 without error. runtimeActivation advances to 1021.
+// blocks 333..340 without error. backfillEndTimestamp is set to 1020
+// (minCrossSafeTime), so the main loop resumes at 1021.
 func TestLogBackfill_MisalignedActivation(t *testing.T) {
 	const (
 		blockTime    uint64 = 3
@@ -384,9 +331,13 @@ func TestLogBackfill_MisalignedActivation(t *testing.T) {
 		Build()
 	h.interop.ctx = context.Background()
 
-	require.NoError(t, h.interop.runLogBackfill())
+	end, err := h.interop.runLogBackfill()
+	require.NoError(t, err)
+	h.interop.backfillEndTimestamp = end
 	require.Equal(t, act, h.interop.activationTimestamp, "protocol activation must not change")
-	require.Equal(t, localSafeTs+1, h.interop.runtimeActivationTimestamp)
+	require.Equal(t, localSafeTs, end,
+		"runLogBackfill must return minCrossSafeTime as the end of the sealed range")
+	require.Equal(t, localSafeTs+1, h.interop.firstVerifiableTimestamp())
 
 	chain10 := h.Mock(10)
 	db := h.interop.logsDBs[chain10.id]
@@ -413,7 +364,7 @@ func TestLogBackfill_MisalignedActivation(t *testing.T) {
 
 func TestLogBackfill_AdvancesActivationAndStartsVerifyAfterCeiling(t *testing.T) {
 	const act = uint64(108)
-	depth := time.Second // crossSafe 110, depth 1s -> T_lo 109; seals 109..110; activation advances to 111
+	depth := time.Second // crossSafe 110, depth 1s -> T_lo 109; seals 109..110; first verifiable ts = 111
 
 	h := newInteropTestHarness(t).
 		WithActivation(act).
@@ -443,8 +394,13 @@ func TestLogBackfill_AdvancesActivationAndStartsVerifyAfterCeiling(t *testing.T)
 	}
 	h.interop.ctx = context.Background()
 
-	require.NoError(t, h.interop.runLogBackfill())
-	require.Equal(t, uint64(111), h.interop.runtimeActivationTimestamp)
+	end, err := h.interop.runLogBackfill()
+	require.NoError(t, err)
+	h.interop.backfillEndTimestamp = end
+	require.Equal(t, uint64(110), end,
+		"runLogBackfill must return minCrossSafeTime as the end of the sealed range")
+	require.Equal(t, uint64(111), h.interop.firstVerifiableTimestamp(),
+		"main loop resumes at backfillEndTimestamp+1")
 	require.Equal(t, act, h.interop.activationTimestamp, "protocol activation must not change")
 
 	chain10 := h.Mock(10)
@@ -463,4 +419,132 @@ func TestLogBackfill_AdvancesActivationAndStartsVerifyAfterCeiling(t *testing.T)
 	require.GreaterOrEqual(t, lastTS, uint64(111))
 	require.Equal(t, int32(1), verifyCalls.Load())
 	require.Equal(t, uint64(111), firstVerifyTS.Load())
+}
+
+// TestLogBackfill_NoOpWhenDepthZero asserts that runLogBackfill short-circuits
+// when logBackfillDepth is zero: it must return (0, nil) without touching
+// SyncStatus, TimestampToBlockNumber, or the logs DB. This is the "feature
+// disabled" path — operators who don't want backfill get no work done.
+func TestLogBackfill_NoOpWhenDepthZero(t *testing.T) {
+	const act = uint64(100)
+
+	var syncStatusCalls atomic.Int32
+	var outputCalls atomic.Int32
+
+	h := newInteropTestHarness(t).
+		WithActivation(act).
+		// no WithLogBackfillDepth → depth stays at zero-value.
+		WithChain(10, func(m *mockChainContainer) {
+			m.syncStatusOverride = func() (*eth.SyncStatus, error) {
+				syncStatusCalls.Add(1)
+				return &eth.SyncStatus{
+					CurrentL1:   eth.L1BlockRef{Number: 1, Hash: common.HexToHash("0xL1")},
+					UnsafeL2:    eth.L2BlockRef{Number: 110, Time: 110},
+					SafeL2:      eth.L2BlockRef{Number: 110, Time: 110},
+					LocalSafeL2: eth.L2BlockRef{Number: 110, Time: 110},
+				}, nil
+			}
+			m.outputV0Override = func(ctx context.Context, num uint64) (*eth.OutputV0, error) {
+				outputCalls.Add(1)
+				return &eth.OutputV0{
+					StateRoot:                eth.Bytes32(common.HexToHash("0xmockstate")),
+					MessagePasserStorageRoot: eth.Bytes32(common.HexToHash("0xmockmsg")),
+					BlockHash:                common.BigToHash(new(big.Int).SetUint64(num)),
+				}, nil
+			}
+		}).
+		Build()
+	h.interop.ctx = context.Background()
+
+	end, err := h.interop.runLogBackfill()
+	require.NoError(t, err)
+	require.Zero(t, end, "depth==0 short-circuits with end=0")
+	require.Zero(t, syncStatusCalls.Load(), "SyncStatus must not be called when depth is zero")
+	require.Zero(t, outputCalls.Load(), "no blocks should be fetched when depth is zero")
+
+	chain10 := h.Mock(10)
+	_, has := h.interop.logsDBs[chain10.id].LatestSealedBlock()
+	require.False(t, has, "logs DB must remain empty")
+
+	// Caller sets backfillEndTimestamp; with end==0 the main loop falls back
+	// to activationTimestamp rather than end+1.
+	h.interop.backfillEndTimestamp = end
+	require.Equal(t, act, h.interop.firstVerifiableTimestamp(),
+		"with end==0 the main loop resumes at activationTimestamp")
+}
+
+// TestLogBackfill_NoOpWhenNoChains asserts that runLogBackfill short-circuits
+// when no chains are registered: no SyncStatus/TimestampToBlockNumber calls
+// can happen because there's nothing to iterate, and end must be zero so the
+// main loop falls back to activationTimestamp.
+func TestLogBackfill_NoOpWhenNoChains(t *testing.T) {
+	const act = uint64(100)
+
+	h := newInteropTestHarness(t).
+		WithActivation(act).
+		WithLogBackfillDepth(10 * time.Second).
+		// no WithChain calls — empty chains map.
+		Build()
+	require.NotNil(t, h.interop, "Interop must initialize with zero chains")
+	h.interop.ctx = context.Background()
+
+	end, err := h.interop.runLogBackfill()
+	require.NoError(t, err)
+	require.Zero(t, end, "empty chains map short-circuits with end=0")
+
+	h.interop.backfillEndTimestamp = end
+	require.Equal(t, act, h.interop.firstVerifiableTimestamp(),
+		"with end==0 the main loop resumes at activationTimestamp")
+}
+
+// TestLogBackfill_ActivationInFuture asserts the edge case where the
+// configured activation is ahead of every chain's cross-safe tip. The
+// window start clamps to activationTimestamp, producing startTime >
+// minCrossSafeTime (i.e. startNum > endNum). runLogBackfill must still
+// return minCrossSafeTime without error; the per-chain backfill loop is
+// a no-op because startNum > endNum. Operationally this means the main
+// loop will wait for the chain to advance past activation before doing
+// any verification work — no blocks get sealed eagerly.
+func TestLogBackfill_ActivationInFuture(t *testing.T) {
+	const act = uint64(2000)
+	depth := 100 * time.Second
+
+	var outputCalls atomic.Int32
+
+	h := newInteropTestHarness(t).
+		WithActivation(act).
+		WithLogBackfillDepth(depth).
+		WithChain(10, func(m *mockChainContainer) {
+			// Cross-safe tip at 1000 — well below activation 2000.
+			m.syncStatusFull = &eth.SyncStatus{
+				CurrentL1:   eth.L1BlockRef{Number: 1, Hash: common.HexToHash("0xL1")},
+				UnsafeL2:    eth.L2BlockRef{Number: 1000, Time: 1000},
+				SafeL2:      eth.L2BlockRef{Number: 1000, Time: 1000},
+				LocalSafeL2: eth.L2BlockRef{Number: 1000, Time: 1000},
+			}
+			m.outputV0Override = func(ctx context.Context, num uint64) (*eth.OutputV0, error) {
+				outputCalls.Add(1)
+				return &eth.OutputV0{
+					StateRoot:                eth.Bytes32(common.HexToHash("0xmockstate")),
+					MessagePasserStorageRoot: eth.Bytes32(common.HexToHash("0xmockmsg")),
+					BlockHash:                common.BigToHash(new(big.Int).SetUint64(num)),
+				}, nil
+			}
+		}).
+		Build()
+	h.interop.ctx = context.Background()
+
+	end, err := h.interop.runLogBackfill()
+	require.NoError(t, err)
+	require.Equal(t, uint64(1000), end,
+		"return value is still minCrossSafeTime even when activation is in the future")
+	require.Zero(t, outputCalls.Load(),
+		"no blocks fetched: startNum > endNum when activation is ahead of cross-safe")
+
+	chain10 := h.Mock(10)
+	_, has := h.interop.logsDBs[chain10.id].LatestSealedBlock()
+	require.False(t, has, "logs DB must remain empty when the window is inverted")
+
+	require.Equal(t, act, h.interop.activationTimestamp,
+		"protocol activation must not change")
 }

--- a/op-supernode/supernode/activity/interop/logdb.go
+++ b/op-supernode/supernode/activity/interop/logdb.go
@@ -170,10 +170,11 @@ func (i *Interop) verifyCanAddTimestamp(chainID eth.ChainID, db LogsDB, ts uint6
 	latestBlock, hasBlocks := db.LatestSealedBlock()
 
 	if !hasBlocks {
-		// The main loop starts at runtimeActivationTimestamp (which may have been
-		// advanced past the protocol activation by backfill). If the DB is empty,
-		// this is the only timestamp the main loop would legitimately seal first.
-		if ts == i.runtimeActivationTimestamp {
+		// The main loop starts at firstVerifiableTimestamp — activationTimestamp
+		// when backfill did not run, or backfillEndTimestamp+1 when it did. If
+		// the DB is empty, this is the only timestamp the main loop would
+		// legitimately seal first.
+		if ts == i.firstVerifiableTimestamp() {
 			return eth.BlockID{}, hasBlocks, nil
 		}
 		// Backfill's first block is TargetBlockNumber(T_lo), which floors the

--- a/op-supernode/supernode/activity/interop/logdb_test.go
+++ b/op-supernode/supernode/activity/interop/logdb_test.go
@@ -222,9 +222,8 @@ func TestVerifyPreviousTimestampSealed(t *testing.T) {
 			t.Parallel()
 
 			interop := &Interop{
-				log:                        gethlog.New(),
-				activationTimestamp:        tt.activationTS,
-				runtimeActivationTimestamp: tt.activationTS,
+				log:                 gethlog.New(),
+				activationTimestamp: tt.activationTS,
 			}
 			chainID := eth.ChainIDFromUInt64(10)
 			expectedHash := common.Hash{0x01}

--- a/op-supernode/supernode/activity/supernode/supernode_test.go
+++ b/op-supernode/supernode/activity/supernode/supernode_test.go
@@ -121,6 +121,10 @@ func (m *mockCC) TimestampToBlockNumber(ctx context.Context, ts uint64) (uint64,
 	return ts, nil
 }
 
+func (m *mockCC) BlockNumberToTimestamp(ctx context.Context, blocknum uint64) (uint64, error) {
+	return 0, nil
+}
+
 var _ cc.ChainContainer = (*mockCC)(nil)
 
 func TestSupernode_SyncStatus_Succeeds(t *testing.T) {

--- a/op-supernode/supernode/activity/superroot/superroot_test.go
+++ b/op-supernode/supernode/activity/superroot/superroot_test.go
@@ -122,6 +122,10 @@ func (m *mockCC) TimestampToBlockNumber(ctx context.Context, ts uint64) (uint64,
 	return ts, nil
 }
 
+func (m *mockCC) BlockNumberToTimestamp(ctx context.Context, blocknum uint64) (uint64, error) {
+	return 0, nil
+}
+
 var _ cc.ChainContainer = (*mockCC)(nil)
 
 func TestSuperroot_AtTimestamp_Succeeds(t *testing.T) {

--- a/op-supernode/supernode/chain_container/chain_container.go
+++ b/op-supernode/supernode/chain_container/chain_container.go
@@ -46,6 +46,7 @@ type ChainContainer interface {
 	LocalSafeBlockAtTimestamp(ctx context.Context, ts uint64) (eth.L2BlockRef, error)
 	// TimestampToBlockNumber maps an L2 unix timestamp to the L2 block number (rollup derivation).
 	TimestampToBlockNumber(ctx context.Context, ts uint64) (uint64, error)
+	BlockNumberToTimestamp(ctx context.Context, blocknum uint64) (uint64, error)
 	SyncStatus(ctx context.Context) (*eth.SyncStatus, error)
 	VerifiedAt(ctx context.Context, ts uint64) (l2, l1 eth.BlockID, err error)
 	OptimisticAt(ctx context.Context, ts uint64) (l2, l1 eth.BlockID, err error)
@@ -372,7 +373,13 @@ func (c *simpleChainContainer) TimestampToBlockNumber(ctx context.Context, ts ui
 }
 
 func (c *simpleChainContainer) BlockNumberToTimestamp(ctx context.Context, blocknum uint64) (uint64, error) {
-	return c.blockNumberToTimestamp(blocknum)
+	if c.vncfg == nil {
+		return 0, fmt.Errorf("rollup config not available")
+	}
+	if blocknum < c.vncfg.Rollup.Genesis.L2.Number {
+		return 0, fmt.Errorf("block number %d before genesis %d", blocknum, c.vncfg.Rollup.Genesis.L2.Number)
+	}
+	return c.vncfg.Rollup.TimestampForBlock(blocknum), nil
 }
 
 // LocalSafeBlockAtTimestamp returns the highest L2 block with timestamp <= ts using the L2 client,
@@ -664,15 +671,4 @@ func (c *simpleChainContainer) PauseAndStopVN(ctx context.Context) error {
 // Calling this while InvalidateBlock may be running is unsafe.
 func (c *simpleChainContainer) SetResetCallback(cb ResetCallback) {
 	c.onReset = cb
-}
-
-// blockNumberToTimestamp converts a block number to its timestamp using rollup config.
-func (c *simpleChainContainer) blockNumberToTimestamp(blockNum uint64) (uint64, error) {
-	if c.vncfg == nil {
-		return 0, fmt.Errorf("rollup config not available")
-	}
-	if blockNum < c.vncfg.Rollup.Genesis.L2.Number {
-		return 0, fmt.Errorf("block number %d before genesis %d", blockNum, c.vncfg.Rollup.Genesis.L2.Number)
-	}
-	return c.vncfg.Rollup.TimestampForBlock(blockNum), nil
 }

--- a/op-supernode/supernode/chain_container/invalidation.go
+++ b/op-supernode/supernode/chain_container/invalidation.go
@@ -389,7 +389,7 @@ func (c *simpleChainContainer) InvalidateBlock(ctx context.Context, height uint6
 	invalidatedBlock := currentBlock.BlockRef()
 
 	// Rewind to the prior block's timestamp
-	priorTimestamp, err := c.blockNumberToTimestamp(height - 1)
+	priorTimestamp, err := c.BlockNumberToTimestamp(ctx, height-1)
 	if err != nil {
 		return false, fmt.Errorf("failed to compute rewind timestamp: %w", err)
 	}


### PR DESCRIPTION
# Tool Use Notice

Implementation written by hand. Tests added via AI.

# Summary

Rewrite of the convoluded generated backfill system. Identifying the Start/End of range is actually not that bad and I suspect this will keep us from falling into more sync issues.

# Tests

New test added to show the asymmetric range (based on time) other tests pass or were removed (some invariants were not appropriate for this backfiller)