### PR TITLE
ci: explicitly disable circleci_ip_ranges on 4 jobs that don't need it (#2366)

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -996,7 +996,7 @@ jobs:
           mentions: "@security-oncall"
 
   contracts-bedrock-tests:
-    circleci_ip_ranges: true
+    circleci_ip_ranges: false
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: 2xlarge
@@ -1085,7 +1085,7 @@ jobs:
           mentions: "@security-oncall"
 
   contracts-bedrock-heavy-fuzz-nightly:
-    circleci_ip_ranges: true
+    circleci_ip_ranges: false
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: 2xlarge
@@ -1143,7 +1143,7 @@ jobs:
   # AI Contracts Test Maintenance System
   # Runbook: https://github.com/ethereum-optimism/optimism/blob/develop/ops/ai-eng/contracts-test-maintenance/docs/runbook.md
   ai-contracts-test:
-    circleci_ip_ranges: true
+    circleci_ip_ranges: false
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: medium
@@ -1883,7 +1883,7 @@ jobs:
         default: 30m
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
-    circleci_ip_ranges: true
+    circleci_ip_ranges: false
     resource_class: 2xlarge+
     steps:
       - utils/checkout-with-mise:


### PR DESCRIPTION
## What this changes

Sets `circleci_ip_ranges: false` on four jobs in `.circleci/continue/main.yml`:

- `contracts-bedrock-tests` (line ~999)
- `contracts-bedrock-heavy-fuzz-nightly` (line ~1088)
- `ai-contracts-test` (line ~1146)
- `op-acceptance-tests` (line ~1886)

(Each was previously `true`. Setting to explicit `false` rather than removing the line keeps behavior unambiguous regardless of what CircleCI's default is for omitted keys.)

## Why

`circleci_ip_ranges: true` routes a job's outbound traffic through CircleCI's 21 published static IPs ([documented here](https://circleci.com/docs/ip-ranges/)). It costs **450 credits per GB** of network data on top of normal compute. It's only valuable when downstream infrastructure allowlists those IPs.

### Where the IPs are actually allowlisted in our infra

Searching the org for one of CircleCI's IPs (`3.228.39.90`) returns exactly one hit: the `ci-ip-whitelist` Traefik middleware at `ethereum-optimism/k8s/kustomize/gke-bootstrap/components/traefik/bases/middleware.yaml`. It allowlists all 21 CircleCI IPs (alongside Hexagate, self-hosted runner, and GitHub Actions ranges).

15 endpoints in the k8s repo use that middleware:
- `proxyd-l1-ci` (mainnet + sepolia)
- `proxyd-l1-ci-archive` (mainnet + sepolia)
- `proxyd-l2-ci` (sepolia)
- `beacon-api-proxy-ci` (mainnet + sepolia)
- `github-event-manager`
- `internal-ingress` for `proxyd-op-rpc`, `proxyd-soneium-rpc`, `proxyd-unichain-rpc`, `proxyd-ink-rpc`, `proxyd-op-fb-rpc`

### Why these four jobs don't need the flag

Each of the four was verified end-to-end against its step definition:

| Job | Network calls in step definition |
|---|---|
| `contracts-bedrock-tests` | None. `forge test` against pre-built artifacts. |
| `contracts-bedrock-heavy-fuzz-nightly` | None. `just test` on pre-built artifacts. |
| `ai-contracts-test` | Devin and Slack APIs only — public, token-authed endpoints, not on the allowlist. |
| `op-acceptance-tests` | Devstack-internal — runs op-node/op-geth/op-reth/kona-node locally from workspace binaries. |

None of them hit any of the 15 allowlisted endpoints. The flag has been paying for static egress these jobs don't use.

### What this PR explicitly does NOT change

The four jobs that genuinely need the flag are left alone:

| Job | Allowlisted endpoint hit |
|---|---|
| `contracts-bedrock-coverage` | `ci-mainnet-l1-archive.optimism.io` (`proxyd-l1-ci`) |
| `contracts-bedrock-tests-upgrade` | `ci-mainnet-l1-archive.optimism.io` (`proxyd-l1-ci`) |
| `contracts-bedrock-tests-l2-fork` | `op-mainnet-rpc.optimism.io` (`proxyd-op-rpc`) for the `op-mainnet` chain (the other 11 chains in `.circleci/l2-rpcs.json` are public RPCs) |
| `go-tests` | `ci-mainnet-l1-archive.optimism.io` and `ci-sepolia-l1-archive.optimism.io` (set as `MAINNET_RPC_URL` / `SEPOLIA_RPC_URL` in the justfile recipes invoked from CI) |

## Estimated savings

~50M IP-range credits per 30 days (~38% of current IP-range spend, ~25% of total org spend).

Breakdown by job (last 30d):
- `contracts-bedrock-tests` (12 matrix variants, both PR-time `liteci` and post-merge `ciheavy`): ~31.4M
- `contracts-bedrock-heavy-fuzz-nightly`: rolled into above figure
- `ai-contracts-test`: ~3K
- `op-acceptance-tests`: ~14K

For comparison, all of W1's resource-class downsizes combined (PRs #20421, #20422, #20423) save roughly 150K credits per refresh of those jobs.

## Validation plan

- One PR with a clean per-job revert path (each change is a single line in a distinct block).
- Watch the next PR run + first nightly heavy-fuzz dispatch + first develop run after merge for any unexpected 403/timeout pointing at internal endpoints.
- Failure mode if a hidden allowlisted call surfaces somewhere is observable: a network error, not silent test corruption.
- Per-job revert is one line.

## Related

Refs: ethereum-optimism/core-team#2366

cc @alfonso-op