### PR TITLE
ci: downsize contracts-bedrock-tests heavy-fuzz to large (#2366)

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -1062,10 +1062,11 @@ jobs:
             TEST_FILES=$(echo "$TEST_FILES" | sed 's|^test/||')
             MATCH_PATH="./test/{$(echo "$TEST_FILES" | paste -sd "," -)}"
             mkdir -p results
-            forge test --match-path "$MATCH_PATH" --junit > results/results.xml
+            forge test --threads 1 --match-path "$MATCH_PATH" --junit > results/results.xml
           environment:
             FOUNDRY_PROFILE: <<parameters.test_profile>>
-            FOUNDRY_THREADS: "2"
+            FOUNDRY_THREADS: "1"
+            RAYON_NUM_THREADS: "1"
           working_directory: packages/contracts-bedrock
           no_output_timeout: <<parameters.test_timeout>>
       - run:

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -999,7 +999,7 @@ jobs:
     circleci_ip_ranges: true
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
-    resource_class: xlarge
+    resource_class: 2xlarge
     parameters:
       test_list:
         description: List of test files to run

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -999,7 +999,7 @@ jobs:
     circleci_ip_ranges: true
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
-    resource_class: 2xlarge
+    resource_class: large
     parameters:
       test_list:
         description: List of test files to run
@@ -1065,6 +1065,7 @@ jobs:
             forge test --match-path "$MATCH_PATH" --junit > results/results.xml
           environment:
             FOUNDRY_PROFILE: <<parameters.test_profile>>
+            FOUNDRY_THREADS: "2"
           working_directory: packages/contracts-bedrock
           no_output_timeout: <<parameters.test_timeout>>
       - run:

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -999,7 +999,7 @@ jobs:
     circleci_ip_ranges: true
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
-    resource_class: large
+    resource_class: xlarge
     parameters:
       test_list:
         description: List of test files to run

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -999,7 +999,7 @@ jobs:
     circleci_ip_ranges: true
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
-    resource_class: 2xlarge
+    resource_class: large
     parameters:
       test_list:
         description: List of test files to run


### PR DESCRIPTION
## What this changes

Downsizes the `contracts-bedrock-tests` job from `resource_class: 2xlarge` to `resource_class: large` in `.circleci/continue/main.yml`.

## Scope

This is the underlying job definition for the heavy-fuzz matrix at line 3037. Changing the line affects:
- All 12 heavy-fuzz matrix variants on **post-merge develop nightly** (`ciheavy` profile)
- All 12 heavy-fuzz matrix variants on **every PR** (`liteci` profile)

## Why this is safe

CircleCI's Excel analysis covers all 12 variants:

| Metric | Range across all 12 variants | CircleCI threshold |
|---|---|---|
| Avg CPU % | 7.5% – 8.7% | ≥ 40% (well-utilized) |
| Avg RAM % | 3.0% – 4.8% | ≥ 40% (well-utilized) |

Including the 5 not shown on the slide deck:
- `OPCM_V2,CANNON_KONA`
- `OPCM_V2,SUPER_ROOT_GAMES_MIGRATION`
- `L2CM`
- `L2CM,CUSTOM_GAS_TOKEN`
- `L2CM,OPTIMISM_PORTAL_INTEROP`

Going from 2xlarge (16 vCPUs) → large (4 vCPUs) brings effective CPU to ~30–35% across all variants, still below threshold.

## Why `large` and not `medium`

CircleCI's slide deck recommended `large`; the underlying Excel recommended `medium`. Going with the slide-deck recommendation as the conservative choice for this first round. If `large` proves stable for ~2 weeks, we can revisit `medium` in a follow-up.

## Validation

- Will watch first ~3 nightly heavy-fuzz dispatches for duration regressions or test_timeout breaches (configured at 1h).
- The 1h test_timeout is the main risk surface: at ~8% CPU averaged across the run on 2xlarge, we have headroom, but a CPU-bound burst on a smaller class could push past the timeout. If this happens, the failure mode is observable (timed-out job) rather than silent.
- Easy single-line revert if needed.

## Out of scope

- `contracts-bedrock-tests-upgrade` and `contracts-bedrock-tests-l2-fork` are separate job definitions (also at 2xlarge, also with circleci_ip_ranges: true) but were not on CircleCI's recommendation list. May follow up in a phase-2 PR if data warrants.
- IP Ranges audit on this job — that's Workstream 2 and is being tracked separately in #2366.

## Related

Refs: ethereum-optimism/core-team#2366

cc @alfonso-op