### PR TITLE
feat(op-dispute-mon): add game type breakdown metric

### DIFF
--- a/op-dispute-mon/metrics/metrics.go
+++ b/op-dispute-mon/metrics/metrics.go
@@ -250,8 +250,8 @@ type Metrics struct {
 	nodeEndpointOutOfSyncCount prometheus.Gauge
 	mixedAvailabilityGames     prometheus.Gauge
 	mixedSafetyGames           prometheus.Gauge
-	differentRootGames prometheus.Gauge
-	gameTypes          prometheus.GaugeVec
+	differentRootGames         prometheus.Gauge
+	gameTypes                  prometheus.GaugeVec
 }
 
 func (m *Metrics) Registry() *prometheus.Registry {

--- a/op-dispute-mon/metrics/metrics.go
+++ b/op-dispute-mon/metrics/metrics.go
@@ -197,6 +197,8 @@ type Metricer interface {
 
 	RecordOldestGameUpdateTime(t time.Time)
 
+	RecordGameTypes(gameTypeCounts map[string]int)
+
 	caching.Metrics
 	contractMetrics.ContractMetricer
 	opmetrics.RPCMetricer
@@ -248,7 +250,8 @@ type Metrics struct {
 	nodeEndpointOutOfSyncCount prometheus.Gauge
 	mixedAvailabilityGames     prometheus.Gauge
 	mixedSafetyGames           prometheus.Gauge
-	differentRootGames         prometheus.Gauge
+	differentRootGames prometheus.Gauge
+	gameTypes          prometheus.GaugeVec
 }
 
 func (m *Metrics) Registry() *prometheus.Registry {
@@ -445,6 +448,13 @@ func NewMetrics() *Metrics {
 			Namespace: Namespace,
 			Name:      "different_root_games",
 			Help:      "Number of games where nodes returned different roots (output roots for FaultDisputeGame, super roots for SuperFaultDisputeGame) in the last update cycle",
+		}),
+		gameTypes: *factory.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: Namespace,
+			Name:      "games",
+			Help:      "Number of games in the monitoring window broken down by game type",
+		}, []string{
+			"game_type",
 		}),
 	}
 }
@@ -674,6 +684,12 @@ func labelValuesFor(status GameAgreementStatus) []string {
 
 	default:
 		panic(fmt.Errorf("unknown game agreement status: %v", status))
+	}
+}
+
+func (m *Metrics) RecordGameTypes(gameTypeCounts map[string]int) {
+	for gameType, count := range gameTypeCounts {
+		m.gameTypes.WithLabelValues(gameType).Set(float64(count))
 	}
 }
 

--- a/op-dispute-mon/metrics/noop.go
+++ b/op-dispute-mon/metrics/noop.go
@@ -65,3 +65,5 @@ func (*NoopMetricsImpl) RecordMixedAvailabilityGames(_ int) {}
 func (*NoopMetricsImpl) RecordMixedSafetyGames(_ int) {}
 
 func (*NoopMetricsImpl) RecordDifferentRootGames(_ int) {}
+
+func (*NoopMetricsImpl) RecordGameTypes(_ map[string]int) {}

--- a/op-dispute-mon/mon/game_types.go
+++ b/op-dispute-mon/mon/game_types.go
@@ -1,0 +1,27 @@
+package mon
+
+import (
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
+)
+
+type GameTypeMetrics interface {
+	RecordGameTypes(gameTypeCounts map[string]int)
+}
+
+type GameTypeMonitor struct {
+	metrics GameTypeMetrics
+}
+
+func NewGameTypeMonitor(metrics GameTypeMetrics) *GameTypeMonitor {
+	return &GameTypeMonitor{metrics: metrics}
+}
+
+func (m *GameTypeMonitor) CheckGameTypes(games []*types.EnrichedGameData) {
+	counts := make(map[string]int)
+	for _, game := range games {
+		gt := gameTypes.GameType(game.GameType).String()
+		counts[gt]++
+	}
+	m.metrics.RecordGameTypes(counts)
+}

--- a/op-dispute-mon/mon/service.go
+++ b/op-dispute-mon/mon/service.go
@@ -242,6 +242,7 @@ func (s *Service) initMonitor(ctx context.Context, cfg *config.Config) {
 	mixedAvailabilityMonitor := NewMixedAvailability(s.logger, s.metrics)
 	mixedSafetyMonitor := NewMixedSafetyMonitor(s.logger, s.metrics)
 	differentRootMonitor := NewDifferentRootMonitor(s.logger, s.metrics)
+	gameTypeMonitor := NewGameTypeMonitor(s.metrics)
 	s.monitor = newGameMonitor(ctx, s.logger, s.cl, s.metrics, cfg.MonitorInterval, cfg.GameWindow, headBlockFetcher,
 		extractor.Extract,
 		forecast.Forecast,
@@ -256,7 +257,8 @@ func (s *Service) initMonitor(ctx context.Context, cfg *config.Config) {
 		nodeEndpointOutOfSyncMonitor.CheckNodeEndpointOutOfSync,
 		mixedAvailabilityMonitor.CheckMixedAvailability,
 		mixedSafetyMonitor.CheckMixedSafety,
-		differentRootMonitor.CheckDifferentRoots)
+		differentRootMonitor.CheckDifferentRoots,
+		gameTypeMonitor.CheckGameTypes)
 }
 
 func (s *Service) Start(ctx context.Context) error {


### PR DESCRIPTION
## Summary
- Adds a new `op_dispute_mon_games` Prometheus gauge metric with a `game_type` label that breaks down monitored games by their dispute game type (cannon, permissioned, super-cannon, etc.)
- Introduces `GameTypeMonitor` following the existing monitor pattern (like `L2ChallengesMonitor`, `DifferentRootMonitor`, etc.) and wires it into the game monitor pipeline
- Enables Grafana dashboards to visualize game type distribution across the monitoring window

## Changes
- **op-dispute-mon/metrics/metrics.go**: Add `gameTypes` GaugeVec field and `RecordGameTypes` method
- **op-dispute-mon/metrics/noop.go**: Add no-op `RecordGameTypes` to satisfy the interface
- **op-dispute-mon/mon/game_types.go**: New `GameTypeMonitor` with `CheckGameTypes` that counts games by type
- **op-dispute-mon/mon/service.go**: Wire `GameTypeMonitor` into the monitor pipeline

No changes to existing metrics or interfaces beyond adding the new `RecordGameTypes` method to `Metricer`.

## Test plan
- [x] `go vet ./op-dispute-mon/...` passes
- [x] `go build ./op-dispute-mon/...` passes
- [x] `go test ./op-dispute-mon/...` passes (all 9 test packages)
- [ ] Verify metric appears in Prometheus after deployment
- [ ] Add Grafana panel for game type distribution

🤖 Generated with [Claude Code](https://claude.com/claude-code)