### PR TITLE
[codex] fix logs DB append atomicity

### DIFF
--- a/op-supervisor/supervisor/backend/db/logs/db.go
+++ b/op-supervisor/supervisor/backend/db/logs/db.go
@@ -552,15 +552,16 @@ func (db *DB) debugTip() {
 	}
 }
 
-func (db *DB) flush() error {
-	for i, e := range db.lastEntryContext.out {
+func (db *DB) flush(next *logContext) error {
+	for i, e := range next.out {
 		db.log.Trace("appending entry", "type", e.Type(), "entry", hexutil.Bytes(e[:]),
-			"next", int(db.lastEntryContext.nextEntryIndex)-len(db.lastEntryContext.out)+i)
+			"next", int(next.nextEntryIndex)-len(next.out)+i)
 	}
-	if err := db.store.Append(db.lastEntryContext.out...); err != nil {
+	if err := db.store.Append(next.out...); err != nil {
 		return fmt.Errorf("failed to append entries: %w", err)
 	}
-	db.lastEntryContext.out = db.lastEntryContext.out[:0]
+	next.out = next.out[:0]
+	db.lastEntryContext = *next
 	db.updateEntryCountMetric()
 	return nil
 }
@@ -569,22 +570,24 @@ func (db *DB) SealBlock(parentHash common.Hash, block eth.BlockID, timestamp uin
 	db.rwLock.Lock()
 	defer db.rwLock.Unlock()
 
-	if err := db.lastEntryContext.SealBlock(parentHash, block, timestamp); err != nil {
+	next := db.lastEntryContext
+	if err := next.SealBlock(parentHash, block, timestamp); err != nil {
 		return fmt.Errorf("failed to seal block: %w", err)
 	}
 	db.log.Trace("Sealed block", "parent", parentHash, "block", block, "timestamp", timestamp)
-	return db.flush()
+	return db.flush(&next)
 }
 
 func (db *DB) AddLog(logHash common.Hash, parentBlock eth.BlockID, logIdx uint32, execMsg *types.ExecutingMessage) error {
 	db.rwLock.Lock()
 	defer db.rwLock.Unlock()
 
-	if err := db.lastEntryContext.ApplyLog(parentBlock, logIdx, logHash, execMsg); err != nil {
+	next := db.lastEntryContext
+	if err := next.ApplyLog(parentBlock, logIdx, logHash, execMsg); err != nil {
 		return fmt.Errorf("failed to apply log: %w", err)
 	}
 	db.log.Trace("Applied log", "parentBlock", parentBlock, "logIndex", logIdx, "logHash", logHash, "executing", execMsg != nil)
-	return db.flush()
+	return db.flush(&next)
 }
 
 // Clear clears the DB such that there is no data left.

--- a/op-supervisor/supervisor/backend/db/logs/db_test.go
+++ b/op-supervisor/supervisor/backend/db/logs/db_test.go
@@ -2,6 +2,7 @@ package logs
 
 import (
 	"encoding/binary"
+	"errors"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -1569,6 +1570,58 @@ func TestRewind(t *testing.T) {
 	})
 }
 
+func TestAppendFailureLeavesStateUntouched(t *testing.T) {
+	createDB := func(t *testing.T) (*DB, *failingAppendStore) {
+		t.Helper()
+		store := &failingAppendStore{
+			MemEntryStore: &entrydb.MemEntryStore[EntryType, Entry]{},
+		}
+		db, err := NewFromEntryStore(testlog.Logger(t, log.LvlTrace), &stubMetrics{}, eth.ChainIDFromUInt64(123), store, false)
+		require.NoError(t, err)
+		return db, store
+	}
+
+	t.Run("SealBlock", func(t *testing.T) {
+		db, store := createDB(t)
+		appendErr := errors.New("append failed")
+		store.appendErr = appendErr
+
+		genesis := createID(0)
+		require.ErrorIs(t, db.SealBlock(common.Hash{}, genesis, 100), appendErr)
+		head, ok := db.LatestSealedBlock()
+		require.False(t, ok, "failed seal must not advance in-memory head")
+		require.Equal(t, eth.BlockID{}, head)
+		require.EqualValues(t, 0, store.Size(), "failed seal must not append entries")
+
+		store.appendErr = nil
+		require.NoError(t, db.SealBlock(common.Hash{}, genesis, 100), "same seal should be retryable")
+		head, ok = db.LatestSealedBlock()
+		require.True(t, ok)
+		require.Equal(t, genesis, head)
+	})
+
+	t.Run("AddLog", func(t *testing.T) {
+		db, store := createDB(t)
+		genesis := createID(0)
+		require.NoError(t, db.SealBlock(common.Hash{}, genesis, 100))
+		entryCountBefore := store.Size()
+
+		appendErr := errors.New("append failed")
+		store.appendErr = appendErr
+		require.ErrorIs(t, db.AddLog(createHash(1), genesis, 0, nil), appendErr)
+		require.Equal(t, entryCountBefore, store.Size(), "failed log append must not append entries")
+		head, ok := db.LatestSealedBlock()
+		require.True(t, ok)
+		require.Equal(t, genesis, head, "failed log append must not advance in-memory state")
+
+		store.appendErr = nil
+		require.NoError(t, db.AddLog(createHash(1), genesis, 0, nil), "same log should be retryable")
+		bl1 := createID(1)
+		require.NoError(t, db.SealBlock(genesis.Hash, bl1, 101))
+		requireContains(t, db, 1, 0, 101, createHash(1))
+	})
+}
+
 type stubMetrics struct {
 	entryCount           int64
 	entriesReadForSearch int64
@@ -1585,3 +1638,17 @@ func (s *stubMetrics) RecordDBSearchEntriesRead(count int64) {
 var _ Metrics = (*stubMetrics)(nil)
 
 var _ entrydb.EntryStore[EntryType, Entry] = (*entrydb.MemEntryStore[EntryType, Entry])(nil)
+
+type failingAppendStore struct {
+	*entrydb.MemEntryStore[EntryType, Entry]
+	appendErr error
+}
+
+func (s *failingAppendStore) Append(entries ...Entry) error {
+	if s.appendErr != nil {
+		return s.appendErr
+	}
+	return s.MemEntryStore.Append(entries...)
+}
+
+var _ entrydb.EntryStore[EntryType, Entry] = (*failingAppendStore)(nil)


### PR DESCRIPTION
## Summary

- Make logs DB append mutators build a candidate logContext and commit it only after EntryStore.Append succeeds.
- Keep failed AddLog and SealBlock attempts from advancing the live in-memory head/log state.
- Add regression coverage with a failing append store to verify failed writes are retryable.

## Performance

This does not add another disk write or wait path. AddLog and SealBlock already synchronously wait for EntryStore.Append before returning. The change adds one small logContext struct copy per append mutation and preserves the existing staged-entry slice behavior; it does not deep-copy entry buffers. The expected performance impact is negligible compared with the existing entry encoding and append I/O.

## Validation

- go test ./op-supervisor/supervisor/backend/db/logs
- go test -race ./op-supervisor/supervisor/backend/db/logs

Builds on #20586 and extends the atomicity fix to append-based logs DB mutators.