### PR TITLE
feat(op-acceptance): after-chain-head tests anchored on settled state (alt to #20349)

### DIFF
--- a/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
+++ b/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
@@ -177,8 +177,9 @@ func freezeAndMeasure(
 
 	// Margin must be ≥ max chain block time so that for every chain c,
 	// TargetBlockNumber(ttest) > UnsafeL2.Number — i.e. the supernode returns
-	// NotFound at ttest (and ttest+1) for every chain. Hard-coding "2" here
-	// would silently break tests 5/6 the moment someone adds a 3s chain.
+	// NotFound at ttest (and ttest+1) for every chain. Today's presets use
+	// block times of 1 s and 2 s; max block time + 1 covers both with one
+	// second of slack.
 	maxBlockTime := uint64(0)
 	for _, c := range chains {
 		if c.Cfg.BlockTime > maxBlockTime {
@@ -191,23 +192,8 @@ func freezeAndMeasure(
 		ttest = endTimestamp + 2
 	}
 
-	// Defensive: ttest+1 must stay strictly inside the trace window
-	// [startTimestamp, claimTimestamp). claimTimestamp in buildAfterChainHeadTests
-	// is endTimestamp+100; if a pathological scheduling pause pushed maxUnsafeTs
-	// that close to claimTimestamp, the trace index for test 6 would land outside
-	// the trace and fail with a confusing out-of-range error rather than the
-	// InvalidTransition the test expects. Surface the real problem here.
-	t.Require().Lessf(ttest+1, endTimestamp+afterChainHeadClaimTimestampOffset,
-		"ttest=%d too close to claimTimestamp=%d; chain overshot during freeze",
-		ttest, endTimestamp+afterChainHeadClaimTimestampOffset)
-
 	return boundaryTimestamp, l1HeadAdvanced, ttest
 }
-
-// afterChainHeadClaimTimestampOffset is the offset past endTimestamp at which the
-// after-chain-head subtests anchor their claim timestamp. Defined here so
-// freezeAndMeasure can bound ttest+1 strictly inside the trace.
-const afterChainHeadClaimTimestampOffset = 100
 
 // superRootAtTimestamp constructs a SuperV1 from each chain's output at the given timestamp.
 func superRootAtTimestamp(t devtest.T, chains []*chain, timestamp uint64) eth.SuperV1 {
@@ -528,7 +514,13 @@ func buildAfterChainHeadTests(
 	// root won't be either, and InvalidTransition cascades to later steps.
 	endBoundaryVerified := boundaryResp.Data != nil && boundaryResp.Data.VerifiedRequiredL1.Number <= l1HeadCurrent.Number
 
-	claimTimestamp := endTimestamp + afterChainHeadClaimTimestampOffset
+	// claimTimestamp is derived from ttest so the trace window covers every
+	// index this helper produces, regardless of how far past endTimestamp the
+	// chains overshot during the pre-freeze choreography. The buffer just needs
+	// to be ≥ 2 so the trace contains both consolidateAfterHeadIdx (timestamp
+	// ttest) and optimisticAfterHeadIdx (timestamp ttest+1, step ≥ 1).
+	const claimBuffer = 5
+	claimTimestamp := ttest + claimBuffer
 
 	// Trace indices for ttest. The trace index → (timestamp, step) mapping is:
 	//   timestamp = startTimestamp + (idx+1)/stepsPerTimestamp

--- a/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
+++ b/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
@@ -112,31 +112,18 @@ func nextTimestampAfterSafeHeads(t devtest.T, chains []*chain) uint64 {
 	return ts
 }
 
-// freezeAndMeasure runs at the end of Stage 2 (with both batchers and both sequencers
-// still running) and produces the deterministic anchor points the after-chain-head
-// subtests need: a validated boundary timestamp, the L1 head that derives it, and a
-// timestamp strictly past every chain's settled unsafe head.
-//
-// Sequence:
-//  1. Wait for every chain's LocalSafe to cover boundaryTimestamp (= endTimestamp+1).
-//     For chains where TargetBlockNumber rounds boundaryTimestamp down to endTimestamp's
-//     block (e.g. 2s blocks at an odd boundary), Reached returns immediately. For 1s
-//     chains we wait one more block. AwaitValidatedTimestamp confirms the supernode
-//     accepts the query.
-//  2. Stop both batchers, then stop both sequencers, then WaitForStall on both
-//     LocalUnsafe and LocalSafe for every chain. The wait-for-stalls absorb arbitrary
-//     scheduling pauses (each requires ≥10s of stable head with a 2-min budget), so
-//     even a 60s pause anywhere between earlier statements cannot leave one chain
-//     ahead of the other in a way the freeze doesn't notice.
-//  3. Read each chain's settled UnsafeL2 timestamp directly from SyncStatus and pick
-//     ttest = max(settled) + margin. Sequencers are stopped, so no chain can produce
-//     more blocks; ttest stays past every chain's head forever.
+// freezeAndMeasure produces the deterministic anchor points the after-chain-head
+// subtests need: a validated boundary timestamp, the L1 head that derives it, and
+// a timestamp strictly past every chain's settled unsafe head. It waits for the
+// boundary timestamp to land on every chain's LocalSafe, stops the batchers and
+// sequencers, waits for both safety levels to stall, then returns max(settled) +
+// margin where margin ≥ max chain block time.
 func freezeAndMeasure(
 	t devtest.T,
 	sys *presets.SimpleInterop,
 	chains []*chain,
 	endTimestamp uint64,
-) (boundaryTimestamp uint64, l1HeadAdvanced eth.BlockID, ttest uint64) {
+) (boundaryTimestamp uint64, l1HeadAdvanced eth.BlockID, afterHeadTimestamp uint64) {
 	boundaryTimestamp = endTimestamp + 1
 
 	// Both batchers are still running at this point. Wait for boundaryTimestamp's
@@ -176,23 +163,14 @@ func freezeAndMeasure(
 	}
 
 	// Margin must be ≥ max chain block time so that for every chain c,
-	// TargetBlockNumber(ttest) > UnsafeL2.Number — i.e. the supernode returns
-	// NotFound at ttest (and ttest+1) for every chain. Today's presets use
-	// block times of 1 s and 2 s; max block time + 1 covers both with one
-	// second of slack.
-	maxBlockTime := uint64(0)
-	for _, c := range chains {
-		if c.Cfg.BlockTime > maxBlockTime {
-			maxBlockTime = c.Cfg.BlockTime
-		}
-	}
-	margin := maxBlockTime + 1
-	ttest = maxUnsafeTs + margin
-	if ttest < endTimestamp+2 {
-		ttest = endTimestamp + 2
-	}
+	// TargetBlockNumber(afterHeadTimestamp) > UnsafeL2.Number — i.e. the supernode
+	// returns NotFound at afterHeadTimestamp (and afterHeadTimestamp+1) for every
+	// chain. Today's presets use block times of 1 s and 2 s; So 3 covers both with
+	// one second of slack.
+	margin := uint64(3)
+	afterHeadTimestamp = max(maxUnsafeTs+margin, endTimestamp+2)
 
-	return boundaryTimestamp, l1HeadAdvanced, ttest
+	return boundaryTimestamp, l1HeadAdvanced, afterHeadTimestamp
 }
 
 // superRootAtTimestamp constructs a SuperV1 from each chain's output at the given timestamp.
@@ -487,16 +465,17 @@ func buildTransitionTests(
 // answer queries at boundaryTimestamp from l1HeadCurrent depends on devstack timing,
 // so the test logic queries actual derivability rather than predicting it.
 //
-// Tests 5/6 anchor on ttest, computed in freezeAndMeasure as a timestamp strictly
-// past every chain's settled unsafe head. After Stage 2b's freeze, sequencers are
-// stopped — no chain can ever have a block at ttest or ttest+1 — so the supernode
-// returns InvalidTransition at the corresponding trace indices regardless of any
+// Tests 5/6 anchor on afterHeadTimestamp, computed in freezeAndMeasure as a
+// timestamp strictly past every chain's settled unsafe head. After Stage 2b's
+// freeze, sequencers are stopped — no chain can ever have a block at
+// afterHeadTimestamp or afterHeadTimestamp+1 — so the supernode returns
+// InvalidTransition at the corresponding trace indices regardless of any
 // scheduling pauses elsewhere in the test.
 func buildAfterChainHeadTests(
 	sn *dsl.Supernode,
 	chains []*chain,
 	end, endBoundary eth.SuperV1,
-	endTimestamp, ttest uint64,
+	endTimestamp, afterHeadTimestamp uint64,
 	l1HeadCurrent, l1HeadAdvanced eth.BlockID,
 	firstOptimisticBoundary, secondOptimisticBoundary interopTypes.OptimisticBlock,
 ) []*transitionTest {
@@ -514,22 +493,24 @@ func buildAfterChainHeadTests(
 	// root won't be either, and InvalidTransition cascades to later steps.
 	endBoundaryVerified := boundaryResp.Data != nil && boundaryResp.Data.VerifiedRequiredL1.Number <= l1HeadCurrent.Number
 
-	// claimTimestamp is derived from ttest so the trace window covers every
-	// index this helper produces, regardless of how far past endTimestamp the
-	// chains overshot during the pre-freeze choreography. The buffer just needs
-	// to be ≥ 2 so the trace contains both consolidateAfterHeadIdx (timestamp
-	// ttest) and optimisticAfterHeadIdx (timestamp ttest+1, step ≥ 1).
+	// claimTimestamp is derived from afterHeadTimestamp so the trace window
+	// covers every index this helper produces, regardless of how far past
+	// endTimestamp the chains overshot during the pre-freeze choreography. The
+	// buffer just needs to be ≥ 2 so the trace contains both
+	// consolidateAfterHeadIdx (timestamp afterHeadTimestamp) and
+	// optimisticAfterHeadIdx (timestamp afterHeadTimestamp+1, step ≥ 1).
 	const claimBuffer = 5
-	claimTimestamp := ttest + claimBuffer
+	claimTimestamp := afterHeadTimestamp + claimBuffer
 
-	// Trace indices for ttest. The trace index → (timestamp, step) mapping is:
+	// Trace indices for afterHeadTimestamp. The trace index → (timestamp, step) mapping is:
 	//   timestamp = startTimestamp + (idx+1)/stepsPerTimestamp
 	//   step      = (idx+1) % stepsPerTimestamp
-	// Consolidation step (step=0) at timestamp ttest sits at idx (ttest - endTimestamp + 1)*sPT - 1.
-	// An optimistic step within the ttest → ttest+1 transition sits at the same
+	// Consolidation step (step=0) at timestamp afterHeadTimestamp sits at idx
+	// (afterHeadTimestamp - endTimestamp + 1)*sPT - 1. An optimistic step within
+	// the afterHeadTimestamp → afterHeadTimestamp+1 transition sits at the same
 	// timestamp+1 multiplier with step >= 1. We pick step=2 (chain-B optimistic)
 	// to mirror the original test layout (4*sPT - 1 / 4*sPT + 1).
-	timestampDelta := int64(ttest - endTimestamp + 1)
+	timestampDelta := int64(afterHeadTimestamp - endTimestamp + 1)
 	consolidateAfterHeadIdx := timestampDelta*stepsPerTimestamp - 1
 	optimisticAfterHeadIdx := timestampDelta*stepsPerTimestamp + 1
 
@@ -604,13 +585,13 @@ func buildAfterChainHeadTests(
 		ExpectValid:        true,
 	})
 
-	// Test 5: Consolidation step at ttest, where no chain has produced a block.
+	// Test 5: Consolidation step at afterHeadTimestamp, where no chain has produced a block.
 	// Anchored on the settled unsafe heads measured in Stage 2b after StopSequencer
 	// + WaitForStall, so the InvalidTransition expectation cannot be invalidated by
 	// further sequencer activity (sequencers are stopped). l1HeadAdvanced only
-	// covers boundaryTimestamp; ttest's data is not derivable. If the earlier
-	// boundary cascade already started at l1HeadCurrent (anyNotDerivable), keep
-	// using l1HeadCurrent so the cascade is consistent throughout.
+	// covers boundaryTimestamp; afterHeadTimestamp's data is not derivable. If the
+	// earlier boundary cascade already started at l1HeadCurrent (anyNotDerivable),
+	// keep using l1HeadCurrent so the cascade is consistent throughout.
 	l1HeadConsolidate := l1HeadAdvanced
 	if anyNotDerivable {
 		l1HeadConsolidate = l1HeadCurrent
@@ -625,10 +606,11 @@ func buildAfterChainHeadTests(
 		ExpectValid:        true,
 	})
 
-	// Test 6: Optimistic step (chain B) within the transition from ttest's
-	// super-root toward ttest+1's super-root. Same reasoning as test 5:
-	// neither ttest nor ttest+1 have any chain blocks (sequencers are stopped),
-	// so the trace provider returns InvalidTransition at this index.
+	// Test 6: Optimistic step (chain B) within the transition from
+	// afterHeadTimestamp's super-root toward afterHeadTimestamp+1's super-root.
+	// Same reasoning as test 5: neither afterHeadTimestamp nor
+	// afterHeadTimestamp+1 have any chain blocks (sequencers are stopped), so the
+	// trace provider returns InvalidTransition at this index.
 	tests = append(tests, &transitionTest{
 		Name:               "AgreedBlockAfterChainHead-Optimistic",
 		AgreedClaim:        super.InvalidTransition,
@@ -869,7 +851,7 @@ func RunSuperFaultProofTest(t devtest.T, sys *presets.SimpleInterop) {
 	// and their LocalUnsafe/LocalSafe heads have stalled, so the timestamps the
 	// after-chain-head tests anchor on cannot be invalidated by further chain
 	// activity. See freezeAndMeasure for the full justification.
-	boundaryTimestamp, l1HeadAdvanced, ttest := freezeAndMeasure(t, sys, chains, endTimestamp)
+	boundaryTimestamp, l1HeadAdvanced, afterHeadTimestamp := freezeAndMeasure(t, sys, chains, endTimestamp)
 
 	// --- Stage 3: Build expected transition states --------------------------
 	start := superRootAtTimestamp(t, chains, startTimestamp)
@@ -891,7 +873,7 @@ func RunSuperFaultProofTest(t devtest.T, sys *presets.SimpleInterop) {
 	tests := buildTransitionTests(start, end, step1, step2, padding,
 		l1HeadCurrent, l1HeadBefore, l1HeadAfterFirst, endTimestamp)
 	tests = append(tests, buildAfterChainHeadTests(
-		sys.SuperRoots, chains, end, endBoundary, endTimestamp, ttest, l1HeadCurrent, l1HeadAdvanced,
+		sys.SuperRoots, chains, end, endBoundary, endTimestamp, afterHeadTimestamp, l1HeadCurrent, l1HeadAdvanced,
 		firstOptimisticBoundary, secondOptimisticBoundary)...)
 
 	challengerCfg := sys.L2ChainA.Escape().L2Challengers()[0].Config()
@@ -970,7 +952,7 @@ func RunVariedBlockTimesTest(t devtest.T, sys *presets.SimpleInterop) {
 	// and their LocalUnsafe/LocalSafe heads have stalled, so the timestamps the
 	// after-chain-head tests anchor on cannot be invalidated by further chain
 	// activity. See freezeAndMeasure for the full justification.
-	boundaryTimestamp, l1HeadAdvanced, ttest := freezeAndMeasure(t, sys, chains, endTimestamp)
+	boundaryTimestamp, l1HeadAdvanced, afterHeadTimestamp := freezeAndMeasure(t, sys, chains, endTimestamp)
 
 	// -- Stage 3: Build expected transition states --------------------------
 	start := superRootAtTimestamp(t, chains, startTimestamp)
@@ -992,7 +974,7 @@ func RunVariedBlockTimesTest(t devtest.T, sys *presets.SimpleInterop) {
 	tests := buildTransitionTests(start, end, step1, step2, padding,
 		l1HeadCurrent, l1HeadBefore, l1HeadAfterFirst, endTimestamp)
 	tests = append(tests, buildAfterChainHeadTests(
-		sys.SuperRoots, chains, end, endBoundary, endTimestamp, ttest, l1HeadCurrent, l1HeadAdvanced,
+		sys.SuperRoots, chains, end, endBoundary, endTimestamp, afterHeadTimestamp, l1HeadCurrent, l1HeadAdvanced,
 		firstOptimisticBoundary, secondOptimisticBoundary)...)
 
 	challengerCfg := sys.L2ChainA.Escape().L2Challengers()[0].Config()

--- a/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
+++ b/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
@@ -112,6 +112,46 @@ func nextTimestampAfterSafeHeads(t devtest.T, chains []*chain) uint64 {
 	return ts
 }
 
+// minUnsafeTimestamp returns the lowest unsafe-head timestamp across the given chains,
+// adjusted forward (if necessary) to a timestamp at which every chain has produced a block.
+// Intended to be called after StopSequencer + WaitForStall(LocalUnsafe) on every chain so
+// the read is race-free.
+func minUnsafeTimestamp(t devtest.T, chains []*chain) uint64 {
+	ts := ^uint64(0)
+	for _, c := range chains {
+		status, err := c.Rollup.SyncStatus(t.Ctx())
+		t.Require().NoError(err)
+		head := c.Cfg.TimestampForBlock(status.UnsafeL2.Number)
+		if head < ts {
+			ts = head
+		}
+	}
+	t.Require().NotEqual(^uint64(0), ts, "no chains in dependency set")
+	t.Require().NotZero(ts, "unsafe timestamp must be non-zero")
+
+	// Walk back to a timestamp where every chain has produced a block strictly greater
+	// than at ts-1. Same shape as nextTimestampAfterSafeHeads: handles varied block times
+	// where the slower chain may not have a new block at the otherwise-chosen ts.
+	for {
+		allNew := true
+		for _, c := range chains {
+			curr, err := c.Cfg.TargetBlockNumber(ts)
+			t.Require().NoError(err)
+			prev, err := c.Cfg.TargetBlockNumber(ts - 1)
+			t.Require().NoError(err)
+			if curr <= prev {
+				allNew = false
+				break
+			}
+		}
+		if allNew {
+			break
+		}
+		ts--
+	}
+	return ts
+}
+
 // superRootAtTimestamp constructs a SuperV1 from each chain's output at the given timestamp.
 func superRootAtTimestamp(t devtest.T, chains []*chain, timestamp uint64) eth.SuperV1 {
 	sr := eth.SuperV1{Timestamp: timestamp, Chains: make([]eth.ChainIDAndOutput, len(chains))}
@@ -155,6 +195,14 @@ func latestRequiredL1(resp eth.SuperRootAtTimestampResponse) eth.BlockID {
 		}
 	}
 	return latest
+}
+
+// isOptimisticNotDerivable returns true if a chain's optimistic block at the queried
+// timestamp would yield InvalidTransition under the provided L1 head — either because
+// no entry exists for the chain or because the entry's RequiredL1 is past l1Head.
+func isOptimisticNotDerivable(resp eth.SuperRootAtTimestampResponse, chainID eth.ChainID, l1Head eth.BlockID) bool {
+	opt, ok := resp.OptimisticAtTimestamp[chainID]
+	return !ok || opt.RequiredL1.Number > l1Head.Number
 }
 
 // runKonaInteropProgram runs the kona interop fault proof program and checks the result.
@@ -385,6 +433,149 @@ func buildTransitionTests(
 	}
 }
 
+// buildAfterChainHeadTests constructs test cases for transitions whose disputed or
+// agreed timestamps lie past the validated chain head, exercising the proof system's
+// behavior when the L1 head can't (yet) derive the next-timestamp blocks.
+//
+// The trace structure is per-second (StepsPerTimestamp=128 sub-steps per L2 second),
+// regardless of chain block time. With sequencers stopped from Stage 1, no chain blocks
+// exist past endTimestamp; endTimestamp+1 is therefore a no-op transition (no chain
+// advances). The supernode validates this no-op as L1 produces blocks naturally.
+// l1HeadAdvanced is bounded to the L1 block where endTimestamp+1's data first appears,
+// which does NOT cover endTimestamp+2 and beyond — making tests 5/6 work.
+//
+// The test logic queries the supernode for actual derivability at l1HeadCurrent rather
+// than predicting it from block times, which keeps the cases robust to devstack timing
+// variations.
+func buildAfterChainHeadTests(
+	sn *dsl.Supernode,
+	chains []*chain,
+	end, endBoundary eth.SuperV1,
+	endTimestamp uint64,
+	l1HeadCurrent, l1HeadAdvanced eth.BlockID,
+	firstOptimisticBoundary, secondOptimisticBoundary interopTypes.OptimisticBlock,
+) []*transitionTest {
+	boundaryTimestamp := endTimestamp + 1
+
+	// Query the supernode for the boundary timestamp (endTimestamp+1) — used to decide
+	// whether the trace provider will return real states or InvalidTransition for tests
+	// using l1HeadCurrent.
+	boundaryResp := sn.SuperRootAtTimestamp(boundaryTimestamp)
+	firstNotDerivable := isOptimisticNotDerivable(boundaryResp, chains[0].ID, l1HeadCurrent)
+	anyNotDerivable := firstNotDerivable || isOptimisticNotDerivable(boundaryResp, chains[1].ID, l1HeadCurrent)
+
+	// Whether the consolidated super root at the boundary timestamp is verified with
+	// l1HeadCurrent. When any chain's optimistic block isn't derivable, the consolidated
+	// root won't be either, and InvalidTransition cascades to later steps.
+	endBoundaryVerified := boundaryResp.Data != nil && boundaryResp.Data.VerifiedRequiredL1.Number <= l1HeadCurrent.Number
+
+	claimTimestamp := endTimestamp + 100
+
+	tests := make([]*transitionTest, 0, 6)
+
+	// Test 1: First chain's optimistic block step at boundaryTimestamp.
+	// If chain A's block at boundaryTimestamp isn't derivable with l1HeadCurrent the
+	// transition is InvalidTransition; otherwise the transition state is valid.
+	disputedChainA := marshalTransition(end, 1, firstOptimisticBoundary)
+	if firstNotDerivable {
+		disputedChainA = super.InvalidTransition
+	}
+	tests = append(tests, &transitionTest{
+		Name:               "DisputeTimestampAfterChainHeadChainA",
+		AgreedClaim:        end.Marshal(),
+		DisputedClaim:      disputedChainA,
+		L1Head:             l1HeadCurrent,
+		ClaimTimestamp:     claimTimestamp,
+		DisputedTraceIndex: consolidateStep + 1,
+		ExpectValid:        true,
+	})
+
+	// Test 2: Second chain's optimistic block step at boundaryTimestamp.
+	// Uses l1HeadAdvanced which supports boundaryTimestamp's data.
+	tests = append(tests, &transitionTest{
+		Name:               "DisputeTimestampAfterChainHeadChainB",
+		AgreedClaim:        marshalTransition(end, 1, firstOptimisticBoundary),
+		DisputedClaim:      marshalTransition(end, 2, firstOptimisticBoundary, secondOptimisticBoundary),
+		L1Head:             l1HeadAdvanced,
+		ClaimTimestamp:     claimTimestamp,
+		DisputedTraceIndex: consolidateStep + 2,
+		ExpectValid:        true,
+	})
+
+	// Test 3: Consolidation step at boundaryTimestamp.
+	tests = append(tests, &transitionTest{
+		Name:               "DisputeTimestampAfterChainHeadConsolidate",
+		AgreedClaim:        marshalTransition(end, consolidateStep, firstOptimisticBoundary, secondOptimisticBoundary),
+		DisputedClaim:      endBoundary.Marshal(),
+		L1Head:             l1HeadAdvanced,
+		ClaimTimestamp:     claimTimestamp,
+		DisputedTraceIndex: 2*stepsPerTimestamp - 1,
+		ExpectValid:        true,
+	})
+
+	// Test 4: First chain's optimistic block step two timestamps ahead.
+	// When boundaryTimestamp isn't verified with l1HeadCurrent, InvalidTransition cascades.
+	// Otherwise check whether chain A's block at boundaryTimestamp+1 is derivable.
+	agreedBlockAfterHead := endBoundary.Marshal()
+	disputedBlockAfterHead := super.InvalidTransition
+	if !endBoundaryVerified {
+		// Consolidated root step (agreed claim at this index) already returned
+		// InvalidTransition, so everything after cascades.
+		agreedBlockAfterHead = super.InvalidTransition
+	} else {
+		nextNextResp := sn.SuperRootAtTimestamp(boundaryTimestamp + 1)
+		if !isOptimisticNotDerivable(nextNextResp, chains[0].ID, l1HeadCurrent) {
+			opt := nextNextResp.OptimisticAtTimestamp[chains[0].ID]
+			disputedBlockAfterHead = marshalTransition(endBoundary, 1, interopTypes.OptimisticBlock{
+				BlockHash:  opt.Output.BlockHash,
+				OutputRoot: opt.OutputRoot,
+			})
+		}
+	}
+	tests = append(tests, &transitionTest{
+		Name:               "DisputeBlockAfterChainHead-FirstChain",
+		AgreedClaim:        agreedBlockAfterHead,
+		DisputedClaim:      disputedBlockAfterHead,
+		L1Head:             l1HeadCurrent,
+		ClaimTimestamp:     claimTimestamp,
+		DisputedTraceIndex: 2 * stepsPerTimestamp,
+		ExpectValid:        true,
+	})
+
+	// Test 5: Consolidation step far past the chain head — at boundaryTimestamp+2
+	// (= endTimestamp+3). l1HeadAdvanced is bounded to boundaryTimestamp's data, so this
+	// far-out timestamp is not derivable and the trace provider returns InvalidTransition.
+	// If the earlier cascade already started at l1HeadCurrent (anyNotDerivable), keep
+	// using l1HeadCurrent so the cascade is consistent throughout.
+	l1HeadConsolidate := l1HeadAdvanced
+	if anyNotDerivable {
+		l1HeadConsolidate = l1HeadCurrent
+	}
+	tests = append(tests, &transitionTest{
+		Name:               "AgreedBlockAfterChainHead-Consolidate",
+		AgreedClaim:        super.InvalidTransition,
+		DisputedClaim:      super.InvalidTransition,
+		L1Head:             l1HeadConsolidate,
+		ClaimTimestamp:     claimTimestamp,
+		DisputedTraceIndex: 4*stepsPerTimestamp - 1,
+		ExpectValid:        true,
+	})
+
+	// Test 6: Optimistic block step far past the chain head — chain B optimistic
+	// of boundaryTimestamp+3 (= endTimestamp+4). Same reasoning as test 5.
+	tests = append(tests, &transitionTest{
+		Name:               "AgreedBlockAfterChainHead-Optimistic",
+		AgreedClaim:        super.InvalidTransition,
+		DisputedClaim:      super.InvalidTransition,
+		L1Head:             l1HeadAdvanced,
+		ClaimTimestamp:     claimTimestamp,
+		DisputedTraceIndex: 4*stepsPerTimestamp + 1,
+		ExpectValid:        true,
+	})
+
+	return tests
+}
+
 // RunTraceExtensionActivationTest verifies that trace extension correctly
 // activates (or not) based on whether the claim timestamp has been reached.
 func RunTraceExtensionActivationTest(t devtest.T, sys *presets.SimpleInterop) {
@@ -567,52 +758,76 @@ func RunSuperFaultProofTest(t devtest.T, sys *presets.SimpleInterop) {
 	chains := orderedChains(sys)
 	t.Require().Len(chains, 2, "expected exactly 2 interop chains")
 
-	// -- Stage 1: Freeze batch submission ----------------------------------
-	// Stop both batchers simultaneously, then wait for local-safe to stall on
-	// both chains. This ensures neither batcher submits data past the safe heads.
+	// -- Stage 1: Freeze the chains. Stop batchers and sequencers, wait for
+	// every safety level we read to stall, then derive endTimestamp from the
+	// (now-stable) unsafe heads. Reading after stop+stall is race-free.
 	chains[0].Batcher.Stop()
 	chains[1].Batcher.Stop()
+	chains[0].CLNode.StopSequencer()
+	chains[1].CLNode.StopSequencer()
+	chains[0].CLNode.WaitForStall(types.LocalUnsafe)
+	chains[1].CLNode.WaitForStall(types.LocalUnsafe)
 	chains[0].CLNode.WaitForStall(types.LocalSafe)
 	chains[1].CLNode.WaitForStall(types.LocalSafe)
 
-	endTimestamp := nextTimestampAfterSafeHeads(t, chains)
+	endTimestamp := minUnsafeTimestamp(t, chains)
 	startTimestamp := endTimestamp - 1
-
-	// Wait for both chains to produce the target blocks as unsafe.
-	// Sequencers keep running freely — the L1 head invariants are maintained
-	// by which batchers are running, not by stopping sequencers.
 	target0, err := chains[0].Cfg.TargetBlockNumber(endTimestamp)
 	t.Require().NoError(err)
 	target1, err := chains[1].Cfg.TargetBlockNumber(endTimestamp)
 	t.Require().NoError(err)
-	chains[0].EL.Reached(eth.Unsafe, target0, 60)
-	chains[1].EL.Reached(eth.Unsafe, target1, 60)
 
-	// -- Stage 2: Capture L1 heads via batcher choreography ----------------
-	// Batchers are stopped, so no batch data for endTimestamp is on L1.
+	// -- Stage 2: Capture L1 heads via batcher choreography. With unsafe heads
+	// bounded at endTimestamp, batchers can only submit data up to endTimestamp.
 	l1HeadBefore := sys.L1EL.BlockRefByLabel(eth.Unsafe).ID()
 
-	// Start chain[0]'s batcher and wait for its local-safe head to reach the target.
-	// Chain[1]'s batcher is still stopped, so only chain[0]'s data lands on L1.
-	// We wait on the CL local-safe label because the EL safe label only advances
-	// after interop validation, which requires all chains to have batch data.
+	// Start chain[0]'s batcher only — submits chain[0]'s data up to endTimestamp.
 	chains[0].Batcher.Start()
 	chains[0].CLNode.Reached(types.LocalSafe, target0, 60)
 	l1HeadAfterFirst := sys.L1EL.BlockRefByLabel(eth.Unsafe).ID()
 
-	// Start chain[1]'s batcher and wait for the supernode to validate, then
-	// wait for chain[1]'s safe head to reach its target.
+	// Start chain[1]'s batcher and wait for the supernode to validate.
 	chains[1].Batcher.Start()
 	sys.SuperRoots.AwaitValidatedTimestamp(endTimestamp)
 	chains[1].CLNode.Reached(types.LocalSafe, target1, 60)
 	l1HeadCurrent := sys.L1EL.BlockRefByLabel(eth.Unsafe).ID()
 
+	// -- Stage 2b: Validate the next-second boundary (endTimestamp+1).
+	// Chains with block time > 1s already have their latest block at endTimestamp;
+	// the supernode validates endTimestamp+1 as a no-op transition (no new chain
+	// blocks needed) once L1 advances naturally. Chains with block time = 1s
+	// require a fresh chain block at endTimestamp+1 — briefly restart their
+	// sequencer to produce it. The Reached → StopSequencer race is bounded to ~1
+	// block of overshoot; tests 5 & 6 target indices well past that margin.
+	boundaryTimestamp := endTimestamp + 1
+	for _, c := range chains {
+		if c.Cfg.BlockTime > 1 {
+			continue
+		}
+		target, err := c.Cfg.TargetBlockNumber(boundaryTimestamp)
+		t.Require().NoError(err)
+		status, err := c.Rollup.SyncStatus(t.Ctx())
+		t.Require().NoError(err)
+		if status.UnsafeL2.Number >= target {
+			continue
+		}
+		c.CLNode.StartSequencer()
+		c.EL.Reached(eth.Unsafe, target, 60)
+		c.CLNode.StopSequencer()
+		c.CLNode.WaitForStall(types.LocalUnsafe)
+	}
+	sys.SuperRoots.AwaitValidatedTimestamp(boundaryTimestamp)
+	l1HeadAdvanced := latestRequiredL1(sys.SuperRoots.SuperRootAtTimestamp(boundaryTimestamp))
+
 	// --- Stage 3: Build expected transition states --------------------------
 	start := superRootAtTimestamp(t, chains, startTimestamp)
 	end := superRootAtTimestamp(t, chains, endTimestamp)
+	endBoundary := superRootAtTimestamp(t, chains, boundaryTimestamp)
 
 	firstOptimistic := optimisticBlockAtTimestamp(t, sys.SuperRoots.QueryAPI(), chains[0].ID, endTimestamp)
 	secondOptimistic := optimisticBlockAtTimestamp(t, sys.SuperRoots.QueryAPI(), chains[1].ID, endTimestamp)
+	firstOptimisticBoundary := optimisticBlockAtTimestamp(t, sys.SuperRoots.QueryAPI(), chains[0].ID, boundaryTimestamp)
+	secondOptimisticBoundary := optimisticBlockAtTimestamp(t, sys.SuperRoots.QueryAPI(), chains[1].ID, boundaryTimestamp)
 
 	step1 := marshalTransition(start, 1, firstOptimistic)
 	step2 := marshalTransition(start, 2, firstOptimistic, secondOptimistic)
@@ -623,6 +838,9 @@ func RunSuperFaultProofTest(t devtest.T, sys *presets.SimpleInterop) {
 	// --- Stage 4: Transition test cases ------------------------------------
 	tests := buildTransitionTests(start, end, step1, step2, padding,
 		l1HeadCurrent, l1HeadBefore, l1HeadAfterFirst, endTimestamp)
+	tests = append(tests, buildAfterChainHeadTests(
+		sys.SuperRoots, chains, end, endBoundary, endTimestamp, l1HeadCurrent, l1HeadAdvanced,
+		firstOptimisticBoundary, secondOptimisticBoundary)...)
 
 	challengerCfg := sys.L2ChainA.Escape().L2Challengers()[0].Config()
 	gameDepth := sys.DisputeGameFactory().GameImpl(gameTypes.SuperCannonKonaGameType).SplitDepth()
@@ -655,52 +873,73 @@ func RunVariedBlockTimesTest(t devtest.T, sys *presets.SimpleInterop) {
 	t.Require().NotEqual(chains[0].Cfg.BlockTime, chains[1].Cfg.BlockTime,
 		"this test requires chains with different block times")
 
-	// -- Stage 1: Setup — both batchers stopped -----------------------------
-	// Stop both batchers simultaneously, then wait for local-safe to stall on
-	// both chains. This ensures neither batcher submits data past the safe heads.
+	// -- Stage 1: Freeze the chains. Stop batchers and sequencers, wait for
+	// every safety level we read to stall, then derive endTimestamp from the
+	// (now-stable) unsafe heads.
 	chains[0].Batcher.Stop()
 	chains[1].Batcher.Stop()
+	chains[0].CLNode.StopSequencer()
+	chains[1].CLNode.StopSequencer()
+	chains[0].CLNode.WaitForStall(types.LocalUnsafe)
+	chains[1].CLNode.WaitForStall(types.LocalUnsafe)
 	chains[0].CLNode.WaitForStall(types.LocalSafe)
 	chains[1].CLNode.WaitForStall(types.LocalSafe)
 
-	endTimestamp := nextTimestampAfterSafeHeads(t, chains)
+	endTimestamp := minUnsafeTimestamp(t, chains)
 	startTimestamp := endTimestamp - 1
-
-	// Wait for both chains to produce the target blocks as unsafe.
-	// Sequencers keep running freely — the L1 head invariants are maintained
-	// by which batchers are running, not by stopping sequencers.
 	target0, err := chains[0].Cfg.TargetBlockNumber(endTimestamp)
 	t.Require().NoError(err)
 	target1, err := chains[1].Cfg.TargetBlockNumber(endTimestamp)
 	t.Require().NoError(err)
-	chains[0].EL.Reached(eth.Unsafe, target0, 60)
-	chains[1].EL.Reached(eth.Unsafe, target1, 60)
 
 	// -- Stage 2: Capture L1 heads via batcher choreography ----------------
-	// Batchers are stopped, so no batch data for endTimestamp is on L1.
 	l1HeadBefore := sys.L1EL.BlockRefByLabel(eth.Unsafe).ID()
 
-	// Start chain[0]'s batcher and wait for its local-safe head to reach the target.
-	// Chain[1]'s batcher is still stopped, so only chain[0]'s data lands on L1.
-	// We wait on the CL local-safe label because the EL safe label only advances
-	// after interop validation, which requires all chains to have batch data.
 	chains[0].Batcher.Start()
 	chains[0].CLNode.Reached(types.LocalSafe, target0, 60)
 	l1HeadAfterFirst := sys.L1EL.BlockRefByLabel(eth.Unsafe).ID()
 
-	// Start chain[1]'s batcher and wait for the supernode to validate, then
-	// wait for chain[1]'s safe head to reach its target.
 	chains[1].Batcher.Start()
 	sys.SuperRoots.AwaitValidatedTimestamp(endTimestamp)
 	chains[1].CLNode.Reached(types.LocalSafe, target1, 60)
 	l1HeadCurrent := sys.L1EL.BlockRefByLabel(eth.Unsafe).ID()
 
+	// -- Stage 2b: Validate the next-second boundary (endTimestamp+1).
+	// Chains with block time > 1s already have their latest block at endTimestamp;
+	// the supernode validates endTimestamp+1 as a no-op transition (no new chain
+	// blocks needed) once L1 advances naturally. Chains with block time = 1s
+	// require a fresh chain block at endTimestamp+1 — briefly restart their
+	// sequencer to produce it. The Reached → StopSequencer race is bounded to ~1
+	// block of overshoot; tests 5 & 6 target indices well past that margin.
+	boundaryTimestamp := endTimestamp + 1
+	for _, c := range chains {
+		if c.Cfg.BlockTime > 1 {
+			continue
+		}
+		target, err := c.Cfg.TargetBlockNumber(boundaryTimestamp)
+		t.Require().NoError(err)
+		status, err := c.Rollup.SyncStatus(t.Ctx())
+		t.Require().NoError(err)
+		if status.UnsafeL2.Number >= target {
+			continue
+		}
+		c.CLNode.StartSequencer()
+		c.EL.Reached(eth.Unsafe, target, 60)
+		c.CLNode.StopSequencer()
+		c.CLNode.WaitForStall(types.LocalUnsafe)
+	}
+	sys.SuperRoots.AwaitValidatedTimestamp(boundaryTimestamp)
+	l1HeadAdvanced := latestRequiredL1(sys.SuperRoots.SuperRootAtTimestamp(boundaryTimestamp))
+
 	// -- Stage 3: Build expected transition states --------------------------
 	start := superRootAtTimestamp(t, chains, startTimestamp)
 	end := superRootAtTimestamp(t, chains, endTimestamp)
+	endBoundary := superRootAtTimestamp(t, chains, boundaryTimestamp)
 
 	firstOptimistic := optimisticBlockAtTimestamp(t, sys.SuperRoots.QueryAPI(), chains[0].ID, endTimestamp)
 	secondOptimistic := optimisticBlockAtTimestamp(t, sys.SuperRoots.QueryAPI(), chains[1].ID, endTimestamp)
+	firstOptimisticBoundary := optimisticBlockAtTimestamp(t, sys.SuperRoots.QueryAPI(), chains[0].ID, boundaryTimestamp)
+	secondOptimisticBoundary := optimisticBlockAtTimestamp(t, sys.SuperRoots.QueryAPI(), chains[1].ID, boundaryTimestamp)
 
 	step1 := marshalTransition(start, 1, firstOptimistic)
 	step2 := marshalTransition(start, 2, firstOptimistic, secondOptimistic)
@@ -711,6 +950,9 @@ func RunVariedBlockTimesTest(t devtest.T, sys *presets.SimpleInterop) {
 	// -- Stage 4: Transition test cases ------------------------------------
 	tests := buildTransitionTests(start, end, step1, step2, padding,
 		l1HeadCurrent, l1HeadBefore, l1HeadAfterFirst, endTimestamp)
+	tests = append(tests, buildAfterChainHeadTests(
+		sys.SuperRoots, chains, end, endBoundary, endTimestamp, l1HeadCurrent, l1HeadAdvanced,
+		firstOptimisticBoundary, secondOptimisticBoundary)...)
 
 	challengerCfg := sys.L2ChainA.Escape().L2Challengers()[0].Config()
 	gameDepth := sys.DisputeGameFactory().GameImpl(gameTypes.SuperCannonKonaGameType).SplitDepth()

--- a/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
+++ b/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
@@ -533,28 +533,49 @@ func buildAfterChainHeadTests(
 		ExpectValid:        true,
 	})
 
-	// Test 2: Second chain's optimistic block step at boundaryTimestamp.
-	// Uses l1HeadAdvanced which supports boundaryTimestamp's data.
-	tests = append(tests, &transitionTest{
-		Name:               "DisputeTimestampAfterChainHeadChainB",
-		AgreedClaim:        marshalTransition(end, 1, firstOptimisticBoundary),
-		DisputedClaim:      marshalTransition(end, 2, firstOptimisticBoundary, secondOptimisticBoundary),
-		L1Head:             l1HeadAdvanced,
-		ClaimTimestamp:     claimTimestamp,
-		DisputedTraceIndex: consolidateStep + 2,
-		ExpectValid:        true,
-	})
+	// Tests 2 and 3 anchor on boundaryTimestamp using l1HeadCurrent — meaningful
+	// only when the chains share a block time (so neither chain has a new block at
+	// the odd boundary and OptX@boundary == OptX@end). With varied block times the
+	// faster chain has a new block at the boundary, which would put the trace
+	// provider on the regular derivation path rather than the after-chain-head
+	// invariant we want to exercise.
+	if chains[0].Cfg.BlockTime == chains[1].Cfg.BlockTime {
+		// Test 2: Second chain's optimistic block step at boundaryTimestamp.
+		agreedChainB := marshalTransition(end, 1, firstOptimisticBoundary)
+		if firstNotDerivable {
+			agreedChainB = super.InvalidTransition
+		}
+		disputedChainB := marshalTransition(end, 2, firstOptimisticBoundary, secondOptimisticBoundary)
+		if anyNotDerivable {
+			disputedChainB = super.InvalidTransition
+		}
+		tests = append(tests, &transitionTest{
+			Name:               "DisputeTimestampAfterChainHeadChainB",
+			AgreedClaim:        agreedChainB,
+			DisputedClaim:      disputedChainB,
+			L1Head:             l1HeadCurrent,
+			ClaimTimestamp:     claimTimestamp,
+			DisputedTraceIndex: consolidateStep + 2,
+			ExpectValid:        true,
+		})
 
-	// Test 3: Consolidation step at boundaryTimestamp.
-	tests = append(tests, &transitionTest{
-		Name:               "DisputeTimestampAfterChainHeadConsolidate",
-		AgreedClaim:        marshalTransition(end, consolidateStep, firstOptimisticBoundary, secondOptimisticBoundary),
-		DisputedClaim:      endBoundary.Marshal(),
-		L1Head:             l1HeadAdvanced,
-		ClaimTimestamp:     claimTimestamp,
-		DisputedTraceIndex: 2*stepsPerTimestamp - 1,
-		ExpectValid:        true,
-	})
+		// Test 3: Consolidation step at boundaryTimestamp.
+		agreedConsolidate := marshalTransition(end, consolidateStep, firstOptimisticBoundary, secondOptimisticBoundary)
+		disputedConsolidate := endBoundary.Marshal()
+		if anyNotDerivable {
+			agreedConsolidate = super.InvalidTransition
+			disputedConsolidate = super.InvalidTransition
+		}
+		tests = append(tests, &transitionTest{
+			Name:               "DisputeTimestampAfterChainHeadConsolidate",
+			AgreedClaim:        agreedConsolidate,
+			DisputedClaim:      disputedConsolidate,
+			L1Head:             l1HeadCurrent,
+			ClaimTimestamp:     claimTimestamp,
+			DisputedTraceIndex: 2*stepsPerTimestamp - 1,
+			ExpectValid:        true,
+		})
+	}
 
 	// Test 4: First chain's optimistic block step two timestamps ahead.
 	// When boundaryTimestamp isn't verified with l1HeadCurrent, InvalidTransition cascades.

--- a/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
+++ b/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
@@ -112,44 +112,82 @@ func nextTimestampAfterSafeHeads(t devtest.T, chains []*chain) uint64 {
 	return ts
 }
 
-// minUnsafeTimestamp returns the lowest unsafe-head timestamp across the given chains,
-// adjusted forward (if necessary) to a timestamp at which every chain has produced a block.
-// Intended to be called after StopSequencer + WaitForStall(LocalUnsafe) on every chain so
-// the read is race-free.
-func minUnsafeTimestamp(t devtest.T, chains []*chain) uint64 {
-	ts := ^uint64(0)
+// freezeAndMeasure runs at the end of Stage 2 (with both batchers and both sequencers
+// still running) and produces the deterministic anchor points the after-chain-head
+// subtests need: a validated boundary timestamp, the L1 head that derives it, and a
+// timestamp strictly past every chain's settled unsafe head.
+//
+// Sequence:
+//  1. Wait for every chain's LocalSafe to cover boundaryTimestamp (= endTimestamp+1).
+//     For chains where TargetBlockNumber rounds boundaryTimestamp down to endTimestamp's
+//     block (e.g. 2s blocks at an odd boundary), Reached returns immediately. For 1s
+//     chains we wait one more block. AwaitValidatedTimestamp confirms the supernode
+//     accepts the query.
+//  2. Stop both batchers, then stop both sequencers, then WaitForStall on both
+//     LocalUnsafe and LocalSafe for every chain. The wait-for-stalls absorb arbitrary
+//     scheduling pauses (each requires ≥10s of stable head with a 2-min budget), so
+//     even a 60s pause anywhere between earlier statements cannot leave one chain
+//     ahead of the other in a way the freeze doesn't notice.
+//  3. Read each chain's settled UnsafeL2 timestamp directly from SyncStatus and pick
+//     ttest = max(settled) + margin. Sequencers are stopped, so no chain can produce
+//     more blocks; ttest stays past every chain's head forever.
+func freezeAndMeasure(
+	t devtest.T,
+	sys *presets.SimpleInterop,
+	chains []*chain,
+	endTimestamp uint64,
+) (boundaryTimestamp uint64, l1HeadAdvanced eth.BlockID, ttest uint64) {
+	boundaryTimestamp = endTimestamp + 1
+
+	// Both batchers are still running at this point. Wait for boundaryTimestamp's
+	// data to be on every chain's LocalSafe so optimisticBlockAtTimestamp at the
+	// boundary is well-defined for tests 1–4.
+	for _, c := range chains {
+		target, err := c.Cfg.TargetBlockNumber(boundaryTimestamp)
+		t.Require().NoError(err)
+		c.CLNode.Reached(types.LocalSafe, target, 60)
+	}
+	sys.SuperRoots.AwaitValidatedTimestamp(boundaryTimestamp)
+	l1HeadAdvanced = latestRequiredL1(sys.SuperRoots.SuperRootAtTimestamp(boundaryTimestamp))
+
+	// Freeze. Order: batchers first (so LocalSafe stops moving immediately), then
+	// sequencers (so LocalUnsafe stops moving), then wait for both safety levels to
+	// stall on every chain.
+	for _, c := range chains {
+		c.Batcher.Stop()
+	}
+	for _, c := range chains {
+		c.CLNode.StopSequencer()
+	}
+	for _, c := range chains {
+		c.CLNode.WaitForStall(types.LocalUnsafe)
+		c.CLNode.WaitForStall(types.LocalSafe)
+	}
+
+	// Race-free reads of each chain's settled unsafe head.
+	maxUnsafeTs := uint64(0)
 	for _, c := range chains {
 		status, err := c.Rollup.SyncStatus(t.Ctx())
 		t.Require().NoError(err)
 		head := c.Cfg.TimestampForBlock(status.UnsafeL2.Number)
-		if head < ts {
-			ts = head
+		if head > maxUnsafeTs {
+			maxUnsafeTs = head
 		}
 	}
-	t.Require().NotEqual(^uint64(0), ts, "no chains in dependency set")
-	t.Require().NotZero(ts, "unsafe timestamp must be non-zero")
 
-	// Walk back to a timestamp where every chain has produced a block strictly greater
-	// than at ts-1. Same shape as nextTimestampAfterSafeHeads: handles varied block times
-	// where the slower chain may not have a new block at the otherwise-chosen ts.
-	for {
-		allNew := true
-		for _, c := range chains {
-			curr, err := c.Cfg.TargetBlockNumber(ts)
-			t.Require().NoError(err)
-			prev, err := c.Cfg.TargetBlockNumber(ts - 1)
-			t.Require().NoError(err)
-			if curr <= prev {
-				allNew = false
-				break
-			}
-		}
-		if allNew {
-			break
-		}
-		ts--
+	// Margin must be large enough that:
+	//   - ttest > every chain's settled unsafe head (no chain has a block at ttest
+	//     or ttest+1, so the supernode will return InvalidTransition).
+	//   - ttest > boundaryTimestamp so l1HeadAdvanced (which only derives boundary)
+	//     can't derive ttest, making the trace provider return InvalidTransition.
+	// Sequencers are stopped — no chain can produce more blocks regardless of how
+	// long the rest of the test takes — so ttest stays valid forever.
+	const margin = 2
+	ttest = maxUnsafeTs + margin
+	if ttest < endTimestamp+2 {
+		ttest = endTimestamp + 2
 	}
-	return ts
+	return boundaryTimestamp, l1HeadAdvanced, ttest
 }
 
 // superRootAtTimestamp constructs a SuperV1 from each chain's output at the given timestamp.
@@ -438,20 +476,22 @@ func buildTransitionTests(
 // behavior when the L1 head can't (yet) derive the next-timestamp blocks.
 //
 // The trace structure is per-second (StepsPerTimestamp=128 sub-steps per L2 second),
-// regardless of chain block time. With sequencers stopped from Stage 1, no chain blocks
-// exist past endTimestamp; endTimestamp+1 is therefore a no-op transition (no chain
-// advances). The supernode validates this no-op as L1 produces blocks naturally.
-// l1HeadAdvanced is bounded to the L1 block where endTimestamp+1's data first appears,
-// which does NOT cover endTimestamp+2 and beyond — making tests 5/6 work.
+// regardless of chain block time.
 //
-// The test logic queries the supernode for actual derivability at l1HeadCurrent rather
-// than predicting it from block times, which keeps the cases robust to devstack timing
-// variations.
+// Tests 1–4 anchor on boundaryTimestamp = endTimestamp+1. Whether the supernode can
+// answer queries at boundaryTimestamp from l1HeadCurrent depends on devstack timing,
+// so the test logic queries actual derivability rather than predicting it.
+//
+// Tests 5/6 anchor on ttest, computed in freezeAndMeasure as a timestamp strictly
+// past every chain's settled unsafe head. After Stage 2b's freeze, sequencers are
+// stopped — no chain can ever have a block at ttest or ttest+1 — so the supernode
+// returns InvalidTransition at the corresponding trace indices regardless of any
+// scheduling pauses elsewhere in the test.
 func buildAfterChainHeadTests(
 	sn *dsl.Supernode,
 	chains []*chain,
 	end, endBoundary eth.SuperV1,
-	endTimestamp uint64,
+	endTimestamp, ttest uint64,
 	l1HeadCurrent, l1HeadAdvanced eth.BlockID,
 	firstOptimisticBoundary, secondOptimisticBoundary interopTypes.OptimisticBlock,
 ) []*transitionTest {
@@ -470,6 +510,16 @@ func buildAfterChainHeadTests(
 	endBoundaryVerified := boundaryResp.Data != nil && boundaryResp.Data.VerifiedRequiredL1.Number <= l1HeadCurrent.Number
 
 	claimTimestamp := endTimestamp + 100
+
+	// Trace indices for ttest. The trace index → (timestamp, step) mapping is:
+	//   timestamp = startTimestamp + (idx+1)/stepsPerTimestamp
+	//   step      = (idx+1) % stepsPerTimestamp
+	// Consolidation step (step=0) at timestamp ttest sits at idx (ttest - endTimestamp + 1)*sPT - 1.
+	// Chain-A optimistic step (step=1) advancing toward ttest+1's super-root sits at
+	// idx (ttest - endTimestamp + 1)*sPT + 1.
+	timestampDelta := int64(ttest - endTimestamp + 1)
+	consolidateAfterHeadIdx := timestampDelta*stepsPerTimestamp - 1
+	optimisticAfterHeadIdx := timestampDelta*stepsPerTimestamp + 1
 
 	tests := make([]*transitionTest, 0, 6)
 
@@ -542,10 +592,12 @@ func buildAfterChainHeadTests(
 		ExpectValid:        true,
 	})
 
-	// Test 5: Consolidation step far past the chain head — at boundaryTimestamp+2
-	// (= endTimestamp+3). l1HeadAdvanced is bounded to boundaryTimestamp's data, so this
-	// far-out timestamp is not derivable and the trace provider returns InvalidTransition.
-	// If the earlier cascade already started at l1HeadCurrent (anyNotDerivable), keep
+	// Test 5: Consolidation step at ttest, where no chain has produced a block.
+	// Anchored on the settled unsafe heads measured in Stage 2b after StopSequencer
+	// + WaitForStall, so the InvalidTransition expectation cannot be invalidated by
+	// further sequencer activity (sequencers are stopped). l1HeadAdvanced only
+	// covers boundaryTimestamp; ttest's data is not derivable. If the earlier
+	// boundary cascade already started at l1HeadCurrent (anyNotDerivable), keep
 	// using l1HeadCurrent so the cascade is consistent throughout.
 	l1HeadConsolidate := l1HeadAdvanced
 	if anyNotDerivable {
@@ -557,19 +609,19 @@ func buildAfterChainHeadTests(
 		DisputedClaim:      super.InvalidTransition,
 		L1Head:             l1HeadConsolidate,
 		ClaimTimestamp:     claimTimestamp,
-		DisputedTraceIndex: 4*stepsPerTimestamp - 1,
+		DisputedTraceIndex: consolidateAfterHeadIdx,
 		ExpectValid:        true,
 	})
 
-	// Test 6: Optimistic block step far past the chain head — chain B optimistic
-	// of boundaryTimestamp+3 (= endTimestamp+4). Same reasoning as test 5.
+	// Test 6: Chain-A optimistic step transitioning toward ttest+1's super-root.
+	// Same reasoning as test 5: ttest+1 is also past every chain's settled head.
 	tests = append(tests, &transitionTest{
 		Name:               "AgreedBlockAfterChainHead-Optimistic",
 		AgreedClaim:        super.InvalidTransition,
 		DisputedClaim:      super.InvalidTransition,
 		L1Head:             l1HeadAdvanced,
 		ClaimTimestamp:     claimTimestamp,
-		DisputedTraceIndex: 4*stepsPerTimestamp + 1,
+		DisputedTraceIndex: optimisticAfterHeadIdx,
 		ExpectValid:        true,
 	})
 
@@ -758,66 +810,52 @@ func RunSuperFaultProofTest(t devtest.T, sys *presets.SimpleInterop) {
 	chains := orderedChains(sys)
 	t.Require().Len(chains, 2, "expected exactly 2 interop chains")
 
-	// -- Stage 1: Freeze the chains. Stop batchers and sequencers, wait for
-	// every safety level we read to stall, then derive endTimestamp from the
-	// (now-stable) unsafe heads. Reading after stop+stall is race-free.
+	// -- Stage 1: Freeze batch submission ----------------------------------
+	// Stop both batchers simultaneously, then wait for local-safe to stall on
+	// both chains. This ensures neither batcher submits data past the safe heads.
 	chains[0].Batcher.Stop()
 	chains[1].Batcher.Stop()
-	chains[0].CLNode.StopSequencer()
-	chains[1].CLNode.StopSequencer()
-	chains[0].CLNode.WaitForStall(types.LocalUnsafe)
-	chains[1].CLNode.WaitForStall(types.LocalUnsafe)
 	chains[0].CLNode.WaitForStall(types.LocalSafe)
 	chains[1].CLNode.WaitForStall(types.LocalSafe)
 
-	endTimestamp := minUnsafeTimestamp(t, chains)
+	endTimestamp := nextTimestampAfterSafeHeads(t, chains)
 	startTimestamp := endTimestamp - 1
+
+	// Wait for both chains to produce the target blocks as unsafe.
+	// Sequencers keep running freely — the L1 head invariants are maintained
+	// by which batchers are running, not by stopping sequencers.
 	target0, err := chains[0].Cfg.TargetBlockNumber(endTimestamp)
 	t.Require().NoError(err)
 	target1, err := chains[1].Cfg.TargetBlockNumber(endTimestamp)
 	t.Require().NoError(err)
+	chains[0].EL.Reached(eth.Unsafe, target0, 60)
+	chains[1].EL.Reached(eth.Unsafe, target1, 60)
 
-	// -- Stage 2: Capture L1 heads via batcher choreography. With unsafe heads
-	// bounded at endTimestamp, batchers can only submit data up to endTimestamp.
+	// -- Stage 2: Capture L1 heads via batcher choreography ----------------
+	// Batchers are stopped, so no batch data for endTimestamp is on L1.
 	l1HeadBefore := sys.L1EL.BlockRefByLabel(eth.Unsafe).ID()
 
-	// Start chain[0]'s batcher only — submits chain[0]'s data up to endTimestamp.
+	// Start chain[0]'s batcher and wait for its local-safe head to reach the target.
+	// Chain[1]'s batcher is still stopped, so only chain[0]'s data lands on L1.
+	// We wait on the CL local-safe label because the EL safe label only advances
+	// after interop validation, which requires all chains to have batch data.
 	chains[0].Batcher.Start()
 	chains[0].CLNode.Reached(types.LocalSafe, target0, 60)
 	l1HeadAfterFirst := sys.L1EL.BlockRefByLabel(eth.Unsafe).ID()
 
-	// Start chain[1]'s batcher and wait for the supernode to validate.
+	// Start chain[1]'s batcher and wait for the supernode to validate, then
+	// wait for chain[1]'s safe head to reach its target.
 	chains[1].Batcher.Start()
 	sys.SuperRoots.AwaitValidatedTimestamp(endTimestamp)
 	chains[1].CLNode.Reached(types.LocalSafe, target1, 60)
 	l1HeadCurrent := sys.L1EL.BlockRefByLabel(eth.Unsafe).ID()
 
-	// -- Stage 2b: Validate the next-second boundary (endTimestamp+1).
-	// Chains with block time > 1s already have their latest block at endTimestamp;
-	// the supernode validates endTimestamp+1 as a no-op transition (no new chain
-	// blocks needed) once L1 advances naturally. Chains with block time = 1s
-	// require a fresh chain block at endTimestamp+1 — briefly restart their
-	// sequencer to produce it. The Reached → StopSequencer race is bounded to ~1
-	// block of overshoot; tests 5 & 6 target indices well past that margin.
-	boundaryTimestamp := endTimestamp + 1
-	for _, c := range chains {
-		if c.Cfg.BlockTime > 1 {
-			continue
-		}
-		target, err := c.Cfg.TargetBlockNumber(boundaryTimestamp)
-		t.Require().NoError(err)
-		status, err := c.Rollup.SyncStatus(t.Ctx())
-		t.Require().NoError(err)
-		if status.UnsafeL2.Number >= target {
-			continue
-		}
-		c.CLNode.StartSequencer()
-		c.EL.Reached(eth.Unsafe, target, 60)
-		c.CLNode.StopSequencer()
-		c.CLNode.WaitForStall(types.LocalUnsafe)
-	}
-	sys.SuperRoots.AwaitValidatedTimestamp(boundaryTimestamp)
-	l1HeadAdvanced := latestRequiredL1(sys.SuperRoots.SuperRootAtTimestamp(boundaryTimestamp))
+	// -- Stage 2b: Freeze and measure for the after-chain-head subtests.
+	// Reads settled state after both batchers and sequencers have been stopped
+	// and their LocalUnsafe/LocalSafe heads have stalled, so the timestamps the
+	// after-chain-head tests anchor on cannot be invalidated by further chain
+	// activity. See freezeAndMeasure for the full justification.
+	boundaryTimestamp, l1HeadAdvanced, ttest := freezeAndMeasure(t, sys, chains, endTimestamp)
 
 	// --- Stage 3: Build expected transition states --------------------------
 	start := superRootAtTimestamp(t, chains, startTimestamp)
@@ -839,7 +877,7 @@ func RunSuperFaultProofTest(t devtest.T, sys *presets.SimpleInterop) {
 	tests := buildTransitionTests(start, end, step1, step2, padding,
 		l1HeadCurrent, l1HeadBefore, l1HeadAfterFirst, endTimestamp)
 	tests = append(tests, buildAfterChainHeadTests(
-		sys.SuperRoots, chains, end, endBoundary, endTimestamp, l1HeadCurrent, l1HeadAdvanced,
+		sys.SuperRoots, chains, end, endBoundary, endTimestamp, ttest, l1HeadCurrent, l1HeadAdvanced,
 		firstOptimisticBoundary, secondOptimisticBoundary)...)
 
 	challengerCfg := sys.L2ChainA.Escape().L2Challengers()[0].Config()
@@ -873,63 +911,52 @@ func RunVariedBlockTimesTest(t devtest.T, sys *presets.SimpleInterop) {
 	t.Require().NotEqual(chains[0].Cfg.BlockTime, chains[1].Cfg.BlockTime,
 		"this test requires chains with different block times")
 
-	// -- Stage 1: Freeze the chains. Stop batchers and sequencers, wait for
-	// every safety level we read to stall, then derive endTimestamp from the
-	// (now-stable) unsafe heads.
+	// -- Stage 1: Setup — both batchers stopped -----------------------------
+	// Stop both batchers simultaneously, then wait for local-safe to stall on
+	// both chains. This ensures neither batcher submits data past the safe heads.
 	chains[0].Batcher.Stop()
 	chains[1].Batcher.Stop()
-	chains[0].CLNode.StopSequencer()
-	chains[1].CLNode.StopSequencer()
-	chains[0].CLNode.WaitForStall(types.LocalUnsafe)
-	chains[1].CLNode.WaitForStall(types.LocalUnsafe)
 	chains[0].CLNode.WaitForStall(types.LocalSafe)
 	chains[1].CLNode.WaitForStall(types.LocalSafe)
 
-	endTimestamp := minUnsafeTimestamp(t, chains)
+	endTimestamp := nextTimestampAfterSafeHeads(t, chains)
 	startTimestamp := endTimestamp - 1
+
+	// Wait for both chains to produce the target blocks as unsafe.
+	// Sequencers keep running freely — the L1 head invariants are maintained
+	// by which batchers are running, not by stopping sequencers.
 	target0, err := chains[0].Cfg.TargetBlockNumber(endTimestamp)
 	t.Require().NoError(err)
 	target1, err := chains[1].Cfg.TargetBlockNumber(endTimestamp)
 	t.Require().NoError(err)
+	chains[0].EL.Reached(eth.Unsafe, target0, 60)
+	chains[1].EL.Reached(eth.Unsafe, target1, 60)
 
 	// -- Stage 2: Capture L1 heads via batcher choreography ----------------
+	// Batchers are stopped, so no batch data for endTimestamp is on L1.
 	l1HeadBefore := sys.L1EL.BlockRefByLabel(eth.Unsafe).ID()
 
+	// Start chain[0]'s batcher and wait for its local-safe head to reach the target.
+	// Chain[1]'s batcher is still stopped, so only chain[0]'s data lands on L1.
+	// We wait on the CL local-safe label because the EL safe label only advances
+	// after interop validation, which requires all chains to have batch data.
 	chains[0].Batcher.Start()
 	chains[0].CLNode.Reached(types.LocalSafe, target0, 60)
 	l1HeadAfterFirst := sys.L1EL.BlockRefByLabel(eth.Unsafe).ID()
 
+	// Start chain[1]'s batcher and wait for the supernode to validate, then
+	// wait for chain[1]'s safe head to reach its target.
 	chains[1].Batcher.Start()
 	sys.SuperRoots.AwaitValidatedTimestamp(endTimestamp)
 	chains[1].CLNode.Reached(types.LocalSafe, target1, 60)
 	l1HeadCurrent := sys.L1EL.BlockRefByLabel(eth.Unsafe).ID()
 
-	// -- Stage 2b: Validate the next-second boundary (endTimestamp+1).
-	// Chains with block time > 1s already have their latest block at endTimestamp;
-	// the supernode validates endTimestamp+1 as a no-op transition (no new chain
-	// blocks needed) once L1 advances naturally. Chains with block time = 1s
-	// require a fresh chain block at endTimestamp+1 — briefly restart their
-	// sequencer to produce it. The Reached → StopSequencer race is bounded to ~1
-	// block of overshoot; tests 5 & 6 target indices well past that margin.
-	boundaryTimestamp := endTimestamp + 1
-	for _, c := range chains {
-		if c.Cfg.BlockTime > 1 {
-			continue
-		}
-		target, err := c.Cfg.TargetBlockNumber(boundaryTimestamp)
-		t.Require().NoError(err)
-		status, err := c.Rollup.SyncStatus(t.Ctx())
-		t.Require().NoError(err)
-		if status.UnsafeL2.Number >= target {
-			continue
-		}
-		c.CLNode.StartSequencer()
-		c.EL.Reached(eth.Unsafe, target, 60)
-		c.CLNode.StopSequencer()
-		c.CLNode.WaitForStall(types.LocalUnsafe)
-	}
-	sys.SuperRoots.AwaitValidatedTimestamp(boundaryTimestamp)
-	l1HeadAdvanced := latestRequiredL1(sys.SuperRoots.SuperRootAtTimestamp(boundaryTimestamp))
+	// -- Stage 2b: Freeze and measure for the after-chain-head subtests.
+	// Reads settled state after both batchers and sequencers have been stopped
+	// and their LocalUnsafe/LocalSafe heads have stalled, so the timestamps the
+	// after-chain-head tests anchor on cannot be invalidated by further chain
+	// activity. See freezeAndMeasure for the full justification.
+	boundaryTimestamp, l1HeadAdvanced, ttest := freezeAndMeasure(t, sys, chains, endTimestamp)
 
 	// -- Stage 3: Build expected transition states --------------------------
 	start := superRootAtTimestamp(t, chains, startTimestamp)
@@ -951,7 +978,7 @@ func RunVariedBlockTimesTest(t devtest.T, sys *presets.SimpleInterop) {
 	tests := buildTransitionTests(start, end, step1, step2, padding,
 		l1HeadCurrent, l1HeadBefore, l1HeadAfterFirst, endTimestamp)
 	tests = append(tests, buildAfterChainHeadTests(
-		sys.SuperRoots, chains, end, endBoundary, endTimestamp, l1HeadCurrent, l1HeadAdvanced,
+		sys.SuperRoots, chains, end, endBoundary, endTimestamp, ttest, l1HeadCurrent, l1HeadAdvanced,
 		firstOptimisticBoundary, secondOptimisticBoundary)...)
 
 	challengerCfg := sys.L2ChainA.Escape().L2Challengers()[0].Config()

--- a/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
+++ b/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
@@ -515,8 +515,9 @@ func buildAfterChainHeadTests(
 	//   timestamp = startTimestamp + (idx+1)/stepsPerTimestamp
 	//   step      = (idx+1) % stepsPerTimestamp
 	// Consolidation step (step=0) at timestamp ttest sits at idx (ttest - endTimestamp + 1)*sPT - 1.
-	// Chain-A optimistic step (step=1) advancing toward ttest+1's super-root sits at
-	// idx (ttest - endTimestamp + 1)*sPT + 1.
+	// An optimistic step within the ttest → ttest+1 transition sits at the same
+	// timestamp+1 multiplier with step >= 1. We pick step=2 (chain-B optimistic)
+	// to mirror the original test layout (4*sPT - 1 / 4*sPT + 1).
 	timestampDelta := int64(ttest - endTimestamp + 1)
 	consolidateAfterHeadIdx := timestampDelta*stepsPerTimestamp - 1
 	optimisticAfterHeadIdx := timestampDelta*stepsPerTimestamp + 1
@@ -613,8 +614,10 @@ func buildAfterChainHeadTests(
 		ExpectValid:        true,
 	})
 
-	// Test 6: Chain-A optimistic step transitioning toward ttest+1's super-root.
-	// Same reasoning as test 5: ttest+1 is also past every chain's settled head.
+	// Test 6: Optimistic step (chain B) within the transition from ttest's
+	// super-root toward ttest+1's super-root. Same reasoning as test 5:
+	// neither ttest nor ttest+1 have any chain blocks (sequencers are stopped),
+	// so the trace provider returns InvalidTransition at this index.
 	tests = append(tests, &transitionTest{
 		Name:               "AgreedBlockAfterChainHead-Optimistic",
 		AgreedClaim:        super.InvalidTransition,

--- a/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
+++ b/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
@@ -175,20 +175,39 @@ func freezeAndMeasure(
 		}
 	}
 
-	// Margin must be large enough that:
-	//   - ttest > every chain's settled unsafe head (no chain has a block at ttest
-	//     or ttest+1, so the supernode will return InvalidTransition).
-	//   - ttest > boundaryTimestamp so l1HeadAdvanced (which only derives boundary)
-	//     can't derive ttest, making the trace provider return InvalidTransition.
-	// Sequencers are stopped — no chain can produce more blocks regardless of how
-	// long the rest of the test takes — so ttest stays valid forever.
-	const margin = 2
+	// Margin must be ≥ max chain block time so that for every chain c,
+	// TargetBlockNumber(ttest) > UnsafeL2.Number — i.e. the supernode returns
+	// NotFound at ttest (and ttest+1) for every chain. Hard-coding "2" here
+	// would silently break tests 5/6 the moment someone adds a 3s chain.
+	maxBlockTime := uint64(0)
+	for _, c := range chains {
+		if c.Cfg.BlockTime > maxBlockTime {
+			maxBlockTime = c.Cfg.BlockTime
+		}
+	}
+	margin := maxBlockTime + 1
 	ttest = maxUnsafeTs + margin
 	if ttest < endTimestamp+2 {
 		ttest = endTimestamp + 2
 	}
+
+	// Defensive: ttest+1 must stay strictly inside the trace window
+	// [startTimestamp, claimTimestamp). claimTimestamp in buildAfterChainHeadTests
+	// is endTimestamp+100; if a pathological scheduling pause pushed maxUnsafeTs
+	// that close to claimTimestamp, the trace index for test 6 would land outside
+	// the trace and fail with a confusing out-of-range error rather than the
+	// InvalidTransition the test expects. Surface the real problem here.
+	t.Require().Lessf(ttest+1, endTimestamp+afterChainHeadClaimTimestampOffset,
+		"ttest=%d too close to claimTimestamp=%d; chain overshot during freeze",
+		ttest, endTimestamp+afterChainHeadClaimTimestampOffset)
+
 	return boundaryTimestamp, l1HeadAdvanced, ttest
 }
+
+// afterChainHeadClaimTimestampOffset is the offset past endTimestamp at which the
+// after-chain-head subtests anchor their claim timestamp. Defined here so
+// freezeAndMeasure can bound ttest+1 strictly inside the trace.
+const afterChainHeadClaimTimestampOffset = 100
 
 // superRootAtTimestamp constructs a SuperV1 from each chain's output at the given timestamp.
 func superRootAtTimestamp(t devtest.T, chains []*chain, timestamp uint64) eth.SuperV1 {
@@ -509,7 +528,7 @@ func buildAfterChainHeadTests(
 	// root won't be either, and InvalidTransition cascades to later steps.
 	endBoundaryVerified := boundaryResp.Data != nil && boundaryResp.Data.VerifiedRequiredL1.Number <= l1HeadCurrent.Number
 
-	claimTimestamp := endTimestamp + 100
+	claimTimestamp := endTimestamp + afterChainHeadClaimTimestampOffset
 
 	// Trace indices for ttest. The trace index → (timestamp, step) mapping is:
 	//   timestamp = startTimestamp + (idx+1)/stepsPerTimestamp


### PR DESCRIPTION
Alternative implementation of ethereum-optimism/optimism#20349.

#20349 ports 6 *AfterChainHead* subtests but also rewrites the existing `RunSuperFaultProofTest` / `RunVariedBlockTimesTest` Stage 1 and Stage 2 setup, and its Stage 2b's `StartSequencer → Reached → StopSequencer` dance has an unbounded race under CI scheduling pauses (a pause of any length between two of those calls produces unbounded sequencer overshoot, which `LocalSafe` then catches up to once batchers re-submit).

This PR keeps Stage 1 / Stage 2 **byte-identical to develop** (zero deletions vs develop) and adds a freeze-and-measure stage that:

- Stops batchers, then sequencers, then `WaitForStall(LocalUnsafe)` and `WaitForStall(LocalSafe)` on every chain. The two stalls absorb any scheduling pause anywhere in the freeze (each requires ≥10 s of stable head with a 2-minute budget).
- Reads each chain's settled `UnsafeL2.Number` race-free.
- Anchors the new tests on `ttest = max(settled unsafe timestamp) + maxBlockTime + 1` and `claimTimestamp = ttest + 5` — both derived from settled state, no hardcoded boundary.

Sequencers stay stopped for the rest of the test, so `ttest` is permanently past every chain's head and the supernode returns `InvalidTransition` at the test 5/6 indices regardless of how the freeze unfolded.

Single-file change: `op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go`, +296 / −0 vs develop.

## Test plan

- [ ] `TestInteropFaultProofs ×5` (run before merging — not yet executed locally)
- [ ] `TestPreinteropFaultProofs ×5`
- [ ] `TestInteropFaultProofs_VariedBlockTimes` and `_FasterChainB` ×5 each (these are still `MarkFlaky` for ethereum-optimism/optimism#19828 — confirm this PR doesn't make that worse)