### PR TITLE
op-interop-filter: expose latest cross-unsafe block

### DIFF
--- a/op-interop-filter/filter/backend.go
+++ b/op-interop-filter/filter/backend.go
@@ -254,3 +254,29 @@ func (b *Backend) GetBlockHashByNumber(chainID eth.ChainID, blockNum rpc.BlockNu
 	}
 	return blockHash, nil
 }
+
+// GetLatestCrossUnsafeBlock returns the latest block for the given chain that has passed cross-unsafe validation.
+func (b *Backend) GetLatestCrossUnsafeBlock(chainID eth.ChainID) (eth.BlockID, error) {
+	if b.FailsafeEnabled() {
+		return eth.BlockID{}, types.ErrFailsafeEnabled
+	}
+	if !b.Ready() {
+		return eth.BlockID{}, types.ErrUninitialized
+	}
+
+	ts, ok := b.crossValidator.CrossValidatedTimestamp()
+	if !ok {
+		return eth.BlockID{}, fmt.Errorf("cross-unsafe timestamp: %w", types.ErrOutOfScope)
+	}
+
+	ingester, ok := b.chains[chainID]
+	if !ok {
+		return eth.BlockID{}, fmt.Errorf("chain %s: %w", chainID, types.ErrUnknownChain)
+	}
+
+	block, ok := ingester.BlockAtOrBeforeTimestamp(ts)
+	if !ok {
+		return eth.BlockID{}, fmt.Errorf("cross-unsafe block for chain %s at timestamp %d: %w", chainID, ts, ethereum.NotFound)
+	}
+	return block, nil
+}

--- a/op-interop-filter/filter/frontend.go
+++ b/op-interop-filter/filter/frontend.go
@@ -35,6 +35,11 @@ func (f *QueryFrontend) GetBlockHashByNumber(ctx context.Context, chainID eth.Ch
 	return f.backend.GetBlockHashByNumber(chainID, blockNum)
 }
 
+// GetLatestCrossUnsafeBlock returns the latest block that has passed cross-unsafe validation.
+func (f *QueryFrontend) GetLatestCrossUnsafeBlock(ctx context.Context, chainID eth.ChainID) (eth.BlockID, error) {
+	return f.backend.GetLatestCrossUnsafeBlock(chainID)
+}
+
 // PublicAdminFrontend exposes read-only admin methods on the public port.
 type PublicAdminFrontend struct {
 	backend *Backend

--- a/op-interop-filter/filter/interfaces.go
+++ b/op-interop-filter/filter/interfaces.go
@@ -38,6 +38,9 @@ type ChainIngester interface {
 	// BlockHashByNumber returns the hash of the ingested block at the given height.
 	BlockHashByNumber(number uint64) (common.Hash, bool)
 
+	// BlockAtOrBeforeTimestamp returns the ingested block at or before the given timestamp.
+	BlockAtOrBeforeTimestamp(timestamp uint64) (eth.BlockID, bool)
+
 	// LatestTimestamp returns the timestamp of the latest ingested block.
 	LatestTimestamp() (uint64, bool)
 

--- a/op-interop-filter/filter/logsdb_chain_ingester.go
+++ b/op-interop-filter/filter/logsdb_chain_ingester.go
@@ -268,6 +268,36 @@ func (c *LogsDBChainIngester) BlockHashByNumber(blockNum uint64) (common.Hash, b
 	return c.BlockHashAt(blockNum)
 }
 
+// BlockAtOrBeforeTimestamp returns the sealed block at or before the given timestamp.
+func (c *LogsDBChainIngester) BlockAtOrBeforeTimestamp(timestamp uint64) (eth.BlockID, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if c.logsDB == nil {
+		return eth.BlockID{}, false
+	}
+
+	blockNum, err := c.rollupCfg.TargetBlockNumber(timestamp)
+	if err != nil {
+		return eth.BlockID{}, false
+	}
+
+	latestBlock, ok := c.logsDB.LatestSealedBlock()
+	if !ok {
+		return eth.BlockID{}, false
+	}
+	if blockNum > latestBlock.Number {
+		blockNum = latestBlock.Number
+	}
+
+	seal, err := c.logsDB.FindSealedBlock(blockNum)
+	if err != nil || seal.Timestamp > timestamp {
+		return eth.BlockID{}, false
+	}
+
+	return eth.BlockID{Hash: seal.Hash, Number: seal.Number}, true
+}
+
 // LatestTimestamp returns the timestamp of the latest sealed block
 func (c *LogsDBChainIngester) LatestTimestamp() (uint64, bool) {
 	c.mu.RLock()

--- a/op-interop-filter/filter/mock_test.go
+++ b/op-interop-filter/filter/mock_test.go
@@ -27,6 +27,9 @@ type mockChainIngester struct {
 	// Blocks keyed by block number
 	blocks map[uint64]eth.BlockID
 
+	// Block timestamps keyed by block number
+	blockTimestamps map[uint64]uint64
+
 	// Executing messages with their inclusion context
 	execMsgs []IncludedMessage
 
@@ -52,10 +55,11 @@ type logKey struct {
 // newMockChainIngester creates a new in-memory chain ingester.
 func newMockChainIngester() *mockChainIngester {
 	return &mockChainIngester{
-		logs:     make(map[logKey]types.BlockSeal),
-		blocks:   make(map[uint64]eth.BlockID),
-		execMsgs: make([]IncludedMessage, 0),
-		ready:    true, // Default to ready for simple tests
+		logs:            make(map[logKey]types.BlockSeal),
+		blocks:          make(map[uint64]eth.BlockID),
+		blockTimestamps: make(map[uint64]uint64),
+		execMsgs:        make([]IncludedMessage, 0),
+		ready:           true, // Default to ready for simple tests
 	}
 }
 
@@ -78,6 +82,7 @@ func (m *mockChainIngester) AddLog(timestamp, blockNum uint64, logIdx uint32, ch
 	}
 	m.logs[key] = seal
 	m.blocks[blockNum] = eth.BlockID{Hash: seal.Hash, Number: blockNum}
+	m.blockTimestamps[blockNum] = timestamp
 
 	// Update latest block/timestamp if needed
 	if blockNum > m.latestBlock.Number {
@@ -95,6 +100,7 @@ func (m *mockChainIngester) AddExecMsg(msg IncludedMessage) {
 	defer m.mu.Unlock()
 
 	m.execMsgs = append(m.execMsgs, msg)
+	m.blockTimestamps[msg.InclusionBlockNum] = msg.InclusionTimestamp
 
 	// Update latest block/timestamp if needed
 	if msg.InclusionBlockNum > m.latestBlock.Number {
@@ -108,12 +114,19 @@ func (m *mockChainIngester) AddExecMsg(msg IncludedMessage) {
 
 // AddBlock adds a block directly to the ingester.
 func (m *mockChainIngester) AddBlock(block eth.BlockID) {
+	m.AddBlockWithTimestamp(block, 0)
+}
+
+// AddBlockWithTimestamp adds a block directly to the ingester with its timestamp.
+func (m *mockChainIngester) AddBlockWithTimestamp(block eth.BlockID, timestamp uint64) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	m.blocks[block.Number] = block
+	m.blockTimestamps[block.Number] = timestamp
 	if block.Number >= m.latestBlock.Number {
 		m.latestBlock = block
+		m.latestTimestamp = timestamp
 	}
 }
 
@@ -164,6 +177,26 @@ func (m *mockChainIngester) BlockHashByNumber(number uint64) (common.Hash, bool)
 		return common.Hash{}, false
 	}
 	return block.Hash, true
+}
+
+// BlockAtOrBeforeTimestamp implements ChainIngester.
+func (m *mockChainIngester) BlockAtOrBeforeTimestamp(timestamp uint64) (eth.BlockID, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	var result eth.BlockID
+	found := false
+	for number, block := range m.blocks {
+		ts, ok := m.blockTimestamps[number]
+		if !ok || ts > timestamp {
+			continue
+		}
+		if !found || number > result.Number {
+			result = block
+			found = true
+		}
+	}
+	return result, found
 }
 
 // LatestTimestamp implements ChainIngester.
@@ -256,10 +289,12 @@ var _ ChainIngester = (*mockChainIngester)(nil)
 
 // mockCrossValidator is a minimal mock for backend tests that don't need real validation.
 type mockCrossValidator struct {
-	validateErr error
-	errState    *ValidatorError
-	resetTs     uint64
-	resetOK     bool
+	validateErr      error
+	errState         *ValidatorError
+	crossValidatedTs uint64
+	crossValidatedOK bool
+	resetTs          uint64
+	resetOK          bool
 }
 
 func (m *mockCrossValidator) Start() error { return nil }
@@ -267,8 +302,17 @@ func (m *mockCrossValidator) Stop() error  { return nil }
 func (m *mockCrossValidator) ValidateAccessEntry(access types.Access, minSafety types.SafetyLevel, execDescriptor types.ExecutingDescriptor) error {
 	return m.validateErr
 }
-func (m *mockCrossValidator) CrossValidatedTimestamp() (uint64, bool) { return 0, false }
-func (m *mockCrossValidator) Error() *ValidatorError                  { return m.errState }
+func (m *mockCrossValidator) CrossValidatedTimestamp() (uint64, bool) {
+	return m.crossValidatedTs, m.crossValidatedOK
+}
+func (m *mockCrossValidator) Error() *ValidatorError { return m.errState }
+
+// SetCrossValidatedTimestamp sets the cross-unsafe progress for tests.
+func (m *mockCrossValidator) SetCrossValidatedTimestamp(ts uint64) {
+	m.crossValidatedTs = ts
+	m.crossValidatedOK = true
+}
+
 func (m *mockCrossValidator) ResetCrossValidatedTimestamp(timestamp uint64) {
 	m.resetTs = timestamp
 	m.resetOK = true

--- a/op-interop-filter/filter/rpc_test.go
+++ b/op-interop-filter/filter/rpc_test.go
@@ -80,3 +80,62 @@ func TestQueryFrontendGetBlockHashByNumberRPC(t *testing.T) {
 		require.ErrorContains(t, err, "unsupported block tag")
 	})
 }
+
+func TestQueryFrontendGetLatestCrossUnsafeBlockRPC(t *testing.T) {
+	logger := testlog.Logger(t, log.LevelInfo)
+	chainID := eth.ChainIDFromUInt64(testChainA)
+	mock := newMockChainIngester()
+	mock.AddBlockWithTimestamp(eth.BlockID{Hash: common.HexToHash("0x01"), Number: 100}, 1000)
+	mock.AddBlockWithTimestamp(eth.BlockID{Hash: common.HexToHash("0x02"), Number: 101}, 1002)
+	mock.AddBlockWithTimestamp(eth.BlockID{Hash: common.HexToHash("0x03"), Number: 102}, 1004)
+
+	crossValidator := &mockCrossValidator{}
+	crossValidator.SetCrossValidatedTimestamp(1003)
+
+	backend := NewBackend(context.Background(), BackendParams{
+		Logger:         logger,
+		Metrics:        metrics.NoopMetrics,
+		Chains:         map[eth.ChainID]ChainIngester{chainID: mock},
+		CrossValidator: crossValidator,
+	})
+
+	server := oprpc.NewServer(
+		"127.0.0.1",
+		0,
+		"test",
+		oprpc.WithLogger(logger),
+	)
+	server.AddAPI(rpc.API{
+		Namespace: "supervisor",
+		Service:   &QueryFrontend{backend: backend},
+	})
+
+	require.NoError(t, server.Start())
+	t.Cleanup(func() {
+		_ = server.Stop()
+	})
+
+	client, err := rpc.Dial("http://" + server.Endpoint())
+	require.NoError(t, err)
+	t.Cleanup(client.Close)
+
+	t.Run("returns latest block at or before cross-unsafe timestamp", func(t *testing.T) {
+		var result eth.BlockID
+		err := client.Call(&result, "supervisor_getLatestCrossUnsafeBlock", chainID)
+		require.NoError(t, err)
+		require.Equal(t, eth.BlockID{Hash: common.HexToHash("0x02"), Number: 101}, result)
+	})
+
+	t.Run("unknown chain", func(t *testing.T) {
+		var result eth.BlockID
+		err := client.Call(&result, "supervisor_getLatestCrossUnsafeBlock", eth.ChainIDFromUInt64(999))
+		require.ErrorContains(t, err, "unknown chain")
+	})
+
+	t.Run("cross-unsafe timestamp unavailable", func(t *testing.T) {
+		backend.crossValidator = &mockCrossValidator{}
+		var result eth.BlockID
+		err := client.Call(&result, "supervisor_getLatestCrossUnsafeBlock", chainID)
+		require.ErrorContains(t, err, "out of scope")
+	})
+}


### PR DESCRIPTION
## Summary

Adds a `supervisor_getLatestCrossUnsafeBlock(chainID)` RPC to op-interop-filter. The endpoint maps the filter's cross-unsafe validated timestamp to the latest ingested block at or before that timestamp and returns an `eth.BlockID` with hash and number.

## Motivation

proxyd needs a block number to cap `latest` responses to blocks that have passed interop-filter cross-unsafe validation. The existing `supervisor_getBlockHashByNumber(chainID, "latest")` endpoint exposes latest ingested data, which has different semantics.

## Validation

- `go test ./op-interop-filter/filter`