### PR TITLE
perf(op-interop-filter): prefetch blocks during ingestion

### DIFF
--- a/op-interop-filter/filter/block_prefetcher.go
+++ b/op-interop-filter/filter/block_prefetcher.go
@@ -1,0 +1,106 @@
+package filter
+
+import (
+	"context"
+
+	gethTypes "github.com/ethereum/go-ethereum/core/types"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+type blockFetch struct {
+	blockNum  uint64
+	blockInfo eth.BlockInfo
+	receipts  gethTypes.Receipts
+	err       error
+}
+
+// BlockPrefetcher fetches block data concurrently and returns results in block-number order.
+type BlockPrefetcher interface {
+	FetchRange(ctx context.Context, startBlock, endBlock uint64) <-chan blockFetch
+}
+
+type blockPrefetcher struct {
+	ethClient   EthClient
+	concurrency int
+}
+
+// NewBlockPrefetcher creates a bounded concurrent prefetcher backed by the given eth client.
+func NewBlockPrefetcher(ethClient EthClient, concurrency int) BlockPrefetcher {
+	return &blockPrefetcher{
+		ethClient:   ethClient,
+		concurrency: concurrency,
+	}
+}
+
+func (p *blockPrefetcher) FetchRange(ctx context.Context, startBlock, endBlock uint64) <-chan blockFetch {
+	if startBlock > endBlock || p.concurrency <= 0 {
+		results := make(chan blockFetch)
+		close(results)
+		return results
+	}
+
+	results := make(chan blockFetch, p.concurrency)
+
+	go func() {
+		defer close(results)
+
+		totalBlocks := endBlock - startBlock + 1
+		window := uint64(p.concurrency)
+		if window > totalBlocks {
+			window = totalBlocks
+		}
+
+		slots := make(map[uint64]chan blockFetch, window)
+		startFetch := func(blockNum uint64) {
+			slot := make(chan blockFetch, 1)
+			slots[blockNum] = slot
+			go func() {
+				fetched := p.fetchBlock(ctx, blockNum)
+				select {
+				case slot <- fetched:
+				case <-ctx.Done():
+				}
+			}()
+		}
+
+		nextFetch := startBlock
+		for i := uint64(0); i < window; i++ {
+			startFetch(nextFetch)
+			nextFetch++
+		}
+
+		for blockNum := startBlock; blockNum <= endBlock; blockNum++ {
+			var fetched blockFetch
+			select {
+			case fetched = <-slots[blockNum]:
+			case <-ctx.Done():
+				return
+			}
+			delete(slots, blockNum)
+
+			if nextFetch <= endBlock {
+				startFetch(nextFetch)
+				nextFetch++
+			}
+
+			select {
+			case results <- fetched:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	return results
+}
+
+func (p *blockPrefetcher) fetchBlock(ctx context.Context, blockNum uint64) blockFetch {
+	blockInfo, receipts, err := p.ethClient.FetchReceiptsByNumber(ctx, blockNum)
+	return blockFetch{
+		blockNum:  blockNum,
+		blockInfo: blockInfo,
+		receipts:  receipts,
+		err:       err,
+	}
+}

--- a/op-interop-filter/filter/config.go
+++ b/op-interop-filter/filter/config.go
@@ -36,6 +36,8 @@ type Config struct {
 	PollInterval                time.Duration // Interval for polling new blocks (default: 2s)
 	ValidationInterval          time.Duration // Interval for cross-chain validation (default: 500ms)
 	Passthrough                 bool          // If true, all transactions pass through without filtering
+	RPCConcurrency              int           // Max concurrent RPC requests per chain (default: 100)
+	FetchConcurrency            int           // Number of blocks to prefetch concurrently (default: 64)
 
 	LogConfig     oplog.CLIConfig
 	MetricsConfig opmetrics.CLIConfig
@@ -67,6 +69,15 @@ func (c *Config) Check() error {
 	if c.ValidationInterval <= 0 {
 		result = errors.Join(result, errors.New("validation-interval must be positive"))
 	}
+	if c.RPCConcurrency <= 0 {
+		result = errors.Join(result, errors.New("rpc-concurrency must be positive"))
+	}
+	if c.FetchConcurrency <= 0 {
+		result = errors.Join(result, errors.New("fetch-concurrency must be positive"))
+	}
+	if c.FetchConcurrency > c.RPCConcurrency {
+		result = errors.Join(result, errors.New("fetch-concurrency must be less than or equal to rpc-concurrency"))
+	}
 	result = errors.Join(result, c.MetricsConfig.Check())
 	result = errors.Join(result, c.PprofConfig.Check())
 	return result
@@ -96,6 +107,19 @@ func NewConfig(ctx *cli.Context, version string) (*Config, error) {
 		return nil, fmt.Errorf("validation-interval must be positive, got %s", validationInterval)
 	}
 
+	rpcConcurrency := ctx.Int(flags.RPCConcurrencyFlag.Name)
+	if rpcConcurrency <= 0 {
+		return nil, fmt.Errorf("rpc-concurrency must be positive, got %d", rpcConcurrency)
+	}
+
+	fetchConcurrency := ctx.Int(flags.FetchConcurrencyFlag.Name)
+	if fetchConcurrency <= 0 {
+		return nil, fmt.Errorf("fetch-concurrency must be positive, got %d", fetchConcurrency)
+	}
+	if fetchConcurrency > rpcConcurrency {
+		return nil, fmt.Errorf("fetch-concurrency (%d) must be less than or equal to rpc-concurrency (%d)", fetchConcurrency, rpcConcurrency)
+	}
+
 	// Load rollup configs from --networks and --rollup-configs
 	rollupConfigs, err := loadRollupConfigs(
 		ctx.StringSlice(flags.NetworksFlag.Name),
@@ -121,6 +145,8 @@ func NewConfig(ctx *cli.Context, version string) (*Config, error) {
 		PollInterval:                pollInterval,
 		ValidationInterval:          validationInterval,
 		Passthrough:                 ctx.Bool(flags.DangerouslyEnablePassthroughFlag.Name),
+		RPCConcurrency:              rpcConcurrency,
+		FetchConcurrency:            fetchConcurrency,
 		LogConfig:                   oplog.ReadCLIConfig(ctx),
 		MetricsConfig:               opmetrics.ReadCLIConfig(ctx),
 		PprofConfig:                 oppprof.ReadCLIConfig(ctx),

--- a/op-interop-filter/filter/config_test.go
+++ b/op-interop-filter/filter/config_test.go
@@ -1,0 +1,50 @@
+package filter
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+func TestConfigCheckConcurrency(t *testing.T) {
+	validConfig := func() *Config {
+		chainID := eth.ChainIDFromUInt64(901)
+		return &Config{
+			L2RPCs:              []string{"http://127.0.0.1:8545"},
+			RollupConfigs:       map[eth.ChainID]*rollup.Config{chainID: testRollupConfig(901, 0, 1000)},
+			BackfillDuration:    time.Hour,
+			MessageExpiryWindow: uint64(time.Hour.Seconds()),
+			PollInterval:        time.Second,
+			ValidationInterval:  time.Second,
+			RPCConcurrency:      100,
+			FetchConcurrency:    64,
+		}
+	}
+
+	t.Run("valid", func(t *testing.T) {
+		require.NoError(t, validConfig().Check())
+	})
+
+	t.Run("rpc concurrency must be positive", func(t *testing.T) {
+		cfg := validConfig()
+		cfg.RPCConcurrency = 0
+		require.ErrorContains(t, cfg.Check(), "rpc-concurrency must be positive")
+	})
+
+	t.Run("fetch concurrency must be positive", func(t *testing.T) {
+		cfg := validConfig()
+		cfg.FetchConcurrency = 0
+		require.ErrorContains(t, cfg.Check(), "fetch-concurrency must be positive")
+	})
+
+	t.Run("fetch concurrency cannot exceed rpc concurrency", func(t *testing.T) {
+		cfg := validConfig()
+		cfg.RPCConcurrency = 4
+		cfg.FetchConcurrency = 5
+		require.ErrorContains(t, cfg.Check(), "fetch-concurrency must be less than or equal to rpc-concurrency")
+	})
+}

--- a/op-interop-filter/filter/logsdb_chain_ingester.go
+++ b/op-interop-filter/filter/logsdb_chain_ingester.go
@@ -34,6 +34,7 @@ type EthClient interface {
 	InfoByLabel(ctx context.Context, label eth.BlockLabel) (eth.BlockInfo, error)
 	InfoByNumber(ctx context.Context, number uint64) (eth.BlockInfo, error)
 	FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, gethTypes.Receipts, error)
+	FetchReceiptsByNumber(ctx context.Context, number uint64) (eth.BlockInfo, gethTypes.Receipts, error)
 	Close()
 }
 
@@ -52,6 +53,7 @@ type LogsDBChainIngester struct {
 	backfillDuration time.Duration // How far back to start ingestion from startTimestamp
 	pollInterval     time.Duration
 	rollupCfg        *rollup.Config // Rollup config for block number calculation
+	blockPrefetcher  BlockPrefetcher
 
 	stopped atomic.Bool
 
@@ -80,6 +82,8 @@ func NewLogsDBChainIngester(
 	backfillDuration time.Duration,
 	pollInterval time.Duration,
 	rollupCfg *rollup.Config,
+	rpcConcurrency int,
+	fetchConcurrency int,
 ) (*LogsDBChainIngester, error) {
 	ctx, cancel := context.WithCancel(parentCtx)
 
@@ -101,7 +105,7 @@ func NewLogsDBChainIngester(
 			HeadersCacheSize:      1000,
 			PayloadsCacheSize:     100,
 			MaxRequestsPerBatch:   20,
-			MaxConcurrentRequests: 10,
+			MaxConcurrentRequests: rpcConcurrency,
 			TrustRPC:              false,
 			MustBePostMerge:       true,
 			RPCProviderKind:       sources.RPCKindStandard,
@@ -124,6 +128,7 @@ func NewLogsDBChainIngester(
 		backfillDuration: backfillDuration,
 		pollInterval:     pollInterval,
 		rollupCfg:        rollupCfg,
+		blockPrefetcher:  NewBlockPrefetcher(ethClient, fetchConcurrency),
 		ctx:              ctx,
 		cancel:           cancel,
 	}, nil
@@ -436,40 +441,15 @@ func (c *LogsDBChainIngester) runIngestion() {
 			}
 		}
 
-		// Inner loop: ingest all available blocks without waiting between them
-		for nextBlock <= head.NumberU64() {
-			// Check for shutdown between blocks
-			select {
-			case <-c.ctx.Done():
-				return
-			default:
-			}
-
-			if err := c.ingestBlock(nextBlock); err != nil {
+		if nextBlock <= head.NumberU64() {
+			var err error
+			nextBlock, lastLogTime, err = c.ingestBlockRange(nextBlock, head.NumberU64(), lastLogTime)
+			if err != nil {
 				// Application context was canceled (e.g., during shutdown).
 				if errors.Is(err, context.Canceled) {
 					return
 				}
-				c.log.Error("Failed to ingest block", "block", nextBlock, "err", err)
-				break // Exit inner loop on error, wait for next tick to retry
-			}
-			nextBlock++
-
-			// Progress logging
-			if clock.SystemClock.Since(lastLogTime) > progressLogInterval {
-				startingBlock := c.calculateStartingBlock()
-				if nextBlock <= startingBlock {
-					progress := float64(nextBlock-c.earliestIngestedBlock.Load()) / float64(startingBlock-c.earliestIngestedBlock.Load()+1)
-					c.log.Info("Ingestion progress",
-						"block", nextBlock-1,
-						"target", startingBlock,
-						"progress", fmt.Sprintf("%.0f%%", progress*100))
-					chainIDUint64, _ := c.chainID.Uint64()
-					c.metrics.RecordBackfillProgress(chainIDUint64, progress)
-				} else {
-					c.log.Debug("Ingestion progress", "block", nextBlock-1, "head", head.NumberU64())
-				}
-				lastLogTime = clock.SystemClock.Now()
+				c.log.Error("Failed to ingest blocks", "block", nextBlock, "err", err)
 			}
 		}
 		// Caught up to head, will wait for next ticker tick
@@ -587,21 +567,65 @@ func (c *LogsDBChainIngester) sealParentBlock(blockNum uint64) error {
 }
 
 func (c *LogsDBChainIngester) ingestBlock(blockNum uint64) error {
+	_, _, err := c.ingestBlockRange(blockNum, blockNum, clock.SystemClock.Now())
+	return err
+}
+
+func (c *LogsDBChainIngester) ingestBlockRange(startBlock, endBlock uint64, lastLogTime time.Time) (uint64, time.Time, error) {
+	if startBlock > endBlock {
+		return startBlock, lastLogTime, nil
+	}
+	if c.Error() != nil {
+		return startBlock, lastLogTime, nil
+	}
+
+	rangeCtx, cancel := context.WithCancel(c.ctx)
+	defer cancel()
+
+	results := c.blockPrefetcher.FetchRange(rangeCtx, startBlock, endBlock)
+
+	for blockNum := startBlock; blockNum <= endBlock; blockNum++ {
+		var fetched blockFetch
+		select {
+		case <-rangeCtx.Done():
+			return blockNum, lastLogTime, rangeCtx.Err()
+		case result, ok := <-results:
+			if !ok {
+				return blockNum, lastLogTime, fmt.Errorf("prefetch stopped before block %d", blockNum)
+			}
+			fetched = result
+		}
+		if fetched.blockNum != blockNum {
+			return blockNum, lastLogTime, fmt.Errorf("expected prefetched block %d but got %d", blockNum, fetched.blockNum)
+		}
+		if fetched.err != nil {
+			return blockNum, lastLogTime, fmt.Errorf("failed to fetch block %d: %w", blockNum, fetched.err)
+		}
+
+		if err := c.writeFetchedBlock(fetched); err != nil {
+			return blockNum, lastLogTime, err
+		}
+		if c.Error() != nil {
+			return blockNum + 1, lastLogTime, nil
+		}
+
+		if clock.SystemClock.Since(lastLogTime) > progressLogInterval {
+			c.recordIngestionProgress(blockNum, endBlock)
+			lastLogTime = clock.SystemClock.Now()
+		}
+	}
+
+	return endBlock + 1, lastLogTime, nil
+}
+
+func (c *LogsDBChainIngester) writeFetchedBlock(fetched blockFetch) error {
 	if c.Error() != nil {
 		return nil
 	}
 
-	blockInfo, err := c.ethClient.InfoByNumber(c.ctx, blockNum)
-	if err != nil {
-		return fmt.Errorf("failed to get block info: %w", err)
-	}
-
+	blockInfo := fetched.blockInfo
+	blockNum := fetched.blockNum
 	blockID := eth.BlockID{Hash: blockInfo.Hash(), Number: blockInfo.NumberU64()}
-
-	_, receipts, err := c.ethClient.FetchReceipts(c.ctx, blockInfo.Hash())
-	if err != nil {
-		return fmt.Errorf("failed to get receipts: %w", err)
-	}
 
 	c.mu.RLock()
 	latestBlock, hasLatest := c.logsDB.LatestSealedBlock()
@@ -624,7 +648,7 @@ func (c *LogsDBChainIngester) ingestBlock(blockNum uint64) error {
 		}
 	}
 
-	logCount, err := c.processBlockLogs(blockInfo, blockID, receipts, blockNum)
+	logCount, err := c.processBlockLogs(blockInfo, blockID, fetched.receipts, blockNum)
 	if err != nil {
 		if errors.Is(err, types.ErrConflict) {
 			c.SetError(ErrorConflict, fmt.Sprintf("database conflict at block %d", blockNum))
@@ -654,6 +678,28 @@ func (c *LogsDBChainIngester) ingestBlock(blockNum uint64) error {
 	}
 
 	return nil
+}
+
+func (c *LogsDBChainIngester) recordIngestionProgress(blockNum, head uint64) {
+	startingBlock := c.calculateStartingBlock()
+	if blockNum <= startingBlock {
+		if !c.earliestIngestedBlockSet.Load() {
+			return
+		}
+		earliest := c.earliestIngestedBlock.Load()
+		if startingBlock < earliest {
+			return
+		}
+		progress := float64(blockNum-earliest) / float64(startingBlock-earliest+1)
+		c.log.Info("Ingestion progress",
+			"block", blockNum,
+			"target", startingBlock,
+			"progress", fmt.Sprintf("%.0f%%", progress*100))
+		chainIDUint64, _ := c.chainID.Uint64()
+		c.metrics.RecordBackfillProgress(chainIDUint64, progress)
+	} else {
+		c.log.Debug("Ingestion progress", "block", blockNum, "head", head)
+	}
 }
 
 func (c *LogsDBChainIngester) processBlockLogs(blockInfo eth.BlockInfo, blockID eth.BlockID,

--- a/op-interop-filter/filter/logsdb_chain_ingester_test.go
+++ b/op-interop-filter/filter/logsdb_chain_ingester_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -14,6 +15,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-interop-filter/metrics"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/clock"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
@@ -51,6 +53,7 @@ func newTestLogsDBChainIngester(t *testing.T, cfg testIngesterConfig) *LogsDBCha
 		backfillDuration: 0,     // No backfill by default in tests
 		pollInterval:     100 * time.Millisecond,
 		rollupCfg:        cfg.rollupCfg,
+		blockPrefetcher:  NewBlockPrefetcher(cfg.ethClient, 4),
 		ctx:              ctx,
 		cancel:           cancel,
 	}
@@ -113,6 +116,38 @@ func createTestReceipts(blockNum uint64, logCount int) gethTypes.Receipts {
 	})
 
 	return receipts
+}
+
+type delayedFetchEthClient struct {
+	*MockEthClient
+
+	mu        sync.Mutex
+	delays    map[uint64]time.Duration
+	completed []uint64
+}
+
+func (m *delayedFetchEthClient) FetchReceiptsByNumber(ctx context.Context, number uint64) (eth.BlockInfo, gethTypes.Receipts, error) {
+	if delay := m.delays[number]; delay > 0 {
+		select {
+		case <-time.After(delay):
+		case <-ctx.Done():
+			return nil, nil, ctx.Err()
+		}
+	}
+
+	blockInfo, receipts, err := m.MockEthClient.FetchReceiptsByNumber(ctx, number)
+
+	m.mu.Lock()
+	m.completed = append(m.completed, number)
+	m.mu.Unlock()
+
+	return blockInfo, receipts, err
+}
+
+func (m *delayedFetchEthClient) Completed() []uint64 {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]uint64(nil), m.completed...)
 }
 
 // =============================================================================
@@ -282,6 +317,133 @@ func TestLogsDBChainIngester_IngestMultipleBlocks(t *testing.T) {
 	ts, ok := ingester.LatestTimestamp()
 	require.True(t, ok)
 	require.Equal(t, uint64(1206), ts) // 1000 + 103*2
+}
+
+func TestLogsDBChainIngester_IngestBlockRange_WritesInOrder(t *testing.T) {
+	chainID := eth.ChainIDFromUInt64(901)
+	tempDir := t.TempDir()
+
+	mockClient := &delayedFetchEthClient{
+		MockEthClient: NewMockEthClient(),
+		delays: map[uint64]time.Duration{
+			100: 50 * time.Millisecond,
+		},
+	}
+	parentHash := common.Hash{}
+	for i := uint64(99); i <= 101; i++ {
+		block := createTestBlock(i, 1000+i*2, parentHash)
+		parentHash = block.Hash()
+
+		var receipts gethTypes.Receipts
+		if i >= 100 {
+			receipts = createTestReceipts(i, 1)
+		}
+		mockClient.AddBlock(block, receipts)
+	}
+
+	ingester := newTestLogsDBChainIngester(t, testIngesterConfig{
+		chainID:   chainID,
+		dataDir:   tempDir,
+		ethClient: mockClient,
+		rollupCfg: testRollupConfig(901, 0, 1000),
+	})
+	ingester.blockPrefetcher = NewBlockPrefetcher(mockClient, 2)
+
+	err := ingester.initLogsDB()
+	require.NoError(t, err)
+	t.Cleanup(func() { ingester.logsDB.Close() })
+
+	err = ingester.sealParentBlock(99)
+	require.NoError(t, err)
+
+	nextBlock, _, err := ingester.ingestBlockRange(100, 101, clock.SystemClock.Now())
+	require.NoError(t, err)
+	require.Equal(t, uint64(102), nextBlock)
+	require.Equal(t, []uint64{101, 100}, mockClient.Completed())
+
+	latestBlock, ok := ingester.LatestBlock()
+	require.True(t, ok)
+	require.Equal(t, uint64(101), latestBlock.Number)
+}
+
+func TestLogsDBChainIngester_IngestBlockRange_FetchFailureReturnsFailingBlock(t *testing.T) {
+	chainID := eth.ChainIDFromUInt64(901)
+	tempDir := t.TempDir()
+
+	parentBlock := createTestBlock(99, 1198, common.Hash{})
+	block100 := createTestBlock(100, 1200, parentBlock.Hash())
+	block101 := createTestBlock(101, 1202, block100.Hash())
+
+	mockClient := NewMockEthClient()
+	mockClient.AddBlock(parentBlock, nil)
+	mockClient.AddBlock(block100, createTestReceipts(100, 1))
+	mockClient.AddBlock(block101, createTestReceipts(101, 1))
+
+	ingester := newTestLogsDBChainIngester(t, testIngesterConfig{
+		chainID:   chainID,
+		dataDir:   tempDir,
+		ethClient: mockClient,
+		rollupCfg: testRollupConfig(901, 0, 1000),
+	})
+	ingester.blockPrefetcher = NewBlockPrefetcher(mockClient, 2)
+
+	err := ingester.initLogsDB()
+	require.NoError(t, err)
+	t.Cleanup(func() { ingester.logsDB.Close() })
+
+	err = ingester.sealParentBlock(99)
+	require.NoError(t, err)
+
+	nextBlock, _, err := ingester.ingestBlockRange(100, 102, clock.SystemClock.Now())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "block 102 not found")
+	require.Equal(t, uint64(102), nextBlock)
+
+	latestBlock, ok := ingester.LatestBlock()
+	require.True(t, ok)
+	require.Equal(t, uint64(101), latestBlock.Number)
+}
+
+func TestLogsDBChainIngester_IngestBlockRange_FetchConcurrencyOne(t *testing.T) {
+	chainID := eth.ChainIDFromUInt64(901)
+	tempDir := t.TempDir()
+
+	mockClient := NewMockEthClient()
+
+	parentHash := common.Hash{}
+	for i := uint64(99); i <= 101; i++ {
+		block := createTestBlock(i, 1000+i*2, parentHash)
+		parentHash = block.Hash()
+
+		var receipts gethTypes.Receipts
+		if i >= 100 {
+			receipts = createTestReceipts(i, 1)
+		}
+		mockClient.AddBlock(block, receipts)
+	}
+
+	ingester := newTestLogsDBChainIngester(t, testIngesterConfig{
+		chainID:   chainID,
+		dataDir:   tempDir,
+		ethClient: mockClient,
+		rollupCfg: testRollupConfig(901, 0, 1000),
+	})
+	ingester.blockPrefetcher = NewBlockPrefetcher(mockClient, 1)
+
+	err := ingester.initLogsDB()
+	require.NoError(t, err)
+	t.Cleanup(func() { ingester.logsDB.Close() })
+
+	err = ingester.sealParentBlock(99)
+	require.NoError(t, err)
+
+	nextBlock, _, err := ingester.ingestBlockRange(100, 101, clock.SystemClock.Now())
+	require.NoError(t, err)
+	require.Equal(t, uint64(102), nextBlock)
+
+	latestBlock, ok := ingester.LatestBlock()
+	require.True(t, ok)
+	require.Equal(t, uint64(101), latestBlock.Number)
 }
 
 func TestLogsDBChainIngester_Ready(t *testing.T) {
@@ -820,7 +982,7 @@ func TestLogsDBChainIngester_IngestBlock_RPCError(t *testing.T) {
 	// Set RPC error - block 100 is not in mock, will fail
 	err = ingester.ingestBlock(100)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "failed to get block info")
+	require.Contains(t, err.Error(), "failed to fetch block 100")
 }
 
 func TestLogsDBChainIngester_IngestBlock_ReceiptsError(t *testing.T) {
@@ -854,7 +1016,7 @@ func TestLogsDBChainIngester_IngestBlock_ReceiptsError(t *testing.T) {
 
 	err = ingester.ingestBlock(100)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "failed to get receipts")
+	require.Contains(t, err.Error(), "failed to fetch block 100")
 }
 
 func TestLogsDBChainIngester_IngestBlock_ErrorStateSkipsIngestion(t *testing.T) {

--- a/op-interop-filter/filter/mock_test.go
+++ b/op-interop-filter/filter/mock_test.go
@@ -351,6 +351,31 @@ func (m *MockEthClient) FetchReceipts(ctx context.Context, blockHash common.Hash
 	return nil, receipts, nil
 }
 
+// FetchReceiptsByNumber implements EthClient.
+func (m *MockEthClient) FetchReceiptsByNumber(ctx context.Context, number uint64) (eth.BlockInfo, gethTypes.Receipts, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if m.infoByNumberErr != nil {
+		return nil, nil, m.infoByNumberErr
+	}
+	if m.fetchReceiptsErr != nil {
+		return nil, nil, m.fetchReceiptsErr
+	}
+
+	block, ok := m.blocksByNumber[number]
+	if !ok {
+		return nil, nil, fmt.Errorf("block %d not found", number)
+	}
+
+	receipts, ok := m.receiptsByHash[block.Hash()]
+	if !ok {
+		return nil, nil, fmt.Errorf("receipts not found for block %d", number)
+	}
+
+	return block, receipts, nil
+}
+
 // Close implements EthClient.
 func (m *MockEthClient) Close() {}
 

--- a/op-interop-filter/filter/service.go
+++ b/op-interop-filter/filter/service.go
@@ -200,6 +200,8 @@ func (s *Service) initBackend(ctx context.Context, cfg *Config) error {
 			cfg.BackfillDuration,
 			cfg.PollInterval,
 			rollupCfg,
+			cfg.RPCConcurrency,
+			cfg.FetchConcurrency,
 		)
 		if err != nil {
 			return fmt.Errorf("failed to create chain ingester for chain %s: %w", chainID, err)

--- a/op-interop-filter/flags/flags.go
+++ b/op-interop-filter/flags/flags.go
@@ -105,6 +105,18 @@ var (
 		Usage:   "Allow all transactions through without interop filtering. DANGEROUS: disables all executing message validation.",
 		EnvVars: prefixEnvVars("DANGEROUSLY_ENABLE_PASSTHROUGH"),
 	}
+	RPCConcurrencyFlag = &cli.IntFlag{
+		Name:    "rpc-concurrency",
+		Usage:   "Maximum number of concurrent RPC requests per chain. Higher values speed up backfill at the cost of more load on the RPC node.",
+		EnvVars: prefixEnvVars("RPC_CONCURRENCY"),
+		Value:   100,
+	}
+	FetchConcurrencyFlag = &cli.IntFlag{
+		Name:    "fetch-concurrency",
+		Usage:   "Number of blocks to prefetch concurrently during ingestion. Must be <= rpc-concurrency.",
+		EnvVars: prefixEnvVars("FETCH_CONCURRENCY"),
+		Value:   64,
+	}
 )
 
 var requiredFlags = []cli.Flag{
@@ -125,6 +137,8 @@ var optionalFlags = []cli.Flag{
 	PollIntervalFlag,
 	ValidationIntervalFlag,
 	DangerouslyEnablePassthroughFlag,
+	RPCConcurrencyFlag,
+	FetchConcurrencyFlag,
 }
 
 func init() {


### PR DESCRIPTION
## Summary

- adds configurable `--rpc-concurrency` and `--fetch-concurrency` settings for op-interop-filter ingestion
- adds a bounded block prefetcher that overlaps RPC fetches while returning blocks in number order
- keeps logs DB writes, parent-hash checks, and executing-message processing on the existing sequential write path
- validates positive concurrency values and requires `fetch-concurrency <= rpc-concurrency`

## Notes

- uses the PR #19993 CLI/API names and defaults: `rpc-concurrency=100`, `fetch-concurrency=64`
- intentionally does not include `--linear-scan` or startup scan behavior changes

## Validation

- `go test ./op-interop-filter/...`
- `go mod tidy -diff`
- `./linter/bin/op-golangci-lint run ./...`
