### PR TITLE
contracts: fail closed resolving semver target branch

### DIFF
--- a/packages/contracts-bedrock/scripts/checks/check-semver-diff.sh
+++ b/packages/contracts-bedrock/scripts/checks/check-semver-diff.sh
@@ -36,11 +36,17 @@ trap 'rm -rf "$temp_dir"' EXIT
 
 # Exit early if semver-lock.json has not changed.
 UPSTREAM_REF="origin/${TARGET_BRANCH}"
-if ! {
-  git diff "$UPSTREAM_REF"...HEAD --name-only
-  git diff --name-only
-  git diff --cached --name-only
-} | grep -q "$SEMVER_LOCK"; then
+if ! git rev-parse --verify --quiet "$UPSTREAM_REF" > /dev/null; then
+  echo "❌ Error: Could not find upstream ref $UPSTREAM_REF"
+  exit 1
+fi
+
+changed_files="$temp_dir/changed_files.txt"
+git diff "$UPSTREAM_REF"...HEAD --name-only > "$changed_files"
+git diff --name-only >> "$changed_files"
+git diff --cached --name-only >> "$changed_files"
+
+if ! grep -qx "$SEMVER_LOCK" "$changed_files"; then
   echo "No changes detected in semver-lock.json"
   exit 0
 fi

--- a/packages/contracts-bedrock/scripts/ops/get-target-branch.sh
+++ b/packages/contracts-bedrock/scripts/ops/get-target-branch.sh
@@ -1,21 +1,44 @@
 #!/usr/bin/env bash
 # Determines the PR target branch and exports TARGET_BRANCH
 
-TARGET_BRANCH=""
-if [ -n "${CIRCLE_PULL_REQUEST:-}" ]; then
-  TARGET_BRANCH=$(curl -s "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls/${CIRCLE_PULL_REQUEST##*/}" | jq -r .base.ref)
-fi
+resolve_pr_target_branch() {
+  local pr_number="${CIRCLE_PULL_REQUEST##*/}"
+  local response
+  local url
 
-# Fallbacks when not a PR or API did not return a branch
-if [ -z "$TARGET_BRANCH" ] || [ "$TARGET_BRANCH" = "null" ]; then
-  # In merge queues, CIRCLE_BRANCH is gh-readonly-queue/<base>/pr-<n>-<sha>.
-  # Extract the base branch via regex; BASH_REMATCH[1] captures the first
-  # parenthesised group, i.e. the <base> segment between the slashes.
-  if [[ "${CIRCLE_BRANCH:-}" =~ ^gh-readonly-queue/([^/]+)/ ]]; then
-    TARGET_BRANCH="${BASH_REMATCH[1]}"
-  else
-    TARGET_BRANCH="${CIRCLE_BRANCH:-develop}"
+  if [ -z "${CIRCLE_PROJECT_USERNAME:-}" ] || [ -z "${CIRCLE_PROJECT_REPONAME:-}" ]; then
+    echo "Error: CIRCLE_PROJECT_USERNAME and CIRCLE_PROJECT_REPONAME are required to resolve PR target branch" >&2
+    return 1
   fi
+
+  url="https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls/${pr_number}"
+  response="$(curl -fsSL "$url")" || {
+    echo "Error: failed to resolve target branch for PR #${pr_number}" >&2
+    return 1
+  }
+
+  TARGET_BRANCH="$(jq -er '.base.ref | select(type == "string" and length > 0)' <<< "$response")" || {
+    echo "Error: GitHub API response did not include base.ref for PR #${pr_number}" >&2
+    return 1
+  }
+}
+
+TARGET_BRANCH=""
+
+# In merge queues, CIRCLE_BRANCH is gh-readonly-queue/<base>/pr-<n>-<sha>.
+# Extract the base branch via regex; BASH_REMATCH[1] captures the first
+# parenthesised group, i.e. the <base> segment between the slashes.
+if [[ "${CIRCLE_BRANCH:-}" =~ ^gh-readonly-queue/([^/]+)/ ]]; then
+  TARGET_BRANCH="${BASH_REMATCH[1]}"
+elif [ -n "${CIRCLE_PULL_REQUEST:-}" ]; then
+  # PR jobs must fail closed if GitHub cannot return the true base branch.
+  # Falling back to CIRCLE_BRANCH can compare a branch against itself.
+  resolve_pr_target_branch || exit 1
+else
+  # Non-PR/manual branch jobs do not have a reliable source for the true base.
+  # Use the repository default branch instead of CIRCLE_BRANCH so diff-based
+  # checks cannot accidentally compare a branch against itself.
+  TARGET_BRANCH="develop"
 fi
 
 echo "Resolved TARGET_BRANCH=$TARGET_BRANCH" >&2


### PR DESCRIPTION
## Summary
- fail PR target branch resolution when GitHub does not return a non-empty `base.ref`
- keep merge queue base parsing, but default non-PR/manual jobs to `develop` instead of `CIRCLE_BRANCH`
- make `check-semver-diff.sh` fail when `origin/${TARGET_BRANCH}` is missing instead of treating the failed diff as no lockfile change

## Reason
The old fallback was likely meant to make non-PR/manual jobs and GitHub API edge cases keep running. That is unsafe for PR jobs: falling back to `CIRCLE_BRANCH` can compare a branch against itself, and the old `git diff | grep` guard could also swallow a missing upstream ref as "No changes detected". This makes those cases fail closed.

Context: CI investigation for #20348.

## Tests
- `mise x -- just semver-diff-check-no-build`
- `shellcheck packages/contracts-bedrock/scripts/ops/get-target-branch.sh packages/contracts-bedrock/scripts/checks/check-semver-diff.sh`
- `mise x -- shfmt -d packages/contracts-bedrock/scripts/ops/get-target-branch.sh packages/contracts-bedrock/scripts/checks/check-semver-diff.sh`
- `git diff --check`
- `mise x -- just pr -no-build`