### PR TITLE
fix(op-node): record effective safe/finalized metrics in supernode mode

### DIFF
--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -289,10 +289,19 @@ func (e *EngineController) RequestForkchoiceUpdate(ctx context.Context) {
 }
 
 func (e *EngineController) requestForkchoiceUpdate(ctx context.Context) {
+	safeHead := e.SafeL2Head()
+	finalizedHead := e.FinalizedHead()
+	// Record the effective safe/finalized refs for metrics. In supernode mode,
+	// SafeL2Head() and FinalizedHead() consult the superAuthority and may return
+	// values different from localSafeHead/localFinalizedHead. The metrics recorded
+	// in SetDeprecatedSafeHead/SetFinalizedHead capture only the local values, so
+	// we overwrite them here with the effective heads that the rest of the system uses.
+	e.metrics.RecordL2Ref("l2_safe", safeHead)
+	e.metrics.RecordL2Ref("l2_finalized", finalizedHead)
 	e.emitter.Emit(ctx, ForkchoiceUpdateEvent{
 		UnsafeL2Head:    e.unsafeHead,
-		SafeL2Head:      e.SafeL2Head(),
-		FinalizedL2Head: e.FinalizedHead(),
+		SafeL2Head:      safeHead,
+		FinalizedL2Head: finalizedHead,
 	})
 }
 


### PR DESCRIPTION
## Summary

Fixes `l2_safe` and `l2_finalized` Prometheus metrics reporting incorrect values in supernode mode, particularly during catchup.

## Problem

In supernode mode, `SafeL2Head()` and `FinalizedHead()` consult the superAuthority (interop verifiers) and return values that may differ from the local internal state (`localSafeHead`/`localFinalizedHead`). The metrics were only recorded in `SetDeprecatedSafeHead()` and `SetFinalizedHead()`, which capture the **local** values — not the effective values that the API and logs report.

This manifests as a metric/API divergence during catchup:
- **API** (`SyncStatus().FinalizedL2`): returns block 87k+ (correct, from verifier)
- **Metric** (`op_node_supernode_refs_number{type="l2_finalized"}`): stuck at 0 (genesis)
- **Logs** (`"Sync progress" l2_finalized=...`): shows block 87k+ (correct, from `FinalizedHead()`)

### Root cause

During catchup, `promoteFinalized(ref)` is blocked by its own guard:

```go
if ref.Number < e.FinalizedHead().Number {
    return // FinalizedHead() already returns 87k from verifier; standard finalizer can't catch up
}
```

So `SetFinalizedHead()` is never called, the metric never updates, and `localFinalizedHead` stays at genesis — even though the effective finalized head (from verifiers) is advancing normally.

This issue is **not visible on fully-synced supernodes** because once the verifier catches up, `localFinalizedHead` converges with the verifier-derived value and the standard finality pipeline resumes normal operation.

## Fix

Record the effective `SafeL2Head()` and `FinalizedHead()` values in `requestForkchoiceUpdate()`, which is where these values are published to the event system (and ultimately the API). The gauge overwrite is a **no-op for standalone op-node** (where local and effective values are identical).

## Test plan

- [x] `go build ./op-node/rollup/engine/...` — compiles clean
- [x] `go test ./op-node/rollup/engine/...` — all tests pass
- [ ] Deploy to catching-up supernode and verify `op_node_supernode_refs_number{type="l2_finalized"}` matches API response

🤖 Generated with [Claude Code](https://claude.com/claude-code)