### PR TITLE
fix(op-proposer): decode EVM revert reasons into human-readable errors

### DIFF
--- a/op-proposer/proposer/driver.go
+++ b/op-proposer/proposer/driver.go
@@ -13,9 +13,11 @@ import (
 	"github.com/ethereum-optimism/optimism/op-proposer/metrics"
 	"github.com/ethereum-optimism/optimism/op-proposer/proposer/source"
 	"github.com/ethereum-optimism/optimism/op-service/dial"
+	"github.com/ethereum-optimism/optimism/op-service/errutil"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
+	"github.com/ethereum-optimism/optimism/packages/contracts-bedrock/snapshots"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -324,6 +326,11 @@ func (l *L2OutputSubmitter) proposeOutput(ctx context.Context, output source.Pro
 		// Add legacy data only if available
 		if output.Legacy.HeadL1 != (eth.L1BlockRef{}) {
 			logCtx = append(logCtx, "l1head", output.Legacy.HeadL1.Number)
+		}
+		// Attempt to decode revert reason using the DisputeGameFactory ABI
+		if revertData, ok := errutil.ExtractRevertData(err); ok {
+			factoryABI := snapshots.LoadDisputeGameFactoryABI()
+			logCtx = append(logCtx, "revert_reason", errutil.DecodeRevertReasonWithABIs(revertData, factoryABI))
 		}
 		l.Log.Error("Failed to send proposal transaction", logCtx...)
 		return

--- a/op-service/errutil/errors.go
+++ b/op-service/errutil/errors.go
@@ -1,8 +1,13 @@
 package errutil
 
 import (
+	"encoding/hex"
 	"errors"
 	"fmt"
+	"math/big"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
 )
 
 type errWithData interface {
@@ -13,10 +18,161 @@ type errWithData interface {
 // This is most useful when attempting to execute gas, as if the transaction reverts this will then show the reason.
 func TryAddRevertReason(err error) error {
 	var errData errWithData
-	ok := errors.As(err, &errData)
-	if ok {
-		return fmt.Errorf("%w, reason: %v", err, errData.ErrorData())
-	} else {
+	if !errors.As(err, &errData) {
 		return err
+	}
+	reason := DecodeRevertReason(errData.ErrorData())
+	return fmt.Errorf("%w, reason: %s", err, reason)
+}
+
+// DecodeRevertReason attempts to decode raw EVM revert data into a human-readable string.
+// It handles:
+//   - Standard Error(string) reverts (selector 0x08c379a0)
+//   - Standard Panic(uint256) reverts (selector 0x4e487b71)
+//   - Unknown selectors: displayed as hex
+//
+// The data parameter is expected to be a hex-encoded string (with or without 0x prefix),
+// as returned by geth's ErrorData() interface.
+func DecodeRevertReason(data interface{}) string {
+	hexStr, ok := data.(string)
+	if !ok {
+		return fmt.Sprintf("%v", data)
+	}
+
+	trimmed := strings.TrimPrefix(hexStr, "0x")
+	if len(trimmed) == 0 {
+		return hexStr
+	}
+	raw, err := hex.DecodeString(trimmed)
+	if err != nil {
+		return hexStr
+	}
+	if len(raw) < 4 {
+		return hexStr
+	}
+
+	selector := [4]byte(raw[:4])
+
+	// Standard Error(string) — selector 0x08c379a0
+	if selector == [4]byte{0x08, 0xc3, 0x79, 0xa0} {
+		strType, _ := abi.NewType("string", "", nil)
+		args := abi.Arguments{{Type: strType}}
+		vals, uErr := args.Unpack(raw[4:])
+		if uErr == nil && len(vals) > 0 {
+			return fmt.Sprintf("Error(%q)", vals[0])
+		}
+	}
+
+	// Standard Panic(uint256) — selector 0x4e487b71
+	if selector == [4]byte{0x4e, 0x48, 0x7b, 0x71} {
+		uint256Type, _ := abi.NewType("uint256", "", nil)
+		args := abi.Arguments{{Type: uint256Type}}
+		vals, uErr := args.Unpack(raw[4:])
+		if uErr == nil && len(vals) > 0 {
+			code := vals[0].(*big.Int)
+			return fmt.Sprintf("Panic(%s: %s)", code, panicReason(code))
+		}
+	}
+
+	// Unknown custom error — show the raw hex as before
+	return hexStr
+}
+
+// DecodeRevertReasonWithABIs is like DecodeRevertReason but additionally attempts
+// to decode custom errors defined in the provided ABIs. If a matching error selector
+// is found, the error name and decoded arguments are returned.
+func DecodeRevertReasonWithABIs(data interface{}, abis ...*abi.ABI) string {
+	hexStr, ok := data.(string)
+	if !ok {
+		return fmt.Sprintf("%v", data)
+	}
+
+	trimmed := strings.TrimPrefix(hexStr, "0x")
+	if len(trimmed) == 0 {
+		return hexStr
+	}
+	raw, err := hex.DecodeString(trimmed)
+	if err != nil {
+		return hexStr
+	}
+	if len(raw) < 4 {
+		return hexStr
+	}
+
+	// Try ABI custom errors first
+	var selector [4]byte
+	copy(selector[:], raw[:4])
+	for _, a := range abis {
+		if a == nil {
+			continue
+		}
+		abiErr, lookupErr := a.ErrorByID(selector)
+		if lookupErr != nil {
+			continue
+		}
+		vals, uErr := abiErr.Inputs.Unpack(raw[4:])
+		if uErr != nil {
+			return fmt.Sprintf("%s(<decode failed>)", abiErr.Name)
+		}
+		return formatABIError(abiErr, vals)
+	}
+
+	// Fall back to standard error decoding
+	return DecodeRevertReason(data)
+}
+
+// formatABIError formats a decoded ABI error with its argument names and values.
+func formatABIError(abiErr *abi.Error, vals []interface{}) string {
+	if len(vals) == 0 {
+		return fmt.Sprintf("%s()", abiErr.Name)
+	}
+	parts := make([]string, len(vals))
+	for i, v := range vals {
+		name := fmt.Sprintf("arg%d", i)
+		if i < len(abiErr.Inputs) && abiErr.Inputs[i].Name != "" {
+			name = abiErr.Inputs[i].Name
+		}
+		parts[i] = fmt.Sprintf("%s=%v", name, v)
+	}
+	return fmt.Sprintf("%s(%s)", abiErr.Name, strings.Join(parts, ", "))
+}
+
+// ExtractRevertData extracts the revert data from an error chain, if present.
+func ExtractRevertData(err error) (interface{}, bool) {
+	var errData errWithData
+	if errors.As(err, &errData) {
+		return errData.ErrorData(), true
+	}
+	return nil, false
+}
+
+// panicReason returns a human-readable description for standard Solidity panic codes.
+func panicReason(code *big.Int) string {
+	if !code.IsUint64() {
+		return "unknown panic code"
+	}
+	switch code.Uint64() {
+	case 0x00:
+		return "generic/compiler-inserted panic"
+	case 0x01:
+		return "assertion failure"
+	case 0x11:
+		return "arithmetic overflow/underflow"
+	case 0x12:
+		return "division or modulo by zero"
+	case 0x21:
+		return "invalid enum value"
+	case 0x22:
+		return "invalid storage byte array"
+	case 0x31:
+		return "pop on empty array"
+	case 0x32:
+		return "array index out of bounds"
+	case 0x41:
+		return "out of memory"
+	case 0x51:
+		return "call to zero-initialized function"
+	default:
+		return "unknown panic code"
 	}
 }

--- a/op-service/errutil/errors_test.go
+++ b/op-service/errutil/errors_test.go
@@ -2,8 +2,10 @@ package errutil
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/stretchr/testify/require"
 )
 
@@ -18,6 +20,116 @@ func TestTryAddRevertReason(t *testing.T) {
 		err := errors.New("boom")
 		result := TryAddRevertReason(err)
 		require.Same(t, err, result)
+	})
+}
+
+func TestDecodeRevertReason(t *testing.T) {
+	t.Run("NonStringData", func(t *testing.T) {
+		result := DecodeRevertReason(42)
+		require.Equal(t, "42", result)
+	})
+
+	t.Run("EmptyString", func(t *testing.T) {
+		result := DecodeRevertReason("")
+		require.Equal(t, "", result)
+	})
+
+	t.Run("InvalidHex", func(t *testing.T) {
+		result := DecodeRevertReason("not-hex")
+		require.Equal(t, "not-hex", result)
+	})
+
+	t.Run("TooShort", func(t *testing.T) {
+		result := DecodeRevertReason("0x1234")
+		require.Equal(t, "0x1234", result)
+	})
+
+	t.Run("StandardErrorString", func(t *testing.T) {
+		// Error("insufficient balance") encoded
+		data := "0x08c379a0" +
+			"0000000000000000000000000000000000000000000000000000000000000020" +
+			"0000000000000000000000000000000000000000000000000000000000000014" +
+			"696e73756666696369656e742062616c616e6365000000000000000000000000"
+		result := DecodeRevertReason(data)
+		require.Equal(t, `Error("insufficient balance")`, result)
+	})
+
+	t.Run("StandardPanic", func(t *testing.T) {
+		// Panic(0x11) — arithmetic overflow
+		data := "0x4e487b71" +
+			"0000000000000000000000000000000000000000000000000000000000000011"
+		result := DecodeRevertReason(data)
+		require.Equal(t, "Panic(17: arithmetic overflow/underflow)", result)
+	})
+
+	t.Run("StandardPanicDivByZero", func(t *testing.T) {
+		// Panic(0x12) — division by zero
+		data := "0x4e487b71" +
+			"0000000000000000000000000000000000000000000000000000000000000012"
+		result := DecodeRevertReason(data)
+		require.Equal(t, "Panic(18: division or modulo by zero)", result)
+	})
+
+	t.Run("UnknownSelector", func(t *testing.T) {
+		// Some unknown 4-byte selector + data
+		data := "0x031c6de40000000000000000000000000000000000000000000000000000000000000001"
+		result := DecodeRevertReason(data)
+		// Falls through to returning raw hex
+		require.Equal(t, data, result)
+	})
+
+	t.Run("NoPrefix", func(t *testing.T) {
+		// Error("hi") without 0x prefix
+		data := "08c379a0" +
+			"0000000000000000000000000000000000000000000000000000000000000020" +
+			"0000000000000000000000000000000000000000000000000000000000000002" +
+			"6869000000000000000000000000000000000000000000000000000000000000"
+		result := DecodeRevertReason(data)
+		require.Equal(t, `Error("hi")`, result)
+	})
+}
+
+func TestDecodeRevertReasonWithABIs(t *testing.T) {
+	t.Run("FallsBackToStandard", func(t *testing.T) {
+		// Error("test") — should decode even with no ABIs provided
+		data := "0x08c379a0" +
+			"0000000000000000000000000000000000000000000000000000000000000020" +
+			"0000000000000000000000000000000000000000000000000000000000000004" +
+			"7465737400000000000000000000000000000000000000000000000000000000"
+		result := DecodeRevertReasonWithABIs(data)
+		require.Equal(t, `Error("test")`, result)
+	})
+
+	t.Run("NilABIs", func(t *testing.T) {
+		data := "0xdeadbeef"
+		result := DecodeRevertReasonWithABIs(data, nil, nil)
+		require.Equal(t, "0xdeadbeef", result)
+	})
+
+	t.Run("CustomABIError", func(t *testing.T) {
+		// NoImplementation(uint32 gameType) — selector 0x031c6de4, gameType=1
+		data := "0x031c6de4" +
+			"0000000000000000000000000000000000000000000000000000000000000001"
+		abiJSON := `[{"type":"error","name":"NoImplementation","inputs":[{"name":"gameType","type":"uint32"}]}]`
+		parsed, err := abi.JSON(strings.NewReader(abiJSON))
+		require.NoError(t, err)
+		result := DecodeRevertReasonWithABIs(data, &parsed)
+		require.Equal(t, "NoImplementation(gameType=1)", result)
+	})
+}
+
+func TestExtractRevertData(t *testing.T) {
+	t.Run("HasData", func(t *testing.T) {
+		err := stubError{}
+		data, ok := ExtractRevertData(err)
+		require.True(t, ok)
+		require.Equal(t, "kaboom", data)
+	})
+
+	t.Run("NoData", func(t *testing.T) {
+		err := errors.New("plain error")
+		_, ok := ExtractRevertData(err)
+		require.False(t, ok)
 	})
 }
 


### PR DESCRIPTION
## Summary

- Adds revert reason decoding to `op-service/errutil` for standard `Error(string)` and `Panic(uint256)` reverts, plus ABI-aware decoding for custom contract errors
- op-proposer now logs a decoded `revert_reason` field when proposal transactions fail, e.g. `NoImplementation(gameType=1)` instead of raw hex `0x031c6de40000000000000000000000000000000000000000000000000000000000000001`

### Before
```
msg="Failed to send proposal transaction" err="...reason: 0x031c6de40000000000000000000000000000000000000000000000000000000000000001"
```

### After
```
msg="Failed to send proposal transaction" err="..." revert_reason="NoImplementation(gameType=1)"
```

## Test plan

- [x] Unit tests for `DecodeRevertReason` covering standard Error/Panic/unknown selectors
- [x] Unit test for `DecodeRevertReasonWithABIs` with a custom ABI error matching the real `NoImplementation(uint32)` signature
- [x] Unit tests for `ExtractRevertData`
- [x] All existing `op-proposer` and `op-service/errutil` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)