### PR TITLE
tests: use InSync check for advancing heads over Matched

### DIFF
--- a/op-acceptance-tests/tests/interop/sync/multisupervisor_interop/interop_sync_test.go
+++ b/op-acceptance-tests/tests/interop/sync/multisupervisor_interop/interop_sync_test.go
@@ -241,5 +241,5 @@ func TestUnsafeChainUnknownToL2CL(gt *testing.T) {
 	// The verifier will quickly catch up with the sequencer unsafe head as well as the primary supervisor.
 	// The verifier will process previously unknown unsafe blocks and advance its unsafe head.
 	logger.Info("Verifier catches up sequencer unsafe chain with was unknown for verifier")
-	sys.L2CLA2.Matched(sys.L2CLA, types.LocalUnsafe, 5)
+	sys.L2CLA2.InSync(sys.L2CLA, types.LocalUnsafe, 5)
 }

--- a/op-acceptance-tests/tests/safeheaddb_clsync/safeheaddb_test.go
+++ b/op-acceptance-tests/tests/safeheaddb_clsync/safeheaddb_test.go
@@ -38,7 +38,7 @@ func TestPreserveDatabaseOnCLResync(gt *testing.T) {
 		sys.L2CL.AdvancedFn(types.LocalSafe, 1, 30),
 		sys.L2CLB.AdvancedFn(types.LocalSafe, 1, 30))
 
-	sys.L2CLB.Matched(sys.L2CL, types.LocalSafe, 30)
+	sys.L2CLB.InSync(sys.L2CL, types.LocalSafe, 30)
 	sys.L2CLB.VerifySafeHeadDatabaseMatches(sys.L2CL)
 
 	// Stop the verifier node. Since the sysgo EL uses in-memory storage this also wipes its database.
@@ -53,7 +53,7 @@ func TestPreserveDatabaseOnCLResync(gt *testing.T) {
 	sys.L2CLB.Start()
 	sys.L2ELB.PeerWith(sys.L2EL)
 
-	sys.L2CLB.Matched(sys.L2CL, types.LocalSafe, 30)
+	sys.L2CLB.InSync(sys.L2CL, types.LocalSafe, 30)
 	sys.L2CLB.Advanced(types.LocalSafe, 1, 30) // At least one safe head db update after resync
 
 	// Safe head db should not have been reset

--- a/op-acceptance-tests/tests/safeheaddb_elsync/safeheaddb_test.go
+++ b/op-acceptance-tests/tests/safeheaddb_elsync/safeheaddb_test.go
@@ -24,8 +24,8 @@ func newSingleChainMultiNodeELSync(t devtest.T) *presets.SingleChainMultiNode {
 	)
 	// Run the initial sync check with 60 attempts (120s) to accommodate EL Sync.
 	dsl.CheckAll(t,
-		sys.L2CLB.MatchedFn(sys.L2CL, types.CrossSafe, 60),
-		sys.L2CLB.MatchedFn(sys.L2CL, types.LocalUnsafe, 60),
+		sys.L2CLB.InSyncFn(sys.L2CL, types.CrossSafe, 60),
+		sys.L2CLB.InSyncFn(sys.L2CL, types.LocalUnsafe, 60),
 	)
 	return sys
 }
@@ -50,7 +50,7 @@ func TestTruncateDatabaseOnELResync(gt *testing.T) {
 		sys.L2CL.AdvancedFn(types.LocalSafe, 1, 30),
 		sys.L2CLB.AdvancedFn(types.LocalSafe, 1, 30))
 
-	sys.L2CLB.Matched(sys.L2CL, types.LocalSafe, 30)
+	sys.L2CLB.InSync(sys.L2CL, types.LocalSafe, 30)
 	sys.L2CLB.VerifySafeHeadDatabaseMatches(sys.L2CL)
 
 	// Stop the verifier node. Since the sysgo EL uses in-memory storage this also wipes its database.
@@ -72,7 +72,7 @@ func TestTruncateDatabaseOnELResync(gt *testing.T) {
 	// EL Sync after a full database wipe requires more time than the initial sync:
 	// the EL must re-download all blocks via P2P before the CL can begin derivation,
 	// and node A keeps advancing LocalSafe in the meantime.
-	sys.L2CLB.Matched(sys.L2CL, types.LocalSafe, 90)
+	sys.L2CLB.InSync(sys.L2CL, types.LocalSafe, 90)
 	sys.L2CLB.Advanced(types.LocalSafe, 1, 90) // At least one safe head db update after resync
 
 	sys.L2CLB.VerifySafeHeadDatabaseMatches(sys.L2CL)
@@ -95,7 +95,7 @@ func TestNotTruncateDatabaseOnRestartWithExistingDatabase(gt *testing.T) {
 	dsl.CheckAll(t,
 		sys.L2CL.AdvancedFn(types.LocalSafe, 1, 30),
 		sys.L2CLB.AdvancedFn(types.LocalSafe, 1, 30))
-	sys.L2CLB.Matched(sys.L2CL, types.LocalSafe, 30)
+	sys.L2CLB.InSync(sys.L2CL, types.LocalSafe, 30)
 
 	preRestartSafeBlock := sys.L2CLB.SafeL2BlockRef().Number
 	sys.L2CLB.VerifySafeHeadDatabaseMatches(sys.L2CL, dsl.WithMinRequiredL2Block(preRestartSafeBlock))
@@ -107,7 +107,7 @@ func TestNotTruncateDatabaseOnRestartWithExistingDatabase(gt *testing.T) {
 
 	sys.L2CLB.Start()
 
-	sys.L2CLB.Matched(sys.L2CL, types.LocalSafe, 60)
+	sys.L2CLB.InSync(sys.L2CL, types.LocalSafe, 60)
 	sys.L2CLB.Advanced(types.LocalSafe, 1, 60) // At least one safe head db update after resync
 
 	sys.L2CLB.VerifySafeHeadDatabaseMatches(sys.L2CL, dsl.WithMinRequiredL2Block(preRestartSafeBlock))

--- a/op-acceptance-tests/tests/supernode/interop/follow_l2/p2p_sync_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/follow_l2/p2p_sync_test.go
@@ -44,5 +44,5 @@ func TestFollowSource_P2PSync(gt *testing.T) {
 	)
 
 	logger.Info("Check sequencer and follower holds identical chain")
-	sys.L2AFollowCL.Matched(sys.L2ACL, types.LocalUnsafe, 30)
+	sys.L2AFollowCL.InSync(sys.L2ACL, types.LocalUnsafe, 30)
 }

--- a/op-acceptance-tests/tests/supernode/interop/follow_l2/sync_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/follow_l2/sync_test.go
@@ -39,8 +39,8 @@ func TestFollowSource_HeadsDivergeThenConverge(gt *testing.T) {
 	initialChecks := make([]dsl.CheckFunc, 0, len(chains)*2)
 	for _, chain := range chains {
 		initialChecks = append(initialChecks,
-			chain.follower.MatchedFn(chain.source, types.LocalSafe, 20),
-			chain.follower.MatchedFn(chain.source, types.CrossSafe, 20),
+			chain.follower.InSyncFn(chain.source, types.LocalSafe, 20),
+			chain.follower.InSyncFn(chain.source, types.CrossSafe, 20),
 		)
 	}
 	dsl.CheckAll(t, initialChecks...)
@@ -107,9 +107,9 @@ func TestFollowSource_HeadsDivergeThenConverge(gt *testing.T) {
 	divergenceChecks := make([]dsl.CheckFunc, 0, len(chains)*3)
 	for _, chain := range chains {
 		divergenceChecks = append(divergenceChecks,
-			chain.follower.MatchedFn(chain.source, types.LocalUnsafe, 20),
-			chain.follower.MatchedFn(chain.source, types.LocalSafe, 20),
-			chain.follower.MatchedFn(chain.source, types.CrossSafe, 20),
+			chain.follower.InSyncFn(chain.source, types.LocalUnsafe, 20),
+			chain.follower.InSyncFn(chain.source, types.LocalSafe, 20),
+			chain.follower.InSyncFn(chain.source, types.CrossSafe, 20),
 		)
 	}
 	dsl.CheckAll(t, divergenceChecks...)
@@ -138,9 +138,9 @@ func TestFollowSource_HeadsDivergeThenConverge(gt *testing.T) {
 	finalChecks := make([]dsl.CheckFunc, 0, len(chains)*3)
 	for _, chain := range chains {
 		finalChecks = append(finalChecks,
-			chain.follower.MatchedFn(chain.source, types.LocalUnsafe, 20),
-			chain.follower.MatchedFn(chain.source, types.LocalSafe, 20),
-			chain.follower.MatchedFn(chain.source, types.CrossSafe, 20),
+			chain.follower.InSyncFn(chain.source, types.LocalUnsafe, 20),
+			chain.follower.InSyncFn(chain.source, types.LocalSafe, 20),
+			chain.follower.InSyncFn(chain.source, types.CrossSafe, 20),
 		)
 	}
 	dsl.CheckAll(t, finalChecks...)

--- a/op-acceptance-tests/tests/sync/elsync/offset_el_safe/sync_test.go
+++ b/op-acceptance-tests/tests/sync/elsync/offset_el_safe/sync_test.go
@@ -34,7 +34,7 @@ func TestELSyncSafeRetractedByOffset(gt *testing.T) {
 	dsl.CheckAll(t,
 		sys.L2CL.AdvancedFn(types.LocalSafe, 1, 30),
 		sys.L2CLB.AdvancedFn(types.LocalSafe, 1, 30))
-	sys.L2CLB.Matched(sys.L2CL, types.LocalSafe, 30)
+	sys.L2CLB.InSync(sys.L2CL, types.LocalSafe, 30)
 
 	// Stop verifier and wipe its EL to force a full EL sync on restart.
 	sys.L2ELB.Stop()

--- a/op-acceptance-tests/tests/sync/elsync/reorg/sync_test.go
+++ b/op-acceptance-tests/tests/sync/elsync/reorg/sync_test.go
@@ -90,12 +90,12 @@ func TestUnsafeGapFillAfterSafeReorg(gt *testing.T) {
 
 	// Restart verifier CL and verify it applies the reorg
 	sys.L2CLB.Start()
-	sys.L2ELB.Matched(sys.L2EL, eth.Safe, 5)
+	sys.L2ELB.InSync(sys.L2EL, eth.Safe, 5)
 
 	// Reconnect CLP2P so verifier can backfill the unsafe gap
 	sys.L2CLB.ConnectPeer(sys.L2CL)
 	sys.L2CL.ConnectPeer(sys.L2CLB)
-	sys.L2ELB.Matched(sys.L2EL, types.LocalUnsafe, 50)
+	sys.L2ELB.InSync(sys.L2EL, types.LocalUnsafe, 50)
 }
 
 // TestUnsafeGapFillAfterUnsafeReorg_RestartL2CL demonstrates the flow where:
@@ -151,7 +151,7 @@ func TestUnsafeGapFillAfterUnsafeReorg_RestartL2CL(gt *testing.T) {
 		return l2Unsafe.Number > 0 && l2Unsafe.L1Origin.Number > startL1Block.Number
 	}, 120*time.Second, 2*time.Second)
 
-	sys.L2ELB.Matched(sys.L2EL, types.LocalUnsafe, 30)
+	sys.L2ELB.InSync(sys.L2EL, types.LocalUnsafe, 30)
 
 	// Pick reorg block
 	l2BlockBeforeReorg := sys.L2EL.BlockRefByLabel(eth.Unsafe)
@@ -159,7 +159,7 @@ func TestUnsafeGapFillAfterUnsafeReorg_RestartL2CL(gt *testing.T) {
 
 	// Make few more unsafe blocks which will be reorged out
 	sys.L2EL.Advanced(eth.Unsafe, 4)
-	sys.L2ELB.Matched(sys.L2EL, types.LocalUnsafe, 30)
+	sys.L2ELB.InSync(sys.L2EL, types.LocalUnsafe, 30)
 
 	// Stop Verifier CL
 	sys.L2CLB.Stop()
@@ -233,7 +233,7 @@ func TestUnsafeGapFillAfterUnsafeReorg_RestartL2CL(gt *testing.T) {
 	// using RR Sync(soon be deprecated), or rely on EL Sync(desired)
 
 	// Unsafe gap is closed
-	sys.L2ELB.Matched(sys.L2EL, types.LocalUnsafe, 50)
+	sys.L2ELB.InSync(sys.L2EL, types.LocalUnsafe, 50)
 
 	seqUnsafe = sys.L2EL.BlockRefByLabel(eth.Unsafe)
 	verUnsafe = sys.L2ELB.BlockRefByLabel(eth.Unsafe)
@@ -291,7 +291,7 @@ func TestUnsafeGapFillAfterUnsafeReorg_RestartCLP2P(gt *testing.T) {
 		return l2Unsafe.Number > 0 && l2Unsafe.L1Origin.Number > startL1Block.Number
 	}, 120*time.Second, 2*time.Second)
 
-	sys.L2ELB.Matched(sys.L2EL, types.LocalUnsafe, 5)
+	sys.L2ELB.InSync(sys.L2EL, types.LocalUnsafe, 5)
 
 	// Pick reorg block
 	l2BlockBeforeReorg := sys.L2EL.BlockRefByLabel(eth.Unsafe)
@@ -299,7 +299,7 @@ func TestUnsafeGapFillAfterUnsafeReorg_RestartCLP2P(gt *testing.T) {
 
 	// Make few more unsafe blocks which will be reorged out
 	sys.L2EL.Advanced(eth.Unsafe, 4)
-	sys.L2ELB.Matched(sys.L2EL, types.LocalUnsafe, 5)
+	sys.L2ELB.InSync(sys.L2EL, types.LocalUnsafe, 5)
 
 	// Disconnect CLP2P
 	sys.L2CLB.DisconnectPeer(sys.L2CL)
@@ -362,7 +362,7 @@ func TestUnsafeGapFillAfterUnsafeReorg_RestartCLP2P(gt *testing.T) {
 	// using RR Sync(soon be deprecated), or rely on EL Sync(desired)
 
 	// Unsafe gap is closed
-	sys.L2ELB.Matched(sys.L2EL, types.LocalUnsafe, 50)
+	sys.L2ELB.InSync(sys.L2EL, types.LocalUnsafe, 50)
 
 	seqUnsafe := sys.L2EL.BlockRefByLabel(eth.Unsafe)
 	verUnsafe = sys.L2ELB.BlockRefByLabel(eth.Unsafe)

--- a/op-acceptance-tests/tests/sync/follow_l2/sync_test.go
+++ b/op-acceptance-tests/tests/sync/follow_l2/sync_test.go
@@ -46,8 +46,8 @@ func TestFollowL2_Safe_Finalized_CurrentL1(gt *testing.T) {
 			sys.L2CLC.ReachedFn(lvl, target, attempts),
 		)
 		dsl.CheckAll(t,
-			sys.L2CLB.MatchedFn(sys.L2CL, lvl, attempts),
-			sys.L2CLB.MatchedFn(sys.L2CLC, lvl, attempts),
+			sys.L2CLB.InSyncFn(sys.L2CL, lvl, attempts),
+			sys.L2CLB.InSyncFn(sys.L2CLC, lvl, attempts),
 		)
 	}
 
@@ -150,10 +150,10 @@ func TestFollowL2_ReorgRecovery(gt *testing.T) {
 
 	attempts := 30
 	dsl.CheckAll(t,
-		sys.L2CL.MatchedFn(sys.L2CLB, types.LocalUnsafe, attempts),
-		sys.L2CLC.MatchedFn(sys.L2CLB, types.LocalUnsafe, attempts),
-		sys.L2CL.MatchedFn(sys.L2CLB, types.LocalSafe, attempts),
-		sys.L2CLC.MatchedFn(sys.L2CLB, types.LocalSafe, attempts),
+		sys.L2CL.InSyncFn(sys.L2CLB, types.LocalUnsafe, attempts),
+		sys.L2CLC.InSyncFn(sys.L2CLB, types.LocalUnsafe, attempts),
+		sys.L2CL.InSyncFn(sys.L2CLB, types.LocalSafe, attempts),
+		sys.L2CLC.InSyncFn(sys.L2CLB, types.LocalSafe, attempts),
 	)
 }
 
@@ -226,11 +226,11 @@ func TestFollowL2_WithoutCLP2P(gt *testing.T) {
 	// Sequencer unsafe payload will arrive to the verifier, triggering EL sync and filling in the unsafe gap
 	dsl.CheckAll(t,
 		// Match with sequencer with derivation disabled
-		sys.L2CLC.MatchedFn(sys.L2CL, types.LocalSafe, attempts),
-		sys.L2CLC.MatchedFn(sys.L2CL, types.LocalUnsafe, attempts),
+		sys.L2CLC.InSyncFn(sys.L2CL, types.LocalSafe, attempts),
+		sys.L2CLC.InSyncFn(sys.L2CL, types.LocalUnsafe, attempts),
 		// Match with other verifier with derivation enabled
-		sys.L2CLC.MatchedFn(sys.L2CLB, types.LocalSafe, attempts),
-		sys.L2CLC.MatchedFn(sys.L2CLB, types.LocalUnsafe, attempts),
+		sys.L2CLC.InSyncFn(sys.L2CLB, types.LocalSafe, attempts),
+		sys.L2CLC.InSyncFn(sys.L2CLB, types.LocalUnsafe, attempts),
 	)
 
 	t.Cleanup(func() {

--- a/op-devstack/dsl/check.go
+++ b/op-devstack/dsl/check.go
@@ -31,6 +31,10 @@ type SyncStatusProvider interface {
 	String() string
 }
 
+type ChainBlockProvider interface {
+	ChainBlockID(chainID eth.ChainID, number uint64) (eth.BlockID, error)
+}
+
 var _ SyncStatusProvider = (*L2CLNode)(nil)
 var _ SyncStatusProvider = (*Supervisor)(nil)
 
@@ -81,6 +85,47 @@ func MatchedFn(baseNode, refNode SyncStatusProvider, log log.Logger, ctx context
 				}
 				logger.Info("Node sync status", "base", base.Number, "ref", ref.Number)
 				return fmt.Errorf("expected head to match: %s", lvl)
+			})
+	}
+}
+
+// InSyncFn checks that baseNode has incorporated the refNode head observed when the check starts.
+// Unlike MatchedFn, this does not require both live heads to be equal in the same polling tick.
+func InSyncFn(baseNode, refNode SyncStatusProvider, log log.Logger, ctx context.Context, lvl types.SafetyLevel, chainID eth.ChainID, attempts int) CheckFunc {
+	return func() error {
+		target := refNode.ChainSyncStatus(chainID, lvl)
+		logger := log.With("base_id", baseNode, "ref_id", refNode, "chain", chainID, "label", lvl, "target", target)
+		logger.Info("Expecting node to sync to reference")
+		blockProvider, canVerifyCanonicalBlock := baseNode.(ChainBlockProvider)
+		return retry.Do0(ctx, attempts, &retry.FixedStrategy{Dur: 2 * time.Second},
+			func() error {
+				base := baseNode.ChainSyncStatus(chainID, lvl)
+				if base.Number < target.Number {
+					logger.Info("Node sync status", "base", base.Number, "target", target.Number)
+					return fmt.Errorf("expected head to reach reference: %s", lvl)
+				}
+				if base.Number == target.Number {
+					if base.Hash == target.Hash {
+						logger.Info("Node reached reference", "target", target.Number)
+						return nil
+					}
+					logger.Info("Node reached target number with different hash", "base", base, "target", target)
+					return fmt.Errorf("expected head to match reference at target number: %s", lvl)
+				}
+				if !canVerifyCanonicalBlock {
+					return fmt.Errorf("base head advanced past reference but canonical block cannot be verified: %s", lvl)
+				}
+				block, err := blockProvider.ChainBlockID(chainID, target.Number)
+				if err != nil {
+					logger.Warn("Failed to fetch canonical block at reference height; will retry", "err", err)
+					return err
+				}
+				if block.Hash == target.Hash {
+					logger.Info("Node includes reference", "target", target.Number, "base", base.Number)
+					return nil
+				}
+				logger.Info("Node has different canonical block at reference height", "base_block", block, "target", target)
+				return fmt.Errorf("expected canonical block to match reference: %s", lvl)
 			})
 	}
 }

--- a/op-devstack/dsl/l2_cl.go
+++ b/op-devstack/dsl/l2_cl.go
@@ -373,6 +373,15 @@ func (cl *L2CLNode) ChainSyncStatus(chainID eth.ChainID, lvl types.SafetyLevel) 
 	return cl.HeadBlockRef(lvl).ID()
 }
 
+func (cl *L2CLNode) ChainBlockID(chainID eth.ChainID, number uint64) (eth.BlockID, error) {
+	cl.require.Equal(chainID, cl.inner.ChainID(), "chain ID mismatch")
+	ref, err := cl.inner.ELClient().BlockRefByNumber(cl.ctx, number)
+	if err != nil {
+		return eth.BlockID{}, err
+	}
+	return ref.ID(), nil
+}
+
 func (cl *L2CLNode) safeHeadAtL1Block(l1BlockNum uint64) *eth.SafeHeadResponse {
 	resp, err := cl.inner.RollupAPI().SafeHeadAtL1Block(cl.ctx, l1BlockNum)
 	if errors.Is(err, safedb.ErrNotFound) {
@@ -394,12 +403,20 @@ func (cl *L2CLNode) MatchedFn(refNode SyncStatusProvider, lvl types.SafetyLevel,
 	return MatchedFn(cl, refNode, cl.log, cl.ctx, lvl, cl.ChainID(), attempts)
 }
 
+func (cl *L2CLNode) InSyncFn(refNode SyncStatusProvider, lvl types.SafetyLevel, attempts int) CheckFunc {
+	return InSyncFn(cl, refNode, cl.log, cl.ctx, lvl, cl.ChainID(), attempts)
+}
+
 func (cl *L2CLNode) Lagged(refNode SyncStatusProvider, lvl types.SafetyLevel, attempts int, allowMatch bool) {
 	cl.require.NoError(cl.LaggedFn(refNode, lvl, attempts, allowMatch)())
 }
 
 func (cl *L2CLNode) Matched(refNode SyncStatusProvider, lvl types.SafetyLevel, attempts int) {
 	cl.require.NoError(cl.MatchedFn(refNode, lvl, attempts)())
+}
+
+func (cl *L2CLNode) InSync(refNode SyncStatusProvider, lvl types.SafetyLevel, attempts int) {
+	cl.require.NoError(cl.InSyncFn(refNode, lvl, attempts)())
 }
 
 func (cl *L2CLNode) MatchedUnsafe(refNode SyncStatusProvider, attempts int) {

--- a/op-devstack/dsl/l2_el.go
+++ b/op-devstack/dsl/l2_el.go
@@ -461,6 +461,15 @@ func (el *L2ELNode) ChainSyncStatus(chainID eth.ChainID, lvl suptypes.SafetyLeve
 	return blockRef.ID()
 }
 
+func (el *L2ELNode) ChainBlockID(chainID eth.ChainID, number uint64) (eth.BlockID, error) {
+	el.require.Equal(chainID, el.inner.ChainID(), "chain ID mismatch")
+	ref, err := el.inner.L2EthClient().L2BlockRefByNumber(el.ctx, number)
+	if err != nil {
+		return eth.BlockID{}, err
+	}
+	return ref.ID(), nil
+}
+
 // WaitForReceipt waits for a transaction receipt to be available, retrying until found or timeout.
 func (el *L2ELNode) WaitForReceipt(txHash common.Hash) *types.Receipt {
 	var receipt *types.Receipt
@@ -480,8 +489,16 @@ func (el *L2ELNode) MatchedFn(refNode SyncStatusProvider, lvl suptypes.SafetyLev
 	return MatchedFn(el, refNode, el.log, el.ctx, lvl, el.ChainID(), attempts)
 }
 
+func (el *L2ELNode) InSyncFn(refNode SyncStatusProvider, lvl suptypes.SafetyLevel, attempts int) CheckFunc {
+	return InSyncFn(el, refNode, el.log, el.ctx, lvl, el.ChainID(), attempts)
+}
+
 func (el *L2ELNode) Matched(refNode SyncStatusProvider, lvl suptypes.SafetyLevel, attempts int) {
 	el.require.NoError(el.MatchedFn(refNode, lvl, attempts)())
+}
+
+func (el *L2ELNode) InSync(refNode SyncStatusProvider, lvl suptypes.SafetyLevel, attempts int) {
+	el.require.NoError(el.InSyncFn(refNode, lvl, attempts)())
 }
 
 func (el *L2ELNode) MatchedUnsafe(refNode SyncStatusProvider, attempts int) {


### PR DESCRIPTION
## Tool Use Notice
Generated. Reviewed the InSyncFn and am generally happy with it. Didn't take as close a look at the tests which got the updated call.

## Summary

Adds a new `InSync` / `InSyncFn` DSL check for tests that need one node to catch up to another while both heads may still be advancing.

Unlike `Matched`, `InSync` snapshots the reference head once, waits for the base node to reach at least that height, and verifies that the sampled reference block is canonical on the base node. This avoids flakes where two live heads are in sync but not sampled at the exact same head in the same polling tick.

## Updated Tests

| Test | Previous `Matched` usage | Why `InSync` is a better fit |
|---|---|---|
| `TestFollowL2_Safe_Finalized_CurrentL1` | Follower/source checks for `LocalUnsafe`, `LocalSafe`, and `Finalized` | The test needs followers to catch up to source heads, not exact live-head equality. |
| `TestFollowL2_ReorgRecovery` | Post-reorg convergence checks for `LocalUnsafe` and `LocalSafe` | Convergence is satisfied once the sampled canonical head is incorporated. |
| `TestFollowL2_WithoutCLP2P` | Final recovery checks after CLP2P reconnect | The assertion is that the unsafe gap is filled, not that actively progressing heads are sampled equal. |
| `TestUnsafeGapFillAfterSafeReorg` | Safe reorg recovery and final unsafe gap closure | The test checks catch-up after reorg/backfill, which should tolerate continued progression. |
| `TestUnsafeGapFillAfterUnsafeReorg_RestartL2CL` | Setup alignment and final unsafe gap closure | Avoids races while preserving the check that the verifier includes the sequencer’s canonical block. |
| `TestUnsafeGapFillAfterUnsafeReorg_RestartCLP2P` | Setup alignment and final unsafe gap closure | Same catch-up behavior without requiring exact same polling tick. |
| `TestELSyncSafeRetractedByOffset` | Initial `LocalSafe` alignment before EL wipe | This is setup synchronization, so catch-up to a sampled reference is sufficient. |
| `TestFollowSource_P2PSync` | Final follower/source `LocalUnsafe` match | The test cares that the follower catches up via P2P. |
| `TestTruncateDatabaseOnELResync` | Initial and post-resync `LocalSafe` checks | These are synchronization gates before SafeDB assertions. |
| `TestNotTruncateDatabaseOnRestartWithExistingDatabase` | Initial and post-restart `LocalSafe` checks | These are synchronization gates before SafeDB assertions. |
| `TestPreserveDatabaseOnCLResync` | Pre/post-resync `LocalSafe` checks | These are synchronization gates before SafeDB assertions. |
| `TestUnsafeChainUnknownToL2CL` | Final verifier catch-up after reconnect | The test needs the verifier to include previously unknown unsafe blocks. |
| `TestFollowSource_HeadsDivergeThenConverge` | Initial, paused, and final follower/source checks | The follower should include the source chain state even while heads continue advancing. |

## Test Plan

- `go test ./op-devstack/dsl ./op-acceptance-tests/tests/sync/follow_l2 ./op-acceptance-tests/tests/sync/elsync/reorg ./op-acceptance-tests/tests/sync/elsync/offset_el_safe ./op-acceptance-tests/tests/supernode/interop/follow_l2 ./op-acceptance-tests/tests/safeheaddb_elsync ./op-acceptance-tests/tests/safeheaddb_clsync ./op-acceptance-tests/tests/interop/sync/multisupervisor_interop -run '^$'`