### PR TITLE
test(revm-ee-tests): add op-revm integration tests from upstream revm

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -12564,6 +12564,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "revm-ee-tests"
+version = "0.2.0"
+dependencies = [
+ "op-revm",
+ "revm",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "revm-handler"
 version = "18.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -52,6 +52,9 @@ members = [
 
   # Op-Revm
   "op-revm/",
+
+  # Revm execution-environment integration tests
+  "revm-ee-tests/",
 ]
 default-members = [
   "kona/bin/host",

--- a/rust/kona/docker/fpvm-prestates/cannon-repro.dockerfile
+++ b/rust/kona/docker/fpvm-prestates/cannon-repro.dockerfile
@@ -74,9 +74,10 @@ COPY rust/op-alloy/ /app/rust/op-alloy/
 COPY rust/alloy-op-evm/ /app/rust/alloy-op-evm/
 COPY rust/alloy-op-hardforks/ /app/rust/alloy-op-hardforks/
 COPY rust/op-revm/ /app/rust/op-revm/
-# op-reth is a workspace member but not a kona-client dependency.
-# We need its Cargo.toml files so the workspace resolves.
+# op-reth and revm-ee-tests are workspace members but not kona-client
+# dependencies. We need their Cargo.toml files so the workspace resolves.
 COPY rust/op-reth/ /app/rust/op-reth/
+COPY rust/revm-ee-tests/ /app/rust/revm-ee-tests/
 
 # kona-hardforks build.rs walks ancestors of CARGO_MANIFEST_DIR for
 # op-core/nuts/bundles. Stage the bundles at /app/op-core so the walk

--- a/rust/revm-ee-tests/CHANGELOG.md
+++ b/rust/revm-ee-tests/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0](https://github.com/bluealloy/revm/compare/revm-ee-tests-v0.1.0...revm-ee-tests-v0.2.0) - 2026-03-04
+
+### Other
+
+- bump revm-database-interface to v10.0.0
+
+## [0.1.0](https://github.com/bluealloy/revm/releases/tag/revm-ee-tests-v0.1.0) - 2025-08-06
+
+### Added
+
+- gastable, record static gas in Interpreter loop ([#2822](https://github.com/bluealloy/revm/pull/2822))
+- fix renamed functions for system_call ([#2824](https://github.com/bluealloy/revm/pull/2824))
+- refactor test utils ([#2813](https://github.com/bluealloy/revm/pull/2813))
+
+### Other
+
+- *(op-revm)* Adds caller nonce assertion to op-revm integration tests ([#2815](https://github.com/bluealloy/revm/pull/2815))

--- a/rust/revm-ee-tests/Cargo.toml
+++ b/rust/revm-ee-tests/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "revm-ee-tests"
+description = "Common test utilities for REVM crates"
+version = "0.2.0"
+authors.workspace = true
+edition.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+serde.workspace = true
+serde_json = { workspace = true, features = ["preserve_order"] }
+revm = { workspace = true, features = ["serde", "std"] }
+op-revm = { workspace = true, features = ["serde"] }
+
+[features]
+default = []
+optional_balance_check = ["op-revm/optional_balance_check"]

--- a/rust/revm-ee-tests/README.md
+++ b/rust/revm-ee-tests/README.md
@@ -1,0 +1,30 @@
+# revm-ee-tests
+
+Shared test utilities and integration tests for **revm** and **op-revm**.
+
+## Running Tests
+
+```bash
+# Run all tests
+cargo test -p revm-ee-tests
+
+# Run a specific test subset (e.g. TIP-1016 state gas tests)
+cargo test -p revm-ee-tests tip1016
+```
+
+## Directory Structure
+
+```
+crates/ee-tests/
+├── src/
+│   ├── lib.rs              # Snapshot comparison utilities (TestdataConfig, compare_or_save_testdata)
+│   ├── revm_tests.rs       # Integration tests for mainnet revm
+│   └── op_revm_tests.rs    # Integration tests for op-revm (Optimism)
+├── tests/
+│   ├── revm_testdata/      # Golden JSON snapshots for revm tests
+│   └── op_revm_testdata/   # Golden JSON snapshots for op-revm tests
+├── tip1016.md              # TIP-1016 State Gas test plan
+└── Cargo.toml
+```
+
+Snapshot files are auto-generated on first run and compared on subsequent runs.

--- a/rust/revm-ee-tests/src/lib.rs
+++ b/rust/revm-ee-tests/src/lib.rs
@@ -1,0 +1,125 @@
+//! Common test utilities for REVM crates.
+//!
+//! This crate provides shared test utilities that are used across different REVM crates.
+
+use std::path::PathBuf;
+
+use serde_json::Value;
+
+/// Configuration for the test data comparison utility.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TestdataConfig {
+    /// The directory where test data files are stored.
+    pub testdata_dir: PathBuf,
+}
+
+impl Default for TestdataConfig {
+    fn default() -> Self {
+        Self { testdata_dir: PathBuf::from("tests/testdata") }
+    }
+}
+
+/// Compares or saves the execution output to a testdata file.
+///
+/// This utility helps maintain consistent test behavior by comparing
+/// execution results against known-good outputs stored in JSON files.
+///
+/// # Arguments
+///
+/// * `filename` - The name of the testdata file, relative to tests/testdata/
+/// * `output` - The execution output to compare or save
+///
+/// # Panics
+///
+/// This function panics if:
+/// - The output doesn't match the expected testdata (when testdata file exists)
+/// - There's an error reading/writing files
+/// - JSON serialization/deserialization fails
+///
+/// # Note
+///
+/// Tests using this function require the `serde` feature to be enabled:
+/// ```bash
+/// cargo test --features serde
+/// ```
+pub fn compare_or_save_testdata<T>(filename: &str, output: &T)
+where
+    T: serde::Serialize + for<'a> serde::Deserialize<'a> + PartialEq + std::fmt::Debug,
+{
+    compare_or_save_testdata_with_config(filename, output, TestdataConfig::default());
+}
+
+/// Compares or saves the execution output to a testdata file with custom configuration.
+///
+/// This is a more flexible version of [`compare_or_save_testdata`] that allows
+/// specifying a custom testdata directory.
+///
+/// # Arguments
+///
+/// * `filename` - The name of the testdata file, relative to the testdata directory
+/// * `output` - The execution output to compare or save
+/// * `config` - Configuration for the test data comparison
+pub fn compare_or_save_testdata_with_config<T>(filename: &str, output: &T, config: TestdataConfig)
+where
+    T: serde::Serialize + for<'a> serde::Deserialize<'a> + PartialEq + std::fmt::Debug,
+{
+    use std::fs;
+
+    let testdata_file = config.testdata_dir.join(filename);
+
+    // Create directory if it doesn't exist
+    if !config.testdata_dir.exists() {
+        fs::create_dir_all(&config.testdata_dir).unwrap();
+    }
+
+    // Serialize the output to serde Value.
+    let output_json = serde_json::to_string(&output).unwrap();
+
+    // convert to Value and sort all objects.
+    let mut temp: Value = serde_json::from_str(&output_json).unwrap();
+    temp.sort_all_objects();
+
+    // serialize to pretty string
+    let output_json = serde_json::to_string_pretty(&temp).unwrap();
+
+    // If the testdata file doesn't exist, save the output
+    if !testdata_file.exists() {
+        fs::write(&testdata_file, &output_json).unwrap();
+        println!("Saved testdata to {}", testdata_file.display());
+        return;
+    }
+
+    // Read the expected output from the testdata file
+    let expected_json = fs::read_to_string(&testdata_file).unwrap();
+
+    // Deserialize to actual object for proper comparison
+    let expected: T = serde_json::from_str(&expected_json).unwrap();
+
+    // Compare the output objects directly
+    assert!(
+        *output == expected,
+        "Value does not match testdata.\nExpected:\n{expected_json}\n\nActual:\n{output_json}"
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+    struct TestData {
+        value: u32,
+        message: String,
+    }
+
+    #[test]
+    fn test_compare_or_save_testdata() {
+        let test_data = TestData { value: 42, message: "test message".to_string() };
+
+        // This will save the test data on first run, then compare on subsequent runs
+        compare_or_save_testdata("test_data.json", &test_data);
+    }
+}
+
+#[cfg(test)]
+mod op_revm_tests;

--- a/rust/revm-ee-tests/src/op_revm_tests.rs
+++ b/rust/revm-ee-tests/src/op_revm_tests.rs
@@ -1,0 +1,1140 @@
+//! Integration tests for the `op-revm` crate.
+
+use crate::TestdataConfig;
+use op_revm::{
+    DefaultOp, L1BlockInfo, OpBuilder, OpHaltReason, OpSpecId, OpTransaction,
+    precompiles::bn254_pair::GRANITE_MAX_INPUT_SIZE,
+};
+use revm::{
+    Context, ExecuteEvm, InspectEvm, Inspector, Journal, SystemCallEvm,
+    bytecode::opcode,
+    context::{
+        BlockEnv, CfgEnv, TxEnv,
+        result::{ExecutionResult, OutOfGasError, ResultGas},
+    },
+    context_interface::result::HaltReason,
+    database::{BENCH_CALLER, BENCH_CALLER_BALANCE, BENCH_TARGET, BenchmarkDB, EmptyDB, State},
+    handler::system_call::SYSTEM_ADDRESS,
+    interpreter::{
+        InterpreterTypes,
+        gas::{InitialAndFloorGas, calculate_initial_tx_gas},
+    },
+    precompile::{bls12_381_const, bls12_381_utils, bn254, secp256r1, u64_to_address},
+    primitives::{Address, Bytes, Log, TxKind, U256, address, bytes, eip7825},
+    state::Bytecode,
+};
+use std::{path::PathBuf, vec::Vec};
+
+// Re-export the constant for testdata directory path
+const TESTS_TESTDATA: &str = "tests/op_revm_testdata";
+
+fn op_revm_testdata_config() -> TestdataConfig {
+    TestdataConfig { testdata_dir: PathBuf::from(TESTS_TESTDATA) }
+}
+
+fn compare_or_save_op_testdata<T>(filename: &str, output: &T)
+where
+    T: serde::Serialize + for<'a> serde::Deserialize<'a> + PartialEq + std::fmt::Debug,
+{
+    crate::compare_or_save_testdata_with_config(filename, output, op_revm_testdata_config());
+}
+
+#[test]
+fn test_deposit_tx() {
+    let ctx = Context::op()
+        .with_tx(
+            OpTransaction::builder()
+                .enveloped_tx(None)
+                .mint(100)
+                .source_hash(revm::primitives::B256::from([1u8; 32]))
+                .build_fill(),
+        )
+        .with_cfg(CfgEnv::new_with_spec(OpSpecId::HOLOCENE));
+
+    let mut evm = ctx.build_op();
+
+    let output = evm.replay().unwrap();
+
+    // balance should be 100
+    assert_eq!(
+        output.state.get(&Address::default()).map(|a| a.info.balance),
+        Some(U256::from(100))
+    );
+    compare_or_save_op_testdata("test_deposit_tx.json", &output);
+}
+
+#[test]
+fn test_halted_deposit_tx() {
+    let ctx = Context::op()
+        .with_tx(
+            OpTransaction::builder()
+                .base(TxEnv::builder().caller(BENCH_CALLER).kind(TxKind::Call(BENCH_TARGET)))
+                .enveloped_tx(None)
+                .mint(100)
+                .source_hash(revm::primitives::B256::from([1u8; 32]))
+                .build_fill(),
+        )
+        .with_cfg(CfgEnv::new_with_spec(OpSpecId::HOLOCENE))
+        .with_db(BenchmarkDB::new_bytecode(Bytecode::new_legacy([opcode::POP].into())));
+
+    // POP would return a halt.
+    let mut evm = ctx.build_op();
+
+    let output = evm.replay().unwrap();
+
+    // balance should be 100 + previous balance
+    assert_eq!(
+        output.result,
+        ExecutionResult::Halt {
+            reason: OpHaltReason::FailedDeposit,
+            gas: ResultGas::default().with_total_gas_spent(eip7825::TX_GAS_LIMIT_CAP),
+            logs: vec![],
+        }
+    );
+    assert_eq!(
+        output.state.get(&BENCH_CALLER).map(|a| a.info.balance),
+        Some(U256::from(100) + BENCH_CALLER_BALANCE)
+    );
+
+    compare_or_save_op_testdata("test_halted_deposit_tx.json", &output);
+}
+
+fn p256verify_test_tx()
+-> Context<BlockEnv, OpTransaction<TxEnv>, CfgEnv<OpSpecId>, EmptyDB, Journal<EmptyDB>, L1BlockInfo>
+{
+    const SPEC_ID: OpSpecId = OpSpecId::FJORD;
+
+    let InitialAndFloorGas { initial_total_gas, .. } =
+        calculate_initial_tx_gas(SPEC_ID.into(), &[], false, 0, 0, 0);
+
+    Context::op()
+        .with_tx(
+            OpTransaction::builder()
+                .base(
+                    TxEnv::builder()
+                        .kind(TxKind::Call(u64_to_address(secp256r1::P256VERIFY_ADDRESS)))
+                        .gas_limit(initial_total_gas + secp256r1::P256VERIFY_BASE_GAS_FEE),
+                )
+                .build_fill(),
+        )
+        .with_cfg(CfgEnv::new_with_spec(SPEC_ID))
+}
+
+#[test]
+fn test_tx_call_p256verify() {
+    let ctx = p256verify_test_tx();
+
+    let mut evm = ctx.build_op();
+    let output = evm.replay().unwrap();
+
+    // assert successful call to P256VERIFY
+    assert!(output.result.is_success());
+
+    compare_or_save_op_testdata("test_tx_call_p256verify.json", &output);
+}
+
+#[test]
+fn test_halted_tx_call_p256verify() {
+    const SPEC_ID: OpSpecId = OpSpecId::FJORD;
+    let InitialAndFloorGas { initial_total_gas, .. } =
+        calculate_initial_tx_gas(SPEC_ID.into(), &[], false, 0, 0, 0);
+    let original_gas_limit = initial_total_gas + secp256r1::P256VERIFY_BASE_GAS_FEE;
+
+    let ctx = Context::op()
+        .with_tx(
+            OpTransaction::builder()
+                .base(
+                    TxEnv::builder()
+                        .kind(TxKind::Call(u64_to_address(secp256r1::P256VERIFY_ADDRESS)))
+                        .gas_limit(original_gas_limit - 1),
+                )
+                .build_fill(),
+        )
+        .with_cfg(CfgEnv::new_with_spec(SPEC_ID));
+
+    let mut evm = ctx.build_op();
+    let output = evm.replay().unwrap();
+
+    // assert out of gas for P256VERIFY
+    assert!(matches!(
+        output.result,
+        ExecutionResult::Halt {
+            reason: OpHaltReason::Base(HaltReason::OutOfGas(OutOfGasError::Precompile)),
+            ..
+        }
+    ));
+
+    compare_or_save_op_testdata("test_halted_tx_call_p256verify.json", &output);
+}
+
+fn bn254_pair_test_tx(
+    spec: OpSpecId,
+) -> Context<BlockEnv, OpTransaction<TxEnv>, CfgEnv<OpSpecId>, EmptyDB, Journal<EmptyDB>, L1BlockInfo>
+{
+    let input = Bytes::from([1; GRANITE_MAX_INPUT_SIZE + 2]);
+    let InitialAndFloorGas { initial_total_gas, .. } =
+        calculate_initial_tx_gas(spec.into(), &input[..], false, 0, 0, 0);
+
+    Context::op()
+        .with_tx(
+            OpTransaction::builder()
+                .base(
+                    TxEnv::builder()
+                        .kind(TxKind::Call(bn254::pair::ADDRESS))
+                        .data(input)
+                        .gas_limit(initial_total_gas),
+                )
+                .build_fill(),
+        )
+        .with_cfg(CfgEnv::new_with_spec(spec))
+}
+
+#[test]
+fn test_halted_tx_call_bn254_pair_fjord() {
+    let ctx = bn254_pair_test_tx(OpSpecId::FJORD);
+
+    let mut evm = ctx.build_op();
+    let output = evm.replay().unwrap();
+
+    // assert out of gas
+    assert!(matches!(
+        output.result,
+        ExecutionResult::Halt {
+            reason: OpHaltReason::Base(HaltReason::OutOfGas(OutOfGasError::Precompile)),
+            ..
+        }
+    ));
+
+    compare_or_save_op_testdata("test_halted_tx_call_bn254_pair_fjord.json", &output);
+}
+
+#[test]
+fn test_halted_tx_call_bn254_pair_granite() {
+    let ctx = bn254_pair_test_tx(OpSpecId::GRANITE);
+
+    let mut evm = ctx.build_op();
+    let output = evm.replay().unwrap();
+
+    // assert bails early because input size too big
+    assert!(matches!(
+        output.result,
+        ExecutionResult::Halt {
+            reason: OpHaltReason::Base(HaltReason::PrecompileErrorWithContext(ref msg)),
+            ..
+        } if msg == "bn254 invalid pair length"
+    ));
+
+    compare_or_save_op_testdata("test_halted_tx_call_bn254_pair_granite.json", &output);
+}
+
+#[test]
+fn test_halted_tx_call_bls12_381_g1_add_out_of_gas() {
+    let ctx = Context::op()
+        .with_tx(
+            OpTransaction::builder()
+                .base(
+                    TxEnv::builder()
+                        .kind(TxKind::Call(bls12_381_const::G1_ADD_ADDRESS))
+                        .gas_limit(21_000 + bls12_381_const::G1_ADD_BASE_GAS_FEE - 1),
+                )
+                .build_fill(),
+        )
+        .modify_chain_chained(|l1_block| {
+            l1_block.operator_fee_constant = Some(U256::ZERO);
+            l1_block.operator_fee_scalar = Some(U256::ZERO)
+        })
+        .with_cfg(CfgEnv::new_with_spec(OpSpecId::ISTHMUS));
+
+    let mut evm = ctx.build_op();
+
+    let output = evm.replay().unwrap();
+
+    // assert out of gas
+    assert!(matches!(
+        output.result,
+        ExecutionResult::Halt {
+            reason: OpHaltReason::Base(HaltReason::OutOfGas(OutOfGasError::Precompile)),
+            ..
+        }
+    ));
+
+    compare_or_save_op_testdata("test_halted_tx_call_bls12_381_g1_add_out_of_gas.json", &output);
+}
+
+#[test]
+fn test_halted_tx_call_bls12_381_g1_add_input_wrong_size() {
+    let ctx = Context::op()
+        .with_tx(
+            OpTransaction::builder()
+                .base(
+                    TxEnv::builder()
+                        .kind(TxKind::Call(bls12_381_const::G1_ADD_ADDRESS))
+                        .gas_limit(21_000 + bls12_381_const::G1_ADD_BASE_GAS_FEE),
+                )
+                .build_fill(),
+        )
+        .modify_chain_chained(|l1_block| {
+            l1_block.operator_fee_constant = Some(U256::ZERO);
+            l1_block.operator_fee_scalar = Some(U256::ZERO)
+        })
+        .with_cfg(CfgEnv::new_with_spec(OpSpecId::ISTHMUS));
+
+    let mut evm = ctx.build_op();
+    let output = evm.replay().unwrap();
+
+    // assert fails post gas check, because input is wrong size
+    assert!(matches!(
+        output.result,
+        ExecutionResult::Halt {
+            reason: OpHaltReason::Base(HaltReason::PrecompileErrorWithContext(ref msg)),
+            ..
+        } if msg == "bls12-381 g1 add input length error"
+    ));
+
+    compare_or_save_op_testdata(
+        "test_halted_tx_call_bls12_381_g1_add_input_wrong_size.json",
+        &output,
+    );
+}
+
+fn g1_msm_test_tx()
+-> Context<BlockEnv, OpTransaction<TxEnv>, CfgEnv<OpSpecId>, EmptyDB, Journal<EmptyDB>, L1BlockInfo>
+{
+    const SPEC_ID: OpSpecId = OpSpecId::ISTHMUS;
+
+    let input = Bytes::from([1; bls12_381_const::G1_MSM_INPUT_LENGTH]);
+    let InitialAndFloorGas { initial_total_gas, .. } =
+        calculate_initial_tx_gas(SPEC_ID.into(), &input[..], false, 0, 0, 0);
+    let gs1_msm_gas = bls12_381_utils::msm_required_gas(
+        1,
+        &bls12_381_const::DISCOUNT_TABLE_G1_MSM,
+        bls12_381_const::G1_MSM_BASE_GAS_FEE,
+    );
+
+    Context::op()
+        .with_tx(
+            OpTransaction::builder()
+                .base(
+                    TxEnv::builder()
+                        .kind(TxKind::Call(bls12_381_const::G1_MSM_ADDRESS))
+                        .data(input)
+                        .gas_limit(initial_total_gas + gs1_msm_gas),
+                )
+                .build_fill(),
+        )
+        .modify_chain_chained(|l1_block| {
+            l1_block.operator_fee_constant = Some(U256::ZERO);
+            l1_block.operator_fee_scalar = Some(U256::ZERO)
+        })
+        .with_cfg(CfgEnv::new_with_spec(SPEC_ID))
+}
+
+#[test]
+fn test_halted_tx_call_bls12_381_g1_msm_input_wrong_size() {
+    const SPEC_ID: OpSpecId = OpSpecId::ISTHMUS;
+    let input = Bytes::from([1; bls12_381_const::G1_MSM_INPUT_LENGTH]);
+    let InitialAndFloorGas { initial_total_gas, .. } =
+        calculate_initial_tx_gas(SPEC_ID.into(), &input[..], false, 0, 0, 0);
+    let gs1_msm_gas = bls12_381_utils::msm_required_gas(
+        1,
+        &bls12_381_const::DISCOUNT_TABLE_G1_MSM,
+        bls12_381_const::G1_MSM_BASE_GAS_FEE,
+    );
+
+    let ctx = Context::op()
+        .with_tx(
+            OpTransaction::builder()
+                .base(
+                    TxEnv::builder()
+                        .kind(TxKind::Call(bls12_381_const::G1_MSM_ADDRESS))
+                        .data(input.slice(1..))
+                        .gas_limit(initial_total_gas + gs1_msm_gas),
+                )
+                .build_fill(),
+        )
+        .modify_chain_chained(|l1_block| {
+            l1_block.operator_fee_constant = Some(U256::ZERO);
+            l1_block.operator_fee_scalar = Some(U256::ZERO)
+        })
+        .with_cfg(CfgEnv::new_with_spec(SPEC_ID));
+
+    let mut evm = ctx.build_op();
+    let output = evm.replay().unwrap();
+
+    // assert fails pre gas check, because input is wrong size
+    assert!(matches!(
+        output.result,
+        ExecutionResult::Halt {
+            reason: OpHaltReason::Base(HaltReason::PrecompileErrorWithContext(ref msg)),
+            ..
+        } if msg == "bls12-381 g1 msm input length error"
+    ));
+
+    compare_or_save_op_testdata(
+        "test_halted_tx_call_bls12_381_g1_msm_input_wrong_size.json",
+        &output,
+    );
+}
+
+#[test]
+fn test_halted_tx_call_bls12_381_g1_msm_out_of_gas() {
+    const SPEC_ID: OpSpecId = OpSpecId::ISTHMUS;
+    let input = Bytes::from([1; bls12_381_const::G1_MSM_INPUT_LENGTH]);
+    let InitialAndFloorGas { initial_total_gas, .. } =
+        calculate_initial_tx_gas(SPEC_ID.into(), &input[..], false, 0, 0, 0);
+    let gs1_msm_gas = bls12_381_utils::msm_required_gas(
+        1,
+        &bls12_381_const::DISCOUNT_TABLE_G1_MSM,
+        bls12_381_const::G1_MSM_BASE_GAS_FEE,
+    );
+
+    let ctx = Context::op()
+        .with_tx(
+            OpTransaction::builder()
+                .base(
+                    TxEnv::builder()
+                        .kind(TxKind::Call(bls12_381_const::G1_MSM_ADDRESS))
+                        .data(input)
+                        .gas_limit(initial_total_gas + gs1_msm_gas - 1),
+                )
+                .build_fill(),
+        )
+        .modify_chain_chained(|l1_block| {
+            l1_block.operator_fee_constant = Some(U256::ZERO);
+            l1_block.operator_fee_scalar = Some(U256::ZERO)
+        })
+        .with_cfg(CfgEnv::new_with_spec(SPEC_ID));
+
+    let mut evm = ctx.build_op();
+    let output = evm.replay().unwrap();
+
+    // assert out of gas
+    assert!(matches!(
+        output.result,
+        ExecutionResult::Halt {
+            reason: OpHaltReason::Base(HaltReason::OutOfGas(OutOfGasError::Precompile)),
+            ..
+        }
+    ));
+
+    compare_or_save_op_testdata("test_halted_tx_call_bls12_381_g1_msm_out_of_gas.json", &output);
+}
+
+#[test]
+fn test_halted_tx_call_bls12_381_g1_msm_wrong_input_layout() {
+    let ctx = g1_msm_test_tx();
+
+    let mut evm = ctx.build_op();
+    let output = evm.replay().unwrap();
+
+    // assert fails post gas check, because input is wrong layout
+    assert!(matches!(
+        output.result,
+        ExecutionResult::Halt {
+            reason: OpHaltReason::Base(HaltReason::PrecompileErrorWithContext(ref msg)),
+            ..
+        } if msg == "bls12-381 fp 64 top bytes of input are not zero"
+    ));
+
+    compare_or_save_op_testdata(
+        "test_halted_tx_call_bls12_381_g1_msm_wrong_input_layout.json",
+        &output,
+    );
+}
+
+#[test]
+fn test_halted_tx_call_bls12_381_g2_add_out_of_gas() {
+    let ctx = Context::op()
+        .with_tx(
+            OpTransaction::builder()
+                .base(
+                    TxEnv::builder()
+                        .kind(TxKind::Call(bls12_381_const::G2_ADD_ADDRESS))
+                        .gas_limit(21_000 + bls12_381_const::G2_ADD_BASE_GAS_FEE - 1),
+                )
+                .build_fill(),
+        )
+        .modify_chain_chained(|l1_block| {
+            l1_block.operator_fee_constant = Some(U256::ZERO);
+            l1_block.operator_fee_scalar = Some(U256::ZERO)
+        })
+        .with_cfg(CfgEnv::new_with_spec(OpSpecId::ISTHMUS));
+
+    let mut evm = ctx.build_op();
+
+    let output = evm.replay().unwrap();
+
+    // assert out of gas
+    assert!(matches!(
+        output.result,
+        ExecutionResult::Halt {
+            reason: OpHaltReason::Base(HaltReason::OutOfGas(OutOfGasError::Precompile)),
+            ..
+        }
+    ));
+
+    compare_or_save_op_testdata("test_halted_tx_call_bls12_381_g2_add_out_of_gas.json", &output);
+}
+
+#[test]
+fn test_halted_tx_call_bls12_381_g2_add_input_wrong_size() {
+    let ctx = Context::op()
+        .with_tx(
+            OpTransaction::builder()
+                .base(
+                    TxEnv::builder()
+                        .kind(TxKind::Call(bls12_381_const::G2_ADD_ADDRESS))
+                        .gas_limit(21_000 + bls12_381_const::G2_ADD_BASE_GAS_FEE),
+                )
+                .build_fill(),
+        )
+        .modify_chain_chained(|l1_block| {
+            l1_block.operator_fee_constant = Some(U256::ZERO);
+            l1_block.operator_fee_scalar = Some(U256::ZERO)
+        })
+        .with_cfg(CfgEnv::new_with_spec(OpSpecId::ISTHMUS));
+
+    let mut evm = ctx.build_op();
+
+    let output = evm.replay().unwrap();
+
+    // assert fails post gas check, because input is wrong size
+    assert!(matches!(
+        output.result,
+        ExecutionResult::Halt {
+            reason: OpHaltReason::Base(HaltReason::PrecompileErrorWithContext(ref msg)),
+            ..
+        } if msg == "bls12-381 g2 add input length error"
+    ));
+
+    compare_or_save_op_testdata(
+        "test_halted_tx_call_bls12_381_g2_add_input_wrong_size.json",
+        &output,
+    );
+}
+
+fn g2_msm_test_tx()
+-> Context<BlockEnv, OpTransaction<TxEnv>, CfgEnv<OpSpecId>, EmptyDB, Journal<EmptyDB>, L1BlockInfo>
+{
+    const SPEC_ID: OpSpecId = OpSpecId::ISTHMUS;
+
+    let input = Bytes::from([1; bls12_381_const::G2_MSM_INPUT_LENGTH]);
+    let InitialAndFloorGas { initial_total_gas, .. } =
+        calculate_initial_tx_gas(SPEC_ID.into(), &input[..], false, 0, 0, 0);
+    let gs2_msm_gas = bls12_381_utils::msm_required_gas(
+        1,
+        &bls12_381_const::DISCOUNT_TABLE_G2_MSM,
+        bls12_381_const::G2_MSM_BASE_GAS_FEE,
+    );
+
+    Context::op()
+        .with_tx(
+            OpTransaction::builder()
+                .base(
+                    TxEnv::builder()
+                        .kind(TxKind::Call(bls12_381_const::G2_MSM_ADDRESS))
+                        .data(input)
+                        .gas_limit(initial_total_gas + gs2_msm_gas),
+                )
+                .build_fill(),
+        )
+        .modify_chain_chained(|l1_block| {
+            l1_block.operator_fee_constant = Some(U256::ZERO);
+            l1_block.operator_fee_scalar = Some(U256::ZERO)
+        })
+        .with_cfg(CfgEnv::new_with_spec(SPEC_ID))
+}
+
+#[test]
+fn test_halted_tx_call_bls12_381_g2_msm_input_wrong_size() {
+    const SPEC_ID: OpSpecId = OpSpecId::ISTHMUS;
+    let input = Bytes::from([1; bls12_381_const::G2_MSM_INPUT_LENGTH]);
+    let InitialAndFloorGas { initial_total_gas, .. } =
+        calculate_initial_tx_gas(SPEC_ID.into(), &input[..], false, 0, 0, 0);
+    let gs2_msm_gas = bls12_381_utils::msm_required_gas(
+        1,
+        &bls12_381_const::DISCOUNT_TABLE_G2_MSM,
+        bls12_381_const::G2_MSM_BASE_GAS_FEE,
+    );
+
+    let ctx = Context::op()
+        .with_tx(
+            OpTransaction::builder()
+                .base(
+                    TxEnv::builder()
+                        .kind(TxKind::Call(bls12_381_const::G2_MSM_ADDRESS))
+                        .data(input.slice(1..))
+                        .gas_limit(initial_total_gas + gs2_msm_gas),
+                )
+                .build_fill(),
+        )
+        .modify_chain_chained(|l1_block| {
+            l1_block.operator_fee_constant = Some(U256::ZERO);
+            l1_block.operator_fee_scalar = Some(U256::ZERO)
+        })
+        .with_cfg(CfgEnv::new_with_spec(SPEC_ID));
+
+    let mut evm = ctx.build_op();
+    let output = evm.replay().unwrap();
+
+    // assert fails pre gas check, because input is wrong size
+    assert!(matches!(
+        output.result,
+        ExecutionResult::Halt {
+            reason: OpHaltReason::Base(HaltReason::PrecompileErrorWithContext(ref msg)),
+            ..
+        } if msg == "bls12-381 g2 msm input length error"
+    ));
+
+    compare_or_save_op_testdata(
+        "test_halted_tx_call_bls12_381_g2_msm_input_wrong_size.json",
+        &output,
+    );
+}
+
+#[test]
+fn test_halted_tx_call_bls12_381_g2_msm_out_of_gas() {
+    const SPEC_ID: OpSpecId = OpSpecId::ISTHMUS;
+    let input = Bytes::from([1; bls12_381_const::G2_MSM_INPUT_LENGTH]);
+    let InitialAndFloorGas { initial_total_gas, .. } =
+        calculate_initial_tx_gas(SPEC_ID.into(), &input[..], false, 0, 0, 0);
+    let gs2_msm_gas = bls12_381_utils::msm_required_gas(
+        1,
+        &bls12_381_const::DISCOUNT_TABLE_G2_MSM,
+        bls12_381_const::G2_MSM_BASE_GAS_FEE,
+    );
+
+    let ctx = Context::op()
+        .with_tx(
+            OpTransaction::builder()
+                .base(
+                    TxEnv::builder()
+                        .kind(TxKind::Call(bls12_381_const::G2_MSM_ADDRESS))
+                        .data(input)
+                        .gas_limit(initial_total_gas + gs2_msm_gas - 1),
+                )
+                .build_fill(),
+        )
+        .modify_chain_chained(|l1_block| {
+            l1_block.operator_fee_constant = Some(U256::ZERO);
+            l1_block.operator_fee_scalar = Some(U256::ZERO)
+        })
+        .with_cfg(CfgEnv::new_with_spec(SPEC_ID));
+
+    let mut evm = ctx.build_op();
+    let output = evm.replay().unwrap();
+
+    // assert out of gas
+    assert!(matches!(
+        output.result,
+        ExecutionResult::Halt {
+            reason: OpHaltReason::Base(HaltReason::OutOfGas(OutOfGasError::Precompile)),
+            ..
+        }
+    ));
+
+    compare_or_save_op_testdata("test_halted_tx_call_bls12_381_g2_msm_out_of_gas.json", &output);
+}
+
+#[test]
+fn test_halted_tx_call_bls12_381_g2_msm_wrong_input_layout() {
+    let ctx = g2_msm_test_tx();
+
+    let mut evm = ctx.build_op();
+    let output = evm.replay().unwrap();
+
+    // assert fails post gas check, because input is wrong layout
+    assert!(matches!(
+        output.result,
+        ExecutionResult::Halt {
+            reason: OpHaltReason::Base(HaltReason::PrecompileErrorWithContext(ref msg)),
+            ..
+        } if msg == "bls12-381 fp 64 top bytes of input are not zero"
+    ));
+
+    compare_or_save_op_testdata(
+        "test_halted_tx_call_bls12_381_g2_msm_wrong_input_layout.json",
+        &output,
+    );
+}
+
+fn bl12_381_pairing_test_tx()
+-> Context<BlockEnv, OpTransaction<TxEnv>, CfgEnv<OpSpecId>, EmptyDB, Journal<EmptyDB>, L1BlockInfo>
+{
+    const SPEC_ID: OpSpecId = OpSpecId::ISTHMUS;
+
+    let input = Bytes::from([1; bls12_381_const::PAIRING_INPUT_LENGTH]);
+    let InitialAndFloorGas { initial_total_gas, .. } =
+        calculate_initial_tx_gas(SPEC_ID.into(), &input[..], false, 0, 0, 0);
+
+    let pairing_gas: u64 =
+        bls12_381_const::PAIRING_MULTIPLIER_BASE + bls12_381_const::PAIRING_OFFSET_BASE;
+
+    Context::op()
+        .with_tx(
+            OpTransaction::builder()
+                .base(
+                    TxEnv::builder()
+                        .kind(TxKind::Call(bls12_381_const::PAIRING_ADDRESS))
+                        .data(input)
+                        .gas_limit(initial_total_gas + pairing_gas),
+                )
+                .build_fill(),
+        )
+        .modify_chain_chained(|l1_block| {
+            l1_block.operator_fee_constant = Some(U256::ZERO);
+            l1_block.operator_fee_scalar = Some(U256::ZERO)
+        })
+        .with_cfg(CfgEnv::new_with_spec(OpSpecId::ISTHMUS))
+}
+
+#[test]
+fn test_halted_tx_call_bls12_381_pairing_input_wrong_size() {
+    const SPEC_ID: OpSpecId = OpSpecId::ISTHMUS;
+    let input = Bytes::from([1; bls12_381_const::PAIRING_INPUT_LENGTH]);
+    let InitialAndFloorGas { initial_total_gas, .. } =
+        calculate_initial_tx_gas(SPEC_ID.into(), &input[..], false, 0, 0, 0);
+    let pairing_gas: u64 =
+        bls12_381_const::PAIRING_MULTIPLIER_BASE + bls12_381_const::PAIRING_OFFSET_BASE;
+
+    let ctx = Context::op()
+        .with_tx(
+            OpTransaction::builder()
+                .base(
+                    TxEnv::builder()
+                        .kind(TxKind::Call(bls12_381_const::PAIRING_ADDRESS))
+                        .data(input.slice(1..))
+                        .gas_limit(initial_total_gas + pairing_gas),
+                )
+                .build_fill(),
+        )
+        .modify_chain_chained(|l1_block| {
+            l1_block.operator_fee_constant = Some(U256::ZERO);
+            l1_block.operator_fee_scalar = Some(U256::ZERO)
+        })
+        .with_cfg(CfgEnv::new_with_spec(OpSpecId::ISTHMUS));
+
+    let mut evm = ctx.build_op();
+    let output = evm.replay().unwrap();
+
+    // assert fails pre gas check, because input is wrong size
+    assert!(matches!(
+        output.result,
+        ExecutionResult::Halt {
+            reason: OpHaltReason::Base(HaltReason::PrecompileErrorWithContext(ref msg)),
+            ..
+        } if msg == "bls12-381 pairing input length error"
+    ));
+
+    compare_or_save_op_testdata(
+        "test_halted_tx_call_bls12_381_pairing_input_wrong_size.json",
+        &output,
+    );
+}
+
+#[test]
+fn test_halted_tx_call_bls12_381_pairing_out_of_gas() {
+    const SPEC_ID: OpSpecId = OpSpecId::ISTHMUS;
+    let input = Bytes::from([1; bls12_381_const::PAIRING_INPUT_LENGTH]);
+    let InitialAndFloorGas { initial_total_gas, .. } =
+        calculate_initial_tx_gas(SPEC_ID.into(), &input[..], false, 0, 0, 0);
+    let pairing_gas: u64 =
+        bls12_381_const::PAIRING_MULTIPLIER_BASE + bls12_381_const::PAIRING_OFFSET_BASE;
+
+    let ctx = Context::op()
+        .with_tx(
+            OpTransaction::builder()
+                .base(
+                    TxEnv::builder()
+                        .kind(TxKind::Call(bls12_381_const::PAIRING_ADDRESS))
+                        .data(input)
+                        .gas_limit(initial_total_gas + pairing_gas - 1),
+                )
+                .build_fill(),
+        )
+        .modify_chain_chained(|l1_block| {
+            l1_block.operator_fee_constant = Some(U256::ZERO);
+            l1_block.operator_fee_scalar = Some(U256::ZERO)
+        })
+        .with_cfg(CfgEnv::new_with_spec(OpSpecId::ISTHMUS));
+
+    let mut evm = ctx.build_op();
+    let output = evm.replay().unwrap();
+
+    // assert out of gas
+    assert!(matches!(
+        output.result,
+        ExecutionResult::Halt {
+            reason: OpHaltReason::Base(HaltReason::OutOfGas(OutOfGasError::Precompile)),
+            ..
+        }
+    ));
+
+    compare_or_save_op_testdata("test_halted_tx_call_bls12_381_pairing_out_of_gas.json", &output);
+}
+
+#[test]
+fn test_tx_call_bls12_381_pairing_wrong_input_layout() {
+    let ctx = bl12_381_pairing_test_tx();
+
+    let mut evm = ctx.build_op();
+    let output = evm.replay().unwrap();
+
+    // assert fails post gas check, because input is wrong layout
+    assert!(matches!(
+        output.result,
+        ExecutionResult::Halt {
+            reason: OpHaltReason::Base(HaltReason::PrecompileErrorWithContext(ref msg)),
+            ..
+        } if msg == "bls12-381 fp 64 top bytes of input are not zero"
+    ));
+
+    compare_or_save_op_testdata(
+        "test_halted_tx_call_bls12_381_pairing_wrong_input_layout.json",
+        &output,
+    );
+}
+
+#[test]
+fn test_halted_tx_call_bls12_381_map_fp_to_g1_out_of_gas() {
+    const SPEC_ID: OpSpecId = OpSpecId::ISTHMUS;
+    let input = Bytes::from([1; bls12_381_const::PADDED_FP_LENGTH]);
+    let InitialAndFloorGas { initial_total_gas, .. } =
+        calculate_initial_tx_gas(SPEC_ID.into(), &input[..], false, 0, 0, 0);
+
+    let ctx = Context::op()
+        .with_tx(
+            OpTransaction::builder()
+                .base(
+                    TxEnv::builder()
+                        .kind(TxKind::Call(bls12_381_const::MAP_FP_TO_G1_ADDRESS))
+                        .data(input)
+                        .gas_limit(
+                            initial_total_gas + bls12_381_const::MAP_FP_TO_G1_BASE_GAS_FEE - 1,
+                        ),
+                )
+                .build_fill(),
+        )
+        .modify_chain_chained(|l1_block| {
+            l1_block.operator_fee_constant = Some(U256::ZERO);
+            l1_block.operator_fee_scalar = Some(U256::ZERO)
+        })
+        .with_cfg(CfgEnv::new_with_spec(SPEC_ID));
+
+    let mut evm = ctx.build_op();
+    let output = evm.replay().unwrap();
+
+    // assert out of gas
+    assert!(matches!(
+        output.result,
+        ExecutionResult::Halt {
+            reason: OpHaltReason::Base(HaltReason::OutOfGas(OutOfGasError::Precompile)),
+            ..
+        }
+    ));
+
+    compare_or_save_op_testdata(
+        "test_halted_tx_call_bls12_381_map_fp_to_g1_out_of_gas.json",
+        &output,
+    );
+}
+
+#[test]
+fn test_halted_tx_call_bls12_381_map_fp_to_g1_input_wrong_size() {
+    const SPEC_ID: OpSpecId = OpSpecId::ISTHMUS;
+    let input = Bytes::from([1; bls12_381_const::PADDED_FP_LENGTH]);
+    let InitialAndFloorGas { initial_total_gas, .. } =
+        calculate_initial_tx_gas(SPEC_ID.into(), &input[..], false, 0, 0, 0);
+
+    let ctx = Context::op()
+        .with_tx(
+            OpTransaction::builder()
+                .base(
+                    TxEnv::builder()
+                        .kind(TxKind::Call(bls12_381_const::MAP_FP_TO_G1_ADDRESS))
+                        .data(input.slice(1..))
+                        .gas_limit(initial_total_gas + bls12_381_const::MAP_FP_TO_G1_BASE_GAS_FEE),
+                )
+                .build_fill(),
+        )
+        .modify_chain_chained(|l1_block| {
+            l1_block.operator_fee_constant = Some(U256::ZERO);
+            l1_block.operator_fee_scalar = Some(U256::ZERO)
+        })
+        .with_cfg(CfgEnv::new_with_spec(SPEC_ID));
+
+    let mut evm = ctx.build_op();
+    let output = evm.replay().unwrap();
+
+    // assert fails post gas check, because input is wrong size
+    assert!(matches!(
+        output.result,
+        ExecutionResult::Halt {
+            reason: OpHaltReason::Base(HaltReason::PrecompileErrorWithContext(ref msg)),
+            ..
+        } if msg == "bls12-381 map fp to g1 input length error"
+    ));
+
+    compare_or_save_op_testdata(
+        "test_halted_tx_call_bls12_381_map_fp_to_g1_input_wrong_size.json",
+        &output,
+    );
+}
+
+#[test]
+fn test_halted_tx_call_bls12_381_map_fp2_to_g2_out_of_gas() {
+    const SPEC_ID: OpSpecId = OpSpecId::ISTHMUS;
+    let input = Bytes::from([1; bls12_381_const::PADDED_FP2_LENGTH]);
+    let InitialAndFloorGas { initial_total_gas, .. } =
+        calculate_initial_tx_gas(SPEC_ID.into(), &input[..], false, 0, 0, 0);
+
+    let ctx = Context::op()
+        .with_tx(
+            OpTransaction::builder()
+                .base(
+                    TxEnv::builder()
+                        .kind(TxKind::Call(bls12_381_const::MAP_FP2_TO_G2_ADDRESS))
+                        .data(input)
+                        .gas_limit(
+                            initial_total_gas + bls12_381_const::MAP_FP2_TO_G2_BASE_GAS_FEE - 1,
+                        ),
+                )
+                .build_fill(),
+        )
+        .modify_chain_chained(|l1_block| {
+            l1_block.operator_fee_constant = Some(U256::ZERO);
+            l1_block.operator_fee_scalar = Some(U256::ZERO)
+        })
+        .with_cfg(CfgEnv::new_with_spec(SPEC_ID));
+
+    let mut evm = ctx.build_op();
+    let output = evm.replay().unwrap();
+
+    // assert out of gas
+    assert!(matches!(
+        output.result,
+        ExecutionResult::Halt {
+            reason: OpHaltReason::Base(HaltReason::OutOfGas(OutOfGasError::Precompile)),
+            ..
+        }
+    ));
+
+    compare_or_save_op_testdata(
+        "test_halted_tx_call_bls12_381_map_fp2_to_g2_out_of_gas.json",
+        &output,
+    );
+}
+
+#[test]
+fn test_l1block_load_for_pre_regolith() {
+    const SPEC_ID: OpSpecId = OpSpecId::REGOLITH;
+
+    let ctx = Context::op()
+        .with_tx(
+            OpTransaction::builder()
+                .base(
+                    TxEnv::builder()
+                        .caller(BENCH_CALLER)
+                        .kind(TxKind::Call(address!("0x0000000000000000000000000000000000100000")))
+                        .value(U256::from(1))
+                        .gas_limit(100_000),
+                )
+                .build_fill(),
+        )
+        .modify_chain_chained(|l1_block| {
+            l1_block.l2_block = None;
+        })
+        .with_cfg(CfgEnv::new_with_spec(SPEC_ID));
+
+    let mut evm =
+        ctx.with_db(State::builder().with_database(BenchmarkDB::default()).build()).build_op();
+    let output = evm.replay().unwrap();
+
+    // assert out of gas
+    assert!(output.result.is_success());
+
+    compare_or_save_op_testdata("test_l1block_load_for_pre_regolith.json", &output);
+}
+
+#[test]
+fn test_halted_tx_call_bls12_381_map_fp2_to_g2_input_wrong_size() {
+    const SPEC_ID: OpSpecId = OpSpecId::ISTHMUS;
+    let input = Bytes::from([1; bls12_381_const::PADDED_FP2_LENGTH]);
+    let InitialAndFloorGas { initial_total_gas, .. } =
+        calculate_initial_tx_gas(SPEC_ID.into(), &input[..], false, 0, 0, 0);
+
+    let ctx = Context::op()
+        .with_tx(
+            OpTransaction::builder()
+                .base(
+                    TxEnv::builder()
+                        .kind(TxKind::Call(bls12_381_const::MAP_FP2_TO_G2_ADDRESS))
+                        .data(input.slice(1..))
+                        .gas_limit(initial_total_gas + bls12_381_const::MAP_FP2_TO_G2_BASE_GAS_FEE),
+                )
+                .build_fill(),
+        )
+        .modify_chain_chained(|l1_block| {
+            l1_block.operator_fee_constant = Some(U256::ZERO);
+            l1_block.operator_fee_scalar = Some(U256::ZERO)
+        })
+        .with_cfg(CfgEnv::new_with_spec(SPEC_ID));
+
+    let mut evm = ctx.build_op();
+    let output = evm.replay().unwrap();
+
+    // assert fails post gas check, because input is wrong size
+    assert!(matches!(
+        output.result,
+        ExecutionResult::Halt {
+            reason: OpHaltReason::Base(HaltReason::PrecompileErrorWithContext(ref msg)),
+            ..
+        } if msg == "bls12-381 map fp2 to g2 input length error"
+    ));
+
+    compare_or_save_op_testdata(
+        "test_halted_tx_call_bls12_381_map_fp2_to_g2_input_wrong_size.json",
+        &output,
+    );
+}
+
+#[test]
+#[cfg(feature = "optional_balance_check")]
+fn test_disable_balance_check() {
+    const RETURN_CALLER_BALANCE_BYTECODE: &[u8] = &[
+        opcode::CALLER,
+        opcode::BALANCE,
+        opcode::PUSH1,
+        0x00,
+        opcode::MSTORE,
+        opcode::PUSH1,
+        0x20,
+        opcode::PUSH1,
+        0x00,
+        opcode::RETURN,
+    ];
+
+    let mut evm = Context::op()
+        .modify_cfg_chained(|cfg| cfg.disable_balance_check = true)
+        .with_db(BenchmarkDB::new_bytecode(Bytecode::new_legacy(
+            RETURN_CALLER_BALANCE_BYTECODE.into(),
+        )))
+        .build_op();
+
+    // Construct tx so that effective cost is more than caller balance.
+    let gas_price = 1;
+    let gas_limit = 100_000;
+    // Make sure value doesn't consume all balance since we want to validate that all effective
+    // cost is deducted.
+    let tx_value = BENCH_CALLER_BALANCE - U256::from(1);
+
+    let result = evm
+        .transact_one(
+            OpTransaction::builder()
+                .base(
+                    TxEnv::builder_for_bench()
+                        .gas_price(gas_price)
+                        .gas_limit(gas_limit)
+                        .value(tx_value),
+                )
+                .build_fill(),
+        )
+        .unwrap();
+
+    assert!(result.is_success());
+
+    let returned_balance = U256::from_be_slice(result.output().unwrap().as_ref());
+    let expected_balance = U256::ZERO;
+    assert_eq!(returned_balance, expected_balance);
+}
+
+#[derive(Default, Debug)]
+struct LogInspector {
+    logs: Vec<Log>,
+}
+
+impl<CTX, INTR: InterpreterTypes> Inspector<CTX, INTR> for LogInspector {
+    fn log(&mut self, _context: &mut CTX, log: Log) {
+        self.logs.push(log);
+    }
+}
+
+#[test]
+fn test_log_inspector() {
+    // simple yul contract emits a log in constructor
+
+    /*object "Contract" {
+        code {
+            log0(0, 0)
+        }
+    }*/
+
+    let contract_data: Bytes =
+        Bytes::from([opcode::PUSH1, 0x00, opcode::DUP1, opcode::LOG0, opcode::STOP]);
+    let bytecode = Bytecode::new_raw(contract_data);
+
+    let ctx = Context::op().with_db(BenchmarkDB::new_bytecode(bytecode));
+
+    let mut evm = ctx.build_op_with_inspector(LogInspector::default());
+
+    let tx = OpTransaction::builder()
+        .base(TxEnv::builder().caller(BENCH_CALLER).kind(TxKind::Call(BENCH_TARGET)))
+        .build_fill();
+
+    // Run evm.
+    let output = evm.inspect_tx(tx).unwrap();
+
+    let inspector = &evm.0.inspector;
+    assert!(!inspector.logs.is_empty());
+
+    compare_or_save_op_testdata("test_log_inspector.json", &output);
+}
+
+#[test]
+fn test_system_call_inspection() {
+    use revm::InspectSystemCallEvm;
+
+    let ctx = Context::op();
+
+    let mut evm = ctx.build_op_with_inspector(LogInspector::default());
+
+    // Test system call inspection
+    let result = evm.inspect_one_system_call(BENCH_TARGET, Bytes::default()).unwrap();
+
+    // Should succeed
+    assert!(result.is_success());
+
+    // Test system call inspection with caller
+    let custom_caller = Address::from([0x12; 20]);
+    let result = evm
+        .inspect_one_system_call_with_caller(custom_caller, BENCH_TARGET, Bytes::default())
+        .unwrap();
+
+    // Should also succeed
+    assert!(result.is_success());
+
+    // Test system call inspection with inspector
+    let result = evm
+        .inspect_one_system_call_with_inspector(
+            BENCH_TARGET,
+            Bytes::default(),
+            LogInspector::default(),
+        )
+        .unwrap();
+
+    // Should succeed
+    assert!(result.is_success());
+}
+
+#[test]
+fn test_system_call() {
+    let ctx = Context::op();
+
+    let mut evm = ctx.build_op();
+
+    let _ = evm.system_call_one(BENCH_TARGET, bytes!("0x0001"));
+    let state = evm.finalize();
+
+    assert!(!state.contains_key(&SYSTEM_ADDRESS));
+    assert!(state.get(&BENCH_TARGET).unwrap().is_touched());
+}

--- a/rust/revm-ee-tests/tests/op_revm_testdata/test_deposit_tx.json
+++ b/rust/revm-ee-tests/tests/op_revm_testdata/test_deposit_tx.json
@@ -1,0 +1,65 @@
+{
+  "result": {
+    "Success": {
+      "gas": {
+        "floor_gas": 0,
+        "gas_refunded": 0,
+        "gas_spent": 21000,
+        "intrinsic_gas": 21000,
+        "limit": 16777216
+      },
+      "logs": [],
+      "output": {
+        "Call": "0x"
+      },
+      "reason": "Stop"
+    }
+  },
+  "state": {
+    "0x0000000000000000000000000000000000000000": {
+      "info": {
+        "balance": "0x64",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 1
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    }
+  }
+}

--- a/rust/revm-ee-tests/tests/op_revm_testdata/test_halted_deposit_tx.json
+++ b/rust/revm-ee-tests/tests/op_revm_testdata/test_halted_deposit_tx.json
@@ -1,0 +1,111 @@
+{
+  "result": {
+    "Halt": {
+      "gas": {
+        "floor_gas": 0,
+        "gas_refunded": 0,
+        "gas_spent": 16777216,
+        "intrinsic_gas": 0,
+        "limit": 16777216
+      },
+      "logs": [],
+      "reason": "FailedDeposit"
+    }
+  },
+  "state": {
+    "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee": {
+      "info": {
+        "balance": "0x2386f26fc10064",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 1
+      },
+      "original_info": {
+        "balance": "0x2386f26fc10000",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0xffffffffffffffffffffffffffffffffffffffff": {
+      "info": {
+        "balance": "0x2386f26fc10000",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x5000",
+            "jump_table": {
+              "bits": 1,
+              "data": [
+                0
+              ],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 1
+          }
+        },
+        "code_hash": "0x7b2ab94bb7d45041581aa3757ae020084674ccad6f75dc3750eb2ea8a92c4e9a",
+        "nonce": 1
+      },
+      "original_info": {
+        "balance": "0x2386f26fc10000",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x5000",
+            "jump_table": {
+              "bits": 1,
+              "data": [
+                0
+              ],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 1
+          }
+        },
+        "code_hash": "0x7b2ab94bb7d45041581aa3757ae020084674ccad6f75dc3750eb2ea8a92c4e9a",
+        "nonce": 1
+      },
+      "status": "Cold",
+      "storage": {},
+      "transaction_id": 0
+    }
+  }
+}

--- a/rust/revm-ee-tests/tests/op_revm_testdata/test_halted_tx_call_bls12_381_g1_add_input_wrong_size.json
+++ b/rust/revm-ee-tests/tests/op_revm_testdata/test_halted_tx_call_bls12_381_g1_add_input_wrong_size.json
@@ -1,0 +1,246 @@
+{
+  "result": {
+    "Halt": {
+      "gas": {
+        "floor_gas": 21000,
+        "gas_refunded": 0,
+        "gas_spent": 21375,
+        "intrinsic_gas": 21000,
+        "limit": 21375
+      },
+      "logs": [],
+      "reason": {
+        "Base": {
+          "PrecompileErrorWithContext": "bls12-381 g1 add input length error"
+        }
+      }
+    }
+  },
+  "state": {
+    "0x0000000000000000000000000000000000000000": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 1
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x000000000000000000000000000000000000000b": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x4200000000000000000000000000000000000019": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x420000000000000000000000000000000000001a": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x420000000000000000000000000000000000001b": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    }
+  }
+}

--- a/rust/revm-ee-tests/tests/op_revm_testdata/test_halted_tx_call_bls12_381_g1_add_out_of_gas.json
+++ b/rust/revm-ee-tests/tests/op_revm_testdata/test_halted_tx_call_bls12_381_g1_add_out_of_gas.json
@@ -1,0 +1,246 @@
+{
+  "result": {
+    "Halt": {
+      "gas": {
+        "floor_gas": 21000,
+        "gas_refunded": 0,
+        "gas_spent": 21374,
+        "intrinsic_gas": 21000,
+        "limit": 21374
+      },
+      "logs": [],
+      "reason": {
+        "Base": {
+          "OutOfGas": "Precompile"
+        }
+      }
+    }
+  },
+  "state": {
+    "0x0000000000000000000000000000000000000000": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 1
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x000000000000000000000000000000000000000b": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x4200000000000000000000000000000000000019": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x420000000000000000000000000000000000001a": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x420000000000000000000000000000000000001b": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    }
+  }
+}

--- a/rust/revm-ee-tests/tests/op_revm_testdata/test_halted_tx_call_bls12_381_g1_msm_input_wrong_size.json
+++ b/rust/revm-ee-tests/tests/op_revm_testdata/test_halted_tx_call_bls12_381_g1_msm_input_wrong_size.json
@@ -1,0 +1,246 @@
+{
+  "result": {
+    "Halt": {
+      "gas": {
+        "floor_gas": 27360,
+        "gas_refunded": 0,
+        "gas_spent": 35560,
+        "intrinsic_gas": 23544,
+        "limit": 35560
+      },
+      "logs": [],
+      "reason": {
+        "Base": {
+          "PrecompileErrorWithContext": "bls12-381 g1 msm input length error"
+        }
+      }
+    }
+  },
+  "state": {
+    "0x0000000000000000000000000000000000000000": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 1
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x000000000000000000000000000000000000000c": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x4200000000000000000000000000000000000019": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x420000000000000000000000000000000000001a": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x420000000000000000000000000000000000001b": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    }
+  }
+}

--- a/rust/revm-ee-tests/tests/op_revm_testdata/test_halted_tx_call_bls12_381_g1_msm_out_of_gas.json
+++ b/rust/revm-ee-tests/tests/op_revm_testdata/test_halted_tx_call_bls12_381_g1_msm_out_of_gas.json
@@ -1,0 +1,246 @@
+{
+  "result": {
+    "Halt": {
+      "gas": {
+        "floor_gas": 27400,
+        "gas_refunded": 0,
+        "gas_spent": 35559,
+        "intrinsic_gas": 23560,
+        "limit": 35559
+      },
+      "logs": [],
+      "reason": {
+        "Base": {
+          "OutOfGas": "Precompile"
+        }
+      }
+    }
+  },
+  "state": {
+    "0x0000000000000000000000000000000000000000": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 1
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x000000000000000000000000000000000000000c": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x4200000000000000000000000000000000000019": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x420000000000000000000000000000000000001a": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x420000000000000000000000000000000000001b": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    }
+  }
+}

--- a/rust/revm-ee-tests/tests/op_revm_testdata/test_halted_tx_call_bls12_381_g1_msm_wrong_input_layout.json
+++ b/rust/revm-ee-tests/tests/op_revm_testdata/test_halted_tx_call_bls12_381_g1_msm_wrong_input_layout.json
@@ -1,0 +1,246 @@
+{
+  "result": {
+    "Halt": {
+      "gas": {
+        "floor_gas": 27400,
+        "gas_refunded": 0,
+        "gas_spent": 35560,
+        "intrinsic_gas": 23560,
+        "limit": 35560
+      },
+      "logs": [],
+      "reason": {
+        "Base": {
+          "PrecompileErrorWithContext": "bls12-381 fp 64 top bytes of input are not zero"
+        }
+      }
+    }
+  },
+  "state": {
+    "0x0000000000000000000000000000000000000000": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 1
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x000000000000000000000000000000000000000c": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x4200000000000000000000000000000000000019": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x420000000000000000000000000000000000001a": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x420000000000000000000000000000000000001b": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    }
+  }
+}

--- a/rust/revm-ee-tests/tests/op_revm_testdata/test_halted_tx_call_bls12_381_g2_add_input_wrong_size.json
+++ b/rust/revm-ee-tests/tests/op_revm_testdata/test_halted_tx_call_bls12_381_g2_add_input_wrong_size.json
@@ -1,0 +1,246 @@
+{
+  "result": {
+    "Halt": {
+      "gas": {
+        "floor_gas": 21000,
+        "gas_refunded": 0,
+        "gas_spent": 21600,
+        "intrinsic_gas": 21000,
+        "limit": 21600
+      },
+      "logs": [],
+      "reason": {
+        "Base": {
+          "PrecompileErrorWithContext": "bls12-381 g2 add input length error"
+        }
+      }
+    }
+  },
+  "state": {
+    "0x0000000000000000000000000000000000000000": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 1
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x000000000000000000000000000000000000000d": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x4200000000000000000000000000000000000019": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x420000000000000000000000000000000000001a": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x420000000000000000000000000000000000001b": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    }
+  }
+}

--- a/rust/revm-ee-tests/tests/op_revm_testdata/test_halted_tx_call_bls12_381_g2_add_out_of_gas.json
+++ b/rust/revm-ee-tests/tests/op_revm_testdata/test_halted_tx_call_bls12_381_g2_add_out_of_gas.json
@@ -1,0 +1,246 @@
+{
+  "result": {
+    "Halt": {
+      "gas": {
+        "floor_gas": 21000,
+        "gas_refunded": 0,
+        "gas_spent": 21599,
+        "intrinsic_gas": 21000,
+        "limit": 21599
+      },
+      "logs": [],
+      "reason": {
+        "Base": {
+          "OutOfGas": "Precompile"
+        }
+      }
+    }
+  },
+  "state": {
+    "0x0000000000000000000000000000000000000000": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 1
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x000000000000000000000000000000000000000d": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x4200000000000000000000000000000000000019": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x420000000000000000000000000000000000001a": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x420000000000000000000000000000000000001b": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    }
+  }
+}

--- a/rust/revm-ee-tests/tests/op_revm_testdata/test_halted_tx_call_bls12_381_g2_msm_input_wrong_size.json
+++ b/rust/revm-ee-tests/tests/op_revm_testdata/test_halted_tx_call_bls12_381_g2_msm_input_wrong_size.json
@@ -1,0 +1,246 @@
+{
+  "result": {
+    "Halt": {
+      "gas": {
+        "floor_gas": 32480,
+        "gas_refunded": 0,
+        "gas_spent": 48108,
+        "intrinsic_gas": 25592,
+        "limit": 48108
+      },
+      "logs": [],
+      "reason": {
+        "Base": {
+          "PrecompileErrorWithContext": "bls12-381 g2 msm input length error"
+        }
+      }
+    }
+  },
+  "state": {
+    "0x0000000000000000000000000000000000000000": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 1
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x000000000000000000000000000000000000000e": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x4200000000000000000000000000000000000019": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x420000000000000000000000000000000000001a": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x420000000000000000000000000000000000001b": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    }
+  }
+}

--- a/rust/revm-ee-tests/tests/op_revm_testdata/test_halted_tx_call_bls12_381_g2_msm_out_of_gas.json
+++ b/rust/revm-ee-tests/tests/op_revm_testdata/test_halted_tx_call_bls12_381_g2_msm_out_of_gas.json
@@ -1,0 +1,246 @@
+{
+  "result": {
+    "Halt": {
+      "gas": {
+        "floor_gas": 32520,
+        "gas_refunded": 0,
+        "gas_spent": 48107,
+        "intrinsic_gas": 25608,
+        "limit": 48107
+      },
+      "logs": [],
+      "reason": {
+        "Base": {
+          "OutOfGas": "Precompile"
+        }
+      }
+    }
+  },
+  "state": {
+    "0x0000000000000000000000000000000000000000": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 1
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x000000000000000000000000000000000000000e": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x4200000000000000000000000000000000000019": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x420000000000000000000000000000000000001a": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x420000000000000000000000000000000000001b": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    }
+  }
+}

--- a/rust/revm-ee-tests/tests/op_revm_testdata/test_halted_tx_call_bls12_381_g2_msm_wrong_input_layout.json
+++ b/rust/revm-ee-tests/tests/op_revm_testdata/test_halted_tx_call_bls12_381_g2_msm_wrong_input_layout.json
@@ -1,0 +1,246 @@
+{
+  "result": {
+    "Halt": {
+      "gas": {
+        "floor_gas": 32520,
+        "gas_refunded": 0,
+        "gas_spent": 48108,
+        "intrinsic_gas": 25608,
+        "limit": 48108
+      },
+      "logs": [],
+      "reason": {
+        "Base": {
+          "PrecompileErrorWithContext": "bls12-381 fp 64 top bytes of input are not zero"
+        }
+      }
+    }
+  },
+  "state": {
+    "0x0000000000000000000000000000000000000000": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 1
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x000000000000000000000000000000000000000e": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x4200000000000000000000000000000000000019": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x420000000000000000000000000000000000001a": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x420000000000000000000000000000000000001b": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    }
+  }
+}

--- a/rust/revm-ee-tests/tests/op_revm_testdata/test_halted_tx_call_bls12_381_map_fp2_to_g2_input_wrong_size.json
+++ b/rust/revm-ee-tests/tests/op_revm_testdata/test_halted_tx_call_bls12_381_map_fp2_to_g2_input_wrong_size.json
@@ -1,0 +1,246 @@
+{
+  "result": {
+    "Halt": {
+      "gas": {
+        "floor_gas": 26080,
+        "gas_refunded": 0,
+        "gas_spent": 46848,
+        "intrinsic_gas": 23032,
+        "limit": 46848
+      },
+      "logs": [],
+      "reason": {
+        "Base": {
+          "PrecompileErrorWithContext": "bls12-381 map fp2 to g2 input length error"
+        }
+      }
+    }
+  },
+  "state": {
+    "0x0000000000000000000000000000000000000000": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 1
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x0000000000000000000000000000000000000011": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x4200000000000000000000000000000000000019": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x420000000000000000000000000000000000001a": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x420000000000000000000000000000000000001b": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    }
+  }
+}

--- a/rust/revm-ee-tests/tests/op_revm_testdata/test_halted_tx_call_bls12_381_map_fp2_to_g2_out_of_gas.json
+++ b/rust/revm-ee-tests/tests/op_revm_testdata/test_halted_tx_call_bls12_381_map_fp2_to_g2_out_of_gas.json
@@ -1,0 +1,246 @@
+{
+  "result": {
+    "Halt": {
+      "gas": {
+        "floor_gas": 26120,
+        "gas_refunded": 0,
+        "gas_spent": 46847,
+        "intrinsic_gas": 23048,
+        "limit": 46847
+      },
+      "logs": [],
+      "reason": {
+        "Base": {
+          "OutOfGas": "Precompile"
+        }
+      }
+    }
+  },
+  "state": {
+    "0x0000000000000000000000000000000000000000": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 1
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x0000000000000000000000000000000000000011": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x4200000000000000000000000000000000000019": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x420000000000000000000000000000000000001a": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x420000000000000000000000000000000000001b": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    }
+  }
+}

--- a/rust/revm-ee-tests/tests/op_revm_testdata/test_halted_tx_call_bls12_381_map_fp_to_g1_input_wrong_size.json
+++ b/rust/revm-ee-tests/tests/op_revm_testdata/test_halted_tx_call_bls12_381_map_fp_to_g1_input_wrong_size.json
@@ -1,0 +1,246 @@
+{
+  "result": {
+    "Halt": {
+      "gas": {
+        "floor_gas": 23520,
+        "gas_refunded": 0,
+        "gas_spent": 27524,
+        "intrinsic_gas": 22008,
+        "limit": 27524
+      },
+      "logs": [],
+      "reason": {
+        "Base": {
+          "PrecompileErrorWithContext": "bls12-381 map fp to g1 input length error"
+        }
+      }
+    }
+  },
+  "state": {
+    "0x0000000000000000000000000000000000000000": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 1
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x0000000000000000000000000000000000000010": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x4200000000000000000000000000000000000019": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x420000000000000000000000000000000000001a": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x420000000000000000000000000000000000001b": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    }
+  }
+}

--- a/rust/revm-ee-tests/tests/op_revm_testdata/test_halted_tx_call_bls12_381_map_fp_to_g1_out_of_gas.json
+++ b/rust/revm-ee-tests/tests/op_revm_testdata/test_halted_tx_call_bls12_381_map_fp_to_g1_out_of_gas.json
@@ -1,0 +1,246 @@
+{
+  "result": {
+    "Halt": {
+      "gas": {
+        "floor_gas": 23560,
+        "gas_refunded": 0,
+        "gas_spent": 27523,
+        "intrinsic_gas": 22024,
+        "limit": 27523
+      },
+      "logs": [],
+      "reason": {
+        "Base": {
+          "OutOfGas": "Precompile"
+        }
+      }
+    }
+  },
+  "state": {
+    "0x0000000000000000000000000000000000000000": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 1
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x0000000000000000000000000000000000000010": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x4200000000000000000000000000000000000019": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x420000000000000000000000000000000000001a": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x420000000000000000000000000000000000001b": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    }
+  }
+}

--- a/rust/revm-ee-tests/tests/op_revm_testdata/test_halted_tx_call_bls12_381_pairing_input_wrong_size.json
+++ b/rust/revm-ee-tests/tests/op_revm_testdata/test_halted_tx_call_bls12_381_pairing_input_wrong_size.json
@@ -1,0 +1,246 @@
+{
+  "result": {
+    "Halt": {
+      "gas": {
+        "floor_gas": 36320,
+        "gas_refunded": 0,
+        "gas_spent": 97444,
+        "intrinsic_gas": 27128,
+        "limit": 97444
+      },
+      "logs": [],
+      "reason": {
+        "Base": {
+          "PrecompileErrorWithContext": "bls12-381 pairing input length error"
+        }
+      }
+    }
+  },
+  "state": {
+    "0x0000000000000000000000000000000000000000": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 1
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x000000000000000000000000000000000000000f": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x4200000000000000000000000000000000000019": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x420000000000000000000000000000000000001a": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x420000000000000000000000000000000000001b": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    }
+  }
+}

--- a/rust/revm-ee-tests/tests/op_revm_testdata/test_halted_tx_call_bls12_381_pairing_out_of_gas.json
+++ b/rust/revm-ee-tests/tests/op_revm_testdata/test_halted_tx_call_bls12_381_pairing_out_of_gas.json
@@ -1,0 +1,246 @@
+{
+  "result": {
+    "Halt": {
+      "gas": {
+        "floor_gas": 36360,
+        "gas_refunded": 0,
+        "gas_spent": 97443,
+        "intrinsic_gas": 27144,
+        "limit": 97443
+      },
+      "logs": [],
+      "reason": {
+        "Base": {
+          "OutOfGas": "Precompile"
+        }
+      }
+    }
+  },
+  "state": {
+    "0x0000000000000000000000000000000000000000": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 1
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x000000000000000000000000000000000000000f": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x4200000000000000000000000000000000000019": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x420000000000000000000000000000000000001a": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x420000000000000000000000000000000000001b": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    }
+  }
+}

--- a/rust/revm-ee-tests/tests/op_revm_testdata/test_halted_tx_call_bls12_381_pairing_wrong_input_layout.json
+++ b/rust/revm-ee-tests/tests/op_revm_testdata/test_halted_tx_call_bls12_381_pairing_wrong_input_layout.json
@@ -1,0 +1,246 @@
+{
+  "result": {
+    "Halt": {
+      "gas": {
+        "floor_gas": 36360,
+        "gas_refunded": 0,
+        "gas_spent": 97444,
+        "intrinsic_gas": 27144,
+        "limit": 97444
+      },
+      "logs": [],
+      "reason": {
+        "Base": {
+          "PrecompileErrorWithContext": "bls12-381 fp 64 top bytes of input are not zero"
+        }
+      }
+    }
+  },
+  "state": {
+    "0x0000000000000000000000000000000000000000": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 1
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x000000000000000000000000000000000000000f": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x4200000000000000000000000000000000000019": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x420000000000000000000000000000000000001a": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x420000000000000000000000000000000000001b": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    }
+  }
+}

--- a/rust/revm-ee-tests/tests/op_revm_testdata/test_halted_tx_call_bn254_pair_fjord.json
+++ b/rust/revm-ee-tests/tests/op_revm_testdata/test_halted_tx_call_bn254_pair_fjord.json
@@ -1,0 +1,246 @@
+{
+  "result": {
+    "Halt": {
+      "gas": {
+        "floor_gas": 0,
+        "gas_refunded": 0,
+        "gas_spent": 1824024,
+        "intrinsic_gas": 1824024,
+        "limit": 1824024
+      },
+      "logs": [],
+      "reason": {
+        "Base": {
+          "OutOfGas": "Precompile"
+        }
+      }
+    }
+  },
+  "state": {
+    "0x0000000000000000000000000000000000000000": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 1
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x0000000000000000000000000000000000000008": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x4200000000000000000000000000000000000019": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x420000000000000000000000000000000000001a": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x420000000000000000000000000000000000001b": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    }
+  }
+}

--- a/rust/revm-ee-tests/tests/op_revm_testdata/test_halted_tx_call_bn254_pair_granite.json
+++ b/rust/revm-ee-tests/tests/op_revm_testdata/test_halted_tx_call_bn254_pair_granite.json
@@ -1,0 +1,246 @@
+{
+  "result": {
+    "Halt": {
+      "gas": {
+        "floor_gas": 0,
+        "gas_refunded": 0,
+        "gas_spent": 1824024,
+        "intrinsic_gas": 1824024,
+        "limit": 1824024
+      },
+      "logs": [],
+      "reason": {
+        "Base": {
+          "PrecompileErrorWithContext": "bn254 invalid pair length"
+        }
+      }
+    }
+  },
+  "state": {
+    "0x0000000000000000000000000000000000000000": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 1
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x0000000000000000000000000000000000000008": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x4200000000000000000000000000000000000019": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x420000000000000000000000000000000000001a": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x420000000000000000000000000000000000001b": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    }
+  }
+}

--- a/rust/revm-ee-tests/tests/op_revm_testdata/test_halted_tx_call_p256verify.json
+++ b/rust/revm-ee-tests/tests/op_revm_testdata/test_halted_tx_call_p256verify.json
@@ -1,0 +1,246 @@
+{
+  "result": {
+    "Halt": {
+      "gas": {
+        "floor_gas": 0,
+        "gas_refunded": 0,
+        "gas_spent": 24449,
+        "intrinsic_gas": 21000,
+        "limit": 24449
+      },
+      "logs": [],
+      "reason": {
+        "Base": {
+          "OutOfGas": "Precompile"
+        }
+      }
+    }
+  },
+  "state": {
+    "0x0000000000000000000000000000000000000000": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 1
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x0000000000000000000000000000000000000100": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x4200000000000000000000000000000000000019": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x420000000000000000000000000000000000001a": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x420000000000000000000000000000000000001b": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    }
+  }
+}

--- a/rust/revm-ee-tests/tests/op_revm_testdata/test_l1block_load_for_pre_regolith.json
+++ b/rust/revm-ee-tests/tests/op_revm_testdata/test_l1block_load_for_pre_regolith.json
@@ -1,0 +1,276 @@
+{
+  "result": {
+    "Success": {
+      "gas": {
+        "floor_gas": 0,
+        "gas_refunded": 0,
+        "gas_spent": 21000,
+        "intrinsic_gas": 21000,
+        "limit": 100000
+      },
+      "logs": [],
+      "output": {
+        "Call": "0x"
+      },
+      "reason": "Stop"
+    }
+  },
+  "state": {
+    "0x0000000000000000000000000000000000000000": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x0000000000000000000000000000000000100000": {
+      "info": {
+        "balance": "0x1",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x4200000000000000000000000000000000000019": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x420000000000000000000000000000000000001a": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x420000000000000000000000000000000000001b": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee": {
+      "info": {
+        "balance": "0x2386f26fc0ffff",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 1
+      },
+      "original_info": {
+        "balance": "0x2386f26fc10000",
+        "code": null,
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched",
+      "storage": {},
+      "transaction_id": 0
+    }
+  }
+}

--- a/rust/revm-ee-tests/tests/op_revm_testdata/test_log_inspector.json
+++ b/rust/revm-ee-tests/tests/op_revm_testdata/test_log_inspector.json
@@ -1,0 +1,286 @@
+{
+  "result": {
+    "Success": {
+      "gas": {
+        "floor_gas": 0,
+        "gas_refunded": 0,
+        "gas_spent": 21381,
+        "intrinsic_gas": 21000,
+        "limit": 16777216
+      },
+      "logs": [
+        {
+          "address": "0xffffffffffffffffffffffffffffffffffffffff",
+          "data": "0x",
+          "topics": []
+        }
+      ],
+      "output": {
+        "Call": "0x"
+      },
+      "reason": "Stop"
+    }
+  },
+  "state": {
+    "0x0000000000000000000000000000000000000000": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x4200000000000000000000000000000000000019": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x420000000000000000000000000000000000001a": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x420000000000000000000000000000000000001b": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee": {
+      "info": {
+        "balance": "0x2386f26fc10000",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 1
+      },
+      "original_info": {
+        "balance": "0x2386f26fc10000",
+        "code": null,
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0xffffffffffffffffffffffffffffffffffffffff": {
+      "info": {
+        "balance": "0x2386f26fc10000",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x600080a000",
+            "jump_table": {
+              "bits": 5,
+              "data": [
+                0
+              ],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 5
+          }
+        },
+        "code_hash": "0x8013c386d5a03c3fa0a6ccbfefcf7d91471dedba2bb94eefef57f916e5929a8d",
+        "nonce": 1
+      },
+      "original_info": {
+        "balance": "0x2386f26fc10000",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x600080a000",
+            "jump_table": {
+              "bits": 5,
+              "data": [
+                0
+              ],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 5
+          }
+        },
+        "code_hash": "0x8013c386d5a03c3fa0a6ccbfefcf7d91471dedba2bb94eefef57f916e5929a8d",
+        "nonce": 1
+      },
+      "status": "Touched",
+      "storage": {},
+      "transaction_id": 0
+    }
+  }
+}

--- a/rust/revm-ee-tests/tests/op_revm_testdata/test_tx_call_p256verify.json
+++ b/rust/revm-ee-tests/tests/op_revm_testdata/test_tx_call_p256verify.json
@@ -1,0 +1,245 @@
+{
+  "result": {
+    "Success": {
+      "gas": {
+        "floor_gas": 0,
+        "gas_refunded": 0,
+        "gas_spent": 24450,
+        "intrinsic_gas": 21000,
+        "limit": 24450
+      },
+      "logs": [],
+      "output": {
+        "Call": "0x"
+      },
+      "reason": "Return"
+    }
+  },
+  "state": {
+    "0x0000000000000000000000000000000000000000": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 1
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x0000000000000000000000000000000000000100": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x4200000000000000000000000000000000000019": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x420000000000000000000000000000000000001a": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x420000000000000000000000000000000000001b": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    }
+  }
+}

--- a/rust/revm-ee-tests/tests/testdata/test_data.json
+++ b/rust/revm-ee-tests/tests/testdata/test_data.json
@@ -1,0 +1,4 @@
+{
+  "message": "test message",
+  "value": 42
+}


### PR DESCRIPTION
## Summary

Ports the op-revm integration tests from upstream revm's [`revm-ee-tests`](https://github.com/bluealloy/revm) crate into the monorepo so they run as part of Rust CI.

- New workspace member `rust/revm-ee-tests/` (added to `rust/Cargo.toml`).
- Only the `op_revm_tests` module is included; upstream `revm_tests` and `eip8037` modules were intentionally dropped (they exercise mainnet revm / TIP-1016, not op-revm).
- `compare_or_save_testdata` snapshot helper ported as-is — first run saves, subsequent runs compare.
- Small adjustments to satisfy this workspace's stricter lints (`clippy::manual_assert`, `redundant_clone`, `unnecessary_get_then_check`) and `cargo fmt` style.

## Test plan

- [ ] `cargo test -p revm-ee-tests --locked` — 28 tests pass
- [ ] `cargo clippy --workspace --all-targets --all-features --locked` — clean
- [ ] `cargo +nightly fmt -- --check` — clean
- [ ] `RUSTDOCFLAGS="-D warnings ..." cargo +nightly doc` — clean
- [ ] `cargo deny --all-features check all` — clean
- [ ] `cargo hack check --each-feature --no-dev-deps -p revm-ee-tests` — clean
- [ ] `zepter run check`, `typos`, `cargo +nightly udeps` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)