### PR TITLE
feat(rust): add fast build without examples

### DIFF
--- a/docs/ai/rust-dev.md
+++ b/docs/ai/rust-dev.md
@@ -22,6 +22,9 @@ cd rust
 # Build the workspace
 just build
 
+# Build the workspace excluding example crates with the fast-build profile
+just build-no-examples
+
 # Build in release mode
 just build-release
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -178,6 +178,15 @@ rand_chacha.opt-level = 3
 rand_xorshift.opt-level = 3
 unarray.opt-level = 3
 
+[profile.fast-build]
+inherits = "dev"
+opt-level = 0
+debug = "none"
+split-debuginfo = "off"
+debug-assertions = false
+incremental = true
+codegen-units = 256
+
 [profile.bench]
 debug = true
 

--- a/rust/justfile
+++ b/rust/justfile
@@ -24,6 +24,28 @@ install-nightly:
 build *args='':
   cargo build --workspace {{args}}
 
+# Build the workspace, excluding example crates, with a fast compile-only profile by default
+build-no-examples *args='':
+  #!/usr/bin/env bash
+  set -euo pipefail
+
+  profile_args="--profile fast-build"
+  case " {{args}} " in
+    *" --release "*|*" --profile "*|*" --profile="*)
+      profile_args=""
+      ;;
+  esac
+
+  exclude_args=""
+  while IFS= read -r package; do
+    exclude_args="$exclude_args --exclude $package"
+  done < <(
+    cargo metadata --no-deps --format-version 1 \
+      | jq -r '.packages[] | select(.manifest_path | contains("/examples/")) | .name'
+  )
+
+  cargo build --workspace $profile_args $exclude_args {{args}}
+
 # Build the workspace in release mode
 build-release *args='':
   cargo build --workspace --release {{args}}


### PR DESCRIPTION
Adds a new Rust just recipe, `just build-no-examples`, for quickly building the Rust workspace while excluding example crates.

---

```
    Finished `dev` profile [optimized + debuginfo] target(s) in 4m 45s
just b  1231.64s user 122.24s system 473% cpu 4:46.14 total
```

vs

```
    Finished `fast-build` profile [unoptimized] target(s) in 2m 48s
just build-no-examples  236.40s user 94.76s system 196% cpu 2:48.40 total

```