### PR TITLE
chore(interopgen): remove stale todo comments

### DIFF
--- a/op-chain-ops/interopgen/deploy.go
+++ b/op-chain-ops/interopgen/deploy.go
@@ -369,7 +369,7 @@ func GenesisL2(l2Host *script.Host, cfg *L2Config, deployment *L2Deployment, mul
 		GasPayingTokenSymbol:                     cfg.GasPayingTokenSymbol,
 		NativeAssetLiquidityAmount:               cfg.NativeAssetLiquidityAmount.ToInt(),
 		LiquidityControllerOwner:                 cfg.LiquidityControllerOwner,
-		DevFeatureBitmap:                         devFeatureBitmapForL2Genesis(multichainDepSet && interopAtGenesis(cfg.L2GenesisInteropTimeOffset)), // TODO(#19102): add support for L2CM
+		DevFeatureBitmap:                         devFeatureBitmapForL2Genesis(multichainDepSet && interopAtGenesis(cfg.L2GenesisInteropTimeOffset)),
 		UseInterop:                               multichainDepSet && interopAtGenesis(cfg.L2GenesisInteropTimeOffset),
 	}); err != nil {
 		return fmt.Errorf("failed L2 genesis: %w", err)
@@ -387,7 +387,6 @@ func interopAtGenesis(interopOffset *hexutil.Uint64) bool {
 // devFeatureBitmapForL2Genesis returns the dev feature bitmap for the L2 genesis based on whether Interop should be
 // enabled or not.
 func devFeatureBitmapForL2Genesis(enableInterop bool) common.Hash {
-	// TODO(#19102): add support for L2CM
 	var bitmap common.Hash
 	if enableInterop {
 		bitmap = devfeatures.EnableDevFeature(bitmap, devfeatures.OptimismPortalInteropFlag)


### PR DESCRIPTION
## Summary

`op-chain-ops/interopgen/deploy.go` carried two TODO(#19102) comments for including `L2CMFlag` support alongside the interop flag. 

We're intentionally deferring this work. L2CM is on a short path to becoming the unconditional default in L2Genesis, at which point any wiring added here would be immediately torn out or just ignored.

Closes #19102 

## Related Issues
#20356 