### PR TITLE
Skip OPCM bytecode checks during coverage

### DIFF
--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
@@ -234,6 +234,8 @@ contract OPContractsManagerV2_Upgrade_TestInit is OPContractsManagerV2_TestInit 
 
     /// @notice Sets up the test suite.
     function setUp() public virtual override {
+        skipIfCoverage();
+
         super.disableUpgradedFork();
         super.setUp();
 

--- a/packages/contracts-bedrock/test/scripts/VerifyOPCM.t.sol
+++ b/packages/contracts-bedrock/test/scripts/VerifyOPCM.t.sol
@@ -173,6 +173,9 @@ contract VerifyOPCM_Run_Test is VerifyOPCM_TestInit {
 
     /// @notice Tests that the runSingle script succeeds when run against production contracts.
     function test_runSingle_succeeds() public {
+        // See test_run_succeeds for why this is coverage-only, not unoptimized-wide.
+        skipIfCoverage();
+
         VerifyOPCM.OpcmContractRef[][2] memory refsByType;
         refsByType[0] = harness.getOpcmContractRefs(opcm, "implementations", false);
         refsByType[1] = harness.getOpcmContractRefs(opcm, "blueprints", true);


### PR DESCRIPTION
## Summary
- skip OPCM V2 upgrade setup during coverage before fork upgrade setup runs
- skip VerifyOPCM runSingle bytecode verification during coverage, matching the existing run() coverage guard

## Context
The develop coverage job fails in the upgrade coverage sub-run:

```
just coverage-lcov-upgrade --match-contract OPContractsManager.*_Upgrade_Test
[FAIL: EvmError: Revert] setUp()
```

Coverage instrumentation changes deployed bytecode relative to artifacts, so these bytecode-sensitive fork/VerifyOPCM paths should be skipped in coverage context.

## Verification
- `mise x -- just lint-check` passed
- attempted `FOUNDRY_PROFILE=cicoverage SYS_FEATURE__CUSTOM_GAS_TOKEN=true mise x -- just coverage-lcov-upgrade --match-contract 'OPContractsManager.*_Upgrade_Test'`; blocked locally because the fresh worktree's contract submodule checkout was incomplete (missing `packages/contracts-bedrock/lib/solady/src/utils/LibString.sol`), before reaching tests