### PR TITLE
fix(kona-interop): init-chain activation gate

### DIFF
--- a/rust/kona/crates/protocol/interop/src/graph.rs
+++ b/rust/kona/crates/protocol/interop/src/graph.rs
@@ -839,9 +839,7 @@ mod test {
         // Init chain (A): `interop_time = None`. Simulates a chain whose rollup config
         // (bundled registry stale, oracle-supplied, or genuinely pre-interop but mis-included
         // in the dep set) has no interop activation.
-        superchain
-            .chain(CHAIN_A_ID)
-            .modify_rollup_cfg(|cfg| cfg.hardforks.interop_time = None);
+        superchain.chain(CHAIN_A_ID).modify_rollup_cfg(|cfg| cfg.hardforks.interop_time = None);
         // Sanity-check the precondition; otherwise we'd be testing the wrong thing.
         assert!(
             superchain.chain(CHAIN_A_ID).rollup_config.hardforks.interop_time.is_none(),

--- a/rust/kona/crates/protocol/interop/src/graph.rs
+++ b/rust/kona/crates/protocol/interop/src/graph.rs
@@ -825,15 +825,17 @@ mod test {
 
     #[tokio::test]
     async fn test_derive_and_resolve_graph_initiating_chain_interop_time_none_rejected() {
-        // The init-chain timestamp gate at `check_single_dependency` uses
-        // `unwrap_or_default()` on `interop_time`. When the init chain's `interop_time`
-        // is `None`, the gate degrades to `init_ts < 0 + block_time`, which is false for
-        // any real timestamp — so arbitrary logs on a chain without interop activation
-        // are accepted as valid initiating messages.
-        //
-        // Spec: a chain with no interop activation cannot produce valid init messages.
+        // A chain with no interop activation cannot produce valid init messages.
         // Op-supervisor's `IsInterop(ts) = InteropTime != nil && ts >= *InteropTime`
-        // returns false in this case, rejecting the message.
+        // rejects in this case, and `check_single_dependency` must do the same via
+        // `is_interop_active`.
+        //
+        // Attack: an attacker plants an arbitrary log on a chain whose kona-visible
+        // rollup config has `interop_time = None` (stale registry, oracle-supplied
+        // config, or a misconfigured dep set), then references it from an executing
+        // message on another chain. Without a `None`-rejecting gate, kona accepts the
+        // forged init message and downstream consumers (e.g. `L2toL2CrossDomainMessenger`)
+        // deliver the call.
         let mut superchain = default_superchain();
 
         // Init chain (A): `interop_time = None`. Simulates a chain whose rollup config

--- a/rust/kona/crates/protocol/interop/src/graph.rs
+++ b/rust/kona/crates/protocol/interop/src/graph.rs
@@ -824,6 +824,68 @@ mod test {
     }
 
     #[tokio::test]
+    async fn test_derive_and_resolve_graph_initiating_chain_interop_time_none_rejected() {
+        // The init-chain timestamp gate at `check_single_dependency` uses
+        // `unwrap_or_default()` on `interop_time`. When the init chain's `interop_time`
+        // is `None`, the gate degrades to `init_ts < 0 + block_time`, which is false for
+        // any real timestamp — so arbitrary logs on a chain without interop activation
+        // are accepted as valid initiating messages.
+        //
+        // Spec: a chain with no interop activation cannot produce valid init messages.
+        // Op-supervisor's `IsInterop(ts) = InteropTime != nil && ts >= *InteropTime`
+        // returns false in this case, rejecting the message.
+        let mut superchain = default_superchain();
+
+        // Init chain (A): `interop_time = None`. Simulates a chain whose rollup config
+        // (bundled registry stale, oracle-supplied, or genuinely pre-interop but mis-included
+        // in the dep set) has no interop activation.
+        superchain
+            .chain(CHAIN_A_ID)
+            .modify_rollup_cfg(|cfg| cfg.hardforks.interop_time = None);
+        // Sanity-check the precondition; otherwise we'd be testing the wrong thing.
+        assert!(
+            superchain.chain(CHAIN_A_ID).rollup_config.hardforks.interop_time.is_none(),
+            "test precondition: init chain must have interop_time = None"
+        );
+
+        let chain_a_time = superchain.chain(CHAIN_A_ID).header.timestamp;
+
+        // Attacker plants an arbitrary log on A and references it from an executing
+        // message on B. With the broken gate, kona accepts. With a spec-correct gate,
+        // kona rejects because A has no interop activation configured.
+        superchain.chain(CHAIN_A_ID).add_initiating_message(MOCK_MESSAGE.into());
+        superchain.chain(CHAIN_B_ID).add_executing_message(
+            ExecutingMessageBuilder::default()
+                .with_message_hash(keccak256(MOCK_MESSAGE))
+                .with_origin_chain_id(CHAIN_A_ID)
+                .with_origin_timestamp(chain_a_time),
+        );
+
+        let (headers, cfgs, provider) = superchain.build();
+
+        let graph = MessageGraph::derive(
+            &headers,
+            &provider,
+            &cfgs,
+            default_dep_set(),
+            MESSAGE_EXPIRY_WINDOW,
+        )
+        .await
+        .unwrap();
+        let MessageGraphError::InvalidMessages(invalid_messages) =
+            graph.resolve().await.unwrap_err()
+        else {
+            panic!("Expected invalid messages — forged init message must be rejected")
+        };
+
+        assert!(
+            invalid_messages.contains_key(&CHAIN_B_ID),
+            "exec chain B's message referencing a non-interop init chain must be invalidated, got {:?}",
+            invalid_messages
+        );
+    }
+
+    #[tokio::test]
     async fn test_derive_and_resolve_graph_executing_before_interop() {
         let mut superchain = default_superchain();
 

--- a/rust/kona/crates/protocol/interop/src/graph.rs
+++ b/rust/kona/crates/protocol/interop/src/graph.rs
@@ -98,8 +98,8 @@ fn detect_cycles(messages: &[EnrichedExecutingMessage], timestamp: u64) -> Vec<u
         //   2. The EM's referenced initiating message must also be at `timestamp`.
         // An EM that passes (1) but fails (2) references historical state and must not be
         // admitted into the same-timestamp cycle graph.
-        if msg.executing_timestamp != timestamp ||
-            msg.inner.identifier.timestamp.saturating_to::<u64>() != timestamp
+        if msg.executing_timestamp != timestamp
+            || msg.inner.identifier.timestamp.saturating_to::<u64>() != timestamp
         {
             continue;
         }
@@ -143,8 +143,8 @@ fn detect_cycles(messages: &[EnrichedExecutingMessage], timestamp: u64) -> Vec<u
             // Cross-chain: depends on executingMessageBefore(targetChain, targetLogIdx).
             let target_chain = nodes[node_idx].target_chain_id;
             let target_log_idx = nodes[node_idx].target_log_index;
-            if let Some(target_indices) = chain_nodes.get(&target_chain) &&
-                let Some(dep_idx) =
+            if let Some(target_indices) = chain_nodes.get(&target_chain)
+                && let Some(dep_idx) =
                     executing_message_before(&nodes, target_indices, target_log_idx)
             {
                 depends_on[node_idx].push(dep_idx);
@@ -366,8 +366,8 @@ where
 
         // Activation invariant: Interop must be active on the executing chain AND the executing
         // block must not be the activation block.
-        if !exec_rollup_config.is_interop_active(message.executing_timestamp) ||
-            exec_rollup_config.is_first_interop_block(message.executing_timestamp)
+        if !exec_rollup_config.is_interop_active(message.executing_timestamp)
+            || exec_rollup_config.is_first_interop_block(message.executing_timestamp)
         {
             return Err(MessageGraphError::ExecutedTooEarly {
                 activation_time: exec_rollup_config.hardforks.interop_time.unwrap_or_default(),
@@ -390,8 +390,8 @@ where
                 max: message.executing_timestamp,
                 actual: initiating_timestamp,
             });
-        } else if initiating_timestamp <
-            rollup_config.hardforks.interop_time.unwrap_or_default() + rollup_config.block_time
+        } else if initiating_timestamp
+            < rollup_config.hardforks.interop_time.unwrap_or_default() + rollup_config.block_time
         {
             return Err(MessageGraphError::InitiatedTooEarly {
                 activation_time: rollup_config.hardforks.interop_time.unwrap_or_default(),
@@ -402,8 +402,8 @@ where
         // Message expiry invariant: The timestamp of the initiating message must be no more than
         // `MESSAGE_EXPIRY_WINDOW` seconds in the past, relative to the timestamp of the executing
         // message.
-        if initiating_timestamp <
-            message.executing_timestamp.saturating_sub(self.message_expiry_window)
+        if initiating_timestamp
+            < message.executing_timestamp.saturating_sub(self.message_expiry_window)
         {
             return Err(MessageGraphError::MessageExpired {
                 initiating_timestamp,
@@ -837,8 +837,8 @@ mod test {
         let mut superchain = default_superchain();
 
         // Init chain (A): `interop_time = None`. Simulates a chain whose rollup config
-        // (bundled registry stale, oracle-supplied, or genuinely pre-interop but mis-included
-        // in the dep set) has no interop activation.
+        // (bundled registry stale, oracle-supplied, or genuinely pre-interop but
+        // incorrectly included in the dep set) has no interop activation.
         superchain.chain(CHAIN_A_ID).modify_rollup_cfg(|cfg| cfg.hardforks.interop_time = None);
         // Sanity-check the precondition; otherwise we'd be testing the wrong thing.
         assert!(

--- a/rust/kona/crates/protocol/interop/src/graph.rs
+++ b/rust/kona/crates/protocol/interop/src/graph.rs
@@ -98,8 +98,8 @@ fn detect_cycles(messages: &[EnrichedExecutingMessage], timestamp: u64) -> Vec<u
         //   2. The EM's referenced initiating message must also be at `timestamp`.
         // An EM that passes (1) but fails (2) references historical state and must not be
         // admitted into the same-timestamp cycle graph.
-        if msg.executing_timestamp != timestamp
-            || msg.inner.identifier.timestamp.saturating_to::<u64>() != timestamp
+        if msg.executing_timestamp != timestamp ||
+            msg.inner.identifier.timestamp.saturating_to::<u64>() != timestamp
         {
             continue;
         }
@@ -143,8 +143,8 @@ fn detect_cycles(messages: &[EnrichedExecutingMessage], timestamp: u64) -> Vec<u
             // Cross-chain: depends on executingMessageBefore(targetChain, targetLogIdx).
             let target_chain = nodes[node_idx].target_chain_id;
             let target_log_idx = nodes[node_idx].target_log_index;
-            if let Some(target_indices) = chain_nodes.get(&target_chain)
-                && let Some(dep_idx) =
+            if let Some(target_indices) = chain_nodes.get(&target_chain) &&
+                let Some(dep_idx) =
                     executing_message_before(&nodes, target_indices, target_log_idx)
             {
                 depends_on[node_idx].push(dep_idx);
@@ -366,8 +366,8 @@ where
 
         // Activation invariant: Interop must be active on the executing chain AND the executing
         // block must not be the activation block.
-        if !exec_rollup_config.is_interop_active(message.executing_timestamp)
-            || exec_rollup_config.is_first_interop_block(message.executing_timestamp)
+        if !exec_rollup_config.is_interop_active(message.executing_timestamp) ||
+            exec_rollup_config.is_first_interop_block(message.executing_timestamp)
         {
             return Err(MessageGraphError::ExecutedTooEarly {
                 activation_time: exec_rollup_config.hardforks.interop_time.unwrap_or_default(),
@@ -390,8 +390,8 @@ where
                 max: message.executing_timestamp,
                 actual: initiating_timestamp,
             });
-        } else if initiating_timestamp
-            < rollup_config.hardforks.interop_time.unwrap_or_default() + rollup_config.block_time
+        } else if initiating_timestamp <
+            rollup_config.hardforks.interop_time.unwrap_or_default() + rollup_config.block_time
         {
             return Err(MessageGraphError::InitiatedTooEarly {
                 activation_time: rollup_config.hardforks.interop_time.unwrap_or_default(),
@@ -402,8 +402,8 @@ where
         // Message expiry invariant: The timestamp of the initiating message must be no more than
         // `MESSAGE_EXPIRY_WINDOW` seconds in the past, relative to the timestamp of the executing
         // message.
-        if initiating_timestamp
-            < message.executing_timestamp.saturating_sub(self.message_expiry_window)
+        if initiating_timestamp <
+            message.executing_timestamp.saturating_sub(self.message_expiry_window)
         {
             return Err(MessageGraphError::MessageExpired {
                 initiating_timestamp,

--- a/rust/kona/crates/protocol/interop/src/graph.rs
+++ b/rust/kona/crates/protocol/interop/src/graph.rs
@@ -390,8 +390,8 @@ where
                 max: message.executing_timestamp,
                 actual: initiating_timestamp,
             });
-        } else if initiating_timestamp <
-            rollup_config.hardforks.interop_time.unwrap_or_default() + rollup_config.block_time
+        } else if !rollup_config.is_interop_active(initiating_timestamp) ||
+            rollup_config.is_first_interop_block(initiating_timestamp)
         {
             return Err(MessageGraphError::InitiatedTooEarly {
                 activation_time: rollup_config.hardforks.interop_time.unwrap_or_default(),


### PR DESCRIPTION
## Summary

`MessageGraph::check_single_dependency` used `unwrap_or_default()` on the initiating chain's `interop_time`, so when the chain had `interop_time = None`, the activation gate degraded to `t < 0 + block_time`, which is false for any real timestamp. Arbitrary logs on such chains were accepted as valid initiating messages.

The executing-chain check on the same path uses `is_interop_active`, which correctly rejects `None`. This PR applies the same pattern to the init-chain check.

## Impact

After the gate, kona only verifies log existence + origin + payload hash. With the gate disabled, any log on a dep-set chain whose kona-visible rollup config has `interop_time = None` becomes a forgeable initiating message, spoofable to `L2toL2CrossDomainMessenger` targets that auth by `(sourceChain, xDomainSender)`.

## Fix

```rust
} else if !rollup_config.is_interop_active(initiating_timestamp) ||
    rollup_config.is_first_interop_block(initiating_timestamp)
{
    return Err(MessageGraphError::InitiatedTooEarly { ... });
}
```

Semantically equivalent to the original when `interop_time = Some(T)`; rejects when None.

## Test

Added `test_derive_and_resolve_graph_initiating_chain_interop_time_none_rejected`: init chain has
`interop_time = None`, attacker plants matching log, exec chain references it. Pre-fix the message
is accepted; post-fix `resolve()` returns `InvalidMessages` for the executing chain.
