### PR TITLE
op-supernode: avoid engine rewind on L1 reorg

### DIFF
--- a/op-supernode/supernode/activity/interop/algo_test.go
+++ b/op-supernode/supernode/activity/interop/algo_test.go
@@ -979,6 +979,9 @@ func (m *algoMockChain) GetDeniedOutput(height uint64, payloadHash common.Hash) 
 func (m *algoMockChain) PruneDeniedAtOrAfterTimestamp(timestamp uint64) (map[uint64][]common.Hash, error) {
 	return nil, nil
 }
+func (m *algoMockChain) HasDeniedAtOrAfterTimestamp(timestamp uint64) (bool, error) {
+	return false, nil
+}
 func (m *algoMockChain) IsDenied(height uint64, payloadHash common.Hash) (bool, error) {
 	return false, nil
 }

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -752,6 +752,18 @@ func (i *Interop) buildRewindPlan(lastTS uint64) (RewindPlan, error) {
 		RewindAtOrAfter: lastTS,
 	}
 
+	resetEngines, err := i.shouldResetEnginesOnRewind(lastTS)
+	if err != nil {
+		return RewindPlan{}, err
+	}
+	if resetEngines {
+		if lastTS == 0 {
+			return RewindPlan{}, fmt.Errorf("cannot reset engines before timestamp 0")
+		}
+		resetTo := lastTS - 1
+		plan.ResetAllChainsTo = &resetTo
+	}
+
 	first, err := i.firstVerifiableTimestamp(i.ctx)
 	if err != nil {
 		return RewindPlan{}, err
@@ -765,9 +777,21 @@ func (i *Interop) buildRewindPlan(lastTS uint64) (RewindPlan, error) {
 	if err != nil {
 		return RewindPlan{}, fmt.Errorf("read previous verified result at %d: %w", rewindTargetTS, err)
 	}
-	plan.ResetAllChainsTo = &rewindTargetTS
 	plan.TargetHeads = prevResult.L2Heads
 	return plan, nil
+}
+
+func (i *Interop) shouldResetEnginesOnRewind(timestamp uint64) (bool, error) {
+	for chainID, chain := range i.chains {
+		hasDenied, err := chain.HasDeniedAtOrAfterTimestamp(timestamp)
+		if err != nil {
+			return false, fmt.Errorf("chain %s: inspect deny list for rewind: %w", chainID, err)
+		}
+		if hasDenied {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func (i *Interop) applyRewindPlan(plan RewindPlan) error {
@@ -798,12 +822,6 @@ func (i *Interop) applyRewindPlan(plan RewindPlan) error {
 			i.log.Error("failed to prune deny list on rewind", "chain", chainID, "err", err)
 			recordErr(fmt.Errorf("chain %s: prune deny list on rewind: %w", chainID, err))
 		}
-		if plan.ResetAllChainsTo != nil {
-			if err := chain.RewindEngine(i.ctx, *plan.ResetAllChainsTo, eth.BlockRef{}); err != nil {
-				i.log.Error("failed to reset chain engine on rewind", "chain", chainID, "err", err)
-				recordErr(fmt.Errorf("chain %s: reset chain engine on rewind: %w", chainID, err))
-			}
-		}
 	}
 
 	if plan.TargetHeads == nil {
@@ -812,6 +830,9 @@ func (i *Interop) applyRewindPlan(plan RewindPlan) error {
 				i.log.Error("failed to clear logsDB on full rewind", "chain", chainID, "err", err)
 				recordErr(fmt.Errorf("chain %s: clear logsDB on full rewind: %w", chainID, err))
 			}
+		}
+		if len(allErrs) == 0 {
+			i.resetChainEnginesIfNeeded(plan, sortedChainIDs, recordErr)
 		}
 		return errors.Join(allErrs...)
 	}
@@ -834,7 +855,24 @@ func (i *Interop) applyRewindPlan(plan RewindPlan) error {
 		}
 	}
 
+	if len(allErrs) == 0 {
+		i.resetChainEnginesIfNeeded(plan, sortedChainIDs, recordErr)
+	}
 	return errors.Join(allErrs...)
+}
+
+func (i *Interop) resetChainEnginesIfNeeded(plan RewindPlan, sortedChainIDs []eth.ChainID, recordErr func(error)) {
+	if plan.ResetAllChainsTo == nil {
+		return
+	}
+	for _, chainID := range sortedChainIDs {
+		i.log.Warn("rewinding chain engine after pruning deny-list entries",
+			"chain", chainID, "rewindToTimestamp", *plan.ResetAllChainsTo)
+		if err := i.chains[chainID].RewindEngine(i.ctx, *plan.ResetAllChainsTo, eth.BlockRef{}); err != nil {
+			i.log.Error("failed to reset chain engine after pruning deny-list entries", "chain", chainID, "err", err)
+			recordErr(fmt.Errorf("chain %s: reset chain engine after pruning deny-list entries: %w", chainID, err))
+		}
+	}
 }
 
 // collectCurrentL1 collects the current L1 head of all chains,

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -1600,8 +1600,8 @@ func TestInterop_ProgressAndRecord_MultiAdvance(t *testing.T) {
 
 // TestInterop_ProgressAndRecord_L1InconsistencyTriggersRewind advances twice
 // through progressAndRecord, flips the l1Checker so observeRound sees an
-// inconsistency, and asserts the next progressAndRecord drives a full rewind
-// end to end: verifiedDB trimmed, engines reset, WAL cleared.
+// inconsistency, and asserts the next progressAndRecord drives a Supernode state
+// rewind end to end: verifiedDB trimmed and WAL cleared without rewinding engines.
 func TestInterop_ProgressAndRecord_L1InconsistencyTriggersRewind(t *testing.T) {
 	h := newInteropTestHarness(t). // newInteropTestHarness calls t.Parallel()
 					WithActivation(100).
@@ -1644,8 +1644,7 @@ func TestInterop_ProgressAndRecord_L1InconsistencyTriggersRewind(t *testing.T) {
 	require.NoError(t, err)
 	require.Nil(t, pending, "WAL cleared after successful rewind")
 
-	require.Len(t, mock.rewindEngineCalls, 1, "engine rewound exactly once on the recovering chain")
-	require.Equal(t, uint64(101), mock.rewindEngineCalls[0])
+	require.Empty(t, mock.rewindEngineCalls, "L1 drift rewinds accepted Supernode state only")
 }
 
 // =============================================================================
@@ -1999,6 +1998,15 @@ func (m *mockChainContainer) PruneDeniedAtOrAfterTimestamp(timestamp uint64) (ma
 	}
 	return nil, nil
 }
+func (m *mockChainContainer) HasDeniedAtOrAfterTimestamp(timestamp uint64) (bool, error) {
+	for _, hashes := range m.pruneDeniedResult {
+		if len(hashes) == 0 {
+			continue
+		}
+		return true, nil
+	}
+	return false, nil
+}
 func (m *mockChainContainer) IsDenied(height uint64, payloadHash common.Hash) (bool, error) {
 	return false, nil
 }
@@ -2108,6 +2116,7 @@ func TestPendingTransition_RecoverInvalidatePreservedOnFailure(t *testing.T) {
 func TestPendingTransition_RecoverRewindPreservedOnFailure(t *testing.T) {
 	h := newInteropTestHarness(t). // newInteropTestHarness calls t.Parallel()
 					WithChain(10, func(m *mockChainContainer) {
+			m.pruneDeniedResult = map[uint64][]common.Hash{100: {common.HexToHash("0xdenied")}}
 			m.rewindEngineErr = errors.New("rewind failed")
 		}).
 		Build()
@@ -2134,7 +2143,7 @@ func TestPendingTransition_RecoverRewindPreservedOnFailure(t *testing.T) {
 	require.NoError(t, h.interop.verifiedDB.SetPendingTransition(pending))
 	_, err = h.interop.applyPendingTransition(pending)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "reset chain engine on rewind")
+	require.Contains(t, err.Error(), "reset chain engine after pruning deny-list entries")
 
 	storedPending, err := h.interop.verifiedDB.GetPendingTransition()
 	require.NoError(t, err)
@@ -2154,6 +2163,7 @@ func TestPendingTransition_RewindReplaysAfterFailure(t *testing.T) {
 	h := newInteropTestHarness(t). // newInteropTestHarness calls t.Parallel()
 					WithChain(10, nil).
 					WithChain(8453, func(m *mockChainContainer) {
+			m.pruneDeniedResult = map[uint64][]common.Hash{200: {common.HexToHash("0xdenied")}}
 			m.rewindEngineErr = errors.New("chain B rewind failed")
 		}).
 		Build()
@@ -2188,7 +2198,7 @@ func TestPendingTransition_RewindReplaysAfterFailure(t *testing.T) {
 
 	// First attempt: chain B's RewindEngine errors, WAL preserved.
 	_, err = h.interop.applyPendingTransition(pending)
-	require.EqualError(t, err, "apply rewind plan: chain 8453: reset chain engine on rewind: chain B rewind failed")
+	require.EqualError(t, err, "apply rewind plan: chain 8453: reset chain engine after pruning deny-list entries: chain B rewind failed")
 
 	stored, err := h.interop.verifiedDB.GetPendingTransition()
 	require.NoError(t, err)
@@ -2217,6 +2227,7 @@ func TestPendingTransition_RewindReplaysAfterFailure(t *testing.T) {
 func TestPendingTransition_RecoverRewindReportsAllFailures(t *testing.T) {
 	h := newInteropTestHarness(t). // newInteropTestHarness calls t.Parallel()
 					WithChain(10, func(m *mockChainContainer) {
+			m.pruneDeniedResult = map[uint64][]common.Hash{100: {common.HexToHash("0xdenied")}}
 			m.rewindEngineErr = errors.New("rewind failed a")
 		}).
 		WithChain(8453, func(m *mockChainContainer) {
@@ -2253,8 +2264,8 @@ func TestPendingTransition_RecoverRewindReportsAllFailures(t *testing.T) {
 	require.NoError(t, h.interop.verifiedDB.SetPendingTransition(pending))
 	_, err = h.interop.applyPendingTransition(pending)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "chain 10: reset chain engine on rewind")
-	require.Contains(t, err.Error(), "chain 8453: reset chain engine on rewind")
+	require.Contains(t, err.Error(), "chain 10: reset chain engine after pruning deny-list entries")
+	require.Contains(t, err.Error(), "chain 8453: reset chain engine after pruning deny-list entries")
 }
 
 func TestPendingTransition_RecoverAdvanceAfterCommitClearsPendingTransition(t *testing.T) {
@@ -2380,6 +2391,7 @@ func TestRewindAccepted(t *testing.T) {
 		// logsDB should have been rewound (not cleared)
 		require.True(t, trackingDB.rewindCalled, "logsDB should be rewound to previous frontier")
 		require.Equal(t, 0, trackingDB.clearCalled, "logsDB should not be cleared")
+		require.Empty(t, mock.rewindEngineCalls, "DecisionRewind should not rewind chain engines")
 	})
 
 	t.Run("clears logsDB when rewinding to empty", func(t *testing.T) {

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -1999,8 +1999,8 @@ func (m *mockChainContainer) PruneDeniedAtOrAfterTimestamp(timestamp uint64) (ma
 	return nil, nil
 }
 func (m *mockChainContainer) HasDeniedAtOrAfterTimestamp(timestamp uint64) (bool, error) {
-	for _, hashes := range m.pruneDeniedResult {
-		if len(hashes) == 0 {
+	for decisionTimestamp, hashes := range m.pruneDeniedResult {
+		if decisionTimestamp < timestamp || len(hashes) == 0 {
 			continue
 		}
 		return true, nil
@@ -2116,7 +2116,7 @@ func TestPendingTransition_RecoverInvalidatePreservedOnFailure(t *testing.T) {
 func TestPendingTransition_RecoverRewindPreservedOnFailure(t *testing.T) {
 	h := newInteropTestHarness(t). // newInteropTestHarness calls t.Parallel()
 					WithChain(10, func(m *mockChainContainer) {
-			m.pruneDeniedResult = map[uint64][]common.Hash{100: {common.HexToHash("0xdenied")}}
+			m.pruneDeniedResult = map[uint64][]common.Hash{1001: {common.HexToHash("0xdenied")}}
 			m.rewindEngineErr = errors.New("rewind failed")
 		}).
 		Build()
@@ -2163,7 +2163,7 @@ func TestPendingTransition_RewindReplaysAfterFailure(t *testing.T) {
 	h := newInteropTestHarness(t). // newInteropTestHarness calls t.Parallel()
 					WithChain(10, nil).
 					WithChain(8453, func(m *mockChainContainer) {
-			m.pruneDeniedResult = map[uint64][]common.Hash{200: {common.HexToHash("0xdenied")}}
+			m.pruneDeniedResult = map[uint64][]common.Hash{1001: {common.HexToHash("0xdenied")}}
 			m.rewindEngineErr = errors.New("chain B rewind failed")
 		}).
 		Build()
@@ -2227,7 +2227,7 @@ func TestPendingTransition_RewindReplaysAfterFailure(t *testing.T) {
 func TestPendingTransition_RecoverRewindReportsAllFailures(t *testing.T) {
 	h := newInteropTestHarness(t). // newInteropTestHarness calls t.Parallel()
 					WithChain(10, func(m *mockChainContainer) {
-			m.pruneDeniedResult = map[uint64][]common.Hash{100: {common.HexToHash("0xdenied")}}
+			m.pruneDeniedResult = map[uint64][]common.Hash{1001: {common.HexToHash("0xdenied")}}
 			m.rewindEngineErr = errors.New("rewind failed a")
 		}).
 		WithChain(8453, func(m *mockChainContainer) {
@@ -2392,6 +2392,73 @@ func TestRewindAccepted(t *testing.T) {
 		require.True(t, trackingDB.rewindCalled, "logsDB should be rewound to previous frontier")
 		require.Equal(t, 0, trackingDB.clearCalled, "logsDB should not be cleared")
 		require.Empty(t, mock.rewindEngineCalls, "DecisionRewind should not rewind chain engines")
+	})
+
+	t.Run("rewinds all engines when deny-list entries are pruned", func(t *testing.T) {
+		h := newInteropTestHarness(t).
+			WithChain(10, nil).
+			WithChain(8453, func(m *mockChainContainer) {
+				m.pruneDeniedResult = map[uint64][]common.Hash{
+					1001: {common.HexToHash("0xdenied")},
+				}
+			}).
+			Build()
+
+		mockA := h.Mock(10)
+		mockB := h.Mock(8453)
+
+		require.NoError(t, h.interop.verifiedDB.Commit(VerifiedResult{
+			Timestamp:   1000,
+			L1Inclusion: eth.BlockID{Number: 50, Hash: common.HexToHash("0xL1a")},
+			L2Heads: map[eth.ChainID]eth.BlockID{
+				mockA.id: {Number: 100, Hash: common.HexToHash("0xa1")},
+				mockB.id: {Number: 200, Hash: common.HexToHash("0xb1")},
+			},
+		}))
+		require.NoError(t, h.interop.verifiedDB.Commit(VerifiedResult{
+			Timestamp:   1001,
+			L1Inclusion: eth.BlockID{Number: 51, Hash: common.HexToHash("0xL1b")},
+			L2Heads: map[eth.ChainID]eth.BlockID{
+				mockA.id: {Number: 101, Hash: common.HexToHash("0xa2")},
+				mockB.id: {Number: 201, Hash: common.HexToHash("0xb2")},
+			},
+		}))
+
+		plan, err := h.interop.buildRewindPlan(1001)
+		require.NoError(t, err)
+		require.NotNil(t, plan.ResetAllChainsTo)
+		require.Equal(t, uint64(1000), *plan.ResetAllChainsTo)
+
+		err = h.interop.applyRewindPlan(plan)
+		require.NoError(t, err)
+		require.Equal(t, []uint64{1000}, mockA.rewindEngineCalls)
+		require.Equal(t, []uint64{1000}, mockB.rewindEngineCalls)
+	})
+
+	t.Run("does not rewind engines for deny-list entries before rewind timestamp", func(t *testing.T) {
+		h := newInteropTestHarness(t).
+			WithChain(10, func(m *mockChainContainer) {
+				m.pruneDeniedResult = map[uint64][]common.Hash{
+					1000: {common.HexToHash("0xdenied")},
+				}
+			}).
+			Build()
+
+		mock := h.Mock(10)
+		require.NoError(t, h.interop.verifiedDB.Commit(VerifiedResult{
+			Timestamp:   1000,
+			L1Inclusion: eth.BlockID{Number: 50, Hash: common.HexToHash("0xL1a")},
+			L2Heads:     map[eth.ChainID]eth.BlockID{mock.id: {Number: 100, Hash: common.HexToHash("0xa1")}},
+		}))
+		require.NoError(t, h.interop.verifiedDB.Commit(VerifiedResult{
+			Timestamp:   1001,
+			L1Inclusion: eth.BlockID{Number: 51, Hash: common.HexToHash("0xL1b")},
+			L2Heads:     map[eth.ChainID]eth.BlockID{mock.id: {Number: 101, Hash: common.HexToHash("0xa2")}},
+		}))
+
+		plan, err := h.interop.buildRewindPlan(1001)
+		require.NoError(t, err)
+		require.Nil(t, plan.ResetAllChainsTo)
 	})
 
 	t.Run("clears logsDB when rewinding to empty", func(t *testing.T) {

--- a/op-supernode/supernode/activity/interop/types.go
+++ b/op-supernode/supernode/activity/interop/types.go
@@ -36,7 +36,7 @@ type Result struct {
 //
 // Phase 2 keeps this intentionally small:
 // - advance/invalidate carry their Result directly
-// - rewind carries the accepted timestamp to rewind from
+// - rewind carries the accepted frontier to rewind from
 // Later phases can expand this into a richer explicit transition plan.
 type PendingTransition struct {
 	Decision Decision    `json:"decision"`
@@ -45,9 +45,8 @@ type PendingTransition struct {
 }
 
 // RewindPlan is the explicit rewind transition persisted in the WAL.
-// It captures the target verified frontier and per-chain logsDB target heads so
-// recovery can apply the same rewind path without recomputing it from live
-// state.
+// It captures the target verified frontier and engine reset decision so recovery
+// can apply the same rewind path without recomputing it from live state.
 type RewindPlan struct {
 	RewindAtOrAfter  uint64                      `json:"rewindAtOrAfter"`
 	ResetAllChainsTo *uint64                     `json:"resetAllChainsTo,omitempty"`

--- a/op-supernode/supernode/chain_container/chain_container.go
+++ b/op-supernode/supernode/chain_container/chain_container.go
@@ -88,6 +88,9 @@ type ChainContainer interface {
 // ChainContainer above so the misuse is caught at compile time.
 type InteropChain interface {
 	ChainContainer
+	// HasDeniedAtOrAfterTimestamp returns true if any deny-list entry has
+	// DecisionTimestamp >= timestamp, without mutating the deny list.
+	HasDeniedAtOrAfterTimestamp(timestamp uint64) (bool, error)
 	// RewindEngine rewinds the engine to the highest block with timestamp less than
 	// or equal to the given timestamp. invalidatedBlock is the block that triggered
 	// the rewind and is passed to reset callbacks.

--- a/op-supernode/supernode/chain_container/invalidation.go
+++ b/op-supernode/supernode/chain_container/invalidation.go
@@ -276,6 +276,34 @@ func (d *DenyList) GetDeniedRecords(height uint64) ([]DenyRecord, error) {
 	return records, err
 }
 
+// HasDeniedAtOrAfterTimestamp returns true if any denied payload has
+// DecisionTimestamp >= timestamp.
+func (d *DenyList) HasDeniedAtOrAfterTimestamp(timestamp uint64) (bool, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	var found bool
+	err := d.db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket(denyListBucketName)
+		c := b.Cursor()
+
+		for _, v := c.First(); v != nil; _, v = c.Next() {
+			records, err := decodeDenyRecords(v)
+			if err != nil {
+				return err
+			}
+			for _, r := range records {
+				if r.DecisionTimestamp >= timestamp {
+					found = true
+					return nil
+				}
+			}
+		}
+		return nil
+	})
+	return found, err
+}
+
 // PruneAtOrAfterTimestamp iterates all keys in the bucket, decodes records,
 // removes any where DecisionTimestamp >= timestamp, re-encodes remaining.
 // Returns map of removed hashes by height.
@@ -417,4 +445,11 @@ func (c *simpleChainContainer) PruneDeniedAtOrAfterTimestamp(timestamp uint64) (
 		return nil, fmt.Errorf("deny list not initialized")
 	}
 	return c.denyList.PruneAtOrAfterTimestamp(timestamp)
+}
+
+func (c *simpleChainContainer) HasDeniedAtOrAfterTimestamp(timestamp uint64) (bool, error) {
+	if c.denyList == nil {
+		return false, fmt.Errorf("deny list not initialized")
+	}
+	return c.denyList.HasDeniedAtOrAfterTimestamp(timestamp)
 }

--- a/op-supernode/supernode/chain_container/invalidation_test.go
+++ b/op-supernode/supernode/chain_container/invalidation_test.go
@@ -740,6 +740,26 @@ func TestDenyList_PruneAtOrAfterTimestamp(t *testing.T) {
 	require.Empty(t, records200)
 }
 
+func TestDenyList_HasDeniedAtOrAfterTimestamp(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	dl, err := OpenDenyList(dir)
+	require.NoError(t, err)
+	defer dl.Close()
+
+	require.NoError(t, dl.Add(100, common.HexToHash("0xaaaa"), 10, eth.Bytes32{}, eth.Bytes32{}))
+	require.NoError(t, dl.Add(50, common.HexToHash("0xbbbb"), 12, eth.Bytes32{}, eth.Bytes32{}))
+	require.NoError(t, dl.Add(25, common.HexToHash("0xcccc"), 9, eth.Bytes32{}, eth.Bytes32{}))
+
+	ok, err := dl.HasDeniedAtOrAfterTimestamp(11)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	ok, err = dl.HasDeniedAtOrAfterTimestamp(13)
+	require.NoError(t, err)
+	require.False(t, ok)
+}
+
 func TestDenyList_GetOutputV0(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Stop resetting chain engines for pure `DecisionRewind` handling caused by L1 reorgs.
- Keep the rewind scoped to Supernode-owned state when no invalidation is being undone: `VerifiedDB`, deny-list pruning, and `LogsDB`.
- If the rewind would prune any deny-list entry, persist `ResetAllChainsTo = lastTS - 1` in the rewind plan and reset all chain engines after the DB cleanup succeeds.

## Motivation

`DecisionRewind` means previously accepted Supernode state no longer lines up with canonical L1. That can happen when L1 reorg handling invalidates previously accepted cross-chain verification state, and it does not necessarily mean any chain engine executed an invalid block.

Previously, the rewind plan populated `ResetAllChainsTo` whenever there was a previous verified timestamp. During apply, every chain engine was reset before the logs DB rewind/clear completed. For a pure L1 reorg, this is more disruptive than the state correction requires: the virtual nodes can be stopped, engines receive synthetic/target forkchoice updates, derivation may need to restart from the reset point, and the backend can look unhealthy while the engine is being reset. Those engine-side effects are unnecessary when only Supernode acceptance state needs to move back to match canonical L1.

The exception is deny-list cleanup. If an L1 reorg rewind prunes a deny-list entry, the prior invalidation may have already moved an engine onto a replacement/deposits-only path. Once that deny-list entry is removed, the engines need a chance to re-derive without that stale invalidation. Deny-list entries are expected to be rare, so this PR chooses the simpler conservative behavior: if any chain has a deny-list entry that will be pruned, reset all chain engines to `lastTS - 1`.

## Crash-safety / ordering

The reset decision is captured in the persisted rewind plan before any side effects are applied. That matters because applying the rewind prunes deny-list entries; if the node crashes after pruning but before engine reset, replaying the WAL still needs to know that engine repair is required.

Engine resets now run after `VerifiedDB`, deny-list, and `LogsDB` cleanup succeed. If the local DB cleanup fails, the pending transition remains and we avoid repeatedly resetting engines before the state rewind has completed.

## Testing

- `go test ./op-supernode/supernode/activity/interop`
- `go test ./op-supernode/supernode/chain_container`
- `go test ./op-supernode/supernode/...`