### PR TITLE
fix(op-devstack): add WithoutHonestProposer preset option for challenger tests

### DIFF
--- a/op-acceptance-tests/tests/interop/proofs/challenger_test.go
+++ b/op-acceptance-tests/tests/interop/proofs/challenger_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestChallengerPlaysGame(gt *testing.T) {
 	t := devtest.ParallelT(gt)
-	sys := presets.NewSimpleInteropSupernodeProofs(t)
+	sys := presets.NewSimpleInteropSupernodeProofs(t, presets.WithoutHonestProposer())
 	dsl.CheckAll(t,
 		sys.L2CLA.AdvancedFn(types.CrossSafe, 1, 30),
 		sys.L2CLB.AdvancedFn(types.CrossSafe, 1, 30),
@@ -38,7 +38,7 @@ func TestChallengerPlaysGame(gt *testing.T) {
 
 func TestChallengerRespondsToMultipleInvalidClaims(gt *testing.T) {
 	t := devtest.ParallelT(gt)
-	sys := presets.NewSimpleInteropSupernodeProofs(t)
+	sys := presets.NewSimpleInteropSupernodeProofs(t, presets.WithoutHonestProposer())
 	dsl.CheckAll(t,
 		sys.L2CLA.AdvancedFn(types.CrossSafe, 1, 30),
 		sys.L2CLB.AdvancedFn(types.CrossSafe, 1, 30),
@@ -61,7 +61,7 @@ func TestChallengerRespondsToMultipleInvalidClaims(gt *testing.T) {
 
 func TestChallengerRespondsToMultipleInvalidClaimsEOA(gt *testing.T) {
 	t := devtest.ParallelT(gt)
-	sys := presets.NewSimpleInteropSupernodeProofs(t)
+	sys := presets.NewSimpleInteropSupernodeProofs(t, presets.WithoutHonestProposer())
 	dsl.CheckAll(t,
 		sys.L2CLA.AdvancedFn(types.CrossSafe, 1, 30),
 		sys.L2CLB.AdvancedFn(types.CrossSafe, 1, 30),

--- a/op-devstack/presets/option_validation.go
+++ b/op-devstack/presets/option_validation.go
@@ -29,6 +29,7 @@ const (
 	optionKindInteropLogBackfill
 	optionKindInteropFilter
 	optionKindPreGenesisSuperGame
+	optionKindSkipHonestProposer
 )
 
 const allOptionKinds = optionKindDeployer |
@@ -48,7 +49,8 @@ const allOptionKinds = optionKindDeployer |
 	optionKindMessageExpiryWindow |
 	optionKindInteropLogBackfill |
 	optionKindInteropFilter |
-	optionKindPreGenesisSuperGame
+	optionKindPreGenesisSuperGame |
+	optionKindSkipHonestProposer
 
 var optionKindLabels = []struct {
 	kind  optionKinds
@@ -72,6 +74,7 @@ var optionKindLabels = []struct {
 	{kind: optionKindInteropLogBackfill, label: "interop log backfill depth"},
 	{kind: optionKindInteropFilter, label: "interop filter"},
 	{kind: optionKindPreGenesisSuperGame, label: "pre-genesis super game"},
+	{kind: optionKindSkipHonestProposer, label: "skip honest proposer"},
 }
 
 func (k optionKinds) String() string {
@@ -152,13 +155,15 @@ const simpleInteropSuperProofsPresetSupportedOptionKinds = optionKindDeployer |
 	optionKindL1EL |
 	optionKindTimeTravel |
 	optionKindMaxSequencingWindow |
-	optionKindRequireInteropNotAtGen
+	optionKindRequireInteropNotAtGen |
+	optionKindSkipHonestProposer
 
 const supernodeProofsPresetSupportedOptionKinds = optionKindDeployer |
 	optionKindBatcher |
 	optionKindL1EL |
 	optionKindTimeTravel |
-	optionKindMessageExpiryWindow
+	optionKindMessageExpiryWindow |
+	optionKindSkipHonestProposer
 
 const twoL2SupernodeProofsPresetSupportedOptionKinds = supernodeProofsPresetSupportedOptionKinds |
 	optionKindPreGenesisSuperGame

--- a/op-devstack/presets/options.go
+++ b/op-devstack/presets/options.go
@@ -305,6 +305,16 @@ func WithInteropLogBackfillDepth(d time.Duration) Option {
 	}
 }
 
+// WithoutHonestProposer disables the in-process op-proposer in proofs presets.
+func WithoutHonestProposer() Option {
+	return option{
+		kinds: optionKindSkipHonestProposer,
+		applyFn: func(cfg *sysgo.PresetConfig) {
+			cfg.SkipHonestProposer = true
+		},
+	}
+}
+
 // WithPreGenesisSuperGame seeds one invalid super dispute game before the
 // rollup start block so tests can exercise supernode/challenger behaviour
 // when a game's L1 head predates rollup genesis. The claimed outputs follow

--- a/op-devstack/presets/options.go
+++ b/op-devstack/presets/options.go
@@ -305,7 +305,7 @@ func WithInteropLogBackfillDepth(d time.Duration) Option {
 	}
 }
 
-// WithoutHonestProposer disables the in-process op-proposer in proofs presets.
+// WithoutHonestProposer skips starting op-proposer.
 func WithoutHonestProposer() Option {
 	return option{
 		kinds: optionKindSkipHonestProposer,

--- a/op-devstack/sysgo/multichain_proofs.go
+++ b/op-devstack/sysgo/multichain_proofs.go
@@ -84,17 +84,19 @@ func attachSupervisorSuperProofs(t devtest.T, runtime *MultiChainRuntime, cfg Pr
 	)
 	runtime.L2ChallengerConfig = challenger.Config()
 
-	_ = startSuperProposer(
-		t,
-		runtime.Keys,
-		"main",
-		proofChain.Network.ChainID(),
-		runtime.L1EL,
-		proofChain.Network,
-		runtime.PrimarySupervisor.UserRPC(),
-		"",
-		cfg.ProposerOptions...,
-	)
+	if !cfg.SkipHonestProposer {
+		_ = startSuperProposer(
+			t,
+			runtime.Keys,
+			"main",
+			proofChain.Network.ChainID(),
+			runtime.L1EL,
+			proofChain.Network,
+			runtime.PrimarySupervisor.UserRPC(),
+			"",
+			cfg.ProposerOptions...,
+		)
+	}
 
 	return runtime
 }
@@ -178,23 +180,25 @@ func attachSuperChallengerAndProposer(
 	)
 	runtime.L2ChallengerConfig = challenger.Config()
 
-	proposerOpts := append([]ProposerOption{
-		func(_ ComponentTarget, c *ps.CLIConfig) {
-			c.DisputeGameType = uint32(proposerGameType)
-		},
-	}, cfg.ProposerOptions...)
+	if !cfg.SkipHonestProposer {
+		proposerOpts := append([]ProposerOption{
+			func(_ ComponentTarget, c *ps.CLIConfig) {
+				c.DisputeGameType = uint32(proposerGameType)
+			},
+		}, cfg.ProposerOptions...)
 
-	_ = startSuperProposer(
-		t,
-		runtime.Keys,
-		"main",
-		proofChain.Network.ChainID(),
-		runtime.L1EL,
-		proofChain.Network,
-		"",
-		runtime.Supernode.UserRPC(),
-		proposerOpts...,
-	)
+		_ = startSuperProposer(
+			t,
+			runtime.Keys,
+			"main",
+			proofChain.Network.ChainID(),
+			runtime.L1EL,
+			proofChain.Network,
+			"",
+			runtime.Supernode.UserRPC(),
+			proposerOpts...,
+		)
+	}
 }
 
 func NewSimpleInteropSuperProofsRuntimeWithConfig(t devtest.T, cfg PresetConfig) *MultiChainRuntime {

--- a/op-devstack/sysgo/preset_config.go
+++ b/op-devstack/sysgo/preset_config.go
@@ -34,6 +34,8 @@ type PresetConfig struct {
 	// initiating-message logs backward from the tip by this duration at startup.
 	InteropLogBackfillDepth time.Duration
 	PreGenesisSuperGame     *PreGenesisSuperGameConfig
+	// SkipHonestProposer skips starting the in-process op-proposer in proofs presets.
+	SkipHonestProposer bool
 }
 
 func NewPresetConfig() PresetConfig {

--- a/op-devstack/sysgo/preset_config.go
+++ b/op-devstack/sysgo/preset_config.go
@@ -34,7 +34,7 @@ type PresetConfig struct {
 	// initiating-message logs backward from the tip by this duration at startup.
 	InteropLogBackfillDepth time.Duration
 	PreGenesisSuperGame     *PreGenesisSuperGameConfig
-	// SkipHonestProposer skips starting the in-process op-proposer in proofs presets.
+	// SkipHonestProposer skips starting op-proposer.
 	SkipHonestProposer bool
 }
 


### PR DESCRIPTION
Fixes ethereum-optimism/optimism#20574.

The DSL helper `StartSuperCannonKonaGame` computes the synthetic honest root claim as `keccak256(extraData)`, which is byte-for-byte identical to the canonical super root the in-process op-proposer submits at the same safe timestamp (`op-service/eth/super_root.go:33`). Since the factory UUID is `keccak256(gameType, rootClaim, extraData)`, when the test's `safeTimestamp()` lands on a value the proposer has already used, both compute the same UUID and one of the `Create` calls reverts with `GameAlreadyExists`. It's intermittent because it only triggers when the L2 safe head hasn't advanced between the proposer's most recent proposal and the test's read.

Tests that don't actually exercise proposer behaviour shouldn't run an honest proposer at all. Adds `presets.WithoutHonestProposer()` so they can opt out cleanly. The option threads `SkipHonestProposer` through `PresetConfig` into the proofs setup paths in `op-devstack/sysgo/multichain_proofs.go`; when set, `startSuperProposer` is skipped.

Applied to the three challenger tests in `op-acceptance-tests/tests/interop/proofs/challenger_test.go` that don't depend on the proposer:

- `TestChallengerRespondsToMultipleInvalidClaims` — the flaky one
- `TestChallengerRespondsToMultipleInvalidClaimsEOA` — same race
- `TestChallengerPlaysGame` — already collision-immune via `WithSuperRootFrom`, opted out for consistency

`TestProposer` and `TestSuperRootWithdrawal` continue to run with the proposer because they exercise it. Tests in `proofs/serial/` and `proofs/fpp/` don't create games on chain, so they aren't exposed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)