### PR TITLE
fix(op-node/engine-controller): management of e.localSafeHead

### DIFF
--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -327,8 +327,10 @@ func (e *EngineController) SetLocalSafeHead(r eth.L2BlockRef) {
 	e.localSafeHead = r
 }
 
-// SetSafeHead sets the cross-safe head.
-func (e *EngineController) SetSafeHead(r eth.L2BlockRef) {
+// etDeprecatedSafeHead sets the cross-safe head.
+//
+// Deprecated: This is only used by supervisor pathways.
+func (e *EngineController) SetDeprecatedSafeHead(r eth.L2BlockRef) {
 	e.metrics.RecordL2Ref("l2_safe", r)
 	e.deprecatedSafeHead = r // TODO Supervisor-only code path
 }
@@ -473,28 +475,29 @@ func (e *EngineController) initializeUnknowns(ctx context.Context) error {
 		e.SetFinalizedHead(finalizedRef)
 		e.log.Info("Loaded initial finalized block ref", "finalized", finalizedRef)
 	}
-	if e.SafeL2Head() == (eth.L2BlockRef{}) {
+	if e.localSafeHead == (eth.L2BlockRef{}) {
 		ref, err := e.engine.L2BlockRefByLabel(ctx, eth.Safe)
 		if err != nil {
 			if errors.Is(err, ethereum.NotFound) {
 				// If the engine doesn't have a safe head, then we can use the finalized head
-				e.SetSafeHead(finalizedRef)
-				e.log.Info("Loaded initial cross-safe block from finalized", "cross_safe", finalizedRef)
+				e.SetLocalSafeHead(finalizedRef)
+				e.log.Info("Loaded initial local-safe block from finalized", "local_safe", finalizedRef)
 			} else {
-				return fmt.Errorf("failed to load cross-safe head: %w", err)
+				return fmt.Errorf("failed to load local-safe head: %w", err)
 			}
 		} else {
-			e.SetSafeHead(ref)
-			e.log.Info("Loaded initial cross-safe block ref", "cross_safe", ref)
+			e.SetLocalSafeHead(ref)
+			e.log.Info("Loaded initial local-safe block ref", "local_safe", ref)
 		}
+	}
+	if e.deprecatedSafeHead == (eth.L2BlockRef{}) {
+		// Set deprecatedSafeHead to match local-safe for supervisor-only code paths
+		e.SetDeprecatedSafeHead(e.localSafeHead)
+		e.log.Info("Set initial cross-safe block ref to match local-safe", "cross_safe", e.localSafeHead)
 	}
 	if e.crossUnsafeHead == (eth.L2BlockRef{}) {
 		e.SetCrossUnsafeHead(e.SafeL2Head()) // preserve cross-safety, don't fall back to a non-cross safety level
 		e.log.Info("Set initial cross-unsafe block ref to match cross-safe", "cross_unsafe", e.SafeL2Head())
-	}
-	if e.localSafeHead == (eth.L2BlockRef{}) {
-		e.SetLocalSafeHead(e.SafeL2Head())
-		e.log.Info("Set initial local-safe block ref to match cross-safe", "local_safe", e.SafeL2Head())
 	}
 	return nil
 }
@@ -639,7 +642,7 @@ func (e *EngineController) insertUnsafePayload(ctx context.Context, envelope *et
 		e.SetUnsafeHead(ref)
 		e.emitter.Emit(ctx, UnsafeUpdateEvent{Ref: ref})
 		e.SetLocalSafeHead(safeRef)
-		e.SetSafeHead(safeRef)
+		e.SetDeprecatedSafeHead(safeRef)
 		e.onSafeUpdate(ctx, safeRef, safeRef)
 		e.SetFinalizedHead(finalizedRef)
 	}
@@ -909,7 +912,7 @@ func (e *EngineController) tryUpdateUnsafe(ctx context.Context, ref eth.L2BlockR
 // or the next SyncStep).
 func (e *EngineController) PromoteSafe(ctx context.Context, ref eth.L2BlockRef, source eth.L1BlockRef) {
 	e.log.Debug("Updating safe", "safe", ref, "unsafe", e.unsafeHead)
-	e.SetSafeHead(ref)
+	e.SetDeprecatedSafeHead(ref)
 	// Finalizer can pick up this safe cross-block now
 	e.emitter.Emit(ctx, SafeDerivedEvent{Safe: ref, Source: source})
 	e.onSafeUpdate(ctx, e.SafeL2Head(), e.localSafeHead)

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -327,7 +327,7 @@ func (e *EngineController) SetLocalSafeHead(r eth.L2BlockRef) {
 	e.localSafeHead = r
 }
 
-// etDeprecatedSafeHead sets the cross-safe head.
+// SetDeprecatedSafeHead sets the cross-safe head.
 //
 // Deprecated: This is only used by supervisor pathways.
 func (e *EngineController) SetDeprecatedSafeHead(r eth.L2BlockRef) {

--- a/op-node/rollup/engine/engine_controller_test.go
+++ b/op-node/rollup/engine/engine_controller_test.go
@@ -313,7 +313,7 @@ func TestEngineController_SafeL2Head(t *testing.T) {
 				ec.SetLocalSafeHead(*tt.setupLocalSafe)
 			}
 			if tt.setupDeprecated != nil {
-				ec.SetSafeHead(*tt.setupDeprecated)
+				ec.SetDeprecatedSafeHead(*tt.setupDeprecated)
 			}
 
 			if tt.setupEngine != nil {
@@ -537,8 +537,8 @@ func TestFollowSource_DivergentLocalSafeAndCrossSafe(t *testing.T) {
 	// Initial state: unsafe=block5, localSafe=block2, crossSafe=block2, finalized=block1
 	ec.unsafeHead = block5
 	ec.SetLocalSafeHead(block2)
-	ec.SetSafeHead(block2)      // deprecatedSafeHead = block2
-	ec.SetFinalizedHead(block1) // deprecatedFinalizedHead = block1
+	ec.SetDeprecatedSafeHead(block2) // deprecatedSafeHead = block2
+	ec.SetFinalizedHead(block1)      // deprecatedFinalizedHead = block1
 	// Set lastForkchoice to match initial state so setup doesn't trigger FCU
 	ec.lastForkchoice = eth.ForkchoiceState{
 		HeadBlockHash:      block5.Hash,

--- a/op-node/rollup/engine/engine_controller_test.go
+++ b/op-node/rollup/engine/engine_controller_test.go
@@ -395,6 +395,86 @@ func TestEngineController_ForkchoiceUpdateUsesSuperAuthority(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestInitializeUnknowns_SetsLocalSafeHead_Regression is a regression test for a bug
+// where initializeUnknowns would fail to properly initialize localSafeHead on restart.
+//
+// The bug occurred because:
+// 1. SafeL2Head() returns localSafeHead when no supervisor/superAuthority is enabled
+// 2. But SetSafeHead() was setting deprecatedSafeHead, not localSafeHead
+// 3. So after loading the safe head from EL, localSafeHead remained zero
+//
+// Symptom: After restarting op-node + op-reth, safe head never advances.
+// The logs showed: "Set initial local-safe block ref to match cross-safe" local_safe=0x0000...0:0
+func TestInitializeUnknowns_SetsLocalSafeHead_Regression(t *testing.T) {
+	cfg := &rollup.Config{
+		Genesis: rollup.Genesis{
+			L2Time: 1000,
+		},
+		BlockTime: 2,
+	}
+
+	// Simulate restart scenario: EL has persisted state, CL starts fresh
+	unsafeRef := eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100}
+	safeRef := eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 80}
+	finalizedRef := eth.L2BlockRef{Hash: common.Hash{0xcc}, Number: 50}
+
+	mockEngine := &testutils.MockEngine{}
+	emitter := &testutils.MockEmitter{}
+
+	// No supervisor, no superAuthority - the standard non-interop case
+	ec := NewEngineController(
+		context.Background(),
+		mockEngine,
+		testlog.Logger(t, 0),
+		metrics.NoopMetrics,
+		cfg,
+		&sync.Config{},
+		false, // supervisorEnabled = false
+		&testutils.MockL1Source{},
+		emitter,
+		nil, // no superAuthority
+	)
+
+	// Verify initial state is zero (simulating fresh CL start)
+	require.Equal(t, eth.L2BlockRef{}, ec.localSafeHead, "localSafeHead should start as zero")
+	require.Equal(t, eth.L2BlockRef{}, ec.deprecatedSafeHead, "deprecatedSafeHead should start as zero")
+
+	// Mock EL returning persisted state (simulating restart with existing EL data)
+	mockEngine.ExpectL2BlockRefByLabel(eth.Unsafe, unsafeRef, nil)
+	mockEngine.ExpectL2BlockRefByLabel(eth.Finalized, finalizedRef, nil)
+	mockEngine.ExpectL2BlockRefByLabel(eth.Safe, safeRef, nil)
+
+	// Expect forkchoice update after initialization
+	emitter.ExpectOnceType("ForkchoiceUpdateEvent")
+	expectedFC := eth.ForkchoiceState{
+		HeadBlockHash:      unsafeRef.Hash,
+		SafeBlockHash:      safeRef.Hash, // Should use localSafeHead, not zero!
+		FinalizedBlockHash: finalizedRef.Hash,
+	}
+	mockEngine.ExpectForkchoiceUpdate(&expectedFC, nil, &eth.ForkchoiceUpdatedResult{
+		PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionValid},
+	}, nil)
+
+	// Run initialization via tryUpdateEngineInternal
+	err := ec.tryUpdateEngineInternal(context.Background())
+	require.NoError(t, err)
+
+	// THE KEY ASSERTION: localSafeHead must be properly set from EL's safe label
+	// Before the fix, this would be zero because SetSafeHead set deprecatedSafeHead instead
+	require.Equal(t, safeRef, ec.localSafeHead,
+		"localSafeHead must be initialized from EL safe label, not left as zero")
+
+	// Also verify SafeL2Head() returns the correct value (uses localSafeHead in non-supervisor mode)
+	require.Equal(t, safeRef, ec.SafeL2Head(),
+		"SafeL2Head() must return the initialized localSafeHead")
+
+	// Verify deprecatedSafeHead is also set (for backward compatibility)
+	require.Equal(t, safeRef, ec.deprecatedSafeHead,
+		"deprecatedSafeHead should also be set to match localSafeHead")
+
+	mockEngine.AssertExpectations(t)
+}
+
 // TestConsolidation_BatchesFCUPerL1Block verifies that on the consolidation path,
 // PromoteSafe does NOT trigger an FCU per L2 block. Instead, a single FCU is sent
 // when DeriverL1StatusEvent fires (at L1 origin transitions).

--- a/op-node/rollup/engine/events.go
+++ b/op-node/rollup/engine/events.go
@@ -130,7 +130,7 @@ type ResetEngineControl interface {
 	SetUnsafeHead(eth.L2BlockRef)
 	SetCrossUnsafeHead(ref eth.L2BlockRef)
 	SetLocalSafeHead(ref eth.L2BlockRef)
-	SetSafeHead(eth.L2BlockRef)
+	SetDeprecatedSafeHead(eth.L2BlockRef)
 	SetFinalizedHead(eth.L2BlockRef)
 	SetBackupUnsafeL2Head(block eth.L2BlockRef, triggerReorg bool)
 	SetPendingSafeL2Head(eth.L2BlockRef)
@@ -147,7 +147,7 @@ func ForceEngineReset(ec ResetEngineControl, localUnsafe, crossUnsafe, localSafe
 	ec.SetPendingSafeL2Head(localSafe)
 
 	// "safe" in RPC terms is cross-safe
-	ec.SetSafeHead(crossSafe)
+	ec.SetDeprecatedSafeHead(crossSafe)
 
 	// finalized head
 	ec.SetFinalizedHead(finalized)


### PR DESCRIPTION
in initializeUnknowns.

* Fix `initializeUnknowns` to set `localSafeHead` to a nonzero ref rather than to `e.SafeL2Head()` which would erroneously just set it to zero again.
* Rename `SetSafeHead` to `SetDeprecatedSafeHead`
* Mark the method as deprecated for supervisor-only pathways.
* Add regression test.