### PR TITLE
feat(op-reth): compute miner fee on pool tx in payload builder

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -11500,6 +11500,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types-debug",
  "alloy-rpc-types-engine",
+ "alloy-rpc-types-eth",
  "derive_more",
  "op-alloy-consensus",
  "op-alloy-rpc-types-engine",

--- a/rust/op-reth/crates/payload/Cargo.toml
+++ b/rust/op-reth/crates/payload/Cargo.toml
@@ -55,3 +55,4 @@ serde.workspace = true
 [dev-dependencies]
 reth-optimism-chainspec.workspace = true
 reth-revm = { workspace = true, features = ["test-utils"] }
+alloy-rpc-types-eth.workspace = true

--- a/rust/op-reth/crates/payload/src/builder.rs
+++ b/rust/op-reth/crates/payload/src/builder.rs
@@ -833,7 +833,7 @@ where
             // denominations into a native-wei tip) before the consensus tx is exposed.
             let miner_fee = tx
                 .effective_tip_per_gas(base_fee)
-                .expect("pool was queried with block.basefee, so max_fee_per_gas >= base_fee");
+                .expect("selected pool transaction must have a valid effective miner tip at the block base fee");
             let tx = tx.into_consensus();
 
             let da_footprint_gas_scalar = self

--- a/rust/op-reth/crates/payload/src/builder.rs
+++ b/rust/op-reth/crates/payload/src/builder.rs
@@ -828,6 +828,12 @@ where
         while let Some(tx) = best_txs.next(()) {
             let interop = tx.interop_deadline();
             let tx_da_size = tx.estimated_da_size();
+            // Compute the miner fee on the pool tx so downstream pool wrappers can
+            // override `effective_tip_per_gas` (e.g. to convert non-native fee
+            // denominations into a native-wei tip) before the consensus tx is exposed.
+            let miner_fee = tx
+                .effective_tip_per_gas(base_fee)
+                .expect("pool was queried with block.basefee, so max_fee_per_gas >= base_fee");
             let tx = tx.into_consensus();
 
             let da_footprint_gas_scalar = self
@@ -903,9 +909,6 @@ where
             info.cumulative_da_bytes_used += tx_da_size;
 
             // update and add to total fees
-            let miner_fee = tx
-                .effective_tip_per_gas(base_fee)
-                .expect("fee is always valid; execution succeeded");
             info.total_fees += U256::from(miner_fee) * U256::from(tx_gas_used);
 
             // Record the successfully committed transaction for callers that want per-call

--- a/rust/op-reth/crates/payload/src/builder/tests.rs
+++ b/rust/op-reth/crates/payload/src/builder/tests.rs
@@ -7,12 +7,17 @@ use crate::{
     config::{OpBuilderConfig, OpDAConfig, OpGasLimitConfig},
 };
 use alloy_consensus::{
-    Header, SignableTransaction, TxEip1559, Typed2718,
+    Header, SignableTransaction, Transaction, TxEip1559, Typed2718,
     transaction::{Recovered, TxHashRef},
 };
-use alloy_eips::eip2718::Encodable2718;
+use alloy_eips::{
+    eip2718::{Encodable2718, WithEncoded},
+    eip2930::AccessList,
+    eip7702::SignedAuthorization,
+};
 use alloy_evm::RecoveredTx;
-use alloy_primitives::{Address, B256, Signature, TxHash, TxKind, U256};
+use alloy_primitives::{Address, B256, Bytes, Signature, TxHash, TxKind, U256};
+use alloy_rpc_types_eth::erc4337::TransactionConditional;
 use op_alloy_consensus::SDMGasEntry;
 use reth_basic_payload_builder::PayloadConfig;
 use reth_chainspec::MIN_TRANSACTION_GAS;
@@ -20,13 +25,16 @@ use reth_evm::execute::{BlockBuilder, BlockExecutionError};
 use reth_optimism_chainspec::{OpChainSpec, OpChainSpecBuilder};
 use reth_optimism_evm::OpEvmConfig;
 use reth_optimism_primitives::{OpPrimitives, OpTransactionSigned};
-use reth_optimism_txpool::OpPooledTransaction;
+use reth_optimism_txpool::{
+    OpPooledTransaction, OpPooledTx, conditional::MaybeConditionalTransaction,
+    estimated_da_size::DataAvailabilitySized, interop::MaybeInteropTransaction,
+};
 use reth_payload_builder_primitives::PayloadBuilderError;
 use reth_payload_util::PayloadTransactionsFixed;
-use reth_primitives_traits::{Account, SealedHeader};
+use reth_primitives_traits::{Account, InMemorySize, SealedHeader};
 use reth_revm::{database::StateProviderDatabase, db::State, test_utils::StateProviderTest};
 use reth_transaction_pool::PoolTransaction;
-use std::{cell::Cell, sync::Arc};
+use std::{borrow::Cow, cell::Cell, sync::Arc};
 
 fn entries(specs: &[(u64, u64)]) -> Vec<SDMGasEntry> {
     specs.iter().map(|&(index, gas_refund)| SDMGasEntry { index, gas_refund }).collect()
@@ -96,12 +104,15 @@ fn tx_hashes<'a>(txs: impl IntoIterator<Item = &'a Recovered<OpTransactionSigned
     txs.into_iter().map(|tx| *TxHashRef::tx_hash(tx)).collect()
 }
 
-fn run_execute_best_transactions(
+fn run_execute_best_transactions<T>(
     signer: Address,
-    txs: Vec<OpPooledTransaction>,
+    txs: Vec<T>,
     gas_limit_cap: Option<u64>,
     committed_txs: Option<&mut Vec<Recovered<OpTransactionSigned>>>,
-) -> (ExecutionInfo, Vec<TxHash>) {
+) -> (ExecutionInfo, Vec<TxHash>)
+where
+    T: PoolTransaction<Consensus = OpTransactionSigned> + OpPooledTx,
+{
     let gas_limit = 1_000_000;
     let chain_spec = Arc::new(OpChainSpecBuilder::base_mainnet().regolith_activated().build());
     let ctx = payload_builder_ctx(chain_spec, gas_limit);
@@ -276,4 +287,178 @@ fn try_include_post_exec_tx_aborts_when_execution_fails() {
         }
         other => panic!("expected EvmExecutionError, got {other:?}"),
     }
+}
+
+/// Regression test for the ordering of `effective_tip_per_gas()` and `into_consensus()` in the
+/// payload builder loop: the miner fee must be read from the pool wrapper before the consensus tx
+/// is exposed, so that callers can override the tip (e.g. to convert non-native fee denominations
+/// into a native-wei tip). If a future change moves the read after `into_consensus()`, the tip
+/// would come from the unwrapped consensus tx and this test would fail.
+#[test]
+fn miner_fee_uses_pool_wrapper_tip() {
+    /// Pool-tx wrapper whose `max_priority_fee_per_gas` (and therefore the default
+    /// `effective_tip_per_gas`) returns a forced value, while `into_consensus()` still exposes
+    /// the unmodified inner tx. Production callers do this to convert non-native fee
+    /// denominations into a native-wei tip.
+    #[derive(Debug, Clone)]
+    struct ForcedTipPooledTx {
+        inner: OpPooledTransaction,
+        forced_priority_fee: u128,
+    }
+
+    impl Typed2718 for ForcedTipPooledTx {
+        fn ty(&self) -> u8 {
+            self.inner.ty()
+        }
+    }
+
+    impl InMemorySize for ForcedTipPooledTx {
+        fn size(&self) -> usize {
+            self.inner.size()
+        }
+    }
+
+    impl Transaction for ForcedTipPooledTx {
+        fn chain_id(&self) -> Option<u64> {
+            self.inner.chain_id()
+        }
+        fn nonce(&self) -> u64 {
+            self.inner.nonce()
+        }
+        fn gas_limit(&self) -> u64 {
+            self.inner.gas_limit()
+        }
+        fn gas_price(&self) -> Option<u128> {
+            self.inner.gas_price()
+        }
+        fn max_fee_per_gas(&self) -> u128 {
+            // High enough that the default `effective_tip_per_gas` impl won't cap
+            // `forced_priority_fee` via `min(max_fee_per_gas - base_fee, priority_fee)`.
+            u128::MAX
+        }
+        fn max_priority_fee_per_gas(&self) -> Option<u128> {
+            Some(self.forced_priority_fee)
+        }
+        fn max_fee_per_blob_gas(&self) -> Option<u128> {
+            self.inner.max_fee_per_blob_gas()
+        }
+        fn priority_fee_or_price(&self) -> u128 {
+            self.inner.priority_fee_or_price()
+        }
+        fn effective_gas_price(&self, base_fee: Option<u64>) -> u128 {
+            self.inner.effective_gas_price(base_fee)
+        }
+        fn is_dynamic_fee(&self) -> bool {
+            self.inner.is_dynamic_fee()
+        }
+        fn kind(&self) -> TxKind {
+            self.inner.kind()
+        }
+        fn is_create(&self) -> bool {
+            self.inner.is_create()
+        }
+        fn value(&self) -> U256 {
+            self.inner.value()
+        }
+        fn input(&self) -> &Bytes {
+            self.inner.input()
+        }
+        fn access_list(&self) -> Option<&AccessList> {
+            self.inner.access_list()
+        }
+        fn blob_versioned_hashes(&self) -> Option<&[B256]> {
+            self.inner.blob_versioned_hashes()
+        }
+        fn authorization_list(&self) -> Option<&[SignedAuthorization]> {
+            self.inner.authorization_list()
+        }
+    }
+
+    impl MaybeConditionalTransaction for ForcedTipPooledTx {
+        fn set_conditional(&mut self, conditional: TransactionConditional) {
+            self.inner.set_conditional(conditional);
+        }
+        fn conditional(&self) -> Option<&TransactionConditional> {
+            self.inner.conditional()
+        }
+    }
+
+    impl MaybeInteropTransaction for ForcedTipPooledTx {
+        fn set_interop_deadline(&self, deadline: u64) {
+            self.inner.set_interop_deadline(deadline);
+        }
+        fn interop_deadline(&self) -> Option<u64> {
+            self.inner.interop_deadline()
+        }
+    }
+
+    impl DataAvailabilitySized for ForcedTipPooledTx {
+        fn estimated_da_size(&self) -> u64 {
+            self.inner.estimated_da_size()
+        }
+    }
+
+    impl PoolTransaction for ForcedTipPooledTx {
+        type TryFromConsensusError =
+            <OpPooledTransaction as PoolTransaction>::TryFromConsensusError;
+        type Consensus = <OpPooledTransaction as PoolTransaction>::Consensus;
+        type Pooled = <OpPooledTransaction as PoolTransaction>::Pooled;
+
+        fn clone_into_consensus(&self) -> Recovered<Self::Consensus> {
+            self.inner.clone_into_consensus()
+        }
+        fn consensus_ref(&self) -> Recovered<&Self::Consensus> {
+            self.inner.consensus_ref()
+        }
+        fn into_consensus(self) -> Recovered<Self::Consensus> {
+            self.inner.into_consensus()
+        }
+        fn into_consensus_with2718(self) -> WithEncoded<Recovered<Self::Consensus>> {
+            self.inner.into_consensus_with2718()
+        }
+        fn from_pooled(_pooled: Recovered<Self::Pooled>) -> Self {
+            unreachable!("payload builder loop never calls from_pooled on the wrapper")
+        }
+        fn hash(&self) -> &TxHash {
+            self.inner.hash()
+        }
+        fn sender(&self) -> Address {
+            self.inner.sender()
+        }
+        fn sender_ref(&self) -> &Address {
+            self.inner.sender_ref()
+        }
+        fn cost(&self) -> &U256 {
+            self.inner.cost()
+        }
+        fn encoded_length(&self) -> usize {
+            self.inner.encoded_length()
+        }
+    }
+
+    impl OpPooledTx for ForcedTipPooledTx {
+        fn encoded_2718(&self) -> Cow<'_, Bytes> {
+            OpPooledTx::encoded_2718(&self.inner)
+        }
+    }
+
+    let signer = Address::repeat_byte(0x11);
+    let inner = op_pooled_tx(0, signer, Address::repeat_byte(0x22));
+    // The inner consensus tx has `max_priority_fee_per_gas = 1`, so its natural effective tip at
+    // `base_fee = 0` is 1 wei/gas. Forcing the wrapper's priority fee to something much larger
+    // guarantees the wrapper-derived total differs from the consensus-tx-derived total.
+    let natural_priority_fee: u128 = 1;
+    let forced_priority_fee: u128 = 1_000_000;
+    let tx = ForcedTipPooledTx { inner, forced_priority_fee };
+
+    let (info, _) = run_execute_best_transactions(signer, vec![tx], None, None);
+
+    let gas_used = U256::from(info.cumulative_gas_used);
+    let expected_fees = U256::from(forced_priority_fee) * gas_used;
+    let natural_fees = U256::from(natural_priority_fee) * gas_used;
+    // Sanity check: if a future change reorders the read back behind `into_consensus()`, the
+    // builder would compute `natural_fees`. Asserting both sides defends against that even if
+    // somebody later tweaks the helper's fee fields and happens to land on `forced_priority_fee`.
+    assert_eq!(info.total_fees, expected_fees);
+    assert_ne!(info.total_fees, natural_fees);
 }


### PR DESCRIPTION
Move the `effective_tip_per_gas` call in `OpPayloadBuilderCtx::execute_best_transactions` to before `into_consensus()`, so the miner fee is computed from the pool transaction rather than the consensus transaction.

Semantically identical for vanilla op-reth users: for stock EIP-1559 / legacy / deposit txs, `effective_tip_per_gas` returns the same value on the pool or consensus form. The pool is queried with `block.basefee`, so any tx returned from `best_txs` satisfies `max_fee_per_gas >= base_fee`. The existing `expect` invariant still holds (I made the message more explicit).

This unblocks a cleanup in Celo's reth implementation. On Celo, `max_fee_per_gas` on the consensus tx can be denominated in an ERC-20 fee currency instead of native wei (CIP-64). The pool validator converts to native equivalents and exposes the correct tip via the pool tx's `effective_tip_per_gas` impl, but op-reth currently discards that view via `into_consensus()` before reading the tip. Without this change, the Celo fork needs a `SignedTx` newtype that stashes native-equivalent fees on the consensus tx solely to thread them through this one call site (~600 lines in celo-kona's `signed_tx.rs`, deletable once this lands).

See https://github.com/celo-org/celo-kona/issues/152