### PR TITLE
tests: Don't use Matched in TestFollowL2_WithoutCLP2P

### DIFF
--- a/op-acceptance-tests/tests/sync/follow_l2/sync_test.go
+++ b/op-acceptance-tests/tests/sync/follow_l2/sync_test.go
@@ -198,7 +198,7 @@ func TestFollowL2_WithoutCLP2P(gt *testing.T) {
 
 	// Advance few safe blocks
 	sys.L2CLC.Advanced(types.LocalSafe, target, attempts)
-	sys.L2CLC.Matched(sys.L2CLB, types.LocalSafe, attempts)
+	sys.L2CLC.ReachedRef(types.LocalSafe, sys.L2CLB.HeadBlockRef(types.LocalSafe).ID(), attempts)
 
 	// Make sure the safe head reaches non-moving unsafe head
 	sys.L2CLC.Reached(types.LocalSafe, sys.L2CLC.UnsafeHead().BlockRef.Number, attempts)


### PR DESCRIPTION
Fixes a flake in `TestFollowL2_WithoutCLP2P` where an exact match is flaking due to both chains actively progressing during the check.

`Matched` seems to have the potential to flake during any test, so we should consider larger modifications. But I'm not willing to touch every test just to fix one.