### PR TITLE
op-dispute-mon: remove super-cannon (game type 4) support

### DIFF
--- a/op-challenger/game/fault/contracts/detect.go
+++ b/op-challenger/game/fault/contracts/detect.go
@@ -34,7 +34,6 @@ func DetectGameType(ctx context.Context, addr common.Address, caller *batching.M
 		gameTypes.CannonKonaGameType,
 		gameTypes.AlphabetGameType,
 		gameTypes.FastGameType,
-		gameTypes.SuperCannonGameType,
 		gameTypes.SuperPermissionedGameType,
 		gameTypes.SuperCannonKonaGameType:
 		return gameType, nil

--- a/op-challenger/game/fault/contracts/disputegame.go
+++ b/op-challenger/game/fault/contracts/disputegame.go
@@ -40,7 +40,7 @@ func NewDisputeGameContractForGame(ctx context.Context, metrics metrics.Contract
 
 func NewDisputeGameContract(ctx context.Context, metrics metrics.ContractMetricer, caller *batching.MultiCaller, gameType gameTypes.GameType, addr common.Address) (DisputeGameContract, error) {
 	switch gameType {
-	case gameTypes.SuperCannonGameType, gameTypes.SuperCannonKonaGameType, gameTypes.SuperPermissionedGameType:
+	case gameTypes.SuperCannonKonaGameType, gameTypes.SuperPermissionedGameType:
 		return NewSuperFaultDisputeGameContract(ctx, metrics, addr, caller)
 
 	case gameTypes.CannonGameType,

--- a/op-challenger/game/fault/contracts/faultdisputegame.go
+++ b/op-challenger/game/fault/contracts/faultdisputegame.go
@@ -85,7 +85,7 @@ func NewFaultDisputeGameContract(ctx context.Context, metrics metrics.ContractMe
 		return nil, fmt.Errorf("failed to detect game type: %w", err)
 	}
 	switch gameType {
-	case gameTypes.SuperCannonGameType, gameTypes.SuperCannonKonaGameType, gameTypes.SuperPermissionedGameType:
+	case gameTypes.SuperCannonKonaGameType, gameTypes.SuperPermissionedGameType:
 		return NewSuperFaultDisputeGameContract(ctx, metrics, addr, caller)
 	default:
 		return NewPreInteropFaultDisputeGameContract(ctx, metrics, addr, caller)

--- a/op-challenger/game/fault/contracts/gamefactory.go
+++ b/op-challenger/game/fault/contracts/gamefactory.go
@@ -288,7 +288,7 @@ func (f *DisputeGameFactoryContract) CreateTx(ctx context.Context, gameType uint
 
 func createGameParams(gameType uint32, outputRoot common.Hash, l2BlockNum uint64, l2ChainID uint64) (common.Hash, []byte) {
 	switch gameTypes.GameType(gameType) {
-	case gameTypes.SuperCannonGameType, gameTypes.SuperCannonKonaGameType, gameTypes.SuperPermissionedGameType:
+	case gameTypes.SuperCannonKonaGameType, gameTypes.SuperPermissionedGameType:
 		extraData := encodeSuperRootProof(l2BlockNum, l2ChainID, outputRoot)
 		return crypto.Keccak256Hash(extraData), extraData
 	default:

--- a/op-challenger/game/types/game_type.go
+++ b/op-challenger/game/types/game_type.go
@@ -15,7 +15,6 @@ const (
 	PermissionedGameType      GameType = 1
 	AsteriscGameType          GameType = 2 // Not supported by op-challenger
 	AsteriscKonaGameType      GameType = 3 // Not supported by op-challenger
-	SuperCannonGameType       GameType = 4 // Not supported by op-challenger
 	SuperPermissionedGameType GameType = 5
 	OPSuccinctGameType        GameType = 6 // Not supported by op-challenger
 	SuperAsteriscKonaGameType GameType = 7 // Not supported by op-challenger
@@ -79,8 +78,6 @@ func (g GameType) String() string {
 		return "asterisc"
 	case AsteriscKonaGameType:
 		return "asterisc-kona"
-	case SuperCannonGameType:
-		return "super-cannon"
 	case SuperPermissionedGameType:
 		return "super-permissioned"
 	case OPSuccinctGameType:

--- a/op-challenger/game/types/game_type.go
+++ b/op-challenger/game/types/game_type.go
@@ -11,10 +11,11 @@ var ErrUnknownGameType = errors.New("unknown game type")
 type GameType uint32
 
 const (
-	CannonGameType            GameType = 0
-	PermissionedGameType      GameType = 1
-	AsteriscGameType          GameType = 2 // Not supported by op-challenger
-	AsteriscKonaGameType      GameType = 3 // Not supported by op-challenger
+	CannonGameType       GameType = 0
+	PermissionedGameType GameType = 1
+	AsteriscGameType     GameType = 2 // Not supported by op-challenger
+	AsteriscKonaGameType GameType = 3 // Not supported by op-challenger
+	// GameType 4 was SuperCannonGameType — removed.
 	SuperPermissionedGameType GameType = 5
 	OPSuccinctGameType        GameType = 6 // Not supported by op-challenger
 	SuperAsteriscKonaGameType GameType = 7 // Not supported by op-challenger

--- a/op-dispute-mon/mon/extract/caller.go
+++ b/op-dispute-mon/mon/extract/caller.go
@@ -56,7 +56,6 @@ func (g *GameCallerCreator) CreateContract(ctx context.Context, game gameTypes.G
 		gameTypes.CannonKonaGameType,
 		gameTypes.AlphabetGameType,
 		gameTypes.FastGameType,
-		gameTypes.SuperCannonGameType,
 		gameTypes.SuperPermissionedGameType,
 		gameTypes.SuperCannonKonaGameType:
 		fdg, err := contracts.NewFaultDisputeGameContract(ctx, g.m, game.Proxy, g.caller)

--- a/op-dispute-mon/mon/extract/caller_test.go
+++ b/op-dispute-mon/mon/extract/caller_test.go
@@ -47,10 +47,6 @@ func TestMetadataCreator_CreateContract(t *testing.T) {
 			game: types.GameMetadata{GameType: uint32(types.FastGameType), Proxy: fdgAddr},
 		},
 		{
-			name: "validSuperCannonGameType",
-			game: types.GameMetadata{GameType: uint32(types.SuperCannonGameType), Proxy: fdgAddr},
-		},
-		{
 			name: "validSuperPermissionedGameType",
 			game: types.GameMetadata{GameType: uint32(types.SuperPermissionedGameType), Proxy: fdgAddr},
 		},
@@ -89,7 +85,6 @@ func TestMetadataCreator_CreateContract(t *testing.T) {
 func setupMetadataLoaderTest(t *testing.T, gameType uint32) (*batching.MultiCaller, *mockCacheMetrics) {
 	fdgAbi := snapshots.LoadFaultDisputeGameABI()
 	if gameType == uint32(types.SuperPermissionedGameType) ||
-		gameType == uint32(types.SuperCannonGameType) ||
 		gameType == uint32(types.SuperCannonKonaGameType) {
 		fdgAbi = snapshots.LoadSuperFaultDisputeGameABI()
 	}

--- a/op-dispute-mon/mon/types/types.go
+++ b/op-dispute-mon/mon/types/types.go
@@ -27,7 +27,6 @@ var outputRootGameTypes = []types.GameType{
 }
 
 var superRootGameTypes = []types.GameType{
-	types.SuperCannonGameType,
 	types.SuperPermissionedGameType,
 	types.SuperAsteriscKonaGameType,
 	types.SuperCannonKonaGameType,


### PR DESCRIPTION
Stacked on #20555.

Removes plain super-cannon (game type 4) support from op-dispute-mon and finishes the cleanup that #20555 deferred. After this lands, no reference to `SuperCannonGameType` or the string `"super-cannon"` remains in op-challenger or op-dispute-mon.

Changes:

- op-dispute-mon: drop the `SuperCannonGameType` case from `GameCallerCreator.CreateContract`, remove it from `superRootGameTypes`, remove the corresponding test case.
- op-challenger shared dispatchers (`game/fault/contracts/{detect,disputegame,faultdisputegame,gamefactory}.go`): remove `SuperCannonGameType` from each switch. These were left untouched in #20555 because op-dispute-mon still consumed them; with op-dispute-mon updated they can go.
- `op-challenger/game/types/game_type.go`: delete the `SuperCannonGameType` constant declaration and its `String()` case. Legacy on-chain games of type 4 now render as `<invalid: 4>`.

`SuperCannonKonaGameType` (9) and `SuperPermissionedGameType` (5) are unchanged.
