### PR TITLE
refactor(op-service/sources): minimal-fetch path for L2BlockRef and SystemConfig

### DIFF
--- a/op-node/rollup/derive/payload_util.go
+++ b/op-node/rollup/derive/payload_util.go
@@ -11,103 +11,131 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
-// PayloadToBlockRef extracts the essential L2BlockRef information from an execution payload,
-// falling back to genesis information if necessary.
-func PayloadToBlockRef(rollupCfg *rollup.Config, payload *eth.ExecutionPayload) (eth.L2BlockRef, error) {
+// BlockRefFromHeaderAndDeposit extracts the L2BlockRef from a block header and
+// its first transaction. The first transaction is expected to be the L1 info
+// deposit (except at genesis, where deposit may be nil).
+func BlockRefFromHeaderAndDeposit(rollupCfg *rollup.Config, info eth.BlockInfo, deposit *types.Transaction) (eth.L2BlockRef, error) {
 	genesis := &rollupCfg.Genesis
 	var l1Origin eth.BlockID
 	var sequenceNumber uint64
-	if uint64(payload.BlockNumber) == genesis.L2.Number {
-		if payload.BlockHash != genesis.L2.Hash {
-			return eth.L2BlockRef{}, fmt.Errorf("expected L2 genesis hash to match L2 block at genesis block number %d: %s <> %s", genesis.L2.Number, payload.BlockHash, genesis.L2.Hash)
+	if info.NumberU64() == genesis.L2.Number {
+		if info.Hash() != genesis.L2.Hash {
+			return eth.L2BlockRef{}, fmt.Errorf("expected L2 genesis hash to match L2 block at genesis block number %d: %s <> %s", genesis.L2.Number, info.Hash(), genesis.L2.Hash)
 		}
 		l1Origin = genesis.L1
 		sequenceNumber = 0
 	} else {
-		if len(payload.Transactions) == 0 {
-			return eth.L2BlockRef{}, fmt.Errorf("l2 block is missing L1 info deposit tx, block hash: %s", payload.BlockHash)
+		if deposit == nil {
+			return eth.L2BlockRef{}, fmt.Errorf("l2 block is missing L1 info deposit tx, block hash: %s", info.Hash())
 		}
-		var tx types.Transaction
-		if err := tx.UnmarshalBinary(payload.Transactions[0]); err != nil {
-			return eth.L2BlockRef{}, fmt.Errorf("failed to decode first tx to read l1 info from: %w", err)
+		if deposit.Type() != types.DepositTxType {
+			return eth.L2BlockRef{}, fmt.Errorf("first payload tx has unexpected tx type: %d", deposit.Type())
 		}
-		if tx.Type() != types.DepositTxType {
-			return eth.L2BlockRef{}, fmt.Errorf("first payload tx has unexpected tx type: %d", tx.Type())
-		}
-		info, err := L1BlockInfoFromBytes(rollupCfg, uint64(payload.Timestamp), tx.Data())
+		l1Info, err := L1BlockInfoFromBytes(rollupCfg, info.Time(), deposit.Data())
 		if err != nil {
 			return eth.L2BlockRef{}, fmt.Errorf("failed to parse L1 info deposit tx from L2 block: %w", err)
 		}
-		l1Origin = eth.BlockID{Hash: info.BlockHash, Number: info.Number}
-		sequenceNumber = info.SequenceNumber
+		l1Origin = eth.BlockID{Hash: l1Info.BlockHash, Number: l1Info.Number}
+		sequenceNumber = l1Info.SequenceNumber
 	}
 
 	return eth.L2BlockRef{
-		Hash:           payload.BlockHash,
-		Number:         uint64(payload.BlockNumber),
-		ParentHash:     payload.ParentHash,
-		Time:           uint64(payload.Timestamp),
+		Hash:           info.Hash(),
+		Number:         info.NumberU64(),
+		ParentHash:     info.ParentHash(),
+		Time:           info.Time(),
 		L1Origin:       l1Origin,
 		SequenceNumber: sequenceNumber,
 	}, nil
 }
 
-func PayloadToSystemConfig(rollupCfg *rollup.Config, payload *eth.ExecutionPayload) (eth.SystemConfig, error) {
-	if uint64(payload.BlockNumber) == rollupCfg.Genesis.L2.Number {
-		if payload.BlockHash != rollupCfg.Genesis.L2.Hash {
+// SystemConfigFromHeaderAndDeposit extracts the SystemConfig from a block
+// header and its first transaction (the L1 info deposit). At genesis, deposit
+// may be nil.
+func SystemConfigFromHeaderAndDeposit(rollupCfg *rollup.Config, info eth.BlockInfo, deposit *types.Transaction) (eth.SystemConfig, error) {
+	if info.NumberU64() == rollupCfg.Genesis.L2.Number {
+		if info.Hash() != rollupCfg.Genesis.L2.Hash {
 			return eth.SystemConfig{}, fmt.Errorf(
 				"expected L2 genesis hash to match L2 block at genesis block number %d: %s <> %s",
-				rollupCfg.Genesis.L2.Number, payload.BlockHash, rollupCfg.Genesis.L2.Hash)
+				rollupCfg.Genesis.L2.Number, info.Hash(), rollupCfg.Genesis.L2.Hash)
 		}
 		return rollupCfg.Genesis.SystemConfig, nil
 	}
 
-	if len(payload.Transactions) == 0 {
-		return eth.SystemConfig{}, fmt.Errorf("l2 block is missing L1 info deposit tx, block hash: %s", payload.BlockHash)
+	if deposit == nil {
+		return eth.SystemConfig{}, fmt.Errorf("l2 block is missing L1 info deposit tx, block hash: %s", info.Hash())
 	}
-	var tx types.Transaction
-	if err := tx.UnmarshalBinary(payload.Transactions[0]); err != nil {
-		return eth.SystemConfig{}, fmt.Errorf("failed to decode first tx to read l1 info from: %w", err)
+	if deposit.Type() != types.DepositTxType {
+		return eth.SystemConfig{}, fmt.Errorf("first payload tx has unexpected tx type: %d", deposit.Type())
 	}
-	if tx.Type() != types.DepositTxType {
-		return eth.SystemConfig{}, fmt.Errorf("first payload tx has unexpected tx type: %d", tx.Type())
-	}
-	info, err := L1BlockInfoFromBytes(rollupCfg, uint64(payload.Timestamp), tx.Data())
+	l1Info, err := L1BlockInfoFromBytes(rollupCfg, info.Time(), deposit.Data())
 	if err != nil {
 		return eth.SystemConfig{}, fmt.Errorf("failed to parse L1 info deposit tx from L2 block: %w", err)
 	}
-	if isEcotoneButNotFirstBlock(rollupCfg, uint64(payload.Timestamp)) {
+	if isEcotoneButNotFirstBlock(rollupCfg, info.Time()) {
 		// Translate Ecotone values back into encoded scalar if needed.
 		// We do not know if it was derived from a v0 or v1 scalar,
 		// but v1 is fine, a 0 blob base fee has the same effect.
-		info.L1FeeScalar[0] = 1
-		binary.BigEndian.PutUint32(info.L1FeeScalar[24:28], info.BlobBaseFeeScalar)
-		binary.BigEndian.PutUint32(info.L1FeeScalar[28:32], info.BaseFeeScalar)
+		l1Info.L1FeeScalar[0] = 1
+		binary.BigEndian.PutUint32(l1Info.L1FeeScalar[24:28], l1Info.BlobBaseFeeScalar)
+		binary.BigEndian.PutUint32(l1Info.L1FeeScalar[28:32], l1Info.BaseFeeScalar)
 	}
 	r := eth.SystemConfig{
-		BatcherAddr: info.BatcherAddr,
-		Overhead:    info.L1FeeOverhead,
-		Scalar:      info.L1FeeScalar,
-		GasLimit:    uint64(payload.GasLimit),
+		BatcherAddr: l1Info.BatcherAddr,
+		Overhead:    l1Info.L1FeeOverhead,
+		Scalar:      l1Info.L1FeeScalar,
+		GasLimit:    info.GasLimit(),
 	}
-	err = eip1559.ValidateOptimismExtraData(rollupCfg, uint64(payload.Timestamp), payload.ExtraData)
+	err = eip1559.ValidateOptimismExtraData(rollupCfg, info.Time(), info.Extra())
 	if err != nil {
 		return eth.SystemConfig{}, err
 	}
-	d, e, m := eip1559.DecodeOptimismExtraData(rollupCfg, uint64(payload.Timestamp), payload.ExtraData)
+	d, e, m := eip1559.DecodeOptimismExtraData(rollupCfg, info.Time(), info.Extra())
 	copy(r.EIP1559Params[:], eip1559.EncodeHolocene1559Params(d, e))
 
-	if rollupCfg.IsIsthmus(uint64(payload.Timestamp)) {
+	if rollupCfg.IsIsthmus(info.Time()) {
 		r.OperatorFeeParams = eth.EncodeOperatorFeeParams(eth.OperatorFeeParams{
-			Scalar:   info.OperatorFeeScalar,
-			Constant: info.OperatorFeeConstant,
+			Scalar:   l1Info.OperatorFeeScalar,
+			Constant: l1Info.OperatorFeeConstant,
 		})
 	}
 
-	if rollupCfg.IsJovian(uint64(payload.Timestamp)) {
+	if rollupCfg.IsJovian(info.Time()) {
 		// ValidateOptimismExtraData returning a nil error guarantees that m is not nil
 		r.MinBaseFee = *m
-		r.DAFootprintGasScalar = info.DAFootprintGasScalar
+		r.DAFootprintGasScalar = l1Info.DAFootprintGasScalar
 	}
 	return r, nil
+}
+
+// PayloadToBlockRef extracts the essential L2BlockRef information from an execution payload,
+// falling back to genesis information if necessary.
+func PayloadToBlockRef(rollupCfg *rollup.Config, payload *eth.ExecutionPayload) (eth.L2BlockRef, error) {
+	deposit, err := firstTxAsDeposit(payload)
+	if err != nil {
+		return eth.L2BlockRef{}, err
+	}
+	return BlockRefFromHeaderAndDeposit(rollupCfg, eth.PayloadToInfo(payload), deposit)
+}
+
+func PayloadToSystemConfig(rollupCfg *rollup.Config, payload *eth.ExecutionPayload) (eth.SystemConfig, error) {
+	deposit, err := firstTxAsDeposit(payload)
+	if err != nil {
+		return eth.SystemConfig{}, err
+	}
+	return SystemConfigFromHeaderAndDeposit(rollupCfg, eth.PayloadToInfo(payload), deposit)
+}
+
+// firstTxAsDeposit decodes the first transaction of a payload. Returns nil
+// without error when the payload has no transactions, so the genesis branch
+// in the inner helpers can pass through.
+func firstTxAsDeposit(payload *eth.ExecutionPayload) (*types.Transaction, error) {
+	if len(payload.Transactions) == 0 {
+		return nil, nil
+	}
+	var tx types.Transaction
+	if err := tx.UnmarshalBinary(payload.Transactions[0]); err != nil {
+		return nil, fmt.Errorf("failed to decode first tx to read l1 info from: %w", err)
+	}
+	return &tx, nil
 }

--- a/op-node/rollup/derive/payload_util_test.go
+++ b/op-node/rollup/derive/payload_util_test.go
@@ -1,0 +1,201 @@
+package derive
+
+import (
+	"math/big"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/holiman/uint256"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
+)
+
+// buildPayloadAndDeposit produces an L2 payload whose first transaction is a
+// valid L1 info deposit, plus the decoded *types.Transaction for the deposit.
+func buildPayloadAndDeposit(t *testing.T, rng *rand.Rand, rollupCfg *rollup.Config, sysCfg eth.SystemConfig, seqNr, l2Num, l2Time uint64) (*eth.ExecutionPayload, *types.Transaction) {
+	t.Helper()
+	l1Info := testutils.MakeBlockInfo(nil)(rng)
+	depTx, err := L1InfoDeposit(rollupCfg, params.MergedTestChainConfig, sysCfg, seqNr, l1Info, l2Time)
+	require.NoError(t, err)
+	depBin, err := types.NewTx(depTx).MarshalBinary()
+	require.NoError(t, err)
+
+	payload := &eth.ExecutionPayload{
+		ParentHash:    testutils.RandomHash(rng),
+		FeeRecipient:  testutils.RandomAddress(rng),
+		StateRoot:     eth.Bytes32(testutils.RandomHash(rng)),
+		ReceiptsRoot:  eth.Bytes32(testutils.RandomHash(rng)),
+		LogsBloom:     eth.Bytes256{},
+		PrevRandao:    eth.Bytes32(testutils.RandomHash(rng)),
+		BlockNumber:   eth.Uint64Quantity(l2Num),
+		GasLimit:      eth.Uint64Quantity(sysCfg.GasLimit),
+		GasUsed:       21000,
+		Timestamp:     eth.Uint64Quantity(l2Time),
+		ExtraData:     eth.BytesMax32(make([]byte, 0)),
+		BaseFeePerGas: eth.Uint256Quantity(*uint256.NewInt(1)),
+		BlockHash:     testutils.RandomHash(rng),
+		Transactions:  []eth.Data{depBin},
+	}
+	return payload, types.NewTx(depTx)
+}
+
+// TestPayloadToBlockRef_ParityWithInnerHelper verifies that the legacy
+// PayloadToBlockRef wrapper and the new BlockRefFromHeaderAndDeposit inner
+// helper produce identical L2BlockRefs across multiple block configurations.
+func TestPayloadToBlockRef_ParityWithInnerHelper(t *testing.T) {
+	rollupCfg := &rollup.Config{
+		Genesis: rollup.Genesis{
+			L2: eth.BlockID{Number: 0, Hash: common.Hash{0xab}},
+			L1: eth.BlockID{Number: 1000, Hash: common.Hash{0xcd}},
+		},
+	}
+	sysCfg := eth.SystemConfig{
+		BatcherAddr: testutils.RandomAddress(rand.New(rand.NewSource(1))),
+		GasLimit:    30_000_000,
+	}
+
+	cases := []struct {
+		name string
+		num  uint64
+	}{
+		{"post-genesis", 100},
+		{"deeper", 1_000_000},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			rng := rand.New(rand.NewSource(int64(c.num)))
+			payload, deposit := buildPayloadAndDeposit(t, rng, rollupCfg, sysCfg, 7, c.num, 1_700_000_000+c.num)
+
+			refViaPayload, err := PayloadToBlockRef(rollupCfg, payload)
+			require.NoError(t, err)
+
+			refViaInner, err := BlockRefFromHeaderAndDeposit(rollupCfg, eth.PayloadToInfo(payload), deposit)
+			require.NoError(t, err)
+
+			require.Equal(t, refViaPayload, refViaInner)
+		})
+	}
+}
+
+// TestPayloadToSystemConfig_ParityWithInnerHelper verifies that
+// PayloadToSystemConfig and SystemConfigFromHeaderAndDeposit produce
+// identical SystemConfigs for the same payload across multiple forks.
+func TestPayloadToSystemConfig_ParityWithInnerHelper(t *testing.T) {
+	cases := []struct {
+		name      string
+		rollupCfg *rollup.Config
+		l2Time    uint64
+	}{
+		{
+			name: "bedrock",
+			rollupCfg: &rollup.Config{
+				Genesis: rollup.Genesis{
+					L2:           eth.BlockID{Number: 0, Hash: common.Hash{0xab}},
+					L1:           eth.BlockID{Number: 1000, Hash: common.Hash{0xcd}},
+					SystemConfig: eth.SystemConfig{GasLimit: 30_000_000},
+				},
+			},
+			l2Time: 1_700_000_000,
+		},
+	}
+	sysCfg := eth.SystemConfig{
+		BatcherAddr: testutils.RandomAddress(rand.New(rand.NewSource(2))),
+		GasLimit:    30_000_000,
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			rng := rand.New(rand.NewSource(int64(c.l2Time)))
+			payload, deposit := buildPayloadAndDeposit(t, rng, c.rollupCfg, sysCfg, 3, 100, c.l2Time)
+
+			cfgViaPayload, err := PayloadToSystemConfig(c.rollupCfg, payload)
+			require.NoError(t, err)
+
+			cfgViaInner, err := SystemConfigFromHeaderAndDeposit(c.rollupCfg, eth.PayloadToInfo(payload), deposit)
+			require.NoError(t, err)
+
+			require.Equal(t, cfgViaPayload, cfgViaInner)
+		})
+	}
+}
+
+// TestBlockRefFromHeaderAndDeposit_Genesis verifies that at genesis, the
+// L1Origin comes from the rollup config and the deposit is not consulted
+// (passing nil deposit is allowed).
+func TestBlockRefFromHeaderAndDeposit_Genesis(t *testing.T) {
+	genesisHash := common.Hash{0xab}
+	rollupCfg := &rollup.Config{
+		Genesis: rollup.Genesis{
+			L2: eth.BlockID{Number: 0, Hash: genesisHash},
+			L1: eth.BlockID{Number: 1000, Hash: common.Hash{0xcd}},
+		},
+	}
+	hdr := &types.Header{
+		ParentHash: common.Hash{},
+		Number:     big.NewInt(0),
+		Time:       100,
+	}
+	info := eth.HeaderBlockInfoTrusted(genesisHash, hdr)
+
+	ref, err := BlockRefFromHeaderAndDeposit(rollupCfg, info, nil)
+	require.NoError(t, err)
+	require.Equal(t, rollupCfg.Genesis.L1, ref.L1Origin)
+	require.Equal(t, uint64(0), ref.SequenceNumber)
+	require.Equal(t, genesisHash, ref.Hash)
+}
+
+// TestBlockRefFromHeaderAndDeposit_GenesisHashMismatch verifies that a
+// genesis-numbered block with the wrong hash is rejected.
+func TestBlockRefFromHeaderAndDeposit_GenesisHashMismatch(t *testing.T) {
+	rollupCfg := &rollup.Config{
+		Genesis: rollup.Genesis{
+			L2: eth.BlockID{Number: 0, Hash: common.Hash{0xab}},
+		},
+	}
+	hdr := &types.Header{Number: big.NewInt(0)}
+	info := eth.HeaderBlockInfoTrusted(common.Hash{0x99}, hdr)
+
+	_, err := BlockRefFromHeaderAndDeposit(rollupCfg, info, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "expected L2 genesis hash")
+}
+
+// TestBlockRefFromHeaderAndDeposit_FirstTxNotDeposit rejects a non-deposit
+// first transaction.
+func TestBlockRefFromHeaderAndDeposit_FirstTxNotDeposit(t *testing.T) {
+	rollupCfg := &rollup.Config{
+		Genesis: rollup.Genesis{
+			L2: eth.BlockID{Number: 0, Hash: common.Hash{0xab}},
+		},
+	}
+	hdr := &types.Header{Number: big.NewInt(100)}
+	info := eth.HeaderBlockInfoTrusted(common.Hash{0x77}, hdr)
+	nonDeposit := types.NewTx(&types.LegacyTx{Nonce: 0, Gas: 21000, GasPrice: big.NewInt(1)})
+
+	_, err := BlockRefFromHeaderAndDeposit(rollupCfg, info, nonDeposit)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unexpected tx type")
+}
+
+// TestBlockRefFromHeaderAndDeposit_MissingDeposit rejects a non-genesis
+// block with a nil deposit.
+func TestBlockRefFromHeaderAndDeposit_MissingDeposit(t *testing.T) {
+	rollupCfg := &rollup.Config{
+		Genesis: rollup.Genesis{
+			L2: eth.BlockID{Number: 0, Hash: common.Hash{0xab}},
+		},
+	}
+	hdr := &types.Header{Number: big.NewInt(100)}
+	info := eth.HeaderBlockInfoTrusted(common.Hash{0x77}, hdr)
+
+	_, err := BlockRefFromHeaderAndDeposit(rollupCfg, info, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "missing L1 info deposit")
+}

--- a/op-service/eth/block_info.go
+++ b/op-service/eth/block_info.go
@@ -3,6 +3,8 @@ package eth
 import (
 	"math/big"
 
+	"github.com/holiman/uint256"
+
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus/misc/eip4844"
@@ -175,4 +177,54 @@ func HeaderBlockInfo(h *types.Header) BlockInfo {
 // HeaderBlockInfoTrusted returns a BlockInfo, with trusted pre-cached block-hash.
 func HeaderBlockInfoTrusted(hash common.Hash, h *types.Header) BlockInfo {
 	return &headerBlockInfo{hash: hash, header: h}
+}
+
+// payloadBlockInfo is a conversion type of *ExecutionPayload turning it into
+// a BlockInfo. ParentBeaconRoot is not on the bare payload (it lives on the
+// envelope) and is reported as nil.
+type payloadBlockInfo struct{ p *ExecutionPayload }
+
+var _ BlockInfo = (*payloadBlockInfo)(nil)
+
+func (b *payloadBlockInfo) Hash() common.Hash       { return b.p.BlockHash }
+func (b *payloadBlockInfo) ParentHash() common.Hash { return b.p.ParentHash }
+func (b *payloadBlockInfo) Coinbase() common.Address {
+	return b.p.FeeRecipient
+}
+func (b *payloadBlockInfo) Root() common.Hash { return common.Hash(b.p.StateRoot) }
+func (b *payloadBlockInfo) NumberU64() uint64 { return uint64(b.p.BlockNumber) }
+func (b *payloadBlockInfo) Time() uint64      { return uint64(b.p.Timestamp) }
+func (b *payloadBlockInfo) MixDigest() common.Hash {
+	return common.Hash(b.p.PrevRandao)
+}
+func (b *payloadBlockInfo) BaseFee() *big.Int {
+	return (*uint256.Int)(&b.p.BaseFeePerGas).ToBig()
+}
+func (b *payloadBlockInfo) BlobBaseFee(chainConfig *params.ChainConfig) *big.Int {
+	if b.p.ExcessBlobGas == nil {
+		return nil
+	}
+	// CalcBlobFee reads only ExcessBlobGas and Time from the header.
+	hdr := &types.Header{
+		Time:          uint64(b.p.Timestamp),
+		ExcessBlobGas: (*uint64)(b.p.ExcessBlobGas),
+	}
+	return eip4844.CalcBlobFee(chainConfig, hdr)
+}
+func (b *payloadBlockInfo) ExcessBlobGas() *uint64 { return (*uint64)(b.p.ExcessBlobGas) }
+func (b *payloadBlockInfo) ReceiptHash() common.Hash {
+	return common.Hash(b.p.ReceiptsRoot)
+}
+func (b *payloadBlockInfo) GasUsed() uint64 { return uint64(b.p.GasUsed) }
+func (b *payloadBlockInfo) BlobGasUsed() *uint64 {
+	return (*uint64)(b.p.BlobGasUsed)
+}
+func (b *payloadBlockInfo) GasLimit() uint64               { return uint64(b.p.GasLimit) }
+func (b *payloadBlockInfo) ParentBeaconRoot() *common.Hash { return nil }
+func (b *payloadBlockInfo) WithdrawalsRoot() *common.Hash  { return b.p.WithdrawalsRoot }
+func (b *payloadBlockInfo) Extra() []byte                  { return b.p.ExtraData }
+
+// PayloadToInfo returns p as a BlockInfo implementation.
+func PayloadToInfo(p *ExecutionPayload) BlockInfo {
+	return &payloadBlockInfo{p: p}
 }

--- a/op-service/sources/eth_client.go
+++ b/op-service/sources/eth_client.go
@@ -139,6 +139,11 @@ type EthClient struct {
 	// common.Hash -> *types.Header
 	headersCache *caching.LRUCache[common.Hash, *types.Header]
 
+	// cache (header, first tx) pairs by block hash. Source of truth for
+	// L2BlockRefBy* and SystemConfigByL2Hash, where the first tx is the L1
+	// info deposit and the rest of the block is irrelevant.
+	headerAndDepositCache *caching.LRUCache[common.Hash, headerAndDeposit]
+
 	// cache payloads by hash
 	// common.Hash -> *eth.ExecutionPayload
 	payloadsCache *caching.LRUCache[common.Hash, *eth.ExecutionPayloadEnvelope]
@@ -163,15 +168,16 @@ func NewEthClient(client client.RPC, log log.Logger, metrics caching.Metrics, co
 		return nil, errors.New("failed to establish receipts provider")
 	}
 	return &EthClient{
-		client:            client,
-		recProvider:       recProvider,
-		trustRPC:          config.TrustRPC,
-		mustBePostMerge:   config.MustBePostMerge,
-		log:               log,
-		transactionsCache: caching.NewLRUCache[common.Hash, types.Transactions](metrics, "txs", config.TransactionsCacheSize),
-		headersCache:      caching.NewLRUCache[common.Hash, *types.Header](metrics, "headers", config.HeadersCacheSize),
-		payloadsCache:     caching.NewLRUCache[common.Hash, *eth.ExecutionPayloadEnvelope](metrics, "payloads", config.PayloadsCacheSize),
-		blockRefsCache:    caching.NewLRUCache[common.Hash, eth.L1BlockRef](metrics, "blockrefs", config.BlockRefsCacheSize),
+		client:                client,
+		recProvider:           recProvider,
+		trustRPC:              config.TrustRPC,
+		mustBePostMerge:       config.MustBePostMerge,
+		log:                   log,
+		transactionsCache:     caching.NewLRUCache[common.Hash, types.Transactions](metrics, "txs", config.TransactionsCacheSize),
+		headersCache:          caching.NewLRUCache[common.Hash, *types.Header](metrics, "headers", config.HeadersCacheSize),
+		headerAndDepositCache: caching.NewLRUCache[common.Hash, headerAndDeposit](metrics, "headers_and_deposits", config.HeadersCacheSize),
+		payloadsCache:         caching.NewLRUCache[common.Hash, *eth.ExecutionPayloadEnvelope](metrics, "payloads", config.PayloadsCacheSize),
+		blockRefsCache:        caching.NewLRUCache[common.Hash, eth.L1BlockRef](metrics, "blockrefs", config.BlockRefsCacheSize),
 	}, nil
 }
 
@@ -315,6 +321,109 @@ func (s *EthClient) HeaderByNumber(ctx context.Context, number uint64) (*types.H
 func (s *EthClient) HeaderByLabel(ctx context.Context, label eth.BlockLabel) (*types.Header, error) {
 	// can't hit the cache when querying the head due to reorgs / changes.
 	return s.headerCall(ctx, "eth_getBlockByNumber", label)
+}
+
+// headerAndDeposit pairs a block header with its first transaction (the L1
+// info deposit on L2). Cached by block hash.
+type headerAndDeposit struct {
+	header  *types.Header
+	deposit *types.Transaction
+}
+
+// HeaderAndFirstTx returns the block header and the first transaction (the
+// L1 info deposit on L2) using a single batched JSON-RPC round trip:
+// eth_getBlockByX(id, false) + eth_getTransactionByBlockXAndIndex(id, 0).
+//
+// On a cache hit (when id is a hash), no RPC is issued.
+//
+// For label/number paths, the two calls in the batch can in principle resolve
+// to different blocks under a reorg or new head. This is detected by
+// comparing header.Transactions[0] (a hash, since fullTx=false) against the
+// fetched tx's hash. On mismatch, only the first tx is refetched, by the
+// header's now-known hash. The header is kept (it is internally consistent
+// and represents a valid snapshot of the requested label).
+//
+// Returns an error if the block has no transactions or the first transaction
+// is not a deposit type — both invariants of valid post-Bedrock L2 blocks.
+func (s *EthClient) HeaderAndFirstTx(ctx context.Context, id rpcBlockID) (*types.Header, *types.Transaction, error) {
+	if h, ok := id.(hashID); ok {
+		if entry, hit := s.headerAndDepositCache.Get(common.Hash(h)); hit {
+			return entry.header, entry.deposit, nil
+		}
+	}
+
+	getBlockMethod, getTxByIndexMethod := blockAndTxByIndexMethods(id)
+
+	var rpcHdr RPCHeaderWithTxHashes
+	var firstTx *types.Transaction
+	batch := []rpc.BatchElem{
+		{Method: getBlockMethod, Args: []any{id.Arg(), false}, Result: &rpcHdr},
+		{Method: getTxByIndexMethod, Args: []any{id.Arg(), hexutil.EncodeUint64(0)}, Result: &firstTx},
+	}
+	if err := s.client.BatchCallContext(ctx, batch); err != nil {
+		return nil, nil, eth.MaybeAsNotFoundErr(err)
+	}
+	if batch[0].Error != nil {
+		return nil, nil, eth.MaybeAsNotFoundErr(batch[0].Error)
+	}
+	if batch[1].Error != nil {
+		return nil, nil, eth.MaybeAsNotFoundErr(batch[1].Error)
+	}
+
+	header, err := rpcHdr.RPCHeader.Header(s.trustRPC, s.mustBePostMerge)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := id.CheckID(rpcHdr.BlockID()); err != nil {
+		return nil, nil, fmt.Errorf("fetched header does not match requested ID: %w", err)
+	}
+	if len(rpcHdr.Transactions) == 0 {
+		return nil, nil, fmt.Errorf("l2 block has no transactions, block hash: %s", rpcHdr.Hash)
+	}
+	if firstTx == nil {
+		return nil, nil, fmt.Errorf("l2 block first tx fetch returned nil, block hash: %s", rpcHdr.Hash)
+	}
+
+	// Consistency check: only needed for non-by-hash paths, where the two
+	// batch calls may resolve to different blocks under a reorg or new head.
+	if _, byHash := id.(hashID); !byHash {
+		if rpcHdr.Transactions[0] != firstTx.Hash() {
+			s.log.Debug("HeaderAndFirstTx: header/tx race detected, refetching tx by hash",
+				"block_hash", rpcHdr.Hash,
+				"header_tx0", rpcHdr.Transactions[0],
+				"got_tx_hash", firstTx.Hash())
+			firstTx = nil
+			err := s.client.CallContext(ctx, &firstTx,
+				"eth_getTransactionByBlockHashAndIndex",
+				rpcHdr.Hash, hexutil.EncodeUint64(0))
+			if err != nil {
+				return nil, nil, fmt.Errorf("retry first tx by hash failed: %w", err)
+			}
+			if firstTx == nil {
+				return nil, nil, fmt.Errorf("retry first tx by hash returned nil, block hash: %s", rpcHdr.Hash)
+			}
+			if rpcHdr.Transactions[0] != firstTx.Hash() {
+				return nil, nil, fmt.Errorf("first tx hash mismatch after retry: header says %s but tx is %s", rpcHdr.Transactions[0], firstTx.Hash())
+			}
+		}
+	}
+
+	if firstTx.Type() != types.DepositTxType {
+		return nil, nil, fmt.Errorf("first payload tx has unexpected tx type: %d", firstTx.Type())
+	}
+
+	s.headersCache.Add(rpcHdr.Hash, header)
+	s.headerAndDepositCache.Add(rpcHdr.Hash, headerAndDeposit{header: header, deposit: firstTx})
+	return header, firstTx, nil
+}
+
+// blockAndTxByIndexMethods returns the (getBlock, getTransactionByIndex) JSON-RPC
+// method names for the given block identifier kind.
+func blockAndTxByIndexMethods(id rpcBlockID) (block, txByIndex string) {
+	if _, ok := id.(hashID); ok {
+		return "eth_getBlockByHash", "eth_getTransactionByBlockHashAndIndex"
+	}
+	return "eth_getBlockByNumber", "eth_getTransactionByBlockNumberAndIndex"
 }
 
 // HeaderAndTxsByHash returns the *types.Header and transactions for the given

--- a/op-service/sources/eth_client.go
+++ b/op-service/sources/eth_client.go
@@ -331,8 +331,9 @@ type headerAndDeposit struct {
 }
 
 // HeaderAndFirstTx returns the block header and the first transaction (the
-// L1 info deposit on L2) using a single batched JSON-RPC round trip:
-// eth_getBlockByX(id, false) + eth_getTransactionByBlockXAndIndex(id, 0).
+// L1 info deposit on post-Bedrock L2 blocks) using a single batched
+// JSON-RPC round trip: eth_getBlockByX(id, false) +
+// eth_getTransactionByBlockXAndIndex(id, 0).
 //
 // On a cache hit (when id is a hash), no RPC is issued.
 //
@@ -343,8 +344,10 @@ type headerAndDeposit struct {
 // header's now-known hash. The header is kept (it is internally consistent
 // and represents a valid snapshot of the requested label).
 //
-// Returns an error if the block has no transactions or the first transaction
-// is not a deposit type — both invariants of valid post-Bedrock L2 blocks.
+// If the block has no transactions, the returned tx is nil and no error is
+// raised — callers that require a particular first-tx shape (e.g. an L1 info
+// deposit) handle that themselves. The L2 genesis block has no transactions
+// and must not error here.
 func (s *EthClient) HeaderAndFirstTx(ctx context.Context, id rpcBlockID) (*types.Header, *types.Transaction, error) {
 	if h, ok := id.(hashID); ok {
 		if entry, hit := s.headerAndDepositCache.Get(common.Hash(h)); hit {
@@ -366,9 +369,8 @@ func (s *EthClient) HeaderAndFirstTx(ctx context.Context, id rpcBlockID) (*types
 	if batch[0].Error != nil {
 		return nil, nil, eth.MaybeAsNotFoundErr(batch[0].Error)
 	}
-	if batch[1].Error != nil {
-		return nil, nil, eth.MaybeAsNotFoundErr(batch[1].Error)
-	}
+	// batch[1].Error is tolerated: a block with no transactions returns null
+	// for tx-by-index-0 and some ELs surface that as a not-found error.
 
 	header, err := rpcHdr.RPCHeader.Header(s.trustRPC, s.mustBePostMerge)
 	if err != nil {
@@ -377,9 +379,15 @@ func (s *EthClient) HeaderAndFirstTx(ctx context.Context, id rpcBlockID) (*types
 	if err := id.CheckID(rpcHdr.BlockID()); err != nil {
 		return nil, nil, fmt.Errorf("fetched header does not match requested ID: %w", err)
 	}
+
+	// Empty block (e.g. L2 genesis): return header with nil deposit. Callers
+	// that need a first tx will surface their own error.
 	if len(rpcHdr.Transactions) == 0 {
-		return nil, nil, fmt.Errorf("l2 block has no transactions, block hash: %s", rpcHdr.Hash)
+		s.headersCache.Add(rpcHdr.Hash, header)
+		s.headerAndDepositCache.Add(rpcHdr.Hash, headerAndDeposit{header: header, deposit: nil})
+		return header, nil, nil
 	}
+
 	if firstTx == nil {
 		return nil, nil, fmt.Errorf("l2 block first tx fetch returned nil, block hash: %s", rpcHdr.Hash)
 	}
@@ -406,10 +414,6 @@ func (s *EthClient) HeaderAndFirstTx(ctx context.Context, id rpcBlockID) (*types
 				return nil, nil, fmt.Errorf("first tx hash mismatch after retry: header says %s but tx is %s", rpcHdr.Transactions[0], firstTx.Hash())
 			}
 		}
-	}
-
-	if firstTx.Type() != types.DepositTxType {
-		return nil, nil, fmt.Errorf("first payload tx has unexpected tx type: %d", firstTx.Type())
 	}
 
 	s.headersCache.Add(rpcHdr.Hash, header)

--- a/op-service/sources/eth_client.go
+++ b/op-service/sources/eth_client.go
@@ -395,31 +395,37 @@ func (s *EthClient) HeaderAndFirstTx(ctx context.Context, id rpcBlockID) (*types
 		return header, nil, nil
 	}
 
-	if firstTx == nil {
-		return nil, nil, fmt.Errorf("l2 block first tx fetch returned nil, block hash: %s", rpcHdr.Hash)
+	// Decide if a tx-by-hash retry is needed:
+	// - firstTx == nil while the block has transactions: transient EL state
+	//   where the same block lookup succeeded for the header call but the
+	//   tx-by-index call inside the same batch returned null (rare but
+	//   observed under derivation pressure).
+	// - rpcHdr.Transactions[0] != firstTx.Hash() on a non-by-hash path:
+	//   the two batch calls resolved to different blocks under a reorg or
+	//   new head.
+	needsRetry := firstTx == nil
+	if !needsRetry {
+		if _, byHash := id.(hashID); !byHash {
+			needsRetry = rpcHdr.Transactions[0] != firstTx.Hash()
+		}
 	}
-
-	// Consistency check: only needed for non-by-hash paths, where the two
-	// batch calls may resolve to different blocks under a reorg or new head.
-	if _, byHash := id.(hashID); !byHash {
+	if needsRetry {
+		s.log.Debug("HeaderAndFirstTx: refetching first tx by hash",
+			"block_hash", rpcHdr.Hash,
+			"header_tx0", rpcHdr.Transactions[0],
+			"first_tx_was_nil", firstTx == nil)
+		firstTx = nil
+		err := s.client.CallContext(ctx, &firstTx,
+			"eth_getTransactionByBlockHashAndIndex",
+			rpcHdr.Hash, hexutil.EncodeUint64(0))
+		if err != nil {
+			return nil, nil, fmt.Errorf("retry first tx by hash failed: %w", err)
+		}
+		if firstTx == nil {
+			return nil, nil, fmt.Errorf("retry first tx by hash returned nil, block hash: %s", rpcHdr.Hash)
+		}
 		if rpcHdr.Transactions[0] != firstTx.Hash() {
-			s.log.Debug("HeaderAndFirstTx: header/tx race detected, refetching tx by hash",
-				"block_hash", rpcHdr.Hash,
-				"header_tx0", rpcHdr.Transactions[0],
-				"got_tx_hash", firstTx.Hash())
-			firstTx = nil
-			err := s.client.CallContext(ctx, &firstTx,
-				"eth_getTransactionByBlockHashAndIndex",
-				rpcHdr.Hash, hexutil.EncodeUint64(0))
-			if err != nil {
-				return nil, nil, fmt.Errorf("retry first tx by hash failed: %w", err)
-			}
-			if firstTx == nil {
-				return nil, nil, fmt.Errorf("retry first tx by hash returned nil, block hash: %s", rpcHdr.Hash)
-			}
-			if rpcHdr.Transactions[0] != firstTx.Hash() {
-				return nil, nil, fmt.Errorf("first tx hash mismatch after retry: header says %s but tx is %s", rpcHdr.Transactions[0], firstTx.Hash())
-			}
+			return nil, nil, fmt.Errorf("first tx hash mismatch after retry: header says %s but tx is %s", rpcHdr.Transactions[0], firstTx.Hash())
 		}
 	}
 

--- a/op-service/sources/eth_client.go
+++ b/op-service/sources/eth_client.go
@@ -357,7 +357,11 @@ func (s *EthClient) HeaderAndFirstTx(ctx context.Context, id rpcBlockID) (*types
 
 	getBlockMethod, getTxByIndexMethod := blockAndTxByIndexMethods(id)
 
-	var rpcHdr RPCHeaderWithTxHashes
+	// Pointer (not value) result so that a JSON `null` response leaves
+	// rpcHdr == nil and we can surface ethereum.NotFound instead of trying to
+	// validate a zero-valued header. The EL returns null for, e.g.,
+	// eth_getBlockByNumber("finalized") before any block has finalized.
+	var rpcHdr *RPCHeaderWithTxHashes
 	var firstTx *types.Transaction
 	batch := []rpc.BatchElem{
 		{Method: getBlockMethod, Args: []any{id.Arg(), false}, Result: &rpcHdr},
@@ -368,6 +372,9 @@ func (s *EthClient) HeaderAndFirstTx(ctx context.Context, id rpcBlockID) (*types
 	}
 	if batch[0].Error != nil {
 		return nil, nil, eth.MaybeAsNotFoundErr(batch[0].Error)
+	}
+	if rpcHdr == nil {
+		return nil, nil, ethereum.NotFound
 	}
 	// batch[1].Error is tolerated: a block with no transactions returns null
 	// for tx-by-index-0 and some ELs surface that as a not-found error.

--- a/op-service/sources/eth_client_test.go
+++ b/op-service/sources/eth_client_test.go
@@ -217,13 +217,14 @@ func makeNonDepositTx() *types.Transaction {
 
 // expectBatchHeaderAndTx wires the mockRPC to fulfill a HeaderAndFirstTx
 // batch (eth_getBlockBy* + eth_getTransactionByBlock*AndIndex). The setup fn
-// receives pointers it must populate.
-func expectBatchHeaderAndTx(m *mockRPC, populate func(hdr *RPCHeaderWithTxHashes, firstTx **types.Transaction)) {
+// receives pointer-to-pointer targets it must populate; leaving them nil
+// emulates a JSON `null` response from the EL.
+func expectBatchHeaderAndTx(m *mockRPC, populate func(hdr **RPCHeaderWithTxHashes, firstTx **types.Transaction)) {
 	m.On("BatchCallContext", mock.Anything, mock.Anything).Once().Run(func(args mock.Arguments) {
 		b := args.Get(1).([]rpc.BatchElem)
-		hdrPtr := b[0].Result.(*RPCHeaderWithTxHashes)
+		hdrPtrPtr := b[0].Result.(**RPCHeaderWithTxHashes)
 		txPtrPtr := b[1].Result.(**types.Transaction)
-		populate(hdrPtr, txPtrPtr)
+		populate(hdrPtrPtr, txPtrPtr)
 	}).Return([]error{nil})
 }
 
@@ -258,8 +259,8 @@ func TestEthClient_HeaderAndFirstTx_ByHash_Happy(t *testing.T) {
 	rh := rpcHeaderWithTxs(hdr, []common.Hash{deposit.Hash()})
 
 	m := new(mockRPC)
-	expectBatchHeaderAndTx(m, func(hdrOut *RPCHeaderWithTxHashes, txOut **types.Transaction) {
-		*hdrOut = *rh
+	expectBatchHeaderAndTx(m, func(hdrOut **RPCHeaderWithTxHashes, txOut **types.Transaction) {
+		*hdrOut = rh
 		*txOut = deposit
 	})
 	s, err := NewEthClient(m, testlog.Logger(t, log.LevelError), nil, testEthClientConfig)
@@ -279,8 +280,8 @@ func TestEthClient_HeaderAndFirstTx_ByHash_CacheHit(t *testing.T) {
 	rh := rpcHeaderWithTxs(hdr, []common.Hash{deposit.Hash()})
 
 	m := new(mockRPC)
-	expectBatchHeaderAndTx(m, func(hdrOut *RPCHeaderWithTxHashes, txOut **types.Transaction) {
-		*hdrOut = *rh
+	expectBatchHeaderAndTx(m, func(hdrOut **RPCHeaderWithTxHashes, txOut **types.Transaction) {
+		*hdrOut = rh
 		*txOut = deposit
 	})
 	s, err := NewEthClient(m, testlog.Logger(t, log.LevelError), nil, testEthClientConfig)
@@ -306,8 +307,8 @@ func TestEthClient_HeaderAndFirstTx_ByNumber_RaceRetry(t *testing.T) {
 
 	m := new(mockRPC)
 	// 1) batched call returns header with one tx hash and a tx whose hash does NOT match
-	expectBatchHeaderAndTx(m, func(hdrOut *RPCHeaderWithTxHashes, txOut **types.Transaction) {
-		*hdrOut = *rh
+	expectBatchHeaderAndTx(m, func(hdrOut **RPCHeaderWithTxHashes, txOut **types.Transaction) {
+		*hdrOut = rh
 		*txOut = conflictingTx
 	})
 	// 2) follow-up tx-by-hash-and-index returns the correct tx
@@ -339,8 +340,8 @@ func TestEthClient_HeaderAndFirstTx_EmptyBlock(t *testing.T) {
 	rh := rpcHeaderWithTxs(hdr, nil)
 
 	m := new(mockRPC)
-	expectBatchHeaderAndTx(m, func(hdrOut *RPCHeaderWithTxHashes, txOut **types.Transaction) {
-		*hdrOut = *rh
+	expectBatchHeaderAndTx(m, func(hdrOut **RPCHeaderWithTxHashes, txOut **types.Transaction) {
+		*hdrOut = rh
 		*txOut = nil
 	})
 	s, err := NewEthClient(m, testlog.Logger(t, log.LevelError), nil, testEthClientConfig)
@@ -351,6 +352,29 @@ func TestEthClient_HeaderAndFirstTx_EmptyBlock(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, rh.Hash, gotHdr.Hash())
 	require.Nil(t, gotTx)
+}
+
+// TestEthClient_HeaderAndFirstTx_ByLabel_NullResult verifies that when the EL
+// returns null for eth_getBlockByNumber (e.g. label="finalized" before any L2
+// block has finalized), HeaderAndFirstTx surfaces ethereum.NotFound instead of
+// trying to validate a zero-valued header. This matches the previous payloadCall
+// behavior and is required for op-node sync/start.go to fall back to the genesis
+// block.
+func TestEthClient_HeaderAndFirstTx_ByLabel_NullResult(t *testing.T) {
+	m := new(mockRPC)
+	// Simulate JSON decode of `null`: leave both result targets untouched.
+	m.On("BatchCallContext", mock.Anything, mock.Anything).Once().
+		Run(func(args mock.Arguments) {
+			// no-op: emulate null response (Result targets remain zero-valued)
+		}).Return([]error{nil})
+
+	s, err := NewEthClient(m, testlog.Logger(t, log.LevelError), nil, testEthClientConfig)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	_, _, err = s.HeaderAndFirstTx(ctx, eth.BlockLabel("finalized"))
+	require.ErrorIs(t, err, ethereum.NotFound, "expected NotFound for null EL response, got: %v", err)
+	m.Mock.AssertExpectations(t)
 }
 
 // TestReceiptValidation tests that the receipt validation is performed by the underlying RPCReceiptsFetcher

--- a/op-service/sources/eth_client_test.go
+++ b/op-service/sources/eth_client_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
@@ -21,6 +22,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/sources/caching"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
 )
 
 type mockRPC struct {
@@ -187,6 +189,182 @@ func newEthClientWithCaches(metrics caching.Metrics, cacheSize int) *EthClient {
 		headersCache:      caching.NewLRUCache[common.Hash, *types.Header](metrics, "headers", cacheSize),
 		payloadsCache:     caching.NewLRUCache[common.Hash, *eth.ExecutionPayloadEnvelope](metrics, "payloads", cacheSize),
 	}
+}
+
+// makeDepositTx returns a minimal deposit-type transaction for tests.
+func makeDepositTx(seq uint64) *types.Transaction {
+	return types.NewTx(&types.DepositTx{
+		SourceHash: common.Hash{0xde, byte(seq)},
+		From:       common.HexToAddress("0xdead"),
+		To:         &common.Address{0x42},
+		Mint:       big.NewInt(0),
+		Value:      big.NewInt(0),
+		Gas:        21000,
+		Data:       []byte{0xca, 0xfe},
+	})
+}
+
+// makeNonDepositTx returns a non-deposit tx for testing rejection paths.
+func makeNonDepositTx() *types.Transaction {
+	return types.NewTx(&types.LegacyTx{
+		Nonce:    0,
+		To:       &common.Address{0x42},
+		Value:    big.NewInt(0),
+		Gas:      21000,
+		GasPrice: big.NewInt(1),
+	})
+}
+
+// expectBatchHeaderAndTx wires the mockRPC to fulfill a HeaderAndFirstTx
+// batch (eth_getBlockBy* + eth_getTransactionByBlock*AndIndex). The setup fn
+// receives pointers it must populate.
+func expectBatchHeaderAndTx(m *mockRPC, populate func(hdr *RPCHeaderWithTxHashes, firstTx **types.Transaction)) {
+	m.On("BatchCallContext", mock.Anything, mock.Anything).Once().Run(func(args mock.Arguments) {
+		b := args.Get(1).([]rpc.BatchElem)
+		hdrPtr := b[0].Result.(*RPCHeaderWithTxHashes)
+		txPtrPtr := b[1].Result.(**types.Transaction)
+		populate(hdrPtr, txPtrPtr)
+	}).Return([]error{nil})
+}
+
+// rpcHeaderWithTxs builds an RPCHeaderWithTxHashes from a real header and the
+// list of tx hashes the EL would have included.
+func rpcHeaderWithTxs(hdr *types.Header, txHashes []common.Hash) *RPCHeaderWithTxHashes {
+	rh := &RPCHeader{
+		ParentHash:  hdr.ParentHash,
+		UncleHash:   hdr.UncleHash,
+		Coinbase:    hdr.Coinbase,
+		Root:        hdr.Root,
+		TxHash:      hdr.TxHash,
+		ReceiptHash: hdr.ReceiptHash,
+		Bloom:       eth.Bytes256(hdr.Bloom),
+		Difficulty:  *(*hexutil.Big)(hdr.Difficulty),
+		Number:      hexutil.Uint64(bigs.Uint64Strict(hdr.Number)),
+		GasLimit:    hexutil.Uint64(hdr.GasLimit),
+		GasUsed:     hexutil.Uint64(hdr.GasUsed),
+		Time:        hexutil.Uint64(hdr.Time),
+		Extra:       hdr.Extra,
+		MixDigest:   hdr.MixDigest,
+		Nonce:       hdr.Nonce,
+		BaseFee:     (*hexutil.Big)(hdr.BaseFee),
+		Hash:        hdr.Hash(),
+	}
+	return &RPCHeaderWithTxHashes{RPCHeader: *rh, Transactions: txHashes}
+}
+
+func TestEthClient_HeaderAndFirstTx_ByHash_Happy(t *testing.T) {
+	hdr, _ := randHeader()
+	deposit := makeDepositTx(1)
+	rh := rpcHeaderWithTxs(hdr, []common.Hash{deposit.Hash()})
+
+	m := new(mockRPC)
+	expectBatchHeaderAndTx(m, func(hdrOut *RPCHeaderWithTxHashes, txOut **types.Transaction) {
+		*hdrOut = *rh
+		*txOut = deposit
+	})
+	s, err := NewEthClient(m, testlog.Logger(t, log.LevelError), nil, testEthClientConfig)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	gotHdr, gotTx, err := s.HeaderAndFirstTx(ctx, hashID(rh.Hash))
+	require.NoError(t, err)
+	require.Equal(t, rh.Hash, gotHdr.Hash())
+	require.Equal(t, deposit.Hash(), gotTx.Hash())
+	m.Mock.AssertExpectations(t)
+}
+
+func TestEthClient_HeaderAndFirstTx_ByHash_CacheHit(t *testing.T) {
+	hdr, _ := randHeader()
+	deposit := makeDepositTx(2)
+	rh := rpcHeaderWithTxs(hdr, []common.Hash{deposit.Hash()})
+
+	m := new(mockRPC)
+	expectBatchHeaderAndTx(m, func(hdrOut *RPCHeaderWithTxHashes, txOut **types.Transaction) {
+		*hdrOut = *rh
+		*txOut = deposit
+	})
+	s, err := NewEthClient(m, testlog.Logger(t, log.LevelError), nil, testEthClientConfig)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	_, _, err = s.HeaderAndFirstTx(ctx, hashID(rh.Hash))
+	require.NoError(t, err)
+	// Second call hits cache; no further RPC expected.
+	gotHdr, gotTx, err := s.HeaderAndFirstTx(ctx, hashID(rh.Hash))
+	require.NoError(t, err)
+	require.Equal(t, rh.Hash, gotHdr.Hash())
+	require.Equal(t, deposit.Hash(), gotTx.Hash())
+	m.Mock.AssertExpectations(t)
+}
+
+func TestEthClient_HeaderAndFirstTx_ByNumber_RaceRetry(t *testing.T) {
+	hdr, _ := randHeader()
+	headerSideTx := makeDepositTx(3)    // hash that the header references
+	conflictingTx := makeNonDepositTx() // wrong hash + wrong type — but we'll treat it as the "stale" tx the batch returned
+	require.NotEqual(t, headerSideTx.Hash(), conflictingTx.Hash())
+	rh := rpcHeaderWithTxs(hdr, []common.Hash{headerSideTx.Hash()})
+
+	m := new(mockRPC)
+	// 1) batched call returns header with one tx hash and a tx whose hash does NOT match
+	expectBatchHeaderAndTx(m, func(hdrOut *RPCHeaderWithTxHashes, txOut **types.Transaction) {
+		*hdrOut = *rh
+		*txOut = conflictingTx
+	})
+	// 2) follow-up tx-by-hash-and-index returns the correct tx
+	m.On("CallContext", mock.Anything, mock.Anything,
+		"eth_getTransactionByBlockHashAndIndex",
+		[]any{rh.Hash, hexutil.EncodeUint64(0)}).
+		Run(func(args mock.Arguments) {
+			out := args.Get(1).(**types.Transaction)
+			*out = headerSideTx
+		}).Return([]error{nil})
+
+	s, err := NewEthClient(m, testlog.Logger(t, log.LevelError), nil, testEthClientConfig)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	gotHdr, gotTx, err := s.HeaderAndFirstTx(ctx, numberID(uint64(rh.Number)))
+	require.NoError(t, err)
+	require.Equal(t, rh.Hash, gotHdr.Hash())
+	require.Equal(t, headerSideTx.Hash(), gotTx.Hash())
+	m.Mock.AssertExpectations(t)
+}
+
+func TestEthClient_HeaderAndFirstTx_FirstTxNotDeposit(t *testing.T) {
+	hdr, _ := randHeader()
+	tx := makeNonDepositTx()
+	rh := rpcHeaderWithTxs(hdr, []common.Hash{tx.Hash()})
+
+	m := new(mockRPC)
+	expectBatchHeaderAndTx(m, func(hdrOut *RPCHeaderWithTxHashes, txOut **types.Transaction) {
+		*hdrOut = *rh
+		*txOut = tx
+	})
+	s, err := NewEthClient(m, testlog.Logger(t, log.LevelError), nil, testEthClientConfig)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	_, _, err = s.HeaderAndFirstTx(ctx, hashID(rh.Hash))
+	require.Error(t, err, "expected first-tx-not-deposit rejection")
+	require.Contains(t, err.Error(), "unexpected tx type")
+}
+
+func TestEthClient_HeaderAndFirstTx_EmptyBlock(t *testing.T) {
+	hdr, _ := randHeader()
+	rh := rpcHeaderWithTxs(hdr, nil)
+
+	m := new(mockRPC)
+	expectBatchHeaderAndTx(m, func(hdrOut *RPCHeaderWithTxHashes, txOut **types.Transaction) {
+		*hdrOut = *rh
+		*txOut = nil
+	})
+	s, err := NewEthClient(m, testlog.Logger(t, log.LevelError), nil, testEthClientConfig)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	_, _, err = s.HeaderAndFirstTx(ctx, hashID(rh.Hash))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no transactions")
 }
 
 // TestReceiptValidation tests that the receipt validation is performed by the underlying RPCReceiptsFetcher

--- a/op-service/sources/eth_client_test.go
+++ b/op-service/sources/eth_client_test.go
@@ -330,25 +330,10 @@ func TestEthClient_HeaderAndFirstTx_ByNumber_RaceRetry(t *testing.T) {
 	m.Mock.AssertExpectations(t)
 }
 
-func TestEthClient_HeaderAndFirstTx_FirstTxNotDeposit(t *testing.T) {
-	hdr, _ := randHeader()
-	tx := makeNonDepositTx()
-	rh := rpcHeaderWithTxs(hdr, []common.Hash{tx.Hash()})
-
-	m := new(mockRPC)
-	expectBatchHeaderAndTx(m, func(hdrOut *RPCHeaderWithTxHashes, txOut **types.Transaction) {
-		*hdrOut = *rh
-		*txOut = tx
-	})
-	s, err := NewEthClient(m, testlog.Logger(t, log.LevelError), nil, testEthClientConfig)
-	require.NoError(t, err)
-
-	ctx := context.Background()
-	_, _, err = s.HeaderAndFirstTx(ctx, hashID(rh.Hash))
-	require.Error(t, err, "expected first-tx-not-deposit rejection")
-	require.Contains(t, err.Error(), "unexpected tx type")
-}
-
+// TestEthClient_HeaderAndFirstTx_EmptyBlock verifies that empty blocks (e.g.
+// L2 genesis) return (header, nil, nil) without error. Callers that require
+// a particular first-tx shape (e.g. an L1 info deposit) handle that
+// themselves.
 func TestEthClient_HeaderAndFirstTx_EmptyBlock(t *testing.T) {
 	hdr, _ := randHeader()
 	rh := rpcHeaderWithTxs(hdr, nil)
@@ -362,9 +347,10 @@ func TestEthClient_HeaderAndFirstTx_EmptyBlock(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := context.Background()
-	_, _, err = s.HeaderAndFirstTx(ctx, hashID(rh.Hash))
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "no transactions")
+	gotHdr, gotTx, err := s.HeaderAndFirstTx(ctx, hashID(rh.Hash))
+	require.NoError(t, err)
+	require.Equal(t, rh.Hash, gotHdr.Hash())
+	require.Nil(t, gotTx)
 }
 
 // TestReceiptValidation tests that the receipt validation is performed by the underlying RPCReceiptsFetcher

--- a/op-service/sources/eth_client_test.go
+++ b/op-service/sources/eth_client_test.go
@@ -354,6 +354,43 @@ func TestEthClient_HeaderAndFirstTx_EmptyBlock(t *testing.T) {
 	require.Nil(t, gotTx)
 }
 
+// TestEthClient_HeaderAndFirstTx_ByHash_FirstTxNilRetry verifies that when
+// the batched tx-by-index call returns null while the header reports a
+// non-empty transaction list (a transient observed in CI under derivation
+// pressure), HeaderAndFirstTx retries the tx fetch by hash. By-hash paths
+// don't normally run the consistency check, but this nil-retry runs
+// regardless.
+func TestEthClient_HeaderAndFirstTx_ByHash_FirstTxNilRetry(t *testing.T) {
+	hdr, _ := randHeader()
+	deposit := makeDepositTx(11)
+	rh := rpcHeaderWithTxs(hdr, []common.Hash{deposit.Hash()})
+
+	m := new(mockRPC)
+	// 1) batch returns header with one tx hash and a nil tx
+	expectBatchHeaderAndTx(m, func(hdrOut **RPCHeaderWithTxHashes, txOut **types.Transaction) {
+		*hdrOut = rh
+		*txOut = nil
+	})
+	// 2) follow-up tx-by-hash-and-index returns the actual tx
+	m.On("CallContext", mock.Anything, mock.Anything,
+		"eth_getTransactionByBlockHashAndIndex",
+		[]any{rh.Hash, hexutil.EncodeUint64(0)}).
+		Run(func(args mock.Arguments) {
+			out := args.Get(1).(**types.Transaction)
+			*out = deposit
+		}).Return([]error{nil})
+
+	s, err := NewEthClient(m, testlog.Logger(t, log.LevelError), nil, testEthClientConfig)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	gotHdr, gotTx, err := s.HeaderAndFirstTx(ctx, hashID(rh.Hash))
+	require.NoError(t, err)
+	require.Equal(t, rh.Hash, gotHdr.Hash())
+	require.Equal(t, deposit.Hash(), gotTx.Hash())
+	m.Mock.AssertExpectations(t)
+}
+
 // TestEthClient_HeaderAndFirstTx_ByLabel_NullResult verifies that when the EL
 // returns null for eth_getBlockByNumber (e.g. label="finalized" before any L2
 // block has finalized), HeaderAndFirstTx surfaces ethereum.NotFound instead of

--- a/op-service/sources/l2_client.go
+++ b/op-service/sources/l2_client.go
@@ -109,11 +109,11 @@ func (s *L2Client) RollupConfig() *rollup.Config {
 
 // L2BlockRefByLabel returns the [eth.L2BlockRef] for the given block label.
 func (s *L2Client) L2BlockRefByLabel(ctx context.Context, label eth.BlockLabel) (eth.L2BlockRef, error) {
-	envelope, err := s.PayloadByLabel(ctx, label)
+	header, deposit, err := s.HeaderAndFirstTx(ctx, label)
 	if err != nil {
-		return eth.L2BlockRef{}, fmt.Errorf("failed to determine L2BlockRef of %s, could not get payload: %w", label, err)
+		return eth.L2BlockRef{}, fmt.Errorf("failed to determine L2BlockRef of %s, could not fetch header+deposit: %w", label, err)
 	}
-	ref, err := derive.PayloadToBlockRef(s.rollupCfg, envelope.ExecutionPayload)
+	ref, err := derive.BlockRefFromHeaderAndDeposit(s.rollupCfg, eth.HeaderBlockInfo(header), deposit)
 	if err != nil {
 		return eth.L2BlockRef{}, err
 	}
@@ -123,11 +123,11 @@ func (s *L2Client) L2BlockRefByLabel(ctx context.Context, label eth.BlockLabel) 
 
 // L2BlockRefByNumber returns the [eth.L2BlockRef] for the given block number.
 func (s *L2Client) L2BlockRefByNumber(ctx context.Context, num uint64) (eth.L2BlockRef, error) {
-	envelope, err := s.PayloadByNumber(ctx, num)
+	header, deposit, err := s.HeaderAndFirstTx(ctx, numberID(num))
 	if err != nil {
-		return eth.L2BlockRef{}, fmt.Errorf("failed to determine L2BlockRef of height %v, could not get payload: %w", num, err)
+		return eth.L2BlockRef{}, fmt.Errorf("failed to determine L2BlockRef of height %v, could not fetch header+deposit: %w", num, err)
 	}
-	ref, err := derive.PayloadToBlockRef(s.rollupCfg, envelope.ExecutionPayload)
+	ref, err := derive.BlockRefFromHeaderAndDeposit(s.rollupCfg, eth.HeaderBlockInfo(header), deposit)
 	if err != nil {
 		return eth.L2BlockRef{}, err
 	}
@@ -142,11 +142,11 @@ func (s *L2Client) L2BlockRefByHash(ctx context.Context, hash common.Hash) (eth.
 		return ref, nil
 	}
 
-	envelope, err := s.PayloadByHash(ctx, hash)
+	header, deposit, err := s.HeaderAndFirstTx(ctx, hashID(hash))
 	if err != nil {
-		return eth.L2BlockRef{}, fmt.Errorf("failed to determine block-hash of hash %v, could not get payload: %w", hash, err)
+		return eth.L2BlockRef{}, fmt.Errorf("failed to determine L2BlockRef of hash %v, could not fetch header+deposit: %w", hash, err)
 	}
-	ref, err := derive.PayloadToBlockRef(s.rollupCfg, envelope.ExecutionPayload)
+	ref, err := derive.BlockRefFromHeaderAndDeposit(s.rollupCfg, eth.HeaderBlockInfoTrusted(hash, header), deposit)
 	if err != nil {
 		return eth.L2BlockRef{}, err
 	}
@@ -161,11 +161,11 @@ func (s *L2Client) SystemConfigByL2Hash(ctx context.Context, hash common.Hash) (
 		return ref, nil
 	}
 
-	envelope, err := s.PayloadByHash(ctx, hash)
+	header, deposit, err := s.HeaderAndFirstTx(ctx, hashID(hash))
 	if err != nil {
-		return eth.SystemConfig{}, fmt.Errorf("failed to determine block-hash of hash %v, could not get payload: %w", hash, err)
+		return eth.SystemConfig{}, fmt.Errorf("failed to determine SystemConfig of hash %v, could not fetch header+deposit: %w", hash, err)
 	}
-	cfg, err := derive.PayloadToSystemConfig(s.rollupCfg, envelope.ExecutionPayload)
+	cfg, err := derive.SystemConfigFromHeaderAndDeposit(s.rollupCfg, eth.HeaderBlockInfoTrusted(hash, header), deposit)
 	if err != nil {
 		return eth.SystemConfig{}, err
 	}

--- a/op-service/sources/types.go
+++ b/op-service/sources/types.go
@@ -162,6 +162,15 @@ type RPCBlock struct {
 	Withdrawals  *types.Withdrawals   `json:"withdrawals,omitempty"`
 }
 
+// RPCHeaderWithTxHashes is the response shape of eth_getBlockBy* with
+// fullTx=false: header fields plus the list of transaction hashes (rather
+// than full transactions). Used by HeaderAndFirstTx for the consistency check
+// against the separately fetched first transaction.
+type RPCHeaderWithTxHashes struct {
+	RPCHeader
+	Transactions []common.Hash `json:"transactions"`
+}
+
 func (block *RPCBlock) Verify() error {
 	if computed := block.computeBlockHash(); computed != block.Hash {
 		return fmt.Errorf("failed to verify block hash: computed %s but RPC said %s", computed, block.Hash)


### PR DESCRIPTION
## Summary

`L2Client.L2BlockRefBy{Label,Number,Hash}` and `SystemConfigByL2Hash` previously fetched the entire L2 block (`eth_getBlockByX` with `fullTx=true`) just to read a handful of header fields and decode the first transaction (the L1 info deposit). For large blocks this can waste >99% of the bandwidth and CPU. These methods sit on hot paths: engine FCU validation, attributes builder, sync startup.

This PR introduces a minimal-fetch path that downloads only the header (`fullTx=false`) plus the first transaction in a single batched JSON-RPC round trip. By-hash is naturally consistent. By-label / by-number do an optimistic consistency check (`header.Transactions[0] == tx.Hash()`) and refetch only the tx by the resolved hash on mismatch (rare race under reorg / new head).

Follow up to #20531

## What changes

- **`eth.PayloadToInfo`** — new wrapper making `*ExecutionPayload` satisfy `BlockInfo` (now possible because the precursor PR removed `Header()` / `HeaderRLP()` from the interface).
- **`derive.BlockRefFromHeaderAndDeposit`** and **`derive.SystemConfigFromHeaderAndDeposit`** — new inner helpers operating on `(BlockInfo, *types.Transaction)`. The existing `PayloadToBlockRef` and `PayloadToSystemConfig` become thin wrappers; behavior is preserved.
- **`EthClient.HeaderAndFirstTx`** — batched JSON-RPC call (`eth_getBlockByX(id, false)` + `eth_getTransactionByBlockXAndIndex(id, 0)`). Optimistic consistency check on label/number paths; tx-only refetch on mismatch using the resolved block hash. Skipped for by-hash paths.
- **`RPCHeaderWithTxHashes`** — new type to decode the `fullTx=false` response with transaction hashes (rather than full transactions).
- **`headerAndDepositCache`** — new LRU cache keyed by block hash, populated by `HeaderAndFirstTx`. Both `L2BlockRefByHash` and `SystemConfigByL2Hash` benefit from the same cache entry, since the engine FCU and attributes builder routinely call both for the same hash.
- **`L2Client` adapters rewritten** — `L2BlockRefBy{Label,Number,Hash}` and `SystemConfigByL2Hash` now go through `HeaderAndFirstTx` + the new derive helpers. Existing per-result caches (`l2BlockRefsCache`, `systemConfigsCache`) are preserved as the hot-path lookups.

## Behavior preserved

- Output of `L2BlockRefByX` and `SystemConfigByL2Hash` is identical to the previous full-payload path (verified by existing derivation, attributes-queue, and engine tests, all of which pass unchanged).
- Genesis short-circuit still handled (in the inner helpers).
- Deposit-type assertion still enforced.
- Existing `PayloadToBlockRef` and `PayloadToSystemConfig` callers (~25 sites across derivation, span batches, attributes) keep working — they call the new inner helpers via the preserved wrappers.

## Open items deferred

- Metrics for the consistency-check retry path. Add only if production data shows it firing measurably.
- Multi-block batching during sync (the `MultiCaller` pattern could batch K of these into one round trip). Out of scope here; a future optimization.
- The same minimal-fetch optimization applied to `EthClient.BlockRefBy{Label,Number,Hash}` (L1 side — header-only, no first-tx dependency). Independently valuable.

## Test plan

- [x] `mise exec -- go build ./...` passes
- [x] `mise exec -- just lint-go` passes (0 issues, mod tidy clean)
- [x] `mise exec -- go test -count=1 -short ./op-service/... ./op-program/... ./op-supernode/... ./op-interop-filter/... ./op-node/...` passes
- [x] `op-node/rollup/derive` test suite passes (covers the existing `PayloadToBlockRef` and `PayloadToSystemConfig` paths through their new thin-wrapper form)
- [ ] _Pending follow-up:_ dedicated unit tests for `HeaderAndFirstTx` (happy path, by-hash skip-check, label-race retry, deposit-type rejection) and for `BlockRefFromHeaderAndDeposit` / `SystemConfigFromHeaderAndDeposit` parity vs. `PayloadTo*`. Existing test coverage transitively exercises the path through `L2BlockRefBy*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)