### PR TITLE
test(flashblocks): split TestFlashblocksTransfer into bounded phases for clearer diagnostics

### DIFF
--- a/op-acceptance-tests/tests/flashblocks/flashblocks_transfer_test.go
+++ b/op-acceptance-tests/tests/flashblocks/flashblocks_transfer_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"math/big"
-	"sort"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -117,8 +117,6 @@ func TestFlashblocksTransfer(gt *testing.T) {
 	var balancesMu sync.Mutex
 
 	collectorCtx, cancelCollector := context.WithCancel(t.Ctx())
-	defer cancelCollector()
-
 	var collectorWG sync.WaitGroup
 	collectorWG.Add(1)
 	go func() {
@@ -149,7 +147,18 @@ func TestFlashblocksTransfer(gt *testing.T) {
 			}
 		}
 	}()
-	defer collectorWG.Wait()
+	// Single defer that cancels first, then waits — must be in this order. The
+	// collector goroutine parks in `<-fbClient.Next()` until either a new flashblock
+	// arrives or its context is cancelled. fbClient's channel is closed by
+	// startClient's t.Cleanup, but Go runs t.Cleanup callbacks AFTER the test
+	// function's defers, so we cannot rely on the channel close to unpark the
+	// collector. We must cancel collectorCtx ourselves to let it return, then
+	// wait for it. Two separate defers (cancel + wait) would deadlock because LIFO
+	// ordering would run Wait before cancel.
+	defer func() {
+		cancelCollector()
+		collectorWG.Wait()
+	}()
 
 	// Phase 1: wait for the tx to land on-chain.
 	//
@@ -194,7 +203,7 @@ func TestFlashblocksTransfer(gt *testing.T) {
 				}
 			}
 			balancesMu.Unlock()
-			sort.Slice(obs, func(i, j int) bool { return obs[i] < obs[j] })
+			slices.Sort(obs)
 			if len(obs) == 0 {
 				t.Require().FailNowf(
 					"no flashblocks observed",

--- a/op-acceptance-tests/tests/flashblocks/flashblocks_transfer_test.go
+++ b/op-acceptance-tests/tests/flashblocks/flashblocks_transfer_test.go
@@ -1,10 +1,14 @@
 package flashblocks
 
 import (
+	"context"
+	"errors"
 	"math/big"
+	"sort"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
@@ -14,6 +18,19 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
 	"github.com/stretchr/testify/require"
 )
+
+// txConfirmTimeout bounds how long the test waits for Alice's transfer to land on-chain.
+// L2 block time is 2s and the tx is straightforward, so 60s is generous enough to absorb
+// CI load and L1 origin churn while still failing fast (with a clear error) when the
+// sequencer or builder cannot include user transactions at all.
+const txConfirmTimeout = 60 * time.Second
+
+// flashblockObserveTimeout bounds how long the test waits for op-rbuilder to publish a
+// flashblock for the confirmed inclusion block. Once the on-chain inclusion block is
+// known, the matching flashblock should already have been emitted (it precedes block
+// sealing). This timeout exists only to absorb propagation latency from op-rbuilder's
+// websocket publisher to the in-process subscriber.
+const flashblockObserveTimeout = 30 * time.Second
 
 // TestFlashblocksTransfer checks that a transfer is reflected in the op-rbuilder
 // flashblock stream for the same block that eventually includes the transaction.
@@ -30,6 +47,18 @@ import (
 //     and whose block_number equals the confirmed inclusion block.
 //   - Bob's balance in new_account_balances for that flashblock must match the
 //     on-chain balance at the inclusion block.
+//
+// The test is structured as two sequential, separately-timed phases so that a
+// failure points clearly at the broken stage:
+//
+//  1. Wait for Alice's tx to confirm on-chain (bounded by txConfirmTimeout).
+//  2. Wait for op-rbuilder to publish a flashblock for the confirmed block
+//     (bounded by flashblockObserveTimeout).
+//
+// If we instead used a single package-level timeout for both phases, every failure
+// mode (sequencer broken, builder broken, websocket dead, …) would surface as the
+// same misleading "never found the transaction in flashblock receipts" message
+// after a 30-minute hang.
 func TestFlashblocksTransfer(gt *testing.T) {
 	t := devtest.ParallelT(gt)
 	// Example error with kona-node:
@@ -72,53 +101,139 @@ func TestFlashblocksTransfer(gt *testing.T) {
 	t.Require().NoError(err)
 	txHash := strings.ToLower(signedTx.Hash().Hex())
 
-	// Buffer the result so cleanup cannot deadlock if we time out before reading it.
-	txCh := make(chan error, 1)
-	var wg sync.WaitGroup
-	defer wg.Wait()
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		_, err := tx.Success.Eval(t.Ctx())
-		txCh <- err
-		close(txCh)
-	}()
-
-	// Accumulate flashblock receipts for the tx, keyed by block number.
-	// A speculative flashblock may carry the tx for block N, but if that block is
-	// rebuilt the tx surfaces again for a later block. We keep reading until the tx
-	// is confirmed on-chain and we have seen a flashblock for its inclusion block.
+	// balancesByBlock collects every flashblock receipt that mentions Alice's tx hash,
+	// keyed by block number. A speculative flashblock may carry the tx for block N,
+	// but if that block is rebuilt the tx surfaces again for a later block. We keep
+	// the entire history so that, once we know the on-chain inclusion block, we can
+	// look up the matching flashblock without racing the WS stream.
+	//
+	// observedBlocks is the ordered set of block numbers that emitted a flashblock
+	// (regardless of whether they referenced our tx). It feeds the diagnostic message
+	// when the test times out — distinguishing "no flashblocks at all" (op-rbuilder
+	// broken) from "flashblocks for other blocks but not our tx's block" (a real
+	// flashblock-vs-inclusion mismatch).
 	balancesByBlock := make(map[uint64]*big.Int)
-	var txBlock eth.BlockRef
+	observedBlocks := make(map[uint64]struct{})
+	var balancesMu sync.Mutex
 
-outer:
-	for {
-		select {
-		case fb, ok := <-fbClient.Next():
-			t.Require().True(ok, "client channel closed before we found the transaction")
-			if _, found := fb.Metadata.Receipts[txHash]; found {
-				var observedBalance *big.Int
-				if balanceStr, ok := fb.Metadata.NewAccountBalances[strings.ToLower(bob.Address().Hex())]; ok {
-					observedBalance, ok = new(big.Int).SetString(balanceStr[2:], 16)
-					t.Require().True(ok)
+	collectorCtx, cancelCollector := context.WithCancel(t.Ctx())
+	defer cancelCollector()
+
+	var collectorWG sync.WaitGroup
+	collectorWG.Add(1)
+	go func() {
+		defer collectorWG.Done()
+		for {
+			select {
+			case fb, ok := <-fbClient.Next():
+				if !ok {
+					// The websocket subscription terminated. Stop collecting; the main
+					// goroutine will report a clear failure if we still need a flashblock.
+					return
 				}
-				balancesByBlock[uint64(fb.Metadata.BlockNumber)] = observedBalance
+				balancesMu.Lock()
+				observedBlocks[uint64(fb.Metadata.BlockNumber)] = struct{}{}
+				if _, found := fb.Metadata.Receipts[txHash]; found {
+					var observedBalance *big.Int
+					if balanceStr, balOk := fb.Metadata.NewAccountBalances[strings.ToLower(bobAddress.Hex())]; balOk {
+						parsed, parseOk := new(big.Int).SetString(strings.TrimPrefix(balanceStr, "0x"), 16)
+						if parseOk {
+							observedBalance = parsed
+						}
+					}
+					balancesByBlock[uint64(fb.Metadata.BlockNumber)] = observedBalance
+				}
+				balancesMu.Unlock()
+			case <-collectorCtx.Done():
+				return
 			}
-		case err := <-txCh:
-			t.Require().NoError(err)
-			txBlock, err = tx.IncludedBlock.Eval(t.Ctx())
-			t.Require().NoError(err)
-			txCh = nil
-		case <-t.Ctx().Done():
-			t.Require().NoError(t.Ctx().Err(), "never found the transaction in flashblock receipts for the confirmed block")
 		}
+	}()
+	defer collectorWG.Wait()
 
-		if _, ok := balancesByBlock[txBlock.Number]; txCh == nil && ok {
-			break outer
+	// Phase 1: wait for the tx to land on-chain.
+	//
+	// Bound this with a short, dedicated timeout so a sequencer/builder pipeline
+	// that never produces user blocks fails the test in ~60s with the actual
+	// reason ("never confirmed") rather than dragging out to the package timeout
+	// and reporting the misleading "never found the transaction in flashblock
+	// receipts" message.
+	confirmCtx, cancelConfirm := context.WithTimeout(t.Ctx(), txConfirmTimeout)
+	defer cancelConfirm()
+	t.Require().NoError(waitConfirmed(confirmCtx, tx),
+		"Alice's transfer never confirmed on the sequencer EL within %s — likely a sequencer or txpool issue, not a flashblock issue",
+		txConfirmTimeout)
+
+	txBlock, err := tx.IncludedBlock.Eval(t.Ctx())
+	t.Require().NoError(err)
+
+	// Phase 2: wait for op-rbuilder to emit a flashblock for the inclusion block
+	// that carries Alice's tx hash. The collector goroutine is already buffering
+	// matching flashblocks in balancesByBlock; we just need to either find an
+	// existing match or block until a new one arrives.
+	observeCtx, cancelObserve := context.WithTimeout(t.Ctx(), flashblockObserveTimeout)
+	defer cancelObserve()
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		balancesMu.Lock()
+		_, ok := balancesByBlock[txBlock.Number]
+		balancesMu.Unlock()
+		if ok {
+			break
+		}
+		select {
+		case <-observeCtx.Done():
+			balancesMu.Lock()
+			seenForTxBlock := false
+			obs := make([]uint64, 0, len(observedBlocks))
+			for n := range observedBlocks {
+				obs = append(obs, n)
+				if n == txBlock.Number {
+					seenForTxBlock = true
+				}
+			}
+			balancesMu.Unlock()
+			sort.Slice(obs, func(i, j int) bool { return obs[i] < obs[j] })
+			if len(obs) == 0 {
+				t.Require().FailNowf(
+					"no flashblocks observed",
+					"op-rbuilder published zero flashblocks during the test (tx confirmed at block %d). "+
+						"This indicates op-rbuilder isn't producing flashblocks at all — investigate the builder, not the test.",
+					txBlock.Number,
+				)
+			}
+			t.Require().FailNowf(
+				"never found the transaction in flashblock receipts for the confirmed block",
+				"tx %s confirmed at block %d but no flashblock for that block contained the tx receipt. "+
+					"flashblocks were observed for blocks %v, seenForTxBlock=%v.",
+				txHash, txBlock.Number, obs, seenForTxBlock,
+			)
+		case <-ticker.C:
 		}
 	}
 
 	expectedBalance, err := sys.L2EL.EthClient().BalanceAt(t.Ctx(), bob.Address(), new(big.Int).SetUint64(txBlock.Number))
 	t.Require().NoError(err)
-	require.Equal(t, expectedBalance, balancesByBlock[txBlock.Number], "Bob's balance must match the on-chain balance at the transaction inclusion block when reported in flashblock metadata")
+	balancesMu.Lock()
+	observed := balancesByBlock[txBlock.Number]
+	balancesMu.Unlock()
+	require.Equal(t, expectedBalance, observed, "Bob's balance must match the on-chain balance at the transaction inclusion block when reported in flashblock metadata")
+}
+
+// waitConfirmed evaluates tx.Success under a bounded context and returns the
+// result, annotating context-deadline errors with a clearer message. The bounded
+// context guarantees the wait fails fast when the tx genuinely cannot be included,
+// rather than dragging out to the package-wide timeout (which produced a misleading
+// "never found the transaction in flashblock receipts" message — see the package
+// doc on the test for context).
+func waitConfirmed(ctx context.Context, tx *txplan.PlannedTx) error {
+	_, err := tx.Success.Eval(ctx)
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		return errors.New("tx never confirmed within the per-phase timeout — see logs for sequencer/builder state")
+	}
+	return err
 }


### PR DESCRIPTION
## Summary

Restructure `TestFlashblocksTransfer` into two sequentially-bounded phases plus a parallel collector goroutine, so failures produce clear diagnostics instead of a 30-minute hang with a misleading message.

**This is a diagnostic fix, not a flake-rate reducer.** When op-rbuilder breaks, the test will still fail — but in ~90s with a clear message identifying which subsystem is at fault, instead of timing out at the 30-minute package deadline with the same generic "never found the transaction in flashblock receipts for the confirmed block" message regardless of root cause.

Refs ethereum-optimism/optimism#19934.

## Background

The original test had a single `select` loop bounded only by the 30-minute package timeout (`-timeout 30m` in `op-acceptance-tests/justfile`). Three distinct failure modes all surfaced at the same line with the same message:

1. Tx never confirmed (sequencer/txpool issue) — `tx.Success.Eval` goroutine never sends on `txCh`.
2. op-rbuilder produces no flashblocks at all — collector observes nothing.
3. Flashblocks for other blocks but not the inclusion block — speculative-flashblock divergence.

ajsutton called this out as a [residual theoretical risk](https://github.com/ethereum-optimism/optimism/issues/19934#issuecomment-3094228127) after the previous fixes (#19942, #19959, #19985, #20013, #20066, #19976) landed.

## Evidence from CircleCI 124622 / job 4997301 (2026-05-07)

- Alice's tx confirmed cleanly (blocks 8-9 sealed with `txs=2`).
- rollup-boost logged `"Error getting fb best payload, falling back on client"` with `"Missing payload"`/`"Unknown payload"` 897 times across the 30-minute window — op-rbuilder produced zero flashblocks.
- Test's outer `select` blocked on `<-fbClient.Next()` for the full 30 min, then fell through to line 113's misleading message — pure mode 3, exactly as predicted.

## Fix

- **Collector goroutine** reads `fbClient.Next()` continuously into `balancesByBlock` and `observedBlocks` (guarded by `balancesMu`). Single `defer { cancelCollector(); collectorWG.Wait() }` for clean shutdown.
- **Phase 1 (60s):** await `tx.Success.Eval(confirmCtx)`. On timeout: "Alice's transfer never confirmed on the sequencer EL within 60s — likely a sequencer or txpool issue, not a flashblock issue".
- **Phase 2 (30s):** poll `balancesByBlock[txBlock.Number]` every 50ms. On timeout, distinguish "op-rbuilder published zero flashblocks during the test" vs "tx confirmed at block N but no flashblock for that block contained the tx receipt; flashblocks were observed for blocks [...]".

## What this PR does NOT do

- It does **not** address why op-rbuilder fails to publish flashblocks under some conditions. That's the underlying flake source and needs a separate investigation/fix on the builder side.
- Flake count on this test is **not expected to drop**. The test will still fail when op-rbuilder breaks; failures will just be ~20× faster and unambiguous about which subsystem to look at.

## Test plan

- [x] `mise exec -- go build ./op-acceptance-tests/...` passes
- [x] `mise exec -- go vet ./op-acceptance-tests/tests/flashblocks/...` passes
- [ ] CI run on this branch — confirm Phase 1 and Phase 2 behave as designed on a healthy run (both should complete in <30s combined)
- [ ] Watch the next several CI runs to confirm timeouts are appropriately tuned (60s/30s); bump if they're too tight on slow runners, don't revert

## Caveats for reviewers

- Could not reproduce the flake locally — requires a full devnet plus a way to break op-rbuilder's payload pipeline. Fix was validated by reading the May-7 CI logs and tracing the failure path through source.
- Adversarial review caught a defer-order deadlock in the first iteration (see commit `c646b906b0`) — the second commit fixes it by collapsing two defers into a single closure with cancel-then-wait order. Worth checking that pattern doesn't regress.
- The two timeouts (`txConfirmTimeout = 60s`, `flashblockObserveTimeout = 30s`) are tight but should be generous vs healthy behavior. If CI proves slower in practice, bump them.

🤖 *Generated by Claude Code*