### PR TITLE
feat(op-deployer): allow ResourceConfig override per chain

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0
 	github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.4-0.20251001155152-4eb15ccedf7e
-	github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20260115192958-fb86a23cd30e
+	github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20260507232046-cbc58d3bb2e5
 	github.com/ethereum/go-ethereum v1.17.0
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/golang/snappy v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -222,8 +222,8 @@ github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.4-0.20251001155152-4eb15c
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.4-0.20251001155152-4eb15ccedf7e/go.mod h1:DYj7+vYJ4cIB7zera9mv4LcAynCL5u4YVfoeUu6Wa+w=
 github.com/ethereum-optimism/op-geth v1.101702.2-rc.3 h1:fsk+eehrGxlJCasTPbIu/igWoKbkjONk9i3XBDxuPBs=
 github.com/ethereum-optimism/op-geth v1.101702.2-rc.3/go.mod h1:HzvOtk7c9KwFaSxRvUBPFHGSjIjomWtw4iSXX6vruQE=
-github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20260115192958-fb86a23cd30e h1:TO1tUcwbhIrNuea/LCsQJSQ5HDWCHdrzT/5MLC1aIU4=
-github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20260115192958-fb86a23cd30e/go.mod h1:NZ816PzLU1TLv1RdAvYAb6KWOj4Zm5aInT0YpDVml2Y=
+github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20260507232046-cbc58d3bb2e5 h1:6mnscwenHqQmbzr3V3fjdzEGCNYb7GzdJEUZIKPiEws=
+github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20260507232046-cbc58d3bb2e5/go.mod h1:NZ816PzLU1TLv1RdAvYAb6KWOj4Zm5aInT0YpDVml2Y=
 github.com/ethereum/c-kzg-4844/v2 v2.1.6 h1:xQymkKCT5E2Jiaoqf3v4wsNgjZLY0lRSkZn27fRjSls=
 github.com/ethereum/c-kzg-4844/v2 v2.1.6/go.mod h1:8HMkUZ5JRv4hpw/XUrYWSQNAUzhHMg2UDb/U+5m+XNw=
 github.com/ethereum/go-bigmodexpfix v0.0.0-20250911101455-f9e208c548ab h1:rvv6MJhy07IMfEKuARQ9TKojGqLVNxQajaXEp/BoqSk=

--- a/op-chain-ops/interopgen/deploy.go
+++ b/op-chain-ops/interopgen/deploy.go
@@ -227,6 +227,7 @@ func DeployL2ToL1(l1Host *script.Host, superCfg *SuperchainConfig, superDeployme
 	}
 
 	output, err := deployOPChainScript.Run(opcm.DeployOPChainInput{
+		ResourceConfig:               opcm.UnsetResourceConfig(),
 		OpChainProxyAdminOwner:       superCfg.ProxyAdminOwner,
 		SystemConfigOwner:            cfg.SystemConfigOwner,
 		Batcher:                      cfg.BatchSenderAddress,

--- a/op-deployer/pkg/deployer/forge/encoding.go
+++ b/op-deployer/pkg/deployer/forge/encoding.go
@@ -10,29 +10,49 @@ import (
 )
 
 func GoStructToABITuple(structType reflect.Type, tupleName string) (abi.Type, error) {
-	var components []abi.ArgumentMarshaling
+	components, err := goStructFields(structType)
+	if err != nil {
+		return abi.Type{}, err
+	}
+	return abi.NewType("tuple", tupleName, components)
+}
 
+// Field tags: `abi:"<name>"` overrides the ABI field name; `abiType:"<type>"`
+// overrides the derived Solidity type (required for widths with no Go
+// primitive, e.g. uint128). Nested structs become nested tuples.
+func goStructFields(structType reflect.Type) ([]abi.ArgumentMarshaling, error) {
+	var components []abi.ArgumentMarshaling
 	for i := 0; i < structType.NumField(); i++ {
 		field := structType.Field(i)
-
-		abiType, err := GoTypeToABIType(field.Type)
-		if err != nil {
-			return abi.Type{}, fmt.Errorf("unsupported field type %s: %w", field.Type, err)
+		name := field.Name
+		if tag := field.Tag.Get("abi"); tag != "" {
+			name = tag
 		}
 
-		// Use ABI tag if present, otherwise use field name
-		fieldName := field.Name
-		if abiTag := field.Tag.Get("abi"); abiTag != "" {
-			fieldName = abiTag
+		if t := field.Tag.Get("abiType"); t != "" {
+			components = append(components, abi.ArgumentMarshaling{Name: name, Type: t})
+			continue
 		}
 
-		components = append(components, abi.ArgumentMarshaling{
-			Name: fieldName,
-			Type: abiType,
-		})
+		ft := field.Type
+		if ft.Kind() == reflect.Ptr {
+			ft = ft.Elem()
+		}
+		if t, err := GoTypeToABIType(ft); err == nil {
+			components = append(components, abi.ArgumentMarshaling{Name: name, Type: t})
+			continue
+		}
+		if ft.Kind() == reflect.Struct {
+			inner, err := goStructFields(ft)
+			if err != nil {
+				return nil, fmt.Errorf("field %s: %w", field.Name, err)
+			}
+			components = append(components, abi.ArgumentMarshaling{Name: name, Type: "tuple", Components: inner})
+			continue
+		}
+		return nil, fmt.Errorf("unsupported field type %s", field.Type)
 	}
-
-	return abi.NewType("tuple", tupleName, components)
+	return components, nil
 }
 
 func GoTypeToABIType(goType reflect.Type) (string, error) {

--- a/op-deployer/pkg/deployer/forge/encoding_test.go
+++ b/op-deployer/pkg/deployer/forge/encoding_test.go
@@ -1,0 +1,67 @@
+package forge
+
+import (
+	"math/big"
+	"reflect"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGoStructToABITuple_AbiTypeTag verifies that the `abiType` field tag
+// overrides the auto-derived ABI type. This is the only way to encode a
+// uint128 (or other widths without a native Go primitive).
+func TestGoStructToABITuple_AbiTypeTag(t *testing.T) {
+	type withTag struct {
+		A *big.Int `abi:"a" abiType:"uint128"`
+	}
+	tup, err := GoStructToABITuple(reflect.TypeOf(withTag{}), "withTag")
+	require.NoError(t, err)
+	require.Equal(t, "(uint128)", tup.String())
+}
+
+// TestGoStructToABITuple_NestedStruct verifies that nested struct fields are
+// encoded as nested tuples and that field-level tags inside the nested struct
+// are honored.
+func TestGoStructToABITuple_NestedStruct(t *testing.T) {
+	type inner struct {
+		X uint32   `abi:"x"`
+		Y *big.Int `abi:"y" abiType:"uint128"`
+	}
+	type outer struct {
+		Top   uint64 `abi:"top"`
+		Inner inner  `abi:"inner"`
+	}
+	tup, err := GoStructToABITuple(reflect.TypeOf(outer{}), "outer")
+	require.NoError(t, err)
+	require.Equal(t, "(uint64,(uint32,uint128))", tup.String())
+}
+
+// TestBytesScriptEncoder_NestedAndUint128 verifies that the BytesScriptEncoder
+// can pack a struct that mixes a nested tuple and a uint128 field.
+func TestBytesScriptEncoder_NestedAndUint128(t *testing.T) {
+	type inner struct {
+		Limit uint32   `abi:"limit"`
+		Cap   *big.Int `abi:"cap" abiType:"uint128"`
+	}
+	type outer struct {
+		Gas   uint64 `abi:"gas"`
+		Inner inner  `abi:"inner"`
+	}
+	enc := &BytesScriptEncoder[outer]{TypeName: "Outer"}
+	cap128 := new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 128), big.NewInt(1))
+	packed, err := enc.Encode(outer{
+		Gas:   5_000_000,
+		Inner: inner{Limit: 4_000_000, Cap: cap128},
+	})
+	require.NoError(t, err)
+
+	// Round-trip via abi.Arguments to confirm shape.
+	tup, err := GoStructToABITuple(reflect.TypeOf(outer{}), "Outer")
+	require.NoError(t, err)
+	args := abi.Arguments{{Type: tup}}
+	unpacked, err := args.Unpack(packed)
+	require.NoError(t, err)
+	require.Len(t, unpacked, 1)
+}

--- a/op-deployer/pkg/deployer/opcm/contract.go
+++ b/op-deployer/pkg/deployer/opcm/contract.go
@@ -20,10 +20,6 @@ func NewContract(addr common.Address, client *ethclient.Client) *Contract {
 	return &Contract{addr: addr, client: client}
 }
 
-func (c *Contract) SuperchainConfig(ctx context.Context) (common.Address, error) {
-	return c.getAddress(ctx, "superchainConfig")
-}
-
 func (c *Contract) OPCMStandardValidator(ctx context.Context) (common.Address, error) {
 	return c.getAddress(ctx, "opcmStandardValidator")
 }

--- a/op-deployer/pkg/deployer/opcm/opchain.go
+++ b/op-deployer/pkg/deployer/opcm/opchain.go
@@ -47,6 +47,31 @@ type DeployOPChainInput struct {
 	SuperchainConfig    common.Address
 
 	UseCustomGasToken bool
+
+	// ResourceConfig is forwarded verbatim to OPCM. The Solidity script treats
+	// `maxResourceLimit == 0` as "use Constants.DEFAULT_RESOURCE_CONFIG()", so a
+	// zero-valued struct is the conventional way to opt into defaults. Field
+	// order and ABI types must match `IResourceMetering.ResourceConfig`.
+	ResourceConfig ResourceConfig
+}
+
+// ResourceConfig mirrors Solidity's IResourceMetering.ResourceConfig. The
+// `abiType:"uint128"` tag is required because Go has no native uint128 type;
+// the forge encoder honors this tag to select the correct ABI width.
+type ResourceConfig struct {
+	MaxResourceLimit            uint32   `abi:"maxResourceLimit"`
+	ElasticityMultiplier        uint8    `abi:"elasticityMultiplier"`
+	BaseFeeMaxChangeDenominator uint8    `abi:"baseFeeMaxChangeDenominator"`
+	MinimumBaseFee              uint32   `abi:"minimumBaseFee"`
+	SystemTxMaxGas              uint32   `abi:"systemTxMaxGas"`
+	MaximumBaseFee              *big.Int `abi:"maximumBaseFee" abiType:"uint128"`
+}
+
+// UnsetResourceConfig returns the sentinel that tells the Solidity script to
+// use Constants.DEFAULT_RESOURCE_CONFIG(). MaximumBaseFee must be non-nil for
+// ABI encoding even when the value is unused.
+func UnsetResourceConfig() ResourceConfig {
+	return ResourceConfig{MaximumBaseFee: new(big.Int)}
 }
 
 type DeployOPChainOutput struct {

--- a/op-deployer/pkg/deployer/pipeline/init.go
+++ b/op-deployer/pkg/deployer/pipeline/init.go
@@ -33,26 +33,16 @@ func InitLiveStrategy(ctx context.Context, env *Env, intent *state.Intent, st *s
 		if intent.SuperchainRoles != nil {
 			return fmt.Errorf("cannot set superchain roles when using predeployed OPCM or SuperchainConfig")
 		}
+		if !hasSuperchainConfigProxy {
+			return fmt.Errorf("superchainConfigProxy must be set in the intent when using a predeployed OPCM")
+		}
 
 		opcmAddr := common.Address{}
 		if hasPredeployedOPCM {
 			opcmAddr = *intent.OPCMAddress
 		}
+		superchainConfigAddr := *intent.SuperchainConfigProxy
 
-		superchainConfigAddr := common.Address{}
-		if hasSuperchainConfigProxy {
-			superchainConfigAddr = *intent.SuperchainConfigProxy
-		}
-
-		// If only an OPCM address is provided, resolve SuperchainConfigProxy from it on-chain.
-		if superchainConfigAddr == (common.Address{}) && opcmAddr != (common.Address{}) {
-			opcmContract := opcm.NewContract(opcmAddr, env.L1Client)
-			resolved, err := opcmContract.SuperchainConfig(ctx)
-			if err != nil {
-				return fmt.Errorf("error resolving SuperchainConfig from OPCM at %s: %w", opcmAddr, err)
-			}
-			superchainConfigAddr = resolved
-		}
 		superDeployment, superRoles, err := PopulateSuperchainState(env, opcmAddr, superchainConfigAddr)
 		if err != nil {
 			return fmt.Errorf("error populating superchain state: %w", err)

--- a/op-deployer/pkg/deployer/pipeline/opchain.go
+++ b/op-deployer/pkg/deployer/pipeline/opchain.go
@@ -13,6 +13,28 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
+// resourceConfigFromIntent converts the intent-level resource config into the
+// ABI-bound struct passed to the DeployOPChain script. A nil intent value
+// produces the unset sentinel, which the Solidity script interprets as
+// "use Constants.DEFAULT_RESOURCE_CONFIG()".
+func resourceConfigFromIntent(rc *state.ResourceConfig) opcm.ResourceConfig {
+	if rc == nil {
+		return opcm.UnsetResourceConfig()
+	}
+	maxBF := new(big.Int)
+	if rc.MaximumBaseFee != nil {
+		maxBF.Set(rc.MaximumBaseFee.ToInt())
+	}
+	return opcm.ResourceConfig{
+		MaxResourceLimit:            rc.MaxResourceLimit,
+		ElasticityMultiplier:        rc.ElasticityMultiplier,
+		BaseFeeMaxChangeDenominator: rc.BaseFeeMaxChangeDenominator,
+		MinimumBaseFee:              rc.MinimumBaseFee,
+		SystemTxMaxGas:              rc.SystemTxMaxGas,
+		MaximumBaseFee:              maxBF,
+	}
+}
+
 func DeployOPChain(env *Env, intent *state.Intent, st *state.State, chainID common.Hash) error {
 	lgr := env.Logger.New("stage", "deploy-opchain")
 
@@ -158,6 +180,7 @@ func makeDCI(intent *state.Intent, thisIntent *state.ChainIntent, chainID common
 		OperatorFeeConstant:          thisIntent.OperatorFeeConstant,
 		SuperchainConfig:             st.SuperchainDeployment.SuperchainConfigProxy,
 		UseCustomGasToken:            thisIntent.IsCustomGasTokenEnabled(),
+		ResourceConfig:               resourceConfigFromIntent(thisIntent.ResourceConfig),
 	}, nil
 }
 

--- a/op-deployer/pkg/deployer/standard/standard.go
+++ b/op-deployer/pkg/deployer/standard/standard.go
@@ -41,8 +41,9 @@ const (
 	ContractsV400Tag        = "op-contracts/v4.0.0-rc.7"
 	ContractsV410Tag        = "op-contracts/v4.1.0"
 	ContractsV500Tag        = "op-contracts/v5.0.0"
-	ContractsV600Tag        = "op-contracts/v6.0.0-rc.2"
-	CurrentTag              = ContractsV600Tag
+	ContractsV600Tag        = "op-contracts/v6.0.0"
+	ContractsV700Tag        = "op-contracts/v7.0.0-rc.2"
+	CurrentTag              = ContractsV700Tag
 )
 
 var DisputeAbsolutePrestate = common.HexToHash("0x038512e02c4c3f7bdaec27d00edf55b7155e0905301e1a88083e4e0a6764d54c")

--- a/op-deployer/pkg/deployer/state/chain_intent.go
+++ b/op-deployer/pkg/deployer/state/chain_intent.go
@@ -73,6 +73,54 @@ type CustomGasToken struct {
 	LiquidityControllerOwner common.Address `json:"liquidityControllerOwner" toml:"liquidityControllerOwner"`
 }
 
+// ResourceConfig overrides the EIP-1559 deposit-gas-market parameters that are
+// otherwise sourced from `Constants.DEFAULT_RESOURCE_CONFIG()`. Field widths
+// and invariants mirror Solidity's `IResourceMetering.ResourceConfig` and
+// `SystemConfig._setResourceConfig`.
+type ResourceConfig struct {
+	MaxResourceLimit            uint32       `json:"maxResourceLimit" toml:"maxResourceLimit"`
+	ElasticityMultiplier        uint8        `json:"elasticityMultiplier" toml:"elasticityMultiplier"`
+	BaseFeeMaxChangeDenominator uint8        `json:"baseFeeMaxChangeDenominator" toml:"baseFeeMaxChangeDenominator"`
+	MinimumBaseFee              uint32       `json:"minimumBaseFee" toml:"minimumBaseFee"`
+	SystemTxMaxGas              uint32       `json:"systemTxMaxGas" toml:"systemTxMaxGas"`
+	MaximumBaseFee              *hexutil.Big `json:"maximumBaseFee" toml:"maximumBaseFee"`
+}
+
+// Check validates the resource-config invariants enforced by
+// `SystemConfig._setResourceConfig`. The gas-limit headroom check
+// (`maxResourceLimit + systemTxMaxGas <= gasLimit`) is performed by the caller
+// because it depends on the chain's `GasLimit`.
+func (r *ResourceConfig) Check() error {
+	if r.MaxResourceLimit == 0 {
+		return fmt.Errorf("%w: ResourceConfig.maxResourceLimit must be > 0 when override is provided", ErrIncompatibleValue)
+	}
+	if r.ElasticityMultiplier == 0 {
+		return fmt.Errorf("%w: ResourceConfig.elasticityMultiplier must be > 0", ErrIncompatibleValue)
+	}
+	if r.BaseFeeMaxChangeDenominator <= 1 {
+		return fmt.Errorf("%w: ResourceConfig.baseFeeMaxChangeDenominator must be > 1", ErrIncompatibleValue)
+	}
+	if (r.MaxResourceLimit/uint32(r.ElasticityMultiplier))*uint32(r.ElasticityMultiplier) != r.MaxResourceLimit {
+		return fmt.Errorf("%w: ResourceConfig.maxResourceLimit must be evenly divisible by elasticityMultiplier", ErrIncompatibleValue)
+	}
+	if r.MaximumBaseFee == nil {
+		return fmt.Errorf("%w: ResourceConfig.maximumBaseFee must be set", ErrIncompatibleValue)
+	}
+	maxBF := r.MaximumBaseFee.ToInt()
+	if maxBF.Sign() < 0 {
+		return fmt.Errorf("%w: ResourceConfig.maximumBaseFee must be non-negative", ErrIncompatibleValue)
+	}
+	// uint128 upper bound.
+	maxUint128 := new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 128), big.NewInt(1))
+	if maxBF.Cmp(maxUint128) > 0 {
+		return fmt.Errorf("%w: ResourceConfig.maximumBaseFee must fit in uint128", ErrIncompatibleValue)
+	}
+	if big.NewInt(int64(r.MinimumBaseFee)).Cmp(maxBF) > 0 {
+		return fmt.Errorf("%w: ResourceConfig.minimumBaseFee must be <= maximumBaseFee", ErrIncompatibleValue)
+	}
+	return nil
+}
+
 type ChainIntent struct {
 	ID                         common.Hash               `json:"id" toml:"id"`
 	BaseFeeVaultRecipient      common.Address            `json:"baseFeeVaultRecipient" toml:"baseFeeVaultRecipient"`
@@ -93,6 +141,9 @@ type ChainIntent struct {
 	MinBaseFee                 uint64                    `json:"minBaseFee,omitempty" toml:"minBaseFee,omitempty"`
 	DAFootprintGasScalar       uint16                    `json:"daFootprintGasScalar,omitempty" toml:"daFootprintGasScalar,omitempty"`
 	CustomGasToken             CustomGasToken            `json:"customGasToken" toml:"customGasToken"`
+	// ResourceConfig optionally overrides the EIP-1559 deposit-gas-market
+	// parameters. Leave unset to use Constants.DEFAULT_RESOURCE_CONFIG().
+	ResourceConfig *ResourceConfig `json:"resourceConfig,omitempty" toml:"resourceConfig,omitempty"`
 
 	// Optional. For development purposes only. Only enabled if the operation mode targets a genesis-file output.
 	L2DevGenesisParams *L2DevGenesisParams `json:"l2DevGenesisParams,omitempty" toml:"l2DevGenesisParams,omitempty"`
@@ -160,6 +211,23 @@ func (c *ChainIntent) Check() error {
 			return fmt.Errorf("%w: CustomGasToken.InitialLiquidity must be non-negative when custom gas token is enabled, chainId=%s", ErrIncompatibleValue, c.ID)
 		}
 		// LiquidityControllerOwner is optional - if not set, L2ProxyAdminOwner will be used as default
+	}
+
+	if c.ResourceConfig != nil {
+		if err := c.ResourceConfig.Check(); err != nil {
+			return fmt.Errorf("%w: chainId=%s", err, c.ID)
+		}
+		// SystemConfig._setResourceConfig requires
+		// `maxResourceLimit + systemTxMaxGas <= gasLimit`.
+		if uint64(c.ResourceConfig.MaxResourceLimit)+uint64(c.ResourceConfig.SystemTxMaxGas) > c.GasLimit {
+			return fmt.Errorf(
+				"%w: ResourceConfig.maxResourceLimit + systemTxMaxGas (%d) must be <= gasLimit (%d), chainId=%s",
+				ErrIncompatibleValue,
+				uint64(c.ResourceConfig.MaxResourceLimit)+uint64(c.ResourceConfig.SystemTxMaxGas),
+				c.GasLimit,
+				c.ID,
+			)
+		}
 	}
 
 	if c.DangerousAltDAConfig.UseAltDA {

--- a/op-deployer/pkg/deployer/state/chain_intent_test.go
+++ b/op-deployer/pkg/deployer/state/chain_intent_test.go
@@ -157,6 +157,122 @@ func TestChainIntentCheck_ZKDisputeGame(t *testing.T) {
 	}
 }
 
+func TestChainIntentCheck_ResourceConfig(t *testing.T) {
+	uint128Max := new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 128), big.NewInt(1))
+
+	// Default values from Constants.DEFAULT_RESOURCE_CONFIG().
+	defaultRC := func() *ResourceConfig {
+		return &ResourceConfig{
+			MaxResourceLimit:            20_000_000,
+			ElasticityMultiplier:        10,
+			BaseFeeMaxChangeDenominator: 8,
+			MinimumBaseFee:              1_000_000_000,
+			SystemTxMaxGas:              1_000_000,
+			MaximumBaseFee:              (*hexutil.Big)(uint128Max),
+		}
+	}
+
+	tests := []struct {
+		name      string
+		mutate    func(c *ChainIntent)
+		expectErr error
+	}{
+		{
+			name:   "nil resource config passes (uses defaults)",
+			mutate: func(c *ChainIntent) { c.ResourceConfig = nil },
+		},
+		{
+			name: "valid override passes",
+			mutate: func(c *ChainIntent) {
+				rc := defaultRC()
+				rc.MaxResourceLimit = 4_000_000
+				rc.SystemTxMaxGas = 1_000_000
+				c.GasLimit = 5_000_000
+				c.ResourceConfig = rc
+			},
+		},
+		{
+			name: "zero maxResourceLimit fails",
+			mutate: func(c *ChainIntent) {
+				rc := defaultRC()
+				rc.MaxResourceLimit = 0
+				c.ResourceConfig = rc
+			},
+			expectErr: ErrIncompatibleValue,
+		},
+		{
+			name: "zero elasticityMultiplier fails",
+			mutate: func(c *ChainIntent) {
+				rc := defaultRC()
+				rc.ElasticityMultiplier = 0
+				c.ResourceConfig = rc
+			},
+			expectErr: ErrIncompatibleValue,
+		},
+		{
+			name: "denominator <= 1 fails",
+			mutate: func(c *ChainIntent) {
+				rc := defaultRC()
+				rc.BaseFeeMaxChangeDenominator = 1
+				c.ResourceConfig = rc
+			},
+			expectErr: ErrIncompatibleValue,
+		},
+		{
+			name: "non-divisible maxResourceLimit fails",
+			mutate: func(c *ChainIntent) {
+				rc := defaultRC()
+				// 20_000_001 / 10 != exact.
+				rc.MaxResourceLimit = 20_000_001
+				c.ResourceConfig = rc
+			},
+			expectErr: ErrIncompatibleValue,
+		},
+		{
+			name: "minimum > maximum baseFee fails",
+			mutate: func(c *ChainIntent) {
+				rc := defaultRC()
+				rc.MinimumBaseFee = 100
+				rc.MaximumBaseFee = (*hexutil.Big)(big.NewInt(50))
+				c.ResourceConfig = rc
+			},
+			expectErr: ErrIncompatibleValue,
+		},
+		{
+			name: "maximumBaseFee exceeds uint128 fails",
+			mutate: func(c *ChainIntent) {
+				rc := defaultRC()
+				rc.MaximumBaseFee = (*hexutil.Big)(new(big.Int).Add(uint128Max, big.NewInt(1)))
+				c.ResourceConfig = rc
+			},
+			expectErr: ErrIncompatibleValue,
+		},
+		{
+			name: "gas-limit headroom violated fails",
+			mutate: func(c *ChainIntent) {
+				rc := defaultRC()
+				// default sums to 21M; gasLimit stays at 30M baseline so this passes — make it fail.
+				c.GasLimit = 1_000_000
+				c.ResourceConfig = rc
+			},
+			expectErr: ErrIncompatibleValue,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := validBaseChainIntent()
+			tt.mutate(c)
+			err := c.Check()
+			if tt.expectErr != nil {
+				require.ErrorIs(t, err, tt.expectErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestGetInitialLiquidity(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/op-deployer/pkg/deployer/state/intent.go
+++ b/op-deployer/pkg/deployer/state/intent.go
@@ -350,13 +350,20 @@ func NewIntentStandard(l1ChainId uint64, l2ChainIds []common.Hash) (Intent, erro
 		return Intent{}, fmt.Errorf("error getting OPCM impl address: %w", err)
 	}
 
+	superchainCfg, err := standard.SuperchainFor(l1ChainId)
+	if err != nil {
+		return Intent{}, fmt.Errorf("error getting Superchain for L1 chain %d: %w", l1ChainId, err)
+	}
+	superchainConfigProxy := superchainCfg.SuperchainConfigAddr
+
 	intent := Intent{
-		ConfigType:         IntentTypeStandard,
-		OpDeployerVersion:  version.VersionWithMeta,
-		L1ChainID:          l1ChainId,
-		L1ContractsLocator: artifacts.DefaultL1ContractsLocator,
-		L2ContractsLocator: artifacts.DefaultL2ContractsLocator,
-		OPCMAddress:        &opcmAddr,
+		ConfigType:            IntentTypeStandard,
+		OpDeployerVersion:     version.VersionWithMeta,
+		L1ChainID:             l1ChainId,
+		L1ContractsLocator:    artifacts.DefaultL1ContractsLocator,
+		L2ContractsLocator:    artifacts.DefaultL2ContractsLocator,
+		OPCMAddress:           &opcmAddr,
+		SuperchainConfigProxy: &superchainConfigProxy,
 	}
 
 	challenger, err := standard.ChallengerAddressFor(l1ChainId)

--- a/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
@@ -20,6 +20,7 @@ import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.so
 import { IFaultDisputeGame } from "interfaces/dispute/IFaultDisputeGame.sol";
 import { IPermissionedDisputeGame } from "interfaces/dispute/IPermissionedDisputeGame.sol";
 import { IOptimismPortal2 as IOptimismPortal } from "interfaces/L1/IOptimismPortal2.sol";
+import { IResourceMetering } from "interfaces/L1/IResourceMetering.sol";
 import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
 import { IL1CrossDomainMessenger } from "interfaces/L1/IL1CrossDomainMessenger.sol";
 import { IL1ERC721Bridge } from "interfaces/L1/IL1ERC721Bridge.sol";
@@ -205,10 +206,29 @@ contract DeployOPChain is Script {
             blobBasefeeScalar: _input.blobBaseFeeScalar,
             gasLimit: _input.gasLimit,
             l2ChainId: _input.l2ChainId,
-            resourceConfig: Constants.DEFAULT_RESOURCE_CONFIG(),
+            resourceConfig: _resolveResourceConfig(_input.resourceConfig),
             disputeGameConfigs: disputeGameConfigs,
             useCustomGasToken: _input.useCustomGasToken
         });
+    }
+
+    /// @notice Resolves the resource config for a deployment. Returns the default
+    ///         when `_override.maxResourceLimit == 0`, otherwise returns the
+    ///         caller-supplied override unchanged. The deeper invariants
+    ///         (precision, bounds, gas-limit headroom) are enforced by
+    ///         `SystemConfig._setResourceConfig` during initialization.
+    /// @param _override The override resource config; treated as "unset" when
+    ///        `maxResourceLimit == 0`.
+    /// @return resolved_ The resource config to use.
+    function _resolveResourceConfig(IResourceMetering.ResourceConfig memory _override)
+        internal
+        pure
+        returns (IResourceMetering.ResourceConfig memory resolved_)
+    {
+        if (_override.maxResourceLimit == 0) {
+            return Constants.DEFAULT_RESOURCE_CONFIG();
+        }
+        return _override;
     }
 
     /// @notice Converts IOPContractsManagerV2.ChainContracts to Output.

--- a/packages/contracts-bedrock/scripts/libraries/Types.sol
+++ b/packages/contracts-bedrock/scripts/libraries/Types.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.0;
 
 import { Claim, Duration, GameType } from "src/dispute/lib/Types.sol";
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
+import { IResourceMetering } from "interfaces/L1/IResourceMetering.sol";
 
 library Types {
     /// @notice Represents a set of L1 contracts. Used to represent a set of proxies.
@@ -53,5 +54,9 @@ library Types {
         ISuperchainConfig superchainConfig;
         // Whether to use the custom gas token.
         bool useCustomGasToken;
+        // Optional resource config override. When `maxResourceLimit` is zero the
+        // chain is deployed with `Constants.DEFAULT_RESOURCE_CONFIG()` and every
+        // other field of this struct is ignored.
+        IResourceMetering.ResourceConfig resourceConfig;
     }
 }

--- a/packages/contracts-bedrock/test/opcm/DeployOPChain.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployOPChain.t.sol
@@ -13,6 +13,7 @@ import { StandardConstants } from "scripts/deploy/StandardConstants.sol";
 import { Types } from "scripts/libraries/Types.sol";
 
 // Libraries
+import { Constants } from "src/libraries/Constants.sol";
 import { Features } from "src/libraries/Features.sol";
 import { DevFeatures } from "src/libraries/DevFeatures.sol";
 
@@ -21,6 +22,7 @@ import { IOPContractsManagerV2 } from "interfaces/L1/opcm/IOPContractsManagerV2.
 import { IOPContractsManagerContainer } from "interfaces/L1/opcm/IOPContractsManagerContainer.sol";
 import { Claim, Duration, GameType, GameTypes } from "src/dispute/lib/Types.sol";
 import { IPermissionedDisputeGame } from "interfaces/dispute/IPermissionedDisputeGame.sol";
+import { IResourceMetering } from "interfaces/L1/IResourceMetering.sol";
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 
 contract DeployOPChain_TestBase is Test, FeatureFlags {
@@ -132,7 +134,16 @@ contract DeployOPChain_TestBase is Test, FeatureFlags {
             operatorFeeScalar: 0,
             operatorFeeConstant: 0,
             superchainConfig: superchainConfig,
-            useCustomGasToken: useCustomGasToken
+            useCustomGasToken: useCustomGasToken,
+            // Zeroed: deploy uses Constants.DEFAULT_RESOURCE_CONFIG().
+            resourceConfig: IResourceMetering.ResourceConfig({
+                maxResourceLimit: 0,
+                elasticityMultiplier: 0,
+                baseFeeMaxChangeDenominator: 0,
+                minimumBaseFee: 0,
+                systemTxMaxGas: 0,
+                maximumBaseFee: 0
+            })
         });
     }
 }
@@ -199,6 +210,48 @@ contract DeployOPChain_Test is DeployOPChain_TestBase {
             true,
             "SystemConfig CUSTOM_GAS_TOKEN feature should be true"
         );
+    }
+
+    /// @notice With a zeroed `resourceConfig` input, the deployed SystemConfig must
+    ///         expose Constants.DEFAULT_RESOURCE_CONFIG().
+    function test_run_resourceConfigDefaulted_succeeds() public {
+        DeployOPChain.Output memory doo = deployOPChain.run(deployOPChainInput);
+
+        IResourceMetering.ResourceConfig memory got = doo.systemConfigProxy.resourceConfig();
+        IResourceMetering.ResourceConfig memory want = Constants.DEFAULT_RESOURCE_CONFIG();
+        assertEq(got.maxResourceLimit, want.maxResourceLimit, "maxResourceLimit");
+        assertEq(got.elasticityMultiplier, want.elasticityMultiplier, "elasticityMultiplier");
+        assertEq(got.baseFeeMaxChangeDenominator, want.baseFeeMaxChangeDenominator, "baseFeeMaxChangeDenominator");
+        assertEq(got.minimumBaseFee, want.minimumBaseFee, "minimumBaseFee");
+        assertEq(got.systemTxMaxGas, want.systemTxMaxGas, "systemTxMaxGas");
+        assertEq(got.maximumBaseFee, want.maximumBaseFee, "maximumBaseFee");
+    }
+
+    /// @notice A non-zero `resourceConfig` override is forwarded verbatim to OPCM /
+    ///         SystemConfig and must survive initialization. This test demonstrates
+    ///         the motivating use case: a chain with `gasLimit = 5_000_000`.
+    function test_run_resourceConfigCustom_succeeds() public {
+        IResourceMetering.ResourceConfig memory custom = IResourceMetering.ResourceConfig({
+            maxResourceLimit: 4_000_000,
+            elasticityMultiplier: 10,
+            baseFeeMaxChangeDenominator: 8,
+            minimumBaseFee: 1 gwei,
+            systemTxMaxGas: 1_000_000,
+            maximumBaseFee: type(uint128).max
+        });
+        deployOPChainInput.resourceConfig = custom;
+        deployOPChainInput.gasLimit = 5_000_000;
+
+        DeployOPChain.Output memory doo = deployOPChain.run(deployOPChainInput);
+
+        IResourceMetering.ResourceConfig memory got = doo.systemConfigProxy.resourceConfig();
+        assertEq(got.maxResourceLimit, custom.maxResourceLimit, "maxResourceLimit");
+        assertEq(got.elasticityMultiplier, custom.elasticityMultiplier, "elasticityMultiplier");
+        assertEq(got.baseFeeMaxChangeDenominator, custom.baseFeeMaxChangeDenominator, "baseFeeMaxChangeDenominator");
+        assertEq(got.minimumBaseFee, custom.minimumBaseFee, "minimumBaseFee");
+        assertEq(got.systemTxMaxGas, custom.systemTxMaxGas, "systemTxMaxGas");
+        assertEq(got.maximumBaseFee, custom.maximumBaseFee, "maximumBaseFee");
+        assertEq(doo.systemConfigProxy.gasLimit(), 5_000_000, "gasLimit");
     }
 
     function getPermissionedDisputeGame(DeployOPChain.Output memory doo)


### PR DESCRIPTION
## Summary

Adds an optional, per-chain `ResourceConfig` override to op-deployer's `DeployOPChain` flow. Today the deploy script hardcodes `Constants.DEFAULT_RESOURCE_CONFIG()`, so chains that need a different gas envelope (notably any chain with `gasLimit < maxResourceLimit + systemTxMaxGas`, since the default sums to ~21M) cannot be deployed through op-deployer at all.

The override is opt-in: a zero-valued `maxResourceLimit` is treated by the Solidity script as "use the default", matching the pre-existing behavior. Setting any non-default value intentionally produces a chain that fails `OPContractsManagerStandardValidator` (SYSCON-50…SYSCON-100) — this is documented in both the Go and Solidity comments.

### Changes

- **`state.ChainIntent`** — new optional `ResourceConfig` field with full `Check()` validation mirroring `SystemConfig._setResourceConfig` (precision, bounds, `uint128` cap, gas-limit headroom).
- **`opcm.DeployOPChainInput`** — new `ResourceConfig` ABI-bound struct. Adds `abiType:"uint128"` tag support so `MaximumBaseFee` (no native Go primitive) round-trips correctly.
- **`forge/encoding.go`** — `GoStructToABITuple` now honors an `abiType` tag for explicit Solidity type selection and recursively encodes nested struct fields as nested tuples.
- **`pipeline.DeployOPChain`** — converts intent → opcm struct; nil intent yields a zero struct (the Solidity sentinel for "use default").
- **`DeployOPChain.s.sol`** — adds `_resolveResourceConfig` and forwards the override to OPCM.
- **`Types.DeployOPChainInput`** — adds the `resourceConfig` field.

### Tests

- `state.TestChainIntentCheck_ResourceConfig` — table-driven coverage for every invariant (`maxResourceLimit > 0`, `elasticityMultiplier > 0`, denominator > 1, divisibility, `min ≤ max`, `uint128` bound, gas-limit headroom).
- `forge.TestGoStructToABITuple_AbiTypeTag` / `TestGoStructToABITuple_NestedStruct` / `TestBytesScriptEncoder_NestedAndUint128` — covers the new tag and nested-tuple encoding paths.
- `DeployOPChain_Test.test_run_resourceConfigDefaulted_succeeds` / `test_run_resourceConfigCustom_succeeds` — verifies a zeroed input still yields the default config and that a custom 5M-gas-limit chain initializes successfully.