### PR TITLE
op-supernode: store verified superroot records

### DIFF
--- a/op-supernode/supernode/activity/interop/checker.go
+++ b/op-supernode/supernode/activity/interop/checker.go
@@ -4,11 +4,14 @@ import (
 	"context"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/common"
 )
 
-// l1ByNumberSource provides L1 block lookups by number for consistency checking.
-type l1ByNumberSource interface {
+// l1Source provides L1 block lookups for consistency checking and CurrentL1
+// claim construction.
+type l1Source interface {
 	L1BlockRefByNumber(ctx context.Context, num uint64) (eth.L1BlockRef, error)
+	InfoByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, error)
 }
 
 // l1ConsistencyChecker verifies that a set of L1 block IDs all belong to
@@ -18,12 +21,12 @@ type l1ConsistencyChecker interface {
 }
 
 // l1ByNumberChecker is the production l1ConsistencyChecker: it checks each
-// head against the canonical L1 chain fetched from an l1ByNumberSource.
+// head against the canonical L1 chain fetched from an l1Source.
 type l1ByNumberChecker struct {
-	l1 l1ByNumberSource
+	l1 l1Source
 }
 
-func newL1ConsistencyChecker(l1 l1ByNumberSource) l1ConsistencyChecker {
+func newL1ConsistencyChecker(l1 l1Source) l1ConsistencyChecker {
 	if l1 == nil {
 		return nil
 	}

--- a/op-supernode/supernode/activity/interop/checker_test.go
+++ b/op-supernode/supernode/activity/interop/checker_test.go
@@ -22,6 +22,20 @@ func (m *mockL1Source) L1BlockRefByNumber(ctx context.Context, num uint64) (eth.
 	return ref, nil
 }
 
+func (m *mockL1Source) InfoByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, error) {
+	for _, ref := range m.blocks {
+		if ref.Hash == hash {
+			return &mockBlockInfo{
+				hash:       ref.Hash,
+				parentHash: ref.ParentHash,
+				number:     ref.Number,
+				timestamp:  ref.Time,
+			}, nil
+		}
+	}
+	return nil, fmt.Errorf("block %s not found", hash)
+}
+
 // noopL1Checker treats every set of heads as canonical. Intended for tests that
 // do not exercise L1 consistency — production must always use the real checker.
 type noopL1Checker struct{}

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -156,6 +156,7 @@ type Interop struct {
 	started bool
 
 	currentL1 eth.BlockID
+	l1Source  l1Source
 
 	// l1Heads is the snapshot captured with blocksAtTimestamp in observeRound; passing
 	// it through avoids a TOCTOU race against L2 reorgs.
@@ -220,7 +221,7 @@ func New(
 	messageExpiryWindow uint64,
 	chains map[eth.ChainID]cc.InteropChain,
 	dataDir string,
-	l1Source l1ByNumberSource,
+	l1Source l1Source,
 	logBackfillDepth time.Duration,
 	metrics *resources.SupernodeMetrics,
 ) *Interop {
@@ -260,8 +261,14 @@ func New(
 		dataDir:             dataDir,
 		activationTimestamp: activationTimestamp,
 		messageExpiryWindow: messageExpiryWindow,
+		l1Source:            l1Source,
 		logBackfillDepth:    logBackfillDepth,
 		metrics:             metrics,
+	}
+	if currentL1, found, err := verifiedDB.CurrentL1(); err != nil {
+		log.Warn("failed to load durable interop CurrentL1", "err", err)
+	} else if found {
+		i.currentL1 = currentL1
 	}
 	// default to using the verifyInteropMessages function
 	// (can be overridden by tests)
@@ -473,10 +480,7 @@ func (i *Interop) refreshCurrentL1OnWait() (bool, error) {
 		i.log.Debug("failed to collect current L1 on wait", "err", err)
 		return false, nil
 	}
-	i.mu.Lock()
-	i.currentL1 = localL1
-	i.mu.Unlock()
-	return false, nil
+	return false, i.updateCurrentL1(localL1)
 }
 
 // progressInterop prepares the next interop action by observing the world,
@@ -612,7 +616,26 @@ func (i *Interop) newInvalidHead(chainID eth.ChainID, blockID eth.BlockID) (Inva
 
 func (i *Interop) buildPendingTransition(output StepOutput, obs RoundObservation) (PendingTransition, error) {
 	switch output.Decision {
-	case DecisionAdvance, DecisionInvalidate:
+	case DecisionAdvance:
+		result := output.Result
+		currentL1, err := i.claimableCurrentL1(result.L1Inclusion)
+		if err != nil {
+			return PendingTransition{}, fmt.Errorf("resolve claimable current L1: %w", err)
+		}
+		if localL1, err := i.collectCurrentL1(); err != nil {
+			i.log.Warn("failed to collect node CurrentL1 on advance, using claimable L1Inclusion parent", "err", err)
+		} else if localL1.Number < currentL1.Number {
+			currentL1 = localL1
+		}
+		record, err := i.buildVerifiedRecord(result, currentL1)
+		if err != nil {
+			return PendingTransition{}, fmt.Errorf("build verified record: %w", err)
+		}
+		return PendingTransition{
+			Decision: DecisionAdvance,
+			Verified: &record,
+		}, nil
+	case DecisionInvalidate:
 		result := output.Result
 		return PendingTransition{
 			Decision: output.Decision,
@@ -638,9 +661,9 @@ func (i *Interop) applyPendingTransition(pending PendingTransition) (bool, error
 		if pending.Rewind == nil {
 			return false, fmt.Errorf("invalid pending rewind transition: missing rewind plan")
 		}
-		i.mu.Lock()
-		i.currentL1 = eth.BlockID{}
-		i.mu.Unlock()
+		if err := i.updateCurrentL1(eth.BlockID{}); err != nil {
+			return false, fmt.Errorf("reset current L1 before rewind: %w", err)
+		}
 		if err := i.applyRewindPlan(*pending.Rewind); err != nil {
 			return false, fmt.Errorf("apply rewind plan: %w", err)
 		}
@@ -710,39 +733,28 @@ func (i *Interop) applyPendingTransition(pending PendingTransition) (bool, error
 		return false, nil
 
 	case DecisionAdvance:
-		if pending.Result == nil {
+		if pending.Verified == nil {
 			if err := i.verifiedDB.ClearPendingTransition(); err != nil {
 				return false, fmt.Errorf("clear empty advance transition: %w", err)
 			}
 			return false, nil
 		}
-		if err := i.persistFrontierLogs(pending.Result.Timestamp, pending.Result.L2Heads); err != nil {
+		record := *pending.Verified
+		if err := i.persistFrontierLogs(record.Timestamp, record.L2Heads); err != nil {
 			return false, fmt.Errorf("persist frontier logs: %w", err)
 		}
 
-		if err := i.commitVerifiedResult(pending.Result.Timestamp, pending.Result.ToVerifiedResult()); err != nil {
-			return false, fmt.Errorf("commit verified result: %w", err)
+		if err := i.verifiedDB.CommitRecord(record); err != nil {
+			return false, fmt.Errorf("commit verified record: %w", err)
 		}
 		if err := i.verifiedDB.ClearPendingTransition(); err != nil {
 			return false, fmt.Errorf("clear pending transition: %w", err)
 		}
-		i.log.Info("committed verified result", "timestamp", pending.Result.Timestamp)
+		i.log.Info("committed verified result", "timestamp", record.Timestamp)
 		i.metrics.InteropTimestampsVerified.Inc()
-		i.metrics.InteropVerifiedTimestamp.Set(float64(pending.Result.Timestamp))
-		// L1Inclusion is the max L1 block used for derivation across all chains at this
-		// timestamp. It can exceed some chains' actual CurrentL1 — e.g. chain A derived
-		// from L1 1000 while chain B derived from L1 990. Chain B may then advance to
-		// the next timestamp (finding its batch at L1 995) without ever reaching L1 1000.
-		// Cap at the min of all nodes' CurrentL1 so this field is individually safe, not
-		// just safe when aggregated with chain CurrentL1s via syncstatus.Aggregate.
-		currentL1 := pending.Result.L1Inclusion
-		if localL1, err := i.collectCurrentL1(); err != nil {
-			i.log.Warn("failed to collect node CurrentL1 on advance, using L1Inclusion", "err", err)
-		} else if localL1.Number < currentL1.Number {
-			currentL1 = localL1
-		}
+		i.metrics.InteropVerifiedTimestamp.Set(float64(record.Timestamp))
 		i.mu.Lock()
-		i.currentL1 = currentL1
+		i.currentL1 = record.CurrentL1
 		i.mu.Unlock()
 		return true, nil
 	}
@@ -878,6 +890,81 @@ func (i *Interop) resetChainEnginesIfNeeded(plan RewindPlan, sortedChainIDs []et
 	}
 }
 
+// claimableCurrentL1 returns the highest L1 block the verifier can safely
+// report as fully processed after producing a result included in l1Inclusion.
+// The inclusion block itself may contain additional batch data for later
+// verification rounds, so the claimable block is its parent.
+func (i *Interop) claimableCurrentL1(l1Inclusion eth.BlockID) (eth.BlockID, error) {
+	if l1Inclusion == (eth.BlockID{}) || l1Inclusion.Number == 0 {
+		return l1Inclusion, nil
+	}
+	if i.l1Source == nil {
+		// Tests may construct Interop without an L1 client. Production New always
+		// receives the L1 client and uses the hash-based lookup below.
+		return eth.BlockID{Number: l1Inclusion.Number - 1}, nil
+	}
+	ctx := i.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	info, err := i.l1Source.InfoByHash(ctx, l1Inclusion.Hash)
+	if err != nil {
+		return eth.BlockID{}, err
+	}
+	return eth.BlockID{
+		Hash:   info.ParentHash(),
+		Number: l1Inclusion.Number - 1,
+	}, nil
+}
+
+func (i *Interop) updateCurrentL1(currentL1 eth.BlockID) error {
+	if err := i.verifiedDB.SetCurrentL1(currentL1); err != nil {
+		return err
+	}
+	i.mu.Lock()
+	i.currentL1 = currentL1
+	i.mu.Unlock()
+	return nil
+}
+
+func (i *Interop) buildVerifiedRecord(result Result, currentL1 eth.BlockID) (VerifiedRecord, error) {
+	chainIDs := make([]eth.ChainID, 0, len(result.L2Heads))
+	for chainID := range result.L2Heads {
+		chainIDs = append(chainIDs, chainID)
+	}
+	sort.Slice(chainIDs, func(i, j int) bool {
+		return chainIDs[i].Cmp(chainIDs[j]) < 0
+	})
+
+	chainOutputs := make([]eth.ChainIDAndOutput, 0, len(chainIDs))
+	for _, chainID := range chainIDs {
+		blockID := result.L2Heads[chainID]
+		chain, ok := i.chains[chainID]
+		if !ok {
+			return VerifiedRecord{}, fmt.Errorf("chain %s not found", chainID)
+		}
+		outputV0, err := chain.OutputV0AtBlockNumber(i.ctx, blockID.Number)
+		if err != nil {
+			return VerifiedRecord{}, fmt.Errorf("chain %s: failed to compute OutputV0 for block %d: %w", chainID, blockID.Number, err)
+		}
+		if outputV0.BlockHash != blockID.Hash {
+			return VerifiedRecord{}, fmt.Errorf("chain %s: block %d hash changed (expected %s, got %s): possible reorg",
+				chainID, blockID.Number, blockID.Hash, outputV0.BlockHash)
+		}
+		chainOutputs = append(chainOutputs, eth.ChainIDAndOutput{
+			ChainID: chainID,
+			Output:  eth.OutputRoot(outputV0),
+		})
+	}
+	return VerifiedRecord{
+		Timestamp:    result.Timestamp,
+		L1Inclusion:  result.L1Inclusion,
+		L2Heads:      result.L2Heads,
+		ChainOutputs: chainOutputs,
+		CurrentL1:    currentL1,
+	}, nil
+}
+
 // collectCurrentL1 collects the current L1 head of all chains,
 // which is the minimum L1 head of all the derivation pipelines in Chain Containers
 func (i *Interop) collectCurrentL1() (eth.BlockID, error) {
@@ -949,10 +1036,6 @@ func (i *Interop) checkChainsReady(ts uint64) (chainsReadyResult, error) {
 	return ready, nil
 }
 
-func (i *Interop) commitVerifiedResult(timestamp uint64, verifiedResult VerifiedResult) error {
-	return i.verifiedDB.Commit(verifiedResult)
-}
-
 // CurrentL1 returns the L1 block which has been fully considered for interop,
 // whether or not it advanced the verified timestamp.
 func (i *Interop) CurrentL1() eth.BlockID {
@@ -976,6 +1059,21 @@ func (i *Interop) VerifiedAtTimestamp(ts uint64) (bool, error) {
 		return true, nil
 	}
 	return i.verifiedDB.Has(ts)
+}
+
+// StoredSuperRootAtTimestamp returns the verifier's durable superroot response.
+func (i *Interop) StoredSuperRootAtTimestamp(ts uint64) (data *eth.SuperRootResponseData, found bool, err error) {
+	if ts < i.activationTimestamp {
+		return nil, false, nil
+	}
+	record, err := i.verifiedDB.GetRecord(ts)
+	if err == nil {
+		return record.ResponseData(), true, nil
+	}
+	if !errors.Is(err, ErrNotFound) {
+		return nil, false, err
+	}
+	return nil, false, nil
 }
 
 // IsActiveAt reports whether the interop verifier is responsible for verifying

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -1073,7 +1073,7 @@ func TestFirstVerifiableTimestampRestoresSafeHeadHandoffAfterRestart(t *testing.
 	dataDir := t.TempDir()
 	db, err := OpenVerifiedDB(dataDir)
 	require.NoError(t, err)
-	require.NoError(t, db.Commit(VerifiedResult{
+	require.NoError(t, commitVerifiedResult(db, VerifiedResult{
 		Timestamp:   126,
 		L1Inclusion: eth.BlockID{Number: 1, Hash: common.HexToHash("0x1")},
 		L2Heads:     map[eth.ChainID]eth.BlockID{eth.ChainIDFromUInt64(10): {Number: 126, Hash: common.HexToHash("0x2")}},
@@ -1176,7 +1176,7 @@ func TestApplyResultCompat(t *testing.T) {
 					Timestamp:   1001,
 					L1Inclusion: eth.BlockID{Number: 100, Hash: common.HexToHash("0xL1")},
 					L2Heads: map[eth.ChainID]eth.BlockID{
-						mock.id: {Number: 500, Hash: common.HexToHash("0xL2")},
+						mock.id: {Number: 500, Hash: common.BigToHash(big.NewInt(500))},
 					},
 				}
 
@@ -1373,7 +1373,7 @@ func TestProgressAndRecord(t *testing.T) {
 			},
 		},
 		{
-			name: "valid result sets L1 to result L1Head",
+			name: "valid result uses parent of L1Inclusion as claimable CurrentL1",
 			setup: func(h *interopTestHarness) *interopTestHarness {
 				return h.WithChain(10, func(m *mockChainContainer) {
 					m.currentL1 = eth.BlockRef{Number: 200, Hash: common.HexToHash("0x200")}
@@ -1390,8 +1390,8 @@ func TestProgressAndRecord(t *testing.T) {
 				require.NoError(t, err)
 				require.True(t, madeProgress, "valid result should advance verified timestamp")
 
-				require.Equal(t, expectedL1Inclusion.Number, h.interop.currentL1.Number)
-				require.Equal(t, expectedL1Inclusion.Hash, h.interop.currentL1.Hash)
+				require.Equal(t, expectedL1Inclusion.Number-1, h.interop.currentL1.Number)
+				require.Equal(t, common.Hash{}, h.interop.currentL1.Hash)
 			},
 		},
 		{
@@ -2122,12 +2122,12 @@ func TestPendingTransition_RecoverRewindPreservedOnFailure(t *testing.T) {
 
 	mock := h.Mock(10)
 
-	require.NoError(t, h.interop.verifiedDB.Commit(VerifiedResult{
+	require.NoError(t, commitVerifiedResult(h.interop.verifiedDB, VerifiedResult{
 		Timestamp:   1000,
 		L1Inclusion: eth.BlockID{Number: 50, Hash: common.HexToHash("0xL1a")},
 		L2Heads:     map[eth.ChainID]eth.BlockID{mock.id: {Number: 100, Hash: common.HexToHash("0x1")}},
 	}))
-	require.NoError(t, h.interop.verifiedDB.Commit(VerifiedResult{
+	require.NoError(t, commitVerifiedResult(h.interop.verifiedDB, VerifiedResult{
 		Timestamp:   1001,
 		L1Inclusion: eth.BlockID{Number: 51, Hash: common.HexToHash("0xL1b")},
 		L2Heads:     map[eth.ChainID]eth.BlockID{mock.id: {Number: 101, Hash: common.HexToHash("0x2")}},
@@ -2170,7 +2170,7 @@ func TestPendingTransition_RewindReplaysAfterFailure(t *testing.T) {
 	mockA := h.Mock(10)
 	mockB := h.Mock(8453)
 
-	require.NoError(t, h.interop.verifiedDB.Commit(VerifiedResult{
+	require.NoError(t, commitVerifiedResult(h.interop.verifiedDB, VerifiedResult{
 		Timestamp:   1000,
 		L1Inclusion: eth.BlockID{Number: 50, Hash: common.HexToHash("0xL1a")},
 		L2Heads: map[eth.ChainID]eth.BlockID{
@@ -2178,7 +2178,7 @@ func TestPendingTransition_RewindReplaysAfterFailure(t *testing.T) {
 			mockB.id: {Number: 200, Hash: common.HexToHash("0xb1")},
 		},
 	}))
-	require.NoError(t, h.interop.verifiedDB.Commit(VerifiedResult{
+	require.NoError(t, commitVerifiedResult(h.interop.verifiedDB, VerifiedResult{
 		Timestamp:   1001,
 		L1Inclusion: eth.BlockID{Number: 51, Hash: common.HexToHash("0xL1b")},
 		L2Heads: map[eth.ChainID]eth.BlockID{
@@ -2237,7 +2237,7 @@ func TestPendingTransition_RecoverRewindReportsAllFailures(t *testing.T) {
 	mockA := h.Mock(10)
 	mockB := h.Mock(8453)
 
-	require.NoError(t, h.interop.verifiedDB.Commit(VerifiedResult{
+	require.NoError(t, commitVerifiedResult(h.interop.verifiedDB, VerifiedResult{
 		Timestamp:   1000,
 		L1Inclusion: eth.BlockID{Number: 50, Hash: common.HexToHash("0xL1a")},
 		L2Heads: map[eth.ChainID]eth.BlockID{
@@ -2245,7 +2245,7 @@ func TestPendingTransition_RecoverRewindReportsAllFailures(t *testing.T) {
 			mockB.id: {Number: 200, Hash: common.HexToHash("0x2")},
 		},
 	}))
-	require.NoError(t, h.interop.verifiedDB.Commit(VerifiedResult{
+	require.NoError(t, commitVerifiedResult(h.interop.verifiedDB, VerifiedResult{
 		Timestamp:   1001,
 		L1Inclusion: eth.BlockID{Number: 51, Hash: common.HexToHash("0xL1b")},
 		L2Heads: map[eth.ChainID]eth.BlockID{
@@ -2277,15 +2277,17 @@ func TestPendingTransition_RecoverAdvanceAfterCommitClearsPendingTransition(t *t
 		Timestamp:   1000,
 		L1Inclusion: eth.BlockID{Hash: common.HexToHash("0xL1"), Number: 100},
 		L2Heads: map[eth.ChainID]eth.BlockID{
-			mock.id: {Hash: common.HexToHash("0xaaa"), Number: 500},
+			mock.id: {Hash: common.BigToHash(big.NewInt(500)), Number: 500},
 		},
 	}
 
+	record, err := h.interop.buildVerifiedRecord(result, eth.BlockID{})
+	require.NoError(t, err)
 	require.NoError(t, h.interop.verifiedDB.SetPendingTransition(PendingTransition{
 		Decision: DecisionAdvance,
-		Result:   &result,
+		Verified: &record,
 	}))
-	require.NoError(t, h.interop.verifiedDB.Commit(result.ToVerifiedResult()))
+	require.NoError(t, h.interop.verifiedDB.CommitRecord(record))
 
 	madeProgress, err := h.interop.progressAndRecord()
 	require.NoError(t, err)
@@ -2312,7 +2314,7 @@ func TestL1CanonicalityCheckErrorPropagates(t *testing.T) {
 	mock := h.Mock(10)
 
 	// Commit a verified result so observeRound has a LastVerified to check
-	err := h.interop.verifiedDB.Commit(VerifiedResult{
+	err := commitVerifiedResult(h.interop.verifiedDB, VerifiedResult{
 		Timestamp:   1000,
 		L1Inclusion: eth.BlockID{Number: 50, Hash: common.HexToHash("0xL1")},
 		L2Heads:     map[eth.ChainID]eth.BlockID{mock.id: {Number: 100, Hash: common.HexToHash("0x1")}},
@@ -2351,13 +2353,13 @@ func TestRewindAccepted(t *testing.T) {
 		}
 
 		// Commit two verified results: T=1000 and T=1001
-		err := h.interop.verifiedDB.Commit(VerifiedResult{
+		err := commitVerifiedResult(h.interop.verifiedDB, VerifiedResult{
 			Timestamp:   1000,
 			L1Inclusion: eth.BlockID{Number: 50, Hash: common.HexToHash("0xL1a")},
 			L2Heads:     map[eth.ChainID]eth.BlockID{chainID: {Number: 100, Hash: common.HexToHash("0x1")}},
 		})
 		require.NoError(t, err)
-		err = h.interop.verifiedDB.Commit(VerifiedResult{
+		err = commitVerifiedResult(h.interop.verifiedDB, VerifiedResult{
 			Timestamp:   1001,
 			L1Inclusion: eth.BlockID{Number: 51, Hash: common.HexToHash("0xL1b")},
 			L2Heads:     map[eth.ChainID]eth.BlockID{chainID: {Number: 101, Hash: common.HexToHash("0x2")}},
@@ -2406,7 +2408,7 @@ func TestRewindAccepted(t *testing.T) {
 		mockA := h.Mock(10)
 		mockB := h.Mock(8453)
 
-		require.NoError(t, h.interop.verifiedDB.Commit(VerifiedResult{
+		require.NoError(t, commitVerifiedResult(h.interop.verifiedDB, VerifiedResult{
 			Timestamp:   1000,
 			L1Inclusion: eth.BlockID{Number: 50, Hash: common.HexToHash("0xL1a")},
 			L2Heads: map[eth.ChainID]eth.BlockID{
@@ -2414,7 +2416,7 @@ func TestRewindAccepted(t *testing.T) {
 				mockB.id: {Number: 200, Hash: common.HexToHash("0xb1")},
 			},
 		}))
-		require.NoError(t, h.interop.verifiedDB.Commit(VerifiedResult{
+		require.NoError(t, commitVerifiedResult(h.interop.verifiedDB, VerifiedResult{
 			Timestamp:   1001,
 			L1Inclusion: eth.BlockID{Number: 51, Hash: common.HexToHash("0xL1b")},
 			L2Heads: map[eth.ChainID]eth.BlockID{
@@ -2444,12 +2446,12 @@ func TestRewindAccepted(t *testing.T) {
 			Build()
 
 		mock := h.Mock(10)
-		require.NoError(t, h.interop.verifiedDB.Commit(VerifiedResult{
+		require.NoError(t, commitVerifiedResult(h.interop.verifiedDB, VerifiedResult{
 			Timestamp:   1000,
 			L1Inclusion: eth.BlockID{Number: 50, Hash: common.HexToHash("0xL1a")},
 			L2Heads:     map[eth.ChainID]eth.BlockID{mock.id: {Number: 100, Hash: common.HexToHash("0xa1")}},
 		}))
-		require.NoError(t, h.interop.verifiedDB.Commit(VerifiedResult{
+		require.NoError(t, commitVerifiedResult(h.interop.verifiedDB, VerifiedResult{
 			Timestamp:   1001,
 			L1Inclusion: eth.BlockID{Number: 51, Hash: common.HexToHash("0xL1b")},
 			L2Heads:     map[eth.ChainID]eth.BlockID{mock.id: {Number: 101, Hash: common.HexToHash("0xa2")}},
@@ -2468,7 +2470,7 @@ func TestRewindAccepted(t *testing.T) {
 		chainID := h.Mock(10).id
 
 		// Commit one result at activation timestamp
-		err := h.interop.verifiedDB.Commit(VerifiedResult{
+		err := commitVerifiedResult(h.interop.verifiedDB, VerifiedResult{
 			Timestamp:   1000,
 			L1Inclusion: eth.BlockID{Number: 50},
 			L2Heads:     map[eth.ChainID]eth.BlockID{chainID: {Number: 100}},
@@ -2537,7 +2539,7 @@ func (m *mockLogsDBWithState) Close() error { return nil }
 
 var _ LogsDB = (*mockLogsDBWithState)(nil)
 
-// errorL1Source implements l1ByNumberSource and always returns an error.
+// errorL1Source implements l1Source and always returns an error.
 // This is separate from mockL1Source in checker_test.go which uses a map lookup.
 type errorL1Source struct {
 	err error
@@ -2545,6 +2547,10 @@ type errorL1Source struct {
 
 func (m *errorL1Source) L1BlockRefByNumber(ctx context.Context, num uint64) (eth.L1BlockRef, error) {
 	return eth.L1BlockRef{}, m.err
+}
+
+func (m *errorL1Source) InfoByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, error) {
+	return nil, m.err
 }
 
 // progressInteropCompat replicates the old progressInterop() behavior for test compatibility.
@@ -2669,7 +2675,7 @@ func TestResetIsNoOp(t *testing.T) {
 		Build()
 
 	mock := h.Mock(10)
-	err := h.interop.verifiedDB.Commit(VerifiedResult{
+	err := commitVerifiedResult(h.interop.verifiedDB, VerifiedResult{
 		Timestamp:   1000,
 		L1Inclusion: eth.BlockID{Number: 50},
 		L2Heads:     map[eth.ChainID]eth.BlockID{mock.id: {Number: 100}},
@@ -2705,7 +2711,7 @@ func TestVerifiedBlockAtL1(t *testing.T) {
 
 		// Commit some verified results so the DB is non-empty
 		for ts := uint64(100); ts <= 110; ts++ {
-			err := h.interop.verifiedDB.Commit(VerifiedResult{
+			err := commitVerifiedResult(h.interop.verifiedDB, VerifiedResult{
 				Timestamp:   ts,
 				L1Inclusion: eth.BlockID{Number: ts + 1000},
 				L2Heads:     map[eth.ChainID]eth.BlockID{h.Mock(10).id: {Number: ts}},
@@ -2733,7 +2739,7 @@ func TestVerifiedBlockAtL1(t *testing.T) {
 			if ts == 1005 {
 				l2Head = expectedL2
 			}
-			err := h.interop.verifiedDB.Commit(VerifiedResult{
+			err := commitVerifiedResult(h.interop.verifiedDB, VerifiedResult{
 				Timestamp:   ts,
 				L1Inclusion: eth.BlockID{Number: ts * 10}, // L1 inclusion grows with timestamp
 				L2Heads:     map[eth.ChainID]eth.BlockID{chainID: l2Head},

--- a/op-supernode/supernode/activity/interop/types.go
+++ b/op-supernode/supernode/activity/interop/types.go
@@ -13,6 +13,33 @@ type VerifiedResult struct {
 	L2Heads     map[eth.ChainID]eth.BlockID `json:"l2Heads"`
 }
 
+// VerifiedRecord is the durable verifier snapshot at a timestamp.
+// It stores only source facts; ResponseData derives the redundant RPC fields.
+type VerifiedRecord struct {
+	Timestamp    uint64                      `json:"timestamp"`
+	L1Inclusion  eth.BlockID                 `json:"l1Inclusion"`
+	L2Heads      map[eth.ChainID]eth.BlockID `json:"l2Heads"`
+	ChainOutputs []eth.ChainIDAndOutput      `json:"chainOutputs"`
+	CurrentL1    eth.BlockID                 `json:"currentL1"`
+}
+
+func (r VerifiedRecord) ToVerifiedResult() VerifiedResult {
+	return VerifiedResult{
+		Timestamp:   r.Timestamp,
+		L1Inclusion: r.L1Inclusion,
+		L2Heads:     r.L2Heads,
+	}
+}
+
+func (r VerifiedRecord) ResponseData() *eth.SuperRootResponseData {
+	super := eth.NewSuperV1(r.Timestamp, r.ChainOutputs...)
+	return &eth.SuperRootResponseData{
+		VerifiedRequiredL1: r.L1Inclusion,
+		Super:              super,
+		SuperRoot:          eth.SuperRoot(super),
+	}
+}
+
 // InvalidHead pairs a block identifier with the output preimage fields needed
 // for optimistic root computation in the superroot API. The full OutputV0 can
 // be reconstructed on demand via OutputV0() since BlockHash is already in BlockID.
@@ -34,14 +61,12 @@ type Result struct {
 // PendingTransition is the generic write-ahead-log entry for an effectful
 // interop decision. Recovery and steady-state both use the same apply path.
 //
-// Phase 2 keeps this intentionally small:
-// - advance/invalidate carry their Result directly
-// - rewind carries the accepted frontier to rewind from
-// Later phases can expand this into a richer explicit transition plan.
+// DecisionAdvance uses Verified, DecisionInvalidate uses Result, and DecisionRewind uses Rewind.
 type PendingTransition struct {
-	Decision Decision    `json:"decision"`
-	Result   *Result     `json:"result,omitempty"`
-	Rewind   *RewindPlan `json:"rewind,omitempty"`
+	Decision Decision        `json:"decision"`
+	Result   *Result         `json:"result,omitempty"`
+	Verified *VerifiedRecord `json:"verified,omitempty"`
+	Rewind   *RewindPlan     `json:"rewind,omitempty"`
 }
 
 // RewindPlan is the explicit rewind transition persisted in the WAL.

--- a/op-supernode/supernode/activity/interop/verified_db.go
+++ b/op-supernode/supernode/activity/interop/verified_db.go
@@ -25,8 +25,11 @@ var (
 	u64Len              = 8
 )
 
-// bucketName is the name of the bbolt bucket used to store verified results.
+// bucketName is the name of the bbolt bucket used to store verified records.
 var bucketName = []byte("verified")
+
+var frontierBucketName = []byte("frontier")
+var currentL1Key = []byte("current_l1")
 
 var pendingTransitionBucketName = []byte("pending_transition")
 var pendingTransitionKey = []byte("pending")
@@ -60,6 +63,9 @@ func OpenVerifiedDB(dataDir string) (*VerifiedDB, error) {
 	// Ensure the buckets exist
 	err = db.Update(func(tx *bolt.Tx) error {
 		if _, err := tx.CreateBucketIfNotExists(bucketName); err != nil {
+			return err
+		}
+		if _, err := tx.CreateBucketIfNotExists(frontierBucketName); err != nil {
 			return err
 		}
 		_, err := tx.CreateBucketIfNotExists(pendingTransitionBucketName)
@@ -115,61 +121,53 @@ func timestampToKey(ts uint64) []byte {
 	return key
 }
 
-// Commit stores a verified result at the given timestamp.
-// Timestamps must be committed sequentially with no gaps.
-func (v *VerifiedDB) Commit(result VerifiedResult) error {
+// CommitRecord stores the verified record and the verifier's
+// CurrentL1 claim in one bbolt transaction. Timestamps must be committed
+// sequentially with no gaps.
+func (v *VerifiedDB) CommitRecord(record VerifiedRecord) error {
 	v.mu.Lock()
 	defer v.mu.Unlock()
 
-	ts := result.Timestamp
-
-	// Check for sequential commitment
+	ts := record.Timestamp
 	if v.initialized {
-		if ts != v.lastTimestamp+1 {
-			if ts <= v.lastTimestamp {
-				// Idempotent replay: crash recovery may call Commit again after the
-				// bbolt write succeeded but before ClearPendingTransition. Compare the
-				// deserialized VerifiedResult rather than raw bytes so byte-level
-				// drift in encoding/json across Go versions does not turn a legitimate
-				// replay into a hard ErrAlreadyCommitted.
-				key := timestampToKey(ts)
-				var existing VerifiedResult
-				err := v.db.View(func(tx *bolt.Tx) error {
-					b := tx.Bucket(bucketName)
-					val := b.Get(key)
-					if val == nil {
-						return ErrNotFound
-					}
-					return json.Unmarshal(val, &existing)
-				})
-				if err != nil {
-					return fmt.Errorf("failed to read existing verified result at %d: %w", ts, err)
-				}
-				if reflect.DeepEqual(existing, result) {
-					return nil
-				}
+		switch {
+		case ts == v.lastTimestamp+1:
+		case ts > v.lastTimestamp:
+			return fmt.Errorf("%w: expected %d, got %d", ErrNonSequential, v.lastTimestamp+1, ts)
+		default:
+			// Idempotent replay after a crash may re-apply a WAL entry that was
+			// already committed before ClearPendingTransition ran.
+			existingRecord, err := readVerifiedRecord(v.db, ts)
+			if err != nil {
+				return fmt.Errorf("failed to read existing verified record at %d: %w", ts, err)
+			}
+			if !reflect.DeepEqual(existingRecord, record) {
 				return fmt.Errorf("%w: %d", ErrAlreadyCommitted, ts)
 			}
-			return fmt.Errorf("%w: expected %d, got %d", ErrNonSequential, v.lastTimestamp+1, ts)
+			return nil
 		}
 	}
 
-	value, err := json.Marshal(result)
+	recordValue, err := json.Marshal(record)
 	if err != nil {
-		return fmt.Errorf("failed to marshal verified result: %w", err)
+		return fmt.Errorf("failed to marshal verified record: %w", err)
+	}
+	currentL1Value, err := json.Marshal(record.CurrentL1)
+	if err != nil {
+		return fmt.Errorf("failed to marshal current L1: %w", err)
 	}
 
-	// Store in database
 	key := timestampToKey(ts)
 	err = v.db.Update(func(tx *bolt.Tx) error {
-		b := tx.Bucket(bucketName)
-		return b.Put(key, value)
+		if err := tx.Bucket(bucketName).Put(key, recordValue); err != nil {
+			return err
+		}
+		return tx.Bucket(frontierBucketName).Put(currentL1Key, currentL1Value)
 	})
 	if err != nil {
-		return fmt.Errorf("failed to write to bbolt: %w", err)
+		return fmt.Errorf("failed to write verified record to bbolt: %w", err)
 	}
 
-	// Update state
 	if !v.initialized {
 		v.firstTimestamp = ts
 	}
@@ -179,38 +177,89 @@ func (v *VerifiedDB) Commit(result VerifiedResult) error {
 	return nil
 }
 
-// Get retrieves the verified result at the given timestamp.
-func (v *VerifiedDB) Get(ts uint64) (VerifiedResult, error) {
-	v.mu.RLock()
-	defer v.mu.RUnlock()
-
+func readVerifiedRecord(db *bolt.DB, ts uint64) (VerifiedRecord, error) {
 	key := timestampToKey(ts)
 	var value []byte
-
-	err := v.db.View(func(tx *bolt.Tx) error {
+	err := db.View(func(tx *bolt.Tx) error {
 		b := tx.Bucket(bucketName)
 		val := b.Get(key)
 		if val == nil {
 			return ErrNotFound
 		}
-		// Copy the value since it's only valid for the life of the transaction
 		value = make([]byte, len(val))
 		copy(value, val)
 		return nil
 	})
+	if err != nil {
+		return VerifiedRecord{}, err
+	}
+	var record VerifiedRecord
+	if err := json.Unmarshal(value, &record); err != nil {
+		return VerifiedRecord{}, fmt.Errorf("failed to unmarshal verified record: %w", err)
+	}
+	return record, nil
+}
+
+// GetRecord retrieves the durable verified record at the given timestamp.
+func (v *VerifiedDB) GetRecord(ts uint64) (VerifiedRecord, error) {
+	v.mu.RLock()
+	defer v.mu.RUnlock()
+	record, err := readVerifiedRecord(v.db, ts)
+	if errors.Is(err, ErrNotFound) {
+		return VerifiedRecord{}, ErrNotFound
+	}
+	if err != nil {
+		return VerifiedRecord{}, fmt.Errorf("failed to read verified record at %d: %w", ts, err)
+	}
+	return record, nil
+}
+
+// SetCurrentL1 stores the verifier's durable current L1 claim.
+func (v *VerifiedDB) SetCurrentL1(currentL1 eth.BlockID) error {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	value, err := json.Marshal(currentL1)
+	if err != nil {
+		return fmt.Errorf("failed to marshal current L1: %w", err)
+	}
+	return v.db.Update(func(tx *bolt.Tx) error {
+		return tx.Bucket(frontierBucketName).Put(currentL1Key, value)
+	})
+}
+
+// CurrentL1 returns the verifier's durable current L1 claim, if any.
+func (v *VerifiedDB) CurrentL1() (eth.BlockID, bool, error) {
+	v.mu.RLock()
+	defer v.mu.RUnlock()
+	var currentL1 eth.BlockID
+	var found bool
+	err := v.db.View(func(tx *bolt.Tx) error {
+		val := tx.Bucket(frontierBucketName).Get(currentL1Key)
+		if val == nil {
+			return nil
+		}
+		found = true
+		return json.Unmarshal(val, &currentL1)
+	})
+	if err != nil {
+		return eth.BlockID{}, false, fmt.Errorf("failed to read current L1: %w", err)
+	}
+	return currentL1, found, nil
+}
+
+// Get retrieves the verified result view at the given timestamp.
+func (v *VerifiedDB) Get(ts uint64) (VerifiedResult, error) {
+	v.mu.RLock()
+	defer v.mu.RUnlock()
+
+	record, err := readVerifiedRecord(v.db, ts)
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {
 			return VerifiedResult{}, ErrNotFound
 		}
 		return VerifiedResult{}, fmt.Errorf("failed to read from bbolt: %w", err)
 	}
-
-	var result VerifiedResult
-	if err := json.Unmarshal(value, &result); err != nil {
-		return VerifiedResult{}, fmt.Errorf("failed to unmarshal verified result: %w", err)
-	}
-
-	return result, nil
+	return record.ToVerifiedResult(), nil
 }
 
 // Has returns whether a timestamp has been verified.

--- a/op-supernode/supernode/activity/interop/verified_db_test.go
+++ b/op-supernode/supernode/activity/interop/verified_db_test.go
@@ -10,6 +10,32 @@ import (
 	bolt "go.etcd.io/bbolt"
 )
 
+func commitVerifiedResult(v *VerifiedDB, result VerifiedResult) error {
+	return v.CommitRecord(testVerifiedRecord(result))
+}
+
+func testVerifiedRecord(result VerifiedResult) VerifiedRecord {
+	chainOutputs := make([]eth.ChainIDAndOutput, 0, len(result.L2Heads))
+	for chainID, l2Head := range result.L2Heads {
+		chainOutputs = append(chainOutputs, eth.ChainIDAndOutput{
+			ChainID: chainID,
+			Output:  eth.Bytes32(l2Head.Hash),
+		})
+	}
+	super := eth.NewSuperV1(result.Timestamp, chainOutputs...)
+	currentL1 := result.L1Inclusion
+	if currentL1.Number > 0 {
+		currentL1.Number--
+	}
+	return VerifiedRecord{
+		Timestamp:    result.Timestamp,
+		L1Inclusion:  result.L1Inclusion,
+		L2Heads:      result.L2Heads,
+		ChainOutputs: super.Chains,
+		CurrentL1:    currentL1,
+	}
+}
+
 func TestVerifiedDB_WriteAndRead(t *testing.T) {
 	// Create a temporary directory for the test database
 	dataDir := t.TempDir()
@@ -50,7 +76,7 @@ func TestVerifiedDB_WriteAndRead(t *testing.T) {
 	}
 
 	// Write the first result
-	err = db.Commit(result1)
+	err = commitVerifiedResult(db, result1)
 	require.NoError(t, err)
 
 	// Verify the last timestamp was updated
@@ -95,7 +121,7 @@ func TestVerifiedDB_SequentialCommits(t *testing.T) {
 	chainID := eth.ChainIDFromUInt64(10)
 
 	// Commit first timestamp
-	err = db.Commit(VerifiedResult{
+	err = commitVerifiedResult(db, VerifiedResult{
 		Timestamp:   100,
 		L1Inclusion: eth.BlockID{Hash: common.HexToHash("0x01"), Number: 1},
 		L2Heads:     map[eth.ChainID]eth.BlockID{chainID: {Hash: common.HexToHash("0x02"), Number: 2}},
@@ -103,7 +129,7 @@ func TestVerifiedDB_SequentialCommits(t *testing.T) {
 	require.NoError(t, err)
 
 	// Commit next sequential timestamp should succeed
-	err = db.Commit(VerifiedResult{
+	err = commitVerifiedResult(db, VerifiedResult{
 		Timestamp:   101,
 		L1Inclusion: eth.BlockID{Hash: common.HexToHash("0x03"), Number: 3},
 		L2Heads:     map[eth.ChainID]eth.BlockID{chainID: {Hash: common.HexToHash("0x04"), Number: 4}},
@@ -111,7 +137,7 @@ func TestVerifiedDB_SequentialCommits(t *testing.T) {
 	require.NoError(t, err)
 
 	// Try to commit non-sequential timestamp (gap)
-	err = db.Commit(VerifiedResult{
+	err = commitVerifiedResult(db, VerifiedResult{
 		Timestamp:   105,
 		L1Inclusion: eth.BlockID{Hash: common.HexToHash("0x05"), Number: 5},
 		L2Heads:     map[eth.ChainID]eth.BlockID{chainID: {Hash: common.HexToHash("0x06"), Number: 6}},
@@ -119,7 +145,7 @@ func TestVerifiedDB_SequentialCommits(t *testing.T) {
 	require.ErrorIs(t, err, ErrNonSequential)
 
 	// Try to commit already committed timestamp
-	err = db.Commit(VerifiedResult{
+	err = commitVerifiedResult(db, VerifiedResult{
 		Timestamp:   100,
 		L1Inclusion: eth.BlockID{Hash: common.HexToHash("0x07"), Number: 7},
 		L2Heads:     map[eth.ChainID]eth.BlockID{chainID: {Hash: common.HexToHash("0x08"), Number: 8}},
@@ -139,14 +165,14 @@ func TestVerifiedDB_Persistence(t *testing.T) {
 	db, err := OpenVerifiedDB(dataDir)
 	require.NoError(t, err)
 
-	err = db.Commit(VerifiedResult{
+	err = commitVerifiedResult(db, VerifiedResult{
 		Timestamp:   500,
 		L1Inclusion: eth.BlockID{Hash: common.HexToHash("0xaaaa"), Number: 50},
 		L2Heads:     map[eth.ChainID]eth.BlockID{chainID: {Hash: common.HexToHash("0xbbbb"), Number: 100}},
 	})
 	require.NoError(t, err)
 
-	err = db.Commit(VerifiedResult{
+	err = commitVerifiedResult(db, VerifiedResult{
 		Timestamp:   501,
 		L1Inclusion: eth.BlockID{Hash: common.HexToHash("0xcccc"), Number: 51},
 		L2Heads:     map[eth.ChainID]eth.BlockID{chainID: {Hash: common.HexToHash("0xdddd"), Number: 101}},
@@ -179,7 +205,7 @@ func TestVerifiedDB_Persistence(t *testing.T) {
 	require.Equal(t, uint64(501), result.Timestamp)
 
 	// Next commit should continue from last timestamp
-	err = db2.Commit(VerifiedResult{
+	err = commitVerifiedResult(db2, VerifiedResult{
 		Timestamp:   502,
 		L1Inclusion: eth.BlockID{Hash: common.HexToHash("0xeeee"), Number: 52},
 		L2Heads:     map[eth.ChainID]eth.BlockID{chainID: {Hash: common.HexToHash("0xffff"), Number: 102}},
@@ -202,7 +228,7 @@ func TestVerifiedDB_RewindTo(t *testing.T) {
 
 		// Commit several timestamps
 		for ts := uint64(100); ts <= 105; ts++ {
-			err = db.Commit(VerifiedResult{
+			err = commitVerifiedResult(db, VerifiedResult{
 				Timestamp:   ts,
 				L1Inclusion: eth.BlockID{Hash: common.BytesToHash([]byte{byte(ts)}), Number: ts},
 				L2Heads:     map[eth.ChainID]eth.BlockID{chainID: {Hash: common.BytesToHash([]byte{byte(ts + 100)}), Number: ts}},
@@ -253,7 +279,7 @@ func TestVerifiedDB_RewindTo(t *testing.T) {
 
 		// Commit up to timestamp 100
 		for ts := uint64(98); ts <= 100; ts++ {
-			err = db.Commit(VerifiedResult{
+			err = commitVerifiedResult(db, VerifiedResult{
 				Timestamp:   ts,
 				L1Inclusion: eth.BlockID{Hash: common.BytesToHash([]byte{byte(ts)}), Number: ts},
 				L2Heads:     map[eth.ChainID]eth.BlockID{chainID: {Hash: common.BytesToHash([]byte{byte(ts + 100)}), Number: ts}},
@@ -283,7 +309,7 @@ func TestVerifiedDB_RewindTo(t *testing.T) {
 
 		// Commit a few entries
 		for ts := uint64(100); ts <= 102; ts++ {
-			err = db.Commit(VerifiedResult{
+			err = commitVerifiedResult(db, VerifiedResult{
 				Timestamp:   ts,
 				L1Inclusion: eth.BlockID{Hash: common.BytesToHash([]byte{byte(ts)}), Number: ts},
 				L2Heads:     map[eth.ChainID]eth.BlockID{chainID: {Hash: common.BytesToHash([]byte{byte(ts + 100)}), Number: ts}},
@@ -320,7 +346,7 @@ func TestVerifiedDB_RewindTo(t *testing.T) {
 
 		// Commit 100-105
 		for ts := uint64(100); ts <= 105; ts++ {
-			err = db.Commit(VerifiedResult{
+			err = commitVerifiedResult(db, VerifiedResult{
 				Timestamp:   ts,
 				L1Inclusion: eth.BlockID{Hash: common.BytesToHash([]byte{byte(ts)}), Number: ts},
 				L2Heads:     map[eth.ChainID]eth.BlockID{chainID: {Hash: common.BytesToHash([]byte{byte(ts + 100)}), Number: ts}},
@@ -333,7 +359,7 @@ func TestVerifiedDB_RewindTo(t *testing.T) {
 		require.NoError(t, err)
 
 		// Should be able to commit 103 again (sequential from 102)
-		err = db.Commit(VerifiedResult{
+		err = commitVerifiedResult(db, VerifiedResult{
 			Timestamp:   103,
 			L1Inclusion: eth.BlockID{Hash: common.HexToHash("0xNEW"), Number: 103},
 			L2Heads:     map[eth.ChainID]eth.BlockID{chainID: {Hash: common.HexToHash("0xNEW2"), Number: 103}},
@@ -365,8 +391,8 @@ func TestVerifiedDB_Commit_IdempotentReplay(t *testing.T) {
 		require.NoError(t, err)
 		defer db.Close()
 
-		require.NoError(t, db.Commit(result))
-		require.NoError(t, db.Commit(result))
+		require.NoError(t, commitVerifiedResult(db, result))
+		require.NoError(t, commitVerifiedResult(db, result))
 	})
 
 	t.Run("different struct at same timestamp is rejected", func(t *testing.T) {
@@ -375,11 +401,11 @@ func TestVerifiedDB_Commit_IdempotentReplay(t *testing.T) {
 		require.NoError(t, err)
 		defer db.Close()
 
-		require.NoError(t, db.Commit(result))
+		require.NoError(t, commitVerifiedResult(db, result))
 
 		different := result
 		different.L1Inclusion.Number = 999
-		require.ErrorIs(t, db.Commit(different), ErrAlreadyCommitted)
+		require.ErrorIs(t, commitVerifiedResult(db, different), ErrAlreadyCommitted)
 	})
 
 	t.Run("byte-divergent but struct-equal replays cleanly", func(t *testing.T) {
@@ -392,11 +418,12 @@ func TestVerifiedDB_Commit_IdempotentReplay(t *testing.T) {
 		require.NoError(t, err)
 		defer db.Close()
 
-		require.NoError(t, db.Commit(result))
+		require.NoError(t, commitVerifiedResult(db, result))
 
-		indented, err := json.MarshalIndent(result, "", "  ")
+		record := testVerifiedRecord(result)
+		indented, err := json.MarshalIndent(record, "", "  ")
 		require.NoError(t, err)
-		canonical, err := json.Marshal(result)
+		canonical, err := json.Marshal(record)
 		require.NoError(t, err)
 		require.NotEqual(t, canonical, indented, "indented JSON should diverge from canonical bytes")
 
@@ -404,7 +431,7 @@ func TestVerifiedDB_Commit_IdempotentReplay(t *testing.T) {
 			return tx.Bucket(bucketName).Put(timestampToKey(result.Timestamp), indented)
 		}))
 
-		require.NoError(t, db.Commit(result))
+		require.NoError(t, commitVerifiedResult(db, result))
 	})
 }
 

--- a/op-supernode/supernode/activity/superroot/superroot.go
+++ b/op-supernode/supernode/activity/superroot/superroot.go
@@ -17,23 +17,28 @@ import (
 // it provides the superroot at a given timestamp for all chains
 // along with the current L1s and the verified and optimistic L1:L2 pairs
 type Superroot struct {
-	log    gethlog.Logger
-	chains map[eth.ChainID]cc.ChainContainer
+	log              gethlog.Logger
+	chains           map[eth.ChainID]cc.ChainContainer
+	verifiedProvider VerifiedSuperRootProvider
 }
 
-func New(log gethlog.Logger, chains map[eth.ChainID]cc.ChainContainer) *Superroot {
+// VerifiedSuperRootProvider supplies durable verifier-owned superroot data.
+type VerifiedSuperRootProvider interface {
+	StoredSuperRootAtTimestamp(ts uint64) (data *eth.SuperRootResponseData, found bool, err error)
+}
+
+func New(log gethlog.Logger, chains map[eth.ChainID]cc.ChainContainer, provider VerifiedSuperRootProvider) *Superroot {
 	return &Superroot{
-		log:    log,
-		chains: chains,
+		log:              log,
+		chains:           chains,
+		verifiedProvider: provider,
 	}
 }
 
 func (s *Superroot) Name() string { return "superroot" }
 
-// Reset is a no-op for superroot - it always queries chain containers directly
-// and doesn't maintain any chain-specific cached state.
+// Reset is a no-op for superroot: it does not maintain chain-specific cached state.
 func (s *Superroot) Reset(chainID eth.ChainID, timestamp uint64, invalidatedBlock eth.BlockRef) {
-	// No-op: superroot queries chain containers directly
 }
 
 func (s *Superroot) RPCNamespace() string    { return "superroot" }
@@ -53,35 +58,18 @@ func (s *Superroot) atTimestamp(ctx context.Context, timestamp uint64) (eth.Supe
 	}
 
 	var (
-		optimistic         = make(map[eth.ChainID]eth.OutputWithRequiredL1, len(s.chains))
-		verifiedRequiredL1 eth.BlockID
-		chainOutputs       = make([]eth.ChainIDAndOutput, 0, len(s.chains))
+		optimistic   = make(map[eth.ChainID]eth.OutputWithRequiredL1, len(s.chains))
+		verifiedData *eth.SuperRootResponseData
 	)
 
-	notFound := false
-	// Collect verified L2 and L1 blocks at the given timestamp
-	for chainID, chain := range s.chains {
-		// verifiedAt returns the L2 block which is fully verified at the given timestamp, and the minimum L1 block at which verification is possible
-		verifiedL2, verifiedL1, err := chain.VerifiedAt(ctx, timestamp)
-		if errors.Is(err, ethereum.NotFound) {
-			notFound = true
-			continue
-		} else if err != nil {
-			s.log.Warn("failed to get verified block", "chain_id", chainID.String(), "err", err)
-			return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("failed to get verified block: %w", err)
-		}
-		// Verified data is available: track the L1 block that includes the data
-		// for every chain — i.e. the MAX of per-chain minimum-required L1s.
-		if verifiedL1.Number > verifiedRequiredL1.Number {
-			verifiedRequiredL1 = verifiedL1
-		}
-		// Compute output root at or before timestamp using the verified L2 block number
-		outRoot, err := chain.OutputRootAtL2BlockNumber(ctx, verifiedL2.Number)
+	if s.verifiedProvider != nil {
+		data, found, err := s.verifiedProvider.StoredSuperRootAtTimestamp(timestamp)
 		if err != nil {
-			s.log.Warn("failed to compute output root at L2 block", "chain_id", chainID.String(), "l2_number", verifiedL2.Number, "err", err)
-			return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("failed to compute output root at L2 block %d for chain ID %v: %w", verifiedL2.Number, chainID, err)
+			return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("failed to get stored verified superroot: %w", err)
 		}
-		chainOutputs = append(chainOutputs, eth.ChainIDAndOutput{ChainID: chainID, Output: outRoot})
+		if found {
+			verifiedData = data
+		}
 	}
 
 	// Collect optimistic data for all chains regardless of whether verified data is available.
@@ -116,16 +104,7 @@ func (s *Superroot) atTimestamp(ctx context.Context, timestamp uint64) (eth.Supe
 		CurrentFinalizedTimestamp: aggregate.FinalizedTimestamp,
 		OptimisticAtTimestamp:     optimistic,
 		ChainIDs:                  aggregate.ChainIDs,
-	}
-	if !notFound {
-		// Build super root from collected outputs
-		superV1 := eth.NewSuperV1(timestamp, chainOutputs...)
-		superRoot := eth.SuperRoot(superV1)
-		response.Data = &eth.SuperRootResponseData{
-			VerifiedRequiredL1: verifiedRequiredL1,
-			Super:              superV1,
-			SuperRoot:          superRoot,
-		}
+		Data:                      verifiedData,
 	}
 	return response, nil
 }

--- a/op-supernode/supernode/activity/superroot/superroot_test.go
+++ b/op-supernode/supernode/activity/superroot/superroot_test.go
@@ -31,6 +31,16 @@ type mockCC struct {
 	syncStatusErr error
 }
 
+type mockVerifiedProvider struct {
+	data  *eth.SuperRootResponseData
+	found bool
+	err   error
+}
+
+func (m mockVerifiedProvider) StoredSuperRootAtTimestamp(uint64) (*eth.SuperRootResponseData, bool, error) {
+	return m.data, m.found, m.err
+}
+
 func (m *mockCC) Start(ctx context.Context) error          { return nil }
 func (m *mockCC) Stop(ctx context.Context) error           { return nil }
 func (m *mockCC) Pause(ctx context.Context) error          { return nil }
@@ -123,6 +133,16 @@ var _ cc.ChainContainer = (*mockCC)(nil)
 
 func TestSuperroot_AtTimestamp_Succeeds(t *testing.T) {
 	t.Parallel()
+	chainOutputs := []eth.ChainIDAndOutput{
+		{ChainID: eth.ChainIDFromUInt64(10), Output: eth.Bytes32{}},
+		{ChainID: eth.ChainIDFromUInt64(420), Output: eth.Bytes32{}},
+	}
+	super := eth.NewSuperV1(123, chainOutputs...)
+	stored := &eth.SuperRootResponseData{
+		VerifiedRequiredL1: eth.BlockID{Number: 1100},
+		Super:              super,
+		SuperRoot:          eth.SuperRoot(super),
+	}
 	chains := map[eth.ChainID]cc.ChainContainer{
 		eth.ChainIDFromUInt64(10): &mockCC{
 			verL2:  eth.BlockID{Number: 100},
@@ -151,7 +171,7 @@ func TestSuperroot_AtTimestamp_Succeeds(t *testing.T) {
 			},
 		},
 	}
-	s := New(gethlog.New(), chains)
+	s := New(gethlog.New(), chains, mockVerifiedProvider{data: stored, found: true})
 	api := &superrootAPI{s: s}
 	out, err := api.AtTimestamp(context.Background(), 123)
 	require.NoError(t, err)
@@ -191,16 +211,24 @@ func TestSuperroot_AtTimestamp_ComputesSuperRoot(t *testing.T) {
 		},
 	}
 	ts := uint64(123)
-	s := New(gethlog.New(), chains)
+	chainOutputs := []eth.ChainIDAndOutput{
+		{ChainID: eth.ChainIDFromUInt64(10), Output: out1},
+		{ChainID: eth.ChainIDFromUInt64(420), Output: out2},
+	}
+	super := eth.NewSuperV1(ts, chainOutputs...)
+	s := New(gethlog.New(), chains, mockVerifiedProvider{
+		data: &eth.SuperRootResponseData{
+			VerifiedRequiredL1: eth.BlockID{Number: 1100},
+			Super:              super,
+			SuperRoot:          eth.SuperRoot(super),
+		},
+		found: true,
+	})
 	api := &superrootAPI{s: s}
 	resp, err := api.AtTimestamp(context.Background(), hexutil.Uint64(ts))
 	require.NoError(t, err)
 
 	// Compute expected super root
-	chainOutputs := []eth.ChainIDAndOutput{
-		{ChainID: eth.ChainIDFromUInt64(10), Output: out1},
-		{ChainID: eth.ChainIDFromUInt64(420), Output: out2},
-	}
 	expected := eth.SuperRoot(eth.NewSuperV1(ts, chainOutputs...))
 	require.Equal(t, expected, resp.Data.SuperRoot)
 }
@@ -212,26 +240,24 @@ func TestSuperroot_AtTimestamp_ErrorOnCurrentL1(t *testing.T) {
 			syncStatusErr: assertErr(),
 		},
 	}
-	s := New(gethlog.New(), chains)
+	s := New(gethlog.New(), chains, nil)
 	api := &superrootAPI{s: s}
 	_, err := api.AtTimestamp(context.Background(), 123)
 	require.Error(t, err)
 }
 
-func TestSuperroot_AtTimestamp_ErrorOnVerifiedAt(t *testing.T) {
+func TestSuperroot_AtTimestamp_ErrorOnStoredVerifiedData(t *testing.T) {
 	t.Parallel()
 	chains := map[eth.ChainID]cc.ChainContainer{
-		eth.ChainIDFromUInt64(10): &mockCC{
-			verifiedErr: assertErr(),
-		},
+		eth.ChainIDFromUInt64(10): &mockCC{},
 	}
-	s := New(gethlog.New(), chains)
+	s := New(gethlog.New(), chains, mockVerifiedProvider{err: assertErr()})
 	api := &superrootAPI{s: s}
 	_, err := api.AtTimestamp(context.Background(), 123)
 	require.Error(t, err)
 }
 
-func TestSuperroot_AtTimestamp_NotFoundOnVerifiedAt(t *testing.T) {
+func TestSuperroot_AtTimestamp_NoStoredVerifiedData(t *testing.T) {
 	t.Parallel()
 	chains := map[eth.ChainID]cc.ChainContainer{
 		eth.ChainIDFromUInt64(10): &mockCC{
@@ -248,7 +274,7 @@ func TestSuperroot_AtTimestamp_NotFoundOnVerifiedAt(t *testing.T) {
 			status: &eth.SyncStatus{CurrentL1: eth.L1BlockRef{Number: 2100}},
 		},
 	}
-	s := New(gethlog.New(), chains)
+	s := New(gethlog.New(), chains, nil)
 	api := &superrootAPI{s: s}
 	actual, err := api.AtTimestamp(context.Background(), 123)
 	require.NoError(t, err)
@@ -274,7 +300,7 @@ func TestSuperroot_AtTimestamp_NotFoundOnVerifiedAtAndOptimisticAt(t *testing.T)
 			status: &eth.SyncStatus{CurrentL1: eth.L1BlockRef{Number: 2100}},
 		},
 	}
-	s := New(gethlog.New(), chains)
+	s := New(gethlog.New(), chains, nil)
 	api := &superrootAPI{s: s}
 	actual, err := api.AtTimestamp(context.Background(), 123)
 	require.NoError(t, err)
@@ -292,13 +318,13 @@ func TestSuperroot_AtTimestamp_ErrorOnOptimisticAtWhenVerifiedNotFound(t *testin
 			optimisticErr: assertErr(),
 		},
 	}
-	s := New(gethlog.New(), chains)
+	s := New(gethlog.New(), chains, nil)
 	api := &superrootAPI{s: s}
 	_, err := api.AtTimestamp(context.Background(), 123)
 	require.Error(t, err)
 }
 
-func TestSuperroot_AtTimestamp_ErrorOnOutputRoot(t *testing.T) {
+func TestSuperroot_AtTimestamp_DoesNotReadLiveVerifiedOutputRoot(t *testing.T) {
 	t.Parallel()
 	chains := map[eth.ChainID]cc.ChainContainer{
 		eth.ChainIDFromUInt64(10): &mockCC{
@@ -306,10 +332,11 @@ func TestSuperroot_AtTimestamp_ErrorOnOutputRoot(t *testing.T) {
 			outputErr: assertErr(),
 		},
 	}
-	s := New(gethlog.New(), chains)
+	s := New(gethlog.New(), chains, nil)
 	api := &superrootAPI{s: s}
-	_, err := api.AtTimestamp(context.Background(), 123)
-	require.Error(t, err)
+	out, err := api.AtTimestamp(context.Background(), 123)
+	require.NoError(t, err)
+	require.Nil(t, out.Data)
 }
 
 func TestSuperroot_AtTimestamp_ErrorOnOptimisticAt(t *testing.T) {
@@ -321,7 +348,7 @@ func TestSuperroot_AtTimestamp_ErrorOnOptimisticAt(t *testing.T) {
 			optimisticErr: assertErr(),
 		},
 	}
-	s := New(gethlog.New(), chains)
+	s := New(gethlog.New(), chains, nil)
 	api := &superrootAPI{s: s}
 	_, err := api.AtTimestamp(context.Background(), 123)
 	require.Error(t, err)
@@ -330,7 +357,7 @@ func TestSuperroot_AtTimestamp_ErrorOnOptimisticAt(t *testing.T) {
 func TestSuperroot_AtTimestamp_EmptyChains(t *testing.T) {
 	t.Parallel()
 	chains := map[eth.ChainID]cc.ChainContainer{}
-	s := New(gethlog.New(), chains)
+	s := New(gethlog.New(), chains, nil)
 	api := &superrootAPI{s: s}
 	out, err := api.AtTimestamp(context.Background(), 123)
 	require.NoError(t, err)
@@ -353,7 +380,7 @@ func TestSuperroot_AtTimestamp_VerifierL1ReducesCurrentL1(t *testing.T) {
 			verifierL1s: []eth.BlockID{{Number: 1500}},
 		},
 	}
-	s := New(gethlog.New(), chains)
+	s := New(gethlog.New(), chains, nil)
 	api := &superrootAPI{s: s}
 	out, err := api.AtTimestamp(context.Background(), 123)
 	require.NoError(t, err)
@@ -377,7 +404,7 @@ func TestSuperroot_AtTimestamp_VerifierL1HigherThanDerivationDoesNotIncrease(t *
 			verifierL1s: []eth.BlockID{{Number: 3000}},
 		},
 	}
-	s := New(gethlog.New(), chains)
+	s := New(gethlog.New(), chains, nil)
 	api := &superrootAPI{s: s}
 	out, err := api.AtTimestamp(context.Background(), 123)
 	require.NoError(t, err)

--- a/op-supernode/supernode/supernode.go
+++ b/op-supernode/supernode/supernode.go
@@ -116,7 +116,6 @@ func New(ctx context.Context, log gethlog.Logger, version string, requestStop co
 	s.activities = []activity.Activity{
 		heartbeat.New(log.New("activity", "heartbeat"), 10*time.Second),
 		supernodeactivity.New(log.New("activity", "supernode"), narrowChains),
-		superroot.New(log.New("activity", "superroot"), narrowChains),
 	}
 
 	interopActivationTimestamp, err := resolveInteropActivationTimestamp(cfg.InteropActivationTimestamp, vnCfgs)
@@ -129,6 +128,7 @@ func New(ctx context.Context, log gethlog.Logger, version string, requestStop co
 	}
 
 	log.Info("initializing interop activity", "enabled", interopActivationTimestamp != nil)
+	var verifiedSuperRootProvider superroot.VerifiedSuperRootProvider
 	// Initialize interop activity if the activation timestamp is known (non-nil).
 	// If it's nil, don't start interop. If it's non-nil (including 0), do start it.
 	if interopActivationTimestamp != nil {
@@ -142,12 +142,14 @@ func New(ctx context.Context, log gethlog.Logger, version string, requestStop co
 		}
 		interopActivity := interop.New(log.New("activity", "interop"), *interopActivationTimestamp, msgExpiryWindow, s.chains, cfg.DataDir, s.l1Client, cfg.InteropLogBackfillDepth, s.supernodeMetrics)
 		s.activities = append(s.activities, interopActivity)
+		verifiedSuperRootProvider = interopActivity
 		for _, chain := range s.chains {
 			chain.RegisterVerifier(interopActivity)
 		}
 		s.interopActivationTs = interopActivationTimestamp
 		s.interopMsgExpiryWindow = msgExpiryWindow
 	}
+	s.activities = append(s.activities, superroot.New(log.New("activity", "superroot"), narrowChains, verifiedSuperRootProvider))
 
 	// Set up reset callbacks on all chain containers
 	// When a chain resets, notify all activities


### PR DESCRIPTION
## Summary
- build the verified superroot record while constructing the `DecisionAdvance` pending transition
- store that exact record in the WAL so replay applies the same observed transition without re-querying live state
- store the full verified superroot record as the canonical timestamp value in the verified DB, deriving the old `VerifiedResult` view from it where needed
- answer `superroot_atTimestamp` verified `Data` from the stored DB record instead of live `VerifiedAt` / output-root reads
- persist the verifier `CurrentL1` frontier and under-claim `DecisionAdvance` by using the parent of `L1Inclusion` before the WAL transition is committed
- keep `DecisionWait` and rewinds updating the durable `CurrentL1` frontier

The DB record intentionally stores only source facts: timestamp, L1 inclusion, per-chain L2 heads, per-chain output roots, and current L1. Redundant RPC fields like `VerifiedRequiredL1` and `SuperRoot` are derived when serving the response.

## DB growth
The new timestamp-keyed record stores compact superroot data rather than full RPC responses. With eventual verified DB GC capped at about two weeks, this should be bounded retained growth rather than unbounded history.

## Tests
- `go test ./op-supernode/supernode/...`