### PR TITLE
[experiment] contracts-bedrock: enable foundry isolate=true by default

### DIFF
--- a/packages/contracts-bedrock/foundry.toml
+++ b/packages/contracts-bedrock/foundry.toml
@@ -85,6 +85,10 @@ ffi = true
 # you increase the gas limit above this value it must be a string.
 gas_limit = 9223372036854775807
 
+# Experiment (L2CM retro): make Foundry deduct intrinsic gas and run each
+# top-level call as a separate EVM transaction, mirroring real client semantics.
+isolate = true
+
 [fuzz]
 runs = 64
 


### PR DESCRIPTION
## Summary

**Experimental — not for merge.** Flips `isolate = true` on the default Foundry profile in `packages/contracts-bedrock/foundry.toml` to surface what fails when every top-level call runs as its own EVM transaction (with proper intrinsic gas deduction).

This is the second half of L2CM retro Group 2 — see #20388.

## What `isolate = true` does

Without it (Foundry default): a test runs as one big EVM context. Top-level calls within the test do not deduct intrinsic gas before forwarding, so the gas the called contract receives is greater than what a real client would forward. That's the class of bug fixed in #20075.

With it: each top-level call is executed as a separate EVM transaction. Foundry deducts intrinsic gas (21,000 + 16/4 per byte of calldata) before the call, mirroring how a real client behaves. Side effects:

- Tests that drive many top-level calls in one harness function now have less gas per call.
- State changes between top-level calls behave more like inter-tx state changes (relevant for transient storage, gas refunds, etc.).
- Some gas-measurement tests (benchmarks) will produce different numbers.
- Tests that depend implicitly on "the whole test is one tx" semantics may break.

## Goal

Run CI and see what fails. The output here is information, not a merge — once we know what breaks and how much, we can decide whether a global flip is worth the migration cost or whether the per-test `forge-config: default.isolate = true` annotation is the right granularity.

## References

- #20075 — trigger incident
- #20388 — Group 2 sub-issue
- #20570 — companion docs PR (style guide subsection on gas accounting in tests)