### PR TITLE
fix(kona-peers): align bootnodes test with registry data

### DIFF
--- a/rust/kona/crates/node/peers/src/nodes.rs
+++ b/rust/kona/crates/node/peers/src/nodes.rs
@@ -139,7 +139,7 @@ mod tests {
         let mainnet = BootNodes::from_chain_id(OP_MAINNET_CHAIN_ID);
         assert_eq!(mainnet.len(), 24);
 
-        let mainnet = BootNodes::from_chain_id(BASE_MAINNET_CHAIN_ID);
+        let mainnet = BootNodes::from_chain_id(57073 /* Ink */);
         assert_eq!(mainnet.len(), 24);
 
         let mainnet = BootNodes::from_chain_id(130 /* Unichain Mainnet */);
@@ -153,6 +153,11 @@ mod tests {
 
         let unknown = BootNodes::from_chain_id(0);
         assert!(unknown.is_empty());
+
+        // Base was removed from the superchain registry, so its chain id no
+        // longer resolves to a known parent and yields no bootnodes.
+        let base = BootNodes::from_chain_id(BASE_MAINNET_CHAIN_ID);
+        assert!(base.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `test_bootnodes_from_chain_id` panicked on current `develop` because Base was removed from the superchain registry in #20366, so `BASE_MAINNET_CHAIN_ID` no longer resolves to a known parent and the assertion expecting 24 bootnodes failed.
- #20406 fixed the analogous `kona-genesis` test but missed this one.
- Replace the Base lookup with Ink (another mainnet OP Stack chain still in the registry) and add an explicit assertion that `BASE_MAINNET_CHAIN_ID` now yields no bootnodes, so a future re-addition trips this test.

## Test plan

- [x] `cargo test -p kona-peers --lib nodes::tests` — all 6 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)