### PR TITLE
feat(op-challenger): default vm-timeout to 6h when --age-game-inputs is set

### DIFF
--- a/op-challenger/cmd/run_trace.go
+++ b/op-challenger/cmd/run_trace.go
@@ -44,8 +44,13 @@ func RunTrace(ctx *cli.Context, _ context.CancelCauseFunc) (cliapp.Lifecycle, er
 			runConfigs = append(runConfigs, runner.RunConfig{GameType: gameType})
 		}
 	}
-	vmTimeout := ctx.Duration(VMTimeoutFlag.Name)
 	ageGameInputs := ctx.Bool(AgeGameInputsFlag.Name)
+	vmTimeout := ctx.Duration(VMTimeoutFlag.Name)
+	if !ctx.IsSet(VMTimeoutFlag.Name) && ageGameInputs {
+		// Aged inputs force kona to walk a much deeper L1 history, which roughly doubles
+		// runtime. Bump the default so an unconfigured deployment doesn't hit timeouts.
+		vmTimeout = DefaultVMTimeoutAgedInputs
+	}
 	return runner.NewRunner(logger, cfg, runConfigs, vmTimeout, ageGameInputs), nil
 }
 
@@ -61,7 +66,10 @@ var RunTraceCommand = &cli.Command{
 	Flags:       runTraceFlags(),
 }
 
-const DefaultVMTimeout = 3 * time.Hour
+const (
+	DefaultVMTimeout           = 3 * time.Hour
+	DefaultVMTimeoutAgedInputs = 6 * time.Hour
+)
 
 var (
 	RunTraceRunFlag = &cli.StringSliceFlag{
@@ -76,7 +84,7 @@ var (
 	}
 	VMTimeoutFlag = &cli.DurationFlag{
 		Name:    "vm-timeout",
-		Usage:   fmt.Sprintf("Maximum duration for VM execution per run. Default is %s. Set to 0 to disable timeout.", DefaultVMTimeout),
+		Usage:   fmt.Sprintf("Maximum duration for VM execution per run. Default is %s, or %s when --age-game-inputs is set. Set to 0 to disable timeout.", DefaultVMTimeout, DefaultVMTimeoutAgedInputs),
 		EnvVars: opservice.PrefixEnvVar(flags.EnvVarPrefix, "VM_TIMEOUT"),
 		Value:   DefaultVMTimeout,
 	}


### PR DESCRIPTION
## Summary
- When `--vm-timeout` is not explicitly set and `--age-game-inputs` is enabled, default to 6h instead of 3h.
- Explicit overrides (CLI flag or env var) are preserved unchanged.
- Updates `--vm-timeout` flag usage string to reflect the conditional default.

## Why

`--age-game-inputs` holds the L1 head ~16 days behind chain head and disputes an L2 block whose L1 origin is another ~7 days earlier. The kona client therefore walks a much deeper L1 history than in the un-aged case (~50K headers from the prestate's L1 head back to the agreed L2 head's L1 origin). Wallclock per run roughly doubles vs. the un-aged path.

The existing 3h default is fine without aging but becomes tight once aging is enabled. We've observed mainnet vm-runner timeouts that go away with a 6h timeout. A measured native run with `--age-game-inputs` against op-mainnet finished in 2h43m on commodity hardware (with PR #20576 applied), which puts 3h at almost no headroom and 6h at ~2× headroom — comfortable but not wasteful.

Coupling the default to the flag prevents the surprise: turning on `--age-game-inputs` no longer silently doubles the run time without also nudging the timeout.

## Behavior summary

| `--vm-timeout` set? | `--age-game-inputs` | Effective timeout |
|---|---|---|
| no  | false | 3h (unchanged) |
| no  | true  | **6h (new)** |
| yes | any   | as set (unchanged) |

## Test plan
- [x] `go build ./...` (op-challenger)
- [x] `go test ./op-challenger/cmd/...`
- [ ] Confirm `OP_CHALLENGER_VM_TIMEOUT` env-var override still wins (cli/v2 `IsSet` returns true for env-set flags)