### PR TITLE
ci: clean up contracts CI and RPC secrets

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -996,7 +996,6 @@ jobs:
           mentions: "@security-oncall"
 
   contracts-bedrock-tests:
-    circleci_ip_ranges: false
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: 2xlarge
@@ -1085,7 +1084,6 @@ jobs:
           mentions: "@security-oncall"
 
   contracts-bedrock-heavy-fuzz-nightly:
-    circleci_ip_ranges: false
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: 2xlarge
@@ -1143,7 +1141,6 @@ jobs:
   # AI Contracts Test Maintenance System
   # Runbook: https://github.com/ethereum-optimism/optimism/blob/develop/ops/ai-eng/contracts-test-maintenance/docs/runbook.md
   ai-contracts-test:
-    circleci_ip_ranges: false
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: medium
@@ -1175,7 +1172,6 @@ jobs:
           mentions: "@security-oncall"
 
   contracts-bedrock-coverage:
-    circleci_ip_ranges: true
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: 2xlarge
@@ -1188,6 +1184,10 @@ jobs:
         description: Profile to use for testing
         type: string
         default: ci
+      l1_archive_rpc_url_env_var:
+        description: Mainnet L1 archive RPC URL environment variable
+        type: env_var_name
+        default: OP_CI_MAINNET_L1_ARCHIVE_RPC_URL
       features:
         description: Comma-separated list of features to enable (e.g., "OPTIMISM_PORTAL_INTEROP", "CUSTOM_GAS_TOKEN")
         type: string
@@ -1211,12 +1211,14 @@ jobs:
       - apt-install:
           packages: "lcov"
       - run:
+          name: Resolve L1 archive RPC URL
+          command: |
+            printf 'export ETH_RPC_URL="${%s:?%s must be set}"\n' "<<parameters.l1_archive_rpc_url_env_var>>" "<<parameters.l1_archive_rpc_url_env_var>>" >> "$BASH_ENV"
+      - run:
           name: Write pinned block number for cache key
           command: |
             just print-pinned-block-number > ./pinnedBlockNumber.txt
             cat pinnedBlockNumber.txt
-          environment:
-            ETH_RPC_URL: https://ci-mainnet-l1-archive.optimism.io
           working_directory: packages/contracts-bedrock
       - restore_cache:
           name: Restore forked state
@@ -1236,7 +1238,6 @@ jobs:
           command: just coverage-lcov-all
           environment:
             FOUNDRY_PROFILE: <<parameters.test_profile>>
-            ETH_RPC_URL: https://ci-mainnet-l1-archive.optimism.io
           working_directory: packages/contracts-bedrock
           no_output_timeout: <<parameters.test_timeout>>
       - run:
@@ -1244,7 +1245,6 @@ jobs:
           command: just test-rerun | tee failed-test-traces.log
           environment:
             FOUNDRY_PROFILE: <<parameters.test_profile>>
-            ETH_RPC_URL: https://ci-mainnet-l1-archive.optimism.io
           working_directory: packages/contracts-bedrock
           when: on_fail
       - codecov/upload:
@@ -1264,7 +1264,6 @@ jobs:
           mentions: "@security-oncall"
 
   contracts-bedrock-tests-upgrade:
-    circleci_ip_ranges: true
     parameters:
       fork_op_chain:
         description: Fork OP Chain
@@ -1274,9 +1273,10 @@ jobs:
         description: Fork Base Chain
         type: string
         default: "mainnet"
-      fork_base_rpc:
-        description: Fork Base RPC
-        type: string
+      fork_base_archive_rpc_env_var:
+        description: Fork base archive RPC URL environment variable
+        type: env_var_name
+        default: OP_CI_MAINNET_L1_ARCHIVE_RPC_URL
       test_profile:
         description: Profile to use for testing
         type: string
@@ -1304,13 +1304,16 @@ jobs:
           command: forge --version
           working_directory: packages/contracts-bedrock
       - run:
+          name: Resolve fork base archive RPC URL
+          command: |
+            printf 'export ETH_RPC_URL="${%s:?%s must be set}"\n' "<<parameters.fork_base_archive_rpc_env_var>>" "<<parameters.fork_base_archive_rpc_env_var>>" >> "$BASH_ENV"
+      - run:
           name: Write pinned block number for cache key
           command: |
             just print-pinned-block-number > ./pinnedBlockNumber.txt
             cat pinnedBlockNumber.txt
           environment:
             FORK_BASE_CHAIN: <<parameters.fork_base_chain>>
-            ETH_RPC_URL: <<parameters.fork_base_rpc>>
           working_directory: packages/contracts-bedrock
       - restore_cache:
           name: Restore forked state
@@ -1327,20 +1330,17 @@ jobs:
             FOUNDRY_FUZZ_SEED: 42424242
             FOUNDRY_FUZZ_RUNS: 1
             FOUNDRY_PROFILE: <<parameters.test_profile>>
-            ETH_RPC_URL: <<parameters.fork_base_rpc>>
             FORK_OP_CHAIN: <<parameters.fork_op_chain>>
             FORK_BASE_CHAIN: <<parameters.fork_base_chain>>
           working_directory: packages/contracts-bedrock
           no_output_timeout: 15m
       - run:
           name: Print failed test traces
-          command: |
-            just test-upgrade-rerun | tee failed-test-traces.log
+          command: just test-upgrade-rerun | tee failed-test-traces.log
           environment:
             FOUNDRY_FUZZ_SEED: 42424242
             FOUNDRY_FUZZ_RUNS: 1
             FOUNDRY_PROFILE: <<parameters.test_profile>>
-            ETH_RPC_URL: <<parameters.fork_base_rpc>>
             FORK_OP_CHAIN: <<parameters.fork_op_chain>>
             FORK_BASE_CHAIN: <<parameters.fork_base_chain>>
           working_directory: packages/contracts-bedrock
@@ -1371,7 +1371,6 @@ jobs:
       - notify-failures-on-develop:
           mentions: "@security-oncall"
   contracts-bedrock-tests-l2-fork:
-    circleci_ip_ranges: true
     parameters:
       fork_op_chain:
         description: L2 chain to fork for testing
@@ -1381,6 +1380,14 @@ jobs:
         description: RPC URL for L2 fork. If empty, derived from fork_op_chain.
         type: string
         default: ""
+      op_mainnet_l2_rpc_url_env_var:
+        description: OP Mainnet L2 RPC URL environment variable
+        type: env_var_name
+        default: OP_CI_MAINNET_L2_RPC_URL
+      op_sepolia_l2_rpc_url_env_var:
+        description: OP Sepolia L2 RPC URL environment variable
+        type: env_var_name
+        default: OP_CI_SEPOLIA_L2_RPC_URL
       l2_fork_block_number:
         description: Block number to fork from
         type: string
@@ -1415,11 +1422,26 @@ jobs:
           name: Resolve RPC URL
           command: |
             RPC="<<parameters.l2_fork_rpc>>"
+            RPC_ENV_VAR=""
             if [ -z "$RPC" ]; then
+              case "<<parameters.fork_op_chain>>" in
+                op-mainnet)
+                  RPC_ENV_VAR="<<parameters.op_mainnet_l2_rpc_url_env_var>>"
+                  ;;
+                op-sepolia)
+                  RPC_ENV_VAR="<<parameters.op_sepolia_l2_rpc_url_env_var>>"
+                  ;;
+              esac
+            fi
+            if [ -n "$RPC_ENV_VAR" ]; then
+              printf 'export L2_FORK_RPC_URL="${%s:?%s must be set}"\n' "$RPC_ENV_VAR" "$RPC_ENV_VAR" >> "$BASH_ENV"
+            elif [ -z "$RPC" ]; then
               RPC=$(jq -r '.["<<parameters.fork_op_chain>>"] // empty' .circleci/l2-rpcs.json)
               [ -z "$RPC" ] && echo "Unknown chain '<<parameters.fork_op_chain>>' — add it to .circleci/l2-rpcs.json" && exit 1
+              printf 'export L2_FORK_RPC_URL=%q\n' "$RPC" >> "$BASH_ENV"
+            else
+              printf 'export L2_FORK_RPC_URL=%q\n' "$RPC" >> "$BASH_ENV"
             fi
-            echo "export L2_FORK_RPC_URL=$RPC" >> $BASH_ENV
       - run:
           name: Get latest block number if not specified
           command: |
@@ -1751,7 +1773,6 @@ jobs:
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
     resource_class: 2xlarge
-    circleci_ip_ranges: true
     parallelism: <<parameters.parallelism>>
     steps:
       - utils/checkout-with-mise:
@@ -1883,7 +1904,6 @@ jobs:
         default: 30m
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
-    circleci_ip_ranges: false
     resource_class: 2xlarge+
     steps:
       - utils/checkout-with-mise:
@@ -2564,6 +2584,7 @@ workflows:
             - prep-superchain
           context:
             - circleci-repo-readonly-authenticated-github-token
+            - circleci-repo-rpc-secrets
           filters:
             branches:
               ignore: develop # Run on all branches EXCEPT develop (PR branches only)
@@ -2584,6 +2605,7 @@ workflows:
             - prep-superchain
           context:
             - circleci-repo-readonly-authenticated-github-token
+            - circleci-repo-rpc-secrets
             - slack
       - analyze-op-program-client:
           context:
@@ -2900,6 +2922,7 @@ workflows:
           context:
             - slack
             - circleci-repo-readonly-authenticated-github-token
+            - circleci-repo-rpc-secrets
           requires:
             - contracts-bedrock-build
             - cannon-prestate
@@ -3020,11 +3043,11 @@ workflows:
       - contracts-bedrock-tests-l2-fork:
           name: contracts-bedrock-tests-l2-fork-dispatch op-mainnet
           fork_op_chain: op-mainnet
-          l2_fork_rpc: https://op-mainnet-rpc.optimism.io/
           l2_fork_block_number: latest
           test_profile: ci
           context:
             - circleci-repo-readonly-authenticated-github-token
+            - circleci-repo-rpc-secrets
             - slack
 
   scheduled-weekly-tests:
@@ -3052,6 +3075,7 @@ workflows:
           test_profile: ci
           context:
             - circleci-repo-readonly-authenticated-github-token
+            - circleci-repo-rpc-secrets
             - slack
 
   contracts-feature-tests:
@@ -3087,12 +3111,9 @@ workflows:
                 - main
                 - CUSTOM_GAS_TOKEN
                 - OPTIMISM_PORTAL_INTEROP
-                - OPCM_V2
-                - OPCM_V2,CUSTOM_GAS_TOKEN
-                - OPCM_V2,OPTIMISM_PORTAL_INTEROP
-                - OPCM_V2,ZK_DISPUTE_GAME
-                - OPCM_V2,CANNON_KONA
-                - OPCM_V2,SUPER_ROOT_GAMES_MIGRATION
+                - ZK_DISPUTE_GAME
+                - CANNON_KONA
+                - SUPER_ROOT_GAMES_MIGRATION
                 - L2CM
                 - L2CM,CUSTOM_GAS_TOKEN
                 - L2CM,OPTIMISM_PORTAL_INTEROP
@@ -3140,13 +3161,13 @@ workflows:
               features: *features_matrix
           context:
             - circleci-repo-readonly-authenticated-github-token
+            - circleci-repo-rpc-secrets
             - slack
       # On PRs, run upgrade tests with lite profile for better build times.
       - contracts-bedrock-tests-upgrade:
           name: contracts-bedrock-tests-upgrade op-mainnet <<matrix.features>>
           fork_op_chain: op
           fork_base_chain: mainnet
-          fork_base_rpc: https://ci-mainnet-l1-archive.optimism.io
           test_profile: liteci
           features: <<matrix.features>>
           matrix:
@@ -3154,6 +3175,7 @@ workflows:
               features: *features_matrix
           context:
             - circleci-repo-readonly-authenticated-github-token
+            - circleci-repo-rpc-secrets
             - slack
           filters:
             branches:
@@ -3163,7 +3185,6 @@ workflows:
           name: contracts-bedrock-tests-upgrade-develop op-mainnet <<matrix.features>>
           fork_op_chain: op
           fork_base_chain: mainnet
-          fork_base_rpc: https://ci-mainnet-l1-archive.optimism.io
           test_profile: ci
           features: <<matrix.features>>
           matrix:
@@ -3171,6 +3192,7 @@ workflows:
               features: *features_matrix
           context:
             - circleci-repo-readonly-authenticated-github-token
+            - circleci-repo-rpc-secrets
             - slack
           filters:
             branches:
@@ -3180,13 +3202,13 @@ workflows:
           name: contracts-bedrock-tests-upgrade <<matrix.fork_op_chain>>-mainnet
           fork_op_chain: <<matrix.fork_op_chain>>
           fork_base_chain: mainnet
-          fork_base_rpc: https://ci-mainnet-l1-archive.optimism.io
           test_profile: liteci
           matrix:
             parameters:
               fork_op_chain: ["op", "ink", "unichain"]
           context:
             - circleci-repo-readonly-authenticated-github-token
+            - circleci-repo-rpc-secrets
             - slack
           filters:
             branches:
@@ -3196,13 +3218,13 @@ workflows:
           name: contracts-bedrock-tests-upgrade-develop <<matrix.fork_op_chain>>-mainnet
           fork_op_chain: <<matrix.fork_op_chain>>
           fork_base_chain: mainnet
-          fork_base_rpc: https://ci-mainnet-l1-archive.optimism.io
           test_profile: ci
           matrix:
             parameters:
               fork_op_chain: ["op", "ink", "unichain"]
           context:
             - circleci-repo-readonly-authenticated-github-token
+            - circleci-repo-rpc-secrets
             - slack
           filters:
             branches:
@@ -3211,11 +3233,11 @@ workflows:
       - contracts-bedrock-tests-l2-fork:
           name: contracts-bedrock-tests-l2-fork op-mainnet
           fork_op_chain: op-mainnet
-          l2_fork_rpc: https://op-mainnet-rpc.optimism.io/
           l2_fork_block_number: latest
           test_profile: ci
           context:
             - circleci-repo-readonly-authenticated-github-token
+            - circleci-repo-rpc-secrets
             - slack
       - contracts-bedrock-checks-fast:
           name: contracts-bedrock-checks-fast-feature-tests

--- a/.circleci/l2-rpcs.json
+++ b/.circleci/l2-rpcs.json
@@ -1,5 +1,5 @@
 {
-  "op-mainnet": "https://mainnet.optimism.io",
+  "op-mainnet": "",
   "zora": "https://rpc.zora.energy",
   "ink": "https://rpc-gel.inkonchain.com",
   "mode": "https://mainnet.mode.network",

--- a/justfile
+++ b/justfile
@@ -273,8 +273,7 @@ _go-tests-ci-internal go_test_flags="":
   export ENABLE_ANVIL=true
   export PARALLEL=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)
   export OP_TESTLOG_FILE_LOGGER_OUTDIR=$(realpath ./tmp/testlogs)
-  export SEPOLIA_RPC_URL="https://ci-sepolia-l1-archive.optimism.io"
-  export MAINNET_RPC_URL="https://ci-mainnet-l1-archive.optimism.io"
+  source ./ops/scripts/source-ci-archive-rpcs.sh
   export NAT_INTEROP_LOADTEST_TARGET=10
   export NAT_INTEROP_LOADTEST_TIMEOUT=30s
   ALL_PACKAGES="{{ALL_TEST_PACKAGES}}"
@@ -330,8 +329,7 @@ go-tests-fraud-proofs-ci:
   export ENABLE_ANVIL=true
   export PARALLEL=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)
   export OP_TESTLOG_FILE_LOGGER_OUTDIR=$(realpath ./tmp/testlogs)
-  export SEPOLIA_RPC_URL="https://ci-sepolia-l1-archive.optimism.io"
-  export MAINNET_RPC_URL="https://ci-mainnet-l1-archive.optimism.io"
+  source ./ops/scripts/source-ci-archive-rpcs.sh
   export NAT_INTEROP_LOADTEST_TARGET=10
   export NAT_INTEROP_LOADTEST_TIMEOUT=30s
   ./ops/scripts/gotestsum-split.sh --format=testname \

--- a/ops/scripts/source-ci-archive-rpcs.sh
+++ b/ops/scripts/source-ci-archive-rpcs.sh
@@ -1,0 +1,4 @@
+# shellcheck shell=bash
+# Source from CI recipes that need historical L1 state.
+export SEPOLIA_RPC_URL="${SEPOLIA_RPC_URL:-${OP_CI_SEPOLIA_L1_ARCHIVE_RPC_URL:?OP_CI_SEPOLIA_L1_ARCHIVE_RPC_URL must be set}}"
+export MAINNET_RPC_URL="${MAINNET_RPC_URL:-${OP_CI_MAINNET_L1_ARCHIVE_RPC_URL:?OP_CI_MAINNET_L1_ARCHIVE_RPC_URL must be set}}"

--- a/packages/contracts-bedrock/scripts/checks/check-semver-diff.sh
+++ b/packages/contracts-bedrock/scripts/checks/check-semver-diff.sh
@@ -19,6 +19,65 @@ SEMVER_LOCK="snapshots/semver-lock.json"
 EXCLUDED_CONTRACTS=(
 )
 
+github_token() {
+  if [ -n "${GH_TOKEN:-}" ]; then
+    printf '%s' "$GH_TOKEN"
+  elif [ -n "${GITHUB_TOKEN:-}" ]; then
+    printf '%s' "$GITHUB_TOKEN"
+  elif [ -n "${GHTOKEN:-}" ]; then
+    printf '%s' "$GHTOKEN"
+  fi
+}
+
+github_repo() {
+  local owner="${CIRCLE_PROJECT_USERNAME:-}"
+  local repo="${CIRCLE_PROJECT_REPONAME:-}"
+  local origin_url
+
+  if [ -z "$owner" ] || [ -z "$repo" ]; then
+    origin_url="$(git config --get remote.origin.url || true)"
+    origin_url="${origin_url%.git}"
+    origin_url="${origin_url#git@github.com:}"
+    origin_url="${origin_url#https://github.com/}"
+    owner="${origin_url%%/*}"
+    repo="${origin_url#*/}"
+  fi
+
+  if [ -n "$owner" ] && [ -n "$repo" ] && [ "$owner" != "$repo" ]; then
+    printf '%s/%s' "$owner" "$repo"
+  fi
+}
+
+fetch_upstream_file_from_github() {
+  local path="$1"
+  local output="$2"
+  local token
+  local repo
+  local url
+  local curl_args=(-fsSL -H "Accept: application/vnd.github.raw")
+
+  token="$(github_token)"
+  repo="$(github_repo)"
+  if [ -z "$token" ] || [ -z "$repo" ]; then
+    return 1
+  fi
+
+  curl_args+=(-H "Authorization: Bearer ${token}")
+  url="https://api.github.com/repos/${repo}/contents/${path}?ref=${TARGET_BRANCH}"
+  curl "${curl_args[@]}" "$url" > "$output"
+}
+
+get_upstream_file() {
+  local path="$1"
+  local output="$2"
+
+  if fetch_upstream_file_from_github "$path" "$output" 2> /dev/null; then
+    return 0
+  fi
+
+  git show "$UPSTREAM_REF":"$path" > "$output" 2> /dev/null
+}
+
 # Helper function to check if a contract is excluded.
 is_excluded() {
   local contract="$1"
@@ -52,7 +111,7 @@ if ! grep -qx "$SEMVER_LOCK" "$changed_files"; then
 fi
 
 # Get the upstream semver-lock.json.
-if ! git show "$UPSTREAM_REF":packages/contracts-bedrock/snapshots/semver-lock.json > "$temp_dir/upstream_semver_lock.json" 2> /dev/null; then
+if ! get_upstream_file packages/contracts-bedrock/snapshots/semver-lock.json "$temp_dir/upstream_semver_lock.json"; then
   echo "❌ Error: Could not find semver-lock.json in the snapshots/ directory of $TARGET_BRANCH branch"
   exit 1
 fi
@@ -94,7 +153,7 @@ for contract in $changed_contracts; do
   # Extract the old and new source files.
   old_source_file="$temp_dir/old_${contract##*/}"
   new_source_file="$temp_dir/new_${contract##*/}"
-  git show "$UPSTREAM_REF":packages/contracts-bedrock/"$contract" > "$old_source_file" 2> /dev/null || true
+  get_upstream_file packages/contracts-bedrock/"$contract" "$old_source_file" || true
   cp "$contract" "$new_source_file"
 
   # Extract the old and new versions.

--- a/packages/contracts-bedrock/scripts/ops/get-target-branch.sh
+++ b/packages/contracts-bedrock/scripts/ops/get-target-branch.sh
@@ -5,6 +5,15 @@ resolve_pr_target_branch() {
   local pr_number="${CIRCLE_PULL_REQUEST##*/}"
   local response
   local url
+  local curl_args=(-fsSL)
+
+  if [ -n "${GH_TOKEN:-}" ]; then
+    curl_args+=(-H "Authorization: Bearer ${GH_TOKEN}")
+  elif [ -n "${GITHUB_TOKEN:-}" ]; then
+    curl_args+=(-H "Authorization: Bearer ${GITHUB_TOKEN}")
+  elif [ -n "${GHTOKEN:-}" ]; then
+    curl_args+=(-H "Authorization: Bearer ${GHTOKEN}")
+  fi
 
   if [ -z "${CIRCLE_PROJECT_USERNAME:-}" ] || [ -z "${CIRCLE_PROJECT_REPONAME:-}" ]; then
     echo "Error: CIRCLE_PROJECT_USERNAME and CIRCLE_PROJECT_REPONAME are required to resolve PR target branch" >&2
@@ -12,7 +21,7 @@ resolve_pr_target_branch() {
   fi
 
   url="https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls/${pr_number}"
-  response="$(curl -fsSL "$url")" || {
+  response="$(curl "${curl_args[@]}" "$url")" || {
     echo "Error: failed to resolve target branch for PR #${pr_number}" >&2
     return 1
   }

--- a/rust/kona/crates/protocol/registry/etc/configs.json
+++ b/rust/kona/crates/protocol/registry/etc/configs.json
@@ -2848,7 +2848,7 @@
         "name": "rehearsal-0-bn",
         "l1": {
           "chain_id": 11155111,
-          "public_rpc": "https://ci-sepolia-l1-archive.optimism.io",
+          "public_rpc": "https://ethereum-sepolia-rpc.publicnode.com",
           "explorer": ""
         },
         "hardforks": {


### PR DESCRIPTION
## Summary

This PR cleans up the contracts-related CircleCI configuration and moves authenticated RPC usage behind CircleCI contexts.

- Simplifies the contracts feature-test matrix by removing redundant `OPCM_V2` combinations now that OPCM v2 is enabled by default.
- Keeps standalone coverage for feature sets that still need explicit coverage: `ZK_DISPUTE_GAME`, `CANNON_KONA`, and `SUPER_ROOT_GAMES_MIGRATION`.
- Removes `circleci_ip_ranges: true` from all remaining test jobs in `.circleci/continue/main.yml`.
- Adds `circleci-repo-readonly-authenticated-github-token` to `contracts-bedrock-checks-fast` and updates semver target-branch/upstream-file lookup code to use a GitHub token when one is available.
- Moves authenticated/internal RPC usage into the `circleci-repo-rpc-secrets` context while preserving archive vs non-archive semantics.
- Deduplicates RPC setup: CircleCI jobs resolve RPC env vars once via `$BASH_ENV`, and Go CI recipes source a shared archive-RPC helper.
- Avoids writing resolved secret values into `$BASH_ENV` for context-backed RPCs; `$BASH_ENV` stores references to the CircleCI env vars instead.
- Removes hardcoded `ci-*.optimism.io` and `op-mainnet-rpc.optimism.io` references from CI/runtime paths. The embedded Kona rehearsal registry entry now uses a public Sepolia L1 RPC instead of an internal CI endpoint.

## CircleCI Secrets

The new `circleci-repo-rpc-secrets` context is expected to provide:

- `OP_CI_MAINNET_L1_ARCHIVE_RPC_URL` for historical Mainnet L1 fork/state tests.
- `OP_CI_SEPOLIA_L1_ARCHIVE_RPC_URL` for historical Sepolia L1 fork/state tests.
- `OP_CI_MAINNET_L2_RPC_URL` for OP Mainnet L2 fork tests.
- `OP_CI_SEPOLIA_L2_RPC_URL` for OP Sepolia L2 fork tests.
- `OP_CI_MAINNET_L1_RPC_URL` and `OP_CI_SEPOLIA_L1_RPC_URL` are available for non-archive L1 callers, but this PR intentionally keeps former archive consumers on the archive secrets.

## Test Plan

- `ruby -e 'require "yaml"; YAML.load_file(".circleci/continue/main.yml"); puts "circle yaml ok"'`
- `shellcheck ops/scripts/source-ci-archive-rpcs.sh`
- `bash -n ops/scripts/source-ci-archive-rpcs.sh packages/contracts-bedrock/scripts/ops/get-target-branch.sh packages/contracts-bedrock/scripts/checks/check-semver-diff.sh`
- `cd packages/contracts-bedrock && ./scripts/checks/check-semver-diff.sh`
- `jq empty .circleci/l2-rpcs.json && jq empty rust/kona/crates/protocol/registry/etc/configs.json`
- `.circleci/scripts/check-l2-chains-sync.sh`
- `just --summary`
- `git diff --check`
- `rg -n "circleci_ip_ranges: true" .circleci || true`
- `rg -n "OPCM_V2" .circleci/continue/main.yml .circleci || true`
- `rg -n --hidden -g '!.git' -g '!node_modules' -g '!target' -g '!vendor' -g '!cache' -g '!tmp' 'ci-[a-z0-9-]+\\.optimism\\.io|op-mainnet-rpc\\.optimism\\.io' || true`
- `rg -n "OP_CI_(MAINNET|SEPOLIA)_L1_RPC_URL" .circleci/continue/main.yml justfile ops/scripts/source-ci-archive-rpcs.sh || true`

CircleCI local CLI is not installed in this environment, so I validated the YAML structure and targeted removals locally.
