### PR TITLE
feat: make cannon-kona default path in devfeature bitmap

### DIFF
--- a/op-core/devfeatures/devfeatures.go
+++ b/op-core/devfeatures/devfeatures.go
@@ -36,6 +36,10 @@ func IsDevFeatureEnabled(bitmap, flag common.Hash) bool {
 	if hasFlag(flag, L2CMFlag) {
 		return true
 	}
+	// CannonKona is enabled by default. TODO(#20084): remove with the broader CannonKonaFlag cleanup.
+	if hasFlag(flag, CannonKonaFlag) {
+		return true
+	}
 	b := new(big.Int).SetBytes(bitmap[:])
 	f := new(big.Int).SetBytes(flag[:])
 

--- a/op-core/devfeatures/devfeatures_test.go
+++ b/op-core/devfeatures/devfeatures_test.go
@@ -80,8 +80,9 @@ func TestIsDevFeatureEnabled(t *testing.T) {
 	})
 
 	t.Run("all against empty", func(t *testing.T) {
-		// Strip L2CM because it is hardcoded enabled regardless of bitmap. TODO(#20084): remove with the broader L2CMFlag cleanup.
-		require.False(t, IsDevFeatureEnabled(EMPTY_FEATURES, and(ALL_FEATURES, not(L2CMFlag))))
+		// Strip L2CM and CannonKona because they are hardcoded enabled regardless of bitmap.
+		// TODO(#20084): remove with the broader L2CMFlag/CannonKonaFlag cleanup.
+		require.False(t, IsDevFeatureEnabled(EMPTY_FEATURES, and(ALL_FEATURES, not(or(L2CMFlag, CannonKonaFlag)))))
 	})
 
 	// L2CM is hardcoded enabled. TODO(#20084): remove with the broader L2CMFlag cleanup.
@@ -95,6 +96,19 @@ func TestIsDevFeatureEnabled(t *testing.T) {
 	t.Run("L2CM always enabled when combined with other flags", func(t *testing.T) {
 		require.True(t, IsDevFeatureEnabled(EMPTY_FEATURES, or(FEATURE_A, L2CMFlag)))
 		require.True(t, IsDevFeatureEnabled(EMPTY_FEATURES, or(FEATURE_B, L2CMFlag)))
+	})
+
+	// CannonKona is hardcoded enabled. TODO(#20084): remove with the broader CannonKonaFlag cleanup.
+	t.Run("CannonKona always enabled regardless of bitmap", func(t *testing.T) {
+		require.True(t, IsDevFeatureEnabled(EMPTY_FEATURES, CannonKonaFlag))
+		require.True(t, IsDevFeatureEnabled(FEATURE_A, CannonKonaFlag))
+		require.True(t, IsDevFeatureEnabled(CannonKonaFlag, CannonKonaFlag))
+	})
+
+	// CannonKona is hardcoded enabled. TODO(#20084): remove with the broader CannonKonaFlag cleanup.
+	t.Run("CannonKona always enabled when combined with other flags", func(t *testing.T) {
+		require.True(t, IsDevFeatureEnabled(EMPTY_FEATURES, or(FEATURE_A, CannonKonaFlag)))
+		require.True(t, IsDevFeatureEnabled(EMPTY_FEATURES, or(FEATURE_B, CannonKonaFlag)))
 	})
 }
 

--- a/packages/contracts-bedrock/src/libraries/DevFeatures.sol
+++ b/packages/contracts-bedrock/src/libraries/DevFeatures.sol
@@ -44,6 +44,8 @@ library DevFeatures {
     function isDevFeatureEnabled(bytes32 _bitmap, bytes32 _feature) internal pure returns (bool) {
         // L2CM is enabled by default. TODO(#20084): remove with the broader L2CMFlag cleanup.
         if (hasFlag(_feature, L2CM)) return true;
+        // CannonKona is enabled by default. TODO(#20084): remove with the broader CannonKonaFlag cleanup.
+        if (hasFlag(_feature, CANNON_KONA)) return true;
         return _feature != 0 && hasFlag(_bitmap, _feature);
     }
 

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerContainer.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerContainer.t.sol
@@ -149,6 +149,8 @@ contract OPContractsManagerContainer_IsDevFeatureEnabled_Test is OPContractsMana
         bytes32 feature = bytes32(uint256(1) << _bitIndex);
         // L2CM is hardcoded enabled. TODO(#20084): remove with the broader L2CMFlag cleanup.
         vm.assume(feature != DevFeatures.L2CM);
+        // CannonKona is hardcoded enabled. TODO(#20084): remove with the broader CannonKonaFlag cleanup.
+        vm.assume(feature != DevFeatures.CANNON_KONA);
 
         // Create a bitmap with all bits set except the one we're testing.
         bytes32 bitmap = bytes32(type(uint256).max ^ (uint256(1) << _bitIndex));
@@ -163,6 +165,8 @@ contract OPContractsManagerContainer_IsDevFeatureEnabled_Test is OPContractsMana
     function testFuzz_isDevFeatureEnabled_zeroBitmap_succeeds(bytes32 _feature) public {
         // L2CM is hardcoded enabled. TODO(#20084): remove with the broader L2CMFlag cleanup.
         vm.assume((_feature & DevFeatures.L2CM) != DevFeatures.L2CM);
+        // CannonKona is hardcoded enabled. TODO(#20084): remove with the broader CannonKonaFlag cleanup.
+        vm.assume((_feature & DevFeatures.CANNON_KONA) != DevFeatures.CANNON_KONA);
         OPContractsManagerContainer container = _deploy(bytes32(0));
 
         assertFalse(container.isDevFeatureEnabled(_feature));
@@ -173,6 +177,13 @@ contract OPContractsManagerContainer_IsDevFeatureEnabled_Test is OPContractsMana
     function test_isDevFeatureEnabled_l2cmAlwaysEnabled_succeeds() public {
         OPContractsManagerContainer container = _deploy(bytes32(0));
         assertTrue(container.isDevFeatureEnabled(DevFeatures.L2CM));
+    }
+
+    /// @notice Tests that isDevFeatureEnabled(CANNON_KONA) always returns true regardless of stored bitmap.
+    /// @dev TODO(#20084): remove with the broader CannonKonaFlag cleanup.
+    function test_isDevFeatureEnabled_cannonKonaAlwaysEnabled_succeeds() public {
+        OPContractsManagerContainer container = _deploy(bytes32(0));
+        assertTrue(container.isDevFeatureEnabled(DevFeatures.CANNON_KONA));
     }
 
     /// @notice Tests that isDevFeatureEnabled returns true for multiple features set at once.

--- a/packages/contracts-bedrock/test/L2/L2DevFeatureFlags.t.sol
+++ b/packages/contracts-bedrock/test/L2/L2DevFeatureFlags.t.sol
@@ -65,6 +65,8 @@ contract L2DevFeatureFlags_IsDevFeatureEnabled_Test is L2DevFeatureFlags_TestIni
         vm.assume(_feature != bytes32(0));
         // L2CM is hardcoded enabled. TODO(#20084): remove with the broader L2CMFlag cleanup.
         vm.assume((_feature & DevFeatures.L2CM) != DevFeatures.L2CM);
+        // CannonKona is hardcoded enabled. TODO(#20084): remove with the broader CannonKonaFlag cleanup.
+        vm.assume((_feature & DevFeatures.CANNON_KONA) != DevFeatures.CANNON_KONA);
         // Ensure `devFeatureBitmap` contains bytes32(0)
         vm.store(address(l2DevFeatureFlags), bytes32(uint256(keccak256("l2devfeatureflags.bitmap")) - 1), bytes32(0));
         assertFalse(l2DevFeatureFlags.isDevFeatureEnabled(_feature));
@@ -76,6 +78,12 @@ contract L2DevFeatureFlags_IsDevFeatureEnabled_Test is L2DevFeatureFlags_TestIni
         assertTrue(l2DevFeatureFlags.isDevFeatureEnabled(DevFeatures.L2CM));
     }
 
+    /// @notice Tests that `isDevFeatureEnabled(CANNON_KONA)` always returns true regardless of stored bitmap.
+    /// @dev TODO(#20084): remove with the broader CannonKonaFlag cleanup.
+    function test_isDevFeatureEnabled_cannonKonaAlwaysEnabled_succeeds() public view {
+        assertTrue(l2DevFeatureFlags.isDevFeatureEnabled(DevFeatures.CANNON_KONA));
+    }
+
     /// @notice Tests that `isDevFeatureEnabled` returns true for a multi-bit query that includes
     ///         the L2CM flag, regardless of the stored bitmap.
     /// @dev TODO(#20084): remove with the broader L2CMFlag cleanup.
@@ -83,6 +91,15 @@ contract L2DevFeatureFlags_IsDevFeatureEnabled_Test is L2DevFeatureFlags_TestIni
         vm.assume(bytes32(1 << uint256(_bitIndex)) != DevFeatures.L2CM);
         bytes32 featureWithL2CM = bytes32(1 << uint256(_bitIndex)) | DevFeatures.L2CM;
         assertTrue(l2DevFeatureFlags.isDevFeatureEnabled(featureWithL2CM));
+    }
+
+    /// @notice Tests that `isDevFeatureEnabled` returns true for a multi-bit query that includes
+    ///         the CANNON_KONA flag, regardless of the stored bitmap.
+    /// @dev TODO(#20084): remove with the broader CannonKonaFlag cleanup.
+    function testFuzz_isDevFeatureEnabled_cannonKonaAlwaysEnabledMultiFlag_succeeds(uint8 _bitIndex) public view {
+        vm.assume(bytes32(1 << uint256(_bitIndex)) != DevFeatures.CANNON_KONA);
+        bytes32 featureWithCannonKona = bytes32(1 << uint256(_bitIndex)) | DevFeatures.CANNON_KONA;
+        assertTrue(l2DevFeatureFlags.isDevFeatureEnabled(featureWithCannonKona));
     }
 
     /// @notice Tests that `isDevFeatureEnabled` returns false for zero feature.
@@ -109,7 +126,7 @@ contract L2DevFeatureFlags_IsDevFeatureEnabled_Test is L2DevFeatureFlags_TestIni
         l2DevFeatureFlags.setDevFeatureBitmap(DevFeatures.OPTIMISM_PORTAL_INTEROP);
 
         assertTrue(l2DevFeatureFlags.isDevFeatureEnabled(DevFeatures.OPTIMISM_PORTAL_INTEROP));
-        assertFalse(l2DevFeatureFlags.isDevFeatureEnabled(DevFeatures.CANNON_KONA));
+        assertFalse(l2DevFeatureFlags.isDevFeatureEnabled(DevFeatures.ZK_DISPUTE_GAME));
     }
 
     /// @notice Tests that `isDevFeatureEnabled` works correctly with multiple features set.

--- a/packages/contracts-bedrock/test/libraries/DevFeatures.t.sol
+++ b/packages/contracts-bedrock/test/libraries/DevFeatures.t.sol
@@ -93,9 +93,11 @@ contract DevFeatures_isDevFeatureEnabled_Test is Test {
 
     /// @notice Tests that ALL_FEATURES against empty bitmap returns false.
     function test_isDevFeatureEnabled_allFeaturesAgainstEmpty_succeeds() public pure {
-        // Strip L2CM because it is hardcoded enabled regardless of bitmap.
-        // TODO(#20084): remove with the broader L2CMFlag cleanup.
-        assertFalse(DevFeatures.isDevFeatureEnabled(EMPTY_FEATURES, ALL_FEATURES & ~DevFeatures.L2CM));
+        // Strip L2CM and CannonKona because they are hardcoded enabled regardless of bitmap.
+        // TODO(#20084): remove with the broader L2CMFlag/CannonKonaFlag cleanup.
+        assertFalse(
+            DevFeatures.isDevFeatureEnabled(EMPTY_FEATURES, ALL_FEATURES & ~DevFeatures.L2CM & ~DevFeatures.CANNON_KONA)
+        );
     }
 
     /// @notice Fuzz test: any non-zero feature should match itself exactly.
@@ -121,6 +123,8 @@ contract DevFeatures_isDevFeatureEnabled_Test is Test {
         vm.assume(_feature != bytes32(0));
         // L2CM is hardcoded enabled. TODO(#20084): remove with the broader L2CMFlag cleanup.
         vm.assume((_feature & DevFeatures.L2CM) != DevFeatures.L2CM);
+        // CannonKona is hardcoded enabled. TODO(#20084): remove with the broader CannonKonaFlag cleanup.
+        vm.assume((_feature & DevFeatures.CANNON_KONA) != DevFeatures.CANNON_KONA);
         bytes32 disjointBitmap = ~_feature;
         assertFalse(DevFeatures.isDevFeatureEnabled(disjointBitmap, _feature));
     }
@@ -131,5 +135,13 @@ contract DevFeatures_isDevFeatureEnabled_Test is Test {
         assertTrue(DevFeatures.isDevFeatureEnabled(EMPTY_FEATURES, DevFeatures.L2CM));
         assertTrue(DevFeatures.isDevFeatureEnabled(~DevFeatures.L2CM, DevFeatures.L2CM));
         assertTrue(DevFeatures.isDevFeatureEnabled(DevFeatures.L2CM, DevFeatures.L2CM));
+    }
+
+    /// @notice Tests that CannonKona is hardcoded enabled regardless of the bitmap.
+    /// @dev TODO(#20084): remove with the broader CannonKonaFlag cleanup.
+    function test_isDevFeatureEnabled_cannonKonaAlwaysEnabled_succeeds() public pure {
+        assertTrue(DevFeatures.isDevFeatureEnabled(EMPTY_FEATURES, DevFeatures.CANNON_KONA));
+        assertTrue(DevFeatures.isDevFeatureEnabled(~DevFeatures.CANNON_KONA, DevFeatures.CANNON_KONA));
+        assertTrue(DevFeatures.isDevFeatureEnabled(DevFeatures.CANNON_KONA, DevFeatures.CANNON_KONA));
     }
 }


### PR DESCRIPTION
Stacks on top of #20439. Mirrors the L2CM override pattern for the `CannonKona` flag: hardcodes `isDevFeatureEnabled(CANNON_KONA)` to true at the library level on both the Go side (`op-core/devfeatures/devfeatures.go`) and the Solidity side (`packages/contracts-bedrock/src/libraries/DevFeatures.sol`).

This makes the CannonKona codepath the default and treats the bitmap bit as a circuit breaker rather than an opt-in toggle, matching the direction of #20356 / #20084.

Also tightens the fuzz `vm.assume` clauses in `DevFeatures.t.sol` and `OPContractsManagerContainer.t.sol` to use bitwise (`&`) checks so multi-bit features that happen to include an override bit don't break the disjoint-bitmap / zero-bitmap fuzz tests.

Related: https://github.com/ethereum-optimism/optimism/issues/20084