### PR TITLE
chore(contracts-bedrock): drop v1 mention from _decodeDisputeGameImpl natspec

### DIFF
--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -21,7 +21,7 @@
   },
   "src/L1/OPContractsManagerStandardValidator.sol:OPContractsManagerStandardValidator": {
     "initCodeHash": "0x805d81c6d895de01993b18d72af668412309e2b83729d9a20f2decee75a76b37",
-    "sourceCodeHash": "0x43e6c5b370632abe417fb0b26f73fdc512a6c1e7a1924762f5585c6f7f446f32"
+    "sourceCodeHash": "0x777dbdb2ee88c69858472caa9b40ff3d3ca28ad38d08a2208f9272154643adba"
   },
   "src/L1/OptimismPortal2.sol:OptimismPortal2": {
     "initCodeHash": "0xf09c4037bec1e0fbf679f1250e8d21d4a208829be24e16a83711e94c9b4b1004",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -20,8 +20,8 @@
     "sourceCodeHash": "0x0ef8461e8bc55314e61e60924465574db17bdf30bbbfe9739b52cac623bba2db"
   },
   "src/L1/OPContractsManagerStandardValidator.sol:OPContractsManagerStandardValidator": {
-    "initCodeHash": "0x805d81c6d895de01993b18d72af668412309e2b83729d9a20f2decee75a76b37",
-    "sourceCodeHash": "0x777dbdb2ee88c69858472caa9b40ff3d3ca28ad38d08a2208f9272154643adba"
+    "initCodeHash": "0x55775112dfd25c0470fc267496c603cb27fece0a3f79d900ddc6b619c657f73f",
+    "sourceCodeHash": "0xd631818bab3c638423c3111f85b29840ab109deb7762186cb1141a8d4d14178b"
   },
   "src/L1/OptimismPortal2.sol:OptimismPortal2": {
     "initCodeHash": "0xf09c4037bec1e0fbf679f1250e8d21d4a208829be24e16a83711e94c9b4b1004",

--- a/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
@@ -1004,8 +1004,7 @@ contract OPContractsManagerStandardValidator is ISemver {
         return _assertValidZKGameArgs(_errors, _sysCfg, _l2ChainID, _admin, _overrides, errorPrefix);
     }
 
-    // @notice Internal function to read all information from a dispute game while supporting both v1 and v2 dispute
-    /// games.
+    /// @notice Internal function to read all information from a dispute game.
     function _decodeDisputeGameImpl(
         IPermissionedDisputeGame _game,
         bytes memory _gameArgsBytes,

--- a/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
@@ -43,8 +43,8 @@ import { IBigStepper } from "interfaces/dispute/IBigStepper.sol";
 /// before and after an upgrade.
 contract OPContractsManagerStandardValidator is ISemver {
     /// @notice The semantic version of the OPContractsManagerStandardValidator contract.
-    /// @custom:semver 2.9.0
-    string public constant version = "2.9.0";
+    /// @custom:semver 2.9.1
+    string public constant version = "2.9.1";
 
     /// @notice The SuperchainConfig contract.
     ISuperchainConfig public superchainConfig;


### PR DESCRIPTION
v1 dispute game support was removed in #18208; the function now only decodes v2 game args. Also fixes a stray `// @notice` so the comment is recognized as natspec.