### PR TITLE
fix(op-acceptance): preserve quoting in just test args

### DIFF
--- a/op-acceptance-tests/justfile
+++ b/op-acceptance-tests/justfile
@@ -36,20 +36,21 @@ build-deps:
 #   just test ./op-acceptance-tests/tests/base/...
 #   just test -run TestMyTest ./op-acceptance-tests/tests/base/
 #   just test -count=10 -run TestMyTest ./op-acceptance-tests/tests/base/
+[positional-arguments]
 test *args: build-deps
     #!/usr/bin/env bash
     set -euo pipefail
     cd {{REPO_ROOT}}
     flags=()
-    case " {{args}} " in
+    case " $* " in
         *" -count="*|*" -count "*) ;;
         *) flags+=(-count=1) ;;
     esac
-    case " {{args}} " in
+    case " $* " in
         *" -timeout="*|*" -timeout "*) ;;
         *) flags+=(-timeout 30m) ;;
     esac
-    exec go test "${flags[@]}" {{args}}
+    exec go test "${flags[@]}" "$@"
 
 # Run acceptance tests
 acceptance-test:


### PR DESCRIPTION
The `just test` recipe used `{{args}}`, which is textual interpolation — args are re-tokenized by the shell, dropping the original quoting. Passing `-run '^A(B)?$|^C$'` produces `syntax error near unexpected token \`('` because the parens, pipe, and `$` reach bash without quotes around them.

Adding `[positional-arguments]` and switching to `"$@"` (and `$*` for the `case` substring matches) hands args to `go test` exactly as the caller passed them.