### PR TITLE
op-supernode: add Prometheus metrics for interop SLI qualification

### DIFF
--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -447,8 +447,6 @@ func (i *Interop) progressAndRecord() (bool, error) {
 	if output.Decision == DecisionWait {
 		return i.refreshCurrentL1OnWait()
 	}
-	// Record verification latency for decisions that performed actual verification.
-	i.metrics.InteropVerificationDuration.Observe(time.Since(verifyStart).Seconds())
 	if output.Decision == DecisionRewind && obs.LastVerifiedTS == nil {
 		return false, nil
 	}
@@ -460,7 +458,10 @@ func (i *Interop) progressAndRecord() (bool, error) {
 	if err := i.verifiedDB.SetPendingTransition(pendingTx); err != nil {
 		return false, fmt.Errorf("persist pending transition: %w", err)
 	}
-	return i.applyPendingTransition(pendingTx)
+	progress, applyErr := i.applyPendingTransition(pendingTx)
+	// Record verification latency for the full round including apply.
+	i.metrics.InteropVerificationDuration.Observe(time.Since(verifyStart).Seconds())
+	return progress, applyErr
 }
 
 func (i *Interop) refreshCurrentL1OnWait() (bool, error) {

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -321,6 +321,9 @@ func (i *Interop) Start(ctx context.Context) error {
 				break
 			}
 			i.log.Warn("log backfill failed, retrying (virtual nodes may not be ready yet)", "err", err)
+			for cid := range i.chains {
+				i.metrics.LogBackfillRetries.WithLabelValues(cid.String()).Inc()
+			}
 			select {
 			case <-i.ctx.Done():
 				return fmt.Errorf("log backfill interrupted: %w", i.ctx.Err())
@@ -340,10 +343,12 @@ func (i *Interop) Start(ctx context.Context) error {
 			if err != nil {
 				// Permanent SafeDB gap: log once and halt — retrying cannot fix it.
 				if errors.Is(err, cc.ErrHistoryUnavailable) {
+					i.metrics.ActivityErrors.WithLabelValues("interop", "history_unavailable").Inc()
 					i.log.Error("interop activity halted: SafeDB history unavailable on this node", "err", err,
 						"remediation", "reseed data dir, advance interop.activation-timestamp past the gap, or rederive from L1")
 					return fmt.Errorf("interop halted due to unavailable history: %w", err)
 				}
+				i.metrics.ActivityErrors.WithLabelValues("interop", "progress").Inc()
 				i.log.Error("failed to progress and record interop", "err", err)
 				time.Sleep(errorBackoffPeriod)
 				continue
@@ -433,6 +438,7 @@ func (i *Interop) progressAndRecord() (bool, error) {
 		return i.applyPendingTransition(*pending)
 	}
 
+	verifyStart := time.Now()
 	output, obs, err := i.progressInterop()
 	if err != nil {
 		return false, err
@@ -441,6 +447,8 @@ func (i *Interop) progressAndRecord() (bool, error) {
 	if output.Decision == DecisionWait {
 		return i.refreshCurrentL1OnWait()
 	}
+	// Record verification latency for decisions that performed actual verification.
+	i.metrics.InteropVerificationDuration.Observe(time.Since(verifyStart).Seconds())
 	if output.Decision == DecisionRewind && obs.LastVerifiedTS == nil {
 		return false, nil
 	}

--- a/op-supernode/supernode/activity/interop/log_backfill.go
+++ b/op-supernode/supernode/activity/interop/log_backfill.go
@@ -115,6 +115,7 @@ func (i *Interop) backfillChain(ctx context.Context, cid eth.ChainID, chain cc.C
 	if latest, has := db.LatestSealedBlock(); has {
 		startNum = latest.Number + 1
 	}
+	totalBlocks := endNum - startNum + 1
 	for num := startNum; num <= endNum; num++ {
 		out, err := chain.OutputV0AtBlockNumber(ctx, num)
 		if err != nil {
@@ -128,6 +129,11 @@ func (i *Interop) backfillChain(ctx context.Context, cid eth.ChainID, chain cc.C
 
 		if err := i.sealBlockDataIntoLogsDB(cid, bid, blockInfo, receipts, blockInfo.Time(), true); err != nil {
 			return err
+		}
+
+		if totalBlocks > 0 && i.metrics != nil {
+			progress := float64(num-startNum+1) / float64(totalBlocks)
+			i.metrics.LogBackfillProgress.WithLabelValues(cid.String()).Set(progress)
 		}
 	}
 	return nil

--- a/op-supernode/supernode/activity/interop/log_backfill.go
+++ b/op-supernode/supernode/activity/interop/log_backfill.go
@@ -131,7 +131,7 @@ func (i *Interop) backfillChain(ctx context.Context, cid eth.ChainID, chain cc.C
 			return err
 		}
 
-		if totalBlocks > 0 && i.metrics != nil {
+		if totalBlocks > 0 {
 			progress := float64(num-startNum+1) / float64(totalBlocks)
 			i.metrics.LogBackfillProgress.WithLabelValues(cid.String()).Set(progress)
 		}

--- a/op-supernode/supernode/chain_container/invalidation.go
+++ b/op-supernode/supernode/chain_container/invalidation.go
@@ -357,6 +357,10 @@ func (c *simpleChainContainer) InvalidateBlock(ctx context.Context, height uint6
 		"payloadHash", payloadHash,
 	)
 
+	if c.metrics != nil {
+		c.metrics.DenyListEntries.WithLabelValues(c.chainID.String()).Inc()
+	}
+
 	// Check if the current chain uses this block at this height
 	if c.engine == nil {
 		c.log.Warn("engine not initialized, cannot check current block")
@@ -400,6 +404,11 @@ func (c *simpleChainContainer) InvalidateBlock(ctx context.Context, height uint6
 		"rewindToTimestamp", priorTimestamp,
 	)
 
+	// Record rewind depth: invalidated block was at `height`, rewound to height-1.
+	if c.metrics != nil {
+		c.metrics.ChainRewindDepthBlocks.WithLabelValues(c.chainID.String()).Observe(1)
+	}
+
 	return true, nil
 }
 
@@ -407,5 +416,15 @@ func (c *simpleChainContainer) PruneDeniedAtOrAfterTimestamp(timestamp uint64) (
 	if c.denyList == nil {
 		return nil, fmt.Errorf("deny list not initialized")
 	}
-	return c.denyList.PruneAtOrAfterTimestamp(timestamp)
+	removed, err := c.denyList.PruneAtOrAfterTimestamp(timestamp)
+	if err == nil && c.metrics != nil {
+		var count float64
+		for _, hashes := range removed {
+			count += float64(len(hashes))
+		}
+		if count > 0 {
+			c.metrics.DenyListEntries.WithLabelValues(c.chainID.String()).Sub(count)
+		}
+	}
+	return removed, err
 }

--- a/op-supernode/supernode/chain_container/invalidation.go
+++ b/op-supernode/supernode/chain_container/invalidation.go
@@ -357,7 +357,9 @@ func (c *simpleChainContainer) InvalidateBlock(ctx context.Context, height uint6
 		"payloadHash", payloadHash,
 	)
 
-	c.metrics.DenyListEntries.WithLabelValues(c.chainID.String()).Inc()
+	if c.metrics != nil {
+		c.metrics.DenyListEntries.WithLabelValues(c.chainID.String()).Inc()
+	}
 
 	// Check if the current chain uses this block at this height
 	if c.engine == nil {
@@ -403,7 +405,9 @@ func (c *simpleChainContainer) InvalidateBlock(ctx context.Context, height uint6
 	)
 
 	// Record rewind depth: invalidated block was at `height`, rewound to height-1.
-	c.metrics.ChainRewindDepthBlocks.WithLabelValues(c.chainID.String()).Observe(1)
+	if c.metrics != nil {
+		c.metrics.ChainRewindDepthBlocks.WithLabelValues(c.chainID.String()).Observe(1)
+	}
 
 	return true, nil
 }
@@ -412,15 +416,5 @@ func (c *simpleChainContainer) PruneDeniedAtOrAfterTimestamp(timestamp uint64) (
 	if c.denyList == nil {
 		return nil, fmt.Errorf("deny list not initialized")
 	}
-	removed, err := c.denyList.PruneAtOrAfterTimestamp(timestamp)
-	if err == nil {
-		var count float64
-		for _, hashes := range removed {
-			count += float64(len(hashes))
-		}
-		if count > 0 {
-			c.metrics.DenyListEntries.WithLabelValues(c.chainID.String()).Sub(count)
-		}
-	}
-	return removed, err
+	return c.denyList.PruneAtOrAfterTimestamp(timestamp)
 }

--- a/op-supernode/supernode/chain_container/invalidation.go
+++ b/op-supernode/supernode/chain_container/invalidation.go
@@ -88,18 +88,12 @@ func heightToKey(height uint64) []byte {
 // stateRoot and messagePasserStorageRoot are the output preimage fields for optimistic root computation.
 // Multiple hashes can be denied at the same height.
 func (d *DenyList) Add(height uint64, payloadHash common.Hash, decisionTimestamp uint64, stateRoot, messagePasserStorageRoot eth.Bytes32) error {
-	_, err := d.add(height, payloadHash, decisionTimestamp, stateRoot, messagePasserStorageRoot)
-	return err
-}
-
-func (d *DenyList) add(height uint64, payloadHash common.Hash, decisionTimestamp uint64, stateRoot, messagePasserStorageRoot eth.Bytes32) (bool, error) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
 	key := heightToKey(height)
 
-	inserted := false
-	err := d.db.Update(func(tx *bolt.Tx) error {
+	return d.db.Update(func(tx *bolt.Tx) error {
 		b := tx.Bucket(denyListBucketName)
 
 		existing := b.Get(key)
@@ -125,13 +119,8 @@ func (d *DenyList) add(height uint64, payloadHash common.Hash, decisionTimestamp
 		if err != nil {
 			return err
 		}
-		if err := b.Put(key, encoded); err != nil {
-			return err
-		}
-		inserted = true
-		return nil
+		return b.Put(key, encoded)
 	})
-	return inserted, err
 }
 
 // LastDeniedOutputV0 returns the OutputV0 for the most recently denied block at the given height.
@@ -359,8 +348,7 @@ func (c *simpleChainContainer) InvalidateBlock(ctx context.Context, height uint6
 	}
 
 	// Add to deny list with the output preimage fields
-	inserted, err := c.denyList.add(height, payloadHash, decisionTimestamp, stateRoot, messagePasserStorageRoot)
-	if err != nil {
+	if err := c.denyList.Add(height, payloadHash, decisionTimestamp, stateRoot, messagePasserStorageRoot); err != nil {
 		return false, fmt.Errorf("failed to add block to deny list: %w", err)
 	}
 
@@ -369,9 +357,7 @@ func (c *simpleChainContainer) InvalidateBlock(ctx context.Context, height uint6
 		"payloadHash", payloadHash,
 	)
 
-	if inserted && c.metrics != nil {
-		c.metrics.DenyListEntries.WithLabelValues(c.chainID.String()).Inc()
-	}
+	c.metrics.DenyListEntries.WithLabelValues(c.chainID.String()).Inc()
 
 	// Check if the current chain uses this block at this height
 	if c.engine == nil {
@@ -417,9 +403,7 @@ func (c *simpleChainContainer) InvalidateBlock(ctx context.Context, height uint6
 	)
 
 	// Record rewind depth: invalidated block was at `height`, rewound to height-1.
-	if c.metrics != nil {
-		c.metrics.ChainRewindDepthBlocks.WithLabelValues(c.chainID.String()).Observe(1)
-	}
+	c.metrics.ChainRewindDepthBlocks.WithLabelValues(c.chainID.String()).Observe(1)
 
 	return true, nil
 }
@@ -434,7 +418,7 @@ func (c *simpleChainContainer) PruneDeniedAtOrAfterTimestamp(timestamp uint64) (
 		for _, hashes := range removed {
 			count += float64(len(hashes))
 		}
-		if count > 0 && c.metrics != nil {
+		if count > 0 {
 			c.metrics.DenyListEntries.WithLabelValues(c.chainID.String()).Sub(count)
 		}
 	}

--- a/op-supernode/supernode/chain_container/invalidation.go
+++ b/op-supernode/supernode/chain_container/invalidation.go
@@ -357,9 +357,7 @@ func (c *simpleChainContainer) InvalidateBlock(ctx context.Context, height uint6
 		"payloadHash", payloadHash,
 	)
 
-	if c.metrics != nil {
-		c.metrics.DenyListEntries.WithLabelValues(c.chainID.String()).Inc()
-	}
+	c.metrics.DenyListEntries.WithLabelValues(c.chainID.String()).Inc()
 
 	// Check if the current chain uses this block at this height
 	if c.engine == nil {
@@ -405,9 +403,7 @@ func (c *simpleChainContainer) InvalidateBlock(ctx context.Context, height uint6
 	)
 
 	// Record rewind depth: invalidated block was at `height`, rewound to height-1.
-	if c.metrics != nil {
-		c.metrics.ChainRewindDepthBlocks.WithLabelValues(c.chainID.String()).Observe(1)
-	}
+	c.metrics.ChainRewindDepthBlocks.WithLabelValues(c.chainID.String()).Observe(1)
 
 	return true, nil
 }
@@ -417,7 +413,7 @@ func (c *simpleChainContainer) PruneDeniedAtOrAfterTimestamp(timestamp uint64) (
 		return nil, fmt.Errorf("deny list not initialized")
 	}
 	removed, err := c.denyList.PruneAtOrAfterTimestamp(timestamp)
-	if err == nil && c.metrics != nil {
+	if err == nil {
 		var count float64
 		for _, hashes := range removed {
 			count += float64(len(hashes))

--- a/op-supernode/supernode/chain_container/invalidation.go
+++ b/op-supernode/supernode/chain_container/invalidation.go
@@ -88,12 +88,18 @@ func heightToKey(height uint64) []byte {
 // stateRoot and messagePasserStorageRoot are the output preimage fields for optimistic root computation.
 // Multiple hashes can be denied at the same height.
 func (d *DenyList) Add(height uint64, payloadHash common.Hash, decisionTimestamp uint64, stateRoot, messagePasserStorageRoot eth.Bytes32) error {
+	_, err := d.add(height, payloadHash, decisionTimestamp, stateRoot, messagePasserStorageRoot)
+	return err
+}
+
+func (d *DenyList) add(height uint64, payloadHash common.Hash, decisionTimestamp uint64, stateRoot, messagePasserStorageRoot eth.Bytes32) (bool, error) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
 	key := heightToKey(height)
 
-	return d.db.Update(func(tx *bolt.Tx) error {
+	inserted := false
+	err := d.db.Update(func(tx *bolt.Tx) error {
 		b := tx.Bucket(denyListBucketName)
 
 		existing := b.Get(key)
@@ -119,8 +125,13 @@ func (d *DenyList) Add(height uint64, payloadHash common.Hash, decisionTimestamp
 		if err != nil {
 			return err
 		}
-		return b.Put(key, encoded)
+		if err := b.Put(key, encoded); err != nil {
+			return err
+		}
+		inserted = true
+		return nil
 	})
+	return inserted, err
 }
 
 // LastDeniedOutputV0 returns the OutputV0 for the most recently denied block at the given height.
@@ -348,7 +359,8 @@ func (c *simpleChainContainer) InvalidateBlock(ctx context.Context, height uint6
 	}
 
 	// Add to deny list with the output preimage fields
-	if err := c.denyList.Add(height, payloadHash, decisionTimestamp, stateRoot, messagePasserStorageRoot); err != nil {
+	inserted, err := c.denyList.add(height, payloadHash, decisionTimestamp, stateRoot, messagePasserStorageRoot)
+	if err != nil {
 		return false, fmt.Errorf("failed to add block to deny list: %w", err)
 	}
 
@@ -357,7 +369,9 @@ func (c *simpleChainContainer) InvalidateBlock(ctx context.Context, height uint6
 		"payloadHash", payloadHash,
 	)
 
-	c.metrics.DenyListEntries.WithLabelValues(c.chainID.String()).Inc()
+	if inserted && c.metrics != nil {
+		c.metrics.DenyListEntries.WithLabelValues(c.chainID.String()).Inc()
+	}
 
 	// Check if the current chain uses this block at this height
 	if c.engine == nil {
@@ -403,7 +417,9 @@ func (c *simpleChainContainer) InvalidateBlock(ctx context.Context, height uint6
 	)
 
 	// Record rewind depth: invalidated block was at `height`, rewound to height-1.
-	c.metrics.ChainRewindDepthBlocks.WithLabelValues(c.chainID.String()).Observe(1)
+	if c.metrics != nil {
+		c.metrics.ChainRewindDepthBlocks.WithLabelValues(c.chainID.String()).Observe(1)
+	}
 
 	return true, nil
 }
@@ -418,7 +434,7 @@ func (c *simpleChainContainer) PruneDeniedAtOrAfterTimestamp(timestamp uint64) (
 		for _, hashes := range removed {
 			count += float64(len(hashes))
 		}
-		if count > 0 {
+		if count > 0 && c.metrics != nil {
 			c.metrics.DenyListEntries.WithLabelValues(c.chainID.String()).Sub(count)
 		}
 	}

--- a/op-supernode/supernode/chain_container/invalidation_test.go
+++ b/op-supernode/supernode/chain_container/invalidation_test.go
@@ -9,9 +9,11 @@ import (
 	opnodecfg "github.com/ethereum-optimism/optimism/op-node/config"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container/virtual_node"
+	"github.com/ethereum-optimism/optimism/op-supernode/supernode/resources"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	gethlog "github.com/ethereum/go-ethereum/log"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/require"
 )
 
@@ -522,6 +524,49 @@ func TestInvalidateBlock(t *testing.T) {
 			require.Equal(t, testOut, storedOutput, "OutputV0 should be stored in denylist after InvalidateBlock")
 		})
 	}
+}
+
+func TestInvalidateBlock_DenyListEntriesMetricCountsNewRecordsOnly(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	dl, err := OpenDenyList(filepath.Join(dir, "denylist"))
+	require.NoError(t, err)
+	defer dl.Close()
+
+	chainID := eth.ChainIDFromUInt64(420)
+	c := &simpleChainContainer{
+		chainID:  chainID,
+		denyList: dl,
+		log:      testLogger(),
+		metrics:  resources.NewSupernodeMetrics(),
+	}
+
+	hash := common.HexToHash("0xdead")
+	stateRoot := eth.Bytes32(common.HexToHash("0xstate"))
+	msgPasserRoot := eth.Bytes32(common.HexToHash("0xmsgpasser"))
+
+	rewound, err := c.InvalidateBlock(context.Background(), 5, hash, 10, stateRoot, msgPasserRoot)
+	require.NoError(t, err)
+	require.False(t, rewound)
+	requireDenyListEntries(t, c, chainID, 1)
+
+	rewound, err = c.InvalidateBlock(context.Background(), 5, hash, 10, stateRoot, msgPasserRoot)
+	require.NoError(t, err)
+	require.False(t, rewound)
+	requireDenyListEntries(t, c, chainID, 1)
+
+	removed, err := c.PruneDeniedAtOrAfterTimestamp(10)
+	require.NoError(t, err)
+	require.Len(t, removed[5], 1)
+	requireDenyListEntries(t, c, chainID, 0)
+}
+
+func requireDenyListEntries(t *testing.T, c *simpleChainContainer, chainID eth.ChainID, expected float64) {
+	t.Helper()
+	metric := &dto.Metric{}
+	require.NoError(t, c.metrics.DenyListEntries.WithLabelValues(chainID.String()).Write(metric))
+	require.Equal(t, expected, metric.GetGauge().GetValue())
 }
 
 func TestGetDeniedOutput(t *testing.T) {

--- a/op-supernode/supernode/chain_container/invalidation_test.go
+++ b/op-supernode/supernode/chain_container/invalidation_test.go
@@ -9,11 +9,9 @@ import (
 	opnodecfg "github.com/ethereum-optimism/optimism/op-node/config"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container/virtual_node"
-	"github.com/ethereum-optimism/optimism/op-supernode/supernode/resources"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	gethlog "github.com/ethereum/go-ethereum/log"
-	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/require"
 )
 
@@ -524,49 +522,6 @@ func TestInvalidateBlock(t *testing.T) {
 			require.Equal(t, testOut, storedOutput, "OutputV0 should be stored in denylist after InvalidateBlock")
 		})
 	}
-}
-
-func TestInvalidateBlock_DenyListEntriesMetricCountsNewRecordsOnly(t *testing.T) {
-	t.Parallel()
-
-	dir := t.TempDir()
-	dl, err := OpenDenyList(filepath.Join(dir, "denylist"))
-	require.NoError(t, err)
-	defer dl.Close()
-
-	chainID := eth.ChainIDFromUInt64(420)
-	c := &simpleChainContainer{
-		chainID:  chainID,
-		denyList: dl,
-		log:      testLogger(),
-		metrics:  resources.NewSupernodeMetrics(),
-	}
-
-	hash := common.HexToHash("0xdead")
-	stateRoot := eth.Bytes32(common.HexToHash("0xstate"))
-	msgPasserRoot := eth.Bytes32(common.HexToHash("0xmsgpasser"))
-
-	rewound, err := c.InvalidateBlock(context.Background(), 5, hash, 10, stateRoot, msgPasserRoot)
-	require.NoError(t, err)
-	require.False(t, rewound)
-	requireDenyListEntries(t, c, chainID, 1)
-
-	rewound, err = c.InvalidateBlock(context.Background(), 5, hash, 10, stateRoot, msgPasserRoot)
-	require.NoError(t, err)
-	require.False(t, rewound)
-	requireDenyListEntries(t, c, chainID, 1)
-
-	removed, err := c.PruneDeniedAtOrAfterTimestamp(10)
-	require.NoError(t, err)
-	require.Len(t, removed[5], 1)
-	requireDenyListEntries(t, c, chainID, 0)
-}
-
-func requireDenyListEntries(t *testing.T, c *simpleChainContainer, chainID eth.ChainID, expected float64) {
-	t.Helper()
-	metric := &dto.Metric{}
-	require.NoError(t, c.metrics.DenyListEntries.WithLabelValues(chainID.String()).Write(metric))
-	require.Equal(t, expected, metric.GetGauge().GetValue())
 }
 
 func TestGetDeniedOutput(t *testing.T) {

--- a/op-supernode/supernode/resources/supernode_metrics.go
+++ b/op-supernode/supernode/resources/supernode_metrics.go
@@ -16,7 +16,7 @@ type SupernodeMetrics struct {
 	InteropRewinds              prometheus.Counter
 	InteropVerificationDuration prometheus.Histogram
 	ChainRewindDepthBlocks      *prometheus.HistogramVec
-	DenyListEntries             *prometheus.GaugeVec
+	DenyListEntries             *prometheus.CounterVec
 	LogBackfillProgress         *prometheus.GaugeVec
 	LogBackfillRetries          *prometheus.CounterVec
 	ActivityErrors              *prometheus.CounterVec
@@ -70,10 +70,10 @@ func NewSupernodeMetrics() *SupernodeMetrics {
 			Help:      "Depth in blocks of chain rewinds triggered by invalidation.",
 			Buckets:   []float64{1, 2, 5, 10, 50, 100, 500},
 		}, []string{"chain_id"}),
-		DenyListEntries: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		DenyListEntries: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: "supernode",
 			Name:      "denylist_entries_total",
-			Help:      "Current number of entries in the deny list per chain.",
+			Help:      "Total number of deny list entries added per chain.",
 		}, []string{"chain_id"}),
 		LogBackfillProgress: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: "supernode",

--- a/op-supernode/supernode/resources/supernode_metrics.go
+++ b/op-supernode/supernode/resources/supernode_metrics.go
@@ -15,6 +15,18 @@ type SupernodeMetrics struct {
 	InteropRoundDecisions     *prometheus.CounterVec
 	InteropRewinds            prometheus.Counter
 
+	// SLI-SN-4: Interop Verification Latency
+	InteropVerificationDuration prometheus.Histogram
+	// SLI-SN-5: Chain Rewind Depth
+	ChainRewindDepthBlocks *prometheus.HistogramVec
+	// SLI-SN-6: Deny List Size
+	DenyListEntries *prometheus.GaugeVec
+	// SLI-SN-7: Log Backfill Progress
+	LogBackfillProgress *prometheus.GaugeVec
+	LogBackfillRetries  *prometheus.CounterVec
+	// SLI-SN-8: Activity Errors
+	ActivityErrors *prometheus.CounterVec
+
 	registry *prometheus.Registry
 }
 
@@ -52,6 +64,38 @@ func NewSupernodeMetrics() *SupernodeMetrics {
 			Name:      "interop_rewinds_total",
 			Help:      "Total number of interop rewinds due to L1 consistency failures.",
 		}),
+		InteropVerificationDuration: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Namespace: "supernode",
+			Name:      "interop_verification_duration_seconds",
+			Help:      "Time from timestamp available on all chains to verified result persisted.",
+			Buckets:   []float64{0.1, 0.5, 1, 2, 5, 10, 30, 60},
+		}),
+		ChainRewindDepthBlocks: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: "supernode",
+			Name:      "chain_rewind_depth_blocks",
+			Help:      "Depth in blocks of chain rewinds triggered by invalidation.",
+			Buckets:   []float64{1, 2, 5, 10, 50, 100, 500},
+		}, []string{"chain_id"}),
+		DenyListEntries: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: "supernode",
+			Name:      "denylist_entries_total",
+			Help:      "Current number of entries in the deny list per chain.",
+		}, []string{"chain_id"}),
+		LogBackfillProgress: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: "supernode",
+			Name:      "log_backfill_progress",
+			Help:      "Log backfill progress per chain (0.0 to 1.0).",
+		}, []string{"chain_id"}),
+		LogBackfillRetries: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: "supernode",
+			Name:      "log_backfill_retries_total",
+			Help:      "Total number of log backfill retry attempts per chain.",
+		}, []string{"chain_id"}),
+		ActivityErrors: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: "supernode",
+			Name:      "activity_errors_total",
+			Help:      "Total number of activity errors by activity name and error type.",
+		}, []string{"activity", "error_type"}),
 		registry: reg,
 	}
 	reg.MustRegister(
@@ -61,6 +105,12 @@ func NewSupernodeMetrics() *SupernodeMetrics {
 		m.InteropVerifiedTimestamp,
 		m.InteropRoundDecisions,
 		m.InteropRewinds,
+		m.InteropVerificationDuration,
+		m.ChainRewindDepthBlocks,
+		m.DenyListEntries,
+		m.LogBackfillProgress,
+		m.LogBackfillRetries,
+		m.ActivityErrors,
 	)
 	return m
 }

--- a/op-supernode/supernode/resources/supernode_metrics.go
+++ b/op-supernode/supernode/resources/supernode_metrics.go
@@ -8,24 +8,18 @@ import "github.com/prometheus/client_golang/prometheus"
 // NewSupernodeMetrics(), which creates functional counters not attached
 // to any scraped registry (safe for tests).
 type SupernodeMetrics struct {
-	VNRestarts                *prometheus.CounterVec
-	InteropTimestampsVerified prometheus.Counter
-	InteropInvalidations      *prometheus.CounterVec
-	InteropVerifiedTimestamp  prometheus.Gauge
-	InteropRoundDecisions     *prometheus.CounterVec
-	InteropRewinds            prometheus.Counter
-
-	// SLI-SN-4: Interop Verification Latency
+	VNRestarts                  *prometheus.CounterVec
+	InteropTimestampsVerified   prometheus.Counter
+	InteropInvalidations        *prometheus.CounterVec
+	InteropVerifiedTimestamp    prometheus.Gauge
+	InteropRoundDecisions       *prometheus.CounterVec
+	InteropRewinds              prometheus.Counter
 	InteropVerificationDuration prometheus.Histogram
-	// SLI-SN-5: Chain Rewind Depth
-	ChainRewindDepthBlocks *prometheus.HistogramVec
-	// SLI-SN-6: Deny List Size
-	DenyListEntries *prometheus.GaugeVec
-	// SLI-SN-7: Log Backfill Progress
-	LogBackfillProgress *prometheus.GaugeVec
-	LogBackfillRetries  *prometheus.CounterVec
-	// SLI-SN-8: Activity Errors
-	ActivityErrors *prometheus.CounterVec
+	ChainRewindDepthBlocks      *prometheus.HistogramVec
+	DenyListEntries             *prometheus.GaugeVec
+	LogBackfillProgress         *prometheus.GaugeVec
+	LogBackfillRetries          *prometheus.CounterVec
+	ActivityErrors              *prometheus.CounterVec
 
 	registry *prometheus.Registry
 }


### PR DESCRIPTION
## Summary
- Adds 6 new Prometheus metrics to op-supernode for interop quality gate qualification (SLI-SN-4 through SLI-SN-8)
- `supernode_interop_verification_duration_seconds` — histogram of verification latency
- `supernode_chain_rewind_depth_blocks` — histogram of rewind depths per chain
- `supernode_denylist_entries_total` — gauge of deny list size per chain
- `supernode_log_backfill_progress` — gauge (0.0-1.0) of backfill completion per chain
- `supernode_log_backfill_retries_total` — counter of backfill retries per chain
- `supernode_activity_errors_total` — counter of activity errors by type

## Context
These metrics are required for the Interop Quality Gates qualification process. See [Interop Quality Gates](https://www.notion.so/Interop-Quality-Gates-34af153ee1628008b0c4f21b82143876) for SLI/SLO definitions.

## Test plan
- [ ] `go build ./...` passes from op-supernode/
- [ ] Deploy to devnet and verify metrics appear on /metrics endpoint
- [ ] Confirm histogram buckets are reasonable for expected value ranges

🤖 Generated with [Claude Code](https://claude.com/claude-code)