### PR TITLE
fix(ci): remove "non-docs" path filtering 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,6 @@ workflows:
             .* c-github-event-base64 << pipeline.parameters.github-event-base64 >> .circleci/continue/main.yml
             .* c-go-cache-version << pipeline.parameters.go-cache-version >> .circleci/continue/main.yml
             rust/.* c-rust_files_changed true .circleci/continue/main.yml
-            ^(?!docs/public-docs/).+ c-non_docs_changes true .circleci/continue/main.yml
             (packages/contracts-bedrock|\.circleci|\.github|ops/check-changed)/.* c-contracts_changed true .circleci/continue/main.yml
             ^(package\.json|mise\.toml)$ c-contracts_changed true .circleci/continue/main.yml
 
@@ -128,7 +127,6 @@ workflows:
             .* c-go-cache-version << pipeline.parameters.go-cache-version >> .circleci/continue/rust-ci.yml
             .* c-rust_ci_dispatch << pipeline.parameters.rust_ci_dispatch >> .circleci/continue/rust-ci.yml
             (rust|\.circleci)/.* c-rust_changes_detected true .circleci/continue/rust-ci.yml
-            ^(?!docs/public-docs/).+ c-non_docs_changes true .circleci/continue/rust-ci.yml
 
             # Rust E2E — always include config, gate jobs via c-rust_changes_detected
             .* c-default_docker_image << pipeline.parameters.default_docker_image >> .circleci/continue/rust-e2e.yml
@@ -136,7 +134,6 @@ workflows:
             .* c-go-cache-version << pipeline.parameters.go-cache-version >> .circleci/continue/rust-e2e.yml
             .* c-rust_e2e_dispatch << pipeline.parameters.rust_e2e_dispatch >> .circleci/continue/rust-e2e.yml
             (rust|op-e2e|\.circleci)/.* c-rust_changes_detected true .circleci/continue/rust-e2e.yml
-            ^(?!docs/public-docs/).+ c-non_docs_changes true .circleci/continue/rust-e2e.yml
 
   setup-tag:
     when:

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -71,11 +71,6 @@ parameters:
   c-rust_files_changed:
     type: boolean
     default: false
-  # Set to true by path-filtering when files outside docs/public-docs/ change.
-  # When false, the main workflow is skipped entirely (docs-only PR).
-  c-non_docs_changes:
-    type: boolean
-    default: false
   # go-cache-version can be used as a cache buster when making breaking changes to caching strategy
   c-go-cache-version:
     type: string
@@ -2470,7 +2465,6 @@ workflows:
         - or:
             - and:
                 - equal: ["webhook", << pipeline.trigger_source >>]
-                - << pipeline.parameters.c-non_docs_changes >>
             - and:
                 - equal: [true, <<pipeline.parameters.c-main_dispatch>>]
                 - equal: ["api", << pipeline.trigger_source >>]
@@ -2760,18 +2754,6 @@ workflows:
           name: generate-flaky-tests-report
           context:
             - circleci-repo-readonly-authenticated-github-token
-            - circleci-api-token
-
-  main-skip:
-    when:
-      and:
-        - equal: ["", << pipeline.git.tag >>]
-        - equal: ["webhook", << pipeline.trigger_source >>]
-        - not: << pipeline.parameters.c-non_docs_changes >>
-    jobs:
-      - ci-gate:
-          always-succeed: true
-          context:
             - circleci-api-token
 
   go-release-op-deployer:
@@ -3084,12 +3066,10 @@ workflows:
         - and:
             - equal: ["webhook", << pipeline.trigger_source >>]
             - << pipeline.parameters.c-contracts_changed >>
-            - << pipeline.parameters.c-non_docs_changes >>
         # Always run on develop (mirrors previous check-changed whitelist behavior)
         - and:
             - equal: ["webhook", << pipeline.trigger_source >>]
             - equal: ["develop", << pipeline.git.branch >>]
-            - << pipeline.parameters.c-non_docs_changes >>
         # Merge queue (merge gate). Match checkout branch.
         - matches:
             pattern: "^gh-readonly-queue/.*"
@@ -3273,19 +3253,17 @@ workflows:
           - and:
               - equal: ["webhook", << pipeline.trigger_source >>]
               - << pipeline.parameters.c-contracts_changed >>
-              - << pipeline.parameters.c-non_docs_changes >>
           # Always run on develop (mirrors previous check-changed whitelist behavior)
           - and:
               - equal: ["webhook", << pipeline.trigger_source >>]
               - equal: ["develop", << pipeline.git.branch >>]
-              - << pipeline.parameters.c-non_docs_changes >>
           # Merge queue (merge gate). Match checkout branch.
           - matches:
               pattern: "^gh-readonly-queue/.*"
               value: << pipeline.git.branch >>
           - and:
-            - equal: [true, <<pipeline.parameters.c-main_dispatch>>]
-            - equal: ["api", << pipeline.trigger_source >>]
+              - equal: [true, <<pipeline.parameters.c-main_dispatch>>]
+              - equal: ["api", << pipeline.trigger_source >>]
     jobs:
       - required-contracts-ci:
           always-succeed: true

--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -1083,9 +1083,27 @@ workflows:
       # -----------------------------------------------------------------------
       - required-rust-ci:
           requires:
-            - rust-tests: terminal
+            - rust-fmt: terminal
             - rust-clippy: terminal
+            - rust-deny: terminal
+            - rust-typos: terminal
+            - rust-zepter: terminal
+            - rust-tests: terminal
+            - rust-doctest: terminal
             - rust-docs: terminal
+            - rust-udeps: terminal
+            - rust-cargo-hack: terminal
+            - rust-build: terminal
+            - rust-build-release: terminal
+            - rust-check-no-std: terminal
+            - rust-wasm-unknown: terminal
+            - rust-wasm-wasi: terminal
+            - op-reth-compact-codec: terminal
+            - op-reth-integration-tests: terminal
+            - kona-lint-cannon: terminal
+            - kona-build-fpvm-cannon-client: terminal
+            - kona-coverage: terminal
+            - kona-host-client-offline-cannon: terminal
           context:
             - circleci-api-token
   # =====================================

--- a/.circleci/continue/rust-e2e.yml
+++ b/.circleci/continue/rust-e2e.yml
@@ -24,9 +24,6 @@ parameters:
   c-rust_changes_detected:
     type: boolean
     default: false
-  c-non_docs_changes:
-    type: boolean
-    default: false
   # Passthrough declarations for setup config parameters.
   # CircleCI forwards all explicitly-passed pipeline parameters to continuation configs.
   # Without these declarations, manually triggered pipelines fail with "Unexpected argument(s)".
@@ -311,7 +308,6 @@ workflows:
         - and:
             - equal: ["webhook", << pipeline.trigger_source >>]
             - << pipeline.parameters.c-rust_changes_detected >>
-            - << pipeline.parameters.c-non_docs_changes >>
         - and:
             - equal: [true, <<pipeline.parameters.c-rust_e2e_dispatch>>]
             - equal: ["api", << pipeline.trigger_source >>]
@@ -347,7 +343,8 @@ workflows:
           name: rust-e2e-<<matrix.devnet_config>>
           matrix:
             parameters:
-              devnet_config: ["simple-kona", "simple-kona-geth", "simple-kona-sequencer"]
+              devnet_config:
+                ["simple-kona", "simple-kona-geth", "simple-kona-sequencer"]
           context:
             - circleci-repo-readonly-authenticated-github-token
           requires:
@@ -395,7 +392,6 @@ workflows:
       and:
         - equal: ["webhook", << pipeline.trigger_source >>]
         - not: << pipeline.parameters.c-rust_changes_detected >>
-        - << pipeline.parameters.c-non_docs_changes >>
     jobs:
       - contracts-bedrock-build:
           build_args: --skip test

--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -70,7 +70,7 @@ exceptions = [
   # gmp feature (optional, LGPL-licensed)
   # gmp-mpfr-sys uses deprecated "LGPL-3.0+" identifier; equivalent to "LGPL-3.0-or-later"
   { allow = ["LGPL-3.0-or-later"], crate = "rug" },
-  { allow = ["LGPL-3.0-or-later", "LGPL-3.0+"], crate = "gmp-mpfr-sys" },
+  { allow = ["LGPL-3.0-or-later", "LGPL-3.0"], crate = "gmp-mpfr-sys" },
   # Grandfathered MPL-2.0 exceptions from op-reth
   { allow = ["MPL-2.0"], name = "option-ext" },
   { allow = ["MPL-2.0"], name = "webpki-root-certs" },

--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -68,8 +68,9 @@ exceptions = [
   # aws-lc-sys includes OpenSSL in its composite license expression
   { allow = ["OpenSSL"], name = "aws-lc-sys" },
   # gmp feature (optional, LGPL-licensed)
+  # gmp-mpfr-sys uses deprecated "LGPL-3.0+" identifier; equivalent to "LGPL-3.0-or-later"
   { allow = ["LGPL-3.0-or-later"], crate = "rug" },
-  { allow = ["LGPL-3.0-or-later"], crate = "gmp-mpfr-sys" },
+  { allow = ["LGPL-3.0-or-later", "LGPL-3.0+"], crate = "gmp-mpfr-sys" },
   # Grandfathered MPL-2.0 exceptions from op-reth
   { allow = ["MPL-2.0"], name = "option-ext" },
   { allow = ["MPL-2.0"], name = "webpki-root-certs" },


### PR DESCRIPTION
This gives certainty that `required-rust-e2e` (a fan-in terminal job which accumulates the status of either the full rust e2e suite, or trivial checks) always runs. This allows us to require it as a check in the github repo settings. 

Also adds more dependency connections to the `required-rust-ci` job, so that if any job failes this job (which we will also make a required check) will fail. 