### PR TITLE
fix(op-challenger): route super-cannon-kona to KonaSuperExecutor in run-trace

### DIFF
--- a/op-challenger/runner/factory.go
+++ b/op-challenger/runner/factory.go
@@ -28,9 +28,12 @@ func createTraceProvider(
 	localInputs utils.LocalGameInputs,
 	dir string,
 ) (types.TraceProvider, error) {
+	serverExecutor, err := serverExecutorForGameType(logger, gameType)
+	if err != nil {
+		return nil, err
+	}
 	switch gameType {
 	case gameTypes.CannonGameType, gameTypes.SuperCannonGameType:
-		serverExecutor := vm.NewOpProgramServerExecutor(logger)
 		stateConverter := cannon.NewStateConverter(cfg.Cannon)
 		prestate, err := prestateSource.getPrestate(ctx, logger, cfg.CannonAbsolutePreStateBaseURL, cfg.CannonAbsolutePreState, dir, stateConverter)
 		if err != nil {
@@ -39,7 +42,6 @@ func createTraceProvider(
 		prestateProvider := vm.NewPrestateProvider(prestate, stateConverter)
 		return cannon.NewTraceProvider(logger, m, cfg.Cannon, serverExecutor, prestateProvider, prestate, localInputs, dir, 42), nil
 	case gameTypes.CannonKonaGameType, gameTypes.SuperCannonKonaGameType:
-		serverExecutor := vm.NewKonaExecutor()
 		stateConverter := cannon.NewStateConverter(cfg.CannonKona)
 		prestate, err := prestateSource.getPrestate(ctx, logger, cfg.CannonKonaAbsolutePreStateBaseURL, cfg.CannonKonaAbsolutePreState, dir, stateConverter)
 		if err != nil {
@@ -47,6 +49,23 @@ func createTraceProvider(
 		}
 		prestateProvider := vm.NewPrestateProvider(prestate, stateConverter)
 		return cannon.NewTraceProvider(logger, m, cfg.CannonKona, serverExecutor, prestateProvider, prestate, localInputs, dir, 42), nil
+	}
+	return nil, errors.New("invalid game type")
+}
+
+// serverExecutorForGameType returns the oracle server executor that matches the
+// production challenger's wiring (op-challenger/game/fault/register.go) for the
+// given game type. Kona splits single-chain and super into separate executors
+// because the kona host CLI exposes them as disjoint subcommands; op-program
+// handles both shapes through one executor.
+func serverExecutorForGameType(logger log.Logger, gameType gameTypes.GameType) (vm.OracleServerExecutor, error) {
+	switch gameType {
+	case gameTypes.CannonGameType, gameTypes.SuperCannonGameType:
+		return vm.NewOpProgramServerExecutor(logger), nil
+	case gameTypes.CannonKonaGameType:
+		return vm.NewKonaExecutor(), nil
+	case gameTypes.SuperCannonKonaGameType:
+		return vm.NewKonaSuperExecutor(), nil
 	}
 	return nil, errors.New("invalid game type")
 }

--- a/op-challenger/runner/factory_test.go
+++ b/op-challenger/runner/factory_test.go
@@ -1,0 +1,72 @@
+package runner
+
+import (
+	"math/big"
+	"slices"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/utils"
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/vm"
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServerExecutorForGameType(t *testing.T) {
+	logger := testlog.Logger(t, log.LevelInfo)
+
+	tests := []struct {
+		gameType gameTypes.GameType
+		want     vm.OracleServerExecutor
+	}{
+		{gameTypes.CannonGameType, &vm.OpProgramServerExecutor{}},
+		{gameTypes.SuperCannonGameType, &vm.OpProgramServerExecutor{}},
+		{gameTypes.CannonKonaGameType, &vm.KonaExecutor{}},
+		{gameTypes.SuperCannonKonaGameType, &vm.KonaSuperExecutor{}},
+	}
+	for _, test := range tests {
+		t.Run(test.gameType.String(), func(t *testing.T) {
+			got, err := serverExecutorForGameType(logger, test.gameType)
+			require.NoError(t, err)
+			require.IsType(t, test.want, got)
+		})
+	}
+}
+
+func TestServerExecutorForGameType_UnknownGameType(t *testing.T) {
+	_, err := serverExecutorForGameType(testlog.Logger(t, log.LevelInfo), gameTypes.AlphabetGameType)
+	require.Error(t, err)
+}
+
+// Guards against regressing super-cannon-kona dispatch into the single-chain
+// KonaExecutor, which has a disjoint flag set and does not run super-state
+// derivation.
+func TestSuperCannonKonaProducesSuperHostCommand(t *testing.T) {
+	executor, err := serverExecutorForGameType(testlog.Logger(t, log.LevelInfo), gameTypes.SuperCannonKonaGameType)
+	require.NoError(t, err)
+
+	cfg := vm.Config{
+		Server:           "/path/to/kona",
+		L1:               "http://l1",
+		L1Beacon:         "http://beacon",
+		L2s:              []string{"http://l2a", "http://l2b"},
+		DepsetConfigPath: "/path/to/depset.json",
+	}
+	inputs := utils.LocalGameInputs{
+		L1Head:           common.Hash{0x11},
+		AgreedPreState:   []byte{0x01, 0x02, 0x03},
+		L2Claim:          common.Hash{0x44},
+		L2SequenceNumber: big.NewInt(100),
+	}
+
+	args, err := executor.OracleCommand(cfg, "/data", inputs)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(args), 2)
+	require.Equal(t, "super", args[1])
+	require.True(t, slices.Contains(args, "--agreed-l2-pre-state"), "missing --agreed-l2-pre-state in %v", args)
+	require.True(t, slices.Contains(args, "--claimed-l2-post-state"), "missing --claimed-l2-post-state in %v", args)
+	require.True(t, slices.Contains(args, "--l2-node-addresses"), "missing --l2-node-addresses in %v", args)
+	require.True(t, slices.Contains(args, "--depset-cfg"), "missing --depset-cfg in %v", args)
+}


### PR DESCRIPTION
The runner factory dispatched both `CannonKonaGameType` and `SuperCannonKonaGameType` through `vm.NewKonaExecutor()`, but the single-chain executor emits the kona host `single` subcommand and reads `inputs.L2Head` / `inputs.L2OutputRoot` — neither of which is populated by `createGameInputsInterop`. The resulting kona-host command can't reach a successful output-root verification for super-cannon-kona.

Split the runner factory case so `SuperCannonKonaGameType` uses `vm.NewKonaSuperExecutor()`, matching the production wiring in `op-challenger/game/fault/register.go`. Adds a runner-level test asserting each game type maps to its expected executor and that super-cannon-kona produces the kona host `super` subcommand with `--agreed-l2-pre-state`, `--claimed-l2-post-state`, `--l2-node-addresses`, and `--depset-cfg`.

Fixes ethereum-optimism/optimism#20506