### PR TITLE
ci: downsize go-binaries-for-sysgo to medium (#2366)

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -1626,7 +1626,7 @@ jobs:
   go-binaries-for-sysgo:
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
-    resource_class: large
+    resource_class: medium
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless


### PR DESCRIPTION
## What this changes

Downsizes the `go-binaries-for-sysgo` job from `resource_class: large` to `resource_class: medium` in `.circleci/continue/main.yml`.

## Why

Per CircleCI's resource class analysis ([issue ethereum-optimism/core-team#2366](https://github.com/ethereum-optimism/core-team/issues/2366)):
- Avg CPU: **24.6%** on large (4 vCPUs)
- Avg RAM: **6.6%**
- Sample size: 371 runs

## Note on downstream impact

This job builds `cannon` and `op-program` Go binaries and persists them to workspaces consumed by multiple downstream jobs. Since Go builds parallelize across cores, halving the cores could lengthen the wall-clock build time more than CPU averages suggest. Will monitor durations of dependent jobs (cannon-prestate, downstream cannon/op-program tests) post-merge.

If wall-clock duration of this job grows by >25%, easy revert.

## Validation

- One-line change, simple revert.
- I'll watch the first ~5 runs post-merge for both this job's duration and any downstream knock-on.

## Related

Refs: ethereum-optimism/core-team#2366

cc @alfonso-op