### PR TITLE
Move interop activation to OPCM migrator

### DIFF
--- a/packages/contracts-bedrock/interfaces/L1/opcm/IOPContractsManagerMigrator.sol
+++ b/packages/contracts-bedrock/interfaces/L1/opcm/IOPContractsManagerMigrator.sol
@@ -37,11 +37,8 @@ interface IOPContractsManagerMigrator {
     /// @notice Thrown when the OPTIMISM_PORTAL_INTEROP dev feature is not enabled.
     error OPContractsManagerMigrator_InteropNotEnabled();
 
-    /// @notice Thrown when a chain's SystemConfig does not have Features.INTEROP enabled.
-    error OPContractsManagerMigrator_InteropFeatureNotEnabled();
-
-    /// @notice Thrown when a chain's SystemConfig does not have Features.ETH_LOCKBOX enabled.
-    error OPContractsManagerMigrator_EthLockboxFeatureNotEnabled();
+    /// @notice Thrown when a chain is paused before migration mutates its portal.
+    error OPContractsManagerMigrator_SystemPaused();
 
     /// @notice Returns the container of blueprint and implementation contract addresses.
     function contractsContainer() external view returns (IOPContractsManagerContainer);

--- a/packages/contracts-bedrock/interfaces/L1/opcm/IOPContractsManagerMigrator.sol
+++ b/packages/contracts-bedrock/interfaces/L1/opcm/IOPContractsManagerMigrator.sol
@@ -37,6 +37,9 @@ interface IOPContractsManagerMigrator {
     /// @notice Thrown when the OPTIMISM_PORTAL_INTEROP dev feature is not enabled.
     error OPContractsManagerMigrator_InteropNotEnabled();
 
+    /// @notice Thrown when a chain does not already have ETHLockbox enabled.
+    error OPContractsManagerMigrator_EthLockboxNotEnabled();
+
     /// @notice Thrown when a chain is paused before migration mutates its portal.
     error OPContractsManagerMigrator_SystemPaused();
 

--- a/packages/contracts-bedrock/interfaces/L1/opcm/IOPContractsManagerMigrator.sol
+++ b/packages/contracts-bedrock/interfaces/L1/opcm/IOPContractsManagerMigrator.sol
@@ -37,9 +37,6 @@ interface IOPContractsManagerMigrator {
     /// @notice Thrown when the OPTIMISM_PORTAL_INTEROP dev feature is not enabled.
     error OPContractsManagerMigrator_InteropNotEnabled();
 
-    /// @notice Thrown when a chain does not already have ETHLockbox enabled.
-    error OPContractsManagerMigrator_EthLockboxNotEnabled();
-
     /// @notice Thrown when a chain is paused before migration mutates its portal.
     error OPContractsManagerMigrator_SystemPaused();
 

--- a/packages/contracts-bedrock/interfaces/L1/opcm/IOPContractsManagerV2.sol
+++ b/packages/contracts-bedrock/interfaces/L1/opcm/IOPContractsManagerV2.sol
@@ -78,6 +78,7 @@ interface IOPContractsManagerV2 {
 
     error OPContractsManagerV2_InvalidGameConfigs();
     error OPContractsManagerV2_InvalidUpgradeInput();
+    error OPContractsManagerV2_InvalidEthLockbox();
     error OPContractsManagerV2_SuperchainConfigNeedsUpgrade();
     error OPContractsManagerV2_InvalidUpgradeInstruction(string _key);
     error OPContractsManagerV2_DuplicateUpgradeInstruction(string _key);

--- a/packages/contracts-bedrock/snapshots/abi/OPContractsManagerMigrator.json
+++ b/packages/contracts-bedrock/snapshots/abi/OPContractsManagerMigrator.json
@@ -112,16 +112,6 @@
   },
   {
     "inputs": [],
-    "name": "OPContractsManagerMigrator_EthLockboxFeatureNotEnabled",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "OPContractsManagerMigrator_InteropFeatureNotEnabled",
-    "type": "error"
-  },
-  {
-    "inputs": [],
     "name": "OPContractsManagerMigrator_InteropNotEnabled",
     "type": "error"
   },
@@ -143,6 +133,11 @@
   {
     "inputs": [],
     "name": "OPContractsManagerMigrator_SuperchainConfigMismatch",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "OPContractsManagerMigrator_SystemPaused",
     "type": "error"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/abi/OPContractsManagerMigrator.json
+++ b/packages/contracts-bedrock/snapshots/abi/OPContractsManagerMigrator.json
@@ -112,11 +112,6 @@
   },
   {
     "inputs": [],
-    "name": "OPContractsManagerMigrator_EthLockboxNotEnabled",
-    "type": "error"
-  },
-  {
-    "inputs": [],
     "name": "OPContractsManagerMigrator_InteropNotEnabled",
     "type": "error"
   },

--- a/packages/contracts-bedrock/snapshots/abi/OPContractsManagerMigrator.json
+++ b/packages/contracts-bedrock/snapshots/abi/OPContractsManagerMigrator.json
@@ -112,6 +112,11 @@
   },
   {
     "inputs": [],
+    "name": "OPContractsManagerMigrator_EthLockboxNotEnabled",
+    "type": "error"
+  },
+  {
+    "inputs": [],
     "name": "OPContractsManagerMigrator_InteropNotEnabled",
     "type": "error"
   },

--- a/packages/contracts-bedrock/snapshots/abi/OPContractsManagerV2.json
+++ b/packages/contracts-bedrock/snapshots/abi/OPContractsManagerV2.json
@@ -817,6 +817,11 @@
   },
   {
     "inputs": [],
+    "name": "OPContractsManagerV2_InvalidEthLockbox",
+    "type": "error"
+  },
+  {
+    "inputs": [],
     "name": "OPContractsManagerV2_InvalidGameConfigs",
     "type": "error"
   },

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -40,8 +40,8 @@
     "sourceCodeHash": "0x2650f2af1df017387e1f1aa6273decc4c46dd4f3ac7f0910c6f0edc92aef4747"
   },
   "src/L1/opcm/OPContractsManagerV2.sol:OPContractsManagerV2": {
-    "initCodeHash": "0x3c06facf387f8316940b9d8bb0cf43c715351f3625660981ffeef7c69949f1bc",
-    "sourceCodeHash": "0x43a71b8fbae4f4642bca291713c2f27197ed3102dc83468a9900ba3f91bbbd96"
+    "initCodeHash": "0xe4a8004cc9657539751b5d11b3ccf602e5c22185f42df0f281db4299e476a93a",
+    "sourceCodeHash": "0x6b968f5cc39634b9604e17b9c808700a715760351a2543765cf39512fdb63ba0"
   },
   "src/L2/BaseFeeVault.sol:BaseFeeVault": {
     "initCodeHash": "0xf1fb169c6dd4eceb5cec6ed6dfa3affc45970e5a01e00827d06af1f9e8df026d",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -40,8 +40,8 @@
     "sourceCodeHash": "0x2650f2af1df017387e1f1aa6273decc4c46dd4f3ac7f0910c6f0edc92aef4747"
   },
   "src/L1/opcm/OPContractsManagerV2.sol:OPContractsManagerV2": {
-    "initCodeHash": "0x4525052e6781fcdfa5f59551fefe0d6b1b9a9573f592a202d0f74708922eb549",
-    "sourceCodeHash": "0xf4031a2c5fe9ef6032d06860da7eba3f68774041bd4c572a4a8c74b8ce91ee19"
+    "initCodeHash": "0x3c06facf387f8316940b9d8bb0cf43c715351f3625660981ffeef7c69949f1bc",
+    "sourceCodeHash": "0x43a71b8fbae4f4642bca291713c2f27197ed3102dc83468a9900ba3f91bbbd96"
   },
   "src/L2/BaseFeeVault.sol:BaseFeeVault": {
     "initCodeHash": "0xf1fb169c6dd4eceb5cec6ed6dfa3affc45970e5a01e00827d06af1f9e8df026d",

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerMigrator.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerMigrator.sol
@@ -54,11 +54,8 @@ contract OPContractsManagerMigrator is OPContractsManagerUtilsCaller {
     /// @notice Thrown when the OPTIMISM_PORTAL_INTEROP dev feature is not enabled.
     error OPContractsManagerMigrator_InteropNotEnabled();
 
-    /// @notice Thrown when a chain's SystemConfig does not have Features.INTEROP enabled.
-    error OPContractsManagerMigrator_InteropFeatureNotEnabled();
-
-    /// @notice Thrown when a chain's SystemConfig does not have Features.ETH_LOCKBOX enabled.
-    error OPContractsManagerMigrator_EthLockboxFeatureNotEnabled();
+    /// @notice Thrown when a chain is paused before migration mutates its portal.
+    error OPContractsManagerMigrator_SystemPaused();
 
     /// @param _utils The utility functions for the OPContractsManager.
     constructor(IOPContractsManagerUtils _utils) OPContractsManagerUtilsCaller(_utils) { }
@@ -85,6 +82,10 @@ contract OPContractsManagerMigrator is OPContractsManagerUtilsCaller {
     /// @dev NOTE: Unlike deploy/upgrade, this function does not enforce a SuperchainConfig
     ///      version floor. The caller is responsible for ensuring the SuperchainConfig is
     ///      upgraded to the current OPCM release version before calling migrate.
+    /// @dev NOTE: OPContractsManagerV2.upgrade() only performs standard chain upgrades. This
+    ///      function performs the one-off interop activation by enabling required features,
+    ///      connecting each portal to the shared ETHLockbox, migrating liquidity, and moving each
+    ///      portal to the shared dispute game contracts.
     /// @param _input The input parameters for the migration.
     function migrate(MigrateInput calldata _input) public {
         // Check that at least one chain is being migrated.
@@ -262,28 +263,51 @@ contract OPContractsManagerMigrator is OPContractsManagerUtilsCaller {
             revert OPContractsManagerMigrator_CustomGasTokenNotSupported();
         }
 
-        // Verify INTEROP is already enabled (set by OPCMv2.upgrade()).
-        // migrateToSharedDisputeGame requires both INTEROP and ETH_LOCKBOX.
-        if (!_systemConfig.isFeatureEnabled(Features.INTEROP)) {
-            revert OPContractsManagerMigrator_InteropFeatureNotEnabled();
-        }
-        if (!_systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX)) {
-            revert OPContractsManagerMigrator_EthLockboxFeatureNotEnabled();
-        }
-
-        // Convert portal to interop portal interface, and grab existing ETHLockbox and DGF.
+        // Convert portal to interop portal interface, and grab existing migration state.
         IOptimismPortal portal = IOptimismPortal(payable(_systemConfig.optimismPortal()));
-        IETHLockbox existingLockbox = IETHLockbox(payable(address(portal.ethLockbox())));
+        IETHLockbox oldLockbox = IETHLockbox(payable(address(portal.ethLockbox())));
+        IAnchorStateRegistry oldASR = portal.anchorStateRegistry();
         IDisputeGameFactory existingDGF = IDisputeGameFactory(payable(address(portal.disputeGameFactory())));
 
+        // Check the current pause state before mutating the portal's lockbox. For chains that
+        // already use a per-chain lockbox, SystemConfig.paused() keys the local pause against the
+        // portal's current lockbox. Reinitializing the portal first would switch the pause
+        // identifier to the shared lockbox and could hide an active old-lockbox pause.
+        if (_systemConfig.paused()) {
+            revert OPContractsManagerMigrator_SystemPaused();
+        }
+
         // Authorize the portal on the new ETHLockbox.
-        _newLockbox.authorizePortal(IOptimismPortal(payable(address(portal))));
+        _newLockbox.authorizePortal(portal);
 
-        // Authorize the existing ETHLockbox to use the new ETHLockbox.
-        _newLockbox.authorizeLockbox(existingLockbox);
+        // Enable the features required by portal liquidity migration and shared game migration.
+        if (!_systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX)) {
+            _systemConfig.setFeature(Features.ETH_LOCKBOX, true);
+        }
+        if (!_systemConfig.isFeatureEnabled(Features.INTEROP)) {
+            _systemConfig.setFeature(Features.INTEROP, true);
+        }
 
-        // Migrate the existing ETHLockbox to the new ETHLockbox.
-        existingLockbox.migrateLiquidity(_newLockbox);
+        // Attach the portal directly to the shared ETHLockbox before migrating portal-held ETH.
+        _upgrade(
+            _systemConfig.proxyAdmin(),
+            address(portal),
+            contractsContainer().implementations().optimismPortalImpl,
+            abi.encodeCall(IOptimismPortal.initialize, (_systemConfig, oldASR, _newLockbox))
+        );
+
+        // Migrate ETH held directly by the portal into the shared ETHLockbox.
+        portal.migrateLiquidity();
+
+        // Sweep any pre-existing per-chain lockbox liquidity into the shared ETHLockbox. Fresh
+        // chains may have no old lockbox, while already-lockbox-enabled chains can have ETH there
+        // that would be stranded after the portal starts pointing at the shared lockbox.
+        if (address(oldLockbox) != address(0) && address(oldLockbox) != address(_newLockbox)) {
+            // The shared lockbox must authorize the old lockbox before receiveLiquidity() will
+            // accept ETH from oldLockbox.migrateLiquidity().
+            _newLockbox.authorizeLockbox(oldLockbox);
+            oldLockbox.migrateLiquidity(_newLockbox);
+        }
 
         // Clear out any implementations that might exist in the old DisputeGameFactory proxy.
         // We clear out all potential game types to be safe. These game types are intentionally
@@ -297,12 +321,6 @@ contract OPContractsManagerMigrator is OPContractsManagerUtilsCaller {
         existingDGF.setImplementation(GameTypes.CANNON_KONA, IDisputeGame(address(0)), hex"");
         existingDGF.setImplementation(GameTypes.SUPER_CANNON_KONA, IDisputeGame(address(0)), hex"");
         existingDGF.setImplementation(GameTypes.ZK_DISPUTE_GAME, IDisputeGame(address(0)), hex"");
-
-        // Enable the ETH lockbox feature on the SystemConfig if not already enabled.
-        // This is needed for the SystemConfig's paused() function to use the correct identifier.
-        if (!_systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX)) {
-            _systemConfig.setFeature(Features.ETH_LOCKBOX, true);
-        }
 
         // Migrate the portal to the new ETHLockbox and AnchorStateRegistry.
         portal.migrateToSharedDisputeGame(_newLockbox, _newASR);

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerMigrator.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerMigrator.sol
@@ -54,6 +54,9 @@ contract OPContractsManagerMigrator is OPContractsManagerUtilsCaller {
     /// @notice Thrown when the OPTIMISM_PORTAL_INTEROP dev feature is not enabled.
     error OPContractsManagerMigrator_InteropNotEnabled();
 
+    /// @notice Thrown when a chain does not already have ETHLockbox enabled.
+    error OPContractsManagerMigrator_EthLockboxNotEnabled();
+
     /// @notice Thrown when a chain is paused before migration mutates its portal.
     error OPContractsManagerMigrator_SystemPaused();
 
@@ -269,6 +272,13 @@ contract OPContractsManagerMigrator is OPContractsManagerUtilsCaller {
         IAnchorStateRegistry oldASR = portal.anchorStateRegistry();
         IDisputeGameFactory existingDGF = IDisputeGameFactory(payable(address(portal.disputeGameFactory())));
 
+        // Chains must already have ETHLockbox enabled before migrating to the shared interop
+        // lockbox. migrate() moves an existing per-chain lockbox into the shared set; it does not
+        // perform first-time ETHLockbox activation.
+        if (!_systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX) || address(oldLockbox) == address(0)) {
+            revert OPContractsManagerMigrator_EthLockboxNotEnabled();
+        }
+
         // Check the current pause state before mutating the portal's lockbox. For chains that
         // already use a per-chain lockbox, SystemConfig.paused() keys the local pause against the
         // portal's current lockbox. Reinitializing the portal first would switch the pause
@@ -281,9 +291,6 @@ contract OPContractsManagerMigrator is OPContractsManagerUtilsCaller {
         _newLockbox.authorizePortal(portal);
 
         // Enable the features required by portal liquidity migration and shared game migration.
-        if (!_systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX)) {
-            _systemConfig.setFeature(Features.ETH_LOCKBOX, true);
-        }
         if (!_systemConfig.isFeatureEnabled(Features.INTEROP)) {
             _systemConfig.setFeature(Features.INTEROP, true);
         }

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerMigrator.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerMigrator.sol
@@ -54,9 +54,6 @@ contract OPContractsManagerMigrator is OPContractsManagerUtilsCaller {
     /// @notice Thrown when the OPTIMISM_PORTAL_INTEROP dev feature is not enabled.
     error OPContractsManagerMigrator_InteropNotEnabled();
 
-    /// @notice Thrown when a chain does not already have ETHLockbox enabled.
-    error OPContractsManagerMigrator_EthLockboxNotEnabled();
-
     /// @notice Thrown when a chain is paused before migration mutates its portal.
     error OPContractsManagerMigrator_SystemPaused();
 
@@ -272,13 +269,6 @@ contract OPContractsManagerMigrator is OPContractsManagerUtilsCaller {
         IAnchorStateRegistry oldASR = portal.anchorStateRegistry();
         IDisputeGameFactory existingDGF = IDisputeGameFactory(payable(address(portal.disputeGameFactory())));
 
-        // Chains must already have ETHLockbox enabled before migrating to the shared interop
-        // lockbox. migrate() moves an existing per-chain lockbox into the shared set; it does not
-        // perform first-time ETHLockbox activation.
-        if (!_systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX) || address(oldLockbox) == address(0)) {
-            revert OPContractsManagerMigrator_EthLockboxNotEnabled();
-        }
-
         // Check the current pause state before mutating the portal's lockbox. For chains that
         // already use a per-chain lockbox, SystemConfig.paused() keys the local pause against the
         // portal's current lockbox. Reinitializing the portal first would switch the pause
@@ -291,6 +281,11 @@ contract OPContractsManagerMigrator is OPContractsManagerUtilsCaller {
         _newLockbox.authorizePortal(portal);
 
         // Enable the features required by portal liquidity migration and shared game migration.
+        // ETH_LOCKBOX must be on so SystemConfig.paused() keys against the portal's lockbox; INTEROP
+        // must be on for the post-migration cross-chain message paths. Both are idempotent.
+        if (!_systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX)) {
+            _systemConfig.setFeature(Features.ETH_LOCKBOX, true);
+        }
         if (!_systemConfig.isFeatureEnabled(Features.INTEROP)) {
             _systemConfig.setFeature(Features.INTEROP, true);
         }

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
@@ -224,6 +224,8 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
     }
 
     /// @notice Upgrades a chain based on the upgrade input.
+    /// @dev This function only performs standard contract upgrades. Interop activation is a
+    ///      one-off migration step handled by OPContractsManagerMigrator.migrate().
     /// @param _inp The chain upgrade input.
     /// @return The upgraded chain contracts.
     function upgrade(UpgradeInput memory _inp) external returns (ChainContracts memory) {
@@ -790,33 +792,16 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
             _cts.proxyAdmin, address(_cts.systemConfig), impls.systemConfigImpl, _makeSystemConfigInitArgs(_cfg, _cts)
         );
 
-        // Update the OptimismPortal.
-        // When interop is enabled, the ETH_LOCKBOX feature must be set on SystemConfig before
-        // upgrading the portal. OptimismPortal2.initialize() calls _assertValidLockboxState()
-        // which requires the ETH_LOCKBOX feature flag and ethLockbox address to be consistent.
-        // Otherwise we end up in a state where we have a lockbox and the feature flag is off.
-        if (isDevFeatureEnabled(DevFeatures.OPTIMISM_PORTAL_INTEROP)) {
-            if (!_cts.systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX)) {
-                _cts.systemConfig.setFeature(Features.ETH_LOCKBOX, true);
-            }
-            _upgrade(
-                _cts.proxyAdmin,
-                address(_cts.optimismPortal),
-                impls.optimismPortalImpl,
-                abi.encodeCall(
-                    IOptimismPortal.initialize, (_cts.systemConfig, _cts.anchorStateRegistry, _cts.ethLockbox)
-                )
-            );
-        } else {
-            _upgrade(
-                _cts.proxyAdmin,
-                address(_cts.optimismPortal),
-                impls.optimismPortalImpl,
-                abi.encodeCall(
-                    IOptimismPortal.initialize, (_cts.systemConfig, _cts.anchorStateRegistry, IETHLockbox(address(0)))
-                )
-            );
-        }
+        // Update the OptimismPortal. If a chain already uses ETHLockbox, preserve that lockbox
+        // during standard upgrades. New interop lockbox activation is performed by migrate().
+        IETHLockbox portalLockbox =
+            _cts.systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX) ? _cts.ethLockbox : IETHLockbox(address(0));
+        _upgrade(
+            _cts.proxyAdmin,
+            address(_cts.optimismPortal),
+            impls.optimismPortalImpl,
+            abi.encodeCall(IOptimismPortal.initialize, (_cts.systemConfig, _cts.anchorStateRegistry, portalLockbox))
+        );
 
         // NOTE: Same general pattern, we call _upgrade for each contract rather than
         // iterating over some sort of array because it's easier to implement and understand.
@@ -832,25 +817,6 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
                 impls.ethLockboxImpl,
                 abi.encodeCall(IETHLockbox.initialize, (_cts.systemConfig, portals))
             );
-        }
-
-        // If interop was requested, also set the ETHLockbox feature and migrate liquidity into the
-        // ETHLockbox contract.
-        if (isDevFeatureEnabled(DevFeatures.OPTIMISM_PORTAL_INTEROP)) {
-            // If we haven't already enabled the ETHLockbox, enable it.
-            // NOTE: setFeature will revert if the system is currently paused because toggling the
-            // lockbox changes the pause identifier. This means a guardian pause will block upgrades
-            // that enable interop. This is acceptable for now since interop is a dev feature and is
-            // not yet production-ready.
-            if (!_cts.systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX)) {
-                _cts.systemConfig.setFeature(Features.ETH_LOCKBOX, true);
-            }
-            if (!_cts.systemConfig.isFeatureEnabled(Features.INTEROP)) {
-                _cts.systemConfig.setFeature(Features.INTEROP, true);
-            }
-
-            // Migrate any ETH into the ETHLockbox.
-            IOptimismPortal(payable(_cts.optimismPortal)).migrateLiquidity();
         }
 
         // Update the L1CrossDomainMessenger.

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
@@ -122,6 +122,9 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
     /// @notice Thrown when an invalid upgrade input is provided.
     error OPContractsManagerV2_InvalidUpgradeInput();
 
+    /// @notice Thrown when ETHLockbox feature state is inconsistent with loaded contracts.
+    error OPContractsManagerV2_InvalidEthLockbox();
+
     /// @notice Thrown when an invalid upgrade instruction is provided.
     error OPContractsManagerV2_InvalidUpgradeInstruction(string _key);
 
@@ -794,8 +797,11 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
 
         // Update the OptimismPortal. If a chain already uses ETHLockbox, preserve that lockbox
         // during standard upgrades. New interop lockbox activation is performed by migrate().
-        IETHLockbox portalLockbox =
-            _cts.systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX) ? _cts.ethLockbox : IETHLockbox(address(0));
+        bool isEthLockboxEnabled = _cts.systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX);
+        if (isEthLockboxEnabled && address(_cts.ethLockbox) == address(0)) {
+            revert OPContractsManagerV2_InvalidEthLockbox();
+        }
+        IETHLockbox portalLockbox = isEthLockboxEnabled ? _cts.ethLockbox : IETHLockbox(address(0));
         _upgrade(
             _cts.proxyAdmin,
             address(_cts.optimismPortal),

--- a/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
+++ b/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
@@ -192,6 +192,16 @@ abstract contract OptimismPortal2_TestInit is DisputeGameFactory_TestInit {
         }
     }
 
+    /// @notice Enables the runtime interop features used by portal migration methods.
+    function forceEnableInterop() public {
+        forceEnableLockbox(address(ethLockbox));
+
+        if (!isSysFeatureEnabled(Features.INTEROP)) {
+            vm.prank(address(proxyAdmin));
+            systemConfig.setFeature(Features.INTEROP, true);
+        }
+    }
+
     /// @notice Sets the useCustomGasToken variable
     function setUseCustomGasToken(bool _useCustomGasToken) public {
         vm.prank(address(proxyAdmin));
@@ -672,10 +682,11 @@ contract OptimismPortal2_DonateETH_Test is OptimismPortal2_TestInit {
 
 /// @title OptimismPortal2_MigrateLiquidity_Test
 /// @notice Test contract for OptimismPortal2 `migrateLiquidity` function.
-contract OptimismPortal2_MigrateLiquidity_Test is CommonTest {
+contract OptimismPortal2_MigrateLiquidity_Test is OptimismPortal2_TestInit {
     function setUp() public virtual override {
         super.setUp();
         skipIfDevFeatureDisabled(DevFeatures.OPTIMISM_PORTAL_INTEROP);
+        forceEnableInterop();
     }
 
     /// @notice Tests the liquidity migration from the portal to the lockbox reverts if not called
@@ -714,6 +725,7 @@ contract OptimismPortal2_migrateToSharedDisputeGame_Test is OptimismPortal2_Test
     function setUp() public override {
         super.setUp();
         skipIfDevFeatureDisabled(DevFeatures.OPTIMISM_PORTAL_INTEROP);
+        forceEnableInterop();
     }
 
     /// @notice Tests that `migrateToSharedDisputeGame` reverts if the caller is not the proxy admin

--- a/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
+++ b/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
@@ -10,7 +10,6 @@ import { ForgeArtifacts, StorageSlot } from "scripts/libraries/ForgeArtifacts.so
 // Libraries
 import { Constants } from "src/libraries/Constants.sol";
 import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
-import { DevFeatures } from "src/libraries/DevFeatures.sol";
 import { Features } from "src/libraries/Features.sol";
 
 // Interfaces
@@ -102,13 +101,9 @@ contract SystemConfig_Initialize_Test is SystemConfig_TestInit {
     }
 
     function test_initialize_interopFlag_succeeds() external view {
-        if (isDevFeatureEnabled(DevFeatures.OPTIMISM_PORTAL_INTEROP)) {
-            /// if devfeature flag is on, check in system config is on
-            assertTrue(systemConfig.isFeatureEnabled(Features.INTEROP));
-        } else {
-            /// if dev feature flag is off, check system config is off
-            assertFalse(systemConfig.isFeatureEnabled(Features.INTEROP));
-        }
+        // The dev feature only makes interop code available. Runtime INTEROP activation is handled
+        // by OPContractsManagerMigrator so initialization does not enable the SystemConfig feature.
+        assertFalse(systemConfig.isFeatureEnabled(Features.INTEROP));
     }
 
     /// @notice Tests that initialization sets the correct values.

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerMigrationValidator.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerMigrationValidator.t.sol
@@ -12,6 +12,7 @@ import { LibGameArgs } from "src/dispute/lib/LibGameArgs.sol";
 import { DevFeatures } from "src/libraries/DevFeatures.sol";
 import { Features } from "src/libraries/Features.sol";
 import { StandardConstants } from "scripts/deploy/StandardConstants.sol";
+import { ForgeArtifacts, StorageSlot } from "scripts/libraries/ForgeArtifacts.sol";
 
 // Interfaces
 import { IDisputeGameFactory } from "interfaces/dispute/IDisputeGameFactory.sol";
@@ -93,6 +94,11 @@ abstract contract OPContractsManagerMigrationValidator_TestInit is CommonTest {
         // Set proposer/challenger before building migration input.
         proposer = makeAddr("superProposer");
         challenger = standardValidator.challenger();
+
+        // Migrator now requires each chain to already have ETH_LOCKBOX enabled with the portal
+        // pointing at its per-chain lockbox. opcmV2.deploy() provisions the lockbox proxy but
+        // does not flip the feature or wire the portal, so simulate that pre-existing state here.
+        _enableEthLockboxes();
 
         // Run real migration with both SPDG and SCKDG.
         _doMigration(_getDefaultMigrateInput());
@@ -243,6 +249,24 @@ abstract contract OPContractsManagerMigrationValidator_TestInit is CommonTest {
         prankDelegateCall(proxyAdminOwner);
         (bool success,) = address(opcmV2).delegatecall(abi.encodeCall(IOPContractsManagerV2.migrate, (_input)));
         assertTrue(success, "migrate failed");
+    }
+
+    /// @notice Enables a chain's existing per-chain ETHLockbox before migration.
+    /// @param _cts The chain contracts to update.
+    function _enableEthLockbox(IOPContractsManagerV2.ChainContracts memory _cts) internal {
+        if (!_cts.systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX)) {
+            vm.prank(address(_cts.proxyAdmin));
+            _cts.systemConfig.setFeature(Features.ETH_LOCKBOX, true);
+        }
+
+        StorageSlot memory slot = ForgeArtifacts.getSlot("OptimismPortal2", "ethLockbox");
+        vm.store(address(_cts.optimismPortal), bytes32(slot.slot), bytes32(uint256(uint160(address(_cts.ethLockbox)))));
+    }
+
+    /// @notice Enables both test chains' per-chain ETHLockboxes before migration.
+    function _enableEthLockboxes() internal {
+        _enableEthLockbox(chainContracts1);
+        _enableEthLockbox(chainContracts2);
     }
 
     /// @notice Builds SharedImplementations from the StandardValidator's state.

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerMigrationValidator.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerMigrationValidator.t.sol
@@ -12,7 +12,6 @@ import { LibGameArgs } from "src/dispute/lib/LibGameArgs.sol";
 import { DevFeatures } from "src/libraries/DevFeatures.sol";
 import { Features } from "src/libraries/Features.sol";
 import { StandardConstants } from "scripts/deploy/StandardConstants.sol";
-import { ForgeArtifacts, StorageSlot } from "scripts/libraries/ForgeArtifacts.sol";
 
 // Interfaces
 import { IDisputeGameFactory } from "interfaces/dispute/IDisputeGameFactory.sol";
@@ -94,11 +93,6 @@ abstract contract OPContractsManagerMigrationValidator_TestInit is CommonTest {
         // Set proposer/challenger before building migration input.
         proposer = makeAddr("superProposer");
         challenger = standardValidator.challenger();
-
-        // Migrator now requires each chain to already have ETH_LOCKBOX enabled with the portal
-        // pointing at its per-chain lockbox. opcmV2.deploy() provisions the lockbox proxy but
-        // does not flip the feature or wire the portal, so simulate that pre-existing state here.
-        _enableEthLockboxes();
 
         // Run real migration with both SPDG and SCKDG.
         _doMigration(_getDefaultMigrateInput());
@@ -249,24 +243,6 @@ abstract contract OPContractsManagerMigrationValidator_TestInit is CommonTest {
         prankDelegateCall(proxyAdminOwner);
         (bool success,) = address(opcmV2).delegatecall(abi.encodeCall(IOPContractsManagerV2.migrate, (_input)));
         assertTrue(success, "migrate failed");
-    }
-
-    /// @notice Enables a chain's existing per-chain ETHLockbox before migration.
-    /// @param _cts The chain contracts to update.
-    function _enableEthLockbox(IOPContractsManagerV2.ChainContracts memory _cts) internal {
-        if (!_cts.systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX)) {
-            vm.prank(address(_cts.proxyAdmin));
-            _cts.systemConfig.setFeature(Features.ETH_LOCKBOX, true);
-        }
-
-        StorageSlot memory slot = ForgeArtifacts.getSlot("OptimismPortal2", "ethLockbox");
-        vm.store(address(_cts.optimismPortal), bytes32(slot.slot), bytes32(uint256(uint160(address(_cts.ethLockbox)))));
-    }
-
-    /// @notice Enables both test chains' per-chain ETHLockboxes before migration.
-    function _enableEthLockboxes() internal {
-        _enableEthLockbox(chainContracts1);
-        _enableEthLockbox(chainContracts2);
     }
 
     /// @notice Builds SharedImplementations from the StandardValidator's state.

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
@@ -540,6 +540,26 @@ contract OPContractsManagerV2_Upgrade_Test is OPContractsManagerV2_Upgrade_TestI
         runCurrentUpgradeV2(chainPAO);
     }
 
+    /// @notice Tests that upgrade does not perform one-off interop activation.
+    function test_upgrade_doesNotActivateInterop_succeeds() public {
+        bool interopEnabledBefore = systemConfig.isFeatureEnabled(Features.INTEROP);
+        bool lockboxEnabledBefore = systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX);
+        uint256 portalBalanceBefore = 1 ether;
+        vm.deal(address(optimismPortal2), portalBalanceBefore);
+
+        IETHLockbox lockboxBefore = optimismPortal2.ethLockbox();
+        uint256 lockboxBalanceBefore = address(lockboxBefore).balance;
+
+        runCurrentUpgradeV2(chainPAO);
+
+        assertEq(systemConfig.isFeatureEnabled(Features.INTEROP), interopEnabledBefore, "INTEROP activation changed");
+        assertEq(
+            systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX), lockboxEnabledBefore, "ETH_LOCKBOX activation changed"
+        );
+        assertEq(address(optimismPortal2).balance, portalBalanceBefore, "portal liquidity migrated during upgrade");
+        assertEq(address(lockboxBefore).balance, lockboxBalanceBefore, "lockbox balance changed during upgrade");
+    }
+
     /// @notice Tests that the upgrade function reverts when not delegatecalled.
     function test_upgrade_notDelegateCalled_reverts() public {
         vm.expectRevert(IOPContractsManagerV2.OPContractsManagerV2_OnlyDelegateCall.selector);
@@ -2186,19 +2206,23 @@ contract OPContractsManagerV2_Migrate_Test is OPContractsManagerV2_TestInit {
     function test_migrate_succeeds() public {
         IOPContractsManagerMigrator.MigrateInput memory input = _getDefaultMigrateInput();
 
-        // Pre-migration setup: Get old lockboxes and fund them.
-        IETHLockbox oldLockbox1;
-        IETHLockbox oldLockbox2;
-        uint256 lockbox1Balance = 10 ether;
-        uint256 lockbox2Balance = 5 ether;
-        {
-            IOptimismPortal2 oldPortal1 = IOptimismPortal2(payable(chainContracts1.systemConfig.optimismPortal()));
-            IOptimismPortal2 oldPortal2 = IOptimismPortal2(payable(chainContracts2.systemConfig.optimismPortal()));
-            oldLockbox1 = oldPortal1.ethLockbox();
-            oldLockbox2 = oldPortal2.ethLockbox();
-            vm.deal(address(oldLockbox1), lockbox1Balance);
-            vm.deal(address(oldLockbox2), lockbox2Balance);
-        }
+        IOptimismPortal2 portal1 = IOptimismPortal2(payable(chainContracts1.systemConfig.optimismPortal()));
+        IOptimismPortal2 portal2 = IOptimismPortal2(payable(chainContracts2.systemConfig.optimismPortal()));
+
+        assertFalse(chainContracts1.systemConfig.isFeatureEnabled(Features.INTEROP), "Chain 1 INTEROP starts enabled");
+        assertFalse(chainContracts2.systemConfig.isFeatureEnabled(Features.INTEROP), "Chain 2 INTEROP starts enabled");
+        assertFalse(
+            chainContracts1.systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX), "Chain 1 ETH_LOCKBOX starts enabled"
+        );
+        assertFalse(
+            chainContracts2.systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX), "Chain 2 ETH_LOCKBOX starts enabled"
+        );
+
+        // Pre-migration setup: fund the portals directly.
+        uint256 portal1Balance = 10 ether;
+        uint256 portal2Balance = 5 ether;
+        vm.deal(address(portal1), portal1Balance);
+        vm.deal(address(portal2), portal2Balance);
 
         // Pre-migration: Get old DisputeGameFactories.
         IDisputeGameFactory oldDGF1 = IDisputeGameFactory(payable(chainContracts1.systemConfig.disputeGameFactory()));
@@ -2210,10 +2234,6 @@ contract OPContractsManagerV2_Migrate_Test is OPContractsManagerV2_TestInit {
         // Assert that the old game implementations are now zeroed out.
         _assertOldGamesZeroed(oldDGF1);
         _assertOldGamesZeroed(oldDGF2);
-
-        // Grab the two OptimismPortal addresses.
-        IOptimismPortal2 portal1 = IOptimismPortal2(payable(chainContracts1.systemConfig.optimismPortal()));
-        IOptimismPortal2 portal2 = IOptimismPortal2(payable(chainContracts2.systemConfig.optimismPortal()));
 
         // Grab the AnchorStateRegistry from the OptimismPortal for both chains, confirm same.
         assertEq(
@@ -2266,18 +2286,80 @@ contract OPContractsManagerV2_Migrate_Test is OPContractsManagerV2_TestInit {
             "SUPER_PERMISSIONED_CANNON init bond mismatch"
         );
 
-        // Check that liquidity was migrated from old lockboxes to the new shared lockbox.
-        assertEq(address(oldLockbox1).balance, 0, "Old lockbox 1 should have 0 balance after migration");
-        assertEq(address(oldLockbox2).balance, 0, "Old lockbox 2 should have 0 balance after migration");
+        // Check that portal liquidity was migrated directly to the new shared lockbox.
+        assertEq(address(portal1).balance, 0, "Portal 1 should have 0 balance after migration");
+        assertEq(address(portal2).balance, 0, "Portal 2 should have 0 balance after migration");
         assertEq(
             address(newLockbox).balance,
-            lockbox1Balance + lockbox2Balance,
-            "New lockbox should have combined balance from both old lockboxes"
+            portal1Balance + portal2Balance,
+            "New lockbox should have combined balance from both portals"
         );
+    }
 
-        // Check that the old lockboxes are authorized on the new lockbox.
-        assertTrue(newLockbox.authorizedLockboxes(oldLockbox1), "Old lockbox 1 should be authorized on new lockbox");
-        assertTrue(newLockbox.authorizedLockboxes(oldLockbox2), "Old lockbox 2 should be authorized on new lockbox");
+    /// @notice Tests that existing per-chain lockbox liquidity is swept into the shared lockbox.
+    function test_migrate_sweepsExistingLockbox_succeeds() public {
+        IOPContractsManagerMigrator.MigrateInput memory input = _getDefaultMigrateInput();
+
+        IOptimismPortal2 portal1 = IOptimismPortal2(payable(chainContracts1.systemConfig.optimismPortal()));
+        IETHLockbox oldLockbox1 = chainContracts1.ethLockbox;
+        IAnchorStateRegistry oldASR = portal1.anchorStateRegistry();
+        uint256 oldLockboxBalance = 7 ether;
+        vm.deal(address(oldLockbox1), oldLockboxBalance);
+
+        // Simulate a chain that already had a per-chain ETHLockbox attached before the interop
+        // migration. The migrator must sweep this old lockbox after moving the portal to the shared
+        // lockbox so the old liquidity is not stranded.
+        vm.mockCall(address(portal1), abi.encodeCall(IOptimismPortal2.ethLockbox, ()), abi.encode(address(oldLockbox1)));
+
+        _doMigration(input);
+
+        vm.clearMockedCalls();
+
+        IETHLockbox newLockbox = portal1.ethLockbox();
+        assertNotEq(address(newLockbox), address(oldLockbox1), "Migration should move portal to shared lockbox");
+        assertNotEq(
+            address(portal1.anchorStateRegistry()), address(oldASR), "Migration should move portal to shared ASR"
+        );
+        assertEq(address(oldLockbox1).balance, 0, "Old lockbox should have 0 balance after migration");
+        assertEq(address(newLockbox).balance, oldLockboxBalance, "New lockbox should receive old lockbox balance");
+        assertTrue(newLockbox.authorizedLockboxes(oldLockbox1), "Old lockbox should be authorized on new lockbox");
+    }
+
+    /// @notice Tests that migration respects a pause keyed to an existing per-chain lockbox.
+    function test_migrate_oldLockboxPaused_reverts() public {
+        IOPContractsManagerMigrator.MigrateInput memory input = _getDefaultMigrateInput();
+
+        IOptimismPortal2 portal1 = IOptimismPortal2(payable(chainContracts1.systemConfig.optimismPortal()));
+        IETHLockbox oldLockbox1 = chainContracts1.ethLockbox;
+
+        // Simulate a chain that already had ETH_LOCKBOX enabled with a per-chain lockbox. The
+        // migrator must check the pause before switching the portal to the shared lockbox, or this
+        // local pause would become invisible because SystemConfig.paused() keys off ethLockbox().
+        vm.mockCall(address(portal1), abi.encodeCall(IOptimismPortal2.ethLockbox, ()), abi.encode(address(oldLockbox1)));
+        vm.prank(address(chainContracts1.proxyAdmin));
+        chainContracts1.systemConfig.setFeature(Features.ETH_LOCKBOX, true);
+        ISuperchainConfig superchainConfig1 = chainContracts1.systemConfig.superchainConfig();
+        vm.prank(superchainConfig1.guardian());
+        superchainConfig1.pause(address(oldLockbox1));
+
+        prankDelegateCall(chainContracts1.proxyAdmin.owner());
+        (bool success, bytes memory returnData) =
+            address(opcmV2).delegatecall(abi.encodeCall(IOPContractsManagerV2.migrate, (input)));
+        assertFalse(success, "migration should revert while the old lockbox is paused");
+        assertEq(bytes4(returnData), IOPContractsManagerMigrator.OPContractsManagerMigrator_SystemPaused.selector);
+
+        vm.clearMockedCalls();
+    }
+
+    /// @notice Tests that migration cannot be rerun.
+    function test_migrate_calledTwice_reverts() public {
+        IOPContractsManagerMigrator.MigrateInput memory input = _getDefaultMigrateInput();
+
+        _doMigration(input);
+
+        prankDelegateCall(chainContracts1.proxyAdmin.owner());
+        (bool success,) = address(opcmV2).delegatecall(abi.encodeCall(IOPContractsManagerV2.migrate, (input)));
+        assertFalse(success, "second migration should revert");
     }
 
     /// @notice Tests that the migration function reverts when the ProxyAdmin owners are mismatched.
@@ -2391,36 +2473,6 @@ contract OPContractsManagerV2_Migrate_Test is OPContractsManagerV2_TestInit {
 
         // Execute the migration, expect revert.
         _doMigration(input, IOPContractsManagerMigrator.OPContractsManagerMigrator_InteropNotEnabled.selector);
-    }
-
-    /// @notice Tests that the migration function reverts when a chain's SystemConfig does not have
-    ///         Features.INTEROP enabled, simulating Step 1 (OPCMv2.upgrade) not having run.
-    function test_migrate_interopFeatureNotEnabled_reverts() public {
-        IOPContractsManagerMigrator.MigrateInput memory input = _getDefaultMigrateInput();
-
-        // Mock one chain's SystemConfig to report Features.INTEROP as disabled.
-        vm.mockCall(
-            address(chainContracts1.systemConfig),
-            abi.encodeCall(ISystemConfig.isFeatureEnabled, (Features.INTEROP)),
-            abi.encode(false)
-        );
-
-        _doMigration(input, IOPContractsManagerMigrator.OPContractsManagerMigrator_InteropFeatureNotEnabled.selector);
-    }
-
-    /// @notice Tests that the migration function reverts when a chain's SystemConfig does not have
-    ///         Features.ETH_LOCKBOX enabled, simulating Step 1 (OPCMv2.upgrade) not having run.
-    function test_migrate_ethLockboxFeatureNotEnabled_reverts() public {
-        IOPContractsManagerMigrator.MigrateInput memory input = _getDefaultMigrateInput();
-
-        // Mock one chain's SystemConfig to report Features.ETH_LOCKBOX as disabled.
-        vm.mockCall(
-            address(chainContracts1.systemConfig),
-            abi.encodeCall(ISystemConfig.isFeatureEnabled, (Features.ETH_LOCKBOX)),
-            abi.encode(false)
-        );
-
-        _doMigration(input, IOPContractsManagerMigrator.OPContractsManagerMigrator_EthLockboxFeatureNotEnabled.selector);
     }
 }
 

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
@@ -10,6 +10,7 @@ import { BatchUpgrader } from "test/L1/opcm/helpers/BatchUpgrader.sol";
 
 // Libraries
 import { Config } from "scripts/libraries/Config.sol";
+import { ForgeArtifacts, StorageSlot } from "scripts/libraries/ForgeArtifacts.sol";
 import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 import { Claim, Duration, Hash } from "src/dispute/lib/LibUDT.sol";
 import { GameType, GameTypes, Proposal } from "src/dispute/lib/Types.sol";
@@ -2169,6 +2170,24 @@ contract OPContractsManagerV2_Migrate_Test is OPContractsManagerV2_TestInit {
         assertLt(gasBefore - gasAfter, 20_000_000, "Gas usage too high");
     }
 
+    /// @notice Helper function to enable a chain's existing per-chain ETHLockbox before migration.
+    /// @param _cts The chain contracts to update.
+    function _enableEthLockbox(IOPContractsManagerV2.ChainContracts memory _cts) internal {
+        if (!_cts.systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX)) {
+            vm.prank(address(_cts.proxyAdmin));
+            _cts.systemConfig.setFeature(Features.ETH_LOCKBOX, true);
+        }
+
+        StorageSlot memory slot = ForgeArtifacts.getSlot("OptimismPortal2", "ethLockbox");
+        vm.store(address(_cts.optimismPortal), bytes32(slot.slot), bytes32(uint256(uint160(address(_cts.ethLockbox)))));
+    }
+
+    /// @notice Helper function to enable both test chains' per-chain ETHLockboxes before migration.
+    function _enableEthLockboxes() internal {
+        _enableEthLockbox(chainContracts1);
+        _enableEthLockbox(chainContracts2);
+    }
+
     /// @notice Helper function to assert that the old game implementations are now zeroed out.
     /// @param _disputeGameFactory The dispute game factory to check.
     function _assertOldGamesZeroed(IDisputeGameFactory _disputeGameFactory) internal view {
@@ -2211,11 +2230,18 @@ contract OPContractsManagerV2_Migrate_Test is OPContractsManagerV2_TestInit {
 
         assertFalse(chainContracts1.systemConfig.isFeatureEnabled(Features.INTEROP), "Chain 1 INTEROP starts enabled");
         assertFalse(chainContracts2.systemConfig.isFeatureEnabled(Features.INTEROP), "Chain 2 INTEROP starts enabled");
+        _enableEthLockboxes();
         assertFalse(
-            chainContracts1.systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX), "Chain 1 ETH_LOCKBOX starts enabled"
+            chainContracts1.systemConfig.isFeatureEnabled(Features.INTEROP), "Chain 1 INTEROP changed during setup"
         );
         assertFalse(
-            chainContracts2.systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX), "Chain 2 ETH_LOCKBOX starts enabled"
+            chainContracts2.systemConfig.isFeatureEnabled(Features.INTEROP), "Chain 2 INTEROP changed during setup"
+        );
+        assertTrue(
+            chainContracts1.systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX), "Chain 1 ETH_LOCKBOX should be enabled"
+        );
+        assertTrue(
+            chainContracts2.systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX), "Chain 2 ETH_LOCKBOX should be enabled"
         );
 
         // Pre-migration setup: fund the portals directly.
@@ -2301,19 +2327,13 @@ contract OPContractsManagerV2_Migrate_Test is OPContractsManagerV2_TestInit {
         IOPContractsManagerMigrator.MigrateInput memory input = _getDefaultMigrateInput();
 
         IOptimismPortal2 portal1 = IOptimismPortal2(payable(chainContracts1.systemConfig.optimismPortal()));
+        _enableEthLockboxes();
         IETHLockbox oldLockbox1 = chainContracts1.ethLockbox;
         IAnchorStateRegistry oldASR = portal1.anchorStateRegistry();
         uint256 oldLockboxBalance = 7 ether;
         vm.deal(address(oldLockbox1), oldLockboxBalance);
 
-        // Simulate a chain that already had a per-chain ETHLockbox attached before the interop
-        // migration. The migrator must sweep this old lockbox after moving the portal to the shared
-        // lockbox so the old liquidity is not stranded.
-        vm.mockCall(address(portal1), abi.encodeCall(IOptimismPortal2.ethLockbox, ()), abi.encode(address(oldLockbox1)));
-
         _doMigration(input);
-
-        vm.clearMockedCalls();
 
         IETHLockbox newLockbox = portal1.ethLockbox();
         assertNotEq(address(newLockbox), address(oldLockbox1), "Migration should move portal to shared lockbox");
@@ -2329,15 +2349,11 @@ contract OPContractsManagerV2_Migrate_Test is OPContractsManagerV2_TestInit {
     function test_migrate_oldLockboxPaused_reverts() public {
         IOPContractsManagerMigrator.MigrateInput memory input = _getDefaultMigrateInput();
 
-        IOptimismPortal2 portal1 = IOptimismPortal2(payable(chainContracts1.systemConfig.optimismPortal()));
+        _enableEthLockboxes();
         IETHLockbox oldLockbox1 = chainContracts1.ethLockbox;
 
-        // Simulate a chain that already had ETH_LOCKBOX enabled with a per-chain lockbox. The
-        // migrator must check the pause before switching the portal to the shared lockbox, or this
-        // local pause would become invisible because SystemConfig.paused() keys off ethLockbox().
-        vm.mockCall(address(portal1), abi.encodeCall(IOptimismPortal2.ethLockbox, ()), abi.encode(address(oldLockbox1)));
-        vm.prank(address(chainContracts1.proxyAdmin));
-        chainContracts1.systemConfig.setFeature(Features.ETH_LOCKBOX, true);
+        // The migrator must check the pause before switching the portal to the shared lockbox, or
+        // this local pause would become invisible because SystemConfig.paused() keys off ethLockbox().
         ISuperchainConfig superchainConfig1 = chainContracts1.systemConfig.superchainConfig();
         vm.prank(superchainConfig1.guardian());
         superchainConfig1.pause(address(oldLockbox1));
@@ -2347,13 +2363,12 @@ contract OPContractsManagerV2_Migrate_Test is OPContractsManagerV2_TestInit {
             address(opcmV2).delegatecall(abi.encodeCall(IOPContractsManagerV2.migrate, (input)));
         assertFalse(success, "migration should revert while the old lockbox is paused");
         assertEq(bytes4(returnData), IOPContractsManagerMigrator.OPContractsManagerMigrator_SystemPaused.selector);
-
-        vm.clearMockedCalls();
     }
 
     /// @notice Tests that migration cannot be rerun.
     function test_migrate_calledTwice_reverts() public {
         IOPContractsManagerMigrator.MigrateInput memory input = _getDefaultMigrateInput();
+        _enableEthLockboxes();
 
         _doMigration(input);
 
@@ -2437,6 +2452,23 @@ contract OPContractsManagerV2_Migrate_Test is OPContractsManagerV2_TestInit {
             _getDefaultMigrateInput(),
             IOPContractsManagerMigrator.OPContractsManagerMigrator_CustomGasTokenNotSupported.selector
         );
+    }
+
+    /// @notice Tests that migration reverts when a chain has not enabled ETHLockbox.
+    function test_migrate_ethLockboxNotEnabled_reverts() public {
+        IOPContractsManagerMigrator.MigrateInput memory input = _getDefaultMigrateInput();
+
+        _doMigration(input, IOPContractsManagerMigrator.OPContractsManagerMigrator_EthLockboxNotEnabled.selector);
+    }
+
+    /// @notice Tests that migration reverts when ETHLockbox is enabled but the portal has no lockbox.
+    function test_migrate_ethLockboxEnabledButPortalLockboxZero_reverts() public {
+        IOPContractsManagerMigrator.MigrateInput memory input = _getDefaultMigrateInput();
+
+        vm.prank(address(chainContracts1.proxyAdmin));
+        chainContracts1.systemConfig.setFeature(Features.ETH_LOCKBOX, true);
+
+        _doMigration(input, IOPContractsManagerMigrator.OPContractsManagerMigrator_EthLockboxNotEnabled.selector);
     }
 
     /// @notice Tests that the migration function reverts when the starting respected game type is invalid.

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
@@ -2454,23 +2454,6 @@ contract OPContractsManagerV2_Migrate_Test is OPContractsManagerV2_TestInit {
         );
     }
 
-    /// @notice Tests that migration reverts when a chain has not enabled ETHLockbox.
-    function test_migrate_ethLockboxNotEnabled_reverts() public {
-        IOPContractsManagerMigrator.MigrateInput memory input = _getDefaultMigrateInput();
-
-        _doMigration(input, IOPContractsManagerMigrator.OPContractsManagerMigrator_EthLockboxNotEnabled.selector);
-    }
-
-    /// @notice Tests that migration reverts when ETHLockbox is enabled but the portal has no lockbox.
-    function test_migrate_ethLockboxEnabledButPortalLockboxZero_reverts() public {
-        IOPContractsManagerMigrator.MigrateInput memory input = _getDefaultMigrateInput();
-
-        vm.prank(address(chainContracts1.proxyAdmin));
-        chainContracts1.systemConfig.setFeature(Features.ETH_LOCKBOX, true);
-
-        _doMigration(input, IOPContractsManagerMigrator.OPContractsManagerMigrator_EthLockboxNotEnabled.selector);
-    }
-
     /// @notice Tests that the migration function reverts when the starting respected game type is invalid.
     /// @param _gameTypeRaw The raw game type value to test.
     function testFuzz_migrate_invalidStartingRespectedGameType_reverts(uint32 _gameTypeRaw) public {


### PR DESCRIPTION
Moves interop activation out of `OPContractsManagerV2.upgrade()` so standard deploy/upgrade flows no longer enable `INTEROP`/`ETH_LOCKBOX` or migrate portal liquidity as a side effect.

`OPContractsManagerMigrator.migrate()` now enables the required features, connects portals to the shared ETHLockbox, migrates portal-held ETH, sweeps existing per-chain lockbox liquidity, and moves portals to the shared dispute-game setup while preserving active old-lockbox pause checks.

Tests were updated for the new activation order, direct shared-lockbox liquidity migration, existing-lockbox sweep coverage, rerun rejection, and validator expectations.

Validation: `just clean`, `forge clean`, `just pre-pr`, targeted OPCM migration/validator tests, and a broader `DEV_FEATURE__OPTIMISM_PORTAL_INTEROP=true just test` run.

Closes #20368.
