### PR TITLE
fix(op-revm): ensure Bedrock deposits bump nonce on Halt

### DIFF
--- a/rust/op-reth/crates/rpc/src/error.rs
+++ b/rust/op-reth/crates/rpc/src/error.rs
@@ -74,9 +74,9 @@ pub enum OpInvalidTransactionError {
     /// A deposit transaction was submitted as a system transaction post-regolith.
     #[error("no system transactions allowed after regolith")]
     DepositSystemTxPostRegolith,
-    /// A deposit transaction halted post-regolith
-    #[error("deposit transaction halted after regolith")]
-    HaltedDepositPostRegolith,
+    /// A deposit transaction halted on execution across all hardforks.
+    #[error("deposit transaction halted")]
+    HaltedDeposit,
     /// The encoded transaction was missing during evm execution.
     #[error("missing enveloped transaction bytes")]
     MissingEnvelopedTx,
@@ -89,7 +89,7 @@ impl From<OpInvalidTransactionError> for jsonrpsee_types::error::ErrorObject<'st
     fn from(err: OpInvalidTransactionError) -> Self {
         match err {
             OpInvalidTransactionError::DepositSystemTxPostRegolith |
-            OpInvalidTransactionError::HaltedDepositPostRegolith |
+            OpInvalidTransactionError::HaltedDeposit |
             OpInvalidTransactionError::MissingEnvelopedTx => {
                 rpc_err(EthRpcErrorCode::TransactionRejected.code(), err.to_string(), None)
             }
@@ -107,7 +107,7 @@ impl TryFrom<OpTxError> for OpInvalidTransactionError {
             OpTransactionError::DepositSystemTxPostRegolith => {
                 Ok(Self::DepositSystemTxPostRegolith)
             }
-            OpTransactionError::HaltedDepositPostRegolith => Ok(Self::HaltedDepositPostRegolith),
+            OpTransactionError::HaltedDeposit => Ok(Self::HaltedDeposit),
             OpTransactionError::MissingEnvelopedTx => Ok(Self::MissingEnvelopedTx),
             OpTransactionError::Base(err) => Err(err),
         }
@@ -202,7 +202,7 @@ impl FromEvmHalt<OpHaltReason> for OpEthApiError {
     fn from_evm_halt(halt: OpHaltReason, gas_limit: u64) -> Self {
         match halt {
             OpHaltReason::FailedDeposit => {
-                OpInvalidTransactionError::HaltedDepositPostRegolith.into()
+                OpInvalidTransactionError::HaltedDeposit.into()
             }
             OpHaltReason::Base(halt) => EthApiError::from_evm_halt(halt, gas_limit).into(),
         }

--- a/rust/op-revm/src/handler.rs
+++ b/rust/op-revm/src/handler.rs
@@ -356,9 +356,8 @@ where
             .map_haltreason(OpHaltReason::Base);
 
         if exec_result.is_halt() {
-            // Post-regolith, if the transaction is a deposit transaction and it halts,
-            // we bubble up to the global return handler. The mint value will be persisted
-            // and the caller nonce will be incremented there.
+            // For any deposit transaction that halts, we bubble up to the global return handler.
+            // The mint value will be persisted and the caller nonce will be incremented there.
             let is_deposit = evm.ctx().tx().tx_type() == DEPOSIT_TRANSACTION_TYPE;
             if is_deposit {
                 return Err(ERROR::from(OpTransactionError::HaltedDeposit));

--- a/rust/op-revm/src/handler.rs
+++ b/rust/op-revm/src/handler.rs
@@ -360,8 +360,8 @@ where
             // we bubble up to the global return handler. The mint value will be persisted
             // and the caller nonce will be incremented there.
             let is_deposit = evm.ctx().tx().tx_type() == DEPOSIT_TRANSACTION_TYPE;
-            if is_deposit && evm.ctx().cfg().spec().is_enabled_in(OpSpecId::REGOLITH) {
-                return Err(ERROR::from(OpTransactionError::HaltedDepositPostRegolith));
+            if is_deposit {
+                return Err(ERROR::from(OpTransactionError::HaltedDeposit));
             }
         }
         evm.ctx().journal_mut().commit_tx();
@@ -468,7 +468,7 @@ mod tests {
         database_interface::EmptyDB,
         handler::EthFrame,
         interpreter::{CallOutcome, InstructionResult, InterpreterResult},
-        primitives::{Address, B256, Bytes, bytes},
+        primitives::{Address, B256, Bytes, TxKind, bytes},
         state::AccountInfo,
     };
     use rstest::rstest;
@@ -1209,7 +1209,7 @@ mod tests {
                 )),
                 ResultGas::default(),
             ),
-            Err(EVMError::Transaction(OpTransactionError::HaltedDepositPostRegolith))
+            Err(EVMError::Transaction(OpTransactionError::HaltedDeposit))
         )
     }
 
@@ -1332,5 +1332,52 @@ mod tests {
             handler.validate_env(&mut evm),
             Err(EVMError::Transaction(OpTransactionError::MissingEnvelopedTx))
         );
+    }
+
+    #[test]
+    fn test_halted_deposit_tx_bedrock_nonce_bump() {
+        let caller = Address::ZERO;
+        let mut db = InMemoryDB::default();
+        db.insert_account_info(
+            caller,
+            AccountInfo { nonce: 10, balance: U256::from(1000), ..Default::default() },
+        );
+
+        let ctx = Context::op()
+            .with_db(db)
+            .modify_tx_chained(|tx| {
+                tx.deposit.source_hash = B256::from([1u8; 32]);
+                tx.base.caller = caller;
+                tx.base.kind = TxKind::Create;
+            })
+            .with_cfg(CfgEnv::new_with_spec(OpSpecId::BEDROCK));
+
+        let mut evm = ctx.build_op();
+        let mut handler =
+            OpHandler::<_, EVMError<_, OpTransactionError>, EthFrame<EthInterpreter>>::new();
+
+        // 1. Initial validation/setup
+        handler.validate_against_state_and_deduct_caller(&mut evm, &mut Default::default()).unwrap();
+
+        // 2. Simulate execution result that is a Halt (e.g. OutOfGas)
+        let result = handler.execution_result(
+            &mut evm,
+            FrameResult::Call(CallOutcome::new(
+                InterpreterResult {
+                    result: InstructionResult::OutOfGas,
+                    output: Default::default(),
+                    gas: Default::default(),
+                },
+                Default::default()
+            )),
+            ResultGas::default(),
+        );
+
+        if let Err(e) = result {
+            handler.catch_error(&mut evm, e).unwrap();
+        }
+
+        let account = evm.ctx().journal_mut().load_account(caller).unwrap();
+        assert_eq!(account.info.nonce, 11, "Nonce should have been bumped even on Halt in Bedrock");
     }
 }

--- a/rust/op-revm/src/transaction/error.rs
+++ b/rust/op-revm/src/transaction/error.rs
@@ -43,7 +43,7 @@ pub enum OpTransactionError {
     /// and special gas accounting rules are applied. Normally on L1, [`EVMError::Transaction`]
     /// errors are cause for non-inclusion, so a special [`OpHaltReason`][crate::OpHaltReason]
     /// variant was introduced to handle this case for failed deposit transactions.
-    HaltedDepositPostRegolith,
+    HaltedDeposit,
     /// Missing enveloped transaction bytes for non-deposit transaction.
     ///
     /// Non-deposit transactions on Optimism must have `enveloped_tx` field set
@@ -60,10 +60,10 @@ impl Display for OpTransactionError {
             Self::DepositSystemTxPostRegolith => {
                 write!(f, "deposit system transactions post regolith hardfork are not supported")
             }
-            Self::HaltedDepositPostRegolith => {
+            Self::HaltedDeposit => {
                 write!(
                     f,
-                    "deposit transaction halted post-regolith; error will be bubbled up to main return handler"
+                    "deposit transaction halted; error will be bubbled up to main return handler"
                 )
             }
             Self::MissingEnvelopedTx => {
@@ -104,8 +104,8 @@ mod test {
             "deposit system transactions post regolith hardfork are not supported"
         );
         assert_eq!(
-            OpTransactionError::HaltedDepositPostRegolith.to_string(),
-            "deposit transaction halted post-regolith; error will be bubbled up to main return handler"
+            OpTransactionError::HaltedDeposit.to_string(),
+            "deposit transaction halted; error will be bubbled up to main return handler"
         );
         assert_eq!(
             OpTransactionError::MissingEnvelopedTx.to_string(),


### PR DESCRIPTION
This PR addresses a state inconsistency in `op-revm` where deposit transactions of type `Create` in the Bedrock hardfork (Pre-Regolith) failed to increment the sender's nonce if the execution resulted in a `Halt` (e.g., `OutOfGas`).

### The Bug
In `OpHandler::execution_result`, halted deposits were only converted to bubble-up errors if the `REGOLITH` hardfork was enabled. For `BEDROCK`, the handler returned `Ok(Halt)`, which bypassed the `catch_error` logic where the nonce bump occurs.

### The Fix
1. Modified `OpHandler::execution_result` to return an `Err(OpTransactionError::HaltedDeposit)` for all halted deposit transactions.
2. Renamed `OpTransactionError::HaltedDepositPostRegolith` to `OpTransactionError::HaltedDeposit` for correctness across forks.

Verified with regression test `test_halted_deposit_tx_bedrock_nonce_bump`.
@rakita 