### PR TITLE
fix(op-supervisor): fsync logs DB at seal and truncate boundaries

### DIFF
--- a/op-supernode/supernode/activity/interop/algo_test.go
+++ b/op-supernode/supernode/activity/interop/algo_test.go
@@ -913,6 +913,7 @@ func (m *algoMockLogsDB) AddLog(logHash common.Hash, parentBlock eth.BlockID, lo
 func (m *algoMockLogsDB) SealBlock(parentHash common.Hash, block eth.BlockID, timestamp uint64) error {
 	return nil
 }
+func (m *algoMockLogsDB) Sync() error                                             { return nil }
 func (m *algoMockLogsDB) Rewind(inv reads.Invalidator, newHead eth.BlockID) error { return nil }
 func (m *algoMockLogsDB) Clear(inv reads.Invalidator) error                       { return nil }
 func (m *algoMockLogsDB) Close() error                                            { return nil }

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -2569,6 +2569,7 @@ func (m *mockLogsDBWithState) AddLog(logHash common.Hash, parentBlock eth.BlockI
 func (m *mockLogsDBWithState) SealBlock(parentHash common.Hash, block eth.BlockID, timestamp uint64) error {
 	return nil
 }
+func (m *mockLogsDBWithState) Sync() error { return nil }
 func (m *mockLogsDBWithState) Rewind(inv reads.Invalidator, newHead eth.BlockID) error {
 	m.rewindCalled = true
 	return nil
@@ -2673,6 +2674,7 @@ func (m *mockLogsDBForInterop) SealBlock(parentHash common.Hash, block eth.Block
 	m.sealCalls++
 	return nil
 }
+func (m *mockLogsDBForInterop) Sync() error { return nil }
 func (m *mockLogsDBForInterop) Rewind(inv reads.Invalidator, newHead eth.BlockID) error {
 	m.rewindCalls = append(m.rewindCalls, newHead)
 	return nil

--- a/op-supernode/supernode/activity/interop/logdb.go
+++ b/op-supernode/supernode/activity/interop/logdb.go
@@ -35,6 +35,8 @@ type LogsDB interface {
 	AddLog(logHash common.Hash, parentBlock eth.BlockID, logIdx uint32, execMsg *types.ExecutingMessage) error
 	// SealBlock seals a block in the database.
 	SealBlock(parentHash common.Hash, block eth.BlockID, timestamp uint64) error
+	// Sync flushes pending writes to durable storage.
+	Sync() error
 	// Rewind removes all blocks after newHead from the database.
 	Rewind(inv reads.Invalidator, newHead eth.BlockID) error
 	// Clear removes all data from the database.
@@ -140,14 +142,14 @@ func (i *Interop) sealBlockDataIntoLogsDB(chainID eth.ChainID, blockID eth.Block
 		if latestBlock.Number > blockID.Number {
 			seal, err := db.FindSealedBlock(blockID.Number)
 			if err == nil && seal.Hash == blockID.Hash {
-				return nil
+				return db.Sync()
 			}
 			return fmt.Errorf("chain %s: logsDB has stale data at height %d: %w",
 				chainID, blockID.Number, ErrStaleLogsDB)
 		}
 		if latestBlock.Number == blockID.Number {
 			if latestBlock.Hash == blockID.Hash {
-				return nil
+				return db.Sync()
 			}
 			return fmt.Errorf("chain %s: logsDB has block %s at height %d, expected %s: %w",
 				chainID, latestBlock.Hash, latestBlock.Number, blockID.Hash, ErrStaleLogsDB)

--- a/op-supernode/supernode/activity/interop/logdb_test.go
+++ b/op-supernode/supernode/activity/interop/logdb_test.go
@@ -483,6 +483,63 @@ func TestProcessBlockLogs(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "seal failed")
 	})
+
+	t.Run("AlreadySealedBlockSyncsBeforeReturning", func(t *testing.T) {
+		h := newInteropTestHarness(t).WithChain(10, nil).Build()
+		chainID := eth.ChainIDFromUInt64(10)
+		blockID := eth.BlockID{Hash: common.Hash{0x02}, Number: 100}
+		db := &mockLogsDB{
+			latestBlock: blockID,
+			hasBlocks:   true,
+			seal: suptypes.BlockSeal{
+				Hash:      blockID.Hash,
+				Number:    blockID.Number,
+				Timestamp: 1000,
+			},
+		}
+		h.interop.logsDBs[chainID] = db
+
+		blockInfo := &testBlockInfo{
+			hash:       blockID.Hash,
+			parentHash: common.Hash{0x01},
+			number:     blockID.Number,
+			timestamp:  1000,
+		}
+		require.NoError(t, h.interop.sealBlockDataIntoLogsDB(chainID, blockID, blockInfo, nil, 1000, false))
+		require.Equal(t, 1, db.syncCalls)
+		require.Zero(t, db.addLogCalls)
+		require.Empty(t, db.sealBlockCalls)
+	})
+
+	t.Run("AlreadySealedBlockSyncErrorPropagates", func(t *testing.T) {
+		h := newInteropTestHarness(t).WithChain(10, nil).Build()
+		chainID := eth.ChainIDFromUInt64(10)
+		blockID := eth.BlockID{Hash: common.Hash{0x02}, Number: 100}
+		expectedErr := errors.New("sync failed")
+		db := &mockLogsDB{
+			latestBlock: blockID,
+			hasBlocks:   true,
+			syncErr:     expectedErr,
+			seal: suptypes.BlockSeal{
+				Hash:      blockID.Hash,
+				Number:    blockID.Number,
+				Timestamp: 1000,
+			},
+		}
+		h.interop.logsDBs[chainID] = db
+
+		blockInfo := &testBlockInfo{
+			hash:       blockID.Hash,
+			parentHash: common.Hash{0x01},
+			number:     blockID.Number,
+			timestamp:  1000,
+		}
+		err := h.interop.sealBlockDataIntoLogsDB(chainID, blockID, blockInfo, nil, 1000, false)
+		require.ErrorIs(t, err, expectedErr)
+		require.Equal(t, 1, db.syncCalls)
+		require.Zero(t, db.addLogCalls)
+		require.Empty(t, db.sealBlockCalls)
+	})
 }
 
 // =============================================================================
@@ -496,6 +553,8 @@ type mockLogsDB struct {
 	findSealErr    error
 	addLogErr      error
 	sealBlockErr   error
+	syncErr        error
+	syncCalls      int
 	addLogCalls    int
 	sealBlockCalls []*sealBlockCall // Track all SealBlock calls
 
@@ -561,6 +620,11 @@ func (m *mockLogsDB) SealBlock(parentHash common.Hash, block eth.BlockID, timest
 		timestamp:  timestamp,
 	})
 	return m.sealBlockErr
+}
+
+func (m *mockLogsDB) Sync() error {
+	m.syncCalls++
+	return m.syncErr
 }
 
 func (m *mockLogsDB) Rewind(inv reads.Invalidator, newHead eth.BlockID) error { return nil }

--- a/op-supervisor/supervisor/backend/db/entrydb/entry_db.go
+++ b/op-supervisor/supervisor/backend/db/entrydb/entry_db.go
@@ -15,6 +15,7 @@ type EntryStore[T EntryType, E Entry[T]] interface {
 	Read(idx EntryIdx) (E, error)
 	Append(entries ...E) error
 	Truncate(idx EntryIdx) error
+	Sync() error
 	Close() error
 }
 
@@ -46,6 +47,7 @@ type dataAccess interface {
 	io.Writer
 	io.Closer
 	Truncate(size int64) error
+	Sync() error
 }
 
 type EntryDB[T EntryType, E Entry[T], B Binary[T, E]] struct {
@@ -145,9 +147,14 @@ func (e *EntryDB[T, E, B]) Append(entries ...E) error {
 }
 
 // Truncate the database so that the last retained entry is idx. Any entries after idx are deleted.
+// The truncate is always synced to durable storage before returning, so a successful Truncate
+// survives a crash.
 func (e *EntryDB[T, E, B]) Truncate(idx EntryIdx) error {
 	if err := e.data.Truncate((int64(idx) + 1) * int64(e.b.EntrySize())); err != nil {
 		return fmt.Errorf("failed to truncate to entry %v: %w", idx, err)
+	}
+	if err := e.data.Sync(); err != nil {
+		return fmt.Errorf("failed to sync truncate to entry %v: %w", idx, err)
 	}
 	// Update the lastEntryIdx cache
 	e.lastEntryIdx = idx
@@ -159,6 +166,15 @@ func (e *EntryDB[T, E, B]) Truncate(idx EntryIdx) error {
 func (e *EntryDB[T, E, B]) recover() error {
 	if err := e.data.Truncate(e.Size() * int64(e.b.EntrySize())); err != nil {
 		return fmt.Errorf("failed to truncate trailing partial entries: %w", err)
+	}
+	return nil
+}
+
+// Sync flushes any buffered data and metadata to durable storage so that
+// preceding successful Append and Truncate calls survive a crash.
+func (e *EntryDB[T, E, B]) Sync() error {
+	if err := e.data.Sync(); err != nil {
+		return fmt.Errorf("failed to sync entry db: %w", err)
 	}
 	return nil
 }

--- a/op-supervisor/supervisor/backend/db/entrydb/entry_db.go
+++ b/op-supervisor/supervisor/backend/db/entrydb/entry_db.go
@@ -9,6 +9,11 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
+// ErrNotDurable indicates that a local file mutation succeeded, but syncing it
+// to durable storage failed. The mutation is visible to the current process, but
+// future appends should not proceed until Sync succeeds.
+var ErrNotDurable = errors.New("entry db mutation is not durable")
+
 type EntryStore[T EntryType, E Entry[T]] interface {
 	Size() int64
 	LastEntryIdx() EntryIdx
@@ -57,6 +62,7 @@ type EntryDB[T EntryType, E Entry[T], B Binary[T, E]] struct {
 	b B
 
 	cleanupFailedWrite bool
+	pendingSync        bool
 }
 
 // NewEntryDB creates an EntryDB. A new file will be created if the specified path does not exist,
@@ -124,19 +130,29 @@ func (e *EntryDB[T, E, B]) Append(entries ...E) error {
 			return fmt.Errorf("failed to recover from previous write error: %w", truncateErr)
 		}
 	}
+	if err := e.ensureSynced(); err != nil {
+		return fmt.Errorf("failed to sync previous mutation before append: %w", err)
+	}
 	data := make([]byte, 0, len(entries)*e.b.EntrySize())
 	for i := range entries {
 		data = e.b.Append(data, &entries[i])
 	}
-	if n, err := e.data.Write(data); err != nil {
+	if n, err := e.data.Write(data); err != nil || n != len(data) {
+		if err == nil {
+			err = io.ErrShortWrite
+		}
 		if n == 0 {
 			// Didn't write any data, so no recovery required
 			return err
 		}
 		// Try to rollback the partially written data
 		if truncateErr := e.Truncate(e.lastEntryIdx); truncateErr != nil {
-			// Failed to rollback, set a flag to attempt the clean up on the next write
-			e.cleanupFailedWrite = true
+			// Failed to roll back the local file mutation, so retry clean up on the next write.
+			// If only the rollback sync failed, the local file length is already restored and
+			// pendingSync will block future appends until the rollback is durable.
+			if !errors.Is(truncateErr, ErrNotDurable) {
+				e.cleanupFailedWrite = true
+			}
 			return errors.Join(err, fmt.Errorf("failed to remove partially written data: %w", truncateErr))
 		}
 		// Successfully rolled back the changes, still report the failed write
@@ -147,18 +163,19 @@ func (e *EntryDB[T, E, B]) Append(entries ...E) error {
 }
 
 // Truncate the database so that the last retained entry is idx. Any entries after idx are deleted.
-// The truncate is always synced to durable storage before returning, so a successful Truncate
-// survives a crash.
+// The local file size and cached last entry index are updated as soon as the truncate syscall succeeds.
+// If the following sync fails, ErrNotDurable is returned and future appends are blocked until Sync succeeds.
 func (e *EntryDB[T, E, B]) Truncate(idx EntryIdx) error {
 	if err := e.data.Truncate((int64(idx) + 1) * int64(e.b.EntrySize())); err != nil {
 		return fmt.Errorf("failed to truncate to entry %v: %w", idx, err)
 	}
-	if err := e.data.Sync(); err != nil {
-		return fmt.Errorf("failed to sync truncate to entry %v: %w", idx, err)
-	}
-	// Update the lastEntryIdx cache
+	// Update the cache as soon as the local truncate succeeds. Even if Sync below
+	// fails, later reads and writes in this process observe the truncated file.
 	e.lastEntryIdx = idx
 	e.cleanupFailedWrite = false
+	if err := e.Sync(); err != nil {
+		return fmt.Errorf("failed to sync truncate to entry %v: %w", idx, err)
+	}
 	return nil
 }
 
@@ -167,16 +184,25 @@ func (e *EntryDB[T, E, B]) recover() error {
 	if err := e.data.Truncate(e.Size() * int64(e.b.EntrySize())); err != nil {
 		return fmt.Errorf("failed to truncate trailing partial entries: %w", err)
 	}
-	return nil
+	return e.Sync()
 }
 
 // Sync flushes any buffered data and metadata to durable storage so that
 // preceding successful Append and Truncate calls survive a crash.
 func (e *EntryDB[T, E, B]) Sync() error {
 	if err := e.data.Sync(); err != nil {
-		return fmt.Errorf("failed to sync entry db: %w", err)
+		e.pendingSync = true
+		return errors.Join(ErrNotDurable, fmt.Errorf("failed to sync entry db: %w", err))
 	}
+	e.pendingSync = false
 	return nil
+}
+
+func (e *EntryDB[T, E, B]) ensureSynced() error {
+	if !e.pendingSync {
+		return nil
+	}
+	return e.Sync()
 }
 
 func (e *EntryDB[T, E, B]) Close() error {

--- a/op-supervisor/supervisor/backend/db/entrydb/entry_db_test.go
+++ b/op-supervisor/supervisor/backend/db/entrydb/entry_db_test.go
@@ -212,6 +212,54 @@ func TestWriteErrors(t *testing.T) {
 	})
 }
 
+func TestSyncErrors(t *testing.T) {
+	expectedErr := errors.New("sync failed")
+
+	t.Run("TruncateSyncFailureUpdatesLocalIndexAndBlocksAppend", func(t *testing.T) {
+		db, stubData := createEntryDBWithStubData()
+		require.NoError(t, db.Append(createEntry(1), createEntry(2)))
+
+		stubData.syncErr = expectedErr
+		err := db.Truncate(0)
+		require.ErrorIs(t, err, expectedErr)
+		require.ErrorIs(t, err, ErrNotDurable)
+		require.EqualValues(t, 1, db.Size(), "local index should match successful truncate")
+		require.Len(t, stubData.data, TestEntrySize, "local data should be truncated")
+		_, err = db.Read(1)
+		require.ErrorIs(t, err, io.EOF)
+
+		err = db.Append(createEntry(3))
+		require.ErrorIs(t, err, expectedErr, "append should not proceed while prior truncate is not durable")
+		require.EqualValues(t, 1, db.Size())
+		require.Len(t, stubData.data, TestEntrySize)
+
+		stubData.syncErr = nil
+		require.NoError(t, db.Append(createEntry(3)))
+		require.EqualValues(t, 2, db.Size())
+		requireRead(t, db, 1, createEntry(3))
+	})
+
+	t.Run("SyncFailureBlocksAppendUntilRetried", func(t *testing.T) {
+		db, stubData := createEntryDBWithStubData()
+		require.NoError(t, db.Append(createEntry(1)))
+
+		stubData.syncErr = expectedErr
+		err := db.Sync()
+		require.ErrorIs(t, err, expectedErr)
+		require.ErrorIs(t, err, ErrNotDurable)
+
+		err = db.Append(createEntry(2))
+		require.ErrorIs(t, err, expectedErr, "append should first retry the failed sync")
+		require.EqualValues(t, 1, db.Size())
+		require.Len(t, stubData.data, TestEntrySize)
+
+		stubData.syncErr = nil
+		require.NoError(t, db.Append(createEntry(2)))
+		require.EqualValues(t, 2, db.Size())
+		requireRead(t, db, 1, createEntry(2))
+	})
+}
+
 func requireRead(t *testing.T, db *TestEntryDB, idx EntryIdx, expected TestEntry) {
 	actual, err := db.Read(idx)
 	require.NoError(t, err)
@@ -243,6 +291,7 @@ type stubDataAccess struct {
 	writeErr           error
 	writeErrAfterBytes int
 	truncateErr        error
+	syncErr            error
 }
 
 func (s *stubDataAccess) ReadAt(p []byte, off int64) (n int, err error) {
@@ -271,6 +320,9 @@ func (s *stubDataAccess) Truncate(size int64) error {
 }
 
 func (s *stubDataAccess) Sync() error {
+	if s.syncErr != nil {
+		return s.syncErr
+	}
 	return nil
 }
 

--- a/op-supervisor/supervisor/backend/db/entrydb/entry_db_test.go
+++ b/op-supervisor/supervisor/backend/db/entrydb/entry_db_test.go
@@ -270,4 +270,8 @@ func (s *stubDataAccess) Truncate(size int64) error {
 	return nil
 }
 
+func (s *stubDataAccess) Sync() error {
+	return nil
+}
+
 var _ dataAccess = (*stubDataAccess)(nil)

--- a/op-supervisor/supervisor/backend/db/entrydb/memdb.go
+++ b/op-supervisor/supervisor/backend/db/entrydb/memdb.go
@@ -34,6 +34,10 @@ func (s *MemEntryStore[T, E]) Truncate(idx EntryIdx) error {
 	return nil
 }
 
+func (s *MemEntryStore[T, E]) Sync() error {
+	return nil
+}
+
 func (s *MemEntryStore[T, E]) Close() error {
 	return nil
 }

--- a/op-supervisor/supervisor/backend/db/logs/db.go
+++ b/op-supervisor/supervisor/backend/db/logs/db.go
@@ -615,6 +615,9 @@ func (db *DB) clear(inv reads.Invalidator) error {
 	defer release()
 	defer db.updateEntryCountMetric()
 	if truncateErr := db.store.Truncate(-1); truncateErr != nil {
+		if errors.Is(truncateErr, entrydb.ErrNotDurable) {
+			db.lastEntryContext = logContext{}
+		}
 		return fmt.Errorf("failed to empty DB: %w", truncateErr)
 	}
 	db.lastEntryContext = logContext{}
@@ -654,10 +657,13 @@ func (db *DB) Rewind(inv reads.Invalidator, newHead eth.BlockID) error {
 		return err
 	}
 	defer release()
-	// iter has already hydrated the post-rewind logContext by walking up to newHead's seal,
-	// so the only remaining mutation is the truncate itself. If truncate fails the in-memory
-	// state stays consistent with disk; if it succeeds we commit the precomputed context.
+	// iter has already hydrated the post-rewind logContext by walking up to newHead's seal.
+	// If the local truncate succeeds but the sync fails, commit the precomputed context so
+	// in-memory state still matches the locally visible file length.
 	if err := db.store.Truncate(iter.NextIndex() - 1); err != nil {
+		if errors.Is(err, entrydb.ErrNotDurable) {
+			db.lastEntryContext = iter.current
+		}
 		return fmt.Errorf("failed to truncate to block %s: %w", newHead, err)
 	}
 	db.lastEntryContext = iter.current
@@ -674,4 +680,13 @@ func (db *DB) readSearchCheckpoint(entryIdx entrydb.EntryIdx) (searchCheckpoint,
 
 func (db *DB) Close() error {
 	return db.store.Close()
+}
+
+func (db *DB) Sync() error {
+	db.rwLock.Lock()
+	defer db.rwLock.Unlock()
+	if err := db.store.Sync(); err != nil {
+		return fmt.Errorf("failed to sync logs DB: %w", err)
+	}
+	return nil
 }

--- a/op-supervisor/supervisor/backend/db/logs/db.go
+++ b/op-supervisor/supervisor/backend/db/logs/db.go
@@ -552,7 +552,11 @@ func (db *DB) debugTip() {
 	}
 }
 
-func (db *DB) flush() error {
+// flush appends any buffered entries to the store. If sync is true the caller is asking for a
+// durability boundary (e.g. a seal): the appended entries are fsynced before flush returns, so
+// a crash after this point cannot lose them. Logs added between seals (sync=false) are
+// re-derivable from chain receipts on restart, so syncing per-log is unnecessary.
+func (db *DB) flush(sync bool) error {
 	for i, e := range db.lastEntryContext.out {
 		db.log.Trace("appending entry", "type", e.Type(), "entry", hexutil.Bytes(e[:]),
 			"next", int(db.lastEntryContext.nextEntryIndex)-len(db.lastEntryContext.out)+i)
@@ -562,6 +566,11 @@ func (db *DB) flush() error {
 	}
 	db.lastEntryContext.out = db.lastEntryContext.out[:0]
 	db.updateEntryCountMetric()
+	if sync {
+		if err := db.store.Sync(); err != nil {
+			return fmt.Errorf("failed to sync entries: %w", err)
+		}
+	}
 	return nil
 }
 
@@ -573,7 +582,7 @@ func (db *DB) SealBlock(parentHash common.Hash, block eth.BlockID, timestamp uin
 		return fmt.Errorf("failed to seal block: %w", err)
 	}
 	db.log.Trace("Sealed block", "parent", parentHash, "block", block, "timestamp", timestamp)
-	return db.flush()
+	return db.flush(true)
 }
 
 func (db *DB) AddLog(logHash common.Hash, parentBlock eth.BlockID, logIdx uint32, execMsg *types.ExecutingMessage) error {
@@ -584,7 +593,7 @@ func (db *DB) AddLog(logHash common.Hash, parentBlock eth.BlockID, logIdx uint32
 		return fmt.Errorf("failed to apply log: %w", err)
 	}
 	db.log.Trace("Applied log", "parentBlock", parentBlock, "logIndex", logIdx, "logHash", logHash, "executing", execMsg != nil)
-	return db.flush()
+	return db.flush(false)
 }
 
 // Clear clears the DB such that there is no data left.

--- a/op-supervisor/supervisor/backend/db/logs/db.go
+++ b/op-supervisor/supervisor/backend/db/logs/db.go
@@ -117,8 +117,26 @@ func (db *DB) trimToLastSealed() error {
 		if err != nil {
 			return fmt.Errorf("failed to read %v to check for trailing entries: %w", i, err)
 		}
-		if entry.Type() == TypeCanonicalHash {
-			// only an executing hash, indicating a sealed block, is a valid point for restart
+		if entry.Type() != TypeCanonicalHash {
+			continue
+		}
+		if i == 0 {
+			continue
+		}
+		checkpointEntry, err := db.store.Read(i - 1)
+		if err != nil {
+			return fmt.Errorf("failed to read checkpoint before canonical hash %v: %w", i, err)
+		}
+		if checkpointEntry.Type() != TypeSearchCheckpoint {
+			continue
+		}
+		checkpoint, err := newSearchCheckpointFromEntry(checkpointEntry)
+		if err != nil {
+			return fmt.Errorf("failed to decode checkpoint before canonical hash %v: %w", i, err)
+		}
+		if checkpoint.logsSince == 0 {
+			// Only a canonical hash after a zero-log checkpoint is a sealed block boundary.
+			// Periodic checkpoints inside an unsealed block also have canonical hashes.
 			break
 		}
 	}

--- a/op-supervisor/supervisor/backend/db/logs/db_test.go
+++ b/op-supervisor/supervisor/backend/db/logs/db_test.go
@@ -1079,6 +1079,35 @@ func TestRecoverOnCreate(t *testing.T) {
 		require.EqualValues(t, int64(2), m.entryCount)
 	})
 
+	t.Run("TruncateWhenLastEntryIsUnsealedPeriodicCanonicalHash", func(t *testing.T) {
+		// Periodic search checkpoints also write a canonical hash, but they are not
+		// safe restart points when they include logs from an unsealed block.
+		store := storeWithEvents(
+			newSearchCheckpoint(0, 0, 100).encode(),
+			newCanonicalHash(createHash(344)).encode(),
+			newInitiatingEvent(createHash(0), false).encode(),
+			newSearchCheckpoint(0, 1, 100).encode(),
+			newCanonicalHash(createHash(344)).encode(),
+		)
+		_, m, err := createDb(t, store)
+		require.NoError(t, err)
+		require.EqualValues(t, int64(2), m.entryCount)
+	})
+
+	t.Run("NoTruncateWhenLastEntryIsBoundarySearchCheckpointCanonicalHash", func(t *testing.T) {
+		// A periodic checkpoint exactly at a block boundary repeats the sealed
+		// state and remains a safe restart point.
+		store := storeWithEvents(
+			newSearchCheckpoint(0, 0, 100).encode(),
+			newCanonicalHash(createHash(344)).encode(),
+			newSearchCheckpoint(0, 0, 100).encode(),
+			newCanonicalHash(createHash(344)).encode(),
+		)
+		_, m, err := createDb(t, store)
+		require.NoError(t, err)
+		require.EqualValues(t, int64(4), m.entryCount)
+	})
+
 	t.Run("TruncateWhenLastEntryInitEventWithExecMsg", func(t *testing.T) {
 		// An initiating event that claims an executing message,
 		// without said executing message, is dropped.


### PR DESCRIPTION
**Claude:** This PR was authored by Claude (AI assistant) on behalf of Adrian.

Stacked on #20586. Addresses logs DB durability and recovery concerns surfaced while investigating audit finding ethereum-optimism/optimism-private#539.

### What changed

- `EntryDB.Truncate` now fsyncs before returning. Truncate is a metadata change with no useful non-durable success mode for logs DB callers.
- `EntryStore` now exposes `Sync()`, and logs DB `SealBlock` syncs after appending seal entries. `AddLog` still avoids per-log sync because unsealed-block logs are re-derivable from receipts.
- `EntryDB` now fails closed after sync failures. If a local mutation succeeds but fsync fails, it returns `ErrNotDurable`, records the pending sync state, and blocks future appends until `Sync()` succeeds.
- Logs DB `Clear` and `Rewind` keep in-memory state aligned with the locally visible file when truncate succeeds but the durability sync fails.
- Supernode idempotent already-sealed handling now calls `Sync()` before returning success, so a previous seal sync failure is retried instead of being silently accepted.
- `trimToLastSealed` now only treats a canonical hash as a safe restart point when it immediately follows a `SearchCheckpoint` with `logsSince == 0`. Periodic checkpoints inside an unsealed block also write canonical hashes, but are not valid sealed restart boundaries.

### Recovery story

On startup, logs DB recovery trims back to the last actual sealed block boundary and discards any trailing unsealed work. A successful `SealBlock` is now durable before it is reported as successful. If fsync fails after a local file mutation, the caller receives an error and the DB refuses to append more entries until durability is re-established.

This is not full rollback-style transactionality for every possible storage failure. If a write or truncate syscall succeeds and the later fsync fails, the local file mutation is already visible and crash persistence is inherently ambiguous. The PR handles that case by failing closed rather than continuing with memory and disk out of sync.

### Validation

```bash
go test ./op-supervisor/supervisor/backend/db/... ./op-supernode/supernode/activity/interop
```

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>