### PR TITLE
feat(op-devstack): add MinimalWithKona preset for native kona-host runs

### DIFF
--- a/op-devstack/dsl/l2_cl.go
+++ b/op-devstack/dsl/l2_cl.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/big"
 	"strings"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/utils"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
 	"github.com/ethereum-optimism/optimism/op-node/node/safedb"
@@ -582,5 +584,28 @@ func (cl *L2CLNode) CurrentL1MatchedFn(refNode *L2CLNode, attempts int) CheckFun
 				cl.log.Info("Chain sync status", "currentL1", currentL1.Number, "ref", ref)
 				return fmt.Errorf("expected currentL1 to match")
 			})
+	}
+}
+
+func (cl *L2CLNode) LocalGameInputs(agreedBlock, claimBlock uint64) *utils.LocalGameInputs {
+	cl.Reached(types.LocalSafe, claimBlock, 60)
+
+	rollupAPI := cl.Escape().RollupAPI()
+
+	agreedOutput, err := rollupAPI.OutputAtBlock(cl.ctx, agreedBlock)
+	cl.require.NoError(err, "fetch output at agreed block %d", agreedBlock)
+
+	claimedOutput, err := rollupAPI.OutputAtBlock(cl.ctx, claimBlock)
+	cl.require.NoError(err, "fetch output at claim block %d", claimBlock)
+
+	syncStatus, err := rollupAPI.SyncStatus(cl.ctx)
+	cl.require.NoError(err, "fetch L2 sync status")
+
+	return &utils.LocalGameInputs{
+		L1Head:           syncStatus.CurrentL1.Hash,
+		L2Head:           agreedOutput.BlockRef.Hash,
+		L2OutputRoot:     common.Hash(agreedOutput.OutputRoot),
+		L2Claim:          common.Hash(claimedOutput.OutputRoot),
+		L2SequenceNumber: new(big.Int).SetUint64(claimBlock),
 	}
 }

--- a/op-devstack/presets/minimal_with_kona.go
+++ b/op-devstack/presets/minimal_with_kona.go
@@ -1,0 +1,34 @@
+package presets
+
+import (
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/vm"
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+)
+
+// MinimalWithKona embeds Minimal and bundles everything needed to run kona-host in --native mode
+// against a live devstack.
+type MinimalWithKona struct {
+	*Minimal
+
+	VMConfig *vm.Config
+	Dir      string
+}
+
+// NewMinimalWithKona creates a Minimal preset with the kona-host binary located and the chain
+// configs needed to invoke kona natively.
+func NewMinimalWithKona(t devtest.T, opts ...Option) *MinimalWithKona {
+	presetCfg, presetOpts := collectSupportedPresetConfig(t, "NewMinimalWithKona", opts, minimalPresetSupportedOptionKinds)
+	out := minimalWithKonaFromRuntime(t, sysgo.NewMinimalRuntimeWithConfig(t, presetCfg))
+	presetOpts.applyPreset(out)
+	return out
+}
+
+func minimalWithKonaFromRuntime(t devtest.T, runtime *sysgo.SingleChainRuntime) *MinimalWithKona {
+	dir := t.TempDir()
+	return &MinimalWithKona{
+		Minimal:  minimalFromRuntime(t, runtime),
+		VMConfig: runtime.VMConfig(t, dir),
+		Dir:      dir,
+	}
+}

--- a/op-devstack/shared/rustbin/kona_host_native.go
+++ b/op-devstack/shared/rustbin/kona_host_native.go
@@ -1,0 +1,42 @@
+package rustbin
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/utils"
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/vm"
+	"github.com/ethereum-optimism/optimism/op-service/logpipe"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+)
+
+// RunKonaNative runs kona-host in --native mode. Returns false if kona disagrees and true
+// otherwise.
+func RunKonaNative(t require.TestingT, logger log.Logger, vmConfig *vm.Config, dir string, inputs *utils.LocalGameInputs) bool {
+	require.NotNil(t, vmConfig)
+	require.NotNil(t, inputs)
+	args, err := vm.NewNativeKonaExecutor().OracleCommand(*vmConfig, dir, *inputs)
+	require.NoError(t, err, "build kona oracle command")
+
+	cmd := exec.Command(args[0], args[1:]...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "KONA_LOG_STDOUT_FORMAT=json", "NO_COLOR=1")
+
+	logOut := logpipe.ToLoggerWithMinLevel(logger.New("component", "kona-host", "src", "stdout"), log.LevelWarn)
+	logErr := logpipe.ToLoggerWithMinLevel(logger.New("component", "kona-host", "src", "stderr"), log.LevelWarn)
+	cmd.Stdout = logpipe.NewLineBuffer(logpipe.LogCallback(func(line []byte) {
+		logOut(logpipe.ParseRustStructuredLogs(line))
+	}))
+	cmd.Stderr = logpipe.NewLineBuffer(logpipe.LogCallback(func(line []byte) {
+		logErr(logpipe.ParseRustStructuredLogs(line))
+	}))
+
+	var exitErr *exec.ExitError
+	if runErr := cmd.Run(); errors.As(runErr, &exitErr) && exitErr.ExitCode() == 1 {
+		return false
+	}
+	require.NoError(t, err)
+	return true
+}

--- a/op-devstack/sysgo/l1_network.go
+++ b/op-devstack/sysgo/l1_network.go
@@ -25,3 +25,7 @@ func (n *L1Network) ChainID() eth.ChainID {
 func (n *L1Network) ChainConfig() *params.ChainConfig {
 	return n.genesis.Config
 }
+
+func (n *L1Network) Genesis() *core.Genesis {
+	return n.genesis
+}

--- a/op-devstack/sysgo/runtime_state.go
+++ b/op-devstack/sysgo/runtime_state.go
@@ -1,8 +1,15 @@
 package sysgo
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+
 	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
 	challengerconfig "github.com/ethereum-optimism/optimism/op-challenger/config"
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/vm"
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/shared/rustbin"
 	"github.com/ethereum-optimism/optimism/op-faucet/faucet"
 	"github.com/ethereum-optimism/optimism/op-service/clock"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -84,6 +91,34 @@ type SingleChainRuntime struct {
 	Flashblocks *FlashblocksRuntimeSupport
 	Interop     *SingleChainInteropSupport
 	P2PEnabled  bool
+}
+
+func (r *SingleChainRuntime) VMConfig(t devtest.T, dir string) *vm.Config {
+	konaHostPath, err := rustbin.Spec{
+		SrcDir:  "rust/kona",
+		Package: "kona-host",
+		Binary:  "kona-host",
+	}.EnsureExists(t.Ctx(), t.Logger())
+	t.Require().NoError(err, "locate/build kona-host")
+
+	rollupCfgPath := filepath.Join(dir, "rollup.json")
+	rollupBytes, err := json.Marshal(r.L2Network.RollupConfig())
+	t.Require().NoError(err, "marshal rollup config")
+	t.Require().NoError(os.WriteFile(rollupCfgPath, rollupBytes, 0o644), "write rollup config")
+
+	l1GenesisPath := filepath.Join(dir, "l1-genesis.json")
+	l1GenesisBytes, err := json.Marshal(r.L1Network.Genesis())
+	t.Require().NoError(err, "marshal l1 genesis")
+	t.Require().NoError(os.WriteFile(l1GenesisPath, l1GenesisBytes, 0o644), "write l1 genesis")
+
+	return &vm.Config{
+		L1:                r.L1EL.UserRPC(),
+		L1Beacon:          r.L1CL.BeaconHTTPAddr(),
+		L2s:               []string{r.L2EL.UserRPC()},
+		RollupConfigPaths: []string{rollupCfgPath},
+		L1GenesisPath:     l1GenesisPath,
+		Server:            konaHostPath,
+	}
 }
 
 type MultiChainNodeRuntime struct {

--- a/op-e2e/actions/proofs/block_data_hint_test.go
+++ b/op-e2e/actions/proofs/block_data_hint_test.go
@@ -96,7 +96,6 @@ func Test_ProgramAction_BlockDataHint(gt *testing.T) {
 		L2ChainID:      chainID,
 		L1Head:         l1Head.Hash(),
 		AgreedPrestate: nil, // not used for block execution
-		InteropEnabled: false,
 		L2Sources: []*helpers.FaultProofProgramL2Source{{
 			Node:        verifier,
 			Engine:      verifierEngine,

--- a/op-e2e/actions/proofs/helpers/env.go
+++ b/op-e2e/actions/proofs/helpers/env.go
@@ -231,10 +231,6 @@ func NewOpProgramCfg(
 
 	dfault := config.NewConfig(rollupConfigs, l2chainConfigs, l1chainConfig, fi.L1Head, fi.L2Head, fi.L2OutputRoot, fi.L2Claim, fi.L2BlockNumber)
 	dfault.L2ChainID = boot.CustomChainIDIndicator
-	if fi.InteropEnabled {
-		dfault.AgreedPrestate = fi.AgreedPrestate
-	}
-	dfault.InteropEnabled = fi.InteropEnabled
 	dfault.DependencySet = fi.DependencySet
 	return dfault
 }

--- a/op-e2e/actions/proofs/helpers/fixture.go
+++ b/op-e2e/actions/proofs/helpers/fixture.go
@@ -29,7 +29,6 @@ type FixtureInputs struct {
 	L1Head         common.Hash                       `toml:"l1-head"`
 	AgreedPrestate []byte                            `toml:"agreed-prestate"`
 	DependencySet  *depset.StaticConfigDependencySet `toml:"dependency-set"`
-	InteropEnabled bool                              `toml:"use-interop"`
 
 	L2Sources []*FaultProofProgramL2Source
 

--- a/op-e2e/actions/proofs/helpers/kona.go
+++ b/op-e2e/actions/proofs/helpers/kona.go
@@ -6,14 +6,15 @@ import (
 	"io/fs"
 	"math/big"
 	"os"
-	"os/exec"
 	"path/filepath"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/utils"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/vm"
+	"github.com/ethereum-optimism/optimism/op-devstack/shared/rustbin"
 	"github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-program/client/claim"
+	"github.com/ethereum-optimism/optimism/op-service/log"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/stretchr/testify/require"
 )
@@ -74,32 +75,13 @@ func RunKonaNative(
 		L2Head:           fixtureInputs.L2Head,
 		L2Claim:          fixtureInputs.L2Claim,
 		L2SequenceNumber: big.NewInt(int64(fixtureInputs.L2BlockNumber)),
+		L2OutputRoot:     fixtureInputs.L2OutputRoot,
 	}
 
-	var hostCmd []string
-	var err error
-	if fixtureInputs.InteropEnabled {
-		inputs.AgreedPreState = fixtureInputs.AgreedPrestate
-		hostCmd, err = vm.NewNativeKonaSuperExecutor().OracleCommand(vmCfg, workDir, inputs)
-	} else {
-		inputs.L2OutputRoot = fixtureInputs.L2OutputRoot
-		hostCmd, err = vm.NewNativeKonaExecutor().OracleCommand(vmCfg, workDir, inputs)
-	}
-	require.NoError(t, err)
+	logger := log.NewLogger(os.Stdout, log.DefaultCLIConfig())
 
-	cmd := exec.Command(hostCmd[0], hostCmd[1:]...)
-	cmd.Dir = workDir
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stdout
-
-	status := cmd.Run()
-	switch status := status.(type) {
-	case *exec.ExitError:
-		if status.ExitCode() == 1 {
-			return claim.ErrClaimNotValid
-		}
-		return fmt.Errorf("kona exited with status %d", status.ExitCode())
-	default:
-		return status
+	if !rustbin.RunKonaNative(t, logger, &vmCfg, workDir, &inputs) {
+		return claim.ErrClaimNotValid
 	}
+	return nil
 }


### PR DESCRIPTION
Bundles everything an acceptance test needs to invoke `kona-host --native` against a live devstack into a single preset. Tests call `RunKona(t, agreedBlock, claimBlock)` and check the returned error: `nil` means kona agrees with the live chain on the block range, `claim.ErrClaimNotValid` means it disagreed.