### PR TITLE
fix(op-acceptance-tests): use preset's ELSync CrossSafe budget for safedb tests

### DIFF
--- a/op-acceptance-tests/tests/safeheaddb_elsync/safeheaddb_test.go
+++ b/op-acceptance-tests/tests/safeheaddb_elsync/safeheaddb_test.go
@@ -12,22 +12,15 @@ import (
 )
 
 func newSingleChainMultiNodeELSync(t devtest.T) *presets.SingleChainMultiNode {
-	// Use WithoutCheck because the default preset sync check uses 30 attempts
-	// (60s) for CrossSafe matching, which is insufficient for EL Sync mode.
-	// EL Sync must complete the initial sync phase before derivation can start,
-	// so CrossSafe takes longer to advance than in CL Sync mode.
-	sys := presets.NewSingleChainMultiNodeWithoutCheck(t,
+	// The default preset sync check auto-detects ELSync mode on node B and
+	// uses a 4x CrossSafe budget (see singlechain_from_runtime.go), which is
+	// what this test needs.
+	return presets.NewSingleChainMultiNode(t,
 		presets.WithGlobalL2CLOption(sysgo.L2CLOptionFn(func(p devtest.T, _ sysgo.ComponentTarget, cfg *sysgo.L2CLConfig) {
 			cfg.VerifierSyncMode = sync.ELSync
 			cfg.SafeDBPath = p.TempDir()
 		})),
 	)
-	// Run the initial sync check with 60 attempts (120s) to accommodate EL Sync.
-	dsl.CheckAll(t,
-		sys.L2CLB.MatchedFn(sys.L2CL, types.CrossSafe, 60),
-		sys.L2CLB.MatchedFn(sys.L2CL, types.LocalUnsafe, 60),
-	)
-	return sys
 }
 
 func TestTruncateDatabaseOnELResync(gt *testing.T) {


### PR DESCRIPTION
## Summary

- `newSingleChainMultiNodeELSync` was bypassing the preset's default initial sync check via `NewSingleChainMultiNodeWithoutCheck` and running a hand-rolled 60-attempt (120s) `CrossSafe` match.
- That bypass was added when the preset default was 30 attempts (60s) — too tight for ELSync. PR #20343 (4a15c8dff4) already raised the preset's default to **120 attempts (240s)** when the verifier is in ELSync mode (see `op-devstack/presets/singlechain_from_runtime.go:13-29,68-80`). The hand-rolled budget now caps the test *below* the preset default, undoing the fix from #20343.
- Reproduces the failure mode from #19897: B's `CrossSafe` never advances past genesis while the sequencer keeps producing blocks, and the 120s window expires before derivation catches up under CI load.

Drop `WithoutCheck` and the manual `dsl.CheckAll` — the preset auto-detects `OpNode.SyncMode() == ELSync` and applies the 4x budget. Same helper is shared with `TestNotTruncateDatabaseOnRestartWithExistingDatabase`, so both benefit.

Closes #19897.

## Test plan

- [ ] CI (acceptance + memory-all-opn-op-geth) passes for several runs without flake on this test.
- [ ] Local `just acceptance-test op-acceptance-tests/tests/safeheaddb_elsync` runs green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)