### PR TITLE
fix(ci): bump rust-doctest to 2xlarge and unify with just test-docs

### DIFF
--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -549,10 +549,10 @@ jobs:
       command:
         description: "Doc test command to run"
         type: string
-        default: "cargo test --workspace --doc"
+        default: "just test-docs"
     docker:
       - image: <<pipeline.parameters.c-rust_base_image>>
-    resource_class: xlarge
+    resource_class: 2xlarge
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
@@ -987,7 +987,6 @@ workflows:
       - rust-ci-doctest:
           name: rust-doctest
           directory: rust
-          command: "cargo test --doc --workspace --all-features"
           context: *rust-ci-context
 
       - rust-ci-docs:

--- a/rust/justfile
+++ b/rust/justfile
@@ -61,7 +61,7 @@ test-online:
 
 # Run doc tests
 test-docs:
-  cargo test --doc --workspace --locked
+  cargo test --doc --workspace --locked --all-features
 
 ############################### Lint ################################
 


### PR DESCRIPTION

`rust-doctest` intermittently OOMs (rustc SIGKILL) compiling
`reth-optimism-node` on the `xlarge` (16 GB) executor. Bumps to
`2xlarge` (32 GB), matching #20100 which fixed the same OOM on the
sibling `rust-ci-cargo-tests` job.

Also unifies CI with the `just test-docs` recipe so the command
doesn't drift between local and CI.

Closes #19935.

## Changes

- `.circleci/continue/rust-ci.yml` — `rust-ci-doctest` job: `resource_class` → `2xlarge`; default command → `just test-docs`; caller drops its inline
override.
- `rust/justfile` — `test-docs` picks up `--all-features` to match CI coverage.