### PR TITLE
docs(contracts-bedrock): note gas accounting quirk in test style guide

### DIFF
--- a/packages/contracts-bedrock/book/src/contributing/style-guide.md
+++ b/packages/contracts-bedrock/book/src/contributing/style-guide.md
@@ -22,6 +22,7 @@
     - [Source Code](#source-code)
     - [Tests](#tests)
       - [Expect Revert with Low Level Calls](#expect-revert-with-low-level-calls)
+      - [Gas Accounting in Tests](#gas-accounting-in-tests)
       - [Organizing Principles](#organizing-principles)
       - [Test function naming convention](#test-function-naming-convention)
         - [Detailed Naming Rules](#detailed-naming-rules)
@@ -363,6 +364,12 @@ There is a non-intuitive behavior in foundry tests, which is documented [here](h
 When testing for a revert on a low-level call, please use the `revertsAsExpected` pattern suggested there.
 
 _Note: This is a work in progress, not all test files are compliant with these guidelines._
+
+#### Gas Accounting in Tests
+
+Foundry's default test runner does not deduct intrinsic gas (21,000 base, plus 16 per non-zero byte and 4 per zero byte of calldata) before forwarding to the called contract. Real Ethereum clients do. Tests that pass `gasLimit` straight through to a call therefore have *more* gas to spend than production would, and code that fits its budget under test can run out of gas onchain. This caused the upgrade-path bug fixed in [#20075](https://github.com/ethereum-optimism/optimism/pull/20075).
+
+Two correct patterns: deduct intrinsic gas manually before the call (`gas: _txn.gasLimit - intrinsicGas_`), or run the test under `forge-config: default.isolate = true`, which makes Foundry execute each top-level call as a separate transaction with proper gas accounting. Use the manual path for tests that drive many top-level calls in one harness and need to control gas precisely; use isolate mode for end-to-end tests that should mirror real client semantics.
 
 #### Organizing Principles
 


### PR DESCRIPTION
## Summary

Adds a short subsection to the contracts-bedrock style guide on Foundry's intrinsic gas behavior in tests, sitting next to the existing "Expect Revert with Low Level Calls" entry.

## Why

PR #20075 fixed a bug where the upgrade path's gas budget worked under test but ran out of gas onchain. Root cause: Foundry's default runner does not deduct intrinsic gas before forwarding to the called contract, so tests had more gas to spend than production. The fix added two patterns (manual deduction + `--isolate`); this doc points future authors at them so the same bug doesn't ship again.

Companion to the L2CM retro action item "Better documentation around edge cases" (sub-issue #20388).

## Notes

- Manually updated the doctoc TOC at the top of the file. If the project relies on `doctoc` regeneration, that should still produce the same result.