### PR TITLE
fix(op-node): seed LightCL genesis sync status

### DIFF
--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -893,12 +893,22 @@ func (e *EngineController) TryUpdateLocalSafe(ctx context.Context, ref eth.L2Blo
 
 // tryUpdateLocalSafe updates the local safe head if the new reference is newer and concluding
 func (e *EngineController) tryUpdateLocalSafe(ctx context.Context, ref eth.L2BlockRef, concluding bool, source eth.L1BlockRef) {
-	if concluding && ref.Number > e.localSafeHead.Number {
+	if concluding && shouldAdvanceL2Ref(e.localSafeHead, ref) {
 		// Promote to local safe
 		e.log.Debug("Updating local safe", "local_safe", ref, "safe", e.SafeL2Head(), "unsafe", e.unsafeHead)
 		e.SetLocalSafeHead(ref)
 		e.emitter.Emit(ctx, LocalSafeUpdateEvent{Ref: ref, Source: source})
 	}
+}
+
+func shouldAdvanceL2Ref(current, next eth.L2BlockRef) bool {
+	if next == (eth.L2BlockRef{}) {
+		return false
+	}
+	if current == (eth.L2BlockRef{}) {
+		return true
+	}
+	return next.Number > current.Number
 }
 
 // TryUpdateUnsafe updates the unsafe head and backs up the previous one if needed
@@ -1239,7 +1249,7 @@ func (e *EngineController) FollowSource(eSafeBlockRef, eLocalSafeRef, eFinalized
 		e.tryUpdateLocalSafe(e.ctx, eLocalSafeRef, true, eth.L1BlockRef{})
 		// Inject external cross-safe. Must happen before promoteFinalized
 		// (which rejects finalized > SafeL2Head).
-		if eSafeBlockRef.Number > e.deprecatedSafeHead.Number {
+		if shouldAdvanceL2Ref(e.deprecatedSafeHead, eSafeBlockRef) {
 			e.PromoteSafe(e.ctx, eSafeBlockRef, eth.L1BlockRef{})
 		}
 		// Directly update the Engine Controller state, bypassing finalizer

--- a/op-node/rollup/engine/engine_controller_test.go
+++ b/op-node/rollup/engine/engine_controller_test.go
@@ -657,6 +657,45 @@ func TestFollowSource_DivergentLocalSafeAndCrossSafe(t *testing.T) {
 		"invariant: cross-safe (deprecatedSafeHead) must not exceed local-safe")
 }
 
+func TestFollowSource_SeedsGenesisRefsFromZeroState(t *testing.T) {
+	rng := mrand.New(mrand.NewSource(20295))
+	l1Origin := testutils.RandomBlockRef(rng)
+	genesis := eth.L2BlockRef{
+		Hash:           testutils.RandomHash(rng),
+		Number:         0,
+		ParentHash:     common.Hash{},
+		Time:           l1Origin.Time,
+		L1Origin:       l1Origin.ID(),
+		SequenceNumber: 0,
+	}
+
+	cfg := &rollup.Config{}
+	mockEngine := &testutils.MockEngine{}
+	emitter := &testutils.MockEmitter{}
+	emitter.Mock.On("Emit", mock.Anything).Maybe()
+
+	ec := NewEngineController(context.Background(), mockEngine, testlog.Logger(t, 0),
+		metrics.NoopMetrics, cfg, &sync.Config{L2FollowSourceEndpoint: "http://localhost"}, false, &testutils.MockL1Source{}, emitter, nil)
+	ec.unsafeHead = genesis
+
+	mockEngine.ExpectL2BlockRefByNumber(0, genesis, nil)
+	mockEngine.ExpectForkchoiceUpdate(
+		&eth.ForkchoiceState{
+			HeadBlockHash:      genesis.Hash,
+			SafeBlockHash:      genesis.Hash,
+			FinalizedBlockHash: genesis.Hash,
+		}, nil,
+		&eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionValid}}, nil,
+	)
+
+	ec.FollowSource(genesis, genesis, genesis)
+
+	require.Equal(t, genesis, ec.localSafeHead)
+	require.Equal(t, genesis, ec.deprecatedSafeHead)
+	require.Equal(t, genesis, ec.deprecatedFinalizedHead)
+	mockEngine.AssertExpectations(t)
+}
+
 // TestEngineController_FinalizedHead tests FinalizedHead behavior with various configurations
 func TestEngineController_FinalizedHead(t *testing.T) {
 	tests := []struct {

--- a/op-node/rollup/status/status.go
+++ b/op-node/rollup/status/status.go
@@ -56,7 +56,7 @@ func (st *StatusTracker) OnEvent(ctx context.Context, ev event.Event) bool {
 		st.log.Debug("Forkchoice update", "unsafe", x.UnsafeL2Head, "safe", x.SafeL2Head, "finalized", x.FinalizedL2Head)
 		st.data.UnsafeL2 = x.UnsafeL2Head
 		st.data.SafeL2 = x.SafeL2Head
-		if st.data.LocalSafeL2.Number < x.SafeL2Head.Number {
+		if shouldAdvanceL2Ref(st.data.LocalSafeL2, x.SafeL2Head) {
 			st.data.LocalSafeL2 = x.SafeL2Head
 		}
 		st.data.FinalizedL2 = x.FinalizedL2Head
@@ -96,6 +96,16 @@ func (st *StatusTracker) UpdateSyncStatus() {
 		published = st.data
 		st.published.Store(&published)
 	}
+}
+
+func shouldAdvanceL2Ref(current, next eth.L2BlockRef) bool {
+	if next == (eth.L2BlockRef{}) {
+		return false
+	}
+	if current == (eth.L2BlockRef{}) {
+		return true
+	}
+	return next.Number > current.Number
 }
 
 func (st *StatusTracker) OnL1Unsafe(x eth.L1BlockRef) {

--- a/op-node/rollup/status/status_test.go
+++ b/op-node/rollup/status/status_test.go
@@ -2,12 +2,14 @@ package status
 
 import (
 	"context"
+	"math/rand"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/engine"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 )
@@ -50,4 +52,28 @@ func TestStatus(t *testing.T) {
 	require.Zero(t, status.SafeL2.Number)
 	require.Zero(t, status.UnsafeL2.Number)
 	require.Zero(t, status.CurrentL1.Number)
+}
+
+func TestForkchoiceUpdateSeedsLocalSafeWithGenesisSafe(t *testing.T) {
+	rng := rand.New(rand.NewSource(20295))
+	l1Origin := testutils.RandomBlockRef(rng)
+	genesis := eth.L2BlockRef{
+		Hash:           testutils.RandomHash(rng),
+		Number:         0,
+		Time:           l1Origin.Time,
+		L1Origin:       l1Origin.ID(),
+		SequenceNumber: 0,
+	}
+
+	tracker := NewStatusTracker(testlog.Logger(t, log.LevelDebug), NoopMetrics{})
+	tracker.OnEvent(context.Background(), engine.ForkchoiceUpdateEvent{
+		UnsafeL2Head:    genesis,
+		SafeL2Head:      genesis,
+		FinalizedL2Head: genesis,
+	})
+
+	status := tracker.SyncStatus()
+	require.Equal(t, genesis, status.SafeL2)
+	require.Equal(t, genesis, status.LocalSafeL2)
+	require.Equal(t, genesis, status.FinalizedL2)
 }


### PR DESCRIPTION
## Summary

Fix LightCL follow-source initialization when upstream reports the real L2 genesis block as safe, local-safe, and finalized while the local engine/status state is still the zero-value L2 block ref.

The previous advancement checks compared only block numbers. Since real genesis and the zero-value ref both have number 0, follow-source did not promote the real genesis safe/local-safe ref. That left optimism_syncStatus reporting zero-value safe_l2, local_safe_l2, and finalized_l2 on fresh-genesis LightCL nodes.

This change treats zero-value -> non-zero L2 block ref as an advancement while preserving the existing monotonic number-based behavior for initialized refs.

Fixes #20295.

## Tests

- go test ./op-node/rollup/engine
- go test ./op-node/rollup/status
- git diff --check