### PR TITLE
fix(contracts): reject oz v5 initializable in opcm

### DIFF
--- a/packages/contracts-bedrock/interfaces/L1/opcm/IOPContractsManagerUtils.sol
+++ b/packages/contracts-bedrock/interfaces/L1/opcm/IOPContractsManagerUtils.sol
@@ -56,7 +56,7 @@ interface IOPContractsManagerUtils {
 
     error OPContractsManagerUtils_DowngradeNotAllowed(address _contract);
     error OPContractsManagerUtils_ExtraTagInProd(address _contract);
-    error OPContractsManagerUtils_InitializingDuringUpgrade();
+    error OPContractsManagerUtils_OZv5InitializableUnsupported();
     error OPContractsManagerUtils_ConfigLoadFailed(string _name);
     error OPContractsManagerUtils_ProxyMustLoad(string _name);
     error OPContractsManagerUtils_UnsupportedGameType();

--- a/packages/contracts-bedrock/snapshots/abi/OPContractsManagerUtils.json
+++ b/packages/contracts-bedrock/snapshots/abi/OPContractsManagerUtils.json
@@ -698,7 +698,7 @@
   },
   {
     "inputs": [],
-    "name": "OPContractsManagerUtils_InitializingDuringUpgrade",
+    "name": "OPContractsManagerUtils_OZv5InitializableUnsupported",
     "type": "error"
   },
   {

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerUtils.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerUtils.sol
@@ -38,6 +38,10 @@ contract OPContractsManagerUtils {
         bytes data;
     }
 
+    /// @notice ERC-7201 Initializable slot used by OpenZeppelin Contracts v5.
+    bytes32 internal constant OZ_V5_INITIALIZABLE_SLOT =
+        0xf0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a00;
+
     /// @notice Emitted when a proxy is created by this contract.
     /// @param name  The name of the proxy.
     /// @param proxy The address of the proxy.
@@ -51,8 +55,8 @@ contract OPContractsManagerUtils {
     /// @param _contract The address of the contract with extra version tags.
     error OPContractsManagerUtils_ExtraTagInProd(address _contract);
 
-    /// @notice Thrown when a contract has `_initializing` as true during an upgrade.
-    error OPContractsManagerUtils_InitializingDuringUpgrade();
+    /// @notice Thrown when an upgrade attempts to reset an OpenZeppelin Contracts v5 Initializable contract.
+    error OPContractsManagerUtils_OZv5InitializableUnsupported();
 
     /// @notice Thrown when a config load fails.
     /// @param _name The name of the config that failed to load.
@@ -336,37 +340,20 @@ contract OPContractsManagerUtils {
         // Upgrade to StorageSetter.
         _proxyAdmin.upgrade(payable(_target), address(implementations().storageSetterImpl));
 
-        // We need to reset the initialized slot and call the initializer.
-        // NOTE: This reset path still assumes `_offset` is a byte offset within a single
-        // storage slot, the generic one-byte clear can clobber OZ v5 `_initializing` if `_slot`
-        // matches the namespaced Initializable slot, and the hardcoded ERC-7201 slot only covers
-        // the default OZ v5 `_initializableStorageSlot()` layout.
+        // OpenZeppelin Contracts v5 Initializable uses an ERC-7201 namespaced slot instead of
+        // the v4 one-byte `_initialized` field. OPCM does not support the v5 layout, so abort
+        // when the caller points at that slot or the target already has state there.
+        if (
+            _slot == OZ_V5_INITIALIZABLE_SLOT
+                || IStorageSetter(_target).getBytes32(OZ_V5_INITIALIZABLE_SLOT) != bytes32(0)
+        ) {
+            revert OPContractsManagerUtils_OZv5InitializableUnsupported();
+        }
+
         // Reset the initialized slot by zeroing the single byte at `_offset` (from the right).
         bytes32 current = IStorageSetter(_target).getBytes32(_slot);
         uint256 mask = ~(uint256(0xff) << (uint256(_offset) * 8));
         IStorageSetter(_target).setBytes32(_slot, bytes32(uint256(current) & mask));
-
-        // Also clear the OZ v5 ERC-7201 Initializable slot. OZ v5 stores `_initialized` as
-        // uint64 in the low 8 bytes and `_initializing` as bool at byte offset 8 of the
-        // namespaced slot. For v4 contracts this slot is all zeros, making this a no-op.
-        // Slot derivation (ERC-7201):
-        //   keccak256(abi.encode(uint256(keccak256("openzeppelin.storage.Initializable")) - 1)) &
-        // ~bytes32(uint256(0xff))
-        // Ref:
-        // https://github.com/OpenZeppelin/openzeppelin-contracts/blob/6b55a93e/contracts/proxy/utils/Initializable.sol#L77
-        bytes32 ozV5Slot = bytes32(uint256(0xf0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a00));
-        bytes32 v5Current = IStorageSetter(_target).getBytes32(ozV5Slot);
-        uint256 v5Value = uint256(v5Current);
-
-        // A contract should never be mid-initialization during an upgrade. The `_initializing`
-        // bool lives at byte offset 8 (bits 64..71). Revert if it is set.
-        if ((v5Value >> 64) & 0xFF != 0) {
-            revert OPContractsManagerUtils_InitializingDuringUpgrade();
-        }
-
-        // Zero the uint64 `_initialized` portion (low 8 bytes), preserving all upper bytes.
-        uint256 v5Mask = ~uint256(0xFFFFFFFFFFFFFFFF);
-        IStorageSetter(_target).setBytes32(ozV5Slot, bytes32(v5Value & v5Mask));
 
         // Upgrade to the implementation and call the initializer.
         _proxyAdmin.upgradeAndCall(payable(address(_target)), _implementation, _data);

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerUtils.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerUtils.t.sol
@@ -694,8 +694,8 @@ contract OPContractsManagerUtils_Upgrade_Test is OPContractsManagerUtils_TestIni
     bytes32 internal constant OZ_V5_INITIALIZABLE_SLOT =
         bytes32(uint256(0xf0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a00));
 
-    /// @notice Tests that v4 contracts are unaffected by the v5 slot clearing logic. For v4
-    ///         contracts the ERC-7201 slot is all zeros, so the new code is a no-op.
+    /// @notice Tests that v4 contracts are unaffected by the v5 unsupported check. For v4
+    ///         contracts the ERC-7201 slot is all zeros, so the check is a no-op.
     function test_upgrade_v4ContractStillWorks_succeeds() public {
         // Set v1 as current implementation.
         vm.prank(address(utils));
@@ -718,8 +718,25 @@ contract OPContractsManagerUtils_Upgrade_Test is OPContractsManagerUtils_TestIni
         assertEq(vm.load(address(proxy), OZ_V5_INITIALIZABLE_SLOT), bytes32(0));
     }
 
-    /// @notice Tests that a v5 contract with `_initialized = 1` at the ERC-7201 slot gets cleared.
-    function test_upgrade_v5SlotCleared_succeeds() public {
+    /// @notice Tests that an upgrade reverts if the caller passes the OZ v5 ERC-7201 slot.
+    function test_upgrade_v5SlotInput_reverts() public {
+        // Set v1 as current implementation.
+        vm.prank(address(utils));
+        proxyAdmin.upgrade(payable(address(proxy)), address(implV1));
+
+        vm.expectRevert(IOPContractsManagerUtils.OPContractsManagerUtils_OZv5InitializableUnsupported.selector);
+        utils.upgrade(
+            proxyAdmin,
+            address(proxy),
+            address(implV2),
+            abi.encodeCall(OPContractsManagerUtils_ImplV2_Harness.initialize, ()),
+            OZ_V5_INITIALIZABLE_SLOT,
+            TEST_OFFSET
+        );
+    }
+
+    /// @notice Tests that an upgrade reverts if the target has OZ v5 Initializable state.
+    function test_upgrade_v5SlotSet_reverts() public {
         // Set v1 as current implementation.
         vm.prank(address(utils));
         proxyAdmin.upgrade(payable(address(proxy)), address(implV1));
@@ -727,7 +744,7 @@ contract OPContractsManagerUtils_Upgrade_Test is OPContractsManagerUtils_TestIni
         // Simulate a v5 contract with _initialized = 1 at the ERC-7201 slot.
         vm.store(address(proxy), OZ_V5_INITIALIZABLE_SLOT, bytes32(uint256(1)));
 
-        // Upgrade to v2 should succeed.
+        vm.expectRevert(IOPContractsManagerUtils.OPContractsManagerUtils_OZv5InitializableUnsupported.selector);
         utils.upgrade(
             proxyAdmin,
             address(proxy),
@@ -736,23 +753,18 @@ contract OPContractsManagerUtils_Upgrade_Test is OPContractsManagerUtils_TestIni
             TEST_SLOT,
             TEST_OFFSET
         );
-
-        assertEq(proxyAdmin.getProxyImplementation(payable(address(proxy))), address(implV2));
-        // The v5 _initialized field should have been cleared.
-        assertEq(vm.load(address(proxy), OZ_V5_INITIALIZABLE_SLOT), bytes32(0));
     }
 
-    /// @notice Tests that a v5 contract with `_initialized = type(uint64).max` (from
-    ///         `_disableInitializers()`) gets cleared.
-    function test_upgrade_v5SlotMaxInitialized_succeeds() public {
+    /// @notice Tests that disabled OZ v5 Initializable state is still unsupported.
+    function test_upgrade_v5SlotMaxInitialized_reverts() public {
         // Set v1 as current implementation.
         vm.prank(address(utils));
         proxyAdmin.upgrade(payable(address(proxy)), address(implV1));
 
-        // Simulate a v5 contract with _initialized = type(uint64).max (disabled initializers).
+        // Simulate a v5 contract with _initialized = type(uint64).max from _disableInitializers().
         vm.store(address(proxy), OZ_V5_INITIALIZABLE_SLOT, bytes32(uint256(type(uint64).max)));
 
-        // Upgrade to v2 should succeed.
+        vm.expectRevert(IOPContractsManagerUtils.OPContractsManagerUtils_OZv5InitializableUnsupported.selector);
         utils.upgrade(
             proxyAdmin,
             address(proxy),
@@ -761,61 +773,6 @@ contract OPContractsManagerUtils_Upgrade_Test is OPContractsManagerUtils_TestIni
             TEST_SLOT,
             TEST_OFFSET
         );
-
-        assertEq(proxyAdmin.getProxyImplementation(payable(address(proxy))), address(implV2));
-        // The v5 _initialized field should have been cleared.
-        assertEq(vm.load(address(proxy), OZ_V5_INITIALIZABLE_SLOT), bytes32(0));
-    }
-
-    /// @notice Tests that upgrade reverts when `_initializing` bool is set at the ERC-7201 slot.
-    function test_upgrade_v5InitializingDuringUpgrade_reverts() public {
-        // Set v1 as current implementation.
-        vm.prank(address(utils));
-        proxyAdmin.upgrade(payable(address(proxy)), address(implV1));
-
-        // Simulate a v5 contract that is mid-initialization. The _initializing bool is at byte
-        // offset 8 (bit 64). Set _initialized = 1 and _initializing = true.
-        uint256 v5Value = 1 | (uint256(1) << 64);
-        vm.store(address(proxy), OZ_V5_INITIALIZABLE_SLOT, bytes32(v5Value));
-
-        vm.expectRevert(IOPContractsManagerUtils.OPContractsManagerUtils_InitializingDuringUpgrade.selector);
-        utils.upgrade(
-            proxyAdmin,
-            address(proxy),
-            address(implV2),
-            abi.encodeCall(OPContractsManagerUtils_ImplV2_Harness.initialize, ()),
-            TEST_SLOT,
-            TEST_OFFSET
-        );
-    }
-
-    /// @notice Tests that the upper bytes of the ERC-7201 slot beyond the Initializable struct
-    ///         are preserved when clearing the `_initialized` field.
-    function test_upgrade_v5SlotPreservesUpperBytes_succeeds() public {
-        // Set v1 as current implementation.
-        vm.prank(address(utils));
-        proxyAdmin.upgrade(payable(address(proxy)), address(implV1));
-
-        // Set the v5 slot with _initialized = 1 in the low 8 bytes and some data in the upper
-        // bytes (above the _initializing bool at byte offset 8). Bytes 9+ are unused by the
-        // Initializable struct but should be preserved.
-        uint256 upperData = uint256(0xDEADBEEF) << 128;
-        uint256 v5Value = upperData | 1;
-        vm.store(address(proxy), OZ_V5_INITIALIZABLE_SLOT, bytes32(v5Value));
-
-        // Upgrade to v2 should succeed.
-        utils.upgrade(
-            proxyAdmin,
-            address(proxy),
-            address(implV2),
-            abi.encodeCall(OPContractsManagerUtils_ImplV2_Harness.initialize, ()),
-            TEST_SLOT,
-            TEST_OFFSET
-        );
-
-        assertEq(proxyAdmin.getProxyImplementation(payable(address(proxy))), address(implV2));
-        // The upper bytes should be preserved, only the low 8 bytes should be zeroed.
-        assertEq(vm.load(address(proxy), OZ_V5_INITIALIZABLE_SLOT), bytes32(upperData));
     }
 }
 


### PR DESCRIPTION
## Summary
- Remove OPCM's OZ v5 Initializable slot-clearing support path
- Add an explicit unsupported revert when the OZ v5 ERC-7201 Initializable slot is passed or populated
- Update OPCM utils tests and ABI snapshot for the new error

## Test plan
- `mise x -- just lint`
- `mise x -- just test-dev --match-contract OPContractsManagerUtils_Upgrade_Test`
- `mise x -- just snapshots-abi-storage`
- `mise x -- just snapshots-check-no-build && mise x -- just interfaces-check-no-build && mise x -- just lint-forge-tests-check-no-build`
- `mise x -- just test-dev --match-path test/L1/opcm/OPContractsManagerUtils.t.sol`
- `mise x -- just pr`