### PR TITLE
fix(ci): add `required-rust-ci` to `ci-gate`

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -2686,6 +2686,7 @@ workflows:
             - memory-all-opn-op-geth: terminal
             - memory-all-opn-op-reth: terminal
             - memory-all-kona-op-reth: terminal
+            - required-rust-ci: terminal
           context:
             - circleci-api-token
           filters:
@@ -3216,8 +3217,8 @@ workflows:
               pattern: "^gh-readonly-queue/.*"
               value: << pipeline.git.branch >>
           - and:
-            - equal: [true, <<pipeline.parameters.c-main_dispatch>>]
-            - equal: ["api", << pipeline.trigger_source >>]
+              - equal: [true, <<pipeline.parameters.c-main_dispatch>>]
+              - equal: ["api", << pipeline.trigger_source >>]
     jobs:
       - required-contracts-ci:
           always-succeed: true


### PR DESCRIPTION
Add missing required-rust-ci dependency to terminal-all job and fix YAML indentation for the api-dispatch workflow filter conditions.

Keeping this draft for now because I'm not actually sure it will work. We use path filtering on the rust ci jobs, so they may not always run. So requiring them here might just block all PRs that don't touch rust code. 