### PR TITLE
op-supernode: serve full superroot RPC from durable state post-activation

### DIFF
--- a/op-supernode/supernode/activity/interop/algo.go
+++ b/op-supernode/supernode/activity/interop/algo.go
@@ -62,6 +62,7 @@ func (i *Interop) verifyInteropMessages(ts uint64, blocksAtTimestamp blockPerCha
 	result := Result{
 		Timestamp:    ts,
 		L2Heads:      make(blockPerChain),
+		L1Heads:      l1Heads,
 		InvalidHeads: make(map[eth.ChainID]InvalidHead),
 	}
 
@@ -107,7 +108,7 @@ func (i *Interop) verifyInteropMessages(ts uint64, blocksAtTimestamp blockPerCha
 								"expected", expectedBlock.Hash,
 								"got", firstBlock.Hash,
 							)
-							invalid, err := i.newInvalidHead(chainID, expectedBlock)
+							invalid, err := i.newInvalidHead(chainID, expectedBlock, l1Heads[chainID])
 							if err != nil {
 								return Result{}, fmt.Errorf("chain %s: %w", chainID, err)
 							}
@@ -128,7 +129,7 @@ func (i *Interop) verifyInteropMessages(ts uint64, blocksAtTimestamp blockPerCha
 				"expected", expectedBlock.Hash,
 				"got", blockRef.Hash,
 			)
-			invalid, err := i.newInvalidHead(chainID, expectedBlock)
+			invalid, err := i.newInvalidHead(chainID, expectedBlock, l1Heads[chainID])
 			if err != nil {
 				return Result{}, fmt.Errorf("chain %s: %w", chainID, err)
 			}
@@ -156,7 +157,7 @@ func (i *Interop) verifyInteropMessages(ts uint64, blocksAtTimestamp blockPerCha
 
 		result.L2Heads[chainID] = expectedBlock
 		if !blockValid {
-			invalid, err := i.newInvalidHead(chainID, expectedBlock)
+			invalid, err := i.newInvalidHead(chainID, expectedBlock, l1Heads[chainID])
 			if err != nil {
 				return Result{}, fmt.Errorf("chain %s: %w", chainID, err)
 			}

--- a/op-supernode/supernode/activity/interop/algo_test.go
+++ b/op-supernode/supernode/activity/interop/algo_test.go
@@ -1006,7 +1006,7 @@ func (m *algoMockChain) RewindEngine(ctx context.Context, timestamp uint64, inva
 	return nil
 }
 func (m *algoMockChain) BlockTime() uint64 { return 1 }
-func (m *algoMockChain) InvalidateBlock(ctx context.Context, height uint64, payloadHash common.Hash, decisionTimestamp uint64, stateRoot, messagePasserStorageRoot eth.Bytes32) (bool, error) {
+func (m *algoMockChain) InvalidateBlock(ctx context.Context, height uint64, payloadHash common.Hash, decisionTimestamp uint64, stateRoot, messagePasserStorageRoot eth.Bytes32, l1Inclusion eth.BlockID) (bool, error) {
 	return false, nil
 }
 func (m *algoMockChain) OutputV0AtBlockNumber(ctx context.Context, l2BlockNum uint64) (*eth.OutputV0, error) {
@@ -1018,6 +1018,9 @@ func (m *algoMockChain) OutputV0AtBlockNumber(ctx context.Context, l2BlockNum ui
 }
 func (m *algoMockChain) GetDeniedOutput(height uint64, payloadHash common.Hash) (*eth.OutputV0, error) {
 	return nil, nil
+}
+func (m *algoMockChain) LastDeniedAtHeight(height uint64) (*eth.OutputV0, eth.BlockID, error) {
+	return nil, eth.BlockID{}, nil
 }
 func (m *algoMockChain) PruneDeniedAtOrAfterTimestamp(timestamp uint64) (map[uint64][]common.Hash, error) {
 	return nil, nil

--- a/op-supernode/supernode/activity/interop/checker.go
+++ b/op-supernode/supernode/activity/interop/checker.go
@@ -4,11 +4,14 @@ import (
 	"context"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/common"
 )
 
-// l1ByNumberSource provides L1 block lookups by number for consistency checking.
-type l1ByNumberSource interface {
+// l1Source provides L1 block lookups for consistency checking and CurrentL1
+// claim construction.
+type l1Source interface {
 	L1BlockRefByNumber(ctx context.Context, num uint64) (eth.L1BlockRef, error)
+	InfoByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, error)
 }
 
 // l1ConsistencyChecker verifies that a set of L1 block IDs all belong to
@@ -18,12 +21,12 @@ type l1ConsistencyChecker interface {
 }
 
 // l1ByNumberChecker is the production l1ConsistencyChecker: it checks each
-// head against the canonical L1 chain fetched from an l1ByNumberSource.
+// head against the canonical L1 chain fetched from an l1Source.
 type l1ByNumberChecker struct {
-	l1 l1ByNumberSource
+	l1 l1Source
 }
 
-func newL1ConsistencyChecker(l1 l1ByNumberSource) l1ConsistencyChecker {
+func newL1ConsistencyChecker(l1 l1Source) l1ConsistencyChecker {
 	if l1 == nil {
 		return nil
 	}

--- a/op-supernode/supernode/activity/interop/checker_test.go
+++ b/op-supernode/supernode/activity/interop/checker_test.go
@@ -22,6 +22,20 @@ func (m *mockL1Source) L1BlockRefByNumber(ctx context.Context, num uint64) (eth.
 	return ref, nil
 }
 
+func (m *mockL1Source) InfoByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, error) {
+	for _, ref := range m.blocks {
+		if ref.Hash == hash {
+			return &mockBlockInfo{
+				hash:       ref.Hash,
+				parentHash: ref.ParentHash,
+				number:     ref.Number,
+				timestamp:  ref.Time,
+			}, nil
+		}
+	}
+	return nil, fmt.Errorf("block %s not found", hash)
+}
+
 // noopL1Checker treats every set of heads as canonical. Intended for tests that
 // do not exercise L1 consistency — production must always use the real checker.
 type noopL1Checker struct{}

--- a/op-supernode/supernode/activity/interop/cycle.go
+++ b/op-supernode/supernode/activity/interop/cycle.go
@@ -169,10 +169,11 @@ func buildCycleGraph(ts uint64, chainEMs map[eth.ChainID]map[uint32]*types.Execu
 // using Kahn's topological sort algorithm.
 //
 // Returns a Result with InvalidHeads populated for chains participating in cycles.
-func (i *Interop) verifyCycleMessages(ts uint64, blocksAtTimestamp map[eth.ChainID]eth.BlockID, view *frontierVerificationView) (Result, error) {
+func (i *Interop) verifyCycleMessages(ts uint64, blocksAtTimestamp map[eth.ChainID]eth.BlockID, l1Heads map[eth.ChainID]eth.BlockID, view *frontierVerificationView) (Result, error) {
 	result := Result{
 		Timestamp: ts,
 		L2Heads:   blocksAtTimestamp,
+		L1Heads:   l1Heads,
 	}
 
 	// collect all EMs for the given blocks per chain
@@ -213,7 +214,7 @@ func (i *Interop) verifyCycleMessages(ts uint64, blocksAtTimestamp map[eth.Chain
 		if len(cycleChains) > 0 {
 			result.InvalidHeads = make(map[eth.ChainID]InvalidHead)
 			for chainID := range cycleChains {
-				invalid, err := i.newInvalidHead(chainID, blocksAtTimestamp[chainID])
+				invalid, err := i.newInvalidHead(chainID, blocksAtTimestamp[chainID], l1Heads[chainID])
 				if err != nil {
 					return Result{}, fmt.Errorf("chain %s: %w", chainID, err)
 				}

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -49,9 +49,14 @@ func init() {
 }
 
 // chainsReadyResult holds the parallel query results from checkChainsReady.
+//
+// blocks/l1Heads/observations may be partial: chains that returned NotFound at
+// the queried timestamp are absent. allReady is true only when every chain
+// returned a successful observation.
 type chainsReadyResult struct {
-	blocks  map[eth.ChainID]eth.BlockID // L2 blocks at the timestamp
-	l1Heads map[eth.ChainID]eth.BlockID // per-chain L1 inclusion heads
+	blocks       map[eth.ChainID]eth.BlockID      // L2 blocks at the timestamp
+	l1Heads      map[eth.ChainID]eth.BlockID      // per-chain L1 inclusion heads
+	observations map[eth.ChainID]ChainObservation // persisted snapshot per chain
 }
 
 // RoundObservation is a consistent snapshot of the current round's state,
@@ -147,8 +152,9 @@ type Interop struct {
 
 	messageExpiryWindow uint64
 
-	verifiedDB *VerifiedDB
-	logsDBs    map[eth.ChainID]LogsDB
+	verifiedDB     *VerifiedDB
+	observationsDB *ObservationsDB
+	logsDBs        map[eth.ChainID]LogsDB
 
 	mu      sync.RWMutex
 	ctx     context.Context
@@ -231,6 +237,13 @@ func New(
 		return nil
 	}
 
+	observationsDB, err := OpenObservationsDB(dataDir)
+	if err != nil {
+		log.Error("failed to open observations DB", "err", err)
+		_ = verifiedDB.Close()
+		return nil
+	}
+
 	// Initialize logsDBs for each chain
 	logsDBs := make(map[eth.ChainID]LogsDB)
 	for chainID := range chains {
@@ -241,6 +254,7 @@ func New(
 			for _, db := range logsDBs {
 				_ = db.Close()
 			}
+			_ = observationsDB.Close()
 			_ = verifiedDB.Close()
 			return nil
 		}
@@ -257,6 +271,7 @@ func New(
 		log:                 log,
 		chains:              chains,
 		verifiedDB:          verifiedDB,
+		observationsDB:      observationsDB,
 		logsDBs:             logsDBs,
 		dataDir:             dataDir,
 		activationTimestamp: activationTimestamp,
@@ -379,8 +394,15 @@ func (i *Interop) readyFirstVerifiableTimestamp(ctx context.Context) (uint64, er
 	if err != nil {
 		return 0, err
 	}
-	if _, err := i.checkChainsReady(first); err != nil {
+	_, allReady, err := i.checkChainsReady(first)
+	if err != nil {
 		return 0, err
+	}
+	if !allReady {
+		// At least one chain reported NotFound — startup must wait until every
+		// chain can serve the optimistic L2/L1 pair. Surface NotFound so the
+		// caller's retry loop polls again.
+		return 0, ethereum.NotFound
 	}
 	return first, nil
 }
@@ -396,6 +418,11 @@ func (i *Interop) Stop(ctx context.Context) error {
 	for chainID, db := range i.logsDBs {
 		if err := db.Close(); err != nil {
 			i.log.Error("failed to close logs DB", "chainID", chainID, "err", err)
+		}
+	}
+	if i.observationsDB != nil {
+		if err := i.observationsDB.Close(); err != nil {
+			i.log.Error("failed to close observations DB", "err", err)
 		}
 	}
 	if i.verifiedDB != nil {
@@ -532,17 +559,29 @@ func (i *Interop) observeRound() (RoundObservation, error) {
 		return obs, nil
 	}
 
-	ready, err := i.checkChainsReady(obs.NextTimestamp)
+	ready, allReady, err := i.checkChainsReady(obs.NextTimestamp)
 	if err != nil {
-		if errors.Is(err, ethereum.NotFound) {
-			obs.ChainsReady = false
-			return obs, nil
-		}
 		return obs, err
 	}
-	obs.ChainsReady = true
+	obs.ChainsReady = allReady
 	obs.BlocksAtTS = ready.blocks
 	obs.L1Heads = ready.l1Heads
+
+	// Persist this round's per-chain observation snapshot atomically. Replacing
+	// the snapshot every round — including dropping chains that previously had
+	// a block but no longer do — is what closes the rewind race against the
+	// OptimisticAtTimestamp RPC. The snapshot remains useful even when not
+	// every chain is ready, since the challenger needs partial visibility to
+	// pinpoint which chain's optimistic step is the InvalidTransition boundary.
+	if i.observationsDB != nil {
+		snap := ObservationsSnapshot{
+			Timestamp: obs.NextTimestamp,
+			Chains:    ready.observations,
+		}
+		if err := i.observationsDB.Set(snap); err != nil {
+			i.log.Warn("failed to persist observation snapshot", "ts", obs.NextTimestamp, "err", err)
+		}
+	}
 
 	// Check that all frontier L1 heads AND the accepted L1 head are on the same canonical fork.
 	heads := make([]eth.BlockID, 0, len(obs.L1Heads)+1)
@@ -817,6 +856,16 @@ func (i *Interop) applyRewindPlan(plan RewindPlan) error {
 		return fmt.Errorf("rewind verifiedDB: %w", err)
 	}
 
+	// Drop the in-flight observation snapshot. After a rewind the snapshot's
+	// timestamp may be at or after the rewind point and the per-chain entries
+	// reflect a chain state that's about to change, so it is unsafe to keep
+	// serving. The next observeRound will rebuild it.
+	if i.observationsDB != nil {
+		if err := i.observationsDB.Clear(); err != nil {
+			i.log.Warn("failed to clear observation snapshot during rewind", "err", err)
+		}
+	}
+
 	var allErrs []error
 	recordErr := func(err error) {
 		if err != nil {
@@ -985,39 +1034,69 @@ func (i *Interop) collectCurrentL1() (eth.BlockID, error) {
 	return currentL1, nil
 }
 
-// checkChainsReady checks if all chains are ready to process the next timestamp.
-// Queries all chains in parallel for better performance.
-// Returns both the L2 blocks at the timestamp and the L1 inclusion heads.
-func (i *Interop) checkChainsReady(ts uint64) (chainsReadyResult, error) {
+// checkChainsReady queries every chain for its optimistic head at the given
+// timestamp and the OutputV0 preimage at that head, in parallel.
+//
+// Returns a partial result: chains that didn't have a block at the timestamp
+// (NotFound) are absent from the maps; allReady is true only when every chain
+// returned successfully. A non-NotFound error from any chain (including the
+// follow-up OutputV0 fetch) is propagated as an unrecoverable error since it
+// indicates a transient RPC issue or invariant violation rather than the
+// chain simply not having a block yet.
+//
+// Captures the per-chain observations (L2 head, L1 head, OutputV0 preimage)
+// so callers can persist them as a durable snapshot. Replacing the snapshot
+// each round — including dropping chains that previously had a block but no
+// longer do — is the mechanism that closes the rewind race against
+// OptimisticAtTimestamp queries.
+func (i *Interop) checkChainsReady(ts uint64) (chainsReadyResult, bool, error) {
 	type result struct {
-		chainID eth.ChainID
-		blockID eth.BlockID
-		l1Head  eth.BlockID
-		err     error
+		chainID  eth.ChainID
+		blockID  eth.BlockID
+		l1Head   eth.BlockID
+		outputV0 *eth.OutputV0
+		notFound bool
+		err      error
 	}
 
 	results := make(chan result, len(i.chains))
 
-	// Query all chains in parallel
 	for _, chain := range i.chains {
-		go func(c cc.ChainContainer) {
+		go func(c cc.InteropChain) {
 			// Use OptimisticAt as the single atomic source for both L2 block and L1 head.
 			// This avoids a TOCTOU race between separate LocalSafeBlockAtTimestamp and OptimisticAt calls.
 			l2Block, l1Block, err := c.OptimisticAt(i.ctx, ts)
 			if err != nil {
-				results <- result{chainID: c.ID(), err: fmt.Errorf("chain %s not ready for timestamp %d: %w", c.ID(), ts, err)}
+				if errors.Is(err, ethereum.NotFound) {
+					results <- result{chainID: c.ID(), notFound: true}
+					return
+				}
+				results <- result{chainID: c.ID(), err: fmt.Errorf("chain %s OptimisticAt %d: %w", c.ID(), ts, err)}
 				return
 			}
-			results <- result{chainID: c.ID(), blockID: l2Block, l1Head: l1Block}
+			outputV0, err := c.OutputV0AtBlockNumber(i.ctx, l2Block.Number)
+			if err != nil {
+				if errors.Is(err, ethereum.NotFound) {
+					results <- result{chainID: c.ID(), notFound: true}
+					return
+				}
+				results <- result{chainID: c.ID(), err: fmt.Errorf("chain %s OutputV0AtBlockNumber %d: %w", c.ID(), l2Block.Number, err)}
+				return
+			}
+			if outputV0.BlockHash != l2Block.Hash {
+				results <- result{chainID: c.ID(), err: fmt.Errorf("chain %s: block %d hash changed (expected %s, got %s): possible reorg", c.ID(), l2Block.Number, l2Block.Hash, outputV0.BlockHash)}
+				return
+			}
+			results <- result{chainID: c.ID(), blockID: l2Block, l1Head: l1Block, outputV0: outputV0}
 		}(chain)
 	}
 
-	// Collect all results before returning so every goroutine completes before the
-	// next call spawns a new batch, preventing accumulation of in-flight RPC calls.
 	ready := chainsReadyResult{
-		blocks:  make(map[eth.ChainID]eth.BlockID),
-		l1Heads: make(map[eth.ChainID]eth.BlockID),
+		blocks:       make(map[eth.ChainID]eth.BlockID),
+		l1Heads:      make(map[eth.ChainID]eth.BlockID),
+		observations: make(map[eth.ChainID]ChainObservation),
 	}
+	allReady := true
 	var firstErr error
 	for range i.chains {
 		r := <-results
@@ -1025,16 +1104,26 @@ func (i *Interop) checkChainsReady(ts uint64) (chainsReadyResult, error) {
 			if firstErr == nil {
 				firstErr = r.err
 			}
-		} else {
-			ready.blocks[r.chainID] = r.blockID
-			ready.l1Heads[r.chainID] = r.l1Head
+			allReady = false
+			continue
+		}
+		if r.notFound {
+			allReady = false
+			continue
+		}
+		ready.blocks[r.chainID] = r.blockID
+		ready.l1Heads[r.chainID] = r.l1Head
+		ready.observations[r.chainID] = ChainObservation{
+			L2Head:                   r.blockID,
+			L1Head:                   r.l1Head,
+			StateRoot:                r.outputV0.StateRoot,
+			MessagePasserStorageRoot: r.outputV0.MessagePasserStorageRoot,
 		}
 	}
 	if firstErr != nil {
-		return chainsReadyResult{}, firstErr
+		return chainsReadyResult{}, false, firstErr
 	}
-
-	return ready, nil
+	return ready, allReady, nil
 }
 
 // CurrentL1 returns the L1 block which has been fully considered for interop,
@@ -1093,35 +1182,70 @@ func (i *Interop) StoredSuperRootAtTimestamp(ts uint64) (data *eth.SuperRootResp
 	return nil, false, nil
 }
 
-// StoredOptimisticAtTimestamp returns the per-chain optimistic snapshot taken
-// at the moment of verification. Each entry is the OutputV0 preimage, its
-// hash, and the per-chain L1 block at which the L2 head became safe.
+// StoredOptimisticAtTimestamp returns the per-chain optimistic snapshot at
+// the timestamp, sourced strictly from durable verifier state.
 //
-// Serving from this durable snapshot rather than a live SafeDB read protects
-// against reorg/pipeline-reset races: even if a chain has rewound between the
-// verifier observing it and the RPC being served, callers see the exact
-// observation that the verifier acted on.
+// Two durable sources are consulted, in order:
 //
-// Denylist overlay: when a chain's L2 block at this timestamp was later
-// invalidated and replaced via cross-safe consolidation, the verified record
-// stores the post-replacement (valid) output. The optimistic view must reflect
-// what the chain ORIGINALLY observed before replacement — that's the denied
-// block. The denylist preserves the original preimage and per-chain L1
-// inclusion captured at decision time, so we override with denylist data
-// whenever a denied record exists at the verified L2 head's height.
+//  1. The committed VerifiedRecord at T — full per-chain cross-safe view.
+//  2. The latest ObservationsSnapshot if it covers T — the verifier's most
+//     recent observation pass at T, which may be partial (some chains absent)
+//     when not all chains had a block ready. Partial views are exactly what
+//     the challenger needs to identify which chain's optimistic step is the
+//     InvalidTransition boundary.
+//
+// In both cases, the per-chain entry is overridden with the denylist record
+// at the L2 head's height when present, so the response reflects the
+// originally-observed (now-denied) block rather than its post-consolidation
+// replacement.
+//
+// No live engine or SafeDB read happens here. After interop activation this
+// function is the sole source of OptimisticAtTimestamp data, closing the
+// race that a chain rewind could otherwise introduce between the response's
+// CurrentL1 field and its per-chain optimistic entries.
 func (i *Interop) StoredOptimisticAtTimestamp(ts uint64) (map[eth.ChainID]eth.OutputWithRequiredL1, bool, error) {
 	if ts < i.activationTimestamp {
 		return nil, false, nil
 	}
+
+	// Prefer the verified record when available.
 	record, err := i.verifiedDB.GetRecord(ts)
-	if errors.Is(err, ErrNotFound) {
+	if err == nil {
+		out, err := i.optimisticFromObservations(record.Chains)
+		if err != nil {
+			return nil, false, err
+		}
+		return out, true, nil
+	}
+	if !errors.Is(err, ErrNotFound) {
+		return nil, false, err
+	}
+
+	// No verified record: fall back to the in-flight observation snapshot if
+	// it covers this timestamp.
+	if i.observationsDB == nil {
 		return nil, false, nil
 	}
+	snap, err := i.observationsDB.Get()
 	if err != nil {
 		return nil, false, err
 	}
-	out := make(map[eth.ChainID]eth.OutputWithRequiredL1, len(record.Chains))
-	for id, obs := range record.Chains {
+	if snap == nil || snap.Timestamp != ts {
+		return nil, false, nil
+	}
+	out, err := i.optimisticFromObservations(snap.Chains)
+	if err != nil {
+		return nil, false, err
+	}
+	return out, true, nil
+}
+
+// optimisticFromObservations builds the per-chain optimistic response from a
+// map of ChainObservation, applying the denylist overlay so invalidated
+// blocks surface their original (denied) output and L1 inclusion.
+func (i *Interop) optimisticFromObservations(observations map[eth.ChainID]ChainObservation) (map[eth.ChainID]eth.OutputWithRequiredL1, error) {
+	out := make(map[eth.ChainID]eth.OutputWithRequiredL1, len(observations))
+	for id, obs := range observations {
 		entry := eth.OutputWithRequiredL1{
 			Output:     ptrOf(obs.OutputV0()),
 			OutputRoot: obs.OutputRoot(),
@@ -1130,7 +1254,7 @@ func (i *Interop) StoredOptimisticAtTimestamp(ts uint64) (map[eth.ChainID]eth.Ou
 		if chain, ok := i.chains[id]; ok {
 			deniedV0, deniedL1, err := chain.LastDeniedAtHeight(obs.L2Head.Number)
 			if err != nil {
-				return nil, false, fmt.Errorf("chain %s: deny list lookup at height %d: %w", id, obs.L2Head.Number, err)
+				return nil, fmt.Errorf("chain %s: deny list lookup at height %d: %w", id, obs.L2Head.Number, err)
 			}
 			if deniedV0 != nil {
 				entry = eth.OutputWithRequiredL1{
@@ -1142,7 +1266,7 @@ func (i *Interop) StoredOptimisticAtTimestamp(ts uint64) (map[eth.ChainID]eth.Ou
 		}
 		out[id] = entry
 	}
-	return out, true, nil
+	return out, nil
 }
 
 func ptrOf[T any](v T) *T { return &v }

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -156,6 +156,7 @@ type Interop struct {
 	started bool
 
 	currentL1 eth.BlockID
+	l1Source  l1Source
 
 	// l1Heads is the snapshot captured with blocksAtTimestamp in observeRound; passing
 	// it through avoids a TOCTOU race against L2 reorgs.
@@ -220,7 +221,7 @@ func New(
 	messageExpiryWindow uint64,
 	chains map[eth.ChainID]cc.InteropChain,
 	dataDir string,
-	l1Source l1ByNumberSource,
+	l1Source l1Source,
 	logBackfillDepth time.Duration,
 	metrics *resources.SupernodeMetrics,
 ) *Interop {
@@ -260,8 +261,14 @@ func New(
 		dataDir:             dataDir,
 		activationTimestamp: activationTimestamp,
 		messageExpiryWindow: messageExpiryWindow,
+		l1Source:            l1Source,
 		logBackfillDepth:    logBackfillDepth,
 		metrics:             metrics,
+	}
+	if currentL1, found, err := verifiedDB.CurrentL1(); err != nil {
+		log.Warn("failed to load durable interop CurrentL1", "err", err)
+	} else if found {
+		i.currentL1 = currentL1
 	}
 	// default to using the verifyInteropMessages function
 	// (can be overridden by tests)
@@ -473,10 +480,7 @@ func (i *Interop) refreshCurrentL1OnWait() (bool, error) {
 		i.log.Debug("failed to collect current L1 on wait", "err", err)
 		return false, nil
 	}
-	i.mu.Lock()
-	i.currentL1 = localL1
-	i.mu.Unlock()
-	return false, nil
+	return false, i.updateCurrentL1(localL1)
 }
 
 // progressInterop prepares the next interop action by observing the world,
@@ -612,7 +616,26 @@ func (i *Interop) newInvalidHead(chainID eth.ChainID, blockID eth.BlockID) (Inva
 
 func (i *Interop) buildPendingTransition(output StepOutput, obs RoundObservation) (PendingTransition, error) {
 	switch output.Decision {
-	case DecisionAdvance, DecisionInvalidate:
+	case DecisionAdvance:
+		result := output.Result
+		currentL1, err := i.claimableCurrentL1(result.L1Inclusion)
+		if err != nil {
+			return PendingTransition{}, fmt.Errorf("resolve claimable current L1: %w", err)
+		}
+		if localL1, err := i.collectCurrentL1(); err != nil {
+			i.log.Warn("failed to collect node CurrentL1 on advance, using claimable L1Inclusion parent", "err", err)
+		} else if localL1.Number < currentL1.Number {
+			currentL1 = localL1
+		}
+		record, err := i.buildVerifiedRecord(result, currentL1)
+		if err != nil {
+			return PendingTransition{}, fmt.Errorf("build verified record: %w", err)
+		}
+		return PendingTransition{
+			Decision: DecisionAdvance,
+			Verified: &record,
+		}, nil
+	case DecisionInvalidate:
 		result := output.Result
 		return PendingTransition{
 			Decision: output.Decision,
@@ -638,9 +661,9 @@ func (i *Interop) applyPendingTransition(pending PendingTransition) (bool, error
 		if pending.Rewind == nil {
 			return false, fmt.Errorf("invalid pending rewind transition: missing rewind plan")
 		}
-		i.mu.Lock()
-		i.currentL1 = eth.BlockID{}
-		i.mu.Unlock()
+		if err := i.updateCurrentL1(eth.BlockID{}); err != nil {
+			return false, fmt.Errorf("reset current L1 before rewind: %w", err)
+		}
 		if err := i.applyRewindPlan(*pending.Rewind); err != nil {
 			return false, fmt.Errorf("apply rewind plan: %w", err)
 		}
@@ -710,39 +733,28 @@ func (i *Interop) applyPendingTransition(pending PendingTransition) (bool, error
 		return false, nil
 
 	case DecisionAdvance:
-		if pending.Result == nil {
+		if pending.Verified == nil {
 			if err := i.verifiedDB.ClearPendingTransition(); err != nil {
 				return false, fmt.Errorf("clear empty advance transition: %w", err)
 			}
 			return false, nil
 		}
-		if err := i.persistFrontierLogs(pending.Result.Timestamp, pending.Result.L2Heads); err != nil {
+		record := *pending.Verified
+		if err := i.persistFrontierLogs(record.Timestamp, record.L2Heads); err != nil {
 			return false, fmt.Errorf("persist frontier logs: %w", err)
 		}
 
-		if err := i.commitVerifiedResult(pending.Result.Timestamp, pending.Result.ToVerifiedResult()); err != nil {
-			return false, fmt.Errorf("commit verified result: %w", err)
+		if err := i.verifiedDB.CommitRecord(record); err != nil {
+			return false, fmt.Errorf("commit verified record: %w", err)
 		}
 		if err := i.verifiedDB.ClearPendingTransition(); err != nil {
 			return false, fmt.Errorf("clear pending transition: %w", err)
 		}
-		i.log.Info("committed verified result", "timestamp", pending.Result.Timestamp)
+		i.log.Info("committed verified result", "timestamp", record.Timestamp)
 		i.metrics.InteropTimestampsVerified.Inc()
-		i.metrics.InteropVerifiedTimestamp.Set(float64(pending.Result.Timestamp))
-		// L1Inclusion is the max L1 block used for derivation across all chains at this
-		// timestamp. It can exceed some chains' actual CurrentL1 — e.g. chain A derived
-		// from L1 1000 while chain B derived from L1 990. Chain B may then advance to
-		// the next timestamp (finding its batch at L1 995) without ever reaching L1 1000.
-		// Cap at the min of all nodes' CurrentL1 so this field is individually safe, not
-		// just safe when aggregated with chain CurrentL1s via syncstatus.Aggregate.
-		currentL1 := pending.Result.L1Inclusion
-		if localL1, err := i.collectCurrentL1(); err != nil {
-			i.log.Warn("failed to collect node CurrentL1 on advance, using L1Inclusion", "err", err)
-		} else if localL1.Number < currentL1.Number {
-			currentL1 = localL1
-		}
+		i.metrics.InteropVerifiedTimestamp.Set(float64(record.Timestamp))
 		i.mu.Lock()
-		i.currentL1 = currentL1
+		i.currentL1 = record.CurrentL1
 		i.mu.Unlock()
 		return true, nil
 	}
@@ -878,6 +890,81 @@ func (i *Interop) resetChainEnginesIfNeeded(plan RewindPlan, sortedChainIDs []et
 	}
 }
 
+// claimableCurrentL1 returns the highest L1 block the verifier can safely
+// report as fully processed after producing a result included in l1Inclusion.
+// The inclusion block itself may contain additional batch data for later
+// verification rounds, so the claimable block is its parent.
+func (i *Interop) claimableCurrentL1(l1Inclusion eth.BlockID) (eth.BlockID, error) {
+	if l1Inclusion == (eth.BlockID{}) || l1Inclusion.Number == 0 {
+		return l1Inclusion, nil
+	}
+	if i.l1Source == nil {
+		// Tests may construct Interop without an L1 client. Production New always
+		// receives the L1 client and uses the hash-based lookup below.
+		return eth.BlockID{Number: l1Inclusion.Number - 1}, nil
+	}
+	ctx := i.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	info, err := i.l1Source.InfoByHash(ctx, l1Inclusion.Hash)
+	if err != nil {
+		return eth.BlockID{}, err
+	}
+	return eth.BlockID{
+		Hash:   info.ParentHash(),
+		Number: l1Inclusion.Number - 1,
+	}, nil
+}
+
+func (i *Interop) updateCurrentL1(currentL1 eth.BlockID) error {
+	if err := i.verifiedDB.SetCurrentL1(currentL1); err != nil {
+		return err
+	}
+	i.mu.Lock()
+	i.currentL1 = currentL1
+	i.mu.Unlock()
+	return nil
+}
+
+func (i *Interop) buildVerifiedRecord(result Result, currentL1 eth.BlockID) (VerifiedRecord, error) {
+	chainIDs := make([]eth.ChainID, 0, len(result.L2Heads))
+	for chainID := range result.L2Heads {
+		chainIDs = append(chainIDs, chainID)
+	}
+	sort.Slice(chainIDs, func(i, j int) bool {
+		return chainIDs[i].Cmp(chainIDs[j]) < 0
+	})
+
+	chainOutputs := make([]eth.ChainIDAndOutput, 0, len(chainIDs))
+	for _, chainID := range chainIDs {
+		blockID := result.L2Heads[chainID]
+		chain, ok := i.chains[chainID]
+		if !ok {
+			return VerifiedRecord{}, fmt.Errorf("chain %s not found", chainID)
+		}
+		outputV0, err := chain.OutputV0AtBlockNumber(i.ctx, blockID.Number)
+		if err != nil {
+			return VerifiedRecord{}, fmt.Errorf("chain %s: failed to compute OutputV0 for block %d: %w", chainID, blockID.Number, err)
+		}
+		if outputV0.BlockHash != blockID.Hash {
+			return VerifiedRecord{}, fmt.Errorf("chain %s: block %d hash changed (expected %s, got %s): possible reorg",
+				chainID, blockID.Number, blockID.Hash, outputV0.BlockHash)
+		}
+		chainOutputs = append(chainOutputs, eth.ChainIDAndOutput{
+			ChainID: chainID,
+			Output:  eth.OutputRoot(outputV0),
+		})
+	}
+	return VerifiedRecord{
+		Timestamp:    result.Timestamp,
+		L1Inclusion:  result.L1Inclusion,
+		L2Heads:      result.L2Heads,
+		ChainOutputs: chainOutputs,
+		CurrentL1:    currentL1,
+	}, nil
+}
+
 // collectCurrentL1 collects the current L1 head of all chains,
 // which is the minimum L1 head of all the derivation pipelines in Chain Containers
 func (i *Interop) collectCurrentL1() (eth.BlockID, error) {
@@ -949,10 +1036,6 @@ func (i *Interop) checkChainsReady(ts uint64) (chainsReadyResult, error) {
 	return ready, nil
 }
 
-func (i *Interop) commitVerifiedResult(timestamp uint64, verifiedResult VerifiedResult) error {
-	return i.verifiedDB.Commit(verifiedResult)
-}
-
 // CurrentL1 returns the L1 block which has been fully considered for interop,
 // whether or not it advanced the verified timestamp.
 func (i *Interop) CurrentL1() eth.BlockID {
@@ -976,6 +1059,21 @@ func (i *Interop) VerifiedAtTimestamp(ts uint64) (bool, error) {
 		return true, nil
 	}
 	return i.verifiedDB.Has(ts)
+}
+
+// StoredSuperRootAtTimestamp returns the verifier's durable superroot response.
+func (i *Interop) StoredSuperRootAtTimestamp(ts uint64) (data *eth.SuperRootResponseData, found bool, err error) {
+	if ts < i.activationTimestamp {
+		return nil, false, nil
+	}
+	record, err := i.verifiedDB.GetRecord(ts)
+	if err == nil {
+		return record.ResponseData(), true, nil
+	}
+	if !errors.Is(err, ErrNotFound) {
+		return nil, false, err
+	}
+	return nil, false, nil
 }
 
 // IsActiveAt reports whether the interop verifier is responsible for verifying

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -165,7 +165,7 @@ type Interop struct {
 	// cycleVerifyFn handles same-timestamp cycle verification.
 	// It is called after verifyFn in progressInterop, and its results are merged.
 	// Set to verifyCycleMessages by default in New().
-	cycleVerifyFn func(ts uint64, blocksAtTimestamp map[eth.ChainID]eth.BlockID, view *frontierVerificationView) (Result, error)
+	cycleVerifyFn func(ts uint64, blocksAtTimestamp map[eth.ChainID]eth.BlockID, l1Heads map[eth.ChainID]eth.BlockID, view *frontierVerificationView) (Result, error)
 
 	// pauseAtTimestamp is used for integration test control only.
 	// When non-zero, progressInterop will return early without processing
@@ -574,7 +574,7 @@ func (i *Interop) verify(ts uint64, blocksAtTS map[eth.ChainID]eth.BlockID, l1He
 		return Result{}, err
 	}
 
-	cycleResult, err := i.cycleVerifyFn(ts, blocksAtTS, view)
+	cycleResult, err := i.cycleVerifyFn(ts, blocksAtTS, l1Heads, view)
 	if err != nil {
 		return Result{}, fmt.Errorf("cycle verification failed: %w", err)
 	}
@@ -595,8 +595,8 @@ func (i *Interop) verify(ts uint64, blocksAtTS map[eth.ChainID]eth.BlockID, l1He
 // fields already attached. Returns an error if the output cannot be computed —
 // at verification time the engine should always have the block, so failure
 // indicates a transient RPC issue or a serious invariant violation.
-func (i *Interop) newInvalidHead(chainID eth.ChainID, blockID eth.BlockID) (InvalidHead, error) {
-	head := InvalidHead{BlockID: blockID}
+func (i *Interop) newInvalidHead(chainID eth.ChainID, blockID eth.BlockID, l1Inclusion eth.BlockID) (InvalidHead, error) {
+	head := InvalidHead{BlockID: blockID, L1Inclusion: l1Inclusion}
 	chain, ok := i.chains[chainID]
 	if !ok {
 		return head, fmt.Errorf("chain %s not found", chainID)
@@ -688,6 +688,7 @@ func (i *Interop) applyPendingTransition(pending PendingTransition) (bool, error
 				Timestamp:                pending.Result.Timestamp,
 				StateRoot:                invalidHead.StateRoot,
 				MessagePasserStorageRoot: invalidHead.MessagePasserStorageRoot,
+				L1Inclusion:              invalidHead.L1Inclusion,
 			})
 		}
 		sort.Slice(invalidations, func(i, j int) bool {
@@ -708,7 +709,7 @@ func (i *Interop) applyPendingTransition(pending PendingTransition) (bool, error
 		}
 		var failedAny bool
 		for _, p := range invalidations {
-			if err := i.invalidateBlock(p.ChainID, p.BlockID, p.Timestamp, p.StateRoot, p.MessagePasserStorageRoot); err != nil {
+			if err := i.invalidateBlock(p.ChainID, p.BlockID, p.Timestamp, p.StateRoot, p.MessagePasserStorageRoot, p.L1Inclusion); err != nil {
 				i.log.Error("invalidation failed, transition preserved for retry on restart",
 					"chain", p.ChainID, "block", p.BlockID, "err", err)
 				failedAny = true
@@ -740,7 +741,7 @@ func (i *Interop) applyPendingTransition(pending PendingTransition) (bool, error
 			return false, nil
 		}
 		record := *pending.Verified
-		if err := i.persistFrontierLogs(record.Timestamp, record.L2Heads); err != nil {
+		if err := i.persistFrontierLogs(record.Timestamp, record.L2Heads()); err != nil {
 			return false, fmt.Errorf("persist frontier logs: %w", err)
 		}
 
@@ -928,17 +929,8 @@ func (i *Interop) updateCurrentL1(currentL1 eth.BlockID) error {
 }
 
 func (i *Interop) buildVerifiedRecord(result Result, currentL1 eth.BlockID) (VerifiedRecord, error) {
-	chainIDs := make([]eth.ChainID, 0, len(result.L2Heads))
-	for chainID := range result.L2Heads {
-		chainIDs = append(chainIDs, chainID)
-	}
-	sort.Slice(chainIDs, func(i, j int) bool {
-		return chainIDs[i].Cmp(chainIDs[j]) < 0
-	})
-
-	chainOutputs := make([]eth.ChainIDAndOutput, 0, len(chainIDs))
-	for _, chainID := range chainIDs {
-		blockID := result.L2Heads[chainID]
+	chains := make(map[eth.ChainID]ChainObservation, len(result.L2Heads))
+	for chainID, blockID := range result.L2Heads {
 		chain, ok := i.chains[chainID]
 		if !ok {
 			return VerifiedRecord{}, fmt.Errorf("chain %s not found", chainID)
@@ -951,17 +943,26 @@ func (i *Interop) buildVerifiedRecord(result Result, currentL1 eth.BlockID) (Ver
 			return VerifiedRecord{}, fmt.Errorf("chain %s: block %d hash changed (expected %s, got %s): possible reorg",
 				chainID, blockID.Number, blockID.Hash, outputV0.BlockHash)
 		}
-		chainOutputs = append(chainOutputs, eth.ChainIDAndOutput{
-			ChainID: chainID,
-			Output:  eth.OutputRoot(outputV0),
-		})
+		// Production callers (verifyInteropMessages) always populate result.L1Heads
+		// per chain. Tolerate a missing entry by falling back to the aggregate
+		// L1Inclusion so test harnesses that synthesise Result without per-chain
+		// L1 heads continue to work; the fallback over-claims (the chain's
+		// per-chain L1 may be earlier than L1Inclusion) but never under-claims.
+		l1Head, ok := result.L1Heads[chainID]
+		if !ok {
+			l1Head = result.L1Inclusion
+		}
+		chains[chainID] = ChainObservation{
+			L2Head:                   blockID,
+			L1Head:                   l1Head,
+			StateRoot:                outputV0.StateRoot,
+			MessagePasserStorageRoot: outputV0.MessagePasserStorageRoot,
+		}
 	}
 	return VerifiedRecord{
-		Timestamp:    result.Timestamp,
-		L1Inclusion:  result.L1Inclusion,
-		L2Heads:      result.L2Heads,
-		ChainOutputs: chainOutputs,
-		CurrentL1:    currentL1,
+		Timestamp: result.Timestamp,
+		Chains:    chains,
+		CurrentL1: currentL1,
 	}, nil
 }
 
@@ -1044,6 +1045,22 @@ func (i *Interop) CurrentL1() eth.BlockID {
 	return i.currentL1
 }
 
+// VerifierCurrentL1 returns the verifier's frontier L1 — the highest L1 block
+// the verifier has fully considered — and whether the value is initialised.
+//
+// Unlike a live SyncStatus aggregate, this value advances on every Wait round
+// (refreshCurrentL1OnWait) without needing a new L2 block, so callers can
+// trust it to keep pace with L1 even between L2 batches. Returns ok=false
+// before the verifier has populated the frontier (pre-activation startup).
+func (i *Interop) VerifierCurrentL1() (eth.BlockID, bool) {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	if i.currentL1 == (eth.BlockID{}) {
+		return eth.BlockID{}, false
+	}
+	return i.currentL1, true
+}
+
 // VerifiedAtTimestamp returns whether the data is verified at the given timestamp.
 // Timestamps before the first verifiable timestamp are already covered by
 // pre-activation consensus or by the safe-head startup handoff.
@@ -1075,6 +1092,60 @@ func (i *Interop) StoredSuperRootAtTimestamp(ts uint64) (data *eth.SuperRootResp
 	}
 	return nil, false, nil
 }
+
+// StoredOptimisticAtTimestamp returns the per-chain optimistic snapshot taken
+// at the moment of verification. Each entry is the OutputV0 preimage, its
+// hash, and the per-chain L1 block at which the L2 head became safe.
+//
+// Serving from this durable snapshot rather than a live SafeDB read protects
+// against reorg/pipeline-reset races: even if a chain has rewound between the
+// verifier observing it and the RPC being served, callers see the exact
+// observation that the verifier acted on.
+//
+// Denylist overlay: when a chain's L2 block at this timestamp was later
+// invalidated and replaced via cross-safe consolidation, the verified record
+// stores the post-replacement (valid) output. The optimistic view must reflect
+// what the chain ORIGINALLY observed before replacement — that's the denied
+// block. The denylist preserves the original preimage and per-chain L1
+// inclusion captured at decision time, so we override with denylist data
+// whenever a denied record exists at the verified L2 head's height.
+func (i *Interop) StoredOptimisticAtTimestamp(ts uint64) (map[eth.ChainID]eth.OutputWithRequiredL1, bool, error) {
+	if ts < i.activationTimestamp {
+		return nil, false, nil
+	}
+	record, err := i.verifiedDB.GetRecord(ts)
+	if errors.Is(err, ErrNotFound) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	out := make(map[eth.ChainID]eth.OutputWithRequiredL1, len(record.Chains))
+	for id, obs := range record.Chains {
+		entry := eth.OutputWithRequiredL1{
+			Output:     ptrOf(obs.OutputV0()),
+			OutputRoot: obs.OutputRoot(),
+			RequiredL1: obs.L1Head,
+		}
+		if chain, ok := i.chains[id]; ok {
+			deniedV0, deniedL1, err := chain.LastDeniedAtHeight(obs.L2Head.Number)
+			if err != nil {
+				return nil, false, fmt.Errorf("chain %s: deny list lookup at height %d: %w", id, obs.L2Head.Number, err)
+			}
+			if deniedV0 != nil {
+				entry = eth.OutputWithRequiredL1{
+					Output:     deniedV0,
+					OutputRoot: eth.OutputRoot(deniedV0),
+					RequiredL1: deniedL1,
+				}
+			}
+		}
+		out[id] = entry
+	}
+	return out, true, nil
+}
+
+func ptrOf[T any](v T) *T { return &v }
 
 // IsActiveAt reports whether the interop verifier is responsible for verifying
 // L2 content at the given timestamp. Returns false for timestamps strictly
@@ -1153,11 +1224,11 @@ func (i *Interop) Reset(chainID eth.ChainID, timestamp uint64, invalidatedBlock 
 
 // invalidateBlock notifies the chain container to add the block to the denylist
 // and potentially rewind if the chain is currently using that block.
-func (i *Interop) invalidateBlock(chainID eth.ChainID, blockID eth.BlockID, decisionTimestamp uint64, stateRoot, messagePasserStorageRoot eth.Bytes32) error {
+func (i *Interop) invalidateBlock(chainID eth.ChainID, blockID eth.BlockID, decisionTimestamp uint64, stateRoot, messagePasserStorageRoot eth.Bytes32, l1Inclusion eth.BlockID) error {
 	chain, ok := i.chains[chainID]
 	if !ok {
 		return fmt.Errorf("chain %s not found", chainID)
 	}
-	_, err := chain.InvalidateBlock(i.ctx, blockID.Number, blockID.Hash, decisionTimestamp, stateRoot, messagePasserStorageRoot)
+	_, err := chain.InvalidateBlock(i.ctx, blockID.Number, blockID.Hash, decisionTimestamp, stateRoot, messagePasserStorageRoot, l1Inclusion)
 	return err
 }

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -616,7 +616,7 @@ func TestCheckChainsReady(t *testing.T) {
 	tests := []struct {
 		name   string
 		setup  func(h *interopTestHarness) *interopTestHarness
-		assert func(t *testing.T, h *interopTestHarness, ready chainsReadyResult, err error)
+		assert func(t *testing.T, h *interopTestHarness, ready chainsReadyResult, allReady bool, err error)
 	}{
 		{
 			name: "all chains ready returns blocks",
@@ -627,25 +627,29 @@ func TestCheckChainsReady(t *testing.T) {
 					m.blockAtTimestamp = eth.L2BlockRef{Number: 200, Hash: common.HexToHash("0x2")}
 				}).Build()
 			},
-			assert: func(t *testing.T, h *interopTestHarness, ready chainsReadyResult, err error) {
+			assert: func(t *testing.T, h *interopTestHarness, ready chainsReadyResult, allReady bool, err error) {
 				require.NoError(t, err)
+				require.True(t, allReady)
 				require.Len(t, ready.blocks, 2)
 				require.NotEqual(t, common.Hash{}, ready.blocks[h.Mock(10).id].Hash)
 				require.NotEqual(t, common.Hash{}, ready.blocks[h.Mock(8453).id].Hash)
 			},
 		},
 		{
-			name: "one chain not ready returns error",
+			name: "one chain not ready returns partial with allReady=false",
 			setup: func(h *interopTestHarness) *interopTestHarness {
 				return h.WithChain(10, func(m *mockChainContainer) {
-					m.blockAtTimestamp = eth.L2BlockRef{Number: 100}
+					m.blockAtTimestamp = eth.L2BlockRef{Number: 100, Hash: common.HexToHash("0x1")}
 				}).WithChain(8453, func(m *mockChainContainer) {
 					m.blockAtTimestampErr = ethereum.NotFound
 				}).Build()
 			},
-			assert: func(t *testing.T, h *interopTestHarness, ready chainsReadyResult, err error) {
-				require.Error(t, err)
-				require.Nil(t, ready.blocks)
+			assert: func(t *testing.T, h *interopTestHarness, ready chainsReadyResult, allReady bool, err error) {
+				require.NoError(t, err)
+				require.False(t, allReady)
+				require.Len(t, ready.blocks, 1)
+				require.Contains(t, ready.blocks, h.Mock(10).id)
+				require.NotContains(t, ready.blocks, h.Mock(8453).id)
 			},
 		},
 		{
@@ -659,32 +663,33 @@ func TestCheckChainsReady(t *testing.T) {
 				}
 				return h.Build()
 			},
-			assert: func(t *testing.T, h *interopTestHarness, ready chainsReadyResult, err error) {
+			assert: func(t *testing.T, h *interopTestHarness, ready chainsReadyResult, allReady bool, err error) {
 				require.NoError(t, err)
+				require.True(t, allReady)
 				require.Len(t, ready.blocks, 5)
 			},
 		},
 		{
 			// Verify that checkChainsReady drains ALL goroutine results before returning,
-			// even when one chain errors early. Without the drain, the slow chain's goroutine
-			// would still be running concurrently when the next call spawns a new batch —
-			// causing goroutine accumulation under repeated retries.
-			name: "drains all goroutine results before returning on error",
+			// even when one chain reports NotFound. Without the drain, the slow chain's
+			// goroutine would still be running concurrently when the next call spawns a
+			// new batch — causing goroutine accumulation under repeated retries.
+			name: "drains all goroutine results before returning on partial",
 			setup: func(h *interopTestHarness) *interopTestHarness {
 				return h.WithChain(10, func(m *mockChainContainer) {
-					// Errors immediately, causing an early-return path.
+					// Returns NotFound immediately.
 					m.blockAtTimestampErr = ethereum.NotFound
 				}).WithChain(8453, func(m *mockChainContainer) {
-					// Slow chain: takes longer than the fast-error chain.
+					// Slow chain: takes longer than the fast-not-found chain.
 					// After checkChainsReady returns, callsCompleted must be 1,
 					// proving the function waited for this goroutine to finish.
 					m.blockAtTimestamp = eth.L2BlockRef{Number: 200}
 					m.blockAtTimestampDelay = 30 * time.Millisecond
 				}).Build()
 			},
-			assert: func(t *testing.T, h *interopTestHarness, ready chainsReadyResult, err error) {
-				require.Error(t, err)
-				require.Nil(t, ready.blocks)
+			assert: func(t *testing.T, h *interopTestHarness, ready chainsReadyResult, allReady bool, err error) {
+				require.NoError(t, err)
+				require.False(t, allReady)
 				// Both goroutines must have completed before checkChainsReady returned.
 				require.EqualValues(t, 1, h.Mock(10).callsCompleted.Load(), "chain 10 goroutine should have completed")
 				require.EqualValues(t, 1, h.Mock(8453).callsCompleted.Load(), "chain 8453 goroutine should have completed before return")
@@ -696,8 +701,8 @@ func TestCheckChainsReady(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			h := newInteropTestHarness(t)
 			tc.setup(h)
-			ready, err := h.interop.checkChainsReady(1000)
-			tc.assert(t, h, ready, err)
+			ready, allReady, err := h.interop.checkChainsReady(1000)
+			tc.assert(t, h, ready, allReady, err)
 		})
 	}
 }

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -382,7 +382,7 @@ func TestStartWithoutBackfillUsesFirstVerifiableTimestamp(t *testing.T) {
 	defer cancel()
 
 	verifiedTS := make(chan uint64, 1)
-	h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
+	h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, l1Heads map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
 		verifiedTS <- ts
 		cancel()
 		return Result{}, nil
@@ -710,14 +710,14 @@ func TestProgressInterop(t *testing.T) {
 	t.Parallel()
 
 	// Default verifyFn that passes through
-	passThroughVerifyFn := func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
+	passThroughVerifyFn := func(ts uint64, blocks map[eth.ChainID]eth.BlockID, l1Heads map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
 		return Result{Timestamp: ts, L1Inclusion: eth.BlockID{Number: 100}, L2Heads: blocks}, nil
 	}
 
 	tests := []struct {
 		name     string
 		setup    func(h *interopTestHarness) *interopTestHarness
-		verifyFn func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error)
+		verifyFn func(ts uint64, blocks map[eth.ChainID]eth.BlockID, l1Heads map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error)
 		assert   func(t *testing.T, result Result, err error)
 		run      func(t *testing.T, h *interopTestHarness) // override for complex cases
 	}{
@@ -791,7 +791,7 @@ func TestProgressInterop(t *testing.T) {
 					m.blockAtTimestamp = eth.L2BlockRef{Number: 500, Hash: common.HexToHash("0xL2")}
 				}).Build()
 			},
-			verifyFn: func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
+			verifyFn: func(ts uint64, blocks map[eth.ChainID]eth.BlockID, l1Heads map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
 				return Result{}, errors.New("verification failed")
 			},
 			assert: func(t *testing.T, result Result, err error) {
@@ -840,7 +840,7 @@ func TestProgressInteropWithCycleVerify(t *testing.T) {
 			},
 			run: func(t *testing.T, h *interopTestHarness) {
 				// Set verifyFn to return a valid result
-				h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
+				h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, l1Heads map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
 					return Result{Timestamp: ts, L2Heads: blocks}, nil
 				}
 				// cycleVerifyFn is overridden with this stub implementation.
@@ -867,13 +867,13 @@ func TestProgressInteropWithCycleVerify(t *testing.T) {
 				chain8453 := eth.ChainIDFromUInt64(8453)
 
 				// verifyFn returns valid result
-				h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
+				h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, l1Heads map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
 					verifyFnCalled = true
 					return Result{Timestamp: ts, L2Heads: blocks}, nil
 				}
 
 				// cycleVerifyFn marks chain 8453 as invalid
-				h.interop.cycleVerifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
+				h.interop.cycleVerifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, l1Heads map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
 					require.True(t, verifyFnCalled, "verifyFn should be called before cycleVerifyFn")
 					cycleVerifyFnCalled = true
 					return Result{
@@ -902,10 +902,10 @@ func TestProgressInteropWithCycleVerify(t *testing.T) {
 				}).Build()
 			},
 			run: func(t *testing.T, h *interopTestHarness) {
-				h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
+				h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, l1Heads map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
 					return Result{Timestamp: ts, L2Heads: blocks}, nil
 				}
-				h.interop.cycleVerifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
+				h.interop.cycleVerifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, l1Heads map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
 					return Result{}, errors.New("cycle verification failed")
 				}
 
@@ -929,7 +929,7 @@ func TestProgressInteropWithCycleVerify(t *testing.T) {
 				chain8453 := eth.ChainIDFromUInt64(8453)
 
 				// verifyFn marks chain 10 as invalid
-				h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
+				h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, l1Heads map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
 					return Result{
 						Timestamp: ts,
 						L2Heads:   blocks,
@@ -940,7 +940,7 @@ func TestProgressInteropWithCycleVerify(t *testing.T) {
 				}
 
 				// cycleVerifyFn marks chain 8453 as invalid
-				h.interop.cycleVerifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
+				h.interop.cycleVerifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, l1Heads map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
 					return Result{
 						Timestamp: ts,
 						L2Heads:   blocks,
@@ -1041,7 +1041,7 @@ func TestVerifiedAtTimestamp(t *testing.T) {
 				}).Build()
 			},
 			run: func(t *testing.T, h *interopTestHarness) {
-				h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
+				h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, l1Heads map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
 					return Result{Timestamp: ts, L1Inclusion: eth.BlockID{Number: 100}, L2Heads: blocks}, nil
 				}
 
@@ -1253,7 +1253,7 @@ func TestInvalidateBlock(t *testing.T) {
 			run: func(t *testing.T, h *interopTestHarness) {
 				mock := h.Mock(10)
 				blockID := eth.BlockID{Number: 500, Hash: common.HexToHash("0xBAD")}
-				err := h.interop.invalidateBlock(mock.id, blockID, 0, eth.Bytes32{}, eth.Bytes32{})
+				err := h.interop.invalidateBlock(mock.id, blockID, 0, eth.Bytes32{}, eth.Bytes32{}, eth.BlockID{})
 				require.NoError(t, err)
 
 				require.Len(t, mock.invalidateBlockCalls, 1)
@@ -1270,7 +1270,7 @@ func TestInvalidateBlock(t *testing.T) {
 				mock := h.Mock(10)
 				unknownChain := eth.ChainIDFromUInt64(999)
 				blockID := eth.BlockID{Number: 500, Hash: common.HexToHash("0xBAD")}
-				err := h.interop.invalidateBlock(unknownChain, blockID, 0, eth.Bytes32{}, eth.Bytes32{})
+				err := h.interop.invalidateBlock(unknownChain, blockID, 0, eth.Bytes32{}, eth.Bytes32{}, eth.BlockID{})
 
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "not found")
@@ -1287,7 +1287,7 @@ func TestInvalidateBlock(t *testing.T) {
 			run: func(t *testing.T, h *interopTestHarness) {
 				mock := h.Mock(10)
 				blockID := eth.BlockID{Number: 500, Hash: common.HexToHash("0xBAD")}
-				err := h.interop.invalidateBlock(mock.id, blockID, 0, eth.Bytes32{}, eth.Bytes32{})
+				err := h.interop.invalidateBlock(mock.id, blockID, 0, eth.Bytes32{}, eth.Bytes32{}, eth.BlockID{})
 
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "engine failure")
@@ -1382,7 +1382,7 @@ func TestProgressAndRecord(t *testing.T) {
 			},
 			run: func(t *testing.T, h *interopTestHarness) {
 				expectedL1Inclusion := eth.BlockID{Number: 150, Hash: common.HexToHash("0xL1Result")}
-				h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
+				h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, l1Heads map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
 					return Result{Timestamp: ts, L1Inclusion: expectedL1Inclusion, L2Heads: blocks}, nil
 				}
 
@@ -1408,7 +1408,7 @@ func TestProgressAndRecord(t *testing.T) {
 			run: func(t *testing.T, h *interopTestHarness) {
 				// L1Inclusion is 1000 (from the leading chain) but chain 8453 is only at 990.
 				// interop.currentL1 must be capped at 990 so it never exceeds any node's CurrentL1.
-				h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
+				h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, l1Heads map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
 					return Result{
 						Timestamp:   ts,
 						L1Inclusion: eth.BlockID{Number: 1000, Hash: common.HexToHash("0xleading")},
@@ -1437,7 +1437,7 @@ func TestProgressAndRecord(t *testing.T) {
 				initialL1 := eth.BlockID{Number: 50, Hash: common.HexToHash("0x50")}
 				h.interop.currentL1 = initialL1
 
-				h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
+				h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, l1Heads map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
 					return Result{
 						Timestamp:    ts,
 						L1Inclusion:  eth.BlockID{Number: 999, Hash: common.HexToHash("0xShouldNotBeUsed")},
@@ -1506,7 +1506,7 @@ func TestInterop_FullCycle(t *testing.T) {
 	require.False(t, hasBlocks)
 
 	// Stub verifyFn
-	interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
+	interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, l1Heads map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
 		return Result{Timestamp: ts, L1Inclusion: eth.BlockID{Number: 100}, L2Heads: blocks}, nil
 	}
 
@@ -1560,10 +1560,10 @@ func TestInterop_ProgressAndRecord_MultiAdvance(t *testing.T) {
 		Build()
 
 	mock := h.Mock(10)
-	h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
+	h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, l1Heads map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
 		return Result{Timestamp: ts, L1Inclusion: eth.BlockID{Number: 100}, L2Heads: blocks}, nil
 	}
-	h.interop.cycleVerifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
+	h.interop.cycleVerifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, l1Heads map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
 		return Result{}, nil
 	}
 
@@ -1612,10 +1612,10 @@ func TestInterop_ProgressAndRecord_L1InconsistencyTriggersRewind(t *testing.T) {
 		Build()
 
 	mock := h.Mock(10)
-	h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
+	h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, l1Heads map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
 		return Result{Timestamp: ts, L1Inclusion: eth.BlockID{Number: 100}, L2Heads: blocks}, nil
 	}
-	h.interop.cycleVerifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
+	h.interop.cycleVerifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, l1Heads map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
 		return Result{}, nil
 	}
 
@@ -1805,6 +1805,7 @@ type invalidateBlockCall struct {
 	payloadHash              common.Hash
 	stateRoot                eth.Bytes32
 	messagePasserStorageRoot eth.Bytes32
+	l1Inclusion              eth.BlockID
 }
 
 func newMockChainContainer(id uint64) *mockChainContainer {
@@ -1967,10 +1968,10 @@ func (m *mockChainContainer) BlockTime() uint64 {
 	}
 	return 1
 }
-func (m *mockChainContainer) InvalidateBlock(ctx context.Context, height uint64, payloadHash common.Hash, decisionTimestamp uint64, stateRoot, messagePasserStorageRoot eth.Bytes32) (bool, error) {
+func (m *mockChainContainer) InvalidateBlock(ctx context.Context, height uint64, payloadHash common.Hash, decisionTimestamp uint64, stateRoot, messagePasserStorageRoot eth.Bytes32, l1Inclusion eth.BlockID) (bool, error) {
 	m.mu.Lock()
 	m.invalidateBlockCalls = append(m.invalidateBlockCalls, invalidateBlockCall{
-		height: height, payloadHash: payloadHash, stateRoot: stateRoot, messagePasserStorageRoot: messagePasserStorageRoot,
+		height: height, payloadHash: payloadHash, stateRoot: stateRoot, messagePasserStorageRoot: messagePasserStorageRoot, l1Inclusion: l1Inclusion,
 	})
 	m.mu.Unlock()
 	if m.callLog != nil {
@@ -1990,6 +1991,9 @@ func (m *mockChainContainer) OutputV0AtBlockNumber(ctx context.Context, l2BlockN
 }
 func (m *mockChainContainer) GetDeniedOutput(height uint64, payloadHash common.Hash) (*eth.OutputV0, error) {
 	return nil, nil
+}
+func (m *mockChainContainer) LastDeniedAtHeight(height uint64) (*eth.OutputV0, eth.BlockID, error) {
+	return nil, eth.BlockID{}, nil
 }
 func (m *mockChainContainer) PruneDeniedAtOrAfterTimestamp(timestamp uint64) (map[uint64][]common.Hash, error) {
 	if m.pruneDeniedResult != nil {
@@ -2348,7 +2352,7 @@ func TestRewindAccepted(t *testing.T) {
 		chainID := mock.id
 
 		// Stub verifyFn
-		h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, _ map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
+		h.interop.verifyFn = func(ts uint64, blocks map[eth.ChainID]eth.BlockID, l1Heads map[eth.ChainID]eth.BlockID, _ *frontierVerificationView) (Result, error) {
 			return Result{Timestamp: ts, L1Inclusion: eth.BlockID{Number: ts}, L2Heads: blocks}, nil
 		}
 

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -1073,7 +1073,7 @@ func TestFirstVerifiableTimestampRestoresSafeHeadHandoffAfterRestart(t *testing.
 	dataDir := t.TempDir()
 	db, err := OpenVerifiedDB(dataDir)
 	require.NoError(t, err)
-	require.NoError(t, db.Commit(VerifiedResult{
+	require.NoError(t, commitVerifiedResult(db, VerifiedResult{
 		Timestamp:   126,
 		L1Inclusion: eth.BlockID{Number: 1, Hash: common.HexToHash("0x1")},
 		L2Heads:     map[eth.ChainID]eth.BlockID{eth.ChainIDFromUInt64(10): {Number: 126, Hash: common.HexToHash("0x2")}},
@@ -1176,7 +1176,7 @@ func TestApplyResultCompat(t *testing.T) {
 					Timestamp:   1001,
 					L1Inclusion: eth.BlockID{Number: 100, Hash: common.HexToHash("0xL1")},
 					L2Heads: map[eth.ChainID]eth.BlockID{
-						mock.id: {Number: 500, Hash: common.HexToHash("0xL2")},
+						mock.id: {Number: 500, Hash: common.BigToHash(big.NewInt(500))},
 					},
 				}
 
@@ -1373,7 +1373,7 @@ func TestProgressAndRecord(t *testing.T) {
 			},
 		},
 		{
-			name: "valid result sets L1 to result L1Head",
+			name: "valid result uses parent of L1Inclusion as claimable CurrentL1",
 			setup: func(h *interopTestHarness) *interopTestHarness {
 				return h.WithChain(10, func(m *mockChainContainer) {
 					m.currentL1 = eth.BlockRef{Number: 200, Hash: common.HexToHash("0x200")}
@@ -1390,8 +1390,8 @@ func TestProgressAndRecord(t *testing.T) {
 				require.NoError(t, err)
 				require.True(t, madeProgress, "valid result should advance verified timestamp")
 
-				require.Equal(t, expectedL1Inclusion.Number, h.interop.currentL1.Number)
-				require.Equal(t, expectedL1Inclusion.Hash, h.interop.currentL1.Hash)
+				require.Equal(t, expectedL1Inclusion.Number-1, h.interop.currentL1.Number)
+				require.Equal(t, common.Hash{}, h.interop.currentL1.Hash)
 			},
 		},
 		{
@@ -2122,12 +2122,12 @@ func TestPendingTransition_RecoverRewindPreservedOnFailure(t *testing.T) {
 
 	mock := h.Mock(10)
 
-	require.NoError(t, h.interop.verifiedDB.Commit(VerifiedResult{
+	require.NoError(t, commitVerifiedResult(h.interop.verifiedDB, VerifiedResult{
 		Timestamp:   1000,
 		L1Inclusion: eth.BlockID{Number: 50, Hash: common.HexToHash("0xL1a")},
 		L2Heads:     map[eth.ChainID]eth.BlockID{mock.id: {Number: 100, Hash: common.HexToHash("0x1")}},
 	}))
-	require.NoError(t, h.interop.verifiedDB.Commit(VerifiedResult{
+	require.NoError(t, commitVerifiedResult(h.interop.verifiedDB, VerifiedResult{
 		Timestamp:   1001,
 		L1Inclusion: eth.BlockID{Number: 51, Hash: common.HexToHash("0xL1b")},
 		L2Heads:     map[eth.ChainID]eth.BlockID{mock.id: {Number: 101, Hash: common.HexToHash("0x2")}},
@@ -2170,7 +2170,7 @@ func TestPendingTransition_RewindReplaysAfterFailure(t *testing.T) {
 	mockA := h.Mock(10)
 	mockB := h.Mock(8453)
 
-	require.NoError(t, h.interop.verifiedDB.Commit(VerifiedResult{
+	require.NoError(t, commitVerifiedResult(h.interop.verifiedDB, VerifiedResult{
 		Timestamp:   1000,
 		L1Inclusion: eth.BlockID{Number: 50, Hash: common.HexToHash("0xL1a")},
 		L2Heads: map[eth.ChainID]eth.BlockID{
@@ -2178,7 +2178,7 @@ func TestPendingTransition_RewindReplaysAfterFailure(t *testing.T) {
 			mockB.id: {Number: 200, Hash: common.HexToHash("0xb1")},
 		},
 	}))
-	require.NoError(t, h.interop.verifiedDB.Commit(VerifiedResult{
+	require.NoError(t, commitVerifiedResult(h.interop.verifiedDB, VerifiedResult{
 		Timestamp:   1001,
 		L1Inclusion: eth.BlockID{Number: 51, Hash: common.HexToHash("0xL1b")},
 		L2Heads: map[eth.ChainID]eth.BlockID{
@@ -2237,7 +2237,7 @@ func TestPendingTransition_RecoverRewindReportsAllFailures(t *testing.T) {
 	mockA := h.Mock(10)
 	mockB := h.Mock(8453)
 
-	require.NoError(t, h.interop.verifiedDB.Commit(VerifiedResult{
+	require.NoError(t, commitVerifiedResult(h.interop.verifiedDB, VerifiedResult{
 		Timestamp:   1000,
 		L1Inclusion: eth.BlockID{Number: 50, Hash: common.HexToHash("0xL1a")},
 		L2Heads: map[eth.ChainID]eth.BlockID{
@@ -2245,7 +2245,7 @@ func TestPendingTransition_RecoverRewindReportsAllFailures(t *testing.T) {
 			mockB.id: {Number: 200, Hash: common.HexToHash("0x2")},
 		},
 	}))
-	require.NoError(t, h.interop.verifiedDB.Commit(VerifiedResult{
+	require.NoError(t, commitVerifiedResult(h.interop.verifiedDB, VerifiedResult{
 		Timestamp:   1001,
 		L1Inclusion: eth.BlockID{Number: 51, Hash: common.HexToHash("0xL1b")},
 		L2Heads: map[eth.ChainID]eth.BlockID{
@@ -2277,15 +2277,17 @@ func TestPendingTransition_RecoverAdvanceAfterCommitClearsPendingTransition(t *t
 		Timestamp:   1000,
 		L1Inclusion: eth.BlockID{Hash: common.HexToHash("0xL1"), Number: 100},
 		L2Heads: map[eth.ChainID]eth.BlockID{
-			mock.id: {Hash: common.HexToHash("0xaaa"), Number: 500},
+			mock.id: {Hash: common.BigToHash(big.NewInt(500)), Number: 500},
 		},
 	}
 
+	record, err := h.interop.buildVerifiedRecord(result, eth.BlockID{})
+	require.NoError(t, err)
 	require.NoError(t, h.interop.verifiedDB.SetPendingTransition(PendingTransition{
 		Decision: DecisionAdvance,
-		Result:   &result,
+		Verified: &record,
 	}))
-	require.NoError(t, h.interop.verifiedDB.Commit(result.ToVerifiedResult()))
+	require.NoError(t, h.interop.verifiedDB.CommitRecord(record))
 
 	madeProgress, err := h.interop.progressAndRecord()
 	require.NoError(t, err)
@@ -2312,7 +2314,7 @@ func TestL1CanonicalityCheckErrorPropagates(t *testing.T) {
 	mock := h.Mock(10)
 
 	// Commit a verified result so observeRound has a LastVerified to check
-	err := h.interop.verifiedDB.Commit(VerifiedResult{
+	err := commitVerifiedResult(h.interop.verifiedDB, VerifiedResult{
 		Timestamp:   1000,
 		L1Inclusion: eth.BlockID{Number: 50, Hash: common.HexToHash("0xL1")},
 		L2Heads:     map[eth.ChainID]eth.BlockID{mock.id: {Number: 100, Hash: common.HexToHash("0x1")}},
@@ -2351,13 +2353,13 @@ func TestRewindAccepted(t *testing.T) {
 		}
 
 		// Commit two verified results: T=1000 and T=1001
-		err := h.interop.verifiedDB.Commit(VerifiedResult{
+		err := commitVerifiedResult(h.interop.verifiedDB, VerifiedResult{
 			Timestamp:   1000,
 			L1Inclusion: eth.BlockID{Number: 50, Hash: common.HexToHash("0xL1a")},
 			L2Heads:     map[eth.ChainID]eth.BlockID{chainID: {Number: 100, Hash: common.HexToHash("0x1")}},
 		})
 		require.NoError(t, err)
-		err = h.interop.verifiedDB.Commit(VerifiedResult{
+		err = commitVerifiedResult(h.interop.verifiedDB, VerifiedResult{
 			Timestamp:   1001,
 			L1Inclusion: eth.BlockID{Number: 51, Hash: common.HexToHash("0xL1b")},
 			L2Heads:     map[eth.ChainID]eth.BlockID{chainID: {Number: 101, Hash: common.HexToHash("0x2")}},
@@ -2406,7 +2408,7 @@ func TestRewindAccepted(t *testing.T) {
 		mockA := h.Mock(10)
 		mockB := h.Mock(8453)
 
-		require.NoError(t, h.interop.verifiedDB.Commit(VerifiedResult{
+		require.NoError(t, commitVerifiedResult(h.interop.verifiedDB, VerifiedResult{
 			Timestamp:   1000,
 			L1Inclusion: eth.BlockID{Number: 50, Hash: common.HexToHash("0xL1a")},
 			L2Heads: map[eth.ChainID]eth.BlockID{
@@ -2414,7 +2416,7 @@ func TestRewindAccepted(t *testing.T) {
 				mockB.id: {Number: 200, Hash: common.HexToHash("0xb1")},
 			},
 		}))
-		require.NoError(t, h.interop.verifiedDB.Commit(VerifiedResult{
+		require.NoError(t, commitVerifiedResult(h.interop.verifiedDB, VerifiedResult{
 			Timestamp:   1001,
 			L1Inclusion: eth.BlockID{Number: 51, Hash: common.HexToHash("0xL1b")},
 			L2Heads: map[eth.ChainID]eth.BlockID{
@@ -2444,12 +2446,12 @@ func TestRewindAccepted(t *testing.T) {
 			Build()
 
 		mock := h.Mock(10)
-		require.NoError(t, h.interop.verifiedDB.Commit(VerifiedResult{
+		require.NoError(t, commitVerifiedResult(h.interop.verifiedDB, VerifiedResult{
 			Timestamp:   1000,
 			L1Inclusion: eth.BlockID{Number: 50, Hash: common.HexToHash("0xL1a")},
 			L2Heads:     map[eth.ChainID]eth.BlockID{mock.id: {Number: 100, Hash: common.HexToHash("0xa1")}},
 		}))
-		require.NoError(t, h.interop.verifiedDB.Commit(VerifiedResult{
+		require.NoError(t, commitVerifiedResult(h.interop.verifiedDB, VerifiedResult{
 			Timestamp:   1001,
 			L1Inclusion: eth.BlockID{Number: 51, Hash: common.HexToHash("0xL1b")},
 			L2Heads:     map[eth.ChainID]eth.BlockID{mock.id: {Number: 101, Hash: common.HexToHash("0xa2")}},
@@ -2468,7 +2470,7 @@ func TestRewindAccepted(t *testing.T) {
 		chainID := h.Mock(10).id
 
 		// Commit one result at activation timestamp
-		err := h.interop.verifiedDB.Commit(VerifiedResult{
+		err := commitVerifiedResult(h.interop.verifiedDB, VerifiedResult{
 			Timestamp:   1000,
 			L1Inclusion: eth.BlockID{Number: 50},
 			L2Heads:     map[eth.ChainID]eth.BlockID{chainID: {Number: 100}},
@@ -2537,7 +2539,7 @@ func (m *mockLogsDBWithState) Close() error { return nil }
 
 var _ LogsDB = (*mockLogsDBWithState)(nil)
 
-// errorL1Source implements l1ByNumberSource and always returns an error.
+// errorL1Source implements l1Source and always returns an error.
 // This is separate from mockL1Source in checker_test.go which uses a map lookup.
 type errorL1Source struct {
 	err error
@@ -2545,6 +2547,10 @@ type errorL1Source struct {
 
 func (m *errorL1Source) L1BlockRefByNumber(ctx context.Context, num uint64) (eth.L1BlockRef, error) {
 	return eth.L1BlockRef{}, m.err
+}
+
+func (m *errorL1Source) InfoByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, error) {
+	return nil, m.err
 }
 
 // progressInteropCompat replicates the old progressInterop() behavior for test compatibility.
@@ -2669,7 +2675,7 @@ func TestResetIsNoOp(t *testing.T) {
 		Build()
 
 	mock := h.Mock(10)
-	err := h.interop.verifiedDB.Commit(VerifiedResult{
+	err := commitVerifiedResult(h.interop.verifiedDB, VerifiedResult{
 		Timestamp:   1000,
 		L1Inclusion: eth.BlockID{Number: 50},
 		L2Heads:     map[eth.ChainID]eth.BlockID{mock.id: {Number: 100}},
@@ -2705,7 +2711,7 @@ func TestVerifiedBlockAtL1(t *testing.T) {
 
 		// Commit some verified results so the DB is non-empty
 		for ts := uint64(100); ts <= 110; ts++ {
-			err := h.interop.verifiedDB.Commit(VerifiedResult{
+			err := commitVerifiedResult(h.interop.verifiedDB, VerifiedResult{
 				Timestamp:   ts,
 				L1Inclusion: eth.BlockID{Number: ts + 1000},
 				L2Heads:     map[eth.ChainID]eth.BlockID{h.Mock(10).id: {Number: ts}},
@@ -2733,7 +2739,7 @@ func TestVerifiedBlockAtL1(t *testing.T) {
 			if ts == 1005 {
 				l2Head = expectedL2
 			}
-			err := h.interop.verifiedDB.Commit(VerifiedResult{
+			err := commitVerifiedResult(h.interop.verifiedDB, VerifiedResult{
 				Timestamp:   ts,
 				L1Inclusion: eth.BlockID{Number: ts * 10}, // L1 inclusion grows with timestamp
 				L2Heads:     map[eth.ChainID]eth.BlockID{chainID: l2Head},

--- a/op-supernode/supernode/activity/interop/observations_db.go
+++ b/op-supernode/supernode/activity/interop/observations_db.go
@@ -1,0 +1,109 @@
+package interop
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"sync"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+
+	bolt "go.etcd.io/bbolt"
+)
+
+const observationsDBName = "ChainObservations"
+
+var (
+	observationsBucketName = []byte("snapshot")
+	observationsKey        = []byte("current")
+)
+
+// ObservationsSnapshot is the per-chain optimistic observation snapshot
+// captured by the verifier during a single round, tied to a specific
+// timestamp. The verifier replaces it atomically each round so RPC reads see
+// a consistent (timestamp, per-chain observations) view tied to the verifier's
+// most recent observation pass — not to live SafeDB state which can race with
+// chain rewinds.
+//
+// Only one snapshot is retained at a time. The verifier processes timestamps
+// sequentially, so a snapshot covers exactly the next-up timestamp the
+// verifier is trying to verify. Once that timestamp is committed as a
+// VerifiedRecord, the verified record supersedes the snapshot for queries at
+// that timestamp; the snapshot is then overwritten by the next round's
+// observation pass at lastVerifiedTS+1.
+type ObservationsSnapshot struct {
+	Timestamp uint64                           `json:"timestamp"`
+	Chains    map[eth.ChainID]ChainObservation `json:"chains"`
+}
+
+// ObservationsDB persists ObservationsSnapshot atomically.
+type ObservationsDB struct {
+	db *bolt.DB
+	mu sync.RWMutex
+}
+
+func OpenObservationsDB(dataDir string) (*ObservationsDB, error) {
+	dbPath := filepath.Join(dataDir, observationsDBName+".db")
+	db, err := bolt.Open(dbPath, 0600, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open observations bbolt at %s: %w", dbPath, err)
+	}
+	err = db.Update(func(tx *bolt.Tx) error {
+		_, err := tx.CreateBucketIfNotExists(observationsBucketName)
+		return err
+	})
+	if err != nil {
+		db.Close()
+		return nil, fmt.Errorf("failed to create observations bucket: %w", err)
+	}
+	return &ObservationsDB{db: db}, nil
+}
+
+// Set replaces the current snapshot atomically.
+func (o *ObservationsDB) Set(snap ObservationsSnapshot) error {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	value, err := json.Marshal(snap)
+	if err != nil {
+		return fmt.Errorf("marshal observations snapshot: %w", err)
+	}
+	return o.db.Update(func(tx *bolt.Tx) error {
+		return tx.Bucket(observationsBucketName).Put(observationsKey, value)
+	})
+}
+
+// Get returns the current snapshot, or nil if nothing has been stored.
+func (o *ObservationsDB) Get() (*ObservationsSnapshot, error) {
+	o.mu.RLock()
+	defer o.mu.RUnlock()
+	var snap *ObservationsSnapshot
+	err := o.db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket(observationsBucketName)
+		val := b.Get(observationsKey)
+		if val == nil {
+			return nil
+		}
+		snap = &ObservationsSnapshot{}
+		return json.Unmarshal(val, snap)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("read observations snapshot: %w", err)
+	}
+	return snap, nil
+}
+
+// Clear removes any stored snapshot. Used on rewind so stale per-chain
+// observations cannot be served after the verifier's frontier moves
+// backward.
+func (o *ObservationsDB) Clear() error {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return o.db.Update(func(tx *bolt.Tx) error {
+		return tx.Bucket(observationsBucketName).Delete(observationsKey)
+	})
+}
+
+// Close closes the database.
+func (o *ObservationsDB) Close() error {
+	return o.db.Close()
+}

--- a/op-supernode/supernode/activity/interop/types.go
+++ b/op-supernode/supernode/activity/interop/types.go
@@ -13,6 +13,33 @@ type VerifiedResult struct {
 	L2Heads     map[eth.ChainID]eth.BlockID `json:"l2Heads"`
 }
 
+// VerifiedRecord is the durable verifier snapshot at a timestamp.
+// It stores only source facts; ResponseData derives the redundant RPC fields.
+type VerifiedRecord struct {
+	Timestamp    uint64                      `json:"timestamp"`
+	L1Inclusion  eth.BlockID                 `json:"l1Inclusion"`
+	L2Heads      map[eth.ChainID]eth.BlockID `json:"l2Heads"`
+	ChainOutputs []eth.ChainIDAndOutput      `json:"chainOutputs"`
+	CurrentL1    eth.BlockID                 `json:"currentL1"`
+}
+
+func (r VerifiedRecord) ToVerifiedResult() VerifiedResult {
+	return VerifiedResult{
+		Timestamp:   r.Timestamp,
+		L1Inclusion: r.L1Inclusion,
+		L2Heads:     r.L2Heads,
+	}
+}
+
+func (r VerifiedRecord) ResponseData() *eth.SuperRootResponseData {
+	super := eth.NewSuperV1(r.Timestamp, r.ChainOutputs...)
+	return &eth.SuperRootResponseData{
+		VerifiedRequiredL1: r.L1Inclusion,
+		Super:              super,
+		SuperRoot:          eth.SuperRoot(super),
+	}
+}
+
 // InvalidHead pairs a block identifier with the output preimage fields needed
 // for optimistic root computation in the superroot API. The full OutputV0 can
 // be reconstructed on demand via OutputV0() since BlockHash is already in BlockID.
@@ -34,14 +61,12 @@ type Result struct {
 // PendingTransition is the generic write-ahead-log entry for an effectful
 // interop decision. Recovery and steady-state both use the same apply path.
 //
-// Phase 2 keeps this intentionally small:
-// - advance/invalidate carry their Result directly
-// - rewind carries the accepted frontier to rewind from
-// Later phases can expand this into a richer explicit transition plan.
+// DecisionAdvance uses Verified, DecisionInvalidate uses Result, and DecisionRewind uses Rewind.
 type PendingTransition struct {
-	Decision Decision    `json:"decision"`
-	Result   *Result     `json:"result,omitempty"`
-	Rewind   *RewindPlan `json:"rewind,omitempty"`
+	Decision Decision        `json:"decision"`
+	Result   *Result         `json:"result,omitempty"`
+	Verified *VerifiedRecord `json:"verified,omitempty"`
+	Rewind   *RewindPlan     `json:"rewind,omitempty"`
 }
 
 // RewindPlan is the explicit rewind transition persisted in the WAL.

--- a/op-supernode/supernode/activity/interop/types.go
+++ b/op-supernode/supernode/activity/interop/types.go
@@ -1,6 +1,8 @@
 package interop
 
 import (
+	"sort"
+
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
@@ -13,28 +15,104 @@ type VerifiedResult struct {
 	L2Heads     map[eth.ChainID]eth.BlockID `json:"l2Heads"`
 }
 
+// ChainObservation captures everything observed for a single chain at a
+// verified timestamp: the L2 head, the L1 block at which that head became safe
+// (the per-chain L1 inclusion), and the OutputV0 preimage fields needed to
+// reconstruct the optimistic output without querying live engine state.
+//
+// BlockHash is intentionally omitted — it is L2Head.Hash. Storing it again
+// would duplicate the canonical block identifier.
+type ChainObservation struct {
+	L2Head                   eth.BlockID `json:"l2Head"`
+	L1Head                   eth.BlockID `json:"l1Head"`
+	StateRoot                eth.Bytes32 `json:"stateRoot"`
+	MessagePasserStorageRoot eth.Bytes32 `json:"messagePasserStorageRoot"`
+}
+
+// OutputV0 reconstructs the full OutputV0 preimage for this chain.
+func (o ChainObservation) OutputV0() eth.OutputV0 {
+	return eth.OutputV0{
+		StateRoot:                o.StateRoot,
+		MessagePasserStorageRoot: o.MessagePasserStorageRoot,
+		BlockHash:                o.L2Head.Hash,
+	}
+}
+
+// OutputRoot returns the per-chain output root hash.
+func (o ChainObservation) OutputRoot() eth.Bytes32 {
+	v0 := o.OutputV0()
+	return eth.OutputRoot(&v0)
+}
+
 // VerifiedRecord is the durable verifier snapshot at a timestamp.
-// It stores only source facts; ResponseData derives the redundant RPC fields.
+// It stores only source facts; aggregates and RPC views are derived on demand.
+//
+// Per-chain observations snapshot the optimistic data that produced this
+// verified record, so superroot_atTimestamp can serve OptimisticAtTimestamp
+// from the durable record without re-reading live SafeDB or engine state.
+// Without this snapshot, a chain rewind between verification and serving
+// could drop derivable optimistic blocks from the response.
 type VerifiedRecord struct {
-	Timestamp    uint64                      `json:"timestamp"`
-	L1Inclusion  eth.BlockID                 `json:"l1Inclusion"`
-	L2Heads      map[eth.ChainID]eth.BlockID `json:"l2Heads"`
-	ChainOutputs []eth.ChainIDAndOutput      `json:"chainOutputs"`
-	CurrentL1    eth.BlockID                 `json:"currentL1"`
+	Timestamp uint64                            `json:"timestamp"`
+	Chains    map[eth.ChainID]ChainObservation  `json:"chains"`
+	CurrentL1 eth.BlockID                       `json:"currentL1"`
+}
+
+// L2Heads returns the per-chain L2 head map for compatibility with consumers
+// that work with the legacy VerifiedResult shape.
+func (r VerifiedRecord) L2Heads() map[eth.ChainID]eth.BlockID {
+	if r.Chains == nil {
+		return nil
+	}
+	out := make(map[eth.ChainID]eth.BlockID, len(r.Chains))
+	for id, obs := range r.Chains {
+		out[id] = obs.L2Head
+	}
+	return out
+}
+
+// L1Inclusion returns the aggregate L1 block at which this superroot is
+// derivable: the maximum per-chain L1 head. Computed on demand from Chains.
+func (r VerifiedRecord) L1Inclusion() eth.BlockID {
+	var max eth.BlockID
+	for _, obs := range r.Chains {
+		if obs.L1Head.Number > max.Number {
+			max = obs.L1Head
+		}
+	}
+	return max
+}
+
+// SortedChainIDs returns the chain IDs sorted ascending — the canonical order
+// used by SuperV1.
+func (r VerifiedRecord) SortedChainIDs() []eth.ChainID {
+	ids := make([]eth.ChainID, 0, len(r.Chains))
+	for id := range r.Chains {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i].Cmp(ids[j]) < 0 })
+	return ids
 }
 
 func (r VerifiedRecord) ToVerifiedResult() VerifiedResult {
 	return VerifiedResult{
 		Timestamp:   r.Timestamp,
-		L1Inclusion: r.L1Inclusion,
-		L2Heads:     r.L2Heads,
+		L1Inclusion: r.L1Inclusion(),
+		L2Heads:     r.L2Heads(),
 	}
 }
 
 func (r VerifiedRecord) ResponseData() *eth.SuperRootResponseData {
-	super := eth.NewSuperV1(r.Timestamp, r.ChainOutputs...)
+	chainOutputs := make([]eth.ChainIDAndOutput, 0, len(r.Chains))
+	for _, id := range r.SortedChainIDs() {
+		chainOutputs = append(chainOutputs, eth.ChainIDAndOutput{
+			ChainID: id,
+			Output:  r.Chains[id].OutputRoot(),
+		})
+	}
+	super := eth.NewSuperV1(r.Timestamp, chainOutputs...)
 	return &eth.SuperRootResponseData{
-		VerifiedRequiredL1: r.L1Inclusion,
+		VerifiedRequiredL1: r.L1Inclusion(),
 		Super:              super,
 		SuperRoot:          eth.SuperRoot(super),
 	}
@@ -43,18 +121,29 @@ func (r VerifiedRecord) ResponseData() *eth.SuperRootResponseData {
 // InvalidHead pairs a block identifier with the output preimage fields needed
 // for optimistic root computation in the superroot API. The full OutputV0 can
 // be reconstructed on demand via OutputV0() since BlockHash is already in BlockID.
+//
+// L1Inclusion is the per-chain L1 block at which the invalid optimistic block
+// became safe; persisted alongside the deny record so OptimisticAtTimestamp can
+// be served from durable state.
 type InvalidHead struct {
 	eth.BlockID
 	StateRoot                eth.Bytes32 `json:"stateRoot"`
 	MessagePasserStorageRoot eth.Bytes32 `json:"messagePasserStorageRoot"`
+	L1Inclusion              eth.BlockID `json:"l1Inclusion"`
 }
 
 // Result represents the result of interop validation at a specific timestamp given current data.
 // it contains all the same information as VerifiedResult, but also contains a list of invalid heads.
+//
+// L1Heads is the per-chain L1 inclusion snapshot captured atomically with
+// L2Heads in observeRound. It is plumbed through verification so that
+// VerifiedRecord and InvalidHead can record the per-chain L1 inclusion at the
+// observation moment.
 type Result struct {
 	Timestamp    uint64                      `json:"timestamp"`
 	L1Inclusion  eth.BlockID                 `json:"l1Inclusion"`
 	L2Heads      map[eth.ChainID]eth.BlockID `json:"l2Heads"`
+	L1Heads      map[eth.ChainID]eth.BlockID `json:"l1Heads"`
 	InvalidHeads map[eth.ChainID]InvalidHead `json:"invalidHeads"`
 }
 

--- a/op-supernode/supernode/activity/interop/verified_db.go
+++ b/op-supernode/supernode/activity/interop/verified_db.go
@@ -25,8 +25,11 @@ var (
 	u64Len              = 8
 )
 
-// bucketName is the name of the bbolt bucket used to store verified results.
+// bucketName is the name of the bbolt bucket used to store verified records.
 var bucketName = []byte("verified")
+
+var frontierBucketName = []byte("frontier")
+var currentL1Key = []byte("current_l1")
 
 var pendingTransitionBucketName = []byte("pending_transition")
 var pendingTransitionKey = []byte("pending")
@@ -60,6 +63,9 @@ func OpenVerifiedDB(dataDir string) (*VerifiedDB, error) {
 	// Ensure the buckets exist
 	err = db.Update(func(tx *bolt.Tx) error {
 		if _, err := tx.CreateBucketIfNotExists(bucketName); err != nil {
+			return err
+		}
+		if _, err := tx.CreateBucketIfNotExists(frontierBucketName); err != nil {
 			return err
 		}
 		_, err := tx.CreateBucketIfNotExists(pendingTransitionBucketName)
@@ -115,61 +121,53 @@ func timestampToKey(ts uint64) []byte {
 	return key
 }
 
-// Commit stores a verified result at the given timestamp.
-// Timestamps must be committed sequentially with no gaps.
-func (v *VerifiedDB) Commit(result VerifiedResult) error {
+// CommitRecord stores the verified record and the verifier's
+// CurrentL1 claim in one bbolt transaction. Timestamps must be committed
+// sequentially with no gaps.
+func (v *VerifiedDB) CommitRecord(record VerifiedRecord) error {
 	v.mu.Lock()
 	defer v.mu.Unlock()
 
-	ts := result.Timestamp
-
-	// Check for sequential commitment
+	ts := record.Timestamp
 	if v.initialized {
-		if ts != v.lastTimestamp+1 {
-			if ts <= v.lastTimestamp {
-				// Idempotent replay: crash recovery may call Commit again after the
-				// bbolt write succeeded but before ClearPendingTransition. Compare the
-				// deserialized VerifiedResult rather than raw bytes so byte-level
-				// drift in encoding/json across Go versions does not turn a legitimate
-				// replay into a hard ErrAlreadyCommitted.
-				key := timestampToKey(ts)
-				var existing VerifiedResult
-				err := v.db.View(func(tx *bolt.Tx) error {
-					b := tx.Bucket(bucketName)
-					val := b.Get(key)
-					if val == nil {
-						return ErrNotFound
-					}
-					return json.Unmarshal(val, &existing)
-				})
-				if err != nil {
-					return fmt.Errorf("failed to read existing verified result at %d: %w", ts, err)
-				}
-				if reflect.DeepEqual(existing, result) {
-					return nil
-				}
+		switch {
+		case ts == v.lastTimestamp+1:
+		case ts > v.lastTimestamp:
+			return fmt.Errorf("%w: expected %d, got %d", ErrNonSequential, v.lastTimestamp+1, ts)
+		default:
+			// Idempotent replay after a crash may re-apply a WAL entry that was
+			// already committed before ClearPendingTransition ran.
+			existingRecord, err := readVerifiedRecord(v.db, ts)
+			if err != nil {
+				return fmt.Errorf("failed to read existing verified record at %d: %w", ts, err)
+			}
+			if !reflect.DeepEqual(existingRecord, record) {
 				return fmt.Errorf("%w: %d", ErrAlreadyCommitted, ts)
 			}
-			return fmt.Errorf("%w: expected %d, got %d", ErrNonSequential, v.lastTimestamp+1, ts)
+			return nil
 		}
 	}
 
-	value, err := json.Marshal(result)
+	recordValue, err := json.Marshal(record)
 	if err != nil {
-		return fmt.Errorf("failed to marshal verified result: %w", err)
+		return fmt.Errorf("failed to marshal verified record: %w", err)
+	}
+	currentL1Value, err := json.Marshal(record.CurrentL1)
+	if err != nil {
+		return fmt.Errorf("failed to marshal current L1: %w", err)
 	}
 
-	// Store in database
 	key := timestampToKey(ts)
 	err = v.db.Update(func(tx *bolt.Tx) error {
-		b := tx.Bucket(bucketName)
-		return b.Put(key, value)
+		if err := tx.Bucket(bucketName).Put(key, recordValue); err != nil {
+			return err
+		}
+		return tx.Bucket(frontierBucketName).Put(currentL1Key, currentL1Value)
 	})
 	if err != nil {
-		return fmt.Errorf("failed to write to bbolt: %w", err)
+		return fmt.Errorf("failed to write verified record to bbolt: %w", err)
 	}
 
-	// Update state
 	if !v.initialized {
 		v.firstTimestamp = ts
 	}
@@ -179,38 +177,89 @@ func (v *VerifiedDB) Commit(result VerifiedResult) error {
 	return nil
 }
 
-// Get retrieves the verified result at the given timestamp.
-func (v *VerifiedDB) Get(ts uint64) (VerifiedResult, error) {
-	v.mu.RLock()
-	defer v.mu.RUnlock()
-
+func readVerifiedRecord(db *bolt.DB, ts uint64) (VerifiedRecord, error) {
 	key := timestampToKey(ts)
 	var value []byte
-
-	err := v.db.View(func(tx *bolt.Tx) error {
+	err := db.View(func(tx *bolt.Tx) error {
 		b := tx.Bucket(bucketName)
 		val := b.Get(key)
 		if val == nil {
 			return ErrNotFound
 		}
-		// Copy the value since it's only valid for the life of the transaction
 		value = make([]byte, len(val))
 		copy(value, val)
 		return nil
 	})
+	if err != nil {
+		return VerifiedRecord{}, err
+	}
+	var record VerifiedRecord
+	if err := json.Unmarshal(value, &record); err != nil {
+		return VerifiedRecord{}, fmt.Errorf("failed to unmarshal verified record: %w", err)
+	}
+	return record, nil
+}
+
+// GetRecord retrieves the durable verified record at the given timestamp.
+func (v *VerifiedDB) GetRecord(ts uint64) (VerifiedRecord, error) {
+	v.mu.RLock()
+	defer v.mu.RUnlock()
+	record, err := readVerifiedRecord(v.db, ts)
+	if errors.Is(err, ErrNotFound) {
+		return VerifiedRecord{}, ErrNotFound
+	}
+	if err != nil {
+		return VerifiedRecord{}, fmt.Errorf("failed to read verified record at %d: %w", ts, err)
+	}
+	return record, nil
+}
+
+// SetCurrentL1 stores the verifier's durable current L1 claim.
+func (v *VerifiedDB) SetCurrentL1(currentL1 eth.BlockID) error {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	value, err := json.Marshal(currentL1)
+	if err != nil {
+		return fmt.Errorf("failed to marshal current L1: %w", err)
+	}
+	return v.db.Update(func(tx *bolt.Tx) error {
+		return tx.Bucket(frontierBucketName).Put(currentL1Key, value)
+	})
+}
+
+// CurrentL1 returns the verifier's durable current L1 claim, if any.
+func (v *VerifiedDB) CurrentL1() (eth.BlockID, bool, error) {
+	v.mu.RLock()
+	defer v.mu.RUnlock()
+	var currentL1 eth.BlockID
+	var found bool
+	err := v.db.View(func(tx *bolt.Tx) error {
+		val := tx.Bucket(frontierBucketName).Get(currentL1Key)
+		if val == nil {
+			return nil
+		}
+		found = true
+		return json.Unmarshal(val, &currentL1)
+	})
+	if err != nil {
+		return eth.BlockID{}, false, fmt.Errorf("failed to read current L1: %w", err)
+	}
+	return currentL1, found, nil
+}
+
+// Get retrieves the verified result view at the given timestamp.
+func (v *VerifiedDB) Get(ts uint64) (VerifiedResult, error) {
+	v.mu.RLock()
+	defer v.mu.RUnlock()
+
+	record, err := readVerifiedRecord(v.db, ts)
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {
 			return VerifiedResult{}, ErrNotFound
 		}
 		return VerifiedResult{}, fmt.Errorf("failed to read from bbolt: %w", err)
 	}
-
-	var result VerifiedResult
-	if err := json.Unmarshal(value, &result); err != nil {
-		return VerifiedResult{}, fmt.Errorf("failed to unmarshal verified result: %w", err)
-	}
-
-	return result, nil
+	return record.ToVerifiedResult(), nil
 }
 
 // Has returns whether a timestamp has been verified.

--- a/op-supernode/supernode/activity/interop/verified_db.go
+++ b/op-supernode/supernode/activity/interop/verified_db.go
@@ -41,6 +41,7 @@ type PendingInvalidation struct {
 	Timestamp                uint64      `json:"timestamp"` // the interop decision timestamp
 	StateRoot                eth.Bytes32 `json:"stateRoot"`
 	MessagePasserStorageRoot eth.Bytes32 `json:"messagePasserStorageRoot"`
+	L1Inclusion              eth.BlockID `json:"l1Inclusion"`
 }
 
 // VerifiedDB provides persistence for verified timestamps using bbolt.

--- a/op-supernode/supernode/activity/interop/verified_db_test.go
+++ b/op-supernode/supernode/activity/interop/verified_db_test.go
@@ -15,24 +15,23 @@ func commitVerifiedResult(v *VerifiedDB, result VerifiedResult) error {
 }
 
 func testVerifiedRecord(result VerifiedResult) VerifiedRecord {
-	chainOutputs := make([]eth.ChainIDAndOutput, 0, len(result.L2Heads))
+	chains := make(map[eth.ChainID]ChainObservation, len(result.L2Heads))
 	for chainID, l2Head := range result.L2Heads {
-		chainOutputs = append(chainOutputs, eth.ChainIDAndOutput{
-			ChainID: chainID,
-			Output:  eth.Bytes32(l2Head.Hash),
-		})
+		chains[chainID] = ChainObservation{
+			L2Head:                   l2Head,
+			L1Head:                   result.L1Inclusion,
+			StateRoot:                eth.Bytes32(l2Head.Hash),
+			MessagePasserStorageRoot: eth.Bytes32{},
+		}
 	}
-	super := eth.NewSuperV1(result.Timestamp, chainOutputs...)
 	currentL1 := result.L1Inclusion
 	if currentL1.Number > 0 {
 		currentL1.Number--
 	}
 	return VerifiedRecord{
-		Timestamp:    result.Timestamp,
-		L1Inclusion:  result.L1Inclusion,
-		L2Heads:      result.L2Heads,
-		ChainOutputs: super.Chains,
-		CurrentL1:    currentL1,
+		Timestamp: result.Timestamp,
+		Chains:    chains,
+		CurrentL1: currentL1,
 	}
 }
 

--- a/op-supernode/supernode/activity/interop/verified_db_test.go
+++ b/op-supernode/supernode/activity/interop/verified_db_test.go
@@ -10,6 +10,32 @@ import (
 	bolt "go.etcd.io/bbolt"
 )
 
+func commitVerifiedResult(v *VerifiedDB, result VerifiedResult) error {
+	return v.CommitRecord(testVerifiedRecord(result))
+}
+
+func testVerifiedRecord(result VerifiedResult) VerifiedRecord {
+	chainOutputs := make([]eth.ChainIDAndOutput, 0, len(result.L2Heads))
+	for chainID, l2Head := range result.L2Heads {
+		chainOutputs = append(chainOutputs, eth.ChainIDAndOutput{
+			ChainID: chainID,
+			Output:  eth.Bytes32(l2Head.Hash),
+		})
+	}
+	super := eth.NewSuperV1(result.Timestamp, chainOutputs...)
+	currentL1 := result.L1Inclusion
+	if currentL1.Number > 0 {
+		currentL1.Number--
+	}
+	return VerifiedRecord{
+		Timestamp:    result.Timestamp,
+		L1Inclusion:  result.L1Inclusion,
+		L2Heads:      result.L2Heads,
+		ChainOutputs: super.Chains,
+		CurrentL1:    currentL1,
+	}
+}
+
 func TestVerifiedDB_WriteAndRead(t *testing.T) {
 	// Create a temporary directory for the test database
 	dataDir := t.TempDir()
@@ -50,7 +76,7 @@ func TestVerifiedDB_WriteAndRead(t *testing.T) {
 	}
 
 	// Write the first result
-	err = db.Commit(result1)
+	err = commitVerifiedResult(db, result1)
 	require.NoError(t, err)
 
 	// Verify the last timestamp was updated
@@ -95,7 +121,7 @@ func TestVerifiedDB_SequentialCommits(t *testing.T) {
 	chainID := eth.ChainIDFromUInt64(10)
 
 	// Commit first timestamp
-	err = db.Commit(VerifiedResult{
+	err = commitVerifiedResult(db, VerifiedResult{
 		Timestamp:   100,
 		L1Inclusion: eth.BlockID{Hash: common.HexToHash("0x01"), Number: 1},
 		L2Heads:     map[eth.ChainID]eth.BlockID{chainID: {Hash: common.HexToHash("0x02"), Number: 2}},
@@ -103,7 +129,7 @@ func TestVerifiedDB_SequentialCommits(t *testing.T) {
 	require.NoError(t, err)
 
 	// Commit next sequential timestamp should succeed
-	err = db.Commit(VerifiedResult{
+	err = commitVerifiedResult(db, VerifiedResult{
 		Timestamp:   101,
 		L1Inclusion: eth.BlockID{Hash: common.HexToHash("0x03"), Number: 3},
 		L2Heads:     map[eth.ChainID]eth.BlockID{chainID: {Hash: common.HexToHash("0x04"), Number: 4}},
@@ -111,7 +137,7 @@ func TestVerifiedDB_SequentialCommits(t *testing.T) {
 	require.NoError(t, err)
 
 	// Try to commit non-sequential timestamp (gap)
-	err = db.Commit(VerifiedResult{
+	err = commitVerifiedResult(db, VerifiedResult{
 		Timestamp:   105,
 		L1Inclusion: eth.BlockID{Hash: common.HexToHash("0x05"), Number: 5},
 		L2Heads:     map[eth.ChainID]eth.BlockID{chainID: {Hash: common.HexToHash("0x06"), Number: 6}},
@@ -119,7 +145,7 @@ func TestVerifiedDB_SequentialCommits(t *testing.T) {
 	require.ErrorIs(t, err, ErrNonSequential)
 
 	// Try to commit already committed timestamp
-	err = db.Commit(VerifiedResult{
+	err = commitVerifiedResult(db, VerifiedResult{
 		Timestamp:   100,
 		L1Inclusion: eth.BlockID{Hash: common.HexToHash("0x07"), Number: 7},
 		L2Heads:     map[eth.ChainID]eth.BlockID{chainID: {Hash: common.HexToHash("0x08"), Number: 8}},
@@ -139,14 +165,14 @@ func TestVerifiedDB_Persistence(t *testing.T) {
 	db, err := OpenVerifiedDB(dataDir)
 	require.NoError(t, err)
 
-	err = db.Commit(VerifiedResult{
+	err = commitVerifiedResult(db, VerifiedResult{
 		Timestamp:   500,
 		L1Inclusion: eth.BlockID{Hash: common.HexToHash("0xaaaa"), Number: 50},
 		L2Heads:     map[eth.ChainID]eth.BlockID{chainID: {Hash: common.HexToHash("0xbbbb"), Number: 100}},
 	})
 	require.NoError(t, err)
 
-	err = db.Commit(VerifiedResult{
+	err = commitVerifiedResult(db, VerifiedResult{
 		Timestamp:   501,
 		L1Inclusion: eth.BlockID{Hash: common.HexToHash("0xcccc"), Number: 51},
 		L2Heads:     map[eth.ChainID]eth.BlockID{chainID: {Hash: common.HexToHash("0xdddd"), Number: 101}},
@@ -179,7 +205,7 @@ func TestVerifiedDB_Persistence(t *testing.T) {
 	require.Equal(t, uint64(501), result.Timestamp)
 
 	// Next commit should continue from last timestamp
-	err = db2.Commit(VerifiedResult{
+	err = commitVerifiedResult(db2, VerifiedResult{
 		Timestamp:   502,
 		L1Inclusion: eth.BlockID{Hash: common.HexToHash("0xeeee"), Number: 52},
 		L2Heads:     map[eth.ChainID]eth.BlockID{chainID: {Hash: common.HexToHash("0xffff"), Number: 102}},
@@ -202,7 +228,7 @@ func TestVerifiedDB_RewindTo(t *testing.T) {
 
 		// Commit several timestamps
 		for ts := uint64(100); ts <= 105; ts++ {
-			err = db.Commit(VerifiedResult{
+			err = commitVerifiedResult(db, VerifiedResult{
 				Timestamp:   ts,
 				L1Inclusion: eth.BlockID{Hash: common.BytesToHash([]byte{byte(ts)}), Number: ts},
 				L2Heads:     map[eth.ChainID]eth.BlockID{chainID: {Hash: common.BytesToHash([]byte{byte(ts + 100)}), Number: ts}},
@@ -253,7 +279,7 @@ func TestVerifiedDB_RewindTo(t *testing.T) {
 
 		// Commit up to timestamp 100
 		for ts := uint64(98); ts <= 100; ts++ {
-			err = db.Commit(VerifiedResult{
+			err = commitVerifiedResult(db, VerifiedResult{
 				Timestamp:   ts,
 				L1Inclusion: eth.BlockID{Hash: common.BytesToHash([]byte{byte(ts)}), Number: ts},
 				L2Heads:     map[eth.ChainID]eth.BlockID{chainID: {Hash: common.BytesToHash([]byte{byte(ts + 100)}), Number: ts}},
@@ -283,7 +309,7 @@ func TestVerifiedDB_RewindTo(t *testing.T) {
 
 		// Commit a few entries
 		for ts := uint64(100); ts <= 102; ts++ {
-			err = db.Commit(VerifiedResult{
+			err = commitVerifiedResult(db, VerifiedResult{
 				Timestamp:   ts,
 				L1Inclusion: eth.BlockID{Hash: common.BytesToHash([]byte{byte(ts)}), Number: ts},
 				L2Heads:     map[eth.ChainID]eth.BlockID{chainID: {Hash: common.BytesToHash([]byte{byte(ts + 100)}), Number: ts}},
@@ -320,7 +346,7 @@ func TestVerifiedDB_RewindTo(t *testing.T) {
 
 		// Commit 100-105
 		for ts := uint64(100); ts <= 105; ts++ {
-			err = db.Commit(VerifiedResult{
+			err = commitVerifiedResult(db, VerifiedResult{
 				Timestamp:   ts,
 				L1Inclusion: eth.BlockID{Hash: common.BytesToHash([]byte{byte(ts)}), Number: ts},
 				L2Heads:     map[eth.ChainID]eth.BlockID{chainID: {Hash: common.BytesToHash([]byte{byte(ts + 100)}), Number: ts}},
@@ -333,7 +359,7 @@ func TestVerifiedDB_RewindTo(t *testing.T) {
 		require.NoError(t, err)
 
 		// Should be able to commit 103 again (sequential from 102)
-		err = db.Commit(VerifiedResult{
+		err = commitVerifiedResult(db, VerifiedResult{
 			Timestamp:   103,
 			L1Inclusion: eth.BlockID{Hash: common.HexToHash("0xNEW"), Number: 103},
 			L2Heads:     map[eth.ChainID]eth.BlockID{chainID: {Hash: common.HexToHash("0xNEW2"), Number: 103}},
@@ -365,8 +391,8 @@ func TestVerifiedDB_Commit_IdempotentReplay(t *testing.T) {
 		require.NoError(t, err)
 		defer db.Close()
 
-		require.NoError(t, db.Commit(result))
-		require.NoError(t, db.Commit(result))
+		require.NoError(t, commitVerifiedResult(db, result))
+		require.NoError(t, commitVerifiedResult(db, result))
 	})
 
 	t.Run("different struct at same timestamp is rejected", func(t *testing.T) {
@@ -375,11 +401,11 @@ func TestVerifiedDB_Commit_IdempotentReplay(t *testing.T) {
 		require.NoError(t, err)
 		defer db.Close()
 
-		require.NoError(t, db.Commit(result))
+		require.NoError(t, commitVerifiedResult(db, result))
 
 		different := result
 		different.L1Inclusion.Number = 999
-		require.ErrorIs(t, db.Commit(different), ErrAlreadyCommitted)
+		require.ErrorIs(t, commitVerifiedResult(db, different), ErrAlreadyCommitted)
 	})
 
 	t.Run("byte-divergent but struct-equal replays cleanly", func(t *testing.T) {
@@ -392,11 +418,12 @@ func TestVerifiedDB_Commit_IdempotentReplay(t *testing.T) {
 		require.NoError(t, err)
 		defer db.Close()
 
-		require.NoError(t, db.Commit(result))
+		require.NoError(t, commitVerifiedResult(db, result))
 
-		indented, err := json.MarshalIndent(result, "", "  ")
+		record := testVerifiedRecord(result)
+		indented, err := json.MarshalIndent(record, "", "  ")
 		require.NoError(t, err)
-		canonical, err := json.Marshal(result)
+		canonical, err := json.Marshal(record)
 		require.NoError(t, err)
 		require.NotEqual(t, canonical, indented, "indented JSON should diverge from canonical bytes")
 
@@ -404,7 +431,7 @@ func TestVerifiedDB_Commit_IdempotentReplay(t *testing.T) {
 			return tx.Bucket(bucketName).Put(timestampToKey(result.Timestamp), indented)
 		}))
 
-		require.NoError(t, db.Commit(result))
+		require.NoError(t, commitVerifiedResult(db, result))
 	})
 }
 

--- a/op-supernode/supernode/activity/supernode/supernode_test.go
+++ b/op-supernode/supernode/activity/supernode/supernode_test.go
@@ -100,6 +100,10 @@ func (m *mockCC) GetDeniedOutput(height uint64, payloadHash common.Hash) (*eth.O
 	return nil, nil
 }
 
+func (m *mockCC) LastDeniedAtHeight(height uint64) (*eth.OutputV0, eth.BlockID, error) {
+	return nil, eth.BlockID{}, nil
+}
+
 func (m *mockCC) IsDenied(height uint64, payloadHash common.Hash) (bool, error) {
 	return false, nil
 }

--- a/op-supernode/supernode/activity/superroot/superroot.go
+++ b/op-supernode/supernode/activity/superroot/superroot.go
@@ -113,6 +113,18 @@ func (s *Superroot) atTimestamp(ctx context.Context, timestamp uint64) (eth.Supe
 		}
 	}
 
+	// Fall back to live verified state when there is no durable record. This
+	// covers pre-activation timestamps (interop verifier dormant) and any
+	// in-flight window where the verifier has not yet committed. Production
+	// interop timestamps use the durable snapshot above; this path only
+	// reads live data when nothing has been recorded.
+	if verifiedData == nil {
+		verifiedData, err = s.collectLiveVerifiedData(ctx, timestamp)
+		if err != nil {
+			return eth.SuperRootAtTimestampResponse{}, err
+		}
+	}
+
 	response := eth.SuperRootAtTimestampResponse{
 		CurrentL1:                 currentL1,
 		CurrentSafeTimestamp:      aggregate.SafeTimestamp,
@@ -123,6 +135,42 @@ func (s *Superroot) atTimestamp(ctx context.Context, timestamp uint64) (eth.Supe
 		Data:                      verifiedData,
 	}
 	return response, nil
+}
+
+// collectLiveVerifiedData rebuilds SuperRootResponseData from each chain's
+// live VerifiedAt. Returns nil when any chain lacks verified data at the
+// timestamp (mirroring the all-or-nothing semantics required by callers
+// who expect Data to be nil unless every chain is covered).
+//
+// Used for timestamps without a durable verified record: pre-activation
+// (interop verifier dormant) and the in-flight pre-commit window.
+func (s *Superroot) collectLiveVerifiedData(ctx context.Context, timestamp uint64) (*eth.SuperRootResponseData, error) {
+	chainOutputs := make([]eth.ChainIDAndOutput, 0, len(s.chains))
+	var verifiedRequiredL1 eth.BlockID
+	for chainID, chain := range s.chains {
+		verifiedL2, verifiedL1, err := chain.VerifiedAt(ctx, timestamp)
+		if errors.Is(err, ethereum.NotFound) {
+			return nil, nil
+		} else if err != nil {
+			s.log.Warn("failed to get verified block", "chain_id", chainID.String(), "err", err)
+			return nil, fmt.Errorf("failed to get verified block: %w", err)
+		}
+		if verifiedL1.Number > verifiedRequiredL1.Number {
+			verifiedRequiredL1 = verifiedL1
+		}
+		outRoot, err := chain.OutputRootAtL2BlockNumber(ctx, verifiedL2.Number)
+		if err != nil {
+			s.log.Warn("failed to compute output root at L2 block", "chain_id", chainID.String(), "l2_number", verifiedL2.Number, "err", err)
+			return nil, fmt.Errorf("failed to compute output root at L2 block %d for chain ID %v: %w", verifiedL2.Number, chainID, err)
+		}
+		chainOutputs = append(chainOutputs, eth.ChainIDAndOutput{ChainID: chainID, Output: outRoot})
+	}
+	super := eth.NewSuperV1(timestamp, chainOutputs...)
+	return &eth.SuperRootResponseData{
+		VerifiedRequiredL1: verifiedRequiredL1,
+		Super:              super,
+		SuperRoot:          eth.SuperRoot(super),
+	}, nil
 }
 
 // collectLiveOptimistic queries each chain for its optimistic head at the

--- a/op-supernode/supernode/activity/superroot/superroot.go
+++ b/op-supernode/supernode/activity/superroot/superroot.go
@@ -32,10 +32,16 @@ type Superroot struct {
 // VerifierCurrentL1 returns the verifier's frontier L1, used by callers like
 // op-challenger to decide whether all L1 data up to the game's L1 head has
 // been processed. Returns ok=false before the verifier has populated it.
+//
+// IsActiveAt reports whether the verifier is responsible for the timestamp.
+// Used to decide whether absence of a durable record is authoritative
+// (post-activation: yes, no live fallback for Data) or just means there was
+// nothing to record (pre-activation: fall back to live VerifiedAt).
 type VerifiedSuperRootProvider interface {
 	StoredSuperRootAtTimestamp(ts uint64) (data *eth.SuperRootResponseData, found bool, err error)
 	StoredOptimisticAtTimestamp(ts uint64) (optimistic map[eth.ChainID]eth.OutputWithRequiredL1, found bool, err error)
 	VerifierCurrentL1() (eth.BlockID, bool)
+	IsActiveAt(ts uint64) bool
 }
 
 func New(log gethlog.Logger, chains map[eth.ChainID]cc.ChainContainer, provider VerifiedSuperRootProvider) *Superroot {
@@ -103,27 +109,31 @@ func (s *Superroot) atTimestamp(ctx context.Context, timestamp uint64) (eth.Supe
 		}
 	}
 
-	// Fall back to live state for timestamps the verifier has not yet committed
-	// (e.g. the in-flight pre-verification window). Once the verifier records
-	// a timestamp, the durable snapshot above is the source of truth.
-	if optimistic == nil {
-		optimistic, err = s.collectLiveOptimistic(ctx, timestamp)
-		if err != nil {
-			return eth.SuperRootAtTimestampResponse{}, err
+	// Live fallback applies ONLY when the verifier is not responsible for the
+	// timestamp — i.e. there is no provider configured at all (preinterop
+	// build), or the timestamp is pre-activation. After interop activation
+	// the verifier is the sole source of truth for both Data and
+	// OptimisticAtTimestamp. Live reads at that point would race with chain
+	// rewinds (the interval between the CurrentL1 read and the per-chain
+	// reads), and would let the challenger act on uncommitted state even
+	// though it has been told CurrentL1 >= game.L1Head.
+	if !s.verifierActiveAt(timestamp) {
+		if optimistic == nil {
+			optimistic, err = s.collectLiveOptimistic(ctx, timestamp)
+			if err != nil {
+				return eth.SuperRootAtTimestampResponse{}, err
+			}
+		}
+		if verifiedData == nil {
+			verifiedData, err = s.collectLiveVerifiedData(ctx, timestamp)
+			if err != nil {
+				return eth.SuperRootAtTimestampResponse{}, err
+			}
 		}
 	}
-
-	// Fall back to live verified state when there is no durable record. This
-	// covers pre-activation timestamps (interop verifier dormant) and any
-	// in-flight window where the verifier has not yet committed. Production
-	// interop timestamps use the durable snapshot above; this path only
-	// reads live data when nothing has been recorded.
-	if verifiedData == nil {
-		verifiedData, err = s.collectLiveVerifiedData(ctx, timestamp)
-		if err != nil {
-			return eth.SuperRootAtTimestampResponse{}, err
-		}
-	}
+	// Post-activation: optimistic and verifiedData remain whatever the
+	// durable provider returned (possibly nil/empty). The challenger reads
+	// "Data == nil" or per-chain absence as authoritative absence.
 
 	response := eth.SuperRootAtTimestampResponse{
 		CurrentL1:                 currentL1,
@@ -135,6 +145,16 @@ func (s *Superroot) atTimestamp(ctx context.Context, timestamp uint64) (eth.Supe
 		Data:                      verifiedData,
 	}
 	return response, nil
+}
+
+// verifierActiveAt reports whether the interop verifier is responsible for
+// the timestamp. When no provider is configured, treat the timestamp as
+// inactive so live fallback applies (preinterop deployments).
+func (s *Superroot) verifierActiveAt(ts uint64) bool {
+	if s.verifiedProvider == nil {
+		return false
+	}
+	return s.verifiedProvider.IsActiveAt(ts)
 }
 
 // collectLiveVerifiedData rebuilds SuperRootResponseData from each chain's

--- a/op-supernode/supernode/activity/superroot/superroot.go
+++ b/op-supernode/supernode/activity/superroot/superroot.go
@@ -17,23 +17,28 @@ import (
 // it provides the superroot at a given timestamp for all chains
 // along with the current L1s and the verified and optimistic L1:L2 pairs
 type Superroot struct {
-	log    gethlog.Logger
-	chains map[eth.ChainID]cc.ChainContainer
+	log              gethlog.Logger
+	chains           map[eth.ChainID]cc.ChainContainer
+	verifiedProvider VerifiedSuperRootProvider
 }
 
-func New(log gethlog.Logger, chains map[eth.ChainID]cc.ChainContainer) *Superroot {
+// VerifiedSuperRootProvider supplies durable verifier-owned superroot data.
+type VerifiedSuperRootProvider interface {
+	StoredSuperRootAtTimestamp(ts uint64) (data *eth.SuperRootResponseData, found bool, err error)
+}
+
+func New(log gethlog.Logger, chains map[eth.ChainID]cc.ChainContainer, provider VerifiedSuperRootProvider) *Superroot {
 	return &Superroot{
-		log:    log,
-		chains: chains,
+		log:              log,
+		chains:           chains,
+		verifiedProvider: provider,
 	}
 }
 
 func (s *Superroot) Name() string { return "superroot" }
 
-// Reset is a no-op for superroot - it always queries chain containers directly
-// and doesn't maintain any chain-specific cached state.
+// Reset is a no-op for superroot: it does not maintain chain-specific cached state.
 func (s *Superroot) Reset(chainID eth.ChainID, timestamp uint64, invalidatedBlock eth.BlockRef) {
-	// No-op: superroot queries chain containers directly
 }
 
 func (s *Superroot) RPCNamespace() string    { return "superroot" }
@@ -53,35 +58,18 @@ func (s *Superroot) atTimestamp(ctx context.Context, timestamp uint64) (eth.Supe
 	}
 
 	var (
-		optimistic         = make(map[eth.ChainID]eth.OutputWithRequiredL1, len(s.chains))
-		verifiedRequiredL1 eth.BlockID
-		chainOutputs       = make([]eth.ChainIDAndOutput, 0, len(s.chains))
+		optimistic   = make(map[eth.ChainID]eth.OutputWithRequiredL1, len(s.chains))
+		verifiedData *eth.SuperRootResponseData
 	)
 
-	notFound := false
-	// Collect verified L2 and L1 blocks at the given timestamp
-	for chainID, chain := range s.chains {
-		// verifiedAt returns the L2 block which is fully verified at the given timestamp, and the minimum L1 block at which verification is possible
-		verifiedL2, verifiedL1, err := chain.VerifiedAt(ctx, timestamp)
-		if errors.Is(err, ethereum.NotFound) {
-			notFound = true
-			continue
-		} else if err != nil {
-			s.log.Warn("failed to get verified block", "chain_id", chainID.String(), "err", err)
-			return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("failed to get verified block: %w", err)
-		}
-		// Verified data is available: track the L1 block that includes the data
-		// for every chain — i.e. the MAX of per-chain minimum-required L1s.
-		if verifiedL1.Number > verifiedRequiredL1.Number {
-			verifiedRequiredL1 = verifiedL1
-		}
-		// Compute output root at or before timestamp using the verified L2 block number
-		outRoot, err := chain.OutputRootAtL2BlockNumber(ctx, verifiedL2.Number)
+	if s.verifiedProvider != nil {
+		data, found, err := s.verifiedProvider.StoredSuperRootAtTimestamp(timestamp)
 		if err != nil {
-			s.log.Warn("failed to compute output root at L2 block", "chain_id", chainID.String(), "l2_number", verifiedL2.Number, "err", err)
-			return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("failed to compute output root at L2 block %d for chain ID %v: %w", verifiedL2.Number, chainID, err)
+			return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("failed to get stored verified superroot: %w", err)
 		}
-		chainOutputs = append(chainOutputs, eth.ChainIDAndOutput{ChainID: chainID, Output: outRoot})
+		if found {
+			verifiedData = data
+		}
 	}
 
 	// Collect optimistic data for all chains regardless of whether verified data is available.
@@ -116,16 +104,7 @@ func (s *Superroot) atTimestamp(ctx context.Context, timestamp uint64) (eth.Supe
 		CurrentFinalizedTimestamp: aggregate.FinalizedTimestamp,
 		OptimisticAtTimestamp:     optimistic,
 		ChainIDs:                  aggregate.ChainIDs,
-	}
-	if !notFound {
-		// Build super root from collected outputs
-		superV1 := eth.NewSuperV1(timestamp, chainOutputs...)
-		superRoot := eth.SuperRoot(superV1)
-		response.Data = &eth.SuperRootResponseData{
-			VerifiedRequiredL1: verifiedRequiredL1,
-			Super:              superV1,
-			SuperRoot:          superRoot,
-		}
+		Data:                      verifiedData,
 	}
 	return response, nil
 }

--- a/op-supernode/supernode/activity/superroot/superroot.go
+++ b/op-supernode/supernode/activity/superroot/superroot.go
@@ -23,8 +23,19 @@ type Superroot struct {
 }
 
 // VerifiedSuperRootProvider supplies durable verifier-owned superroot data.
+//
+// StoredOptimisticAtTimestamp returns the per-chain optimistic snapshot
+// captured at the moment of verification. Serving from this durable snapshot
+// avoids races against chain rewinds and pipeline resets between the verifier
+// observing the chains and the RPC response being constructed.
+//
+// VerifierCurrentL1 returns the verifier's frontier L1, used by callers like
+// op-challenger to decide whether all L1 data up to the game's L1 head has
+// been processed. Returns ok=false before the verifier has populated it.
 type VerifiedSuperRootProvider interface {
 	StoredSuperRootAtTimestamp(ts uint64) (data *eth.SuperRootResponseData, found bool, err error)
+	StoredOptimisticAtTimestamp(ts uint64) (optimistic map[eth.ChainID]eth.OutputWithRequiredL1, found bool, err error)
+	VerifierCurrentL1() (eth.BlockID, bool)
 }
 
 func New(log gethlog.Logger, chains map[eth.ChainID]cc.ChainContainer, provider VerifiedSuperRootProvider) *Superroot {
@@ -58,9 +69,13 @@ func (s *Superroot) atTimestamp(ctx context.Context, timestamp uint64) (eth.Supe
 	}
 
 	var (
-		optimistic   = make(map[eth.ChainID]eth.OutputWithRequiredL1, len(s.chains))
+		optimistic   map[eth.ChainID]eth.OutputWithRequiredL1
 		verifiedData *eth.SuperRootResponseData
 	)
+
+	// Default CurrentL1 to the live aggregate; overridden below with the
+	// verifier's durable frontier when available.
+	currentL1 := aggregate.CurrentL1
 
 	if s.verifiedProvider != nil {
 		data, found, err := s.verifiedProvider.StoredSuperRootAtTimestamp(timestamp)
@@ -70,35 +85,36 @@ func (s *Superroot) atTimestamp(ctx context.Context, timestamp uint64) (eth.Supe
 		if found {
 			verifiedData = data
 		}
+
+		stored, found, err := s.verifiedProvider.StoredOptimisticAtTimestamp(timestamp)
+		if err != nil {
+			return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("failed to get stored optimistic snapshot: %w", err)
+		}
+		if found {
+			optimistic = stored
+		}
+
+		// Prefer the verifier's frontier L1 over the live aggregate. The frontier
+		// is what op-challenger needs to decide whether the game's L1 head has
+		// been fully processed; it advances every Wait round so it tracks live
+		// L1 progress within a few blocks even between L2 batches.
+		if l1, ok := s.verifiedProvider.VerifierCurrentL1(); ok {
+			currentL1 = l1
+		}
 	}
 
-	// Collect optimistic data for all chains regardless of whether verified data is available.
-	for chainID, chain := range s.chains {
-		optimisticOut, err := chain.OptimisticOutputAtTimestamp(ctx, timestamp)
-		if errors.Is(err, ethereum.NotFound) {
-			// If optimistic data is also absent, the chain is simply excluded from OptimisticAtTimestamp.
-			continue
-		} else if err != nil {
-			s.log.Warn("failed to get optimistic block", "chain_id", chainID.String(), "err", err)
-			return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("failed to get optimistic block at timestamp %v for chain ID %v: %w", timestamp, chainID, err)
-		}
-		// Also include the source L1 for context
-		_, optimisticL1, err := chain.OptimisticAt(ctx, timestamp)
-		if errors.Is(err, ethereum.NotFound) {
-			continue
-		} else if err != nil {
-			s.log.Warn("failed to get optimistic source L1", "chain_id", chainID.String(), "err", err)
-			return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("failed to get optimistic source L1 at timestamp %v for chain ID %v: %w", timestamp, chainID, err)
-		}
-		optimistic[chainID] = eth.OutputWithRequiredL1{
-			Output:     optimisticOut,
-			OutputRoot: eth.OutputRoot(optimisticOut),
-			RequiredL1: optimisticL1,
+	// Fall back to live state for timestamps the verifier has not yet committed
+	// (e.g. the in-flight pre-verification window). Once the verifier records
+	// a timestamp, the durable snapshot above is the source of truth.
+	if optimistic == nil {
+		optimistic, err = s.collectLiveOptimistic(ctx, timestamp)
+		if err != nil {
+			return eth.SuperRootAtTimestampResponse{}, err
 		}
 	}
 
 	response := eth.SuperRootAtTimestampResponse{
-		CurrentL1:                 aggregate.CurrentL1,
+		CurrentL1:                 currentL1,
 		CurrentSafeTimestamp:      aggregate.SafeTimestamp,
 		CurrentLocalSafeTimestamp: aggregate.LocalSafeTimestamp,
 		CurrentFinalizedTimestamp: aggregate.FinalizedTimestamp,
@@ -107,4 +123,34 @@ func (s *Superroot) atTimestamp(ctx context.Context, timestamp uint64) (eth.Supe
 		Data:                      verifiedData,
 	}
 	return response, nil
+}
+
+// collectLiveOptimistic queries each chain for its optimistic head at the
+// timestamp. Used only when the verifier has no durable snapshot yet (the
+// pre-verification window). For verified timestamps the durable snapshot is
+// preferred — see StoredOptimisticAtTimestamp.
+func (s *Superroot) collectLiveOptimistic(ctx context.Context, timestamp uint64) (map[eth.ChainID]eth.OutputWithRequiredL1, error) {
+	optimistic := make(map[eth.ChainID]eth.OutputWithRequiredL1, len(s.chains))
+	for chainID, chain := range s.chains {
+		optimisticOut, err := chain.OptimisticOutputAtTimestamp(ctx, timestamp)
+		if errors.Is(err, ethereum.NotFound) {
+			continue
+		} else if err != nil {
+			s.log.Warn("failed to get optimistic block", "chain_id", chainID.String(), "err", err)
+			return nil, fmt.Errorf("failed to get optimistic block at timestamp %v for chain ID %v: %w", timestamp, chainID, err)
+		}
+		_, optimisticL1, err := chain.OptimisticAt(ctx, timestamp)
+		if errors.Is(err, ethereum.NotFound) {
+			continue
+		} else if err != nil {
+			s.log.Warn("failed to get optimistic source L1", "chain_id", chainID.String(), "err", err)
+			return nil, fmt.Errorf("failed to get optimistic source L1 at timestamp %v for chain ID %v: %w", timestamp, chainID, err)
+		}
+		optimistic[chainID] = eth.OutputWithRequiredL1{
+			Output:     optimisticOut,
+			OutputRoot: eth.OutputRoot(optimisticOut),
+			RequiredL1: optimisticL1,
+		}
+	}
+	return optimistic, nil
 }

--- a/op-supernode/supernode/activity/superroot/superroot_test.go
+++ b/op-supernode/supernode/activity/superroot/superroot_test.go
@@ -32,13 +32,26 @@ type mockCC struct {
 }
 
 type mockVerifiedProvider struct {
-	data  *eth.SuperRootResponseData
-	found bool
-	err   error
+	data            *eth.SuperRootResponseData
+	found           bool
+	err             error
+	optimistic      map[eth.ChainID]eth.OutputWithRequiredL1
+	optFound        bool
+	optErr          error
+	currentL1       eth.BlockID
+	currentL1Known  bool
 }
 
 func (m mockVerifiedProvider) StoredSuperRootAtTimestamp(uint64) (*eth.SuperRootResponseData, bool, error) {
 	return m.data, m.found, m.err
+}
+
+func (m mockVerifiedProvider) StoredOptimisticAtTimestamp(uint64) (map[eth.ChainID]eth.OutputWithRequiredL1, bool, error) {
+	return m.optimistic, m.optFound, m.optErr
+}
+
+func (m mockVerifiedProvider) VerifierCurrentL1() (eth.BlockID, bool) {
+	return m.currentL1, m.currentL1Known
 }
 
 func (m *mockCC) Start(ctx context.Context) error          { return nil }
@@ -112,6 +125,9 @@ func (m *mockCC) OutputV0AtBlockNumber(ctx context.Context, l2BlockNum uint64) (
 }
 func (m *mockCC) GetDeniedOutput(height uint64, payloadHash common.Hash) (*eth.OutputV0, error) {
 	return nil, nil
+}
+func (m *mockCC) LastDeniedAtHeight(height uint64) (*eth.OutputV0, eth.BlockID, error) {
+	return nil, eth.BlockID{}, nil
 }
 func (m *mockCC) PruneDeniedAtOrAfterTimestamp(timestamp uint64) (map[uint64][]common.Hash, error) {
 	return nil, nil

--- a/op-supernode/supernode/activity/superroot/superroot_test.go
+++ b/op-supernode/supernode/activity/superroot/superroot_test.go
@@ -32,14 +32,15 @@ type mockCC struct {
 }
 
 type mockVerifiedProvider struct {
-	data            *eth.SuperRootResponseData
-	found           bool
-	err             error
-	optimistic      map[eth.ChainID]eth.OutputWithRequiredL1
-	optFound        bool
-	optErr          error
-	currentL1       eth.BlockID
-	currentL1Known  bool
+	data           *eth.SuperRootResponseData
+	found          bool
+	err            error
+	optimistic     map[eth.ChainID]eth.OutputWithRequiredL1
+	optFound       bool
+	optErr         error
+	currentL1      eth.BlockID
+	currentL1Known bool
+	activeAt       bool
 }
 
 func (m mockVerifiedProvider) StoredSuperRootAtTimestamp(uint64) (*eth.SuperRootResponseData, bool, error) {
@@ -52,6 +53,10 @@ func (m mockVerifiedProvider) StoredOptimisticAtTimestamp(uint64) (map[eth.Chain
 
 func (m mockVerifiedProvider) VerifierCurrentL1() (eth.BlockID, bool) {
 	return m.currentL1, m.currentL1Known
+}
+
+func (m mockVerifiedProvider) IsActiveAt(uint64) bool {
+	return m.activeAt
 }
 
 func (m *mockCC) Start(ctx context.Context) error          { return nil }
@@ -338,6 +343,73 @@ func TestSuperroot_AtTimestamp_ErrorOnOptimisticAtWhenVerifiedNotFound(t *testin
 	api := &superrootAPI{s: s}
 	_, err := api.AtTimestamp(context.Background(), 123)
 	require.Error(t, err)
+}
+
+func TestSuperroot_AtTimestamp_PostActivationNoRecordReturnsNilData(t *testing.T) {
+	t.Parallel()
+	// Post-activation timestamp with no durable record: the verifier is the
+	// source of truth, so Data must remain nil rather than being filled in
+	// from live local-safe state. This is what makes
+	// "CurrentL1 >= game.L1Head" sufficient for the challenger to know it
+	// is acting on durable cross-safe data.
+	chains := map[eth.ChainID]cc.ChainContainer{
+		eth.ChainIDFromUInt64(10): &mockCC{
+			verL2:  eth.BlockID{Number: 100},
+			verL1:  eth.BlockID{Number: 1000},
+			output: eth.Bytes32{1},
+		},
+	}
+	s := New(gethlog.New(), chains, mockVerifiedProvider{activeAt: true})
+	api := &superrootAPI{s: s}
+	out, err := api.AtTimestamp(context.Background(), 123)
+	require.NoError(t, err)
+	require.Nil(t, out.Data)
+}
+
+func TestSuperroot_AtTimestamp_PostActivationDoesNotReadLive(t *testing.T) {
+	t.Parallel()
+	// Post-activation, no durable optimistic snapshot: the response must
+	// reflect "nothing observed" rather than fall back to live SafeDB.
+	// Live reads here would race with chain rewinds and undermine the
+	// CurrentL1 >= game.L1Head durability guarantee.
+	chains := map[eth.ChainID]cc.ChainContainer{
+		eth.ChainIDFromUInt64(10): &mockCC{optL2: eth.BlockID{Number: 100}, optL1: eth.BlockID{Number: 1000}},
+	}
+	s := New(gethlog.New(), chains, mockVerifiedProvider{activeAt: true})
+	api := &superrootAPI{s: s}
+	out, err := api.AtTimestamp(context.Background(), 123)
+	require.NoError(t, err)
+	require.Nil(t, out.Data)
+	require.Empty(t, out.OptimisticAtTimestamp, "post-activation must not return live optimistic data")
+}
+
+func TestSuperroot_AtTimestamp_PostActivationServesPartialFromProvider(t *testing.T) {
+	t.Parallel()
+	// Post-activation, the provider returns a partial per-chain optimistic
+	// view (e.g. captured by the verifier when only some chains had a block
+	// ready). The handler must pass this through unchanged so the challenger
+	// can pinpoint which chain is the InvalidTransition boundary step.
+	partial := map[eth.ChainID]eth.OutputWithRequiredL1{
+		eth.ChainIDFromUInt64(10): {
+			OutputRoot: eth.Bytes32{1},
+			RequiredL1: eth.BlockID{Number: 999},
+		},
+	}
+	chains := map[eth.ChainID]cc.ChainContainer{
+		eth.ChainIDFromUInt64(10): &mockCC{},
+		eth.ChainIDFromUInt64(20): &mockCC{},
+	}
+	s := New(gethlog.New(), chains, mockVerifiedProvider{
+		activeAt:   true,
+		optimistic: partial,
+		optFound:   true,
+	})
+	api := &superrootAPI{s: s}
+	out, err := api.AtTimestamp(context.Background(), 123)
+	require.NoError(t, err)
+	require.Len(t, out.OptimisticAtTimestamp, 1)
+	_, has10 := out.OptimisticAtTimestamp[eth.ChainIDFromUInt64(10)]
+	require.True(t, has10)
 }
 
 func TestSuperroot_AtTimestamp_LiveVerifiedFallbackPropagatesError(t *testing.T) {

--- a/op-supernode/supernode/activity/superroot/superroot_test.go
+++ b/op-supernode/supernode/activity/superroot/superroot_test.go
@@ -31,6 +31,16 @@ type mockCC struct {
 	syncStatusErr error
 }
 
+type mockVerifiedProvider struct {
+	data  *eth.SuperRootResponseData
+	found bool
+	err   error
+}
+
+func (m mockVerifiedProvider) StoredSuperRootAtTimestamp(uint64) (*eth.SuperRootResponseData, bool, error) {
+	return m.data, m.found, m.err
+}
+
 func (m *mockCC) Start(ctx context.Context) error          { return nil }
 func (m *mockCC) Stop(ctx context.Context) error           { return nil }
 func (m *mockCC) Pause(ctx context.Context) error          { return nil }
@@ -123,6 +133,16 @@ var _ cc.ChainContainer = (*mockCC)(nil)
 
 func TestSuperroot_AtTimestamp_Succeeds(t *testing.T) {
 	t.Parallel()
+	chainOutputs := []eth.ChainIDAndOutput{
+		{ChainID: eth.ChainIDFromUInt64(10), Output: eth.Bytes32{}},
+		{ChainID: eth.ChainIDFromUInt64(420), Output: eth.Bytes32{}},
+	}
+	super := eth.NewSuperV1(123, chainOutputs...)
+	stored := &eth.SuperRootResponseData{
+		VerifiedRequiredL1: eth.BlockID{Number: 1100},
+		Super:              super,
+		SuperRoot:          eth.SuperRoot(super),
+	}
 	chains := map[eth.ChainID]cc.ChainContainer{
 		eth.ChainIDFromUInt64(10): &mockCC{
 			verL2:  eth.BlockID{Number: 100},
@@ -151,7 +171,7 @@ func TestSuperroot_AtTimestamp_Succeeds(t *testing.T) {
 			},
 		},
 	}
-	s := New(gethlog.New(), chains)
+	s := New(gethlog.New(), chains, mockVerifiedProvider{data: stored, found: true})
 	api := &superrootAPI{s: s}
 	out, err := api.AtTimestamp(context.Background(), 123)
 	require.NoError(t, err)
@@ -191,16 +211,24 @@ func TestSuperroot_AtTimestamp_ComputesSuperRoot(t *testing.T) {
 		},
 	}
 	ts := uint64(123)
-	s := New(gethlog.New(), chains)
+	chainOutputs := []eth.ChainIDAndOutput{
+		{ChainID: eth.ChainIDFromUInt64(10), Output: out1},
+		{ChainID: eth.ChainIDFromUInt64(420), Output: out2},
+	}
+	super := eth.NewSuperV1(ts, chainOutputs...)
+	s := New(gethlog.New(), chains, mockVerifiedProvider{
+		data: &eth.SuperRootResponseData{
+			VerifiedRequiredL1: eth.BlockID{Number: 1100},
+			Super:              super,
+			SuperRoot:          eth.SuperRoot(super),
+		},
+		found: true,
+	})
 	api := &superrootAPI{s: s}
 	resp, err := api.AtTimestamp(context.Background(), hexutil.Uint64(ts))
 	require.NoError(t, err)
 
 	// Compute expected super root
-	chainOutputs := []eth.ChainIDAndOutput{
-		{ChainID: eth.ChainIDFromUInt64(10), Output: out1},
-		{ChainID: eth.ChainIDFromUInt64(420), Output: out2},
-	}
 	expected := eth.SuperRoot(eth.NewSuperV1(ts, chainOutputs...))
 	require.Equal(t, expected, resp.Data.SuperRoot)
 }
@@ -212,26 +240,24 @@ func TestSuperroot_AtTimestamp_ErrorOnCurrentL1(t *testing.T) {
 			syncStatusErr: assertErr(),
 		},
 	}
-	s := New(gethlog.New(), chains)
+	s := New(gethlog.New(), chains, nil)
 	api := &superrootAPI{s: s}
 	_, err := api.AtTimestamp(context.Background(), 123)
 	require.Error(t, err)
 }
 
-func TestSuperroot_AtTimestamp_ErrorOnVerifiedAt(t *testing.T) {
+func TestSuperroot_AtTimestamp_ErrorOnStoredVerifiedData(t *testing.T) {
 	t.Parallel()
 	chains := map[eth.ChainID]cc.ChainContainer{
-		eth.ChainIDFromUInt64(10): &mockCC{
-			verifiedErr: assertErr(),
-		},
+		eth.ChainIDFromUInt64(10): &mockCC{},
 	}
-	s := New(gethlog.New(), chains)
+	s := New(gethlog.New(), chains, mockVerifiedProvider{err: assertErr()})
 	api := &superrootAPI{s: s}
 	_, err := api.AtTimestamp(context.Background(), 123)
 	require.Error(t, err)
 }
 
-func TestSuperroot_AtTimestamp_NotFoundOnVerifiedAt(t *testing.T) {
+func TestSuperroot_AtTimestamp_NoStoredVerifiedData(t *testing.T) {
 	t.Parallel()
 	chains := map[eth.ChainID]cc.ChainContainer{
 		eth.ChainIDFromUInt64(10): &mockCC{
@@ -248,7 +274,7 @@ func TestSuperroot_AtTimestamp_NotFoundOnVerifiedAt(t *testing.T) {
 			status: &eth.SyncStatus{CurrentL1: eth.L1BlockRef{Number: 2100}},
 		},
 	}
-	s := New(gethlog.New(), chains)
+	s := New(gethlog.New(), chains, nil)
 	api := &superrootAPI{s: s}
 	actual, err := api.AtTimestamp(context.Background(), 123)
 	require.NoError(t, err)
@@ -274,7 +300,7 @@ func TestSuperroot_AtTimestamp_NotFoundOnVerifiedAtAndOptimisticAt(t *testing.T)
 			status: &eth.SyncStatus{CurrentL1: eth.L1BlockRef{Number: 2100}},
 		},
 	}
-	s := New(gethlog.New(), chains)
+	s := New(gethlog.New(), chains, nil)
 	api := &superrootAPI{s: s}
 	actual, err := api.AtTimestamp(context.Background(), 123)
 	require.NoError(t, err)
@@ -292,13 +318,13 @@ func TestSuperroot_AtTimestamp_ErrorOnOptimisticAtWhenVerifiedNotFound(t *testin
 			optimisticErr: assertErr(),
 		},
 	}
-	s := New(gethlog.New(), chains)
+	s := New(gethlog.New(), chains, nil)
 	api := &superrootAPI{s: s}
 	_, err := api.AtTimestamp(context.Background(), 123)
 	require.Error(t, err)
 }
 
-func TestSuperroot_AtTimestamp_ErrorOnOutputRoot(t *testing.T) {
+func TestSuperroot_AtTimestamp_DoesNotReadLiveVerifiedOutputRoot(t *testing.T) {
 	t.Parallel()
 	chains := map[eth.ChainID]cc.ChainContainer{
 		eth.ChainIDFromUInt64(10): &mockCC{
@@ -306,10 +332,11 @@ func TestSuperroot_AtTimestamp_ErrorOnOutputRoot(t *testing.T) {
 			outputErr: assertErr(),
 		},
 	}
-	s := New(gethlog.New(), chains)
+	s := New(gethlog.New(), chains, nil)
 	api := &superrootAPI{s: s}
-	_, err := api.AtTimestamp(context.Background(), 123)
-	require.Error(t, err)
+	out, err := api.AtTimestamp(context.Background(), 123)
+	require.NoError(t, err)
+	require.Nil(t, out.Data)
 }
 
 func TestSuperroot_AtTimestamp_ErrorOnOptimisticAt(t *testing.T) {
@@ -321,7 +348,7 @@ func TestSuperroot_AtTimestamp_ErrorOnOptimisticAt(t *testing.T) {
 			optimisticErr: assertErr(),
 		},
 	}
-	s := New(gethlog.New(), chains)
+	s := New(gethlog.New(), chains, nil)
 	api := &superrootAPI{s: s}
 	_, err := api.AtTimestamp(context.Background(), 123)
 	require.Error(t, err)
@@ -330,7 +357,7 @@ func TestSuperroot_AtTimestamp_ErrorOnOptimisticAt(t *testing.T) {
 func TestSuperroot_AtTimestamp_EmptyChains(t *testing.T) {
 	t.Parallel()
 	chains := map[eth.ChainID]cc.ChainContainer{}
-	s := New(gethlog.New(), chains)
+	s := New(gethlog.New(), chains, nil)
 	api := &superrootAPI{s: s}
 	out, err := api.AtTimestamp(context.Background(), 123)
 	require.NoError(t, err)
@@ -353,7 +380,7 @@ func TestSuperroot_AtTimestamp_VerifierL1ReducesCurrentL1(t *testing.T) {
 			verifierL1s: []eth.BlockID{{Number: 1500}},
 		},
 	}
-	s := New(gethlog.New(), chains)
+	s := New(gethlog.New(), chains, nil)
 	api := &superrootAPI{s: s}
 	out, err := api.AtTimestamp(context.Background(), 123)
 	require.NoError(t, err)
@@ -377,7 +404,7 @@ func TestSuperroot_AtTimestamp_VerifierL1HigherThanDerivationDoesNotIncrease(t *
 			verifierL1s: []eth.BlockID{{Number: 3000}},
 		},
 	}
-	s := New(gethlog.New(), chains)
+	s := New(gethlog.New(), chains, nil)
 	api := &superrootAPI{s: s}
 	out, err := api.AtTimestamp(context.Background(), 123)
 	require.NoError(t, err)

--- a/op-supernode/supernode/activity/superroot/superroot_test.go
+++ b/op-supernode/supernode/activity/superroot/superroot_test.go
@@ -340,8 +340,12 @@ func TestSuperroot_AtTimestamp_ErrorOnOptimisticAtWhenVerifiedNotFound(t *testin
 	require.Error(t, err)
 }
 
-func TestSuperroot_AtTimestamp_DoesNotReadLiveVerifiedOutputRoot(t *testing.T) {
+func TestSuperroot_AtTimestamp_LiveVerifiedFallbackPropagatesError(t *testing.T) {
 	t.Parallel()
+	// With no verified provider configured (preinterop, or pre-activation),
+	// the response data is rebuilt from live VerifiedAt + OutputRootAtL2BlockNumber.
+	// Errors from those live reads must propagate so callers can distinguish
+	// "no data yet" from "node is broken".
 	chains := map[eth.ChainID]cc.ChainContainer{
 		eth.ChainIDFromUInt64(10): &mockCC{
 			verL2:     eth.BlockID{Number: 100},
@@ -350,9 +354,28 @@ func TestSuperroot_AtTimestamp_DoesNotReadLiveVerifiedOutputRoot(t *testing.T) {
 	}
 	s := New(gethlog.New(), chains, nil)
 	api := &superrootAPI{s: s}
+	_, err := api.AtTimestamp(context.Background(), 123)
+	require.Error(t, err)
+}
+
+func TestSuperroot_AtTimestamp_LiveVerifiedFallbackPopulatesData(t *testing.T) {
+	t.Parallel()
+	// With no verified provider configured (preinterop), the response data
+	// must be populated from live VerifiedAt + OutputRootAtL2BlockNumber so
+	// fault-proof callers waiting for resp.Data != nil can make progress.
+	chains := map[eth.ChainID]cc.ChainContainer{
+		eth.ChainIDFromUInt64(10): &mockCC{
+			verL2:  eth.BlockID{Number: 100},
+			verL1:  eth.BlockID{Number: 1000},
+			output: eth.Bytes32{1},
+		},
+	}
+	s := New(gethlog.New(), chains, nil)
+	api := &superrootAPI{s: s}
 	out, err := api.AtTimestamp(context.Background(), 123)
 	require.NoError(t, err)
-	require.Nil(t, out.Data)
+	require.NotNil(t, out.Data)
+	require.Equal(t, uint64(1000), out.Data.VerifiedRequiredL1.Number)
 }
 
 func TestSuperroot_AtTimestamp_ErrorOnOptimisticAt(t *testing.T) {

--- a/op-supernode/supernode/chain_container/chain_container.go
+++ b/op-supernode/supernode/chain_container/chain_container.go
@@ -74,6 +74,11 @@ type ChainContainer interface {
 	// GetDeniedOutput returns the reconstructed OutputV0 for a denied block.
 	// Returns nil if the block is not denied at that height.
 	GetDeniedOutput(height uint64, payloadHash common.Hash) (*eth.OutputV0, error)
+	// LastDeniedAtHeight returns the OutputV0 and per-chain L1 inclusion for
+	// the most recently denied block at the given height. Returns (nil, BlockID{}, nil)
+	// when nothing is denied. Used to recover the original optimistic block
+	// after invalidation+replacement.
+	LastDeniedAtHeight(height uint64) (*eth.OutputV0, eth.BlockID, error)
 	// OutputV0AtBlockNumber returns the full OutputV0 for the block at the given number.
 	OutputV0AtBlockNumber(ctx context.Context, l2BlockNum uint64) (*eth.OutputV0, error)
 	// SetResetCallback sets a callback that is invoked when the chain resets.
@@ -98,7 +103,7 @@ type InteropChain interface {
 	// InvalidateBlock adds a block to the deny list and triggers a rewind if the
 	// chain currently uses that block at the specified height. Returns true if a
 	// rewind was triggered, false otherwise.
-	InvalidateBlock(ctx context.Context, height uint64, payloadHash common.Hash, decisionTimestamp uint64, stateRoot, messagePasserStorageRoot eth.Bytes32) (bool, error)
+	InvalidateBlock(ctx context.Context, height uint64, payloadHash common.Hash, decisionTimestamp uint64, stateRoot, messagePasserStorageRoot eth.Bytes32, l1Inclusion eth.BlockID) (bool, error)
 }
 
 type virtualNodeFactory func(cfg *opnodecfg.Config, log gethlog.Logger, initOverrides *rollupNode.InitializationOverrides, appVersion string, superAuthority rollup.SuperAuthority) virtual_node.VirtualNode
@@ -563,12 +568,16 @@ func (c *simpleChainContainer) OptimisticOutputAtTimestamp(ctx context.Context, 
 	}
 
 	if c.denyList != nil {
-		outV0, err := c.denyList.LastDeniedOutputV0(blockNum)
+		rec, err := c.denyList.LastDeniedRecord(blockNum)
 		if err != nil {
 			return nil, fmt.Errorf("failed to query deny list at height %d: %w", blockNum, err)
 		}
-		if outV0 != nil {
-			return outV0, nil
+		if rec != nil {
+			return &eth.OutputV0{
+				StateRoot:                rec.StateRoot,
+				MessagePasserStorageRoot: rec.MessagePasserStorageRoot,
+				BlockHash:                rec.PayloadHash,
+			}, nil
 		}
 	}
 

--- a/op-supernode/supernode/chain_container/chain_container_test.go
+++ b/op-supernode/supernode/chain_container/chain_container_test.go
@@ -1279,7 +1279,7 @@ func TestChainContainer_OptimisticOutputAtTimestamp_ReturnsDeniedOutput(t *testi
 	// Block at height 5: timestamp = 1000 + 5*2 = 1010
 	height := uint64(5)
 	ts := genesisTime + height*blockTime
-	require.NoError(t, dl.Add(height, payloadHash, 0, stateRoot, msgPasserRoot))
+	require.NoError(t, dl.Add(height, payloadHash, 0, stateRoot, msgPasserRoot, eth.BlockID{}))
 
 	container := &simpleChainContainer{
 		vncfg:    vncfg,
@@ -1316,12 +1316,12 @@ func TestChainContainer_OptimisticOutputAtTimestamp_UsesLatestDeniedRecord(t *te
 
 	// Add two denied records at the same height — the latest should win
 	firstHash := common.HexToHash("0x1111")
-	require.NoError(t, dl.Add(height, firstHash, 100, eth.Bytes32{0x01}, eth.Bytes32{0x02}))
+	require.NoError(t, dl.Add(height, firstHash, 100, eth.Bytes32{0x01}, eth.Bytes32{0x02}, eth.BlockID{}))
 
 	latestHash := common.HexToHash("0x2222")
 	latestState := eth.Bytes32(common.HexToHash("0xlatest"))
 	latestMsgPasser := eth.Bytes32(common.HexToHash("0xlatestmp"))
-	require.NoError(t, dl.Add(height, latestHash, 200, latestState, latestMsgPasser))
+	require.NoError(t, dl.Add(height, latestHash, 200, latestState, latestMsgPasser, eth.BlockID{}))
 
 	container := &simpleChainContainer{
 		vncfg:    vncfg,

--- a/op-supernode/supernode/chain_container/invalidation.go
+++ b/op-supernode/supernode/chain_container/invalidation.go
@@ -31,11 +31,17 @@ type DenyList struct {
 
 // DenyRecord stores a denied payload hash along with decision provenance
 // and the output preimage fields for optimistic root computation.
+//
+// L1Inclusion is the per-chain L1 block at which the denied optimistic block
+// became safe. It is captured at decision time so the superroot RPC can serve
+// OptimisticAtTimestamp.RequiredL1 from durable state without re-reading
+// SafeDB after a rewind.
 type DenyRecord struct {
 	PayloadHash              common.Hash `json:"payloadHash"`
 	DecisionTimestamp        uint64      `json:"decisionTimestamp"`
 	StateRoot                eth.Bytes32 `json:"stateRoot"`
 	MessagePasserStorageRoot eth.Bytes32 `json:"messagePasserStorageRoot"`
+	L1Inclusion              eth.BlockID `json:"l1Inclusion"`
 }
 
 func encodeDenyRecords(records []DenyRecord) ([]byte, error) {
@@ -87,8 +93,9 @@ func heightToKey(height uint64) []byte {
 
 // Add adds a payload hash to the deny list at the given block height.
 // stateRoot and messagePasserStorageRoot are the output preimage fields for optimistic root computation.
+// l1Inclusion is the per-chain L1 block at which the denied block became safe.
 // Multiple hashes can be denied at the same height.
-func (d *DenyList) Add(height uint64, payloadHash common.Hash, decisionTimestamp uint64, stateRoot, messagePasserStorageRoot eth.Bytes32) error {
+func (d *DenyList) Add(height uint64, payloadHash common.Hash, decisionTimestamp uint64, stateRoot, messagePasserStorageRoot eth.Bytes32, l1Inclusion eth.BlockID) error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
@@ -114,6 +121,7 @@ func (d *DenyList) Add(height uint64, payloadHash common.Hash, decisionTimestamp
 			DecisionTimestamp:        decisionTimestamp,
 			StateRoot:                stateRoot,
 			MessagePasserStorageRoot: messagePasserStorageRoot,
+			L1Inclusion:              l1Inclusion,
 		})
 
 		encoded, err := encodeDenyRecords(records)
@@ -122,6 +130,35 @@ func (d *DenyList) Add(height uint64, payloadHash common.Hash, decisionTimestamp
 		}
 		return b.Put(key, encoded)
 	})
+}
+
+// LastDeniedRecord returns the most recently denied record at the given height,
+// or nil if no blocks are denied. Used to recover the original optimistic
+// output (preimage + per-chain L1 inclusion) for a block that was later
+// invalidated and replaced.
+func (d *DenyList) LastDeniedRecord(height uint64) (*DenyRecord, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	key := heightToKey(height)
+	var result *DenyRecord
+	err := d.db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket(denyListBucketName)
+		existing := b.Get(key)
+		if existing == nil {
+			return nil
+		}
+		records, err := decodeDenyRecords(existing)
+		if err != nil {
+			return err
+		}
+		if len(records) > 0 {
+			r := records[len(records)-1]
+			result = &r
+		}
+		return nil
+	})
+	return result, err
 }
 
 // LastDeniedOutputV0 returns the OutputV0 for the most recently denied block at the given height.
@@ -366,7 +403,7 @@ func (d *DenyList) Close() error {
 // uses that block at the specified height.
 // Returns true if a rewind was triggered, false otherwise.
 // Note: Genesis block (height=0) cannot be invalidated as there is no prior block to rewind to.
-func (c *simpleChainContainer) InvalidateBlock(ctx context.Context, height uint64, payloadHash common.Hash, decisionTimestamp uint64, stateRoot, messagePasserStorageRoot eth.Bytes32) (bool, error) {
+func (c *simpleChainContainer) InvalidateBlock(ctx context.Context, height uint64, payloadHash common.Hash, decisionTimestamp uint64, stateRoot, messagePasserStorageRoot eth.Bytes32, l1Inclusion eth.BlockID) (bool, error) {
 	if c.denyList == nil {
 		return false, fmt.Errorf("deny list not initialized")
 	}
@@ -377,7 +414,7 @@ func (c *simpleChainContainer) InvalidateBlock(ctx context.Context, height uint6
 	}
 
 	// Add to deny list with the output preimage fields
-	if err := c.denyList.Add(height, payloadHash, decisionTimestamp, stateRoot, messagePasserStorageRoot); err != nil {
+	if err := c.denyList.Add(height, payloadHash, decisionTimestamp, stateRoot, messagePasserStorageRoot, l1Inclusion); err != nil {
 		return false, fmt.Errorf("failed to add block to deny list: %w", err)
 	}
 

--- a/op-supernode/supernode/chain_container/invalidation_test.go
+++ b/op-supernode/supernode/chain_container/invalidation_test.go
@@ -29,7 +29,7 @@ func TestDenyList_AddAndContains(t *testing.T) {
 			name: "single hash at height",
 			setup: func(t *testing.T, dl *DenyList) {
 				hash := common.HexToHash("0x1111111111111111111111111111111111111111111111111111111111111111")
-				require.NoError(t, dl.Add(100, hash, 0, eth.Bytes32{}, eth.Bytes32{}))
+				require.NoError(t, dl.Add(100, hash, 0, eth.Bytes32{}, eth.Bytes32{}, eth.BlockID{}))
 			},
 			check: func(t *testing.T, dl *DenyList) {
 				hash := common.HexToHash("0x1111111111111111111111111111111111111111111111111111111111111111")
@@ -47,7 +47,7 @@ func TestDenyList_AddAndContains(t *testing.T) {
 					common.HexToHash("0xcccc"),
 				}
 				for _, h := range hashes {
-					require.NoError(t, dl.Add(50, h, 0, eth.Bytes32{}, eth.Bytes32{}))
+					require.NoError(t, dl.Add(50, h, 0, eth.Bytes32{}, eth.Bytes32{}, eth.BlockID{}))
 				}
 			},
 			check: func(t *testing.T, dl *DenyList) {
@@ -67,7 +67,7 @@ func TestDenyList_AddAndContains(t *testing.T) {
 			name: "hash at wrong height returns false",
 			setup: func(t *testing.T, dl *DenyList) {
 				hash := common.HexToHash("0xdddd")
-				require.NoError(t, dl.Add(10, hash, 0, eth.Bytes32{}, eth.Bytes32{}))
+				require.NoError(t, dl.Add(10, hash, 0, eth.Bytes32{}, eth.Bytes32{}, eth.BlockID{}))
 			},
 			check: func(t *testing.T, dl *DenyList) {
 				hash := common.HexToHash("0xdddd")
@@ -86,9 +86,9 @@ func TestDenyList_AddAndContains(t *testing.T) {
 			name: "duplicate add is idempotent",
 			setup: func(t *testing.T, dl *DenyList) {
 				hash := common.HexToHash("0xeeee")
-				require.NoError(t, dl.Add(200, hash, 0, eth.Bytes32{}, eth.Bytes32{}))
-				require.NoError(t, dl.Add(200, hash, 0, eth.Bytes32{}, eth.Bytes32{})) // Add again
-				require.NoError(t, dl.Add(200, hash, 0, eth.Bytes32{}, eth.Bytes32{})) // And again
+				require.NoError(t, dl.Add(200, hash, 0, eth.Bytes32{}, eth.Bytes32{}, eth.BlockID{}))
+				require.NoError(t, dl.Add(200, hash, 0, eth.Bytes32{}, eth.Bytes32{}, eth.BlockID{})) // Add again
+				require.NoError(t, dl.Add(200, hash, 0, eth.Bytes32{}, eth.Bytes32{}, eth.BlockID{})) // And again
 			},
 			check: func(t *testing.T, dl *DenyList) {
 				hash := common.HexToHash("0xeeee")
@@ -138,7 +138,7 @@ func TestDenyList_Persistence(t *testing.T) {
 					{300, common.HexToHash("0x4444")},
 				}
 				for _, h := range hashes {
-					require.NoError(t, dl.Add(h.height, h.hash, 0, eth.Bytes32{}, eth.Bytes32{}))
+					require.NoError(t, dl.Add(h.height, h.hash, 0, eth.Bytes32{}, eth.Bytes32{}, eth.BlockID{}))
 				}
 
 				require.NoError(t, dl.Close())
@@ -220,7 +220,7 @@ func TestDenyList_GetDeniedHashes(t *testing.T) {
 			setup: func(t *testing.T, dl *DenyList) {
 				for i := 0; i < 5; i++ {
 					hash := common.BigToHash(common.Big1.Add(common.Big1, common.Big0.SetInt64(int64(i))))
-					require.NoError(t, dl.Add(100, hash, 0, eth.Bytes32{}, eth.Bytes32{}))
+					require.NoError(t, dl.Add(100, hash, 0, eth.Bytes32{}, eth.Bytes32{}, eth.BlockID{}))
 				}
 			},
 			check: func(t *testing.T, dl *DenyList) {
@@ -233,8 +233,8 @@ func TestDenyList_GetDeniedHashes(t *testing.T) {
 			name: "empty for clean height",
 			setup: func(t *testing.T, dl *DenyList) {
 				// Add hashes at other heights
-				require.NoError(t, dl.Add(10, common.HexToHash("0xaaaa"), 0, eth.Bytes32{}, eth.Bytes32{}))
-				require.NoError(t, dl.Add(30, common.HexToHash("0xbbbb"), 0, eth.Bytes32{}, eth.Bytes32{}))
+				require.NoError(t, dl.Add(10, common.HexToHash("0xaaaa"), 0, eth.Bytes32{}, eth.Bytes32{}, eth.BlockID{}))
+				require.NoError(t, dl.Add(30, common.HexToHash("0xbbbb"), 0, eth.Bytes32{}, eth.Bytes32{}, eth.BlockID{}))
 			},
 			check: func(t *testing.T, dl *DenyList) {
 				hashes, err := dl.GetDeniedHashes(20)
@@ -246,12 +246,12 @@ func TestDenyList_GetDeniedHashes(t *testing.T) {
 			name: "isolated by height",
 			setup: func(t *testing.T, dl *DenyList) {
 				// Add different hashes at different heights
-				require.NoError(t, dl.Add(10, common.HexToHash("0x1010"), 0, eth.Bytes32{}, eth.Bytes32{}))
-				require.NoError(t, dl.Add(10, common.HexToHash("0x1011"), 0, eth.Bytes32{}, eth.Bytes32{}))
-				require.NoError(t, dl.Add(20, common.HexToHash("0x2020"), 0, eth.Bytes32{}, eth.Bytes32{}))
-				require.NoError(t, dl.Add(20, common.HexToHash("0x2021"), 0, eth.Bytes32{}, eth.Bytes32{}))
-				require.NoError(t, dl.Add(20, common.HexToHash("0x2022"), 0, eth.Bytes32{}, eth.Bytes32{}))
-				require.NoError(t, dl.Add(30, common.HexToHash("0x3030"), 0, eth.Bytes32{}, eth.Bytes32{}))
+				require.NoError(t, dl.Add(10, common.HexToHash("0x1010"), 0, eth.Bytes32{}, eth.Bytes32{}, eth.BlockID{}))
+				require.NoError(t, dl.Add(10, common.HexToHash("0x1011"), 0, eth.Bytes32{}, eth.Bytes32{}, eth.BlockID{}))
+				require.NoError(t, dl.Add(20, common.HexToHash("0x2020"), 0, eth.Bytes32{}, eth.Bytes32{}, eth.BlockID{}))
+				require.NoError(t, dl.Add(20, common.HexToHash("0x2021"), 0, eth.Bytes32{}, eth.Bytes32{}, eth.BlockID{}))
+				require.NoError(t, dl.Add(20, common.HexToHash("0x2022"), 0, eth.Bytes32{}, eth.Bytes32{}, eth.BlockID{}))
+				require.NoError(t, dl.Add(30, common.HexToHash("0x3030"), 0, eth.Bytes32{}, eth.Bytes32{}, eth.BlockID{}))
 			},
 			check: func(t *testing.T, dl *DenyList) {
 				hashes10, err := dl.GetDeniedHashes(10)
@@ -412,7 +412,7 @@ func TestInvalidateBlock(t *testing.T) {
 		}
 
 		ctx := context.Background()
-		rewound, err := c.InvalidateBlock(ctx, 0, common.HexToHash("0xgenesis"), 0, eth.Bytes32{}, eth.Bytes32{})
+		rewound, err := c.InvalidateBlock(ctx, 0, common.HexToHash("0xgenesis"), 0, eth.Bytes32{}, eth.Bytes32{}, eth.BlockID{})
 
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "cannot invalidate genesis block")
@@ -439,7 +439,7 @@ func TestInvalidateBlock(t *testing.T) {
 		}
 
 		hash := common.HexToHash("0xdead")
-		rewound, err := c.InvalidateBlock(context.Background(), 5, hash, 0, eth.Bytes32{}, eth.Bytes32{})
+		rewound, err := c.InvalidateBlock(context.Background(), 5, hash, 0, eth.Bytes32{}, eth.Bytes32{}, eth.BlockID{})
 
 		require.Error(t, err)
 		require.ErrorIs(t, err, engine_controller.ErrNoEngineClient)
@@ -469,7 +469,7 @@ func TestInvalidateBlock(t *testing.T) {
 		}
 
 		hash := common.HexToHash("0xdead")
-		rewound, err := c.InvalidateBlock(context.Background(), 5, hash, 0, eth.Bytes32{}, eth.Bytes32{})
+		rewound, err := c.InvalidateBlock(context.Background(), 5, hash, 0, eth.Bytes32{}, eth.Bytes32{}, eth.BlockID{})
 
 		require.Error(t, err)
 		require.ErrorIs(t, err, fetchErr)
@@ -500,7 +500,7 @@ func TestInvalidateBlock(t *testing.T) {
 			vn:       &mockVNForInvalidation{},
 		}
 
-		rewound, err := c.InvalidateBlock(context.Background(), 5, common.HexToHash("0xdead"), 0, eth.Bytes32{}, eth.Bytes32{})
+		rewound, err := c.InvalidateBlock(context.Background(), 5, common.HexToHash("0xdead"), 0, eth.Bytes32{}, eth.Bytes32{}, eth.BlockID{})
 
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to compute rewind timestamp")
@@ -546,7 +546,7 @@ func TestInvalidateBlock(t *testing.T) {
 			}
 
 			ctx := context.Background()
-			rewound, err := c.InvalidateBlock(ctx, tt.height, tt.payloadHash, 0, testStateRoot, testMsgPasserRoot)
+			rewound, err := c.InvalidateBlock(ctx, tt.height, tt.payloadHash, 0, testStateRoot, testMsgPasserRoot, eth.BlockID{})
 			require.NoError(t, err)
 
 			// Verify rewind behavior
@@ -587,7 +587,7 @@ func TestGetDeniedOutput(t *testing.T) {
 	}
 
 	t.Run("returns output after InvalidateBlock", func(t *testing.T) {
-		require.NoError(t, dl.Add(100, hash, 0, testStateRoot, testMsgPasserRoot))
+		require.NoError(t, dl.Add(100, hash, 0, testStateRoot, testMsgPasserRoot, eth.BlockID{}))
 
 		got, err := c.GetDeniedOutput(100, hash)
 		require.NoError(t, err)
@@ -661,7 +661,7 @@ func TestIsDenied(t *testing.T) {
 			defer dl.Close()
 
 			// Setup
-			require.NoError(t, dl.Add(tt.setupHeight, tt.setupHash, 0, eth.Bytes32{}, eth.Bytes32{}))
+			require.NoError(t, dl.Add(tt.setupHeight, tt.setupHash, 0, eth.Bytes32{}, eth.Bytes32{}, eth.BlockID{}))
 
 			// Create container
 			c := &simpleChainContainer{
@@ -718,7 +718,7 @@ func TestDenyList_ConcurrentAccess(t *testing.T) {
 				hash := makeHash(accessorID, j)
 
 				// Write
-				err := dl.Add(height, hash, 0, eth.Bytes32{}, eth.Bytes32{})
+				err := dl.Add(height, hash, 0, eth.Bytes32{}, eth.Bytes32{}, eth.BlockID{})
 				require.NoError(t, err)
 
 				// Read own write
@@ -761,9 +761,9 @@ func TestDenyList_PruneAtOrAfterTimestamp(t *testing.T) {
 	hashA := common.HexToHash("0xaaaa")
 	hashB := common.HexToHash("0xbbbb")
 	hashC := common.HexToHash("0xcccc")
-	require.NoError(t, dl.Add(100, hashA, 10, eth.Bytes32{}, eth.Bytes32{}))
-	require.NoError(t, dl.Add(100, hashB, 11, eth.Bytes32{}, eth.Bytes32{}))
-	require.NoError(t, dl.Add(200, hashC, 12, eth.Bytes32{}, eth.Bytes32{}))
+	require.NoError(t, dl.Add(100, hashA, 10, eth.Bytes32{}, eth.Bytes32{}, eth.BlockID{}))
+	require.NoError(t, dl.Add(100, hashB, 11, eth.Bytes32{}, eth.Bytes32{}, eth.BlockID{}))
+	require.NoError(t, dl.Add(200, hashC, 12, eth.Bytes32{}, eth.Bytes32{}, eth.BlockID{}))
 
 	removed, err := dl.PruneAtOrAfterTimestamp(11)
 	require.NoError(t, err)
@@ -792,9 +792,9 @@ func TestDenyList_HasDeniedAtOrAfterTimestamp(t *testing.T) {
 	require.NoError(t, err)
 	defer dl.Close()
 
-	require.NoError(t, dl.Add(100, common.HexToHash("0xaaaa"), 10, eth.Bytes32{}, eth.Bytes32{}))
-	require.NoError(t, dl.Add(50, common.HexToHash("0xbbbb"), 12, eth.Bytes32{}, eth.Bytes32{}))
-	require.NoError(t, dl.Add(25, common.HexToHash("0xcccc"), 9, eth.Bytes32{}, eth.Bytes32{}))
+	require.NoError(t, dl.Add(100, common.HexToHash("0xaaaa"), 10, eth.Bytes32{}, eth.Bytes32{}, eth.BlockID{}))
+	require.NoError(t, dl.Add(50, common.HexToHash("0xbbbb"), 12, eth.Bytes32{}, eth.Bytes32{}, eth.BlockID{}))
+	require.NoError(t, dl.Add(25, common.HexToHash("0xcccc"), 9, eth.Bytes32{}, eth.Bytes32{}, eth.BlockID{}))
 
 	ok, err := dl.HasDeniedAtOrAfterTimestamp(11)
 	require.NoError(t, err)
@@ -819,7 +819,7 @@ func TestDenyList_GetOutputV0(t *testing.T) {
 		BlockHash:                common.HexToHash("0xblock"),
 	}
 	hash := common.HexToHash("0x1111")
-	require.NoError(t, dl.Add(100, hash, 0, out.StateRoot, out.MessagePasserStorageRoot))
+	require.NoError(t, dl.Add(100, hash, 0, out.StateRoot, out.MessagePasserStorageRoot, eth.BlockID{}))
 
 	want := &eth.OutputV0{
 		StateRoot:                out.StateRoot,
@@ -858,7 +858,7 @@ func TestDenyList_GetOutputV0(t *testing.T) {
 			BlockHash:                common.HexToHash("0xblock2"),
 		}
 		hash2 := common.HexToHash("0x2222")
-		require.NoError(t, dl.Add(100, hash2, 0, out2.StateRoot, out2.MessagePasserStorageRoot))
+		require.NoError(t, dl.Add(100, hash2, 0, out2.StateRoot, out2.MessagePasserStorageRoot, eth.BlockID{}))
 
 		got1, err := dl.GetOutputV0(100, hash)
 		require.NoError(t, err)
@@ -893,7 +893,7 @@ func TestDenyList_LastDeniedOutputV0(t *testing.T) {
 		hash := common.HexToHash("0xaaaa")
 		stateRoot := eth.Bytes32(common.HexToHash("0xstate1"))
 		msgPasser := eth.Bytes32(common.HexToHash("0xmp1"))
-		require.NoError(t, dl.Add(50, hash, 100, stateRoot, msgPasser))
+		require.NoError(t, dl.Add(50, hash, 100, stateRoot, msgPasser, eth.BlockID{}))
 
 		got, err := dl.LastDeniedOutputV0(50)
 		require.NoError(t, err)
@@ -906,12 +906,12 @@ func TestDenyList_LastDeniedOutputV0(t *testing.T) {
 
 	t.Run("returns the last record when multiple exist", func(t *testing.T) {
 		firstHash := common.HexToHash("0xbbbb")
-		require.NoError(t, dl.Add(60, firstHash, 100, eth.Bytes32{0x01}, eth.Bytes32{0x02}))
+		require.NoError(t, dl.Add(60, firstHash, 100, eth.Bytes32{0x01}, eth.Bytes32{0x02}, eth.BlockID{}))
 
 		lastHash := common.HexToHash("0xcccc")
 		lastState := eth.Bytes32(common.HexToHash("0xlast_state"))
 		lastMsgPasser := eth.Bytes32(common.HexToHash("0xlast_mp"))
-		require.NoError(t, dl.Add(60, lastHash, 200, lastState, lastMsgPasser))
+		require.NoError(t, dl.Add(60, lastHash, 200, lastState, lastMsgPasser, eth.BlockID{}))
 
 		got, err := dl.LastDeniedOutputV0(60)
 		require.NoError(t, err)
@@ -943,7 +943,7 @@ func TestDenyList_OutputPersistence(t *testing.T) {
 	// Write and close
 	dl, err := OpenDenyList(dir)
 	require.NoError(t, err)
-	require.NoError(t, dl.Add(100, hash, 42, out.StateRoot, out.MessagePasserStorageRoot))
+	require.NoError(t, dl.Add(100, hash, 42, out.StateRoot, out.MessagePasserStorageRoot, eth.BlockID{}))
 	require.NoError(t, dl.Close())
 
 	// Reopen and verify output persisted
@@ -985,8 +985,8 @@ func TestDenyList_GetDeniedRecords_IncludesRoots(t *testing.T) {
 	hash1 := common.HexToHash("0xaaaa")
 	hash2 := common.HexToHash("0xbbbb")
 
-	require.NoError(t, dl.Add(100, hash1, 10, out1.StateRoot, out1.MessagePasserStorageRoot))
-	require.NoError(t, dl.Add(100, hash2, 11, out2.StateRoot, out2.MessagePasserStorageRoot))
+	require.NoError(t, dl.Add(100, hash1, 10, out1.StateRoot, out1.MessagePasserStorageRoot, eth.BlockID{}))
+	require.NoError(t, dl.Add(100, hash2, 11, out2.StateRoot, out2.MessagePasserStorageRoot, eth.BlockID{}))
 
 	records, err := dl.GetDeniedRecords(100)
 	require.NoError(t, err)

--- a/op-supernode/supernode/chain_container/super_authority.go
+++ b/op-supernode/supernode/chain_container/super_authority.go
@@ -152,6 +152,27 @@ func (c *simpleChainContainer) GetDeniedOutput(height uint64, payloadHash common
 	return c.denyList.GetOutputV0(height, payloadHash)
 }
 
+// LastDeniedAtHeight returns the OutputV0 and per-chain L1 inclusion for the
+// most recently denied block at the given height, or (nil, BlockID{}, nil) if
+// nothing is denied. The L1 inclusion is the L1 block at which the denied
+// optimistic block became safe — captured at decision time so callers can
+// reconstruct OptimisticAtTimestamp.RequiredL1 for invalidated blocks without
+// touching live SafeDB state.
+func (c *simpleChainContainer) LastDeniedAtHeight(height uint64) (*eth.OutputV0, eth.BlockID, error) {
+	if c.denyList == nil {
+		return nil, eth.BlockID{}, fmt.Errorf("deny list not initialized")
+	}
+	rec, err := c.denyList.LastDeniedRecord(height)
+	if err != nil || rec == nil {
+		return nil, eth.BlockID{}, err
+	}
+	return &eth.OutputV0{
+		StateRoot:                rec.StateRoot,
+		MessagePasserStorageRoot: rec.MessagePasserStorageRoot,
+		BlockHash:                rec.PayloadHash,
+	}, rec.L1Inclusion, nil
+}
+
 // OutputV0AtBlockNumber returns the full OutputV0 for the block at the given number.
 func (c *simpleChainContainer) OutputV0AtBlockNumber(ctx context.Context, l2BlockNum uint64) (*eth.OutputV0, error) {
 	if c.engine == nil {

--- a/op-supernode/supernode/supernode.go
+++ b/op-supernode/supernode/supernode.go
@@ -116,7 +116,6 @@ func New(ctx context.Context, log gethlog.Logger, version string, requestStop co
 	s.activities = []activity.Activity{
 		heartbeat.New(log.New("activity", "heartbeat"), 10*time.Second),
 		supernodeactivity.New(log.New("activity", "supernode"), narrowChains),
-		superroot.New(log.New("activity", "superroot"), narrowChains),
 	}
 
 	interopActivationTimestamp, err := resolveInteropActivationTimestamp(cfg.InteropActivationTimestamp, vnCfgs)
@@ -129,6 +128,7 @@ func New(ctx context.Context, log gethlog.Logger, version string, requestStop co
 	}
 
 	log.Info("initializing interop activity", "enabled", interopActivationTimestamp != nil)
+	var verifiedSuperRootProvider superroot.VerifiedSuperRootProvider
 	// Initialize interop activity if the activation timestamp is known (non-nil).
 	// If it's nil, don't start interop. If it's non-nil (including 0), do start it.
 	if interopActivationTimestamp != nil {
@@ -142,12 +142,14 @@ func New(ctx context.Context, log gethlog.Logger, version string, requestStop co
 		}
 		interopActivity := interop.New(log.New("activity", "interop"), *interopActivationTimestamp, msgExpiryWindow, s.chains, cfg.DataDir, s.l1Client, cfg.InteropLogBackfillDepth, s.supernodeMetrics)
 		s.activities = append(s.activities, interopActivity)
+		verifiedSuperRootProvider = interopActivity
 		for _, chain := range s.chains {
 			chain.RegisterVerifier(interopActivity)
 		}
 		s.interopActivationTs = interopActivationTimestamp
 		s.interopMsgExpiryWindow = msgExpiryWindow
 	}
+	s.activities = append(s.activities, superroot.New(log.New("activity", "superroot"), narrowChains, verifiedSuperRootProvider))
 
 	// Set up reset callbacks on all chain containers
 	// When a chain resets, notify all activities


### PR DESCRIPTION
## Summary

Stacked on top of #20558. Adds the infrastructure needed for `superroot_atTimestamp` to serve **`Data`, `OptimisticAtTimestamp`, and `CurrentL1` entirely from durable verifier state** post-interop-activation, so `CurrentL1 ≥ game.L1Head` is sufficient for op-challenger to know it is only acting on cross-safe-consistent data.

Three commits:

1. **Serve `OptimisticAtTimestamp` from durable verified records** + per-chain L1 inclusion in `VerifiedRecord` and `DenyRecord`. Denylist overlay preserves the original optimistic block when a chain was invalidated and replaced.
2. **Preinterop / pre-activation live fallback** for `Data` (the existing `chain.VerifiedAt` path), so preinterop fault-proof acceptance tests can still observe `Data != nil`.
3. **Durable per-chain observation snapshot** so in-flight (post-activation, pre-commit) timestamps can serve `OptimisticAtTimestamp` partial views without a live SafeDB read. This closes the rewind race and is what makes the durability guarantee complete.

## Design overview

### `VerifiedRecord` (already in #20558, extended here)
- Per-chain `ChainObservation` (L2 head, L1 head, OutputV0 preimage). Aggregate `L1Inclusion` and per-chain output roots are derived on demand.
- `DenyRecord` and `InvalidHead` carry per-chain `L1Inclusion` captured at decision time.

### `ObservationsSnapshot` (new)
- Single `(timestamp, map[chainID]ChainObservation)` value, replaced atomically by the verifier each round in `checkChainsReady`.
- Replacement (including dropping chains that previously had a block but no longer do) is what closes the rewind race.
- `checkChainsReady` now returns partial results plus an `allReady` bool. NotFound from a chain is no longer fatal — the round is treated as Wait, but the partial snapshot is still persisted so the challenger can serve per-chain partial visibility (needed to identify which chain's optimistic step is the InvalidTransition boundary).
- Cleared on rewind in `applyRewindPlan` so post-rewind queries cannot return stale observations.

### Verifier frontier `CurrentL1`
- `Interop.VerifierCurrentL1()` exposes the durable frontier (already maintained in `frontier_bucket`/`current_l1`). The handler prefers it over the live aggregate.
- Advances every Wait round (`refreshCurrentL1OnWait`) so it tracks live L1 within a few blocks even between L2 batches.

### Live reads
The handler now consults live state **only** when `verifierActiveAt(timestamp) == false` — i.e. there is no provider configured (preinterop build) or the timestamp is pre-activation. Post-activation, every cross-safe-derived field is durable.

## Live vs durable audit

### Pre-interop activation (`!verifierActiveAt(timestamp)`)

Live reads only — there is no cross-safe state to be durable.

| Field | Source |
|---|---|
| `Data` | live `chain.VerifiedAt` + `chain.OutputRootAtL2BlockNumber` per chain |
| `OptimisticAtTimestamp` | live `chain.OptimisticOutputAtTimestamp` (with chain-side denylist overlay) + `chain.OptimisticAt` per chain |
| `CurrentL1` | `aggregate.CurrentL1` (live `chain.SyncStatus().CurrentL1`, reduced by registered verifiers' L1s) |
| `CurrentSafeTimestamp`, `CurrentLocalSafeTimestamp`, `CurrentFinalizedTimestamp` | live, from `chain.SyncStatus()` |
| `ChainIDs` | sorted keys of the chains map |

This branch handles preinterop deployments and any pre-activation timestamp on an interop deployment. The challenger's `CurrentL1 ≥ game.L1Head` guarantee doesn't apply here because the verifier isn't producing it; preinterop fault games don't depend on cross-safe verification anyway.

### Post-interop activation (`verifierActiveAt(timestamp) == true`)

No live reads of cross-safe data.

| Field | Source | Notes |
|---|---|---|
| `Data` | `Interop.StoredSuperRootAtTimestamp` → `VerifiedRecord.ResponseData()` | Returns nil if no record. No live fallback. |
| `OptimisticAtTimestamp` | `Interop.StoredOptimisticAtTimestamp` → `VerifiedRecord.Chains` if present, else `ObservationsSnapshot.Chains` if it covers the timestamp; both paths apply the denylist overlay | Returns empty (and partial within the snapshot) when the verifier hasn't observed the timestamp at all. No live fallback. |
| `CurrentL1` | `Interop.VerifierCurrentL1()` (durable verifier frontier in bbolt's `frontier_bucket`/`current_l1` key) | Falls back to live aggregate only before the verifier has populated the frontier (true cold start, pre-activation). |
| `CurrentSafeTimestamp`, `CurrentLocalSafeTimestamp`, `CurrentFinalizedTimestamp` | live `chain.SyncStatus()` | Local node sync state, not cross-safe data. Not consumed by the challenger for game decisions. |
| `ChainIDs` | sorted keys of the chains map | Matches the dependency set. |

### How each durable source is built

`VerifiedRecord` (committed by `applyPendingTransition` on `DecisionAdvance`):
- Per-chain L2 head, L1 head, OutputV0 preimage all snapshotted at observation time inside `buildVerifiedRecord` (using the `result.L1Heads` populated by `verifyInteropMessages` from `obs.L1Heads`).
- Aggregate `L1Inclusion()` is `max(per-chain L1Head)`, derived not stored.

`ObservationsSnapshot` (replaced by `observeRound` each round in `observationsDB.Set`):
- Built in `checkChainsReady` from per-chain `OptimisticAt(ts)` + `OutputV0AtBlockNumber(...)` calls. Each chain that returns successfully gets a `ChainObservation`; chains that return NotFound are absent.
- Replaced atomically in a single bbolt transaction so RPC reads see a consistent (timestamp, chains) view, not a torn snapshot.
- Cleared on rewind (`applyRewindPlan`) so a later round at a now-rewound timestamp cannot serve stale observations.

`DenyList` overlay (applied to both sources by `optimisticFromObservations`):
- Per-chain `LastDeniedAtHeight(L2Head.Number)` returns the original (denied) preimage and per-chain L1 inclusion captured at decision time. Overrides the verified/observed entry when present so the response surfaces the originally-observed (now-replaced) block, matching the semantic the challenger relies on.

### Why `CurrentL1 ≥ game.L1Head` is now sufficient

For any post-activation timestamp T:

1. The handler reads `verifiedProvider.VerifierCurrentL1()` — the durable frontier the verifier has fully digested. No live data influences `CurrentL1`.
2. If a `VerifiedRecord` exists at T → cross-safe view, all chains, full preimages and per-chain L1 inclusions. `VerifiedRequiredL1 ≤ CurrentL1` by construction (the verifier sets `CurrentL1 = parent(L1Inclusion)` on commit).
3. If no record at T but the observation snapshot covers T → partial cross-safe-candidate view. Each entry's `RequiredL1` is the per-chain L1 head observed in that round. Chains absent from the snapshot are absent from the response, exactly the per-chain partial visibility the challenger needs.
4. If neither covers T → empty response. The verifier hasn't observed T, so any answer would be a guess. The challenger correctly treats this as InvalidTransition.

In all three cases the response is built from a single bbolt-consistent snapshot. Chain rewinds between when the round committed and when the RPC fires can't desync `CurrentL1` from the per-chain entries, because both come from the same durable store.

### Live reads after activation

The only post-activation live reads are the L2 timestamp aggregates (`SafeTimestamp`, `LocalSafeTimestamp`, `FinalizedTimestamp`) — local node sync metadata that doesn't feed challenger decisions. Everything derived from L1 ≤ CurrentL1 — `Data`, `OptimisticAtTimestamp`, `CurrentL1`, denylist overlays — is durable, deterministic, and consistent.

## Tests

- `op-supernode/...` unit tests: pass.
- `op-acceptance-tests/tests/interop/proofs/serial/...` (11 tests): pass.
- `op-acceptance-tests/tests/interop/proofs-singlechain/...`: pass.
- `op-acceptance-tests/tests/isthmus/preinterop/...` (8 tests): pass.
- `op-acceptance-tests/tests/isthmus/preinterop-singlechain/...`: pass.