### PR TITLE
test(contracts-bedrock): enable isolate for XDM baseGas fuzz tests

### DIFF
--- a/packages/contracts-bedrock/test/L1/L1CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/L1/L1CrossDomainMessenger.t.sol
@@ -587,6 +587,7 @@ contract L1CrossDomainMessenger_Uncategorized_Test is L1CrossDomainMessenger_Tes
     /// @notice Tests that the `relayMessage` function on L2 will always succeed for any potential
     ///         message, regardless of the size of the message, the minimum gas limit, or the
     ///         amount of gas used by the target contract.
+    /// forge-config: default.isolate = true
     function testFuzz_relayMessage_baseGasSufficient_succeeds(
         uint24 _messageLength,
         uint32 _minGasLimit,
@@ -594,10 +595,6 @@ contract L1CrossDomainMessenger_Uncategorized_Test is L1CrossDomainMessenger_Tes
     )
         external
     {
-        // TODO(#14609): Update this test to use default.isolate = true once a new stable Foundry
-        // release is available that includes #9904. That will allow us to use this test to check
-        // for changes to the EVM itself that might cause our gas formula to be incorrect.
-
         // Skip if this is a fork test, won't work.
         skipIfForkTest("L2CrossDomainMessenger doesn't exist on L1 in forked test");
 

--- a/packages/contracts-bedrock/test/L2/L2CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/L2/L2CrossDomainMessenger.t.sol
@@ -285,6 +285,7 @@ contract L2CrossDomainMessenger_Uncategorized_Test is L2CrossDomainMessenger_Tes
     /// @notice Tests that `relayMessage` on L2 will always succeed for any potential message,
     ///         regardless of the size of the message, the minimum gas limit, or the amount of gas
     ///         used by the target contract.
+    /// forge-config: default.isolate = true
     function testFuzz_relayMessage_baseGasSufficient_succeeds(
         uint24 _messageLength,
         uint32 _minGasLimit,
@@ -292,10 +293,6 @@ contract L2CrossDomainMessenger_Uncategorized_Test is L2CrossDomainMessenger_Tes
     )
         external
     {
-        // TODO(#14609): Update this test to use default.isolate = true once a new stable Foundry
-        // release is available that includes #9904. That will allow us to use this test to check
-        // for changes to the EVM itself that might cause our gas formula to be incorrect.
-
         // Skip if this is a fork test, won't work.
         skipIfForkTest("L2CrossDomainMessenger doesn't exist on L1 in forked test");
 


### PR DESCRIPTION
  **Description**                                                                                                                                                                                
                                                                                                                                                                                                 
  This PR enables inline Foundry isolation for the CrossDomainMessenger base-gas sufficiency fuzz tests by adding `forge-config: default.isolate = true` to both:                                
  - `test/L1/L1CrossDomainMessenger.t.sol`                                                                                                                                                       
  - `test/L2/L2CrossDomainMessenger.t.sol`                                                                                                                                                       
                                                                                                                                                                                                 
  It also removes the now-stale `TODO(#14609)` notes that were waiting on Foundry support.                                                                                                       
                                                                                                                                                                                                 
  This makes these fuzz tests execute under transaction semantics that better match real gas accounting behavior.                                                                                
                                                                                                                                                                                                 
  **Tests**                                                                                                                                                                                      
                                                                                                                                                                                                 
  No new test cases were added.                                                                                                                                                                  
                                                                                                                                                                                                 
  This change updates execution mode for existing tests:                                                                                                                                         
  - `testFuzz_relayMessage_baseGasSufficient_succeeds` in `L1CrossDomainMessenger.t.sol`                                                                                                         
  - `testFuzz_relayMessage_baseGasSufficient_succeeds` in `L2CrossDomainMessenger.t.sol`                                                                                                         
                                                                                                                                                                                                 
  CI will validate the updated tests in the normal contracts-bedrock test pipeline.                                                                                                              
                                                                                                                                                                                                 
  **Additional context**                                                                                                                                                                         
                                                                                                                                                                                                 
  This follows the direction documented in the contracts-bedrock style guide gas-accounting notes and unblocks the long-standing follow-up tracked in #14609.                                    
                                                                                                                                                                                                 
  **Metadata**                                                                                                                                                                                   
                                                                                                                                                                                                 
  - Fixes #14609   