### PR TITLE
fix(kona): align chain list test with registry data

### DIFF
--- a/rust/kona/crates/protocol/genesis/src/superchain/chain_list.rs
+++ b/rust/kona/crates/protocol/genesis/src/superchain/chain_list.rs
@@ -129,7 +129,7 @@ mod tests {
     fn read_chain_list_file() {
         let chain_list = include_str!("../../../registry/etc/chainList.json");
         let chains: Vec<Chain> = serde_json::from_str(chain_list).unwrap();
-        let base_chain = chains.iter().find(|c| c.name == "Base").unwrap();
-        assert_eq!(base_chain.chain_id, 8453);
+        let op_chain = chains.iter().find(|c| c.name == "OP Mainnet").unwrap();
+        assert_eq!(op_chain.chain_id, 10);
     }
 }


### PR DESCRIPTION
The `read_chain_list_file` test in `kona-genesis` looks up `"Base"` in the embedded `chainList.json`, but Base was removed from the registry in #20366 and the cleanup PR #20393 missed this test. CI fails on any branch that runs `kona-genesis` tests against current `develop`.

Switches the lookup to OP Mainnet, which is the canonical entry to assert against. Fix authored by @karlfloersch (already present in #20398, lifted out here so it can land standalone and unblock other PRs).