### PR TITLE
refactor(op-service/eth): remove BlockInfo Header() and HeaderRLP() escape hatches

### DIFF
--- a/op-acceptance-tests/tests/jovian/bpo2/joviantest/cases.go
+++ b/op-acceptance-tests/tests/jovian/bpo2/joviantest/cases.go
@@ -20,7 +20,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus/misc/eip1559"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/rlp"
 )
 
 type SetupFn func(t devtest.T) *presets.Minimal
@@ -171,23 +170,13 @@ func (mbf *minBaseFeeEnv) waitForMinBaseFeeConfigChangeOnL2(t devtest.T, expecte
 			return false
 		}
 
-		// Get header RLP and decode to access Extra field.
-		headerRLP, err := info.HeaderRLP()
-		if err != nil {
+		extra := info.Extra()
+		if len(extra) != 17 {
 			return false
 		}
 
-		var header types.Header
-		if err := rlp.DecodeBytes(headerRLP, &header); err != nil {
-			return false
-		}
-
-		if len(header.Extra) != 17 {
-			return false
-		}
-
-		got := binary.BigEndian.Uint64(header.Extra[9:])
-		actualBlockExtraData = header.Extra
+		got := binary.BigEndian.Uint64(extra[9:])
+		actualBlockExtraData = extra
 		return got == expected
 	}, 2*time.Minute, 5*time.Second, "L2 min base fee in block header did not sync within timeout")
 

--- a/op-acceptance-tests/tests/jovian/min_base_fee.go
+++ b/op-acceptance-tests/tests/jovian/min_base_fee.go
@@ -17,8 +17,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/txintent/bindings"
 	"github.com/ethereum-optimism/optimism/op-service/txintent/contractio"
 	"github.com/ethereum/go-ethereum/consensus/misc/eip1559"
-	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/rlp"
 )
 
 type minBaseFeeEnv struct {
@@ -93,23 +91,13 @@ func (mbf *minBaseFeeEnv) waitForMinBaseFeeConfigChangeOnL2(t devtest.T, expecte
 			return false
 		}
 
-		// Get header RLP and decode to access Extra field
-		headerRLP, err := info.HeaderRLP()
-		if err != nil {
+		extra := info.Extra()
+		if len(extra) != 17 {
 			return false
 		}
 
-		var header types.Header
-		if err := rlp.DecodeBytes(headerRLP, &header); err != nil {
-			return false
-		}
-
-		if len(header.Extra) != 17 {
-			return false
-		}
-
-		got := binary.BigEndian.Uint64(header.Extra[9:])
-		actualBlockExtraData = header.Extra
+		got := binary.BigEndian.Uint64(extra[9:])
+		actualBlockExtraData = extra
 		return got == expected
 	}, 2*time.Minute, 5*time.Second, "L2 min base fee in block header did not sync within timeout")
 

--- a/op-devstack/dsl/proofs/dispute_game_factory.go
+++ b/op-devstack/dsl/proofs/dispute_game_factory.go
@@ -586,9 +586,5 @@ type ethClientHeaderProvider struct {
 }
 
 func (p *ethClientHeaderProvider) HeaderByNumber(ctx context.Context, blockNum *big.Int) (*types.Header, error) {
-	info, err := p.client.InfoByNumber(ctx, bigs.Uint64Strict(blockNum))
-	if err != nil {
-		return nil, err
-	}
-	return info.Header(), nil
+	return p.client.HeaderByNumber(ctx, bigs.Uint64Strict(blockNum))
 }

--- a/op-interop-filter/filter/mock_test.go
+++ b/op-interop-filter/filter/mock_test.go
@@ -451,10 +451,9 @@ func (b *mockBlockInfo) ExcessBlobGas() *uint64                     { return nil
 func (b *mockBlockInfo) BlobGasUsed() *uint64                       { return nil }
 func (b *mockBlockInfo) ParentBeaconRoot() *common.Hash             { return nil }
 func (b *mockBlockInfo) WithdrawalsRoot() *common.Hash              { return nil }
+func (b *mockBlockInfo) Extra() []byte                              { return nil }
 func (b *mockBlockInfo) ID() eth.BlockID                            { return eth.BlockID{Hash: b.hash, Number: b.number} }
 func (b *mockBlockInfo) MixDigest() common.Hash                     { return common.Hash{} }
-func (b *mockBlockInfo) HeaderRLP() ([]byte, error)                 { return nil, nil }
-func (b *mockBlockInfo) Header() *gethTypes.Header                  { return nil }
 
 // LoadCapturedData loads captured test data from a JSON file
 func LoadCapturedData(path string) (*CapturedData, error) {

--- a/op-node/rollup/derive/l1_traversal_managed_test.go
+++ b/op-node/rollup/derive/l1_traversal_managed_test.go
@@ -68,7 +68,6 @@ func TestL1TraversalManaged(t *testing.T) {
 		InfoReceiptRoot:      common.Hash{},
 		InfoGasUsed:          0,
 		InfoGasLimit:         30_000_000,
-		InfoHeaderRLP:        nil,
 		InfoParentBeaconRoot: nil,
 	}, nil, nil)
 	require.NoError(t, tr.ProvideNextL1(context.Background(), b))

--- a/op-program/host/common/l2_source.go
+++ b/op-program/host/common/l2_source.go
@@ -109,12 +109,12 @@ func (l *L2Source) NodeByHash(ctx context.Context, hash common.Hash) ([]byte, er
 	return l.canonicalDebugClient.NodeByHash(ctx, hash)
 }
 
-// InfoAndTxsByHash implements prefetcher.L2Source.
-func (l *L2Source) InfoAndTxsByHash(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Transactions, error) {
+// HeaderAndTxsByHash implements prefetcher.L2Source.
+func (l *L2Source) HeaderAndTxsByHash(ctx context.Context, blockHash common.Hash) (*types.Header, types.Transactions, error) {
 	if l.ExperimentalEnabled() {
-		return l.experimentalClient.InfoAndTxsByHash(ctx, blockHash)
+		return l.experimentalClient.HeaderAndTxsByHash(ctx, blockHash)
 	}
-	return l.canonicalEthClient.InfoAndTxsByHash(ctx, blockHash)
+	return l.canonicalEthClient.HeaderAndTxsByHash(ctx, blockHash)
 }
 
 // OutputByRoot implements prefetcher.L2Source.

--- a/op-program/host/prefetcher/prefetcher.go
+++ b/op-program/host/prefetcher/prefetcher.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/rlp"
 )
 
 var (
@@ -48,7 +49,7 @@ var acceleratedPrecompiles = []common.Address{
 }
 
 type L1Source interface {
-	InfoByHash(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, error)
+	HeaderByHash(ctx context.Context, blockHash common.Hash) (*types.Header, error)
 	InfoAndTxsByHash(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Transactions, error)
 	FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Receipts, error)
 }
@@ -286,11 +287,11 @@ func (p *Prefetcher) prefetch(ctx context.Context, hint string) error {
 			return fmt.Errorf("invalid L1 block hint: %x", hint)
 		}
 		hash := common.Hash(hintBytes)
-		header, err := p.l1Fetcher.InfoByHash(ctx, hash)
+		header, err := p.l1Fetcher.HeaderByHash(ctx, hash)
 		if err != nil {
 			return fmt.Errorf("failed to fetch L1 block %s header: %w", hash, err)
 		}
-		data, err := header.HeaderRLP()
+		data, err := rlp.EncodeToBytes(header)
 		if err != nil {
 			return fmt.Errorf("marshall header: %w", err)
 		}
@@ -417,11 +418,11 @@ func (p *Prefetcher) prefetch(ctx context.Context, hint string) error {
 		if err != nil {
 			return err
 		}
-		header, txs, err := source.InfoAndTxsByHash(ctx, hash)
+		header, txs, err := source.HeaderAndTxsByHash(ctx, hash)
 		if err != nil {
 			return fmt.Errorf("failed to fetch L2 block %s: %w", hash, err)
 		}
-		data, err := header.HeaderRLP()
+		data, err := rlp.EncodeToBytes(header)
 		if err != nil {
 			return fmt.Errorf("failed to encode header to RLP: %w", err)
 		}

--- a/op-program/host/prefetcher/prefetcher_test.go
+++ b/op-program/host/prefetcher/prefetcher_test.go
@@ -78,7 +78,7 @@ func TestFetchL1BlockHeader(t *testing.T) {
 
 	t.Run("Unknown", func(t *testing.T) {
 		prefetcher, l1Cl, _, _, _ := createPrefetcher(t)
-		l1Cl.ExpectInfoByHash(hash, eth.HeaderBlockInfo(block.Header()), nil)
+		l1Cl.ExpectHeaderByHash(hash, block.Header(), nil)
 		defer l1Cl.AssertExpectations(t)
 
 		require.NoError(t, prefetcher.Hint(l1.BlockHeaderHint(hash).Hint()))
@@ -107,7 +107,7 @@ func TestFetchL1Transactions(t *testing.T) {
 
 	t.Run("Unknown", func(t *testing.T) {
 		prefetcher, l1Cl, _, _, _ := createPrefetcher(t)
-		l1Cl.ExpectInfoByHash(hash, eth.BlockToInfo(block), nil)
+		l1Cl.ExpectHeaderByHash(hash, block.Header(), nil)
 		l1Cl.ExpectInfoAndTxsByHash(hash, eth.BlockToInfo(block), block.Transactions(), nil)
 		defer l1Cl.AssertExpectations(t)
 
@@ -136,7 +136,7 @@ func TestFetchL1Receipts(t *testing.T) {
 
 	t.Run("Unknown", func(t *testing.T) {
 		prefetcher, l1Cl, _, _, _ := createPrefetcher(t)
-		l1Cl.ExpectInfoByHash(hash, eth.BlockToInfo(block), nil)
+		l1Cl.ExpectHeaderByHash(hash, block.Header(), nil)
 		l1Cl.ExpectInfoAndTxsByHash(hash, eth.BlockToInfo(block), block.Transactions(), nil)
 		l1Cl.ExpectFetchReceipts(hash, eth.BlockToInfo(block), receipts, nil)
 		defer l1Cl.AssertExpectations(t)
@@ -151,7 +151,7 @@ func TestFetchL1Receipts(t *testing.T) {
 	// Check that the node already existing is handled
 	t.Run("CommonTrieNodes", func(t *testing.T) {
 		prefetcher, l1Cl, _, _, kv := createPrefetcher(t)
-		l1Cl.ExpectInfoByHash(hash, eth.BlockToInfo(block), nil)
+		l1Cl.ExpectHeaderByHash(hash, block.Header(), nil)
 		l1Cl.ExpectInfoAndTxsByHash(hash, eth.BlockToInfo(block), block.Transactions(), nil)
 		l1Cl.ExpectFetchReceipts(hash, eth.BlockToInfo(block), receipts, nil)
 		defer l1Cl.AssertExpectations(t)
@@ -434,7 +434,7 @@ func TestFetchL2Block(t *testing.T) {
 	t.Run("Unknown", func(t *testing.T) {
 		prefetcher, _, _, l2Cls, _ := createPrefetcher(t)
 		l2Cl := l2Cls.sources[defaultChainID]
-		l2Cl.ExpectInfoAndTxsByHash(hash, eth.BlockToInfo(block), block.Transactions(), nil)
+		l2Cl.ExpectHeaderAndTxsByHash(hash, block.Header(), block.Transactions(), nil)
 		defer l2Cl.MockL2Client.AssertExpectations(t)
 
 		oracle := l2.NewPreimageOracle(asOracleFn(t, prefetcher), asHinter(t, prefetcher), false)
@@ -446,7 +446,7 @@ func TestFetchL2Block(t *testing.T) {
 	t.Run("WithChainID", func(t *testing.T) {
 		prefetcher, _, _, l2Cls, _ := createPrefetcher(t, eth.ChainIDFromUInt64(5), eth.ChainIDFromUInt64(7), eth.ChainIDFromUInt64(10))
 		l2Cl := l2Cls.sources[eth.ChainIDFromUInt64(7)]
-		l2Cl.ExpectInfoAndTxsByHash(hash, eth.BlockToInfo(block), block.Transactions(), nil)
+		l2Cl.ExpectHeaderAndTxsByHash(hash, block.Header(), block.Transactions(), nil)
 		defer assertAllClientExpectations(t, l2Cls)
 
 		oracle := l2.NewPreimageOracle(asOracleFn(t, prefetcher), asHinter(t, prefetcher), true)
@@ -474,7 +474,7 @@ func TestFetchL2Transactions(t *testing.T) {
 	t.Run("Unknown", func(t *testing.T) {
 		prefetcher, _, _, l2Cls, _ := createPrefetcher(t)
 		l2Cl := l2Cls.sources[defaultChainID]
-		l2Cl.ExpectInfoAndTxsByHash(hash, eth.BlockToInfo(block), block.Transactions(), nil)
+		l2Cl.ExpectHeaderAndTxsByHash(hash, block.Header(), block.Transactions(), nil)
 		defer l2Cl.MockL2Client.AssertExpectations(t)
 
 		oracle := l2.NewPreimageOracle(asOracleFn(t, prefetcher), asHinter(t, prefetcher), false)
@@ -485,7 +485,7 @@ func TestFetchL2Transactions(t *testing.T) {
 	t.Run("WithChainID", func(t *testing.T) {
 		prefetcher, _, _, l2Cls, _ := createPrefetcher(t, eth.ChainIDFromUInt64(5), eth.ChainIDFromUInt64(7), eth.ChainIDFromUInt64(10))
 		l2Cl := l2Cls.sources[eth.ChainIDFromUInt64(7)]
-		l2Cl.ExpectInfoAndTxsByHash(hash, eth.BlockToInfo(block), block.Transactions(), nil)
+		l2Cl.ExpectHeaderAndTxsByHash(hash, block.Header(), block.Transactions(), nil)
 		defer assertAllClientExpectations(t, l2Cls)
 
 		oracle := l2.NewPreimageOracle(asOracleFn(t, prefetcher), asHinter(t, prefetcher), true)
@@ -636,10 +636,10 @@ func TestFetchL2BlockData(t *testing.T) {
 		isCanonical := clientErrs[len(clientErrs)-1] == nil
 
 		for _, clientErr := range clientErrs {
-			l2Client.ExpectInfoAndTxsByHash(disputedBlock.Hash(), eth.BlockToInfo(nil), nil, clientErr)
+			l2Client.ExpectHeaderAndTxsByHash(disputedBlock.Hash(), nil, nil, clientErr)
 		}
 		if !isCanonical {
-			l2Client.ExpectInfoAndTxsByHash(block.Hash(), eth.BlockToInfo(block), block.Transactions(), nil)
+			l2Client.ExpectHeaderAndTxsByHash(block.Hash(), block.Header(), block.Transactions(), nil)
 			output := &eth.OutputV0{
 				BlockHash:                block.Hash(),
 				StateRoot:                eth.Bytes32(block.Root()),

--- a/op-program/host/prefetcher/reexec.go
+++ b/op-program/host/prefetcher/reexec.go
@@ -8,6 +8,7 @@ import (
 	preimage "github.com/ethereum-optimism/optimism/op-preimage"
 	"github.com/ethereum-optimism/optimism/op-program/client/l2"
 	hostcommon "github.com/ethereum-optimism/optimism/op-program/host/common"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/retry"
 	"github.com/ethereum/go-ethereum"
@@ -30,12 +31,12 @@ func (p *Prefetcher) nativeReExecuteBlock(
 		return err
 	}
 	notFound, err := retry.Do(ctx, maxAttempts, retry.Exponential(), func() (bool, error) {
-		_, _, err := source.InfoAndTxsByHash(ctx, blockHash)
+		_, _, err := source.HeaderAndTxsByHash(ctx, blockHash)
 		if errors.Is(err, ethereum.NotFound) {
 			return true, nil
 		}
 		if err != nil {
-			p.logger.Warn("Failed to retrieve l2 info and txs", "hash", blockHash, "err", err)
+			p.logger.Warn("Failed to retrieve l2 header and txs", "hash", blockHash, "err", err)
 		}
 		return false, err
 	})
@@ -52,7 +53,7 @@ func (p *Prefetcher) nativeReExecuteBlock(
 	if err != nil {
 		return fmt.Errorf("failed to get l2 source: %w", err)
 	}
-	header, _, err := retrying.InfoAndTxsByHash(ctx, agreedBlockHash)
+	header, _, err := retrying.HeaderAndTxsByHash(ctx, agreedBlockHash)
 	if err != nil {
 		return fmt.Errorf("failed to get agreed block header: %w", err)
 	}
@@ -60,8 +61,9 @@ func (p *Prefetcher) nativeReExecuteBlock(
 	if err != nil {
 		return fmt.Errorf("failed to get agreed output root: %w", err)
 	}
-	p.logger.Info("Re-executing block", "block_hash", blockHash, "block_number", header.NumberU64())
-	if err = p.executor.RunProgram(ctx, p, header.NumberU64()+1, agreedOutput, chainID, hostcommon.NewL2KeyValueStore(p.kvStore)); err != nil {
+	blockNum := bigs.Uint64Strict(header.Number)
+	p.logger.Info("Re-executing block", "block_hash", blockHash, "block_number", blockNum)
+	if err = p.executor.RunProgram(ctx, p, blockNum+1, agreedOutput, chainID, hostcommon.NewL2KeyValueStore(p.kvStore)); err != nil {
 		return err
 	}
 

--- a/op-program/host/prefetcher/retry.go
+++ b/op-program/host/prefetcher/retry.go
@@ -29,11 +29,11 @@ func NewRetryingL1Source(logger log.Logger, source L1Source) *RetryingL1Source {
 	}
 }
 
-func (s *RetryingL1Source) InfoByHash(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, error) {
-	return retry.Do(ctx, maxAttempts, s.strategy, func() (eth.BlockInfo, error) {
-		res, err := s.source.InfoByHash(ctx, blockHash)
+func (s *RetryingL1Source) HeaderByHash(ctx context.Context, blockHash common.Hash) (*types.Header, error) {
+	return retry.Do(ctx, maxAttempts, s.strategy, func() (*types.Header, error) {
+		res, err := s.source.HeaderByHash(ctx, blockHash)
 		if err != nil {
-			s.logger.Warn("Failed to retrieve info", "hash", blockHash, "err", err)
+			s.logger.Warn("Failed to retrieve header", "hash", blockHash, "err", err)
 		}
 		return res, err
 	})
@@ -101,13 +101,13 @@ func (s *RetryingL2Source) ExperimentalEnabled() bool {
 	return s.source.ExperimentalEnabled()
 }
 
-func (s *RetryingL2Source) InfoAndTxsByHash(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Transactions, error) {
-	return retry.Do2(ctx, maxAttempts, s.strategy, func() (eth.BlockInfo, types.Transactions, error) {
-		i, t, err := s.source.InfoAndTxsByHash(ctx, blockHash)
+func (s *RetryingL2Source) HeaderAndTxsByHash(ctx context.Context, blockHash common.Hash) (*types.Header, types.Transactions, error) {
+	return retry.Do2(ctx, maxAttempts, s.strategy, func() (*types.Header, types.Transactions, error) {
+		h, t, err := s.source.HeaderAndTxsByHash(ctx, blockHash)
 		if err != nil {
-			s.logger.Warn("Failed to retrieve l2 info and txs", "hash", blockHash, "err", err)
+			s.logger.Warn("Failed to retrieve l2 header and txs", "hash", blockHash, "err", err)
 		}
-		return i, t, err
+		return h, t, err
 	})
 }
 

--- a/op-program/host/prefetcher/retry_test.go
+++ b/op-program/host/prefetcher/retry_test.go
@@ -3,6 +3,7 @@ package prefetcher
 import (
 	"context"
 	"errors"
+	"math/big"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
@@ -33,26 +34,28 @@ func TestRetryingL1Source(t *testing.T) {
 		&types.Receipt{},
 	}
 
-	t.Run("InfoByHash Success", func(t *testing.T) {
+	hdr := &types.Header{Number: big.NewInt(int64(info.NumberU64())), Time: info.Time()}
+
+	t.Run("HeaderByHash Success", func(t *testing.T) {
 		source, mock := createL1Source(t)
 		defer mock.AssertExpectations(t)
-		mock.ExpectInfoByHash(hash, info, nil)
+		mock.ExpectHeaderByHash(hash, hdr, nil)
 
-		result, err := source.InfoByHash(ctx, hash)
+		result, err := source.HeaderByHash(ctx, hash)
 		require.NoError(t, err)
-		require.Equal(t, info, result)
+		require.Equal(t, hdr, result)
 	})
 
-	t.Run("InfoByHash Error", func(t *testing.T) {
+	t.Run("HeaderByHash Error", func(t *testing.T) {
 		source, mock := createL1Source(t)
 		defer mock.AssertExpectations(t)
 		expectedErr := errors.New("boom")
-		mock.ExpectInfoByHash(hash, wrongInfo, expectedErr)
-		mock.ExpectInfoByHash(hash, info, nil)
+		mock.ExpectHeaderByHash(hash, nil, expectedErr)
+		mock.ExpectHeaderByHash(hash, hdr, nil)
 
-		result, err := source.InfoByHash(ctx, hash)
+		result, err := source.HeaderByHash(ctx, hash)
 		require.NoError(t, err)
-		require.Equal(t, info, result)
+		require.Equal(t, hdr, result)
 	})
 
 	t.Run("InfoAndTxsByHash Success", func(t *testing.T) {
@@ -178,8 +181,7 @@ func TestRetryingL2Source(t *testing.T) {
 	hash := common.Hash{0xab}
 	blockNum := uint64(14982)
 	info := &testutils.MockBlockInfo{InfoHash: hash, InfoNum: blockNum}
-	// The mock really doesn't like returning nil for a eth.BlockInfo so return a value we expect to be ignored instead
-	wrongInfo := &testutils.MockBlockInfo{InfoHash: common.Hash{0x99}}
+	hdr := &types.Header{Number: big.NewInt(int64(blockNum))}
 	txs := types.Transactions{
 		&types.Transaction{},
 	}
@@ -190,27 +192,27 @@ func TestRetryingL2Source(t *testing.T) {
 	output := &eth.OutputV0{}
 	wrongOutput := &eth.OutputV0{BlockHash: common.Hash{0x99}}
 
-	t.Run("InfoAndTxsByHash Success", func(t *testing.T) {
+	t.Run("HeaderAndTxsByHash Success", func(t *testing.T) {
 		source, mock := createL2Source(t)
 		defer mock.AssertExpectations(t)
-		mock.ExpectInfoAndTxsByHash(hash, info, txs, nil)
+		mock.ExpectHeaderAndTxsByHash(hash, hdr, txs, nil)
 
-		actualInfo, actualTxs, err := source.InfoAndTxsByHash(ctx, hash)
+		actualHdr, actualTxs, err := source.HeaderAndTxsByHash(ctx, hash)
 		require.NoError(t, err)
-		require.Equal(t, info, actualInfo)
+		require.Equal(t, hdr, actualHdr)
 		require.Equal(t, txs, actualTxs)
 	})
 
-	t.Run("InfoAndTxsByHash Error", func(t *testing.T) {
+	t.Run("HeaderAndTxsByHash Error", func(t *testing.T) {
 		source, mock := createL2Source(t)
 		defer mock.AssertExpectations(t)
 		expectedErr := errors.New("boom")
-		mock.ExpectInfoAndTxsByHash(hash, wrongInfo, nil, expectedErr)
-		mock.ExpectInfoAndTxsByHash(hash, info, txs, nil)
+		mock.ExpectHeaderAndTxsByHash(hash, nil, nil, expectedErr)
+		mock.ExpectHeaderAndTxsByHash(hash, hdr, txs, nil)
 
-		actualInfo, actualTxs, err := source.InfoAndTxsByHash(ctx, hash)
+		actualHdr, actualTxs, err := source.HeaderAndTxsByHash(ctx, hash)
 		require.NoError(t, err)
-		require.Equal(t, info, actualInfo)
+		require.Equal(t, hdr, actualHdr)
 		require.Equal(t, txs, actualTxs)
 	})
 
@@ -346,9 +348,9 @@ func (m *MockL2Source) GetProof(ctx context.Context, address common.Address, sto
 	return out[0].(*eth.AccountResult), *out[1].(*error)
 }
 
-func (m *MockL2Source) InfoAndTxsByHash(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Transactions, error) {
-	out := m.Mock.MethodCalled("InfoAndTxsByHash", blockHash)
-	return out[0].(eth.BlockInfo), out[1].(types.Transactions), *out[2].(*error)
+func (m *MockL2Source) HeaderAndTxsByHash(ctx context.Context, blockHash common.Hash) (*types.Header, types.Transactions, error) {
+	out := m.Mock.MethodCalled("HeaderAndTxsByHash", blockHash)
+	return out[0].(*types.Header), out[1].(types.Transactions), *out[2].(*error)
 }
 
 func (m *MockL2Source) NodeByHash(ctx context.Context, hash common.Hash) ([]byte, error) {
@@ -376,8 +378,8 @@ func (m *MockL2Source) OutputByNumber(ctx context.Context, blockNum uint64) (eth
 	return out[0].(eth.Output), *out[1].(*error)
 }
 
-func (m *MockL2Source) ExpectInfoAndTxsByHash(blockHash common.Hash, info eth.BlockInfo, txs types.Transactions, err error) {
-	m.Mock.On("InfoAndTxsByHash", blockHash).Once().Return(info, txs, &err)
+func (m *MockL2Source) ExpectHeaderAndTxsByHash(blockHash common.Hash, header *types.Header, txs types.Transactions, err error) {
+	m.Mock.On("HeaderAndTxsByHash", blockHash).Once().Return(header, txs, &err)
 }
 
 func (m *MockL2Source) ExpectNodeByHash(hash common.Hash, node []byte, err error) {

--- a/op-program/host/types/types.go
+++ b/op-program/host/types/types.go
@@ -20,7 +20,7 @@ const (
 var SupportedDataFormats = []DataFormat{DataFormatFile, DataFormatDirectory, DataFormatPebble}
 
 type L2Source interface {
-	InfoAndTxsByHash(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Transactions, error)
+	HeaderAndTxsByHash(ctx context.Context, blockHash common.Hash) (*types.Header, types.Transactions, error)
 	NodeByHash(ctx context.Context, hash common.Hash) ([]byte, error)
 	CodeByHash(ctx context.Context, hash common.Hash) ([]byte, error)
 	FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Receipts, error)

--- a/op-service/apis/eth.go
+++ b/op-service/apis/eth.go
@@ -33,6 +33,16 @@ type EthBlockInfo interface {
 	InfoAndTxsByLabel(ctx context.Context, label eth.BlockLabel) (eth.BlockInfo, types.Transactions, error)
 }
 
+type EthHeader interface {
+	HeaderByHash(ctx context.Context, hash common.Hash) (*types.Header, error)
+
+	HeaderByNumber(ctx context.Context, number uint64) (*types.Header, error)
+
+	HeaderByLabel(ctx context.Context, label eth.BlockLabel) (*types.Header, error)
+
+	HeaderAndTxsByHash(ctx context.Context, hash common.Hash) (*types.Header, types.Transactions, error)
+}
+
 type EthPayload interface {
 	PayloadByHash(ctx context.Context, hash common.Hash) (*eth.ExecutionPayloadEnvelope, error)
 
@@ -137,6 +147,7 @@ type RPCCaller interface {
 type EthClient interface {
 	ChainID
 	EthBlockInfo
+	EthHeader
 	ReceiptFetcher
 	ExecutionWitness
 	EthProof

--- a/op-service/eth/block_info.go
+++ b/op-service/eth/block_info.go
@@ -8,7 +8,6 @@ import (
 	"github.com/ethereum/go-ethereum/consensus/misc/eip4844"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
-	"github.com/ethereum/go-ethereum/rlp"
 )
 
 type BlockInfo interface {
@@ -31,11 +30,7 @@ type BlockInfo interface {
 	GasLimit() uint64
 	ParentBeaconRoot() *common.Hash // Dencun extension
 	WithdrawalsRoot() *common.Hash  // Isthmus extension
-
-	// HeaderRLP returns the RLP of the block header as per consensus rules
-	// Returns an error if the header RLP could not be written
-	HeaderRLP() ([]byte, error)
-	Header() *types.Header
+	Extra() []byte
 }
 
 func InfoToL1BlockRef(info BlockInfo) L1BlockRef {
@@ -67,11 +62,7 @@ func (b blockInfo) BlobBaseFee(chainConfig *params.ChainConfig) *big.Int {
 	if ebg == nil {
 		return nil
 	}
-	return eip4844.CalcBlobFee(chainConfig, b.Header())
-}
-
-func (b blockInfo) HeaderRLP() ([]byte, error) {
-	return rlp.EncodeToBytes(b.Header())
+	return eip4844.CalcBlobFee(chainConfig, b.Block.Header())
 }
 
 func (b blockInfo) ParentBeaconRoot() *common.Hash {
@@ -79,7 +70,7 @@ func (b blockInfo) ParentBeaconRoot() *common.Hash {
 }
 
 func (b blockInfo) WithdrawalsRoot() *common.Hash {
-	return b.Header().WithdrawalsHash
+	return b.Block.Header().WithdrawalsHash
 }
 
 func BlockToInfo(b *types.Block) BlockInfo {
@@ -160,16 +151,12 @@ func (h *headerBlockInfo) ParentBeaconRoot() *common.Hash {
 	return h.header.ParentBeaconRoot
 }
 
-func (h *headerBlockInfo) HeaderRLP() ([]byte, error) {
-	return rlp.EncodeToBytes(h.header) // usage is rare and mostly 1-time-use, no need to cache
-}
-
-func (h *headerBlockInfo) Header() *types.Header {
-	return h.header
-}
-
 func (h *headerBlockInfo) WithdrawalsRoot() *common.Hash {
 	return h.header.WithdrawalsHash
+}
+
+func (h *headerBlockInfo) Extra() []byte {
+	return h.header.Extra
 }
 
 func (h *headerBlockInfo) MarshalJSON() ([]byte, error) {

--- a/op-service/sources/eth_client.go
+++ b/op-service/sources/eth_client.go
@@ -136,8 +136,8 @@ type EthClient struct {
 	transactionsCache *caching.LRUCache[common.Hash, types.Transactions]
 
 	// cache block headers of blocks by hash
-	// common.Hash -> *HeaderInfo
-	headersCache *caching.LRUCache[common.Hash, eth.BlockInfo]
+	// common.Hash -> *types.Header
+	headersCache *caching.LRUCache[common.Hash, *types.Header]
 
 	// cache payloads by hash
 	// common.Hash -> *eth.ExecutionPayload
@@ -169,7 +169,7 @@ func NewEthClient(client client.RPC, log log.Logger, metrics caching.Metrics, co
 		mustBePostMerge:   config.MustBePostMerge,
 		log:               log,
 		transactionsCache: caching.NewLRUCache[common.Hash, types.Transactions](metrics, "txs", config.TransactionsCacheSize),
-		headersCache:      caching.NewLRUCache[common.Hash, eth.BlockInfo](metrics, "headers", config.HeadersCacheSize),
+		headersCache:      caching.NewLRUCache[common.Hash, *types.Header](metrics, "headers", config.HeadersCacheSize),
 		payloadsCache:     caching.NewLRUCache[common.Hash, *eth.ExecutionPayloadEnvelope](metrics, "payloads", config.PayloadsCacheSize),
 		blockRefsCache:    caching.NewLRUCache[common.Hash, eth.L1BlockRef](metrics, "blockrefs", config.BlockRefsCacheSize),
 	}, nil
@@ -212,27 +212,34 @@ func (n numberID) CheckID(id eth.BlockID) error {
 	return nil
 }
 
-func (s *EthClient) headerCall(ctx context.Context, method string, id rpcBlockID) (eth.BlockInfo, error) {
-	var header *RPCHeader
-	err := s.client.CallContext(ctx, &header, method, id.Arg(), false) // headers are just blocks without txs
+// headerCall fetches a header (eth_getBlockBy* with fullTx=false), verifies it,
+// caches it, and returns it. It is the single source of truth for both
+// HeaderBy* and InfoBy*.
+func (s *EthClient) headerCall(ctx context.Context, method string, id rpcBlockID) (*types.Header, error) {
+	var rpcHdr *RPCHeader
+	err := s.client.CallContext(ctx, &rpcHdr, method, id.Arg(), false) // headers are just blocks without txs
 	if err != nil {
 		return nil, eth.MaybeAsNotFoundErr(err)
 	}
-	if header == nil {
+	if rpcHdr == nil {
 		return nil, ethereum.NotFound
 	}
-	info, err := header.Info(s.trustRPC, s.mustBePostMerge)
+	header, err := rpcHdr.Header(s.trustRPC, s.mustBePostMerge)
 	if err != nil {
 		return nil, err
 	}
-	if err := id.CheckID(eth.ToBlockID(info)); err != nil {
+	if err := id.CheckID(rpcHdr.BlockID()); err != nil {
 		return nil, fmt.Errorf("fetched block header does not match requested ID: %w", err)
 	}
-	s.headersCache.Add(info.Hash(), info)
-	return info, nil
+	s.headersCache.Add(rpcHdr.Hash, header)
+	return header, nil
 }
 
-func (s *EthClient) blockCall(ctx context.Context, method string, id rpcBlockID) (eth.BlockInfo, types.Transactions, error) {
+// blockCall fetches a header + transactions (eth_getBlockBy* with fullTx=true),
+// verifies the header and block-level data (txs root, withdrawals), caches
+// both, and returns them. Source of truth for both HeaderAndTxsBy* and
+// InfoAndTxsBy*.
+func (s *EthClient) blockCall(ctx context.Context, method string, id rpcBlockID) (*types.Header, types.Transactions, error) {
 	var block *RPCBlock
 	err := s.client.CallContext(ctx, &block, method, id.Arg(), true)
 	if err != nil {
@@ -241,16 +248,21 @@ func (s *EthClient) blockCall(ctx context.Context, method string, id rpcBlockID)
 	if block == nil {
 		return nil, nil, ethereum.NotFound
 	}
-	info, txs, err := block.Info(s.trustRPC, s.mustBePostMerge)
-	if err != nil {
-		return nil, nil, err
+	if !s.trustRPC {
+		if err := block.Verify(); err != nil {
+			return nil, nil, err
+		}
 	}
-	if err := id.CheckID(eth.ToBlockID(info)); err != nil {
+	header, err := block.RPCHeader.Header(s.trustRPC, s.mustBePostMerge)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to verify block from RPC: %w", err)
+	}
+	if err := id.CheckID(block.BlockID()); err != nil {
 		return nil, nil, fmt.Errorf("fetched block data does not match requested ID: %w", err)
 	}
-	s.headersCache.Add(info.Hash(), info)
-	s.transactionsCache.Add(info.Hash(), txs)
-	return info, txs, nil
+	s.headersCache.Add(block.Hash, header)
+	s.transactionsCache.Add(block.Hash, block.Transactions)
+	return header, block.Transactions, nil
 }
 
 func (s *EthClient) payloadCall(ctx context.Context, method string, id rpcBlockID) (*eth.ExecutionPayloadEnvelope, error) {
@@ -283,24 +295,32 @@ func (s *EthClient) ChainID(ctx context.Context) (*big.Int, error) {
 	return (*big.Int)(&id), nil
 }
 
-func (s *EthClient) InfoByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, error) {
+// HeaderByHash returns the *types.Header for the given block hash. It is the
+// source of truth for header fetching: HeaderBy* and InfoBy* both flow
+// through the same headersCache + headerCall path.
+func (s *EthClient) HeaderByHash(ctx context.Context, hash common.Hash) (*types.Header, error) {
 	if header, ok := s.headersCache.Get(hash); ok {
 		return header, nil
 	}
 	return s.headerCall(ctx, "eth_getBlockByHash", hashID(hash))
 }
 
-func (s *EthClient) InfoByNumber(ctx context.Context, number uint64) (eth.BlockInfo, error) {
+// HeaderByNumber returns the *types.Header for the given block number.
+func (s *EthClient) HeaderByNumber(ctx context.Context, number uint64) (*types.Header, error) {
 	// can't hit the cache when querying by number due to reorgs.
 	return s.headerCall(ctx, "eth_getBlockByNumber", numberID(number))
 }
 
-func (s *EthClient) InfoByLabel(ctx context.Context, label eth.BlockLabel) (eth.BlockInfo, error) {
+// HeaderByLabel returns the *types.Header for the given block label.
+func (s *EthClient) HeaderByLabel(ctx context.Context, label eth.BlockLabel) (*types.Header, error) {
 	// can't hit the cache when querying the head due to reorgs / changes.
 	return s.headerCall(ctx, "eth_getBlockByNumber", label)
 }
 
-func (s *EthClient) InfoAndTxsByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, types.Transactions, error) {
+// HeaderAndTxsByHash returns the *types.Header and transactions for the given
+// block hash. Source of truth for block fetching: HeaderAndTxs* and
+// InfoAndTxs* both flow through this and blockCall.
+func (s *EthClient) HeaderAndTxsByHash(ctx context.Context, hash common.Hash) (*types.Header, types.Transactions, error) {
 	if header, ok := s.headersCache.Get(hash); ok {
 		if txs, ok := s.transactionsCache.Get(hash); ok {
 			return header, txs, nil
@@ -309,14 +329,54 @@ func (s *EthClient) InfoAndTxsByHash(ctx context.Context, hash common.Hash) (eth
 	return s.blockCall(ctx, "eth_getBlockByHash", hashID(hash))
 }
 
+func (s *EthClient) InfoByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, error) {
+	header, err := s.HeaderByHash(ctx, hash)
+	if err != nil {
+		return nil, err
+	}
+	return eth.HeaderBlockInfoTrusted(hash, header), nil
+}
+
+func (s *EthClient) InfoByNumber(ctx context.Context, number uint64) (eth.BlockInfo, error) {
+	header, err := s.HeaderByNumber(ctx, number)
+	if err != nil {
+		return nil, err
+	}
+	return eth.HeaderBlockInfo(header), nil
+}
+
+func (s *EthClient) InfoByLabel(ctx context.Context, label eth.BlockLabel) (eth.BlockInfo, error) {
+	header, err := s.HeaderByLabel(ctx, label)
+	if err != nil {
+		return nil, err
+	}
+	return eth.HeaderBlockInfo(header), nil
+}
+
+func (s *EthClient) InfoAndTxsByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, types.Transactions, error) {
+	header, txs, err := s.HeaderAndTxsByHash(ctx, hash)
+	if err != nil {
+		return nil, nil, err
+	}
+	return eth.HeaderBlockInfoTrusted(hash, header), txs, nil
+}
+
 func (s *EthClient) InfoAndTxsByNumber(ctx context.Context, number uint64) (eth.BlockInfo, types.Transactions, error) {
 	// can't hit the cache when querying by number due to reorgs.
-	return s.blockCall(ctx, "eth_getBlockByNumber", numberID(number))
+	header, txs, err := s.blockCall(ctx, "eth_getBlockByNumber", numberID(number))
+	if err != nil {
+		return nil, nil, err
+	}
+	return eth.HeaderBlockInfo(header), txs, nil
 }
 
 func (s *EthClient) InfoAndTxsByLabel(ctx context.Context, label eth.BlockLabel) (eth.BlockInfo, types.Transactions, error) {
 	// can't hit the cache when querying the head due to reorgs / changes.
-	return s.blockCall(ctx, "eth_getBlockByNumber", label)
+	header, txs, err := s.blockCall(ctx, "eth_getBlockByNumber", label)
+	if err != nil {
+		return nil, nil, err
+	}
+	return eth.HeaderBlockInfo(header), txs, nil
 }
 
 func (s *EthClient) PayloadByHash(ctx context.Context, hash common.Hash) (*eth.ExecutionPayloadEnvelope, error) {

--- a/op-service/sources/eth_client_test.go
+++ b/op-service/sources/eth_client_test.go
@@ -184,7 +184,7 @@ func TestEthClient_WrongInfoByHash(t *testing.T) {
 func newEthClientWithCaches(metrics caching.Metrics, cacheSize int) *EthClient {
 	return &EthClient{
 		transactionsCache: caching.NewLRUCache[common.Hash, types.Transactions](metrics, "txs", cacheSize),
-		headersCache:      caching.NewLRUCache[common.Hash, eth.BlockInfo](metrics, "headers", cacheSize),
+		headersCache:      caching.NewLRUCache[common.Hash, *types.Header](metrics, "headers", cacheSize),
 		payloadsCache:     caching.NewLRUCache[common.Hash, *eth.ExecutionPayloadEnvelope](metrics, "payloads", cacheSize),
 	}
 }

--- a/op-service/sources/types.go
+++ b/op-service/sources/types.go
@@ -125,7 +125,9 @@ func (hdr *RPCHeader) CreateGethHeader() *types.Header {
 	}
 }
 
-func (hdr *RPCHeader) Info(trustCache bool, mustBePostMerge bool) (eth.BlockInfo, error) {
+// Header runs trust/post-merge verification on the RPC-provided header and
+// returns the underlying *types.Header.
+func (hdr *RPCHeader) Header(trustCache bool, mustBePostMerge bool) (*types.Header, error) {
 	if mustBePostMerge {
 		if err := hdr.checkPostMerge(); err != nil {
 			return nil, err
@@ -136,7 +138,15 @@ func (hdr *RPCHeader) Info(trustCache bool, mustBePostMerge bool) (eth.BlockInfo
 			return nil, fmt.Errorf("failed to verify block hash: computed %s but RPC said %s", computed, hdr.Hash)
 		}
 	}
-	return eth.HeaderBlockInfoTrusted(hdr.Hash, hdr.CreateGethHeader()), nil
+	return hdr.CreateGethHeader(), nil
+}
+
+func (hdr *RPCHeader) Info(trustCache bool, mustBePostMerge bool) (eth.BlockInfo, error) {
+	header, err := hdr.Header(trustCache, mustBePostMerge)
+	if err != nil {
+		return nil, err
+	}
+	return eth.HeaderBlockInfoTrusted(hdr.Hash, header), nil
 }
 
 func (hdr *RPCHeader) BlockID() eth.BlockID {

--- a/op-service/testutils/l1info.go
+++ b/op-service/testutils/l1info.go
@@ -1,7 +1,6 @@
 package testutils
 
 import (
-	"errors"
 	"math/big"
 	"math/rand"
 
@@ -30,14 +29,10 @@ type MockBlockInfo struct {
 	InfoGasUsed       uint64
 	InfoBlobGasUsed   *uint64
 	InfoGasLimit      uint64
-	InfoHeaderRLP     []byte
 
 	InfoParentBeaconRoot *common.Hash
 	InfoWithdrawalsRoot  *common.Hash
-}
-
-func (l *MockBlockInfo) Header() *types.Header {
-	panic("not implemented")
+	InfoExtra            []byte
 }
 
 func (l *MockBlockInfo) Hash() common.Hash {
@@ -108,11 +103,8 @@ func (l *MockBlockInfo) WithdrawalsRoot() *common.Hash {
 	return l.InfoWithdrawalsRoot
 }
 
-func (l *MockBlockInfo) HeaderRLP() ([]byte, error) {
-	if l.InfoHeaderRLP == nil {
-		return nil, errors.New("header rlp not available")
-	}
-	return l.InfoHeaderRLP, nil
+func (l *MockBlockInfo) Extra() []byte {
+	return l.InfoExtra
 }
 
 func (l *MockBlockInfo) BlockRef() eth.L1BlockRef {

--- a/op-service/testutils/mock_eth_client.go
+++ b/op-service/testutils/mock_eth_client.go
@@ -76,6 +76,42 @@ func (m *MockEthClient) ExpectInfoAndTxsByLabel(label eth.BlockLabel, info eth.B
 	m.Mock.On("InfoAndTxsByLabel", label).Once().Return(info, transactions, err)
 }
 
+func (m *MockEthClient) HeaderByHash(ctx context.Context, hash common.Hash) (*types.Header, error) {
+	out := m.Mock.Called(hash)
+	return out.Get(0).(*types.Header), out.Error(1)
+}
+
+func (m *MockEthClient) ExpectHeaderByHash(hash common.Hash, header *types.Header, err error) {
+	m.Mock.On("HeaderByHash", hash).Once().Return(header, err)
+}
+
+func (m *MockEthClient) HeaderByNumber(ctx context.Context, number uint64) (*types.Header, error) {
+	out := m.Mock.Called(number)
+	return out.Get(0).(*types.Header), out.Error(1)
+}
+
+func (m *MockEthClient) ExpectHeaderByNumber(number uint64, header *types.Header, err error) {
+	m.Mock.On("HeaderByNumber", number).Once().Return(header, err)
+}
+
+func (m *MockEthClient) HeaderByLabel(ctx context.Context, label eth.BlockLabel) (*types.Header, error) {
+	out := m.Mock.Called(label)
+	return out.Get(0).(*types.Header), out.Error(1)
+}
+
+func (m *MockEthClient) ExpectHeaderByLabel(label eth.BlockLabel, header *types.Header, err error) {
+	m.Mock.On("HeaderByLabel", label).Once().Return(header, err)
+}
+
+func (m *MockEthClient) HeaderAndTxsByHash(ctx context.Context, hash common.Hash) (*types.Header, types.Transactions, error) {
+	out := m.Mock.Called(hash)
+	return out.Get(0).(*types.Header), out.Get(1).(types.Transactions), out.Error(2)
+}
+
+func (m *MockEthClient) ExpectHeaderAndTxsByHash(hash common.Hash, header *types.Header, transactions types.Transactions, err error) {
+	m.Mock.On("HeaderAndTxsByHash", hash).Once().Return(header, transactions, err)
+}
+
 func (m *MockEthClient) PayloadByHash(ctx context.Context, hash common.Hash) (*eth.ExecutionPayloadEnvelope, error) {
 	out := m.Mock.Called(hash)
 	return out.Get(0).(*eth.ExecutionPayloadEnvelope), out.Error(1)

--- a/op-supernode/supernode/activity/interop/algo_test.go
+++ b/op-supernode/supernode/activity/interop/algo_test.go
@@ -899,8 +899,7 @@ func (m *testBlockInfo) GasLimit() uint64                                     { 
 func (m *testBlockInfo) BlobGasUsed() *uint64                                 { return nil }
 func (m *testBlockInfo) ParentBeaconRoot() *common.Hash                       { return nil }
 func (m *testBlockInfo) WithdrawalsRoot() *common.Hash                        { return nil }
-func (m *testBlockInfo) HeaderRLP() ([]byte, error)                           { return nil, nil }
-func (m *testBlockInfo) Header() *types.Header                                { return nil }
+func (m *testBlockInfo) Extra() []byte                                        { return nil }
 func (m *testBlockInfo) ID() eth.BlockID                                      { return eth.BlockID{Hash: m.hash, Number: m.number} }
 
 var _ eth.BlockInfo = (*testBlockInfo)(nil)

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -1701,8 +1701,7 @@ func (m *mockBlockInfo) GasLimit() uint64                                     { 
 func (m *mockBlockInfo) BlobGasUsed() *uint64                                 { return nil }
 func (m *mockBlockInfo) ParentBeaconRoot() *common.Hash                       { return nil }
 func (m *mockBlockInfo) WithdrawalsRoot() *common.Hash                        { return nil }
-func (m *mockBlockInfo) HeaderRLP() ([]byte, error)                           { return nil, nil }
-func (m *mockBlockInfo) Header() *types.Header                                { return nil }
+func (m *mockBlockInfo) Extra() []byte                                        { return nil }
 func (m *mockBlockInfo) ID() eth.BlockID                                      { return eth.BlockID{Hash: m.hash, Number: m.number} }
 
 var _ eth.BlockInfo = (*mockBlockInfo)(nil)


### PR DESCRIPTION
## Summary

`eth.BlockInfo` exposed two escape-hatch methods, `Header() *types.Header` and `HeaderRLP() ([]byte, error)`, that forced every implementation to either hold a `*types.Header` or panic (leaky abstraction). They had only four production callers and two acceptance-test callers, all of which can be served by either a new `Extra() []byte` accessor or a direct `HeaderBy*` method on `EthClient`.

This PR removes those escape hatches, adds `Extra()` to `BlockInfo`, and inverts the layering inside `EthClient` so `HeaderBy*` is the source of truth and `InfoBy*` wraps into `BlockInfo` on the way out.

### What changes

- **Interface surface**
  - `BlockInfo` gains `Extra() []byte`; loses `Header()` and `HeaderRLP()`.
  - New `apis.EthHeader` interface (`HeaderByHash/Number/Label`, `HeaderAndTxsByHash`) embedded in `apis.EthClient`.
  - `EthClient` exposes the four new methods, sharing RPC dispatch and the headers/txs caches with the existing `InfoBy*` paths.
  - Prefetcher source interfaces gain matching methods; `L1Source.InfoByHash` and `L2Source.InfoAndTxsByHash` (now unused) are removed.

- **Internal layering**
  - `headersCache` is now `LRUCache[Hash, *types.Header]` (was `LRUCache[Hash, BlockInfo]`).
  - `headerCall` / `blockCall` return `*types.Header` directly; `RPCHeader.Info` becomes a thin wrapper that calls a new `RPCHeader.Header` for the verification logic, eliminating duplication.

- **Caller migrations**
  - `op-devstack/dsl/proofs/dispute_game_factory.go` adapter: forwards directly to `client.HeaderByNumber`.
  - `op-program/host/prefetcher/prefetcher.go`: L1 + L2 block-header hint paths use `HeaderByHash` / `HeaderAndTxsByHash` and `rlp.EncodeToBytes(header)`.
  - `op-program/host/prefetcher/reexec.go`: switches to `HeaderAndTxsByHash`.
  - `op-acceptance-tests/tests/jovian/{min_base_fee,bpo2/joviantest/cases}.go`: replace RLP-roundtrip just-to-read-`Extra` with `info.Extra()` directly (net negative diff).
  - Internal `BlobBaseFee` in `block_info.go` reads via `b.Block.Header()` (go-ethereum native), no longer through the now-removed interface method.

### Out of scope

The `dispute_game_factory.ethClientHeaderProvider` adapter remains: it does a real `*big.Int → uint64` conversion to bridge challenger's `L2HeaderSource` interface (go-ethereum convention) and `apis.EthClient.HeaderByNumber` (optimism convention). Removing it would require changing challenger's public interface signature, which is broader scope than this PR. Worth a follow-up if we want to standardize on `uint64` everywhere.

`RPCBlock.Info` is kept; three receipts tests still call it. Migrating them is a small follow-up.

## Test plan

- [x] `mise exec -- go build ./...` passes
- [x] `mise exec -- just lint-go` passes (0 issues, mod tidy clean)
- [x] `mise exec -- go test -count=1 -short ./op-service/... ./op-program/... ./op-supernode/... ./op-interop-filter/... ./op-node/...` passes
- [x] L1 + L2 prefetcher tests exercise the new `HeaderByHash` / `HeaderAndTxsByHash` paths end-to-end (header fetch → RLP encode → kvStore.Put)
- [x] `RetryingL1Source` / `RetryingL2Source` retry-loop tests rewritten for the new methods
- [x] Verified locally that `trustRPC=false` retains full hash verification: `RPCHeader.Header` checks `computeBlockHash() == rpcHdr.Hash`, plus `id.CheckID` confirms `request hash == claimed hash`. `HeaderBlockInfoTrusted(hash, header)` is sound at every call site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)