### PR TITLE
fix(op-acceptance-tests): drain LocalSafe in freezeChains

### DIFF
--- a/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
+++ b/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
@@ -45,20 +45,30 @@ type chain struct {
 	Batcher *dsl.L2Batcher
 }
 
-// freezeChains takes exclusive control of L2 block production: stops every
-// chain's real sequencer and batcher, and waits for both safety levels to
-// stall. After this returns no real-sequencer or batcher activity advances
-// the chain — block production is the caller's via TestSequencer.SequenceBlock.
+// freezeChains takes exclusive control of L2 block production. After this
+// returns: real sequencers are stopped, batchers are stopped, and on every
+// chain LocalSafe == LocalUnsafe. From here, only the caller advances the
+// chain via TestSequencer.SequenceBlock.
+//
+// Order matters: stopping the batcher before LocalSafe catches up to
+// LocalUnsafe leaves safe behind unsafe, which breaks downstream code that
+// expects "the head" to be unambiguous (e.g. nextTimestampAfterSafeHeads).
+// So we stop sequencers first, wait for unsafe to stall, then let the still-
+// running batchers drain the remaining unsafe blocks to L1 until safe catches
+// up, and only then stop the batchers.
 func freezeChains(chains []*chain) {
 	for _, c := range chains {
 		c.CLNode.StopSequencer()
 	}
 	for _, c := range chains {
-		c.Batcher.Stop()
+		c.CLNode.WaitForStall(types.LocalUnsafe)
 	}
 	for _, c := range chains {
-		c.CLNode.WaitForStall(types.LocalUnsafe)
-		c.CLNode.WaitForStall(types.LocalSafe)
+		unsafeNumber := c.CLNode.HeadBlockRef(types.LocalUnsafe).Number
+		c.CLNode.Reached(types.LocalSafe, unsafeNumber, 30)
+	}
+	for _, c := range chains {
+		c.Batcher.Stop()
 	}
 }
 


### PR DESCRIPTION
Fixes ethereum-optimism/optimism#19804.

`freezeChains` stopped sequencers and batchers in parallel and only waited for `LocalUnsafe` and `LocalSafe` to *stall*. `WaitForStall` watches one safety level at a time and does not imply equality across levels, so the batcher could be stopped before draining the most recent unsafe block(s) — leaving `LocalSafe < LocalUnsafe` at exit. `nextTimestampAfterSafeHeads` then derived `endTimestamp` from safe heads, and `startTimestamp = endTimestamp - 1` could land below the unsafe head time on the 1s chain, tripping the `head.Time <= target` assertion at `superfaultproofs.go:78`.

Reorder `freezeChains` to deliver `LocalSafe == LocalUnsafe` on return:

1. Stop sequencers.
2. Wait for `LocalUnsafe` to stall.
3. With batchers still running, wait for `LocalSafe` to reach the captured `LocalUnsafe.Number` per chain.
4. Stop batchers.