### PR TITLE
op-node: only set FCU finalized after initial EL-sync

### DIFF
--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -512,9 +512,12 @@ func (e *EngineController) tryUpdateEngineInternal(ctx context.Context) error {
 		return err
 	}
 	fc := eth.ForkchoiceState{
-		HeadBlockHash:      e.unsafeHead.Hash,
-		SafeBlockHash:      e.SafeL2Head().Hash,
-		FinalizedBlockHash: e.FinalizedHead().Hash,
+		HeadBlockHash: e.unsafeHead.Hash,
+		SafeBlockHash: e.SafeL2Head().Hash,
+	}
+	// only set finalized after initial EL sync
+	if !e.isEngineInitialELSyncing() {
+		fc.FinalizedBlockHash = e.FinalizedHead().Hash
 	}
 	if fc == e.lastForkchoice {
 		return nil
@@ -620,9 +623,12 @@ func (e *EngineController) insertUnsafePayload(ctx context.Context, envelope *et
 
 	// Mark the new payload as valid
 	fc := eth.ForkchoiceState{
-		HeadBlockHash:      envelope.ExecutionPayload.BlockHash,
-		SafeBlockHash:      e.SafeL2Head().Hash,
-		FinalizedBlockHash: e.FinalizedHead().Hash,
+		HeadBlockHash: envelope.ExecutionPayload.BlockHash,
+		SafeBlockHash: e.SafeL2Head().Hash,
+	}
+	// only set finalized after initial EL sync
+	if !e.isEngineInitialELSyncing() {
+		fc.FinalizedBlockHash = e.FinalizedHead().Hash
 	}
 	if e.syncStatus == syncStatusFinishedELButNotFinalized {
 		offsetRef := ref

--- a/op-node/rollup/engine/engine_controller_test.go
+++ b/op-node/rollup/engine/engine_controller_test.go
@@ -895,9 +895,9 @@ func TestTryUpdateEngine_SyncingInELSyncModeIsAccepted(t *testing.T) {
 	// Mock ForkchoiceUpdate to return SYNCING
 	mockEngine.ExpectForkchoiceUpdate(
 		&eth.ForkchoiceState{
-			HeadBlockHash:      unsafeRef.Hash,
-			SafeBlockHash:      safeRef.Hash,
-			FinalizedBlockHash: finalRef.Hash,
+			HeadBlockHash: unsafeRef.Hash,
+			SafeBlockHash: safeRef.Hash,
+			// we omit FinalizedBlockHash because we expect it to NOT be set in EL sync mode
 		},
 		nil,
 		&eth.ForkchoiceUpdatedResult{


### PR DESCRIPTION
When reth & op-reth receive a FCU call with a non-zero finalized hash that doesn't advance the local hash, it ignores the unsafe hash and doesn't start syncing towards it. This causes syncing reth nodes to stall when they already have a finalized head which they get echoed back by op-node while it tries to update its unsafe sync target. This behavior causes op-reth to just stall and not make syncing progress.

This PR changes op-node's engine controller to use a zero finalized hash while the engine is still syncing, irrespective of its local view of the finalized hash. The finalized hash will eventually be set when the engine exits syncing.