### PR TITLE
docs: clarify historical proofs are required for permissioned chains

### DIFF
--- a/docs/public-docs/node-operators/tutorials/reth-historical-proofs.mdx
+++ b/docs/public-docs/node-operators/tutorials/reth-historical-proofs.mdx
@@ -42,7 +42,7 @@ A `BlockChangeSet` reverse index enables efficient pruning: given a block number
 
 ## Prerequisites
 
-*   op-reth v2.1.0 or above.
+*   [op-reth v2.2.3 or later](https://github.com/ethereum-optimism/optimism/releases/tag/op-reth%2Fv2.2.3) — required to enable historical proofs v2 (`--proofs-history.storage-version=v2`).
 *   An op-reth datadir, either initialized from genesis or restored from a [snapshot](https://datadirs.optimism.io/) (covered in the next two sections).
 *   Basic understanding of [execution client configuration](/node-operators/guides/configuration/execution-clients).
 *   Sufficient disk: estimate `chain_size + 20% buffer` for the proofs database (e.g., ~1 TB for 4 weeks on Base at 2s block time).
@@ -224,6 +224,7 @@ When this happens, op-reth exits with an error indicating the number of blocks t
 op-reth proofs prune \
   --datadir /path/to/reth-datadir \
   --proofs-history.storage-path /path/to/proofs-db \
+  --proofs-history.storage-version v2 \
   --proofs-history.window 1296000
 ```
 
@@ -235,6 +236,7 @@ Recover from corruption by reverting the proofs database to a specific block:
 op-reth proofs unwind \
   --datadir /path/to/reth-datadir \
   --proofs-history.storage-path /path/to/proofs-db \
+  --proofs-history.storage-version v2 \
   --target <BLOCK_NUMBER>
 ```
 
@@ -255,5 +257,6 @@ Benchmarked on Base Sepolia (~700k block window, WETH contract):
 
 ## Next steps
 
+*   See the [op-reth v2.2.3 release notes](https://github.com/ethereum-optimism/optimism/releases/tag/op-reth%2Fv2.2.3) for the change that introduced the historical proof store (v2).
 *   See the [op-reth historical proof configuration reference](/node-operators/reference/op-reth-historical-proof-config) for the full set of `--proofs-history.*` flags, management commands, RPC endpoints, and Prometheus metrics.
 *   See the [op-reth configuration reference](/node-operators/reference/op-reth-config) for all standard op-reth flags inherited by this fork.

--- a/docs/public-docs/node-operators/tutorials/reth-historical-proofs.mdx
+++ b/docs/public-docs/node-operators/tutorials/reth-historical-proofs.mdx
@@ -11,7 +11,7 @@ Use historical proofs storage format v2 by setting `--proofs-history.storage-ver
 
 ## Problem
 
-Reth's default `eth_getProof` implementation works by reverting in-memory state diffs backward from the current tip. For blocks older than ~7 days, this causes unbounded memory growth and out-of-memory (OOM) crashes — a critical issue for infrastructure serving rollup fault proofs and indexers that query historical state.
+Reth's default `eth_getProof` implementation works by reverting in-memory state diffs backward from the current tip. The `--rpc.eth-proof-window <num_blocks>` flag (default 0) allows queries against older blocks via this reconstruction, but performance and memory cost grow the further back the query reaches — making it impractical for any meaningful historical window. This is a critical issue for infrastructure serving rollup fault proofs, withdrawal proving, and indexers that query historical state.
 
 ## Solution
 
@@ -130,6 +130,10 @@ Once initialized, you can start the execution client with the `--proofs-history`
 
 <Info>
 Make sure to include all other standard flags required for your network (e.g., specific bootnodes). See the configuration reference for details.
+</Info>
+
+<Info>
+The default `--proofs-history.window` is **1,296,000 blocks**, corresponding to ~30 days at 2s block times. For chains with a different block time, set `--proofs-history.window=<num_blocks>` explicitly using `target_retention_seconds / block_time_seconds`.
 </Info>
 
 ## Running Consensus Node

--- a/docs/public-docs/node-operators/tutorials/reth-historical-proofs.mdx
+++ b/docs/public-docs/node-operators/tutorials/reth-historical-proofs.mdx
@@ -11,7 +11,7 @@ Use historical proofs storage format v2 by setting `--proofs-history.storage-ver
 
 ## Problem
 
-Reth's default `eth_getProof` implementation works by reverting in-memory state diffs backward from the current tip. The `--rpc.eth-proof-window <num_blocks>` flag (default 0) allows queries against older blocks via this reconstruction, but performance and memory cost grow the further back the query reaches — making it impractical for any meaningful historical window. This is a critical issue for infrastructure serving rollup fault proofs, withdrawal proving, and indexers that query historical state.
+Reth's default eth_getProof implementation works by reverting in-memory state diffs backward from the current tip. The --rpc.eth-proof-window <num_blocks> flag (default 0) controls how far back from the current tip the node can serve eth_getProof responses. For withdrawal proving to work, the window must reach back to the block referenced by any dispute game created after the withdrawal was submitted on L2.
 
 ## Solution
 

--- a/docs/public-docs/notices/op-geth-deprecation.mdx
+++ b/docs/public-docs/notices/op-geth-deprecation.mdx
@@ -49,9 +49,11 @@ For OP Mainnet snapshots, you can find [snapshots here](https://datadirs.optimis
 As soon as op-reth is fully synced, take a snapshot. Refresh it regularly as Glamsterdam approaches.
 Syncing an op-reth node as soon as possible helps ensure a snapshot is available for other validators on your chain so they do not need to sync from scratch.
 
+Withdrawal proving calls `eth_getProof` against the L2 block where the withdrawal was included on every chain, permissioned or permissionless. Because op-reth does not serve historical `eth_getProof` by default, all chain operators should follow the [historical proofs with op-reth guide](https://docs.optimism.io/node-operators/tutorials/reth-historical-proofs) to keep withdrawal finalization working after migrating from op-geth.
+
 ### Permissionless Chain Operators
 
-In parallel, the fault proof program is moving from **op-program** to **kona client**. Current op-program deployments are expected to remain usable until the next hardfork, Karst, when chain operators will need to migrate to **kona-client**. Optimism will handle the onchain prestate updates for managed chains. If you operate a permissionless fault proof chain, checkout our guide on [how to run historical proofs with op-reth](https://docs.optimism.io/node-operators/tutorials/reth-historical-proofs).
+In parallel, the fault proof program is moving from **op-program** to **kona client**. Current op-program deployments are expected to remain usable until the next hardfork, Karst, when chain operators will need to migrate to **kona-client**. Optimism will handle the onchain prestate updates for managed chains.
 
 ## Resources
 

--- a/docs/public-docs/notices/op-geth-deprecation.mdx
+++ b/docs/public-docs/notices/op-geth-deprecation.mdx
@@ -37,6 +37,10 @@ All node operators should migrate to op-reth as soon as possible. For more detai
 </Warning>
 
 <Info>
+  Migrate to [op-reth v2.2.3 or later](https://github.com/ethereum-optimism/optimism/releases/tag/op-reth%2Fv2.2.3). v2.2.3 is required to enable the historical proof store (v2) via `--proofs-history.storage-version=v2`. See the [historical proofs guide](/node-operators/tutorials/reth-historical-proofs) for the setup procedure.
+</Info>
+
+<Info>
   Syncing op-reth takes time. Start early to allow adequate validation before the hardfork window.
 </Info>
 
@@ -63,6 +67,7 @@ In parallel, the fault proof program is moving from **op-program** to **kona cli
 ## Resources
 
 - [op-reth repository](https://github.com/ethereum-optimism/optimism/tree/develop/rust)
+- [op-reth v2.2.3 release notes](https://github.com/ethereum-optimism/optimism/releases/tag/op-reth%2Fv2.2.3)
 - [op-reth configuration](https://docs.optimism.io/node-operators/guides/configuration/execution-clients#op-reth-configuration)
 - [op-reth OP Mainnet Snapshots](https://datadirs.optimism.io/)
 - [op-reth historical proofs guide](https://docs.optimism.io/node-operators/tutorials/reth-historical-proofs)

--- a/docs/public-docs/notices/op-geth-deprecation.mdx
+++ b/docs/public-docs/notices/op-geth-deprecation.mdx
@@ -49,7 +49,12 @@ For OP Mainnet snapshots, you can find [snapshots here](https://datadirs.optimis
 As soon as op-reth is fully synced, take a snapshot. Refresh it regularly as Glamsterdam approaches.
 Syncing an op-reth node as soon as possible helps ensure a snapshot is available for other validators on your chain so they do not need to sync from scratch.
 
-Withdrawal proving calls `eth_getProof` against the L2 block where the withdrawal was included on every chain, permissioned or permissionless. Because op-reth does not serve historical `eth_getProof` by default, all chain operators should follow the [historical proofs with op-reth guide](https://docs.optimism.io/node-operators/tutorials/reth-historical-proofs) to keep withdrawal finalization working after migrating from op-geth.
+Historical L2 state on op-reth is required for **permissioned chains as well**, not just permissionless. Withdrawal proving calls `eth_getProof` on the L2 block where the withdrawal was included regardless of your dispute-game model — op-geth handled this via archive state, and op-reth needs equivalent configuration. Two options:
+
+- `--rpc.eth-proof-window <num_blocks>` — no ExEx, but performance and memory cost grow the further back you query. Size to cover your dispute-game publishing cadence with margin.
+- `--proofs-history` — bounded memory, but storage-heavy. The default `--proofs-history.window` is 1,296,000 blocks (~30 days at 2s block time); adjust if your chain's block time differs.
+
+See [how to run historical proofs with op-reth](https://docs.optimism.io/node-operators/tutorials/reth-historical-proofs) for sizing guidance and configuration details.
 
 ### Permissionless Chain Operators
 


### PR DESCRIPTION
## Summary
- Move the historical-proofs link out of the "Permissionless Chain Operators" section and into "Chain Operators", with a one-paragraph explanation that withdrawal proving calls `eth_getProof` on historical L2 state on every chain regardless of the dispute game model.
- Drop the now-duplicate sentence from "Permissionless Chain Operators".

## Why
The fault proof mechanism is identical for permissioned and permissionless chains; permissioned chains just assume proposals are never challenged, so op-program / kona-client doesn't run in practice. However, withdrawal proving calls `eth_getProof` on the L2 block where the withdrawal was included on every chain. reth's default `eth_getProof` OOMs on blocks older than ~7 days, so without the proofs-history ExEx, users can fail to prove and finalize withdrawals once the relevant L2 block ages out — including on permissioned mainnets. A permissioned-chain operator hit this exact failure mode on their devnet.

## Test plan
- [ ] Confirm the link to `/node-operators/tutorials/reth-historical-proofs` still resolves.