### PR TITLE
feat(devstack): support SDM acceptance tests

### DIFF
--- a/op-devstack/sysgo/l2_el_opreth.go
+++ b/op-devstack/sysgo/l2_el_opreth.go
@@ -14,6 +14,68 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
+// OpRethConfig holds the configurable knobs applied to an op-reth node before it is started.
+type OpRethConfig struct {
+	// ExtraArgs are appended to the generated CLI args.
+	ExtraArgs []string
+}
+
+// DefaultOpRethConfig returns a zero-valued OpRethConfig that callers can mutate via OpRethOptions.
+func DefaultOpRethConfig() *OpRethConfig {
+	return &OpRethConfig{}
+}
+
+// OpRethOption customises an OpRethConfig for a specific component target.
+type OpRethOption interface {
+	Apply(p devtest.T, target ComponentTarget, cfg *OpRethConfig)
+}
+
+// OpRethOptionFn adapts a plain function into an OpRethOption.
+type OpRethOptionFn func(p devtest.T, target ComponentTarget, cfg *OpRethConfig)
+
+var _ OpRethOption = OpRethOptionFn(nil)
+
+// Apply invokes the underlying function against the supplied config.
+func (fn OpRethOptionFn) Apply(p devtest.T, target ComponentTarget, cfg *OpRethConfig) {
+	fn(p, target, cfg)
+}
+
+// OpRethOptionBundle applies multiple OpRethOptions in order.
+type OpRethOptionBundle []OpRethOption
+
+var _ OpRethOption = OpRethOptionBundle(nil)
+
+// Apply runs each contained option against cfg, failing the test on a nil entry.
+func (b OpRethOptionBundle) Apply(p devtest.T, target ComponentTarget, cfg *OpRethConfig) {
+	for _, opt := range b {
+		p.Require().NotNil(opt, "cannot Apply nil OpRethOption")
+		opt.Apply(p, target, cfg)
+	}
+}
+
+// OpRethWithExtraArgs appends raw CLI arguments to the op-reth invocation.
+func OpRethWithExtraArgs(args ...string) OpRethOption {
+	return OpRethOptionFn(func(p devtest.T, _ ComponentTarget, cfg *OpRethConfig) {
+		cfg.ExtraArgs = append(cfg.ExtraArgs, args...)
+	})
+}
+
+// OpRethWithSDMEnabled enables Sequencer-Defined Metering on the op-reth node.
+func OpRethWithSDMEnabled() OpRethOption {
+	return OpRethWithExtraArgs("--rollup.sdm-enabled")
+}
+
+// OpRethWithSupervisorURL wires the op-reth node to the given supervisor HTTP endpoint.
+// An empty supervisorURL is a no-op so callers can pass the value unconditionally.
+func OpRethWithSupervisorURL(supervisorURL string) OpRethOption {
+	return OpRethOptionFn(func(p devtest.T, _ ComponentTarget, cfg *OpRethConfig) {
+		if supervisorURL == "" {
+			return
+		}
+		cfg.ExtraArgs = append(cfg.ExtraArgs, "--rollup.supervisor-http="+supervisorURL)
+	})
+}
+
 type OpReth struct {
 	mu sync.Mutex
 

--- a/op-devstack/sysgo/mixed_runtime.go
+++ b/op-devstack/sysgo/mixed_runtime.go
@@ -117,6 +117,8 @@ type MixedSingleChainPresetConfig struct {
 	TestSequencerName          string
 	LocalContractArtifactsPath string
 	DeployerOptions            []DeployerOption
+	BatcherOptions             []BatcherOption
+	OpRethOptions              []OpRethOption
 }
 
 type mixedSingleChainNode struct {
@@ -169,9 +171,9 @@ func NewMixedSingleChainRuntime(t devtest.T, cfg MixedSingleChainPresetConfig) *
 		case MixedL2ELOpGeth:
 			el = startL2ELNode(t, l2Net, jwtPath, jwtSecret, spec.ELKey, identity)
 		case MixedL2ELOpReth:
-			el = startMixedOpRethNode(t, l2Net, spec.ELKey, jwtPath, jwtSecret, metricsRegistrar, "v1")
+			el = startMixedOpRethNode(t, l2Net, spec.ELKey, jwtPath, jwtSecret, metricsRegistrar, "v1", cfg.OpRethOptions...)
 		case MixedL2ELOpRethV2:
-			el = startMixedOpRethNode(t, l2Net, spec.ELKey, jwtPath, jwtSecret, metricsRegistrar, "v2")
+			el = startMixedOpRethNode(t, l2Net, spec.ELKey, jwtPath, jwtSecret, metricsRegistrar, "v2", cfg.OpRethOptions...)
 		default:
 			require.FailNowf("unsupported EL kind", "unsupported mixed EL kind %q", spec.ELKind)
 		}
@@ -227,7 +229,7 @@ func NewMixedSingleChainRuntime(t devtest.T, cfg MixedSingleChainPresetConfig) *
 	}
 	require.NotNil(sequencerNode, "mixed runtime requires at least one sequencer node")
 
-	l2Batcher := startMinimalBatcher(t, keys, l2Net, l1EL, sequencerNode.cl, sequencerNode.el)
+	l2Batcher := startMinimalBatcher(t, keys, l2Net, l1EL, sequencerNode.cl, sequencerNode.el, cfg.BatcherOptions...)
 	faucetService := startFaucets(t, keys, l1Net.ChainID(), l2Net.ChainID(), l1EL.UserRPC(), sequencerNode.el.UserRPC())
 
 	var testSequencer *testSequencer
@@ -276,7 +278,6 @@ func mixedNodeRefs(nodes []mixedSingleChainNode) []MixedSingleChainNodeRefs {
 }
 
 // buildMixedOpRethNode constructs an OpReth node without starting it.
-// Use this when you need to customize args (e.g. --rollup.supervisor-http) before starting.
 func buildMixedOpRethNode(
 	t devtest.T,
 	l2Net *L2Network,
@@ -285,6 +286,7 @@ func buildMixedOpRethNode(
 	jwtSecret [32]byte,
 	metricsRegistrar L2MetricsRegistrar,
 	storageVersion string,
+	opts ...OpRethOption,
 ) *OpReth {
 	tempDir := t.TempDir()
 
@@ -374,6 +376,10 @@ func buildMixedOpRethNode(
 		"--proofs-history.storage-version="+storageVersion,
 	)
 
+	opRethCfg := DefaultOpRethConfig()
+	OpRethOptionBundle(opts).Apply(t, NewComponentTarget(key, l2Net.ChainID()), opRethCfg)
+	args = append(args, opRethCfg.ExtraArgs...)
+
 	return &OpReth{
 		name:               key,
 		chainID:            l2Net.ChainID(),
@@ -397,8 +403,9 @@ func startMixedOpRethNode(
 	jwtSecret [32]byte,
 	metricsRegistrar L2MetricsRegistrar,
 	storageVersion string,
+	opts ...OpRethOption,
 ) *OpReth {
-	node := buildMixedOpRethNode(t, l2Net, key, jwtPath, jwtSecret, metricsRegistrar, storageVersion)
+	node := buildMixedOpRethNode(t, l2Net, key, jwtPath, jwtSecret, metricsRegistrar, storageVersion, opts...)
 	t.Logger().Info("Starting op-reth", "name", key, "chain", l2Net.ChainID())
 	node.Start()
 	t.Cleanup(node.Stop)
@@ -417,11 +424,10 @@ func startMixedOpRethNodeWithSupervisorURL(
 	metricsRegistrar L2MetricsRegistrar,
 	supervisorURL string,
 	storageVersion string,
+	opts ...OpRethOption,
 ) *OpReth {
-	node := buildMixedOpRethNode(t, l2Net, key, jwtPath, jwtSecret, metricsRegistrar, storageVersion)
-	if supervisorURL != "" {
-		node.args = append(node.args, "--rollup.supervisor-http="+supervisorURL)
-	}
+	opts = append(opts, OpRethWithSupervisorURL(supervisorURL))
+	node := buildMixedOpRethNode(t, l2Net, key, jwtPath, jwtSecret, metricsRegistrar, storageVersion, opts...)
 	t.Logger().Info("Starting op-reth with supervisor URL",
 		"name", key, "chain", l2Net.ChainID(), "supervisorURL", supervisorURL)
 	node.Start()


### PR DESCRIPTION
Adds configuration options to `op-reth` so we can run it with `--rollup.sdm-enabled` flag.