### PR TITLE
fix(op-proposer): fail over to caught-up supernode sync status

### DIFF
--- a/op-proposer/proposer/source/source_supernode.go
+++ b/op-proposer/proposer/source/source_supernode.go
@@ -67,7 +67,7 @@ func (s *SuperNodeProposalSource) SyncStatus(ctx context.Context) (SyncStatus, e
 	close(results)
 
 	var errs []error
-	var earliestResponse eth.SuperRootAtTimestampResponse
+	var highestResponse eth.SuperRootAtTimestampResponse
 	var hasValidResponse bool
 	for result := range results {
 		if result.err != nil {
@@ -75,9 +75,10 @@ func (s *SuperNodeProposalSource) SyncStatus(ctx context.Context) (SyncStatus, e
 			errs = append(errs, result.err)
 			continue
 		}
-		// Use the response with the lowest CurrentL1 block number (most conservative)
-		if !hasValidResponse || result.resp.CurrentL1.Number < earliestResponse.CurrentL1.Number {
-			earliestResponse = result.resp
+		// Use the source with the highest L1 view so lagging supernodes do not
+		// hold back failover when another healthy source is caught up.
+		if !hasValidResponse || result.resp.CurrentL1.Number > highestResponse.CurrentL1.Number {
+			highestResponse = result.resp
 			hasValidResponse = true
 		}
 	}
@@ -87,9 +88,9 @@ func (s *SuperNodeProposalSource) SyncStatus(ctx context.Context) (SyncStatus, e
 	}
 
 	return SyncStatus{
-		CurrentL1:   earliestResponse.CurrentL1,
-		SafeL2:      earliestResponse.CurrentSafeTimestamp,
-		FinalizedL2: earliestResponse.CurrentFinalizedTimestamp,
+		CurrentL1:   highestResponse.CurrentL1,
+		SafeL2:      highestResponse.CurrentSafeTimestamp,
+		FinalizedL2: highestResponse.CurrentFinalizedTimestamp,
 	}, nil
 }
 

--- a/op-proposer/proposer/source/source_supernode_test.go
+++ b/op-proposer/proposer/source/source_supernode_test.go
@@ -34,7 +34,7 @@ func TestSuperNodeSource_SyncStatus(t *testing.T) {
 		}, status)
 	})
 
-	t.Run("Multi-ReturnLowestCurrentL1", func(t *testing.T) {
+	t.Run("Multi-ReturnHighestCurrentL1", func(t *testing.T) {
 		client1 := &mockSuperNodeClient{
 			fn: func(_ context.Context, _ uint64) (eth.SuperRootAtTimestampResponse, error) {
 				return eth.SuperRootAtTimestampResponse{
@@ -57,9 +57,9 @@ func TestSuperNodeSource_SyncStatus(t *testing.T) {
 		status, err := source.SyncStatus(context.Background())
 		require.NoError(t, err)
 		require.Equal(t, SyncStatus{
-			CurrentL1:   eth.BlockID{Hash: common.Hash{0x02}, Number: 100},
-			SafeL2:      123,
-			FinalizedL2: 456,
+			CurrentL1:   eth.BlockID{Hash: common.Hash{0x01}, Number: 999},
+			SafeL2:      9999,
+			FinalizedL2: 9999,
 		}, status)
 	})
 


### PR DESCRIPTION
## Summary
- Update op-proposer supernode `SyncStatus` aggregation to use the highest healthy `CurrentL1`
- Prevent lagging supernode RPCs from blocking proposer failover when another configured supernode is caught up