### PR TITLE
fix(op-supernode): recover logsDB from offline L2 reorg on restart

### DIFF
--- a/op-supernode/supernode/activity/interop/log_backfill.go
+++ b/op-supernode/supernode/activity/interop/log_backfill.go
@@ -112,6 +112,9 @@ func (i *Interop) runLogBackfill() (uint64, error) {
 
 func (i *Interop) backfillChain(ctx context.Context, cid eth.ChainID, chain cc.ChainContainer, startNum, endNum uint64) error {
 	db := i.logsDBs[cid]
+	if err := i.reconcileLogsDBTail(ctx, cid, chain, db); err != nil {
+		return err
+	}
 	if latest, has := db.LatestSealedBlock(); has {
 		startNum = latest.Number + 1
 	}
@@ -137,4 +140,44 @@ func (i *Interop) backfillChain(ctx context.Context, cid eth.ChainID, chain cc.C
 		}
 	}
 	return nil
+}
+
+// reconcileLogsDBTail trims tail blocks whose hash no longer matches canonical,
+// so backfill resumes from a block that is still in force. Without this, an L2
+// reorg that occurs while supernode is offline leaves the tail diverged and the
+// first seal on resume loops forever on ErrParentHashMismatch (see #20627).
+func (i *Interop) reconcileLogsDBTail(ctx context.Context, cid eth.ChainID, chain cc.ChainContainer, db LogsDB) error {
+	for {
+		latest, has := db.LatestSealedBlock()
+		if !has {
+			return nil
+		}
+		out, err := chain.OutputV0AtBlockNumber(ctx, latest.Number)
+		if err != nil {
+			return fmt.Errorf("chain %s: output at block %d during logsDB reconcile: %w", cid, latest.Number, err)
+		}
+		if out.BlockHash == latest.Hash {
+			return nil
+		}
+		i.log.Warn("trimming stale logsDB tail block",
+			"chain", cid, "blockNumber", latest.Number,
+			"storedHash", latest.Hash, "canonicalHash", out.BlockHash)
+
+		first, err := db.FirstSealedBlock()
+		if err != nil || latest.Number <= first.Number {
+			i.log.Warn("reorg reaches first sealed block; clearing logsDB",
+				"chain", cid, "firstSealed", first.Number)
+			if err := db.Clear(&noopInvalidator{}); err != nil {
+				return fmt.Errorf("chain %s: clear logsDB during reconcile: %w", cid, err)
+			}
+			return nil
+		}
+		prev, err := db.FindSealedBlock(latest.Number - 1)
+		if err != nil {
+			return fmt.Errorf("chain %s: find sealed block %d during reconcile: %w", cid, latest.Number-1, err)
+		}
+		if err := db.Rewind(&noopInvalidator{}, eth.BlockID{Number: prev.Number, Hash: prev.Hash}); err != nil {
+			return fmt.Errorf("chain %s: rewind logsDB during reconcile: %w", cid, err)
+		}
+	}
 }

--- a/op-supernode/supernode/activity/interop/log_backfill.go
+++ b/op-supernode/supernode/activity/interop/log_backfill.go
@@ -145,39 +145,53 @@ func (i *Interop) backfillChain(ctx context.Context, cid eth.ChainID, chain cc.C
 // reconcileLogsDBTail trims tail blocks whose hash no longer matches canonical,
 // so backfill resumes from a block that is still in force. Without this, an L2
 // reorg that occurs while supernode is offline leaves the tail diverged and the
-// first seal on resume loops forever on ErrParentHashMismatch (see #20627).
+// first seal on resume loops forever on ErrParentHashMismatch.
 func (i *Interop) reconcileLogsDBTail(ctx context.Context, cid eth.ChainID, chain cc.ChainContainer, db LogsDB) error {
-	for {
-		latest, has := db.LatestSealedBlock()
-		if !has {
-			return nil
-		}
-		out, err := chain.OutputV0AtBlockNumber(ctx, latest.Number)
-		if err != nil {
-			return fmt.Errorf("chain %s: output at block %d during logsDB reconcile: %w", cid, latest.Number, err)
-		}
-		if out.BlockHash == latest.Hash {
-			return nil
-		}
-		i.log.Warn("trimming stale logsDB tail block",
-			"chain", cid, "blockNumber", latest.Number,
-			"storedHash", latest.Hash, "canonicalHash", out.BlockHash)
+	latest, has := db.LatestSealedBlock()
+	if !has {
+		return nil
+	}
+	latestOut, err := chain.OutputV0AtBlockNumber(ctx, latest.Number)
+	if err != nil {
+		return fmt.Errorf("chain %s: output at block %d during logsDB reconcile: %w", cid, latest.Number, err)
+	}
+	if latestOut.BlockHash == latest.Hash {
+		return nil
+	}
 
-		first, err := db.FirstSealedBlock()
-		if err != nil || latest.Number <= first.Number {
-			i.log.Warn("reorg reaches first sealed block; clearing logsDB",
-				"chain", cid, "firstSealed", first.Number)
-			if err := db.Clear(&noopInvalidator{}); err != nil {
-				return fmt.Errorf("chain %s: clear logsDB during reconcile: %w", cid, err)
-			}
-			return nil
-		}
-		prev, err := db.FindSealedBlock(latest.Number - 1)
+	first, err := db.FirstSealedBlock()
+	if err != nil {
+		return fmt.Errorf("chain %s: first sealed block during reconcile: %w", cid, err)
+	}
+
+	// Walk back from latest.Number-1 looking for the deepest sealed block whose
+	// hash still matches canonical. latest itself is already known to diverge.
+	for n := latest.Number; n > first.Number; {
+		n--
+		seal, err := db.FindSealedBlock(n)
 		if err != nil {
-			return fmt.Errorf("chain %s: find sealed block %d during reconcile: %w", cid, latest.Number-1, err)
+			return fmt.Errorf("chain %s: find sealed block %d during reconcile: %w", cid, n, err)
 		}
-		if err := db.Rewind(&noopInvalidator{}, eth.BlockID{Number: prev.Number, Hash: prev.Hash}); err != nil {
+		out, err := chain.OutputV0AtBlockNumber(ctx, n)
+		if err != nil {
+			return fmt.Errorf("chain %s: output at block %d during reconcile: %w", cid, n, err)
+		}
+		if seal.Hash != out.BlockHash {
+			continue
+		}
+		i.log.Warn("rewinding logsDB to last canonical block",
+			"chain", cid, "rewindTo", n, "trimmedTipNumber", latest.Number,
+			"trimmedTipStored", latest.Hash, "trimmedTipCanonical", latestOut.BlockHash)
+		if err := db.Rewind(&noopInvalidator{}, eth.BlockID{Number: n, Hash: seal.Hash}); err != nil {
 			return fmt.Errorf("chain %s: rewind logsDB during reconcile: %w", cid, err)
 		}
+		return nil
 	}
+
+	i.log.Warn("entire logsDB diverges from canonical; clearing",
+		"chain", cid, "firstSealed", first.Number, "latestSealed", latest.Number)
+	if err := db.Clear(&noopInvalidator{}); err != nil {
+		return fmt.Errorf("chain %s: clear logsDB during reconcile: %w", cid, err)
+	}
+	return nil
 }

--- a/op-supernode/supernode/activity/interop/log_backfill.go
+++ b/op-supernode/supernode/activity/interop/log_backfill.go
@@ -112,6 +112,12 @@ func (i *Interop) runLogBackfill() (uint64, error) {
 
 func (i *Interop) backfillChain(ctx context.Context, cid eth.ChainID, chain cc.ChainContainer, startNum, endNum uint64) error {
 	db := i.logsDBs[cid]
+	// This is a startup best-effort repair for pre-existing logsDB reorg drift,
+	// separate from the normal interop observation/apply loop. It does not close
+	// the window where an L2 reorg lands after reconciliation/backfill and before
+	// normal interop persists its first frontier block. In that case the write path
+	// fails with ErrParentHashMismatch or ErrStaleLogsDB instead of appending
+	// inconsistent logs.
 	if err := i.reconcileLogsDBTail(ctx, cid, chain, db); err != nil {
 		return err
 	}

--- a/op-supernode/supernode/activity/interop/log_backfill_test.go
+++ b/op-supernode/supernode/activity/interop/log_backfill_test.go
@@ -92,8 +92,8 @@ func TestLogBackfill_ResumesAfterInterruption(t *testing.T) {
 	require.True(t, has)
 	require.Equal(t, uint64(110), latest.Number)
 
-	// Should have fetched only blocks 106..110 (5 blocks), not 100..110 (11 blocks).
-	require.Equal(t, int32(5), fetchCount.Load())
+	// 5 fetches for blocks 106..110 + 1 reconcile probe at block 105.
+	require.Equal(t, int32(6), fetchCount.Load())
 }
 
 func TestLogBackfill_RetriesWhenVirtualNodesNotReady(t *testing.T) {
@@ -158,17 +158,9 @@ func TestLogBackfill_RetriesWhenVirtualNodesNotReady(t *testing.T) {
 	<-done
 }
 
-// TestLogBackfill_RecoversFromOfflineReorg asserts the desired behaviour for
-// https://github.com/ethereum-optimism/optimism/issues/20627: if an L2 reorg
-// invalidates a sealed block in the logsDB while supernode is stopped, on
-// restart Start must complete backfill and leave the logsDB reflecting the
-// canonical chain — not get stuck in an infinite ErrParentHashMismatch retry
-// loop requiring the operator to delete logs.db.
-//
-// Today this test FAILS: backfill resumes from latest.Number+1 and trips
-// ErrParentHashMismatch on the first seal, retrying forever. The fix needs to
-// trim the logsDB back to the highest block whose hash still matches canonical
-// (or Clear() if none does) before retrying.
+// TestLogBackfill_RecoversFromOfflineReorg covers #20627: an L2 reorg that
+// invalidates a sealed block while supernode is offline must self-heal on
+// restart, not loop forever on ErrParentHashMismatch.
 func TestLogBackfill_RecoversFromOfflineReorg(t *testing.T) {
 	const act = uint64(100)
 	depth := 20 * time.Second
@@ -190,13 +182,8 @@ func TestLogBackfill_RecoversFromOfflineReorg(t *testing.T) {
 	chain10 := h.Mock(10)
 	db := h.interop.logsDBs[chain10.id]
 
-	// Simulate a pre-shutdown logsDB whose tail is on a stale "v1" fork that no
-	// longer matches the canonical chain returned by the mock (which represents
-	// the post-reorg "v2" canonical view, where block N has hash BigToHash(N)).
-	//
-	// Pre-seed blocks 100..105 directly via SealBlock so we can choose hashes.
-	// The first seal on an empty DB skips parent validation, so each subsequent
-	// seal just needs to link to the previous v1 hash.
+	// Pre-seed blocks 100..105 with a stale "v1" fork hash; the mock's canonical
+	// view ("v2") returns BigToHash(n).
 	v1Hash := func(n uint64) common.Hash {
 		return common.BigToHash(new(big.Int).SetUint64(n | 0xdead0000))
 	}
@@ -209,12 +196,8 @@ func TestLogBackfill_RecoversFromOfflineReorg(t *testing.T) {
 	before, has := db.LatestSealedBlock()
 	require.True(t, has)
 	require.Equal(t, uint64(105), before.Number)
-	require.Equal(t, v1Hash(105), before.Hash,
-		"pre-seed should have placed the v1 (pre-reorg) chain into the logsDB")
+	require.Equal(t, v1Hash(105), before.Hash)
 
-	// Shorten the retry backoff so a buggy implementation doesn't drag the test
-	// out — we still rely on the require.Eventually timeout to detect the stuck
-	// loop. Match TestLogBackfill_RetriesWhenVirtualNodesNotReady.
 	origBackoff := errorBackoffPeriod
 	errorBackoffPeriod = 10 * time.Millisecond
 	t.Cleanup(func() { errorBackoffPeriod = origBackoff })
@@ -225,31 +208,30 @@ func TestLogBackfill_RecoversFromOfflineReorg(t *testing.T) {
 	done := make(chan error, 1)
 	go func() { done <- h.interop.Start(ctx) }()
 
-	// Start must complete backfill: the canonical chain has block 110 at the
-	// cross-safe tip and supernode must catch up to it after self-healing the
-	// stale logsDB tail.
 	require.Eventually(t, func() bool {
 		return h.interop.backfillCompleted.Load()
 	}, 15*time.Second, 20*time.Millisecond,
 		"Start must recover from an offline reorg, not loop forever on ErrParentHashMismatch")
 
-	require.Equal(t, uint64(110), h.interop.backfillEndTimestamp,
-		"backfill must seal up to the cross-safe tip")
+	require.Equal(t, uint64(110), h.interop.backfillEndTimestamp)
 
-	// The logsDB tail must now reflect the canonical (post-reorg) chain, not
-	// the stale v1 fork it was pre-seeded with.
-	latest, has := db.LatestSealedBlock()
-	require.True(t, has)
-	require.Equal(t, uint64(110), latest.Number, "logsDB tail must advance to the canonical tip")
-	require.Equal(t, common.BigToHash(new(big.Int).SetUint64(110)), latest.Hash,
-		"logsDB tail must be the canonical v2 hash, not the stale v1 hash")
-
-	// Spot-check an interior reorged height: block 103 must hold the canonical
-	// hash, not v1Hash(103).
+	// Assert specific heights, not LatestSealedBlock: once backfill completes
+	// the main loop may seal further blocks before we read state.
+	canonicalHash := func(n uint64) common.Hash {
+		return common.BigToHash(new(big.Int).SetUint64(n))
+	}
+	seal110, err := db.FindSealedBlock(110)
+	require.NoError(t, err, "backfill tip must be sealed")
+	require.Equal(t, canonicalHash(110), seal110.Hash,
+		"backfill tip must hold the canonical hash, not a stale v1 hash")
 	seal103, err := db.FindSealedBlock(103)
 	require.NoError(t, err)
-	require.Equal(t, common.BigToHash(new(big.Int).SetUint64(103)), seal103.Hash,
+	require.Equal(t, canonicalHash(103), seal103.Hash,
 		"reorged interior block must be replaced with the canonical hash")
+	seal100, err := db.FindSealedBlock(100)
+	require.NoError(t, err)
+	require.Equal(t, canonicalHash(100), seal100.Hash,
+		"activation block must be replaced with the canonical hash")
 
 	cancel()
 	<-done

--- a/op-supernode/supernode/activity/interop/log_backfill_test.go
+++ b/op-supernode/supernode/activity/interop/log_backfill_test.go
@@ -158,6 +158,103 @@ func TestLogBackfill_RetriesWhenVirtualNodesNotReady(t *testing.T) {
 	<-done
 }
 
+// TestLogBackfill_RecoversFromOfflineReorg asserts the desired behaviour for
+// https://github.com/ethereum-optimism/optimism/issues/20627: if an L2 reorg
+// invalidates a sealed block in the logsDB while supernode is stopped, on
+// restart Start must complete backfill and leave the logsDB reflecting the
+// canonical chain — not get stuck in an infinite ErrParentHashMismatch retry
+// loop requiring the operator to delete logs.db.
+//
+// Today this test FAILS: backfill resumes from latest.Number+1 and trips
+// ErrParentHashMismatch on the first seal, retrying forever. The fix needs to
+// trim the logsDB back to the highest block whose hash still matches canonical
+// (or Clear() if none does) before retrying.
+func TestLogBackfill_RecoversFromOfflineReorg(t *testing.T) {
+	const act = uint64(100)
+	depth := 20 * time.Second
+
+	h := newInteropTestHarness(t).
+		WithActivation(act).
+		WithLogBackfillDepth(depth).
+		WithChain(10, func(m *mockChainContainer) {
+			m.currentL1 = eth.BlockRef{Number: 1, Hash: common.HexToHash("0xL1")}
+			m.syncStatusFull = &eth.SyncStatus{
+				CurrentL1:   eth.L1BlockRef{Number: 1, Hash: common.HexToHash("0xL1")},
+				UnsafeL2:    eth.L2BlockRef{Number: 110, Time: 110},
+				SafeL2:      eth.L2BlockRef{Number: 110, Time: 110},
+				LocalSafeL2: eth.L2BlockRef{Number: 110, Time: 110},
+			}
+		}).
+		Build()
+
+	chain10 := h.Mock(10)
+	db := h.interop.logsDBs[chain10.id]
+
+	// Simulate a pre-shutdown logsDB whose tail is on a stale "v1" fork that no
+	// longer matches the canonical chain returned by the mock (which represents
+	// the post-reorg "v2" canonical view, where block N has hash BigToHash(N)).
+	//
+	// Pre-seed blocks 100..105 directly via SealBlock so we can choose hashes.
+	// The first seal on an empty DB skips parent validation, so each subsequent
+	// seal just needs to link to the previous v1 hash.
+	v1Hash := func(n uint64) common.Hash {
+		return common.BigToHash(new(big.Int).SetUint64(n | 0xdead0000))
+	}
+	require.NoError(t, db.SealBlock(common.Hash{},
+		eth.BlockID{Number: 100, Hash: v1Hash(100)}, 100))
+	for n := uint64(101); n <= 105; n++ {
+		require.NoError(t, db.SealBlock(v1Hash(n-1),
+			eth.BlockID{Number: n, Hash: v1Hash(n)}, n))
+	}
+	before, has := db.LatestSealedBlock()
+	require.True(t, has)
+	require.Equal(t, uint64(105), before.Number)
+	require.Equal(t, v1Hash(105), before.Hash,
+		"pre-seed should have placed the v1 (pre-reorg) chain into the logsDB")
+
+	// Shorten the retry backoff so a buggy implementation doesn't drag the test
+	// out — we still rely on the require.Eventually timeout to detect the stuck
+	// loop. Match TestLogBackfill_RetriesWhenVirtualNodesNotReady.
+	origBackoff := errorBackoffPeriod
+	errorBackoffPeriod = 10 * time.Millisecond
+	t.Cleanup(func() { errorBackoffPeriod = origBackoff })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- h.interop.Start(ctx) }()
+
+	// Start must complete backfill: the canonical chain has block 110 at the
+	// cross-safe tip and supernode must catch up to it after self-healing the
+	// stale logsDB tail.
+	require.Eventually(t, func() bool {
+		return h.interop.backfillCompleted.Load()
+	}, 15*time.Second, 20*time.Millisecond,
+		"Start must recover from an offline reorg, not loop forever on ErrParentHashMismatch")
+
+	require.Equal(t, uint64(110), h.interop.backfillEndTimestamp,
+		"backfill must seal up to the cross-safe tip")
+
+	// The logsDB tail must now reflect the canonical (post-reorg) chain, not
+	// the stale v1 fork it was pre-seeded with.
+	latest, has := db.LatestSealedBlock()
+	require.True(t, has)
+	require.Equal(t, uint64(110), latest.Number, "logsDB tail must advance to the canonical tip")
+	require.Equal(t, common.BigToHash(new(big.Int).SetUint64(110)), latest.Hash,
+		"logsDB tail must be the canonical v2 hash, not the stale v1 hash")
+
+	// Spot-check an interior reorged height: block 103 must hold the canonical
+	// hash, not v1Hash(103).
+	seal103, err := db.FindSealedBlock(103)
+	require.NoError(t, err)
+	require.Equal(t, common.BigToHash(new(big.Int).SetUint64(103)), seal103.Hash,
+		"reorged interior block must be replaced with the canonical hash")
+
+	cancel()
+	<-done
+}
+
 func TestLogBackfill_RetriesStopOnContextCancel(t *testing.T) {
 	const act = uint64(100)
 	depth := 10 * time.Second

--- a/op-supernode/supernode/activity/interop/log_backfill_test.go
+++ b/op-supernode/supernode/activity/interop/log_backfill_test.go
@@ -158,8 +158,8 @@ func TestLogBackfill_RetriesWhenVirtualNodesNotReady(t *testing.T) {
 	<-done
 }
 
-// TestLogBackfill_RecoversFromOfflineReorg covers #20627: an L2 reorg that
-// invalidates a sealed block while supernode is offline must self-heal on
+// TestLogBackfill_RecoversFromOfflineReorg tests an L2 reorg that
+// invalidates a sealed block while supernode is offline self-heals on
 // restart, not loop forever on ErrParentHashMismatch.
 func TestLogBackfill_RecoversFromOfflineReorg(t *testing.T) {
 	const act = uint64(100)


### PR DESCRIPTION
Closes ethereum-optimism/optimism#20627.

If an L2 reorg invalidated a sealed block in a chain's `logs.db` while supernode was stopped, `backfillChain` resumed from `LatestSealedBlock+1` and tripped `ErrParentHashMismatch` on the first seal forever — the only operator recovery was deleting `logs.db`. The online rewind path was unreachable because it's gated behind the main loop, which backfill blocks.

Fix: before resuming, `reconcileLogsDBTail` walks back through the sealed range to find the deepest block still on canonical, then `Rewind`s once (or `Clear`s if no sealed block matches). Single pass, single truncation regardless of reorg depth. No-reorg cost is one extra `OutputV0AtBlockNumber` per chain per restart.