### PR TITLE
fix(op-challenger): create-game cli super root encoding

### DIFF
--- a/op-challenger/cmd/create_game.go
+++ b/op-challenger/cmd/create_game.go
@@ -26,13 +26,18 @@ var (
 	}
 	OutputRootFlag = &cli.StringFlag{
 		Name:    "output-root",
-		Usage:   "The output root for the fault dispute game.",
+		Usage:   "The output root for the fault dispute game. For super games this is encoded into a single-chain super root proof.",
 		EnvVars: opservice.PrefixEnvVar(flags.EnvVarPrefix, "OUTPUT_ROOT"),
 	}
 	L2BlockNumFlag = &cli.StringFlag{
 		Name:    "l2-block-num",
-		Usage:   "The l2 block number for the game.",
+		Usage:   "The L2 block number for the game. For super games this is the super root timestamp/sequence number.",
 		EnvVars: opservice.PrefixEnvVar(flags.EnvVarPrefix, "L2_BLOCK_NUM"),
+	}
+	L2ChainIDFlag = &cli.StringFlag{
+		Name:    "l2-chain-id",
+		Usage:   "The L2 chain ID to include in the super root proof.",
+		EnvVars: opservice.PrefixEnvVar(flags.EnvVarPrefix, "L2_CHAIN_ID"),
 	}
 )
 
@@ -40,6 +45,7 @@ func CreateGame(ctx *cli.Context) error {
 	outputRoot := common.HexToHash(ctx.String(OutputRootFlag.Name))
 	gameType := ctx.Uint64(GameTypeFlag.Name)
 	l2BlockNum := ctx.Uint64(L2BlockNumFlag.Name)
+	l2ChainID := ctx.Uint64(L2ChainIDFlag.Name)
 
 	contract, txMgr, err := NewContractWithTxMgr[*contracts.DisputeGameFactoryContract](ctx, flags.FactoryAddress,
 		func(ctx context.Context, metricer contractMetrics.ContractMetricer, address common.Address, caller *batching.MultiCaller) (*contracts.DisputeGameFactoryContract, error) {
@@ -50,7 +56,7 @@ func CreateGame(ctx *cli.Context) error {
 	}
 
 	creator := tools.NewGameCreator(contract, txMgr)
-	gameAddr, err := creator.CreateGame(ctx.Context, outputRoot, gameType, l2BlockNum)
+	gameAddr, err := creator.CreateGame(ctx.Context, outputRoot, gameType, l2BlockNum, l2ChainID)
 	if err != nil {
 		return fmt.Errorf("failed to create game: %w", err)
 	}
@@ -66,6 +72,7 @@ func createGameFlags() []cli.Flag {
 		GameTypeFlag,
 		OutputRootFlag,
 		L2BlockNumFlag,
+		L2ChainIDFlag,
 	}
 	cliFlags = append(cliFlags, txmgr.CLIFlagsWithDefaults(flags.EnvVarPrefix, txmgr.DefaultChallengerFlagValues)...)
 	cliFlags = append(cliFlags, oplog.CLIFlags(flags.EnvVarPrefix)...)

--- a/op-challenger/game/fault/contracts/gamefactory.go
+++ b/op-challenger/game/fault/contracts/gamefactory.go
@@ -3,6 +3,7 @@ package contracts
 import (
 	"context"
 	_ "embed"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"math/big"
@@ -18,6 +19,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	ethTypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
 )
 
 const (
@@ -268,19 +270,39 @@ func (f *DisputeGameFactoryContract) GetAllGames(ctx context.Context, blockHash 
 	return games, nil
 }
 
-func (f *DisputeGameFactoryContract) CreateTx(ctx context.Context, gameType uint32, outputRoot common.Hash, l2BlockNum uint64) (txmgr.TxCandidate, error) {
+func (f *DisputeGameFactoryContract) CreateTx(ctx context.Context, gameType uint32, outputRoot common.Hash, l2BlockNum uint64, l2ChainID uint64) (txmgr.TxCandidate, error) {
 	result, err := f.multiCaller.SingleCall(ctx, rpcblock.Latest, f.contract.Call(methodInitBonds, gameType))
 	if err != nil {
 		return txmgr.TxCandidate{}, fmt.Errorf("failed to fetch init bond: %w", err)
 	}
 	initBond := result.GetBigInt(0)
-	call := f.contract.Call(methodCreateGame, gameType, outputRoot, common.BigToHash(big.NewInt(int64(l2BlockNum))).Bytes())
+	rootClaim, extraData := createGameParams(gameType, outputRoot, l2BlockNum, l2ChainID)
+	call := f.contract.Call(methodCreateGame, gameType, rootClaim, extraData)
 	candidate, err := call.ToTxCandidate()
 	if err != nil {
 		return txmgr.TxCandidate{}, err
 	}
 	candidate.Value = initBond
 	return candidate, err
+}
+
+func createGameParams(gameType uint32, outputRoot common.Hash, l2BlockNum uint64, l2ChainID uint64) (common.Hash, []byte) {
+	switch gameTypes.GameType(gameType) {
+	case gameTypes.SuperCannonGameType, gameTypes.SuperCannonKonaGameType, gameTypes.SuperPermissionedGameType:
+		extraData := encodeSuperRootProof(l2BlockNum, l2ChainID, outputRoot)
+		return crypto.Keccak256Hash(extraData), extraData
+	default:
+		return outputRoot, common.BigToHash(new(big.Int).SetUint64(l2BlockNum)).Bytes()
+	}
+}
+
+func encodeSuperRootProof(timestamp uint64, l2ChainID uint64, outputRoot common.Hash) []byte {
+	extraData := make([]byte, 1+8+32+32)
+	extraData[0] = 0x01
+	binary.BigEndian.PutUint64(extraData[1:9], timestamp)
+	copy(extraData[9:41], common.BigToHash(new(big.Int).SetUint64(l2ChainID)).Bytes())
+	copy(extraData[41:], outputRoot.Bytes())
+	return extraData
 }
 
 func (f *DisputeGameFactoryContract) DecodeDisputeGameCreatedLog(rcpt *ethTypes.Receipt) (common.Address, uint32, common.Hash, error) {

--- a/op-challenger/game/fault/contracts/gamefactory_test.go
+++ b/op-challenger/game/fault/contracts/gamefactory_test.go
@@ -2,6 +2,7 @@ package contracts
 
 import (
 	"context"
+	"encoding/binary"
 	"fmt"
 	"math/big"
 	"slices"
@@ -17,6 +18,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	ethTypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/require"
 )
 
@@ -472,7 +474,33 @@ func TestCreateTx(t *testing.T) {
 			bond := big.NewInt(49284294829)
 			stubRpc.SetResponse(factoryAddr, methodInitBonds, rpcblock.Latest, []interface{}{gameType}, []interface{}{bond})
 			stubRpc.SetResponse(factoryAddr, methodCreateGame, rpcblock.Latest, []interface{}{gameType, outputRoot, l2BlockNum}, nil)
-			tx, err := factory.CreateTx(context.Background(), gameType, outputRoot, uint64(456))
+			tx, err := factory.CreateTx(context.Background(), gameType, outputRoot, uint64(456), uint64(0))
+			require.NoError(t, err)
+			stubRpc.VerifyTxCandidate(tx)
+			require.NotNil(t, tx.Value)
+			require.Truef(t, bond.Cmp(tx.Value) == 0, "Expected bond %v but was %v", bond, tx.Value)
+		})
+	}
+}
+
+func TestCreateTxSuperGame(t *testing.T) {
+	for _, version := range factoryVersions {
+		t.Run(version.String(), func(t *testing.T) {
+			stubRpc, factory := setupDisputeGameFactoryTest(t, version)
+			gameType := uint32(gameTypes.SuperCannonKonaGameType)
+			outputRoot := common.Hash{0x01}
+			l2BlockNum := uint64(456)
+			l2ChainID := uint64(11155420)
+			extraData := make([]byte, 1+8+32+32)
+			extraData[0] = 0x01
+			binary.BigEndian.PutUint64(extraData[1:9], l2BlockNum)
+			copy(extraData[9:41], common.BigToHash(new(big.Int).SetUint64(l2ChainID)).Bytes())
+			copy(extraData[41:], outputRoot.Bytes())
+			rootClaim := crypto.Keccak256Hash(extraData)
+			bond := big.NewInt(49284294829)
+			stubRpc.SetResponse(factoryAddr, methodInitBonds, rpcblock.Latest, []interface{}{gameType}, []interface{}{bond})
+			stubRpc.SetResponse(factoryAddr, methodCreateGame, rpcblock.Latest, []interface{}{gameType, rootClaim, extraData}, nil)
+			tx, err := factory.CreateTx(context.Background(), gameType, outputRoot, l2BlockNum, l2ChainID)
 			require.NoError(t, err)
 			stubRpc.VerifyTxCandidate(tx)
 			require.NotNil(t, tx.Value)

--- a/op-challenger/tools/create_game.go
+++ b/op-challenger/tools/create_game.go
@@ -22,8 +22,8 @@ func NewGameCreator(contract *contracts.DisputeGameFactoryContract, txMgr txmgr.
 	}
 }
 
-func (g *GameCreator) CreateGame(ctx context.Context, outputRoot common.Hash, gameType uint64, l2BlockNum uint64) (common.Address, error) {
-	txCandidate, err := g.contract.CreateTx(ctx, uint32(gameType), outputRoot, l2BlockNum)
+func (g *GameCreator) CreateGame(ctx context.Context, outputRoot common.Hash, gameType uint64, l2BlockNum uint64, l2ChainID uint64) (common.Address, error) {
+	txCandidate, err := g.contract.CreateTx(ctx, uint32(gameType), outputRoot, l2BlockNum, l2ChainID)
 	if err != nil {
 		return common.Address{}, fmt.Errorf("failed to create tx: %w", err)
 	}


### PR DESCRIPTION
Fix `op-challenger create-game` calldata generation for super dispute games.

Super dispute games expect `extraData` to be an encoded single-chain super root proof: `0x01 || uint64(timestamp) || uint256(l2ChainID) || bytes32(outputRoot)` and the root claim must be `keccak256(extraData)`. The previous create-game path always used the non-super encoding, where the root claim was the provided output root and `extraData` was `bytes32(l2BlockNum)`. For game type `9` this caused `SuperFaultDisputeGame.initialize` to revert with `BadExtraData()`.