### PR TITLE
chore(contracts-bedrock): clean up unused test helpers

### DIFF
--- a/packages/contracts-bedrock/test/L2/ETHLiquidity.t.sol
+++ b/packages/contracts-bedrock/test/L2/ETHLiquidity.t.sol
@@ -31,12 +31,7 @@ abstract contract ETHLiquidity_TestInit is CommonTest {
         super.enableInterop();
         super.setUp();
 
-        {
-            // TODO: Remove this block when L2Genesis includes this contract.
-            vm.etch(address(superchainETHBridge), vm.getDeployedCode("SuperchainETHBridge.sol:SuperchainETHBridge"));
-            vm.etch(address(ethLiquidity), vm.getDeployedCode("ETHLiquidity.sol:ETHLiquidity"));
-            vm.deal(address(ethLiquidity), type(uint248).max);
-        }
+        vm.deal(address(ethLiquidity), type(uint248).max);
     }
 
     /// @notice Tests that contract is set up with the correct starting balance.

--- a/packages/contracts-bedrock/test/L2/SuperchainETHBridge.t.sol
+++ b/packages/contracts-bedrock/test/L2/SuperchainETHBridge.t.sol
@@ -27,12 +27,6 @@ abstract contract SuperchainETHBridge_TestInit is CommonTest, MockHelper {
     function setUp() public virtual override {
         super.enableInterop();
         super.setUp();
-
-        {
-            // TODO: Remove this block when L2Genesis includes this contract.
-            vm.etch(address(superchainETHBridge), vm.getDeployedCode("SuperchainETHBridge.sol:SuperchainETHBridge"));
-            vm.etch(address(ethLiquidity), vm.getDeployedCode("ETHLiquidity.sol:ETHLiquidity"));
-        }
     }
 }
 

--- a/packages/contracts-bedrock/test/dispute/FaultDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/dispute/FaultDisputeGame.t.sol
@@ -56,6 +56,22 @@ contract ClaimCreditReenter {
     }
 }
 
+interface IBondedDisputeGame {
+    function claimData(uint256)
+        external
+        view
+        returns (
+            uint32 parentIndex,
+            address counteredBy,
+            address claimant,
+            uint128 bond,
+            Claim claim,
+            Position position,
+            Clock clock
+        );
+    function getRequiredBond(Position _position) external view returns (uint256 requiredBond_);
+}
+
 /// @notice Helper to change the VM status byte of a claim.
 function _changeClaimStatus(Claim _claim, VMStatus _status) pure returns (Claim out_) {
     assembly {
@@ -66,6 +82,20 @@ function _changeClaimStatus(Claim _claim, VMStatus _status) pure returns (Claim 
 /// @notice Helper to return a pseudo-random claim.
 function _dummyClaim() view returns (Claim) {
     return Claim.wrap(keccak256(abi.encode(gasleft())));
+}
+
+function _copyBytes(bytes memory src, bytes memory dest) pure returns (bytes memory) {
+    uint256 byteCount = src.length < dest.length ? src.length : dest.length;
+    for (uint256 i = 0; i < byteCount; i++) {
+        dest[i] = src[i];
+    }
+    return dest;
+}
+
+function _requiredBondForGame(address _gameProxy, uint256 _claimIndex) view returns (uint256 bond_) {
+    (,,,,, Position parent,) = IBondedDisputeGame(_gameProxy).claimData(_claimIndex);
+    Position pos = parent.move(true);
+    bond_ = IBondedDisputeGame(_gameProxy).getRequiredBond(pos);
 }
 
 /// @title BaseFaultDisputeGame_TestInit
@@ -135,14 +165,6 @@ abstract contract BaseFaultDisputeGame_TestInit is DisputeGameFactory_TestInit {
     fallback() external payable { }
 
     receive() external payable { }
-
-    function copyBytes(bytes memory src, bytes memory dest) internal pure returns (bytes memory) {
-        uint256 byteCount = src.length < dest.length ? src.length : dest.length;
-        for (uint256 i = 0; i < byteCount; i++) {
-            dest[i] = src[i];
-        }
-        return dest;
-    }
 }
 
 /// @title FaultDisputeGame_TestInit
@@ -211,9 +233,7 @@ abstract contract FaultDisputeGame_TestInit is BaseFaultDisputeGame_TestInit {
 
     /// @notice Helper to get the required bond for the given claim index.
     function _getRequiredBond(uint256 _claimIndex) internal view returns (uint256 bond_) {
-        (,,,,, Position parent,) = gameProxy.claimData(_claimIndex);
-        Position pos = parent.move(true);
-        bond_ = gameProxy.getRequiredBond(pos);
+        bond_ = _requiredBondForGame(address(gameProxy), _claimIndex);
     }
 
     /// @notice Helper to get the localized key for an identifier in the context of the game proxy.
@@ -430,7 +450,7 @@ contract FaultDisputeGame_Initialize_Test is FaultDisputeGame_TestInit {
         _extraByteCount = bound(_extraByteCount, 1, 23_500);
         bytes memory immutableArgs = new bytes(_extraByteCount + correctArgs.length);
         // Copy correct args into immutable args
-        copyBytes(correctArgs, immutableArgs);
+        _copyBytes(correctArgs, immutableArgs);
 
         // Set up dispute game implementation with target immutableArgs
         setupFaultDisputeGame(immutableArgs);
@@ -452,7 +472,7 @@ contract FaultDisputeGame_Initialize_Test is FaultDisputeGame_TestInit {
         _truncatedByteCount = (_truncatedByteCount % correctArgs.length) + 1;
         bytes memory immutableArgs = new bytes(correctArgs.length - _truncatedByteCount);
         // Copy correct args into immutable args
-        copyBytes(correctArgs, immutableArgs);
+        _copyBytes(correctArgs, immutableArgs);
 
         // Set up dispute game implementation with target immutableArgs
         setupFaultDisputeGame(immutableArgs);

--- a/packages/contracts-bedrock/test/dispute/FaultDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/dispute/FaultDisputeGame.t.sol
@@ -61,13 +61,13 @@ interface IBondedDisputeGame {
         external
         view
         returns (
-            uint32 parentIndex,
-            address counteredBy,
-            address claimant,
-            uint128 bond,
-            Claim claim,
-            Position position,
-            Clock clock
+            uint32 parentIndex_,
+            address counteredBy_,
+            address claimant_,
+            uint128 bond_,
+            Claim claim_,
+            Position position_,
+            Clock clock_
         );
     function getRequiredBond(Position _position) external view returns (uint256 requiredBond_);
 }

--- a/packages/contracts-bedrock/test/dispute/FaultDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/dispute/FaultDisputeGame.t.sol
@@ -56,8 +56,12 @@ contract ClaimCreditReenter {
     }
 }
 
+/// @notice Minimal dispute game interface used by shared test helpers.
 interface IBondedDisputeGame {
-    function claimData(uint256)
+    /// @notice Returns claim data for a given claim index.
+    ///
+    /// @param _claimIndex Index of the claim to read.
+    function claimData(uint256 _claimIndex)
         external
         view
         returns (
@@ -69,6 +73,12 @@ interface IBondedDisputeGame {
             Position position_,
             Clock clock_
         );
+
+    /// @notice Returns the required bond for a move at a given position.
+    ///
+    /// @param _position Position to compute the required bond for.
+    ///
+    /// @return requiredBond_ Required bond amount.
     function getRequiredBond(Position _position) external view returns (uint256 requiredBond_);
 }
 
@@ -84,18 +94,30 @@ function _dummyClaim() view returns (Claim) {
     return Claim.wrap(keccak256(abi.encode(gasleft())));
 }
 
-function _copyBytes(bytes memory src, bytes memory dest) pure returns (bytes memory) {
-    uint256 byteCount = src.length < dest.length ? src.length : dest.length;
+/// @notice Copies bytes from `_src` into `_dest`, stopping at the shorter array length.
+///
+/// @param _src Source bytes to copy from.
+/// @param _dest Destination bytes to copy into.
+///
+/// @return copied_ Destination bytes after copying.
+function _copyBytes(bytes memory _src, bytes memory _dest) pure returns (bytes memory copied_) {
+    uint256 byteCount = _src.length < _dest.length ? _src.length : _dest.length;
     for (uint256 i = 0; i < byteCount; i++) {
-        dest[i] = src[i];
+        _dest[i] = _src[i];
     }
-    return dest;
+    copied_ = _dest;
 }
 
+/// @notice Computes the required bond to attack a claim in a dispute game.
+///
+/// @param _gameProxy Dispute game proxy address.
+/// @param _claimIndex Index of the claim whose next attack bond is needed.
+///
+/// @return bond_ Required bond for the next attack position.
 function _requiredBondForGame(address _gameProxy, uint256 _claimIndex) view returns (uint256 bond_) {
-    (,,,,, Position parent,) = IBondedDisputeGame(_gameProxy).claimData(_claimIndex);
-    Position pos = parent.move(true);
-    bond_ = IBondedDisputeGame(_gameProxy).getRequiredBond(pos);
+    (,,,,, Position parentPosition,) = IBondedDisputeGame(_gameProxy).claimData(_claimIndex);
+    Position attackPosition = parentPosition.move(true);
+    bond_ = IBondedDisputeGame(_gameProxy).getRequiredBond(attackPosition);
 }
 
 /// @title BaseFaultDisputeGame_TestInit

--- a/packages/contracts-bedrock/test/dispute/PermissionedDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/dispute/PermissionedDisputeGame.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.15;
 
 // Testing
 import { DisputeGameFactory_TestInit } from "test/dispute/DisputeGameFactory.t.sol";
-import { _changeClaimStatus, _dummyClaim } from "test/dispute/FaultDisputeGame.t.sol";
+import { _changeClaimStatus, _copyBytes, _dummyClaim, _requiredBondForGame } from "test/dispute/FaultDisputeGame.t.sol";
 import { AlphabetVM } from "test/mocks/AlphabetVM.sol";
 
 // Libraries
@@ -112,22 +112,12 @@ abstract contract PermissionedDisputeGame_TestInit is DisputeGameFactory_TestIni
 
     /// @dev Helper to get the required bond for the given claim index.
     function _getRequiredBond(uint256 _claimIndex) internal view returns (uint256 bond_) {
-        (,,,,, Position parent,) = gameProxy.claimData(_claimIndex);
-        Position pos = parent.move(true);
-        bond_ = gameProxy.getRequiredBond(pos);
+        bond_ = _requiredBondForGame(address(gameProxy), _claimIndex);
     }
 
     fallback() external payable { }
 
     receive() external payable { }
-
-    function copyBytes(bytes memory src, bytes memory dest) internal pure returns (bytes memory) {
-        uint256 byteCount = src.length < dest.length ? src.length : dest.length;
-        for (uint256 i = 0; i < byteCount; i++) {
-            dest[i] = src[i];
-        }
-        return dest;
-    }
 }
 
 /// @title PermissionedDisputeGame_Version_Test
@@ -282,7 +272,7 @@ contract PermissionedDisputeGame_Initialize_Test is PermissionedDisputeGame_Test
         _extraByteCount = bound(_extraByteCount, 1, 23_500);
         bytes memory immutableArgs = new bytes(_extraByteCount + correctArgs.length);
         // Copy correct args into immutable args
-        copyBytes(correctArgs, immutableArgs);
+        _copyBytes(correctArgs, immutableArgs);
 
         // Set up dispute game implementation with target immutableArgs
         setupPermissionedDisputeGame(immutableArgs);
@@ -305,7 +295,7 @@ contract PermissionedDisputeGame_Initialize_Test is PermissionedDisputeGame_Test
         _truncatedByteCount = (_truncatedByteCount % correctArgs.length) + 1;
         bytes memory immutableArgs = new bytes(correctArgs.length - _truncatedByteCount);
         // Copy correct args into immutable args
-        copyBytes(correctArgs, immutableArgs);
+        _copyBytes(correctArgs, immutableArgs);
 
         // Set up dispute game implementation with target immutableArgs
         setupPermissionedDisputeGame(immutableArgs);

--- a/packages/contracts-bedrock/test/dispute/SuperFaultDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/dispute/SuperFaultDisputeGame.t.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.15;
 // Testing
 import { Vm } from "forge-std/Vm.sol";
 import { DisputeGameFactory_TestInit } from "test/dispute/DisputeGameFactory.t.sol";
-import { _changeClaimStatus, _dummyClaim } from "test/dispute/FaultDisputeGame.t.sol";
+import { _changeClaimStatus, _dummyClaim, _requiredBondForGame } from "test/dispute/FaultDisputeGame.t.sol";
 import { AlphabetVM } from "test/mocks/AlphabetVM.sol";
 import { ByteUtils } from "test/setup/ByteUtils.sol";
 import { stdError } from "forge-std/StdError.sol";
@@ -19,7 +19,6 @@ import { DisputeActor, HonestDisputeActor } from "test/actors/FaultDisputeActors
 import { Types } from "src/libraries/Types.sol";
 import { Hashing } from "src/libraries/Hashing.sol";
 import { Encoding } from "src/libraries/Encoding.sol";
-import { RLPWriter } from "src/libraries/rlp/RLPWriter.sol";
 import { LibClock } from "src/dispute/lib/LibUDT.sol";
 import { LibPosition } from "src/dispute/lib/LibPosition.sol";
 import "src/dispute/lib/Types.sol";
@@ -176,45 +175,9 @@ abstract contract SuperFaultDisputeGame_TestInit is BaseSuperFaultDisputeGame_Te
         init({ _rootClaim: ROOT_CLAIM, _absolutePrestate: absolutePrestate, _super: SUPER_ROOT_PROOF });
     }
 
-    /// @notice Helper to generate a mock RLP encoded header (with only a real block number) & an
-    ///         output root proof.
-    function _generateOutputRootProof(
-        bytes32 _storageRoot,
-        bytes32 _withdrawalRoot,
-        bytes memory _l2SequenceNumber
-    )
-        internal
-        pure
-        returns (Types.OutputRootProof memory proof_, bytes32 root_, bytes memory rlp_)
-    {
-        // L2 Block header
-        bytes[] memory rawHeaderRLP = new bytes[](9);
-        rawHeaderRLP[0] = hex"83FACADE";
-        rawHeaderRLP[1] = hex"83FACADE";
-        rawHeaderRLP[2] = hex"83FACADE";
-        rawHeaderRLP[3] = hex"83FACADE";
-        rawHeaderRLP[4] = hex"83FACADE";
-        rawHeaderRLP[5] = hex"83FACADE";
-        rawHeaderRLP[6] = hex"83FACADE";
-        rawHeaderRLP[7] = hex"83FACADE";
-        rawHeaderRLP[8] = RLPWriter.writeBytes(_l2SequenceNumber);
-        rlp_ = RLPWriter.writeList(rawHeaderRLP);
-
-        // Output root
-        proof_ = Types.OutputRootProof({
-            version: 0,
-            stateRoot: _storageRoot,
-            messagePasserStorageRoot: _withdrawalRoot,
-            latestBlockhash: keccak256(rlp_)
-        });
-        root_ = Hashing.hashOutputRootProof(proof_);
-    }
-
     /// @notice Helper to get the required bond for the given claim index.
     function _getRequiredBond(uint256 _claimIndex) internal view returns (uint256 bond_) {
-        (,,,,, Position parent,) = gameProxy.claimData(_claimIndex);
-        Position pos = parent.move(true);
-        bond_ = gameProxy.getRequiredBond(pos);
+        bond_ = _requiredBondForGame(address(gameProxy), _claimIndex);
     }
 
     /// @notice Helper to return a pseudo-random super root proof
@@ -233,11 +196,6 @@ abstract contract SuperFaultDisputeGame_TestInit is BaseSuperFaultDisputeGame_Te
         superRootProof_.version = bytes1(uint8(1));
         superRootProof_.timestamp = uint64(_l2SequenceNumber);
         superRootProof_.outputRoots = outputRoots;
-    }
-
-    /// @notice Helper to return a pseudo-random super root with the specified l2 sequence number
-    function _dummySuperRoot(uint64 _l2SequenceNumber) internal view returns (bytes32 superRoot_________) {
-        return Hashing.hashSuperRootProof(_dummySuper(_l2SequenceNumber));
     }
 
     /// @notice Helper to return a pseudo-random root claim with the specified l2 sequence number

--- a/packages/contracts-bedrock/test/dispute/SuperPermissionedDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/dispute/SuperPermissionedDisputeGame.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.15;
 
 // Testing
 import { DisputeGameFactory_TestInit } from "test/dispute/DisputeGameFactory.t.sol";
-import { _changeClaimStatus, _dummyClaim } from "test/dispute/FaultDisputeGame.t.sol";
+import { _changeClaimStatus, _copyBytes, _dummyClaim, _requiredBondForGame } from "test/dispute/FaultDisputeGame.t.sol";
 import { AlphabetVM } from "test/mocks/AlphabetVM.sol";
 
 // Libraries
@@ -125,9 +125,7 @@ abstract contract SuperPermissionedDisputeGame_TestInit is DisputeGameFactory_Te
 
     /// @notice Helper to get the required bond for the given claim index.
     function _getRequiredBond(uint256 _claimIndex) internal view returns (uint256 bond_) {
-        (,,,,, Position parent,) = gameProxy.claimData(_claimIndex);
-        Position pos = parent.move(true);
-        bond_ = gameProxy.getRequiredBond(pos);
+        bond_ = _requiredBondForGame(address(gameProxy), _claimIndex);
     }
 
     /// @notice Helper to create an arbitrary SuperRootProof
@@ -143,14 +141,6 @@ abstract contract SuperPermissionedDisputeGame_TestInit is DisputeGameFactory_Te
     fallback() external payable { }
 
     receive() external payable { }
-
-    function copyBytes(bytes memory src, bytes memory dest) internal pure returns (bytes memory) {
-        uint256 byteCount = src.length < dest.length ? src.length : dest.length;
-        for (uint256 i = 0; i < byteCount; i++) {
-            dest[i] = src[i];
-        }
-        return dest;
-    }
 }
 
 /// @title SuperPermissionedDisputeGame_Version_Test
@@ -346,7 +336,7 @@ contract SuperPermissionedDisputeGame_Initialize_Test is SuperPermissionedDisput
         _truncatedByteCount = (_truncatedByteCount % correctArgs.length) + 1;
         bytes memory immutableArgs = new bytes(correctArgs.length - _truncatedByteCount);
         // Copy correct args into immutable args
-        copyBytes(correctArgs, immutableArgs);
+        _copyBytes(correctArgs, immutableArgs);
 
         // Set up dispute game implementation with target immutableArgs
         setupSuperPermissionedDisputeGame(immutableArgs);

--- a/packages/contracts-bedrock/test/opcm/DeploySuperchain.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeploySuperchain.t.sol
@@ -32,10 +32,6 @@ contract DeploySuperchain_Test is Test {
         return bytes32(ProtocolVersion.unwrap(_pv));
     }
 
-    function hash(bytes32 _seed, uint256 _i) internal pure returns (bytes32) {
-        return keccak256(abi.encode(_seed, _i));
-    }
-
     function testFuzz_run_memory_succeeds(
         address _superchainProxyAdminOwner,
         address _protocolVersionsOwner,

--- a/packages/contracts-bedrock/test/safe/LivenessModule2.t.sol
+++ b/packages/contracts-bedrock/test/safe/LivenessModule2.t.sol
@@ -35,27 +35,6 @@ abstract contract LivenessModule2_TestUtils is Test, SafeTestTools {
         );
     }
 
-    /// @notice Helper to disable the LivenessModule2 for a Safe
-    function _disableModule(SafeInstance memory _safe) internal {
-        // First disable the module at the Safe level
-        SafeTestLib.execTransaction(
-            _safe,
-            address(_safe.safe),
-            0,
-            abi.encodeCall(ModuleManager.disableModule, (address(0x1), address(livenessModule2))),
-            Enum.Operation.Call
-        );
-
-        // Then clear the module configuration
-        SafeTestLib.execTransaction(
-            _safe,
-            address(livenessModule2),
-            0,
-            abi.encodeCall(LivenessModule2.clearLivenessModule, ()),
-            Enum.Operation.Call
-        );
-    }
-
     /// @notice Helper to respond to a challenge from a Safe
     function _respondToChallenge(SafeInstance memory _safe) internal {
         SafeTestLib.execTransaction(

--- a/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
+++ b/packages/contracts-bedrock/test/safe/TimelockGuard.t.sol
@@ -34,11 +34,6 @@ library TransactionBuilder {
 
     address internal constant VM_ADDR = 0x7109709ECfa91a80626fF3989D68f67F5b1DD12D;
 
-    /// @notice Sets a nonce value on the provided transaction struct.
-    function setNonce(Transaction memory _tx, uint256 _nonce) internal pure {
-        _tx.nonce = _nonce;
-    }
-
     /// @notice Computes and stores the Safe transaction hash for the struct.
     function setHash(Transaction memory _tx) internal view {
         _tx.hash = _tx.safeInstance.safe.getTransactionHash({

--- a/packages/contracts-bedrock/test/scripts/VerifyOPCM.t.sol
+++ b/packages/contracts-bedrock/test/scripts/VerifyOPCM.t.sol
@@ -571,13 +571,6 @@ contract VerifyOPCM_Run_Test is VerifyOPCM_TestInit {
         }
     }
 
-    /// @notice Helper function to check if a field represents an OPCM component.
-    /// @param _field The field name to check.
-    /// @return True if the field represents an OPCM component (starts with "opcm"), false otherwise.
-    function _isOpcmComponent(string memory _field) internal pure returns (bool) {
-        return LibString.startsWith(_field, "opcm");
-    }
-
     /// @notice Helper function to check if a field represents an OPCM component that has contractsContainer().
     /// @param _field The field name to check.
     /// @return True if the field represents an OPCM component with contractsContainer(), false otherwise.
@@ -639,17 +632,6 @@ contract VerifyOPCM_Run_Test is VerifyOPCM_TestInit {
         // Environment variables are set in setUp() to match the actual OPCM addresses.
         bool result = harness.verifyOpcmImmutableVariables(opcm);
         assertTrue(result, "OPCM immutable variables should be valid");
-    }
-
-    /// @notice Mocks a call to the OPCM contract and verifies validation fails.
-    /// @param _selector The function selector for the OPCM contract method to mock.
-    function _assertOnOpcmGetter(bytes4 _selector) internal {
-        bytes memory callData = abi.encodePacked(_selector);
-        vm.mockCall(address(opcm), callData, abi.encode(address(0x8888)));
-
-        // Verify that immutable variables fail validation
-        bool result = harness.verifyOpcmImmutableVariables(opcm);
-        assertFalse(result, "OPCM with invalid immutable variables should fail verification");
     }
 
     /// @notice Tests that the ABI getter validation succeeds when all getters are accounted for.


### PR DESCRIPTION
## Summary

- remove unused helpers from contracts-bedrock safe, opcm, script, L2, and dispute tests
- drop stale manual interop predeploy etching from L2 tests now covered by genesis setup
- centralize duplicated dispute-game byte-copy and required-bond helper logic

## Testing

- mise exec -- just test --match-path test/safe/TimelockGuard.t.sol
- mise exec -- just test --match-path test/safe/LivenessModule2.t.sol
- mise exec -- just test --match-path test/dispute/SuperFaultDisputeGame.t.sol --match-test test_version_works
- mise exec -- just test --match-path test/scripts/VerifyOPCM.t.sol --match-test test_runSingle_withoutExplicitSetUp_succeeds
- mise exec -- just test --match-path test/opcm/DeploySuperchain.t.sol
- mise exec -- just test --match-path test/L2/SuperchainETHBridge.t.sol
- mise exec -- just test --match-path test/L2/ETHLiquidity.t.sol
- mise exec -- just test --match-test test_initialize_missingImmutableArgsBytes_reverts
- mise exec -- forge test --match-path test/dispute/FaultDisputeGame.t.sol --match-test test_getRequiredBond_succeeds
- mise exec -- forge test --match-path test/dispute/SuperFaultDisputeGame.t.sol --match-test test_getRequiredBond_succeeds
- mise exec -- forge test --match-path test/dispute/PermissionedDisputeGame.t.sol --match-test test_participateInGame_challenger_succeeds
- mise exec -- forge test --match-path test/dispute/SuperPermissionedDisputeGame.t.sol --match-test test_participateInGame_challenger_succeeds
- mise exec -- forge fmt --check test/dispute/FaultDisputeGame.t.sol test/dispute/PermissionedDisputeGame.t.sol test/dispute/SuperFaultDisputeGame.t.sol test/dispute/SuperPermissionedDisputeGame.t.sol
- mise exec -- just unused-imports-check-no-build
- mise exec -- just lint-forge-tests-check-no-build
- git diff --check
