### PR TITLE
feat(op-devstack): add WithSequencerDisabled / WithBatcherDisabled preset options

### DIFF
--- a/op-devstack/presets/option_validation.go
+++ b/op-devstack/presets/option_validation.go
@@ -29,6 +29,7 @@ const (
 	optionKindInteropLogBackfill
 	optionKindInteropFilter
 	optionKindPreGenesisSuperGame
+	optionKindSequencerDisabled
 )
 
 const allOptionKinds = optionKindDeployer |
@@ -48,7 +49,8 @@ const allOptionKinds = optionKindDeployer |
 	optionKindMessageExpiryWindow |
 	optionKindInteropLogBackfill |
 	optionKindInteropFilter |
-	optionKindPreGenesisSuperGame
+	optionKindPreGenesisSuperGame |
+	optionKindSequencerDisabled
 
 var optionKindLabels = []struct {
 	kind  optionKinds
@@ -72,6 +74,7 @@ var optionKindLabels = []struct {
 	{kind: optionKindInteropLogBackfill, label: "interop log backfill depth"},
 	{kind: optionKindInteropFilter, label: "interop filter"},
 	{kind: optionKindPreGenesisSuperGame, label: "pre-genesis super game"},
+	{kind: optionKindSequencerDisabled, label: "sequencer disabled"},
 }
 
 func (k optionKinds) String() string {
@@ -158,7 +161,8 @@ const supernodeProofsPresetSupportedOptionKinds = optionKindDeployer |
 	optionKindBatcher |
 	optionKindL1EL |
 	optionKindTimeTravel |
-	optionKindMessageExpiryWindow
+	optionKindMessageExpiryWindow |
+	optionKindSequencerDisabled
 
 const twoL2SupernodeProofsPresetSupportedOptionKinds = supernodeProofsPresetSupportedOptionKinds |
 	optionKindPreGenesisSuperGame

--- a/op-devstack/presets/options.go
+++ b/op-devstack/presets/options.go
@@ -3,6 +3,7 @@ package presets
 import (
 	"time"
 
+	bss "github.com/ethereum-optimism/optimism/op-batcher/batcher"
 	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -280,6 +281,33 @@ func WithMessageExpiryWindow(window uint64) Option {
 			cfg.MessageExpiryWindow = &v
 		},
 	}
+}
+
+// WithSequencerDisabled starts every L2 chain's real op-node sequencer in the
+// stopped state. By default the sequencer runs from startup; pass this option
+// for tests that drive block production exclusively via the TestSequencer
+// Control API. The sequencer can later be started via L2CLNode.StartSequencer
+// if a test needs to.
+//
+// Currently supported only on the supernode-proofs presets.
+func WithSequencerDisabled() Option {
+	return option{
+		kinds: optionKindSequencerDisabled,
+		applyFn: func(cfg *sysgo.PresetConfig) {
+			cfg.SequencerDisabled = true
+		},
+	}
+}
+
+// WithBatcherDisabled starts every L2 chain's batcher in the stopped state. By
+// default the batcher runs from startup. Pass this option for tests that need
+// fine-grained control over when L2 batches land on L1 — pair it with
+// WithSequencerDisabled() so the chain has no movement at all until the test
+// explicitly drives it. The batcher can later be started via L2Batcher.Start.
+func WithBatcherDisabled() Option {
+	return WithBatcherOption(func(_ sysgo.ComponentTarget, cfg *bss.CLIConfig) {
+		cfg.Stopped = true
+	})
 }
 
 // WithL2BlockTimes configures per-chain L2 block times via the deployer.

--- a/op-devstack/sysgo/multichain_supernode_runtime.go
+++ b/op-devstack/sysgo/multichain_supernode_runtime.go
@@ -171,7 +171,7 @@ func newSingleChainSupernodeRuntimeWithConfig(t devtest.T, interopAtGenesis bool
 		require.NoError(overrideErr, "failed to override message expiry window")
 	}
 
-	supernode, l2CL := startSingleChainSharedSupernode(t, l1Net, l1EL, l1CL, l2Net, l2EL, depSetStatic, jwtSecret, interopAtGenesis)
+	supernode, l2CL := startSingleChainSharedSupernode(t, l1Net, l1EL, l1CL, l2Net, l2EL, depSetStatic, jwtSecret, interopAtGenesis, !cfg.SequencerDisabled)
 	l2Batcher := startMinimalBatcher(t, keys, l2Net, l1EL, l2CL, l2EL, cfg.BatcherOptions...)
 	faucetService := startFaucets(t, keys, l1Net.ChainID(), l2Net.ChainID(), l1EL.UserRPC(), l2EL.UserRPC())
 
@@ -292,6 +292,7 @@ func newTwoL2SupernodeRuntimeWithConfig(t devtest.T, enableInterop bool, delaySe
 		interopActivationTimestamp,
 		cfg.InteropLogBackfillDepth,
 		jwtSecret,
+		!cfg.SequencerDisabled,
 	)
 
 	l2ABatcher := startMinimalBatcher(t, keys, l2ANet, l1EL, l2ACL, l2AEL, cfg.BatcherOptions...)
@@ -471,6 +472,7 @@ func startTwoL2SharedSupernode(
 	interopActivationTimestamp *uint64,
 	interopLogBackfillDepth time.Duration,
 	jwtSecret [32]byte,
+	sequencerEnabled bool,
 ) (*SuperNode, *SuperNodeProxy, *SuperNodeProxy) {
 	require := t.Require()
 	logger := t.Logger().New("component", "supernode")
@@ -503,7 +505,7 @@ func startTwoL2SharedSupernode(
 			},
 			DependencySet:                   depSet,
 			Beacon:                          &opnodeconfig.L1BeaconEndpointConfig{BeaconAddr: l1CL.beaconHTTPAddr},
-			Driver:                          driver.Config{SequencerEnabled: true, SequencerConfDepth: 2},
+			Driver:                          driver.Config{SequencerEnabled: sequencerEnabled, SequencerConfDepth: 2},
 			Rollup:                          *l2Net.rollupCfg,
 			P2PSigner:                       p2pSignerSetup,
 			RPC:                             oprpc.CLIConfig{ListenAddr: "127.0.0.1", ListenPort: 0, EnableAdmin: true},
@@ -589,6 +591,7 @@ func startSingleChainSharedSupernode(
 	depSet *depset.StaticConfigDependencySet,
 	jwtSecret [32]byte,
 	interopAtGenesis bool,
+	sequencerEnabled bool,
 ) (*SuperNode, *SuperNodeProxy) {
 	require := t.Require()
 	logger := t.Logger().New("component", "supernode")
@@ -621,7 +624,7 @@ func startSingleChainSharedSupernode(
 			},
 			DependencySet:                   depSet,
 			Beacon:                          &opnodeconfig.L1BeaconEndpointConfig{BeaconAddr: l1CL.beaconHTTPAddr},
-			Driver:                          driver.Config{SequencerEnabled: true, SequencerConfDepth: 2},
+			Driver:                          driver.Config{SequencerEnabled: sequencerEnabled, SequencerConfDepth: 2},
 			Rollup:                          *l2Net.rollupCfg,
 			P2PSigner:                       p2pSignerSetup,
 			RPC:                             oprpc.CLIConfig{ListenAddr: "127.0.0.1", ListenPort: 0, EnableAdmin: true},

--- a/op-devstack/sysgo/preset_config.go
+++ b/op-devstack/sysgo/preset_config.go
@@ -34,6 +34,11 @@ type PresetConfig struct {
 	// initiating-message logs backward from the tip by this duration at startup.
 	InteropLogBackfillDepth time.Duration
 	PreGenesisSuperGame     *PreGenesisSuperGameConfig
+	// SequencerDisabled, when true, starts the real op-node sequencer in the
+	// stopped state on every L2 chain. Default zero value (false) keeps the
+	// historical behavior of starting with the sequencer running. Useful for
+	// tests that drive block production via the TestSequencer Control API.
+	SequencerDisabled bool
 }
 
 func NewPresetConfig() PresetConfig {


### PR DESCRIPTION
Adds two new preset options that opt out of the default "everything starts running" behavior in supernode-proofs presets:

- **`WithSequencerDisabled()`** — starts every L2 chain's real op-node sequencer in the stopped state (`Driver.Config.SequencerEnabled = false`).
- **`WithBatcherDisabled()`** — starts every L2 chain's batcher in the stopped state (`bss.CLIConfig.Stopped = true`).

Motivation: tests that drive L2 block production via `TestSequencer.SequenceBlock` and produce L1 batches at deterministic moments currently have to call `StopSequencer()` and `Batcher.Stop()` after the system is up, which races with the first block under CI scheduling pauses. With both disabled at startup, the test owns the chain end-to-end without ever needing to race-stop a service that already produced blocks.

Either component can be started later via `L2CLNode.StartSequencer` or `L2Batcher.Start` as needed.

No functional change for any existing test — both options are opt-in.

## Test plan

- [x] `go build ./op-devstack/... ./op-acceptance-tests/...`
- [x] `go test ./op-devstack/presets/`
- [ ] Follow-up branch will use both options in `RunSuperFaultProofTest` / `RunVariedBlockTimesTest`.
