### PR TITLE
op-stack: ignore protocol versions address in rollup config

### DIFF
--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -66,6 +66,12 @@ type AltDAConfig struct {
 	DAResolveWindow uint64 `json:"da_resolve_window"`
 }
 
+type ignoredJSONField struct{}
+
+func (ignoredJSONField) IsZero() bool { return true }
+
+func (*ignoredJSONField) UnmarshalJSON([]byte) error { return nil }
+
 type Config struct {
 	// Genesis anchor point of the rollup
 	Genesis Genesis `json:"genesis"`
@@ -146,6 +152,9 @@ type Config struct {
 	DepositContractAddress common.Address `json:"deposit_contract_address"`
 	// L1 System Config Address
 	L1SystemConfigAddress common.Address `json:"l1_system_config_address"`
+	// ProtocolVersionsAddress is accepted for backwards compatibility with legacy rollup configs.
+	// The value is ignored and omitted when marshaling.
+	ProtocolVersionsAddress ignoredJSONField `json:"protocol_versions_address,omitzero"`
 
 	// ChainOpConfig is the OptimismConfig of the execution layer ChainConfig.
 	// It is used during safe chain consolidation to translate zero SystemConfig EIP1559

--- a/op-node/rollup/types_test.go
+++ b/op-node/rollup/types_test.go
@@ -63,9 +63,49 @@ func TestConfigJSON(t *testing.T) {
 	config := randConfig()
 	data, err := json.Marshal(config)
 	assert.NoError(t, err)
+	require.NotContains(t, string(data), "protocol_versions_address")
 	var roundTripped Config
 	assert.NoError(t, json.Unmarshal(data, &roundTripped))
 	assert.Equal(t, &roundTripped, config)
+}
+
+func TestParseRollupConfigIgnoresProtocolVersionsAddress(t *testing.T) {
+	config := randConfig()
+	data, err := json.Marshal(config)
+	require.NoError(t, err)
+
+	var fields map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(data, &fields))
+	fields["protocol_versions_address"] = json.RawMessage(
+		`"0x0000000000000000000000000000000000000001"`,
+	)
+	data, err = json.Marshal(fields)
+	require.NoError(t, err)
+
+	var parsed Config
+	require.NoError(t, parsed.ParseRollupConfig(strings.NewReader(string(data))))
+	require.Equal(t, config, &parsed)
+
+	data, err = json.Marshal(&parsed)
+	require.NoError(t, err)
+	require.NotContains(t, string(data), "protocol_versions_address")
+}
+
+func TestParseRollupConfigRejectsUnknownField(t *testing.T) {
+	config := randConfig()
+	data, err := json.Marshal(config)
+	require.NoError(t, err)
+
+	var fields map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(data, &fields))
+	fields["unknown_field"] = json.RawMessage(`true`)
+	data, err = json.Marshal(fields)
+	require.NoError(t, err)
+
+	var parsed Config
+	err = parsed.ParseRollupConfig(strings.NewReader(string(data)))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `unknown field "unknown_field"`)
 }
 
 type mockL1Client struct {

--- a/rust/kona/crates/protocol/genesis/src/chain/config.rs
+++ b/rust/kona/crates/protocol/genesis/src/chain/config.rs
@@ -159,6 +159,7 @@ impl ChainConfig {
                 .as_ref()
                 .and_then(|a| a.system_config_proxy)
                 .unwrap_or_default(),
+            protocol_versions_address: (),
             superchain_config_address: None,
             blobs_enabled_l1_timestamp: None,
             da_challenge_address: self

--- a/rust/kona/crates/protocol/genesis/src/rollup.rs
+++ b/rust/kona/crates/protocol/genesis/src/rollup.rs
@@ -31,6 +31,15 @@ const fn default_fjord_max_sequencer_drift() -> u64 {
     FJORD_MAX_SEQUENCER_DRIFT
 }
 
+#[cfg(feature = "serde")]
+fn deserialize_ignored_any<'de, D>(deserializer: D) -> Result<(), D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    <serde::de::IgnoredAny as serde::Deserialize>::deserialize(deserializer)?;
+    Ok(())
+}
+
 /// The Rollup configuration.
 #[derive(Debug, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -72,6 +81,15 @@ pub struct RollupConfig {
     pub deposit_contract_address: Address,
     /// `l1_system_config_address` is the L1 address that the system config is stored at.
     pub l1_system_config_address: Address,
+    /// Legacy protocol versions contract address.
+    ///
+    /// This field is accepted when deserializing older rollup configs, but its value is ignored
+    /// and it is never serialized.
+    #[cfg_attr(
+        feature = "serde",
+        serde(default, skip_serializing, deserialize_with = "deserialize_ignored_any")
+    )]
+    pub protocol_versions_address: (),
     /// The superchain config address.
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub superchain_config_address: Option<Address>,
@@ -121,6 +139,7 @@ impl<'a> arbitrary::Arbitrary<'a> for RollupConfig {
             batch_inbox_address: Address::arbitrary(u)?,
             deposit_contract_address: Address::arbitrary(u)?,
             l1_system_config_address: Address::arbitrary(u)?,
+            protocol_versions_address: (),
             superchain_config_address: Option::<Address>::arbitrary(u)?,
             blobs_enabled_l1_timestamp: Option::<u64>::arbitrary(u)?,
             da_challenge_address: Option::<Address>::arbitrary(u)?,
@@ -148,6 +167,7 @@ impl Default for RollupConfig {
             batch_inbox_address: Address::ZERO,
             deposit_contract_address: Address::ZERO,
             l1_system_config_address: Address::ZERO,
+            protocol_versions_address: (),
             superchain_config_address: None,
             blobs_enabled_l1_timestamp: None,
             da_challenge_address: None,
@@ -918,6 +938,7 @@ mod tests {
             batch_inbox_address: address!("ff00000000000000000000000000000000042069"),
             deposit_contract_address: address!("08073dc48dde578137b8af042bcbc1c2491f1eb2"),
             l1_system_config_address: address!("94ee52a9d8edd72a85dea7fae3ba6d75e4bf1710"),
+            protocol_versions_address: (),
             superchain_config_address: None,
             blobs_enabled_l1_timestamp: None,
             da_challenge_address: None,
@@ -975,6 +996,62 @@ mod tests {
 
         let err = serde_json::from_str::<RollupConfig>(raw).unwrap_err();
         assert_eq!(err.classify(), serde_json::error::Category::Data);
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn test_protocol_versions_address_is_ignored() {
+        let raw: &str = r#"
+        {
+          "genesis": {
+            "l1": {
+              "hash": "0x481724ee99b1f4cb71d826e2ec5a37265f460e9b112315665c977f4050b0af54",
+              "number": 10
+            },
+            "l2": {
+              "hash": "0x88aedfbf7dea6bfa2c4ff315784ad1a7f145d8f650969359c003bbed68c87631",
+              "number": 0
+            },
+            "l2_time": 1725557164,
+            "system_config": {
+              "batcherAddr": "0xc81f87a644b41e49b3221f41251f15c6cb00ce03",
+              "overhead": "0x0000000000000000000000000000000000000000000000000000000000000000",
+              "scalar": "0x00000000000000000000000000000000000000000000000000000000000f4240",
+              "gasLimit": 30000000
+            }
+          },
+          "block_time": 2,
+          "max_sequencer_drift": 600,
+          "seq_window_size": 3600,
+          "channel_timeout": 300,
+          "l1_chain_id": 3151908,
+          "l2_chain_id": 1337,
+          "regolith_time": 0,
+          "canyon_time": 0,
+          "delta_time": 0,
+          "ecotone_time": 0,
+          "fjord_time": 0,
+          "batch_inbox_address": "0xff00000000000000000000000000000000042069",
+          "deposit_contract_address": "0x08073dc48dde578137b8af042bcbc1c2491f1eb2",
+          "l1_system_config_address": "0x94ee52a9d8edd72a85dea7fae3ba6d75e4bf1710",
+          "protocol_versions_address": "0x0000000000000000000000000000000000000001"
+        }
+        "#;
+
+        let deserialized: RollupConfig = serde_json::from_str(raw).unwrap();
+        assert_eq!(deserialized.protocol_versions_address, ());
+
+        let serialized = serde_json::to_string(&deserialized).unwrap();
+        assert!(!serialized.contains("protocol_versions_address"));
+
+        let without_legacy_field = raw.replace(
+            r#",
+          "protocol_versions_address": "0x0000000000000000000000000000000000000001""#,
+            "",
+        );
+        let deserialized_without_legacy_field: RollupConfig =
+            serde_json::from_str(&without_legacy_field).unwrap();
+        assert_eq!(deserialized_without_legacy_field.protocol_versions_address, ());
     }
 
     #[test]

--- a/rust/kona/crates/protocol/registry/src/test_utils/base_mainnet.rs
+++ b/rust/kona/crates/protocol/registry/src/test_utils/base_mainnet.rs
@@ -67,6 +67,7 @@ pub const BASE_MAINNET_CONFIG: RollupConfig = RollupConfig {
     batch_inbox_address: address!("ff00000000000000000000000000000000008453"),
     deposit_contract_address: address!("49048044d57e1c92a77f79988d21fa8faf74e97e"),
     l1_system_config_address: address!("73a79fab69143498ed3712e519a88a918e1f4072"),
+    protocol_versions_address: (),
     superchain_config_address: Some(address!("95703e0982140D16f8ebA6d158FccEde42f04a4C")),
     da_challenge_address: None,
     blobs_enabled_l1_timestamp: None,

--- a/rust/kona/crates/protocol/registry/src/test_utils/base_sepolia.rs
+++ b/rust/kona/crates/protocol/registry/src/test_utils/base_sepolia.rs
@@ -69,6 +69,7 @@ pub const BASE_SEPOLIA_CONFIG: RollupConfig = RollupConfig {
     batch_inbox_address: address!("ff00000000000000000000000000000000084532"),
     deposit_contract_address: address!("49f53e41452c74589e85ca1677426ba426459e85"),
     l1_system_config_address: address!("f272670eb55e895584501d564afeb048bed26194"),
+    protocol_versions_address: (),
     superchain_config_address: Some(address!("C2Be75506d5724086DEB7245bd260Cc9753911Be")),
     da_challenge_address: None,
     blobs_enabled_l1_timestamp: None,

--- a/rust/kona/crates/protocol/registry/src/test_utils/op_mainnet.rs
+++ b/rust/kona/crates/protocol/registry/src/test_utils/op_mainnet.rs
@@ -69,6 +69,7 @@ pub const OP_MAINNET_CONFIG: RollupConfig = RollupConfig {
     batch_inbox_address: address!("ff00000000000000000000000000000000000010"),
     deposit_contract_address: address!("beb5fc579115071764c7423a4f12edde41f106ed"),
     l1_system_config_address: address!("229047fed2591dbec1ef1118d64f7af3db9eb290"),
+    protocol_versions_address: (),
     superchain_config_address: Some(address!("95703e0982140D16f8ebA6d158FccEde42f04a4C")),
     da_challenge_address: None,
     blobs_enabled_l1_timestamp: None,

--- a/rust/kona/crates/protocol/registry/src/test_utils/op_sepolia.rs
+++ b/rust/kona/crates/protocol/registry/src/test_utils/op_sepolia.rs
@@ -69,6 +69,7 @@ pub const OP_SEPOLIA_CONFIG: RollupConfig = RollupConfig {
     batch_inbox_address: address!("ff00000000000000000000000000000011155420"),
     deposit_contract_address: address!("16fc5058f25648194471939df75cf27a2fdc48bc"),
     l1_system_config_address: address!("034edd2a225f7f429a63e0f1d2084b9e0a93b538"),
+    protocol_versions_address: (),
     superchain_config_address: Some(address!("C2Be75506d5724086DEB7245bd260Cc9753911Be")),
     da_challenge_address: None,
     blobs_enabled_l1_timestamp: None,


### PR DESCRIPTION
## Summary

Accept the legacy `protocol_versions_address` key in rollup config JSON without restoring protocol-version behavior.

Alternative to #20373

## Changes

- Add an ignored Rust `RollupConfig::protocol_versions_address` unit field that deserializes any legacy value and is skipped on serialization.
- Add an ignored Go JSON field so `ParseRollupConfig` remains strict while accepting old configs.
- Update registry fixtures and config construction sites for the Rust field.
- Add Rust and Go tests covering legacy-key acceptance, marshal omission, and unrelated unknown-field rejection.

## Validation

- `cargo nextest run -p kona-genesis --features serde,arbitrary`
- `go test ./op-node/rollup/... ./op-node/chaincfg/...`
- `mise exec -- just f`
- `mise exec -- just lint`
- `mise exec -- just lint-go`
