### PR TITLE
refactor(op-reth): drop BuildPostExecTransaction

### DIFF
--- a/rust/op-reth/crates/node/src/node.rs
+++ b/rust/op-reth/crates/node/src/node.rs
@@ -6,7 +6,8 @@ use crate::{
     engine::OpEngineValidator,
     txpool::{OpTransactionPool, OpTransactionValidator},
 };
-use op_alloy_consensus::{OpPooledTransaction, interop::SafetyLevel};
+use alloy_primitives::Sealed;
+use op_alloy_consensus::{OpPooledTransaction, TxPostExec, interop::SafetyLevel};
 use reth_chainspec::{
     BaseFeeParams, ChainSpecProvider, EthChainSpec, EthereumHardforks, ForkCondition, Hardforks,
 };
@@ -42,7 +43,7 @@ use reth_optimism_payload_builder::{
     builder::OpPayloadTransactions,
     config::{OpBuilderConfig, OpDAConfig, OpGasLimitConfig},
 };
-use reth_optimism_primitives::{BuildPostExecTransaction, DepositReceipt, OpPrimitives};
+use reth_optimism_primitives::{DepositReceipt, OpPrimitives};
 use reth_optimism_rpc::{
     SequencerClient,
     eth::{OpEthApiBuilder, ext::OpEthExtApi},
@@ -159,7 +160,7 @@ pub trait OpFullNodeTypes:
         Payload: EngineTypes<ExecutionData = OpExecData>,
     >
 where
-    <<Self as NodeTypes>::Primitives as NodePrimitives>::SignedTx: BuildPostExecTransaction,
+    <<Self as NodeTypes>::Primitives as NodePrimitives>::SignedTx: From<Sealed<TxPostExec>>,
 {
 }
 
@@ -171,7 +172,7 @@ where
             Storage = OpStorage,
             Payload: EngineTypes<ExecutionData = OpExecData>,
         >,
-    <N::Primitives as NodePrimitives>::SignedTx: BuildPostExecTransaction,
+    <N::Primitives as NodePrimitives>::SignedTx: From<Sealed<TxPostExec>>,
 {
 }
 
@@ -626,7 +627,7 @@ where
             >,
             Pool: TransactionPool<Transaction: OpPooledTx<Consensus = TxTy<N::Types>>>,
         >,
-    TxTy<N::Types>: BuildPostExecTransaction,
+    TxTy<N::Types>: From<Sealed<TxPostExec>>,
     EthB: EthApiBuilder<N>,
     PVB: Send,
     EB: EngineApiBuilder<N>,
@@ -760,7 +761,7 @@ where
                 >,
             >,
         >,
-    TxTy<N::Types>: BuildPostExecTransaction,
+    TxTy<N::Types>: From<Sealed<TxPostExec>>,
     <<N as FullNodeComponents>::Pool as TransactionPool>::Transaction:
         OpPooledTx<Consensus = TxTy<N::Types>>,
     EthB: EthApiBuilder<N>,
@@ -1322,7 +1323,7 @@ where
                 >,
             >,
         >,
-    TxTy<Node::Types>: BuildPostExecTransaction,
+    TxTy<Node::Types>: From<Sealed<TxPostExec>>,
     Evm: ConfigurePostExecEvm<
             Primitives = PrimitivesTy<Node::Types>,
             NextBlockEnvCtx: BuildNextEnv<

--- a/rust/op-reth/crates/payload/src/builder.rs
+++ b/rust/op-reth/crates/payload/src/builder.rs
@@ -3,12 +3,12 @@ use crate::{
     OpAttributes, OpPayloadBuilderAttributes, OpPayloadPrimitives, config::OpBuilderConfig,
     error::OpPayloadBuilderError, payload::OpBuiltPayload,
 };
-use alloy_consensus::{BlockHeader, Transaction, Typed2718, transaction::Recovered};
+use alloy_consensus::{BlockHeader, Sealable, Transaction, Typed2718, transaction::Recovered};
 use alloy_evm::Evm as AlloyEvm;
-use alloy_primitives::{B256, U256};
+use alloy_primitives::{Address, B256, Sealed, U256};
 use alloy_rpc_types_debug::ExecutionWitness;
 use alloy_rpc_types_engine::PayloadId;
-use op_alloy_consensus::SDMGasEntry;
+use op_alloy_consensus::{SDMGasEntry, TxPostExec, build_post_exec_tx};
 use op_revm::{L1BlockInfo, constants::L1_BLOCK_CONTRACT};
 use reth_basic_payload_builder::*;
 use reth_chainspec::{ChainSpecProvider, EthChainSpec};
@@ -22,9 +22,7 @@ use reth_evm::{
 use reth_execution_types::BlockExecutionOutput;
 use reth_optimism_evm::{ConfigurePostExecEvm, PostExecExecutorExt, PostExecMode};
 use reth_optimism_forks::OpHardforks;
-use reth_optimism_primitives::{
-    BuildPostExecTransaction, L2_TO_L1_MESSAGE_PASSER_ADDRESS, OpTransaction,
-};
+use reth_optimism_primitives::{L2_TO_L1_MESSAGE_PASSER_ADDRESS, OpTransaction};
 use reth_optimism_txpool::{
     OpPooledTx,
     estimated_da_size::DataAvailabilitySized,
@@ -48,9 +46,10 @@ use tracing::{debug, trace, warn};
 
 fn build_post_exec_recovered_tx<Tx>(block_number: u64, entries: Vec<SDMGasEntry>) -> Recovered<Tx>
 where
-    Tx: BuildPostExecTransaction,
+    Tx: From<Sealed<TxPostExec>>,
 {
-    Tx::build_recovered_post_exec(block_number, entries)
+    let sealed = build_post_exec_tx(block_number, entries).seal_slow();
+    Recovered::new_unchecked(Tx::from(sealed), Address::ZERO)
 }
 
 /// Wraps refund entries in a post-exec transaction and executes it via `execute`.
@@ -70,7 +69,7 @@ fn try_include_post_exec_tx<Tx, Err>(
     execute: impl FnOnce(Recovered<Tx>) -> Result<u64, Err>,
 ) -> Result<bool, PayloadBuilderError>
 where
-    Tx: BuildPostExecTransaction,
+    Tx: From<Sealed<TxPostExec>>,
     Err: core::error::Error + Send + Sync + 'static,
 {
     if entries.is_empty() {
@@ -201,7 +200,7 @@ where
     Pool: TransactionPool<Transaction: OpPooledTx<Consensus = N::SignedTx>>,
     Client: StateProviderFactory + ChainSpecProvider<ChainSpec: OpHardforks>,
     N: OpPayloadPrimitives,
-    N::SignedTx: BuildPostExecTransaction,
+    N::SignedTx: From<Sealed<TxPostExec>>,
     Evm: ConfigurePostExecEvm<
             Primitives = N,
             NextBlockEnvCtx: BuildNextEnv<Attrs, N::BlockHeader, Client::ChainSpec>,
@@ -284,7 +283,7 @@ impl<Pool, Client, Evm, N, Txs> PayloadBuilder
     for OpPayloadBuilder<Pool, Client, Evm, Txs, OpPayloadBuilderAttributes<N::SignedTx>>
 where
     N: OpPayloadPrimitives,
-    N::SignedTx: BuildPostExecTransaction,
+    N::SignedTx: From<Sealed<TxPostExec>>,
     Client: StateProviderFactory + ChainSpecProvider<ChainSpec: OpHardforks> + Clone,
     Pool: TransactionPool<Transaction: OpPooledTx<Consensus = N::SignedTx>>,
     Evm: ConfigurePostExecEvm<
@@ -416,7 +415,7 @@ impl<Txs> OpBuilder<'_, Txs> {
             >,
         ChainSpec: EthChainSpec + OpHardforks,
         N: OpPayloadPrimitives,
-        N::SignedTx: BuildPostExecTransaction,
+        N::SignedTx: From<Sealed<TxPostExec>>,
         Txs:
             PayloadTransactions<Transaction: PoolTransaction<Consensus = N::SignedTx> + OpPooledTx>,
         Attrs: OpAttributes<Transaction = N::SignedTx>,
@@ -508,7 +507,7 @@ impl<Txs> OpBuilder<'_, Txs> {
             >,
         ChainSpec: EthChainSpec + OpHardforks,
         N: OpPayloadPrimitives,
-        N::SignedTx: BuildPostExecTransaction,
+        N::SignedTx: From<Sealed<TxPostExec>>,
         Txs: PayloadTransactions<Transaction: PoolTransaction<Consensus = N::SignedTx>>,
         Attrs: OpAttributes<Transaction = N::SignedTx>,
     {

--- a/rust/op-reth/crates/primitives/src/transaction/mod.rs
+++ b/rust/op-reth/crates/primitives/src/transaction/mod.rs
@@ -1,10 +1,5 @@
 //! Optimism transaction types
 
-use alloc::vec::Vec;
-use alloy_consensus::{Sealable, transaction::Recovered};
-use alloy_primitives::Address;
-use reth_primitives_traits::SignedTransaction;
-
 mod tx_type;
 
 /// Kept for consistency tests
@@ -18,27 +13,3 @@ pub use op_alloy_consensus::{
 
 /// Signed transaction.
 pub type OpTransactionSigned = OpTxEnvelope;
-
-/// Capability trait for signed transaction types that can synthesize the OP post-exec tx.
-pub trait BuildPostExecTransaction: SignedTransaction + OpTransaction + Sized {
-    /// Builds the post-exec tx for the given block and refund entries.
-    fn build_post_exec(block_number: u64, gas_refund_entries: Vec<SDMGasEntry>) -> Self;
-
-    /// Builds a recovered post-exec tx with the canonical zero signer.
-    #[must_use]
-    fn build_recovered_post_exec(
-        block_number: u64,
-        gas_refund_entries: Vec<SDMGasEntry>,
-    ) -> Recovered<Self> {
-        Recovered::new_unchecked(
-            Self::build_post_exec(block_number, gas_refund_entries),
-            Address::ZERO,
-        )
-    }
-}
-
-impl BuildPostExecTransaction for OpTransactionSigned {
-    fn build_post_exec(block_number: u64, gas_refund_entries: Vec<SDMGasEntry>) -> Self {
-        Self::PostExec(build_post_exec_tx(block_number, gas_refund_entries).seal_slow())
-    }
-}

--- a/rust/op-reth/crates/rpc/src/debug.rs
+++ b/rust/op-reth/crates/rpc/src/debug.rs
@@ -6,13 +6,14 @@ use crate::{
 };
 use alloy_consensus::BlockHeader;
 use alloy_eips::{BlockId, BlockNumberOrTag};
-use alloy_primitives::B256;
+use alloy_primitives::{B256, Sealed};
 use alloy_rlp::Encodable;
 use alloy_rpc_types_debug::ExecutionWitness;
 use async_trait::async_trait;
 use jsonrpsee::proc_macros::rpc;
 use jsonrpsee_core::RpcResult;
 use jsonrpsee_types::error::ErrorObject;
+use op_alloy_consensus::TxPostExec;
 use reth_basic_payload_builder::PayloadConfig;
 use reth_evm::{ConfigureEvm, execute::Executor};
 use reth_node_api::{BuildNextEnv, NodePrimitives, PayloadBuilderError};
@@ -172,7 +173,7 @@ where
     P: OpProofsStore + Clone + 'static,
     Attrs: OpAttributes<Transaction = TxTy<EvmConfig::Primitives>, RpcPayloadAttributes: Send>,
     N: OpPayloadPrimitives,
-    N::SignedTx: reth_optimism_primitives::BuildPostExecTransaction,
+    N::SignedTx: From<Sealed<TxPostExec>>,
     EvmConfig: reth_optimism_evm::ConfigurePostExecEvm<
             Primitives = N,
             NextBlockEnvCtx: BuildNextEnv<Attrs, N::BlockHeader, Provider::ChainSpec>,

--- a/rust/op-reth/crates/rpc/src/witness.rs
+++ b/rust/op-reth/crates/rpc/src/witness.rs
@@ -1,14 +1,14 @@
 //! Support for optimism specific witness RPCs.
 
-use alloy_primitives::B256;
+use alloy_primitives::{B256, Sealed};
 use alloy_rpc_types_debug::ExecutionWitness;
 use jsonrpsee_core::{RpcResult, async_trait};
+use op_alloy_consensus::TxPostExec;
 use reth_chainspec::ChainSpecProvider;
 use reth_node_api::{BuildNextEnv, NodePrimitives};
 use reth_optimism_evm::ConfigurePostExecEvm;
 use reth_optimism_forks::OpHardforks;
 use reth_optimism_payload_builder::{OpAttributes, OpPayloadBuilder, OpPayloadPrimitives};
-use reth_optimism_primitives::BuildPostExecTransaction;
 use reth_optimism_txpool::OpPooledTx;
 use reth_primitives_traits::{SealedHeader, TxTy};
 pub use reth_rpc_api::DebugExecutionWitnessApiServer;
@@ -71,7 +71,7 @@ where
         + ChainSpecProvider<ChainSpec: OpHardforks>
         + Clone
         + 'static,
-    <Provider::Primitives as NodePrimitives>::SignedTx: BuildPostExecTransaction,
+    <Provider::Primitives as NodePrimitives>::SignedTx: From<Sealed<TxPostExec>>,
     EvmConfig: ConfigurePostExecEvm<
             Primitives = Provider::Primitives,
             NextBlockEnvCtx: BuildNextEnv<Attrs, Provider::Header, Provider::ChainSpec>,

--- a/rust/op-reth/examples/custom-node/src/primitives/tx.rs
+++ b/rust/op-reth/examples/custom-node/src/primitives/tx.rs
@@ -1,18 +1,18 @@
 use super::TxPayment;
 use alloy_consensus::{
-    Sealable, Signed, TransactionEnvelope,
+    Signed, TransactionEnvelope,
     crypto::RecoveryError,
     transaction::{SignerRecoverable, TxHashRef},
 };
 use alloy_eips::Encodable2718;
 use alloy_primitives::{B256, Sealed, Signature};
 use alloy_rlp::BufMut;
-use op_alloy_consensus::{OpTxEnvelope, SDMGasEntry, TxDeposit, TxPostExec, build_post_exec_tx};
+use op_alloy_consensus::{OpTxEnvelope, TxDeposit, TxPostExec};
 use reth_codecs::{
     Compact,
     alloy::transaction::{CompactEnvelope, FromTxCompact, ToTxCompact},
 };
-use reth_op::{BuildPostExecTransaction, OpTransaction};
+use reth_op::OpTransaction;
 use reth_primitives_traits::InMemorySize;
 use revm_primitives::Address;
 
@@ -112,11 +112,9 @@ impl OpTransaction for CustomTransaction {
     }
 }
 
-impl BuildPostExecTransaction for CustomTransaction {
-    fn build_post_exec(block_number: u64, gas_refund_entries: Vec<SDMGasEntry>) -> Self {
-        Self::Op(OpTxEnvelope::PostExec(
-            build_post_exec_tx(block_number, gas_refund_entries).seal_slow(),
-        ))
+impl From<Sealed<TxPostExec>> for CustomTransaction {
+    fn from(value: Sealed<TxPostExec>) -> Self {
+        Self::Op(value.into())
     }
 }
 


### PR DESCRIPTION
Remove `BuildPostExecTransaction` trait in favor of `From<Sealed<TxPostExec>>`.