### PR TITLE
fix: update each system config to have the same weth on migrate

### DIFF
--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerMigrationValidator.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerMigrationValidator.sol
@@ -415,6 +415,7 @@ contract OPContractsManagerMigrationValidator {
         address sharedASR = address(firstPortal.anchorStateRegistry());
         IETHLockbox sharedLockbox = firstPortal.ethLockbox();
         IDisputeGameFactory sharedDGF = IDisputeGameFactory(_chainSystemConfigs[0].disputeGameFactory());
+        address sharedWETH = _chainSystemConfigs[0].delayedWETH();
 
         // Guard against missing lockbox — would revert on authorizedPortals call.
         if (address(sharedLockbox) == address(0)) {
@@ -481,6 +482,10 @@ contract OPContractsManagerMigrationValidator {
                 _chainSystemConfigs[i].isFeatureEnabled(Features.ETH_LOCKBOX),
                 string.concat("MIG-CHAIN-", idx, "-110"),
                 _errors
+            );
+
+            _errors = internalRequire(
+                _chainSystemConfigs[i].delayedWETH() == sharedWETH, string.concat("MIG-CHAIN-", idx, "-120"), _errors
             );
         }
 

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerMigrator.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerMigrator.sol
@@ -223,6 +223,7 @@ contract OPContractsManagerMigrator is OPContractsManagerUtilsCaller {
 
             // Migrate each portal to the new ETHLockbox and AnchorStateRegistry.
             for (uint256 i = 0; i < _input.chainSystemConfigs.length; i++) {
+                _updateSystemConfigDelayedWETH(_input.chainSystemConfigs[i], delayedWETH, impls.systemConfigImpl);
                 _migratePortal(_input.chainSystemConfigs[i], ethLockbox, anchorStateRegistry);
             }
         }
@@ -244,6 +245,61 @@ contract OPContractsManagerMigrator is OPContractsManagerUtilsCaller {
             );
             disputeGameFactory.setInitBond(_input.disputeGameConfigs[i].gameType, _input.disputeGameConfigs[i].initBond);
         }
+    }
+
+    /// @notice Updates a chain's SystemConfig to point at the shared DelayedWETH while preserving
+    ///         all other per-chain configuration values.
+    /// @param _systemConfig The system config for the chain being migrated.
+    /// @param _delayedWETH The shared DelayedWETH to store in the SystemConfig.
+    /// @param _systemConfigImpl The SystemConfig implementation to reinitialize with.
+    function _updateSystemConfigDelayedWETH(
+        ISystemConfig _systemConfig,
+        IDelayedWETH _delayedWETH,
+        address _systemConfigImpl
+    )
+        internal
+    {
+        ISystemConfig.Addresses memory addrs = _systemConfig.getAddresses();
+        addrs.delayedWETH = address(_delayedWETH);
+        addrs.opcm = _systemConfig.lastUsedOPCM();
+
+        _upgrade(
+            _systemConfig.proxyAdmin(),
+            address(_systemConfig),
+            _systemConfigImpl,
+            _makeSystemConfigInitArgs(_systemConfig, addrs)
+        );
+    }
+
+    /// @notice Builds SystemConfig initialize calldata from the chain's current values.
+    /// @dev Kept separate from _updateSystemConfigDelayedWETH to avoid stack-too-deep errors.
+    /// @param _systemConfig The system config to read existing values from.
+    /// @param _addrs The L1 contract address set to write.
+    /// @return Calldata for SystemConfig.initialize.
+    function _makeSystemConfigInitArgs(
+        ISystemConfig _systemConfig,
+        ISystemConfig.Addresses memory _addrs
+    )
+        internal
+        view
+        returns (bytes memory)
+    {
+        return abi.encodeCall(
+            ISystemConfig.initialize,
+            (
+                _systemConfig.owner(),
+                _systemConfig.basefeeScalar(),
+                _systemConfig.blobbasefeeScalar(),
+                _systemConfig.batcherHash(),
+                _systemConfig.gasLimit(),
+                _systemConfig.unsafeBlockSigner(),
+                _systemConfig.resourceConfig(),
+                _systemConfig.batchInbox(),
+                _addrs,
+                _systemConfig.l2ChainId(),
+                _systemConfig.superchainConfig()
+            )
+        );
     }
 
     /// @notice Migrates a single portal to the new ETHLockbox and AnchorStateRegistry.

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerMigrationValidator.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerMigrationValidator.t.sol
@@ -705,6 +705,16 @@ contract OPContractsManagerMigrationValidator_PerChain_Test is OPContractsManage
         );
         assertEq("MIG-CHAIN-0-110", _validateMigration(true));
     }
+
+    /// @notice MIG-CHAIN-1-120: Second chain's SystemConfig delayedWETH doesn't match shared WETH.
+    function test_validate_chain1120DelayedWethMismatch_succeeds() public {
+        vm.mockCall(
+            address(chainContracts2.systemConfig),
+            abi.encodeCall(ISystemConfig.delayedWETH, ()),
+            abi.encode(address(0xbadDE1a4ed))
+        );
+        assertEq("MIG-CHAIN-1-120", _validateMigration(true));
+    }
 }
 
 /// @title OPContractsManagerMigrationValidator_SharedDGF_Test

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
@@ -14,6 +14,7 @@ import { ForgeArtifacts, StorageSlot } from "scripts/libraries/ForgeArtifacts.so
 import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 import { Claim, Duration, Hash } from "src/dispute/lib/LibUDT.sol";
 import { GameType, GameTypes, Proposal } from "src/dispute/lib/Types.sol";
+import { LibGameArgs } from "src/dispute/lib/LibGameArgs.sol";
 import { Constants } from "src/libraries/Constants.sol";
 import { DevFeatures } from "src/libraries/DevFeatures.sol";
 import { Features } from "src/libraries/Features.sol";
@@ -2320,6 +2321,12 @@ contract OPContractsManagerV2_Migrate_Test is OPContractsManagerV2_TestInit {
             0.08 ether,
             "SUPER_PERMISSIONED_CANNON init bond mismatch"
         );
+        {
+            IDisputeGameFactory sharedDGF = IDisputeGameFactory(asr.disputeGameFactory());
+            address sharedWETH = LibGameArgs.decode(sharedDGF.gameArgs(GameTypes.SUPER_PERMISSIONED_CANNON)).weth;
+            assertEq(chainContracts1.systemConfig.delayedWETH(), sharedWETH, "Chain 1 delayedWETH mismatch");
+            assertEq(chainContracts2.systemConfig.delayedWETH(), sharedWETH, "Chain 2 delayedWETH mismatch");
+        }
 
         // Check that portal liquidity was migrated directly to the new shared lockbox.
         assertEq(address(portal1).balance, 0, "Portal 1 should have 0 balance after migration");


### PR DESCRIPTION
Updates OPCM migration so each migrated SystemConfig is reinitialized with the shared DelayedWETH while preserving its per-chain configuration values. 

Adds migration validation that all chain SystemConfigs agree on the shared delayedWETH after migration. Extends OPCM migration tests to assert the shared dispute game WETH matches both migrated SystemConfigs, plus a validator regression for MIG-CHAIN-*-120.

Validation: 
`DEV_FEATURE__OPTIMISM_PORTAL_INTEROP=true forge test --match-contract 'OPContractsManagerV2_Migrate_Test|OPContractsManagerMigrationValidator_PerChain_Test'`.

fixes https://github.com/ethereum-optimism/optimism/issues/20511 