### PR TITLE
chore(contracts-bedrock): remove stale U15 fork guards

### DIFF
--- a/packages/contracts-bedrock/test/L1/ETHLockbox.t.sol
+++ b/packages/contracts-bedrock/test/L1/ETHLockbox.t.sol
@@ -33,11 +33,6 @@ abstract contract ETHLockbox_TestInit is CommonTest {
     function setUp() public virtual override {
         super.setUp();
 
-        // If not on the last upgrade network, we skip the test since the `ETHLockbox` won't be yet
-        // deployed
-        // TODO(#14691): Remove this check once Upgrade 15 is deployed on Mainnet.
-        if (isL1ForkTest() && !deploy.cfg().useUpgradedFork()) vm.skip(true);
-
         // If the ETHLockbox system feature is not enabled, skip these tests.
         skipIfSysFeatureDisabled(Features.ETH_LOCKBOX);
     }

--- a/packages/contracts-bedrock/test/setup/Setup.sol
+++ b/packages/contracts-bedrock/test/setup/Setup.sol
@@ -374,14 +374,10 @@ abstract contract Setup is FeatureFlags {
 
         optimismPortal2 = IOptimismPortal(artifacts.mustGetAddress("OptimismPortalProxy"));
 
-        // Only skip ETHLockbox assignment if we're in a fork test with non-upgraded fork
-        // TODO(#14691): Remove this check once Upgrade 15 is deployed on Mainnet.
-        if (!isL1ForkTest() || deploy.cfg().useUpgradedFork()) {
-            // Here we use getAddress instead of mustGetAddress because some chains might not have
-            // the ETHLockbox proxy. Chains that don't have the ETHLockbox proxy will just return
-            // address(0) and cause a revert if we use mustGetAddress.
-            ethLockbox = IETHLockbox(artifacts.getAddress("ETHLockboxProxy"));
-        }
+        // Here we use getAddress instead of mustGetAddress because some chains might not have
+        // the ETHLockbox proxy. Chains that don't have the ETHLockbox proxy will just return
+        // address(0) and cause a revert if we use mustGetAddress.
+        ethLockbox = IETHLockbox(artifacts.getAddress("ETHLockboxProxy"));
 
         systemConfig = ISystemConfig(artifacts.mustGetAddress("SystemConfigProxy"));
         l1StandardBridge = IL1StandardBridge(artifacts.mustGetAddress("L1StandardBridgeProxy"));


### PR DESCRIPTION
## Summary
- remove stale Upgrade 15 fork guards around ETHLockbox setup
- always register ETHLockbox from artifacts via getAddress, preserving address(0) fallback for chains without a lockbox
- keep the generic non-upgraded fork path for OPCM upgrade tests

## Testing
- mise exec -- forge fmt --check test/L1/ETHLockbox.t.sol test/setup/Setup.sol
- mise exec -- just test --match-path test/L1/ETHLockbox.t.sol
- mise exec -- just test --match-path test/L1/OptimismPortal2.t.sol --match-test test_version_succeeds
- FORK_TEST=true FORK_RPC_URL=https://ethereum-rpc.publicnode.com FORK_BLOCK_NUMBER=24951601 FOUNDRY_FORK_RETRIES=10 FOUNDRY_FORK_RETRY_BACKOFF=1000 mise exec -- forge test --match-path test/L1/opcm/OPContractsManagerV2.t.sol --match-test test_upgrade_succeeds -vv
- git diff --check