### PR TITLE
op-challenger: remove super-cannon (game type 4) support

### DIFF
--- a/op-challenger/cmd/main_test.go
+++ b/op-challenger/cmd/main_test.go
@@ -108,9 +108,6 @@ func TestL1Beacon(t *testing.T) {
 }
 
 func TestSuperNodeRpc(t *testing.T) {
-	t.Run("RequiredForSuperCannon", func(t *testing.T) {
-		verifyArgsInvalid(t, "flag supernode-rpc is required", addRequiredArgsExcept(gameTypes.SuperCannonGameType, "--supernode-rpc"))
-	})
 	t.Run("RequiredForSuperPermissioned", func(t *testing.T) {
 		verifyArgsInvalid(t, "flag supernode-rpc is required", addRequiredArgsExcept(gameTypes.SuperPermissionedGameType, "--supernode-rpc"))
 	})
@@ -120,7 +117,7 @@ func TestSuperNodeRpc(t *testing.T) {
 
 	for _, gameType := range gameTypes.SupportedGameTypes {
 		gameType := gameType
-		if gameType == gameTypes.SuperCannonGameType || gameType == gameTypes.SuperPermissionedGameType || gameType == gameTypes.SuperCannonKonaGameType {
+		if gameType == gameTypes.SuperPermissionedGameType || gameType == gameTypes.SuperCannonKonaGameType {
 			continue
 		}
 
@@ -128,13 +125,6 @@ func TestSuperNodeRpc(t *testing.T) {
 			configForArgs(t, addRequiredArgsExcept(gameType, "--supernode-rpc"))
 		})
 	}
-
-	t.Run("Valid-SuperCannon", func(t *testing.T) {
-		url := "http://localhost/super"
-		cfg := configForArgs(t, addRequiredArgsExcept(gameTypes.SuperCannonGameType, "--supernode-rpc", "--supernode-rpc", url))
-		require.Equal(t, url, cfg.SuperRPC)
-		require.True(t, cfg.UseSuperNode)
-	})
 
 	t.Run("Valid-SuperPermissioned", func(t *testing.T) {
 		url := "http://localhost/super"
@@ -490,93 +480,6 @@ func TestCannonCustomConfigArgs(t *testing.T) {
 	}
 }
 
-func TestSuperCannonCustomConfigArgs(t *testing.T) {
-	for _, gameType := range []gameTypes.GameType{gameTypes.SuperCannonGameType} {
-		gameType := gameType
-
-		t.Run(fmt.Sprintf("TestRequireEitherCannonNetworkOrRollupAndGenesisAndDepset-%v", gameType), func(t *testing.T) {
-			expectedErrorMessage := "flag network or rollup-config/cannon-rollup-config, l2-genesis/cannon-l2-genesis and depset-config/cannon-depset-config is required"
-			// Missing all
-			verifyArgsInvalid(
-				t,
-				expectedErrorMessage,
-				addRequiredArgsExcept(gameType, "--network"))
-			// Missing l2-genesis
-			verifyArgsInvalid(
-				t,
-				expectedErrorMessage,
-				addRequiredArgsExcept(gameType, "--network", "--cannon-rollup-config=rollup.json", "--cannon-depset-config=depset.json"))
-			// Missing rollup-config
-			verifyArgsInvalid(
-				t,
-				expectedErrorMessage,
-				addRequiredArgsExcept(gameType, "--network", "--cannon-l2-genesis=gensis.json", "--cannon-depset-config=depset.json"))
-			// Missing depset-config
-			verifyArgsInvalid(
-				t,
-				expectedErrorMessage,
-				addRequiredArgsExcept(gameType, "--network", "--cannon-rollup-config=rollup.json", "--cannon-l2-genesis=gensis.json"))
-		})
-
-		validateCustomNetworkFlagsProhibitedWithNetworkFlag(t, gameType, gameTypes.CannonGameType, "cannon-l2-custom")
-
-		t.Run(fmt.Sprintf("TestNetwork-%v", gameType), func(t *testing.T) {
-			t.Run("NotRequiredWhenRollupGenesisAndDepsetIsSpecified", func(t *testing.T) {
-				configForArgs(t, addRequiredArgsExcept(gameType, "--network",
-					"--cannon-rollup-config=rollup.json", "--cannon-l2-genesis=genesis.json", "--cannon-depset-config=depset.json"))
-			})
-
-			t.Run("Valid", func(t *testing.T) {
-				cfg := configForArgs(t, addRequiredArgsExcept(gameType, "--network", "--network", testNetwork))
-				require.Equal(t, []string{testNetwork}, cfg.Cannon.Networks)
-			})
-		})
-
-		t.Run(fmt.Sprintf("TestSetCannonL2ChainId-%v", gameType), func(t *testing.T) {
-			cfg := configForArgs(t, addRequiredArgsExcept(gameType, "--network",
-				"--cannon-rollup-config=rollup.json",
-				"--cannon-l2-genesis=genesis.json",
-				"--cannon-depset-config=depset.json",
-				"--cannon-l2-custom"))
-			require.True(t, cfg.Cannon.L2Custom)
-		})
-
-		t.Run(fmt.Sprintf("TestCannonRollupConfig-%v", gameType), func(t *testing.T) {
-			t.Run("NotRequiredForAlphabetTrace", func(t *testing.T) {
-				configForArgs(t, addRequiredArgsExcept(gameTypes.AlphabetGameType, "--cannon-rollup-config"))
-			})
-
-			t.Run("Valid", func(t *testing.T) {
-				cfg := configForArgs(t, addRequiredArgsExcept(gameType, "--network",
-					"--cannon-rollup-config=rollup.json", "--cannon-l2-genesis=genesis.json", "--cannon-depset-config=depset.json"))
-				require.Equal(t, []string{"rollup.json"}, cfg.Cannon.RollupConfigPaths)
-			})
-		})
-
-		t.Run(fmt.Sprintf("TestCannonL2Genesis-%v", gameType), func(t *testing.T) {
-			t.Run("NotRequiredForAlphabetTrace", func(t *testing.T) {
-				configForArgs(t, addRequiredArgsExcept(gameTypes.AlphabetGameType, "--cannon-l2-genesis"))
-			})
-
-			t.Run("Valid", func(t *testing.T) {
-				cfg := configForArgs(t, addRequiredArgsExcept(gameType, "--network", "--cannon-rollup-config=rollup.json", "--cannon-l2-genesis=genesis.json", "--cannon-depset-config=depset.json"))
-				require.Equal(t, []string{"genesis.json"}, cfg.Cannon.L2GenesisPaths)
-			})
-		})
-
-		t.Run(fmt.Sprintf("TestCannonDepsetConfig-%v", gameType), func(t *testing.T) {
-			t.Run("NotRequiredForAlphabetTrace", func(t *testing.T) {
-				configForArgs(t, addRequiredArgsExcept(gameTypes.AlphabetGameType, "--cannon-depset-config"))
-			})
-
-			t.Run("Valid", func(t *testing.T) {
-				cfg := configForArgs(t, addRequiredArgsExcept(gameType, "--network", "--cannon-rollup-config=rollup.json", "--cannon-l2-genesis=genesis.json", "--cannon-depset-config=depset.json"))
-				require.Equal(t, "depset.json", cfg.Cannon.DepsetConfigPath)
-			})
-		})
-	}
-}
-
 func TestSuperCannonKonaCustomConfigArgs(t *testing.T) {
 	for _, gameType := range []gameTypes.GameType{gameTypes.SuperCannonKonaGameType, gameTypes.SuperPermissionedGameType} {
 		gameType := gameType
@@ -665,7 +568,7 @@ func TestSuperCannonKonaCustomConfigArgs(t *testing.T) {
 }
 
 func TestCannonRequiredArgs(t *testing.T) {
-	for _, gameType := range []gameTypes.GameType{gameTypes.CannonGameType, gameTypes.PermissionedGameType, gameTypes.SuperCannonGameType} {
+	for _, gameType := range []gameTypes.GameType{gameTypes.CannonGameType, gameTypes.PermissionedGameType} {
 		gameType := gameType
 		t.Run(fmt.Sprintf("TestCannonBin-%v", gameType), func(t *testing.T) {
 			t.Run("NotRequiredForAlphabetTrace", func(t *testing.T) {
@@ -868,13 +771,7 @@ func TestCannonKonaRequiredArgs(t *testing.T) {
 
 func TestDepsetConfig(t *testing.T) {
 	for _, gameType := range gameTypes.SupportedGameTypes {
-		if gameType == gameTypes.SuperCannonGameType {
-			t.Run("Required-"+gameType.String(), func(t *testing.T) {
-				verifyArgsInvalid(t,
-					"flag network or rollup-config/cannon-rollup-config, l2-genesis/cannon-l2-genesis and depset-config/cannon-depset-config is required",
-					addRequiredArgsExcept(gameType, "--network", "--rollup-config=rollup.json", "--l2-genesis=genesis.json"))
-			})
-		} else if gameType == gameTypes.SuperCannonKonaGameType || gameType == gameTypes.SuperPermissionedGameType {
+		if gameType == gameTypes.SuperCannonKonaGameType || gameType == gameTypes.SuperPermissionedGameType {
 			t.Run("Required-"+gameType.String(), func(t *testing.T) {
 				verifyArgsInvalid(t,
 					"flag network or rollup-config/cannon-kona-rollup-config, l2-genesis/cannon-kona-l2-genesis and depset-config/cannon-kona-depset-config is required",
@@ -908,7 +805,7 @@ func TestRollupRpc(t *testing.T) {
 	for _, gameType := range gameTypes.SupportedGameTypes {
 		gameType := gameType
 
-		if gameType == gameTypes.SuperCannonGameType || gameType == gameTypes.SuperPermissionedGameType || gameType == gameTypes.SuperCannonKonaGameType {
+		if gameType == gameTypes.SuperPermissionedGameType || gameType == gameTypes.SuperCannonKonaGameType {
 			t.Run(fmt.Sprintf("NotRequiredFor-%v", gameType), func(t *testing.T) {
 				configForArgs(t, addRequiredArgsExcept(gameType, "--rollup-rpc"))
 			})
@@ -1091,19 +988,12 @@ func requiredArgs(gameType gameTypes.GameType) map[string]string {
 		addRequiredCannonArgs(args)
 	case gameTypes.CannonKonaGameType:
 		addRequiredCannonKonaArgs(args)
-	case gameTypes.SuperCannonGameType:
-		addRequiredSuperCannonArgs(args)
 	case gameTypes.SuperCannonKonaGameType, gameTypes.SuperPermissionedGameType:
 		addRequiredSuperCannonKonaArgs(args)
 	case gameTypes.ZKDisputeGameType, gameTypes.AlphabetGameType, gameTypes.FastGameType:
 		addRequiredOutputRootArgs(args)
 	}
 	return args
-}
-
-func addRequiredSuperCannonArgs(args map[string]string) {
-	addRequiredCannonBaseArgs(args)
-	args["--supernode-rpc"] = superRpc
 }
 
 func addRequiredCannonArgs(args map[string]string) {

--- a/op-challenger/config/config.go
+++ b/op-challenger/config/config.go
@@ -243,18 +243,6 @@ func (c Config) Check() error {
 	if c.MaxConcurrency == 0 {
 		return ErrMaxConcurrencyZero
 	}
-	if c.GameTypeEnabled(gameTypes.SuperCannonGameType) {
-		if c.SuperRPC == "" {
-			return ErrMissingSuperRpc
-		}
-
-		if len(c.Cannon.Networks) == 0 && c.Cannon.DepsetConfigPath == "" {
-			return ErrMissingDepsetConfig
-		}
-		if err := c.validateBaseCannonOptions(); err != nil {
-			return err
-		}
-	}
 	if c.GameTypeEnabled(gameTypes.CannonGameType) || c.GameTypeEnabled(gameTypes.PermissionedGameType) {
 		if c.RollupRpc == "" {
 			return ErrMissingRollupRpc

--- a/op-challenger/config/config_test.go
+++ b/op-challenger/config/config_test.go
@@ -40,14 +40,7 @@ var (
 )
 
 var singleCannonGameTypes = []gameTypes.GameType{gameTypes.CannonGameType, gameTypes.PermissionedGameType}
-var superCannonGameTypes = []gameTypes.GameType{gameTypes.SuperCannonGameType}
-var allCannonGameTypes []gameTypes.GameType
 var cannonKonaGameTypes = []gameTypes.GameType{gameTypes.CannonKonaGameType, gameTypes.SuperCannonKonaGameType, gameTypes.SuperPermissionedGameType}
-
-func init() {
-	allCannonGameTypes = append(allCannonGameTypes, singleCannonGameTypes...)
-	allCannonGameTypes = append(allCannonGameTypes, superCannonGameTypes...)
-}
 
 func ensureExists(path string) error {
 	_, err := os.Stat(path)
@@ -63,11 +56,6 @@ func ensureExists(path string) error {
 		return err
 	}
 	return file.Close()
-}
-
-func applyValidConfigForSuperCannon(t *testing.T, cfg *Config) {
-	cfg.SuperRPC = validSuperRpc
-	applyValidConfigForCannon(t, cfg)
 }
 
 func applyValidConfigForCannon(t *testing.T, cfg *Config) {
@@ -115,9 +103,6 @@ func applyValidConfigForZKDisputeGame(cfg *Config) {
 
 func validConfig(t *testing.T, gameType gameTypes.GameType) Config {
 	cfg := NewConfig(validGameFactoryAddress, validL1EthRpc, validL1BeaconUrl, validRollupRpc, validL2Rpc, validDatadir, gameType)
-	if gameType == gameTypes.SuperCannonGameType {
-		applyValidConfigForSuperCannon(t, &cfg)
-	}
 	if gameType == gameTypes.CannonGameType || gameType == gameTypes.PermissionedGameType {
 		applyValidConfigForCannon(t, &cfg)
 	}
@@ -143,7 +128,7 @@ func validConfigWithNoNetworks(t *testing.T, gameType gameTypes.GameType) Config
 		cfg.L1GenesisPath = "bar.json"
 		cfg.DepsetConfigPath = "foo.json"
 	}
-	if slices.Contains(allCannonGameTypes, gameType) {
+	if slices.Contains(singleCannonGameTypes, gameType) {
 		mutateVmConfig(&cfg.Cannon)
 	}
 	if slices.Contains(cannonKonaGameTypes, gameType) {
@@ -208,7 +193,7 @@ func TestGameAllowlistNotRequired(t *testing.T) {
 }
 
 func TestCannonRequiredArgs(t *testing.T) {
-	for _, gameType := range allCannonGameTypes {
+	for _, gameType := range singleCannonGameTypes {
 		gameType := gameType
 
 		t.Run(fmt.Sprintf("TestCannonBinRequired-%v", gameType), func(t *testing.T) {
@@ -456,18 +441,6 @@ func TestCannonKonaRequiredArgs(t *testing.T) {
 }
 
 func TestDepsetConfig(t *testing.T) {
-	for _, gameType := range superCannonGameTypes {
-		gameType := gameType
-		t.Run(fmt.Sprintf("TestCannonNetworkOrDepsetConfigRequired-%v", gameType), func(t *testing.T) {
-			cfg := validConfig(t, gameType)
-			cfg.Cannon.Networks = nil
-			cfg.Cannon.RollupConfigPaths = []string{"foo.json"}
-			cfg.Cannon.L2GenesisPaths = []string{"genesis.json"}
-			cfg.Cannon.DepsetConfigPath = ""
-			require.ErrorIs(t, cfg.Check(), ErrMissingDepsetConfig)
-		})
-	}
-
 	for _, gameType := range []gameTypes.GameType{gameTypes.SuperCannonKonaGameType, gameTypes.SuperPermissionedGameType} {
 		gameType := gameType
 		t.Run(fmt.Sprintf("TestCannonKonaNetworkOrDepsetConfigRequired-%v", gameType), func(t *testing.T) {
@@ -523,7 +496,7 @@ func TestHttpPollInterval(t *testing.T) {
 func TestRollupRpcRequired(t *testing.T) {
 	for _, gameType := range gameTypes.SupportedGameTypes {
 		gameType := gameType
-		if gameType == gameTypes.SuperCannonGameType || gameType == gameTypes.SuperPermissionedGameType || gameType == gameTypes.SuperCannonKonaGameType {
+		if gameType == gameTypes.SuperPermissionedGameType || gameType == gameTypes.SuperCannonKonaGameType {
 			continue
 		}
 		t.Run(gameType.String(), func(t *testing.T) {
@@ -535,12 +508,6 @@ func TestRollupRpcRequired(t *testing.T) {
 }
 
 func TestRollupRpcNotRequiredForInterop(t *testing.T) {
-	t.Run("SuperCannon", func(t *testing.T) {
-		config := validConfig(t, gameTypes.SuperCannonGameType)
-		config.RollupRpc = ""
-		require.NoError(t, config.Check())
-	})
-
 	t.Run("SuperPermissioned", func(t *testing.T) {
 		config := validConfig(t, gameTypes.SuperPermissionedGameType)
 		config.RollupRpc = ""
@@ -557,7 +524,7 @@ func TestRollupRpcNotRequiredForInterop(t *testing.T) {
 func TestSuperRpc(t *testing.T) {
 	for _, gameType := range gameTypes.SupportedGameTypes {
 		gameType := gameType
-		if gameType == gameTypes.SuperCannonGameType || gameType == gameTypes.SuperPermissionedGameType || gameType == gameTypes.SuperCannonKonaGameType {
+		if gameType == gameTypes.SuperPermissionedGameType || gameType == gameTypes.SuperCannonKonaGameType {
 			t.Run("RequiredFor"+gameType.String(), func(t *testing.T) {
 				config := validConfig(t, gameType)
 				config.SuperRPC = ""

--- a/op-challenger/flags/flags.go
+++ b/op-challenger/flags/flags.go
@@ -40,7 +40,6 @@ var (
 	faultDisputeVMs = []gameTypes.GameType{
 		gameTypes.CannonGameType,
 		gameTypes.CannonKonaGameType,
-		gameTypes.SuperCannonGameType,
 		gameTypes.SuperCannonKonaGameType,
 	}
 	// Required Flags
@@ -348,24 +347,6 @@ func CheckCannonBaseFlags(ctx *cli.Context) error {
 	return nil
 }
 
-func CheckSuperCannonFlags(ctx *cli.Context) error {
-	if !ctx.IsSet(SuperNodeRpcFlag.Name) {
-		return fmt.Errorf("flag %v is required", SuperNodeRpcFlag.Name)
-	}
-	if !ctx.IsSet(flags.NetworkFlagName) &&
-		!(RollupConfigFlag.IsSet(ctx, gameTypes.CannonGameType) && L2GenesisFlag.IsSet(ctx, gameTypes.CannonGameType) && DepsetConfigFlag.IsSet(ctx, gameTypes.CannonGameType)) {
-		return fmt.Errorf("flag %v or %v, %v and %v is required",
-			flags.NetworkFlagName,
-			RollupConfigFlag.EitherFlagName(gameTypes.CannonGameType),
-			L2GenesisFlag.EitherFlagName(gameTypes.CannonGameType),
-			DepsetConfigFlag.EitherFlagName(gameTypes.CannonGameType))
-	}
-	if err := CheckCannonBaseFlags(ctx); err != nil {
-		return err
-	}
-	return nil
-}
-
 func CheckSuperCannonKonaFlags(ctx *cli.Context) error {
 	if !ctx.IsSet(SuperNodeRpcFlag.Name) {
 		return fmt.Errorf("flag %v is required", SuperNodeRpcFlag.Name)
@@ -455,10 +436,6 @@ func CheckRequired(ctx *cli.Context, types []gameTypes.GameType) error {
 			}
 		case gameTypes.CannonKonaGameType:
 			if err := CheckCannonKonaFlags(ctx); err != nil {
-				return err
-			}
-		case gameTypes.SuperCannonGameType:
-			if err := CheckSuperCannonFlags(ctx); err != nil {
 				return err
 			}
 		case gameTypes.SuperCannonKonaGameType, gameTypes.SuperPermissionedGameType:

--- a/op-challenger/game/fault/contracts/detect.go
+++ b/op-challenger/game/fault/contracts/detect.go
@@ -34,7 +34,6 @@ func DetectGameType(ctx context.Context, addr common.Address, caller *batching.M
 		gameTypes.CannonKonaGameType,
 		gameTypes.AlphabetGameType,
 		gameTypes.FastGameType,
-		gameTypes.SuperCannonGameType,
 		gameTypes.SuperPermissionedGameType,
 		gameTypes.SuperCannonKonaGameType:
 		return gameType, nil

--- a/op-challenger/game/fault/contracts/detect.go
+++ b/op-challenger/game/fault/contracts/detect.go
@@ -34,6 +34,7 @@ func DetectGameType(ctx context.Context, addr common.Address, caller *batching.M
 		gameTypes.CannonKonaGameType,
 		gameTypes.AlphabetGameType,
 		gameTypes.FastGameType,
+		gameTypes.SuperCannonGameType,
 		gameTypes.SuperPermissionedGameType,
 		gameTypes.SuperCannonKonaGameType:
 		return gameType, nil

--- a/op-challenger/game/fault/contracts/disputegame.go
+++ b/op-challenger/game/fault/contracts/disputegame.go
@@ -40,7 +40,7 @@ func NewDisputeGameContractForGame(ctx context.Context, metrics metrics.Contract
 
 func NewDisputeGameContract(ctx context.Context, metrics metrics.ContractMetricer, caller *batching.MultiCaller, gameType gameTypes.GameType, addr common.Address) (DisputeGameContract, error) {
 	switch gameType {
-	case gameTypes.SuperCannonGameType, gameTypes.SuperCannonKonaGameType, gameTypes.SuperPermissionedGameType:
+	case gameTypes.SuperCannonKonaGameType, gameTypes.SuperPermissionedGameType:
 		return NewSuperFaultDisputeGameContract(ctx, metrics, addr, caller)
 
 	case gameTypes.CannonGameType,

--- a/op-challenger/game/fault/contracts/disputegame.go
+++ b/op-challenger/game/fault/contracts/disputegame.go
@@ -40,7 +40,7 @@ func NewDisputeGameContractForGame(ctx context.Context, metrics metrics.Contract
 
 func NewDisputeGameContract(ctx context.Context, metrics metrics.ContractMetricer, caller *batching.MultiCaller, gameType gameTypes.GameType, addr common.Address) (DisputeGameContract, error) {
 	switch gameType {
-	case gameTypes.SuperCannonKonaGameType, gameTypes.SuperPermissionedGameType:
+	case gameTypes.SuperCannonGameType, gameTypes.SuperCannonKonaGameType, gameTypes.SuperPermissionedGameType:
 		return NewSuperFaultDisputeGameContract(ctx, metrics, addr, caller)
 
 	case gameTypes.CannonGameType,

--- a/op-challenger/game/fault/contracts/faultdisputegame.go
+++ b/op-challenger/game/fault/contracts/faultdisputegame.go
@@ -85,7 +85,7 @@ func NewFaultDisputeGameContract(ctx context.Context, metrics metrics.ContractMe
 		return nil, fmt.Errorf("failed to detect game type: %w", err)
 	}
 	switch gameType {
-	case gameTypes.SuperCannonGameType, gameTypes.SuperCannonKonaGameType, gameTypes.SuperPermissionedGameType:
+	case gameTypes.SuperCannonKonaGameType, gameTypes.SuperPermissionedGameType:
 		return NewSuperFaultDisputeGameContract(ctx, metrics, addr, caller)
 	default:
 		return NewPreInteropFaultDisputeGameContract(ctx, metrics, addr, caller)

--- a/op-challenger/game/fault/contracts/faultdisputegame.go
+++ b/op-challenger/game/fault/contracts/faultdisputegame.go
@@ -85,7 +85,7 @@ func NewFaultDisputeGameContract(ctx context.Context, metrics metrics.ContractMe
 		return nil, fmt.Errorf("failed to detect game type: %w", err)
 	}
 	switch gameType {
-	case gameTypes.SuperCannonKonaGameType, gameTypes.SuperPermissionedGameType:
+	case gameTypes.SuperCannonGameType, gameTypes.SuperCannonKonaGameType, gameTypes.SuperPermissionedGameType:
 		return NewSuperFaultDisputeGameContract(ctx, metrics, addr, caller)
 	default:
 		return NewPreInteropFaultDisputeGameContract(ctx, metrics, addr, caller)

--- a/op-challenger/game/fault/contracts/faultdisputegame_test.go
+++ b/op-challenger/game/fault/contracts/faultdisputegame_test.go
@@ -53,17 +53,17 @@ func (c contractVersion) String() string {
 }
 
 func (c contractVersion) IsSuperGame() bool {
-	return c.gameType == gameTypes.SuperCannonGameType || c.gameType == gameTypes.SuperPermissionedGameType
+	return c.gameType == gameTypes.SuperCannonKonaGameType || c.gameType == gameTypes.SuperPermissionedGameType
 }
 
 const (
-	vers080        = "0.8.0"
-	vers0180       = "0.18.0"
-	vers111        = "1.1.1"
-	vers120        = "1.2.0"
-	vers131        = "1.3.1"
-	versLatest     = "1.4.0"
-	verSuperCannon = "0.1.0"
+	vers080            = "0.8.0"
+	vers0180           = "0.18.0"
+	vers111            = "1.1.1"
+	vers120            = "1.2.0"
+	vers131            = "1.3.1"
+	versLatest         = "1.4.0"
+	verSuperCannonKona = "0.1.0"
 )
 
 var versions = []contractVersion{
@@ -108,8 +108,8 @@ var versions = []contractVersion{
 		loadAbi:  snapshots.LoadFaultDisputeGameABI,
 	},
 	{
-		version:  verSuperCannon,
-		gameType: gameTypes.SuperCannonGameType,
+		version:  verSuperCannonKona,
+		gameType: gameTypes.SuperCannonKonaGameType,
 		loadAbi:  snapshots.LoadSuperFaultDisputeGameABI,
 	},
 }

--- a/op-challenger/game/fault/contracts/gamefactory.go
+++ b/op-challenger/game/fault/contracts/gamefactory.go
@@ -288,7 +288,7 @@ func (f *DisputeGameFactoryContract) CreateTx(ctx context.Context, gameType uint
 
 func createGameParams(gameType uint32, outputRoot common.Hash, l2BlockNum uint64, l2ChainID uint64) (common.Hash, []byte) {
 	switch gameTypes.GameType(gameType) {
-	case gameTypes.SuperCannonGameType, gameTypes.SuperCannonKonaGameType, gameTypes.SuperPermissionedGameType:
+	case gameTypes.SuperCannonKonaGameType, gameTypes.SuperPermissionedGameType:
 		extraData := encodeSuperRootProof(l2BlockNum, l2ChainID, outputRoot)
 		return crypto.Keccak256Hash(extraData), extraData
 	default:

--- a/op-challenger/game/fault/contracts/gamefactory.go
+++ b/op-challenger/game/fault/contracts/gamefactory.go
@@ -288,7 +288,7 @@ func (f *DisputeGameFactoryContract) CreateTx(ctx context.Context, gameType uint
 
 func createGameParams(gameType uint32, outputRoot common.Hash, l2BlockNum uint64, l2ChainID uint64) (common.Hash, []byte) {
 	switch gameTypes.GameType(gameType) {
-	case gameTypes.SuperCannonKonaGameType, gameTypes.SuperPermissionedGameType:
+	case gameTypes.SuperCannonGameType, gameTypes.SuperCannonKonaGameType, gameTypes.SuperPermissionedGameType:
 		extraData := encodeSuperRootProof(l2BlockNum, l2ChainID, outputRoot)
 		return crypto.Keccak256Hash(extraData), extraData
 	default:

--- a/op-challenger/game/fault/register.go
+++ b/op-challenger/game/fault/register.go
@@ -67,13 +67,6 @@ func RegisterGameTypes(
 		}
 		registerTasks = append(registerTasks, NewCannonKonaRegisterTask(gameTypes.CannonKonaGameType, cfg, m, vm.NewKonaExecutor(), l2HeaderSource, rollupClient, syncValidator))
 	}
-	if cfg.GameTypeEnabled(gameTypes.SuperCannonGameType) {
-		rootProvider, superNodeProvider, syncValidator, err := clients.SuperchainClients()
-		if err != nil {
-			return err
-		}
-		registerTasks = append(registerTasks, NewSuperCannonRegisterTask(gameTypes.SuperCannonGameType, cfg, m, vm.NewOpProgramServerExecutor(logger), rootProvider, superNodeProvider, syncValidator))
-	}
 	if cfg.GameTypeEnabled(gameTypes.SuperCannonKonaGameType) {
 		rootProvider, superNodeProvider, syncValidator, err := clients.SuperchainClients()
 		if err != nil {

--- a/op-challenger/game/fault/register_task.go
+++ b/op-challenger/game/fault/register_task.go
@@ -52,10 +52,6 @@ type RegisterTask struct {
 		poststateBlock uint64) (*trace.Accessor, error)
 }
 
-func NewSuperCannonRegisterTask(gameType gameTypes.GameType, cfg *config.Config, m caching.Metrics, serverExecutor vm.OracleServerExecutor, rootProvider *sources.SupervisorClient, superNodeProvider *sources.SuperNodeClient, syncValidator gameTypes.SyncValidator) *RegisterTask {
-	return newSuperCannonVMRegisterTaskWithConfig(gameType, cfg, m, serverExecutor, rootProvider, superNodeProvider, syncValidator, cfg.Cannon, cfg.CannonAbsolutePreStateBaseURL, cfg.CannonAbsolutePreState)
-}
-
 func NewSuperCannonKonaRegisterTask(gameType gameTypes.GameType, cfg *config.Config, m caching.Metrics, serverExecutor vm.OracleServerExecutor, rootProvider *sources.SupervisorClient, superNodeProvider *sources.SuperNodeClient, syncValidator gameTypes.SyncValidator) *RegisterTask {
 	return newSuperCannonVMRegisterTaskWithConfig(gameType, cfg, m, serverExecutor, rootProvider, superNodeProvider, syncValidator, cfg.CannonKona, cfg.CannonKonaAbsolutePreStateBaseURL, cfg.CannonKonaAbsolutePreState)
 }

--- a/op-challenger/game/fault/register_task_test.go
+++ b/op-challenger/game/fault/register_task_test.go
@@ -76,7 +76,7 @@ func TestRegisterOracle_AddsOracle(t *testing.T) {
 	}
 	for _, testCase := range tests {
 		t.Run(testCase.name, func(t *testing.T) {
-			for _, gameType := range []gameTypes.GameType{gameTypes.CannonGameType, gameTypes.SuperCannonGameType, gameTypes.SuperCannonKonaGameType} {
+			for _, gameType := range []gameTypes.GameType{gameTypes.CannonGameType, gameTypes.SuperCannonKonaGameType} {
 				t.Run(fmt.Sprintf("%v", gameType), func(t *testing.T) {
 					gameFactoryAddr := common.Address{0xaa}
 					gameImplAddr := common.Address{0xbb}
@@ -86,7 +86,7 @@ func TestRegisterOracle_AddsOracle(t *testing.T) {
 					rpc.SetResponse(gameFactoryAddr, "version", rpcblock.Latest, nil, []interface{}{testCase.version})
 					if gameType == gameTypes.CannonGameType {
 						rpc.AddContract(gameImplAddr, snapshots.LoadFaultDisputeGameABI())
-					} else if gameType == gameTypes.SuperCannonGameType || gameType == gameTypes.SuperCannonKonaGameType {
+					} else if gameType == gameTypes.SuperCannonKonaGameType {
 						rpc.AddContract(gameImplAddr, snapshots.LoadSuperFaultDisputeGameABI())
 					} else {
 						t.Fatalf("game type %v not supported", gameType)

--- a/op-challenger/game/types/game_type.go
+++ b/op-challenger/game/types/game_type.go
@@ -11,11 +11,11 @@ var ErrUnknownGameType = errors.New("unknown game type")
 type GameType uint32
 
 const (
-	CannonGameType            GameType = 0
-	PermissionedGameType      GameType = 1
-	AsteriscGameType          GameType = 2 // Not supported by op-challenger
-	AsteriscKonaGameType      GameType = 3 // Not supported by op-challenger
-	SuperCannonGameType       GameType = 4 // Not supported by op-challenger
+	CannonGameType       GameType = 0
+	PermissionedGameType GameType = 1
+	AsteriscGameType     GameType = 2 // Not supported by op-challenger
+	AsteriscKonaGameType GameType = 3 // Not supported by op-challenger
+	// GameType 4 was SuperCannonGameType — removed.
 	SuperPermissionedGameType GameType = 5
 	OPSuccinctGameType        GameType = 6 // Not supported by op-challenger
 	SuperAsteriscKonaGameType GameType = 7 // Not supported by op-challenger
@@ -79,8 +79,6 @@ func (g GameType) String() string {
 		return "asterisc"
 	case AsteriscKonaGameType:
 		return "asterisc-kona"
-	case SuperCannonGameType:
-		return "super-cannon"
 	case SuperPermissionedGameType:
 		return "super-permissioned"
 	case OPSuccinctGameType:

--- a/op-challenger/game/types/game_type.go
+++ b/op-challenger/game/types/game_type.go
@@ -15,7 +15,7 @@ const (
 	PermissionedGameType      GameType = 1
 	AsteriscGameType          GameType = 2 // Not supported by op-challenger
 	AsteriscKonaGameType      GameType = 3 // Not supported by op-challenger
-	SuperCannonGameType       GameType = 4
+	SuperCannonGameType       GameType = 4 // Not supported by op-challenger
 	SuperPermissionedGameType GameType = 5
 	OPSuccinctGameType        GameType = 6 // Not supported by op-challenger
 	SuperAsteriscKonaGameType GameType = 7 // Not supported by op-challenger
@@ -36,7 +36,6 @@ var SupportedGameTypes = []GameType{
 	CannonKonaGameType,
 	PermissionedGameType,
 	FastGameType,
-	SuperCannonGameType,
 	SuperCannonKonaGameType,
 	SuperPermissionedGameType,
 	ZKDisputeGameType,

--- a/op-challenger/game/types/game_type_test.go
+++ b/op-challenger/game/types/game_type_test.go
@@ -29,6 +29,12 @@ func TestGameTypeFromStringForAllSupportedGameTypes(t *testing.T) {
 	}
 }
 
+func TestSupportedGameTypeFromString_RejectsSuperCannon(t *testing.T) {
+	result, err := SupportedGameTypeFromString("super-cannon")
+	require.ErrorIs(t, err, ErrUnknownGameType)
+	require.Equal(t, UnknownGameType, result)
+}
+
 func TestKnownStringForAllSupportedGameTypes(t *testing.T) {
 	for _, gameType := range SupportedGameTypes {
 		t.Run(gameType.String(), func(t *testing.T) {

--- a/op-challenger/runner/factory.go
+++ b/op-challenger/runner/factory.go
@@ -33,7 +33,7 @@ func createTraceProvider(
 		return nil, err
 	}
 	switch gameType {
-	case gameTypes.CannonGameType, gameTypes.SuperCannonGameType:
+	case gameTypes.CannonGameType:
 		stateConverter := cannon.NewStateConverter(cfg.Cannon)
 		prestate, err := prestateSource.getPrestate(ctx, logger, cfg.CannonAbsolutePreStateBaseURL, cfg.CannonAbsolutePreState, dir, stateConverter)
 		if err != nil {
@@ -60,7 +60,7 @@ func createTraceProvider(
 // handles both shapes through one executor.
 func serverExecutorForGameType(logger log.Logger, gameType gameTypes.GameType) (vm.OracleServerExecutor, error) {
 	switch gameType {
-	case gameTypes.CannonGameType, gameTypes.SuperCannonGameType:
+	case gameTypes.CannonGameType:
 		return vm.NewOpProgramServerExecutor(logger), nil
 	case gameTypes.CannonKonaGameType:
 		return vm.NewKonaExecutor(), nil

--- a/op-challenger/runner/factory_test.go
+++ b/op-challenger/runner/factory_test.go
@@ -22,7 +22,6 @@ func TestServerExecutorForGameType(t *testing.T) {
 		want     vm.OracleServerExecutor
 	}{
 		{gameTypes.CannonGameType, &vm.OpProgramServerExecutor{}},
-		{gameTypes.SuperCannonGameType, &vm.OpProgramServerExecutor{}},
 		{gameTypes.CannonKonaGameType, &vm.KonaExecutor{}},
 		{gameTypes.SuperCannonKonaGameType, &vm.KonaSuperExecutor{}},
 	}

--- a/op-challenger/runner/game_inputs.go
+++ b/op-challenger/runner/game_inputs.go
@@ -30,7 +30,7 @@ const (
 
 func createGameInputs(ctx context.Context, log log.Logger, rollupClient *sources.RollupClient, superNodeClient *sources.SuperNodeClient, l1Client *ethclient.Client, typeName string, gameType gameTypes.GameType, ageGameInputs bool) (utils.LocalGameInputs, error) {
 	switch gameType {
-	case gameTypes.SuperCannonGameType, gameTypes.SuperPermissionedGameType, gameTypes.SuperCannonKonaGameType:
+	case gameTypes.SuperPermissionedGameType, gameTypes.SuperCannonKonaGameType:
 		if superNodeClient == nil {
 			return utils.LocalGameInputs{}, fmt.Errorf("game type %s requires supernode rpc to be set", gameType)
 		}

--- a/op-dispute-mon/mon/extract/caller.go
+++ b/op-dispute-mon/mon/extract/caller.go
@@ -56,7 +56,6 @@ func (g *GameCallerCreator) CreateContract(ctx context.Context, game gameTypes.G
 		gameTypes.CannonKonaGameType,
 		gameTypes.AlphabetGameType,
 		gameTypes.FastGameType,
-		gameTypes.SuperCannonGameType,
 		gameTypes.SuperPermissionedGameType,
 		gameTypes.SuperCannonKonaGameType:
 		fdg, err := contracts.NewFaultDisputeGameContract(ctx, g.m, game.Proxy, g.caller)

--- a/op-dispute-mon/mon/extract/caller_test.go
+++ b/op-dispute-mon/mon/extract/caller_test.go
@@ -47,10 +47,6 @@ func TestMetadataCreator_CreateContract(t *testing.T) {
 			game: types.GameMetadata{GameType: uint32(types.FastGameType), Proxy: fdgAddr},
 		},
 		{
-			name: "validSuperCannonGameType",
-			game: types.GameMetadata{GameType: uint32(types.SuperCannonGameType), Proxy: fdgAddr},
-		},
-		{
 			name: "validSuperPermissionedGameType",
 			game: types.GameMetadata{GameType: uint32(types.SuperPermissionedGameType), Proxy: fdgAddr},
 		},
@@ -89,7 +85,6 @@ func TestMetadataCreator_CreateContract(t *testing.T) {
 func setupMetadataLoaderTest(t *testing.T, gameType uint32) (*batching.MultiCaller, *mockCacheMetrics) {
 	fdgAbi := snapshots.LoadFaultDisputeGameABI()
 	if gameType == uint32(types.SuperPermissionedGameType) ||
-		gameType == uint32(types.SuperCannonGameType) ||
 		gameType == uint32(types.SuperCannonKonaGameType) {
 		fdgAbi = snapshots.LoadSuperFaultDisputeGameABI()
 	}

--- a/op-dispute-mon/mon/types/types.go
+++ b/op-dispute-mon/mon/types/types.go
@@ -27,7 +27,6 @@ var outputRootGameTypes = []types.GameType{
 }
 
 var superRootGameTypes = []types.GameType{
-	types.SuperCannonGameType,
 	types.SuperPermissionedGameType,
 	types.SuperAsteriscKonaGameType,
 	types.SuperCannonKonaGameType,


### PR DESCRIPTION
Removes plain super-cannon (game type 4) support from op-challenger and op-dispute-mon. SuperCannonKona (9) and SuperPermissioned (5) are unchanged.

The `SuperCannonGameType` constant is removed; a comment in its place documents that game type 4 was SuperCannonGameType and has been removed. Removed from `SupportedGameTypes`, all dispatch switches, register/register_task, flags, config validation, and tests.