### PR TITLE
fix(kona-interop): guard executing chain against interop activation block

### DIFF
--- a/rust/kona/crates/protocol/interop/src/errors.rs
+++ b/rust/kona/crates/protocol/interop/src/errors.rs
@@ -64,6 +64,16 @@ pub enum MessageGraphError<E: Debug> {
         /// The timestamp of the initiating message
         initiating_message_time: u64,
     },
+    /// Interop has not been activated for at least one block on the executing message's chain.
+    #[error(
+        "Interop has not been active for at least one block on executing message's chain. Activation time: {activation_time}, executing message time: {executing_message_time}"
+    )]
+    ExecutedTooEarly {
+        /// The timestamp of the interop activation on the executing chain.
+        activation_time: u64,
+        /// The timestamp of the executing message.
+        executing_message_time: u64,
+    },
     /// Message is in the future
     #[error("Message is in the future. Expected timestamp to be <= {max}, got {actual}")]
     MessageInFuture {

--- a/rust/kona/crates/protocol/interop/src/graph.rs
+++ b/rust/kona/crates/protocol/interop/src/graph.rs
@@ -357,6 +357,24 @@ where
             return Err(MessageGraphError::ChainNotInDependencySet(initiating_chain_id));
         }
 
+        // Attempt to fetch the rollup config for the executing chain from the registry. If the
+        // rollup config is not found, fall back to the local rollup configs.
+        let exec_rollup_config = ROLLUP_CONFIGS
+            .get(&message.executing_chain_id)
+            .or_else(|| self.rollup_configs.get(&message.executing_chain_id))
+            .ok_or(MessageGraphError::MissingRollupConfig(message.executing_chain_id))?;
+
+        // Activation invariant: Interop must be active on the executing chain AND the executing
+        // block must not be the activation block.
+        if !exec_rollup_config.is_interop_active(message.executing_timestamp) ||
+            exec_rollup_config.is_first_interop_block(message.executing_timestamp)
+        {
+            return Err(MessageGraphError::ExecutedTooEarly {
+                activation_time: exec_rollup_config.hardforks.interop_time.unwrap_or_default(),
+                executing_message_time: message.executing_timestamp,
+            });
+        }
+
         // Attempt to fetch the rollup config for the initiating chain from the registry. If the
         // rollup config is not found, fall back to the local rollup configs.
         let rollup_config = ROLLUP_CONFIGS
@@ -802,6 +820,144 @@ mod test {
         assert_eq!(
             *invalid_messages.get(&CHAIN_B_ID).unwrap(),
             MessageGraphError::InitiatedTooEarly { activation_time: 2, initiating_message_time: 2 }
+        );
+    }
+
+    #[tokio::test]
+    async fn test_derive_and_resolve_graph_executing_before_interop() {
+        let mut superchain = default_superchain();
+
+        let chain_a_time = superchain.chain(CHAIN_A_ID).header.timestamp;
+        let chain_b_time = superchain.chain(CHAIN_B_ID).header.timestamp;
+
+        // Move CHAIN_B (the executing chain) activation to t=50, so its block at t=2 is
+        // pre-interop. CHAIN_A (initiating) stays at the default (interop_time=0, well
+        // past activation). The executing-chain guard must reject via `!is_interop_active`.
+        superchain.chain(CHAIN_B_ID).with_interop_activation_time(50);
+        superchain.chain(CHAIN_A_ID).add_initiating_message(MOCK_MESSAGE.into());
+        superchain.chain(CHAIN_B_ID).add_executing_message(
+            ExecutingMessageBuilder::default()
+                .with_message_hash(keccak256(MOCK_MESSAGE))
+                .with_origin_chain_id(CHAIN_A_ID)
+                .with_origin_timestamp(chain_a_time),
+        );
+
+        let (headers, cfgs, provider) = superchain.build();
+
+        let graph = MessageGraph::derive(
+            &headers,
+            &provider,
+            &cfgs,
+            default_dep_set(),
+            MESSAGE_EXPIRY_WINDOW,
+        )
+        .await
+        .unwrap();
+        let MessageGraphError::InvalidMessages(invalid_messages) =
+            graph.resolve().await.unwrap_err()
+        else {
+            panic!("Expected invalid messages")
+        };
+
+        assert_eq!(invalid_messages.len(), 1);
+        assert_eq!(
+            *invalid_messages.get(&CHAIN_B_ID).unwrap(),
+            MessageGraphError::ExecutedTooEarly {
+                activation_time: 50,
+                executing_message_time: chain_b_time,
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn test_derive_and_resolve_graph_executing_before_interop_unaligned_activation() {
+        let mut superchain = default_superchain();
+
+        let chain_a_time = superchain.chain(CHAIN_A_ID).header.timestamp;
+        let chain_b_time = superchain.chain(CHAIN_B_ID).header.timestamp;
+
+        // CHAIN_B activates @ `1s`, unaligned with the block time of `2s`. The first
+        // CHAIN_B block at t=2 IS its activation block (`is_first_interop_block` is
+        // true under unaligned activation: `is_interop_active(2) && !is_interop_active(0)`).
+        superchain.chain(CHAIN_B_ID).with_interop_activation_time(1);
+        superchain.chain(CHAIN_A_ID).add_initiating_message(MOCK_MESSAGE.into());
+        superchain.chain(CHAIN_B_ID).add_executing_message(
+            ExecutingMessageBuilder::default()
+                .with_message_hash(keccak256(MOCK_MESSAGE))
+                .with_origin_chain_id(CHAIN_A_ID)
+                .with_origin_timestamp(chain_a_time),
+        );
+
+        let (headers, cfgs, provider) = superchain.build();
+
+        let graph = MessageGraph::derive(
+            &headers,
+            &provider,
+            &cfgs,
+            default_dep_set(),
+            MESSAGE_EXPIRY_WINDOW,
+        )
+        .await
+        .unwrap();
+        let MessageGraphError::InvalidMessages(invalid_messages) =
+            graph.resolve().await.unwrap_err()
+        else {
+            panic!("Expected invalid messages")
+        };
+
+        assert_eq!(invalid_messages.len(), 1);
+        assert_eq!(
+            *invalid_messages.get(&CHAIN_B_ID).unwrap(),
+            MessageGraphError::ExecutedTooEarly {
+                activation_time: 1,
+                executing_message_time: chain_b_time,
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn test_derive_and_resolve_graph_executing_at_interop_activation() {
+        let mut superchain = default_superchain();
+
+        let chain_a_time = superchain.chain(CHAIN_A_ID).header.timestamp;
+        let chain_b_time = superchain.chain(CHAIN_B_ID).header.timestamp;
+
+        // CHAIN_B activates @ `chain_b_time`, exactly aligned with block_time. The block
+        // at `chain_b_time` IS the activation block. Mirrors the existing init-side test
+        // which uses `with_interop_activation_time(chain_a_time)`.
+        superchain.chain(CHAIN_B_ID).with_interop_activation_time(chain_b_time);
+        superchain.chain(CHAIN_A_ID).add_initiating_message(MOCK_MESSAGE.into());
+        superchain.chain(CHAIN_B_ID).add_executing_message(
+            ExecutingMessageBuilder::default()
+                .with_message_hash(keccak256(MOCK_MESSAGE))
+                .with_origin_chain_id(CHAIN_A_ID)
+                .with_origin_timestamp(chain_a_time),
+        );
+
+        let (headers, cfgs, provider) = superchain.build();
+
+        let graph = MessageGraph::derive(
+            &headers,
+            &provider,
+            &cfgs,
+            default_dep_set(),
+            MESSAGE_EXPIRY_WINDOW,
+        )
+        .await
+        .unwrap();
+        let MessageGraphError::InvalidMessages(invalid_messages) =
+            graph.resolve().await.unwrap_err()
+        else {
+            panic!("Expected invalid messages")
+        };
+
+        assert_eq!(invalid_messages.len(), 1);
+        assert_eq!(
+            *invalid_messages.get(&CHAIN_B_ID).unwrap(),
+            MessageGraphError::ExecutedTooEarly {
+                activation_time: chain_b_time,
+                executing_message_time: chain_b_time,
+            }
         );
     }
 


### PR DESCRIPTION
`MessageGraph::check_single_dependency` only enforces the interop activation invariant on the initiating chain. The interop spec forbids executing messages in any chain's activation block, and op-supervisor's `LinkCheckerImpl.CanExecute` and op-program's consolidation enforce both sides. Without the executing-side guard, kona-client accepts exec-message-in-activation-block while op-program rejects it, producing divergent post-states from the same agreed pre-state at the dispute boundary.

This adds the missing guard, mirroring op-supervisor's structure (`op-supervisor/supervisor/backend/depset/links.go:43,47-48`):

if !exec_cfg.is_interop_active(t) || exec_cfg.is_first_interop_block(t)

Surfaced as a new `MessageGraphError::ExecutedTooEarly` variant, symmetric to the existing `InitiatedTooEarly`. Three tests cover: activation set well in the future, unaligned activation that lands the first block on the activation timestamp, and aligned activation at the local-safe head.

Closes #20528