### PR TITLE
op-supernode: pass observeRound L1 heads through to l1Inclusion

### DIFF
--- a/op-supernode/supernode/activity/interop/algo.go
+++ b/op-supernode/supernode/activity/interop/algo.go
@@ -29,19 +29,18 @@ var (
 
 type blockPerChain = map[eth.ChainID]eth.BlockID
 
-// l1Inclusion returns the earliest L1 block such that all L2 blocks at the supplied timestamp were derived
-// from a source at or before that L1 block.
-func (i *Interop) l1Inclusion(ts uint64, blocksAtTimestamp blockPerChain) (eth.BlockID, error) {
+// l1Inclusion returns the latest L1 block from the l1Heads snapshot. l1Heads must be the
+// per-chain snapshot captured atomically with blocksAtTimestamp in observeRound; re-reading
+// it here would race with L2 reorgs between observation and verification.
+func (i *Interop) l1Inclusion(blocksAtTimestamp blockPerChain, l1Heads blockPerChain) (eth.BlockID, error) {
 	l1Inclusion := eth.BlockID{}
 	for chainID := range blocksAtTimestamp {
-		chain, ok := i.chains[chainID]
-		if !ok {
+		if _, ok := i.chains[chainID]; !ok {
 			continue
 		}
-		_, l1Block, err := chain.OptimisticAt(i.ctx, ts)
-		if err != nil {
-			i.log.Error("failed to get L1 inclusion for L2 block", "chainID", chainID, "timestamp", ts, "err", err)
-			return eth.BlockID{}, fmt.Errorf("chain %s: failed to get L1 inclusion: %w", chainID, err)
+		l1Block, ok := l1Heads[chainID]
+		if !ok {
+			return eth.BlockID{}, fmt.Errorf("chain %s: missing L1 inclusion in observation snapshot", chainID)
 		}
 		if l1Block.Number >= l1Inclusion.Number {
 			l1Inclusion = l1Block
@@ -59,14 +58,14 @@ func (i *Interop) l1Inclusion(ts uint64, blocksAtTimestamp blockPerChain) (eth.B
 //   - Verify the initiating message exists in the source chain's logsDB
 //   - Verify the initiating message timestamp <= executing message timestamp
 //   - Verify the initiating message hasn't expired (within message expiry window)
-func (i *Interop) verifyInteropMessages(ts uint64, blocksAtTimestamp blockPerChain, view *frontierVerificationView) (Result, error) {
+func (i *Interop) verifyInteropMessages(ts uint64, blocksAtTimestamp blockPerChain, l1Heads blockPerChain, view *frontierVerificationView) (Result, error) {
 	result := Result{
 		Timestamp:    ts,
 		L2Heads:      make(blockPerChain),
 		InvalidHeads: make(map[eth.ChainID]InvalidHead),
 	}
 
-	if l1Inclusion, err := i.l1Inclusion(ts, blocksAtTimestamp); err != nil {
+	if l1Inclusion, err := i.l1Inclusion(blocksAtTimestamp, l1Heads); err != nil {
 		return Result{}, err
 	} else {
 		result.L1Inclusion = l1Inclusion

--- a/op-supernode/supernode/activity/interop/algo_test.go
+++ b/op-supernode/supernode/activity/interop/algo_test.go
@@ -48,7 +48,7 @@ type verifyInteropTestCase struct {
 func runVerifyInteropTest(t *testing.T, tc verifyInteropTestCase) {
 	t.Parallel()
 	interop, timestamp, blocks := tc.setup()
-	result, err := interop.verifyInteropMessages(timestamp, blocks, nil)
+	result, err := interop.verifyInteropMessages(timestamp, blocks, l1HeadsFromMocks(interop.chains, blocks), nil)
 
 	if tc.expectError {
 		require.Error(t, err)
@@ -62,6 +62,20 @@ func runVerifyInteropTest(t *testing.T, tc verifyInteropTestCase) {
 	if tc.validate != nil {
 		tc.validate(t, result)
 	}
+}
+
+// l1HeadsFromMocks builds the snapshot observeRound would produce, by reading optimisticL1
+// from each mock. Mocks tagged with optimisticAtErr are omitted to simulate a missing entry.
+func l1HeadsFromMocks(chains map[eth.ChainID]cc.InteropChain, blocks map[eth.ChainID]eth.BlockID) map[eth.ChainID]eth.BlockID {
+	heads := make(map[eth.ChainID]eth.BlockID, len(blocks))
+	for chainID := range blocks {
+		mock, ok := chains[chainID].(*algoMockChain)
+		if !ok || mock.optimisticAtErr != nil {
+			continue
+		}
+		heads[chainID] = mock.optimisticL1
+	}
+	return heads
 }
 
 func TestL1Inclusion(t *testing.T) {
@@ -152,10 +166,11 @@ func TestL1Inclusion(t *testing.T) {
 			},
 		},
 		{
-			name: "OptimisticAtError_ReturnsError",
+			name: "MissingL1HeadInSnapshot_ReturnsError",
 			setup: func() (*Interop, uint64, map[eth.ChainID]eth.BlockID) {
 				chainID := eth.ChainIDFromUInt64(10)
 
+				// optimisticAtErr makes l1HeadsFromMocks omit the chain, simulating a snapshot gap.
 				interop := &Interop{
 					messageExpiryWindow: defaultMessageExpiryWindow,
 					log:                 gethlog.New(),
@@ -169,7 +184,7 @@ func TestL1Inclusion(t *testing.T) {
 				}
 			},
 			expectError: true,
-			errorMsg:    "failed to get L1 inclusion",
+			errorMsg:    "missing L1 inclusion in observation snapshot",
 		},
 		{
 			name: "NoChains_ReturnsEmpty",
@@ -213,8 +228,8 @@ func TestL1Inclusion(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			interop, ts, blocks := tc.setup()
-			l1, err := interop.l1Inclusion(ts, blocks)
+			interop, _, blocks := tc.setup()
+			l1, err := interop.l1Inclusion(blocks, l1HeadsFromMocks(interop.chains, blocks))
 
 			if tc.expectError {
 				require.Error(t, err)
@@ -230,6 +245,35 @@ func TestL1Inclusion(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestL1Inclusion_UsesSnapshotNotChainContainer pins the reorg-safety property: l1Inclusion
+// must read from the snapshot, not re-query the chain. The mock errors on OptimisticAt to
+// catch any regression that re-introduces the call.
+func TestL1Inclusion_UsesSnapshotNotChainContainer(t *testing.T) {
+	t.Parallel()
+
+	chainID := eth.ChainIDFromUInt64(10)
+
+	interop := &Interop{
+		messageExpiryWindow: defaultMessageExpiryWindow,
+		log:                 gethlog.New(),
+		logsDBs:             map[eth.ChainID]LogsDB{},
+		chains: map[eth.ChainID]cc.InteropChain{
+			chainID: &algoMockChain{id: chainID, optimisticAtErr: errors.New("chain container must not be called")},
+		},
+	}
+
+	blocks := map[eth.ChainID]eth.BlockID{
+		chainID: {Number: 100, Hash: common.HexToHash("0xL2")},
+	}
+	snapshot := map[eth.ChainID]eth.BlockID{
+		chainID: {Number: 50, Hash: common.HexToHash("0xL1Snapshot")},
+	}
+
+	l1, err := interop.l1Inclusion(blocks, snapshot)
+	require.NoError(t, err)
+	require.Equal(t, snapshot[chainID], l1)
 }
 
 func TestVerifyInteropMessages(t *testing.T) {

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -157,7 +157,9 @@ type Interop struct {
 
 	currentL1 eth.BlockID
 
-	verifyFn func(ts uint64, blocksAtTimestamp map[eth.ChainID]eth.BlockID, view *frontierVerificationView) (Result, error)
+	// l1Heads is the snapshot captured with blocksAtTimestamp in observeRound; passing
+	// it through avoids a TOCTOU race against L2 reorgs.
+	verifyFn func(ts uint64, blocksAtTimestamp map[eth.ChainID]eth.BlockID, l1Heads map[eth.ChainID]eth.BlockID, view *frontierVerificationView) (Result, error)
 
 	// cycleVerifyFn handles same-timestamp cycle verification.
 	// It is called after verifyFn in progressInterop, and its results are merged.
@@ -490,7 +492,7 @@ func (i *Interop) progressInterop() (StepOutput, RoundObservation, error) {
 		return *early, obs, nil
 	}
 
-	result, err := i.verify(obs.NextTimestamp, obs.BlocksAtTS)
+	result, err := i.verify(obs.NextTimestamp, obs.BlocksAtTS, obs.L1Heads)
 	if err != nil {
 		return StepOutput{}, obs, err
 	}
@@ -556,13 +558,14 @@ func (i *Interop) observeRound() (RoundObservation, error) {
 }
 
 // verify runs the heavy I/O: log loading, message verification, and cycle detection.
-func (i *Interop) verify(ts uint64, blocksAtTS map[eth.ChainID]eth.BlockID) (Result, error) {
+// l1Heads must be the snapshot from observeRound — see verifyFn doc comment.
+func (i *Interop) verify(ts uint64, blocksAtTS map[eth.ChainID]eth.BlockID, l1Heads map[eth.ChainID]eth.BlockID) (Result, error) {
 	view, err := i.resolveFrontierVerificationView(blocksAtTS)
 	if err != nil {
 		return Result{}, fmt.Errorf("resolve frontier verification view: %w", err)
 	}
 
-	result, err := i.verifyFn(ts, blocksAtTS, view)
+	result, err := i.verifyFn(ts, blocksAtTS, l1Heads, view)
 	if err != nil {
 		return Result{}, err
 	}

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -382,7 +382,7 @@ func TestStartWithoutBackfillUsesFirstVerifiableTimestamp(t *testing.T) {
 	defer cancel()
 
 	verifiedTS := make(chan uint64, 1)
-	h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
+	h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
 		verifiedTS <- ts
 		cancel()
 		return Result{}, nil
@@ -710,14 +710,14 @@ func TestProgressInterop(t *testing.T) {
 	t.Parallel()
 
 	// Default verifyFn that passes through
-	passThroughVerifyFn := func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
+	passThroughVerifyFn := func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
 		return Result{Timestamp: ts, L1Inclusion: eth.BlockID{Number: 100}, L2Heads: blocks}, nil
 	}
 
 	tests := []struct {
 		name     string
 		setup    func(h *interopTestHarness) *interopTestHarness
-		verifyFn func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error)
+		verifyFn func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error)
 		assert   func(t *testing.T, result Result, err error)
 		run      func(t *testing.T, h *interopTestHarness) // override for complex cases
 	}{
@@ -791,7 +791,7 @@ func TestProgressInterop(t *testing.T) {
 					m.blockAtTimestamp = eth.L2BlockRef{Number: 500, Hash: common.HexToHash("0xL2")}
 				}).Build()
 			},
-			verifyFn: func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
+			verifyFn: func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
 				return Result{}, errors.New("verification failed")
 			},
 			assert: func(t *testing.T, result Result, err error) {
@@ -840,7 +840,7 @@ func TestProgressInteropWithCycleVerify(t *testing.T) {
 			},
 			run: func(t *testing.T, h *interopTestHarness) {
 				// Set verifyFn to return a valid result
-				h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
+				h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
 					return Result{Timestamp: ts, L2Heads: blocks}, nil
 				}
 				// cycleVerifyFn is overridden with this stub implementation.
@@ -867,7 +867,7 @@ func TestProgressInteropWithCycleVerify(t *testing.T) {
 				chain8453 := eth.ChainIDFromUInt64(8453)
 
 				// verifyFn returns valid result
-				h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
+				h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
 					verifyFnCalled = true
 					return Result{Timestamp: ts, L2Heads: blocks}, nil
 				}
@@ -902,7 +902,7 @@ func TestProgressInteropWithCycleVerify(t *testing.T) {
 				}).Build()
 			},
 			run: func(t *testing.T, h *interopTestHarness) {
-				h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
+				h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
 					return Result{Timestamp: ts, L2Heads: blocks}, nil
 				}
 				h.interop.cycleVerifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
@@ -929,7 +929,7 @@ func TestProgressInteropWithCycleVerify(t *testing.T) {
 				chain8453 := eth.ChainIDFromUInt64(8453)
 
 				// verifyFn marks chain 10 as invalid
-				h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
+				h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
 					return Result{
 						Timestamp: ts,
 						L2Heads:   blocks,
@@ -1041,7 +1041,7 @@ func TestVerifiedAtTimestamp(t *testing.T) {
 				}).Build()
 			},
 			run: func(t *testing.T, h *interopTestHarness) {
-				h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
+				h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
 					return Result{Timestamp: ts, L1Inclusion: eth.BlockID{Number: 100}, L2Heads: blocks}, nil
 				}
 
@@ -1382,7 +1382,7 @@ func TestProgressAndRecord(t *testing.T) {
 			},
 			run: func(t *testing.T, h *interopTestHarness) {
 				expectedL1Inclusion := eth.BlockID{Number: 150, Hash: common.HexToHash("0xL1Result")}
-				h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
+				h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
 					return Result{Timestamp: ts, L1Inclusion: expectedL1Inclusion, L2Heads: blocks}, nil
 				}
 
@@ -1408,7 +1408,7 @@ func TestProgressAndRecord(t *testing.T) {
 			run: func(t *testing.T, h *interopTestHarness) {
 				// L1Inclusion is 1000 (from the leading chain) but chain 8453 is only at 990.
 				// interop.currentL1 must be capped at 990 so it never exceeds any node's CurrentL1.
-				h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
+				h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
 					return Result{
 						Timestamp:   ts,
 						L1Inclusion: eth.BlockID{Number: 1000, Hash: common.HexToHash("0xleading")},
@@ -1437,7 +1437,7 @@ func TestProgressAndRecord(t *testing.T) {
 				initialL1 := eth.BlockID{Number: 50, Hash: common.HexToHash("0x50")}
 				h.interop.currentL1 = initialL1
 
-				h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
+				h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
 					return Result{
 						Timestamp:    ts,
 						L1Inclusion:  eth.BlockID{Number: 999, Hash: common.HexToHash("0xShouldNotBeUsed")},
@@ -1506,7 +1506,7 @@ func TestInterop_FullCycle(t *testing.T) {
 	require.False(t, hasBlocks)
 
 	// Stub verifyFn
-	interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
+	interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
 		return Result{Timestamp: ts, L1Inclusion: eth.BlockID{Number: 100}, L2Heads: blocks}, nil
 	}
 
@@ -1560,7 +1560,7 @@ func TestInterop_ProgressAndRecord_MultiAdvance(t *testing.T) {
 		Build()
 
 	mock := h.Mock(10)
-	h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
+	h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
 		return Result{Timestamp: ts, L1Inclusion: eth.BlockID{Number: 100}, L2Heads: blocks}, nil
 	}
 	h.interop.cycleVerifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
@@ -1612,7 +1612,7 @@ func TestInterop_ProgressAndRecord_L1InconsistencyTriggersRewind(t *testing.T) {
 		Build()
 
 	mock := h.Mock(10)
-	h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
+	h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
 		return Result{Timestamp: ts, L1Inclusion: eth.BlockID{Number: 100}, L2Heads: blocks}, nil
 	}
 	h.interop.cycleVerifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
@@ -2347,7 +2347,7 @@ func TestRewindAccepted(t *testing.T) {
 		chainID := mock.id
 
 		// Stub verifyFn
-		h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
+		h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
 			return Result{Timestamp: ts, L1Inclusion: eth.BlockID{Number: ts}, L2Heads: blocks}, nil
 		}
 
@@ -2558,7 +2558,7 @@ func progressInteropCompat(i *Interop) (Result, error) {
 	if obs.Paused || !obs.ChainsReady {
 		return Result{}, nil
 	}
-	return i.verify(obs.NextTimestamp, obs.BlocksAtTS)
+	return i.verify(obs.NextTimestamp, obs.BlocksAtTS, obs.L1Heads)
 }
 
 // applyResultCompat replicates the old result-application behavior for test compatibility.
@@ -2657,7 +2657,7 @@ func TestVerify_DoesNotPersistFrontierLogs(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, obs.ChainsReady)
 
-	result, err := h.interop.verify(obs.NextTimestamp, obs.BlocksAtTS)
+	result, err := h.interop.verify(obs.NextTimestamp, obs.BlocksAtTS, obs.L1Heads)
 	require.NoError(t, err)
 	require.False(t, result.IsEmpty())
 	require.Zero(t, trackingDB.addLogCalls, "verify must not write logs into logsDB")

--- a/op-supernode/supernode/activity/interop/log_backfill_test.go
+++ b/op-supernode/supernode/activity/interop/log_backfill_test.go
@@ -389,7 +389,7 @@ func TestLogBackfill_AdvancesActivationAndStartsVerifyAfterCeiling(t *testing.T)
 
 	var verifyCalls atomic.Int32
 	var firstVerifyTS atomic.Uint64
-	h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
+	h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
 		if verifyCalls.Add(1) == 1 {
 			firstVerifyTS.Store(ts)
 		}


### PR DESCRIPTION
`l1Inclusion` was calling `chain.OptimisticAt(ts)` independently from `observeRound`, so an L2 reorg between observation and verification could make the L1 inclusion inconsistent with the L2 heads being verified. Use the per-chain L1 inclusion snapshot that `checkChainsReady` already captures atomically instead of re-querying the chain container.

Fixes ethereum-optimism/optimism-private#547 (RV interop v2 audit, medium severity).