### PR TITLE
op-deployer: cache resolved artifacts persistently

### DIFF
--- a/op-deployer/cmd/op-deployer/main.go
+++ b/op-deployer/cmd/op-deployer/main.go
@@ -20,6 +20,7 @@ func main() {
 	app.ErrWriter = os.Stderr
 	err := app.Run(os.Args)
 	if err != nil {
+		_ = artifacts.CleanupAll()
 		_, _ = fmt.Fprintf(os.Stderr, "Application failed: %v\n", err)
 		os.Exit(1)
 	}

--- a/op-deployer/pkg/deployer/apply.go
+++ b/op-deployer/pkg/deployer/apply.go
@@ -305,23 +305,24 @@ func ApplyPipeline(
 	}
 	st := opts.State
 
-	l1ArtifactsFS, err := artifacts.Download(ctx, intent.L1ContractsLocator, ioutil.BarProgressor(), opts.CacheDir)
+	l1Artifacts, err := artifacts.Resolve(ctx, intent.L1ContractsLocator, ioutil.BarProgressor(), opts.CacheDir)
 	if err != nil {
 		return fmt.Errorf("failed to download L1 artifacts: %w", err)
 	}
 
 	var l2ArtifactsFS foundry.StatDirFs
 	if intent.L1ContractsLocator.Equal(intent.L2ContractsLocator) {
-		l2ArtifactsFS = l1ArtifactsFS
+		l2ArtifactsFS = l1Artifacts.FS
 	} else {
-		l2ArtifactsFS, err = artifacts.Download(ctx, intent.L2ContractsLocator, ioutil.BarProgressor(), opts.CacheDir)
+		l2Artifacts, err := artifacts.Resolve(ctx, intent.L2ContractsLocator, ioutil.BarProgressor(), opts.CacheDir)
 		if err != nil {
 			return fmt.Errorf("failed to download L2 artifacts: %w", err)
 		}
+		l2ArtifactsFS = l2Artifacts.FS
 	}
 
 	bundle := pipeline.ArtifactsBundle{
-		L1: l1ArtifactsFS,
+		L1: l1Artifacts.FS,
 		L2: l2ArtifactsFS,
 	}
 
@@ -438,13 +439,15 @@ func ApplyPipeline(
 	// Initialize Forge client if UseForge flag is enabled
 	var forgeClient *forge.Client
 	if opts.UseForge {
-		// Forge needs to run from the artifacts directory where foundry.toml is located
-		// The workdir is for storing state, not for running forge commands
-		artifactsPath := fmt.Sprintf("%v", bundle.L1)
-		forgeClient, err = forge.NewStandardClient(artifactsPath)
+		forgeClient, err = forge.NewStandardClient(l1Artifacts.ProjectDir)
 		if err != nil {
 			return fmt.Errorf("failed to create Forge client: %w", err)
 		}
+		buildKey, err := forge.BuildCacheKey(l1Artifacts.CacheKey, l1Artifacts.ProjectDir)
+		if err != nil {
+			return fmt.Errorf("failed to create Forge cache key: %w", err)
+		}
+		forgeClient.ProjectOpts = forge.ProjectOptions(l1Artifacts.ProjectDir, opts.CacheDir, buildKey)
 	}
 
 	pEnv := &pipeline.Env{

--- a/op-deployer/pkg/deployer/artifacts/download.go
+++ b/op-deployer/pkg/deployer/artifacts/download.go
@@ -35,39 +35,11 @@ type Extractor interface {
 }
 
 func Download(ctx context.Context, loc *Locator, progressor ioutil.Progressor, targetDir string) (foundry.StatDirFs, error) {
-	if progressor == nil {
-		progressor = ioutil.NoopProgressor()
+	resolved, err := Resolve(ctx, loc, progressor, targetDir)
+	if err != nil {
+		return nil, err
 	}
-
-	var err error
-	u := loc.URL
-	checker := new(noopIntegrityChecker)
-
-	var artifactsFS fs.FS
-	switch u.Scheme {
-	case "http", "https":
-		artifactsFS, err = downloadHTTP(ctx, u, progressor, checker, targetDir)
-		if err != nil {
-			return nil, fmt.Errorf("failed to download artifacts: %w", err)
-		}
-	case "file":
-		// Check the path has forge-artifacts directory
-		forgeArtifactsDir := path.Join(u.Path, "forge-artifacts")
-		if _, err := os.Stat(forgeArtifactsDir); err != nil {
-			// TODO(#18346): Accept this for now but in the future we should error
-			artifactsFS = os.DirFS(u.Path)
-		} else {
-			artifactsFS = os.DirFS(forgeArtifactsDir)
-		}
-	case "embedded":
-		artifactsFS, err = ExtractEmbedded(targetDir)
-		if err != nil {
-			return nil, fmt.Errorf("failed to extract embedded artifacts: %w", err)
-		}
-	default:
-		return nil, ErrUnsupportedArtifactsScheme
-	}
-	return artifactsFS.(foundry.StatDirFs), nil
+	return resolved.FS, nil
 }
 
 func downloadHTTP(ctx context.Context, u *url.URL, progressor ioutil.Progressor, checker integrityChecker, targetDir string) (fs.FS, error) {
@@ -147,6 +119,10 @@ func (d *CachingDownloader) Download(ctx context.Context, url string, progress i
 		return "", fmt.Errorf("failed to download: %w", err)
 	}
 	if err := os.Rename(tmpPath, cachePath); err != nil {
+		if _, statErr := os.Stat(cachePath); statErr == nil {
+			_ = os.Remove(tmpPath)
+			return cachePath, nil
+		}
 		return "", fmt.Errorf("failed to move downloaded file to cache: %w", err)
 	}
 	return cachePath, nil

--- a/op-deployer/pkg/deployer/artifacts/download_test.go
+++ b/op-deployer/pkg/deployer/artifacts/download_test.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -112,6 +113,125 @@ func TestDownloadArtifacts_MockArtifacts(t *testing.T) {
 		_, err = downloadHTTP(ctx, u, nil, correctIntegrity, testCacheDir)
 		require.ErrorContains(t, err, "integrity check failed")
 	})
+}
+
+func TestResolveArtifactsPersistentCache(t *testing.T) {
+	testTarGzPath := filepath.Join("testdata", "test.tar.gz")
+	var callCount int32
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		f, err := os.Open(testTarGzPath)
+		require.NoError(t, err)
+		defer f.Close()
+		w.WriteHeader(http.StatusOK)
+		_, err = io.Copy(w, f)
+		require.NoError(t, err)
+		atomic.AddInt32(&callCount, 1)
+	}))
+	defer ts.Close()
+
+	ctx := context.Background()
+	cacheDir := testutils.IsolatedTestDirWithAutoCleanup(t)
+
+	loc := MustNewLocatorFromURL(ts.URL + "/artifacts.tar.gz")
+	first, err := Resolve(ctx, loc, nil, cacheDir)
+	require.NoError(t, err)
+	second, err := Resolve(ctx, loc, nil, cacheDir)
+	require.NoError(t, err)
+
+	require.Equal(t, first.ProjectDir, second.ProjectDir)
+	require.Equal(t, first.ArtifactsDir, second.ArtifactsDir)
+	require.Equal(t, first.CacheKey, second.CacheKey)
+	require.Equal(t, int32(1), atomic.LoadInt32(&callCount))
+	require.FileExists(t, filepath.Join(first.ProjectDir, cacheMetadataFile))
+
+	sameBytesLoc := MustNewLocatorFromURL(ts.URL + "/same-bytes.tar.gz")
+	third, err := Resolve(ctx, sameBytesLoc, nil, cacheDir)
+	require.NoError(t, err)
+	require.Equal(t, first.ProjectDir, third.ProjectDir)
+	require.Equal(t, int32(2), atomic.LoadInt32(&callCount))
+}
+
+func TestResolveEmbeddedArtifactsPersistentCache(t *testing.T) {
+	if _, err := embeddedArtifactBytes(); err != nil {
+		t.Skipf("embedded artifact bundle not populated: %v", err)
+	}
+
+	ctx := context.Background()
+	cacheDir := testutils.IsolatedTestDirWithAutoCleanup(t)
+
+	first, err := Resolve(ctx, EmbeddedLocator, nil, cacheDir)
+	require.NoError(t, err)
+	second, err := Resolve(ctx, EmbeddedLocator, nil, cacheDir)
+	require.NoError(t, err)
+
+	require.Equal(t, first.ProjectDir, second.ProjectDir)
+	require.Equal(t, first.ArtifactsDir, second.ArtifactsDir)
+	require.True(t, first.CacheOwned)
+	require.FileExists(t, filepath.Join(first.ProjectDir, cacheMetadataFile))
+}
+
+func TestResolveFileLocatorUsesDirectoryDirectly(t *testing.T) {
+	projectDir := t.TempDir()
+	artifactsDir := filepath.Join(projectDir, "forge-artifacts")
+	require.NoError(t, os.MkdirAll(artifactsDir, 0o755))
+
+	resolved, err := Resolve(context.Background(), MustNewFileLocator(projectDir), nil, t.TempDir())
+	require.NoError(t, err)
+
+	require.Equal(t, projectDir, resolved.ProjectDir)
+	require.Equal(t, artifactsDir, resolved.ArtifactsDir)
+	require.False(t, resolved.CacheOwned)
+	require.NoFileExists(t, filepath.Join(projectDir, cacheMetadataFile))
+}
+
+func TestResolveArtifactsConcurrent(t *testing.T) {
+	testTarGzPath := filepath.Join("testdata", "test.tar.gz")
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		f, err := os.Open(testTarGzPath)
+		require.NoError(t, err)
+		defer f.Close()
+		w.WriteHeader(http.StatusOK)
+		_, err = io.Copy(w, f)
+		require.NoError(t, err)
+	}))
+	defer ts.Close()
+
+	ctx := context.Background()
+	cacheDir := testutils.IsolatedTestDirWithAutoCleanup(t)
+	loc := MustNewLocatorFromURL(ts.URL + "/artifacts.tar.gz")
+
+	const workers = 4
+	results := make(chan *ResolvedArtifacts, workers)
+	errs := make(chan error, workers)
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			resolved, err := Resolve(ctx, loc, nil, cacheDir)
+			if err != nil {
+				errs <- err
+				return
+			}
+			results <- resolved
+		}()
+	}
+	wg.Wait()
+	close(results)
+	close(errs)
+
+	for err := range errs {
+		require.NoError(t, err)
+	}
+	var projectDir string
+	for resolved := range results {
+		if projectDir == "" {
+			projectDir = resolved.ProjectDir
+		}
+		require.Equal(t, projectDir, resolved.ProjectDir)
+		require.DirExists(t, resolved.ArtifactsDir)
+	}
 }
 
 func TestTarballExtractor_Extract(t *testing.T) {

--- a/op-deployer/pkg/deployer/artifacts/resolve.go
+++ b/op-deployer/pkg/deployer/artifacts/resolve.go
@@ -1,0 +1,329 @@
+package artifacts
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/foundry"
+	"github.com/ethereum-optimism/optimism/op-service/ioutil"
+	"github.com/klauspost/compress/zstd"
+)
+
+const cacheMetadataFile = ".op-deployer-artifacts.json"
+
+type ResolvedArtifacts struct {
+	FS           foundry.StatDirFs
+	ProjectDir   string
+	ArtifactsDir string
+	CacheKey     string
+	CacheOwned   bool
+}
+
+type cacheMetadata struct {
+	Version      int    `json:"version"`
+	CacheKey     string `json:"cacheKey"`
+	Source       string `json:"source"`
+	ArtifactsDir string `json:"artifactsDir"`
+}
+
+func Resolve(ctx context.Context, loc *Locator, progressor ioutil.Progressor, cacheDir string) (*ResolvedArtifacts, error) {
+	if progressor == nil {
+		progressor = ioutil.NoopProgressor()
+	}
+
+	switch loc.URL.Scheme {
+	case "http", "https":
+		return resolveHTTP(ctx, loc.URL, progressor, cacheDir)
+	case "file":
+		return resolveFile(loc.URL)
+	case "embedded":
+		return resolveEmbedded(cacheDir)
+	default:
+		return nil, ErrUnsupportedArtifactsScheme
+	}
+}
+
+func resolveHTTP(ctx context.Context, u *url.URL, progressor ioutil.Progressor, cacheDir string) (*ResolvedArtifacts, error) {
+	archivesDir := filepath.Join(cacheDir, "artifacts", "archives")
+	cacher := &CachingDownloader{d: new(HTTPDownloader)}
+	archivePath, err := cacher.Download(ctx, u.String(), progressor, archivesDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to download artifacts: %w", err)
+	}
+
+	cacheKey, err := hashFile(archivePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to hash artifact archive: %w", err)
+	}
+
+	return resolveCachedProject(cacheDir, cacheKey, "http", func(dest string) error {
+		if strings.HasSuffix(archivePath, ".tzst") {
+			return extractZstdTarFile(archivePath, dest)
+		}
+		extractor := &TarballExtractor{checker: new(noopIntegrityChecker)}
+		return extractor.Extract(archivePath, dest)
+	})
+}
+
+func resolveEmbedded(cacheDir string) (*ResolvedArtifacts, error) {
+	data, err := embeddedArtifactBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	cacheKey := fmt.Sprintf("%x", sha256.Sum256(data))
+	return resolveCachedProject(cacheDir, cacheKey, "embedded", func(dest string) error {
+		return extractZstdTar(bytesReader(data), dest)
+	})
+}
+
+func resolveFile(u *url.URL) (*ResolvedArtifacts, error) {
+	projectDir, artifactsDir, err := detectProjectDirs(u.Path, true)
+	if err != nil {
+		return nil, err
+	}
+	artifactsFS := os.DirFS(artifactsDir)
+	statFS, ok := artifactsFS.(foundry.StatDirFs)
+	if !ok {
+		return nil, fmt.Errorf("artifact directory %q does not implement StatDirFs", artifactsDir)
+	}
+	return &ResolvedArtifacts{
+		FS:           statFS,
+		ProjectDir:   projectDir,
+		ArtifactsDir: artifactsDir,
+		CacheKey:     fmt.Sprintf("%x", sha256.Sum256([]byte(filepath.Clean(projectDir)))),
+		CacheOwned:   false,
+	}, nil
+}
+
+func resolveCachedProject(cacheDir, cacheKey, source string, extract func(dest string) error) (*ResolvedArtifacts, error) {
+	projectsDir := filepath.Join(cacheDir, "artifacts", "projects")
+	tmpRoot := filepath.Join(cacheDir, "artifacts", "tmp")
+	projectDir := filepath.Join(projectsDir, cacheKey)
+
+	if resolved, err := validateCachedProject(projectDir, cacheKey); err == nil {
+		return resolved, nil
+	} else if !os.IsNotExist(err) {
+		return nil, err
+	}
+
+	if err := os.MkdirAll(tmpRoot, 0o700); err != nil {
+		return nil, fmt.Errorf("failed to create artifact temp dir: %w", err)
+	}
+	if err := os.MkdirAll(projectsDir, 0o700); err != nil {
+		return nil, fmt.Errorf("failed to create artifact projects dir: %w", err)
+	}
+
+	tmpDir, err := os.MkdirTemp(tmpRoot, cacheKey+"-*")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create artifact extraction dir: %w", err)
+	}
+	RegisterForCleanup(tmpDir)
+
+	if err := extract(tmpDir); err != nil {
+		_ = os.RemoveAll(tmpDir)
+		return nil, fmt.Errorf("failed to extract artifacts: %w", err)
+	}
+
+	projectRoot, artifactsDir, err := detectProjectDirs(tmpDir, false)
+	if err != nil {
+		_ = os.RemoveAll(tmpDir)
+		return nil, fmt.Errorf("failed to validate extracted artifacts: %w", err)
+	}
+	if projectRoot != tmpDir {
+		normalizedTmp, err := os.MkdirTemp(tmpRoot, cacheKey+"-normalized-*")
+		if err != nil {
+			_ = os.RemoveAll(tmpDir)
+			return nil, fmt.Errorf("failed to create normalized artifact extraction dir: %w", err)
+		}
+		_ = os.RemoveAll(normalizedTmp)
+		if err := os.Rename(projectRoot, normalizedTmp); err != nil {
+			_ = os.RemoveAll(tmpDir)
+			_ = os.RemoveAll(normalizedTmp)
+			return nil, fmt.Errorf("failed to normalize extracted artifacts: %w", err)
+		}
+		_ = os.RemoveAll(tmpDir)
+		tmpDir = normalizedTmp
+		artifactsDir = filepath.Join(tmpDir, filepath.Base(artifactsDir))
+		RegisterForCleanup(tmpDir)
+	}
+
+	metadata := cacheMetadata{
+		Version:      1,
+		CacheKey:     cacheKey,
+		Source:       source,
+		ArtifactsDir: filepath.Base(artifactsDir),
+	}
+	if err := writeCacheMetadata(tmpDir, metadata); err != nil {
+		_ = os.RemoveAll(tmpDir)
+		return nil, err
+	}
+
+	if err := os.Rename(tmpDir, projectDir); err != nil {
+		if _, statErr := os.Stat(projectDir); statErr == nil {
+			_ = os.RemoveAll(tmpDir)
+			return validateCachedProject(projectDir, cacheKey)
+		}
+		_ = os.RemoveAll(tmpDir)
+		return nil, fmt.Errorf("failed to publish artifact cache project: %w", err)
+	}
+
+	return validateCachedProject(projectDir, cacheKey)
+}
+
+func validateCachedProject(projectDir, cacheKey string) (*ResolvedArtifacts, error) {
+	metadataPath, err := safeCachePath(projectDir, cacheMetadataFile)
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(metadataPath)
+	if err != nil {
+		return nil, err
+	}
+	var metadata cacheMetadata
+	if err := json.Unmarshal(data, &metadata); err != nil {
+		return nil, fmt.Errorf("failed to read artifact cache metadata: %w", err)
+	}
+	if metadata.Version != 1 {
+		return nil, fmt.Errorf("unsupported artifact cache metadata version %d", metadata.Version)
+	}
+	if metadata.CacheKey != cacheKey {
+		return nil, fmt.Errorf("artifact cache metadata key mismatch: expected %s, got %s", cacheKey, metadata.CacheKey)
+	}
+	artifactsDir, err := safeCachePath(projectDir, metadata.ArtifactsDir)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := os.Stat(artifactsDir); err != nil {
+		return nil, fmt.Errorf("artifact cache entry is missing artifact dir: %w", err)
+	}
+	artifactsFS := os.DirFS(artifactsDir)
+	statFS, ok := artifactsFS.(foundry.StatDirFs)
+	if !ok {
+		return nil, fmt.Errorf("artifact directory %q does not implement StatDirFs", artifactsDir)
+	}
+	if _, err := statFS.ReadDir("."); err != nil {
+		return nil, fmt.Errorf("artifact cache dir is not readable: %w", err)
+	}
+	return &ResolvedArtifacts{
+		FS:           statFS,
+		ProjectDir:   projectDir,
+		ArtifactsDir: artifactsDir,
+		CacheKey:     cacheKey,
+		CacheOwned:   true,
+	}, nil
+}
+
+func detectProjectDirs(input string, allowRootArtifacts bool) (string, string, error) {
+	clean := filepath.Clean(input)
+	info, err := os.Stat(clean)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to stat artifact path %q: %w", input, err)
+	}
+	if !info.IsDir() {
+		return "", "", fmt.Errorf("artifact path %q is not a directory", input)
+	}
+
+	base := filepath.Base(clean)
+	if base == "forge-artifacts" || base == "out" {
+		return filepath.Dir(clean), clean, nil
+	}
+
+	for _, dir := range []string{"forge-artifacts", "out"} {
+		candidate := filepath.Join(clean, dir)
+		if st, err := os.Stat(candidate); err == nil && st.IsDir() {
+			return clean, candidate, nil
+		}
+	}
+
+	if allowRootArtifacts {
+		return clean, clean, nil
+	}
+
+	return "", "", fmt.Errorf("artifact path %q does not contain forge-artifacts or out", input)
+}
+
+func writeCacheMetadata(projectDir string, metadata cacheMetadata) error {
+	data, err := json.MarshalIndent(metadata, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to encode artifact cache metadata: %w", err)
+	}
+	data = append(data, '\n')
+	metadataPath, err := safeCachePath(projectDir, cacheMetadataFile)
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(metadataPath, data, 0o600); err != nil {
+		return fmt.Errorf("failed to write artifact cache metadata: %w", err)
+	}
+	return nil
+}
+
+func safeCachePath(baseDir string, name string) (string, error) {
+	if name == "" || filepath.IsAbs(name) || filepath.Base(name) != name {
+		return "", fmt.Errorf("invalid artifact cache path component %q", name)
+	}
+	if name != cacheMetadataFile && !slices.Contains([]string{"forge-artifacts", "out"}, name) {
+		return "", fmt.Errorf("unsupported artifact cache path component %q", name)
+	}
+	return filepath.Join(baseDir, name), nil
+}
+
+func hashFile(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%x", h.Sum(nil)), nil
+}
+
+func embeddedArtifactBytes() ([]byte, error) {
+	f, err := embedDir.Open(filepath.Join("forge-artifacts", embeddedArtifactsZstdShort))
+	if err != nil {
+		return nil, fmt.Errorf("could not open embedded artifacts %q: %w", embeddedArtifactsZstdShort, err)
+	}
+	defer f.Close()
+	return io.ReadAll(f)
+}
+
+func extractZstdTarFile(src, dest string) error {
+	f, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("could not open zstd tar file: %w", err)
+	}
+	defer f.Close()
+	return extractZstdTar(f, dest)
+}
+
+func extractZstdTar(src io.Reader, dest string) error {
+	zr, err := zstd.NewReader(src)
+	if err != nil {
+		return fmt.Errorf("could not create zstd reader: %w", err)
+	}
+	defer zr.Close()
+	tr := tar.NewReader(zr)
+	if err := ioutil.Untar(dest, tr); err != nil {
+		return fmt.Errorf("failed to untar zstd artifacts: %w", err)
+	}
+	return nil
+}
+
+func bytesReader(data []byte) io.Reader {
+	return bytes.NewReader(data)
+}

--- a/op-deployer/pkg/deployer/bootstrap/implementations.go
+++ b/op-deployer/pkg/deployer/bootstrap/implementations.go
@@ -198,10 +198,11 @@ func Implementations(ctx context.Context, cfg ImplementationsConfig) (opcm.Deplo
 
 	lgr := cfg.Logger
 
-	artifactsFS, err := artifacts.Download(ctx, cfg.ArtifactsLocator, ioutil.BarProgressor(), cfg.CacheDir)
+	resolvedArtifacts, err := artifacts.Resolve(ctx, cfg.ArtifactsLocator, ioutil.BarProgressor(), cfg.CacheDir)
 	if err != nil {
 		return dio, fmt.Errorf("failed to download artifacts: %w", err)
 	}
+	artifactsFS := resolvedArtifacts.FS
 
 	input := opcm.DeployImplementationsInput{
 		WithdrawalDelaySeconds:          new(big.Int).SetUint64(cfg.WithdrawalDelaySeconds),
@@ -223,10 +224,15 @@ func Implementations(ctx context.Context, cfg ImplementationsConfig) (opcm.Deplo
 
 	if cfg.UseForge {
 		lgr.Info("using Forge for DeployImplementations")
-		forgeClient, err := forge.NewStandardClient(fmt.Sprintf("%v", artifactsFS))
+		forgeClient, err := forge.NewStandardClient(resolvedArtifacts.ProjectDir)
 		if err != nil {
 			return dio, fmt.Errorf("failed to create forge client: %w", err)
 		}
+		buildKey, err := forge.BuildCacheKey(resolvedArtifacts.CacheKey, resolvedArtifacts.ProjectDir)
+		if err != nil {
+			return dio, fmt.Errorf("failed to create forge cache key: %w", err)
+		}
+		forgeClient.ProjectOpts = forge.ProjectOptions(resolvedArtifacts.ProjectDir, cfg.CacheDir, buildKey)
 
 		forgeEnv := &opcm.ForgeEnv{
 			Client:     forgeClient,

--- a/op-deployer/pkg/deployer/bootstrap/superchain.go
+++ b/op-deployer/pkg/deployer/bootstrap/superchain.go
@@ -164,10 +164,11 @@ func Superchain(ctx context.Context, cfg SuperchainConfig) (opcm.DeploySuperchai
 
 	lgr := cfg.Logger
 	cacheDir := cfg.CacheDir
-	artifactsFS, err := artifacts.Download(ctx, cfg.ArtifactsLocator, ioutil.BarProgressor(), cacheDir)
+	resolvedArtifacts, err := artifacts.Resolve(ctx, cfg.ArtifactsLocator, ioutil.BarProgressor(), cacheDir)
 	if err != nil {
 		return dso, fmt.Errorf("failed to download artifacts: %w", err)
 	}
+	artifactsFS := resolvedArtifacts.FS
 
 	input := opcm.DeploySuperchainInput{
 		SuperchainProxyAdminOwner: cfg.SuperchainProxyAdminOwner,
@@ -177,10 +178,15 @@ func Superchain(ctx context.Context, cfg SuperchainConfig) (opcm.DeploySuperchai
 
 	if cfg.UseForge {
 		lgr.Info("using Forge for DeploySuperchain")
-		forgeClient, err := forge.NewStandardClient(fmt.Sprintf("%v", artifactsFS))
+		forgeClient, err := forge.NewStandardClient(resolvedArtifacts.ProjectDir)
 		if err != nil {
 			return dso, fmt.Errorf("failed to create forge client: %w", err)
 		}
+		buildKey, err := forge.BuildCacheKey(resolvedArtifacts.CacheKey, resolvedArtifacts.ProjectDir)
+		if err != nil {
+			return dso, fmt.Errorf("failed to create forge cache key: %w", err)
+		}
+		forgeClient.ProjectOpts = forge.ProjectOptions(resolvedArtifacts.ProjectDir, cacheDir, buildKey)
 
 		forgeEnv := &opcm.ForgeEnv{
 			Client:     forgeClient,

--- a/op-deployer/pkg/deployer/forge/cache.go
+++ b/op-deployer/pkg/deployer/forge/cache.go
@@ -1,0 +1,42 @@
+package forge
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func BuildCacheKey(artifactKey, projectDir string) (string, error) {
+	foundryTomlPath, err := safeProjectPath(projectDir, "foundry.toml")
+	if err != nil {
+		return "", err
+	}
+	foundryToml, err := os.ReadFile(foundryTomlPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read foundry.toml for forge cache key: %w", err)
+	}
+	h := sha256.New()
+	_, _ = h.Write([]byte(artifactKey))
+	_, _ = h.Write([]byte{0})
+	_, _ = h.Write([]byte(StandardVersion))
+	_, _ = h.Write([]byte{0})
+	_, _ = h.Write(foundryToml)
+	return fmt.Sprintf("%x", h.Sum(nil)), nil
+}
+
+func ProjectOptions(projectDir, cacheDir, buildKey string) []string {
+	buildDir := filepath.Join(cacheDir, "forge", "builds", buildKey)
+	return []string{
+		"--root", projectDir,
+		"--cache-path", filepath.Join(buildDir, "cache"),
+		"--out", filepath.Join(buildDir, "out"),
+	}
+}
+
+func safeProjectPath(projectDir string, name string) (string, error) {
+	if name == "" || filepath.IsAbs(name) || filepath.Base(name) != name {
+		return "", fmt.Errorf("invalid project path component %q", name)
+	}
+	return filepath.Join(projectDir, name), nil
+}

--- a/op-deployer/pkg/deployer/forge/client.go
+++ b/op-deployer/pkg/deployer/forge/client.go
@@ -24,10 +24,11 @@ type VersionInfo struct {
 }
 
 type Client struct {
-	Binary Binary
-	Stdout io.Writer
-	Stderr io.Writer
-	Wd     string
+	Binary      Binary
+	Stdout      io.Writer
+	Stderr      io.Writer
+	Wd          string
+	ProjectOpts []string
 }
 
 func NewStandardClient(workdir string) (*Client, error) {
@@ -106,17 +107,17 @@ func (c *Client) Version(ctx context.Context) (VersionInfo, error) {
 }
 
 func (c *Client) Build(ctx context.Context, opts ...string) error {
-	return c.execCmd(ctx, io.Discard, io.Discard, append([]string{"build"}, opts...)...)
+	return c.execCmd(ctx, io.Discard, io.Discard, append([]string{"build"}, c.withProjectOpts(opts...)...)...)
 }
 
 func (c *Client) Clean(ctx context.Context, opts ...string) error {
-	return c.execCmd(ctx, io.Discard, io.Discard, append([]string{"clean"}, opts...)...)
+	return c.execCmd(ctx, io.Discard, io.Discard, append([]string{"clean"}, c.withRootProjectOpts(opts...)...)...)
 }
 
 func (c *Client) RunScript(ctx context.Context, script string, sig string, args []byte, opts ...string) (string, error) {
 	buf := new(bytes.Buffer)
 	cliOpts := []string{"script"}
-	cliOpts = append(cliOpts, opts...)
+	cliOpts = append(cliOpts, c.withProjectOpts(opts...)...)
 	cliOpts = append(cliOpts, "--sig", sig, script, "0x"+hex.EncodeToString(args))
 	if err := c.execCmd(ctx, buf, io.Discard, cliOpts...); err != nil {
 		return "", fmt.Errorf("failed to execute forge script: %w", err)
@@ -127,11 +128,42 @@ func (c *Client) RunScript(ctx context.Context, script string, sig string, args 
 func (c *Client) VerifyContract(ctx context.Context, opts ...string) (string, error) {
 	buf := new(bytes.Buffer)
 	cliOpts := []string{"verify-contract"}
-	cliOpts = append(cliOpts, opts...)
+	cliOpts = append(cliOpts, c.withVerifyProjectOpts(opts...)...)
 	if err := c.execCmd(ctx, buf, buf, cliOpts...); err != nil {
 		return buf.String(), fmt.Errorf("failed to verify contract: %w", err)
 	}
 	return buf.String(), nil
+}
+
+func (c *Client) withProjectOpts(opts ...string) []string {
+	if len(c.ProjectOpts) == 0 {
+		return opts
+	}
+	out := make([]string, 0, len(c.ProjectOpts)+len(opts))
+	out = append(out, c.ProjectOpts...)
+	out = append(out, opts...)
+	return out
+}
+
+func (c *Client) withVerifyProjectOpts(opts ...string) []string {
+	return c.withRootProjectOpts(opts...)
+}
+
+func (c *Client) withRootProjectOpts(opts ...string) []string {
+	projectOpts := make([]string, 0, 2)
+	for i := 0; i < len(c.ProjectOpts); i++ {
+		if c.ProjectOpts[i] == "--root" && i+1 < len(c.ProjectOpts) {
+			projectOpts = append(projectOpts, c.ProjectOpts[i], c.ProjectOpts[i+1])
+			i++
+		}
+	}
+	if len(projectOpts) == 0 {
+		return opts
+	}
+	out := make([]string, 0, len(projectOpts)+len(opts))
+	out = append(out, projectOpts...)
+	out = append(out, opts...)
+	return out
 }
 
 func (c *Client) execCmd(ctx context.Context, stdout io.Writer, stderr io.Writer, args ...string) error {

--- a/op-deployer/pkg/deployer/forge/client_test.go
+++ b/op-deployer/pkg/deployer/forge/client_test.go
@@ -88,6 +88,33 @@ func TestClient_OutputRedirection(t *testing.T) {
 	require.True(t, strings.HasPrefix(cl.Stdout.(*bytes.Buffer).String(), "forge Version"))
 }
 
+func TestClient_WithProjectOpts(t *testing.T) {
+	cl := NewClient(StaticBinary("forge"))
+	cl.ProjectOpts = []string{"--root", "/project", "--cache-path", "/cache", "--out", "/out"}
+
+	opts := cl.withProjectOpts("--broadcast")
+	require.Equal(t, []string{"--root", "/project", "--cache-path", "/cache", "--out", "/out", "--broadcast"}, opts)
+
+	verifyOpts := cl.withVerifyProjectOpts("--watch")
+	require.Equal(t, []string{"--root", "/project", "--watch"}, verifyOpts)
+}
+
+func TestBuildCacheKey(t *testing.T) {
+	projectDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "foundry.toml"), []byte("[profile.default]\n"), 0o644))
+
+	first, err := BuildCacheKey("artifact-key", projectDir)
+	require.NoError(t, err)
+	second, err := BuildCacheKey("artifact-key", projectDir)
+	require.NoError(t, err)
+	require.Equal(t, first, second)
+
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "foundry.toml"), []byte("[profile.changed]\n"), 0o644))
+	changed, err := BuildCacheKey("artifact-key", projectDir)
+	require.NoError(t, err)
+	require.NotEqual(t, first, changed)
+}
+
 func TestScriptCaller(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()

--- a/op-deployer/pkg/deployer/verify/auto_verify.go
+++ b/op-deployer/pkg/deployer/verify/auto_verify.go
@@ -32,7 +32,7 @@ func AutoVerify(ctx context.Context, logger log.Logger, rpcUrl string, chainID u
 	logger.Info("Starting automatic contract verification", "verifiers", verifierTypes)
 
 	cacheDir := flags.DefaultCacheDir()
-	artifactsFS, err := artifacts.Download(ctx, artifactsLocator, nil, cacheDir)
+	resolvedArtifacts, err := artifacts.Resolve(ctx, artifactsLocator, nil, cacheDir)
 	if err != nil {
 		return fmt.Errorf("failed to download artifacts: %w", err)
 	}
@@ -58,7 +58,10 @@ func AutoVerify(ctx context.Context, logger log.Logger, rpcUrl string, chainID u
 			VerifierUrl:  verifierUrl,
 			ApiKey:       apiKey,
 			ChainID:      chainID,
-			ArtifactsFS:  artifactsFS,
+			ArtifactsFS:  resolvedArtifacts.FS,
+			ProjectDir:   resolvedArtifacts.ProjectDir,
+			CacheDir:     cacheDir,
+			ArtifactKey:  resolvedArtifacts.CacheKey,
 			Logger:       logger,
 		})
 		if err != nil {

--- a/op-deployer/pkg/deployer/verify/forge_verifier.go
+++ b/op-deployer/pkg/deployer/verify/forge_verifier.go
@@ -33,6 +33,9 @@ type ForgeVerifierOpts struct {
 	ApiKey       string
 	ChainID      uint64
 	ArtifactsFS  foundry.StatDirFs
+	ProjectDir   string
+	CacheDir     string
+	ArtifactKey  string
 	Logger       log.Logger
 }
 
@@ -41,17 +44,30 @@ func NewForgeVerifier(opts ForgeVerifierOpts) (*ForgeVerifier, error) {
 		return nil, fmt.Errorf("unsupported verifier type: %s (must be 'etherscan', 'blockscout', or 'custom')", opts.VerifierType)
 	}
 
-	forgeTomlPath := filepath.Join(fmt.Sprintf("%v", opts.ArtifactsFS), "foundry.toml")
-	if _, err := os.Stat(forgeTomlPath); err != nil {
-		opts.Logger.Warn("foundry.toml not found, checking parent directory", "path", forgeTomlPath)
-		forgeTomlPath = filepath.Join(fmt.Sprintf("%v", opts.ArtifactsFS), "..", "foundry.toml")
+	projectDir := opts.ProjectDir
+	if projectDir == "" {
+		forgeTomlPath := filepath.Join(fmt.Sprintf("%v", opts.ArtifactsFS), "foundry.toml")
 		if _, err := os.Stat(forgeTomlPath); err != nil {
-			return nil, fmt.Errorf("foundry.toml not found in any of the possible directories: %w", err)
+			opts.Logger.Warn("foundry.toml not found, checking parent directory", "path", forgeTomlPath)
+			forgeTomlPath = filepath.Join(fmt.Sprintf("%v", opts.ArtifactsFS), "..", "foundry.toml")
+			if _, err := os.Stat(forgeTomlPath); err != nil {
+				return nil, fmt.Errorf("foundry.toml not found in any of the possible directories: %w", err)
+			}
 		}
+		projectDir = filepath.Dir(forgeTomlPath)
+	} else if _, err := os.Stat(filepath.Join(projectDir, "foundry.toml")); err != nil {
+		return nil, fmt.Errorf("foundry.toml not found in any of the possible directories: %w", err)
 	}
-	forgeClient, err := forge.NewStandardClient(forgeTomlPath)
+	forgeClient, err := forge.NewStandardClient(projectDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create forge client: %w", err)
+	}
+	if opts.CacheDir != "" && opts.ArtifactKey != "" {
+		buildKey, err := forge.BuildCacheKey(opts.ArtifactKey, projectDir)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create forge cache key: %w", err)
+		}
+		forgeClient.ProjectOpts = forge.ProjectOptions(projectDir, opts.CacheDir, buildKey)
 	}
 
 	var apiChecker APIChecker

--- a/op-deployer/pkg/deployer/verify/forge_verifier_test.go
+++ b/op-deployer/pkg/deployer/verify/forge_verifier_test.go
@@ -54,6 +54,11 @@ func TestNewForgeVerifier_HTTPLocator(t *testing.T) {
 }
 
 func TestNewForgeVerifier_EmbeddedLocator(t *testing.T) {
+	_, err := artifacts.Resolve(context.Background(), artifacts.EmbeddedLocator, nil, t.TempDir())
+	if err != nil {
+		t.Skipf("embedded artifact bundle not populated: %v", err)
+	}
+
 	ctx := context.Background()
 	loc := artifacts.EmbeddedLocator
 

--- a/op-deployer/pkg/deployer/verify/verifier.go
+++ b/op-deployer/pkg/deployer/verify/verifier.go
@@ -111,7 +111,7 @@ func VerifyCLI(cliCtx *cli.Context) error {
 	}
 
 	cacheDir := flags.DefaultCacheDir()
-	artifactsFS, err := artifacts.Download(ctx, locator, nil, cacheDir)
+	resolvedArtifacts, err := artifacts.Resolve(ctx, locator, nil, cacheDir)
 	if err != nil {
 		return fmt.Errorf("failed to get artifacts: %w", err)
 	}
@@ -140,7 +140,10 @@ func VerifyCLI(cliCtx *cli.Context) error {
 			VerifierUrl:  verifierUrl,
 			ApiKey:       verifierAPIKey,
 			ChainID:      l1ChainId,
-			ArtifactsFS:  artifactsFS,
+			ArtifactsFS:  resolvedArtifacts.FS,
+			ProjectDir:   resolvedArtifacts.ProjectDir,
+			CacheDir:     cacheDir,
+			ArtifactKey:  resolvedArtifacts.CacheKey,
 			Logger:       l,
 		})
 		if err != nil {


### PR DESCRIPTION
## Summary

op-deployer was creating a large number of files under --cache-dir because artifact bundles were extracted into fresh temporary directories on each run. Even when the same contracts/artifact locator were reused, only the downloaded archive was cached;
the extracted project directory was not. This also meant forge could not reliably reuse its compilation cache across repeated --use-forge commands.

This PR adds a persistent artifact resolution cache so repeated commands using the same artifact content reuse the same extracted project.

## What Changed

- Adds `artifacts.Resolve`, returning the artifact FS plus explicit project/cache metadata.
- Keeps `artifacts.Download` as a compatibility wrapper.
- Caches HTTP downloads under artifacts/archives.
- Caches extracted artifact projects by artifact content hash under artifacts/projects.
- Reuses embedded and HTTP artifact extractions across repeated commands.
- Leaves `file://` locators user-owned and uncached.
- Updates Forge paths to use explicit project roots instead of deriving paths from `fmt.Sprintf("%v", artifactsFS)`.
- Adds forge --root, --cache-path, and --out options so repeated Forge runs can share build cache.
- Ensures artifact temp cleanup runs before CLI error exits.