### PR TITLE
test(kona): post-exec tx / SDM coverage in proof executor

### DIFF
--- a/rust/kona/crates/proof/executor/Cargo.toml
+++ b/rust/kona/crates/proof/executor/Cargo.toml
@@ -56,6 +56,23 @@ alloy-rpc-client = { workspace = true, optional = true }
 alloy-transport = { workspace = true, optional = true }
 alloy-transport-http = { workspace = true, optional = true }
 
+# Mirrors the optional `test-utils` feature deps so `cargo test -p kona-executor`
+# compiles the `test_utils` module (and the post-exec unit tests in `core`) without
+# requiring `--features test-utils`.
+[dev-dependencies]
+alloy-provider = { workspace = true, features = ["reqwest"] }
+alloy-rpc-client.workspace = true
+alloy-rpc-types-engine.workspace = true
+alloy-transport.workspace = true
+alloy-transport-http.workspace = true
+kona-registry.workspace = true
+rocksdb = { workspace = true, features = ["snappy"] }
+rstest.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+tempfile.workspace = true
+tokio = { workspace = true, features = ["full"] }
+
 [features]
 test-utils = [
 	"dep:alloy-provider",

--- a/rust/kona/crates/proof/executor/src/builder/core.rs
+++ b/rust/kona/crates/proof/executor/src/builder/core.rs
@@ -99,6 +99,9 @@ where
     /// understand OP-specific transaction types, system calls, and state
     /// management required for proper L2 block execution.
     pub(crate) factory: OpBlockExecutorFactory<OpAlloyReceiptBuilder, RollupConfig, Evm>,
+    /// Test-only override for SDM activation while the fork is not yet scheduled.
+    #[cfg(any(test, feature = "test-utils"))]
+    pub(crate) sdm_active_override: Option<bool>,
 }
 
 impl<'a, P, H, Evm> StatelessL2Builder<'a, P, H, Evm>
@@ -153,7 +156,29 @@ where
             config.clone(),
             evm_factory,
         );
-        Self { config, trie_db, factory }
+        Self {
+            config,
+            trie_db,
+            factory,
+            #[cfg(any(test, feature = "test-utils"))]
+            sdm_active_override: None,
+        }
+    }
+
+    /// Overrides SDM activation for tests and fixture tooling.
+    #[cfg(any(test, feature = "test-utils"))]
+    pub const fn set_sdm_active_override(&mut self, sdm_active_override: Option<bool>) {
+        self.sdm_active_override = sdm_active_override;
+    }
+
+    /// Returns whether SDM is active at the given timestamp.
+    const fn is_sdm_active(&self, timestamp: u64) -> bool {
+        #[cfg(any(test, feature = "test-utils"))]
+        if let Some(active) = self.sdm_active_override {
+            return active;
+        }
+
+        self.config.is_sdm_active(timestamp)
     }
 
     /// Builds and executes a new L2 block using the provided payload attributes.
@@ -255,6 +280,9 @@ where
             "Beginning block building."
         );
 
+        // Compute SDM activation before borrowing `self.trie_db` mutably below.
+        let sdm_active = self.is_sdm_active(block_env.timestamp.saturating_to());
+
         // Step 2. Create the executor, using the trie database.
         let mut state =
             State::builder().with_database(&mut self.trie_db).with_bundle_update().build();
@@ -267,7 +295,7 @@ where
         let post_exec_mode = parse_post_exec_payload_from_transactions(
             transactions.iter().map(RecoveredTx::tx),
             block_env.number.saturating_to(),
-            self.config.is_sdm_active(block_env.timestamp.saturating_to()),
+            sdm_active,
         )
         .map_err(|err| ExecutorError::InvalidPostExecPayload(err.into_string()))?
         .map(|parsed| PostExecMode::Verify(parsed.payload))
@@ -331,18 +359,4 @@ impl From<(Sealed<Header>, BlockExecutionResult<OpReceiptEnvelope>)> for BlockBu
 }
 
 #[cfg(test)]
-mod test {
-    use crate::test_utils::run_test_fixture;
-    use rstest::rstest;
-    use std::path::PathBuf;
-
-    #[rstest]
-    #[tokio::test]
-    async fn test_statelessly_execute_block(
-        #[base_dir = "./testdata"]
-        #[files("*.tar.gz")]
-        path: PathBuf,
-    ) {
-        run_test_fixture(path).await;
-    }
-}
+mod tests;

--- a/rust/kona/crates/proof/executor/src/builder/core/tests.rs
+++ b/rust/kona/crates/proof/executor/src/builder/core/tests.rs
@@ -1,0 +1,217 @@
+use crate::{
+    ExecutorError,
+    test_utils::{execute_loaded_fixture, load_test_fixture, run_test_fixture},
+};
+use alloy_consensus::Header;
+use alloy_eips::Encodable2718;
+use op_alloy_consensus::{OpReceiptEnvelope, SDMGasEntry, build_post_exec_tx};
+use rstest::rstest;
+use std::path::PathBuf;
+
+/// Path to the fixture used by all post-exec tests.
+///
+/// The chosen fixture must contain a regular (non-deposit, non-post-exec) tx at index 1, since
+/// several tests target that index when constructing payload entries.
+fn post_exec_fixture_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("testdata/block-26207960.tar.gz")
+}
+
+fn fixture_block_number(parent_header: &Header) -> u64 {
+    parent_header.number + 1
+}
+
+fn append_post_exec_tx(
+    transactions: &mut Vec<alloy_primitives::Bytes>,
+    block_number: u64,
+    gas_refund_entries: Vec<SDMGasEntry>,
+) {
+    let tx = build_post_exec_tx(block_number, gas_refund_entries);
+    let mut encoded = Vec::with_capacity(tx.eip2718_encoded_length());
+    tx.encode_2718(&mut encoded);
+    transactions.push(encoded.into());
+}
+
+/// Asserts that `err` is a post-exec validation failure containing `expected`.
+///
+/// Matches both the parser-level [`ExecutorError::InvalidPostExecPayload`] and the
+/// execution-level `OpBlockExecutionError::InvalidPostExecPayload` wrapped in
+/// [`ExecutorError::ExecutionError`], since both render with the substring
+/// `"invalid post-exec payload"`.
+fn assert_post_exec_validation_failure(err: ExecutorError, expected: &str) {
+    let err = err.to_string();
+    assert!(err.to_lowercase().contains("invalid post-exec payload"), "unexpected error: {err}");
+    assert!(err.contains(expected), "expected {err:?} to contain {expected:?}");
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_statelessly_execute_block(
+    #[base_dir = "./testdata"]
+    #[files("*.tar.gz")]
+    path: PathBuf,
+) {
+    run_test_fixture(path).await;
+}
+
+/// Verifies the default fallthrough: with no override, [`StatelessL2Builder`] consults the
+/// rollup config, where SDM is currently unscheduled and reports inactive.
+#[tokio::test]
+async fn post_exec_sdm_inherit_rejects_post_exec_tx() {
+    let mut loaded = load_test_fixture(post_exec_fixture_path()).await;
+    let block_number = fixture_block_number(&loaded.fixture.parent_header);
+    append_post_exec_tx(
+        loaded.fixture.executing_payload.transactions.as_mut().unwrap(),
+        block_number,
+        Vec::new(),
+    );
+
+    let err = execute_loaded_fixture(loaded, None).unwrap_err();
+    assert_post_exec_validation_failure(err, "SDM not active");
+}
+
+/// Verifies the explicit-override deactivation path. Pairs with
+/// [`post_exec_sdm_inherit_rejects_post_exec_tx`] above, which exercises the inherit branch.
+#[tokio::test]
+async fn post_exec_sdm_forced_inactive_rejects_appended_post_exec_tx() {
+    let mut loaded = load_test_fixture(post_exec_fixture_path()).await;
+    let block_number = fixture_block_number(&loaded.fixture.parent_header);
+    append_post_exec_tx(
+        loaded.fixture.executing_payload.transactions.as_mut().unwrap(),
+        block_number,
+        Vec::new(),
+    );
+
+    let err = execute_loaded_fixture(loaded, Some(false)).unwrap_err();
+    assert_post_exec_validation_failure(err, "SDM not active");
+}
+
+#[tokio::test]
+async fn post_exec_sdm_enabled_rejects_wrong_block_number() {
+    let mut loaded = load_test_fixture(post_exec_fixture_path()).await;
+    let block_number = fixture_block_number(&loaded.fixture.parent_header);
+    append_post_exec_tx(
+        loaded.fixture.executing_payload.transactions.as_mut().unwrap(),
+        block_number + 1,
+        Vec::new(),
+    );
+
+    let err = execute_loaded_fixture(loaded, Some(true)).unwrap_err();
+    assert_post_exec_validation_failure(err, "does not match block number");
+}
+
+#[tokio::test]
+async fn post_exec_sdm_enabled_rejects_duplicate_post_exec_txs() {
+    let mut loaded = load_test_fixture(post_exec_fixture_path()).await;
+    let block_number = fixture_block_number(&loaded.fixture.parent_header);
+    let transactions = loaded.fixture.executing_payload.transactions.as_mut().unwrap();
+    append_post_exec_tx(transactions, block_number, Vec::new());
+    append_post_exec_tx(transactions, block_number, Vec::new());
+
+    let err = execute_loaded_fixture(loaded, Some(true)).unwrap_err();
+    assert_post_exec_validation_failure(err, "multiple post-exec transactions");
+}
+
+#[tokio::test]
+async fn post_exec_valid_empty_payload_executes_without_state_or_gas_change() {
+    let baseline = execute_loaded_fixture(load_test_fixture(post_exec_fixture_path()).await, None)
+        .expect("baseline fixture must execute");
+
+    let mut loaded = load_test_fixture(post_exec_fixture_path()).await;
+    let block_number = fixture_block_number(&loaded.fixture.parent_header);
+    append_post_exec_tx(
+        loaded.fixture.executing_payload.transactions.as_mut().unwrap(),
+        block_number,
+        Vec::new(),
+    );
+
+    let outcome = execute_loaded_fixture(loaded, Some(true)).expect("post-exec fixture executes");
+    assert_eq!(
+        outcome.execution_result.receipts.len(),
+        baseline.execution_result.receipts.len() + 1
+    );
+    assert!(matches!(
+        outcome.execution_result.receipts.last(),
+        Some(OpReceiptEnvelope::PostExec(_))
+    ));
+    assert_eq!(outcome.execution_result.gas_used, baseline.execution_result.gas_used);
+    assert_eq!(outcome.header.state_root, baseline.header.state_root);
+    assert_ne!(outcome.header.transactions_root, baseline.header.transactions_root);
+    assert_ne!(outcome.header.receipts_root, baseline.header.receipts_root);
+}
+
+#[tokio::test]
+async fn post_exec_payload_rejects_deposit_target() {
+    let mut loaded = load_test_fixture(post_exec_fixture_path()).await;
+    let block_number = fixture_block_number(&loaded.fixture.parent_header);
+    append_post_exec_tx(
+        loaded.fixture.executing_payload.transactions.as_mut().unwrap(),
+        block_number,
+        vec![SDMGasEntry { index: 0, gas_refund: 1 }],
+    );
+
+    let err = execute_loaded_fixture(loaded, Some(true)).unwrap_err();
+    assert_post_exec_validation_failure(err, "payload entry targets deposit tx index 0");
+}
+
+#[tokio::test]
+async fn post_exec_payload_rejects_post_exec_target() {
+    let mut loaded = load_test_fixture(post_exec_fixture_path()).await;
+    let block_number = fixture_block_number(&loaded.fixture.parent_header);
+    let post_exec_index =
+        loaded.fixture.executing_payload.transactions.as_ref().unwrap().len() as u64;
+    append_post_exec_tx(
+        loaded.fixture.executing_payload.transactions.as_mut().unwrap(),
+        block_number,
+        vec![SDMGasEntry { index: post_exec_index, gas_refund: 1 }],
+    );
+
+    let err = execute_loaded_fixture(loaded, Some(true)).unwrap_err();
+    assert_post_exec_validation_failure(
+        err,
+        &format!("payload entry targets post-exec tx index {post_exec_index}"),
+    );
+}
+
+#[tokio::test]
+async fn post_exec_payload_rejects_duplicate_entries() {
+    let mut loaded = load_test_fixture(post_exec_fixture_path()).await;
+    let block_number = fixture_block_number(&loaded.fixture.parent_header);
+    append_post_exec_tx(
+        loaded.fixture.executing_payload.transactions.as_mut().unwrap(),
+        block_number,
+        vec![SDMGasEntry { index: 1, gas_refund: 1 }, SDMGasEntry { index: 1, gas_refund: 2 }],
+    );
+
+    let err = execute_loaded_fixture(loaded, Some(true)).unwrap_err();
+    assert_post_exec_validation_failure(err, "duplicate post-exec payload entry for tx index 1");
+}
+
+#[tokio::test]
+async fn post_exec_payload_rejects_unconsumed_entry() {
+    let mut loaded = load_test_fixture(post_exec_fixture_path()).await;
+    let block_number = fixture_block_number(&loaded.fixture.parent_header);
+    let out_of_range_index =
+        loaded.fixture.executing_payload.transactions.as_ref().unwrap().len() as u64 + 1;
+    append_post_exec_tx(
+        loaded.fixture.executing_payload.transactions.as_mut().unwrap(),
+        block_number,
+        vec![SDMGasEntry { index: out_of_range_index, gas_refund: 1 }],
+    );
+
+    let err = execute_loaded_fixture(loaded, Some(true)).unwrap_err();
+    assert_post_exec_validation_failure(err, "unconsumed post-exec payload entries");
+}
+
+#[tokio::test]
+async fn post_exec_payload_rejects_refund_exceeding_gas_used() {
+    let mut loaded = load_test_fixture(post_exec_fixture_path()).await;
+    let block_number = fixture_block_number(&loaded.fixture.parent_header);
+    append_post_exec_tx(
+        loaded.fixture.executing_payload.transactions.as_mut().unwrap(),
+        block_number,
+        vec![SDMGasEntry { index: 1, gas_refund: u64::MAX }],
+    );
+
+    let err = execute_loaded_fixture(loaded, Some(true)).unwrap_err();
+    assert_post_exec_validation_failure(err, "exceeds evm_gas_used");
+}

--- a/rust/kona/crates/proof/executor/src/test_utils.rs
+++ b/rust/kona/crates/proof/executor/src/test_utils.rs
@@ -1,6 +1,6 @@
 //! Test utilities for the executor.
 
-use crate::{StatelessL2Builder, TrieDBProvider};
+use crate::{BlockBuildingOutcome, ExecutorResult, StatelessL2Builder, TrieDBProvider};
 use alloy_consensus::Header;
 use alloy_op_evm::OpEvmFactory;
 use alloy_primitives::{B256, Bytes, Sealable};
@@ -18,10 +18,19 @@ use serde::{Deserialize, Serialize};
 use std::{path::PathBuf, sync::Arc};
 use tokio::{fs, runtime::Handle, sync::Mutex};
 
-/// Executes a [`ExecutorTestFixture`] stored at the passed `fixture_path` and asserts that the
-/// produced block hash matches the expected block hash.
-pub async fn run_test_fixture(fixture_path: PathBuf) {
-    // First, untar the fixture.
+/// A loaded executor test fixture and its backing temporary fixture directory.
+#[derive(Debug)]
+pub struct LoadedExecutorTestFixture {
+    /// Keeps the untarred fixture directory alive while the `RocksDB` provider is open.
+    pub fixture_dir: tempfile::TempDir,
+    /// The deserialized fixture metadata and payload.
+    pub fixture: ExecutorTestFixture,
+    /// Trie/database provider backed by the fixture's key-value store.
+    pub provider: DiskTrieNodeProvider,
+}
+
+/// Loads a [`ExecutorTestFixture`] stored at the passed `fixture_path`.
+pub async fn load_test_fixture(fixture_path: PathBuf) -> LoadedExecutorTestFixture {
     let fixture_dir = tempfile::tempdir().expect("Failed to create temporary directory");
     tokio::process::Command::new("tar")
         .arg("-xvf")
@@ -43,19 +52,39 @@ pub async fn run_test_fixture(fixture_path: PathBuf) {
         serde_json::from_slice(&fs::read(fixture_dir.path().join("fixture.json")).await.unwrap())
             .expect("Failed to deserialize fixture");
 
+    LoadedExecutorTestFixture { fixture_dir, fixture, provider }
+}
+
+/// Executes a loaded fixture, optionally overriding SDM activation for the run.
+pub fn execute_loaded_fixture(
+    loaded: LoadedExecutorTestFixture,
+    sdm_active_override: Option<bool>,
+) -> ExecutorResult<BlockBuildingOutcome> {
+    let LoadedExecutorTestFixture { fixture_dir: _fixture_dir, fixture, provider } = loaded;
+    let ExecutorTestFixture { rollup_config, parent_header, executing_payload, .. } = fixture;
+
     let mut executor = StatelessL2Builder::new(
-        &fixture.rollup_config,
+        &rollup_config,
         OpEvmFactory::<alloy_op_evm::OpTx>::default(),
         provider,
         NoopTrieHinter,
-        fixture.parent_header.seal_slow(),
+        parent_header.seal_slow(),
     );
+    executor.set_sdm_active_override(sdm_active_override);
 
-    let outcome = executor.build_block(fixture.executing_payload).unwrap();
+    executor.build_block(executing_payload)
+}
+
+/// Executes a [`ExecutorTestFixture`] stored at the passed `fixture_path` and asserts that the
+/// produced block hash matches the expected block hash.
+pub async fn run_test_fixture(fixture_path: PathBuf) {
+    let loaded = load_test_fixture(fixture_path).await;
+    let expected_block_hash = loaded.fixture.expected_block_hash;
+    let outcome = execute_loaded_fixture(loaded, None).unwrap();
 
     assert_eq!(
         outcome.header.hash(),
-        fixture.expected_block_hash,
+        expected_block_hash,
         "Produced header does not match the expected header"
     );
 }


### PR DESCRIPTION
- Adds 10 post-exec / `SDM` unit tests to `kona-executor` covering parser checks, executor payload validation, and a happy-path `PostExec` execution.
- Adds a `cfg(test, feature = "test-utils")`-gated SDM activation override on `StatelessL2Builder` (SDM has no scheduled fork yet) and splits `test_utils` into `load`/`execute`/`run` so tests can mutate fixtures and inspect outcomes.

Once SDM gets a scheduled hardfork timestamp on `RollupConfig::Hardforks`, all three current overrides (kona's `sdm_active_override`, `OpEvmConfig::sdm_enabled`, `OpBuilderConfig::sdm_enabled`) become dead code: `is_sdm_active(timestamp)` does the right thing on all chains.

Removing the overrides is the cleanup PR that lands alongside the activation schedule.