### PR TITLE
op-interop-filter: add latency histogram and rejection reason metrics

### DIFF
--- a/op-interop-filter/filter/backend.go
+++ b/op-interop-filter/filter/backend.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"sync/atomic"
+	"time"
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
@@ -136,9 +137,28 @@ func supportedSafetyLevel(level types.SafetyLevel) bool {
 	return level == types.LocalUnsafe || level == types.CrossUnsafe
 }
 
+// classifyRejectionReason categorizes an error from CheckAccessList into a rejection reason label.
+func classifyRejectionReason(err error) string {
+	switch {
+	case errors.Is(err, types.ErrFailsafeEnabled):
+		return "failsafe"
+	case errors.Is(err, types.ErrUnknownChain):
+		return "unknown_chain"
+	case errors.Is(err, types.ErrConflict):
+		return "expired_message"
+	default:
+		return "invalid_executing_message"
+	}
+}
+
 // CheckAccessList validates the given access list entries.
 func (b *Backend) CheckAccessList(ctx context.Context, inboxEntries []common.Hash,
 	minSafety types.SafetyLevel, execDescriptor types.ExecutingDescriptor) error {
+
+	start := time.Now()
+	defer func() {
+		b.metrics.RecordCheckAccessListDuration(time.Since(start).Seconds())
+	}()
 
 	if b.passthrough {
 		b.metrics.RecordCheckAccessList(true)
@@ -147,23 +167,27 @@ func (b *Backend) CheckAccessList(ctx context.Context, inboxEntries []common.Has
 
 	if b.FailsafeEnabled() {
 		b.metrics.RecordCheckAccessList(false)
+		b.metrics.RecordCheckAccessListRejection("failsafe")
 		return types.ErrFailsafeEnabled
 	}
 
 	if !b.Ready() {
 		b.metrics.RecordCheckAccessList(false)
+		b.metrics.RecordCheckAccessListRejection("failsafe")
 		b.log.Debug("Backend not ready; rejecting access list check")
 		return types.ErrUninitialized
 	}
 
 	if !supportedSafetyLevel(minSafety) {
 		b.metrics.RecordCheckAccessList(false)
+		b.metrics.RecordCheckAccessListRejection("invalid_executing_message")
 		return fmt.Errorf("unsupported safety level %s: only %s and %s are supported",
 			minSafety, types.LocalUnsafe, types.CrossUnsafe)
 	}
 
 	if _, ok := b.chains[execDescriptor.ChainID]; !ok {
 		b.metrics.RecordCheckAccessList(false)
+		b.metrics.RecordCheckAccessListRejection("unknown_chain")
 		return fmt.Errorf("executing chain %s: %w", execDescriptor.ChainID, types.ErrUnknownChain)
 	}
 
@@ -174,11 +198,13 @@ func (b *Backend) CheckAccessList(ctx context.Context, inboxEntries []common.Has
 		remaining, access, err = types.ParseAccess(remaining)
 		if err != nil {
 			b.metrics.RecordCheckAccessList(false)
+			b.metrics.RecordCheckAccessListRejection("parse_error")
 			return fmt.Errorf("failed to parse access entry: %w", err)
 		}
 
 		if err := b.crossValidator.ValidateAccessEntry(access, minSafety, execDescriptor); err != nil {
 			b.metrics.RecordCheckAccessList(false)
+			b.metrics.RecordCheckAccessListRejection(classifyRejectionReason(err))
 			return err
 		}
 	}

--- a/op-interop-filter/metrics/metrics.go
+++ b/op-interop-filter/metrics/metrics.go
@@ -16,6 +16,8 @@ type Metricer interface {
 	RecordFailsafeEnabled(enabled bool)
 	RecordChainHead(chainID uint64, blockNum uint64)
 	RecordCheckAccessList(success bool)
+	RecordCheckAccessListDuration(duration float64)
+	RecordCheckAccessListRejection(reason string)
 	RecordBackfillProgress(chainID uint64, progress float64)
 	RecordReorgDetected(chainID uint64)
 	RecordLogsAdded(chainID uint64, count int64)
@@ -32,7 +34,9 @@ type Metrics struct {
 	up               prometheus.Gauge
 	failsafeEnabled  prometheus.Gauge
 	chainHead        *prometheus.GaugeVec
-	checkAccessTotal *prometheus.CounterVec
+	checkAccessTotal         *prometheus.CounterVec
+	checkAccessListDuration  prometheus.Histogram
+	checkAccessListRejectVec *prometheus.CounterVec
 
 	// Chain-specific metrics
 	backfillProgress              *prometheus.GaugeVec
@@ -88,6 +92,19 @@ func NewMetrics(procName string) *Metrics {
 			Name:      "check_access_list_total",
 			Help:      "Total checkAccessList requests",
 		}, []string{"success"}),
+
+		checkAccessListDuration: factory.NewHistogram(prometheus.HistogramOpts{
+			Namespace: ns,
+			Name:      "check_access_list_duration_seconds",
+			Help:      "Duration of CheckAccessList calls in seconds",
+			Buckets:   []float64{0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5},
+		}),
+
+		checkAccessListRejectVec: factory.NewCounterVec(prometheus.CounterOpts{
+			Namespace: ns,
+			Name:      "check_access_list_rejections_total",
+			Help:      "Access list rejections by reason",
+		}, []string{"reason"}),
 
 		backfillProgress: factory.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: ns,
@@ -157,6 +174,14 @@ func (m *Metrics) RecordCheckAccessList(success bool) {
 	m.checkAccessTotal.WithLabelValues(label).Inc()
 }
 
+func (m *Metrics) RecordCheckAccessListDuration(duration float64) {
+	m.checkAccessListDuration.Observe(duration)
+}
+
+func (m *Metrics) RecordCheckAccessListRejection(reason string) {
+	m.checkAccessListRejectVec.WithLabelValues(reason).Inc()
+}
+
 func (m *Metrics) RecordBackfillProgress(chainID uint64, progress float64) {
 	m.backfillProgress.WithLabelValues(strconv.FormatUint(chainID, 10)).Set(progress)
 }
@@ -187,6 +212,8 @@ func (n *noopMetrics) RecordUp()                                               {
 func (n *noopMetrics) RecordFailsafeEnabled(enabled bool)                      {}
 func (n *noopMetrics) RecordChainHead(chainID uint64, blockNum uint64)         {}
 func (n *noopMetrics) RecordCheckAccessList(success bool)                      {}
+func (n *noopMetrics) RecordCheckAccessListDuration(duration float64)          {}
+func (n *noopMetrics) RecordCheckAccessListRejection(reason string)            {}
 func (n *noopMetrics) RecordBackfillProgress(chainID uint64, progress float64) {}
 func (n *noopMetrics) RecordReorgDetected(chainID uint64)                      {}
 func (n *noopMetrics) RecordLogsAdded(chainID uint64, count int64)             {}

--- a/op-interop-filter/metrics/metrics.go
+++ b/op-interop-filter/metrics/metrics.go
@@ -30,10 +30,10 @@ type Metrics struct {
 	registry *prometheus.Registry
 	factory  opmetrics.Factory
 
-	info             *prometheus.GaugeVec
-	up               prometheus.Gauge
-	failsafeEnabled  prometheus.Gauge
-	chainHead        *prometheus.GaugeVec
+	info                     *prometheus.GaugeVec
+	up                       prometheus.Gauge
+	failsafeEnabled          prometheus.Gauge
+	chainHead                *prometheus.GaugeVec
 	checkAccessTotal         *prometheus.CounterVec
 	checkAccessListDuration  prometheus.Histogram
 	checkAccessListRejectVec *prometheus.CounterVec


### PR DESCRIPTION
## Summary
- Adds 2 new Prometheus metrics to op-interop-filter for interop quality gate qualification (SLI-IF-7, SLI-IF-8)
- `check_access_list_duration_seconds` — histogram of CheckAccessList call latency (buckets: 1ms to 5s)
- `check_access_list_rejections_total` — counter of access list rejections by reason (failsafe, unknown_chain, expired_message, invalid_executing_message, parse_error)

## Context
These metrics are required for the Interop Quality Gates qualification process. See [Interop Quality Gates](https://www.notion.so/Interop-Quality-Gates-34af153ee1628008b0c4f21b82143876) for SLI/SLO definitions.

## Test plan
- [ ] `go build ./...` passes from op-interop-filter/
- [ ] `go vet ./...` passes
- [ ] Deploy to devnet and verify metrics appear on /metrics endpoint
- [ ] Confirm rejection reason labels match actual error paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)