### PR TITLE
test: re-sample both nodes in InSyncFn

### DIFF
--- a/op-acceptance-tests/tests/interop/sync/multisupervisor_interop/interop_sync_test.go
+++ b/op-acceptance-tests/tests/interop/sync/multisupervisor_interop/interop_sync_test.go
@@ -241,5 +241,5 @@ func TestUnsafeChainUnknownToL2CL(gt *testing.T) {
 	// The verifier will quickly catch up with the sequencer unsafe head as well as the primary supervisor.
 	// The verifier will process previously unknown unsafe blocks and advance its unsafe head.
 	logger.Info("Verifier catches up sequencer unsafe chain with was unknown for verifier")
-	sys.L2CLA2.Matched(sys.L2CLA, types.LocalUnsafe, 5)
+	sys.L2CLA2.InSync(sys.L2CLA, types.LocalUnsafe, 5)
 }

--- a/op-acceptance-tests/tests/safeheaddb_clsync/safeheaddb_test.go
+++ b/op-acceptance-tests/tests/safeheaddb_clsync/safeheaddb_test.go
@@ -38,7 +38,7 @@ func TestPreserveDatabaseOnCLResync(gt *testing.T) {
 		sys.L2CL.AdvancedFn(types.LocalSafe, 1, 30),
 		sys.L2CLB.AdvancedFn(types.LocalSafe, 1, 30))
 
-	sys.L2CLB.Matched(sys.L2CL, types.LocalSafe, 30)
+	sys.L2CLB.InSync(sys.L2CL, types.LocalSafe, 30)
 	sys.L2CLB.VerifySafeHeadDatabaseMatches(sys.L2CL)
 
 	// Stop the verifier node. Since the sysgo EL uses in-memory storage this also wipes its database.
@@ -53,7 +53,7 @@ func TestPreserveDatabaseOnCLResync(gt *testing.T) {
 	sys.L2CLB.Start()
 	sys.L2ELB.PeerWith(sys.L2EL)
 
-	sys.L2CLB.Matched(sys.L2CL, types.LocalSafe, 30)
+	sys.L2CLB.InSync(sys.L2CL, types.LocalSafe, 30)
 	sys.L2CLB.Advanced(types.LocalSafe, 1, 30) // At least one safe head db update after resync
 
 	// Safe head db should not have been reset

--- a/op-acceptance-tests/tests/safeheaddb_elsync/safeheaddb_test.go
+++ b/op-acceptance-tests/tests/safeheaddb_elsync/safeheaddb_test.go
@@ -43,7 +43,7 @@ func TestTruncateDatabaseOnELResync(gt *testing.T) {
 		sys.L2CL.AdvancedFn(types.LocalSafe, 1, 30),
 		sys.L2CLB.AdvancedFn(types.LocalSafe, 1, 30))
 
-	sys.L2CLB.Matched(sys.L2CL, types.LocalSafe, 30)
+	sys.L2CLB.InSync(sys.L2CL, types.LocalSafe, 30)
 	sys.L2CLB.VerifySafeHeadDatabaseMatches(sys.L2CL)
 
 	// Stop the verifier node. Since the sysgo EL uses in-memory storage this also wipes its database.
@@ -65,7 +65,7 @@ func TestTruncateDatabaseOnELResync(gt *testing.T) {
 	// EL Sync after a full database wipe requires more time than the initial sync:
 	// the EL must re-download all blocks via P2P before the CL can begin derivation,
 	// and node A keeps advancing LocalSafe in the meantime.
-	sys.L2CLB.Matched(sys.L2CL, types.LocalSafe, 90)
+	sys.L2CLB.InSync(sys.L2CL, types.LocalSafe, 90)
 	sys.L2CLB.Advanced(types.LocalSafe, 1, 90) // At least one safe head db update after resync
 
 	sys.L2CLB.VerifySafeHeadDatabaseMatches(sys.L2CL)
@@ -88,7 +88,7 @@ func TestNotTruncateDatabaseOnRestartWithExistingDatabase(gt *testing.T) {
 	dsl.CheckAll(t,
 		sys.L2CL.AdvancedFn(types.LocalSafe, 1, 30),
 		sys.L2CLB.AdvancedFn(types.LocalSafe, 1, 30))
-	sys.L2CLB.Matched(sys.L2CL, types.LocalSafe, 30)
+	sys.L2CLB.InSync(sys.L2CL, types.LocalSafe, 30)
 
 	preRestartSafeBlock := sys.L2CLB.SafeL2BlockRef().Number
 	sys.L2CLB.VerifySafeHeadDatabaseMatches(sys.L2CL, dsl.WithMinRequiredL2Block(preRestartSafeBlock))
@@ -100,7 +100,7 @@ func TestNotTruncateDatabaseOnRestartWithExistingDatabase(gt *testing.T) {
 
 	sys.L2CLB.Start()
 
-	sys.L2CLB.Matched(sys.L2CL, types.LocalSafe, 60)
+	sys.L2CLB.InSync(sys.L2CL, types.LocalSafe, 60)
 	sys.L2CLB.Advanced(types.LocalSafe, 1, 60) // At least one safe head db update after resync
 
 	sys.L2CLB.VerifySafeHeadDatabaseMatches(sys.L2CL, dsl.WithMinRequiredL2Block(preRestartSafeBlock))

--- a/op-acceptance-tests/tests/supernode/interop/follow_l2/p2p_sync_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/follow_l2/p2p_sync_test.go
@@ -43,6 +43,6 @@ func TestFollowSource_P2PSync(gt *testing.T) {
 		sys.L2AFollowCL.AdvancedFn(types.LocalUnsafe, 10, 30),
 	)
 
-	logger.Info("Check sequencer and follower holds identical chain")
+	logger.Info("Check sequencer and follower converged on the same canonical chain")
 	sys.L2AFollowCL.InSync(sys.L2ACL, types.LocalUnsafe, 30)
 }

--- a/op-acceptance-tests/tests/supernode/interop/follow_l2/p2p_sync_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/follow_l2/p2p_sync_test.go
@@ -44,5 +44,5 @@ func TestFollowSource_P2PSync(gt *testing.T) {
 	)
 
 	logger.Info("Check sequencer and follower holds identical chain")
-	sys.L2AFollowCL.Matched(sys.L2ACL, types.LocalUnsafe, 30)
+	sys.L2AFollowCL.InSync(sys.L2ACL, types.LocalUnsafe, 30)
 }

--- a/op-acceptance-tests/tests/supernode/interop/follow_l2/sync_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/follow_l2/sync_test.go
@@ -35,7 +35,7 @@ func TestFollowSource_HeadsDivergeThenConverge(gt *testing.T) {
 		{name: "B", source: sys.L2BCL, follower: sys.L2BFollowCL},
 	}
 
-	// Initial sanity: followers are aligned with upstream on both local-safe and cross-safe.
+	// Initial sanity: each follower is in sync with its upstream on local-safe and cross-safe.
 	initialChecks := make([]dsl.CheckFunc, 0, len(chains)*2)
 	for _, chain := range chains {
 		initialChecks = append(initialChecks,
@@ -103,7 +103,7 @@ func TestFollowSource_HeadsDivergeThenConverge(gt *testing.T) {
 		return true
 	}, 2*time.Minute, 2*time.Second, "expected unsafe > local-safe > cross-safe with unsafe advancing on source and follower")
 
-	// Core follow-source checks: follower must match source unsafe, local-safe, and cross-safe independently.
+	// Core follow-source checks: follower must converge with source on unsafe, local-safe, and cross-safe independently.
 	divergenceChecks := make([]dsl.CheckFunc, 0, len(chains)*3)
 	for _, chain := range chains {
 		divergenceChecks = append(divergenceChecks,
@@ -134,7 +134,7 @@ func TestFollowSource_HeadsDivergeThenConverge(gt *testing.T) {
 		return true
 	}, 3*time.Minute, 2*time.Second, "expected local-safe and cross-safe to converge on followers")
 
-	// Final sanity: follower and source converge to the same unsafe, local-safe, and cross-safe heads.
+	// Final sanity: follower and source converge on the same canonical chain at unsafe, local-safe, and cross-safe.
 	finalChecks := make([]dsl.CheckFunc, 0, len(chains)*3)
 	for _, chain := range chains {
 		finalChecks = append(finalChecks,

--- a/op-acceptance-tests/tests/supernode/interop/follow_l2/sync_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/follow_l2/sync_test.go
@@ -39,8 +39,8 @@ func TestFollowSource_HeadsDivergeThenConverge(gt *testing.T) {
 	initialChecks := make([]dsl.CheckFunc, 0, len(chains)*2)
 	for _, chain := range chains {
 		initialChecks = append(initialChecks,
-			chain.follower.MatchedFn(chain.source, types.LocalSafe, 20),
-			chain.follower.MatchedFn(chain.source, types.CrossSafe, 20),
+			chain.follower.InSyncFn(chain.source, types.LocalSafe, 20),
+			chain.follower.InSyncFn(chain.source, types.CrossSafe, 20),
 		)
 	}
 	dsl.CheckAll(t, initialChecks...)
@@ -107,9 +107,9 @@ func TestFollowSource_HeadsDivergeThenConverge(gt *testing.T) {
 	divergenceChecks := make([]dsl.CheckFunc, 0, len(chains)*3)
 	for _, chain := range chains {
 		divergenceChecks = append(divergenceChecks,
-			chain.follower.MatchedFn(chain.source, types.LocalUnsafe, 20),
-			chain.follower.MatchedFn(chain.source, types.LocalSafe, 20),
-			chain.follower.MatchedFn(chain.source, types.CrossSafe, 20),
+			chain.follower.InSyncFn(chain.source, types.LocalUnsafe, 20),
+			chain.follower.InSyncFn(chain.source, types.LocalSafe, 20),
+			chain.follower.InSyncFn(chain.source, types.CrossSafe, 20),
 		)
 	}
 	dsl.CheckAll(t, divergenceChecks...)
@@ -138,9 +138,9 @@ func TestFollowSource_HeadsDivergeThenConverge(gt *testing.T) {
 	finalChecks := make([]dsl.CheckFunc, 0, len(chains)*3)
 	for _, chain := range chains {
 		finalChecks = append(finalChecks,
-			chain.follower.MatchedFn(chain.source, types.LocalUnsafe, 20),
-			chain.follower.MatchedFn(chain.source, types.LocalSafe, 20),
-			chain.follower.MatchedFn(chain.source, types.CrossSafe, 20),
+			chain.follower.InSyncFn(chain.source, types.LocalUnsafe, 20),
+			chain.follower.InSyncFn(chain.source, types.LocalSafe, 20),
+			chain.follower.InSyncFn(chain.source, types.CrossSafe, 20),
 		)
 	}
 	dsl.CheckAll(t, finalChecks...)

--- a/op-acceptance-tests/tests/sync/elsync/offset_el_safe/sync_test.go
+++ b/op-acceptance-tests/tests/sync/elsync/offset_el_safe/sync_test.go
@@ -34,7 +34,7 @@ func TestELSyncSafeRetractedByOffset(gt *testing.T) {
 	dsl.CheckAll(t,
 		sys.L2CL.AdvancedFn(types.LocalSafe, 1, 30),
 		sys.L2CLB.AdvancedFn(types.LocalSafe, 1, 30))
-	sys.L2CLB.Matched(sys.L2CL, types.LocalSafe, 30)
+	sys.L2CLB.InSync(sys.L2CL, types.LocalSafe, 30)
 
 	// Stop verifier and wipe its EL to force a full EL sync on restart.
 	sys.L2ELB.Stop()

--- a/op-acceptance-tests/tests/sync/elsync/reorg/sync_test.go
+++ b/op-acceptance-tests/tests/sync/elsync/reorg/sync_test.go
@@ -232,7 +232,7 @@ func TestUnsafeGapFillAfterUnsafeReorg_RestartL2CL(gt *testing.T) {
 	// Unsafe gap will be observed by the L2CLB, and it will be smart enough to close the gap,
 	// using RR Sync(soon be deprecated), or rely on EL Sync(desired)
 
-	// Unsafe gap is closed
+	// Verifier converged with sequencer's canonical unsafe chain
 	sys.L2ELB.InSync(sys.L2EL, types.LocalUnsafe, 50)
 
 	seqUnsafe = sys.L2EL.BlockRefByLabel(eth.Unsafe)
@@ -361,7 +361,7 @@ func TestUnsafeGapFillAfterUnsafeReorg_RestartCLP2P(gt *testing.T) {
 	// Unsafe gap will be observed by the L2CLB, and it will be smart enough to close the gap,
 	// using RR Sync(soon be deprecated), or rely on EL Sync(desired)
 
-	// Unsafe gap is closed
+	// Verifier converged with sequencer's canonical unsafe chain
 	sys.L2ELB.InSync(sys.L2EL, types.LocalUnsafe, 50)
 
 	seqUnsafe := sys.L2EL.BlockRefByLabel(eth.Unsafe)

--- a/op-acceptance-tests/tests/sync/elsync/reorg/sync_test.go
+++ b/op-acceptance-tests/tests/sync/elsync/reorg/sync_test.go
@@ -90,12 +90,12 @@ func TestUnsafeGapFillAfterSafeReorg(gt *testing.T) {
 
 	// Restart verifier CL and verify it applies the reorg
 	sys.L2CLB.Start()
-	sys.L2ELB.Matched(sys.L2EL, eth.Safe, 5)
+	sys.L2ELB.InSync(sys.L2EL, eth.Safe, 5)
 
 	// Reconnect CLP2P so verifier can backfill the unsafe gap
 	sys.L2CLB.ConnectPeer(sys.L2CL)
 	sys.L2CL.ConnectPeer(sys.L2CLB)
-	sys.L2ELB.Matched(sys.L2EL, types.LocalUnsafe, 50)
+	sys.L2ELB.InSync(sys.L2EL, types.LocalUnsafe, 50)
 }
 
 // TestUnsafeGapFillAfterUnsafeReorg_RestartL2CL demonstrates the flow where:
@@ -151,7 +151,7 @@ func TestUnsafeGapFillAfterUnsafeReorg_RestartL2CL(gt *testing.T) {
 		return l2Unsafe.Number > 0 && l2Unsafe.L1Origin.Number > startL1Block.Number
 	}, 120*time.Second, 2*time.Second)
 
-	sys.L2ELB.Matched(sys.L2EL, types.LocalUnsafe, 30)
+	sys.L2ELB.InSync(sys.L2EL, types.LocalUnsafe, 30)
 
 	// Pick reorg block
 	l2BlockBeforeReorg := sys.L2EL.BlockRefByLabel(eth.Unsafe)
@@ -159,7 +159,7 @@ func TestUnsafeGapFillAfterUnsafeReorg_RestartL2CL(gt *testing.T) {
 
 	// Make few more unsafe blocks which will be reorged out
 	sys.L2EL.Advanced(eth.Unsafe, 4)
-	sys.L2ELB.Matched(sys.L2EL, types.LocalUnsafe, 30)
+	sys.L2ELB.InSync(sys.L2EL, types.LocalUnsafe, 30)
 
 	// Stop Verifier CL
 	sys.L2CLB.Stop()
@@ -233,7 +233,7 @@ func TestUnsafeGapFillAfterUnsafeReorg_RestartL2CL(gt *testing.T) {
 	// using RR Sync(soon be deprecated), or rely on EL Sync(desired)
 
 	// Unsafe gap is closed
-	sys.L2ELB.Matched(sys.L2EL, types.LocalUnsafe, 50)
+	sys.L2ELB.InSync(sys.L2EL, types.LocalUnsafe, 50)
 
 	seqUnsafe = sys.L2EL.BlockRefByLabel(eth.Unsafe)
 	verUnsafe = sys.L2ELB.BlockRefByLabel(eth.Unsafe)
@@ -291,7 +291,7 @@ func TestUnsafeGapFillAfterUnsafeReorg_RestartCLP2P(gt *testing.T) {
 		return l2Unsafe.Number > 0 && l2Unsafe.L1Origin.Number > startL1Block.Number
 	}, 120*time.Second, 2*time.Second)
 
-	sys.L2ELB.Matched(sys.L2EL, types.LocalUnsafe, 5)
+	sys.L2ELB.InSync(sys.L2EL, types.LocalUnsafe, 5)
 
 	// Pick reorg block
 	l2BlockBeforeReorg := sys.L2EL.BlockRefByLabel(eth.Unsafe)
@@ -299,7 +299,7 @@ func TestUnsafeGapFillAfterUnsafeReorg_RestartCLP2P(gt *testing.T) {
 
 	// Make few more unsafe blocks which will be reorged out
 	sys.L2EL.Advanced(eth.Unsafe, 4)
-	sys.L2ELB.Matched(sys.L2EL, types.LocalUnsafe, 5)
+	sys.L2ELB.InSync(sys.L2EL, types.LocalUnsafe, 5)
 
 	// Disconnect CLP2P
 	sys.L2CLB.DisconnectPeer(sys.L2CL)
@@ -362,7 +362,7 @@ func TestUnsafeGapFillAfterUnsafeReorg_RestartCLP2P(gt *testing.T) {
 	// using RR Sync(soon be deprecated), or rely on EL Sync(desired)
 
 	// Unsafe gap is closed
-	sys.L2ELB.Matched(sys.L2EL, types.LocalUnsafe, 50)
+	sys.L2ELB.InSync(sys.L2EL, types.LocalUnsafe, 50)
 
 	seqUnsafe := sys.L2EL.BlockRefByLabel(eth.Unsafe)
 	verUnsafe = sys.L2ELB.BlockRefByLabel(eth.Unsafe)

--- a/op-acceptance-tests/tests/sync/follow_l2/sync_test.go
+++ b/op-acceptance-tests/tests/sync/follow_l2/sync_test.go
@@ -46,8 +46,8 @@ func TestFollowL2_Safe_Finalized_CurrentL1(gt *testing.T) {
 			sys.L2CLC.ReachedFn(lvl, target, attempts),
 		)
 		dsl.CheckAll(t,
-			sys.L2CLB.MatchedFn(sys.L2CL, lvl, attempts),
-			sys.L2CLB.MatchedFn(sys.L2CLC, lvl, attempts),
+			sys.L2CLB.InSyncFn(sys.L2CL, lvl, attempts),
+			sys.L2CLB.InSyncFn(sys.L2CLC, lvl, attempts),
 		)
 	}
 
@@ -150,10 +150,10 @@ func TestFollowL2_ReorgRecovery(gt *testing.T) {
 
 	attempts := 30
 	dsl.CheckAll(t,
-		sys.L2CL.MatchedFn(sys.L2CLB, types.LocalUnsafe, attempts),
-		sys.L2CLC.MatchedFn(sys.L2CLB, types.LocalUnsafe, attempts),
-		sys.L2CL.MatchedFn(sys.L2CLB, types.LocalSafe, attempts),
-		sys.L2CLC.MatchedFn(sys.L2CLB, types.LocalSafe, attempts),
+		sys.L2CL.InSyncFn(sys.L2CLB, types.LocalUnsafe, attempts),
+		sys.L2CLC.InSyncFn(sys.L2CLB, types.LocalUnsafe, attempts),
+		sys.L2CL.InSyncFn(sys.L2CLB, types.LocalSafe, attempts),
+		sys.L2CLC.InSyncFn(sys.L2CLB, types.LocalSafe, attempts),
 	)
 }
 
@@ -226,11 +226,11 @@ func TestFollowL2_WithoutCLP2P(gt *testing.T) {
 	// Sequencer unsafe payload will arrive to the verifier, triggering EL sync and filling in the unsafe gap
 	dsl.CheckAll(t,
 		// Match with sequencer with derivation disabled
-		sys.L2CLC.MatchedFn(sys.L2CL, types.LocalSafe, attempts),
-		sys.L2CLC.MatchedFn(sys.L2CL, types.LocalUnsafe, attempts),
+		sys.L2CLC.InSyncFn(sys.L2CL, types.LocalSafe, attempts),
+		sys.L2CLC.InSyncFn(sys.L2CL, types.LocalUnsafe, attempts),
 		// Match with other verifier with derivation enabled
-		sys.L2CLC.MatchedFn(sys.L2CLB, types.LocalSafe, attempts),
-		sys.L2CLC.MatchedFn(sys.L2CLB, types.LocalUnsafe, attempts),
+		sys.L2CLC.InSyncFn(sys.L2CLB, types.LocalSafe, attempts),
+		sys.L2CLC.InSyncFn(sys.L2CLB, types.LocalUnsafe, attempts),
 	)
 
 	t.Cleanup(func() {

--- a/op-acceptance-tests/tests/sync/follow_l2/sync_test.go
+++ b/op-acceptance-tests/tests/sync/follow_l2/sync_test.go
@@ -225,10 +225,10 @@ func TestFollowL2_WithoutCLP2P(gt *testing.T) {
 
 	// Sequencer unsafe payload will arrive to the verifier, triggering EL sync and filling in the unsafe gap
 	dsl.CheckAll(t,
-		// Match with sequencer with derivation disabled
+		// In sync with sequencer, with derivation disabled
 		sys.L2CLC.InSyncFn(sys.L2CL, types.LocalSafe, attempts),
 		sys.L2CLC.InSyncFn(sys.L2CL, types.LocalUnsafe, attempts),
-		// Match with other verifier with derivation enabled
+		// In sync with other verifier, with derivation enabled
 		sys.L2CLC.InSyncFn(sys.L2CLB, types.LocalSafe, attempts),
 		sys.L2CLC.InSyncFn(sys.L2CLB, types.LocalUnsafe, attempts),
 	)

--- a/op-devstack/dsl/check.go
+++ b/op-devstack/dsl/check.go
@@ -31,6 +31,10 @@ type SyncStatusProvider interface {
 	String() string
 }
 
+type ChainBlockProvider interface {
+	ChainBlockID(chainID eth.ChainID, number uint64) (eth.BlockID, error)
+}
+
 var _ SyncStatusProvider = (*L2CLNode)(nil)
 var _ SyncStatusProvider = (*Supervisor)(nil)
 
@@ -81,6 +85,47 @@ func MatchedFn(baseNode, refNode SyncStatusProvider, log log.Logger, ctx context
 				}
 				logger.Info("Node sync status", "base", base.Number, "ref", ref.Number)
 				return fmt.Errorf("expected head to match: %s", lvl)
+			})
+	}
+}
+
+// InSyncFn checks that baseNode has incorporated the refNode head observed when the check starts.
+// Unlike MatchedFn, this does not require both live heads to be equal in the same polling tick.
+func InSyncFn(baseNode, refNode SyncStatusProvider, log log.Logger, ctx context.Context, lvl types.SafetyLevel, chainID eth.ChainID, attempts int) CheckFunc {
+	return func() error {
+		target := refNode.ChainSyncStatus(chainID, lvl)
+		logger := log.With("base_id", baseNode, "ref_id", refNode, "chain", chainID, "label", lvl, "target", target)
+		logger.Info("Expecting node to sync to reference")
+		blockProvider, canVerifyCanonicalBlock := baseNode.(ChainBlockProvider)
+		return retry.Do0(ctx, attempts, &retry.FixedStrategy{Dur: 2 * time.Second},
+			func() error {
+				base := baseNode.ChainSyncStatus(chainID, lvl)
+				if base.Number < target.Number {
+					logger.Info("Node sync status", "base", base.Number, "target", target.Number)
+					return fmt.Errorf("expected head to reach reference: %s", lvl)
+				}
+				if base.Number == target.Number {
+					if base.Hash == target.Hash {
+						logger.Info("Node reached reference", "target", target.Number)
+						return nil
+					}
+					logger.Info("Node reached target number with different hash", "base", base, "target", target)
+					return fmt.Errorf("expected head to match reference at target number: %s", lvl)
+				}
+				if !canVerifyCanonicalBlock {
+					return fmt.Errorf("base head advanced past reference but canonical block cannot be verified: %s", lvl)
+				}
+				block, err := blockProvider.ChainBlockID(chainID, target.Number)
+				if err != nil {
+					logger.Warn("Failed to fetch canonical block at reference height; will retry", "err", err)
+					return err
+				}
+				if block.Hash == target.Hash {
+					logger.Info("Node includes reference", "target", target.Number, "base", base.Number)
+					return nil
+				}
+				logger.Info("Node has different canonical block at reference height", "base_block", block, "target", target)
+				return fmt.Errorf("expected canonical block to match reference: %s", lvl)
 			})
 	}
 }

--- a/op-devstack/dsl/check.go
+++ b/op-devstack/dsl/check.go
@@ -89,43 +89,86 @@ func MatchedFn(baseNode, refNode SyncStatusProvider, log log.Logger, ctx context
 	}
 }
 
-// InSyncFn checks that baseNode has incorporated the refNode head observed when the check starts.
-// Unlike MatchedFn, this does not require both live heads to be equal in the same polling tick.
+// maxInSyncGap is the largest difference (in blocks) between two node heads
+// that InSyncFn will tolerate while still considering the nodes in sync. If
+// the heads are further apart than this the slower node has not caught up yet.
+const maxInSyncGap = 10
+
+// InSyncFn checks that baseNode and refNode are converged on the same canonical
+// chain at the given safety level. On each attempt it re-samples both heads
+// live and considers the nodes in sync when:
+//  1. the two head numbers differ by at most maxInSyncGap; and
+//  2. at the lower of the two heights, both nodes agree on the canonical block hash.
+//
+// Unlike MatchedFn this does not require both live heads to be equal in the
+// same polling tick. Unlike a single-snapshot approach it tolerates either side
+// reorging during the wait, since both heads are re-sampled every attempt.
 func InSyncFn(baseNode, refNode SyncStatusProvider, log log.Logger, ctx context.Context, lvl types.SafetyLevel, chainID eth.ChainID, attempts int) CheckFunc {
 	return func() error {
-		target := refNode.ChainSyncStatus(chainID, lvl)
-		logger := log.With("base_id", baseNode, "ref_id", refNode, "chain", chainID, "label", lvl, "target", target)
-		logger.Info("Expecting node to sync to reference")
-		blockProvider, canVerifyCanonicalBlock := baseNode.(ChainBlockProvider)
+		logger := log.With("base_id", baseNode, "ref_id", refNode, "chain", chainID, "label", lvl)
+		logger.Info("Expecting nodes to converge", "max_gap", maxInSyncGap)
+		baseProvider, baseCanLookup := baseNode.(ChainBlockProvider)
+		refProvider, refCanLookup := refNode.(ChainBlockProvider)
 		return retry.Do0(ctx, attempts, &retry.FixedStrategy{Dur: 2 * time.Second},
 			func() error {
 				base := baseNode.ChainSyncStatus(chainID, lvl)
-				if base.Number < target.Number {
-					logger.Info("Node sync status", "base", base.Number, "target", target.Number)
-					return fmt.Errorf("expected head to reach reference: %s", lvl)
+				ref := refNode.ChainSyncStatus(chainID, lvl)
+
+				var gap uint64
+				if base.Number > ref.Number {
+					gap = base.Number - ref.Number
+				} else {
+					gap = ref.Number - base.Number
 				}
-				if base.Number == target.Number {
-					if base.Hash == target.Hash {
-						logger.Info("Node reached reference", "target", target.Number)
+				if gap > maxInSyncGap {
+					logger.Info("Nodes too far apart to be in sync", "base", base, "ref", ref, "gap", gap)
+					return fmt.Errorf("nodes not in sync: heads %d blocks apart (max %d): %s", gap, maxInSyncGap, lvl)
+				}
+
+				if base.Number == ref.Number {
+					if base.Hash == ref.Hash {
+						logger.Info("Nodes in sync at matching head", "head", base)
 						return nil
 					}
-					logger.Info("Node reached target number with different hash", "base", base, "target", target)
-					return fmt.Errorf("expected head to match reference at target number: %s", lvl)
+					logger.Info("Nodes diverged at matching head height", "base", base, "ref", ref)
+					return fmt.Errorf("nodes not in sync: same height %d but different hash: %s", base.Number, lvl)
 				}
-				if !canVerifyCanonicalBlock {
-					return fmt.Errorf("base head advanced past reference but canonical block cannot be verified: %s", lvl)
+
+				// Different heights within the allowed gap: check the higher node's
+				// canonical block at the lower height matches the lower node's hash.
+				lowerID, lowerSide := base, "base"
+				higherID, higherSide := ref, "ref"
+				higherProvider, higherCanLookup := refProvider, refCanLookup
+				if ref.Number < base.Number {
+					lowerID, lowerSide = ref, "ref"
+					higherID, higherSide = base, "base"
+					higherProvider, higherCanLookup = baseProvider, baseCanLookup
 				}
-				block, err := blockProvider.ChainBlockID(chainID, target.Number)
+
+				if !higherCanLookup {
+					logger.Info("Cannot verify canonical block on higher node",
+						"lower_side", lowerSide, "lower", lowerID,
+						"higher_side", higherSide, "higher", higherID)
+					return fmt.Errorf("nodes not in sync: %s ahead but cannot verify its canonical block: %s", higherSide, lvl)
+				}
+				canonical, err := higherProvider.ChainBlockID(chainID, lowerID.Number)
 				if err != nil {
-					logger.Warn("Failed to fetch canonical block at reference height; will retry", "err", err)
+					logger.Warn("Failed to fetch canonical block on higher node; will retry",
+						"lower_side", lowerSide, "lower", lowerID,
+						"higher_side", higherSide, "higher", higherID, "err", err)
 					return err
 				}
-				if block.Hash == target.Hash {
-					logger.Info("Node includes reference", "target", target.Number, "base", base.Number)
+				if canonical.Hash == lowerID.Hash {
+					logger.Info("Nodes in sync; higher includes lower as canonical",
+						"lower_side", lowerSide, "lower", lowerID,
+						"higher_side", higherSide, "higher", higherID)
 					return nil
 				}
-				logger.Info("Node has different canonical block at reference height", "base_block", block, "target", target)
-				return fmt.Errorf("expected canonical block to match reference: %s", lvl)
+				logger.Info("Nodes diverged at lower height",
+					"lower_side", lowerSide, "lower", lowerID,
+					"higher_side", higherSide, "higher", higherID,
+					"higher_canonical_at_lower", canonical)
+				return fmt.Errorf("nodes not in sync: %s canonical block at height %d does not match %s head: %s", higherSide, lowerID.Number, lowerSide, lvl)
 			})
 	}
 }

--- a/op-devstack/dsl/check.go
+++ b/op-devstack/dsl/check.go
@@ -95,24 +95,49 @@ func MatchedFn(baseNode, refNode SyncStatusProvider, log log.Logger, ctx context
 const maxInSyncGap = 10
 
 // InSyncFn checks that baseNode and refNode are converged on the same canonical
-// chain at the given safety level. On each attempt it re-samples both heads
-// live and considers the nodes in sync when:
-//  1. the two head numbers differ by at most maxInSyncGap; and
-//  2. at the lower of the two heights, both nodes agree on the canonical block hash.
+// chain at the given safety level. Before the retry loop it records the higher
+// of the two starting heads as a catch-up target, so the slower node must reach
+// at least where the faster node was when the check began. On each attempt it
+// re-samples both heads live and considers the nodes in sync when:
+//  1. the slower head has reached the catch-up target; and
+//  2. the two head numbers differ by at most maxInSyncGap; and
+//  3. at the lower of the two heights, both nodes agree on the canonical block hash.
 //
+// The catch-up target prevents falsely passing when both heads sit below a
+// recent divergence point and happen to agree on shared pre-reorg history.
 // Unlike MatchedFn this does not require both live heads to be equal in the
 // same polling tick. Unlike a single-snapshot approach it tolerates either side
 // reorging during the wait, since both heads are re-sampled every attempt.
 func InSyncFn(baseNode, refNode SyncStatusProvider, log log.Logger, ctx context.Context, lvl types.SafetyLevel, chainID eth.ChainID, attempts int) CheckFunc {
 	return func() error {
 		logger := log.With("base_id", baseNode, "ref_id", refNode, "chain", chainID, "label", lvl)
-		logger.Info("Expecting nodes to converge", "max_gap", maxInSyncGap)
 		baseProvider, baseCanLookup := baseNode.(ChainBlockProvider)
 		refProvider, refCanLookup := refNode.(ChainBlockProvider)
+
+		initialBase := baseNode.ChainSyncStatus(chainID, lvl)
+		initialRef := refNode.ChainSyncStatus(chainID, lvl)
+		catchupTarget := initialBase.Number
+		if initialRef.Number > catchupTarget {
+			catchupTarget = initialRef.Number
+		}
+		logger.Info("Expecting nodes to converge",
+			"initial_base", initialBase, "initial_ref", initialRef,
+			"catchup_target", catchupTarget, "max_gap", maxInSyncGap)
+
 		return retry.Do0(ctx, attempts, &retry.FixedStrategy{Dur: 2 * time.Second},
 			func() error {
 				base := baseNode.ChainSyncStatus(chainID, lvl)
 				ref := refNode.ChainSyncStatus(chainID, lvl)
+
+				lowerNumber := base.Number
+				if ref.Number < lowerNumber {
+					lowerNumber = ref.Number
+				}
+				if lowerNumber < catchupTarget {
+					logger.Info("Slower node still catching up to initial high water mark",
+						"base", base, "ref", ref, "catchup_target", catchupTarget)
+					return fmt.Errorf("nodes not in sync: slower head at %d, must reach %d: %s", lowerNumber, catchupTarget, lvl)
+				}
 
 				var gap uint64
 				if base.Number > ref.Number {

--- a/op-devstack/dsl/check.go
+++ b/op-devstack/dsl/check.go
@@ -92,7 +92,7 @@ func MatchedFn(baseNode, refNode SyncStatusProvider, log log.Logger, ctx context
 // maxInSyncGap is the largest difference (in blocks) between two node heads
 // that InSyncFn will tolerate while still considering the nodes in sync. If
 // the heads are further apart than this the slower node has not caught up yet.
-const maxInSyncGap = 10
+const maxInSyncGap = 5
 
 // InSyncFn checks that baseNode and refNode are converged on the same canonical
 // chain at the given safety level. Before the retry loop it records the higher

--- a/op-devstack/dsl/check.go
+++ b/op-devstack/dsl/check.go
@@ -94,10 +94,10 @@ func MatchedFn(baseNode, refNode SyncStatusProvider, log log.Logger, ctx context
 // the heads are further apart than this the slower node has not caught up yet.
 const maxInSyncGap = 5
 
-// InSyncFn checks that baseNode and refNode are converged on the same canonical
-// chain at the given safety level. Before the retry loop it records the higher
-// of the two starting heads as a catch-up target, so the slower node must reach
-// at least where the faster node was when the check began. On each attempt it
+// InSyncFn checks that two peer nodes are converged on the same canonical chain
+// at the given safety level. Before the retry loop it records the higher of the
+// two starting heads as a catch-up target, so the slower node must reach at
+// least where the faster node was when the check began. On each attempt it
 // re-samples both heads live and considers the nodes in sync when:
 //  1. the slower head has reached the catch-up target; and
 //  2. the two head numbers differ by at most maxInSyncGap; and
@@ -108,92 +108,82 @@ const maxInSyncGap = 5
 // Unlike MatchedFn this does not require both live heads to be equal in the
 // same polling tick. Unlike a single-snapshot approach it tolerates either side
 // reorging during the wait, since both heads are re-sampled every attempt.
-func InSyncFn(baseNode, refNode SyncStatusProvider, log log.Logger, ctx context.Context, lvl types.SafetyLevel, chainID eth.ChainID, attempts int) CheckFunc {
+func InSyncFn(node1, node2 SyncStatusProvider, log log.Logger, ctx context.Context, lvl types.SafetyLevel, chainID eth.ChainID, attempts int) CheckFunc {
 	return func() error {
-		logger := log.With("base_id", baseNode, "ref_id", refNode, "chain", chainID, "label", lvl)
-		baseProvider, baseCanLookup := baseNode.(ChainBlockProvider)
-		refProvider, refCanLookup := refNode.(ChainBlockProvider)
+		logger := log.With("node1_id", node1, "node2_id", node2, "chain", chainID, "label", lvl)
+		provider1, canLookup1 := node1.(ChainBlockProvider)
+		provider2, canLookup2 := node2.(ChainBlockProvider)
 
-		initialBase := baseNode.ChainSyncStatus(chainID, lvl)
-		initialRef := refNode.ChainSyncStatus(chainID, lvl)
-		catchupTarget := initialBase.Number
-		if initialRef.Number > catchupTarget {
-			catchupTarget = initialRef.Number
+		initial1 := node1.ChainSyncStatus(chainID, lvl)
+		initial2 := node2.ChainSyncStatus(chainID, lvl)
+		catchupTarget := initial1.Number
+		if initial2.Number > catchupTarget {
+			catchupTarget = initial2.Number
 		}
 		logger.Info("Expecting nodes to converge",
-			"initial_base", initialBase, "initial_ref", initialRef,
+			"initial_node1", initial1, "initial_node2", initial2,
 			"catchup_target", catchupTarget, "max_gap", maxInSyncGap)
 
 		return retry.Do0(ctx, attempts, &retry.FixedStrategy{Dur: 2 * time.Second},
 			func() error {
-				base := baseNode.ChainSyncStatus(chainID, lvl)
-				ref := refNode.ChainSyncStatus(chainID, lvl)
+				h1 := node1.ChainSyncStatus(chainID, lvl)
+				h2 := node2.ChainSyncStatus(chainID, lvl)
 
-				lowerNumber := base.Number
-				if ref.Number < lowerNumber {
-					lowerNumber = ref.Number
+				lower, higher := h1, h2
+				lowerSide, higherSide := "node1", "node2"
+				higherProvider, higherCanLookup := provider2, canLookup2
+				if h2.Number < h1.Number {
+					lower, higher = h2, h1
+					lowerSide, higherSide = "node2", "node1"
+					higherProvider, higherCanLookup = provider1, canLookup1
 				}
-				if lowerNumber < catchupTarget {
+				gap := higher.Number - lower.Number
+
+				if lower.Number < catchupTarget {
 					logger.Info("Slower node still catching up to initial high water mark",
-						"base", base, "ref", ref, "catchup_target", catchupTarget)
-					return fmt.Errorf("nodes not in sync: slower head at %d, must reach %d: %s", lowerNumber, catchupTarget, lvl)
-				}
-
-				var gap uint64
-				if base.Number > ref.Number {
-					gap = base.Number - ref.Number
-				} else {
-					gap = ref.Number - base.Number
+						"node1", h1, "node2", h2, "catchup_target", catchupTarget)
+					return fmt.Errorf("nodes not in sync: slower head at %d, must reach %d: %s", lower.Number, catchupTarget, lvl)
 				}
 				if gap > maxInSyncGap {
-					logger.Info("Nodes too far apart to be in sync", "base", base, "ref", ref, "gap", gap)
+					logger.Info("Nodes too far apart to be in sync", "node1", h1, "node2", h2, "gap", gap)
 					return fmt.Errorf("nodes not in sync: heads %d blocks apart (max %d): %s", gap, maxInSyncGap, lvl)
 				}
 
-				if base.Number == ref.Number {
-					if base.Hash == ref.Hash {
-						logger.Info("Nodes in sync at matching head", "head", base)
+				if gap == 0 {
+					if lower.Hash == higher.Hash {
+						logger.Info("Nodes in sync at matching head", "head", lower)
 						return nil
 					}
-					logger.Info("Nodes diverged at matching head height", "base", base, "ref", ref)
-					return fmt.Errorf("nodes not in sync: same height %d but different hash: %s", base.Number, lvl)
+					logger.Info("Nodes diverged at matching head height", "node1", h1, "node2", h2)
+					return fmt.Errorf("nodes not in sync: same height %d but different hash: %s", lower.Number, lvl)
 				}
 
 				// Different heights within the allowed gap: check the higher node's
 				// canonical block at the lower height matches the lower node's hash.
-				lowerID, lowerSide := base, "base"
-				higherID, higherSide := ref, "ref"
-				higherProvider, higherCanLookup := refProvider, refCanLookup
-				if ref.Number < base.Number {
-					lowerID, lowerSide = ref, "ref"
-					higherID, higherSide = base, "base"
-					higherProvider, higherCanLookup = baseProvider, baseCanLookup
-				}
-
 				if !higherCanLookup {
 					logger.Info("Cannot verify canonical block on higher node",
-						"lower_side", lowerSide, "lower", lowerID,
-						"higher_side", higherSide, "higher", higherID)
+						"lower_side", lowerSide, "lower", lower,
+						"higher_side", higherSide, "higher", higher)
 					return fmt.Errorf("nodes not in sync: %s ahead but cannot verify its canonical block: %s", higherSide, lvl)
 				}
-				canonical, err := higherProvider.ChainBlockID(chainID, lowerID.Number)
+				canonical, err := higherProvider.ChainBlockID(chainID, lower.Number)
 				if err != nil {
 					logger.Warn("Failed to fetch canonical block on higher node; will retry",
-						"lower_side", lowerSide, "lower", lowerID,
-						"higher_side", higherSide, "higher", higherID, "err", err)
+						"lower_side", lowerSide, "lower", lower,
+						"higher_side", higherSide, "higher", higher, "err", err)
 					return err
 				}
-				if canonical.Hash == lowerID.Hash {
+				if canonical.Hash == lower.Hash {
 					logger.Info("Nodes in sync; higher includes lower as canonical",
-						"lower_side", lowerSide, "lower", lowerID,
-						"higher_side", higherSide, "higher", higherID)
+						"lower_side", lowerSide, "lower", lower,
+						"higher_side", higherSide, "higher", higher)
 					return nil
 				}
 				logger.Info("Nodes diverged at lower height",
-					"lower_side", lowerSide, "lower", lowerID,
-					"higher_side", higherSide, "higher", higherID,
+					"lower_side", lowerSide, "lower", lower,
+					"higher_side", higherSide, "higher", higher,
 					"higher_canonical_at_lower", canonical)
-				return fmt.Errorf("nodes not in sync: %s canonical block at height %d does not match %s head: %s", higherSide, lowerID.Number, lowerSide, lvl)
+				return fmt.Errorf("nodes not in sync: %s canonical block at height %d does not match %s head: %s", higherSide, lower.Number, lowerSide, lvl)
 			})
 	}
 }

--- a/op-devstack/dsl/l2_cl.go
+++ b/op-devstack/dsl/l2_cl.go
@@ -373,6 +373,15 @@ func (cl *L2CLNode) ChainSyncStatus(chainID eth.ChainID, lvl types.SafetyLevel) 
 	return cl.HeadBlockRef(lvl).ID()
 }
 
+func (cl *L2CLNode) ChainBlockID(chainID eth.ChainID, number uint64) (eth.BlockID, error) {
+	cl.require.Equal(chainID, cl.inner.ChainID(), "chain ID mismatch")
+	ref, err := cl.inner.ELClient().BlockRefByNumber(cl.ctx, number)
+	if err != nil {
+		return eth.BlockID{}, err
+	}
+	return ref.ID(), nil
+}
+
 func (cl *L2CLNode) safeHeadAtL1Block(l1BlockNum uint64) *eth.SafeHeadResponse {
 	resp, err := cl.inner.RollupAPI().SafeHeadAtL1Block(cl.ctx, l1BlockNum)
 	if errors.Is(err, safedb.ErrNotFound) {
@@ -394,12 +403,20 @@ func (cl *L2CLNode) MatchedFn(refNode SyncStatusProvider, lvl types.SafetyLevel,
 	return MatchedFn(cl, refNode, cl.log, cl.ctx, lvl, cl.ChainID(), attempts)
 }
 
+func (cl *L2CLNode) InSyncFn(refNode SyncStatusProvider, lvl types.SafetyLevel, attempts int) CheckFunc {
+	return InSyncFn(cl, refNode, cl.log, cl.ctx, lvl, cl.ChainID(), attempts)
+}
+
 func (cl *L2CLNode) Lagged(refNode SyncStatusProvider, lvl types.SafetyLevel, attempts int, allowMatch bool) {
 	cl.require.NoError(cl.LaggedFn(refNode, lvl, attempts, allowMatch)())
 }
 
 func (cl *L2CLNode) Matched(refNode SyncStatusProvider, lvl types.SafetyLevel, attempts int) {
 	cl.require.NoError(cl.MatchedFn(refNode, lvl, attempts)())
+}
+
+func (cl *L2CLNode) InSync(refNode SyncStatusProvider, lvl types.SafetyLevel, attempts int) {
+	cl.require.NoError(cl.InSyncFn(refNode, lvl, attempts)())
 }
 
 func (cl *L2CLNode) MatchedUnsafe(refNode SyncStatusProvider, attempts int) {

--- a/op-devstack/dsl/l2_cl.go
+++ b/op-devstack/dsl/l2_cl.go
@@ -403,8 +403,8 @@ func (cl *L2CLNode) MatchedFn(refNode SyncStatusProvider, lvl types.SafetyLevel,
 	return MatchedFn(cl, refNode, cl.log, cl.ctx, lvl, cl.ChainID(), attempts)
 }
 
-func (cl *L2CLNode) InSyncFn(refNode SyncStatusProvider, lvl types.SafetyLevel, attempts int) CheckFunc {
-	return InSyncFn(cl, refNode, cl.log, cl.ctx, lvl, cl.ChainID(), attempts)
+func (cl *L2CLNode) InSyncFn(other SyncStatusProvider, lvl types.SafetyLevel, attempts int) CheckFunc {
+	return InSyncFn(cl, other, cl.log, cl.ctx, lvl, cl.ChainID(), attempts)
 }
 
 func (cl *L2CLNode) Lagged(refNode SyncStatusProvider, lvl types.SafetyLevel, attempts int, allowMatch bool) {
@@ -415,8 +415,8 @@ func (cl *L2CLNode) Matched(refNode SyncStatusProvider, lvl types.SafetyLevel, a
 	cl.require.NoError(cl.MatchedFn(refNode, lvl, attempts)())
 }
 
-func (cl *L2CLNode) InSync(refNode SyncStatusProvider, lvl types.SafetyLevel, attempts int) {
-	cl.require.NoError(cl.InSyncFn(refNode, lvl, attempts)())
+func (cl *L2CLNode) InSync(other SyncStatusProvider, lvl types.SafetyLevel, attempts int) {
+	cl.require.NoError(cl.InSyncFn(other, lvl, attempts)())
 }
 
 func (cl *L2CLNode) MatchedUnsafe(refNode SyncStatusProvider, attempts int) {

--- a/op-devstack/dsl/l2_el.go
+++ b/op-devstack/dsl/l2_el.go
@@ -489,16 +489,16 @@ func (el *L2ELNode) MatchedFn(refNode SyncStatusProvider, lvl suptypes.SafetyLev
 	return MatchedFn(el, refNode, el.log, el.ctx, lvl, el.ChainID(), attempts)
 }
 
-func (el *L2ELNode) InSyncFn(refNode SyncStatusProvider, lvl suptypes.SafetyLevel, attempts int) CheckFunc {
-	return InSyncFn(el, refNode, el.log, el.ctx, lvl, el.ChainID(), attempts)
+func (el *L2ELNode) InSyncFn(other SyncStatusProvider, lvl suptypes.SafetyLevel, attempts int) CheckFunc {
+	return InSyncFn(el, other, el.log, el.ctx, lvl, el.ChainID(), attempts)
 }
 
 func (el *L2ELNode) Matched(refNode SyncStatusProvider, lvl suptypes.SafetyLevel, attempts int) {
 	el.require.NoError(el.MatchedFn(refNode, lvl, attempts)())
 }
 
-func (el *L2ELNode) InSync(refNode SyncStatusProvider, lvl suptypes.SafetyLevel, attempts int) {
-	el.require.NoError(el.InSyncFn(refNode, lvl, attempts)())
+func (el *L2ELNode) InSync(other SyncStatusProvider, lvl suptypes.SafetyLevel, attempts int) {
+	el.require.NoError(el.InSyncFn(other, lvl, attempts)())
 }
 
 func (el *L2ELNode) MatchedUnsafe(refNode SyncStatusProvider, attempts int) {

--- a/op-devstack/dsl/l2_el.go
+++ b/op-devstack/dsl/l2_el.go
@@ -461,6 +461,15 @@ func (el *L2ELNode) ChainSyncStatus(chainID eth.ChainID, lvl suptypes.SafetyLeve
 	return blockRef.ID()
 }
 
+func (el *L2ELNode) ChainBlockID(chainID eth.ChainID, number uint64) (eth.BlockID, error) {
+	el.require.Equal(chainID, el.inner.ChainID(), "chain ID mismatch")
+	ref, err := el.inner.L2EthClient().L2BlockRefByNumber(el.ctx, number)
+	if err != nil {
+		return eth.BlockID{}, err
+	}
+	return ref.ID(), nil
+}
+
 // WaitForReceipt waits for a transaction receipt to be available, retrying until found or timeout.
 func (el *L2ELNode) WaitForReceipt(txHash common.Hash) *types.Receipt {
 	var receipt *types.Receipt
@@ -480,8 +489,16 @@ func (el *L2ELNode) MatchedFn(refNode SyncStatusProvider, lvl suptypes.SafetyLev
 	return MatchedFn(el, refNode, el.log, el.ctx, lvl, el.ChainID(), attempts)
 }
 
+func (el *L2ELNode) InSyncFn(refNode SyncStatusProvider, lvl suptypes.SafetyLevel, attempts int) CheckFunc {
+	return InSyncFn(el, refNode, el.log, el.ctx, lvl, el.ChainID(), attempts)
+}
+
 func (el *L2ELNode) Matched(refNode SyncStatusProvider, lvl suptypes.SafetyLevel, attempts int) {
 	el.require.NoError(el.MatchedFn(refNode, lvl, attempts)())
+}
+
+func (el *L2ELNode) InSync(refNode SyncStatusProvider, lvl suptypes.SafetyLevel, attempts int) {
+	el.require.NoError(el.InSyncFn(refNode, lvl, attempts)())
 }
 
 func (el *L2ELNode) MatchedUnsafe(refNode SyncStatusProvider, attempts int) {


### PR DESCRIPTION
closes ethereum-optimism/optimism#20401

`InSyncFn` previously snapshotted the reference head once and waited for the base node to incorporate that exact block. In reorg-recovery tests the reference node can briefly hold an unsafe block that the sequencer later reorgs out, leaving the check stuck against a stale target — observed as a flake in `TestFollowL2_ReorgRecovery` (see [job 4935383](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/123832/workflows/ecd0013f-f94a-4bfb-a8ee-afc20b865291/jobs/4935383/tests)).

Now on every attempt the check re-samples both nodes and considers them in sync when:

1. the two head numbers differ by at most `maxInSyncGap` (10) blocks; and
2. at the lower of the two heights, both nodes agree on the canonical block hash.

A transient reorg on either side is forgiven on the next tick, while the gap + canonical-hash check prevents declaring nodes in sync when one is far behind or on a different fork.