### PR TITLE
fix(op-interop-filter): validate earliest block on resume

### DIFF
--- a/op-interop-filter/filter/logsdb_chain_ingester.go
+++ b/op-interop-filter/filter/logsdb_chain_ingester.go
@@ -310,7 +310,12 @@ func (c *LogsDBChainIngester) GetExecMsgsAtTimestamp(timestamp uint64) ([]Includ
 		return nil, nil
 	}
 
-	if !c.earliestIngestedBlockSet.Load() || blockNum < c.earliestIngestedBlock.Load() {
+	if !c.earliestIngestedBlockSet.Load() {
+		// We have not yet ingested any block with log data. Backfill is in progress
+		// (or hasn't started); we must not silently report "no executing messages".
+		return nil, types.ErrUninitialized
+	}
+	if blockNum < c.earliestIngestedBlock.Load() {
 		return nil, nil
 	}
 
@@ -335,22 +340,47 @@ func (c *LogsDBChainIngester) GetExecMsgsAtTimestamp(timestamp uint64) ([]Includ
 	return results, nil
 }
 
-func (c *LogsDBChainIngester) findAndSetEarliestBlock() {
+// findAndSetEarliestBlock determines the earliest queryable block on resume.
+//
+// The first sealed block is the anchor checkpoint (sealed without log data).
+// The earliest block that can be opened for queries is the block immediately
+// after it. nextBlock is the next block ingestion will attempt (i.e.
+// latestSealed+1) and is used to distinguish two states:
+//
+//   - nextBlock == first+1: the DB contains only the anchor. No blocks with
+//     log data have been ingested yet. We leave earliestIngestedBlockSet false
+//     and let the first successful ingestBlock set it, exactly as in the
+//     fresh-start path.
+//   - nextBlock > first+1: at least one block past the anchor has been sealed,
+//     which under normal operation also means it has log data. We verify with
+//     OpenBlock(first+1); if that fails the DB is in an unexpected state and
+//     we refuse to start rather than serve potentially incorrect query
+//     results.
+func (c *LogsDBChainIngester) findAndSetEarliestBlock(nextBlock uint64) error {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
-	// The first sealed block is the anchor checkpoint. The earliest ingested
-	// block with log data is the next block after it.
 	first, err := c.logsDB.FirstSealedBlock()
 	if err != nil {
-		c.log.Warn("Failed to find first sealed block in DB", "err", err)
-		return
+		return fmt.Errorf("failed to find first sealed block in DB: %w", err)
 	}
 	earliest := first.Number + 1
+
+	if nextBlock == earliest {
+		c.log.Info("DB contains only anchor block; deferring earliest-block tracking to first ingestion",
+			"anchor", first.Number)
+		return nil
+	}
+
+	if _, _, _, err := c.logsDB.OpenBlock(earliest); err != nil {
+		return fmt.Errorf("DB has sealed blocks past anchor %d but earliest %d cannot be opened: %w",
+			first.Number, earliest, err)
+	}
 
 	c.earliestIngestedBlock.Store(earliest)
 	c.earliestIngestedBlockSet.Store(true)
 	c.log.Info("Found earliest block in DB", "block", earliest, "anchor", first.Number)
+	return nil
 }
 
 // calculateStartingBlock returns the block number where ingestion should start,
@@ -522,7 +552,9 @@ func (c *LogsDBChainIngester) initIngestion() (uint64, error) {
 		c.log.Info("Resuming from existing DB", "lastSealed", latestSealed.Number, "resumeFrom", nextBlock)
 
 		if !c.earliestIngestedBlockSet.Load() {
-			c.findAndSetEarliestBlock()
+			if err := c.findAndSetEarliestBlock(nextBlock); err != nil {
+				return 0, fmt.Errorf("failed to determine earliest ingested block: %w", err)
+			}
 		}
 
 		return nextBlock, nil

--- a/op-interop-filter/filter/logsdb_chain_ingester_test.go
+++ b/op-interop-filter/filter/logsdb_chain_ingester_test.go
@@ -698,6 +698,90 @@ func TestLogsDBChainIngester_QueryMethods(t *testing.T) {
 	require.False(t, ok)
 }
 
+// TestLogsDBChainIngester_GetExecMsgsAtTimestamp_AnchorOnly verifies that
+// GetExecMsgsAtTimestamp returns ErrUninitialized when the DB contains only
+// the anchor block (no block with log data has been ingested yet). It must
+// not silently report "no executing messages" in this state.
+func TestLogsDBChainIngester_GetExecMsgsAtTimestamp_AnchorOnly(t *testing.T) {
+	chainID := eth.ChainIDFromUInt64(901)
+	tempDir := t.TempDir()
+
+	mockClient := NewMockEthClient()
+
+	parentBlock := createTestBlock(99, 1198, common.Hash{})
+	mockClient.AddBlock(parentBlock, nil)
+
+	block100 := createTestBlock(100, 1200, parentBlock.Hash())
+	mockClient.AddBlock(block100, createTestReceipts(100, 1))
+
+	ingester := newTestLogsDBChainIngester(t, testIngesterConfig{
+		chainID:   chainID,
+		dataDir:   tempDir,
+		ethClient: mockClient,
+		rollupCfg: testRollupConfig(901, 0, 1000),
+	})
+
+	require.NoError(t, ingester.initLogsDB())
+	t.Cleanup(func() { ingester.logsDB.Close() })
+
+	require.NoError(t, ingester.sealParentBlock(99))
+	require.False(t, ingester.earliestIngestedBlockSet.Load(),
+		"sealParentBlock alone must not mark the ingester initialized")
+
+	// The anchor block is in range (blockNum <= latestSealed) but no block
+	// has been ingested with logs yet, so the lower bound is unset. The
+	// query must surface ErrUninitialized rather than silently returning
+	// (nil, nil) — that distinguishes "we haven't ingested anything yet"
+	// from "no executing messages at this timestamp".
+	_, err := ingester.GetExecMsgsAtTimestamp(1198)
+	require.ErrorIs(t, err, types.ErrUninitialized)
+
+	// Queries past the latest sealed block still return (nil, nil) — that's
+	// the existing "block not sealed yet" semantics, unchanged by this fix.
+	msgs, err := ingester.GetExecMsgsAtTimestamp(1200)
+	require.NoError(t, err)
+	require.Empty(t, msgs)
+}
+
+// TestLogsDBChainIngester_GetExecMsgsAtTimestamp_BeforeEarliest verifies that
+// once the ingester is initialized, queries for blocks older than
+// earliestIngestedBlock return (nil, nil) rather than an error. This is the
+// "we don't have data that old" branch, distinct from "uninitialized".
+func TestLogsDBChainIngester_GetExecMsgsAtTimestamp_BeforeEarliest(t *testing.T) {
+	chainID := eth.ChainIDFromUInt64(901)
+	tempDir := t.TempDir()
+
+	mockClient := NewMockEthClient()
+
+	parentBlock := createTestBlock(99, 1198, common.Hash{})
+	mockClient.AddBlock(parentBlock, nil)
+
+	block100 := createTestBlock(100, 1200, parentBlock.Hash())
+	mockClient.AddBlock(block100, createTestReceipts(100, 1))
+
+	ingester := newTestLogsDBChainIngester(t, testIngesterConfig{
+		chainID:   chainID,
+		dataDir:   tempDir,
+		ethClient: mockClient,
+		rollupCfg: testRollupConfig(901, 0, 1000),
+	})
+
+	require.NoError(t, ingester.initLogsDB())
+	t.Cleanup(func() { ingester.logsDB.Close() })
+
+	require.NoError(t, ingester.sealParentBlock(99))
+	require.NoError(t, ingester.ingestBlock(100))
+
+	require.True(t, ingester.earliestIngestedBlockSet.Load())
+	require.Equal(t, uint64(100), ingester.earliestIngestedBlock.Load())
+
+	// Anchor block 99 (timestamp 1198) is sealed but predates earliest=100.
+	// The query path must distinguish this from the uninitialized state.
+	msgs, err := ingester.GetExecMsgsAtTimestamp(1198)
+	require.NoError(t, err)
+	require.Empty(t, msgs)
+}
+
 // =============================================================================
 // Integration Test: Full Ingestion Flow with Real LogsDB
 // =============================================================================
@@ -918,6 +1002,62 @@ func TestLogsDBChainIngester_InitIngestion_ResumeFromExistingDB(t *testing.T) {
 	require.Equal(t, uint64(102), nextBlock) // Should resume after block 101
 
 	// Verify earliest block was found
+	require.True(t, ingester2.earliestIngestedBlockSet.Load())
+	require.Equal(t, uint64(100), ingester2.earliestIngestedBlock.Load())
+}
+
+// TestLogsDBChainIngester_InitIngestion_ResumeAnchorOnly covers the case where
+// a previous run died after sealing the anchor but before ingesting any block.
+// On resume the DB contains only the anchor, so initIngestion must succeed
+// without setting earliestIngestedBlockSet — ingestion of the first real block
+// will set it, exactly like the fresh-start path.
+func TestLogsDBChainIngester_InitIngestion_ResumeAnchorOnly(t *testing.T) {
+	chainID := eth.ChainIDFromUInt64(901)
+	tempDir := t.TempDir()
+
+	mockClient := NewMockEthClient()
+
+	parentBlock := createTestBlock(99, 1198, common.Hash{})
+	mockClient.AddBlock(parentBlock, nil)
+
+	block100 := createTestBlock(100, 1200, parentBlock.Hash())
+	mockClient.AddBlock(block100, createTestReceipts(100, 1))
+
+	headBlock := createTestBlock(200, 3000, common.Hash{0x99})
+	mockClient.AddBlock(headBlock, nil)
+	mockClient.SetHeadBlock(headBlock)
+
+	// First ingester: seal the anchor only, then close.
+	ingester1 := newTestLogsDBChainIngester(t, testIngesterConfig{
+		chainID:   chainID,
+		dataDir:   tempDir,
+		ethClient: mockClient,
+		rollupCfg: testRollupConfig(901, 0, 1000),
+	})
+	require.NoError(t, ingester1.initLogsDB())
+	require.NoError(t, ingester1.sealParentBlock(99))
+	require.NoError(t, ingester1.logsDB.Close())
+
+	// Second ingester: resume from a DB containing only the anchor.
+	ingester2 := newTestLogsDBChainIngester(t, testIngesterConfig{
+		chainID:   chainID,
+		dataDir:   tempDir,
+		ethClient: mockClient,
+		rollupCfg: testRollupConfig(901, 0, 1000),
+	})
+	require.NoError(t, ingester2.initLogsDB())
+	t.Cleanup(func() { ingester2.logsDB.Close() })
+
+	nextBlock, err := ingester2.initIngestion()
+	require.NoError(t, err)
+	require.Equal(t, uint64(100), nextBlock,
+		"resume should pick up immediately after the anchor")
+
+	require.False(t, ingester2.earliestIngestedBlockSet.Load(),
+		"with only the anchor sealed, earliest must remain unset until first ingestion")
+
+	// Ingesting the first real block then sets earliest, matching the fresh-start path.
+	require.NoError(t, ingester2.ingestBlock(100))
 	require.True(t, ingester2.earliestIngestedBlockSet.Load())
 	require.Equal(t, uint64(100), ingester2.earliestIngestedBlock.Load())
 }


### PR DESCRIPTION
Closes ethereum-optimism/optimism-private#538

Addresses RV audit finding (medium): unchecked edge cases in `findAndSetEarliestBlock`.

`findAndSetEarliestBlock` stored `first.Number+1` as the earliest queryable block on resume without verifying that block was openable, and `GetExecMsgsAtTimestamp` conflated "uninitialized" with "before earliest" (both returned `(nil, nil)`). Combined, these could let the filter silently report "no executing messages" while in a partially-initialized state.

The function now distinguishes:
- DB has only the anchor (e.g. previous run died between `sealParentBlock` and the first `ingestBlock`) → leave the flag unset; the next `ingestBlock` sets it, matching the fresh-start path.
- DB has blocks past the anchor → verify `OpenBlock(first+1)` and fail to start if it errors, rather than serving from an unexpected state.

`GetExecMsgsAtTimestamp` now returns `ErrUninitialized` when the lower bound is unset, distinct from the genuine `(nil, nil)` "before earliest" case. Both call sites (`Backend.CheckAccessList` and the lockstep cross-validator) already gate on `Ready()`, so this branch is defensive — but the existing silent-empty fallback was the audit's concern.