### PR TITLE
op-supernode: filter inactive interop backfill logs

### DIFF
--- a/op-supernode/supernode/activity/interop/algo.go
+++ b/op-supernode/supernode/activity/interop/algo.go
@@ -25,6 +25,10 @@ var (
 	// ErrMessageExpired is returned when an executing message references
 	// an initiating message that has expired (older than the message expiry window).
 	ErrMessageExpired = errors.New("initiating message has expired")
+
+	// ErrInteropMessageInactive is returned when an executing message depends on
+	// a timestamp that is not allowed to contain interop messages.
+	ErrInteropMessageInactive = errors.New("interop message timestamp is inactive")
 )
 
 type blockPerChain = map[eth.ChainID]eth.BlockID
@@ -176,6 +180,19 @@ func (i *Interop) verifyExecutingMessage(executingChain eth.ChainID, executingTi
 	sourceDB, ok := i.logsDBs[execMsg.ChainID]
 	if !ok {
 		return fmt.Errorf("source chain %s not found: %w", execMsg.ChainID, ErrUnknownChain)
+	}
+
+	if ok, err := i.canContainInteropMessages(executingChain, executingTimestamp); err != nil {
+		return err
+	} else if !ok {
+		return fmt.Errorf("executing chain %s timestamp %d cannot contain interop executing messages: %w",
+			executingChain, executingTimestamp, ErrInteropMessageInactive)
+	}
+	if ok, err := i.canContainInteropMessages(execMsg.ChainID, execMsg.Timestamp); err != nil {
+		return err
+	} else if !ok {
+		return fmt.Errorf("initiating chain %s timestamp %d cannot contain interop initiating messages: %w",
+			execMsg.ChainID, execMsg.Timestamp, ErrInteropMessageInactive)
 	}
 
 	// Verify timestamp ordering: initiating message timestamp must be <= executing block timestamp.

--- a/op-supernode/supernode/activity/interop/algo_test.go
+++ b/op-supernode/supernode/activity/interop/algo_test.go
@@ -64,6 +64,32 @@ func runVerifyInteropTest(t *testing.T, tc verifyInteropTestCase) {
 	}
 }
 
+func TestVerifyExecutingMessageRejectsInactiveInitiatingTimestamp(t *testing.T) {
+	t.Parallel()
+
+	sourceChainID := eth.ChainIDFromUInt64(10)
+	executingChainID := eth.ChainIDFromUInt64(20)
+	interop := &Interop{
+		activationTimestamp: 100,
+		messageExpiryWindow: defaultMessageExpiryWindow,
+		log:                 gethlog.New(),
+		logsDBs: map[eth.ChainID]LogsDB{
+			sourceChainID: &algoMockLogsDB{},
+		},
+		chains: map[eth.ChainID]cc.InteropChain{
+			sourceChainID:    newMockChainWithL1(sourceChainID, eth.BlockID{}),
+			executingChainID: newMockChainWithL1(executingChainID, eth.BlockID{}),
+		},
+	}
+
+	err := interop.verifyExecutingMessage(executingChainID, 101, 0, &suptypes.ExecutingMessage{
+		ChainID:   sourceChainID,
+		Timestamp: 99,
+	}, nil)
+
+	require.ErrorIs(t, err, ErrInteropMessageInactive)
+}
+
 // l1HeadsFromMocks builds the snapshot observeRound would produce, by reading optimisticL1
 // from each mock. Mocks tagged with optimisticAtErr are omitted to simulate a missing entry.
 func l1HeadsFromMocks(chains map[eth.ChainID]cc.InteropChain, blocks map[eth.ChainID]eth.BlockID) map[eth.ChainID]eth.BlockID {

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -283,36 +283,6 @@ func (i *Interop) Start(ctx context.Context) error {
 	i.started = true
 	i.mu.Unlock()
 
-	firstVerifiableLog := uint64(0)
-	if lastTS, initialized := i.verifiedDB.LastTimestamp(); initialized {
-		firstVerifiableLog = lastTS + 1
-	} else {
-		for {
-			first, err := i.readyFirstVerifiableTimestamp(i.ctx)
-			if err == nil {
-				i.firstVerifiable = first
-				i.firstVerifiableSet = true
-				firstVerifiableLog = first
-				break
-			}
-			// Permanent SafeDB gap: log once and halt — retrying cannot fix it.
-			if errors.Is(err, cc.ErrHistoryUnavailable) {
-				i.log.Error("interop activity halted: SafeDB history unavailable on this node", "err", err,
-					"remediation", "reseed data dir, advance interop.activation-timestamp past the gap, or rederive from L1")
-				return fmt.Errorf("interop halted due to unavailable history: %w", err)
-			}
-			i.log.Warn("first verifiable timestamp unavailable, retrying (virtual nodes may not be ready yet)", "err", err)
-			select {
-			case <-i.ctx.Done():
-				return fmt.Errorf("first verifiable timestamp interrupted: %w", i.ctx.Err())
-			case <-time.After(errorBackoffPeriod):
-			}
-		}
-	}
-	i.log.Info("interop first verifiable timestamp resolved",
-		"activationTimestamp", i.activationTimestamp,
-		"firstVerifiableTimestamp", firstVerifiableLog)
-
 	if i.logBackfillDepth > 0 {
 		i.log.Info("interop log backfill depth configured", "duration", i.logBackfillDepth.String())
 		for {
@@ -335,6 +305,42 @@ func (i *Interop) Start(ctx context.Context) error {
 	}
 	i.backfillCompleted.Store(true)
 	i.log.Info("log backfill complete", "backfillEndTimestamp", i.backfillEndTimestamp)
+
+	firstVerifiableLog := uint64(0)
+	if i.backfillEndTimestamp != 0 {
+		firstVerifiableLog = i.backfillEndTimestamp + 1
+		if firstVerifiableLog < i.activationTimestamp {
+			firstVerifiableLog = i.activationTimestamp
+		}
+	} else if lastTS, initialized := i.verifiedDB.LastTimestamp(); initialized {
+		firstVerifiableLog = lastTS + 1
+	} else {
+		for {
+			first, err := i.readyFirstVerifiableTimestamp(i.ctx)
+			if err == nil {
+				i.firstVerifiable = first
+				i.firstVerifiableSet = true
+				firstVerifiableLog = first
+				break
+			}
+			// Permanent SafeDB gap must halt normal startup cleanly. Backfill-enabled
+			// startup reaches this path only if backfill had no range to seal.
+			if errors.Is(err, cc.ErrHistoryUnavailable) {
+				i.log.Error("interop activity halted: SafeDB history unavailable on this node", "err", err,
+					"remediation", "reseed data dir, advance interop.activation-timestamp past the gap, or rederive from L1")
+				return fmt.Errorf("interop halted due to unavailable history: %w", err)
+			}
+			i.log.Warn("first verifiable timestamp unavailable, retrying (virtual nodes may not be ready yet)", "err", err)
+			select {
+			case <-i.ctx.Done():
+				return fmt.Errorf("first verifiable timestamp interrupted: %w", i.ctx.Err())
+			case <-time.After(errorBackoffPeriod):
+			}
+		}
+	}
+	i.log.Info("interop first verifiable timestamp resolved",
+		"activationTimestamp", i.activationTimestamp,
+		"firstVerifiableTimestamp", firstVerifiableLog)
 
 	for {
 		select {

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -401,6 +401,50 @@ func TestStartWithoutBackfillUsesFirstVerifiableTimestamp(t *testing.T) {
 	require.ErrorIs(t, <-done, context.Canceled)
 }
 
+func TestStartWithBackfillRunsBeforeSafeDBReadyCheck(t *testing.T) {
+	const activation = uint64(100)
+	const safe = uint64(125)
+
+	h := newInteropTestHarness(t).
+		WithActivation(activation).
+		WithLogBackfillDepth(5*time.Second).
+		WithChain(10, func(m *mockChainContainer) {
+			m.currentL1 = eth.BlockRef{Number: 100, Hash: common.HexToHash("0x1")}
+			m.syncStatusFull = &eth.SyncStatus{
+				SafeL2:      eth.L2BlockRef{Number: safe, Time: safe},
+				LocalSafeL2: eth.L2BlockRef{Number: safe, Time: safe},
+			}
+			m.optimisticAtErr = cc.ErrHistoryUnavailable
+		}).
+		Build()
+
+	done := make(chan error, 1)
+	go func() { done <- h.interop.Start(context.Background()) }()
+
+	var err error
+	select {
+	case err = <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("interop did not halt after post-backfill SafeDB readiness failure")
+	}
+	require.ErrorIs(t, err, cc.ErrHistoryUnavailable)
+	require.Equal(t, int32(1), h.interop.BackfillAttempts())
+	require.Equal(t, safe, h.interop.BackfillEndTimestamp())
+
+	first, err := h.interop.FirstSealedBlock(eth.ChainIDFromUInt64(10))
+	require.NoError(t, err)
+	// The first real backfilled block is 120, and the logs DB records its
+	// virtual parent as the first sealed block.
+	require.Equal(t, uint64(119), first.Number)
+	require.Equal(t, uint64(120), first.Timestamp)
+
+	latest, ok, err := h.interop.LatestSealedBlock(eth.ChainIDFromUInt64(10))
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, safe, latest.Number)
+	require.Equal(t, safe, latest.Timestamp)
+}
+
 // =============================================================================
 // TestStartStop
 // =============================================================================

--- a/op-supernode/supernode/activity/interop/logdb.go
+++ b/op-supernode/supernode/activity/interop/logdb.go
@@ -96,6 +96,30 @@ var (
 	ErrStaleLogsDB = errors.New("logsDB has stale block data from a reorg")
 )
 
+func interopMessageTimestampAllowed(activationTimestamp uint64, blockTime uint64, ts uint64) bool {
+	if ts < activationTimestamp {
+		return false
+	}
+	if activationTimestamp == 0 || blockTime == 0 {
+		return true
+	}
+	if ts < blockTime {
+		return true
+	}
+	// Match supervisor dependency-set semantics: the first block whose timestamp
+	// crosses activation is the activation block, and activation-block logs are
+	// not valid interop initiating/executing messages.
+	return ts-blockTime >= activationTimestamp
+}
+
+func (i *Interop) canContainInteropMessages(chainID eth.ChainID, ts uint64) (bool, error) {
+	chain, ok := i.chains[chainID]
+	if !ok {
+		return false, fmt.Errorf("chain %s not found: %w", chainID, ErrUnknownChain)
+	}
+	return interopMessageTimestampAllowed(i.activationTimestamp, chain.BlockTime(), ts), nil
+}
+
 // persistFrontierLogs persists the exact accepted frontier blocks for a
 // timestamp. Frontier logs are only written here, during DecisionAdvance
 // transition apply — verification itself is read-only.
@@ -134,6 +158,12 @@ func (i *Interop) sealBlockDataIntoLogsDB(chainID eth.ChainID, blockID eth.Block
 	latestBlock, hasBlocks, err := i.verifyCanAddTimestamp(chainID, db, ts, chain.BlockTime(), isBackfill)
 	if err != nil {
 		return err
+	}
+
+	if ok, err := i.canContainInteropMessages(chainID, blockInfo.Time()); err != nil {
+		return err
+	} else if !ok {
+		receipts = nil
 	}
 
 	if hasBlocks {

--- a/op-supernode/supernode/activity/interop/logdb_test.go
+++ b/op-supernode/supernode/activity/interop/logdb_test.go
@@ -1,6 +1,7 @@
 package interop
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	cc "github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/reads"
 	suptypes "github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
 )
@@ -109,6 +111,32 @@ func TestLogsDB_Persistence(t *testing.T) {
 // =============================================================================
 // TestVerifyPreviousTimestampSealed
 // =============================================================================
+
+func TestInteropMessageTimestampAllowed(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		activation uint64
+		blockTime  uint64
+		timestamp  uint64
+		want       bool
+	}{
+		{name: "pre activation rejected", activation: 1000, blockTime: 3, timestamp: 999, want: false},
+		{name: "misaligned activation block rejected", activation: 1000, blockTime: 3, timestamp: 1002, want: false},
+		{name: "post activation block accepted", activation: 1000, blockTime: 3, timestamp: 1005, want: true},
+		{name: "aligned activation block rejected", activation: 1000, blockTime: 2, timestamp: 1000, want: false},
+		{name: "aligned post activation block accepted", activation: 1000, blockTime: 2, timestamp: 1002, want: true},
+		{name: "genesis activation accepted", activation: 0, blockTime: 2, timestamp: 0, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, interopMessageTimestampAllowed(tt.activation, tt.blockTime, tt.timestamp))
+		})
+	}
+}
 
 func TestVerifyPreviousTimestampSealed(t *testing.T) {
 	t.Parallel()
@@ -483,6 +511,38 @@ func TestProcessBlockLogs(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "seal failed")
 	})
+}
+
+func TestSealBlockDataIntoLogsDB_FiltersInactiveInteropMessageTimestamps(t *testing.T) {
+	t.Parallel()
+
+	chainID := eth.ChainIDFromUInt64(10)
+	chain := newMockChainContainer(10)
+	chain.blockTimeOverride = 3
+	db := &mockLogsDB{}
+	interop := &Interop{
+		log:                 gethlog.New(),
+		activationTimestamp: 1000,
+		chains:              map[eth.ChainID]cc.InteropChain{chainID: chain},
+		logsDBs:             map[eth.ChainID]LogsDB{chainID: db},
+		ctx:                 context.Background(),
+		firstVerifiableSet:  true,
+		firstVerifiable:     1003,
+	}
+	blockInfo := &testBlockInfo{
+		hash:       common.Hash{0x02},
+		parentHash: common.Hash{0x01},
+		number:     333,
+		timestamp:  999,
+	}
+	receipts := types.Receipts{
+		&types.Receipt{Logs: []*types.Log{{Address: common.Address{0xAA}, Data: []byte{0x01}}}},
+	}
+
+	err := interop.sealBlockDataIntoLogsDB(chainID, eth.BlockID{Hash: common.Hash{0x02}, Number: 333}, blockInfo, receipts, blockInfo.Time(), true)
+	require.NoError(t, err)
+	require.Zero(t, db.addLogCalls, "pre-activation anchor blocks should be sealed without indexing logs")
+	require.Len(t, db.sealBlockCalls, 2)
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

This is a small follow-up branch on top of #20568 to make the activation-boundary concern concrete. It keeps pre-activation / activation-boundary blocks available as sealed continuity anchors, but prevents their receipts from populating interop message logs. It also rejects executing-message verification when either side references a timestamp that cannot contain interop messages.

## Validation

- go test ./op-supernode/supernode/activity/interop
- go test ./op-supernode/supernode/...

## Notes

Draft for discussion. The key semantic choice is matching supervisor dependency-set behavior: pre-interop and activation-block timestamps are not valid initiating/executing message timestamps.