### PR TITLE
fix(supernode): VerifiedRequiredL1 takes MAX of per-chain L1s

### DIFF
--- a/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
+++ b/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
@@ -159,10 +159,6 @@ type transitionTest struct {
 	L1Head             eth.BlockID
 	ClaimTimestamp     uint64
 	ExpectValid        bool
-	// SkipChallenger, if true, runs only the FPP half of this subtest. Used
-	// to work around known op-challenger / op-supernode bugs while still
-	// exercising the FPP path. Each use must reference the tracking issue.
-	SkipChallenger bool
 }
 
 // orderedChains returns the two interop chains sorted by chain ID.
@@ -590,18 +586,9 @@ func buildAfterChainHeadTests(
 	// l1HeadCurrent, so by idx 2*sPT-1 the cascade rule says "always Invalid".
 	test3Agreed := marshalTransition(end, consolidateStep, firstOptNext, secondOptNext)
 	test3Disputed := endNext.Marshal()
-	test3SkipChallenger := false
 	if anyExpects {
 		test3Agreed = interop.InvalidTransition
 		test3Disputed = interop.InvalidTransition
-		// op-supernode bug ethereum-optimism/optimism#20481: at idx 2*sPT-1
-		// (step=0 at boundary) the trace provider's VerifiedRequiredL1 check
-		// uses MIN of per-chain verified L1s instead of MAX, so the boundary
-		// super root looks "verified" at l1HeadCurrent when it isn't. The
-		// challenger then returns SuperRoot(boundary) instead of cascading,
-		// disagreeing with the FPP. Skip the challenger half of this subtest
-		// until the supernode is fixed.
-		test3SkipChallenger = true
 	}
 	tests = append(tests, &transitionTest{
 		Name:               "DisputeTimestampAfterChainHeadConsolidate",
@@ -611,7 +598,6 @@ func buildAfterChainHeadTests(
 		ClaimTimestamp:     claimTimestamp,
 		DisputedTraceIndex: 2*stepsPerTimestamp - 1,
 		ExpectValid:        true,
-		SkipChallenger:     test3SkipChallenger,
 	})
 
 	// Test 4 — chain A's optimistic step at boundary+1.
@@ -620,14 +606,8 @@ func buildAfterChainHeadTests(
 	// expects a block at boundary+1 but its LocalSafe is at endTimestamp.
 	// In varied: cascade — agreed and disputed both InvalidTransition.
 	test4Agreed := endNext.Marshal()
-	test4SkipChallenger := false
 	if anyExpects {
 		test4Agreed = interop.InvalidTransition
-		// Same op-supernode bug ethereum-optimism/optimism#20481: agreed at
-		// idx 2*sPT-1 is SuperRoot(boundary) from the buggy challenger when
-		// the cascade rule says it should be InvalidTransition. Skip the
-		// challenger half until the supernode is fixed.
-		test4SkipChallenger = true
 	}
 	tests = append(tests, &transitionTest{
 		Name:               "DisputeBlockAfterChainHead-FirstChain",
@@ -637,7 +617,6 @@ func buildAfterChainHeadTests(
 		ClaimTimestamp:     claimTimestamp,
 		DisputedTraceIndex: 2 * stepsPerTimestamp,
 		ExpectValid:        true,
-		SkipChallenger:     test4SkipChallenger,
 	})
 
 	// Tests 5 & 6 — far past chain head. Cascade.
@@ -946,9 +925,6 @@ func runFaultProofTest(t devtest.T, sys *presets.SimpleInterop) {
 				test.AgreedClaim, crypto.Keccak256Hash(test.DisputedClaim),
 				test.ClaimTimestamp, test.ExpectValid)
 		})
-		if test.SkipChallenger {
-			continue
-		}
 		t.Run(test.Name+"-challenger", func(t devtest.T) {
 			runChallengerProviderTest(t, sys.SuperRoots.QueryAPI(), gameDepth, startTimestamp, test.ClaimTimestamp, test)
 		})

--- a/op-supernode/supernode/activity/superroot/superroot.go
+++ b/op-supernode/supernode/activity/superroot/superroot.go
@@ -53,9 +53,9 @@ func (s *Superroot) atTimestamp(ctx context.Context, timestamp uint64) (eth.Supe
 	}
 
 	var (
-		optimistic            = make(map[eth.ChainID]eth.OutputWithRequiredL1, len(s.chains))
-		minVerifiedRequiredL1 eth.BlockID
-		chainOutputs          = make([]eth.ChainIDAndOutput, 0, len(s.chains))
+		optimistic         = make(map[eth.ChainID]eth.OutputWithRequiredL1, len(s.chains))
+		verifiedRequiredL1 eth.BlockID
+		chainOutputs       = make([]eth.ChainIDAndOutput, 0, len(s.chains))
 	)
 
 	notFound := false
@@ -70,9 +70,10 @@ func (s *Superroot) atTimestamp(ctx context.Context, timestamp uint64) (eth.Supe
 			s.log.Warn("failed to get verified block", "chain_id", chainID.String(), "err", err)
 			return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("failed to get verified block: %w", err)
 		}
-		// Verified data is available: update min required L1 and collect the output root
-		if verifiedL1.Number < minVerifiedRequiredL1.Number || minVerifiedRequiredL1 == (eth.BlockID{}) {
-			minVerifiedRequiredL1 = verifiedL1
+		// Verified data is available: track the L1 block that includes the data
+		// for every chain — i.e. the MAX of per-chain minimum-required L1s.
+		if verifiedL1.Number > verifiedRequiredL1.Number {
+			verifiedRequiredL1 = verifiedL1
 		}
 		// Compute output root at or before timestamp using the verified L2 block number
 		outRoot, err := chain.OutputRootAtL2BlockNumber(ctx, verifiedL2.Number)
@@ -121,7 +122,7 @@ func (s *Superroot) atTimestamp(ctx context.Context, timestamp uint64) (eth.Supe
 		superV1 := eth.NewSuperV1(timestamp, chainOutputs...)
 		superRoot := eth.SuperRoot(superV1)
 		response.Data = &eth.SuperRootResponseData{
-			VerifiedRequiredL1: minVerifiedRequiredL1,
+			VerifiedRequiredL1: verifiedRequiredL1,
 			Super:              superV1,
 			SuperRoot:          superRoot,
 		}

--- a/op-supernode/supernode/activity/superroot/superroot_test.go
+++ b/op-supernode/supernode/activity/superroot/superroot_test.go
@@ -161,7 +161,9 @@ func TestSuperroot_AtTimestamp_Succeeds(t *testing.T) {
 	require.Equal(t, uint64(170), out.CurrentSafeTimestamp)
 	require.Equal(t, uint64(180), out.CurrentLocalSafeTimestamp)
 	require.Equal(t, uint64(140), out.CurrentFinalizedTimestamp)
-	require.Equal(t, uint64(1000), out.Data.VerifiedRequiredL1.Number)
+	// VerifiedRequiredL1 is the MAX of per-chain required L1s — the L1 block
+	// that includes data for every chain.
+	require.Equal(t, uint64(1100), out.Data.VerifiedRequiredL1.Number)
 	// With zero outputs, the superroot will be deterministic, just ensure it's set
 	_ = out.Data.SuperRoot
 }


### PR DESCRIPTION
Resolves ethereum-optimism/optimism#20481. `Superroot.atTimestamp` was tracking the MIN of per-chain `VerifiedAt` L1 blocks; per the field's docstring it should be the MAX (the L1 block including data for *every* chain). Renames the local `minVerifiedRequiredL1` accordingly.

Also unskips the two challenger subtests that worked around this bug (`DisputeTimestampAfterChainHeadConsolidate-challenger`, `DisputeBlockAfterChainHead-FirstChain-challenger`) and drops the now-unused `SkipChallenger` field on `transitionTest`.

Stacked on top of ethereum-optimism/optimism#20482, which carries the test-setup tightening that the MAX semantics surfaced.

## Test plan

All `superfaultproofs.go`-using tests run locally and passing:

- [x] `op-supernode/.../superroot` unit tests
- [x] `interop/proofs/serial` (all 12 tests, including `TestInteropFaultProofs`, `_VariedBlockTimes`, `_VariedBlockTimes_FasterChainB`)
- [x] `interop/proofs-singlechain` (`TestInteropSingleChainFaultProofs`)
- [x] `isthmus/preinterop` (`TestPreinteropFaultProofs`, `_VariedBlockTimes`, `_VariedBlockTimes_FasterChainB`, `_TraceExtensionActivation`, `_UnsafeProposal`)
- [x] `isthmus/preinterop-singlechain` (`TestPreinteropSingleChainFaultProofs`)

`TestChallengerPlaysGame` (`isthmus/preinterop/challenger_test.go`) failed with `context deadline exceeded` waiting for a counter-claim. It does not use `superfaultproofs.go` and is unrelated to this change.