### PR TITLE
fix(op-wheel): route logs to stderr to keep stdout JSON clean

### DIFF
--- a/op-wheel/cmd/main.go
+++ b/op-wheel/cmd/main.go
@@ -28,7 +28,7 @@ func main() {
 	app.Flags = []cli.Flag{wheel.GlobalGethLogLvlFlag}
 	app.Before = func(c *cli.Context) error {
 		lvl := c.Generic(wheel.GlobalGethLogLvlFlag.Name).(*oplog.LevelFlagValue).Level()
-		oplog.SetGlobalLogHandler(log.NewTerminalHandlerWithLevel(os.Stdout, lvl, true))
+		oplog.SetGlobalLogHandler(log.NewTerminalHandlerWithLevel(os.Stderr, lvl, true))
 		return nil
 	}
 	app.Action = func(c *cli.Context) error {


### PR DESCRIPTION
The global log handler in `op-wheel` was wired to `os.Stdout`, so any log line interleaved with the JSON emitted by `cheat head-block`, `cheat head-header`, and `engine status` (all via `ctx.App.Writer`). Switched to `os.Stderr`, matching `op-chain-ops/cmd/check-derivation`, so `jq` and friends can parse the output.

- [x] `go build ./...` in `op-wheel`
- [ ] manual: `op-wheel cheat head-block ... | jq .`