### PR TITLE
fix(op-supervisor): tighten atomicity of logs DB Clear and Rewind

### DIFF
--- a/op-supervisor/supervisor/backend/db/logs/db.go
+++ b/op-supervisor/supervisor/backend/db/logs/db.go
@@ -590,6 +590,13 @@ func (db *DB) AddLog(logHash common.Hash, parentBlock eth.BlockID, logIdx uint32
 // Clear clears the DB such that there is no data left.
 // An invalidator is required as argument, to force users to invalidate any current open reads.
 func (db *DB) Clear(inv reads.Invalidator) error {
+	db.rwLock.Lock()
+	defer db.rwLock.Unlock()
+	return db.clear(inv)
+}
+
+// clear is the unlocked implementation of Clear, for use by callers that already hold rwLock.
+func (db *DB) clear(inv reads.Invalidator) error {
 	release, invalidateErr := inv.TryInvalidate(reads.InvalidationRules{
 		reads.DerivedInvalidation{Timestamp: 0},
 	})
@@ -617,7 +624,7 @@ func (db *DB) Rewind(inv reads.Invalidator, newHead eth.BlockID) error {
 	iter, err := db.newIteratorAt(newHead.Number, 0)
 	if err != nil {
 		if errors.Is(err, types.ErrPreviousToFirst) || errors.Is(err, types.ErrSkipped) {
-			if err := db.Clear(inv); err != nil {
+			if err := db.clear(inv); err != nil {
 				return fmt.Errorf("failed to clear logs DB, upon rewinding to log block %s before first block: %w", newHead, err)
 			}
 			return nil

--- a/op-supervisor/supervisor/backend/db/logs/db.go
+++ b/op-supervisor/supervisor/backend/db/logs/db.go
@@ -645,14 +645,13 @@ func (db *DB) Rewind(inv reads.Invalidator, newHead eth.BlockID) error {
 		return err
 	}
 	defer release()
-	// Truncate to contain idx entries. The Truncate func keeps the given index as last index.
+	// iter has already hydrated the post-rewind logContext by walking up to newHead's seal,
+	// so the only remaining mutation is the truncate itself. If truncate fails the in-memory
+	// state stays consistent with disk; if it succeeds we commit the precomputed context.
 	if err := db.store.Truncate(iter.NextIndex() - 1); err != nil {
 		return fmt.Errorf("failed to truncate to block %s: %w", newHead, err)
 	}
-	// Use db.init() to find the log context for the new latest log entry
-	if err := db.init(true); err != nil {
-		return fmt.Errorf("failed to find new last entry context: %w", err)
-	}
+	db.lastEntryContext = iter.current
 	return nil
 }
 

--- a/op-supervisor/supervisor/backend/db/logs/db_test.go
+++ b/op-supervisor/supervisor/backend/db/logs/db_test.go
@@ -1393,6 +1393,180 @@ func TestRewind(t *testing.T) {
 				requireFuture(t, db, 17, 0, tOffset(17), createHash(42))
 			})
 	})
+
+	t.Run("HashConflictLeavesStateUntouched", func(t *testing.T) {
+		t50, t51, t52 := uint64(500), uint64(502), uint64(504)
+		runDBTest(t,
+			func(t *testing.T, db *DB, m *stubMetrics) {
+				bl50 := eth.BlockID{Hash: createHash(50), Number: 50}
+				require.NoError(t, db.SealBlock(createHash(49), bl50, t50))
+				require.NoError(t, db.AddLog(createHash(1), bl50, 0, nil))
+				bl51 := eth.BlockID{Hash: createHash(51), Number: 51}
+				require.NoError(t, db.SealBlock(bl50.Hash, bl51, t51))
+				require.NoError(t, db.AddLog(createHash(2), bl51, 0, nil))
+				bl52 := eth.BlockID{Hash: createHash(52), Number: 52}
+				require.NoError(t, db.SealBlock(bl51.Hash, bl52, t52))
+
+				before, ok := db.LatestSealedBlock()
+				require.True(t, ok)
+				require.Equal(t, bl52, before)
+
+				// Rewind to block 51 with the wrong hash. Validation must fail
+				// before any mutation, leaving disk and in-memory state untouched.
+				inv := &reads.TestInvalidator{}
+				wrong := eth.BlockID{Hash: createHash(9999), Number: 51}
+				require.ErrorIs(t, db.Rewind(inv, wrong), types.ErrConflict)
+				require.False(t, inv.Invalidated, "validation failure must not invalidate readers")
+
+				after, ok := db.LatestSealedBlock()
+				require.True(t, ok)
+				require.Equal(t, bl52, after, "head must be unchanged after a failed rewind")
+			},
+			func(t *testing.T, db *DB, m *stubMetrics) {
+				// All pre-rewind data must still be present.
+				requireContains(t, db, 51, 0, t51, createHash(1))
+				requireContains(t, db, 52, 0, t52, createHash(2))
+				head, ok := db.LatestSealedBlock()
+				require.True(t, ok)
+				require.Equal(t, uint64(52), head.Number)
+				require.Equal(t, createHash(52), head.Hash)
+			})
+	})
+
+	t.Run("HeadIdentityAcrossCheckpoint", func(t *testing.T) {
+		runDBTest(t,
+			func(t *testing.T, db *DB, m *stubMetrics) {
+				// Build well past a search checkpoint so the rewind target's
+				// preceding checkpoint differs from the pre-rewind tail's checkpoint.
+				bl0 := eth.BlockID{Hash: createHash(0), Number: 0}
+				require.NoError(t, db.SealBlock(createHash(-1), bl0, tOffset(0)))
+				// Logs added on top of bl0 belong to block 1 once bl1 is sealed.
+				for i := uint32(0); m.entryCount < searchCheckpointFrequency*2; i++ {
+					require.NoError(t, db.AddLog(createHash(int(i)), bl0, i, nil))
+				}
+				bl1 := eth.BlockID{Hash: createHash(1), Number: 1}
+				require.NoError(t, db.SealBlock(bl0.Hash, bl1, tOffset(1)))
+				bl2 := eth.BlockID{Hash: createHash(2), Number: 2}
+				require.NoError(t, db.SealBlock(bl1.Hash, bl2, tOffset(2)))
+
+				inv := &reads.TestInvalidator{}
+				require.NoError(t, db.Rewind(inv, bl1))
+				require.True(t, inv.Invalidated)
+				require.Equal(t, tOffset(1), inv.InvalidatedDerivedTimestamp)
+
+				head, ok := db.LatestSealedBlock()
+				require.True(t, ok)
+				require.Equal(t, bl1, head, "head must be exactly the rewind target")
+			},
+			func(t *testing.T, db *DB, m *stubMetrics) {
+				// All block-1 logs must still be present after a checkpoint-crossing rewind.
+				requireContains(t, db, 1, 0, tOffset(1), createHash(0))
+				requireContains(t, db, 1, 5, tOffset(1), createHash(5))
+				// State after rewind must accept new blocks built directly on bl1.
+				bl2alt := eth.BlockID{Hash: createHash(2222), Number: 2}
+				require.NoError(t, db.SealBlock(createHash(1), bl2alt, tOffset(20)))
+				head, ok := db.LatestSealedBlock()
+				require.True(t, ok)
+				require.Equal(t, bl2alt, head)
+			})
+	})
+
+	t.Run("RewindToCurrentHeadIsNoop", func(t *testing.T) {
+		t50, t51 := uint64(500), uint64(502)
+		runDBTest(t,
+			func(t *testing.T, db *DB, m *stubMetrics) {
+				bl50 := eth.BlockID{Hash: createHash(50), Number: 50}
+				require.NoError(t, db.SealBlock(createHash(49), bl50, t50))
+				require.NoError(t, db.AddLog(createHash(1), bl50, 0, nil))
+				bl51 := eth.BlockID{Hash: createHash(51), Number: 51}
+				require.NoError(t, db.SealBlock(bl50.Hash, bl51, t51))
+
+				countBefore := m.entryCount
+				inv := &reads.TestInvalidator{}
+				require.NoError(t, db.Rewind(inv, bl51))
+				require.True(t, inv.Invalidated)
+				require.Equal(t, t51, inv.InvalidatedDerivedTimestamp)
+				require.Equal(t, countBefore, m.entryCount, "no entries should be removed")
+
+				head, ok := db.LatestSealedBlock()
+				require.True(t, ok)
+				require.Equal(t, bl51, head)
+			},
+			func(t *testing.T, db *DB, m *stubMetrics) {
+				requireContains(t, db, 51, 0, t51, createHash(1))
+				// Subsequent writes must work against the unchanged state.
+				bl51 := eth.BlockID{Hash: createHash(51), Number: 51}
+				require.NoError(t, db.AddLog(createHash(99), bl51, 0, nil))
+				bl52 := eth.BlockID{Hash: createHash(52), Number: 52}
+				require.NoError(t, db.SealBlock(bl51.Hash, bl52, uint64(504)))
+				requireContains(t, db, 52, 0, uint64(504), createHash(99))
+			})
+	})
+
+	t.Run("ChainedRewindsAndWrites", func(t *testing.T) {
+		runDBTest(t,
+			func(t *testing.T, db *DB, m *stubMetrics) {
+				// Build a chain of blocks 0..10 where each block contains one log.
+				// AddLog(_, parent, _) writes a log into the next block to be sealed,
+				// so the seal-then-add-then-seal pattern places one log inside block i.
+				prev := common.Hash{}
+				prevID := eth.BlockID{}
+				for i := uint32(0); i <= 10; i++ {
+					if i > 0 {
+						require.NoError(t, db.AddLog(createHash(int(100+i)), prevID, 0, nil))
+					}
+					bl := eth.BlockID{Hash: createHash(int(i)), Number: uint64(i)}
+					require.NoError(t, db.SealBlock(prev, bl, tOffset(int(i))))
+					prev = bl.Hash
+					prevID = bl
+				}
+
+				inv1 := &reads.TestInvalidator{}
+				require.NoError(t, db.Rewind(inv1, createID(5)))
+				require.True(t, inv1.Invalidated)
+				require.Equal(t, tOffset(5), inv1.InvalidatedDerivedTimestamp)
+				head, ok := db.LatestSealedBlock()
+				require.True(t, ok)
+				require.Equal(t, createID(5), head)
+
+				// Build a divergent fork on top of bl5, again with one log per block.
+				prev = createHash(5)
+				prevID = createID(5)
+				for i := uint32(6); i <= 9; i++ {
+					require.NoError(t, db.AddLog(createHash(int(200+i)), prevID, 0, nil))
+					bl := eth.BlockID{Hash: createHash(int(i) + 1000), Number: uint64(i)}
+					require.NoError(t, db.SealBlock(prev, bl, tOffset(int(i)+1000)))
+					prev = bl.Hash
+					prevID = bl
+				}
+
+				// Rewind into the new fork.
+				inv2 := &reads.TestInvalidator{}
+				forked7 := eth.BlockID{Hash: createHash(1007), Number: 7}
+				require.NoError(t, db.Rewind(inv2, forked7))
+				require.True(t, inv2.Invalidated)
+				require.Equal(t, tOffset(1007), inv2.InvalidatedDerivedTimestamp)
+
+				head, ok = db.LatestSealedBlock()
+				require.True(t, ok)
+				require.Equal(t, forked7, head)
+			},
+			func(t *testing.T, db *DB, m *stubMetrics) {
+				// Block 5's log (from the original chain) survives.
+				requireContains(t, db, 5, 0, tOffset(5), createHash(105))
+				// Block 7's log (from the divergent fork) survives.
+				requireContains(t, db, 7, 0, tOffset(1007), createHash(207))
+				// Block 8's log was truncated by the second rewind.
+				requireFuture(t, db, 8, 0, tOffset(1008), createHash(208))
+
+				// Can keep writing on top of the post-rewind head.
+				forked7 := eth.BlockID{Hash: createHash(1007), Number: 7}
+				require.NoError(t, db.AddLog(createHash(31415), forked7, 0, nil))
+				bl8 := eth.BlockID{Hash: createHash(2008), Number: 8}
+				require.NoError(t, db.SealBlock(forked7.Hash, bl8, tOffset(2008)))
+				requireContains(t, db, 8, 0, tOffset(2008), createHash(31415))
+			})
+	})
 }
 
 type stubMetrics struct {


### PR DESCRIPTION
**Claude:** This PR was authored by Claude (AI assistant) on behalf of Adrian.

Two related fixes to the op-supervisor logs DB, both surfaced during analysis of audit finding.

Fixes ethereum-optimism/optimism-private#539.

### `Clear` now acquires the write lock

`Clear` was the only mutator that did not acquire `db.rwLock` — `SealBlock`, `AddLog`, and `Rewind` all hold the write lock for the duration of their mutations. The `reads.Invalidator` blocks *new* reads but does not stop in-flight readers or concurrent writers, so `db.store.Truncate(-1)` could race against them. The body is extracted into an unlocked `clear` helper so `Rewind` (which already holds the write lock) can call it without re-entering the non-reentrant `sync.RWMutex`.

### `Rewind` validates before truncating

`Rewind` previously truncated the entry store and then called `init` to rehydrate the in-memory `logContext`. If `init` returned an error, disk was already truncated while `lastEntryContext` retained its pre-rewind value, leaving the running process serving a stale head until the next successful operation or a restart. This is the audit's literal finding.

The iterator returned by `newIteratorAt` has already walked from a search checkpoint up to and through `newHead`'s seal, so `iter.current` is the hydrated post-rewind `logContext`. Hydration now happens before any disk mutation: validate via the iterator, truncate (the only mutation), assign `iter.current`. If `Truncate` fails, both disk and memory remain consistent; if it succeeds, the precomputed in-memory state is committed alongside.

### Tests

Adds `TestRewind` subtests for the failure-path and edge-case invariants:

- hash-conflict rewind leaves state and invalidator untouched
- head identity preserved across a checkpoint-crossing rewind
- no-op rewind to the current head doesn't change entry count
- chained rewinds with writes between them produce a consistent head at each step

Each runs through both the fresh-DB and the close-and-reopen variants of the existing harness, so the on-disk state after rewind is verified by reconstruction via `init`.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
