### PR TITLE
chore(op-interop-filter): add ingestion diagnostics

### DIFF
--- a/op-interop-filter/filter/backend.go
+++ b/op-interop-filter/filter/backend.go
@@ -152,6 +152,7 @@ func (b *Backend) CheckAccessList(ctx context.Context, inboxEntries []common.Has
 
 	if !b.Ready() {
 		b.metrics.RecordCheckAccessList(false)
+		b.log.Debug("Backend not ready; rejecting access list check")
 		return types.ErrUninitialized
 	}
 

--- a/op-interop-filter/filter/logsdb_chain_ingester.go
+++ b/op-interop-filter/filter/logsdb_chain_ingester.go
@@ -212,6 +212,7 @@ func (c *LogsDBChainIngester) Contains(query types.ContainsQuery) (types.BlockSe
 	defer c.mu.RUnlock()
 
 	if c.logsDB == nil {
+		c.log.Warn("Contains called but logs DB not initialized")
 		return types.BlockSeal{}, types.ErrUninitialized
 	}
 
@@ -280,6 +281,7 @@ func (c *LogsDBChainIngester) GetExecMsgsAtTimestamp(timestamp uint64) ([]Includ
 	defer c.mu.RUnlock()
 
 	if c.logsDB == nil {
+		c.log.Warn("GetExecMsgsAtTimestamp called but logs DB not initialized")
 		return nil, types.ErrUninitialized
 	}
 
@@ -437,6 +439,10 @@ func (c *LogsDBChainIngester) runIngestion() {
 
 		// Reorg detection: if head moved behind our progress, check hash
 		if head.NumberU64() < nextBlock {
+			c.log.Info("Chain head is behind ingestion progress, waiting for node to catch up",
+				"head", head.NumberU64(),
+				"next_block", nextBlock,
+			)
 			if err := c.checkReorg(head); err != nil {
 				continue
 			}
@@ -652,6 +658,8 @@ func (c *LogsDBChainIngester) ingestBlock(blockNum uint64) error {
 	c.metrics.RecordBlocksSealed(chainIDUint64, 1)
 	c.metrics.RecordLogsAdded(chainIDUint64, int64(logCount))
 
+	c.log.Debug("Ingested block", "block", blockNum, "hash", blockID.Hash, "timestamp", blockInfo.Time(), "logs", logCount)
+
 	// Set earliest block on first successful ingestion (fresh start case).
 	// On restart, findAndSetEarliestBlock handles this instead.
 	if !c.earliestIngestedBlockSet.Load() {
@@ -682,6 +690,17 @@ func (c *LogsDBChainIngester) processBlockLogs(blockInfo eth.BlockInfo, blockID 
 			execMsg, err := processors.DecodeExecutingMessageLog(l)
 			if err != nil {
 				return 0, fmt.Errorf("invalid log %d in block %d: %w: %w", l.Index, blockNum, ErrInvalidLog, err)
+			}
+
+			if execMsg != nil {
+				c.log.Debug("Found executing message in block",
+					"block", blockNum,
+					"log_index", logIndex,
+					"src_chain", execMsg.ChainID,
+					"src_block", execMsg.BlockNum,
+					"src_log_index", execMsg.LogIdx,
+					"src_timestamp", execMsg.Timestamp,
+				)
 			}
 
 			if err := c.logsDB.AddLog(logHash, parentBlock, logIndex, execMsg); err != nil {


### PR DESCRIPTION
## Summary

This is a logging-only breakout from #19993. It keeps the low-risk diagnostic logging additions from that PR while leaving the ingestion pipeline, concurrency, and startup-scan changes out of scope.

The intent is to land the observability improvements independently so operators get useful signals without coupling them to the larger performance refactor.

## Breakout from #19993

This PR carries over equivalent diagnostic intent for:

- access-list checks that arrive before the backend is ready, implemented as a single `Debug` log in the hot path
- query paths called before the logs DB is initialized
- cases where the chain head is behind the ingester's next block
- successful block ingestion, including block hash, timestamp, and log count
- executing messages found while processing block logs

One difference from #19993 is intentional: this PR does not add `StartTimestamp` plumbing or per-chain readiness iteration through the backend hot path. The readiness rejection log is kept lightweight and debug-level.

## Validation

- `go test ./op-interop-filter/filter`
- `go test ./op-interop-filter/...`
- `./linter/bin/op-golangci-lint run ./...`
- `go mod tidy -diff`
