### PR TITLE
feat(op-node): serve superroot_atTimestamp for non-interop chains

### DIFF
--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -626,7 +626,7 @@ func registerAPIs(cfg *config.Config, node *OpNode, handler *oprpc.Handler) erro
 	// `superroot_atTimestamp` for non-interop chains; always-on, harmless until games activate.
 	if err := handler.AddAPI(rpc.API{
 		Namespace: "superroot",
-		Service:   NewSuperrootAPI(&cfg.Rollup, node.l2Source.L2Client, node.l2Driver, node.safeDB, node.log),
+		Service:   NewSuperrootAPI(&cfg.Rollup, node.l2Source.L2Client, node.l2Driver, node.safeDB),
 	}); err != nil {
 		return fmt.Errorf("failed to add Superroot API: %w", err)
 	}

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -623,6 +623,16 @@ func registerAPIs(cfg *config.Config, node *OpNode, handler *oprpc.Handler) erro
 		return fmt.Errorf("failed to add Optimism API: %w", err)
 	}
 
+	// Register the superroot namespace. For non-interop chains, op-node is the
+	// canonical source of `superroot_atTimestamp` for op-challenger and op-dispute-mon.
+	// Always-on; harmless on chains that have not yet activated super-root games.
+	if err := handler.AddAPI(rpc.API{
+		Namespace: "superroot",
+		Service:   NewSuperrootAPI(&cfg.Rollup, node.l2Source.L2Client, node.l2Driver, node.safeDB, node.log),
+	}); err != nil {
+		return fmt.Errorf("failed to add Superroot API: %w", err)
+	}
+
 	if p2pNode := node.getP2PNodeIfEnabled(); p2pNode != nil {
 		if err := handler.AddAPI(rpc.API{
 			Namespace: p2p.NamespaceRPC,

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -623,9 +623,7 @@ func registerAPIs(cfg *config.Config, node *OpNode, handler *oprpc.Handler) erro
 		return fmt.Errorf("failed to add Optimism API: %w", err)
 	}
 
-	// Register the superroot namespace. For non-interop chains, op-node is the
-	// canonical source of `superroot_atTimestamp` for op-challenger and op-dispute-mon.
-	// Always-on; harmless on chains that have not yet activated super-root games.
+	// `superroot_atTimestamp` for non-interop chains; always-on, harmless until games activate.
 	if err := handler.AddAPI(rpc.API{
 		Namespace: "superroot",
 		Service:   NewSuperrootAPI(&cfg.Rollup, node.l2Source.L2Client, node.l2Driver, node.safeDB, node.log),

--- a/op-node/node/superroot_api.go
+++ b/op-node/node/superroot_api.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -21,11 +20,10 @@ type superrootAPI struct {
 	client l2EthClient
 	dr     driverClient
 	safeDB SafeDBReader
-	log    log.Logger
 }
 
-func NewSuperrootAPI(cfg *rollup.Config, client l2EthClient, dr driverClient, safeDB SafeDBReader, log log.Logger) *superrootAPI {
-	return &superrootAPI{cfg: cfg, client: client, dr: dr, safeDB: safeDB, log: log}
+func NewSuperrootAPI(cfg *rollup.Config, client l2EthClient, dr driverClient, safeDB SafeDBReader) *superrootAPI {
+	return &superrootAPI{cfg: cfg, client: client, dr: dr, safeDB: safeDB}
 }
 
 // AtTimestamp serves the "superroot_atTimestamp" wire method.

--- a/op-node/node/superroot_api.go
+++ b/op-node/node/superroot_api.go
@@ -9,7 +9,6 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/log"
 
-	"github.com/ethereum-optimism/optimism/op-node/node/safedb"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
@@ -43,35 +42,28 @@ func (s *superrootAPI) atTimestamp(ctx context.Context, timestamp uint64) (eth.S
 		return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("target block number for timestamp %d: %w", timestamp, err)
 	}
 
-	// Use BlockRefWithStatus so the LocalSafeL2 bound below sees a status consistent
-	// with the resolved ref.
+	// BlockRefWithStatus returns a non-nil status alongside ethereum.NotFound, so the
+	// LocalSafeL2 bound and any omit-chain response describe the same snapshot as
+	// the failed lookup.
 	ref, status, err := s.dr.BlockRefWithStatus(ctx, blockNum)
 	if err != nil {
-		// NotFound (beyond unsafe head): omit chain, populate sync fields from a
-		// fresh SyncStatus call. Other errors propagate.
-		if !errors.Is(err, ethereum.NotFound) {
-			return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("blockRefWithStatus@%d: %w", blockNum, err)
+		// Block beyond known head: omit chain. Other errors propagate.
+		if errors.Is(err, ethereum.NotFound) {
+			return responseSkeleton(status, chainID), nil
 		}
-		status, ssErr := s.dr.SyncStatus(ctx)
-		if ssErr != nil {
-			return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("syncStatus after blockRef NotFound@%d: %w", blockNum, ssErr)
-		}
-		return responseSkeleton(status, chainID), nil
+		return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("blockRefWithStatus@%d: %w", blockNum, err)
 	}
 
 	resp := responseSkeleton(status, chainID)
 
-	// op-supernode omits the chain past LocalSafeL2; any synthetic entry here would
-	// diverge for consumers that read OptimisticAtTimestamp without checking Data.
+	// Omit the chain past LocalSafeL2, matching op-supernode.
 	if blockNum > status.LocalSafeL2.Number {
 		return resp, nil
 	}
 
 	output, err := s.client.OutputV0AtBlock(ctx, ref.Hash)
 	if err != nil {
-		if errors.Is(err, ethereum.NotFound) {
-			return resp, nil
-		}
+		// We already resolved ref by number; a later miss means state shifted.
 		return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("outputV0AtBlock@%s: %w", ref, err)
 	}
 	outputRoot := eth.OutputRoot(output)
@@ -85,12 +77,7 @@ func (s *superrootAPI) atTimestamp(ctx context.Context, timestamp uint64) (eth.S
 		requiredL1, _, err = s.safeDB.L1AtSafeHead(ctx, ref.Number)
 	}
 	if err != nil {
-		// Only transient SafeDB lag (ErrL1AtSafeHeadNotFound) omits the chain;
-		// permanent gaps and disabled-DB / IO errors propagate.
-		if errors.Is(err, safedb.ErrL1AtSafeHeadNotFound) {
-			s.log.Debug("L1AtSafeHead transient, omitting chain", "err", err, "block", ref)
-			return resp, nil
-		}
+		// ref is at-or-below LocalSafeL2, so SafeDB should have a record; propagate.
 		return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("l1AtSafeHead@%s: %w", ref, err)
 	}
 

--- a/op-node/node/superroot_api.go
+++ b/op-node/node/superroot_api.go
@@ -2,11 +2,13 @@ package node
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/log"
 
+	"github.com/ethereum-optimism/optimism/op-node/node/safedb"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
@@ -54,12 +56,20 @@ func (s *superrootAPI) atTimestamp(ctx context.Context, timestamp uint64) (eth.S
 
 	blockNum, err := s.cfg.TargetBlockNumber(timestamp)
 	if err != nil {
-		// Pre-genesis: empty optimistic, nil Data, sync fields populated.
+		// Pre-genesis. op-supernode equivalent: LocalSafeBlockAtTimestamp returns the same
+		// error → both VerifiedAt and OptimisticAt fail → chain absent from OptimisticAtTimestamp,
+		// Data nil. We return success with the same shape.
 		return resp, nil
 	}
 
-	if blockNum > status.UnsafeL2.Number {
-		// Beyond local head: empty optimistic, nil Data, sync fields populated.
+	// op-supernode bounds the optimistic branch by LocalSafeL2 (LocalSafeBlockAtTimestamp
+	// returns ethereum.NotFound when blockNum > localSafe). Beyond LocalSafeL2 — including
+	// beyond UnsafeL2 — both VerifiedAt and OptimisticAt return NotFound, so the chain is
+	// absent from OptimisticAtTimestamp and Data is nil. Mirror that exactly: do NOT add an
+	// optimistic entry derived from L1Origin; consumers (op-challenger SuperNodeTraceProvider
+	// at step > 0) read OptimisticAtTimestamp[chainID] without checking Data, so any extra
+	// entry here would create a behavioral divergence at non-zero game steps.
+	if blockNum > status.LocalSafeL2.Number {
 		return resp, nil
 	}
 
@@ -73,17 +83,6 @@ func (s *superrootAPI) atTimestamp(ctx context.Context, timestamp uint64) (eth.S
 	}
 	outputRoot := eth.OutputRoot(output)
 
-	// Optimistic-only branch: block exists but is not yet local-safe. RequiredL1 is the
-	// L2 block's L1 origin (the L1 height required to derive this L2 block).
-	if blockNum > status.LocalSafeL2.Number {
-		resp.OptimisticAtTimestamp[chainID] = eth.OutputWithRequiredL1{
-			Output:     output,
-			OutputRoot: outputRoot,
-			RequiredL1: ref.L1Origin,
-		}
-		return resp, nil
-	}
-
 	// Verified branch: ask safeDB for the earliest L1 at which ref became safe.
 	// Mirror op-supernode's genesis special case: L2 genesis is trivially safe at L1
 	// block 0 (not cfg.Genesis.L1, since contracts may pre-date it).
@@ -94,15 +93,17 @@ func (s *superrootAPI) atTimestamp(ctx context.Context, timestamp uint64) (eth.S
 		requiredL1, _, err = s.safeDB.L1AtSafeHead(ctx, ref.Number)
 	}
 	if err != nil {
-		// Mirror op-supernode behavior: when safeDB cannot resolve (transient or permanent),
-		// degrade to optimistic-only with L1Origin as RequiredL1 and Data nil. Consumers
-		// (op-challenger, op-dispute-mon) treat Data nil as "not yet verified."
-		s.log.Debug("L1AtSafeHead unavailable, returning optimistic-only", "err", err, "block", ref)
-		resp.OptimisticAtTimestamp[chainID] = eth.OutputWithRequiredL1{
-			Output:     output,
-			OutputRoot: outputRoot,
-			RequiredL1: ref.L1Origin,
+		// Match op-supernode chain_container.safeDBAtL2 mapping exactly:
+		//   ErrL1AtSafeHeadUnavailable (permanent gap) → ErrHistoryUnavailable → bubbled to RPC
+		//   ErrL1AtSafeHeadNotFound (transient lag)    → ethereum.NotFound → chain omitted from
+		//                                                OptimisticAtTimestamp, Data nil.
+		// Returning a fabricated optimistic entry with RequiredL1 = L1Origin would understate the
+		// requirement and could cause op-challenger to include a chain at step > 0 where
+		// op-supernode would have triggered InvalidTransition.
+		if errors.Is(err, safedb.ErrL1AtSafeHeadUnavailable) {
+			return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("L1 at safe head unavailable for L2 %s: %w", ref, err)
 		}
+		s.log.Debug("L1AtSafeHead transient unavailable, returning Data nil", "err", err, "block", ref)
 		return resp, nil
 	}
 

--- a/op-node/node/superroot_api.go
+++ b/op-node/node/superroot_api.go
@@ -39,6 +39,16 @@ func (s *superrootAPI) AtTimestamp(ctx context.Context, timestamp hexutil.Uint64
 // atTimestamp is the internal implementation. Lowercase first letter so it is not
 // exposed as an RPC method by go-ethereum's reflection-based registration.
 func (s *superrootAPI) atTimestamp(ctx context.Context, timestamp uint64) (eth.SuperRootAtTimestampResponse, error) {
+	// SafeDB is required: the verified branch walks safe-head-at-L1 history to compute
+	// RequiredL1. Without it, requests within LocalSafeL2 would surface as
+	// safedb.ErrNotEnabled from the helper, while requests beyond LocalSafeL2 would
+	// short-circuit successfully with Data=nil — so an operator who forgot --safedb.path
+	// on a node serving dispute infrastructure would see inconsistent responses.
+	// Reject up front instead.
+	if reader, ok := s.safeDB.(interface{ Enabled() bool }); ok && !reader.Enabled() {
+		return eth.SuperRootAtTimestampResponse{}, errors.New("safedb not enabled: --safedb.path is required to serve superroot_atTimestamp")
+	}
+
 	status, err := s.dr.SyncStatus(ctx)
 	if err != nil {
 		return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("syncStatus: %w", err)

--- a/op-node/node/superroot_api.go
+++ b/op-node/node/superroot_api.go
@@ -14,10 +14,9 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
-// superrootAPI serves `superroot_atTimestamp` against op-node's single rollup chain,
-// the non-interop counterpart to op-supernode's superroot activity. Dispute infra
-// (op-challenger, op-dispute-mon) can point `--supernode-rpc` at op-node and get a
-// SuperRootAtTimestampResponse with `len(ChainIDs) == 1`.
+// superrootAPI serves `superroot_atTimestamp` for op-node's single rollup chain,
+// the non-interop counterpart to op-supernode's superroot activity. Lets dispute
+// infra point `--supernode-rpc` at op-node and get `len(ChainIDs) == 1`.
 type superrootAPI struct {
 	cfg    *rollup.Config
 	client l2EthClient
@@ -30,14 +29,12 @@ func NewSuperrootAPI(cfg *rollup.Config, client l2EthClient, dr driverClient, sa
 	return &superrootAPI{cfg: cfg, client: client, dr: dr, safeDB: safeDB, log: log}
 }
 
-// AtTimestamp serves wire method "superroot_atTimestamp" (namespace "superroot",
-// matching op-supernode so existing clients work unchanged).
+// AtTimestamp serves the "superroot_atTimestamp" wire method.
 func (s *superrootAPI) AtTimestamp(ctx context.Context, timestamp hexutil.Uint64) (eth.SuperRootAtTimestampResponse, error) {
 	return s.atTimestamp(ctx, uint64(timestamp))
 }
 
-// atTimestamp is unexported so go-ethereum's reflection-based registration doesn't
-// expose it as a separate RPC method.
+// atTimestamp is unexported so go-ethereum doesn't auto-register it as an RPC method.
 func (s *superrootAPI) atTimestamp(ctx context.Context, timestamp uint64) (eth.SuperRootAtTimestampResponse, error) {
 	chainID := eth.ChainIDFromBig(s.cfg.L2ChainID)
 
@@ -46,14 +43,12 @@ func (s *superrootAPI) atTimestamp(ctx context.Context, timestamp uint64) (eth.S
 		return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("target block number for timestamp %d: %w", timestamp, err)
 	}
 
-	// BlockRefWithStatus returns ref and the SyncStatus captured at the same instant,
-	// so the LocalSafeL2 bound check below is consistent with the ref we just resolved.
+	// Use BlockRefWithStatus so the LocalSafeL2 bound below sees a status consistent
+	// with the resolved ref.
 	ref, status, err := s.dr.BlockRefWithStatus(ctx, blockNum)
 	if err != nil {
-		// ethereum.NotFound means the block isn't known yet (beyond unsafe head). Mirror
-		// op-supernode: omit the chain and return sync timestamps from a separate
-		// SyncStatus call. All other errors (context deadlines, EL transport, etc.)
-		// fail the RPC — silently emitting an empty response would mask real failures.
+		// NotFound (beyond unsafe head): omit chain, populate sync fields from a
+		// fresh SyncStatus call. Other errors propagate.
 		if !errors.Is(err, ethereum.NotFound) {
 			return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("blockRefWithStatus@%d: %w", blockNum, err)
 		}
@@ -66,17 +61,14 @@ func (s *superrootAPI) atTimestamp(ctx context.Context, timestamp uint64) (eth.S
 
 	resp := responseSkeleton(status, chainID)
 
-	// op-supernode omits the chain when blockNum > LocalSafeL2: LocalSafeBlockAtTimestamp
-	// returns ethereum.NotFound, so both VerifiedAt and OptimisticAt fail. Consumers
-	// (op-challenger SuperNodeTraceProvider at step > 0) read OptimisticAtTimestamp
-	// without checking Data, so any synthetic entry here would diverge from supernode.
+	// op-supernode omits the chain past LocalSafeL2; any synthetic entry here would
+	// diverge for consumers that read OptimisticAtTimestamp without checking Data.
 	if blockNum > status.LocalSafeL2.Number {
 		return resp, nil
 	}
 
 	output, err := s.client.OutputV0AtBlock(ctx, ref.Hash)
 	if err != nil {
-		// op-supernode parity: omit the chain on NotFound, propagate other errors.
 		if errors.Is(err, ethereum.NotFound) {
 			return resp, nil
 		}
@@ -84,8 +76,8 @@ func (s *superrootAPI) atTimestamp(ctx context.Context, timestamp uint64) (eth.S
 	}
 	outputRoot := eth.OutputRoot(output)
 
-	// L2 genesis is trivially safe at L1 block 0 (not cfg.Genesis.L1, since contracts may
-	// pre-date it). Otherwise ask SafeDB for the earliest L1 at which ref became safe.
+	// L2 genesis is trivially safe at L1 block 0 — not cfg.Genesis.L1, since
+	// contracts may pre-date it.
 	var requiredL1 eth.BlockID
 	if ref.ID() == s.cfg.Genesis.L2 {
 		requiredL1 = eth.BlockID{Number: 0}
@@ -93,9 +85,8 @@ func (s *superrootAPI) atTimestamp(ctx context.Context, timestamp uint64) (eth.S
 		requiredL1, _, err = s.safeDB.L1AtSafeHead(ctx, ref.Number)
 	}
 	if err != nil {
-		// ErrL1AtSafeHeadNotFound is transient (SafeDB lag); op-supernode maps it to
-		// ethereum.NotFound and omits the chain. All other errors (ErrL1AtSafeHeadUnavailable,
-		// ErrNotEnabled from a disabled DB, network/IO failures) propagate.
+		// Only transient SafeDB lag (ErrL1AtSafeHeadNotFound) omits the chain;
+		// permanent gaps and disabled-DB / IO errors propagate.
 		if errors.Is(err, safedb.ErrL1AtSafeHeadNotFound) {
 			s.log.Debug("L1AtSafeHead transient, omitting chain", "err", err, "block", ref)
 			return resp, nil

--- a/op-node/node/superroot_api.go
+++ b/op-node/node/superroot_api.go
@@ -13,11 +13,10 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
-// superrootAPI serves the `superroot_atTimestamp` JSON-RPC method against op-node's
-// single rollup chain. It is the non-interop counterpart to op-supernode's superroot
-// activity: dispute infrastructure (op-challenger, op-dispute-mon) can point
-// `--supernode-rpc` at op-node and receive an eth.SuperRootAtTimestampResponse with
-// `len(ChainIDs) == 1`.
+// superrootAPI serves `superroot_atTimestamp` against op-node's single rollup chain,
+// the non-interop counterpart to op-supernode's superroot activity. Dispute infra
+// (op-challenger, op-dispute-mon) can point `--supernode-rpc` at op-node and get a
+// SuperRootAtTimestampResponse with `len(ChainIDs) == 1`.
 type superrootAPI struct {
 	cfg    *rollup.Config
 	client l2EthClient
@@ -30,72 +29,53 @@ func NewSuperrootAPI(cfg *rollup.Config, client l2EthClient, dr driverClient, sa
 	return &superrootAPI{cfg: cfg, client: client, dr: dr, safeDB: safeDB, log: log}
 }
 
-// AtTimestamp serves wire method "superroot_atTimestamp". The namespace is "superroot",
-// matching op-supernode exactly so existing clients (sources.SuperNodeClient) work unchanged.
+// AtTimestamp serves wire method "superroot_atTimestamp" (namespace "superroot",
+// matching op-supernode so existing clients work unchanged).
 func (s *superrootAPI) AtTimestamp(ctx context.Context, timestamp hexutil.Uint64) (eth.SuperRootAtTimestampResponse, error) {
 	return s.atTimestamp(ctx, uint64(timestamp))
 }
 
-// atTimestamp is the internal implementation. Lowercase first letter so it is not
-// exposed as an RPC method by go-ethereum's reflection-based registration.
+// atTimestamp is unexported so go-ethereum's reflection-based registration doesn't
+// expose it as a separate RPC method.
 func (s *superrootAPI) atTimestamp(ctx context.Context, timestamp uint64) (eth.SuperRootAtTimestampResponse, error) {
-	// SafeDB is required: the verified branch walks safe-head-at-L1 history to compute
-	// RequiredL1. Without it, requests within LocalSafeL2 would surface as
-	// safedb.ErrNotEnabled from the helper, while requests beyond LocalSafeL2 would
-	// short-circuit successfully with Data=nil — so an operator who forgot --safedb.path
-	// on a node serving dispute infrastructure would see inconsistent responses.
-	// Reject up front instead.
-	if reader, ok := s.safeDB.(interface{ Enabled() bool }); ok && !reader.Enabled() {
-		return eth.SuperRootAtTimestampResponse{}, errors.New("safedb not enabled: --safedb.path is required to serve superroot_atTimestamp")
-	}
-
-	status, err := s.dr.SyncStatus(ctx)
-	if err != nil {
-		return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("syncStatus: %w", err)
-	}
-
 	chainID := eth.ChainIDFromBig(s.cfg.L2ChainID)
-	resp := eth.SuperRootAtTimestampResponse{
-		CurrentL1:                 status.CurrentL1.ID(),
-		CurrentSafeTimestamp:      status.SafeL2.Time,
-		CurrentLocalSafeTimestamp: status.LocalSafeL2.Time,
-		CurrentFinalizedTimestamp: status.FinalizedL2.Time,
-		ChainIDs:                  []eth.ChainID{chainID},
-		OptimisticAtTimestamp:     map[eth.ChainID]eth.OutputWithRequiredL1{},
-	}
 
 	blockNum, err := s.cfg.TargetBlockNumber(timestamp)
 	if err != nil {
-		// Pre-genesis. op-supernode equivalent: LocalSafeBlockAtTimestamp returns the same
-		// error → both VerifiedAt and OptimisticAt fail → chain absent from OptimisticAtTimestamp,
-		// Data nil. We return success with the same shape.
-		return resp, nil
+		return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("target block number for timestamp %d: %w", timestamp, err)
 	}
 
-	// op-supernode bounds the optimistic branch by LocalSafeL2 (LocalSafeBlockAtTimestamp
-	// returns ethereum.NotFound when blockNum > localSafe). Beyond LocalSafeL2 — including
-	// beyond UnsafeL2 — both VerifiedAt and OptimisticAt return NotFound, so the chain is
-	// absent from OptimisticAtTimestamp and Data is nil. Mirror that exactly: do NOT add an
-	// optimistic entry derived from L1Origin; consumers (op-challenger SuperNodeTraceProvider
-	// at step > 0) read OptimisticAtTimestamp[chainID] without checking Data, so any extra
-	// entry here would create a behavioral divergence at non-zero game steps.
+	// BlockRefWithStatus returns ref and the SyncStatus captured at the same instant,
+	// so the LocalSafeL2 bound check below is consistent with the ref we just resolved.
+	ref, status, err := s.dr.BlockRefWithStatus(ctx, blockNum)
+	if err != nil {
+		// Block doesn't exist yet (beyond unsafe head). Mirror op-supernode: omit the
+		// chain, return sync timestamps from a separate SyncStatus call.
+		status, ssErr := s.dr.SyncStatus(ctx)
+		if ssErr != nil {
+			return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("blockRefWithStatus@%d: %w (sync status: %v)", blockNum, err, ssErr)
+		}
+		return responseSkeleton(status, chainID), nil
+	}
+
+	resp := responseSkeleton(status, chainID)
+
+	// op-supernode omits the chain when blockNum > LocalSafeL2: LocalSafeBlockAtTimestamp
+	// returns ethereum.NotFound, so both VerifiedAt and OptimisticAt fail. Consumers
+	// (op-challenger SuperNodeTraceProvider at step > 0) read OptimisticAtTimestamp
+	// without checking Data, so any synthetic entry here would diverge from supernode.
 	if blockNum > status.LocalSafeL2.Number {
 		return resp, nil
 	}
 
-	ref, _, err := s.dr.BlockRefWithStatus(ctx, blockNum)
-	if err != nil {
-		return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("blockRefWithStatus@%d: %w", blockNum, err)
-	}
 	output, err := s.client.OutputV0AtBlock(ctx, ref.Hash)
 	if err != nil {
 		return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("outputV0AtBlock@%s: %w", ref, err)
 	}
 	outputRoot := eth.OutputRoot(output)
 
-	// Verified branch: ask safeDB for the earliest L1 at which ref became safe.
-	// Mirror op-supernode's genesis special case: L2 genesis is trivially safe at L1
-	// block 0 (not cfg.Genesis.L1, since contracts may pre-date it).
+	// L2 genesis is trivially safe at L1 block 0 (not cfg.Genesis.L1, since contracts may
+	// pre-date it). Otherwise ask SafeDB for the earliest L1 at which ref became safe.
 	var requiredL1 eth.BlockID
 	if ref.ID() == s.cfg.Genesis.L2 {
 		requiredL1 = eth.BlockID{Number: 0}
@@ -103,18 +83,14 @@ func (s *superrootAPI) atTimestamp(ctx context.Context, timestamp uint64) (eth.S
 		requiredL1, _, err = s.safeDB.L1AtSafeHead(ctx, ref.Number)
 	}
 	if err != nil {
-		// Match op-supernode chain_container.safeDBAtL2 mapping exactly:
-		//   ErrL1AtSafeHeadUnavailable (permanent gap) → ErrHistoryUnavailable → bubbled to RPC
-		//   ErrL1AtSafeHeadNotFound (transient lag)    → ethereum.NotFound → chain omitted from
-		//                                                OptimisticAtTimestamp, Data nil.
-		// Returning a fabricated optimistic entry with RequiredL1 = L1Origin would understate the
-		// requirement and could cause op-challenger to include a chain at step > 0 where
-		// op-supernode would have triggered InvalidTransition.
-		if errors.Is(err, safedb.ErrL1AtSafeHeadUnavailable) {
-			return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("L1 at safe head unavailable for L2 %s: %w", ref, err)
+		// ErrL1AtSafeHeadNotFound is transient (SafeDB lag); op-supernode maps it to
+		// ethereum.NotFound and omits the chain. All other errors (ErrL1AtSafeHeadUnavailable,
+		// ErrNotEnabled from a disabled DB, network/IO failures) propagate.
+		if errors.Is(err, safedb.ErrL1AtSafeHeadNotFound) {
+			s.log.Debug("L1AtSafeHead transient, omitting chain", "err", err, "block", ref)
+			return resp, nil
 		}
-		s.log.Debug("L1AtSafeHead transient unavailable, returning Data nil", "err", err, "block", ref)
-		return resp, nil
+		return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("l1AtSafeHead@%s: %w", ref, err)
 	}
 
 	resp.OptimisticAtTimestamp[chainID] = eth.OutputWithRequiredL1{
@@ -133,4 +109,15 @@ func (s *superrootAPI) atTimestamp(ctx context.Context, timestamp uint64) (eth.S
 		SuperRoot:          eth.SuperRoot(superV1),
 	}
 	return resp, nil
+}
+
+func responseSkeleton(status *eth.SyncStatus, chainID eth.ChainID) eth.SuperRootAtTimestampResponse {
+	return eth.SuperRootAtTimestampResponse{
+		CurrentL1:                 status.CurrentL1.ID(),
+		CurrentSafeTimestamp:      status.SafeL2.Time,
+		CurrentLocalSafeTimestamp: status.LocalSafeL2.Time,
+		CurrentFinalizedTimestamp: status.FinalizedL2.Time,
+		ChainIDs:                  []eth.ChainID{chainID},
+		OptimisticAtTimestamp:     map[eth.ChainID]eth.OutputWithRequiredL1{},
+	}
 }

--- a/op-node/node/superroot_api.go
+++ b/op-node/node/superroot_api.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/log"
 
@@ -49,11 +50,16 @@ func (s *superrootAPI) atTimestamp(ctx context.Context, timestamp uint64) (eth.S
 	// so the LocalSafeL2 bound check below is consistent with the ref we just resolved.
 	ref, status, err := s.dr.BlockRefWithStatus(ctx, blockNum)
 	if err != nil {
-		// Block doesn't exist yet (beyond unsafe head). Mirror op-supernode: omit the
-		// chain, return sync timestamps from a separate SyncStatus call.
+		// ethereum.NotFound means the block isn't known yet (beyond unsafe head). Mirror
+		// op-supernode: omit the chain and return sync timestamps from a separate
+		// SyncStatus call. All other errors (context deadlines, EL transport, etc.)
+		// fail the RPC — silently emitting an empty response would mask real failures.
+		if !errors.Is(err, ethereum.NotFound) {
+			return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("blockRefWithStatus@%d: %w", blockNum, err)
+		}
 		status, ssErr := s.dr.SyncStatus(ctx)
 		if ssErr != nil {
-			return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("blockRefWithStatus@%d: %w (sync status: %v)", blockNum, err, ssErr)
+			return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("syncStatus after blockRef NotFound@%d: %w", blockNum, ssErr)
 		}
 		return responseSkeleton(status, chainID), nil
 	}
@@ -70,6 +76,10 @@ func (s *superrootAPI) atTimestamp(ctx context.Context, timestamp uint64) (eth.S
 
 	output, err := s.client.OutputV0AtBlock(ctx, ref.Hash)
 	if err != nil {
+		// op-supernode parity: omit the chain on NotFound, propagate other errors.
+		if errors.Is(err, ethereum.NotFound) {
+			return resp, nil
+		}
 		return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("outputV0AtBlock@%s: %w", ref, err)
 	}
 	outputRoot := eth.OutputRoot(output)

--- a/op-node/node/superroot_api.go
+++ b/op-node/node/superroot_api.go
@@ -1,0 +1,125 @@
+package node
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+// superrootAPI serves the `superroot_atTimestamp` JSON-RPC method against op-node's
+// single rollup chain. It is the non-interop counterpart to op-supernode's superroot
+// activity: dispute infrastructure (op-challenger, op-dispute-mon) can point
+// `--supernode-rpc` at op-node and receive an eth.SuperRootAtTimestampResponse with
+// `len(ChainIDs) == 1`.
+type superrootAPI struct {
+	cfg    *rollup.Config
+	client l2EthClient
+	dr     driverClient
+	safeDB SafeDBReader
+	log    log.Logger
+}
+
+func NewSuperrootAPI(cfg *rollup.Config, client l2EthClient, dr driverClient, safeDB SafeDBReader, log log.Logger) *superrootAPI {
+	return &superrootAPI{cfg: cfg, client: client, dr: dr, safeDB: safeDB, log: log}
+}
+
+// AtTimestamp serves wire method "superroot_atTimestamp". The namespace is "superroot",
+// matching op-supernode exactly so existing clients (sources.SuperNodeClient) work unchanged.
+func (s *superrootAPI) AtTimestamp(ctx context.Context, timestamp hexutil.Uint64) (eth.SuperRootAtTimestampResponse, error) {
+	return s.atTimestamp(ctx, uint64(timestamp))
+}
+
+// atTimestamp is the internal implementation. Lowercase first letter so it is not
+// exposed as an RPC method by go-ethereum's reflection-based registration.
+func (s *superrootAPI) atTimestamp(ctx context.Context, timestamp uint64) (eth.SuperRootAtTimestampResponse, error) {
+	status, err := s.dr.SyncStatus(ctx)
+	if err != nil {
+		return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("syncStatus: %w", err)
+	}
+
+	chainID := eth.ChainIDFromBig(s.cfg.L2ChainID)
+	resp := eth.SuperRootAtTimestampResponse{
+		CurrentL1:                 status.CurrentL1.ID(),
+		CurrentSafeTimestamp:      status.SafeL2.Time,
+		CurrentLocalSafeTimestamp: status.LocalSafeL2.Time,
+		CurrentFinalizedTimestamp: status.FinalizedL2.Time,
+		ChainIDs:                  []eth.ChainID{chainID},
+		OptimisticAtTimestamp:     map[eth.ChainID]eth.OutputWithRequiredL1{},
+	}
+
+	blockNum, err := s.cfg.TargetBlockNumber(timestamp)
+	if err != nil {
+		// Pre-genesis: empty optimistic, nil Data, sync fields populated.
+		return resp, nil
+	}
+
+	if blockNum > status.UnsafeL2.Number {
+		// Beyond local head: empty optimistic, nil Data, sync fields populated.
+		return resp, nil
+	}
+
+	ref, _, err := s.dr.BlockRefWithStatus(ctx, blockNum)
+	if err != nil {
+		return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("blockRefWithStatus@%d: %w", blockNum, err)
+	}
+	output, err := s.client.OutputV0AtBlock(ctx, ref.Hash)
+	if err != nil {
+		return eth.SuperRootAtTimestampResponse{}, fmt.Errorf("outputV0AtBlock@%s: %w", ref, err)
+	}
+	outputRoot := eth.OutputRoot(output)
+
+	// Optimistic-only branch: block exists but is not yet local-safe. RequiredL1 is the
+	// L2 block's L1 origin (the L1 height required to derive this L2 block).
+	if blockNum > status.LocalSafeL2.Number {
+		resp.OptimisticAtTimestamp[chainID] = eth.OutputWithRequiredL1{
+			Output:     output,
+			OutputRoot: outputRoot,
+			RequiredL1: ref.L1Origin,
+		}
+		return resp, nil
+	}
+
+	// Verified branch: ask safeDB for the earliest L1 at which ref became safe.
+	// Mirror op-supernode's genesis special case: L2 genesis is trivially safe at L1
+	// block 0 (not cfg.Genesis.L1, since contracts may pre-date it).
+	var requiredL1 eth.BlockID
+	if ref.ID() == s.cfg.Genesis.L2 {
+		requiredL1 = eth.BlockID{Number: 0}
+	} else {
+		requiredL1, _, err = s.safeDB.L1AtSafeHead(ctx, ref.Number)
+	}
+	if err != nil {
+		// Mirror op-supernode behavior: when safeDB cannot resolve (transient or permanent),
+		// degrade to optimistic-only with L1Origin as RequiredL1 and Data nil. Consumers
+		// (op-challenger, op-dispute-mon) treat Data nil as "not yet verified."
+		s.log.Debug("L1AtSafeHead unavailable, returning optimistic-only", "err", err, "block", ref)
+		resp.OptimisticAtTimestamp[chainID] = eth.OutputWithRequiredL1{
+			Output:     output,
+			OutputRoot: outputRoot,
+			RequiredL1: ref.L1Origin,
+		}
+		return resp, nil
+	}
+
+	resp.OptimisticAtTimestamp[chainID] = eth.OutputWithRequiredL1{
+		Output:     output,
+		OutputRoot: outputRoot,
+		RequiredL1: requiredL1,
+	}
+
+	superV1 := eth.NewSuperV1(timestamp, eth.ChainIDAndOutput{
+		ChainID: chainID,
+		Output:  outputRoot,
+	})
+	resp.Data = &eth.SuperRootResponseData{
+		VerifiedRequiredL1: requiredL1,
+		Super:              superV1,
+		SuperRoot:          eth.SuperRoot(superV1),
+	}
+	return resp, nil
+}

--- a/op-node/node/superroot_api_test.go
+++ b/op-node/node/superroot_api_test.go
@@ -102,11 +102,10 @@ func (f *fixture) expectBlockRef(blockNum uint64, hash common.Hash, l1Origin eth
 	return ref
 }
 
-// expectBlockMissing mocks the beyond-unsafe path: BlockRefWithStatus → NotFound,
-// then a SyncStatus fallback to populate the response.
+// expectBlockMissing mocks the beyond-unsafe path: NotFound paired with a non-nil
+// status, per the driver contract.
 func (f *fixture) expectBlockMissing(blockNum uint64) {
-	f.dr.ExpectBlockRefWithStatus(blockNum, eth.L2BlockRef{}, nil, ethereum.NotFound)
-	f.dr.Mock.On("SyncStatus").Return(f.syncStatus)
+	f.dr.ExpectBlockRefWithStatus(blockNum, eth.L2BlockRef{}, f.syncStatus, ethereum.NotFound)
 }
 
 func (f *fixture) expectOutputV0(hash common.Hash) *eth.OutputV0 {
@@ -193,8 +192,8 @@ func TestSuperrootAPI_VerifiedAtGenesisL2(t *testing.T) {
 	f.safeDB.Mock.AssertNotCalled(t, "L1AtSafeHead")
 }
 
-func TestSuperrootAPI_SafeDBNotFound_OmitsChain(t *testing.T) {
-	// Transient SafeDB lag: omit chain (op-supernode maps it to ethereum.NotFound).
+func TestSuperrootAPI_SafeDBNotFound_Errors(t *testing.T) {
+	// Block is at-or-below LocalSafeL2; missing SafeDB record is inconsistency, propagate.
 	f := newFixture(t)
 
 	hash := common.Hash{0x40}
@@ -202,10 +201,8 @@ func TestSuperrootAPI_SafeDBNotFound_OmitsChain(t *testing.T) {
 	f.expectOutputV0(hash)
 	f.safeDB.ExpectL1AtSafeHead(uint64(40), eth.BlockID{}, eth.BlockID{}, safedb.ErrL1AtSafeHeadNotFound)
 
-	resp, err := f.api.atTimestamp(context.Background(), testGenesisL2Ts+40*testBlockTime)
-	require.NoError(t, err)
-	require.Nil(t, resp.Data)
-	require.Empty(t, resp.OptimisticAtTimestamp)
+	_, err := f.api.atTimestamp(context.Background(), testGenesisL2Ts+40*testBlockTime)
+	require.ErrorIs(t, err, safedb.ErrL1AtSafeHeadNotFound)
 }
 
 func TestSuperrootAPI_SafeDBUnavailable_ReturnsError(t *testing.T) {
@@ -244,17 +241,15 @@ func TestSuperrootAPI_BlockRefError_Propagates(t *testing.T) {
 	require.ErrorIs(t, err, driverErr)
 }
 
-func TestSuperrootAPI_OutputNotFound_OmitsChain(t *testing.T) {
-	// OutputV0AtBlock → NotFound: omit chain (block known, output not yet available).
+func TestSuperrootAPI_OutputNotFound_Errors(t *testing.T) {
+	// Ref already resolved; later NotFound on its hash means state shifted, propagate.
 	f := newFixture(t)
 	hash := common.Hash{0x40}
 	f.expectBlockRef(40, hash, eth.BlockID{Number: 170})
 	f.l2Client.ExpectOutputV0AtBlock(hash, (*eth.OutputV0)(nil), ethereum.NotFound)
 
-	resp, err := f.api.atTimestamp(context.Background(), testGenesisL2Ts+40*testBlockTime)
-	require.NoError(t, err)
-	require.Nil(t, resp.Data)
-	require.Empty(t, resp.OptimisticAtTimestamp)
+	_, err := f.api.atTimestamp(context.Background(), testGenesisL2Ts+40*testBlockTime)
+	require.ErrorIs(t, err, ethereum.NotFound)
 }
 
 func TestSuperrootAPI_OutputClientError(t *testing.T) {

--- a/op-node/node/superroot_api_test.go
+++ b/op-node/node/superroot_api_test.go
@@ -8,13 +8,11 @@ import (
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum-optimism/optimism/op-node/node/safedb"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
 )
 
@@ -38,7 +36,6 @@ type fixture struct {
 func newFixture(t *testing.T) *fixture {
 	t.Helper()
 
-	logger := testlog.Logger(t, log.LevelError)
 	cfg := &rollup.Config{
 		L2ChainID: big.NewInt(testL2ChainID),
 		Genesis: rollup.Genesis{
@@ -76,7 +73,7 @@ func newFixture(t *testing.T) *fixture {
 	dr := &mockDriverClient{}
 	l2Client := &testutils.MockL2Client{}
 	safeDB := &mockSafeDBReader{}
-	api := NewSuperrootAPI(cfg, l2Client, dr, safeDB, logger)
+	api := NewSuperrootAPI(cfg, l2Client, dr, safeDB)
 
 	return &fixture{
 		cfg:        cfg,
@@ -221,7 +218,7 @@ func TestSuperrootAPI_SafeDBUnavailable_ReturnsError(t *testing.T) {
 func TestSuperrootAPI_SafeDBDisabled_Errors(t *testing.T) {
 	// Without --safedb.path, safedb.Disabled returns ErrNotEnabled; propagate it.
 	f := newFixture(t)
-	api := NewSuperrootAPI(f.cfg, f.l2Client, f.dr, safedb.Disabled, testlog.Logger(t, log.LevelError))
+	api := NewSuperrootAPI(f.cfg, f.l2Client, f.dr, safedb.Disabled)
 
 	hash := common.Hash{0x40}
 	f.expectBlockRef(40, hash, eth.BlockID{Number: 170})

--- a/op-node/node/superroot_api_test.go
+++ b/op-node/node/superroot_api_test.go
@@ -176,6 +176,23 @@ func TestSuperrootAPI_VerifiedHappyPath(t *testing.T) {
 	require.Equal(t, eth.SuperRoot(expectedSuper), resp.Data.SuperRoot)
 }
 
+func TestSuperrootAPI_VerifiedAtGenesisL2(t *testing.T) {
+	// L2 genesis is trivially safe at L1 block 0; SafeDB is not consulted.
+	f := newFixture(t)
+
+	genesisHash := f.cfg.Genesis.L2.Hash
+	f.expectBlockRef(0, genesisHash, eth.BlockID{Number: 0})
+	output := f.expectOutputV0(genesisHash)
+
+	resp, err := f.api.atTimestamp(context.Background(), testGenesisL2Ts)
+	require.NoError(t, err)
+	require.NotNil(t, resp.Data)
+	require.Equal(t, eth.BlockID{Number: 0}, resp.Data.VerifiedRequiredL1)
+	require.Equal(t, eth.OutputRoot(output), resp.OptimisticAtTimestamp[f.chainID].OutputRoot)
+	require.Equal(t, eth.BlockID{Number: 0}, resp.OptimisticAtTimestamp[f.chainID].RequiredL1)
+	f.safeDB.Mock.AssertNotCalled(t, "L1AtSafeHead")
+}
+
 func TestSuperrootAPI_SafeDBNotFound_OmitsChain(t *testing.T) {
 	// Transient SafeDB lag: omit chain (op-supernode maps it to ethereum.NotFound).
 	f := newFixture(t)

--- a/op-node/node/superroot_api_test.go
+++ b/op-node/node/superroot_api_test.go
@@ -89,9 +89,8 @@ func newFixture(t *testing.T) *fixture {
 	}
 }
 
-// expectBlockRef mocks a successful BlockRefWithStatus, returning ref alongside the
-// fixture's syncStatus (the production code uses that status for the response, so
-// callers don't need a separate SyncStatus expectation).
+// expectBlockRef mocks a successful BlockRefWithStatus, returning ref alongside
+// the fixture's syncStatus (no separate SyncStatus expectation needed).
 func (f *fixture) expectBlockRef(blockNum uint64, hash common.Hash, l1Origin eth.BlockID) eth.L2BlockRef {
 	ref := eth.L2BlockRef{
 		Hash:     hash,
@@ -103,9 +102,8 @@ func (f *fixture) expectBlockRef(blockNum uint64, hash common.Hash, l1Origin eth
 	return ref
 }
 
-// expectBlockMissing mocks BlockRefWithStatus returning ethereum.NotFound for blockNum
-// (beyond unsafe head) and the SyncStatus fallback that production code makes to
-// populate the response.
+// expectBlockMissing mocks the beyond-unsafe path: BlockRefWithStatus → NotFound,
+// then a SyncStatus fallback to populate the response.
 func (f *fixture) expectBlockMissing(blockNum uint64) {
 	f.dr.ExpectBlockRefWithStatus(blockNum, eth.L2BlockRef{}, nil, ethereum.NotFound)
 	f.dr.Mock.On("SyncStatus").Return(f.syncStatus)
@@ -122,21 +120,16 @@ func (f *fixture) expectOutputV0(hash common.Hash) *eth.OutputV0 {
 }
 
 func TestSuperrootAPI_PreGenesis(t *testing.T) {
-	// Pre-genesis: rollup.TargetBlockNumber errors. Surface that error directly so
-	// dispute infra (which never legitimately queries before genesis) gets a clear
-	// signal rather than a successful empty response.
+	// Pre-genesis: surface TargetBlockNumber's error rather than a silent empty response.
 	f := newFixture(t)
 
 	_, err := f.api.atTimestamp(context.Background(), testGenesisL2Ts-1)
-	require.Error(t, err)
 	require.ErrorContains(t, err, "target block number")
 }
 
 func TestSuperrootAPI_BeyondUnsafe(t *testing.T) {
+	// Block 70 > UnsafeL2 (60): omit chain, populate sync fields via the SyncStatus fallback.
 	f := newFixture(t)
-
-	// Block 70: beyond UnsafeL2 (60). BlockRefWithStatus fails; we fall back to
-	// SyncStatus and omit the chain.
 	f.expectBlockMissing(70)
 
 	resp, err := f.api.atTimestamp(context.Background(), testGenesisL2Ts+70*testBlockTime)
@@ -147,13 +140,9 @@ func TestSuperrootAPI_BeyondUnsafe(t *testing.T) {
 }
 
 func TestSuperrootAPI_BeyondLocalSafe_OmitsChain(t *testing.T) {
-	// op-supernode parity: blocks beyond LocalSafeL2 fail both VerifiedAt and OptimisticAt
-	// (LocalSafeBlockAtTimestamp returns ethereum.NotFound), so the chain is omitted from
-	// OptimisticAtTimestamp and Data is nil.
+	// Block 55: between LocalSafeL2 (50) and UnsafeL2 (60). op-supernode omits the
+	// chain here; we do too.
 	f := newFixture(t)
-
-	// Block 55: between LocalSafeL2 (50) and UnsafeL2 (60). BlockRefWithStatus succeeds
-	// (block exists) but blockNum > LocalSafeL2 triggers the omit path.
 	f.expectBlockRef(55, common.Hash{0x55}, eth.BlockID{Number: 180})
 
 	resp, err := f.api.atTimestamp(context.Background(), testGenesisL2Ts+55*testBlockTime)
@@ -188,8 +177,7 @@ func TestSuperrootAPI_VerifiedHappyPath(t *testing.T) {
 }
 
 func TestSuperrootAPI_SafeDBNotFound_OmitsChain(t *testing.T) {
-	// SafeDB lag (target above latest, or DB empty) is transient; op-supernode maps it
-	// to ethereum.NotFound and omits the chain.
+	// Transient SafeDB lag: omit chain (op-supernode maps it to ethereum.NotFound).
 	f := newFixture(t)
 
 	hash := common.Hash{0x40}
@@ -204,8 +192,7 @@ func TestSuperrootAPI_SafeDBNotFound_OmitsChain(t *testing.T) {
 }
 
 func TestSuperrootAPI_SafeDBUnavailable_ReturnsError(t *testing.T) {
-	// Permanent SafeDB gap (target predates recorded history) — op-supernode bubbles
-	// ErrHistoryUnavailable to the RPC; operator must intervene.
+	// Permanent SafeDB gap: propagate. Operator must intervene.
 	f := newFixture(t)
 
 	hash := common.Hash{0x40}
@@ -218,8 +205,7 @@ func TestSuperrootAPI_SafeDBUnavailable_ReturnsError(t *testing.T) {
 }
 
 func TestSuperrootAPI_SafeDBDisabled_Errors(t *testing.T) {
-	// A node started without --safedb.path uses safedb.Disabled, whose L1AtSafeHead
-	// returns safedb.ErrNotEnabled. That error must propagate (not degrade to Data nil).
+	// Without --safedb.path, safedb.Disabled returns ErrNotEnabled; propagate it.
 	f := newFixture(t)
 	api := NewSuperrootAPI(f.cfg, f.l2Client, f.dr, safedb.Disabled, testlog.Logger(t, log.LevelError))
 
@@ -232,8 +218,7 @@ func TestSuperrootAPI_SafeDBDisabled_Errors(t *testing.T) {
 }
 
 func TestSuperrootAPI_BlockRefError_Propagates(t *testing.T) {
-	// Non-NotFound errors from BlockRefWithStatus (context deadline, EL transport,
-	// driver-loop failures) must fail the RPC rather than degrade to an empty response.
+	// Non-NotFound BlockRefWithStatus errors fail the RPC (no silent degradation).
 	f := newFixture(t)
 	driverErr := errors.New("driver-loop fail")
 	f.dr.ExpectBlockRefWithStatus(40, eth.L2BlockRef{}, nil, driverErr)
@@ -243,9 +228,7 @@ func TestSuperrootAPI_BlockRefError_Propagates(t *testing.T) {
 }
 
 func TestSuperrootAPI_OutputNotFound_OmitsChain(t *testing.T) {
-	// op-supernode parity: OutputV0AtBlock returning ethereum.NotFound omits the
-	// chain (Data nil, no entry); the block exists but the EL hasn't surfaced an
-	// output for it yet.
+	// OutputV0AtBlock → NotFound: omit chain (block known, output not yet available).
 	f := newFixture(t)
 	hash := common.Hash{0x40}
 	f.expectBlockRef(40, hash, eth.BlockID{Number: 170})

--- a/op-node/node/superroot_api_test.go
+++ b/op-node/node/superroot_api_test.go
@@ -256,6 +256,19 @@ func TestSuperrootAPI_SafeDBUnavailable_ReturnsError(t *testing.T) {
 	require.ErrorIs(t, err, safedb.ErrL1AtSafeHeadUnavailable)
 }
 
+func TestSuperrootAPI_SafeDBDisabled_Errors(t *testing.T) {
+	// A node started without --safedb.path uses safedb.Disabled. Without an up-front
+	// gate, requests within LocalSafeL2 would surface ErrNotEnabled from the helper
+	// while requests beyond LocalSafeL2 would short-circuit successfully with Data=nil
+	// — operators serving dispute infra would see inconsistent responses. Assert the
+	// handler rejects loudly before doing any work (no SyncStatus / output calls).
+	f := newFixture(t)
+	api := NewSuperrootAPI(f.cfg, f.l2Client, f.dr, safedb.Disabled, testlog.Logger(t, log.LevelError))
+
+	_, err := api.AtTimestamp(context.Background(), hexutil.Uint64(testGenesisL2Ts+10*testBlockTime))
+	require.ErrorContains(t, err, "safedb not enabled")
+}
+
 func TestSuperrootAPI_DriverSyncStatusError(t *testing.T) {
 	f := newFixture(t)
 	// Replace SyncStatus expectation with a failing one.

--- a/op-node/node/superroot_api_test.go
+++ b/op-node/node/superroot_api_test.go
@@ -1,0 +1,311 @@
+package node
+
+import (
+	"context"
+	"errors"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-node/node/safedb"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
+)
+
+// superRootProvider mirrors the minimal interface that op-challenger
+// (SuperNodeRootProvider) and op-dispute-mon (SuperRootProvider) require from any
+// `superroot_atTimestamp` server. op-node MUST satisfy it.
+type superRootProvider interface {
+	SuperRootAtTimestamp(ctx context.Context, timestamp uint64) (eth.SuperRootAtTimestampResponse, error)
+}
+
+// superrootAPIQueryAdapter exposes superrootAPI through superRootProvider for
+// compile-time and runtime interface conformance checking. It is NOT registered as
+// an RPC service — placing the SuperRootAtTimestamp method on this adapter (rather
+// than the live *superrootAPI) avoids leaking a `superroot_superRootAtTimestamp`
+// wire method that go-ethereum would auto-register from any exported method on the
+// live struct.
+type superrootAPIQueryAdapter struct{ *superrootAPI }
+
+func (a superrootAPIQueryAdapter) SuperRootAtTimestamp(ctx context.Context, ts uint64) (eth.SuperRootAtTimestampResponse, error) {
+	return a.atTimestamp(ctx, ts)
+}
+
+var _ superRootProvider = superrootAPIQueryAdapter{}
+
+const (
+	testL2ChainID    = 420
+	testGenesisL1Num = uint64(100)
+	testBlockTime    = uint64(2)
+	testGenesisL2Ts  = uint64(1000)
+)
+
+// fixture sets up a realistic single-chain SyncStatus and a deterministic OutputV0.
+type fixture struct {
+	cfg        *rollup.Config
+	dr         *mockDriverClient
+	l2Client   *testutils.MockL2Client
+	safeDB     *mockSafeDBReader
+	api        *superrootAPI
+	syncStatus *eth.SyncStatus
+	chainID    eth.ChainID
+}
+
+func newFixture(t *testing.T) *fixture {
+	t.Helper()
+
+	logger := testlog.Logger(t, log.LevelError)
+	cfg := &rollup.Config{
+		L2ChainID: big.NewInt(testL2ChainID),
+		Genesis: rollup.Genesis{
+			L1:     eth.BlockID{Number: testGenesisL1Num, Hash: common.Hash{0xa0}},
+			L2:     eth.BlockID{Number: 0, Hash: common.Hash{0xb0}},
+			L2Time: testGenesisL2Ts,
+		},
+		BlockTime: testBlockTime,
+	}
+
+	syncStatus := &eth.SyncStatus{
+		CurrentL1: eth.L1BlockRef{Number: 200, Hash: common.Hash{0xc0}},
+		UnsafeL2: eth.L2BlockRef{
+			Hash:   common.Hash{0xd0},
+			Number: 60,
+			Time:   testGenesisL2Ts + 60*testBlockTime,
+		},
+		SafeL2: eth.L2BlockRef{
+			Hash:   common.Hash{0xe0},
+			Number: 50,
+			Time:   testGenesisL2Ts + 50*testBlockTime,
+		},
+		LocalSafeL2: eth.L2BlockRef{
+			Hash:   common.Hash{0xe1},
+			Number: 50,
+			Time:   testGenesisL2Ts + 50*testBlockTime,
+		},
+		FinalizedL2: eth.L2BlockRef{
+			Hash:   common.Hash{0xf0},
+			Number: 40,
+			Time:   testGenesisL2Ts + 40*testBlockTime,
+		},
+	}
+
+	dr := &mockDriverClient{}
+	l2Client := &testutils.MockL2Client{}
+	safeDB := &mockSafeDBReader{}
+	api := NewSuperrootAPI(cfg, l2Client, dr, safeDB, logger)
+
+	return &fixture{
+		cfg:        cfg,
+		dr:         dr,
+		l2Client:   l2Client,
+		safeDB:     safeDB,
+		api:        api,
+		syncStatus: syncStatus,
+		chainID:    eth.ChainIDFromBig(cfg.L2ChainID),
+	}
+}
+
+func (f *fixture) expectSyncStatus() {
+	f.dr.Mock.On("SyncStatus").Return(f.syncStatus)
+}
+
+func (f *fixture) expectBlockRef(blockNum uint64, hash common.Hash, l1Origin eth.BlockID) eth.L2BlockRef {
+	ref := eth.L2BlockRef{
+		Hash:     hash,
+		Number:   blockNum,
+		Time:     testGenesisL2Ts + blockNum*testBlockTime,
+		L1Origin: l1Origin,
+	}
+	f.dr.ExpectBlockRefWithStatus(blockNum, ref, f.syncStatus, nil)
+	return ref
+}
+
+func (f *fixture) expectOutputV0(hash common.Hash) *eth.OutputV0 {
+	output := &eth.OutputV0{
+		StateRoot:                eth.Bytes32{0x11},
+		MessagePasserStorageRoot: eth.Bytes32{0x22},
+		BlockHash:                hash,
+	}
+	f.l2Client.ExpectOutputV0AtBlock(hash, output, nil)
+	return output
+}
+
+func TestSuperrootAPI_PreGenesis(t *testing.T) {
+	f := newFixture(t)
+	f.expectSyncStatus()
+
+	// Timestamp before genesis.
+	resp, err := f.api.AtTimestamp(context.Background(), hexutil.Uint64(testGenesisL2Ts-1))
+	require.NoError(t, err)
+	require.Equal(t, []eth.ChainID{f.chainID}, resp.ChainIDs)
+	require.Empty(t, resp.OptimisticAtTimestamp)
+	require.Nil(t, resp.Data)
+	require.Equal(t, f.syncStatus.CurrentL1.ID(), resp.CurrentL1)
+	require.Equal(t, f.syncStatus.SafeL2.Time, resp.CurrentSafeTimestamp)
+	require.Equal(t, f.syncStatus.LocalSafeL2.Time, resp.CurrentLocalSafeTimestamp)
+	require.Equal(t, f.syncStatus.FinalizedL2.Time, resp.CurrentFinalizedTimestamp)
+}
+
+func TestSuperrootAPI_BeyondUnsafe(t *testing.T) {
+	f := newFixture(t)
+	f.expectSyncStatus()
+
+	// Timestamp maps to block 70, beyond UnsafeL2 (60).
+	tsBeyond := testGenesisL2Ts + 70*testBlockTime
+	resp, err := f.api.AtTimestamp(context.Background(), hexutil.Uint64(tsBeyond))
+	require.NoError(t, err)
+	require.Equal(t, []eth.ChainID{f.chainID}, resp.ChainIDs)
+	require.Empty(t, resp.OptimisticAtTimestamp)
+	require.Nil(t, resp.Data)
+}
+
+func TestSuperrootAPI_OptimisticOnly_BeyondLocalSafe(t *testing.T) {
+	f := newFixture(t)
+	f.expectSyncStatus()
+
+	// Block 55: between LocalSafeL2 (50) and UnsafeL2 (60).
+	tsOpt := testGenesisL2Ts + 55*testBlockTime
+	hash := common.Hash{0x55}
+	l1Origin := eth.BlockID{Number: 180, Hash: common.Hash{0x18}}
+	f.expectBlockRef(55, hash, l1Origin)
+	output := f.expectOutputV0(hash)
+
+	resp, err := f.api.AtTimestamp(context.Background(), hexutil.Uint64(tsOpt))
+	require.NoError(t, err)
+	require.Nil(t, resp.Data)
+	require.Len(t, resp.OptimisticAtTimestamp, 1)
+	entry := resp.OptimisticAtTimestamp[f.chainID]
+	require.Equal(t, output, entry.Output)
+	require.Equal(t, eth.OutputRoot(output), entry.OutputRoot)
+	require.Equal(t, l1Origin, entry.RequiredL1)
+}
+
+func TestSuperrootAPI_VerifiedHappyPath(t *testing.T) {
+	f := newFixture(t)
+	f.expectSyncStatus()
+
+	// Block 40: at-or-before LocalSafeL2 (50).
+	tsVerified := testGenesisL2Ts + 40*testBlockTime
+	hash := common.Hash{0x40}
+	l1Origin := eth.BlockID{Number: 170, Hash: common.Hash{0x17}}
+	ref := f.expectBlockRef(40, hash, l1Origin)
+	output := f.expectOutputV0(hash)
+
+	// SafeDB.L1AtSafeHead returns the earliest L1 at which the recorded L2 safe head reached target.
+	verifiedL1 := eth.BlockID{Number: 205, Hash: common.Hash{0x20}}
+	f.safeDB.ExpectL1AtSafeHead(uint64(40), verifiedL1, ref.ID(), nil)
+
+	resp, err := f.api.AtTimestamp(context.Background(), hexutil.Uint64(tsVerified))
+	require.NoError(t, err)
+	require.NotNil(t, resp.Data)
+	require.Equal(t, verifiedL1, resp.Data.VerifiedRequiredL1)
+	require.Equal(t, eth.OutputRoot(output), resp.OptimisticAtTimestamp[f.chainID].OutputRoot)
+	require.Equal(t, verifiedL1, resp.OptimisticAtTimestamp[f.chainID].RequiredL1)
+
+	expectedSuper := eth.NewSuperV1(tsVerified, eth.ChainIDAndOutput{
+		ChainID: f.chainID,
+		Output:  eth.OutputRoot(output),
+	})
+	require.Equal(t, eth.SuperRoot(expectedSuper), resp.Data.SuperRoot)
+}
+
+func TestSuperrootAPI_VerifiedFallback_SafeDBNotFound(t *testing.T) {
+	f := newFixture(t)
+	f.expectSyncStatus()
+
+	tsVerified := testGenesisL2Ts + 40*testBlockTime
+	hash := common.Hash{0x40}
+	l1Origin := eth.BlockID{Number: 170, Hash: common.Hash{0x17}}
+	f.expectBlockRef(40, hash, l1Origin)
+	output := f.expectOutputV0(hash)
+
+	// SafeDB returns ErrL1AtSafeHeadNotFound (transient: empty DB or target above latest);
+	// superrootAPI maps it to optimistic-only with L1Origin as RequiredL1.
+	f.safeDB.ExpectL1AtSafeHead(uint64(40), eth.BlockID{}, eth.BlockID{}, safedb.ErrL1AtSafeHeadNotFound)
+
+	resp, err := f.api.AtTimestamp(context.Background(), hexutil.Uint64(tsVerified))
+	require.NoError(t, err)
+	require.Nil(t, resp.Data) // fallback: Data is nil
+	entry := resp.OptimisticAtTimestamp[f.chainID]
+	require.Equal(t, output, entry.Output)
+	require.Equal(t, l1Origin, entry.RequiredL1)
+}
+
+func TestSuperrootAPI_DriverSyncStatusError(t *testing.T) {
+	f := newFixture(t)
+	// Replace SyncStatus expectation with a failing one.
+	failing := &failingDriver{err: errors.New("drv-fail")}
+	api := NewSuperrootAPI(f.cfg, f.l2Client, failing, f.safeDB, testlog.Logger(t, log.LevelError))
+
+	_, err := api.AtTimestamp(context.Background(), hexutil.Uint64(testGenesisL2Ts+10*testBlockTime))
+	require.ErrorContains(t, err, "syncStatus")
+}
+
+func TestSuperrootAPI_OutputClientError(t *testing.T) {
+	f := newFixture(t)
+	f.expectSyncStatus()
+
+	tsVerified := testGenesisL2Ts + 30*testBlockTime
+	hash := common.Hash{0x30}
+	f.expectBlockRef(30, hash, eth.BlockID{Number: 160})
+	f.l2Client.ExpectOutputV0AtBlock(hash, (*eth.OutputV0)(nil), errors.New("output-fail"))
+
+	_, err := f.api.AtTimestamp(context.Background(), hexutil.Uint64(tsVerified))
+	require.ErrorContains(t, err, "outputV0AtBlock")
+}
+
+func TestSuperrootAPI_ChainIDsAlwaysSingleEntry(t *testing.T) {
+	for _, ts := range []uint64{
+		testGenesisL2Ts - 1,                // pre-genesis
+		testGenesisL2Ts + 70*testBlockTime, // beyond unsafe
+	} {
+		t.Run("", func(t *testing.T) {
+			f := newFixture(t)
+			f.expectSyncStatus()
+			resp, err := f.api.AtTimestamp(context.Background(), hexutil.Uint64(ts))
+			require.NoError(t, err)
+			require.Len(t, resp.ChainIDs, 1)
+		})
+	}
+}
+
+func TestSuperrootAPI_SuperRootProviderCompat(t *testing.T) {
+	// Compile-time check at package scope (var _ superRootProvider = ...).
+	// Runtime check: invoke through the interface to confirm op-node is drop-in for
+	// op-challenger's SuperNodeRootProvider and op-dispute-mon's SuperRootProvider.
+	f := newFixture(t)
+	f.expectSyncStatus()
+
+	var provider superRootProvider = superrootAPIQueryAdapter{f.api}
+	resp, err := provider.SuperRootAtTimestamp(context.Background(), testGenesisL2Ts-1)
+	require.NoError(t, err)
+	require.Equal(t, []eth.ChainID{f.chainID}, resp.ChainIDs)
+}
+
+// failingDriver is a minimal driverClient stub that returns a configured error from SyncStatus.
+type failingDriver struct {
+	err error
+}
+
+func (f *failingDriver) SyncStatus(_ context.Context) (*eth.SyncStatus, error) {
+	return nil, f.err
+}
+func (f *failingDriver) BlockRefWithStatus(_ context.Context, _ uint64) (eth.L2BlockRef, *eth.SyncStatus, error) {
+	return eth.L2BlockRef{}, nil, f.err
+}
+func (f *failingDriver) ResetDerivationPipeline(_ context.Context) error       { return f.err }
+func (f *failingDriver) StartSequencer(_ context.Context, _ common.Hash) error { return f.err }
+func (f *failingDriver) StopSequencer(_ context.Context) (common.Hash, error) {
+	return common.Hash{}, f.err
+}
+func (f *failingDriver) SequencerActive(_ context.Context) (bool, error)                      { return false, f.err }
+func (f *failingDriver) OnUnsafeL2Payload(_ context.Context, _ *eth.ExecutionPayloadEnvelope) {}
+func (f *failingDriver) OverrideLeader(_ context.Context) error                               { return f.err }
+func (f *failingDriver) ConductorEnabled(_ context.Context) (bool, error)                     { return false, f.err }
+func (f *failingDriver) SetRecoverMode(_ context.Context, _ bool) error                       { return f.err }

--- a/op-node/node/superroot_api_test.go
+++ b/op-node/node/superroot_api_test.go
@@ -165,25 +165,20 @@ func TestSuperrootAPI_BeyondUnsafe(t *testing.T) {
 	require.Nil(t, resp.Data)
 }
 
-func TestSuperrootAPI_OptimisticOnly_BeyondLocalSafe(t *testing.T) {
+func TestSuperrootAPI_BeyondLocalSafe_OmitsChain(t *testing.T) {
+	// op-supernode parity: blocks beyond LocalSafeL2 are treated as absent for both
+	// verified and optimistic, so the chain is omitted from OptimisticAtTimestamp and
+	// Data is nil. (LocalSafeBlockAtTimestamp returns ethereum.NotFound there, which
+	// makes both VerifiedAt and OptimisticAt fail in op-supernode.)
 	f := newFixture(t)
 	f.expectSyncStatus()
 
 	// Block 55: between LocalSafeL2 (50) and UnsafeL2 (60).
 	tsOpt := testGenesisL2Ts + 55*testBlockTime
-	hash := common.Hash{0x55}
-	l1Origin := eth.BlockID{Number: 180, Hash: common.Hash{0x18}}
-	f.expectBlockRef(55, hash, l1Origin)
-	output := f.expectOutputV0(hash)
-
 	resp, err := f.api.AtTimestamp(context.Background(), hexutil.Uint64(tsOpt))
 	require.NoError(t, err)
 	require.Nil(t, resp.Data)
-	require.Len(t, resp.OptimisticAtTimestamp, 1)
-	entry := resp.OptimisticAtTimestamp[f.chainID]
-	require.Equal(t, output, entry.Output)
-	require.Equal(t, eth.OutputRoot(output), entry.OutputRoot)
-	require.Equal(t, l1Origin, entry.RequiredL1)
+	require.Empty(t, resp.OptimisticAtTimestamp)
 }
 
 func TestSuperrootAPI_VerifiedHappyPath(t *testing.T) {
@@ -215,7 +210,12 @@ func TestSuperrootAPI_VerifiedHappyPath(t *testing.T) {
 	require.Equal(t, eth.SuperRoot(expectedSuper), resp.Data.SuperRoot)
 }
 
-func TestSuperrootAPI_VerifiedFallback_SafeDBNotFound(t *testing.T) {
+func TestSuperrootAPI_SafeDBNotFound_OmitsChain(t *testing.T) {
+	// op-supernode parity: when safeDBAtL2 returns ethereum.NotFound (mapped from
+	// ErrL1AtSafeHeadNotFound), both VerifiedAt and OptimisticAt return NotFound and the
+	// chain is OMITTED from OptimisticAtTimestamp. Returning an entry with L1Origin would
+	// understate the requirement and could let op-challenger include the chain at step > 0
+	// where op-supernode would trigger InvalidTransition.
 	f := newFixture(t)
 	f.expectSyncStatus()
 
@@ -223,18 +223,37 @@ func TestSuperrootAPI_VerifiedFallback_SafeDBNotFound(t *testing.T) {
 	hash := common.Hash{0x40}
 	l1Origin := eth.BlockID{Number: 170, Hash: common.Hash{0x17}}
 	f.expectBlockRef(40, hash, l1Origin)
-	output := f.expectOutputV0(hash)
+	f.expectOutputV0(hash)
 
 	// SafeDB returns ErrL1AtSafeHeadNotFound (transient: empty DB or target above latest);
-	// superrootAPI maps it to optimistic-only with L1Origin as RequiredL1.
+	// op-supernode maps this to ethereum.NotFound and OMITS the chain.
 	f.safeDB.ExpectL1AtSafeHead(uint64(40), eth.BlockID{}, eth.BlockID{}, safedb.ErrL1AtSafeHeadNotFound)
 
 	resp, err := f.api.AtTimestamp(context.Background(), hexutil.Uint64(tsVerified))
 	require.NoError(t, err)
-	require.Nil(t, resp.Data) // fallback: Data is nil
-	entry := resp.OptimisticAtTimestamp[f.chainID]
-	require.Equal(t, output, entry.Output)
-	require.Equal(t, l1Origin, entry.RequiredL1)
+	require.Nil(t, resp.Data)
+	require.Empty(t, resp.OptimisticAtTimestamp)
+}
+
+func TestSuperrootAPI_SafeDBUnavailable_ReturnsError(t *testing.T) {
+	// op-supernode parity: ErrL1AtSafeHeadUnavailable (permanent history gap) bubbles up
+	// as ErrHistoryUnavailable from the RPC. Operator must intervene; consumers should not
+	// silently degrade.
+	f := newFixture(t)
+	f.expectSyncStatus()
+
+	tsVerified := testGenesisL2Ts + 40*testBlockTime
+	hash := common.Hash{0x40}
+	l1Origin := eth.BlockID{Number: 170, Hash: common.Hash{0x17}}
+	f.expectBlockRef(40, hash, l1Origin)
+	f.expectOutputV0(hash)
+
+	// SafeDB returns ErrL1AtSafeHeadUnavailable: target predates recorded history.
+	f.safeDB.ExpectL1AtSafeHead(uint64(40), eth.BlockID{}, eth.BlockID{}, safedb.ErrL1AtSafeHeadUnavailable)
+
+	_, err := f.api.AtTimestamp(context.Background(), hexutil.Uint64(tsVerified))
+	require.Error(t, err)
+	require.ErrorIs(t, err, safedb.ErrL1AtSafeHeadUnavailable)
 }
 
 func TestSuperrootAPI_DriverSyncStatusError(t *testing.T) {

--- a/op-node/node/superroot_api_test.go
+++ b/op-node/node/superroot_api_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 
@@ -18,27 +17,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
 )
 
-// superRootProvider mirrors the minimal interface that op-challenger
-// (SuperNodeRootProvider) and op-dispute-mon (SuperRootProvider) require from any
-// `superroot_atTimestamp` server. op-node MUST satisfy it.
-type superRootProvider interface {
-	SuperRootAtTimestamp(ctx context.Context, timestamp uint64) (eth.SuperRootAtTimestampResponse, error)
-}
-
-// superrootAPIQueryAdapter exposes superrootAPI through superRootProvider for
-// compile-time and runtime interface conformance checking. It is NOT registered as
-// an RPC service — placing the SuperRootAtTimestamp method on this adapter (rather
-// than the live *superrootAPI) avoids leaking a `superroot_superRootAtTimestamp`
-// wire method that go-ethereum would auto-register from any exported method on the
-// live struct.
-type superrootAPIQueryAdapter struct{ *superrootAPI }
-
-func (a superrootAPIQueryAdapter) SuperRootAtTimestamp(ctx context.Context, ts uint64) (eth.SuperRootAtTimestampResponse, error) {
-	return a.atTimestamp(ctx, ts)
-}
-
-var _ superRootProvider = superrootAPIQueryAdapter{}
-
 const (
 	testL2ChainID    = 420
 	testGenesisL1Num = uint64(100)
@@ -46,7 +24,6 @@ const (
 	testGenesisL2Ts  = uint64(1000)
 )
 
-// fixture sets up a realistic single-chain SyncStatus and a deterministic OutputV0.
 type fixture struct {
 	cfg        *rollup.Config
 	dr         *mockDriverClient
@@ -111,10 +88,9 @@ func newFixture(t *testing.T) *fixture {
 	}
 }
 
-func (f *fixture) expectSyncStatus() {
-	f.dr.Mock.On("SyncStatus").Return(f.syncStatus)
-}
-
+// expectBlockRef mocks a successful BlockRefWithStatus, returning ref alongside the
+// fixture's syncStatus (the production code uses that status for the response, so
+// callers don't need a separate SyncStatus expectation).
 func (f *fixture) expectBlockRef(blockNum uint64, hash common.Hash, l1Origin eth.BlockID) eth.L2BlockRef {
 	ref := eth.L2BlockRef{
 		Hash:     hash,
@@ -124,6 +100,13 @@ func (f *fixture) expectBlockRef(blockNum uint64, hash common.Hash, l1Origin eth
 	}
 	f.dr.ExpectBlockRefWithStatus(blockNum, ref, f.syncStatus, nil)
 	return ref
+}
+
+// expectBlockMissing mocks BlockRefWithStatus failing for blockNum (e.g. beyond unsafe
+// head) and the SyncStatus fallback that production code makes to populate the response.
+func (f *fixture) expectBlockMissing(blockNum uint64) {
+	f.dr.ExpectBlockRefWithStatus(blockNum, eth.L2BlockRef{}, nil, errors.New("not found"))
+	f.dr.Mock.On("SyncStatus").Return(f.syncStatus)
 }
 
 func (f *fixture) expectOutputV0(hash common.Hash) *eth.OutputV0 {
@@ -137,28 +120,24 @@ func (f *fixture) expectOutputV0(hash common.Hash) *eth.OutputV0 {
 }
 
 func TestSuperrootAPI_PreGenesis(t *testing.T) {
+	// Pre-genesis: rollup.TargetBlockNumber errors. Surface that error directly so
+	// dispute infra (which never legitimately queries before genesis) gets a clear
+	// signal rather than a successful empty response.
 	f := newFixture(t)
-	f.expectSyncStatus()
 
-	// Timestamp before genesis.
-	resp, err := f.api.AtTimestamp(context.Background(), hexutil.Uint64(testGenesisL2Ts-1))
-	require.NoError(t, err)
-	require.Equal(t, []eth.ChainID{f.chainID}, resp.ChainIDs)
-	require.Empty(t, resp.OptimisticAtTimestamp)
-	require.Nil(t, resp.Data)
-	require.Equal(t, f.syncStatus.CurrentL1.ID(), resp.CurrentL1)
-	require.Equal(t, f.syncStatus.SafeL2.Time, resp.CurrentSafeTimestamp)
-	require.Equal(t, f.syncStatus.LocalSafeL2.Time, resp.CurrentLocalSafeTimestamp)
-	require.Equal(t, f.syncStatus.FinalizedL2.Time, resp.CurrentFinalizedTimestamp)
+	_, err := f.api.atTimestamp(context.Background(), testGenesisL2Ts-1)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "target block number")
 }
 
 func TestSuperrootAPI_BeyondUnsafe(t *testing.T) {
 	f := newFixture(t)
-	f.expectSyncStatus()
 
-	// Timestamp maps to block 70, beyond UnsafeL2 (60).
-	tsBeyond := testGenesisL2Ts + 70*testBlockTime
-	resp, err := f.api.AtTimestamp(context.Background(), hexutil.Uint64(tsBeyond))
+	// Block 70: beyond UnsafeL2 (60). BlockRefWithStatus fails; we fall back to
+	// SyncStatus and omit the chain.
+	f.expectBlockMissing(70)
+
+	resp, err := f.api.atTimestamp(context.Background(), testGenesisL2Ts+70*testBlockTime)
 	require.NoError(t, err)
 	require.Equal(t, []eth.ChainID{f.chainID}, resp.ChainIDs)
 	require.Empty(t, resp.OptimisticAtTimestamp)
@@ -166,16 +145,16 @@ func TestSuperrootAPI_BeyondUnsafe(t *testing.T) {
 }
 
 func TestSuperrootAPI_BeyondLocalSafe_OmitsChain(t *testing.T) {
-	// op-supernode parity: blocks beyond LocalSafeL2 are treated as absent for both
-	// verified and optimistic, so the chain is omitted from OptimisticAtTimestamp and
-	// Data is nil. (LocalSafeBlockAtTimestamp returns ethereum.NotFound there, which
-	// makes both VerifiedAt and OptimisticAt fail in op-supernode.)
+	// op-supernode parity: blocks beyond LocalSafeL2 fail both VerifiedAt and OptimisticAt
+	// (LocalSafeBlockAtTimestamp returns ethereum.NotFound), so the chain is omitted from
+	// OptimisticAtTimestamp and Data is nil.
 	f := newFixture(t)
-	f.expectSyncStatus()
 
-	// Block 55: between LocalSafeL2 (50) and UnsafeL2 (60).
-	tsOpt := testGenesisL2Ts + 55*testBlockTime
-	resp, err := f.api.AtTimestamp(context.Background(), hexutil.Uint64(tsOpt))
+	// Block 55: between LocalSafeL2 (50) and UnsafeL2 (60). BlockRefWithStatus succeeds
+	// (block exists) but blockNum > LocalSafeL2 triggers the omit path.
+	f.expectBlockRef(55, common.Hash{0x55}, eth.BlockID{Number: 180})
+
+	resp, err := f.api.atTimestamp(context.Background(), testGenesisL2Ts+55*testBlockTime)
 	require.NoError(t, err)
 	require.Nil(t, resp.Data)
 	require.Empty(t, resp.OptimisticAtTimestamp)
@@ -183,20 +162,16 @@ func TestSuperrootAPI_BeyondLocalSafe_OmitsChain(t *testing.T) {
 
 func TestSuperrootAPI_VerifiedHappyPath(t *testing.T) {
 	f := newFixture(t)
-	f.expectSyncStatus()
 
-	// Block 40: at-or-before LocalSafeL2 (50).
 	tsVerified := testGenesisL2Ts + 40*testBlockTime
 	hash := common.Hash{0x40}
-	l1Origin := eth.BlockID{Number: 170, Hash: common.Hash{0x17}}
-	ref := f.expectBlockRef(40, hash, l1Origin)
+	ref := f.expectBlockRef(40, hash, eth.BlockID{Number: 170, Hash: common.Hash{0x17}})
 	output := f.expectOutputV0(hash)
 
-	// SafeDB.L1AtSafeHead returns the earliest L1 at which the recorded L2 safe head reached target.
 	verifiedL1 := eth.BlockID{Number: 205, Hash: common.Hash{0x20}}
 	f.safeDB.ExpectL1AtSafeHead(uint64(40), verifiedL1, ref.ID(), nil)
 
-	resp, err := f.api.AtTimestamp(context.Background(), hexutil.Uint64(tsVerified))
+	resp, err := f.api.atTimestamp(context.Background(), tsVerified)
 	require.NoError(t, err)
 	require.NotNil(t, resp.Data)
 	require.Equal(t, verifiedL1, resp.Data.VerifiedRequiredL1)
@@ -211,116 +186,72 @@ func TestSuperrootAPI_VerifiedHappyPath(t *testing.T) {
 }
 
 func TestSuperrootAPI_SafeDBNotFound_OmitsChain(t *testing.T) {
-	// op-supernode parity: when safeDBAtL2 returns ethereum.NotFound (mapped from
-	// ErrL1AtSafeHeadNotFound), both VerifiedAt and OptimisticAt return NotFound and the
-	// chain is OMITTED from OptimisticAtTimestamp. Returning an entry with L1Origin would
-	// understate the requirement and could let op-challenger include the chain at step > 0
-	// where op-supernode would trigger InvalidTransition.
+	// SafeDB lag (target above latest, or DB empty) is transient; op-supernode maps it
+	// to ethereum.NotFound and omits the chain.
 	f := newFixture(t)
-	f.expectSyncStatus()
 
-	tsVerified := testGenesisL2Ts + 40*testBlockTime
 	hash := common.Hash{0x40}
-	l1Origin := eth.BlockID{Number: 170, Hash: common.Hash{0x17}}
-	f.expectBlockRef(40, hash, l1Origin)
+	f.expectBlockRef(40, hash, eth.BlockID{Number: 170})
 	f.expectOutputV0(hash)
-
-	// SafeDB returns ErrL1AtSafeHeadNotFound (transient: empty DB or target above latest);
-	// op-supernode maps this to ethereum.NotFound and OMITS the chain.
 	f.safeDB.ExpectL1AtSafeHead(uint64(40), eth.BlockID{}, eth.BlockID{}, safedb.ErrL1AtSafeHeadNotFound)
 
-	resp, err := f.api.AtTimestamp(context.Background(), hexutil.Uint64(tsVerified))
+	resp, err := f.api.atTimestamp(context.Background(), testGenesisL2Ts+40*testBlockTime)
 	require.NoError(t, err)
 	require.Nil(t, resp.Data)
 	require.Empty(t, resp.OptimisticAtTimestamp)
 }
 
 func TestSuperrootAPI_SafeDBUnavailable_ReturnsError(t *testing.T) {
-	// op-supernode parity: ErrL1AtSafeHeadUnavailable (permanent history gap) bubbles up
-	// as ErrHistoryUnavailable from the RPC. Operator must intervene; consumers should not
-	// silently degrade.
+	// Permanent SafeDB gap (target predates recorded history) — op-supernode bubbles
+	// ErrHistoryUnavailable to the RPC; operator must intervene.
 	f := newFixture(t)
-	f.expectSyncStatus()
 
-	tsVerified := testGenesisL2Ts + 40*testBlockTime
 	hash := common.Hash{0x40}
-	l1Origin := eth.BlockID{Number: 170, Hash: common.Hash{0x17}}
-	f.expectBlockRef(40, hash, l1Origin)
+	f.expectBlockRef(40, hash, eth.BlockID{Number: 170})
 	f.expectOutputV0(hash)
-
-	// SafeDB returns ErrL1AtSafeHeadUnavailable: target predates recorded history.
 	f.safeDB.ExpectL1AtSafeHead(uint64(40), eth.BlockID{}, eth.BlockID{}, safedb.ErrL1AtSafeHeadUnavailable)
 
-	_, err := f.api.AtTimestamp(context.Background(), hexutil.Uint64(tsVerified))
-	require.Error(t, err)
+	_, err := f.api.atTimestamp(context.Background(), testGenesisL2Ts+40*testBlockTime)
 	require.ErrorIs(t, err, safedb.ErrL1AtSafeHeadUnavailable)
 }
 
 func TestSuperrootAPI_SafeDBDisabled_Errors(t *testing.T) {
-	// A node started without --safedb.path uses safedb.Disabled. Without an up-front
-	// gate, requests within LocalSafeL2 would surface ErrNotEnabled from the helper
-	// while requests beyond LocalSafeL2 would short-circuit successfully with Data=nil
-	// — operators serving dispute infra would see inconsistent responses. Assert the
-	// handler rejects loudly before doing any work (no SyncStatus / output calls).
+	// A node started without --safedb.path uses safedb.Disabled, whose L1AtSafeHead
+	// returns safedb.ErrNotEnabled. That error must propagate (not degrade to Data nil).
 	f := newFixture(t)
 	api := NewSuperrootAPI(f.cfg, f.l2Client, f.dr, safedb.Disabled, testlog.Logger(t, log.LevelError))
 
-	_, err := api.AtTimestamp(context.Background(), hexutil.Uint64(testGenesisL2Ts+10*testBlockTime))
-	require.ErrorContains(t, err, "safedb not enabled")
+	hash := common.Hash{0x40}
+	f.expectBlockRef(40, hash, eth.BlockID{Number: 170})
+	f.expectOutputV0(hash)
+
+	_, err := api.atTimestamp(context.Background(), testGenesisL2Ts+40*testBlockTime)
+	require.ErrorIs(t, err, safedb.ErrNotEnabled)
 }
 
-func TestSuperrootAPI_DriverSyncStatusError(t *testing.T) {
+func TestSuperrootAPI_DriverError(t *testing.T) {
+	// Driver failures (both the primary BlockRefWithStatus call and the SyncStatus
+	// fallback) surface as a single error from the RPC.
 	f := newFixture(t)
-	// Replace SyncStatus expectation with a failing one.
 	failing := &failingDriver{err: errors.New("drv-fail")}
 	api := NewSuperrootAPI(f.cfg, f.l2Client, failing, f.safeDB, testlog.Logger(t, log.LevelError))
 
-	_, err := api.AtTimestamp(context.Background(), hexutil.Uint64(testGenesisL2Ts+10*testBlockTime))
-	require.ErrorContains(t, err, "syncStatus")
+	_, err := api.atTimestamp(context.Background(), testGenesisL2Ts+10*testBlockTime)
+	require.ErrorContains(t, err, "drv-fail")
 }
 
 func TestSuperrootAPI_OutputClientError(t *testing.T) {
 	f := newFixture(t)
-	f.expectSyncStatus()
 
-	tsVerified := testGenesisL2Ts + 30*testBlockTime
 	hash := common.Hash{0x30}
 	f.expectBlockRef(30, hash, eth.BlockID{Number: 160})
 	f.l2Client.ExpectOutputV0AtBlock(hash, (*eth.OutputV0)(nil), errors.New("output-fail"))
 
-	_, err := f.api.AtTimestamp(context.Background(), hexutil.Uint64(tsVerified))
+	_, err := f.api.atTimestamp(context.Background(), testGenesisL2Ts+30*testBlockTime)
 	require.ErrorContains(t, err, "outputV0AtBlock")
 }
 
-func TestSuperrootAPI_ChainIDsAlwaysSingleEntry(t *testing.T) {
-	for _, ts := range []uint64{
-		testGenesisL2Ts - 1,                // pre-genesis
-		testGenesisL2Ts + 70*testBlockTime, // beyond unsafe
-	} {
-		t.Run("", func(t *testing.T) {
-			f := newFixture(t)
-			f.expectSyncStatus()
-			resp, err := f.api.AtTimestamp(context.Background(), hexutil.Uint64(ts))
-			require.NoError(t, err)
-			require.Len(t, resp.ChainIDs, 1)
-		})
-	}
-}
-
-func TestSuperrootAPI_SuperRootProviderCompat(t *testing.T) {
-	// Compile-time check at package scope (var _ superRootProvider = ...).
-	// Runtime check: invoke through the interface to confirm op-node is drop-in for
-	// op-challenger's SuperNodeRootProvider and op-dispute-mon's SuperRootProvider.
-	f := newFixture(t)
-	f.expectSyncStatus()
-
-	var provider superRootProvider = superrootAPIQueryAdapter{f.api}
-	resp, err := provider.SuperRootAtTimestamp(context.Background(), testGenesisL2Ts-1)
-	require.NoError(t, err)
-	require.Equal(t, []eth.ChainID{f.chainID}, resp.ChainIDs)
-}
-
-// failingDriver is a minimal driverClient stub that returns a configured error from SyncStatus.
+// failingDriver returns a configured error from every driverClient method.
 type failingDriver struct {
 	err error
 }
@@ -341,3 +272,4 @@ func (f *failingDriver) OnUnsafeL2Payload(_ context.Context, _ *eth.ExecutionPay
 func (f *failingDriver) OverrideLeader(_ context.Context) error                               { return f.err }
 func (f *failingDriver) ConductorEnabled(_ context.Context) (bool, error)                     { return false, f.err }
 func (f *failingDriver) SetRecoverMode(_ context.Context, _ bool) error                       { return f.err }
+

--- a/op-node/node/superroot_api_test.go
+++ b/op-node/node/superroot_api_test.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
@@ -102,10 +103,11 @@ func (f *fixture) expectBlockRef(blockNum uint64, hash common.Hash, l1Origin eth
 	return ref
 }
 
-// expectBlockMissing mocks BlockRefWithStatus failing for blockNum (e.g. beyond unsafe
-// head) and the SyncStatus fallback that production code makes to populate the response.
+// expectBlockMissing mocks BlockRefWithStatus returning ethereum.NotFound for blockNum
+// (beyond unsafe head) and the SyncStatus fallback that production code makes to
+// populate the response.
 func (f *fixture) expectBlockMissing(blockNum uint64) {
-	f.dr.ExpectBlockRefWithStatus(blockNum, eth.L2BlockRef{}, nil, errors.New("not found"))
+	f.dr.ExpectBlockRefWithStatus(blockNum, eth.L2BlockRef{}, nil, ethereum.NotFound)
 	f.dr.Mock.On("SyncStatus").Return(f.syncStatus)
 }
 
@@ -229,20 +231,35 @@ func TestSuperrootAPI_SafeDBDisabled_Errors(t *testing.T) {
 	require.ErrorIs(t, err, safedb.ErrNotEnabled)
 }
 
-func TestSuperrootAPI_DriverError(t *testing.T) {
-	// Driver failures (both the primary BlockRefWithStatus call and the SyncStatus
-	// fallback) surface as a single error from the RPC.
+func TestSuperrootAPI_BlockRefError_Propagates(t *testing.T) {
+	// Non-NotFound errors from BlockRefWithStatus (context deadline, EL transport,
+	// driver-loop failures) must fail the RPC rather than degrade to an empty response.
 	f := newFixture(t)
-	failing := &failingDriver{err: errors.New("drv-fail")}
-	api := NewSuperrootAPI(f.cfg, f.l2Client, failing, f.safeDB, testlog.Logger(t, log.LevelError))
+	driverErr := errors.New("driver-loop fail")
+	f.dr.ExpectBlockRefWithStatus(40, eth.L2BlockRef{}, nil, driverErr)
 
-	_, err := api.atTimestamp(context.Background(), testGenesisL2Ts+10*testBlockTime)
-	require.ErrorContains(t, err, "drv-fail")
+	_, err := f.api.atTimestamp(context.Background(), testGenesisL2Ts+40*testBlockTime)
+	require.ErrorIs(t, err, driverErr)
+}
+
+func TestSuperrootAPI_OutputNotFound_OmitsChain(t *testing.T) {
+	// op-supernode parity: OutputV0AtBlock returning ethereum.NotFound omits the
+	// chain (Data nil, no entry); the block exists but the EL hasn't surfaced an
+	// output for it yet.
+	f := newFixture(t)
+	hash := common.Hash{0x40}
+	f.expectBlockRef(40, hash, eth.BlockID{Number: 170})
+	f.l2Client.ExpectOutputV0AtBlock(hash, (*eth.OutputV0)(nil), ethereum.NotFound)
+
+	resp, err := f.api.atTimestamp(context.Background(), testGenesisL2Ts+40*testBlockTime)
+	require.NoError(t, err)
+	require.Nil(t, resp.Data)
+	require.Empty(t, resp.OptimisticAtTimestamp)
 }
 
 func TestSuperrootAPI_OutputClientError(t *testing.T) {
+	// Non-NotFound OutputV0AtBlock errors propagate.
 	f := newFixture(t)
-
 	hash := common.Hash{0x30}
 	f.expectBlockRef(30, hash, eth.BlockID{Number: 160})
 	f.l2Client.ExpectOutputV0AtBlock(hash, (*eth.OutputV0)(nil), errors.New("output-fail"))
@@ -250,26 +267,3 @@ func TestSuperrootAPI_OutputClientError(t *testing.T) {
 	_, err := f.api.atTimestamp(context.Background(), testGenesisL2Ts+30*testBlockTime)
 	require.ErrorContains(t, err, "outputV0AtBlock")
 }
-
-// failingDriver returns a configured error from every driverClient method.
-type failingDriver struct {
-	err error
-}
-
-func (f *failingDriver) SyncStatus(_ context.Context) (*eth.SyncStatus, error) {
-	return nil, f.err
-}
-func (f *failingDriver) BlockRefWithStatus(_ context.Context, _ uint64) (eth.L2BlockRef, *eth.SyncStatus, error) {
-	return eth.L2BlockRef{}, nil, f.err
-}
-func (f *failingDriver) ResetDerivationPipeline(_ context.Context) error       { return f.err }
-func (f *failingDriver) StartSequencer(_ context.Context, _ common.Hash) error { return f.err }
-func (f *failingDriver) StopSequencer(_ context.Context) (common.Hash, error) {
-	return common.Hash{}, f.err
-}
-func (f *failingDriver) SequencerActive(_ context.Context) (bool, error)                      { return false, f.err }
-func (f *failingDriver) OnUnsafeL2Payload(_ context.Context, _ *eth.ExecutionPayloadEnvelope) {}
-func (f *failingDriver) OverrideLeader(_ context.Context) error                               { return f.err }
-func (f *failingDriver) ConductorEnabled(_ context.Context) (bool, error)                     { return false, f.err }
-func (f *failingDriver) SetRecoverMode(_ context.Context, _ bool) error                       { return f.err }
-

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -413,7 +413,9 @@ func (s *Driver) SyncStatus(ctx context.Context) (*eth.SyncStatus, error) {
 
 // BlockRefWithStatus blocks the driver event loop and captures the syncing status,
 // along with an L2 block reference by number consistent with that same status.
-// If the event loop is too busy and the context expires, a context error is returned.
+// If the event loop is too busy and the context expires before the request is
+// accepted, a context error is returned with a nil status. Otherwise the returned
+// status is non-nil, including when ref lookup fails with ethereum.NotFound.
 func (s *Driver) BlockRefWithStatus(ctx context.Context, num uint64) (eth.L2BlockRef, *eth.SyncStatus, error) {
 	resp := s.StatusTracker.SyncStatus()
 	if resp.FinalizedL2.Number >= num { // If finalized, we are certain it does not reorg, and don't have to lock.


### PR DESCRIPTION
## Summary

Adds a `superroot` JSON-RPC namespace on op-node with one method, `superroot_atTimestamp`, mirroring op-supernode's wire contract so op-challenger / op-dispute-mon can point `--supernode-rpc` at op-node on non-interop chains.

Closes #20552 (server side; devstack wiring, acceptance tests, and an op-supernode parity test are follow-ups per the original plan).

## Why

After the super-roots upgrade, fault dispute games on non-interop chains reason over super roots, not output roots. The dispute infra already consumes `superroot_atTimestamp`, but only op-supernode serves it today, and non-interop chains don't run op-supernode.

## Field semantics

- `OptimisticAtTimestamp[chainID].RequiredL1` and `VerifiedRequiredL1` come from `SafeDB.L1AtSafeHead` (the lookup landed in #20845). This value is correctness-critical: op-challenger gates `InvalidTransition` on it.
- L2 genesis is trivially safe at L1 block 0 (not `cfg.Genesis.L1` — contracts may pre-date it). Same special case as op-supernode.
- Error classes: `BlockRefWithStatus` NotFound (block beyond known head) → omit chain, `Data: nil`. `OutputV0AtBlock` NotFound and `SafeDB.L1AtSafeHead` NotFound after a ref has been resolved indicate state inconsistency and propagate as RPC errors. Context errors, EL transport failures, permanent SafeDB gap, and `ErrNotEnabled` (no `--safedb.path`) also propagate.
- Pre-genesis returns the error from `rollup.TargetBlockNumber` rather than a silent empty response.
