### PR TITLE
ci: downsize contracts-bedrock-build to large (#2366)

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -931,7 +931,7 @@ jobs:
   contracts-bedrock-build:
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
-    resource_class: 2xlarge
+    resource_class: large
     parameters:
       build_args:
         description: Forge build arguments


### PR DESCRIPTION
## What this changes

Downsizes the `contracts-bedrock-build` job from `resource_class: 2xlarge` to `resource_class: large` in `.circleci/continue/main.yml`.

## Why

Per CircleCI's resource class analysis ([issue ethereum-optimism/core-team#2366](https://github.com/ethereum-optimism/core-team/issues/2366)):
- Avg CPU: **9.5%** on 2xlarge (8 vCPUs) → effectively using <1 core
- Avg RAM: **3.7%**
- Sample size: 1,368 runs
- CircleCI's threshold for "well-utilized": ≥40%

Going to `large` (4 vCPUs) brings effective utilization to ~19%, still well below the threshold but with meaningful credit savings.

## Estimated savings

~95K credits per run (from CircleCI's analysis). This job runs on every PR plus develop, so the monthly impact is significant. The change also covers 3 additional invocations of the same job definition in `rust-e2e-ci`, `rust-e2e-gate-skip`, and `develop-fault-proofs` workflows.

## Validation

- One-line config change, easy to validate and revert.
- I'll watch the first few `develop` runs after merge for any duration regression or build failures.
- If anything regresses, the revert is a single-line change back to `2xlarge`.

## Related

Refs: ethereum-optimism/core-team#2366 (Workstream 1)

cc @alfonso-op