### PR TITLE
feat(op-node): support post-exec span batches

### DIFF
--- a/op-devstack/dsl/l2_network.go
+++ b/op-devstack/dsl/l2_network.go
@@ -501,12 +501,7 @@ func (n *L2Network) DeriveData(blocks int) (channels []derive.ChannelID, channel
 				}
 
 			} else if batchType == derive.SpanBatchType {
-				spanBatch, err := derive.DeriveSpanBatch(
-					batchData,
-					rollupCfg.BlockTime,
-					rollupCfg.Genesis.L2Time,
-					rollupCfg.L2ChainID,
-				)
+				spanBatch, err := derive.DeriveSpanBatch(batchData, rollupCfg)
 				if err != nil {
 					l.Warn("Failed to decode span batch",
 						"channelID", channelID.String(),

--- a/op-node/cmd/batch_decoder/reassemble/reassemble.go
+++ b/op-node/cmd/batch_decoder/reassemble/reassemble.go
@@ -141,7 +141,7 @@ func ProcessFrames(cfg Config, rollupCfg *rollup.Config, id derive.ChannelID, fr
 						// singularBatch will be nil when errored
 						batches = append(batches, singularBatch)
 					case derive.SpanBatchType:
-						spanBatch, err := derive.DeriveSpanBatch(batchData, cfg.L2BlockTime, cfg.L2GenesisTime, cfg.L2ChainID)
+						spanBatch, err := derive.DeriveSpanBatch(batchData, rollupCfg)
 						if err != nil {
 							invalidBatches = true
 							fmt.Printf("Error deriving spanBatch from batchData for channel %v. Err: %v\n", id.String(), err)

--- a/op-node/rollup/derive/batch_test.go
+++ b/op-node/rollup/derive/batch_test.go
@@ -132,6 +132,11 @@ func TestBatchRoundTrip(t *testing.T) {
 	blockTime := uint64(2)
 	genesisTimestamp := uint64(0)
 	chainID := new(big.Int).SetUint64(rng.Uint64())
+	rollupCfg := &rollup.Config{
+		Genesis:   rollup.Genesis{L2Time: genesisTimestamp},
+		BlockTime: blockTime,
+		L2ChainID: chainID,
+	}
 
 	batches := []*BatchData{
 		NewBatchData(
@@ -164,7 +169,7 @@ func TestBatchRoundTrip(t *testing.T) {
 		err = dec.UnmarshalBinary(enc)
 		require.NoError(t, err)
 		if dec.GetBatchType() == SpanBatchType {
-			_, err := DeriveSpanBatch(&dec, blockTime, genesisTimestamp, chainID)
+			_, err := DeriveSpanBatch(&dec, rollupCfg)
 			require.NoError(t, err)
 		}
 		requireEqual(t, batch, &dec, "Batch not equal test case %v", i)
@@ -176,6 +181,11 @@ func TestBatchRoundTripRLP(t *testing.T) {
 	blockTime := uint64(2)
 	genesisTimestamp := uint64(0)
 	chainID := new(big.Int).SetUint64(rng.Uint64())
+	rollupCfg := &rollup.Config{
+		Genesis:   rollup.Genesis{L2Time: genesisTimestamp},
+		BlockTime: blockTime,
+		L2ChainID: chainID,
+	}
 
 	batches := []*BatchData{
 		NewBatchData(
@@ -212,7 +222,7 @@ func TestBatchRoundTripRLP(t *testing.T) {
 		err = dec.DecodeRLP(s)
 		require.NoError(t, err)
 		if dec.GetBatchType() == SpanBatchType {
-			_, err = DeriveSpanBatch(&dec, blockTime, genesisTimestamp, chainID)
+			_, err = DeriveSpanBatch(&dec, rollupCfg)
 			require.NoError(t, err)
 		}
 		requireEqual(t, batch, &dec, "Batch not equal test case %v", i)

--- a/op-node/rollup/derive/channel_in_reader.go
+++ b/op-node/rollup/derive/channel_in_reader.go
@@ -114,7 +114,7 @@ func (cr *ChannelInReader) NextBatch(ctx context.Context) (Batch, error) {
 			cr.log.Warn("dropping span batch before Delta activation", "origin", origin)
 			return nil, NotEnoughData
 		}
-		batch.Batch, err = DeriveSpanBatch(batchData, cr.cfg.BlockTime, cr.cfg.Genesis.L2Time, cr.cfg.L2ChainID)
+		batch.Batch, err = DeriveSpanBatch(batchData, cr.cfg)
 		if err != nil {
 			if errors.Is(err, ErrCritical) {
 				return nil, err

--- a/op-node/rollup/derive/channel_out_test.go
+++ b/op-node/rollup/derive/channel_out_test.go
@@ -469,7 +469,7 @@ func testSpanChannelOut_MaxBlocksPerSpanBatch(t *testing.T, tt maxBlocksTest) {
 		bd, err := br()
 		require.NoError(t, err)
 		require.EqualValues(t, SpanBatchType, bd.GetBatchType())
-		sb, err := DeriveSpanBatch(bd, rollupCfg.BlockTime, rollupCfg.Genesis.L2Time, cout.spanBatch.ChainID)
+		sb, err := DeriveSpanBatch(bd, &rollupCfg)
 		require.NoError(t, err)
 		require.Equal(t, expBlocks, sb.GetBlockCount())
 		sbs0, err := sb.GetSingularBatches([]eth.L1BlockRef{l1Origin}, l2SafeHead)

--- a/op-node/rollup/derive/span_batch.go
+++ b/op-node/rollup/derive/span_batch.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/common/math"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rlp"
 
@@ -643,13 +644,27 @@ func NewSpanBatch(genesisTimestamp uint64, chainID *big.Int) *SpanBatch {
 }
 
 // DeriveSpanBatch derives SpanBatch from BatchData.
-func DeriveSpanBatch(batchData *BatchData, blockTime, genesisTimestamp uint64, chainID *big.Int) (*SpanBatch, error) {
+func DeriveSpanBatch(batchData *BatchData, cfg *rollup.Config) (*SpanBatch, error) {
 	rawSpanBatch, ok := batchData.inner.(*RawSpanBatch)
 	if !ok {
 		return nil, NewCriticalError(errors.New("failed type assertion to SpanBatch"))
 	}
-	// If the batch type is Span batch, derive block inputs from RawSpanBatch.
-	return rawSpanBatch.ToSpanBatch(blockTime, genesisTimestamp, chainID)
+	spanBatch, err := rawSpanBatch.ToSpanBatch(cfg.BlockTime, cfg.Genesis.L2Time, cfg.L2ChainID)
+	if err != nil {
+		return nil, err
+	}
+	// Reject PostExec transactions in blocks where SDM is not active.
+	for _, b := range spanBatch.Batches {
+		if cfg.IsSDM(b.Timestamp) {
+			continue
+		}
+		for _, raw := range b.Transactions {
+			if len(raw) > 0 && raw[0] == types.PostExecTxType {
+				return nil, fmt.Errorf("span batch contains PostExec tx at block ts=%d but SDM is not active", b.Timestamp)
+			}
+		}
+	}
+	return spanBatch, nil
 }
 
 // ReadTxData reads raw RLP tx data from reader and returns txData and txType

--- a/op-node/rollup/derive/span_batch_test.go
+++ b/op-node/rollup/derive/span_batch_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rlp"
 
@@ -613,4 +614,50 @@ func TestSpanBatchTotalBlockTxCountNotOverflow(t *testing.T) {
 	err = sb.decodeTxs(r)
 
 	require.ErrorIs(t, err, ErrTooBigSpanBatchSize)
+}
+
+// TestDeriveSpanBatchSDMGate verifies that DeriveSpanBatch rejects PostExec
+// transactions when SDM is not active and accepts them once it is.
+func TestDeriveSpanBatchSDMGate(t *testing.T) {
+	chainID := big.NewInt(901)
+	const (
+		genesisTime = uint64(100)
+		blockTime   = uint64(2)
+		blockTS     = genesisTime + blockTime
+	)
+
+	rawPostExecTx, err := testPostExecTx().MarshalBinary()
+	require.NoError(t, err)
+
+	singular := &SingularBatch{
+		ParentHash:   common.Hash{0x01},
+		EpochNum:     1,
+		EpochHash:    common.Hash{0x02},
+		Timestamp:    blockTS,
+		Transactions: []hexutil.Bytes{rawPostExecTx},
+	}
+	sb := NewSpanBatch(genesisTime, chainID)
+	require.NoError(t, sb.AppendSingularBatch(singular, 0))
+	rawSb, err := sb.ToRawSpanBatch()
+	require.NoError(t, err)
+	bd := NewBatchData(rawSb)
+
+	disabled := &rollup.Config{
+		Genesis:   rollup.Genesis{L2Time: genesisTime},
+		BlockTime: blockTime,
+		L2ChainID: chainID,
+	}
+	_, err = DeriveSpanBatch(bd, disabled)
+	require.ErrorContains(t, err, "PostExec tx")
+
+	sdmTime := blockTS
+	enabled := &rollup.Config{
+		Genesis:     rollup.Genesis{L2Time: genesisTime},
+		BlockTime:   blockTime,
+		L2ChainID:   chainID,
+		InteropTime: &sdmTime,
+	}
+	derived, err := DeriveSpanBatch(bd, enabled)
+	require.NoError(t, err)
+	require.Equal(t, 1, derived.GetBlockCount())
 }

--- a/op-node/rollup/derive/span_batch_test.go
+++ b/op-node/rollup/derive/span_batch_test.go
@@ -501,13 +501,24 @@ func TestSpanBatchReadTxData(t *testing.T) {
 			}
 
 			for txIdx := 0; txIdx < testCase.trials; txIdx++ {
-				r := bytes.NewReader(rawTxs[i])
+				r := bytes.NewReader(rawTxs[txIdx])
 				_, txType, err := ReadTxData(r)
 				require.NoError(t, err)
-				assert.Equal(t, int(txs[i].Type()), txType)
+				assert.Equal(t, int(txs[txIdx].Type()), txType)
 			}
 		})
 	}
+}
+
+func TestSpanBatchReadPostExecTxData(t *testing.T) {
+	rawTx, err := testPostExecTx().MarshalBinary()
+	require.NoError(t, err)
+
+	r := bytes.NewReader(rawTx)
+	txData, txType, err := ReadTxData(r)
+	require.NoError(t, err)
+	require.Equal(t, int(types.PostExecTxType), txType)
+	require.Equal(t, rawTx, txData)
 }
 
 func TestSpanBatchReadTxDataInvalid(t *testing.T) {

--- a/op-node/rollup/derive/span_batch_tx.go
+++ b/op-node/rollup/derive/span_batch_tx.go
@@ -3,6 +3,7 @@ package derive
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -57,6 +58,29 @@ type spanBatchSetCodeTxData struct {
 
 func (txData *spanBatchSetCodeTxData) txType() byte { return types.SetCodeTxType }
 
+type spanBatchPostExecTxData struct {
+	Data []byte
+}
+
+func (txData *spanBatchPostExecTxData) txType() byte { return types.PostExecTxType }
+
+// EncodeRLP writes the opaque post-exec payload bytes directly. Unlike other typed
+// span batch tx data, the post-exec payload is not wrapped in an RLP list.
+func (txData *spanBatchPostExecTxData) EncodeRLP(w io.Writer) error {
+	_, err := w.Write(txData.Data)
+	return err
+}
+
+// DecodeRLP captures the complete opaque post-exec payload value.
+func (txData *spanBatchPostExecTxData) DecodeRLP(s *rlp.Stream) error {
+	data, err := s.Raw()
+	if err != nil {
+		return err
+	}
+	txData.Data = data
+	return nil
+}
+
 // Type returns the transaction type.
 func (tx *spanBatchTx) Type() uint8 {
 	return tx.inner.txType()
@@ -110,6 +134,13 @@ func (tx *spanBatchTx) decodeTyped(b []byte) (spanBatchTxData, error) {
 		err := rlp.DecodeBytes(b[1:], &inner)
 		if err != nil {
 			return nil, fmt.Errorf("failed to decode spanBatchSetCodeTxData: %w", err)
+		}
+		return &inner, nil
+	case types.PostExecTxType:
+		var inner spanBatchPostExecTxData
+		err := rlp.DecodeBytes(b[1:], &inner)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode spanBatchPostExecTxData: %w", err)
 		}
 		return &inner, nil
 	default:
@@ -208,6 +239,9 @@ func (tx *spanBatchTx) convertToFullTx(nonce, gas uint64, to *common.Address, ch
 			R:          uint256.MustFromBig(R),
 			S:          uint256.MustFromBig(S),
 		}
+	case types.PostExecTxType:
+		postExecTxInner := tx.inner.(*spanBatchPostExecTxData)
+		inner = &types.PostExecTx{Data: common.CopyBytes(postExecTxInner.Data)}
 	default:
 		return nil, fmt.Errorf("invalid tx type: %d", tx.Type())
 	}
@@ -248,6 +282,8 @@ func newSpanBatchTx(tx *types.Transaction) (*spanBatchTx, error) {
 			AccessList:        tx.AccessList(),
 			AuthorizationList: tx.SetCodeAuthorizations(),
 		}
+	case types.PostExecTxType:
+		inner = &spanBatchPostExecTxData{Data: common.CopyBytes(tx.Data())}
 	default:
 		return nil, fmt.Errorf("invalid tx type: %d", tx.Type())
 	}

--- a/op-node/rollup/derive/span_batch_tx_test.go
+++ b/op-node/rollup/derive/span_batch_tx_test.go
@@ -95,6 +95,47 @@ func TestSpanBatchTxRoundTrip(t *testing.T) {
 	}
 }
 
+func testPostExecTx() *types.Transaction {
+	return types.NewTx(&types.PostExecTx{Data: []byte{0xc2, 0x01, 0xc0}})
+}
+
+func TestSpanBatchTxPostExecConvert(t *testing.T) {
+	tx := testPostExecTx()
+	v, r, s := tx.RawSignatureValues()
+
+	sbtx, err := newSpanBatchTx(tx)
+	require.NoError(t, err)
+
+	// Deliberately pass non-canonical tx envelope fields. PostExec reconstruction
+	// must ignore them and preserve only the opaque payload bytes.
+	tx2, err := sbtx.convertToFullTx(123, 456, nil, big.NewInt(901), v, r, s)
+	require.NoError(t, err)
+
+	txEncoded, err := tx.MarshalBinary()
+	require.NoError(t, err)
+	tx2Encoded, err := tx2.MarshalBinary()
+	require.NoError(t, err)
+	require.Equal(t, txEncoded, tx2Encoded)
+}
+
+func TestSpanBatchTxPostExecRoundTrip(t *testing.T) {
+	tx := testPostExecTx()
+
+	sbtx, err := newSpanBatchTx(tx)
+	require.NoError(t, err)
+
+	sbtxEncoded, err := sbtx.MarshalBinary()
+	require.NoError(t, err)
+	txEncoded, err := tx.MarshalBinary()
+	require.NoError(t, err)
+	require.Equal(t, txEncoded, sbtxEncoded)
+
+	var sbtx2 spanBatchTx
+	err = sbtx2.UnmarshalBinary(sbtxEncoded)
+	require.NoError(t, err)
+	require.Equal(t, sbtx, &sbtx2)
+}
+
 type spanBatchDummyTxData struct{}
 
 func (txData *spanBatchDummyTxData) txType() byte { return types.DepositTxType }

--- a/op-node/rollup/derive/span_batch_txs.go
+++ b/op-node/rollup/derive/span_batch_txs.go
@@ -274,6 +274,9 @@ func (btx *spanBatchTxs) recoverV(chainID *big.Int) error {
 		case types.AccessListTxType, types.DynamicFeeTxType, types.SetCodeTxType:
 			// For non-legacy tx types, v is just the y-parity bit (0 or 1).
 			v = big.NewInt(int64(bit))
+		case types.PostExecTxType:
+			// PostExec txs are synthetic, unsigned, and chain-agnostic.
+			v = big.NewInt(0)
 		default:
 			return fmt.Errorf("invalid tx type: %d", txType)
 		}
@@ -348,7 +351,7 @@ func (btx *spanBatchTxs) fullTxs(chainID *big.Int) ([][]byte, error) {
 		}
 		nonce := btx.txNonces[idx]
 		gas := btx.txGases[idx]
-		var to *common.Address = nil
+		var to *common.Address
 		bit := btx.contractCreationBits.Bit(idx)
 		if bit == 0 {
 			if len(btx.txTos) <= toIdx {
@@ -386,12 +389,10 @@ func convertVToYParity(v *big.Int, txType int) (uint, error) {
 			// unprotected legacy txs must have v = 27 or 28
 			yParityBit = uint(bigs.Uint64Strict(v) - 27)
 		}
-	case types.AccessListTxType:
+	case types.AccessListTxType, types.DynamicFeeTxType, types.SetCodeTxType:
 		yParityBit = uint(bigs.Uint64Strict(v))
-	case types.DynamicFeeTxType:
-		yParityBit = uint(bigs.Uint64Strict(v))
-	case types.SetCodeTxType:
-		yParityBit = uint(bigs.Uint64Strict(v))
+	case types.PostExecTxType:
+		yParityBit = 0
 	default:
 		return 0, fmt.Errorf("invalid tx type: %d", txType)
 	}
@@ -428,11 +429,10 @@ func newSpanBatchTxs(txs [][]byte, chainID *big.Int) (*spanBatchTxs, error) {
 }
 
 func (sbtx *spanBatchTxs) AddTxs(txs [][]byte, chainID *big.Int) error {
-	totalBlockTxCount := uint64(len(txs))
 	offset := sbtx.totalBlockTxCount
-	for idx := 0; idx < int(totalBlockTxCount); idx++ {
+	for idx, rawTx := range txs {
 		tx := &types.Transaction{}
-		if err := tx.UnmarshalBinary(txs[idx]); err != nil {
+		if err := tx.UnmarshalBinary(rawTx); err != nil {
 			return errors.New("failed to decode tx")
 		}
 		if tx.Type() == types.LegacyTxType {
@@ -443,7 +443,7 @@ func (sbtx *spanBatchTxs) AddTxs(txs [][]byte, chainID *big.Int) error {
 			sbtx.protectedBits.SetBit(sbtx.protectedBits, int(sbtx.totalLegacyTxCount), protectedBit)
 			sbtx.totalLegacyTxCount++
 		}
-		if tx.Protected() && tx.ChainId().Cmp(chainID) != 0 {
+		if tx.Type() != types.PostExecTxType && tx.Protected() && tx.ChainId().Cmp(chainID) != 0 {
 			return fmt.Errorf("protected tx has chain ID %d, but expected chain ID %d", tx.ChainId(), chainID)
 		}
 		var txSig spanBatchSignature
@@ -478,6 +478,6 @@ func (sbtx *spanBatchTxs) AddTxs(txs [][]byte, chainID *big.Int) error {
 		sbtx.txDatas = append(sbtx.txDatas, txData)
 		sbtx.txTypes = append(sbtx.txTypes, int(tx.Type()))
 	}
-	sbtx.totalBlockTxCount += totalBlockTxCount
+	sbtx.totalBlockTxCount += uint64(len(txs))
 	return nil
 }

--- a/op-node/rollup/derive/span_batch_txs_test.go
+++ b/op-node/rollup/derive/span_batch_txs_test.go
@@ -458,6 +458,50 @@ func TestSpanBatchTxsRoundTripFullTxs(t *testing.T) {
 	}
 }
 
+func TestSpanBatchTxsPostExecRoundTripFullTxs(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x7d7331))
+	chainID := big.NewInt(901)
+	signer := types.NewIsthmusSigner(chainID)
+
+	normalTx := testutils.RandomDynamicFeeTx(rng, signer)
+	postExecTx := testPostExecTx()
+
+	var txs [][]byte
+	for _, tx := range []*types.Transaction{normalTx, postExecTx} {
+		rawTx, err := tx.MarshalBinary()
+		require.NoError(t, err)
+		txs = append(txs, rawTx)
+	}
+
+	sbt, err := newSpanBatchTxs(txs, chainID)
+	require.NoError(t, err)
+
+	txs2, err := sbt.fullTxs(chainID)
+	require.NoError(t, err)
+	require.Equal(t, txs, txs2)
+}
+
+func TestSpanBatchTxsPostExecSkipsChainIDValidation(t *testing.T) {
+	chainID := big.NewInt(901)
+	rawPostExecTx, err := testPostExecTx().MarshalBinary()
+	require.NoError(t, err)
+
+	_, err = newSpanBatchTxs([][]byte{rawPostExecTx}, chainID)
+	require.NoError(t, err)
+}
+
+func TestSpanBatchTxsRejectsWrongChainIDForProtectedTx(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x901902))
+	chainID := big.NewInt(901)
+	wrongChainID := big.NewInt(902)
+	tx := testutils.RandomDynamicFeeTx(rng, types.NewIsthmusSigner(wrongChainID))
+	rawTx, err := tx.MarshalBinary()
+	require.NoError(t, err)
+
+	_, err = newSpanBatchTxs([][]byte{rawTx}, chainID)
+	require.ErrorContains(t, err, "protected tx has chain ID 902, but expected chain ID 901")
+}
+
 func TestSpanBatchTxsRecoverVInvalidTxType(t *testing.T) {
 	rng := rand.New(rand.NewSource(0x321))
 	chainID := big.NewInt(rng.Int63n(1000))

--- a/op-node/rollup/toggles.go
+++ b/op-node/rollup/toggles.go
@@ -22,3 +22,9 @@ func (c *Config) IsL2CMActivationBlock(l2BlockTime uint64) bool {
 	}
 	return c.IsKarstActivationBlock(l2BlockTime)
 }
+
+// IsSDM gates Sequencer-Defined Metering. When this returns false, span batches
+// carrying PostExec transactions are rejected during derivation.
+func (c *Config) IsSDM(time uint64) bool {
+	return c.IsInterop(time)
+}


### PR DESCRIPTION
Adds op-node derivation support for PostExec transactions inside span batches, gated on a new SDM (Sequencer-Defined Metering) rollup toggle.

  - Span batch codec supports the `PostExecTxType`.
  - `DeriveSpanBatch` rejects span batches that carry a `PostExec` tx in any block whose timestamp is before SDM activation.
  - New `Config.IsSDM(time)` toggle in `op-node/rollup/toggles.go`. Currently aliased to `IsInterop` as a placeholder until the activation fork is decided.