### PR TITLE
ci(kona): run all proofs/ action tests under kona-host by default

### DIFF
--- a/op-node/rollup/derive/upgrade_transaction.go
+++ b/op-node/rollup/derive/upgrade_transaction.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"math/big"
+	"strings"
 
 	"github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum-optimism/optimism/op-core/nuts"
@@ -41,6 +42,17 @@ type nutBundle struct {
 	Transactions []networkUpgradeTransaction `json:"transactions"`
 }
 
+// capitalizeForkName returns the fork name with its first character upper-cased.
+// Mirrors rust/kona/crates/protocol/hardforks/build_helpers.rs::capitalize so the
+// qualified intent strings (and therefore source hashes) agree across implementations.
+func capitalizeForkName(f forks.Name) string {
+	s := string(f)
+	if s == "" {
+		return s
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
+}
+
 // readNUTBundle reads and parses a NUT bundle from an io.Reader. The fork name
 // is used to namespace each transaction's intent when deriving source hashes.
 func readNUTBundle(fork forks.Name, r io.Reader) (*nutBundle, error) {
@@ -72,7 +84,10 @@ func (b *nutBundle) toDepositTransactions() ([]hexutil.Bytes, error) {
 			return nil, fmt.Errorf("tx %d: missing intent", i)
 		}
 
-		qualifiedIntent := fmt.Sprintf("%s %d: %s", b.ForkName, i, nutTx.Intent)
+		// The fork name is capitalized to match kona's NUT bundle codegen
+		// (rust/kona/crates/protocol/hardforks/build_helpers.rs::capitalize),
+		// so both implementations derive the same UpgradeDepositSource hashes.
+		qualifiedIntent := fmt.Sprintf("%s %d: %s", capitalizeForkName(b.ForkName), i, nutTx.Intent)
 		source := UpgradeDepositSource{Intent: qualifiedIntent}
 		depTx := &types.DepositTx{
 			SourceHash:          source.SourceHash(),

--- a/rust/kona/tests/justfile
+++ b/rust/kona/tests/justfile
@@ -173,8 +173,13 @@ long-running-test FILTER="" OUTPUT_LOGS_DIR="":
     # Run the test with count=1 to avoid caching the test results.
     cd {{SOURCE}} && go test -count=1 -timeout 0 -v ./node/long-running $FILTER
 
-# Run action tests for the single-chain client program on the native target
-action-tests-single test_name='Test_ProgramAction' *args='': action-tests-build (action-tests-single-run test_name args)
+# Run action tests for the single-chain client program on the native target.
+#
+# By default, runs every Test* in op-e2e/actions/proofs/ except those
+# matching `skip_pattern`. The exclusion encodes "this test is op-program-only
+# and not expected to pass under kona-host" — opt out by naming a test
+# `Test_OPProgramAction_*` rather than opting in by prefix.
+action-tests-single test_name='.*' skip_pattern='^Test_OPProgramAction' *args='': action-tests-build (action-tests-single-run test_name skip_pattern args)
 
 # Build action tests for host program
 action-tests-build:
@@ -184,7 +189,7 @@ action-tests-build:
   just build-native --release --bin kona-host
 
 # Run action tests for the single-chain client program on the native target
-action-tests-single-run test_name='Test_ProgramAction' parallel="0" *args='':
+action-tests-single-run test_name='.*' skip_pattern='^Test_OPProgramAction' parallel="0" *args='':
   #!/bin/bash
   set -euo pipefail
 
@@ -222,13 +227,13 @@ action-tests-single-run test_name='Test_ProgramAction' parallel="0" *args='':
     export NODE_INDEX=${CIRCLE_NODE_INDEX:-0}
     export NODE_TOTAL=${CIRCLE_NODE_TOTAL:-1}
 
-    # List matching test names, filtering out the "ok" summary line from go test -list.
-    # Note: go test -list uses full-match regex, so we need .* suffix to match prefixes.
-    go test -list '{{test_name}}.*' . | grep -E '^{{test_name}}' > /tmp/tests.txt
+    # List matching test names, filtering out the "ok" summary line from go test -list,
+    # and excluding tests matched by skip_pattern (op-program-only tests).
+    go test -list '{{test_name}}' . | grep -E '^Test' | grep -vE '{{skip_pattern}}' > /tmp/tests.txt
 
     TOTAL_TESTS=$(wc -l < /tmp/tests.txt | tr -d ' ')
     if [ "$TOTAL_TESTS" -eq 0 ]; then
-      echo "Error: no tests matched pattern '^{{test_name}}'" >&2
+      echo "Error: no tests matched '{{test_name}}' after excluding '{{skip_pattern}}'" >&2
       exit 1
     fi
     echo "Found $TOTAL_TESTS tests to split across $NODE_TOTAL nodes"
@@ -259,7 +264,7 @@ action-tests-single-run test_name='Test_ProgramAction' parallel="0" *args='':
   {{SOURCE}}/../../../ops/scripts/gotestsum-split.sh --format=testname \
     --junitfile=./tmp/test-results/results.xml \
     --jsonfile=./tmp/testlogs/log.json \
-    -- -count=1 -parallel=$PARALLEL -coverprofile=coverage.out -timeout=60m -run "{{test_name}}"
+    -- -count=1 -parallel=$PARALLEL -coverprofile=coverage.out -timeout=60m -run "{{test_name}}" -skip "{{skip_pattern}}"
 
 # Run action tests for the interop client program on the native target
 action-tests-interop test_name='TestInteropFaultProofs' *args='': action-tests-build (action-tests-interop-run test_name args)


### PR DESCRIPTION
## Summary

The kona action-test selector in `rust/kona/tests/justfile` required a `Test_ProgramAction_` prefix to opt into the kona-host runner. Tests in `op-e2e/actions/proofs/` that were fault-proof-aware but named differently — e.g. `TestActivationBlockNUTBundle`, `TestActivationBlockTxOmission` — were silently excluded, hiding cross-implementation divergences between op-node/op-program and kona's derivation/host.

Flip the default: include every `Test*` in the proofs package, and opt out via `Test_OPProgramAction_*` for op-program-only tests.

## Notes for reviewers

- First push under will pick up two previously-excluded tests, and should fail.
- A follow up commit will include the fix.