### PR TITLE
ci: downsize check-kontrol-build to medium (#2366)

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -973,7 +973,7 @@ jobs:
   check-kontrol-build:
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
-    resource_class: xlarge
+    resource_class: medium
     steps:
       - utils/checkout-with-mise:
           enable-mise-cache: true


### PR DESCRIPTION
## What this changes

Downsizes the `check-kontrol-build` job from `resource_class: xlarge` to `resource_class: medium` in `.circleci/continue/main.yml`.

## Why

Per CircleCI's resource class analysis ([issue ethereum-optimism/core-team#2366](https://github.com/ethereum-optimism/core-team/issues/2366)):
- Avg CPU: **19.5%** on xlarge (8 vCPUs)
- Avg RAM: **2.8%**
- Sample size: 346 runs
- CircleCI's specific recommendation: `xlarge → medium`

## Note on the size jump

CircleCI's Docker resource class hierarchy is `small (1 vCPU) → medium (2) → medium+ (3) → large (4) → xlarge (8) → 2xlarge (16)`, so xlarge → medium is a 4x reduction in vCPUs. At 19.5% on xlarge, that maps to ~78% effective utilization on medium — above CircleCI's 40% "well-utilized" threshold but below saturation.

CircleCI's slide deck explicitly recommended `medium` for this job. If reviewers prefer a more conservative step, the intermediate options are:
- `large` (4 vCPUs) → ~39% effective utilization, cleanly under threshold
- `medium+` (3 vCPUs) → ~52% effective utilization

Going with `medium` per CircleCI's explicit recommendation; happy to step up if reviewers prefer a more conservative first cut.

## Validation

- This job uses `setup_remote_docker` with layer caching, which is unaffected by the executor's resource class.
- I'll watch the first few runs post-merge for any timeout or memory issues.

## Related

Refs: ethereum-optimism/core-team#2366

cc @alfonso-op