### PR TITLE
fix(op-acceptance): default cannon-kona challenger on

### DIFF
--- a/op-acceptance-tests/tests/base/withdrawal/withdrawal_test_helper.go
+++ b/op-acceptance-tests/tests/base/withdrawal/withdrawal_test_helper.go
@@ -27,9 +27,6 @@ func withdrawalOpts(gameType gameTypes.GameType) []presets.Option {
 			cfg.DisputeGameType = uint32(gameType)
 		}),
 	}
-	if gameType == gameTypes.CannonKonaGameType {
-		opts = append(opts, presets.WithChallengerCannonKonaEnabled())
-	}
 	return opts
 }
 

--- a/op-acceptance-tests/tests/interop/proofs-singlechain/interop_fault_proofs_test.go
+++ b/op-acceptance-tests/tests/interop/proofs-singlechain/interop_fault_proofs_test.go
@@ -10,6 +10,6 @@ import (
 
 func TestInteropSingleChainFaultProofs(gt *testing.T) {
 	t := devtest.SerialT(gt)
-	sys := presets.NewSingleChainInteropSupernodeProofs(t, presets.WithChallengerCannonKonaEnabled())
+	sys := presets.NewSingleChainInteropSupernodeProofs(t)
 	sfp.RunSingleChainSuperFaultProofSmokeTest(t, sys)
 }

--- a/op-acceptance-tests/tests/interop/proofs/challenger_test.go
+++ b/op-acceptance-tests/tests/interop/proofs/challenger_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestChallengerPlaysGame(gt *testing.T) {
 	t := devtest.ParallelT(gt)
-	sys := presets.NewSimpleInteropSupernodeProofs(t, presets.WithChallengerCannonKonaEnabled())
+	sys := presets.NewSimpleInteropSupernodeProofs(t)
 	dsl.CheckAll(t,
 		sys.L2CLA.AdvancedFn(types.CrossSafe, 1, 30),
 		sys.L2CLB.AdvancedFn(types.CrossSafe, 1, 30),
@@ -38,7 +38,7 @@ func TestChallengerPlaysGame(gt *testing.T) {
 
 func TestChallengerRespondsToMultipleInvalidClaims(gt *testing.T) {
 	t := devtest.ParallelT(gt)
-	sys := presets.NewSimpleInteropSupernodeProofs(t, presets.WithChallengerCannonKonaEnabled())
+	sys := presets.NewSimpleInteropSupernodeProofs(t)
 	dsl.CheckAll(t,
 		sys.L2CLA.AdvancedFn(types.CrossSafe, 1, 30),
 		sys.L2CLB.AdvancedFn(types.CrossSafe, 1, 30),
@@ -61,7 +61,7 @@ func TestChallengerRespondsToMultipleInvalidClaims(gt *testing.T) {
 
 func TestChallengerRespondsToMultipleInvalidClaimsEOA(gt *testing.T) {
 	t := devtest.ParallelT(gt)
-	sys := presets.NewSimpleInteropSupernodeProofs(t, presets.WithChallengerCannonKonaEnabled())
+	sys := presets.NewSimpleInteropSupernodeProofs(t)
 	dsl.CheckAll(t,
 		sys.L2CLA.AdvancedFn(types.CrossSafe, 1, 30),
 		sys.L2CLB.AdvancedFn(types.CrossSafe, 1, 30),
@@ -89,7 +89,6 @@ func TestChallengerCountersPreGenesisGame(gt *testing.T) {
 	t := devtest.SerialT(gt)
 	sys := presets.NewSimpleInteropSupernodeProofs(
 		t,
-		presets.WithChallengerCannonKonaEnabled(),
 		presets.WithPreGenesisSuperGame(
 			eth.Bytes32(common.HexToHash("0x1111000000000000000000000000000000000000000000000000000000000000")),
 			eth.Bytes32(common.HexToHash("0x2222000000000000000000000000000000000000000000000000000000000000")),

--- a/op-acceptance-tests/tests/interop/proofs/fpp/fpp_test.go
+++ b/op-acceptance-tests/tests/interop/proofs/fpp/fpp_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestFPP(gt *testing.T) {
 	t := devtest.ParallelT(gt)
-	sys := presets.NewSimpleInteropSupernodeProofs(t, presets.WithChallengerCannonKonaEnabled())
+	sys := presets.NewSimpleInteropSupernodeProofs(t)
 
 	startTimestamp := max(sys.L2ChainA.Escape().RollupConfig().TimestampForBlock(1), sys.L2ChainB.Escape().RollupConfig().TimestampForBlock(1))
 	endTimestamp := sys.L2ChainA.Escape().RollupConfig().TimestampForBlock(5)
@@ -22,7 +22,7 @@ func TestFPP(gt *testing.T) {
 
 func TestNextSuperRootNotFound(gt *testing.T) {
 	t := devtest.ParallelT(gt)
-	sys := presets.NewSimpleInteropSupernodeProofs(t, presets.WithChallengerCannonKonaEnabled())
+	sys := presets.NewSimpleInteropSupernodeProofs(t)
 	blockTime := sys.L2ChainA.Escape().RollupConfig().BlockTime
 
 	// Need to setup situation where the next super root is not found but the next block is safe on the first chain, but not safe on the second.

--- a/op-acceptance-tests/tests/interop/proofs/proposer_test.go
+++ b/op-acceptance-tests/tests/interop/proofs/proposer_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestProposer(gt *testing.T) {
 	t := devtest.ParallelT(gt)
-	sys := presets.NewSimpleInteropSupernodeProofs(t, presets.WithChallengerCannonKonaEnabled())
+	sys := presets.NewSimpleInteropSupernodeProofs(t)
 
 	dgf := sys.DisputeGameFactory()
 

--- a/op-acceptance-tests/tests/interop/proofs/serial/interop_fault_proofs_test.go
+++ b/op-acceptance-tests/tests/interop/proofs/serial/interop_fault_proofs_test.go
@@ -12,13 +12,13 @@ import (
 
 func TestInteropFaultProofs(gt *testing.T) {
 	t := devtest.ParallelT(gt)
-	sys := presets.NewSimpleInteropSupernodeProofs(t, presets.WithChallengerCannonKonaEnabled())
+	sys := presets.NewSimpleInteropSupernodeProofs(t)
 	sfp.RunSuperFaultProofTest(t, sys)
 }
 
 func TestInteropFaultProofs_PreForkActivation(gt *testing.T) {
 	t := devtest.SerialT(gt)
-	sys := presets.NewSimpleInteropSupernodeProofs(t, presets.WithChallengerCannonKonaEnabled(), presets.WithSuggestedInteropActivationOffset(365*24*60*60))
+	sys := presets.NewSimpleInteropSupernodeProofs(t, presets.WithSuggestedInteropActivationOffset(365*24*60*60))
 	sfp.RunPreForkActivationTest(t, sys)
 }
 
@@ -27,7 +27,6 @@ func TestInteropFaultProofs_ActivationBoundary(gt *testing.T) {
 	// Set interop activation ~6s (3 blocks) after genesis. A small offset keeps
 	// the fork reachable within CI timeouts while still having pre-interop blocks.
 	sys := presets.NewSimpleInteropSupernodeProofs(t,
-		presets.WithChallengerCannonKonaEnabled(),
 		presets.WithSuggestedInteropActivationOffset(6),
 	)
 	sfp.RunInteropActivationBoundaryTest(t, sys)
@@ -35,13 +34,13 @@ func TestInteropFaultProofs_ActivationBoundary(gt *testing.T) {
 
 func TestInteropFaultProofs_ConsolidateValidCrossChainMessage(gt *testing.T) {
 	t := devtest.ParallelT(gt)
-	sys := presets.NewSimpleInteropSupernodeProofs(t, presets.WithChallengerCannonKonaEnabled())
+	sys := presets.NewSimpleInteropSupernodeProofs(t)
 	sfp.RunConsolidateValidCrossChainMessageTest(t, sys)
 }
 
 func TestInteropFaultProofs_DepositMessage(gt *testing.T) {
 	t := devtest.SerialT(gt)
-	sys := presets.NewSimpleInteropSupernodeProofs(t, presets.WithChallengerCannonKonaEnabled())
+	sys := presets.NewSimpleInteropSupernodeProofs(t)
 	sfp.RunDepositMessageTest(t, sys)
 }
 
@@ -52,7 +51,6 @@ func TestInteropFaultProofs_VariedBlockTimes(gt *testing.T) {
 	t.MarkFlaky("ethereum-optimism/optimism#19828")
 	sys := presets.NewSimpleInteropSupernodeProofs(
 		t,
-		presets.WithChallengerCannonKonaEnabled(),
 		presets.WithL2BlockTimes(map[eth.ChainID]uint64{
 			sysgo.DefaultL2AID: 1,
 			sysgo.DefaultL2BID: 2,
@@ -68,7 +66,6 @@ func TestInteropFaultProofs_VariedBlockTimes_FasterChainB(gt *testing.T) {
 	t.MarkFlaky("ethereum-optimism/optimism#19828")
 	sys := presets.NewSimpleInteropSupernodeProofs(
 		t,
-		presets.WithChallengerCannonKonaEnabled(),
 		presets.WithL2BlockTimes(map[eth.ChainID]uint64{
 			sysgo.DefaultL2AID: 2,
 			sysgo.DefaultL2BID: 1,
@@ -79,7 +76,7 @@ func TestInteropFaultProofs_VariedBlockTimes_FasterChainB(gt *testing.T) {
 
 func TestInteropFaultProofs_InvalidBlock(gt *testing.T) {
 	t := devtest.SerialT(gt)
-	sys := presets.NewSimpleInteropSupernodeProofs(t, presets.WithChallengerCannonKonaEnabled())
+	sys := presets.NewSimpleInteropSupernodeProofs(t)
 	sfp.RunInvalidBlockTest(t, sys)
 }
 
@@ -87,7 +84,7 @@ func TestInteropFaultProofs_IntraBlock(gt *testing.T) {
 	for _, tc := range sfp.IntraBlockCases() {
 		gt.Run(tc.Name, func(gt *testing.T) {
 			t := devtest.SerialT(gt)
-			sys := presets.NewSimpleInteropSupernodeProofs(t, presets.WithChallengerCannonKonaEnabled())
+			sys := presets.NewSimpleInteropSupernodeProofs(t)
 			sfp.RunIntraBlockConsolidationTest(t, sys, tc)
 		})
 	}
@@ -95,7 +92,7 @@ func TestInteropFaultProofs_IntraBlock(gt *testing.T) {
 
 func TestInteropFaultProofs_DepositMessage_InvalidExecution(gt *testing.T) {
 	t := devtest.SerialT(gt)
-	sys := presets.NewSimpleInteropSupernodeProofs(t, presets.WithChallengerCannonKonaEnabled())
+	sys := presets.NewSimpleInteropSupernodeProofs(t)
 	sfp.RunDepositMessageInvalidExecutionTest(t, sys)
 }
 
@@ -103,7 +100,6 @@ func TestInteropFaultProofs_MessageExpiry(gt *testing.T) {
 	t := devtest.SerialT(gt)
 	const messageExpiryWindow = uint64(12) // 12 seconds for fast test
 	sys := presets.NewSimpleInteropSupernodeProofs(t,
-		presets.WithChallengerCannonKonaEnabled(),
 		presets.WithMessageExpiryWindow(messageExpiryWindow),
 	)
 	sfp.RunMessageExpiryTest(t, sys, messageExpiryWindow)

--- a/op-acceptance-tests/tests/interop/proofs/withdrawal/withdrawal_test.go
+++ b/op-acceptance-tests/tests/interop/proofs/withdrawal/withdrawal_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestSuperRootWithdrawal(gt *testing.T) {
 	t := devtest.ParallelT(gt)
-	sys := presets.NewSimpleInteropSupernodeProofs(t, presets.WithTimeTravelEnabled(), presets.WithChallengerCannonKonaEnabled())
+	sys := presets.NewSimpleInteropSupernodeProofs(t, presets.WithTimeTravelEnabled())
 	sys.L1Network.WaitForOnline()
 
 	initialL1Balance := eth.HalfEther

--- a/op-acceptance-tests/tests/isthmus/preinterop-singlechain/interop_fault_proofs_test.go
+++ b/op-acceptance-tests/tests/isthmus/preinterop-singlechain/interop_fault_proofs_test.go
@@ -10,9 +10,6 @@ import (
 
 func TestPreinteropSingleChainFaultProofs(gt *testing.T) {
 	t := devtest.ParallelT(gt)
-	sys := presets.NewSingleChainInteropIsthmusSuper(
-		t,
-		presets.WithChallengerCannonKonaEnabled(),
-	)
+	sys := presets.NewSingleChainInteropIsthmusSuper(t)
 	sfp.RunSingleChainSuperFaultProofSmokeTest(t, sys)
 }

--- a/op-acceptance-tests/tests/isthmus/preinterop/interop_fault_proofs_test.go
+++ b/op-acceptance-tests/tests/isthmus/preinterop/interop_fault_proofs_test.go
@@ -32,7 +32,6 @@ func TestPreinteropFaultProofs_VariedBlockTimes(gt *testing.T) {
 	t := devtest.SerialT(gt)
 	sys := presets.NewSimpleInteropIsthmusSuper(
 		t,
-		presets.WithChallengerCannonKonaEnabled(),
 		presets.WithL2BlockTimes(map[eth.ChainID]uint64{
 			sysgo.DefaultL2AID: 1,
 			sysgo.DefaultL2BID: 2,
@@ -45,7 +44,6 @@ func TestPreinteropFaultProofs_VariedBlockTimes_FasterChainB(gt *testing.T) {
 	t := devtest.SerialT(gt)
 	sys := presets.NewSimpleInteropIsthmusSuper(
 		t,
-		presets.WithChallengerCannonKonaEnabled(),
 		presets.WithL2BlockTimes(map[eth.ChainID]uint64{
 			sysgo.DefaultL2AID: 2,
 			sysgo.DefaultL2BID: 1,

--- a/op-acceptance-tests/tests/isthmus/preinterop/setup_test.go
+++ b/op-acceptance-tests/tests/isthmus/preinterop/setup_test.go
@@ -6,8 +6,5 @@ import (
 )
 
 func newSimpleInteropPreinterop(t devtest.T) *presets.SimpleInterop {
-	return presets.NewSimpleInteropIsthmusSuper(
-		t,
-		presets.WithChallengerCannonKonaEnabled(),
-	)
+	return presets.NewSimpleInteropIsthmusSuper(t)
 }

--- a/op-acceptance-tests/tests/proofs/cannon/setup_test.go
+++ b/op-acceptance-tests/tests/proofs/cannon/setup_test.go
@@ -10,7 +10,7 @@ import (
 func cannonOpts() []presets.Option {
 	return []presets.Option{
 		presets.WithGameTypeAdded(gameTypes.CannonGameType),
-		presets.WithCannonKonaGameTypeAdded(),
+		presets.WithGameTypeAdded(gameTypes.CannonKonaGameType),
 		presets.WithDeployerOptions(sysgo.WithJovianAtGenesis),
 		presets.WithGlobalL2CLOption(sysgo.L2CLOptionFn(func(p devtest.T, _ sysgo.ComponentTarget, cfg *sysgo.L2CLConfig) {
 			cfg.SafeDBPath = p.TempDir()

--- a/op-devstack/presets/option_validation.go
+++ b/op-devstack/presets/option_validation.go
@@ -20,7 +20,6 @@ const (
 	optionKindL1EL
 	optionKindAddedGameType
 	optionKindRespectedGameType
-	optionKindChallengerCannonKona
 	optionKindTimeTravel
 	optionKindMaxSequencingWindow
 	optionKindRequireInteropNotAtGen
@@ -41,7 +40,6 @@ const allOptionKinds = optionKindDeployer |
 	optionKindL1EL |
 	optionKindAddedGameType |
 	optionKindRespectedGameType |
-	optionKindChallengerCannonKona |
 	optionKindTimeTravel |
 	optionKindMaxSequencingWindow |
 	optionKindRequireInteropNotAtGen |
@@ -65,7 +63,6 @@ var optionKindLabels = []struct {
 	{kind: optionKindL1EL, label: "L1 EL options"},
 	{kind: optionKindAddedGameType, label: "added game types"},
 	{kind: optionKindRespectedGameType, label: "respected game types"},
-	{kind: optionKindChallengerCannonKona, label: "challenger cannon-kona"},
 	{kind: optionKindTimeTravel, label: "time travel"},
 	{kind: optionKindMaxSequencingWindow, label: "max sequencing window"},
 	{kind: optionKindRequireInteropNotAtGen, label: "interop-not-at-genesis"},
@@ -117,7 +114,6 @@ const minimalPresetSupportedOptionKinds = optionKindDeployer |
 	optionKindL1EL |
 	optionKindAddedGameType |
 	optionKindRespectedGameType |
-	optionKindChallengerCannonKona |
 	optionKindTimeTravel |
 	optionKindAfterBuild |
 	optionKindProofValidation
@@ -154,14 +150,12 @@ const simpleInteropSuperProofsPresetSupportedOptionKinds = optionKindDeployer |
 	optionKindProposer |
 	optionKindGlobalL2CL |
 	optionKindL1EL |
-	optionKindChallengerCannonKona |
 	optionKindTimeTravel |
 	optionKindMaxSequencingWindow |
 	optionKindRequireInteropNotAtGen
 
 const supernodeProofsPresetSupportedOptionKinds = optionKindDeployer |
 	optionKindBatcher |
-	optionKindChallengerCannonKona |
 	optionKindL1EL |
 	optionKindTimeTravel |
 	optionKindMessageExpiryWindow

--- a/op-devstack/presets/options.go
+++ b/op-devstack/presets/options.go
@@ -230,25 +230,6 @@ func WithRespectedGameTypeOverride(gameType gameTypes.GameType) Option {
 	}
 }
 
-func WithCannonKonaGameTypeAdded() Option {
-	return option{
-		kinds: optionKindAddedGameType | optionKindChallengerCannonKona,
-		applyFn: func(cfg *sysgo.PresetConfig) {
-			cfg.EnableCannonKonaForChall = true
-			cfg.AddedGameTypes = append(cfg.AddedGameTypes, gameTypes.CannonKonaGameType)
-		},
-	}
-}
-
-func WithChallengerCannonKonaEnabled() Option {
-	return option{
-		kinds: optionKindChallengerCannonKona,
-		applyFn: func(cfg *sysgo.PresetConfig) {
-			cfg.EnableCannonKonaForChall = true
-		},
-	}
-}
-
 func WithTimeTravelEnabled() Option {
 	return option{
 		kinds: optionKindTimeTravel,

--- a/op-devstack/presets/options_test.go
+++ b/op-devstack/presets/options_test.go
@@ -18,13 +18,6 @@ func TestOptionKindsFromCompositeOptions(t *testing.T) {
 		)
 	})
 
-	t.Run("WithCannonKonaGameTypeAdded", func(t *testing.T) {
-		require.Equal(t,
-			optionKindAddedGameType|optionKindChallengerCannonKona,
-			WithCannonKonaGameTypeAdded().optionKinds(),
-		)
-	})
-
 	t.Run("WithL1Geth", func(t *testing.T) {
 		require.Equal(t,
 			optionKindL1EL,
@@ -82,12 +75,6 @@ func TestUnsupportedPresetOptionKinds(t *testing.T) {
 			want:      0,
 		},
 		{
-			name:      "minimal with conductors rejects challenger toggle",
-			supported: minimalWithConductorsPresetSupportedOptionKinds,
-			opts:      WithChallengerCannonKonaEnabled(),
-			want:      optionKindChallengerCannonKona,
-		},
-		{
 			name:      "flashblocks allows builder and deployer adapters",
 			supported: singleChainWithFlashblocksPresetSupportedOptionKinds,
 			opts: Combine(
@@ -110,7 +97,6 @@ func TestUnsupportedPresetOptionKinds(t *testing.T) {
 			name:      "shared supernode proofs reject pre-genesis super game",
 			supported: supernodeProofsPresetSupportedOptionKinds,
 			opts: Combine(
-				WithChallengerCannonKonaEnabled(),
 				WithTimeTravelEnabled(),
 				WithPreGenesisSuperGame(eth.Bytes32{0x01}, eth.Bytes32{0x02}),
 			),
@@ -120,7 +106,6 @@ func TestUnsupportedPresetOptionKinds(t *testing.T) {
 			name:      "two l2 supernode proofs accept pre-genesis super game",
 			supported: twoL2SupernodeProofsPresetSupportedOptionKinds,
 			opts: Combine(
-				WithChallengerCannonKonaEnabled(),
 				WithTimeTravelEnabled(),
 				WithPreGenesisSuperGame(eth.Bytes32{0x01}, eth.Bytes32{0x02}),
 			),

--- a/op-devstack/sysgo/multichain_proofs.go
+++ b/op-devstack/sysgo/multichain_proofs.go
@@ -81,7 +81,7 @@ func attachSupervisorSuperProofs(t devtest.T, runtime *MultiChainRuntime, cfg Pr
 		false,
 		nets,
 		els,
-		cfg.EnableCannonKonaForChall,
+		!cfg.DisableCannonKonaForChall,
 	)
 	runtime.L2ChallengerConfig = challenger.Config()
 
@@ -176,7 +176,7 @@ func attachSuperChallengerAndProposer(
 		true,
 		nets,
 		els,
-		cfg.EnableCannonKonaForChall,
+		!cfg.DisableCannonKonaForChall,
 	)
 	runtime.L2ChallengerConfig = challenger.Config()
 

--- a/op-devstack/sysgo/multichain_proofs.go
+++ b/op-devstack/sysgo/multichain_proofs.go
@@ -81,7 +81,6 @@ func attachSupervisorSuperProofs(t devtest.T, runtime *MultiChainRuntime, cfg Pr
 		false,
 		nets,
 		els,
-		!cfg.DisableCannonKonaForChall,
 	)
 	runtime.L2ChallengerConfig = challenger.Config()
 
@@ -176,7 +175,6 @@ func attachSuperChallengerAndProposer(
 		true,
 		nets,
 		els,
-		!cfg.DisableCannonKonaForChall,
 	)
 	runtime.L2ChallengerConfig = challenger.Config()
 
@@ -300,7 +298,6 @@ func startInteropChallenger(
 	useSuperNode bool,
 	l2Nets []*L2Network,
 	l2ELs []L2ELNode,
-	enableCannonKona bool,
 ) *L2Challenger {
 	require := t.Require()
 	require.NotEmpty(l2Nets, "at least one L2 network is required")
@@ -332,14 +329,9 @@ func startInteropChallenger(
 		sharedchallenger.WithCannonConfig(rollupCfgs, l1Net.genesis, l2Geneses, sharedchallenger.InteropVariant),
 		sharedchallenger.WithSuperCannonGameType(),
 		sharedchallenger.WithSuperPermissionedGameType(),
-	}
-	if enableCannonKona {
-		t.Log("Enabling cannon-kona for super challenger")
-		options = append(options,
-			sharedchallenger.WithCannonKonaInteropConfig(rollupCfgs, l1Net.genesis, l2Geneses),
-			sharedchallenger.WithSuperCannonKonaGameType(),
-			sharedchallenger.WithExperimentalWitnessEndpoint(),
-		)
+		sharedchallenger.WithCannonKonaInteropConfig(rollupCfgs, l1Net.genesis, l2Geneses),
+		sharedchallenger.WithSuperCannonKonaGameType(),
+		sharedchallenger.WithExperimentalWitnessEndpoint(),
 	}
 	cfg, err := sharedchallenger.NewInteropChallengerConfig(
 		t.Ctx(),

--- a/op-devstack/sysgo/multichain_supernode_runtime.go
+++ b/op-devstack/sysgo/multichain_supernode_runtime.go
@@ -222,7 +222,7 @@ func newTwoL2SupernodeRuntimeWithConfig(t devtest.T, enableInterop bool, delaySe
 	}
 	l1EL, l1CL := startInProcessL1WithClockConfig(t, l1Net, jwtPath, l1Clock, cfg)
 	if cfg.PreGenesisSuperGame != nil {
-		preparePreGenesisSuperGame(t, keys, wb, l1Net, l1EL, migration, !cfg.DisableCannonKonaForChall, cfg.PreGenesisSuperGame, l2ANet, l2BNet)
+		preparePreGenesisSuperGame(t, keys, wb, l1Net, l1EL, migration, cfg.PreGenesisSuperGame, l2ANet, l2BNet)
 	}
 
 	var l2AEL, l2BEL L2ELNode

--- a/op-devstack/sysgo/multichain_supernode_runtime.go
+++ b/op-devstack/sysgo/multichain_supernode_runtime.go
@@ -222,7 +222,7 @@ func newTwoL2SupernodeRuntimeWithConfig(t devtest.T, enableInterop bool, delaySe
 	}
 	l1EL, l1CL := startInProcessL1WithClockConfig(t, l1Net, jwtPath, l1Clock, cfg)
 	if cfg.PreGenesisSuperGame != nil {
-		preparePreGenesisSuperGame(t, keys, wb, l1Net, l1EL, migration, cfg.EnableCannonKonaForChall, cfg.PreGenesisSuperGame, l2ANet, l2BNet)
+		preparePreGenesisSuperGame(t, keys, wb, l1Net, l1EL, migration, !cfg.DisableCannonKonaForChall, cfg.PreGenesisSuperGame, l2ANet, l2BNet)
 	}
 
 	var l2AEL, l2BEL L2ELNode

--- a/op-devstack/sysgo/pre_genesis_super_game.go
+++ b/op-devstack/sysgo/pre_genesis_super_game.go
@@ -33,7 +33,6 @@ func preparePreGenesisSuperGame(
 	l1Net *L1Network,
 	l1EL *L1Geth,
 	migration *interopMigrationState,
-	enableCannonKona bool,
 	gameCfg *PreGenesisSuperGameConfig,
 	l2Nets ...*L2Network,
 ) {
@@ -85,11 +84,7 @@ func preparePreGenesisSuperGame(
 		startingProposal,
 		l2Nets[0].ChainID(),
 	)
-
-	gameType := superCannonGameType
-	if enableCannonKona {
-		gameType = superCannonKonaGameType
-	}
+	gameType := superCannonKonaGameType
 
 	claimedChains := make([]eth.ChainIDAndOutput, 0, len(l2Nets))
 	for i, l2Net := range l2Nets {

--- a/op-devstack/sysgo/preset_config.go
+++ b/op-devstack/sysgo/preset_config.go
@@ -25,12 +25,13 @@ type PresetConfig struct {
 	L1GethExecPath             string
 	AddedGameTypes             []gameTypes.GameType
 	RespectedGameTypes         []gameTypes.GameType
-	EnableCannonKonaForChall   bool
-	EnableTimeTravel           bool
-	MaxSequencingWindow        *uint64
-	RequireInteropNotAtGen     bool
-	MessageExpiryWindow        *uint64
-	UseInteropFilter           bool
+	// DisableCannonKonaForChall disables cannon-kona support in the op-challenger; cannon-kona is enabled by default.
+	DisableCannonKonaForChall bool
+	EnableTimeTravel          bool
+	MaxSequencingWindow       *uint64
+	RequireInteropNotAtGen    bool
+	MessageExpiryWindow       *uint64
+	UseInteropFilter          bool
 	// InteropLogBackfillDepth, if non-zero, configures the supernode to backfill
 	// initiating-message logs backward from the tip by this duration at startup.
 	InteropLogBackfillDepth time.Duration

--- a/op-devstack/sysgo/preset_config.go
+++ b/op-devstack/sysgo/preset_config.go
@@ -25,13 +25,11 @@ type PresetConfig struct {
 	L1GethExecPath             string
 	AddedGameTypes             []gameTypes.GameType
 	RespectedGameTypes         []gameTypes.GameType
-	// DisableCannonKonaForChall disables cannon-kona support in the op-challenger; cannon-kona is enabled by default.
-	DisableCannonKonaForChall bool
-	EnableTimeTravel          bool
-	MaxSequencingWindow       *uint64
-	RequireInteropNotAtGen    bool
-	MessageExpiryWindow       *uint64
-	UseInteropFilter          bool
+	EnableTimeTravel           bool
+	MaxSequencingWindow        *uint64
+	RequireInteropNotAtGen     bool
+	MessageExpiryWindow        *uint64
+	UseInteropFilter           bool
 	// InteropLogBackfillDepth, if non-zero, configures the supernode to backfill
 	// initiating-message logs backward from the tip by this duration at startup.
 	InteropLogBackfillDepth time.Duration

--- a/op-devstack/sysgo/singlechain_runtime.go
+++ b/op-devstack/sysgo/singlechain_runtime.go
@@ -117,7 +117,7 @@ func newSingleChainRuntimeWithConfig(t devtest.T, cfg PresetConfig, spec singleC
 
 	var l2Challenger *L2Challenger
 	if spec.StartChallenger {
-		l2Challenger = startMinimalChallenger(t, keys, world.L1Network, world.L2Network, l1EL, l1CL, primary.EL, primary.CL, cfg.EnableCannonKonaForChall)
+		l2Challenger = startMinimalChallenger(t, keys, world.L1Network, world.L2Network, l1EL, l1CL, primary.EL, primary.CL, !cfg.DisableCannonKonaForChall)
 	}
 
 	applyMinimalGameTypeOptions(t, keys, world.L1Network, world.L2Network, l1EL, cfg.AddedGameTypes, cfg.RespectedGameTypes)

--- a/op-devstack/sysgo/singlechain_runtime.go
+++ b/op-devstack/sysgo/singlechain_runtime.go
@@ -117,7 +117,7 @@ func newSingleChainRuntimeWithConfig(t devtest.T, cfg PresetConfig, spec singleC
 
 	var l2Challenger *L2Challenger
 	if spec.StartChallenger {
-		l2Challenger = startMinimalChallenger(t, keys, world.L1Network, world.L2Network, l1EL, l1CL, primary.EL, primary.CL, !cfg.DisableCannonKonaForChall)
+		l2Challenger = startMinimalChallenger(t, keys, world.L1Network, world.L2Network, l1EL, l1CL, primary.EL, primary.CL)
 	}
 
 	applyMinimalGameTypeOptions(t, keys, world.L1Network, world.L2Network, l1EL, cfg.AddedGameTypes, cfg.RespectedGameTypes)
@@ -320,7 +320,6 @@ func startMinimalChallenger(
 	l1CL *L1CLNode,
 	l2EL L2ELNode,
 	l2CL L2CLNode,
-	enableCannonKona bool,
 ) *L2Challenger {
 	require := t.Require()
 	challengerSecret, err := keys.Secret(devkeys.ChallengerRole.Key(l2Net.ChainID().ToBig()))
@@ -338,14 +337,9 @@ func startMinimalChallenger(
 		sharedchallenger.WithCannonGameType(),
 		sharedchallenger.WithPermissionedGameType(),
 		sharedchallenger.WithFastGames(),
-	}
-	if enableCannonKona {
-		t.Log("Enabling cannon-kona for challenger")
-		options = append(options,
-			sharedchallenger.WithCannonKonaConfig(rollupCfgs, l1Net.genesis, l2Geneses),
-			sharedchallenger.WithCannonKonaGameType(),
-			sharedchallenger.WithExperimentalWitnessEndpoint(),
-		)
+		sharedchallenger.WithCannonKonaConfig(rollupCfgs, l1Net.genesis, l2Geneses),
+		sharedchallenger.WithCannonKonaGameType(),
+		sharedchallenger.WithExperimentalWitnessEndpoint(),
 	}
 	cfg, err := sharedchallenger.NewPreInteropChallengerConfig(
 		t.Ctx(),


### PR DESCRIPTION
## Summary

- ~Default op-devstack challenger runtimes to cannon-kona enabled by replacing `EnableCannonKonaForChall` with `DisableCannonKonaForChall` that defaults to `false`.~
- Delete the now-dead `presets.WithChallengerCannonKonaEnabled` and `presets.WithCannonKonaGameTypeAdded` helpers and their option-kind validation.
- Remove the repeated op-acceptance test opt-ins, keeping explicit `WithGameTypeAdded(gameTypes.CannonKonaGameType)` registration where single-chain tests still need the game type added on-chain.
- Removes `EnableCannonKonaForChall` flag and unconditionally enables cannon kona.

Fixes https://github.com/ethereum-optimism/optimism/issues/19092

~I chose not to add a `WithChallengerCannonKonaDisabled` preset option since we don't really want to support that, but I kept `DisableCannonKonaForChall` in `PresetConfig` in case we need to override this behavior somewhere though. I can remove it entirely instead if anyone thinks that'd be a better idea.~

## Test Plan

- [x] `mise exec -- just lint-go-fix`
- [x] `mise exec -- just lint-go`
- [x] `mise exec -- go test ./op-devstack/presets/... ./op-devstack/sysgo/...`
- [x] `mise exec -- go test ./op-devstack/...`
- [x] `mise exec -- just reproducible-prestate-kona`
- [x] Cutover grep: no matches for `EnableCannonKonaForChall|WithChallengerCannonKonaEnabled|WithCannonKonaGameTypeAdded|optionKindChallengerCannonKona`
- [x] CI guard: no `.circleci/continue/main.yml` additions for kona build/prestate dependencies
- [x] `RUST_JIT_BUILD=1 mise exec -- just -f op-acceptance-tests/justfile test -timeout=0 ./op-acceptance-tests/tests/proofs/cannon/...`
- [x] `RUST_JIT_BUILD=1 mise exec -- just -f op-acceptance-tests/justfile test -timeout=0 ./op-acceptance-tests/tests/base/withdrawal/cannon_kona/...`
- [x] `RUST_JIT_BUILD=1 mise exec -- just -f op-acceptance-tests/justfile test -timeout=0 ./op-acceptance-tests/tests/interop/proofs/...`

Note: the acceptance tests timed out locally, and I am rerunning them locally without the default timeout.

Edit: The acceptance tests only timed out because I didn't set `DEVSTACK_L2EL_KIND=op-reth`, which tried running the cannon tests with default op-reth EL which is a known hang. They actually worked fine locally after that.
