### PR TITLE
ci(op-reth): use fast-build profile in PR docker bake

### DIFF
--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -268,6 +268,7 @@ jobs:
       set: |
         *.args.GIT_COMMIT=${{ github.sha }}
         *.args.GIT_DATE=${{ needs.prep.outputs.date }}
+        op-reth.args.BUILD_PROFILE=${{ github.event_name == 'pull_request' && 'fast-build' || 'maxperf' }}
     permissions:
       contents: read
       id-token: write
@@ -295,6 +296,7 @@ jobs:
       set: |
         *.args.GIT_COMMIT=${{ github.sha }}
         *.args.GIT_DATE=${{ needs.prep.outputs.date }}
+        op-reth.args.BUILD_PROFILE=${{ github.event_name == 'pull_request' && 'fast-build' || 'maxperf' }}
     permissions:
       contents: read
 


### PR DESCRIPTION
## Summary
- Override `BUILD_PROFILE` for the `op-reth` bake target to `fast-build` on `pull_request` events; keep `maxperf` for pushes to `develop`, scheduled builds, and tags.
- `maxperf` uses `lto = "fat"` + `codegen-units = 1`, which serializes the final link and dominates op-reth build time. `fast-build` (defined in `rust/Cargo.toml`) uses `opt-level = 0`, `codegen-units = 256`, `incremental = true`, dropping the link bottleneck and parallelizing codegen.
- Tags workflow (`tags.yaml`) untouched; release artifacts stay on `maxperf`.
- Merge queue not affected (`branches.yaml` has no `merge_group:` trigger today).

## Test plan
- [ ] PR build: confirm op-reth bake step uses `BUILD_PROFILE=fast-build` and finishes faster than baseline.
- [ ] Push to `develop` after merge: confirm bake uses `BUILD_PROFILE=maxperf`.
- [ ] op-reth image still functional under runtime checks (`check-cross-platform-rust` runs `--version`).
- [ ] Any e2e tests pulling the PR image still pass with non-LTO build.