### PR TITLE
fix(op-reth): commit RW txn before init_from_state_dump to fix init-state stall

### DIFF
--- a/rust/op-reth/crates/cli/src/commands/init_state.rs
+++ b/rust/op-reth/crates/cli/src/commands/init_state.rs
@@ -12,7 +12,8 @@ use reth_optimism_primitives::{
 };
 use reth_primitives_traits::{SealedHeader, header::HeaderMut};
 use reth_provider::{
-    BlockNumReader, DatabaseProviderFactory, StaticFileProviderFactory, StaticFileWriter,
+    BlockNumReader, DBProvider, DatabaseProviderFactory, StaticFileProviderFactory,
+    StaticFileWriter,
 };
 use std::{io::BufReader, sync::Arc};
 use tracing::info;
@@ -94,6 +95,11 @@ impl<C: ChainSpecParser<ChainSpec = OpChainSpec>> InitStateCommandOp<C> {
                 "Data directory should be empty when calling init-state with --without-ovm."
             ));
         }
+
+        // Commit the RW provider before `init_from_state_dump`: that call opens its own
+        // RW transaction via `provider_factory`, and MDBX permits only one writer at a time —
+        // holding `provider_rw` here would deadlock the inner txn.
+        provider_rw.commit()?;
 
         info!(target: "reth::cli", "Initiating state dump");
 


### PR DESCRIPTION
## Summary

- `op-reth init-state --without-ovm` on `develop` stalls right after `Initiating state dump` with `Process stalled, awaiting read-write transaction lock` (no progress, MDBX deadlock).
- Cause: in `execute_with_bedrock_header`, a RW provider `provider_rw = provider_factory.database_provider_rw()?` is acquired up-front (for the optional bedrock setup branch). The current `init_from_state_dump` signature takes a `DatabaseProviderFactory` and opens its own RW transaction internally. MDBX permits only one writer at a time, so the inner txn waits forever for the outer one to release.
- Fix: `provider_rw.commit()?` before invoking `init_from_state_dump`, so the writer lock is released before the inner transaction is opened.

The bug entered in #20169 (`chore(rust): bump revm to 38`), which switched the second arg from `&provider_rw` to `&provider_factory` (forced by an upstream API change in `init_from_state_dump`) but did not commit/drop the now-redundant outer RW txn. It was briefly fixed-by-accident in #20236, then re-introduced by the same hunk in #20300.

Fixes #20464

## Test plan

- [x] `cargo check -p reth-optimism-cli` (verified locally — clean build).
- [x] Build `op-reth` and run `op-reth init-state --without-ovm --chain optimism --datadir <fresh> <state-dump>` against a fresh datadir; expect the state dump to proceed past `Initiating state dump` and emit the usual `parsed_new_accounts` / `Writing accounts to db` / `Genesis block written` log progression (matching the v1.11.0 trace in the issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)