### PR TITLE
fix(op-reth): hardcode payload-id version byte to V3

### DIFF
--- a/rust/op-reth/crates/payload/src/payload.rs
+++ b/rust/op-reth/crates/payload/src/payload.rs
@@ -129,8 +129,11 @@ impl From<alloy_rpc_types_engine::PayloadAttributes> for OpPayloadAttrs {
 
 impl reth_payload_primitives::PayloadAttributes for OpPayloadAttrs {
     fn payload_id(&self, parent_hash: &B256) -> PayloadId {
-        // Use the default engine API message version for computing the payload id.
-        payload_id_optimism(parent_hash, &self.0, EngineApiMessageVersion::default() as u8)
+        // Revisit if op-node ever bumps its FCU version. Pre-PR-#23202 reth threaded the
+        // version through `PayloadBuilderAttributes::try_new(parent, attrs, version)`; the
+        // refactor removed that channel, so for now V3 is the only correct choice instead
+        // of the V4 default
+        payload_id_optimism(parent_hash, &self.0, EngineApiMessageVersion::V3 as u8)
     }
 
     fn timestamp(&self) -> u64 {

--- a/rust/op-reth/crates/payload/src/payload.rs
+++ b/rust/op-reth/crates/payload/src/payload.rs
@@ -129,10 +129,8 @@ impl From<alloy_rpc_types_engine::PayloadAttributes> for OpPayloadAttrs {
 
 impl reth_payload_primitives::PayloadAttributes for OpPayloadAttrs {
     fn payload_id(&self, parent_hash: &B256) -> PayloadId {
-        // Revisit if op-node ever bumps its FCU version. Pre-PR-#23202 reth threaded the
-        // version through `PayloadBuilderAttributes::try_new(parent, attrs, version)`; the
-        // refactor removed that channel, so for now V3 is the only correct choice instead
-        // of the V4 default
+        // Pin to V3 for byte parity with op-node.
+        // See https://github.com/ethereum-optimism/optimism/issues/20226
         payload_id_optimism(parent_hash, &self.0, EngineApiMessageVersion::V3 as u8)
     }
 


### PR DESCRIPTION
hotfix for #20226

`OpPayloadAttrs::payload_id` was using `EngineApiMessageVersion::default()`, which is V4 in upstream reth (Prague is mainnet). Production op-stack chains issue V3 FCUs for every Ecotone+ timestamp, so op-geth emits payload ids beginning 0x03 and op-reth emitted ids beginning 0x04.

Hardcode V3 to restore byte-parity with op-geth. Revisit if op-node ever bumps its FCU version.