### PR TITLE
chore(ci): drop op-rbuilder image from docker build matrix

### DIFF
--- a/.github/docker-images.json
+++ b/.github/docker-images.json
@@ -100,11 +100,6 @@
       "check": "go",
       "paths": ["op-interop-filter/**"]
     },
-    "op-rbuilder": {
-      "type": "rust",
-      "check": "rust",
-      "paths": ["op-rbuilder/**"]
-    },
     "kona-node": {
       "type": "rust",
       "check": "rust",

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -331,18 +331,6 @@ target "op-interop-mon" {
 
 // Rust-based images
 
-target "op-rbuilder" {
-  dockerfile = "Dockerfile"
-  context = "op-rbuilder"
-  target = "rbuilder-runtime"
-  args = {
-    RBUILDER_BIN = "op-rbuilder"
-    FEATURES = ""
-  }
-  platforms = split(",", PLATFORMS)
-  tags = [for tag in split(",", IMAGE_TAGS) : "${REGISTRY}/${REPOSITORY}/op-rbuilder:${tag}"]
-}
-
 target "kona-node" {
   dockerfile = "kona/docker/apps/kona_app_generic.dockerfile"
   context = "rust"


### PR DESCRIPTION
The monorepo published us-docker.pkg.dev/oplabs-tools-artifacts/images/op-rbuilder:<sha> on every develop commit and every non-fork PR, but no consumer reads that tag — prod pulls from a private-fork pipeline that publishes to internal-images/op-rbuilder, and the upstream Flashbots build is pushed manually under separate version tags. The submodule pointer is also frozen since #18540, so the per-commit images are byte-identical apart from baked-in GIT_COMMIT.

It is also currently red-gating develop on a cargo-chef MSRV bump (cargo-platform 0.3.3 → rustc 1.91, vs the image's pinned 1.88).

Removing the registry entry alone drops it from the matrix; the bake target is removed for cleanliness. The CircleCI rust-build-submodule binary build for acceptance tests is intentionally untouched.