### PR TITLE
fix(op-deployer): Add support for v7 OPCM deployment

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0
 	github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.4-0.20251001155152-4eb15ccedf7e
-	github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20260115192958-fb86a23cd30e
+	github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20260507232046-cbc58d3bb2e5
 	github.com/ethereum/go-ethereum v1.17.0
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/golang/snappy v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -222,8 +222,8 @@ github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.4-0.20251001155152-4eb15c
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.4-0.20251001155152-4eb15ccedf7e/go.mod h1:DYj7+vYJ4cIB7zera9mv4LcAynCL5u4YVfoeUu6Wa+w=
 github.com/ethereum-optimism/op-geth v1.101702.2-rc.3 h1:fsk+eehrGxlJCasTPbIu/igWoKbkjONk9i3XBDxuPBs=
 github.com/ethereum-optimism/op-geth v1.101702.2-rc.3/go.mod h1:HzvOtk7c9KwFaSxRvUBPFHGSjIjomWtw4iSXX6vruQE=
-github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20260115192958-fb86a23cd30e h1:TO1tUcwbhIrNuea/LCsQJSQ5HDWCHdrzT/5MLC1aIU4=
-github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20260115192958-fb86a23cd30e/go.mod h1:NZ816PzLU1TLv1RdAvYAb6KWOj4Zm5aInT0YpDVml2Y=
+github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20260507232046-cbc58d3bb2e5 h1:6mnscwenHqQmbzr3V3fjdzEGCNYb7GzdJEUZIKPiEws=
+github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20260507232046-cbc58d3bb2e5/go.mod h1:NZ816PzLU1TLv1RdAvYAb6KWOj4Zm5aInT0YpDVml2Y=
 github.com/ethereum/c-kzg-4844/v2 v2.1.6 h1:xQymkKCT5E2Jiaoqf3v4wsNgjZLY0lRSkZn27fRjSls=
 github.com/ethereum/c-kzg-4844/v2 v2.1.6/go.mod h1:8HMkUZ5JRv4hpw/XUrYWSQNAUzhHMg2UDb/U+5m+XNw=
 github.com/ethereum/go-bigmodexpfix v0.0.0-20250911101455-f9e208c548ab h1:rvv6MJhy07IMfEKuARQ9TKojGqLVNxQajaXEp/BoqSk=

--- a/op-chain-ops/opcmregistry/registry.go
+++ b/op-chain-ops/opcmregistry/registry.go
@@ -427,7 +427,7 @@ type ResolvedOPCM struct {
 }
 
 // GetResolvedOPCMs fetches OPCM addresses from the registry, queries their OPCM versions
-// on-chain using the provided querier, filters to only include stable versions >= 6.x.x,
+// on-chain using the provided querier, filters to only include stable versions >= 7.x.x,
 // and returns them sorted by OPCM version ascending.
 // Prerelease versions (e.g., rc, beta) are excluded.
 func GetResolvedOPCMs(chainID uint64, queryOPCMVersion OPCMVersionQuerier) ([]ResolvedOPCM, error) {
@@ -455,8 +455,9 @@ func GetResolvedOPCMs(chainID uint64, queryOPCMVersion OPCMVersionQuerier) ([]Re
 			continue
 		}
 
-		// Only include versions >= 6.x.x (V1 OPCMs start at 6.x.x)
-		if sv.Major < 6 {
+		// Only include versions >= 7.x.x. V1 OPCMs (6.x.x) are no longer supported by
+		// UpgradeOPChain.s.sol — passing them through the upgrade script reverts.
+		if sv.Major < 7 {
 			continue
 		}
 

--- a/op-chain-ops/opcmregistry/registry_test.go
+++ b/op-chain-ops/opcmregistry/registry_test.go
@@ -417,7 +417,7 @@ func TestFilterByLastUsedOPCMVersion(t *testing.T) {
 
 func TestGetResolvedOPCMs(t *testing.T) {
 	// This test uses a mock version querier to avoid network calls
-	t.Run("filters out versions below 6.x.x", func(t *testing.T) {
+	t.Run("filters out versions below 7.x.x", func(t *testing.T) {
 		// Create a mock registry with in-memory data
 		mockVersions := Versions{
 			"old-release": {
@@ -426,9 +426,9 @@ func TestGetResolvedOPCMs(t *testing.T) {
 					Address: addrPtr("0x1111111111111111111111111111111111111111"),
 				},
 			},
-			"v6-release": {
+			"v7-release": {
 				OPContractsManager: &ContractData{
-					Version: "1.6.0",
+					Version: "1.7.0",
 					Address: addrPtr("0x2222222222222222222222222222222222222222"),
 				},
 			},
@@ -438,9 +438,9 @@ func TestGetResolvedOPCMs(t *testing.T) {
 		mockQuerier := func(addr common.Address) (string, error) {
 			switch addr.Hex() {
 			case "0x1111111111111111111111111111111111111111":
-				return "5.0.0", nil // Should be filtered out (< 6.x.x)
+				return "6.0.0", nil // Should be filtered out (< 7.x.x)
 			case "0x2222222222222222222222222222222222222222":
-				return "6.0.0", nil // Should be included
+				return "7.0.0", nil // Should be included
 			default:
 				return "", nil
 			}
@@ -468,7 +468,7 @@ func TestGetResolvedOPCMs(t *testing.T) {
 				continue
 			}
 			sv, err := ParseSemver(opcmVersion)
-			if err != nil || sv.IsPrerelease() || sv.Major < 6 {
+			if err != nil || sv.IsPrerelease() || sv.Major < 7 {
 				continue
 			}
 			resolved = append(resolved, ResolvedOPCM{

--- a/op-deployer/pkg/deployer/integration_test/shared/shared.go
+++ b/op-deployer/pkg/deployer/integration_test/shared/shared.go
@@ -325,7 +325,7 @@ func RunPastUpgrades(t *testing.T, host *script.Host, chainID uint64, prank comm
 		return getOPCMVersion(caller, addr)
 	}
 
-	// Get resolved OPCMs (fetches from registry, queries versions on-chain, filters >= 6.x.x)
+	// Get resolved OPCMs (fetches from registry, queries versions on-chain, filters >= 7.x.x)
 	resolved, err := opcmregistry.GetResolvedOPCMs(chainID, queryVersion)
 	if err != nil {
 		t.Logf("Failed to get resolved OPCMs: %v", err)
@@ -333,7 +333,7 @@ func RunPastUpgrades(t *testing.T, host *script.Host, chainID uint64, prank comm
 	}
 
 	if len(resolved) == 0 {
-		t.Logf("No OPCMs >= 6.x.x found for chain %d", chainID)
+		t.Logf("No OPCMs >= 7.x.x found for chain %d", chainID)
 		return
 	}
 
@@ -343,7 +343,7 @@ func RunPastUpgrades(t *testing.T, host *script.Host, chainID uint64, prank comm
 		t.Fatalf("Failed to query lastUsedOPCMVersion: %v", err)
 	}
 	if !hasLastVersion {
-		t.Logf("SystemConfig.lastUsedOPCMVersion() reverted - chain is pre-6.x.x, will apply all upgrades from 6.x.x")
+		t.Logf("SystemConfig.lastUsedOPCMVersion() reverted - chain is pre-6.x.x, will apply all upgrades from 7.x.x")
 		lastVersion = ""
 	} else {
 		t.Logf("SystemConfig.lastUsedOPCMVersion() = %s", lastVersion)
@@ -393,7 +393,7 @@ func RunPastUpgradesWithRPC(t *testing.T, l1RPCUrl string, afactsFS foundry.Stat
 		return getOPCMVersion(caller, addr)
 	}
 
-	// Get resolved OPCMs (fetches from registry, queries versions on-chain, filters >= 6.x.x)
+	// Get resolved OPCMs (fetches from registry, queries versions on-chain, filters >= 7.x.x)
 	resolved, err := opcmregistry.GetResolvedOPCMs(chainID, queryVersion)
 	if err != nil {
 		t.Logf("Failed to get resolved OPCMs: %v", err)
@@ -401,7 +401,7 @@ func RunPastUpgradesWithRPC(t *testing.T, l1RPCUrl string, afactsFS foundry.Stat
 	}
 
 	if len(resolved) == 0 {
-		t.Logf("No OPCMs >= 6.x.x found for chain %d", chainID)
+		t.Logf("No OPCMs >= 7.x.x found for chain %d", chainID)
 		return
 	}
 
@@ -411,7 +411,7 @@ func RunPastUpgradesWithRPC(t *testing.T, l1RPCUrl string, afactsFS foundry.Stat
 		t.Fatalf("Failed to query lastUsedOPCMVersion: %v", err)
 	}
 	if !hasLastVersion {
-		t.Logf("SystemConfig.lastUsedOPCMVersion() reverted - chain is pre-6.x.x, will apply all upgrades from 6.x.x")
+		t.Logf("SystemConfig.lastUsedOPCMVersion() reverted - chain is pre-6.x.x, will apply all upgrades from 7.x.x")
 		lastVersion = ""
 	} else {
 		t.Logf("SystemConfig.lastUsedOPCMVersion() = %s", lastVersion)

--- a/op-deployer/pkg/deployer/opcm/contract.go
+++ b/op-deployer/pkg/deployer/opcm/contract.go
@@ -20,10 +20,6 @@ func NewContract(addr common.Address, client *ethclient.Client) *Contract {
 	return &Contract{addr: addr, client: client}
 }
 
-func (c *Contract) SuperchainConfig(ctx context.Context) (common.Address, error) {
-	return c.getAddress(ctx, "superchainConfig")
-}
-
 func (c *Contract) OPCMStandardValidator(ctx context.Context) (common.Address, error) {
 	return c.getAddress(ctx, "opcmStandardValidator")
 }

--- a/op-deployer/pkg/deployer/pipeline/init.go
+++ b/op-deployer/pkg/deployer/pipeline/init.go
@@ -33,26 +33,16 @@ func InitLiveStrategy(ctx context.Context, env *Env, intent *state.Intent, st *s
 		if intent.SuperchainRoles != nil {
 			return fmt.Errorf("cannot set superchain roles when using predeployed OPCM or SuperchainConfig")
 		}
+		if !hasSuperchainConfigProxy {
+			return fmt.Errorf("superchainConfigProxy must be set in the intent when using a predeployed OPCM")
+		}
 
 		opcmAddr := common.Address{}
 		if hasPredeployedOPCM {
 			opcmAddr = *intent.OPCMAddress
 		}
+		superchainConfigAddr := *intent.SuperchainConfigProxy
 
-		superchainConfigAddr := common.Address{}
-		if hasSuperchainConfigProxy {
-			superchainConfigAddr = *intent.SuperchainConfigProxy
-		}
-
-		// If only an OPCM address is provided, resolve SuperchainConfigProxy from it on-chain.
-		if superchainConfigAddr == (common.Address{}) && opcmAddr != (common.Address{}) {
-			opcmContract := opcm.NewContract(opcmAddr, env.L1Client)
-			resolved, err := opcmContract.SuperchainConfig(ctx)
-			if err != nil {
-				return fmt.Errorf("error resolving SuperchainConfig from OPCM at %s: %w", opcmAddr, err)
-			}
-			superchainConfigAddr = resolved
-		}
 		superDeployment, superRoles, err := PopulateSuperchainState(env, opcmAddr, superchainConfigAddr)
 		if err != nil {
 			return fmt.Errorf("error populating superchain state: %w", err)

--- a/op-deployer/pkg/deployer/pipeline/init_test.go
+++ b/op-deployer/pkg/deployer/pipeline/init_test.go
@@ -88,12 +88,16 @@ func TestInitLiveStrategy_OPCMReuseLogicSepolia(t *testing.T) {
 			opcmAddr, err := standard.OPCMImplAddressFor(l1ChainID, standard.CurrentTag)
 			require.NoError(t, err)
 
+			superchain, err := standard.SuperchainFor(l1ChainID)
+			require.NoError(t, err)
+
 			intent := &state.Intent{
-				ConfigType:         configType,
-				L1ChainID:          l1ChainID,
-				L1ContractsLocator: artifacts.EmbeddedLocator,
-				L2ContractsLocator: artifacts.EmbeddedLocator,
-				OPCMAddress:        &opcmAddr,
+				ConfigType:            configType,
+				L1ChainID:             l1ChainID,
+				L1ContractsLocator:    artifacts.EmbeddedLocator,
+				L2ContractsLocator:    artifacts.EmbeddedLocator,
+				OPCMAddress:           &opcmAddr,
+				SuperchainConfigProxy: &superchain.SuperchainConfigAddr,
 			}
 			st := &state.State{
 				Version: 1,
@@ -632,75 +636,6 @@ func TestInitLiveStrategy_OPCMV1WithSuperchainRoles_reverts(t *testing.T) {
 	)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "cannot set superchain roles when using predeployed OPCM or SuperchainConfig")
-}
-
-// Validates that the correct flow is chosen when
-// hasPredeployedOPCM && !opcmV2Enabled, and that PopulateSuperchainState is called with correct parameters.
-func TestInitLiveStrategy_FlowSelection_OPCMV1(t *testing.T) {
-	t.Parallel()
-
-	rpcURL := os.Getenv("SEPOLIA_RPC_URL")
-	require.NotEmpty(t, rpcURL, "SEPOLIA_RPC_URL must be set")
-
-	lgr := testlog.Logger(t, slog.LevelInfo)
-	retryProxy := devnet.NewRetryProxy(lgr, rpcURL)
-	require.NoError(t, retryProxy.Start())
-	t.Cleanup(func() {
-		require.NoError(t, retryProxy.Stop())
-	})
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	rpcClient, err := rpc.Dial(retryProxy.Endpoint())
-	require.NoError(t, err)
-	client := ethclient.NewClient(rpcClient)
-
-	l1ChainID := uint64(11155111)
-	opcmAddr, err := standard.OPCMImplAddressFor(l1ChainID, standard.CurrentTag)
-	require.NoError(t, err)
-
-	_, afacts := testutil.LocalArtifacts(t)
-	host, err := env.DefaultForkedScriptHost(
-		ctx,
-		broadcaster.NoopBroadcaster(),
-		testlog.Logger(t, log.LevelInfo),
-		common.Address{'D'},
-		afacts,
-		rpcClient,
-	)
-	require.NoError(t, err)
-
-	// Don't set opcmV2Enabled flag (defaults to false)
-	intent := &state.Intent{
-		ConfigType:         state.IntentTypeStandard,
-		L1ChainID:          l1ChainID,
-		L1ContractsLocator: artifacts.EmbeddedLocator,
-		L2ContractsLocator: artifacts.EmbeddedLocator,
-		OPCMAddress:        &opcmAddr,
-	}
-
-	st := &state.State{
-		Version: 1,
-	}
-
-	err = InitLiveStrategy(
-		ctx,
-		&Env{
-			L1Client:     client,
-			Logger:       lgr,
-			L1ScriptHost: host,
-		},
-		intent,
-		st,
-	)
-	require.NoError(t, err)
-
-	require.NotNil(t, st.SuperchainDeployment)
-
-	// Verify ImplementationsDeployment was set
-	require.NotNil(t, st.ImplementationsDeployment)
-	require.Equal(t, opcmAddr, st.ImplementationsDeployment.OpcmV2Impl)
 }
 
 // Validates that the correct flow is chosen when

--- a/op-deployer/pkg/deployer/standard/standard.go
+++ b/op-deployer/pkg/deployer/standard/standard.go
@@ -41,8 +41,9 @@ const (
 	ContractsV400Tag        = "op-contracts/v4.0.0-rc.7"
 	ContractsV410Tag        = "op-contracts/v4.1.0"
 	ContractsV500Tag        = "op-contracts/v5.0.0"
-	ContractsV600Tag        = "op-contracts/v6.0.0-rc.2"
-	CurrentTag              = ContractsV600Tag
+	ContractsV600Tag        = "op-contracts/v6.0.0"
+	ContractsV700Tag        = "op-contracts/v7.0.0-rc.2"
+	CurrentTag              = ContractsV700Tag
 )
 
 var DisputeAbsolutePrestate = common.HexToHash("0x038512e02c4c3f7bdaec27d00edf55b7155e0905301e1a88083e4e0a6764d54c")

--- a/op-deployer/pkg/deployer/state/intent.go
+++ b/op-deployer/pkg/deployer/state/intent.go
@@ -350,13 +350,20 @@ func NewIntentStandard(l1ChainId uint64, l2ChainIds []common.Hash) (Intent, erro
 		return Intent{}, fmt.Errorf("error getting OPCM impl address: %w", err)
 	}
 
+	superchainCfg, err := standard.SuperchainFor(l1ChainId)
+	if err != nil {
+		return Intent{}, fmt.Errorf("error getting Superchain for L1 chain %d: %w", l1ChainId, err)
+	}
+	superchainConfigProxy := superchainCfg.SuperchainConfigAddr
+
 	intent := Intent{
-		ConfigType:         IntentTypeStandard,
-		OpDeployerVersion:  version.VersionWithMeta,
-		L1ChainID:          l1ChainId,
-		L1ContractsLocator: artifacts.DefaultL1ContractsLocator,
-		L2ContractsLocator: artifacts.DefaultL2ContractsLocator,
-		OPCMAddress:        &opcmAddr,
+		ConfigType:            IntentTypeStandard,
+		OpDeployerVersion:     version.VersionWithMeta,
+		L1ChainID:             l1ChainId,
+		L1ContractsLocator:    artifacts.DefaultL1ContractsLocator,
+		L2ContractsLocator:    artifacts.DefaultL2ContractsLocator,
+		OPCMAddress:           &opcmAddr,
+		SuperchainConfigProxy: &superchainConfigProxy,
 	}
 
 	challenger, err := standard.ChallengerAddressFor(l1ChainId)

--- a/op-deployer/pkg/deployer/state/intent.go
+++ b/op-deployer/pkg/deployer/state/intent.go
@@ -154,10 +154,6 @@ func (c *Intent) validateStandardValues() error {
 		return err
 	}
 
-	if c.SuperchainConfigProxy != nil {
-		return ErrIncompatibleValue
-	}
-
 	if c.SuperchainRoles != nil {
 		return ErrIncompatibleValue
 	}
@@ -168,6 +164,14 @@ func (c *Intent) validateStandardValues() error {
 	}
 	if c.OPCMAddress == nil || *c.OPCMAddress != standardOPCM {
 		return fmt.Errorf("%w: opcmAddress=%s", ErrNonStandardValue, standardOPCM)
+	}
+
+	standardSuperchain, err := standard.SuperchainFor(c.L1ChainID)
+	if err != nil {
+		return fmt.Errorf("error getting Superchain: %w", err)
+	}
+	if c.SuperchainConfigProxy == nil || *c.SuperchainConfigProxy != standardSuperchain.SuperchainConfigAddr {
+		return fmt.Errorf("%w: superchainConfigProxy=%s", ErrNonStandardValue, standardSuperchain.SuperchainConfigAddr)
 	}
 
 	for _, chain := range c.Chains {

--- a/op-deployer/pkg/deployer/state/intent_test.go
+++ b/op-deployer/pkg/deployer/state/intent_test.go
@@ -87,7 +87,7 @@ func TestValidateStandardValues(t *testing.T) {
 				addr := common.HexToAddress("0x9999")
 				intent.SuperchainConfigProxy = &addr
 			},
-			ErrIncompatibleValue,
+			ErrNonStandardValue,
 		},
 		{
 			"OPCMAddress",


### PR DESCRIPTION
## Summary

Brings op-deployer up to date with the v7 OPCM. Three concerns, each in its own commit:

- **Add support for `op-contracts/v7.0.0-rc.2`.** Bumps the `superchain-registry/validation` module to a commit containing the v7.0.0-rc.2 standard-versions entries, registers `ContractsV700Tag`, removes the `opcm.superchainConfig()` wrapper (the v7 OPCM no longer exposes that getter), and requires `superchainConfigProxy` to be set in the intent when a predeployed OPCM is provided (the auto-resolve path in `init.go` was the only caller of the deleted method).
- **Auto-fill `superchainConfigProxy` in `NewIntentStandard`.** Without this, `op-deployer init --intent-type standard` would scaffold an intent that fails the new validation on first apply. The address comes from the same registry the OPCM lookup uses (`standard.SuperchainFor(chainID).SuperchainConfigAddr`), keeping `init` -> `apply` working out of the box for standard / standard-overrides.
- **Bump `GetResolvedOPCMs` version floor from 6 to 7.** `UpgradeOPChain.s.sol` stopped supporting OPCMv1 (v6.x.x) in #19795, but the registry resolver still handed v6 OPCMs to `RunPastUpgrades`, breaking `TestEndToEndBootstrapApplyWithUpgrade/run_past_upgrades`. Pre-existing failure on develop that slipped through because develop runs `go-tests-full`, not `go-tests-short`.

This will also need to be cherry-picked onto the `proposal/op-contracts/v7.0.0` branch.

## Test plan

- [ ] CI green on `go-tests-short`, `go-lint`
- [ ] `op-deployer init --intent-type standard ...` produces an intent.toml with both `opcmAddress` and `superchainConfigProxy` populated
- [ ] Custom intents are unaffected (no auto-fill, error message points to the missing field)
