### PR TITLE
perf(op-interop-filter): fetch blocks concurrently during ingestion

### DIFF
--- a/op-devstack/sysgo/interop_filter.go
+++ b/op-devstack/sysgo/interop_filter.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-interop-filter/filter"
+	filterflags "github.com/ethereum-optimism/optimism/op-interop-filter/flags"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/log"
@@ -106,6 +107,8 @@ func startInteropFilter(
 		MessageExpiryWindow: 7 * 24 * 3600, // 7 days in seconds
 		PollInterval:        500 * time.Millisecond,
 		ValidationInterval:  200 * time.Millisecond,
+		RPCConcurrency:      filterflags.DefaultRPCConcurrency,
+		FetchConcurrency:    filterflags.DefaultFetchConcurrency,
 		RPCAddr:             "127.0.0.1",
 		RPCPort:             0, // Auto-assign
 		Version:             "devstack",

--- a/op-interop-filter/filter/config.go
+++ b/op-interop-filter/filter/config.go
@@ -37,6 +37,8 @@ type Config struct {
 	ValidationInterval          time.Duration // Interval for cross-chain validation (default: 500ms)
 	ReorgRecoveryEnabled        bool          // If true, automatically rewinds reorg-triggered failsafe to finalized
 	Passthrough                 bool          // If true, all transactions pass through without filtering
+	RPCConcurrency              int           // Max concurrent RPC requests per chain (default: 100)
+	FetchConcurrency            int           // Number of blocks to fetch concurrently (default: 64)
 
 	LogConfig     oplog.CLIConfig
 	MetricsConfig opmetrics.CLIConfig
@@ -68,6 +70,15 @@ func (c *Config) Check() error {
 	if c.ValidationInterval <= 0 {
 		result = errors.Join(result, errors.New("validation-interval must be positive"))
 	}
+	if c.RPCConcurrency <= 0 {
+		result = errors.Join(result, errors.New("rpc-concurrency must be positive"))
+	}
+	if c.FetchConcurrency <= 0 {
+		result = errors.Join(result, errors.New("fetch-concurrency must be positive"))
+	}
+	if c.FetchConcurrency > c.RPCConcurrency {
+		result = errors.Join(result, errors.New("fetch-concurrency must be less than or equal to rpc-concurrency"))
+	}
 	result = errors.Join(result, c.MetricsConfig.Check())
 	result = errors.Join(result, c.PprofConfig.Check())
 	return result
@@ -96,6 +107,17 @@ func NewConfig(ctx *cli.Context, version string) (*Config, error) {
 	if validationInterval <= 0 {
 		return nil, fmt.Errorf("validation-interval must be positive, got %s", validationInterval)
 	}
+	rpcConcurrency := ctx.Int(flags.RPCConcurrencyFlag.Name)
+	if rpcConcurrency <= 0 {
+		return nil, fmt.Errorf("rpc-concurrency must be positive, got %d", rpcConcurrency)
+	}
+	fetchConcurrency := ctx.Int(flags.FetchConcurrencyFlag.Name)
+	if fetchConcurrency <= 0 {
+		return nil, fmt.Errorf("fetch-concurrency must be positive, got %d", fetchConcurrency)
+	}
+	if fetchConcurrency > rpcConcurrency {
+		return nil, fmt.Errorf("fetch-concurrency (%d) must be less than or equal to rpc-concurrency (%d)", fetchConcurrency, rpcConcurrency)
+	}
 
 	// Load rollup configs from --networks and --rollup-configs
 	rollupConfigs, err := loadRollupConfigs(
@@ -123,6 +145,8 @@ func NewConfig(ctx *cli.Context, version string) (*Config, error) {
 		ValidationInterval:          validationInterval,
 		ReorgRecoveryEnabled:        ctx.Bool(flags.ReorgRecoveryEnabledFlag.Name),
 		Passthrough:                 ctx.Bool(flags.DangerouslyEnablePassthroughFlag.Name),
+		RPCConcurrency:              rpcConcurrency,
+		FetchConcurrency:            fetchConcurrency,
 		LogConfig:                   oplog.ReadCLIConfig(ctx),
 		MetricsConfig:               opmetrics.ReadCLIConfig(ctx),
 		PprofConfig:                 oppprof.ReadCLIConfig(ctx),

--- a/op-interop-filter/filter/logsdb_chain_ingester.go
+++ b/op-interop-filter/filter/logsdb_chain_ingester.go
@@ -782,7 +782,8 @@ func (c *LogsDBChainIngester) writeFetchedBlock(fetched blockFetch) error {
 func (c *LogsDBChainIngester) recordIngestionProgress(blockNum, head uint64) {
 	startingBlock := c.calculateStartingBlock()
 	if blockNum <= startingBlock {
-		progress := float64(blockNum-c.earliestIngestedBlock.Load()) / float64(startingBlock-c.earliestIngestedBlock.Load()+1)
+		earliest := c.earliestIngestedBlock.Load()
+		progress := float64(blockNum-earliest+1) / float64(startingBlock-earliest+1)
 		c.log.Info("Ingestion progress",
 			"block", blockNum,
 			"target", startingBlock,

--- a/op-interop-filter/filter/logsdb_chain_ingester.go
+++ b/op-interop-filter/filter/logsdb_chain_ingester.go
@@ -35,7 +35,6 @@ type EthClient interface {
 	InfoByLabel(ctx context.Context, label eth.BlockLabel) (eth.BlockInfo, error)
 	InfoByNumber(ctx context.Context, number uint64) (eth.BlockInfo, error)
 	FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, gethTypes.Receipts, error)
-	FetchReceiptsByNumber(ctx context.Context, number uint64) (eth.BlockInfo, gethTypes.Receipts, error)
 	Close()
 }
 
@@ -671,7 +670,11 @@ func (c *LogsDBChainIngester) ingestBlockRange(startBlock, endBlock uint64, last
 	startFetch := func(blockNum uint64) {
 		slot := slots[blockNum%concurrency]
 		go func() {
-			blockInfo, receipts, err := c.ethClient.FetchReceiptsByNumber(rangeCtx, blockNum)
+			blockInfo, err := c.ethClient.InfoByNumber(rangeCtx, blockNum)
+			var receipts gethTypes.Receipts
+			if err == nil {
+				_, receipts, err = c.ethClient.FetchReceipts(rangeCtx, blockInfo.Hash())
+			}
 			select {
 			case slot <- blockFetch{blockNum: blockNum, blockInfo: blockInfo, receipts: receipts, err: err}:
 			case <-rangeCtx.Done():

--- a/op-interop-filter/filter/logsdb_chain_ingester.go
+++ b/op-interop-filter/filter/logsdb_chain_ingester.go
@@ -35,7 +35,15 @@ type EthClient interface {
 	InfoByLabel(ctx context.Context, label eth.BlockLabel) (eth.BlockInfo, error)
 	InfoByNumber(ctx context.Context, number uint64) (eth.BlockInfo, error)
 	FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, gethTypes.Receipts, error)
+	FetchReceiptsByNumber(ctx context.Context, number uint64) (eth.BlockInfo, gethTypes.Receipts, error)
 	Close()
+}
+
+type blockFetch struct {
+	blockNum  uint64
+	blockInfo eth.BlockInfo
+	receipts  gethTypes.Receipts
+	err       error
 }
 
 // LogsDBChainIngester handles block ingestion and log storage for a single chain.
@@ -53,6 +61,7 @@ type LogsDBChainIngester struct {
 	backfillDuration time.Duration // How far back to start ingestion from startTimestamp
 	pollInterval     time.Duration
 	rollupCfg        *rollup.Config // Rollup config for block number calculation
+	fetchConcurrency int
 
 	stopped atomic.Bool
 
@@ -84,6 +93,8 @@ func NewLogsDBChainIngester(
 	backfillDuration time.Duration,
 	pollInterval time.Duration,
 	rollupCfg *rollup.Config,
+	rpcConcurrency int,
+	fetchConcurrency int,
 ) (*LogsDBChainIngester, error) {
 	ctx, cancel := context.WithCancel(parentCtx)
 
@@ -105,7 +116,7 @@ func NewLogsDBChainIngester(
 			HeadersCacheSize:      1000,
 			PayloadsCacheSize:     100,
 			MaxRequestsPerBatch:   20,
-			MaxConcurrentRequests: 10,
+			MaxConcurrentRequests: rpcConcurrency,
 			TrustRPC:              false,
 			MustBePostMerge:       true,
 			RPCProviderKind:       sources.RPCKindStandard,
@@ -128,6 +139,7 @@ func NewLogsDBChainIngester(
 		backfillDuration: backfillDuration,
 		pollInterval:     pollInterval,
 		rollupCfg:        rollupCfg,
+		fetchConcurrency: fetchConcurrency,
 		ctx:              ctx,
 		cancel:           cancel,
 	}, nil
@@ -448,43 +460,15 @@ func (c *LogsDBChainIngester) runIngestion() {
 			}
 		}
 
-		// Inner loop: ingest all available blocks without waiting between them
-		for nextBlock <= head.NumberU64() {
-			// Check for shutdown between blocks
-			select {
-			case <-c.ctx.Done():
-				return
-			default:
-			}
-
-			if err := c.ingestBlock(nextBlock); err != nil {
+		if nextBlock <= head.NumberU64() {
+			var err error
+			nextBlock, lastLogTime, err = c.ingestBlockRange(nextBlock, head.NumberU64(), lastLogTime)
+			if err != nil {
 				// Application context was canceled (e.g., during shutdown).
 				if errors.Is(err, context.Canceled) {
 					return
 				}
-				c.log.Error("Failed to ingest block", "block", nextBlock, "err", err)
-				break // Exit inner loop on error, wait for next tick to retry
-			}
-			if c.Error() != nil {
-				break
-			}
-			nextBlock++
-
-			// Progress logging
-			if clock.SystemClock.Since(lastLogTime) > progressLogInterval {
-				startingBlock := c.calculateStartingBlock()
-				if nextBlock <= startingBlock {
-					progress := float64(nextBlock-c.earliestIngestedBlock.Load()) / float64(startingBlock-c.earliestIngestedBlock.Load()+1)
-					c.log.Info("Ingestion progress",
-						"block", nextBlock-1,
-						"target", startingBlock,
-						"progress", fmt.Sprintf("%.0f%%", progress*100))
-					chainIDUint64, _ := c.chainID.Uint64()
-					c.metrics.RecordBackfillProgress(chainIDUint64, progress)
-				} else {
-					c.log.Debug("Ingestion progress", "block", nextBlock-1, "head", head.NumberU64())
-				}
-				lastLogTime = clock.SystemClock.Now()
+				c.log.Error("Failed to ingest blocks", "block", nextBlock, "err", err)
 			}
 		}
 		// Caught up to head, will wait for next ticker tick
@@ -655,21 +639,90 @@ func (c *LogsDBChainIngester) sealParentBlock(blockNum uint64) error {
 }
 
 func (c *LogsDBChainIngester) ingestBlock(blockNum uint64) error {
+	_, _, err := c.ingestBlockRange(blockNum, blockNum, clock.SystemClock.Now())
+	return err
+}
+
+func (c *LogsDBChainIngester) ingestBlockRange(startBlock, endBlock uint64, lastLogTime time.Time) (uint64, time.Time, error) {
+	if c.Error() != nil {
+		return startBlock, lastLogTime, nil
+	}
+	if startBlock > endBlock {
+		return startBlock, lastLogTime, nil
+	}
+
+	total := endBlock - startBlock + 1
+	concurrency := uint64(c.fetchConcurrency)
+	if concurrency == 0 {
+		return startBlock, lastLogTime, errors.New("fetch-concurrency must be positive")
+	}
+	if concurrency > total {
+		concurrency = total
+	}
+
+	rangeCtx, cancel := context.WithCancel(c.ctx)
+	defer cancel()
+
+	slots := make([]chan blockFetch, concurrency)
+	for i := range slots {
+		slots[i] = make(chan blockFetch, 1)
+	}
+
+	startFetch := func(blockNum uint64) {
+		slot := slots[blockNum%concurrency]
+		go func() {
+			blockInfo, receipts, err := c.ethClient.FetchReceiptsByNumber(rangeCtx, blockNum)
+			select {
+			case slot <- blockFetch{blockNum: blockNum, blockInfo: blockInfo, receipts: receipts, err: err}:
+			case <-rangeCtx.Done():
+			}
+		}()
+	}
+
+	nextFetch := startBlock
+	for i := uint64(0); i < concurrency; i++ {
+		startFetch(nextFetch)
+		nextFetch++
+	}
+
+	for blockNum := startBlock; blockNum <= endBlock; blockNum++ {
+		var fetched blockFetch
+		select {
+		case <-rangeCtx.Done():
+			return blockNum, lastLogTime, rangeCtx.Err()
+		case fetched = <-slots[blockNum%concurrency]:
+		}
+
+		if nextFetch <= endBlock {
+			startFetch(nextFetch)
+			nextFetch++
+		}
+		if fetched.err != nil {
+			return blockNum, lastLogTime, fmt.Errorf("failed to fetch block %d: %w", blockNum, fetched.err)
+		}
+		if err := c.writeFetchedBlock(fetched); err != nil {
+			return blockNum, lastLogTime, err
+		}
+		if c.Error() != nil {
+			return blockNum + 1, lastLogTime, nil
+		}
+		if clock.SystemClock.Since(lastLogTime) > progressLogInterval {
+			c.recordIngestionProgress(blockNum, endBlock)
+			lastLogTime = clock.SystemClock.Now()
+		}
+	}
+
+	return endBlock + 1, lastLogTime, nil
+}
+
+func (c *LogsDBChainIngester) writeFetchedBlock(fetched blockFetch) error {
 	if c.Error() != nil {
 		return nil
 	}
 
-	blockInfo, err := c.ethClient.InfoByNumber(c.ctx, blockNum)
-	if err != nil {
-		return fmt.Errorf("failed to get block info: %w", err)
-	}
-
+	blockInfo := fetched.blockInfo
+	blockNum := fetched.blockNum
 	blockID := eth.BlockID{Hash: blockInfo.Hash(), Number: blockInfo.NumberU64()}
-
-	_, receipts, err := c.ethClient.FetchReceipts(c.ctx, blockInfo.Hash())
-	if err != nil {
-		return fmt.Errorf("failed to get receipts: %w", err)
-	}
 
 	c.mu.RLock()
 	latestBlock, hasLatest := c.logsDB.LatestSealedBlock()
@@ -692,7 +745,7 @@ func (c *LogsDBChainIngester) ingestBlock(blockNum uint64) error {
 		}
 	}
 
-	logCount, err := c.processBlockLogs(blockInfo, blockID, receipts, blockNum)
+	logCount, err := c.processBlockLogs(blockInfo, blockID, fetched.receipts, blockNum)
 	if err != nil {
 		if errors.Is(err, types.ErrConflict) {
 			c.SetError(ErrorConflict, fmt.Sprintf("database conflict at block %d", blockNum))
@@ -724,6 +777,21 @@ func (c *LogsDBChainIngester) ingestBlock(blockNum uint64) error {
 	}
 
 	return nil
+}
+
+func (c *LogsDBChainIngester) recordIngestionProgress(blockNum, head uint64) {
+	startingBlock := c.calculateStartingBlock()
+	if blockNum <= startingBlock {
+		progress := float64(blockNum-c.earliestIngestedBlock.Load()) / float64(startingBlock-c.earliestIngestedBlock.Load()+1)
+		c.log.Info("Ingestion progress",
+			"block", blockNum,
+			"target", startingBlock,
+			"progress", fmt.Sprintf("%.0f%%", progress*100))
+		chainIDUint64, _ := c.chainID.Uint64()
+		c.metrics.RecordBackfillProgress(chainIDUint64, progress)
+	} else {
+		c.log.Debug("Ingestion progress", "block", blockNum, "head", head)
+	}
 }
 
 func (c *LogsDBChainIngester) processBlockLogs(blockInfo eth.BlockInfo, blockID eth.BlockID,

--- a/op-interop-filter/filter/logsdb_chain_ingester.go
+++ b/op-interop-filter/filter/logsdb_chain_ingester.go
@@ -696,12 +696,15 @@ func (c *LogsDBChainIngester) ingestBlockRange(startBlock, endBlock uint64, last
 		case fetched = <-slots[blockNum%concurrency]:
 		}
 
-		if nextFetch <= endBlock {
-			startFetch(nextFetch)
-			nextFetch++
+		if fetched.blockNum != blockNum {
+			return blockNum, lastLogTime, fmt.Errorf("expected fetched block %d but got %d", blockNum, fetched.blockNum)
 		}
 		if fetched.err != nil {
 			return blockNum, lastLogTime, fmt.Errorf("failed to fetch block %d: %w", blockNum, fetched.err)
+		}
+		if nextFetch <= endBlock {
+			startFetch(nextFetch)
+			nextFetch++
 		}
 		if err := c.writeFetchedBlock(fetched); err != nil {
 			return blockNum, lastLogTime, err

--- a/op-interop-filter/filter/logsdb_chain_ingester.go
+++ b/op-interop-filter/filter/logsdb_chain_ingester.go
@@ -670,10 +670,17 @@ func (c *LogsDBChainIngester) ingestBlockRange(startBlock, endBlock uint64, last
 	startFetch := func(blockNum uint64) {
 		slot := slots[blockNum%concurrency]
 		go func() {
+			// Resolve the number to a hash first, then fetch receipts by hash so
+			// the receipts are pinned to the block identity we are about to write.
 			blockInfo, err := c.ethClient.InfoByNumber(rangeCtx, blockNum)
 			var receipts gethTypes.Receipts
-			if err == nil {
+			if err != nil {
+				err = fmt.Errorf("fetch block info: %w", err)
+			} else {
 				_, receipts, err = c.ethClient.FetchReceipts(rangeCtx, blockInfo.Hash())
+				if err != nil {
+					err = fmt.Errorf("fetch block receipts: %w", err)
+				}
 			}
 			select {
 			case slot <- blockFetch{blockNum: blockNum, blockInfo: blockInfo, receipts: receipts, err: err}:

--- a/op-interop-filter/filter/logsdb_chain_ingester_test.go
+++ b/op-interop-filter/filter/logsdb_chain_ingester_test.go
@@ -126,26 +126,32 @@ type delayedFetchEthClient struct {
 	completed []uint64
 }
 
-func (m *delayedFetchEthClient) FetchReceiptsByNumber(ctx context.Context, number uint64) (eth.BlockInfo, gethTypes.Receipts, error) {
+func (m *delayedFetchEthClient) InfoByNumber(ctx context.Context, number uint64) (eth.BlockInfo, error) {
 	if delay := m.delays[number]; delay > 0 {
 		select {
 		case <-time.After(delay):
 		case <-ctx.Done():
-			return nil, nil, ctx.Err()
+			return nil, ctx.Err()
 		}
 	}
 
-	blockInfo, receipts, err := m.MockEthClient.FetchReceiptsByNumber(ctx, number)
+	blockInfo, err := m.MockEthClient.InfoByNumber(ctx, number)
 	m.mu.Lock()
 	m.completed = append(m.completed, number)
 	m.mu.Unlock()
-	return blockInfo, receipts, err
+	return blockInfo, err
 }
 
 func (m *delayedFetchEthClient) Completed() []uint64 {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return append([]uint64(nil), m.completed...)
+}
+
+func (m *delayedFetchEthClient) ResetCompleted() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.completed = nil
 }
 
 type backfillProgressMetrics struct {
@@ -361,6 +367,7 @@ func TestLogsDBChainIngester_IngestBlockRange_WritesInOrder(t *testing.T) {
 	require.NoError(t, ingester.initLogsDB())
 	t.Cleanup(func() { ingester.logsDB.Close() })
 	require.NoError(t, ingester.sealParentBlock(99))
+	mockClient.ResetCompleted()
 
 	nextBlock, _, err := ingester.ingestBlockRange(100, 101, clock.SystemClock.Now())
 	require.NoError(t, err)

--- a/op-interop-filter/filter/logsdb_chain_ingester_test.go
+++ b/op-interop-filter/filter/logsdb_chain_ingester_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -14,6 +15,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-interop-filter/metrics"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/clock"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
@@ -114,6 +116,48 @@ func createTestReceipts(blockNum uint64, logCount int) gethTypes.Receipts {
 	})
 
 	return receipts
+}
+
+type delayedFetchEthClient struct {
+	*MockEthClient
+
+	mu        sync.Mutex
+	delays    map[uint64]time.Duration
+	completed []uint64
+}
+
+func (m *delayedFetchEthClient) FetchReceiptsByNumber(ctx context.Context, number uint64) (eth.BlockInfo, gethTypes.Receipts, error) {
+	if delay := m.delays[number]; delay > 0 {
+		select {
+		case <-time.After(delay):
+		case <-ctx.Done():
+			return nil, nil, ctx.Err()
+		}
+	}
+
+	blockInfo, receipts, err := m.MockEthClient.FetchReceiptsByNumber(ctx, number)
+	m.mu.Lock()
+	m.completed = append(m.completed, number)
+	m.mu.Unlock()
+	return blockInfo, receipts, err
+}
+
+func (m *delayedFetchEthClient) Completed() []uint64 {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]uint64(nil), m.completed...)
+}
+
+type backfillProgressMetrics struct {
+	metrics.Metricer
+
+	chainID  uint64
+	progress float64
+}
+
+func (m *backfillProgressMetrics) RecordBackfillProgress(chainID uint64, progress float64) {
+	m.chainID = chainID
+	m.progress = progress
 }
 
 // =============================================================================
@@ -283,6 +327,106 @@ func TestLogsDBChainIngester_IngestMultipleBlocks(t *testing.T) {
 	ts, ok := ingester.LatestTimestamp()
 	require.True(t, ok)
 	require.Equal(t, uint64(1206), ts) // 1000 + 103*2
+}
+
+func TestLogsDBChainIngester_IngestBlockRange_WritesInOrder(t *testing.T) {
+	chainID := eth.ChainIDFromUInt64(901)
+	tempDir := t.TempDir()
+
+	mockClient := &delayedFetchEthClient{
+		MockEthClient: NewMockEthClient(),
+		delays:        map[uint64]time.Duration{100: 50 * time.Millisecond},
+	}
+
+	parentHash := common.Hash{}
+	for i := uint64(99); i <= 101; i++ {
+		block := createTestBlock(i, 1000+i*2, parentHash)
+		parentHash = block.Hash()
+
+		var receipts gethTypes.Receipts
+		if i >= 100 {
+			receipts = createTestReceipts(i, 1)
+		}
+		mockClient.AddBlock(block, receipts)
+	}
+
+	ingester := newTestLogsDBChainIngester(t, testIngesterConfig{
+		chainID:   chainID,
+		dataDir:   tempDir,
+		ethClient: mockClient,
+		rollupCfg: testRollupConfig(901, 0, 1000),
+	})
+	ingester.fetchConcurrency = 2
+
+	require.NoError(t, ingester.initLogsDB())
+	t.Cleanup(func() { ingester.logsDB.Close() })
+	require.NoError(t, ingester.sealParentBlock(99))
+
+	nextBlock, _, err := ingester.ingestBlockRange(100, 101, clock.SystemClock.Now())
+	require.NoError(t, err)
+	require.Equal(t, uint64(102), nextBlock)
+	require.Equal(t, []uint64{101, 100}, mockClient.Completed())
+
+	latestBlock, ok := ingester.LatestBlock()
+	require.True(t, ok)
+	require.Equal(t, uint64(101), latestBlock.Number)
+}
+
+func TestLogsDBChainIngester_IngestBlockRange_FetchFailureReturnsFailingBlock(t *testing.T) {
+	chainID := eth.ChainIDFromUInt64(901)
+	tempDir := t.TempDir()
+
+	mockClient := NewMockEthClient()
+
+	parentBlock := createTestBlock(99, 1198, common.Hash{})
+	block100 := createTestBlock(100, 1200, parentBlock.Hash())
+	block101 := createTestBlock(101, 1202, block100.Hash())
+	mockClient.AddBlock(parentBlock, nil)
+	mockClient.AddBlock(block100, createTestReceipts(100, 1))
+	mockClient.AddBlock(block101, createTestReceipts(101, 1))
+
+	ingester := newTestLogsDBChainIngester(t, testIngesterConfig{
+		chainID:   chainID,
+		dataDir:   tempDir,
+		ethClient: mockClient,
+		rollupCfg: testRollupConfig(901, 0, 1000),
+	})
+	ingester.fetchConcurrency = 2
+
+	require.NoError(t, ingester.initLogsDB())
+	t.Cleanup(func() { ingester.logsDB.Close() })
+	require.NoError(t, ingester.sealParentBlock(99))
+
+	nextBlock, _, err := ingester.ingestBlockRange(100, 102, clock.SystemClock.Now())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "block 102 not found")
+	require.Equal(t, uint64(102), nextBlock)
+
+	latestBlock, ok := ingester.LatestBlock()
+	require.True(t, ok)
+	require.Equal(t, uint64(101), latestBlock.Number)
+}
+
+func TestLogsDBChainIngester_RecordIngestionProgressCountsCompletedBlock(t *testing.T) {
+	chainID := eth.ChainIDFromUInt64(901)
+	recorder := &backfillProgressMetrics{Metricer: metrics.NoopMetrics}
+
+	ingester := newTestLogsDBChainIngester(t, testIngesterConfig{
+		chainID:   chainID,
+		dataDir:   t.TempDir(),
+		ethClient: NewMockEthClient(),
+		rollupCfg: testRollupConfig(901, 0, 0),
+	})
+	ingester.metrics = recorder
+	ingester.startTimestamp = 400
+	ingester.backfillDuration = 0
+	ingester.earliestIngestedBlock.Store(100)
+	ingester.earliestIngestedBlockSet.Store(true)
+
+	ingester.recordIngestionProgress(200, 200)
+
+	require.Equal(t, uint64(901), recorder.chainID)
+	require.Equal(t, 1.0, recorder.progress)
 }
 
 func TestLogsDBChainIngester_Ready(t *testing.T) {

--- a/op-interop-filter/filter/logsdb_chain_ingester_test.go
+++ b/op-interop-filter/filter/logsdb_chain_ingester_test.go
@@ -51,6 +51,7 @@ func newTestLogsDBChainIngester(t *testing.T, cfg testIngesterConfig) *LogsDBCha
 		backfillDuration: 0,     // No backfill by default in tests
 		pollInterval:     100 * time.Millisecond,
 		rollupCfg:        cfg.rollupCfg,
+		fetchConcurrency: 4,
 		ctx:              ctx,
 		cancel:           cancel,
 	}
@@ -863,7 +864,7 @@ func TestLogsDBChainIngester_IngestBlock_RPCError(t *testing.T) {
 	// Set RPC error - block 100 is not in mock, will fail
 	err = ingester.ingestBlock(100)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "failed to get block info")
+	require.Contains(t, err.Error(), "failed to fetch block 100")
 }
 
 func TestLogsDBChainIngester_IngestBlock_ReceiptsError(t *testing.T) {
@@ -897,7 +898,7 @@ func TestLogsDBChainIngester_IngestBlock_ReceiptsError(t *testing.T) {
 
 	err = ingester.ingestBlock(100)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "failed to get receipts")
+	require.Contains(t, err.Error(), "failed to fetch block 100")
 }
 
 func TestLogsDBChainIngester_IngestBlock_ErrorStateSkipsIngestion(t *testing.T) {

--- a/op-interop-filter/filter/logsdb_chain_ingester_test.go
+++ b/op-interop-filter/filter/logsdb_chain_ingester_test.go
@@ -1016,6 +1016,7 @@ func TestLogsDBChainIngester_IngestBlock_RPCError(t *testing.T) {
 	err = ingester.ingestBlock(100)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to fetch block 100")
+	require.Contains(t, err.Error(), "fetch block info")
 }
 
 func TestLogsDBChainIngester_IngestBlock_ReceiptsError(t *testing.T) {
@@ -1050,6 +1051,7 @@ func TestLogsDBChainIngester_IngestBlock_ReceiptsError(t *testing.T) {
 	err = ingester.ingestBlock(100)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to fetch block 100")
+	require.Contains(t, err.Error(), "fetch block receipts")
 }
 
 func TestLogsDBChainIngester_IngestBlock_ErrorStateSkipsIngestion(t *testing.T) {

--- a/op-interop-filter/filter/mock_test.go
+++ b/op-interop-filter/filter/mock_test.go
@@ -371,15 +371,6 @@ func (m *MockEthClient) FetchReceipts(ctx context.Context, blockHash common.Hash
 	return nil, receipts, nil
 }
 
-// FetchReceiptsByNumber implements EthClient.
-func (m *MockEthClient) FetchReceiptsByNumber(ctx context.Context, number uint64) (eth.BlockInfo, gethTypes.Receipts, error) {
-	block, err := m.InfoByNumber(ctx, number)
-	if err != nil {
-		return nil, nil, err
-	}
-	return m.FetchReceipts(ctx, block.Hash())
-}
-
 // Close implements EthClient.
 func (m *MockEthClient) Close() {}
 

--- a/op-interop-filter/filter/mock_test.go
+++ b/op-interop-filter/filter/mock_test.go
@@ -371,6 +371,15 @@ func (m *MockEthClient) FetchReceipts(ctx context.Context, blockHash common.Hash
 	return nil, receipts, nil
 }
 
+// FetchReceiptsByNumber implements EthClient.
+func (m *MockEthClient) FetchReceiptsByNumber(ctx context.Context, number uint64) (eth.BlockInfo, gethTypes.Receipts, error) {
+	block, err := m.InfoByNumber(ctx, number)
+	if err != nil {
+		return nil, nil, err
+	}
+	return m.FetchReceipts(ctx, block.Hash())
+}
+
 // Close implements EthClient.
 func (m *MockEthClient) Close() {}
 

--- a/op-interop-filter/filter/service.go
+++ b/op-interop-filter/filter/service.go
@@ -200,6 +200,8 @@ func (s *Service) initBackend(ctx context.Context, cfg *Config) error {
 			cfg.BackfillDuration,
 			cfg.PollInterval,
 			rollupCfg,
+			cfg.RPCConcurrency,
+			cfg.FetchConcurrency,
 		)
 		if err != nil {
 			return fmt.Errorf("failed to create chain ingester for chain %s: %w", chainID, err)

--- a/op-interop-filter/flags/flags.go
+++ b/op-interop-filter/flags/flags.go
@@ -14,7 +14,11 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/oppprof"
 )
 
-const EnvVarPrefix = "OP_INTEROP_FILTER"
+const (
+	EnvVarPrefix            = "OP_INTEROP_FILTER"
+	DefaultRPCConcurrency   = 100
+	DefaultFetchConcurrency = 64
+)
 
 func prefixEnvVars(name string) []string {
 	return opservice.PrefixEnvVar(EnvVarPrefix, name)
@@ -109,13 +113,13 @@ var (
 		Name:    "rpc-concurrency",
 		Usage:   "Maximum number of concurrent RPC requests per chain",
 		EnvVars: prefixEnvVars("RPC_CONCURRENCY"),
-		Value:   100,
+		Value:   DefaultRPCConcurrency,
 	}
 	FetchConcurrencyFlag = &cli.IntFlag{
 		Name:    "fetch-concurrency",
 		Usage:   "Number of blocks to fetch concurrently during ingestion. Must be <= rpc-concurrency.",
 		EnvVars: prefixEnvVars("FETCH_CONCURRENCY"),
-		Value:   64,
+		Value:   DefaultFetchConcurrency,
 	}
 	DangerouslyEnablePassthroughFlag = &cli.BoolFlag{
 		Name:    "dangerously-enable-passthrough",

--- a/op-interop-filter/flags/flags.go
+++ b/op-interop-filter/flags/flags.go
@@ -105,6 +105,18 @@ var (
 		Usage:   "Automatically resolve reorg-triggered failsafe by rewinding logs DBs to finalized.",
 		EnvVars: prefixEnvVars("REORG_RECOVERY_ENABLED"),
 	}
+	RPCConcurrencyFlag = &cli.IntFlag{
+		Name:    "rpc-concurrency",
+		Usage:   "Maximum number of concurrent RPC requests per chain",
+		EnvVars: prefixEnvVars("RPC_CONCURRENCY"),
+		Value:   100,
+	}
+	FetchConcurrencyFlag = &cli.IntFlag{
+		Name:    "fetch-concurrency",
+		Usage:   "Number of blocks to fetch concurrently during ingestion. Must be <= rpc-concurrency.",
+		EnvVars: prefixEnvVars("FETCH_CONCURRENCY"),
+		Value:   64,
+	}
 	DangerouslyEnablePassthroughFlag = &cli.BoolFlag{
 		Name:    "dangerously-enable-passthrough",
 		Usage:   "Allow all transactions through without interop filtering. DANGEROUS: disables all executing message validation.",
@@ -130,6 +142,8 @@ var optionalFlags = []cli.Flag{
 	PollIntervalFlag,
 	ValidationIntervalFlag,
 	ReorgRecoveryEnabledFlag,
+	RPCConcurrencyFlag,
+	FetchConcurrencyFlag,
 	DangerouslyEnablePassthroughFlag,
 }
 


### PR DESCRIPTION
## Summary

- Adds `--rpc-concurrency` and `--fetch-concurrency` with defaults `100` and `64`.
- Uses the ingester's existing `[nextBlock, unsafeHead]` range to fetch block receipts concurrently with a bounded sliding window.
- Keeps logsDB writes, parent-hash validation, error handling, and metrics updates serial and ordered.

## Test Plan

- `go test ./op-interop-filter/...`
- `go mod tidy -diff`
