### PR TITLE
fix(op-node): seed LightCL genesis sync status

### DIFF
--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -893,7 +893,7 @@ func (e *EngineController) TryUpdateLocalSafe(ctx context.Context, ref eth.L2Blo
 
 // tryUpdateLocalSafe updates the local safe head if the new reference is newer and concluding
 func (e *EngineController) tryUpdateLocalSafe(ctx context.Context, ref eth.L2BlockRef, concluding bool, source eth.L1BlockRef) {
-	if concluding && ref.Number > e.localSafeHead.Number {
+	if concluding && eth.L2BlockRefAdvances(e.localSafeHead, ref) {
 		// Promote to local safe
 		e.log.Debug("Updating local safe", "local_safe", ref, "safe", e.SafeL2Head(), "unsafe", e.unsafeHead)
 		e.SetLocalSafeHead(ref)
@@ -1239,7 +1239,7 @@ func (e *EngineController) FollowSource(eSafeBlockRef, eLocalSafeRef, eFinalized
 		e.tryUpdateLocalSafe(e.ctx, eLocalSafeRef, true, eth.L1BlockRef{})
 		// Inject external cross-safe. Must happen before promoteFinalized
 		// (which rejects finalized > SafeL2Head).
-		if eSafeBlockRef.Number > e.deprecatedSafeHead.Number {
+		if eth.L2BlockRefAdvances(e.deprecatedSafeHead, eSafeBlockRef) {
 			e.PromoteSafe(e.ctx, eSafeBlockRef, eth.L1BlockRef{})
 		}
 		// Directly update the Engine Controller state, bypassing finalizer

--- a/op-node/rollup/engine/engine_controller_test.go
+++ b/op-node/rollup/engine/engine_controller_test.go
@@ -657,6 +657,45 @@ func TestFollowSource_DivergentLocalSafeAndCrossSafe(t *testing.T) {
 		"invariant: cross-safe (deprecatedSafeHead) must not exceed local-safe")
 }
 
+func TestFollowSource_SeedsGenesisRefsFromZeroState(t *testing.T) {
+	rng := mrand.New(mrand.NewSource(20295))
+	l1Origin := testutils.RandomBlockRef(rng)
+	genesis := eth.L2BlockRef{
+		Hash:           testutils.RandomHash(rng),
+		Number:         0,
+		ParentHash:     common.Hash{},
+		Time:           l1Origin.Time,
+		L1Origin:       l1Origin.ID(),
+		SequenceNumber: 0,
+	}
+
+	cfg := &rollup.Config{}
+	mockEngine := &testutils.MockEngine{}
+	emitter := &testutils.MockEmitter{}
+	emitter.Mock.On("Emit", mock.Anything).Maybe()
+
+	ec := NewEngineController(context.Background(), mockEngine, testlog.Logger(t, 0),
+		metrics.NoopMetrics, cfg, &sync.Config{L2FollowSourceEndpoint: "http://localhost"}, false, &testutils.MockL1Source{}, emitter, nil)
+	ec.unsafeHead = genesis
+
+	mockEngine.ExpectL2BlockRefByNumber(0, genesis, nil)
+	mockEngine.ExpectForkchoiceUpdate(
+		&eth.ForkchoiceState{
+			HeadBlockHash:      genesis.Hash,
+			SafeBlockHash:      genesis.Hash,
+			FinalizedBlockHash: genesis.Hash,
+		}, nil,
+		&eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionValid}}, nil,
+	)
+
+	ec.FollowSource(genesis, genesis, genesis)
+
+	require.Equal(t, genesis, ec.localSafeHead)
+	require.Equal(t, genesis, ec.deprecatedSafeHead)
+	require.Equal(t, genesis, ec.deprecatedFinalizedHead)
+	mockEngine.AssertExpectations(t)
+}
+
 // TestEngineController_FinalizedHead tests FinalizedHead behavior with various configurations
 func TestEngineController_FinalizedHead(t *testing.T) {
 	tests := []struct {

--- a/op-node/rollup/status/status.go
+++ b/op-node/rollup/status/status.go
@@ -56,7 +56,7 @@ func (st *StatusTracker) OnEvent(ctx context.Context, ev event.Event) bool {
 		st.log.Debug("Forkchoice update", "unsafe", x.UnsafeL2Head, "safe", x.SafeL2Head, "finalized", x.FinalizedL2Head)
 		st.data.UnsafeL2 = x.UnsafeL2Head
 		st.data.SafeL2 = x.SafeL2Head
-		if st.data.LocalSafeL2.Number < x.SafeL2Head.Number {
+		if eth.L2BlockRefAdvances(st.data.LocalSafeL2, x.SafeL2Head) {
 			st.data.LocalSafeL2 = x.SafeL2Head
 		}
 		st.data.FinalizedL2 = x.FinalizedL2Head

--- a/op-node/rollup/status/status_test.go
+++ b/op-node/rollup/status/status_test.go
@@ -2,12 +2,14 @@ package status
 
 import (
 	"context"
+	"math/rand"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/engine"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 )
@@ -50,4 +52,28 @@ func TestStatus(t *testing.T) {
 	require.Zero(t, status.SafeL2.Number)
 	require.Zero(t, status.UnsafeL2.Number)
 	require.Zero(t, status.CurrentL1.Number)
+}
+
+func TestForkchoiceUpdateSeedsLocalSafeWithGenesisSafe(t *testing.T) {
+	rng := rand.New(rand.NewSource(20295))
+	l1Origin := testutils.RandomBlockRef(rng)
+	genesis := eth.L2BlockRef{
+		Hash:           testutils.RandomHash(rng),
+		Number:         0,
+		Time:           l1Origin.Time,
+		L1Origin:       l1Origin.ID(),
+		SequenceNumber: 0,
+	}
+
+	tracker := NewStatusTracker(testlog.Logger(t, log.LevelDebug), NoopMetrics{})
+	tracker.OnEvent(context.Background(), engine.ForkchoiceUpdateEvent{
+		UnsafeL2Head:    genesis,
+		SafeL2Head:      genesis,
+		FinalizedL2Head: genesis,
+	})
+
+	status := tracker.SyncStatus()
+	require.Equal(t, genesis, status.SafeL2)
+	require.Equal(t, genesis, status.LocalSafeL2)
+	require.Equal(t, genesis, status.FinalizedL2)
 }

--- a/op-service/eth/id.go
+++ b/op-service/eth/id.go
@@ -59,6 +59,16 @@ func (id L2BlockRef) BlockRef() BlockRef {
 	}
 }
 
+func L2BlockRefAdvances(current, candidate L2BlockRef) bool {
+	if candidate == (L2BlockRef{}) {
+		return false
+	}
+	if current == (L2BlockRef{}) {
+		return true
+	}
+	return candidate.Number > current.Number
+}
+
 type L1BlockRef struct {
 	Hash       common.Hash `json:"hash"`
 	Number     uint64      `json:"number"`

--- a/op-service/eth/id_test.go
+++ b/op-service/eth/id_test.go
@@ -1,0 +1,64 @@
+package eth
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestL2BlockRefAdvances(t *testing.T) {
+	current := L2BlockRef{Hash: common.Hash{0x01}, Number: 1}
+	genesis := L2BlockRef{Hash: common.Hash{0x02}, Number: 0}
+	next := L2BlockRef{Hash: common.Hash{0x03}, Number: 2}
+
+	tests := []struct {
+		name      string
+		candidate L2BlockRef
+		current   L2BlockRef
+		expected  bool
+	}{
+		{
+			name:      "zero candidate does not advance zero current",
+			candidate: L2BlockRef{},
+			current:   L2BlockRef{},
+			expected:  false,
+		},
+		{
+			name:      "zero candidate does not advance initialized current",
+			candidate: L2BlockRef{},
+			current:   current,
+			expected:  false,
+		},
+		{
+			name:      "real genesis advances zero current",
+			candidate: genesis,
+			current:   L2BlockRef{},
+			expected:  true,
+		},
+		{
+			name:      "higher number advances initialized current",
+			candidate: next,
+			current:   current,
+			expected:  true,
+		},
+		{
+			name:      "same number does not advance initialized current",
+			candidate: L2BlockRef{Hash: common.Hash{0x04}, Number: current.Number},
+			current:   current,
+			expected:  false,
+		},
+		{
+			name:      "lower number does not advance initialized current",
+			candidate: genesis,
+			current:   current,
+			expected:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, L2BlockRefAdvances(tt.current, tt.candidate))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fix LightCL follow-source initialization when upstream reports the real L2 genesis block as safe, local-safe, and finalized while the local engine/status state is still the zero-value L2 block ref.

The previous advancement checks compared only block numbers. Since real genesis and the zero-value ref both have number 0, follow-source did not promote the real genesis safe/local-safe ref. That left optimism_syncStatus reporting zero-value safe_l2, local_safe_l2, and finalized_l2 on fresh-genesis LightCL nodes.

This change adds a shared eth.L2BlockRefAdvances(candidate, current) helper that treats zero-value -> non-zero L2 block ref as an advancement while preserving the existing monotonic number-based behavior for initialized refs.

Fixes #20295.

## Tests

- go test ./op-service/eth
- go test ./op-node/rollup/engine
- go test ./op-node/rollup/status
- git diff --check