### PR TITLE
chore(kona-interop): remove dead InteropValidator trait and InteropValidationError

### DIFF
--- a/rust/kona/crates/protocol/interop/src/errors.rs
+++ b/rust/kona/crates/protocol/interop/src/errors.rs
@@ -132,26 +132,3 @@ pub enum SuperRootError {
 
 /// A [Result] alias for the [`SuperRootError`] type.
 pub type SuperRootResult<T> = core::result::Result<T, SuperRootError>;
-
-/// Errors that can occur during interop validation.
-#[derive(Debug, Error, PartialEq, Eq)]
-pub enum InteropValidationError {
-    /// Interop is not enabled on one or both chains at the required timestamp.
-    #[error("interop not enabled")]
-    InteropNotEnabled,
-
-    /// Executing timestamp is earlier than the initiating timestamp.
-    #[error(
-        "executing timestamp is earlier than initiating timestamp, executing: {executing}, initiating: {initiating}"
-    )]
-    InvalidTimestampInvariant {
-        /// Executing timestamp of the message
-        executing: u64,
-        /// Initiating timestamp of the message
-        initiating: u64,
-    },
-
-    /// Timestamp is outside the allowed interop expiry window.
-    #[error("timestamp outside allowed interop window, timestamp: {0}")]
-    InvalidInteropTimestamp(u64),
-}

--- a/rust/kona/crates/protocol/interop/src/lib.rs
+++ b/rust/kona/crates/protocol/interop/src/lib.rs
@@ -21,15 +21,13 @@ mod replacement;
 pub use replacement::BlockReplacement;
 
 mod traits;
-pub use traits::{InteropProvider, InteropValidator};
+pub use traits::InteropProvider;
 
 mod safety;
 pub use safety::SafetyLevelParseError;
 
 mod errors;
-pub use errors::{
-    InteropValidationError, MessageGraphError, MessageGraphResult, SuperRootError, SuperRootResult,
-};
+pub use errors::{MessageGraphError, MessageGraphResult, SuperRootError, SuperRootResult};
 
 mod root;
 pub use root::{ChainRootInfo, OutputRootWithChain, SuperRoot, SuperRootOutput};

--- a/rust/kona/crates/protocol/interop/src/traits.rs
+++ b/rust/kona/crates/protocol/interop/src/traits.rs
@@ -1,12 +1,10 @@
 //! Traits for the `kona-interop` crate.
 
-use crate::InteropValidationError;
 use alloc::{boxed::Box, vec::Vec};
 use alloy_consensus::Header;
-use alloy_primitives::{B256, ChainId};
+use alloy_primitives::B256;
 use async_trait::async_trait;
 use core::error::Error;
-use kona_protocol::BlockInfo;
 use op_alloy_consensus::OpReceiptEnvelope;
 
 /// Describes the interface of the interop data provider. This provider is multiplexed over several
@@ -32,44 +30,4 @@ pub trait InteropProvider {
         chain_id: u64,
         block_hash: B256,
     ) -> Result<Vec<OpReceiptEnvelope>, Self::Error>;
-}
-
-/// Trait for validating interop-related timestamps and blocks.
-pub trait InteropValidator: Send + Sync {
-    /// Validates that the provided timestamps and chain IDs are eligible for interop execution.
-    ///
-    /// # Arguments
-    /// * `initiating_chain_id` - The chain ID where the message was initiated
-    /// * `initiating_timestamp` - The timestamp when the message was initiated
-    /// * `executing_chain_id` - The chain ID where the message is being executed
-    /// * `executing_timestamp` - The timestamp when the message is being executed
-    /// * `timeout` - Optional timeout value to add to the execution deadline
-    ///
-    /// # Returns
-    /// * `Ok(())` if the timestamps are valid for interop execution
-    /// * `Err(InteropValidationError)` if validation fails
-    fn validate_interop_timestamps(
-        &self,
-        initiating_chain_id: ChainId,
-        initiating_timestamp: u64,
-        executing_chain_id: ChainId,
-        executing_timestamp: u64,
-        timeout: Option<u64>,
-    ) -> Result<(), InteropValidationError>;
-
-    /// Returns `true` if the timestamp is strictly after the interop activation block.
-    ///
-    /// This function checks whether the provided timestamp is *after* that activation,
-    /// skipping the activation block itself.
-    ///
-    /// Returns `false` if `interop_time` is not configured.
-    fn is_post_interop(&self, chain_id: ChainId, timestamp: u64) -> bool;
-
-    /// Returns `true` if the block is the interop activation block for the specified chain.
-    ///
-    /// An interop activation block is defined as the block that is right after the
-    /// interop activation time.
-    ///
-    /// Returns `false` if `interop_time` is not configured.
-    fn is_interop_activation_block(&self, chain_id: ChainId, block: BlockInfo) -> bool;
 }


### PR DESCRIPTION
The `InteropValidator` trait at `traits.rs` declares `validate_interop_timestamps`, `is_post_interop`, and `is_interop_activation_block` but has zero implementations and zero callers in the kona tree. The companion `InteropValidationError` enum at `errors.rs` is only referenced as the return type of those orphan methods.

Both are re-exported from `lib.rs` but no external Rust crate consumes them either. They are dead speculative design code from before the current `MessageGraph::check_single_dependency` flow took over interop validation in kona-client. Removing them per project YAGNI rules.

No behavioral change. Same crate, same workspace, same exports for everything still in use.