### PR TITLE
feat(op-supernode): honour user-supplied p2p listen ports

### DIFF
--- a/op-supernode/README.md
+++ b/op-supernode/README.md
@@ -40,8 +40,7 @@ This allows for *roughly* 1:1 setup and behavior between Node and Supernode, wit
 - Some behaviors are expected to be configured at the `op-supernode` level and are not respected per usual when the application starts:
   - `l1` and `l1.beacon` are used to create the shared L1 client. Any L1 configuration will not be respected by a Virtual Node.
   - Log and Metric settings are passed down to the Virtual node from the top level Log/Metric flags, and individual chain settings may not be respected.
-  - `p2p` is enabled/disabled at the top level and sets all listen ports to `0` to prevent collisions. Per-chain P2P functionality will added
-  via a shared resource in the future.
+  - `p2p` is enabled/disabled at the top level. While enabled, listen ports default to `0` (dynamic) to prevent collisions, but `--vn.all.p2p.listen.tcp` / `--vn.all.p2p.listen.udp` and the per-chain `--vn.<chainID>.p2p.listen.tcp` / `--vn.<chainID>.p2p.listen.udp` flags are honoured when set. The user is responsible for picking distinct ports across chains. Per-chain P2P functionality will be added via a shared resource in the future.
 
 Example launch of Supernode:
 ```

--- a/op-supernode/cmd/main.go
+++ b/op-supernode/cmd/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strconv"
 
 	"github.com/ethereum-optimism/optimism/op-service/ctxinterrupt"
@@ -152,30 +151,4 @@ func warnSupernodeOwnedFlags(vcli *flags.VirtualCLI, chainID uint64, l log.Logge
 				"flag", name, "chain", chainID)
 		}
 	}
-}
-
-func withNoP2P(vcli *flags.VirtualCLI) error {
-	vcli.WithBoolOverride(opnodeflags.DisableP2PName, true)
-	vcli.WithStringOverride(opnodeflags.P2PPrivPathName, "")
-	vcli.WithStringOverride(opnodeflags.PeerstorePathName, "")
-	vcli.WithStringOverride(opnodeflags.DiscoveryPathName, "")
-	vcli.WithUintOverride(opnodeflags.ListenTCPPortName, 0)
-	vcli.WithUintOverride(opnodeflags.ListenUDPPortName, 0)
-	return nil
-}
-
-func withNamespacedP2P(vcli *flags.VirtualCLI, datadir string, namespace string) error {
-	// Configure per-VN P2P using namespaced DataDir and dynamic ports
-	p2pDir := filepath.Join(datadir, namespace, "p2p")
-	// Ensure per-VN p2p directory exists for key and databases
-	if err := os.MkdirAll(p2pDir, 0o700); err != nil {
-		return fmt.Errorf("failed creating p2p dir for chain %s: %w", namespace, err)
-	}
-	vcli.WithStringOverride(opnodeflags.P2PPrivPathName, filepath.Join(p2pDir, "opnode_p2p_priv.txt"))
-	vcli.WithStringOverride(opnodeflags.PeerstorePathName, filepath.Join(p2pDir, "peerstore_db"))
-	vcli.WithStringOverride(opnodeflags.DiscoveryPathName, filepath.Join(p2pDir, "discovery_db"))
-	// Force dynamic TCP/UDP listen ports to avoid collisions
-	vcli.WithUintOverride(opnodeflags.ListenTCPPortName, 0)
-	vcli.WithUintOverride(opnodeflags.ListenUDPPortName, 0)
-	return nil
 }

--- a/op-supernode/cmd/p2p.go
+++ b/op-supernode/cmd/p2p.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	opnodeflags "github.com/ethereum-optimism/optimism/op-node/flags"
+	"github.com/ethereum-optimism/optimism/op-supernode/flags"
+)
+
+func withNoP2P(vcli *flags.VirtualCLI) error {
+	vcli.WithBoolOverride(opnodeflags.DisableP2PName, true)
+	vcli.WithStringOverride(opnodeflags.P2PPrivPathName, "")
+	vcli.WithStringOverride(opnodeflags.PeerstorePathName, "")
+	vcli.WithStringOverride(opnodeflags.DiscoveryPathName, "")
+	vcli.WithUintOverride(opnodeflags.ListenTCPPortName, 0)
+	vcli.WithUintOverride(opnodeflags.ListenUDPPortName, 0)
+	return nil
+}
+
+func withNamespacedP2P(vcli *flags.VirtualCLI, datadir string, namespace string) error {
+	p2pDir := filepath.Join(datadir, namespace, "p2p")
+	if err := os.MkdirAll(p2pDir, 0o700); err != nil {
+		return fmt.Errorf("failed creating p2p dir for chain %s: %w", namespace, err)
+	}
+	vcli.WithStringOverride(opnodeflags.P2PPrivPathName, filepath.Join(p2pDir, "opnode_p2p_priv.txt"))
+	vcli.WithStringOverride(opnodeflags.PeerstorePathName, filepath.Join(p2pDir, "peerstore_db"))
+	vcli.WithStringOverride(opnodeflags.DiscoveryPathName, filepath.Join(p2pDir, "discovery_db"))
+	// Default listen ports to 0 (dynamic) to prevent collisions when the user
+	// has not pinned a port. Honour vn.all.<flag> and vn.<id>.<flag> when set.
+	if !vcli.IsSet(opnodeflags.ListenTCPPortName) {
+		vcli.WithUintOverride(opnodeflags.ListenTCPPortName, 0)
+	}
+	if !vcli.IsSet(opnodeflags.ListenUDPPortName) {
+		vcli.WithUintOverride(opnodeflags.ListenUDPPortName, 0)
+	}
+	return nil
+}

--- a/op-supernode/cmd/p2p_test.go
+++ b/op-supernode/cmd/p2p_test.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	opnodeflags "github.com/ethereum-optimism/optimism/op-node/flags"
+	"github.com/ethereum-optimism/optimism/op-supernode/flags"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
+)
+
+const testChainID uint64 = 11155420
+
+// portFlags returns the supernode-cloned variants of the listen TCP/UDP flags
+// so tests can drive them through cli context parsing the same way the real
+// supernode does at runtime.
+func portFlags() []cli.Flag {
+	return []cli.Flag{
+		&cli.UintFlag{Name: flags.VNFlagGlobalPrefix + opnodeflags.ListenTCPPortName},
+		&cli.UintFlag{Name: flags.VNFlagGlobalPrefix + opnodeflags.ListenUDPPortName},
+		&cli.UintFlag{Name: fmt.Sprintf("%s%d.%s", flags.VNFlagNamePrefix, testChainID, opnodeflags.ListenTCPPortName)},
+		&cli.UintFlag{Name: fmt.Sprintf("%s%d.%s", flags.VNFlagNamePrefix, testChainID, opnodeflags.ListenUDPPortName)},
+	}
+}
+
+func newCtx(t *testing.T, flagSet []cli.Flag, args []string) *cli.Context {
+	t.Helper()
+	app := &cli.App{Flags: flagSet}
+	set := flag.NewFlagSet("test", flag.ContinueOnError)
+	for _, f := range flagSet {
+		require.NoError(t, f.Apply(set))
+	}
+	require.NoError(t, set.Parse(args))
+	return cli.NewContext(app, set, nil)
+}
+
+func newVCLI(t *testing.T, args []string) *flags.VirtualCLI {
+	t.Helper()
+	return flags.NewVirtualCLI(newCtx(t, portFlags(), args), testChainID)
+}
+
+func TestWithNamespacedP2P_DefaultsListenPortsToZero(t *testing.T) {
+	vcli := newVCLI(t, nil)
+	require.NoError(t, withNamespacedP2P(vcli, t.TempDir(), fmt.Sprintf("%d", testChainID)))
+
+	require.Equal(t, uint(0), vcli.Uint(opnodeflags.ListenTCPPortName))
+	require.Equal(t, uint(0), vcli.Uint(opnodeflags.ListenUDPPortName))
+}
+
+func TestWithNamespacedP2P_HonoursGlobalListenPorts(t *testing.T) {
+	// A global vn.all.* port collides at bind time when more than one chain is
+	// running, but the supernode honours it as configured -- test for
+	// completeness so a single-chain deployment can pin a fixed port.
+	vcli := newVCLI(t, []string{
+		"--" + flags.VNFlagGlobalPrefix + opnodeflags.ListenTCPPortName + "=9222",
+		"--" + flags.VNFlagGlobalPrefix + opnodeflags.ListenUDPPortName + "=9223",
+	})
+	require.NoError(t, withNamespacedP2P(vcli, t.TempDir(), fmt.Sprintf("%d", testChainID)))
+
+	require.Equal(t, uint(9222), vcli.Uint(opnodeflags.ListenTCPPortName))
+	require.Equal(t, uint(9223), vcli.Uint(opnodeflags.ListenUDPPortName))
+}
+
+func TestWithNamespacedP2P_HonoursPerChainListenPorts(t *testing.T) {
+	tcpName := fmt.Sprintf("%s%d.%s", flags.VNFlagNamePrefix, testChainID, opnodeflags.ListenTCPPortName)
+	udpName := fmt.Sprintf("%s%d.%s", flags.VNFlagNamePrefix, testChainID, opnodeflags.ListenUDPPortName)
+	vcli := newVCLI(t, []string{
+		"--" + tcpName + "=9000",
+		"--" + udpName + "=9001",
+	})
+	require.NoError(t, withNamespacedP2P(vcli, t.TempDir(), fmt.Sprintf("%d", testChainID)))
+
+	require.Equal(t, uint(9000), vcli.Uint(opnodeflags.ListenTCPPortName))
+	require.Equal(t, uint(9001), vcli.Uint(opnodeflags.ListenUDPPortName))
+}
+
+func TestWithNamespacedP2P_PerChainOverridesGlobal(t *testing.T) {
+	tcpName := fmt.Sprintf("%s%d.%s", flags.VNFlagNamePrefix, testChainID, opnodeflags.ListenTCPPortName)
+	vcli := newVCLI(t, []string{
+		"--" + flags.VNFlagGlobalPrefix + opnodeflags.ListenTCPPortName + "=9222",
+		"--" + tcpName + "=9000",
+	})
+	require.NoError(t, withNamespacedP2P(vcli, t.TempDir(), fmt.Sprintf("%d", testChainID)))
+
+	require.Equal(t, uint(9000), vcli.Uint(opnodeflags.ListenTCPPortName))
+	// UDP fell through to the default-zero override.
+	require.Equal(t, uint(0), vcli.Uint(opnodeflags.ListenUDPPortName))
+}
+
+func TestWithNamespacedP2P_CreatesP2PDir(t *testing.T) {
+	dataDir := t.TempDir()
+	ns := fmt.Sprintf("%d", testChainID)
+	require.NoError(t, withNamespacedP2P(newVCLI(t, nil), dataDir, ns))
+
+	expected := filepath.Join(dataDir, ns, "p2p")
+	info, err := os.Stat(expected)
+	require.NoError(t, err)
+	require.True(t, info.IsDir(), "expected p2p dir at %s", expected)
+}
+
+func TestWithNoP2P_AlwaysForcesListenPortsToZero(t *testing.T) {
+	// Even when the user pinned ports, withNoP2P should zero them out because
+	// P2P is being disabled outright.
+	tcpName := fmt.Sprintf("%s%d.%s", flags.VNFlagNamePrefix, testChainID, opnodeflags.ListenTCPPortName)
+	udpName := fmt.Sprintf("%s%d.%s", flags.VNFlagNamePrefix, testChainID, opnodeflags.ListenUDPPortName)
+	vcli := newVCLI(t, []string{
+		"--" + tcpName + "=9000",
+		"--" + udpName + "=9001",
+	})
+	require.NoError(t, withNoP2P(vcli))
+
+	require.Equal(t, uint(0), vcli.Uint(opnodeflags.ListenTCPPortName))
+	require.Equal(t, uint(0), vcli.Uint(opnodeflags.ListenUDPPortName))
+}


### PR DESCRIPTION
op-supernode previously forced each virtual node's `p2p.listen.tcp` / `p2p.listen.udp` to `0` regardless of user input, so a fixed port could not be pinned. With this change the supernode only injects the `0` default when the user hasn't supplied a value via `vn.all.<flag>` or `vn.<chainID>.<flag>` — the existing dynamic-port behaviour is unchanged when no flags are set, and `--disable-p2p` still zeroes the ports since they're unused. The user is responsible for picking distinct ports when running multiple chains; collisions surface as the underlying op-node bind error.