### PR TITLE
op-challenger: route SuperPermissionedGameType through cannon-kona

### DIFF
--- a/op-challenger/cmd/main_test.go
+++ b/op-challenger/cmd/main_test.go
@@ -491,7 +491,7 @@ func TestCannonCustomConfigArgs(t *testing.T) {
 }
 
 func TestSuperCannonCustomConfigArgs(t *testing.T) {
-	for _, gameType := range []gameTypes.GameType{gameTypes.SuperCannonGameType, gameTypes.SuperPermissionedGameType} {
+	for _, gameType := range []gameTypes.GameType{gameTypes.SuperCannonGameType} {
 		gameType := gameType
 
 		t.Run(fmt.Sprintf("TestRequireEitherCannonNetworkOrRollupAndGenesisAndDepset-%v", gameType), func(t *testing.T) {
@@ -578,92 +578,94 @@ func TestSuperCannonCustomConfigArgs(t *testing.T) {
 }
 
 func TestSuperCannonKonaCustomConfigArgs(t *testing.T) {
-	gameType := gameTypes.SuperCannonKonaGameType
+	for _, gameType := range []gameTypes.GameType{gameTypes.SuperCannonKonaGameType, gameTypes.SuperPermissionedGameType} {
+		gameType := gameType
 
-	t.Run(fmt.Sprintf("TestRequireEitherCannonKonaNetworkOrRollupAndGenesisAndDepset-%v", gameType), func(t *testing.T) {
-		expectedErrorMessage := "flag network or rollup-config/cannon-kona-rollup-config, l2-genesis/cannon-kona-l2-genesis and depset-config/cannon-kona-depset-config is required"
-		// Missing all
-		verifyArgsInvalid(
-			t,
-			expectedErrorMessage,
-			addRequiredArgsExcept(gameType, "--network"))
-		// Missing l2-genesis
-		verifyArgsInvalid(
-			t,
-			expectedErrorMessage,
-			addRequiredArgsExcept(gameType, "--network", "--cannon-kona-rollup-config=rollup.json", "--cannon-kona-depset-config=depset.json"))
-		// Missing rollup-config
-		verifyArgsInvalid(
-			t,
-			expectedErrorMessage,
-			addRequiredArgsExcept(gameType, "--network", "--cannon-kona-l2-genesis=gensis.json", "--cannon-kona-depset-config=depset.json"))
-		// Missing depset-config
-		verifyArgsInvalid(
-			t,
-			expectedErrorMessage,
-			addRequiredArgsExcept(gameType, "--network", "--cannon-kona-rollup-config=rollup.json", "--cannon-kona-l2-genesis=gensis.json"))
-	})
-
-	validateCustomNetworkFlagsProhibitedWithNetworkFlag(t, gameType, gameTypes.CannonKonaGameType, "cannon-kona-l2-custom")
-
-	t.Run(fmt.Sprintf("TestNetwork-%v", gameType), func(t *testing.T) {
-		t.Run("NotRequiredWhenRollupGenesisAndDepsetIsSpecified", func(t *testing.T) {
-			configForArgs(t, addRequiredArgsExcept(gameType, "--network",
-				"--cannon-kona-rollup-config=rollup.json", "--cannon-kona-l2-genesis=genesis.json", "--cannon-kona-depset-config=depset.json"))
+		t.Run(fmt.Sprintf("TestRequireEitherCannonKonaNetworkOrRollupAndGenesisAndDepset-%v", gameType), func(t *testing.T) {
+			expectedErrorMessage := "flag network or rollup-config/cannon-kona-rollup-config, l2-genesis/cannon-kona-l2-genesis and depset-config/cannon-kona-depset-config is required"
+			// Missing all
+			verifyArgsInvalid(
+				t,
+				expectedErrorMessage,
+				addRequiredArgsExcept(gameType, "--network"))
+			// Missing l2-genesis
+			verifyArgsInvalid(
+				t,
+				expectedErrorMessage,
+				addRequiredArgsExcept(gameType, "--network", "--cannon-kona-rollup-config=rollup.json", "--cannon-kona-depset-config=depset.json"))
+			// Missing rollup-config
+			verifyArgsInvalid(
+				t,
+				expectedErrorMessage,
+				addRequiredArgsExcept(gameType, "--network", "--cannon-kona-l2-genesis=gensis.json", "--cannon-kona-depset-config=depset.json"))
+			// Missing depset-config
+			verifyArgsInvalid(
+				t,
+				expectedErrorMessage,
+				addRequiredArgsExcept(gameType, "--network", "--cannon-kona-rollup-config=rollup.json", "--cannon-kona-l2-genesis=gensis.json"))
 		})
 
-		t.Run("Valid", func(t *testing.T) {
-			cfg := configForArgs(t, addRequiredArgsExcept(gameType, "--network", "--network", testNetwork))
-			require.Equal(t, []string{testNetwork}, cfg.CannonKona.Networks)
-		})
-	})
+		validateCustomNetworkFlagsProhibitedWithNetworkFlag(t, gameType, gameTypes.CannonKonaGameType, "cannon-kona-l2-custom")
 
-	t.Run(fmt.Sprintf("TestSetCannonKonaL2ChainId-%v", gameType), func(t *testing.T) {
-		cfg := configForArgs(t, addRequiredArgsExcept(gameType, "--network",
-			"--cannon-kona-rollup-config=rollup.json",
-			"--cannon-kona-l2-genesis=genesis.json",
-			"--cannon-kona-depset-config=depset.json",
-			"--cannon-kona-l2-custom"))
-		require.True(t, cfg.CannonKona.L2Custom)
-	})
+		t.Run(fmt.Sprintf("TestNetwork-%v", gameType), func(t *testing.T) {
+			t.Run("NotRequiredWhenRollupGenesisAndDepsetIsSpecified", func(t *testing.T) {
+				configForArgs(t, addRequiredArgsExcept(gameType, "--network",
+					"--cannon-kona-rollup-config=rollup.json", "--cannon-kona-l2-genesis=genesis.json", "--cannon-kona-depset-config=depset.json"))
+			})
 
-	t.Run(fmt.Sprintf("TestCannonKonaRollupConfig-%v", gameType), func(t *testing.T) {
-		t.Run("NotRequiredForAlphabetTrace", func(t *testing.T) {
-			configForArgs(t, addRequiredArgsExcept(gameTypes.AlphabetGameType, "--cannon-kona-rollup-config"))
+			t.Run("Valid", func(t *testing.T) {
+				cfg := configForArgs(t, addRequiredArgsExcept(gameType, "--network", "--network", testNetwork))
+				require.Equal(t, []string{testNetwork}, cfg.CannonKona.Networks)
+			})
 		})
 
-		t.Run("Valid", func(t *testing.T) {
+		t.Run(fmt.Sprintf("TestSetCannonKonaL2ChainId-%v", gameType), func(t *testing.T) {
 			cfg := configForArgs(t, addRequiredArgsExcept(gameType, "--network",
-				"--cannon-kona-rollup-config=rollup.json", "--cannon-kona-l2-genesis=genesis.json", "--cannon-kona-depset-config=depset.json"))
-			require.Equal(t, []string{"rollup.json"}, cfg.CannonKona.RollupConfigPaths)
-		})
-	})
-
-	t.Run(fmt.Sprintf("TestCannonKonaL2Genesis-%v", gameType), func(t *testing.T) {
-		t.Run("NotRequiredForAlphabetTrace", func(t *testing.T) {
-			configForArgs(t, addRequiredArgsExcept(gameTypes.AlphabetGameType, "--cannon-kona-l2-genesis"))
+				"--cannon-kona-rollup-config=rollup.json",
+				"--cannon-kona-l2-genesis=genesis.json",
+				"--cannon-kona-depset-config=depset.json",
+				"--cannon-kona-l2-custom"))
+			require.True(t, cfg.CannonKona.L2Custom)
 		})
 
-		t.Run("Valid", func(t *testing.T) {
-			cfg := configForArgs(t, addRequiredArgsExcept(gameType, "--network", "--cannon-kona-rollup-config=rollup.json", "--cannon-kona-l2-genesis=genesis.json", "--cannon-kona-depset-config=depset.json"))
-			require.Equal(t, []string{"genesis.json"}, cfg.CannonKona.L2GenesisPaths)
-		})
-	})
+		t.Run(fmt.Sprintf("TestCannonKonaRollupConfig-%v", gameType), func(t *testing.T) {
+			t.Run("NotRequiredForAlphabetTrace", func(t *testing.T) {
+				configForArgs(t, addRequiredArgsExcept(gameTypes.AlphabetGameType, "--cannon-kona-rollup-config"))
+			})
 
-	t.Run(fmt.Sprintf("TestCannonKonaDepsetConfig-%v", gameType), func(t *testing.T) {
-		t.Run("NotRequiredForAlphabetTrace", func(t *testing.T) {
-			configForArgs(t, addRequiredArgsExcept(gameTypes.AlphabetGameType, "--cannon-kona-depset-config"))
+			t.Run("Valid", func(t *testing.T) {
+				cfg := configForArgs(t, addRequiredArgsExcept(gameType, "--network",
+					"--cannon-kona-rollup-config=rollup.json", "--cannon-kona-l2-genesis=genesis.json", "--cannon-kona-depset-config=depset.json"))
+				require.Equal(t, []string{"rollup.json"}, cfg.CannonKona.RollupConfigPaths)
+			})
 		})
 
-		t.Run("Valid", func(t *testing.T) {
-			cfg := configForArgs(t, addRequiredArgsExcept(gameType, "--network", "--cannon-kona-rollup-config=rollup.json", "--cannon-kona-l2-genesis=genesis.json", "--cannon-kona-depset-config=depset.json"))
-			require.Equal(t, "depset.json", cfg.CannonKona.DepsetConfigPath)
+		t.Run(fmt.Sprintf("TestCannonKonaL2Genesis-%v", gameType), func(t *testing.T) {
+			t.Run("NotRequiredForAlphabetTrace", func(t *testing.T) {
+				configForArgs(t, addRequiredArgsExcept(gameTypes.AlphabetGameType, "--cannon-kona-l2-genesis"))
+			})
+
+			t.Run("Valid", func(t *testing.T) {
+				cfg := configForArgs(t, addRequiredArgsExcept(gameType, "--network", "--cannon-kona-rollup-config=rollup.json", "--cannon-kona-l2-genesis=genesis.json", "--cannon-kona-depset-config=depset.json"))
+				require.Equal(t, []string{"genesis.json"}, cfg.CannonKona.L2GenesisPaths)
+			})
 		})
-	})
+
+		t.Run(fmt.Sprintf("TestCannonKonaDepsetConfig-%v", gameType), func(t *testing.T) {
+			t.Run("NotRequiredForAlphabetTrace", func(t *testing.T) {
+				configForArgs(t, addRequiredArgsExcept(gameTypes.AlphabetGameType, "--cannon-kona-depset-config"))
+			})
+
+			t.Run("Valid", func(t *testing.T) {
+				cfg := configForArgs(t, addRequiredArgsExcept(gameType, "--network", "--cannon-kona-rollup-config=rollup.json", "--cannon-kona-l2-genesis=genesis.json", "--cannon-kona-depset-config=depset.json"))
+				require.Equal(t, "depset.json", cfg.CannonKona.DepsetConfigPath)
+			})
+		})
+	}
 }
 
 func TestCannonRequiredArgs(t *testing.T) {
-	for _, gameType := range []gameTypes.GameType{gameTypes.CannonGameType, gameTypes.PermissionedGameType, gameTypes.SuperCannonGameType, gameTypes.SuperPermissionedGameType} {
+	for _, gameType := range []gameTypes.GameType{gameTypes.CannonGameType, gameTypes.PermissionedGameType, gameTypes.SuperCannonGameType} {
 		gameType := gameType
 		t.Run(fmt.Sprintf("TestCannonBin-%v", gameType), func(t *testing.T) {
 			t.Run("NotRequiredForAlphabetTrace", func(t *testing.T) {
@@ -801,15 +803,78 @@ func TestCannonRequiredArgs(t *testing.T) {
 	}
 }
 
+func TestCannonKonaRequiredArgs(t *testing.T) {
+	for _, gameType := range []gameTypes.GameType{gameTypes.CannonKonaGameType, gameTypes.SuperCannonKonaGameType, gameTypes.SuperPermissionedGameType} {
+		gameType := gameType
+		t.Run(fmt.Sprintf("TestCannonKonaServer-%v", gameType), func(t *testing.T) {
+			t.Run("NotRequiredForAlphabetTrace", func(t *testing.T) {
+				configForArgs(t, addRequiredArgsExcept(gameTypes.AlphabetGameType, "--cannon-kona-server"))
+			})
+
+			t.Run("Required", func(t *testing.T) {
+				verifyArgsInvalid(t, "flag cannon-kona-server is required", addRequiredArgsExcept(gameType, "--cannon-kona-server"))
+			})
+
+			t.Run("Valid", func(t *testing.T) {
+				cfg := configForArgs(t, addRequiredArgsExcept(gameType, "--cannon-kona-server", "--cannon-kona-server=./kona-host"))
+				require.Equal(t, "./kona-host", cfg.CannonKona.Server)
+			})
+		})
+
+		t.Run(fmt.Sprintf("TestCannonKonaAbsolutePrestate-%v", gameType), func(t *testing.T) {
+			t.Run("NotRequiredForAlphabetTrace", func(t *testing.T) {
+				configForArgs(t, addRequiredArgsExcept(gameTypes.AlphabetGameType, "--cannon-kona-prestate"))
+			})
+
+			t.Run("Required", func(t *testing.T) {
+				verifyArgsInvalid(t, "flag prestates-url/cannon-kona-prestates-url or cannon-kona-prestate is required", addRequiredArgsExcept(gameType, "--cannon-kona-prestate"))
+			})
+
+			t.Run("Valid", func(t *testing.T) {
+				cfg := configForArgs(t, addRequiredArgsExcept(gameType, "--cannon-kona-prestate", "--cannon-kona-prestate=./pre.json"))
+				require.Equal(t, "./pre.json", cfg.CannonKonaAbsolutePreState)
+			})
+		})
+
+		t.Run(fmt.Sprintf("TestCannonKonaPrestatesBaseURL-%v", gameType), func(t *testing.T) {
+			t.Run("Valid", func(t *testing.T) {
+				cfg := configForArgs(t, addRequiredArgsExcept(gameType, "--cannon-kona-prestates-url", "--cannon-kona-prestates-url=http://localhost/foo"))
+				require.Equal(t, "http://localhost/foo", cfg.CannonKonaAbsolutePreStateBaseURL.String())
+			})
+		})
+
+		t.Run(fmt.Sprintf("TestKonaPrestateBaseURL-%v", gameType), func(t *testing.T) {
+			allPrestateOptions := []string{"--prestates-url", "--cannon-kona-prestates-url", "--cannon-kona-prestate"}
+			t.Run("NotRequiredIfCannonKonaPrestatesBaseURLSet", func(t *testing.T) {
+				configForArgs(t, addRequiredArgsExceptArr(gameType, allPrestateOptions, "--cannon-kona-prestates-url=http://localhost/foo"))
+			})
+
+			t.Run("CannonKonaPrestatesBaseURLTakesPrecedence", func(t *testing.T) {
+				cfg := configForArgs(t, addRequiredArgsExceptArr(gameType, allPrestateOptions, "--cannon-kona-prestates-url=http://localhost/foo", "--prestates-url=http://localhost/bar"))
+				require.Equal(t, "http://localhost/foo", cfg.CannonKonaAbsolutePreStateBaseURL.String())
+			})
+
+			t.Run("RequiredIfCannonKonaPrestatesBaseURLNotSet", func(t *testing.T) {
+				verifyArgsInvalid(t, "flag prestates-url/cannon-kona-prestates-url or cannon-kona-prestate is required", addRequiredArgsExceptArr(gameType, allPrestateOptions))
+			})
+
+			t.Run("Valid", func(t *testing.T) {
+				cfg := configForArgs(t, addRequiredArgsExceptArr(gameType, allPrestateOptions, "--prestates-url=http://localhost/foo"))
+				require.Equal(t, "http://localhost/foo", cfg.CannonKonaAbsolutePreStateBaseURL.String())
+			})
+		})
+	}
+}
+
 func TestDepsetConfig(t *testing.T) {
 	for _, gameType := range gameTypes.SupportedGameTypes {
-		if gameType == gameTypes.SuperCannonGameType || gameType == gameTypes.SuperPermissionedGameType {
+		if gameType == gameTypes.SuperCannonGameType {
 			t.Run("Required-"+gameType.String(), func(t *testing.T) {
 				verifyArgsInvalid(t,
 					"flag network or rollup-config/cannon-rollup-config, l2-genesis/cannon-l2-genesis and depset-config/cannon-depset-config is required",
 					addRequiredArgsExcept(gameType, "--network", "--rollup-config=rollup.json", "--l2-genesis=genesis.json"))
 			})
-		} else if gameType == gameTypes.SuperCannonKonaGameType {
+		} else if gameType == gameTypes.SuperCannonKonaGameType || gameType == gameTypes.SuperPermissionedGameType {
 			t.Run("Required-"+gameType.String(), func(t *testing.T) {
 				verifyArgsInvalid(t,
 					"flag network or rollup-config/cannon-kona-rollup-config, l2-genesis/cannon-kona-l2-genesis and depset-config/cannon-kona-depset-config is required",
@@ -1026,9 +1091,9 @@ func requiredArgs(gameType gameTypes.GameType) map[string]string {
 		addRequiredCannonArgs(args)
 	case gameTypes.CannonKonaGameType:
 		addRequiredCannonKonaArgs(args)
-	case gameTypes.SuperCannonGameType, gameTypes.SuperPermissionedGameType:
+	case gameTypes.SuperCannonGameType:
 		addRequiredSuperCannonArgs(args)
-	case gameTypes.SuperCannonKonaGameType:
+	case gameTypes.SuperCannonKonaGameType, gameTypes.SuperPermissionedGameType:
 		addRequiredSuperCannonKonaArgs(args)
 	case gameTypes.ZKDisputeGameType, gameTypes.AlphabetGameType, gameTypes.FastGameType:
 		addRequiredOutputRootArgs(args)

--- a/op-challenger/config/config.go
+++ b/op-challenger/config/config.go
@@ -243,7 +243,7 @@ func (c Config) Check() error {
 	if c.MaxConcurrency == 0 {
 		return ErrMaxConcurrencyZero
 	}
-	if c.GameTypeEnabled(gameTypes.SuperCannonGameType) || c.GameTypeEnabled(gameTypes.SuperPermissionedGameType) {
+	if c.GameTypeEnabled(gameTypes.SuperCannonGameType) {
 		if c.SuperRPC == "" {
 			return ErrMissingSuperRpc
 		}
@@ -263,7 +263,7 @@ func (c Config) Check() error {
 			return err
 		}
 	}
-	if c.GameTypeEnabled(gameTypes.SuperCannonKonaGameType) {
+	if c.GameTypeEnabled(gameTypes.SuperCannonKonaGameType) || c.GameTypeEnabled(gameTypes.SuperPermissionedGameType) {
 		if c.SuperRPC == "" {
 			return ErrMissingSuperRpc
 		}

--- a/op-challenger/config/config_test.go
+++ b/op-challenger/config/config_test.go
@@ -40,9 +40,9 @@ var (
 )
 
 var singleCannonGameTypes = []gameTypes.GameType{gameTypes.CannonGameType, gameTypes.PermissionedGameType}
-var superCannonGameTypes = []gameTypes.GameType{gameTypes.SuperCannonGameType, gameTypes.SuperPermissionedGameType}
+var superCannonGameTypes = []gameTypes.GameType{gameTypes.SuperCannonGameType}
 var allCannonGameTypes []gameTypes.GameType
-var cannonKonaGameTypes = []gameTypes.GameType{gameTypes.CannonKonaGameType, gameTypes.SuperCannonKonaGameType}
+var cannonKonaGameTypes = []gameTypes.GameType{gameTypes.CannonKonaGameType, gameTypes.SuperCannonKonaGameType, gameTypes.SuperPermissionedGameType}
 
 func init() {
 	allCannonGameTypes = append(allCannonGameTypes, singleCannonGameTypes...)
@@ -115,7 +115,7 @@ func applyValidConfigForZKDisputeGame(cfg *Config) {
 
 func validConfig(t *testing.T, gameType gameTypes.GameType) Config {
 	cfg := NewConfig(validGameFactoryAddress, validL1EthRpc, validL1BeaconUrl, validRollupRpc, validL2Rpc, validDatadir, gameType)
-	if gameType == gameTypes.SuperCannonGameType || gameType == gameTypes.SuperPermissionedGameType {
+	if gameType == gameTypes.SuperCannonGameType {
 		applyValidConfigForSuperCannon(t, &cfg)
 	}
 	if gameType == gameTypes.CannonGameType || gameType == gameTypes.PermissionedGameType {
@@ -124,7 +124,7 @@ func validConfig(t *testing.T, gameType gameTypes.GameType) Config {
 	if gameType == gameTypes.CannonKonaGameType {
 		applyValidConfigForCannonKona(t, &cfg)
 	}
-	if gameType == gameTypes.SuperCannonKonaGameType {
+	if gameType == gameTypes.SuperCannonKonaGameType || gameType == gameTypes.SuperPermissionedGameType {
 		applyValidConfigForSuperCannonKona(t, &cfg)
 	}
 	if gameType == gameTypes.ZKDisputeGameType {
@@ -464,6 +464,18 @@ func TestDepsetConfig(t *testing.T) {
 			cfg.Cannon.RollupConfigPaths = []string{"foo.json"}
 			cfg.Cannon.L2GenesisPaths = []string{"genesis.json"}
 			cfg.Cannon.DepsetConfigPath = ""
+			require.ErrorIs(t, cfg.Check(), ErrMissingDepsetConfig)
+		})
+	}
+
+	for _, gameType := range []gameTypes.GameType{gameTypes.SuperCannonKonaGameType, gameTypes.SuperPermissionedGameType} {
+		gameType := gameType
+		t.Run(fmt.Sprintf("TestCannonKonaNetworkOrDepsetConfigRequired-%v", gameType), func(t *testing.T) {
+			cfg := validConfig(t, gameType)
+			cfg.CannonKona.Networks = nil
+			cfg.CannonKona.RollupConfigPaths = []string{"foo.json"}
+			cfg.CannonKona.L2GenesisPaths = []string{"genesis.json"}
+			cfg.CannonKona.DepsetConfigPath = ""
 			require.ErrorIs(t, cfg.Check(), ErrMissingDepsetConfig)
 		})
 	}

--- a/op-challenger/flags/flags.go
+++ b/op-challenger/flags/flags.go
@@ -391,6 +391,12 @@ func CheckSuperCannonKonaFlags(ctx *cli.Context) error {
 	if err := CheckCannonKonaBaseFlags(ctx, gameTypes.CannonKonaGameType); err != nil {
 		return err
 	}
+	if !ctx.IsSet(CannonKonaServerFlag.Name) {
+		return fmt.Errorf("flag %s is required", CannonKonaServerFlag.Name)
+	}
+	if !PreStatesURLFlag.IsSet(ctx, gameTypes.CannonKonaGameType) && !ctx.IsSet(CannonKonaPreStateFlag.Name) {
+		return fmt.Errorf("flag %s or %s is required", PreStatesURLFlag.EitherFlagName(gameTypes.CannonKonaGameType), CannonKonaPreStateFlag.Name)
+	}
 	return nil
 }
 

--- a/op-challenger/flags/flags.go
+++ b/op-challenger/flags/flags.go
@@ -461,11 +461,11 @@ func CheckRequired(ctx *cli.Context, types []gameTypes.GameType) error {
 			if err := CheckCannonKonaFlags(ctx); err != nil {
 				return err
 			}
-		case gameTypes.SuperCannonGameType, gameTypes.SuperPermissionedGameType:
+		case gameTypes.SuperCannonGameType:
 			if err := CheckSuperCannonFlags(ctx); err != nil {
 				return err
 			}
-		case gameTypes.SuperCannonKonaGameType:
+		case gameTypes.SuperCannonKonaGameType, gameTypes.SuperPermissionedGameType:
 			if err := CheckSuperCannonKonaFlags(ctx); err != nil {
 				return err
 			}

--- a/op-challenger/game/fault/register.go
+++ b/op-challenger/game/fault/register.go
@@ -93,7 +93,7 @@ func RegisterGameTypes(
 		if err != nil {
 			return err
 		}
-		registerTasks = append(registerTasks, NewSuperCannonRegisterTask(gameTypes.SuperPermissionedGameType, cfg, m, vm.NewOpProgramServerExecutor(logger), rootProvider, superNodeProvider, syncValidator))
+		registerTasks = append(registerTasks, NewSuperCannonKonaRegisterTask(gameTypes.SuperPermissionedGameType, cfg, m, vm.NewKonaSuperExecutor(), rootProvider, superNodeProvider, syncValidator))
 	}
 	if cfg.GameTypeEnabled(gameTypes.FastGameType) {
 		l2HeaderSource, rollupClient, syncValidator, err := clients.SingleChainClients()


### PR DESCRIPTION
SUPER_PERMISSIONED_CANNON uses the kona-interop super absolute prestate on-chain, so the challenger has to fetch the kona prestate and run kona-host — not op-program. Switch its registration, config validation, and CLI flag checks to the cannon-kona path. Also enforce `--cannon-kona-server` and `--cannon-kona-prestate` (or kona prestates URL) in `CheckSuperCannonKonaFlags`, parallel to how the cannon side enforces those flags via `CheckCannonBaseFlags` (closes the same latent gap for SUPER_CANNON_KONA).

Closes https://github.com/ethereum-optimism/optimism/issues/20404