### PR TITLE
feat(kona-genesis,op-revm): wire KARST hardfork into spec_id

### DIFF
--- a/rust/kona/crates/protocol/genesis/src/rollup.rs
+++ b/rust/kona/crates/protocol/genesis/src/rollup.rs
@@ -168,6 +168,8 @@ impl RollupConfig {
     pub fn spec_id(&self, timestamp: u64) -> op_revm::OpSpecId {
         if self.is_interop_active(timestamp) {
             op_revm::OpSpecId::INTEROP
+        } else if self.is_karst_active(timestamp) {
+            op_revm::OpSpecId::KARST
         } else if self.is_jovian_active(timestamp) {
             op_revm::OpSpecId::JOVIAN
         } else if self.is_isthmus_active(timestamp) {
@@ -534,6 +536,12 @@ mod tests {
         assert_eq!(config.spec_id(50), op_revm::OpSpecId::HOLOCENE);
         config.hardforks.isthmus_time = Some(60);
         assert_eq!(config.spec_id(60), op_revm::OpSpecId::ISTHMUS);
+        config.hardforks.jovian_time = Some(70);
+        assert_eq!(config.spec_id(70), op_revm::OpSpecId::JOVIAN);
+        config.hardforks.karst_time = Some(80);
+        assert_eq!(config.spec_id(80), op_revm::OpSpecId::KARST);
+        config.hardforks.interop_time = Some(90);
+        assert_eq!(config.spec_id(90), op_revm::OpSpecId::INTEROP);
     }
 
     #[test]

--- a/rust/op-revm/src/spec.rs
+++ b/rust/op-revm/src/spec.rs
@@ -212,6 +212,28 @@ mod tests {
                     (OpSpecId::FJORD, true),
                     (OpSpecId::HOLOCENE, true),
                     (OpSpecId::ISTHMUS, true),
+                    (OpSpecId::JOVIAN, true),
+                ],
+            ),
+            (
+                OpSpecId::KARST,
+                vec![
+                    (SpecId::OSAKA, true),
+                    (SpecId::PRAGUE, true),
+                    (SpecId::SHANGHAI, true),
+                    (SpecId::CANCUN, true),
+                    (SpecId::MERGE, true),
+                ],
+                vec![
+                    (OpSpecId::BEDROCK, true),
+                    (OpSpecId::REGOLITH, true),
+                    (OpSpecId::CANYON, true),
+                    (OpSpecId::ECOTONE, true),
+                    (OpSpecId::FJORD, true),
+                    (OpSpecId::HOLOCENE, true),
+                    (OpSpecId::ISTHMUS, true),
+                    (OpSpecId::JOVIAN, true),
+                    (OpSpecId::KARST, true),
                 ],
             ),
         ];


### PR DESCRIPTION
Map the KARST timestamp activation to op_revm::OpSpecId::KARST in RollupConfig::spec_id, ordered after JOVIAN and before INTEROP. Extend the spec_id and is_enabled_in tests to cover JOVIAN, KARST, and INTEROP, and bump the superchain-registry submodule.