### PR TITLE
refactor(kona): make debug_executePayload witness collection the default

### DIFF
--- a/op-challenger/flags/flags.go
+++ b/op-challenger/flags/flags.go
@@ -231,15 +231,6 @@ var (
 		Value:   false,
 		Hidden:  true,
 	}
-	CannonKonaExperimentalWitnessEndpointFlag = &cli.BoolFlag{
-		Name: "cannon-kona-experimental-witness-endpoint",
-		Usage: "Enable experimental witness endpoint for Kona interop. " +
-			"Uses debug_executePayload RPC to collect execution witnesses, " +
-			"reducing proof generation time by avoiding re-execution. " +
-			"Requires op-reth or execution client started with " +
-			"--proofs-history enabled to provide debug_executePayload support.",
-		EnvVars: prefixEnvVars("CANNON_KONA_EXPERIMENTAL_WITNESS_ENDPOINT"),
-	}
 	GameWindowFlag = &cli.DurationFlag{
 		Name: "game-window",
 		Usage: "The time window which the challenger will look for games to progress and claim bonds. " +
@@ -304,7 +295,6 @@ var optionalFlags = []cli.Flag{
 	CannonKonaServerFlag,
 	CannonKonaPreStateFlag,
 	CannonKonaL2CustomFlag,
-	CannonKonaExperimentalWitnessEndpointFlag,
 	GameWindowFlag,
 	SelectiveClaimResolutionFlag,
 	UnsafeAllowInvalidPrestate,
@@ -647,24 +637,23 @@ func NewConfigFromCLI(ctx *cli.Context, logger log.Logger) (*config.Config, erro
 		CannonAbsolutePreState:        ctx.String(CannonPreStateFlag.Name),
 		CannonAbsolutePreStateBaseURL: cannonPreStatesURL,
 		CannonKona: vm.Config{
-			VmType:                            gameTypes.CannonKonaGameType,
-			L1:                                l1EthRpc,
-			L1Beacon:                          l1Beacon,
-			L2s:                               l2Rpcs,
-			L2Experimental:                    l2Experimental,
-			VmBin:                             ctx.String(CannonBinFlag.Name),
-			Server:                            ctx.String(CannonKonaServerFlag.Name),
-			Networks:                          networks,
-			L2Custom:                          ctx.Bool(CannonKonaL2CustomFlag.Name),
-			RollupConfigPaths:                 RollupConfigFlag.StringSlice(ctx, gameTypes.CannonKonaGameType),
-			L1GenesisPath:                     L1GenesisFlag.String(ctx, gameTypes.CannonKonaGameType),
-			L2GenesisPaths:                    L2GenesisFlag.StringSlice(ctx, gameTypes.CannonKonaGameType),
-			DepsetConfigPath:                  DepsetConfigFlag.String(ctx, gameTypes.CannonKonaGameType),
-			SnapshotFreq:                      ctx.Uint(CannonSnapshotFreqFlag.Name),
-			InfoFreq:                          ctx.Uint(CannonInfoFreqFlag.Name),
-			DebugInfo:                         true,
-			BinarySnapshots:                   true,
-			EnableExperimentalWitnessEndpoint: ctx.Bool(CannonKonaExperimentalWitnessEndpointFlag.Name),
+			VmType:            gameTypes.CannonKonaGameType,
+			L1:                l1EthRpc,
+			L1Beacon:          l1Beacon,
+			L2s:               l2Rpcs,
+			L2Experimental:    l2Experimental,
+			VmBin:             ctx.String(CannonBinFlag.Name),
+			Server:            ctx.String(CannonKonaServerFlag.Name),
+			Networks:          networks,
+			L2Custom:          ctx.Bool(CannonKonaL2CustomFlag.Name),
+			RollupConfigPaths: RollupConfigFlag.StringSlice(ctx, gameTypes.CannonKonaGameType),
+			L1GenesisPath:     L1GenesisFlag.String(ctx, gameTypes.CannonKonaGameType),
+			L2GenesisPaths:    L2GenesisFlag.StringSlice(ctx, gameTypes.CannonKonaGameType),
+			DepsetConfigPath:  DepsetConfigFlag.String(ctx, gameTypes.CannonKonaGameType),
+			SnapshotFreq:      ctx.Uint(CannonSnapshotFreqFlag.Name),
+			InfoFreq:          ctx.Uint(CannonInfoFreqFlag.Name),
+			DebugInfo:         true,
+			BinarySnapshots:   true,
 		},
 		CannonKonaAbsolutePreState:        ctx.String(CannonKonaPreStateFlag.Name),
 		CannonKonaAbsolutePreStateBaseURL: cannonKonaPreStatesURL,

--- a/op-challenger/game/fault/trace/vm/executor.go
+++ b/op-challenger/game/fault/trace/vm/executor.go
@@ -60,13 +60,6 @@ type Config struct {
 	L1GenesisPath     string
 	L2GenesisPaths    []string
 	DepsetConfigPath  string
-
-	// EnableExperimentalWitnessEndpoint enables kona's L2PayloadWitness hint,
-	// which uses debug_executePayload to collect execution witnesses.
-	// This can reduce proof generation time by avoiding full block re-derivation
-	// and re-execution. Requires an execution client with debug_executePayload
-	// support (e.g., op-reth).
-	EnableExperimentalWitnessEndpoint bool
 }
 
 func (c *Config) Check() error {

--- a/op-challenger/game/fault/trace/vm/kona_server_executor.go
+++ b/op-challenger/game/fault/trace/vm/kona_server_executor.go
@@ -61,9 +61,5 @@ func (s *KonaExecutor) OracleCommand(cfg Config, dataDir string, inputs utils.Lo
 		args = append(args, "--l1-config-path", cfg.L1GenesisPath)
 	}
 
-	if cfg.EnableExperimentalWitnessEndpoint {
-		args = append(args, "--enable-experimental-witness-endpoint")
-	}
-
 	return args, nil
 }

--- a/op-challenger/game/fault/trace/vm/kona_server_executor_test.go
+++ b/op-challenger/game/fault/trace/vm/kona_server_executor_test.go
@@ -10,54 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestKonaExecutorWithWitnessEndpoint(t *testing.T) {
-	t.Parallel()
-	executor := NewKonaExecutor()
-	cfg := Config{
-		Server:                            "/path/to/kona",
-		L1:                                "http://l1",
-		L1Beacon:                          "http://beacon",
-		L2s:                               []string{"http://l2"},
-		Networks:                          []string{"op-sepolia"},
-		EnableExperimentalWitnessEndpoint: true,
-	}
-	inputs := utils.LocalGameInputs{
-		L1Head:           common.Hash{0x11},
-		L2Head:           common.Hash{0x22},
-		L2OutputRoot:     common.Hash{0x33},
-		L2Claim:          common.Hash{0x44},
-		L2SequenceNumber: big.NewInt(100),
-	}
-
-	args, err := executor.OracleCommand(cfg, "/data", inputs)
-	require.NoError(t, err)
-	require.True(t, slices.Contains(args, "--enable-experimental-witness-endpoint"))
-}
-
-func TestKonaExecutorWithoutWitnessEndpoint(t *testing.T) {
-	t.Parallel()
-	executor := NewKonaExecutor()
-	cfg := Config{
-		Server:                            "/path/to/kona",
-		L1:                                "http://l1",
-		L1Beacon:                          "http://beacon",
-		L2s:                               []string{"http://l2"},
-		Networks:                          []string{"op-sepolia"},
-		EnableExperimentalWitnessEndpoint: false,
-	}
-	inputs := utils.LocalGameInputs{
-		L1Head:           common.Hash{0x11},
-		L2Head:           common.Hash{0x22},
-		L2OutputRoot:     common.Hash{0x33},
-		L2Claim:          common.Hash{0x44},
-		L2SequenceNumber: big.NewInt(100),
-	}
-
-	args, err := executor.OracleCommand(cfg, "/data", inputs)
-	require.NoError(t, err)
-	require.False(t, slices.Contains(args, "--enable-experimental-witness-endpoint"))
-}
-
 func TestKonaFillHostCommand(t *testing.T) {
 	dir := "mockdir"
 	cfg := Config{

--- a/op-challenger/game/fault/trace/vm/kona_super_server_executor.go
+++ b/op-challenger/game/fault/trace/vm/kona_super_server_executor.go
@@ -58,9 +58,5 @@ func (s *KonaSuperExecutor) OracleCommand(cfg Config, dataDir string, inputs uti
 		args = append(args, "--depset-cfg", cfg.DepsetConfigPath)
 	}
 
-	if cfg.EnableExperimentalWitnessEndpoint {
-		args = append(args, "--enable-experimental-witness-endpoint")
-	}
-
 	return args, nil
 }

--- a/op-challenger/game/fault/trace/vm/kona_super_server_executor_test.go
+++ b/op-challenger/game/fault/trace/vm/kona_super_server_executor_test.go
@@ -10,28 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestKonaSuperExecutorWithWitnessEndpoint(t *testing.T) {
-	t.Parallel()
-	executor := NewKonaSuperExecutor()
-	cfg := Config{
-		Server:                            "/path/to/kona",
-		L1:                                "http://l1",
-		L1Beacon:                          "http://beacon",
-		L2s:                               []string{"http://l2a", "http://l2b"},
-		EnableExperimentalWitnessEndpoint: true,
-	}
-	inputs := utils.LocalGameInputs{
-		L1Head:           common.Hash{0x11},
-		AgreedPreState:   []byte{0x01, 0x02},
-		L2Claim:          common.Hash{0x44},
-		L2SequenceNumber: big.NewInt(100),
-	}
-
-	args, err := executor.OracleCommand(cfg, "/data", inputs)
-	require.NoError(t, err)
-	require.True(t, slices.Contains(args, "--enable-experimental-witness-endpoint"))
-}
-
 func TestKonaSuperExecutorWithDepsetConfig(t *testing.T) {
 	t.Parallel()
 	executor := NewKonaSuperExecutor()
@@ -75,26 +53,4 @@ func TestKonaSuperExecutorWithoutDepsetConfig(t *testing.T) {
 	args, err := executor.OracleCommand(cfg, "/data", inputs)
 	require.NoError(t, err)
 	require.False(t, slices.Contains(args, "--depset-cfg"))
-}
-
-func TestKonaSuperExecutorWithoutWitnessEndpoint(t *testing.T) {
-	t.Parallel()
-	executor := NewKonaSuperExecutor()
-	cfg := Config{
-		Server:                            "/path/to/kona",
-		L1:                                "http://l1",
-		L1Beacon:                          "http://beacon",
-		L2s:                               []string{"http://l2a", "http://l2b"},
-		EnableExperimentalWitnessEndpoint: false,
-	}
-	inputs := utils.LocalGameInputs{
-		L1Head:           common.Hash{0x11},
-		AgreedPreState:   []byte{0x01, 0x02},
-		L2Claim:          common.Hash{0x44},
-		L2SequenceNumber: big.NewInt(100),
-	}
-
-	args, err := executor.OracleCommand(cfg, "/data", inputs)
-	require.NoError(t, err)
-	require.False(t, slices.Contains(args, "--enable-experimental-witness-endpoint"))
 }

--- a/op-devstack/shared/challenger/challenger.go
+++ b/op-devstack/shared/challenger/challenger.go
@@ -216,17 +216,6 @@ func WithFastGames() Option {
 	}
 }
 
-// WithExperimentalWitnessEndpoint enables kona's experimental witness endpoint feature.
-// This uses debug_executePayload to collect execution witnesses, reducing proof generation
-// time by avoiding full block re-derivation and re-execution.
-// Requires op-reth or execution client with debug_executePayload support.
-func WithExperimentalWitnessEndpoint() Option {
-	return func(_ context.Context, c *config.Config) error {
-		c.CannonKona.EnableExperimentalWitnessEndpoint = true
-		return nil
-	}
-}
-
 func NewInteropChallengerConfig(ctx context.Context, dir string, l1Endpoint string, l1Beacon string, supervisorEndpoint string, l2Endpoints []string, options ...Option) (*config.Config, error) {
 	cfg := config.NewInteropConfig(common.Address{}, l1Endpoint, l1Beacon, supervisorEndpoint, l2Endpoints, dir)
 	if err := applyCommonChallengerOpts(ctx, &cfg, options...); err != nil {

--- a/op-devstack/sysgo/multichain_proofs.go
+++ b/op-devstack/sysgo/multichain_proofs.go
@@ -332,7 +332,6 @@ func startInteropChallenger(
 		sharedchallenger.WithSuperPermissionedGameType(),
 		sharedchallenger.WithCannonKonaInteropConfig(rollupCfgs, l1Net.genesis, l2Geneses),
 		sharedchallenger.WithSuperCannonKonaGameType(),
-		sharedchallenger.WithExperimentalWitnessEndpoint(),
 	}
 	cfg, err := sharedchallenger.NewInteropChallengerConfig(
 		t.Ctx(),

--- a/op-devstack/sysgo/singlechain_runtime.go
+++ b/op-devstack/sysgo/singlechain_runtime.go
@@ -339,7 +339,6 @@ func startMinimalChallenger(
 		sharedchallenger.WithFastGames(),
 		sharedchallenger.WithCannonKonaConfig(rollupCfgs, l1Net.genesis, l2Geneses),
 		sharedchallenger.WithCannonKonaGameType(),
-		sharedchallenger.WithExperimentalWitnessEndpoint(),
 	}
 	cfg, err := sharedchallenger.NewPreInteropChallengerConfig(
 		t.Ctx(),

--- a/rust/kona/bin/host/src/interop/cfg.rs
+++ b/rust/kona/bin/host/src/interop/cfg.rs
@@ -109,10 +109,6 @@ pub struct InteropHost {
     /// dependency set. The config should be stored as a serde-JSON serialized file.
     #[arg(long, alias = "depset-cfg", env)]
     pub dependency_set_path: Option<PathBuf>,
-    /// Optionally enables the use of `debug_executePayload` to collect the execution witness from
-    /// the execution layer.
-    #[arg(long, env)]
-    pub enable_experimental_witness_endpoint: bool,
 }
 
 /// An error that can occur when handling interop hosts

--- a/rust/kona/bin/host/src/interop/handler.rs
+++ b/rust/kona/bin/host/src/interop/handler.rs
@@ -37,7 +37,7 @@ use kona_registry::{L1_CONFIGS, ROLLUP_CONFIGS};
 use op_alloy_rpc_types_engine::OpPayloadAttributes;
 use std::sync::Arc;
 use tokio::task;
-use tracing::{Instrument, debug, info, info_span, warn};
+use tracing::{Instrument, debug, info, info_span};
 
 /// Parses the binary framing of a [`HintType::L2PayloadWitness`] hint.
 ///
@@ -668,25 +668,16 @@ impl HintHandler for InteropHintHandler {
                 );
             }
             HintType::L2PayloadWitness => {
-                // 1. Check feature flag
-                if !cfg.enable_experimental_witness_endpoint {
-                    warn!(
-                        target: "interop_hint_handler",
-                        "L2PayloadWitness hint was sent, but payload witness is disabled. Skipping hint."
-                    );
-                    return Ok(());
-                }
-
-                // 2. Parse hint data
+                // 1. Parse hint data
                 let (parent_block_hash, payload_attributes_bytes, chain_id) =
                     parse_l2_payload_witness_hint(&hint.data)?;
                 let payload_attributes: OpPayloadAttributes =
                     serde_json::from_slice(payload_attributes_bytes)?;
 
-                // 3. Route to correct L2 provider
+                // 2. Route to correct L2 provider
                 let l2_provider = providers.l2(&chain_id)?;
 
-                // 4. Call debug_executePayload RPC
+                // 3. Call debug_executePayload RPC
                 let execute_payload_response = match l2_provider
                     .client()
                     .request::<(B256, OpPayloadAttributes), ExecutionWitness>(
@@ -708,7 +699,7 @@ impl HintHandler for InteropHintHandler {
                     }
                 };
 
-                // 5. Store preimages in KV store
+                // 4. Store preimages in KV store
                 let preimages = execute_payload_response
                     .state
                     .into_iter()

--- a/rust/kona/bin/host/src/single/cfg.rs
+++ b/rust/kona/bin/host/src/single/cfg.rs
@@ -113,10 +113,6 @@ pub struct SingleChainHost {
     /// look up the config in the known l1 configs.
     #[arg(long, alias = "l1-cfg", env)]
     pub l1_config_path: Option<PathBuf>,
-    /// Optionally enables the use of `debug_executePayload` to collect the execution witness from
-    /// the execution layer.
-    #[arg(long, env)]
-    pub enable_experimental_witness_endpoint: bool,
 }
 
 /// An error that can occur when handling single chain hosts
@@ -345,18 +341,6 @@ mod test {
                     "--server",
                     "--l2-chain-id",
                     "0",
-                ]
-                .as_slice(),
-                true,
-            ),
-            (
-                [
-                    "--server",
-                    "--l2-chain-id",
-                    "0",
-                    "--data-dir",
-                    "dummy",
-                    "--enable-experimental-witness-endpoint",
                 ]
                 .as_slice(),
                 true,

--- a/rust/kona/bin/host/src/single/handler.rs
+++ b/rust/kona/bin/host/src/single/handler.rs
@@ -399,14 +399,6 @@ impl HintHandler for SingleChainHintHandler {
                 })?;
             }
             HintType::L2PayloadWitness => {
-                if !cfg.enable_experimental_witness_endpoint {
-                    warn!(
-                        target: "single_hint_handler",
-                        "L2PayloadWitness hint was sent, but payload witness is disabled. Skipping hint."
-                    );
-                    return Ok(());
-                }
-
                 ensure!(hint.data.len() >= 32, "Invalid hint data length");
 
                 let parent_block_hash = B256::from_slice(&hint.data.as_ref()[..32]);


### PR DESCRIPTION
Graduate the `L2PayloadWitness` hint out of experimental: drop the `--cannon-kona-experimental-witness-endpoint` flag from op-challenger, the `WithExperimentalWitnessEndpoint` helper from op-devstack, and the `enable_experimental_witness_endpoint` field on kona's `SingleChainHost` and `InteropHost` configs. The kona handlers now run the `debug_executePayload`-based witness path unconditionally; the silent fallback when an EL doesn't implement the RPC is preserved, so non-reth ELs (op-geth) continue to work via the legacy proof path.

The cannon-kona acceptance suite has been exercising this path under op-reth with `--proofs-history` since #19408 introduced the flag, so this change just removes the now-redundant opt-in.

**Breaking change:** any operator passing `--cannon-kona-experimental-witness-endpoint` or setting `CANNON_KONA_EXPERIMENTAL_WITNESS_ENDPOINT` in op-challenger configs must remove those — op-challenger will reject them as unknown. 
