### PR TITLE
feat(sdm): acceptance tests coverage; SDM post-exec replay RPC, tooling

### DIFF
--- a/op-acceptance-tests/tests/sdm/block_test.go
+++ b/op-acceptance-tests/tests/sdm/block_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/eth/safety"
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
-	suptypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -460,8 +460,8 @@ func testSDMPostExecBlockDerivesAndChainProgresses(t devtest.T, batchType string
 	l1BeforeBatching := sys.L1EL.BlockRefByLabel(eth.Unsafe)
 	sys.L2Batcher.Start()
 	dsl.CheckAll(t,
-		sys.L2CL.ReachedRefFn(suptypes.CrossSafe, sentinelRef.ID(), 120),
-		sys.L2CLVerifier.ReachedRefFn(suptypes.CrossSafe, sentinelRef.ID(), 120),
+		sys.L2CL.ReachedRefFn(safety.CrossSafe, sentinelRef.ID(), 120),
+		sys.L2CLVerifier.ReachedRefFn(safety.CrossSafe, sentinelRef.ID(), 120),
 		sys.L2EL.ReachedFn(eth.Safe, sentinelBlockNum, 120),
 		sys.L2ELVerifier.ReachedFn(eth.Safe, sentinelBlockNum, 120),
 	)

--- a/op-acceptance-tests/tests/sdm/block_test.go
+++ b/op-acceptance-tests/tests/sdm/block_test.go
@@ -1,0 +1,842 @@
+package sdm
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/pkg/sdmreplay"
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/txplan"
+	suptypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+// rpcTransaction is a minimal representation of a transaction from eth_getBlockByNumber
+// with full transactions. We use raw JSON to avoid depending on op-geth types for deposit
+// fields that may differ between op-geth and op-reth RPC responses.
+type rpcTransaction struct {
+	Hash  common.Hash    `json:"hash"`
+	Type  hexutil.Uint64 `json:"type"`
+	Input hexutil.Bytes  `json:"input"`
+}
+
+// rpcBlock is a minimal representation of a block from eth_getBlockByNumber(n, true).
+type rpcBlock struct {
+	Number       hexutil.Uint64   `json:"number"`
+	Hash         common.Hash      `json:"hash"`
+	GasUsed      hexutil.Uint64   `json:"gasUsed"`
+	Transactions []rpcTransaction `json:"transactions"`
+}
+
+type replaySdmRefundEvent struct {
+	ClaimingReplayTxIndex      uint64         `json:"claiming_replay_tx_index"`
+	ClaimingTxIndex            uint64         `json:"claiming_tx_index"`
+	Kind                       string         `json:"kind"`
+	Amount                     uint64         `json:"amount"`
+	Address                    common.Address `json:"address"`
+	Slot                       *common.Hash   `json:"slot"`
+	FirstWarmedByReplayTxIndex uint64         `json:"first_warmed_by_replay_tx_index"`
+	FirstWarmedByTxIndex       uint64         `json:"first_warmed_by_tx_index"`
+}
+
+type replaySdmTx struct {
+	TxIndex            uint64                 `json:"tx_index"`
+	ReplayTxIndex      uint64                 `json:"replay_tx_index"`
+	TxHash             common.Hash            `json:"tx_hash"`
+	TxType             uint64                 `json:"tx_type"`
+	IsDepositTx        bool                   `json:"is_deposit_tx"`
+	RawGasUsed         uint64                 `json:"raw_gas_used"`
+	CanonicalGasUsed   uint64                 `json:"canonical_gas_used"`
+	OPGasRefundReplay  uint64                 `json:"op_gas_refund_replay"`
+	OPGasRefundPayload *uint64                `json:"op_gas_refund_payload"`
+	RefundBreakdown    []replaySdmRefundEvent `json:"refund_breakdown"`
+	Mismatch           bool                   `json:"mismatch"`
+}
+
+type replaySdmMismatch struct {
+	Category string  `json:"category"`
+	BlockNum uint64  `json:"block_num"`
+	TxIndex  *uint64 `json:"tx_index"`
+	Expected *uint64 `json:"expected"`
+	Actual   *uint64 `json:"actual"`
+	Message  string  `json:"message"`
+}
+
+type replaySdmSummary struct {
+	BlockNum                  uint64      `json:"block_num"`
+	BlockHash                 common.Hash `json:"block_hash"`
+	TxCountTotal              int         `json:"tx_count_total"`
+	TxCountUser               int         `json:"tx_count_user"`
+	PostExecTxPresent         bool        `json:"post_exec_tx_present"`
+	PostExecPayloadEntryCount int         `json:"post_exec_payload_entry_count"`
+	BlockGasUsed              uint64      `json:"block_gas_used"`
+	BlockRawGasUsed           uint64      `json:"block_raw_gas_used"`
+	ReplayRefundTotal         uint64      `json:"replay_refund_total"`
+	PayloadRefundTotal        uint64      `json:"payload_refund_total"`
+	MismatchCount             int         `json:"mismatch_count"`
+}
+
+type replaySdmBlock struct {
+	BlockNum                uint64                     `json:"block_num"`
+	BlockHash               common.Hash                `json:"block_hash"`
+	ParentHash              common.Hash                `json:"parent_hash"`
+	PostExecTxPresent       bool                       `json:"post_exec_tx_present"`
+	PostExecTxIndex         *uint64                    `json:"post_exec_tx_index"`
+	EmbeddedPayload         *sdmreplay.PostExecPayload `json:"embedded_payload"`
+	SynthesizedPayload      sdmreplay.PostExecPayload  `json:"synthesized_payload"`
+	SynthesizedPayloadBytes hexutil.Bytes              `json:"synthesized_payload_bytes"`
+	Txs                     []replaySdmTx              `json:"txs"`
+	Mismatches              []replaySdmMismatch        `json:"mismatches"`
+	Summary                 replaySdmSummary           `json:"summary"`
+}
+
+// getBlockWithTxs fetches a block by number with full transaction objects via raw JSON RPC.
+func getBlockWithTxs(t devtest.T, l2EL *dsl.L2ELNode, blockNum uint64) *rpcBlock {
+	rpcClient := l2EL.Escape().L2EthClient().RPC()
+	var raw json.RawMessage
+	err := rpcClient.CallContext(t.Ctx(), &raw, "eth_getBlockByNumber",
+		fmt.Sprintf("0x%x", blockNum), true)
+	t.Require().NoError(err, "eth_getBlockByNumber RPC failed for block %d", blockNum)
+	t.Require().NotNil(raw, "block %d not found", blockNum)
+
+	var block rpcBlock
+	err = json.Unmarshal(raw, &block)
+	t.Require().NoError(err, "failed to unmarshal block %d", blockNum)
+	return &block
+}
+
+func replayBlockWithSDM(t devtest.T, l2EL *dsl.L2ELNode, blockNum uint64) *replaySdmBlock {
+	rpcClient := l2EL.Escape().L2EthClient().RPC()
+	var raw json.RawMessage
+	err := rpcClient.CallContext(t.Ctx(), &raw, "debug_replaySDMBlock",
+		fmt.Sprintf("0x%x", blockNum),
+		map[string]bool{
+			"compare_payload": true,
+		},
+	)
+	t.Require().NoError(err, "debug_replaySDMBlock RPC failed for block %d", blockNum)
+	t.Require().NotNil(raw, "replay result for block %d must not be nil", blockNum)
+
+	var replay replaySdmBlock
+	err = json.Unmarshal(raw, &replay)
+	t.Require().NoError(err, "failed to unmarshal replay result for block %d", blockNum)
+	return &replay
+}
+
+// findPostExecTransaction searches for the post-exec tx anywhere in the block.
+// Returns the transaction and its position if found, nil/-1 otherwise.
+// The post-exec tx is identified purely by type 0x7D.
+func findPostExecTransaction(block *rpcBlock) (*rpcTransaction, int) {
+	for i := range block.Transactions {
+		tx := &block.Transactions[i]
+		if uint64(tx.Type) != sdmreplay.SDMTxType {
+			continue
+		}
+		return tx, i
+	}
+	return nil, -1
+}
+
+func mustFindReplayTxByHash(t devtest.T, replay *replaySdmBlock, txHash common.Hash) *replaySdmTx {
+	for i := range replay.Txs {
+		if replay.Txs[i].TxHash == txHash {
+			return &replay.Txs[i]
+		}
+	}
+
+	t.Require().FailNowf("replay tx missing", "tx %s not found in replay for block %d", txHash, replay.BlockNum)
+	return nil
+}
+
+// submitTxWithoutWait sends a transaction to the mempool without waiting for inclusion.
+// Returns the PlannedTx whose Included field can be evaluated later.
+// The caller must provide a nonce to avoid the default PendingNonce lookup racing between txs.
+func submitTxWithoutWait(
+	t devtest.T,
+	alice *dsl.EOA,
+	nonce uint64,
+	opts ...txplan.Option,
+) *txplan.PlannedTx {
+	combined := append([]txplan.Option{
+		alice.Plan(),
+		txplan.WithNonce(nonce),
+	}, opts...)
+	ptx := txplan.NewPlannedTx(combined...)
+	_, err := ptx.Submitted.Eval(t.Ctx())
+	t.Require().NoError(err, "failed to submit tx with nonce %d", nonce)
+	return ptx
+}
+
+type includedTx struct {
+	receipt  *types.Receipt
+	blockNum uint64
+}
+
+func mustFindRepeatedSlotBlock(
+	t devtest.T,
+	sys *sdmRethSystem,
+	minUserTxs int,
+	maxAttempts int,
+) (*rpcBlock, []includedTx, uint64) {
+	l := t.Logger()
+
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		alice := sys.FunderL2.NewFundedEOA(eth.OneEther)
+		stateBloatAddr := deployContract(t, alice, stateBloatBin)
+
+		const batchSize = 50
+		const slotCount = 20
+		startNonce := alice.PendingNonce()
+		plannedTxs := make([]*txplan.PlannedTx, 0, batchSize)
+
+		l.Info("Submitting repeated-slot workload",
+			"attempt", attempt,
+			"alice", alice.Address(),
+			"contract", stateBloatAddr,
+			"startNonce", startNonce,
+			"batchSize", batchSize,
+			"slotCount", slotCount)
+
+		for i := 0; i < batchSize; i++ {
+			nonce := startNonce + uint64(i)
+			plannedTxs = append(plannedTxs, submitTxWithoutWait(
+				t,
+				alice,
+				nonce,
+				txplan.WithTo(addrPtr(stateBloatAddr)),
+				txplan.WithData(encodeRun(slotCount)),
+				txplan.WithGasLimit(1_000_000),
+			))
+		}
+
+		blockTxs := make(map[uint64][]includedTx)
+		for i, ptx := range plannedTxs {
+			receipt, err := ptx.Included.Eval(t.Ctx())
+			t.Require().NoError(err, "attempt %d tx %d: failed to get receipt", attempt, i)
+			t.Require().Equal(types.ReceiptStatusSuccessful, receipt.Status,
+				"attempt %d tx %d: must succeed", attempt, i)
+
+			itx := includedTx{receipt: receipt, blockNum: bigs.Uint64Strict(receipt.BlockNumber)}
+			blockTxs[itx.blockNum] = append(blockTxs[itx.blockNum], itx)
+		}
+
+		var targetBlockNum uint64
+		var targetIncluded []includedTx
+		for blockNum, txs := range blockTxs {
+			if len(txs) > len(targetIncluded) {
+				targetBlockNum = blockNum
+				targetIncluded = txs
+			}
+		}
+		if len(targetIncluded) < minUserTxs {
+			l.Warn("Repeated-slot workload did not produce a dense-enough block",
+				"attempt", attempt,
+				"requiredUserTxs", minUserTxs,
+				"bestUserTxs", len(targetIncluded),
+				"bestBlock", targetBlockNum)
+			continue
+		}
+
+		block := getBlockWithTxs(t, sys.L2EL, targetBlockNum)
+		t.Require().Greater(len(block.Transactions), 0, "block must have at least one transaction")
+		t.Require().Equal(uint64(types.DepositTxType), uint64(block.Transactions[0].Type),
+			"position 0 must be a deposit tx (L1 info)")
+		return block, targetIncluded, targetBlockNum
+	}
+
+	t.Require().FailNowf("repeated-slot workload failed",
+		"no block with at least %d user txs found after %d attempts", minUserTxs, maxAttempts)
+	return nil, nil, 0
+}
+
+func TestSDMDisabledNoRefunds(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := newSDMRethSystem(t, false)
+	verifyOpReth(t, sys.L2EL)
+
+	block, included, targetBlockNum := mustFindRepeatedSlotBlock(t, sys, 2, 3)
+	t.Require().GreaterOrEqual(len(included), 2, "target block must contain multiple user txs")
+
+	postExecTx, _ := findPostExecTransaction(block)
+	t.Require().Nil(postExecTx, "SDM-disabled sequencer must not include a post-exec tx")
+
+	for _, itx := range included {
+		refund, present := getOPGasRefund(t, sys.L2EL, itx.receipt.TxHash)
+		t.Require().False(present, "legacy block %d tx %s must not expose opGasRefund",
+			targetBlockNum, itx.receipt.TxHash)
+		t.Require().Zero(refund, "absent opGasRefund must decode to zero")
+	}
+}
+
+func TestSDMEnabledPayloadAndReplayMatch(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := newSDMRethSystem(t, true)
+	verifyOpReth(t, sys.L2EL)
+
+	block, included, targetBlockNum := mustFindRepeatedSlotBlock(t, sys, 2, 3)
+	postExecTx, postExecPos := findPostExecTransaction(block)
+	t.Require().NotNil(postExecTx, "SDM-enabled sequencer must include a post-exec tx")
+	t.Require().Greater(len(postExecTx.Input), 0, "post-exec tx input must not be empty")
+	t.Require().Equal(uint64(sdmreplay.SDMTxType), uint64(postExecTx.Type), "post-exec tx type must be 0x7D")
+
+	payload, err := sdmreplay.DecodePayload(postExecTx.Input)
+	t.Require().NoError(err, "post-exec payload must decode")
+	t.Require().Equal(sdmreplay.PostExecPayloadVersion, payload.Version, "post-exec payload version must be 1")
+	t.Require().NotEmpty(payload.GasRefundEntries, "post-exec payload must be non-empty for repeated-slot workload")
+
+	receiptByHash := make(map[common.Hash]*types.Receipt, len(included))
+	hasNonZeroReceiptRefund := false
+	for _, itx := range included {
+		receiptByHash[itx.receipt.TxHash] = itx.receipt
+		refund, _ := getOPGasRefund(t, sys.L2EL, itx.receipt.TxHash)
+		if refund > 0 {
+			hasNonZeroReceiptRefund = true
+		}
+	}
+	t.Require().True(hasNonZeroReceiptRefund, "at least one repeated-slot tx must have non-zero opGasRefund")
+
+	for _, entry := range payload.GasRefundEntries {
+		t.Require().Less(int(entry.Index), len(block.Transactions), "payload index must be in block range")
+		targetTx := block.Transactions[entry.Index]
+		t.Require().NotEqual(uint64(types.DepositTxType), uint64(targetTx.Type), "payload must not target deposits")
+		t.Require().NotEqual(uint64(sdmreplay.SDMTxType), uint64(targetTx.Type), "payload must not target the SDM tx itself")
+
+		refund, present := getOPGasRefund(t, sys.L2EL, targetTx.Hash)
+		t.Require().True(present, "SDM receipt must expose opGasRefund for tx index %d", entry.Index)
+		t.Require().Equal(entry.GasRefund, refund,
+			"payload refund must match receipt opGasRefund for tx index %d", entry.Index)
+	}
+
+	replay := replayBlockWithSDM(t, sys.L2EL, targetBlockNum)
+	t.Require().Equal(targetBlockNum, replay.BlockNum, "replay must target the selected block")
+	t.Require().Equal(block.Hash, replay.BlockHash, "replay block hash must match source block")
+	t.Require().True(replay.PostExecTxPresent, "replay must report the post-exec tx in the source block")
+	t.Require().NotNil(replay.PostExecTxIndex, "replay must report the post-exec tx index")
+	t.Require().Equal(uint64(postExecPos), *replay.PostExecTxIndex, "replay post-exec tx index must match source block")
+	t.Require().Equal(len(block.Transactions)-1, len(replay.Txs),
+		"replay must strip the post-exec tx and preserve the remaining tx ordering")
+	t.Require().Empty(replay.Mismatches, "canonical post-exec block should replay without mismatches")
+	t.Require().Equal(len(replay.SynthesizedPayload.GasRefundEntries), replay.Summary.PostExecPayloadEntryCount,
+		"summary payload entry count must match synthesized payload")
+
+	expectedOriginalIndexes := make([]uint64, 0, len(block.Transactions)-1)
+	for i := range block.Transactions {
+		if i == postExecPos {
+			continue
+		}
+		expectedOriginalIndexes = append(expectedOriginalIndexes, uint64(i))
+	}
+
+	replayRefundByIndex := make(map[uint64]uint64, len(replay.Txs))
+	hasReplayRefund := false
+	for i, tx := range replay.Txs {
+		t.Require().Equal(uint64(i), tx.ReplayTxIndex, "replay tx indexes must be sequential")
+		t.Require().Equal(expectedOriginalIndexes[i], tx.TxIndex,
+			"replay tx %d must preserve original block index", i)
+
+		sourceTx := block.Transactions[tx.TxIndex]
+		t.Require().Equal(sourceTx.Hash, tx.TxHash, "replay tx hash must match source tx at index %d", tx.TxIndex)
+		t.Require().Equal(uint64(sourceTx.Type), tx.TxType, "replay tx type must match source tx at index %d", tx.TxIndex)
+		t.Require().Equal(uint64(types.DepositTxType) == uint64(sourceTx.Type), tx.IsDepositTx,
+			"deposit classification must match source tx at index %d", tx.TxIndex)
+		t.Require().Equal(tx.RawGasUsed, tx.CanonicalGasUsed+tx.OPGasRefundReplay,
+			"raw gas must equal canonical gas plus refund at tx index %d", tx.TxIndex)
+
+		if tx.OPGasRefundReplay > 0 {
+			hasReplayRefund = true
+		}
+		replayRefundByIndex[tx.TxIndex] = tx.OPGasRefundReplay
+
+		if tx.OPGasRefundPayload != nil {
+			t.Require().Equal(*tx.OPGasRefundPayload, tx.OPGasRefundReplay,
+				"payload refund must match replay refund at tx index %d", tx.TxIndex)
+		}
+		if receipt, ok := receiptByHash[tx.TxHash]; ok {
+			t.Require().Equal(receipt.GasUsed, tx.CanonicalGasUsed,
+				"receipt gasUsed must already be canonical for tx %s", tx.TxHash)
+			if refund, _ := getOPGasRefund(t, sys.L2EL, tx.TxHash); refund > 0 {
+				t.Require().Greater(tx.RawGasUsed, receipt.GasUsed,
+					"raw gas must exceed receipt gas when refund is non-zero for tx %s", tx.TxHash)
+			}
+		}
+	}
+	t.Require().True(hasReplayRefund, "replay must produce non-zero refunds for repeated-slot block")
+
+	var totalReplayRefund uint64
+	for _, entry := range replay.SynthesizedPayload.GasRefundEntries {
+		sourceTx := block.Transactions[entry.Index]
+		refund, present := getOPGasRefund(t, sys.L2EL, sourceTx.Hash)
+		t.Require().True(present, "SDM receipt must expose opGasRefund for tx index %d", entry.Index)
+		t.Require().Equal(refund, entry.GasRefund,
+			"synthesized payload refund must match receipt opGasRefund for tx index %d", entry.Index)
+		t.Require().Equal(entry.GasRefund, replayRefundByIndex[entry.Index],
+			"synthesized payload refund must match replay tx refund for tx index %d", entry.Index)
+		totalReplayRefund += entry.GasRefund
+	}
+	t.Require().Equal(totalReplayRefund, replay.Summary.ReplayRefundTotal,
+		"summary replay refund total must match synthesized payload")
+	t.Require().Equal(totalReplayRefund, replay.Summary.PayloadRefundTotal,
+		"summary payload refund total must match synthesized payload")
+	t.Require().Equal(uint64(block.GasUsed), replay.Summary.BlockGasUsed,
+		"block gasUsed must already be canonical")
+	t.Require().Equal(replay.Summary.BlockRawGasUsed,
+		replay.Summary.BlockGasUsed+replay.Summary.ReplayRefundTotal,
+		"raw block gas must equal canonical block gas plus total refund")
+
+	dsl.CheckAll(t,
+		sys.L2EL.AdvancedFn(eth.Unsafe, 10),
+		sys.L2ELVerifier.AdvancedFn(eth.Unsafe, 10),
+	)
+
+	t.Logger().Info("TestSDMEnabledPayloadAndReplayMatch passed",
+		"block_num", targetBlockNum,
+		"block_hash", block.Hash,
+		"user_txs", len(included),
+		"post_exec_tx_index", postExecPos,
+		"payload_entries", len(payload.GasRefundEntries),
+		"replay_refund_total", replay.Summary.ReplayRefundTotal,
+		"block_gas_used", replay.Summary.BlockGasUsed,
+		"block_raw_gas_used", replay.Summary.BlockRawGasUsed)
+}
+
+func TestSDMPostExecBlockDerivesAndChainProgresses(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	for _, testCase := range []struct {
+		name     string
+		singular bool
+	}{
+		{name: "span_batch"},
+		{name: "singular_batch", singular: true},
+	} {
+		t.Run(testCase.name, func(t devtest.T) {
+			testSDMPostExecBlockDerivesAndChainProgresses(t, testCase.name, testCase.singular)
+		})
+	}
+}
+
+func testSDMPostExecBlockDerivesAndChainProgresses(t devtest.T, batchType string, singular bool) {
+	var sys *sdmRethSystem
+	if singular {
+		sys = newSDMRethSystemWithBatcherOptions(t, true, withSingularBatcher)
+	} else {
+		// Use the default SpanBatch path to verify post-exec txs derive after batching.
+		sys = newSDMRethSystem(t, true)
+	}
+	verifyOpReth(t, sys.L2EL)
+	verifyOpReth(t, sys.L2ELVerifier)
+
+	block, included, targetBlockNum := mustFindRepeatedSlotBlock(t, sys, 2, 3)
+	t.Require().NotEmpty(included, "target block must include workload transactions")
+	postExecTx, postExecPos := findPostExecTransaction(block)
+	t.Require().NotNil(postExecTx, "SDM-enabled sequencer must include a post-exec tx before batching")
+	t.Require().Greater(len(postExecTx.Input), 0, "post-exec tx input must not be empty")
+
+	payload, err := sdmreplay.DecodePayload(postExecTx.Input)
+	t.Require().NoError(err, "post-exec payload must decode before derivation")
+	t.Require().NotEmpty(payload.GasRefundEntries, "post-exec payload must be non-empty for repeated-slot workload")
+	targetRef := sys.L2EL.BlockRefByNumber(targetBlockNum)
+	t.Require().Equal(block.Hash, targetRef.Hash, "selected post-exec block hash must match canonical sequencer block")
+
+	alice := sys.FunderL2.NewFundedEOA(eth.OneEther)
+	sentinel := txplan.NewPlannedTx(
+		alice.Plan(),
+		txplan.WithTo(addrPtr(common.HexToAddress("0x000000000000000000000000000000000000dEaD"))),
+		txplan.WithValue(eth.OneHundredthEther),
+	)
+	sentinelReceipt, err := sentinel.Included.Eval(t.Ctx())
+	t.Require().NoError(err, "sentinel tx after the post-exec block must be included")
+	t.Require().Equal(types.ReceiptStatusSuccessful, sentinelReceipt.Status, "sentinel tx must succeed")
+	sentinelBlockNum := bigs.Uint64Strict(sentinelReceipt.BlockNumber)
+	t.Require().Greater(sentinelBlockNum, targetBlockNum,
+		"sentinel tx must land after the post-exec block so derivation proves chain progress past it")
+	sentinelRef := sys.L2EL.BlockRefByNumber(sentinelBlockNum)
+
+	l1BeforeBatching := sys.L1EL.BlockRefByLabel(eth.Unsafe)
+	sys.L2Batcher.Start()
+	dsl.CheckAll(t,
+		sys.L2CL.ReachedRefFn(suptypes.CrossSafe, sentinelRef.ID(), 120),
+		sys.L2CLVerifier.ReachedRefFn(suptypes.CrossSafe, sentinelRef.ID(), 120),
+		sys.L2EL.ReachedFn(eth.Safe, sentinelBlockNum, 120),
+		sys.L2ELVerifier.ReachedFn(eth.Safe, sentinelBlockNum, 120),
+	)
+	l1AfterBatching := sys.L1EL.BlockRefByLabel(eth.Unsafe)
+	t.Require().Greater(l1AfterBatching.Number, l1BeforeBatching.Number,
+		"L1 must advance while the batch containing the post-exec block is submitted")
+
+	verifierPostExecRef := sys.L2ELVerifier.BlockRefByNumber(targetBlockNum)
+	t.Require().Equal(targetRef.Hash, verifierPostExecRef.Hash,
+		"verifier must derive the same post-exec block as the sequencer")
+	verifierSentinelRef := sys.L2ELVerifier.BlockRefByNumber(sentinelBlockNum)
+	t.Require().Equal(sentinelRef.Hash, verifierSentinelRef.Hash,
+		"verifier must derive blocks after the post-exec block")
+
+	sequencerStatus := sys.L2CL.SyncStatus()
+	verifierStatus := sys.L2CLVerifier.SyncStatus()
+	sequencerSafeRef := sys.L2EL.BlockRefByLabel(eth.Safe)
+	sequencerFinalizedRef := sys.L2EL.BlockRefByLabel(eth.Finalized)
+	verifierSafeRef := sys.L2ELVerifier.BlockRefByLabel(eth.Safe)
+	verifierFinalizedRef := sys.L2ELVerifier.BlockRefByLabel(eth.Finalized)
+	t.Require().GreaterOrEqual(sequencerStatus.SafeL2.Number, sentinelBlockNum,
+		"sequencer SyncStatus safe head must reach the sentinel block")
+	t.Require().GreaterOrEqual(verifierStatus.SafeL2.Number, sentinelBlockNum,
+		"verifier SyncStatus safe head must reach the sentinel block")
+	t.Require().GreaterOrEqual(sequencerSafeRef.Number, sentinelBlockNum,
+		"sequencer EL safe head must reach the sentinel block")
+	t.Require().GreaterOrEqual(verifierSafeRef.Number, sentinelBlockNum,
+		"verifier EL safe head must reach the sentinel block")
+	t.Require().LessOrEqual(sequencerStatus.FinalizedL2.Number, sequencerStatus.SafeL2.Number,
+		"sequencer SyncStatus finalized head must not be ahead of safe head")
+	t.Require().LessOrEqual(verifierStatus.FinalizedL2.Number, verifierStatus.SafeL2.Number,
+		"verifier SyncStatus finalized head must not be ahead of safe head")
+	t.Require().LessOrEqual(sequencerFinalizedRef.Number, sequencerSafeRef.Number,
+		"sequencer EL finalized head must not be ahead of safe head")
+	t.Require().LessOrEqual(verifierFinalizedRef.Number, verifierSafeRef.Number,
+		"verifier EL finalized head must not be ahead of safe head")
+
+	var totalSDMRefund uint64
+	for _, entry := range payload.GasRefundEntries {
+		totalSDMRefund += entry.GasRefund
+	}
+	t.Logger().Info("post exec block num",
+		"batch_type", batchType,
+		"block_num", targetBlockNum,
+		"block_hash", targetRef.Hash)
+	t.Logger().Info("post exec tx",
+		"batch_type", batchType,
+		"tx_hash", postExecTx.Hash,
+		"tx_index", postExecPos,
+		"tx_type", postExecTx.Type,
+		"payload_bytes", len(postExecTx.Input))
+	t.Logger().Info("printed SDMGasEntries",
+		"batch_type", batchType,
+		"entries", payload.GasRefundEntries,
+		"entry_count", len(payload.GasRefundEntries),
+		"total_sdm_refund", totalSDMRefund)
+	t.Logger().Info("L2SafeBlock",
+		"batch_type", batchType,
+		"post_exec_block_is_safe", sequencerSafeRef.Number >= targetBlockNum && verifierSafeRef.Number >= targetBlockNum,
+		"sequencer_safe_block", sequencerSafeRef.ID(),
+		"verifier_safe_block", verifierSafeRef.ID(),
+		"post_exec_block", targetRef.ID(),
+		"sentinel_block", sentinelRef.ID())
+
+	t.Logger().Info("TestSDMPostExecBlockDerivesAndChainProgresses passed",
+		"batch_type", batchType,
+		"post_exec_block", targetBlockNum,
+		"post_exec_block_hash", targetRef.Hash,
+		"post_exec_tx_index", postExecPos,
+		"payload_entries", len(payload.GasRefundEntries),
+		"sentinel_block", sentinelBlockNum,
+		"sentinel_block_hash", sentinelRef.Hash,
+		"sequencer_sync_status", sequencerStatus,
+		"verifier_sync_status", verifierStatus,
+		"sequencer_safe_head", sequencerSafeRef.ID(),
+		"sequencer_finalized_head", sequencerFinalizedRef.ID(),
+		"verifier_safe_head", verifierSafeRef.ID(),
+		"verifier_finalized_head", verifierFinalizedRef.ID(),
+		"l1_before_batching", l1BeforeBatching.ID(),
+		"l1_after_batching", l1AfterBatching.ID())
+}
+
+func TestSDMStorageRefundBreakdown(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := newSDMRethSystem(t, true)
+	verifyOpReth(t, sys.L2EL)
+
+	const (
+		sameSlotTouches = 100
+		manySlotTouches = 100
+		maxAttempts     = 3
+	)
+
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		alice := sys.FunderL2.NewFundedEOA(eth.OneEther)
+		contract := deployContract(t, alice, slotTouchBin)
+		startNonce := alice.PendingNonce()
+
+		planned := []*txplan.PlannedTx{
+			submitTxWithoutWait(
+				t,
+				alice,
+				startNonce,
+				txplan.WithTo(addrPtr(contract)),
+				txplan.WithData(encodeHitSameSlot(1)),
+				txplan.WithGasLimit(300_000),
+			),
+			submitTxWithoutWait(
+				t,
+				alice,
+				startNonce+1,
+				txplan.WithTo(addrPtr(contract)),
+				txplan.WithData(encodeHitSameSlot(sameSlotTouches)),
+				txplan.WithGasLimit(1_500_000),
+			),
+			submitTxWithoutWait(
+				t,
+				alice,
+				startNonce+2,
+				txplan.WithTo(addrPtr(contract)),
+				txplan.WithData(encodeHitManySlots(manySlotTouches)),
+				txplan.WithGasLimit(3_000_000),
+			),
+			submitTxWithoutWait(
+				t,
+				alice,
+				startNonce+3,
+				txplan.WithTo(addrPtr(contract)),
+				txplan.WithData(encodeHitManySlots(manySlotTouches)),
+				txplan.WithGasLimit(3_000_000),
+			),
+		}
+
+		receipts := make([]*types.Receipt, len(planned))
+		for i, ptx := range planned {
+			receipt, err := ptx.Included.Eval(t.Ctx())
+			t.Require().NoError(err, "attempt %d tx %d: failed to get receipt", attempt, i)
+			t.Require().Equal(types.ReceiptStatusSuccessful, receipt.Status,
+				"attempt %d tx %d: must succeed", attempt, i)
+			receipts[i] = receipt
+		}
+
+		sameWarmBlock := bigs.Uint64Strict(receipts[0].BlockNumber)
+		sameClaimBlock := bigs.Uint64Strict(receipts[1].BlockNumber)
+		manyWarmBlock := bigs.Uint64Strict(receipts[2].BlockNumber)
+		manyClaimBlock := bigs.Uint64Strict(receipts[3].BlockNumber)
+		if sameWarmBlock != sameClaimBlock || manyWarmBlock != manyClaimBlock {
+			t.Logger().Warn("slot-touch workload pairs split across blocks; retrying",
+				"attempt", attempt,
+				"sameWarmBlock", sameWarmBlock,
+				"sameClaimBlock", sameClaimBlock,
+				"manyWarmBlock", manyWarmBlock,
+				"manyClaimBlock", manyClaimBlock)
+			continue
+		}
+
+		sameRefund, sameRefundPresent := getOPGasRefund(t, sys.L2EL, receipts[1].TxHash)
+		t.Require().True(sameRefundPresent, "SDM receipt must expose opGasRefund for repeated same-slot tx")
+		sameReplay := replayBlockWithSDM(t, sys.L2EL, sameClaimBlock)
+		sameTx := mustFindReplayTxByHash(t, sameReplay, receipts[1].TxHash)
+		t.Require().Equal(sameRefund, sameTx.OPGasRefundReplay,
+			"replay refund must match receipt refund for repeated same-slot tx")
+
+		var sameSlotSstoreEvents int
+		var sameSlotSstoreRefund uint64
+		for i, event := range sameTx.RefundBreakdown {
+			if event.Kind != "warm_sstore" {
+				continue
+			}
+			t.Require().Equal(uint64(2100), event.Amount, "same-slot warm SSTORE event %d must be 2100 gas", i)
+			t.Require().NotNil(event.Slot, "same-slot warm SSTORE event %d must identify the touched slot", i)
+			sameSlotSstoreEvents++
+			sameSlotSstoreRefund += event.Amount
+		}
+		t.Require().Equal(1, sameSlotSstoreEvents,
+			"repeating the same warmed storage slot %d times should only produce one warm SSTORE refund event", sameSlotTouches)
+		t.Require().Equal(uint64(2100), sameSlotSstoreRefund,
+			"repeating the same warmed storage slot should only rebate one warm SSTORE access")
+
+		manyRefund, manyRefundPresent := getOPGasRefund(t, sys.L2EL, receipts[3].TxHash)
+		t.Require().True(manyRefundPresent, "SDM receipt must expose opGasRefund for many-slot tx")
+		manyReplay := replayBlockWithSDM(t, sys.L2EL, manyClaimBlock)
+		manyTx := mustFindReplayTxByHash(t, manyReplay, receipts[3].TxHash)
+		t.Require().Equal(manyRefund, manyTx.OPGasRefundReplay,
+			"replay refund must match receipt refund for many-slot tx")
+
+		var totalBreakdown uint64
+		var manySlotSstoreEvents int
+		var manySlotSstoreRefund uint64
+		for i, event := range manyTx.RefundBreakdown {
+			totalBreakdown += event.Amount
+			if event.Kind != "warm_sstore" {
+				continue
+			}
+			t.Require().Equal(uint64(2100), event.Amount, "warm SSTORE refund event %d must be 2100 gas", i)
+			t.Require().NotNil(event.Slot, "warm SSTORE refund event %d must identify the warmed slot", i)
+			manySlotSstoreEvents++
+			manySlotSstoreRefund += event.Amount
+		}
+		t.Require().Equal(manySlotTouches, manySlotSstoreEvents,
+			"touching %d distinct warmed slots should produce %d warm SSTORE refund events", manySlotTouches, manySlotTouches)
+		t.Require().Equal(uint64(2100*manySlotTouches), manySlotSstoreRefund,
+			"distinct warmed slots should rebate 2100 gas each")
+		t.Require().Equal(manyRefund, totalBreakdown,
+			"sum of many-slot refund events must equal the receipt-level refund")
+		t.Require().Greater(manyRefund, manyTx.RawGasUsed/5,
+			"SDM refunds are not capped at the EIP-3529 20%% rule once applied canonically")
+		t.Require().Equal(receipts[3].GasUsed, manyTx.CanonicalGasUsed,
+			"receipt gasUsed must already be canonical for many-slot tx")
+		t.Require().Equal(manyTx.RawGasUsed, manyTx.CanonicalGasUsed+manyRefund,
+			"raw gas must equal canonical gas plus SDM refund for many-slot tx")
+
+		return
+	}
+
+	t.Require().FailNowf("slot-touch workload failed",
+		"no attempt produced both same-slot and many-slot warm/claim pairs in the same block after %d attempts", maxAttempts)
+}
+
+// TestSDMMixedWorkloadSmoke submits transactions from multiple categories in a single burst,
+// without calling .Eval() between submissions. This tests that different tx types
+// (transfer, compute, events, state writes) can be batched into the same block.
+func TestSDMMixedWorkloadSmoke(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := newSDMRethSystem(t, true)
+	l := t.Logger()
+
+	clientVersion := verifyOpReth(t, sys.L2EL)
+	l.Info("Verified op-reth", "version", clientVersion)
+
+	alice := sys.FunderL2.NewFundedEOA(eth.OneEther)
+	bob := sys.FunderL2.NewFundedEOA(eth.ZeroWei)
+
+	computeHeavyAddr := deployContract(t, alice, computeHeavyBin)
+	stateBloatAddr := deployContract(t, alice, stateBloatBin)
+	eventLoggerAddr := alice.DeployEventLogger()
+	l.Info("Deployed contracts",
+		"computeHeavy", computeHeavyAddr,
+		"stateBloat", stateBloatAddr,
+		"eventLogger", eventLoggerAddr)
+
+	startNonce := alice.PendingNonce()
+	type batchEntry struct {
+		category string
+		ptx      *txplan.PlannedTx
+	}
+
+	categories := []struct {
+		name string
+		opts []txplan.Option
+	}{
+		{
+			name: "eoa_transfer",
+			opts: []txplan.Option{
+				txplan.WithTo(addrPtr(bob.Address())),
+				txplan.WithValue(eth.OneHundredthEther),
+			},
+		},
+		{
+			name: "compute_heavy",
+			opts: []txplan.Option{
+				txplan.WithTo(addrPtr(computeHeavyAddr)),
+				txplan.WithData(encodeRun(200)),
+				txplan.WithGasLimit(200_000),
+			},
+		},
+		{
+			name: "event_emitter",
+			opts: []txplan.Option{
+				txplan.WithTo(addrPtr(eventLoggerAddr)),
+				txplan.WithData(encodeEmitLog(3, 64)),
+				txplan.WithGasLimit(200_000),
+			},
+		},
+		{
+			name: "state_bloat",
+			opts: []txplan.Option{
+				txplan.WithTo(addrPtr(stateBloatAddr)),
+				txplan.WithData(encodeRun(20)),
+				txplan.WithGasLimit(500_000),
+			},
+		},
+		{
+			name: "compute_heavy_2",
+			opts: []txplan.Option{
+				txplan.WithTo(addrPtr(computeHeavyAddr)),
+				txplan.WithData(encodeRun(200)),
+				txplan.WithGasLimit(200_000),
+			},
+		},
+		{
+			name: "event_emitter_2",
+			opts: []txplan.Option{
+				txplan.WithTo(addrPtr(eventLoggerAddr)),
+				txplan.WithData(encodeEmitLog(3, 64)),
+				txplan.WithGasLimit(200_000),
+			},
+		},
+		{
+			name: "state_bloat_2",
+			opts: []txplan.Option{
+				txplan.WithTo(addrPtr(stateBloatAddr)),
+				txplan.WithData(encodeRun(20)),
+				txplan.WithGasLimit(500_000),
+			},
+		},
+		{
+			name: "eoa_transfer_2",
+			opts: []txplan.Option{
+				txplan.WithTo(addrPtr(bob.Address())),
+				txplan.WithValue(eth.OneHundredthEther),
+			},
+		},
+	}
+	batch := make([]batchEntry, 0, len(categories))
+
+	l.Info("Submitting batch", "txCount", len(categories), "startNonce", startNonce)
+
+	for i, cat := range categories {
+		nonce := startNonce + uint64(i)
+		ptx := submitTxWithoutWait(t, alice, nonce, cat.opts...)
+		batch = append(batch, batchEntry{category: cat.name, ptx: ptx})
+		l.Info("Submitted", "category", cat.name, "nonce", nonce)
+	}
+
+	blockCounts := make(map[uint64]int)
+	for i, entry := range batch {
+		receipt, err := entry.ptx.Included.Eval(t.Ctx())
+		t.Require().NoError(err, "tx %d (%s): failed to get receipt", i, entry.category)
+		t.Require().Equal(types.ReceiptStatusSuccessful, receipt.Status,
+			"tx %d (%s): must succeed", i, entry.category)
+
+		blockNum := bigs.Uint64Strict(receipt.BlockNumber)
+		blockCounts[blockNum]++
+
+		refund, _ := getOPGasRefund(t, sys.L2EL, receipt.TxHash)
+		l.Info("Included",
+			"category", entry.category,
+			"block", blockNum,
+			"txIdx", receipt.TransactionIndex,
+			"gasUsed", receipt.GasUsed,
+			"opGasRefund", refund)
+	}
+
+	l.Info("Batch distribution", "numBlocks", len(blockCounts))
+	maxInBlock := 0
+	var maxBlockNum uint64
+	for blockNum, count := range blockCounts {
+		l.Info("Block", "number", blockNum, "txCount", count)
+		if count > maxInBlock {
+			maxInBlock = count
+			maxBlockNum = blockNum
+		}
+	}
+
+	if maxInBlock >= 2 {
+		l.Info("Multi-tx block found — inspecting for SDM tx",
+			"block", maxBlockNum, "txCount", maxInBlock)
+
+		block := getBlockWithTxs(t, sys.L2EL, maxBlockNum)
+		postExecTx, postExecPos := findPostExecTransaction(block)
+		if postExecTx != nil {
+			l.Info("Post-exec transaction present in multi-category block!",
+				"block", maxBlockNum,
+				"position", postExecPos,
+				"inputLen", len(postExecTx.Input))
+		} else {
+			l.Info("No post-exec tx in block (fork not active yet)",
+				"block", maxBlockNum)
+		}
+	} else {
+		l.Warn("All txs landed in separate blocks — no cross-tx warming possible")
+	}
+}
+
+func addrPtr(addr common.Address) *common.Address {
+	return &addr
+}

--- a/op-acceptance-tests/tests/sdm/boundary_test.go
+++ b/op-acceptance-tests/tests/sdm/boundary_test.go
@@ -1,0 +1,74 @@
+package sdm
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/pkg/sdmreplay"
+	"github.com/ethereum-optimism/optimism/op-core/forks"
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+)
+
+// boundaryInteropOffset schedules Interop a few blocks after L2 genesis so the test
+// can observe both pre- and post-activation block production within a short window.
+// At 2s block time, 30s ≈ 15 blocks of pre-activation runway.
+const boundaryInteropOffset uint64 = 30
+
+// TestSDMActivatesAtInteropBoundary exercises the chain-spec-driven SDM gate across
+// the Interop activation timestamp. Both layers (op-node derivation and op-reth
+// execution) read IsInterop(timestamp) from the same chain spec, so flipping Interop
+// active mid-run must flip SDM on without any node-level override.
+//
+// Phase 1 (pre-Interop): a repeated-slot workload lands in a block whose timestamp
+// is before Interop activation; the block must not contain a PostExec (0x7D) tx.
+//
+// Phase 2 (post-Interop): the same workload after activation must produce a block
+// containing a PostExec tx with refund entries.
+func TestSDMActivatesAtInteropBoundary(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	offset := boundaryInteropOffset
+	sys := newSDMRethSystemWithInteropOffset(t, &offset)
+	verifyOpReth(t, sys.L2EL)
+
+	t.Require().False(sys.L2Network.IsForkActive(forks.Interop),
+		"Interop must not be active yet at the start of the boundary test")
+
+	// Phase 1: pre-Interop workload. We may need a few attempts to land the densest
+	// block before the activation timestamp; mustFindRepeatedSlotBlock retries
+	// internally and findPostExecTransaction tolerates absence.
+	preBlock, preIncluded, preBlockNum := mustFindRepeatedSlotBlock(t, sys, 2, 3)
+	t.Require().GreaterOrEqual(len(preIncluded), 2, "pre-Interop target block must contain user txs")
+	preRef := sys.L2EL.BlockRefByNumber(preBlockNum)
+	t.Require().False(sys.L2Network.IsForkActiveAt(forks.Interop, preRef.Time),
+		"pre-Interop workload block %d (ts=%d) must land before Interop activation",
+		preBlockNum, preRef.Time)
+
+	prePostExecTx, _ := findPostExecTransaction(preBlock)
+	t.Require().Nil(prePostExecTx,
+		"pre-Interop block %d must not contain a PostExec tx; chain-spec gates SDM off", preBlockNum)
+
+	// Phase 2: wait for Interop activation, then drive the workload again.
+	activationBlock := sys.L2Network.AwaitActivation(t, forks.Interop)
+	t.Logger().Info("Interop activated", "block", activationBlock)
+	t.Require().True(sys.L2Network.IsForkActive(forks.Interop),
+		"Interop must be active after AwaitActivation returns")
+
+	postBlock, postIncluded, postBlockNum := mustFindRepeatedSlotBlock(t, sys, 2, 3)
+	t.Require().GreaterOrEqual(len(postIncluded), 2, "post-Interop target block must contain user txs")
+	postRef := sys.L2EL.BlockRefByNumber(postBlockNum)
+	t.Require().True(sys.L2Network.IsForkActiveAt(forks.Interop, postRef.Time),
+		"post-Interop workload block %d (ts=%d) must land after Interop activation",
+		postBlockNum, postRef.Time)
+
+	postPostExecTx, _ := findPostExecTransaction(postBlock)
+	t.Require().NotNil(postPostExecTx,
+		"post-Interop block %d must contain a PostExec tx; chain-spec gates SDM on", postBlockNum)
+	t.Require().Equal(uint64(sdmreplay.SDMTxType), uint64(postPostExecTx.Type),
+		"post-exec tx type must be 0x7D")
+
+	payload, err := sdmreplay.DecodePayload(postPostExecTx.Input)
+	t.Require().NoError(err, "post-exec payload must decode")
+	t.Require().Equal(sdmreplay.PostExecPayloadVersion, payload.Version,
+		"post-exec payload version must be 1")
+	t.Require().NotEmpty(payload.GasRefundEntries,
+		"post-exec payload must carry refund entries for the repeated-slot workload")
+}

--- a/op-acceptance-tests/tests/sdm/helpers_test.go
+++ b/op-acceptance-tests/tests/sdm/helpers_test.go
@@ -1,0 +1,118 @@
+package sdm
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"strings"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-service/txplan"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/lmittmann/w3"
+)
+
+// ComputeHeavy: run(uint256 n) loops keccak256 n times (pure computation).
+const computeHeavyBin = "6080604052348015600e575f5ffd5b506101908061001c5f395ff3fe608060405234801561000f575f5ffd5b5060043610610029575f3560e01c8063a444f5e91461002d575b5f5ffd5b610047600480360381019061004291906100ec565b610049565b005b5f7f66a80b61b29ec044d14c4c8c613e762ba1fb8eeb0c454d1ee00ed6dedaa5b5c590505f5f90505b828110156100b0578160405160200161008b9190610140565b6040516020818303038152906040528051906020012091508080600101915050610072565b505050565b5f5ffd5b5f819050919050565b6100cb816100b9565b81146100d5575f5ffd5b50565b5f813590506100e6816100c2565b92915050565b5f60208284031215610101576101006100b5565b5b5f61010e848285016100d8565b91505092915050565b5f819050919050565b5f819050919050565b61013a61013582610117565b610120565b82525050565b5f61014b8284610129565b6020820191508190509291505056fea264697066735822122013cd314931f1991e7797e220c9553bb73dfef407d4d266dd8b2553907d5bc14364736f6c634300081c0033"
+
+// StateBloat: run(uint256 n) writes n unique SSTORE slots (state growth).
+const stateBloatBin = "6080604052348015600e575f5ffd5b5060f28061001b5f395ff3fe6080604052348015600e575f5ffd5b50600436106026575f3560e01c8063a444f5e914602a575b5f5ffd5b60406004803603810190603c91906096565b6042565b005b5f5f90505b8181101560605760018101815580806001019150506047565b5050565b5f5ffd5b5f819050919050565b6078816068565b81146081575f5ffd5b50565b5f813590506090816071565b92915050565b5f6020828403121560a85760a76064565b5b5f60b3848285016084565b9150509291505056fea2646970667358221220fb9ef6750b6ac6ded2dd901595e50b6daefe24726b41a0346f3a36ac6fcf5f8264736f6c634300081c0033"
+
+// SlotTouch: repeatedly touches either one storage slot or many distinct slots.
+const slotTouchBin = "6080604052348015600e575f5ffd5b5061010e8061001c5f395ff3fe6080604052348015600e575f5ffd5b50600436106030575f3560e01c80637ebfc845146034578063f1ac3593146045575b5f5ffd5b6043603f366004609e565b6054565b005b60436050366004609e565b6073565b5f5b81811015606f57606681600160b4565b5f556001016056565b5050565b5f5b81811015606f57608581600160b4565b5f82815260016020819052604090912091909155016075565b5f6020828403121560ad575f5ffd5b5035919050565b8082018082111560d257634e487b7160e01b5f52601160045260245ffd5b9291505056fea264697066735822122032537b9a0375aae151d7e212351ad336fe397942ba90c7fb77682efb97e309f564736f6c63430008210033"
+
+var (
+	funcRun          = w3.MustNewFunc("run(uint256)", "")
+	funcEmitLog      = w3.MustNewFunc("emitLog(bytes32[],bytes)", "")
+	funcHitSameSlot  = w3.MustNewFunc("hitSameSlot(uint256)", "")
+	funcHitManySlots = w3.MustNewFunc("hitManySlots(uint256)", "")
+)
+
+// verifyOpReth checks the L2 execution layer client is op-reth by calling
+// web3_clientVersion via the L2EthClient's RPC and asserting it contains "reth".
+func verifyOpReth(t devtest.T, l2EL *dsl.L2ELNode) string {
+	rpcClient := l2EL.Escape().L2EthClient().RPC()
+	var clientVersion string
+	err := rpcClient.CallContext(t.Ctx(), &clientVersion, "web3_clientVersion")
+	t.Require().NoError(err, "web3_clientVersion RPC failed — cannot verify EL client")
+
+	lower := strings.ToLower(clientVersion)
+	t.Require().True(
+		strings.Contains(lower, "reth"),
+		"FATAL: Expected op-reth execution client, but got: %q. "+
+			"This test MUST run on op-reth. "+
+			"Set DEVSTACK_L2EL_KIND=op-reth or ensure op-reth binary is available.",
+		clientVersion,
+	)
+	t.Require().False(
+		strings.Contains(lower, "geth"),
+		"FATAL: Detected op-geth (%q) but this test requires op-reth.", clientVersion,
+	)
+
+	return clientVersion
+}
+
+// getOPGasRefund reads the opGasRefund field from a transaction receipt via
+// raw JSON RPC. The boolean return value reports whether the field was present.
+func getOPGasRefund(t devtest.T, l2EL *dsl.L2ELNode, txHash common.Hash) (uint64, bool) {
+	rpcClient := l2EL.Escape().L2EthClient().RPC()
+	var raw json.RawMessage
+	err := rpcClient.CallContext(t.Ctx(), &raw, "eth_getTransactionReceipt", txHash)
+	t.Require().NoError(err, "eth_getTransactionReceipt RPC failed for tx %s", txHash)
+	t.Require().NotNil(raw, "receipt %s not found", txHash)
+
+	var result struct {
+		OPGasRefund *hexutil.Uint64 `json:"opGasRefund"`
+	}
+	err = json.Unmarshal(raw, &result)
+	t.Require().NoError(err, "failed to unmarshal receipt %s", txHash)
+	if result.OPGasRefund == nil {
+		return 0, false
+	}
+	return uint64(*result.OPGasRefund), true
+}
+
+func deployContract(t devtest.T, eoa *dsl.EOA, hexBytecode string) common.Address {
+	tx := txplan.NewPlannedTx(eoa.Plan(), txplan.WithData(common.FromHex(hexBytecode)))
+	res, err := tx.Included.Eval(t.Ctx())
+	t.Require().NoError(err, "failed to deploy contract")
+	return res.ContractAddress
+}
+
+func encodeRun(n uint64) []byte {
+	return encodeUintArg(funcRun, "run", n)
+}
+
+func encodeEmitLog(topicCount int, dataLen int) []byte {
+	topics := make([][32]byte, topicCount)
+	for i := range topics {
+		topics[i] = [32]byte{byte(i + 1)}
+	}
+	opaqueData := make([]byte, dataLen)
+	for i := range opaqueData {
+		opaqueData[i] = byte(i % 256)
+	}
+	data, err := funcEmitLog.EncodeArgs(topics, opaqueData)
+	if err != nil {
+		panic(fmt.Sprintf("failed to encode emitLog: %v", err))
+	}
+	return data
+}
+
+func encodeHitSameSlot(n uint64) []byte {
+	return encodeUintArg(funcHitSameSlot, "hitSameSlot", n)
+}
+
+func encodeHitManySlots(n uint64) []byte {
+	return encodeUintArg(funcHitManySlots, "hitManySlots", n)
+}
+
+func encodeUintArg(fn *w3.Func, name string, n uint64) []byte {
+	data, err := fn.EncodeArgs(new(big.Int).SetUint64(n))
+	if err != nil {
+		panic(fmt.Sprintf("failed to encode %s(%d): %v", name, n, err))
+	}
+	return data
+}

--- a/op-acceptance-tests/tests/sdm/init_test.go
+++ b/op-acceptance-tests/tests/sdm/init_test.go
@@ -1,0 +1,82 @@
+package sdm
+
+import (
+	bss "github.com/ethereum-optimism/optimism/op-batcher/batcher"
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+)
+
+type sdmRethSystem struct {
+	L1EL         *dsl.L1ELNode
+	L2EL         *dsl.L2ELNode
+	L2CL         *dsl.L2CLNode
+	L2ELVerifier *dsl.L2ELNode
+	L2CLVerifier *dsl.L2CLNode
+	L2Batcher    *dsl.L2Batcher
+	FunderL2     *dsl.Funder
+}
+
+func newSDMRethSystem(t devtest.T, sdmEnabled bool) *sdmRethSystem {
+	return newSDMRethSystemWithBatcherOptions(t, sdmEnabled)
+}
+
+func newSDMRethSystemWithBatcherOptions(t devtest.T, sdmEnabled bool, batcherOpts ...sysgo.BatcherOption) *sdmRethSystem {
+	var opRethOpts []sysgo.OpRethOption
+	if sdmEnabled {
+		opRethOpts = append(opRethOpts, sysgo.OpRethWithSDMEnabled())
+	}
+
+	runtime := sysgo.NewMixedSingleChainRuntime(t, sysgo.MixedSingleChainPresetConfig{
+		NodeSpecs: []sysgo.MixedSingleChainNodeSpec{
+			{
+				ELKey:       "sequencer-op-reth",
+				CLKey:       "sequencer",
+				ELKind:      sysgo.MixedL2ELOpReth,
+				CLKind:      sysgo.MixedL2CLOpNode,
+				IsSequencer: true,
+			},
+			{
+				ELKey:       "verifier-op-reth",
+				CLKey:       "verifier",
+				ELKind:      sysgo.MixedL2ELOpReth,
+				CLKind:      sysgo.MixedL2CLOpNode,
+				IsSequencer: false,
+			},
+		},
+		BatcherOptions: batcherOpts,
+		OpRethOptions:  opRethOpts,
+	})
+	frontends := presets.NewMixedSingleChainFrontends(t, runtime)
+	frontends.L2Batcher.Stop()
+	t.Require().Len(frontends.Nodes, 2, "SDM op-reth system must include sequencer and verifier nodes")
+
+	var verifierEL *dsl.L2ELNode
+	var verifierCL *dsl.L2CLNode
+	for _, node := range frontends.Nodes {
+		if !node.Spec.IsSequencer {
+			verifierEL = node.EL
+			verifierCL = node.CL
+			break
+		}
+	}
+	t.Require().NotNil(verifierEL, "missing SDM verifier EL node")
+	t.Require().NotNil(verifierCL, "missing SDM verifier CL node")
+
+	wallet := dsl.NewRandomHDWallet(t, 30)
+	return &sdmRethSystem{
+		L1EL:         frontends.L1EL,
+		L2EL:         frontends.L2Network.PrimaryEL(),
+		L2CL:         frontends.L2Network.PrimaryCL(),
+		L2ELVerifier: verifierEL,
+		L2CLVerifier: verifierCL,
+		L2Batcher:    frontends.L2Batcher,
+		FunderL2:     dsl.NewFunder(wallet, frontends.FaucetL2, frontends.L2Network.PrimaryEL()),
+	}
+}
+
+func withSingularBatcher(_ sysgo.ComponentTarget, cfg *bss.CLIConfig) {
+	cfg.BatchType = derive.SingularBatchType
+}

--- a/op-acceptance-tests/tests/sdm/init_test.go
+++ b/op-acceptance-tests/tests/sdm/init_test.go
@@ -2,17 +2,25 @@ package sdm
 
 import (
 	bss "github.com/ethereum-optimism/optimism/op-batcher/batcher"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
+	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/intentbuilder"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 )
+
+// sdmDisabledInteropOffset pushes Interop far past any reasonable acceptance-test
+// window so the chain spec gates SDM off. Used by sdmEnabled=false tests.
+const sdmDisabledInteropOffset uint64 = 3_600
 
 type sdmRethSystem struct {
 	L1EL         *dsl.L1ELNode
 	L2EL         *dsl.L2ELNode
 	L2CL         *dsl.L2CLNode
+	L2Network    *dsl.L2Network
 	L2ELVerifier *dsl.L2ELNode
 	L2CLVerifier *dsl.L2CLNode
 	L2Batcher    *dsl.L2Batcher
@@ -24,9 +32,43 @@ func newSDMRethSystem(t devtest.T, sdmEnabled bool) *sdmRethSystem {
 }
 
 func newSDMRethSystemWithBatcherOptions(t devtest.T, sdmEnabled bool, batcherOpts ...sysgo.BatcherOption) *sdmRethSystem {
-	var opRethOpts []sysgo.OpRethOption
+	// SDM activation tracks the Interop hardfork in chain spec: both op-node derivation
+	// and op-reth execution read IsInterop(timestamp) from the same chain spec. To toggle
+	// SDM in tests, we toggle Interop activation rather than a separate node-level flag.
+	var interopOffset *uint64
+	if !sdmEnabled {
+		off := sdmDisabledInteropOffset
+		interopOffset = &off
+	}
+	sys := newSDMRethSystemWithInteropOffset(t, interopOffset, batcherOpts...)
+
 	if sdmEnabled {
-		opRethOpts = append(opRethOpts, sysgo.OpRethWithSDMEnabled())
+		t.Require().True(sys.L2Network.IsForkActive(forks.Interop),
+			"Interop must be active for SDM-enabled tests; otherwise chain-spec gates SDM off")
+	} else {
+		t.Require().False(sys.L2Network.IsForkActive(forks.Interop),
+			"Interop must be inactive for SDM-disabled tests; otherwise chain-spec gates SDM on")
+	}
+	return sys
+}
+
+// newSDMRethSystemWithInteropOffset builds the SDM system with an explicit Interop activation
+// offset. Pass nil to leave Interop at genesis (SDM active from the first block); pass a non-nil
+// offset (in seconds from L2 genesis) to schedule Interop later. Used by the boundary test that
+// exercises the chain-spec gate across the activation timestamp.
+func newSDMRethSystemWithInteropOffset(
+	t devtest.T,
+	interopOffset *uint64,
+	batcherOpts ...sysgo.BatcherOption,
+) *sdmRethSystem {
+	var deployerOpts []sysgo.DeployerOption
+	if interopOffset != nil {
+		offset := *interopOffset
+		deployerOpts = append(deployerOpts, func(_ devtest.T, _ devkeys.Keys, builder intentbuilder.Builder) {
+			for _, l2Cfg := range builder.L2s() {
+				l2Cfg.WithForkAtOffset(forks.Interop, &offset)
+			}
+		})
 	}
 
 	runtime := sysgo.NewMixedSingleChainRuntime(t, sysgo.MixedSingleChainPresetConfig{
@@ -46,8 +88,8 @@ func newSDMRethSystemWithBatcherOptions(t devtest.T, sdmEnabled bool, batcherOpt
 				IsSequencer: false,
 			},
 		},
-		BatcherOptions: batcherOpts,
-		OpRethOptions:  opRethOpts,
+		BatcherOptions:  batcherOpts,
+		DeployerOptions: deployerOpts,
 	})
 	frontends := presets.NewMixedSingleChainFrontends(t, runtime)
 	frontends.L2Batcher.Stop()
@@ -70,6 +112,7 @@ func newSDMRethSystemWithBatcherOptions(t devtest.T, sdmEnabled bool, batcherOpt
 		L1EL:         frontends.L1EL,
 		L2EL:         frontends.L2Network.PrimaryEL(),
 		L2CL:         frontends.L2Network.PrimaryCL(),
+		L2Network:    frontends.L2Network,
 		L2ELVerifier: verifierEL,
 		L2CLVerifier: verifierCL,
 		L2Batcher:    frontends.L2Batcher,

--- a/op-chain-ops/pkg/sdmreplay/payload.go
+++ b/op-chain-ops/pkg/sdmreplay/payload.go
@@ -1,0 +1,72 @@
+package sdmreplay
+
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+const SDMTxType = 0x7d
+
+// PostExecPayloadVersion is the only PostExecPayload version the Go decoder accepts.
+// Must stay in lock-step with POST_EXEC_PAYLOAD_VERSION in rust/op-alloy, which rejects
+// unknown versions at decode time; Go accepting what Rust rejects is a cross-language
+// drift hazard on any replay/verifier pipeline sitting between the two.
+const PostExecPayloadVersion uint64 = 1
+
+// SDMGasEntry is one per-transaction refund entry inside the SDM portion of a post-exec payload.
+type SDMGasEntry struct {
+	Index     uint64 `json:"index"`
+	GasRefund uint64 `json:"gas_refund"`
+}
+
+// PostExecPayload is the decoded RLP payload carried by the synthetic post-exec tx.
+// Today this contains the SDM gas refund entries and the L2 block number the payload is anchored to.
+// Older payloads may omit BlockNumber.
+type PostExecPayload struct {
+	Version          uint64        `json:"version"`
+	BlockNumber      uint64        `json:"block_number,omitempty"`
+	GasRefundEntries []SDMGasEntry `json:"gas_refund_entries"`
+}
+
+// DecodePayload decodes an RLP-encoded post-exec payload from the post-exec tx input.
+func DecodePayload(input []byte) (*PostExecPayload, error) {
+	if len(input) == 0 {
+		return nil, fmt.Errorf("empty post-exec payload")
+	}
+
+	payload, err := decodePayloadStruct(input)
+	if err != nil {
+		return nil, err
+	}
+	if payload.Version != PostExecPayloadVersion {
+		return nil, fmt.Errorf(
+			"unsupported post-exec payload version %d (expected %d)",
+			payload.Version, PostExecPayloadVersion,
+		)
+	}
+	return payload, nil
+}
+
+// decodePayloadStruct tries the current RLP shape first, then falls back to the legacy
+// two-field shape. Version validation is applied by the caller so unknown versions are
+// rejected on either path.
+func decodePayloadStruct(input []byte) (*PostExecPayload, error) {
+	var payload PostExecPayload
+	if err := rlp.DecodeBytes(input, &payload); err == nil {
+		return &payload, nil
+	}
+
+	// Backward compatibility for older payloads that encoded only version + refund entries.
+	var legacy struct {
+		Version          uint64
+		GasRefundEntries []SDMGasEntry
+	}
+	if err := rlp.DecodeBytes(input, &legacy); err != nil {
+		return nil, fmt.Errorf("decode post-exec payload: %w", err)
+	}
+	return &PostExecPayload{
+		Version:          legacy.Version,
+		GasRefundEntries: legacy.GasRefundEntries,
+	}, nil
+}

--- a/op-devstack/sysgo/l2_el_opreth.go
+++ b/op-devstack/sysgo/l2_el_opreth.go
@@ -60,11 +60,6 @@ func OpRethWithExtraArgs(args ...string) OpRethOption {
 	})
 }
 
-// OpRethWithSDMEnabled enables Sequencer-Defined Metering on the op-reth node.
-func OpRethWithSDMEnabled() OpRethOption {
-	return OpRethWithExtraArgs("--rollup.sdm-enabled")
-}
-
 // OpRethWithSupervisorURL wires the op-reth node to the given supervisor HTTP endpoint.
 // An empty supervisorURL is a no-op so callers can pass the value unconditionally.
 func OpRethWithSupervisorURL(supervisorURL string) OpRethOption {

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -11534,7 +11534,7 @@ name = "reth-optimism-post-exec-replay"
 version = "1.11.3"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.4",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "op-alloy-consensus",
  "reth-evm",
@@ -11581,6 +11581,7 @@ version = "1.11.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.5",
+ "alloy-genesis",
  "alloy-json-rpc",
  "alloy-op-evm",
  "alloy-op-hardforks",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -11530,6 +11530,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-optimism-post-exec-replay"
+version = "1.11.3"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips 2.0.4",
+ "alloy-primitives",
+ "op-alloy-consensus",
+ "reth-evm",
+ "reth-execution-errors",
+ "reth-node-api",
+ "reth-optimism-evm",
+ "reth-optimism-primitives",
+ "reth-primitives-traits",
+ "revm",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "reth-optimism-primitives"
 version = "1.11.3"
 dependencies = [
@@ -11601,6 +11620,7 @@ dependencies = [
  "reth-optimism-flashblocks",
  "reth-optimism-forks",
  "reth-optimism-payload-builder",
+ "reth-optimism-post-exec-replay",
  "reth-optimism-primitives",
  "reth-optimism-trie",
  "reth-optimism-txpool",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -35,6 +35,7 @@ members = [
   "op-reth/crates/hardforks/",
   "op-reth/crates/node/",
   "op-reth/crates/payload/",
+  "op-reth/crates/post-exec-replay/",
   "op-reth/crates/primitives/",
   "op-reth/crates/reth/",
   "op-reth/crates/rpc/",
@@ -292,6 +293,7 @@ reth-optimism-flashblocks = { path = "op-reth/crates/flashblocks/" }
 reth-optimism-forks = { path = "op-reth/crates/hardforks/", default-features = false }
 reth-optimism-node = { path = "op-reth/crates/node/" }
 reth-optimism-payload-builder = { path = "op-reth/crates/payload/" }
+reth-optimism-post-exec-replay = { path = "op-reth/crates/post-exec-replay/" }
 reth-optimism-primitives = { path = "op-reth/crates/primitives/", default-features = false }
 reth-op = { path = "op-reth/crates/reth/", default-features = false }
 reth-optimism-rpc = { path = "op-reth/crates/rpc/" }

--- a/rust/alloy-op-evm/src/block/mod.rs
+++ b/rust/alloy-op-evm/src/block/mod.rs
@@ -43,7 +43,7 @@ use revm::{
 
 use crate::post_exec::{
     PostExecEvm, PostExecEvmFactoryAdapter, PostExecEvmFactoryHooks, PostExecTxContext,
-    PostExecTxKind,
+    PostExecTxKind, WarmingRefundEvent,
 };
 
 mod canyon;
@@ -249,6 +249,8 @@ pub struct PostExecAdjustment {
     /// Wei to debit from the operator-fee recipient — operator-fee share of the refund
     /// (post-Isthmus).
     pub operator_fee_balance_delta: U256,
+    /// Exact warming refund attribution events that produced the refund.
+    pub warming_events: Vec<WarmingRefundEvent>,
 }
 
 /// The result of executing an OP transaction.
@@ -317,6 +319,8 @@ pub struct OpBlockExecutor<Evm, R: OpReceiptBuilder, Spec> {
     pub l1_block_info: Option<L1BlockInfo>,
     /// Post-exec execution state (mode and producer/verifier working state).
     pub post_exec: PostExecState,
+    /// Per-transaction exact warming refund attribution events aligned with receipts.
+    pub warming_events_by_tx: Vec<Vec<WarmingRefundEvent>>,
 }
 
 impl<E, R, Spec> OpBlockExecutor<E, R, Spec>
@@ -341,6 +345,7 @@ where
             ctx,
             l1_block_info: None,
             post_exec,
+            warming_events_by_tx: Vec::new(),
         }
     }
 
@@ -363,6 +368,11 @@ where
     /// Returns the entries and clears the internal state.
     pub fn take_post_exec_entries(&mut self) -> Vec<SDMGasEntry> {
         self.post_exec.take_entries()
+    }
+
+    /// Take the exact per-transaction warming refund attribution events aligned with receipts.
+    pub fn take_warming_events_by_tx(&mut self) -> Vec<Vec<WarmingRefundEvent>> {
+        core::mem::take(&mut self.warming_events_by_tx)
     }
 }
 
@@ -637,6 +647,7 @@ where
             beneficiary_balance_delta,
             base_fee_balance_delta,
             operator_fee_balance_delta,
+            warming_events: Vec::new(),
         })
     }
 
@@ -809,8 +820,9 @@ where
         })?;
 
         let evm_gas_used = result.result.tx_gas_used();
-        let post_exec_refund = if self.post_exec.is_producing() {
-            let refund = self.evm.take_last_post_exec_tx_result().refund_total;
+        let (post_exec_refund, warming_events) = if self.post_exec.is_producing() {
+            let post_exec_result = self.evm.take_last_post_exec_tx_result();
+            let refund = post_exec_result.refund_total;
             // The inspector's accumulated refund must never exceed the tx's evm_gas_used. If
             // it does, we'd emit an `SDMGasEntry` that any honest verifier would reject
             // at pre-execution ("payload refund exceeds evm_gas_used"), so the sequencer
@@ -821,19 +833,24 @@ where
                     "produced refund {refund} exceeds evm_gas_used {evm_gas_used} for tx index {tx_index}",
                 )));
             }
-            refund
+            (refund, post_exec_result.refund_events)
         } else {
-            self.verifier_post_exec_refund_for_tx(tx_index, is_deposit, false, evm_gas_used)?
+            (
+                self.verifier_post_exec_refund_for_tx(tx_index, is_deposit, false, evm_gas_used)?,
+                Vec::new(),
+            )
         };
         let canonical_gas_used = evm_gas_used.saturating_sub(post_exec_refund);
-        let deltas = self.post_exec_settlement_deltas(
+        let mut deltas = self.post_exec_settlement_deltas(
             &tx,
             evm_gas_used,
             post_exec_refund,
             is_deposit,
             false,
         )?;
-        let post_exec = (post_exec_refund > 0).then_some(deltas);
+        deltas.warming_events = warming_events;
+        let post_exec =
+            (post_exec_refund > 0 || !deltas.warming_events.is_empty()).then_some(deltas);
 
         // Pre-compute depositor nonce here so `commit_transaction` can be infallible.
         // Only post-regolith deposit transactions need the depositor account from DB.
@@ -886,7 +903,10 @@ where
             depositor_nonce,
         } = output;
 
-        let post_exec_refund = post_exec.as_ref().map(|d| d.refund).unwrap_or(0);
+        let (post_exec_refund, warming_events) = match post_exec {
+            Some(deltas) => (deltas.refund, deltas.warming_events),
+            None => (0, Vec::new()),
+        };
 
         if !is_deposit && !is_post_exec && post_exec_refund > 0 {
             if let Some(entries) = self.post_exec.produced_entries_mut() {
@@ -895,6 +915,9 @@ where
         }
         if self.post_exec.is_verifying() && post_exec_refund > 0 {
             self.post_exec.consume_verifier_entry(tx_index);
+        }
+        if !is_post_exec {
+            self.warming_events_by_tx.push(warming_events);
         }
 
         self.system_caller.on_state(StateChangeSource::Transaction(self.receipts.len()), &state);

--- a/rust/alloy-op-evm/src/lib.rs
+++ b/rust/alloy-op-evm/src/lib.rs
@@ -72,7 +72,7 @@ pub struct OpEvm<DB: Database, I, P = OpPrecompiles, Tx = OpTx> {
     >,
     inspect: bool,
     post_exec_tracking_active: bool,
-    last_tx_warming_savings: u64,
+    last_tx_post_exec_result: post_exec::PostExecExecutedTx,
     _tx: PhantomData<Tx>,
 }
 
@@ -142,7 +142,7 @@ impl<DB: Database, I, P, Tx> OpEvm<DB, I, P, Tx> {
             }),
             inspect,
             post_exec_tracking_active: false,
-            last_tx_warming_savings: 0,
+            last_tx_post_exec_result: post_exec::PostExecExecutedTx::default(),
             _tx: PhantomData,
         }
     }
@@ -159,9 +159,7 @@ impl<DB: Database, I, P, Tx> OpEvm<DB, I, P, Tx> {
 
     /// Take the extracted post-exec result for the most recently executed transaction.
     pub fn take_last_post_exec_tx_result(&mut self) -> post_exec::PostExecExecutedTx {
-        post_exec::PostExecExecutedTx {
-            refund_total: core::mem::take(&mut self.last_tx_warming_savings),
-        }
+        core::mem::take(&mut self.last_tx_post_exec_result)
     }
 }
 
@@ -249,7 +247,7 @@ where
         &mut self,
         tx: Self::Tx,
     ) -> Result<ResultAndState<Self::HaltReason>, Self::Error> {
-        self.last_tx_warming_savings = 0;
+        self.last_tx_post_exec_result = post_exec::PostExecExecutedTx::default();
 
         let track_post_exec = self.post_exec_tracking_active;
         let result = if self.inspect || track_post_exec {
@@ -269,8 +267,7 @@ where
                 }
             }
 
-            let post_exec_result = self.inner.0.inspector.finish_post_exec_tx();
-            self.last_tx_warming_savings = post_exec_result.refund_total;
+            self.last_tx_post_exec_result = self.inner.0.inspector.finish_post_exec_tx();
             self.post_exec_tracking_active = false;
         }
 

--- a/rust/alloy-op-evm/src/post_exec/inspector.rs
+++ b/rust/alloy-op-evm/src/post_exec/inspector.rs
@@ -1,4 +1,8 @@
-use alloy_primitives::{Address, B256, map::HashSet};
+use alloc::vec::Vec;
+use alloy_primitives::{
+    Address, B256,
+    map::{HashMap, HashSet},
+};
 use revm::{
     Inspector,
     bytecode::opcode,
@@ -15,25 +19,37 @@ use revm::{
     primitives::TxKind,
 };
 
-// EIP-2929 repeat-access savings. SDM refunds the cold-access premium when a tx
-// re-touches something a prior tx in the same block already warmed, making canonical gas
-// reflect block-level warming.
-//
-// Values are derived from EIP-2929 cold-access premiums:
-//   account touch: COLD_ACCOUNT_ACCESS_COST (2600) - WARM_STORAGE_READ_COST (100) = 2500
-//   SLOAD:         COLD_SLOAD_COST          (2100) - WARM_STORAGE_READ_COST (100) = 2000
-//   SSTORE:        cold storage-key surcharge is the full COLD_SLOAD_COST         = 2100
-//                  (EIP-2929 uses this SLOAD-named constant for cold SSTORE too)
-
-/// Refund for re-touching an account warmed earlier in the block (BALANCE, EXTCODE*, CALL, …).
 const ACCOUNT_REWARM_REFUND: u64 = 2500;
-/// Refund for re-touching a storage slot warmed earlier in the block via SLOAD.
 const SLOAD_REWARM_REFUND: u64 = 2000;
-/// Refund for re-touching a storage slot warmed earlier in the block via SSTORE.
-///
-/// Higher than the SLOAD refund because EIP-2929 charges cold SSTORE the full
-/// `COLD_SLOAD_COST` surcharge too, despite the SLOAD-specific constant name.
 const SSTORE_REWARM_REFUND: u64 = 2100;
+
+/// Exact refund categories for post-exec block-level warming.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WarmingRefundKind {
+    /// Warm account rebate (+2500).
+    WarmAccount,
+    /// Warm storage read rebate (+2000).
+    WarmSload,
+    /// Warm storage write rebate (+2100).
+    WarmSstore,
+}
+
+/// Exact refund attribution event emitted when a warming rebate is granted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WarmingRefundEvent {
+    /// Replay-local transaction index that claimed the rebate.
+    pub claiming_tx_index: u64,
+    /// Refund kind.
+    pub kind: WarmingRefundKind,
+    /// Rebate amount in gas.
+    pub amount: u64,
+    /// Account touched by the rebate.
+    pub address: Address,
+    /// Storage slot touched by the rebate, when applicable.
+    pub slot: Option<B256>,
+    /// Replay-local transaction index that first warmed this account or slot.
+    pub first_warmed_by_tx_index: u64,
+}
 
 /// Classification for the currently executing transaction.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -62,17 +78,26 @@ pub struct PostExecTxContext {
 }
 
 /// Extracted result for the most recently executed transaction.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct PostExecExecutedTx {
     /// Total refund for the tx.
     pub refund_total: u64,
+    /// Exact attribution events for the tx.
+    pub refund_events: Vec<WarmingRefundEvent>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct WarmProvenance {
+    first_warmed_by_tx_index: u64,
 }
 
 #[derive(Debug, Clone, Default)]
 struct CurrentTxState {
+    tx_index: u64,
     kind: Option<PostExecTxKind>,
     initialized_top_level: bool,
     refund_total: u64,
+    refund_events: Vec<WarmingRefundEvent>,
     touched_accounts: HashSet<Address>,
     touched_slots: HashSet<(Address, B256)>,
     intrinsic_warm_accounts: HashSet<Address>,
@@ -81,9 +106,11 @@ struct CurrentTxState {
 
 impl CurrentTxState {
     fn begin(&mut self, ctx: PostExecTxContext) {
+        self.tx_index = ctx.tx_index;
         self.kind = Some(ctx.kind);
         self.initialized_top_level = false;
         self.refund_total = 0;
+        self.refund_events.clear();
         self.touched_accounts.clear();
         self.touched_slots.clear();
         self.intrinsic_warm_accounts.clear();
@@ -97,12 +124,30 @@ impl CurrentTxState {
     fn finish(&mut self) -> PostExecExecutedTx {
         self.kind = None;
         self.initialized_top_level = false;
-        PostExecExecutedTx { refund_total: core::mem::take(&mut self.refund_total) }
+        PostExecExecutedTx {
+            refund_total: core::mem::take(&mut self.refund_total),
+            refund_events: core::mem::take(&mut self.refund_events),
+        }
     }
 
-    fn add_refund(&mut self, amount: u64) {
+    fn emit_refund(
+        &mut self,
+        provenance: WarmProvenance,
+        kind: WarmingRefundKind,
+        amount: u64,
+        address: Address,
+        slot: Option<B256>,
+    ) {
         if self.kind.is_some_and(PostExecTxKind::claims_refunds) {
             self.refund_total = self.refund_total.saturating_add(amount);
+            self.refund_events.push(WarmingRefundEvent {
+                claiming_tx_index: self.tx_index,
+                kind,
+                amount,
+                address,
+                slot,
+                first_warmed_by_tx_index: provenance.first_warmed_by_tx_index,
+            });
         }
     }
 }
@@ -110,8 +155,8 @@ impl CurrentTxState {
 /// Lightweight inspector that computes post-exec block-warming refunds.
 #[derive(Debug, Clone, Default)]
 pub struct SDMWarmingInspector {
-    warmed_accounts: HashSet<Address>,
-    warmed_slots: HashSet<(Address, B256)>,
+    warmed_accounts: HashMap<Address, WarmProvenance>,
+    warmed_slots: HashMap<(Address, B256), WarmProvenance>,
     current_tx: CurrentTxState,
     last_tx: PostExecExecutedTx,
 }
@@ -129,9 +174,8 @@ impl SDMWarmingInspector {
 
     /// Finishes the current transaction and stores the extracted result.
     pub fn finish_tx(&mut self) -> PostExecExecutedTx {
-        let last = self.current_tx.finish();
-        self.last_tx = last;
-        last
+        self.last_tx = self.current_tx.finish();
+        self.last_tx.clone()
     }
 
     /// Takes the extracted result for the most recently finished transaction.
@@ -191,13 +235,22 @@ impl SDMWarmingInspector {
 
         if self.current_tx.touched_accounts.insert(address) &&
             allow_refund &&
-            !self.current_tx.intrinsic_warm_accounts.contains(&address) &&
-            self.warmed_accounts.contains(&address)
+            !self.current_tx.intrinsic_warm_accounts.contains(&address)
         {
-            self.current_tx.add_refund(ACCOUNT_REWARM_REFUND);
+            if let Some(provenance) = self.warmed_accounts.get(&address).copied() {
+                self.current_tx.emit_refund(
+                    provenance,
+                    WarmingRefundKind::WarmAccount,
+                    ACCOUNT_REWARM_REFUND,
+                    address,
+                    None,
+                );
+            }
         }
 
-        self.warmed_accounts.insert(address);
+        self.warmed_accounts
+            .entry(address)
+            .or_insert(WarmProvenance { first_warmed_by_tx_index: self.current_tx.tx_index });
     }
 
     fn observe_slot_touch(&mut self, address: Address, slot: B256, is_sstore: bool) {
@@ -208,18 +261,23 @@ impl SDMWarmingInspector {
         // Storage accesses should never also claim the account refund.
         self.observe_account_touch(address, false);
 
-        if self.current_tx.touched_slots.insert((address, slot)) &&
-            !self.current_tx.intrinsic_warm_slots.contains(&(address, slot)) &&
-            self.warmed_slots.contains(&(address, slot))
+        let slot_key = (address, slot);
+        if self.current_tx.touched_slots.insert(slot_key) &&
+            !self.current_tx.intrinsic_warm_slots.contains(&slot_key)
         {
-            self.current_tx.add_refund(if is_sstore {
-                SSTORE_REWARM_REFUND
-            } else {
-                SLOAD_REWARM_REFUND
-            });
+            if let Some(provenance) = self.warmed_slots.get(&slot_key).copied() {
+                let (kind, amount) = if is_sstore {
+                    (WarmingRefundKind::WarmSstore, SSTORE_REWARM_REFUND)
+                } else {
+                    (WarmingRefundKind::WarmSload, SLOAD_REWARM_REFUND)
+                };
+                self.current_tx.emit_refund(provenance, kind, amount, address, Some(slot));
+            }
         }
 
-        self.warmed_slots.insert((address, slot));
+        self.warmed_slots
+            .entry(slot_key)
+            .or_insert(WarmProvenance { first_warmed_by_tx_index: self.current_tx.tx_index });
     }
 }
 

--- a/rust/alloy-op-evm/src/post_exec/mod.rs
+++ b/rust/alloy-op-evm/src/post_exec/mod.rs
@@ -13,7 +13,7 @@ use revm::{Inspector, inspector::NoOpInspector};
 
 pub use inspector::{
     PostExecCompositeInspector, PostExecExecutedTx, PostExecTxContext, PostExecTxKind,
-    SDMWarmingInspector,
+    SDMWarmingInspector, WarmingRefundEvent, WarmingRefundKind,
 };
 
 use crate::block::{OpBlockExecutor, receipt_builder::OpReceiptBuilder};
@@ -220,6 +220,9 @@ where
 pub trait PostExecExecutorExt {
     /// Take the accumulated post-exec entries for the current block.
     fn take_post_exec_entries(&mut self) -> Vec<SDMGasEntry>;
+
+    /// Take the exact per-transaction warming refund attribution events aligned with receipts.
+    fn take_warming_events_by_tx(&mut self) -> Vec<Vec<WarmingRefundEvent>>;
 }
 
 impl<E, R, Spec> PostExecExecutorExt for OpBlockExecutor<E, R, Spec>
@@ -230,5 +233,9 @@ where
 {
     fn take_post_exec_entries(&mut self) -> Vec<SDMGasEntry> {
         Self::take_post_exec_entries(self)
+    }
+
+    fn take_warming_events_by_tx(&mut self) -> Vec<Vec<WarmingRefundEvent>> {
+        Self::take_warming_events_by_tx(self)
     }
 }

--- a/rust/op-reth/crates/evm/src/lib.rs
+++ b/rust/op-reth/crates/evm/src/lib.rs
@@ -68,7 +68,7 @@ pub use tx::OpTx;
 
 pub use alloy_op_evm::{
     OpBlockExecutionCtx, OpBlockExecutorFactory, OpEvm, OpEvmFactory, PostExecMode,
-    post_exec::PostExecExecutorExt,
+    post_exec::{PostExecExecutorExt, WarmingRefundEvent, WarmingRefundKind},
 };
 
 mod post_exec_ext;

--- a/rust/op-reth/crates/evm/src/lib.rs
+++ b/rust/op-reth/crates/evm/src/lib.rs
@@ -86,12 +86,6 @@ pub struct OpEvmConfig<
     pub executor_factory: OpBlockExecutorFactory<R, Arc<ChainSpec>, EvmFactory>,
     /// Optimism block assembler.
     pub block_assembler: OpBlockAssembler<ChainSpec>,
-    /// Whether SDM post-exec transactions are enabled for this node.
-    ///
-    /// SDM is not scheduled yet. Keep this disabled outside of explicit
-    /// integration-test setups.
-    #[doc(hidden)]
-    pub sdm_enabled: bool,
     #[doc(hidden)]
     pub _pd: core::marker::PhantomData<N>,
 }
@@ -103,7 +97,6 @@ impl<ChainSpec, N: NodePrimitives, R: Clone, EvmFactory: Clone> Clone
         Self {
             executor_factory: self.executor_factory.clone(),
             block_assembler: self.block_assembler.clone(),
-            sdm_enabled: self.sdm_enabled,
             _pd: self._pd,
         }
     }
@@ -126,16 +119,8 @@ impl<ChainSpec: OpHardforks, N: NodePrimitives, R> OpEvmConfig<ChainSpec, N, R> 
                 chain_spec,
                 OpEvmFactory::<OpTx>::default(),
             ),
-            sdm_enabled: false,
             _pd: core::marker::PhantomData,
         }
-    }
-
-    /// Configures the temporary SDM integration-test override.
-    #[must_use]
-    pub const fn with_sdm_enabled(mut self, sdm_enabled: bool) -> Self {
-        self.sdm_enabled = sdm_enabled;
-        self
     }
 }
 
@@ -151,10 +136,10 @@ where
 
     /// Returns true when SDM post-exec transactions are consensus-active at `timestamp`.
     ///
-    /// SDM has no scheduled hardfork activation. It is disabled by default, including after Jovian
-    /// and Karst, and can only be enabled explicitly for integration tests.
-    pub const fn is_sdm_active_at_timestamp(&self, _timestamp: u64) -> bool {
-        self.sdm_enabled
+    /// SDM activates with the Interop hardfork: both layers (op-node derivation and op-reth
+    /// execution) gate on `IsInterop(timestamp)` from the same chain spec, so they cannot drift.
+    pub fn is_sdm_active_at_timestamp(&self, timestamp: u64) -> bool {
+        self.chain_spec().is_interop_active_at_timestamp(timestamp)
     }
 
     /// Builds a block execution context with an optional post-exec mode override.
@@ -429,20 +414,30 @@ mod tests {
         OpEvmConfig::optimism(BASE_MAINNET.clone())
     }
 
-    #[test]
-    fn test_sdm_disabled_by_default_and_explicitly_enabled() {
+    fn test_evm_config_interop_active() -> OpEvmConfig {
         let chain_spec = Arc::new(
+            OpChainSpecBuilder::default()
+                .chain(10.into())
+                .genesis(Genesis::default())
+                .interop_activated()
+                .build(),
+        );
+        OpEvmConfig::optimism(chain_spec)
+    }
+
+    #[test]
+    fn test_sdm_tracks_interop_activation() {
+        let pre_interop = OpEvmConfig::optimism(Arc::new(
             OpChainSpecBuilder::default()
                 .chain(10.into())
                 .genesis(Genesis::default())
                 .jovian_activated()
                 .build(),
-        );
-        let evm_config = OpEvmConfig::optimism(chain_spec.clone());
+        ));
+        assert!(!pre_interop.is_sdm_active_at_timestamp(0));
 
-        assert!(chain_spec.is_jovian_active_at_timestamp(0));
-        assert!(!evm_config.is_sdm_active_at_timestamp(0));
-        assert!(evm_config.with_sdm_enabled(true).is_sdm_active_at_timestamp(0));
+        let interop_active = test_evm_config_interop_active();
+        assert!(interop_active.is_sdm_active_at_timestamp(0));
     }
 
     fn block_with_post_exec_tx(
@@ -465,19 +460,20 @@ mod tests {
         })
     }
 
-    // Covers config-driven SDM activation for imported blocks: disabled nodes reject 0x7d,
-    // enabled nodes enter Verify mode, and malformed payload anchors are rejected.
+    // Covers chain-spec-driven SDM activation for imported blocks: pre-Interop chain specs
+    // reject 0x7d, Interop-active specs enter Verify mode, and malformed payload anchors are
+    // rejected.
     #[test]
     fn context_for_block_applies_sdm_post_exec_mode() {
         let disabled_err = test_evm_config()
             .context_for_block(&block_with_post_exec_tx(7, 123, 7))
-            .expect_err("SDM disabled rejects 0x7d");
+            .expect_err("pre-Interop chain spec rejects 0x7d");
         assert!(matches!(disabled_err, EIP1559ParamError::InvalidPostExecPayload));
 
-        let evm_config = test_evm_config().with_sdm_enabled(true);
+        let evm_config = test_evm_config_interop_active();
         let ctx = evm_config
             .context_for_block(&block_with_post_exec_tx(7, 123, 7))
-            .expect("SDM-enabled block parses");
+            .expect("SDM-active block parses");
         let PostExecMode::Verify(payload) = ctx.post_exec_mode else {
             panic!("expected Verify mode");
         };

--- a/rust/op-reth/crates/node/src/args.rs
+++ b/rust/op-reth/crates/node/src/args.rs
@@ -49,12 +49,6 @@ pub struct RollupArgs {
     #[arg(long = "rollup.enable-tx-conditional", default_value = "false")]
     pub enable_tx_conditional: bool,
 
-    /// Enable experimental SDM support for integration tests.
-    ///
-    /// SDM is not scheduled for Jovian or Karst; leave this disabled for production networks.
-    #[arg(long = "rollup.sdm-enabled", default_value = "false")]
-    pub sdm_enabled: bool,
-
     /// HTTP endpoint for the supervisor. When not set, interop transaction validation is disabled.
     #[arg(long = "rollup.supervisor-http", value_name = "SUPERVISOR_HTTP_URL")]
     pub supervisor_http: Option<String>,
@@ -160,7 +154,6 @@ impl Default for RollupArgs {
             compute_pending_block: false,
             discovery_v4: false,
             enable_tx_conditional: false,
-            sdm_enabled: false,
             supervisor_http: None,
             supervisor_safety_level: SafetyLevel::CrossUnsafe,
             sequencer_headers: Vec::new(),

--- a/rust/op-reth/crates/node/src/node.rs
+++ b/rust/op-reth/crates/node/src/node.rs
@@ -49,7 +49,7 @@ use reth_optimism_rpc::{
     eth::{OpEthApiBuilder, ext::OpEthExtApi},
     historical::{HistoricalRpc, HistoricalRpcClient},
     miner::{MinerApiExtServer, OpMinerExtApi},
-    witness::{DebugExecutionWitnessApiServer, OpDebugWitnessApi},
+    witness::{DebugExecutionWitnessApiServer, OpDebugPostExecApiServer, OpDebugWitnessApi},
 };
 use reth_optimism_storage::OpStorage;
 use reth_optimism_txpool::{OpPool, OpPooledTx, supervisor::SupervisorClient};
@@ -135,6 +135,29 @@ impl PayloadAttributesBuilder<OpPayloadAttrs> for OpLocalPayloadAttributesBuilde
         })
     }
 }
+/// Helper trait for OP primitives whose block is the standard alloy block shape.
+pub trait OpReplayNodePrimitives:
+    OpPayloadPrimitives
+    + NodePrimitives<
+        Block = alloy_consensus::Block<Self::_TX, Self::_Header>,
+        BlockBody = alloy_consensus::BlockBody<Self::_TX, Self::_Header>,
+        BlockHeader = Self::_Header,
+        SignedTx = Self::_TX,
+    >
+{
+}
+
+impl<T> OpReplayNodePrimitives for T where
+    T: OpPayloadPrimitives
+        + NodePrimitives<
+            Block = alloy_consensus::Block<T::_TX, T::_Header>,
+            BlockBody = alloy_consensus::BlockBody<T::_TX, T::_Header>,
+            BlockHeader = T::_Header,
+            SignedTx = T::_TX,
+        >
+{
+}
+
 /// Marker trait for Optimism node types with standard engine, chain spec, and primitives.
 pub trait OpNodeTypes:
     NodeTypes<Payload = OpEngineTypes, ChainSpec: OpHardforks + Hardforks, Primitives = OpPrimitives>
@@ -615,7 +638,7 @@ where
     N: FullNodeComponents<
             Types: NodeTypes<
                 ChainSpec: OpHardforks + Hardforks,
-                Primitives: OpPayloadPrimitives<_Header: HeaderMut>,
+                Primitives: OpReplayNodePrimitives<_Header: HeaderMut>,
             >,
             Evm: ConfigurePostExecEvm<
                 Primitives = PrimitivesTy<N::Types>,
@@ -687,6 +710,7 @@ where
                 ctx.node.provider().clone(),
                 ctx.node.task_executor().clone(),
                 builder,
+                ctx.node.evm_config().clone(),
             );
         let miner_ext = OpMinerExtApi::new(da_config, gas_limit_config);
 
@@ -710,7 +734,14 @@ where
                 modules.merge_if_module_configured(RethRpcModule::Eth, eth_config.into_rpc())?;
 
                 debug!(target: "reth::cli", "Installing debug payload witness rpc endpoint");
-                modules.merge_if_module_configured(RethRpcModule::Debug, debug_ext.into_rpc())?;
+                modules.merge_if_module_configured(
+                    RethRpcModule::Debug,
+                    DebugExecutionWitnessApiServer::into_rpc(debug_ext.clone()),
+                )?;
+                modules.merge_if_module_configured(
+                    RethRpcModule::Debug,
+                    OpDebugPostExecApiServer::into_rpc(debug_ext.clone()),
+                )?;
 
                 // extend the miner namespace if configured in the regular http server
                 modules.add_or_replace_if_module_configured(
@@ -750,7 +781,7 @@ where
     N: FullNodeComponents<
             Types: NodeTypes<
                 ChainSpec: OpHardforks + Hardforks,
-                Primitives: OpPayloadPrimitives<_Header: HeaderMut>,
+                Primitives: OpReplayNodePrimitives<_Header: HeaderMut>,
             >,
             Evm: ConfigurePostExecEvm<
                 Primitives = PrimitivesTy<N::Types>,

--- a/rust/op-reth/crates/node/src/node.rs
+++ b/rust/op-reth/crates/node/src/node.rs
@@ -259,7 +259,7 @@ impl OpNode {
             self.args;
         ComponentsBuilder::default()
             .node_types::<Node>()
-            .executor(OpExecutorBuilder::default().with_sdm_enabled(self.args.sdm_enabled))
+            .executor(OpExecutorBuilder::default())
             .pool(
                 OpPoolBuilder::default()
                     .with_enable_tx_conditional(self.args.enable_tx_conditional)
@@ -271,8 +271,7 @@ impl OpNode {
             .payload(BasicPayloadServiceBuilder::new(
                 OpPayloadBuilder::new(compute_pending_block)
                     .with_da_config(self.da_config.clone())
-                    .with_gas_limit_config(self.gas_limit_config.clone())
-                    .with_sdm_enabled(self.args.sdm_enabled),
+                    .with_gas_limit_config(self.gas_limit_config.clone()),
             ))
             .network(OpNetworkBuilder::new(disable_txpool_gossip, !discovery_v4))
             .consensus(OpConsensusBuilder::default())
@@ -285,7 +284,6 @@ impl OpNode {
             .with_sequencer_headers(self.args.sequencer_headers.clone())
             .with_da_config(self.da_config.clone())
             .with_gas_limit_config(self.gas_limit_config.clone())
-            .with_sdm_enabled(self.args.sdm_enabled)
             .with_enable_tx_conditional(self.args.enable_tx_conditional)
             .with_min_suggested_priority_fee(self.args.min_suggested_priority_fee)
             .with_historical_rpc(self.args.historical_rpc.clone())
@@ -416,8 +414,6 @@ pub struct OpAddOns<
     ///
     /// This can be used to forward pre-bedrock rpc requests (op-mainnet).
     pub historical_rpc: Option<String>,
-    /// Whether SDM is explicitly enabled for integration tests.
-    sdm_enabled: bool,
     /// Enable transaction conditionals.
     enable_tx_conditional: bool,
     min_suggested_priority_fee: u64,
@@ -437,7 +433,6 @@ where
         sequencer_url: Option<String>,
         sequencer_headers: Vec<String>,
         historical_rpc: Option<String>,
-        sdm_enabled: bool,
         enable_tx_conditional: bool,
         min_suggested_priority_fee: u64,
     ) -> Self {
@@ -448,7 +443,6 @@ where
             sequencer_url,
             sequencer_headers,
             historical_rpc,
-            sdm_enabled,
             enable_tx_conditional,
             min_suggested_priority_fee,
         }
@@ -500,7 +494,6 @@ where
             sequencer_url,
             sequencer_headers,
             historical_rpc,
-            sdm_enabled,
             enable_tx_conditional,
             min_suggested_priority_fee,
             ..
@@ -512,7 +505,6 @@ where
             sequencer_url,
             sequencer_headers,
             historical_rpc,
-            sdm_enabled,
             enable_tx_conditional,
             min_suggested_priority_fee,
         )
@@ -529,7 +521,6 @@ where
             gas_limit_config,
             sequencer_url,
             sequencer_headers,
-            sdm_enabled,
             enable_tx_conditional,
             min_suggested_priority_fee,
             historical_rpc,
@@ -542,7 +533,6 @@ where
             sequencer_url,
             sequencer_headers,
             historical_rpc,
-            sdm_enabled,
             enable_tx_conditional,
             min_suggested_priority_fee,
         )
@@ -559,7 +549,6 @@ where
             gas_limit_config,
             sequencer_url,
             sequencer_headers,
-            sdm_enabled,
             enable_tx_conditional,
             min_suggested_priority_fee,
             historical_rpc,
@@ -572,7 +561,6 @@ where
             sequencer_url,
             sequencer_headers,
             historical_rpc,
-            sdm_enabled,
             enable_tx_conditional,
             min_suggested_priority_fee,
         )
@@ -592,7 +580,6 @@ where
             gas_limit_config,
             sequencer_url,
             sequencer_headers,
-            sdm_enabled,
             enable_tx_conditional,
             min_suggested_priority_fee,
             historical_rpc,
@@ -605,7 +592,6 @@ where
             sequencer_url,
             sequencer_headers,
             historical_rpc,
-            sdm_enabled,
             enable_tx_conditional,
             min_suggested_priority_fee,
         )
@@ -840,8 +826,6 @@ pub struct OpAddOnsBuilder<NetworkT, RpcMiddleware = Identity> {
     da_config: Option<OpDAConfig>,
     /// Gas limit configuration for the OP builder.
     gas_limit_config: Option<OpGasLimitConfig>,
-    /// Whether SDM is explicitly enabled for integration tests.
-    sdm_enabled: bool,
     /// Enable transaction conditionals.
     enable_tx_conditional: bool,
     /// Marker for network types.
@@ -866,7 +850,6 @@ impl<NetworkT> Default for OpAddOnsBuilder<NetworkT> {
             historical_rpc: None,
             da_config: None,
             gas_limit_config: None,
-            sdm_enabled: false,
             enable_tx_conditional: false,
             min_suggested_priority_fee: 1_000_000,
             _nt: PhantomData,
@@ -900,13 +883,6 @@ impl<NetworkT, RpcMiddleware> OpAddOnsBuilder<NetworkT, RpcMiddleware> {
     /// Configure the gas limit configuration for the OP payload builder.
     pub fn with_gas_limit_config(mut self, gas_limit_config: OpGasLimitConfig) -> Self {
         self.gas_limit_config = Some(gas_limit_config);
-        self
-    }
-
-    /// Configure the temporary SDM integration-test override.
-    #[must_use]
-    pub const fn with_sdm_enabled(mut self, sdm_enabled: bool) -> Self {
-        self.sdm_enabled = sdm_enabled;
         self
     }
 
@@ -944,7 +920,6 @@ impl<NetworkT, RpcMiddleware> OpAddOnsBuilder<NetworkT, RpcMiddleware> {
             historical_rpc,
             da_config,
             gas_limit_config,
-            sdm_enabled,
             enable_tx_conditional,
             min_suggested_priority_fee,
             tokio_runtime,
@@ -959,7 +934,6 @@ impl<NetworkT, RpcMiddleware> OpAddOnsBuilder<NetworkT, RpcMiddleware> {
             historical_rpc,
             da_config,
             gas_limit_config,
-            sdm_enabled,
             enable_tx_conditional,
             min_suggested_priority_fee,
             _nt,
@@ -1000,7 +974,6 @@ impl<NetworkT, RpcMiddleware> OpAddOnsBuilder<NetworkT, RpcMiddleware> {
             sequencer_headers,
             da_config,
             gas_limit_config,
-            sdm_enabled,
             enable_tx_conditional,
             min_suggested_priority_fee,
             historical_rpc,
@@ -1017,7 +990,6 @@ impl<NetworkT, RpcMiddleware> OpAddOnsBuilder<NetworkT, RpcMiddleware> {
                     .with_sequencer(sequencer_url.clone())
                     .with_sequencer_headers(sequencer_headers.clone())
                     .with_min_suggested_priority_fee(min_suggested_priority_fee)
-                    .with_sdm_enabled(sdm_enabled)
                     .with_flashblocks(flashblocks_url)
                     .with_flashblock_consensus(flashblock_consensus),
                 PVB::default(),
@@ -1032,7 +1004,6 @@ impl<NetworkT, RpcMiddleware> OpAddOnsBuilder<NetworkT, RpcMiddleware> {
             sequencer_url,
             sequencer_headers,
             historical_rpc,
-            sdm_enabled,
             enable_tx_conditional,
             min_suggested_priority_fee,
         )
@@ -1042,19 +1013,7 @@ impl<NetworkT, RpcMiddleware> OpAddOnsBuilder<NetworkT, RpcMiddleware> {
 /// A regular optimism evm and executor builder.
 #[derive(Debug, Copy, Clone, Default)]
 #[non_exhaustive]
-pub struct OpExecutorBuilder {
-    /// Whether SDM is explicitly enabled for integration tests.
-    pub sdm_enabled: bool,
-}
-
-impl OpExecutorBuilder {
-    /// Configure the temporary SDM integration-test override.
-    #[must_use]
-    pub const fn with_sdm_enabled(mut self, sdm_enabled: bool) -> Self {
-        self.sdm_enabled = sdm_enabled;
-        self
-    }
-}
+pub struct OpExecutorBuilder;
 
 impl<Node> ExecutorBuilder<Node> for OpExecutorBuilder
 where
@@ -1064,10 +1023,7 @@ where
         OpEvmConfig<<Node::Types as NodeTypes>::ChainSpec, <Node::Types as NodeTypes>::Primitives>;
 
     async fn build_evm(self, ctx: &BuilderContext<Node>) -> eyre::Result<Self::EVM> {
-        let evm_config = OpEvmConfig::new(ctx.chain_spec(), OpRethReceiptBuilder::default())
-            .with_sdm_enabled(self.sdm_enabled);
-
-        Ok(evm_config)
+        Ok(OpEvmConfig::new(ctx.chain_spec(), OpRethReceiptBuilder::default()))
     }
 }
 
@@ -1287,11 +1243,6 @@ pub struct OpPayloadBuilder<Txs = ()> {
     /// Gas limit configuration for the OP builder.
     /// This is used to configure gas limit related constraints for the payload builder.
     pub gas_limit_config: OpGasLimitConfig,
-    /// Whether produced payloads should inject a post-exec transaction.
-    ///
-    /// This is a temporary integration-test override; SDM has no scheduled Jovian/Karst
-    /// activation.
-    pub sdm_enabled: bool,
 }
 
 impl OpPayloadBuilder {
@@ -1303,7 +1254,6 @@ impl OpPayloadBuilder {
             best_transactions: (),
             da_config: OpDAConfig::default(),
             gas_limit_config: OpGasLimitConfig::default(),
-            sdm_enabled: false,
         }
     }
 
@@ -1318,27 +1268,14 @@ impl OpPayloadBuilder {
         self.gas_limit_config = gas_limit_config;
         self
     }
-
-    /// Configure whether the OP payload builder should inject a post-exec tx in integration tests.
-    #[must_use]
-    pub const fn with_sdm_enabled(mut self, sdm_enabled: bool) -> Self {
-        self.sdm_enabled = sdm_enabled;
-        self
-    }
 }
 
 impl<Txs> OpPayloadBuilder<Txs> {
     /// Configures the type responsible for yielding the transactions that should be included in the
     /// payload.
     pub fn with_transactions<T>(self, best_transactions: T) -> OpPayloadBuilder<T> {
-        let Self { compute_pending_block, da_config, gas_limit_config, sdm_enabled, .. } = self;
-        OpPayloadBuilder {
-            compute_pending_block,
-            best_transactions,
-            da_config,
-            gas_limit_config,
-            sdm_enabled,
-        }
+        let Self { compute_pending_block, da_config, gas_limit_config, .. } = self;
+        OpPayloadBuilder { compute_pending_block, best_transactions, da_config, gas_limit_config }
     }
 }
 
@@ -1387,7 +1324,6 @@ where
             OpBuilderConfig {
                 da_config: self.da_config.clone(),
                 gas_limit_config: self.gas_limit_config.clone(),
-                sdm_enabled: self.sdm_enabled,
             },
         )
         .with_transactions(self.best_transactions.clone())

--- a/rust/op-reth/crates/node/tests/it/builder.rs
+++ b/rust/op-reth/crates/node/tests/it/builder.rs
@@ -61,21 +61,6 @@ fn test_basic_setup() {
         .check_launch();
 }
 
-// Launch-plumbing coverage for the SDM CLI/config flag: the node builder should still compose
-// when the experimental override is enabled.
-#[test]
-fn test_basic_setup_with_sdm_enabled_flag() {
-    let config = NodeConfig::new(BASE_MAINNET.clone());
-    let db = create_test_rw_db();
-    let args = RollupArgs { sdm_enabled: true, ..Default::default() };
-    let op_node = OpNode::new(args);
-    let _builder = NodeBuilder::new(config)
-        .with_database(db)
-        .with_types_and_provider::<OpNode, BlockchainProvider<NodeTypesWithDBAdapter<OpNode, _>>>()
-        .with_components(op_node.components())
-        .with_add_ons(op_node.add_ons())
-        .check_launch();
-}
 
 #[test]
 fn test_setup_custom_precompiles() {
@@ -185,7 +170,7 @@ fn test_setup_custom_precompiles() {
         >;
 
         async fn build_evm(self, ctx: &BuilderContext<Node>) -> eyre::Result<Self::EVM> {
-            let OpEvmConfig { executor_factory, block_assembler, sdm_enabled, _pd: _ } =
+            let OpEvmConfig { executor_factory, block_assembler, _pd: _ } =
                 OpExecutorBuilder::default().build_evm(ctx).await?;
             let uni_executor_factory = OpBlockExecutorFactory::new(
                 *executor_factory.receipt_builder(),
@@ -195,7 +180,6 @@ fn test_setup_custom_precompiles() {
             let uni_evm_config = OpEvmConfig {
                 executor_factory: uni_executor_factory,
                 block_assembler,
-                sdm_enabled,
                 _pd: PhantomData,
             };
             Ok(uni_evm_config)

--- a/rust/op-reth/crates/payload/src/builder.rs
+++ b/rust/op-reth/crates/payload/src/builder.rs
@@ -684,10 +684,13 @@ where
         )
     }
 
-    /// Returns whether SDM production is enabled for this payload by the explicit integration-test
-    /// override.
-    pub const fn sdm_production_enabled(&self) -> bool {
-        self.builder_config.sdm_enabled
+    /// Returns whether SDM production is consensus-active for the block being built.
+    ///
+    /// SDM activates with the Interop hardfork; both this EL gate and the op-node CL gate
+    /// (`IsSDM == IsInterop` in `op-node/rollup/toggles.go`) read from the same chain spec, so
+    /// they cannot drift.
+    pub fn sdm_production_enabled(&self) -> bool {
+        self.chain_spec.is_interop_active_at_timestamp(self.attributes().timestamp())
     }
 
     /// Returns the unique id for this payload job.

--- a/rust/op-reth/crates/payload/src/builder/tests.rs
+++ b/rust/op-reth/crates/payload/src/builder/tests.rs
@@ -1,11 +1,7 @@
 use super::{
-    ExecutionInfo, OpPayloadBuilder, OpPayloadBuilderCtx, build_post_exec_recovered_tx,
-    try_include_post_exec_tx,
+    ExecutionInfo, OpPayloadBuilderCtx, build_post_exec_recovered_tx, try_include_post_exec_tx,
 };
-use crate::{
-    OpPayloadBuilderAttributes,
-    config::{OpBuilderConfig, OpDAConfig, OpGasLimitConfig},
-};
+use crate::{OpPayloadBuilderAttributes, config::OpBuilderConfig};
 use alloy_consensus::{
     Header, SignableTransaction, TxEip1559, Typed2718,
     transaction::{Recovered, TxHashRef},
@@ -148,24 +144,6 @@ fn run_execute_best_transactions(
         .collect();
 
     (info, included_tx_hashes)
-}
-
-// Ensures the payload builder keeps SDM disabled by default and preserves the explicit
-// integration-test override when swapping in a transaction source.
-#[test]
-fn payload_builder_preserves_sdm_config() {
-    let default = OpBuilderConfig::new(OpDAConfig::default(), OpGasLimitConfig::default());
-    assert!(!default.sdm_enabled);
-
-    let builder = OpPayloadBuilder::<(), (), (), (), ()>::with_builder_config(
-        (),
-        (),
-        (),
-        OpBuilderConfig::new_with_sdm(OpDAConfig::default(), OpGasLimitConfig::default(), true),
-    )
-    .with_transactions(42u64);
-    assert!(builder.config.sdm_enabled);
-    assert_eq!(builder.best_transactions, 42);
 }
 
 #[test]

--- a/rust/op-reth/crates/payload/src/config.rs
+++ b/rust/op-reth/crates/payload/src/config.rs
@@ -9,28 +9,12 @@ pub struct OpBuilderConfig {
     pub da_config: OpDAConfig,
     /// Gas limit configuration for the OP builder.
     pub gas_limit_config: OpGasLimitConfig,
-    /// Whether post-exec transactions should be injected for produced payloads.
-    ///
-    /// This is a temporary integration-test override; SDM has no scheduled Jovian/Karst
-    /// activation.
-    pub sdm_enabled: bool,
 }
 
 impl OpBuilderConfig {
     /// Creates a new OP builder configuration with the given data availability configuration.
     pub const fn new(da_config: OpDAConfig, gas_limit_config: OpGasLimitConfig) -> Self {
-        Self { da_config, gas_limit_config, sdm_enabled: false }
-    }
-
-    /// Creates a new OP builder configuration with SDM (Sequencer-Defined Metering) enabled per
-    /// the given flag.
-    #[must_use]
-    pub const fn new_with_sdm(
-        da_config: OpDAConfig,
-        gas_limit_config: OpGasLimitConfig,
-        sdm_enabled: bool,
-    ) -> Self {
-        Self { da_config, gas_limit_config, sdm_enabled }
+        Self { da_config, gas_limit_config }
     }
 
     /// Returns the Data Availability configuration for the OP builder, if it has configured

--- a/rust/op-reth/crates/post-exec-replay/Cargo.toml
+++ b/rust/op-reth/crates/post-exec-replay/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "reth-optimism-post-exec-replay"
+version = "1.11.3"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage = "https://paradigmxyz.github.io/reth"
+repository = "https://github.com/paradigmxyz/reth"
+description = "Counterfactual post-exec replay support for op-reth."
+
+[lints]
+workspace = true
+
+[dependencies]
+reth-evm.workspace = true
+reth-execution-errors.workspace = true
+reth-node-api.workspace = true
+reth-optimism-evm = { workspace = true, features = ["std"] }
+reth-primitives-traits.workspace = true
+
+revm.workspace = true
+
+alloy-consensus.workspace = true
+alloy-eips.workspace = true
+alloy-primitives.workspace = true
+op-alloy-consensus.workspace = true
+
+serde.workspace = true
+thiserror.workspace = true
+
+[dev-dependencies]
+alloy-primitives.workspace = true
+reth-optimism-primitives = { workspace = true, features = ["serde", "reth-codec"] }

--- a/rust/op-reth/crates/post-exec-replay/src/lib.rs
+++ b/rust/op-reth/crates/post-exec-replay/src/lib.rs
@@ -1,0 +1,14 @@
+//! Counterfactual post-exec replay support for op-reth.
+
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+
+mod replay;
+mod types;
+
+pub use replay::{PostExecReplayError, replay_block, strip_post_exec_tx_for_replay};
+pub use types::{
+    PostExecReplayBlock, PostExecReplayConfig, PostExecReplayMismatch, PostExecReplayMismatchKind,
+    PostExecReplayPayload, PostExecReplayPayloadEntry, PostExecReplayRefundEvent,
+    PostExecReplayRefundKind, PostExecReplaySummary, PostExecReplayTx, ReplayPostExecBlockOptions,
+    ReplayPostExecBlockRequest,
+};

--- a/rust/op-reth/crates/post-exec-replay/src/replay.rs
+++ b/rust/op-reth/crates/post-exec-replay/src/replay.rs
@@ -1,0 +1,574 @@
+use crate::types::{
+    PostExecReplayBlock, PostExecReplayConfig, PostExecReplayMismatch, PostExecReplayMismatchKind,
+    PostExecReplayPayload, PostExecReplayPayloadEntry, PostExecReplayRefundEvent,
+    PostExecReplayRefundKind, PostExecReplaySummary, PostExecReplayTx,
+};
+use alloy_consensus::{
+    Block as AlloyBlock, BlockBody, BlockHeader as AlloyBlockHeader, TxReceipt, Typed2718,
+};
+use op_alloy_consensus::{
+    OpTransaction, POST_EXEC_PAYLOAD_VERSION, POST_EXEC_TX_TYPE_ID, PostExecPayload, SDMGasEntry,
+    build_post_exec_tx,
+};
+use reth_evm::{Database, execute::BlockExecutor};
+use reth_execution_errors::BlockExecutionError;
+use reth_node_api::NodePrimitives;
+use reth_optimism_evm::{
+    ConfigurePostExecEvm, PostExecExecutorExt, WarmingRefundEvent, WarmingRefundKind,
+};
+use reth_primitives_traits::{Block, BlockHeader, RecoveredBlock, SignedTransaction};
+use revm::database::State;
+use std::collections::{BTreeMap, BTreeSet};
+
+/// Replay error.
+#[derive(Debug, thiserror::Error)]
+pub enum PostExecReplayError {
+    /// Execution failed.
+    #[error(transparent)]
+    Execution(#[from] BlockExecutionError),
+}
+
+struct NormalizedBlock<Tx, Header>
+where
+    Tx: SignedTransaction + OpTransaction + Clone,
+    Header: BlockHeader + AlloyBlockHeader + Clone,
+    AlloyBlock<Tx, Header>: Block<Header = Header, Body = BlockBody<Tx, Header>>,
+{
+    replay_block: RecoveredBlock<AlloyBlock<Tx, Header>>,
+    original_indexes: Vec<u64>,
+    embedded_payload: Option<PostExecPayload>,
+    post_exec_tx_index: Option<u64>,
+}
+
+/// Strip the synthetic post-exec tx from a block before replay while preserving original indexes.
+pub fn strip_post_exec_tx_for_replay<Tx, Header>(
+    block: &RecoveredBlock<AlloyBlock<Tx, Header>>,
+) -> (RecoveredBlock<AlloyBlock<Tx, Header>>, Vec<u64>)
+where
+    Tx: SignedTransaction + OpTransaction + Clone,
+    Header: BlockHeader + AlloyBlockHeader + Clone,
+    AlloyBlock<Tx, Header>: Block<Header = Header, Body = BlockBody<Tx, Header>>,
+{
+    let normalized = normalize_block(block);
+    (normalized.replay_block, normalized.original_indexes)
+}
+
+fn normalize_block<Tx, Header>(
+    block: &RecoveredBlock<AlloyBlock<Tx, Header>>,
+) -> NormalizedBlock<Tx, Header>
+where
+    Tx: SignedTransaction + OpTransaction + Clone,
+    Header: BlockHeader + AlloyBlockHeader + Clone,
+    AlloyBlock<Tx, Header>: Block<Header = Header, Body = BlockBody<Tx, Header>>,
+{
+    let (raw_block, senders) = block.clone().split();
+    let (header, body) = raw_block.split();
+    let BlockBody { transactions, ommers, withdrawals } = body;
+
+    let mut replay_transactions = Vec::with_capacity(transactions.len());
+    let mut replay_senders = Vec::with_capacity(senders.len());
+    let mut original_indexes = Vec::with_capacity(transactions.len());
+    let mut embedded_payload = None;
+    let mut post_exec_tx_index = None;
+
+    for (original_index, (tx, sender)) in
+        transactions.into_iter().zip(senders.into_iter()).enumerate()
+    {
+        let original_index = original_index as u64;
+        if Typed2718::ty(&tx) == POST_EXEC_TX_TYPE_ID {
+            post_exec_tx_index = Some(original_index);
+            if let Some(post_exec) = tx.as_post_exec() {
+                embedded_payload = Some(post_exec.inner().payload.clone());
+            }
+            continue;
+        }
+
+        original_indexes.push(original_index);
+        replay_transactions.push(tx);
+        replay_senders.push(sender);
+    }
+
+    let replay_block = RecoveredBlock::new_unhashed(
+        AlloyBlock::new(
+            header,
+            BlockBody { transactions: replay_transactions, ommers, withdrawals },
+        ),
+        replay_senders,
+    );
+
+    NormalizedBlock { replay_block, original_indexes, embedded_payload, post_exec_tx_index }
+}
+
+const fn into_refund_kind(kind: WarmingRefundKind) -> PostExecReplayRefundKind {
+    match kind {
+        WarmingRefundKind::WarmAccount => PostExecReplayRefundKind::WarmAccount,
+        WarmingRefundKind::WarmSload => PostExecReplayRefundKind::WarmSload,
+        WarmingRefundKind::WarmSstore => PostExecReplayRefundKind::WarmSstore,
+    }
+}
+
+fn original_tx_index(original_indexes: &[u64], replay_tx_index: u64) -> u64 {
+    original_indexes.get(replay_tx_index as usize).copied().unwrap_or(replay_tx_index)
+}
+
+fn into_refund_event(
+    event: WarmingRefundEvent,
+    claiming_replay_tx_index: u64,
+    original_indexes: &[u64],
+) -> PostExecReplayRefundEvent {
+    let first_warmed_by_replay_tx_index = event.first_warmed_by_tx_index;
+
+    PostExecReplayRefundEvent {
+        claiming_replay_tx_index,
+        claiming_tx_index: original_tx_index(original_indexes, claiming_replay_tx_index),
+        kind: into_refund_kind(event.kind),
+        amount: event.amount,
+        address: event.address,
+        slot: event.slot,
+        first_warmed_by_replay_tx_index,
+        first_warmed_by_tx_index: original_tx_index(
+            original_indexes,
+            first_warmed_by_replay_tx_index,
+        ),
+    }
+}
+
+const fn replay_mismatch(
+    category: PostExecReplayMismatchKind,
+    block_num: u64,
+    tx_index: Option<u64>,
+    expected: Option<u64>,
+    actual: Option<u64>,
+    message: String,
+) -> PostExecReplayMismatch {
+    PostExecReplayMismatch { category, block_num, tx_index, expected, actual, message }
+}
+
+fn build_payload_map<Tx, Header>(
+    block_number: u64,
+    block: &RecoveredBlock<AlloyBlock<Tx, Header>>,
+    payload: &PostExecPayload,
+    mismatches: &mut Vec<PostExecReplayMismatch>,
+) -> BTreeMap<u64, u64>
+where
+    Tx: SignedTransaction + OpTransaction + Typed2718,
+    Header: BlockHeader,
+    AlloyBlock<Tx, Header>: Block<Header = Header, Body = BlockBody<Tx, Header>>,
+{
+    let transactions = &block.body().transactions;
+    let tx_count = transactions.len() as u64;
+    let mut refunds = BTreeMap::new();
+    let mut seen = BTreeSet::new();
+
+    for entry in &payload.gas_refund_entries {
+        let tx_index = entry.index;
+        if !seen.insert(tx_index) {
+            mismatches.push(replay_mismatch(
+                PostExecReplayMismatchKind::DuplicatePayloadIndex,
+                block_number,
+                Some(tx_index),
+                None,
+                Some(entry.gas_refund),
+                format!("duplicate payload entry for tx index {tx_index}"),
+            ));
+            continue;
+        }
+
+        if tx_index >= tx_count {
+            mismatches.push(replay_mismatch(
+                PostExecReplayMismatchKind::PayloadIndexOutOfRange,
+                block_number,
+                Some(tx_index),
+                Some(tx_count.saturating_sub(1)),
+                Some(tx_index),
+                format!("payload entry targets out-of-range tx index {tx_index}"),
+            ));
+            continue;
+        }
+
+        let tx = &transactions[tx_index as usize];
+        if tx.is_deposit() {
+            mismatches.push(replay_mismatch(
+                PostExecReplayMismatchKind::PayloadTargetsDeposit,
+                block_number,
+                Some(tx_index),
+                Some(0),
+                Some(entry.gas_refund),
+                format!("payload entry targets deposit tx index {tx_index}"),
+            ));
+            continue;
+        }
+
+        if Typed2718::ty(tx) == POST_EXEC_TX_TYPE_ID {
+            mismatches.push(replay_mismatch(
+                PostExecReplayMismatchKind::PayloadTargetsPostExec,
+                block_number,
+                Some(tx_index),
+                Some(0),
+                Some(entry.gas_refund),
+                format!("payload entry targets post-exec tx index {tx_index}"),
+            ));
+            continue;
+        }
+
+        refunds.insert(tx_index, entry.gas_refund);
+    }
+
+    refunds
+}
+
+fn into_replay_payload(payload: PostExecPayload) -> PostExecReplayPayload {
+    PostExecReplayPayload {
+        version: payload.version.into(),
+        block_number: payload.block_number,
+        gas_refund_entries: payload
+            .gas_refund_entries
+            .into_iter()
+            .map(|entry| PostExecReplayPayloadEntry {
+                index: entry.index,
+                gas_refund: entry.gas_refund,
+            })
+            .collect(),
+    }
+}
+
+struct CompareRefundsInput<'a> {
+    block_number: u64,
+    tx_index: u64,
+    raw_gas_used: u64,
+    replay_refund: u64,
+    payload_refund: Option<u64>,
+    config: &'a PostExecReplayConfig,
+}
+
+fn compare_refunds(
+    input: CompareRefundsInput<'_>,
+    mismatches: &mut Vec<PostExecReplayMismatch>,
+) -> bool {
+    let CompareRefundsInput {
+        block_number,
+        tx_index,
+        raw_gas_used,
+        replay_refund,
+        payload_refund,
+        config,
+    } = input;
+    let mismatch_count = mismatches.len();
+
+    if let Some(payload_refund) = payload_refund &&
+        payload_refund > raw_gas_used
+    {
+        mismatches.push(replay_mismatch(
+            PostExecReplayMismatchKind::PayloadRefundExceedsRawGas,
+            block_number,
+            Some(tx_index),
+            Some(raw_gas_used),
+            Some(payload_refund),
+            format!("payload refund exceeds raw gas for tx index {tx_index}"),
+        ));
+    }
+
+    if config.compare_payload && payload_refund.unwrap_or_default() != replay_refund {
+        mismatches.push(replay_mismatch(
+            PostExecReplayMismatchKind::PayloadRefundMismatch,
+            block_number,
+            Some(tx_index),
+            payload_refund,
+            Some(replay_refund),
+            format!("payload refund mismatch for tx index {tx_index}"),
+        ));
+    }
+
+    mismatches.len() != mismatch_count
+}
+
+/// Replay a historical block with post-exec enabled counterfactually.
+pub fn replay_block<DB, EvmConfig, Tx, Header>(
+    evm_config: &EvmConfig,
+    db: DB,
+    block: &RecoveredBlock<AlloyBlock<Tx, Header>>,
+    config: PostExecReplayConfig,
+) -> Result<PostExecReplayBlock, PostExecReplayError>
+where
+    DB: Database,
+    EvmConfig: ConfigurePostExecEvm,
+    EvmConfig::Primitives: NodePrimitives<
+            Block = AlloyBlock<Tx, Header>,
+            BlockBody = BlockBody<Tx, Header>,
+            BlockHeader = Header,
+            SignedTx = Tx,
+        >,
+    Tx: SignedTransaction + OpTransaction + Clone,
+    Header: BlockHeader + AlloyBlockHeader + Clone,
+    AlloyBlock<Tx, Header>: Block<Header = Header, Body = BlockBody<Tx, Header>>,
+{
+    let normalized = normalize_block(block);
+    let block_number = block.header().number();
+    let block_hash = block.hash();
+    let post_exec_tx_present = normalized.post_exec_tx_index.is_some();
+
+    let mut state = State::builder().with_database(db).with_bundle_update().build();
+    let mut executor = evm_config
+        .post_exec_executor_for_block(
+            &mut state,
+            normalized.replay_block.sealed_block(),
+            reth_optimism_evm::PostExecMode::Produce,
+        )
+        .map_err(BlockExecutionError::other)?;
+
+    executor.apply_pre_execution_changes()?;
+    for tx in normalized.replay_block.clone_transactions_recovered() {
+        executor.execute_transaction(tx)?;
+    }
+    let replay_entries: Vec<SDMGasEntry> = executor.take_post_exec_entries();
+    let warming_events_by_tx = executor.take_warming_events_by_tx();
+    let execution = executor.apply_post_execution_changes()?;
+
+    let replay_payload = PostExecPayload {
+        version: POST_EXEC_PAYLOAD_VERSION,
+        block_number,
+        gas_refund_entries: replay_entries.clone(),
+    };
+    let replay_refunds: BTreeMap<u64, u64> =
+        replay_entries.iter().map(|entry| (entry.index, entry.gas_refund)).collect();
+
+    let mut mismatches = Vec::new();
+    let payload_refunds = match (config.compare_payload, normalized.embedded_payload.as_ref()) {
+        (true, Some(payload)) => build_payload_map(block_number, block, payload, &mut mismatches),
+        _ => BTreeMap::new(),
+    };
+
+    let mut txs = Vec::with_capacity(normalized.replay_block.body().transactions.len());
+    let mut previous_cumulative_gas = 0_u64;
+
+    for (replay_idx, (tx, &tx_index)) in normalized
+        .replay_block
+        .body()
+        .transactions
+        .iter()
+        .zip(&normalized.original_indexes)
+        .enumerate()
+    {
+        let replay_tx_index = replay_idx as u64;
+        let cumulative_gas_used = execution.receipts[replay_idx].cumulative_gas_used();
+        let canonical_gas_used = cumulative_gas_used.saturating_sub(previous_cumulative_gas);
+        previous_cumulative_gas = cumulative_gas_used;
+
+        let replay_refund = replay_refunds.get(&tx_index).copied().unwrap_or_default();
+        let raw_gas_used = canonical_gas_used.saturating_add(replay_refund);
+        let payload_refund = payload_refunds.get(&tx_index).copied();
+        let refund_breakdown = warming_events_by_tx
+            .get(replay_idx)
+            .into_iter()
+            .flatten()
+            .copied()
+            .map(|event| into_refund_event(event, replay_tx_index, &normalized.original_indexes))
+            .collect();
+        let mismatch = compare_refunds(
+            CompareRefundsInput {
+                block_number,
+                tx_index,
+                raw_gas_used,
+                replay_refund,
+                payload_refund,
+                config: &config,
+            },
+            &mut mismatches,
+        );
+
+        txs.push(PostExecReplayTx {
+            tx_index,
+            replay_tx_index,
+            tx_hash: *tx.tx_hash(),
+            tx_type: tx.ty(),
+            is_deposit_tx: tx.is_deposit(),
+            raw_gas_used,
+            canonical_gas_used,
+            op_gas_refund_replay: replay_refund,
+            op_gas_refund_payload: payload_refund,
+            refund_breakdown,
+            mismatch,
+        });
+    }
+
+    let tx_count_user = txs.iter().filter(|tx| !tx.is_deposit_tx).count();
+    let replay_refund_total = txs.iter().map(|tx| tx.op_gas_refund_replay).sum::<u64>();
+    let payload_refund_total =
+        txs.iter().map(|tx| tx.op_gas_refund_payload.unwrap_or_default()).sum::<u64>();
+    let block_gas_used = txs.iter().map(|tx| tx.canonical_gas_used).sum::<u64>();
+    let block_raw_gas_used = txs.iter().map(|tx| tx.raw_gas_used).sum::<u64>();
+
+    let summary = PostExecReplaySummary {
+        block_num: block_number,
+        block_hash,
+        tx_count_total: txs.len(),
+        tx_count_user,
+        post_exec_tx_present,
+        post_exec_payload_entry_count: replay_entries.len(),
+        block_gas_used,
+        block_raw_gas_used,
+        replay_refund_total,
+        payload_refund_total,
+        mismatch_count: mismatches.len(),
+    };
+
+    Ok(PostExecReplayBlock {
+        config,
+        block_num: block_number,
+        block_hash,
+        parent_hash: block.header().parent_hash(),
+        post_exec_tx_present,
+        post_exec_tx_index: normalized.post_exec_tx_index,
+        embedded_payload: normalized.embedded_payload.map(into_replay_payload),
+        synthesized_payload_bytes: build_post_exec_tx(block_number, replay_entries)
+            .payload
+            .to_rlp_bytes(),
+        synthesized_payload: into_replay_payload(replay_payload),
+        txs,
+        mismatches,
+        summary,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        CompareRefundsInput, build_payload_map, compare_refunds, normalize_block,
+        strip_post_exec_tx_for_replay,
+    };
+    use crate::{PostExecReplayConfig, PostExecReplayMismatchKind};
+    use alloy_consensus::{BlockBody, Header, Sealable, SignableTransaction, TxLegacy};
+    use alloy_primitives::{Address, Signature, U256};
+    use op_alloy_consensus::{
+        OpTxEnvelope, POST_EXEC_PAYLOAD_VERSION, TxDeposit, build_post_exec_tx,
+    };
+    use reth_optimism_primitives::OpTransactionSigned;
+    use reth_primitives_traits::RecoveredBlock;
+
+    fn user_tx() -> OpTransactionSigned {
+        OpTxEnvelope::Legacy(TxLegacy::default().into_signed(Signature::new(
+            U256::ZERO,
+            U256::ZERO,
+            false,
+        )))
+    }
+
+    #[test]
+    fn strips_post_exec_tx_and_preserves_original_indexes() {
+        let deposit: OpTransactionSigned = OpTxEnvelope::Deposit(TxDeposit::default().seal_slow());
+        let user = user_tx();
+        let post_exec: OpTransactionSigned =
+            OpTransactionSigned::PostExec(build_post_exec_tx(0, vec![]).seal_slow());
+
+        let block = RecoveredBlock::new_unhashed(
+            alloy_consensus::Block::new(
+                Header::default(),
+                BlockBody {
+                    transactions: vec![deposit, user, post_exec],
+                    ommers: vec![],
+                    withdrawals: None,
+                },
+            ),
+            vec![Address::ZERO, Address::ZERO, Address::ZERO],
+        );
+
+        let (replay_block, original_indexes) = strip_post_exec_tx_for_replay(&block);
+        assert_eq!(replay_block.body().transactions.len(), 2);
+        assert_eq!(original_indexes, vec![0, 1]);
+    }
+
+    #[test]
+    fn normalize_block_extracts_embedded_payload_and_post_exec_index() {
+        let deposit: OpTransactionSigned = OpTxEnvelope::Deposit(TxDeposit::default().seal_slow());
+        let user = user_tx();
+        let payload_entries = vec![op_alloy_consensus::SDMGasEntry { index: 1, gas_refund: 9 }];
+        let post_exec: OpTransactionSigned = OpTransactionSigned::PostExec(
+            build_post_exec_tx(0, payload_entries.clone()).seal_slow(),
+        );
+
+        let block = RecoveredBlock::new_unhashed(
+            alloy_consensus::Block::new(
+                Header::default(),
+                BlockBody {
+                    transactions: vec![deposit, user, post_exec],
+                    ommers: vec![],
+                    withdrawals: None,
+                },
+            ),
+            vec![Address::ZERO, Address::ZERO, Address::ZERO],
+        );
+
+        let normalized = normalize_block(&block);
+        assert_eq!(normalized.post_exec_tx_index, Some(2));
+        assert_eq!(normalized.original_indexes, vec![0, 1]);
+        assert_eq!(normalized.embedded_payload.unwrap().gas_refund_entries, payload_entries);
+        assert_eq!(normalized.replay_block.body().transactions.len(), 2);
+    }
+
+    #[test]
+    fn build_payload_map_reports_invalid_targets_and_duplicates() {
+        let deposit: OpTransactionSigned = OpTxEnvelope::Deposit(TxDeposit::default().seal_slow());
+        let user = user_tx();
+        let post_exec: OpTransactionSigned =
+            OpTransactionSigned::PostExec(build_post_exec_tx(0, vec![]).seal_slow());
+        let block = RecoveredBlock::new_unhashed(
+            alloy_consensus::Block::new(
+                Header::default(),
+                BlockBody {
+                    transactions: vec![deposit, user, post_exec],
+                    ommers: vec![],
+                    withdrawals: None,
+                },
+            ),
+            vec![Address::ZERO, Address::ZERO, Address::ZERO],
+        );
+        let payload = op_alloy_consensus::PostExecPayload {
+            version: POST_EXEC_PAYLOAD_VERSION,
+            block_number: 100,
+            gas_refund_entries: vec![
+                op_alloy_consensus::SDMGasEntry { index: 0, gas_refund: 1 },
+                op_alloy_consensus::SDMGasEntry { index: 2, gas_refund: 2 },
+                op_alloy_consensus::SDMGasEntry { index: 8, gas_refund: 3 },
+                op_alloy_consensus::SDMGasEntry { index: 1, gas_refund: 4 },
+                op_alloy_consensus::SDMGasEntry { index: 1, gas_refund: 5 },
+            ],
+        };
+
+        let mut mismatches = Vec::new();
+        let refunds = build_payload_map(100, &block, &payload, &mut mismatches);
+
+        assert_eq!(refunds.get(&1), Some(&4));
+        assert_eq!(refunds.len(), 1);
+        assert_eq!(
+            mismatches.iter().map(|m| m.category).collect::<Vec<_>>(),
+            vec![
+                PostExecReplayMismatchKind::PayloadTargetsDeposit,
+                PostExecReplayMismatchKind::PayloadTargetsPostExec,
+                PostExecReplayMismatchKind::PayloadIndexOutOfRange,
+                PostExecReplayMismatchKind::DuplicatePayloadIndex,
+            ]
+        );
+    }
+
+    #[test]
+    fn compare_refunds_detects_tampered_payload_mismatches() {
+        let config = PostExecReplayConfig { compare_payload: true };
+        let mut mismatches = Vec::new();
+
+        let mismatch = compare_refunds(
+            CompareRefundsInput {
+                block_number: 100,
+                tx_index: 3,
+                raw_gas_used: 40,
+                replay_refund: 5,
+                payload_refund: Some(7),
+                config: &config,
+            },
+            &mut mismatches,
+        );
+
+        assert!(mismatch);
+        assert_eq!(mismatches.len(), 1);
+        assert_eq!(mismatches[0].category, PostExecReplayMismatchKind::PayloadRefundMismatch);
+    }
+}

--- a/rust/op-reth/crates/post-exec-replay/src/types.rs
+++ b/rust/op-reth/crates/post-exec-replay/src/types.rs
@@ -1,0 +1,172 @@
+#![allow(missing_docs)]
+
+use alloy_eips::BlockNumberOrTag;
+use alloy_primitives::{Address, B256, Bytes};
+use serde::{Deserialize, Serialize};
+
+const fn compare_payload_default() -> bool {
+    true
+}
+
+/// Single-block replay request, accepting either a block tag/number or a block hash.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ReplayPostExecBlockRequest {
+    /// A block number or tag like `latest`.
+    Number(BlockNumberOrTag),
+    /// A block hash.
+    Hash(B256),
+}
+
+/// Options for `debug_replaySDMBlock`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReplayPostExecBlockOptions {
+    /// Compare replay refunds against any embedded post-exec payload in the source block.
+    #[serde(default = "compare_payload_default")]
+    pub compare_payload: bool,
+}
+
+impl Default for ReplayPostExecBlockOptions {
+    fn default() -> Self {
+        Self { compare_payload: compare_payload_default() }
+    }
+}
+
+/// Replay configuration.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PostExecReplayConfig {
+    /// Compare replay refunds against an embedded payload when present.
+    pub compare_payload: bool,
+}
+
+impl Default for PostExecReplayConfig {
+    fn default() -> Self {
+        Self { compare_payload: compare_payload_default() }
+    }
+}
+
+impl From<ReplayPostExecBlockOptions> for PostExecReplayConfig {
+    fn from(options: ReplayPostExecBlockOptions) -> Self {
+        Self { compare_payload: options.compare_payload }
+    }
+}
+
+/// Exact refund categories emitted by the replay engine.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PostExecReplayRefundKind {
+    /// Warm account rebate (+2500).
+    WarmAccount,
+    /// Warm storage read rebate (+2000).
+    WarmSload,
+    /// Warm storage write rebate (+2100).
+    WarmSstore,
+}
+
+/// Exact refund attribution event for one replayed transaction.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PostExecReplayRefundEvent {
+    /// Replay-local transaction index that claimed the rebate.
+    pub claiming_replay_tx_index: u64,
+    /// Original transaction index in the source block that claimed the rebate.
+    pub claiming_tx_index: u64,
+    /// Refund kind.
+    pub kind: PostExecReplayRefundKind,
+    /// Refund amount in gas.
+    pub amount: u64,
+    /// Account touched by the rebate.
+    pub address: Address,
+    /// Storage slot touched by the rebate, when applicable.
+    pub slot: Option<B256>,
+    /// Replay-local transaction index that first warmed the account or slot.
+    pub first_warmed_by_replay_tx_index: u64,
+    /// Original transaction index in the source block that first warmed the account or slot.
+    pub first_warmed_by_tx_index: u64,
+}
+
+/// Per-transaction replay row.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PostExecReplayTx {
+    pub tx_index: u64,
+    pub replay_tx_index: u64,
+    pub tx_hash: B256,
+    pub tx_type: u8,
+    pub is_deposit_tx: bool,
+    pub raw_gas_used: u64,
+    pub canonical_gas_used: u64,
+    pub op_gas_refund_replay: u64,
+    pub op_gas_refund_payload: Option<u64>,
+    pub refund_breakdown: Vec<PostExecReplayRefundEvent>,
+    pub mismatch: bool,
+}
+
+/// Replay mismatch category.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PostExecReplayMismatchKind {
+    DuplicatePayloadIndex,
+    PayloadIndexOutOfRange,
+    PayloadTargetsDeposit,
+    PayloadTargetsPostExec,
+    PayloadRefundMismatch,
+    PayloadRefundExceedsRawGas,
+}
+
+/// Replay mismatch row.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PostExecReplayMismatch {
+    pub category: PostExecReplayMismatchKind,
+    pub block_num: u64,
+    pub tx_index: Option<u64>,
+    pub expected: Option<u64>,
+    pub actual: Option<u64>,
+    pub message: String,
+}
+
+/// Block-level summary.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PostExecReplaySummary {
+    pub block_num: u64,
+    pub block_hash: B256,
+    pub tx_count_total: usize,
+    pub tx_count_user: usize,
+    pub post_exec_tx_present: bool,
+    pub post_exec_payload_entry_count: usize,
+    pub block_gas_used: u64,
+    pub block_raw_gas_used: u64,
+    pub replay_refund_total: u64,
+    pub payload_refund_total: u64,
+    pub mismatch_count: usize,
+}
+
+/// Single-block replay response.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PostExecReplayBlock {
+    pub config: PostExecReplayConfig,
+    pub block_num: u64,
+    pub block_hash: B256,
+    pub parent_hash: B256,
+    pub post_exec_tx_present: bool,
+    pub post_exec_tx_index: Option<u64>,
+    pub embedded_payload: Option<PostExecReplayPayload>,
+    pub synthesized_payload: PostExecReplayPayload,
+    pub synthesized_payload_bytes: Bytes,
+    pub txs: Vec<PostExecReplayTx>,
+    pub mismatches: Vec<PostExecReplayMismatch>,
+    pub summary: PostExecReplaySummary,
+}
+
+/// Serializable replay payload entry.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PostExecReplayPayloadEntry {
+    pub index: u64,
+    pub gas_refund: u64,
+}
+
+/// Serializable replay payload.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PostExecReplayPayload {
+    pub version: u64,
+    pub block_number: u64,
+    pub gas_refund_entries: Vec<PostExecReplayPayloadEntry>,
+}

--- a/rust/op-reth/crates/rpc/Cargo.toml
+++ b/rust/op-reth/crates/rpc/Cargo.toml
@@ -37,6 +37,7 @@ reth-provider.workspace = true
 reth-optimism-evm.workspace = true
 reth-optimism-flashblocks.workspace = true
 reth-optimism-payload-builder.workspace = true
+reth-optimism-post-exec-replay.workspace = true
 reth-optimism-txpool.workspace = true
 # TODO remove node-builder import
 reth-optimism-primitives = { workspace = true, features = ["reth-codec", "serde-bincode-compat", "serde"] }

--- a/rust/op-reth/crates/rpc/Cargo.toml
+++ b/rust/op-reth/crates/rpc/Cargo.toml
@@ -96,6 +96,7 @@ strum.workspace = true
 
 [dev-dependencies]
 reth-optimism-chainspec.workspace = true
+alloy-genesis.workspace = true
 alloy-op-hardforks.workspace = true
 
 [features]

--- a/rust/op-reth/crates/rpc/src/eth/mod.rs
+++ b/rust/op-reth/crates/rpc/src/eth/mod.rs
@@ -467,8 +467,6 @@ pub struct OpEthApiBuilder<NetworkT = Optimism> {
     /// `newPayload` and `forkchoiceUpdated` calls, advancing the canonical chain state.
     /// Requires `flashblocks_url` to be set.
     flashblock_consensus: bool,
-    /// Whether SDM is explicitly enabled for integration tests.
-    sdm_enabled: bool,
     /// Marker for network types.
     _nt: PhantomData<NetworkT>,
 }
@@ -481,7 +479,6 @@ impl<NetworkT> Default for OpEthApiBuilder<NetworkT> {
             min_suggested_priority_fee: 1_000_000,
             flashblocks_url: None,
             flashblock_consensus: false,
-            sdm_enabled: false,
             _nt: PhantomData,
         }
     }
@@ -496,7 +493,6 @@ impl<NetworkT> OpEthApiBuilder<NetworkT> {
             min_suggested_priority_fee: 1_000_000,
             flashblocks_url: None,
             flashblock_consensus: false,
-            sdm_enabled: false,
             _nt: PhantomData,
         }
     }
@@ -528,13 +524,6 @@ impl<NetworkT> OpEthApiBuilder<NetworkT> {
     /// With flashblock consensus client enabled to drive chain forward
     pub const fn with_flashblock_consensus(mut self, flashblock_consensus: bool) -> Self {
         self.flashblock_consensus = flashblock_consensus;
-        self
-    }
-
-    /// Configure the temporary SDM integration-test override.
-    #[must_use]
-    pub const fn with_sdm_enabled(mut self, sdm_enabled: bool) -> Self {
-        self.sdm_enabled = sdm_enabled;
         self
     }
 }
@@ -572,13 +561,11 @@ where
             min_suggested_priority_fee,
             flashblocks_url,
             flashblock_consensus,
-            sdm_enabled,
             ..
         } = self;
-        let rpc_converter = RpcConverter::new(
-            OpReceiptConverter::new(ctx.components.provider().clone())
-                .with_sdm_enabled(sdm_enabled),
-        )
+        let rpc_converter = RpcConverter::new(OpReceiptConverter::new(
+            ctx.components.provider().clone(),
+        ))
         .with_mapper(OpTxInfoMapper::new(ctx.components.provider().clone()))
         .with_tx_env_converter(reth_optimism_evm::tx::OpTxEnvConverter);
 

--- a/rust/op-reth/crates/rpc/src/eth/receipt.rs
+++ b/rust/op-reth/crates/rpc/src/eth/receipt.rs
@@ -32,21 +32,12 @@ where
 #[derive(Debug, Clone)]
 pub struct OpReceiptConverter<Provider> {
     provider: Provider,
-    /// Whether SDM is explicitly enabled for integration tests.
-    sdm_enabled: bool,
 }
 
 impl<Provider> OpReceiptConverter<Provider> {
     /// Creates a new [`OpReceiptConverter`].
     pub const fn new(provider: Provider) -> Self {
-        Self { provider, sdm_enabled: false }
-    }
-
-    /// Configures the temporary SDM integration-test override.
-    #[must_use]
-    pub const fn with_sdm_enabled(mut self, sdm_enabled: bool) -> Self {
-        self.sdm_enabled = sdm_enabled;
-        self
+        Self { provider }
     }
 }
 
@@ -98,7 +89,7 @@ where
         let post_exec_payload = parse_post_exec_payload_from_transactions(
             block.body().transactions(),
             block.header().number(),
-            self.sdm_enabled,
+            self.provider.chain_spec().is_interop_active_at_timestamp(block.header().timestamp()),
         )?
         .map(|parsed| parsed.payload);
 
@@ -392,9 +383,11 @@ mod test {
         OP_MAINNET_ISTHMUS_TIMESTAMP, OP_MAINNET_JOVIAN_TIMESTAMP, OpChainHardforks,
     };
     use alloy_primitives::{Address, Bytes, Signature, U256, hex};
+    use alloy_genesis::Genesis;
     use op_alloy_consensus::{OpTypedTransaction, SDMGasEntry, build_post_exec_tx};
     use op_alloy_network::eip2718::Decodable2718;
-    use reth_optimism_chainspec::{BASE_MAINNET, OP_MAINNET};
+    use reth_optimism_chainspec::{BASE_MAINNET, OP_MAINNET, OpChainSpecBuilder};
+    use std::sync::Arc;
     use reth_optimism_primitives::{OpPrimitives, OpTransactionSigned};
     use reth_primitives_traits::{Recovered, SealedBlock};
 
@@ -554,11 +547,17 @@ mod test {
             },
         });
 
+        let interop_chain_spec = Arc::new(
+            OpChainSpecBuilder::default()
+                .chain(OP_MAINNET.chain())
+                .genesis(Genesis::default())
+                .interop_activated()
+                .build(),
+        );
         let converter = OpReceiptConverter::new(reth_storage_api::noop::NoopProvider::<
             _,
             OpPrimitives,
-        >::new(OP_MAINNET.clone()))
-        .with_sdm_enabled(true);
+        >::new(interop_chain_spec));
         let receipts =
             <OpReceiptConverter<_> as ReceiptConverter<OpPrimitives>>::convert_receipts_with_block(
                 &converter,

--- a/rust/op-reth/crates/rpc/src/witness.rs
+++ b/rust/op-reth/crates/rpc/src/witness.rs
@@ -1,5 +1,7 @@
 //! Support for optimism specific witness RPCs.
 
+use alloy_consensus::{Block as AlloyBlock, BlockHeader};
+use alloy_eips::BlockId;
 use alloy_primitives::{B256, Sealed};
 use alloy_rpc_types_debug::ExecutionWitness;
 use jsonrpsee::proc_macros::rpc;
@@ -10,8 +12,13 @@ use reth_node_api::{BuildNextEnv, NodePrimitives};
 use reth_optimism_evm::ConfigurePostExecEvm;
 use reth_optimism_forks::OpHardforks;
 use reth_optimism_payload_builder::{OpAttributes, OpPayloadBuilder, OpPayloadPrimitives};
+use reth_optimism_post_exec_replay::{
+    PostExecReplayBlock, PostExecReplayConfig, ReplayPostExecBlockOptions,
+    ReplayPostExecBlockRequest, replay_block,
+};
 use reth_optimism_txpool::OpPooledTx;
-use reth_primitives_traits::{SealedHeader, TxTy};
+use reth_primitives_traits::{RecoveredBlock, SealedHeader, TxTy};
+use reth_revm::database::StateProviderDatabase;
 use reth_rpc_server_types::{ToRpcResult, result::internal_rpc_err};
 
 /// Trait for the `debug_executePayload` endpoint, which re-executes a payload and returns the
@@ -32,13 +39,35 @@ pub trait DebugExecutionWitnessApi<Attributes> {
     ) -> RpcResult<ExecutionWitness>;
 }
 use reth_storage_api::{
-    BlockReaderIdExt, NodePrimitivesProvider, StateProviderFactory,
+    BlockReaderIdExt, NodePrimitivesProvider, StateProviderFactory, TransactionVariant,
     errors::{ProviderError, ProviderResult},
 };
 use reth_tasks::Runtime;
 use reth_transaction_pool::TransactionPool;
 use std::{fmt::Debug, sync::Arc};
 use tokio::sync::{Semaphore, oneshot};
+
+/// An extension to the `debug_` namespace for post-exec replay.
+///
+/// This trait is registered under the `debug` namespace and is intended for operator and
+/// research tooling only. Do not expose the `debug` namespace on public RPC endpoints: each
+/// call replays an entire historical block against live state and is unbounded in cost, so
+/// an unauthenticated caller can trivially saturate the node.
+#[cfg_attr(not(test), rpc(server, namespace = "debug"))]
+#[cfg_attr(test, rpc(server, client, namespace = "debug"))]
+pub trait OpDebugPostExecApi {
+    /// Counterfactually replay a historical block with post-exec enabled.
+    ///
+    /// Replays one block per call; callers driving a block range are responsible for
+    /// their own pacing and cancellation. Requires historical state for the target block
+    /// (full/archive node); on a pruned node this will fail at state lookup.
+    #[method(name = "replaySDMBlock")]
+    async fn replay_post_exec_block(
+        &self,
+        block: ReplayPostExecBlockRequest,
+        options: Option<ReplayPostExecBlockOptions>,
+    ) -> RpcResult<PostExecReplayBlock>;
+}
 
 /// An extension to the `debug_` namespace of the RPC API.
 pub struct OpDebugWitnessApi<Pool, Provider, EvmConfig, Attrs> {
@@ -51,16 +80,17 @@ impl<Pool, Provider, EvmConfig, Attrs> OpDebugWitnessApi<Pool, Provider, EvmConf
         provider: Provider,
         task_spawner: Runtime,
         builder: OpPayloadBuilder<Pool, Provider, EvmConfig, (), Attrs>,
+        evm_config: EvmConfig,
     ) -> Self {
         let semaphore = Arc::new(Semaphore::new(3));
-        let inner = OpDebugWitnessApiInner { provider, builder, task_spawner, semaphore };
+        let inner =
+            OpDebugWitnessApiInner { provider, builder, evm_config, task_spawner, semaphore };
         Self { inner: Arc::new(inner) }
     }
 }
 
 impl<Pool, Provider, EvmConfig, Attrs> OpDebugWitnessApi<Pool, Provider, EvmConfig, Attrs>
 where
-    EvmConfig: ConfigurePostExecEvm,
     Provider: NodePrimitivesProvider<Primitives: NodePrimitives<BlockHeader = Provider::Header>>
         + BlockReaderIdExt,
 {
@@ -73,6 +103,39 @@ where
             .provider
             .sealed_header_by_hash(parent_block_hash)?
             .ok_or_else(|| ProviderError::HeaderNotFound(parent_block_hash.into()))
+    }
+}
+
+impl<Pool, Provider, EvmConfig, Attrs> OpDebugWitnessApi<Pool, Provider, EvmConfig, Attrs>
+where
+    Provider: BlockReaderIdExt<
+            Block = AlloyBlock<
+                <Provider::Primitives as OpPayloadPrimitives>::_TX,
+                <Provider::Primitives as OpPayloadPrimitives>::_Header,
+            >,
+            Header = <Provider::Primitives as NodePrimitives>::BlockHeader,
+        > + NodePrimitivesProvider<Primitives: OpPayloadPrimitives>,
+{
+    fn replay_block_by_request(
+        &self,
+        request: ReplayPostExecBlockRequest,
+    ) -> ProviderResult<RecoveredBlock<Provider::Block>> {
+        let provider = &self.inner.provider;
+        match request {
+            ReplayPostExecBlockRequest::Hash(hash) => provider
+                .recovered_block(hash.into(), TransactionVariant::NoHash)?
+                .ok_or_else(|| ProviderError::HeaderNotFound(hash.into())),
+            ReplayPostExecBlockRequest::Number(number_or_tag) => provider
+                .block_with_senders_by_id(
+                    BlockId::Number(number_or_tag),
+                    TransactionVariant::NoHash,
+                )?
+                .ok_or_else(|| {
+                    ProviderError::HeaderNotFound(
+                        number_or_tag.as_number().unwrap_or_default().into(),
+                    )
+                }),
+        }
     }
 }
 
@@ -118,6 +181,73 @@ where
     }
 }
 
+#[async_trait]
+impl<Pool, Provider, EvmConfig, Attrs> OpDebugPostExecApiServer
+    for OpDebugWitnessApi<Pool, Provider, EvmConfig, Attrs>
+where
+    Provider::Primitives: OpPayloadPrimitives
+        + NodePrimitives<
+            Block = AlloyBlock<
+                <Provider::Primitives as OpPayloadPrimitives>::_TX,
+                <Provider::Primitives as OpPayloadPrimitives>::_Header,
+            >,
+            BlockBody = alloy_consensus::BlockBody<
+                <Provider::Primitives as OpPayloadPrimitives>::_TX,
+                <Provider::Primitives as OpPayloadPrimitives>::_Header,
+            >,
+            BlockHeader = <Provider::Primitives as OpPayloadPrimitives>::_Header,
+            SignedTx = <Provider::Primitives as OpPayloadPrimitives>::_TX,
+        >,
+    Pool: TransactionPool<
+            Transaction: OpPooledTx<Consensus = <Provider::Primitives as NodePrimitives>::SignedTx>,
+        > + 'static,
+    Provider: BlockReaderIdExt<
+            Block = AlloyBlock<
+                <Provider::Primitives as OpPayloadPrimitives>::_TX,
+                <Provider::Primitives as OpPayloadPrimitives>::_Header,
+            >,
+            Header = <Provider::Primitives as NodePrimitives>::BlockHeader,
+        > + NodePrimitivesProvider
+        + StateProviderFactory
+        + ChainSpecProvider<ChainSpec: OpHardforks>
+        + Clone
+        + 'static,
+    EvmConfig: ConfigurePostExecEvm<
+            Primitives = Provider::Primitives,
+            NextBlockEnvCtx: BuildNextEnv<Attrs, Provider::Header, Provider::ChainSpec>,
+        > + Clone
+        + 'static,
+    Attrs: OpAttributes<Transaction = TxTy<EvmConfig::Primitives>>,
+{
+    async fn replay_post_exec_block(
+        &self,
+        request: ReplayPostExecBlockRequest,
+        options: Option<ReplayPostExecBlockOptions>,
+    ) -> RpcResult<PostExecReplayBlock> {
+        let _permit = self.inner.semaphore.acquire().await;
+        let block = self.replay_block_by_request(request).to_rpc_result()?;
+        let config: PostExecReplayConfig = options.unwrap_or_default().into();
+
+        let (tx, rx) = oneshot::channel();
+        let this = self.clone();
+        self.inner.task_spawner.spawn_blocking_task(async move {
+            let res = (|| {
+                let state_provider = this
+                    .inner
+                    .provider
+                    .state_by_block_hash(block.header().parent_hash())
+                    .map_err(|err| internal_rpc_err(err.to_string()))?;
+                let db = StateProviderDatabase::new(&state_provider);
+                replay_block(&this.inner.evm_config, db, &block, config)
+                    .map_err(|err| internal_rpc_err(err.to_string()))
+            })();
+            let _ = tx.send(res);
+        });
+
+        rx.await.map_err(|err| internal_rpc_err(err.to_string()))?
+    }
+}
+
 impl<Pool, Provider, EvmConfig, Attrs> Clone
     for OpDebugWitnessApi<Pool, Provider, EvmConfig, Attrs>
 {
@@ -136,6 +266,7 @@ impl<Pool, Provider, EvmConfig, Attrs> Debug
 struct OpDebugWitnessApiInner<Pool, Provider, EvmConfig, Attrs> {
     provider: Provider,
     builder: OpPayloadBuilder<Pool, Provider, EvmConfig, (), Attrs>,
+    evm_config: EvmConfig,
     task_spawner: Runtime,
     semaphore: Arc<Semaphore>,
 }

--- a/rust/op-reth/examples/custom-node/src/evm/executor.rs
+++ b/rust/op-reth/examples/custom-node/src/evm/executor.rs
@@ -17,7 +17,7 @@ use alloy_evm::{
 use alloy_op_evm::{
     OpBlockExecutionCtx, OpBlockExecutor, OpEvmContext,
     block::OpTxResult,
-    post_exec::{PostExecEvm, PostExecExecutorExt},
+    post_exec::{PostExecEvm, PostExecExecutorExt, WarmingRefundEvent},
 };
 use op_alloy_consensus::SDMGasEntry;
 use reth_op::{OpReceipt, OpTxType, chainspec::OpChainSpec, node::OpRethReceiptBuilder};
@@ -92,6 +92,10 @@ where
 {
     fn take_post_exec_entries(&mut self) -> Vec<SDMGasEntry> {
         self.inner.take_post_exec_entries()
+    }
+
+    fn take_warming_events_by_tx(&mut self) -> Vec<Vec<WarmingRefundEvent>> {
+        self.inner.take_warming_events_by_tx()
     }
 }
 


### PR DESCRIPTION
Adds `op-acceptance-tests` integration coverage for SDM on op-reth, backed by a new `debug_replaySDMBlock` RPC and lightweight Go replay client.

   ## Acceptance tests

   This PR adds four SDM op-acceptance tests:

   - `TestSDMDisabledNoRefunds` verifies SDM-disabled op-reth nodes do not emit post-exec transactions or `opGasRefund`.
   - `TestSDMEnabledPayloadAndReplayMatch` verifies post-exec payload refunds, receipt `opGasRefund`, replayed refunds, and block gas accounting all match.
   - `TestSDMStorageRefundBreakdown` verifies exact warm storage refund attribution for same-slot and many-slot workloads.
   - `TestSDMMixedWorkloadSmoke` submits a batched mixed workload across transfers, compute, logs, and state writes.

   ## Main changes

   - Adds an `SDMEnabled` flag to mixed op-reth devstack setup.
   - Adds `debug_replaySDMBlock` to op-reth for replaying historical blocks with post-exec enabled.
   - Adds `op-chain-ops/pkg/sdmreplay` helpers for calling the replay RPC and comparing payload/receipt/replay output.


