### PR TITLE
op-interop-filter: record cross unsafe timestamp metric

### DIFF
--- a/op-interop-filter/filter/lockstep_cross_validator.go
+++ b/op-interop-filter/filter/lockstep_cross_validator.go
@@ -291,6 +291,7 @@ func (v *LockstepCrossValidator) advanceValidation() {
 	if !v.crossValidatedOK.Load() {
 		v.crossValidatedTs.Store(v.startTimestamp)
 		v.crossValidatedOK.Store(true)
+		v.metrics.RecordCrossUnsafeValidatedTimestamp(v.startTimestamp)
 		v.log.Info("Cross-validator initialized", "startTimestamp", v.startTimestamp)
 		return
 	}
@@ -315,6 +316,7 @@ func (v *LockstepCrossValidator) advanceValidation() {
 
 		// Advance
 		v.crossValidatedTs.Store(nextTs)
+		v.metrics.RecordCrossUnsafeValidatedTimestamp(nextTs)
 		currentTs = nextTs
 
 		v.log.Debug("Advanced cross-validated timestamp", "timestamp", nextTs)

--- a/op-interop-filter/filter/lockstep_cross_validator_test.go
+++ b/op-interop-filter/filter/lockstep_cross_validator_test.go
@@ -14,6 +14,25 @@ import (
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
+type recordingMetricer struct {
+	crossUnsafeValidated []uint64
+}
+
+func (r *recordingMetricer) RecordInfo(version string)                               {}
+func (r *recordingMetricer) RecordUp()                                               {}
+func (r *recordingMetricer) RecordFailsafeEnabled(enabled bool)                      {}
+func (r *recordingMetricer) RecordChainHead(chainID uint64, blockNum uint64)         {}
+func (r *recordingMetricer) RecordCheckAccessList(success bool)                      {}
+func (r *recordingMetricer) RecordCheckAccessListDuration(duration float64)          {}
+func (r *recordingMetricer) RecordCheckAccessListRejection(reason string)            {}
+func (r *recordingMetricer) RecordBackfillProgress(chainID uint64, progress float64) {}
+func (r *recordingMetricer) RecordReorgDetected(chainID uint64)                      {}
+func (r *recordingMetricer) RecordLogsAdded(chainID uint64, count int64)             {}
+func (r *recordingMetricer) RecordBlocksSealed(chainID uint64, count int64)          {}
+func (r *recordingMetricer) RecordCrossUnsafeValidatedTimestamp(timestamp uint64) {
+	r.crossUnsafeValidated = append(r.crossUnsafeValidated, timestamp)
+}
+
 // Note: Test helpers (newTestCrossValidator, makeAccess, makeExecDescriptor) and
 // constants (testExpiryWindow, testChainA) are defined in backend_test.go
 
@@ -244,6 +263,30 @@ func TestCrossValidator_StartTimestampZeroStillAdvances(t *testing.T) {
 	ts, ok = cv.CrossValidatedTimestamp()
 	require.True(t, ok)
 	require.Equal(t, uint64(1), ts)
+}
+
+func TestCrossValidator_RecordsCrossUnsafeValidatedTimestampMetric(t *testing.T) {
+	mock := newMockChainIngester()
+	mock.SetLatestTimestamp(102)
+
+	chains := map[eth.ChainID]ChainIngester{
+		eth.ChainIDFromUInt64(testChainA): mock,
+	}
+	rec := &recordingMetricer{}
+	cv := NewLockstepCrossValidator(
+		context.Background(),
+		testlog.Logger(t, log.LevelCrit),
+		rec,
+		testExpiryWindow,
+		100,
+		time.Hour,
+		chains,
+	)
+
+	cv.advanceValidation()
+	cv.advanceValidation()
+
+	require.Equal(t, []uint64{100, 101, 102}, rec.crossUnsafeValidated)
 }
 
 // =============================================================================


### PR DESCRIPTION
Records the cross-unsafe validated timestamp gauge whenever the lockstep cross-validator initializes or advances its internal timestamp.

Without this, `op_interop_filter_*_cross_unsafe_validated_timestamp` remains at the Prometheus default of 0 even while the validator is advancing internally.

Tests:
- `go test ./op-interop-filter/filter ./op-interop-filter/metrics`