### PR TITLE
op-supernode: shared interop start from safe head

### DIFF
--- a/op-devstack/dsl/supernode.go
+++ b/op-devstack/dsl/supernode.go
@@ -170,8 +170,8 @@ func (s *Supernode) AwaitBackfillCompleted() {
 //     (the first seal is at most one block before activation; when activation
 //     is not aligned to a block boundary, the block representing the chain
 //     state as of activation is the correct pairing anchor and is sealed).
-//  2. firstSealed.Timestamp <  FirstVerifiableTimestamp
-//     (the main loop's handoff happens strictly after the backfilled range)
+//  2. firstSealed.Timestamp <  BackfillEndTimestamp()+1
+//     (the post-backfill handoff happens strictly after the backfilled range)
 //  3. firstSealed.Timestamp <= max(ActivationTimestamp, latestSealed.Timestamp - depth)
 //     + blockTime                         (backfill reached ~depth back,
 //     or all the way to activation if the chain is younger than depth)
@@ -184,7 +184,10 @@ func (s *Supernode) AssertBackfillCovers(depth time.Duration, blockTime uint64, 
 	ia := s.interopActivity()
 
 	activation := ia.ActivationTimestamp()
-	firstVerifiable := ia.FirstVerifiableTimestamp()
+	backfillHandoff := ia.FirstVerifiableTimestamp()
+	if backfillEnd := ia.BackfillEndTimestamp(); backfillEnd != 0 {
+		backfillHandoff = backfillEnd + 1
+	}
 	depthSec := uint64(depth / time.Second)
 
 	for _, chainID := range chains {
@@ -198,9 +201,9 @@ func (s *Supernode) AssertBackfillCovers(depth time.Duration, blockTime uint64, 
 			"chain %s: first seal ts %d must be within one block time (%d) of activation ts %d",
 			chainID, first.Timestamp, blockTime, activation)
 
-		s.require.Lessf(first.Timestamp, firstVerifiable,
-			"chain %s: first seal ts %d must be < first-verifiable ts %d (backfill must hand off strictly before main loop)",
-			chainID, first.Timestamp, firstVerifiable)
+		s.require.Lessf(first.Timestamp, backfillHandoff,
+			"chain %s: first seal ts %d must be < backfill handoff ts %d (backfill must hand off strictly after the sealed range)",
+			chainID, first.Timestamp, backfillHandoff)
 
 		expectedLowerBound := activation
 		if latest.Timestamp > activation+depthSec {
@@ -218,7 +221,7 @@ func (s *Supernode) AssertBackfillCovers(depth time.Duration, blockTime uint64, 
 			"chain", chainID,
 			"first_num", first.Number, "first_ts", first.Timestamp,
 			"latest_num", latest.Number, "latest_ts", latest.Timestamp,
-			"activation", activation, "first_verifiable", firstVerifiable,
+			"activation", activation, "backfill_handoff", backfillHandoff,
 			"depth_sec", depthSec)
 	}
 }

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -189,9 +189,15 @@ func (i *Interop) Name() string {
 }
 
 // firstVerifiableTimestamp is the earliest timestamp the main loop will attempt
-// to verify. It is backfillEndTimestamp+1 after log backfill, otherwise the
-// safe-head-derived startup timestamp.
+// to verify. If verification has already committed results, the first committed
+// timestamp is the durable handoff boundary. Otherwise it is backfillEndTimestamp+1
+// after log backfill, or the safe-head-derived startup timestamp.
 func (i *Interop) firstVerifiableTimestamp(ctx context.Context) (uint64, error) {
+	if i.verifiedDB != nil {
+		if first, initialized := i.verifiedDB.FirstTimestamp(); initialized {
+			return first, nil
+		}
+	}
 	if i.backfillEndTimestamp != 0 {
 		next := i.backfillEndTimestamp + 1
 		if next < i.activationTimestamp {
@@ -201,11 +207,6 @@ func (i *Interop) firstVerifiableTimestamp(ctx context.Context) (uint64, error) 
 	}
 	if i.firstVerifiableSet {
 		return i.firstVerifiable, nil
-	}
-	if i.verifiedDB != nil {
-		if first, initialized := i.verifiedDB.FirstTimestamp(); initialized {
-			return first, nil
-		}
 	}
 	return i.resolveFirstVerifiableTimestamp(ctx)
 }

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -137,9 +137,11 @@ type Interop struct {
 
 	// backfillEndTimestamp represents the end of the range of timestamps that were sealed by runLogBackfill.
 	// this is used for loop handoff from log backfill to main processing.
-	// firstVerifiableTimestamp is used to determine the start of the main processing loop, which is backfillEndTimestamp + 1,
-	// or activationTimestamp if backfill was not used.
+	// firstVerifiableTimestamp is used to determine the start of the main processing loop, which is backfillEndTimestamp + 1
+	// after backfill, or the safe-head-derived startup timestamp when backfill was not used.
 	backfillEndTimestamp uint64
+	firstVerifiableSet   bool
+	firstVerifiable      uint64
 
 	dataDir string
 
@@ -184,21 +186,6 @@ type Interop struct {
 
 func (i *Interop) Name() string {
 	return "interop"
-}
-
-// firstVerifiableTimestamp is the earliest timestamp the main loop will
-// attempt to verify. It is activationTimestamp when backfill did not run,
-// or backfillEndTimestamp+1 when it did (clamped so it never falls below
-// activation, though by construction backfillEndTimestamp >= activation).
-func (i *Interop) firstVerifiableTimestamp() uint64 {
-	if i.backfillEndTimestamp == 0 {
-		return i.activationTimestamp
-	}
-	next := i.backfillEndTimestamp + 1
-	if next < i.activationTimestamp {
-		return i.activationTimestamp
-	}
-	return next
 }
 
 // New constructs a new Interop activity.
@@ -287,7 +274,32 @@ func (i *Interop) Start(ctx context.Context) error {
 			case <-time.After(errorBackoffPeriod):
 			}
 		}
+	} else if _, initialized := i.verifiedDB.LastTimestamp(); !initialized {
+		for {
+			first, err := i.resolveFirstVerifiableTimestamp(i.ctx)
+			if err == nil {
+				i.firstVerifiable = first
+				i.firstVerifiableSet = true
+				break
+			}
+			i.log.Warn("first verifiable timestamp unavailable, retrying (virtual nodes may not be ready yet)", "err", err)
+			select {
+			case <-i.ctx.Done():
+				return fmt.Errorf("first verifiable timestamp interrupted: %w", i.ctx.Err())
+			case <-time.After(errorBackoffPeriod):
+			}
+		}
 	}
+	firstVerifiableLog := uint64(0)
+	if lastTS, initialized := i.verifiedDB.LastTimestamp(); initialized {
+		firstVerifiableLog = lastTS + 1
+	} else if first, err := i.firstVerifiableTimestamp(i.ctx); err == nil {
+		firstVerifiableLog = first
+	}
+	i.log.Info("interop first verifiable timestamp resolved",
+		"activationTimestamp", i.activationTimestamp,
+		"backfillEndTimestamp", i.backfillEndTimestamp,
+		"firstVerifiableTimestamp", firstVerifiableLog)
 	i.backfillCompleted.Store(true)
 	i.log.Info("log backfill complete", "backfillEndTimestamp", i.backfillEndTimestamp)
 
@@ -451,7 +463,11 @@ func (i *Interop) observeRound() (RoundObservation, error) {
 		obs.LastVerified = &result
 		obs.NextTimestamp = lastTS + 1
 	} else {
-		obs.NextTimestamp = i.firstVerifiableTimestamp()
+		next, err := i.firstVerifiableTimestamp(i.ctx)
+		if err != nil {
+			return obs, err
+		}
+		obs.NextTimestamp = next
 	}
 
 	if pauseTS := i.pauseAtTimestamp.Load(); pauseTS != 0 && obs.NextTimestamp >= pauseTS {
@@ -685,7 +701,11 @@ func (i *Interop) buildRewindPlan(lastTS uint64) (RewindPlan, error) {
 		RewindAtOrAfter: lastTS,
 	}
 
-	if lastTS <= i.firstVerifiableTimestamp() {
+	first, err := i.firstVerifiableTimestamp(i.ctx)
+	if err != nil {
+		return RewindPlan{}, err
+	}
+	if lastTS <= first {
 		return plan, nil
 	}
 

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -258,6 +258,30 @@ func (i *Interop) Start(ctx context.Context) error {
 	i.started = true
 	i.mu.Unlock()
 
+	firstVerifiableLog := uint64(0)
+	if lastTS, initialized := i.verifiedDB.LastTimestamp(); initialized {
+		firstVerifiableLog = lastTS + 1
+	} else {
+		for {
+			first, err := i.resolveFirstVerifiableTimestamp(i.ctx)
+			if err == nil {
+				i.firstVerifiable = first
+				i.firstVerifiableSet = true
+				firstVerifiableLog = first
+				break
+			}
+			i.log.Warn("first verifiable timestamp unavailable, retrying (virtual nodes may not be ready yet)", "err", err)
+			select {
+			case <-i.ctx.Done():
+				return fmt.Errorf("first verifiable timestamp interrupted: %w", i.ctx.Err())
+			case <-time.After(errorBackoffPeriod):
+			}
+		}
+	}
+	i.log.Info("interop first verifiable timestamp resolved",
+		"activationTimestamp", i.activationTimestamp,
+		"firstVerifiableTimestamp", firstVerifiableLog)
+
 	if i.logBackfillDepth > 0 {
 		i.log.Info("interop log backfill depth configured", "duration", i.logBackfillDepth.String())
 		for {
@@ -274,32 +298,7 @@ func (i *Interop) Start(ctx context.Context) error {
 			case <-time.After(errorBackoffPeriod):
 			}
 		}
-	} else if _, initialized := i.verifiedDB.LastTimestamp(); !initialized {
-		for {
-			first, err := i.resolveFirstVerifiableTimestamp(i.ctx)
-			if err == nil {
-				i.firstVerifiable = first
-				i.firstVerifiableSet = true
-				break
-			}
-			i.log.Warn("first verifiable timestamp unavailable, retrying (virtual nodes may not be ready yet)", "err", err)
-			select {
-			case <-i.ctx.Done():
-				return fmt.Errorf("first verifiable timestamp interrupted: %w", i.ctx.Err())
-			case <-time.After(errorBackoffPeriod):
-			}
-		}
 	}
-	firstVerifiableLog := uint64(0)
-	if lastTS, initialized := i.verifiedDB.LastTimestamp(); initialized {
-		firstVerifiableLog = lastTS + 1
-	} else if first, err := i.firstVerifiableTimestamp(i.ctx); err == nil {
-		firstVerifiableLog = first
-	}
-	i.log.Info("interop first verifiable timestamp resolved",
-		"activationTimestamp", i.activationTimestamp,
-		"backfillEndTimestamp", i.backfillEndTimestamp,
-		"firstVerifiableTimestamp", firstVerifiableLog)
 	i.backfillCompleted.Store(true)
 	i.log.Info("log backfill complete", "backfillEndTimestamp", i.backfillEndTimestamp)
 

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -870,13 +870,17 @@ func (i *Interop) CurrentL1() eth.BlockID {
 }
 
 // VerifiedAtTimestamp returns whether the data is verified at the given timestamp.
-// For timestamps before the activation timestamp, this returns true since interop
-// wasn't active yet and verification proceeds automatically.
-// For timestamps at or after the activation timestamp, this checks the verifiedDB.
+// Timestamps before the first verifiable timestamp are already covered by
+// pre-activation consensus or by the safe-head startup handoff.
 func (i *Interop) VerifiedAtTimestamp(ts uint64) (bool, error) {
-	// Timestamps before the activation timestamp are considered verified
-	// because interop wasn't active yet
 	if ts < i.activationTimestamp {
+		return true, nil
+	}
+	firstVerifiable, err := i.firstVerifiableTimestamp(i.ctx)
+	if err != nil {
+		return false, err
+	}
+	if ts < firstVerifiable {
 		return true, nil
 	}
 	return i.verifiedDB.Has(ts)

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -203,8 +203,8 @@ func (i *Interop) firstVerifiableTimestamp(ctx context.Context) (uint64, error) 
 		return i.firstVerifiable, nil
 	}
 	if i.verifiedDB != nil {
-		if _, initialized := i.verifiedDB.LastTimestamp(); initialized {
-			return i.activationTimestamp, nil
+		if first, initialized := i.verifiedDB.FirstTimestamp(); initialized {
+			return first, nil
 		}
 	}
 	return i.resolveFirstVerifiableTimestamp(ctx)

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -188,6 +188,28 @@ func (i *Interop) Name() string {
 	return "interop"
 }
 
+// firstVerifiableTimestamp is the earliest timestamp the main loop will attempt
+// to verify. It is backfillEndTimestamp+1 after log backfill, otherwise the
+// safe-head-derived startup timestamp.
+func (i *Interop) firstVerifiableTimestamp(ctx context.Context) (uint64, error) {
+	if i.backfillEndTimestamp != 0 {
+		next := i.backfillEndTimestamp + 1
+		if next < i.activationTimestamp {
+			return i.activationTimestamp, nil
+		}
+		return next, nil
+	}
+	if i.firstVerifiableSet {
+		return i.firstVerifiable, nil
+	}
+	if i.verifiedDB != nil {
+		if _, initialized := i.verifiedDB.LastTimestamp(); initialized {
+			return i.activationTimestamp, nil
+		}
+	}
+	return i.resolveFirstVerifiableTimestamp(ctx)
+}
+
 // New constructs a new Interop activity.
 func New(
 	log log.Logger,

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -1027,9 +1027,18 @@ func TestFirstVerifiableTimestampRestoresSafeHeadHandoffAfterRestart(t *testing.
 	require.NoError(t, err)
 	require.Equal(t, uint64(126), first)
 
+	interop.backfillEndTimestamp = 200
+	first, err = interop.firstVerifiableTimestamp(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, uint64(126), first, "persisted verifier lower bound takes precedence over restart backfill")
+
 	verified, err := interop.VerifiedAtTimestamp(125)
 	require.NoError(t, err)
 	require.True(t, verified, "timestamp before first committed result remains covered by the startup handoff")
+
+	verified, err = interop.VerifiedAtTimestamp(150)
+	require.NoError(t, err)
+	require.False(t, verified, "restart backfill must not widen the implicit handoff range")
 
 	plan, err := interop.buildRewindPlan(126)
 	require.NoError(t, err)

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -1006,6 +1006,36 @@ func TestVerifiedAtTimestamp(t *testing.T) {
 	}
 }
 
+func TestFirstVerifiableTimestampRestoresSafeHeadHandoffAfterRestart(t *testing.T) {
+	t.Parallel()
+
+	dataDir := t.TempDir()
+	db, err := OpenVerifiedDB(dataDir)
+	require.NoError(t, err)
+	require.NoError(t, db.Commit(VerifiedResult{
+		Timestamp:   126,
+		L1Inclusion: eth.BlockID{Number: 1, Hash: common.HexToHash("0x1")},
+		L2Heads:     map[eth.ChainID]eth.BlockID{eth.ChainIDFromUInt64(10): {Number: 126, Hash: common.HexToHash("0x2")}},
+	}))
+	require.NoError(t, db.Close())
+
+	interop := New(testLogger(), 100, 0, nil, dataDir, nil, 0, nil)
+	require.NotNil(t, interop)
+	defer func() { require.NoError(t, interop.Stop(context.Background())) }()
+
+	first, err := interop.firstVerifiableTimestamp(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, uint64(126), first)
+
+	verified, err := interop.VerifiedAtTimestamp(125)
+	require.NoError(t, err)
+	require.True(t, verified, "timestamp before first committed result remains covered by the startup handoff")
+
+	plan, err := interop.buildRewindPlan(126)
+	require.NoError(t, err)
+	require.Equal(t, uint64(126), plan.RewindAtOrAfter)
+}
+
 // =============================================================================
 // TestIsActiveAt
 // =============================================================================

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -3,7 +3,6 @@ package interop
 import (
 	"context"
 	"errors"
-	"log/slog"
 	"math/big"
 	"sync"
 	"sync/atomic"
@@ -11,7 +10,6 @@ import (
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/activity"
 	cc "github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/reads"
@@ -319,9 +317,6 @@ func TestStartWithoutBackfillUsesFirstVerifiableTimestamp(t *testing.T) {
 		}).
 		Build()
 
-	logger, logs := testlog.CaptureLogger(t, gethlog.LevelDebug)
-	h.interop.log = logger
-
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -343,12 +338,6 @@ func TestStartWithoutBackfillUsesFirstVerifiableTimestamp(t *testing.T) {
 	}
 
 	require.ErrorIs(t, <-done, context.Canceled)
-	require.NotNil(t, logs.FindLog(
-		testlog.NewLevelFilter(slog.LevelInfo),
-		testlog.NewMessageContainsFilter("interop first verifiable timestamp resolved"),
-		testlog.NewAttributesFilter("activationTimestamp", "100"),
-		testlog.NewAttributesFilter("firstVerifiableTimestamp", "126"),
-	))
 }
 
 // =============================================================================

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -3,6 +3,7 @@ package interop
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"math/big"
 	"sync"
 	"sync/atomic"
@@ -10,6 +11,7 @@ import (
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/activity"
 	cc "github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/reads"
@@ -94,6 +96,10 @@ func (h *interopTestHarness) Build() *interopTestHarness {
 	}
 	chains := make(map[eth.ChainID]cc.InteropChain)
 	for id, mock := range h.mocks {
+		if !mock.defaultSafeSet {
+			mock.defaultSafeTime = h.activationTime
+			mock.defaultSafeSet = true
+		}
 		chains[id] = mock
 	}
 	h.interop = New(testLogger(), h.activationTime, 0, chains, h.dataDir, nil, h.logBackfillDepth, nil)
@@ -180,6 +186,169 @@ func TestInteropActivationTimestampFlagEnvVar(t *testing.T) {
 	t.Parallel()
 
 	require.Contains(t, InteropActivationTimestampFlag.GetEnvVars(), "OP_SUPERNODE_INTEROP_ACTIVATION_TIMESTAMP")
+}
+
+/*
+Spec: firstVerifiableTimestamp is the common interop startup readiness gate.
+
+  - It returns an error while virtual-node sync status is unavailable or before
+    every chain's cross-safe head reaches activation.
+  - Once ready, it returns activation when there are no chains, or one past the
+    minimum cross-safe timestamp across chains otherwise.
+  - The no-backfill startup path uses that same timestamp for its first
+    verification attempt.
+*/
+func TestFirstVerifiableTimestamp(t *testing.T) {
+	tests := []struct {
+		name    string
+		setup   func(*interopTestHarness) *interopTestHarness
+		want    uint64
+		wantErr bool
+	}{
+		{
+			name: "no chains returns activation",
+			setup: func(h *interopTestHarness) *interopTestHarness {
+				return h.WithActivation(100).Build()
+			},
+			want: 100,
+		},
+		{
+			name: "sync status error blocks startup",
+			setup: func(h *interopTestHarness) *interopTestHarness {
+				return h.WithActivation(100).
+					WithChain(10, func(m *mockChainContainer) {
+						m.syncStatusOverride = func() (*eth.SyncStatus, error) {
+							return nil, errors.New("virtual node not ready")
+						}
+					}).
+					Build()
+			},
+			wantErr: true,
+		},
+		{
+			name: "zero local-safe blocks startup",
+			setup: func(h *interopTestHarness) *interopTestHarness {
+				return h.WithActivation(100).
+					WithChain(10, func(m *mockChainContainer) {
+						m.syncStatusFull = &eth.SyncStatus{
+							SafeL2:      eth.L2BlockRef{Number: 100, Time: 100},
+							LocalSafeL2: eth.L2BlockRef{},
+						}
+					}).
+					Build()
+			},
+			wantErr: true,
+		},
+		{
+			name: "cross-safe before activation blocks startup",
+			setup: func(h *interopTestHarness) *interopTestHarness {
+				return h.WithActivation(100).
+					WithChain(10, func(m *mockChainContainer) {
+						m.syncStatusFull = &eth.SyncStatus{
+							SafeL2:      eth.L2BlockRef{Number: 99, Time: 99},
+							LocalSafeL2: eth.L2BlockRef{Number: 99, Time: 99},
+						}
+					}).
+					Build()
+			},
+			wantErr: true,
+		},
+		{
+			name: "cross-safe at activation returns timestamp after activation",
+			setup: func(h *interopTestHarness) *interopTestHarness {
+				return h.WithActivation(100).
+					WithChain(10, func(m *mockChainContainer) {
+						m.syncStatusFull = &eth.SyncStatus{
+							SafeL2:      eth.L2BlockRef{Number: 100, Time: 100},
+							LocalSafeL2: eth.L2BlockRef{Number: 100, Time: 100},
+						}
+					}).
+					Build()
+			},
+			want: 101,
+		},
+		{
+			name: "returns timestamp after minimum cross-safe across chains",
+			setup: func(h *interopTestHarness) *interopTestHarness {
+				return h.WithActivation(100).
+					WithChain(10, func(m *mockChainContainer) {
+						m.syncStatusFull = &eth.SyncStatus{
+							SafeL2:      eth.L2BlockRef{Number: 140, Time: 140},
+							LocalSafeL2: eth.L2BlockRef{Number: 140, Time: 140},
+						}
+					}).
+					WithChain(20, func(m *mockChainContainer) {
+						m.syncStatusFull = &eth.SyncStatus{
+							SafeL2:      eth.L2BlockRef{Number: 125, Time: 125},
+							LocalSafeL2: eth.L2BlockRef{Number: 125, Time: 125},
+						}
+					}).
+					Build()
+			},
+			want: 126,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newInteropTestHarness(t)
+			tc.setup(h)
+
+			got, err := h.interop.firstVerifiableTimestamp(context.Background())
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestStartWithoutBackfillUsesFirstVerifiableTimestamp(t *testing.T) {
+	const activation = uint64(100)
+	const safe = uint64(125)
+
+	h := newInteropTestHarness(t).
+		WithActivation(activation).
+		WithChain(10, func(m *mockChainContainer) {
+			m.syncStatusFull = &eth.SyncStatus{
+				SafeL2:      eth.L2BlockRef{Number: safe, Time: safe},
+				LocalSafeL2: eth.L2BlockRef{Number: safe, Time: safe},
+			}
+		}).
+		Build()
+
+	logger, logs := testlog.CaptureLogger(t, gethlog.LevelDebug)
+	h.interop.log = logger
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	verifiedTS := make(chan uint64, 1)
+	h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
+		verifiedTS <- ts
+		cancel()
+		return Result{}, nil
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- h.interop.Start(ctx) }()
+
+	select {
+	case ts := <-verifiedTS:
+		require.Equal(t, safe+1, ts)
+	case <-time.After(5 * time.Second):
+		t.Fatal("interop did not attempt verification")
+	}
+
+	require.ErrorIs(t, <-done, context.Canceled)
+	require.NotNil(t, logs.FindLog(
+		testlog.NewLevelFilter(slog.LevelInfo),
+		testlog.NewMessageContainsFilter("interop first verifiable timestamp resolved"),
+		testlog.NewAttributesFilter("activationTimestamp", "100"),
+		testlog.NewAttributesFilter("firstVerifiableTimestamp", "126"),
+	))
 }
 
 // =============================================================================
@@ -503,7 +672,7 @@ func TestProgressInterop(t *testing.T) {
 		run      func(t *testing.T, h *interopTestHarness) // override for complex cases
 	}{
 		{
-			name: "not initialized uses activation timestamp",
+			name: "not initialized uses first timestamp after safe head",
 			setup: func(h *interopTestHarness) *interopTestHarness {
 				return h.WithActivation(5000).WithChain(10, func(m *mockChainContainer) {
 					m.blockAtTimestamp = eth.L2BlockRef{Number: 100, Hash: common.HexToHash("0x1")}
@@ -512,7 +681,7 @@ func TestProgressInterop(t *testing.T) {
 			verifyFn: passThroughVerifyFn,
 			assert: func(t *testing.T, result Result, err error) {
 				require.NoError(t, err)
-				require.Equal(t, uint64(5000), result.Timestamp)
+				require.Equal(t, uint64(5001), result.Timestamp)
 			},
 		},
 		{
@@ -528,7 +697,7 @@ func TestProgressInterop(t *testing.T) {
 				// First progress
 				result1, err := progressInteropCompat(h.interop)
 				require.NoError(t, err)
-				require.Equal(t, uint64(1000), result1.Timestamp)
+				require.Equal(t, uint64(1001), result1.Timestamp)
 
 				// Commit
 				err = applyResultCompat(h.interop, result1)
@@ -537,7 +706,7 @@ func TestProgressInterop(t *testing.T) {
 				// Second progress should use next timestamp
 				result2, err := progressInteropCompat(h.interop)
 				require.NoError(t, err)
-				require.Equal(t, uint64(1001), result2.Timestamp)
+				require.Equal(t, uint64(1002), result2.Timestamp)
 			},
 		},
 		{
@@ -810,7 +979,7 @@ func TestVerifiedAtTimestamp(t *testing.T) {
 				err = applyResultCompat(h.interop, result)
 				require.NoError(t, err)
 
-				verified, err := h.interop.VerifiedAtTimestamp(1000)
+				verified, err := h.interop.VerifiedAtTimestamp(1001)
 				require.NoError(t, err)
 				require.True(t, verified)
 			},
@@ -893,7 +1062,7 @@ func TestApplyResultCompat(t *testing.T) {
 			run: func(t *testing.T, h *interopTestHarness) {
 				mock := h.Mock(10)
 				validResult := Result{
-					Timestamp:   1000,
+					Timestamp:   1001,
 					L1Inclusion: eth.BlockID{Number: 100, Hash: common.HexToHash("0xL1")},
 					L2Heads: map[eth.ChainID]eth.BlockID{
 						mock.id: {Number: 500, Hash: common.HexToHash("0xL2")},
@@ -903,11 +1072,11 @@ func TestApplyResultCompat(t *testing.T) {
 				err := applyResultCompat(h.interop, validResult)
 				require.NoError(t, err)
 
-				has, err := h.interop.verifiedDB.Has(1000)
+				has, err := h.interop.verifiedDB.Has(1001)
 				require.NoError(t, err)
 				require.True(t, has)
 
-				retrieved, err := h.interop.verifiedDB.Get(1000)
+				retrieved, err := h.interop.verifiedDB.Get(1001)
 				require.NoError(t, err)
 				require.Equal(t, validResult.Timestamp, retrieved.Timestamp)
 				require.Equal(t, validResult.L1Inclusion, retrieved.L1Inclusion)
@@ -1209,6 +1378,11 @@ func TestInterop_FullCycle(t *testing.T) {
 	mock := newMockChainContainer(10)
 	mock.currentL1 = eth.BlockRef{Number: 1000, Hash: common.HexToHash("0xL1")}
 	mock.blockAtTimestamp = eth.L2BlockRef{Number: 500, Hash: common.HexToHash("0xL2")}
+	mock.syncStatusFull = &eth.SyncStatus{
+		CurrentL1:   eth.L1BlockRef{Number: 1000, Hash: common.HexToHash("0xL1")},
+		SafeL2:      eth.L2BlockRef{Number: 100, Time: 100},
+		LocalSafeL2: eth.L2BlockRef{Number: 100, Time: 100},
+	}
 
 	chains := map[eth.ChainID]cc.InteropChain{mock.id: mock}
 	interop := New(testLogger(), 100, 0, chains, dataDir, nil, 0, nil)
@@ -1240,7 +1414,7 @@ func TestInterop_FullCycle(t *testing.T) {
 	}
 
 	// Verify timestamps committed with correct L2Heads
-	for ts := uint64(100); ts <= 102; ts++ {
+	for ts := uint64(101); ts <= 103; ts++ {
 		has, err := interop.verifiedDB.Has(ts)
 		require.NoError(t, err)
 		require.True(t, has)
@@ -1255,7 +1429,7 @@ func TestInterop_FullCycle(t *testing.T) {
 	// Verify logsDB populated
 	latestBlock, hasBlocks := interop.logsDBs[mock.id].LatestSealedBlock()
 	require.True(t, hasBlocks)
-	require.Equal(t, uint64(102), latestBlock.Number)
+	require.Equal(t, uint64(103), latestBlock.Number)
 }
 
 // =============================================================================
@@ -1295,9 +1469,9 @@ func TestInterop_ProgressAndRecord_MultiAdvance(t *testing.T) {
 
 	lastTS, ok := h.interop.verifiedDB.LastTimestamp()
 	require.True(t, ok)
-	require.Equal(t, uint64(100+cycles-1), lastTS)
+	require.Equal(t, uint64(101+cycles-1), lastTS)
 
-	for ts := uint64(100); ts <= lastTS; ts++ {
+	for ts := uint64(101); ts <= lastTS; ts++ {
 		result, err := h.interop.verifiedDB.Get(ts)
 		require.NoError(t, err)
 		require.Equal(t, ts, result.Timestamp)
@@ -1340,7 +1514,7 @@ func TestInterop_ProgressAndRecord_L1InconsistencyTriggersRewind(t *testing.T) {
 	}
 	lastTS, ok := h.interop.verifiedDB.LastTimestamp()
 	require.True(t, ok)
-	require.Equal(t, uint64(101), lastTS)
+	require.Equal(t, uint64(102), lastTS)
 
 	// Flip the L1 checker so observeRound returns L1Consistent=false, which
 	// drives checkPreconditions into DecisionRewind.
@@ -1350,17 +1524,17 @@ func TestInterop_ProgressAndRecord_L1InconsistencyTriggersRewind(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, made, "rewind does not advance the verified timestamp")
 
-	// Rewind removed the last-committed entry and left activation in place.
+	// Rewind removed the last-committed entry and left the first verified timestamp in place.
 	lastTS, ok = h.interop.verifiedDB.LastTimestamp()
 	require.True(t, ok)
-	require.Equal(t, uint64(100), lastTS)
+	require.Equal(t, uint64(101), lastTS)
 
 	pending, err := h.interop.verifiedDB.GetPendingTransition()
 	require.NoError(t, err)
 	require.Nil(t, pending, "WAL cleared after successful rewind")
 
 	require.Len(t, mock.rewindEngineCalls, 1, "engine rewound exactly once on the recovering chain")
-	require.Equal(t, uint64(100), mock.rewindEngineCalls[0])
+	require.Equal(t, uint64(101), mock.rewindEngineCalls[0])
 }
 
 // =============================================================================
@@ -1482,6 +1656,8 @@ type mockChainContainer struct {
 	// If set, SyncStatus returns this instead of synthesizing from currentL1 only.
 	syncStatusFull     *eth.SyncStatus
 	syncStatusOverride func() (*eth.SyncStatus, error)
+	defaultSafeTime    uint64
+	defaultSafeSet     bool
 
 	// PauseAndStopVN / Resume tracking
 	pauseAndStopVNCalls int
@@ -1657,7 +1833,12 @@ func (m *mockChainContainer) SyncStatus(ctx context.Context) (*eth.SyncStatus, e
 	if m.syncStatusFull != nil {
 		return m.syncStatusFull, nil
 	}
-	return &eth.SyncStatus{CurrentL1: m.currentL1}, nil
+	safeNum := m.defaultSafeTime
+	if safeNum == 0 {
+		safeNum = 1
+	}
+	safe := eth.L2BlockRef{Number: safeNum, Time: m.defaultSafeTime}
+	return &eth.SyncStatus{CurrentL1: m.currentL1, SafeL2: safe, LocalSafeL2: safe}, nil
 }
 func (m *mockChainContainer) TimestampToBlockNumber(ctx context.Context, ts uint64) (uint64, error) {
 	if m.timestampToBlockNumberOverride != nil {

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -191,8 +191,8 @@ func TestInteropActivationTimestampFlagEnvVar(t *testing.T) {
 /*
 Spec: firstVerifiableTimestamp is the common interop startup readiness gate.
 
-  - It returns an error while virtual-node sync status is unavailable or before
-    every chain's cross-safe head reaches activation.
+  - It returns an error while virtual-node sync status is unavailable or local
+    safe has not advanced.
   - Once ready, it returns activation when there are no chains, or one past the
     minimum cross-safe timestamp across chains otherwise.
   - The no-backfill startup path uses that same timestamp for its first
@@ -240,7 +240,7 @@ func TestFirstVerifiableTimestamp(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "cross-safe before activation blocks startup",
+			name: "cross-safe before activation returns activation",
 			setup: func(h *interopTestHarness) *interopTestHarness {
 				return h.WithActivation(100).
 					WithChain(10, func(m *mockChainContainer) {
@@ -251,7 +251,7 @@ func TestFirstVerifiableTimestamp(t *testing.T) {
 					}).
 					Build()
 			},
-			wantErr: true,
+			want: 100,
 		},
 		{
 			name: "cross-safe at activation returns timestamp after activation",

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -962,6 +962,28 @@ func TestVerifiedAtTimestamp(t *testing.T) {
 			},
 		},
 		{
+			name: "safe-head handoff timestamps are verified",
+			setup: func(h *interopTestHarness) *interopTestHarness {
+				return h.WithActivation(100).
+					WithChain(10, func(m *mockChainContainer) {
+						m.syncStatusFull = &eth.SyncStatus{
+							SafeL2:      eth.L2BlockRef{Number: 125, Time: 125},
+							LocalSafeL2: eth.L2BlockRef{Number: 125, Time: 125},
+						}
+					}).
+					Build()
+			},
+			run: func(t *testing.T, h *interopTestHarness) {
+				verified, err := h.interop.VerifiedAtTimestamp(125)
+				require.NoError(t, err)
+				require.True(t, verified)
+
+				verified, err = h.interop.VerifiedAtTimestamp(126)
+				require.NoError(t, err)
+				require.False(t, verified)
+			},
+		},
+		{
 			name: "committed timestamp verified",
 			setup: func(h *interopTestHarness) *interopTestHarness {
 				return h.WithChain(10, func(m *mockChainContainer) {

--- a/op-supernode/supernode/activity/interop/interop_test_access.go
+++ b/op-supernode/supernode/activity/interop/interop_test_access.go
@@ -6,6 +6,7 @@ package interop
 // in this file so the boundary is easy to audit.
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -70,11 +71,14 @@ func (i *Interop) BackfillEndTimestamp() uint64 {
 	return i.backfillEndTimestamp
 }
 
-// FirstVerifiableTimestamp returns the timestamp at which the main loop
-// begins verification: ActivationTimestamp() when backfill did not run,
-// or BackfillEndTimestamp()+1 when it did.
+// FirstVerifiableTimestamp returns the timestamp at which the main loop begins
+// verification. It is intended for tests after startup has completed.
 func (i *Interop) FirstVerifiableTimestamp() uint64 {
-	return i.firstVerifiableTimestamp()
+	ts, err := i.firstVerifiableTimestamp(context.Background())
+	if err != nil {
+		return 0
+	}
+	return ts
 }
 
 // ---------------------------------------------------------------------------

--- a/op-supernode/supernode/activity/interop/log_backfill.go
+++ b/op-supernode/supernode/activity/interop/log_backfill.go
@@ -67,9 +67,13 @@ func (i *Interop) runLogBackfill() (uint64, error) {
 		return 0, nil
 	}
 
-	firstVerifiable, err := i.resolveFirstVerifiableTimestamp(i.ctx)
-	if err != nil {
-		return 0, err
+	firstVerifiable := i.firstVerifiable
+	if !i.firstVerifiableSet {
+		var err error
+		firstVerifiable, err = i.resolveFirstVerifiableTimestamp(i.ctx)
+		if err != nil {
+			return 0, err
+		}
 	}
 	if firstVerifiable == i.activationTimestamp {
 		return 0, nil

--- a/op-supernode/supernode/activity/interop/log_backfill.go
+++ b/op-supernode/supernode/activity/interop/log_backfill.go
@@ -10,28 +10,6 @@ import (
 	cc "github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container"
 )
 
-// firstVerifiableTimestamp is the earliest timestamp the main loop will attempt
-// to verify. It is backfillEndTimestamp+1 after log backfill, otherwise the
-// safe-head-derived startup timestamp.
-func (i *Interop) firstVerifiableTimestamp(ctx context.Context) (uint64, error) {
-	if i.backfillEndTimestamp != 0 {
-		next := i.backfillEndTimestamp + 1
-		if next < i.activationTimestamp {
-			return i.activationTimestamp, nil
-		}
-		return next, nil
-	}
-	if i.firstVerifiableSet {
-		return i.firstVerifiable, nil
-	}
-	if i.verifiedDB != nil {
-		if _, initialized := i.verifiedDB.LastTimestamp(); initialized {
-			return i.activationTimestamp, nil
-		}
-	}
-	return i.resolveFirstVerifiableTimestamp(ctx)
-}
-
 // resolveFirstVerifiableTimestamp consults all chain sync statuses and returns
 // the first timestamp not already covered by the minimum cross-safe head.
 func (i *Interop) resolveFirstVerifiableTimestamp(ctx context.Context) (uint64, error) {

--- a/op-supernode/supernode/activity/interop/log_backfill.go
+++ b/op-supernode/supernode/activity/interop/log_backfill.go
@@ -10,6 +10,55 @@ import (
 	cc "github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container"
 )
 
+// firstVerifiableTimestamp is the earliest timestamp the main loop will attempt
+// to verify. It is backfillEndTimestamp+1 after log backfill, otherwise the
+// safe-head-derived startup timestamp.
+func (i *Interop) firstVerifiableTimestamp(ctx context.Context) (uint64, error) {
+	if i.backfillEndTimestamp != 0 {
+		next := i.backfillEndTimestamp + 1
+		if next < i.activationTimestamp {
+			return i.activationTimestamp, nil
+		}
+		return next, nil
+	}
+	if i.firstVerifiableSet {
+		return i.firstVerifiable, nil
+	}
+	if i.verifiedDB != nil {
+		if _, initialized := i.verifiedDB.LastTimestamp(); initialized {
+			return i.activationTimestamp, nil
+		}
+	}
+	return i.resolveFirstVerifiableTimestamp(ctx)
+}
+
+// resolveFirstVerifiableTimestamp consults all chain sync statuses and returns
+// the first timestamp not already covered by the minimum cross-safe head.
+func (i *Interop) resolveFirstVerifiableTimestamp(ctx context.Context) (uint64, error) {
+	if len(i.chains) == 0 {
+		return i.activationTimestamp, nil
+	}
+
+	minCrossSafeTime := uint64(math.MaxUint64)
+	for _, chain := range i.chains {
+		syncStatus, err := chain.SyncStatus(ctx)
+		if err != nil {
+			return 0, fmt.Errorf("chain %s: sync status: %w", chain.ID(), err)
+		}
+		// local safe should advance even if cross safe has nothing to work from.
+		if syncStatus.LocalSafeL2.Number == 0 {
+			return 0, fmt.Errorf("chain %s: local safe L2 number is 0", chain.ID())
+		}
+		i.log.Debug("first verifiable timestamp: sync status",
+			"chain", chain.ID(), "safe", syncStatus.SafeL2, "localSafe", syncStatus.LocalSafeL2)
+		minCrossSafeTime = min(minCrossSafeTime, syncStatus.SafeL2.Time)
+	}
+	if minCrossSafeTime < i.activationTimestamp {
+		return 0, fmt.Errorf("minimum cross-safe timestamp %d is before activation timestamp %d", minCrossSafeTime, i.activationTimestamp)
+	}
+	return minCrossSafeTime + 1, nil
+}
+
 func (i *Interop) runLogBackfill() (uint64, error) {
 	if i.logBackfillDepth <= 0 {
 		return 0, nil
@@ -18,36 +67,18 @@ func (i *Interop) runLogBackfill() (uint64, error) {
 		return 0, nil
 	}
 
-	// identify the minimum cross-safe time across all chains
-	minCrossSafeTime := uint64(math.MaxUint64)
-	for _, chain := range i.chains {
-		syncStatus, err := chain.SyncStatus(i.ctx)
-		if err != nil {
-			return 0, fmt.Errorf("chain %s: sync status: %w", chain.ID(), err)
-		}
-		// watch that local safe advances to become non-zero
-		// local safe should advance even if cross safe has nothing to work from
-		if syncStatus.LocalSafeL2.Number == 0 {
-			return 0, fmt.Errorf("chain %s: local safe L2 number is 0", chain.ID())
-		}
-		i.log.Debug("log backfill: sync status",
-			"chain", chain.ID(), "safe", syncStatus.SafeL2, "localSafe", syncStatus.LocalSafeL2)
-		minCrossSafeTime = min(minCrossSafeTime, syncStatus.SafeL2.Time)
+	firstVerifiable, err := i.resolveFirstVerifiableTimestamp(i.ctx)
+	if err != nil {
+		return 0, err
 	}
-
-	// if activation falls after the backfill range end, don't backfill
-	if i.activationTimestamp > minCrossSafeTime {
-		i.log.Info("log backfill: activation timestamp falls after backfill range end, skipping backfill",
-			"activationTimestamp", i.activationTimestamp, "minCrossSafeTime", minCrossSafeTime)
-		return 0, nil
-	}
+	endTime := firstVerifiable - 1
 
 	// naively, end minus depth is the ideal backfill start.
 	// guard the subtraction so a young chain (crossSafe < depth) doesn't wrap.
 	depthSec := uint64(i.logBackfillDepth.Seconds())
 	var idealStart uint64
-	if minCrossSafeTime >= depthSec {
-		idealStart = minCrossSafeTime - depthSec
+	if endTime >= depthSec {
+		idealStart = endTime - depthSec
 	}
 	// clamp to the activation timestamp: never backfill before activation.
 	startTime := max(idealStart, i.activationTimestamp)
@@ -72,9 +103,9 @@ func (i *Interop) runLogBackfill() (uint64, error) {
 				i.log.Error("log backfill: timestamp to block number for start", "chain", chain.ID(), "err", err)
 				return
 			}
-			endNum, err := chain.TimestampToBlockNumber(i.ctx, minCrossSafeTime)
+			endNum, err := chain.TimestampToBlockNumber(i.ctx, endTime)
 			if err != nil {
-				errCh <- fmt.Errorf("chain %s: timestamp to block number for end %d: %w", chain.ID(), minCrossSafeTime, err)
+				errCh <- fmt.Errorf("chain %s: timestamp to block number for end %d: %w", chain.ID(), endTime, err)
 				i.log.Error("log backfill: timestamp to block number for end", "chain", chain.ID(), "err", err)
 				return
 			}
@@ -91,7 +122,7 @@ func (i *Interop) runLogBackfill() (uint64, error) {
 	for err := range errCh {
 		return 0, err
 	}
-	return minCrossSafeTime, nil
+	return endTime, nil
 }
 
 func (i *Interop) backfillChain(ctx context.Context, cid eth.ChainID, chain cc.ChainContainer, startNum, endNum uint64) error {

--- a/op-supernode/supernode/activity/interop/log_backfill.go
+++ b/op-supernode/supernode/activity/interop/log_backfill.go
@@ -54,7 +54,7 @@ func (i *Interop) resolveFirstVerifiableTimestamp(ctx context.Context) (uint64, 
 		minCrossSafeTime = min(minCrossSafeTime, syncStatus.SafeL2.Time)
 	}
 	if minCrossSafeTime < i.activationTimestamp {
-		return 0, fmt.Errorf("minimum cross-safe timestamp %d is before activation timestamp %d", minCrossSafeTime, i.activationTimestamp)
+		return i.activationTimestamp, nil
 	}
 	return minCrossSafeTime + 1, nil
 }
@@ -70,6 +70,9 @@ func (i *Interop) runLogBackfill() (uint64, error) {
 	firstVerifiable, err := i.resolveFirstVerifiableTimestamp(i.ctx)
 	if err != nil {
 		return 0, err
+	}
+	if firstVerifiable == i.activationTimestamp {
+		return 0, nil
 	}
 	endTime := firstVerifiable - 1
 

--- a/op-supernode/supernode/activity/interop/log_backfill_test.go
+++ b/op-supernode/supernode/activity/interop/log_backfill_test.go
@@ -25,6 +25,13 @@ func progressInteropUntil(t *testing.T, i *Interop, maxIters int, cond func() bo
 	}
 }
 
+func requireFirstVerifiableTimestamp(t *testing.T, i *Interop, want uint64, msgAndArgs ...interface{}) {
+	t.Helper()
+	got, err := i.firstVerifiableTimestamp(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, want, got, msgAndArgs...)
+}
+
 func TestLogBackfill_ResumesAfterInterruption(t *testing.T) {
 	const act = uint64(100)
 	depth := 10 * time.Second // crossSafe 110, depth 10s -> T_lo 100; should seal 100..110
@@ -77,7 +84,7 @@ func TestLogBackfill_ResumesAfterInterruption(t *testing.T) {
 	h.interop.backfillEndTimestamp = end
 	require.Equal(t, uint64(110), end,
 		"runLogBackfill must return minCrossSafeTime as the end of the sealed range")
-	require.Equal(t, uint64(111), h.interop.firstVerifiableTimestamp(),
+	requireFirstVerifiableTimestamp(t, h.interop, 111,
 		"main loop resumes at backfillEndTimestamp+1")
 	require.Equal(t, act, h.interop.activationTimestamp, "protocol activation must not change")
 
@@ -144,7 +151,7 @@ func TestLogBackfill_RetriesWhenVirtualNodesNotReady(t *testing.T) {
 	require.GreaterOrEqual(t, syncStatusCalls.Load(), failUntil,
 		"SyncStatus should have been called at least %d times (the failing ones)", failUntil)
 	require.Equal(t, uint64(110), h.interop.backfillEndTimestamp)
-	require.Equal(t, uint64(111), h.interop.firstVerifiableTimestamp())
+	requireFirstVerifiableTimestamp(t, h.interop, 111)
 	require.Equal(t, act, h.interop.activationTimestamp, "protocol activation must not change")
 
 	cancel()
@@ -257,7 +264,7 @@ func TestLogBackfill_AsymmetricMultiChain(t *testing.T) {
 	require.Equal(t, act, h.interop.activationTimestamp, "protocol activation must not change")
 	require.Equal(t, uint64(100), end,
 		"runLogBackfill must return minCrossSafeTime as the end of the sealed range")
-	require.Equal(t, uint64(101), h.interop.firstVerifiableTimestamp(),
+	requireFirstVerifiableTimestamp(t, h.interop, 101,
 		"main loop resumes at backfillEndTimestamp+1")
 
 	chain10 := h.Mock(10)
@@ -337,7 +344,7 @@ func TestLogBackfill_MisalignedActivation(t *testing.T) {
 	require.Equal(t, act, h.interop.activationTimestamp, "protocol activation must not change")
 	require.Equal(t, localSafeTs, end,
 		"runLogBackfill must return minCrossSafeTime as the end of the sealed range")
-	require.Equal(t, localSafeTs+1, h.interop.firstVerifiableTimestamp())
+	requireFirstVerifiableTimestamp(t, h.interop, localSafeTs+1)
 
 	chain10 := h.Mock(10)
 	db := h.interop.logsDBs[chain10.id]
@@ -399,7 +406,7 @@ func TestLogBackfill_AdvancesActivationAndStartsVerifyAfterCeiling(t *testing.T)
 	h.interop.backfillEndTimestamp = end
 	require.Equal(t, uint64(110), end,
 		"runLogBackfill must return minCrossSafeTime as the end of the sealed range")
-	require.Equal(t, uint64(111), h.interop.firstVerifiableTimestamp(),
+	requireFirstVerifiableTimestamp(t, h.interop, 111,
 		"main loop resumes at backfillEndTimestamp+1")
 	require.Equal(t, act, h.interop.activationTimestamp, "protocol activation must not change")
 
@@ -466,11 +473,11 @@ func TestLogBackfill_NoOpWhenDepthZero(t *testing.T) {
 	_, has := h.interop.logsDBs[chain10.id].LatestSealedBlock()
 	require.False(t, has, "logs DB must remain empty")
 
-	// Caller sets backfillEndTimestamp; with end==0 the main loop falls back
-	// to activationTimestamp rather than end+1.
+	// Caller sets backfillEndTimestamp; with end==0 the main loop derives the
+	// first unverified timestamp from the current safe head.
 	h.interop.backfillEndTimestamp = end
-	require.Equal(t, act, h.interop.firstVerifiableTimestamp(),
-		"with end==0 the main loop resumes at activationTimestamp")
+	requireFirstVerifiableTimestamp(t, h.interop, 111,
+		"with end==0 the main loop starts after the safe head")
 }
 
 // TestLogBackfill_NoOpWhenNoChains asserts that runLogBackfill short-circuits
@@ -493,18 +500,15 @@ func TestLogBackfill_NoOpWhenNoChains(t *testing.T) {
 	require.Zero(t, end, "empty chains map short-circuits with end=0")
 
 	h.interop.backfillEndTimestamp = end
-	require.Equal(t, act, h.interop.firstVerifiableTimestamp(),
+	requireFirstVerifiableTimestamp(t, h.interop, act,
 		"with end==0 the main loop resumes at activationTimestamp")
 }
 
 // TestLogBackfill_ActivationInFuture asserts the edge case where the
 // configured activation is ahead of every chain's cross-safe tip.
-// runLogBackfill must short-circuit with (0, nil) — the "backfill did
-// not run" convention — rather than claiming minCrossSafeTime was
-// sealed when nothing was. This keeps backfillEndTimestamp honest for
-// external observers (devstack/integration assertions) and routes the
-// main loop through the activationTimestamp path of
-// firstVerifiableTimestamp().
+// firstVerifiableTimestamp is the common startup readiness gate, so backfill
+// must return an error and retry rather than claiming a range end that has not
+// become cross-safe yet.
 func TestLogBackfill_ActivationInFuture(t *testing.T) {
 	const act = uint64(2000)
 	depth := 100 * time.Second
@@ -535,24 +539,21 @@ func TestLogBackfill_ActivationInFuture(t *testing.T) {
 	h.interop.ctx = context.Background()
 
 	end, err := h.interop.runLogBackfill()
-	require.NoError(t, err)
-	require.Zero(t, end,
-		"activation-in-future must short-circuit with end=0 (backfill did not run)")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "before activation timestamp")
+	require.Zero(t, end)
 	require.Zero(t, outputCalls.Load(),
-		"no blocks fetched: backfill is skipped when activation is ahead of cross-safe")
+		"no blocks fetched: backfill waits when activation is ahead of cross-safe")
 
 	chain10 := h.Mock(10)
 	_, has := h.interop.logsDBs[chain10.id].LatestSealedBlock()
-	require.False(t, has, "logs DB must remain empty when backfill is skipped")
+	require.False(t, has, "logs DB must remain empty while backfill waits")
 
 	require.Equal(t, act, h.interop.activationTimestamp,
 		"protocol activation must not change")
 
-	// With end==0 the main loop falls through to activationTimestamp,
-	// which is the correct handoff when activation is still in the future.
-	h.interop.backfillEndTimestamp = end
-	require.Equal(t, act, h.interop.firstVerifiableTimestamp(),
-		"main loop resumes at activationTimestamp when backfill is skipped")
+	_, err = h.interop.firstVerifiableTimestamp(context.Background())
+	require.Error(t, err, "main loop also waits on the shared readiness gate")
 }
 
 // TestLogBackfill_ClampsStartToGenesis asserts that when a chain's genesis

--- a/op-supernode/supernode/activity/interop/log_backfill_test.go
+++ b/op-supernode/supernode/activity/interop/log_backfill_test.go
@@ -506,9 +506,8 @@ func TestLogBackfill_NoOpWhenNoChains(t *testing.T) {
 
 // TestLogBackfill_ActivationInFuture asserts the edge case where the
 // configured activation is ahead of every chain's cross-safe tip.
-// firstVerifiableTimestamp is the common startup readiness gate, so backfill
-// must return an error and retry rather than claiming a range end that has not
-// become cross-safe yet.
+// firstVerifiableTimestamp clamps to activation, and backfill must no-op
+// instead of sealing beyond the current cross-safe head.
 func TestLogBackfill_ActivationInFuture(t *testing.T) {
 	const act = uint64(2000)
 	depth := 100 * time.Second
@@ -539,11 +538,10 @@ func TestLogBackfill_ActivationInFuture(t *testing.T) {
 	h.interop.ctx = context.Background()
 
 	end, err := h.interop.runLogBackfill()
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "before activation timestamp")
+	require.NoError(t, err)
 	require.Zero(t, end)
 	require.Zero(t, outputCalls.Load(),
-		"no blocks fetched: backfill waits when activation is ahead of cross-safe")
+		"no blocks fetched: backfill no-ops when activation is ahead of cross-safe")
 
 	chain10 := h.Mock(10)
 	_, has := h.interop.logsDBs[chain10.id].LatestSealedBlock()
@@ -552,8 +550,8 @@ func TestLogBackfill_ActivationInFuture(t *testing.T) {
 	require.Equal(t, act, h.interop.activationTimestamp,
 		"protocol activation must not change")
 
-	_, err = h.interop.firstVerifiableTimestamp(context.Background())
-	require.Error(t, err, "main loop also waits on the shared readiness gate")
+	requireFirstVerifiableTimestamp(t, h.interop, act,
+		"main loop resumes at activation when cross-safe is still pre-activation")
 }
 
 // TestLogBackfill_ClampsStartToGenesis asserts that when a chain's genesis

--- a/op-supernode/supernode/activity/interop/logdb.go
+++ b/op-supernode/supernode/activity/interop/logdb.go
@@ -170,11 +170,13 @@ func (i *Interop) verifyCanAddTimestamp(chainID eth.ChainID, db LogsDB, ts uint6
 	latestBlock, hasBlocks := db.LatestSealedBlock()
 
 	if !hasBlocks {
-		// The main loop starts at firstVerifiableTimestamp — activationTimestamp
-		// when backfill did not run, or backfillEndTimestamp+1 when it did. If
-		// the DB is empty, this is the only timestamp the main loop would
-		// legitimately seal first.
-		if ts == i.firstVerifiableTimestamp() {
+		// The main loop starts at firstVerifiableTimestamp. If the DB is empty,
+		// this is the only timestamp the main loop would legitimately seal first.
+		firstVerifiable, err := i.firstVerifiableTimestamp(i.ctx)
+		if err != nil {
+			return eth.BlockID{}, hasBlocks, err
+		}
+		if ts == firstVerifiable {
 			return eth.BlockID{}, hasBlocks, nil
 		}
 		// Backfill's first block is TargetBlockNumber(T_lo), which floors the

--- a/op-supernode/supernode/activity/interop/verified_db.go
+++ b/op-supernode/supernode/activity/interop/verified_db.go
@@ -42,10 +42,11 @@ type PendingInvalidation struct {
 
 // VerifiedDB provides persistence for verified timestamps using bbolt.
 type VerifiedDB struct {
-	db            *bolt.DB
-	mu            sync.RWMutex
-	lastTimestamp uint64
-	initialized   bool
+	db             *bolt.DB
+	mu             sync.RWMutex
+	firstTimestamp uint64
+	lastTimestamp  uint64
+	initialized    bool
 }
 
 // OpenVerifiedDB opens or creates a VerifiedDB at the given data directory.
@@ -73,17 +74,18 @@ func OpenVerifiedDB(dataDir string) (*VerifiedDB, error) {
 		db: db,
 	}
 
-	// Initialize the last timestamp from the database
-	if err := vdb.initLastTimestamp(); err != nil {
+	// Initialize the timestamp bounds from the database
+	if err := vdb.initTimestampBounds(); err != nil {
 		db.Close()
-		return nil, fmt.Errorf("failed to initialize last timestamp: %w", err)
+		return nil, fmt.Errorf("failed to initialize timestamp bounds: %w", err)
 	}
 
 	return vdb, nil
 }
 
-// initLastTimestamp scans the database to find the highest committed timestamp.
-func (v *VerifiedDB) initLastTimestamp() error {
+// initTimestampBounds scans the database to find the lowest and highest committed timestamp.
+func (v *VerifiedDB) initTimestampBounds() error {
+	v.firstTimestamp = 0
 	v.lastTimestamp = 0
 	v.initialized = false
 	return v.db.View(func(tx *bolt.Tx) error {
@@ -93,9 +95,11 @@ func (v *VerifiedDB) initLastTimestamp() error {
 		}
 
 		c := b.Cursor()
-		key, _ := c.Last()
-		if len(key) == u64Len {
-			v.lastTimestamp = binary.BigEndian.Uint64(key)
+		firstKey, _ := c.First()
+		lastKey, _ := c.Last()
+		if len(firstKey) == u64Len && len(lastKey) == u64Len {
+			v.firstTimestamp = binary.BigEndian.Uint64(firstKey)
+			v.lastTimestamp = binary.BigEndian.Uint64(lastKey)
 			v.initialized = true
 		}
 
@@ -166,6 +170,9 @@ func (v *VerifiedDB) Commit(result VerifiedResult) error {
 	}
 
 	// Update state
+	if !v.initialized {
+		v.firstTimestamp = ts
+	}
 	v.lastTimestamp = ts
 	v.initialized = true
 
@@ -226,6 +233,14 @@ func (v *VerifiedDB) Has(ts uint64) (bool, error) {
 	return found, nil
 }
 
+// FirstTimestamp returns the first committed timestamp.
+// Returns 0 and false if no timestamps have been committed.
+func (v *VerifiedDB) FirstTimestamp() (uint64, bool) {
+	v.mu.RLock()
+	defer v.mu.RUnlock()
+	return v.firstTimestamp, v.initialized
+}
+
 // LastTimestamp returns the most recently committed timestamp.
 // Returns 0 and false if no timestamps have been committed.
 func (v *VerifiedDB) LastTimestamp() (uint64, bool) {
@@ -262,8 +277,8 @@ func (v *VerifiedDB) Rewind(timestamp uint64) (bool, error) {
 
 	// Update state
 	if deleted {
-		if err := v.initLastTimestamp(); err != nil {
-			return deleted, fmt.Errorf("failed to reinitialize lastTimestamp after rewind: %w", err)
+		if err := v.initTimestampBounds(); err != nil {
+			return deleted, fmt.Errorf("failed to reinitialize timestamp bounds after rewind: %w", err)
 		}
 	}
 

--- a/op-supernode/supernode/activity/interop/verified_db_test.go
+++ b/op-supernode/supernode/activity/interop/verified_db_test.go
@@ -23,6 +23,9 @@ func TestVerifiedDB_WriteAndRead(t *testing.T) {
 	lastTs, initialized := db.LastTimestamp()
 	require.False(t, initialized)
 	require.Equal(t, uint64(0), lastTs)
+	firstTs, initialized := db.FirstTimestamp()
+	require.False(t, initialized)
+	require.Equal(t, uint64(0), firstTs)
 
 	// Create test data
 	chainID1 := eth.ChainIDFromUInt64(10)
@@ -54,6 +57,9 @@ func TestVerifiedDB_WriteAndRead(t *testing.T) {
 	lastTs, initialized = db.LastTimestamp()
 	require.True(t, initialized)
 	require.Equal(t, uint64(1000), lastTs)
+	firstTs, initialized = db.FirstTimestamp()
+	require.True(t, initialized)
+	require.Equal(t, uint64(1000), firstTs)
 
 	// Read it back
 	retrieved, err := db.Get(1000)
@@ -158,6 +164,9 @@ func TestVerifiedDB_Persistence(t *testing.T) {
 	lastTs, initialized := db2.LastTimestamp()
 	require.True(t, initialized)
 	require.Equal(t, uint64(501), lastTs)
+	firstTs, initialized := db2.FirstTimestamp()
+	require.True(t, initialized)
+	require.Equal(t, uint64(500), firstTs)
 
 	// Data should be readable
 	result, err := db2.Get(500)
@@ -227,6 +236,9 @@ func TestVerifiedDB_RewindTo(t *testing.T) {
 		// Last timestamp should be updated to 102
 		lastTs, _ = db.LastTimestamp()
 		require.Equal(t, uint64(102), lastTs)
+		firstTs, ok := db.FirstTimestamp()
+		require.True(t, ok)
+		require.Equal(t, uint64(100), firstTs)
 	})
 
 	t.Run("returns false when no entries deleted", func(t *testing.T) {


### PR DESCRIPTION
## Tool Use Notice
Generated. In self-review.

## Summary

This PR unifies interop startup around the `firstVerifiableTimestamp` path. Both backfill and non-backfill startup now consult the same safe-head-aware readiness gate before verification begins.

The shared rule is:

- If backfill ran, first verifiable is `backfillEndTimestamp + 1`.
- If backfill did not run and cross-safe is before activation, first verifiable is `activationTimestamp`.
- If backfill did not run and cross-safe is at/after activation, first verifiable is `minCrossSafeTime + 1`.
- If sync status is unavailable or local-safe is zero, startup waits/retries.
- Startup emits an `INFO` log with the resolved first-verifiable timestamp.

## Core Functional Changes

| Area | Change | Code |
|---|---|---|
| Shared first-verifiable path | `firstVerifiableTimestamp(ctx)` now returns `(uint64, error)` and centralizes backfill handoff, cached startup handoff, and safe-head resolution. | `op-supernode/supernode/activity/interop/log_backfill.go:13-32` |
| Safe-head readiness gate | `resolveFirstVerifiableTimestamp(ctx)` reads every chain `SyncStatus`, requires non-zero `LocalSafeL2`, clamps pre-activation cross-safe to activation, and otherwise returns `minCrossSafeTime + 1`. | `op-supernode/supernode/activity/interop/log_backfill.go:35-60` |
| Backfill parity | Backfill calls the same resolver, no-ops if first-verifiable is activation, and otherwise derives its inclusive backfill end as `firstVerifiable - 1`. | `op-supernode/supernode/activity/interop/log_backfill.go:70-77` |
| No-backfill startup | When there is no prior verified state and no backfill, startup resolves and caches the first-verifiable timestamp before entering verification. | `op-supernode/supernode/activity/interop/interop.go:277-292` |
| Startup visibility | Startup always logs the resolved `firstVerifiableTimestamp` at `INFO`. | `op-supernode/supernode/activity/interop/interop.go:293-302` |
| Main loop handoff | `observeRound` asks the shared path for the next timestamp when there is no existing verified state. | `op-supernode/supernode/activity/interop/interop.go:455-470` |
| Empty logs DB validation | The first non-backfill log seal is accepted only at the shared first-verifiable timestamp. | `op-supernode/supernode/activity/interop/logdb.go:172-180` |

## Spec And Test Coverage

| Spec Claim | Test Coverage | Lines |
|---|---|---|
| `firstVerifiableTimestamp` is the common startup readiness gate. | `TestFirstVerifiableTimestamp` directly exercises the shared API. | `op-supernode/supernode/activity/interop/interop_test.go:191-306` |
| Sync status errors block startup. | Test case `"sync status error blocks startup"` returns a sync status error and expects `wantErr`. | `op-supernode/supernode/activity/interop/interop_test.go:215-227` |
| Zero local-safe blocks startup. | Test case `"zero local-safe blocks startup"` sets empty `LocalSafeL2` and expects `wantErr`. | `op-supernode/supernode/activity/interop/interop_test.go:228-240` |
| Cross-safe before activation returns activation. | Test case `"cross-safe before activation returns activation"` sets `SafeL2.Time=99`, activation `100`, and expects `100`. | `op-supernode/supernode/activity/interop/interop_test.go:242-254` |
| No chains returns activation. | Test case `"no chains returns activation"` expects `100`. | `op-supernode/supernode/activity/interop/interop_test.go:208-213` |
| Cross-safe at activation returns first unverified timestamp. | Test case `"cross-safe at activation returns timestamp after activation"` expects `101`. | `op-supernode/supernode/activity/interop/interop_test.go:256-268` |
| Multi-chain startup uses one past the minimum cross-safe timestamp. | Test case with safe times `140` and `125` expects `126`. | `op-supernode/supernode/activity/interop/interop_test.go:270-288` |
| No-backfill startup uses the same first-verifiable timestamp for verification. | `TestStartWithoutBackfillUsesFirstVerifiableTimestamp` captures `verifyFn` timestamp and asserts `safe+1`. | `op-supernode/supernode/activity/interop/interop_test.go:308-345` |
| Startup logs the resolved first-verifiable timestamp. | Same test captures logs and asserts the `INFO` line includes `firstVerifiableTimestamp=126`. | `op-supernode/supernode/activity/interop/interop_test.go:346-350` |
| Backfill no-ops when activation is ahead of cross-safe. | `TestLogBackfill_ActivationInFuture` expects `runLogBackfill` to return `end=0`, fetch no blocks, leave the logs DB empty, and keep first-verifiable at activation. | `op-supernode/supernode/activity/interop/log_backfill_test.go:507-554` |

## Test Plan

- `go test ./supernode/activity/interop`
- `go test ./supernode/activity/...`