### PR TITLE
chore(rust): ignore RUSTSEC-2026-0118 and RUSTSEC-2026-0119

### DIFF
--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -14,6 +14,12 @@ ignore = [
   "RUSTSEC-2024-0436",
   # bincode is unmaintained but still functional; transitive dep from reth-nippy-jar and test-fuzz.
   "RUSTSEC-2025-0141",
+  # hickory-proto <0.26.1 NSEC3 closest-encloser DNSSEC validation unbounded loop;
+  # transitive via reth-network -> reth-dns-discovery. Pending upstream bump.
+  "RUSTSEC-2026-0118",
+  # hickory-proto <0.26.1 O(n^2) name-compression CPU exhaustion in BinEncoder;
+  # transitive via reth-network -> reth-dns-discovery. Pending upstream bump.
+  "RUSTSEC-2026-0119",
 ]
 
 # This section is considered when running `cargo deny check bans`.


### PR DESCRIPTION
## Summary

- `cargo deny check advisories` started failing on every Rust-touching PR after RustSec published two new advisories on 2026-05-01: `RUSTSEC-2026-0118` (NSEC3 closest-encloser DNSSEC validation unbounded loop) and `RUSTSEC-2026-0119` (O(n²) name compression CPU exhaustion in `BinEncoder`).
- Both affect `hickory-proto <0.26.1`. Our tree pins `hickory-proto v0.25.2` transitively via `reth-network` → `reth-dns-discovery`, so we can't fix at the source until an upstream bump lands.
- Adds both IDs to `rust/deny.toml`'s `[advisories].ignore` list with comments explaining the path and that the entries should be removed once `hickory-proto` is bumped to 0.26.1+.

## Test plan

- [x] `cd rust && cargo deny --all-features check all` → `advisories ok, bans ok, licenses ok, sources ok`
- [x] CI `rust-deny` job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)