### PR TITLE
fix(op-devstack): extend preset CrossSafe budget for ELSync mode

### DIFF
--- a/op-devstack/presets/singlechain_from_runtime.go
+++ b/op-devstack/presets/singlechain_from_runtime.go
@@ -5,8 +5,27 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+	nodeSync "github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+)
+
+// Initial-sync-check budgets for singleChainMultiNodeFromRuntime. Attempts are
+// polled every 2s by dsl.MatchedFn.
+//
+//   - LocalUnsafe: EL P2P / CL gossip is fast; 60s covers CI contention.
+//   - CrossSafe (CLSync mode): requires derivation to process the first L1
+//     origin and advance safe; 60s is enough in practice.
+//   - CrossSafe (ELSync mode): the verifier must first complete EL sync over
+//     P2P (which can take tens of seconds on a cold node under CI load)
+//     before the forkchoice update that seeds safe/finalized fires; only
+//     after that does derivation start and begin advancing CrossSafe. The
+//     combined path is consistently slower than the CLSync case, so we give
+//     it a 4x budget. See issue #20334 for the failure mode this guards.
+const (
+	initialSyncCheckAttemptsLocalUnsafe     = 30
+	initialSyncCheckAttemptsCrossSafe       = 30
+	initialSyncCheckAttemptsCrossSafeELSync = 120
 )
 
 func singleChainMultiNodeFromRuntime(t devtest.T, runtime *sysgo.SingleChainRuntime, runSyncChecks bool) *SingleChainMultiNode {
@@ -48,9 +67,16 @@ func singleChainMultiNodeFromRuntime(t devtest.T, runtime *sysgo.SingleChainRunt
 	}
 	if runSyncChecks {
 		// Ensure the follower node is in sync with the sequencer before starting tests.
+		// CrossSafe requires derivation to run, which under ELSync can only begin
+		// after the EL completes P2P sync and the node emits its first forkchoice
+		// update — so size that budget by the follower's sync mode.
+		crossSafeAttempts := initialSyncCheckAttemptsCrossSafe
+		if opNode, ok := nodeB.CL.(*sysgo.OpNode); ok && opNode.SyncMode() == nodeSync.ELSync {
+			crossSafeAttempts = initialSyncCheckAttemptsCrossSafeELSync
+		}
 		dsl.CheckAll(t,
-			preset.L2CLB.MatchedFn(preset.L2CL, types.CrossSafe, 30),
-			preset.L2CLB.MatchedFn(preset.L2CL, types.LocalUnsafe, 30),
+			preset.L2CLB.MatchedFn(preset.L2CL, types.CrossSafe, crossSafeAttempts),
+			preset.L2CLB.MatchedFn(preset.L2CL, types.LocalUnsafe, initialSyncCheckAttemptsLocalUnsafe),
 		)
 	}
 	return preset

--- a/op-devstack/sysgo/l2_cl_opnode.go
+++ b/op-devstack/sysgo/l2_cl_opnode.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/opnode"
 	"github.com/ethereum-optimism/optimism/op-node/config"
+	nodeSync "github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 	"github.com/ethereum-optimism/optimism/op-service/clock"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testutils/tcpproxy"
@@ -22,11 +23,18 @@ type OpNode struct {
 	interopEndpoint  string
 	interopJwtSecret eth.Bytes32
 	cfg              *config.Config
+	syncMode         nodeSync.Mode
 	p                devtest.CommonT
 	logger           log.Logger
 	userProxy        *tcpproxy.Proxy
 	interopProxy     *tcpproxy.Proxy
 	clock            clock.Clock
+}
+
+// SyncMode reports the sync mode the op-node was started with
+// (VerifierSyncMode for verifiers, SequencerSyncMode for sequencers).
+func (n *OpNode) SyncMode() nodeSync.Mode {
+	return n.syncMode
 }
 
 var _ L2CLNode = (*OpNode)(nil)

--- a/op-devstack/sysgo/singlechain_build.go
+++ b/op-devstack/sysgo/singlechain_build.go
@@ -430,12 +430,13 @@ func startL2CLNode(
 		ExperimentalOPStackAPI:          true,
 	}
 	l2CL := &OpNode{
-		name:   startCfg.Key,
-		opNode: nil,
-		cfg:    nodeCfg,
-		p:      t,
-		logger: logger,
-		clock:  clock.SystemClock,
+		name:     startCfg.Key,
+		opNode:   nil,
+		cfg:      nodeCfg,
+		syncMode: syncMode,
+		p:        t,
+		logger:   logger,
+		clock:    clock.SystemClock,
 	}
 	l2CL.Start()
 	t.Cleanup(l2CL.Stop)


### PR DESCRIPTION
The SingleChainMultiNode preset's initial sync check runs the same 30-attempt (60s) CrossSafe match for every verifier sync mode. In ELSync mode that is too tight: the verifier must finish P2P EL sync and emit its first forkchoice update before derivation can start advancing safe, and under CI load that chain of events routinely exceeds 60s, causing TestELSyncSafeRetractedByOffset and TestTruncateDatabaseOnELResync to flake at setup. Expose the resolved sync mode on OpNode and give ELSync verifiers a 4x CrossSafe budget. LocalUnsafe and CLSync budgets are unchanged.

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

Fixes https://github.com/ethereum-optimism/optimism/issues/20334

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
