### PR TITLE
feat(interopgen): add UseL2CM toggle to L2Config

### DIFF
--- a/op-chain-ops/interopgen/configs.go
+++ b/op-chain-ops/interopgen/configs.go
@@ -81,6 +81,7 @@ type L2Config struct {
 	DisputeSplitDepth           uint64
 	DisputeClockExtension       uint64
 	DisputeMaxClockDuration     uint64
+	UseL2CM                     bool
 }
 
 func (c *L2Config) Check(log log.Logger) error {

--- a/op-chain-ops/interopgen/configs.go
+++ b/op-chain-ops/interopgen/configs.go
@@ -81,7 +81,8 @@ type L2Config struct {
 	DisputeSplitDepth           uint64
 	DisputeClockExtension       uint64
 	DisputeMaxClockDuration     uint64
-	UseL2CM                     bool
+	// TODO(#20084): remove once L2CM is the default codepath and DevFeatures are removed.
+	UseL2CM bool
 }
 
 func (c *L2Config) Check(log log.Logger) error {

--- a/op-chain-ops/interopgen/deploy.go
+++ b/op-chain-ops/interopgen/deploy.go
@@ -369,7 +369,7 @@ func GenesisL2(l2Host *script.Host, cfg *L2Config, deployment *L2Deployment, mul
 		GasPayingTokenSymbol:                     cfg.GasPayingTokenSymbol,
 		NativeAssetLiquidityAmount:               cfg.NativeAssetLiquidityAmount.ToInt(),
 		LiquidityControllerOwner:                 cfg.LiquidityControllerOwner,
-		DevFeatureBitmap:                         devFeatureBitmapForL2Genesis(multichainDepSet && interopAtGenesis(cfg.L2GenesisInteropTimeOffset)),
+		DevFeatureBitmap:                         devFeatureBitmapForL2Genesis(multichainDepSet && interopAtGenesis(cfg.L2GenesisInteropTimeOffset), cfg.UseL2CM),
 		UseInterop:                               multichainDepSet && interopAtGenesis(cfg.L2GenesisInteropTimeOffset),
 	}); err != nil {
 		return fmt.Errorf("failed L2 genesis: %w", err)
@@ -384,12 +384,15 @@ func interopAtGenesis(interopOffset *hexutil.Uint64) bool {
 	return interopOffset != nil && *interopOffset == 0
 }
 
-// devFeatureBitmapForL2Genesis returns the dev feature bitmap for the L2 genesis based on whether Interop should be
-// enabled or not.
-func devFeatureBitmapForL2Genesis(enableInterop bool) common.Hash {
+// devFeatureBitmapForL2Genesis returns the dev feature bitmap for the L2 genesis based on whether Interop and L2CM
+// should be enabled or not.
+func devFeatureBitmapForL2Genesis(enableInterop, useL2CM bool) common.Hash {
 	var bitmap common.Hash
 	if enableInterop {
 		bitmap = devfeatures.EnableDevFeature(bitmap, devfeatures.OptimismPortalInteropFlag)
+	}
+	if useL2CM {
+		bitmap = devfeatures.EnableDevFeature(bitmap, devfeatures.L2CMFlag)
 	}
 	return bitmap
 }

--- a/op-chain-ops/interopgen/deploy.go
+++ b/op-chain-ops/interopgen/deploy.go
@@ -384,8 +384,8 @@ func interopAtGenesis(interopOffset *hexutil.Uint64) bool {
 	return interopOffset != nil && *interopOffset == 0
 }
 
-// devFeatureBitmapForL2Genesis returns the dev feature bitmap for the L2 genesis based on whether Interop and L2CM
-// should be enabled or not.
+// devFeatureBitmapForL2Genesis returns the dev feature bitmap for the Interop and L2CM flags.
+// TODO(#20084): drop useL2CM and the L2CMFlag branch once DevFeatures are removed.
 func devFeatureBitmapForL2Genesis(enableInterop, useL2CM bool) common.Hash {
 	var bitmap common.Hash
 	if enableInterop {

--- a/op-chain-ops/interopgen/deploy_test.go
+++ b/op-chain-ops/interopgen/deploy_test.go
@@ -3,6 +3,7 @@ package interopgen
 import (
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-core/devfeatures"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/stretchr/testify/require"
@@ -28,11 +29,27 @@ func TestInteropAtGenesis(t *testing.T) {
 	}
 }
 
-// devFeatureBitmapForL2Genesis sets the OptimismPortalInteropFlag when interop is enabled.
-// Verify the bitmap differs between enabled and disabled states.
+// devFeatureBitmapForL2Genesis sets the OptimismPortalInteropFlag when interop is enabled and the L2CMFlag when L2CM
+// is enabled.
 func TestDevFeatureBitmapForL2Genesis(t *testing.T) {
-	enabled := devFeatureBitmapForL2Genesis(true)
-	disabled := devFeatureBitmapForL2Genesis(false)
-	require.NotEqual(t, enabled, disabled, "bitmap should differ when interop is enabled vs disabled")
-	require.True(t, disabled == (common.Hash{}), "disabled bitmap should be zero")
+	interopOnly := devfeatures.EnableDevFeature(common.Hash{}, devfeatures.OptimismPortalInteropFlag)
+	l2cmOnly := devfeatures.EnableDevFeature(common.Hash{}, devfeatures.L2CMFlag)
+	both := devfeatures.EnableDevFeature(interopOnly, devfeatures.L2CMFlag)
+
+	tests := []struct {
+		name          string
+		enableInterop bool
+		useL2CM       bool
+		want          common.Hash
+	}{
+		{"both disabled", false, false, common.Hash{}},
+		{"interop only", true, false, interopOnly},
+		{"L2CM only", false, true, l2cmOnly},
+		{"both enabled", true, true, both},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, devFeatureBitmapForL2Genesis(tt.enableInterop, tt.useL2CM))
+		})
+	}
 }

--- a/op-chain-ops/interopgen/recipe.go
+++ b/op-chain-ops/interopgen/recipe.go
@@ -131,6 +131,7 @@ type InteropDevL2Recipe struct {
 	ChainID       uint64
 	BlockTime     uint64
 	InteropOffset uint64
+	UseL2CM       bool
 }
 
 func prefundL2Accounts(l1Cfg *L1Config, l2Cfg *L2Config, addrs devkeys.Addresses) error {
@@ -304,6 +305,7 @@ func (r *InteropDevL2Recipe) build(l1ChainID uint64, addrs devkeys.Addresses) (*
 		DisputeSplitDepth:           30,
 		DisputeClockExtension:       10800,  // 3 hours (input in seconds)
 		DisputeMaxClockDuration:     302400, // 3.5 days (input in seconds)
+		UseL2CM:                     r.UseL2CM,
 	}
 
 	l2Users := devkeys.ChainUserKeys(new(big.Int).SetUint64(r.ChainID))

--- a/op-chain-ops/interopgen/recipe.go
+++ b/op-chain-ops/interopgen/recipe.go
@@ -131,7 +131,8 @@ type InteropDevL2Recipe struct {
 	ChainID       uint64
 	BlockTime     uint64
 	InteropOffset uint64
-	UseL2CM       bool
+	// TODO(#20084): remove alongside L2Config.UseL2CM.
+	UseL2CM bool
 }
 
 func prefundL2Accounts(l1Cfg *L1Config, l2Cfg *L2Config, addrs devkeys.Addresses) error {

--- a/op-chain-ops/interopgen/recipe_test.go
+++ b/op-chain-ops/interopgen/recipe_test.go
@@ -1,0 +1,25 @@
+package interopgen
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
+)
+
+func TestInteropDevRecipeBuildUseL2CM(t *testing.T) {
+	rec := InteropDevRecipe{
+		L1ChainID:        900100,
+		L2s:              []InteropDevL2Recipe{{ChainID: 900200, UseL2CM: true}, {ChainID: 900201}},
+		GenesisTimestamp: uint64(1234567),
+	}
+	hd, err := devkeys.NewMnemonicDevKeys(devkeys.TestMnemonic)
+	require.NoError(t, err)
+
+	worldCfg, err := rec.Build(hd)
+	require.NoError(t, err)
+
+	require.True(t, worldCfg.L2s["900200"].UseL2CM)
+	require.False(t, worldCfg.L2s["900201"].UseL2CM)
+}


### PR DESCRIPTION
## Description

Adds `UseL2CM` to `interopgen.L2Config` and threads it into `devFeatureBitmapForL2Genesis`. When set, `devfeatures.L2CMFlag` is OR'd into `L2GenesisInput.DevFeatureBitmap`, which `L2Genesis.s.sol` already consumes to gate L2CM genesis setup.

Also adds `UseL2CM` to `InteropDevL2Recipe` and copies it into the generated `L2Config`, so recipe-based interopgen worlds can enable the same L2CM path. Without this, callers using `InteropDevRecipe.Build()` would always get the zero-value `false` in `L2Config`.

This fills the interopgen wiring gap left after #20378 removed the stale TODOs without adding the config toggle. It is complementary to #20356, which tracks making L2CM default centrally at the genesis consumption site. This field is temporary and should be removed with the broader `L2CMFlag` cleanup.

## Tests

- Extended `TestDevFeatureBitmapForL2Genesis` into a table-driven test covering all `(enableInterop, useL2CM)` combinations and asserting each toggle sets its corresponding bit independently.
- Added `TestInteropDevRecipeBuildUseL2CM` to verify `InteropDevL2Recipe.UseL2CM` is preserved when building `WorldConfig.L2s[*].UseL2CM`.

## Metadata

Closes #20431