### PR TITLE
op-interop-filter: optional reorg support

### DIFF
--- a/op-interop-filter/README.md
+++ b/op-interop-filter/README.md
@@ -2,7 +2,7 @@
 
 A lightweight service that validates interop executing messages for op-geth or op-reth transaction filtering.
 
-Any reorg will trigger the failsafe which disables all interop transactions.
+Any reorg will trigger the failsafe which disables all interop transactions. If `--reorg-recovery-enabled` is set, reorg-triggered failsafe is automatically resolved by rewinding logs DB state to finalized.
 
 ## Usage
 

--- a/op-interop-filter/filter/backend.go
+++ b/op-interop-filter/filter/backend.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -35,7 +36,11 @@ type Backend struct {
 	// Passthrough mode: all transactions pass without filtering
 	passthrough bool
 
+	ctx    context.Context
 	cancel context.CancelFunc
+
+	reorgRecoveryEnabled bool
+	reorgRecoveryWg      sync.WaitGroup
 }
 
 // BackendParams contains parameters for creating a Backend.
@@ -45,19 +50,23 @@ type BackendParams struct {
 	Chains         map[eth.ChainID]ChainIngester
 	CrossValidator CrossValidator
 	Passthrough    bool
+
+	ReorgRecoveryEnabled bool
 }
 
 // NewBackend creates a new Backend instance with the provided components.
 func NewBackend(parentCtx context.Context, params BackendParams) *Backend {
-	_, cancel := context.WithCancel(parentCtx)
+	ctx, cancel := context.WithCancel(parentCtx)
 
 	return &Backend{
-		log:            params.Logger,
-		metrics:        params.Metrics,
-		chains:         params.Chains,
-		crossValidator: params.CrossValidator,
-		passthrough:    params.Passthrough,
-		cancel:         cancel,
+		log:                  params.Logger,
+		metrics:              params.Metrics,
+		chains:               params.Chains,
+		crossValidator:       params.CrossValidator,
+		passthrough:          params.Passthrough,
+		ctx:                  ctx,
+		cancel:               cancel,
+		reorgRecoveryEnabled: params.ReorgRecoveryEnabled,
 	}
 }
 
@@ -75,6 +84,11 @@ func (b *Backend) Start(ctx context.Context) error {
 		return fmt.Errorf("failed to start cross-validator: %w", err)
 	}
 
+	if b.reorgRecoveryEnabled {
+		b.reorgRecoveryWg.Add(1)
+		go b.runReorgRecovery(b.ctx)
+	}
+
 	return nil
 }
 
@@ -84,6 +98,8 @@ func (b *Backend) Stop(ctx context.Context) error {
 	b.cancel()
 
 	var result error
+
+	b.reorgRecoveryWg.Wait()
 
 	if err := b.crossValidator.Stop(); err != nil {
 		result = errors.Join(result, fmt.Errorf("failed to stop cross-validator: %w", err))

--- a/op-interop-filter/filter/backend_reorg_recovery.go
+++ b/op-interop-filter/filter/backend_reorg_recovery.go
@@ -1,0 +1,74 @@
+package filter
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+const reorgRecoveryInterval = 500 * time.Millisecond
+
+func (b *Backend) runReorgRecovery(ctx context.Context) {
+	defer b.reorgRecoveryWg.Done()
+
+	ticker := time.NewTicker(reorgRecoveryInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			b.tryResolveReorgs(ctx)
+		}
+	}
+}
+
+func (b *Backend) tryResolveReorgs(ctx context.Context) {
+	for chainID, ingester := range b.chains {
+		if ingester.Error() == nil {
+			continue
+		}
+
+		blockID, timestamp, err := b.recoverChainReorg(ctx, chainID, ingester)
+		if err != nil {
+			b.log.Warn("Failed to auto-resolve reorg", "chain", chainID, "target", eth.Finalized, "err", err)
+			continue
+		}
+
+		b.crossValidator.ResetCrossValidatedTimestamp(timestamp)
+		ingester.ClearError()
+		b.log.Info("Auto-resolved reorg-triggered failsafe",
+			"chain", chainID,
+			"target", eth.Finalized,
+			"block", blockID.Number,
+			"hash", blockID.Hash,
+			"timestamp", timestamp)
+	}
+}
+
+func (b *Backend) recoverChainReorg(
+	ctx context.Context,
+	chainID eth.ChainID,
+	ingester ChainIngester,
+) (eth.BlockID, uint64, error) {
+	errState := ingester.Error()
+	if errState == nil {
+		return eth.BlockID{}, 0, fmt.Errorf("cannot auto-resolve reorg: chain %s has no ingester error", chainID)
+	}
+	if errState.Reason != ErrorReorg {
+		return eth.BlockID{}, 0, reorgResolutionSkipped(errState.Reason)
+	}
+
+	blockID, timestamp, err := ingester.RewindToFinalized(ctx)
+	if err != nil {
+		return eth.BlockID{}, 0, fmt.Errorf("failed to rewind to finalized: %w", err)
+	}
+	return blockID, timestamp, nil
+}
+
+func reorgResolutionSkipped(reason IngesterErrorReason) error {
+	return fmt.Errorf("cannot auto-resolve ingester error reason %s", reason)
+}

--- a/op-interop-filter/filter/backend_test.go
+++ b/op-interop-filter/filter/backend_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 
@@ -171,6 +172,56 @@ func TestBackend_Failsafe_AllClear(t *testing.T) {
 	// Even after some operations, failsafe stays off
 	mock.SetLatestTimestamp(300)
 	require.False(t, backend.FailsafeEnabled())
+}
+
+func TestBackend_ReorgRecovery_ResolvesReorgError(t *testing.T) {
+	mock := newMockChainIngester()
+	mock.AddBlock(eth.BlockID{Hash: common.Hash{0x01}, Number: 10})
+	mock.SetLatestTimestamp(120)
+	mock.SetError(ErrorReorg, "reorg detected")
+
+	chains := map[eth.ChainID]ChainIngester{
+		eth.ChainIDFromUInt64(testChainA): mock,
+	}
+	cv := &mockCrossValidator{}
+	backend := NewBackend(context.Background(), BackendParams{Logger: testlog.Logger(t, log.LevelCrit), Metrics: metrics.NoopMetrics, Chains: chains, CrossValidator: cv})
+
+	require.True(t, backend.FailsafeEnabled())
+	backend.tryResolveReorgs(context.Background())
+	require.Equal(t, 1, mock.rewindToFinalizedCount)
+	require.True(t, cv.resetOK)
+	require.Equal(t, uint64(120), cv.resetTs)
+	require.Nil(t, mock.Error())
+	require.False(t, backend.FailsafeEnabled())
+}
+
+func TestBackend_ReorgRecovery_NoErrorIsNotResolvable(t *testing.T) {
+	mock := newMockChainIngester()
+	chains := map[eth.ChainID]ChainIngester{
+		eth.ChainIDFromUInt64(testChainA): mock,
+	}
+	backend := NewBackend(context.Background(), BackendParams{Logger: testlog.Logger(t, log.LevelCrit), Metrics: metrics.NoopMetrics, Chains: chains, CrossValidator: &mockCrossValidator{}})
+
+	_, _, err := backend.recoverChainReorg(context.Background(), eth.ChainIDFromUInt64(testChainA), mock)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no ingester error")
+	require.Equal(t, 0, mock.rewindToFinalizedCount)
+}
+
+func TestBackend_ReorgRecovery_IgnoresNonReorgError(t *testing.T) {
+	mock := newMockChainIngester()
+	mock.SetError(ErrorConflict, "conflict")
+
+	chains := map[eth.ChainID]ChainIngester{
+		eth.ChainIDFromUInt64(testChainA): mock,
+	}
+	cv := &mockCrossValidator{}
+	backend := NewBackend(context.Background(), BackendParams{Logger: testlog.Logger(t, log.LevelCrit), Metrics: metrics.NoopMetrics, Chains: chains, CrossValidator: cv})
+
+	backend.tryResolveReorgs(context.Background())
+	require.NotNil(t, mock.Error())
+	require.Equal(t, 0, mock.rewindToFinalizedCount)
+	require.False(t, cv.resetOK)
 }
 
 // =============================================================================

--- a/op-interop-filter/filter/config.go
+++ b/op-interop-filter/filter/config.go
@@ -35,6 +35,7 @@ type Config struct {
 	Version                     string
 	PollInterval                time.Duration // Interval for polling new blocks (default: 2s)
 	ValidationInterval          time.Duration // Interval for cross-chain validation (default: 500ms)
+	ReorgRecoveryEnabled        bool          // If true, automatically rewinds reorg-triggered failsafe to finalized
 	Passthrough                 bool          // If true, all transactions pass through without filtering
 
 	LogConfig     oplog.CLIConfig
@@ -120,6 +121,7 @@ func NewConfig(ctx *cli.Context, version string) (*Config, error) {
 		Version:                     version,
 		PollInterval:                pollInterval,
 		ValidationInterval:          validationInterval,
+		ReorgRecoveryEnabled:        ctx.Bool(flags.ReorgRecoveryEnabledFlag.Name),
 		Passthrough:                 ctx.Bool(flags.DangerouslyEnablePassthroughFlag.Name),
 		LogConfig:                   oplog.ReadCLIConfig(ctx),
 		MetricsConfig:               opmetrics.ReadCLIConfig(ctx),

--- a/op-interop-filter/filter/interfaces.go
+++ b/op-interop-filter/filter/interfaces.go
@@ -1,6 +1,8 @@
 package filter
 
 import (
+	"context"
+
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -53,6 +55,9 @@ type ChainIngester interface {
 
 	// ClearError clears the error state.
 	ClearError()
+
+	// RewindToFinalized rewinds durable log state to finalized.
+	RewindToFinalized(ctx context.Context) (eth.BlockID, uint64, error)
 }
 
 // CrossValidator validates cross-chain messages.
@@ -74,4 +79,8 @@ type CrossValidator interface {
 	// Error returns the current error state, if any.
 	// Validation errors (invalid executing messages) are tracked here.
 	Error() *ValidatorError
+
+	// ResetCrossValidatedTimestamp rewinds in-memory validation progress after
+	// the underlying log DB has been rewound.
+	ResetCrossValidatedTimestamp(timestamp uint64)
 }

--- a/op-interop-filter/filter/lockstep_cross_validator.go
+++ b/op-interop-filter/filter/lockstep_cross_validator.go
@@ -119,6 +119,21 @@ func (v *LockstepCrossValidator) CrossValidatedTimestamp() (uint64, bool) {
 	return v.crossValidatedTs.Load(), true
 }
 
+// ResetCrossValidatedTimestamp rewinds validation progress after a logs DB rewind.
+func (v *LockstepCrossValidator) ResetCrossValidatedTimestamp(timestamp uint64) {
+	for {
+		current := v.crossValidatedTs.Load()
+		if v.crossValidatedOK.Load() && current <= timestamp {
+			return
+		}
+		if v.crossValidatedTs.CompareAndSwap(current, timestamp) {
+			v.crossValidatedOK.Store(true)
+			v.log.Info("Reset cross-validated timestamp", "timestamp", timestamp)
+			return
+		}
+	}
+}
+
 // validateMessageTiming is a pure function that validates temporal constraints for cross-chain messages.
 // Parameters:
 //   - initTimestamp: when the initiating message was created

--- a/op-interop-filter/filter/logsdb_chain_ingester.go
+++ b/op-interop-filter/filter/logsdb_chain_ingester.go
@@ -22,6 +22,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/db/logs"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/processors"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/reads"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
 
@@ -64,6 +65,9 @@ type LogsDBChainIngester struct {
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
 	mu     sync.RWMutex
+
+	pendingRewindResumeFrom    uint64
+	pendingRewindResumeFromSet bool
 }
 
 // NewLogsDBChainIngester creates a new LogsDBChainIngester for the given chain.
@@ -416,6 +420,8 @@ func (c *LogsDBChainIngester) runIngestion() {
 		case <-ticker.C:
 		}
 
+		nextBlock = c.applyPendingRewind(nextBlock)
+
 		// Skip if in error state
 		if c.Error() != nil {
 			continue
@@ -459,6 +465,9 @@ func (c *LogsDBChainIngester) runIngestion() {
 				c.log.Error("Failed to ingest block", "block", nextBlock, "err", err)
 				break // Exit inner loop on error, wait for next tick to retry
 			}
+			if c.Error() != nil {
+				break
+			}
 			nextBlock++
 
 			// Progress logging
@@ -480,6 +489,20 @@ func (c *LogsDBChainIngester) runIngestion() {
 		}
 		// Caught up to head, will wait for next ticker tick
 	}
+}
+
+func (c *LogsDBChainIngester) applyPendingRewind(current uint64) uint64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if !c.pendingRewindResumeFromSet {
+		return current
+	}
+	nextBlock := c.pendingRewindResumeFrom
+	c.pendingRewindResumeFrom = 0
+	c.pendingRewindResumeFromSet = false
+	c.log.Info("Applied pending rewind", "resume_from", nextBlock)
+	return nextBlock
 }
 
 // initIngestion performs one-time setup and returns the first block to ingest.
@@ -564,6 +587,45 @@ func (c *LogsDBChainIngester) checkReorg(head eth.BlockInfo) error {
 	c.SetError(ErrorReorg, fmt.Sprintf("reorg at height %d: db has %s, chain has %s",
 		headNum, dbHash, head.Hash()))
 	return fmt.Errorf("reorg detected")
+}
+
+// RewindToFinalized rewinds durable logs DB state to the finalized block, then
+// requests that the ingestion loop resume from the following block.
+func (c *LogsDBChainIngester) RewindToFinalized(ctx context.Context) (eth.BlockID, uint64, error) {
+	target := eth.BlockLabel(eth.Finalized)
+	targetInfo, err := c.ethClient.InfoByLabel(ctx, target)
+	if err != nil {
+		return eth.BlockID{}, 0, fmt.Errorf("failed to get %s block: %w", target, err)
+	}
+	targetID := eth.BlockID{Hash: targetInfo.Hash(), Number: targetInfo.NumberU64()}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.logsDB == nil {
+		return eth.BlockID{}, 0, types.ErrUninitialized
+	}
+
+	// Recovery is intentionally fail-closed: finalized should already be in
+	// logsDB. If it is missing or mismatched, leave failsafe enabled instead of
+	// searching backwards for a common ancestor.
+	storedSeal, err := c.logsDB.FindSealedBlock(targetID.Number)
+	if err != nil {
+		return eth.BlockID{}, 0, fmt.Errorf("failed to find finalized block %d in logs DB: %w", targetID.Number, err)
+	}
+	if storedSeal.Hash != targetID.Hash {
+		return eth.BlockID{}, 0, fmt.Errorf("finalized block %d hash mismatch: db has %s, chain has %s: %w",
+			targetID.Number, storedSeal.Hash, targetID.Hash, types.ErrConflict)
+	}
+
+	if err := c.logsDB.Rewind(reads.NoopRegistry{}, targetID); err != nil {
+		return eth.BlockID{}, 0, fmt.Errorf("failed to rewind logs DB to finalized block %s: %w", targetID, err)
+	}
+
+	c.pendingRewindResumeFrom = targetID.Number + 1
+	c.pendingRewindResumeFromSet = true
+	c.log.Info("Rewound logs DB to finalized", "block", targetID.Number, "hash", targetID.Hash)
+	return targetID, targetInfo.Time(), nil
 }
 
 func (c *LogsDBChainIngester) sealParentBlock(blockNum uint64) error {

--- a/op-interop-filter/filter/logsdb_chain_ingester_test.go
+++ b/op-interop-filter/filter/logsdb_chain_ingester_test.go
@@ -448,6 +448,49 @@ func TestLogsDBChainIngester_ReorgDetection(t *testing.T) {
 	require.Equal(t, ErrorReorg, ingesterErr.Reason)
 }
 
+func TestLogsDBChainIngester_RewindToFinalized(t *testing.T) {
+	chainID := eth.ChainIDFromUInt64(901)
+	tempDir := t.TempDir()
+
+	mockClient := NewMockEthClient()
+
+	parentBlock := createTestBlock(99, 1198, common.Hash{})
+	mockClient.AddBlock(parentBlock, nil)
+
+	block100 := createTestBlock(100, 1200, parentBlock.Hash())
+	mockClient.AddBlock(block100, createTestReceipts(100, 1))
+
+	block101 := createTestBlock(101, 1202, block100.Hash())
+	mockClient.AddBlock(block101, createTestReceipts(101, 1))
+	mockClient.SetLabelBlock(eth.Finalized, block100)
+
+	ingester := newTestLogsDBChainIngester(t, testIngesterConfig{
+		chainID:   chainID,
+		dataDir:   tempDir,
+		ethClient: mockClient,
+		rollupCfg: testRollupConfig(901, 0, 1000),
+	})
+
+	err := ingester.initLogsDB()
+	require.NoError(t, err)
+	t.Cleanup(func() { ingester.logsDB.Close() })
+
+	require.NoError(t, ingester.sealParentBlock(99))
+	require.NoError(t, ingester.ingestBlock(100))
+	require.NoError(t, ingester.ingestBlock(101))
+
+	target, timestamp, err := ingester.RewindToFinalized(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, eth.BlockID{Hash: block100.Hash(), Number: 100}, target)
+	require.Equal(t, uint64(1200), timestamp)
+	require.Equal(t, uint64(101), ingester.applyPendingRewind(102))
+	require.Equal(t, uint64(102), ingester.applyPendingRewind(102))
+
+	latest, ok := ingester.LatestBlock()
+	require.True(t, ok)
+	require.Equal(t, target, latest)
+}
+
 func TestLogsDBChainIngester_QueryMethods(t *testing.T) {
 	chainID := eth.ChainIDFromUInt64(901)
 	tempDir := t.TempDir()

--- a/op-interop-filter/filter/mock_test.go
+++ b/op-interop-filter/filter/mock_test.go
@@ -36,6 +36,9 @@ type mockChainIngester struct {
 	latestBlock           eth.BlockID
 	latestTimestamp       uint64
 	earliestIngestedBlock uint64
+
+	rewindToFinalizedErr   error
+	rewindToFinalizedCount int
 }
 
 // logKey uniquely identifies a log entry
@@ -219,6 +222,17 @@ func (m *mockChainIngester) ClearError() {
 	m.err = nil
 }
 
+// RewindToFinalized implements ChainIngester.
+func (m *mockChainIngester) RewindToFinalized(ctx context.Context) (eth.BlockID, uint64, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.rewindToFinalizedCount++
+	if m.rewindToFinalizedErr != nil {
+		return eth.BlockID{}, 0, m.rewindToFinalizedErr
+	}
+	return m.latestBlock, m.latestTimestamp, nil
+}
+
 // SetLatestTimestamp sets the latest ingested timestamp (for testing).
 func (m *mockChainIngester) SetLatestTimestamp(ts uint64) {
 	m.mu.Lock()
@@ -244,6 +258,8 @@ var _ ChainIngester = (*mockChainIngester)(nil)
 type mockCrossValidator struct {
 	validateErr error
 	errState    *ValidatorError
+	resetTs     uint64
+	resetOK     bool
 }
 
 func (m *mockCrossValidator) Start() error { return nil }
@@ -253,6 +269,10 @@ func (m *mockCrossValidator) ValidateAccessEntry(access types.Access, minSafety 
 }
 func (m *mockCrossValidator) CrossValidatedTimestamp() (uint64, bool) { return 0, false }
 func (m *mockCrossValidator) Error() *ValidatorError                  { return m.errState }
+func (m *mockCrossValidator) ResetCrossValidatedTimestamp(timestamp uint64) {
+	m.resetTs = timestamp
+	m.resetOK = true
+}
 
 // SetError sets the error state for the mock validator.
 func (m *mockCrossValidator) SetError(msg string) {
@@ -369,6 +389,14 @@ func (m *MockEthClient) SetHeadBlock(block eth.BlockInfo) {
 	defer m.mu.Unlock()
 
 	m.blocksByLabel[eth.Unsafe] = block
+}
+
+// SetLabelBlock sets a block for the given label.
+func (m *MockEthClient) SetLabelBlock(label eth.BlockLabel, block eth.BlockInfo) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.blocksByLabel[label] = block
 }
 
 // SetInfoByNumberErr sets an error to return from InfoByNumber.

--- a/op-interop-filter/filter/service.go
+++ b/op-interop-filter/filter/service.go
@@ -224,6 +224,8 @@ func (s *Service) initBackend(ctx context.Context, cfg *Config) error {
 		Chains:         chains,
 		CrossValidator: crossValidator,
 		Passthrough:    cfg.Passthrough,
+
+		ReorgRecoveryEnabled: cfg.ReorgRecoveryEnabled,
 	})
 
 	s.log.Info("Created backend", "chains", len(chains))

--- a/op-interop-filter/flags/flags.go
+++ b/op-interop-filter/flags/flags.go
@@ -100,6 +100,11 @@ var (
 		EnvVars: prefixEnvVars("VALIDATION_INTERVAL"),
 		Value:   500 * time.Millisecond,
 	}
+	ReorgRecoveryEnabledFlag = &cli.BoolFlag{
+		Name:    "reorg-recovery-enabled",
+		Usage:   "Automatically resolve reorg-triggered failsafe by rewinding logs DBs to finalized.",
+		EnvVars: prefixEnvVars("REORG_RECOVERY_ENABLED"),
+	}
 	DangerouslyEnablePassthroughFlag = &cli.BoolFlag{
 		Name:    "dangerously-enable-passthrough",
 		Usage:   "Allow all transactions through without interop filtering. DANGEROUS: disables all executing message validation.",
@@ -124,6 +129,7 @@ var optionalFlags = []cli.Flag{
 	RPCPortFlag,
 	PollIntervalFlag,
 	ValidationIntervalFlag,
+	ReorgRecoveryEnabledFlag,
 	DangerouslyEnablePassthroughFlag,
 }
 


### PR DESCRIPTION
## Summary

Adds optional backend-owned reorg recovery for `op-interop-filter` behind `--reorg-recovery-enabled`.

When a chain ingester enters `ErrorReorg`, the backend keeps failsafe enabled while it coordinates recovery: it asks the affected ingester to rewind logs DB state to finalized, resets in-memory cross-validation progress, and only then clears the ingester error so failsafe disables naturally. With the flag disabled, existing behavior is unchanged: reorg errors keep failsafe enabled.

## Details

- Adds backend reorg recovery, started only when `--reorg-recovery-enabled` is set.
- Keeps recovery isolated from the access-list validation path.
- Rewinds durable logs DB state before requesting ingestion resume from finalized + 1.
- Resets cross-validator progress before clearing the ingester error.
- Always rewinds to finalized, without an operator-selectable target.
- If finalized is not present in logs DB or its hash does not match, recovery fails closed and failsafe remains enabled.
- Leaves non-reorg ingester errors and cross-validator errors fail-closed.

## Validation

- `go test ./op-interop-filter/...`