### PR TITLE
feat(op-supernode): exclude supernode-owned flags from VN flag cloning

### DIFF
--- a/op-supernode/flags/flags.go
+++ b/op-supernode/flags/flags.go
@@ -111,21 +111,26 @@ func init() {
 
 var Flags []cli.Flag
 
-// SupernodeOwnedFlags lists op-node flag names whose resources are owned by the
-// supernode (e.g. the shared L1 client) rather than individual virtual nodes.
-// Setting these at the vn.all.* or vn.<id>.* level has no effect because the
-// supernode injects pre-built resources via InitializationOverrides.
+// SupernodeOwnedFlags lists op-node flag names that remain valid per-VN flags
+// (still cloned into vn.all.* / vn.<id>.* variants) but whose value the supernode
+// may override in some configurations. warnSupernodeOwnedFlags logs a warning
+// when an operator sets one, so it is clear the supernode-level value can win.
 //
-// Extend this list when new shared resources are added to the supernode.
+// Policy: list a flag here only when a per-VN value is still meaningful in some
+// configurations (e.g. interop.dependency-set takes effect unless the supernode's
+// --dependency-set is set). If the supernode *unconditionally* owns the resource
+// so a per-VN value can never take effect, put it in ExcludedVNFlags instead --
+// that removes the flag from the CLI surface entirely; do not also list it here.
 var SupernodeOwnedFlags = []string{
-	opnodeflags.L1HTTPPollInterval.Name,   // "l1.http-poll-interval"
 	opnodeflags.InteropDependencySet.Name, // "interop.dependency-set"
 }
 
 // ExcludedVNFlags lists op-node flag names that should not be cloned into
-// vn.all.* or vn.<id>.* variants. These flags are managed by the supernode
-// and are not configurable per virtual node.
+// vn.all.* or vn.<id>.* variants. The supernode unconditionally owns these
+// resources, so a per-VN value could never take effect -- removing them from the
+// CLI surface entirely avoids exposing flags that are silently ignored.
 // Add entries here as the supernode takes ownership of more op-node resources.
+// See SupernodeOwnedFlags for flags that stay configurable per-VN but warn.
 var ExcludedVNFlags = map[string]bool{
 	// Data paths — derived from --data-dir/<chainID>/...
 	"safedb.path":        true,

--- a/op-supernode/flags/flags.go
+++ b/op-supernode/flags/flags.go
@@ -122,6 +122,25 @@ var SupernodeOwnedFlags = []string{
 	opnodeflags.InteropDependencySet.Name, // "interop.dependency-set"
 }
 
+// ExcludedVNFlags lists op-node flag names that should not be cloned into
+// vn.all.* or vn.<id>.* variants. These flags are managed by the supernode
+// and are not configurable per virtual node.
+// Add entries here as the supernode takes ownership of more op-node resources.
+var ExcludedVNFlags = map[string]bool{
+	// Data paths — derived from --data-dir/<chainID>/...
+	"safedb.path":        true,
+	"p2p.peerstore.path": true,
+	"p2p.discovery.path": true,
+	"p2p.priv.path":      true,
+	// P2P listen ports — forced to 0 (dynamic) by the supernode
+	"p2p.listen.tcp": true,
+	"p2p.listen.udp": true,
+	// L1 endpoints — shared across all VNs, configured at supernode level
+	"l1":                  true,
+	"l1.beacon":           true,
+	"l1.http-poll-interval": true,
+}
+
 func CheckRequired(ctx *cli.Context) error {
 	for _, f := range requiredFlags {
 		if !ctx.IsSet(f.Names()[0]) {
@@ -141,6 +160,9 @@ func FullDynamicFlags(chains []uint64) []cli.Flag {
 	// for each op-node flag, add vn.all.<name> and vn.<id>.<name> variants
 	for _, f := range opnodeflags.Flags {
 		baseName := f.Names()[0]
+		if ExcludedVNFlags[baseName] {
+			continue
+		}
 		// vn.all.* env var/alias prefixing
 		allEnvs := upgradeEnvVarPrefixes(f, opnodeflags.EnvVarPrefix, "VN_ALL")
 		allAliases := prefixAliases(f, VNFlagGlobalPrefix)

--- a/op-supernode/flags/flags.go
+++ b/op-supernode/flags/flags.go
@@ -136,8 +136,8 @@ var ExcludedVNFlags = map[string]bool{
 	"p2p.listen.tcp": true,
 	"p2p.listen.udp": true,
 	// L1 endpoints — shared across all VNs, configured at supernode level
-	"l1":                  true,
-	"l1.beacon":           true,
+	"l1":                    true,
+	"l1.beacon":             true,
 	"l1.http-poll-interval": true,
 }
 

--- a/op-supernode/flags/virtual_test.go
+++ b/op-supernode/flags/virtual_test.go
@@ -108,9 +108,12 @@ func TestFullDynamicFlags_ClonesAllFlagsForChainsAndGlobal(t *testing.T) {
 		seen[name] = struct{}{}
 	}
 
-	// For every op-node flag, we expect vn.all.<base> and vn.<id>.<base>
+	// For every non-excluded op-node flag, we expect vn.all.<base> and vn.<id>.<base>
 	for _, f := range opnodeflags.Flags {
 		base := f.Names()[0]
+		if ExcludedVNFlags[base] {
+			continue
+		}
 		globalName := VNFlagGlobalPrefix + base
 		if _, ok := seen[globalName]; !ok {
 			t.Fatalf("missing global clone for %q: expected flag %q", base, globalName)
@@ -120,6 +123,26 @@ func TestFullDynamicFlags_ClonesAllFlagsForChainsAndGlobal(t *testing.T) {
 			if _, ok := seen[perName]; !ok {
 				t.Fatalf("missing per-chain clone for %q: expected flag %q", base, perName)
 			}
+		}
+	}
+}
+
+func TestFullDynamicFlags_ExcludesExcludedVNFlags(t *testing.T) {
+	chains := []uint64{100}
+	flagsOut := FullDynamicFlags(chains)
+	seen := make(map[string]struct{})
+	for _, f := range flagsOut {
+		seen[f.Names()[0]] = struct{}{}
+	}
+
+	for name := range ExcludedVNFlags {
+		globalName := VNFlagGlobalPrefix + name
+		if _, ok := seen[globalName]; ok {
+			t.Fatalf("excluded flag %q should not appear as %q", name, globalName)
+		}
+		perName := fmt.Sprintf("%s%d.%s", VNFlagNamePrefix, 100, name)
+		if _, ok := seen[perName]; ok {
+			t.Fatalf("excluded flag %q should not appear as %q", name, perName)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `ExcludedVNFlags` map to `op-supernode/flags` that prevents specified op-node flags from being cloned into `vn.all.*` / `vn.<id>.*` variants
- Excludes 9 flags the supernode already overrides: data paths (`safedb.path`, `p2p.peerstore.path`, `p2p.discovery.path`, `p2p.priv.path`), P2P listen ports (`p2p.listen.tcp`, `p2p.listen.udp`), and L1 endpoints (`l1`, `l1.beacon`, `l1.http-poll-interval`)
- These flags appeared in `--help` and accepted `OP_SUPERNODE_VN_ALL_*` env vars, but values were silently discarded — now they're removed from the CLI surface entirely
- To exclude more flags in the future, add an entry to the `ExcludedVNFlags` map

## Motivation

The supernode derives data paths from `--data-dir`, forces dynamic P2P listen ports, and shares a single L1 client across all virtual nodes. Exposing these as per-VN flags was misleading — operators could set them without error but they had no effect.

## Test plan

- [x] `go test ./op-supernode/flags/ -v` — all pass
- [x] Existing `TestFullDynamicFlags_ClonesAllFlagsForChainsAndGlobal` updated to skip excluded flags
- [x] New `TestFullDynamicFlags_ExcludesExcludedVNFlags` verifies excluded flags don't appear in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)