### PR TITLE
op-proposer/op-challenger: add supernode CLI flags

### DIFF
--- a/op-challenger/cmd/main_test.go
+++ b/op-challenger/cmd/main_test.go
@@ -133,18 +133,21 @@ func TestSuperNodeRpc(t *testing.T) {
 		url := "http://localhost/super"
 		cfg := configForArgs(t, addRequiredArgsExcept(gameTypes.SuperCannonGameType, "--supernode-rpc", "--supernode-rpc", url))
 		require.Equal(t, url, cfg.SuperRPC)
+		require.True(t, cfg.UseSuperNode)
 	})
 
 	t.Run("Valid-SuperPermissioned", func(t *testing.T) {
 		url := "http://localhost/super"
 		cfg := configForArgs(t, addRequiredArgsExcept(gameTypes.SuperPermissionedGameType, "--supernode-rpc", "--supernode-rpc", url))
 		require.Equal(t, url, cfg.SuperRPC)
+		require.True(t, cfg.UseSuperNode)
 	})
 
 	t.Run("Valid-SuperCannonKona", func(t *testing.T) {
 		url := "http://localhost/super"
 		cfg := configForArgs(t, addRequiredArgsExcept(gameTypes.SuperCannonKonaGameType, "--supernode-rpc", "--supernode-rpc", url))
 		require.Equal(t, url, cfg.SuperRPC)
+		require.True(t, cfg.UseSuperNode)
 	})
 }
 

--- a/op-challenger/config/config_test.go
+++ b/op-challenger/config/config_test.go
@@ -103,6 +103,12 @@ func applyValidConfigForSuperCannonKona(t *testing.T, cfg *Config) {
 	applyValidConfigForCannonKona(t, cfg)
 }
 
+func TestNewInteropConfigUsesSupervisorByDefault(t *testing.T) {
+	cfg := NewInteropConfig(validGameFactoryAddress, validL1EthRpc, validL1BeaconUrl, validSuperRpc, []string{validL2Rpc}, validDatadir)
+	require.Equal(t, validSuperRpc, cfg.SuperRPC)
+	require.False(t, cfg.UseSuperNode)
+}
+
 func applyValidConfigForZKDisputeGame(cfg *Config) {
 	cfg.RollupRpc = validRollupRpc
 }

--- a/op-challenger/flags/flags.go
+++ b/op-challenger/flags/flags.go
@@ -624,6 +624,7 @@ func NewConfigFromCLI(ctx *cli.Context, logger log.Logger) (*config.Config, erro
 		AdditionalBondClaimants: claimants,
 		RollupRpc:               ctx.String(RollupRpcFlag.Name),
 		SuperRPC:                ctx.String(SuperNodeRpcFlag.Name),
+		UseSuperNode:            ctx.String(SuperNodeRpcFlag.Name) != "",
 		Cannon: vm.Config{
 			VmType:            gameTypes.CannonGameType,
 			L1:                l1EthRpc,

--- a/op-proposer/flags/flags.go
+++ b/op-proposer/flags/flags.go
@@ -37,6 +37,11 @@ var (
 		Usage:   "HTTP provider URLs for the supervisor nodes. Multiple URLs can be provided to automatically fail over.",
 		EnvVars: prefixEnvVars("SUPERVISOR_RPCS"),
 	}
+	SuperNodeRpcsFlag = &cli.StringSliceFlag{
+		Name:    "supernode-rpcs",
+		Usage:   "HTTP provider URLs for the supernode instances. Multiple URLs can be provided to automatically fail over.",
+		EnvVars: prefixEnvVars("SUPERNODE_RPCS"),
+	}
 
 	// Optional flags
 	PollIntervalFlag = &cli.DurationFlag{
@@ -90,6 +95,7 @@ var requiredFlags = []cli.Flag{
 var optionalFlags = []cli.Flag{
 	RollupRpcFlag,
 	SupervisorRpcsFlag,
+	SuperNodeRpcsFlag,
 	PollIntervalFlag,
 	AllowNonFinalizedFlag,
 	L2OutputHDPathFlag,

--- a/op-proposer/proposer/config.go
+++ b/op-proposer/proposer/config.go
@@ -143,6 +143,7 @@ func NewConfig(ctx *cli.Context) *CLIConfig {
 		L1EthRpc:                     ctx.String(flags.L1EthRpcFlag.Name),
 		RollupRpc:                    ctx.String(flags.RollupRpcFlag.Name),
 		SupervisorRpcs:               ctx.StringSlice(flags.SupervisorRpcsFlag.Name),
+		SuperNodeRpcs:                ctx.StringSlice(flags.SuperNodeRpcsFlag.Name),
 		PollInterval:                 ctx.Duration(flags.PollIntervalFlag.Name),
 		TxMgrConfig:                  txmgr.ReadCLIConfig(ctx),
 		AllowNonFinalized:            ctx.Bool(flags.AllowNonFinalizedFlag.Name),

--- a/op-proposer/proposer/config_test.go
+++ b/op-proposer/proposer/config_test.go
@@ -3,6 +3,7 @@ package proposer
 import (
 	"testing"
 
+	proposerFlags "github.com/ethereum-optimism/optimism/op-proposer/flags"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
 	"github.com/ethereum-optimism/optimism/op-service/oppprof"
@@ -10,11 +11,32 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
 )
 
 func TestValidConfigIsValid(t *testing.T) {
 	cfg := validConfig()
 	require.NoError(t, cfg.Check())
+}
+
+func TestNewConfigReadsSuperNodeRpcs(t *testing.T) {
+	var cfg *CLIConfig
+	app := cli.NewApp()
+	app.Flags = proposerFlags.Flags
+	app.Action = func(ctx *cli.Context) error {
+		cfg = NewConfig(ctx)
+		return nil
+	}
+	err := app.Run([]string{
+		"op-proposer",
+		"--supernode-rpcs", "http://localhost:8882/supernode-a",
+		"--supernode-rpcs", "http://localhost:8883/supernode-b",
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"http://localhost:8882/supernode-a",
+		"http://localhost:8883/supernode-b",
+	}, cfg.SuperNodeRpcs)
 }
 
 func TestRollupRpc(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add the multi-value `op-proposer --supernode-rpcs` flag and bind it to the existing supernode proposer config/runtime path.
- Wire `op-challenger --supernode-rpc` CLI config to select the existing `SuperNodeClient` path.
- Preserve supervisor-backed config/runtime behavior for existing e2e/devstack usage.

Closes #20457

I was initially going to remove the older supervisor flags from op-proposer and op-challenger, but I didn't want to remove the existing op-e2e tests we have that make use of them.

## Test plan
- `mise exec -- go test ./op-proposer/flags ./op-proposer/proposer ./op-challenger/cmd ./op-challenger/config`
- `mise exec -- go test ./op-challenger/flags`
- `mise exec -- just lint-go`
- `mise exec -- go run ./op-proposer/cmd --help`
- `git diff --check`