### PR TITLE
feat(op-interop-filter): add chain tip lag and ingestion lag metrics

### DIFF
--- a/op-interop-filter/filter/logsdb_chain_ingester.go
+++ b/op-interop-filter/filter/logsdb_chain_ingester.go
@@ -477,6 +477,21 @@ func (c *LogsDBChainIngester) runIngestion() {
 			continue
 		}
 
+		// Record chain tip and lag metrics
+		chainIDUint64, _ := c.chainID.Uint64()
+		c.metrics.RecordChainTip(chainIDUint64, head.NumberU64())
+		if nextBlock > 0 {
+			ingestedHead := nextBlock - 1
+			if head.NumberU64() > ingestedHead {
+				c.metrics.RecordTipLagBlocks(chainIDUint64, head.NumberU64()-ingestedHead)
+			} else {
+				c.metrics.RecordTipLagBlocks(chainIDUint64, 0)
+			}
+			if ts, ok := c.LatestTimestamp(); ok {
+				c.metrics.RecordIngestionLagSeconds(chainIDUint64, clock.SystemClock.Since(time.Unix(int64(ts), 0)).Seconds())
+			}
+		}
+
 		// Reorg detection: if head moved behind our progress, check hash
 		if head.NumberU64() < nextBlock {
 			c.log.Info("Chain head is behind ingestion progress, waiting for node to catch up",

--- a/op-interop-filter/filter/logsdb_integration_helpers_test.go
+++ b/op-interop-filter/filter/logsdb_integration_helpers_test.go
@@ -533,7 +533,10 @@ func (m *capturingMetrics) RecordFailsafeEnabled(enabled bool) {}
 func (m *capturingMetrics) RecordChainHead(chainID uint64, blockNum uint64) {
 	m.locked(func() { m.chainHead[chainID] = blockNum })
 }
-func (m *capturingMetrics) RecordCheckAccessList(success bool)             {}
+func (m *capturingMetrics) RecordChainTip(chainID uint64, blockNum uint64)      {}
+func (m *capturingMetrics) RecordTipLagBlocks(chainID uint64, lag uint64)       {}
+func (m *capturingMetrics) RecordIngestionLagSeconds(chainID uint64, _ float64) {}
+func (m *capturingMetrics) RecordCheckAccessList(success bool)                  {}
 func (m *capturingMetrics) RecordCheckAccessListDuration(duration float64) {}
 func (m *capturingMetrics) RecordCheckAccessListRejection(reason string) {
 	m.locked(func() { m.rejections[reason]++ })

--- a/op-interop-filter/filter/logsdb_integration_helpers_test.go
+++ b/op-interop-filter/filter/logsdb_integration_helpers_test.go
@@ -537,7 +537,7 @@ func (m *capturingMetrics) RecordChainTip(chainID uint64, blockNum uint64)      
 func (m *capturingMetrics) RecordTipLagBlocks(chainID uint64, lag uint64)       {}
 func (m *capturingMetrics) RecordIngestionLagSeconds(chainID uint64, _ float64) {}
 func (m *capturingMetrics) RecordCheckAccessList(success bool)                  {}
-func (m *capturingMetrics) RecordCheckAccessListDuration(duration float64) {}
+func (m *capturingMetrics) RecordCheckAccessListDuration(duration float64)      {}
 func (m *capturingMetrics) RecordCheckAccessListRejection(reason string) {
 	m.locked(func() { m.rejections[reason]++ })
 }

--- a/op-interop-filter/metrics/metrics.go
+++ b/op-interop-filter/metrics/metrics.go
@@ -15,6 +15,9 @@ type Metricer interface {
 	RecordUp()
 	RecordFailsafeEnabled(enabled bool)
 	RecordChainHead(chainID uint64, blockNum uint64)
+	RecordChainTip(chainID uint64, blockNum uint64)
+	RecordTipLagBlocks(chainID uint64, lag uint64)
+	RecordIngestionLagSeconds(chainID uint64, lagSeconds float64)
 	RecordCheckAccessList(success bool)
 	RecordCheckAccessListDuration(duration float64)
 	RecordCheckAccessListRejection(reason string)
@@ -39,6 +42,10 @@ type Metrics struct {
 	checkAccessListRejectVec *prometheus.CounterVec
 
 	// Chain-specific metrics
+	chainTip            *prometheus.GaugeVec
+	tipLagBlocks        *prometheus.GaugeVec
+	ingestionLagSeconds *prometheus.GaugeVec
+
 	backfillProgress              *prometheus.GaugeVec
 	reorgDetectedTotal            *prometheus.CounterVec
 	logsAddedTotal                *prometheus.CounterVec
@@ -106,6 +113,24 @@ func NewMetrics(procName string) *Metrics {
 			Help:      "Access list rejections by reason",
 		}, []string{"reason"}),
 
+		chainTip: factory.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: ns,
+			Name:      "chain_tip",
+			Help:      "Latest known chain tip block number from RPC",
+		}, []string{"chain_id"}),
+
+		tipLagBlocks: factory.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: ns,
+			Name:      "tip_lag_blocks",
+			Help:      "Number of blocks the ingester is behind the chain tip",
+		}, []string{"chain_id"}),
+
+		ingestionLagSeconds: factory.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: ns,
+			Name:      "ingestion_lag_seconds",
+			Help:      "Seconds between now and the timestamp of the latest ingested block",
+		}, []string{"chain_id"}),
+
 		backfillProgress: factory.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: ns,
 			Name:      "backfill_progress",
@@ -166,6 +191,18 @@ func (m *Metrics) RecordChainHead(chainID uint64, blockNum uint64) {
 	m.chainHead.WithLabelValues(strconv.FormatUint(chainID, 10)).Set(float64(blockNum))
 }
 
+func (m *Metrics) RecordChainTip(chainID uint64, blockNum uint64) {
+	m.chainTip.WithLabelValues(strconv.FormatUint(chainID, 10)).Set(float64(blockNum))
+}
+
+func (m *Metrics) RecordTipLagBlocks(chainID uint64, lag uint64) {
+	m.tipLagBlocks.WithLabelValues(strconv.FormatUint(chainID, 10)).Set(float64(lag))
+}
+
+func (m *Metrics) RecordIngestionLagSeconds(chainID uint64, lagSeconds float64) {
+	m.ingestionLagSeconds.WithLabelValues(strconv.FormatUint(chainID, 10)).Set(lagSeconds)
+}
+
 func (m *Metrics) RecordCheckAccessList(success bool) {
 	label := "false"
 	if success {
@@ -211,6 +248,9 @@ func (n *noopMetrics) RecordInfo(version string)                               {
 func (n *noopMetrics) RecordUp()                                               {}
 func (n *noopMetrics) RecordFailsafeEnabled(enabled bool)                      {}
 func (n *noopMetrics) RecordChainHead(chainID uint64, blockNum uint64)         {}
+func (n *noopMetrics) RecordChainTip(chainID uint64, blockNum uint64)          {}
+func (n *noopMetrics) RecordTipLagBlocks(chainID uint64, lag uint64)           {}
+func (n *noopMetrics) RecordIngestionLagSeconds(chainID uint64, lag float64)   {}
 func (n *noopMetrics) RecordCheckAccessList(success bool)                      {}
 func (n *noopMetrics) RecordCheckAccessListDuration(duration float64)          {}
 func (n *noopMetrics) RecordCheckAccessListRejection(reason string)            {}


### PR DESCRIPTION
## Summary
- Adds three new per-chain Prometheus gauges: `chain_tip` (RPC head block), `tip_lag_blocks` (blocks behind tip), and `ingestion_lag_seconds` (wall-clock seconds behind tip)
- Recorded every poll tick in the ingestion loop after fetching the chain head

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [ ] Deploy to devnet and verify metrics appear on `/metrics` endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)